### PR TITLE
Implementation of sparse tensor

### DIFF
--- a/include/onnxruntime/core/framework/data_types.h
+++ b/include/onnxruntime/core/framework/data_types.h
@@ -456,7 +456,7 @@ class SparseTensorType : public SparseTensorTypeBase {
  private:
   SparseTensorType() {
     using namespace data_types_internal;
-    TensorContainedTypeSetter<elemT>::SetSparseTensorElementType(this->mutable_type_proto());
+    TensorContainedTypeSetter<elemT>::SetSparseTensorElementType(mutable_type_proto());
   }
 };
 

--- a/include/onnxruntime/core/framework/data_types.h
+++ b/include/onnxruntime/core/framework/data_types.h
@@ -37,6 +37,10 @@ using VectorMapInt64ToFloat = std::vector<MapInt64ToFloat>;
 
 class DataTypeImpl;
 class TensorTypeBase;
+class SparseTensorTypeBase;
+class MLValue;
+class Tensor;
+class SparseTensor;
 
 // MLFloat16
 union MLFloat16 {
@@ -122,8 +126,8 @@ inline bool operator!=(const BFloat16& left, const BFloat16& right) {
 // DataTypeImpl pointer as unique DataTypeImpl identifier.
 using MLDataType = const DataTypeImpl*;
 // be used with class MLValue
-using DeleteFunc = void(*)(void*);
-using CreateFunc = void*(*)();
+using DeleteFunc = void (*)(void*);
+using CreateFunc = void* (*)();
 
 /**
  * \brief Base class for MLDataType
@@ -146,6 +150,11 @@ class DataTypeImpl {
 
   virtual DeleteFunc GetDeleteFunc() const = 0;
 
+  virtual CreateFunc GetCreateFunc() const {
+    //
+    ORT_NOT_IMPLEMENTED(__FUNCTION__, " is not implemented");
+  }
+
   /**
    * \brief Retrieves an instance of TypeProto for
    *        a given MLDataType
@@ -158,8 +167,17 @@ class DataTypeImpl {
     return false;
   }
 
+  virtual bool IsSparseTensorType() const {
+    return false;
+  }
+
   // Returns this if this is of tensor-type and null otherwise
   virtual const TensorTypeBase* AsTensorType() const {
+    return nullptr;
+  }
+
+  // Returns this if this is of sparse-tensor-type and null otherwise
+  virtual const SparseTensorTypeBase* AsSparseTensorType() const {
     return nullptr;
   }
 
@@ -171,6 +189,10 @@ class DataTypeImpl {
   template <typename elemT>
   static MLDataType GetTensorType();
 
+  // Return the MLDataType for a concrete sparse tensor type.
+  template <typename elemT>
+  static MLDataType GetSparseTensorType();
+
   /**
    * Convert an ONNX TypeProto to onnxruntime DataTypeImpl.
    * However, this conversion is lossy. Don't try to use 'this->GetTypeProto()' converting it back
@@ -180,6 +202,8 @@ class DataTypeImpl {
   static MLDataType TypeFromProto(const ONNX_NAMESPACE::TypeProto& proto);
 
   static const TensorTypeBase* TensorTypeFromONNXEnum(int type);
+  static const SparseTensorTypeBase* SparseTensorTypeFromONNXEnum(int type);
+
   static const char* ToString(MLDataType type);
   // Registers ONNX_NAMESPACE::DataType (internalized string) with
   // MLDataType. DataType is produced by internalizing an instance of
@@ -233,6 +257,15 @@ template <typename T>
 struct IsTensorContainedType : public IsAnyOf<T, float, uint8_t, int8_t, uint16_t, int16_t,
                                               int32_t, int64_t, std::string, bool, MLFloat16,
                                               double, uint32_t, uint64_t, BFloat16> {
+};
+
+/// Use "IsSparseTensorContainedType<T>::value" to test if a type T
+/// is permitted as the element-type of a sparse-tensor.
+
+template <typename T>
+struct IsSparseTensorContainedType : public IsAnyOf<T, float, uint8_t, int8_t, uint16_t, int16_t,
+                                                    int32_t, int64_t, bool, MLFloat16,
+                                                    double, uint32_t, uint64_t, BFloat16> {
 };
 
 /// This template's Get() returns a corresponding MLDataType
@@ -375,6 +408,67 @@ class TensorType : public TensorTypeBase {
   }
 };
 
+/// Common base-class for all sparse-tensors (with different element types).
+class SparseTensorTypeBase : public DataTypeImpl {
+ public:
+  static MLDataType Type();
+
+  bool IsSparseTensorType() const override {
+    return true;
+  }
+
+  const SparseTensorTypeBase* AsSparseTensorType() const override {
+    return this;
+  }
+
+  bool IsCompatible(const ONNX_NAMESPACE::TypeProto& type_proto) const override;
+
+  size_t Size() const override;
+
+  DeleteFunc GetDeleteFunc() const override;
+  // CreateFunc GetCreateFunc() const override;
+
+  const ONNX_NAMESPACE::TypeProto* GetTypeProto() const override;
+
+  virtual MLDataType GetElementType() const {
+    // should never reach here.
+    ORT_NOT_IMPLEMENTED(__FUNCTION__, " is not implemented");
+  }
+
+  SparseTensorTypeBase(const SparseTensorTypeBase&) = delete;
+  SparseTensorTypeBase& operator=(const SparseTensorTypeBase&) = delete;
+
+ protected:
+  ONNX_NAMESPACE::TypeProto& mutable_type_proto();
+
+  SparseTensorTypeBase();
+  ~SparseTensorTypeBase() override;
+
+ private:
+  struct Impl;
+  Impl* impl_;
+};
+
+template <typename elemT>
+class SparseTensorType : public SparseTensorTypeBase {
+ public:
+  static_assert(data_types_internal::IsSparseTensorContainedType<elemT>::value,
+                "Requires one of the sparse-tensor fundamental types");
+
+  static MLDataType Type();
+
+  /// Return a MLDataType representing the element-type
+  MLDataType GetElementType() const override {
+    return DataTypeImpl::GetType<elemT>();
+  }
+
+ private:
+  SparseTensorType() {
+    using namespace data_types_internal;
+    TensorContainedTypeSetter<elemT>::SetSparseTensorElementType(this->mutable_type_proto());
+  }
+};
+
 /**
  * \brief Base type for all non-tensors, maps, sequences and opaques
  */
@@ -384,7 +478,7 @@ class NonTensorTypeBase : public DataTypeImpl {
 
   DeleteFunc GetDeleteFunc() const override = 0;
 
-  virtual CreateFunc GetCreateFunc() const = 0;
+  CreateFunc GetCreateFunc() const override = 0;
 
   const ONNX_NAMESPACE::TypeProto* GetTypeProto() const override;
 
@@ -558,6 +652,17 @@ class NonOnnxType : public DataTypeImpl {
   template <>                                           \
   MLDataType DataTypeImpl::GetTensorType<ELEM_TYPE>() { \
     return TensorType<ELEM_TYPE>::Type();               \
+  }
+
+#define ORT_REGISTER_SPARSE_TENSOR_TYPE(ELEM_TYPE)            \
+  template <>                                                 \
+  MLDataType SparseTensorType<ELEM_TYPE>::Type() {            \
+    static SparseTensorType<ELEM_TYPE> tensor_type;           \
+    return &tensor_type;                                      \
+  }                                                           \
+  template <>                                                 \
+  MLDataType DataTypeImpl::GetSparseTensorType<ELEM_TYPE>() { \
+    return SparseTensorType<ELEM_TYPE>::Type();               \
   }
 
 #define ORT_REGISTER_MAP(TYPE)               \

--- a/include/onnxruntime/core/framework/data_types.h
+++ b/include/onnxruntime/core/framework/data_types.h
@@ -38,9 +38,6 @@ using VectorMapInt64ToFloat = std::vector<MapInt64ToFloat>;
 class DataTypeImpl;
 class TensorTypeBase;
 class SparseTensorTypeBase;
-class MLValue;
-class Tensor;
-class SparseTensor;
 
 // MLFloat16
 union MLFloat16 {
@@ -149,11 +146,6 @@ class DataTypeImpl {
   virtual size_t Size() const = 0;
 
   virtual DeleteFunc GetDeleteFunc() const = 0;
-
-  virtual CreateFunc GetCreateFunc() const {
-    //
-    ORT_NOT_IMPLEMENTED(__FUNCTION__, " is not implemented");
-  }
 
   /**
    * \brief Retrieves an instance of TypeProto for
@@ -426,7 +418,6 @@ class SparseTensorTypeBase : public DataTypeImpl {
   size_t Size() const override;
 
   DeleteFunc GetDeleteFunc() const override;
-  // CreateFunc GetCreateFunc() const override;
 
   const ONNX_NAMESPACE::TypeProto* GetTypeProto() const override;
 
@@ -478,7 +469,7 @@ class NonTensorTypeBase : public DataTypeImpl {
 
   DeleteFunc GetDeleteFunc() const override = 0;
 
-  CreateFunc GetCreateFunc() const override = 0;
+  virtual CreateFunc GetCreateFunc() const = 0;
 
   const ONNX_NAMESPACE::TypeProto* GetTypeProto() const override;
 

--- a/include/onnxruntime/core/framework/op_kernel.h
+++ b/include/onnxruntime/core/framework/op_kernel.h
@@ -104,6 +104,11 @@ class OpKernelContext {
   // Return nullptr if the output is an unused optional output.
   Tensor* Output(int index, const TensorShape& shape);
 
+  // Fetch a sparse-tensor output corresponding to the specified index.
+  // num_values must specify the number of non-zero values (commonly known as NNZ/nnz),
+  // and shape must specify the shape of the underlying dense-tensor.
+  // Memory allocation for the output may happen when this method is invoked,
+  // unless static optimization pre-allocates it.
   SparseTensor* Output(int index, size_t num_values, const TensorShape& shape);
 
   const logging::Logger& Logger() const {
@@ -163,6 +168,8 @@ class OpKernelContext {
   OrtValue* GetOutputMLValue(int index);
 
   // Creates the OrtValue* based on the shape, if it does not exist
+  // The parameter nnz is used only for sparse-tensors and indicates the
+  // number of non-zero values (the number of elements in the values buffer allocated).
   OrtValue* OutputMLValue(int index, const TensorShape& shape, size_t nnz = 0);
 
  private:

--- a/include/onnxruntime/core/framework/op_kernel.h
+++ b/include/onnxruntime/core/framework/op_kernel.h
@@ -14,6 +14,7 @@
 #include "core/framework/op_kernel_info.h"
 #include "core/framework/op_node_proto_helper.h"
 #include "core/framework/tensor.h"
+#include "core/framework/sparse_tensor.h"
 #include "core/graph/constants.h"
 #include "core/graph/graph_viewer.h"
 #include "gsl/span"
@@ -103,6 +104,8 @@ class OpKernelContext {
   // Return nullptr if the output is an unused optional output.
   Tensor* Output(int index, const TensorShape& shape);
 
+  SparseTensor* Output(int index, size_t num_values, const TensorShape& shape);
+
   const logging::Logger& Logger() const {
     return *logger_;
   }
@@ -158,7 +161,9 @@ class OpKernelContext {
   const OrtValue* GetInputMLValue(int index) const;
   const OrtValue* GetImplicitInputMLValue(int index) const;
   OrtValue* GetOutputMLValue(int index);
-  OrtValue* OutputMLValue(int index, const TensorShape& shape);  // Creates the OrtValue* based on the shape, if it does not exist
+
+  // Creates the OrtValue* based on the shape, if it does not exist
+  OrtValue* OutputMLValue(int index, const TensorShape& shape, size_t nnz = 0);
 
  private:
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(OpKernelContext);

--- a/include/onnxruntime/core/framework/sparse_tensor.h
+++ b/include/onnxruntime/core/framework/sparse_tensor.h
@@ -1,0 +1,74 @@
+#pragma once
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/framework/data_types.h"
+#include "core/framework/tensor_shape.h"
+#include "core/framework/tensor.h"
+
+using namespace onnxruntime::common;
+
+namespace onnxruntime {
+
+/**
+ * @brief This class implements SparseTensor. 
+ * We represent a SparseTensor as a triple <values, indices, shape>. "values" and "indices" themselves
+ * are implemented as Tensors. 
+ * We follow the Tensor design for memory ownership/management: a sparse-tensor does not own the "value"
+ * or "indices" tensors.
+ */
+
+class SparseTensor final {
+ public:
+  SparseTensor(MLDataType elt_type,
+               const TensorShape& shape,
+               size_t nnz,
+               void* values_data,
+               void* indices_data,
+               const OrtAllocatorInfo& allocator_info);
+
+  SparseTensor(MLDataType elt_type,
+               const TensorShape& shape,
+               size_t nnz,
+               std::shared_ptr<IAllocator> allocator);
+
+  ~SparseTensor() = default;
+
+  // For now, disallow all copy, assignment, and move.
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(SparseTensor);
+
+  // Returns the number of entries in the values tensor (aka "NNZ" or "number of nonzero values")
+  size_t NumValues() const { return values_.Shape().Size(); }
+
+  const Tensor& Values() const {
+    return values_;
+  }
+
+  const Tensor& Indices() const {
+    return indices_;
+  }
+
+  const TensorShape& Shape() const {
+    return shape_;
+  }
+
+  Tensor& Values() {
+    return values_;
+  }
+
+  Tensor& Indices() {
+    return indices_;
+  }
+
+  TensorShape& Shape() {
+    return shape_;
+  }
+
+ private:
+  Tensor values_;
+  Tensor indices_;
+  TensorShape shape_;  // The shape of corresponding dense-tensor.
+};
+
+}  // namespace onnxruntime

--- a/include/onnxruntime/core/framework/sparse_tensor.h
+++ b/include/onnxruntime/core/framework/sparse_tensor.h
@@ -53,17 +53,17 @@ class SparseTensor final {
     return shape_;
   }
 
-  Tensor& Values() {
+  Tensor& MutableValues() {
     return values_;
   }
 
-  Tensor& Indices() {
+  Tensor& MutableIndices() {
     return indices_;
   }
 
-  TensorShape& Shape() {
-    return shape_;
-  }
+  //TensorShape& MutableShape() {
+  //  return shape_;
+  //}
 
  private:
   Tensor values_;

--- a/onnxruntime/core/framework/data_types.cc
+++ b/onnxruntime/core/framework/data_types.cc
@@ -414,10 +414,6 @@ DeleteFunc SparseTensorTypeBase::GetDeleteFunc() const {
   return &Delete<SparseTensor>;
 }
 
-//CreateFunc SparseTensorTypeBase::GetCreateFunc() const {
-//  return []() -> void* { return new SparseTensor(); };
-//}
-
 const ONNX_NAMESPACE::TypeProto* SparseTensorTypeBase::GetTypeProto() const {
   return impl_->GetProto();
 }

--- a/onnxruntime/core/framework/data_types.cc
+++ b/onnxruntime/core/framework/data_types.cc
@@ -726,7 +726,7 @@ const SparseTensorTypeBase* DataTypeImpl::SparseTensorTypeFromONNXEnum(int type)
     case TensorProto_DataType_BFLOAT16:
       return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<BFloat16>());
     default:
-      ORT_NOT_IMPLEMENTED("tensor type ", type, " is not supported");
+      ORT_NOT_IMPLEMENTED("sparse tensor type ", type, " is not supported");
   }
 }
 

--- a/onnxruntime/core/framework/data_types.cc
+++ b/onnxruntime/core/framework/data_types.cc
@@ -3,6 +3,7 @@
 
 #include "core/framework/data_types.h"
 #include "core/framework/tensor.h"
+#include "core/framework/sparse_tensor.h"
 #include "core/graph/onnx_protobuf.h"
 
 #ifdef __GNUC__
@@ -16,11 +17,19 @@
 #endif
 
 using namespace ONNX_NAMESPACE;
+
 namespace onnxruntime {
 
+// Return the MLDataType used for a generic Tensor
 template <>
 MLDataType DataTypeImpl::GetType<Tensor>() {
   return TensorTypeBase::Type();
+}
+
+// Return the MLDataType used for a generic SparseTensor
+template <>
+MLDataType DataTypeImpl::GetType<SparseTensor>() {
+  return SparseTensorTypeBase::Type();
 }
 
 static bool IsTensorTypeScalar(const ONNX_NAMESPACE::TypeProto_Tensor& tensor_type_proto) {
@@ -94,6 +103,9 @@ template <typename T>
 struct TensorContainedTypeSetter<T> {
   static void SetTensorElementType(ONNX_NAMESPACE::TypeProto& proto) {
     proto.mutable_tensor_type()->set_elem_type(ToTensorDataType<T>());
+  }
+  static void SetSparseTensorElementType(ONNX_NAMESPACE::TypeProto& proto) {
+    proto.mutable_sparse_tensor_type()->set_elem_type(ToTensorDataType<T>());
   }
   static void SetMapKeyType(ONNX_NAMESPACE::TypeProto& proto) {
     proto.mutable_map_type()->set_key_type(ToTensorDataType<T>());
@@ -369,6 +381,56 @@ MLDataType TensorTypeBase::Type() {
   return &tensor_base;
 }
 
+/// SparseTensor
+
+struct SparseTensorTypeBase::Impl : public data_types_internal::TypeProtoImpl {
+};
+
+SparseTensorTypeBase::SparseTensorTypeBase() : impl_(new Impl()) {}
+SparseTensorTypeBase::~SparseTensorTypeBase() {
+  delete impl_;
+}
+
+bool SparseTensorTypeBase::IsCompatible(const ONNX_NAMESPACE::TypeProto& type_proto) const {
+  const auto* thisProto = GetTypeProto();
+  if (&type_proto == thisProto) {
+    return true;
+  }
+  if (type_proto.value_case() != TypeProto::ValueCase::kSparseTensorType) {
+    return false;
+  }
+
+  ORT_ENFORCE(thisProto->value_case() == TypeProto::ValueCase::kSparseTensorType);
+  ORT_ENFORCE(thisProto->sparse_tensor_type().has_elem_type());
+
+  return data_types_internal::IsCompatible(thisProto->sparse_tensor_type(), type_proto.sparse_tensor_type());
+}
+
+size_t SparseTensorTypeBase::Size() const {
+  return sizeof(SparseTensor);
+}
+
+DeleteFunc SparseTensorTypeBase::GetDeleteFunc() const {
+  return &Delete<SparseTensor>;
+}
+
+//CreateFunc SparseTensorTypeBase::GetCreateFunc() const {
+//  return []() -> void* { return new SparseTensor(); };
+//}
+
+const ONNX_NAMESPACE::TypeProto* SparseTensorTypeBase::GetTypeProto() const {
+  return impl_->GetProto();
+}
+
+ONNX_NAMESPACE::TypeProto& SparseTensorTypeBase::mutable_type_proto() {
+  return impl_->mutable_type_proto();
+}
+
+MLDataType SparseTensorTypeBase::Type() {
+  static SparseTensorTypeBase sparse_tensor_base;
+  return &sparse_tensor_base;
+}
+
 /// NoTensorTypeBase
 struct NonTensorTypeBase::Impl : public data_types_internal::TypeProtoImpl {};
 
@@ -443,6 +505,21 @@ ORT_REGISTER_TENSOR_TYPE(uint64_t);
 ORT_REGISTER_TENSOR_TYPE(MLFloat16);
 ORT_REGISTER_TENSOR_TYPE(BFloat16);
 
+ORT_REGISTER_SPARSE_TENSOR_TYPE(int32_t);
+ORT_REGISTER_SPARSE_TENSOR_TYPE(float);
+ORT_REGISTER_SPARSE_TENSOR_TYPE(bool);
+// ORT_REGISTER_SPARSE_TENSOR_TYPE(std::string);
+ORT_REGISTER_SPARSE_TENSOR_TYPE(int8_t);
+ORT_REGISTER_SPARSE_TENSOR_TYPE(uint8_t);
+ORT_REGISTER_SPARSE_TENSOR_TYPE(uint16_t);
+ORT_REGISTER_SPARSE_TENSOR_TYPE(int16_t);
+ORT_REGISTER_SPARSE_TENSOR_TYPE(int64_t);
+ORT_REGISTER_SPARSE_TENSOR_TYPE(double);
+ORT_REGISTER_SPARSE_TENSOR_TYPE(uint32_t);
+ORT_REGISTER_SPARSE_TENSOR_TYPE(uint64_t);
+ORT_REGISTER_SPARSE_TENSOR_TYPE(MLFloat16);
+ORT_REGISTER_SPARSE_TENSOR_TYPE(BFloat16);
+
 ORT_REGISTER_MAP(MapStringToString);
 ORT_REGISTER_MAP(MapStringToInt64);
 ORT_REGISTER_MAP(MapStringToFloat);
@@ -465,6 +542,12 @@ ORT_REGISTER_SEQ(VectorMapInt64ToFloat);
   {                                                          \
     MLDataType mltype = DataTypeImpl::GetTensorType<TYPE>(); \
     reg_fn(mltype);                                          \
+  }
+
+#define REGISTER_SPARSE_TENSOR_PROTO(TYPE, reg_fn)                 \
+  {                                                                \
+    MLDataType mltype = DataTypeImpl::GetSparseTensorType<TYPE>(); \
+    reg_fn(mltype);                                                \
   }
 
 #define REGISTER_ONNX_PROTO(TYPE, reg_fn)              \
@@ -490,6 +573,21 @@ void RegisterAllProtos(const std::function<void(MLDataType)>& reg_fn) {
   REGISTER_TENSOR_PROTO(uint64_t, reg_fn);
   REGISTER_TENSOR_PROTO(MLFloat16, reg_fn);
   REGISTER_TENSOR_PROTO(BFloat16, reg_fn);
+
+  REGISTER_SPARSE_TENSOR_PROTO(int32_t, reg_fn);
+  REGISTER_SPARSE_TENSOR_PROTO(float, reg_fn);
+  REGISTER_SPARSE_TENSOR_PROTO(bool, reg_fn);
+  // REGISTER_SPARSE_TENSOR_PROTO(std::string, reg_fn);
+  REGISTER_SPARSE_TENSOR_PROTO(int8_t, reg_fn);
+  REGISTER_SPARSE_TENSOR_PROTO(uint8_t, reg_fn);
+  REGISTER_SPARSE_TENSOR_PROTO(uint16_t, reg_fn);
+  REGISTER_SPARSE_TENSOR_PROTO(int16_t, reg_fn);
+  REGISTER_SPARSE_TENSOR_PROTO(int64_t, reg_fn);
+  REGISTER_SPARSE_TENSOR_PROTO(double, reg_fn);
+  REGISTER_SPARSE_TENSOR_PROTO(uint32_t, reg_fn);
+  REGISTER_SPARSE_TENSOR_PROTO(uint64_t, reg_fn);
+  REGISTER_SPARSE_TENSOR_PROTO(MLFloat16, reg_fn);
+  REGISTER_SPARSE_TENSOR_PROTO(BFloat16, reg_fn);
 
   REGISTER_ONNX_PROTO(MapStringToString, reg_fn);
   REGISTER_ONNX_PROTO(MapStringToInt64, reg_fn);
@@ -601,6 +699,41 @@ const TensorTypeBase* DataTypeImpl::TensorTypeFromONNXEnum(int type) {
   }
 }
 
+const SparseTensorTypeBase* DataTypeImpl::SparseTensorTypeFromONNXEnum(int type) {
+  switch (type) {
+    case TensorProto_DataType_FLOAT:
+      return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<float>());
+    case TensorProto_DataType_BOOL:
+      return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<bool>());
+    case TensorProto_DataType_INT32:
+      return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<int32_t>());
+    case TensorProto_DataType_DOUBLE:
+      return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<double>());
+    // case TensorProto_DataType_STRING:
+    // return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<std::string>());
+    case TensorProto_DataType_UINT8:
+      return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<uint8_t>());
+    case TensorProto_DataType_UINT16:
+      return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<uint16_t>());
+    case TensorProto_DataType_INT8:
+      return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<int8_t>());
+    case TensorProto_DataType_INT16:
+      return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<int16_t>());
+    case TensorProto_DataType_INT64:
+      return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<int64_t>());
+    case TensorProto_DataType_UINT32:
+      return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<uint32_t>());
+    case TensorProto_DataType_UINT64:
+      return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<uint64_t>());
+    case TensorProto_DataType_FLOAT16:
+      return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<MLFloat16>());
+    case TensorProto_DataType_BFLOAT16:
+      return reinterpret_cast<const SparseTensorTypeBase*>(DataTypeImpl::GetSparseTensorType<BFloat16>());
+    default:
+      ORT_NOT_IMPLEMENTED("tensor type ", type, " is not supported");
+  }
+}
+
 MLDataType DataTypeImpl::TypeFromProto(const ONNX_NAMESPACE::TypeProto& proto) {
   const auto& registry = data_types_internal::DataTypeRegistry::instance();
 
@@ -610,6 +743,11 @@ MLDataType DataTypeImpl::TypeFromProto(const ONNX_NAMESPACE::TypeProto& proto) {
       ORT_ENFORCE(tensor_type.has_elem_type());
       return TensorTypeFromONNXEnum(tensor_type.elem_type());
     } break;  // kTensorType
+    case TypeProto::ValueCase::kSparseTensorType: {
+      const auto& sparse_tensor_type = proto.sparse_tensor_type();
+      ORT_ENFORCE(sparse_tensor_type.has_elem_type());
+      return SparseTensorTypeFromONNXEnum(sparse_tensor_type.elem_type());
+    } break;  // kSparseTensorType
     case TypeProto::ValueCase::kMapType: {
       const auto& maptype = proto.map_type();
       auto keytype = maptype.key_type();

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -44,7 +44,9 @@ OrtValue* IExecutionFrame::GetMutableNodeInputOrOutputMLValue(int index) {
 // TO DO: make it thread safe
 // This method is not thread safe!
 // Return S_OK and nullptr if index map to an value that is an unused optional input/output
-Status IExecutionFrame::GetOrCreateNodeOutputMLValue(int index, const TensorShape* shape, OrtValue*& p_ort_value) {
+
+Status IExecutionFrame::GetOrCreateNodeOutputMLValue(int index, const TensorShape* shape, OrtValue*& p_ort_value,
+                                                     size_t nnz) {
   auto status = Status::OK();
   int ort_value_idx = GetNodeIdxToMLValueIdx(index);
 
@@ -63,7 +65,7 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(int index, const TensorShap
                     " Requested shape:", shape ? shape->ToString() : "null");
       }
     } else {
-      status = CreateNodeOutputMLValueImpl(*p_ort_value, ort_value_idx, shape);
+      status = CreateNodeOutputMLValueImpl(*p_ort_value, ort_value_idx, shape, nnz);
     }
   }
 
@@ -340,8 +342,27 @@ static Status AllocateTraditionalMLValue(OrtValue& ort_value, const NonTensorTyp
   return Status::OK();
 }
 
+static Status AllocateSparseTensor(MLValue& mlvalue, const DataTypeImpl& ml_type, AllocatorPtr allocator,
+                                   const TensorShape& shape, size_t nnz, bool create_fence,
+                                   const SessionState& session_state) {
+  auto element_type = ml_type.AsSparseTensorType()->GetElementType();
+  auto sparse = std::make_unique<SparseTensor>(element_type, shape, nnz, allocator);
+  auto deleter = DataTypeImpl::GetType<SparseTensor>()->GetDeleteFunc();
+  mlvalue.Init(sparse.release(), DataTypeImpl::GetType<SparseTensor>(), deleter);
+
+  // create fence if needed
+  if (create_fence) {
+    ORT_ENFORCE(mlvalue.Fence() == nullptr);
+    FencePtr f = allocator->CreateFence(&session_state);
+    mlvalue.SetFence(f);
+  }
+
+  return Status::OK();
+}
+
 // This method is not thread safe!
-Status ExecutionFrame::AllocateAsPerAllocationPlan(OrtValue& ort_value, int ort_value_index, const TensorShape* shape) {
+Status ExecutionFrame::AllocateAsPerAllocationPlan(OrtValue& ort_value, int ort_value_index, const TensorShape* shape,
+                                                   size_t nnz) {
   // if there is a custom allocator for this ort_value_index, call it to do the allocation
   auto custom_alloc_entry = custom_allocators_.find(ort_value_index);
   if (custom_alloc_entry != custom_allocators_.cend()) {
@@ -361,6 +382,10 @@ Status ExecutionFrame::AllocateAsPerAllocationPlan(OrtValue& ort_value, int ort_
         ONNXRUNTIME, INVALID_ARGUMENT,
         "Tried to allocate without valid type information, ort_value index=" + std::to_string(ort_value_index));
 
+  if (ml_type->IsSparseTensorType()) {
+    return AllocateSparseTensor(ort_value, *ml_type, GetAllocator(alloc_info),
+                                *shape, nnz, per_alloc_plan.create_fence_if_async, session_state_);
+  }
   if (!ml_type->IsTensorType()) {
     return AllocateTraditionalMLValue(ort_value, *static_cast<const NonTensorTypeBase*>(ml_type));
   }
@@ -408,8 +433,8 @@ AllocatorPtr ExecutionFrame::GetAllocatorImpl(const OrtAllocatorInfo& info) cons
 
 // This method is not thread safe!
 // Return S_OK and nullptr if index map to an value that is an unused optional input/output
-Status ExecutionFrame::CreateNodeOutputMLValueImpl(OrtValue& ort_value, int ort_value_idx, const TensorShape* shape) {
-  return AllocateAsPerAllocationPlan(ort_value, ort_value_idx, shape);
+Status ExecutionFrame::CreateNodeOutputMLValueImpl(OrtValue& ort_value, int ort_value_idx, const TensorShape* shape, size_t nnz) {
+  return AllocateAsPerAllocationPlan(ort_value, ort_value_idx, shape, nnz);
 }
 
 Status ExecutionFrame::ReleaseMLValueImpl(int ort_value_idx) {

--- a/onnxruntime/core/framework/execution_frame.h
+++ b/onnxruntime/core/framework/execution_frame.h
@@ -46,7 +46,7 @@ class IExecutionFrame {
   // This method is not thread safe!
   // Return S_OK and nullptr if index map to an value that is an unused optional input/output
   // Shape is required for tensors but not traditional ML values.
-  Status GetOrCreateNodeOutputMLValue(int index, const TensorShape* shape, OrtValue*& p_ort_value);
+  Status GetOrCreateNodeOutputMLValue(int index, const TensorShape* shape, OrtValue*& p_ort_value, size_t nnz = 0);
 
   /**
    * write the output values to the 'fetches' vector
@@ -82,7 +82,8 @@ class IExecutionFrame {
   }
 
   virtual AllocatorPtr GetAllocatorImpl(const OrtAllocatorInfo& info) const = 0;
-  virtual Status CreateNodeOutputMLValueImpl(OrtValue& ort_value, int ort_value_idx, const TensorShape* shape) = 0;
+
+  virtual Status CreateNodeOutputMLValueImpl(OrtValue& ort_value, int ort_value_idx, const TensorShape* shape, size_t nnz) = 0;
 
   const NodeIndexInfo& node_index_info_;
 
@@ -126,9 +127,10 @@ class ExecutionFrame final : public IExecutionFrame {
 
   AllocatorPtr GetAllocatorImpl(const OrtAllocatorInfo& info) const override;
   Status ReleaseMLValueImpl(int ort_value_idx) override;
-  Status CreateNodeOutputMLValueImpl(OrtValue& ort_value, int ort_value_idx, const TensorShape* shape) override;
+  Status CreateNodeOutputMLValueImpl(OrtValue& ort_value, int ort_value_idx, const TensorShape* shape, size_t nnz) override;
 
-  common::Status AllocateAsPerAllocationPlan(OrtValue& ort_value, int ort_value_index, const TensorShape* shape);
+  common::Status AllocateAsPerAllocationPlan(OrtValue& ort_value, int ort_value_index, const TensorShape* shape,
+                                             size_t nnz);
 
   Status AllocateMLValueTensorSelfOwnBufferHelper(OrtValue& ort_value, int ort_value_index, MLDataType element_type,
                                                   const OrtAllocatorInfo& location, const TensorShape& shape,

--- a/onnxruntime/core/framework/op_kernel.cc
+++ b/onnxruntime/core/framework/op_kernel.cc
@@ -28,7 +28,12 @@ Tensor* OpKernelContext::Output(int index, const TensorShape& shape) {
   return p_ml_value ? p_ml_value->GetMutable<Tensor>() : nullptr;
 }
 
-OrtValue* OpKernelContext::OutputMLValue(int index, const TensorShape& shape) {
+SparseTensor* OpKernelContext::Output(int index, size_t nnz, const TensorShape& shape) {
+  auto p_ml_value = OutputMLValue(index, shape, nnz);
+  return p_ml_value ? p_ml_value->GetMutable<SparseTensor>() : nullptr;
+}
+
+OrtValue* OpKernelContext::OutputMLValue(int index, const TensorShape& shape, size_t nnz) {
   if (index < 0 || index >= OutputCount())
     return nullptr;
 
@@ -36,8 +41,9 @@ OrtValue* OpKernelContext::OutputMLValue(int index, const TensorShape& shape) {
   //"error: 'ret' may be used uninitialized in this function"
   //This warning only exists in Release build.
   //I believe it's a false alarm.
+
   OrtValue* p_ml_value = nullptr;
-  Status status = execution_frame_->GetOrCreateNodeOutputMLValue(GetOutputArgIndex(index), &shape, p_ml_value);
+  Status status = execution_frame_->GetOrCreateNodeOutputMLValue(GetOutputArgIndex(index), &shape, p_ml_value, nnz);
   ORT_ENFORCE(status.IsOK(), status.ErrorMessage());
   return p_ml_value;
 }

--- a/onnxruntime/core/framework/sparse_tensor.cc
+++ b/onnxruntime/core/framework/sparse_tensor.cc
@@ -14,20 +14,20 @@ SparseTensor::SparseTensor(MLDataType elt_type,
                            void* values_data,
                            void* indices_data,
                            const OrtAllocatorInfo& allocator_info)
-    : shape_(shape),
-      values_(elt_type, TensorShape({static_cast<int64_t>(nnz)}), values_data, allocator_info, 0),
+    : values_(elt_type, TensorShape({static_cast<int64_t>(nnz)}), values_data, allocator_info, 0),
       indices_(DataTypeImpl::GetType<int64_t>(),
                TensorShape({static_cast<int64_t>(nnz), static_cast<int64_t>(shape.NumDimensions())}),
-               indices_data, allocator_info, 0) {}
+               indices_data, allocator_info, 0),
+      shape_(shape) {}
 
 SparseTensor::SparseTensor(MLDataType elt_type,
                            const TensorShape& shape,
                            size_t nnz,
                            std::shared_ptr<IAllocator> allocator)
-    : shape_(shape),
-      values_(elt_type, TensorShape({static_cast<int64_t>(nnz)}), allocator, 0),
+    : values_(elt_type, TensorShape({static_cast<int64_t>(nnz)}), allocator, 0),
       indices_(DataTypeImpl::GetType<int64_t>(),
                TensorShape({static_cast<int64_t>(nnz), static_cast<int64_t>(shape.NumDimensions())}),
-               allocator, 0) {}
+               allocator, 0),
+      shape_(shape) {}
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/sparse_tensor.cc
+++ b/onnxruntime/core/framework/sparse_tensor.cc
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/framework/data_types.h"
+#include "core/framework/sparse_tensor.h"
+
+using namespace onnxruntime::common;
+
+namespace onnxruntime {
+
+SparseTensor::SparseTensor(MLDataType elt_type,
+                           const TensorShape& shape,
+                           size_t nnz,
+                           void* values_data,
+                           void* indices_data,
+                           const OrtAllocatorInfo& allocator_info)
+    : shape_(shape),
+      values_(elt_type, TensorShape({static_cast<int64_t>(nnz)}), values_data, allocator_info, 0),
+      indices_(DataTypeImpl::GetType<int64_t>(),
+               TensorShape({static_cast<int64_t>(nnz), static_cast<int64_t>(shape.NumDimensions())}),
+               indices_data, allocator_info, 0) {}
+
+SparseTensor::SparseTensor(MLDataType elt_type,
+                           const TensorShape& shape,
+                           size_t nnz,
+                           std::shared_ptr<IAllocator> allocator)
+    : shape_(shape),
+      values_(elt_type, TensorShape({static_cast<int64_t>(nnz)}), allocator, 0),
+      indices_(DataTypeImpl::GetType<int64_t>(),
+               TensorShape({static_cast<int64_t>(nnz), static_cast<int64_t>(shape.NumDimensions())}),
+               allocator, 0) {}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/optimizer_execution_frame.cc
+++ b/onnxruntime/core/optimizer/optimizer_execution_frame.cc
@@ -90,7 +90,7 @@ AllocatorPtr OptimizerExecutionFrame::GetAllocatorImpl(const OrtAllocatorInfo& i
 // This method is not thread safe!
 // Return S_OK and nullptr if index map to an value that is an unused optional input/output
 Status OptimizerExecutionFrame::CreateNodeOutputMLValueImpl(OrtValue& ort_value, int ort_value_idx,
-                                                            const TensorShape* shape) {
+                                                            const TensorShape* shape, size_t nnz) {
   const DataTypeImpl* ml_type = utils::GetMLDataType(*(info_.GetMLValueIdxNodeArgMap().at(ort_value_idx)));
   if (ml_type == nullptr)
     return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,

--- a/onnxruntime/core/optimizer/optimizer_execution_frame.cc
+++ b/onnxruntime/core/optimizer/optimizer_execution_frame.cc
@@ -95,6 +95,13 @@ Status OptimizerExecutionFrame::CreateNodeOutputMLValueImpl(OrtValue& ort_value,
   if (ml_type == nullptr)
     return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
                   "Tried to allocate without valid type information, ort_value index=" + std::to_string(ort_value_idx));
+  if (ml_type->IsSparseTensorType()) {
+    auto element_type = ml_type->AsSparseTensorType()->GetElementType();
+    auto container_type = DataTypeImpl::GetType<SparseTensor>();
+    auto sparse = std::make_unique<SparseTensor>(element_type, *shape, nnz, info_.GetAllocator());
+    ort_value.Init(sparse.release(), container_type, container_type->GetDeleteFunc());
+    return Status::OK();
+  }
   if (!ml_type->IsTensorType()) {
     const NonTensorTypeBase* non_tensor_type = static_cast<const NonTensorTypeBase*>(ml_type);
     auto creator = non_tensor_type->GetCreateFunc();

--- a/onnxruntime/core/optimizer/optimizer_execution_frame.h
+++ b/onnxruntime/core/optimizer/optimizer_execution_frame.h
@@ -79,7 +79,8 @@ class OptimizerExecutionFrame final : public IExecutionFrame {
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(OptimizerExecutionFrame);
 
   AllocatorPtr GetAllocatorImpl(const OrtAllocatorInfo& info) const override;
-  Status CreateNodeOutputMLValueImpl(OrtValue& ort_value, int ort_value_idx, const TensorShape* shape) override;
+
+  Status CreateNodeOutputMLValueImpl(OrtValue& ort_value, int ort_value_idx, const TensorShape* shape, size_t nnz) override;
 
   const Info& info_;
 };

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -332,6 +332,7 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph,
       std::ostringstream oss;
       oss << "Could not find an implementation for the node ";
       if (!node.Name().empty()) oss << node.Name() << ":";
+
       oss << node.OpType();
       if (node.Op()) {
         oss << "(" << node.Op()->since_version() << ")";

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -332,7 +332,6 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph,
       std::ostringstream oss;
       oss << "Could not find an implementation for the node ";
       if (!node.Name().empty()) oss << node.Name() << ":";
-
       oss << node.OpType();
       if (node.Op()) {
         oss << "(" << node.Op()->since_version() << ")";

--- a/onnxruntime/test/framework/sparse_kernels_test.cc
+++ b/onnxruntime/test/framework/sparse_kernels_test.cc
@@ -1,0 +1,489 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/framework/data_types.h"
+#include "onnx/defs/schema.h"
+#include "core/graph/constants.h"
+#include "core/framework/op_kernel.h"
+#include "core/framework/sparse_tensor.h"
+
+#include "core/graph/model.h"
+#include "core/session/inference_session.h"
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+#include "test_utils.h"
+
+using namespace ONNX_NAMESPACE;
+using namespace onnxruntime::common;
+
+namespace onnxruntime {
+namespace test {
+
+// op SparseFromCOO
+struct SparseFromCOO {
+  static std::string OpName() { return "SparseFromCOO"; };
+
+  static ONNX_NAMESPACE::OpSchema OpSchema() {
+    ONNX_NAMESPACE::OpSchema schema;
+    schema.SetDoc(R"DOC(
+This operator constructs a sparse tensor from three tensors that provide a COO
+(coordinate) representation.
+)DOC")
+        .Input(
+            0,
+            "values",
+            "A 1-dimensional tensor of shape [NNZ] that holds all non-zero values",
+            "T1",
+            OpSchema::Single)
+        .Input(
+            1,
+            "indices",
+            "A 2-dimensional tensor of shape [NNZ,d] that holds the (d) indices of non-zero values",
+            "T2",
+            OpSchema::Single)
+        .Input(
+            2,
+            "shape",
+            "A 1-dimensional tensor of shape [d] that holds the shape of the underlying dense tensor",
+            "T2",
+            OpSchema::Single)
+        .Output(
+            0,
+            "sparse_rep",
+            "A sparse representation of the tensor",
+            "T",
+            OpSchema::Single)
+        .TypeConstraint(
+            "T1",
+            {"tensor(int64)"},
+            "Type of the values (input tensor)")
+        .TypeConstraint(
+            "T2",
+            {"tensor(int64)"},
+            "Type of index tensor and shape")
+        .TypeConstraint(
+            "T",
+            {"sparse_tensor(int64)"},
+            "Output type");
+    return schema;
+  }
+
+  /**
+ *  @brief An implementation of the SparseFromCOO op.
+ */
+  class OpKernelImpl final : public OpKernel {
+   public:
+    OpKernelImpl(const OpKernelInfo& info) : OpKernel{info} {}
+
+    Status Compute(OpKernelContext* ctx) const override {
+      ORT_ENFORCE(ctx->InputCount() == 3, "Expecting 3 inputs");
+
+      const Tensor& values = *ctx->Input<Tensor>(0);
+      const Tensor& indices = *ctx->Input<Tensor>(1);
+      const Tensor& shape_tensor = *ctx->Input<Tensor>(2);
+
+      // values and indices should be 1-dimensional tensors
+      const TensorShape& val_shape = values.Shape();
+      const TensorShape& ind_shape = indices.Shape();
+      const TensorShape& shape_shape = shape_tensor.Shape();
+
+      auto nnz = val_shape.Size();
+      auto numdims = shape_shape.Size();
+
+      ORT_ENFORCE(val_shape.NumDimensions() == 1, "Values must be a 1-dimensional tensor.");
+
+      ORT_ENFORCE(ind_shape.NumDimensions() == 2, "Indices must be a 2-dimensional tensor.");
+      ORT_ENFORCE(ind_shape[0] == nnz, "Indices must have [NNZ,d] shape.");
+      ORT_ENFORCE(ind_shape[1] == numdims, "Indices must have [NNZ,d] shape.");
+
+      ORT_ENFORCE(shape_shape.NumDimensions() == 1, "Shape must be a 1-dimensional tensor.");
+
+      TensorShape shape(shape_tensor.Data<int64_t>(), shape_shape.Size());
+
+      SparseTensor* output = ctx->Output(0, static_cast<size_t>(nnz), shape);
+      ORT_ENFORCE(output != nullptr);
+
+      memcpy(output->Values().MutableData<int64_t>(), values.Data<int64_t>(), nnz * sizeof(int64_t));
+      memcpy(output->Indices().MutableData<int64_t>(), indices.Data<int64_t>(), nnz * numdims * sizeof(int64_t));
+      // output->Shape() = TensorShape(shape_tensor.Data<int64_t>(), shape_shape.Size());
+
+      return Status::OK();
+    }
+  };
+
+  static KernelDefBuilder KernelDef() {
+    KernelDefBuilder def;
+    def.SetName(SparseFromCOO::OpName())
+        .TypeConstraint("values", DataTypeImpl::GetTensorType<int64_t>())
+        .TypeConstraint("indices", DataTypeImpl::GetTensorType<int64_t>())
+        .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
+        .TypeConstraint("sparse_rep", DataTypeImpl::GetSparseTensorType<int64_t>());
+    return def;
+  }
+};
+
+// op SparseAbs
+struct SparseAbs {
+  static const std::string OpName() { return "SparseAbs"; };
+
+  // The ONNX schema for SparseAbs:
+  static ONNX_NAMESPACE::OpSchema OpSchema() {
+    ONNX_NAMESPACE::OpSchema schema;
+    schema.SetDoc(R"DOC(
+This operator applies the Abs op element-wise to the input sparse-tensor.
+)DOC")
+        .Input(
+            0,
+            "input",
+            "Input sparse tensor",
+            "T",
+            OpSchema::Single)
+        .Output(
+            0,
+            "output",
+            "Output sparse tensor",
+            "T",
+            OpSchema::Single)
+        .TypeConstraint(
+            "T",
+            {"sparse_tensor(int64)"},
+            "Input and Output type");
+    return schema;
+  }
+
+  // A kernel implementation of SparseAbs:
+  class OpKernelImpl final : public OpKernel {
+   public:
+    OpKernelImpl(const OpKernelInfo& info) : OpKernel{info} {}
+
+    Status Compute(OpKernelContext* ctx) const override {
+      ORT_ENFORCE(ctx->InputCount() == 1, "Expecting 1 input");
+
+      const SparseTensor* input = ctx->Input<SparseTensor>(0);
+      auto* input_values = input->Values().Data<int64_t>();
+      auto nnz = input->NumValues();
+      auto& shape = input->Shape();
+
+      // Allocate/get output-tensor:
+      SparseTensor* output = ctx->Output(0, nnz, shape);
+
+      // compute output values:
+      auto* output_values = output->Values().MutableData<int64_t>();
+      for (int i = 0; i < nnz; ++i)
+        output_values[i] = std::abs(input_values[i]);
+
+      // Currently, there is no way to share the indices/shape between two sparse-tensors.
+      // So, we copy indices/shape from input to output.
+      // TODO: Extend allocation-planner to enable such sharing.
+      const auto& input_indices = input->Indices();
+      auto num_indices = input_indices.Shape().Size();
+      memcpy(output->Indices().MutableData<int64_t>(), input_indices.Data<int64_t>(), num_indices * sizeof(int64_t));
+
+      output->Shape() = shape;
+
+      return Status::OK();
+    }
+  };
+
+  // A KernelDefBuilder for SparseAbs:
+  static KernelDefBuilder KernelDef() {
+    KernelDefBuilder def;
+    def.SetName(OpName())
+        .TypeConstraint("T", DataTypeImpl::GetSparseTensorType<int64_t>());
+    return def;
+  }
+};
+
+// op SparseToValues
+struct SparseToValues {
+  static const std::string OpName() { return "SparseToValues"; };
+
+  static ONNX_NAMESPACE::OpSchema OpSchema() {
+    ONNX_NAMESPACE::OpSchema schema;
+    schema.SetDoc("Return the non-zero values in a sparse tensor (as a dense tensor).")
+        .Input(
+            0,
+            "sparse_rep",
+            "Input sparse tensor.",
+            "T1",
+            OpSchema::Single)
+        .Output(
+            0,
+            "values",
+            "A single dimensional tensor that holds non-zero values in the input",
+            "T2",
+            OpSchema::Single)
+        .TypeConstraint(
+            "T1",
+            {"sparse_tensor(int64)"},
+            "Only int64 is allowed")
+        .TypeConstraint(
+            "T2",
+            {"tensor(int64)"},
+            "Type of the values component");
+    return schema;
+  }
+
+  //  A kernel implementation of SparseToValues
+  class OpKernelImpl final : public OpKernel {
+   public:
+    OpKernelImpl(const OpKernelInfo& info) : OpKernel{info} {}
+
+    Status Compute(OpKernelContext* ctx) const override {
+      ORT_ENFORCE(ctx->InputCount() == 1, "Expecting a single SparseTensorSample input");
+      const SparseTensor* sparse_input = ctx->Input<SparseTensor>(0);
+      const auto* values = sparse_input->Values().Data<int64_t>();
+      auto nnz = static_cast<int64_t>(sparse_input->NumValues());
+
+      TensorShape output_shape{nnz};
+
+      Tensor* output = ctx->Output(0, output_shape);
+      int64_t* output_data = output->MutableData<int64_t>();
+      ORT_ENFORCE(output_data != nullptr);
+
+      memcpy(output_data, values, nnz * sizeof(int64_t));
+
+      return Status::OK();
+    }
+  };
+
+  // A KernelDefBuilder for SparseToValues
+  static KernelDefBuilder KernelDef() {
+    KernelDefBuilder def;
+    def.SetName(OpName())
+        .TypeConstraint("sparse_rep", DataTypeImpl::GetSparseTensorType<int64_t>())
+        .TypeConstraint("values", DataTypeImpl::GetTensorType<int64_t>());
+    return def;
+  }
+};
+
+using Action = std::function<void(CustomRegistry*)>;
+
+class SparseTensorTests : public testing::Test {
+ public:
+  SparseTensorTests() : session_object(SessionOptions(), &DefaultLoggingManager()),
+                        registry(std::make_shared<CustomRegistry>()),
+                        custom_schema_registries_{registry->GetOpschemaRegistry()},
+                        domain_to_version{{onnxruntime::kMLDomain, 10}},
+                        model("SparseTensorTest", false, ModelMetaData(), custom_schema_registries_, domain_to_version),
+                        graph(model.MainGraph()) {
+    EXPECT_TRUE(session_object.RegisterCustomRegistry(registry).IsOK());
+  }
+
+  template <typename Op>
+  void Add() {
+    auto schema = Op::OpSchema();
+    schema.SetName(Op::OpName());
+    schema.SetDomain(onnxruntime::kMLDomain);
+    schema.SinceVersion(10);
+    schemas.push_back(schema);
+
+    Action register_kernel = [](CustomRegistry* registry) {
+      auto kernel_def_builder = Op::KernelDef();
+      kernel_def_builder
+          .SetDomain(onnxruntime::kMLDomain)
+          .SinceVersion(10)
+          .Provider(onnxruntime::kCpuExecutionProvider);
+      EXPECT_TRUE(registry->RegisterCustomKernel(kernel_def_builder, [](const OpKernelInfo& info) { return new Op::OpKernelImpl(info); }).IsOK());
+    };
+    register_actions.push_back(register_kernel);
+  }
+
+  template <typename Op1, typename Op2, typename... Ops>
+  void Add() {
+    Add<Op1>();
+    Add<Op2, Ops...>();
+  }
+
+  template <typename... Ops>
+  void RegisterOps() {
+    Add<Ops...>();
+    EXPECT_TRUE(registry->RegisterOpSet(schemas, onnxruntime::kMLDomain, 10, 11).IsOK());
+    for (auto registerop : register_actions)
+      registerop(registry.get());
+  }
+
+  void SerializeAndLoad() {
+    // Serialize model and deserialize it back
+    std::string serialized_model;
+    auto model_proto = model.ToProto();
+    EXPECT_TRUE(model_proto.SerializeToString(&serialized_model));
+    std::stringstream sstr(serialized_model);
+    EXPECT_TRUE(session_object.Load(sstr).IsOK());
+    EXPECT_TRUE(session_object.Initialize().IsOK());
+  }
+
+  NodeArg* Sparse(std::string name) {
+    types.push_back(*DataTypeImpl::GetSparseTensorType<int64_t>()->GetTypeProto());
+    auto& arg = graph.GetOrCreateNodeArg(name, &types.back());
+    return &arg;
+  }
+
+  NodeArg* Dense(std::string name) {
+    types.push_back(*DataTypeImpl::GetTensorType<int64_t>()->GetTypeProto());
+    auto& arg = graph.GetOrCreateNodeArg(name, &types.back());
+    return &arg;
+  }
+
+  void Node(std::string op, const std::vector<NodeArg*> inputs, const std::vector<NodeArg*> outputs) {
+    auto& node = graph.AddNode("", op, "", inputs, outputs, nullptr, onnxruntime::kMLDomain);
+    node.SetExecutionProviderType(onnxruntime::kCpuExecutionProvider);
+  }
+
+  MLValue Constant(const std::vector<int64_t>& elts) {
+    const std::vector<int64_t> shape{static_cast<int64_t>(elts.size())};
+    return Constant(elts, shape);
+  }
+
+  MLValue Constant(const std::vector<int64_t>& elts, const std::vector<int64_t>& shape) {
+    MLValue mlvalue;
+    CreateMLValue<int64_t>(TestCPUExecutionProvider()->GetAllocator(0, OrtMemTypeDefault), shape, elts, &mlvalue);
+    return mlvalue;
+  }
+
+  NameMLValMap feeds;
+
+  void AddInput(NodeArg* arg, const std::vector<int64_t>& value) {
+    feeds[arg->Name()] = Constant(value);
+  }
+
+  void AddInput(NodeArg* arg, const std::vector<int64_t>& value, const std::vector<int64_t>& shape) {
+    feeds[arg->Name()] = Constant(value, shape);
+  }
+
+  void ExpectEq(MLValue val1, MLValue val2) {
+    // Restricted to case where val1 and val2 are int64_t tensors
+    auto& tensor1 = val1.Get<Tensor>();
+    auto& tensor2 = val2.Get<Tensor>();
+    EXPECT_EQ(tensor1.Shape().Size(), tensor2.Shape().Size());
+    auto* data1 = tensor1.Data<int64_t>();
+    auto* data2 = tensor2.Data<int64_t>();
+    for (int64_t i = 0, limit = tensor1.Shape().Size(); i < limit; ++i) {
+      EXPECT_EQ(data1[i], data2[i]);
+    }
+  }
+
+  void ExpectEq(MLValue val1, const std::vector<int64_t>& data2) {
+    // Restricted to case where val1 is an int64_t tensor
+    auto& tensor1 = val1.Get<Tensor>();
+    EXPECT_EQ(static_cast<uint64_t>(tensor1.Shape().Size()), data2.size());
+    auto* data1 = tensor1.Data<int64_t>();
+    for (int64_t i = 0, limit = tensor1.Shape().Size(); i < limit; ++i) {
+      EXPECT_EQ(data1[i], data2[i]);
+    }
+  }
+
+  std::vector<std::string> output_names;
+  std::vector<MLValue> expected_output;
+
+  void ExpectOutput(NodeArg* arg, const std::vector<int64_t>& value) {
+    output_names.push_back(arg->Name());
+    expected_output.push_back(Constant(value));
+  }
+
+  void RunTest() {
+    RunOptions run_options;
+    std::vector<MLValue> fetches;
+
+    EXPECT_TRUE(session_object.Run(run_options, feeds, output_names, &fetches).IsOK());
+
+    ASSERT_EQ(expected_output.size(), fetches.size());
+    for (int i = 0; i < fetches.size(); ++i) {
+      ExpectEq(fetches[i], expected_output[i]);
+    }
+  }
+
+ protected:
+  std::vector<OpSchema> schemas;
+  std::vector<Action> register_actions;
+  std::shared_ptr<CustomRegistry> registry;
+  InferenceSession session_object;
+
+  IOnnxRuntimeOpSchemaRegistryList custom_schema_registries_;
+  std::unordered_map<std::string, int> domain_to_version;
+  Model model;
+  Graph& graph;
+
+  std::vector<TypeProto> types;
+};
+
+// Test ops SparseFromCOO, SparseAbs, and SparseToValues.
+// Tests 1-dimensional int64 sparse tensor.
+TEST_F(SparseTensorTests, Test1) {
+  // Register ops
+  RegisterOps<SparseFromCOO, SparseAbs, SparseToValues>();
+
+  // Build model/graph
+
+  // Node: create a sparse tensor from COO components:
+  // sparse1 <- SparseFromCOO(values, indices, shape)
+  auto values = Dense("values");     // a dense tensor containing non-zero-values
+  auto indices = Dense("indices");   // a dense tensor containing indices of non-zero-values
+  auto shape = Dense("shape");       // a dense tensor representing shape
+  auto sparse1 = Sparse("sparse1");  // a sparse tensor created from above
+
+  Node(SparseFromCOO::OpName(), {values, indices, shape}, {sparse1});
+
+  // Node:apply SparseAbs op
+  // sparse2 <- SparseAbs(sparse1)
+  auto sparse2 = Sparse("sparse2");
+  Node(SparseAbs::OpName(), {sparse1}, {sparse2});
+
+  // Node: Extract non-zero values from sparse2
+  // output <- SparseToValues(sparse2)
+  auto output = Dense("output");
+  Node(SparseToValues::OpName(), {sparse2}, {output});
+
+  // Check graph, serialize it and deserialize it back
+  EXPECT_TRUE(graph.Resolve().IsOK());
+  SerializeAndLoad();
+
+  // Run the model
+  AddInput(values, {-99, 2});
+  AddInput(indices, {1, 4}, {2, 1});
+  AddInput(shape, {5});
+  ExpectOutput(output, {99, 2});
+  RunTest();
+}
+
+// Test ops SparseFromCOO, SparseAbs, and SparseToValues.
+// Tests 2-dimensional int64 sparse tensor.
+TEST_F(SparseTensorTests, Test2) {
+  // Register ops
+  RegisterOps<SparseFromCOO, SparseAbs, SparseToValues>();
+
+  // Build model/graph
+
+  // Node: create a sparse tensor from COO components:
+  // sparse1 <- SparseFromCOO(values, indices, shape)
+  auto values = Dense("values");     // a dense tensor containing non-zero-values
+  auto indices = Dense("indices");   // a dense tensor containing indices of non-zero-values
+  auto shape = Dense("shape");       // a dense tensor representing shape
+  auto sparse1 = Sparse("sparse1");  // a sparse tensor created from above
+
+  Node(SparseFromCOO::OpName(), {values, indices, shape}, {sparse1});
+
+  // Node:apply SparseAbs op
+  // sparse2 <- SparseAbs(sparse1)
+  auto sparse2 = Sparse("sparse2");
+  Node(SparseAbs::OpName(), {sparse1}, {sparse2});
+
+  // Node: Extract non-zero values from sparse2
+  // output <- SparseToValues(sparse2)
+  auto output = Dense("output");
+  Node(SparseToValues::OpName(), {sparse2}, {output});
+
+  // Check graph, serialize it and deserialize it back
+  EXPECT_TRUE(graph.Resolve().IsOK());
+  SerializeAndLoad();
+
+  // Run the model
+  AddInput(values, {-99, 2});
+  AddInput(indices, {1, 1, 4, 4}, {2, 2});
+  AddInput(shape, {5, 5});
+  ExpectOutput(output, {99, 2});
+  RunTest();
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/framework/sparse_kernels_test.cc
+++ b/onnxruntime/test/framework/sparse_kernels_test.cc
@@ -19,6 +19,15 @@ using namespace onnxruntime::common;
 namespace onnxruntime {
 namespace test {
 
+// This file contains sample implementations of several ops with sparse-tensor inputs/outputs.
+// Each op is implemented as a struct with the following signature:
+// struct SparseOp {
+//    static std::string OpName();
+//    static ONNX_NAMESPACE::OpSchema OpSchema();
+//    class OpKernelImpl final : public OpKernel {...};
+//    static KernelDefBuilder KernelDef();
+// }
+
 // op SparseFromCOO
 struct SparseFromCOO {
   static std::string OpName() { return "SparseFromCOO"; };
@@ -105,7 +114,6 @@ This operator constructs a sparse tensor from three tensors that provide a COO
 
       memcpy(output->Values().MutableData<int64_t>(), values.Data<int64_t>(), nnz * sizeof(int64_t));
       memcpy(output->Indices().MutableData<int64_t>(), indices.Data<int64_t>(), nnz * numdims * sizeof(int64_t));
-      // output->Shape() = TensorShape(shape_tensor.Data<int64_t>(), shape_shape.Size());
 
       return Status::OK();
     }

--- a/onnxruntime/test/framework/sparse_kernels_test.cc
+++ b/onnxruntime/test/framework/sparse_kernels_test.cc
@@ -297,15 +297,7 @@ class SparseTensorTests : public testing::Test {
     register_actions.push_back(register_kernel);
   }
 
-  template <typename Op1, typename Op2, typename... Ops>
-  void Add() {
-    Add<Op1>();
-    Add<Op2, Ops...>();
-  }
-
-  template <typename... Ops>
   void RegisterOps() {
-    Add<Ops...>();
     EXPECT_TRUE(registry->RegisterOpSet(schemas, onnxruntime::kMLDomain, 10, 11).IsOK());
     for (auto registerop : register_actions)
       registerop(registry.get());
@@ -419,7 +411,10 @@ class SparseTensorTests : public testing::Test {
 // Tests 1-dimensional int64 sparse tensor.
 TEST_F(SparseTensorTests, Test1) {
   // Register ops
-  RegisterOps<SparseFromCOO, SparseAbs, SparseToValues>();
+  Add<SparseFromCOO>();
+  Add<SparseAbs>();
+  Add<SparseToValues>();
+  RegisterOps();
 
   // Build model/graph
 
@@ -458,7 +453,10 @@ TEST_F(SparseTensorTests, Test1) {
 // Tests 2-dimensional int64 sparse tensor.
 TEST_F(SparseTensorTests, Test2) {
   // Register ops
-  RegisterOps<SparseFromCOO, SparseAbs, SparseToValues>();
+  Add<SparseFromCOO>();
+  Add<SparseAbs>();
+  Add<SparseToValues>();
+  RegisterOps();
 
   // Build model/graph
 

--- a/onnxruntime/test/framework/sparse_kernels_test.cc
+++ b/onnxruntime/test/framework/sparse_kernels_test.cc
@@ -2,7 +2,19 @@
 // Licensed under the MIT License.
 
 #include "core/framework/data_types.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-qualifiers"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
 #include "onnx/defs/schema.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
 #include "core/graph/constants.h"
 #include "core/framework/op_kernel.h"
 #include "core/framework/sparse_tensor.h"

--- a/onnxruntime/test/framework/sparse_kernels_test.cc
+++ b/onnxruntime/test/framework/sparse_kernels_test.cc
@@ -177,7 +177,7 @@ This operator applies the Abs op element-wise to the input sparse-tensor.
 
       // compute output values:
       auto* output_values = output->Values().MutableData<int64_t>();
-      for (int i = 0; i < nnz; ++i)
+      for (size_t i = 0; i < nnz; ++i)
         output_values[i] = std::abs(input_values[i]);
 
       // Currently, there is no way to share the indices/shape between two sparse-tensors.
@@ -292,7 +292,8 @@ class SparseTensorTests : public testing::Test {
           .SetDomain(onnxruntime::kMLDomain)
           .SinceVersion(10)
           .Provider(onnxruntime::kCpuExecutionProvider);
-      EXPECT_TRUE(registry->RegisterCustomKernel(kernel_def_builder, [](const OpKernelInfo& info) { return new Op::OpKernelImpl(info); }).IsOK());
+      KernelCreateFn kernel_create_fn = [](const OpKernelInfo& info) { return new typename Op::OpKernelImpl(info); };
+      EXPECT_TRUE(registry->RegisterCustomKernel(kernel_def_builder, kernel_create_fn).IsOK());
     };
     register_actions.push_back(register_kernel);
   }
@@ -388,7 +389,7 @@ class SparseTensorTests : public testing::Test {
     EXPECT_TRUE(session_object.Run(run_options, feeds, output_names, &fetches).IsOK());
 
     ASSERT_EQ(expected_output.size(), fetches.size());
-    for (int i = 0; i < fetches.size(); ++i) {
+    for (size_t i = 0; i < fetches.size(); ++i) {
       ExpectEq(fetches[i], expected_output[i]);
     }
   }

--- a/onnxruntime/test/framework/sparse_kernels_test.cc
+++ b/onnxruntime/test/framework/sparse_kernels_test.cc
@@ -124,8 +124,8 @@ This operator constructs a sparse tensor from three tensors that provide a COO
       SparseTensor* output = ctx->Output(0, static_cast<size_t>(nnz), shape);
       ORT_ENFORCE(output != nullptr);
 
-      memcpy(output->Values().MutableData<int64_t>(), values.Data<int64_t>(), nnz * sizeof(int64_t));
-      memcpy(output->Indices().MutableData<int64_t>(), indices.Data<int64_t>(), nnz * numdims * sizeof(int64_t));
+      memcpy(output->MutableValues().MutableData<int64_t>(), values.Data<int64_t>(), nnz * sizeof(int64_t));
+      memcpy(output->MutableIndices().MutableData<int64_t>(), indices.Data<int64_t>(), nnz * numdims * sizeof(int64_t));
 
       return Status::OK();
     }
@@ -188,7 +188,7 @@ This operator applies the Abs op element-wise to the input sparse-tensor.
       SparseTensor* output = ctx->Output(0, nnz, shape);
 
       // compute output values:
-      auto* output_values = output->Values().MutableData<int64_t>();
+      auto* output_values = output->MutableValues().MutableData<int64_t>();
       for (size_t i = 0; i < nnz; ++i)
         output_values[i] = std::abs(input_values[i]);
 
@@ -196,10 +196,7 @@ This operator applies the Abs op element-wise to the input sparse-tensor.
       // So, we copy indices/shape from input to output.
       // TODO: Extend allocation-planner to enable such sharing.
       const auto& input_indices = input->Indices();
-      memcpy(output->Indices().MutableData<int64_t>(), input_indices.Data<int64_t>(), input_indices.Size());
-
-      output->Shape() = shape;
-
+      memcpy(output->MutableIndices().MutableData<int64_t>(), input_indices.Data<int64_t>(), input_indices.Size());
       return Status::OK();
     }
   };


### PR DESCRIPTION
Add
(a) Implementation of sparse tensor,
(b) Updates to datatypes, opkernel, and execution-frame to support sparse-tensor, and
(c) Test-case illustrating three new ops involving sparse tensors and their implementation.