### PR TITLE
Implement StringNormalizer

### DIFF
--- a/onnxruntime/contrib_ops/contrib_ops.cc
+++ b/onnxruntime/contrib_ops/contrib_ops.cc
@@ -479,7 +479,7 @@ The bounding box coordinates corresponding to the selected indices can then be o
           "locale",
           "Platform dependent string that denotes the locale according to which output strings needs to be upper/lowercased. Default en_US",
           AttributeProto::STRING,
-          "en_US")
+          OPTIONAL)
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
         output_elem_type->set_elem_type(ONNX_NAMESPACE::TensorProto::STRING);

--- a/onnxruntime/contrib_ops/contrib_ops.cc
+++ b/onnxruntime/contrib_ops/contrib_ops.cc
@@ -484,8 +484,7 @@ The bounding box coordinates corresponding to the selected indices can then be o
         auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
         output_elem_type->set_elem_type(ONNX_NAMESPACE::TensorProto::STRING);
       })
-      .SetDoc(R"DOC([optional] Step1: Remove elements in X if they matches any of stop words so that output tensor may not contain any stop word. This operator only accepts [C]- and [1, C]-tensor. If all elements in X are dropped, the output will be the default value of string tensor with shape [1] if input shape is [C] and shape [1, 1] if input shape is [1, C]. 
-[optional] Step2: Lower all characters (if action is LOWER) in X or capitalize them (when action is UPPER))DOC");
+      .SetDoc(R"DOC([optional] Step1: Remove elements in X if they match any of the stop words so that the output tensor will not contain any stop words. This operator only accepts [C]- and [1, C]-tensors. If all elements in X are dropped, the output will be the default value of string tensor with shape [1] if input shape is [C] and shape [1, 1] if input shape is [1, C].)DOC");
 }
 
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SampleOp);

--- a/onnxruntime/contrib_ops/contrib_ops.cc
+++ b/onnxruntime/contrib_ops/contrib_ops.cc
@@ -452,6 +452,40 @@ The bounding box coordinates corresponding to the selected indices can then be o
               ->set_dim_value(1);
         }
       });
+
+  ONNX_CONTRIB_OPERATOR_SCHEMA(StringNormalizer)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .Input(0, "X", "Strings to normalize", "T")
+      .Output(0, "Y", "Normalized strings", "T")
+      .TypeConstraint(
+          "T",
+          {"tensor(string)"},
+          "Input/Output is a string tensor")
+      .Attr(
+          "casechangeaction",
+          "string enum that cases output to be lowercased/uppercases/unchanged. Valid values are \"LOWER\", \"UPPER\", \"NONE\"",
+          AttributeProto::STRING)
+      .Attr(
+          "iscasesensitive",
+          "Boolean. Whether the identification of stop words in X is case-sensitive.",
+          AttributeProto::INT)
+      .Attr(
+          "stopwords",
+          "List of stop words",
+          AttributeProto::STRINGS,
+          OPTIONAL)
+      .Attr(
+          "locale",
+          "Platform dependent string that denotes the locale according to which output strings needs to be upper/lowercased. Default en_US",
+          AttributeProto::STRING,
+          "en_US")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
+        output_elem_type->set_elem_type(ONNX_NAMESPACE::TensorProto::STRING);
+      })
+      .SetDoc(R"DOC([optional] Step1: Remove elements in X if they matches any of stop words so that output tensor may not contain any stop word. This operator only accepts [C]- and [1, C]-tensor. If all elements in X are dropped, the output will be the default value of string tensor with shape [1] if input shape is [C] and shape [1, 1] if input shape is [1, C]. 
+[optional] Step2: Lower all characters (if action is LOWER) in X or capitalize them (when action is UPPER))DOC");
 }
 
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SampleOp);
@@ -461,6 +495,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, DequantizeLinear);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int8_t, DequantizeLinear);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, QuantizeLinear);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, string, StringNormalizer);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, NonMaxSuppression);
 
 void RegisterContribKernels(std::function<void(KernelCreateInfo&&)> fn) {
@@ -474,6 +509,7 @@ void RegisterContribKernels(std::function<void(KernelCreateInfo&&)> fn) {
   fn(BuildKernel<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, DequantizeLinear)>());
   fn(BuildKernel<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int8_t, DequantizeLinear)>());
   fn(BuildKernel<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, QuantizeLinear)>());
