### PR TITLE
update kernel memory type interface

### DIFF
--- a/include/onnxruntime/core/framework/kernel_def_builder.h
+++ b/include/onnxruntime/core/framework/kernel_def_builder.h
@@ -26,10 +26,7 @@ inline bool MemTypeOnCpuExplicitly(OrtMemType mem_type) {
 
 class KernelDef {
  public:
-  explicit KernelDef() : KernelDef(OrtMemType::OrtMemTypeDefault, OrtMemType::OrtMemTypeDefault) {
-  }
-
-  explicit KernelDef(OrtMemType default_inputs, OrtMemType default_outputs) : default_inputs_mem_type_(default_inputs), default_outputs_mem_type_(default_outputs) {
+  explicit KernelDef() : default_inputs_mem_type_(OrtMemTypeDefault), default_outputs_mem_type_(OrtMemTypeDefault) {
   }
 
   const std::string& OpName() const {
@@ -127,11 +124,8 @@ class KernelDef {
 
 class KernelDefBuilder {
  public:
-  explicit KernelDefBuilder(OrtMemType inputs_mem_type, OrtMemType outputs_mem_type)
-      : kernel_def_(new KernelDef(inputs_mem_type, outputs_mem_type)) {}
-
   explicit KernelDefBuilder()
-      : KernelDefBuilder(OrtMemType::OrtMemTypeDefault, OrtMemType::OrtMemTypeDefault) {}
+      : kernel_def_(new KernelDef()) {}
 
   KernelDefBuilder& SetName(const std::string& op_name);
   KernelDefBuilder& SetName(const char* op_name);
@@ -224,6 +218,22 @@ class KernelDefBuilder {
   */
   KernelDefBuilder& ExecQueueId(int queue_id) {
     kernel_def_->exec_queue_id_ = queue_id;
+    return *this;
+  }
+
+  /**
+  Specify the default inputs memory type, if not specified, it is DefaultMemory
+  */
+  KernelDefBuilder& SetDefaultInputsMemoryType(OrtMemType mem_type) {
+    kernel_def_->default_inputs_mem_type_ = mem_type;
+    return *this;
+  }
+
+  /**
+  Specify the default outputs memory type, if not specified, it is DefaultMemory
+  */
+  KernelDefBuilder& SetDefaultOutputMemoryType(OrtMemType mem_type) {
+    kernel_def_->default_outputs_mem_type_ = mem_type;
     return *this;
   }
 

--- a/include/onnxruntime/core/framework/kernel_def_builder.h
+++ b/include/onnxruntime/core/framework/kernel_def_builder.h
@@ -234,7 +234,7 @@ class KernelDefBuilder {
     return std::move(kernel_def_);
   }
 
- protected:
+ private:
   // we own the KernelDef until Build() is called.
   std::unique_ptr<KernelDef> kernel_def_;
 };

--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -380,7 +380,6 @@ class PlannerImpl {
       ORT_ENFORCE(exec_provider);
 
       auto& default_allocator_info = exec_provider->GetAllocator(0, OrtMemTypeDefault)->Info();
-      auto& mem_type_allocated_args = p_kernelDef->OutputMemoryType();
       auto& outputs = pnode->OutputDefs();
       auto num_outputs = outputs.size();
 
@@ -393,11 +392,11 @@ class PlannerImpl {
           if (strcmp(default_allocator_info.name, CPU) != 0) {
             // By default, outputs of this node are allocated on the default device allocator,
             // except for outputs marked for allocation in MemoryType:
-            auto memory_type_iter = mem_type_allocated_args.find(i);
-            if (memory_type_iter == mem_type_allocated_args.end()) {
+            auto memory_type = p_kernelDef->OutputMemoryType(i);
+            if (memory_type == OrtMemTypeDefault) {
               AllocPlan(index).location = default_allocator_info;
             } else {
-              AllocPlan(index).location = exec_provider->GetAllocator(0, memory_type_iter->second)->Info();
+              AllocPlan(index).location = exec_provider->GetAllocator(0, memory_type)->Info();
             }
           }
         }
@@ -438,7 +437,7 @@ class PlannerImpl {
 
             thisplan.alloc_kind = AllocKind::kAllocateStatically;
             auto p_opkernelDef = utils::GetKernelDef(kernel_registry_, node);
-            if (MemTypeOnCpuExplicitly(p_opkernelDef->InputMemoryType(), index))
+            if (MemTypeOnCpuExplicitly(p_opkernelDef->InputMemoryType(index)))
               // weights are not output from any node, so it's OK to put its location on CPU provider
               thisplan.location = execution_providers_.Get(onnxruntime::kCpuExecutionProvider)->GetAllocator(0, OrtMemTypeDefault)->Info();
             else

--- a/onnxruntime/core/framework/kernel_def_builder.cc
+++ b/onnxruntime/core/framework/kernel_def_builder.cc
@@ -66,20 +66,20 @@ bool KernelDef::IsConflict(const KernelDef& other) const {
     return false;
 
   //check memory type
-  auto other_input_mem_types = other.InputMemoryType();
+  auto& other_input_mem_types = other.input_memory_type_args_;
   for (auto it : input_memory_type_args_) {
-    if (other_input_mem_types.count(it.first) && other_input_mem_types[it.first] == it.second)
+    if (other_input_mem_types.count(it.first) && other_input_mem_types.find(it.first)->second == it.second)
       return false;
   }
-  if (input_memory_type_args_.empty() && !other.InputMemoryType().empty())
+  if (input_memory_type_args_.empty() && !other.input_memory_type_args_.empty())
     return false;
 
-  auto other_output_mem_types = other.OutputMemoryType();
+  auto& other_output_mem_types = other.output_memory_type_args_;
   for (auto it : output_memory_type_args_) {
-    if (other_output_mem_types.count(it.first) && other_output_mem_types[it.first] == it.second)
+    if (other_output_mem_types.count(it.first) && other_output_mem_types.find(it.second)->second == it.second)
       return false;
   }
-  return !(output_memory_type_args_.empty() && !other.OutputMemoryType().empty());
+  return !(output_memory_type_args_.empty() && !other.output_memory_type_args_.empty());
 }
 
 KernelDefBuilder& KernelDefBuilder::SetName(const std::string& op_name) {

--- a/onnxruntime/core/session/IOBinding.cc
+++ b/onnxruntime/core/session/IOBinding.cc
@@ -60,10 +60,9 @@ common::Status IOBinding::CopyOneInputAcrossDevices(const SessionState& session_
     size_t index = node_info.index;
     auto& node = *node_info.p_node;
     const KernelCreateInfo* kci = node_info.kci;
-    const auto* node_input_mem_types = (kci != nullptr) ? &kci->kernel_def->InputMemoryType() : nullptr;
 
     // node may declare input_mem_type to be on CPU explicitly
-    bool node_input_on_cpu = node_input_mem_types && MemTypeOnCpuExplicitly(*node_input_mem_types, index);
+    bool node_input_on_cpu = kci && MemTypeOnCpuExplicitly(kci->kernel_def->InputMemoryType(index));
     auto& required_provider_type = node_input_on_cpu ? onnxruntime::kCpuExecutionProvider : node.GetExecutionProviderType();
     if (!orig_mlvalue.IsTensor()) {
       // copying not supported for non-tensor types


### PR DESCRIPTION
current kernel memory type interface can't support variadic inputs. Cheng the interface to query-based so we could have a customized default memory type.