### PR TITLE
Fix a build warning in onnxruntime python extension

### DIFF
--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -49,6 +49,8 @@ if(APPLE)
   set(ONNXRUNTIME_SO_LINK_FLAG "-Xlinker -exported_symbols_list ${ONNXRUNTIME_ROOT}/python/exported_symbols.lst")
 elseif(UNIX)
   set(ONNXRUNTIME_SO_LINK_FLAG "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/python/version_script.lds -Xlinker --no-undefined")
+else()
+  set(ONNXRUNTIME_SO_LINK_FLAG "-DEF:${ONNXRUNTIME_ROOT}/python/pybind.def")
 endif()
 
 set(onnxruntime_pybind11_state_libs

--- a/onnxruntime/python/pybind.def
+++ b/onnxruntime/python/pybind.def
@@ -1,0 +1,3 @@
+LIBRARY "onnxruntime_pybind11_state.pyd"
+EXPORTS
+ PyInit_onnxruntime_pybind11_state @1


### PR DESCRIPTION
"[warning]onnxruntime_pybind11_state.exp(0,0): Warning LNK4070: /OUT:onnxruntime.dll directive in .EXP differs from output filename 'C:\agent\_work\1\b\Debug\Debug\onnxruntime_pybind11_state.pyd'; ignoring directive"