### PR TITLE
Test session - Check thread pool size isn't default before setting

### DIFF
--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -79,7 +79,9 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
   else
     session_options.DisableSequentialExecution();
   fprintf(stdout, "Setting thread pool size to %d\n", performance_test_config.run_config.session_thread_pool_size);
-  session_options.SetThreadPoolSize(performance_test_config.run_config.session_thread_pool_size);
+  // Don't set the thread pool size unless it has been changed from our zero default value (as zero will fail)
+  if (performance_test_config.run_config.session_thread_pool_size != 0)
+    session_options.SetThreadPoolSize(performance_test_config.run_config.session_thread_pool_size);
   // Set optimization level.
   session_options.SetGraphOptimizationLevel(performance_test_config.run_config.optimization_level);
   if (!performance_test_config.run_config.profile_file.empty())


### PR DESCRIPTION
The new C++ wrappers check all return values, previously we were setting the size to '0' and it was ignoring the failure code.

The default value is zero, but if the thread pool is set to size zero it will fail.