### PR TITLE
cmake changes for x86 and mlas

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -47,8 +47,6 @@ option(onnxruntime_ENABLE_STATIC_ANALYSIS "Enable static analysis" OFF)
 option(onnxruntime_ENABLE_PYTHON "Enable python buildings" OFF)
 option(onnxruntime_USE_CUDA "Build with CUDA support" OFF)
 option(onnxruntime_USE_NSYNC "Build with NSYNC support. This option only takes effect on Linux" OFF)
-option(onnxruntime_USE_EIGEN_FOR_BLAS "Use eign for blas" ON)
-option(onnxruntime_USE_MLAS "Use optimized blas library for GEMM and 2D Convolution" ON)
 option(onnxruntime_USE_MKLDNN "Build with MKL-DNN support" OFF)
 option(onnxruntime_USE_MKLML "Build MKL-DNN with MKL-ML binary dependency" OFF)
 option(onnxruntime_USE_NGRAPH "Build with nGraph support" OFF)
@@ -192,11 +190,6 @@ else()
     string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO " -march=native -mtune=native")
     string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO " -march=native -mtune=native")
   endif()
-  if(onnxruntime_BUILD_x86)
-    set (CMAKE_SYSTEM_PROCESSOR "x86")
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2 -mfpmath=sse -Wno-narrowing")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -mfpmath=sse -Wno-narrowing")
-  endif()
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
@@ -269,10 +262,6 @@ if (onnxruntime_USE_CUDA AND "${onnxruntime_CUDNN_HOME}" STREQUAL "")
   message(FATAL_ERROR "onnxruntime_CUDNN_HOME required for onnxruntime_USE_CUDA")
 endif()
 
-if (onnxruntime_USE_EIGEN_FOR_BLAS)
-  add_definitions(-DUSE_EIGEN_FOR_BLAS)
-endif()
-
 if (onnxruntime_USE_OPENBLAS AND "${onnxruntime_OPENBLAS_HOME}" STREQUAL "" AND WIN32)
   # On linux we assume blas is installed via 'apt-get install libopenblas-dev'
   message(FATAL_ERROR "onnxruntime_OPENBLAS_HOME required for onnxruntime_USE_OPENBLAS")
@@ -311,6 +300,7 @@ include(eigen)
 # mkldnn/mklml, openblas, onnxruntime_codegen_tvm, tvm, nnvm_compiler and pthread
 # pthread is always at the last
 set(onnxruntime_EXTERNAL_LIBRARIES onnx onnx_proto protobuf::libprotobuf re2)
+list(APPEND onnxruntime_EXTERNAL_LIBRARIES onnxruntime_mlas)
 
 function(onnxruntime_add_include_to_target dst_target)
     foreach(src_target ${ARGN})
@@ -361,10 +351,6 @@ endif()
 
 if (onnxruntime_RUN_ONNX_TESTS)
   add_definitions(-DORT_RUN_EXTERNAL_ONNX_TESTS)
-endif()
-
-if (onnxruntime_USE_MLAS)
-  add_definitions(-DUSE_MLAS)
 endif()
 
 #Adjust warning flags

--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -69,7 +69,6 @@ target_link_libraries(onnxruntime PRIVATE
     ${END_WHOLE_ARCHIVE}
     onnxruntime_graph
     onnxruntime_common
-    onnxruntime_mlas
     ${onnxruntime_EXTERNAL_LIBRARIES})
 
 if (onnxruntime_ENABLE_LANGUAGE_INTEROP_OPS)

--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -80,7 +80,6 @@ set(onnxruntime_pybind11_state_libs
     onnxruntime_util
     onnxruntime_graph
     onnxruntime_common
-    onnxruntime_mlas
 )
 
 set(onnxruntime_pybind11_state_dependencies

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -162,7 +162,6 @@ set(onnxruntime_test_framework_libs
   onnxruntime_util
   onnxruntime_graph
   onnxruntime_common
-  onnxruntime_mlas
   )
 
 set(onnxruntime_test_server_libs
@@ -212,7 +211,6 @@ set(ONNXRUNTIME_TEST_LIBS
     onnxruntime_util
     onnxruntime_graph
     onnxruntime_common
-    onnxruntime_mlas
 )
 
 set(onnxruntime_test_providers_libs
@@ -644,6 +642,7 @@ if (onnxruntime_BUILD_SERVER)
   )
 
 endif()
+
 
 add_executable(onnxruntime_mlas_test ${TEST_SRC_DIR}/mlas/unittest.cpp)
 target_include_directories(onnxruntime_mlas_test PRIVATE ${ONNXRUNTIME_ROOT}/core/mlas/inc)

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -10,7 +10,7 @@
 #include "Eigen/src/Core/arch/GPU/Half.h"
 #include "core/common/common.h"
 
-#if defined(USE_MLAS) && defined(_M_AMD64)
+#if defined(_M_AMD64)
 #include "core/mlas/inc/mlas.h"
 #endif
 
@@ -40,7 +40,7 @@ inline void CastData<MLFloat16, float>(const Tensor* in, Tensor* out, const Tens
   auto out_data = out->template MutableData<float>();
   auto in_data = in->template Data<MLFloat16>();
   auto shape_size = shape.Size();
-#if defined(USE_MLAS) && defined(_M_AMD64)
+#if defined(_M_AMD64)
   MlasConvertHalfToFloatBuffer(&in_data[0].val, out_data, shape_size);
 #else
   auto in_vector = ConstEigenVectorMap<Eigen::half>(static_cast<const Eigen::half*>(static_cast<const void*>(in_data)), shape_size);


### PR DESCRIPTION
1. Remove onnxruntime_USE_MLAS option. As it should be always on. Currently, onnxruntime can't be built without mlas. Therefore this options is kind of misleading.  I've talked with Pranav/Yuan/Tracy, we all agree this option should be removed. However, Mlas is not supported on all architectures(e.g. some ARM devices). We know this is a problem, we'll solve it later. 

2. Remove onnxruntime_USE_EIGEN_FOR_BLAS cmake option. It is only useful when onnxruntime_USE_MLAS is OFF. As we are turning onnxruntime_USE_MLAS to always ON, onnxruntime_USE_EIGEN_FOR_BLAS is no longer useful.

3. CMAKE_SYSTEM_PROCESSOR is the cpu arch for running the build, not the target arch. So, when we run the x86 build on a x64 cpu, it points to x64. It's correct, we shouldn't override it.
