### PR TITLE
Add option to access static profiler instance when debugging in single session

### DIFF
--- a/onnxruntime/core/common/profiler.cc
+++ b/onnxruntime/core/common/profiler.cc
@@ -7,6 +7,8 @@ namespace onnxruntime {
 namespace profiling {
 using namespace std::chrono;
 
+Profiler* Profiler::instance_ = nullptr;
+
 ::onnxruntime::TimePoint profiling::Profiler::StartTime() const {
   return std::chrono::high_resolution_clock::now();
 }
@@ -14,6 +16,8 @@ using namespace std::chrono;
 void Profiler::Initialize(const logging::Logger* session_logger) {
   ORT_ENFORCE(session_logger != nullptr);
   session_logger_ = session_logger;
+  ORT_ENFORCE(instance_ == nullptr);  // can only have one profiler instance
+  instance_ = this;
 }
 
 void Profiler::StartProfiling(const logging::Logger* custom_logger) {

--- a/onnxruntime/core/common/profiler.cc
+++ b/onnxruntime/core/common/profiler.cc
@@ -9,6 +9,10 @@ using namespace std::chrono;
 
 Profiler* Profiler::instance_ = nullptr;
 
+profiling::Profiler::~Profiler() {
+  instance_ = nullptr;
+}
+
 ::onnxruntime::TimePoint profiling::Profiler::StartTime() const {
   return std::chrono::high_resolution_clock::now();
 }

--- a/onnxruntime/core/common/profiler.cc
+++ b/onnxruntime/core/common/profiler.cc
@@ -7,11 +7,15 @@ namespace onnxruntime {
 namespace profiling {
 using namespace std::chrono;
 
+#ifdef ENABLE_STATIC_PROFILER_INSTANCE
 Profiler* Profiler::instance_ = nullptr;
 
 profiling::Profiler::~Profiler() {
   instance_ = nullptr;
 }
+#else
+profiling::Profiler::~Profiler() {}
+#endif
 
 ::onnxruntime::TimePoint profiling::Profiler::StartTime() const {
   return std::chrono::high_resolution_clock::now();
@@ -20,8 +24,10 @@ profiling::Profiler::~Profiler() {
 void Profiler::Initialize(const logging::Logger* session_logger) {
   ORT_ENFORCE(session_logger != nullptr);
   session_logger_ = session_logger;
-  ORT_ENFORCE(instance_ == nullptr);  // can only have one profiler instance
+#ifdef ENABLE_STATIC_PROFILER_INSTANCE
+  ORT_ENFORCE(instance_ == nullptr, "Static profiler instance only works with single session");
   instance_ = this;
+#endif
 }
 
 void Profiler::StartProfiling(const logging::Logger* custom_logger) {

--- a/onnxruntime/core/common/profiler.h
+++ b/onnxruntime/core/common/profiler.h
@@ -23,6 +23,8 @@ class Profiler {
   /// Even this function is marked as noexcept, the code inside it may throw exceptions
   Profiler() noexcept {};  //NOLINT
 
+  ~Profiler();
+
   /*
   Initializes Profiler with the session logger to log framework specific messages
   */

--- a/onnxruntime/core/common/profiler.h
+++ b/onnxruntime/core/common/profiler.h
@@ -64,6 +64,11 @@ class Profiler {
   */
   std::string EndProfiling();
 
+  static Profiler& Instance() {
+    ORT_ENFORCE(instance_ != nullptr);
+    return *instance_;
+  }
+
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(Profiler);
 
@@ -79,6 +84,8 @@ class Profiler {
   bool max_events_reached{false};
   static constexpr size_t max_num_events_ = 1000000;
   bool profile_with_logger_{false};
+
+  static Profiler* instance_;
 };
 
 }  // namespace profiling

--- a/onnxruntime/core/common/profiler.h
+++ b/onnxruntime/core/common/profiler.h
@@ -13,6 +13,10 @@ namespace onnxruntime {
 
 namespace profiling {
 
+// uncomment the macro below, or use -DENABLE_STATIC_PROFILER_INSTANCE for debugging
+// note that static profiler instance only works with single session
+//#define ENABLE_STATIC_PROFILER_INSTANCE
+
 /**
  * Main class for profiling. It continues to accumulate events and produce
  * a corresponding "complete event (X)" in "chrome tracing" format.
@@ -67,8 +71,12 @@ class Profiler {
   std::string EndProfiling();
 
   static Profiler& Instance() {
+#ifdef ENABLE_STATIC_PROFILER_INSTANCE
     ORT_ENFORCE(instance_ != nullptr);
     return *instance_;
+#else
+    ORT_THROW("Static profiler instance is not enabled, please compile with -DENABLE_STATIC_PROFILER_INSTANCE")
+#endif
   }
 
  private:
@@ -87,7 +95,9 @@ class Profiler {
   static constexpr size_t max_num_events_ = 1000000;
   bool profile_with_logger_{false};
 
+#ifdef ENABLE_STATIC_PROFILER_INSTANCE
   static Profiler* instance_;
+#endif
 };
 
 }  // namespace profiling

--- a/onnxruntime/core/common/profiler.h
+++ b/onnxruntime/core/common/profiler.h
@@ -75,7 +75,7 @@ class Profiler {
     ORT_ENFORCE(instance_ != nullptr);
     return *instance_;
 #else
-    ORT_THROW("Static profiler instance is not enabled, please compile with -DENABLE_STATIC_PROFILER_INSTANCE")
+    ORT_THROW("Static profiler instance is not enabled, please compile with -DENABLE_STATIC_PROFILER_INSTANCE");
 #endif
   }
 


### PR DESCRIPTION
It would be easier for some code like this:

auto ts = profiling::Profiler::Instance().StartTime();
...
profiling::Profiler::Instance().EndTimeAndRecordEvent(profiling::EventCategory::NODE_EVENT, name, ts);