### PR TITLE
Remove AgentPool setting in CI yaml

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -1,5 +1,4 @@
 parameters:
-  AgentPool : 'Win-CPU'
   DoDebugBuild: 'true'
   DoCompliance: 'false'
   BuildCommand: ''
@@ -17,7 +16,6 @@ parameters:
 jobs:
 - job: ${{ parameters.JobName }}
   timeoutInMinutes: 120
-  pool: ${{ parameters.AgentPool }}
   variables:
     buildDirectory: '$(Build.BinariesDirectory)'
     BuildCommand: ${{ parameters.BuildCommand }}


### PR DESCRIPTION
**Description**: 

Remove AgentPool setting in Windows CI yaml file

**Motivation and Context**
- Why is this change required? What problem does it solve?

An internal build pipeline is failing, because it can't find the agent pool.
We don't need to set the agent pool for each job, because by default it will use the one of the pipeline.

- If it fixes an open issue, please link to the issue here.
