### PR TITLE
(de)quantize_linear optimizations

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantize_linear.h
+++ b/onnxruntime/contrib_ops/cpu/quantize_linear.h
@@ -20,7 +20,7 @@ class DequantizeLinear final : public OpKernel {
   Status Compute(OpKernelContext* context) const override;
 
  private:
-  int64_t axis_;
+  int64_t axis_ = 0;
   bool has_axis_;
 };
 
@@ -34,7 +34,7 @@ class QuantizeLinear final : public OpKernel {
   Status Compute(OpKernelContext* context) const override;
 
  private:
-  int64_t axis_;
+  int64_t axis_ = 0;
   bool has_axis_;
 };
 }  // namespace contrib

--- a/onnxruntime/test/contrib_ops/quantize_linear_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_linear_test.cc
@@ -7,6 +7,7 @@
 namespace onnxruntime {
 namespace test {
 
+// scalar zero & scale with uint8
 TEST(DequantizeLinearOpTest, DequantizeLinear_0) {
   OpTester test("DequantizeLinear", 1, onnxruntime::kMSDomain);
   std::vector<int64_t> dims{4};
@@ -17,6 +18,7 @@ TEST(DequantizeLinearOpTest, DequantizeLinear_0) {
   test.Run();
 }
 
+// scalar zero & scale with int8
 TEST(DequantizeLinearOpTest, DequantizeLinear_1) {
   OpTester test("DequantizeLinear", 1, onnxruntime::kMSDomain);
   std::vector<int64_t> dims{4};
@@ -27,6 +29,7 @@ TEST(DequantizeLinearOpTest, DequantizeLinear_1) {
   test.Run();
 }
 
+// 1d zero & scale with uint8 broadcast axis 0
 TEST(DequantizeLinearOpTest, DequantizeLinear_2) {
   OpTester test("DequantizeLinear", 1, onnxruntime::kMSDomain);
   std::vector<int64_t> dims{3, 4};
@@ -34,9 +37,15 @@ TEST(DequantizeLinearOpTest, DequantizeLinear_2) {
                          {0, 1, 2, 3,
                           0, 1, 2, 3,
                           0, 10, 20, 30});
-  test.AddAttribute<int64_t>("axis", 1);
-  test.AddInput<float>("scale", {3}, {1.0f, 2.0f, 4.0f});
-  test.AddInput<uint8_t>("zero_point", {3}, {0, 0, 0});
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddInput<float>("scale", {3},
+                       {1.0f,
+                        2.0f,
+                        4.0f});
+  test.AddInput<uint8_t>("zero_point", {3},
+                         {0,
+                          0,
+                          0});
   test.AddOutput<float>("Y", dims,
                         {0, 1, 2, 3,
                          0, 2, 4, 6,
@@ -44,6 +53,95 @@ TEST(DequantizeLinearOpTest, DequantizeLinear_2) {
   test.Run();
 }
 
+// 1d zero & scale with int8 broadcast axis 1
+TEST(DequantizeLinearOpTest, DequantizeLinear_3) {
+  OpTester test("DequantizeLinear", 1, onnxruntime::kMSDomain);
+  std::vector<int64_t> dims{3, 4};
+  test.AddInput<int8_t>("X", dims,
+                        {0, 1, 2, 3,
+                         0, 2, 4, 6,
+                         0, 10, 20, 30});
+  test.AddAttribute<int64_t>("axis", 1);
+  test.AddInput<float>("scale", {4}, {1, 2, 4, 8});
+  test.AddInput<int8_t>("zero_point", {4}, {0, -10, -20, -30});
+  test.AddOutput<float>("Y", dims,
+                        {0, 22, 88, 264,
+                         0, 24, 96, 288,
+                         0, 40, 160, 480});
+  test.Run();
+}
+
+// 1d zero & scale with int8 broadcast axis 0 with 4d tensor input/output
+TEST(DequantizeLinearOpTest, DequantizeLinear_4) {
+  OpTester test("DequantizeLinear", 1, onnxruntime::kMSDomain);
+  std::vector<int64_t> dims{2, 3, 2, 4};
+  test.AddInput<int8_t>("X", dims,
+                        {7, 9, 10, 10,
+                         5, 8, 9, 1,
+
+                         8, 6, 7, 9,
+                         10, 0, 7, 10,
+
+                         8, 2, 6, 0,
+                         5, 9, 8, 1,
+
+                         2, 7, 5, 3,
+                         2, 4, 1, 3,
+
+                         8, 7, 4, 8,
+                         10, 1, 5, 5,
+
+                         7, 7, 0, 2,
+                         4, 4, 0, 5});
+  test.AddAttribute<int64_t>("axis", 1);
+  test.AddInput<float>("scale", {3}, {1, 10, 7});
+  test.AddInput<int8_t>("zero_point", {3}, {10, 2, 1});
+  test.AddOutput<float>("Y", dims,
+                        {-3, -1, 0, 0,
+                         -5, -2, -1, -9,
+
+                         60, 40, 50, 70,
+                         80, -20, 50, 80,
+
+                         49, 7, 35, -7,
+                         28, 56, 49, 0,
+
+                         -8, -3, -5, -7,
+                         -8, -6, -9, -7,
+
+                         60, 50, 20, 60,
+                         80, -10, 30, 30,
+
+                         42, 42, -7, 7,
+                         21, 21, -7, 28});
+  test.Run();
+}
+
+// 1d zero & scale with uint8 broadcast axis -2 (-2 resolves to axis 0)
+TEST(DequantizeLinearOpTest, DequantizeLinear_5) {
+  OpTester test("DequantizeLinear", 1, onnxruntime::kMSDomain);
+  std::vector<int64_t> dims{3, 4};
+  test.AddInput<uint8_t>("X", dims,
+                         {0, 1, 2, 3,
+                          0, 1, 2, 3,
+                          0, 10, 20, 30});
+  test.AddAttribute<int64_t>("axis", -2);
+  test.AddInput<float>("scale", {3},
+                       {1.0f,
+                        2.0f,
+                        4.0f});
+  test.AddInput<uint8_t>("zero_point", {3},
+                         {0,
+                          0,
+                          0});
+  test.AddOutput<float>("Y", dims,
+                        {0, 1, 2, 3,
+                         0, 2, 4, 6,
+                         0, 40, 80, 120});
+  test.Run();
+}
+
+// quantize with scalar zero point and scale
 TEST(QuantizeLinearOpTest, QuantizeLinear_0) {
   OpTester test("QuantizeLinear", 1, onnxruntime::kMSDomain);
   std::vector<int64_t> dims{6};
@@ -54,19 +152,15 @@ TEST(QuantizeLinearOpTest, QuantizeLinear_0) {
   test.Run();
 }
 
-// TODO this test is failing for Mac. needs to be debugged.
-#if defined(__MACH__)
-TEST(QuantizeLinearOpTest, DISABLED_QuantizeLinear_1) {
-#else
+// quantize with broadcasting
 TEST(QuantizeLinearOpTest, QuantizeLinear_1) {
-#endif
   OpTester test("QuantizeLinear", 1, onnxruntime::kMSDomain);
   std::vector<int64_t> dims{3, 4};
   test.AddInput<float>("X", dims,
                        {0, 2, 3, 1000,
                         0, 2, 3, 1000,
                         0, 2, 3, 1000});
-  test.AddAttribute<int64_t>("axis", 1);
+  test.AddAttribute<int64_t>("axis", 0);
   test.AddInput<float>("scale", {3}, {1, 2, 4});
   test.AddInput<uint8_t>("zero_point", {3}, {0, 0, 0});
   test.AddOutput<uint8_t>("Y", dims,
@@ -76,5 +170,22 @@ TEST(QuantizeLinearOpTest, QuantizeLinear_1) {
   test.Run();
 }
 
+// quantize with broadcasting and negative axis (-2 resolves to axis 0)
+TEST(QuantizeLinearOpTest, QuantizeLinear_2) {
+  OpTester test("QuantizeLinear", 1, onnxruntime::kMSDomain);
+  std::vector<int64_t> dims{3, 4};
+  test.AddInput<float>("X", dims,
+                       {0, 2, 3, 1000,
+                        0, 2, 3, 1000,
+                        0, 2, 3, 1000});
+  test.AddAttribute<int64_t>("axis", -2);
+  test.AddInput<float>("scale", {3}, {1, 2, 4});
+  test.AddInput<uint8_t>("zero_point", {3}, {0, 0, 0});
+  test.AddOutput<uint8_t>("Y", dims,
+                          {0, 2, 3, 255,
+                           0, 1, 2, 255,
+                           0, 1, 1, 250});
+  test.Run();
+}
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
previously both were doing two broadcast loops when they didn't need to since zero_point and scale get broadcast in the same manner. Also the code is simplified to not rely on the eigen templates unnecessarily.