### PR TITLE
NCHWc: Support Sum opset6 for ONNX 1.2 models

### DIFF
--- a/onnxruntime/core/optimizer/nchwc_transformer.cc
+++ b/onnxruntime/core/optimizer/nchwc_transformer.cc
@@ -637,7 +637,7 @@ void NchwcTransformerImpl::Transform(Node& node) {
     // needed for correct operation. This avoids doing extra string checks for
     // nodes unrelated to this transformer.
     if (graph_utils::IsSupportedOptypeVersionAndDomain(node, "Add", {7}) ||
-        graph_utils::IsSupportedOptypeVersionAndDomain(node, "Sum", {8})) {
+        graph_utils::IsSupportedOptypeVersionAndDomain(node, "Sum", {6, 8})) {
       TransformAdd(node);
     } else if (graph_utils::IsSupportedOptypeVersionAndDomain(node, "Concat", {4})) {
       TransformConcat(node);


### PR DESCRIPTION
**Description**: 
The NCHWc transform was missing support for the Sum_6 operator from ONNX 1.2. Older models would add unnecessary reorder ops and also would not use the Conv/Add fusion.

**Motivation and Context**
I was trying more test models from the model zoo. The Dense Upsampling Convolution (DUC) sample is an ONNX 1.2 model and wasn't fusing as expected. 

The transformer change is trivial to include the opset6 Sum operator. The transformer test code has been enhanced to use different opsets to test the fusions.
