### PR TITLE
Add concurrent run support for perf_test

### DIFF
--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -30,6 +30,7 @@ namespace perftest {
       "\t-e [cpu|cuda|mkldnn]: Specifies the provider 'cpu','cuda','mkldnn'. Default:'cpu'.\n"
       "\t-r [repeated_times]: Specifies the repeated times if running in 'times' test mode.Default:1000.\n"
       "\t-t [seconds_to_run]: Specifies the seconds to run for 'duration' mode. Default:600.\n"
+      "\t-c [concurrent_run]: Specifies the number of concurrent run, 0 means disabling concurrent run. Default:0.\n"
       "\t-p [profile_file]: Specifies the profile name to enable profiling and dump the profile data to the file.\n"
       "\t-s: Show statistics result, like P75, P90.\n"
       "\t-v: Show verbose information.\n"
@@ -39,7 +40,7 @@ namespace perftest {
 
 /*static*/ bool CommandLineParser::ParseArguments(PerformanceTestConfig& test_config, int argc, char* argv[]) {
   int ch;
-  while ((ch = getopt(argc, argv, "m:e:r:t:p:xvhs")) != -1) {
+  while ((ch = getopt(argc, argv, "m:e:r:t:c:p:xvhs")) != -1) {
     switch (ch) {
       case 'm':
         if (!strcmp(optarg, "duration")) {
@@ -75,6 +76,12 @@ namespace perftest {
       case 't':
         test_config.run_config.duration_in_seconds = static_cast<int>(strtol(optarg, nullptr, 10));
         if (test_config.run_config.repeated_times <= 0) {
+          return false;
+        }
+        break;
+      case 'c':
+        test_config.run_config.concurrent_run = static_cast<int>(strtol(optarg, nullptr, 10));
+        if (test_config.run_config.concurrent_run <= 0) {
           return false;
         }
         break;

--- a/onnxruntime/test/perftest/performance_runner.cc
+++ b/onnxruntime/test/perftest/performance_runner.cc
@@ -18,12 +18,19 @@ using onnxruntime::Status;
 namespace onnxruntime {
 namespace perftest {
 Status PerformanceRunner::Run() {
-  if (!Initialize()) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "failed to initialize.");
+  if (performance_test_config_.run_config.concurrent_run > 0) {
+    if (!Initialize(static_cast<int>(performance_test_config_.run_config.concurrent_run))) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "failed to initialize.");
+    }
+    // warm up
+    RunMultipleIteration(true /*isWarmup*/);
+  } else {
+    if (!Initialize()) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "failed to initialize.");
+    }
+    // warm up
+    RunOneIteration(true /*isWarmup*/);
   }
-
-  // warm up
-  RunOneIteration(true /*isWarmup*/);
 
   if (!performance_test_config_.run_config.profile_file.empty())
     session_object_->StartProfiling(performance_test_config_.run_config.profile_file);
@@ -51,7 +58,7 @@ Status PerformanceRunner::Run() {
   return Status::OK();
 }
 
-bool PerformanceRunner::Initialize() {
+bool PerformanceRunner::Initialize(int count) {
   path model_path(performance_test_config_.model_info.model_file_path);
   if (model_path.extension() != ".onnx") {
     LOGF_DEFAULT(ERROR, "input path is not a valid model");
@@ -78,14 +85,18 @@ bool PerformanceRunner::Initialize() {
   provider_types = {performance_test_config_.machine_config.provider_type_name};
   SessionFactory sf(provider_types, true, true);
   sf.enable_sequential_execution = performance_test_config_.run_config.enable_sequential_execution;
-  sf.session_thread_pool_size = 6;
+  sf.session_thread_pool_size = count;
 
   sf.create(session_object_, test_case->GetModelUrl(), test_case->GetTestCaseName());
 
   // Initialize IO Binding
-  if (!session_object_->NewIOBinding(&io_binding_).IsOK()) {
-    LOGF_DEFAULT(ERROR, "Failed to init session and IO binding");
-    return false;
+  for (int i = 0; i < count; ++i) {
+    std::unique_ptr<IOBinding> io_binding;
+    if (!session_object_->NewIOBinding(&io_binding).IsOK()) {
+      LOGF_DEFAULT(ERROR, "Failed to init session and IO binding");
+      return false;
+    }
+    io_bindings_.emplace_back(std::move(io_binding));
   }
 
   auto provider_type = performance_test_config_.machine_config.provider_type_name;
@@ -94,7 +105,8 @@ bool PerformanceRunner::Initialize() {
   if (provider_type == onnxruntime::kMklDnnExecutionProvider) {
     provider_type = onnxruntime::kCpuExecutionProvider;
   }
-  AllocatorPtr cpu_allocator = io_binding_->GetCPUAllocator(0, provider_type);
+  // use the first allocator
+  AllocatorPtr cpu_allocator = io_bindings_.front()->GetCPUAllocator(0, provider_type);
   test_case->SetAllocator(cpu_allocator);
 
   if (test_case->GetDataCount() <= 0) {
@@ -102,25 +114,27 @@ bool PerformanceRunner::Initialize() {
     return false;
   }
 
-  std::unordered_map<std::string, ::onnxruntime::MLValue> feeds;
-  test_case->LoadTestData(0 /* id */, feeds, true);
-  for (auto feed : feeds) {
-    io_binding_->BindInput(feed.first, feed.second);
-  }
-  auto outputs = session_object_->GetModelOutputs();
-  auto status = outputs.first;
-  if (!outputs.first.IsOK()) {
-    LOGF_DEFAULT(ERROR, "GetOutputs failed, TestCaseName:%s, ErrorMessage:%s",
-                 test_case->GetTestCaseName().c_str(),
-                 status.ErrorMessage().c_str());
-    return false;
-  }
+  for (int i = 0; i < count; ++i) {
+    std::unordered_map<std::string, ::onnxruntime::MLValue> feeds;
+    test_case->LoadTestData(0 /* id */, feeds, true);  // load the same data, in case user not creating test set
+    for (auto feed : feeds) {
+      io_bindings_[i]->BindInput(feed.first, feed.second);
+    }
+    auto outputs = session_object_->GetModelOutputs();
+    auto status = outputs.first;
+    if (!outputs.first.IsOK()) {
+      LOGF_DEFAULT(ERROR, "GetOutputs failed, TestCaseName:%s, ErrorMessage:%s",
+                   test_case->GetTestCaseName().c_str(),
+                   status.ErrorMessage().c_str());
+      return false;
+    }
 
-  std::vector<MLValue> output_mlvalues(outputs.second->size());
-  for (size_t i_output = 0; i_output < outputs.second->size(); ++i_output) {
-    auto output = outputs.second->at(i_output);
-    if (!output) continue;
-    io_binding_->BindOutput(output->Name(), output_mlvalues[i_output]);
+    std::vector<MLValue> output_mlvalues(outputs.second->size());
+    for (size_t i_output = 0; i_output < outputs.second->size(); ++i_output) {
+      auto output = outputs.second->at(i_output);
+      if (!output) continue;
+      io_bindings_[i]->BindOutput(output->Name(), output_mlvalues[i_output]);
+    }
   }
 
   return true;

--- a/onnxruntime/test/perftest/test_configuration.h
+++ b/onnxruntime/test/perftest/test_configuration.h
@@ -38,6 +38,7 @@ struct RunConfig {
   TestMode test_mode{TestMode::kFixDurationMode};
   size_t repeated_times{1000};
   size_t duration_in_seconds{600};
+  size_t concurrent_run{0};
   bool f_dump_statistics{false};
   bool f_verbose{false};
   bool enable_sequential_execution{true};


### PR DESCRIPTION
Add concurrent run support for perf_test
It is useful to help study concurrent run.

Use -c to enable and setup concurrent run.
It also needs to set OMP_NUM_THREADS