### PR TITLE
Fix shape inference bug in GatherND contrib op

### DIFF
--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -929,7 +929,7 @@ with the exception that numpy default keepdims to False instead of True.)DOC")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         propagateElemTypeFromInputToOutput(ctx, 0, 0);
         if (!hasNInputShapes(ctx, 2)) {
-          fail_shape_inference("GatherND requires two tensor inputs.");
+          return;
         }
         auto& data_shape = ctx.getInputType(0)->tensor_type().shape();
         auto& indices_shape = ctx.getInputType(1)->tensor_type().shape();


### PR DESCRIPTION
Blocking conversion and validation of Mask RCNN model

Shape inference shouldn't fail if two input shapes are not present, rather it should silently return without performing shape inference.