### PR TITLE
Support missing optional attribute in Squeeze operator

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/squeeze.h
+++ b/onnxruntime/core/providers/cpu/tensor/squeeze.h
@@ -15,15 +15,13 @@ class SqueezeBase {
     std::vector<int64_t> axes;
     // Parse attribute 'axes'
     Status status = info.GetAttrs<int64_t>("axes", axes); 
-    // to avoid the unused variable warning
-    (void)(status);
 
-    // Handle out of order and repeating dims for non-empty 'axes'.
-    if (axes.size() > 0) {
+    // Handle out of order and repeating dims when 'axes' exists.
+    if (status.IsOK()) {
       std::sort(axes.begin(), axes.end());
       axes.erase(std::unique(axes.begin(), axes.end()), axes.end());
+      axes_ = axes;
     }
-    axes_ = axes;
   }
 
   static std::vector<int64_t> ComputeOutputShape(

--- a/onnxruntime/core/providers/cpu/tensor/squeeze.h
+++ b/onnxruntime/core/providers/cpu/tensor/squeeze.h
@@ -14,7 +14,9 @@ class SqueezeBase {
   explicit SqueezeBase(const OpKernelInfo& info) {
     std::vector<int64_t> axes;
     // Parse attribute 'axes'
-    info.GetAttrs<int64_t>("axes", axes);
+    Status status = info.GetAttrs<int64_t>("axes", axes); 
+    // to avoid the unused variable warning
+    (void)(status);
 
     // Handle out of order and repeating dims for non-empty 'axes'.
     if (axes.size() > 0) {

--- a/onnxruntime/core/providers/cpu/tensor/squeeze.h
+++ b/onnxruntime/core/providers/cpu/tensor/squeeze.h
@@ -13,12 +13,14 @@ class SqueezeBase {
  protected:
   explicit SqueezeBase(const OpKernelInfo& info) {
     std::vector<int64_t> axes;
-    Status status = info.GetAttrs<int64_t>("axes", axes);
-    ORT_ENFORCE(status.IsOK(), "Attribute axes is not set.");
+    // Parse attribute 'axes'
+    info.GetAttrs<int64_t>("axes", axes);
 
-    // Handle out of order and repeating dims.
-    std::sort(axes.begin(), axes.end());
-    axes.erase(std::unique(axes.begin(), axes.end()), axes.end());
+    // Handle out of order and repeating dims for non-empty 'axes'.
+    if (axes.size() > 0) {
+      std::sort(axes.begin(), axes.end());
+      axes.erase(std::unique(axes.begin(), axes.end()), axes.end());
+    }
     axes_ = axes;
   }
 
@@ -28,7 +30,8 @@ class SqueezeBase {
     size_t j = 0;
     std::vector<int64_t> output_shape;
     for (size_t i = 0; i < input_shape.NumDimensions(); ++i) {
-      if (j < axes.NumDimensions() && axes[j] == static_cast<int64_t>(i)) {
+      if ((j < axes.NumDimensions() && axes[j] == static_cast<int64_t>(i)) ||
+          (axes.NumDimensions() == 0 && input_shape[i] == 1)) {
         ORT_ENFORCE(input_shape[i] == 1, "Dimension of input ", i, " must be 1 instead of ", input_shape[i],
                     ". shape=", input_shape);
         ++j;

--- a/onnxruntime/test/providers/cpu/tensor/squeeze_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/squeeze_op_test.cc
@@ -18,6 +18,21 @@ TEST(SqueezeOpTest, Squeeze_1) {
   test.Run();
 }
 
+TEST(SqueezeOpTest, Squeeze_Empty_Axes_1) {
+  OpTester test("Squeeze");
+  test.AddInput<float>("data", {1, 1, 4, 1}, std::vector<float>(4, 1.0f));
+  test.AddOutput<float>("squeezed", {4}, std::vector<float>(4, 1.0f));
+  test.Run();
+}
+
+TEST(SqueezeOpTest, Squeeze_Empty_Axes_2) {
+  OpTester test("Squeeze");
+  // nothing to "squeeze" out in the input shape
+  test.AddInput<float>("data", {2, 4}, std::vector<float>(8, 1.0f));
+  test.AddOutput<float>("squeezed", {2, 4}, std::vector<float>(8, 1.0f));
+  test.Run();
+}
+
 TEST(SqueezeOpTest, Squeeze_1_int32) {
   OpTester test("Squeeze");
   test.AddAttribute("axes", std::vector<int64_t>{0});

--- a/onnxruntime/test/providers/cpu/tensor/squeeze_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/squeeze_op_test.cc
@@ -22,7 +22,8 @@ TEST(SqueezeOpTest, Squeeze_Empty_Axes_1) {
   OpTester test("Squeeze");
   test.AddInput<float>("data", {1, 1, 4, 1}, std::vector<float>(4, 1.0f));
   test.AddOutput<float>("squeezed", {4}, std::vector<float>(4, 1.0f));
-  test.Run();
+  // TensorRT doesn't seem to support missing 'axes'
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",  {kTensorrtExecutionProvider});
 }
 
 TEST(SqueezeOpTest, Squeeze_Empty_Axes_2) {
@@ -30,7 +31,8 @@ TEST(SqueezeOpTest, Squeeze_Empty_Axes_2) {
   // nothing to "squeeze" out in the input shape
   test.AddInput<float>("data", {2, 4}, std::vector<float>(8, 1.0f));
   test.AddOutput<float>("squeezed", {2, 4}, std::vector<float>(8, 1.0f));
-  test.Run();
+  // TensorRT doesn't seem to support missing 'axes'
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
 TEST(SqueezeOpTest, Squeeze_1_int32) {


### PR DESCRIPTION
**Description**: 
`Squeeze` operator supports cases where the `axes` attribute may be missing (as the attribute is optional per spec). This change removes that the strict enforcement that the optional attribute be present.

**Motivation and Context**
Resolve #1496 
