### PR TITLE
User lower case while comparing the activation method

### DIFF
--- a/onnxruntime/test/providers/cpu/rnn/deep_cpu_lstm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/deep_cpu_lstm_op_test.cc
@@ -23,8 +23,7 @@ T DuplicateContainer(const T& container) {
   return doubled;
 }
 
-static void RunLstmTest(bool run_on_gpu,
-                        const std::vector<float>& X_data,
+static void RunLstmTest(const std::vector<float>& X_data,
                         const std::vector<float>& W_data,
                         const std::vector<float>& R_data,
                         const std::vector<float>& Y_data,
@@ -137,15 +136,10 @@ static void RunLstmTest(bool run_on_gpu,
     test.AddMissingOptionalOutput<float>();
   }
 
-  std::unordered_set<std::string> excluded_providers;
-  if (!run_on_gpu) {
-    excluded_providers.insert(kCudaExecutionProvider);
-  }
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", excluded_providers);
+  test.Run();
 }
 
-void SimpleWeightsNoBiasTwoRows(bool run_on_gpu,
-                                std::string direction,
+void SimpleWeightsNoBiasTwoRows(std::string direction,
                                 const std::vector<float>& Y_data,
                                 const std::vector<float>& Y_h_data,
                                 const std::vector<float>& Y_c_data,
@@ -171,14 +165,14 @@ void SimpleWeightsNoBiasTwoRows(bool run_on_gpu,
     W_data = DuplicateContainer(W_data);
   }
 
-  RunLstmTest(run_on_gpu, X_data, W_data, R_data, Y_data, Y_h_data, Y_c_data,
+  RunLstmTest(X_data, W_data, R_data, Y_data, Y_h_data, Y_c_data,
               input_size, batch_size, hidden_size, seq_length,
               nullptr, nullptr, nullptr, nullptr, seq_lengths, direction);
 
   // need at least one output, so we need Y_h or Y_c to be requested (non-empty output to compare against) in order
   // to test Y not being returned (output_sequence == false)
   if (!Y_h_data.empty() || !Y_c_data.empty())
-    RunLstmTest(run_on_gpu, X_data, W_data, R_data, Y_data, Y_h_data, Y_c_data,
+    RunLstmTest(X_data, W_data, R_data, Y_data, Y_h_data, Y_c_data,
                 input_size, batch_size, hidden_size, seq_length,
                 nullptr, nullptr, nullptr, nullptr, seq_lengths, direction, 999.f, /* output_sequence*/ false);
 }
@@ -199,11 +193,10 @@ TEST(LSTMTest, ForwardSimpleWeightsNoBiasTwoRows) {
       1.27731147f, 1.44181041f, 1.53179041f,
       1.3249796f, 1.51063104f, 1.61451544f};
 
-  bool run_on_gpu = true;
-  SimpleWeightsNoBiasTwoRows(run_on_gpu, "forward", Y_data, Y_h_data, Y_c_data);
+  SimpleWeightsNoBiasTwoRows("forward", Y_data, Y_h_data, Y_c_data);
 
   // test Y_h and Y_c being optional
-  SimpleWeightsNoBiasTwoRows(run_on_gpu, "forward", Y_data, {}, {});
+  SimpleWeightsNoBiasTwoRows("forward", Y_data, {}, {});
 }
 
 TEST(LSTMTest, ReverseSimpleWeightsNoBiasTwoRows) {
@@ -222,8 +215,7 @@ TEST(LSTMTest, ReverseSimpleWeightsNoBiasTwoRows) {
       1.27850552f, 1.46799496f, 1.57641257f,
       1.34960834f, 1.54772296f, 1.65633056f};
 
-  bool run_on_gpu = true;
-  SimpleWeightsNoBiasTwoRows(run_on_gpu, "reverse", Y_data, Y_h_data, Y_c_data);
+  SimpleWeightsNoBiasTwoRows("reverse", Y_data, Y_h_data, Y_c_data);
 }
 
 TEST(LSTMTest, BidirectionalSimpleWeightsNoBiasTwoRows) {
@@ -257,8 +249,7 @@ TEST(LSTMTest, BidirectionalSimpleWeightsNoBiasTwoRows) {
       1.34960834f, 1.54772296f, 1.65633056f};
 
   // cudnn don't support customized activation
-  bool run_on_gpu = true;
-  SimpleWeightsNoBiasTwoRows(run_on_gpu, "bidirectional", Y_data, Y_h_data, Y_c_data);
+  SimpleWeightsNoBiasTwoRows("bidirectional", Y_data, Y_h_data, Y_c_data);
 }
 
 TEST(LSTMTest, MixedSequenceLengths) {
@@ -282,8 +273,7 @@ TEST(LSTMTest, MixedSequenceLengths) {
       1.3249796f, 1.51063104f, 1.61451544f};
 
   // Not able to mask on Y_c for CUDA using cudnn lib
-  bool run_on_gpu = false;
-  SimpleWeightsNoBiasTwoRows(run_on_gpu, "forward", Y_data, Y_h_data, Y_c_data, &seq_lengths);
+  SimpleWeightsNoBiasTwoRows("forward", Y_data, Y_h_data, Y_c_data, &seq_lengths);
 
   // swap which one is short
   seq_lengths = {2, 1};
@@ -303,7 +293,7 @@ TEST(LSTMTest, MixedSequenceLengths) {
       1.27731147f, 1.44181041f, 1.53179041f,
       0.54983425f, 0.59868795f, 0.64565659f};
 
-  SimpleWeightsNoBiasTwoRows(run_on_gpu, "forward", Y_data, Y_h_data, Y_c_data, &seq_lengths);
+  SimpleWeightsNoBiasTwoRows("forward", Y_data, Y_h_data, Y_c_data, &seq_lengths);
 }
 
 TEST(LSTMTest, MixedSequenceLengthsReverse) {
@@ -326,8 +316,7 @@ TEST(LSTMTest, MixedSequenceLengthsReverse) {
       0.52497941f, 0.54983425f, 0.5744428f,
       1.34960834f, 1.54772296f, 1.65633056f};
 
-  bool run_on_gpu = false;
-  SimpleWeightsNoBiasTwoRows(run_on_gpu, "reverse", Y_data, Y_h_data, Y_c_data, &seq_lengths);
+  SimpleWeightsNoBiasTwoRows("reverse", Y_data, Y_h_data, Y_c_data, &seq_lengths);
 
   // swap which one is short
   seq_lengths = {2, 1};
@@ -347,7 +336,7 @@ TEST(LSTMTest, MixedSequenceLengthsReverse) {
       1.27850552f, 1.46799496f, 1.57641257f,
       0.54983425f, 0.59868795f, 0.64565659f};
 
-  SimpleWeightsNoBiasTwoRows(run_on_gpu, "reverse", Y_data, Y_h_data, Y_c_data, &seq_lengths);
+  SimpleWeightsNoBiasTwoRows("reverse", Y_data, Y_h_data, Y_c_data, &seq_lengths);
 }
 
 // test path in LSTM model where batch_parallel_ is false and there are multiple steps (seq_length > 1)
@@ -374,13 +363,12 @@ TEST(LSTMTest, BatchParallelFalseSeqLengthGreaterThanOne) {
   std::vector<float> Y_c_data{
       1.02721067f, 1.15254318f};
 
-  bool run_on_gpu = true;
-  RunLstmTest(run_on_gpu, X_data, W_data, R_data, Y_data, {}, Y_c_data,
+  RunLstmTest(X_data, W_data, R_data, Y_data, {}, Y_c_data,
               input_size, batch_size, hidden_size, seq_length);
 }
 
 // make sure GateComputations works correctly if batch_parallel_ is true due to large batch size
-static void LargeBatchWithClip(bool run_on_gpu, const std::vector<float>& Y_h_data, float clip = 9999.0) {
+static void LargeBatchWithClip(const std::vector<float>& Y_h_data, float clip = 9999.0) {
   int64_t seq_length = 2;
   int batch_size = 32;
   int64_t input_size = 1;
@@ -401,7 +389,7 @@ static void LargeBatchWithClip(bool run_on_gpu, const std::vector<float>& Y_h_da
 
   std::vector<float> R_data(num_directions * 4 * hidden_size * hidden_size, 0.1f);
 
-  RunLstmTest(run_on_gpu, X_data, W_data, R_data, {}, Y_h_data, {},
+  RunLstmTest(X_data, W_data, R_data, {}, Y_h_data, {},
               input_size, batch_size, hidden_size, seq_length,
               nullptr, nullptr, nullptr, nullptr, nullptr, direction, clip);
 }
@@ -441,8 +429,7 @@ TEST(LSTMTest, LargeBatchNoClipping) {
       0.96073964f, 0.96388402f, 0.96402112f,
       0.96105254f, 0.96391004f, 0.96402279f};
 
-  bool run_on_gpu = true;
-  LargeBatchWithClip(run_on_gpu, Y_h_data);
+  LargeBatchWithClip(Y_h_data);
 }
 
 // make sure GateComputations with clipping works correctly if batch_parallel_ is true due to large batch size
@@ -481,8 +468,7 @@ TEST(LSTMTest, LargeBatchWithClip) {
       0.94072091f, 0.94266769f, 0.94266769f,
       0.94103248f, 0.94266769f, 0.94266769f};
 
-  bool run_on_gpu = false;
-  LargeBatchWithClip(run_on_gpu, Y_h_data, 4.f);
+  LargeBatchWithClip(Y_h_data, 4.f);
 }
 
 // ONNXRuntime tests
@@ -608,8 +594,7 @@ class LstmOpContext2x1x2x2 {
     // RunTest(seq_len, batch_size, num_direction, Y_data, output_first);
   }
 
-  void RunTest(bool run_on_gpu,
-               const std::vector<float>& X,
+  void RunTest(const std::vector<float>& X,
                const int batch_size,
                const int seq_length,
                const std::vector<float>* initial_h,
@@ -623,7 +608,7 @@ class LstmOpContext2x1x2x2 {
                float clip = 9999.f,
                bool input_forget = false) {
     // run with and without output_sequence to test UniDirectionalLstm handling when Y isn't returned
-    ::onnxruntime::test::RunLstmTest(run_on_gpu, X, input_weights_, recurrent_weights_,
+    ::onnxruntime::test::RunLstmTest(X, input_weights_, recurrent_weights_,
                                      expected_Y, expected_Y_h, expected_Y_c,
                                      input_size_, batch_size, hidden_size_, seq_length,
                                      use_bias ? &bias_ : nullptr,
@@ -638,7 +623,7 @@ class LstmOpContext2x1x2x2 {
                                      activation_alphas_,
                                      activation_betas_);
 
-    ::onnxruntime::test::RunLstmTest(run_on_gpu, X, input_weights_, recurrent_weights_,
+    ::onnxruntime::test::RunLstmTest(X, input_weights_, recurrent_weights_,
                                      expected_Y, expected_Y_h, expected_Y_c,
                                      input_size_, batch_size, hidden_size_, seq_length,
                                      use_bias ? &bias_ : nullptr,
@@ -681,8 +666,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMForwardPeepHole) {
 
   //Run Test
   LstmOpContext2x1x2x2 context(direction);
-  bool run_on_gpu = false;
-  context.RunTest(run_on_gpu, input, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data);
+  context.RunTest(input, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data);
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMBidirectionalBasic) {
@@ -700,8 +684,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMBidirectionalBasic) {
                                  -0.0753684f, 0.120794f};
 
   LstmOpContext2x1x2x2 context("bidirectional");
-  bool run_on_gpu = false;
-  context.RunTest(run_on_gpu, X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data);
+  context.RunTest(X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data);
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMForwardNoBiasUsePeepholes) {
@@ -718,8 +701,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMForwardNoBiasUsePeepholes) {
   std::vector<float> Y_c_data = {0.11169686f, 0.00625722f};
 
   LstmOpContext2x1x2x2 context("forward");
-  bool run_on_gpu = false;
-  context.RunTest(run_on_gpu, X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data, nullptr,
+  context.RunTest(X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data, nullptr,
                   use_bias, use_peepholes);
 }
 
@@ -740,8 +722,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMForwardInputForget) {
 
   LstmOpContext2x1x2x2 context("forward");
   // cudnn don't support peepholes
-  bool run_on_gpu = false;
-  context.RunTest(run_on_gpu, X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data, nullptr,
+  context.RunTest(X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data, nullptr,
                   use_bias, use_peepholes, clip, input_forget);
 }
 
@@ -760,8 +741,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMForwardClip) {
   std::vector<float> Y_c_data = {-0.07415761f, 0.07395997f};
 
   LstmOpContext2x1x2x2 context("forward");
-  bool run_on_gpu = false;
-  context.RunTest(run_on_gpu, X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data, nullptr,
+  context.RunTest(X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data, nullptr,
                   use_bias, use_peepholes, clip);
 }
 
@@ -776,8 +756,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMBackward) {
   std::vector<float> Y_c_data = {-0.07536839f, 0.12079399f};
 
   LstmOpContext2x1x2x2 context("reverse");
-  bool run_on_gpu = false;
-  context.RunTest(run_on_gpu, X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data);
+  context.RunTest(X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data);
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMBackward_gpu) {
@@ -791,9 +770,8 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMBackward_gpu) {
   std::vector<float> Y_c_data = {-0.076699793f, 0.11975205f};
 
   LstmOpContext2x1x2x2 context("reverse");
-  bool run_on_gpu = true;
   // Disable peephole since cudnn doesn't support it
-  context.RunTest(run_on_gpu, X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data, nullptr, true, false);
+  context.RunTest(X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data, nullptr, true, false);
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMForwardHiddenState) {
@@ -811,8 +789,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMForwardHiddenState) {
   std::vector<float> Y_c_data = {-0.07285583f, -0.02545788f};
 
   LstmOpContext2x1x2x2 context("forward");
-  bool run_on_gpu = true;
-  context.RunTest(run_on_gpu, X_data, batch_size, seq_len, &hidden_state, nullptr, Y_data, Y_h_data, Y_c_data,
+  context.RunTest(X_data, batch_size, seq_len, &hidden_state, nullptr, Y_data, Y_h_data, Y_c_data,
                   nullptr, use_bias, use_peepholes);
 }
 
@@ -832,8 +809,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMForwardCellState) {
   std::vector<float> Y_c_data = {0.06408449f, 0.03139432f};
 
   LstmOpContext2x1x2x2 context("forward");
-  bool run_on_gpu = true;
-  context.RunTest(run_on_gpu, X_data, batch_size, seq_len, &hidden_state, &cell_state, Y_data, Y_h_data, Y_c_data,
+  context.RunTest(X_data, batch_size, seq_len, &hidden_state, &cell_state, Y_data, Y_h_data, Y_c_data,
                   nullptr, use_bias, use_peepholes);
 }
 
@@ -853,8 +829,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMActivation) {
   std::vector<float> Y_c_data = {0.1624992f, 0.04672481f};
 
   LstmOpContext2x1x2x2 context("forward", activations);
-  bool run_on_gpu = false;
-  context.RunTest(run_on_gpu, X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data,
+  context.RunTest(X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data,
                   nullptr, use_bias, use_peepholes);
 }
 
@@ -882,8 +857,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMBatchReallocation) {
   std::vector<float> Y_c_data = {0.1624992f, 0.04672481f};
 
   LstmOpContext2x1x2x2 context(direction, activations);
-  bool run_on_gpu = false;
-  context.RunTest(run_on_gpu, X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data,
+  context.RunTest(X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data,
                   nullptr, use_bias, use_peepholes);
 
   batch_size = 3;
@@ -912,7 +886,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMBatchReallocation) {
               0.23038f, -0.0239f,
               0.24572f, 0.051626f};
 
-  context.RunTest(run_on_gpu, X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data,
+  context.RunTest(X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data,
                   nullptr, use_bias, use_peepholes);
 }
 
@@ -945,8 +919,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMOutputWrite) {
 
   std::string direction = "bidirectional";
   LstmOpContext2x1x2x2 context(direction, activations);
-  bool run_on_gpu = false;
-  context.RunTest(run_on_gpu, X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data,
+  context.RunTest(X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data,
                   nullptr, use_bias, use_peepholes);
 
   batch_size = 3;
@@ -992,7 +965,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMOutputWrite) {
               0.22469461f, -0.02200207f,
               0.18284359f, -0.01078442f};
 
-  context.RunTest(run_on_gpu, X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data,
+  context.RunTest(X_data, batch_size, seq_len, nullptr, nullptr, Y_data, Y_h_data, Y_c_data,
                   nullptr, use_bias, use_peepholes);
 }
 


### PR DESCRIPTION
User lower case while comparing the activation method as it's not clear in the spec.
Fix the bug for RNN/GRU/LSTM auto fall back, the supported activation should cover bidirectional mode.
Update the test to remove the flag to enable gpu test since we can auto fallback to cpu