### PR TITLE
Refine node selection logic in ShapeToInitializer optimizer

### DIFF
--- a/onnxruntime/core/optimizer/shape_to_initializer.cc
+++ b/onnxruntime/core/optimizer/shape_to_initializer.cc
@@ -59,15 +59,17 @@ bool ShapeToInitializer::SatisfyCondition(const Graph& graph, const Node& node) 
     return false;
   }
 
-  // The shape of the input has to be statically known. Moreover, each dimension should have a specific value
-  // (the rule cannot be applied if one of the dimension is a symbolic variable).
+  // The shape of the input has to be statically known. Moreover, each dimension should have a meaningful value
+  // (the rule cannot be applied if one of the dimension is a symbolic variable (or)
+  // if the dimension has an alias value whose real value can only be inferred at inference run time (e.g.) '-1').
   const auto* input_shape = node.InputDefs()[0]->Shape();
   if (!input_shape) {
     return false;
   }
 
   for (int i = 0, num_dims = input_shape->dim_size(); i < num_dims; i++) {
-    if (!input_shape->dim(i).has_dim_value()) {
+    const auto& input_dim = input_shape->dim(i);
+    if (!input_dim.has_dim_value() || input_dim.dim_value() < 0) {
       return false;
     }
   }

--- a/onnxruntime/core/optimizer/shape_to_initializer.cc
+++ b/onnxruntime/core/optimizer/shape_to_initializer.cc
@@ -60,8 +60,7 @@ bool ShapeToInitializer::SatisfyCondition(const Graph& graph, const Node& node) 
   }
 
   // The shape of the input has to be statically known. Moreover, each dimension should have a meaningful value
-  // (the rule cannot be applied if one of the dimension is a symbolic variable (or)
-  // if the dimension has an alias value whose real value can only be inferred at inference run time (e.g.) '-1').
+  // (the rule cannot be applied if one of the dimensions has a negative value or if it is a symbolic variable).
   const auto* input_shape = node.InputDefs()[0]->Shape();
   if (!input_shape) {
     return false;

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -142,7 +142,7 @@ TEST(GraphTransformationTests, ShapeToInitializer) {
 
   op_to_count = CountOpsInGraph(graph);
   // Two of the Shapes are not eliminated because: 
-  // One contains includes a symbolic dimension.
+  // One includes a symbolic dimension.
   // Another one includes a negative dimension
   ASSERT_TRUE(op_to_count["Shape"] == 2);
 }

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -131,7 +131,7 @@ TEST(GraphTransformationTests, ShapeToInitializer) {
   ASSERT_TRUE(Model::Load(model_uri, model).IsOK());
   Graph& graph = model->MainGraph();
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
-  ASSERT_TRUE(op_to_count["Shape"] == 3);
+  ASSERT_TRUE(op_to_count["Shape"] == 4);
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformerL1");
@@ -141,8 +141,10 @@ TEST(GraphTransformationTests, ShapeToInitializer) {
   ASSERT_TRUE(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1).IsOK());
 
   op_to_count = CountOpsInGraph(graph);
-  // One of the Shapes is not eliminated because it inlcludes a symbolic dimension.
-  ASSERT_TRUE(op_to_count["Shape"] == 1);
+  // Two of the Shapes are not eliminated because: 
+  // One contains includes a symbolic dimension.
+  // Another one includes a negative dimension
+  ASSERT_TRUE(op_to_count["Shape"] == 2);
 }
 
 // Check transformations in the case of a subgraph with constant inputs.

--- a/onnxruntime/test/testdata/transform/shape-add.onnx
+++ b/onnxruntime/test/testdata/transform/shape-add.onnx
@@ -1,15 +1,20 @@
-lotus-transfomrs:â
+lotus-transfomrs:Å
 
-AC"Shape
+AD"Shape
 
-BD"Shape
+BE"Shape
+
+CG"Shape
 
-C
-DE"Add
+D
+EF"Add
+
+F
+GH"Add
 
-EF"Shape
+HI"Shape
 
-FG"Identity	shape-addZ
+IJ"Identity	shape-addZ
 A
 
 
@@ -19,15 +24,16 @@
 
 
 N
-b
-G
+Z 
+C
+
+
+
+ÿÿÿÿÿÿÿÿÿb
+J
 
 
 j
-C
-
-
-j
 D
 
 
@@ -36,7 +42,19 @@
 
 
 j
+G
+
+
+j
 F
+
+
+j
+H
+
+
+j
+I
 
 
 B


### PR DESCRIPTION
ShapeToInitializer optimizer shouldn't replace 'Shape' even when the input shape is statically known (through shape inference) when -

1) The dimensions have one or more symbolic dimensions (logic added in the original PR #1159)
2)  The dimensions have all values known but one or more are "virtual" symbolic dimension value where the real value is only inferred  at inference run time. For example, in the case where a model has a graph input [-1, 20] feeding into a 'Shape' node, this node should not be converted to an initializer.
   