### PR TITLE
Rename OrtInitialize to OrtCreateEnv in preparation for future.

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML.OnnxRuntime
 
         #region Runtime/Environment API
         [DllImport(nativeLib, CharSet = charSet)]
-        public static extern IntPtr /* OrtStatus* */OrtInitialize(
+        public static extern IntPtr /* OrtStatus* */OrtCreateEnv(
                                                          LogLevel default_warning_level,
                                                          string logId,
                                                          out IntPtr /*(OrtEnv*)*/ env);

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ML.OnnxRuntime
             handle = IntPtr.Zero;
             try
             {
-                NativeApiStatus.VerifySuccess(NativeMethods.OrtInitialize(LogLevel.Warning, @"CSharpOnnxRuntime", out handle));
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtCreateEnv(LogLevel.Warning, @"CSharpOnnxRuntime", out handle));
             }
             catch (OnnxRuntimeException e)
             {

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -516,7 +516,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 return;
             var entryPointNames = new[]{
-            "OrtInitialize","OrtReleaseEnv","OrtGetErrorCode","OrtGetErrorMessage",
+            "OrtCreateEnv","OrtReleaseEnv","OrtGetErrorCode","OrtGetErrorMessage",
             "OrtReleaseStatus","OrtCreateSession","OrtRun","OrtSessionGetInputCount",
             "OrtSessionGetOutputCount","OrtSessionGetInputName","OrtSessionGetOutputName","OrtSessionGetInputTypeInfo",
             "OrtSessionGetOutputTypeInfo","OrtReleaseSession","OrtCreateSessionOptions","OrtCloneSessionOptions",

--- a/docs/C_API.md
+++ b/docs/C_API.md
@@ -1,7 +1,5 @@
 # C API
 
-**NOTE: The C API is PRE-RELEASE and subject to change.**
-
 ## Features
 
 * Creating an InferenceSession from an on-disk model file and a set of SessionOptions.
@@ -13,14 +11,13 @@
 * Setting the thread pool size for each session.
 * Dynamically loading custom ops.
 
-## How to use it
+## Very simplified outline of how to use it
 
 1. Include [onnxruntime_c_api.h](/include/onnxruntime/core/session/onnxruntime_c_api.h).
-2. Call ONNXRuntimeInitialize
-3. Create Session: ONNXRuntimeCreateInferenceSession(env, model_uri, nullptr,...)
+2. Call OrtCreateEnv
+3. Create Session: OrtCreateSession(env, model_uri, nullptr,...)
 4. Create Tensor
-   1) ONNXRuntimeCreateAllocatorInfo
-   2) ONNXRuntimeCreateTensorWithDataAsONNXValue
-5. ONNXRuntimeRunInference
-
+   1) OrtCreateAllocatorInfo
+   2) OrtCreateTensorWithDataAsONNXValue
+5. OrtRun
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// =====================================================================================================
-// NOTE: This header is PRE-RELEASE and subject to change. Please do not rely on this file not changing.
-// =====================================================================================================
-
 #pragma once
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
 
