### PR TITLE
Log exceptions in parallel executor instead of swallowing

### DIFF
--- a/onnxruntime/core/framework/parallel_executor.cc
+++ b/onnxruntime/core/framework/parallel_executor.cc
@@ -258,8 +258,11 @@ void ParallelExecutor::EnqueueNode(size_t p_node_index, const SessionState& sess
   executor_pool_->Schedule([this, p_node_index, &session_state, &logger]() {
     try {
       ParallelExecutor::RunNodeAsync(p_node_index, std::cref(session_state), std::cref(logger));
-    } catch (...) {
+    } catch (::onnxruntime::OnnxRuntimeException & ex) {
       // catch node processing failure exceptions here to prevent app crash.
+      LOGS(logger, WARNING) << "Node processing failure: " << ex.what();
+    } catch (...) {
+      LOGS(logger, WARNING) << "Unknown node processing failure";
     }
   });
 }


### PR DESCRIPTION
**Description**: Logs exceptions during node processing within parallel executor with WARNING level.

**Motivation and Context**
Node processing errors were swallowed when using parallel executor which makes error analysis harder.

Ideally, the exception should be fully propagated to the outside, so this PR can be considered an intermediate solution.