### PR TITLE
Fix an SAL annotation in onnxruntime_c_api.h

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -192,7 +192,7 @@ ORT_API_STATUS(OrtCreateSessionFromArray, _In_ OrtEnv* env, _In_ const void* mod
                _In_ const OrtSessionOptions* options, _Out_ OrtSession** out);
 
 ORT_API_STATUS(OrtRun, _Inout_ OrtSession* sess,
-               _In_ const OrtRunOptions* run_options,
+               _In_opt_ const OrtRunOptions* run_options,
                _In_ const char* const* input_names, _In_ const OrtValue* const* input, size_t input_len,
                _In_ const char* const* output_names, size_t output_names_len, _Out_ OrtValue** output);
 


### PR DESCRIPTION
**Description**: Describe your changes.
Fix an SAL annotation in onnxruntime_c_api.h
**Motivation and Context**
- Why is this change required? What problem does it solve?

run_options should be optional.

- If it fixes an open issue, please link to the issue here.
