### PR TITLE
Enable use of session based threadpool.

### DIFF
--- a/cmake/onnxruntime_common.cmake
+++ b/cmake/onnxruntime_common.cmake
@@ -4,6 +4,7 @@
 set(onnxruntime_common_src_patterns
     "${ONNXRUNTIME_INCLUDE_DIR}/core/common/*.h"
     "${ONNXRUNTIME_INCLUDE_DIR}/core/common/logging/*.h"
+    "${ONNXRUNTIME_INCLUDE_DIR}/core/platform/*.h"
     "${ONNXRUNTIME_ROOT}/core/common/*.h"
     "${ONNXRUNTIME_ROOT}/core/common/*.cc"
     "${ONNXRUNTIME_ROOT}/core/common/logging/*.h"
@@ -38,13 +39,15 @@ source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_common_src})
 add_library(onnxruntime_common ${onnxruntime_common_src})
 
 onnxruntime_add_include_to_target(onnxruntime_common gsl date_interface)
-target_include_directories(onnxruntime_common PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT}
+target_include_directories(onnxruntime_common PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT} ${eigen_INCLUDE_DIRS}
         PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/external/nsync/public")
 if(onnxruntime_USE_NSYNC)
     target_compile_definitions(onnxruntime_common PUBLIC USE_NSYNC)
 endif()
-#threadpool uses eigen
-add_dependencies(onnxruntime_common eigen)
+if(onnxruntime_USE_EIGEN_THREADPOOL)
+    target_compile_definitions(onnxruntime_common PUBLIC USE_EIGEN_THREADPOOL)
+    add_dependencies(onnxruntime_common ${onnxruntime_EXTERNAL_DEPENDENCIES} eigen)
+endif()
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/../include/onnxruntime/core/common  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnxruntime/core)
 set_target_properties(onnxruntime_common PROPERTIES LINKER_LANGUAGE CXX)

--- a/cmake/onnxruntime_common.cmake
+++ b/cmake/onnxruntime_common.cmake
@@ -39,12 +39,13 @@ source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_common_src})
 add_library(onnxruntime_common ${onnxruntime_common_src})
 
 onnxruntime_add_include_to_target(onnxruntime_common gsl date_interface)
-target_include_directories(onnxruntime_common PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT} ${eigen_INCLUDE_DIRS}
+target_include_directories(onnxruntime_common PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT}
         PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/external/nsync/public")
 if(onnxruntime_USE_NSYNC)
     target_compile_definitions(onnxruntime_common PUBLIC USE_NSYNC)
 endif()
 if(onnxruntime_USE_EIGEN_THREADPOOL)
+    target_include_directories(onnxruntime_common PRIVATE ${eigen_INCLUDE_DIRS})
     target_compile_definitions(onnxruntime_common PUBLIC USE_EIGEN_THREADPOOL)
     add_dependencies(onnxruntime_common ${onnxruntime_EXTERNAL_DEPENDENCIES} eigen)
 endif()

--- a/cmake/onnxruntime_framework.cmake
+++ b/cmake/onnxruntime_framework.cmake
@@ -11,7 +11,7 @@ source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_framework_srcs})
 
 add_library(onnxruntime_framework ${onnxruntime_framework_srcs})
 
-target_include_directories(onnxruntime_framework PRIVATE ${ONNXRUNTIME_ROOT} PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${eigen_INCLUDE_DIRS})
+target_include_directories(onnxruntime_framework PRIVATE ${ONNXRUNTIME_ROOT} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 onnxruntime_add_include_to_target(onnxruntime_framework onnxruntime_common gsl onnx onnx_proto protobuf::libprotobuf)
 set_target_properties(onnxruntime_framework PROPERTIES FOLDER "ONNXRuntime")
 # need onnx to build to create headers that this project includes
@@ -21,8 +21,4 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/../include/onnxruntime/core/framework  D
 if (WIN32)
     # Add Code Analysis properties to enable C++ Core checks. Have to do it via a props file include.
     set_target_properties(onnxruntime_framework PROPERTIES VS_USER_PROPS ${PROJECT_SOURCE_DIR}/ConfigureVisualStudioCodeAnalysis.props)
-endif()
-
-if(onnxruntime_USE_EIGEN_THREADPOOL)
-    target_compile_definitions(onnxruntime_framework PUBLIC USE_EIGEN_THREADPOOL)
 endif()

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -539,5 +539,5 @@ endif()
 
 add_executable(onnxruntime_mlas_test ${TEST_SRC_DIR}/mlas/unittest.cpp)
 target_include_directories(onnxruntime_mlas_test PRIVATE ${ONNXRUNTIME_ROOT}/core/mlas/inc)
-target_link_libraries(onnxruntime_mlas_test PRIVATE onnxruntime_mlas)
+target_link_libraries(onnxruntime_mlas_test PRIVATE onnxruntime_mlas onnxruntime_common Threads::Threads)
 set_target_properties(onnxruntime_mlas_test PROPERTIES FOLDER "ONNXRuntimeTest")

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 set(TEST_SRC_DIR ${ONNXRUNTIME_ROOT}/test)
-set(TEST_INC_DIR ${ONNXRUNTIME_ROOT} ${eigen_INCLUDE_DIRS} ${CUDA_INCLUDE_DIRS} ${onnxruntime_CUDNN_HOME}/include)
+set(TEST_INC_DIR ${ONNXRUNTIME_ROOT})
 if (onnxruntime_USE_TVM)
   list(APPEND TEST_INC_DIR ${TVM_INCLUDES})
 endif()
@@ -26,7 +26,7 @@ function(AddTest)
   set_target_properties(${_UT_TARGET} PROPERTIES FOLDER "ONNXRuntimeTest")
 
   if (_UT_DEPENDS)
-    add_dependencies(${_UT_TARGET} ${_UT_DEPENDS} eigen)
+    add_dependencies(${_UT_TARGET} ${_UT_DEPENDS})
   endif(_UT_DEPENDS)
   if(_UT_DYN)
     target_link_libraries(${_UT_TARGET} PRIVATE ${_UT_LIBS} gtest gmock onnxruntime ${CMAKE_DL_LIBS} Threads::Threads)
@@ -35,7 +35,9 @@ function(AddTest)
   endif()
   onnxruntime_add_include_to_target(${_UT_TARGET} date_interface gsl eigen)
   target_include_directories(${_UT_TARGET} PRIVATE ${TEST_INC_DIR})
-
+  if (onnxruntime_USE_CUDA)
+    target_include_directories(${_UT_TARGET} PRIVATE ${CUDA_INCLUDE_DIRS} ${onnxruntime_CUDNN_HOME}/include)
+  endif()
   if (WIN32)
     if (onnxruntime_USE_CUDA)
       # disable a warning from the CUDA headers about unreferenced local functions

--- a/cmake/onnxruntime_util.cmake
+++ b/cmake/onnxruntime_util.cmake
@@ -9,7 +9,7 @@ file(GLOB_RECURSE onnxruntime_util_srcs
 source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_util_srcs})
 
 add_library(onnxruntime_util ${onnxruntime_util_srcs})
-target_include_directories(onnxruntime_util PRIVATE ${ONNXRUNTIME_ROOT} ${eigen_INCLUDE_DIRS} ${MKLML_INCLUDE_DIR})
+target_include_directories(onnxruntime_util PRIVATE ${ONNXRUNTIME_ROOT} ${MKLML_INCLUDE_DIR} PUBLIC ${eigen_INCLUDE_DIRS})
 onnxruntime_add_include_to_target(onnxruntime_util onnxruntime_common onnxruntime_framework gsl onnx onnx_proto protobuf::libprotobuf)
 if(UNIX)
     target_compile_options(onnxruntime_util PUBLIC "-Wno-error=comment")

