### PR TITLE
Copy inputs and outputs directly in InferenceSession::SaveModelMetadata

### DIFF
--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -220,7 +220,7 @@ common::Status InferenceSession::RegisterExecutionProvider(std::unique_ptr<IExec
   return Status::OK();
 }
 
-common::Status InferenceSession::RegisterGraphTransformer(std::unique_ptr<onnxruntime::GraphTransformer> p_graph_transformer,                                                          
+common::Status InferenceSession::RegisterGraphTransformer(std::unique_ptr<onnxruntime::GraphTransformer> p_graph_transformer,
                                                           TransformerLevel level) {
   if (p_graph_transformer == nullptr) {
     return Status(common::ONNXRUNTIME, common::FAIL, "Received nullptr for graph transformer");
@@ -930,10 +930,9 @@ common::Status InferenceSession::SaveModelMetadata(const onnxruntime::Model& mod
 
   // save required inputs
   const auto& required_inputs = graph.GetInputs();  // inputs excluding initializers
-  required_input_def_list_.reserve(required_inputs.size());
+  required_input_def_list_ = required_inputs;       // A direct copy of required inputs
   required_model_input_names_.reserve(required_inputs.size());
   for (const auto& elem : required_inputs) {
-    required_input_def_list_.push_back(elem);
     required_model_input_names_.insert(elem->Name());
   }
 
@@ -948,10 +947,9 @@ common::Status InferenceSession::SaveModelMetadata(const onnxruntime::Model& mod
 
   // save outputs
   const auto& outputs = graph.GetOutputs();
-  output_def_list_.reserve(outputs.size());
+  output_def_list_ = outputs;  // A direct copy of outputs
   model_output_names_.reserve(outputs.size());
   for (const auto& elem : outputs) {
-    output_def_list_.push_back(elem);
     model_output_names_.insert(elem->Name());
   }
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -220,7 +220,8 @@ common::Status InferenceSession::RegisterExecutionProvider(std::unique_ptr<IExec
   return Status::OK();
 }
 
-common::Status InferenceSession::RegisterGraphTransformer(std::unique_ptr<onnxruntime::GraphTransformer> p_graph_transformer, TransformerLevel level) {
+common::Status InferenceSession::RegisterGraphTransformer(std::unique_ptr<onnxruntime::GraphTransformer> p_graph_transformer,
+                                                          TransformerLevel level) {
   if (p_graph_transformer == nullptr) {
     return Status(common::ONNXRUNTIME, common::FAIL, "Received nullptr for graph transformer");
   }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -220,8 +220,7 @@ common::Status InferenceSession::RegisterExecutionProvider(std::unique_ptr<IExec
   return Status::OK();
 }
 
-common::Status InferenceSession::RegisterGraphTransformer(std::unique_ptr<onnxruntime::GraphTransformer> p_graph_transformer,
-                                                          TransformerLevel level) {
+common::Status InferenceSession::RegisterGraphTransformer(std::unique_ptr<onnxruntime::GraphTransformer> p_graph_transformer, TransformerLevel level) {
   if (p_graph_transformer == nullptr) {
     return Status(common::ONNXRUNTIME, common::FAIL, "Received nullptr for graph transformer");
   }


### PR DESCRIPTION
Copy inputs and outputs directly in InferenceSession::SaveModelMetadata.
In training codes, SaveModelMetadata would be called multiple times, this trivial change is just to make things correct.