### PR TITLE
Use windows specific C-runtime based solution for lowercasing/uppercasing

### DIFF
--- a/onnxruntime/contrib_ops/cpu/string_normalizer.cc
+++ b/onnxruntime/contrib_ops/cpu/string_normalizer.cc
@@ -6,6 +6,10 @@
 #include "core/common/common.h"
 #include "core/framework/tensor.h"
 
+#ifdef _MSC_VER
+#include <locale.h>
+#endif
+
 #include <codecvt>
 #include <locale>
 #include <functional>
@@ -25,22 +29,85 @@ ONNX_CPU_OPERATOR_TYPED_MS_KERNEL(
 namespace string_normalizer {
 const std::string conv_error("Conversion Error");
 const std::wstring wconv_error(L"Conversion Error");
-// performs tolower/toupper in-place
-inline void ChangeCase(const std::locale& loc, StringNormalizer::CaseAction caseaction,
-                       std::wstring& wstr) {
-  assert(caseaction != StringNormalizer::NONE);
-  if (caseaction == StringNormalizer::LOWER) {
-    std::transform(wstr.begin(), wstr.end(), wstr.begin(),
-                   [&loc](wchar_t ch) { return std::tolower(ch, loc); });
-  } else {
-    std::transform(wstr.begin(), wstr.end(), wstr.begin(),
-                   [&loc](wchar_t ch) { return std::toupper(ch, loc); });
+
+// We need to specialize for MS as there is
+// a std::locale creation bug that affects different
+// environments in a different way
+#ifdef _MSC_VER
+
+class Locale {
+ public:
+  explicit Locale(const std::string& name)
+      : loc_(nullptr) {
+    loc_ = _create_locale(LC_CTYPE, name.c_str());
+    if (loc_ == nullptr) {
+      ONNXRUNTIME_THROW("Failed to construct locale with name:",
+                        name, ":", ":Please, install necessary language-pack-XX and configure locales");
+    }
   }
-}
+
+  ~Locale() {
+    if (loc_ != nullptr) {
+      _free_locale(loc_);
+    }
+  }
+
+  Locale(const Locale&) = delete;
+  Locale& operator=(const Locale&) = delete;
+
+  void ChangeCase(StringNormalizer::CaseAction caseaction,
+                  std::wstring& wstr) const {
+    assert(caseaction != StringNormalizer::NONE);
+    if (caseaction == StringNormalizer::LOWER) {
+      std::transform(wstr.begin(), wstr.end(), wstr.begin(),
+                     [this](wchar_t ch) { return ::_towlower_l(ch, loc_); });
+    } else {
+      std::transform(wstr.begin(), wstr.end(), wstr.begin(),
+                     [this](wchar_t ch) { return ::_towupper_l(ch, loc_); });
+    }
+  }
+
+ private:
+  _locale_t loc_;
+};
+
+const std::string default_locale("en-US");
+
+#else
+class Locale {
+ public:
+  explicit Locale(const std::string& name) try : loc_(name) {
+  } catch (const std::runtime_error& e) {
+    ONNXRUNTIME_THROW("Failed to construct locale with name:",
+                      name, ":", e.what(), ":Please, install necessary language-pack-XX and configure locales");
+  }
+
+  Locale(const Locale&) = delete;
+  Locale& operator=(const Locale&) = delete;
+
+  void ChangeCase(StringNormalizer::CaseAction caseaction,
+                  std::wstring& wstr) const {
+    assert(caseaction != StringNormalizer::NONE);
+    if (caseaction == StringNormalizer::LOWER) {
+      std::transform(wstr.begin(), wstr.end(), wstr.begin(),
+                     [this](wchar_t ch) { return std::tolower(ch, loc_); });
+    } else {
+      std::transform(wstr.begin(), wstr.end(), wstr.begin(),
+                     [this](wchar_t ch) { return std::toupper(ch, loc_); });
+    }
+  }
+
+ private:
+  std::locale loc_;
+};
+
+const std::string default_locale("en_US.UTF-8");
+
+#endif
 
 template <class ForwardIter>
 Status CopyCaseAction(ForwardIter first, ForwardIter end, OpKernelContext* ctx,
-                      const std::locale& loc,
+                      const Locale& loc,
                       std::wstring_convert<std::codecvt_utf8<wchar_t>>& converter,
                       size_t N, size_t C,
                       StringNormalizer::CaseAction caseaction) {
@@ -75,7 +142,7 @@ Status CopyCaseAction(ForwardIter first, ForwardIter end, OpKernelContext* ctx,
                       "Input contains invalid utf8 chars at: " + static_cast<const std::string&>(s));
       }
       // In place transform
-      ChangeCase(loc, caseaction, wstr);
+      loc.ChangeCase(caseaction, wstr);
       new (output_data + output_idx) std::string(converter.to_bytes(wstr));
     } else {
       assert(caseaction == StringNormalizer::NONE);
@@ -86,16 +153,6 @@ Status CopyCaseAction(ForwardIter first, ForwardIter end, OpKernelContext* ctx,
     ++first;
   }
   return Status::OK();
-}
-
-inline std::locale GetLocale(const std::string& locale_name) {
-  try {
-    std::locale result(locale_name);
-    return result;
-  } catch (const std::runtime_error& e) {
-    ONNXRUNTIME_THROW("Failed to construct locale with name:",
-                      locale_name, ":", e.what(), ":Please, install necessary language-pack-XX and configure locales");
-  }
 }
 }  // namespace string_normalizer
 
@@ -128,8 +185,8 @@ StringNormalizer::StringNormalizer(const OpKernelInfo& info) : OpKernel(info),
     compare_caseaction_ = (casechangeaction_ == UPPER) ? UPPER : LOWER;
   }
 
