### PR TITLE
Disable one more test when contrib ops are disabled.

### DIFF
--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -392,6 +392,7 @@ int real_main(int argc, char* argv[], OrtEnv** p_env) {
   broken_tests["coreml_Inceptionv3_ImageNet"] = "This model uses contrib ops.";
   broken_tests["coreml_FNS-Candy_ImageNet"] = "This model uses contrib ops.";
   broken_tests["coreml_AgeNet_ImageNet"] = "This model uses contrib ops.";
+  broken_tests["coreml_DictVectorizer-RandomForestRegressor_sklearn_load_diabetes"] = "This model uses contrib ops.";  
 #endif
 
   int result = 0;


### PR DESCRIPTION
One more test failed as per https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=79109. Not sure why this didn't fail earlier.