### PR TITLE
Fix sign-compare warnings with gcc

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2460,7 +2460,7 @@ Status Graph::SetGraphInputsOutputs() {
 // calling private ctor
 GSL_SUPPRESS(r .11)
 gsl::not_null<Node*> Graph::AllocateNode() {
-  ORT_ENFORCE(nodes_.size() < std::numeric_limits<int>::max());
+  ORT_ENFORCE(nodes_.size() < static_cast<unsigned int>(std::numeric_limits<int>::max()));
   std::unique_ptr<Node> new_node(new Node(nodes_.size(), *this));
   Node* node{new_node.get()};
 

--- a/onnxruntime/core/optimizer/unsqueeze_elimination.cc
+++ b/onnxruntime/core/optimizer/unsqueeze_elimination.cc
@@ -29,7 +29,7 @@ Status UnsqueezeElimination::Apply(Graph& graph, Node& node, RewriteRuleEffect& 
   ORT_ENFORCE(tensor_proto);
 
   std::vector<int64_t> new_dims(axes.size() + tensor_proto->dims().size(), 0);
-  if (new_dims.size() >= std::numeric_limits<int>::max()) {
+  if (new_dims.size() >= static_cast<unsigned int>(std::numeric_limits<int>::max())) {
     return Status(ONNXRUNTIME, FAIL, "index out of range");
   }
 

--- a/onnxruntime/test/onnx/runner.cc
+++ b/onnxruntime/test/onnx/runner.cc
@@ -362,7 +362,7 @@ EXECUTE_RESULT DataRunner::RunTaskImpl(size_t task_id) {
     output_names[i] = output_name;
     default_allocator->Free(output_name);
   }
-  if (feeds.size() > std::numeric_limits<int>::max()) {
+  if (feeds.size() > static_cast<unsigned int>(std::numeric_limits<int>::max())) {
     ORT_THROW("length overflow");
   }
   std::vector<const char*> input_names(feeds.size());


### PR DESCRIPTION
**Description**:
Fix some warnings

**Motivation and Context**
- Why is this change required? What problem does it solve?
Like
```
onnxruntime/core/optimizer/unsqueeze_elimination.cc: In member function ‘virtual onnxruntime::common::Status onnxruntime::UnsqueezeElimination::Apply(onnxruntime::Graph&, onnxruntime::Node&, onnxruntime::RewriteRule::RewriteRuleEffect&) const’:
/home/chasun/src/onnxruntime/onnxruntime/core/optimizer/unsqueeze_elimination.cc:32:23: error: comparison of integer expressions of different signedness: ‘std::vector<long int>::size_type’ {aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
   32 |   if (new_dims.size() >= std::numeric_limits<int>::max()) {
      |       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```
- If it fixes an open issue, please link to the issue here.