--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
+
+namespace onnxruntime {
+
+namespace concurrency {
+
+/**
+ * Generic class for instantiating thread pools.
+ */
+class ThreadPool {
+ public:
+  /*
+  Initializes a thread pool given the current environment.
+  */
+  ThreadPool(const std::string& name, int num_threads);
+
+  /*
+  Enqueue a unit of work.
+  */
+  void Schedule(std::function<void()> fn);
+
+  /*
+  Schedule work in the interval [0, total).
+  */
+  void ParallelFor(int32_t total, std::function<void(int32_t)> fn);
+
+  /*
+  Schedule work in the interval [first, last].
+  */
+  void ParallelForRange(int64_t first, int64_t last, std::function<void(int64_t, int64_t)> fn);
+
+  // This is not supported until the latest Eigen
+  // void SetStealPartitions(const std::vector<std::pair<unsigned, unsigned>>& partitions);
+
+  int NumThreads() const;
+
+  int CurrentThreadId() const;
+
+  /*
+  Ensure that the pool has terminated and cleaned up all threads cleanly.
+  */
+  ~ThreadPool();
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace concurrency
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/attnlstm/deep_cpu_attn_lstm.h
+++ b/onnxruntime/contrib_ops/cpu/attnlstm/deep_cpu_attn_lstm.h
@@ -96,11 +96,7 @@ class DeepCpuAttnLstmOp final : public OpKernel {
 // across them. mutable due to this.
 // The alternative would be to create a threadpool in each call to Compute but that would incur thread creation
 // cost on every call.
-#ifdef USE_EIGEN_THREADPOOL
-  mutable Eigen::NonBlockingThreadPool ttp_{static_cast<int>(std::thread::hardware_concurrency())};
-#else
-  mutable TaskThreadPool ttp_{std::thread::hardware_concurrency()};
-#endif
+  mutable onnxruntime::concurrency::ThreadPool ttp_{"DEEPCPU_ATTN_LSTM", (int)std::thread::hardware_concurrency()};
 };
 
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cpu/attnlstm/uni_dir_attn_lstm.cc
+++ b/onnxruntime/contrib_ops/cpu/attnlstm/uni_dir_attn_lstm.cc
@@ -45,11 +45,7 @@ UniDirectionalAttnLstm<T>::UniDirectionalAttnLstm(AllocatorPtr allocator,
                                                   const ActivationFuncs::Entry& activation_func_g,
                                                   const ActivationFuncs::Entry& activation_func_h,
                                                   const float clip,
-#ifdef USE_EIGEN_THREADPOOL
-                                                  Eigen::NonBlockingThreadPool& ttp)
-#else
-                                                  TaskThreadPool& ttp)
-#endif
+                                                  onnxruntime::concurrency::ThreadPool& ttp)
     : allocator_(allocator),
       logger_(logger),
       seq_length_(seq_length),

--- a/onnxruntime/contrib_ops/cpu/attnlstm/uni_dir_attn_lstm.h
+++ b/onnxruntime/contrib_ops/cpu/attnlstm/uni_dir_attn_lstm.h
@@ -51,11 +51,7 @@ class UniDirectionalAttnLstm {
                          const ActivationFuncs::Entry& activation_func_g,
                          const ActivationFuncs::Entry& activation_func_h,
                          const float clip,
-#ifdef USE_EIGEN_THREADPOOL
-                         Eigen::NonBlockingThreadPool& ttp);
-#else
-                         TaskThreadPool& ttp);
-#endif
+                         onnxruntime::concurrency::ThreadPool& ttp);
 
   void Compute(const gsl::span<const T>& inputs,
                const gsl::span<const int>& sequence_lengths,
@@ -155,11 +151,7 @@ class UniDirectionalAttnLstm {
 
   AttentionWrapper<T>& attention_wrapper_;
 
-#ifdef USE_EIGEN_THREADPOOL
-  Eigen::NonBlockingThreadPool& ttp_;
-#else
-  TaskThreadPool& ttp_;
-#endif
+  onnxruntime::concurrency::ThreadPool& ttp_;
 };
 
 }  // namespace detail

--- a/onnxruntime/contrib_ops/cpu/gather_nd.h
+++ b/onnxruntime/contrib_ops/cpu/gather_nd.h
@@ -5,6 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
+#include "core/platform/threadpool.h"
 
 namespace onnxruntime {
 namespace contrib {
@@ -41,8 +42,8 @@ public:
   explicit GatherND(const OpKernelInfo& info) : OpKernel(info) {}
   Status Compute(OpKernelContext* context) const override;
 private:
-  Status GatherNumber(const Prepare& p) const;
-  Status GatherString(const Prepare& p) const;
+  Status GatherNumber(const Prepare& p, const onnxruntime::concurrency::ThreadPool* ttp) const;
+  Status GatherString(const Prepare& p, const onnxruntime::concurrency::ThreadPool* ttp) const;
 };
 
 } // namespace contrib

--- a/onnxruntime/contrib_ops/cpu/maxpool_with_mask.h
+++ b/onnxruntime/contrib_ops/cpu/maxpool_with_mask.h
@@ -7,7 +7,7 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
+#include "core/framework/op_kernel_context_internal.h"
 #include "core/framework/tensor.h"
 #include "core/providers/cpu/nn/pool_base.h"
 
@@ -25,6 +25,10 @@ class MaxpoolWithMask : public OpKernel, public PoolBase {
     const TensorShape& x_shape = X->Shape();
     const TensorShape& m_shape = M->Shape();
     ORT_RETURN_IF_NOT(x_shape.NumDimensions() >= 3, "Input dimension cannot be less than 3.");
+
+    // Get access to the internal threadpool
+    auto ctx_internal = static_cast<OpKernelContextInternal*>(context);
+    auto thread_pool = ctx_internal->GetOperatorThreadPool();
 
     //TODO: fix this checker later
     //ONNXRUNTIME_RETURN_IF_NOT((x_shape[2] == m_shape[2]) && (x_shape[3] == m_shape[3]), " Input shape and mask shape mismatch: ", x_shape, " vs ", m_shape);
@@ -54,10 +58,8 @@ class MaxpoolWithMask : public OpKernel, public PoolBase {
         int64_t y_step = pooled_height;
         const int64_t total_channels = x_shape[0] * channels;
         const int64_t total_mask_channels = m_shape[0] * m_shape[1];
-#ifdef USE_OPENMP
-#pragma omp parallel for
-#endif
-        for (int64_t c = 0; c < total_channels; ++c) {
+
+        std::function<void(int32_t)> work_object = [&](int32_t c) {
           const float* x_d = X_data + c * x_step;
           const int32_t* m_d = M_data + (c * x_step) % total_mask_channels;
           float* y_d = Y_data + c * y_step;
@@ -74,7 +76,8 @@ class MaxpoolWithMask : public OpKernel, public PoolBase {
             }
             y_d[ph] = Yh;
           }
-        }
+        };
+        const_cast<ThreadPool*>(thread_pool)->ParallelFor((int32_t)total_channels, work_object);
 
         break;
       }
@@ -84,10 +87,8 @@ class MaxpoolWithMask : public OpKernel, public PoolBase {
         int64_t y_step = pooled_height * pooled_width;
         const int64_t total_channels = x_shape[0] * channels;
         const int64_t total_mask_channels = m_shape[0] * m_shape[1];
-#ifdef USE_OPENMP
-#pragma omp parallel for
-#endif
-        for (int64_t c = 0; c < total_channels; ++c) {
+
+        std::function<void(int32_t)> work_object = [&](int32_t c) {
           const float* x_d = X_data + c * x_step;
           const int32_t* m_d = M_data + (c * x_step) % total_mask_channels;
           float* y_d = Y_data + c * y_step;
@@ -114,7 +115,9 @@ class MaxpoolWithMask : public OpKernel, public PoolBase {
               y_d[pool_index] = Yh;
             }
           }
-        }
+        };
+        const_cast<ThreadPool*>(thread_pool)->ParallelFor((int32_t)total_channels, work_object);
+
         break;
       }
       case 3: {
@@ -122,10 +125,8 @@ class MaxpoolWithMask : public OpKernel, public PoolBase {
         int64_t y_step = pooled_height * pooled_width * pooled_depth;
         const int64_t total_channels = x_shape[0] * channels;
         const int64_t total_mask_channels = m_shape[0] * m_shape[1];
-#ifdef USE_OPENMP
-#pragma omp parallel for
-#endif
-        for (int64_t c = 0; c < total_channels; ++c) {
+
+        std::function<void(int32_t)> work_object = [&](int32_t c) {
           const float* x_d = X_data + c * x_step;
           const int32_t* m_d = M_data + (c * x_step) % total_mask_channels;
           float* y_d = Y_data + c * y_step;
@@ -160,7 +161,9 @@ class MaxpoolWithMask : public OpKernel, public PoolBase {
               }
             }
           }
-        }
+        };
+        const_cast<ThreadPool*>(thread_pool)->ParallelFor((int32_t)total_channels, work_object);
+
         break;
       }
       default:

--- a/onnxruntime/core/common/task_thread_pool.h
+++ b/onnxruntime/core/common/task_thread_pool.h
@@ -118,6 +118,15 @@ class TaskThreadPool {
     }
   }
 
