### PR TITLE
Remove store_true for --trt_path

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -120,7 +120,7 @@ Use the individual flags to only run the specified stages.
     parser.add_argument("--brain_slice_client_package_name", help="Name of brainslice client package")
     parser.add_argument("--use_nuphar", action='store_true', help="Build with nuphar")
     parser.add_argument("--use_trt", action='store_true', help="Build with trt")
-    parser.add_argument("--trt_path", action='store_true', help="Path to trt dir")
+    parser.add_argument("--trt_path", help="Path to trt dir")
     return parser.parse_args()
 
 def resolve_executable_path(command_or_path):


### PR DESCRIPTION
This PR fixes a wrong argument declaration in build.py for TensorRT build. `--trt_path` should be a string-valued argument instead of a boolean value.