### PR TITLE
Remove path change in build.py

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -737,7 +737,6 @@ def main():
     os.makedirs(build_dir, exist_ok=True)
 
     log.info("Build started")
-    os.environ["PATH"] = os.environ["PATH"] + os.pathsep + os.path.dirname(sys.executable)
     if (args.update):
         cmake_extra_args = []
         if(is_windows()):


### PR DESCRIPTION
First, we don't need this line of code.
Second, it may change path unintentionally. That, you want to use gcc from /usr/lib/ccache/gcc, but cmake pickup it from /usr/bin.
