### PR TITLE
Cache CUDNN convolution benchmark results in cuda::Conv kernels

### DIFF
--- a/onnxruntime/core/providers/cuda/nn/conv.cc
+++ b/onnxruntime/core/providers/cuda/nn/conv.cc
@@ -51,8 +51,10 @@ Status Conv<T>::ComputeInternal(OpKernelContext* context) const {
       if (input_dims_changed)
         s_.last_x_dims = x_dims;
 
-      if (w_dims_changed)
+      if (w_dims_changed) {
         s_.last_w_dims = w_dims;
+        s_.cached_benchmark_results.clear();
+      }
 
       const int64_t N = X->Shape()[0];
       const int64_t M = W->Shape()[0];
@@ -119,8 +121,7 @@ Status Conv<T>::ComputeInternal(OpKernelContext* context) const {
       Tensor* Y = context->Output(0, TensorShape(s_.y_dims));
       y_data = reinterpret_cast<CudaT*>(Y->template MutableData<T>());
 
-      auto input_shapes = std::make_pair(x_dims, w_dims);
-      if (!s_.cached_benchmark_results.contains(input_shapes)) {
+      if (!s_.cached_benchmark_results.contains(x_dims)) {
         IAllocatorUniquePtr<void> algo_search_workspace = GetScratchBuffer<void>(AlgoSearchWorkspaceSize);
 
         // set math type to tensor core before algorithm search
@@ -143,10 +144,10 @@ Status Conv<T>::ComputeInternal(OpKernelContext* context) const {
             &perf,
             algo_search_workspace.get(),
             AlgoSearchWorkspaceSize));
-        s_.cached_benchmark_results.insert(input_shapes, perf);
+        s_.cached_benchmark_results.insert(x_dims, perf);
       }
 
-      const auto& perf = s_.cached_benchmark_results.at(input_shapes);
+      const auto& perf = s_.cached_benchmark_results.at(x_dims);
       CUDNN_RETURN_IF_ERROR(cudnnSetConvolutionMathType(s_.conv_desc, perf.mathType));
       s_.algo = perf.algo;
       s_.workspace_bytes = perf.memory;

--- a/onnxruntime/core/providers/cuda/nn/conv.cc
+++ b/onnxruntime/core/providers/cuda/nn/conv.cc
@@ -121,7 +121,7 @@ Status Conv<T>::ComputeInternal(OpKernelContext* context) const {
       Tensor* Y = context->Output(0, TensorShape(s_.y_dims));
       y_data = reinterpret_cast<CudaT*>(Y->template MutableData<T>());
 
-      if (!s_.cached_benchmark_results.contains(x_dims)) {
+      if (!s_.cached_benchmark_results.contains(x_dims_cudnn)) {
         IAllocatorUniquePtr<void> algo_search_workspace = GetScratchBuffer<void>(AlgoSearchWorkspaceSize);
 
         // set math type to tensor core before algorithm search
@@ -144,10 +144,10 @@ Status Conv<T>::ComputeInternal(OpKernelContext* context) const {
             &perf,
             algo_search_workspace.get(),
             AlgoSearchWorkspaceSize));
-        s_.cached_benchmark_results.insert(x_dims, perf);
+        s_.cached_benchmark_results.insert(x_dims_cudnn, perf);
       }
 
-      const auto& perf = s_.cached_benchmark_results.at(x_dims);
+      const auto& perf = s_.cached_benchmark_results.at(x_dims_cudnn);
       CUDNN_RETURN_IF_ERROR(cudnnSetConvolutionMathType(s_.conv_desc, perf.mathType));
       s_.algo = perf.algo;
       s_.workspace_bytes = perf.memory;

--- a/onnxruntime/core/providers/cuda/nn/conv.cc
+++ b/onnxruntime/core/providers/cuda/nn/conv.cc
@@ -144,7 +144,7 @@ Status Conv<T>::ComputeInternal(OpKernelContext* context) const {
             &perf,
             algo_search_workspace.get(),
             AlgoSearchWorkspaceSize));
-        s_.cached_benchmark_results.insert(x_dims_cudnn, perf);
+        s_.cached_benchmark_results.insert(x_dims_cudnn, {perf.algo, perf.memory, perf.mathType});
       }
 
       const auto& perf = s_.cached_benchmark_results.at(x_dims_cudnn);

--- a/onnxruntime/core/providers/cuda/nn/conv.h
+++ b/onnxruntime/core/providers/cuda/nn/conv.h
@@ -125,7 +125,13 @@ struct CudnnConvState {
   CudnnTensor y_tensor;
   CudnnConvolutionDescriptor conv_desc;
 
-  lru_unordered_map<std::vector<int64_t>, AlgoPerfType, vector_hash<int64_t>> cached_benchmark_results { MAX_CACHED_ALGO_PERF_RESULTS };
+  struct PerfResultParams {
+    decltype(AlgoPerfType().algo)     algo;
+    decltype(AlgoPerfType().memory)   memory;
+    decltype(AlgoPerfType().mathType) mathType;
+  };
+
+  lru_unordered_map<std::vector<int64_t>, PerfResultParams, vector_hash<int64_t>> cached_benchmark_results { MAX_CACHED_ALGO_PERF_RESULTS };
 
   // note that conv objects are shared between execution frames, and a lock is needed to avoid multi-thread racing
   OrtMutex mutex;

--- a/onnxruntime/core/providers/cuda/nn/conv.h
+++ b/onnxruntime/core/providers/cuda/nn/conv.h
@@ -69,6 +69,11 @@ class lru_map {
     return handles_.size();
   }
 
+  void clear() {
+    items_.clear();
+    handles_.clear();
+  }
+
 private:
   using value_type = std::pair<Key, T>;
   using iterator_type = typename std::list<value_type>::iterator;
@@ -95,8 +100,7 @@ struct CudnnConvState {
   CudnnTensor y_tensor;
   CudnnConvolutionDescriptor conv_desc;
 
-  using input_shapes = std::pair<std::vector<int64_t>, std::vector<int64_t>>;
-  lru_map<input_shapes, AlgoPerfType> cached_benchmark_results { 10000 };
+  lru_map<std::vector<int64_t>, AlgoPerfType> cached_benchmark_results { 10000 };
 
   // note that conv objects are shared between execution frames, and a lock is needed to avoid multi-thread racing
   OrtMutex mutex;

--- a/onnxruntime/core/providers/cuda/nn/conv.h
+++ b/onnxruntime/core/providers/cuda/nn/conv.h
@@ -84,6 +84,8 @@ private:
 };
 
 // cached cudnn descriptors
+constexpr size_t MAX_CACHED_ALGO_PERF_RESULTS = 10000;
+
 template <typename AlgoPerfType>
 struct CudnnConvState {
   // if x/w dims changed, update algo and cudnnTensors
@@ -100,7 +102,7 @@ struct CudnnConvState {
   CudnnTensor y_tensor;
   CudnnConvolutionDescriptor conv_desc;
 
-  lru_map<std::vector<int64_t>, AlgoPerfType> cached_benchmark_results { 10000 };
+  lru_map<std::vector<int64_t>, AlgoPerfType> cached_benchmark_results { MAX_CACHED_ALGO_PERF_RESULTS };
 
   // note that conv objects are shared between execution frames, and a lock is needed to avoid multi-thread racing
   OrtMutex mutex;

--- a/onnxruntime/core/providers/cuda/nn/conv_transpose.cc
+++ b/onnxruntime/core/providers/cuda/nn/conv_transpose.cc
@@ -106,7 +106,7 @@ Status ConvTranspose<T>::ComputeInternal(OpKernelContext* context) const {
             &perf,
             algo_search_workspace.get(),
             AlgoSearchWorkspaceSize));
-        s_.cached_benchmark_results.insert(x_dims, perf);
+        s_.cached_benchmark_results.insert(x_dims, {perf.algo, perf.memory, perf.mathType});
       }
 
       const auto& perf = s_.cached_benchmark_results.at(x_dims);

--- a/onnxruntime/core/providers/cuda/nn/conv_transpose.cc
+++ b/onnxruntime/core/providers/cuda/nn/conv_transpose.cc
@@ -82,8 +82,7 @@ Status ConvTranspose<T>::ComputeInternal(OpKernelContext* context) const {
       y_data = reinterpret_cast<CudaT*>(p.Y->template MutableData<T>());
 
       auto input_shapes = std::make_pair(x_dims, w_dims);
-      auto it = s_.cached_benchmark_results.find(input_shapes);
-      if (it == s_.cached_benchmark_results.end()) {
+      if (!s_.cached_benchmark_results.contains(input_shapes)) {
         IAllocatorUniquePtr<void> algo_search_workspace = GetScratchBuffer<void>(AlgoSearchWorkspaceSize);
 
         // set math type to tensor core before algorithm search
@@ -106,10 +105,10 @@ Status ConvTranspose<T>::ComputeInternal(OpKernelContext* context) const {
             &perf,
             algo_search_workspace.get(),
             AlgoSearchWorkspaceSize));
-        it = s_.cached_benchmark_results.insert({input_shapes, perf}).first;
+        s_.cached_benchmark_results.insert(input_shapes, perf);
       }
 
-      const auto& perf = it->second;
+      const auto& perf = s_.cached_benchmark_results.at(input_shapes);
       CUDNN_RETURN_IF_ERROR(cudnnSetConvolutionMathType(s_.conv_desc, perf.mathType));
       s_.algo = perf.algo;
       s_.workspace_bytes = perf.memory;

--- a/onnxruntime/core/providers/cuda/nn/conv_transpose.h
+++ b/onnxruntime/core/providers/cuda/nn/conv_transpose.h
@@ -17,7 +17,7 @@ class ConvTranspose : public CudaKernel, public ConvTransposeBase {
   Status ComputeInternal(OpKernelContext* context) const override;
 
  private:
-  mutable CudnnConvState<cudnnConvolutionBwdDataAlgo_t> s_;
+  mutable CudnnConvState<cudnnConvolutionBwdDataAlgoPerf_t> s_;
 };
 
 }  // namespace cuda


### PR DESCRIPTION
Previously, the best convolution algorithm was determined by running
cudnnFindConvolutionForwardAlgorithmEx and cudnnFindConvolutionBackwardDataAlgorithmEx
on every shape change.

This is very detrimental for variable input shapes, such as variable batch
sizes.

This change adds a map to cache previously determined benchmark results.

The caching results in significant speedups for variable input shapes.

Fixes: #709 