### PR TITLE
Fix ROI Pooling bin size calculation

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/roi_pool.cc
+++ b/onnxruntime/core/providers/cpu/nn/roi_pool.cc
@@ -48,11 +48,6 @@ Status RoiPool<float>::Compute(OpKernelContext* context) const {
     int roi_height = std::max(roi_end_h - roi_start_h + 1, 1);
     int roi_width = std::max(roi_end_w - roi_start_w + 1, 1);
 
-    const float bin_size_h =
-        static_cast<float>(roi_height) / static_cast<float>(pooled_height_);
-    const float bin_size_w =
-        static_cast<float>(roi_width) / static_cast<float>(pooled_width_);
-
     const float* batch_data = Xdata + roi_batch_id * X->Shape().SizeFromDimension(1);
 
     for (int c = 0; c < channels; ++c) {
@@ -61,10 +56,10 @@ Status RoiPool<float>::Compute(OpKernelContext* context) const {
           // Compute pooling region for this output unit:
           //  start (included) = floor(ph * roi_height / pooled_height_)
           //  end (excluded) = ceil((ph + 1) * roi_height / pooled_height_)
-          int hstart = static_cast<int>(std::floor(static_cast<float>(ph) * bin_size_h));
-          int wstart = static_cast<int>(std::floor(static_cast<float>(pw) * bin_size_w));
-          int hend = static_cast<int>(std::ceil(static_cast<float>(ph + 1) * bin_size_h));
-          int wend = static_cast<int>(std::ceil(static_cast<float>(pw + 1) * bin_size_w));
+          int hstart = (ph * roi_height) / static_cast<int>(pooled_height_);
+          int wstart = (pw * roi_width) / static_cast<int>(pooled_width_);
+          int hend = ((ph + 1) * roi_height + static_cast<int>(pooled_height_) - 1) / static_cast<int>(pooled_height_);
+          int wend = ((ph + 1) * roi_width + static_cast<int>(pooled_width_) - 1) / static_cast<int>(pooled_width_);
 
           // Add roi offsets and clip to input boundaries
           hstart = std::min(std::max(hstart + roi_start_h, 0), height);

--- a/onnxruntime/core/providers/cpu/nn/roi_pool.cc
+++ b/onnxruntime/core/providers/cpu/nn/roi_pool.cc
@@ -54,8 +54,8 @@ Status RoiPool<float>::Compute(OpKernelContext* context) const {
       for (int ph = 0; ph < pooled_height_; ++ph) {
         for (int pw = 0; pw < pooled_width_; ++pw) {
           // Compute pooling region for this output unit:
-          //  start (included) = floor(ph * roi_height / pooled_height_)
-          //  end (excluded) = ceil((ph + 1) * roi_height / pooled_height_)
+          //  start (included) = (ph * roi_height) / pooled_height_
+          //  end (excluded) = ((ph + 1) * roi_height + pooled_height_ - 1) / pooled_height_
           int hstart = (ph * roi_height) / static_cast<int>(pooled_height_);
           int wstart = (pw * roi_width) / static_cast<int>(pooled_width_);
           int hend = ((ph + 1) * roi_height + static_cast<int>(pooled_height_) - 1) / static_cast<int>(pooled_height_);


### PR DESCRIPTION
**Description**: Improve ROI Pooling bin size calculation by doing integer flooring/ceiling instead of float flooring/ceiling.

**Motivation and Context**
- Why is this change required? What problem does it solve?

Even if an integer is a multiple of another integer, dividing them together after converting them to floats is not guaranteed to give a number representable by an integer. For example, `4.00000 / 2.00000` could give `2.00000` or `1.99994` depending on the architecture (e.g. x64 vs ARM) or other factors. This is especially a problem here because of `floor` and `ceil`, which can give 2 completely different indices depending on the result of the division. `floor(2.00000) == 2.00000`, but `floor(1.99994) == 1.00000`.

Since all operands of the division before `ceil` and `floor` are positive integers, we can do integer flooring and ceiling instead of converting them to float beforehand. This will give more precise results, and most importantly consistent results. We don't have to do any float arithmetic during this operation.