+  int NumThreads() const {
+    return (int)threads_.size();
+  }
+
+  // This thread pool does not support ids
+  int CurrentThreadId() const {
+    return -1;
+  }
+
   void RunTask(std::packaged_task<void()>&& task) {
     std::unique_lock<OrtMutex> lock(mutex_);
 

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/platform/threadpool.h"
+#include "core/common/common.h"
+
+#ifdef USE_EIGEN_THREADPOOL
+#if defined(_MSC_VER)
+#pragma warning(disable : 4267)
+#endif
+#include <unsupported/Eigen/CXX11/ThreadPool>
+#else
+#include "task_thread_pool.h"
+#endif
+
+namespace onnxruntime {
+
+namespace concurrency {
+#ifdef USE_EIGEN_THREADPOOL
+
+// TODO: This is temporarily taken from Eigen until we upgrade its version.
+// Barrier is an object that allows one or more threads to wait until
+// Notify has been called a specified number of times.
+class Barrier {
+ public:
+  Barrier(unsigned int count) : state_(count << 1), notified_(false) {
+    eigen_assert(((count << 1) >> 1) == count);
+  }
+  ~Barrier() {
+    eigen_assert((state_ >> 1) == 0);
+  }
+
+  void Notify() {
+    unsigned int v = state_.fetch_sub(2, std::memory_order_acq_rel) - 2;
+    if (v != 1) {
+      eigen_assert(((v + 2) & ~1) != 0);
+      return;  // either count has not dropped to 0, or waiter is not waiting
+    }
+    std::unique_lock<std::mutex> l(mu_);
+    eigen_assert(!notified_);
+    notified_ = true;
+    cv_.notify_all();
+  }
+
+  void Wait() {
+    unsigned int v = state_.fetch_or(1, std::memory_order_acq_rel);
+    if ((v >> 1) == 0) return;
+    std::unique_lock<std::mutex> l(mu_);
+    while (!notified_) {
+      cv_.wait(l);
+    }
+  }
+
+ private:
+  std::mutex mu_;
+  std::condition_variable cv_;
+  std::atomic<unsigned int> state_;  // low bit is waiter flag
+  bool notified_;
+};
+
+class ThreadPool::Impl : public Eigen::NonBlockingThreadPool {
+ public:
+  Impl(const std::string& name, int num_threads)
+      : Eigen::NonBlockingThreadPool(num_threads) {
+    ORT_UNUSED_PARAMETER(name);
+  }
+
+  void ParallelFor(int32_t total, std::function<void(int32_t)> fn) {
+    // TODO: Eigen supports a more efficient ThreadPoolDevice mechanism
+    // We will simply rely on the work queue and stealing in the short term.
+    Barrier barrier(static_cast<unsigned int>(total));
+    std::function<void(int32_t)> handle_iteration;
+    handle_iteration = [=, &handle_iteration, &barrier, &fn](int iteration) {
+      fn(iteration);
+      barrier.Notify();
+    };
+
+    for (int32_t id = 0; id < total; ++id) {
+      Schedule([=, &handle_iteration]() { handle_iteration(id); });
+    }
+
+    barrier.Wait();
+  }
+
+  void ParallelForRange(int64_t first, int64_t last, std::function<void(int64_t, int64_t)> fn) {
+    // TODO: Eigen supports a more efficient ThreadPoolDevice mechanism
+    // We will simply rely on the work queue and stealing in the short term.
+    Barrier barrier(static_cast<unsigned int>(last - first + 1));
+    std::function<void(int64_t, int64_t)> handle_range;
+    handle_range = [=, &handle_range, &barrier, &fn](int64_t first, int64_t last) {
+      fn(first, last);
+      barrier.Notify();
+    };
+
+    for (int64_t id = first; id <= last; ++id) {
+      Schedule([=, &handle_range]() { handle_range(id, id + 1); });
+    }
+
+    barrier.Wait();
+  }
+};
+#else
+class ThreadPool::Impl : public TaskThreadPool {
+ public:
+  Impl(const std::string& name, int num_threads)
+      : TaskThreadPool(num_threads) {
+    ORT_UNUSED_PARAMETER(name);
+  }
+
+  void Schedule(std::function<void()> fn) {
+    std::packaged_task<void()> task(fn);
+    RunTask(std::move(task));
+  }
+
+  void ParallelFor(int32_t total, std::function<void(int32_t)> fn) {
+#ifdef USE_OPENMP
+#pragma omp parallel for
+    for (int32_t id = 0; id < total; ++id) {
+      fn(id);
+    }
+#else
+    for (int32_t id = 0; id < total; ++id) {
+      std::packaged_task<void()> task(std::bind(fn, id));
+      RunTask(std::move(task));
+    }
+    WaitWorkComplete();
+#endif
+  }
+
+  void ParallelForRange(int64_t first, int64_t last, std::function<void(int64_t, int64_t)> fn) {
+#ifdef USE_OPENMP
+#pragma omp parallel for
+    for (int64_t id = first; id < last; ++id) {
+      fn(id, id + 1);
+    }
+#else
+    for (int64_t id = first; id < last; ++id) {
+      std::packaged_task<void()> task(std::bind(fn, id, id + 1));
+      RunTask(std::move(task));
+    }
+    WaitWorkComplete();
+#endif
+  }
+};
+#endif
+
+//
+// ThreadPool
+//
+ThreadPool::ThreadPool(const std::string& name, int num_threads)
+    : impl_(std::make_unique<Impl>(name, num_threads)) {
+}
+
+void ThreadPool::Schedule(std::function<void()> fn) { impl_->Schedule(fn); }
+
+void ThreadPool::ParallelFor(int32_t total, std::function<void(int32_t)> fn) {
+  if (total <= 0) {
+    return;
+  }
+
+  impl_->ParallelFor(total, fn);
+}
+
+void ThreadPool::ParallelForRange(int64_t first, int64_t last, std::function<void(int64_t, int64_t)> fn) {
+  if (last <= first) {
+    fn(first, last);
+    return;
+  }
+
+  impl_->ParallelForRange(first, last, fn);
+}
+
+// void ThreadPool::SetStealPartitions(const std::vector<std::pair<unsigned, unsigned>>& partitions) {
+//   impl_->SetStealPartitions(partitions);
+// }
+
+int ThreadPool::NumThreads() const { return impl_->NumThreads(); }
+
+int ThreadPool::CurrentThreadId() const { return impl_->CurrentThreadId(); }
+
+ThreadPool::~ThreadPool() {}
+
+}  // namespace concurrency
+}  // namespace onnxruntime

--- a/onnxruntime/core/framework/op_kernel_context_internal.h
+++ b/onnxruntime/core/framework/op_kernel_context_internal.h
@@ -57,6 +57,8 @@ class OpKernelContextInternal : public OpKernelContext {
 
   const bool& GetTerminateFlag() const noexcept { return terminate_flag_; }
 
+  const onnxruntime::concurrency::ThreadPool* GetOperatorThreadPool() const { return session_state_.GetThreadPool(); }
+
  private:
   const SessionState& session_state_;
   const std::vector<NodeArg*>& implicit_inputs_;

--- a/onnxruntime/core/framework/parallel_executor.cc
+++ b/onnxruntime/core/framework/parallel_executor.cc
@@ -9,16 +9,12 @@
 #include <vector>
 #include "core/common/common.h"
 #include "core/common/logging/logging.h"
-
-#ifndef USE_EIGEN_THREADPOOL
-#include "core/common/task_thread_pool.h"
-#endif
-
 #include "core/framework/allocation_planner.h"
 #include "core/framework/execution_frame.h"
 #include "core/framework/session_state.h"
 #include "core/framework/op_kernel_context_internal.h"
 #include "core/framework/utils.h"
+#include "core/platform/threadpool.h"
 
 namespace onnxruntime {
 
@@ -29,6 +25,8 @@ ParallelExecutor::ParallelExecutor(const SessionState& session_state, const bool
   for (auto& node : graph_viewer->Nodes()) {
     node_refs_[node.Index()] = node.GetInputEdgesCount();
   }
+
+  executor_pool_ = std::make_unique<onnxruntime::concurrency::ThreadPool>("EXECUTOR", 32);
 }
 
 Status ParallelExecutor::Execute(const SessionState& session_state,
@@ -259,17 +257,12 @@ void ParallelExecutor::EnqueueNode(size_t p_node_index, const SessionState& sess
     out_standings_++;
   }
 
-#ifdef USE_EIGEN_THREADPOOL
-  session_state.GetThreadPool()->Schedule([this, p_node_index, &session_state, &logger]() {
+  executor_pool_->Schedule([this, p_node_index, &session_state, &logger]() {
     try {
       ParallelExecutor::RunNodeAsync(p_node_index, std::cref(session_state), std::cref(logger));
     } catch (...) {
       // catch node processing failure exceptions here to prevent app crash.
     }
   });
-#else
-  std::packaged_task<void()> task{std::bind(&ParallelExecutor::RunNodeAsync, this, p_node_index, std::cref(session_state), std::cref(logger))};
-  session_state.GetThreadPool()->RunTask(std::move(task));
-#endif
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/parallel_executor.h
+++ b/onnxruntime/core/framework/parallel_executor.h
@@ -61,5 +61,7 @@ class ParallelExecutor : public IExecutor {
   OrtCondVar complete_cv_;
 
   const bool& terminate_flag_;
+  // TODO: Temporary threadpool for the executor.  This is a costly way to handle the problem.
+  std::unique_ptr<onnxruntime::concurrency::ThreadPool> executor_pool_;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -24,10 +24,7 @@
 #include "core/framework/node_index_info.h"
 #include "core/graph/graph_viewer.h"
 #include "core/framework/fuse_nodes_funcs.h"
-
-#ifdef USE_EIGEN_THREADPOOL
-#include <unsupported/Eigen/CXX11/ThreadPool>
-#endif
+#include "core/platform/threadpool.h"
 
 namespace onnxruntime {
 
@@ -37,10 +34,6 @@ class OpKernel;
 class NodeIndexInfo;
 struct SequentialExecutionPlan;
 struct MemoryPatternGroup;
-
-#ifndef USE_EIGEN_THREADPOOL
-class TaskThreadPool;
-#endif
 
 /**
  * SessionState should be modified by the inference session class only.
@@ -168,13 +161,8 @@ class SessionState {
 
   SessionState* GetMutableSubgraphSessionState(onnxruntime::NodeIndex index, const std::string& attribute_name);
 
-#ifdef USE_EIGEN_THREADPOOL
-  Eigen::NonBlockingThreadPool* GetThreadPool() const { return thread_pool_; }
-  void SetThreadPool(Eigen::NonBlockingThreadPool* p_pool) { thread_pool_ = p_pool; }
-#else
-  TaskThreadPool* GetThreadPool() const { return thread_pool_; }
-  void SetThreadPool(TaskThreadPool* p_pool) { thread_pool_ = p_pool; }
-#endif
+  onnxruntime::concurrency::ThreadPool* GetThreadPool() const { return thread_pool_; }
+  void SetThreadPool(onnxruntime::concurrency::ThreadPool* p_pool) { thread_pool_ = p_pool; }
 
   bool ExportDll() const { return export_fused_dll_; }
   void SetExportDllFlag(bool flag) { export_fused_dll_ = flag; }
@@ -223,11 +211,7 @@ class SessionState {
       std::unordered_map<onnxruntime::NodeIndex, std::unordered_map<std::string, std::unique_ptr<SessionState>>>;
   SubgraphSessionStateMap subgraph_session_states_;
 
-#ifdef USE_EIGEN_THREADPOOL
-  Eigen::NonBlockingThreadPool* thread_pool_ = nullptr;
-#else
-  TaskThreadPool* thread_pool_ = nullptr;
-#endif
+  onnxruntime::concurrency::ThreadPool* thread_pool_ = nullptr;
 
   bool export_fused_dll_ = false;
   FuncManager fused_funcs_mgr_;

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -44,7 +44,13 @@ typedef enum { CblasLeft=141, CblasRight=142} CBLAS_SIDE;
 #endif
 
 //
-// Activiation routines.
+// External threadpool definition
+//
+#include "core/platform/threadpool.h"
+using namespace onnxruntime::concurrency;
+
+//
+// Activation routines.
 //
 
 enum MLAS_ACTIVATION_KIND {
@@ -91,7 +97,8 @@ MlasSgemm(
     size_t ldb,
     float beta,
     float* C,
-    size_t ldc
+    size_t ldc,
+    ThreadPool* ExternalThreadPool
     );
 
 //
@@ -120,6 +127,7 @@ struct MLAS_CONV_PARAMETERS {
     size_t InputSize;
     size_t OutputSize;
     size_t K;
+    size_t ThreadCount;
     MLAS_CONV_ALGORITHM Algorithm;
     union {
         struct {
@@ -148,7 +156,8 @@ MlasConvPrepare(
     const int64_t* OutputShape,
     size_t FilterCount,
     const MLAS_ACTIVATION* Activation,
-    size_t* WorkingBufferSize
+    size_t* WorkingBufferSize,
+    int32_t ThreadPoolLimit
     );
 
 void
@@ -159,7 +168,8 @@ MlasConv(
     const float* Filter,
     const float* Bias,
     float* WorkingBuffer,
-    float* Output
+    float* Output,
+    ThreadPool *ExternalThreadPool
     );
 
 //
@@ -183,7 +193,8 @@ MlasPool(
     const int64_t* StrideShape,
     const int64_t* OutputShape,
     const float* Input,
-    float* Output
+    float* Output,
+    ThreadPool *ExternalThreadPool
     );
 
 //

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -308,7 +308,8 @@ void
 MlasExecuteThreaded(
     PMLAS_THREADED_ROUTINE ThreadedRoutine,
     void* Context,
-    int32_t Iterations
+    int32_t Iterations,
+    ThreadPool *ExternalThreadPool
     );
 
 //

--- a/onnxruntime/core/mlas/lib/sgemm.cpp
+++ b/onnxruntime/core/mlas/lib/sgemm.cpp
@@ -1080,7 +1080,8 @@ MlasSgemmTryMultithread(
     size_t ldb,
     float beta,
     float* C,
-    size_t ldc
+    size_t ldc,
+    ThreadPool *ExternalThreadPool
     )
 /*++
 
@@ -1231,7 +1232,7 @@ Return Value:
         }
     }
 
-    MlasExecuteThreaded(MlasSgemmOperationThreaded, &WorkBlock, Index);
+    MlasExecuteThreaded(MlasSgemmOperationThreaded, &WorkBlock, Index, ExternalThreadPool);
 
     return true;
 
@@ -1254,6 +1255,7 @@ Return Value:
     MLAS_UNREFERENCED_PARAMETER(beta);
     MLAS_UNREFERENCED_PARAMETER(C);
     MLAS_UNREFERENCED_PARAMETER(ldc);
+    MLAS_UNREFERENCED_PARAMETER(ExternalThreadPool);
 
     return false;
 
@@ -1276,7 +1278,8 @@ MlasSgemm(
     size_t ldb,
     float beta,
     float* C,
-    size_t ldc
+    size_t ldc,
+    ThreadPool *ExternalThreadPool
     )
 /*++
 
@@ -1325,7 +1328,7 @@ Return Value:
     // single thread based on the GEMM parameters and system configuration.
     //
 
-    if (!MlasSgemmTryMultithread(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc)) {
+    if (!MlasSgemmTryMultithread(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc, ExternalThreadPool)) {
         MlasSgemmOperation(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
     }
 }

--- a/onnxruntime/core/platform/env.cc
+++ b/onnxruntime/core/platform/env.cc
@@ -20,6 +20,4 @@ namespace onnxruntime {
 
 Env::Env() = default;
 
-Thread::~Thread() = default;
-
 }  // namespace onnxruntime

--- a/onnxruntime/core/platform/env.h
+++ b/onnxruntime/core/platform/env.h
@@ -34,9 +34,6 @@ limitations under the License.
 
 namespace onnxruntime {
 
-class Thread;
-
-struct ThreadOptions;
 #ifdef _WIN32
 using PIDType = unsigned long;
 #else
@@ -54,13 +51,7 @@ using PIDType = pid_t;
 class Env {
  public:
   virtual ~Env() = default;
-  /// for use with Eigen::ThreadPool
-  using EnvThread = Thread;
 
-  /// for use with Eigen::ThreadPool
-  struct Task {
-    std::function<void()> f;
-  };
   /// \brief Returns a default environment suitable for the current operating
   /// system.
   ///
@@ -81,21 +72,6 @@ class Env {
   /// Sleeps/delays the thread for the prescribed number of micro-seconds.
   /// On Windows, it's the min time to sleep, not the actual one.
   virtual void SleepForMicroseconds(int64_t micros) const = 0;
-
-  /// for use with Eigen::ThreadPool
-  virtual EnvThread* CreateThread(std::function<void()> f) const = 0;
-  /// for use with Eigen::ThreadPool
-  virtual Task CreateTask(std::function<void()> f) const = 0;
-  /// for use with Eigen::ThreadPool
-  virtual void ExecuteTask(const Task& t) const = 0;
-
-  /// \brief Returns a new thread that is running fn() and is identified
-  /// (for debugging/performance-analysis) by "name".
-  ///
-  /// Caller takes ownership of the result and must delete it eventually
-  /// (the deletion will block until fn() stops running).
-  virtual Thread* StartThread(const ThreadOptions& thread_options, const std::string& name,
-                              std::function<void()> fn) const = 0;
 
 #ifndef _WIN32
   /**
@@ -163,29 +139,6 @@ class Env {
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(Env);
   EnvTime* env_time_ = EnvTime::Default();
-};
-
-/// Represents a thread used to run a onnxruntime function.
-class Thread {
- public:
-  Thread() noexcept = default;
-
-  /// Blocks until the thread of control stops running.
-  virtual ~Thread();
-
- private:
-  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(Thread);
-};
-
-/// \brief Options to configure a Thread.
-///
-/// Note that the options are all hints, and the
-/// underlying implementation may choose to ignore it.
-struct ThreadOptions {
-  /// Thread stack size to use (in bytes).
-  size_t stack_size = 0;  // 0: use system default value
-  /// Guard area size to use near thread stacks to use (in bytes)
-  size_t guard_size = 0;  // 0: use system default value
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/nn/pool.cc
+++ b/onnxruntime/core/providers/cpu/nn/pool.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include "core/framework/op_kernel_context_internal.h"
 #include "core/providers/cpu/nn/pool.h"
 #include <cmath>
 using namespace ::onnxruntime::common;
@@ -29,6 +30,10 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
   const float* X_data = X->template Data<float>();
   float* Y_data = Y->template MutableData<float>();
 
+  // Get access to the internal threadpool
+  auto ctx_internal = static_cast<OpKernelContextInternal*>(context);
+  auto thread_pool = ctx_internal->GetOperatorThreadPool();
+
   // The main loop
   int64_t channels = x_shape[1];
   int64_t height = x_shape[2];
@@ -44,10 +49,7 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
       int64_t y_step = pooled_height;
       const int64_t total_channels = x_shape[0] * channels;
 
-#ifdef USE_OPENMP
-#pragma omp parallel for
-#endif
-      for (int64_t c = 0; c < total_channels; ++c) {
+      std::function<void(int32_t)> work_object = [&](int32_t c) {
         const float* x_d = X_data + c * x_step;
         float* y_d = Y_data + c * y_step;
 
@@ -66,7 +68,8 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
           }
           y_d[ph] = Yh;
         }
-      }
+      };
+      const_cast<ThreadPool*>(thread_pool)->ParallelFor((int32_t)total_channels, work_object);
 
       break;
     }
@@ -76,10 +79,7 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
       int64_t y_step = pooled_height * pooled_width;
       const int64_t total_channels = x_shape[0] * channels;
 
-#ifdef USE_OPENMP
-#pragma omp parallel for
-#endif
-      for (int64_t c = 0; c < total_channels; ++c) {
+      std::function<void(int32_t)> work_object = [&](int32_t c) {
         const float* x_d = X_data + c * x_step;
         float* y_d = Y_data + c * y_step;
 
@@ -107,7 +107,8 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
             y_d[pool_index] = Yh;
           }
         }
-      }
+      };
+      const_cast<ThreadPool*>(thread_pool)->ParallelFor((int32_t)total_channels, work_object);
 
       break;
     }
@@ -116,10 +117,7 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
       int64_t y_step = pooled_height * pooled_width * pooled_depth;
       const int64_t total_channels = x_shape[0] * channels;
 
-#ifdef USE_OPENMP
-#pragma omp parallel for
-#endif
-      for (int64_t c = 0; c < total_channels; ++c) {
+      std::function<void(int32_t)> work_object = [&](int32_t c) {
         const float* x_d = X_data + c * x_step;
         float* y_d = Y_data + c * y_step;
 
@@ -156,7 +154,8 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
             }
           }
         }
-      }
+      };
+      const_cast<ThreadPool*>(thread_pool)->ParallelFor((int32_t)total_channels, work_object);
 
       break;
     }
@@ -186,6 +185,11 @@ Status PoolBase::Compute(OpKernelContext* context, MLAS_POOLING_KIND kind) const
   std::vector<int64_t> output_dims = PoolBase::SetOutputSize(x_shape, x_shape[1], &pads);
   Tensor* Y = context->Output(0, TensorShape(output_dims));
 
+  // Get access to the internal threadpool
+  // Temporarily derive concurrency parameters without access to session state
+  auto ctx_internal = static_cast<OpKernelContextInternal*>(context);
+  auto thread_pool = ctx_internal->GetOperatorThreadPool();
+
   MlasPool(kind,
            pooling_dims,
            X->Shape().GetDims().data(),
@@ -194,7 +198,8 @@ Status PoolBase::Compute(OpKernelContext* context, MLAS_POOLING_KIND kind) const
            global_pooling_ ? nullptr : strides_.data(),
            output_dims.data(),
            X->template Data<float>(),
-           Y->template MutableData<float>());
+           Y->template MutableData<float>(),
+           const_cast<ThreadPool*>(thread_pool));
 
   return Status::OK();
 }
@@ -232,6 +237,10 @@ Status Pool<float, MaxPool<8 /*VERSION*/>>::Compute(OpKernelContext* context) co
   float* Y_data = Y->template MutableData<float>();
   int64_t* I_data = I != nullptr ? I->template MutableData<int64_t>() : nullptr;
 
+  // Get access to the internal threadpool
+  auto ctx_internal = static_cast<OpKernelContextInternal*>(context);
+  auto thread_pool = ctx_internal->GetOperatorThreadPool();
+
   // The main loop
   int64_t channels = x_shape[1];
   int64_t height = x_shape[2];
@@ -247,10 +256,7 @@ Status Pool<float, MaxPool<8 /*VERSION*/>>::Compute(OpKernelContext* context) co
       int64_t y_step = pooled_height;
       const int64_t total_channels = x_shape[0] * channels;
 
-#ifdef USE_OPENMP
-#pragma omp parallel for
-#endif
-      for (int64_t c = 0; c < total_channels; ++c) {
+      std::function<void(int32_t)> work_object = [&](int32_t c) {
         const float* x_d = X_data + c * x_step;
         float* y_d = Y_data + c * y_step;
         int64_t* i_d = I_data ? I_data + c * y_step : nullptr;
@@ -269,7 +275,8 @@ Status Pool<float, MaxPool<8 /*VERSION*/>>::Compute(OpKernelContext* context) co
           y_d[ph] = Yh;
           if (i_d != nullptr) i_d[ph] = c * x_step + h_index;
         }
-      }
+      };
+      const_cast<ThreadPool*>(thread_pool)->ParallelFor((int32_t)total_channels, work_object);
 
       break;
     }
@@ -279,10 +286,7 @@ Status Pool<float, MaxPool<8 /*VERSION*/>>::Compute(OpKernelContext* context) co
       int64_t y_step = pooled_height * pooled_width;
       const int64_t total_channels = x_shape[0] * channels;
 
-#ifdef USE_OPENMP
-#pragma omp parallel for
-#endif
-      for (int64_t c = 0; c < total_channels; ++c) {
+      std::function<void(int32_t)> work_object = [&](int32_t c) {
         const float* x_d = X_data + c * x_step;
         float* y_d = Y_data + c * y_step;
         int64_t* i_d = I_data ? I_data + c * y_step : nullptr;
@@ -315,7 +319,9 @@ Status Pool<float, MaxPool<8 /*VERSION*/>>::Compute(OpKernelContext* context) co
                                                     : c * x_step + h_index + w_index * height;
           }
         }
-      }
+      };
+      const_cast<ThreadPool*>(thread_pool)->ParallelFor((int32_t)total_channels, work_object);
+
       break;
     }
     case 3: {
@@ -323,10 +329,7 @@ Status Pool<float, MaxPool<8 /*VERSION*/>>::Compute(OpKernelContext* context) co
       int64_t y_step = pooled_height * pooled_width * pooled_depth;
       const int64_t total_channels = x_shape[0] * channels;
 
-#ifdef USE_OPENMP
-#pragma omp parallel for
-#endif
-      for (int64_t c = 0; c < total_channels; ++c) {
+      std::function<void(int32_t)> work_object = [&](int32_t c) {
         const float* x_d = X_data + c * x_step;
         float* y_d = Y_data + c * y_step;
         int64_t* i_d = I_data ? I_data + c * y_step : nullptr;
@@ -369,7 +372,9 @@ Status Pool<float, MaxPool<8 /*VERSION*/>>::Compute(OpKernelContext* context) co
             }
           }
         }
-      }
+      };
+      const_cast<ThreadPool*>(thread_pool)->ParallelFor((int32_t)total_channels, work_object);
+
       break;
     }
     default:

