### PR TITLE
Optimize pad performance

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/pad.cc
+++ b/onnxruntime/core/providers/cpu/tensor/pad.cc
@@ -70,7 +70,7 @@ static void FlattenInnerShape(const std::vector<int64_t>& input_dims, const std:
         && slices[inner_axis] == 0 && slices[inner_axis + dims_count] == 0))
       break;
 
-  } while (--inner_axis >= 0);
+  } while (inner_axis-- > 0);
 
   reshaped_dims.resize(inner_axis + 1);
   std::copy(input_dims.begin(), input_dims.begin() + inner_axis + 1, reshaped_dims.begin());

--- a/onnxruntime/core/providers/cpu/tensor/pad.cc
+++ b/onnxruntime/core/providers/cpu/tensor/pad.cc
@@ -47,43 +47,48 @@ static void PadAxisConstant(T* output, T constant, size_t size) {
     *output++ = constant;
 }
 
-// Flatten no padding inner most Axis, so one memcpy cover multile Axis.
+// Flatten no padding inner most Axis, so one memcpy cover multiple Axis.
 // For example, for a shape of [1,224,224,3] with padding [0,3,3,0,0,3,3,0], can be flatten as 
-// [1,224,224*3] with padding [0,1,2,0,1,2].
-static void FlattenInnerShape(const std::vector<int64_t>& input_dims, const std::vector<int64_t>& pads, const std::vector<int64_t>& slices, std::vector<int64_t>& reshaped_dims)
+// [1,224,224*3] with padding [0,3,3*3,0,3,3*3].
+static void FlattenInnerShape(const std::vector<int64_t>& input_dims, const std::vector<int64_t>& pads, 
+                              const std::vector<int64_t>& slices, std::vector<int64_t>& reshaped_dims)
 {
-    size_t dims_count = input_dims.size();
-    size_t inner_axis = dims_count - 1;
-    size_t inner_size = 1;
+  size_t dims_count = input_dims.size();
+  size_t inner_axis = dims_count - 1;
+  size_t inner_size = 1;
 
-    // Find all inner most dimensions that can be flattened.
-    do
-    {
-        inner_size *= input_dims[inner_axis];
+  // Find all inner most dimensions that can be flattened.
+  do
+  {
+    inner_size *= input_dims[inner_axis];
 
-        if (inner_axis == 0)
-            break;
+    if (inner_axis == 0)
+      break;
 
-        // Break on first Axis that has padding
-        if (!(pads[inner_axis] == 0 && pads[inner_axis + dims_count] == 0
-            && slices[inner_axis] == 0 && slices[inner_axis + dims_count] == 0))
-            break;
+    // Break on first Axis that has padding
+    if (!(pads[inner_axis] == 0 && pads[inner_axis + dims_count] == 0
+        && slices[inner_axis] == 0 && slices[inner_axis + dims_count] == 0))
+      break;
 
-    } while (--inner_axis >= 0);
+  } while (--inner_axis >= 0);
 
-    reshaped_dims.resize(inner_axis + 1);
-    std::copy(input_dims.begin(), input_dims.begin() + inner_axis + 1, reshaped_dims.begin());
-    reshaped_dims[inner_axis] = inner_size;
+  reshaped_dims.resize(inner_axis + 1);
+  std::copy(input_dims.begin(), input_dims.begin() + inner_axis + 1, reshaped_dims.begin());
+
+  // Flatten inner axis.
+  reshaped_dims[inner_axis] = inner_size;
 }
 
