### PR TITLE
perf test: fix an index out-of-bound bug

### DIFF
--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -12,9 +12,10 @@ namespace onnxruntime {
 namespace perftest {
 
 std::chrono::duration<double> OnnxRuntimeTestSession::Run() {
-  const std::uniform_int_distribution<int>::param_type p(0, input_length);
+  //Randomly pick one OrtValueArray from test_inputs_. (NOT ThreadSafe)
+  const std::uniform_int_distribution<int>::param_type p(0, static_cast<int>(test_inputs_.size() - 1));
   const size_t id = static_cast<size_t>(dist_(rand_engine_, p));
-  OrtValueArray* const input = test_inputs.at(id);
+  OrtValueArray* const input = test_inputs_.at(id);
   auto start = std::chrono::high_resolution_clock::now();
   ORT_THROW_ON_ERROR(OrtRun(session_object_, nullptr, input_names_.data(), input->Data(), input_names_.size(),
                             output_names_raw_ptr.data(), output_names_raw_ptr.size(), output_values_.data()));
@@ -30,7 +31,7 @@ std::chrono::duration<double> OnnxRuntimeTestSession::Run() {
 OnnxRuntimeTestSession::OnnxRuntimeTestSession(OrtEnv* env, std::random_device& rd,
                                                const PerformanceTestConfig& performance_test_config,
                                                const TestModelInfo* m)
-    : rand_engine_(rd()), input_names_(m->GetInputCount()), input_length(m->GetInputCount()) {
+    : rand_engine_(rd()), input_names_(m->GetInputCount()), input_length_(m->GetInputCount()) {
   SessionOptionsWrapper sf(env);
   const bool enable_cpu_mem_arena = true;
   const std::string& provider_name = performance_test_config.machine_config.provider_type_name;

--- a/onnxruntime/test/perftest/ort_test_session.h
+++ b/onnxruntime/test/perftest/ort_test_session.h
@@ -15,13 +15,13 @@ class OnnxRuntimeTestSession : public TestSession {
                          const TestModelInfo* m);
 
   void PreLoadTestData(size_t test_data_id, size_t input_id, OrtValue* value) override {
-    if (test_inputs.size() < test_data_id + 1) {
-      test_inputs.resize(test_data_id + 1);
+    if (test_inputs_.size() < test_data_id + 1) {
+      test_inputs_.resize(test_data_id + 1);
     }
-    if (test_inputs.at(test_data_id) == nullptr) {
-      test_inputs[test_data_id] = new OrtValueArray(input_length);
+    if (test_inputs_.at(test_data_id) == nullptr) {
+      test_inputs_[test_data_id] = new OrtValueArray(input_length_);
     }
-    test_inputs[test_data_id]->Set(input_id, value);
+    test_inputs_[test_data_id]->Set(input_id, value);
   }
 
   ~OnnxRuntimeTestSession() override {
@@ -38,14 +38,14 @@ class OnnxRuntimeTestSession : public TestSession {
   OrtSession* session_object_ = nullptr;
   std::mt19937 rand_engine_;
   std::uniform_int_distribution<int> dist_;
-  std::vector<OrtValueArray*> test_inputs;
+  std::vector<OrtValueArray*> test_inputs_;
   std::vector<std::string> output_names_;
   // The same size with output_names_.
   // TODO: implement a customized allocator, then we can remove output_names_ to simplify this code
   std::vector<const char*> output_names_raw_ptr;
   std::vector<OrtValue*> output_values_;
   std::vector<char*> input_names_;
-  int input_length;
+  const int input_length_;
 };
 
 }  // namespace perftest


### PR DESCRIPTION
1. Fix an index out-of-bound bug
2. Fix a memory leak in the TF test runner