--- a/onnxruntime/core/providers/cpu/rnn/deep_cpu_gru.h
+++ b/onnxruntime/core/providers/cpu/rnn/deep_cpu_gru.h
@@ -70,11 +70,7 @@ class DeepCpuGruOp final : public OpKernel {
   // across them. mutable due to this.
   // The alternative would be to create a threadpool in each call to Compute but that would incur thread creation
   // cost on every call.
-#ifdef USE_EIGEN_THREADPOOL
-  mutable Eigen::NonBlockingThreadPool ttp_{static_cast<int>(std::thread::hardware_concurrency())};
-#else
-  mutable TaskThreadPool ttp_{std::thread::hardware_concurrency()};
-#endif
+  mutable onnxruntime::concurrency::ThreadPool ttp_{"DEEPCPU_GRU", (int)std::thread::hardware_concurrency()};
 
   template <typename T>
   Status ComputeImpl(OpKernelContext& context) const;

--- a/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.cc
+++ b/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.cc
@@ -203,11 +203,7 @@ class UniDirectionalLstm {
                      const ActivationFuncs::Entry& activation_func_g,
                      const ActivationFuncs::Entry& activation_func_h,
                      const float clip,
-#ifdef USE_EIGEN_THREADPOOL
-                     Eigen::NonBlockingThreadPool& ttp);
-#else
-                     TaskThreadPool& ttp);
-#endif
+                     onnxruntime::concurrency::ThreadPool& ttp);
 
   void Compute(const gsl::span<const T>& inputs,
                const gsl::span<const int>& sequence_lengths,
@@ -299,11 +295,7 @@ class UniDirectionalLstm {
   ActivationInfo<deepcpu::ActivationFuncPtr> activation_g_;
   ActivationInfo<deepcpu::LstmMergeGatesFuncPtr> activation_h_;
 
-#ifdef USE_EIGEN_THREADPOOL
-  Eigen::NonBlockingThreadPool& ttp_;
-#else
-  TaskThreadPool& ttp_;
-#endif
+  onnxruntime::concurrency::ThreadPool& ttp_;
 };
 
 }  // namespace detail
