### PR TITLE
Improve error messaging based on raised issues

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -484,6 +484,7 @@ Status Node::UpdateInputArgCount() {
 
   if (total_arg_count < 0 || static_cast<size_t>(total_arg_count) != definitions_.input_defs.size()) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "This is an invalid model. "
                            "The sum of input arg count is not equal to size of input defs in node (",
                            name_, ")");
   }
@@ -710,7 +711,7 @@ Status Graph::VerifyNoDuplicateName() {
     if (!node_name.empty() && node_name_to_index.end() != node_name_to_index.find(node_name)) {
       // The node has name and its name was used by another node.
       Status status(ONNXRUNTIME, FAIL,
-                    "Error: two nodes with same node name (" + node_name + ").");
+                    "This is an invalid model. Error: two nodes with same node name (" + node_name + ").");
       return status;
     }
 
@@ -724,14 +725,14 @@ Status Graph::VerifyNoDuplicateName() {
         auto& output_arg_name = output_def->Name();
         if (inputs_and_initializers.count(output_arg_name)) {
           Status status(ONNXRUNTIME, FAIL,
-                        "Error: Duplicate definition of name (" + output_arg_name + ").");
+                        "This is an invalid model. Error: Duplicate definition of name (" + output_arg_name + ").");
           return status;
         }
         auto result = output_args.insert({output_arg_name, {&node, output_index}});
         if (!result.second) {
           // Two outputs with same name, so that insertion fails.
           Status status(ONNXRUNTIME, FAIL,
-                        "Error: Duplicate definition of name (" + output_arg_name + ").");
+                        "This is an invalid model. Error: Duplicate definition of name (" + output_arg_name + ").");
           return status;
         }
       }
@@ -901,7 +902,7 @@ Status Graph::BuildConnections(std::vector<std::string>& outer_scope_node_args_c
             if (!parent_graph_) {
               return ORT_MAKE_STATUS(
                   ONNXRUNTIME, INVALID_GRAPH,
-                  "At top level graph without matching NodeArg that subgraph consumes. Name=",
+                  "This is an invalid graph. At top level graph without matching NodeArg that subgraph consumes. Name=",
                   node_arg_name,
                   " Graph may not conform to the ONNX spec and contain initializers that are not graph inputs.");
             }
@@ -912,7 +913,7 @@ Status Graph::BuildConnections(std::vector<std::string>& outer_scope_node_args_c
             if (!node_arg) {
               return ORT_MAKE_STATUS(
                   ONNXRUNTIME, INVALID_GRAPH,
-                  "Failed to find NodeArg in all parent graphs. Name=", node_arg_name,
+                  "This is an invalid graph. Failed to find NodeArg in all parent graphs. Name=", node_arg_name,
                   " Graph may not conform to the ONNX spec and contain initializers that are not graph inputs.");
             }
           }
@@ -1129,7 +1130,7 @@ Status Graph::PerformTopologicalSortAndCheckIsAcyclic() {
     for (auto iter = node->InputNodesBegin(); iter != node->InputNodesEnd(); ++iter) {
       const NodeIndex idx = (*iter).Index();
       if (output_nodes.find(idx) != output_nodes.end()) {
-        Status status(ONNXRUNTIME, FAIL, "Error: the graph is not acyclic.");
+        Status status(ONNXRUNTIME, FAIL, "This is an invalid graph. Error: the graph is not acyclic.");
         return status;
       }
 
@@ -1145,7 +1146,7 @@ Status Graph::PerformTopologicalSortAndCheckIsAcyclic() {
   if (num_of_nodes_ >= 0 && static_cast<size_t>(num_of_nodes_) == nodes_in_topological_order_.size()) {
     return Status::OK();
   } else {
-    return Status(ONNXRUNTIME, FAIL, "Error: the graph is not acyclic.");
+    return Status(ONNXRUNTIME, FAIL, "This is an invalid graph. Error: the graph is not acyclic.");
   }
 }
 
@@ -1421,8 +1422,9 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op) {
         // Logic error: This should not happen if we properly checked that every use has
         // a corresponding def, for which type-inference already produced a valid type
         Status status(ONNXRUNTIME, FAIL,
+                      "This is an invalid model. "
                       "Node (" + node_name + ") input arg (" +
-                          input_def->Name() + ") does not have type information set by parent node.");
+                       input_def->Name() + ") does not have type information set by parent node.");
         return status;
       }
 
@@ -1435,6 +1437,7 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op) {
         // Type error in input model/graph.
 
         Status status(ONNXRUNTIME, INVALID_GRAPH,
+                      "This is an invalid graph. "
                       "Type Error: Type '" + *input_type + "' of input parameter (" + input_def->Name() +
                           ") of operator (" + op.Name() + ") in node (" + node_name + ") is invalid.");
         return status;
@@ -1456,10 +1459,11 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op) {
           // Type error in input model/graph:
           // The type-parameter T is bound to different values for different inputs.
           Status status(ONNXRUNTIME, FAIL,
+                        "This is an invalid model. "
                         "Type Error: Type parameter (" + op_formal_parameter.GetTypeStr() +
-                            ") bound to different types (" + *(param_to_type_iter->second) +
-                            " and " + *(input_def->Type()) +
-                            " in node (" + node_name + ").");
+                        ") bound to different types (" + *(param_to_type_iter->second) +
+                        " and " + *(input_def->Type()) +
+                        " in node (" + node_name + ").");
           return status;
         }
       }
@@ -1565,7 +1569,8 @@ common::Status Graph::TypeCheckInputsAndInitializers() {
   // Check that the type of every input is specified:
   for (auto* graph_input : GetInputs()) {
     if (nullptr == graph_input->Type()) {
-      Status status(ONNXRUNTIME, FAIL, "Model input (" + graph_input->Name() + ") does not have type information.");
+      Status status(ONNXRUNTIME, FAIL, "This is an invalid model. " 
+                                       "Model input (" + graph_input->Name() + ") does not have type information.");
       return status;
     }
   }
@@ -1656,7 +1661,7 @@ Status Graph::VerifyNodeAndOpMatch() {
       try {
         checker::check_node(node_proto, ctx, lsc);
       } catch (const std::exception& ex) {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, "Node:", node_name, " ", ex.what());
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, "This is an invalid graph. Error in Node:", node_name, " : ", ex.what());
       }
 
       auto maxInclusiveVersion = DomainToVersionMap().find(domain)->second;
