### PR TITLE
fix ngraph build

### DIFF
--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -100,7 +100,7 @@ def create_backend_test(testname=None):
                                  '^test_quantizelinear_cpu.*')
         # Failing for nGraph.
         if c2.supports_device('NGRAPH'):
-            current_failing_tests = current_failing_tests + ('|^test_operator_repeat_dim_overflow_cpu.*')
+            current_failing_tests = current_failing_tests + ('|^test_operator_repeat_dim_overflow_cpu.*',)
 
         filters = current_failing_tests + \
                   tests_with_pre_opset7_dependencies_filters() + \

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -98,6 +98,9 @@ def create_backend_test(testname=None):
                                  '^test_shrink_cpu.*',
                                  '^test_qlinearconv_cpu.*',
                                  '^test_quantizelinear_cpu.*')
+        # Failing for nGraph.
+        if c2.supports_device('NGRAPH'):
+            current_failing_tests = current_failing_tests + ('|^test_operator_repeat_dim_overflow_cpu.*')
 
         filters = current_failing_tests + \
                   tests_with_pre_opset7_dependencies_filters() + \


### PR DESCRIPTION
disabling failing onnx backend test for ngraph (failure is under investigation) 
the test was previously disabled but got added back recently.
this time, disabling only for ngraph.