### PR TITLE
Move build dependencies like setuptools wheel numpy into docker image

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -562,7 +562,8 @@ def main():
             cmake_extra_args = ['-A','x64','-T', toolset, '-G', 'Visual Studio 15 2017']
         if is_ubuntu_1604():
             install_ubuntu_deps(args)
-            install_python_deps()
+            if not is_docker():
+                install_python_deps()
         if (args.enable_pybind and is_windows()):
             install_python_deps()
         if (not args.skip_submodule_sync):

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -28,9 +28,6 @@ for build_type in 'Debug' 'Relwithdebinfo'; do
 done
 export ONNX_ML=1
 INSTALLED_PYTHON_VERSION=$(python3 -c 'import sys; version=sys.version_info[:2]; print("{0}.{1}".format(*version));')
-
-pip3 install setuptools wheel numpy
-
 if [ "$INSTALLED_PYTHON_VERSION" = "3.7" ];then
   pip3 install --upgrade setuptools
 fi

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -28,6 +28,9 @@ for build_type in 'Debug' 'Relwithdebinfo'; do
 done
 export ONNX_ML=1
 INSTALLED_PYTHON_VERSION=$(python3 -c 'import sys; version=sys.version_info[:2]; print("{0}.{1}".format(*version));')
+
+pip3 install setuptools wheel numpy
+
 if [ "$INSTALLED_PYTHON_VERSION" = "3.7" ];then
   pip3 install --upgrade setuptools
 fi


### PR DESCRIPTION
Move build dependencies like setuptools wheel numpy into docker image, so won't install them again and again for docker build