### PR TITLE
Fix ORTSRV nightly build

### DIFF
--- a/onnxruntime/test/server/integration_tests/model_zoo_tests.py
+++ b/onnxruntime/test/server/integration_tests/model_zoo_tests.py
@@ -70,13 +70,13 @@ class ModelZooTests(unittest.TestCase):
                 test_util.pb_response_validation(self, resp, os.path.join(test, 'response.pb'))
 
                 test_util.test_log('[{0}] GRPC testing ....'.format(model_path))
-                    uri = ("{}:{}".format(self.server_ip, self.grpc_port))
-                    with open(os.path.join(test, 'request.pb'), 'rb') as f:
-                        request_payload = f.read()
-                    with grpc.insecure_channel(uri) as channel:
-                        stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
-                        resp = stub.Predict(request_payload)
-                    test_util.pb_response_validation(self, resp, os.path.join(test, 'response.pb'))
+                uri = ("{}:{}".format(self.server_ip, self.grpc_port))
+                with open(os.path.join(test, 'request.pb'), 'rb') as f:
+                    request_payload = f.read()
+                with grpc.insecure_channel(uri) as channel:
+                    stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
+                    resp = stub.Predict(request_payload)
+                test_util.pb_response_validation(self, resp, os.path.join(test, 'response.pb'))
         finally:
             test_util.shutdown_server_app(server_app_proc, self.server_off_in_seconds)
 

--- a/tools/ci_build/github/linux/server_run_build.sh
+++ b/tools/ci_build/github/linux/server_run_build.sh
@@ -15,7 +15,7 @@ done
 
  if [ $BUILD_DEVICE = "gpu" ]; then
     _CUDNN_VERSION=$(echo $CUDNN_VERSION | cut -d. -f1-2)
-    python3 $SCRIPT_DIR/../../build.py --build_dir /home/onnxruntimedev \
+    python3 $SCRIPT_DIR/../../build.py --build_dir /build \
         --config Debug Release \
         --skip_submodule_sync --enable_onnx_tests \
         --parallel --build_shared_lib \
@@ -24,7 +24,7 @@ done
         --cudnn_home /usr/local/cudnn-$_CUDNN_VERSION/cuda --build_shared_lib $BUILD_EXTR_PAR
     /home/onnxruntimedev/Release/onnx_test_runner -e cuda /data/onnx
 else
-    python3 $SCRIPT_DIR/../../build.py --build_dir /home/onnxruntimedev \
+    python3 $SCRIPT_DIR/../../build.py --build_dir /build \
         --skip_submodule_sync  \
         --parallel $BUILD_EXTR_PAR
     # /home/onnxruntimedev/Release/onnx_test_runner /data/onnx

--- a/tools/ci_build/github/linux/server_run_build.sh
+++ b/tools/ci_build/github/linux/server_run_build.sh
@@ -22,10 +22,8 @@ done
         --use_cuda --use_openmp \
         --cuda_home /usr/local/cuda \
         --cudnn_home /usr/local/cudnn-$_CUDNN_VERSION/cuda --build_shared_lib $BUILD_EXTR_PAR
-    /home/onnxruntimedev/Release/onnx_test_runner -e cuda /data/onnx
 else
     python3 $SCRIPT_DIR/../../build.py --build_dir /build \
         --skip_submodule_sync  \
         --parallel $BUILD_EXTR_PAR
-    # /home/onnxruntimedev/Release/onnx_test_runner /data/onnx
 fi


### PR DESCRIPTION
**Description**: Nightly build failed due to could not find the model test path.

**Motivation and Context**
- Why is this change required? What problem does it solve?
The `server_run_build.sh` was created before merged back to master. When pick it up for GRPC build, the `build_dir` was not been updated. It will not impact the regular build since it self-sufficient for unit tests and integration tests. It is not enough for nightly build since nightly build depends on the model downloaded from blob storage.

- If it fixes an open issue, please link to the issue here.
