### PR TITLE
Rename utils namespace related to graph operations to graph_utils

### DIFF
--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -7,7 +7,7 @@
 
 namespace onnxruntime {
 
-namespace utils {
+namespace graph_utils {
 // fusion is only done for ONNX domain ops
 bool IsSupportedOptypeVersionAndDomain(const Node& node,
                                        const std::string& op_type,
@@ -148,6 +148,6 @@ size_t RemoveNodeOutputEdges(Graph& graph, Node& node) {
   return edges_to_remove.size();
 }
 
-}  // namespace utils
+}  // namespace graph_utils
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/graph/graph_utils.h
+++ b/onnxruntime/core/graph/graph_utils.h
@@ -8,7 +8,7 @@
 
 namespace onnxruntime {
 
-namespace utils {
+namespace graph_utils {
 bool IsSupportedOptypeVersionAndDomain(const Node& node,
                                        const std::string& op_type,
                                        ONNX_NAMESPACE::OperatorSetVersion version,
@@ -28,7 +28,7 @@ template <typename T>
 bool GetRepeatedNodeAttributeValues(const Node& node,
                                     const std::string& attr_name,
                                     std::vector<T>& values) {
-  const auto* attr = utils::GetNodeAttribute(node, attr_name);
+  const auto* attr = graph_utils::GetNodeAttribute(node, attr_name);
   if (attr) {
     values = ONNX_NAMESPACE::RetrieveValues<T>(*attr);
     return true;
@@ -50,6 +50,6 @@ bool IsConstantInputsNode(const Graph& graph, const Node& node);
     This should probably be elevated to the Graph API eventually. */
 size_t RemoveNodeOutputEdges(Graph& graph, Node& node);
 
-}  // namespace utils
+}  // namespace graph_utils
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -45,7 +45,7 @@ Status ConstantFolding::Apply(Graph& graph, Node& node, bool& modified, bool& de
   }
 
   // Remove the output edges of the constant node and then remove the node itself.
-  utils::RemoveNodeOutputEdges(graph, node);
+  graph_utils::RemoveNodeOutputEdges(graph, node);
   graph.RemoveNode(node.Index());
 
   // The output nodes already have the right input arg, since we used the same name in the initializer.
@@ -57,7 +57,7 @@ Status ConstantFolding::Apply(Graph& graph, Node& node, bool& modified, bool& de
 }  // namespace onnxruntime
 
 bool ConstantFolding::SatisfyCondition(const Graph& graph, const Node& node) {
-  return OpTypeCondition(node) && utils::IsConstantInputsNode(graph, node);
+  return OpTypeCondition(node) && graph_utils::IsConstantInputsNode(graph, node);
 }
 
 bool ConstantFolding::OpTypeCondition(const Node& node) {

--- a/onnxruntime/core/optimizer/conv_activation_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_activation_fusion.cc
@@ -12,10 +12,10 @@ namespace onnxruntime {
 
 namespace {
 bool IsFusableActivation(const Node& node) {
-  return utils::IsSupportedOptypeVersionAndDomain(node, "LeakyRelu", 6) ||
-         utils::IsSupportedOptypeVersionAndDomain(node, "Relu", 6) ||
-         utils::IsSupportedOptypeVersionAndDomain(node, "Sigmoid", 6) ||
-         utils::IsSupportedOptypeVersionAndDomain(node, "Tanh", 6);
+  return graph_utils::IsSupportedOptypeVersionAndDomain(node, "LeakyRelu", 6) ||
+         graph_utils::IsSupportedOptypeVersionAndDomain(node, "Relu", 6) ||
+         graph_utils::IsSupportedOptypeVersionAndDomain(node, "Sigmoid", 6) ||
+         graph_utils::IsSupportedOptypeVersionAndDomain(node, "Tanh", 6);
 }
 
 void HandleActivationNodeEdges(Graph& g, const Node& act, Node& fused_conv) {
@@ -46,7 +46,7 @@ Status ConvActivationFusion::ApplyImpl(Graph& graph, bool& modified, int graph_l
     auto node = graph.GetNode(index);
     ORT_RETURN_IF_ERROR(Recurse(*node, modified, graph_level));
 
-    if (!utils::IsSupportedOptypeVersionAndDomain(*node, "Conv", 1) || node->GetOutputEdgesCount() != 1) {
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(*node, "Conv", 1) || node->GetOutputEdgesCount() != 1) {
       continue;
     }
     const Node& next_node = *(node->OutputNodesBegin());

--- a/onnxruntime/core/optimizer/conv_add_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_add_fusion.cc
@@ -14,12 +14,12 @@ Status ConvAddFusion::ApplyImpl(onnxruntime::Graph& graph, bool& modified, int g
   for (auto& node : graph.Nodes()) {
     ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level));
 
-    if (!utils::IsSupportedOptypeVersionAndDomain(node, "Conv", 1) || node.GetOutputEdgesCount() != 1) {
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(node, "Conv", 1) || node.GetOutputEdgesCount() != 1) {
       continue;
     }
 
     const Node& next_node = *node.OutputNodesBegin();
-    if (!utils::IsSupportedOptypeVersionAndDomain(next_node, "Add", 7) ||
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(next_node, "Add", 7) ||
         next_node.GetInputEdgesCount() != 1 ||
         graph.IsNodeOutputsInGraphOutputs(next_node)) {
       continue;

--- a/onnxruntime/core/optimizer/conv_bn_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_bn_fusion.cc
@@ -14,12 +14,12 @@ Status ConvBNFusion::ApplyImpl(onnxruntime::Graph& graph, bool& modified, int gr
   for (auto& node : graph.Nodes()) {
     ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level));
 
-    if (!utils::IsSupportedOptypeVersionAndDomain(node, "Conv", 1) || node.GetOutputEdgesCount() != 1) {
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(node, "Conv", 1) || node.GetOutputEdgesCount() != 1) {
       continue;
     }
 
     const Node& next_node = *node.OutputNodesBegin();
-    if (!utils::IsSupportedOptypeVersionAndDomain(next_node, "BatchNormalization", 7) ||
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(next_node, "BatchNormalization", 7) ||
         next_node.GetInputEdgesCount() != 1 ||
         graph.IsNodeOutputsInGraphOutputs(next_node)) {
       continue;

--- a/onnxruntime/core/optimizer/conv_mul_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_mul_fusion.cc
@@ -14,12 +14,12 @@ Status ConvMulFusion::ApplyImpl(onnxruntime::Graph& graph, bool& modified, int g
   for (auto& node : graph.Nodes()) {
     ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level));
     
-    if (!utils::IsSupportedOptypeVersionAndDomain(node, "Conv", 1) || node.GetOutputEdgesCount() != 1) {
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(node, "Conv", 1) || node.GetOutputEdgesCount() != 1) {
       continue;
     }
 
     const Node& next_node = *node.OutputNodesBegin();
-    if (!utils::IsSupportedOptypeVersionAndDomain(next_node, "Mul", 7) ||
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(next_node, "Mul", 7) ||
         next_node.GetInputEdgesCount() != 1 ||
         graph.IsNodeOutputsInGraphOutputs(next_node)) {
       continue;

--- a/onnxruntime/core/optimizer/gemm_activation_fusion.cc
+++ b/onnxruntime/core/optimizer/gemm_activation_fusion.cc
@@ -12,10 +12,10 @@ namespace onnxruntime {
 
 namespace {
 bool IsFusableActivation(const Node& node) {
-  return utils::IsSupportedOptypeVersionAndDomain(node, "LeakyRelu", 6) ||
-         utils::IsSupportedOptypeVersionAndDomain(node, "Relu", 6) ||
-         utils::IsSupportedOptypeVersionAndDomain(node, "Sigmoid", 6) ||
-         utils::IsSupportedOptypeVersionAndDomain(node, "Tanh", 6);
+  return graph_utils::IsSupportedOptypeVersionAndDomain(node, "LeakyRelu", 6) ||
+         graph_utils::IsSupportedOptypeVersionAndDomain(node, "Relu", 6) ||
+         graph_utils::IsSupportedOptypeVersionAndDomain(node, "Sigmoid", 6) ||
+         graph_utils::IsSupportedOptypeVersionAndDomain(node, "Tanh", 6);
 }
 
 void HandleActivationNodeEdges(Graph& g, const Node& act, Node& fused_gemm) {
@@ -46,8 +46,8 @@ Status GemmActivationFusion::ApplyImpl(Graph& graph, bool& modified, int graph_l
     auto& node = *graph.GetNode(index);
     ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level));
 
-    if (!(utils::IsSupportedOptypeVersionAndDomain(node, "Gemm", 7) ||
-          utils::IsSupportedOptypeVersionAndDomain(node, "Gemm", 9)) ||
+    if (!(graph_utils::IsSupportedOptypeVersionAndDomain(node, "Gemm", 7) ||
+          graph_utils::IsSupportedOptypeVersionAndDomain(node, "Gemm", 9)) ||
         node.GetOutputEdgesCount() != 1) {
       continue;
     }

--- a/onnxruntime/core/optimizer/identity_elimination.cc
+++ b/onnxruntime/core/optimizer/identity_elimination.cc
@@ -11,7 +11,7 @@
 namespace onnxruntime {
 
 Status EliminateIdentity::Apply(Graph& graph, Node& node, bool& modified, bool& deleted) {
-  if (utils::RemoveSingleInSingleOutNode(graph, node)) {
+  if (graph_utils::RemoveSingleInSingleOutNode(graph, node)) {
     modified = deleted = true;
   }
 
@@ -19,7 +19,7 @@ Status EliminateIdentity::Apply(Graph& graph, Node& node, bool& modified, bool& 
 }
 
 bool EliminateIdentity::SatisfyCondition(const Graph& /*graph*/, const Node& node) {
-  return OpTypeCondition(node) && utils::IsSingleInSingleOutNode(node);
+  return OpTypeCondition(node) && graph_utils::IsSingleInSingleOutNode(node);
 }
 
 bool EliminateIdentity::OpTypeCondition(const Node& node) {

--- a/onnxruntime/core/optimizer/matmul_add_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_add_fusion.cc
@@ -19,8 +19,8 @@ Status MatMulAddFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level)
     auto& node = *graph.GetNode(node_index);
     ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level));
 
-    if (!(utils::IsSupportedOptypeVersionAndDomain(node, "MatMul", 1) ||
-          utils::IsSupportedOptypeVersionAndDomain(node, "MatMul", 9)) ||
+    if (!(graph_utils::IsSupportedOptypeVersionAndDomain(node, "MatMul", 1) ||
+          graph_utils::IsSupportedOptypeVersionAndDomain(node, "MatMul", 9)) ||
         node.GetOutputEdgesCount() != 1) {
       continue;
     }
@@ -31,7 +31,7 @@ Status MatMulAddFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level)
     }
 
     const Node& next_node = (*next_node_itr);
-    if (!utils::IsSupportedOptypeVersionAndDomain(next_node, "Add", 7)) {
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(next_node, "Add", 7)) {
       continue;
     }
 

--- a/onnxruntime/core/optimizer/slice_elimination.cc
+++ b/onnxruntime/core/optimizer/slice_elimination.cc
@@ -9,7 +9,7 @@
 namespace onnxruntime {
 
 Status EliminateSlice::Apply(Graph& graph, Node& node, bool& modified, bool& removed) {
-  if (utils::RemoveSingleInSingleOutNode(graph, node)) {
+  if (graph_utils::RemoveSingleInSingleOutNode(graph, node)) {
     removed = modified = true;
   }
 
@@ -22,19 +22,19 @@ bool EliminateSlice::SatisfyCondition(const Graph& /*graph*/, const Node& node) 
   }
 
   // At the moment, we eliminate a slice operator only if it has a single input and a single output.
-  if (!utils::IsSingleInSingleOutNode(node)) {
+  if (!graph_utils::IsSingleInSingleOutNode(node)) {
     return false;
   }
 
   std::vector<int64_t> starts;
   std::vector<int64_t> ends;
-  if (!utils::GetRepeatedNodeAttributeValues(node, "starts", starts) ||
-      !utils::GetRepeatedNodeAttributeValues(node, "ends", ends) ||
+  if (!graph_utils::GetRepeatedNodeAttributeValues(node, "starts", starts) ||
+      !graph_utils::GetRepeatedNodeAttributeValues(node, "ends", ends) ||
       starts.size() != ends.size()) {
     return false;
   }
   std::vector<int64_t> axes;
-  if (!utils::GetRepeatedNodeAttributeValues(node, "axes", axes)) {
+  if (!graph_utils::GetRepeatedNodeAttributeValues(node, "axes", axes)) {
     for (int i = 0; (size_t)i < starts.size(); ++i) {
       axes.push_back(i);
     }


### PR DESCRIPTION
Renaming utils namespace that is related to graph operations to graph_utils to avoid name conflicts and make easier to understand where these helper functions are coming from.