### PR TITLE
One fix for #1397, disable onnxruntime_PYBIND_EXPORT_OPSCHEMA is --gen_doc is not set up…

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -375,6 +375,8 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
 
     if args.gen_doc:
         cmake_args += ["-Donnxruntime_PYBIND_EXPORT_OPSCHEMA=ON"]
+    else:
+        cmake_args += ["-Donnxruntime_PYBIND_EXPORT_OPSCHEMA=OFF"]
 
     cmake_args += ["-D{}".format(define) for define in cmake_extra_defines]
 


### PR DESCRIPTION
**Description**: Describe your changes.
See issue #1397.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
