### PR TITLE
Add the ability to use a custom allocator for fetches to avoid unnecessary copies in control flow operators.

### DIFF
--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -11,17 +11,21 @@
 #include "core/framework/session_state.h"
 #include "core/framework/utils.h"
 
-using namespace ::onnxruntime::common;
+using namespace onnxruntime::common;
+
 namespace onnxruntime {
 
 ExecutionFrame::ExecutionFrame(const std::unordered_map<std::string, MLValue>& feeds,
                                const std::vector<std::string>& output_names,
                                const std::vector<MLValue>& fetches,
-                               const ::onnxruntime::SessionState& session_state)
-    : session_state_(session_state), mem_patterns_(nullptr), planner_(nullptr) {
+                               const std::unordered_map<size_t, IExecutor::CustomAllocator>& fetch_allocators,
+                               const SessionState& session_state)
+    : session_state_(session_state),
+      mem_patterns_(nullptr),
+      planner_(nullptr) {
   auto* graph = session_state.GetGraphViewer();
   ORT_ENFORCE(graph);
-  Init(*graph, feeds, output_names, fetches);
+  Init(*graph, feeds, output_names, fetches, fetch_allocators);
 
   // If the session enable memory pattern optimization
   // and we have execution plan generated, try to setup
@@ -96,7 +100,7 @@ Status ExecutionFrame::AllocateMLValueTensorSelfOwnBufferHelper(int mlvalue_inde
   // create fence if needed
   if (create_fence) {
     ORT_ENFORCE(p_mlvalue->Fence() == nullptr);
-    FencePtr f = alloc->CreateFence(&SessionState());
+    FencePtr f = alloc->CreateFence(&GetSessionState());
     // it is OK to have fence been nullptr if the execution provider has no async execution,
     // and allocator::CreateFence returns nullptr
     p_mlvalue->SetFence(f);
@@ -189,7 +193,7 @@ Status ExecutionFrame::AllocateMLValueTensorPreAllocateBuffer(int mlvalue_index_
   // create fence on reused mlvalue if needed
   // TODO: differentiate reuse and alias, by add AllocKind::kAlias?
   if (create_fence && p_mlvalue_reuse->Fence() == nullptr) {
-    FencePtr f = GetAllocator(location)->CreateFence(&SessionState());
+    FencePtr f = GetAllocator(location)->CreateFence(&GetSessionState());
     p_mlvalue_reuse->SetFence(f);
   }
 
@@ -256,6 +260,13 @@ Status ExecutionFrame::AllocateAsPerAllocationPlan(int mlvalue_index,
   if (mlvalue_index < 0 || mlvalue_index >= all_values_.size())
     return Status(ONNXRUNTIME, INVALID_ARGUMENT,
                   "Tried to allocated with invalid mlvalue index: " + std::to_string(mlvalue_index));
+
+  // if there is a custom allocator for this mlvalue_index, call it to do the allocation
+  auto custom_alloc_entry = custom_allocators_.find(mlvalue_index);
+  if (custom_alloc_entry != custom_allocators_.cend()) {
+    return (custom_alloc_entry->second)(parameters.GetTensorShape(), all_values_[mlvalue_index]);
+  }
+
   const SequentialExecutionPlan* p_seq_exec_plan = session_state_.GetExecutionPlan();
   const auto& alloc_plan = p_seq_exec_plan->allocation_plan;
   ORT_ENFORCE(mlvalue_index >= 0 && mlvalue_index < alloc_plan.size());
@@ -282,20 +293,20 @@ Status ExecutionFrame::AllocateAsPerAllocationPlan(int mlvalue_index,
     case AllocKind::kAllocateOutput:
     case AllocKind::kAllocate: {
       ORT_RETURN_IF_ERROR(AllocateMLValueTensorSelfOwnBuffer(mlvalue_index,
-                                                                     ml_data_type,
-                                                                     alloc_info,
-                                                                     parameters.GetTensorShape(),
-                                                                     per_alloc_plan.create_fence_if_async));
+                                                             ml_data_type,
+                                                             alloc_info,
+                                                             parameters.GetTensorShape(),
+                                                             per_alloc_plan.create_fence_if_async));
       break;
     }
     case AllocKind::kReuse: {
       int reuse_mlvalue_index = per_alloc_plan.reused_buffer;
       ORT_RETURN_IF_ERROR(AllocateMLValueTensorPreAllocateBuffer(mlvalue_index,
-                                                                         reuse_mlvalue_index,
-                                                                         ml_data_type,
-                                                                         alloc_info,
-                                                                         parameters.GetTensorShape(),
-                                                                         per_alloc_plan.create_fence_if_async));
+                                                                 reuse_mlvalue_index,
+                                                                 ml_data_type,
+                                                                 alloc_info,
+                                                                 parameters.GetTensorShape(),
+                                                                 per_alloc_plan.create_fence_if_async));
       break;
     }
     default: {
@@ -311,7 +322,8 @@ Status ExecutionFrame::AllocateAsPerAllocationPlan(int mlvalue_index,
 void ExecutionFrame::Init(const onnxruntime::GraphViewer& graph,
                           const std::unordered_map<std::string, MLValue>& feeds,
                           const std::vector<std::string>& output_names,
-                          const std::vector<MLValue>& fetches) {
+                          const std::vector<MLValue>& fetches,
+                          const std::unordered_map<size_t, IExecutor::CustomAllocator>& fetch_allocators) {
   // 1. resize the node_offsets and all_value_ vector
   // We need to use the max index rather than number of nodes as we use Node.Index()
   // when inserting into node_offsets_
@@ -341,8 +353,8 @@ void ExecutionFrame::Init(const onnxruntime::GraphViewer& graph,
   if (!fetches.empty()) {
     // should've already verified this much before when Run() starts
     ORT_ENFORCE(output_names.size() == fetches.size(),
-                        "output_names vector size: " + std::to_string(output_names.size()) +
-                            " does not match that of fetches vector: " + std::to_string(fetches.size()));
+                "output_names vector size: " + std::to_string(output_names.size()) +
+                    " does not match that of fetches vector: " + std::to_string(fetches.size()));
 
     // setup output_indices_, we dont' want to generate mem plan on output tensors.
     output_indices_.reserve(output_names.size());
@@ -351,15 +363,21 @@ void ExecutionFrame::Init(const onnxruntime::GraphViewer& graph,
       int mlvalue_idx;
       Status status = mlvalue_idx_map.GetIdx(oname, mlvalue_idx);
       ORT_ENFORCE(status.IsOK(), status.ErrorMessage());
-      all_values_[mlvalue_idx] = fetches.at(idx++);
+      all_values_[mlvalue_idx] = fetches.at(idx);
       output_indices_.push_back(mlvalue_idx);
+
+      auto custom_alloc_entry = fetch_allocators.find(idx);
+      if (custom_alloc_entry != fetch_allocators.cend()) {
+        custom_allocators_[mlvalue_idx] = custom_alloc_entry->second;
+      }
+
+      ++idx;
     }
   }
 
   // 5. set node args
   std::size_t total_def_count{};
-  for (const auto& node : graph.Nodes())
-  {
+  for (const auto& node : graph.Nodes()) {
     node.ForEachDef([&](const onnxruntime::NodeArg& /*arg*/, bool /*is_input*/) {
       ++total_def_count;
     });
@@ -455,8 +473,8 @@ static inline void VerifyShape(const MLValue* p_mlvalue,
     const Tensor* tensor = &p_mlvalue->Get<Tensor>();
 
     ORT_ENFORCE(tensor->Shape() == parameters.GetTensorShape(),
-                        "MLValue shape verification failed. Current shape:", tensor->Shape(),
-                        " Requested shape:", parameters.GetTensorShape());
+                "MLValue shape verification failed. Current shape:", tensor->Shape(),
+                " Requested shape:", parameters.GetTensorShape());
   }
 }
 
@@ -484,10 +502,11 @@ Status ExecutionFrame::GetOrCreateNodeOutputMLValue(int index,
     VerifyShape(p_mlvalue, parameters);  // TODO find a better way to do this
     return Status::OK();
   }
-    // It's not allocated, then allocate it with given shape and return.
-    // Perform allocation based on the allocation plan
-    ORT_RETURN_IF_ERROR(AllocateAsPerAllocationPlan(node_values_[index], parameters));
-    return Status::OK();
+
+  // It's not allocated, then allocate it with given shape and return.
+  // Perform allocation based on the allocation plan
+  ORT_RETURN_IF_ERROR(AllocateAsPerAllocationPlan(node_values_[index], parameters));
+  return Status::OK();
 }
 
 Status ExecutionFrame::ReleaseMLValue(int mlvalue_idx) {

--- a/onnxruntime/core/framework/execution_frame.h
+++ b/onnxruntime/core/framework/execution_frame.h
@@ -8,6 +8,7 @@
 #include "core/common/common.h"
 #include "core/common/logging/logging.h"
 #include "core/common/status.h"
+#include "core/framework/iexecutor.h"
 #include "core/framework/ml_value.h"
 #include "core/framework/sequential_execution_plan.h"
 #include "core/framework/tensor.h"
@@ -41,6 +42,8 @@ class ExecutionFrame {
   ExecutionFrame(const std::unordered_map<std::string, MLValue>& feeds,
                  const std::vector<std::string>& output_names,
                  const std::vector<MLValue>& fetches,
+                 // optional custom allocators. key is index in fetches
+                 const std::unordered_map<size_t, IExecutor::CustomAllocator>& fetch_allocators,
                  const SessionState& session_state);
 
   ~ExecutionFrame();
@@ -112,7 +115,7 @@ class ExecutionFrame {
 
   Status ReleaseMLValue(int mlvalue_idx);
 
-  const ::onnxruntime::SessionState& SessionState() const {
+  const SessionState& GetSessionState() const {
     return session_state_;
   }
 
@@ -140,7 +143,8 @@ class ExecutionFrame {
   void Init(const onnxruntime::GraphViewer& graph,
             const std::unordered_map<std::string, MLValue>& feeds,
             const std::vector<std::string>& output_names,
-            const std::vector<MLValue>& fetches);
+            const std::vector<MLValue>& fetches,
+            const std::unordered_map<size_t, IExecutor::CustomAllocator>& fetch_allocators);
 
   void SetupNodeArg(const onnxruntime::NodeArg* arg);
 
@@ -174,7 +178,10 @@ class ExecutionFrame {
 
   std::unordered_map<std::string, int> value_name_to_index_;
 
-  const ::onnxruntime::SessionState& session_state_;
+  // map of index to custom allocator
+  std::unordered_map<int, IExecutor::CustomAllocator> custom_allocators_;
+
+  const SessionState& session_state_;
 
   // If we already have cached memory pattern on these input shapes
   // Use this mem pattern that create a big chunk for all the internal

--- a/onnxruntime/core/framework/iexecutor.h
+++ b/onnxruntime/core/framework/iexecutor.h
@@ -12,19 +12,34 @@
 
 namespace onnxruntime {
 
+class MLValue;
 class SessionState;
+class Status;
+class TensorShape;
 namespace logging {
 class Logger;
 }
 
 class IExecutor {
  public:
+  using CustomAllocator = std::function<Status(const TensorShape&, MLValue&)>;
+
   virtual ~IExecutor() = default;
+
+  common::Status Execute(const SessionState& session_state,
+                         const NameMLValMap& feeds,
+                         const std::vector<std::string>& output_names,
+                         std::vector<MLValue>& fetches,
+                         const logging::Logger& logger) {
+    return Execute(session_state, feeds, output_names, fetches, {}, logger);
+  }
 
   virtual common::Status Execute(const SessionState& session_state,
                                  const NameMLValMap& feeds,
                                  const std::vector<std::string>& output_names,
                                  std::vector<MLValue>& fetches,
+                                 // optional custom allocators. key is index in fetches
+                                 const std::unordered_map<size_t, CustomAllocator> fetch_allocators,
                                  const logging::Logger& logger) = 0;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/iexecutor.h
+++ b/onnxruntime/core/framework/iexecutor.h
@@ -14,7 +14,6 @@ namespace onnxruntime {
 
 class MLValue;
 class SessionState;
-class Status;
 class TensorShape;
 namespace logging {
 class Logger;

--- a/onnxruntime/core/framework/op_kernel.cc
+++ b/onnxruntime/core/framework/op_kernel.cc
@@ -119,7 +119,7 @@ onnxruntime::NodeIndex OpKernelContext::GetNodeIndex() const {
 }
 
 const SessionState& OpKernelContext::GetSessionState() const {
-  return execution_frame_->SessionState();
+  return execution_frame_->GetSessionState();
 }
 
 const MLValue* OpKernelContext::GetInputMLValue(int index) const {

--- a/onnxruntime/core/framework/parallel_executor.h
+++ b/onnxruntime/core/framework/parallel_executor.h
@@ -28,6 +28,7 @@ class ParallelExecutor : public IExecutor {
                          const NameMLValMap& feeds,
                          const std::vector<std::string>& output_names,
                          std::vector<MLValue>& fetches,
+                         const std::unordered_map<size_t, CustomAllocator> fetch_allocators,
                          const logging::Logger& logger) override;
 
  private:

--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -30,6 +30,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state,
                                    const NameMLValMap& feeds,
                                    const std::vector<std::string>& output_names,
                                    std::vector<MLValue>& fetches,
+                                   const std::unordered_map<size_t, CustomAllocator> fetch_allocators,
                                    const logging::Logger& logger) {
   bool f_profiler_enabled = session_state.Profiler().FEnabled();
   TimePoint tp;
@@ -40,7 +41,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state,
     tp = session_state.Profiler().StartTime();
   }
 
-  ExecutionFrame frame{feeds, output_names, fetches, session_state};
+  ExecutionFrame frame{feeds, output_names, fetches, fetch_allocators, session_state};
 
   LOGS(logger, INFO) << "Begin execution";
   const SequentialExecutionPlan& seq_exec_plan = *session_state.GetExecutionPlan();

--- a/onnxruntime/core/framework/sequential_executor.h
+++ b/onnxruntime/core/framework/sequential_executor.h
@@ -22,6 +22,7 @@ class SequentialExecutor : public IExecutor {
                          const NameMLValMap& feeds,
                          const std::vector<std::string>& output_names,
                          std::vector<MLValue>& fetches,
+                         const std::unordered_map<size_t, CustomAllocator> fetch_allocators,
                          const logging::Logger& logger) override;
 
  private:

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -365,6 +365,7 @@ common::Status ExecuteGraph(const SessionState& session_state,
                             const NameMLValMap& feeds,
                             const std::vector<std::string>& output_names,
                             std::vector<MLValue>& fetches,
+                            const std::unordered_map<size_t, IExecutor::CustomAllocator>& fetch_allocators,
                             bool sequential_execution,
                             const bool& terminate_flag,
                             const logging::Logger& logger) {
@@ -386,7 +387,7 @@ common::Status ExecuteGraph(const SessionState& session_state,
     p_exec = std::unique_ptr<IExecutor>(new ParallelExecutor(session_state, terminate_flag));
   }
 
-  ORT_RETURN_IF_ERROR(p_exec->Execute(session_state, device_feeds, output_names, device_fetches, logger));
+  ORT_RETURN_IF_ERROR(p_exec->Execute(session_state, device_feeds, output_names, device_fetches, fetch_allocators, logger));
   ORT_RETURN_IF_ERROR(utils::CopyOutputsAcrossDevices(session_state, device_fetches, fetches));
 
   return Status::OK();

--- a/onnxruntime/core/framework/utils.h
+++ b/onnxruntime/core/framework/utils.h
@@ -7,6 +7,7 @@
 #include "core/framework/allocator.h"
 #include "core/framework/data_types.h"
 #include "core/framework/framework_common.h"
+#include "core/framework/iexecutor.h"
 #include "core/framework/session_state.h"
 
 namespace onnxruntime {
@@ -60,6 +61,7 @@ common::Status ExecuteGraph(const SessionState& session_state,
                             const NameMLValMap& feeds,
                             const std::vector<std::string>& output_names,
                             std::vector<MLValue>& fetches,
+                            const std::unordered_map<size_t, IExecutor::CustomAllocator>& fetch_allocators,
                             bool sequential_execution,
                             const bool& terminate_flag,
                             const logging::Logger& logger);

--- a/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
@@ -122,6 +122,7 @@ Status IterateSequence(OpKernelContextInternal& context,
 
   NameMLValMap feeds;
   std::vector<MLValue> fetches;
+  std::unordered_map<size_t, IExecutor::CustomAllocator> fetch_allocators;
   feeds.reserve(num_variadic_inputs + implicit_inputs.size());
   fetches.resize(num_variadic_outputs);
 
@@ -151,39 +152,34 @@ Status IterateSequence(OpKernelContextInternal& context,
 
     fetches.clear();
 
-    // one or more outputs have symbolic dimensions and need the first fetch to be copied to the OutputIterator
-    bool have_symbolic_dim_in_output = false;
-
     for (int output = 0, end = num_variadic_outputs; output < end; ++output) {
       if (output < num_loop_state_variables) {
         // add loop state variable output
         fetches.push_back(loop_state_variables[output].Output());
       } else {
-        // add MLValue from sliced output
         auto& iterator = *output_iterators[output];
-        auto& mlvalue = *iterator;
-        fetches.push_back(mlvalue);
 
-        // mlvalue.IsAllocated will be false when the OutputIterator is using a temporary MLValue
-        // and not the overall output buffer.
-        have_symbolic_dim_in_output = seq_no == 0 &&
-                                      (mlvalue.IsAllocated() == false ||
-                                       have_symbolic_dim_in_output);  // don't unset
+        if (iterator.FinalOutputAllocated()) {
+          // add MLValue from sliced output
+          auto& mlvalue = *iterator;
+          fetches.push_back(mlvalue);
+        } else {
+          // use a custom allocator that will forward the allocation request to the Scan context
+          // and add the sequence length dimension. this avoids using a temporary value for the first output
+          fetch_allocators[output] =
+              [&context, output, &iterator](const TensorShape& shape, MLValue& mlvalue) {
+                return iterator.AllocateSubgraphOutput(shape, mlvalue);
+              };
+
+          // also need a dummy empty entry in fetches so the order matches the output names
+          fetches.push_back({});
+        }
       }
     }
 
     // Create Executor and run graph.
-    // TODO: Consider pulling ExecutionFrame up from within SequentialExecutor
-    // and separating it out a bit so we can maybe just update the feeds/fetches in the frame on each iteration.
-    // Many of the other pieces are constant across usages.
-    // Not sure how best to handle the memory pattern side of things though.
-    // For now just making it work. Optimization and refinement will follow.
-    //SequentialExecutor executor{context.GetTerminateFlag()};
-    //status = executor.Execute(session_state, feeds, subgraph_output_names, fetches, context.Logger());
-    //ORT_RETURN_IF_ERROR(status);
-
-    status = utils::ExecuteGraph(session_state, feeds, subgraph_output_names, fetches, /*sequential_execution*/ true,
-                                 context.GetTerminateFlag(), context.Logger());
+    status = utils::ExecuteGraph(session_state, feeds, subgraph_output_names, fetches, fetch_allocators,
+                                 /*sequential_execution*/ true, context.GetTerminateFlag(), context.Logger());
     ORT_RETURN_IF_ERROR(status);
 
     // cycle the LoopStateVariable input/output in preparation for the next iteration
@@ -191,15 +187,12 @@ Status IterateSequence(OpKernelContextInternal& context,
 
     // and move the output iterators.
     for (int output = num_loop_state_variables; output < num_variadic_outputs; ++output) {
-      auto& iterator = *output_iterators[output];
+      ++(*output_iterators[output]);
+    }
 
-      // copy data from the fetch to the iterator so it can setup the overall output when the iterator is incremented.
-      // if the iterator is already using the overall output buffer IsAllocated() will be true and no copy is required.
-      if (have_symbolic_dim_in_output && (*iterator).IsAllocated() == false) {
-        *iterator = fetches[output];
-      }
-
-      ++iterator;
+    if (seq_no == 0) {
+      // we only ever use custom allocators on the first iteration as the final output is always allocated during that
+      fetch_allocators.clear();
     }
   }
 
@@ -356,7 +349,7 @@ Status OutputIterator::Initialize() {
     status = AllocateFinalBuffer();
     ORT_RETURN_IF_ERROR(status);
   } else {
-    // use first_output_
+    // delay until the first subgraph execution calls AllocateSubgraphOutput.
   }
 
   return Status::OK();
@@ -364,8 +357,7 @@ Status OutputIterator::Initialize() {
 
 Status OutputIterator::AllocateFinalBuffer() {
   // make sure a single buffer for the full output is created upfront.
-  // we slice this into per-iteration pieces in Execute using MLValueTensorSlicer.
-  // get the output tensor we just created as an MLValue
+  // we slice this into per-iteration pieces using MLValueTensorSlicer.
   if (!temporary_) {
     // we can write directly to the Scan output
     auto* tensor = context_.Output(output_index_, final_shape_);
@@ -374,6 +366,7 @@ Status OutputIterator::AllocateFinalBuffer() {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to create output tensor for output #", output_index_);
     }
 
+    // get the output tensor we just created as an MLValue
     final_output_mlvalue_ = context_.GetOutputMLValue(output_index_);
   } else {
     // we need to do a transpose at the end so need to write to a temporary buffer when executing the subgraph.
@@ -416,67 +409,52 @@ Status OutputIterator::AllocateFinalBuffer() {
   return Status::OK();
 }
 
-Status OutputIterator::MakeConcrete() {
-  ORT_ENFORCE(first_output_.IsAllocated(), "First usage of OutputIterator did not result in any output.");
-  Status status = Status::OK();
+Status OutputIterator::AllocateSubgraphOutput(const TensorShape& shape, MLValue& mlvalue) {
+  ORT_ENFORCE(!is_concrete_shape_, "If shape was concrete we shouldn't be using a custom allocator");
 
-  auto& tensor = first_output_.Get<Tensor>();
-  auto& tensor_shape = tensor.Shape();
-
-  // update the final shape
-  status = MakeShapeConcrete(tensor_shape, final_shape_);
+  // update the final shape now that we can fill in the symbolic dimension with an actual value
+  auto status = MakeShapeConcrete(shape, final_shape_);
   ORT_RETURN_IF_ERROR(status);
 
   is_concrete_shape_ = true;
   status = AllocateFinalBuffer();
   ORT_RETURN_IF_ERROR(status);
 
-  // copy first output to final buffer
-  auto input_span = gsl::make_span<const gsl::byte>(static_cast<const gsl::byte*>(tensor.DataRaw()), tensor.Size());
+  // get MLValue from operator*()
+  mlvalue = **this;
 
-  auto output = (**this).GetMutable<Tensor>();
-  auto output_span = gsl::make_span<gsl::byte>(static_cast<gsl::byte*>(output->MutableDataRaw()), output->Size());
-
-  gsl::copy(input_span, output_span);
-
-  // release the MLValue we used for the first output
-  first_output_ = {};
-
-  return status;
+  return Status::OK();
 }
 
 MLValue& OutputIterator::operator*() {
   ORT_ENFORCE(cur_iteration_ < num_iterations_);
+  ORT_ENFORCE(is_concrete_shape_,
+              "Expected AllocateSubgraphOutput to have been called to before we read the MLValue from the iterator.");
 
-  if (is_concrete_shape_)
-    // for v8 both outputs and loop state vars use slicers. for v9 only outputs do
-    if (is_v8_ || !is_loop_state_var_)
-      return **cur_slicer_iterator_;
-    else
-      return *final_output_mlvalue_;
+  // for v8 both outputs and loop state vars use slicers. for v9 only outputs do
+  if (is_v8_ || !is_loop_state_var_)
+    return **cur_slicer_iterator_;
   else
-    return first_output_;
+    return *final_output_mlvalue_;
 }
 
 OutputIterator& OutputIterator::operator++() {
   if (cur_iteration_ < num_iterations_) {
-    if (!is_concrete_shape_) {
-      // we should have an output now, so convert to using the overall output buffer and slicers
-      auto status = MakeConcrete();
-      ORT_ENFORCE(status.IsOK(), status.ErrorMessage());
-    }
+    ORT_ENFORCE(is_concrete_shape_,
+                "Expected AllocateSubgraphOutput to have been called to before we increment the iterator");
 
     ++cur_iteration_;
 
     if (is_v8_) {
-      // if not a loop state var, see if we just finished the current sequence (dim 1)
+      // if not a loop state var, see if we just finished the current sequence (dim 1) and need to move to the
+      // next iterator. otherwise increment the current one
       if (!is_loop_state_var_ && cur_iteration_ % final_shape_[1] == 0) {
         ++cur_slicer_iterator_;
       } else {
         ++(*cur_slicer_iterator_);
       }
     } else if (!is_loop_state_var_) {
-      // v9 output uses iterator
+      // v9 output uses iterator (v9 loop state vars do not)
       ++(*cur_slicer_iterator_);
     }
   }

--- a/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
@@ -167,7 +167,7 @@ Status IterateSequence(OpKernelContextInternal& context,
           // use a custom allocator that will forward the allocation request to the Scan context
           // and add the sequence length dimension. this avoids using a temporary value for the first output
           fetch_allocators[output] =
-              [&context, output, &iterator](const TensorShape& shape, MLValue& mlvalue) {
+              [&iterator](const TensorShape& shape, MLValue& mlvalue) {
                 return iterator.AllocateSubgraphOutput(shape, mlvalue);
               };
 

--- a/onnxruntime/core/providers/cpu/controlflow/scan_utils.h
+++ b/onnxruntime/core/providers/cpu/controlflow/scan_utils.h
@@ -89,6 +89,14 @@ class OutputIterator {
   MLValue& operator*();
   OutputIterator& operator++();
 
+  bool FinalOutputAllocated() const { return is_concrete_shape_; }
+
+  // custom fetch allocator that can be used when the final shape is not concrete.
+  // when the subgraph requests the allocation of the subgraph output, we forward the request to this instance,
+  // allocate the overall output (taking into account the sequence length dimension),
+  // and use a slicer to return the chunk for the subgraph output for this iteration.
+  Status AllocateSubgraphOutput(const TensorShape& shape, MLValue& mlvalue);
+
   // set the output for the current iteration to zeros. used for short sequence lengths
   void ZeroOutCurrent() {
     auto* tensor = (**this).GetMutable<Tensor>();
@@ -112,7 +120,6 @@ class OutputIterator {
 
   Status Initialize();
   Status AllocateFinalBuffer();
-  Status MakeConcrete();
 
   OpKernelContextInternal& context_;
   bool is_v8_;
@@ -130,10 +137,6 @@ class OutputIterator {
   // one or more slicers for writing to the output
   std::vector<MLValueTensorSlicer<MLValue>::Iterator> slicer_iterators_;
   std::vector<MLValueTensorSlicer<MLValue>::Iterator>::iterator cur_slicer_iterator_;
-
-  // if shape is not concrete we need the first output to know the missing dimension before
-  // we can allocate final_output_mlvalue_ and use the slicers.
-  MLValue first_output_;
 
   // if true allocate temporary_final_output_mlvalue_ with data_type_ using the temporary allocator
   // and point final_output_value_ at that.

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -638,7 +638,7 @@ class InferenceSession::Impl {
       }
 
       ORT_CHECK_AND_SET_RETVAL(
-          utils::ExecuteGraph(session_state_, feeds, output_names, *p_fetches,
+          utils::ExecuteGraph(session_state_, feeds, output_names, *p_fetches, {},
                               session_options_.enable_sequential_execution, run_options.terminate, run_logger));
     } catch (const std::exception& e) {
       retval = Status(common::ONNXRUNTIME, common::FAIL, e.what());

--- a/onnxruntime/test/framework/execution_frame_test.cc
+++ b/onnxruntime/test/framework/execution_frame_test.cc
@@ -71,10 +71,7 @@ TEST(ExecutionFrameTest, TensorAllocationTest) {
   state.SetExecutionPlan(std::move(p_seq_exec_plan));
 
   vector<MLValue> outputs;
-  ExecutionFrame frame(std::unordered_map<std::string, MLValue>{},
-                       std::vector<std::string>{},
-                       outputs,
-                       state);
+  ExecutionFrame frame(std::unordered_map<std::string, MLValue>{}, std::vector<std::string>{}, outputs, {}, state);
 
   int start_index = frame.GetFirstArgIndex(node->Index());
   EXPECT_EQ(start_index, 0);
@@ -149,9 +146,7 @@ TEST(ExecutionFrameTest, FeedInDataTest) {
 
   vector<MLValue> outputs;
   ExecutionFrame frame(std::unordered_map<std::string, MLValue>{{"X", value}},
-                       std::vector<std::string>{},
-                       outputs,
-                       state);
+                       std::vector<std::string>{}, outputs, {}, state);
 
   MLValue* p_ml_value = frame.GetMutableNodeInputOrOutputMLValue(0);
   Tensor* p_tensor_arg_0 = p_ml_value ? p_ml_value->GetMutable<Tensor>() : nullptr;
@@ -228,9 +223,7 @@ TEST(ExecutionFrameTest, MemPatternTest) {
 
   vector<MLValue> outputs;
   ExecutionFrame frame(std::unordered_map<std::string, MLValue>{{"X1", v1}, {"X2", v2}, {"X3", v3}},
-                       std::vector<std::string>{"T3"},
-                       outputs,
-                       state);
+                       std::vector<std::string>{"T3"}, outputs, {}, state);
 
   status = frame.AllocateMLValueTensorSelfOwnBuffer(3,
                                                     DataTypeImpl::GetType<float>(),


### PR DESCRIPTION
Allows control flow nodes to forward the allocation to the control flow op and avoid an unnecessary copy when the subgraph output has a symbolic dimension.

Update Scan and If to use custom allocators when applicable.