### PR TITLE
Avoid to call memory allocation if tensor size is 0

### DIFF
--- a/onnxruntime/core/framework/tensor.cc
+++ b/onnxruntime/core/framework/tensor.cc
@@ -21,7 +21,9 @@ Tensor::Tensor(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAll
   int64_t shape_size = shape.Size();
   if (shape_size < 0 || static_cast<uint64_t>(shape_size) >= std::numeric_limits<size_t>::max())
     ORT_THROW("shape.Size() must >=0");
-  void* p_data = allocator->AllocArray(static_cast<size_t>(shape_size), p_type->Size());
+  void* p_data = nullptr;
+  if(shape_size > 0)
+     p_data = allocator->AllocArray(static_cast<size_t>(shape_size), p_type->Size());
   Init(p_type, shape, p_data, allocator, offset);
 }
 


### PR DESCRIPTION
For nonzero operator, it is common that the tensor size is 0. It is always printing a warning ' tried to allocate 0 bytes'. This PR add logic to avoid to call memory allocation if tensor size is 0