### PR TITLE
Split Windows build into multiple stages

### DIFF
--- a/cmake/onnxruntime_csharp.cmake
+++ b/cmake/onnxruntime_csharp.cmake
@@ -9,4 +9,5 @@ include(CSharpUtilities)
 include_external_msproject(${CSHARP_MASTER_TARGET}
                            ${CSHARP_MASTER_PROJECT}
                            onnxruntime   # make it depend on the native onnxruntime project
+                           ${onnxruntime_EXTERNAL_DEPENDENCIES}
                            )

--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -1,19 +1,110 @@
 jobs:
 - job: Windows_CI_Dev
-  pool: Win-CPU
+  variables:
+    buildDirectory: '$(Build.BinariesDirectory)'
   steps:
-    - template: templates/set-test-data-variables-step.yml
+    - template: templates/set-test-data-variables-step.yml    
+    - task: NuGetCommand@2
+      displayName: 'NuGet restore'
+      inputs:
+        restoreSolution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+        feedsToUse: config
+        nugetConfigPath: '$(Build.SourcesDirectory)\csharp\Nuget.CSharp.config'
+        restoreDirectory: '$(Build.SourcesDirectory)\csharp'
+    - task: UniversalPackages@0
+      displayName: 'Download python'
+      inputs:
+        command: download
+        vstsFeed: '$(System.TeamProject)'
+        vstsFeedPackage: 'miniconda3_win64'
+        vstsPackageVersion: '4.5.11'
+        downloadDirectory: '$(Build.BinariesDirectory)\python'
+    - task: CmdLine@1
+      displayName: 'Run python installer'
+      inputs:
+        filename: '$(Build.BinariesDirectory)\python\installer.exe'
+        arguments: '/S /NoRegistry=1 /AddToPath=0 /RegisterPython=0 /D=$(Build.BinariesDirectory)\packages\python'
+      timeoutInMinutes: 10
+    - task: BatchScript@1
+      displayName: 'Run post_build_vsts.bat'
+      inputs:
+        filename: '$(Build.SourcesDirectory)\tools\ci_build\github\windows\setup_env.bat'
+        modifyEnvironment: true
+        workingFolder: '$(Build.BinariesDirectory)'
+    - task: CmdLine@1
+      displayName: 'Install conda modules'
+      inputs:
+        filename: '$(Build.BinariesDirectory)\packages\python\scripts\conda.exe'
+        arguments: 'install -q --insecure -y pyopenssl setuptools wheel numpy'
+      timeoutInMinutes: 10
 
     - task: CmdLine@1
       displayName: 'Download cmake'
       inputs:
-        filename: python
+        filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
         arguments: '$(Build.SourcesDirectory)\tools\ci_build\github\windows\download_cmake.py --build_dir $(Build.BinariesDirectory)'
-
-    - task: BatchScript@1
+    - task: CmdLine@1
+      displayName: 'Download test data and generate cmake config'
       inputs:
