### PR TITLE
Fix Scatter Assertion `dst_offset_bytes < total_input_bytes' failure

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/scatter.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter.cc
@@ -106,7 +106,7 @@ Status CopyScatterData(const Tensor* data_input, const Tensor* indices_input, co
     // We start at num_dims - 2 because we already pre-populated
     // the last element above
     for (int64_t i = int64_t(num_dims - 2); i >= 0; --i) {
-      dim_block_size[i] = input_data_shape[i] * dim_block_size[i + 1];
+      dim_block_size[i] = input_data_shape[i + 1] * dim_block_size[i + 1];
     }
   }
 

--- a/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
@@ -124,5 +124,27 @@ TEST(ScatterOpTest, IndicesUpdatesDimsDonotMatch) {
   test.AddOutput<float>("y", {1, 5}, {1.0f, 1.1f, 3.0f, 2.1f, 5.0f});
   test.Run(OpTester::ExpectResult::kExpectFailure, "Indices vs updates dimensions differs at position=1 3 vs 2");
 }
+
+TEST(ScatterOpTest, ValidIndex) {
+  OpTester test("Scatter", Scatter_ver);
+  test.AddAttribute<int64_t>("axis", 0);
+
+  test.AddInput<float>("data", {4, 2, 1}, {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f});
+  test.AddInput<int64_t>("indices", {1, 1, 1}, {3});
+  test.AddInput<float>("updates", {1, 1, 1}, {5.0f});
+  test.AddOutput<float>("y", {4, 2, 1}, {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 5.0f, 0.0f});
+  test.Run();
+}
+
+TEST(ScatterOpTest, InvalidIndex) {
+  OpTester test("Scatter", Scatter_ver);
+  test.AddAttribute<int64_t>("axis", 0);
+
+  test.AddInput<float>("data", {4, 2, 1}, {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f});
+  test.AddInput<int64_t>("indices", {1, 1, 1}, {4});
+  test.AddInput<float>("updates", {1, 1, 1}, {5.0f});
+  test.AddOutput<float>("y", {4, 2, 1}, {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 5.0f, 0.0f});
+  test.Run(OpTester::ExpectResult::kExpectFailure, "indices element out of data bounds, idx=4 data_dim=4");
+}
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
#628 is the original PR, reopening since the original PR couldn't start build checks.

=====================================================
**Describe the bug**

Scatter throws Assertion `dst_offset_bytes < total_input_bytes' failed when running the below test case.
```c++
TEST(ScatterOpTest, ValidAxis) {
  OpTester test("Scatter", Scatter_ver);
  test.AddAttribute<int64_t>("axis", 0);

  test.AddInput<float>("data", {4, 2, 1}, {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f});
  test.AddInput<int64_t>("indices", {1, 1, 1}, {3});
  test.AddInput<float>("updates", {1, 1, 1}, {5.0f});
  test.AddOutput<float>("y", {4, 2, 1}, {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 5.0f, 0.0f});
  test.Run();
}
```
It seems the line from here https://github.com/Microsoft/onnxruntime/blob/37f7ed156e96b9d9479054723333b686aa75f6cc/onnxruntime/core/providers/cpu/tensor/scatter.cc#L109 should be
```c++
  dim_block_size[i] = input_data_shape[i + 1] * dim_block_size[i + 1];
```
in order to match the description in the comments about how to compute `dim_block_size`. 
For the example provided in the comments of vector with dimensions `[4, 2, 3]`, the expected `dim_block_size` should be `[6, 3, 1]` however the current code produces `[8, 2, 1]`. 
