### PR TITLE
Implement N-gram

### DIFF
--- a/onnxruntime/contrib_ops/contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/contrib_kernels.cc
@@ -12,6 +12,9 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedConv);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, AttnLSTM);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, string, Tokenizer);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, string, Ngram);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int32_t, Ngram);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int64_t, Ngram);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, DequantizeLinear);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int8_t, DequantizeLinear);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, QuantizeLinear);
@@ -32,6 +35,9 @@ void RegisterContribKernels(std::function<void(KernelCreateInfo&&)> fn) {
   fn(BuildKernel<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedConv)>());
   fn(BuildKernel<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, AttnLSTM)>());
   fn(BuildKernel<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, string, Tokenizer)>());
+  fn(BuildKernel<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, string, Ngram)>());
+  fn(BuildKernel<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int32_t, Ngram)>());
+  fn(BuildKernel<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int64_t, Ngram)>());
   fn(BuildKernel<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, DequantizeLinear)>());
   fn(BuildKernel<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int8_t, DequantizeLinear)>());
   fn(BuildKernel<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, QuantizeLinear)>());

--- a/onnxruntime/contrib_ops/cpu/ngram.cc
+++ b/onnxruntime/contrib_ops/cpu/ngram.cc
@@ -1,0 +1,485 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "ngram.h"
+#include "onnx/defs/schema.h"
+#include "core/common/common.h"
+#include "core/framework/tensor.h"
+
+#include <functional>
+#include <unordered_set>
+#include <ostream>
+#include <iterator>
+
+namespace onnxruntime {
+namespace contrib {
+
+ONNX_CPU_OPERATOR_TYPED_MS_KERNEL(
+    Ngram,
+    1,
+    string,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<std::string>())
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<float>()),
+    contrib::Ngram);
+
+ONNX_CPU_OPERATOR_TYPED_MS_KERNEL(
+    Ngram,
+    1,
+    int32_t,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<int32_t>())
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<float>()),
+    contrib::Ngram);
+
+ONNX_CPU_OPERATOR_TYPED_MS_KERNEL(
+    Ngram,
+    1,
+    int64_t,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<int64_t>())
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<float>()),
+    contrib::Ngram);
+
+namespace ngram_details {
+
+class NgramElementBase {
+  size_t id_;  // id in the pool
+ protected:
+  NgramElementBase(size_t id) : id_(id) {}
+  ~NgramElementBase() = default;
+
+ public:
+  size_t id() const { return id_; }
+};
+
+template <>
+class NGramItem<int64_t> : public NgramElementBase {
+  std::vector<int64_t> items_;
+
+ public:
+  template <typename ForwardIter>
+  explicit NGramItem(size_t id, ForwardIter first, ForwardIter last) : NgramElementBase(id),
+                                                                       items_(first, last) {
+    assert(!items_.empty());
+  }
+  // For sampling
+  explicit NGramItem() : NgramElementBase(0) {}
+  void AddItem(int64_t t) { items_.push_back(t); }
+  void DebugPrint() const {
+    std::copy(items_.cbegin(), items_.cend(), std::ostream_iterator<int64_t>(std::cout, ","));
+    std::cout << std::endl;
+  }
+  void Clear() { items_.clear(); }
+  bool operator==(const NGramItem& o) const {
+    return items_ == o.items_;
+  }
+  size_t hash() const {
+    if (items_.empty()) return 0;
+    auto first = items_.cbegin();
+    auto const end = items_.cend();
+    std::hash<int64_t> hf{};
+    auto hash = hf(*first);
+    while (++first != end) {
+      hash ^= hf(*first) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+    }
+    return hash;
+  }
+};
+
+template <class T>
+class NGramItem;
+
+template <>
+class NGramItem<int32_t> : public NGramItem<int64_t> {
+ public:
+  template <typename ForwardIter>
+  explicit NGramItem(size_t id, ForwardIter first, ForwardIter last) : NGramItem<int64_t>(id, first, last) {}
+  explicit NGramItem() = default;
+};
+
+template <>
+class NGramItem<std::string> : public NgramElementBase {
+ private:
+  std::vector<std::reference_wrapper<const std::string>> items_;
+
+ public:
+  template <typename ForwardIter>
+  explicit NGramItem(size_t id, ForwardIter first, ForwardIter last) : NgramElementBase(id) {
+    std::transform(first, last, std::back_inserter(items_),
+                   [](const std::string& s) { return std::cref(s); });
+    assert(!items_.empty());
+  }
+  explicit NGramItem() : NgramElementBase(0) {}
+  void AddItem(const std::string& s) { items_.push_back(std::cref(s)); }
+  void DebugPrint() const {
+    std::copy(items_.cbegin(), items_.cend(), std::ostream_iterator<std::string>(std::cout, ","));
+    std::cout << std::endl;
+  }
+  void Clear() { items_.clear(); }
+
+  bool operator==(const NGramItem& o) const {
+    if (items_.size() == o.items_.size()) {
+      return std::equal(items_.cbegin(), items_.cend(),
+                        o.items_.cbegin(), o.items_.cend(),
+                        std::equal_to<std::string>());
+    }
+    return false;
+  }
+  size_t hash() const {
+    if (items_.empty()) return 0;
+    auto first = items_.cbegin();
+    auto const end = items_.cend();
+    std::hash<std::string> hf{};
+    auto hash = hf(*first);
+    while (++first != end) {
+      hash ^= hf(*first) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+    }
+    return hash;
+  }
+};
+
+using IntegerPoolSet = std::unordered_set<NGramItem<int64_t>>;
+// Does not own strings, contains references to them. This helps
+// to search by string references that point to the current input.
+using StringPoolSet = std::unordered_set<NGramItem<std::string>>;
+
+template <typename ForwardIter, typename Cont>
+inline void Emplace(ForwardIter first, size_t ngrams, size_t ngram_size, size_t& ngram_id, Cont& c) {
+  for (; ngrams > 0; --ngrams) {
+    c.emplace(ngram_id, first, first + ngram_size);
+    first += ngram_size;
+    ++ngram_id;
+  }
+}
+
+}  // namespace ngram_details
+}  // namespace contrib
+}  // namespace onnxruntime
+
+using namespace onnxruntime::contrib::ngram_details;
+
+namespace std {
+template <typename T>
+struct hash<NGramItem<T>> {
+  typedef NGramItem<T> argument_type;
+  typedef size_t result_type;
+  result_type operator()(const argument_type& a) const {
+    return a.hash();
+  }
+};
+}  // namespace std
+
+namespace onnxruntime {
+namespace contrib {
+
+enum Mode {
+  kNone = 0,
+  kTF = 1,
+  kIDF = 2,
+  kTFIDF = 3
+};
+
+struct Ngram::Impl {
+  Mode mode_ = kNone;
+  int64_t N_ = 0;
+  int64_t M_ = 0;
+  int64_t S_ = 0;
+  bool all_ = false;
+  std::vector<int64_t> ngram_counts_;
+  std::vector<int64_t> ngram_indexes_;
+  std::vector<float> weights_;
+
+  std::vector<std::string> pool_strings_;
+  StringPoolSet str_set_;
+  IntegerPoolSet int_set_;
+  size_t output_size_ = 0;
+
+  MLDataType int32_dt_;
+  MLDataType int64_dt_;
+  MLDataType string_dt_;
+  Impl() {
+    int32_dt_ = DataTypeImpl::GetType<int32_t>();
+    int64_dt_ = DataTypeImpl::GetType<int64_t>();
+    string_dt_ = DataTypeImpl::GetType<std::string>();
+  }
+
+  template <typename T>
+  auto PoolEnd() const;
+
+  template <typename T>
+  auto Find(const ngram_details::NGramItem<T>&) const;
+
+  void IncrementCount(size_t ngram_id, std::vector<uint32_t>& frequencies) const {
+    assert(ngram_id < ngram_indexes_.size());
+    auto output_idx = ngram_indexes_[ngram_id];
+    ONNXRUNTIME_ENFORCE(output_idx >= 0, "ngram_indxes has a negative index");
+    assert(static_cast<size_t>(output_idx) < frequencies.size());
+    ++frequencies[output_idx];
+  }
+};
+
+template <>
+inline auto Ngram::Impl::PoolEnd<int64_t>() const {
+  return int_set_.cend();
+}
+
+template <>
+inline auto Ngram::Impl::PoolEnd<int32_t>() const {
+  return PoolEnd<int64_t>();
+}
+
+template <>
+inline auto Ngram::Impl::PoolEnd<std::string>() const {
+  return str_set_.cend();
+}
+
+template <>
+inline auto Ngram::Impl::Find<int64_t>(const NGramItem<int64_t>& i) const {
+  return int_set_.find(i);
+}
+
+template <>
+inline auto Ngram::Impl::Find<int32_t>(const NGramItem<int32_t>& i) const {
+  return int_set_.find(i);
+}
+
+template <>
+inline auto Ngram::Impl::Find<std::string>(const NGramItem<std::string>& i) const {
+  return str_set_.find(i);
+}
+
+Ngram::Ngram(const OpKernelInfo& info) : OpKernel(info), impl_(new Impl) {
+  std::string mode;
+  Status status = info.GetAttr("mode", &mode);
+  ONNXRUNTIME_ENFORCE(status.IsOK(), "mode is required");
+  if (mode == "TF") {
+    impl_->mode_ = kTF;
+  } else if (mode == "IDF") {
+    impl_->mode_ = kIDF;
+  } else if (mode == "TFIDF") {
+    impl_->mode_ = kTFIDF;
+  }
+  ONNXRUNTIME_ENFORCE(impl_->mode_ != kNone, "Unrecognized mode");
+
+  status = info.GetAttr("M", &impl_->M_);
+  ONNXRUNTIME_ENFORCE(status.IsOK() && impl_->M_ > 0, "Positive Attr M is required");
+  status = info.GetAttr("N", &impl_->N_);
+  ONNXRUNTIME_ENFORCE(status.IsOK() && impl_->N_ >= impl_->M_, "Positive M >= N is required");
+  status = info.GetAttr("S", &impl_->S_);
+  ONNXRUNTIME_ENFORCE(status.IsOK() && impl_->N_ >= 0, "Non-negative number of skips S is required");
+
+  int64_t all = 0;
+  status = info.GetAttr("all", &all);
+  ONNXRUNTIME_ENFORCE(status.IsOK(), "Attribute all is required");
+  impl_->all_ = (all != 0);
+
+  status = info.GetAttrs(std::string("ngram_counts"), impl_->ngram_counts_);
+  ONNXRUNTIME_ENFORCE(status.IsOK() && !impl_->ngram_counts_.empty(), "Non-empty ngram_counts is required");
+  ONNXRUNTIME_ENFORCE(size_t(impl_->M_) <= impl_->ngram_counts_.size(), "M must be inbounds of ngram_counts");
+  ONNXRUNTIME_ENFORCE(size_t(impl_->N_) <= impl_->ngram_counts_.size(), "N must be inbounds of ngram_counts");
+
+  status = info.GetAttrs("ngram_indexes", impl_->ngram_indexes_);
+  ONNXRUNTIME_ENFORCE(status.IsOK() && !impl_->ngram_indexes_.empty(), "Non-empty ngram_indexes is required");
+  {
+    // Check that all are positive
+    ONNXRUNTIME_ENFORCE(std::all_of(impl_->ngram_indexes_.cbegin(), impl_->ngram_indexes_.cend(),
+                                    [](int64_t i) { return i >= 0; }),
+                        "Negative ngram_indexes values are not allowed");
+    // Set output size to max output index + 1;
+    auto greatest_hit = std::max_element(impl_->ngram_indexes_.cbegin(), impl_->ngram_indexes_.cend());
+    impl_->output_size_ = *greatest_hit + 1;
+  }
+
+  status = info.GetAttrs("weights", impl_->weights_);
+  if (status.IsOK()) {
+    ONNXRUNTIME_ENFORCE(impl_->weights_.size() == impl_->ngram_indexes_.size(),
+                        "weights and indexes must have equal size");
+  }
+
+  std::vector<int64_t> pool_int64s;
+  status = info.GetAttrs("pool_strings", impl_->pool_strings_);
+  if (status.IsOK()) {
+    ONNXRUNTIME_ENFORCE(!impl_->pool_strings_.empty(), "pool_strings must not be empty if specified");
+  } else {
+    status = info.GetAttrs("pool_int64s", pool_int64s);
+    ONNXRUNTIME_ENFORCE(status.IsOK() && !pool_int64s.empty(), "non-empty pool_int64s is required if pool_strings not provided");
+  }
+
+  // Iterator via the pool. Insert 1 item for 1-grams, 2 items for 2-grams, etc.
+  const auto total_items = (impl_->pool_strings_.empty()) ? pool_int64s.size() : impl_->pool_strings_.size();
+  size_t ngram_id = 0;
+  // Load into dictionary only required Ns
+  const size_t M = impl_->M_;
+  const size_t N = impl_->N_;
+  size_t ngram_size = 1;
+  for (size_t i = 0; i < impl_->ngram_counts_.size(); ++i) {
+    size_t start_idx = impl_->ngram_counts_[i];
+    size_t end_idx = ((i + 1) < impl_->ngram_counts_.size()) ? impl_->ngram_counts_[i + 1] : total_items;
+    ONNXRUNTIME_ENFORCE(end_idx >= start_idx && end_idx <= total_items,
+                        "n-gram counts out of bounds for ", std::to_string(ngram_size), "-grams");
+    auto items = end_idx - start_idx;
+    if (items > 0) {
+      ONNXRUNTIME_ENFORCE((items % ngram_size == 0),
+                          "Number of items must compose whole ", std::to_string(ngram_size), "-grams");
+      auto ngrams = items / ngram_size;
+      // Skip loading into hash_set ngrams that are not N or not in the range of [M-N] for all=true;
+      if ((impl_->all_ && (ngram_size >= M && ngram_size <= N)) ||
+          ngram_size == N) {
+        if (impl_->pool_strings_.empty()) {
+          auto before_insert = impl_->int_set_.size();
+          Emplace(pool_int64s.begin() + start_idx, ngrams, ngram_size, ngram_id, impl_->int_set_);
+          ONNXRUNTIME_ENFORCE((before_insert + ngrams) == impl_->int_set_.size(), "pool_int64s duplicate ", std::to_string(ngram_size), "-grams detected");
+        } else {
+          auto before_insert = impl_->str_set_.size();
+          Emplace(impl_->pool_strings_.begin() + start_idx, ngrams, ngram_size, ngram_id, impl_->str_set_);
+          ONNXRUNTIME_ENFORCE((before_insert + ngrams) == impl_->str_set_.size(), "poll_strings duplicate ", std::to_string(ngram_size), "-grams detected");
+        }
+      } else {
+        ngram_id += ngrams;
+      }
+    }
+    ++ngram_size;
+  }
+}
+
+Ngram::~Ngram() {
+}
+
+void Ngram::OutputResult(OpKernelContext* ctx, const std::vector<uint32_t>& frequences) const {
+  std::vector<int64_t> output_dims;
+  output_dims.push_back(frequences.size());
+
+  TensorShape output_shape(output_dims);
+  auto Y = ctx->Output(0, output_shape);
+  auto output_data = Y->MutableData<float>();
+  const auto& w = impl_->weights_;
+  switch (impl_->mode_) {
+    case kTF: {
+      std::transform(frequences.cbegin(), frequences.cend(), output_data,
+                     [](uint32_t f) { return static_cast<float>(f); });
+    } break;
+    case kIDF: {
+      if (!w.empty()) {
+        assert(frequences.size() == w.size());
+        for (size_t i = 0; i < frequences.size(); ++i) {
+          *output_data++ = (frequences[i] > 0) ? w[i] : 0;
+        }
+      } else {
+        for (auto f : frequences) {
+          *output_data++ = (f > 0) ? 1.0f : 0;
+        }
+      }
+      break;
+      case kTFIDF: {
+        if (!w.empty()) {
+          assert(frequences.size() == w.size());
+          for (size_t i = 0; i < frequences.size(); ++i) {
+            *output_data++ = frequences[i] * w[i];
+          }
+        } else {
+          std::transform(frequences.cbegin(), frequences.cend(), output_data,
+                         [](uint32_t f) { return static_cast<float>(f); });
+        }
+      } break;
+      case kNone:  // fall-through
+      default:
+        assert(false);
+    }
+  }
+}
+
+template <typename T>
+void Ngram::ComputeImpl(OpKernelContext* ctx, size_t total_items) const {
+  const auto& impl = *impl_;
+  auto const set_end = impl.PoolEnd<T>();
+  // Frequency holder, init all to zero
+  std::vector<uint32_t> frequencies;
+  frequencies.resize(impl.output_size_, 0);
+
+  const auto N = impl.N_;
+  const auto S = impl.S_ + 1;  // Convert to distance
+  const auto n = (impl.all_) ? impl.M_ : N;
+
+  auto X = ctx->Input<Tensor>(0);
+  auto const input_data = X->template Data<T>();
+  auto const end_data = input_data + total_items;
+  NGramItem<T> sample;
+  for (auto ni = n; ni <= N; ++ni) {
+    // skip does not apply to unigrams
+    if (ni == 1) {
+      auto first = input_data;
+      while (first != end_data) {
+        sample.Clear();
+        sample.AddItem(*first);
+        auto hit = impl.Find<T>(sample);
+        if (hit != set_end) {
+          // record frequency
+          auto ngram_id = hit->id();
+          impl.IncrementCount(ngram_id, frequencies);
+        }
+        ++first;
+      }
+    } else {
+      // Convert skip into distance between n-gram items
+      // by adding 1
+      for (auto si = 1; si <= S; ++si) {
+        auto ngram_start = input_data;
+        while (ngram_start < end_data) {
+          // we are interested only in a whole n-gram so if the end
+          // does not fit, we stop
+          auto const ngram_end = ngram_start + si * (ni - 1) + 1;
+          if (ngram_end > end_data) {
+            break;
+          }
+          sample.Clear();
+          auto ngram_item = ngram_start;
+          while (ngram_item < ngram_end) {
+            sample.AddItem(*ngram_item);
+            ngram_item += si;
+          }
+          auto hit = impl.Find<T>(sample);
+          if (hit != set_end) {
+            // record frequency
+            auto ngram_id = hit->id();
+            impl.IncrementCount(ngram_id, frequencies);
+          }
+          ++ngram_start;
+        }
+      }
+    }
+  }
+  OutputResult(ctx, frequencies);
+}
+
+Status Ngram::Compute(OpKernelContext* ctx) const {
+  Status s;
+
+  auto X = ctx->Input<Tensor>(0);
+  auto& input_dims = X->Shape().GetDims();
+  size_t total_items = 1;
+  // Scalar
+  if (input_dims.empty() || (input_dims.size() == 1 && input_dims[0] == 0)) {
+    total_items = 1;
+  } else {
+    for (const auto& dim : input_dims) {
+      total_items *= dim;
+    }
+  }
+
+  if (X->DataType() == impl_->int32_dt_) {
+    ComputeImpl<int32_t>(ctx, total_items);
+  } else if (X->DataType() == impl_->int64_dt_) {
+    ComputeImpl<int64_t>(ctx, total_items);
+  } else if (X->DataType() == impl_->string_dt_) {
+    ComputeImpl<std::string>(ctx, total_items);
+  } else {
+    return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
+                  "Invalid type of the input argument");
+  }
+
+  return s;
+}
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/ngram.cc
+++ b/onnxruntime/contrib_ops/cpu/ngram.cc
@@ -53,6 +53,9 @@ class NgramElementBase {
   size_t id() const { return id_; }
 };
 
+template <class T>
+class NGramItem;
+
 template <>
 class NGramItem<int64_t> : public NgramElementBase {
   std::vector<int64_t> items_;
@@ -86,9 +89,6 @@ class NGramItem<int64_t> : public NgramElementBase {
     return hash;
   }
 };
-
-template <class T>
-class NGramItem;
 
 template <>
 class NGramItem<int32_t> : public NGramItem<int64_t> {
@@ -356,8 +356,9 @@ void Ngram::OutputResult(OpKernelContext* ctx, const std::vector<uint32_t>& freq
   const auto& w = impl_->weights_;
   switch (impl_->mode_) {
     case kTF: {
-      std::transform(frequences.cbegin(), frequences.cend(), output_data,
-                     [](uint32_t f) { return static_cast<float>(f); });
+      for (auto f : frequences) {
+        *output_data++ = static_cast<float>(f);
+      }
     } break;
     case kIDF: {
       if (!w.empty()) {
@@ -378,8 +379,9 @@ void Ngram::OutputResult(OpKernelContext* ctx, const std::vector<uint32_t>& freq
             *output_data++ = frequences[i] * w[i];
           }
         } else {
-          std::transform(frequences.cbegin(), frequences.cend(), output_data,
-                         [](uint32_t f) { return static_cast<float>(f); });
+          for (auto f : frequences) {
+            *output_data++ = static_cast<float>(f);
+          }
         }
       } break;
       case kNone:  // fall-through

--- a/onnxruntime/contrib_ops/cpu/ngram.cc
+++ b/onnxruntime/contrib_ops/cpu/ngram.cc
@@ -417,23 +417,22 @@ void Ngram::OutputResult(OpKernelContext* ctx, size_t B, const std::vector<uint3
           *output_data++ = (f > 0) ? 1.0f : 0;
         }
       }
-      break;
-      case kTFIDF: {
-        if (!w.empty()) {
-          assert(frequences.size() == w.size());
-          for (size_t i = 0; i < frequences.size(); ++i) {
-            *output_data++ = frequences[i] * w[i];
-          }
-        } else {
-          for (auto f : frequences) {
-            *output_data++ = static_cast<float>(f);
-          }
+    } break;
+    case kTFIDF: {
+      if (!w.empty()) {
+        assert(frequences.size() == w.size());
+        for (size_t i = 0; i < frequences.size(); ++i) {
+          *output_data++ = frequences[i] * w[i];
         }
-      } break;
-      case kNone:  // fall-through
-      default:
-        assert(false);
-    }
+      } else {
+        for (auto f : frequences) {
+          *output_data++ = static_cast<float>(f);
+        }
+      }
+    } break;
+    case kNone:  // fall-through
+    default:
+      assert(false);
   }
 }
 

