### PR TITLE
Fix Seg fault when repeats input contain a 0

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/tile.cc
+++ b/onnxruntime/core/providers/cpu/tensor/tile.cc
@@ -46,18 +46,17 @@ Status Tile<float>::Compute(OpKernelContext* ctx) const {
   // Calculate the shape of the output tensor
   auto* repeats = repeats_tensor.template Data<int64_t>();
   std::vector<int64_t> output_dims = input_tensor.Shape().GetDims();
-  bool returnEmptyTensor = false;
   for (auto axis = 0; axis < input_tensor.Shape().NumDimensions(); axis++) {
     output_dims[axis] *= repeats[axis];
-    if (repeats[axis] == 0) {
-      returnEmptyTensor = true;
-    }
   }
 
   TensorShape outputShape(output_dims);
   auto& output_tensor = *ctx->Output(0, outputShape);
 
-  if (returnEmptyTensor) {
+  // Repeat tensor input can have 0 as a valid value
+  // check if the computed outputshape size is 0 and
+  // return an empty tensor if so.
+  if (outputShape.Size() == 0) {
     return Status::OK();
   }
 

--- a/onnxruntime/core/providers/cpu/tensor/tile.cc
+++ b/onnxruntime/core/providers/cpu/tensor/tile.cc
@@ -46,10 +46,20 @@ Status Tile<float>::Compute(OpKernelContext* ctx) const {
   // Calculate the shape of the output tensor
   auto* repeats = repeats_tensor.template Data<int64_t>();
   std::vector<int64_t> output_dims = input_tensor.Shape().GetDims();
-  for (auto axis = 0; axis < input_tensor.Shape().NumDimensions(); axis++)
+  bool returnEmptyTensor = false;
+  for (auto axis = 0; axis < input_tensor.Shape().NumDimensions(); axis++) {
     output_dims[axis] *= repeats[axis];
+    if (repeats[axis] == 0) {
+      returnEmptyTensor = true;
+    }
+  }
+
   TensorShape outputShape(output_dims);
   auto& output_tensor = *ctx->Output(0, outputShape);
+
+  if (returnEmptyTensor) {
+    return Status::OK();
+  }
 
   auto* output = output_tensor.template MutableData<float>();
   auto* input = input_tensor.template Data<float>();

--- a/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
@@ -7,6 +7,26 @@
 namespace onnxruntime {
 namespace test {
 
+TEST(TensorOpTest, Tile1DWithZeroRepeats) {
+  OpTester test("Tile");
+
+  test.AddInput<float>("input", {3}, {1.0f, 2.0f, 3.0f});
+  test.AddInput<int64_t>("repeats", {1}, {0});
+  test.AddOutput<float>("output", {0}, {});
+  test.Run();
+}
+
+TEST(TensorOpTest, Tile2DWithZeroRepeats) {
+  OpTester test("Tile");
+
+  test.AddInput<float>("input", {2, 2},
+                       {11.0f, 12.0f,
+                        21.0f, 22.0f});
+  test.AddInput<int64_t>("repeats", {2}, {2, 0});
+  test.AddOutput<float>("output", {4, 0}, {});
+  test.Run();
+}
+
 TEST(TensorOpTest, Tile1D) {
   OpTester test("Tile");
 


### PR DESCRIPTION
The fix is to return an empty tensor with shape 0 for dims with a 0 in the repeats.