### PR TITLE
Add new C function OrtOnnxTypeFromTypeInfo

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
@@ -299,6 +299,12 @@ namespace Microsoft.ML.OnnxRuntime
 
         internal static NodeMetadata GetMetadataFromTypeInfo(IntPtr typeInfo)
         {
+            var valueType = NativeMethods.OrtOnnxTypeFromTypeInfo(typeInfo);
+            if (valueType != OnnxValueType.ONNX_TYPE_TENSOR && valueType != OnnxValueType.ONNX_TYPE_SPARSETENSOR)
+            {
+                return new NodeMetadata(valueType, new int[] { }, typeof(NamedOnnxValue));
+            }
+
             IntPtr tensorInfo = NativeMethods.OrtCastTypeInfoToTensorInfo(typeInfo);
             // Convert the newly introduced OrtTypeInfo* to the older OrtTypeAndShapeInfo*
 
@@ -317,7 +323,7 @@ namespace Microsoft.ML.OnnxRuntime
             {
                 intDimensions[i] = (int)dimensions[i];
             }
-            return new NodeMetadata(intDimensions, dotnetType);
+            return new NodeMetadata(valueType, intDimensions, dotnetType);
         }
 
         #endregion
@@ -360,13 +366,23 @@ namespace Microsoft.ML.OnnxRuntime
     /// </summary>
     public class NodeMetadata
     {
+        private OnnxValueType _onnxValueType;
         private int[] _dimensions;
         private Type _type;
 
-        internal NodeMetadata(int[] dimensions, Type type)
+        internal NodeMetadata(OnnxValueType onnxValueType, int[] dimensions, Type type)
         {
+            _onnxValueType = onnxValueType;
             _dimensions = dimensions;
             _type = type;
+        }
+
+        public OnnxValueType OnnxValueType
+        {
+            get
+            {
+                return _onnxValueType;
+            }
         }
 
         public int[] Dimensions

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.cs
@@ -345,7 +345,7 @@ namespace Microsoft.ML.OnnxRuntime
         DataTypeMax = 17
     }
 
