### PR TITLE
Fix profiling with C API

### DIFF
--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -193,7 +193,18 @@ InferenceSession::InferenceSession(const SessionOptions& session_options, loggin
 
 InferenceSession::~InferenceSession() {
   if (session_options_.enable_profiling) {
-    EndProfiling();
+    try {
+      EndProfiling();
+    } catch (std::exception& e) {
+      // TODO: Currently we have no way to transport this error to the API user
+      // Maybe this should be refactored, so that profiling must be explicitly
+      // started and stopped via C-API functions.
+      // And not like now a session option and therefore profiling must be started
+      // and stopped implicitly.
+      LOGS(*session_logger_, ERROR) << "Error during EndProfiling(): " << e.what();
+    } catch (...) {
+      LOGS(*session_logger_, ERROR) << "Unknown error during EndProfiling()";
+    }
   }
 }
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -191,7 +191,11 @@ InferenceSession::InferenceSession(const SessionOptions& session_options, loggin
   }
 }
 
-InferenceSession::~InferenceSession() = default;
+InferenceSession::~InferenceSession() {
+  if (session_options_.enable_profiling) {
+    EndProfiling();
+  }
+}
 
 common::Status InferenceSession::RegisterExecutionProvider(std::unique_ptr<IExecutionProvider> p_exec_provider) {
   if (p_exec_provider == nullptr) {


### PR DESCRIPTION
Currently, when using OrtEnableProfiling to enable profiling using the C API,
the profile output file is created but is always empty.

The reason is that InferenceSession::EndProfiling() needs to be called to
write the profiling data to the output file.

However there's currently no way to call this function via the C API.

This adds a call to EndProfiling() to the descructor of the session if
profiling is enabled in the session options.