### PR TITLE
Fix a issue for cuda reduce Max Min

### DIFF
--- a/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
@@ -192,9 +192,8 @@ Status ReduceKernel<allow_multi_axes>::ComputeImpl(OpKernelContext* ctx, cudnnRe
       return Status::OK();
     }
 
-    // Only Max Min need to set ReduceTensorIndices CUDNN_REDUCE_TENSOR_FLATTENED_INDICES as per cudnn library manual
     // Only Max Min will have indices output, need to set the indices to nullptr for other ops
-    if (CUDNN_REDUCE_TENSOR_MAX == ReduceTensorIndices || CUDNN_REDUCE_TENSOR_MIN == ReduceTensorIndices) {
+    if (CUDNN_REDUCE_TENSOR_MAX == cudnnReduceOp || CUDNN_REDUCE_TENSOR_MIN == cudnnReduceOp) {
       size_t indices_bytes = 0;
       CUDNN_RETURN_IF_ERROR(cudnnGetReductionIndicesSize(CudnnHandle(), reduce_desc, input_tensor, output_tensor, &indices_bytes));
       auto indices_cuda = GetScratchBuffer<void>(indices_bytes);

--- a/onnxruntime/core/providers/cuda/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_ops.h
@@ -76,7 +76,7 @@ class ReduceMax final : public ReduceKernel<true> {
   ReduceMax(const OpKernelInfo& info) : ReduceKernel<true>(info) {}
 
   Status ComputeInternal(OpKernelContext* ctx) const override {
-    return ComputeImpl<T, CUDNN_REDUCE_TENSOR_FLATTENED_INDICES>(ctx, CUDNN_REDUCE_TENSOR_MAX);
+    return ComputeImpl<T>(ctx, CUDNN_REDUCE_TENSOR_MAX);
   }
 };
 
@@ -96,7 +96,7 @@ class ReduceMin final : public ReduceKernel<true> {
   ReduceMin(const OpKernelInfo& info) : ReduceKernel<true>(info) {}
 
   Status ComputeInternal(OpKernelContext* ctx) const override {
-    return ComputeImpl<T, CUDNN_REDUCE_TENSOR_FLATTENED_INDICES>(ctx, CUDNN_REDUCE_TENSOR_MIN);
+    return ComputeImpl<T>(ctx, CUDNN_REDUCE_TENSOR_MIN);
   }
 };
 

--- a/onnxruntime/core/providers/cuda/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_ops.h
@@ -17,6 +17,8 @@ class ReduceKernel : public CudaKernel, public ReduceKernelBase<allow_multi_axes
                                            calculate_sqt_(false),
                                            log_sum_exp_(false) {}
 
+  // Only Max Min need to set ReduceTensorIndices CUDNN_REDUCE_TENSOR_FLATTENED_INDICES as per cudnn library manual
+  // Only Max Min will have indices output, need to set the indices to nullptr for other ops
   template <typename T, cudnnReduceTensorIndices_t ReduceTensorIndices = CUDNN_REDUCE_TENSOR_NO_INDICES>
   Status ComputeImpl(OpKernelContext* ctx, cudnnReduceTensorOp_t cudnnReduceOp) const;
 
@@ -74,7 +76,7 @@ class ReduceMax final : public ReduceKernel<true> {
   ReduceMax(const OpKernelInfo& info) : ReduceKernel<true>(info) {}
 
   Status ComputeInternal(OpKernelContext* ctx) const override {
-    return ComputeImpl<T>(ctx, CUDNN_REDUCE_TENSOR_MAX);
+    return ComputeImpl<T, CUDNN_REDUCE_TENSOR_FLATTENED_INDICES>(ctx, CUDNN_REDUCE_TENSOR_MAX);
   }
 };
 
@@ -94,7 +96,7 @@ class ReduceMin final : public ReduceKernel<true> {
   ReduceMin(const OpKernelInfo& info) : ReduceKernel<true>(info) {}
 
   Status ComputeInternal(OpKernelContext* ctx) const override {
-    return ComputeImpl<T>(ctx, CUDNN_REDUCE_TENSOR_MIN);
+    return ComputeImpl<T, CUDNN_REDUCE_TENSOR_FLATTENED_INDICES>(ctx, CUDNN_REDUCE_TENSOR_MIN);
   }
 };
 


### PR DESCRIPTION
Fix a issue for Reduce Max, Min. Per cudnn document, only Max/Min ops requires the indices output, it will report error if requesting indices for the other reduction ops.
