### PR TITLE
Changed nativeLib name in C# interop from onnxruntime.dll to onnxruntime, for cross…

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
@@ -12,7 +12,7 @@ namespace Microsoft.ML.OnnxRuntime
 
     internal static class NativeMethods
     {
-        private const string nativeLib = "onnxruntime.dll";
+        private const string nativeLib = "onnxruntime";
         internal const CharSet charSet = CharSet.Ansi;
 
         #region Runtime/Environment API


### PR DESCRIPTION
… platform