### PR TITLE
make getkernelregistry not pure virtual function

### DIFF
--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -82,7 +82,7 @@ class IExecutionProvider {
      3. onnxruntime (framework/session) does not depend on any specific
      execution provider lib.
   */
-  virtual std::shared_ptr<KernelRegistry> GetKernelRegistry() const = 0;
+  virtual std::shared_ptr<KernelRegistry> GetKernelRegistry() const;
 
   /**
    * Copy tensor between execution providers.  It's always a deep copy

--- a/onnxruntime/core/framework/execution_provider.cc
+++ b/onnxruntime/core/framework/execution_provider.cc
@@ -78,4 +78,8 @@ common::Status IExecutionProvider::Compile(const std::vector<onnxruntime::Node*>
   return common::Status(common::ONNXRUNTIME, common::NOT_IMPLEMENTED);
 }
 
+std::shared_ptr<KernelRegistry> IExecutionProvider::GetKernelRegistry() const {
+  return nullptr;
+}
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/kernel_registry_manager.cc
+++ b/onnxruntime/core/framework/kernel_registry_manager.cc
@@ -58,8 +58,7 @@ Status KernelRegistryManager::RegisterKernels(const ExecutionProviders& executio
 
     auto registry = provider->GetKernelRegistry();
     if (!registry) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Execution provider ", provider->Type(),
-                             "does not have a kernel registry.");
+      continue;
     }
 
     provider_type_to_registry_.insert(std::make_pair(provider->Type(), registry));

--- a/onnxruntime/core/providers/ngraph/ngraph_execution_provider.cc
+++ b/onnxruntime/core/providers/ngraph/ngraph_execution_provider.cc
@@ -57,10 +57,6 @@ NGRAPHExecutionProvider::NGRAPHExecutionProvider(const NGRAPHExecutionProviderIn
   }
 }
 
-std::shared_ptr<KernelRegistry> NGRAPHExecutionProvider::GetKernelRegistry() const {
-  return std::make_shared<KernelRegistry>();
-}
-
 /**
  * Checks if a tensor represented by srcLocation can be copied into the dstLocation tensor
  * @param src_location result of Location().name call on the source tensor

--- a/onnxruntime/core/providers/ngraph/ngraph_execution_provider.h
+++ b/onnxruntime/core/providers/ngraph/ngraph_execution_provider.h
@@ -33,8 +33,6 @@ class NGRAPHExecutionProvider : public IExecutionProvider {
   Status Compile(const std::vector<onnxruntime::Node*>& fused_nodes,
                  std::vector<NodeComputeInfo>& node_compute_funcs) override;
 
-  std::shared_ptr<KernelRegistry> GetKernelRegistry() const override;
-
  private:
   std::shared_ptr<ngraph::runtime::Backend> ng_backend_;
 };

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -279,11 +279,6 @@ TensorrtExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
   return result;
 }
 
-std::shared_ptr<KernelRegistry> TensorrtExecutionProvider::GetKernelRegistry() const {
-  static std::shared_ptr<KernelRegistry> kernel_registry = std::make_shared<KernelRegistry>();
-  return kernel_registry;
-}
-
 common::Status TensorrtExecutionProvider::CopyTensor(const Tensor& src, Tensor& dst) const {
   ORT_UNUSED_PARAMETER(src);
   ORT_UNUSED_PARAMETER(dst);

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -64,8 +64,6 @@ class TensorrtExecutionProvider : public IExecutionProvider {
 
   Status CopyTensor(const Tensor& src, Tensor& dst) const override;
 
-  std::shared_ptr<KernelRegistry> GetKernelRegistry() const override;
-
   void SetMaxBatchSize(const int batch_size) {
     max_batch_size_ = batch_size;
   }


### PR DESCRIPTION
GetKernelRegistry is designed to allow execution provider to have its own (per Type/Class) kernel registry, which is used to register its own kernels. This is not needed for "runtime" based eps, for example, ngraph, tensorrt, nnapi, etc. For these eps, the Compile API is the one used to get executable to run nodes.