### PR TITLE
Show performance number as ms instead of second

### DIFF
--- a/onnxruntime/test/perftest/performance_runner.cc
+++ b/onnxruntime/test/perftest/performance_runner.cc
@@ -47,7 +47,7 @@ Status PerformanceRunner::Run() {
 
   std::cout << "Total time cost:" << performance_result_.total_time_cost << std::endl
             << "Total iterations:" << performance_result_.time_costs.size() << std::endl
-            << "Average time cost:" << performance_result_.total_time_cost / performance_result_.time_costs.size() << std::endl;
+            << "Average time cost:" << performance_result_.total_time_cost / performance_result_.time_costs.size() * 1000 << " ms" << std::endl;
   return Status::OK();
 }
 


### PR DESCRIPTION
It's annoying to multipy by 1000 to get cost in ms manually