### PR TITLE
Minor fix to disallow an execution provider registering a nullptr.  

### DIFF
--- a/onnxruntime/core/framework/kernel_registry_manager.cc
+++ b/onnxruntime/core/framework/kernel_registry_manager.cc
@@ -60,7 +60,14 @@ Status KernelRegistryManager::RegisterKernels(const ExecutionProviders& executio
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "found duplicated provider ", provider->Type(),
                              " in KernelRegistryManager");
     }
-    provider_type_to_registry_.insert(std::make_pair(provider->Type(), provider->GetKernelRegistry()));
+
+    auto registry = provider->GetKernelRegistry();
+    if (!registry) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Execution provider ", provider->Type(),
+                             "does not have a kernel registry.");
+    }
+
+    provider_type_to_registry_.insert(std::make_pair(provider->Type(), registry));
   }
   return Status::OK();
 }


### PR DESCRIPTION
This maintains the expected behavior of GetKernelRegistriesByProviderType to not return any nullptrs.