### PR TITLE
Add unique identifier in function subgraph

### DIFF
--- a/onnxruntime/core/graph/function.cc
+++ b/onnxruntime/core/graph/function.cc
@@ -212,6 +212,13 @@ FunctionImpl::FunctionImpl(const onnxruntime::Graph& graph,
   auto attr_map = node_in_parent_graph->GetAttributes();
   for (auto& node : onnx_func_proto_->node()) {
     std::vector<onnxruntime::NodeArg*> inputs, outputs;
+    std::string uniq_identifier = node.name();
+    if (!node.has_name()) {
+      std::stringstream ss;
+      ss << static_cast<const void*>(&node);
+      uniq_identifier = ss.str();
+    }
+
     for (int idx = 0; idx < node.input_size(); ++idx) {
       std::string tensor_name = node.input().Get(idx);
       auto iter = input_name_idx_map.find(tensor_name);
@@ -257,7 +264,7 @@ FunctionImpl::FunctionImpl(const onnxruntime::Graph& graph,
         new_attr_map[attr.name()] = attr;
       }
     }
-    sub_graph.AddNode(node.name() + "_" + std::to_string(node_index), node.op_type(), node.doc_string(), inputs, outputs, &new_attr_map, node.domain());
+    sub_graph.AddNode(uniq_identifier + "_" + std::to_string(node_index), node.op_type(), node.doc_string(), inputs, outputs, &new_attr_map, node.domain());
   }
   auto status = sub_graph.Resolve();
   ORT_ENFORCE(status.IsOK());

--- a/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
@@ -561,7 +561,7 @@ void MeanVarianceNormalizationFunctionAcrossChannels(std::vector<int64_t> axes) 
   test.Run();
 }
 
-TEST(TensorOpTest, DISABLED_MeanVarianceNormalizationCPUTest) {
+TEST(TensorOpTest, MeanVarianceNormalizationCPUTest) {
   // across_channels: true, normalize_variance: true
   MeanVarianceNormalizationAcrossChannels(true, true);
 


### PR DESCRIPTION
After we introduced changes in function authoring, the newly added macro removed sub graph node names, which was used as unique identifier in function's subgraph. This fix will generate one without the presence of such name out of the node's memory address.