### PR TITLE
Make x86_64 MLAS assembly files relocatable so they work with -fPIC

### DIFF
--- a/onnxruntime/core/mlas/lib/x86_64/LogisticKernelFma3.S
+++ b/onnxruntime/core/mlas/lib/x86_64/LogisticKernelFma3.S
@@ -72,7 +72,7 @@ Return Value:
         .globl  C_UNDERSCORE(MlasLogisticKernelFma3)
 C_UNDERSCORE(MlasLogisticKernelFma3):
 
-        lea     rax,C_UNDERSCORE(MlasLogisticConstants)[rip]
+        lea     rax,C_UNDERSCORE(MlasLogisticConstants)@GOTPCREL[rip]
         vbroadcastss ymm4,LogisticConstants_LowerRange[rax]
         vbroadcastss ymm5,LogisticConstants_UpperRange[rax]
         vbroadcastss ymm6,LogisticConstants_alpha_9[rax]
@@ -121,7 +121,7 @@ C_UNDERSCORE(MlasLogisticKernelFma3):
         jz      .LExitKernel
         mov     DWORD PTR LogisticKernelFrame_CountN[rsp],edx
         vbroadcastss ymm2,DWORD PTR LogisticKernelFrame_CountN[rsp]
-        vpcmpgtd ymm2,ymm2,YMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip]
+        vpcmpgtd ymm2,ymm2,YMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip]
         vmaskmovps ymm0,ymm2,YMMWORD PTR [rdi]
         vmaxps  ymm0,ymm4,ymm0                  # clamp lower bound
         vminps  ymm0,ymm5,ymm0                  # clamp upper bound

--- a/onnxruntime/core/mlas/lib/x86_64/SgemmKernelAvx.S
+++ b/onnxruntime/core/mlas/lib/x86_64/SgemmKernelAvx.S
@@ -375,8 +375,8 @@ C_UNDERSCORE(MlasSgemmKernel\Mode\()Avx):
 .L\Mode\().OutputMasked8x4Block:
         vmovd   xmm0,r9d
         vshufps xmm0,xmm0,xmm0,0
-        vpcmpgtd xmm1,xmm0,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip+16]
-        vpcmpgtd xmm0,xmm0,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip]
+        vpcmpgtd xmm1,xmm0,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip+16]
+        vpcmpgtd xmm0,xmm0,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip]
         vinsertf128 ymm0,ymm0,xmm1,1
 .ifeqs "\Mode\()","Add"
         vmaskmovps ymm8,ymm0,YMMWORD PTR [rdx]
@@ -473,8 +473,8 @@ C_UNDERSCORE(MlasSgemmKernel\Mode\()Avx):
 .L\Mode\().OutputMasked8x2Block:
         vmovd   xmm0,r9d
         vshufps xmm0,xmm0,xmm0,0
-        vpcmpgtd xmm1,xmm0,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip+16]
-        vpcmpgtd xmm0,xmm0,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip]
+        vpcmpgtd xmm1,xmm0,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip+16]
+        vpcmpgtd xmm0,xmm0,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip]
         vinsertf128 ymm0,ymm0,xmm1,1
 .ifeqs "\Mode\()","Add"
         vmaskmovps ymm8,ymm0,YMMWORD PTR [rdx]
@@ -539,8 +539,8 @@ C_UNDERSCORE(MlasSgemmKernel\Mode\()Avx):
 .L\Mode\().OutputMasked8x1Block:
         vmovd   xmm0,r9d
         vshufps xmm0,xmm0,xmm0,0
-        vpcmpgtd xmm1,xmm0,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip+16]
-        vpcmpgtd xmm0,xmm0,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip]
+        vpcmpgtd xmm1,xmm0,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip+16]
+        vpcmpgtd xmm0,xmm0,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip]
         vinsertf128 ymm0,ymm0,xmm1,1
 .ifeqs "\Mode\()","Add"
         vmaskmovps ymm8,ymm0,YMMWORD PTR [rdx]

--- a/onnxruntime/core/mlas/lib/x86_64/SgemmKernelFma3.S
+++ b/onnxruntime/core/mlas/lib/x86_64/SgemmKernelFma3.S
@@ -436,7 +436,7 @@ C_UNDERSCORE(MlasSgemmKernel\Mode\()Fma3):
 .L\Mode\().OutputMasked8x6Block:
         mov     DWORD PTR [rsp+SgemmKernelFrame_mask],r9d
         vbroadcastss ymm0,DWORD PTR [rsp+SgemmKernelFrame_mask]
-        vpcmpgtd ymm0,ymm0,YMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip]
+        vpcmpgtd ymm0,ymm0,YMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip]
 .ifeqs "\Mode\()","Add"
         vmaskmovps ymm4,ymm0,YMMWORD PTR [rdx]
         vmaskmovps ymm6,ymm0,YMMWORD PTR [rdx+rax]
