### PR TITLE
Add shape inference logic for Crop (contrib) op

### DIFF
--- a/onnxruntime/contrib_ops/cpu/crop.h
+++ b/onnxruntime/contrib_ops/cpu/crop.h
@@ -40,12 +40,12 @@ class CropBase {
             rightBorder = border_[2],
             bottomBorder = border_[3];
 
-    if (H <= topBorder + bottomBorder) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input's height (", H, ") needs to be greater than the topBorder (", topBorder, ") + bottomBorder (", bottomBorder, ")");
+    if (H < topBorder + bottomBorder) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input's height (", H, ") needs to be greater than or equal to the topBorder (", topBorder, ") + bottomBorder (", bottomBorder, ")");
     }
 
-    if (W <= leftBorder + rightBorder) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input's width (", W, ") needs to be greater than the leftBorder (", leftBorder, ") + rightBorder (", rightBorder, ")");
+    if (W < leftBorder + rightBorder) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input's width (", W, ") needs to be greater than or equal to the leftBorder (", leftBorder, ") + rightBorder (", rightBorder, ")");
     }
 
     int64_t bottomLimit = H - bottomBorder;
@@ -58,11 +58,11 @@ class CropBase {
 
       if (H < bottomLimit) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                               "Input's height (", H, ") needs to be greater than the topBorder (", topBorder, ") + scale_[0] (", scale_[0], ")");
+                               "Input's height (", H, ") needs to be greater than or equal to the topBorder (", topBorder, ") + scale_[0] (", scale_[0], ")");
       }
 
       if (W < rightLimit) {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input's width (", W, ") needs to be greater than the leftBorder (", leftBorder, ") + scale_[1] (", scale_[1], ")");
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input's width (", W, ") needs to be greater than or equal to the leftBorder (", leftBorder, ") + scale_[1] (", scale_[1], ")");
       }
     }
 

--- a/onnxruntime/contrib_ops/cpu/crop.h
+++ b/onnxruntime/contrib_ops/cpu/crop.h
@@ -19,16 +19,16 @@ class CropBase {
   }
 
   Status ValidateInput(const Tensor* X) const {
-    if (border_.size() < 4) {
+    if (border_.size() != 4) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                              "Attribute border needs to be specified with four border elements, got ", border_.size());
     }
 
     const auto dims = X->Shape().GetDims();
 
-    if (dims.size() < 4) {
+    if (dims.size() != 4) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "Input is expected to have four dimensions corresponding to [N,C,H,W], got ", dims.size());
+                             "Input is expected to have four dimensions corresponding to [N,C,H,W], got ", dims.size(), " input dimensions instead");
     }
 
     const int64_t H = dims[2];
@@ -40,11 +40,11 @@ class CropBase {
             rightBorder = border_[2],
             bottomBorder = border_[3];
 
-    if (H < topBorder + bottomBorder) {
+    if (H <= topBorder + bottomBorder) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input's height (", H, ") needs to be greater than the topBorder (", topBorder, ") + bottomBorder (", bottomBorder, ")");
     }
 
-    if (W < leftBorder + rightBorder) {
+    if (W <= leftBorder + rightBorder) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input's width (", W, ") needs to be greater than the leftBorder (", leftBorder, ") + rightBorder (", rightBorder, ")");
     }
 
@@ -132,5 +132,5 @@ class Crop final : public CropBase, public OpKernel {
   }
 };
 
-}
+}  // namespace contrib
 }  //namespace onnxruntime

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -437,7 +437,7 @@ and op)DOC";
       .SinceVersion(10)
       .Deprecate()
       .SetDoc(Crop_ver1_doc)
-      .Attr("border", "A 1-D values of (leftBorder, topBorder, rightBorder, bottomBorder).", AttributeProto::INTS, OPTIONAL)
+      .Attr("border", "A 1-D values of (leftBorder, topBorder, rightBorder, bottomBorder).", AttributeProto::INTS)
       .Attr("scale", "A 1-D values of (height, width).", AttributeProto::INTS, OPTIONAL)
       .Input(0, "input", "Input tensor of shape [N,C,H,W]", "T")
       .Output(0, "output", "Result, has same type as input, with H and W dimensions reduced.", "T")

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -496,11 +496,13 @@ and op)DOC";
                   right_border = border[2],
                   bottom_border = border[3];
 
-          if (H <= top_border + bottom_border)
-            fail_shape_inference("Input's height (", H, ") needs to be greater than the top_border (", top_border, ") + bottom_border (", bottom_border, ")");
+          if (H < top_border + bottom_border)
+            fail_shape_inference("Input's height (", H, ") needs to be greater than or equal to "
+                                 "the top_border (", top_border, ") + bottom_border (", bottom_border, ")");
 
-          if (W <= left_border + right_border)
-            fail_shape_inference("Input's width (", W, ") needs to be greater than the left_border (", left_border, ") + right_border (", right_border, ")");
+          if (W < left_border + right_border)
+            fail_shape_inference("Input's width (", W, ") needs to be greater than or equal to "
+                                 "the left_border (", left_border, ") + right_border (", right_border, ")");
 
           int64_t bottom_limit = H - bottom_border;
           int64_t right_limit = W - right_border;
@@ -511,10 +513,10 @@ and op)DOC";
             right_limit = left_border + scale[1];
 
             if (H < bottom_limit)
-              fail_shape_inference("Input's height (", H, ") needs to be greater than the top_border (", top_border, ") + scale[0] (", scale[0], ")");
+              fail_shape_inference("Input's height (", H, ") needs to be greater than or equal to the top_border (", top_border, ") + scale[0] (", scale[0], ")");
 
             if (W < right_limit)
-              fail_shape_inference("Input's width (", W, ") needs to be greater than the left_border (", left_border, ") + scale[1] (", scale[1], ")");
+              fail_shape_inference("Input's width (", W, ") needs to be greater than or equal to the left_border (", left_border, ") + scale[1] (", scale[1], ")");
           }
 
           auto* h_output_dim = output_shape->add_dim();

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -89,7 +89,7 @@ If scale is not provided, crop the borders as provided.)DOC";
   ONNX_CONTRIB_OPERATOR_SCHEMA(Crop)
       .SinceVersion(1)
       .SetDoc(Crop_ver1_doc)
-      .Attr("border", "A 1-D values of (left_border, top_border, right_border, bottom_border).", AttributeProto::INTS, OPTIONAL)
+      .Attr("border", "A 1-D values of (leftBorder, topBorder, rightBorder, bottomBorder).", AttributeProto::INTS, OPTIONAL)
       .Attr("scale", "A 1-D values of (height, width).", AttributeProto::INTS, OPTIONAL)
       .Input(0, "input", "Input tensor of shape [N,C,H,W]", "T")
       .Output(0, "output", "Result, has same type as input, with H and W dimensions reduced.", "T")
@@ -107,9 +107,7 @@ is applied to the tensor elementwise. )DOC";
       .Input(0, "X", "Input tensor", "T")
       .Output(0, "Y", "Output tensor", "T")
       .TypeConstraint("T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input and output types to float tensors.")
-      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-
-      });
+      .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput);
 
   static const char* DynamicSlice_ver1_doc = R"DOC(
 Produces a slice of the input tensor along multiple axes. Similar to numpy:
@@ -439,7 +437,7 @@ and op)DOC";
       .SinceVersion(10)
       .Deprecate()
       .SetDoc(Crop_ver1_doc)
-      .Attr("border", "A 1-D values of (left_border, top_border, right_border, bottom_border).", AttributeProto::INTS, OPTIONAL)
+      .Attr("border", "A 1-D values of (leftBorder, topBorder, rightBorder, bottomBorder).", AttributeProto::INTS, OPTIONAL)
       .Attr("scale", "A 1-D values of (height, width).", AttributeProto::INTS, OPTIONAL)
       .Input(0, "input", "Input tensor of shape [N,C,H,W]", "T")
       .Output(0, "output", "Result, has same type as input, with H and W dimensions reduced.", "T")
@@ -534,574 +532,563 @@ and op)DOC";
         }
       });
 
-ONNX_CONTRIB_OPERATOR_SCHEMA(DynamicSlice)
-    .SinceVersion(10)
-    .Deprecate()
-    .SetDoc(DynamicSlice_ver1_doc)
-    .Input(0, "data", "Tensor of data to extract slices from.", "T")
-    .Input(1, "starts", "1-D tensor of starting indices of corresponding axis in `axes`", "Tind")
-    .Input(2, "ends", "1-D tensor of ending indices (exclusive) of corresponding axis in axes", "Tind")
-    .Input(3, "axes", "1-D tensor of axes that `starts` and `ends` apply to.", "Tind", OpSchema::Optional)
-    .Output(0, "output", "Sliced data tensor.", "T")
-    .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
-    .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types");
+  ONNX_CONTRIB_OPERATOR_SCHEMA(DynamicSlice)
+      .SinceVersion(10)
+      .Deprecate()
+      .SetDoc(DynamicSlice_ver1_doc)
+      .Input(0, "data", "Tensor of data to extract slices from.", "T")
+      .Input(1, "starts", "1-D tensor of starting indices of corresponding axis in `axes`", "Tind")
+      .Input(2, "ends", "1-D tensor of ending indices (exclusive) of corresponding axis in axes", "Tind")
+      .Input(3, "axes", "1-D tensor of axes that `starts` and `ends` apply to.", "Tind", OpSchema::Optional)
+      .Output(0, "output", "Sliced data tensor.", "T")
+      .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
+      .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types");
 
-ONNX_OPERATOR_SCHEMA(ScaledTanh)
-    .SinceVersion(10)
-    .Deprecate()
-    .Attr("alpha", "Scaling value", AttributeProto::FLOAT, OPTIONAL)
-    .Attr("beta", "Scaling value", AttributeProto::FLOAT, OPTIONAL)
-    .Input(0, "input", "Input tensor", "T")
-    .Output(
-        0,
-        "output",
-        "The scaled hyperbolic tangent values of the input tensor "
-        "computed element-wise",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput);
+  ONNX_OPERATOR_SCHEMA(ScaledTanh)
+      .SinceVersion(10)
+      .Deprecate()
+      .Attr("alpha", "Scaling value", AttributeProto::FLOAT, OPTIONAL)
+      .Attr("beta", "Scaling value", AttributeProto::FLOAT, OPTIONAL)
+      .Input(0, "input", "Input tensor", "T")
+      .Output(
+          0,
+          "output",
+          "The scaled hyperbolic tangent values of the input tensor "
+          "computed element-wise",
+          "T")
+      .TypeConstraint(
+          "T",
+          {"tensor(float16)", "tensor(float)", "tensor(double)"},
+          "Constrain input and output types to float tensors.")
+      .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput);
 
-// End of ONNX exp ops(Affine, Crop, ParametricSoftplus, ImageScaler, ThresholdedRelu, DynamicSlice, ScaledTanh, MVN) old version history maintenance
+  // End of ONNX exp ops(Affine, Crop, ParametricSoftplus, ImageScaler, ThresholdedRelu, DynamicSlice, ScaledTanh, MVN) old version history maintenance
 
-ONNX_CONTRIB_OPERATOR_SCHEMA(SampleOp)
-    .SetDomain(kMSDomain)
-    .SinceVersion(1)
-    .Input(0, "X", "input", "T")
-    .Output(0, "Y", "output", "T")
-    .TypeConstraint(
-        "T",
-        ONNX_NAMESPACE::OpSchema::numeric_types_for_math_reduction(),
-        "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
-    .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput)
-    .SetDoc(R"DOC(
+  ONNX_CONTRIB_OPERATOR_SCHEMA(SampleOp)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .Input(0, "X", "input", "T")
+      .Output(0, "Y", "output", "T")
+      .TypeConstraint(
+          "T",
+          ONNX_NAMESPACE::OpSchema::numeric_types_for_math_reduction(),
+          "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
+      .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput)
+      .SetDoc(R"DOC(
 Sample echo operator.)DOC");
 
-// register schemas for more operators here
-ONNX_CONTRIB_OPERATOR_SCHEMA(MaxpoolWithMask)
-    .SetDomain(kMSDomain)
-    .SinceVersion(1)
-    .SetDoc(R"DOC(For internal use.)DOC")
-    .Attr(
-        "auto_pad",
-        "",
-        AttributeProto::STRING,
-        std::string("NOTSET"))
-    .Attr(
-        "kernel_shape",
-        "",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr("pads",
+  // register schemas for more operators here
+  ONNX_CONTRIB_OPERATOR_SCHEMA(MaxpoolWithMask)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetDoc(R"DOC(For internal use.)DOC")
+      .Attr(
+          "auto_pad",
           "",
-          AttributeProto::INTS, OPTIONAL)
-    .Attr(
-        "storage_order",
-        "",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "strides", "", AttributeProto::INTS, OPTIONAL)
-    .Input(
-        0,
-        "X",
-        "",
-        "T")
-    .Input(1, "M", "mask", "tensor(int32)")
-    .Output(
-        0,
-        "Y",
-        "",
-        "T")
-    .TypeConstraint("T", {"tensor(float)"}, "Constrain input0 and output types to float tensors")
-    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-      ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      ONNX_NAMESPACE::convPoolShapeInference(ctx, false, true, 0, 1);
-    });
-
-ONNX_CONTRIB_OPERATOR_SCHEMA(ConvTransposeWithDynamicPads)
-    .SetDomain(kMSDomain)
-    .SinceVersion(1)
-    .SetDoc(R"DOC()DOC")
-    .Attr(
-        "kernel_shape",
-        "",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr("output_padding",
+          AttributeProto::STRING,
+          std::string("NOTSET"))
+      .Attr(
+          "kernel_shape",
           "",
           AttributeProto::INTS,
           OPTIONAL)
-    .Attr(
-        "dilations",
-        "",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "strides",
-        "",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "auto_pad",
-        "",
-        AttributeProto::STRING,
-        std::string("NOTSET"))
-    .Attr(
-        "group",
-        "",
-        AttributeProto::INT,
-        static_cast<int64_t>(1))
-    .Input(
-        0,
-        "X",
-        "",
-        "T")
-    .Input(
-        1,
-        "W",
-        "",
-        "T")
-    .Input(2, "Pads", "", "tensor(int64)", OpSchema::Optional)
-    .Input(3, "B", "", "T", OpSchema::Optional)
-    .Output(
-        0,
-        "Y",
-        "",
-        "T")
-    .TypeConstraint("T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input and output types to float tensors")
-    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
-    });
+      .Attr("pads",
+            "",
+            AttributeProto::INTS, OPTIONAL)
+      .Attr(
+          "storage_order",
+          "",
+          AttributeProto::INT,
+          static_cast<int64_t>(0))
+      .Attr(
+          "strides", "", AttributeProto::INTS, OPTIONAL)
+      .Input(
+          0,
+          "X",
+          "",
+          "T")
+      .Input(1, "M", "mask", "tensor(int32)")
+      .Output(
+          0,
+          "Y",
+          "",
+          "T")
+      .TypeConstraint("T", {"tensor(float)"}, "Constrain input0 and output types to float tensors")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        ONNX_NAMESPACE::convPoolShapeInference(ctx, false, true, 0, 1);
+      });
 
-ONNX_CONTRIB_OPERATOR_SCHEMA(FusedConv)
-    .SetDomain(kMSDomain)
-    .SinceVersion(1)
-    .SetDoc(R"DOC(
+  ONNX_CONTRIB_OPERATOR_SCHEMA(ConvTransposeWithDynamicPads)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetDoc(R"DOC()DOC")
+      .Attr(
+          "kernel_shape",
+          "",
+          AttributeProto::INTS,
+          OPTIONAL)
+      .Attr("output_padding",
+            "",
+            AttributeProto::INTS,
+            OPTIONAL)
+      .Attr(
+          "dilations",
+          "",
+          AttributeProto::INTS,
+          OPTIONAL)
+      .Attr(
+          "strides",
+          "",
+          AttributeProto::INTS,
+          OPTIONAL)
+      .Attr(
+          "auto_pad",
+          "",
+          AttributeProto::STRING,
+          std::string("NOTSET"))
+      .Attr(
+          "group",
+          "",
+          AttributeProto::INT,
+          static_cast<int64_t>(1))
+      .Input(
+          0,
+          "X",
+          "",
+          "T")
+      .Input(
+          1,
+          "W",
+          "",
+          "T")
+      .Input(2, "Pads", "", "tensor(int64)", OpSchema::Optional)
+      .Input(3, "B", "", "T", OpSchema::Optional)
+      .Output(
+          0,
+          "Y",
+          "",
+          "T")
+      .TypeConstraint("T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input and output types to float tensors")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        propagateElemTypeFromInputToOutput(ctx, 0, 0);
+      });
+
+  ONNX_CONTRIB_OPERATOR_SCHEMA(FusedConv)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetDoc(R"DOC(
 The fused convolution operator schema is the same as Conv besides it includes an attribute
 activation.)DOC")
