### PR TITLE
Generalise strerror_r preprocessor switch

### DIFF
--- a/onnxruntime/core/framework/path_lib.h
+++ b/onnxruntime/core/framework/path_lib.h
@@ -236,10 +236,9 @@ void LoopDir(const std::string& dir_name, T func) {
     auto e = errno;
     char buf[1024];
     char* msg;
-#if defined(_GNU_SOURCE) && !defined(__APPLE__)
+#if defined(__GLIBC__) && defined(_GNU_SOURCE)
     msg = strerror_r(e, buf, sizeof(buf));
 #else
-    // for Mac OS X
     if (strerror_r(e, buf, sizeof(buf)) != 0) {
       buf[0] = '\0';
     }

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -180,10 +180,9 @@ class PosixEnv : public Env {
     char buf[1024];
     const char* msg = "";
     if (e > 0) {
-#if defined(_GNU_SOURCE) && !defined(__APPLE__)
+#if defined(__GLIBC__) && defined(_GNU_SOURCE)
       msg = strerror_r(e, buf, sizeof(buf));
 #else
-      // for Mac OS X
       if (strerror_r(e, buf, sizeof(buf)) != 0) {
         buf[0] = '\0';
       }


### PR DESCRIPTION
Same approach as in https://reviews.llvm.org/D25071. This catches all cases including building against musl (e.g. on Alpine Linux) like in the linked issue.