### PR TITLE
Add fall-back for threadpool size if hardware_concurrency() is 0

### DIFF
--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -106,6 +106,10 @@ InferenceSession::InferenceSession(const SessionOptions& session_options, loggin
     int pool_size = session_options_.session_thread_pool_size <= 0
                         ? std::thread::hardware_concurrency() / 2
                         : session_options_.session_thread_pool_size;
+    if (pool_size == 0) {
+      // hardware_concurrency() may have returned 0, reset to safe default
+      pool_size = 1;
+    }
 
     thread_pool_ = std::make_unique<onnxruntime::concurrency::ThreadPool>("SESSION", pool_size);
   }


### PR DESCRIPTION
**Description**: The change allows ORT to run on environments where hardware_concurrency() returns 0 by resetting to 1. Example: https://stackoverflow.com/questions/37000731/threadhardware-concurrency-checking-returns-zero-value

**Motivation and Context**
- Why is this change required? What problem does it solve? The threadpool can't deal with 0 currently, it would just deadlock. Therefore a check has to be added that resets it to a safe default.
