### PR TITLE
Fix:  OStreamSink produces interleaved output

### DIFF
--- a/onnxruntime/core/common/logging/sinks/ostream_sink.cc
+++ b/onnxruntime/core/common/logging/sinks/ostream_sink.cc
@@ -21,9 +21,9 @@ void OStreamSink::SendImpl(const Timestamp& timestamp, const std::string& logger
   std::ostringstream msg;
 
   msg << timestamp << " [" << message.SeverityPrefix() << ":" << message.Category() << ":" << logger_id << ", "
-      << message.Location().ToString() << "] " << message.Message();
+      << message.Location().ToString() << "] " << message.Message() << "\n";
 
-  (*stream_) << msg.str() << "\n";
+  (*stream_) << msg.str();
 
   if (flush_) {
     stream_->flush();


### PR DESCRIPTION
**Description**:  OStreamSink produces interleaved output due to issuing multiple operator<< calls to the underlying stream.  Fix this by adding the newline "\n" to the existing string stream, and issuing a single call to the stream.