### PR TITLE
re-enable disabled tests on nGraph after fixing remaining subgraph resolve error

### DIFF
--- a/onnxruntime/core/providers/ngraph/ngraph_execution_provider.cc
+++ b/onnxruntime/core/providers/ngraph/ngraph_execution_provider.cc
@@ -409,6 +409,7 @@ static void GetInputsOutputsOfCluster(const GraphViewer& graph_viewer,
     if ((initializers.count(in_arg) && !original_graph_inputs.count(in_arg)) ||
         ng_required_initializers.count(in_arg)) {
       cluster_initializers.push_back(in_arg);
+      cluster_inputs.push_back(in_arg);
     } else if (!output_args.count(in_arg)) {
       cluster_inputs.push_back(in_arg);
     }

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -370,8 +370,6 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   broken_tests.insert({"dequantizelinear", "ambiguity in scalar dimensions [] vs [1]"});
   broken_tests.insert({"qlinearconv", "ambiguity in scalar dimensions [] vs [1]"});
   broken_tests.insert({"quantizelinear", "ambiguity in scalar dimensions [] vs [1]"});
-  broken_tests.insert({"tiny_yolov2", "temporarily disable due to graph resolve failure."});
-  broken_tests.insert({"operator_repeat_dim_overflow", "temporarily disable due to graph resolve failure."});
 #endif
 
 #ifdef USE_CUDA

--- a/onnxruntime/test/providers/ngraph/ngraph_execution_provider_test.cc
+++ b/onnxruntime/test/providers/ngraph/ngraph_execution_provider_test.cc
@@ -340,7 +340,7 @@ This test is to ensure, we do not have cyclic dependent sub-graphs.
 Example: Sub-Graph-1{1,2,3,5} is invalid because the output of this cluster is input to UnSupportedOp whose output is again input to the same cluster.
 
 */
-TEST(NGraphExecutionProviderTest, DISABLED_Independent_SubGraphs) {
+TEST(NGraphExecutionProviderTest, Independent_SubGraphs) {
   NameMLValMap feeds;
   add_feeds(feeds, "A", {4}, {1.0f, 2.0f, 3.0f, 4.0f});
 

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -121,9 +121,9 @@ def create_backend_test(testname=None):
         if version_tag == 'onnx150' or onnx.__version__ == '1.5.0':
             current_failing_tests = current_failing_tests + ('^test_constantofshape_*.*',)
 
-        # Failing for nGraph.
-        if c2.supports_device('NGRAPH'):
-            current_failing_tests = current_failing_tests + ('|^test_operator_repeat_dim_overflow_cpu.*',)
+        # Example of how to disable tests for a specific provider.
+        # if c2.supports_device('NGRAPH'):
+        #    current_failing_tests = current_failing_tests + ('|^test_operator_repeat_dim_overflow_cpu.*',)
 
         filters = current_failing_tests + \
                   tests_with_pre_opset7_dependencies_filters() + \


### PR DESCRIPTION
https://github.com/microsoft/onnxruntime/pull/1019 broke nGraph provider because it required IndexedSubGraph MetaDef inputs to contain initializers.
https://github.com/microsoft/onnxruntime/pull/1062 fixed the issue for the most part but there were a few tests still failing. (disabled for the interim)
This PR addresses the remaining failure case, which occur when there are partitions (also called clusters in nGraph provider implementation) and the inputs are not processed in correct order.
