### PR TITLE
Introduce basic BFloat16 runtime support

### DIFF
--- a/onnxruntime/core/framework/data_types.cc
+++ b/onnxruntime/core/framework/data_types.cc
@@ -85,6 +85,10 @@ template <>
 constexpr ONNX_NAMESPACE::TensorProto_DataType ToTensorDataType<uint64_t>() {
   return ONNX_NAMESPACE::TensorProto_DataType_UINT64;
 };
+template <>
+constexpr ONNX_NAMESPACE::TensorProto_DataType ToTensorDataType<BFloat16>() {
+  return ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16;
+};
 
 template <typename T>
 struct TensorContainedTypeSetter<T> {
@@ -123,6 +127,8 @@ template struct
     TensorContainedTypeSetter<uint32_t>;
 template struct
     TensorContainedTypeSetter<uint64_t>;
+template struct
+    TensorContainedTypeSetter<BFloat16>;
 
 void CopyMutableMapValue(const ONNX_NAMESPACE::TypeProto& value_proto,
                          ONNX_NAMESPACE::TypeProto& map_proto) {
@@ -435,6 +441,7 @@ ORT_REGISTER_TENSOR_TYPE(double);
 ORT_REGISTER_TENSOR_TYPE(uint32_t);
 ORT_REGISTER_TENSOR_TYPE(uint64_t);
 ORT_REGISTER_TENSOR_TYPE(MLFloat16);
+ORT_REGISTER_TENSOR_TYPE(BFloat16);
 
 ORT_REGISTER_MAP(MapStringToString);
 ORT_REGISTER_MAP(MapStringToInt64);
@@ -482,6 +489,7 @@ void RegisterAllProtos(const std::function<void(MLDataType)>& reg_fn) {
   REGISTER_TENSOR_PROTO(uint32_t, reg_fn);
   REGISTER_TENSOR_PROTO(uint64_t, reg_fn);
   REGISTER_TENSOR_PROTO(MLFloat16, reg_fn);
+  REGISTER_TENSOR_PROTO(BFloat16, reg_fn);
 
   REGISTER_ONNX_PROTO(MapStringToString, reg_fn);
   REGISTER_ONNX_PROTO(MapStringToInt64, reg_fn);
@@ -540,6 +548,8 @@ MLDataType DataTypeImpl::TypeFromProto(const ONNX_NAMESPACE::TypeProto& proto) {
           return DataTypeImpl::GetTensorType<uint64_t>();
         case TensorProto_DataType_FLOAT16:
           return DataTypeImpl::GetTensorType<MLFloat16>();
+        case TensorProto_DataType_BFLOAT16:
+          return DataTypeImpl::GetTensorType<BFloat16>();
         default:
           ORT_NOT_IMPLEMENTED("tensor type ", tensor_type.elem_type(), " is not supported");
       }
@@ -685,6 +695,7 @@ ORT_REGISTER_NON_ONNX_TYPE(double);
 ORT_REGISTER_NON_ONNX_TYPE(uint32_t);
 ORT_REGISTER_NON_ONNX_TYPE(uint64_t);
 ORT_REGISTER_NON_ONNX_TYPE(MLFloat16);
+ORT_REGISTER_NON_ONNX_TYPE(BFloat16);
 
 const std::vector<MLDataType>& DataTypeImpl::AllFixedSizeTensorTypes() {
   static std::vector<MLDataType> all_fixed_size_tensor_types =
@@ -699,6 +710,7 @@ const std::vector<MLDataType>& DataTypeImpl::AllFixedSizeTensorTypes() {
        DataTypeImpl::GetTensorType<int8_t>(),
        DataTypeImpl::GetTensorType<uint8_t>(),
        DataTypeImpl::GetTensorType<MLFloat16>(),
+       DataTypeImpl::GetTensorType<BFloat16>(),
        DataTypeImpl::GetTensorType<bool>()};
 
   return all_fixed_size_tensor_types;
@@ -717,6 +729,7 @@ const std::vector<MLDataType>& DataTypeImpl::AllTensorTypes() {
        DataTypeImpl::GetTensorType<int8_t>(),
        DataTypeImpl::GetTensorType<uint8_t>(),
        DataTypeImpl::GetTensorType<MLFloat16>(),
+       DataTypeImpl::GetTensorType<BFloat16>(),
        DataTypeImpl::GetTensorType<bool>(),
        DataTypeImpl::GetTensorType<std::string>()};
 

--- a/onnxruntime/core/framework/onnxruntime_typeinfo.cc
+++ b/onnxruntime/core/framework/onnxruntime_typeinfo.cc
@@ -8,6 +8,7 @@
 #include "core/framework/tensor.h"
 #include "core/graph/onnx_protobuf.h"
 
+using onnxruntime::BFloat16;
 using onnxruntime::DataTypeImpl;
 using onnxruntime::MLFloat16;
 using onnxruntime::Tensor;
@@ -80,6 +81,9 @@ const DataTypeImpl* ElementTypeFromProto(int type) {
       return DataTypeImpl::GetType<uint64_t>();
     case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
       return DataTypeImpl::GetType<MLFloat16>();
+    case ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16:
+      return DataTypeImpl::GetType<BFloat16>();
+
     default:
       ORT_NOT_IMPLEMENTED(__FUNCTION__, ":tensor type ", type, " is not supported");
   }

--- a/onnxruntime/core/framework/tensor_type_and_shape.cc
+++ b/onnxruntime/core/framework/tensor_type_and_shape.cc
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <atomic>
 
+using onnxruntime::BFloat16;
 using onnxruntime::DataTypeImpl;
 using onnxruntime::MLFloat16;
 using onnxruntime::Tensor;
@@ -102,6 +103,8 @@ inline ONNXTensorElementDataType MLDataTypeToOnnxRuntimeTensorElementDataType(
     type = ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL;
   } else if (cpp_type == onnxruntime::DataTypeImpl::GetType<MLFloat16>()) {
     type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16;
+  } else if (cpp_type == onnxruntime::DataTypeImpl::GetType<BFloat16>()) {
+    type = ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16;
   } else if (cpp_type == onnxruntime::DataTypeImpl::GetType<double>()) {
     type = ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE;
   } else if (cpp_type == onnxruntime::DataTypeImpl::GetType<uint32_t>()) {

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -26,6 +26,7 @@
 #include "abi_session_options_impl.h"
 
 using namespace onnxruntime::logging;
+using onnxruntime::BFloat16;
 using onnxruntime::DataTypeImpl;
 using onnxruntime::Environment;
 using onnxruntime::IAllocator;
@@ -259,6 +260,9 @@ ORT_API_STATUS_IMPL(OrtCreateTensorWithDataAsOrtValue, _In_ const OrtAllocatorIn
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
       ORT_API_RETURN_IF_ERROR(CreateTensorImpl<MLFloat16>(shape, shape_len, info, p_data, p_data_len, &tensor));
       break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+      ORT_API_RETURN_IF_ERROR(CreateTensorImpl<BFloat16>(shape, shape_len, info, p_data, p_data_len, &tensor));
+      break;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
       ORT_API_RETURN_IF_ERROR(CreateTensorImpl<double>(shape, shape_len, info, p_data, p_data_len, &tensor));
       break;
@@ -322,6 +326,9 @@ ORT_API_STATUS_IMPL(OrtCreateTensorAsOrtValue, _Inout_ OrtAllocator* allocator,
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
       ORT_API_RETURN_IF_ERROR(CreateTensorImpl<MLFloat16>(shape, shape_len, allocator, &tensor));
       break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+      ORT_API_RETURN_IF_ERROR(CreateTensorImpl<BFloat16>(shape, shape_len, allocator, &tensor));
+      break;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
       ORT_API_RETURN_IF_ERROR(CreateTensorImpl<double>(shape, shape_len, allocator, &tensor));
       break;
@@ -333,7 +340,6 @@ ORT_API_STATUS_IMPL(OrtCreateTensorAsOrtValue, _Inout_ OrtAllocator* allocator,
       break;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64:
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128:
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
     default: {
       std::ostringstream oss;
       oss << "type " << type << " is not supported in this function";

--- a/onnxruntime/test/framework/data_types_test.cc
+++ b/onnxruntime/test/framework/data_types_test.cc
@@ -351,6 +351,42 @@ TEST_F(DataTypeTest, VectorMapInt64ToFloatTest) {
   EXPECT_FALSE(DataTypeImpl::GetType<VectorMapInt64ToFloat>()->IsCompatible(tensor_type));
 }
 
+TEST_F(DataTypeTest, BFloat16Test) {
+  // Test data type
+  {
+    const float sample = 1.0f;
+    BFloat16 flt16(sample);
+    auto int_rep = flt16.val;
+    BFloat16 flt_from_int(int_rep);
+    const double diff = fabs(sample - flt_from_int.ToFloat());
+    if (diff > FLT_EPSILON || (std::isnan(diff) && !std::isnan(sample))) {
+      EXPECT_TRUE(false);
+    }
+  }
+  // Test bulk conversion
+  {
+    float sample[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+    BFloat16 converted[sizeof(sample) / sizeof(float)];
+    static_assert(sizeof(sample) / sizeof(float) == sizeof(converted) / sizeof(BFloat16), "Must have the same count");
+    FloatToBFloat16(sample, converted, sizeof(sample) / sizeof(float));
+    for (size_t i = 0; i < sizeof(sample) / sizeof(float); ++i) {
+      const double diff = fabs(sample[i] - converted[i].ToFloat());
+      if (diff > FLT_EPSILON || (std::isnan(diff) && !std::isnan(sample[i]))) {
+        EXPECT_TRUE(false);
+      }
+    }
+
+    float back_converted[sizeof(sample) / sizeof(float)];
+    BFloat16ToFloat(converted, back_converted, sizeof(sample) / sizeof(float));
+    for (size_t i = 0; i < sizeof(sample) / sizeof(float); ++i) {
+      const double diff = fabs(sample[i] - back_converted[i]);
+      if (diff > FLT_EPSILON || (std::isnan(diff) && !std::isnan(sample[i]))) {
+        EXPECT_TRUE(false);
+      }
+    }
+  }
+}
+
 TEST_F(DataTypeTest, DataUtilsTest) {
   using namespace ONNX_NAMESPACE::Utils;
   // Test Tensor
@@ -366,6 +402,20 @@ TEST_F(DataTypeTest, DataUtilsTest) {
     EXPECT_EQ(ten_dt, ten_from_str);
     const auto& from_dt_proto = DataTypeUtils::ToTypeProto(ten_dt);
     EXPECT_TRUE(DataTypeImpl::GetTensorType<uint64_t>()->IsCompatible(from_dt_proto));
+  }
+  // Test Tensor with bfloat16
+  {
+    const std::string tensor_uint64("tensor(bfloat16)");
+    const auto* ten_proto = DataTypeImpl::GetTensorType<BFloat16>()->GetTypeProto();
+    EXPECT_NE(ten_proto, nullptr);
+    DataType ten_dt = DataTypeUtils::ToType(*ten_proto);
+    EXPECT_NE(ten_dt, nullptr);
+    EXPECT_EQ(tensor_uint64, *ten_dt);
+    DataType ten_from_str = DataTypeUtils::ToType(*ten_dt);
+    // Expect internalized strings
+    EXPECT_EQ(ten_dt, ten_from_str);
+    const auto& from_dt_proto = DataTypeUtils::ToTypeProto(ten_dt);
+    EXPECT_TRUE(DataTypeImpl::GetTensorType<BFloat16>()->IsCompatible(from_dt_proto));
   }
   // SparseTensor
   // Currently test only with proto, no MLDataType yet.

--- a/onnxruntime/test/providers/provider_test_utils.cc
+++ b/onnxruntime/test/providers/provider_test_utils.cc
@@ -90,7 +90,7 @@ void Check(const OpTester::Data& expected_data, const Tensor& output_tensor, con
                   "] did not match run output shape [" +
                   output_tensor.Shape().ToString() + "] for " + expected_data.def_.Name());
 
-  CheckDispatch<bool, float, double, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, std::string, MLFloat16>(output_tensor.DataType(), expected_data, output_tensor, provider_type);
+  CheckDispatch<bool, float, double, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, std::string, MLFloat16, BFloat16>(output_tensor.DataType(), expected_data, output_tensor, provider_type);
 }
 
 // Check for non tensor types

--- a/onnxruntime/test/providers/provider_test_utils.h
+++ b/onnxruntime/test/providers/provider_test_utils.h
@@ -83,6 +83,9 @@ constexpr ONNX_NAMESPACE::TensorProto_DataType TypeToDataType<std::string>() { r
 template <>
 constexpr ONNX_NAMESPACE::TensorProto_DataType TypeToDataType<MLFloat16>() { return ONNX_NAMESPACE::TensorProto_DataType_FLOAT16; }
 
+template <>
+constexpr ONNX_NAMESPACE::TensorProto_DataType TypeToDataType<BFloat16>() { return ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16; }
+
 template <typename T>
 struct TTypeProto : ONNX_NAMESPACE::TypeProto {
   TTypeProto(const std::vector<int64_t>* shape = nullptr) {
@@ -149,8 +152,8 @@ class OpTester {
 
   // Set whether the NodeArg created by AddInput/AddOutput should include shape information
   // for Tensor types. If not added, shape inferencing should resolve. If added, shape inferencing
-  // should validate. Default is to not add. 
-  // Additionally a symbolic dimension will be added if symbolic_dim matches a dimension in the input. 
+  // should validate. Default is to not add.
+  // Additionally a symbolic dimension will be added if symbolic_dim matches a dimension in the input.
   OpTester& AddShapeToTensorData(bool add_shape = true, int symbolic_dim = -1) {
     add_shape_to_tensor_data_ = add_shape;
     add_symbolic_dim_to_tensor_data_ = symbolic_dim;
@@ -271,7 +274,7 @@ class OpTester {
     try {
       TensorShape shape{dims};
       ORT_ENFORCE(shape.Size() == values_count, values_count,
-                          " input values doesn't match tensor size of ", shape.Size());
+                  " input values doesn't match tensor size of ", shape.Size());
 
       auto allocator = test::AllocatorManager::Instance().GetAllocator(CPU);
       auto size_in_bytes = values_count * sizeof(T);

--- a/onnxruntime/test/util/compare_mlvalue.cc
+++ b/onnxruntime/test/util/compare_mlvalue.cc
@@ -13,11 +13,11 @@
 using namespace onnxruntime;
 
 #if (!EIGEN_VERSION_AT_LEAST(3, 3, 6))
-  namespace Eigen {
-    namespace half_impl {
-      using __half_raw = ::Eigen::half_impl::__half;
-    }
-  }
+namespace Eigen {
+namespace half_impl {
+using __half_raw = ::Eigen::half_impl::__half;
+}
+}  // namespace Eigen
 #endif
 
 #define CASE_TYPE(X)                             \
@@ -131,6 +131,29 @@ std::pair<COMPARE_RESULT, std::string> CompareFloat16Result(const Tensor& outval
   return std::make_pair(COMPARE_RESULT::SUCCESS, "");
 }
 
+std::pair<COMPARE_RESULT, std::string> CompareBFloat16Result(const Tensor& outvalue, const Tensor& expected_value,
+                                                             double per_sample_tolerance,
+                                                             double relative_per_sample_tolerance,
+                                                             bool post_processing) {
+  const size_t size1 = expected_value.Shape().Size();
+  const BFloat16* expected_output = expected_value.template Data<BFloat16>();
+  const BFloat16* real_output = outvalue.template Data<BFloat16>();
+  for (size_t di = 0; di != size1; ++di) {
+    float expected = expected_output[di].ToFloat();
+    float real = real_output[di].ToFloat();
+    real = post_processing ? std::max(0.0f, std::min(255.0f, real)) : real;
+    const double diff = fabs(expected - real);
+    const double rtol = per_sample_tolerance + relative_per_sample_tolerance * fabs(expected);
+    if (diff > rtol || (std::isnan(diff) && !std::isnan(expected))) {
+      std::ostringstream oss;
+      oss << "expected " << expected << ", got " << real << ", diff: " << diff << ", tol=" << rtol;
+
+      return std::make_pair(COMPARE_RESULT::RESULT_DIFFERS, oss.str());
+    }
+  }
+  return std::make_pair(COMPARE_RESULT::SUCCESS, "");
+}
+
 std::pair<COMPARE_RESULT, std::string> CompareTwoTensors(const Tensor& outvalue, const Tensor& expected_tensor,
                                                          double per_sample_tolerance,
                                                          double relative_per_sample_tolerance,
@@ -170,6 +193,9 @@ std::pair<COMPARE_RESULT, std::string> CompareTwoTensors(const Tensor& outvalue,
   } else if (p1 == DataTypeImpl::GetType<MLFloat16>()) {
     return CompareFloat16Result(outvalue, expected_tensor,
                                 per_sample_tolerance, relative_per_sample_tolerance, post_processing);
+  } else if (p1 == DataTypeImpl::GetType<BFloat16>()) {
+    return CompareBFloat16Result(outvalue, expected_tensor,
+                                 per_sample_tolerance, relative_per_sample_tolerance, post_processing);
   } else {
     return std::make_pair(COMPARE_RESULT::NOT_SUPPORT, "");
   }
@@ -259,6 +285,8 @@ const char* ElementTypeToString(MLDataType type) {
 
   else if (type == DataTypeImpl::GetType<MLFloat16>()) {
     return "tensor(MLFloat16)";
+  } else if (type == DataTypeImpl::GetType<BFloat16>()) {
+    return "tensor(bfloat16)";
   } else {
     return "unknown";
   }

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -33,7 +33,6 @@ else
   #Install ONNX
   #5af210ca8a1c73aa6bae8754c9346ec54d0a756e is v1.2.3
   #bae6333e149a59a3faa9c4d9c44974373dcf5256 is v1.3.0
-  #0c8d857bb162431912b255d5c0e773fb7c131a65 is v1.3.0
   #0a7cc483eb0c34e15414437bbbb420f52df4d8c2 is v1.3.0 latest
   for onnx_version in "5af210ca8a1c73aa6bae8754c9346ec54d0a756e" "bae6333e149a59a3faa9c4d9c44974373dcf5256" "0a7cc483eb0c34e15414437bbbb420f52df4d8c2"; do
     if [ -z ${lastest_onnx_version+x} ]; then

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -33,8 +33,9 @@ else
   #Install ONNX
   #5af210ca8a1c73aa6bae8754c9346ec54d0a756e is v1.2.3
   #bae6333e149a59a3faa9c4d9c44974373dcf5256 is v1.3.0
-  #0c8d857bb162431912b255d5c0e773fb7c131a65 is v1.3.0 latest
-  for onnx_version in "5af210ca8a1c73aa6bae8754c9346ec54d0a756e" "bae6333e149a59a3faa9c4d9c44974373dcf5256" "0c8d857bb162431912b255d5c0e773fb7c131a65"; do
+  #0c8d857bb162431912b255d5c0e773fb7c131a65 is v1.3.0
+  #0a7cc483eb0c34e15414437bbbb420f52df4d8c2 is v1.3.0 latest
+  for onnx_version in "5af210ca8a1c73aa6bae8754c9346ec54d0a756e" "bae6333e149a59a3faa9c4d9c44974373dcf5256" "0a7cc483eb0c34e15414437bbbb420f52df4d8c2"; do
     if [ -z ${lastest_onnx_version+x} ]; then
       echo "first pass";
     else


### PR DESCRIPTION
Introduce `BFloat16` runtime type
- advance onnx submodule for bfloat16 type_str
- To/From `float` conversion
- adjust data_types with data_type_tests
- tensorprotoutils/tensorutils, type_and_shape
- onnxruntime_c_api
- provider_test_utils
- MLvalue support
- No cast operations support included.