-    .Attr(
-        "auto_pad",
-        "",
-        AttributeProto::STRING,
-        std::string("NOTSET"))
-    .Attr(
-        "kernel_shape",
-        "",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "dilations",
-        "",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "strides", "", AttributeProto::INTS, OPTIONAL)
-    .Attr("pads",
+      .Attr(
+          "auto_pad",
           "",
-          AttributeProto::INTS, OPTIONAL)
-    .Attr(
-        "group",
-        "",
-        AttributeProto::INT,
-        static_cast<int64_t>(1))
-    .Attr(
-        "activation",
-        "",
-        AttributeProto::STRING,
-        OPTIONAL)
-    .Attr(
-        "alpha",
-        "",
-        AttributeProto::FLOAT,
-        OPTIONAL)
-    .Input(
-        0,
-        "X",
-        "",
-        "T")
-    .Input(
-        1,
-        "W",
-        "",
-        "T")
-    .Input(2, "B", "", "T", OpSchema::Optional)
-    .Output(
-        0,
-        "Y",
-        "",
-        "T")
-    .TypeConstraint("T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input and output types to float tensors")
-    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-      ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      ONNX_NAMESPACE::convPoolShapeInference(ctx, true, false, 0, 1);
-    });
+          AttributeProto::STRING,
+          std::string("NOTSET"))
+      .Attr(
+          "kernel_shape",
+          "",
+          AttributeProto::INTS,
+          OPTIONAL)
+      .Attr(
+          "dilations",
+          "",
+          AttributeProto::INTS,
+          OPTIONAL)
+      .Attr(
+          "strides", "", AttributeProto::INTS, OPTIONAL)
+      .Attr("pads",
+            "",
+            AttributeProto::INTS, OPTIONAL)
+      .Attr(
+          "group",
+          "",
+          AttributeProto::INT,
+          static_cast<int64_t>(1))
+      .Attr(
+          "activation",
+          "",
+          AttributeProto::STRING,
+          OPTIONAL)
+      .Attr(
+          "alpha",
+          "",
+          AttributeProto::FLOAT,
+          OPTIONAL)
+      .Input(
+          0,
+          "X",
+          "",
+          "T")
+      .Input(
+          1,
+          "W",
+          "",
+          "T")
+      .Input(2, "B", "", "T", OpSchema::Optional)
+      .Output(
+          0,
+          "Y",
+          "",
+          "T")
+      .TypeConstraint("T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input and output types to float tensors")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        ONNX_NAMESPACE::convPoolShapeInference(ctx, true, false, 0, 1);
+      });
 
-ONNX_CONTRIB_OPERATOR_SCHEMA(FusedGemm)
-    .SetDomain(kMSDomain)
-    .SinceVersion(1)
-    .SetDoc(R"DOC(
+  ONNX_CONTRIB_OPERATOR_SCHEMA(FusedGemm)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetDoc(R"DOC(
 The FusedGemm operator schema is the same as Gemm besides it includes attributes
 activation and leaky_relu_alpha.)DOC")
-    .Input(
-        0,
-        "A",
-        "Input tensor A. "
-        "The shape of A should be (M, K) if transA is 0, "
-        "or (K, M) if transA is non-zero.",
-        "T")
-    .Input(
-        1,
-        "B",
-        "Input tensor B. "
-        "The shape of B should be (K, N) if transB is 0, "
-        "or (N, K) if transB is non-zero.",
-        "T")
-    .Input(
-        2,
-        "C",
-        "Input tensor C. "
-        "The shape of C should be unidirectional broadcastable to (M, N).",
-        "T")
-    .Output(0, "Y", "Output tensor of shape (M, N).", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)",
-         "tensor(float)",
-         "tensor(double)",
-         "tensor(uint32)",
-         "tensor(uint64)",
-         "tensor(int32)",
-         "tensor(int64)"},
-        "Constrain input and output types to float/int tensors.")
-    .Attr(
-        "transA",
-        "Whether A should be transposed",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "transB",
-        "Whether B should be transposed",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "alpha",
-        "Scalar multiplier for the product of input tensors A * B.",
-        AttributeProto::FLOAT,
-        1.0f)
-    .Attr(
-        "beta",
-        "Scalar multiplier for input tensor C.",
-        AttributeProto::FLOAT,
-        1.0f)
-    .Attr(
-        "activation",
-        "",
-        AttributeProto::STRING,
-        OPTIONAL)
-    .Attr(
-        "leaky_relu_alpha",
-        "",
-        AttributeProto::FLOAT,
-        OPTIONAL)
-    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      if (hasNInputShapes(ctx, 2)) {
-        auto transAAttr = ctx.getAttribute("transA");
-        bool transA =
-            transAAttr ? static_cast<int>(transAAttr->i()) != 0 : false;
-        auto transBAttr = ctx.getAttribute("transB");
-        bool transB =
-            transBAttr ? static_cast<int>(transBAttr->i()) != 0 : false;
-        auto& first_input_shape = getInputShape(ctx, 0);
-        auto& second_input_shape = getInputShape(ctx, 1);
-        if (first_input_shape.dim_size() != 2)
-          fail_shape_inference("First input does not have rank 2");
-        if (second_input_shape.dim_size() != 2)
-          fail_shape_inference("Second input does not have rank 2");
-        updateOutputShape(
-            ctx,
-            0,
-            {first_input_shape.dim(transA ? 1 : 0),
-             second_input_shape.dim(transB ? 0 : 1)});
-      }
-    });
+      .Input(
+          0,
+          "A",
+          "Input tensor A. "
+          "The shape of A should be (M, K) if transA is 0, "
+          "or (K, M) if transA is non-zero.",
+          "T")
+      .Input(
+          1,
+          "B",
+          "Input tensor B. "
+          "The shape of B should be (K, N) if transB is 0, "
+          "or (N, K) if transB is non-zero.",
+          "T")
+      .Input(
+          2,
+          "C",
+          "Input tensor C. "
+          "The shape of C should be unidirectional broadcastable to (M, N).",
+          "T")
+      .Output(0, "Y", "Output tensor of shape (M, N).", "T")
+      .TypeConstraint(
+          "T",
+          {"tensor(float16)",
+           "tensor(float)",
+           "tensor(double)",
+           "tensor(uint32)",
+           "tensor(uint64)",
+           "tensor(int32)",
+           "tensor(int64)"},
+          "Constrain input and output types to float/int tensors.")
+      .Attr(
+          "transA",
+          "Whether A should be transposed",
+          AttributeProto::INT,
+          static_cast<int64_t>(0))
+      .Attr(
+          "transB",
+          "Whether B should be transposed",
+          AttributeProto::INT,
+          static_cast<int64_t>(0))
+      .Attr(
+          "alpha",
+          "Scalar multiplier for the product of input tensors A * B.",
+          AttributeProto::FLOAT,
+          1.0f)
+      .Attr(
+          "beta",
+          "Scalar multiplier for input tensor C.",
+          AttributeProto::FLOAT,
+          1.0f)
+      .Attr(
+          "activation",
+          "",
+          AttributeProto::STRING,
+          OPTIONAL)
+      .Attr(
+          "leaky_relu_alpha",
+          "",
+          AttributeProto::FLOAT,
+          OPTIONAL)
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        if (hasNInputShapes(ctx, 2)) {
+          auto transAAttr = ctx.getAttribute("transA");
+          bool transA =
+              transAAttr ? static_cast<int>(transAAttr->i()) != 0 : false;
+          auto transBAttr = ctx.getAttribute("transB");
+          bool transB =
+              transBAttr ? static_cast<int>(transBAttr->i()) != 0 : false;
+          auto& first_input_shape = getInputShape(ctx, 0);
+          auto& second_input_shape = getInputShape(ctx, 1);
+          if (first_input_shape.dim_size() != 2)
+            fail_shape_inference("First input does not have rank 2");
+          if (second_input_shape.dim_size() != 2)
+            fail_shape_inference("Second input does not have rank 2");
+          updateOutputShape(
+              ctx,
+              0,
+              {first_input_shape.dim(transA ? 1 : 0),
+               second_input_shape.dim(transB ? 0 : 1)});
+        }
+      });
 
-ONNX_CONTRIB_OPERATOR_SCHEMA(ExpandDims)
-    .SetDomain(kMSDomain)
-    .SinceVersion(1)
-    .Input(0, "X", "input", "T")
-    .Input(1, "axis", "Specified axis to insert a dimension", "tensor(int32)")
-    .Output(0, "Y", "output", "T")
-    .TypeConstraint(
-        "T",
-        ONNX_NAMESPACE::OpSchema::all_tensor_types(),
-        "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
-    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-      // Type inference
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
+  ONNX_CONTRIB_OPERATOR_SCHEMA(ExpandDims)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .Input(0, "X", "input", "T")
+      .Input(1, "axis", "Specified axis to insert a dimension", "tensor(int32)")
+      .Output(0, "Y", "output", "T")
+      .TypeConstraint(
+          "T",
+          ONNX_NAMESPACE::OpSchema::all_tensor_types(),
+          "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        // Type inference
+        propagateElemTypeFromInputToOutput(ctx, 0, 0);
 
-      // Shape inference
-      if (!hasInputShape(ctx, 0))
-        return;
+        // Shape inference
+        if (!hasInputShape(ctx, 0))
+          return;
 
-      auto& input_shape = getInputShape(ctx, 0);
-      const int rank = input_shape.dim_size();
-      const ONNX_NAMESPACE::TensorProto* axis_initializer = ctx.getInputData(1);
-      if (!axis_initializer)
-        return;
-      const int axis = axis_initializer->int32_data()[0];
-      if (axis > rank || axis < -rank - 1) {
-        fail_shape_inference("Input axis is invalid: ", axis);
-      }
-      int pos = axis >= 0 ? axis : rank + axis - 1;
-      ONNX_NAMESPACE::TensorShapeProto output_shape;
-      for (int i = 0; i < pos; ++i) {
+        auto& input_shape = getInputShape(ctx, 0);
+        const int rank = input_shape.dim_size();
+        const ONNX_NAMESPACE::TensorProto* axis_initializer = ctx.getInputData(1);
+        if (!axis_initializer)
+          return;
+        const int axis = axis_initializer->int32_data()[0];
+        if (axis > rank || axis < -rank - 1) {
+          fail_shape_inference("Input axis is invalid: ", axis);
+        }
+        int pos = axis >= 0 ? axis : rank + axis - 1;
+        ONNX_NAMESPACE::TensorShapeProto output_shape;
+        for (int i = 0; i < pos; ++i) {
+          output_shape.add_dim();
+          *(output_shape.mutable_dim(i)) = input_shape.dim(i);
+        }
         output_shape.add_dim();
-        *(output_shape.mutable_dim(i)) = input_shape.dim(i);
-      }
-      output_shape.add_dim();
-      output_shape.mutable_dim(pos)->set_dim_value(1);
-      for (int i = pos + 1; i < rank + 1; ++i) {
-        output_shape.add_dim();
-        *(output_shape.mutable_dim(i)) = input_shape.dim(i - 1);
-      }
-      updateOutputShape(ctx, 0, output_shape);
-    })
-    .SetDoc(R"DOC(ExpandDims echo operator.)DOC");
+        output_shape.mutable_dim(pos)->set_dim_value(1);
+        for (int i = pos + 1; i < rank + 1; ++i) {
+          output_shape.add_dim();
+          *(output_shape.mutable_dim(i)) = input_shape.dim(i - 1);
+        }
+        updateOutputShape(ctx, 0, output_shape);
+      })
+      .SetDoc(R"DOC(ExpandDims echo operator.)DOC");
 
-ONNX_CONTRIB_OPERATOR_SCHEMA_ELSEWHERE(AttnLSTM, RegisterAttnLSTMContribOpSchema);
-ONNX_CONTRIB_OPERATOR_SCHEMA_ELSEWHERE(Range, RegisterRangeOpSchema);
+  ONNX_CONTRIB_OPERATOR_SCHEMA_ELSEWHERE(AttnLSTM, RegisterAttnLSTMContribOpSchema);
+  ONNX_CONTRIB_OPERATOR_SCHEMA_ELSEWHERE(Range, RegisterRangeOpSchema);
 
-static const char* Tokenizer_ver1_doc = R"DOC(
+  static const char* Tokenizer_ver1_doc = R"DOC(
   Tokenizer divides each string in X into a vector of strings along the last axis. Allowed input shapes are [C] and [N, C].
   If the maximum number of tokens found per input string is D, the output shape would be [N, C, D] when input shape is [N, C].
   Similarly, if input shape is [C] then the output should be [C, D]. Tokenizer has two different operation modes.
   The first mode is selected when "tokenexp" is not set and "separators" is set. If "tokenexp" is set and "separators" is not set,
   the second mode will be used. The first mode breaks each input string into tokens by matching and removing separators.
   "separators" is a list of strings which are regular expressions. "tokenexp" is a single regular expression.
-
   Let's assume "separators" is [" "] and consider an example.
   If input is
-
   ["Hello World", "I love computer science !"] whose shape is [2],
-
   then the output would be
-
  [["Hello", "World", padvalue, padvalue, padvalue],
  ["I", "love", "computer", "science", "!"]]
-
  whose shape is [2, 5] because you can find at most 5 tokens per input string.
  Note that the input at most can have two axes, so 3-D and higher dimension are not supported.
-
  If "separators" contains a single empty string, the Tokenizer will enter into character tokenezation mode. This means all strings
  will be broken part into individual characters.
-
  For each input string, the second mode searches matches of "tokenexp" and each match will be a token in Y.
  The matching of "tokenexp" is conducted greedily (i.e., a match should be as long as possible).
  This operator searches for the first match starting from the beginning of the considered string,
  and then launches another search starting from the first remained character after the first matched token.
  If no match found, this operator will remove the first character from the remained string and do another search.
  This procedure will be repeated until reaching the end of the considered string.
-
   Let's consider another example to illustrate the effect of setting "mark" to true.
   If input is ["Hello", "World"],
   then the corresponding output would be [0x02, "Hello", "World", 0x03].
   This implies that if mark is true, [C]/[N, C] - input's output shape becomes [C, D+2]/[N, C, D+2].
-
 If tokenizer removes the entire content of [C]-input, it will produce [[]].
 I.e. the output shape should be [C][0] or [N][C][0] if input shape was [N][C].
-
 If the tokenizer receives empty input of [0] then the output is [0] if empty input
 of [N, 0] then [N, 0].
-
 )DOC";
 
