### PR TITLE
Switch to use nvidia-docker2 command format

### DIFF
--- a/tools/ci_build/github/linux/run_dockerbuild.sh
+++ b/tools/ci_build/github/linux/run_dockerbuild.sh
@@ -80,13 +80,13 @@ if [ -z "$NIGHTLY_BUILD" ]; then
 fi
 
 if [ $BUILD_DEVICE = "cpu" ] || [ $BUILD_DEVICE = "ngraph" ] || [ $BUILD_DEVICE = "openvino" ]; then
-    ONNX_DOCKER=docker
+    RUNTIME=
 else
-    ONNX_DOCKER=nvidia-docker
+    RUNTIME="--runtime=nvidia"
 fi
 
 docker rm -f "onnxruntime-$BUILD_DEVICE" || true
-$ONNX_DOCKER run -h $HOSTNAME \
+docker run $RUNTIME -h $HOSTNAME \
     --name "onnxruntime-$BUILD_DEVICE" \
     --volume "$SOURCE_ROOT:/onnxruntime_src" \
     --volume "$BUILD_DIR:/build" \


### PR DESCRIPTION
**Description**: Describe your changes.
See [https://github.com/NVIDIA/nvidia-docker/wiki/Usage](https://github.com/NVIDIA/nvidia-docker/wiki/Usage)

nvidia-docker has two versions: v1 and v2.  We are using v2, but with the old v1 style command.


**Motivation and Context**
- Why is this change required? What problem does it solve?
To enable GPU support for any container image

- If it fixes an open issue, please link to the issue here.