-        filename: build.bat
-        arguments: ' --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --config Debug Release --use_tvm --enable_pybind --use_mkldnn --use_mklml --use_openmp --build_shared_lib --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum)'
+        filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --config Debug Release --use_tvm --enable_pybind --use_mkldnn --use_mklml --use_openmp --build_shared_lib  --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --update'
+        workingDirectory: "$(Build.BinariesDirectory)"
+
+    - task: VSBuild@1
+      displayName: 'Build Debug'
+      inputs:
+        solution: '$(Build.BinariesDirectory)\Debug\onnxruntime.sln'
+        platform: 'x64'
+        configuration: 'Debug'
+        msbuildArgs: '/m'
+        msbuildArchitecture: 'x64'
+        logProjectEvents: true
+        workingFolder: '$(Build.BinariesDirectory)\Debug'
+    - task: BatchScript@1
+      displayName: 'Test Debug'
+      inputs:
+        filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --config Debug --use_tvm --enable_pybind --use_mkldnn --use_mklml --use_openmp --build_shared_lib  --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --test'
+        workingFolder: '$(Build.BinariesDirectory)'
+    - task: VSBuild@1
+      displayName: 'Build C# Debug'
+      inputs:
+        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+        configuration: 'Debug'
+        restoreNugetPackages: false
+        msbuildArchitecture: 'x64'
+        workingFolder: '$(Build.SourcesDirectory)\csharp'
+    - task: VSBuild@1
+      displayName: 'Build Release'
+      inputs:
+        solution: '$(Build.BinariesDirectory)\Release\onnxruntime.sln'
+        platform: 'x64'
+        configuration: 'Release'
+        msbuildArgs: '/m'
+        msbuildArchitecture: 'x64'
+        logProjectEvents: true
+        workingFolder: '$(Build.BinariesDirectory)\Release'
+    - task: BatchScript@1
+      displayName: 'Test Release'
+      inputs:
+        filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --config Debug --use_tvm --enable_pybind --use_mkldnn --use_mklml --use_openmp --build_shared_lib  --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --test'
         workingFolder: "$(Build.BinariesDirectory)"
 
+    - task: VSBuild@1
+      displayName: 'Build c# Release'
+      inputs:
+        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+        configuration: 'Release'
+        msbuildArchitecture: 'x64'
+        restoreNugetPackages: false
+        workingFolder: '$(Build.SourcesDirectory)\csharp'
+
+    - task: PublishTestResults@2
+      displayName: 'Publish unit test results'
+      inputs:
+        testResultsFiles: '**\*.results.xml'
+        searchFolder: '$(Build.BinariesDirectory)'
+        testRunTitle: 'Unit Test Run'
+      condition: succeededOrFailed()
     - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
@@ -1,15 +1,48 @@
 jobs:
 - job: Windows_CI_GPU_Dev
-  pool: Win-GPU-CUDA10
   variables:
     CUDA_VERSION: '10.0'
   steps:
     - template: templates/set-test-data-variables-step.yml
+    - task: NuGetCommand@2
+      displayName: 'NuGet restore'
+      inputs:
+        restoreSolution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+        feedsToUse: config
+        nugetConfigPath: '$(Build.SourcesDirectory)\csharp\Nuget.CSharp.config'
+        restoreDirectory: '$(Build.SourcesDirectory)\csharp'
+    - task: UniversalPackages@0
+      displayName: 'Download python'
+      inputs:
+        command: download
+        vstsFeed: '$(System.TeamProject)'
+        vstsFeedPackage: 'miniconda3_win64'
+        vstsPackageVersion: '4.5.11'
+        downloadDirectory: '$(Build.BinariesDirectory)\python'
+    - task: CmdLine@1
+      displayName: 'Run python installer'
+      inputs:
+        filename: '$(Build.BinariesDirectory)\python\installer.exe'
+        arguments: '/S /NoRegistry=1 /AddToPath=0 /RegisterPython=0 /D=$(Build.BinariesDirectory)\packages\python'
+      timeoutInMinutes: 10
+    - task: BatchScript@1
+      displayName: 'Run post_build_vsts.bat'
+      inputs:
+        filename: '$(Build.SourcesDirectory)\tools\ci_build\github\windows\setup_env.bat'
+        modifyEnvironment: true
+        workingFolder: '$(Build.BinariesDirectory)'
+    - task: CmdLine@1
+      displayName: 'Install conda modules'
+      inputs:
+        filename: '$(Build.BinariesDirectory)\packages\python\scripts\conda.exe'
+        arguments: 'install -q --insecure -y pyopenssl setuptools wheel numpy'
+      timeoutInMinutes: 10
+
 
     - task: CmdLine@1
       displayName: 'Download cmake'
       inputs:
-        filename: python
+        filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
         arguments: '$(Build.SourcesDirectory)\tools\ci_build\github\windows\download_cmake.py --build_dir $(Build.BinariesDirectory)'
 
     - task: PowerShell@1
