### PR TITLE
Increment/decrement UseCount for node outputs in allocation planner

### DIFF
--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -389,6 +389,7 @@ class PlannerImpl {
         if (node_output->Exists()) {
           MLValueIndex index = Index(node_output->Name());
           ProcessDef(index, node_output);
+          ++UseCount(index);
           if (strcmp(default_allocator_info.name, CPU) != 0) {
             // By default, outputs of this node are allocated on the default device allocator,
             // except for outputs marked for allocation in MemoryType:
@@ -528,7 +529,7 @@ class PlannerImpl {
         if (node_output->Exists()) {
           auto& sym = node_output->Name();
           auto original = Buffer(Index(sym));
-          if (0 == UseCount(original))
+          if (0 == --UseCount(original))
             freelist_.push_front(FreeBufferInfo(original, program_counter));
         }
       }


### PR DESCRIPTION
Increment/decrement UseCount for outputs so that we don't prematurely free a re-used output that is used for a dead output (output with zero users). If an output has a UseCount of 0 it gets added to the freelist prematurely as it could be re-used in the same step in ComputeUseCount.