--- a/onnxruntime/contrib_ops/cpu/ngram.h
+++ b/onnxruntime/contrib_ops/cpu/ngram.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "core/common/common.h"
 #include "core/framework/op_kernel.h"
 #include <memory>
 #include <vector>
@@ -14,7 +15,7 @@ class Ngram final : public OpKernel {
  public:
   explicit Ngram(const OpKernelInfo& info);
   ~Ngram();
-  ONNXRUNTIME_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(Ngram);
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(Ngram);
 
   Status Compute(OpKernelContext* ctx) const override;
 

--- a/onnxruntime/contrib_ops/cpu/ngram.h
+++ b/onnxruntime/contrib_ops/cpu/ngram.h
@@ -10,11 +10,6 @@
 namespace onnxruntime {
 namespace contrib {
 
-namespace ngram_details {
-template <class T>
-class NGramItem;
-}
-
 class Ngram final : public OpKernel {
  public:
   explicit Ngram(const OpKernelInfo& info);

--- a/onnxruntime/contrib_ops/cpu/ngram.h
+++ b/onnxruntime/contrib_ops/cpu/ngram.h
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/framework/op_kernel.h"
+#include <memory>
+#include <vector>
+
+namespace onnxruntime {
+namespace contrib {
+
+namespace ngram_details {
+template <class T>
+class NGramItem;
+}
+
+class Ngram final : public OpKernel {
+ public:
+  explicit Ngram(const OpKernelInfo& info);
+  ~Ngram();
+  ONNXRUNTIME_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(Ngram);
+
+  Status Compute(OpKernelContext* ctx) const override;
+
+ private:
+  template <typename T>
+  void ComputeImpl(OpKernelContext* ctx, size_t total_items) const;
+
+  // Apply weighing criteria and output
+  void OutputResult(OpKernelContext* ctx, const std::vector<uint32_t>& frequences) const;
+
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/ngram.h
+++ b/onnxruntime/contrib_ops/cpu/ngram.h
@@ -21,7 +21,7 @@ class Ngram final : public OpKernel {
 
  private:
   template <typename T>
-  void ComputeImpl(OpKernelContext* ctx, size_t total_items) const;
+  void ComputeImpl(OpKernelContext* ctx) const;
 
   // Apply weighing criteria and output
   void OutputResult(OpKernelContext* ctx, const std::vector<uint32_t>& frequences) const;

--- a/onnxruntime/contrib_ops/cpu/ngram.h
+++ b/onnxruntime/contrib_ops/cpu/ngram.h
@@ -21,10 +21,10 @@ class Ngram final : public OpKernel {
 
  private:
   template <typename T>
-  void ComputeImpl(OpKernelContext* ctx) const;
+  Status ComputeImpl(OpKernelContext* ctx) const;
 
   // Apply weighing criteria and output
-  void OutputResult(OpKernelContext* ctx, const std::vector<uint32_t>& frequences) const;
+  void OutputResult(OpKernelContext* ctx, size_t b_dim, const std::vector<uint32_t>& frequences) const;
 
   struct Impl;
   std::unique_ptr<Impl> impl_;

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -214,6 +214,90 @@ activation.)DOC")
       })
       .SetDoc(R"DOC(Tokenizer divides each string in X into a vector of strings along the last axis. All input strings including attributes are UTF-8 encoded.)DOC");
 
+  ONNX_CONTRIB_OPERATOR_SCHEMA(Ngram)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .Input(0, "X", "Input for n-gram extraction", "T")
+      .Output(0, "Y", "NGram results", "T1")
+      .TypeConstraint(
+          "T",
+          {"tensor(string)", "tensor(int32)", "tensor(int64)"},
+          "Input is ether string UTF-8 or int32/int64")
+      .TypeConstraint(
+          "T1",
+          {"tensor(float)"},
+          "1-D tensor of floats")
+      .Attr(
+          "N",
+          "Maximum n-gram length",
+          AttributeProto::INT)
+      .Attr(
+          "M",
+          "Minimum n-gram length",
+          AttributeProto::INT)
+      .Attr(
+          "all",
+          "Boolean to store all n-gram lengths [M-N] or only N.",
+          AttributeProto::INT)
+      .Attr(
+          "S",
+          "Maximum number of items(integers/strings) to be skipped when constructing an n-gram from X.",
+          AttributeProto::INT)
+      .Attr(
+          "pool_strings",
+          "List of strings n-grams learned from the training set. Either this or pool_int64s attributes must be present but not both."
+          "It's an 1-D tensor starting with the collections of all 1-grams and ending with the collections of n-grams."
+          "The i-th element in pool stores the n-gram that should be mapped to index ngram_indexes[i] in the output vector.",
+          AttributeProto::STRINGS,
+          OPTIONAL)
+      .Attr(
+          "pool_int64s",
+          "List of int64 n-grams learned from the training set. Either this or pool_strings attributes must be present but not both."
+          "It's an 1-D tensor starting with the collections of all 1-grams and ending with the collections of n-grams."
+          "The i-th element in pool stores the n-gram that should be mapped to index ngram_indexes[i] in the output vector.",
+          AttributeProto::INTS,
+          OPTIONAL)
+      .Attr(
+          "ngram_counts",
+          "The starting indexes of 1-grams, 2-grams, and so on in pool."
+          "It is useful when determining the boundary between two consecutive collections of n-grams."
+          "For example, if ngram_counts is [0, 17, 36], the first index (zero-based) of 1-gram/2-gram/3-gram"
+          "in pool are 0/17/36",
+          AttributeProto::INTS)
+      .Attr(
+          "ngram_indexes",
+          "list of int64s (type: AttributeProto::INTS). This list is parallel to the specified 'pool_*' attribute."
+          "The i-th element in ngram_indexes indicate the coordinate of the i-th n-gram in the output tensor.",
+          AttributeProto::INTS)
+      .Attr(
+          "weights",
+          "list of floats. This attribute stores the weight of each n-gram in pool. The i-th element in weights"
+          "is the weight of the i-th n-gram in pool. Its length equals to the size of ngram_indexes."
+          "By default, weights is an all-one tensor.This attribute is used when mode is \"IDF\" or \"TFIDF\""
+          "to scale the associated word counts.",
+          AttributeProto::FLOATS,
+          OPTIONAL)
+      .Attr(
+          "mode",
+          "The weighting criteria. It can be one of \"TF\" (term frequency),"
+          "\"IDF\" (inverse document frequency), and \"TFIDF\" (the combination of TF and IDF)",
+          AttributeProto::STRING)
+      .SetDoc(R"DOC(
+This transform extracts n-grams from the input integer sequence and save them as a vector.
+ In contract to standard n-gram extraction, here, the indexes of extracting an n-gram from the original
+ sequence are not necessarily consecutive numbers. The discontinuity between indexes are controlled by the number of skips. 
+ If the number of skips is 2, we should skip two tokens when scanning through the original sequence.
+ Let's consider an example. Assume that input sequence is [94, 17, 36, 12, 28] and the number of skips is 2.
+ The associated 2-grams are [94, 12] and [17, 28] respectively indexed by [0, 3] and [1, 4].
+ If the number of skips becomes 0, the 2-grams generated are [94, 17], [17, 36], [36, 12], [12, 28]
+ indexed by [0, 1], [1, 2], [2, 3], [3, 4], respectively. The output vector stores the count of each n-gram;
+ Y[i] indicates the times that the i-th n-gram is found. The attribute "ngrams" is used to determine the mapping
+ between index i and the corresponding n-gram. If "ngrams" is [ [94 , 17] , [ 17, 36 ] ], then the Y[0] (first element in Y)
+ and Y[1] (second element in Y) are the counts of [94, 17] and [17, 36], respectively.
+ An n-gram which cannot be found in gramPool should be ignored and has no effect on the output.
+ Note that we may consider all skips up to skipLength when generating the n-grams. 
+)DOC");
+
   // Operators for linear 8 bit quanitzation support.
   ONNX_CONTRIB_OPERATOR_SCHEMA(QuantizeLinear)
       .SetDomain(kMSDomain)

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -312,7 +312,7 @@ activation.)DOC")
             output_shape.add_dim()->set_dim_value(max_last_axis);
           } else {
             fail_shape_inference(
-                "Input shape must either be [C] or [B][C]");
+                "Input shape must have either [C] or [B,C] dimensions where C > 0 and B > 0");
           }
           updateOutputShape(ctx, 0, output_shape);
         }

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -236,10 +236,6 @@ activation.)DOC")
           "Minimum n-gram length",
           AttributeProto::INT)
       .Attr(
-          "all",
-          "Boolean to store all n-gram lengths [M-N] or only N.",
-          AttributeProto::INT)
-      .Attr(
           "S",
           "Maximum number of items(integers/strings) to be skipped when constructing an n-gram from X.",
           AttributeProto::INT)
