### PR TITLE
BuildFusedKernelDef uses N^2 algorithm verifying input - optimize

### DIFF
--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -48,10 +48,6 @@ KernelDefBuilder& BuildFusedKernelDef(KernelDefBuilder& builder, const onnxrunti
       .SetDomain(schema->domain())
       .SinceVersion(schema->SinceVersion())
       .Provider(node.GetExecutionProviderType());
-  auto& inputs = node.InputDefs();
-  for (auto input : inputs) {
-    builder.TypeConstraint(input->Name(), DataTypeImpl::TypeFromProto(*input->TypeAsProto()));
-  }
   return builder;
 }
 


### PR DESCRIPTION
This optimization is required for WinML to prevent tests timing out.