-ONNX_CONTRIB_OPERATOR_SCHEMA(Tokenizer)
-    .SetDomain(kMSDomain)
-    .SinceVersion(1)
-    .Input(0, "X", "Strings to tokenize", "T")
-    .Output(0, "Y", "Tokenized strings", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(string)"},
-        "Input/Output is a string tensor")
-    .Attr(
-        "mark",
-        "Boolean whether to mark the beginning/end character with start of text character (0x02)/end of text character (0x03).",
-        AttributeProto::INT)
-    .Attr(
-        "pad_value",
-        "The string used to pad output tensors when the tokens extracted doesn't match the maximum number of tokens found. If start/end markers are needed, padding will appear outside the markers.",
-        AttributeProto::STRING)
-    .Attr(
-        "tokenexp",
-        "An optional string. Token's regular expression in basic POSIX format"
-        " (http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_03)."
-        " If set, tokenizer may produce tokens matching the specified pattern. Note that one and only of"
-        " 'tokenexp' and 'separators' should be set.",
-        AttributeProto::STRING,
-        OPTIONAL)
-    .Attr(
-        "separators",
-        "an optional list of strings attribute that contains a list of separators - regular expressions to match separators"
-        " Two consecutive segments in X connected by a separator would be divided into two tokens."
-        " For example, if the input is \"Hello World!\" and this attribute contains only one space character,"
-        " the corresponding output would be [\"Hello\", \"World!\"]. To achieve character-level tokenization,"
-        " one should set the 'separators' to [\"\"], which contains an empty string.",
-        AttributeProto::STRINGS,
-        OPTIONAL)
-    .Attr(
-        "mincharnum",
-        "Minimum number of characters allowed in the output. For example, if mincharnum is 2, tokens such as \"A\" and \"B\" would be ignored",
-        AttributeProto::INT)
-    .SetDoc(Tokenizer_ver1_doc)
-    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
+  ONNX_CONTRIB_OPERATOR_SCHEMA(Tokenizer)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .Input(0, "X", "Strings to tokenize", "T")
+      .Output(0, "Y", "Tokenized strings", "T")
+      .TypeConstraint(
+          "T",
+          {"tensor(string)"},
+          "Input/Output is a string tensor")
+      .Attr(
+          "mark",
+          "Boolean whether to mark the beginning/end character with start of text character (0x02)/end of text character (0x03).",
+          AttributeProto::INT)
+      .Attr(
+          "pad_value",
+          "The string used to pad output tensors when the tokens extracted doesn't match the maximum number of tokens found. If start/end markers are needed, padding will appear outside the markers.",
+          AttributeProto::STRING)
+      .Attr(
+          "tokenexp",
+          "An optional string. Token's regular expression in basic POSIX format"
+          " (http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_03)."
+          " If set, tokenizer may produce tokens matching the specified pattern. Note that one and only of"
+          " 'tokenexp' and 'separators' should be set.",
+          AttributeProto::STRING,
+          OPTIONAL)
+      .Attr(
+          "separators",
+          "an optional list of strings attribute that contains a list of separators - regular expressions to match separators"
+          " Two consecutive segments in X connected by a separator would be divided into two tokens."
+          " For example, if the input is \"Hello World!\" and this attribute contains only one space character,"
+          " the corresponding output would be [\"Hello\", \"World!\"]. To achieve character-level tokenization,"
+          " one should set the 'separators' to [\"\"], which contains an empty string.",
+          AttributeProto::STRINGS,
+          OPTIONAL)
+      .Attr(
+          "mincharnum",
+          "Minimum number of characters allowed in the output. For example, if mincharnum is 2, tokens such as \"A\" and \"B\" would be ignored",
+          AttributeProto::INT)
+      .SetDoc(Tokenizer_ver1_doc)
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        propagateElemTypeFromInputToOutput(ctx, 0, 0);
 
-      // Shape inference
-      if (!hasInputShape(ctx, 0))
-        return;
+        // Shape inference
+        if (!hasInputShape(ctx, 0))
+          return;
 
-      ONNX_NAMESPACE::TensorShapeProto output_shape;
-      auto& input_shape = getInputShape(ctx, 0);
-      auto& dims = input_shape.dim();
-      if (dims.size() < 1 || dims.size() > 2) {
-        fail_shape_inference("Input dimensions are either [C] or [N][C] allowed");
-      }
-
-      int64_t size = 1;
-      for (auto& dim : dims) {
-        if (dim.has_dim_value()) {
-          size *= dim.dim_value();
+        ONNX_NAMESPACE::TensorShapeProto output_shape;
+        auto& input_shape = getInputShape(ctx, 0);
+        auto& dims = input_shape.dim();
+        if (dims.size() < 1 || dims.size() > 2) {
+          fail_shape_inference("Input dimensions are either [C] or [N][C] allowed");
         }
-      }
 
-      if (size > 0) {
+        int64_t size = 1;
         for (auto& dim : dims) {
-          *output_shape.add_dim() = dim;
+          if (dim.has_dim_value()) {
+            size *= dim.dim_value();
+          }
         }
-        // Add the last unknown dimension
-        // only if the input is not empty
-        output_shape.add_dim();
-      } else if (size == 0) {
-        if (dims.size() == 2) {
-          *output_shape.add_dim() = dims[0];
-        }
-        output_shape.add_dim()->set_dim_value(0);
-      }
-      updateOutputShape(ctx, 0, output_shape);
-    });
 
-ONNX_CONTRIB_OPERATOR_SCHEMA(ReduceSumInteger)
-    .SetDomain(kMSDomain)
-    .SinceVersion(1)
-    .SetDoc(R"DOC(
+        if (size > 0) {
+          for (auto& dim : dims) {
+            *output_shape.add_dim() = dim;
+          }
+          // Add the last unknown dimension
+          // only if the input is not empty
+          output_shape.add_dim();
+        } else if (size == 0) {
+          if (dims.size() == 2) {
+            *output_shape.add_dim() = dims[0];
+          }
+          output_shape.add_dim()->set_dim_value(0);
+        }
+        updateOutputShape(ctx, 0, output_shape);
+      });
+
+  ONNX_CONTRIB_OPERATOR_SCHEMA(ReduceSumInteger)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetDoc(R"DOC(
 Computes the sum of the low-precision input tensor's element along the provided axes.
 The resulting tensor has the same rank as the input if keepdims equal 1. If keepdims equal 0,
 then the resulting tensor have the reduced dimension pruned. The above behavior is similar to numpy,
 with the exception that numpy default keepdims to False instead of True.)DOC")
-    .Input(0, "data", "An input tensor.", "T1")
-    .Output(0, "reduced", "Reduced output tensor.", "T2")
-    .TypeConstraint("T1", {"tensor(int8)", "tensor(uint8)"}, "Constrain input type to 8-bit integer tensor.")
-    .TypeConstraint("T2",
-                    {"tensor(int32)", "tensor(uint32)"},
-                    "Constrain output data type to 32-bit integer tensor."
-                    "T2 must be tensor(uint32) when T1 is tensor(uint8),"
-                    "or must be tensor(int32) when T1 is tensor(int8).")
-    .Attr(
-        "axes",
-        "A list of integers, along which to reduce. The default is to reduce over all the dimensions of the input tensor.",
-        AttributeProto::INTS)
-    .Attr(
-        "keepdims",
-        "Keep the reduced dimension or not, default 1 mean keep reduced dimension.",
-        AttributeProto::INT);
+      .Input(0, "data", "An input tensor.", "T1")
+      .Output(0, "reduced", "Reduced output tensor.", "T2")
+      .TypeConstraint("T1", {"tensor(int8)", "tensor(uint8)"}, "Constrain input type to 8-bit integer tensor.")
+      .TypeConstraint("T2",
+                      {"tensor(int32)", "tensor(uint32)"},
+                      "Constrain output data type to 32-bit integer tensor."
+                      "T2 must be tensor(uint32) when T1 is tensor(uint8),"
+                      "or must be tensor(int32) when T1 is tensor(int8).")
+      .Attr(
+          "axes",
+          "A list of integers, along which to reduce. The default is to reduce over all the dimensions of the input tensor.",
+          AttributeProto::INTS)
+      .Attr(
+          "keepdims",
+          "Keep the reduced dimension or not, default 1 mean keep reduced dimension.",
+          AttributeProto::INT);
 
-ONNX_CONTRIB_OPERATOR_SCHEMA(MurmurHash3)
-    .SetDomain(kMSDomain)
-    .SinceVersion(1)
-    .SetDoc(R"DOC(The underlying implementation is MurmurHash3_x86_32 generating low latency 32bits hash suitable for implementing lookup tables, Bloom filters, count min sketch or feature hashing.)DOC")
-    .Input(0, "X", "An input tensor to hash.", "T1")
-    .Output(0, "Y", "32-bit hash value.", "T2")
-    .TypeConstraint("T1", {"tensor(uint32)", "tensor(int32)", "tensor(string)"}, "Constrain input type to unsigned or signed 32-bit integer tensor, or string tensor. It should be utf-8 encoded if using unicode.")
-    .TypeConstraint("T2", {"tensor(uint32)", "tensor(int32)"}, "Constrain output type to unsigned and signed 32-bit integer tensor.")
-    .Attr(
-        "seed",
-        "Seed for the hashing algorithm, unsigned 32-bit integer, default to 0.",
-        AttributeProto::INT,
-        (int64_t)0LL)
-    .Attr(
-        "positive",
-        "If value is 1, output type is uint32_t, else int32_t. Default value is 1.",
-        AttributeProto::INT,
-        (int64_t)1LL)
-    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-      // type inference
-      auto positive_attr = ctx.getAttribute("positive");
-      bool is_positive =
-          positive_attr ? (static_cast<int>(positive_attr->i()) == 1 ? true : false) : true /* default value if attribute not present */;
-      auto output_data_type = ctx.getOutputType(0)->mutable_tensor_type();
-      if (is_positive) {
-        output_data_type->set_elem_type(::ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT32);
-      } else {
-        output_data_type->set_elem_type(::ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT32);
-      }
+  ONNX_CONTRIB_OPERATOR_SCHEMA(MurmurHash3)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetDoc(R"DOC(The underlying implementation is MurmurHash3_x86_32 generating low latency 32bits hash suitable for implementing lookup tables, Bloom filters, count min sketch or feature hashing.)DOC")
+      .Input(0, "X", "An input tensor to hash.", "T1")
+      .Output(0, "Y", "32-bit hash value.", "T2")
+      .TypeConstraint("T1", {"tensor(uint32)", "tensor(int32)", "tensor(string)"}, "Constrain input type to unsigned or signed 32-bit integer tensor, or string tensor. It should be utf-8 encoded if using unicode.")
+      .TypeConstraint("T2", {"tensor(uint32)", "tensor(int32)"}, "Constrain output type to unsigned and signed 32-bit integer tensor.")
+      .Attr(
+          "seed",
+          "Seed for the hashing algorithm, unsigned 32-bit integer, default to 0.",
+          AttributeProto::INT,
+          (int64_t)0LL)
+      .Attr(
+          "positive",
+          "If value is 1, output type is uint32_t, else int32_t. Default value is 1.",
+          AttributeProto::INT,
+          (int64_t)1LL)
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        // type inference
+        auto positive_attr = ctx.getAttribute("positive");
+        bool is_positive =
+            positive_attr ? (static_cast<int>(positive_attr->i()) == 1 ? true : false) : true /* default value if attribute not present */;
+        auto output_data_type = ctx.getOutputType(0)->mutable_tensor_type();
+        if (is_positive) {
+          output_data_type->set_elem_type(::ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT32);
+        } else {
+          output_data_type->set_elem_type(::ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT32);
+        }
 
-      // Shape inference
-      if (!hasInputShape(ctx, 0))
-        return;
+        // Shape inference
+        if (!hasInputShape(ctx, 0))
+          return;
 
-      auto& input_shape = getInputShape(ctx, 0);
-      updateOutputShape(ctx, 0, input_shape);
-    });
+        auto& input_shape = getInputShape(ctx, 0);
+        updateOutputShape(ctx, 0, input_shape);
+      });
 
-ONNX_CONTRIB_OPERATOR_SCHEMA(GatherND)
-    .SetDomain(kMSDomain)
-    .SinceVersion(1)
-    .Input(0, "data", "Tensor of rank r >= 1.", "T")
-    .Input(1, "indices", "Tensor of rank q >= 1.", "Tind")
-    .Output(0, "output", "Tensor of rank q-1+r-indices[-1].", "T")
-    .TypeConstraint(
-        "T",
-        OpSchema::all_tensor_types(),
-        "Constrain input and output types to any tensor type.")
-    .TypeConstraint(
-        "Tind",
-        {"tensor(int32)", "tensor(int64)"},
-        "Constrain indice type to int32 or int64")
-    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      if (!hasNInputShapes(ctx, 2)) {
-        return;
-      }
-      auto& data_shape = ctx.getInputType(0)->tensor_type().shape();
-      auto& indices_shape = ctx.getInputType(1)->tensor_type().shape();
-      auto data_rank = data_shape.dim_size();
-      auto indices_rank = indices_shape.dim_size();
-      if (data_rank < 1 || indices_rank < 1) {
-        fail_shape_inference("both data and indices tensor need to have rank larger than zero.");
-      }
-      auto last_indice_dimension = indices_shape.dim(indices_rank - 1).dim_value();
-      if (last_indice_dimension > data_rank) {
-        fail_shape_inference("last dimension of indices must not be larger and rank of data tensor");
-      }
-      for (int i = 0; i < indices_rank - 1; ++i) {
-        *ctx.getOutputType(0)
-             ->mutable_tensor_type()
-             ->mutable_shape()
-             ->add_dim() = indices_shape.dim(i);
-      }
-      for (int i = static_cast<int>(last_indice_dimension); i < data_rank; ++i) {
-        *ctx.getOutputType(0)
-             ->mutable_tensor_type()
-             ->mutable_shape()
-             ->add_dim() = data_shape.dim(i);
-      }
-    })
-    .SetDoc(R"DOC(
+  ONNX_CONTRIB_OPERATOR_SCHEMA(GatherND)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .Input(0, "data", "Tensor of rank r >= 1.", "T")
+      .Input(1, "indices", "Tensor of rank q >= 1.", "Tind")
+      .Output(0, "output", "Tensor of rank q-1+r-indices[-1].", "T")
+      .TypeConstraint(
+          "T",
+          OpSchema::all_tensor_types(),
+          "Constrain input and output types to any tensor type.")
+      .TypeConstraint(
+          "Tind",
+          {"tensor(int32)", "tensor(int64)"},
+          "Constrain indice type to int32 or int64")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        if (!hasNInputShapes(ctx, 2)) {
+          return;
+        }
+        auto& data_shape = ctx.getInputType(0)->tensor_type().shape();
+        auto& indices_shape = ctx.getInputType(1)->tensor_type().shape();
+        auto data_rank = data_shape.dim_size();
+        auto indices_rank = indices_shape.dim_size();
+        if (data_rank < 1 || indices_rank < 1) {
+          fail_shape_inference("both data and indices tensor need to have rank larger than zero.");
+        }
+        auto last_indice_dimension = indices_shape.dim(indices_rank - 1).dim_value();
+        if (last_indice_dimension > data_rank) {
+          fail_shape_inference("last dimension of indices must not be larger and rank of data tensor");
+        }
+        for (int i = 0; i < indices_rank - 1; ++i) {
+          *ctx.getOutputType(0)
+               ->mutable_tensor_type()
+               ->mutable_shape()
+               ->add_dim() = indices_shape.dim(i);
+        }
+        for (int i = static_cast<int>(last_indice_dimension); i < data_rank; ++i) {
+          *ctx.getOutputType(0)
+               ->mutable_tensor_type()
+               ->mutable_shape()
+               ->add_dim() = data_shape.dim(i);
+        }
+      })
+      .SetDoc(R"DOC(
 Given `data` tensor of rank r >= 1, and `indices` tensor of rank q >= 1, gather
 slices of `data` into an output tensor of rank q - 1 + r - indices[-1].
 Example 1:
@@ -1122,135 +1109,135 @@ Example 4:
   output  = [[[2,3]],[[4,5]]]
 )DOC");
 
