### PR TITLE
Added helper script to call vcvarsall.bat found using vswhere.exe.

### DIFF
--- a/build.amd64.1411.bat
+++ b/build.amd64.1411.bat
@@ -6,7 +6,7 @@ rem It currently defaults to amd64 but that could be made configurable if that w
 @echo off
 
 rem Use 14.11 toolset
-call "%VCINSTALLDIR%\Auxiliary\Build\vcvarsall.bat" amd64 -vcvars_ver=14.11
+call "%~dp0\tools\vs2017_vcvarsall.bat" amd64 -vcvars_ver=14.11
 
 rem Requires a python 3.6 or higher install to be available in your PATH
 python %~dp0\tools\ci_build\build.py --build_dir %~dp0\build\Windows %*

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-arm.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-arm.yml
@@ -73,7 +73,7 @@ jobs:
       - task: BatchScript@1
         displayName: 'Setup VS2017 env vars'
         inputs:
-          filename: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat'
+          filename: '$(Build.SourcesDirectory)\tools\vs2017_vcvarsall.bat'
           arguments: 'x64 -vcvars_ver=14.11'
           modifyEnvironment: true
 

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -75,7 +75,7 @@ jobs:
         displayName: 'Test C# Debug'
         inputs:
           script: |
-           FOR /F  %%f IN ('dir /s /b test\Microsoft.ML.OnnxRuntime.Tests\bin\*Tests.dll') DO %dotnetexe% vstest %%f 
+           FOR /F  %%f IN ('dir /s /b test\Microsoft.ML.OnnxRuntime.Tests\bin\*Tests.dll') DO %dotnetexe% vstest %%f
           workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
     # Run test coverage report
@@ -121,7 +121,7 @@ jobs:
       displayName: 'Test C# RelWithDebInfo'
       inputs:
         script: |
-         FOR /F  %%f IN ('dir /s /b test\Microsoft.ML.OnnxRuntime.Tests\bin\*Tests.dll') DO %dotnetexe% vstest %%f 
+         FOR /F  %%f IN ('dir /s /b test\Microsoft.ML.OnnxRuntime.Tests\bin\*Tests.dll') DO %dotnetexe% vstest %%f
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
     - task: PublishTestResults@2
@@ -137,7 +137,7 @@ jobs:
       - task: BatchScript@1
         displayName: 'Setup VS2017 env vars'
         inputs:
-          filename: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat'
+          filename: '$(Build.SourcesDirectory)\tools\vs2017_vcvarsall.bat'
           arguments: 'x64 -vcvars_ver=14.11'
           modifyEnvironment: true
 

--- a/tools/ci_build/github/azure-pipelines/templates/win-x86-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-x86-ci.yml
@@ -69,7 +69,7 @@ jobs:
         displayName: 'Test C# Debug'
         inputs:
           script: |
-           FOR /F  %%f IN ('dir /s /b test\Microsoft.ML.OnnxRuntime.Tests\bin\*Tests.dll') DO %dotnetexe% vstest %%f 
+           FOR /F  %%f IN ('dir /s /b test\Microsoft.ML.OnnxRuntime.Tests\bin\*Tests.dll') DO %dotnetexe% vstest %%f
           workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
     # Build RelWithDebInfo -- this variable required to build C#
@@ -112,7 +112,7 @@ jobs:
       displayName: 'Test C# RelWithDebInfo'
       inputs:
         script: |
-         FOR /F  %%f IN ('dir /s /b test\Microsoft.ML.OnnxRuntime.Tests\bin\*Tests.dll') DO %dotnetexe% vstest %%f 
+         FOR /F  %%f IN ('dir /s /b test\Microsoft.ML.OnnxRuntime.Tests\bin\*Tests.dll') DO %dotnetexe% vstest %%f
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
     - task: PublishTestResults@2
@@ -128,7 +128,7 @@ jobs:
       - task: BatchScript@1
         displayName: 'Setup VS2017 env vars'
         inputs:
-          filename: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat'
+          filename: '$(Build.SourcesDirectory)\tools\vs2017_vcvarsall.bat'
           arguments: 'x86 -vcvars_ver=14.11'
           modifyEnvironment: true
 

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -57,7 +57,7 @@ steps:
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
         arguments: '$(Build.SourcesDirectory)\tools\ci_build\github\windows\download_cmake.py --build_dir $(Build.BinariesDirectory)'
-    
+
     - task: PowerShell@2
       displayName: 'Download OpenCppCoverage installer'
       continueOnError: true
@@ -81,7 +81,7 @@ steps:
     - task: BatchScript@1
       displayName: 'Setup VS2017 env vars'
       inputs:
-        filename: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat'
+        filename: '$(Build.SourcesDirectory)\tools\vs2017_vcvarsall.bat'
         arguments: '${{parameters.buildArch}} -vcvars_ver=14.11'
         modifyEnvironment: true
       condition: ${{parameters.setVcvars}}

