### PR TITLE
call install_onnx.sh with relative path

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -28,9 +28,7 @@ fi
 if [ "$INSTALLED_PYTHON_VERSION" = "3.4" ];then
   echo "Python 3.5 and above is needed for running onnx tests!" 1>&2
 else
-  current_script_path=`readlink -f $0`
-  processed_current_script_path=${current_script_path//\&#x2F;/\/}
-  source `dirname {processed_current_script_path}`/install_onnx.sh $INSTALLED_PYTHON_VERSION
+  source ${0/install_deps/install_onnx} $INSTALLED_PYTHON_VERSION
 fi
 
 #The last onnx version will be kept

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -28,7 +28,7 @@ fi
 if [ "$INSTALLED_PYTHON_VERSION" = "3.4" ];then
   echo "Python 3.5 and above is needed for running onnx tests!" 1>&2
 else
-  source ${0/install_deps\.sh/install_onnx\.sh} $INSTALLED_PYTHON_VERSION
+  source ${0/%install_deps\.sh/install_onnx\.sh} $INSTALLED_PYTHON_VERSION
 fi
 
 #The last onnx version will be kept

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -28,7 +28,7 @@ fi
 if [ "$INSTALLED_PYTHON_VERSION" = "3.4" ];then
   echo "Python 3.5 and above is needed for running onnx tests!" 1>&2
 else
-  source /tmp/scripts/install_onnx.sh $INSTALLED_PYTHON_VERSION
+  source ./install_onnx.sh $INSTALLED_PYTHON_VERSION
 fi
 
 #The last onnx version will be kept

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -28,7 +28,8 @@ fi
 if [ "$INSTALLED_PYTHON_VERSION" = "3.4" ];then
   echo "Python 3.5 and above is needed for running onnx tests!" 1>&2
 else
-  source install_onnx.sh $INSTALLED_PYTHON_VERSION
+  current_script_path=`readlink -f $0`
+  source `dirname {current_script_path}`/install_onnx.sh $INSTALLED_PYTHON_VERSION
 fi
 
 #The last onnx version will be kept

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -28,7 +28,7 @@ fi
 if [ "$INSTALLED_PYTHON_VERSION" = "3.4" ];then
   echo "Python 3.5 and above is needed for running onnx tests!" 1>&2
 else
-  source ${0/install_deps/install_onnx} $INSTALLED_PYTHON_VERSION
+  source ${0/install_deps\.sh/install_onnx\.sh} $INSTALLED_PYTHON_VERSION
 fi
 
 #The last onnx version will be kept

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -29,7 +29,8 @@ if [ "$INSTALLED_PYTHON_VERSION" = "3.4" ];then
   echo "Python 3.5 and above is needed for running onnx tests!" 1>&2
 else
   current_script_path=`readlink -f $0`
-  source `dirname {current_script_path}`/install_onnx.sh $INSTALLED_PYTHON_VERSION
+  processed_current_script_path=${current_script_path//\&#x2F;/\/}
+  source `dirname {processed_current_script_path}`/install_onnx.sh $INSTALLED_PYTHON_VERSION
 fi
 
 #The last onnx version will be kept

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -28,7 +28,7 @@ fi
 if [ "$INSTALLED_PYTHON_VERSION" = "3.4" ];then
   echo "Python 3.5 and above is needed for running onnx tests!" 1>&2
 else
-  source ./install_onnx.sh $INSTALLED_PYTHON_VERSION
+  source install_onnx.sh $INSTALLED_PYTHON_VERSION
 fi
 
 #The last onnx version will be kept


### PR DESCRIPTION
"/tmp/scripts/install_onnx.sh" will cause failure if a build environment is not following the way that ci pipelines saving scripts. Switch to relative current path to solve the issue.