### PR TITLE
Jignparm/copy cuda extensions

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -38,7 +38,7 @@ jobs:
         displayName: 'Set CUDA path'
         inputs:
           scriptName: 'tools/ci_build/vsts/windows/set_cuda_path.ps1'
-          arguments: '-CudaMsbuildPath C:\local\cudaMsbuildIntegration-10.0.130-win10 -CudaVersion ${{ CudaVersion }}'
+          arguments: '-CudaMsbuildPath C:\local\cudaMsbuildIntegration-10.0.130-win10 -CudaVersion ${{ parameters.CudaVersion }}'
 
     - task: CmdLine@1
       displayName: 'Download test data and generate cmake config'
@@ -179,7 +179,7 @@ jobs:
         displayName: 'Clean up CUDA props files'
         inputs:
           scriptName: 'tools/ci_build/vsts/windows/clean_up_cuda_prop_files.ps1'
-          arguments: '-CudaVersion ${{ CudaVersion }}'
+          arguments: '-CudaVersion ${{ parameters.CudaVersion }}'
 
 
     # Compliance tasks require logs from Debug Build

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -178,7 +178,7 @@ jobs:
       - task: PowerShell@1
         displayName: 'Clean up CUDA props files'
         inputs:
-          scriptName: 'tools/ci_build/vsts/windows/clean_up_cuda_prop_files.ps1'
+          scriptName: 'tools/ci_build/github/windows/clean_up_cuda_prop_files.ps1'
           arguments: '-CudaVersion ${{ parameters.CudaVersion }}'
 
 

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -32,6 +32,14 @@ jobs:
         buildArch: ${{ parameters.BuildArch }}
         setVcvars: ${{ parameters.SetVcvars }}
 
+    # Copy CUDA props files if needed
+    - ${{ if eq(parameters['CudaVersion'], '10.0') }}:
+      - task: PowerShell@1
+        displayName: 'Set CUDA path'
+        inputs:
+          scriptName: 'tools/ci_build/vsts/windows/set_cuda_path.ps1'
+          arguments: '-CudaMsbuildPath C:\local\cudaMsbuildIntegration-10.0.130-win10 -CudaVersion ${{ CudaVersion }}'
+
     - task: CmdLine@1
       displayName: 'Download test data and generate cmake config'
       inputs:
@@ -164,6 +172,15 @@ jobs:
         inputs:
           artifactName: ${{ parameters.ArtifactName }}
           targetPath: '$(Build.ArtifactStagingDirectory)'
+
+    # Remove CUDA props files after build
+    - ${{ if eq(parameters['CudaVersion'], '10.0') }}:
+      - task: PowerShell@1
+        displayName: 'Clean up CUDA props files'
+        inputs:
+          scriptName: 'tools/ci_build/vsts/windows/clean_up_cuda_prop_files.ps1'
+          arguments: '-CudaVersion ${{ CudaVersion }}'
+
 
     # Compliance tasks require logs from Debug Build
     - ${{ if eq(parameters['DoCompliance'], 'true') }}:

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -37,7 +37,7 @@ jobs:
       - task: PowerShell@1
         displayName: 'Set CUDA path'
         inputs:
-          scriptName: 'tools/ci_build/vsts/windows/set_cuda_path.ps1'
+          scriptName: 'tools/ci_build/github/windows/set_cuda_path.ps1'
           arguments: '-CudaMsbuildPath C:\local\cudaMsbuildIntegration-10.0.130-win10 -CudaVersion ${{ parameters.CudaVersion }}'
 
     - task: CmdLine@1


### PR DESCRIPTION
**Description**: Add CUDA 10 extensions explicitly for build agents

**Motivation and Context**
The CUDA 10 extension files can possible be removed by another build job on the build agents (e.g. CNTK), causing build failures. This PR explicitly copies the CUDA 10 extensions to guarantee they are are in place prior to CMAKE.
