### PR TITLE
Revert "Bump up onnx version"

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -49,7 +49,7 @@
          "component":{
             "type":"git",
             "git":{
-               "commitHash":"c1c04af4e9fa0c96fbc1fda7b330bb994118f3c5",
+               "commitHash":"27d4b617e7097cda7d0d4c45ff2b09d248f33179",
                "repositoryUrl":"https://github.com/onnx/onnx.git"
             }
          }

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -38,8 +38,8 @@ else
   #5af210ca8a1c73aa6bae8754c9346ec54d0a756e is v1.2.3
   #bae6333e149a59a3faa9c4d9c44974373dcf5256 is v1.3.0
   #9e55ace55aad1ada27516038dfbdc66a8a0763db is v1.4.1
-  #c1c04af4e9fa0c96fbc1fda7b330bb994118f3c5 is v1.4.1 latest
-    for onnx_version in "5af210ca8a1c73aa6bae8754c9346ec54d0a756e" "bae6333e149a59a3faa9c4d9c44974373dcf5256" "9e55ace55aad1ada27516038dfbdc66a8a0763db" "c1c04af4e9fa0c96fbc1fda7b330bb994118f3c5"; do
+  #27d4b617e7097cda7d0d4c45ff2b09d248f33179 is v1.4.1 latest
+    for onnx_version in "5af210ca8a1c73aa6bae8754c9346ec54d0a756e" "bae6333e149a59a3faa9c4d9c44974373dcf5256" "9e55ace55aad1ada27516038dfbdc66a8a0763db" "27d4b617e7097cda7d0d4c45ff2b09d248f33179"; do
     if [ -z ${lastest_onnx_version+x} ]; then
       echo "first pass";
     else


### PR DESCRIPTION
Reverts Microsoft/onnxruntime#936 

The previous PR is not complete and I'am resending it to the release branch, will merge back later. Reverting this PR can avoid future merge conflict.

