### PR TITLE
Add null check before calling node.op_->Deprecated().

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -1649,7 +1649,7 @@ Status Graph::VerifyNodeAndOpMatch() {
       auto maxInclusiveVersion = DomainToVersionMap().find(domain)->second;
       node.op_ = schema_registry_->GetSchema(node.OpType(), maxInclusiveVersion, node.Domain());
 
-      if (node.op_->Deprecated()) {
+      if (node.op_ && node.op_->Deprecated()) {
         node.op_ = nullptr;
       }
 


### PR DESCRIPTION
It seems possible that the node.op_ returned from https://github.com/Microsoft/onnxruntime/blob/dc8b37f4c491872f75d4fe1963525f98fdb9974b/include/onnxruntime/core/graph/schema_registry.h#L53 is a nullptr. 