### PR TITLE
Update property file for Nuget Linux package

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -40,10 +40,7 @@ else()
 endif()
 
 if (NOT WIN32)
-  set(CMAKE_SKIP_BUILD_RPATH  FALSE)
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-  set(CMAKE_INSTALL_RPATH "$ORIGIN/")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath='$ORIGIN'")
 endif()
 
 #The BEGIN_WHOLE_ARCHIVE/END_WHOLE_ARCHIVE part should contain the implementations of all the C API functions

--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -39,6 +39,13 @@ else()
   set(ONNXRUNTIME_SO_LINK_FLAG "-DEF:${SYMBOL_FILE}")
 endif()
 
+if (NOT WIN32)
+  set(CMAKE_SKIP_BUILD_RPATH  FALSE)
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+  set(CMAKE_INSTALL_RPATH "$ORIGIN/")
+endif()
+
 #The BEGIN_WHOLE_ARCHIVE/END_WHOLE_ARCHIVE part should contain the implementations of all the C API functions
 target_link_libraries(onnxruntime PRIVATE
     ${BEGIN_WHOLE_ARCHIVE}

--- a/csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.props
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.props
@@ -17,11 +17,4 @@
       <Visible>false</Visible>
     </None>
   </ItemGroup>
-    <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)\..\..\runtimes\linux-x64\native\*"
-          Condition="'$(OS)' == 'Unix'">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
 </Project>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.props
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.props
@@ -17,4 +17,11 @@
       <Visible>false</Visible>
     </None>
   </ItemGroup>
+    <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)\..\..\runtimes\linux-x64\native\libmkldnn*"
+          Condition="'$(OS)' == 'Unix'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Copy mkldnn to output folder for linux. Nuget doesn't resolve dll dependency correctly within a package.