--- a/tools/get_vcvarsall_path.ps1
+++ b/tools/get_vcvarsall_path.ps1
@@ -1,0 +1,41 @@
+# Gets the path to vcvarsall.bat for a particular Visual Studio version
+# Run with -Verbose to see error output
+
+param (
+  [Parameter(Mandatory=$true)][string]$VsVersion
+)
+
+function ErrorExit([string]$message) {
+  Write-Verbose $message
+  Exit 1
+}
+
+$VS_VERSION_RANGE_MAP = @{
+  "2017" = "[15.0,16.0)"
+  "2019" = "[16.0,17.0)"
+}
+if (!$VS_VERSION_RANGE_MAP.Contains($VsVersion)) {
+  $validVersions = $VS_VERSION_RANGE_MAP.Keys -join ", "
+  ErrorExit("Invalid value for VsVersion. Allowed values: ${validVersions}")
+}
+$VsVersionRange = $VS_VERSION_RANGE_MAP[$VsVersion]
+
+$VsWhereKnownPath = "${env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe"
+if (!(Test-Path -PathType Leaf -LiteralPath ${VsWhereKnownPath})) {
+  ErrorExit("VsWhere.exe not found in expected location: ${VsWhereKnownPath}")
+}
+
+$VsInstallationPath = & ${VsWhereKnownPath} -latest -version ${VsVersionRange} -property installationPath -format value
+if (!${?}) {
+  ErrorExit("VsWhere.exe call failed.")
+}
+if ($VsInstallationPath.GetType() -ne [string]) {
+  ErrorExit("Got unexpected output from VsWhere.exe.")
+}
+
+$VcVarsAllPath = "${VsInstallationPath}/VC/Auxiliary/Build/vcvarsall.bat"
+if (!(Test-Path -PathType Leaf -LiteralPath ${VcVarsAllPath})) {
+  ErrorExit("vcvarsall.bat not found in expected location: ${VcVarsAllPath}")
+}
+
+Write-Output $VcVarsAllPath

--- a/tools/vs2017_vcvarsall.bat
+++ b/tools/vs2017_vcvarsall.bat
@@ -1,0 +1,16 @@
+:: Locates and calls VS 2017's vcvarsall.bat
+
+@echo off
+
+for /f "usebackq delims=" %%i in (`"%~dp0\vswhere.bat" -version 15.0 -property installationPath`) do (
+  if exist "%%i\VC\Auxiliary\Build\vcvarsall.bat" (
+    set "VcVarsAllPath=%%i\VC\Auxiliary\Build\vcvarsall.bat"
+  )
+)
+
+if "%VcVarsAllPath%"=="" (
+  echo Unable to get path to vcvarsall.bat.
+  exit /b 1
+)
+
+call "%VcVarsAllPath%" %*

--- a/tools/vs2017_vcvarsall.bat
+++ b/tools/vs2017_vcvarsall.bat
@@ -2,10 +2,9 @@
 
 @echo off
 
-for /f "usebackq delims=" %%i in (`"%~dp0\vswhere.bat" -version 15.0 -property installationPath`) do (
-  if exist "%%i\VC\Auxiliary\Build\vcvarsall.bat" (
-    set "VcVarsAllPath=%%i\VC\Auxiliary\Build\vcvarsall.bat"
-  )
+for /f "usebackq delims=" %%i in (`powershell -Command "%~dp0\get_vcvarsall_path.ps1" -VsVersion 2017`) do (
+  echo %%i
+  set "VcVarsAllPath=%%i"
 )
 
 if "%VcVarsAllPath%"=="" (

--- a/tools/vswhere.bat
+++ b/tools/vswhere.bat
@@ -1,0 +1,5 @@
+:: Calls vswhere.exe from its known location
+
+@echo off
+
+call "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" %*

--- a/tools/vswhere.bat
+++ b/tools/vswhere.bat
@@ -1,5 +1,0 @@
-:: Calls vswhere.exe from its known location
-
-@echo off
-
-call "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" %*


### PR DESCRIPTION
Added helper script to call vcvarsall.bat found using vswhere.exe. Updated existing usages of vcvarsall.bat.

**Description**:
This change adds some helper scripts for calling VS2017's vcvarsall.bat and updates existing calls to vcvarsall.bat. The locating of vcvarsall.bat is delegated to vswhere.exe (https://github.com/Microsoft/vswhere), which seems like a robust way of finding it.

**Motivation and Context**
1. Remove some hard-coded paths to Visual Studio installations. Make it easier for other tools to invoke vcvarsall.bat.
3. build.amd64.1411.bat was assuming the existence of a VCINSTALLDIR variable to find vcvarsall.bat. That variable was not present in a non-VS command prompt.