### PR TITLE
Add calling convention spec for Linux x86_32

### DIFF
--- a/include/onnxruntime/core/common/callback.h
+++ b/include/onnxruntime/core/common/callback.h
@@ -8,7 +8,7 @@ extern "C" {
 #endif
 
 typedef struct OrtCallback {
-  void(ORT_API_CALL* f)(void* param) NO_EXCEPTION;
+  void(ORT_API_FUNCTION(*f))(void* param) NO_EXCEPTION;
   void* param;
 } OrtDeleter;
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -28,7 +28,6 @@ extern "C" {
 #define _Frees_ptr_opt_
 #define ORT_ALL_ARGS_NONNULL __attribute__((nonnull))
 #define ORT_MUST_USE_RESULT __attribute__((warn_unused_result))
-#define ORT_API_CALL
 #if defined(__i386__)
 #define ORT_API_FUNCTION(name) __attribute__((stdcall)) name
 #else
@@ -37,7 +36,6 @@ extern "C" {
 #else
 #define ORT_ALL_ARGS_NONNULL
 #define ORT_MUST_USE_RESULT
-#define ORT_API_CALL _stdcall
 #define ORT_API_FUNCTION(name) name _stdcall
 #endif
 
@@ -166,12 +164,12 @@ ORT_RUNTIME_CLASS(CustomOpDomain);
 // is not destroyed until the last allocated object using it is freed.
 typedef struct OrtAllocator {
   uint32_t version;  // Initialize to ORT_API_VERSION
-  void*(ORT_API_CALL* Alloc)(struct OrtAllocator* this_, size_t size);
-  void(ORT_API_CALL* Free)(struct OrtAllocator* this_, void* p);
-  const struct OrtAllocatorInfo*(ORT_API_CALL* Info)(const struct OrtAllocator* this_);
+  void*(ORT_API_FUNCTION(*Alloc))(struct OrtAllocator* this_, size_t size);
+  void(ORT_API_FUNCTION(*Free))(struct OrtAllocator* this_, void* p);
+  const struct OrtAllocatorInfo*(ORT_API_FUNCTION(*Info))(const struct OrtAllocator* this_);
 } OrtAllocator;
 
-typedef void(ORT_API_CALL* OrtLoggingFunction)(
+typedef void ORT_API_FUNCTION((*OrtLoggingFunction))(
     void* param, OrtLoggingLevel severity, const char* category, const char* logid, const char* code_location,
     const char* message);
 

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -306,7 +306,7 @@ ORT_API_STATUS(OrtInitializeBufferForTensor, _In_opt_ void* input, size_t input_
  */
 ORT_API(void, OrtUninitializeBuffer, _In_opt_ void* input, size_t input_len, enum ONNXTensorElementDataType type);
 
-static void ORT_API_CALL UnInitTensor(void* param) noexcept {
+static void ORT_API_FUNCTION(UnInitTensor)(void* param) noexcept {
   UnInitializeParam* p = reinterpret_cast<UnInitializeParam*>(param);
   OrtUninitializeBuffer(p->preallocated, p->preallocated_size, p->ele_type);
   delete p;

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -41,7 +41,7 @@ namespace onnxruntime {
 namespace {
 constexpr int OneMillion = 1000000;
 
-static void ORT_API_CALL DeleteBuffer(void* param) noexcept { ::free(param); }
+static void ORT_API_FUNCTION(DeleteBuffer)(void* param) noexcept { ::free(param); }
 
 class UnmapFileParam {
  public:
@@ -50,7 +50,7 @@ class UnmapFileParam {
   int fd;
 };
 
-static void ORT_API_CALL UnmapFile(void* param) noexcept {
+static void ORT_API_FUNCTION(UnmapFile)(void* param) noexcept {
   UnmapFileParam* p = reinterpret_cast<UnmapFileParam*>(param);
   int ret = munmap(p->addr, p->len);
   if (ret != 0) {

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -30,7 +30,7 @@ namespace onnxruntime {
 
 namespace {
 
-static void ORT_API_CALL DeleteBuffer(void* param) noexcept { ::free(param); }
+static void ORT_API_FUNCTION(DeleteBuffer)(void* param) noexcept { ::free(param); }
 
 class WindowsEnv : public Env {
  public:

--- a/onnxruntime/core/session/default_cpu_allocator_c_api.cc
+++ b/onnxruntime/core/session/default_cpu_allocator_c_api.cc
@@ -12,11 +12,17 @@ struct OrtAllocatorImpl : OrtAllocator {
 };
 
 struct OrtDefaultAllocator : OrtAllocatorImpl {
+ private:
+  static void* ORT_API_FUNCTION(AllocImpl)(OrtAllocator* this_, size_t size) { return static_cast<OrtDefaultAllocator*>(this_)->Alloc(size); }
+  static void ORT_API_FUNCTION(FreeImpl)(OrtAllocator* this_, void* p) { static_cast<OrtDefaultAllocator*>(this_)->Free(p); }
+  static const struct OrtAllocatorInfo* ORT_API_FUNCTION(InfoImpl)(const OrtAllocator* this_) { return static_cast<const OrtDefaultAllocator*>(this_)->Info(); };
+
+ public:
   OrtDefaultAllocator() {
     OrtAllocator::version = ORT_API_VERSION;
-    OrtAllocator::Alloc = [](OrtAllocator* this_, size_t size) { return static_cast<OrtDefaultAllocator*>(this_)->Alloc(size); };
-    OrtAllocator::Free = [](OrtAllocator* this_, void* p) { static_cast<OrtDefaultAllocator*>(this_)->Free(p); };
-    OrtAllocator::Info = [](const OrtAllocator* this_) { return static_cast<const OrtDefaultAllocator*>(this_)->Info(); };
+    OrtAllocator::Alloc = &AllocImpl;
+    OrtAllocator::Free = &FreeImpl;
+    OrtAllocator::Info = &InfoImpl;
     ORT_THROW_ON_ERROR(OrtCreateAllocatorInfo("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault, &cpuAllocatorInfo));
   }
 

--- a/onnxruntime/test/shared_lib/test_fixture.h
+++ b/onnxruntime/test/shared_lib/test_fixture.h
@@ -13,7 +13,7 @@ typedef const char* PATH_TYPE;
 #endif
 
 //empty
-static inline void ORT_API_CALL MyLoggingFunction(void*, OrtLoggingLevel, const char*, const char*, const char*, const char*) {
+static inline void ORT_API_FUNCTION(MyLoggingFunction)(void*, OrtLoggingLevel, const char*, const char*, const char*, const char*) {
 }
 
 template <bool use_customer_logger>


### PR DESCRIPTION
#1175

gcc 5.4 doesn't support calling conversion for lambda. The latest version supports that.