+  fn(BuildKernel<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, string, StringNormalizer)>());
   fn(BuildKernel<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, NonMaxSuppression)>());
 }
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/contrib_ops.cc
+++ b/onnxruntime/contrib_ops/contrib_ops.cc
@@ -12,8 +12,8 @@
 namespace onnxruntime {
 namespace contrib {
 using ::ONNX_NAMESPACE::AttributeProto;
-using ::ONNX_NAMESPACE::OPTIONAL;
 using ::ONNX_NAMESPACE::OpSchema;
+using ::ONNX_NAMESPACE::OPTIONAL;
 
 void RegisterContribSchemas() {
   ONNX_CONTRIB_OPERATOR_SCHEMA(SampleOp)
@@ -467,7 +467,7 @@ The bounding box coordinates corresponding to the selected indices can then be o
           "string enum that cases output to be lowercased/uppercases/unchanged. Valid values are \"LOWER\", \"UPPER\", \"NONE\"",
           AttributeProto::STRING)
       .Attr(
-          "iscasesensitive",
+          "is_case_sensitive",
           "Boolean. Whether the identification of stop words in X is case-sensitive.",
           AttributeProto::INT)
       .Attr(
@@ -477,7 +477,7 @@ The bounding box coordinates corresponding to the selected indices can then be o
           OPTIONAL)
       .Attr(
           "locale",
-          "Platform dependent string that denotes the locale according to which output strings needs to be upper/lowercased. Default en_US",
+          "Environment dependent string that denotes the locale according to which output strings needs to be upper/lowercased. Default en_US",
           AttributeProto::STRING,
           OPTIONAL)
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {

--- a/onnxruntime/contrib_ops/cpu/string_normalizer.cc
+++ b/onnxruntime/contrib_ops/cpu/string_normalizer.cc
@@ -105,7 +105,7 @@ StringNormalizer::StringNormalizer(const OpKernelInfo& info) : OpKernel(info) {
   ONNXRUNTIME_ENFORCE(status.IsOK(), "attribute iscasesensitive is not set");
   iscasesensitive_ = iscasesensitive != 0;
 
-  info.GetAttrs<std::string>("stopwords", stopwords_);
+  status = info.GetAttrs<std::string>("stopwords", stopwords_);
   ONNXRUNTIME_ENFORCE(status.IsOK(), "Failed to get stopwords");
 
   locale_ = info.GetAttrOrDefault("locale", std::string("en_US"));

--- a/onnxruntime/contrib_ops/cpu/string_normalizer.cc
+++ b/onnxruntime/contrib_ops/cpu/string_normalizer.cc
@@ -105,9 +105,7 @@ StringNormalizer::StringNormalizer(const OpKernelInfo& info) : OpKernel(info) {
   ONNXRUNTIME_ENFORCE(status.IsOK(), "attribute iscasesensitive is not set");
   iscasesensitive_ = iscasesensitive != 0;
 
-  status = info.GetAttrs<std::string>("stopwords", stopwords_);
-  ONNXRUNTIME_ENFORCE(status.IsOK(), "Failed to get stopwords");
-
+  stopwords_ = info.GetAttrsOrDefault<std::string>("stopwords");
   locale_ = info.GetAttrOrDefault("locale", std::string("en_US"));
 }
 

--- a/onnxruntime/contrib_ops/cpu/string_normalizer.cc
+++ b/onnxruntime/contrib_ops/cpu/string_normalizer.cc
@@ -118,7 +118,7 @@ StringNormalizer::StringNormalizer(const OpKernelInfo& info) : OpKernel(info),
     compare_caseaction_ = (casechangeaction_ == UPPER) ? UPPER : LOWER;
   }
 
-  locale_ = info.GetAttrOrDefault("locale", std::string("en_US"));
+  locale_ = info.GetAttrOrDefault("locale", std::string("en_US.UTF-8"));
   std::locale locale(locale_);
   std::wstring_convert<std::codecvt_utf8<wchar_t>> converter(conv_error, wconv_error);
 

--- a/onnxruntime/contrib_ops/cpu/string_normalizer.cc
+++ b/onnxruntime/contrib_ops/cpu/string_normalizer.cc
@@ -1,0 +1,203 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "string_normalizer.h"
+#include "onnx/defs/schema.h"
+#include "core/common/common.h"
+#include "core/framework/tensor.h"
+
+#include <codecvt>
+#include <locale>
+#include <functional>
+#include <unordered_set>
+
+namespace onnxruntime {
+namespace contrib {
+
+ONNX_CPU_OPERATOR_TYPED_MS_KERNEL(
+    StringNormalizer,
+    1,
+    string,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<std::string>()),
+    contrib::StringNormalizer);
+
+namespace string_normalizer {
+const std::string conv_error("Conversion Error");
+const std::wstring wconv_error(L"Conversion Error");
+// performs tolower/toupper in-place
+void ChangeCase(const std::locale& loc, StringNormalizer::CaseAction caseaction,
+                std::wstring& wstr) {
+  if (caseaction == StringNormalizer::LOWER) {
+    std::transform(wstr.begin(), wstr.end(), wstr.begin(),
+                   [&loc](wchar_t ch) { return std::tolower(ch, loc); });
+  } else {
+    std::transform(wstr.begin(), wstr.end(), wstr.begin(),
+                   [&loc](wchar_t ch) { return std::toupper(ch, loc); });
+  }
+}
+
+template <class ForwardIter>
+Status CopyCaseAction(ForwardIter first, ForwardIter end, OpKernelContext* ctx,
+                      const std::locale& loc,
+                      std::wstring_convert<std::codecvt_utf8<wchar_t>>& converter,
+                      size_t N, size_t C,
+                      StringNormalizer::CaseAction caseaction) {
+  std::vector<int64_t> output_dims;
+  if (N == 1) {
+    output_dims.push_back(1);
+  }
+
+  // Empty output case
+  if (C == 0) {
+    output_dims.push_back(1);
+    TensorShape output_shape(output_dims);
+    ctx->Output(0, output_shape);
+    return Status::OK();
+  }
+
+  output_dims.push_back(C);
+
+  TensorShape output_shape(output_dims);
+  auto output_tensor = ctx->Output(0, output_shape);
+  auto const output_data = output_tensor->template MutableData<std::string>();
+
+  size_t output_idx = 0;
+  while (first != end) {
+    const std::string& s = *first;
+    if (caseaction == StringNormalizer::LOWER || caseaction == StringNormalizer::UPPER) {
+      std::wstring wstr = converter.from_bytes(s);
+      if (wstr == wconv_error) {
+        return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
+                      "Input contains invalid utf8 chars at: " + s);
+      }
+      // In place transform
+      ChangeCase(loc, caseaction, wstr);
+      new (output_data + output_idx) std::string(converter.to_bytes(wstr));
+    } else {
+      // Simple copy
+      new (output_data + output_idx) std::string(s);
+    }
+    ++output_idx;
+    ++first;
+  }
+  return Status::OK();
+}
+}  // namespace string_normalizer
+
+StringNormalizer::StringNormalizer(const OpKernelInfo& info) : OpKernel(info) {
+  std::string casechangeaction;
+  auto status = info.GetAttr("casechangeaction", &casechangeaction);
+  ONNXRUNTIME_ENFORCE(status.IsOK(), "attribute caseaction is not set");
+  if (casechangeaction == "LOWER") {
+    casechangeaction_ = LOWER;
+  } else if (casechangeaction == "UPPER") {
+    casechangeaction_ = UPPER;
+  } else if (casechangeaction == "NONE") {
+    casechangeaction_ = NONE;
+  } else {
+    ONNXRUNTIME_ENFORCE(false, "attribute casechangeaction has invalid value");
+  }
+  int64_t iscasesensitive = 0;
+  status = info.GetAttr("iscasesensitive", &iscasesensitive);
+  ONNXRUNTIME_ENFORCE(status.IsOK(), "attribute iscasesensitive is not set");
+  iscasesensitive_ = iscasesensitive != 0;
+
+  info.GetAttrs<std::string>("stopwords", stopwords_);
+  // Default is specified in the schema
+  status = info.GetAttr("locale", &locale_);
+  ONNXRUNTIME_ENFORCE(status.IsOK(), "Failed to get locale");
+}
+
+Status StringNormalizer::Compute(OpKernelContext* ctx) const {
+  using namespace string_normalizer;
+
+  auto X = ctx->Input<Tensor>(0);
+  auto& input_dims = X->Shape().GetDims();
+
+  size_t N = 0;
+  size_t C = 0;
+  if (input_dims.size() == 1) {
+    if (input_dims[0] < 1) {
+      return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
+                    "Single dimension value must be greater than 0");
+    }
+    C = input_dims[0];
+  } else if (input_dims.size() == 2) {
+    if (input_dims[0] != 1 || input_dims[1] < 1) {
+      return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
+                    "Input dimensions are either[C > 0] or [1][C > 0] allowed");
+    }
+    N = 1;
+    C = input_dims[1];
+  } else {
+    return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
+                  "Input dimensions are either[C > 0] or [1][C > 0] allowed");
+  }
+
+  Status status;
+  std::locale loc(locale_);
+  std::wstring_convert<std::codecvt_utf8<wchar_t>> converter(conv_error, wconv_error);
+  auto const input_data = X->template Data<std::string>();
+
+  using StrRef = std::reference_wrapper<const std::string>;
+  if (iscasesensitive_) {
+    if (!stopwords_.empty()) {
+      // Create a filter and create filtered output
+      std::unordered_set<StrRef,
+                         std::hash<std::string>,
+                         std::equal_to<std::string>>
+          swords;
+      std::transform(stopwords_.begin(), stopwords_.end(), std::inserter(swords, swords.end()),
+                     [](const std::string& s) { return std::cref(s); });
+
+      std::vector<StrRef> filtered_strings;
+      filtered_strings.reserve(C);
+      for (size_t input_idx = 0; input_idx < C; ++input_idx) {
+        const std::string& s = *(input_data + input_idx);
+        if (0 == swords.count(s)) {
+          filtered_strings.push_back(std::cref(s));
+        }
+      }
+      status = CopyCaseAction(filtered_strings.cbegin(), filtered_strings.cend(), ctx, loc, converter,
+                              N, filtered_strings.size(), casechangeaction_);
+    } else {
+      // Nothing to filter. Copy input to output and change case if needed
+      status = CopyCaseAction(input_data, input_data + C, ctx, loc, converter, N, C, casechangeaction_);
+    }
+  } else {
+    if (!stopwords_.empty()) {
+      // Perform case-insensitive comparison. Convert to lowercase for NONE, LOWER and UPPER otherwise.
+      const CaseAction ca = (casechangeaction_ == UPPER) ? UPPER : LOWER;
+      std::unordered_set<std::wstring> swords;
+      std::transform(stopwords_.begin(), stopwords_.end(), std::inserter(swords, swords.end()),
+                     [&loc, &converter, ca](const std::string& s) {
+                       std::wstring wstr = converter.from_bytes(s);
+                       ChangeCase(loc, ca, wstr);
+                       return wstr;
+                     });
+
+      // Filter input. We choose to undergo conversion twice (if needed)
+      // as oppose to preserve lower/uppercased strings to favor lower memory
+      // consumption.
+      std::vector<StrRef> filtered_strings;
+      filtered_strings.reserve(C);
+      for (size_t input_idx = 0; input_idx < C; ++input_idx) {
+        const std::string& s = *(input_data + input_idx);
+        std::wstring wstr = converter.from_bytes(s);
+        ChangeCase(loc, ca, wstr);
+        if (0 == swords.count(wstr)) {
+          filtered_strings.push_back(std::cref(s));
+        }
+      }
+      status = CopyCaseAction(filtered_strings.cbegin(), filtered_strings.cend(), ctx, loc, converter,
+                              N, filtered_strings.size(), casechangeaction_);
+    } else {
+      // Nothing to filter. Copy input to output and change case if needed
+      status = CopyCaseAction(input_data, input_data + C, ctx, loc, converter, N, C, casechangeaction_);
+    }
+  }
+  return status;
+}
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/string_normalizer.cc
+++ b/onnxruntime/contrib_ops/cpu/string_normalizer.cc
@@ -93,8 +93,8 @@ inline std::locale GetLocale(const std::string& locale_name) {
     std::locale result(locale_name);
     return result;
   } catch (const std::runtime_error& e) {
-    ONNXRUNTIME_THROW("Failed to construct locale with name: ",
-                      locale_name, e.what(), " Please, install necessary language-pack-XX");
+    ONNXRUNTIME_THROW("Failed to construct locale with name:",
+                      locale_name, ":", e.what(), ":Please, install necessary language-pack-XX and configure locales");
   }
 }
 }  // namespace string_normalizer