-ONNX_CONTRIB_OPERATOR_SCHEMA(WordConvEmbedding)
-    .SetDomain(kMSDomain)
-    .SinceVersion(1)
-    .Attr(
-        "embedding_size",
-        "Integer representing the embedding vector size for each word."
-        "If not provide, use the fileter size of conv weight",
-        AttributeProto::INT,
-        OPTIONAL)
-    .Attr(
-        "conv_window_size",
-        "This operator applies convolution to word from left to right with window equal to conv_window_size and stride to 1."
-        "Take word 'example' for example, with conv_window_size equal to 2, conv is applied to [ex],[xa], [am], [mp]..."
-        "If not provide, use the first dimension of conv kernal shape.",
-        AttributeProto::INT,
-        OPTIONAL)
-    .Attr(
-        "char_embedding_size",
-        "Integer representing the embedding vector size for each char."
-        "If not provide, use the char embedding size of embedding vector.",
-        AttributeProto::INT,
-        OPTIONAL)
-    .Input(0, "Sequence", "Specify batchs of sequence words to embedding", "T")
-    .Input(1, "W", "Specify weights of conv", "T1")
-    .Input(2, "B", "Specify bias of conv", "T1")
-    .Input(3, "C", "Specify embedding vector of char", "T1")
-    .Output(0, "Y", "output", "T1")
-    .TypeConstraint(
-        "T",
-        {"tensor(int32)"},
-        "Constrain to tensor(int32).")
-    .TypeConstraint(
-        "T1",
-        {"tensor(float)"},
-        "Constrain to tensor(float).")
-    .SetDoc(R"DOC(The WordConvEmbedding takes in a batch of sequence words and embed each word to a vector.)DOC");
+  ONNX_CONTRIB_OPERATOR_SCHEMA(WordConvEmbedding)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .Attr(
+          "embedding_size",
+          "Integer representing the embedding vector size for each word."
+          "If not provide, use the fileter size of conv weight",
+          AttributeProto::INT,
+          OPTIONAL)
+      .Attr(
+          "conv_window_size",
+          "This operator applies convolution to word from left to right with window equal to conv_window_size and stride to 1."
+          "Take word 'example' for example, with conv_window_size equal to 2, conv is applied to [ex],[xa], [am], [mp]..."
+          "If not provide, use the first dimension of conv kernal shape.",
+          AttributeProto::INT,
+          OPTIONAL)
+      .Attr(
+          "char_embedding_size",
+          "Integer representing the embedding vector size for each char."
+          "If not provide, use the char embedding size of embedding vector.",
+          AttributeProto::INT,
+          OPTIONAL)
+      .Input(0, "Sequence", "Specify batchs of sequence words to embedding", "T")
+      .Input(1, "W", "Specify weights of conv", "T1")
+      .Input(2, "B", "Specify bias of conv", "T1")
+      .Input(3, "C", "Specify embedding vector of char", "T1")
+      .Output(0, "Y", "output", "T1")
+      .TypeConstraint(
+          "T",
+          {"tensor(int32)"},
+          "Constrain to tensor(int32).")
+      .TypeConstraint(
+          "T1",
+          {"tensor(float)"},
+          "Constrain to tensor(float).")
+      .SetDoc(R"DOC(The WordConvEmbedding takes in a batch of sequence words and embed each word to a vector.)DOC");
 
-ONNX_CONTRIB_OPERATOR_SCHEMA(Pad)
-    .SetDomain(kMSDomain)
-    .SinceVersion(1)
-    .Attr(
-        "mode",
-        "Three modes: `constant`(default) - pads with a given constant value, "
-        "`reflect` - pads with the reflection of the vector mirrored on the first and last values of the vector along each axis, "
-        "`edge` - pads with the edge values of array",
-        AttributeProto::STRING,
-        std::string("constant"))
-    .Input(0, "data", "Input tensor.", "T")
-    .Input(
-        1,
-        "pads",
-        "Tensor of integers indicating the number of padding elements to add or remove (if negative) "
-        "at the beginning and end of each axis. For 2D input tensor, it is the number of pixels. "
-        "`pads` should be a 1D tensor of shape [2 * input_rank] or a 2D tensor of shape [1, 2 * input_rank]. "
-        "`pads` format (1D example) should be as follow [x1_begin, x2_begin,...,x1_end, x2_end,...], "
-        "where xi_begin is the number of pixels added at the beginning of axis `i` and "
-        "xi_end, the number of pixels added at the end of axis `i`.",
-        "tensor(int64)")
-    .Input(
-        2,
-        "value",
-        "(Optional) A scalar or rank 1 tensor containing a single value to be filled if the mode chosen is `constant` (by default it is 0.0).",
-        "T",
-        OpSchema::Optional)
-    .Output(0, "output", "Tensor after padding.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-      // Type inference
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      // Shape inference needs the input data shape
-      if (!hasNInputShapes(ctx, 1)) {
-        return;
-      }
-      const auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
-      const auto input_rank = input_shape.dim_size();
-
-      // Infer output shape if 'pads' tensor is available
-      const auto* pads_initializer = ctx.getInputData(1);
-      if (nullptr != pads_initializer) {
-        const auto& pads_shape = ctx.getInputType(1)->tensor_type().shape();
-        if ((pads_initializer->dims_size() != 1 &&
-             pads_initializer->dims_size() != 2) ||
-            (pads_initializer->dims_size() == 2 &&
-             pads_shape.dim((int)0).dim_value() != 1) ||
-            pads_initializer->data_type() != ONNX_NAMESPACE::TensorProto::INT64)
-          fail_shape_inference(
-              "'pads' input must be a 1D (shape: [input_rank]) "
-              "or 2D tensor (shape: [1, input_rank]) of type int64");
-
-        // make a copy of the returned const vector - may have to resize
-        // this in next step
-        std::vector<int64_t> pads_data;
-        if (pads_initializer->has_raw_data())
+  ONNX_CONTRIB_OPERATOR_SCHEMA(Pad)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .Attr(
+          "mode",
+          "Three modes: `constant`(default) - pads with a given constant value, "
+          "`reflect` - pads with the reflection of the vector mirrored on the first and last values of the vector along each axis, "
+          "`edge` - pads with the edge values of array",
+          AttributeProto::STRING,
+          std::string("constant"))
+      .Input(0, "data", "Input tensor.", "T")
+      .Input(
+          1,
+          "pads",
+          "Tensor of integers indicating the number of padding elements to add or remove (if negative) "
+          "at the beginning and end of each axis. For 2D input tensor, it is the number of pixels. "
+          "`pads` should be a 1D tensor of shape [2 * input_rank] or a 2D tensor of shape [1, 2 * input_rank]. "
+          "`pads` format (1D example) should be as follow [x1_begin, x2_begin,...,x1_end, x2_end,...], "
+          "where xi_begin is the number of pixels added at the beginning of axis `i` and "
+          "xi_end, the number of pixels added at the end of axis `i`.",
+          "tensor(int64)")
+      .Input(
+          2,
+          "value",
+          "(Optional) A scalar or rank 1 tensor containing a single value to be filled if the mode chosen is `constant` (by default it is 0.0).",
+          "T",
+          OpSchema::Optional)
+      .Output(0, "output", "Tensor after padding.", "T")
+      .TypeConstraint(
+          "T",
+          {"tensor(float16)", "tensor(float)", "tensor(double)"},
+          "Constrain input and output types to float tensors.")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        // Type inference
+        propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        // Shape inference needs the input data shape
+        if (!hasNInputShapes(ctx, 1)) {
           return;
-        else
-          pads_data.insert(
-              pads_data.end(),
-              pads_initializer->int64_data().begin(),
-              pads_initializer->int64_data().end());
+        }
+        const auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
+        const auto input_rank = input_shape.dim_size();
 
-        // fill with zeros if needed to reach appropriate size
-        if (pads_data.size() != static_cast<size_t>(2 * input_rank))
-          pads_data.resize(2 * input_rank, 0);
+        // Infer output shape if 'pads' tensor is available
+        const auto* pads_initializer = ctx.getInputData(1);
+        if (nullptr != pads_initializer) {
+          const auto& pads_shape = ctx.getInputType(1)->tensor_type().shape();
+          if ((pads_initializer->dims_size() != 1 &&
+               pads_initializer->dims_size() != 2) ||
+              (pads_initializer->dims_size() == 2 &&
+               pads_shape.dim((int)0).dim_value() != 1) ||
+              pads_initializer->data_type() != ONNX_NAMESPACE::TensorProto::INT64)
+            fail_shape_inference(
+                "'pads' input must be a 1D (shape: [input_rank]) "
+                "or 2D tensor (shape: [1, input_rank]) of type int64");
 
-        const auto& output_shape =
-            ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
-        for (size_t i = 0; (int64_t)i < input_rank; ++i) {
-          const auto& input_dim = input_shape.dim((int)i);
-          auto* output_dim = output_shape->add_dim();
-          if (input_dim.has_dim_value()) {
-            output_dim->set_dim_value(
-                input_dim.dim_value() + pads_data[i] + pads_data[i + input_rank]);
-          } else if (pads_data[i] + pads_data[i + input_rank] == 0) {
-            *output_dim = input_dim;
+          // make a copy of the returned const vector - may have to resize
+          // this in next step
+          std::vector<int64_t> pads_data;
+          if (pads_initializer->has_raw_data())
+            return;
+          else
+            pads_data.insert(
+                pads_data.end(),
+                pads_initializer->int64_data().begin(),
+                pads_initializer->int64_data().end());
+
+          // fill with zeros if needed to reach appropriate size
+          if (pads_data.size() != static_cast<size_t>(2 * input_rank))
+            pads_data.resize(2 * input_rank, 0);
+
+          const auto& output_shape =
+              ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+          for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+            const auto& input_dim = input_shape.dim((int)i);
+            auto* output_dim = output_shape->add_dim();
+            if (input_dim.has_dim_value()) {
+              output_dim->set_dim_value(
+                  input_dim.dim_value() + pads_data[i] + pads_data[i + input_rank]);
+            } else if (pads_data[i] + pads_data[i + input_rank] == 0) {
+              *output_dim = input_dim;
+            }
+          }
+        } else {
+          // Infer ouput shapes' rank in any case
+          auto* output_shape_0 = getOutputShape(ctx, 0);
+          for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+            output_shape_0->add_dim();
           }
         }
-      } else {
-        // Infer ouput shapes' rank in any case
-        auto* output_shape_0 = getOutputShape(ctx, 0);
-        for (size_t i = 0; (int64_t)i < input_rank; ++i) {
-          output_shape_0->add_dim();
-        }
-      }
-      return;
-    })
-    .SetDoc(R"DOC(
+        return;
+      })
+      .SetDoc(R"DOC(
             Given `data` tensor, pads, mode, and value.
             Example:
             Insert 0 pads to the beginning of the second dimension.
@@ -1269,57 +1256,57 @@ ONNX_CONTRIB_OPERATOR_SCHEMA(Pad)
                     ]
             )DOC");
 
-ONNX_CONTRIB_OPERATOR_SCHEMA(Unique)
-    .SetDomain(kMSDomain)
-    .SinceVersion(1)
-    .Input(0, "x", "A 1-D input tensor that is to be processed.", "T")
-    .Output(0, "y",
-            "A 1-D tensor of the same type as 'x' "
-            "containing all the unique values in 'x' sorted "
-            "in the same order that they occur in the input 'x'",
-            "T")
-    .Output(1, "idx",
-            "A 1-D INT64 tensor of the same size as 'x' "
-            "containing the indices for each value in 'x' "
-            "in the output 'uniques'",
-            "tensor(int64)")
-    .Output(2, "counts",
-            "A 1-D INT64 tensor containing the "
-            "the count of each element "
-            "of 'uniques' in the input 'x'",
-            "tensor(int64)")
-    .TypeConstraint("T", OpSchema::all_tensor_types(), "Input can be of any tensor type.")
-    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-      // Type inference
-      ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      ONNX_NAMESPACE::updateOutputElemType(ctx, 1, ONNX_NAMESPACE::TensorProto::INT64);
-      ONNX_NAMESPACE::updateOutputElemType(ctx, 2, ONNX_NAMESPACE::TensorProto::INT64);
+  ONNX_CONTRIB_OPERATOR_SCHEMA(Unique)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .Input(0, "x", "A 1-D input tensor that is to be processed.", "T")
+      .Output(0, "y",
+              "A 1-D tensor of the same type as 'x' "
+              "containing all the unique values in 'x' sorted "
+              "in the same order that they occur in the input 'x'",
+              "T")
+      .Output(1, "idx",
+              "A 1-D INT64 tensor of the same size as 'x' "
+              "containing the indices for each value in 'x' "
+              "in the output 'uniques'",
+              "tensor(int64)")
+      .Output(2, "counts",
+              "A 1-D INT64 tensor containing the "
+              "the count of each element "
+              "of 'uniques' in the input 'x'",
+              "tensor(int64)")
+      .TypeConstraint("T", OpSchema::all_tensor_types(), "Input can be of any tensor type.")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        // Type inference
+        ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        ONNX_NAMESPACE::updateOutputElemType(ctx, 1, ONNX_NAMESPACE::TensorProto::INT64);
+        ONNX_NAMESPACE::updateOutputElemType(ctx, 2, ONNX_NAMESPACE::TensorProto::INT64);
 
-      // Shape inference
+        // Shape inference
 
-      // shape of output 'uniques' and 'counts'
-      // depends on actual input data, but the rank is always 1
-      ctx.getOutputType(0)
-          ->mutable_tensor_type()
-          ->mutable_shape()
-          ->add_dim();
+        // shape of output 'uniques' and 'counts'
+        // depends on actual input data, but the rank is always 1
+        ctx.getOutputType(0)
+            ->mutable_tensor_type()
+            ->mutable_shape()
+            ->add_dim();
 
-      ctx.getOutputType(2)
-          ->mutable_tensor_type()
-          ->mutable_shape()
-          ->add_dim();
+        ctx.getOutputType(2)
+            ->mutable_tensor_type()
+            ->mutable_shape()
+            ->add_dim();
 
-      // if the input shape doesn't exist, further shape inference is not possible
-      if (!hasNInputShapes(ctx, 1)) {
+        // if the input shape doesn't exist, further shape inference is not possible
+        if (!hasNInputShapes(ctx, 1)) {
+          return;
+        }
+
+        // 'idx' output has same shape as input
+        ONNX_NAMESPACE::propagateShapeFromInputToOutput(ctx, 0, 1);
+
         return;
-      }
-
-      // 'idx' output has same shape as input
-      ONNX_NAMESPACE::propagateShapeFromInputToOutput(ctx, 0, 1);
-
-      return;
-    })
-    .SetDoc(R"DOC(
+      })
+      .SetDoc(R"DOC(
               Finds all the unique values (deduped list) present in the given input tensor. 
               This operator returns 3 outputs. 
               The first output tensor 'uniques' contains all of the unique elements of the input, 
@@ -1335,9 +1322,9 @@ ONNX_CONTRIB_OPERATOR_SCHEMA(Unique)
               )DOC");
 
 #ifdef MICROSOFT_INTERNAL
-// register internal ops
-RegisterInternalSchemas();
+  // register internal ops
+  RegisterInternalSchemas();
 #endif
 }  // namespace contrib
-}  // namespace onnxruntime
+}  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -475,12 +475,12 @@ and op)DOC";
 
           // actual shape inference processing
           // [N, C] can be copied over from the input as is
-          *output_shape->mutable_dim((int)0) = input_shape.dim((int)0);
-          *output_shape->mutable_dim((int)1) = input_shape.dim((int)1);
+          *output_shape->mutable_dim(static_cast<int>(0)) = input_shape.dim(static_cast<int>(0));
+          *output_shape->mutable_dim(static_cast<int>(1)) = input_shape.dim(static_cast<int>(1));
 
           // process 'H' and 'W'
-          if (!input_shape.dim((int)2).has_dim_value() ||
-              !input_shape.dim((int)3).has_dim_value()) {
+          if (!input_shape.dim(static_cast<int>(2)).has_dim_value() ||
+              !input_shape.dim(static_cast<int>(3)).has_dim_value()) {
             // either height and width input has symbolic dims, so can't proceed further
             // add two dims as placeholders for output_H and output_W and return
             output_shape->add_dim();
@@ -488,8 +488,8 @@ and op)DOC";
             return;
           }
 
-          int64_t H = input_shape.dim((int)2).dim_value();
-          int64_t W = input_shape.dim((int)3).dim_value();
+          int64_t H = input_shape.dim(static_cast<int>(2)).dim_value();
+          int64_t W = input_shape.dim(static_cast<int>(3)).dim_value();
 
           int64_t left_border = border[0],
                   top_border = border[1],
