### PR TITLE
Allow building Docker container based on a different git repo.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+.gitattributes
+docs
+

--- a/dockerfiles/Dockerfile.arm32v7
+++ b/dockerfiles/Dockerfile.arm32v7
@@ -1,5 +1,8 @@
 FROM balenalib/raspberrypi3-python:latest-stretch-build
 
+ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
+ARG ONNXRUNTIME_SERVER_BRANCH=master
+
 #Enforces cross-compilation through Quemu
 RUN [ "cross-build-start" ]
 
@@ -37,7 +40,7 @@ ARG BUILDARGS="--config ${BUILDTYPE} --arm"
 
 # Prepare onnxruntime Repo
 WORKDIR /code
-RUN git clone --recursive https://github.com/Microsoft/onnxruntime
+RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime
 
 # Start the basic build
 WORKDIR /code/onnxruntime

--- a/dockerfiles/Dockerfile.ngraph
+++ b/dockerfiles/Dockerfile.ngraph
@@ -4,7 +4,10 @@
 #--------------------------------------------------------------------------
 
 FROM ubuntu:16.04
+
 ARG PYTHON_VERSION=3.5
+ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
+ARG ONNXRUNTIME_SERVER_BRANCH=master
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -12,7 +15,7 @@ RUN apt-get update && \
     apt-get install -y sudo git bash
 
 ENV PATH="/opt/cmake/bin:${PATH}"
-RUN git clone --recursive https://github.com/Microsoft/onnxruntime onnxruntime
+RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime
 RUN /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh -p ${PYTHON_VERSION} && \
     /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_deps.sh
 

--- a/dockerfiles/Dockerfile.server
+++ b/dockerfiles/Dockerfile.server
@@ -11,6 +11,7 @@ MAINTAINER Harry Yang "huayang@microsoft.com"
 
 FROM ubuntu:16.04 AS build
 ARG PYTHON_VERSION=3.5
+ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
 ARG ONNXRUNTIME_SERVER_BRANCH=master
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -18,7 +19,7 @@ RUN apt-get update && \
     apt-get install -y sudo git bash
 
 ENV PATH="/opt/cmake/bin:${PATH}"
-RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive https://github.com/Microsoft/onnxruntime onnxruntime
+RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime
 RUN /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh -p ${PYTHON_VERSION} && \
     /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_deps.sh
 


### PR DESCRIPTION
- Introduce Docker build ARG `ONNXRUNTIME_REPO`
  to allow building Docker container based on a different git repo.

Example docker build command:

```bash
cd dockerfiles
docker build -t onnx-runtime \
  --build-arg ONNXRUNTIME_REPO=https://github.com/jthelin/onnxruntime \
  --build-arg ONNXRUNTIME_SERVER_BRANCH=my-branch \
  -f Dockerfile.server .
```

- For consistency, also changed `dockerfiles/Dockerfile.arm32v7` and `dockerfiles/Dockerfile.ngraph` 
  to allow the same `ONNXRUNTIME_REPO` and `ONNXRUNTIME_SERVER_BRANCH` build arguments 
  as `dockerfiles/Dockerfile.server`. 
  The default behavior remains as before - build from the master branch in the central onnxruntime repo 
  if not overridden by specifying docker build args.

- Run `install_onnx.sh` script from the same location as `install_deps.sh`,
  rather than requiring it to be pre-installed into the `/tmp` directory in container.

  This fixes a file-not-found error when following instructions in the README file to do a docker build using `Dockerfile.server` https://github.com/microsoft/onnxruntime/blob/master/dockerfiles/README.md

```bash
/onnxruntime/tools/ci_build/github/linux/docker/scripts/install_deps.sh: line 31: /tmp/scripts/install_onnx.sh: No such file or directory
```

- Add a basic `.dockerignore` file, to cut down the number of filles passed into the Docker build context.