@@ -1700,6 +1705,7 @@ Status Graph::VerifyNodeAndOpMatch() {
           // TODO: Handle optional attribute but no default value specified in op definition.
         } else {
           Status status(ONNXRUNTIME, FAIL,
+                        "This is an invalid model. "
                         "Node (" + node_name + ") attribute (" + attr_def.first +
                             ") is required but not specified.");
           return status;
@@ -2279,7 +2285,8 @@ Status Graph::SetGraphInputsOutputs() {
           auto iter3 = graph_inputs.find(graph_output_name);
           if (graph_inputs.end() == iter3) {
             // Graph output is not found as any graph input.
-            return Status(ONNXRUNTIME, FAIL, "Graph output (" + graph_output_name + ") does not exist in the graph.");
+            return Status(ONNXRUNTIME, FAIL, "This is an invalid model. " 
+                                             "Graph output (" + graph_output_name + ") does not exist in the graph.");
           }
           graph_outputs_.push_back(iter3->second);
           continue;

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -902,7 +902,7 @@ Status Graph::BuildConnections(std::vector<std::string>& outer_scope_node_args_c
             if (!parent_graph_) {
               return ORT_MAKE_STATUS(
                   ONNXRUNTIME, INVALID_GRAPH,
-                  "This is an invalid graph. At top level graph without matching NodeArg that subgraph consumes. Name=",
+                  "This is an invalid model. At top level graph without matching NodeArg that subgraph consumes. Name=",
                   node_arg_name,
                   " Graph may not conform to the ONNX spec and contain initializers that are not graph inputs.");
             }
@@ -913,7 +913,7 @@ Status Graph::BuildConnections(std::vector<std::string>& outer_scope_node_args_c
             if (!node_arg) {
               return ORT_MAKE_STATUS(
                   ONNXRUNTIME, INVALID_GRAPH,
-                  "This is an invalid graph. Failed to find NodeArg in all parent graphs. Name=", node_arg_name,
+                  "This is an invalid model. Failed to find NodeArg in all parent graphs. Name=", node_arg_name,
                   " Graph may not conform to the ONNX spec and contain initializers that are not graph inputs.");
             }
           }
@@ -1130,7 +1130,7 @@ Status Graph::PerformTopologicalSortAndCheckIsAcyclic() {
     for (auto iter = node->InputNodesBegin(); iter != node->InputNodesEnd(); ++iter) {
       const NodeIndex idx = (*iter).Index();
       if (output_nodes.find(idx) != output_nodes.end()) {
-        Status status(ONNXRUNTIME, FAIL, "This is an invalid graph. Error: the graph is not acyclic.");
+        Status status(ONNXRUNTIME, FAIL, "This is an invalid model. Error: the graph is not acyclic.");
         return status;
       }
 
@@ -1146,7 +1146,7 @@ Status Graph::PerformTopologicalSortAndCheckIsAcyclic() {
   if (num_of_nodes_ >= 0 && static_cast<size_t>(num_of_nodes_) == nodes_in_topological_order_.size()) {
     return Status::OK();
   } else {
-    return Status(ONNXRUNTIME, FAIL, "This is an invalid graph. Error: the graph is not acyclic.");
+    return Status(ONNXRUNTIME, FAIL, "This is an invalid model. Error: the graph is not acyclic.");
   }
 }
 
@@ -1437,7 +1437,7 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op) {
         // Type error in input model/graph.
 
         Status status(ONNXRUNTIME, INVALID_GRAPH,
-                      "This is an invalid graph. "
+                      "This is an invalid model. "
                       "Type Error: Type '" + *input_type + "' of input parameter (" + input_def->Name() +
                           ") of operator (" + op.Name() + ") in node (" + node_name + ") is invalid.");
         return status;
@@ -1661,7 +1661,7 @@ Status Graph::VerifyNodeAndOpMatch() {
       try {
         checker::check_node(node_proto, ctx, lsc);
       } catch (const std::exception& ex) {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, "This is an invalid graph. Error in Node:", node_name, " : ", ex.what());
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, "This is an invalid model. Error in Node:", node_name, " : ", ex.what());
       }
 
       auto maxInclusiveVersion = DomainToVersionMap().find(domain)->second;

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -1459,7 +1459,6 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op) {
           // Type error in input model/graph:
           // The type-parameter T is bound to different values for different inputs.
           Status status(ONNXRUNTIME, FAIL,
-                        "This is an invalid model. "
                         "Type Error: Type parameter (" + op_formal_parameter.GetTypeStr() +
                         ") bound to different types (" + *(param_to_type_iter->second) +
                         " and " + *(input_def->Type()) +

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -902,7 +902,7 @@ Status Graph::BuildConnections(std::vector<std::string>& outer_scope_node_args_c
             if (!parent_graph_) {
               return ORT_MAKE_STATUS(
                   ONNXRUNTIME, INVALID_GRAPH,
-                  "This is an invalid model. At top level graph without matching NodeArg that subgraph consumes. Name=",
+                  "This is an invalid graph. At top level graph without matching NodeArg that subgraph consumes. Name=",
                   node_arg_name,
                   " Graph may not conform to the ONNX spec and contain initializers that are not graph inputs.");
             }
@@ -913,7 +913,7 @@ Status Graph::BuildConnections(std::vector<std::string>& outer_scope_node_args_c
             if (!node_arg) {
               return ORT_MAKE_STATUS(
                   ONNXRUNTIME, INVALID_GRAPH,
-                  "This is an invalid model. Failed to find NodeArg in all parent graphs. Name=", node_arg_name,
+                  "This is an invalid graph. Failed to find NodeArg in all parent graphs. Name=", node_arg_name,
                   " Graph may not conform to the ONNX spec and contain initializers that are not graph inputs.");
             }
           }
@@ -1130,7 +1130,7 @@ Status Graph::PerformTopologicalSortAndCheckIsAcyclic() {
     for (auto iter = node->InputNodesBegin(); iter != node->InputNodesEnd(); ++iter) {
       const NodeIndex idx = (*iter).Index();
       if (output_nodes.find(idx) != output_nodes.end()) {
-        Status status(ONNXRUNTIME, FAIL, "This is an invalid model. Error: the graph is not acyclic.");
+        Status status(ONNXRUNTIME, FAIL, "This is an invalid graph. Error: the graph is not acyclic.");
         return status;
       }
 
@@ -1146,7 +1146,7 @@ Status Graph::PerformTopologicalSortAndCheckIsAcyclic() {
   if (num_of_nodes_ >= 0 && static_cast<size_t>(num_of_nodes_) == nodes_in_topological_order_.size()) {
     return Status::OK();
   } else {
-    return Status(ONNXRUNTIME, FAIL, "This is an invalid model. Error: the graph is not acyclic.");
+    return Status(ONNXRUNTIME, FAIL, "This is an invalid graph. Error: the graph is not acyclic.");
   }
 }
 
@@ -1437,7 +1437,7 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op) {
         // Type error in input model/graph.
 
         Status status(ONNXRUNTIME, INVALID_GRAPH,
-                      "This is an invalid model. "
+                      "This is an invalid graph. "
                       "Type Error: Type '" + *input_type + "' of input parameter (" + input_def->Name() +
                           ") of operator (" + op.Name() + ") in node (" + node_name + ") is invalid.");
         return status;
@@ -1661,7 +1661,7 @@ Status Graph::VerifyNodeAndOpMatch() {
       try {
         checker::check_node(node_proto, ctx, lsc);
       } catch (const std::exception& ex) {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, "This is an invalid model. Error in Node:", node_name, " : ", ex.what());
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, "This is an invalid graph. Error in Node:", node_name, " : ", ex.what());
       }
 
       auto maxInclusiveVersion = DomainToVersionMap().find(domain)->second;

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -432,10 +432,10 @@ common::Status InferenceSession::Initialize() {
 
         if (it->get()->Type() == onnxruntime::kCudaExecutionProvider) {
           LOGS(*session_logger_, ERROR) << "Parallel execution cannot be enabled "
-                                           "when CUDA execution provider is registered.";
+                                           "when CUDA execution provider is registered as first priority.";
           return common::Status(common::ONNXRUNTIME, common::FAIL,
                                 "Parallel execution cannot be enabled "
-                                "when CUDA execution provider is registered.");
+                                "when CUDA execution provider is registered as first priority.");
         }
       }
     }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -432,7 +432,7 @@ common::Status InferenceSession::Initialize() {
 
         if (it->get()->Type() == onnxruntime::kCudaExecutionProvider) {
           LOGS(*session_logger_, ERROR) << "Parallel execution cannot be enabled "
-                                           "when CUDA execution provider is registeredas first priority.";
+                                           "when CUDA execution provider is registered as first priority.";
           return common::Status(common::ONNXRUNTIME, common::FAIL,
                                 "Parallel execution cannot be enabled "
                                 "when CUDA execution provider is registered as first priority.");

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -432,10 +432,10 @@ common::Status InferenceSession::Initialize() {
 
         if (it->get()->Type() == onnxruntime::kCudaExecutionProvider) {
           LOGS(*session_logger_, ERROR) << "Parallel execution cannot be enabled "
-                                           "when CUDA execution provider is registered as first priority.";
+                                           "when CUDA execution provider is registered.";
           return common::Status(common::ONNXRUNTIME, common::FAIL,
                                 "Parallel execution cannot be enabled "
-                                "when CUDA execution provider is registered as first priority.");
+                                "when CUDA execution provider is registered.");
         }
       }
     }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -432,10 +432,10 @@ common::Status InferenceSession::Initialize() {
 
         if (it->get()->Type() == onnxruntime::kCudaExecutionProvider) {
           LOGS(*session_logger_, ERROR) << "Parallel execution cannot be enabled "
-                                           "when CUDA execution provider is registered.";
+                                           "when CUDA execution provider is registeredas first priority.";
           return common::Status(common::ONNXRUNTIME, common::FAIL,
                                 "Parallel execution cannot be enabled "
-                                "when CUDA execution provider is registered.");
+                                "when CUDA execution provider is registered as first priority.");
         }
       }
     }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -422,8 +422,7 @@ common::Status InferenceSession::Initialize() {
                                                    std::make_unique<CPUExecutionProvider>(epi)));
     }
 
-    if (!execution_providers_.Get(onnxruntime::kCudaExecutionProvider) &&
-        !session_options_.enable_sequential_execution) {
+    if (!session_options_.enable_sequential_execution) {
       for (auto it = execution_providers_.begin(); it != execution_providers_.end(); ++it) {
         // very rare case - user has registered CPU provider first -
         // so parallel execution is still possible as all nodes will get assigned CPU provider
@@ -431,7 +430,7 @@ common::Status InferenceSession::Initialize() {
           break;
         }
 
-        else if (it->get()->Type() == onnxruntime::kCudaExecutionProvider) {
+        if (it->get()->Type() == onnxruntime::kCudaExecutionProvider) {
           LOGS(*session_logger_, ERROR) << "Parallel execution cannot be enabled "
                                            "when CUDA execution provider is registered.";
           return common::Status(common::ONNXRUNTIME, common::FAIL,

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -427,7 +427,7 @@ common::Status InferenceSession::Initialize() {
         first_provider->get()->Type() != onnxruntime::kCpuExecutionProvider) {
       LOGS(*session_logger_, ERROR) << "Parallel execution is only supported "
                                        "for the CPU Execution Provider currently.";
-      return common::Status(common::ONNXRUNTIME, common::FAIL,
+      return common::Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
                             "Parallel execution is only supported "
                             "for the CPU Execution Provider currently.");
     }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -422,14 +422,13 @@ common::Status InferenceSession::Initialize() {
                                                    std::make_unique<CPUExecutionProvider>(epi)));
     }
 
-    const auto first_provider = std::cbegin(execution_providers_);
     if (!session_options_.enable_sequential_execution &&
-        first_provider->get()->Type() != onnxruntime::kCpuExecutionProvider) {
-      LOGS(*session_logger_, ERROR) << "Parallel execution is only supported "
-                                       "for the CPU Execution Provider currently.";
+        execution_providers_.Get(onnxruntime::kCudaExecutionProvider)) {
+      LOGS(*session_logger_, ERROR) << "Parallel execution is currently not supported "
+                                       "for the registered CUDA Execution Provider.";
       return common::Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
-                            "Parallel execution is only supported "
-                            "for the CPU Execution Provider currently.");
+                            "Parallel execution is currently not supported "
+                            "for the registered CUDA Execution Provider.");
     }
 
     // add predefined transformers

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -1411,6 +1411,28 @@ TEST(InferenceSessionTests, TestParallelExecutionWithCudaProvider) {
 
   auto status = session_object.Initialize();
 
+  ASSERT_TRUE(!status.IsOK());
+}
+
+TEST(InferenceSessionTests, TestParallelExecutionWithCpuAndCudaProviders) {
+  string model_uri = "testdata/transform/fusion/fuse-conv-bn-mul-add-unsqueeze.onnx";
+
+  SessionOptions so;
+  so.enable_sequential_execution = false;
+  so.session_logid = "InferenceSessionTests.TestParallelExecutionWithCudaProvider";
+  InferenceSession session_object{so};
+
+  CPUExecutionProviderInfo epi1;
+  EXPECT_TRUE(session_object.RegisterExecutionProvider(std::make_unique<CPUExecutionProvider>(epi1)).IsOK());
+
+  CUDAExecutionProviderInfo epi2;
+  epi2.device_id = 0;
+  EXPECT_TRUE(session_object.RegisterExecutionProvider(std::make_unique<CUDAExecutionProvider>(epi2)).IsOK());
+
+  ASSERT_TRUE(session_object.Load(model_uri).IsOK());
+
+  auto status = session_object.Initialize();
+
   ASSERT_TRUE(status.IsOK());
 }
 #endif

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -1395,6 +1395,7 @@ TEST(InferenceSessionTests, TestL1AndL2Transformers) {
 }
 
 #ifdef USE_CUDA
+
 TEST(InferenceSessionTests, TestParallelExecutionWithCudaProvider) {
   string model_uri = "testdata/transform/fusion/fuse-conv-bn-mul-add-unsqueeze.onnx";
 
@@ -1414,27 +1415,6 @@ TEST(InferenceSessionTests, TestParallelExecutionWithCudaProvider) {
   ASSERT_TRUE(!status.IsOK());
 }
 
-TEST(InferenceSessionTests, TestParallelExecutionWithCpuAndCudaProviders) {
-  string model_uri = "testdata/transform/fusion/fuse-conv-bn-mul-add-unsqueeze.onnx";
-
-  SessionOptions so;
-  so.enable_sequential_execution = false;
-  so.session_logid = "InferenceSessionTests.TestParallelExecutionWithCudaProvider";
-  InferenceSession session_object{so};
-
-  CPUExecutionProviderInfo epi1;
-  EXPECT_TRUE(session_object.RegisterExecutionProvider(std::make_unique<CPUExecutionProvider>(epi1)).IsOK());
-
-  CUDAExecutionProviderInfo epi2;
-  epi2.device_id = 0;
-  EXPECT_TRUE(session_object.RegisterExecutionProvider(std::make_unique<CUDAExecutionProvider>(epi2)).IsOK());
-
-  ASSERT_TRUE(session_object.Load(model_uri).IsOK());
-
-  auto status = session_object.Initialize();
-
-  ASSERT_TRUE(status.IsOK());
-}
 #endif
 
 }  // namespace test

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -1394,5 +1394,26 @@ TEST(InferenceSessionTests, TestL1AndL2Transformers) {
   }
 }
 
+#ifdef USE_CUDA
+TEST(InferenceSessionTests, TestParallelExecutionWithCudaProvider) {
+  string model_uri = "testdata/transform/fusion/fuse-conv-bn-mul-add-unsqueeze.onnx";
+
+  SessionOptions so;
+  so.enable_sequential_execution = false;
+  so.session_logid = "InferenceSessionTests.TestParallelExecutionWithCudaProvider";
+  InferenceSession session_object{so};
+  
+  CUDAExecutionProviderInfo epi;
+  epi.device_id = 0;
+  EXPECT_TRUE(session_object.RegisterExecutionProvider(std::make_unique<CUDAExecutionProvider>(epi)).IsOK());
+
+  ASSERT_TRUE(session_object.Load(model_uri).IsOK());
+
+  auto status = session_object.Initialize();
+
+  ASSERT_TRUE(status.IsOK());
+}
+#endif
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -229,7 +229,7 @@ TEST(ResolvingGraphTest, GraphConstruction_VerifyNoDuplicateName) {
   auto& node_with_dup_name = graph.AddNode("node_1", "Variable", "node 2", inputs, outputs);
   auto status = graph.Resolve();
   EXPECT_FALSE(status.IsOK());
-  EXPECT_EQ("Error: two nodes with same node name (node_1).", status.ErrorMessage());
+  EXPECT_EQ("This is an invalid model. Error: two nodes with same node name (node_1).", status.ErrorMessage());
   graph.RemoveNode(node_with_dup_name.Index());
 
   // Case 2: Adding two nodes with same output arg name should fail.
@@ -258,7 +258,7 @@ TEST(ResolvingGraphTest, GraphConstruction_VerifyNodeAndOpMatch) {
   graph.AddNode("node_1", "OpNotExist", "node 1", inputs, outputs);
   auto status = graph.Resolve();
   EXPECT_FALSE(status.IsOK());
-  EXPECT_EQ(0, status.ErrorMessage().find_first_of("No Schema registered for OpNotExist"));
+  EXPECT_EQ(0, status.ErrorMessage().find_first_of("This is an invalid model. No Schema registered for OpNotExist"));
 }
 
 TEST(ResolvingGraphTest, GraphConstruction_CheckIsAcyclic) {
@@ -626,7 +626,7 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckIsNotAcyclic) {
 
   auto status = graph.Resolve();
   EXPECT_FALSE(status.IsOK());
-  EXPECT_EQ("Error: the graph is not acyclic.", status.ErrorMessage());
+  EXPECT_EQ("This is an invalid graph. Error: the graph is not acyclic.", status.ErrorMessage());
 }
 
 TEST(ResolvingGraphTest, GraphConstruction_OnlyInitializer) {

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -626,7 +626,7 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckIsNotAcyclic) {
 
   auto status = graph.Resolve();
   EXPECT_FALSE(status.IsOK());
-  EXPECT_EQ("This is an invalid graph. Error: the graph is not acyclic.", status.ErrorMessage());
+  EXPECT_EQ("This is an invalid model. Error: the graph is not acyclic.", status.ErrorMessage());
 }
 
 TEST(ResolvingGraphTest, GraphConstruction_OnlyInitializer) {

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -36,72 +36,72 @@ namespace test {
 
 static bool RegisterCustomSchemas() {
   OPERATOR_SCHEMA(Variable_DFS)
-	  .SetDoc("Input variable.")
-	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+      .SetDoc("Input variable.")
+      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
   OPERATOR_SCHEMA(Add_DFS)
-	  .SetDoc("Add two integers.")
-	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-	  .Input(1, "input_2", "docstr for input_2.", "tensor(int32)")
-	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+      .SetDoc("Add two integers.")
+      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+      .Input(1, "input_2", "docstr for input_2.", "tensor(int32)")
+      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
   OPERATOR_SCHEMA(NoOp_DFS)
-	  .SetDoc("Operator doing nothing.")
-	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+      .SetDoc("Operator doing nothing.")
+      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
 
   OPERATOR_SCHEMA(Variable_Fake)
-	  .SetDoc("Input variable.")
-	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+      .SetDoc("Input variable.")
+      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
   OPERATOR_SCHEMA(Add_Fake)
-	  .SetDoc("Add two integers.")
-	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-	  .Input(1, "input_2", "docstr for input_2.", "tensor(int32)")
-	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+      .SetDoc("Add two integers.")
+      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+      .Input(1, "input_2", "docstr for input_2.", "tensor(int32)")
+      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
   OPERATOR_SCHEMA(NoOp_Fake)
-	  .SetDoc("Operator doing nothing.")
-	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+      .SetDoc("Operator doing nothing.")
+      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
 
   OPERATOR_SCHEMA(Identity_Fake)
-	  .SetDoc("Identity.")
-	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+      .SetDoc("Identity.")
+      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
   OPERATOR_SCHEMA(Merge_Fake)
-	  .SetDoc("Merge.")
-	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-	  .Input(1, "input_2", "docstr for input_2.", "tensor(int32)")
-	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+      .SetDoc("Merge.")
+      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+      .Input(1, "input_2", "docstr for input_2.", "tensor(int32)")
+      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
 
   // we need more than 8 outputs to trigger the unordered_map that's used in Graph::SetGraphInputsOutputs to
   // re-allocate and re-order to prove the code works.
   OPERATOR_SCHEMA(Split_Fake)
-	  .SetDoc("Split.")
-	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)")
-	  .Output(1, "output_2", "docstr for output_2.", "tensor(int32)")
-	  .Output(2, "output_3", "docstr for output_3.", "tensor(int32)")
-	  .Output(3, "output_4", "docstr for output_4.", "tensor(int32)")
-	  .Output(4, "output_5", "docstr for output_5.", "tensor(int32)")
-	  .Output(5, "output_6", "docstr for output_6.", "tensor(int32)")
-	  .Output(6, "output_7", "docstr for output_7.", "tensor(int32)")
-	  .Output(7, "output_8", "docstr for output_8.", "tensor(int32)")
-	  .Output(8, "output_9", "docstr for output_9.", "tensor(int32)")
-	  .Output(9, "output_10", "docstr for output_10.", "tensor(int32)");
+      .SetDoc("Split.")
+      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)")
+      .Output(1, "output_2", "docstr for output_2.", "tensor(int32)")
+      .Output(2, "output_3", "docstr for output_3.", "tensor(int32)")
+      .Output(3, "output_4", "docstr for output_4.", "tensor(int32)")
+      .Output(4, "output_5", "docstr for output_5.", "tensor(int32)")
+      .Output(5, "output_6", "docstr for output_6.", "tensor(int32)")
+      .Output(6, "output_7", "docstr for output_7.", "tensor(int32)")
+      .Output(7, "output_8", "docstr for output_8.", "tensor(int32)")
+      .Output(8, "output_9", "docstr for output_9.", "tensor(int32)")
+      .Output(9, "output_10", "docstr for output_10.", "tensor(int32)");
 
   OPERATOR_SCHEMA(Variable2_Fake)
-	  .SetDoc("Input variable.")
-	  .Input(0, "input_1", "docstr for input_1.", "T")
-	  .Output(0, "output_1", "docstr for output_1.", "T")
-	  .TypeConstraint("T", {"tensor(int32)", "tensor(float)"}, "input/output types");
+      .SetDoc("Input variable.")
+      .Input(0, "input_1", "docstr for input_1.", "T")
+      .Output(0, "output_1", "docstr for output_1.", "T")
+      .TypeConstraint("T", {"tensor(int32)", "tensor(float)"}, "input/output types");
 
   OPERATOR_SCHEMA(Max_Fake)
-	  .SetDoc("Add two integers.")
-	  .Input(0, "input_1", "docstr for input_1.", "T")
-	  .Input(1, "input_2", "docstr for input_2.", "T")
-	  .Input(2, "input_3", "docstr for input_3.", "T")
-	  .Output(0, "output_1", "docstr for output_1.", "T")
-	  .TypeConstraint("T", {"tensor(int32)", "tensor(float)"}, "input/output types");
+      .SetDoc("Add two integers.")
+      .Input(0, "input_1", "docstr for input_1.", "T")
+      .Input(1, "input_2", "docstr for input_2.", "T")
+      .Input(2, "input_3", "docstr for input_3.", "T")
+      .Output(0, "output_1", "docstr for output_1.", "T")
+      .TypeConstraint("T", {"tensor(int32)", "tensor(float)"}, "input/output types");
 
   return true;
 }
@@ -117,7 +117,7 @@ TEST(GraphTraversalTest, ReverseDFS) {
   // Case 1: A normal graph.
   //                 SouceNode
   //                 /       \
-			//  node_1 (Variable)      node_2 (Variable)
+            //  node_1 (Variable)      node_2 (Variable)
   //                 \       /
   //                 node_3 (Add)
   //                     |
@@ -168,33 +168,33 @@ TEST(GraphTraversalTest, ReverseDFS) {
 
   std::vector<const Node*> from;
   for (auto& node : graph.Nodes()) {
-	if (node.OutputEdgesBegin() == node.OutputEdgesEnd()) {
-	  // This is a leaf node.
-	  from.push_back(&node);
-	}
+    if (node.OutputEdgesBegin() == node.OutputEdgesEnd()) {
+      // This is a leaf node.
+      from.push_back(&node);
+    }
   }
 
   std::vector<std::string> enter_leave_sequence;
 
   struct NodeCompareName {
-	bool operator()(const Node* n1, const Node* n2) const {
-	  return n1->Name() < n2->Name();
-	}
+    bool operator()(const Node* n1, const Node* n2) const {
+      return n1->Name() < n2->Name();
+    }
   };
 
   graph.ReverseDFSFrom(
-	  from,
-	  [&enter_leave_sequence](const Node* n) {
-		std::string s("enter:");
-		s += n->Name();
-		enter_leave_sequence.push_back(s);
-	  },
-	  [&enter_leave_sequence](const Node* n) {
-		std::string s("leave:");
-		s += n->Name();
-		enter_leave_sequence.push_back(s);
-	  },
-	  NodeCompareName());
+      from,
+      [&enter_leave_sequence](const Node* n) {
+        std::string s("enter:");
+        s += n->Name();
+        enter_leave_sequence.push_back(s);
+      },
+      [&enter_leave_sequence](const Node* n) {
+        std::string s("leave:");
+        s += n->Name();
+        enter_leave_sequence.push_back(s);
+      },
+      NodeCompareName());
 
   EXPECT_EQ(enter_leave_sequence.size(), 8);
   EXPECT_EQ("enter:node_4", enter_leave_sequence.at(0));
@@ -270,7 +270,7 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckIsAcyclic) {
   // A normal graph.
   //                 SouceNode
   //                 /       \
-			//    node_1 (Variable)  node_2 (Variable)
+            //    node_1 (Variable)  node_2 (Variable)
   //                 \       /
   //                 node_3 (Add)
   //                     |
@@ -281,7 +281,7 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckIsAcyclic) {
   std::vector<NodeArg*> outputs;
 
   std::unordered_map<std::string, std::pair<std::vector<NodeArg*>, std::vector<NodeArg*>>>
-	  expected_node_name_to_input_output_args;
+      expected_node_name_to_input_output_args;
 
   TypeProto tensor_int32;
   tensor_int32.mutable_tensor_type()->set_elem_type(TensorProto_DataType_INT32);
@@ -336,20 +336,20 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckIsAcyclic) {
   model2.reset(new Model(model_proto2));
   Graph& graph2 = model2->MainGraph();
   for (auto& node : graph2.Nodes()) {
-	auto node_name_to_input_output_iter = expected_node_name_to_input_output_args.find(node.Name());
-	EXPECT_FALSE(node_name_to_input_output_iter == expected_node_name_to_input_output_args.end());
+    auto node_name_to_input_output_iter = expected_node_name_to_input_output_args.find(node.Name());
+    EXPECT_FALSE(node_name_to_input_output_iter == expected_node_name_to_input_output_args.end());
 
-	EXPECT_EQ(node_name_to_input_output_iter->second.first.size(), node.InputDefs().size());
-	for (size_t i = 0; i < node_name_to_input_output_iter->second.first.size(); ++i) {
-	  EXPECT_EQ(node_name_to_input_output_iter->second.first[i]->Name(), node.InputDefs()[i]->Name());
-	  EXPECT_EQ(node_name_to_input_output_iter->second.first[i]->Type(), node.InputDefs()[i]->Type());
-	}
+    EXPECT_EQ(node_name_to_input_output_iter->second.first.size(), node.InputDefs().size());
+    for (size_t i = 0; i < node_name_to_input_output_iter->second.first.size(); ++i) {
+      EXPECT_EQ(node_name_to_input_output_iter->second.first[i]->Name(), node.InputDefs()[i]->Name());
+      EXPECT_EQ(node_name_to_input_output_iter->second.first[i]->Type(), node.InputDefs()[i]->Type());
+    }
 
-	EXPECT_EQ(node_name_to_input_output_iter->second.second.size(), node.OutputDefs().size());
-	for (size_t i = 0; i < node_name_to_input_output_iter->second.second.size(); ++i) {
-	  EXPECT_EQ(node_name_to_input_output_iter->second.second[i]->Name(), node.OutputDefs()[i]->Name());
-	  EXPECT_EQ(node_name_to_input_output_iter->second.second[i]->Type(), node.OutputDefs()[i]->Type());
-	}
+    EXPECT_EQ(node_name_to_input_output_iter->second.second.size(), node.OutputDefs().size());
+    for (size_t i = 0; i < node_name_to_input_output_iter->second.second.size(); ++i) {
+      EXPECT_EQ(node_name_to_input_output_iter->second.second[i]->Name(), node.OutputDefs()[i]->Name());
+      EXPECT_EQ(node_name_to_input_output_iter->second.second[i]->Type(), node.OutputDefs()[i]->Type());
+    }
   }
 }
 
@@ -367,7 +367,7 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckInputNodeOrderMaintained) {
   //                     |
 
   std::unordered_map<std::string, std::pair<std::vector<NodeArg*>, std::vector<NodeArg*>>>
-	  expected_node_name_to_input_output_args;
+      expected_node_name_to_input_output_args;
 
   TypeProto tensor_int32;
   tensor_int32.mutable_tensor_type()->set_elem_type(TensorProto_DataType_INT32);
@@ -421,15 +421,15 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckInputNodeOrderMaintained) {
   bool seen2 = false;
 
   for (auto i : topological_order) {
-	auto node = graph.GetNode(i);
+    auto node = graph.GetNode(i);
 
-	if (node->Name() == "node_1") {
-	  EXPECT_TRUE(!seen2) << "node_1 should remain before node_2 after the topological sort.";
-	  seen1 = true;
-	} else if (node->Name() == "node_2") {
-	  EXPECT_TRUE(seen1) << "node_1 should be before node_2 after the topological sort.";
-	  seen2 = true;
-	}
+    if (node->Name() == "node_1") {
+      EXPECT_TRUE(!seen2) << "node_1 should remain before node_2 after the topological sort.";
+      seen1 = true;
+    } else if (node->Name() == "node_2") {
+      EXPECT_TRUE(seen1) << "node_1 should be before node_2 after the topological sort.";
+      seen2 = true;
+    }
   }
 }
 
@@ -442,7 +442,7 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckGraphInputOutputOrderMaintained)
   std::unordered_map<std::string, int> map;
 
   for (auto i = 0; i < 20; ++i) {
-	map.insert({std::to_string(i), i});
+    map.insert({std::to_string(i), i});
   }
 
   //               |         |
@@ -468,9 +468,9 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckGraphInputOutputOrderMaintained)
   std::vector<NodeArg*> split_outputs;
   std::vector<const NodeArg*> graph_outputs;
   for (int i = 0; i < 10; ++i) {
-	auto arg = &graph.GetOrCreateNodeArg("node_d_out_" + std::to_string(i + 1), &tensor_int32);
-	split_outputs.push_back(arg);
-	graph_outputs.push_back(arg);
+    auto arg = &graph.GetOrCreateNodeArg("node_d_out_" + std::to_string(i + 1), &tensor_int32);
+    split_outputs.push_back(arg);
+    graph_outputs.push_back(arg);
   }
   std::reverse(graph_outputs.begin(), graph_outputs.end());
   std::vector<NodeArg*> inputs;
