### PR TITLE
Support type int32_t for Split op

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/split.cc
+++ b/onnxruntime/core/providers/cpu/tensor/split.cc
@@ -18,7 +18,6 @@ ONNX_CPU_OPERATOR_KERNEL(
                                           DataTypeImpl::GetTensorType<float>(),
                                           DataTypeImpl::GetTensorType<double>(),
                                           DataTypeImpl::GetTensorType<int32_t>(),
-                                          DataTypeImpl::GetTensorType<int64_t>(),
                                       }),
     Split);
 
@@ -32,8 +31,6 @@ Status Split::Compute(OpKernelContext* context) const {
     status = ComputeImpl<float>(*context, input);
   else if (data_type == DataTypeImpl::GetType<int32_t>())
     status = ComputeImpl<int32_t>(*context, input);
-  else if (data_type == DataTypeImpl::GetType<int64_t>())
-    status = ComputeImpl<int64_t>(*context, input);
   else if (data_type == DataTypeImpl::GetType<double>()) {
     /* Need to update CopyMatrix to support double...
     status = ComputeImpl<double>(*context, input); */

--- a/onnxruntime/core/providers/cpu/tensor/split.cc
+++ b/onnxruntime/core/providers/cpu/tensor/split.cc
@@ -17,6 +17,8 @@ ONNX_CPU_OPERATOR_KERNEL(
                                       std::vector<MLDataType>{
                                           DataTypeImpl::GetTensorType<float>(),
                                           DataTypeImpl::GetTensorType<double>(),
+                                          DataTypeImpl::GetTensorType<int32_t>(),
+                                          DataTypeImpl::GetTensorType<int64_t>(),
                                       }),
     Split);
 
@@ -28,6 +30,10 @@ Status Split::Compute(OpKernelContext* context) const {
 
   if (data_type == DataTypeImpl::GetType<float>())
     status = ComputeImpl<float>(*context, input);
+  else if (data_type == DataTypeImpl::GetType<int32_t>())
+    status = ComputeImpl<int32_t>(*context, input);
+  else if (data_type == DataTypeImpl::GetType<int64_t>())
+    status = ComputeImpl<int64_t>(*context, input);
   else if (data_type == DataTypeImpl::GetType<double>()) {
     /* Need to update CopyMatrix to support double...
     status = ComputeImpl<double>(*context, input); */

--- a/onnxruntime/test/providers/cpu/tensor/split_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/split_op_test.cc
@@ -56,6 +56,28 @@ TEST(SplitOperatorTest, Axis0EqualSplit) {
   RunTest(axis, {}, input, outputs);
 }
 
+TEST(SplitOperatorTest, Axis0EqualSplitInt32) {
+  const int64_t axis = 0;
+  std::vector<ShapeAndData> outputs;
+
+  // input shape and data
+  ShapeAndData input = {{4, 2},  // shape
+                        {1, 2,
+                         3, 4,
+                         5, 6,
+                         7, 8}};
+
+  outputs.push_back({{2, 2},
+                     {1, 2,
+                      3, 4}});
+
+  outputs.push_back({{2, 2},
+                     {5, 6,
+                      7, 8}});
+
+  RunTest(axis, {}, input, outputs);
+}
+
 TEST(SplitOperatorTest, Axis0UnequalSplit) {
   const int64_t axis = 0;
   std::vector<ShapeAndData> outputs;

--- a/onnxruntime/test/providers/cpu/tensor/split_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/split_op_test.cc
@@ -8,6 +8,7 @@ namespace onnxruntime {
 namespace test {
 
 using ShapeAndData = std::pair<const std::vector<int64_t>, const std::vector<float>>;
+using ShapeAndInt32Data = std::pair<const std::vector<int64_t>, const std::vector<int32_t>>;
 using ExpectResult = OpTester::ExpectResult;
 
 void RunTest(int64_t axis, const std::vector<int64_t> split_sizes, const ShapeAndData& input,
@@ -58,14 +59,14 @@ TEST(SplitOperatorTest, Axis0EqualSplit) {
 
 TEST(SplitOperatorTest, Axis0EqualSplitInt32) {
   const int64_t axis = 0;
-  std::vector<ShapeAndData> outputs;
+  std::vector<ShapeAndInt32Data> outputs;
 
   // input shape and data
-  ShapeAndData input = {{4, 2},  // shape
-                        {1, 2,
-                         3, 4,
-                         5, 6,
-                         7, 8}};
+  ShapeAndInt32Data input = {{4, 2},  // shape
+                             {1, 2,
+                              3, 4,
+                              5, 6,
+                              7, 8}};
 
   outputs.push_back({{2, 2},
                      {1, 2,


### PR DESCRIPTION
We have a customer speech model, and when we convert it, we get a split op where the input is int type. We need onnxruntime support this.