### PR TITLE
Fix a warning in GraphTransformerManager

### DIFF
--- a/onnxruntime/core/optimizer/graph_transformer_mgr.h
+++ b/onnxruntime/core/optimizer/graph_transformer_mgr.h
@@ -26,7 +26,6 @@ class GraphTransformerManager {
   common::Status ApplyTransformers(Graph& graph, const TransformerLevel& level) const;
 
  private:
-  GraphTransformerManager() = default;
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(GraphTransformerManager);
 
   const std::vector<std::string>& GetProvidersForTransformer(const std::string& name) const {


### PR DESCRIPTION
```
onnxruntime/core/optimizer/graph_transformer_mgr.h:29:3: error: explicitly defaulted default constructor is
      implicitly deleted [-Werror,-Wdefaulted-function-deleted]
  GraphTransformerManager() = default;
  ^
onnxruntime/core/optimizer/graph_transformer_mgr.h:38:18: note: default constructor of 'GraphTransformerManager' is
      implicitly deleted because field 'steps_' of const-qualified type 'const unsigned int' would not be initialized
  const unsigned steps_;
```