### PR TITLE
Update transpose logic for Scan 9 outputs so it's the inverse of the input transpose logic.

### DIFF
--- a/onnxruntime/core/providers/cpu/controlflow/scan_9.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/scan_9.cc
@@ -343,7 +343,7 @@ Status ScanImpl::SetupInputs() {
 
       std::vector<int64_t> permutations;
       std::vector<int64_t> new_shape;
-      CalculateTransposedShape(input_shape, sequence_dim, permutations, new_shape);
+      CalculateTransposedShapeForInput(input_shape, sequence_dim, permutations, new_shape);
 
       if (!alloc) {
         status = context_.GetTempSpaceAllocator(&alloc);
@@ -474,7 +474,7 @@ Status ScanImpl::TransposeOutput() {
 
       std::vector<int64_t> permutations;
       std::vector<int64_t> new_shape;
-      CalculateTransposedShape(temporary_output_tensor.Shape(), axis, permutations, new_shape);
+      CalculateTransposedShapeForOutput(temporary_output_tensor.Shape(), axis, permutations, new_shape);
 
       Tensor* output = context_.Output(output_index, new_shape);
       ORT_ENFORCE(output, "Outputs from Scan are not optional and should never be null.");

--- a/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
@@ -218,22 +218,44 @@ MLValue AllocateTensorInMLValue(const MLDataType data_type, const TensorShape& s
                  DataTypeImpl::GetType<Tensor>()->GetDeleteFunc()};
 };
 
-void CalculateTransposedShape(const TensorShape& input_shape, int64_t axis,
-                              std::vector<int64_t>& permutations, std::vector<int64_t>& output_shape) {
-  int64_t rank = input_shape.NumDimensions();
-  const auto& dims = input_shape.GetDims();
+void CalculateTransposedShapeForInput(const TensorShape& original_shape, int64_t axis,
+                                      std::vector<int64_t>& permutations, std::vector<int64_t>& transposed_shape) {
+  int64_t rank = original_shape.NumDimensions();
+  const auto& dims = original_shape.GetDims();
 
   permutations.reserve(rank);
   permutations.push_back(axis);
 
-  output_shape.reserve(rank);
-  output_shape.push_back(dims[axis]);
+  transposed_shape.reserve(rank);
+  transposed_shape.push_back(dims[axis]);
 
   for (int64_t i = 0; i < rank; ++i) {
     if (i != axis) {
       permutations.push_back(i);
-      output_shape.push_back(dims[i]);
+      transposed_shape.push_back(dims[i]);
     }
+  }
+}
+
+void CalculateTransposedShapeForOutput(const TensorShape& original_shape, int64_t axis,
+                                       std::vector<int64_t>& permutations, std::vector<int64_t>& transposed_shape) {
+  int64_t rank = original_shape.NumDimensions();
+  const auto& dims = original_shape.GetDims();
+
+  permutations.reserve(rank);
+  transposed_shape.reserve(rank);
+
+  for (int64_t i = 1; i <= axis; ++i) {
+    permutations.push_back(i);
+    transposed_shape.push_back(dims[i]);
+  }
+
+  permutations.push_back(0);
+  transposed_shape.push_back(dims[0]);
+
+  for (int64_t i = axis + 1; i < rank; ++i) {
+    permutations.push_back(i);
+    transposed_shape.push_back(dims[i]);
   }
 }
 

--- a/onnxruntime/core/providers/cpu/controlflow/scan_utils.h
+++ b/onnxruntime/core/providers/cpu/controlflow/scan_utils.h
@@ -170,14 +170,23 @@ Status IterateSequence(OpKernelContextInternal& context,
 MLValue AllocateTensorInMLValue(const MLDataType data_type, const TensorShape& shape, AllocatorPtr& allocator);
 
 /**
-Calculate the transpose permutations and output shape by shifting the chosen axis to the first dimension.
+Calculate the transpose permutations and shape by shifting the chosen axis TO the first dimension.
 The other dimension indexes or values are pushed in order after the chosen axis.
 
 e.g. if shape is {2, 3, 4} and axis 1 is chosen the permutations will be {1, 0, 2} and output shape will be {3, 2, 4}
      if axis 2 is chosen the permutations will be {2, 0, 1} and the output shape will be {4, 2, 3}
 */
-void CalculateTransposedShape(const TensorShape& input_shape, int64_t axis,
-                              std::vector<int64_t>& permutations, std::vector<int64_t>& output_shape);
+void CalculateTransposedShapeForInput(const TensorShape& original_shape, int64_t axis,
+                                      std::vector<int64_t>& permutations, std::vector<int64_t>& transposed_shape);
+
+/**
+Calculate the transpose permutations and shape by shifting the chosen axis FROM the first dimension.
+
+e.g. if shape is {4, 2, 3} and axis 2 is chosen, dimension 0 will move to dimension 2, 
+     the permutations will be {1, 2, 0} and output shape will be {2, 3, 4}
+*/
+void CalculateTransposedShapeForOutput(const TensorShape& original_shape, int64_t axis,
+                                       std::vector<int64_t>& permutations, std::vector<int64_t>& transposed_shape);
 
 }  // namespace detail
 }  // namespace scan


### PR DESCRIPTION
For Scan outputs the transpose should be the inverse of how input transpose works.

For inputs we move the chosen axis to dimension 0 and iterate it.
For outputs we should move dimension 0 to the chosen axis.