### PR TITLE
Fix buffer overrun bug in CPU upsample op

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -342,7 +342,7 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context, const std::vector<floa
   Tensor* Y = context->Output(0, Y_dims);
 
   if (no_scale) {
-    memcpy(Y->MutableDataRaw(), X->DataRaw(), Y->Size() * sizeof(T));
+    memcpy(Y->MutableDataRaw(), X->DataRaw(), Y->Size());
     return Status::OK();
   }
 


### PR DESCRIPTION
**Description**: 
Fix buffer overrun bug in CPU upsample op. Introduced in #1484
**Motivation and Context**
- Why is this change required? What problem does it solve?
A buffer overrun bug may cause application crash. (wrote more bytes than the buffer has)

- If it fixes an open issue, please link to the issue here.
