### PR TITLE
enable quantization tests in onnx_backend_test_series.py

### DIFF
--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -93,9 +93,7 @@ def create_backend_test(testname=None):
         # Tests that are failing temporarily and should be fixed
         current_failing_tests = ('^test_cast_STRING_to_FLOAT_cpu.*',
                                  '^test_cast_FLOAT_to_STRING_cpu.*',
-                                 '^test_dequantizelinear_cpu.*',
                                  '^test_qlinearconv_cpu.*',
-                                 '^test_quantizelinear_cpu.*',
                                  '^test_gru_seq_length_cpu.*',
                                  '^test_bitshift_right_uint16_cpu.*',
                                  '^test_bitshift_right_uint32_cpu.*',


### PR DESCRIPTION
**Description**: Enable quantization tests in onnx_backend_test_series.py

**Motivation and Context**
- These tests are now fixed and there is no reason to keep them disabled.
