### PR TITLE
Fix: IExecutionProvider::GetCapability returns redundant subgraphs

### DIFF
--- a/onnxruntime/core/framework/execution_provider.cc
+++ b/onnxruntime/core/framework/execution_provider.cc
@@ -35,6 +35,7 @@ IExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
         std::unique_ptr<IndexedSubGraph> sub_graph = std::make_unique<IndexedSubGraph>();
         sub_graph->nodes.push_back(node.Index());
         result.push_back(std::make_unique<ComputeCapability>(std::move(sub_graph)));
+        break;
       }
     }
   }

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -864,7 +864,6 @@ bool CUDAExecutionProvider::ConvNeedFallbackToCPU(const onnxruntime::Node& node)
 std::vector<std::unique_ptr<ComputeCapability>>
 CUDAExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
                                      const std::vector<const KernelRegistry*>& kernel_registries) const {
-  std::vector<std::unique_ptr<ComputeCapability>> result = IExecutionProvider::GetCapability(graph, kernel_registries);
 
   for (auto& node : graph.Nodes()) {
     bool fallback_to_cpu_provider = false;
@@ -888,6 +887,7 @@ CUDAExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
       update_node->SetExecutionProviderType(onnxruntime::kCpuExecutionProvider);
     }
   }
+  std::vector<std::unique_ptr<ComputeCapability>> result = IExecutionProvider::GetCapability(graph, kernel_registries);
 
   return result;
 }


### PR DESCRIPTION
IExecutionProvider::GetCapability returns redundant subgraphs when kernel_registries contains multiple registries supporting the op

This bug was reported by Jeff from WinML team.