### PR TITLE
switch build agents to the CUDA 10 pool

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: Linux_CI_GPU_Dev
-  pool: Linux-GPU
+  pool: Linux-GPU-CUDA10
   steps:
     - script: 'tools/ci_build/github/linux/run_dockerbuild.sh -o ubuntu16.04 -d gpu -r $(Build.BinariesDirectory)'
       displayName: 'Command Line Script'

--- a/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: Windows_CI_GPU_Dev
-  pool: Win-GPU
+  pool: Win-GPU-CUDA10
   variables:
     CUDA_VERSION: '9.1'
   steps:


### PR DESCRIPTION
In order to make the cuda 10 build switch smooth, switch the existing build to the cuda 10 agent pool first. After this in, make another PR to update the build to use cuda 10 library.