### PR TITLE
Add missing include to status.h

### DIFF
--- a/include/onnxruntime/core/common/status.h
+++ b/include/onnxruntime/core/common/status.h
@@ -14,6 +14,7 @@ limitations under the License.
 #pragma once
 
 #include <memory>
+#include <ostream>
 #include <string>
 #include "core/common/ml_status.h"
 


### PR DESCRIPTION
status.h must include `<ostream>` to use `std::ostream`.

(This happened to compile because `<string>` transitively includes `<iostream>` in older MSVC versions, but that's no longer the case in VS2019.)