### PR TITLE
Uninstall the preinstalled cmake in tensorrt image because it's too old

### DIFF
--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt
@@ -7,7 +7,8 @@ FROM nvcr.io/nvidia/tensorrt:19.02-py3
 ARG PYTHON_VERSION=3.5
 
 ADD scripts /tmp/scripts
-RUN /tmp/scripts/install_ubuntu.sh -p ${PYTHON_VERSION} && /tmp/scripts/install_deps.sh && rm -rf /tmp/scripts
+RUN /tmp/scripts/install_ubuntu.sh -p ${PYTHON_VERSION} && /tmp/scripts/install_deps.sh && rm -rf /tmp/scripts \
+    && rm /usr/local/bin/cmake && rm /usr/local/bin/ctest && rm -r /usr/local/share/cmake-3.12
 
 WORKDIR /root
 


### PR DESCRIPTION
**Description**: 
Uninstall the preinstalled cmake in tensorrt image because it's too old that it can't be used for building onnxruntime. Also, it's the default one.

**Motivation and Context**
- Why is this change required? What problem does it solve?
By default, when people run build.sh in tensorrt's docker image, it will fail, because cmake version is too old, even there is a newer one in /usr.

- If it fixes an open issue, please link to the issue here.

