### PR TITLE
Remap node index in trt execution provider

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -79,7 +79,10 @@ TensorrtExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
   int counter = 0;
   for (const auto& group : supported_nodes_vector) {
     if (!group.empty()) {
-      std::set<size_t> node_set(group.begin(), group.end());
+      std::set<size_t> node_set;
+      for (const auto& index : group) {
+        node_set.insert(node_index[index]);
+      }
       std::unique_ptr<IndexedSubGraph> sub_graph = std::make_unique<IndexedSubGraph>();
       // Find inputs and outputs of the subgraph
       std::map<const NodeArg *, int> fused_inputs, fused_outputs, fused_outputs_to_add;
@@ -88,9 +91,9 @@ TensorrtExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
       int output_order = 0;
 
       for (const auto& index : group) {
-        supported_nodes_set.insert(index);
-        sub_graph->nodes.push_back(index);
-        const auto& node = graph.GetNode(index);
+        supported_nodes_set.insert(node_index[index]);
+        sub_graph->nodes.push_back(node_index[index]);
+        const auto& node = graph.GetNode(node_index[index]);
 
         for (const auto& input : node->InputDefs()) {
           const auto& it = fused_outputs.find(input);


### PR DESCRIPTION
The indices in `supported_nodes_vector` is different from the one in `group` if there are `nullptr` in `graph`. This change re-maps the index from `supported_nodes_vector` to that  of `graph`.