### PR TITLE
Use O_TRUNC when saving ONNX models to prevent possible file corruption.

### DIFF
--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -154,7 +154,7 @@ class WindowsEnv : public Env {
   }
 
   common::Status FileOpenWr(const std::wstring& path, /*out*/ int& fd) const override {
-    _wsopen_s(&fd, path.c_str(), _O_CREAT | _O_SEQUENTIAL | _O_BINARY | _O_WRONLY, _SH_DENYWR, _S_IREAD | _S_IWRITE);
+    _wsopen_s(&fd, path.c_str(), _O_CREAT | _O_TRUNC | _O_SEQUENTIAL | _O_BINARY | _O_WRONLY, _SH_DENYWR, _S_IREAD | _S_IWRITE);
     if (0 > fd) {
       return common::Status(common::SYSTEM, errno);
     }
@@ -170,7 +170,7 @@ class WindowsEnv : public Env {
   }
 
   common::Status FileOpenWr(const std::string& path, /*out*/ int& fd) const override {
-    _sopen_s(&fd, path.c_str(), _O_CREAT | _O_SEQUENTIAL | _O_BINARY | _O_WRONLY, _SH_DENYWR, _S_IREAD | _S_IWRITE);
+    _sopen_s(&fd, path.c_str(), _O_CREAT | _O_TRUNC | _O_SEQUENTIAL | _O_BINARY | _O_WRONLY, _SH_DENYWR, _S_IREAD | _S_IWRITE);
     if (0 > fd) {
       return common::Status(common::SYSTEM, errno);
     }


### PR DESCRIPTION
Not having O_TRUNC mode on Windows results in possible junk at the end of file if a file with that name already exists.

Posix version of env.cc already uses O_TRUNC.

I fixed this in CNTK copy of onnx runtime some time ago:
https://github.com/Microsoft/CNTK/commit/a02752ef96873c7fae1e02bf78caa448d10a40d0