### PR TITLE
Fix OpenMP usage from MlasSgemm

### DIFF
--- a/onnxruntime/core/mlas/lib/sgemm.cpp
+++ b/onnxruntime/core/mlas/lib/sgemm.cpp
@@ -1288,9 +1288,8 @@ Return Value:
 
 #if defined(MLAS_USE_OPENMP)
 
-    #pragma omp parallel num_threads(Index)
-    {
-        int tid = omp_get_thread_num();
+    #pragma omp parallel for
+    for (int32_t tid = 0; tid < int32_t(Index); tid++) {
 
         MLAS_SGEMM_WORK_BLOCK::SEGMENT* Segment = &WorkBlock.Segments[tid];
 


### PR DESCRIPTION
Fix the OpenMP usage of #pragma parallel inside MlasSgemm to use "#pragma omp parallel for" instead of "#pragma omp num_threads()". MlasSgemm computes the number of threads that can usefully do work fo the GEMM and I had thought the num_threads syntax was the cleanest way to schedule the work, but as the number of threads changes, OpenMP runtimes painfully re-create the thread pool. Using "#pragma omp parallel for" keeps the existing thread pool around and hopefully avoids waking threads that won't have any work to do.