### PR TITLE
fix extra copy in function kernel

### DIFF
--- a/include/onnxruntime/core/framework/kernel_registry.h
+++ b/include/onnxruntime/core/framework/kernel_registry.h
@@ -26,7 +26,7 @@ class KernelRegistry {
   // TODO(Task:132) Make usage of unique_ptr/shared_ptr as out param consistent
   Status TryCreateKernel(const onnxruntime::Node& node, const IExecutionProvider& execution_provider,
                          const std::unordered_map<int, MLValue>& initialized_tensors,
-                         const MLValueNameIdxMap& mlvalue_name_idx_map, const FuncManager& funcs_mgr,
+                         const SessionState& session_state,
                          std::unique_ptr<OpKernel>& op_kernel) const;
 
   // Check if an execution provider can create kernel for a node and return

--- a/include/onnxruntime/core/framework/kernel_registry.h
+++ b/include/onnxruntime/core/framework/kernel_registry.h
@@ -26,7 +26,9 @@ class KernelRegistry {
   // TODO(Task:132) Make usage of unique_ptr/shared_ptr as out param consistent
   Status TryCreateKernel(const onnxruntime::Node& node, const IExecutionProvider& execution_provider,
                          const std::unordered_map<int, MLValue>& initialized_tensors,
-                         const SessionState& session_state,
+                         const MLValueNameIdxMap& mlvalue_name_idx_map,
+                         const FuncManager& funcs_mgr,
+                         const std::vector<AllocatorPtr>& output_allocators,
                          std::unique_ptr<OpKernel>& op_kernel) const;
 
   // Check if an execution provider can create kernel for a node and return

--- a/include/onnxruntime/core/framework/op_kernel_info.h
+++ b/include/onnxruntime/core/framework/op_kernel_info.h
@@ -26,7 +26,9 @@ class OpKernelInfo : public OpNodeProtoHelper<ProtoHelperNodeContext> {
                         const KernelDef& kernel_def,
                         const IExecutionProvider& execution_provider,
                         const std::unordered_map<int, MLValue>& initialized_tensors,
-                        const SessionState& session_state);
+	                    const MLValueNameIdxMap& mlvalue_name_idx_map,
+	                    const FuncManager& funcs_mgr,
+                        const std::vector<AllocatorPtr>& output_allocators);
 
   OpKernelInfo(const OpKernelInfo& other);
 
@@ -45,7 +47,7 @@ class OpKernelInfo : public OpNodeProtoHelper<ProtoHelperNodeContext> {
   common::Status GetFusedFuncs(ComputeFunc* compute, CreateFunctionStateFunc* create, DestroyFunctionStateFunc* release) const;
 
   // find the allocator for i-th output tensor, based on the allocation plan
-  common::Status GetOutputTensorAllocator(int output_id, AllocatorPtr& allocator) const;
+  common::Status GetOutputTensorAllocator(size_t output_id, AllocatorPtr& allocator) const;
 
  private:
   ORT_DISALLOW_MOVE(OpKernelInfo);
@@ -57,7 +59,9 @@ class OpKernelInfo : public OpNodeProtoHelper<ProtoHelperNodeContext> {
   // will delegate kernel compute call to <execution_provider> compute call.
   gsl::not_null<const ::onnxruntime::IExecutionProvider*> execution_provider_;
   const std::unordered_map<int, MLValue>& initialized_tensors_;
-  const SessionState& session_state_;
+  const MLValueNameIdxMap& mlvalue_name_idx_map_;
+  const FuncManager& funcs_mgr_;
+  std::vector<AllocatorPtr> output_allocators_;
   ProtoHelperNodeContext proto_helper_context_;
 };
 

--- a/include/onnxruntime/core/framework/op_kernel_info.h
+++ b/include/onnxruntime/core/framework/op_kernel_info.h
@@ -26,8 +26,8 @@ class OpKernelInfo : public OpNodeProtoHelper<ProtoHelperNodeContext> {
                         const KernelDef& kernel_def,
                         const IExecutionProvider& execution_provider,
                         const std::unordered_map<int, MLValue>& initialized_tensors,
-	                    const MLValueNameIdxMap& mlvalue_name_idx_map,
-	                    const FuncManager& funcs_mgr,
+                        const MLValueNameIdxMap& mlvalue_name_idx_map,
+                        const FuncManager& funcs_mgr,
                         const std::vector<AllocatorPtr>& output_allocators);
 
   OpKernelInfo(const OpKernelInfo& other);

--- a/include/onnxruntime/core/framework/op_kernel_info.h
+++ b/include/onnxruntime/core/framework/op_kernel_info.h
@@ -15,7 +15,7 @@ namespace onnxruntime {
 
 class MLValueNameIdxMap;
 class FuncManager;
-    /**
+/**
    A very light-weight class, which works as an aggregated
    view of all data needed for constructing a Kernel instance.
    NOTE: it does not own/hold any objects.
@@ -26,8 +26,7 @@ class OpKernelInfo : public OpNodeProtoHelper<ProtoHelperNodeContext> {
                         const KernelDef& kernel_def,
                         const IExecutionProvider& execution_provider,
                         const std::unordered_map<int, MLValue>& initialized_tensors,
-                        const MLValueNameIdxMap& mlvalue_name_idx_map,
-                        const FuncManager& funcs_mgr);
+                        const SessionState& session_state);
 
   OpKernelInfo(const OpKernelInfo& other);
 
@@ -45,6 +44,9 @@ class OpKernelInfo : public OpNodeProtoHelper<ProtoHelperNodeContext> {
 
   common::Status GetFusedFuncs(ComputeFunc* compute, CreateFunctionStateFunc* create, DestroyFunctionStateFunc* release) const;
 
+  // find the allocator for i-th output tensor, based on the allocation plan
+  common::Status GetOutputTensorAllocator(int output_id, AllocatorPtr& allocator) const;
+
  private:
   ORT_DISALLOW_MOVE(OpKernelInfo);
   ORT_DISALLOW_ASSIGNMENT(OpKernelInfo);
@@ -55,8 +57,7 @@ class OpKernelInfo : public OpNodeProtoHelper<ProtoHelperNodeContext> {
   // will delegate kernel compute call to <execution_provider> compute call.
   gsl::not_null<const ::onnxruntime::IExecutionProvider*> execution_provider_;
   const std::unordered_map<int, MLValue>& initialized_tensors_;
-  const MLValueNameIdxMap& mlvalue_name_idx_map_;
-  const FuncManager& funcs_mgr_;
+  const SessionState& session_state_;
   ProtoHelperNodeContext proto_helper_context_;
 };
 

--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -182,6 +182,14 @@ class Tensor final {
     return ret;
   }
 
+  /**
+  Replace the tensor's buffer with another buffer. The original buffer will be released!!!
+    p:  the replacement buffer
+	shape: the replacement buffer's shape
+	allocator:  the allocator for replacement buffer
+  */
+  Status ReplaceBuffer(void* p, const TensorShape& shape, AllocatorPtr allocator, int64_t offset = 0);
+
   // More API methods.
  private:
   void Init(MLDataType p_type,

--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -13,6 +13,7 @@
 #include "core/framework/data_types.h"
 #include "core/framework/tensor_shape.h"
 #include "onnxruntime_config.h"
+#include "core/framework/func_api.h"
 
 namespace onnxruntime {
 
@@ -183,12 +184,11 @@ class Tensor final {
   }
 
   /**
-  Replace the tensor's buffer with another buffer. The original buffer will be released!!!
-    p:  the replacement buffer
-	shape: the replacement buffer's shape
+  Replace the tensor's buffer with a ONNXRuntime C-Tenosr. The original buffer will be released!!!
+    p:  the replacement tensor
 	allocator:  the allocator for replacement buffer
   */
-  Status ReplaceBuffer(void* p, const TensorShape& shape, AllocatorPtr allocator, int64_t offset = 0);
+  Status ReplaceBuffer(ONNXRunTimeTensor* p, AllocatorPtr allocator, int64_t offset = 0);
 
   // More API methods.
  private:

--- a/onnxruntime/core/framework/execution_frame.h
+++ b/onnxruntime/core/framework/execution_frame.h
@@ -50,7 +50,7 @@ class IExecutionFrame {
   // Return S_OK and nullptr if index map to an value that is an unused optional input/output
   // Shape is required for tensors but not traditional ML values.
   Status GetOrCreateNodeOutputMLValue(int index, const TensorShape* shape, MLValue*& p_mlvalue);
-
+  
   /**
    * write the output values to the 'fetches' vector
    * Don't access the values after SessionState is destroyed 

--- a/onnxruntime/core/framework/kernel_registry.cc
+++ b/onnxruntime/core/framework/kernel_registry.cc
@@ -241,7 +241,9 @@ Status KernelRegistry::Register(KernelCreateInfo&& create_info) {
 
 Status KernelRegistry::TryCreateKernel(const onnxruntime::Node& node, const IExecutionProvider& execution_provider,
                                        const std::unordered_map<int, MLValue>& initialized_tensors,
-                                       const SessionState& session_state,
+                                       const MLValueNameIdxMap& mlvalue_name_idx_map,
+                                       const FuncManager& funcs_mgr,
+                                       const std::vector<AllocatorPtr>& output_allocators,
                                        /*out*/ std::unique_ptr<OpKernel>& op_kernel) const {
   const KernelCreateInfo* kernel_create_info = TryFindKernel(node, execution_provider.Type());
 
@@ -253,7 +255,9 @@ Status KernelRegistry::TryCreateKernel(const onnxruntime::Node& node, const IExe
                            *kernel_create_info->kernel_def,
                            execution_provider,
                            initialized_tensors,
-                           session_state);
+                           mlvalue_name_idx_map,
+                           funcs_mgr,
+                           output_allocators);
   op_kernel.reset(kernel_create_info->kernel_create_func(kernel_info));
   return Status::OK();
 }

--- a/onnxruntime/core/framework/kernel_registry.cc
+++ b/onnxruntime/core/framework/kernel_registry.cc
@@ -241,7 +241,7 @@ Status KernelRegistry::Register(KernelCreateInfo&& create_info) {
 
 Status KernelRegistry::TryCreateKernel(const onnxruntime::Node& node, const IExecutionProvider& execution_provider,
                                        const std::unordered_map<int, MLValue>& initialized_tensors,
-                                       const MLValueNameIdxMap& mlvalue_name_idx_map, const FuncManager& funcs_mgr,
+                                       const SessionState& session_state,
                                        /*out*/ std::unique_ptr<OpKernel>& op_kernel) const {
   const KernelCreateInfo* kernel_create_info = TryFindKernel(node, execution_provider.Type());
 
@@ -253,8 +253,7 @@ Status KernelRegistry::TryCreateKernel(const onnxruntime::Node& node, const IExe
                            *kernel_create_info->kernel_def,
                            execution_provider,
                            initialized_tensors,
-                           mlvalue_name_idx_map,
-                           funcs_mgr);
+                           session_state);
   op_kernel.reset(kernel_create_info->kernel_create_func(kernel_info));
   return Status::OK();
 }

--- a/onnxruntime/core/framework/kernel_registry_manager.cc
+++ b/onnxruntime/core/framework/kernel_registry_manager.cc
@@ -24,7 +24,7 @@ Status KernelRegistryManager::CreateKernel(const onnxruntime::Node& node,
     std::lock_guard<OrtMutex> lock(lock_);
     for (auto& registry : custom_kernel_registries_) {
       status = registry->TryCreateKernel(node, execution_provider, session_state.GetInitializedTensors(),
-                                         session_state.GetMLValueNameIdxMap(), session_state.GetFuncMgr(), op_kernel);
+                                         session_state, op_kernel);
       if (status.IsOK()) {
         return status;
       }

--- a/onnxruntime/core/framework/kernel_registry_manager.cc
+++ b/onnxruntime/core/framework/kernel_registry_manager.cc
@@ -6,10 +6,37 @@
 #include "core/framework/customregistry.h"
 #include "core/framework/execution_providers.h"
 #include "core/framework/session_state.h"
+#include "core/framework/utils.h"
 
 using namespace ONNX_NAMESPACE;
 using namespace ::onnxruntime::common;
 namespace onnxruntime {
+
+static void FindOutputAllocators(const onnxruntime::Node& node,
+                                 const SessionState& session_state,
+                                 std::vector<AllocatorPtr>& output_allocators) {
+  for (auto* arg : node.OutputDefs()) {
+    int ml_index;
+    if (session_state.GetMLValueNameIdxMap().GetIdx(arg->Name(), ml_index).IsOK()) {
+      const SequentialExecutionPlan* p_seq_exec_plan = session_state.GetExecutionPlan();
+      const auto& alloc_plan = p_seq_exec_plan->allocation_plan;
+      ORT_ENFORCE(ml_index >= 0 && ml_index < alloc_plan.size());
+      const auto& per_alloc_plan = alloc_plan[ml_index];
+
+      auto alloc_info = per_alloc_plan.location;
+      auto ml_type = per_alloc_plan.value_type;
+      if (ml_type == nullptr ||
+          !ml_type->IsTensorType()) {
+        output_allocators.push_back(nullptr);
+      } else {
+        output_allocators.push_back(utils::GetAllocator(session_state, per_alloc_plan.location));
+      }
+    } else {
+      output_allocators.push_back(nullptr);
+    }
+  }
+}
+
 Status KernelRegistryManager::CreateKernel(const onnxruntime::Node& node,
                                            const IExecutionProvider& execution_provider,
                                            const SessionState& session_state,
@@ -19,12 +46,19 @@ Status KernelRegistryManager::CreateKernel(const onnxruntime::Node& node,
     return Status(ONNXRUNTIME, FAIL,
                   "The node is not placed on any Execution Provider, therefore, can't find a suitable kernel for it");
   }
+  std::vector<AllocatorPtr> output_allocators;
+  FindOutputAllocators(node, session_state, output_allocators);
+
   Status status;
   {
     std::lock_guard<OrtMutex> lock(lock_);
     for (auto& registry : custom_kernel_registries_) {
-      status = registry->TryCreateKernel(node, execution_provider, session_state.GetInitializedTensors(),
-                                         session_state, op_kernel);
+      status = registry->TryCreateKernel(node, execution_provider,
+                                         session_state.GetInitializedTensors(),
+                                         session_state.GetMLValueNameIdxMap(),
+                                         session_state.GetFuncMgr(),
+                                         output_allocators,
+                                         op_kernel);
       if (status.IsOK()) {
         return status;
       }
@@ -38,8 +72,12 @@ Status KernelRegistryManager::CreateKernel(const onnxruntime::Node& node,
     if (iter != provider_type_to_registry_.end()) p = iter->second.get();
   }
   if (p != nullptr) {
-    status = p->TryCreateKernel(node, execution_provider, session_state.GetInitializedTensors(),
-                                session_state.GetMLValueNameIdxMap(), session_state.GetFuncMgr(), op_kernel);
+    status = p->TryCreateKernel(node, execution_provider,
+                                session_state.GetInitializedTensors(),
+                                session_state.GetMLValueNameIdxMap(),
+                                session_state.GetFuncMgr(),
+                                output_allocators,
+                                op_kernel);
     if (status.IsOK()) {
       return status;
     }

--- a/onnxruntime/core/framework/kernel_registry_manager.cc
+++ b/onnxruntime/core/framework/kernel_registry_manager.cc
@@ -23,7 +23,6 @@ static void FindOutputAllocators(const onnxruntime::Node& node,
       ORT_ENFORCE(ml_index >= 0 && ml_index < alloc_plan.size());
       const auto& per_alloc_plan = alloc_plan[ml_index];
 
-      auto alloc_info = per_alloc_plan.location;
       auto ml_type = per_alloc_plan.value_type;
       if (ml_type == nullptr ||
           !ml_type->IsTensorType()) {

--- a/onnxruntime/core/framework/op_kernel_info.cc
+++ b/onnxruntime/core/framework/op_kernel_info.cc
@@ -5,6 +5,8 @@
 #include "core/framework/fuse_nodes_funcs.h"
 #include "core/framework/op_kernel.h"
 #include "core/framework/op_kernel_info.h"
+#include "core/framework/session_state.h"
+#include "core/framework/utils.h"
 
 namespace onnxruntime {
 
@@ -12,15 +14,13 @@ OpKernelInfo::OpKernelInfo(const onnxruntime::Node& node,
                            const KernelDef& kernel_def,
                            const IExecutionProvider& execution_provider,
                            const std::unordered_map<int, MLValue>& initialized_tensors,
-                           const MLValueNameIdxMap& mlvalue_name_idx_map,
-                           const FuncManager& funcs_mgr)
+                           const SessionState& session_state)
     : OpNodeProtoHelper(&proto_helper_context_),
       node_(node),
       kernel_def_(kernel_def),
       execution_provider_(&execution_provider),
       initialized_tensors_(initialized_tensors),
-      mlvalue_name_idx_map_(mlvalue_name_idx_map),
-      funcs_mgr_(funcs_mgr),
+      session_state_(session_state),
       proto_helper_context_(node) {}
 
 OpKernelInfo::OpKernelInfo(const OpKernelInfo& other)
@@ -28,8 +28,7 @@ OpKernelInfo::OpKernelInfo(const OpKernelInfo& other)
                    other.kernel_def_,
                    *other.execution_provider_,
                    other.initialized_tensors_,
-                   other.mlvalue_name_idx_map_,
-                   other.funcs_mgr_) {}
+                   other.session_state_) {}
 
 const OrtAllocatorInfo& OpKernelInfo::GetAllocatorInfo(int device_id, OrtMemType mem_type) const {
   AllocatorPtr alloc = GetAllocator(device_id, mem_type);
@@ -59,7 +58,7 @@ bool OpKernelInfo::TryGetConstantInput(int input_index, const Tensor** constant_
   }
   auto& input_arg_name = node_.InputDefs()[input_index]->Name();
   int input_arg_index = -1;
-  if (!mlvalue_name_idx_map_.GetIdx(input_arg_name, input_arg_index).IsOK()) {
+  if (!session_state_.GetMLValueNameIdxMap().GetIdx(input_arg_name, input_arg_index).IsOK()) {
     return false;
   }
 
@@ -76,6 +75,32 @@ bool OpKernelInfo::TryGetConstantInput(int input_index, const Tensor** constant_
 }
 
 common::Status OpKernelInfo::GetFusedFuncs(ComputeFunc* compute, CreateFunctionStateFunc* create, DestroyFunctionStateFunc* release) const {
-  return funcs_mgr_.GetFuncs(node_.Name(), compute, create, release);
+  return session_state_.GetFuncMgr().GetFuncs(node_.Name(), compute, create, release);
+}
+
+common::Status OpKernelInfo::GetOutputTensorAllocator(int output_id, AllocatorPtr& allocator) const{
+  ORT_ENFORCE(output_id >= 0 && output_id < node_.OutputDefs().size());
+  auto* arg = node_.OutputDefs()[output_id];
+  int ml_index;
+  ORT_RETURN_IF_ERROR(session_state_.GetMLValueNameIdxMap().GetIdx(arg->Name(), ml_index));
+  const SequentialExecutionPlan* p_seq_exec_plan = session_state_.GetExecutionPlan();
+  const auto& alloc_plan = p_seq_exec_plan->allocation_plan;
+  ORT_ENFORCE(ml_index >= 0 && ml_index < alloc_plan.size());
+  const auto& per_alloc_plan = alloc_plan[ml_index];
+
+  auto alloc_info = per_alloc_plan.location;
+  auto ml_type = per_alloc_plan.value_type;
+  if (ml_type == nullptr)
+    return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
+                  "Tried to allocate without valid type information, mlvalue index=" + std::to_string(ml_index));
+
+  if (!ml_type->IsTensorType()) {
+    return Status(common::ONNXRUNTIME, common::FAIL,
+                  "No allocator for non-tensor type value, mlvalue index=" + std::to_string(ml_index));
+  }
+
+  ORT_ENFORCE(per_alloc_plan.alloc_kind == AllocKind::kAllocate || per_alloc_plan.alloc_kind == AllocKind::kAllocateOutput);
+  allocator = utils::GetAllocator(session_state_, per_alloc_plan.location);
+  return Status::OK();
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/op_kernel_info.cc
+++ b/onnxruntime/core/framework/op_kernel_info.cc
@@ -6,7 +6,6 @@
 #include "core/framework/op_kernel.h"
 #include "core/framework/op_kernel_info.h"
 #include "core/framework/session_state.h"
-#include "core/framework/utils.h"
 
 namespace onnxruntime {
 
@@ -14,13 +13,17 @@ OpKernelInfo::OpKernelInfo(const onnxruntime::Node& node,
                            const KernelDef& kernel_def,
                            const IExecutionProvider& execution_provider,
                            const std::unordered_map<int, MLValue>& initialized_tensors,
-                           const SessionState& session_state)
+                           const MLValueNameIdxMap& mlvalue_name_idx_map,
+                           const FuncManager& funcs_mgr,
+                           const std::vector<AllocatorPtr>& output_allocators)
     : OpNodeProtoHelper(&proto_helper_context_),
       node_(node),
       kernel_def_(kernel_def),
       execution_provider_(&execution_provider),
       initialized_tensors_(initialized_tensors),
-      session_state_(session_state),
+      mlvalue_name_idx_map_(mlvalue_name_idx_map),
+      funcs_mgr_(funcs_mgr),
+      output_allocators_(output_allocators),
       proto_helper_context_(node) {}
 
 OpKernelInfo::OpKernelInfo(const OpKernelInfo& other)
@@ -28,7 +31,9 @@ OpKernelInfo::OpKernelInfo(const OpKernelInfo& other)
                    other.kernel_def_,
                    *other.execution_provider_,
                    other.initialized_tensors_,
-                   other.session_state_) {}
+                   other.mlvalue_name_idx_map_,
+                   other.funcs_mgr_,
+                   other.output_allocators_) {}
 
 const OrtAllocatorInfo& OpKernelInfo::GetAllocatorInfo(int device_id, OrtMemType mem_type) const {
   AllocatorPtr alloc = GetAllocator(device_id, mem_type);
@@ -58,7 +63,7 @@ bool OpKernelInfo::TryGetConstantInput(int input_index, const Tensor** constant_
   }
   auto& input_arg_name = node_.InputDefs()[input_index]->Name();
   int input_arg_index = -1;
-  if (!session_state_.GetMLValueNameIdxMap().GetIdx(input_arg_name, input_arg_index).IsOK()) {
+  if (!mlvalue_name_idx_map_.GetIdx(input_arg_name, input_arg_index).IsOK()) {
     return false;
   }
 
@@ -75,32 +80,12 @@ bool OpKernelInfo::TryGetConstantInput(int input_index, const Tensor** constant_
 }
 
 common::Status OpKernelInfo::GetFusedFuncs(ComputeFunc* compute, CreateFunctionStateFunc* create, DestroyFunctionStateFunc* release) const {
-  return session_state_.GetFuncMgr().GetFuncs(node_.Name(), compute, create, release);
+  return funcs_mgr_.GetFuncs(node_.Name(), compute, create, release);
 }
 
-common::Status OpKernelInfo::GetOutputTensorAllocator(int output_id, AllocatorPtr& allocator) const{
-  ORT_ENFORCE(output_id >= 0 && output_id < node_.OutputDefs().size());
-  auto* arg = node_.OutputDefs()[output_id];
-  int ml_index;
-  ORT_RETURN_IF_ERROR(session_state_.GetMLValueNameIdxMap().GetIdx(arg->Name(), ml_index));
-  const SequentialExecutionPlan* p_seq_exec_plan = session_state_.GetExecutionPlan();
-  const auto& alloc_plan = p_seq_exec_plan->allocation_plan;
-  ORT_ENFORCE(ml_index >= 0 && ml_index < alloc_plan.size());
-  const auto& per_alloc_plan = alloc_plan[ml_index];
-
-  auto alloc_info = per_alloc_plan.location;
-  auto ml_type = per_alloc_plan.value_type;
-  if (ml_type == nullptr)
-    return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
-                  "Tried to allocate without valid type information, mlvalue index=" + std::to_string(ml_index));
-
-  if (!ml_type->IsTensorType()) {
-    return Status(common::ONNXRUNTIME, common::FAIL,
-                  "No allocator for non-tensor type value, mlvalue index=" + std::to_string(ml_index));
-  }
-
-  ORT_ENFORCE(per_alloc_plan.alloc_kind == AllocKind::kAllocate || per_alloc_plan.alloc_kind == AllocKind::kAllocateOutput);
-  allocator = utils::GetAllocator(session_state_, per_alloc_plan.location);
+common::Status OpKernelInfo::GetOutputTensorAllocator(size_t output_id, AllocatorPtr& allocator) const {
+  ORT_ENFORCE(output_id < node_.OutputDefs().size());
+  allocator = output_allocators_[output_id];
   return Status::OK();
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/tensor.cc
+++ b/onnxruntime/core/framework/tensor.cc
@@ -98,12 +98,14 @@ void Tensor::ReleaseBuffer() {
   }
 }
 
-Status Tensor::ReplaceBuffer(void* p, const TensorShape& shape, AllocatorPtr allocator, int64_t offset) {
+Status Tensor::ReplaceBuffer(ONNXRunTimeTensor* p, AllocatorPtr allocator, int64_t offset) {
   if (!buffer_deleter_ || buffer_deleter_ != allocator)
     return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, "The replacement buffer is not allocated at the same allocator");
   ReleaseBuffer();
-  p_data_ = p;
-  shape_ = shape;
+  p_data_ = p->data;
+  std::vector<int64_t> new_shape;
+  new_shape.assign(p->shape, p->shape + p->ndim);
+  shape_ = {new_shape};
   byte_offset_ = offset;
   return Status::OK();
 }

--- a/onnxruntime/core/framework/tensor.cc
+++ b/onnxruntime/core/framework/tensor.cc
@@ -98,4 +98,14 @@ void Tensor::ReleaseBuffer() {
   }
 }
 
+Status Tensor::ReplaceBuffer(void* p, const TensorShape& shape, AllocatorPtr allocator, int64_t offset) {
+  if (!buffer_deleter_ || buffer_deleter_ != allocator)
+    return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, "The replacement buffer is not allocated at the same allocator");
+  ReleaseBuffer();
+  p_data_ = p;
+  shape_ = shape;
+  byte_offset_ = offset;
+  return Status::OK();
+}
+
 }  // namespace onnxruntime

--- a/onnxruntime/test/framework/allocation_planner_test.cc
+++ b/onnxruntime/test/framework/allocation_planner_test.cc
@@ -194,12 +194,14 @@ class PlannerTest : public ::testing::Test {
   }
 
   void BindKernel(onnxruntime::Node* p_node, ::onnxruntime::KernelDef& kernel_def) {
+    std::vector<AllocatorPtr> output_allocators(p_node->OutputDefs().size(), nullptr);
     auto info = std::make_unique<OpKernelInfo>(*p_node,
                                                kernel_def,
                                                *execution_providers_.Get(*p_node),
                                                state_.GetInitializedTensors(),
                                                state_.GetMLValueNameIdxMap(),
-                                               state_.GetFuncMgr());
+                                               state_.GetFuncMgr(),
+                                               output_allocators);
     auto dummy = std::make_unique<DummyOpKernel>(*info);
     op_kernel_infos_.push_back(std::move(info));
     state_.AddKernel(p_node->Index(), std::move(dummy));

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -53,12 +53,14 @@ TEST(SessionStateTest, AddGetKernelTest) {
   KernelDef kernel_def;
   CPUExecutionProvider execution_provider{CPUExecutionProviderInfo{"CPUExecutionProvider"}};
 
+  std::vector<AllocatorPtr> output_allocators(node.OutputDefs().size(), nullptr);
   OpKernelInfo p_info(node,
                       kernel_def,
                       execution_provider,
                       s.GetInitializedTensors(),
                       s.GetMLValueNameIdxMap(),
-                      s.GetFuncMgr());
+                      s.GetFuncMgr(),
+                      output_allocators);
   unique_ptr<TestOpKernel> p_kernel;
   p_kernel.reset(new TestOpKernel(p_info));
   size_t orig_num_outputs = p_kernel->Node().OutputDefs().size();


### PR DESCRIPTION
avoid the stupid copy of output tensor in function kernel by swap the memory into execution frame.
A better solution might be leverage Ryan's custom op C api, which has a c implementation of op kernel context. But nGraph is now rely on existing function api for integration. I will refine this part after nGraph integration finished.