### PR TITLE
Fix in Slice Elimination (issue #885)

### DIFF
--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -278,7 +278,7 @@ bool MatchesOpSinceVersion(const Node& node, ONNX_NAMESPACE::OperatorSetVersion 
 }
 
 bool MatchesOpSetDomain(const Node& node, const std::string& domain) {
-  auto node_domain = node.Domain();
+  const auto& node_domain = node.Domain();
   // Check if it uses the ONNX domain, which has two aliases; otherwise check if domains coincide
   return ((node_domain == kOnnxDomain || node_domain == kOnnxDomainAlias) &&
           (domain == kOnnxDomain || domain == kOnnxDomainAlias)) ||

--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -249,6 +249,11 @@ static bool RemoveNodeWithSingleInitializerIn(Graph& graph, Node& node) {
   return true;
 }
 
+/** Returns true if the given op set domain is the onnx one. */
+static bool IsOnnxOpSetDomain(const std::string& domain) {
+  return domain == kOnnxDomain || domain == kOnnxDomainAlias;
+}
+
 //----------------------------
 //--- end of local helpers ---
 //----------------------------
@@ -265,17 +270,23 @@ const std::string& GetNodeOutputName(const Node& node, int index) {
   return outputs[index]->Name();
 }
 
-// fusion is only done for ONNX domain ops
 bool IsSupportedOptypeVersionAndDomain(const Node& node,
                                        const std::string& op_type,
                                        ONNX_NAMESPACE::OperatorSetVersion version,
                                        const std::string& domain) {
   if (node.OpType() != op_type ||
       node.Op()->Deprecated() || node.Op()->SinceVersion() != version ||
-      (!node.Domain().empty() && node.Domain() != domain)) {
+      (!(IsOnnxOpSetDomain(node.Domain()) && IsOnnxOpSetDomain(domain)) && node.Domain() != domain)) {
     return false;
   }
+
+
+
   return true;
+}
+
+bool MatchesOpSinceVersion(const Node& node, ONNX_NAMESPACE::OperatorSetVersion version) {
+  return node.Op()->SinceVersion() == version;
 }
 
 bool IsSupportedProvider(const Node& node,

--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -279,10 +279,10 @@ bool MatchesOpSinceVersion(const Node& node, ONNX_NAMESPACE::OperatorSetVersion 
 
 bool MatchesOpSetDomain(const Node& node, const std::string& domain) {
   const auto& node_domain = node.Domain();
-  // Check if it uses the ONNX domain, which has two aliases; otherwise check if domains coincide
-  return ((node_domain == kOnnxDomain || node_domain == kOnnxDomainAlias) &&
-          (domain == kOnnxDomain || domain == kOnnxDomainAlias)) ||
-         node_domain == domain;
+  // We do a special check for the ONNX domain, as it has two aliases.
+  return node_domain == domain ||
+         ((node_domain == kOnnxDomain || node_domain == kOnnxDomainAlias) &&
+          (domain == kOnnxDomain || domain == kOnnxDomainAlias));
 }
 
 bool IsSupportedProvider(const Node& node,

--- a/onnxruntime/core/graph/graph_utils.h
+++ b/onnxruntime/core/graph/graph_utils.h
@@ -10,18 +10,21 @@ namespace onnxruntime {
 
 namespace graph_utils {
 
+/** Checks if the operator's type, version, and domain of the given node match the given values. */
 bool IsSupportedOptypeVersionAndDomain(const Node& node,
                                        const std::string& op_type,
                                        ONNX_NAMESPACE::OperatorSetVersion version,
                                        const std::string& domain = kOnnxDomainAlias);
 
-/* Returns true if the execution provider assigned to current node is present in the compatible providers list
- * or if the compatible_providers list is empty
- */
+/** Checks if the node has the same operator since version as the given one. */
+bool MatchesOpSinceVersion(const Node& node, ONNX_NAMESPACE::OperatorSetVersion version);
+
+/** Returns true if the execution provider assigned to current node is present in the compatible providers list
+    or if the compatible_providers list is empty. */
 bool IsSupportedProvider(const Node& node,
                          const std::unordered_set<std::string>& compatible_providers);
 
-/** Check whether the node has a single input and a single output. The single input can be either the output of
+/** Checks whether the node has a single input and a single output. The single input can be either the output of
     another node or an initializer, but not an implicit input from a parent subgraph. The single output can be 
     fed to multiple downstream operators, i.e., it can have multiple output edges. */
 bool IsSingleInSingleOutNode(const Node& node);
@@ -32,16 +35,16 @@ bool IsGraphInput(const Graph& graph, const NodeArg* input);
 /** Checks if the given node has only constant inputs (initializers). */
 bool AllNodeInputsAreConstant(const Graph& graph, const Node& node);
 
-/** Get the name of the incoming NodeArg with the specified index for the given node. */
+/** Gets the name of the incoming NodeArg with the specified index for the given node. */
 const std::string& GetNodeInputName(const Node& node, int index);
 
-/** Get the name of the outgoing NodeArg with the specified index for the given node. */
+/** Gets the name of the outgoing NodeArg with the specified index for the given node. */
 const std::string& GetNodeOutputName(const Node& node, int index);
 
-/** Return the attribute of a Node with a given name. */
+/** Returns the attribute of a Node with a given name. */
 const ONNX_NAMESPACE::AttributeProto* GetNodeAttribute(const Node& node, const std::string& attr_name);
 
-/** Retrieve the values for a repeated attribute of a node and place them to the values vector. */
+/** Retrieves the values for a repeated attribute of a node and place them to the values vector. */
 template <typename T>
 bool GetRepeatedNodeAttributeValues(const Node& node,
                                     const std::string& attr_name,
@@ -58,12 +61,12 @@ bool GetRepeatedNodeAttributeValues(const Node& node,
 Status ForAllMutableSubgraphs(Graph& main_graph, std::function<Status(Graph&)> func);
 Status ForAllSubgraphs(const Graph& main_graph, std::function<Status(const Graph&)> func);
 
-/** Remove the given single-input Node from the Graph. The single input might be either
+/** Removes the given single-input Node from the Graph. The single input might be either
     another node or an initializer, but not an implicit input. The node should have a single
     output but can have multiple output edges. */
 bool RemoveSingleInputNode(Graph& graph, Node& node);
 
-/** Remove all output edges from the given Node of the Graph. 
+/** Removes all output edges from the given Node of the Graph. 
     This should probably be elevated to the Graph API eventually. */
 size_t RemoveNodeOutputEdges(Graph& graph, Node& node);
 

--- a/onnxruntime/core/graph/graph_utils.h
+++ b/onnxruntime/core/graph/graph_utils.h
@@ -19,6 +19,9 @@ bool IsSupportedOptypeVersionAndDomain(const Node& node,
 /** Checks if the node has the same operator since version as the given one. */
 bool MatchesOpSinceVersion(const Node& node, ONNX_NAMESPACE::OperatorSetVersion version);
 
+/** Checks if the node has the same op set domain as the given one. */
+bool MatchesOpSetDomain(const Node& node, const std::string& domain);
+
 /** Returns true if the execution provider assigned to current node is present in the compatible providers list
     or if the compatible_providers list is empty. */
 bool IsSupportedProvider(const Node& node,

--- a/onnxruntime/core/optimizer/slice_elimination.cc
+++ b/onnxruntime/core/optimizer/slice_elimination.cc
@@ -49,11 +49,10 @@ bool EliminateSlice::SatisfyCondition(const Graph& graph, const Node& node) {
   // "steps" attribute is added since version 10. If it exists and is not 1s, slice is not redundant.
   if (graph_utils::MatchesOpSinceVersion(node, 10)) {
     std::vector<int64_t> steps;
-    if (graph_utils::GetRepeatedNodeAttributeValues(node, "steps", starts)) {
-      if (steps.size() != starts.size() ||
-          std::any_of(steps.cbegin(), steps.cend(), [](int64_t step) { return step > 1; })) {
-        return false;
-      }
+    if (graph_utils::GetRepeatedNodeAttributeValues(node, "steps", starts) &&
+        (steps.size() != starts.size() ||
+         std::any_of(steps.cbegin(), steps.cend(), [](int64_t step) { return step > 1; }))) {
+      return false;
     }
   }
 

--- a/onnxruntime/core/optimizer/slice_elimination.cc
+++ b/onnxruntime/core/optimizer/slice_elimination.cc
@@ -46,7 +46,8 @@ bool EliminateSlice::SatisfyCondition(const Graph& graph, const Node& node) {
     }
   }
 
-  // "steps" attribute is added since version 10. If it exists and is not 1s, slice is not redundant.
+  // "steps" attribute is added since version 10. If it exists and is not 1s, parts of the input will be skipped,
+  // so slice cannot be eliminated.
   if (graph_utils::MatchesOpSinceVersion(node, 10)) {
     std::vector<int64_t> steps;
     if (graph_utils::GetRepeatedNodeAttributeValues(node, "steps", starts) &&

--- a/onnxruntime/core/optimizer/slice_elimination.cc
+++ b/onnxruntime/core/optimizer/slice_elimination.cc
@@ -38,17 +38,6 @@ bool EliminateSlice::SatisfyCondition(const Graph& graph, const Node& node) {
     return false;
   }
 
-  auto in_size = node.InputDefs()[0]->Shape()->dim_size();
-  auto out_size = node.OutputDefs()[0]->Shape()->dim_size();
-  if (in_size != out_size) {
-    return false;
-  }
-  auto dimin = node.InputDefs()[0]->Shape()->dim(0).dim_value();
-  auto dimout = node.OutputDefs()[0]->Shape()->dim(0).dim_value();
-  if (dimin != dimout) {
-    return false;
-  }
-
   // For now eliminate slice operators if starts=0 and ends=MAX_INT.
   // TODO: Take into account the input's shape to get a tighter bound for the ends.
   for (size_t i = 0; i < axes.size(); ++i) {

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -77,7 +77,7 @@ TEST(GraphTransformationTests, SliceElimination) {
   ASSERT_TRUE(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1).IsOK());
 
   op_to_count = CountOpsInGraph(graph);
-  ASSERT_TRUE(op_to_count["Slice"] == 3);
+  ASSERT_TRUE(op_to_count["Slice"] == 4);
 }
 
 TEST(GraphTransformationTests, ConstantFolding1) {
@@ -304,6 +304,18 @@ TEST(GraphTransformationTests, Gemm_Relu_three_input) {
   ASSERT_TRUE(op_to_count["Relu"] == 0);
 }
 #endif
+
+TEST(GraphTransformationTests, TestShapeInferenceBug) {
+  string model_uri = MODEL_FOLDER + "faster_rcnn_resnet50_coco.onnx";
+
+  SessionOptions so;
+  so.session_logid = "GraphTransformationTests.LoadModelToTransform";
+  so.graph_optimization_level = TransformerLevel::Level1;
+  InferenceSession session_object{so, &DefaultLoggingManager()};
+  ASSERT_TRUE(session_object.Load(model_uri).IsOK());
+  ASSERT_TRUE(session_object.Initialize().IsOK());
+
+}
 
 TEST(GraphTransformationTests, FuseConvBnAddMulFloat16) {
   string model_uri = MODEL_FOLDER + "fusion/fuse-conv-bn-add-mul-float16.onnx";

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -305,18 +305,6 @@ TEST(GraphTransformationTests, Gemm_Relu_three_input) {
 }
 #endif
 
-TEST(GraphTransformationTests, TestShapeInferenceBug) {
-  string model_uri = MODEL_FOLDER + "faster_rcnn_resnet50_coco.onnx";
-
-  SessionOptions so;
-  so.session_logid = "GraphTransformationTests.LoadModelToTransform";
-  so.graph_optimization_level = TransformerLevel::Level1;
-  InferenceSession session_object{so, &DefaultLoggingManager()};
-  ASSERT_TRUE(session_object.Load(model_uri).IsOK());
-  ASSERT_TRUE(session_object.Initialize().IsOK());
-
-}
-
 TEST(GraphTransformationTests, FuseConvBnAddMulFloat16) {
   string model_uri = MODEL_FOLDER + "fusion/fuse-conv-bn-add-mul-float16.onnx";
 


### PR DESCRIPTION
Slice Elimination should not be performed if any of the starts or ends is negative.
Also added extra checks to support new Slice version introduced in OpSet v10.