-  locale_name_ = info.GetAttrOrDefault("locale", std::string("en_US.UTF-8"));
-  std::locale locale = GetLocale(locale_name_);
+  locale_name_ = info.GetAttrOrDefault("locale", default_locale);
+  Locale locale(locale_name_);
   std::wstring_convert<std::codecvt_utf8<wchar_t>> converter(conv_error, wconv_error);
 
   std::vector<std::string> swords = info.GetAttrsOrDefault<std::string>("stopwords");
@@ -141,7 +198,7 @@ StringNormalizer::StringNormalizer(const OpKernelInfo& info) : OpKernel(info),
     } else {
       std::wstring wstr = converter.from_bytes(sw);
       ONNXRUNTIME_ENFORCE(wstr != wconv_error, "Stopword contains invalid utf8 chars");
-      ChangeCase(locale, compare_caseaction_, wstr);
+      locale.ChangeCase(compare_caseaction_, wstr);
       auto p = wstopwords_.insert(wstr);
       ONNXRUNTIME_ENFORCE(p.second, "Duplicate stopwords not allowed");
     }
@@ -175,7 +232,7 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
   }
 
   Status status;
-  std::locale locale = GetLocale(locale_name_);
+  Locale locale(locale_name_);
   std::wstring_convert<std::codecvt_utf8<wchar_t>> converter(conv_error, wconv_error);
   auto const input_data = X->template Data<std::string>();
   using StrRef = std::reference_wrapper<const std::string>;
@@ -216,7 +273,7 @@ Status StringNormalizer::Compute(OpKernelContext* ctx) const {
           return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
                         "Input contains invalid utf8 chars at: " + s);
         }
-        ChangeCase(locale, compare_caseaction_, wstr);
+        locale.ChangeCase(compare_caseaction_, wstr);
         if (0 == wstopwords_.count(wstr)) {
           if (casechangeaction_ == NONE) {
             filtered_orignal_strings.push_back(std::cref(s));

--- a/onnxruntime/test/contrib_ops/string_normalizer_test.cc
+++ b/onnxruntime/test/contrib_ops/string_normalizer_test.cc
@@ -12,6 +12,12 @@ namespace str_normalizer_test {
 constexpr const char* domain = onnxruntime::kMSDomain;
 const int opset_ver = 1;
 
+#ifdef _MSC_VER
+const std::string test_locale("en-US");
+#else
+const std::string test_locale("en_US.UTF-8");
+#endif
+
 void InitTestAttr(OpTester& test, const std::string& casechangeaction,
                   bool iscasesensitive,
                   const std::vector<std::string>& stopwords,
@@ -36,7 +42,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - No change case action
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "NONE", true, {}, "en_US.UTF-8");
+    InitTestAttr(test, "NONE", true, {}, test_locale);
     std::vector<int64_t> dims{2, 2};
     std::vector<std::string> input = {std::string("monday"), std::string("tuesday"), std::string("wednesday"), std::string("thursday")};
     test.AddInput<std::string>("T", dims, input);
@@ -50,7 +56,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - No change case action
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "NONE", true, {}, "en_US.UTF-8");
+    InitTestAttr(test, "NONE", true, {}, test_locale);
     std::vector<int64_t> dims{4};
     std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
                                       std::string("wednesday"), std::string("thursday")};
@@ -64,7 +70,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - No change case action
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "NONE", true, {"monday"}, "en_US.UTF-8");
+    InitTestAttr(test, "NONE", true, {"monday"}, test_locale);
     std::vector<int64_t> dims{4};
     std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
                                       std::string("wednesday"), std::string("thursday")};
@@ -80,7 +86,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - LOWER should produce the same output as they are all lower.
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "LOWER", true, {"monday"}, "en_US.UTF-8");
+    InitTestAttr(test, "LOWER", true, {"monday"}, test_locale);
     std::vector<int64_t> dims{4};
     std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
                                       std::string("wednesday"), std::string("thursday")};
@@ -96,7 +102,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - UPPER should produce the same output as they are all lower.
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "UPPER", true, {"monday"}, "en_US.UTF-8");
+    InitTestAttr(test, "UPPER", true, {"monday"}, test_locale);
     std::vector<int64_t> dims{4};
     std::vector<std::string> input = {std::string("monday"), std::string("tuesday"),
                                       std::string("wednesday"), std::string("thursday")};
@@ -114,7 +120,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - UPPER should produce the same output as they are all lower.
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "UPPER", true, {u8"monday"}, "en_US.UTF-8");
+    InitTestAttr(test, "UPPER", true, {u8"monday"}, test_locale);
     std::vector<int64_t> dims{7};
     std::vector<std::string> input = {std::string(u8"monday"),
                                       std::string(u8"tuesday"),
@@ -147,7 +153,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - UPPER should produce the same output as they are all lower.
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "UPPER", false, {u8"monday"}, "en_US.UTF-8");
+    InitTestAttr(test, "UPPER", false, {u8"monday"}, test_locale);
     std::vector<int64_t> dims{7};
     std::vector<std::string> input = {std::string(u8"monday"),
                                       std::string(u8"tuesday"),
@@ -180,7 +186,7 @@ TEST(ContribOpTest, StringNormalizerTest) {
   // - UPPER should produce the same output as they are all lower.
   {
     OpTester test("StringNormalizer", opset_ver, domain);
-    InitTestAttr(test, "UPPER", true, {"monday"}, "en_US.UTF-8");
+    InitTestAttr(test, "UPPER", true, {"monday"}, test_locale);
     std::vector<int64_t> dims{2};
     std::vector<std::string> input = {std::string("monday"),
                                       std::string("monday")};


### PR DESCRIPTION
  This worksaround cpp runtime bug with std::locale construction.