@@ -299,7 +295,14 @@ This transform extracts n-grams from the input sequence and save them as a vecto
  between index i and the corresponding n-gram. If "ngrams" is [ [94 , 17] , [ 17, 36 ] ], then the Y[0] (first element in Y)
  and Y[1] (second element in Y) are the counts of [94, 17] and [17, 36], respectively.
  An n-gram which cannot be found in pool_strings/pool_int64s should be ignored and has no effect on the output.
- Note that we may consider all skips up to skipLength when generating the n-grams. 
+ Note that we may consider all skips up to S when generating the n-grams.
+
+The examples used above are true if mode is "TF". If mode is "IDF", all the counts larger than 1 would be truncated to 1 and
+the i-th element in weights would be used to scale (by multiplication) the count of the i-th n-gram in pool. If mode is "TFIDF",
+this operator first computes the counts of all n-grams and then scale them by the associated values in the weights attribute.
+
+Only one of pool_strings and pool_int64s can be set. If pool_int64s is set, the input should be an integer tensor.
+If pool_strings is set, the input must be a string tensor.
 )DOC");
 
   // Operators for linear 8 bit quanitzation support.

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -282,9 +282,13 @@ activation.)DOC")
           "The weighting criteria. It can be one of \"TF\" (term frequency),"
           "\"IDF\" (inverse document frequency), and \"TFIDF\" (the combination of TF and IDF)",
           AttributeProto::STRING)
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
+        output_elem_type->set_elem_type(ONNX_NAMESPACE::TensorProto::FLOAT);
+      })
       .SetDoc(R"DOC(
-This transform extracts n-grams from the input integer sequence and save them as a vector.
- In contract to standard n-gram extraction, here, the indexes of extracting an n-gram from the original
+This transform extracts n-grams from the input sequence and save them as a vector.
+ In contrast to standard n-gram extraction, here, the indexes of extracting an n-gram from the original
  sequence are not necessarily consecutive numbers. The discontinuity between indexes are controlled by the number of skips. 
  If the number of skips is 2, we should skip two tokens when scanning through the original sequence.
  Let's consider an example. Assume that input sequence is [94, 17, 36, 12, 28] and the number of skips is 2.
@@ -294,7 +298,7 @@ This transform extracts n-grams from the input integer sequence and save them as
  Y[i] indicates the times that the i-th n-gram is found. The attribute "ngrams" is used to determine the mapping
  between index i and the corresponding n-gram. If "ngrams" is [ [94 , 17] , [ 17, 36 ] ], then the Y[0] (first element in Y)
  and Y[1] (second element in Y) are the counts of [94, 17] and [17, 36], respectively.
- An n-gram which cannot be found in gramPool should be ignored and has no effect on the output.
+ An n-gram which cannot be found in pool_strings/pool_int64s should be ignored and has no effect on the output.
  Note that we may consider all skips up to skipLength when generating the n-grams. 
 )DOC");
 

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -258,7 +258,8 @@ activation.)DOC")
           "The starting indexes of 1-grams, 2-grams, and so on in pool."
           "It is useful when determining the boundary between two consecutive collections of n-grams."
           "For example, if ngram_counts is [0, 17, 36], the first index (zero-based) of 1-gram/2-gram/3-gram"