--- a/onnxruntime/contrib_ops/cpu/string_normalizer.h
+++ b/onnxruntime/contrib_ops/cpu/string_normalizer.h
@@ -29,7 +29,7 @@ class StringNormalizer : public OpKernel {
   bool is_case_sensitive_;
   CaseAction casechangeaction_;
   CaseAction compare_caseaction_;  // used for case-insensitive compare
-  std::locale locale_;             // needed for upper/lowercasing actions and case insensitive compare
+  std::string locale_;
   // Either if these are populated but not both
   std::unordered_set<std::string> stopwords_;
   std::unordered_set<std::wstring> wstopwords_;

--- a/onnxruntime/contrib_ops/cpu/string_normalizer.h
+++ b/onnxruntime/contrib_ops/cpu/string_normalizer.h
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/framework/op_kernel.h"
+
+#include <string>
+#include <vector>
+
+namespace onnxruntime {
+namespace contrib {
+
+class StringNormalizer : public OpKernel {
+ public:
+  enum CaseAction {
+    NONE = 0,
+    LOWER = 1,
+    UPPER = 2,
+  };
+
+  explicit StringNormalizer(const OpKernelInfo& info);
+  ~StringNormalizer() = default;
+
+  Status Compute(OpKernelContext* ctx) const override;
+
+ private:
+  CaseAction casechangeaction_;
+  bool iscasesensitive_;
+  std::vector<std::string> stopwords_;
+  std::string locale_;  // needed for upper/lowercasing actions and case insensitive compare
+};
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/string_normalizer.h
+++ b/onnxruntime/contrib_ops/cpu/string_normalizer.h
@@ -5,8 +5,9 @@
 
 #include "core/framework/op_kernel.h"
 
+#include <locale>
 #include <string>
-#include <vector>
+#include <unordered_set>
 
 namespace onnxruntime {
 namespace contrib {
@@ -25,10 +26,13 @@ class StringNormalizer : public OpKernel {
   Status Compute(OpKernelContext* ctx) const override;
 
  private:
+  bool is_case_sensitive_;
   CaseAction casechangeaction_;
-  bool iscasesensitive_;
-  std::vector<std::string> stopwords_;
-  std::string locale_;  // needed for upper/lowercasing actions and case insensitive compare
+  CaseAction compare_caseaction_;  // used for case-insensitive compare
+  std::locale locale_;             // needed for upper/lowercasing actions and case insensitive compare
+  // Either if these are populated but not both
+  std::unordered_set<std::string> stopwords_;
+  std::unordered_set<std::wstring> wstopwords_;
 };
 
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cpu/string_normalizer.h
+++ b/onnxruntime/contrib_ops/cpu/string_normalizer.h
@@ -29,7 +29,7 @@ class StringNormalizer : public OpKernel {
   bool is_case_sensitive_;
   CaseAction casechangeaction_;
   CaseAction compare_caseaction_;  // used for case-insensitive compare
-  std::string locale_;
+  std::string locale_name_;
   // Either if these are populated but not both
   std::unordered_set<std::string> stopwords_;
   std::unordered_set<std::wstring> wstopwords_;

--- a/onnxruntime/test/contrib_ops/string_normalizer_test.cc
+++ b/onnxruntime/test/contrib_ops/string_normalizer_test.cc
@@ -17,7 +17,7 @@ void InitTestAttr(OpTester& test, const std::string& casechangeaction,
                   const std::vector<std::string>& stopwords,
                   const std::string& locale) {
   test.AddAttribute("casechangeaction", casechangeaction);
-  test.AddAttribute("iscasesensitive", int64_t{iscasesensitive});
+  test.AddAttribute("is_case_sensitive", int64_t{iscasesensitive});
   if (!stopwords.empty()) {
     test.AddAttribute("stopwords", stopwords);
   }
@@ -38,7 +38,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
     OpTester test("StringNormalizer", opset_ver, domain);
     InitTestAttr(test, "NONE", true, {}, "en_US");
     std::vector<int64_t> dims{2, 2};
-    std::vector<std::string> input = {std::string("monday"), std::string("tuesday"), std::string("wendsday"), std::string("thursday")};
+    std::vector<std::string> input = {std::string("monday"), std::string("tuesday"), std::string("wednesday"), std::string("thursday")};
     test.AddInput<std::string>("T", dims, input);
     std::vector<std::string> output(input);  // do the same for now
     test.AddOutput<std::string>("Y", dims, output);

--- a/onnxruntime/test/contrib_ops/string_normalizer_test.cc
+++ b/onnxruntime/test/contrib_ops/string_normalizer_test.cc
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <codecvt>
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace str_normalizer_test {
+constexpr const char* domain = onnxruntime::kMSDomain;
+const int opset_ver = 1;
+
+void InitTestAttr(OpTester& test, const std::string& casechangeaction,
+                  bool iscasesensitive,
+                  const std::vector<std::string>& stopwords,
+                  const std::string& locale) {
+  test.AddAttribute("casechangeaction", casechangeaction);
+  test.AddAttribute("iscasesensitive", int64_t{iscasesensitive});
+  if (!stopwords.empty()) {
+    test.AddAttribute("stopwords", stopwords);
+  }
+  test.AddAttribute("locale", locale);
+}
+}  // namespace str_normalizer_test
+
+using namespace str_normalizer_test;
+
+TEST(ContribOpTest, StringNormalizerTest) {
+  // Test wrong 2 dimensions
+  // - casesensitive approach
+  // - no stopwords.
+  // - No change case action
+  {
+    OpTester test("StringNormalizer", opset_ver, domain);
+    InitTestAttr(test, "NONE", true, {}, "en_US");
+    std::vector<int64_t> dims{2, 2};
+    std::vector<std::string> input = {std::string("monday"), std::string("tuesday"), std::string("wendsday"), std::string("thursday")};
+    test.AddInput<std::string>("T", dims, input);
+    std::vector<std::string> output(input);  // do the same for now
+    test.AddOutput<std::string>("Y", dims, output);
+
+    test.Run(OpTester::ExpectResult::kExpectFailure, "Input dimensions are either[C > 0] or [1][C > 0] allowed");
+  }
+  // - casesensitive approach
+  // - no stopwords.
+  // - No change case action
+  {
+    OpTester test("StringNormalizer", opset_ver, domain);
+    InitTestAttr(test, "NONE", true, {}, "en_US");
+    std::vector<int64_t> dims{4};
+    std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
+                                      std::string("wednesday"), std::string("thursday")};
+    test.AddInput<std::string>("T", dims, input);
+    std::vector<std::string> output(input);  // do the same for now
+    test.AddOutput<std::string>("Y", dims, output);
+    test.Run(OpTester::ExpectResult::kExpectSuccess);
+  }
+  // - casesensitive approach
+  // - filter out monday
+  // - No change case action
+  {
+    OpTester test("StringNormalizer", opset_ver, domain);
+    InitTestAttr(test, "NONE", true, {"monday"}, "en_US");
+    std::vector<int64_t> dims{4};
+    std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
+                                      std::string("wednesday"), std::string("thursday")};
+    test.AddInput<std::string>("T", dims, input);
+
+    std::vector<std::string> output = {std::string("tuesday"),
+                                       std::string("wednesday"), std::string("thursday")};
+    test.AddOutput<std::string>("Y", {3}, output);
+    test.Run(OpTester::ExpectResult::kExpectSuccess);
+  }
+  // - casesensitive approach
+  // - filter out monday
+  // - LOWER should produce the same output as they are all lower.
+  {
+    OpTester test("StringNormalizer", opset_ver, domain);
+    InitTestAttr(test, "LOWER", true, {"monday"}, "en_US");
+    std::vector<int64_t> dims{4};
+    std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
+                                      std::string("wednesday"), std::string("thursday")};
+    test.AddInput<std::string>("T", dims, input);
+
+    std::vector<std::string> output = {std::string("tuesday"),
+                                       std::string("wednesday"), std::string("thursday")};
+    test.AddOutput<std::string>("Y", {3}, output);
+    test.Run(OpTester::ExpectResult::kExpectSuccess);
+  }
+  // - casesensitive approach
+  // - filter out monday
+  // - UPPER should produce the same output as they are all lower.
+  {
+    OpTester test("StringNormalizer", opset_ver, domain);
+    InitTestAttr(test, "UPPER", true, {"monday"}, "en_US");
+    std::vector<int64_t> dims{4};
+    std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
+                                      std::string("wednesday"), std::string("thursday")};
+    test.AddInput<std::string>("T", dims, input);
+
+    std::vector<std::string> output = {std::string("TUESDAY"),
+                                       std::string("WEDNESDAY"), std::string("THURSDAY")};
+    test.AddOutput<std::string>("Y", {3}, output);
+    test.Run(OpTester::ExpectResult::kExpectSuccess);
+  }
+  // Empty output case
+  // - casesensitive approach
+  // - filter out monday
+  // - UPPER should produce the same output as they are all lower.
+  {
+    OpTester test("StringNormalizer", opset_ver, domain);
+    InitTestAttr(test, "UPPER", true, {"monday"}, "en_US");
+    std::vector<int64_t> dims{2};
+    std::vector<std::string> input = {std::string("monday"),
+                                      std::string("monday")};
+    test.AddInput<std::string>("T", dims, input);
+
+    std::vector<std::string> output;
+    test.AddOutput<std::string>("Y", {1}, output);
+    test.Run(OpTester::ExpectResult::kExpectSuccess);
+  }
+  // Empty output case
+  // - casesensitive approach
+  // - filter out monday
+  // - UPPER should produce the same output as they are all lower.
+  {
+    OpTester test("StringNormalizer", opset_ver, domain);
+    InitTestAttr(test, "UPPER", true, {"monday"}, "en_US");
+    std::vector<int64_t> dims{1, 2};
+    std::vector<std::string> input = {std::string("monday"),
+                                      std::string("monday")};
+    test.AddInput<std::string>("T", dims, input);
+
+    std::vector<std::string> output;
+    test.AddOutput<std::string>("Y", {1, 1}, output);
+    test.Run(OpTester::ExpectResult::kExpectSuccess);
+  }
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/string_normalizer_test.cc
+++ b/onnxruntime/test/contrib_ops/string_normalizer_test.cc
@@ -36,7 +36,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - No change case action
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "NONE", true, {}, "en_US");
+    InitTestAttr(test, "NONE", true, {}, "en_US.UTF-8");
     std::vector<int64_t> dims{2, 2};
     std::vector<std::string> input = {std::string("monday"), std::string("tuesday"), std::string("wednesday"), std::string("thursday")};
     test.AddInput<std::string>("T", dims, input);
@@ -50,7 +50,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - No change case action
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "NONE", true, {}, "en_US");
+    InitTestAttr(test, "NONE", true, {}, "en_US.UTF-8");
     std::vector<int64_t> dims{4};
     std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
                                       std::string("wednesday"), std::string("thursday")};
@@ -64,7 +64,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - No change case action
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "NONE", true, {"monday"}, "en_US");
+    InitTestAttr(test, "NONE", true, {"monday"}, "en_US.UTF-8");
     std::vector<int64_t> dims{4};
     std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
                                       std::string("wednesday"), std::string("thursday")};
