### PR TITLE
Fix path_lib.h for Mac and refine #include in InferenceSesssion.h

### DIFF
--- a/onnxruntime/core/framework/path_lib.h
+++ b/onnxruntime/core/framework/path_lib.h
@@ -236,7 +236,7 @@ void LoopDir(const std::string& dir_name, T func) {
     auto e = errno;
     char buf[1024];
     char* msg;
-#ifdef _GNU_SOURCE
+#if defined(_GNU_SOURCE) && !defined(__APPLE__)
     msg = strerror_r(e, buf, sizeof(buf));
 #else
     // for Mac OS X

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -14,7 +14,6 @@
 #include "core/framework/framework_common.h"
 #include "core/framework/iexecutor.h"
 #include "core/framework/kernel_registry_manager.h"
-#include "core/framework/path_lib.h"
 #include "core/framework/session_state.h"
 #include "core/graph/basic_types.h"
 #include "core/optimizer/graph_transformer_level.h"
@@ -313,7 +312,7 @@ class InferenceSession {
   std::unordered_set<std::string> model_output_names_;
 
   // The file path of where the model was loaded. e.g. /tmp/test_squeezenet/model.onnx
-  std::basic_string<PATH_CHAR_TYPE> model_location_;
+  std::basic_string<ORTCHAR_T> model_location_;
 
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(InferenceSession);


### PR DESCRIPTION
Otherwise, there will be compiling errors under Mac when python binding is ON, due to _GNU_SOURCE being defined somewhere and incorrect version of "strerror_r" is compiled.