### PR TITLE
Update documentation to reflect the latest changes on converter side

### DIFF
--- a/docs/python/README.rst
+++ b/docs/python/README.rst
@@ -34,12 +34,12 @@ replaces *scikit-learn* to compute the predictions.
     clr.fit(X_train, y_train)
 
     # Convert into ONNX format with onnxmltools
-    from onnxmltools import convert_sklearn
-    from onnxmltools.utils import save_model
-    from onnxmltools.convert.common.data_types import FloatTensorType
+    from skl2onnx import convert_sklearn
+    from skl2onnx.common.data_types import FloatTensorType
     initial_type = [('float_input', FloatTensorType([1, 4]))]
     onx = convert_sklearn(clr, initial_types=initial_type)
-    save_model(onx, "rf_iris.onnx")
+    with open("rf_iris.onnx", "wb") as f:
+        f.write(onx.SerializeToString())
 
     # Compute the prediction with ONNX Runtime
     import onnxruntime as rt

--- a/docs/python/conf.py
+++ b/docs/python/conf.py
@@ -8,20 +8,21 @@
 import os
 import sys
 import shutil
+import warnings
 # Check these extensions were installed.
 import sphinx_gallery.gen_gallery
 # The package should be installed in a virtual environment.
 import onnxruntime
-# The documentation requires two extensions available at:
+# markdown output: it requires two extensions available at:
 # https://github.com/xadupre/sphinx-docfx-yaml
 # https://github.com/xadupre/sphinx-docfx-markdown
 import sphinx_modern_theme
-
+import recommonmark
 
 # -- Project information -----------------------------------------------------
 
 project = 'ONNX Runtime'
-copyright = '2018, Microsoft'
+copyright = '2018-2019, Microsoft'
 author = 'Microsoft'
 version = onnxruntime.__version__
 release = version
@@ -37,8 +38,6 @@ extensions = [
     'sphinx.ext.githubpages',
     "sphinx_gallery.gen_gallery",
     'sphinx.ext.autodoc',
-    "docfx_yaml.extension",
-    "docfx_markdown",
     "pyquickhelper.sphinxext.sphinx_runpython_extension",
 ]
 
@@ -48,9 +47,20 @@ source_parsers = {
    '.md': 'recommonmark.parser.CommonMarkParser',
 }
 
-source_suffix = ['.rst', '.md']
+source_suffix = ['.rst'] # , '.md']
 
-master_doc = 'intro'
+# enables markdown output
+try:
+    import docfx_markdown
+    extension.extend([
+        "docfx_yaml.extension",
+        "docfx_markdown",
+    ])
+    source_suffix.append('md')
+except ImportError:
+    warnings.warn("markdown output is not available")
+
+master_doc = 'index'
 language = "en"
 exclude_patterns = []
 pygments_style = 'sphinx'
@@ -59,7 +69,7 @@ pygments_style = 'sphinx'
 
 html_theme = "sphinx_modern_theme"
 html_theme_path = [sphinx_modern_theme.get_html_theme_path()]
-html_logo = "../MSFT-Onnx-Runtime-11282019-Logo.png"
+html_logo = "../ONNX_Runtime_icon.png"
 html_static_path = ['_static']
 
 # -- Options for intersphinx extension ---------------------------------------

--- a/docs/python/examples/plot_convert_pipeline_vectorizer.py
+++ b/docs/python/examples/plot_convert_pipeline_vectorizer.py
@@ -54,17 +54,17 @@ print(r2_score(y_test, pred))
 # +++++++++++++++++++++++++
 #
 # We use module 
-# `onnxmltools <https://github.com/onnx/onnxmltools>`_
+# `sklearn-onnx <https://github.com/onnx/sklearn-onnx>`_
 # to convert the model into ONNX format.
 
-from onnxmltools import convert_sklearn
-from onnxmltools.utils import save_model
-from onnxmltools.convert.common.data_types import FloatTensorType, Int64TensorType, DictionaryType, SequenceType
+from skl2onnx import convert_sklearn
+from skl2onnx.common.data_types import FloatTensorType, Int64TensorType, DictionaryType, SequenceType
 
 # initial_type = [('float_input', DictionaryType(Int64TensorType([1]), FloatTensorType([])))]
 initial_type = [('float_input', DictionaryType(Int64TensorType([1]), FloatTensorType([])))]
 onx = convert_sklearn(pipe, initial_types=initial_type)
-save_model(onx, "pipeline_vectorize.onnx")
+with open("pipeline_vectorize.onnx", "wb") as f:
+    f.write(onx.SerializeToString())
 
 ##################################
 # We load the model with ONNX Runtime and look at

--- a/docs/python/examples/plot_dl_keras.py
+++ b/docs/python/examples/plot_dl_keras.py
@@ -14,6 +14,7 @@ of a pretrained deep learning model obtained from
 with *onnxruntime*. The conversion requires
 `keras <https://keras.io/>`_,
 `tensorflow <https://www.tensorflow.org/>`_,
+`sklearn-onnx <https://github.com/onnx/sklearn-onnx/>`_,
 `onnxmltools <https://pypi.org/project/onnxmltools/>`_
 but then only *onnxruntime* is required
 to compute the predictions.
