### PR TITLE
Remove onnxruntime_USE_PREBUILT_PB

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -50,7 +50,6 @@ option(onnxruntime_USE_MKLDNN "Build with MKL-DNN support" OFF)
 option(onnxruntime_USE_MKLML "Build MKL-DNN with MKL-ML binary dependency" OFF)
 option(onnxruntime_USE_OPENBLAS "Use openblas" OFF)
 option(onnxruntime_DEV_MODE "Enable developer warnings and treat most of them as error." OFF)
-option(onnxruntime_USE_PREBUILT_PB "Use prebuilt protobuf library" OFF)
 option(onnxruntime_USE_JEMALLOC "Use jecmalloc" OFF)
 option(onnxruntime_MSVC_STATIC_RUNTIME "Compile for the static CRT" OFF)
 option(onnxruntime_BUILD_UNIT_TESTS "Build ONNXRuntime unit tests" ON)
@@ -184,44 +183,26 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/external/nsync EXCLUDE_FROM_ALL)
 # External dependencies
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/external)
 
-#Here we support three build mode:
-#1. (recommended)onnxruntime_USE_PREBUILT_PB is set (ONNX_CUSTOM_PROTOC_EXECUTABLE should also be set)
-#   We will not build protobuf, will use a prebuilt binary instead. This mode can also support cross-compiling
-#2. onnxruntime_USE_PREBUILT_PB is not set but ONNX_CUSTOM_PROTOC_EXECUTABLE is set
-#   Build Protobuf from source, except protoc.exe. This mode is mainly for cross-compiling
-#3. both onnxruntime_USE_PREBUILT_PB and ONNX_CUSTOM_PROTOC_EXECUTABLE are not set
-#   Compile everything from source code. Slowest option.
+#Here we support two build mode:
+#1. if ONNX_CUSTOM_PROTOC_EXECUTABLE is set, build Protobuf from source, except protoc.exe. This mode is mainly 
+    for cross-compiling
+#2. if ONNX_CUSTOM_PROTOC_EXECUTABLE is not set, Compile everything(including protoc) from source code.
 
-if(onnxruntime_USE_PREBUILT_PB)
-  get_filename_component(
-     _PROTOBUF_INSTALL_PREFIX
-     ${ONNX_CUSTOM_PROTOC_EXECUTABLE}
-     DIRECTORY)
-  get_filename_component(
-    _PROTOBUF_INSTALL_PREFIX
-    ${_PROTOBUF_INSTALL_PREFIX}/..
-    REALPATH)
-  if(WIN32)
-    include(${_PROTOBUF_INSTALL_PREFIX}/cmake/protobuf-config.cmake)
-  else()
-    include(${_PROTOBUF_INSTALL_PREFIX}/lib64/cmake/protobuf/protobuf-config.cmake)
-  endif()
-  include(protobuf_function.cmake)
+
+# use protobuf as a submodule
+add_subdirectory(${PROJECT_SOURCE_DIR}/external/protobuf/cmake EXCLUDE_FROM_ALL)
+set_target_properties(libprotobuf PROPERTIES FOLDER "External/Protobuf")
+set_target_properties(libprotobuf-lite PROPERTIES FOLDER "External/Protobuf")
+set_target_properties(libprotoc PROPERTIES FOLDER "External/Protobuf")
+set_target_properties(protoc PROPERTIES FOLDER "External/Protobuf")
+if (onnxruntime_USE_FULL_PROTOBUF)
+  add_library(protobuf::libprotobuf ALIAS libprotobuf)
 else()
-  # use protobuf as a submodule
-  add_subdirectory(${PROJECT_SOURCE_DIR}/external/protobuf/cmake EXCLUDE_FROM_ALL)
-  set_target_properties(libprotobuf PROPERTIES FOLDER "External/Protobuf")
-  set_target_properties(libprotobuf-lite PROPERTIES FOLDER "External/Protobuf")
-  set_target_properties(libprotoc PROPERTIES FOLDER "External/Protobuf")
-  set_target_properties(protoc PROPERTIES FOLDER "External/Protobuf")
-  if (onnxruntime_USE_FULL_PROTOBUF)
-    add_library(protobuf::libprotobuf ALIAS libprotobuf)
-  else()
-    add_library(protobuf::libprotobuf ALIAS libprotobuf-lite)
-  endif()
-  add_executable(protobuf::protoc ALIAS protoc)
-  include(protobuf_function.cmake)
+  add_library(protobuf::libprotobuf ALIAS libprotobuf-lite)
 endif()
