### PR TITLE
Fix a crash issue relate to threadpool and subgraph

### DIFF
--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -348,6 +348,8 @@ common::Status InferenceSession::CreateSubgraphSessionState(Graph& graph, Sessio
       auto subgraph_session_state = std::make_unique<SessionState>(execution_providers_);
       subgraph_session_state->SetProfiler(session_profiler_);
       subgraph_session_state->SetLogger(*session_logger_);
+      // Pass threadpool to subgraph
+      subgraph_session_state->SetThreadPool(session_state.GetThreadPool());
 
       // recurse
       ORT_RETURN_IF_ERROR(CreateSubgraphSessionState(*subgraph, *subgraph_session_state));


### PR DESCRIPTION
Fix a issue that ort may crash if the model has subgraph created by controlflow ops like loop, if, scan, and ops inside the subgraph uses threadpool.

Root cause:
The crash is caused by the null threadpool in the op. The op is inside the subgraph. theadpool is set on the session_state. However it doesn't pass it to the session_sate owned by subgraph.
Fix:
Pass the threadpool to the session_sate owned by subgraph when we create CreateSubgraphSessionState.