### PR TITLE
Modify the kernel declaration for Shrink op

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/shrink.cc
+++ b/onnxruntime/core/providers/cpu/nn/shrink.cc
@@ -11,7 +11,8 @@ namespace onnxruntime {
 ONNX_CPU_OPERATOR_KERNEL(
     Shrink,
     9,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::AllNumericTensorTypes()),
+    KernelDefBuilder().MayInplace(0, 0)
+    .TypeConstraint("T", DataTypeImpl::AllNumericTensorTypes()),
     Shrink);
 
 namespace shrink_internal {

--- a/onnxruntime/core/providers/cpu/nn/shrink.cc
+++ b/onnxruntime/core/providers/cpu/nn/shrink.cc
@@ -11,7 +11,8 @@ namespace onnxruntime {
 ONNX_CPU_OPERATOR_KERNEL(
     Shrink,
     9,
-    KernelDefBuilder().MayInplace(0, 0)
+    KernelDefBuilder()
+    .MayInplace(0, 0)
     .TypeConstraint("T", DataTypeImpl::AllNumericTensorTypes()),
     Shrink);
 

--- a/onnxruntime/core/providers/cuda/nn/shrink.cc
+++ b/onnxruntime/core/providers/cuda/nn/shrink.cc
@@ -17,6 +17,7 @@ namespace cuda {
       T,                                                          \
       kCudaExecutionProvider,                                     \
       KernelDefBuilder()                                          \
+          .MayInplace(0, 0)                                       \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
       Shrink<T>);
 


### PR DESCRIPTION
**Description**: Add capability so that the input and output of Shrink op can share a common buffer if the graph structure allows them to do so
