### PR TITLE
make sure thread_pool is non-zero

### DIFF
--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -171,6 +171,7 @@ class ThreadPool::Impl : public TaskThreadPool {
 //
 ThreadPool::ThreadPool(const std::string& name, int num_threads)
     : impl_(std::make_unique<Impl>(name, num_threads)) {
+  ORT_ENFORCE(num_threads > 0, "The number of threads must be > 0!");
 }
 
 void ThreadPool::Schedule(std::function<void()> fn) { impl_->Schedule(fn); }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -106,6 +106,8 @@ InferenceSession::InferenceSession(const SessionOptions& session_options, loggin
     int pool_size = session_options_.session_thread_pool_size <= 0
                         ? std::thread::hardware_concurrency() / 2
                         : session_options_.session_thread_pool_size;
+    if (pool_size == 0)
+      pool_size = 1;
 
     thread_pool_ = std::make_unique<onnxruntime::concurrency::ThreadPool>("SESSION", pool_size);
   }


### PR DESCRIPTION
when the hardware_concurrency() returns 1, we will end up creating
an empty thread pool. This commit fixed the issue.