### PR TITLE
Enable release build in Windows CI pipelines

### DIFF
--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -5,7 +5,7 @@ jobs:
     - task: BatchScript@1
       inputs:
         filename: build.bat
-        arguments: ' --enable_pybind --use_mkldnn --use_mklml --use_openmp --build_shared_lib --build_csharp --enable_onnx_tests'
+        arguments: ' --config Debug Release --enable_pybind --use_mkldnn --use_mklml --use_openmp --build_shared_lib --build_csharp --enable_onnx_tests'
         workingFolder: "$(Build.SourcesDirectory)"
 
     - task: CmdLine@1

--- a/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
@@ -18,7 +18,7 @@ jobs:
     - task: BatchScript@1
       inputs:
         filename: build.bat
-        arguments: ' --enable_onnx_tests --use_mkldnn --build_shared_lib --build_csharp --use_cuda --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda"'
+        arguments: ' --config Debug Release --enable_onnx_tests --use_mkldnn --build_shared_lib --build_csharp --use_cuda --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda"'
         workingFolder: "$(Build.SourcesDirectory)"
     - task: PowerShell@1
       displayName: 'Clean up CUDA props files'


### PR DESCRIPTION
Model zoo model tests is only enabled in release build, we should run them.
