### PR TITLE
remove use_tvm from base script. Put it in yaml configuration

### DIFF
--- a/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
@@ -16,7 +16,7 @@ jobs:
       displayName: 'Run build script'
       inputs:
         scriptPath: 'tools/ci_build/github/linux/run_dockerbuild.sh'
-        args: '-c Release -o ubuntu16.04 -d cpu -r $(Build.BinariesDirectory) -p $(python.version) -x "--build_wheel --use_mkldnn --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum)"'
+        args: '-c Release -o ubuntu16.04 -d cpu -r $(Build.BinariesDirectory) -p $(python.version) -x "--build_wheel --use_mkldnn --use_tvm --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum)"'
 
     - task: CopyFiles@2
       displayName: 'Copy Python Wheel to:  $(Build.ArtifactStagingDirectory)'

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -4,7 +4,7 @@ jobs:
   steps:
     - template: templates/set-test-data-variables-step.yml
 
-    - script: 'tools/ci_build/github/linux/run_dockerbuild.sh -o ubuntu16.04 -d cpu -r $(Build.BinariesDirectory) -x "--use_mklml --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum)"'
+    - script: 'tools/ci_build/github/linux/run_dockerbuild.sh -o ubuntu16.04 -d cpu -r $(Build.BinariesDirectory) -x "--use_mklml --use_tvm --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum)"'
       displayName: 'Command Line Script'
 
     - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/linux/run_build.sh
+++ b/tools/ci_build/github/linux/run_build.sh
@@ -26,7 +26,6 @@ if [ $BUILD_DEVICE = "gpu" ]; then
 else
     python3 $SCRIPT_DIR/../../build.py --build_dir /home/onnxruntimedev \
         --config Debug Release --build_shared_lib \
-        --use_tvm \
         --skip_submodule_sync --enable_onnx_tests \
         --enable_pybind \
         --parallel --use_openmp --use_mkldnn --build_shared_lib $BUILD_EXTR_PAR


### PR DESCRIPTION
TVM should not be part of the base docker script, since that is common between github ci build and vsts ci build.  Otherwise the nuget package will always require the libtvm.so to be included.