### PR TITLE
Optimize the resize and upsample

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -39,21 +39,25 @@ Status UpsampleNearest(const T* input,
     return Status(ONNXRUNTIME, FAIL, "Upsample: input/output value is nullptr");
   if (input_shape.NumDimensions() != output_shape.NumDimensions())
     return Status(ONNXRUNTIME, FAIL, "Upsample: input/output value's dimension mismatch");
+  if (input_shape.NumDimensions() == 0) {
+    return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
+                  "Upsample: input shape needs to be at least a single dimension.");
+  }
 
-  auto n_dim = input_shape.NumDimensions();
-  std::vector<int64_t> output_dim_counter(n_dim);
+  int64_t n_dim = static_cast<int64_t>(input_shape.NumDimensions());
+  return std::vector<int64_t> output_dim_counter(n_dim);
   output_dim_counter[n_dim - 1] = -1;  // initialize dimension counter
 
   std::vector<int64_t> input_dim_counters(n_dim);
   std::vector<int64_t> input_dim_factor(n_dim);
   input_dim_factor[n_dim - 1] = 1;  // initialize dimension factor
-  for (auto dim_idx = static_cast<int64_t>(n_dim - 2); dim_idx >= 0; dim_idx--) {
+  for (int64_t dim_idx = n_dim - 2; dim_idx >= 0; dim_idx--) {
     input_dim_factor[dim_idx] = input_dim_factor[dim_idx + 1] * input_shape[dim_idx + 1];
   }
 
   int64_t input_idx = 0;
   for (int64_t output_idx = 0; output_idx < output_shape.Size(); output_idx++) {
-    for (auto dim_idx = static_cast<int64_t>(n_dim - 1); dim_idx >= 0; dim_idx--) {
+    for (int64_t dim_idx = n_dim - 1; dim_idx >= 0; dim_idx--) {
       if (++output_dim_counter[dim_idx] < output_shape[dim_idx]) {
         int64_t current_input_dim_counter = 0;
         if (scales[dim_idx] < 1)  //downsample

--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -49,6 +49,11 @@ Status UpsampleNearest(const T* input,
   output_dim_counter[n_dim - 1] = -1;  // initialize dimension counter
 
   std::vector<int64_t> input_dim_counters(n_dim);
+  std::vector<float> input_dim_value(n_dim);
+  std::vector<float> scales_reciprocal(n_dim);
+  for (int64_t scales_inx = 0; scales_inx < n_dim; scales_inx++) {
+    scales_reciprocal[scales_inx] = 1.0f / scales[scales_inx];
+  }
   std::vector<int64_t> input_dim_factor(n_dim);
   input_dim_factor[n_dim - 1] = 1;  // initialize dimension factor
   for (int64_t dim_idx = n_dim - 2; dim_idx >= 0; dim_idx--) {
@@ -64,14 +69,16 @@ Status UpsampleNearest(const T* input,
   int64_t output_idx = 0;
   int64_t input_idx = 0;
 
-#define OneDemensionProcessor(dim_inx)                                                                                                                  \
-  int64_t input_dim##dim_inx##_inx =                                                                                                                    \
-      static_cast<int64_t>(scales[dim_inx] < 1 ? std::ceil(output_dim##dim_inx##_inx / scales[dim_inx]) : output_dim##dim_inx##_inx / scales[dim_inx]); \
-  if (input_dim##dim_inx##_inx > input_shape[dim_inx] - 1) input_dim##dim_inx##_inx = input_shape[dim_inx] - 1;                                         \
-  if (input_dim##dim_inx##_inx != input_dim_counters[dim_inx]) {                                                                                        \
-    input_idx += (input_dim##dim_inx##_inx - input_dim_counters[dim_inx]) * input_dim_factor[dim_inx];                                                  \
-    input_dim_counters[dim_inx] = input_dim##dim_inx##_inx;                                                                                             \
-  }
+#define OneDemensionProcessor(dim_inx)                                                                            \
+  int64_t input_dim##dim_inx##_inx =                                                                              \
+      static_cast<int64_t>(scales[dim_inx] < 1 ? std::ceil(input_dim_value[dim_inx]) : input_dim_value[dim_inx]); \
+  if (input_dim##dim_inx##_inx > input_shape[dim_inx] - 1) input_dim##dim_inx##_inx = input_shape[dim_inx] - 1;   \
+  if (input_dim##dim_inx##_inx != input_dim_counters[dim_inx]) {                                                  \
+    input_idx += (input_dim##dim_inx##_inx - input_dim_counters[dim_inx]) * input_dim_factor[dim_inx];            \
+    input_dim_counters[dim_inx] = input_dim##dim_inx##_inx;                                                       \
+  }                                                                                                               \
+  input_dim_value[dim_inx] += scales_reciprocal[dim_inx];                                                         \
+  if (dim_inx + 1 < n_dim) input_dim_value[dim_inx + 1] = 0.0f;
 
   if (n_dim == 1) {
     for (int64_t output_dim0_inx = 0; output_dim0_inx < output_shape[0]; output_dim0_inx++) {

--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -45,7 +45,7 @@ Status UpsampleNearest(const T* input,
   }
 
   int64_t n_dim = static_cast<int64_t>(input_shape.NumDimensions());
-  return std::vector<int64_t> output_dim_counter(n_dim);
+  std::vector<int64_t> output_dim_counter(n_dim);
   output_dim_counter[n_dim - 1] = -1;  // initialize dimension counter
 
   std::vector<int64_t> input_dim_counters(n_dim);


### PR DESCRIPTION
**Description**: Describe your changes.
Optimize the resize and upsample operators
**Motivation and Context**
- Why is this change required? What problem does it solve?
For case with input with shape [1,128, 267, 200] and scales [1, 1, 1.97, 2], Resize and upsample get 15x gain (w/o: 1020ms, w: 71ms on my local box). It should benefit other scenarios at similar level.  
- If it fixes an open issue, please link to the issue here.
