### PR TITLE
Fix the issue in CreateConstantOnes which cause the float 16 model test failure

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -11,6 +11,7 @@
 #include "shared_inc/fast_divmod.h"
 #include "core/util/math.h"
 #include "cuda_fwd.h"
+#include "cuda_type_common.h"
 
 namespace onnxruntime {
 namespace cuda {
@@ -138,26 +139,6 @@ class CudaKernel : public OpKernel {
 
  private:
   CUDAExecutionProvider* provider_;
-};
-
-// Type mapping for MLFloat16 to half
-template <typename T>
-class ToCudaType {
- public:
-  typedef T MappedType;
-  static MappedType FromFloat(float f) {
-    return static_cast<T>(f);
-  }
-};
-
-template <>
-class ToCudaType<MLFloat16> {
- public:
-  typedef half MappedType;
-  static MappedType FromFloat(float f) {
-    uint16_t h = math::floatToHalf(f);
-    return *reinterpret_cast<MappedType*>(&h);
-  }
 };
 
 inline bool CalculateFdmStrides(gsl::span<fast_divmod> p, const std::vector<int64_t>& dims) {

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.h
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.h
@@ -9,6 +9,7 @@
 #include "core/framework/execution_provider.h"
 #include "shared_inc/cuda_utils.h"
 #include <deque>
+#include "core/providers/cuda/cuda_type_common.h"
 
 namespace onnxruntime {
 
@@ -126,17 +127,20 @@ class CUDAExecutionProvider : public IExecutionProvider {
     const T* GetConstOnes(size_t count) {
       if (std::is_same<T, float>::value) {
         if (!constant_ones_float_) {
-          constant_ones_float_ = cuda::CreateConstantOnes<float>();
+          auto one = cuda::ToCudaType<float>::FromFloat(1.0f);
+          constant_ones_float_ = cuda::CreateConstantOnes<float>(one);
         }
         return reinterpret_cast<const T*>(constant_ones_float_->GetBuffer(count));
       } else if (std::is_same<T, double>::value) {
         if (!constant_ones_double_) {
-          constant_ones_double_ = cuda::CreateConstantOnes<double>();
+          auto one = cuda::ToCudaType<double>::FromFloat(1.0f);
+          constant_ones_double_ = cuda::CreateConstantOnes<double>(one);
         }
         return reinterpret_cast<const T*>(constant_ones_double_->GetBuffer(count));
       } else if (std::is_same<T, half>::value) {
         if (!constant_ones_half_) {
-          constant_ones_half_ = cuda::CreateConstantOnes<half>();
+          auto one = cuda::ToCudaType<MLFloat16>::FromFloat(1.0f);
+          constant_ones_half_ = cuda::CreateConstantOnes<half>(one);
         }
         return reinterpret_cast<const T*>(constant_ones_half_->GetBuffer(count));
       } else {

--- a/onnxruntime/core/providers/cuda/cuda_type_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_type_common.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "cuda_pch.h"
+#include "core/common/status.h"
+#include "shared_inc/cuda_call.h"
+#include "core/util/math.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+// Type mapping for MLFloat16 to half
+template <typename T>
+class ToCudaType {
+ public:
+  typedef T MappedType;
+  static MappedType FromFloat(float f) {
+    return static_cast<T>(f);
+  }
+};
+
+template <>
+class ToCudaType<MLFloat16> {
+ public:
+  typedef half MappedType;
+  static MappedType FromFloat(float f) {
+    uint16_t h = math::floatToHalf(f);
+    return *reinterpret_cast<MappedType*>(&h);
+  }
+};
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/cuda_utils.cu
+++ b/onnxruntime/core/providers/cuda/cuda_utils.cu
@@ -30,13 +30,13 @@ class ConstantBufferImpl : public IConstantBuffer<T> {
 };
 
 template <typename T>
-std::unique_ptr<IConstantBuffer<T>> CreateConstantOnes() {
-  return std::make_unique<ConstantBufferImpl<T>>((T)1);
+std::unique_ptr<IConstantBuffer<T>> CreateConstantOnes(T value) {
+  return std::make_unique<ConstantBufferImpl<T>>(value);
 }
 
-template std::unique_ptr<IConstantBuffer<float>> CreateConstantOnes<float>();
-template std::unique_ptr<IConstantBuffer<double>> CreateConstantOnes<double>();
-template std::unique_ptr<IConstantBuffer<half>> CreateConstantOnes<half>();
+template std::unique_ptr<IConstantBuffer<float>> CreateConstantOnes<float>(float value);
+template std::unique_ptr<IConstantBuffer<double>> CreateConstantOnes<double>(double value);
+template std::unique_ptr<IConstantBuffer<half>> CreateConstantOnes<half>(half value);
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/cuda/math/binary_elementwise_ops.cc
@@ -106,7 +106,7 @@ Status BinaryElementwise<ShouldBroadcast>::Prepare(OpKernelContext* context, int
   Status x<T>::ComputeInternal(OpKernelContext* context) const {                                                 \
     BinaryElementwisePreparation prepare(this);                                                                  \
     Prepare(context, 0, &prepare);                                                                               \
-    ORT_RETURN_IF_ERROR(prepare.CopyToGpu());                                                            \
+    ORT_RETURN_IF_ERROR(prepare.CopyToGpu());                                                                    \
     Impl_##x<typename ToCudaType<T>::MappedType>(                                                                \
         prepare.output_rank_or_simple_broadcast,                                                                 \
         prepare.lhs_padded_strides.GpuPtr(),                                                                     \

--- a/onnxruntime/core/providers/cuda/shared_inc/cuda_utils.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/cuda_utils.h
@@ -28,7 +28,7 @@ class IConstantBuffer {
 };
 
 template <typename T>
-std::unique_ptr<IConstantBuffer<T>> CreateConstantOnes();
+std::unique_ptr<IConstantBuffer<T>> CreateConstantOnes(T value);
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -351,7 +351,6 @@ int real_main(int argc, char* argv[]) {
 
   broken_tests["fp16_tiny_yolov2"] = "unknown failure on CUDA";
   broken_tests["fp16_shufflenet"] = "unknown failure on CUDA";
-  broken_tests["fp16_inception_v1"] = "unknown failure on CUDA";
 #endif
 
   int result = 0;


### PR DESCRIPTION
Fix the issue in CreateConstantOnes which cause the float 16 model test failure. The CreateConstantOnes doesn't create the data with correct data type for float 16. For float 16, should use cuda::ToCudaType<MLFloat16>::FromFloat(1.0f) to create the data.