### PR TITLE
Bump up cmake_minimum_required to 3.13

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -42,7 +42,7 @@ ONNX Runtime python binding only supports Python 3.x. Please use python 3.5+.
    git clone --recursive https://github.com/Microsoft/onnxruntime
    cd onnxruntime
    ```
-2. Install cmake-3.11 or better from https://cmake.org/download/.
+2. Install cmake-3.13 or better from https://cmake.org/download/.
 3. (optional) Install protobuf 3.6.1 from source code (cmake/external/protobuf). CMake flag protobuf\_BUILD\_SHARED\_LIBS must be turned off. After the installation, you should have the 'protoc' executable in your PATH.
 4. (optional) Install onnx from source code (cmake/external/onnx)
     ```

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Minimum CMake required
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.13)
 
 # Project
 project(onnxruntime C CXX)

--- a/tools/ci_build/github/linux/docker/scripts/install_deps_x86.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps_x86.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
-aria2c -q -d /tmp/src https://github.com/Kitware/CMake/releases/download/v3.12.4/cmake-3.12.4.tar.gz
-tar -xf /tmp/src/cmake-3.12.4.tar.gz -C /tmp/src
-cd /tmp/src/cmake-3.12.4
+aria2c -q -d /tmp/src https://github.com/Kitware/CMake/releases/download/v3.13.2/cmake-3.13.2.tar.gz
+tar -xf /tmp/src/cmake-3.13.2.tar.gz -C /tmp/src
+cd /tmp/src/cmake-3.13.2
 ./configure
 make
 make install

--- a/tools/ci_build/github/linux/ubuntu16.04/install.sh
+++ b/tools/ci_build/github/linux/ubuntu16.04/install.sh
@@ -44,8 +44,8 @@ rm -rf /tmp/azcopy
 #install protobuf
 mkdir -p /tmp/src
 mkdir -p /opt/cmake
-aria2c -q -d /tmp/src   https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz
-tar -xf /tmp/src/cmake-3.12.1-Linux-x86_64.tar.gz --strip 1 -C /opt/cmake
+aria2c -q -d /tmp/src   https://github.com/Kitware/CMake/releases/download/v3.13.2/cmake-3.13.2-Linux-x86_64.tar.gz
+tar -xf /tmp/src/cmake-3.13.2-Linux-x86_64.tar.gz --strip 1 -C /opt/cmake
 aria2c -q -d /tmp/src https://github.com/protocolbuffers/protobuf/archive/v3.6.1.tar.gz
 tar -xf /tmp/src/protobuf-3.6.1.tar.gz -C /tmp/src
 cd /tmp/src/protobuf-3.6.1


### PR DESCRIPTION
This is consistent with CI version. cmake 3.11 has issues with CUDA build.