### PR TITLE
Fix the allocator type in lru of cuda conv algorithm cache.

### DIFF
--- a/onnxruntime/core/providers/cuda/nn/conv.h
+++ b/onnxruntime/core/providers/cuda/nn/conv.h
@@ -44,7 +44,6 @@ struct vector_hash {
 template <typename Key, typename T,
           typename Hash = std::hash<Key>,
           typename KeyEqual = std::equal_to<Key>,
-          typename Allocator = std::allocator<std::pair<const Key, T>>,
           typename ListAllocator = std::allocator<Key>>
 class lru_unordered_map {
  public:
@@ -96,13 +95,14 @@ private:
     T value;
     iterator_type lru_iterator;
   };
+  using MapAllocator = std::allocator<std::pair<const Key, value_type>>;
 
   void move_to_front(iterator_type it) {
     lru_list_.splice(lru_list_.begin(), lru_list_, it);
   }
 
   size_t max_size_;
-  std::unordered_map<Key, value_type, Hash, KeyEqual, Allocator> items_;
+  std::unordered_map<Key, value_type, Hash, KeyEqual, MapAllocator> items_;
   list_type lru_list_;
 };
 


### PR DESCRIPTION
This PR is to follow-up the ongoing review in #712 by fixing the Allocator type in the algorithm cache of CuDNN Conv op. Please see steps of repro here: https://github.com/Microsoft/onnxruntime/pull/712#issuecomment-483889359

The PR itself is pretty straightforward. The `unordered_map` on line 105 has key type `Key` and item type  `value_type` (defined on line 95). So it should have the allocator type of `std::allocator<std::pair<const Key, value_type>>`. However, the current implementation uses allocator of type `std::allocator<std::pair<const Key, T>>`. The PR correct this error.

The previous error was not catched by the CI system possibly because of the toolchain version but I don't have the bandwidth to double-check that. I tried with CUDA 9.0 + VS14.11 and it generates the error in RelWithDebInfo mode but not in Release mode.