### PR TITLE
Uncomment mod tests and make infra run them

### DIFF
--- a/onnxruntime/core/providers/mkldnn/mkldnn_execution_provider.cc
+++ b/onnxruntime/core/providers/mkldnn/mkldnn_execution_provider.cc
@@ -32,16 +32,26 @@ ONNX_OPERATOR_KERNEL_EX(
 
 }  // namespace mkl_dnn
 
-MKLDNNExecutionProvider::MKLDNNExecutionProvider(const MKLDNNExecutionProviderInfo& /*info*/)
-      : IExecutionProvider{onnxruntime::kMklDnnExecutionProvider} {
+MKLDNNExecutionProvider::MKLDNNExecutionProvider(const MKLDNNExecutionProviderInfo& info)
+    : IExecutionProvider{onnxruntime::kMklDnnExecutionProvider} {
   DeviceAllocatorRegistrationInfo default_allocator_info({OrtMemTypeDefault,
                                                           [](int) { return std::make_unique<CPUAllocator>(std::make_unique<OrtAllocatorInfo>(MKLDNN, OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemTypeDefault)); }, std::numeric_limits<size_t>::max()});
-  InsertAllocator(CreateAllocator(default_allocator_info));
 
   DeviceAllocatorRegistrationInfo cpu_allocator_info({OrtMemTypeCPUOutput,
                                                       [](int) { return std::make_unique<CPUAllocator>(std::make_unique<OrtAllocatorInfo>(MKLDNN_CPU, OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemTypeCPUOutput)); }, std::numeric_limits<size_t>::max()});
-  InsertAllocator(CreateAllocator(cpu_allocator_info));
-}
+
+  if (info.create_arena) {
+    InsertAllocator(CreateAllocator(default_allocator_info));
+
+    InsertAllocator(CreateAllocator(cpu_allocator_info));
+  } else {
+    InsertAllocator(std::shared_ptr<IArenaAllocator>(
+        std::make_unique<DummyArena>(default_allocator_info.factory(0))));
+
+    InsertAllocator(std::shared_ptr<IArenaAllocator>(
+        std::make_unique<DummyArena>(cpu_allocator_info.factory(0))));
+  }
+}  // namespace onnxruntime
 
 MKLDNNExecutionProvider::~MKLDNNExecutionProvider() {
 }
