### PR TITLE
do replacement based on node arg usage, instead of provider type

### DIFF
--- a/onnxruntime/core/framework/transformer_memcpy.h
+++ b/onnxruntime/core/framework/transformer_memcpy.h
@@ -20,6 +20,7 @@ class TransformerMemcpyImpl {
 
  private:
   void ProcessDefs(onnxruntime::Node& node, const KernelRegistryManager& kernel_registries);
+  void BuildDefsMapping(const onnxruntime::NodeArg* arg, const KernelRegistryManager& kernel_registries);
   void AddCopyNode(onnxruntime::NodeArg* arg, bool is_input);
   void ProcessInitializers();
 
@@ -45,7 +46,9 @@ class TransformerMemcpyImpl {
   std::set<onnxruntime::NodeArg*, NodeArgCompare> non_provider_output_defs_;       // all output defs of non-provider nodes
   std::set<const onnxruntime::NodeArg*, NodeArgCompare> provider_input_defs_;      // all input defs of provider nodes that should be in provider allocator
   std::set<onnxruntime::NodeArg*, NodeArgCompare> provider_output_defs_;           // all output defs of provider nodes that should be in provider allocator
-  std::map<const onnxruntime::NodeArg*, onnxruntime::NodeArg*> replacements_;
+  std::map<const onnxruntime::NodeArg*, std::set<onnxruntime::Node*, NodeCompare>> provider_input_nodes_;
+  std::map<const onnxruntime::NodeArg*, std::set<onnxruntime::Node*, NodeCompare>> provider_output_nodes_;
+
   onnxruntime::Graph& graph_;
   std::string provider_;
 };


### PR DESCRIPTION
Previously at the last step of memcpy_transformer, it does the node arg replacement based on provider nodes, it assuming that the node assign to this provider will always place the tensor on device, this is not true if the kernel declare to use host memory. We found the issue when test with inception_v4 model. 
This PR is to looking at the node arg usage (is it really used as device memory), by build a arg to node map. it may be not that efficient, but works.