@@ -1197,7 +1197,7 @@ Example 4:
           if ((pads_initializer->dims_size() != 1 &&
                pads_initializer->dims_size() != 2) ||
               (pads_initializer->dims_size() == 2 &&
-               pads_shape.dim((int)0).dim_value() != 1) ||
+               pads_shape.dim(static_cast<int>(0)).dim_value() != 1) ||
               pads_initializer->data_type() != ONNX_NAMESPACE::TensorProto::INT64)
             fail_shape_inference(
                 "'pads' input must be a 1D (shape: [input_rank]) "
@@ -1220,8 +1220,8 @@ Example 4:
 
           const auto& output_shape =
               ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
-          for (size_t i = 0; (int64_t)i < input_rank; ++i) {
-            const auto& input_dim = input_shape.dim((int)i);
+          for (size_t i = 0; static_cast<int64_t>(i) < input_rank; ++i) {
+            const auto& input_dim = input_shape.dim(static_cast<int>(i));
             auto* output_dim = output_shape->add_dim();
             if (input_dim.has_dim_value()) {
               output_dim->set_dim_value(
@@ -1233,7 +1233,7 @@ Example 4:
         } else {
           // Infer ouput shapes' rank in any case
           auto* output_shape_0 = getOutputShape(ctx, 0);
-          for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+          for (size_t i = 0; static_cast<int64_t>(i) < input_rank; ++i) {
             output_shape_0->add_dim();
           }
         }

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -89,7 +89,7 @@ If scale is not provided, crop the borders as provided.)DOC";
   ONNX_CONTRIB_OPERATOR_SCHEMA(Crop)
       .SinceVersion(1)
       .SetDoc(Crop_ver1_doc)
-      .Attr("border", "A 1-D values of (leftBorder, topBorder, rightBorder, bottomBorder).", AttributeProto::INTS, OPTIONAL)
+      .Attr("border", "A 1-D values of (left_border, top_border, right_border, bottom_border).", AttributeProto::INTS, OPTIONAL)
       .Attr("scale", "A 1-D values of (height, width).", AttributeProto::INTS, OPTIONAL)
       .Input(0, "input", "Input tensor of shape [N,C,H,W]", "T")
       .Output(0, "output", "Result, has same type as input, with H and W dimensions reduced.", "T")
@@ -107,7 +107,9 @@ is applied to the tensor elementwise. )DOC";
       .Input(0, "X", "Input tensor", "T")
       .Output(0, "Y", "Output tensor", "T")
       .TypeConstraint("T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input and output types to float tensors.")
-      .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput);
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+
+      });
 
   static const char* DynamicSlice_ver1_doc = R"DOC(
 Produces a slice of the input tensor along multiple axes. Similar to numpy:
@@ -437,354 +439,443 @@ and op)DOC";
       .SinceVersion(10)
       .Deprecate()
       .SetDoc(Crop_ver1_doc)
-      .Attr("border", "A 1-D values of (leftBorder, topBorder, rightBorder, bottomBorder).", AttributeProto::INTS, OPTIONAL)
+      .Attr("border", "A 1-D values of (left_border, top_border, right_border, bottom_border).", AttributeProto::INTS, OPTIONAL)
       .Attr("scale", "A 1-D values of (height, width).", AttributeProto::INTS, OPTIONAL)
       .Input(0, "input", "Input tensor of shape [N,C,H,W]", "T")
       .Output(0, "output", "Result, has same type as input, with H and W dimensions reduced.", "T")
