### PR TITLE
Avoid using transformers that rely on contrib ops in tests

### DIFF
--- a/onnxruntime/test/optimizer/graph_transform_utils_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_utils_test.cc
@@ -56,8 +56,8 @@ TEST(GraphTransformerUtilsTests, TestGenerateGraphTransformers_CustomList) {
   // custom list of rules and transformers
   std::string l1_rule1 = "EliminateIdentity";
   std::string l1_transformer = "ConstantFolding";
-  std::string l2_transformer = "GemmActivationFusion";
-  std::vector<std::string> custom_list = {l1_rule1, l1_transformer, l2_transformer};
+  std::string l2_rule1 = "ConvBNFusion";
+  std::vector<std::string> custom_list = {l1_rule1, l1_transformer, l2_rule1};
 
   auto transformers = transformer_utils::GenerateTransformers(TransformerLevel::Level1, custom_list);
   ASSERT_TRUE(transformers.size() == 2);
@@ -72,7 +72,8 @@ TEST(GraphTransformerUtilsTests, TestGenerateGraphTransformers_CustomList) {
   
   transformers = transformer_utils::GenerateTransformers(TransformerLevel::Level2, custom_list);
   ASSERT_TRUE(transformers.size() == 1);
-  ASSERT_TRUE(transformers[0]->Name() == l2_transformer);
+  rule_transformer = dynamic_cast<RuleBasedGraphTransformer*>(transformers[0].get());
+  ASSERT_TRUE(rule_transformer->RulesCount() == 1);
 }
 
 }  // namespace test


### PR DESCRIPTION
When DISABLE_CONTRIB_OPS flag is enabled, graph transformers that rely on contrib ops are disabled, which causes one of the tests to fail. This PR updates this test to use graph transformers that do not rely on contrib ops.