### PR TITLE
Use MLAS to retrieve the CPU preferred tensor buffer alignment

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -17,13 +17,7 @@ set(mlas_common_srcs
 
 if(MSVC)
 
-  if(CMAKE_GENERATOR_PLATFORM STREQUAL "ARM")
-
-    set(mlas_platform_srcs
-      ${ONNXRUNTIME_ROOT}/core/mlas/lib/arm/sgemmc.cpp
-    )
-
-  elseif(CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64")
+  if(CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64")
 
     set(asm_filename ${ONNXRUNTIME_ROOT}/core/mlas/lib/arm64/sgemma.asm)
     set(pre_filename ${CMAKE_CURRENT_BINARY_DIR}/sgemma.i)
@@ -45,17 +39,13 @@ if(MSVC)
 
     set(mlas_platform_srcs ${obj_filename})
 
-  elseif(CMAKE_GENERATOR_PLATFORM STREQUAL "Win32")
-
-    enable_language(ASM_MASM)
-
-    set(CMAKE_ASM_MASM_FLAGS "${CMAKE_ASM_MASM_FLAGS} /safeseh")
+  elseif(CMAKE_GENERATOR_PLATFORM STREQUAL "ARM" OR CMAKE_GENERATOR MATCHES "ARM")
 
     set(mlas_platform_srcs
-      ${ONNXRUNTIME_ROOT}/core/mlas/lib/i386/sgemma.asm
+      ${ONNXRUNTIME_ROOT}/core/mlas/lib/arm/sgemmc.cpp
     )
 
-  elseif(CMAKE_GENERATOR_PLATFORM STREQUAL "x64")
+  elseif(CMAKE_GENERATOR_PLATFORM STREQUAL "x64" OR CMAKE_GENERATOR MATCHES "Win64")
 
     enable_language(ASM_MASM)
 
@@ -76,6 +66,16 @@ if(MSVC)
       ${ONNXRUNTIME_ROOT}/core/mlas/lib/amd64/LogisticKernelFma3.asm
       ${ONNXRUNTIME_ROOT}/core/mlas/lib/amd64/TanhKernelFma3.asm
       ${ONNXRUNTIME_ROOT}/core/mlas/lib/amd64/ErfKernelFma3.asm
+    )
+
+  else()
+
+    enable_language(ASM_MASM)
+
+    set(CMAKE_ASM_MASM_FLAGS "${CMAKE_ASM_MASM_FLAGS} /safeseh")
+
+    set(mlas_platform_srcs
+      ${ONNXRUNTIME_ROOT}/core/mlas/lib/i386/sgemma.asm
     )
 
   endif()

--- a/onnxruntime/core/framework/allocator.cc
+++ b/onnxruntime/core/framework/allocator.cc
@@ -3,6 +3,7 @@
 
 #include "core/framework/allocator.h"
 #include "core/framework/allocatormgr.h"
+#include "core/mlas/inc/mlas.h"
 #include <cstdlib>
 #include <sstream>
 
@@ -11,15 +12,8 @@ namespace onnxruntime {
 void* CPUAllocator::Alloc(size_t size) {
   if (size <= 0)
     return nullptr;
-  //default align to 64;
   void* p;
-#if defined(__AVX512F__)
-  size_t alignment = 64;
-#elif defined(__AVX__)
-  size_t alignment = 32;
-#else
-  size_t alignment = 32; //Indeed, the default one(8 or 16) should be enough
-#endif
+  size_t alignment = MlasGetPreferredBufferAlignment();
 #if _MSC_VER
   p = _aligned_malloc(size, alignment);
   if (p == nullptr) throw std::bad_alloc();

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -46,7 +46,7 @@ typedef enum { CblasLeft=141, CblasRight=142} CBLAS_SIDE;
 //
 // Forward declare the thread pool implementation class.
 //
-// N.B. Avoid including onnxruntime headers here to keep the dependencies for
+// N.B. Avoid including ONNX Runtime headers here to keep the dependencies for
 // standalone MLAS test executables smaller.
 //
 
@@ -57,6 +57,16 @@ namespace onnxruntime {
 };
 
 using MLAS_THREADPOOL = onnxruntime::concurrency::ThreadPool;
+
+//
+// Platform routines.
+//
+
+size_t
+MLASCALL
+MlasGetPreferredBufferAlignment(
+    void
+    );
 
 //
 // Activation routines.

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -359,6 +359,23 @@ extern "C" {
 }
 
 //
+// Define the default preferred byte alignment for buffers.
+//
+// MLAS_TARGET_AMD64_IX86: The typical architecture uses AVX instructions
+// accessing 256-bit vectors. MLAS_TARGET_AMD64 returns a larger value if the
+// platform supports 512-bit vectors to ensure that vectors are not split.
+//
+// MLAS_TARGET_ARM64: The kernels use "load pair" instructions to access 128-bit
+// vectors, so this value keeps both vectors in the same cache line.
+//
+// MLAS_TARGET_ARM: Using 16 for a single 128-bit vector may be sufficient for
+// this architecture, but the ONNX Runtime has historically used this larger
+// value.
+//
+
+#define MLAS_DEFAULT_PREFERRED_BUFFER_ALIGNMENT     32
+
+//
 // Define the target number of per-thread multiplies before using another
 // thread to perform additional work.
 //
@@ -424,6 +441,7 @@ struct MLAS_PLATFORM {
     PMLAS_TANH_KERNEL_ROUTINE TanhKernelRoutine;
     PMLAS_ERF_KERNEL_ROUTINE ErfKernelRoutine;
     uint32_t NchwcBlockSize;
+    uint32_t PreferredBufferAlignment;
 #endif
 
 #if defined(MLAS_USE_WIN32_THREADPOOL)

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -99,6 +99,7 @@ Return Value:
     this->TanhKernelRoutine = MlasTanhKernel;
     this->ErfKernelRoutine = MlasErfKernel;
     this->NchwcBlockSize = 8;
+    this->PreferredBufferAlignment = MLAS_DEFAULT_PREFERRED_BUFFER_ALIGNMENT;
 #endif
 
     //
@@ -168,6 +169,7 @@ Return Value:
                     this->PoolFloatKernel[MlasAveragePoolingExcludePad] = MlasPoolAverageExcludePadFloatKernelAvx512F;
                     this->PoolFloatKernel[MlasAveragePoolingIncludePad] = MlasPoolAverageIncludePadFloatKernelAvx512F;
                     this->NchwcBlockSize = 16;
+                    this->PreferredBufferAlignment = 64;
 
                 } else {
 
@@ -209,4 +211,34 @@ Return Value:
 
 #endif
 
+}
+
+size_t
+MLASCALL
+MlasGetPreferredBufferAlignment(
+    void
+    )
+/*++
+
+Routine Description:
+
+    This routine returns the preferred byte alignment for buffers that are used
+    with this library. Buffers that are not bytes aligned to this value will
+    function, but will not achieve best performance.
+
+Arguments:
+
+    None.
+
+Return Value:
+
+    Returns the preferred byte alignment for buffers.
+
+--*/
+{
+#if defined(MLAS_TARGET_AMD64)
+    return MlasPlatform.PreferredBufferAlignment;
+#else
+    return MLAS_DEFAULT_PREFERRED_BUFFER_ALIGNMENT;
+#endif
 }


### PR DESCRIPTION
**Description**: 
Add MlasGetPreferredBufferAlignment() for use by CPUAllocator::Alloc to get the byte alignment for CPU tensors. Using MLAS allows the value to be based on the platform the binary is running on instead of a constant value fixed at compile time.

Also fixed onnxruntime_mlas.cmake to accept the older cmake style for specifying MSVC architecture via CMAKE_GENERATOR (fixing issue #1305).

**Motivation and Context**
Using 64 byte alignment for tensors is critical to get best performance out of the NCHWc kernels. Using 32 byte alignment, the onnxzoo resnet50 averaged 22ms per inference. Using 64 byte alignment, the same model averages 17.5ms per inference. 

[classification_sample from OpenVINO 2019 r1 is getting 16ms per inference using the same model. onnxruntime_perf_test -o2 is at 32ms per inference, with the 64 byte alignment]
