### PR TITLE
optimize unordered_map in profiler

### DIFF
--- a/onnxruntime/core/common/profiler.cc
+++ b/onnxruntime/core/common/profiler.cc
@@ -33,14 +33,15 @@ void Profiler::StartProfiling(const std::string& file_name) {
 void Profiler::EndTimeAndRecordEvent(EventCategory category,
                                      const std::string& event_name,
                                      TimePoint& start_time,
-                                     std::unordered_map<std::string, std::string>&& event_args,
+                                     const std::initializer_list<std::pair<std::string, std::string>>& event_args,
                                      bool /*sync_gpu*/) {
   if (!enabled_ && !profile_with_logger_)
     return;
   long long dur = TimeDiffMicroSeconds(start_time);
   long long ts = TimeDiffMicroSeconds(profiling_start_time_, start_time);
+
   EventRecord event(category, logging::GetProcessId(),
-                    logging::GetThreadId(), event_name, ts, dur, std::move(event_args));
+                    logging::GetThreadId(), event_name, ts, dur, { event_args.begin(), event_args.end() });
   if (profile_with_logger_) {
     custom_logger_->SendProfileEvent(event);
   } else {

--- a/onnxruntime/core/common/profiler.h
+++ b/onnxruntime/core/common/profiler.h
@@ -4,6 +4,8 @@
 #pragma once
 #include <iostream>
 #include <fstream>
+#include <tuple>
+#include <initializer_list>
 #include "core/common/logging/logging.h"
 
 namespace onnxruntime {
@@ -45,7 +47,7 @@ class Profiler {
   void EndTimeAndRecordEvent(EventCategory category,
                              const std::string& event_name,
                              TimePoint& start_time,
-                             std::unordered_map<std::string, std::string>&& event_args = std::unordered_map<std::string, std::string>(),
+                             const std::initializer_list<std::pair<std::string, std::string>>& event_args = {},
                              bool sync_gpu = false);
 
   /*

--- a/onnxruntime/core/framework/parallel_executor.cc
+++ b/onnxruntime/core/framework/parallel_executor.cc
@@ -147,8 +147,7 @@ void ParallelExecutor::RunNodeAsyncInternal(size_t p_node_index,
     session_state.Profiler().EndTimeAndRecordEvent(profiling::NODE_EVENT,
                                                    node_name + "_fence_before",
                                                    sync_time_begin,
-                                                   std::unordered_map<std::string,
-                                                                      std::string>{{"op_name", op_name}});
+                                                   {{"op_name", op_name}});
 
     // call compute on the kernel
     VLOGS(logger, 1) << "Computing kernel: " << p_op_kernel->Node().Name();
@@ -164,7 +163,7 @@ void ParallelExecutor::RunNodeAsyncInternal(size_t p_node_index,
     session_state.Profiler().EndTimeAndRecordEvent(profiling::NODE_EVENT,
                                                    node_name + "_kernel_time",
                                                    kernel_begin_time,
-                                                   std::unordered_map<std::string, std::string>{{"op_name", op_name}});
+                                                   {{"op_name", op_name}});
 
     sync_time_begin = session_state.Profiler().StartTime();
     // sync after compute for outputs
@@ -191,7 +190,7 @@ void ParallelExecutor::RunNodeAsyncInternal(size_t p_node_index,
     session_state.Profiler().EndTimeAndRecordEvent(profiling::NODE_EVENT,
                                                    node_name + "_fence_after",
                                                    sync_time_begin,
-                                                   std::unordered_map<std::string, std::string>{{"op_name", op_name}});
+                                                   {{"op_name", op_name}});
 
     //std::cout << "Run async node finish: " << p_node_index << std::endl;
 

--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -92,8 +92,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state,
     session_state.Profiler().EndTimeAndRecordEvent(profiling::NODE_EVENT,
                                                    node_name + "_fence_before",
                                                    sync_time_begin,
-                                                   std::unordered_map<std::string,
-                                                                      std::string>{{"op_name", op_name}});
+                                                   {{"op_name", op_name}});
 
     // call compute on the kernel
     VLOGS(logger, 1) << "Computing kernel: " << p_op_kernel->Node().Name();
@@ -103,7 +102,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state,
     session_state.Profiler().EndTimeAndRecordEvent(profiling::NODE_EVENT,
                                                    node_name + "_kernel_time",
                                                    kernel_begin_time,
-                                                   std::unordered_map<std::string, std::string>{{"op_name", op_name}});
+                                                   {{"op_name", op_name}});
 
     sync_time_begin = session_state.Profiler().StartTime();
     // sync after compute for outputs
@@ -130,7 +129,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state,
     session_state.Profiler().EndTimeAndRecordEvent(profiling::NODE_EVENT,
                                                    node_name + "_fence_after",
                                                    sync_time_begin,
-                                                   std::unordered_map<std::string, std::string>{{"op_name", op_name}});
+                                                   {{"op_name", op_name}});
 
     // free ml-values corresponding to this node
     VLOGS(logger, 1) << "Releasing node ML values after computing kernel: " << p_op_kernel->Node().Name();


### PR DESCRIPTION
Arguments of Profiler::EndTimeAndRecordEvent are constructed even profiler is disabled. The unordered_map construction is very expensive in terms of both CPU and latency (dynamic allocation then memory contention). It costs 6.1% CPU in test. After this optimization, end-2-end avg latency reduced from 686us to 608us (11.4%), 1min CPU samples reduced from 19K to 13K (31,6%). operator new inc% reduced from 8.9% to 4.6%. (Absolute values subject to variance test by test)
The test is performed under 1000QPS, 10 threads on production V15 machine. 