### PR TITLE
Add -M and -A arg to onnxruntime_perf_test

### DIFF
--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -26,10 +26,13 @@ namespace perftest {
   printf(
       "perf_test [options...] model_path result_file\n"
       "Options:\n"
-      "\t-m [test_mode]: Specifies the test mode. Value coulde be 'duration' or 'times'.\n"
+      "\t-m [test_mode]: Specifies the test mode. Value could be 'duration' or 'times'.\n"
       "\t\tProvide 'duration' to run the test for a fix duration, and 'times' to repeated for a certain times. "
+      "\t-M: Disable memory pattern.\n"
+      "\t-A: Disable memory arena\n"
       "\t-c [parallel runs]: Specifies the (max) number of runs to invoke simultaneously. Default:1.\n"
-      "\t-e [cpu|cuda|mkldnn|tensorrt|ngraph]: Specifies the provider 'cpu','cuda','mkldnn','tensorrt' or 'ngraph'. Default:'cpu'.\n"
+      "\t-e [cpu|cuda|mkldnn|tensorrt|ngraph]: Specifies the provider 'cpu','cuda','mkldnn','tensorrt' or 'ngraph'. "
+      "Default:'cpu'.\n"
       "\t-b [tf|ort]: backend to use. Default:ort\n"
       "\t-r [repeated_times]: Specifies the repeated times if running in 'times' test mode.Default:1000.\n"
       "\t-t [seconds_to_run]: Specifies the seconds to run for 'duration' mode. Default:600.\n"
@@ -43,7 +46,7 @@ namespace perftest {
 
 /*static*/ bool CommandLineParser::ParseArguments(PerformanceTestConfig& test_config, int argc, ORTCHAR_T* argv[]) {
   int ch;
-  while ((ch = getopt(argc, argv, ORT_TSTR("b:m:e:r:t:p:x:c:o:vhs"))) != -1) {
+  while ((ch = getopt(argc, argv, ORT_TSTR("b:m:e:r:t:p:x:c:o:AMvhs"))) != -1) {
     switch (ch) {
       case 'm':
         if (!CompareCString(optarg, ORT_TSTR("duration"))) {
@@ -59,6 +62,12 @@ namespace perftest {
         break;
       case 'p':
         test_config.run_config.profile_file = optarg;
+        break;
+      case 'M':
+        test_config.run_config.enable_memory_pattern = false;
+        break;
+      case 'A':
+        test_config.run_config.enable_cpu_mem_arena = false;
         break;
       case 'e':
         if (!CompareCString(optarg, ORT_TSTR("cpu"))) {
@@ -105,7 +114,8 @@ namespace perftest {
         }
         break;
       case 'c':
-        test_config.run_config.concurrent_session_runs = static_cast<int>(OrtStrtol<PATH_CHAR_TYPE>(optarg, nullptr));
+        test_config.run_config.concurrent_session_runs =
+            static_cast<size_t>(OrtStrtol<PATH_CHAR_TYPE>(optarg, nullptr));
         if (test_config.run_config.concurrent_session_runs <= 0) {
           return false;
         }

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -33,7 +33,6 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(OrtEnv* env, std::random_device& 
                                                const TestModelInfo* m)
     : rand_engine_(rd()), input_names_(m->GetInputCount()), input_length_(m->GetInputCount()) {
   SessionOptionsWrapper sf(env);
-  const bool enable_cpu_mem_arena = true;
   const std::string& provider_name = performance_test_config.machine_config.provider_type_name;
   if (provider_name == onnxruntime::kMklDnnExecutionProvider) {
 #ifdef USE_MKLDNN
@@ -70,10 +69,15 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(OrtEnv* env, std::random_device& 
     ORT_THROW("This backend is not included in perf test runner.\n");
   }
 
-  if (enable_cpu_mem_arena)
+  if (performance_test_config.run_config.enable_cpu_mem_arena)
     sf.EnableCpuMemArena();
   else
     sf.DisableCpuMemArena();
+  if (performance_test_config.run_config.enable_memory_pattern &&
+      performance_test_config.run_config.enable_sequential_execution)
+    sf.EnableMemPattern();
+  else
+    sf.DisableMemPattern();
   if (performance_test_config.run_config.enable_sequential_execution)
     sf.EnableSequentialExecution();
   else

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -36,7 +36,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(OrtEnv* env, std::random_device& 
   const std::string& provider_name = performance_test_config.machine_config.provider_type_name;
   if (provider_name == onnxruntime::kMklDnnExecutionProvider) {
 #ifdef USE_MKLDNN
-    ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_Mkldnn(sf, enable_cpu_mem_arena ? 1 : 0));
+    ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_Mkldnn(sf, performance_test_config.run_config.enable_cpu_mem_arena ? 1 : 0));
 #else
     ORT_THROW("MKL-DNN is not supported in this build\n");
 #endif

--- a/onnxruntime/test/perftest/test_configuration.h
+++ b/onnxruntime/test/perftest/test_configuration.h
@@ -41,6 +41,8 @@ struct RunConfig {
   size_t concurrent_session_runs{1};
   bool f_dump_statistics{false};
   bool f_verbose{false};
+  bool enable_memory_pattern{true};
+  bool enable_cpu_mem_arena{true};
   bool enable_sequential_execution{true};
   int session_thread_pool_size{0};
   uint32_t optimization_level{2};


### PR DESCRIPTION
The '-M' option is required for the [BiDAF](https://github.com/onnx/models/tree/master/bidaf) model