### PR TITLE
Avoid releasing MLValue output on non-default CUDA stream.

### DIFF
--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -164,11 +164,9 @@ Status SequentialExecutor::Execute(const SessionState& session_state,
                                                      {{"op_name", p_op_kernel->KernelDef().OpName()}});
     }
 
-    if (p_op_kernel->Node().GetExecutionProviderType() != kCudaExecutionProvider || queue_id == 0) {
-      // free ml-values corresponding to this node
-      VLOGS(logger, 1) << "Releasing node ML values after computing kernel: " << p_op_kernel->Node().Name();
-      ORT_RETURN_IF_ERROR(ReleaseNodeMLValues(frame, seq_exec_plan, node_exec_plan, logger));
-    }
+    // free ml-values corresponding to this node
+    VLOGS(logger, 1) << "Releasing node ML values after computing kernel: " << p_op_kernel->Node().Name();
+    ORT_RETURN_IF_ERROR(ReleaseNodeMLValues(frame, seq_exec_plan, node_exec_plan, logger));
   }
 
   VLOGS(logger, 1) << "Fetching output.";

--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -164,9 +164,11 @@ Status SequentialExecutor::Execute(const SessionState& session_state,
                                                      {{"op_name", p_op_kernel->KernelDef().OpName()}});
     }
 
-    // free ml-values corresponding to this node
-    VLOGS(logger, 1) << "Releasing node ML values after computing kernel: " << p_op_kernel->Node().Name();
-    ORT_RETURN_IF_ERROR(ReleaseNodeMLValues(frame, seq_exec_plan, node_exec_plan, logger));
+    if (p_op_kernel->Node().GetExecutionProviderType() != kCudaExecutionProvider || queue_id == 0) {
+      // free ml-values corresponding to this node
+      VLOGS(logger, 1) << "Releasing node ML values after computing kernel: " << p_op_kernel->Node().Name();
+      ORT_RETURN_IF_ERROR(ReleaseNodeMLValues(frame, seq_exec_plan, node_exec_plan, logger));
+    }
   }
 
   VLOGS(logger, 1) << "Fetching output.";

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -22,7 +22,6 @@ ONNX_OPERATOR_KERNEL_EX(
     kCudaExecutionProvider,
     KernelDefBuilder()
         .InputMemoryType<OrtMemTypeCPUInput>(0)
-        .ExecQueueId(kCudaStreamCopyIn)
         .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes()),
     Memcpy);
 
@@ -33,7 +32,6 @@ ONNX_OPERATOR_KERNEL_EX(
     kCudaExecutionProvider,
     KernelDefBuilder()
         .OutputMemoryType<OrtMemTypeCPUOutput>(0)
-        .ExecQueueId(kCudaStreamCopyOut)
         .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes()),
     Memcpy);
 


### PR DESCRIPTION
This PR is to fix a bug when using mixed CPU/GPU operators in a sequential executor. The basic idea of sequential executor is to execute operators in the graph one-by-one, i.e., if op B is executed after op A, op A must have completed. However, this assumption breaks when cross-device memcpy exists.

Assume we have a model that consists of the following three operators:
```
+-----+      +-----+
|     |      |     |
|  A  |      |  B  |
|     |      |     |
+-----+      +-----+
   |            |
   |            |
   |            |
   +------------+
          |
          v
      +-------+
      |       |
      |   C   |
      |       |
      +-------+
```
in which `A` and `B` are CUDA operators while `C` is a CPU operator. During the `TransformGraph` process of ONNX Runtime, two memcpy operators `D` and `E` will be inserted after `A` and `B`, respectively. So the transformed graph will become
```
+-----+      +-----+
|     |      |     |
|  A  |      |  B  |
|     |      |     |
+-----+      +-----+
   |            |
   |            |  GPU tensors
   |            |
+--v--+      +--v--+
|     |      |     |
|  D  |      |  E  |
|     |      |     |
+-----+      +-----+
   |            |
   |            | CPU tensors
   |            |
   +------------+
          |
          |
      +---v---+
      |       |
      |   C   |
      |       |
      +-------+
```

In the current execution model of CUDA provider, the cross-device memcpy's are always executed in a separated CUDA stream to avoid blocking the main stream. This breaks the assumption of sequential execution because cudaMemcpyAsync could be executed later than the following operators. In this particular case, the execution order is
```
A (GPU stream 0) -> D (GPU stream 2) -> B (GPU stream 0) -> E (GPU stream 2) -> C (CPU)
```
The brackets after the node names identify the device and stream (if any) on which the operator will be running. Note that `D` and `E` run in a separated GPU stream than the default (0). After `Compute` is called in D, ONNX Runtime would consider the input of `D` as used and before processing the next operator, `SequentialExector` will release the `MLValue` of the input of `D`. And this GPU memory space will be reused by operator `B` to store its own output. However, since the async function of memcpy could be still ongoing, the input of `D` may still be needed until `cudaMemcpyAsync` is completed. In other words, ONNX Runtime may corrupt the buffer of the input of `D` before `D` is done.

This PR proposes an ad-hoc solution that avoid releasing those MLValues used for memcpy. It determines whether to release the MLValues by checking if the node is executed on CUDA provider with a non-default stream.