### PR TITLE
Add C++ API test for NuGet package

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/CXX_Api_Sample.cpp
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/CXX_Api_Sample.cpp
@@ -32,7 +32,13 @@ int main(int argc, char* argv[]) {
   // create session and load model into memory
   // using squeezenet version 1.3
   // URL = https://github.com/onnx/models/tree/master/squeezenet
+#ifdef _WIN32
   const wchar_t* model_path = L"squeezenet.onnx";
+#else
+  const char* model_path = "squeezenet.onnx";
+#endif
+
+  printf("Using Onnxruntime C++ API\n");
   Ort::Session session(env, model_path, session_options);
 
   //*************************************************************************

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/C_Api_Sample.cpp
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/C_Api_Sample.cpp
@@ -55,6 +55,7 @@ int main(int argc, char* argv[]) {
   const char* model_path = "squeezenet.onnx";
 #endif
 
+  printf("Using Onnxruntime C API\n");
   CHECK_STATUS(OrtCreateSession(env, model_path, session_options, &session));
 
   //*************************************************************************

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/Microsoft.ML.OnnxRuntime.EndToEndTests.RunCapi.vcxproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/Microsoft.ML.OnnxRuntime.EndToEndTests.RunCapi.vcxproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <OnnxRuntimeCsharpRoot>$(MSBuildThisFileDirectory)..\..</OnnxRuntimeCsharpRoot>
     <PackageName Condition="'$(PackageName)' == ''">Microsoft.ML.OnnxRuntime</PackageName>
+    <OnnxRuntimeSampleCode Condition="'$(OnnxRuntimeSampleCode)' == ''">C_Api_Sample.cpp</OnnxRuntimeSampleCode>
   </PropertyGroup>
   <Import Project="..\packages\$(PackageName).$(CurrentOnnxRuntimeVersion)\build\native\$(PackageName).props" Condition="Exists('..\packages\$(PackageName).$(CurrentOnnxRuntimeVersion)\build\native\$(PackageName).props')" />
 
@@ -108,7 +109,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="C_Api_Sample.cpp" />
+    <ClCompile Include="$(OnnxRuntimeSampleCode)" />
   </ItemGroup>
   <ItemGroup>
    <None Include="$(OnnxRuntimeCSharpRoot)\testdata\*">

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -67,7 +67,23 @@ jobs:
          EXIT 1
      }
     workingDirectory: '$(Build.SourcesDirectory)\csharp'
-    displayName: 'Run End to End Test (C++) '
+    displayName: 'Run End to End Test (C-API) '
+    timeoutInMinutes: 30
+    continueOnError: true
+
+  # test C++ API sample
+  - script: |
+     @echo ##vso[task.setvariable variable=OnnxRuntimeSampleCode]CXX_Api_Sample.cpp
+
+  - script: |
+     @echo "Running runtest.bat"
+     test\Microsoft.ML.OnnxRuntime.EndToEndTests.Capi\runtest.bat $(Build.BinariesDirectory)\nuget-artifact
+     REM Need an ErrorLevel check, since the script uses Exit /B
+     IF NOT %ERRORLEVEL% EQU 0 {
+         EXIT 1
+     }
+    workingDirectory: '$(Build.SourcesDirectory)\csharp'
+    displayName: 'Run End to End Test (C++ API) '
     timeoutInMinutes: 30
     continueOnError: true
 


### PR DESCRIPTION
**Description**: Add a test for C++ API from NuGet package (verifies that user sample will always work)

**Motivation and Context**
Currently the user C++ sample code is not tested -- this test ensures that users can use the C++ API sample code from the NuGet package.
