### PR TITLE
Treat attribute warning as non-error on cross compiling ARM

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -132,6 +132,8 @@ add_definitions(-DEIGEN_MPL2_ONLY)
 
 if(onnxruntime_CROSS_COMPILING)
   set(CMAKE_CROSSCOMPILING ON)
+  string(APPEND CMAKE_CXX_FLAGS " -Wno-error=attributes")
+  string(APPEND CMAKE_C_FLAGS " -Wno-error=attributes")
 endif()
 
 #must after OpenMP settings

--- a/dockerfiles/Dockerfile.arm32v7
+++ b/dockerfiles/Dockerfile.arm32v7
@@ -14,7 +14,8 @@ RUN install_packages \
     python3-pip \
     python3-dev \
     git \
-    tar
+    tar \
+    libatlas-base-dev
 
 RUN pip3 install --upgrade pip
 RUN pip3 install --upgrade setuptools


### PR DESCRIPTION
Address issue:
https://github.com/microsoft/onnxruntime/issues/1232
When building ARM by cross-compiling, compiler treat eigen attributes warning as error. 