### PR TITLE
Fix regression with empty quote

### DIFF
--- a/cmake/external/mkldnn.cmake
+++ b/cmake/external/mkldnn.cmake
@@ -62,9 +62,9 @@ if (onnxruntime_USE_MKLDNN)
   set (MKLDNN_CMAKE_EXTRA_ARGS)
   if(NOT onnxruntime_BUILD_FOR_NATIVE_MACHINE)
     # pre-v1.0
-    list(APPEND MKLDNN_CMAKE_EXTRA_ARGS "-DARCH_OPT_FLAGS=\"\"")
+    list(APPEND MKLDNN_CMAKE_EXTRA_ARGS "-DARCH_OPT_FLAGS=")
     # v1.0
-    list(APPEND MKLDNN_CMAKE_EXTRA_ARGS "-DMKLDNN_ARCH_OPT_FLAGS=\"\"")
+    list(APPEND MKLDNN_CMAKE_EXTRA_ARGS "-DMKLDNN_ARCH_OPT_FLAGS=")
     set(MKLDNN_PATCH_COMMAND1 git apply ${CMAKE_SOURCE_DIR}/patches/mkldnn/mem-patch.cmake.patch)
     # discard prior changes due to patching in mkldnn source to unblock incremental builds.
     set(MKLDNN_PATCH_DISCARD_COMMAND cd ${MKLDNN_SOURCE} && git checkout -- .)


### PR DESCRIPTION
Empty double quote `""` is passed to `find_package(Thread)`, causing a test command `gcc ... "" ...` failed while trying to compile a source file with empty name.

```
[user@******** /]# gcc ""
gcc: error: : No such file or directory
gcc: fatal error: no input files
compilation terminated.
```

This fixed the "Thread not found" issue in https://github.com/microsoft/onnxruntime/pull/1469