### PR TITLE
fixing clang build failure

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -10,7 +10,7 @@ include(CheckCXXCompilerFlag)
 include(CheckLanguage)
 
 # Set C++14 as standard for the whole project
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "")
 
 # General C# prperties
 if (onnxruntime_BUILD_CSHARP)


### PR DESCRIPTION
Build failure with Clang :
OS : Linux, Ubuntu 16.04LTS
gcc version : 5.4.0
clang version 6.0.0
cmake version : 3.11.4

Root Cause 
    The external/date library internally uses C++17 standard by default, although it can be built with
 c++14. So, CMAKE_CXX_STANDARD in Date library have defined it as cache variable so that it can be
overridden.
    In onnxruntime code, CMAKE_CXX_STANDARD is not declared as cache variable. So the 
requiremet of C++14 is not passed onto date library. The date library uses string_view if C++17 is on. 
That class is not part of gcc 5.4.0 and we  get a compilation error.

Why g++ compilation passes?
    In date libary, string_view is used only when __cplusplus flag is >= 201703. In case of g++ 5.4.0
 CMake adds, deprecated -std=gnu++1z instead of standard -std=gnu++17. In presence of 
-std=gnu++1z __cplusplus is evaluated as 201500 (which is non standard) and the string_view is 
never invoked. This behaviour has been observed till gcc 6.2.0 and corrected from gcc 7.1.0 onwards. 
Whereas clang sets __cplusplus to 201703 when -std=gnu++1z is passed.

Resolution : 
    set(CMAKE_CXX_STANDARD 14 CACHE STRING ""). in cmake/CMakeLists.txt.

Check correctness :
    check CXX_FLAGS in build/Linux/Debug/external/date/CMakeFiles/tz.dir/flags.make. -std=gnu++14
gets added with the fix (which is otherwise -std=gnu++1z)
    
Alternative :
    1) The current repo of Date library as introduced, a CMake variable to turn off the string_view usage. 
We can move to the new branch and add the option. 
    2) Use gcc 7.1.0 or onwards so that clang/gcc picks up correct c++ libary with c++17 support. The 
problem with this approach is that there will be multiple c++ standards across the project. 