### PR TITLE
Remove cntk_simple_seg from the list of broken tests.

### DIFF
--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -309,7 +309,6 @@ int real_main(int argc, char* argv[]) {
       {"operator_rnn_single_layer", "disable reason"},
       {"prelu_broadcast", "disable reason"},
       {"prelu_example", "disable reason"},
-      {"cntk_simple_seg", "mkldnn test failed"},
       {"maxunpool_export_with_output_shape", "opset 9 not supported yet"},
       {"maxunpool_export_without_output_shape", "opset 9 not supported yet"},
       {"upsample_nearest", "opset 9 not supported yet"},


### PR DESCRIPTION
This test failure cannot be reproduced any more.