### PR TITLE
Fix ceil_mode not defined for mkldnn pool.cc warning

### DIFF
--- a/onnxruntime/core/providers/mkldnn/nn/pool.cc
+++ b/onnxruntime/core/providers/mkldnn/nn/pool.cc
@@ -254,7 +254,7 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
     strides.assign(kernel_shape.size(), 1);
   }
 
-  std::vector<int64_t> y_dims = PoolBase::SetOutputSize(x_shape, x_shape[1], &pads, this->dilations_, ceil_mode_);
+  std::vector<int64_t> y_dims = PoolBase::SetOutputSize(x_shape, x_shape[1], &pads, this->dilations_, this->ceil_mode_);
   Tensor* Y = context->Output(0, TensorShape(y_dims));
 
   size_t num_outputs = OpKernel::Node().OutputDefs().size();


### PR DESCRIPTION
Fixes #903 , ceil_mode  not defined compiler warning when building using --use-mkldnn build option.