@@ -24,10 +25,9 @@ if not os.path.exists('dense121.onnx'):
     model = DenseNet121(include_top=True, weights='imagenet')
 
     from onnxmltools import convert_keras
-    onx = convert_keras(model, 'dense121.onnx')
-    
-    from onnxmltools.utils import save_model
-    save_model(onx, "dense121.onnx")
+    onx = convert_keras(model, 'dense121.onnx')    
+    with open("dense121.onnx", "wb") as f:
+        f.write(onx.SerializeToString())
 
 ##################################
 # Let's load an image (source: wikipedia).

--- a/docs/python/examples/plot_metadata.py
+++ b/docs/python/examples/plot_metadata.py
@@ -11,7 +11,7 @@ is deployed to production to keep track of which
 instance was used at a specific time.
 Let's see how to do that with a simple 
 logistic regression model trained with
-*scikit-learn* and converted with *onnxmltools*.
+*scikit-learn* and converted with *sklearn-onnx*.
 """
 
 from onnxruntime.datasets import get_example

--- a/docs/python/examples/plot_train_convert_predict.py
+++ b/docs/python/examples/plot_train_convert_predict.py
@@ -48,16 +48,16 @@ print(confusion_matrix(y_test, pred))
 # +++++++++++++++++++++++++
 #
 # We use module 
-# `onnxmltools <https://github.com/onnx/onnxmltools>`_
+# `sklearn-onnx <https://github.com/onnx/sklearn-onnx>`_
 # to convert the model into ONNX format.
 
-from onnxmltools import convert_sklearn
-from onnxmltools.utils import save_model
-from onnxmltools.convert.common.data_types import FloatTensorType
+from skl2onnx import convert_sklearn
+from skl2onnx.common.data_types import FloatTensorType
 
 initial_type = [('float_input', FloatTensorType([1, 4]))]
 onx = convert_sklearn(clr, initial_types=initial_type)
-save_model(onx, "logreg_iris.onnx")
+with open("logreg_iris.onnx", "wb") as f:
+    f.write(onx.SerializeToString())
 
 ##################################
 # We load the model with ONNX Runtime and look at
@@ -172,7 +172,8 @@ rf.fit(X_train, y_train)
 
 initial_type = [('float_input', FloatTensorType([1, 4]))]
 onx = convert_sklearn(rf, initial_types=initial_type)
-save_model(onx, "rf_iris.onnx")
+with open("rf_iris.onnx", "wb") as f:
+    f.write(onx.SerializeToString())
 
 ###################################
 # We compare.
@@ -199,7 +200,8 @@ for n_trees in range(5, 51, 5):
     rf.fit(X_train, y_train)
     initial_type = [('float_input', FloatTensorType([1, 4]))]
     onx = convert_sklearn(rf, initial_types=initial_type)
-    save_model(onx, "rf_iris_%d.onnx" % n_trees)
+    with open("rf_iris_%d.onnx" % n_trees, "wb") as f:
+        f.write(onx.SerializeToString())
     sess = rt.InferenceSession("rf_iris_%d.onnx" % n_trees)
     def sess_predict_proba_loop(x):
         return sess.run([prob_name], {input_name: x.astype(numpy.float32)})[0]

--- a/docs/python/index.rst
+++ b/docs/python/index.rst
@@ -10,26 +10,14 @@ community, it supports traditional ML models as well
 as Deep Learning algorithms in the
 `ONNX-ML format <https://github.com/onnx/onnx/blob/master/docs/IR.md>`_.
 
-.. only:: html
+.. toctree::
+    :maxdepth: 1
 
-    .. toctree::
-        :maxdepth: 1
+    tutorial
+    api_summary
+    auto_examples/index
 
-        tutorial
-        api_summary
-        auto_examples/index
-
-    :ref:`genindex`
-
-.. only:: md
-
-    .. toctree::
-        :maxdepth: 1
-        :caption: Contents:
-
-        tutorial
-        api_summary
-        examples_md
+:ref:`genindex`
 
 The core library is implemented in C++.
 *ONNX Runtime* is available on

--- a/docs/python/tutorial.rst
+++ b/docs/python/tutorial.rst
@@ -58,13 +58,13 @@ to convert other model formats into ONNX. Here we will use
     :store:
     :warningout: ImportWarning FutureWarning
 
-    from onnxmltools import convert_sklearn
-    from onnxmltools.utils import save_model
-    from onnxmltools.convert.common.data_types import FloatTensorType
+    from skl2onnx import convert_sklearn
+    from skl2onnx.common.data_types import FloatTensorType
 
     initial_type = [('float_input', FloatTensorType([1, 4]))]
     onx = convert_sklearn(clr, initial_types=initial_type)
-    save_model(onx, "logreg_iris.onnx")
+    with open("logreg_iris.onnx", "wb") as f:
+        f.write(onx.SerializeToString())
 
 Step 3: Load and run the model using ONNX Runtime
 +++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
- removes markdown output
- rename intro into index
- uses skl2onnx anywhere possible instead of onnxmltools