+add_executable(protobuf::protoc ALIAS protoc)
+include(protobuf_function.cmake)
+
 
 if (onnxruntime_USE_FULL_PROTOBUF)
   add_definitions(-DUSE_FULL_PROTOBUF)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -185,7 +185,7 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/external)
 
 #Here we support two build mode:
 #1. if ONNX_CUSTOM_PROTOC_EXECUTABLE is set, build Protobuf from source, except protoc.exe. This mode is mainly 
-    for cross-compiling
+#   for cross-compiling
 #2. if ONNX_CUSTOM_PROTOC_EXECUTABLE is not set, Compile everything(including protoc) from source code.
 
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -281,7 +281,7 @@ def setup_test_data(build_dir, configs, test_data_url, test_data_checksum, azure
                 log.debug("creating shortcut %s -> %s"  % (src_model_dir, dest_model_dir))
                 run_subprocess(['mklink', '/D', '/J', dest_model_dir, src_model_dir], shell=True)
 
-def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home, tensorrt_home, pb_home, path_to_protoc_exe, configs, cmake_extra_defines, args, cmake_extra_args):
+def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home, tensorrt_home, path_to_protoc_exe, configs, cmake_extra_defines, args, cmake_extra_args):
     log.info("Generating CMake build tree")
     cmake_dir = os.path.join(source_dir, "cmake")
     # TODO: fix jemalloc build so it does not conflict with onnxruntime shared lib builds. (e.g. onnxuntime_pybind)

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -64,8 +64,7 @@ Use the individual flags to only run the specified stages.
     # enable ONNX tests
     parser.add_argument("--enable_onnx_tests", action='store_true',
                         help='''When running the Test phase, run onnx_test_running against available test data directories.''')
-    parser.add_argument("--pb_home", help="Path to protobuf installation")
-    parser.add_argument("--path_to_protoc_exe", help="Path to protoc exe. Will be overridden by {pb_home}/bin/protoc.exe if {pb_home} is set.")
+    parser.add_argument("--path_to_protoc_exe", help="Path to protoc exe. ")
     parser.add_argument("--download_test_data", action="store_true",
                         help='''Downloads test data without running the tests''')
     parser.add_argument("--test_data_url", help="Test data URL.")
@@ -337,10 +336,7 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
         cmake_args += ["-Donnxruntime_USE_PREINSTALLED_EIGEN=ON",
                        "-Deigen_SOURCE_PATH=" + args.eigen_path]
 
-    if pb_home:
-        cmake_args += ["-DONNX_CUSTOM_PROTOC_EXECUTABLE=" + os.path.join(pb_home,'bin','protoc'), '-Donnxruntime_USE_PREBUILT_PB=ON']
-
-    elif path_to_protoc_exe:
+    if path_to_protoc_exe:
         cmake_args += ["-DONNX_CUSTOM_PROTOC_EXECUTABLE=%s" % path_to_protoc_exe]
 
     cmake_args += ["-D{}".format(define) for define in cmake_extra_defines]
@@ -682,7 +678,7 @@ def main():
         elif args.arm or args.arm64:
             path_to_protoc_exe = os.path.join(build_dir, 'host_protoc', 'Release', 'protoc.exe')
 
-        generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home, tensorrt_home, args.pb_home, path_to_protoc_exe, configs, cmake_extra_defines,
+        generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home, tensorrt_home, path_to_protoc_exe, configs, cmake_extra_defines,
                             args, cmake_extra_args)
 
     if (args.clean):


### PR DESCRIPTION
It's out of maintenance and became broken after the last change of switching to protobuf-lite.
The option was added by me. It was for speeding up build time a little. 