### PR TITLE
enable matmul tests

### DIFF
--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -44,7 +44,7 @@ void usage() {
 int GetNumCpuCores() {
   SYSTEM_LOGICAL_PROCESSOR_INFORMATION buffer[256];
   DWORD returnLength = sizeof(buffer);
-  if (GetLogicalProcessorInformation(buffer, &returnLength) == false) {
+  if (GetLogicalProcessorInformation(buffer, &returnLength) == FALSE) {
     // try GetSystemInfo
     SYSTEM_INFO sysInfo;
     GetSystemInfo(&sysInfo);

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -44,7 +44,7 @@ void usage() {
 int GetNumCpuCores() {
   SYSTEM_LOGICAL_PROCESSOR_INFORMATION buffer[256];
   DWORD returnLength = sizeof(buffer);
-  if (GetLogicalProcessorInformation(buffer, &returnLength) == FALSE) {
+  if (GetLogicalProcessorInformation(buffer, &returnLength) == false) {
     // try GetSystemInfo
     SYSTEM_INFO sysInfo;
     GetSystemInfo(&sysInfo);
@@ -319,12 +319,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
       {"constantofshape_float_ones", "test data bug", {"onnx141","onnx150"}},
       {"constantofshape_int_zeros", "test data bug", {"onnx141","onnx150"}},
       {"convtranspose_1d", "disable reason"},
-      {"convtranspose_3d", "disable reason"},
-      {"gemm_broadcast", "disable reason"},
-      {"gemm_nobroadcast", "disable reason"},
-      {"matmul_2d", "disable reason"},
-      {"matmul_3d", "disable reason"},
-      {"matmul_4d", "disable reason"},
+      {"convtranspose_3d", "disable reason"},      
       {"cast_STRING_to_FLOAT", "Cast opset 9 not supported yet"},
       {"cast_FLOAT_to_STRING", "Cast opset 9 not supported yet"},
       {"tf_inception_resnet_v2", "Cast opset 9 not supported yet"},


### PR DESCRIPTION
**Description**: Enable matmul and gemm tests which were disabled.

**Motivation and Context**
- This is one of the MQ goals to clean up the disabled tests. 
- In this particular case these tests were disabled since the very beginning. They are working now (at least for latest ONNX version) and hence I am simply enabling them again without any code fixes.  