-      .TypeConstraint("T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input and output types to float tensors.");
-
-  ONNX_CONTRIB_OPERATOR_SCHEMA(DynamicSlice)
-      .SinceVersion(10)
-      .Deprecate()
-      .SetDoc(DynamicSlice_ver1_doc)
-      .Input(0, "data", "Tensor of data to extract slices from.", "T")
-      .Input(1, "starts", "1-D tensor of starting indices of corresponding axis in `axes`", "Tind")
-      .Input(2, "ends", "1-D tensor of ending indices (exclusive) of corresponding axis in axes", "Tind")
-      .Input(3, "axes", "1-D tensor of axes that `starts` and `ends` apply to.", "Tind", OpSchema::Optional)
-      .Output(0, "output", "Sliced data tensor.", "T")
-      .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
-      .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types");
-
-  ONNX_OPERATOR_SCHEMA(ScaledTanh)
-      .SinceVersion(10)
-      .Deprecate()
-      .Attr("alpha", "Scaling value", AttributeProto::FLOAT, OPTIONAL)
-      .Attr("beta", "Scaling value", AttributeProto::FLOAT, OPTIONAL)
-      .Input(0, "input", "Input tensor", "T")
-      .Output(
-          0,
-          "output",
-          "The scaled hyperbolic tangent values of the input tensor "
-          "computed element-wise",
-          "T")
-      .TypeConstraint(
-          "T",
-          {"tensor(float16)", "tensor(float)", "tensor(double)"},
-          "Constrain input and output types to float tensors.")
-      .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput);
-
-  // End of ONNX exp ops(Affine, Crop, ParametricSoftplus, ImageScaler, ThresholdedRelu, DynamicSlice, ScaledTanh, MVN) old version history maintenance
-
-  ONNX_CONTRIB_OPERATOR_SCHEMA(SampleOp)
-      .SetDomain(kMSDomain)
-      .SinceVersion(1)
-      .Input(0, "X", "input", "T")
-      .Output(0, "Y", "output", "T")
-      .TypeConstraint(
-          "T",
-          ONNX_NAMESPACE::OpSchema::numeric_types_for_math_reduction(),
-          "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
-      .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput)
-      .SetDoc(R"DOC(
-Sample echo operator.)DOC");
-
-  // register schemas for more operators here
-  ONNX_CONTRIB_OPERATOR_SCHEMA(MaxpoolWithMask)
-      .SetDomain(kMSDomain)
-      .SinceVersion(1)
-      .SetDoc(R"DOC(For internal use.)DOC")
-      .Attr(
-          "auto_pad",
-          "",
-          AttributeProto::STRING,
-          std::string("NOTSET"))
-      .Attr(
-          "kernel_shape",
-          "",
-          AttributeProto::INTS,
-          OPTIONAL)
-      .Attr("pads",
-            "",
-            AttributeProto::INTS, OPTIONAL)
-      .Attr(
-          "storage_order",
-          "",
-          AttributeProto::INT,
-          static_cast<int64_t>(0))
-      .Attr(
-          "strides", "", AttributeProto::INTS, OPTIONAL)
-      .Input(
-          0,
-          "X",
-          "",
-          "T")
-      .Input(1, "M", "mask", "tensor(int32)")
-      .Output(
-          0,
-          "Y",
-          "",
-          "T")
-      .TypeConstraint("T", {"tensor(float)"}, "Constrain input0 and output types to float tensors")
-      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
-        ONNX_NAMESPACE::convPoolShapeInference(ctx, false, true, 0, 1);
-      });
-
-  ONNX_CONTRIB_OPERATOR_SCHEMA(ConvTransposeWithDynamicPads)
-      .SetDomain(kMSDomain)
-      .SinceVersion(1)
-      .SetDoc(R"DOC()DOC")
-      .Attr(
-          "kernel_shape",
-          "",
-          AttributeProto::INTS,
-          OPTIONAL)
-      .Attr("output_padding",
-            "",
-            AttributeProto::INTS,
-            OPTIONAL)
-      .Attr(
-          "dilations",
-          "",
-          AttributeProto::INTS,
-          OPTIONAL)
-      .Attr(
-          "strides",
-          "",
-          AttributeProto::INTS,
-          OPTIONAL)
-      .Attr(
-          "auto_pad",
-          "",
-          AttributeProto::STRING,
-          std::string("NOTSET"))
-      .Attr(
-          "group",
-          "",
-          AttributeProto::INT,
-          static_cast<int64_t>(1))
-      .Input(
-          0,
-          "X",
-          "",
-          "T")
-      .Input(
-          1,
-          "W",
-          "",
-          "T")
-      .Input(2, "Pads", "", "tensor(int64)", OpSchema::Optional)
-      .Input(3, "B", "", "T", OpSchema::Optional)
-      .Output(
-          0,
-          "Y",
-          "",
-          "T")
-      .TypeConstraint("T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input and output types to float tensors")
-      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      });
-
-  ONNX_CONTRIB_OPERATOR_SCHEMA(FusedConv)
-      .SetDomain(kMSDomain)
-      .SinceVersion(1)
-      .SetDoc(R"DOC(
-The fused convolution operator schema is the same as Conv besides it includes an attribute
-activation.)DOC")
-      .Attr(
-          "auto_pad",
-          "",
-          AttributeProto::STRING,
-          std::string("NOTSET"))
-      .Attr(
-          "kernel_shape",
-          "",
-          AttributeProto::INTS,
-          OPTIONAL)
-      .Attr(
-          "dilations",
-          "",
-          AttributeProto::INTS,
-          OPTIONAL)
-      .Attr(
-          "strides", "", AttributeProto::INTS, OPTIONAL)
-      .Attr("pads",
-            "",
-            AttributeProto::INTS, OPTIONAL)
-      .Attr(
-          "group",
-          "",
-          AttributeProto::INT,
-          static_cast<int64_t>(1))
-      .Attr(
-          "activation",
-          "",
-          AttributeProto::STRING,
-          OPTIONAL)
-      .Attr(
-          "alpha",
-          "",
-          AttributeProto::FLOAT,
-          OPTIONAL)
-      .Input(
-          0,
-          "X",
-          "",
-          "T")
-      .Input(
-          1,
-          "W",
-          "",
-          "T")
-      .Input(2, "B", "", "T", OpSchema::Optional)
-      .Output(
-          0,
-          "Y",
-          "",
-          "T")
-      .TypeConstraint("T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input and output types to float tensors")
-      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
-        ONNX_NAMESPACE::convPoolShapeInference(ctx, true, false, 0, 1);
-      });
-
-  ONNX_CONTRIB_OPERATOR_SCHEMA(FusedGemm)
-      .SetDomain(kMSDomain)
-      .SinceVersion(1)
-      .SetDoc(R"DOC(
-The FusedGemm operator schema is the same as Gemm besides it includes attributes
-activation and leaky_relu_alpha.)DOC")
-      .Input(
-          0,
-          "A",
-          "Input tensor A. "
-          "The shape of A should be (M, K) if transA is 0, "
-          "or (K, M) if transA is non-zero.",
-          "T")
-      .Input(
-          1,
-          "B",
-          "Input tensor B. "
-          "The shape of B should be (K, N) if transB is 0, "
-          "or (N, K) if transB is non-zero.",
-          "T")
-      .Input(
-          2,
-          "C",
-          "Input tensor C. "
-          "The shape of C should be unidirectional broadcastable to (M, N).",
-          "T")
-      .Output(0, "Y", "Output tensor of shape (M, N).", "T")
-      .TypeConstraint(
-          "T",
-          {"tensor(float16)",
-           "tensor(float)",
-           "tensor(double)",
-           "tensor(uint32)",
-           "tensor(uint64)",
-           "tensor(int32)",
-           "tensor(int64)"},
-          "Constrain input and output types to float/int tensors.")
-      .Attr(
-          "transA",
-          "Whether A should be transposed",
-          AttributeProto::INT,
-          static_cast<int64_t>(0))
-      .Attr(
-          "transB",
-          "Whether B should be transposed",
-          AttributeProto::INT,
-          static_cast<int64_t>(0))
-      .Attr(
-          "alpha",
-          "Scalar multiplier for the product of input tensors A * B.",
-          AttributeProto::FLOAT,
-          1.0f)
-      .Attr(
-          "beta",
-          "Scalar multiplier for input tensor C.",
-          AttributeProto::FLOAT,
-          1.0f)
-      .Attr(
-          "activation",
-          "",
-          AttributeProto::STRING,
-          OPTIONAL)
-      .Attr(
-          "leaky_relu_alpha",
-          "",
-          AttributeProto::FLOAT,
-          OPTIONAL)
-      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        propagateElemTypeFromInputToOutput(ctx, 0, 0);
-        if (hasNInputShapes(ctx, 2)) {
-          auto transAAttr = ctx.getAttribute("transA");
-          bool transA =
-              transAAttr ? static_cast<int>(transAAttr->i()) != 0 : false;
-          auto transBAttr = ctx.getAttribute("transB");
-          bool transB =
-              transBAttr ? static_cast<int>(transBAttr->i()) != 0 : false;
-          auto& first_input_shape = getInputShape(ctx, 0);
-          auto& second_input_shape = getInputShape(ctx, 1);
-          if (first_input_shape.dim_size() != 2)
-            fail_shape_inference("First input does not have rank 2");
-          if (second_input_shape.dim_size() != 2)
-            fail_shape_inference("Second input does not have rank 2");
-          updateOutputShape(
-              ctx,
-              0,
-              {first_input_shape.dim(transA ? 1 : 0),
-               second_input_shape.dim(transB ? 0 : 1)});
-        }
-      });
-
-  ONNX_CONTRIB_OPERATOR_SCHEMA(ExpandDims)
-      .SetDomain(kMSDomain)
-      .SinceVersion(1)
-      .Input(0, "X", "input", "T")
-      .Input(1, "axis", "Specified axis to insert a dimension", "tensor(int32)")
-      .Output(0, "Y", "output", "T")
-      .TypeConstraint(
-          "T",
-          ONNX_NAMESPACE::OpSchema::all_tensor_types(),
-          "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
+      .TypeConstraint("T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input and output types to float tensors.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         // Type inference
-        propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
 
         // Shape inference
-        if (!hasInputShape(ctx, 0))
-          return;
+        auto* output_shape =
+            ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
 
-        auto& input_shape = getInputShape(ctx, 0);
-        const int rank = input_shape.dim_size();
-        const ONNX_NAMESPACE::TensorProto* axis_initializer = ctx.getInputData(1);
-        if (!axis_initializer)
-          return;
-        const int axis = axis_initializer->int32_data()[0];
-        if (axis > rank || axis < -rank - 1) {
-          fail_shape_inference("Input axis is invalid: ", axis);
+        if (ONNX_NAMESPACE::hasNInputShapes(ctx, 1)) {
+          const auto& input_shape =
+              ctx.getInputType(0)->tensor_type().shape();
+          const auto input_rank =
+              input_shape.dim_size();
+          if (input_rank != 4)
+            fail_shape_inference("Input's shape must be 4-D");
+
+          // parse necessary attributes for futher processing
+          std::vector<int64_t> border;
+          bool border_present =
+              getRepeatedAttribute(ctx, "border", border);
+          if (!border_present || border.size() != 4)
+            fail_shape_inference(
+                "'Border' attribute must be present and must contain exactly 4 values - "
+                "(left_border, top_border, right_border, bottom_border)");
+
+          std::vector<int64_t> scale;
+          bool scale_present =
+              getRepeatedAttribute(ctx, "scale", scale);
+          if (scale_present && scale.size() != 2)
+            fail_shape_inference("'Scale' must contain exactly 2 values - (height, width)");
+
+          // actual shape inference processing
+          // [N, C] can be copied over from the input as is
+          *output_shape->mutable_dim((int)0) = input_shape.dim((int)0);
+          *output_shape->mutable_dim((int)1) = input_shape.dim((int)1);
+
+          // process 'H' and 'W'
+          if (!input_shape.dim((int)2).has_dim_value() ||
+              !input_shape.dim((int)3).has_dim_value()) {
+            // either height and width input has symbolic dims, so can't proceed further
+            // add two dims as placeholders for output_H and output_W and return
+            output_shape->add_dim();
+            output_shape->add_dim();
+            return;
+          }
+
+          int64_t H = input_shape.dim((int)2).dim_value();
+          int64_t W = input_shape.dim((int)3).dim_value();
+
+          int64_t left_border = border[0],
+                  top_border = border[1],
+                  right_border = border[2],
+                  bottom_border = border[3];
+
+          if (H <= top_border + bottom_border)
+            fail_shape_inference("Input's height (", H, ") needs to be greater than the top_border (", top_border, ") + bottom_border (", bottom_border, ")");
+
+          if (W <= left_border + right_border)
+            fail_shape_inference("Input's width (", W, ") needs to be greater than the left_border (", left_border, ") + right_border (", right_border, ")");
+
+          int64_t bottom_limit = H - bottom_border;
+          int64_t right_limit = W - right_border;
+
+          // scale = (height, width)
+          if (!scale.empty()) {
+            bottom_limit = top_border + scale[0];
+            right_limit = left_border + scale[1];
+
+            if (H < bottom_limit)
+              fail_shape_inference("Input's height (", H, ") needs to be greater than the top_border (", top_border, ") + scale[0] (", scale[0], ")");
+
+            if (W < right_limit)
+              fail_shape_inference("Input's width (", W, ") needs to be greater than the left_border (", left_border, ") + scale[1] (", scale[1], ")");
+          }
+
+          auto* h_output_dim = output_shape->add_dim();
+          h_output_dim->set_dim_value(bottom_limit - top_border);
+
+          auto* w_output_dim = output_shape->add_dim();
+          w_output_dim->set_dim_value(right_limit - left_border);
+
+        } else {
+          // Rank Inference at the very least
+          // (We know that the output is going to be 4-D)
+          for (int i = 0; i < 4; ++i) {
+            output_shape->add_dim();
+          }
         }
-        int pos = axis >= 0 ? axis : rank + axis - 1;
-        ONNX_NAMESPACE::TensorShapeProto output_shape;
-        for (int i = 0; i < pos; ++i) {
-          output_shape.add_dim();
-          *(output_shape.mutable_dim(i)) = input_shape.dim(i);
-        }
+      });
+
+ONNX_CONTRIB_OPERATOR_SCHEMA(DynamicSlice)
+    .SinceVersion(10)
+    .Deprecate()
+    .SetDoc(DynamicSlice_ver1_doc)
+    .Input(0, "data", "Tensor of data to extract slices from.", "T")
+    .Input(1, "starts", "1-D tensor of starting indices of corresponding axis in `axes`", "Tind")
+    .Input(2, "ends", "1-D tensor of ending indices (exclusive) of corresponding axis in axes", "Tind")
+    .Input(3, "axes", "1-D tensor of axes that `starts` and `ends` apply to.", "Tind", OpSchema::Optional)
+    .Output(0, "output", "Sliced data tensor.", "T")
+    .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
+    .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types");
+
+ONNX_OPERATOR_SCHEMA(ScaledTanh)
+    .SinceVersion(10)
+    .Deprecate()
+    .Attr("alpha", "Scaling value", AttributeProto::FLOAT, OPTIONAL)
+    .Attr("beta", "Scaling value", AttributeProto::FLOAT, OPTIONAL)
+    .Input(0, "input", "Input tensor", "T")
+    .Output(
+        0,
+        "output",
+        "The scaled hyperbolic tangent values of the input tensor "
+        "computed element-wise",
+        "T")
+    .TypeConstraint(
+        "T",
+        {"tensor(float16)", "tensor(float)", "tensor(double)"},
+        "Constrain input and output types to float tensors.")
+    .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput);
+
+// End of ONNX exp ops(Affine, Crop, ParametricSoftplus, ImageScaler, ThresholdedRelu, DynamicSlice, ScaledTanh, MVN) old version history maintenance
+
+ONNX_CONTRIB_OPERATOR_SCHEMA(SampleOp)
+    .SetDomain(kMSDomain)
+    .SinceVersion(1)
+    .Input(0, "X", "input", "T")
+    .Output(0, "Y", "output", "T")
+    .TypeConstraint(
+        "T",
+        ONNX_NAMESPACE::OpSchema::numeric_types_for_math_reduction(),
+        "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
+    .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput)
+    .SetDoc(R"DOC(
+Sample echo operator.)DOC");
+
+// register schemas for more operators here
+ONNX_CONTRIB_OPERATOR_SCHEMA(MaxpoolWithMask)
+    .SetDomain(kMSDomain)
+    .SinceVersion(1)
+    .SetDoc(R"DOC(For internal use.)DOC")
+    .Attr(
+        "auto_pad",
+        "",
+        AttributeProto::STRING,
+        std::string("NOTSET"))
+    .Attr(
+        "kernel_shape",
+        "",
+        AttributeProto::INTS,
+        OPTIONAL)
+    .Attr("pads",
+          "",
+          AttributeProto::INTS, OPTIONAL)
+    .Attr(
+        "storage_order",
+        "",
+        AttributeProto::INT,
+        static_cast<int64_t>(0))
+    .Attr(
+        "strides", "", AttributeProto::INTS, OPTIONAL)
+    .Input(
+        0,
+        "X",
+        "",
+        "T")
+    .Input(1, "M", "mask", "tensor(int32)")
+    .Output(
+        0,
+        "Y",
+        "",
+        "T")
+    .TypeConstraint("T", {"tensor(float)"}, "Constrain input0 and output types to float tensors")
+    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+      ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
+      ONNX_NAMESPACE::convPoolShapeInference(ctx, false, true, 0, 1);
+    });
+
+ONNX_CONTRIB_OPERATOR_SCHEMA(ConvTransposeWithDynamicPads)
+    .SetDomain(kMSDomain)
+    .SinceVersion(1)
+    .SetDoc(R"DOC()DOC")
+    .Attr(
+        "kernel_shape",
+        "",
+        AttributeProto::INTS,
+        OPTIONAL)
+    .Attr("output_padding",
+          "",
+          AttributeProto::INTS,
+          OPTIONAL)
+    .Attr(
+        "dilations",
+        "",
+        AttributeProto::INTS,
+        OPTIONAL)
+    .Attr(
+        "strides",
+        "",
+        AttributeProto::INTS,
+        OPTIONAL)
+    .Attr(
+        "auto_pad",
+        "",
+        AttributeProto::STRING,
+        std::string("NOTSET"))
+    .Attr(
+        "group",
+        "",
+        AttributeProto::INT,
+        static_cast<int64_t>(1))
+    .Input(
+        0,
+        "X",
+        "",
+        "T")
+    .Input(
+        1,
+        "W",
+        "",
+        "T")
+    .Input(2, "Pads", "", "tensor(int64)", OpSchema::Optional)
+    .Input(3, "B", "", "T", OpSchema::Optional)
+    .Output(
+        0,
+        "Y",
+        "",
+        "T")
+    .TypeConstraint("T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input and output types to float tensors")
+    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+      propagateElemTypeFromInputToOutput(ctx, 0, 0);
+    });
+
+ONNX_CONTRIB_OPERATOR_SCHEMA(FusedConv)
+    .SetDomain(kMSDomain)
+    .SinceVersion(1)
+    .SetDoc(R"DOC(
+The fused convolution operator schema is the same as Conv besides it includes an attribute
+activation.)DOC")
+    .Attr(
+        "auto_pad",
+        "",
+        AttributeProto::STRING,
+        std::string("NOTSET"))
+    .Attr(
+        "kernel_shape",
+        "",
+        AttributeProto::INTS,
+        OPTIONAL)
+    .Attr(
+        "dilations",
+        "",
+        AttributeProto::INTS,
+        OPTIONAL)
+    .Attr(
+        "strides", "", AttributeProto::INTS, OPTIONAL)
+    .Attr("pads",
+          "",
+          AttributeProto::INTS, OPTIONAL)
+    .Attr(
+        "group",
+        "",
+        AttributeProto::INT,
+        static_cast<int64_t>(1))
+    .Attr(
+        "activation",
+        "",
+        AttributeProto::STRING,
+        OPTIONAL)
+    .Attr(
+        "alpha",
+        "",
+        AttributeProto::FLOAT,
+        OPTIONAL)
+    .Input(
+        0,
+        "X",
+        "",
+        "T")
+    .Input(
+        1,
+        "W",
+        "",
+        "T")
+    .Input(2, "B", "", "T", OpSchema::Optional)
+    .Output(
+        0,
+        "Y",
+        "",
+        "T")
+    .TypeConstraint("T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input and output types to float tensors")
+    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+      ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
+      ONNX_NAMESPACE::convPoolShapeInference(ctx, true, false, 0, 1);
+    });
+
+ONNX_CONTRIB_OPERATOR_SCHEMA(FusedGemm)
+    .SetDomain(kMSDomain)
+    .SinceVersion(1)
+    .SetDoc(R"DOC(
+The FusedGemm operator schema is the same as Gemm besides it includes attributes
+activation and leaky_relu_alpha.)DOC")
+    .Input(
+        0,
+        "A",
+        "Input tensor A. "
+        "The shape of A should be (M, K) if transA is 0, "
+        "or (K, M) if transA is non-zero.",
+        "T")
+    .Input(
+        1,
+        "B",
+        "Input tensor B. "
+        "The shape of B should be (K, N) if transB is 0, "
+        "or (N, K) if transB is non-zero.",
+        "T")
+    .Input(
+        2,
+        "C",
+        "Input tensor C. "
+        "The shape of C should be unidirectional broadcastable to (M, N).",
+        "T")
+    .Output(0, "Y", "Output tensor of shape (M, N).", "T")
+    .TypeConstraint(
+        "T",
+        {"tensor(float16)",
+         "tensor(float)",
+         "tensor(double)",
+         "tensor(uint32)",
+         "tensor(uint64)",
+         "tensor(int32)",
+         "tensor(int64)"},
+        "Constrain input and output types to float/int tensors.")
+    .Attr(
+        "transA",
+        "Whether A should be transposed",
+        AttributeProto::INT,
+        static_cast<int64_t>(0))
+    .Attr(
+        "transB",
+        "Whether B should be transposed",
+        AttributeProto::INT,
+        static_cast<int64_t>(0))
+    .Attr(
+        "alpha",
+        "Scalar multiplier for the product of input tensors A * B.",
+        AttributeProto::FLOAT,
+        1.0f)
+    .Attr(
+        "beta",
+        "Scalar multiplier for input tensor C.",
+        AttributeProto::FLOAT,
+        1.0f)
+    .Attr(
+        "activation",
+        "",
+        AttributeProto::STRING,
+        OPTIONAL)
+    .Attr(
+        "leaky_relu_alpha",
+        "",
+        AttributeProto::FLOAT,
+        OPTIONAL)
+    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+      propagateElemTypeFromInputToOutput(ctx, 0, 0);
+      if (hasNInputShapes(ctx, 2)) {
+        auto transAAttr = ctx.getAttribute("transA");
+        bool transA =
+            transAAttr ? static_cast<int>(transAAttr->i()) != 0 : false;
+        auto transBAttr = ctx.getAttribute("transB");
+        bool transB =
+            transBAttr ? static_cast<int>(transBAttr->i()) != 0 : false;
+        auto& first_input_shape = getInputShape(ctx, 0);
+        auto& second_input_shape = getInputShape(ctx, 1);
+        if (first_input_shape.dim_size() != 2)
+          fail_shape_inference("First input does not have rank 2");
+        if (second_input_shape.dim_size() != 2)
+          fail_shape_inference("Second input does not have rank 2");
+        updateOutputShape(
+            ctx,
+            0,
+            {first_input_shape.dim(transA ? 1 : 0),
+             second_input_shape.dim(transB ? 0 : 1)});
+      }
+    });
+
+ONNX_CONTRIB_OPERATOR_SCHEMA(ExpandDims)
+    .SetDomain(kMSDomain)
+    .SinceVersion(1)
+    .Input(0, "X", "input", "T")
+    .Input(1, "axis", "Specified axis to insert a dimension", "tensor(int32)")
+    .Output(0, "Y", "output", "T")
+    .TypeConstraint(
+        "T",
+        ONNX_NAMESPACE::OpSchema::all_tensor_types(),
+        "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
+    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+      // Type inference
+      propagateElemTypeFromInputToOutput(ctx, 0, 0);
+
+      // Shape inference
+      if (!hasInputShape(ctx, 0))
+        return;
+
+      auto& input_shape = getInputShape(ctx, 0);
+      const int rank = input_shape.dim_size();
+      const ONNX_NAMESPACE::TensorProto* axis_initializer = ctx.getInputData(1);
+      if (!axis_initializer)
+        return;
+      const int axis = axis_initializer->int32_data()[0];
+      if (axis > rank || axis < -rank - 1) {
+        fail_shape_inference("Input axis is invalid: ", axis);
+      }
+      int pos = axis >= 0 ? axis : rank + axis - 1;
+      ONNX_NAMESPACE::TensorShapeProto output_shape;
+      for (int i = 0; i < pos; ++i) {
         output_shape.add_dim();
-        output_shape.mutable_dim(pos)->set_dim_value(1);
-        for (int i = pos + 1; i < rank + 1; ++i) {
-          output_shape.add_dim();
-          *(output_shape.mutable_dim(i)) = input_shape.dim(i - 1);
-        }
-        updateOutputShape(ctx, 0, output_shape);
-      })
-      .SetDoc(R"DOC(ExpandDims echo operator.)DOC");
+        *(output_shape.mutable_dim(i)) = input_shape.dim(i);
+      }
+      output_shape.add_dim();
+      output_shape.mutable_dim(pos)->set_dim_value(1);
+      for (int i = pos + 1; i < rank + 1; ++i) {
+        output_shape.add_dim();
+        *(output_shape.mutable_dim(i)) = input_shape.dim(i - 1);
+      }
+      updateOutputShape(ctx, 0, output_shape);
+    })
+    .SetDoc(R"DOC(ExpandDims echo operator.)DOC");
 
-  ONNX_CONTRIB_OPERATOR_SCHEMA_ELSEWHERE(AttnLSTM, RegisterAttnLSTMContribOpSchema);
-  ONNX_CONTRIB_OPERATOR_SCHEMA_ELSEWHERE(Range, RegisterRangeOpSchema);
+ONNX_CONTRIB_OPERATOR_SCHEMA_ELSEWHERE(AttnLSTM, RegisterAttnLSTMContribOpSchema);
+ONNX_CONTRIB_OPERATOR_SCHEMA_ELSEWHERE(Range, RegisterRangeOpSchema);
 
-  static const char* Tokenizer_ver1_doc = R"DOC(
+static const char* Tokenizer_ver1_doc = R"DOC(
   Tokenizer divides each string in X into a vector of strings along the last axis. Allowed input shapes are [C] and [N, C].
   If the maximum number of tokens found per input string is D, the output shape would be [N, C, D] when input shape is [N, C].
   Similarly, if input shape is [C] then the output should be [C, D]. Tokenizer has two different operation modes.
@@ -828,189 +919,189 @@ of [N, 0] then [N, 0].
 
 )DOC";
 
