### PR TITLE
Optimize graph partition

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -408,9 +408,13 @@ install(TARGETS onnx_test_runner
         RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 if(onnxruntime_BUILD_BENCHMARKS AND (HAS_FILESYSTEM_H OR HAS_EXPERIMENTAL_FILESYSTEM_H))
-  add_executable(onnxruntime_benchmark ${TEST_SRC_DIR}/onnx/microbenchmark/main.cc ${TEST_SRC_DIR}/onnx/microbenchmark/modeltest.cc)
+  add_executable(onnxruntime_benchmark ${TEST_SRC_DIR}/onnx/microbenchmark/main.cc ${TEST_SRC_DIR}/onnx/microbenchmark/modeltest.cc ${TEST_SRC_DIR}/onnx/microbenchmark/model_init.cc)
   target_include_directories(onnxruntime_benchmark PRIVATE ${ONNXRUNTIME_ROOT} ${onnxruntime_graph_header} benchmark)
-  target_compile_options(onnxruntime_benchmark PRIVATE "/wd4141")
+  onnxruntime_add_include_to_target(onnxruntime_benchmark gsl)
+  if(WIN32)
+    target_compile_options(onnxruntime_benchmark PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler /wd4141>"
+                      "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/wd4141>")
+  endif()
   target_link_libraries(onnxruntime_benchmark PRIVATE onnx_test_runner_common benchmark ${onnx_test_libs})
   add_dependencies(onnxruntime_benchmark ${onnxruntime_EXTERNAL_DEPENDENCIES})
   set_target_properties(onnxruntime_benchmark PROPERTIES FOLDER "ONNXRuntimeTest")

--- a/include/onnxruntime/core/framework/kernel_registry.h
+++ b/include/onnxruntime/core/framework/kernel_registry.h
@@ -6,6 +6,10 @@
 #include "core/framework/op_kernel.h"
 
 namespace onnxruntime {
+/**
+ * Each provider has a KernelRegistry. Often, the KernelRegistry only belongs to that specific provider.
+ *
+ */
 class KernelRegistry {
  public:
   KernelRegistry() = default;
@@ -16,29 +20,37 @@ class KernelRegistry {
 
   Status Register(KernelCreateInfo&& create_info);
 
-  // Mainly for provide debug info
-  std::vector<std::string> GetAllRegisteredOpNames() const;
-
   // factory functions should always return a unique_ptr for maximum flexibility
   // for its clients unless the factory is managing the lifecycle of the pointer
   // itself.
   // TODO(Task:132) Make usage of unique_ptr/shared_ptr as out param consistent
-  Status CreateKernel(const onnxruntime::Node& node,
-                      const IExecutionProvider& execution_provider,
-                      const std::unordered_map<int, MLValue>& initialized_tensors,
-                      const MLValueNameIdxMap& mlvalue_name_idx_map,
-                      const FuncManager& funcs_mgr,
-                      std::unique_ptr<OpKernel>& op_kernel) const;
+  Status TryCreateKernel(const onnxruntime::Node& node, const IExecutionProvider& execution_provider,
+                         const std::unordered_map<int, MLValue>& initialized_tensors,
+                         const MLValueNameIdxMap& mlvalue_name_idx_map, const FuncManager& funcs_mgr,
+                         std::unique_ptr<OpKernel>& op_kernel) const;
 
   // Check if an execution provider can create kernel for a node and return
   // the kernel if so
   const KernelCreateInfo* TryFindKernel(const onnxruntime::Node& node,
                                         onnxruntime::ProviderType exec_provider) const;
 
+  bool IsEmpty() const { return kernel_creator_fn_map_.empty(); }
+
  private:
-  // Check if the node's input/outpuData/attributes are compatible with this
-  // kernel_def, If so, the kernel defined by the kernel_def is used to
-  // execute this node. exec_provider is used to match kernel when node has no provider
+  // Check whether the types of inputs/outputs of the given node match the extra
+  // type-constraints of the given kernel. This serves two purposes: first, to
+  // select the right kernel implementation based on the types of the arguments
+  // when we have multiple kernels, e.g., Clip<float> and Clip<int>; second, to
+  // accommodate (and check) mapping of ONNX (specification) type to the onnxruntime
+  // implementation type (e.g., if we want to implement ONNX's float16 as a regular
+  // float in onnxruntime). (The second, however, requires a globally uniform mapping.)
+  //
+  // Note that this is not intended for type-checking the node against the ONNX
+  // type specification of the corresponding op, which is done before this check.
+  //
+  // if this function is called before graph partition, then node.provider is not set.
+  // In this case, kernel_def.provider must equal to exec_provider
+  // otherwise, kernel_def.provider must equal to node.provider. exec_provider is ignored.
   static bool VerifyKernelDef(const onnxruntime::Node& node,
                               const KernelDef& kernel_def,
                               std::string& error_str,

--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -164,8 +164,16 @@ class Tensor final {
   /**
   The number of bytes of data.
   */
-  size_t Size() const noexcept {
-    return shape_.Size() * dtype_->Size();
+  size_t Size() const {
+    size_t ret;
+    int64_t l = shape_.Size();
+    if (l >= static_cast<int64_t>(std::numeric_limits<ptrdiff_t>::max())) {
+      ORT_THROW("tensor size overflow");
+    }
+    if (!IAllocator::CalcMemSizeForArray(static_cast<size_t>(shape_.Size()), dtype_->Size(), &ret)) {
+      ORT_THROW("tensor size overflow");
+    }
+    return ret;
   }
 
   // More API methods.

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -7,16 +7,23 @@
 #include <string>
 #include <stdexcept>
 #include <memory>
+#include "core/common/exceptions.h"
 
 //TODO: encode error code in the message?
-#define ORT_THROW_ON_ERROR(expr)                                       \
-  do {                                                                 \
-    OrtStatus* onnx_status = (expr);                                   \
-    if (onnx_status != nullptr) {                                      \
-      std::string ort_error_message = OrtGetErrorMessage(onnx_status); \
-      OrtReleaseStatus(onnx_status);                                   \
-      throw std::runtime_error(ort_error_message);                     \
-    }                                                                  \
+#define ORT_THROW_ON_ERROR(expr)                                                 \
+  do {                                                                           \
+    OrtStatus* onnx_status = (expr);                                             \
+    if (onnx_status != nullptr) {                                                \
+      std::string ort_error_message = OrtGetErrorMessage(onnx_status);           \
+      OrtErrorCode error_code = OrtGetErrorCode(onnx_status);                    \
+      OrtReleaseStatus(onnx_status);                                             \
+      switch (error_code) {                                                      \
+        case ORT_NOT_IMPLEMENTED:                                                \
+          throw onnxruntime::NotImplementedException(ort_error_message);         \
+        default:                                                                 \
+          throw onnxruntime::OnnxRuntimeException(ORT_WHERE, ort_error_message); \
+      }                                                                          \
+    }                                                                            \
   } while (0);
 
 #define ORT_REDIRECT_SIMPLE_FUNCTION_CALL(NAME) \

--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -195,13 +195,13 @@ class PlannerImpl {
   // Find if there exists some input tensor that we can use in-place for output_arg
   bool FindReusableInput(const onnxruntime::Node& node, int output_arg_num, MLValueIndex* reusable_input) {
     auto p_output_arg = node.OutputDefs()[output_arg_num];
-    auto p_opkernel_def = utils::GetKernelDef(kernel_registry_, node);
+    const KernelCreateInfo* ci;
+    Status st = kernel_registry_.SearchKernelRegistry(node, &ci);
+    if (!st.IsOK() || ci == nullptr || ci->kernel_def == nullptr) {
+      return false;
+    }
 
-    // Note: We expect a KernelDef to be available at this point. If it is not available, the
-    // planner would have returned an error status earlier on.
-    ORT_ENFORCE(nullptr != p_opkernel_def);
-
-    const std::vector<std::pair<int, int>>& alias_map = p_opkernel_def->Alias();
+    const std::vector<std::pair<int, int>>& alias_map = ci->kernel_def->Alias();
     auto& input_args = node.InputDefs();
     for (auto pair : alias_map) {
       if (pair.second == output_arg_num) {
@@ -216,7 +216,7 @@ class PlannerImpl {
       }
     }
 
-    const std::vector<std::pair<int, int>>& inplace_map = p_opkernel_def->MayInplace();
+    const std::vector<std::pair<int, int>>& inplace_map = ci->kernel_def->MayInplace();
     for (auto pair : inplace_map) {
       if (pair.second == output_arg_num) {
         if ((0 <= pair.first) && (static_cast<size_t>(pair.first) < input_args.size())) {
@@ -354,6 +354,7 @@ class PlannerImpl {
 
     for (SequentialExecutionPlan::NodeExecutionPlan& step : plan_.execution_plan) {
       auto pnode = graph_viewer_.GetNode(step.node_index);
+      if (pnode == nullptr) return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Can not find the node ", step.node_index);
       for (auto node_input : pnode->InputDefs()) {
         if (node_input->Exists())
           UseCount(node_input->Name())++;
@@ -363,21 +364,26 @@ class PlannerImpl {
         if (node_input->Exists())
           UseCount(node_input->Name())++;
       }
-
       // Identify where each output of this node should be allocated.
       // This is determined by the opkernel bound to the node.
-      auto node = graph_viewer_.GetNode(step.node_index);
-      ORT_ENFORCE(nullptr != node);
-      auto p_kernelDef = utils::GetKernelDef(kernel_registry_, *node);
+      const KernelCreateInfo* kernel_create_info = nullptr;
+      ORT_RETURN_IF_ERROR(kernel_registry_.SearchKernelRegistry(*pnode, &kernel_create_info));
+      auto p_kernelDef = kernel_create_info->kernel_def.get();
       if (nullptr == p_kernelDef) {
         std::ostringstream errormsg;
-        errormsg << "No suitable kernel definition found for op " << pnode->OpType() << "(" << pnode->Op()->since_version() << ")";
+        errormsg << "No suitable kernel definition found for op " << pnode->OpType();
+        if (pnode->Op() != nullptr) {
+          errormsg << "(" << pnode->Op()->since_version() << ")";
+        }
         if (!pnode->Name().empty()) errormsg << " (node " << pnode->Name() << ")";
         return Status(ONNXRUNTIME, FAIL, errormsg.str());
       }
 
-      auto exec_provider = execution_providers_.Get(*node);
-      ORT_ENFORCE(exec_provider);
+      auto exec_provider = execution_providers_.Get(*pnode);
+      if (exec_provider == nullptr) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Can not find the execution provider ",
+                               pnode->GetExecutionProviderType());
+      }
 
       auto& default_allocator_info = exec_provider->GetAllocator(0, OrtMemTypeDefault)->Info();
       auto& outputs = pnode->OutputDefs();
@@ -419,36 +425,41 @@ class PlannerImpl {
     return Status::OK();
   }
 
-  void GeneratePlanForWeights() {
+  // TODO: Don't generate plan for CPU tensors, which may get its memory from 'mmap(2)'
+  Status GeneratePlanForWeights() {
     auto& weights = graph_viewer_.GetAllInitializedTensors();
 
     for (auto& node : graph_viewer_.Nodes()) {
-      onnxruntime::Node::ForEachWithIndex(
-          node.InputDefs(),
-          [this, &node, &weights](const onnxruntime::NodeArg& def, size_t index) {
-            auto& def_name = def.Name();
-            if (!weights.count(def_name))
-              return Status::OK();
+      ORT_RETURN_IF_ERROR(onnxruntime::Node::ForEachWithIndex(node.InputDefs(), [this, &node, &weights](
+                                                                                    const onnxruntime::NodeArg& def,
+                                                                                    size_t index) {
+        auto& def_name = def.Name();
+        if (!weights.count(def_name)) return Status::OK();
 
-            auto wt_index = Index(def_name);
-            SequentialExecutionPlan::AllocPlanPerValue& thisplan = AllocPlan(wt_index);
-            auto* p_provider = execution_providers_.Get(node);
-            ORT_ENFORCE(p_provider);
+        auto wt_index = Index(def_name);
+        SequentialExecutionPlan::AllocPlanPerValue& thisplan = AllocPlan(wt_index);
+        auto* p_provider = execution_providers_.Get(node);
+        ORT_ENFORCE(p_provider);
 
-            thisplan.alloc_kind = AllocKind::kAllocateStatically;
-            auto p_opkernelDef = utils::GetKernelDef(kernel_registry_, node);
-            if (MemTypeOnCpuExplicitly(p_opkernelDef->InputMemoryType(index)))
-              // weights are not output from any node, so it's OK to put its location on CPU provider
-              thisplan.location = execution_providers_.Get(onnxruntime::kCpuExecutionProvider)->GetAllocator(0, OrtMemTypeDefault)->Info();
-            else
-              thisplan.location = p_provider->GetAllocator(0, OrtMemTypeDefault)->Info();
+        thisplan.alloc_kind = AllocKind::kAllocateStatically;
+        const KernelCreateInfo* kernel_create_info;
+        ORT_RETURN_IF_ERROR(kernel_registry_.SearchKernelRegistry(node, &kernel_create_info));
+        if (kernel_create_info == nullptr || kernel_create_info->kernel_def == nullptr)
+          return Status(ONNXRUNTIME, FAIL, "search kernel failed");  // shouldn't reach here
+        if (MemTypeOnCpuExplicitly(kernel_create_info->kernel_def->InputMemoryType(index)))
+          // weights are not output from any node, so it's OK to put its location on CPU provider
+          thisplan.location =
+              execution_providers_.Get(onnxruntime::kCpuExecutionProvider)->GetAllocator(0, OrtMemTypeDefault)->Info();
+        else
+          thisplan.location = p_provider->GetAllocator(0, OrtMemTypeDefault)->Info();
 
-            return Status::OK();
-          });
+        return Status::OK();
+      }));
     }
+    return Status::OK();
   }
 
-  void ComputeReusePlan() {
+  Status ComputeReusePlan() {
     std::vector<SequentialExecutionPlan::NodeExecutionPlan>& execution_plan{plan_.execution_plan};
 
     // Identify allocation/deallocation plan for every ml-value
@@ -472,7 +483,7 @@ class PlannerImpl {
       setup_preexisting(outer_scope_node_arg);
     }
 
-    GeneratePlanForWeights();
+    ORT_RETURN_IF_ERROR(GeneratePlanForWeights());
 
     for (size_t program_counter = 0; program_counter < execution_plan.size(); ++program_counter) {
       SequentialExecutionPlan::NodeExecutionPlan step = execution_plan[program_counter];
@@ -533,6 +544,7 @@ class PlannerImpl {
         }
       }
     }
+    return Status::OK();
   }
 
   // Convert information in a freelist (about which ml-value becomes free when) into
@@ -590,7 +602,7 @@ Status PlannerImpl::CreatePlan() {
   ORT_RETURN_IF_ERROR(ComputeUseCounts());
 
   // determine sharing/reuse among ml-values
-  ComputeReusePlan();
+  ORT_RETURN_IF_ERROR(ComputeReusePlan());
 
   // convert information in the freelist_ into a deallocation plan in required format
   GenerateDeallocationPlan();

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -55,6 +55,61 @@ KernelDefBuilder& BuildFusedKernelDef(KernelDefBuilder& builder, const onnxrunti
   return builder;
 }
 
+/**
+ * Check if a node can be placed on a specific provider.
+ * Do nothing if the node is already assigned
+ * \param graph
+ * \param capability
+ * \param kernel_registry_mgr
+ * \param provider_type name of the provider to test
+ * \param count A counter for generating fused node names. Should be unique within this subgraph
+ * \return Fused node. Return nullptr if there is no fuse
+ */
+static Node* PlaceNode(Graph& graph, std::unique_ptr<IndexedSubGraph> capability,
+                       const KernelRegistryManager& kernel_registry_mgr, const std::string& provider_type, int& count) {
+  if (nullptr == capability) {
+    return nullptr;
+  }
+
+  if (nullptr == capability->GetMetaDef()) {
+    // The <provider> can run a single node in the <graph> if not using meta-defs.
+    // A fused kernel is not supported in this case.
+    ORT_ENFORCE(1 == capability->nodes.size());
+
+    auto node = graph.GetNode(capability->nodes[0]);
+    if (nullptr != node && node->GetExecutionProviderType().empty()) {
+      // The node was not fused or assigned. Assign it to this <provider>.
+      node->SetExecutionProviderType(provider_type);
+    }
+  } else {
+    // The <provider> can run a fused <sub_graph> in the <graph>.
+    ORT_ENFORCE(nullptr != capability->GetMetaDef());
+    // Check whether any node in the <sub_graph> was already assigned.
+    bool sub_graph_available_for_assignment = true;
+    for (auto node_index : capability->nodes) {
+      auto node = graph.GetNode(node_index);
+      if (nullptr == node || !node->GetExecutionProviderType().empty()) {
+        // The node was fused or assigned, so that the whole sub-graph will not be assigned to this <provider>
+        // The assumption is that this <provider> can only run the sub-graph as a whole unit.
+        sub_graph_available_for_assignment = false;
+        break;
+      }
+    }
+    if (sub_graph_available_for_assignment) {
+      std::ostringstream oss;
+      oss << provider_type << "_" << capability->GetMetaDef()->name << "_" << count++;
+      std::string node_name = oss.str();
+      auto& fused_node = graph.FuseSubGraph(std::move(capability), node_name);
+      fused_node.SetExecutionProviderType(provider_type);
+      // searching in kernel registries, if no kernel registered for the fused_node, use compile approach
+      if (!kernel_registry_mgr.HasImplementationOf(fused_node, provider_type)) {
+        return &fused_node;
+      }
+    }
+  }
+  return nullptr;
+}
+
 Status GraphPartitioner::Partition(Graph& graph, bool export_dll, FuncManager& func_mgr) const {
   // It is a greedy partitioning algorithm per provider preferences user provided when calling ONNX RUNTIME right now.
   // 1. Execution providers' capabilities are checked one by one.
@@ -62,7 +117,8 @@ Status GraphPartitioner::Partition(Graph& graph, bool export_dll, FuncManager& f
   //    NOTE: A 'sub-graph' is a subset of nodes within the current Graph instance.
   //          The control flow nodes have nested Graph instance/s which are also called subgraphs,
   //          but are completely separate Graph instances and not a subset of nodes within a single Graph instance.
-  // 3. CPU execution provider is expected to be able to run any node and is the last one in execution provider preference.
+  // 3. CPU execution provider is expected to be able to run any node and is the last one in execution provider
+  //    preference.
   if (providers_.Empty()) {
     return Status(ONNXRUNTIME, INVALID_ARGUMENT, "No provider specified.");
   }
@@ -80,13 +136,7 @@ Status GraphPartitioner::Partition(Graph& graph, bool export_dll, FuncManager& f
   // It is only visible for current session.
   std::shared_ptr<KernelRegistry> fused_kernel_registry = std::make_shared<KernelRegistry>();
   // Partitioning <graph> based on provider preference and their capabilities.
-  auto kernel_registries = kernel_registry_mgr_.GetAllKernelRegistries();
-
-  std::vector<std::vector<std::unique_ptr<ComputeCapability>>> capabilities_of_all_providers;
   GraphViewer graph_viewer(graph);
-  for (auto& provider : providers_) {
-    capabilities_of_all_providers.push_back(provider->GetCapability(graph_viewer, kernel_registries));
-  }
 
   // If an execution provider return the capability that he could run a sub-graph,
   // onnxruntime will fuse the sub-graph into a function node. if the execution provider
@@ -98,59 +148,19 @@ Status GraphPartitioner::Partition(Graph& graph, bool export_dll, FuncManager& f
   // TODO: when the graph contain a function node, and user pass in the dll which could
   // run the function by SessionOption, we should create a function kernel for it and
   // delegate the compute to the functions inside the dlls.
-  int i = 0;
   for (auto& provider : providers_) {
     int count = 0;
     std::vector<Node*> nodes_need_compile;
-    for (auto& capability : capabilities_of_all_providers[i++]) {
-      if (nullptr == capability || nullptr == capability->sub_graph) {
-        continue;
-      }
-
-      if (nullptr == capability->sub_graph->GetMetaDef()) {
-        // The <provider> can run a single node in the <graph> if not using meta-defs.
-        // A fused kernel is not supported in this case.
-        ORT_ENFORCE(1 == capability->sub_graph->nodes.size());
-
-        auto node = graph.GetNode(capability->sub_graph->nodes[0]);
-        if (nullptr != node && node->GetExecutionProviderType().empty()) {
-          // The node was not fused or assigned. Assign it to this <provider>.
-          node->SetExecutionProviderType(provider->Type());
-        }
-      } else {
-        // The <provider> can run a fused <sub_graph> in the <graph>.
-        ORT_ENFORCE(nullptr != capability->sub_graph->GetMetaDef());
-        // Check whether any node in the <sub_graph> was already assigned.
-        bool sub_graph_available_for_assignment = true;
-        for (auto node_index : capability->sub_graph->nodes) {
-          auto node = graph.GetNode(node_index);
-          if (nullptr == node || !node->GetExecutionProviderType().empty()) {
-            // The node was fused or assigned, so that the whole sub-graph will not be assigned to this <provider>
-            // The assumption is that this <provider> can only run the sub-graph as a whole unit.
-            sub_graph_available_for_assignment = false;
-            break;
-          }
-        }
-        if (sub_graph_available_for_assignment) {
-          std::string node_name = provider->Type() + "_" + capability->sub_graph->GetMetaDef()->name + "_" + std::to_string(count++);
-          auto& fused_node = graph.FuseSubGraph(std::move(capability->sub_graph), node_name);
-          fused_node.SetExecutionProviderType(provider->Type());
-          // searching in kernel registries, if no kernel registered for the fused_node, use compile approach
-          bool need_compile = true;
-          for (auto* kernel_registry : kernel_registries) {
-            if (kernel_registry->TryFindKernel(fused_node, provider->Type())) {
-              need_compile = false;
-              break;
-            }
-          }
-
-          if (need_compile)
-            nodes_need_compile.push_back(&fused_node);
-        }
+    std::vector<std::unique_ptr<ComputeCapability>> capabilities =
+        provider->GetCapability(graph_viewer, kernel_registry_mgr_.GetKernelRegistriesByProviderType(provider->Type()));
+    for (auto& capability : capabilities) {
+      Node* n = PlaceNode(graph, std::move(capability->sub_graph), kernel_registry_mgr_, provider->Type(), count);
+      if (n != nullptr) {
+        nodes_need_compile.push_back(n);
       }
     }
 
-    if (nodes_need_compile.size() > 0) {
+    if (!nodes_need_compile.empty()) {
       if (export_dll) {
         std::string dll_path;
         ORT_RETURN_IF_ERROR(provider->Compile(nodes_need_compile, dll_path));
@@ -159,20 +169,24 @@ Status GraphPartitioner::Partition(Graph& graph, bool export_dll, FuncManager& f
       } else {
         std::vector<NodeComputeInfo> node_compute_funcs;
         ORT_RETURN_IF_ERROR(provider->Compile(nodes_need_compile, node_compute_funcs));
-        ORT_ENFORCE(node_compute_funcs.size() == nodes_need_compile.size(), "Provider doesn't return correct number of compiled functions");
-        for (auto j = 0; j < nodes_need_compile.size(); j++)
-          ORT_RETURN_IF_ERROR(func_mgr.AddFuncInfo(nodes_need_compile[j]->Name(), node_compute_funcs[j].compute_func, node_compute_funcs[j].create_state_func, node_compute_funcs[j].release_state_func));
+        ORT_ENFORCE(node_compute_funcs.size() == nodes_need_compile.size(),
+                    "Provider doesn't return correct number of compiled functions");
+        for (size_t j = 0; j < nodes_need_compile.size(); j++)
+          ORT_RETURN_IF_ERROR(func_mgr.AddFuncInfo(nodes_need_compile[j]->Name(), node_compute_funcs[j].compute_func,
+                                                   node_compute_funcs[j].create_state_func,
+                                                   node_compute_funcs[j].release_state_func));
       }
       for (auto* node : nodes_need_compile) {
         //prepare the func kernel
         KernelDefBuilder builder;
         BuildFusedKernelDef(builder, *node);
-        fused_kernel_registry->Register(builder, [](const OpKernelInfo& info) { return new FunctionKernel(info); });
+        ORT_RETURN_IF_ERROR(fused_kernel_registry->Register(
+            builder, [](const OpKernelInfo& info) { return new FunctionKernel(info); }));
       }
     }
   }
 
-  ORT_ENFORCE(graph.Resolve().IsOK());
+  ORT_RETURN_IF_ERROR(graph.Resolve());
 
   // To see if the node with no provider can be inlined. If one such nodes can be
   // successfully inlined, we re-run the partitioner on the modified graph.
@@ -183,10 +197,9 @@ Status GraphPartitioner::Partition(Graph& graph, bool export_dll, FuncManager& f
       if (nullptr == node_func) {
         continue;
       }
-      Status inliner_status = graph.InlineFunction(node);
       // If the node has a functionbody with no kernel and cannot be inlined
       // it is a invalid function
-      if (!inliner_status.IsOK()) return inliner_status;
+      ORT_RETURN_IF_ERROR(graph.InlineFunction(node));
       // Set the flag for re-run graph partition after successful inlining
       inline_flag = true;
       break;
@@ -212,7 +225,7 @@ Status GraphPartitioner::Partition(Graph& graph, bool export_dll, FuncManager& f
   }
 #endif
 
-  kernel_registry_mgr_.RegisterKernelRegistry(fused_kernel_registry, KernelRegistryPriority::HighPriority);
+  if (!fused_kernel_registry->IsEmpty()) kernel_registry_mgr_.RegisterKernelRegistry(fused_kernel_registry);
 
   return Status::OK();
 }

--- a/onnxruntime/core/framework/kernel_registry.cc
+++ b/onnxruntime/core/framework/kernel_registry.cc
@@ -113,25 +113,6 @@ class TypeBindingResolver {
 };
 };  // namespace
 
-std::vector<std::string> KernelRegistry::GetAllRegisteredOpNames() const {
-  std::vector<std::string> ret(kernel_creator_fn_map_.size());
-  size_t i = 0;
-  for (const auto& kvp : kernel_creator_fn_map_) {
-    ret[i++] = kvp.first;
-  }
-  return ret;
-}
-
-// Check whether the types of inputs/outputs of the given node match the extra
-// type-constraints of the given kernel. This serves two purposes: first, to
-// select the right kernel implementation based on the types of the arguments
-// when we have multiple kernels, e.g., Clip<float> and Clip<int>; second, to
-// accommodate (and check) mapping of ONNX (specification) type to the onnxruntime
-// implementation type (e.g., if we want to implement ONNX's float16 as a regular
-// float in onnxruntime). (The second, however, requires a globally uniform mapping.)
-//
-// Note that this is not intended for type-checking the node against the ONNX
-// type specification of the corresponding op, which is done before this check.
 bool KernelRegistry::VerifyKernelDef(const onnxruntime::Node& node,
                                      const KernelDef& kernel_def,
                                      std::string& error_str,
@@ -258,12 +239,10 @@ Status KernelRegistry::Register(KernelCreateInfo&& create_info) {
   return Status::OK();
 }
 
-Status KernelRegistry::CreateKernel(const onnxruntime::Node& node,
-                                    const IExecutionProvider& execution_provider,
-                                    const std::unordered_map<int, MLValue>& initialized_tensors,
-                                    const MLValueNameIdxMap& mlvalue_name_idx_map,
-                                    const FuncManager& funcs_mgr,
-                                    /*out*/ std::unique_ptr<OpKernel>& op_kernel) const {
+Status KernelRegistry::TryCreateKernel(const onnxruntime::Node& node, const IExecutionProvider& execution_provider,
+                                       const std::unordered_map<int, MLValue>& initialized_tensors,
+                                       const MLValueNameIdxMap& mlvalue_name_idx_map, const FuncManager& funcs_mgr,
+                                       /*out*/ std::unique_ptr<OpKernel>& op_kernel) const {
   const KernelCreateInfo* kernel_create_info = TryFindKernel(node, execution_provider.Type());
 
   if (!kernel_create_info) {
@@ -287,6 +266,11 @@ static std::string ToString(const std::vector<std::string>& error_strs) {
   return ostr.str();
 }
 
+// TODO: return a Status instead of logging error messages here.
+// Because this function often returns nullptr, which is totally expected.
+// if this function is called before graph partition, then node.provider is not set.
+// In this case, the kernel's provider must equal to exec_provider
+// otherwise, kernel_def.provider must equal to node.provider. exec_provider is ignored.
 const KernelCreateInfo* KernelRegistry::TryFindKernel(const onnxruntime::Node& node,
                                                       onnxruntime::ProviderType exec_provider) const {
   auto range = kernel_creator_fn_map_.equal_range(node.OpType());
@@ -303,7 +287,9 @@ const KernelCreateInfo* KernelRegistry::TryFindKernel(const onnxruntime::Node& n
     }
     error_strs.push_back(error_str);
   }
-  LOGS_DEFAULT(INFO) << node.OpType() << " kernel is not supported in " << exec_provider
+  std::string expected_provider =
+      (node.GetExecutionProviderType().empty() ? exec_provider : node.GetExecutionProviderType());
+  LOGS_DEFAULT(INFO) << node.OpType() << " kernel is not supported in " << expected_provider
                      << " Encountered following errors: " << ToString(error_strs);
   return nullptr;
 }

--- a/onnxruntime/core/framework/kernel_registry_manager.h
+++ b/onnxruntime/core/framework/kernel_registry_manager.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <vector>
 #include <list>
+#include <unordered_map>
 #include "core/common/status.h"
 #include "core/platform/ort_mutex.h"
 #include "core/graph/graph_viewer.h"
@@ -17,47 +18,70 @@ class KernelRegistry;
 class OpKernel;
 class SessionState;
 
-enum class KernelRegistryPriority {
-  HighPriority,
-  LowPriority
-};
-
 // Kernel registries' manager.
 // There're 2 kinds of kernel registries with priority from high to low as below,
 // 1. Custom execution provider type specific kernel registries.
 // 2. common execution provider type specific kernel registries.
 // The 1st and 2nd ones are shared across sessions.
+
+// This class is thread safe
 class KernelRegistryManager {
  public:
   KernelRegistryManager() = default;
 
-  void RegisterKernels(const ExecutionProviders& execution_providers,
-                       KernelRegistryPriority priority = KernelRegistryPriority::LowPriority);
+  // Register kernels from providers
+  Status RegisterKernels(const ExecutionProviders& execution_providers);
 
-  void RegisterKernelRegistry(std::shared_ptr<KernelRegistry> kernel_registry, KernelRegistryPriority priority);
+  // The registry passed in this function has highest priority than anything already in this KernelRegistryManager,
+  // and anything registered from RegisterKernels
+  // For example, if you do:
+  // RegisterKernels(providers)
+  // RegisterKernelRegistry(A);
+  // RegisterKernelRegistry(B);
+  // Then B > A > providers
+  void RegisterKernelRegistry(std::shared_ptr<KernelRegistry> kernel_registry);
 
+  // This function assumes the node is already assigned to an execution provider
+  // Don't call this function before graph partition is done
   Status CreateKernel(const onnxruntime::Node& node,
                       const IExecutionProvider& execution_provider,
                       const SessionState& session_state,
                       /*out*/ std::unique_ptr<OpKernel>& op_kernel) const;
 
+  // This function assumes the node is already assigned to an execution provider
+  // Don't call this function before graph partition is done
   Status SearchKernelRegistry(const onnxruntime::Node& node,
                               /*out*/ const KernelCreateInfo** kernel_create_info) const;
 
-  // Get all kernel registries. There are no nullptr entries.
-  std::vector<const KernelRegistry*> GetAllKernelRegistries() const {
+  /**
+   * Whether this node can be run on this provider
+   */
+  bool HasImplementationOf(const Node& node, const std::string& provider_type) const;
+
+  /**
+   * Search kernel registry by provider type.
+   * @param type provider type string
+   * @return It returns all the possible results. The returned value may contain garbage that doesn't belong to
+   *         this provider. Caller should do the filtering. The returned value won't have no nullptrs.
+   */
+  std::vector<const KernelRegistry*> GetKernelRegistriesByProviderType(const std::string& type) const {
     std::vector<const KernelRegistry*> result;
-    for (auto& registry : kernel_registries_) {
+    for (auto& registry : custom_kernel_registries_) {
       result.push_back(registry.get());
     }
+    auto iter = provider_type_to_registry_.find(type);
+    if (iter != provider_type_to_registry_.end()) result.push_back(iter->second.get());
     return result;
   }
 
- private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(KernelRegistryManager);
 
-  // This list stores all kernel registries shared across sessions, including common ones and customized ones.
-  std::list<std::shared_ptr<KernelRegistry>> kernel_registries_;
+ private:
+  // key is provider type. Each kernel registry in this collection only belongs to one specific provider
+  std::unordered_map<std::string, std::shared_ptr<KernelRegistry>> provider_type_to_registry_;
+  // Each kernel registry may contain kernels from many different providers.
+  // in order to search kernels from a specific provider, we have to iterate all its elements
+  std::list<std::shared_ptr<KernelRegistry>> custom_kernel_registries_;
   mutable OrtMutex lock_;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -127,15 +127,22 @@ class SessionState {
   bool GetEnableMemoryPattern() const;
 
   struct NodeInfo {
+    /**
+     *
+     * \param index0
+     * \param p_node0 Nullable
+     * \param kci0 Nullable
+     */
     NodeInfo(size_t index0, const onnxruntime::Node* p_node0, const KernelCreateInfo* kci0)
         : index(index0),
           p_node(p_node0),
           kci(kci0) {
     }
-    NodeInfo() = default;
 
     size_t index;
+    // Nullable
     const onnxruntime::Node* p_node = nullptr;
+    // Nullable
     const KernelCreateInfo* kci = nullptr;
   };
 

--- a/onnxruntime/core/framework/session_state_initializer.h
+++ b/onnxruntime/core/framework/session_state_initializer.h
@@ -20,6 +20,7 @@ namespace logging {
 class Logger;
 }
 
+// Don't use this class before graph partition is done
 class SessionStateInitializer {
  public:
   SessionStateInitializer(onnxruntime::Graph& graph,

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -17,19 +17,6 @@
 
 namespace onnxruntime {
 namespace utils {
-
-const KernelDef* GetKernelDef(const KernelRegistryManager& kernel_registry,
-                              const onnxruntime::Node& node) {
-  const KernelCreateInfo* kernel_create_info = nullptr;
-  const KernelDef* kernel_def = nullptr;
-
-  if (kernel_registry.SearchKernelRegistry(node, &kernel_create_info).IsOK()) {
-    kernel_def = kernel_create_info->kernel_def.get();
-  }
-
-  return kernel_def;
-}
-
 AllocatorPtr GetAllocator(const ExecutionProviders& exec_providers, const OrtAllocatorInfo& allocator_info) {
   return exec_providers.GetAllocator(allocator_info);
 }
@@ -48,8 +35,9 @@ common::Status AllocateHelper(const IExecutionProvider& execution_provider,
   }
 
   void* buffer = nullptr;
-  if (fetched_tensor.Size() != 0) {
-    buffer = allocator->Alloc(fetched_tensor.Size());
+  const size_t len = fetched_tensor.Size();
+  if (len != 0) {
+    buffer = allocator->Alloc(len);
     if (!buffer) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to allocate buffer. Execution provider type=",
                              execution_provider.Type());

--- a/onnxruntime/core/framework/utils.h
+++ b/onnxruntime/core/framework/utils.h
@@ -26,8 +26,6 @@ class Logger;
 }
 
 namespace utils {
-const KernelDef* GetKernelDef(const KernelRegistryManager& kernel_registry,
-                              const onnxruntime::Node& node);
 
 AllocatorPtr GetAllocator(const ExecutionProviders& exec_providers, const OrtAllocatorInfo& allocator_info);
 

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -90,7 +90,7 @@ Model::Model(std::unique_ptr<ModelProto> model_proto, const IOnnxRuntimeOpSchema
         " specifies which version of the ONNX OperatorSet is being imported.");
   }
 
-  model_proto_.reset(std::move(model_proto.release()));
+  model_proto_ = std::move(model_proto);
   for (auto& prop : model_proto_->metadata_props()) {
     model_metadata_[prop.key()] = prop.value();
   }

--- a/onnxruntime/core/providers/cpu/cpu_execution_provider.h
+++ b/onnxruntime/core/providers/cpu/cpu_execution_provider.h
@@ -45,9 +45,9 @@ class CPUExecutionProvider : public IExecutionProvider {
     return onnxruntime::kCpuExecutionProvider;
   }
 
-  virtual std::vector<std::unique_ptr<ComputeCapability>>
-  GetCapability(const onnxruntime::GraphViewer& graph,
-                const std::vector<const KernelRegistry*>& kernel_registries) const override;
+  std::vector<std::unique_ptr<ComputeCapability>> GetCapability(
+      const onnxruntime::GraphViewer& graph,
+      const std::vector<const KernelRegistry*>& kernel_registries) const override;
 
   ///requires src.buffer_deleter_ == nullptr
   Status CopyTensor(const Tensor&, Tensor&) const override {
@@ -59,7 +59,7 @@ class CPUExecutionProvider : public IExecutionProvider {
     return nullptr;
   }
 
-  virtual std::shared_ptr<KernelRegistry> GetKernelRegistry() const override;
+  std::shared_ptr<KernelRegistry> GetKernelRegistry() const override;
 
   void InsertFusedRules(FuseRuleFn rule);
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -129,7 +129,7 @@ class InferenceSession::Impl {
     }
 
     // Insert session-level customized kernel registry.
-    kernel_registry_manager_.RegisterKernelRegistry(custom_registry, KernelRegistryPriority::HighPriority);
+    kernel_registry_manager_.RegisterKernelRegistry(custom_registry);
     custom_schema_registries_.push_back(custom_registry);
     return Status::OK();
   }
@@ -235,6 +235,20 @@ class InferenceSession::Impl {
 
     // Insert cast node/s.
     ORT_RETURN_IF_ERROR(insert_cast_transformer.Apply(graph, modified));
+
+    // Now every node should be already assigned to an execution provider
+    for (auto& node : graph.Nodes()) {
+      if (node.GetExecutionProviderType().empty()) {
+        std::ostringstream oss;
+        oss << "Could not find an implementation for the node ";
+        if (!node.Name().empty()) oss << node.Name() << ":";
+        oss << node.OpType();
+        if (node.Op()) {
+          oss << "(" << node.Op()->since_version() << ")";
+        }
+        return Status(common::ONNXRUNTIME, common::NOT_IMPLEMENTED, oss.str());
+      }
+    }
 
     std::vector<std::string> provider_types;
     for (auto& provider_ptr : providers) {
@@ -342,7 +356,7 @@ class InferenceSession::Impl {
       // The 1st ones should have already been registered via session-level API into KernelRegistryManager.
       //
       // Register 2nd registries into KernelRegistryManager.
-      kernel_registry_manager_.RegisterKernels(execution_providers_, KernelRegistryPriority::LowPriority);
+      ORT_RETURN_IF_ERROR(kernel_registry_manager_.RegisterKernels(execution_providers_));
 
       SessionStateInitializer session_initializer{graph, session_state_, execution_providers_,
                                                   kernel_registry_manager_};

--- a/onnxruntime/test/framework/allocation_planner_test.cc
+++ b/onnxruntime/test/framework/allocation_planner_test.cc
@@ -232,15 +232,14 @@ class PlannerTest : public ::testing::Test {
 
     auto cpu_execution_provider = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
     KernelRegistryManager kernel_registry_manager;
-    kernel_registry_manager.RegisterKernelRegistry(cpu_execution_provider->GetKernelRegistry(), KernelRegistryPriority::LowPriority);
-
     ExecutionProviders execution_providers;
     execution_providers.Add(onnxruntime::kCpuExecutionProvider, std::move(cpu_execution_provider));
+    auto status = kernel_registry_manager.RegisterKernels(execution_providers);
+    EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
 
     SequentialPlannerTestContext test_context(&shape_map_);
-    auto status = SequentialPlanner::CreatePlan(
-        GraphViewer(graph_), outer_scope_node_args, execution_providers, kernel_registry_manager,
-        mlvalue_name_idx_map, test_context, plan_);
+    status = SequentialPlanner::CreatePlan(GraphViewer(graph_), outer_scope_node_args, execution_providers,
+                                           kernel_registry_manager, mlvalue_name_idx_map, test_context, plan_);
 
     EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
     AllocationPlanTestUtility::BasicIntegrityCheck(*plan_, name_to_arg_.size());

--- a/onnxruntime/test/framework/execution_frame_test.cc
+++ b/onnxruntime/test/framework/execution_frame_test.cc
@@ -47,12 +47,11 @@ TEST(ExecutionFrameTest, TensorAllocationTest) {
 
   auto cpu_xp = CreateCPUExecutionProvider();
   auto xp_typ = cpu_xp->Type();
-
-  KernelRegistryManager kernel_registry_manager;
-  kernel_registry_manager.RegisterKernelRegistry(cpu_xp->GetKernelRegistry(), KernelRegistryPriority::LowPriority);
-
   ExecutionProviders execution_providers;
   execution_providers.Add(xp_typ, std::move(cpu_xp));
+  KernelRegistryManager kernel_registry_manager;
+  status = kernel_registry_manager.RegisterKernels(execution_providers);
+  EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
 
   SessionState state{execution_providers};
   state.SetGraphViewer(std::make_unique<GraphViewer>(graph));
@@ -133,10 +132,9 @@ TEST(ExecutionFrameTest, FeedInDataTest) {
   auto xp_typ = cpu_xp->Type();
 
   KernelRegistryManager kernel_registry_manager;
-  kernel_registry_manager.RegisterKernelRegistry(cpu_xp->GetKernelRegistry(), KernelRegistryPriority::LowPriority);
-
   ExecutionProviders execution_providers;
-  execution_providers.Add("", std::move(cpu_xp));
+  execution_providers.Add(xp_typ, std::move(cpu_xp));
+  EXPECT_TRUE(kernel_registry_manager.RegisterKernels(execution_providers).IsOK());
 
   SessionState state{execution_providers};
   state.SetGraphViewer(std::make_unique<GraphViewer>(graph));
@@ -185,7 +183,7 @@ TEST(ExecutionFrameTest, MemPatternTest) {
   EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
 
   KernelRegistryManager kernel_registry_manager;
-  kernel_registry_manager.RegisterKernelRegistry(cpu_xp->GetKernelRegistry(), KernelRegistryPriority::LowPriority);
+  kernel_registry_manager.RegisterKernelRegistry(cpu_xp->GetKernelRegistry());
 
   ExecutionProviders execution_providers;
   execution_providers.Add(xp_type, std::move(cpu_xp));

--- a/onnxruntime/test/framework/memcpy_transformer_test.cc
+++ b/onnxruntime/test/framework/memcpy_transformer_test.cc
@@ -97,7 +97,7 @@ TEST(TransformerTest, MemcpyTransformerTest) {
 
   auto cpu_execution_provider = TestCPUExecutionProvider();
   KernelRegistryManager test_registry_manager;
-  test_registry_manager.RegisterKernelRegistry(cpu_execution_provider->GetKernelRegistry(), KernelRegistryPriority::LowPriority);
+  test_registry_manager.RegisterKernelRegistry(cpu_execution_provider->GetKernelRegistry());
 
   MemcpyTransformer transformer({onnxruntime::kCudaExecutionProvider}, test_registry_manager);
 
@@ -143,8 +143,7 @@ TEST(TransformerTest, MemcpyTransformerTestCudaFirst) {
 
   auto cpu_execution_provider = TestCPUExecutionProvider();
   KernelRegistryManager test_registry_manager;
-  test_registry_manager.RegisterKernelRegistry(cpu_execution_provider->GetKernelRegistry(),
-                                               KernelRegistryPriority::LowPriority);
+  test_registry_manager.RegisterKernelRegistry(cpu_execution_provider->GetKernelRegistry());
 
   MemcpyTransformer transformer({onnxruntime::kCudaExecutionProvider}, test_registry_manager);
 

--- a/onnxruntime/test/onnx/microbenchmark/model_init.cc
+++ b/onnxruntime/test/onnx/microbenchmark/model_init.cc
@@ -1,0 +1,222 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <benchmark/benchmark.h>
+#include <core/graph/model.h>
+#include <core/framework/execution_providers.h>
+#include <core/framework/kernel_registry_manager.h>
+#include <core/framework/session_state.h>
+#include <core/framework/graph_partitioner.h>
+#include <core/providers/cpu/cpu_execution_provider.h>
+#ifdef USE_CUDA
+#include <core/providers/cuda/cuda_execution_provider.h>
+#endif
+#ifdef USE_MKLDNN
+#include <core/providers/mkldnn/mkldnn_execution_provider.h>
+#endif
+#include <core/platform/env.h>
+#include <core/graph/onnx_protobuf.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <google/protobuf/text_format.h>
+using namespace google::protobuf::io;
+
+constexpr const char* model_str =
+    "ir_version: 4\n"
+    "graph {\n"
+    "  node {\n"
+    "    input: \"X\"\n"
+    "    input: \"X\"\n"
+    "    output: \"Y\"\n"
+    "    op_type: \"MatMul\"\n"
+    "  }\n"
+    "  name: \"test-model\"\n"
+    "  input {\n"
+    "    name: \"X\"\n"
+    "    type {\n"
+    "      tensor_type {\n"
+    "        elem_type: 1\n"
+    "        shape {\n"
+    "          dim {\n"
+    "            dim_value: 2\n"
+    "          }\n"
+    "          dim {\n"
+    "            dim_value: 2\n"
+    "          }\n"
+    "        }\n"
+    "      }\n"
+    "    }\n"
+    "  }\n"
+    "  output {\n"
+    "    name: \"Y\"\n"
+    "    type {\n"
+    "      tensor_type {\n"
+    "        elem_type: 1\n"
+    "        shape {\n"
+    "          dim {\n"
+    "            dim_value: 2\n"
+    "          }\n"
+    "          dim {\n"
+    "            dim_value: 2\n"
+    "          }\n"
+    "        }\n"
+    "      }\n"
+    "    }\n"
+    "  }\n"
+    "}\n"
+    "opset_import {\n"
+    "  version: 8\n"
+    "}";
+
+using namespace onnxruntime;
+
+#define BM_BREAK_IF_ERROR(expr)                                                 \
+  do {                                                                          \
+    auto _status = (expr);                                                      \
+    if ((!_status.IsOK())) state.SkipWithError(_status.ErrorMessage().c_str()); \
+  } while (0)
+
+Status CreateModelFromStr(const char* str, std::unique_ptr<Model>* out) {
+  onnx::ModelProto mp;
+  if (!google::protobuf::TextFormat::ParseFromString(str, &mp)) throw std::runtime_error("load model failed");
+  *out = std::make_unique<Model>(mp);
+  return Status::OK();
+}
+
+Status CreateExecutionProviders(std::unique_ptr<ExecutionProviders>* ret) {
+  std::unique_ptr<ExecutionProviders> execution_providers = std::make_unique<ExecutionProviders>();
+#ifdef USE_CUDA
+  {
+    CUDAExecutionProviderInfo epi;
+    ORT_RETURN_IF_ERROR(
+        execution_providers->Add(onnxruntime::kCudaExecutionProvider, std::make_unique<CUDAExecutionProvider>(epi)));
+  }
+#endif
+#ifdef USE_MKLDNN
+  {
+    MKLDNNExecutionProviderInfo epi;
+    ORT_RETURN_IF_ERROR(execution_providers->Add(onnxruntime::kMklDnnExecutionProvider,
+                                                 std::make_unique<MKLDNNExecutionProvider>(epi)));
+  }
+#endif
+  {
+    CPUExecutionProviderInfo epi;
+    ORT_RETURN_IF_ERROR(
+        execution_providers->Add(onnxruntime::kCpuExecutionProvider, std::make_unique<CPUExecutionProvider>(epi)));
+  }
+  *ret = std::move(execution_providers);
+  return Status::OK();
+}
+
+Status CreateKernelRegistryManagerFromModel(std::unique_ptr<KernelRegistryManager>* ret, Model* model) {
+  std::unique_ptr<ExecutionProviders> execution_providers;
+  ORT_RETURN_IF_ERROR(CreateExecutionProviders(&execution_providers));
+  std::unique_ptr<KernelRegistryManager> kernel_registry_manager = std::make_unique<KernelRegistryManager>();
+  ORT_RETURN_IF_ERROR(kernel_registry_manager->RegisterKernels(*execution_providers));
+  SessionState s{*execution_providers};
+  s.SetLogger(logging::LoggingManager::DefaultLogger());
+
+  ORT_RETURN_IF_ERROR(model->MainGraph().Resolve());
+  s.SetGraphViewer(std::make_unique<GraphViewer>(model->MainGraph()));
+  GraphPartitioner partitioner(*kernel_registry_manager, *execution_providers);
+  ORT_RETURN_IF_ERROR(partitioner.Partition(model->MainGraph(), s.ExportDll(), s.GetMutableFuncMgr()));
+  *ret = std::move(kernel_registry_manager);
+  return Status::OK();
+}
+
+static void SearchKernelRegistry_IMPL(benchmark::State& state, Model* model) {
+  std::unique_ptr<KernelRegistryManager> kernel_registry_manager;
+  auto st = CreateKernelRegistryManagerFromModel(&kernel_registry_manager, model);
+  if (!st.IsOK()) throw std::runtime_error("failed");
+  for (auto _ : state) {
+    for (const auto& n : model->MainGraph().Nodes()) {
+      const KernelCreateInfo* info;
+      BM_BREAK_IF_ERROR(kernel_registry_manager->SearchKernelRegistry(n, &info));
+      if (info == nullptr) state.SkipWithError("Search kernel failed");
+    }
+  }
+}
+
+static void BM_SearchKernelRegistry_SingleNodeModel(benchmark::State& state) {
+  std::unique_ptr<Model> model;
+  Status st = CreateModelFromStr(model_str, &model);
+  if (!st.IsOK()) throw std::runtime_error("failed");
+  SearchKernelRegistry_IMPL(state, model.get());
+}
+
+BENCHMARK(BM_SearchKernelRegistry_SingleNodeModel);
+
+static void BM_SearchKernelRegistry_RealModel_tiny_yolo(benchmark::State& state) {
+  std::shared_ptr<onnxruntime::Model> model;
+  auto st = onnxruntime::Model::Load("../models/opset8/test_tiny_yolov2/model.onnx", model);
+  SearchKernelRegistry_IMPL(state, model.get());
+}
+
+BENCHMARK(BM_SearchKernelRegistry_RealModel_tiny_yolo);
+
+static void BM_SearchKernelRegistry_RealModel_inception_v4(benchmark::State& state) {
+  std::shared_ptr<onnxruntime::Model> model;
+  auto st = onnxruntime::Model::Load("../models/opset9/tf_inception_v4/model.onnx", model);
+  SearchKernelRegistry_IMPL(state, model.get());
+}
+
+BENCHMARK(BM_SearchKernelRegistry_RealModel_inception_v4);
+
+static void BM_PartitionModel_tiny_yolo(benchmark::State& state) {
+  int fd;
+  Status status = Env::Default().FileOpenRd("../models/opset8/test_tiny_yolov2/model.onnx", fd);
+  if (!status.IsOK()) throw std::runtime_error("open test data failed");
+  auto raw_input = std::unique_ptr<ZeroCopyInputStream>(std::make_unique<FileInputStream>(fd));
+  auto coded_input = std::make_unique<CodedInputStream>(raw_input.get());
+
+  onnx::ModelProto model_proto;
+  if (!model_proto.ParseFromCodedStream(coded_input.get())) throw std::runtime_error("open test data failed");
+  std::unique_ptr<ExecutionProviders> execution_providers;
+  BM_BREAK_IF_ERROR(CreateExecutionProviders(&execution_providers));
+  std::unique_ptr<KernelRegistryManager> kernel_registry_manager = std::make_unique<KernelRegistryManager>();
+  status = kernel_registry_manager->RegisterKernels(*execution_providers);
+  if (!status.IsOK()) throw std::runtime_error("RegisterKernels failed");
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::shared_ptr<onnxruntime::Model> model = std::make_shared<onnxruntime::Model>(model_proto);
+    SessionState s{*execution_providers};
+    s.SetLogger(logging::LoggingManager::DefaultLogger());
+    BM_BREAK_IF_ERROR(model->MainGraph().Resolve());
+    s.SetGraphViewer(std::make_unique<GraphViewer>(model->MainGraph()));
+    GraphPartitioner partitioner(*kernel_registry_manager, *execution_providers);
+    state.ResumeTiming();
+    BM_BREAK_IF_ERROR(partitioner.Partition(model->MainGraph(), s.ExportDll(), s.GetMutableFuncMgr()));
+  }
+}
+
+BENCHMARK(BM_PartitionModel_tiny_yolo);
+
+static void BM_PartitionModel_inception_v4(benchmark::State& state) {
+  int fd;
+  Status status = Env::Default().FileOpenRd("../models/opset9/tf_inception_v4/model.onnx", fd);
+  if (!status.IsOK()) throw std::runtime_error("open test data failed");
+  auto raw_input = std::unique_ptr<ZeroCopyInputStream>(std::make_unique<FileInputStream>(fd));
+  auto coded_input = std::make_unique<CodedInputStream>(raw_input.get());
+
+  onnx::ModelProto model_proto;
+  if (!model_proto.ParseFromCodedStream(coded_input.get())) throw std::runtime_error("open test data failed");
+  std::unique_ptr<ExecutionProviders> execution_providers;
+  BM_BREAK_IF_ERROR(CreateExecutionProviders(&execution_providers));
+  std::unique_ptr<KernelRegistryManager> kernel_registry_manager = std::make_unique<KernelRegistryManager>();
+  status = kernel_registry_manager->RegisterKernels(*execution_providers);
+  if (!status.IsOK()) throw std::runtime_error("RegisterKernels failed");
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::shared_ptr<onnxruntime::Model> model = std::make_shared<onnxruntime::Model>(model_proto);
+    SessionState s{*execution_providers};
+    s.SetLogger(logging::LoggingManager::DefaultLogger());
+    BM_BREAK_IF_ERROR(model->MainGraph().Resolve());
+    s.SetGraphViewer(std::make_unique<GraphViewer>(model->MainGraph()));
+    GraphPartitioner partitioner(*kernel_registry_manager, *execution_providers);
+    state.ResumeTiming();
+    BM_BREAK_IF_ERROR(partitioner.Partition(model->MainGraph(), s.ExportDll(), s.GetMutableFuncMgr()));
+  }
+}
+
+BENCHMARK(BM_PartitionModel_inception_v4);

--- a/onnxruntime/test/onnx/runner.cc
+++ b/onnxruntime/test/onnx/runner.cc
@@ -485,7 +485,7 @@ void SeqTestRunner::Start(ORT_CALLBACK_INSTANCE pci, size_t) {
 void RunSingleTestCase(ITestCase* info, const onnxruntime::SessionOptionsWrapper& sf, size_t concurrent_runs, size_t repeat_count, PThreadPool tpool, ORT_CALLBACK_INSTANCE pci, TestCaseCallBack on_finished) {
   std::shared_ptr<TestCaseResult> ret;
   size_t data_count = info->GetDataCount();
-  {
+  try {
     DataRunner* r = nullptr;
     std::string node_name;
     Status status = info->GetNodeName(&node_name);
@@ -510,6 +510,10 @@ void RunSingleTestCase(ITestCase* info, const onnxruntime::SessionOptionsWrapper
     session_object.release();
     r->Start(pci, concurrent_runs);
     return;
+  } catch (onnxruntime::NotImplementedException& ex) {
+    LOGF_DEFAULT(ERROR, "Test %s failed:%s", info->GetTestCaseName().c_str(), ex.what());
+    std::string node_name;
+    ret = std::make_shared<TestCaseResult>(data_count, EXECUTE_RESULT::NOT_SUPPORT, "");
   }
 end:
   on_finished(ret, pci);


### PR DESCRIPTION
Before this change,
If there are 3 providers, GPU, CPU, mkldnn
Then for each node, KernelRegistry::TryFindKernel will be called 3x3 = 9 times, instead of 3.
N providers need O(N^2) searches. It should be O(N).

Perf result:

**Baseline**:

Benchmark                  |Time          | CPU |Iterations
------------------------|------------|-------|------------
BM_SearchKernelRegistry_SingleNodeModel            |245 ns        |244 ns  |172212113
BM_SearchKernelRegistry_RealModel_tiny_yolo       |9551 ns       |9540 ns    |4412595
BM_SearchKernelRegistry_RealModel_inception_v4       |149148 ns       |148933 ns    |281947
BM_PartitionModel_tiny_yolo       |1971998 ns    |1961591 ns       |1435
BM_PartitionModel_inception_v4    |4453991 ns    |4443086 ns        |626

New code:

Benchmark                                                                     |Time                |Time Diff   |  CPU |Iterations
----------------------------------------------------------- |----------------|-------|-------|-------------------
BM_SearchKernelRegistry_SingleNodeModel                |291 ns             | +19%|291 ns  |143936682
BM_SearchKernelRegistry_RealModel_tiny_yolo            |11401 ns         |+19% |11389 ns    |3681155
BM_SearchKernelRegistry_RealModel_inception_v4      |138977 ns       |-7%    | 138789 ns    |302019
BM_PartitionModel_tiny_yolo                                        |1686156 ns     |-16%  | 1676349 ns       |1673
BM_PartitionModel_inception_v4                                  |1683208 ns     |-62%  |1676687 ns       |1656



For each kernel search call, it's about 20 percent slower.
However, overall, the graph partition process is significantly faster. And the new implementation works much better on complex models.