@@ -577,11 +569,7 @@ UniDirectionalLstm<T>::UniDirectionalLstm(AllocatorPtr allocator,
                                           const ActivationFuncs::Entry& activation_func_g,
                                           const ActivationFuncs::Entry& activation_func_h,
                                           const float clip,
-#ifdef USE_EIGEN_THREADPOOL
-                                          Eigen::NonBlockingThreadPool& ttp)
-#else
-                                          TaskThreadPool& ttp)
-#endif
+                                          onnxruntime::concurrency::ThreadPool& ttp)
     : allocator_(allocator),
       logger_(logger),
       seq_length_(seq_length),

--- a/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.h
+++ b/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.h
@@ -7,10 +7,7 @@
 
 #include "core/framework/op_kernel.h"
 #include "core/providers/cpu/rnn/rnn_helpers.h"
-
-#ifndef USE_EIGEN_THREADPOOL
-#include "core/common/task_thread_pool.h"
-#endif
+#include "core/platform/threadpool.h"
 
 namespace onnxruntime {
 
@@ -85,12 +82,7 @@ class DeepCpuLstmOp final : public OpKernel {
   // across them. mutable due to this.
   // The alternative would be to create a threadpool in each call to Compute but that would incur thread creation
   // cost on every call.
-
-#ifdef USE_EIGEN_THREADPOOL
-  mutable Eigen::NonBlockingThreadPool ttp_{static_cast<int>(std::thread::hardware_concurrency())};
-#else
-  mutable TaskThreadPool ttp_{std::thread::hardware_concurrency()};
-#endif
+  mutable onnxruntime::concurrency::ThreadPool ttp_{"DEEPCPU_LSTM", (int)std::thread::hardware_concurrency()};
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -11,11 +11,12 @@
 #include <sstream>
 #include <unordered_set>
 #include <list>
+#include <thread>
 
 #include "core/common/logging/logging.h"
-#include "core/common/task_thread_pool.h"
 #include "core/platform/notification.h"
 #include "core/platform/ort_mutex.h"
+#include "core/platform/threadpool.h"
 #include "core/graph/graph_viewer.h"
 #include "core/graph/graph_utils.h"
 #include "core/graph/model.h"
@@ -48,10 +49,6 @@
 #include "core/util/protobuf_parsing_utils.h"
 #include "core/optimizer/rule_based_graph_transformer.h"
 #include "core/optimizer/graph_transformer_utils.h"
-
-#ifdef USE_EIGEN_THREADPOOL
-#include <unsupported/Eigen/CXX11/ThreadPool>
-#endif
 
 using namespace ONNX_NAMESPACE;
 
@@ -102,18 +99,14 @@ InferenceSession::InferenceSession(const SessionOptions& session_options, loggin
 
   InitLogger(logging_manager);
 
-  // currently the threadpool is used by the parallel executor only and hence
-  // there is no point creating it when only sequential execution is enabled.
-  if (!session_options.enable_sequential_execution) {
-    int pool_size = session_options_.session_thread_pool_size == 0
+  // The threadpool is currently evolving.  We will always create a per session threadpool.
+  // Beyond this, we will create a global thread pool to share across sessions.
+  {
+    int pool_size = session_options_.session_thread_pool_size <= 0
                         ? std::thread::hardware_concurrency() / 2
                         : session_options_.session_thread_pool_size;
 
-#ifdef USE_EIGEN_THREADPOOL
-    thread_pool_ = std::make_unique<Eigen::NonBlockingThreadPool>(pool_size);
-#else
-    thread_pool_ = std::make_unique<TaskThreadPool>(pool_size);
-#endif
+    thread_pool_ = std::make_unique<onnxruntime::concurrency::ThreadPool>("SESSION", pool_size);
   }
 
   session_state_.SetThreadPool(thread_pool_.get());

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -396,18 +396,8 @@ class InferenceSession {
   std::unordered_map<std::string, const NodeArg*> input_def_map_;
   OutputDefList output_def_list_;
 
-// Environment for this session
-// not used now; we'll need it when we introduce threadpool
-// statically allocated pointer, no need to manage its lifetime.
-//Env* env_;
-
-// Threadpool for this session
-//thread::ThreadPool thread_pool_; // not used for now; will add it later when implementing RunAsync
-#ifdef USE_EIGEN_THREADPOOL
-  std::unique_ptr<Eigen::NonBlockingThreadPool> thread_pool_;
-#else
-  std::unique_ptr<TaskThreadPool> thread_pool_;
-#endif
+  // Threadpool for this session
+  std::unique_ptr<onnxruntime::concurrency::ThreadPool> thread_pool_;
 
   // Number of concurrently running executors
   std::atomic<int> current_num_runs_;

--- a/onnxruntime/core/util/math_cpu.cc
+++ b/onnxruntime/core/util/math_cpu.cc
@@ -141,7 +141,8 @@ void Gemm<float, CPUMathUtil>(
 #if defined(USE_MLAS)
   int lda = (int)((TransA == CblasNoTrans) ? K : M);
   int ldb = (int)((TransB == CblasNoTrans) ? N : K);
-  MlasSgemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, N);
+  // TODO: Make this use the operator threadpool
+  MlasSgemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, N, nullptr);
 #else
   GemmEigen<float>(TransA, TransB, M, N, K, alpha, A, B, beta, C);
 #endif
@@ -254,7 +255,7 @@ void GemmEx<float, CPUMathUtil>(
     const int ldc,
     CPUMathUtil*) {
 #if defined(USE_MLAS)
-  MlasSgemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
+  MlasSgemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc, nullptr);
 #else
   using OuterStride = Eigen::OuterStride<Eigen::Dynamic>;
   using StridedMap = Eigen::Map<Eigen::MatrixXf, 0, OuterStride>;

--- a/onnxruntime/test/mlas/unittest.cpp
+++ b/onnxruntime/test/mlas/unittest.cpp
@@ -240,7 +240,7 @@ TrialSgemm(
         CReference[f] = -0.5f;
     }
 
-    MlasSgemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
+    MlasSgemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc, nullptr);
     ReferenceSgemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, CReference, ldc);
 
     for (size_t f = 0; f < M * N; f++) {
@@ -439,7 +439,7 @@ ReferenceConv2D(
             }
 
             MlasSgemm(CblasNoTrans, CblasNoTrans, FilterCount, OutputSize, K, 1.0f,
-                filter, K, Im2Col, OutputSize, 0.0f, Output, OutputSize);
+                filter, K, Im2Col, OutputSize, 0.0f, Output, OutputSize, nullptr);
 
             //
             // Apply the bias.
@@ -516,7 +516,8 @@ TrialConv2D(
                     OutputShape,
                     FilterCount,
                     &Activation,
-                    &WorkingBufferSize);
+                    &WorkingBufferSize,
+                    0);
 
     size_t OutputHeight = size_t(OutputHeight64);
     size_t OutputWidth = size_t(OutputWidth64);
@@ -549,7 +550,8 @@ TrialConv2D(
              Filter,
              Bias,
              BufferWorking.GetBuffer(WorkingBufferSize),
-             Output);
+             Output,
+             nullptr);
 
     ReferenceConv2D(BatchCount,
                     GroupCount,
@@ -975,7 +977,7 @@ TrialPool2D(
     float* Output = BufferOutput.GetBuffer(OutputBufferElements);
     float* OutputReference = BufferOutputReference.GetBuffer(OutputBufferElements);
 
-    MlasPool(MlasMaximumPooling, 2, InputShape, KernelShape, Padding, StrideShape, OutputShape, Input, Output);
+    MlasPool(MlasMaximumPooling, 2, InputShape, KernelShape, Padding, StrideShape, OutputShape, Input, Output, nullptr);
     ReferenceMaximumPool2D(InputShape, KernelShape, Padding, StrideShape, Input, OutputReference);
 
     if (memcmp(Output, OutputReference, OutputBufferElements * sizeof(float)) != 0) {
@@ -983,7 +985,7 @@ TrialPool2D(
             InputChannels, InputHeight, InputWidth, KernelHeight, KernelWidth);
     }
 
-    MlasPool(MlasAveragePoolingExcludePad, 2, InputShape, KernelShape, Padding, StrideShape, OutputShape, Input, Output);
+    MlasPool(MlasAveragePoolingExcludePad, 2, InputShape, KernelShape, Padding, StrideShape, OutputShape, Input, Output, nullptr);
     ReferenceAveragePool2D(InputShape, KernelShape, Padding, StrideShape, Input, OutputReference, false);
 
     if (memcmp(Output, OutputReference, OutputBufferElements * sizeof(float)) != 0) {
@@ -991,7 +993,7 @@ TrialPool2D(
             InputChannels, InputHeight, InputWidth, KernelHeight, KernelWidth);
     }
 
-    MlasPool(MlasAveragePoolingIncludePad, 2, InputShape, KernelShape, Padding, StrideShape, OutputShape, Input, Output);
+    MlasPool(MlasAveragePoolingIncludePad, 2, InputShape, KernelShape, Padding, StrideShape, OutputShape, Input, Output, nullptr);
     ReferenceAveragePool2D(InputShape, KernelShape, Padding, StrideShape, Input, OutputReference, true);
 
     if (memcmp(Output, OutputReference, OutputBufferElements * sizeof(float)) != 0) {
@@ -1042,7 +1044,7 @@ TrialPool3D(
     float* Output = BufferOutput.GetBuffer(OutputBufferElements);
     float* OutputReference = BufferOutputReference.GetBuffer(OutputBufferElements);
 
-    MlasPool(MlasMaximumPooling, 3, InputShape, KernelShape, Padding, StrideShape, OutputShape, Input, Output);
+    MlasPool(MlasMaximumPooling, 3, InputShape, KernelShape, Padding, StrideShape, OutputShape, Input, Output, nullptr);
     ReferenceMaximumPool3D(InputShape, KernelShape, Padding, StrideShape, Input, OutputReference);
 
     if (memcmp(Output, OutputReference, OutputBufferElements * sizeof(float)) != 0) {
@@ -1050,7 +1052,7 @@ TrialPool3D(
             InputChannels, InputDepth, InputHeight, InputWidth, KernelDepth, KernelHeight, KernelWidth);
     }
 
-    MlasPool(MlasAveragePoolingExcludePad, 3, InputShape, KernelShape, Padding, StrideShape, OutputShape, Input, Output);
+    MlasPool(MlasAveragePoolingExcludePad, 3, InputShape, KernelShape, Padding, StrideShape, OutputShape, Input, Output, nullptr);
     ReferenceAveragePool3D(InputShape, KernelShape, Padding, StrideShape, Input, OutputReference, false);
 
     if (memcmp(Output, OutputReference, OutputBufferElements * sizeof(float)) != 0) {
@@ -1058,7 +1060,7 @@ TrialPool3D(
             InputChannels, InputDepth, InputHeight, InputWidth, KernelDepth, KernelHeight, KernelWidth);
     }
 
-    MlasPool(MlasAveragePoolingIncludePad, 3, InputShape, KernelShape, Padding, StrideShape, OutputShape, Input, Output);
+    MlasPool(MlasAveragePoolingIncludePad, 3, InputShape, KernelShape, Padding, StrideShape, OutputShape, Input, Output, nullptr);
     ReferenceAveragePool3D(InputShape, KernelShape, Padding, StrideShape, Input, OutputReference, true);
 
     if (memcmp(Output, OutputReference, OutputBufferElements * sizeof(float)) != 0) {
@@ -1190,7 +1192,7 @@ EvaluateThreadingPerformance(
                 DWORD start = GetTickCount();
                 DWORD stop;
                 do {
-                    MlasSgemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.0f, A, K, B, N, 0.0f, C, N);
+                    MlasSgemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.0f, A, K, B, N, 0.0f, C, N, nullptr);
                     stop = GetTickCount();
                     NumberIterations++;
                 } while ((stop - start) <= 5000);
@@ -1210,7 +1212,7 @@ EvaluateThreadingPerformance(
 
                     start = GetTickCount();
                     for (size_t iters = 0; iters < NumberIterations; iters++) {
-                        MlasSgemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.0f, A, K, B, N, 0.0f, C, N);
+                        MlasSgemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.0f, A, K, B, N, 0.0f, C, N, nullptr);
                         stop = GetTickCount();
                         if ((stop - start) > 20000) {
                             break;

--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -29,6 +29,7 @@ namespace perftest {
       "\t-m [test_mode]: Specifies the test mode. Value coulde be 'duration' or 'times'.\n"
       "\t\tProvide 'duration' to run the test for a fix duration, and 'times' to repeated for a certain times. "
       "Default:'duration'.\n"
+      "\t-c [parallel runs]: Specifies the (max) number of runs to invoke simultaneously. Default:1.\n"
       "\t-e [cpu|cuda|mkldnn|tensorrt]: Specifies the provider 'cpu','cuda','mkldnn' or 'tensorrt'. Default:'cpu'.\n"
       "\t-b [tf|ort]: backend to use. Default:ort\n"
       "\t-r [repeated_times]: Specifies the repeated times if running in 'times' test mode.Default:1000.\n"
@@ -43,7 +44,7 @@ namespace perftest {
 
 /*static*/ bool CommandLineParser::ParseArguments(PerformanceTestConfig& test_config, int argc, ORTCHAR_T* argv[]) {
   int ch;
-  while ((ch = getopt(argc, argv, ORT_TSTR("b:m:e:r:t:p:x:o:vhs"))) != -1) {
+  while ((ch = getopt(argc, argv, ORT_TSTR("b:m:e:r:t:p:x:c:o:vhs"))) != -1) {
     switch (ch) {
       case 'm':
         if (!CompareCString(optarg, ORT_TSTR("duration"))) {
@@ -99,6 +100,12 @@ namespace perftest {
         test_config.run_config.enable_sequential_execution = false;
         test_config.run_config.session_thread_pool_size = static_cast<int>(OrtStrtol<PATH_CHAR_TYPE>(optarg, nullptr));
         if (test_config.run_config.session_thread_pool_size <= 0) {
+          return false;
+        }
+        break;
+      case 'c':
+        test_config.run_config.concurrent_session_runs = static_cast<int>(OrtStrtol<PATH_CHAR_TYPE>(optarg, nullptr));
+        if (test_config.run_config.concurrent_session_runs <= 0) {
           return false;
         }
         break;

--- a/onnxruntime/test/perftest/performance_runner.cc
+++ b/onnxruntime/test/perftest/performance_runner.cc
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// TODO: Remove when removing Eigen
+#if defined(_MSC_VER)
+#pragma warning(disable : 4267)
+#endif
+
 #include "performance_runner.h"
 #include <iostream>
 
@@ -12,6 +17,20 @@
 #include "tf_test_session.h"
 #endif
 using onnxruntime::Status;
+
+// TODO: Temporary, while we bring up the threadpool impl...
+#include "core/platform/threadpool.h"
+#include <unsupported/Eigen/CXX11/ThreadPool>
+using DefaultThreadPoolType = Eigen::NonBlockingThreadPool;
+static std::unique_ptr<DefaultThreadPoolType> default_pool;
+static std::once_flag default_pool_init;
+Eigen::ThreadPoolInterface* GetDefaultThreadPool(const onnxruntime::Env& env) {
+  std::call_once(default_pool_init, [&env] {
+    int core_num = env.GetNumCpuCores();
+    default_pool.reset(new DefaultThreadPoolType(core_num));
+  });
+  return default_pool.get();
+}
 
 namespace onnxruntime {
 namespace perftest {
@@ -29,14 +48,15 @@ Status PerformanceRunner::Run() {
   std::unique_ptr<utils::ICPUUsage> p_ICPUUsage = utils::CreateICPUUsage();
   switch (performance_test_config_.run_config.test_mode) {
     case TestMode::kFixDurationMode:
-      ORT_RETURN_IF_ERROR(RunFixDuration());
+      ORT_RETURN_IF_ERROR(FixDurationTest());
       break;
     case TestMode::KFixRepeatedTimesMode:
-      ORT_RETURN_IF_ERROR(RunRepeatedTimes());
+      ORT_RETURN_IF_ERROR(RepeatedTimesTest());
       break;
     default:
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "unknown test mode.");
   }
+
   performance_result_.average_CPU_usage = p_ICPUUsage->GetUsage();
   performance_result_.peak_workingset_size = utils::GetPeakWorkingSetSize();
 
@@ -52,12 +72,95 @@ Status PerformanceRunner::Run() {
 Status PerformanceRunner::RunOneIteration(bool isWarmup) {
   std::chrono::duration<double> duration_seconds = session_->Run(inputs_.Data());
   if (!isWarmup) {
+    std::lock_guard<std::mutex> guard(results_mutex_);
     performance_result_.time_costs.emplace_back(duration_seconds.count());
     performance_result_.total_time_cost += duration_seconds.count();
     if (performance_test_config_.run_config.f_verbose) {
       std::cout << "iteration:" << performance_result_.time_costs.size() << ","
                 << "time_cost:" << performance_result_.time_costs.back() << std::endl;
     }
+  }
+  return Status::OK();
+}
+
+Status PerformanceRunner::FixDurationTest() {
+  if (performance_test_config_.run_config.concurrent_session_runs <= 1) {
+    return RunFixDuration();
+  }
+
+  return RunParallelDuration();
+}
+
+Status PerformanceRunner::RepeatedTimesTest() {
+  if (performance_test_config_.run_config.concurrent_session_runs <= 1) {
+    return RunRepeatedTimes();
+  }
+
+  return ForkJoinRepeat();
+}
+
+Status PerformanceRunner::RunParallelDuration() {
+  // Simple method to continually queue parallel work until the timer has run down.
+  // TODO: Make each thread enqueue a new worker.
+  auto tpool = GetDefaultThreadPool(Env::Default());
+  std::atomic<int> counter = {0};
+  std::mutex m;
+  std::condition_variable cv;
+
+  auto start = std::chrono::high_resolution_clock::now();
+  auto end = start;
+  std::chrono::duration<double> duration_seconds;
+  do {
+    // We will queue work as deep as requested, ignoring the size of the threadpool itself
+    int count = counter.load(std::memory_order_seq_cst);
+    while (count < performance_test_config_.run_config.concurrent_session_runs) {
+      count++;
+      counter++;
+      tpool->Schedule([this, &counter, &m, &cv]() {
+        RunOneIteration();
+        // Simplified version of Eigen::Barrier
+        std::lock_guard<std::mutex> lg(m);
+        counter--;
+        cv.notify_all();
+      });
+    }
+    end = std::chrono::high_resolution_clock::now();
+    duration_seconds = end - start;
+  } while (duration_seconds.count() < performance_test_config_.run_config.duration_in_seconds);
+
+  //Join
+  std::unique_lock<std::mutex> lock(m);
+  cv.wait(lock, [&counter]() { return counter == 0; });
+
+  return Status::OK();
+}
+
+Status PerformanceRunner::ForkJoinRepeat() {
+  // Adding trivially simple parallelization to the repeated times test will simply perform
+  // m instances of n parallel invocations with a synchronized join after each invocation.
+  // TODO: When the thread pool implementation is done, redo if it has join semantics.
+  auto tpool = GetDefaultThreadPool(Env::Default());
+  std::atomic<int> counter = {0};
+  std::mutex m;
+  std::condition_variable cv;
+
+  for (size_t ite = 0; ite < performance_test_config_.run_config.repeated_times; ite++) {
+    // Fork
+    counter.load(std::memory_order_seq_cst);
+    for (size_t i = 0; i != performance_test_config_.run_config.concurrent_session_runs; ++i) {
+      counter++;
+      tpool->Schedule([this, &counter, &m, &cv]() {
+        RunOneIteration();
+        // Simplified version of Eigen::Barrier
+        std::lock_guard<std::mutex> lg(m);
+        counter--;
+        cv.notify_all();
+      });
+    }
+
+    //Join
+    std::unique_lock<std::mutex> lock(m);
+    cv.wait(lock, [&counter]() { return counter == 0; });
   }
   return Status::OK();
 }

--- a/onnxruntime/test/perftest/performance_runner.h
+++ b/onnxruntime/test/perftest/performance_runner.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <mutex>
 
 // onnxruntime dependencies
 #include <core/common/common.h>
@@ -56,6 +57,8 @@ struct PerformanceResult {
       std::sort(sorted_time.begin(), sorted_time.end());
 
       outfile << std::endl;
+      outfile << "Min Latency is " << sorted_time[0] << "sec" << std::endl;
+      outfile << "Max Latency is " << sorted_time[total - 1] << "sec" << std::endl;
       outfile << "P50 Latency is " << sorted_time[n50] << "sec" << std::endl;
       outfile << "P90 Latency is " << sorted_time[n90] << "sec" << std::endl;
       outfile << "P95 Latency is " << sorted_time[n95] << "sec" << std::endl;
@@ -86,6 +89,11 @@ class PerformanceRunner {
   bool Initialize();
   Status RunOneIteration(bool isWarmup = false);
 
+  Status FixDurationTest();
+  Status RepeatedTimesTest();
+  Status ForkJoinRepeat();
+  Status RunParallelDuration();
+
   inline Status RunFixDuration() {
     while (performance_result_.total_time_cost < performance_test_config_.run_config.duration_in_seconds) {
       ORT_RETURN_IF_ERROR(RunOneIteration());
@@ -108,6 +116,9 @@ class PerformanceRunner {
   OrtValueArray inputs_;
   HeapBuffer b_;
   std::unique_ptr<ITestCase> test_case_;
+
+  // TODO: Convert to OrtMutex
+  std::mutex results_mutex_;
 };
 }  // namespace perftest
 }  // namespace onnxruntime

--- a/onnxruntime/test/perftest/test_configuration.h
+++ b/onnxruntime/test/perftest/test_configuration.h
@@ -38,10 +38,11 @@ struct RunConfig {
   TestMode test_mode{TestMode::kFixDurationMode};
   size_t repeated_times{1000};
   size_t duration_in_seconds{600};
+  size_t concurrent_session_runs{1};
   bool f_dump_statistics{false};
   bool f_verbose{false};
   bool enable_sequential_execution{true};
-  int session_thread_pool_size{6};
+  int session_thread_pool_size{0};
   uint32_t optimization_level{2};
 };
 


### PR DESCRIPTION
Enlightening the design of ORT to control parallelism and concurrency. This first set of changes enables a common threadpool to be configured and used per session. This threadpool is used by operators for scheduling parallel units of work. The parallel executor currently shares the same group of threads, but this will be changed in the next set of changes.