-  ONNX_CONTRIB_OPERATOR_SCHEMA(Tokenizer)
-      .SetDomain(kMSDomain)
-      .SinceVersion(1)
-      .Input(0, "X", "Strings to tokenize", "T")
-      .Output(0, "Y", "Tokenized strings", "T")
-      .TypeConstraint(
-          "T",
-          {"tensor(string)"},
-          "Input/Output is a string tensor")
-      .Attr(
-          "mark",
-          "Boolean whether to mark the beginning/end character with start of text character (0x02)/end of text character (0x03).",
-          AttributeProto::INT)
-      .Attr(
-          "pad_value",
-          "The string used to pad output tensors when the tokens extracted doesn't match the maximum number of tokens found. If start/end markers are needed, padding will appear outside the markers.",
-          AttributeProto::STRING)
-      .Attr(
-          "tokenexp",
-          "An optional string. Token's regular expression in basic POSIX format"
-          " (http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_03)."
-          " If set, tokenizer may produce tokens matching the specified pattern. Note that one and only of"
-          " 'tokenexp' and 'separators' should be set.",
-          AttributeProto::STRING,
-          OPTIONAL)
-      .Attr(
-          "separators",
-          "an optional list of strings attribute that contains a list of separators - regular expressions to match separators"
-          " Two consecutive segments in X connected by a separator would be divided into two tokens."
-          " For example, if the input is \"Hello World!\" and this attribute contains only one space character,"
-          " the corresponding output would be [\"Hello\", \"World!\"]. To achieve character-level tokenization,"
-          " one should set the 'separators' to [\"\"], which contains an empty string.",
-          AttributeProto::STRINGS,
-          OPTIONAL)
-      .Attr(
-          "mincharnum",
-          "Minimum number of characters allowed in the output. For example, if mincharnum is 2, tokens such as \"A\" and \"B\" would be ignored",
-          AttributeProto::INT)
-      .SetDoc(Tokenizer_ver1_doc)
-      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        propagateElemTypeFromInputToOutput(ctx, 0, 0);
+ONNX_CONTRIB_OPERATOR_SCHEMA(Tokenizer)
+    .SetDomain(kMSDomain)
+    .SinceVersion(1)
+    .Input(0, "X", "Strings to tokenize", "T")
+    .Output(0, "Y", "Tokenized strings", "T")
+    .TypeConstraint(
+        "T",
+        {"tensor(string)"},
+        "Input/Output is a string tensor")
+    .Attr(
+        "mark",
+        "Boolean whether to mark the beginning/end character with start of text character (0x02)/end of text character (0x03).",
+        AttributeProto::INT)
+    .Attr(
+        "pad_value",
+        "The string used to pad output tensors when the tokens extracted doesn't match the maximum number of tokens found. If start/end markers are needed, padding will appear outside the markers.",
+        AttributeProto::STRING)
+    .Attr(
+        "tokenexp",
+        "An optional string. Token's regular expression in basic POSIX format"
+        " (http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_03)."
+        " If set, tokenizer may produce tokens matching the specified pattern. Note that one and only of"
+        " 'tokenexp' and 'separators' should be set.",
+        AttributeProto::STRING,
+        OPTIONAL)
+    .Attr(
+        "separators",
+        "an optional list of strings attribute that contains a list of separators - regular expressions to match separators"
+        " Two consecutive segments in X connected by a separator would be divided into two tokens."
+        " For example, if the input is \"Hello World!\" and this attribute contains only one space character,"
+        " the corresponding output would be [\"Hello\", \"World!\"]. To achieve character-level tokenization,"
+        " one should set the 'separators' to [\"\"], which contains an empty string.",
+        AttributeProto::STRINGS,
+        OPTIONAL)
+    .Attr(
+        "mincharnum",
+        "Minimum number of characters allowed in the output. For example, if mincharnum is 2, tokens such as \"A\" and \"B\" would be ignored",
+        AttributeProto::INT)
+    .SetDoc(Tokenizer_ver1_doc)
+    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+      propagateElemTypeFromInputToOutput(ctx, 0, 0);
 
-        // Shape inference
-        if (!hasInputShape(ctx, 0))
-          return;
+      // Shape inference
+      if (!hasInputShape(ctx, 0))
+        return;
 
-        ONNX_NAMESPACE::TensorShapeProto output_shape;
-        auto& input_shape = getInputShape(ctx, 0);
-        auto& dims = input_shape.dim();
-        if (dims.size() < 1 || dims.size() > 2) {
-          fail_shape_inference("Input dimensions are either [C] or [N][C] allowed");
+      ONNX_NAMESPACE::TensorShapeProto output_shape;
+      auto& input_shape = getInputShape(ctx, 0);
+      auto& dims = input_shape.dim();
+      if (dims.size() < 1 || dims.size() > 2) {
+        fail_shape_inference("Input dimensions are either [C] or [N][C] allowed");
+      }
+
+      int64_t size = 1;
+      for (auto& dim : dims) {
+        if (dim.has_dim_value()) {
+          size *= dim.dim_value();
         }
+      }
 
-        int64_t size = 1;
+      if (size > 0) {
         for (auto& dim : dims) {
-          if (dim.has_dim_value()) {
-            size *= dim.dim_value();
-          }
+          *output_shape.add_dim() = dim;
         }
-
-        if (size > 0) {
-          for (auto& dim : dims) {
-            *output_shape.add_dim() = dim;
-          }
-          // Add the last unknown dimension
-          // only if the input is not empty
-          output_shape.add_dim();
-        } else if (size == 0) {
-          if (dims.size() == 2) {
-            *output_shape.add_dim() = dims[0];
-          }
-          output_shape.add_dim()->set_dim_value(0);
+        // Add the last unknown dimension
+        // only if the input is not empty
+        output_shape.add_dim();
+      } else if (size == 0) {
+        if (dims.size() == 2) {
+          *output_shape.add_dim() = dims[0];
         }
-        updateOutputShape(ctx, 0, output_shape);
-      });
+        output_shape.add_dim()->set_dim_value(0);
+      }
+      updateOutputShape(ctx, 0, output_shape);
+    });
 
-  ONNX_CONTRIB_OPERATOR_SCHEMA(ReduceSumInteger)
-      .SetDomain(kMSDomain)
-      .SinceVersion(1)
-      .SetDoc(R"DOC(
+ONNX_CONTRIB_OPERATOR_SCHEMA(ReduceSumInteger)
+    .SetDomain(kMSDomain)
+    .SinceVersion(1)
+    .SetDoc(R"DOC(
 Computes the sum of the low-precision input tensor's element along the provided axes.
 The resulting tensor has the same rank as the input if keepdims equal 1. If keepdims equal 0,
 then the resulting tensor have the reduced dimension pruned. The above behavior is similar to numpy,
 with the exception that numpy default keepdims to False instead of True.)DOC")
-      .Input(0, "data", "An input tensor.", "T1")
-      .Output(0, "reduced", "Reduced output tensor.", "T2")
-      .TypeConstraint("T1", {"tensor(int8)", "tensor(uint8)"}, "Constrain input type to 8-bit integer tensor.")
-      .TypeConstraint("T2",
-                      {"tensor(int32)", "tensor(uint32)"},
-                      "Constrain output data type to 32-bit integer tensor."
-                      "T2 must be tensor(uint32) when T1 is tensor(uint8),"
-                      "or must be tensor(int32) when T1 is tensor(int8).")
-      .Attr(
-          "axes",
-          "A list of integers, along which to reduce. The default is to reduce over all the dimensions of the input tensor.",
-          AttributeProto::INTS)
-      .Attr(
-          "keepdims",
-          "Keep the reduced dimension or not, default 1 mean keep reduced dimension.",
-          AttributeProto::INT);
+    .Input(0, "data", "An input tensor.", "T1")
+    .Output(0, "reduced", "Reduced output tensor.", "T2")
+    .TypeConstraint("T1", {"tensor(int8)", "tensor(uint8)"}, "Constrain input type to 8-bit integer tensor.")
+    .TypeConstraint("T2",
+                    {"tensor(int32)", "tensor(uint32)"},
+                    "Constrain output data type to 32-bit integer tensor."
+                    "T2 must be tensor(uint32) when T1 is tensor(uint8),"
+                    "or must be tensor(int32) when T1 is tensor(int8).")
+    .Attr(
+        "axes",
+        "A list of integers, along which to reduce. The default is to reduce over all the dimensions of the input tensor.",
+        AttributeProto::INTS)
+    .Attr(
+        "keepdims",
+        "Keep the reduced dimension or not, default 1 mean keep reduced dimension.",
+        AttributeProto::INT);
 
-  ONNX_CONTRIB_OPERATOR_SCHEMA(MurmurHash3)
-      .SetDomain(kMSDomain)
-      .SinceVersion(1)
-      .SetDoc(R"DOC(The underlying implementation is MurmurHash3_x86_32 generating low latency 32bits hash suitable for implementing lookup tables, Bloom filters, count min sketch or feature hashing.)DOC")
-      .Input(0, "X", "An input tensor to hash.", "T1")
-      .Output(0, "Y", "32-bit hash value.", "T2")
-      .TypeConstraint("T1", {"tensor(uint32)", "tensor(int32)", "tensor(string)"}, "Constrain input type to unsigned or signed 32-bit integer tensor, or string tensor. It should be utf-8 encoded if using unicode.")
-      .TypeConstraint("T2", {"tensor(uint32)", "tensor(int32)"}, "Constrain output type to unsigned and signed 32-bit integer tensor.")
-      .Attr(
-          "seed",
-          "Seed for the hashing algorithm, unsigned 32-bit integer, default to 0.",
-          AttributeProto::INT,
-          (int64_t)0LL)
-      .Attr(
-          "positive",
-          "If value is 1, output type is uint32_t, else int32_t. Default value is 1.",
-          AttributeProto::INT,
-          (int64_t)1LL)
-      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        // type inference
-        auto positive_attr = ctx.getAttribute("positive");
-        bool is_positive =
-            positive_attr ? (static_cast<int>(positive_attr->i()) == 1 ? true : false) : true /* default value if attribute not present */;
-        auto output_data_type = ctx.getOutputType(0)->mutable_tensor_type();
-        if (is_positive) {
-          output_data_type->set_elem_type(::ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT32);
-        } else {
-          output_data_type->set_elem_type(::ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT32);
-        }
+ONNX_CONTRIB_OPERATOR_SCHEMA(MurmurHash3)
+    .SetDomain(kMSDomain)
+    .SinceVersion(1)
+    .SetDoc(R"DOC(The underlying implementation is MurmurHash3_x86_32 generating low latency 32bits hash suitable for implementing lookup tables, Bloom filters, count min sketch or feature hashing.)DOC")
+    .Input(0, "X", "An input tensor to hash.", "T1")
+    .Output(0, "Y", "32-bit hash value.", "T2")
+    .TypeConstraint("T1", {"tensor(uint32)", "tensor(int32)", "tensor(string)"}, "Constrain input type to unsigned or signed 32-bit integer tensor, or string tensor. It should be utf-8 encoded if using unicode.")
+    .TypeConstraint("T2", {"tensor(uint32)", "tensor(int32)"}, "Constrain output type to unsigned and signed 32-bit integer tensor.")
+    .Attr(
+        "seed",
+        "Seed for the hashing algorithm, unsigned 32-bit integer, default to 0.",
+        AttributeProto::INT,
+        (int64_t)0LL)
+    .Attr(
+        "positive",
+        "If value is 1, output type is uint32_t, else int32_t. Default value is 1.",
+        AttributeProto::INT,
+        (int64_t)1LL)
+    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+      // type inference
+      auto positive_attr = ctx.getAttribute("positive");
+      bool is_positive =
+          positive_attr ? (static_cast<int>(positive_attr->i()) == 1 ? true : false) : true /* default value if attribute not present */;
+      auto output_data_type = ctx.getOutputType(0)->mutable_tensor_type();
+      if (is_positive) {
+        output_data_type->set_elem_type(::ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT32);
+      } else {
+        output_data_type->set_elem_type(::ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT32);
+      }
 
-        // Shape inference
-        if (!hasInputShape(ctx, 0))
-          return;
+      // Shape inference
+      if (!hasInputShape(ctx, 0))
+        return;
 
-        auto& input_shape = getInputShape(ctx, 0);
-        updateOutputShape(ctx, 0, input_shape);
-      });
+      auto& input_shape = getInputShape(ctx, 0);
+      updateOutputShape(ctx, 0, input_shape);
+    });
 
-  ONNX_CONTRIB_OPERATOR_SCHEMA(GatherND)
-      .SetDomain(kMSDomain)
-      .SinceVersion(1)
-      .Input(0, "data", "Tensor of rank r >= 1.", "T")
-      .Input(1, "indices", "Tensor of rank q >= 1.", "Tind")
-      .Output(0, "output", "Tensor of rank q-1+r-indices[-1].", "T")
-      .TypeConstraint(
-          "T",
-          OpSchema::all_tensor_types(),
-          "Constrain input and output types to any tensor type.")
-      .TypeConstraint(
-          "Tind",
-          {"tensor(int32)", "tensor(int64)"},
-          "Constrain indice type to int32 or int64")
-      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        propagateElemTypeFromInputToOutput(ctx, 0, 0);
-        if (!hasNInputShapes(ctx, 2)) {
-          return;
-        }
-        auto& data_shape = ctx.getInputType(0)->tensor_type().shape();
-        auto& indices_shape = ctx.getInputType(1)->tensor_type().shape();
-        auto data_rank = data_shape.dim_size();
-        auto indices_rank = indices_shape.dim_size();
-        if (data_rank < 1 || indices_rank < 1) {
-          fail_shape_inference("both data and indices tensor need to have rank larger than zero.");
-        }
-        auto last_indice_dimension = indices_shape.dim(indices_rank - 1).dim_value();
-        if (last_indice_dimension > data_rank) {
-          fail_shape_inference("last dimension of indices must not be larger and rank of data tensor");
-        }
-        for (int i = 0; i < indices_rank - 1; ++i) {
-          *ctx.getOutputType(0)
-               ->mutable_tensor_type()
-               ->mutable_shape()
-               ->add_dim() = indices_shape.dim(i);
-        }
-        for (int i = static_cast<int>(last_indice_dimension); i < data_rank; ++i) {
-          *ctx.getOutputType(0)
-               ->mutable_tensor_type()
-               ->mutable_shape()
-               ->add_dim() = data_shape.dim(i);
-        }
-      })
-      .SetDoc(R"DOC(
+ONNX_CONTRIB_OPERATOR_SCHEMA(GatherND)
+    .SetDomain(kMSDomain)
+    .SinceVersion(1)
+    .Input(0, "data", "Tensor of rank r >= 1.", "T")
+    .Input(1, "indices", "Tensor of rank q >= 1.", "Tind")
+    .Output(0, "output", "Tensor of rank q-1+r-indices[-1].", "T")
+    .TypeConstraint(
+        "T",
+        OpSchema::all_tensor_types(),
+        "Constrain input and output types to any tensor type.")
+    .TypeConstraint(
+        "Tind",
+        {"tensor(int32)", "tensor(int64)"},
+        "Constrain indice type to int32 or int64")
+    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+      propagateElemTypeFromInputToOutput(ctx, 0, 0);
+      if (!hasNInputShapes(ctx, 2)) {
+        return;
+      }
+      auto& data_shape = ctx.getInputType(0)->tensor_type().shape();
+      auto& indices_shape = ctx.getInputType(1)->tensor_type().shape();
+      auto data_rank = data_shape.dim_size();
+      auto indices_rank = indices_shape.dim_size();
+      if (data_rank < 1 || indices_rank < 1) {
+        fail_shape_inference("both data and indices tensor need to have rank larger than zero.");
+      }
+      auto last_indice_dimension = indices_shape.dim(indices_rank - 1).dim_value();
+      if (last_indice_dimension > data_rank) {
+        fail_shape_inference("last dimension of indices must not be larger and rank of data tensor");
+      }
+      for (int i = 0; i < indices_rank - 1; ++i) {
+        *ctx.getOutputType(0)
+             ->mutable_tensor_type()
+             ->mutable_shape()
+             ->add_dim() = indices_shape.dim(i);
+      }
+      for (int i = static_cast<int>(last_indice_dimension); i < data_rank; ++i) {
+        *ctx.getOutputType(0)
+             ->mutable_tensor_type()
+             ->mutable_shape()
+             ->add_dim() = data_shape.dim(i);
+      }
+    })
+    .SetDoc(R"DOC(
 Given `data` tensor of rank r >= 1, and `indices` tensor of rank q >= 1, gather
 slices of `data` into an output tensor of rank q - 1 + r - indices[-1].
 Example 1:
@@ -1031,135 +1122,135 @@ Example 4:
   output  = [[[2,3]],[[4,5]]]
 )DOC");
 
