### PR TITLE
Copy shared library in Dockerfile.server

### DIFF
--- a/dockerfiles/Dockerfile.server
+++ b/dockerfiles/Dockerfile.server
@@ -31,6 +31,7 @@ FROM minimal AS final
 WORKDIR /onnxruntime/server/
 ENV MODEL_ABSOLUTE_PATH /onnxruntime/model/model.onnx
 COPY --from=build /onnxruntime/build/Release/onnxruntime_server /onnxruntime/server/
+COPY --from=build /onnxruntime/build/Release/libonnxruntime.so.* /lib/
 RUN apt-get update \
     && apt-get install -y libgomp1
 ENTRYPOINT /onnxruntime/server/onnxruntime_server --model_path $MODEL_ABSOLUTE_PATH


### PR DESCRIPTION
**Description**: Copy ORT shared library to `/lib` in the ORT Server Dockerfile.

**Motivation and Context**
After [PR 1271](https://github.com/microsoft/onnxruntime/pull/1271), the ONNX Runtime Server needs the ONNX Runtime shared library. So we need to add it into the Dockerfile as well.
