### PR TITLE
Fix SessionStateInitializer calling CleanAllInitializedTensors too early

### DIFF
--- a/onnxruntime/core/framework/session_state_initializer.h
+++ b/onnxruntime/core/framework/session_state_initializer.h
@@ -29,9 +29,7 @@ class SessionStateInitializer {
                           const logging::Logger& logger);
 
   // First perform any transformations and create the execution plan
-  common::Status CreatePlan(const onnxruntime::GraphTransformerManager& graph_transformation_manager,
-                            const InsertCastTransformer& insert_cast_transformer,
-                            const std::vector<NodeArg*>& outer_scope_node_args,
+  common::Status CreatePlan(const std::vector<NodeArg*>& outer_scope_node_args,
                             bool enable_sequential_execution);
 
   // initialize tensors, and save. save kernels and input/output node mappings

--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -4,18 +4,70 @@
 namespace onnxruntime {
 
 namespace utils {
-  // fusion is only done for ONNX domain ops
-  bool IsSupportedOptypeVersionAndDomain(const Node& node,
-                                         const std::string& op_type,
-                                         ONNX_NAMESPACE::OperatorSetVersion version,
-                                         const std::string& domain) {
-    if (node.OpType() != op_type ||
-        node.Op()->Deprecated() || node.Op()->SinceVersion() != version ||
-        (!node.Domain().empty() && node.Domain() != domain)) {
-      return false;
-    }
-    return true;
+// fusion is only done for ONNX domain ops
+bool IsSupportedOptypeVersionAndDomain(const Node& node,
+                                       const std::string& op_type,
+                                       ONNX_NAMESPACE::OperatorSetVersion version,
+                                       const std::string& domain) {
+  if (node.OpType() != op_type ||
+      node.Op()->Deprecated() || node.Op()->SinceVersion() != version ||
+      (!node.Domain().empty() && node.Domain() != domain)) {
+    return false;
   }
+  return true;
 }
 
+Status ForAllMutableSubgraphs(Graph& graph, std::function<Status(Graph&)> func) {
+  Status status = Status::OK();
+
+  for (auto& node : graph.Nodes()) {
+    for (auto& attribute : node.GetAttributes()) {
+      auto& name = attribute.first;
+      auto& proto = attribute.second;
+
+      // check if it has a subgraph
+      if (proto.has_g()) {
+        Graph* subgraph = node.GetMutableGraphAttribute(name);
+        ORT_ENFORCE(subgraph, "Main Graph instance should have populated all subgraphs when being resolved.");
+
+        status = func(*subgraph);
+        ORT_RETURN_IF_ERROR(status);
+
+        // recurse
+        status = ForAllMutableSubgraphs(*subgraph, func);
+        ORT_RETURN_IF_ERROR(status);
+      }
+    }
+  }
+
+  return status;
+}
+
+Status ForAllSubgraphs(const Graph& graph, std::function<Status(const Graph&)> func) {
+  Status status = Status::OK();
+
+  for (auto& node : graph.Nodes()) {
+    for (auto& attribute : node.GetAttributes()) {
+      auto& name = attribute.first;
+      auto& proto = attribute.second;
+
+      // check if it has a subgraph
+      if (proto.has_g()) {
+        const Graph* subgraph = node.GetGraphAttribute(name);
+        ORT_ENFORCE(subgraph, "Main Graph instance should have populated all subgraphs when being resolved.");
+
+        status = func(*subgraph);
+        ORT_RETURN_IF_ERROR(status);
+
+        // recurse
+        status = ForAllSubgraphs(*subgraph, func);
+        ORT_RETURN_IF_ERROR(status);
+      }
+    }
+  }
+
+  return status;
+}
+
+}  // namespace utils
 }  // namespace onnxruntime

--- a/onnxruntime/core/graph/graph_utils.h
+++ b/onnxruntime/core/graph/graph_utils.h
@@ -9,10 +9,13 @@
 namespace onnxruntime {
 
 namespace utils {
-  bool IsSupportedOptypeVersionAndDomain(const Node& node,
-                                         const std::string& op_type,
-                                         ONNX_NAMESPACE::OperatorSetVersion version,
-                                         const std::string& domain = kOnnxDomainAlias);
-}
+bool IsSupportedOptypeVersionAndDomain(const Node& node,
+                                       const std::string& op_type,
+                                       ONNX_NAMESPACE::OperatorSetVersion version,
+                                       const std::string& domain = kOnnxDomainAlias);
 
-}
+Status ForAllMutableSubgraphs(Graph& main_graph, std::function<Status(Graph&)> func);
+Status ForAllSubgraphs(Graph& main_graph, std::function<Status(Graph&)> func);
+
+}  // namespace utils
+}  // namespace onnxruntime


### PR DESCRIPTION
Re-structure the inference session initialization to
  - apply any transforms to the main graph and any subgraphs first
  - call Graph::Resolve() once on the main graph, which will recurse into the subgraphs
    - previously it was called after the transform on each subgraph, which results in it traversing up to the main graph to call resolve, and that resolve call recursing into all subgraphs every time.
  - do session state initialization for the main and subgraphs last

This avoids lots of unnecessary Graph::Resolve calls, and prevents subgraphs from being broken by SessionStateInitializer::InitializeAndSave calling graph_.CleanAllInitializedTensors() prior to the final Graph::Resolve call. If a subgraph has optional inputs the backing initializers were removed by CleanAllInitializedTensors causing the next Graph::Resolve to incorrectly turn them into required inputs.
