### PR TITLE
Clone nGraph in shallow mode

### DIFF
--- a/cmake/external/ngraph.cmake
+++ b/cmake/external/ngraph.cmake
@@ -32,6 +32,7 @@ ExternalProject_Add(project_ngraph
         PREFIX ngraph
         GIT_REPOSITORY ${ngraph_URL}
         GIT_TAG ${ngraph_TAG}
+        GIT_SHALLOW TRUE
         # Here we use onnx and protobuf built by onnxruntime to avoid linking with incompatible libraries. This might change in future.
         PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/patches/ngraph/ngraph_onnx.cmake ${ngraph_SRC}/cmake/external_onnx.cmake
         # TODO: Use cmake.file+copy as above. 


### PR DESCRIPTION
With this option, nGraph will be cloned in shallow mode which will speed up the build and reduce the amount of data downloaded from github.

The same can be done for other dependencies handled with `ExternalProject_Add`