### PR TITLE
Fix memory corruption issue when CPU->CUDA memcpy is involved

### DIFF
--- a/include/onnxruntime/core/framework/fence.h
+++ b/include/onnxruntime/core/framework/fence.h
@@ -45,6 +45,11 @@ class IFence {
      This should update the write fence of the MLValue
   */
   virtual void AfterUsedAsOutput(int queue_id) = 0;
+
+  /**
+  Called by executor before release MLValue to see whether async data read is finished or not. This is non-blocking.
+  */
+  virtual bool CanRelease() = 0;
 };
 using Fence_t = IFence*;
 using FencePtr = std::shared_ptr<IFence>;

--- a/onnxruntime/core/providers/cuda/cuda_fence.cc
+++ b/onnxruntime/core/providers/cuda/cuda_fence.cc
@@ -42,6 +42,10 @@ void CUDAFence::BeforeUsingAsOutput(onnxruntime::ProviderType provider_type, int
   }
 }
 
+bool CUDAFence::CanRelease() {
+    return cudaEventQuery(read_event_) == cudaSuccess;
+}
+
 void CUDAFence::AfterUsedAsInput(int queue_id) {
   // update read fence
   cudaStream_t stream = provider_->GetStream(queue_id);

--- a/onnxruntime/core/providers/cuda/cuda_fence.h
+++ b/onnxruntime/core/providers/cuda/cuda_fence.h
@@ -14,6 +14,7 @@ class CUDAFence : public IFence {
   virtual void BeforeUsingAsOutput(onnxruntime::ProviderType provider_type, int queue_id) override;
   virtual void AfterUsedAsInput(int queue_id) override;
   virtual void AfterUsedAsOutput(int queue_id) override;
+  virtual bool CanRelease() override;
 
  private:
   cudaEvent_t read_event_;


### PR DESCRIPTION
Mem corruption happens when there is a CPU to CUDA memcpy. The reason is memcpy node is executed in async, so the input is get released immediately even if CUDA memcpy is still ongoing.

The fix is to check whether the async read is completed or not. If not, defer release to the end of Session.run().