### PR TITLE
Fix inconsistent dimension data type in C-API

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -289,7 +289,7 @@ ORT_API(void, OrtRunOptionsSetTerminate, _In_ OrtRunOptions*, _In_ int flag);
  * \param type must be one of TENSOR_ELEMENT_DATA_TYPE_xxxx
  */
 ORT_API_STATUS(OrtCreateTensorAsOrtValue, _Inout_ OrtAllocator* allocator,
-               _In_ const size_t* shape, size_t shape_len, ONNXTensorElementDataType type,
+               _In_ const int64_t* shape, size_t shape_len, ONNXTensorElementDataType type,
                _Out_ OrtValue** out);
 
 /**
@@ -298,7 +298,7 @@ ORT_API_STATUS(OrtCreateTensorAsOrtValue, _Inout_ OrtAllocator* allocator,
  * \param out Should be freed by calling OrtReleaseValue
  */
 ORT_API_STATUS(OrtCreateTensorWithDataAsOrtValue, _In_ const OrtAllocatorInfo* info,
-               _Inout_ void* p_data, size_t p_data_len, _In_ const size_t* shape, size_t shape_len,
+               _Inout_ void* p_data, size_t p_data_len, _In_ const int64_t* shape, size_t shape_len,
                ONNXTensorElementDataType type, _Out_ OrtValue** out);
 
 // This function doesn't work with string tensor

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -129,13 +129,13 @@ class SessionOptionsWrapper {
   }
 #endif
 };