-          "in pool are 0/17/36",
+          "in pool are 0/17/36. This format is essentially identical to CSR (or CSC) sparse matrix format, "
+          "and we choose to keep this due to its popularity.",
           AttributeProto::INTS)
       .Attr(
           "ngram_indexes",

--- a/onnxruntime/test/contrib_ops/ngram_test.cc
+++ b/onnxruntime/test/contrib_ops/ngram_test.cc
@@ -1,0 +1,395 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+
+#include <stdint.h>
+
+namespace onnxruntime {
+namespace test {
+namespace ngram_test {
+
+constexpr const char* domain = onnxruntime::kMSDomain;
+const int opset_ver = 1;
+
+void InitTestAttr(OpTester& test, const std::string& mode,
+                  int64_t M, int64_t N, int64_t S, bool all,
+                  const std::vector<int64_t>& ngram_counts,
+                  const std::vector<int64_t>& ngram_indexes,
+                  const std::vector<float>& weights,
+                  const std::vector<int64_t>& pool_int64s,
+                  const std::vector<std::string>& pool_strings) {
+  test.AddAttribute("mode", mode);
+  test.AddAttribute("M", M);
+  test.AddAttribute("N", N);
+  test.AddAttribute("S", S);
+  test.AddAttribute("all", int64_t{all});
+  test.AddAttribute("ngram_counts", ngram_counts);
+  test.AddAttribute("ngram_indexes", ngram_indexes);
+  // optional
+  if (!weights.empty()) {
+    test.AddAttribute("weights", weights);
+  }
+  if (!pool_int64s.empty()) {
+    test.AddAttribute("pool_int64s", pool_int64s);
+  } else {
+    test.AddAttribute("pool_strings", pool_strings);
+  }
+}
+}  // namespace ngram_test
+
+using namespace ngram_test;
+
+TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_Skip0) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=0, , all=false, weights empty, int32
+  InitTestAttr(test, "TF", 1, 2, 0, false,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {2, 3, 5, 4,         //1-grams
+                5, 6, 7, 8, 6, 7},  //bi-grams
+               {});
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 0, 0, 0, 1, 1, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, Ngram_String_TF_AllFalse_Skip0) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=0, , all=false, weights empty, string
+  InitTestAttr(test, "TF", 1, 2, 0, false,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {},
+               {"two", "three", "five", "four",                     //1-grams
+                "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
+                                 "six", "seven", "five", "six", "eight"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 0, 0, 0, 1, 1, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_Skip0_LevelEmpty) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=0, , all=false, weights empty, int32
+  InitTestAttr(test, "TF", 1, 2, 0, false,
+               {0, 0},
+               {
+                   0,
+                   1,
+                   2,
+               },  //7 output indexes
+               {},
+               {                    //1-grams none
+                5, 6, 7, 8, 6, 7},  //bi-grams
+               {});
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{3};
+  std::vector<float> output = {1, 1, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=5, , all=false, weights empty, int32
+  InitTestAttr(test, "TF", 1, 2, 5, false,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {2, 3, 5, 4,         //1-grams
+                5, 6, 7, 8, 6, 7},  //bi-grams
+               {});
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 0, 0, 0, 1, 3, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, Ngram_String_TF_AllFalse_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=0, , all=false, weights empty, string
+  InitTestAttr(test, "TF", 1, 2, 5, false,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {},
+               {"two", "three", "five", "four",                     //1-grams
+                "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
+                                 "six", "seven", "five", "six", "eight"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 0, 0, 0, 1, 3, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, Ngram_Int32_TF_AllTrue_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=5, , all=false, weights empty, int32
+  InitTestAttr(test, "TF", 1, 2, 5, true,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {2, 3, 5, 4,         //1-grams
+                5, 6, 7, 8, 6, 7},  //bi-grams
+               {});
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 3, 1, 0, 1, 3, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, Ngram_String_TF_AllTrue_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=0, , all=false, weights empty, string
+  InitTestAttr(test, "TF", 1, 2, 5, true,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {},
+               {"two", "three", "five", "four",                     //1-grams
+                "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
+                                 "six", "seven", "five", "six", "eight"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 3, 1, 0, 1, 3, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, Ngram_Int32_IDF_AllFalse_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=5, , all=false, weights empty, int32
+  // We change to IDF but do not supply weights so
+  // we should get all 1.0f
+  InitTestAttr(test, "IDF", 1, 2, 5, false,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {2, 3, 5, 4,         //1-grams
+                5, 6, 7, 8, 6, 7},  //bi-grams
+               {});
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 0, 0, 0, 1, 1, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, Ngram_String_IDF_AllFalse_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=0, , all=false, weights empty, string
+  InitTestAttr(test, "IDF", 1, 2, 5, false,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {},
+               {"two", "three", "five", "four",                     //1-grams
+                "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
+                                 "six", "seven", "five", "six", "eight"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 0, 0, 0, 1, 1, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, Ngram_Int32_TFIDF_AllFalse_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=5, , all=false, weights empty, int32
+  // We change to TFIDF but do not supply weights so
+  // we should all get the original values as weights are 1.0f by
+  // default
+  InitTestAttr(test, "TFIDF", 1, 2, 5, false,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {2, 3, 5, 4,         //1-grams
+                5, 6, 7, 8, 6, 7},  //bi-grams
+               {});
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 0, 0, 0, 1, 3, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, Ngram_String_TFIDF_AllFalse_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=0, , all=false, weights empty, string
+  InitTestAttr(test, "TFIDF", 1, 2, 5, false,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {},
+               {"two", "three", "five", "four",                     //1-grams
+                "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
+                                 "six", "seven", "five", "six", "eight"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 0, 0, 0, 1, 3, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, Ngram_Int32_IDFWeights_AllFalse_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=5, , all=false, weights empty, int32
+  // We change to IDF with supplied weights. All
+  // with non-zero counts must be replaced with the supplied weights
+  InitTestAttr(test, "IDF", 1, 2, 5, false,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},
+               {2, 3, 5, 4,         //1-grams
+                5, 6, 7, 8, 6, 7},  //bi-grams
+               {});
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 0, 0, 0, 2, 3, 2};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, Ngram_String_IDFWeights_AllFalse_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=0, , all=false, weights empty, string
+  InitTestAttr(test, "IDF", 1, 2, 5, false,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},
+               {},
+               {"two", "three", "five", "four",                     //1-grams
+                "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
+                                 "six", "seven", "five", "six", "eight"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 0, 0, 0, 2, 3, 2};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, Ngram_Int32_TFIDFWeights_AllFalse_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=5, , all=false, weights empty, int32
+  // We change to TFIDF with supplied weights.
+  // We should have all counts scaled by weights
+  InitTestAttr(test, "TFIDF", 1, 2, 5, false,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},
+               {2, 3, 5, 4,         //1-grams
+                5, 6, 7, 8, 6, 7},  //bi-grams
+               {});
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 0, 0, 0, 2, 9, 2};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpTest, Ngram_String_TFIDFWeights_AllFalse_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // 1 - 2, s=0, , all=false, weights empty, string
+  InitTestAttr(test, "TFIDF", 1, 2, 5, false,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},
+               {},
+               {"two", "three", "five", "four",                     //1-grams
+                "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
+                                 "six", "seven", "five", "six", "eight"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 0, 0, 0, 2, 9, 2};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/ngram_test.cc
+++ b/onnxruntime/test/contrib_ops/ngram_test.cc
@@ -41,6 +41,14 @@ void InitTestAttr(OpTester& test, const std::string& mode,
 
 using namespace ngram_test;
 
+// Here is what takes place in general and in particular
+// in this unit test.There are 7 n - grams : 4 unigrams and 3 bigrams
+// that are expressed as 10 items(integers in this case) contained within pool_int64 attribute.
+// We only count and then optionally scale those ngrams that appear in the supplied pool parameter(either int64 or string).
+// M = 1 and N = 2 in this case.
+// However, attribute all controls whether we consider all of the supplied ngram[M..N] sizes
+// into consideration or not.With all = false, we only consider N - grams.
+
 TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_Skip0) {
   OpTester test("Ngram", opset_ver, domain);
   // 1 - 2, s=0, , all=false, weights empty, int32
@@ -57,6 +65,7 @@ TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_Skip0) {
   test.AddInput<int32_t>("T", dims, input);
 
   std::vector<int64_t> out_dims{7};
+  // all=false, only bi-grams are counted
   std::vector<float> output = {0, 0, 0, 0, 1, 1, 1};
   test.AddOutput<float>("Y", out_dims, output);
 
@@ -80,6 +89,7 @@ TEST(ContribOpTest, Ngram_String_TF_AllFalse_Skip0) {
   test.AddInput<std::string>("T", dims, input);
 
   std::vector<int64_t> out_dims{7};
+  // all=false, only bi-grams are counted
   std::vector<float> output = {0, 0, 0, 0, 1, 1, 1};
   test.AddOutput<float>("Y", out_dims, output);
 
@@ -90,7 +100,7 @@ TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_Skip0_LevelEmpty) {
   OpTester test("Ngram", opset_ver, domain);
   // 1 - 2, s=0, , all=false, weights empty, int32
   InitTestAttr(test, "TF", 1, 2, 0, false,
-               {0, 0},
+               {0, 0},  // no unigrams, bi-grams start immediately
                {
                    0,
                    1,
@@ -106,6 +116,7 @@ TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_Skip0_LevelEmpty) {
   test.AddInput<int32_t>("T", dims, input);
 
   std::vector<int64_t> out_dims{3};
+  // No 1-grams only bi-grams
   std::vector<float> output = {1, 1, 1};
   test.AddOutput<float>("Y", out_dims, output);
 
@@ -128,6 +139,8 @@ TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_Skip5) {
   test.AddInput<int32_t>("T", dims, input);
 
   std::vector<int64_t> out_dims{7};
+  // No 1-grams but Skip is 5 so we manage to count 3
+  // occurrences of [7,8]
   std::vector<float> output = {0, 0, 0, 0, 1, 3, 1};
   test.AddOutput<float>("Y", out_dims, output);
 
@@ -151,6 +164,8 @@ TEST(ContribOpTest, Ngram_String_TF_AllFalse_Skip5) {
   test.AddInput<std::string>("T", dims, input);
 
   std::vector<int64_t> out_dims{7};
+  // No 1-grams but Skip is 5 so we manage to count 3
+  // occurrences of [7,8]
   std::vector<float> output = {0, 0, 0, 0, 1, 3, 1};
   test.AddOutput<float>("Y", out_dims, output);
 
@@ -173,6 +188,7 @@ TEST(ContribOpTest, Ngram_Int32_TF_AllTrue_Skip5) {
   test.AddInput<int32_t>("T", dims, input);
 
   std::vector<int64_t> out_dims{7};
+  // We consider both 1-grams and 2-grams so get all the counts here
   std::vector<float> output = {0, 3, 1, 0, 1, 3, 1};
   test.AddOutput<float>("Y", out_dims, output);
 

--- a/onnxruntime/test/contrib_ops/ngram_test.cc
+++ b/onnxruntime/test/contrib_ops/ngram_test.cc
@@ -14,7 +14,7 @@ constexpr const char* domain = onnxruntime::kMSDomain;
 const int opset_ver = 1;
 
 void InitTestAttr(OpTester& test, const std::string& mode,
-                  int64_t M, int64_t N, int64_t S, bool all,
+                  int64_t M, int64_t N, int64_t S,
                   const std::vector<int64_t>& ngram_counts,
                   const std::vector<int64_t>& ngram_indexes,
                   const std::vector<float>& weights,
@@ -24,7 +24,6 @@ void InitTestAttr(OpTester& test, const std::string& mode,
   test.AddAttribute("M", M);
   test.AddAttribute("N", N);
   test.AddAttribute("S", S);
-  test.AddAttribute("all", int64_t{all});
   test.AddAttribute("ngram_counts", ngram_counts);
   test.AddAttribute("ngram_indexes", ngram_indexes);
   // optional
@@ -49,10 +48,10 @@ using namespace ngram_test;
 // However, attribute all controls whether we consider all of the supplied ngram[M..N] sizes
 // into consideration or not.With all = false, we only consider N - grams.
 
-TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_Skip0) {
+TEST(ContribOpTest, Ngram_Int32_TF_onlyBigrams_Skip0) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , all=false, weights empty, int32
-  InitTestAttr(test, "TF", 1, 2, 0, false,
+  // 1 - 2, s=0, , M=N, weights empty, int32
+  InitTestAttr(test, "TF", 2, 2, 0,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
                {},
@@ -72,10 +71,10 @@ TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_Skip0) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_String_TF_AllFalse_Skip0) {
+TEST(ContribOpTest, Ngram_String_TF_onlyBigrams_Skip0) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , all=false, weights empty, string
-  InitTestAttr(test, "TF", 1, 2, 0, false,
+  // 1 - 2, s=0, , M=N, weights empty, string
+  InitTestAttr(test, "TF", 2, 2, 0,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
                {},
@@ -96,10 +95,10 @@ TEST(ContribOpTest, Ngram_String_TF_AllFalse_Skip0) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_Skip0_LevelEmpty) {
+TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_onlyBigrams_LevelEmpty) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , all=false, weights empty, int32
-  InitTestAttr(test, "TF", 1, 2, 0, false,
+  // 1 - 2, s=0, , M=N, weights empty, int32
+  InitTestAttr(test, "TF", 2, 2, 0,
                {0, 0},  // no unigrams, bi-grams start immediately
                {
                    0,
@@ -123,10 +122,10 @@ TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_Skip0_LevelEmpty) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_Skip5) {
+TEST(ContribOpTest, Ngram_Int32_TF_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=5, , all=false, weights empty, int32
-  InitTestAttr(test, "TF", 1, 2, 5, false,
+  // 1 - 2, s=5, , M=N, weights empty, int32
+  InitTestAttr(test, "TF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
                {},
@@ -147,10 +146,10 @@ TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_String_TF_AllFalse_Skip5) {
+TEST(ContribOpTest, Ngram_String_TF_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , all=false, weights empty, string
-  InitTestAttr(test, "TF", 1, 2, 5, false,
+  // 1 - 2, s=0, , M=N, weights empty, string
+  InitTestAttr(test, "TF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
                {},
@@ -172,10 +171,10 @@ TEST(ContribOpTest, Ngram_String_TF_AllFalse_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_Int32_TF_AllTrue_Skip5) {
+TEST(ContribOpTest, Ngram_Int32_TF_UniAndBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=5, , all=false, weights empty, int32
-  InitTestAttr(test, "TF", 1, 2, 5, true,
+  // 1 - 2, s=5, , M=1, N=2, weights empty, int32
+  InitTestAttr(test, "TF", 1, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
                {},
@@ -195,10 +194,10 @@ TEST(ContribOpTest, Ngram_Int32_TF_AllTrue_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_String_TF_AllTrue_Skip5) {
+TEST(ContribOpTest, Ngram_String_TF_UniAndBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , all=false, weights empty, string
-  InitTestAttr(test, "TF", 1, 2, 5, true,
+  // 1 - 2, s=0, , M=1, N=2, weights empty, string
+  InitTestAttr(test, "TF", 1, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
                {},
@@ -218,12 +217,12 @@ TEST(ContribOpTest, Ngram_String_TF_AllTrue_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_Int32_IDF_AllFalse_Skip5) {
+TEST(ContribOpTest, Ngram_Int32_IDF_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=5, , all=false, weights empty, int32
+  // 1 - 2, s=5, , M=N, weights empty, int32
   // We change to IDF but do not supply weights so
   // we should get all 1.0f
-  InitTestAttr(test, "IDF", 1, 2, 5, false,
+  InitTestAttr(test, "IDF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
                {},
@@ -242,10 +241,10 @@ TEST(ContribOpTest, Ngram_Int32_IDF_AllFalse_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_String_IDF_AllFalse_Skip5) {
+TEST(ContribOpTest, Ngram_String_IDF_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , all=false, weights empty, string
-  InitTestAttr(test, "IDF", 1, 2, 5, false,
+  // 1 - 2, s=0, , M=N, weights empty, string
+  InitTestAttr(test, "IDF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
                {},
@@ -265,13 +264,13 @@ TEST(ContribOpTest, Ngram_String_IDF_AllFalse_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_Int32_TFIDF_AllFalse_Skip5) {
+TEST(ContribOpTest, Ngram_Int32_TFIDF_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=5, , all=false, weights empty, int32
+  // 1 - 2, s=5, , M=N=2, weights empty, int32
   // We change to TFIDF but do not supply weights so
   // we should all get the original values as weights are 1.0f by
   // default
-  InitTestAttr(test, "TFIDF", 1, 2, 5, false,
+  InitTestAttr(test, "TFIDF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
                {},
@@ -290,10 +289,10 @@ TEST(ContribOpTest, Ngram_Int32_TFIDF_AllFalse_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_String_TFIDF_AllFalse_Skip5) {
+TEST(ContribOpTest, Ngram_String_TFIDF_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , all=false, weights empty, string
-  InitTestAttr(test, "TFIDF", 1, 2, 5, false,
+  // 1 - 2, s=0, , M=N=2, weights empty, string
+  InitTestAttr(test, "TFIDF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
                {},
@@ -313,12 +312,12 @@ TEST(ContribOpTest, Ngram_String_TFIDF_AllFalse_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_Int32_IDFWeights_AllFalse_Skip5) {
+TEST(ContribOpTest, Ngram_Int32_IDFWeights_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=5, , all=false, weights empty, int32
+  // 1 - 2, s=5, , M=N=2, weights empty, int32
   // We change to IDF with supplied weights. All
   // with non-zero counts must be replaced with the supplied weights
-  InitTestAttr(test, "IDF", 1, 2, 5, false,
+  InitTestAttr(test, "IDF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
                {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},
@@ -337,10 +336,10 @@ TEST(ContribOpTest, Ngram_Int32_IDFWeights_AllFalse_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_String_IDFWeights_AllFalse_Skip5) {
+TEST(ContribOpTest, Ngram_String_IDFWeights_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , all=false, weights empty, string
-  InitTestAttr(test, "IDF", 1, 2, 5, false,
+  // 1 - 2, s=0, , M=N=2, weights empty, string
+  InitTestAttr(test, "IDF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
                {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},
@@ -360,12 +359,12 @@ TEST(ContribOpTest, Ngram_String_IDFWeights_AllFalse_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_Int32_TFIDFWeights_AllFalse_Skip5) {
+TEST(ContribOpTest, Ngram_Int32_TFIDFWeights_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=5, , all=false, weights empty, int32
+  // 1 - 2, s=5, , M=N=2, weights empty, int32
   // We change to TFIDF with supplied weights.
   // We should have all counts scaled by weights
-  InitTestAttr(test, "TFIDF", 1, 2, 5, false,
+  InitTestAttr(test, "TFIDF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
                {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},
@@ -384,10 +383,10 @@ TEST(ContribOpTest, Ngram_Int32_TFIDFWeights_AllFalse_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_String_TFIDFWeights_AllFalse_Skip5) {
+TEST(ContribOpTest, Ngram_String_TFIDFWeights_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , all=false, weights empty, string
-  InitTestAttr(test, "TFIDF", 1, 2, 5, false,
+  // 1 - 2, s=0, , M=N=2, weights empty, string
+  InitTestAttr(test, "TFIDF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
                {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},

--- a/onnxruntime/test/contrib_ops/ngram_test.cc
+++ b/onnxruntime/test/contrib_ops/ngram_test.cc
@@ -14,16 +14,16 @@ constexpr const char* domain = onnxruntime::kMSDomain;
 const int opset_ver = 1;
 
 void InitTestAttr(OpTester& test, const std::string& mode,
-                  int64_t M, int64_t N, int64_t S,
+                  int64_t min_gram_length, int64_t max_gram_length, int64_t max_skip_count,
                   const std::vector<int64_t>& ngram_counts,
                   const std::vector<int64_t>& ngram_indexes,
                   const std::vector<float>& weights,
                   const std::vector<int64_t>& pool_int64s,
                   const std::vector<std::string>& pool_strings) {
   test.AddAttribute("mode", mode);
-  test.AddAttribute("M", M);
-  test.AddAttribute("N", N);
-  test.AddAttribute("S", S);
+  test.AddAttribute("min_gram_length", min_gram_length);
+  test.AddAttribute("max_gram_length", max_gram_length);
+  test.AddAttribute("max_skip_count", max_skip_count);
   test.AddAttribute("ngram_counts", ngram_counts);
   test.AddAttribute("ngram_indexes", ngram_indexes);
   // optional
@@ -48,9 +48,9 @@ using namespace ngram_test;
 // However, attribute all controls whether we consider all of the supplied ngram[M..N] sizes
 // into consideration or not.With all = false, we only consider N - grams.
 
-TEST(ContribOpTest, Ngram_Int32_TF_onlyBigrams_Skip0) {
+TEST(ContribOpNgramTest, Int32_TF_onlyBigrams_Skip0) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , M=N, weights empty, int32
+  // s=0, Min=Max=2, weights empty, int32
   InitTestAttr(test, "TF", 2, 2, 0,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
@@ -59,21 +59,68 @@ TEST(ContribOpTest, Ngram_Int32_TF_onlyBigrams_Skip0) {
                 5, 6, 7, 8, 6, 7},  //bi-grams
                {});
 
-  std::vector<int64_t> dims{2, 6};
+  std::vector<int64_t> dims{12};
   std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
   test.AddInput<int32_t>("T", dims, input);
 
   std::vector<int64_t> out_dims{7};
-  // all=false, only bi-grams are counted
   std::vector<float> output = {0, 0, 0, 0, 1, 1, 1};
   test.AddOutput<float>("Y", out_dims, output);
 
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_String_TF_onlyBigrams_Skip0) {
+TEST(ContribOpNgramTest, Int32_TF_BatchOnlyBigrams_Skip0) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , M=N, weights empty, string
+  // s=0, Min=Max=2, weights empty, int32
+  InitTestAttr(test, "TF", 2, 2, 0,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {2, 3, 5, 4,         //1-grams
+                5, 6, 7, 8, 6, 7},  //bi-grams
+               {});
+
+  // Tow batches by six
+  std::vector<int64_t> dims{2, 6};
+  std::vector<int32_t> input = {1, 1, 3, 3, 3, 7,
+                                8, 6, 7, 5, 6, 8};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{2, 7};
+  std::vector<float> output = {0, 0, 0, 0, 0, 0, 0,
+                               0, 0, 0, 0, 1, 0, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpNgramTest, String_TF_OnlyBigrams_Skip0) {
+  OpTester test("Ngram", opset_ver, domain);
+  // s=0, Min=Max=2, weights empty, string
+  InitTestAttr(test, "TF", 2, 2, 0,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {},
+               {"two", "three", "five", "four",                     //1-grams
+                "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
+
+  std::vector<int64_t> dims{12};
+  std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
+                                 "six", "seven", "five", "six", "eight"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 0, 0, 0, 1, 1, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpNgramTest, String_TF_BatchOnlyBigrams_Skip0) {
+  OpTester test("Ngram", opset_ver, domain);
+  // s=0, Min=Max=2, weights empty, string
   InitTestAttr(test, "TF", 2, 2, 0,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
@@ -83,21 +130,24 @@ TEST(ContribOpTest, Ngram_String_TF_onlyBigrams_Skip0) {
                 "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
 
   std::vector<int64_t> dims{2, 6};
-  std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
-                                 "six", "seven", "five", "six", "eight"};
+  std::vector<std::string> input{"one", "one", "three", "three", "three", "seven",
+                                 "eight", "six", "seven", "five", "six", "eight"};
   test.AddInput<std::string>("T", dims, input);
 
-  std::vector<int64_t> out_dims{7};
-  // all=false, only bi-grams are counted
-  std::vector<float> output = {0, 0, 0, 0, 1, 1, 1};
+  std::vector<int64_t> out_dims{2, 7};
+  // ["seven", "eight"] can not be found due to batch boundary and s=0
+  // bigram elements have to be next to each other
+  std::vector<float> output = {0, 0, 0, 0, 0, 0, 0,
+                               0, 0, 0, 0, 1, 0, 1};
+
   test.AddOutput<float>("Y", out_dims, output);
 
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_onlyBigrams_LevelEmpty) {
+TEST(ContribOpNgramTest, Int32_TF_onlyBigrams_LevelEmpty) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , M=N, weights empty, int32
+  // s=0, Min=Max=2, weights empty, int32
   InitTestAttr(test, "TF", 2, 2, 0,
                {0, 0},  // no unigrams, bi-grams start immediately
                {
@@ -110,21 +160,20 @@ TEST(ContribOpTest, Ngram_Int32_TF_AllFalse_onlyBigrams_LevelEmpty) {
                 5, 6, 7, 8, 6, 7},  //bi-grams
                {});
 
-  std::vector<int64_t> dims{2, 6};
+  std::vector<int64_t> dims{12};
   std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
   test.AddInput<int32_t>("T", dims, input);
 
   std::vector<int64_t> out_dims{3};
-  // No 1-grams only bi-grams
   std::vector<float> output = {1, 1, 1};
   test.AddOutput<float>("Y", out_dims, output);
 
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_Int32_TF_onlyBigrams_Skip5) {
+TEST(ContribOpNgramTest, Int32_TF_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=5, , M=N, weights empty, int32
+  // s=5, Min=Max=2, weights empty, int32
   InitTestAttr(test, "TF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
@@ -133,7 +182,7 @@ TEST(ContribOpTest, Ngram_Int32_TF_onlyBigrams_Skip5) {
                 5, 6, 7, 8, 6, 7},  //bi-grams
                {});
 
-  std::vector<int64_t> dims{2, 6};
+  std::vector<int64_t> dims{12};
   std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
   test.AddInput<int32_t>("T", dims, input);
 
@@ -146,9 +195,60 @@ TEST(ContribOpTest, Ngram_Int32_TF_onlyBigrams_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_String_TF_onlyBigrams_Skip5) {
+TEST(ContribOpNgramTest, Int32_TF_BatchOnlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , M=N, weights empty, string
+  // s=5, , Min=Max=2, weights empty, int32
+  InitTestAttr(test, "TF", 2, 2, 5,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {2, 3, 5, 4,         //1-grams
+                5, 6, 7, 8, 6, 7},  //bi-grams
+               {});
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<int32_t> input = {1, 1, 3, 3, 3, 7,
+                                8, 6, 7, 5, 6, 8};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{2, 7};
+  // Skip is 5 but we are constraint by row boundaries
+  // so count only 1 of each
+  std::vector<float> output = {0, 0, 0, 0, 0, 0, 0,
+                               0, 0, 0, 0, 1, 1, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpNgramTest, String_TF_onlyBigrams_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // s=5, , Min=Max=2, weights empty, string
+  InitTestAttr(test, "TF", 2, 2, 5,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {},
+               {"two", "three", "five", "four",                     //1-grams
+                "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
+
+  std::vector<int64_t> dims{12};
+  std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
+                                 "six", "seven", "five", "six", "eight"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  // No 1-grams but Skip is 5 so we manage to count 3
+  // occurrences of [7,8] in one batch (row)
+  std::vector<float> output = {0, 0, 0, 0, 1, 3, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpNgramTest, String_TF_BatchOnlyBigrams_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // s=5, , Min=Max=2, weights empty, string
   InitTestAttr(test, "TF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
@@ -162,18 +262,17 @@ TEST(ContribOpTest, Ngram_String_TF_onlyBigrams_Skip5) {
                                  "six", "seven", "five", "six", "eight"};
   test.AddInput<std::string>("T", dims, input);
 
-  std::vector<int64_t> out_dims{7};
-  // No 1-grams but Skip is 5 so we manage to count 3
-  // occurrences of [7,8]
-  std::vector<float> output = {0, 0, 0, 0, 1, 3, 1};
+  std::vector<int64_t> out_dims{2, 7};
+  std::vector<float> output = {0, 0, 0, 0, 0, 0, 0,
+                               0, 0, 0, 0, 1, 1, 1};
   test.AddOutput<float>("Y", out_dims, output);
 
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_Int32_TF_UniAndBigrams_Skip5) {
+TEST(ContribOpNgramTest, Int32_TF_UniAndBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=5, , M=1, N=2, weights empty, int32
+  // s=5, , Min=1, Max=2, weights empty, int32
   InitTestAttr(test, "TF", 1, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
@@ -182,7 +281,7 @@ TEST(ContribOpTest, Ngram_Int32_TF_UniAndBigrams_Skip5) {
                 5, 6, 7, 8, 6, 7},  //bi-grams
                {});
 
-  std::vector<int64_t> dims{2, 6};
+  std::vector<int64_t> dims{12};
   std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
   test.AddInput<int32_t>("T", dims, input);
 
@@ -194,9 +293,57 @@ TEST(ContribOpTest, Ngram_Int32_TF_UniAndBigrams_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_String_TF_UniAndBigrams_Skip5) {
+TEST(ContribOpNgramTest, Int32_TF_BatchUniAndBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , M=1, N=2, weights empty, string
+  // s=5, Min=1, Max=2, weights empty, int32
+  InitTestAttr(test, "TF", 1, 2, 5,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {2, 3, 5, 4,         //1-grams
+                5, 6, 7, 8, 6, 7},  //bi-grams
+               {});
+
+  std::vector<int64_t> dims{2, 6};
+  std::vector<int32_t> input = {1, 1, 3, 3, 3, 7,
+                                8, 6, 7, 5, 6, 8};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{2, 7};
+  // Counts are now per row (batch)
+  std::vector<float> output = {0, 3, 0, 0, 0, 0, 0,
+                               0, 0, 1, 0, 1, 1, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpNgramTest, String_TF_UniAndBigrams_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // s=5, Min=1, Max=2, weights empty, string
+  InitTestAttr(test, "TF", 1, 2, 5,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
+               {},
+               {},
+               {"two", "three", "five", "four",                     //1-grams
+                "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
+
+  std::vector<int64_t> dims{12};
+  std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
+                                 "six", "seven", "five", "six", "eight"};
+  test.AddInput<std::string>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  std::vector<float> output = {0, 3, 1, 0, 1, 3, 1};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(ContribOpNgramTest, String_TF_BatchUniAndBigrams_Skip5) {
+  OpTester test("Ngram", opset_ver, domain);
+  // s=5, Min=1, Max=2, weights empty, string
   InitTestAttr(test, "TF", 1, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
@@ -210,18 +357,20 @@ TEST(ContribOpTest, Ngram_String_TF_UniAndBigrams_Skip5) {
                                  "six", "seven", "five", "six", "eight"};
   test.AddInput<std::string>("T", dims, input);
 
-  std::vector<int64_t> out_dims{7};
-  std::vector<float> output = {0, 3, 1, 0, 1, 3, 1};
+  std::vector<int64_t> out_dims{2, 7};
+  std::vector<float> output = {0, 3, 0, 0, 0, 0, 0,
+                               0, 0, 1, 0, 1, 1, 1};
+
   test.AddOutput<float>("Y", out_dims, output);
 
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_Int32_IDF_onlyBigrams_Skip5) {
+TEST(ContribOpNgramTest, Int32_IDF_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=5, , M=N, weights empty, int32
+  // s=5, Min=Max=2, weights empty, int32
   // We change to IDF but do not supply weights so
-  // we should get all 1.0f
+  // we should get all 1.0f where count is not zero
   InitTestAttr(test, "IDF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
@@ -230,7 +379,7 @@ TEST(ContribOpTest, Ngram_Int32_IDF_onlyBigrams_Skip5) {
                 5, 6, 7, 8, 6, 7},  //bi-grams
                {});
 
-  std::vector<int64_t> dims{2, 6};
+  std::vector<int64_t> dims{12};
   std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
   test.AddInput<int32_t>("T", dims, input);
 
@@ -241,9 +390,9 @@ TEST(ContribOpTest, Ngram_Int32_IDF_onlyBigrams_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_String_IDF_onlyBigrams_Skip5) {
+TEST(ContribOpNgramTest, String_IDF_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , M=N, weights empty, string
+  // s=5, Min=Max=2, weights empty, string
   InitTestAttr(test, "IDF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
@@ -252,7 +401,7 @@ TEST(ContribOpTest, Ngram_String_IDF_onlyBigrams_Skip5) {
                {"two", "three", "five", "four",                     //1-grams
                 "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
 
-  std::vector<int64_t> dims{2, 6};
+  std::vector<int64_t> dims{12};
   std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
                                  "six", "seven", "five", "six", "eight"};
   test.AddInput<std::string>("T", dims, input);
@@ -264,9 +413,9 @@ TEST(ContribOpTest, Ngram_String_IDF_onlyBigrams_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_Int32_TFIDF_onlyBigrams_Skip5) {
+TEST(ContribOpNgramTest, Int32_TFIDF_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=5, , M=N=2, weights empty, int32
+  // s=5, Min=Max=2, weights empty, int32
   // We change to TFIDF but do not supply weights so
   // we should all get the original values as weights are 1.0f by
   // default
@@ -278,7 +427,7 @@ TEST(ContribOpTest, Ngram_Int32_TFIDF_onlyBigrams_Skip5) {
                 5, 6, 7, 8, 6, 7},  //bi-grams
                {});
 
-  std::vector<int64_t> dims{2, 6};
+  std::vector<int64_t> dims{12};
   std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
   test.AddInput<int32_t>("T", dims, input);
 
@@ -289,9 +438,9 @@ TEST(ContribOpTest, Ngram_Int32_TFIDF_onlyBigrams_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_String_TFIDF_onlyBigrams_Skip5) {
+TEST(ContribOpNgramTest, String_TFIDF_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , M=N=2, weights empty, string
+  // s=5, Min=Max=2, weights empty, string
   InitTestAttr(test, "TFIDF", 2, 2, 5,
                {0, 4},
                {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
@@ -300,7 +449,7 @@ TEST(ContribOpTest, Ngram_String_TFIDF_onlyBigrams_Skip5) {
                {"two", "three", "five", "four",                     //1-grams
                 "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
 
-  std::vector<int64_t> dims{2, 6};
+  std::vector<int64_t> dims{12};
   std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
                                  "six", "seven", "five", "six", "eight"};
   test.AddInput<std::string>("T", dims, input);
@@ -312,20 +461,20 @@ TEST(ContribOpTest, Ngram_String_TFIDF_onlyBigrams_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_Int32_IDFWeights_onlyBigrams_Skip5) {
+TEST(ContribOpNgramTest, Int32_IDFWeights_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=5, , M=N=2, weights empty, int32
+  // s=5, Min=Max=2, weights specified, int32
   // We change to IDF with supplied weights. All
   // with non-zero counts must be replaced with the supplied weights
   InitTestAttr(test, "IDF", 2, 2, 5,
                {0, 4},
-               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
-               {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},
-               {2, 3, 5, 4,         //1-grams
-                5, 6, 7, 8, 6, 7},  //bi-grams
+               {0, 1, 2, 3, 4, 5, 6},                //7 output indexes
+               {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},  // weights
+               {2, 3, 5, 4,                          //1-grams
+                5, 6, 7, 8, 6, 7},                   //bi-grams
                {});
 
-  std::vector<int64_t> dims{2, 6};
+  std::vector<int64_t> dims{12};
   std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
   test.AddInput<int32_t>("T", dims, input);
 
@@ -336,18 +485,18 @@ TEST(ContribOpTest, Ngram_Int32_IDFWeights_onlyBigrams_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_String_IDFWeights_onlyBigrams_Skip5) {
+TEST(ContribOpNgramTest, String_IDFWeights_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , M=N=2, weights empty, string
+  // s=5, Min=Max=2, weights specified, string
   InitTestAttr(test, "IDF", 2, 2, 5,
                {0, 4},
-               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
-               {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},
+               {0, 1, 2, 3, 4, 5, 6},                //7 output indexes
+               {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},  // weights
                {},
                {"two", "three", "five", "four",                     //1-grams
                 "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
 
-  std::vector<int64_t> dims{2, 6};
+  std::vector<int64_t> dims{12};
   std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
                                  "six", "seven", "five", "six", "eight"};
   test.AddInput<std::string>("T", dims, input);
@@ -359,20 +508,20 @@ TEST(ContribOpTest, Ngram_String_IDFWeights_onlyBigrams_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_Int32_TFIDFWeights_onlyBigrams_Skip5) {
+TEST(ContribOpNgramTest, Int32_TFIDFWeights_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=5, , M=N=2, weights empty, int32
+  // s=5, Min=Max=2, weights specified, int32
   // We change to TFIDF with supplied weights.
   // We should have all counts scaled by weights
   InitTestAttr(test, "TFIDF", 2, 2, 5,
                {0, 4},
-               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
-               {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},
-               {2, 3, 5, 4,         //1-grams
-                5, 6, 7, 8, 6, 7},  //bi-grams
+               {0, 1, 2, 3, 4, 5, 6},                //7 output indexes
+               {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},  // weights
+               {2, 3, 5, 4,                          //1-grams
+                5, 6, 7, 8, 6, 7},                   //bi-grams
                {});
 
-  std::vector<int64_t> dims{2, 6};
+  std::vector<int64_t> dims{12};
   std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
   test.AddInput<int32_t>("T", dims, input);
 
@@ -383,18 +532,18 @@ TEST(ContribOpTest, Ngram_Int32_TFIDFWeights_onlyBigrams_Skip5) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-TEST(ContribOpTest, Ngram_String_TFIDFWeights_onlyBigrams_Skip5) {
+TEST(ContribOpNgramTest, String_TFIDFWeights_onlyBigrams_Skip5) {
   OpTester test("Ngram", opset_ver, domain);
-  // 1 - 2, s=0, , M=N=2, weights empty, string
+  // s=5, Min=Max=2, weights specified, string
   InitTestAttr(test, "TFIDF", 2, 2, 5,
                {0, 4},
-               {0, 1, 2, 3, 4, 5, 6},  //7 output indexes
-               {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},
+               {0, 1, 2, 3, 4, 5, 6},                //7 output indexes
+               {2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0},  // weights
                {},
                {"two", "three", "five", "four",                     //1-grams
                 "five", "six", "seven", "eight", "six", "seven"});  //bi-grams
 
-  std::vector<int64_t> dims{2, 6};
+  std::vector<int64_t> dims{12};
   std::vector<std::string> input{"one", "one", "three", "three", "three", "seven", "eight",
                                  "six", "seven", "five", "six", "eight"};
   test.AddInput<std::string>("T", dims, input);


### PR DESCRIPTION
Inputs: 
X: tensor<int32>, tensor<int64>, tensor<string> in UTF-8 format. 
Outputs:  
Y: tensor<float> 
Attributes: 
M: int, Minimum n-gram length. 
 
N: int, Maximum n-gram length. 
 
all: bool. Whether to store all n-gram lengths up to N, or only N. For example, N=2 with all=1 means 1-grams and 2-grams would be extracted. Similarly, if N=2 with all=0, only 2-grams would be produced. 
 
S: Maximum number of integers to be skipped when constructing an n-gram from X. If S=1, M=2, N=3, this operator may generate 2-grams with S=0 and S=1, and 3-grams with S=0 and S=1. 
 
ngram_indexes: list of int64s (type: AttributeProto::INTS). This list is parallel to the specified 'pool_*' attribute. The i-th element in ngram_indexes indicates the output coordinate of the i-th n-gram in pool. 
 
pool_strings: list of strings (type: AttributeProto::STRINGS). n-grams learned from the training set. It's an 1-D tensor starting with the collections of all 1-grams and ending with the collections of N-grams. The i-th n-gram in pool should be mapped to position indexed by ngram_indexe[i] in the output vector. 
 
pool_int64s: list of int64s (type: AttributeProto::INTS). n-grams learned from the training set. It's an 1-D tensor starting with the collections of all 1-grams and ending with the collections of N-grams. The i-th n-gram in pool should be mapped to position indexed by ngram_indexe[i] in the output vector. 
 
ngram_counts: list of int64s (type: AttributeProto::INTS). The starting indexes of 1-grams, 2-grams, and so on in pool. It is useful when determining the boundary between two consecutive collections of n-grams. For example, if ngram_counts is [0, 17, 36], the first index (zero-based) of 1-gram/2-gram/3-gram in pool are 0/17/36. 
 
mode: string. The weighting criteria. It can be one of "TF" (term frequency), "IDF" (inverse document frequency), and "TFIDF" (the combination of TF and IDF). 
 
weights: list of floats (type: AttributeProto::FLOATS). This attribute stores the weight of each n-gram in pool. The i-th element in weights is the weight of the i-th n-gram in pool. Its length equals to the size of ngram_indexes. By default, weights is an all-one tensor. This attribute is used when mode is "IDF" or "TFIDF" to scale the associated word counts. 
Description: 
This transform extracts n-grams from the input integer sequence and save them as a vector. In contract to standard n-gram extraction, here, the indexes of extracting an n-gram from the original sequence are not necessarily consecutive numbers. The discontinuity between indexes are controlled by the number of skips. If the number of skips is 2, we should skip two tokens when scanning through the original sequence. Let's consider an example. Assume that input sequence is [94, 17, 36, 12, 28] and the number of skips is 2. The associated 2-grams are [94, 12] and [17, 28] respectively indexed by [0, 3] and [1, 4]. If the number of skips becomes 0, the 2-grams generated are [94, 17], [17, 36], [36, 12], [12, 28] indexed by [0, 1], [1, 2], [2, 3], [3, 4], respectively. The output vector stores the count of each n-gram; Y[i] indicates the times that the i-th n-gram is found. The attribute "ngrams" is used to determine the mapping between index i and the corresponding n-gram. If "ngrams" is [ [94 , 17] , [ 17, 36 ] ], then the Y[0] (first element in Y) and Y[1] (second element in Y) are the counts of [94, 17] and [17, 36], respectively. An n-gram which cannot be found in gramPool should be ignored and has no effect on the output. Note that we may consider all skips up to skipLength when generating the n-grams. 
 
The examples used above are true if mode is "TF". If mode is "IDF", all the counts larger than 1 would be truncated to 1 and the i-th element in weights would be used to scale (by multiplication) the count of the i-th n-gram in pool. If mode is "TFIDF", this operator first computes the counts of all n-grams and then scale them by the associated values in the weights attribute. 
 
 Only one of pool_strings and pool_int64s can be set. If pool_int64s is set, the input should be an integer tensor. If pool_strings is set, the input must be a string tensor. 
 
StringNormalizer (used as Stop Words Remover Transform in ML.NET, used in CountVectorizer/TfidfVectorizer in scikit-learn,  used in Keras text_to_word_sequence/tokenizer; used in text normalization in ML.NET, used in CountVectorizer/TdidfVectorizer in scikit-leran, used in Keras text_to_word_sequence/tokenizer. C# upper version, C# lower version, C++ upper version, C++ lower version.) 
Inputs: 
X: tensor<string>, string in UTF-8 format. 
Outputs: 
Y: tensor<string>, string in UTF-8 format. 
Attribute: 
casechangeaction: enum {"LOWER", "UPPER", "NONE"}. 
iscasesenstive: bool. Whether the identification of stop words in X is case-sensitive. 
stopwords: list of strings (type: AttributeProto::STRINGS). A 1-D tensor of strings. Each element is a stop word. 
locale: string. This attribute specifies culture for culture-specific string operations. 
Description: 
This operator can do below 2 operations: 
[optional] Step1: Remove elements in X if they matches any of stop words so that output tensor may not contain any stop word. This operator only accepts [C]- and [1, C]-tensor. If all elements in X are dropped, the output will be the empty value of string tensor with shape [1] if input shape is [C] and shape [1, 1] if input shape is [1, C]. 
[optional] Step2: Lower all characters (if action is LOWER) in X or capitalize them (when action is UPPER). 