### PR TITLE
Delete Tensor's copy constructor

### DIFF
--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -69,11 +69,8 @@ class Tensor final {
 
   ~Tensor();
 
-  /**
-     Copy constructor and assign op will just pass the shape and memory
-     reference to another tensor. Not deep clone/copy.
-  */
-  Tensor(const Tensor& src);
+  //Move is allowed
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(Tensor);
 
   ///requires other.buffer_deleter_ == nullptr
   Tensor& ShallowCopy(const Tensor& other);

--- a/onnxruntime/core/framework/tensor.cc
+++ b/onnxruntime/core/framework/tensor.cc
@@ -79,17 +79,6 @@ Tensor& Tensor::operator=(Tensor&& other) {
   return *this;
 }
 
-Tensor::Tensor(const Tensor& src)
-    : shape_(src.shape_), dtype_(src.dtype_), alloc_info_(src.alloc_info_), byte_offset_(src.byte_offset_) {
-  // it may be better to refactor it a little bit to make it a compile error
-  // but right now just keep it simple first.
-  ORT_ENFORCE(src.buffer_deleter_ == nullptr,
-              "Can't copy tensor with its owned buffer. Please transfer ownership by move.");
-
-  p_data_ = src.p_data_;
-  buffer_deleter_ = nullptr;
-}
-
 Tensor::~Tensor() {
   ReleaseBuffer();
 }

--- a/onnxruntime/test/framework/tensor_test.cc
+++ b/onnxruntime/test/framework/tensor_test.cc
@@ -140,24 +140,6 @@ TEST(TensorTest, EmptyTensorTest) {
   EXPECT_EQ(location.type, OrtAllocatorType::OrtArenaAllocator);
 }
 
-TEST(TensorTest, TensorCopyAssignOpTest) {
-  TensorShape shape({1, 2, 3});
-  auto alloc = TestCPUExecutionProvider()->GetAllocator(0, OrtMemTypeDefault);
-  auto data = alloc->Alloc(sizeof(int) * shape.Size());
-  EXPECT_TRUE(data);
-  Tensor t1(DataTypeImpl::GetType<int>(), shape, data, alloc->Info());
-  Tensor t2 = t1;
-  EXPECT_EQ(t2.DataType(), DataTypeImpl::GetType<int>());
-  EXPECT_EQ(t2.Shape(), shape);
-  auto location = t2.Location();
-  ASSERT_STREQ(location.name, CPU);
-  EXPECT_EQ(location.id, 0);
-  EXPECT_EQ(location.type, OrtAllocatorType::OrtArenaAllocator);
-  auto t_data = t2.template Data<int>();
-  EXPECT_EQ((void*)t_data, data);
-  alloc->Free(data);
-}
-
 TEST(TensorTest, StringTensorTest) {
 //add scope to explicitly delete tensor
 #ifdef _MSC_VER


### PR DESCRIPTION
 Copy constructor and  copy assignment operator, either we implement **both** of them, or none of them.
As the Tensor class' copy constructor is not used in any place, we can safely delete it.