@@ -80,7 +80,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - LOWER should produce the same output as they are all lower.
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "LOWER", true, {"monday"}, "en_US");
+    InitTestAttr(test, "LOWER", true, {"monday"}, "en_US.UTF-8");
     std::vector<int64_t> dims{4};
     std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
                                       std::string("wednesday"), std::string("thursday")};
@@ -96,7 +96,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - UPPER should produce the same output as they are all lower.
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "UPPER", true, {"monday"}, "en_US");
+    InitTestAttr(test, "UPPER", true, {"monday"}, "en_US.UTF-8");
     std::vector<int64_t> dims{4};
     std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
                                       std::string("wednesday"), std::string("thursday")};
@@ -114,7 +114,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - UPPER should produce the same output as they are all lower.
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "UPPER", true, {u8"monday"}, "en_US");
+    InitTestAttr(test, "UPPER", true, {u8"monday"}, "en_US.UTF-8");
     std::vector<int64_t> dims{7};
     std::vector<std::string> input = {std::string(u8"monday"),
                                       std::string(u8"tuesday"),
@@ -147,7 +147,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - UPPER should produce the same output as they are all lower.
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "UPPER", false, {u8"monday"}, "en_US");
+    InitTestAttr(test, "UPPER", false, {u8"monday"}, "en_US.UTF-8");
     std::vector<int64_t> dims{7};
     std::vector<std::string> input = {std::string(u8"monday"),
                                       std::string(u8"tuesday"),
@@ -180,7 +180,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - UPPER should produce the same output as they are all lower.
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "UPPER", true, {"monday"}, "en_US");
+    InitTestAttr(test, "UPPER", true, {"monday"}, "en_US.UTF-8");
     std::vector<int64_t> dims{2};
     std::vector<std::string> input = {std::string("monday"),
                                       std::string("monday")};

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -557,10 +557,7 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckGraphInputOutputOrderMaintained)
 // Validate that an unused initializer doesn't break graph loading/resolution
 // and is removed as expected.
 TEST(ResolvingGraphTest, UnusedInitializerIsIgnored) {
-  OPERATOR_SCHEMA(Identity_Fake)
-      .SetDoc("Identity.")
-      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+  ASSERT_TRUE(kSchemasRegistered);
 
   Model model("UnusedInitializerIsIgnored");
   auto& graph = model.MainGraph();

--- a/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh
@@ -25,6 +25,7 @@ apt-get update && apt-get install -y --no-install-recommends \
         sudo \
         gfortran \
         python3-dev \
+        language-pack-en \
         libopenblas-dev \
         liblttng-ust0 \
         libcurl3 \

--- a/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh
@@ -39,6 +39,9 @@ apt-get update && apt-get install -y --no-install-recommends \
         rsync libunwind8 libpng16-dev \
         python3-setuptools python3-numpy python3-wheel python python3-pip python3-pytest
 
+locale-gen en_US.UTF-8
+update-locale LANG=en_US.UTF-8
+
 if [ $PYTHON_VER != "3.5" ]; then
     apt-get install -y --no-install-recommends \
             python${PYTHON_VER} \

--- a/tools/ci_build/github/linux/ubuntu16.04/install.sh
+++ b/tools/ci_build/github/linux/ubuntu16.04/install.sh
@@ -16,6 +16,7 @@ apt-get update && apt-get install -y --no-install-recommends \
         sudo \
         gfortran \
         python3-dev \
+        language-pack-en \
         libopenblas-dev \
         liblttng-ust0 \
         libcurl3 \

--- a/tools/ci_build/github/linux/ubuntu16.04/install.sh
+++ b/tools/ci_build/github/linux/ubuntu16.04/install.sh
@@ -29,6 +29,9 @@ apt-get update && apt-get install -y --no-install-recommends \
         rsync libunwind8 \
         python3-setuptools python3-numpy python3-wheel python python3-pip
 
+locale-gen en_US.UTF-8
+update-locale LANG=en_US.UTF-8
+
 rm -rf /var/lib/apt/lists/*
 
 aria2c -q -d /tmp https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip


### PR DESCRIPTION
Inputs: 
X: tensor<string>, string 
Outputs: 
Y: tensor<string>, string 
Attribute: 
casechangeaction: enum {"LOWER", "UPPER", "NONE"}. 
iscasesenstive: bool. Whether the identification of stop words in X is case-sensitive. 
stopwords: list of strings (type: AttributeProto::STRINGS). A 1-D tensor of strings. Each element is a stop word. 
locale: string. This attribute specifies culture for culture-specific string operations. 
Description: 
This operator can do below 2 operations: 
[optional] Step1: Remove elements in X if they matches any of stop words so that output tensor may not contain any stop word. This operator only accepts [C]- and [1, C]-tensor. If all elements in X are dropped, the output will be the empty value of string tensor with shape [1] if input shape is [C] and shape [1, 1] if input shape is [1, C]. 
[optional] Step2: Lower all characters (if action is LOWER) in X or capitalize them (when action is UPPE