### PR TITLE
fix for tensorrt_basic_test not being run.

### DIFF
--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -5,7 +5,7 @@
 #include "test/providers/provider_test_utils.h"
 #include "test/framework/test_utils.h"
 #include "gtest/gtest.h"
-#include "core/providers/trt/trt_execution_provider.h"
+#include "core/providers/tensorrt/tensorrt_execution_provider.h"
 
 using namespace std;
 using namespace ONNX_NAMESPACE;

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -484,7 +484,12 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs, enab
     for config in configs:
         log.info("Running tests for %s configuration", config)
         cwd = get_config_build_dir(build_dir, config)
-        dll_path = os.path.join(build_dir, config, "external", "tvm", config) if enable_tvm else None
+        if enable_tvm:
+          dll_path = os.path.join(build_dir, config, "external", "tvm", config)
+        elif enable_tensorrt:
+          dll_path = os.path.join(args.tensorrt_home, 'lib')
+        else:
+          dll_path = None
         run_subprocess([ctest_path, "--build-config", config, "--verbose"],
                        cwd=cwd, dll_path=dll_path)
 


### PR DESCRIPTION
tenssort_basic_test was not being built nor run as part of unit tests.
this fix re-enables the test.