### PR TITLE
optimize onnxruntime::common::Status

### DIFF
--- a/include/onnxruntime/core/common/status.h
+++ b/include/onnxruntime/core/common/status.h
@@ -52,6 +52,8 @@ class Status {
 
   Status(StatusCategory category, int code, const std::string& msg);
 
+  Status(StatusCategory category, int code, const char* msg);
+
   Status(StatusCategory category, int code);
 
   Status(const Status& other)
@@ -72,7 +74,9 @@ class Status {
   Status& operator=(Status&& other) = default;
   ~Status() = default;
 
-  bool IsOK() const noexcept;
+  bool IsOK() const {
+    return (state_ == nullptr);
+  }
 
   int Code() const noexcept;
 
@@ -90,13 +94,18 @@ class Status {
     return !(*this == other);
   }
 
-  static const Status& OK() noexcept;
+  static Status OK() {
+    return Status();
+  }
 
  private:
   static const std::string& EmptyString() noexcept;
 
   struct State {
     State(StatusCategory cat0, int code0, const std::string& msg0)
+        : category(cat0), code(code0), msg(msg0) {}
+
+    State(StatusCategory cat0, int code0, const char* msg0)
         : category(cat0), code(code0), msg(msg0) {}
 
     const StatusCategory category;

--- a/onnxruntime/core/common/status.cc
+++ b/onnxruntime/core/common/status.cc
@@ -23,12 +23,15 @@ Status::Status(StatusCategory category, int code, const std::string& msg) {
   state_ = std::make_unique<State>(category, code, msg);
 }
 
-Status::Status(StatusCategory category, int code)
-    : Status(category, code, EmptyString()) {
+Status::Status(StatusCategory category, int code, const char* msg) {
+  // state_ will be allocated here causing the status to be treated as a failure
+  ORT_ENFORCE(code != static_cast<int>(MLStatus::OK));
+
+  state_ = std::make_unique<State>(category, code, msg);
 }
 
-bool Status::IsOK() const noexcept {
-  return (state_ == nullptr);
+Status::Status(StatusCategory category, int code)
+    : Status(category, code, "") {
 }
 
 StatusCategory Status::Category() const noexcept {
@@ -58,8 +61,6 @@ std::string Status::ToString() const {
     result += "[ONNXRuntimeError]";
     result += " : ";
     result += std::to_string(Code());
-    std::string msg;
-
     result += " : ";
     result += MLStatusToString(static_cast<MLStatus>(Code()));
     result += " : ";
@@ -76,10 +77,6 @@ std::string Status::ToString() const {
 #pragma warning(push)
 #pragma warning(disable : 26426)
 #endif
-const Status& Status::OK() noexcept {
-  static Status s_ok;
-  return s_ok;
-}
 
 const std::string& Status::EmptyString() noexcept {
   static std::string s_empty;


### PR DESCRIPTION
Reduce code size by changing:
1. Status::OK() was returning a per-thread static object ref which was then passed through a copy constructor to get the final Status object for a return. This is unnecessary as Status is so simple and can instead just return a locally constructed object. The TF version of status.cc does this.
2. Status::IsOK() is now inlined in status.h to avoid call overhead for what is just a simple pointer check. Same as TF.
3. Add a Status constructor that takes a const char* in addition to the existing std::string constructor so that a string doesn't need to be allocated at the caller.

Shrunk the size of the release onnxruntime_perf_test by 43KB.