@@ -550,7 +550,7 @@ C_UNDERSCORE(MlasSgemmKernel\Mode\()Fma3):
 .L\Mode\().OutputMasked8x3Block:
         mov     DWORD PTR [rsp+SgemmKernelFrame_mask],r9d
         vbroadcastss ymm0,DWORD PTR [rsp+SgemmKernelFrame_mask]
-        vpcmpgtd ymm0,ymm0,YMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip]
+        vpcmpgtd ymm0,ymm0,YMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip]
 .ifeqs "\Mode\()","Add"
         vmaskmovps ymm4,ymm0,YMMWORD PTR [rdx]
         vmaskmovps ymm6,ymm0,YMMWORD PTR [rdx+rax]
@@ -652,7 +652,7 @@ C_UNDERSCORE(MlasSgemmKernel\Mode\()Fma3):
 .L\Mode\().OutputMasked8x1Block:
         mov     DWORD PTR [rsp+SgemmKernelFrame_mask],r9d
         vbroadcastss ymm0,DWORD PTR [rsp+SgemmKernelFrame_mask]
-        vpcmpgtd ymm0,ymm0,YMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip]
+        vpcmpgtd ymm0,ymm0,YMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip]
 .ifeqs "\Mode\()","Add"
         vmaskmovps ymm4,ymm0,YMMWORD PTR [rdx]
         vfmadd213ps ymm5,ymm2,ymm4

--- a/onnxruntime/core/mlas/lib/x86_64/SgemmKernelM1Avx.S
+++ b/onnxruntime/core/mlas/lib/x86_64/SgemmKernelM1Avx.S
@@ -81,8 +81,8 @@ C_UNDERSCORE(MlasSgemmKernelM1Avx):
         and     eax,7
         vmovd   xmm7,eax
         vshufps xmm7,xmm7,xmm7,0
-        vpcmpgtd xmm6,xmm7,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip+16]
-        vpcmpgtd xmm7,xmm7,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip]
+        vpcmpgtd xmm6,xmm7,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip+16]
+        vpcmpgtd xmm7,xmm7,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip]
         vinsertf128 ymm7,ymm7,xmm6,1
 
 //

--- a/onnxruntime/core/mlas/lib/x86_64/SgemmKernelM1TransposeBAvx.S
+++ b/onnxruntime/core/mlas/lib/x86_64/SgemmKernelM1TransposeBAvx.S
@@ -80,8 +80,8 @@ C_UNDERSCORE(MlasSgemmKernelM1TransposeBAvx):
         and     eax,7
         vmovd   xmm7,eax
         vshufps xmm7,xmm7,xmm7,0
-        vpcmpgtd xmm6,xmm7,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip+16]
-        vpcmpgtd xmm7,xmm7,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip]
+        vpcmpgtd xmm6,xmm7,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip+16]
+        vpcmpgtd xmm7,xmm7,XMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip]
         vinsertf128 ymm7,ymm7,xmm6,1
 
 //

--- a/onnxruntime/core/mlas/lib/x86_64/TanhKernelFma3.S
+++ b/onnxruntime/core/mlas/lib/x86_64/TanhKernelFma3.S
@@ -72,7 +72,7 @@ Return Value:
         .globl  C_UNDERSCORE(MlasTanhKernelFma3)
 C_UNDERSCORE(MlasTanhKernelFma3):
 
-        lea     rax,C_UNDERSCORE(MlasTanhConstants)[rip]
+        lea     rax,C_UNDERSCORE(MlasTanhConstants)@GOTPCREL[rip]
         vbroadcastss ymm4,TanhConstants_LowerRange[rax]
         vbroadcastss ymm5,TanhConstants_UpperRange[rax]
         vbroadcastss ymm6,TanhConstants_alpha_13[rax]
@@ -117,7 +117,7 @@ C_UNDERSCORE(MlasTanhKernelFma3):
         jz      .LExitKernel
         mov     DWORD PTR TanhKernelFrame_CountN[rsp],edx
         vbroadcastss ymm2,DWORD PTR TanhKernelFrame_CountN[rsp]
-        vpcmpgtd ymm2,ymm2,YMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)[rip]
+        vpcmpgtd ymm2,ymm2,YMMWORD PTR C_UNDERSCORE(MlasMaskMoveAvx)@GOTPCREL[rip]
         vmaskmovps ymm0,ymm2,YMMWORD PTR [rdi]
         vmaxps  ymm0,ymm4,ymm0                  # clamp lower bound
         vminps  ymm0,ymm5,ymm0                  # clamp upper bound


### PR DESCRIPTION
First thanks for creating onnxruntime, it's a great tool for deploying DL models.

There is an issue when trying to build dynamic libraries with -fPIC (Linux) and this is due to how the symbols from a cpp file are accessed from the assembly files in MLAS.

This fixes this issue on Linux. You can check that it's doing what it should if you make MLAS `SHARED` instead of `STATIC` in its CMake file.

(For future reference, I used https://stackoverflow.com/questions/9341212/elf-shared-object-in-x86-64-assembly-language as a guide on how to fix this)

EDIT: performance-wise I didn't see a regression on my side.