@@ -80,19 +90,19 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomai
 
 void RegisterMKLDNNKernels(KernelRegistry& kernel_registry) {
   static const BuildKernelCreateInfoFn function_table[] = {
-    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 1, Conv)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 7, Gemm)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 1, MemcpyFromHost)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 1, MemcpyToHost)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 6, Relu)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 6, Sum)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 7, BatchNormalization)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 7, 8, float, AveragePool)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 1, 8, float, GlobalAveragePool)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 1, 7, float, MaxPool)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 8, 8, float, MaxPool)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 1, 8, float, GlobalMaxPool)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 1, float, LRN)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 1, Conv)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 7, Gemm)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 1, MemcpyFromHost)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 1, MemcpyToHost)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 6, Relu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 6, Sum)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 7, BatchNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 7, 8, float, AveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 1, 8, float, GlobalAveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 1, 7, float, MaxPool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 8, 8, float, MaxPool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 1, 8, float, GlobalMaxPool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kMklDnnExecutionProvider, kOnnxDomain, 1, float, LRN)>,
   };
 
   for (auto& function_table_entry : function_table) {

--- a/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
@@ -24,12 +24,14 @@ int OnnxRuntimeTensorToNumpyType(const DataTypeImpl* tensor_type) {
   static std::map<MLDataType, int> type_map{
       {DataTypeImpl::GetType<bool>(), NPY_BOOL},
       {DataTypeImpl::GetType<float>(), NPY_FLOAT},
+      {DataTypeImpl::GetType<MLFloat16>(), NPY_FLOAT16},
       {DataTypeImpl::GetType<double>(), NPY_DOUBLE},
-      {DataTypeImpl::GetType<int32_t>(), NPY_INT},
       {DataTypeImpl::GetType<int8_t>(), NPY_INT8},
       {DataTypeImpl::GetType<uint8_t>(), NPY_UINT8},
       {DataTypeImpl::GetType<int16_t>(), NPY_INT16},
       {DataTypeImpl::GetType<uint16_t>(), NPY_UINT16},
+      {DataTypeImpl::GetType<int32_t>(), NPY_INT},
+      {DataTypeImpl::GetType<uint32_t>(), NPY_ULONG},
       {DataTypeImpl::GetType<int64_t>(), NPY_LONGLONG},
       {DataTypeImpl::GetType<uint64_t>(), NPY_ULONGLONG},
       {DataTypeImpl::GetType<std::string>(), NPY_OBJECT},
@@ -47,6 +49,7 @@ const DataTypeImpl* NumpyToOnnxRuntimeTensorType(int numpy_type) {
   static std::map<int, MLDataType> type_map{
       {NPY_BOOL, DataTypeImpl::GetType<bool>()},
       {NPY_FLOAT, DataTypeImpl::GetType<float>()},
+      {NPY_FLOAT16, DataTypeImpl::GetType<MLFloat16>()},
       {NPY_DOUBLE, DataTypeImpl::GetType<double>()},
       {NPY_INT, DataTypeImpl::GetType<int32_t>()},
       {NPY_INT8, DataTypeImpl::GetType<int8_t>()},
@@ -56,6 +59,9 @@ const DataTypeImpl* NumpyToOnnxRuntimeTensorType(int numpy_type) {
       {NPY_LONG,
        sizeof(long) == sizeof(int) ? DataTypeImpl::GetType<int32_t>()
                                    : DataTypeImpl::GetType<int64_t>()},
+      {NPY_ULONG,
+       sizeof(unsigned long) == sizeof(unsigned int) ? DataTypeImpl::GetType<uint32_t>()
+                                                     : DataTypeImpl::GetType<uint64_t>()},
       {NPY_LONGLONG, DataTypeImpl::GetType<int64_t>()},
       {NPY_ULONGLONG, DataTypeImpl::GetType<uint64_t>()},
       {NPY_UNICODE, DataTypeImpl::GetType<std::string>()},

--- a/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
@@ -31,7 +31,7 @@ int OnnxRuntimeTensorToNumpyType(const DataTypeImpl* tensor_type) {
       {DataTypeImpl::GetType<int16_t>(), NPY_INT16},
       {DataTypeImpl::GetType<uint16_t>(), NPY_UINT16},
       {DataTypeImpl::GetType<int32_t>(), NPY_INT},
-      {DataTypeImpl::GetType<uint32_t>(), NPY_ULONG},
+      {DataTypeImpl::GetType<uint32_t>(), NPY_UINT},
       {DataTypeImpl::GetType<int64_t>(), NPY_LONGLONG},
       {DataTypeImpl::GetType<uint64_t>(), NPY_ULONGLONG},
       {DataTypeImpl::GetType<std::string>(), NPY_OBJECT},
@@ -49,19 +49,32 @@ const DataTypeImpl* NumpyToOnnxRuntimeTensorType(int numpy_type) {
   static std::map<int, MLDataType> type_map{
       {NPY_BOOL, DataTypeImpl::GetType<bool>()},
       {NPY_FLOAT, DataTypeImpl::GetType<float>()},
+      // Special, not a C type expands to enum value of 16
       {NPY_FLOAT16, DataTypeImpl::GetType<MLFloat16>()},
       {NPY_DOUBLE, DataTypeImpl::GetType<double>()},
-      {NPY_INT, DataTypeImpl::GetType<int32_t>()},
-      {NPY_INT8, DataTypeImpl::GetType<int8_t>()},
-      {NPY_UINT8, DataTypeImpl::GetType<uint8_t>()},
-      {NPY_INT16, DataTypeImpl::GetType<int16_t>()},
-      {NPY_UINT16, DataTypeImpl::GetType<uint16_t>()},
+      // We don't want to use size specific types such
+      // as NPY_INT32 bc they are not enums but hash defines
+      // which may map into other enums and may conflict with other entries here
+      // also NPY docs define these sizes as platform specific, thus we
+      // choose to do some rudimentary checks for proper mapping on C++ size
+      {NPY_BYTE, DataTypeImpl::GetType<int8_t>()},
+      {NPY_UBYTE, DataTypeImpl::GetType<uint8_t>()},
+      {NPY_SHORT, sizeof(short) == sizeof(int16_t) ? DataTypeImpl::GetType<int16_t>()
+                                                   : DataTypeImpl::GetType<int32_t>()},
+      {NPY_USHORT, sizeof(unsigned short) == sizeof(uint16_t) ? DataTypeImpl::GetType<uint16_t>()
+                                                              : DataTypeImpl::GetType<uint32_t>()},
+      {NPY_INT,
+       sizeof(int) == sizeof(int32_t) ? DataTypeImpl::GetType<int32_t>()
+                                      : DataTypeImpl::GetType<int64_t>()},
+      {NPY_UINT, sizeof(int) == sizeof(int32_t) ? DataTypeImpl::GetType<uint32_t>()
+                                                : DataTypeImpl::GetType<uint64_t>()},
+
       {NPY_LONG,
-       sizeof(long) == sizeof(int) ? DataTypeImpl::GetType<int32_t>()
-                                   : DataTypeImpl::GetType<int64_t>()},
+       sizeof(long) == sizeof(int32_t) ? DataTypeImpl::GetType<int32_t>()
+                                       : DataTypeImpl::GetType<int64_t>()},
       {NPY_ULONG,
-       sizeof(unsigned long) == sizeof(unsigned int) ? DataTypeImpl::GetType<uint32_t>()
-                                                     : DataTypeImpl::GetType<uint64_t>()},
+       sizeof(unsigned long) == sizeof(uint32_t) ? DataTypeImpl::GetType<uint32_t>()
+                                                 : DataTypeImpl::GetType<uint64_t>()},
       {NPY_LONGLONG, DataTypeImpl::GetType<int64_t>()},
       {NPY_ULONGLONG, DataTypeImpl::GetType<uint64_t>()},
       {NPY_UNICODE, DataTypeImpl::GetType<std::string>()},

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -355,8 +355,7 @@ int real_main(int argc, char* argv[], OrtEnv** p_env) {
       {"tf_mobilenet_v2_1.4_224", "result mismatch"},
       {"tf_mobilenet_v1_1.0_224", "result mismatch"},
       {"mobilenetv2-1.0", "result mismatch"},
-      {"mxnet_arcface", "result mismatch"},
-      {"mod_float_mixed_sign_example", "faulty test"}
+      {"mxnet_arcface", "result mismatch"}
   };
 
 #ifdef USE_NGRAPH

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -90,8 +90,6 @@ backend_test.exclude(r'('
 '|^test_reversesequence_batch_cpu.*'
 '|^test_reversesequence_time_cpu.*'
 '|^test_roialign_cpu.*'
-'|^test_mod_mixed_sign_float16_cpu.*'
-'|^test_mod_uint32_cpu.*'
 ')')
 
 # import all test cases at global scope to make

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -87,13 +87,11 @@ backend_test.exclude(r'('
 '|^test_mvn_cpu.*'
 '|^test_qlinearconv_cpu.*'
 '|^test_quantizelinear_cpu.*'
-'|^test_mod_float_mixed_sign_example.*'
 '|^test_reversesequence_batch_cpu.*'
 '|^test_reversesequence_time_cpu.*'
 '|^test_roialign_cpu.*'
 '|^test_mod_mixed_sign_float16_cpu.*'
 '|^test_mod_uint32_cpu.*'
-'|^test_mod_uint64_cpu.*'
 ')')
 
 # import all test cases at global scope to make


### PR DESCRIPTION
ONNX unit python tests and other python scripts may use various Numpy datatypes to feed and output data from the backend. The examples include float16, uint32, uint8 etc and not all of them are currently supported by our numpy layer.

This PR adds additional datatype mappings. It also replaces certain hash defines for types to the actual numpy enums to prevent mapping conflicts and at the same time maintain compatibility and appropriate datatype size.