-  ONNX_CONTRIB_OPERATOR_SCHEMA(WordConvEmbedding)
-      .SetDomain(kMSDomain)
-      .SinceVersion(1)
-      .Attr(
-          "embedding_size",
-          "Integer representing the embedding vector size for each word."
-          "If not provide, use the fileter size of conv weight",
-          AttributeProto::INT,
-          OPTIONAL)
-      .Attr(
-          "conv_window_size",
-          "This operator applies convolution to word from left to right with window equal to conv_window_size and stride to 1."
-          "Take word 'example' for example, with conv_window_size equal to 2, conv is applied to [ex],[xa], [am], [mp]..."
-          "If not provide, use the first dimension of conv kernal shape.",
-          AttributeProto::INT,
-          OPTIONAL)
-      .Attr(
-          "char_embedding_size",
-          "Integer representing the embedding vector size for each char."
-          "If not provide, use the char embedding size of embedding vector.",
-          AttributeProto::INT,
-          OPTIONAL)
-      .Input(0, "Sequence", "Specify batchs of sequence words to embedding", "T")
-      .Input(1, "W", "Specify weights of conv", "T1")
-      .Input(2, "B", "Specify bias of conv", "T1")
-      .Input(3, "C", "Specify embedding vector of char", "T1")
-      .Output(0, "Y", "output", "T1")
-      .TypeConstraint(
-          "T",
-          {"tensor(int32)"},
-          "Constrain to tensor(int32).")
-      .TypeConstraint(
-          "T1",
-          {"tensor(float)"},
-          "Constrain to tensor(float).")
-      .SetDoc(R"DOC(The WordConvEmbedding takes in a batch of sequence words and embed each word to a vector.)DOC");
+ONNX_CONTRIB_OPERATOR_SCHEMA(WordConvEmbedding)
+    .SetDomain(kMSDomain)
+    .SinceVersion(1)
+    .Attr(
+        "embedding_size",
+        "Integer representing the embedding vector size for each word."
+        "If not provide, use the fileter size of conv weight",
+        AttributeProto::INT,
+        OPTIONAL)
+    .Attr(
+        "conv_window_size",
+        "This operator applies convolution to word from left to right with window equal to conv_window_size and stride to 1."
+        "Take word 'example' for example, with conv_window_size equal to 2, conv is applied to [ex],[xa], [am], [mp]..."
+        "If not provide, use the first dimension of conv kernal shape.",
+        AttributeProto::INT,
+        OPTIONAL)
+    .Attr(
+        "char_embedding_size",
+        "Integer representing the embedding vector size for each char."
+        "If not provide, use the char embedding size of embedding vector.",
+        AttributeProto::INT,
+        OPTIONAL)
+    .Input(0, "Sequence", "Specify batchs of sequence words to embedding", "T")
+    .Input(1, "W", "Specify weights of conv", "T1")
+    .Input(2, "B", "Specify bias of conv", "T1")
+    .Input(3, "C", "Specify embedding vector of char", "T1")
+    .Output(0, "Y", "output", "T1")
+    .TypeConstraint(
+        "T",
+        {"tensor(int32)"},
+        "Constrain to tensor(int32).")
+    .TypeConstraint(
+        "T1",
+        {"tensor(float)"},
+        "Constrain to tensor(float).")
+    .SetDoc(R"DOC(The WordConvEmbedding takes in a batch of sequence words and embed each word to a vector.)DOC");
 
-  ONNX_CONTRIB_OPERATOR_SCHEMA(Pad)
-      .SetDomain(kMSDomain)
-      .SinceVersion(1)
-      .Attr(
-          "mode",
-          "Three modes: `constant`(default) - pads with a given constant value, "
-          "`reflect` - pads with the reflection of the vector mirrored on the first and last values of the vector along each axis, "
-          "`edge` - pads with the edge values of array",
-          AttributeProto::STRING,
-          std::string("constant"))
-      .Input(0, "data", "Input tensor.", "T")
-      .Input(
-          1,
-          "pads",
-          "Tensor of integers indicating the number of padding elements to add or remove (if negative) "
-          "at the beginning and end of each axis. For 2D input tensor, it is the number of pixels. "
-          "`pads` should be a 1D tensor of shape [2 * input_rank] or a 2D tensor of shape [1, 2 * input_rank]. "
-          "`pads` format (1D example) should be as follow [x1_begin, x2_begin,...,x1_end, x2_end,...], "
-          "where xi_begin is the number of pixels added at the beginning of axis `i` and "
-          "xi_end, the number of pixels added at the end of axis `i`.",
-          "tensor(int64)")
-      .Input(
-          2,
-          "value",
-          "(Optional) A scalar or rank 1 tensor containing a single value to be filled if the mode chosen is `constant` (by default it is 0.0).",
-          "T",
-          OpSchema::Optional)
-      .Output(0, "output", "Tensor after padding.", "T")
-      .TypeConstraint(
-          "T",
-          {"tensor(float16)", "tensor(float)", "tensor(double)"},
-          "Constrain input and output types to float tensors.")
-      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        // Type inference
-        propagateElemTypeFromInputToOutput(ctx, 0, 0);
-        // Shape inference needs the input data shape
-        if (!hasNInputShapes(ctx, 1)) {
-          return;
-        }
-        const auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
-        const auto input_rank = input_shape.dim_size();
-
-        // Infer output shape if 'pads' tensor is available
-        const auto* pads_initializer = ctx.getInputData(1);
-        if (nullptr != pads_initializer) {
-          const auto& pads_shape = ctx.getInputType(1)->tensor_type().shape();
-          if ((pads_initializer->dims_size() != 1 &&
-               pads_initializer->dims_size() != 2) ||
-              (pads_initializer->dims_size() == 2 &&
-               pads_shape.dim((int)0).dim_value() != 1) ||
-              pads_initializer->data_type() != ONNX_NAMESPACE::TensorProto::INT64)
-            fail_shape_inference(
-                "'pads' input must be a 1D (shape: [input_rank]) "
-                "or 2D tensor (shape: [1, input_rank]) of type int64");
-
-          // make a copy of the returned const vector - may have to resize
-          // this in next step
-          std::vector<int64_t> pads_data;
-          if (pads_initializer->has_raw_data())
-            return;
-          else
-            pads_data.insert(
-                pads_data.end(),
-                pads_initializer->int64_data().begin(),
-                pads_initializer->int64_data().end());
-
-          // fill with zeros if needed to reach appropriate size
-          if (pads_data.size() != static_cast<size_t>(2 * input_rank))
-            pads_data.resize(2 * input_rank, 0);
-
-          const auto& output_shape =
-              ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
-          for (size_t i = 0; (int64_t)i < input_rank; ++i) {
-            const auto& input_dim = input_shape.dim((int)i);
-            auto* output_dim = output_shape->add_dim();
-            if (input_dim.has_dim_value()) {
-              output_dim->set_dim_value(
-                  input_dim.dim_value() + pads_data[i] + pads_data[i + input_rank]);
-            } else if (pads_data[i] + pads_data[i + input_rank] == 0) {
-              *output_dim = input_dim;
-            }
-          }
-        } else {
-          // Infer ouput shapes' rank in any case
-          auto* output_shape_0 = getOutputShape(ctx, 0);
-          for (size_t i = 0; (int64_t)i < input_rank; ++i) {
-            output_shape_0->add_dim();
-          }
-        }
+ONNX_CONTRIB_OPERATOR_SCHEMA(Pad)
+    .SetDomain(kMSDomain)
+    .SinceVersion(1)
+    .Attr(
+        "mode",
+        "Three modes: `constant`(default) - pads with a given constant value, "
+        "`reflect` - pads with the reflection of the vector mirrored on the first and last values of the vector along each axis, "
+        "`edge` - pads with the edge values of array",
+        AttributeProto::STRING,
+        std::string("constant"))
+    .Input(0, "data", "Input tensor.", "T")
+    .Input(
+        1,
+        "pads",
+        "Tensor of integers indicating the number of padding elements to add or remove (if negative) "
+        "at the beginning and end of each axis. For 2D input tensor, it is the number of pixels. "
+        "`pads` should be a 1D tensor of shape [2 * input_rank] or a 2D tensor of shape [1, 2 * input_rank]. "
+        "`pads` format (1D example) should be as follow [x1_begin, x2_begin,...,x1_end, x2_end,...], "
+        "where xi_begin is the number of pixels added at the beginning of axis `i` and "
+        "xi_end, the number of pixels added at the end of axis `i`.",
+        "tensor(int64)")
+    .Input(
+        2,
+        "value",
+        "(Optional) A scalar or rank 1 tensor containing a single value to be filled if the mode chosen is `constant` (by default it is 0.0).",
+        "T",
+        OpSchema::Optional)
+    .Output(0, "output", "Tensor after padding.", "T")
+    .TypeConstraint(
+        "T",
+        {"tensor(float16)", "tensor(float)", "tensor(double)"},
+        "Constrain input and output types to float tensors.")
+    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+      // Type inference
+      propagateElemTypeFromInputToOutput(ctx, 0, 0);
+      // Shape inference needs the input data shape
+      if (!hasNInputShapes(ctx, 1)) {
         return;
-      })
-      .SetDoc(R"DOC(
+      }
+      const auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
+      const auto input_rank = input_shape.dim_size();
+
+      // Infer output shape if 'pads' tensor is available
+      const auto* pads_initializer = ctx.getInputData(1);
+      if (nullptr != pads_initializer) {
+        const auto& pads_shape = ctx.getInputType(1)->tensor_type().shape();
+        if ((pads_initializer->dims_size() != 1 &&
+             pads_initializer->dims_size() != 2) ||
+            (pads_initializer->dims_size() == 2 &&
+             pads_shape.dim((int)0).dim_value() != 1) ||
+            pads_initializer->data_type() != ONNX_NAMESPACE::TensorProto::INT64)
+          fail_shape_inference(
+              "'pads' input must be a 1D (shape: [input_rank]) "
+              "or 2D tensor (shape: [1, input_rank]) of type int64");
+
+        // make a copy of the returned const vector - may have to resize
+        // this in next step
+        std::vector<int64_t> pads_data;
+        if (pads_initializer->has_raw_data())
+          return;
+        else
+          pads_data.insert(
+              pads_data.end(),
+              pads_initializer->int64_data().begin(),
+              pads_initializer->int64_data().end());
+
+        // fill with zeros if needed to reach appropriate size
+        if (pads_data.size() != static_cast<size_t>(2 * input_rank))
+          pads_data.resize(2 * input_rank, 0);
+
+        const auto& output_shape =
+            ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+        for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+          const auto& input_dim = input_shape.dim((int)i);
+          auto* output_dim = output_shape->add_dim();
+          if (input_dim.has_dim_value()) {
+            output_dim->set_dim_value(
+                input_dim.dim_value() + pads_data[i] + pads_data[i + input_rank]);
+          } else if (pads_data[i] + pads_data[i + input_rank] == 0) {
+            *output_dim = input_dim;
+          }
+        }
+      } else {
+        // Infer ouput shapes' rank in any case
+        auto* output_shape_0 = getOutputShape(ctx, 0);
+        for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+          output_shape_0->add_dim();
+        }
+      }
+      return;
+    })
+    .SetDoc(R"DOC(
             Given `data` tensor, pads, mode, and value.
             Example:
             Insert 0 pads to the beginning of the second dimension.
@@ -1178,57 +1269,57 @@ Example 4:
                     ]
             )DOC");
 
-  ONNX_CONTRIB_OPERATOR_SCHEMA(Unique)
-      .SetDomain(kMSDomain)
-      .SinceVersion(1)
-      .Input(0, "x", "A 1-D input tensor that is to be processed.", "T")
-      .Output(0, "y",
-              "A 1-D tensor of the same type as 'x' "
-              "containing all the unique values in 'x' sorted "
-              "in the same order that they occur in the input 'x'",
-              "T")
-      .Output(1, "idx",
-              "A 1-D INT64 tensor of the same size as 'x' "
-              "containing the indices for each value in 'x' "
-              "in the output 'uniques'",
-              "tensor(int64)")
-      .Output(2, "counts",
-              "A 1-D INT64 tensor containing the "
-              "the count of each element "
-              "of 'uniques' in the input 'x'",
-              "tensor(int64)")
-      .TypeConstraint("T", OpSchema::all_tensor_types(), "Input can be of any tensor type.")
-      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        // Type inference
-        ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
-        ONNX_NAMESPACE::updateOutputElemType(ctx, 1, ONNX_NAMESPACE::TensorProto::INT64);
-        ONNX_NAMESPACE::updateOutputElemType(ctx, 2, ONNX_NAMESPACE::TensorProto::INT64);
+ONNX_CONTRIB_OPERATOR_SCHEMA(Unique)
+    .SetDomain(kMSDomain)
+    .SinceVersion(1)
+    .Input(0, "x", "A 1-D input tensor that is to be processed.", "T")
+    .Output(0, "y",
+            "A 1-D tensor of the same type as 'x' "
+            "containing all the unique values in 'x' sorted "
+            "in the same order that they occur in the input 'x'",
+            "T")
+    .Output(1, "idx",
+            "A 1-D INT64 tensor of the same size as 'x' "
+            "containing the indices for each value in 'x' "
+            "in the output 'uniques'",
+            "tensor(int64)")
+    .Output(2, "counts",
+            "A 1-D INT64 tensor containing the "
+            "the count of each element "
+            "of 'uniques' in the input 'x'",
+            "tensor(int64)")
+    .TypeConstraint("T", OpSchema::all_tensor_types(), "Input can be of any tensor type.")
+    .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+      // Type inference
+      ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
+      ONNX_NAMESPACE::updateOutputElemType(ctx, 1, ONNX_NAMESPACE::TensorProto::INT64);
+      ONNX_NAMESPACE::updateOutputElemType(ctx, 2, ONNX_NAMESPACE::TensorProto::INT64);
 
-        // Shape inference
+      // Shape inference
 
-        // shape of output 'uniques' and 'counts'
-        // depends on actual input data, but the rank is always 1
-        ctx.getOutputType(0)
-            ->mutable_tensor_type()
-            ->mutable_shape()
-            ->add_dim();
+      // shape of output 'uniques' and 'counts'
+      // depends on actual input data, but the rank is always 1
+      ctx.getOutputType(0)
+          ->mutable_tensor_type()
+          ->mutable_shape()
+          ->add_dim();
 
-        ctx.getOutputType(2)
-            ->mutable_tensor_type()
-            ->mutable_shape()
-            ->add_dim();
+      ctx.getOutputType(2)
+          ->mutable_tensor_type()
+          ->mutable_shape()
+          ->add_dim();
 
-        // if the input shape doesn't exist, further shape inference is not possible
-        if (!hasNInputShapes(ctx, 1)) {
-          return;
-        }
-
-        // 'idx' output has same shape as input
-        ONNX_NAMESPACE::propagateShapeFromInputToOutput(ctx, 0, 1);
-
+      // if the input shape doesn't exist, further shape inference is not possible
+      if (!hasNInputShapes(ctx, 1)) {
         return;
-      })
-      .SetDoc(R"DOC(
+      }
+
+      // 'idx' output has same shape as input
+      ONNX_NAMESPACE::propagateShapeFromInputToOutput(ctx, 0, 1);
+
+      return;
+    })
+    .SetDoc(R"DOC(
               Finds all the unique values (deduped list) present in the given input tensor. 
               This operator returns 3 outputs. 
               The first output tensor 'uniques' contains all of the unique elements of the input, 
@@ -1244,9 +1335,9 @@ Example 4:
               )DOC");
 
 #ifdef MICROSOFT_INTERNAL
-  // register internal ops
-  RegisterInternalSchemas();
+// register internal ops
+RegisterInternalSchemas();
 #endif
 }  // namespace contrib
-}  // namespace contrib
+}  // namespace onnxruntime
 }  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/crop_op_test.cc
+++ b/onnxruntime/test/contrib_ops/crop_op_test.cc
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+TEST(CropOpTest, Crop_Border) {
+  OpTester test("Crop", 1, onnxruntime::kOnnxDomain);
+  test.AddInput<float>("x", {1, 1, 4, 4}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0});
+  std::vector<int64_t> border{1, 1, 1, 1};
+  test.AddAttribute("border", border);
+  test.AddOutput<float>("y", {1, 1, 2, 2}, {6.0, 7.0, 10.0, 11.0});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(CropOpTest, Crop_Scale) {
+  OpTester test("Crop", 1, onnxruntime::kOnnxDomain);
+  test.AddInput<float>("x", {1, 1, 4, 4}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0});
+
+  std::vector<int64_t> border{1, 1, 1, 1};
+  test.AddAttribute("border", border);
+
+  std::vector<int64_t> scale{2, 2};
+  test.AddAttribute("scale", scale);
+
+  test.AddOutput<float>("y", {1, 1, 2, 2}, {6.0, 7.0, 10.0, 11.0});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
* Add shape inference logic for `Crop` contrib op as requested by TensorRT team
* Fix some minor nits in the `ValidateInput()` method of the op
* Check-in some unit tests to validate all above changes

cc: @stevenlix   