-    internal enum OnnxValueType
+    public enum OnnxValueType
     {
         ONNX_TYPE_UNKNOWN = 0,
         ONNX_TYPE_TENSOR = 1,

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
@@ -250,6 +250,9 @@ namespace Microsoft.ML.OnnxRuntime
         public static extern OnnxValueType /*Onnxtype*/   OrtGetValueType(IntPtr /*(OrtValue*)*/ value);
 
         [DllImport(nativeLib, CharSet = charSet)]
+        public static extern OnnxValueType /*Onnxtype*/   OrtOnnxTypeFromTypeInfo(IntPtr /*(OrtTypeInfo*)*/ typeinfo);
+
+        [DllImport(nativeLib, CharSet = charSet)]
         public static extern IntPtr /*(OrtStatus*)*/ OrtGetValueCount(IntPtr /*(OrtValue*)*/ value, out IntPtr /*(size_t*)*/ count);
 
         [DllImport(nativeLib, CharSet = charSet)]

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -536,6 +536,11 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_sequence_map_int_float.pb");
             using (var session = new InferenceSession(modelPath))
             {
+
+                var outMeta = session.OutputMetadata;
+                Assert.Equal(OnnxValueType.ONNX_TYPE_TENSOR, outMeta["label"].OnnxValueType);
+                Assert.Equal(OnnxValueType.ONNX_TYPE_SEQUENCE, outMeta["probabilities"].OnnxValueType);
+
                 var container = new List<NamedOnnxValue>();
                 var tensorIn = new DenseTensor<float>(new float[] { 5.8f, 2.8f }, new int[] { 1, 2 });
                 var nov = NamedOnnxValue.CreateFromTensor("input", tensorIn);
@@ -584,6 +589,10 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
             using (var session = new InferenceSession(modelPath))
             {
+                var outMeta = session.OutputMetadata;
+                Assert.Equal(OnnxValueType.ONNX_TYPE_TENSOR, outMeta["label"].OnnxValueType);
+                Assert.Equal(OnnxValueType.ONNX_TYPE_SEQUENCE, outMeta["probabilities"].OnnxValueType);
+
                 var container = new List<NamedOnnxValue>();
                 var tensorIn = new DenseTensor<float>(new float[] { 5.8f, 2.8f }, new int[] { 1, 2 });
                 var nov = NamedOnnxValue.CreateFromTensor("input", tensorIn);

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -361,7 +361,7 @@ ORT_API(const OrtTensorTypeAndShapeInfo*, OrtCastTypeInfoToTensorInfo, _In_ OrtT
 /**
  * Return OnnxType from OrtTypeInfo
  */
-ORT_API(const ONNXType, OrtOnnxTypeFromTypeInfo, _In_ OrtTypeInfo*);
+ORT_API(enum ONNXType, OrtOnnxTypeFromTypeInfo, _In_ OrtTypeInfo*);
 
 /**
  * The retured value should be released by calling OrtReleaseTensorTypeAndShapeInfo

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -361,7 +361,7 @@ ORT_API(const OrtTensorTypeAndShapeInfo*, OrtCastTypeInfoToTensorInfo, _In_ OrtT
 /**
  * Return OnnxType from OrtTypeInfo
  */
-ORT_API(enum ONNXType, OrtOnnxTypeFromTypeInfo, _In_ OrtTypeInfo*);
+ORT_API(enum ONNXType, OrtOnnxTypeFromTypeInfo, _In_ const OrtTypeInfo*);
 
 /**
  * The retured value should be released by calling OrtReleaseTensorTypeAndShapeInfo

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -359,6 +359,11 @@ ORT_API_STATUS(OrtGetTensorMemSizeInBytesFromTensorProto, _In_ const void* input
 ORT_API(const OrtTensorTypeAndShapeInfo*, OrtCastTypeInfoToTensorInfo, _In_ OrtTypeInfo*);
 
 /**
+ * Return OnnxType from OrtTypeInfo
+ */
+ORT_API(const ONNXType, OrtOnnxTypeFromTypeInfo, _In_ OrtTypeInfo*);
+
+/**
  * The retured value should be released by calling OrtReleaseTensorTypeAndShapeInfo
  */
 ORT_API(OrtTensorTypeAndShapeInfo*, OrtCreateTensorTypeAndShapeInfo);

--- a/onnxruntime/core/framework/onnxruntime_typeinfo.cc
+++ b/onnxruntime/core/framework/onnxruntime_typeinfo.cc
@@ -21,6 +21,10 @@ OrtTypeInfo::~OrtTypeInfo() {
   OrtReleaseTensorTypeAndShapeInfo(data);
 }
 
+ORT_API(const ONNXType, OrtOnnxTypeFromTypeInfo, _In_ struct OrtTypeInfo* input) {
+  return input->type;
+}
+
 ORT_API(const struct OrtTensorTypeAndShapeInfo*, OrtCastTypeInfoToTensorInfo, _In_ struct OrtTypeInfo* input) {
   return input->type == ONNX_TYPE_TENSOR ? input->data : nullptr;
 }

--- a/onnxruntime/core/framework/onnxruntime_typeinfo.cc
+++ b/onnxruntime/core/framework/onnxruntime_typeinfo.cc
@@ -21,7 +21,7 @@ OrtTypeInfo::~OrtTypeInfo() {
   OrtReleaseTensorTypeAndShapeInfo(data);
 }
 
-ORT_API(enum ONNXType, OrtOnnxTypeFromTypeInfo, _In_ struct OrtTypeInfo* input) {
+ORT_API(enum ONNXType, OrtOnnxTypeFromTypeInfo, _In_ const struct OrtTypeInfo* input) {
   return input->type;
 }
 

--- a/onnxruntime/core/framework/onnxruntime_typeinfo.cc
+++ b/onnxruntime/core/framework/onnxruntime_typeinfo.cc
@@ -21,7 +21,7 @@ OrtTypeInfo::~OrtTypeInfo() {
   OrtReleaseTensorTypeAndShapeInfo(data);
 }
 
-ORT_API(const ONNXType, OrtOnnxTypeFromTypeInfo, _In_ struct OrtTypeInfo* input) {
+ORT_API(enum ONNXType, OrtOnnxTypeFromTypeInfo, _In_ struct OrtTypeInfo* input) {
   return input->type;
 }
 

--- a/onnxruntime/core/providers/cpu/symbols.txt
+++ b/onnxruntime/core/providers/cpu/symbols.txt
@@ -49,6 +49,7 @@ OrtGetValue
 OrtGetValueCount
 OrtGetValueType
 OrtIsTensor
+OrtOnnxTypeFromTypeInfo
 OrtReleaseAllocator
 OrtReleaseAllocatorInfo
 OrtReleaseCustomOpDomain

--- a/onnxruntime/test/shared_lib/test_io_types.cc
+++ b/onnxruntime/test/shared_lib/test_io_types.cc
@@ -25,6 +25,9 @@ static void TestModelInfo(const OrtSession* inference_session, bool is_input, co
     input_type_info.reset(t);
   }
   ASSERT_NE(nullptr, input_type_info);
+  enum ONNXType otype = OrtOnnxTypeFromTypeInfo(input_type_info.get());
+  ASSERT_EQ(ONNX_TYPE_TENSOR, otype);
+
   const OrtTensorTypeAndShapeInfo* p = OrtCastTypeInfoToTensorInfo(input_type_info.get());
   ASSERT_NE(nullptr, p);
 


### PR DESCRIPTION
This is needed to identify if an input or output is a tensor type, or some other type such as sequence or map.