### PR TITLE
TopK Op: Include support for valid `axis` attribute in implementation 

### DIFF
--- a/onnxruntime/core/providers/cpu/math/top_k.cc
+++ b/onnxruntime/core/providers/cpu/math/top_k.cc
@@ -31,7 +31,6 @@ ONNX_CPU_OPERATOR_KERNEL(
     KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()).TypeConstraint("I", DataTypeImpl::GetTensorType<int64_t>()),
     TopK<float>);
 
-/*
 static int64_t SizeToDim(size_t k, const vector<int64_t>& dims) {
   ORT_ENFORCE(k <= dims.size());
   int64_t r = 1;
@@ -49,7 +48,6 @@ static int64_t SizeFromDim(size_t k, const vector<int64_t>& dims) {
   }
   return r;
 }
-*/
 
 // Define these two names to allow lookup into the 2d tensors like
 // mytensor(i, j)

--- a/onnxruntime/core/providers/cpu/math/top_k.cc
+++ b/onnxruntime/core/providers/cpu/math/top_k.cc
@@ -80,7 +80,7 @@ Status TopK<float>::Compute(OpKernelContext* p_op_kernel_context) const {
   // Check to ensure k_ is within the bounds of what is available in that specific axis 	
   if (in_dims.at(axis_parsed) < k_) {
     ostringstream err_msg;
-    err_msg << "k argment [" << k_ << "] should not be greater than specified axis dim [" << in_dims.at(axis_parsed) << "]";
+    err_msg << "k argment [" << k_ << "] should not be greater than specified axis dim value [" << in_dims.at(axis_parsed) << "]";
     return Status(common::ONNXRUNTIME, common::FAIL, err_msg.str());
   }
 

--- a/onnxruntime/core/providers/cpu/math/top_k.cc
+++ b/onnxruntime/core/providers/cpu/math/top_k.cc
@@ -91,9 +91,9 @@ Status TopK<float>::Compute(OpKernelContext* p_op_kernel_context) const {
       rows,
       cols);
 
-  // Resize output tensors to be the same shape as the linearized input except
-  // for the specified dimension (axis_parsed), which will be of size k. E.x. for an input tensor
-  // of shape [3, 4, 5] and k=2 with axis=1, both of these will be shape [3, 2, 5]
+  // Resize output tensors to be the same shape as the input except
+  // for the specified dimension ((i.e.) axis_parsed), which will be of size k_. E.x. for an input tensor
+  // of shape [3, 4, 5] and k_=2 with axis_parsed=1, both of these will be shape [3, 2, 5]
   vector<int64_t> output_linear_shape = in_dims;
   output_linear_shape[axis_parsed] = k_;
   auto* Values = p_op_kernel_context->Output(0, output_linear_shape);

--- a/onnxruntime/test/providers/cpu/math/topk_op_test.cc
+++ b/onnxruntime/test/providers/cpu/math/topk_op_test.cc
@@ -74,37 +74,48 @@ TEST(TopKOperator, Top1ExplicitAxis) {
   int64_t axis = 0;
   RunTest(1, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
 }
-/*
+
 TEST(TopKOperator, Top2ExplicitAxis) {
-  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.4f, 0.2f};
-  std::vector<int64_t> input_dimensions = {4, 2};
-  std::vector<float> expected_vals = {0.4f, 0.3f, 0.4f, 0.3f};
-  std::vector<int64_t> expected_indices = {3, 1, 2, 1};
-  std::vector<int64_t> expected_dimensions = {2, 2};
+  std::vector<float> input_vals = {0.0f, 1.0f, 2.0f, 11.0f, 08.0f, 5.0f, 6.0f, 7.0f, 4.0f, 9.0f, 10.0f, 3.0f};
+  std::vector<int64_t> input_dimensions = {3, 4};
+  std::vector<float> expected_vals = {8.0f, 9.0f, 10.0f, 11.0f, 4.0f, 5.0f, 6.0f, 7.0f};
+  std::vector<int64_t> expected_indices = {1, 2, 2, 0, 2, 1, 1, 1};
+  std::vector<int64_t> expected_dimensions = {2, 4};
   int64_t axis = 0;
   RunTest(2, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
 }
 
 TEST(TopKOperator, Top3ExplicitAxis) {
-  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.4f, 0.2f};
+  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
   std::vector<int64_t> input_dimensions = {4, 2};
-  std::vector<float> expected_vals = {0.4f, 0.3f, 0.2f, 0.4f, 0.3f, 0.2f};
-  std::vector<int64_t> expected_indices = {3, 1, 2, 2, 1, 3};
+  std::vector<float> expected_vals = {0.3f, 0.4f, 0.2f, 0.3f, 0.1f, 0.3f};
+  std::vector<int64_t> expected_indices = {3, 1, 1, 0, 0, 2};
   std::vector<int64_t> expected_dimensions = {3, 2};
   int64_t axis = 0;
   RunTest(3, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
 }
 
+
 TEST(TopKOperator, TopAllExplicitAxis) {
   std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
   std::vector<int64_t> input_dimensions = {4, 2};
-  std::vector<float> expected_vals = {0.4f, 0.3f, 0.2f, 0.1f, 0.3f, 0.3f, 0.2f, 0.1f};
-  std::vector<int64_t> expected_indices = {3, 1, 2, 0, 1, 2, 3, 0};
+  std::vector<float> expected_vals = {0.3f, 0.4f, 0.2f, 0.3f, 0.1f, 0.3f, 0.1f, 0.2f};
+  std::vector<int64_t> expected_indices = {3, 1, 1, 0, 0, 2, 2, 3};
   std::vector<int64_t> expected_dimensions = {4, 2};
   int64_t axis = 0;
   RunTest(4, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
 }
-*/
+
+TEST(TopKOperator, TopAllExplicitAxis1DInput) {
+  std::vector<float> input_vals = {93.0f, 695.0f, 971.0f, 978.0f, 483.0f, 247.0f, 242.0f, 983.0f, 531.0f, 723.0f, 285.0f, 527.0f, 862.0f};
+  std::vector<int64_t> input_dimensions = {13};
+  std::vector<float> expected_vals = {983.0f, 978.0f, 971.0f, 862.0f, 723.0f, 695.0f, 531.0f, 527.0f, 483.0f, 285.0f, 247.0f, 242.0f, 93.0f};
+  std::vector<int64_t> expected_indices = {7, 3, 2, 12, 9, 1, 8, 11, 4, 10, 5, 6,0};
+  std::vector<int64_t> expected_dimensions = {13};
+  int64_t axis = 0;
+  RunTest(13, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
+}
+
 TEST(TopKOperator, InvalidK) {
   std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
   std::vector<int64_t> input_dimensions = {2, 4};

--- a/onnxruntime/test/providers/cpu/math/topk_op_test.cc
+++ b/onnxruntime/test/providers/cpu/math/topk_op_test.cc
@@ -116,6 +116,16 @@ TEST(TopKOperator, TopAllExplicitAxis1DInput) {
   RunTest(13, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
 }
 
+TEST(TopKOperator, Top1ExplicitAxisMultiDInput) {
+  std::vector<float> input_vals = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
+  std::vector<int64_t> input_dimensions = {2, 2, 2};
+  std::vector<float> expected_vals = {3, 4, 7, 8};
+  std::vector<int64_t> expected_indices = {1, 1, 1, 1};
+  std::vector<int64_t> expected_dimensions = {2, 1, 2};
+  int64_t axis = 1;
+  RunTest(1, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
+}
+
 TEST(TopKOperator, InvalidK) {
   std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
   std::vector<int64_t> input_dimensions = {2, 4};

--- a/onnxruntime/test/providers/cpu/math/topk_op_test.cc
+++ b/onnxruntime/test/providers/cpu/math/topk_op_test.cc
@@ -14,12 +14,12 @@ static void RunTest(int64_t k,
                     const std::vector<float>& expected_vals,
                     const std::vector<int64_t>& expected_indices,
                     const std::vector<int64_t>& expected_dimensions,
-                    int64_t axis = 1,
+                    int64_t axis = -1,
                     OpTester::ExpectResult expect_result = OpTester::ExpectResult::kExpectSuccess,
                     const std::string& expected_err_str = "") {
   OpTester test("TopK");
   test.AddAttribute("k", k);
-  if (axis != 1) {
+  if (axis != -1) {
     test.AddAttribute("axis", axis);
   }
 
@@ -29,7 +29,7 @@ static void RunTest(int64_t k,
   test.Run(expect_result, expected_err_str);
 }
 
-TEST(TopKOperator, Top1) {
+TEST(TopKOperator, Top1DefaultAxis) {
   std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
   std::vector<int64_t> input_dimensions = {2, 4};
   std::vector<float> expected_vals = {0.4f, 0.3f};
@@ -38,7 +38,7 @@ TEST(TopKOperator, Top1) {
   RunTest(1, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions);
 }
 
-TEST(TopKOperator, Top2) {
+TEST(TopKOperator, Top2DefaultAxis) {
   std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.4f, 0.2f};
   std::vector<int64_t> input_dimensions = {2, 4};
   std::vector<float> expected_vals = {0.4f, 0.3f, 0.4f, 0.3f};
@@ -47,7 +47,7 @@ TEST(TopKOperator, Top2) {
   RunTest(2, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions);
 }
 
-TEST(TopKOperator, Top3) {
+TEST(TopKOperator, Top3DefaultAxis) {
   std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.4f, 0.2f};
   std::vector<int64_t> input_dimensions = {2, 4};
   std::vector<float> expected_vals = {0.4f, 0.3f, 0.2f, 0.4f, 0.3f, 0.2f};
@@ -56,7 +56,7 @@ TEST(TopKOperator, Top3) {
   RunTest(3, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions);
 }
 
-TEST(TopKOperator, TopAll) {
+TEST(TopKOperator, TopAllDefaultAxis) {
   std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
   std::vector<int64_t> input_dimensions = {2, 4};
   std::vector<float> expected_vals = {0.4f, 0.3f, 0.2f, 0.1f, 0.3f, 0.3f, 0.2f, 0.1f};
@@ -65,6 +65,46 @@ TEST(TopKOperator, TopAll) {
   RunTest(4, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions);
 }
 
+TEST(TopKOperator, Top1ExplicitAxis) {
+  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
+  std::vector<int64_t> input_dimensions = {4, 2};
+  std::vector<float> expected_vals = {0.3f, 0.4f};
+  std::vector<int64_t> expected_indices = {3, 1};
+  std::vector<int64_t> expected_dimensions = {1, 2};
+  int64_t axis = 0;
+  RunTest(1, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
+}
+/*
+TEST(TopKOperator, Top2ExplicitAxis) {
+  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.4f, 0.2f};
+  std::vector<int64_t> input_dimensions = {4, 2};
+  std::vector<float> expected_vals = {0.4f, 0.3f, 0.4f, 0.3f};
+  std::vector<int64_t> expected_indices = {3, 1, 2, 1};
+  std::vector<int64_t> expected_dimensions = {2, 2};
+  int64_t axis = 0;
+  RunTest(2, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
+}
+
+TEST(TopKOperator, Top3ExplicitAxis) {
+  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.4f, 0.2f};
+  std::vector<int64_t> input_dimensions = {4, 2};
+  std::vector<float> expected_vals = {0.4f, 0.3f, 0.2f, 0.4f, 0.3f, 0.2f};
+  std::vector<int64_t> expected_indices = {3, 1, 2, 2, 1, 3};
+  std::vector<int64_t> expected_dimensions = {3, 2};
+  int64_t axis = 0;
+  RunTest(3, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
+}
+
+TEST(TopKOperator, TopAllExplicitAxis) {
+  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
+  std::vector<int64_t> input_dimensions = {4, 2};
+  std::vector<float> expected_vals = {0.4f, 0.3f, 0.2f, 0.1f, 0.3f, 0.3f, 0.2f, 0.1f};
+  std::vector<int64_t> expected_indices = {3, 1, 2, 0, 1, 2, 3, 0};
+  std::vector<int64_t> expected_dimensions = {4, 2};
+  int64_t axis = 0;
+  RunTest(4, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
+}
+*/
 TEST(TopKOperator, InvalidK) {
   std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
   std::vector<int64_t> input_dimensions = {2, 4};


### PR DESCRIPTION
* TopK operator supports attribute `axis` indicating axis on which to sort. The current implementation only supports the default value for this attribute (-1) which is the innermost dimension. Extending the implementation to support any given valid `axis` attribute value

* Currently the output for a valid 1D input tensor is incorrect. As part of the change, made sure that got fixed and checking-in a test case for the same. 