### PR TITLE
fix 'trivial copy-assignment of string' warning in scatter op

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/scatter.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter.cc
@@ -60,7 +60,7 @@ Status CopyScatterData(const Tensor* data_input, const Tensor* indices_input, co
       std::string* dst = data_output->template MutableData<std::string>();
       std::copy(str_begin, str_end, dst);
     } else {
-      memcpy(dst_base, src_base, total_input_bytes);
+      memcpy(static_cast<void*>(dst_base), static_cast<const void*>(src_base), total_input_bytes);
     }
   }
 


### PR DESCRIPTION
Fix following warning for some platforms:
 onnxruntime/core/providers/cpu/tensor/scatter.cc:63:13: error: 'void* memcpy(void*, const void*, size_t)' writing to an object of type 'class std::__cxx11::basic_string' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Werror=class-memaccess]
memcpy(dst_base, src_base, total_input_bytes);