### PR TITLE
Use cmath instead of math.h for fabs

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 #include "core/providers/cpu/tensor/upsample.h"
-#include <math.h>  //for fabs
+#include <cmath>
 
-using namespace ::onnxruntime::common;
+using namespace onnxruntime::common;
 using namespace std;
 namespace onnxruntime {
 
@@ -185,8 +185,8 @@ void upsampleBilinear(
     float in_y = std::min(y / height_scale, static_cast<float>(input_height - 1));
     const int64_t in_y1 = std::min(static_cast<int64_t>(in_y), input_height - 1);
     const int64_t in_y2 = std::min(in_y1 + 1, input_height - 1);
-    dy1[y] = fabs(in_y - in_y1);
-    dy2[y] = fabs(in_y - in_y2);
+    dy1[y] = std::fabs(in_y - in_y1);
+    dy2[y] = std::fabs(in_y - in_y2);
     if (in_y1 == in_y2) {
       dy1[y] = 0.5f;
       dy2[y] = 0.5f;

--- a/onnxruntime/test/framework/data_types_test.cc
+++ b/onnxruntime/test/framework/data_types_test.cc
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include <typeinfo>
-#include <math.h> //for fabs
+#include <cmath>
 
 #include "core/framework/data_types.h"
 #include "core/graph/onnx_protobuf.h"
@@ -15,7 +15,7 @@
 #endif
 #include "onnx/defs/data_type_utils.h"
 #ifdef __GNUC__
-#pragma GCC diagnostic pop
+#pragma GCC diagnostic popfabs
 #endif
 
 namespace onnxruntime {
@@ -359,7 +359,7 @@ TEST_F(DataTypeTest, BFloat16Test) {
     BFloat16 flt16(sample);
     auto int_rep = flt16.val;
     BFloat16 flt_from_int(int_rep);
-    const double diff = fabs(sample - flt_from_int.ToFloat());
+    const double diff = std::fabs(sample - flt_from_int.ToFloat());
     if (diff > FLT_EPSILON || (std::isnan(diff) && !std::isnan(sample))) {
       EXPECT_TRUE(false);
     }
@@ -371,7 +371,7 @@ TEST_F(DataTypeTest, BFloat16Test) {
     static_assert(sizeof(sample) / sizeof(float) == sizeof(converted) / sizeof(BFloat16), "Must have the same count");
     FloatToBFloat16(sample, converted, sizeof(sample) / sizeof(float));
     for (size_t i = 0; i < sizeof(sample) / sizeof(float); ++i) {
-      const double diff = fabs(sample[i] - converted[i].ToFloat());
+      const double diff = std::fabs(sample[i] - converted[i].ToFloat());
       if (diff > FLT_EPSILON || (std::isnan(diff) && !std::isnan(sample[i]))) {
         EXPECT_TRUE(false);
       }
@@ -380,7 +380,7 @@ TEST_F(DataTypeTest, BFloat16Test) {
     float back_converted[sizeof(sample) / sizeof(float)];
     BFloat16ToFloat(converted, back_converted, sizeof(sample) / sizeof(float));
     for (size_t i = 0; i < sizeof(sample) / sizeof(float); ++i) {
-      const double diff = fabs(sample[i] - back_converted[i]);
+      const double diff = std::fabs(sample[i] - back_converted[i]);
       if (diff > FLT_EPSILON || (std::isnan(diff) && !std::isnan(sample[i]))) {
         EXPECT_TRUE(false);
       }

--- a/onnxruntime/test/framework/data_types_test.cc
+++ b/onnxruntime/test/framework/data_types_test.cc
@@ -15,7 +15,7 @@
 #endif
 #include "onnx/defs/data_type_utils.h"
 #ifdef __GNUC__
-#pragma GCC diagnostic popfabs
+#pragma GCC diagnostic pop
 #endif
 
 namespace onnxruntime {


### PR DESCRIPTION
Address #1215 and #1214 

We were including math.h instead of cmath in a couple of places leading to build failing on gcc 5.5.

Change to use cmath, and qualify some calls to fabs with 'std::' due to change. 