### PR TITLE
fix trivial size_t warnings

### DIFF
--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -33,7 +33,7 @@ Status ConstantFolding::Apply(Graph& graph, Node& node, bool& modified, bool& de
   // Go over all output node args and substitute them with the newly computed tensors, which will be
   // added to the graph as initializers.
   ORT_ENFORCE(fetches.size() == node.OutputDefs().size());
-  for (int fetch_idx = 0; fetch_idx < fetches.size(); ++fetch_idx) {
+  for (size_t fetch_idx = 0; fetch_idx < fetches.size(); ++fetch_idx) {
     MLValue& mlvalue = fetches[fetch_idx];
 
     // Build the TensorProto that corresponds to the computed MLValue and add it as initializer to the graph.

--- a/onnxruntime/core/optimizer/slice_elimination.cc
+++ b/onnxruntime/core/optimizer/slice_elimination.cc
@@ -41,7 +41,7 @@ bool EliminateSlice::SatisfyCondition(const Graph& graph, const Node& node) {
 
   // For now eliminate slice operators if starts=0 and ends=MAX_INT or -1.
   // TODO: Take into account the input's shape to get a tighter bound for the ends.
-  for (int i = 0; i < axes.size(); ++i) {
+  for (size_t i = 0; i < axes.size(); ++i) {
     if (starts[i] > 0 || starts[i] < 0 ||
         (ends[i] > 0 && ends[i] < INT64_MAX)) {
       return false;

--- a/onnxruntime/core/providers/cpu/math/matmul_integer.cc
+++ b/onnxruntime/core/providers/cpu/math/matmul_integer.cc
@@ -57,20 +57,20 @@ Status MatMulInteger<uint8_t, uint8_t, int32_t>::Compute(OpKernelContext* ctx) c
   int32_t b_offset = 0;
   if (has_a_zero_point_) {
     auto a_zero_point = ctx->Input<Tensor>(2);
-    ORT_ENFORCE(a_zero_point->Shape().NumDimensions() == 0 || 
-        (a_zero_point->Shape().NumDimensions() == 1 && a_zero_point->Shape().GetDims().size() == 1), 
+    ORT_ENFORCE(a_zero_point->Shape().NumDimensions() == 0 ||
+        (a_zero_point->Shape().NumDimensions() == 1 && a_zero_point->Shape().GetDims().size() == 1),
         "Currently only scalar zero_point is supported. TODO: add per channel zero point support.");
     a_offset = static_cast<int32_t>(*a_zero_point->template Data<uint8_t>());
   }
   if (has_b_zero_point_) {
     auto b_zero_point = ctx->Input<Tensor>(3);
-    ORT_ENFORCE(b_zero_point->Shape().NumDimensions() == 0 || 
+    ORT_ENFORCE(b_zero_point->Shape().NumDimensions() == 0 ||
         (b_zero_point->Shape().NumDimensions() == 1 && b_zero_point->Shape().GetDims().size() == 1),
         "Currently only scalar zero_point is supported. TODO: add per channel zero point support.");
     b_offset = static_cast<int32_t>(*b_zero_point->template Data<uint8_t>());
   }
 
-  for (int i = 0; i < helper.OutputOffsets().size(); i++) {
+  for (size_t i = 0; i < helper.OutputOffsets().size(); i++) {
     GemmlowpMultiply(a->template Data<uint8_t>() + helper.LeftOffsets()[i],
                      b->template Data<uint8_t>() + helper.RightOffsets()[i],
                      y->template MutableData<int32_t>() + helper.OutputOffsets()[i],

--- a/onnxruntime/core/providers/cpu/math/quantize_linear_matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/quantize_linear_matmul.cc
@@ -12,7 +12,7 @@
 
 namespace onnxruntime {
 
-// only register this operator if low precision computation is enabled. 
+// only register this operator if low precision computation is enabled.
 ONNX_OPERATOR_KERNEL_EX(
     QLinearMatMul,
     kOnnxDomain,
@@ -52,13 +52,13 @@ void QuantizeMultiplier(float fp_multiplier, std::int32_t* integer_multiplier, i
   uint32_t* fp_as_bits = reinterpret_cast<uint32_t*>(&fp_multiplier);
   auto current_exponent = (*fp_as_bits >> 23);
   // bring multiplier in [.5,1) range and calculate the shift
-  auto bumped_multiplier_as_bits = 
+  auto bumped_multiplier_as_bits =
       (*fp_as_bits & UINT32_C(0x007fffff)) | UINT32_C(0x3f000000);
-  float* bumped_multiplier = 
+  float* bumped_multiplier =
       reinterpret_cast<float*>(&bumped_multiplier_as_bits);
   auto shift = 126 - current_exponent;
   // convert to fixed point number
-  std::int64_t int_multiplier = 
+  std::int64_t int_multiplier =
       static_cast<std::int64_t>(std::round(*bumped_multiplier * (1ll << 31)));
 
   *integer_multiplier = static_cast<int32_t>(int_multiplier);
@@ -66,11 +66,11 @@ void QuantizeMultiplier(float fp_multiplier, std::int32_t* integer_multiplier, i
 }
 
 void ScaleAndZeropointPairValidationHelper(const Tensor* scale, const Tensor* zeropoint) {
-  ORT_ENFORCE(scale->Shape().NumDimensions() == 0 || 
-      (scale->Shape().NumDimensions() == 1 && scale->Shape().GetDims().size() == 1), 
+  ORT_ENFORCE(scale->Shape().NumDimensions() == 0 ||
+      (scale->Shape().NumDimensions() == 1 && scale->Shape().GetDims().size() == 1),
       "scale must be a scalar");
-  ORT_ENFORCE(zeropoint->Shape().NumDimensions() == 0 || 
-      (zeropoint->Shape().NumDimensions() == 1 && zeropoint->Shape().GetDims().size() == 1), 
+  ORT_ENFORCE(zeropoint->Shape().NumDimensions() == 0 ||
+      (zeropoint->Shape().NumDimensions() == 1 && zeropoint->Shape().GetDims().size() == 1),
       "zeropoint must be a scalar");
 }
 
@@ -104,7 +104,7 @@ Status QLinearMatMul<uint8_t, uint8_t, uint8_t>::Compute(OpKernelContext* ctx) c
   int right_shift;
   QuantizeMultiplier(real_multiplier, &integer_multiplier, &right_shift);
 
-  for (int i = 0; i < helper.OutputOffsets().size(); i++) {
+  for (size_t i = 0; i < helper.OutputOffsets().size(); i++) {
     GemmlowpMultiply(a->template Data<uint8_t>() + helper.LeftOffsets()[i],
                      b->template Data<uint8_t>() + helper.RightOffsets()[i],
                      y->template MutableData<uint8_t>() + helper.OutputOffsets()[i],

--- a/onnxruntime/core/providers/cpu/nn/Unpool.cc
+++ b/onnxruntime/core/providers/cpu/nn/Unpool.cc
@@ -53,7 +53,7 @@ Status MaxUnpool::Compute(OpKernelContext* context) const {
   inferredOutputShape[1] = X_shape[1];
 
   // For feature dims calculate reversing the formula used for Maxpool
-  for (auto dim = 0; dim < kernel_shape_.size(); ++dim) {
+  for (size_t dim = 0; dim < kernel_shape_.size(); ++dim) {
     inferredOutputShape[dim + 2] = (X_shape[dim + 2] - 1) * strides_[dim] - (pads_[dim + 2] + pads_[kernel_shape_.size() + dim + 4]) + kernel_shape_[dim];
   }
 
@@ -75,7 +75,7 @@ Status MaxUnpool::Compute(OpKernelContext* context) const {
     inferredPads.resize(inferredOutputShape.size() * 2, 0);
 
     // calculate if output shape has any padding over the inferred shape for feature dims.
-    for (auto dim = 2; dim < shape.size(); dim++) {
+    for (size_t dim = 2; dim < shape.size(); dim++) {
       ORT_RETURN_IF_NOT(inferredOutputShape[dim] <= shape[dim], "Incorrect output shape");
 
       int64_t inferredPad = shape[dim] - inferredOutputShape[dim];
@@ -97,7 +97,7 @@ Status MaxUnpool::Compute(OpKernelContext* context) const {
   int64_t totalPooledElem = 1;
   int64_t totalOutputElem = 1;
 
-  for (auto dim = 0; dim < X_shape.NumDimensions(); dim++) {
+  for (size_t dim = 0; dim < X_shape.NumDimensions(); dim++) {
     totalPooledElem *= X_shape[dim];
     totalOutputElem *= inferredOutputShape[dim];
   }

--- a/onnxruntime/test/contrib_ops/attention_lstm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/attention_lstm_op_test.cc
@@ -197,7 +197,7 @@ static std::vector<T> ConcatDup(const std::vector<T>& src) {
 template <typename T>
 static std::vector<T> ConcatLastDim(const std::vector<T>& a, const std::vector<T>& b, int depth) {
   std::vector<T> dst(2 * a.size());
-  for (int s = 0; s < a.size(); s += depth) {
+  for (size_t s = 0; s < a.size(); s += depth) {
     std::copy(a.cbegin() + s, a.cbegin() + s + depth, dst.begin() + 2 * s);
     std::copy(b.cbegin() + s, b.cbegin() + s + depth, dst.begin() + 2 * s + depth);
   }
@@ -237,7 +237,7 @@ static std::vector<T> ConvertBatchSeqToSeqBatch(
 template <typename T>
 static std::vector<T> ConvertIcfoToIofc(const std::vector<T>& icfo, int cell_hidden_size) {
   std::vector<T> iofc(icfo.size());
-  for (int i = 0; i < icfo.size(); i += 4 * cell_hidden_size) {
+  for (size_t i = 0; i < icfo.size(); i += 4 * cell_hidden_size) {
     auto src = icfo.cbegin() + i;
     auto dst = iofc.begin() + i;
 

--- a/onnxruntime/test/framework/allocation_planner_test.cc
+++ b/onnxruntime/test/framework/allocation_planner_test.cc
@@ -67,14 +67,14 @@ class AllocationPlanTestUtility {
  public:
   static void CheckAllocationKind(const SequentialExecutionPlan& plan, std::vector<AllocKind>& expected) {
     ASSERT_EQ(plan.allocation_plan.size(), expected.size()) << "Allocation plan of wrong size";
-    for (int i = 0; i < expected.size(); ++i) {
+    for (size_t i = 0; i < expected.size(); ++i) {
       EXPECT_EQ(plan.allocation_plan[i].alloc_kind, expected[i]) << "Error in allocation kind at position " << i;
     }
   }
 
   static void CheckToBeFreed(const SequentialExecutionPlan& plan, const std::vector<MLValueIndex>& expected) {
     ASSERT_EQ(plan.to_be_freed.size(), expected.size()) << "Allocation plan's to_be_freed of wrong size";
-    for (int i = 0; i < expected.size(); ++i) {
+    for (size_t i = 0; i < expected.size(); ++i) {
       EXPECT_EQ(plan.to_be_freed[i], expected[i]) << "Error in to_be_freed at position " << i;
     }
   }
@@ -82,7 +82,7 @@ class AllocationPlanTestUtility {
   static void CheckFreedAtEachStep(const SequentialExecutionPlan& plan, const std::vector<int>& expected_num_freed) {
     ASSERT_EQ(plan.execution_plan.size(), expected_num_freed.size()) << "Execution plan is of wrong size";
     int start = 0;
-    for (int i = 0; i < expected_num_freed.size(); ++i) {
+    for (size_t i = 0; i < expected_num_freed.size(); ++i) {
       if (expected_num_freed[i] > 0) {
         EXPECT_EQ(plan.execution_plan[i].free_from_index, start) << "Error in free_from_index at position " << i;
         EXPECT_EQ(plan.execution_plan[i].free_to_index, start + expected_num_freed[i] - 1)

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -1239,7 +1239,7 @@ TEST(InferenceSessionTests, TestTruncatedSequence) {
   auto& rtensor = fetches.front().Get<Tensor>();
   TensorShape expected_shape(Y_dims);
   ASSERT_EQ(expected_shape, rtensor.Shape());
-  for (int i = 0; i < Y_data.size(); ++i)
+  for (size_t i = 0; i < Y_data.size(); ++i)
     EXPECT_NEAR(Y_data[i], rtensor.template Data<float>()[i], FLT_EPSILON);
 
   // run truncated sequence
@@ -1262,7 +1262,7 @@ TEST(InferenceSessionTests, TestTruncatedSequence) {
     if (seq_start > 0) {
       // continue from truncated sequence
       ASSERT_TRUE(fetches.size() == output_names.size());
-      for (int i_output = 0; i_output < output_names.size(); ++i_output) {
+      for (size_t i_output = 0; i_output < output_names.size(); ++i_output) {
         auto iter = init_state_map.find(output_names[i_output]);
         if (iter != init_state_map.end())
           truncated_feeds.insert(std::make_pair(iter->second, fetches[i_output]));

--- a/onnxruntime/test/framework/math_test.cc
+++ b/onnxruntime/test/framework/math_test.cc
@@ -30,10 +30,10 @@ TEST(MathTest, GemmNoTransNoTrans) {
   math::Set<float, CPUMathUtil>(X.size(), 1, VECTOR_HEAD(X), &provider);
   math::Set<float, CPUMathUtil>(W.size(), 1, VECTOR_HEAD(W), &provider);
   EXPECT_EQ(Y.size(), 30);
-  for (int i = 0; i < X.size(); ++i) {
+  for (size_t i = 0; i < X.size(); ++i) {
     EXPECT_EQ(X[i], 1);
   }
-  for (int i = 0; i < W.size(); ++i) {
+  for (size_t i = 0; i < W.size(); ++i) {
     EXPECT_EQ(W[i], 1);
   }
 
@@ -44,7 +44,7 @@ TEST(MathTest, GemmNoTransNoTrans) {
                                  VECTOR_HEAD(X), VECTOR_HEAD(W), kZero, VECTOR_HEAD(Y),
                                  &provider);
   EXPECT_EQ(Y.size(), 30);
-  for (int i = 0; i < Y.size(); ++i) {
+  for (size_t i = 0; i < Y.size(); ++i) {
     EXPECT_EQ(Y[i], 10) << i;
   }
   // Test Accumulate
@@ -52,7 +52,7 @@ TEST(MathTest, GemmNoTransNoTrans) {
                                  VECTOR_HEAD(X), VECTOR_HEAD(W), kPointFive,
                                  VECTOR_HEAD(Y), &provider);
   EXPECT_EQ(Y.size(), 30);
-  for (int i = 0; i < Y.size(); ++i) {
+  for (size_t i = 0; i < Y.size(); ++i) {
     EXPECT_EQ(Y[i], 15) << i;
   }
   // Test Accumulate
@@ -61,7 +61,7 @@ TEST(MathTest, GemmNoTransNoTrans) {
                                  VECTOR_HEAD(X), VECTOR_HEAD(W), kOne, VECTOR_HEAD(Y),
                                  &provider);
   EXPECT_EQ(Y.size(), 30);
-  for (int i = 0; i < Y.size(); ++i) {
+  for (size_t i = 0; i < Y.size(); ++i) {
     EXPECT_EQ(Y[i], 20) << i;
   }
 }
@@ -74,10 +74,10 @@ TEST(MathTest, GemmNoTransTrans) {
   math::Set<float, CPUMathUtil>(X.size(), 1, VECTOR_HEAD(X), &provider);
   math::Set<float, CPUMathUtil>(W.size(), 1, VECTOR_HEAD(W), &provider);
   EXPECT_EQ(Y.size(), 30);
-  for (int i = 0; i < X.size(); ++i) {
+  for (size_t i = 0; i < X.size(); ++i) {
     EXPECT_EQ(X[i], 1);
   }
-  for (int i = 0; i < W.size(); ++i) {
+  for (size_t i = 0; i < W.size(); ++i) {
     EXPECT_EQ(W[i], 1);
   }
 
@@ -88,7 +88,7 @@ TEST(MathTest, GemmNoTransTrans) {
                                  VECTOR_HEAD(X), VECTOR_HEAD(W), kZero, VECTOR_HEAD(Y),
                                  &provider);
   EXPECT_EQ(Y.size(), 30);
-  for (int i = 0; i < Y.size(); ++i) {
+  for (size_t i = 0; i < Y.size(); ++i) {
     EXPECT_EQ(Y[i], 10) << i;
   }
   // Test Accumulate
@@ -96,14 +96,14 @@ TEST(MathTest, GemmNoTransTrans) {
                                  VECTOR_HEAD(X), VECTOR_HEAD(W), kPointFive,
                                  VECTOR_HEAD(Y), &provider);
   EXPECT_EQ(Y.size(), 30);
-  for (int i = 0; i < Y.size(); ++i) {
+  for (size_t i = 0; i < Y.size(); ++i) {
     EXPECT_EQ(Y[i], 15) << i;
   }
   math::Gemm<float, CPUMathUtil>(CblasNoTrans, CblasTrans, 5, 6, 10, kPointFive,
                                  VECTOR_HEAD(X), VECTOR_HEAD(W), kOne, VECTOR_HEAD(Y),
                                  &provider);
   EXPECT_EQ(Y.size(), 30);
-  for (int i = 0; i < Y.size(); ++i) {
+  for (size_t i = 0; i < Y.size(); ++i) {
     EXPECT_EQ(Y[i], 20) << i;
   }
 }
@@ -116,10 +116,10 @@ TEST(MathTest, GemvNoTrans) {
   math::Set<float, CPUMathUtil>(A.size(), 1, VECTOR_HEAD(A), &provider);
   math::Set<float, CPUMathUtil>(X.size(), 1, VECTOR_HEAD(X), &provider);
   EXPECT_EQ(Y.size(), 5);
-  for (int i = 0; i < A.size(); ++i) {
+  for (size_t i = 0; i < A.size(); ++i) {
     EXPECT_EQ(A[i], 1);
   }
-  for (int i = 0; i < X.size(); ++i) {
+  for (size_t i = 0; i < X.size(); ++i) {
     EXPECT_EQ(X[i], 1);
   }
 
@@ -128,20 +128,20 @@ TEST(MathTest, GemvNoTrans) {
   const float kZero = 0.0;
   math::Gemv<float, CPUMathUtil>(CblasNoTrans, 5, 10, kOne, VECTOR_HEAD(A), VECTOR_HEAD(X),
                                  kZero, VECTOR_HEAD(Y), &provider);
-  for (int i = 0; i < Y.size(); ++i) {
+  for (size_t i = 0; i < Y.size(); ++i) {
     EXPECT_EQ(Y[i], 10) << i;
   }
   // Test Accumulate
   math::Gemv<float, CPUMathUtil>(CblasNoTrans, 5, 10, kOne, VECTOR_HEAD(A), VECTOR_HEAD(X),
                                  kPointFive, VECTOR_HEAD(Y), &provider);
-  for (int i = 0; i < Y.size(); ++i) {
+  for (size_t i = 0; i < Y.size(); ++i) {
     EXPECT_EQ(Y[i], 15) << i;
   }
   // Test Accumulate
   math::Gemv<float, CPUMathUtil>(CblasNoTrans, 5, 10, kPointFive, VECTOR_HEAD(A),
                                  VECTOR_HEAD(X), kOne, VECTOR_HEAD(Y),
                                  &provider);
-  for (int i = 0; i < Y.size(); ++i) {
+  for (size_t i = 0; i < Y.size(); ++i) {
     EXPECT_EQ(Y[i], 20) << i;
   }
 }
@@ -154,10 +154,10 @@ TEST(MathTest, GemvTrans) {
   math::Set<float, CPUMathUtil>(A.size(), 1, VECTOR_HEAD(A), &provider);
   math::Set<float, CPUMathUtil>(X.size(), 1, VECTOR_HEAD(X), &provider);
   EXPECT_EQ(Y.size(), 10);
-  for (int i = 0; i < A.size(); ++i) {
+  for (size_t i = 0; i < A.size(); ++i) {
     EXPECT_EQ(A[i], 1);
   }
-  for (int i = 0; i < X.size(); ++i) {
+  for (size_t i = 0; i < X.size(); ++i) {
     EXPECT_EQ(X[i], 1);
   }
 
@@ -166,20 +166,20 @@ TEST(MathTest, GemvTrans) {
   const float kZero = 0.0;
   math::Gemv<float, CPUMathUtil>(CblasTrans, 6, 10, kOne, VECTOR_HEAD(A), VECTOR_HEAD(X),
                                  kZero, VECTOR_HEAD(Y), &provider);
-  for (int i = 0; i < Y.size(); ++i) {
+  for (size_t i = 0; i < Y.size(); ++i) {
     EXPECT_EQ(Y[i], 6) << i;
   }
   // Test Accumulate
   math::Gemv<float, CPUMathUtil>(CblasTrans, 6, 10, kOne, VECTOR_HEAD(A), VECTOR_HEAD(X),
                                  kPointFive, VECTOR_HEAD(Y), &provider);
-  for (int i = 0; i < Y.size(); ++i) {
+  for (size_t i = 0; i < Y.size(); ++i) {
     EXPECT_EQ(Y[i], 9) << i;
   }
   // Test Accumulate
   math::Gemv<float, CPUMathUtil>(CblasTrans, 6, 10, kPointFive, VECTOR_HEAD(A),
                                  VECTOR_HEAD(X), kOne, VECTOR_HEAD(Y),
                                  &provider);
-  for (int i = 0; i < Y.size(); ++i) {
+  for (size_t i = 0; i < Y.size(); ++i) {
     EXPECT_EQ(Y[i], 12) << i;
   }
 }

--- a/onnxruntime/test/providers/provider_test_utils.cc
+++ b/onnxruntime/test/providers/provider_test_utils.cc
@@ -169,7 +169,7 @@ void OpTester::FillFeedsAndOutputNames(std::unordered_map<std::string, MLValue>&
       output_names.push_back(output.def_.Name());
   }
 
-  for (auto i = 0; i < input_data_.size(); ++i) {
+  for (size_t i = 0; i < input_data_.size(); ++i) {
     if (std::find(initializer_index_.begin(), initializer_index_.end(), i) == initializer_index_.end() && input_data_[i].def_.Exists()) {
       feeds[input_data_[i].def_.Name()] = input_data_[i].data_;
     }
@@ -244,7 +244,7 @@ std::unique_ptr<onnxruntime::Model> OpTester::BuildGraph() {
   std::vector<onnxruntime::NodeArg*> node_input_defs;
   std::vector<onnxruntime::NodeArg*> output_defs;
 
-  for (auto i = 0; i < input_data_.size(); ++i) {
+  for (size_t i = 0; i < input_data_.size(); ++i) {
     node_input_defs.push_back(&input_data_[i].def_);
   }
 
@@ -340,7 +340,7 @@ void OpTester::ExecuteModel(Model& model,
           auto inferred_dims = utils::GetTensorShapeFromTensorShapeProto(*out_shape_proto);
           const auto& expected_shape = expected_data.data_.Get<Tensor>().Shape();
           EXPECT_TRUE(inferred_dims.size() == expected_shape.NumDimensions());
-          for (int d = 0; d < inferred_dims.size(); ++d) {
+          for (size_t d = 0; d < inferred_dims.size(); ++d) {
             // check equal unless the input involved a symbolic dimension
             if (inferred_dims[d] != -1)
               EXPECT_EQ(expected_shape[d], inferred_dims[d]) << "Output idx = " << idx << " dim = " << d;

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -28,7 +28,7 @@ void RunSession(OrtAllocator* env, OrtSession* session_object,
   std::vector<OrtValue*> ort_inputs;
   std::vector<std::unique_ptr<OrtValue, decltype(&OrtReleaseValue)>> ort_inputs_cleanup;
   std::vector<const char*> input_names;
-  for (int i = 0; i < inputs.size(); i++) {
+  for (size_t i = 0; i < inputs.size(); i++) {
     input_names.emplace_back(inputs[i].name);
     ort_inputs.emplace_back(OrtCreateTensorWithDataAsOrtValue(env->Info(env), (void*)inputs[i].values.data(), inputs[i].values.size() * sizeof(inputs[i].values[0]), inputs[i].dims, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT));
     ort_inputs_cleanup.emplace_back(ort_inputs.back(), OrtReleaseValue);
@@ -176,7 +176,7 @@ struct OrtTensorDimensions : std::vector<int64_t> {
 
   size_t ElementCount() const {
     int64_t count = 1;
-    for (int i = 0; i < size(); i++)
+    for (size_t i = 0; i < size(); i++)
       count *= (*this)[i];
     return count;
   }


### PR DESCRIPTION
Fix trivial non-fatal warnings that I see when doing a Linux build. It bugs me seeing warnings scroll by. This doesn't fix all of the warnings, just those that are trivial type changes of the index type.