### PR TITLE
Enable float16 MatMul+Add -> GEMM fusion for performance boost

### DIFF
--- a/onnxruntime/core/optimizer/matmul_add_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_add_fusion.cc
@@ -43,10 +43,13 @@ Status MatMulAddFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level)
     auto matmul_input_defs = matmul_node.MutableInputDefs();
     auto add_input_defs = add_node.MutableInputDefs();
 
-    // Gemm only support float, so the inputs of MatMul
+    // Gemm requires that inputs be the same data type and both floating point (float32/float16).
     auto matmul_type = matmul_input_defs[0]->Type();
     auto add_type = add_input_defs[0]->Type();
-    if ((*matmul_type) != "tensor(float)" || (*add_type) != "tensor(float)") {
+    if ((*matmul_type) != (*add_type)) {
+      continue;
+    }
+    if ((*matmul_type) != "tensor(float)" && (*matmul_type) != "tensor(float16)") {
       continue;
     }
 


### PR DESCRIPTION
**Description**:
Enable float16 MatMul+Add -> GEMM fusion, which is currently blocked by a slightly too restrictive type check. The fusion does actually work correctly with float16 on both DirectML GPU and CPU with the check loosened.

**Motivation and Context**
- The current 'if' check misses a measurable perf improvement opportunity for float16 models such as EmotionFerPlus. This perf issue was brought up by an external IHV while profiling on their hardware.
- This is tested against our ONNX conformance suite and WinML model zoo.
- https://github.com/microsoft/onnxruntime/issues/1494 (related OS bug #22555607)