### PR TITLE
A tiny change to onnxruntime::Model

### DIFF
--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -28,7 +28,7 @@ namespace onnxruntime {
 Model::Model(const std::string& graph_name,
              bool is_onnx_domain_only,
              const ModelMetaData& model_metadata,
-             const IOnnxRuntimeOpSchemaRegistryList local_registries,
+             const IOnnxRuntimeOpSchemaRegistryList& local_registries,
              const std::unordered_map<std::string, int>& domain_to_version,
              const std::vector<ONNX_NAMESPACE::FunctionProto>& model_functions) {
   model_proto_ = std::make_unique<ModelProto>();

--- a/onnxruntime/core/graph/model.h
+++ b/onnxruntime/core/graph/model.h
@@ -26,7 +26,7 @@ class Model {
   explicit Model(const std::string& graph_name,
                  bool is_onnx_domain_only = false,
                  const ModelMetaData& model_metadata = ModelMetaData(),
-                 const IOnnxRuntimeOpSchemaRegistryList local_registries = {},
+                 IOnnxRuntimeOpSchemaRegistryList local_registries = {},
                  const std::unordered_map<std::string, int>& domain_to_version = {},
                  const std::vector<ONNX_NAMESPACE::FunctionProto>& model_specific_functions = {});
 

--- a/onnxruntime/core/graph/model.h
+++ b/onnxruntime/core/graph/model.h
@@ -26,7 +26,7 @@ class Model {
   explicit Model(const std::string& graph_name,
                  bool is_onnx_domain_only = false,
                  const ModelMetaData& model_metadata = ModelMetaData(),
-                 IOnnxRuntimeOpSchemaRegistryList local_registries = {},
+                 const IOnnxRuntimeOpSchemaRegistryList& local_registries = IOnnxRuntimeOpSchemaRegistryList(),
                  const std::unordered_map<std::string, int>& domain_to_version = {},
                  const std::vector<ONNX_NAMESPACE::FunctionProto>& model_specific_functions = {});
 


### PR DESCRIPTION
If it is passed by value, it doesn't need 'const'. 
If it is passed by ref, const ref is better.