+// This value is used in structures passed to ORT so that a newer version of ORT will still work with
 #define ORT_API_VERSION 1
 
 #ifdef __cplusplus

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -10,6 +10,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#define ORT_API_VERSION 1
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -147,6 +149,7 @@ ORT_RUNTIME_CLASS(SessionOptions);
 // When passing in an allocator to any ORT function, be sure that the allocator object
 // is not destroyed until the last allocated object using it is freed.
 typedef struct OrtAllocator {
+  uint32_t version;  // Initialize to ORT_API_VERSION
   void*(ORT_API_CALL* Alloc)(struct OrtAllocator* this_, size_t size);
   void(ORT_API_CALL* Free)(struct OrtAllocator* this_, void* p);
   const struct OrtAllocatorInfo*(ORT_API_CALL* Info)(const struct OrtAllocator* this_);
@@ -157,17 +160,15 @@ typedef void(ORT_API_CALL* OrtLoggingFunction)(
     const char* message);
 
 /**
- * OrtEnv is process-wide. For each process, only one OrtEnv can be created.
  * \param out Should be freed by `OrtReleaseEnv` after use
  */
-ORT_API_STATUS(OrtInitialize, OrtLoggingLevel default_warning_level, _In_ const char* logid, _Out_ OrtEnv** out)
+ORT_API_STATUS(OrtCreateEnv, OrtLoggingLevel default_warning_level, _In_ const char* logid, _Out_ OrtEnv** out)
 ORT_ALL_ARGS_NONNULL;
 
 /**
- * OrtEnv is process-wise. For each process, only one OrtEnv can be created. Don't do it multiple times
  * \param out Should be freed by `OrtReleaseEnv` after use
  */
-ORT_API_STATUS(OrtInitializeWithCustomLogger, OrtLoggingFunction logging_function,
+ORT_API_STATUS(OrtCreateEnvWithCustomLogger, OrtLoggingFunction logging_function,
                _In_opt_ void* logger_param, OrtLoggingLevel default_warning_level,
                _In_ const char* logid,
                _Out_ OrtEnv** out);

--- a/onnxruntime/core/providers/cpu/symbols.txt
+++ b/onnxruntime/core/providers/cpu/symbols.txt
@@ -12,6 +12,8 @@ OrtCompareAllocatorInfo
 OrtCreateAllocatorInfo
 OrtCreateCpuAllocatorInfo
 OrtCreateDefaultAllocator
+OrtCreateEnv
+OrtCreateEnvWithCustomLogger
 OrtCreateRunOptions
 OrtCreateSession
 OrtCreateSessionOptions
@@ -39,8 +41,6 @@ OrtGetTensorShapeAndType
 OrtGetTensorShapeElementCount
 OrtGetTypeInfo
 OrtGetValueType
-OrtInitialize
-OrtInitializeWithCustomLogger
 OrtIsTensor
 OrtReleaseAllocator
 OrtReleaseAllocatorInfo

--- a/onnxruntime/core/session/default_cpu_allocator_c_api.cc
+++ b/onnxruntime/core/session/default_cpu_allocator_c_api.cc
@@ -13,6 +13,7 @@ struct OrtAllocatorImpl : OrtAllocator {
 
 struct OrtDefaultAllocator : OrtAllocatorImpl {
   OrtDefaultAllocator() {
+    OrtAllocator::version = ORT_API_VERSION;
     OrtAllocator::Alloc = [](OrtAllocator* this_, size_t size) { return static_cast<OrtDefaultAllocator*>(this_)->Alloc(size); };
     OrtAllocator::Free = [](OrtAllocator* this_, void* p) { static_cast<OrtDefaultAllocator*>(this_)->Free(p); };
     OrtAllocator::Info = [](const OrtAllocator* this_) { return static_cast<const OrtDefaultAllocator*>(this_)->Info(); };

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/graph/onnx_protobuf.h"  //TODO: remove this
 #include "core/session/onnxruntime_c_api.h"
 #include "core/session/allocator_impl.h"
 #include "core/framework/error_code_helper.h"

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -96,7 +96,7 @@ class LoggingWrapper : public ISink {
   void* logger_param_;
 };
 
-ORT_API_STATUS_IMPL(OrtInitializeWithCustomLogger, OrtLoggingFunction logging_function,
+ORT_API_STATUS_IMPL(OrtCreateEnvWithCustomLogger, OrtLoggingFunction logging_function,
                     _In_opt_ void* logger_param, OrtLoggingLevel default_warning_level, _In_ const char* logid,
                     _Out_ OrtEnv** out) {
   API_IMPL_BEGIN
@@ -114,7 +114,7 @@ ORT_API_STATUS_IMPL(OrtInitializeWithCustomLogger, OrtLoggingFunction logging_fu
   API_IMPL_END
 }
 
-ORT_API_STATUS_IMPL(OrtInitialize, OrtLoggingLevel default_warning_level,
+ORT_API_STATUS_IMPL(OrtCreateEnv, OrtLoggingLevel default_warning_level,
                     _In_ const char* logid, _Out_ OrtEnv** out) {
   API_IMPL_BEGIN
   std::string name = logid;

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -165,7 +165,7 @@ int real_main(int argc, char* argv[]) {
   std::unique_ptr<OrtEnv> env;
   {
     OrtEnv* t;
-    OrtStatus* ost = OrtInitialize(logging_level, "Default", &t);
+    OrtStatus* ost = OrtCreateEnv(logging_level, "Default", &t);
     if (ost != nullptr) {
       fprintf(stderr, "Error creating environment: %s \n", OrtGetErrorMessage(ost));
       OrtReleaseStatus(ost);

--- a/onnxruntime/test/shared_lib/fns_candy_style_transfer.c
+++ b/onnxruntime/test/shared_lib/fns_candy_style_transfer.c
@@ -195,7 +195,7 @@ int main(int argc, char* argv[]) {
   char* input_file = argv[2];
   char* output_file = argv[3];
   OrtEnv* env;
-  ORT_ABORT_ON_ERROR(OrtInitialize(ORT_LOGGING_LEVEL_WARNING, "test", &env));
+  ORT_ABORT_ON_ERROR(OrtCreateEnv(ORT_LOGGING_LEVEL_WARNING, "test", &env));
   OrtSessionOptions* session_option = OrtCreateSessionOptions();
 #ifdef USE_CUDA
   enable_cuda(session_option);

--- a/onnxruntime/test/shared_lib/test_fixture.h
+++ b/onnxruntime/test/shared_lib/test_fixture.h
@@ -22,9 +22,9 @@ class CApiTestImpl : public ::testing::Test {
 
   void SetUp() override {
     if (use_customer_logger) {
-      ORT_THROW_ON_ERROR(OrtInitializeWithCustomLogger(MyLoggingFunction, nullptr, ORT_LOGGING_LEVEL_INFO, "Default", &env));
+      ORT_THROW_ON_ERROR(OrtCreateEnvWithCustomLogger(MyLoggingFunction, nullptr, ORT_LOGGING_LEVEL_INFO, "Default", &env));
     } else {
-      ORT_THROW_ON_ERROR(OrtInitialize(ORT_LOGGING_LEVEL_INFO, "Default", &env));
+      ORT_THROW_ON_ERROR(OrtCreateEnv(ORT_LOGGING_LEVEL_INFO, "Default", &env));
     }
   }
 

--- a/onnxruntime/test/util/test_allocator.cc
+++ b/onnxruntime/test/util/test_allocator.cc
@@ -4,6 +4,7 @@
 #include "test_allocator.h"
 
 MockedOrtAllocator::MockedOrtAllocator() {
+  OrtAllocator::version = ORT_API_VERSION;
   OrtAllocator::Alloc = [](OrtAllocator* this_, size_t size) { return static_cast<MockedOrtAllocator*>(this_)->Alloc(size); };
   OrtAllocator::Free = [](OrtAllocator* this_, void* p) { static_cast<MockedOrtAllocator*>(this_)->Free(p); };
   OrtAllocator::Info = [](const OrtAllocator* this_) { return static_cast<const MockedOrtAllocator*>(this_)->Info(); };


### PR DESCRIPTION
Add version number to structures