### PR TITLE
Add constant initializer support in GraphViewer for precompilation

### DIFF
--- a/include/onnxruntime/core/graph/graph_viewer.h
+++ b/include/onnxruntime/core/graph/graph_viewer.h
@@ -38,6 +38,9 @@ class GraphViewer {
   */
   bool GetInitializedTensor(const std::string& tensor_name, const ONNX_NAMESPACE::TensorProto*& value) const;
 
+  /** Returns true if an initializer value can be overridden by a graph input with the same name. */
+  bool CanOverrideInitializer() const noexcept;
+
   /**
   Gets the Graph inputs, excluding initializers.
   @returns Collection of NodeArg pointers for the graph inputs, excluding inputs that have matching initializers.
@@ -102,8 +105,14 @@ class GraphViewer {
     return graph_->DomainToVersionMap();
   }
 
-  /** Check if this is a Subgraph */
+  /** Checks if this is a Subgraph */
   bool IsSubgraph() const;
+
+  /** 
+  Returns true if 'name' is an initializer, and is constant and cannot be overridden at runtime. 
+  @param check_outer_scope If true and the 'graph_' is a subgraph, check parent graph/s for 'name' if not found in 'graph_'.
+  */
+  bool IsConstantInitializer(const std::string& name, bool check_outer_scope) const;
 
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(GraphViewer);

--- a/onnxruntime/core/graph/graph_viewer.cc
+++ b/onnxruntime/core/graph/graph_viewer.cc
@@ -8,6 +8,8 @@
 
 #include "core/graph/graph_viewer.h"
 
+#include "core/graph/graph_utils.h"
+
 namespace onnxruntime {
 
 struct NodeCompare {
@@ -25,12 +27,13 @@ GraphViewer::GraphViewer(const Graph& graph) {
       leaf_nodes.push_back(&node);
     }
   }
-  graph.ReverseDFSFrom(leaf_nodes,
-                       nullptr,
-                       [this](const Node* n) {
-                         nodes_in_topological_order_.push_back(n->Index());
-                       },
-                       NodeCompare());
+  graph.ReverseDFSFrom(
+      leaf_nodes,
+      nullptr,
+      [this](const Node* n) {
+        nodes_in_topological_order_.push_back(n->Index());
+      },
+      NodeCompare());
 
   for (auto& node : graph_->Nodes()) {
     if (node.InputEdgesBegin() == node.InputEdgesEnd()) {
@@ -50,6 +53,10 @@ const std::string& GraphViewer::Description() const noexcept {
 
 bool GraphViewer::GetInitializedTensor(const std::string& tensor_name, const ONNX_NAMESPACE::TensorProto*& value) const {
   return graph_->GetInitializedTensor(tensor_name, value);
+}
+
+bool GraphViewer::CanOverrideInitializer() const noexcept {
+  return graph_->CanOverrideInitializer();
 }
 
 // Graph inputs excluding initializers.
@@ -107,6 +114,10 @@ const NodeArg* GraphViewer::GetNodeArg(const std::string& name) const {
 
 bool GraphViewer::IsSubgraph() const {
   return graph_->IsSubgraph();
+}
+
+bool GraphViewer::IsConstantInitializer(const std::string& name, bool check_outer_scope) const {
+  return graph_utils::IsConstantInitializer(*graph_, name, check_outer_scope);
 }
 
 }  // namespace onnxruntime


### PR DESCRIPTION
Precompilation has only access to GraphViwer, not Graph.
Therefore, to safely support constant initializer and initializer override for IR version>4, 
several member or utility functions need to be added in GraphViewer.

- Add access of Graph's CanOverrideInitializer in GraphViewer.
- Add graph_utils::IsConstantInitializer to a member func of GraphViewer

