### PR TITLE
tile op: make implementation type-agnostic (and support a few more types)

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/tile.cc
+++ b/onnxruntime/core/providers/cpu/tensor/tile.cc
@@ -24,47 +24,17 @@ namespace onnxruntime {
 ONNX_CPU_OPERATOR_KERNEL(
     Tile,
     6,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
-    Tile<float>);
+    KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                                            DataTypeImpl::GetTensorType<int32_t>()}),
+    Tile);
 
-template <>
-Status Tile<float>::Compute(OpKernelContext* ctx) const {
-  const Tensor* tensor_pointer = ctx->Input<Tensor>(0);
-  if (tensor_pointer == nullptr) return Status(common::ONNXRUNTIME, common::FAIL, "Input count of Tile OP mismatch, the first one is empty");
-  const Tensor& input_tensor = *tensor_pointer;
-  tensor_pointer = ctx->Input<Tensor>(1);
-  if (tensor_pointer == nullptr) return Status(common::ONNXRUNTIME, common::FAIL, "Input count of Tile OP mismatch, the second one is empty");
-  const Tensor& repeats_tensor = *tensor_pointer;
 
+template <typename T>
+Status TileCore(const Tensor& input_tensor, Tensor& output_tensor, const int64_t* repeats, TensorAxisCounters& input_counters, const TensorPitches& output_pitches) {
   size_t dimension_count = input_tensor.Shape().NumDimensions();
 
-  if (repeats_tensor.Shape().NumDimensions() != 1)
-    return Status(ONNXRUNTIME, INVALID_ARGUMENT, "'repeat' input tensor must be 1 dimensional");
-  if (size_t(repeats_tensor.Shape().Size()) != input_tensor.Shape().NumDimensions())
-    return Status(ONNXRUNTIME, INVALID_ARGUMENT, "'repeat' input tensor must have the same length as the 'input' tensor");
-
-  // Calculate the shape of the output tensor
-  auto* repeats = repeats_tensor.template Data<int64_t>();
-  std::vector<int64_t> output_dims = input_tensor.Shape().GetDims();
-  for (auto axis = 0; axis < input_tensor.Shape().NumDimensions(); axis++) {
-    output_dims[axis] *= repeats[axis];
-  }
-
-  TensorShape outputShape(output_dims);
-  auto& output_tensor = *ctx->Output(0, outputShape);
-
-  // Repeat tensor input can have 0 as a valid value
-  // check if the computed outputshape size is 0 and
-  // return an empty tensor if so.
-  if (outputShape.Size() == 0) {
-    return Status::OK();
-  }
-
-  auto* output = output_tensor.template MutableData<float>();
-  auto* input = input_tensor.template Data<float>();
-
-  TensorPitches output_pitches(output_tensor);
-  TensorAxisCounters input_counters(input_tensor);
+  auto* input = input_tensor.template Data<T>();
+  auto* output = output_tensor.template MutableData<T>();
 
   while (input_counters) {
     // Copy the input data over
@@ -88,4 +58,46 @@ Status Tile<float>::Compute(OpKernelContext* ctx) const {
   }
   return Status::OK();
 }
+
+  Status Tile::Compute(OpKernelContext* ctx) const {
+  const Tensor* tensor_pointer = ctx->Input<Tensor>(0);
+  if (tensor_pointer == nullptr) return Status(common::ONNXRUNTIME, common::FAIL, "Input count of Tile OP mismatch, the first one is empty");
+  const Tensor& input_tensor = *tensor_pointer;
+  tensor_pointer = ctx->Input<Tensor>(1);
+  if (tensor_pointer == nullptr) return Status(common::ONNXRUNTIME, common::FAIL, "Input count of Tile OP mismatch, the second one is empty");
+  const Tensor& repeats_tensor = *tensor_pointer;
+
+  if (repeats_tensor.Shape().NumDimensions() != 1)
+    return Status(ONNXRUNTIME, INVALID_ARGUMENT, "'repeat' input tensor must be 1 dimensional");
+  if (size_t(repeats_tensor.Shape().Size()) != input_tensor.Shape().NumDimensions())
+    return Status(ONNXRUNTIME, INVALID_ARGUMENT, "'repeat' input tensor must have the same length as the 'input' tensor");
+
+  // Calculate the shape of the output tensor
+  auto* repeats = repeats_tensor.template Data<int64_t>();
+  std::vector<int64_t> output_dims = input_tensor.Shape().GetDims();
+  for (auto axis = 0; axis < input_tensor.Shape().NumDimensions(); axis++) {
+    output_dims[axis] *= repeats[axis];
+  }
+
+  TensorShape outputShape(output_dims);
+  auto& output_tensor = *ctx->Output(0, outputShape);
+
+  // Repeat tensor input can have 0 as a valid value
+  // check if the computed outputshape size is 0 and
+  // return an empty tensor if so.
+  if (outputShape.Size() == 0) {
+    return Status::OK();
+  }
+
+  const auto& dtype = input_tensor.DataType();
+  TensorAxisCounters input_counters(input_tensor);
+  TensorPitches output_pitches(output_tensor);
+
+  if (dtype == DataTypeImpl::GetType<float>())
+    return TileCore<float>(input_tensor, output_tensor, repeats, input_counters, output_pitches);
+  else if (dtype == DataTypeImpl::GetType<int32_t>())
+    return TileCore<int32_t>(input_tensor, output_tensor, repeats, input_counters, output_pitches);
+  else
+    ORT_THROW("Tile doesn't have an implementation yet for the type: ", dtype);
+  }
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/tensor/tile.h
+++ b/onnxruntime/core/providers/cpu/tensor/tile.h
@@ -7,7 +7,6 @@
 
 namespace onnxruntime {
 
-template <typename T>
 struct Tile final : OpKernel {
   Tile(const OpKernelInfo& info) : OpKernel(info) {
   }

--- a/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
@@ -7,158 +7,104 @@
 namespace onnxruntime {
 namespace test {
 
-TEST(TensorOpTest, Tile1DWithZeroRepeatsFloatInput) {
+template <typename T>
+void RunTest(std::initializer_list<T> input,
+             std::initializer_list<int64_t> input_dims,
+             std::initializer_list<int64_t> repeat,
+             std::initializer_list<int64_t> repeat_dims,
+             std::initializer_list<T> output,
+             std::initializer_list<int64_t> output_dims) {
   OpTester test("Tile");
-
-  test.AddInput<float>("input", {3}, {1.0f, 2.0f, 3.0f});
-  test.AddInput<int64_t>("repeats", {1}, {0});
-  test.AddOutput<float>("output", {0}, {});
+  test.AddInput<T>("input", input_dims, input);
+  test.AddInput<int64_t>("repeats", repeat_dims, repeat);
+  test.AddOutput<T>("output", output_dims, output);
   test.Run();
 }
 
-TEST(TensorOpTest, Tile1DWithZeroRepeatsInt32Input) {
-  OpTester test("Tile");
+template <typename T>
+void RunTestWrapper() {
+  // Tile1DWithZeroRepeats
+  RunTest<T>({1, 2, 3}, {3}, {0}, {1}, {}, {0});
 
-  test.AddInput<int32_t>("input", {3}, {1, 2, 3});
-  test.AddInput<int64_t>("repeats", {1}, {0});
-  test.AddOutput<int32_t>("output", {0}, {});
-  test.Run();
+  // Tile2DWithZeroRepeats
+  RunTest<T>({11, 12, 21, 22}, {2, 2}, {2, 0}, {2}, {}, {4, 0});
+
+  // Tile1D
+  RunTest<T>({1, 2, 3}, {3}, {3}, {1}, {1, 2, 3, 1, 2, 3, 1, 2, 3}, {9});
+
+  // Tile2D_1Axis
+  RunTest<T>({11, 12, 21, 22}, {2, 2}, {2, 1}, {2}, {11, 12, 21, 22, 11, 12, 21, 22}, {4, 2});
+
+  // Tile2D_2Axes
+  RunTest<T>({11, 12, 21, 22}, {2, 2}, {2, 2}, {2}, {11, 12, 11, 12, 21, 22, 21, 22, 11, 12, 11, 12, 21, 22, 21, 22}, {4, 4});
+
+  // Tile3D
+  RunTest<T>({111, 112, 113, 122, 123, 124}, {2, 1, 3}, {1, 2, 1}, {3}, {111, 112, 113, 111, 112, 113, 122, 123, 124, 122, 123, 124}, {2, 2, 3});
 }
 
-TEST(TensorOpTest, Tile2DWithZeroRepeatsFloatInput) {
-  OpTester test("Tile");
+template <>
+void RunTestWrapper<bool>() {
+  // Tile1DWithZeroRepeats
+  RunTest<bool>({true, false, true}, {3}, {0}, {1}, {}, {0});
 
-  test.AddInput<float>("input", {2, 2},
-                       {11.0f, 12.0f,
-                        21.0f, 22.0f});
-  test.AddInput<int64_t>("repeats", {2}, {2, 0});
-  test.AddOutput<float>("output", {4, 0}, {});
-  test.Run();
+  // Tile2DWithZeroRepeats
+  RunTest<bool>({true, false, true, false}, {2, 2}, {2, 0}, {2}, {}, {4, 0});
+
+  // Tile1D
+  RunTest<bool>({true, false, true}, {3}, {3}, {1}, {true, false, true, true, false, true, true, false, true}, {9});
+
+  // Tile2D_1Axis
+  RunTest<bool>({true, false, true, false}, {2, 2}, {2, 1}, {2}, {true, false, true, false, true, false, true, false}, {4, 2});
+
+  // Tile2D_2Axes
+  RunTest<bool>({true, false, true, false}, {2, 2}, {2, 2}, {2}, {true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false}, {4, 4});
+
+  // Tile3D
+  RunTest<bool>({true, false, true, false, true, false}, {2, 1, 3}, {1, 2, 1}, {3}, {true, false, true, true, false, true, false, true, false, false, true, false}, {2, 2, 3});
 }
 
-TEST(TensorOpTest, Tile2DWithZeroRepeatsInt32Input) {
-  OpTester test("Tile");
-
-  test.AddInput<int32_t>("input", {2, 2},
-                       {11, 12,
-                        21, 22});
-  test.AddInput<int64_t>("repeats", {2}, {2, 0});
-  test.AddOutput<int32_t>("output", {4, 0}, {});
-  test.Run();
+TEST(TensorOpTest, TileFloatType) {
+  RunTestWrapper<float>();
 }
 
-TEST(TensorOpTest, Tile1DFloatInput) {
-  OpTester test("Tile");
-
-  test.AddInput<float>("input", {3}, {1.0f, 2.0f, 3.0f});
-  test.AddInput<int64_t>("repeats", {1}, {3});
-  test.AddOutput<float>("output", {9}, {1.0f, 2.0f, 3.0f, 1.0f, 2.0f, 3.0f, 1.0f, 2.0f, 3.0f});
-  test.Run();
+TEST(TensorOpTest, TileDoubleType) {
+  RunTestWrapper<double>();
 }
 
-TEST(TensorOpTest, Tile1DInt32Input) {
-  OpTester test("Tile");
-
-  test.AddInput<int32_t>("input", {3}, {1, 2, 3});
-  test.AddInput<int64_t>("repeats", {1}, {3});
-  test.AddOutput<int32_t>("output", {9}, {1, 2, 3, 1, 2, 3, 1, 2, 3});
-  test.Run();
+TEST(TensorOpTest, TileInt8Type) {
+  RunTestWrapper<int8_t>();
 }
 
-TEST(TensorOpTest, Tile2D_1AxisFloatInput) {
-  OpTester test("Tile");
-
-  test.AddInput<float>("input", {2, 2},
-                       {11.0f, 12.0f,
-                        21.0f, 22.0f});
-  test.AddInput<int64_t>("repeats", {2}, {2, 1});
-  test.AddOutput<float>("output", {4, 2},
-                        {11.0f, 12.0f,
-                         21.0f, 22.0f,
-                         11.0f, 12.0f,
-                         21.0f, 22.0f});
-
-  test.Run();
+TEST(TensorOpTest, TileUint8Type) {
+  RunTestWrapper<uint8_t>();
 }
 
-TEST(TensorOpTest, Tile2D_1AxisInt32Input) {
-  OpTester test("Tile");
-
-  test.AddInput<int32_t>("input", {2, 2},
-                       {11, 12,
-                        21, 22});
-  test.AddInput<int64_t>("repeats", {2}, {2, 1});
-  test.AddOutput<int32_t>("output", {4, 2},
-                        {11, 12,
-                         21, 22,
-                         11, 12,
-                         21, 22});
-
-  test.Run();
+TEST(TensorOpTest, TileInt16Type) {
+  RunTestWrapper<int16_t>();
 }
 
-TEST(TensorOpTest, Tile2D_2AxesFloatInput) {
-  OpTester test("Tile");
-
-  test.AddInput<float>("input", {2, 2},
-                       {11.0f, 12.0f,
-                        21.0f, 22.0f});
-  test.AddInput<int64_t>("repeats", {2}, {2, 2});
-  test.AddOutput<float>("output", {4, 4},
-                        {11.0f, 12.0f, 11.0f, 12.0f,
-                         21.0f, 22.0f, 21.0f, 22.0f,
-                         11.0f, 12.0f, 11.0f, 12.0f,
-                         21.0f, 22.0f, 21.0f, 22.0f});
-
-  test.Run();
+TEST(TensorOpTest, TileUint16Type) {
+  RunTestWrapper<uint16_t>();
 }
 
-TEST(TensorOpTest, Tile2D_2AxesInt32Input) {
-  OpTester test("Tile");
-
-  test.AddInput<int32_t>("input", {2, 2},
-                       {11, 12,
-                        21, 22});
-  test.AddInput<int64_t>("repeats", {2}, {2, 2});
-  test.AddOutput<int32_t>("output", {4, 4},
-                        {11, 12, 11, 12,
-                         21, 22, 21, 22,
-                         11, 12, 11, 12,
-                         21, 22, 21, 22});
-
-  test.Run();
+TEST(TensorOpTest, TileInt32Type) {
+  RunTestWrapper<int32_t>();
 }
 
-TEST(TensorOpTest, Tile3DFloatInput) {
-  OpTester test("Tile");
-
-  test.AddInput<float>("input", {2, 1, 3},
-                       {111.0f, 112.0f, 113.0f,
-                        211.0f, 212.0f, 213.0f});
-  test.AddInput<int64_t>("repeats", {3}, {1, 2, 1});
-  test.AddOutput<float>("output", {2, 2, 3},
-                        {111.0f, 112.0f, 113.0f,
-                         111.0f, 112.0f, 113.0f,
-
-                         211.0f, 212.0f, 213.0f,
-                         211.0f, 212.0f, 213.0f});
-  test.Run();
+TEST(TensorOpTest, TileUint32Type) {
+  RunTestWrapper<uint32_t>();
 }
 
-TEST(TensorOpTest, Tile3DInt32Input) {
-  OpTester test("Tile");
+TEST(TensorOpTest, TileInt64Type) {
+  RunTestWrapper<int64_t>();
+}
 
-  test.AddInput<int32_t>("input", {2, 1, 3},
-                       {111, 112, 113,
-                        211, 212, 213});
-  test.AddInput<int64_t>("repeats", {3}, {1, 2, 1});
-  test.AddOutput<int32_t>("output", {2, 2, 3},
-                        {111, 112, 113,
-                         111, 112, 113,
+TEST(TensorOpTest, TileUint64Type) {
+  RunTestWrapper<uint64_t>();
+}
 
-                         211, 212, 213,
-                         211, 212, 213});
-  test.Run();
+TEST(TensorOpTest, TileBoolType) {
+  RunTestWrapper<bool>();
 }
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
@@ -7,7 +7,7 @@
 namespace onnxruntime {
 namespace test {
 
-TEST(TensorOpTest, Tile1DWithZeroRepeats) {
+TEST(TensorOpTest, Tile1DWithZeroRepeatsFloatInput) {
   OpTester test("Tile");
 
   test.AddInput<float>("input", {3}, {1.0f, 2.0f, 3.0f});
@@ -16,7 +16,16 @@ TEST(TensorOpTest, Tile1DWithZeroRepeats) {
   test.Run();
 }
 
-TEST(TensorOpTest, Tile2DWithZeroRepeats) {
+TEST(TensorOpTest, Tile1DWithZeroRepeatsInt32Input) {
+  OpTester test("Tile");
+
+  test.AddInput<int32_t>("input", {3}, {1, 2, 3});
+  test.AddInput<int64_t>("repeats", {1}, {0});
+  test.AddOutput<int32_t>("output", {0}, {});
+  test.Run();
+}
+
+TEST(TensorOpTest, Tile2DWithZeroRepeatsFloatInput) {
   OpTester test("Tile");
 
   test.AddInput<float>("input", {2, 2},
@@ -27,7 +36,18 @@ TEST(TensorOpTest, Tile2DWithZeroRepeats) {
   test.Run();
 }
 
-TEST(TensorOpTest, Tile1D) {
+TEST(TensorOpTest, Tile2DWithZeroRepeatsInt32Input) {
+  OpTester test("Tile");
+
+  test.AddInput<int32_t>("input", {2, 2},
+                       {11, 12,
+                        21, 22});
+  test.AddInput<int64_t>("repeats", {2}, {2, 0});
+  test.AddOutput<int32_t>("output", {4, 0}, {});
+  test.Run();
+}
+
+TEST(TensorOpTest, Tile1DFloatInput) {
   OpTester test("Tile");
 
   test.AddInput<float>("input", {3}, {1.0f, 2.0f, 3.0f});
@@ -36,7 +56,16 @@ TEST(TensorOpTest, Tile1D) {
   test.Run();
 }
 
-TEST(TensorOpTest, Tile2D_1Axis) {
+TEST(TensorOpTest, Tile1DInt32Input) {
+  OpTester test("Tile");
+
+  test.AddInput<int32_t>("input", {3}, {1, 2, 3});
+  test.AddInput<int64_t>("repeats", {1}, {3});
+  test.AddOutput<int32_t>("output", {9}, {1, 2, 3, 1, 2, 3, 1, 2, 3});
+  test.Run();
+}
+
+TEST(TensorOpTest, Tile2D_1AxisFloatInput) {
   OpTester test("Tile");
 
   test.AddInput<float>("input", {2, 2},
@@ -52,7 +81,23 @@ TEST(TensorOpTest, Tile2D_1Axis) {
   test.Run();
 }
 
-TEST(TensorOpTest, Tile2D_2Axes) {
+TEST(TensorOpTest, Tile2D_1AxisInt32Input) {
+  OpTester test("Tile");
+
+  test.AddInput<int32_t>("input", {2, 2},
+                       {11, 12,
+                        21, 22});
+  test.AddInput<int64_t>("repeats", {2}, {2, 1});
+  test.AddOutput<int32_t>("output", {4, 2},
+                        {11, 12,
+                         21, 22,
+                         11, 12,
+                         21, 22});
+
+  test.Run();
+}
+
+TEST(TensorOpTest, Tile2D_2AxesFloatInput) {
   OpTester test("Tile");
 
   test.AddInput<float>("input", {2, 2},
@@ -68,7 +113,23 @@ TEST(TensorOpTest, Tile2D_2Axes) {
   test.Run();
 }
 
-TEST(TensorOpTest, Tile3D) {
+TEST(TensorOpTest, Tile2D_2AxesInt32Input) {
+  OpTester test("Tile");
+
+  test.AddInput<int32_t>("input", {2, 2},
+                       {11, 12,
+                        21, 22});
+  test.AddInput<int64_t>("repeats", {2}, {2, 2});
+  test.AddOutput<int32_t>("output", {4, 4},
+                        {11, 12, 11, 12,
+                         21, 22, 21, 22,
+                         11, 12, 11, 12,
+                         21, 22, 21, 22});
+
+  test.Run();
+}
+
+TEST(TensorOpTest, Tile3DFloatInput) {
   OpTester test("Tile");
 
   test.AddInput<float>("input", {2, 1, 3},
@@ -84,5 +145,20 @@ TEST(TensorOpTest, Tile3D) {
   test.Run();
 }
 
+TEST(TensorOpTest, Tile3DInt32Input) {
+  OpTester test("Tile");
+
+  test.AddInput<int32_t>("input", {2, 1, 3},
+                       {111, 112, 113,
+                        211, 212, 213});
+  test.AddInput<int64_t>("repeats", {3}, {1, 2, 1});
+  test.AddOutput<int32_t>("output", {2, 2, 3},
+                        {111, 112, 113,
+                         111, 112, 113,
+
+                         211, 212, 213,
+                         211, 212, 213});
+  test.Run();
+}
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
Needed for quick integration with a partner and so only extending to support `int32_t` for now 