-inline OrtValue* OrtCreateTensorAsOrtValue(_Inout_ OrtAllocator* env, const std::vector<size_t>& shape, ONNXTensorElementDataType type) {
+inline OrtValue* OrtCreateTensorAsOrtValue(_Inout_ OrtAllocator* env, const std::vector<int64_t>& shape, ONNXTensorElementDataType type) {
   OrtValue* ret;
   ORT_THROW_ON_ERROR(::OrtCreateTensorAsOrtValue(env, shape.data(), shape.size(), type, &ret));
   return ret;
 }
 
-inline OrtValue* OrtCreateTensorWithDataAsOrtValue(_In_ const OrtAllocatorInfo* info, _In_ void* p_data, size_t p_data_len, const std::vector<size_t>& shape, ONNXTensorElementDataType type) {
+inline OrtValue* OrtCreateTensorWithDataAsOrtValue(_In_ const OrtAllocatorInfo* info, _In_ void* p_data, size_t p_data_len, const std::vector<int64_t>& shape, ONNXTensorElementDataType type) {
   OrtValue* ret;
   ORT_THROW_ON_ERROR(::OrtCreateTensorWithDataAsOrtValue(info, p_data, p_data_len, shape.data(), shape.size(), type, &ret));
   return ret;

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -796,7 +796,7 @@ OrtStatus* OrtGetValueImplSeqOfPrimitives(const MLValue* p_ml_value, int index, 
   using ElemType = typename T::value_type;
   auto& data = p_ml_value->Get<T>();
   auto& data_elem = data.at(index);
-  std::vector<size_t> dims = {1};
+  std::vector<int64_t> dims = {1};
   OrtStatus* st = OrtCreateTensorAsOrtValue(allocator, dims.data(), dims.size(),
                                             GetONNXTensorElementDataType<ElemType>(), out);
   return st ? st : PopulateTensorWithData<ElemType>(*out, &data_elem, 1);
@@ -830,7 +830,7 @@ static OrtStatus* OrtGetValueImplMapHelper(const MLValue* p_ml_value, int index,
   using TKey = typename T::key_type;
   using TVal = typename T::mapped_type;
   auto& data = p_ml_value->Get<T>();
-  size_t num_kv_pairs = data.size();
+  int64_t num_kv_pairs = data.size();
   switch (index) {
     case 0: {  // user is requesting keys
       std::vector<TKey> vec;
@@ -838,7 +838,7 @@ static OrtStatus* OrtGetValueImplMapHelper(const MLValue* p_ml_value, int index,
       for (const auto& kv : data) {
         vec.push_back(kv.first);
       }
-      std::vector<size_t> dims{num_kv_pairs};
+      std::vector<int64_t> dims{num_kv_pairs};
       OrtStatus* st = OrtCreateTensorAsOrtValue(allocator, dims.data(), dims.size(),
                                                 GetONNXTensorElementDataType<TKey>(), out);
       return st ? st : PopulateTensorWithData<TKey>(*out, vec.data(), num_kv_pairs);
@@ -849,7 +849,7 @@ static OrtStatus* OrtGetValueImplMapHelper(const MLValue* p_ml_value, int index,
       for (const auto& kv : data) {
         vec.push_back(kv.second);
       }
-      std::vector<size_t> dims{num_kv_pairs};
+      std::vector<int64_t> dims{num_kv_pairs};
       OrtStatus* st = OrtCreateTensorAsOrtValue(allocator, dims.data(), dims.size(),
                                                 GetONNXTensorElementDataType<TVal>(), out);
       return st ? st : PopulateTensorWithData<TVal>(*out, vec.data(), num_kv_pairs);

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -167,7 +167,7 @@ ORT_API_STATUS_IMPL(OrtFillStringTensor, _In_ OrtValue* value, _In_ const char* 
 }
 
 template <typename T>
-OrtStatus* CreateTensorImpl(const size_t* shape, size_t shape_len, OrtAllocator* allocator,
+OrtStatus* CreateTensorImpl(const int64_t* shape, size_t shape_len, OrtAllocator* allocator,
                             std::unique_ptr<Tensor>* out) {
   std::vector<int64_t> shapes(shape_len);
   for (size_t i = 0; i != shape_len; ++i) {
@@ -183,7 +183,7 @@ OrtStatus* CreateTensorImpl(const size_t* shape, size_t shape_len, OrtAllocator*
  * this function will create a copy of the allocator info
  */
 template <typename T>
-OrtStatus* CreateTensorImpl(const size_t* shape, size_t shape_len, const OrtAllocatorInfo* info,
+OrtStatus* CreateTensorImpl(const int64_t* shape, size_t shape_len, const OrtAllocatorInfo* info,
                             void* p_data, size_t p_data_len, std::unique_ptr<Tensor>* out) {
   size_t elem_count = 1;
   std::vector<int64_t> shapes(shape_len);
@@ -209,7 +209,7 @@ OrtStatus* CreateTensorImpl(const size_t* shape, size_t shape_len, const OrtAllo
  * this function will create a copy of the allocator info
  */
 ORT_API_STATUS_IMPL(OrtCreateTensorWithDataAsOrtValue, _In_ const OrtAllocatorInfo* info,
-                    _Inout_ void* p_data, size_t p_data_len, _In_ const size_t* shape, size_t shape_len,
+                    _Inout_ void* p_data, size_t p_data_len, _In_ const int64_t* shape, size_t shape_len,
                     ONNXTensorElementDataType type, _Out_ OrtValue** out) {
   API_IMPL_BEGIN
   std::unique_ptr<Tensor> tensor;
@@ -275,7 +275,7 @@ ORT_API_STATUS_IMPL(OrtCreateTensorWithDataAsOrtValue, _In_ const OrtAllocatorIn
 }
 
 ORT_API_STATUS_IMPL(OrtCreateTensorAsOrtValue, _Inout_ OrtAllocator* allocator,
-                    _In_ const size_t* shape, size_t shape_len, ONNXTensorElementDataType type,
+                    _In_ const int64_t* shape, size_t shape_len, ONNXTensorElementDataType type,
                     _Out_ OrtValue** out) {
   API_IMPL_BEGIN
   std::unique_ptr<Tensor> tensor;

--- a/onnxruntime/test/shared_lib/fns_candy_style_transfer.c
+++ b/onnxruntime/test/shared_lib/fns_candy_style_transfer.c
@@ -147,7 +147,7 @@ int run_inference(OrtSession* session, const char* input_file, const char* outpu
   }
   OrtAllocatorInfo* allocator_info;
   ORT_ABORT_ON_ERROR(OrtCreateCpuAllocatorInfo(OrtArenaAllocator, OrtMemTypeDefault, &allocator_info));
-  const size_t input_shape[] = {1, 3, 720, 720};
+  const int64_t input_shape[] = {1, 3, 720, 720};
   const size_t input_shape_len = sizeof(input_shape) / sizeof(input_shape[0]);
   const size_t model_input_len = model_input_ele_count * sizeof(float);
 

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -110,9 +110,9 @@ void TestInference(OrtEnv* env, T model_uri,
   std::unique_ptr<OrtValue, decltype(&OrtReleaseValue)> value_y(nullptr, OrtReleaseValue);
   {
     std::vector<OrtValue*> allocated_outputs(1);
-    std::vector<size_t> dims_y(expected_dims_y.size());
+    std::vector<int64_t> dims_y(expected_dims_y.size());
     for (size_t i = 0; i != expected_dims_y.size(); ++i) {
-      dims_y[i] = static_cast<size_t>(expected_dims_y[i]);
+      dims_y[i] = expected_dims_y[i];
     }
 
     allocated_outputs[0] =
@@ -227,7 +227,7 @@ struct MyCustomOp : OrtCustomOp {
 
 TEST_F(CApiTest, custom_op_handler) {
   std::cout << "Running custom op inference" << std::endl;
-  std::vector<size_t> dims_x = {3, 2};
+  std::vector<int64_t> dims_x = {3, 2};
   std::vector<float> values_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
 
   // prepare expected inputs and outputs

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -14,7 +14,7 @@
 using namespace onnxruntime;
 
 void RunSession(OrtAllocator* env, OrtSession* session_object,
-                const std::vector<size_t>& dims_x,
+                const std::vector<int64_t>& dims_x,
                 const std::vector<float>& values_x,
                 const std::vector<int64_t>& dims_y,
                 const std::vector<float>& values_y,
@@ -59,7 +59,7 @@ void RunSession(OrtAllocator* env, OrtSession* session_object,
 
 template <typename T>
 void TestInference(OrtEnv* env, T model_uri,
-                   const std::vector<size_t>& dims_x,
+                   const std::vector<int64_t>& dims_x,
                    const std::vector<float>& values_x,
                    const std::vector<int64_t>& expected_dims_y,
                    const std::vector<float>& expected_values_y,
@@ -141,7 +141,7 @@ class CApiTestWithProvider : public CApiTest,
 TEST_P(CApiTestWithProvider, simple) {
   // simple inference test
   // prepare inputs
-  std::vector<size_t> dims_x = {3, 2};
+  std::vector<int64_t> dims_x = {3, 2};
   std::vector<float> values_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
 
   // prepare expected inputs and outputs
@@ -253,7 +253,7 @@ TEST_F(CApiTest, create_session_without_session_option) {
 #endif
 TEST_F(CApiTest, create_tensor) {
   const char* s[] = {"abc", "kmp"};
-  size_t expected_len = 2;
+  int64_t expected_len = 2;
   std::unique_ptr<MockedOrtAllocator> default_allocator(std::make_unique<MockedOrtAllocator>());
   {
     std::unique_ptr<OrtValue, decltype(&OrtReleaseValue)> tensor(
@@ -266,7 +266,7 @@ TEST_F(CApiTest, create_tensor) {
       ORT_THROW_ON_ERROR(OrtGetTensorShapeAndType(tensor.get(), &shape_info_ptr));
       shape_info.reset(shape_info_ptr);
     }
-    size_t len = static_cast<size_t>(OrtGetTensorShapeElementCount(shape_info.get()));
+    int64_t len = OrtGetTensorShapeElementCount(shape_info.get());
     ASSERT_EQ(len, expected_len);
     std::vector<int64_t> shape_array(len);
 
@@ -284,7 +284,7 @@ TEST_F(CApiTest, create_tensor_with_data) {
   constexpr size_t values_length = sizeof(values) / sizeof(values[0]);
   OrtAllocatorInfo* info;
   ORT_THROW_ON_ERROR(OrtCreateAllocatorInfo("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault, &info));
-  std::vector<size_t> dims = {4};
+  std::vector<int64_t> dims = {4};
   std::unique_ptr<OrtValue, decltype(&OrtReleaseValue)> tensor(
       OrtCreateTensorWithDataAsOrtValue(info, values, values_length * sizeof(float), dims, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT), OrtReleaseValue);
   OrtReleaseAllocatorInfo(info);

--- a/onnxruntime/test/shared_lib/test_nontensor_types.cc
+++ b/onnxruntime/test/shared_lib/test_nontensor_types.cc
@@ -40,7 +40,7 @@ TEST_F(CApiTest, CreateGetVectorOfMapsInt64Float) {  // support zipmap output ty
   const int NUM_KV_PAIRS = 4;
   std::vector<OrtValue*> in(N);
   std::vector<int64_t> keys{3, 1, 2, 0};
-  std::vector<size_t> dims = {4};
+  std::vector<int64_t> dims = {4};
   std::vector<float> values{3.0f, 1.0f, 2.f, 0.f};
   for (int i = 0; i < N; ++i) {
     // create key tensor
@@ -147,11 +147,11 @@ TEST_F(CApiTest, CreateGetVectorOfMapsStringFloat) {  // support zipmap output t
   RelAllocations<OrtStatus> rels(&OrtReleaseStatus);
 
   const int N = 3;
-  const size_t NUM_KV_PAIRS = 4;
+  const int64_t NUM_KV_PAIRS = 4;
   std::vector<OrtValue*> in(N);
   const char* keys_arr[NUM_KV_PAIRS] = {"abc", "def", "ghi", "jkl"};
   std::vector<std::string> keys{keys_arr, keys_arr + NUM_KV_PAIRS};
-  std::vector<size_t> dims = {NUM_KV_PAIRS};
+  std::vector<int64_t> dims = {NUM_KV_PAIRS};
   std::vector<float> values{3.0f, 1.0f, 2.f, 0.f};
   for (int i = 0; i < N; ++i) {
     // create key tensor


### PR DESCRIPTION
C API uses both size_t and int64_t for dimensions, this change make them all consistent. Choosing int64_t as negative values are valid dimension values, negative values indicates unknown or dynamic dimensions. 