### PR TITLE
Add EnableMemPattern/DisableMemPattern to the C++ API

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -40,7 +40,7 @@ struct Exception : std::exception {
   Exception(std::string&& string, OrtErrorCode code) : message_{std::move(string)}, code_{code} {}
 
   OrtErrorCode GetOrtErrorCode() const { return code_; }
-  const char* what() const noexcept { return message_.c_str(); }
+  const char* what() const noexcept override { return message_.c_str(); }
 
  private:
   std::string message_;
@@ -149,6 +149,9 @@ struct SessionOptions : Base<OrtSessionOptions> {
 
   SessionOptions& EnableCpuMemArena();
   SessionOptions& DisableCpuMemArena();
+
+  SessionOptions& EnableMemPattern();
+  SessionOptions& DisableMemPattern();
 
   SessionOptions& EnableSequentialExecution();
   SessionOptions& DisableSequentialExecution();
@@ -321,6 +324,16 @@ inline SessionOptions& SessionOptions::SetThreadPoolSize(int session_thread_pool
 inline SessionOptions& SessionOptions::SetGraphOptimizationLevel(uint32_t graph_optimization_level) {
   if (OrtSetSessionGraphOptimizationLevel(p_, graph_optimization_level) == -1)
     throw Exception("Error calling SessionOptions::SetGraphOptimizationLevel", ORT_FAIL);
+  return *this;
+}
+
+inline SessionOptions& SessionOptions::EnableMemPattern() {
+  OrtEnableMemPattern(p_);
+  return *this;
+}
+
+inline SessionOptions& SessionOptions::DisableMemPattern() {
+  OrtDisableMemPattern(p_);
   return *this;
 }
 

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -28,11 +28,13 @@ void usage() {
       "Options:\n"
       "\t-j [models]: Specifies the number of models to run simultaneously.\n"
       "\t-A : Disable memory arena\n"
+      "\t-M : Disable memory pattern\n"
       "\t-c [runs]: Specifies the number of Session::Run() to invoke simultaneously for each model.\n"
       "\t-r [repeat]: Specifies the number of times to repeat\n"
       "\t-v: verbose\n"
       "\t-n [test_case_name]: Specifies a single test case to run.\n"
-      "\t-e [EXECUTION_PROVIDER]: EXECUTION_PROVIDER could be 'cpu', 'cuda', 'mkldnn', 'tensorrt' or 'ngraph'. Default: 'cpu'.\n"
+      "\t-e [EXECUTION_PROVIDER]: EXECUTION_PROVIDER could be 'cpu', 'cuda', 'mkldnn', 'tensorrt' or 'ngraph'. "
+      "Default: 'cpu'.\n"
       "\t-x: Use parallel executor, default (without -x): sequential executor.\n"
       "\t-h: help\n");
 }
@@ -83,10 +85,11 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   bool enable_ngraph = false;
   bool enable_nuphar = false;
   bool enable_tensorrt = false;
+  bool enable_mem_pattern = true;
   OrtLoggingLevel logging_level = ORT_LOGGING_LEVEL_WARNING;
   {
     int ch;
-    while ((ch = getopt(argc, argv, ORT_TSTR("Ac:hj:m:n:r:e:xv"))) != -1) {
+    while ((ch = getopt(argc, argv, ORT_TSTR("Ac:hj:Mn:r:e:xv"))) != -1) {
       switch (ch) {
         case 'A':
           enable_cpu_mem_arena = false;
@@ -115,8 +118,8 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
             return -1;
           }
           break;
-        case 'm':
-          // ignore.
+        case 'M':
+          enable_mem_pattern = false;
           break;
         case 'n':
           // run only some whitelisted tests
@@ -187,6 +190,10 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
       sf.EnableCpuMemArena();
     else
       sf.DisableCpuMemArena();
+    if (enable_mem_pattern)
+      sf.EnableMemPattern();
+    else
+      sf.DisableMemPattern();
     if (enable_sequential_execution)
       sf.EnableSequentialExecution();
     else


### PR DESCRIPTION
1. Add EnableMemPattern/DisableMemPattern to the C++ API.
2. Add a command line option in onnx_test_runner for controlling memory pattern
3. Add 'override' keyword to the Exception class in the C++ API wrapper.