### PR TITLE
perf test runner: support NCHW->NHWC rotation

### DIFF
--- a/onnxruntime/test/onnx/OrtValueList.h
+++ b/onnxruntime/test/onnx/OrtValueList.h
@@ -12,6 +12,7 @@ class OrtValueArray {
   std::vector<OrtValue*> values;
 
  public:
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(OrtValueArray);
   //n must be non-negative
   OrtValueArray(int n) : values(static_cast<size_t>(n), nullptr){};
   ~OrtValueArray() {

--- a/onnxruntime/test/perftest/main.cc
+++ b/onnxruntime/test/perftest/main.cc
@@ -3,7 +3,7 @@
 
 // onnxruntime dependencies
 #include <core/session/onnxruntime_c_api.h>
-
+#include <random>
 #include "command_args_parser.h"
 #include "performance_runner.h"
 
@@ -30,7 +30,8 @@ int real_main(int argc, char* argv[], OrtEnv** p_env) {
     }
     *p_env = env;
   }
-  perftest::PerformanceRunner perf_runner(env, test_config);
+  std::random_device rd;
+  perftest::PerformanceRunner perf_runner(env, test_config, rd);
   auto status = perf_runner.Run();
   if (!status.IsOK()) {
     printf("Run failed:%s\n", status.ErrorMessage().c_str());

--- a/onnxruntime/test/perftest/ort_test_session.h
+++ b/onnxruntime/test/perftest/ort_test_session.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include <core/session/onnxruntime_cxx_api.h>
+#include <random>
 #include "test_configuration.h"
 #include "test_session.h"
 class TestModelInfo;
@@ -10,7 +11,18 @@ namespace onnxruntime {
 namespace perftest {
 class OnnxRuntimeTestSession : public TestSession {
  public:
-  OnnxRuntimeTestSession(OrtEnv* env, const PerformanceTestConfig& performance_test_config, const TestModelInfo* m);
+  OnnxRuntimeTestSession(OrtEnv* env, std::random_device& rd, const PerformanceTestConfig& performance_test_config,
+                         const TestModelInfo* m);
+
+  void PreLoadTestData(size_t test_data_id, size_t input_id, OrtValue* value) override {
+    if (test_inputs.size() < test_data_id + 1) {
+      test_inputs.resize(test_data_id + 1);
+    }
+    if (test_inputs.at(test_data_id) == nullptr) {
+      test_inputs[test_data_id] = new OrtValueArray(input_length);
+    }
+    test_inputs[test_data_id]->Set(input_id, value);
+  }
 
   ~OnnxRuntimeTestSession() override {
     if (session_object_ != nullptr) OrtReleaseSession(session_object_);
@@ -18,18 +30,22 @@ class OnnxRuntimeTestSession : public TestSession {
       free(p);
     }
   }
-  std::chrono::duration<double> Run(const OrtValue* const* input) override;
+  std::chrono::duration<double> Run() override;
 
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(OnnxRuntimeTestSession);
 
  private:
   OrtSession* session_object_ = nullptr;
+  std::mt19937 rand_engine_;
+  std::uniform_int_distribution<int> dist_;
+  std::vector<OrtValueArray*> test_inputs;
   std::vector<std::string> output_names_;
   // The same size with output_names_.
   // TODO: implement a customized allocator, then we can remove output_names_ to simplify this code
   std::vector<const char*> output_names_raw_ptr;
   std::vector<OrtValue*> output_values_;
   std::vector<char*> input_names_;
+  int input_length;
 };
 
 }  // namespace perftest

--- a/onnxruntime/test/perftest/test_session.h
+++ b/onnxruntime/test/perftest/test_session.h
@@ -2,11 +2,21 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include <stdlib.h>
+
+#include "OrtValueList.h"
+
 namespace onnxruntime {
 namespace perftest {
 class TestSession {
  public:
-  virtual std::chrono::duration<double> Run(const OrtValue* const* input) = 0;
+  virtual std::chrono::duration<double> Run() = 0;
+  // TODO: implement it
+  // This function won't return duration, because it may vary largely.
+  // Please measure the perf at a higher level.
+  void ThreadSafeRun() { abort(); }
+  virtual void PreLoadTestData(size_t test_data_id, size_t input_id, OrtValue* value) = 0;
+
   virtual ~TestSession() = default;
 };
 }  // namespace perftest


### PR DESCRIPTION
1. Support NCHW->NHWC rotation. For some models, they have different input data for ONNX and TF.  Like the mlperf resnet50 model,  the onnx model expects NCHW input but TF expects NHWC.  NHWC is the TensorFlow default, however NCHW is the optimal format for both MKL and CUDNN.  Unless I can get another TF model in NCHW format,  I have to rotate the input by myself.

2.  Previously, the perf test tool only randomly pick one test data set, and repeatedly run with it again and again. This PR will load all the test data sets and do the random choice for each InferenceSession::Run(). 