### PR TITLE
Raise max request size in ORT server

### DIFF
--- a/onnxruntime/server/http/core/session.cc
+++ b/onnxruntime/server/http/core/session.cc
@@ -18,7 +18,7 @@ void HttpSession::DoRead() {
   req_.emplace();
 
   // TODO: make the max request size configable.
-  req_->body_limit(10 * 1024 * 1024);  // Max request size: 10 MiB
+  req_->body_limit(25 * 1024 * 1024);  // Max request size: 25 MiB
 
   http::async_read(socket_, buffer_, *req_,
                    net::bind_executor(


### PR DESCRIPTION
Building a notebook to demo the usage of ORT server to host the SSD model. The SSD model takes an input of size 1 * 3 * 1200 * 1200 ( * 4 bytes ) = 17 MB approx. So raise the ceiling a bit more to quickly unblock. As the TODO indicates, there are plans to make this configurable in the future.