### PR TITLE
Handle negative axes for reduce ops

### DIFF
--- a/onnxruntime/core/providers/cpu/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/cpu/reduction/reduction_ops.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/providers/cpu/reduction/reduction_ops.h"
+#include "core/providers/common.h"
 #include "core/util/math_cpuonly.h"
 using namespace std;
 namespace onnxruntime {
@@ -53,11 +54,9 @@ bool PrepareForReduce(OpKernelContext* ctx,
   const Tensor& input = *input_tensor_ptr;
 
   size_t ndim = input.Shape().GetDims().size();
-  std::vector<int64_t> axes = axes_;
-  for (size_t i = 0; i < axes.size(); i++) {
-    if (axes[i] < 0)
-      axes[i] += ndim;
-    ORT_ENFORCE(axes[i] >= 0 && axes[i] < (int64_t)ndim, "Axis attribute out of range");
+  std::vector<int64_t> axes;
+  for (int64_t axis : axes_) {
+    axes.push_back(HandleNegativeAxis(axis, static_cast<int64_t>(ndim)));
   }
 
   if (axes.empty()) {

--- a/onnxruntime/core/providers/cpu/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/cpu/reduction/reduction_ops.cc
@@ -53,11 +53,13 @@ bool PrepareForReduce(OpKernelContext* ctx,
   const Tensor& input = *input_tensor_ptr;
 
   size_t ndim = input.Shape().GetDims().size();
-  for (int64_t axe : axes_) {
-    ORT_ENFORCE(axe >= 0 && axe < (int64_t)ndim, "Axis attribute out of range");
+  std::vector<int64_t> axes = axes_;
+  for (size_t i = 0; i < axes.size(); i++) {
+    if (axes[i] < 0)
+      axes[i] += ndim;
+    ORT_ENFORCE(axes[i] >= 0 && axes[i] < (int64_t)ndim, "Axis attribute out of range");
   }
 
-  std::vector<int64_t> axes = axes_;
   if (axes.empty()) {
     // This is the default case for non-arg kind reductions. Reduce on all dimensions.
     for (size_t i = 0; i < ndim; i++)


### PR DESCRIPTION
* negative axes are not handled in shape inference if input shape
 is not known at that time.