### PR TITLE
adjust the quantization ops' definitions

### DIFF
--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -18,8 +18,8 @@ void convPoolTypeAndShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, bool u
 namespace onnxruntime {
 namespace contrib {
 using ::ONNX_NAMESPACE::AttributeProto;
-using ::ONNX_NAMESPACE::OpSchema;
 using ::ONNX_NAMESPACE::OPTIONAL;
+using ::ONNX_NAMESPACE::OpSchema;
 
 void RegisterContribSchemas() {
   ONNX_CONTRIB_OPERATOR_SCHEMA(SampleOp)
@@ -465,12 +465,12 @@ if the input is 8 bits or in 64 bits if the input is 16 bits.)DOC")
           "X.shape[1] == (W.shape[1] * group) == C "
           "(assuming zero based indices for the shape array). "
           "Or in other words FILTER_IN_CHANNEL should be equal to DATA_CHANNEL. ",
-          "T1")
+          "T2")
       .Input(4, "w_scale", "Scale tensor for input 'w'. It could be a scalar or a 1-D tensor, which means a per-tensor or per-channel quantization. If it's a 1-D tensor, its number of elements should be equal to the number of channels of input 'w'.", "tensor(float)")
-      .Input(5, "w_zero_point", "Scale tensor for input 'w'. It could be a scalar or a 1-D tensor, which means a per-tensor or per-channel quantization. If it's a 1-D tensor, its number of elements should be equal to the number of channels of input 'w'.", "T1")
+      .Input(5, "w_zero_point", "Scale tensor for input 'w'. It could be a scalar or a 1-D tensor, which means a per-tensor or per-channel quantization. If it's a 1-D tensor, its number of elements should be equal to the number of channels of input 'w'.", "T2")
       .Input(6, "y_scale", "Scale tensor for output 'y'. It could be a scalar or a 1-D tensor, which means a per-tensor or per-channel quantization. If it's a 1-D tensor, its number of elements should be equal to the number of channels of input 'y'.", "tensor(float)")
-      .Input(7, "y_zero_point", "Scale tensor for output 'y'. It could be a scalar or a 1-D tensor, which means a per-tensor or per-channel quantization. If it's a 1-D tensor, its number of elements should be equal to the number of channels of input 'y'.", "T1")
-      .Input(8, "B", "Optional 1D bias to be added to the convolution, has size of M.", "T2", OpSchema::Optional)
+      .Input(7, "y_zero_point", "Scale tensor for output 'y'. It could be a scalar or a 1-D tensor, which means a per-tensor or per-channel quantization. If it's a 1-D tensor, its number of elements should be equal to the number of channels of input 'y'.", "T3")
+      .Input(8, "B", "Optional 1D bias to be added to the convolution, has size of M.", "T4", OpSchema::Optional)
       .Output(
           0,
           "y",
@@ -481,8 +481,16 @@ if the input is 8 bits or in 64 bits if the input is 16 bits.)DOC")
       .TypeConstraint(
           "T1",
           {"tensor(int8)", "tensor(uint8)", "tensor(int16)", "tensor(uint16)"},
-          "Constrain input, filter, and output types to 8-bit or 16-bit integer tensors.")
-      .TypeConstraint("T2", {"tensor(int32)", "tensor(uint32)"}, "Constrain bias type to 32-bit integer tensor.")
+          "Constrain input types to 8-bit or 16-bit integer tensors.")
+      .TypeConstraint(
+          "T2",
+          {"tensor(int8)", "tensor(uint8)", "tensor(int16)", "tensor(uint16)"},
+          "Constrain filter types to 8-bit or 16-bit integer tensors.")
+      .TypeConstraint(
+          "T3",
+          {"tensor(int8)", "tensor(uint8)", "tensor(int16)", "tensor(uint16)"},
+          "Constrain output types to 8-bit or 16-bit integer tensors.")
+      .TypeConstraint("T4", {"tensor(int32)", "tensor(uint32)"}, "Constrain bias type to 32-bit integer tensor.")
       .Attr(
           "auto_pad",
           auto_pad_doc,
@@ -552,7 +560,16 @@ The integer convolution operator consumes an input tensor, a filter, and a paddi
           "(assuming zero based indices for the shape array). "
           "Or in other words FILTER_IN_CHANNEL should be equal to DATA_CHANNEL. ",
           "T2")
-      .Input(2, "z", "Padding value (zero_point normally), it's optional and default value is 0.", "T1", OpSchema::Optional)
+      .Input(2, "x_zero_point",
+             "Zero point tensor for input 'x'. It's optional and default value is 0. It could be a scalar or a 1-D tensor, "
+             "which means a per-tensor or per-channel quantization. If it's a 1-D tensor, its number of elements "
+             "should be equal to the number of channels of input 'x'.",
+             "T1", OpSchema::Optional)
+      .Input(3, "w_zero_point",
+             "Scale tensor for input 'w'. It's optional and default value is 0.  It could be a scalar or a 1-D tensor, "
+             "which means a per-tensor or per-channel quantization. If it's a 1-D tensor, its number "
+             "of elements should be equal to the number of channels of input 'w'.",
+             "T2", OpSchema::Optional)
       .Output(
           0,
           "y",
@@ -606,6 +623,16 @@ Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-
  The production MUST never overflow. The accumulation may overflow if and only if in 32 bits.)DOC")
       .Input(0, "A", "N-dimensional matrix A", "T1")
       .Input(1, "B", "N-dimensional matrix B", "T2")
+      .Input(2, "a_zero_point",
+             "Zero point tensor for input 'A'. It's optional and default value is 0. It could be a scalar or a 1-D tensor, "
+             "which means a per-tensor or per-row quantization. If it's a 1-D tensor, its number of elements "
+             "should be equal to the number of rows of input 'A'.",
+             "T1", OpSchema::Optional)
+      .Input(3, "b_zero_point",
+             "Scale tensor for input 'B'. It's optional and default value is 0.  It could be a scalar or a 1-D tensor, "
+             "which means a per-tensor or per-column quantization. If it's a 1-D tensor, its number "
+             "of elements should be equal to the number of columns of input 'B'.",
+             "T2", OpSchema::Optional)
       .Output(0, "Y", "Matrix multiply results from A * B", "T3")
       .TypeConstraint("T1", {"tensor(int8)", "tensor(uint8)"}, "Constrain input A data types as 8-bit integer tensor")
       .TypeConstraint("T2", {"tensor(int8)", "tensor(uint8)"}, "Constrain input B data types as 8-bit integer tensor")


### PR DESCRIPTION
the PR contains,
1. Fix type constraints for QLinearConv (input. filter and output do not need to be same type though they're all 8-bit integers.
2. Add zero point as op input for ConvInteger and MatMulInteger.

The linear quantization math (zero_point/scale)'s math is,
r = (q-z)*s   -- r, s are floats, q, z are 8 bit integers.

so, the op design idea is, for matmul, there will be one op:
QLinearMatMul: q_y = (s_a*s_b)/s_y (q_a-z_a)(q_b-z_b) + z_y
s_a, s_b, s_y are floats;
q_a, z_a, q_b, z_b, q_y, z_y are 8 bit integers;

and one op:
MatMulInteger: q_y = (q_a-z_a)(q_b-z_b)
q_a, z_a, q_b, z_b are 8 bit integers;
q_z are 32 bit integers;

In this way, QLinearMatMul is actually be able to composed by MatMulInteger and some elementwise operators (Mul/Div/Add). 
