### PR TITLE
allocate 64-bit aligned memory

### DIFF
--- a/onnxruntime/core/session/default_cpu_allocator_c_api.cc
+++ b/onnxruntime/core/session/default_cpu_allocator_c_api.cc
@@ -25,10 +25,29 @@ struct OrtDefaultAllocator : OrtAllocatorImpl {
   }
 
   void* Alloc(size_t size) {
-    return ::malloc(size);
+    if (size == 0)
+      return nullptr;
+    // default align to 64;
+    void* p;
+    size_t alignment = 64;
+#if _MSC_VER
+    p = _aligned_malloc(size, alignment);
+    if (p == nullptr) throw std::bad_alloc();
+#elif defined(_LIBCPP_SGX_CONFIG)
+    p = memalign(alignment, size);
+    if (p == nullptr) throw std::bad_alloc();
+#else
+    int ret = posix_memalign(&p, alignment, size);
+    if (ret != 0) throw std::bad_alloc();
+#endif
+    return p;
   }
   void Free(void* p) {
-    return ::free(p);
+#if _MSC_VER
+    _aligned_free(p);
+#else
+    free(p);
+#endif
   }
   const OrtAllocatorInfo* Info() const {
     return cpuAllocatorInfo;


### PR DESCRIPTION
Similar to our CPUAllocator, let C API's cpu allocator return
64-bit aligned memory, too.