### PR TITLE
Add --cuda_version option to enable manually specifying cuda version

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -70,6 +70,7 @@ Use the individual flags to only run the specified stages.
     parser.add_argument("--test_data_checksum", help="Test data checksum (MD5 digest).")
     # CUDA related
     parser.add_argument("--use_cuda", action='store_true', help="Enable CUDA.")
+    parser.add_argument("--cuda_version", help="The version of CUDA toolkit to use. Auto-detect if not specified. e.g. 9.0")
     parser.add_argument("--cuda_home", help="Path to CUDA home."
                                             "Read from CUDA_HOME environment variable if --use_cuda is true and --cuda_home is not specified.")
     parser.add_argument("--cudnn_home", help="Path to CUDNN home. "
@@ -542,6 +543,8 @@ def main():
             toolset = 'host=x64'
             if (args.msvc_toolset):
                 toolset += ',version=' + args.msvc_toolset
+            if (args.cuda_version):
+                toolset += ',cuda=' + args.cuda_version
 
             cmake_extra_args = ['-A','x64','-T', toolset, '-G', 'Visual Studio 15 2017']
         if is_ubuntu_1604():


### PR DESCRIPTION
This pull request is a patch for the build system when multiple CUDA SDKs are installed on the build machine and you want to build ONNX Runtime for a lower CUDA version with Visual Studio as CMake generator. Since it relates to the build system, not the algorithm, it does not come with a unit test.

By default, CMake always use the newest `nvcc` as the compiler for cuda source, i.e., when you have both CUDA 9.0 and CUDA 10.0 installed, CMake would always use `nvcc` comes with CUDA 10.0. This will cause compilation error when trying to compile with CUDA 9.0 with `nvcc` of CUDA 10.0. More specifically, the build command is (note that cuda 9.0 only works with VS 14.11, not VS 15.x):
> .\build.bat --config RelWithDebInfo --build_wheel --use_cuda --cuda_home "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.0" --cudnn_home "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.0" --msvc_toolset 14.11 --use_mklml

And the error generated is:

> CUDACOMPILE : nvcc error : 'cicc' died with status 0xC0000005 (ACCESS_VIOLATION) [D:\Repos\Lotus\build\Windows\RelWithDebInfo\onnxruntime_providers_cuda.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\VC\VCTargets\BuildCustomizations\CUDA 10.0.targets(712,9): error MSB3722: The command ""C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0\bin\nvcc.exe" -g
encode=arch=compute_30,code=\"sm_30,compute_30\" -gencode=arch=compute_50,code=\"sm_50,compute_50\" -gencode=arch=compute_60,code=\"sm_60,compute_60\" -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use-local-env -ccbin "C:\Program
 Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.11.25503\bin\HostX64\x64" -x cu  -ID:\Repos\Lotus\include\onnxruntime -ID:\Repos\Lotus\build\Windows\RelWithDebInfo -ID:\Repos\Lotus\build\Windows\RelWithDebInfo\exte
rnal\eigen -ID:\Repos\Lotus\cmake\external\gsl -ID:\Repos\Lotus\cmake\external\gsl\include -ID:\Repos\Lotus\cmake\external\onnx -ID:\Repos\Lotus\cmake\external\protobuf\src -ID:\Repos\Lotus\build\Windows\RelWithDebInfo\onnx\.. -ID:\Repo
s\Lotus\onnxruntime -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.0\include" -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0\include"     --keep-dir x64\RelWithDebInfo -maxrregcount=0  --machine 64 --compile -cuda
rt shared --default-stream per-thread -Xcompiler="-Zi -Ob1"    -DNDEBUG -D_SCL_SECURE_NO_WARNINGS -DONNX_ML -DONNX_NAMESPACE=onnx -DUSE_EIGEN_FOR_BLAS -DUSE_MLAS -DPLATFORM_WINDOWS -DNOGDI -DNOMINMAX -D_USE_MATH_DEFINES -DUSE_MKLML=1 -D
USE_CUDA=1 -D"CMAKE_INTDIR=\"RelWithDebInfo\"" -DWIN32 -D_WINDOWS -DGSL_THROW_ON_CONTRACT_VIOLATION -DEIGEN_HAS_C99_MATH -DNDEBUG -DGSL_UNENFORCED_ON_CONTRACT_VIOLATION -D_SCL_SECURE_NO_WARNINGS -DONNX_ML -DONNX_NAMESPACE=onnx -DUSE_EIG
EN_FOR_BLAS -DUSE_MLAS -DPLATFORM_WINDOWS -DNOGDI -DNOMINMAX -D_USE_MATH_DEFINES -DUSE_MKLML=1 -DUSE_CUDA=1 -D"CMAKE_INTDIR=\"RelWithDebInfo\"" -D_MBCS -Xcompiler "/EHsc /W3 /nologo /O2 /Fdonnxruntime_providers_cuda.dir\RelWithDebInfo\o
nnxruntime_providers_cuda.pdb /FS /Zi  /MD /GR" -o onnxruntime_providers_cuda.dir\RelWithDebInfo\activations_impl.obj "D:\Repos\Lotus\onnxruntime\core\providers\cuda\activation\activations_impl.cu"" exited with code 5. Please verify tha
t you have sufficient rights to run this command. [D:\Repos\Lotus\build\Windows\RelWithDebInfo\onnxruntime_providers_cuda.vcxproj]

From [the source code of CMake](https://gitlab.kitware.com/cmake/cmake/blob/fa5bf870df1ce5d9cbcf61be736beb0b1e87b85b/Source/cmGlobalVisualStudio10Generator.cxx#L233), we can know it always finds the highest version of CUDA tools in the Visual Studio `BuildCustomizations` folder. This means, even if you specify `CUDA_HOME` to CUDA 9.0 directory, as long as CUDA 10 is installed, it will use `nvcc` of CUDA 10. The only way to get rid of this, is override CUDA toolset version in CMake argument as this pull request shows.

This PR works for me on Windows but I don't have environment to test Linux/Mac. Nevertheless, I guess everything should be fine since CMake target parameter should be cross-platform.