### PR TITLE
Don't use MLAS unconditionally; default to Eigen when MLAS is disabled.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -86,7 +86,7 @@ if(onnxruntime_USE_OPENMP)
 endif()
 
 if(onnxruntime_CROSS_COMPILING)
-  set(CMAKE_CROSSCOMPILING ON)  
+  set(CMAKE_CROSSCOMPILING ON)
 endif()
 
 #must after OpenMP settings
@@ -350,7 +350,7 @@ if (WIN32)
         string(APPEND CMAKE_CXX_FLAGS " /W4")
     endif()
 
-    # treat warning as error only on x64 platform. 
+    # treat warning as error only on x64 platform.
     # For x86 and cross-compiled ARM64 binaries, there are too many warnings to fix, hence ignore warnings for now
     if (CMAKE_SIZEOF_VOID_P EQUAL 8 AND onnxruntime_DEV_MODE AND NOT CMAKE_CROSSCOMPILING)
       # treat warnings as errors

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -308,7 +308,7 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
                  "-Donnxruntime_ENABLE_MICROSOFT_INTERNAL=" + ("ON" if args.enable_msinternal else "OFF"),
                  "-Donnxruntime_USE_BRAINSLICE=" + ("ON" if args.use_brainslice else "OFF"),
                  "-Donnxruntime_USE_NUPHAR=" + ("ON" if args.use_nuphar else "OFF"),
-                 "-Donnxruntime_USE_EIGEN_THREADPOOL=" + ("ON" if args.use_eigenthreadpool else "OFF"), 
+                 "-Donnxruntime_USE_EIGEN_THREADPOOL=" + ("ON" if args.use_eigenthreadpool else "OFF"),
                  "-Donnxruntime_USE_TRT=" + ("ON" if args.use_trt else "OFF"),
                   # By default - we currently support only cross compiling for ARM/ARM64 (no native compilation supported through this script)
                  "-Donnxruntime_CROSS_COMPILING=" + ("ON" if args.arm64 or args.arm else "OFF"),
@@ -512,9 +512,9 @@ def run_onnx_tests(build_dir, configs, onnx_test_data_dir, provider, enable_para
           cmd.append(model_dir)
         if os.path.exists(onnx_test_data_dir):
           cmd.append(onnx_test_data_dir)
-        
+
         if enable_parallel_executor_test:
-          run_subprocess([exe] + cmd, cwd=cwd)  
+          run_subprocess([exe] + cmd, cwd=cwd)
           if provider == 'mkldnn':
             #limit concurrency to 1
             run_subprocess([exe,'-x', '-c', '1'] + cmd, cwd=cwd)
@@ -580,7 +580,7 @@ def main():
 
     if args.build_wheel:
         args.enable_pybind = True
-    
+
     if args.build_csharp:
         args.build_shared_lib = True
 


### PR DESCRIPTION
Currently the Mlas* APIs are used unconditionally. Certain partners (confidential) had trouble compiling MLAS on certain platforms. Hence the PR.