### PR TITLE
Implement DynamicTopK as a contrib_op

### DIFF
--- a/onnxruntime/contrib_ops/contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/contrib_kernels.cc
@@ -29,6 +29,7 @@ class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, ConvI
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, ROIAlign);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, double, ROIAlign);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, QLinearConv);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, DynamicTopK);
 
 void RegisterContribKernels(KernelRegistry& kernel_registry) {
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SampleOp)>());
@@ -56,6 +57,7 @@ void RegisterContribKernels(KernelRegistry& kernel_registry) {
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, ROIAlign)>());
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, double, ROIAlign)>());
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, QLinearConv)>());
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, DynamicTopK)>());
 }
 
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cpu/dynamic_top_k.cc
+++ b/onnxruntime/contrib_ops/cpu/dynamic_top_k.cc
@@ -69,6 +69,7 @@ Status DynamicTopK<float>::Compute(OpKernelContext* p_op_kernel_context) const {
   const vector<int64_t>& y_shape = Y->Shape().GetDims();
   if (y_shape.size() != 1 || y_shape[0] != 1) return Status(common::ONNXRUNTIME, common::FAIL, "k tensor should be a 1D tensor of size 1");	
   const auto k_ = Y->template Data<int64_t>()[0];
+  if (k_ <= 0) return Status(common::ONNXRUNTIME, common::FAIL, "Value of k should be greater than 0");	
   const vector<int64_t>& in_dims = X->Shape().GetDims();
   // Will return axis_ as is if positive or fixes it in case it is negative
   auto axis_parsed = HandleNegativeAxis(axis_, in_dims.size());	

--- a/onnxruntime/contrib_ops/cpu/dynamic_top_k.cc
+++ b/onnxruntime/contrib_ops/cpu/dynamic_top_k.cc
@@ -29,7 +29,7 @@ ONNX_OPERATOR_KERNEL_EX(
 	kCpuExecutionProvider,
 	KernelDefBuilder()
 	.TypeConstraint("T", DataTypeImpl::GetTensorType<float>())
-	.TypeConstraint("I", DataTypeImpl::GetType<int64_t>()),
+    .TypeConstraint("I", DataTypeImpl::GetTensorType<int64_t>()),
 	DynamicTopK<float>);
 
 static int64_t SizeToDim(size_t k, const vector<int64_t>& dims) {

--- a/onnxruntime/contrib_ops/cpu/dynamic_top_k.cc
+++ b/onnxruntime/contrib_ops/cpu/dynamic_top_k.cc
@@ -21,16 +21,16 @@
 #include <queue>
 using namespace std;
 namespace onnxruntime {
-namespace contrib {	
+namespace contrib {
 ONNX_OPERATOR_KERNEL_EX(
-	DynamicTopK,
-	kMSDomain,
-	1,
-	kCpuExecutionProvider,
-	KernelDefBuilder()
-	.TypeConstraint("T", DataTypeImpl::GetTensorType<float>())
-    .TypeConstraint("I", DataTypeImpl::GetTensorType<int64_t>()),
-	DynamicTopK<float>);
+    DynamicTopK,
+    kMSDomain,
+    1,
+    kCpuExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>())
+        .TypeConstraint("I", DataTypeImpl::GetTensorType<int64_t>()),
+    DynamicTopK<float>);
 
 static int64_t SizeToDim(size_t k, const vector<int64_t>& dims) {
   ORT_ENFORCE(k <= dims.size());
@@ -64,16 +64,16 @@ struct ValueCmp {
 template <>
 Status DynamicTopK<float>::Compute(OpKernelContext* p_op_kernel_context) const {
   const Tensor* X = p_op_kernel_context->Input<Tensor>(0);
-  const Tensor* Y = p_op_kernel_context->Input<Tensor>(1);  
+  const Tensor* Y = p_op_kernel_context->Input<Tensor>(1);
   if (X == nullptr || Y == nullptr) return Status(common::ONNXRUNTIME, common::FAIL, "input count mismatch, expected 2 inputs");
   const vector<int64_t>& y_shape = Y->Shape().GetDims();
-  if (y_shape.size() != 1 || y_shape[0] != 1) return Status(common::ONNXRUNTIME, common::FAIL, "k tensor should be a 1D tensor of size 1");	
+  if (y_shape.size() != 1 || y_shape[0] != 1) return Status(common::ONNXRUNTIME, common::FAIL, "k tensor should be a 1D tensor of size 1");
   const auto k_ = Y->template Data<int64_t>()[0];
-  if (k_ <= 0) return Status(common::ONNXRUNTIME, common::FAIL, "Value of k should be greater than 0");	
+  if (k_ <= 0) return Status(common::ONNXRUNTIME, common::FAIL, "Value of k should be greater than 0");
   const vector<int64_t>& in_dims = X->Shape().GetDims();
   // Will return axis_ as is if positive or fixes it in case it is negative
-  auto axis_parsed = HandleNegativeAxis(axis_, in_dims.size());	
-  // Check to ensure k_ is within the bounds of what is available in that specific axis 	
+  auto axis_parsed = HandleNegativeAxis(axis_, in_dims.size());
+  // Check to ensure k_ is within the bounds of what is available in that specific axis
   if (in_dims.at(axis_parsed) < k_) {
     ostringstream err_msg;
     err_msg << "k argment [" << k_ << "] should not be greater than specified axis dim value [" << in_dims.at(axis_parsed) << "]";
@@ -102,38 +102,38 @@ Status DynamicTopK<float>::Compute(OpKernelContext* p_op_kernel_context) const {
   auto Indices_map = EigenMatrixMapRowMajor<int64_t>(
       Indices->template MutableData<int64_t>(), rows, reduced_cols);
 
-  // This is basically the number of elements within each of the "k_" rows  
+  // This is basically the number of elements within each of the "k_" rows
   const int64_t block_slice = reduced_cols / k_;
   // Sort preserving Indices
   for (int64_t i = 0; i < rows; ++i) {
-	  for (int64_t j = 0; j < block_slice; ++j) {
-		// Build a min-heap, the heap element is pair of (value, idx)
-		// the top of the heap is the smallest value
-		priority_queue<
-			pair<float, int64_t>,
-			vector<pair<float, int64_t>>,
-			ValueCmp<float>>
-			min_heap;
-		// Maintain the size of heap to be less or equal to k_, so the
-		// heap will hold the k_ largest Values
-		for (int64_t k = 0; k < in_dims[axis_parsed]; ++k) {
-			const auto value = input_map(i, k * block_slice + j);
-			if (min_heap.size() < gsl::narrow_cast<uint64_t>(k_) || value > min_heap.top().first) {
-				min_heap.push({value, k});
-			}
-			if (min_heap.size() > gsl::narrow_cast<uint64_t>(k_)) {
-				min_heap.pop();
-			}    
-		} 
-		// Extract these k_ elements and place them in the results placeholder
-		for (int64_t l = 0; l < k_; ++l) {
-			auto& pqElem = min_heap.top();
-			auto col_index = (k_ - l -1) * block_slice + j;  
-			Values_map(i, col_index) = pqElem.first;
-			Indices_map(i, col_index) = pqElem.second;
-			min_heap.pop();
-		}
-	  }
+    for (int64_t j = 0; j < block_slice; ++j) {
+      // Build a min-heap, the heap element is pair of (value, idx)
+      // the top of the heap is the smallest value
+      priority_queue<
+          pair<float, int64_t>,
+          vector<pair<float, int64_t>>,
+          ValueCmp<float>>
+          min_heap;
+      // Maintain the size of heap to be less or equal to k_, so the
+      // heap will hold the k_ largest Values
+      for (int64_t k = 0; k < in_dims[axis_parsed]; ++k) {
+        const auto value = input_map(i, k * block_slice + j);
+        if (min_heap.size() < gsl::narrow_cast<uint64_t>(k_) || value > min_heap.top().first) {
+          min_heap.push({value, k});
+        }
+        if (min_heap.size() > gsl::narrow_cast<uint64_t>(k_)) {
+          min_heap.pop();
+        }
+      }
+      // Extract these k_ elements and place them in the results placeholder
+      for (int64_t l = 0; l < k_; ++l) {
+        auto& pqElem = min_heap.top();
+        auto col_index = (k_ - l - 1) * block_slice + j;
+        Values_map(i, col_index) = pqElem.first;
+        Indices_map(i, col_index) = pqElem.second;
+        min_heap.pop();
+      }
+    }
   }
 
   return Status::OK();

--- a/onnxruntime/contrib_ops/cpu/dynamic_top_k.cc
+++ b/onnxruntime/contrib_ops/cpu/dynamic_top_k.cc
@@ -1,0 +1,141 @@
+/**
+* Copyright (c) 2016-present, Facebook, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "dynamic_top_k.h"
+#include "core/providers/common.h"
+#include "core/framework/tensor.h"
+#include "core/util/math_cpuonly.h"
+#include <queue>
+using namespace std;
+namespace onnxruntime {
+namespace contrib {	
+ONNX_OPERATOR_KERNEL_EX(
+	DynamicTopK,
+	kMSDomain,
+	1,
+	kCpuExecutionProvider,
+	KernelDefBuilder()
+	.TypeConstraint("T", DataTypeImpl::GetTensorType<float>())
+	.TypeConstraint("I", DataTypeImpl::GetType<int64_t>()),
+	DynamicTopK<float>);
+
+static int64_t SizeToDim(size_t k, const vector<int64_t>& dims) {
+  ORT_ENFORCE(k <= dims.size());
+  int64_t r = 1;
+  for (size_t i = 0; i < k; ++i) {
+    r *= dims[i];
+  }
+  return r;
+}
+
+static int64_t SizeFromDim(size_t k, const vector<int64_t>& dims) {
+  ORT_ENFORCE(k <= dims.size());
+  int64_t r = 1;
+  for (size_t i = k; i < dims.size(); ++i) {
+    r *= dims[i];
+  }
+  return r;
+}
+
+template <typename T>
+struct ValueCmp {
+  bool operator()(
+      const pair<T, int64_t>& lhs,
+      const pair<T, int64_t>& rhs) {
+    return (
+        lhs.first > rhs.first ||
+        (lhs.first == rhs.first && lhs.second < rhs.second));
+  }
+};
+
+template <>
+Status DynamicTopK<float>::Compute(OpKernelContext* p_op_kernel_context) const {
+  const Tensor* X = p_op_kernel_context->Input<Tensor>(0);
+  const Tensor* Y = p_op_kernel_context->Input<Tensor>(1);  
+  if (X == nullptr || Y == nullptr) return Status(common::ONNXRUNTIME, common::FAIL, "input count mismatch, expected 2 inputs");
+  const vector<int64_t>& y_shape = Y->Shape().GetDims();
+  if (y_shape.size() != 1 || y_shape[0] != 1) return Status(common::ONNXRUNTIME, common::FAIL, "k tensor should be a 1D tensor of size 1");	
+  const auto k_ = Y->template Data<int64_t>()[0];
+  const vector<int64_t>& in_dims = X->Shape().GetDims();
+  // Will return axis_ as is if positive or fixes it in case it is negative
+  auto axis_parsed = HandleNegativeAxis(axis_, in_dims.size());	
+  // Check to ensure k_ is within the bounds of what is available in that specific axis 	
+  if (in_dims.at(axis_parsed) < k_) {
+    ostringstream err_msg;
+    err_msg << "k argment [" << k_ << "] should not be greater than specified axis dim value [" << in_dims.at(axis_parsed) << "]";
+    return Status(common::ONNXRUNTIME, common::FAIL, err_msg.str());
+  }
+
+  const int64_t rows = SizeToDim(axis_parsed, in_dims);
+  const int64_t cols = X->Shape().Size() / rows;
+  auto input_map = ConstEigenMatrixMapRowMajor<float>(
+      static_cast<const float*>(X->template Data<float>()),
+      rows,
+      cols);
+
+  // Resize output tensors to be the same shape as the input except
+  // for the specified dimension ((i.e.) axis_parsed), which will be of size k_. E.x. for an input tensor
+  // of shape [3, 4, 5] and k_=2 with axis_parsed=1, both of these will be shape [3, 2, 5]
+  vector<int64_t> output_linear_shape = in_dims;
+  output_linear_shape[axis_parsed] = k_;
+  auto* Values = p_op_kernel_context->Output(0, output_linear_shape);
+  auto* Indices = p_op_kernel_context->Output(1, output_linear_shape);
+
+  // Use Eigen maps to allow indexing into the 2d tensors like Values_map(i,j)
+  const int64_t reduced_cols = SizeFromDim(axis_parsed, output_linear_shape);
+  auto Values_map = EigenMatrixMapRowMajor<float>(
+      Values->template MutableData<float>(), rows, reduced_cols);
+  auto Indices_map = EigenMatrixMapRowMajor<int64_t>(
+      Indices->template MutableData<int64_t>(), rows, reduced_cols);
+
+  // This is basically the number of elements within each of the "k_" rows  
+  const int64_t block_slice = reduced_cols / k_;
+  // Sort preserving Indices
+  for (int64_t i = 0; i < rows; ++i) {
+	  for (int64_t j = 0; j < block_slice; ++j) {
+		// Build a min-heap, the heap element is pair of (value, idx)
+		// the top of the heap is the smallest value
+		priority_queue<
+			pair<float, int64_t>,
+			vector<pair<float, int64_t>>,
+			ValueCmp<float>>
+			min_heap;
+		// Maintain the size of heap to be less or equal to k_, so the
+		// heap will hold the k_ largest Values
+		for (int64_t k = 0; k < in_dims[axis_parsed]; ++k) {
+			const auto value = input_map(i, k * block_slice + j);
+			if (min_heap.size() < gsl::narrow_cast<uint64_t>(k_) || value > min_heap.top().first) {
+				min_heap.push({value, k});
+			}
+			if (min_heap.size() > gsl::narrow_cast<uint64_t>(k_)) {
+				min_heap.pop();
+			}    
+		} 
+		// Extract these k_ elements and place them in the results placeholder
+		for (int64_t l = 0; l < k_; ++l) {
+			auto& pqElem = min_heap.top();
+			auto col_index = (k_ - l -1) * block_slice + j;  
+			Values_map(i, col_index) = pqElem.first;
+			Indices_map(i, col_index) = pqElem.second;
+			min_heap.pop();
+		}
+	  }
+  }
+
+  return Status::OK();
+}
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/dynamic_top_k.h
+++ b/onnxruntime/contrib_ops/cpu/dynamic_top_k.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/framework/op_kernel.h"
+
+namespace onnxruntime {
+namespace contrib {
+template <typename T>
+class DynamicTopK final : public OpKernel {
+ public:
+  DynamicTopK(const OpKernelInfo& op_kernel_info) : OpKernel(op_kernel_info) {
+    int64_t axis_temp;
+    ORT_ENFORCE(op_kernel_info.GetAttr<int64_t>("axis", &axis_temp).IsOK());
+    axis_ = gsl::narrow_cast<int>(axis_temp);
+  }
+
+  Status Compute(OpKernelContext* p_op_kernel_context) const override;
+
+ private:
+  int axis_;
+};
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -248,7 +248,11 @@ Sample echo operator.)DOC");
           "X",
           "",
           "T")
-      .Input(1, "K", "", "tensor(int64)")
+      .Input(
+		  1,
+		  "K",
+		  "",
+		  "tensor(int64)")
       .Output(
           0,
           "Values",

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -262,9 +262,9 @@ Sample echo operator.)DOC");
           1,
           "Indices",
           "",
-          "T1")
+          "I")
       .TypeConstraint("T", {"tensor(float)"}, "Constrain input0 and output types to float tensors")
-	  .TypeConstraint("T1", {"tensor(int64)"}, "Constrain index tensor to int64")
+	  .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
 		// Type inference:
 		propagateElemTypeFromInputToOutput(ctx, 0, 0);

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -262,9 +262,9 @@ Sample echo operator.)DOC");
           1,
           "Indices",
           "",
-          "I")
+          "T1")
       .TypeConstraint("T", {"tensor(float)"}, "Constrain input0 and output types to float tensors")
-      .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64")
+	  .TypeConstraint("T1", {"tensor(int64)"}, "Constrain index tensor to int64")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
 		// Type inference:
 		propagateElemTypeFromInputToOutput(ctx, 0, 0);

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -249,10 +249,10 @@ Sample echo operator.)DOC");
           "",
           "T")
       .Input(
-		  1,
-		  "K",
-		  "",
-		  "tensor(int64)")
+          1,
+          "K",
+          "",
+          "tensor(int64)")
       .Output(
           0,
           "Values",
@@ -264,43 +264,43 @@ Sample echo operator.)DOC");
           "",
           "I")
       .TypeConstraint("T", {"tensor(float)"}, "Constrain input0 and output types to float tensors")
-	  .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64")
+      .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-		// Type inference:
-		propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        // Type inference:
+        propagateElemTypeFromInputToOutput(ctx, 0, 0);
         updateOutputElemType(ctx, 1, ONNX_NAMESPACE::TensorProto::INT64);
 
-		// Shape inference:
-		if (!hasInputShape(ctx, 0))
-		  return;
-		auto& input_shape = getInputShape(ctx, 0);
-		int64_t rank = input_shape.dim_size();
-		int64_t axis = getAttribute(ctx, "axis", -1);
-		if (axis < 0)
-		  axis += rank;
-		if (axis < 0 || axis >= rank)
-		  fail_shape_inference("Invalid value for attribute axis");
-		// TODO: unclear what results should be if axis has less than k
-		// elements.
-		// Infer output shape if 'K' is available
+        // Shape inference:
+        if (!hasInputShape(ctx, 0))
+          return;
+        auto& input_shape = getInputShape(ctx, 0);
+        int64_t rank = input_shape.dim_size();
+        int64_t axis = getAttribute(ctx, "axis", -1);
+        if (axis < 0)
+          axis += rank;
+        if (axis < 0 || axis >= rank)
+          fail_shape_inference("Invalid value for attribute axis");
+        // TODO: unclear what results should be if axis has less than k
+        // elements.
+        // Infer output shape if 'K' is available
         const auto* k = ctx.getInputData(1);
-		if (nullptr != k) {
+        if (nullptr != k) {
           if (k->dims_size() != 1 || k->int64_data_size() != 1 || k->data_type() != ONNX_NAMESPACE::TensorProto::INT64)
-			fail_shape_inference("K input must be a one-dimensional tensor of size 1 and of type int64.");
+            fail_shape_inference("K input must be a one-dimensional tensor of size 1 and of type int64.");
           ONNX_NAMESPACE::TensorShapeProto result_shape = input_shape;
-		  result_shape.mutable_dim(static_cast<int>(axis))->set_dim_value(k->int64_data(0));
-		  updateOutputShape(ctx, 0, result_shape);
-		  updateOutputShape(ctx, 1, result_shape);
-		} else {
-		  // Infer output shapes' rank in any case
-		  auto* output_shape_0 = getOutputShape(ctx, 0);
-		  auto* output_shape_1 = getOutputShape(ctx, 1);
-		  for (int i = 0; i < input_shape.dim_size(); ++i) {
-			output_shape_0->add_dim();
-			output_shape_1->add_dim();
-		  }
-		}
-		return;
+          result_shape.mutable_dim(static_cast<int>(axis))->set_dim_value(k->int64_data(0));
+          updateOutputShape(ctx, 0, result_shape);
+          updateOutputShape(ctx, 1, result_shape);
+        } else {
+          // Infer output shapes' rank in any case
+          auto* output_shape_0 = getOutputShape(ctx, 0);
+          auto* output_shape_1 = getOutputShape(ctx, 1);
+          for (int i = 0; i < input_shape.dim_size(); ++i) {
+            output_shape_0->add_dim();
+            output_shape_1->add_dim();
+          }
+        }
+        return;
       });
 
   ONNX_CONTRIB_OPERATOR_SCHEMA(MaxpoolWithMask)

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -234,6 +234,71 @@ void RegisterContribSchemas() {
 Sample echo operator.)DOC");
 
   // register schemas for more operators here
+  ONNX_CONTRIB_OPERATOR_SCHEMA(DynamicTopK)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetDoc(R"DOC(For internal use.)DOC")
+      .Attr(
+          "axis",
+          "Dimension on which to do the sort.",
+          AttributeProto::INT,
+          static_cast<int64_t>(-1))
+      .Input(
+          0,
+          "X",
+          "",
+          "T")
+      .Input(1, "K", "", "tensor(int64)")
+      .Output(
+          0,
+          "Values",
+          "",
+          "T")
+      .Output(
+          1,
+          "Indices",
+          "",
+          "I")
+      .TypeConstraint("T", {"tensor(float)"}, "Constrain input0 and output types to float tensors")
+      .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+		// Type inference:
+		propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        updateOutputElemType(ctx, 1, ONNX_NAMESPACE::TensorProto::INT64);
+
+		// Shape inference:
+		if (!hasInputShape(ctx, 0))
+		  return;
+		auto& input_shape = getInputShape(ctx, 0);
+		int64_t rank = input_shape.dim_size();
+		int64_t axis = getAttribute(ctx, "axis", -1);
+		if (axis < 0)
+		  axis += rank;
+		if (axis < 0 || axis >= rank)
+		  fail_shape_inference("Invalid value for attribute axis");
+		// TODO: unclear what results should be if axis has less than k
+		// elements.
+		// Infer output shape if 'K' is available
+        const auto* k = ctx.getInputData(1);
+		if (nullptr != k) {
+          if (k->dims_size() != 1 || k->int64_data_size() != 1 || k->data_type() != ONNX_NAMESPACE::TensorProto::INT64)
+			fail_shape_inference("K input must be a one-dimensional tensor of size 1 and of type int64.");
+          ONNX_NAMESPACE::TensorShapeProto result_shape = input_shape;
+		  result_shape.mutable_dim(static_cast<int>(axis))->set_dim_value(k->int64_data(0));
+		  updateOutputShape(ctx, 0, result_shape);
+		  updateOutputShape(ctx, 1, result_shape);
+		} else {
+		  // Infer output shapes' rank in any case
+		  auto* output_shape_0 = getOutputShape(ctx, 0);
+		  auto* output_shape_1 = getOutputShape(ctx, 1);
+		  for (int i = 0; i < input_shape.dim_size(); ++i) {
+			output_shape_0->add_dim();
+			output_shape_1->add_dim();
+		  }
+		}
+		return;
+      });
+
   ONNX_CONTRIB_OPERATOR_SCHEMA(MaxpoolWithMask)
       .SetDomain(kMSDomain)
       .SinceVersion(1)

--- a/onnxruntime/test/contrib_ops/dynamic_topk_op_test.cc
+++ b/onnxruntime/test/contrib_ops/dynamic_topk_op_test.cc
@@ -139,7 +139,7 @@ TEST(DynamicTopKOperator, InvalidK) {
           expected_dimensions,
           1,
           OpTester::ExpectResult::kExpectFailure,
-          "Invalid value for attribute k");
+          "Value of k should be greater than 0");
 }
 
 }  // namespace test

--- a/onnxruntime/test/contrib_ops/dynamic_topk_op_test.cc
+++ b/onnxruntime/test/contrib_ops/dynamic_topk_op_test.cc
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+static void RunTest(int64_t k,
+                    const std::vector<float>& input_vals,
+                    const std::vector<int64_t>& input_dimensions,
+                    const std::vector<float>& expected_vals,
+                    const std::vector<int64_t>& expected_indices,
+                    const std::vector<int64_t>& expected_dimensions,
+                    int64_t axis = -1,
+                    OpTester::ExpectResult expect_result = OpTester::ExpectResult::kExpectSuccess,
+                    const std::string& expected_err_str = "") {
+  OpTester test("DynamicTopK", 1, onnxruntime::kMSDomain);
+  if (axis != -1) {
+    test.AddAttribute("axis", axis);
+  }
+  test.AddInput<float>("X", input_dimensions, input_vals);
+  test.AddInput<int64_t>("K", {1}, {k});  
+  test.AddOutput<float>("Values", expected_dimensions, expected_vals);
+  test.AddOutput<int64_t>("Indices", expected_dimensions, expected_indices);
+  test.Run(expect_result, expected_err_str);
+}
+
+TEST(DynamicTopKOperator, Top1DefaultAxis) {
+  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
+  std::vector<int64_t> input_dimensions = {2, 4};
+  std::vector<float> expected_vals = {0.4f, 0.3f};
+  std::vector<int64_t> expected_indices = {3, 1};
+  std::vector<int64_t> expected_dimensions = {2, 1};
+  RunTest(1, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions);
+}
+
+TEST(DynamicTopKOperator, Top2DefaultAxis) {
+  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.4f, 0.2f};
+  std::vector<int64_t> input_dimensions = {2, 4};
+  std::vector<float> expected_vals = {0.4f, 0.3f, 0.4f, 0.3f};
+  std::vector<int64_t> expected_indices = {3, 1, 2, 1};
+  std::vector<int64_t> expected_dimensions = {2, 2};
+  RunTest(2, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions);
+}
+
+TEST(DynamicTopKOperator, Top3DefaultAxis) {
+  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.4f, 0.2f};
+  std::vector<int64_t> input_dimensions = {2, 4};
+  std::vector<float> expected_vals = {0.4f, 0.3f, 0.2f, 0.4f, 0.3f, 0.2f};
+  std::vector<int64_t> expected_indices = {3, 1, 2, 2, 1, 3};
+  std::vector<int64_t> expected_dimensions = {2, 3};
+  RunTest(3, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions);
+}
+
+TEST(DynamicTopKOperator, TopAllDefaultAxis) {
+  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
+  std::vector<int64_t> input_dimensions = {2, 4};
+  std::vector<float> expected_vals = {0.4f, 0.3f, 0.2f, 0.1f, 0.3f, 0.3f, 0.2f, 0.1f};
+  std::vector<int64_t> expected_indices = {3, 1, 2, 0, 1, 2, 3, 0};
+  std::vector<int64_t> expected_dimensions = {2, 4};
+  RunTest(4, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions);
+}
+
+TEST(DynamicTopKOperator, Top1ExplicitAxis) {
+  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
+  std::vector<int64_t> input_dimensions = {4, 2};
+  std::vector<float> expected_vals = {0.3f, 0.4f};
+  std::vector<int64_t> expected_indices = {3, 1};
+  std::vector<int64_t> expected_dimensions = {1, 2};
+  int64_t axis = 0;
+  RunTest(1, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
+}
+
+TEST(DynamicTopKOperator, Top2ExplicitAxis) {
+  std::vector<float> input_vals = {0.0f, 1.0f, 2.0f, 11.0f, 08.0f, 5.0f, 6.0f, 7.0f, 4.0f, 9.0f, 10.0f, 3.0f};
+  std::vector<int64_t> input_dimensions = {3, 4};
+  std::vector<float> expected_vals = {8.0f, 9.0f, 10.0f, 11.0f, 4.0f, 5.0f, 6.0f, 7.0f};
+  std::vector<int64_t> expected_indices = {1, 2, 2, 0, 2, 1, 1, 1};
+  std::vector<int64_t> expected_dimensions = {2, 4};
+  int64_t axis = 0;
+  RunTest(2, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
+}
+
+TEST(DynamicTopKOperator, Top3ExplicitAxis) {
+  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
+  std::vector<int64_t> input_dimensions = {4, 2};
+  std::vector<float> expected_vals = {0.3f, 0.4f, 0.2f, 0.3f, 0.1f, 0.3f};
+  std::vector<int64_t> expected_indices = {3, 1, 1, 0, 0, 2};
+  std::vector<int64_t> expected_dimensions = {3, 2};
+  int64_t axis = 0;
+  RunTest(3, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
+}
+
+
+TEST(DynamicTopKOperator, TopAllExplicitAxis) {
+  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
+  std::vector<int64_t> input_dimensions = {4, 2};
+  std::vector<float> expected_vals = {0.3f, 0.4f, 0.2f, 0.3f, 0.1f, 0.3f, 0.1f, 0.2f};
+  std::vector<int64_t> expected_indices = {3, 1, 1, 0, 0, 2, 2, 3};
+  std::vector<int64_t> expected_dimensions = {4, 2};
+  int64_t axis = 0;
+  RunTest(4, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
+}
+
+TEST(DynamicTopKOperator, TopAllExplicitAxis1DInput) {
+  std::vector<float> input_vals = {93.0f, 695.0f, 971.0f, 978.0f, 483.0f, 247.0f, 242.0f, 983.0f, 531.0f, 723.0f, 285.0f, 527.0f, 862.0f};
+  std::vector<int64_t> input_dimensions = {13};
+  std::vector<float> expected_vals = {983.0f, 978.0f, 971.0f, 862.0f, 723.0f, 695.0f, 531.0f, 527.0f, 483.0f, 285.0f, 247.0f, 242.0f, 93.0f};
+  std::vector<int64_t> expected_indices = {7, 3, 2, 12, 9, 1, 8, 11, 4, 10, 5, 6,0};
+  std::vector<int64_t> expected_dimensions = {13};
+  int64_t axis = 0;
+  RunTest(13, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
+}
+
+TEST(DynamicTopKOperator, Top1ExplicitAxisMultiDInput) {
+  std::vector<float> input_vals = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
+  std::vector<int64_t> input_dimensions = {2, 2, 2};
+  std::vector<float> expected_vals = {3, 4, 7, 8};
+  std::vector<int64_t> expected_indices = {1, 1, 1, 1};
+  std::vector<int64_t> expected_dimensions = {2, 1, 2};
+  int64_t axis = 1;
+  RunTest(1, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
+}
+
+TEST(DynamicTopKOperator, InvalidK) {
+  std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
+  std::vector<int64_t> input_dimensions = {2, 4};
+  std::vector<float> expected_vals = {0.4f, 0.3f, 0.2f, 0.1f, 0.3f, 0.3f, 0.2f, 0.1f};
+  std::vector<int64_t> expected_indices = {3, 1, 2, 0, 1, 2, 3, 0};
+  std::vector<int64_t> expected_dimensions = {2, 4};
+  RunTest(0,
+          input_vals,
+          input_dimensions,
+          expected_vals,
+          expected_indices,
+          expected_dimensions,
+          1,
+          OpTester::ExpectResult::kExpectFailure,
+          "Invalid value for attribute k");
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/dynamic_topk_op_test.cc
+++ b/onnxruntime/test/contrib_ops/dynamic_topk_op_test.cc
@@ -22,7 +22,7 @@ static void RunTest(int64_t k,
     test.AddAttribute("axis", axis);
   }
   test.AddInput<float>("X", input_dimensions, input_vals);
-  test.AddInput<int64_t>("K", {1}, {k});  
+  test.AddInput<int64_t>("K", {1}, {k});
   test.AddOutput<float>("Values", expected_dimensions, expected_vals);
   test.AddOutput<int64_t>("Indices", expected_dimensions, expected_indices);
   test.Run(expect_result, expected_err_str);
@@ -94,7 +94,6 @@ TEST(DynamicTopKOperator, Top3ExplicitAxis) {
   RunTest(3, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);
 }
 
-
 TEST(DynamicTopKOperator, TopAllExplicitAxis) {
   std::vector<float> input_vals = {0.1f, 0.3f, 0.2f, 0.4f, 0.1f, 0.3f, 0.3f, 0.2f};
   std::vector<int64_t> input_dimensions = {4, 2};
@@ -109,7 +108,7 @@ TEST(DynamicTopKOperator, TopAllExplicitAxis1DInput) {
   std::vector<float> input_vals = {93.0f, 695.0f, 971.0f, 978.0f, 483.0f, 247.0f, 242.0f, 983.0f, 531.0f, 723.0f, 285.0f, 527.0f, 862.0f};
   std::vector<int64_t> input_dimensions = {13};
   std::vector<float> expected_vals = {983.0f, 978.0f, 971.0f, 862.0f, 723.0f, 695.0f, 531.0f, 527.0f, 483.0f, 285.0f, 247.0f, 242.0f, 93.0f};
-  std::vector<int64_t> expected_indices = {7, 3, 2, 12, 9, 1, 8, 11, 4, 10, 5, 6,0};
+  std::vector<int64_t> expected_indices = {7, 3, 2, 12, 9, 1, 8, 11, 4, 10, 5, 6, 0};
   std::vector<int64_t> expected_dimensions = {13};
   int64_t axis = 0;
   RunTest(13, input_vals, input_dimensions, expected_vals, expected_indices, expected_dimensions, axis);


### PR DESCRIPTION
This op provides the same functionality as TopK except that it takes `k` to be a dynamic input (as opposed to being a static attribute). This is required for conversion (and running the subsequently converted models) of Fast RCNN and Mask RCNN from Keras to ONNX.

This interface change has been proposed to ONNX (https://github.com/onnx/onnx/pull/1829) for the existing TopK operator for Opset 10.

cc: @wenbingl @EmmaNingMS  