### PR TITLE
Add back MacOS leg of the Python packaging job (#1523)

### DIFF
--- a/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
@@ -209,3 +209,45 @@ jobs:
       displayName: 'Component Detection'
 
     - template: templates/clean-agent-build-directory-step.yml
+    
+- job: MacOS_py_Wheels
+  pool:
+    vmImage: 'macOS-10.13'
+  strategy:
+    matrix:
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+  steps:
+    - task: CondaEnvironment@1
+      inputs:
+        createCustomEnvironment: true
+        environmentName: 'py$(python.version)'
+        packageSpecs: 'python=$(python.version)'
+        cleanEnvironment: true
+
+    - script: |
+        sudo python -m pip install numpy==1.15.0
+        sudo xcode-select --switch /Applications/Xcode_10.app/Contents/Developer
+        ./build.sh --config Release --skip_submodule_sync --parallel --use_openmp --build_wheel      
+      displayName: 'Command Line Script' 
+      
+    - task: CopyFiles@2
+      displayName: 'Copy Python Wheel to: $(Build.ArtifactStagingDirectory)'
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/build/Linux/Release/dist'
+        Contents: '*.whl'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: ONNXRuntime python wheel'
+      inputs:
+        ArtifactName: onnxruntime
+
+    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+      displayName: 'Component Detection'
+
+    - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/linux/docker/scripts/install_manylinux2010.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_manylinux2010.sh
@@ -26,7 +26,7 @@ if [ ! -f /opt/onnxruntime-python/bin/python${PYTHON_VER} ]; then
   ln -s python /opt/onnxruntime-python/bin/python${PYTHON_VER}
 fi
 python -m pip install --upgrade --force-reinstall pip==19.1.1
-python -m pip install --upgrade --force-reinstall numpy==1.16.3
+python -m pip install --upgrade --force-reinstall numpy==1.15.0
 python -m pip install --upgrade --force-reinstall requests==2.21.0
 python -m pip install --upgrade --force-reinstall wheel==0.31.1
 python -m pip install --upgrade --force-reinstall setuptools==41.0.1


### PR DESCRIPTION
**Description**: Cherry-pick #1523 

This change tries to fix a couple of issues introduced by #1282 :

Add back macOS leg of the Python packaging job
Take a dependency on a lower version of numpy (1.15.0). This was the version of Numpy ORT was originally taking a dependency on. #1282 updated it to 1.16.3.

**Motivation and Context**
Taking in changes from rel-0.5.0 into master. There is a minor conflict preventing directly merging rel-0.5.0 and master so picking only the pertinent change.