-static void ReshapePads(const std::vector<int64_t>& src_pad, size_t src_dim_count, size_t new_dim_count, size_t inner_no_pad_size, std::vector<int64_t>& reshaped_pad) {
+static void ReshapePads(const std::vector<int64_t>& src_pad, size_t src_dim_count, size_t new_dim_count, 
+                        size_t inner_no_pad_size, std::vector<int64_t>& reshaped_pad) {
 
-    size_t inner_axis = new_dim_count - 1;
-    std::copy(src_pad.begin(), src_pad.begin() + inner_axis, reshaped_pad.begin());
-    std::copy(src_pad.begin() + src_dim_count, src_pad.begin() + src_dim_count + inner_axis, reshaped_pad.begin() + new_dim_count);
+  size_t inner_axis = new_dim_count - 1;
+  std::copy(src_pad.begin(), src_pad.begin() + inner_axis, reshaped_pad.begin());
+  std::copy(src_pad.begin() + src_dim_count, src_pad.begin() + src_dim_count + inner_axis, reshaped_pad.begin() + new_dim_count);
     
-    reshaped_pad[inner_axis] = src_pad[inner_axis] * inner_no_pad_size;
-    reshaped_pad[inner_axis + new_dim_count] = src_pad[inner_axis + src_dim_count] * inner_no_pad_size;
+  // Flatten inner axis.
+  reshaped_pad[inner_axis] = src_pad[inner_axis] * inner_no_pad_size;
+  reshaped_pad[inner_axis + new_dim_count] = src_pad[inner_axis + src_dim_count] * inner_no_pad_size;
 }
 
 template <>
@@ -99,7 +104,7 @@ Status Pad<float>::Compute(OpKernelContext* ctx) const {
   std::vector<int64_t> reshaped_input_dims;
   FlattenInnerShape(output_dims, pads_, slices_, reshaped_input_dims);
 
-  //Reshape padding
+  // Reshape padding
   size_t new_dims_count = reshaped_input_dims.size();
   size_t inner_axis = new_dims_count - 1;
   size_t inner_no_pad_size = reshaped_input_dims[inner_axis] / output_dims[inner_axis];
@@ -121,14 +126,14 @@ Status Pad<float>::Compute(OpKernelContext* ctx) const {
   }
 
   for (size_t i = 0; i < dimension_count; i++) {
-      output_dims[i] += pads_[i] + pads_[i + dimension_count] + slices_[i] + slices_[i + dimension_count];
+    output_dims[i] += pads_[i] + pads_[i + dimension_count] + slices_[i] + slices_[i + dimension_count];
   }
   TensorShape output_shape(output_dims);
 
   TensorShape input_shape(reshaped_input_dims);
   SliceIterator<float> input(input_tensor, input_shape, input_starts, input_extents);
 
-  // output_shape need to keep original
+  // output_shape need to keep original.
   auto& output_tensor = *ctx->Output(0, output_shape);
   auto* output = output_tensor.template MutableData<float>();
 

--- a/onnxruntime/core/providers/cpu/tensor/pad.cc
+++ b/onnxruntime/core/providers/cpu/tensor/pad.cc
@@ -47,6 +47,45 @@ static void PadAxisConstant(T* output, T constant, size_t size) {
     *output++ = constant;
 }
 
+// Flatten no padding inner most Axis, so one memcpy cover multile Axis.
+// For example, for a shape of [1,224,224,3] with padding [0,3,3,0,0,3,3,0], can be flatten as 
+// [1,224,224*3] with padding [0,1,2,0,1,2].
+static void FlattenInnerShape(const std::vector<int64_t>& input_dims, const std::vector<int64_t>& pads, const std::vector<int64_t>& slices, std::vector<int64_t>& reshaped_dims)
+{
+    size_t dims_count = input_dims.size();
+    size_t inner_axis = dims_count - 1;
+    size_t inner_size = 1;
+
+    // Find all inner most dimensions that can be flattened.
+    do
+    {
+        inner_size *= input_dims[inner_axis];
+
+        if (inner_axis == 0)
+            break;
+
+        // Break on first Axis that has padding
+        if (!(pads[inner_axis] == 0 && pads[inner_axis + dims_count] == 0
+            && slices[inner_axis] == 0 && slices[inner_axis + dims_count] == 0))
+            break;
+
+    } while (--inner_axis >= 0);
+
+    reshaped_dims.resize(inner_axis + 1);
+    std::copy(input_dims.begin(), input_dims.begin() + inner_axis + 1, reshaped_dims.begin());
+    reshaped_dims[inner_axis] = inner_size;
+}
+
+static void ReshapePads(const std::vector<int64_t>& src_pad, size_t src_dim_count, size_t new_dim_count, size_t inner_no_pad_size, std::vector<int64_t>& reshaped_pad) {
+
+    size_t inner_axis = new_dim_count - 1;
+    std::copy(src_pad.begin(), src_pad.begin() + inner_axis, reshaped_pad.begin());
+    std::copy(src_pad.begin() + src_dim_count, src_pad.begin() + src_dim_count + inner_axis, reshaped_pad.begin() + new_dim_count);
+    
+    reshaped_pad[inner_axis] = src_pad[inner_axis] * inner_no_pad_size;
+    reshaped_pad[inner_axis + new_dim_count] = src_pad[inner_axis + src_dim_count] * inner_no_pad_size;
+}
+
 template <>
 Status Pad<float>::Compute(OpKernelContext* ctx) const {
   auto& input_tensor = *ctx->Input<Tensor>(0);
@@ -56,29 +95,50 @@ Status Pad<float>::Compute(OpKernelContext* ctx) const {
   ORT_ENFORCE(dimension_count > 0, "Input tensor has no dimensions");
   ORT_ENFORCE(dimension_count * 2 == pads_.size(), "'pads' attribute has wrong number of values");
 
+  // Reshape input dims
+  std::vector<int64_t> reshaped_input_dims;
+  FlattenInnerShape(output_dims, pads_, slices_, reshaped_input_dims);
+
+  //Reshape padding
+  size_t new_dims_count = reshaped_input_dims.size();
+  size_t inner_axis = new_dims_count - 1;
+  size_t inner_no_pad_size = reshaped_input_dims[inner_axis] / output_dims[inner_axis];
+  std::vector<int64_t> reshaped_pad(2 * new_dims_count), reshaped_slice(2 * new_dims_count);
+  ReshapePads(pads_, dimension_count, new_dims_count, inner_no_pad_size, reshaped_pad);
+  ReshapePads(slices_, dimension_count, new_dims_count, inner_no_pad_size, reshaped_slice);
+
+  std::vector<int64_t> reshaped_output_dims = reshaped_input_dims;
   std::vector<int64_t> input_starts;
   std::vector<int64_t> input_extents;
 
   // Calculate output dimensions, and handle any negative padding
+  input_starts.reserve(2 * new_dims_count);
+  input_extents.reserve(2 * new_dims_count);
+  for (size_t i = 0; i < new_dims_count; i++) {
+    input_starts.push_back(reshaped_slice[i]);
+    input_extents.push_back(reshaped_input_dims[i] + reshaped_slice[i] + reshaped_slice[i + new_dims_count]);
+    reshaped_output_dims[i] += reshaped_pad[i] + reshaped_pad[i + new_dims_count] + reshaped_slice[i] + reshaped_slice[i + new_dims_count];
+  }
+
   for (size_t i = 0; i < dimension_count; i++) {
-    input_starts.push_back(slices_[i]);
-    input_extents.push_back(output_dims[i] + slices_[i] + slices_[i + dimension_count]);
-    output_dims[i] += pads_[i] + pads_[i + dimension_count] + slices_[i] + slices_[i + dimension_count];
+      output_dims[i] += pads_[i] + pads_[i + dimension_count] + slices_[i] + slices_[i + dimension_count];
   }
   TensorShape output_shape(output_dims);
 
-  SliceIterator<float> input(input_tensor, input_starts, input_extents);
+  TensorShape input_shape(reshaped_input_dims);
+  SliceIterator<float> input(input_tensor, input_shape, input_starts, input_extents);
+
+  // output_shape need to keep original
   auto& output_tensor = *ctx->Output(0, output_shape);
   auto* output = output_tensor.template MutableData<float>();
 
-  TensorPitches output_pitches(output_tensor);
+  TensorPitches output_pitches(reshaped_output_dims);
   size_t alignSkip = 0;  // Amount to skip to align to where the next input tensor data needs to be written
 
   // Initial skip, sum up the begin padding on each axis
-  for (size_t i = 0; i < dimension_count; i++)
-    alignSkip += pads_[i] * output_pitches[i];
+  for (size_t i = 0; i < new_dims_count; i++)
+    alignSkip += reshaped_pad[i] * output_pitches[i];
 
-  size_t inner_axis = dimension_count - 1;
   ExtentAxisCounters input_counters(input_extents);
 
   switch (mode_) {
@@ -92,8 +152,8 @@ Status Pad<float>::Compute(OpKernelContext* ctx) const {
           float* axisStart = output;
           output = input.CopyInnermostAxis(output);
 
-          int64_t prePad = pads_[inner_axis];
-          int64_t postPad = pads_[inner_axis + dimension_count];
+          int64_t prePad = reshaped_pad[inner_axis];
+          int64_t postPad = reshaped_pad[inner_axis + new_dims_count];
           PadAxisConstant(axisStart - prePad, value_, prePad);
           PadAxisConstant(output, value_, postPad);
           output += postPad;
@@ -103,8 +163,8 @@ Status Pad<float>::Compute(OpKernelContext* ctx) const {
         while (input_counters.Increment()) {
           ptrdiff_t inner_pitch = output_pitches[input_counters.Axis()];
           float* axisStart = output - inner_pitch * input_extents[input_counters.Axis()];
-          int64_t prePad = pads_[input_counters.Axis()];
-          int64_t postPad = pads_[input_counters.Axis() + dimension_count];
+          int64_t prePad = reshaped_pad[input_counters.Axis()];
+          int64_t postPad = reshaped_pad[input_counters.Axis() + new_dims_count];
           PadAxisConstant(axisStart - prePad * inner_pitch, value_, prePad * inner_pitch);
           PadAxisConstant(output, value_, postPad * inner_pitch);
           output += inner_pitch * postPad;
@@ -123,8 +183,8 @@ Status Pad<float>::Compute(OpKernelContext* ctx) const {
           float* axisStart = output;
           output = input.CopyInnermostAxis(output);
 
-          int64_t prePad = pads_[inner_axis];
-          int64_t postPad = pads_[inner_axis + dimension_count];
+          int64_t prePad = reshaped_pad[inner_axis];
+          int64_t postPad = reshaped_pad[inner_axis + new_dims_count];
           PadAxisConstant(axisStart - prePad, *axisStart, prePad);
           PadAxisConstant(output, *(output - 1), postPad);
           output += postPad;
@@ -134,8 +194,8 @@ Status Pad<float>::Compute(OpKernelContext* ctx) const {
         while (input_counters.Increment()) {
           ptrdiff_t inner_pitch = output_pitches[input_counters.Axis()];
           float* axisStart = output - inner_pitch * input_extents[input_counters.Axis()];
-          int64_t prePad = pads_[input_counters.Axis()];
-          int64_t postPad = pads_[input_counters.Axis() + dimension_count];
+          int64_t prePad = reshaped_pad[input_counters.Axis()];
+          int64_t postPad = reshaped_pad[input_counters.Axis() + new_dims_count];
           PadAxis(axisStart - prePad * inner_pitch, axisStart, 1, -inner_pitch, inner_pitch, prePad);
           PadAxis(output, output - inner_pitch, 1, -inner_pitch, inner_pitch, postPad);
           output += inner_pitch * postPad;
@@ -154,8 +214,8 @@ Status Pad<float>::Compute(OpKernelContext* ctx) const {
           float* axisStart = output;
           output = input.CopyInnermostAxis(output);
 
-          int64_t prePad = pads_[inner_axis];
-          int64_t postPad = pads_[inner_axis + dimension_count];
+          int64_t prePad = reshaped_pad[inner_axis];
+          int64_t postPad = reshaped_pad[inner_axis + new_dims_count];
           PadInnermostAxis(axisStart - prePad, axisStart + prePad, -1 /* inputDelta */, prePad);
           PadInnermostAxis(output, output - 2, -1 /* inputDelta */, postPad);
           output += postPad;
@@ -165,8 +225,8 @@ Status Pad<float>::Compute(OpKernelContext* ctx) const {
         while (input_counters.Increment()) {
           ptrdiff_t inner_pitch = output_pitches[input_counters.Axis()];
           float* axisStart = output - inner_pitch * input_extents[input_counters.Axis()];
-          int64_t prePad = pads_[input_counters.Axis()];
-          int64_t postPad = pads_[input_counters.Axis() + dimension_count];
+          int64_t prePad = reshaped_pad[input_counters.Axis()];
+          int64_t postPad = reshaped_pad[input_counters.Axis() + new_dims_count];
           PadAxis(axisStart - prePad * inner_pitch, axisStart + prePad * inner_pitch, 1, -inner_pitch * 2, inner_pitch, prePad);
           PadAxis(output, output - 2 * inner_pitch, 1, -inner_pitch * 2, inner_pitch, postPad);
           output += inner_pitch * postPad;

--- a/onnxruntime/core/providers/cpu/tensor/utils.h
+++ b/onnxruntime/core/providers/cpu/tensor/utils.h
@@ -159,7 +159,7 @@ struct SliceIterator {
   }
 
   // Initialize initial skip and inner_extent.
-  void Init(const std::vector<int64_t> dims, gsl::span<const int64_t> starts) {
+  void Init(const std::vector<int64_t>& dims, gsl::span<const int64_t> starts) {
     size_t pitch = 1;
     // Initial skip, so that input_ points to the first element to copy
     for (size_t i = dims.size(); i-- > 0;) {

--- a/onnxruntime/core/providers/cpu/tensor/utils.h
+++ b/onnxruntime/core/providers/cpu/tensor/utils.h
@@ -141,11 +141,11 @@ template <typename T>
 struct SliceIterator {
     SliceIterator(const Tensor& tensor, gsl::span<const int64_t> starts, gsl::span<const int64_t> extents)
         : tensor_(tensor), extents_(extents), skips_(tensor_.Shape(), extents), indices_(extents.size(), 0) {
-        auto& dims = tensor_.Shape().GetDims();
-        ORT_ENFORCE(static_cast<ptrdiff_t>(dims.size()) == starts.size() && static_cast<ptrdiff_t>(dims.size()) == extents.size());
+    auto& dims = tensor_.Shape().GetDims();
+    ORT_ENFORCE(static_cast<ptrdiff_t>(dims.size()) == starts.size() && static_cast<ptrdiff_t>(dims.size()) == extents.size());
 
-        Init(dims, starts);
-    }
+    Init(dims, starts);
+  }
     
     // This construct takes a explicit tensor_shape which might be different from the shape defined in input tensor.
     // The explicit tensor_shape usually has inner most axis flattened. For example, given shape[1,4,4,2], if last axis
@@ -163,8 +163,8 @@ struct SliceIterator {
     size_t pitch = 1;
     // Initial skip, so that input_ points to the first element to copy
     for (size_t i = dims.size(); i-- > 0;) {
-        input_ += pitch * starts[i];
-        pitch *= dims[i];
+      input_ += pitch * starts[i];
+      pitch *= dims[i];
     }
 
     inner_extent_ = extents_[dims.size() - 1];

--- a/onnxruntime/core/providers/cpu/tensor/utils.h
+++ b/onnxruntime/core/providers/cpu/tensor/utils.h
@@ -122,9 +122,9 @@ struct ExtentAxisCounters {
 // A std::vector that holds the number of entries to skip to go to the next axis start given an extent in each axis
 // This is used by the SliceIterator to iterate over a slice of a tensor
 struct SliceSkips : std::vector<int64_t> {
-  SliceSkips(const Tensor& tensor, gsl::span<const int64_t> extents)
-      : std::vector<int64_t>(tensor.Shape().NumDimensions(), 0) {
-    auto& dims = tensor.Shape().GetDims();
+  SliceSkips(const TensorShape& input_shape, gsl::span<const int64_t> extents)
+      : std::vector<int64_t>(input_shape.NumDimensions(), 0) {
+    auto& dims = input_shape.GetDims();
     ORT_ENFORCE(static_cast<ptrdiff_t>(dims.size()) == extents.size());
     size_t pitch = dims.back();
     back() = pitch - extents[size() - 1];
@@ -139,16 +139,32 @@ struct SliceSkips : std::vector<int64_t> {
 // This provides easy sequential iteration over a subset of a tensor given a span of starts & extents
 template <typename T>
 struct SliceIterator {
-  SliceIterator(const Tensor& tensor, gsl::span<const int64_t> starts, gsl::span<const int64_t> extents)
-      : tensor_(tensor), extents_(extents), skips_(tensor, extents), indices_(extents.size(), 0) {
-    auto& dims = tensor_.Shape().GetDims();
-    ORT_ENFORCE(static_cast<ptrdiff_t>(dims.size()) == starts.size() && static_cast<ptrdiff_t>(dims.size()) == extents.size());
+    SliceIterator(const Tensor& tensor, gsl::span<const int64_t> starts, gsl::span<const int64_t> extents)
+        : tensor_(tensor), extents_(extents), skips_(tensor_.Shape(), extents), indices_(extents.size(), 0) {
+        auto& dims = tensor_.Shape().GetDims();
+        ORT_ENFORCE(static_cast<ptrdiff_t>(dims.size()) == starts.size() && static_cast<ptrdiff_t>(dims.size()) == extents.size());
 
+        Init(dims, starts);
+    }
+    
+    // This construct takes a explicit tensor_shape which might be different from the shape defined in input tensor.
+    // The explicit tensor_shape usually has inner most axis flattened. For example, given shape[1,4,4,2], if last axis
+    // does not have padding or slice, then it will be flattened as [1,4,8] for better performance (One inner most copy instead of 4).
+    SliceIterator(const Tensor& tensor, const TensorShape& tensor_shape, gsl::span<const int64_t> starts, gsl::span<const int64_t> extents)
+      : tensor_(tensor), extents_(extents), skips_(tensor_shape, extents), indices_(extents.size(), 0) {
+    auto& dims = tensor_shape.GetDims();
+    ORT_ENFORCE(static_cast<ptrdiff_t>(dims.size()) == starts.size() && static_cast<ptrdiff_t>(dims.size()) == extents.size());
+    
+    Init(dims, starts);
+  }
+
+  // Initialize initial skip and inner_extent.
+  void Init(const std::vector<int64_t> dims, gsl::span<const int64_t> starts) {
     size_t pitch = 1;
     // Initial skip, so that input_ points to the first element to copy
     for (size_t i = dims.size(); i-- > 0;) {
-      input_ += pitch * starts[i];
-      pitch *= dims[i];
+        input_ += pitch * starts[i];
+        pitch *= dims[i];
     }
 
     inner_extent_ = extents_[dims.size() - 1];

--- a/onnxruntime/core/providers/cpu/tensor/utils.h
+++ b/onnxruntime/core/providers/cpu/tensor/utils.h
@@ -142,7 +142,6 @@ struct SliceIterator {
     SliceIterator(const Tensor& tensor, gsl::span<const int64_t> starts, gsl::span<const int64_t> extents)
         : tensor_(tensor), extents_(extents), skips_(tensor_.Shape(), extents), indices_(extents.size(), 0) {
     auto& dims = tensor_.Shape().GetDims();
-    ORT_ENFORCE(static_cast<ptrdiff_t>(dims.size()) == starts.size() && static_cast<ptrdiff_t>(dims.size()) == extents.size());
 
     Init(dims, starts);
   }
@@ -153,13 +152,15 @@ struct SliceIterator {
     SliceIterator(const Tensor& tensor, const TensorShape& tensor_shape, gsl::span<const int64_t> starts, gsl::span<const int64_t> extents)
       : tensor_(tensor), extents_(extents), skips_(tensor_shape, extents), indices_(extents.size(), 0) {
     auto& dims = tensor_shape.GetDims();
-    ORT_ENFORCE(static_cast<ptrdiff_t>(dims.size()) == starts.size() && static_cast<ptrdiff_t>(dims.size()) == extents.size());
     
     Init(dims, starts);
   }
 
   // Initialize initial skip and inner_extent.
   void Init(const std::vector<int64_t>& dims, gsl::span<const int64_t> starts) {
+
+    ORT_ENFORCE(static_cast<ptrdiff_t>(dims.size()) == starts.size() && static_cast<ptrdiff_t>(dims.size()) == extents_.size());
+
     size_t pitch = 1;
     // Initial skip, so that input_ points to the first element to copy
     for (size_t i = dims.size(); i-- > 0;) {


### PR DESCRIPTION
Optimize pad performance by flatten the inner most no padding axis. This will significantly reduces the total number of memcpy since memcpy usually only happen for inner most axis.

For example, for a shape of [1,224,224,3] with padding [0,3,3,0,0,3,3,0], can be flatten as [1,224,224*3] with padding [0,3,3*3,0,3,3*3].

With this fix, Pad performance can be improved by >7 times for above example.