### PR TITLE
Make sure submodule urls are up-to-date

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -181,6 +181,7 @@ def run_subprocess(args, cwd=None, capture=False, dll_path=None, shell=False):
     return subprocess.run(args, cwd=cwd, check=True, stdout=stdout, stderr=stderr, env=my_env, shell=shell)
 
 def update_submodules(source_dir):
+    run_subprocess(["git", "submodule", "sync"], cwd=source_dir)
     run_subprocess(["git", "submodule", "update", "--init", "--recursive"], cwd=source_dir)
 
 def is_docker():


### PR DESCRIPTION
**Description**:

This extends build.py to run `git submodule sync` before running `git submodule update --init --recursive`. This makes sure submodule URLs are up-to-date.

**Motivation and Context**

Recently, the submodule URL for tvm changed. If you have an existing clone of the repository, then running build.sh/build.py will not update to the new URL and `git submodule update --init --recursive` will raise an error as it doesn't find the submodule commit in the old repo.