### PR TITLE
Change bind2nd to bind

### DIFF
--- a/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
@@ -361,7 +361,7 @@ std::pair<float, float> MeanStdev(std::vector<float>& v) {
 
   std::vector<float> diff(v.size());
   std::transform(v.begin(), v.end(), diff.begin(),
-                 std::bind2nd(std::minus<float>(), mean));
+                 std::bind(std::minus<float>(), std::placeholders::_1, mean));
   float sq_sum = std::inner_product(diff.begin(), diff.end(), diff.begin(), 0.0f);
   float stdev = std::sqrt(sq_sum / v.size());
 
@@ -374,11 +374,11 @@ void Normalize(std::vector<float>& v,
   float stdev = mean_stdev.second;
 
   std::transform(v.begin(), v.end(), v.begin(),
-                 std::bind2nd(std::minus<float>(), mean));
+                 std::bind(std::minus<float>(), std::placeholders::_1, mean));
 
   if (normalize_variance) {
     std::transform(v.begin(), v.end(), v.begin(),
-                   std::bind2nd(std::divides<float>(), stdev));
+                   std::bind(std::divides<float>(), std::placeholders::_1, stdev));
   }
 }
 


### PR DESCRIPTION
`std::bind2nd` is deprecated in C++11 and removed in C++17 (see [MSDN documentation](https://docs.microsoft.com/en-us/cpp/standard-library/functional-functions?view=vs-2017#bind2nd)). Change to `std::bind` with placeholder instead.