@@ -25,11 +58,71 @@ jobs:
         arguments: 'amd64 -vcvars_ver=14.11'
         modifyEnvironment: true
 
-    - task: BatchScript@1
+    - task: CmdLine@1
+      displayName: 'Download test data and generate cmake config'
       inputs:
-        filename: build.bat
-        arguments: ' --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --config Debug Release --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --use_mkldnn --build_shared_lib --build_csharp --use_cuda --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda"'
-        workingFolder: "$(Build.SourcesDirectory)"
+        filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --config Debug Release --enable_pybind --use_mkldnn --use_mklml --use_openmp --build_shared_lib  --enable_onnx_tests --use_cuda --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --update'
+        workingDirectory: "$(Build.BinariesDirectory)"
+
+    - task: VSBuild@1
+      displayName: 'Build Debug'
+      inputs:
+        solution: '$(Build.BinariesDirectory)\Debug\onnxruntime.sln'
+        platform: 'x64'
+        configuration: 'Debug'
+        msbuildArgs: '/m'
+        msbuildArchitecture: 'x64'
+        logProjectEvents: true
+        workingFolder: '$(Build.BinariesDirectory)\Debug'
+    - task: BatchScript@1
+      displayName: 'Test Debug'
+      inputs:
+        filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --config Debug --enable_pybind --use_mkldnn --use_mklml --use_openmp --build_shared_lib  --enable_onnx_tests --use_cuda --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --test'
+        workingFolder: '$(Build.BinariesDirectory)'
+    - task: VSBuild@1
+      displayName: 'Build C# Debug'
+      inputs:
+        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+        configuration: 'Debug'
+        restoreNugetPackages: false
+        msbuildArchitecture: 'x64'
+        workingFolder: '$(Build.SourcesDirectory)\csharp'
+    - task: VSBuild@1
+      displayName: 'Build Release'
+      inputs:
+        solution: '$(Build.BinariesDirectory)\Release\onnxruntime.sln'
+        platform: 'x64'
+        configuration: 'Release'
+        msbuildArgs: '/m'
+        msbuildArchitecture: 'x64'
+        logProjectEvents: true
+        workingFolder: '$(Build.BinariesDirectory)\Release'
+
+    - task: BatchScript@1
+      displayName: 'Test Release'
+      inputs:
+        filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --config Debug --enable_pybind --use_mkldnn --use_mklml --use_openmp --build_shared_lib  --enable_onnx_tests --use_cuda --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --test'
+        workingFolder: "$(Build.BinariesDirectory)"
+
+    - task: VSBuild@1
+      displayName: 'Build c# Release'
+      inputs:
+        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+        configuration: 'Release'
+        msbuildArchitecture: 'x64'
+        restoreNugetPackages: false
+        workingFolder: '$(Build.SourcesDirectory)\csharp'
+
+    - task: PublishTestResults@2
+      displayName: 'Publish unit test results'
+      inputs:
+        testResultsFiles: '**\*.results.xml'
+        searchFolder: '$(Build.BinariesDirectory)'
+        testRunTitle: 'Unit Test Run'
+      condition: succeededOrFailed()
 
     - task: PowerShell@1
       displayName: 'Clean up CUDA props files'

--- a/tools/ci_build/github/windows/setup_env.bat
+++ b/tools/ci_build/github/windows/setup_env.bat
@@ -1,0 +1,1 @@
+set PATH=%PATH%;%BUILD_BINARIESDIRECTORY%\packages\python;%BUILD_BINARIESDIRECTORY%\packages\python\DLLs;%BUILD_BINARIESDIRECTORY%\packages\python\Library\bin;%BUILD_BINARIESDIRECTORY%\packages\python\script


### PR DESCRIPTION
1. Split Windows build into multiple stages, so that we can better know how the time was spent
2. Create a fresh python installation at the beginning of every build.  so that we can freely choose python version.