### PR TITLE
fix mkldnn linux build break.

### DIFF
--- a/onnxruntime/core/providers/mkldnn/mkldnn_execution_provider.cc
+++ b/onnxruntime/core/providers/mkldnn/mkldnn_execution_provider.cc
@@ -111,8 +111,7 @@ std::shared_ptr<KernelRegistry> MKLDNNExecutionProvider::GetKernelRegistry() con
   return kernel_registry;
 }
 
-bool MKLDNNExecutionProvider::UseSubgraph(const onnxruntime::GraphViewer& graph_viewer,
-                                          const std::vector<const KernelRegistry*>& kernel_registries) const {
+bool MKLDNNExecutionProvider::UseSubgraph(const onnxruntime::GraphViewer& graph_viewer) const {
   // switch between mkldnn-vanilla and mkldnn-subgraph implementation using
   // MKLDNN_SUBGRAPH environment variable
   bool use_subgraph = true;
@@ -224,7 +223,7 @@ std::vector<std::unique_ptr<ComputeCapability>> MKLDNNExecutionProvider::GetCapa
 
   // temporary switch to toggle between mkldnn-vanilla and mkldnn-subgraph implementation using
   // ORT_MKLDNN_SUBGRAPH environment variable
-  if (UseSubgraph(graph_viewer, kernel_registries) == false) {
+  if (UseSubgraph(graph_viewer) == false) {
     return IExecutionProvider::GetCapability(graph_viewer, kernel_registries);
   }
 

--- a/onnxruntime/core/providers/mkldnn/mkldnn_execution_provider.h
+++ b/onnxruntime/core/providers/mkldnn/mkldnn_execution_provider.h
@@ -98,8 +98,7 @@ class MKLDNNExecutionProvider : public IExecutionProvider {
     return graph_name;
   }
 
-  bool UseSubgraph(const onnxruntime::GraphViewer& graph_viewer,
-                   const std::vector<const KernelRegistry*>& kernel_registries) const;
+  bool UseSubgraph(const onnxruntime::GraphViewer& graph_viewer) const;
 
   // Some dimensions are not supported by MKL-DNN
   // example: Pool with NumDimensions <= 3 is not supported


### PR DESCRIPTION
**Description**: fix build break when building with --use_mkldnn
due to unused param warning.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
