### PR TITLE
Adding versioned dlls to tar/zip packages

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
@@ -65,7 +65,7 @@ jobs:
       parameters:
           buildConfig: 'RelWithDebInfo'
           artifactName: 'onnxruntime-osx-x64-$(OnnxRuntimeVersion)'
-          libraryName: 'libonnxruntime.dylib.$(OnnxRuntimeVersion)'
+          libraryName: 'libonnxruntime.$(OnnxRuntimeVersion).dylib'
           commitId: $(OnnxRuntimeGitCommitHash)
           
     - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
       parameters:
           buildConfig: 'Release'
           artifactName: 'onnxruntime-linux-x64-$(OnnxRuntimeVersion)'
-          libraryName: 'libonnxruntime.so'
+          libraryName: 'libonnxruntime.so.$(OnnxRuntimeVersion)'
           commitId: $(OnnxRuntimeGitCommitHash)
     - template: templates/clean-agent-build-directory-step.yml
 
@@ -28,7 +28,7 @@ jobs:
       parameters:
           buildConfig: 'Release'
           artifactName: 'onnxruntime-linux-x86-$(OnnxRuntimeVersion)'
-          libraryName: 'libonnxruntime.so'
+          libraryName: 'libonnxruntime.so.$(OnnxRuntimeVersion)'
           commitId: $(OnnxRuntimeGitCommitHash)          
     - template: templates/clean-agent-build-directory-step.yml
 
@@ -44,7 +44,7 @@ jobs:
       parameters:
           buildConfig: 'Release'
           artifactName: 'onnxruntime-linux-x64-gpu-$(OnnxRuntimeVersion)'
-          libraryName: 'libonnxruntime.so'
+          libraryName: 'libonnxruntime.so.$(OnnxRuntimeVersion)'
           commitId: $(OnnxRuntimeGitCommitHash)
     - template: templates/clean-agent-build-directory-step.yml
  
@@ -65,7 +65,7 @@ jobs:
       parameters:
           buildConfig: 'RelWithDebInfo'
           artifactName: 'onnxruntime-osx-x64-$(OnnxRuntimeVersion)'
-          libraryName: 'libonnxruntime.dylib'
+          libraryName: 'libonnxruntime.dylib.$(OnnxRuntimeVersion)'
           commitId: $(OnnxRuntimeGitCommitHash)
           
     - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/linux/copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/copy_strip_binary.sh
@@ -28,6 +28,7 @@ then
     strip -S $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME
     ln -s  $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME  $BINARY_DIR/$ARTIFACT_NAME/lib/libonnxruntime.dylib
 elif [[ $LIB_NAME == *.so.* ]]
+then     
     ln -s $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME $BINARY_DIR/$ARTIFACT_NAME/lib/libonnxruntime.so
 fi
 cp $SOURCE_DIR/include/onnxruntime/core/session/onnxruntime_c_api.h  $BINARY_DIR/$ARTIFACT_NAME/include

--- a/tools/ci_build/github/linux/copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/copy_strip_binary.sh
@@ -26,10 +26,10 @@ if [[ $LIB_NAME == *.dylib.* ]]
 then
     dsymutil $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME -o $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME.dSYM
     strip -S $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME
-    ln -s  $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME  $BINARY_DIR/$ARTIFACT_NAME/lib/libonnxruntime.dylib
+    ln -s $LIB_NAME $BINARY_DIR/$ARTIFACT_NAME/lib/libonnxruntime.dylib
 elif [[ $LIB_NAME == *.so.* ]]
-then     
-    ln -s $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME $BINARY_DIR/$ARTIFACT_NAME/lib/libonnxruntime.so
+then
+    ln -s $LIB_NAME $BINARY_DIR/$ARTIFACT_NAME/lib/libonnxruntime.so
 fi
 cp $SOURCE_DIR/include/onnxruntime/core/session/onnxruntime_c_api.h  $BINARY_DIR/$ARTIFACT_NAME/include
 # copy the README, licence and TPN

--- a/tools/ci_build/github/linux/copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/copy_strip_binary.sh
@@ -22,10 +22,13 @@ mkdir $BINARY_DIR/$ARTIFACT_NAME/include
 echo "Directories created"
 cp $BINARY_DIR/$BUILD_CONFIG/$LIB_NAME $BINARY_DIR/$ARTIFACT_NAME/lib
 echo "Copy debug symbols in a separate file and strip the original binary."
-if [[ $LIB_NAME == *.dylib ]]
+if [[ $LIB_NAME == *.dylib.* ]]
 then
     dsymutil $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME -o $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME.dSYM
     strip -S $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME
+    ln -s  $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME  $BINARY_DIR/$ARTIFACT_NAME/lib/libonnxruntime.dylib
+elif [[ $LIB_NAME == *.so.* ]]
+    ln -s $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME $BINARY_DIR/$ARTIFACT_NAME/lib/libonnxruntime.so
 fi
 cp $SOURCE_DIR/include/onnxruntime/core/session/onnxruntime_c_api.h  $BINARY_DIR/$ARTIFACT_NAME/include
 # copy the README, licence and TPN
@@ -34,6 +37,8 @@ cp $SOURCE_DIR/docs/C_API.md $BINARY_DIR/$ARTIFACT_NAME/C_API.md
 cp $SOURCE_DIR/LICENSE $BINARY_DIR/$ARTIFACT_NAME/LICENSE
 cp $SOURCE_DIR/ThirdPartyNotices.txt $BINARY_DIR/$ARTIFACT_NAME/ThirdPartyNotices.txt
 cp $SOURCE_DIR/VERSION_NUMBER $BINARY_DIR/$ARTIFACT_NAME/VERSION_NUMBER
+
+
 echo $COMMIT_ID > $BINARY_DIR/$ARTIFACT_NAME/GIT_COMMIT_ID
 
 EXIT_CODE=$?

--- a/tools/ci_build/github/linux/copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/copy_strip_binary.sh
@@ -22,7 +22,7 @@ mkdir $BINARY_DIR/$ARTIFACT_NAME/include
 echo "Directories created"
 cp $BINARY_DIR/$BUILD_CONFIG/$LIB_NAME $BINARY_DIR/$ARTIFACT_NAME/lib
 echo "Copy debug symbols in a separate file and strip the original binary."
-if [[ $LIB_NAME == *.dylib.* ]]
+if [[ $LIB_NAME == *.dylib ]]
 then
     dsymutil $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME -o $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME.dSYM
     strip -S $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME


### PR DESCRIPTION
For Linux and Mac, gcc linking required the correct versioned DLL files. Adding the versioned DLLs as well as a friendly symlink to them.