### PR TITLE
drop GIL before Run to enable multiple python threads to execute in parallel

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -361,8 +361,6 @@ void addOpSchemaSubmodule(py::module& m){
 #endif //onnxruntime_PYBIND_EXPORT_OPSCHEMA
 
 void addObjectMethods(py::module& m) {
-  // allow unit tests to redirect std::cout and std::cerr to sys.stdout and sys.stderr
-  py::add_ostream_redirect(m, "onnxruntime_ostream_redirect");
   py::class_<SessionOptions>(m, "SessionOptions", R"pbdoc(Configuration information for a session.)pbdoc")
       .def(py::init())
       .def_readwrite("enable_cpu_mem_arena", &SessionOptions::enable_cpu_mem_arena,
@@ -512,10 +510,14 @@ including arg name, arg type (contains both type and shape).)pbdoc")
         std::vector<MLValue> fetches;
         common::Status status;
 
-        if (run_options != nullptr) {
-          status = sess->Run(*run_options, feeds, output_names, &fetches);
-        } else {
-          status = sess->Run(feeds, output_names, &fetches);
+        {
+          // release GIL to allow multiple python threads to invoke Run() in parallel.
+          py::gil_scoped_release release;
+          if (run_options != nullptr) {
+            status = sess->Run(*run_options, feeds, output_names, &fetches);
+          } else {
+            status = sess->Run(feeds, output_names, &fetches);
+          }
         }
 
         if (!status.IsOK()) {

--- a/setup.py
+++ b/setup.py
@@ -99,11 +99,9 @@ setup(
     package_data={
         'onnxruntime': data + examples + extra,
     },
-    install_requires={
-        'numpy': ['numpy>=1.15.0']
-    },
     extras_require={
-        'backend': ['onnx>=1.2.3']
+        'backend': ['onnx>=1.2.3'],
+        'numpy': ['numpy>=1.15.0']
     },
     entry_points= {
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -99,9 +99,11 @@ setup(
     package_data={
         'onnxruntime': data + examples + extra,
     },
-    extras_require={
-        'backend': ['onnx>=1.2.3'],
+    install_requires={
         'numpy': ['numpy>=1.15.0']
+    },
+    extras_require={
+        'backend': ['onnx>=1.2.3']
     },
     entry_points= {
         'console_scripts': [


### PR DESCRIPTION
-release GIL before calling C++ Run() to allow multiple python threads to execute in parallel.
-remove ostream_redirect due to conflict with GIL , causes exception in logger destruction. it wasn't exposed to users, so it didn't have any external value.
-we weren't correctly enforcing numpy dependency requirement in setup.py (should not have been in extras_require)