@@ -496,18 +496,18 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckGraphInputOutputOrderMaintained)
   graph.AddNode("d", "Split_Fake", "d", inputs, split_outputs);
 
   auto validate_inputs_outputs = [&graph_outputs](const Graph& graph) {
-	auto inputs = graph.GetInputs();
-	auto outputs = graph.GetOutputs();
+    auto inputs = graph.GetInputs();
+    auto outputs = graph.GetOutputs();
 
-	ASSERT_TRUE(inputs.size() == 2);
+    ASSERT_TRUE(inputs.size() == 2);
 
-	EXPECT_TRUE(inputs[0]->Name() == "node_a_in_1");  // 'a' was added first
-	EXPECT_TRUE(inputs[1]->Name() == "node_b_in_1");
+    EXPECT_TRUE(inputs[0]->Name() == "node_a_in_1");  // 'a' was added first
+    EXPECT_TRUE(inputs[1]->Name() == "node_b_in_1");
 
-	ASSERT_TRUE(outputs.size() == 10);
-	for (int i = 0; i < 10; ++i) {
-	  EXPECT_TRUE(graph_outputs[i]->Name() == outputs[i]->Name());
-	}
+    ASSERT_TRUE(outputs.size() == 10);
+    for (int i = 0; i < 10; ++i) {
+      EXPECT_TRUE(graph_outputs[i]->Name() == outputs[i]->Name());
+    }
   };
   graph.SetInputs({&input_arg_a, &input_arg_b});
   graph.SetOutputs(graph_outputs);
