### PR TITLE
Optimize Fence checking performance

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -167,6 +167,16 @@ class Node {
     return definitions_.output_defs;
   }
 
+  /** Whether current node needs fence check or not. Fence check is needed when either one input or output
+  data needs to be copied cross devices asynchronously, etc CPU<->GPU **/
+  bool NeedFenceCheck() const noexcept {
+    return need_fence_check_;
+  }
+
+  void SetFenceCheck(bool needCheck = false) noexcept {
+    need_fence_check_ = needCheck;
+  }
+
   /** Struct to provide sorting between EdgeEnd instances based on NodeIndex first, and NodeArg::Name second. */
   struct EdgeEndCompare {
     bool operator()(const EdgeEnd& lhs, const EdgeEnd& rhs) const {
@@ -380,7 +390,7 @@ class Node {
   // the data members directly, so that the Node can maintain its internal invariants.
   friend class Graph;
 
-  Node(NodeIndex index, Graph& graph) : index_(index), graph_(&graph) {}
+  Node(NodeIndex index, Graph& graph) : index_(index), graph_(&graph), need_fence_check_(false) {}
 
   void Init(const std::string& name,
             const std::string& op_type,
@@ -441,6 +451,9 @@ class Node {
 
   // Device.
   std::string execution_provider_type_;
+
+  // Needs Fence Check or Not.
+  bool need_fence_check_;
 
   // Map from attribute name to attribute.
   // This allows attribute adding and removing.

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -390,7 +390,7 @@ class Node {
   // the data members directly, so that the Node can maintain its internal invariants.
   friend class Graph;
 
-  Node(NodeIndex index, Graph& graph) : index_(index), graph_(&graph), need_fence_check_(false) {}
+  Node(NodeIndex index, Graph& graph) : index_(index), graph_(&graph) {}
 
   void Init(const std::string& name,
             const std::string& op_type,
@@ -453,7 +453,7 @@ class Node {
   std::string execution_provider_type_;
 
   // Needs Fence Check or Not.
-  bool need_fence_check_;
+  bool need_fence_check_ = false;
 
   // Map from attribute name to attribute.
   // This allows attribute adding and removing.

--- a/onnxruntime/core/framework/parallel_executor.cc
+++ b/onnxruntime/core/framework/parallel_executor.cc
@@ -150,32 +150,36 @@ Status ParallelExecutor::RunNodeAsync(size_t p_node_index,
     // sync before compute
     int queue_id = p_op_kernel->KernelDef().ExecQueueId();
 
-    for (int input_index = 0; input_index < op_kernel_context.InputCount(); ++input_index) {
-      Fence_t fence = op_kernel_context.InputFence(input_index);
-      if (fence) {
-        auto execution_provider_type = p_op_kernel->Node().GetExecutionProviderType();
-        if (OrtMemTypeCPUInput == p_op_kernel->KernelDef().InputMemoryType(input_index)) {
-          execution_provider_type = kCpuExecutionProvider;
+    // Fence is created only if queue_id != 0. Retrieving fence with input_index is costly,
+    // so we can do fence check only when queue_id != 0.
+    if (queue_id != 0) {
+      for (int input_index = 0; input_index < op_kernel_context.InputCount(); ++input_index) {
+        Fence_t fence = op_kernel_context.InputFence(input_index);
+        if (fence) {
+          auto execution_provider_type = p_op_kernel->Node().GetExecutionProviderType();
+          if (OrtMemTypeCPUInput == p_op_kernel->KernelDef().InputMemoryType(input_index)) {
+            execution_provider_type = kCpuExecutionProvider;
+          }
+          fence->BeforeUsingAsInput(execution_provider_type, queue_id);
         }
-        fence->BeforeUsingAsInput(execution_provider_type, queue_id);
       }
-    }
 
-    for (int input_index = 0; input_index < op_kernel_context.ImplicitInputCount(); ++input_index) {
-      Fence_t fence = op_kernel_context.ImplicitInputFence(input_index);
-      if (fence) {
-        auto execution_provider_type = p_op_kernel->Node().GetExecutionProviderType();
-        if (OrtMemTypeCPUInput == p_op_kernel->KernelDef().InputMemoryType(input_index)) {
-          execution_provider_type = kCpuExecutionProvider;
+      for (int input_index = 0; input_index < op_kernel_context.ImplicitInputCount(); ++input_index) {
+        Fence_t fence = op_kernel_context.ImplicitInputFence(input_index);
+        if (fence) {
+          auto execution_provider_type = p_op_kernel->Node().GetExecutionProviderType();
+          if (OrtMemTypeCPUInput == p_op_kernel->KernelDef().InputMemoryType(input_index)) {
+            execution_provider_type = kCpuExecutionProvider;
+          }
+          fence->BeforeUsingAsInput(execution_provider_type, queue_id);
         }
-        fence->BeforeUsingAsInput(execution_provider_type, queue_id);
       }
-    }
 
-    for (int output_index = 0; output_index < op_kernel_context.OutputCount(); ++output_index) {
-      Fence_t fence = op_kernel_context.OutputFence(output_index);
-      if (fence) {
-        fence->BeforeUsingAsOutput(p_op_kernel->Node().GetExecutionProviderType(), queue_id);
+      for (int output_index = 0; output_index < op_kernel_context.OutputCount(); ++output_index) {
+        Fence_t fence = op_kernel_context.OutputFence(output_index);
+        if (fence) {
+          fence->BeforeUsingAsOutput(p_op_kernel->Node().GetExecutionProviderType(), queue_id);
+        }
       }
     }
 
@@ -208,27 +212,31 @@ Status ParallelExecutor::RunNodeAsync(size_t p_node_index,
 
       sync_time_begin = session_state.Profiler().StartTime();
     }
-    // sync after compute for outputs
-    for (int input_index = 0; input_index < op_kernel_context.InputCount(); ++input_index) {
-      Fence_t fence = op_kernel_context.InputFence(input_index);
-      if (fence) {
-        fence->AfterUsedAsInput(queue_id);
+
+    // Sync after compute for outputs.
+    if (queue_id != 0) {
+      for (int input_index = 0; input_index < op_kernel_context.InputCount(); ++input_index) {
+        Fence_t fence = op_kernel_context.InputFence(input_index);
+        if (fence) {
+          fence->AfterUsedAsInput(queue_id);
+        }
+      }
+
+      for (int input_index = 0; input_index < op_kernel_context.ImplicitInputCount(); ++input_index) {
+        Fence_t fence = op_kernel_context.ImplicitInputFence(input_index);
+        if (fence) {
+          fence->AfterUsedAsInput(queue_id);
+        }
+      }
+
+      for (int output_index = 0; output_index < op_kernel_context.OutputCount(); ++output_index) {
+        Fence_t fence = op_kernel_context.OutputFence(output_index);
+        if (fence) {
+          fence->AfterUsedAsOutput(queue_id);
+        }
       }
     }
 
-    for (int input_index = 0; input_index < op_kernel_context.ImplicitInputCount(); ++input_index) {
-      Fence_t fence = op_kernel_context.ImplicitInputFence(input_index);
-      if (fence) {
-        fence->AfterUsedAsInput(queue_id);
-      }
-    }
-
-    for (int output_index = 0; output_index < op_kernel_context.OutputCount(); ++output_index) {
-      Fence_t fence = op_kernel_context.OutputFence(output_index);
-      if (fence) {
-        fence->AfterUsedAsOutput(queue_id);
-      }
-    }
     if (f_profiler_enabled) {
       session_state.Profiler().EndTimeAndRecordEvent(profiling::NODE_EVENT,
                                                      p_op_kernel->Node().Name() + "_fence_after",

--- a/onnxruntime/core/framework/parallel_executor.cc
+++ b/onnxruntime/core/framework/parallel_executor.cc
@@ -152,7 +152,7 @@ Status ParallelExecutor::RunNodeAsync(size_t p_node_index,
 
     // Fence is created only if queue_id != 0. Retrieving fence with input_index is costly,
     // so we can do fence check only when queue_id != 0.
-    if (queue_id != 0) {
+    if (p_op_kernel->Node().NeedFenceCheck()) {
       for (int input_index = 0; input_index < op_kernel_context.InputCount(); ++input_index) {
         Fence_t fence = op_kernel_context.InputFence(input_index);
         if (fence) {
@@ -214,7 +214,7 @@ Status ParallelExecutor::RunNodeAsync(size_t p_node_index,
     }
 
     // Sync after compute for outputs.
-    if (queue_id != 0) {
+    if (p_op_kernel->Node().NeedFenceCheck()) {
       for (int input_index = 0; input_index < op_kernel_context.InputCount(); ++input_index) {
         Fence_t fence = op_kernel_context.InputFence(input_index);
         if (fence) {

--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -74,7 +74,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
     
     // Fence is created only if queue_id != 0. Retrieving fence with input_index is costly,
     // so we can do fence check only when queue_id != 0.
-    if (queue_id != 0) {
+    if (p_op_kernel->Node().NeedFenceCheck()) {
       for (int input_index = 0; input_index < op_kernel_context.InputCount(); ++input_index) {
         Fence_t fence = op_kernel_context.InputFence(input_index);
         if (fence) {
@@ -142,7 +142,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
       sync_time_begin = session_state.Profiler().StartTime();
     }
 
-    if (queue_id != 0) {
+    if (p_op_kernel->Node().NeedFenceCheck()) {
       // sync after compute for outputs
       for (int input_index = 0; input_index < op_kernel_context.InputCount(); ++input_index) {
         Fence_t fence = op_kernel_context.InputFence(input_index);

--- a/onnxruntime/core/optimizer/transformer_memcpy.cc
+++ b/onnxruntime/core/optimizer/transformer_memcpy.cc
@@ -271,16 +271,26 @@ void TransformerMemcpyImpl::AddCopyNode(onnxruntime::NodeArg* arg, bool is_input
                                   std::vector<onnxruntime::NodeArg*>{src_arg},
                                   std::vector<onnxruntime::NodeArg*>{dst_arg});
   new_node.SetExecutionProviderType(provider_);
+  
+  // Enable fence check for memcpy node
+  new_node.SetFenceCheck(true);
+
   std::map<const onnxruntime::NodeArg*, onnxruntime::NodeArg*> map = {{arg, new_arg}};
   auto it = provider_input_nodes_.find(arg);
   if (it != provider_input_nodes_.end()) {
-    for (auto* node : it->second)
+    for (auto* node : it->second) {
       node->ReplaceDefs(map);
+      // Enable fence check for parent nodes of memcpy.
+      node->SetFenceCheck(true);
+    }
   }
   it = provider_output_nodes_.find(arg);
   if (it != provider_output_nodes_.end()) {
-    for (auto* node : it->second)
+    for (auto* node : it->second) {
       node->ReplaceDefs(map);
+      // Enable fence check for child nodes of memcpy.
+      node->SetFenceCheck(true);
+    }
   }
 }
 


### PR DESCRIPTION
**Description**: Describe your changes.
- For majority of nodes, we do not need to do fence check. Instead, we only need to do FenceCheck for  CPU<->GPU mem sync node
- But we pay the Fence check cost for every single node and every single input and output.

This change will minimize the Fence check to only do it when necessary.

**Motivation and Context**
- Why is this change required? What problem does it solve?
Perf profiling on light weight models shows that Fence check has significant overhead. This overhead can be minimized.
- If it fixes an open issue, please link to the issue here.
Epic 479465