### PR TITLE
Fix CUDA thread_local to allow multiple CUDA execution providers

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_allocator.cc
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.cc
@@ -20,7 +20,7 @@ void CUDAAllocator::CheckDevice() const {
   // if it's expected to change, call cudaSetDevice instead of the check
   int current_device;
   CUDA_CALL_THROW(cudaGetDevice(&current_device));
-  ORT_ENFORCE(current_device == device_id_);
+  ORT_ENFORCE(current_device == info_.id);
 #endif
 }
 

--- a/onnxruntime/core/providers/cuda/cuda_allocator.h
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.h
@@ -11,7 +11,7 @@ constexpr const char* CUDA_PINNED = "CudaPinned";
 
 class CUDAAllocator : public IDeviceAllocator {
  public:
-  CUDAAllocator(int device_id) : device_id_(device_id), info_(CUDA, OrtAllocatorType::OrtDeviceAllocator, device_id, OrtMemTypeDefault) {}
+  CUDAAllocator(int device_id) : info_(CUDA, OrtAllocatorType::OrtDeviceAllocator, device_id, OrtMemTypeDefault) {}
   virtual void* Alloc(size_t size) override;
   virtual void Free(void* p) override;
   virtual const OrtAllocatorInfo& Info() const override;
@@ -21,7 +21,6 @@ class CUDAAllocator : public IDeviceAllocator {
   void CheckDevice() const;
 
  private:
-  const int device_id_;
   const OrtAllocatorInfo info_;
 };
 

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.h
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.h
@@ -43,18 +43,11 @@ class CUDAExecutionProvider : public IExecutionProvider {
   Status CopyTensor(const Tensor& src, Tensor& dst, int exec_queue_id) const override;
 
   cublasHandle_t PerThreadCublasHandle() {
-    // Assure each thread has its TLS context.
-    if (!per_thread_context_)
-      per_thread_context_ = std::make_shared<PerThreadContext>(device_id_);
-    return per_thread_context_->CublasHandle();
+    return GetPerThreadContext().CublasHandle();
   }
 
   cudnnHandle_t PerThreadCudnnHandle() {
-    // Assure each thread has its TLS context.
-    // TODO: improve its performance when calling cuda functions from multiple threads.
-    if (!per_thread_context_)
-      per_thread_context_ = std::make_shared<PerThreadContext>(device_id_);
-    return per_thread_context_->CudnnHandle();
+    return GetPerThreadContext().CudnnHandle();
   }
 
   cudaStream_t GetStream(int queue_id) const {
@@ -64,10 +57,7 @@ class CUDAExecutionProvider : public IExecutionProvider {
 
   template <typename T>
   const T* GetConstOnes(size_t count) {
-    // Assure each thread has its TLS context.
-    if (!per_thread_context_)
-      per_thread_context_ = std::make_shared<PerThreadContext>(device_id_);
-    return per_thread_context_->template GetConstOnes<T>(count);
+    return GetPerThreadContext().template GetConstOnes<T>(count);
   }
 
   void AddDeferredReleaseCPUPtr(void* p);
@@ -136,6 +126,10 @@ class CUDAExecutionProvider : public IExecutionProvider {
       }
     }
 
+    AllocatorPtr GetAllocator() const {
+      return allocator_;
+    }
+
    private:
     cublasHandle_t cublas_handle_ = nullptr;
     cudnnHandle_t cudnn_handle_ = nullptr;
@@ -148,22 +142,19 @@ class CUDAExecutionProvider : public IExecutionProvider {
     std::unique_ptr<cuda::IConstantBuffer<float>> constant_ones_float_;
     std::unique_ptr<cuda::IConstantBuffer<double>> constant_ones_double_;
     std::unique_ptr<cuda::IConstantBuffer<half>> constant_ones_half_;
+
+    AllocatorPtr allocator_;
   };
 
   // thread local context during execution
-  static thread_local std::shared_ptr<PerThreadContext> per_thread_context_;
-
-  // thread local GPU memory allocator. could be used before execution
-  static thread_local AllocatorPtr per_thread_default_allocator_;
-
-  // reuse thread local GPU memory allocator for memory pattern
-  mutable std::deque<AllocatorPtr> default_allocator_pool_;
-  mutable OrtMutex default_allocator_pool_mutex_;
+  using PerThreadContextMap = std::unordered_map<const CUDAExecutionProvider*, std::shared_ptr<PerThreadContext>>;
+  static thread_local std::unique_ptr<PerThreadContextMap> per_thread_context_map_;
 
   // reuse thread local context
   mutable std::deque<std::shared_ptr<PerThreadContext>> context_pool_;
   mutable OrtMutex context_pool_mutex_;
 
+  PerThreadContext& GetPerThreadContext() const;
   void ReleasePerThreadStuffs() const;
 };
 


### PR DESCRIPTION
This fixes #1034: Can't Create Model Sessions on Different GPU
The root cause of the bug is that CUDA execution provider uses thread_local to save per-thread-context and allocator, and when two CUDA execution providers are running on the same thread there's a conflict. The fix is to add a std::unordered_map to differentiate EPs in the same thread.