@@ -626,7 +626,7 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckIsNotAcyclic) {
 
   auto status = graph.Resolve();
   EXPECT_FALSE(status.IsOK());
-  EXPECT_EQ("This is an invalid model. Error: the graph is not acyclic.", status.ErrorMessage());
+  EXPECT_EQ("This is an invalid graph. Error: the graph is not acyclic.", status.ErrorMessage());
 }
 
 TEST(ResolvingGraphTest, GraphConstruction_OnlyInitializer) {
@@ -656,7 +656,7 @@ TEST(ResolvingGraphTest, GraphConstruction_TypeInference) {
   // Case 1: A normal graph.
   //                         SourceNode
   //                   /         |         \
-			//  node_1 (Variable)  node_2 (Variable)  node_3 (Variable)
+            //  node_1 (Variable)  node_2 (Variable)  node_3 (Variable)
   //                   \         |         / (it's all 3 nodes above outputs to the one input of node_4)
   //                        node_4 (Max)
   //                             |
@@ -703,7 +703,7 @@ TEST(ResolvingGraphTest, GraphConstruction_TypeInference) {
   std::unordered_set<std::string> expected_graph_inputs = {"node_1_in_1", "node_3_in_1"};
   EXPECT_EQ(2, graph.GetInputs().size());
   for (auto& graph_input : graph.GetInputs()) {
-	EXPECT_TRUE(expected_graph_inputs.find(graph_input->Name()) != expected_graph_inputs.end());
+    EXPECT_TRUE(expected_graph_inputs.find(graph_input->Name()) != expected_graph_inputs.end());
   }
   EXPECT_EQ(1, graph.GetOutputs().size());
   EXPECT_EQ("node_4_out_1", graph.GetOutputs()[0]->Name());
@@ -717,7 +717,7 @@ TEST(ResolvingGraphTest, GraphConstruction_TypeInference) {
   auto& graph_proto = graph.ToGraphProto();
   EXPECT_EQ(2, graph_proto.input_size());
   for (auto& graphProtoInput : graph_proto.input()) {
-	EXPECT_TRUE(expected_graph_inputs.find(graphProtoInput.name()) != expected_graph_inputs.end());
+    EXPECT_TRUE(expected_graph_inputs.find(graphProtoInput.name()) != expected_graph_inputs.end());
   }
   EXPECT_EQ(1, graph_proto.output_size());
   EXPECT_EQ("node_4_out_1", graph_proto.output(0).name());
@@ -725,9 +725,9 @@ TEST(ResolvingGraphTest, GraphConstruction_TypeInference) {
 
 TEST(TestAddAttribute, AddTensorAttribute) {
   OPERATOR_SCHEMA(__Constant)
-	  .SetDoc("Constant Op.")
-	  .Attr(kConstantValue, "constant value", AttrType::AttributeProto_AttributeType_TENSOR)
-	  .Output(0, "output_1", "docstr for output_1.", "tensor(int64)");
+      .SetDoc("Constant Op.")
+      .Attr(kConstantValue, "constant value", AttrType::AttributeProto_AttributeType_TENSOR)
+      .Output(0, "output_1", "docstr for output_1.", "tensor(int64)");
   std::vector<NodeArg*> inputs;
   std::vector<NodeArg*> outputs;
   Model model("graph_1");
@@ -766,7 +766,7 @@ void AddAttribute(onnxruntime::Node& p_node, const std::string& attr_name, std::
   attr.set_name(attr_name);
   attr.set_type(AttributeProto_AttributeType_INTS);
   for (auto v : attr_value) {
-	attr.add_ints(v);
+    attr.add_ints(v);
   }
   p_node.AddAttribute(attr_name, attr);
 }

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -36,72 +36,72 @@ namespace test {
 
 static bool RegisterCustomSchemas() {
   OPERATOR_SCHEMA(Variable_DFS)
-      .SetDoc("Input variable.")
-      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+	  .SetDoc("Input variable.")
+	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
   OPERATOR_SCHEMA(Add_DFS)
-      .SetDoc("Add two integers.")
-      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-      .Input(1, "input_2", "docstr for input_2.", "tensor(int32)")
-      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+	  .SetDoc("Add two integers.")
+	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+	  .Input(1, "input_2", "docstr for input_2.", "tensor(int32)")
+	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
   OPERATOR_SCHEMA(NoOp_DFS)
-      .SetDoc("Operator doing nothing.")
-      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+	  .SetDoc("Operator doing nothing.")
+	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
 
   OPERATOR_SCHEMA(Variable_Fake)
-      .SetDoc("Input variable.")
-      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+	  .SetDoc("Input variable.")
+	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
   OPERATOR_SCHEMA(Add_Fake)
-      .SetDoc("Add two integers.")
-      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-      .Input(1, "input_2", "docstr for input_2.", "tensor(int32)")
-      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+	  .SetDoc("Add two integers.")
+	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+	  .Input(1, "input_2", "docstr for input_2.", "tensor(int32)")
+	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
   OPERATOR_SCHEMA(NoOp_Fake)
-      .SetDoc("Operator doing nothing.")
-      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+	  .SetDoc("Operator doing nothing.")
+	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
 
   OPERATOR_SCHEMA(Identity_Fake)
-      .SetDoc("Identity.")
-      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+	  .SetDoc("Identity.")
+	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
   OPERATOR_SCHEMA(Merge_Fake)
-      .SetDoc("Merge.")
-      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-      .Input(1, "input_2", "docstr for input_2.", "tensor(int32)")
-      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
+	  .SetDoc("Merge.")
+	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+	  .Input(1, "input_2", "docstr for input_2.", "tensor(int32)")
+	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)");
 
   // we need more than 8 outputs to trigger the unordered_map that's used in Graph::SetGraphInputsOutputs to
   // re-allocate and re-order to prove the code works.
   OPERATOR_SCHEMA(Split_Fake)
-      .SetDoc("Split.")
-      .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
-      .Output(0, "output_1", "docstr for output_1.", "tensor(int32)")
-      .Output(1, "output_2", "docstr for output_2.", "tensor(int32)")
-      .Output(2, "output_3", "docstr for output_3.", "tensor(int32)")
-      .Output(3, "output_4", "docstr for output_4.", "tensor(int32)")
-      .Output(4, "output_5", "docstr for output_5.", "tensor(int32)")
-      .Output(5, "output_6", "docstr for output_6.", "tensor(int32)")
-      .Output(6, "output_7", "docstr for output_7.", "tensor(int32)")
-      .Output(7, "output_8", "docstr for output_8.", "tensor(int32)")
-      .Output(8, "output_9", "docstr for output_9.", "tensor(int32)")
-      .Output(9, "output_10", "docstr for output_10.", "tensor(int32)");
+	  .SetDoc("Split.")
+	  .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
+	  .Output(0, "output_1", "docstr for output_1.", "tensor(int32)")
+	  .Output(1, "output_2", "docstr for output_2.", "tensor(int32)")
+	  .Output(2, "output_3", "docstr for output_3.", "tensor(int32)")
+	  .Output(3, "output_4", "docstr for output_4.", "tensor(int32)")
+	  .Output(4, "output_5", "docstr for output_5.", "tensor(int32)")
+	  .Output(5, "output_6", "docstr for output_6.", "tensor(int32)")
+	  .Output(6, "output_7", "docstr for output_7.", "tensor(int32)")
+	  .Output(7, "output_8", "docstr for output_8.", "tensor(int32)")
+	  .Output(8, "output_9", "docstr for output_9.", "tensor(int32)")
+	  .Output(9, "output_10", "docstr for output_10.", "tensor(int32)");
 
   OPERATOR_SCHEMA(Variable2_Fake)
-      .SetDoc("Input variable.")
-      .Input(0, "input_1", "docstr for input_1.", "T")
-      .Output(0, "output_1", "docstr for output_1.", "T")
-      .TypeConstraint("T", {"tensor(int32)", "tensor(float)"}, "input/output types");
+	  .SetDoc("Input variable.")
+	  .Input(0, "input_1", "docstr for input_1.", "T")
+	  .Output(0, "output_1", "docstr for output_1.", "T")
+	  .TypeConstraint("T", {"tensor(int32)", "tensor(float)"}, "input/output types");
 
   OPERATOR_SCHEMA(Max_Fake)
-      .SetDoc("Add two integers.")
-      .Input(0, "input_1", "docstr for input_1.", "T")
-      .Input(1, "input_2", "docstr for input_2.", "T")
-      .Input(2, "input_3", "docstr for input_3.", "T")
-      .Output(0, "output_1", "docstr for output_1.", "T")
-      .TypeConstraint("T", {"tensor(int32)", "tensor(float)"}, "input/output types");
+	  .SetDoc("Add two integers.")
+	  .Input(0, "input_1", "docstr for input_1.", "T")
+	  .Input(1, "input_2", "docstr for input_2.", "T")
+	  .Input(2, "input_3", "docstr for input_3.", "T")
+	  .Output(0, "output_1", "docstr for output_1.", "T")
+	  .TypeConstraint("T", {"tensor(int32)", "tensor(float)"}, "input/output types");
 
   return true;
 }
@@ -117,7 +117,7 @@ TEST(GraphTraversalTest, ReverseDFS) {
   // Case 1: A normal graph.
   //                 SouceNode
   //                 /       \
-            //  node_1 (Variable)      node_2 (Variable)
+			//  node_1 (Variable)      node_2 (Variable)
   //                 \       /
   //                 node_3 (Add)
   //                     |
@@ -168,33 +168,33 @@ TEST(GraphTraversalTest, ReverseDFS) {
 
   std::vector<const Node*> from;
   for (auto& node : graph.Nodes()) {
-    if (node.OutputEdgesBegin() == node.OutputEdgesEnd()) {
-      // This is a leaf node.
-      from.push_back(&node);
-    }
+	if (node.OutputEdgesBegin() == node.OutputEdgesEnd()) {
+	  // This is a leaf node.
+	  from.push_back(&node);
+	}
   }
 
   std::vector<std::string> enter_leave_sequence;
 
   struct NodeCompareName {
-    bool operator()(const Node* n1, const Node* n2) const {
-      return n1->Name() < n2->Name();
-    }
+	bool operator()(const Node* n1, const Node* n2) const {
+	  return n1->Name() < n2->Name();
+	}
   };
 
   graph.ReverseDFSFrom(
-      from,
-      [&enter_leave_sequence](const Node* n) {
-        std::string s("enter:");
-        s += n->Name();
-        enter_leave_sequence.push_back(s);
-      },
-      [&enter_leave_sequence](const Node* n) {
-        std::string s("leave:");
-        s += n->Name();
-        enter_leave_sequence.push_back(s);
-      },
-      NodeCompareName());
+	  from,
+	  [&enter_leave_sequence](const Node* n) {
+		std::string s("enter:");
+		s += n->Name();
+		enter_leave_sequence.push_back(s);
+	  },
+	  [&enter_leave_sequence](const Node* n) {
+		std::string s("leave:");
+		s += n->Name();
+		enter_leave_sequence.push_back(s);
+	  },
+	  NodeCompareName());
 
   EXPECT_EQ(enter_leave_sequence.size(), 8);
   EXPECT_EQ("enter:node_4", enter_leave_sequence.at(0));
@@ -270,7 +270,7 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckIsAcyclic) {
   // A normal graph.
   //                 SouceNode
   //                 /       \
-            //    node_1 (Variable)  node_2 (Variable)
+			//    node_1 (Variable)  node_2 (Variable)
   //                 \       /
   //                 node_3 (Add)
   //                     |
@@ -281,7 +281,7 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckIsAcyclic) {
   std::vector<NodeArg*> outputs;
 
   std::unordered_map<std::string, std::pair<std::vector<NodeArg*>, std::vector<NodeArg*>>>
-      expected_node_name_to_input_output_args;
+	  expected_node_name_to_input_output_args;
 
   TypeProto tensor_int32;
   tensor_int32.mutable_tensor_type()->set_elem_type(TensorProto_DataType_INT32);
@@ -336,20 +336,20 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckIsAcyclic) {
   model2.reset(new Model(model_proto2));
   Graph& graph2 = model2->MainGraph();
   for (auto& node : graph2.Nodes()) {
-    auto node_name_to_input_output_iter = expected_node_name_to_input_output_args.find(node.Name());
-    EXPECT_FALSE(node_name_to_input_output_iter == expected_node_name_to_input_output_args.end());
+	auto node_name_to_input_output_iter = expected_node_name_to_input_output_args.find(node.Name());
+	EXPECT_FALSE(node_name_to_input_output_iter == expected_node_name_to_input_output_args.end());
 
-    EXPECT_EQ(node_name_to_input_output_iter->second.first.size(), node.InputDefs().size());
-    for (size_t i = 0; i < node_name_to_input_output_iter->second.first.size(); ++i) {
-      EXPECT_EQ(node_name_to_input_output_iter->second.first[i]->Name(), node.InputDefs()[i]->Name());
-      EXPECT_EQ(node_name_to_input_output_iter->second.first[i]->Type(), node.InputDefs()[i]->Type());
-    }
+	EXPECT_EQ(node_name_to_input_output_iter->second.first.size(), node.InputDefs().size());
+	for (size_t i = 0; i < node_name_to_input_output_iter->second.first.size(); ++i) {
+	  EXPECT_EQ(node_name_to_input_output_iter->second.first[i]->Name(), node.InputDefs()[i]->Name());
+	  EXPECT_EQ(node_name_to_input_output_iter->second.first[i]->Type(), node.InputDefs()[i]->Type());
+	}
 
-    EXPECT_EQ(node_name_to_input_output_iter->second.second.size(), node.OutputDefs().size());
-    for (size_t i = 0; i < node_name_to_input_output_iter->second.second.size(); ++i) {
-      EXPECT_EQ(node_name_to_input_output_iter->second.second[i]->Name(), node.OutputDefs()[i]->Name());
-      EXPECT_EQ(node_name_to_input_output_iter->second.second[i]->Type(), node.OutputDefs()[i]->Type());
-    }
+	EXPECT_EQ(node_name_to_input_output_iter->second.second.size(), node.OutputDefs().size());
+	for (size_t i = 0; i < node_name_to_input_output_iter->second.second.size(); ++i) {
+	  EXPECT_EQ(node_name_to_input_output_iter->second.second[i]->Name(), node.OutputDefs()[i]->Name());
+	  EXPECT_EQ(node_name_to_input_output_iter->second.second[i]->Type(), node.OutputDefs()[i]->Type());
+	}
   }
 }
 
@@ -367,7 +367,7 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckInputNodeOrderMaintained) {
   //                     |
 
   std::unordered_map<std::string, std::pair<std::vector<NodeArg*>, std::vector<NodeArg*>>>
-      expected_node_name_to_input_output_args;
+	  expected_node_name_to_input_output_args;
 
   TypeProto tensor_int32;
   tensor_int32.mutable_tensor_type()->set_elem_type(TensorProto_DataType_INT32);
@@ -421,15 +421,15 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckInputNodeOrderMaintained) {
   bool seen2 = false;
 
   for (auto i : topological_order) {
-    auto node = graph.GetNode(i);
+	auto node = graph.GetNode(i);
 
-    if (node->Name() == "node_1") {
-      EXPECT_TRUE(!seen2) << "node_1 should remain before node_2 after the topological sort.";
-      seen1 = true;
-    } else if (node->Name() == "node_2") {
-      EXPECT_TRUE(seen1) << "node_1 should be before node_2 after the topological sort.";
-      seen2 = true;
-    }
+	if (node->Name() == "node_1") {
+	  EXPECT_TRUE(!seen2) << "node_1 should remain before node_2 after the topological sort.";
+	  seen1 = true;
+	} else if (node->Name() == "node_2") {
+	  EXPECT_TRUE(seen1) << "node_1 should be before node_2 after the topological sort.";
+	  seen2 = true;
+	}
   }
 }
 
@@ -442,7 +442,7 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckGraphInputOutputOrderMaintained)
   std::unordered_map<std::string, int> map;
 
   for (auto i = 0; i < 20; ++i) {
-    map.insert({std::to_string(i), i});
+	map.insert({std::to_string(i), i});
   }
 
   //               |         |
@@ -468,9 +468,9 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckGraphInputOutputOrderMaintained)
   std::vector<NodeArg*> split_outputs;
   std::vector<const NodeArg*> graph_outputs;
   for (int i = 0; i < 10; ++i) {
-    auto arg = &graph.GetOrCreateNodeArg("node_d_out_" + std::to_string(i + 1), &tensor_int32);
-    split_outputs.push_back(arg);
-    graph_outputs.push_back(arg);
+	auto arg = &graph.GetOrCreateNodeArg("node_d_out_" + std::to_string(i + 1), &tensor_int32);
+	split_outputs.push_back(arg);
+	graph_outputs.push_back(arg);
   }
   std::reverse(graph_outputs.begin(), graph_outputs.end());
   std::vector<NodeArg*> inputs;
@@ -496,18 +496,18 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckGraphInputOutputOrderMaintained)
   graph.AddNode("d", "Split_Fake", "d", inputs, split_outputs);
 
   auto validate_inputs_outputs = [&graph_outputs](const Graph& graph) {
-    auto inputs = graph.GetInputs();
-    auto outputs = graph.GetOutputs();
+	auto inputs = graph.GetInputs();
+	auto outputs = graph.GetOutputs();
 
-    ASSERT_TRUE(inputs.size() == 2);
+	ASSERT_TRUE(inputs.size() == 2);
 
-    EXPECT_TRUE(inputs[0]->Name() == "node_a_in_1");  // 'a' was added first
-    EXPECT_TRUE(inputs[1]->Name() == "node_b_in_1");
+	EXPECT_TRUE(inputs[0]->Name() == "node_a_in_1");  // 'a' was added first
+	EXPECT_TRUE(inputs[1]->Name() == "node_b_in_1");
 
-    ASSERT_TRUE(outputs.size() == 10);
-    for (int i = 0; i < 10; ++i) {
-      EXPECT_TRUE(graph_outputs[i]->Name() == outputs[i]->Name());
-    }
+	ASSERT_TRUE(outputs.size() == 10);
+	for (int i = 0; i < 10; ++i) {
+	  EXPECT_TRUE(graph_outputs[i]->Name() == outputs[i]->Name());
+	}
   };
   graph.SetInputs({&input_arg_a, &input_arg_b});
   graph.SetOutputs(graph_outputs);
@@ -626,7 +626,7 @@ TEST(ResolvingGraphTest, GraphConstruction_CheckIsNotAcyclic) {
 
   auto status = graph.Resolve();
   EXPECT_FALSE(status.IsOK());
-  EXPECT_EQ("This is an invalid graph. Error: the graph is not acyclic.", status.ErrorMessage());
+  EXPECT_EQ("This is an invalid model. Error: the graph is not acyclic.", status.ErrorMessage());
 }
 
 TEST(ResolvingGraphTest, GraphConstruction_OnlyInitializer) {
@@ -656,7 +656,7 @@ TEST(ResolvingGraphTest, GraphConstruction_TypeInference) {
   // Case 1: A normal graph.
   //                         SourceNode
   //                   /         |         \
-            //  node_1 (Variable)  node_2 (Variable)  node_3 (Variable)
+			//  node_1 (Variable)  node_2 (Variable)  node_3 (Variable)
   //                   \         |         / (it's all 3 nodes above outputs to the one input of node_4)
   //                        node_4 (Max)
   //                             |
@@ -703,7 +703,7 @@ TEST(ResolvingGraphTest, GraphConstruction_TypeInference) {
   std::unordered_set<std::string> expected_graph_inputs = {"node_1_in_1", "node_3_in_1"};
   EXPECT_EQ(2, graph.GetInputs().size());
   for (auto& graph_input : graph.GetInputs()) {
-    EXPECT_TRUE(expected_graph_inputs.find(graph_input->Name()) != expected_graph_inputs.end());
+	EXPECT_TRUE(expected_graph_inputs.find(graph_input->Name()) != expected_graph_inputs.end());
   }
   EXPECT_EQ(1, graph.GetOutputs().size());
   EXPECT_EQ("node_4_out_1", graph.GetOutputs()[0]->Name());
@@ -717,7 +717,7 @@ TEST(ResolvingGraphTest, GraphConstruction_TypeInference) {
   auto& graph_proto = graph.ToGraphProto();
   EXPECT_EQ(2, graph_proto.input_size());
   for (auto& graphProtoInput : graph_proto.input()) {
-    EXPECT_TRUE(expected_graph_inputs.find(graphProtoInput.name()) != expected_graph_inputs.end());
+	EXPECT_TRUE(expected_graph_inputs.find(graphProtoInput.name()) != expected_graph_inputs.end());
   }
   EXPECT_EQ(1, graph_proto.output_size());
   EXPECT_EQ("node_4_out_1", graph_proto.output(0).name());
@@ -725,9 +725,9 @@ TEST(ResolvingGraphTest, GraphConstruction_TypeInference) {
 
 TEST(TestAddAttribute, AddTensorAttribute) {
   OPERATOR_SCHEMA(__Constant)
-      .SetDoc("Constant Op.")
-      .Attr(kConstantValue, "constant value", AttrType::AttributeProto_AttributeType_TENSOR)
-      .Output(0, "output_1", "docstr for output_1.", "tensor(int64)");
+	  .SetDoc("Constant Op.")
+	  .Attr(kConstantValue, "constant value", AttrType::AttributeProto_AttributeType_TENSOR)
+	  .Output(0, "output_1", "docstr for output_1.", "tensor(int64)");
   std::vector<NodeArg*> inputs;
   std::vector<NodeArg*> outputs;
   Model model("graph_1");
@@ -766,7 +766,7 @@ void AddAttribute(onnxruntime::Node& p_node, const std::string& attr_name, std::
   attr.set_name(attr_name);
   attr.set_type(AttributeProto_AttributeType_INTS);
   for (auto v : attr_value) {
-    attr.add_ints(v);
+	attr.add_ints(v);
   }
   p_node.AddAttribute(attr_name, attr);
 }


### PR DESCRIPTION
This change strives to address feedback received from the following issues:

1) #717 
    Don't allow parallel executor when CUDA provider is registered. Instead of segfaulting, return appropriate Status object with descriptive error message during initialization

2) #649 
   In obvious cases, prepend the error message with `This is an invalid model.` or `This is an invalid graph.` (as the case maybe) along with the technical error message

Suggestions involving doing this differently to achieve the same end goal are welcome. 

CC: @faxu 