### PR TITLE
[Linux] add missing libstdc++fs library to onnxruntime_test_all target

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Minimum CMake required
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.8)
 
 # Project
 project(onnxruntime C CXX)

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -246,6 +246,12 @@ if (SingleUnitTestProject)
     list(APPEND all_libs ${onnxruntime_tvm_libs})
     list(APPEND all_dependencies ${onnxruntime_tvm_dependencies})
   endif()
+
+  if (UNIX AND NOT APPLE)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    list(APPEND all_libs stdc++fs)
+  endif()
+
   # we can only have one 'main', so remove them all and add back the providers test_main as it sets
   # up everything we need for all tests
   file(GLOB_RECURSE test_mains "${TEST_SRC_DIR}/*/test_main.cc")

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -61,9 +61,15 @@ function(AddTest)
 endfunction(AddTest)
 
 #Check whether C++17 header file <filesystem> is present
-include(CheckIncludeFiles)
-check_include_files("filesystem" HAS_FILESYSTEM_H LANGUAGE CXX)
-check_include_files("experimental/filesystem" HAS_EXPERIMENTAL_FILESYSTEM_H LANGUAGE CXX)
+if (${CMAKE_VERSION} VERSION_LESS 3.11)
+  include(CheckIncludeFileCXX)
+  check_include_file_cxx("filesystem" HAS_FILESYSTEM_H)
+  check_include_file_cxx("experimental/filesystem" HAS_EXPERIMENTAL_FILESYSTEM_H)
+else()
+  include(CheckIncludeFiles)
+  check_include_files("filesystem" HAS_FILESYSTEM_H LANGUAGE CXX)
+  check_include_files("experimental/filesystem" HAS_EXPERIMENTAL_FILESYSTEM_H LANGUAGE CXX)
+endif()
 
 #Do not add '${TEST_SRC_DIR}/util/include' to your include directories directly
 #Use onnxruntime_add_include_to_target or target_link_libraries, so that compile definitions
@@ -245,11 +251,6 @@ if (SingleUnitTestProject)
     list(APPEND all_tests ${onnxruntime_test_tvm_src})
     list(APPEND all_libs ${onnxruntime_tvm_libs})
     list(APPEND all_dependencies ${onnxruntime_tvm_dependencies})
-  endif()
-
-  if (UNIX AND NOT APPLE)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-    list(APPEND all_libs stdc++fs)
   endif()
 
   # we can only have one 'main', so remove them all and add back the providers test_main as it sets


### PR DESCRIPTION
Discovered on: Ubuntu 18.x, compilers used: GCC 7.x and GCC 8.2

Due to missing library linker is reporting `std::filesystem` unresolved symbols for target `onnxruntime_test_all`.
Adding `libstdc++fs` to the target's linking rules solves the issue.

Signed-off-by: Artur Wojcik <artur.wojcik@intel.com>