### PR TITLE
Fix C-API sample (causing internal build failure)

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/C_Api_Sample.cpp
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/C_Api_Sample.cpp
@@ -78,7 +78,7 @@ int main(int argc, char* argv[]) {
     printf("Input %zu : type=%d\n", i, type);
 
     // print input shapes/dims
-    size_t num_dims = OrtGetNumOfDimensions(tensor_info);
+    size_t num_dims = OrtGetDimensionsCount(tensor_info);
     printf("Input %zu : num_dims=%zu\n", i, num_dims);
     input_node_dims.resize(num_dims);
     OrtGetDimensions(tensor_info, (int64_t*)input_node_dims.data(), num_dims);


### PR DESCRIPTION
The C-API sample is not gated by CI, but is tested during NuGet package creation.

**OrtGetNumOfDimensions** changed to **OrtGetDimensionsCount**, and hence needs to be updated to get builds passing.