### PR TITLE
Temp fix for a crash in fused graph

### DIFF
--- a/onnxruntime/core/graph/function.cc
+++ b/onnxruntime/core/graph/function.cc
@@ -106,6 +106,7 @@ FunctionImpl::FunctionImpl(const onnxruntime::Graph& graph,
     auto input_arg = parent_graph_->GetNodeArg(input);
     auto& sub_graph_input_arg = sub_graph.GetOrCreateNodeArg(input_arg->Name(), input_arg->TypeAsProto());
     sub_graph_inputs[i] = &sub_graph_input_arg;
+    ORT_ENFORCE(input_arg->Type() != nullptr);
     op_schema_->Input(i, input, "", *input_arg->Type());
     ++i;
   }


### PR DESCRIPTION
**Description**: 

Fix a null pointer issue

**Motivation and Context**
- Why is this change required? What problem does it solve?
Sometimes input_arg->Type() is NULL(but shouldn't be).  If we dereference it, the program will crash.
Now we have to quick solution for this bug.  So I add a line of code to detect this bug, instead of let it crash there.
- If it fixes an open issue, please link to the issue here.
