### PR TITLE
Parallelize TreeEnsembleClassifier batch predition

### DIFF
--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_classifier.cc
+++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_classifier.cc
@@ -358,20 +358,23 @@ common::Status TreeEnsembleClassifier<T>::Compute(OpKernelContext* context) cons
   int64_t N = x_dims.size() == 1 ? 1 : x_dims[0];
   Tensor* Y = context->Output(0, TensorShape({N}));
   auto* Z = context->Output(1, TensorShape({N, class_count_}));
-
-  int64_t zindex = 0;
   const T* x_data = X.template Data<T>();
 
-  // for each class
-  std::vector<float> scores;
-  scores.reserve(class_count_);
+  common::Status status;
+#ifdef USE_OPENMP
+#pragma omp parallel for
+#endif
   for (int64_t i = 0; i < N; ++i) {
-    scores.clear();
+    int64_t zindex = i * class_count_;
+    std::vector<float> scores(0.f, class_count_);
     int64_t current_weight_0 = i * stride;
     std::map<int64_t, float> classes;
     // walk each tree from its root
     for (size_t j = 0, end = roots_.size(); j < end; ++j) {
-      ORT_RETURN_IF_ERROR(ProcessTreeNode(classes, roots_[j], x_data, current_weight_0));
+      auto process_status = ProcessTreeNode(classes, roots_[j], x_data, current_weight_0);
+      if (!process_status.IsOK()) {
+        status = process_status;
+      }
     }
     float maxweight = 0.f;
     int64_t maxclass = -1;
@@ -444,7 +447,7 @@ common::Status TreeEnsembleClassifier<T>::Compute(OpKernelContext* context) cons
     write_scores(scores, post_transform_, zindex, Z, write_additional_scores);
     zindex += scores.size();
   }  // namespace ml
-  return Status::OK();
+  return status;
 }  // namespace ml
 
 template <typename T>

--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_classifier.cc
+++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_classifier.cc
@@ -366,7 +366,7 @@ common::Status TreeEnsembleClassifier<T>::Compute(OpKernelContext* context) cons
 #endif
   for (int64_t i = 0; i < N; ++i) {
     int64_t zindex = i * class_count_;
-    std::vector<float> scores(0.f, static_cast<uint32_t>(class_count_));
+    std::vector<float> scores;
     int64_t current_weight_0 = i * stride;
     std::map<int64_t, float> classes;
     // walk each tree from its root

--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_classifier.cc
+++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_classifier.cc
@@ -366,7 +366,7 @@ common::Status TreeEnsembleClassifier<T>::Compute(OpKernelContext* context) cons
 #endif
   for (int64_t i = 0; i < N; ++i) {
     int64_t zindex = i * class_count_;
-    std::vector<float> scores(0.f, class_count_);
+    std::vector<float> scores(0.f, static_cast<uint32_t>(class_count_));
     int64_t current_weight_0 = i * stride;
     std::map<int64_t, float> classes;
     // walk each tree from its root
@@ -445,7 +445,6 @@ common::Status TreeEnsembleClassifier<T>::Compute(OpKernelContext* context) cons
       }
     }
     write_scores(scores, post_transform_, zindex, Z, write_additional_scores);
-    zindex += scores.size();
   }  // namespace ml
   return status;
 }  // namespace ml


### PR DESCRIPTION
Fixing https://github.com/microsoft/onnxruntime/issues/827 https://github.com/microsoft/onnxruntime/issues/886
By perf test we found that EnsembleTreeClassifier could be improved by using openmp:

Before:
//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
{"cat" : "Node","pid" :8988,"tid" :8988,"dur" :297089,"ts" :1086133,"ph" : "X","name" :"TreeEnsembleClassifier_kernel_time","args" : {"provider" : "CPUExecutionProvider","op_name" : "TreeEnsembleClassifier"}},

After:
//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
{"cat" : "Node","pid" :28268,"tid" :28268,"dur" :66756,"ts" :1084282,"ph" : "X","name" :"TreeEnsembleClassifier_kernel_time","args" : {"provider" : "CPUExecutionProvider","op_name" : "TreeEnsembleClassifier"}},

