### PR TITLE
fix return of flakey mnist test on gpu.

### DIFF
--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -209,9 +209,8 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   {
     double per_sample_tolerance = 1e-3;
     // when cuda is enabled, set it to a larger value for resolving random MNIST test failure
-    double relative_per_sample_tolerance = enable_cuda ? 0.017 : 1e-3;
     // when openvino is enabled, set it to a larger value for resolving MNIST accuracy mismatch
-    relative_per_sample_tolerance = enable_openvino ? 0.009 : 1e-3;
+    double relative_per_sample_tolerance = enable_cuda ? 0.017 : enable_openvino ? 0.009 : 1e-3;
 
     Ort::SessionOptions sf;
 


### PR DESCRIPTION
**Description**: GPU build has been failing due to flakey mnist test. Previously the mnist thresholds on cuda were relaxed but due to a bug, it was effectively disabled. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
