### PR TITLE
roll back model test update for ngraph provider.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-ngraph-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ngraph-ci-pipeline.yml
@@ -26,7 +26,8 @@ jobs:
       displayName: 'Download test data'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-        arguments: --test_data_url $(TestDataUrl)
+        # nGraph provider fails on the latest 20190729.zip test. revert back to previous zip file until failures can be investigated
+        arguments: --test_data_url https://onnxruntimetestdata.blob.core.windows.net/models/20190419.zip
         pythonInterpreter: '/usr/bin/python3'
         workingDirectory: $(Build.BinariesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/win-ngraph-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ngraph-ci-pipeline.yml
@@ -3,6 +3,9 @@ jobs:
   timeoutInMinutes: 120
   variables:
     buildDirectory: '$(Build.BinariesDirectory)'
+    # nGraph provider fails on the latest 20190729.zip test. revert back to previous zip file until failures can be investigated
+    TestDataUrl: https://onnxruntimetestdata.blob.core.windows.net/models/20190419.zip
+    TestDataChecksum: 3f46c31ee02345dbe707210b339e31fe
   steps:
     - template: templates/set-test-data-variables-step.yml
     - template: templates/windows-build-tools-setup-steps.yml


### PR DESCRIPTION
**Description**: Recent model test update https://github.com/microsoft/onnxruntime/pull/1512 breaks the nGraph CI. roll back the test zip for nGraph CI's while it's being investigated.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
