### PR TITLE
Support using the standard version of 7-Zip in build.py

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -269,8 +269,10 @@ def download_test_data(build_dir, src_url, expected_md5, azure_sas_key):
         shutil.rmtree(models_dir)
     if shutil.which('unzip'):
         run_subprocess(['unzip','-qd', models_dir, local_zip_file])
-    elif shutil.which('7za'):
-        run_subprocess(['7za','x', local_zip_file, '-y', '-o' + models_dir])
+    elif shutil.which('7z'):  # 7-Zip
+        run_subprocess(['7z','x', local_zip_file, '-y', '-o' + models_dir])
+    elif shutil.which('7za'):  # 7-Zip standalone
+        run_subprocess(['7za', 'x', local_zip_file, '-y', '-o' + models_dir])
     else:
         #TODO: use python for unzip
         log.error("No unzip tool for use")


### PR DESCRIPTION
Currently download_test_data in build.py supports only the standalone version of 7-Zip by looking for 7za.exe. Add support for the standard version which has 7z.exe.