### PR TITLE
Avoid downloading test data into C:\

### DIFF
--- a/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
@@ -24,7 +24,7 @@ jobs:
       displayName: 'Download test data'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-        arguments: --test_data_url $(TestDataUrl)
+        arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
         pythonInterpreter: '/usr/bin/python3'
         workingDirectory: $(Build.BinariesDirectory)
 
@@ -86,7 +86,7 @@ jobs:
       displayName: 'Download test data'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-        arguments: --test_data_url $(TestDataUrl)
+        arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
         pythonInterpreter: '/usr/bin/python3'
         workingDirectory: $(Build.BinariesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
@@ -156,7 +156,7 @@ jobs:
       displayName: 'Build and Test OnnxRuntime'
       inputs:
         script: |
-          $(Build.BinariesDirectory)\packages\python\python.exe $(Build.SourcesDirectory)\tools\ci_build\build.py --config $(buildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --use_openmp --msvc_toolset=14.11 --use_cuda  --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda"
+          $(Build.BinariesDirectory)\packages\python\python.exe $(Build.SourcesDirectory)\tools\ci_build\build.py --config $(buildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --enable_onnx_tests --use_openmp --msvc_toolset=14.11 --use_cuda  --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda"
         workingDirectory: '$(Build.BinariesDirectory)'
 
     - template: templates/c-api-artifacts-package-and-publish-steps-windows.yml

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline-cuda9.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline-cuda9.yml
@@ -16,7 +16,7 @@ jobs:
       displayName: 'Download test data'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-        arguments: --test_data_url $(TestDataUrl)
+        arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
         pythonInterpreter: '/usr/bin/python3'
         workingDirectory: $(Build.BinariesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-ci-pipeline.yml
@@ -16,7 +16,7 @@ jobs:
       inputs:
         scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
         # There are some tests in 20190130.zip that TensorRT can't run. Instead here use 20181210 opset8 for TensorRT test.
-        arguments: --test_data_url https://onnxruntimetestdata.blob.core.windows.net/models/20181210.zip
+        arguments: --test_data_url https://onnxruntimetestdata.blob.core.windows.net/models/20181210.zip --build_dir $(Build.BinariesDirectory)
         pythonInterpreter: '/usr/bin/python3'
         workingDirectory: $(Build.BinariesDirectory)
     

--- a/tools/ci_build/github/azure-pipelines/linux-ngraph-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ngraph-ci-pipeline.yml
@@ -27,7 +27,7 @@ jobs:
       inputs:
         scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
         # nGraph provider fails on the latest 20190729.zip test. revert back to previous zip file until failures can be investigated
-        arguments: --test_data_url https://onnxruntimetestdata.blob.core.windows.net/models/20190419.zip
+        arguments: --test_data_url https://onnxruntimetestdata.blob.core.windows.net/models/20190419.zip --build_dir $(Build.BinariesDirectory)
         pythonInterpreter: '/usr/bin/python3'
         workingDirectory: $(Build.BinariesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/linux-nocontribops-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-nocontribops-ci-pipeline.yml
@@ -31,7 +31,7 @@ jobs:
       displayName: 'Download test data'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-        arguments: --test_data_url $(TestDataUrlNoContribOps)
+        arguments: --test_data_url $(TestDataUrlNoContribOps) --build_dir $(Build.BinariesDirectory)
         pythonInterpreter: '/usr/bin/python3'
         workingDirectory: $(Build.BinariesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/linux-openvino-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-openvino-ci-pipeline.yml
@@ -26,7 +26,7 @@ jobs:
       displayName: 'Download test data'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-        arguments: --test_data_url $(TestDataUrl)
+        arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
         pythonInterpreter: '/usr/bin/python3'
         workingDirectory: $(Build.BinariesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/linux-ort-srv-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ort-srv-ci-pipeline.yml
@@ -26,7 +26,7 @@ jobs:
       displayName: 'Download test data'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-        arguments: --test_data_url $(TestDataUrl)
+        arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
         pythonInterpreter: '/usr/bin/python3'
         workingDirectory: $(Build.BinariesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/linux-ort-srv-nightly-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ort-srv-nightly-pipeline.yml
@@ -26,7 +26,7 @@ jobs:
       displayName: 'Download test data'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-        arguments: --test_data_url $(TestDataUrl)
+        arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
         pythonInterpreter: '/usr/bin/python3'
         workingDirectory: $(Build.BinariesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/linux-x86-nocontribops-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-x86-nocontribops-ci-pipeline.yml
@@ -32,7 +32,7 @@ jobs:
       displayName: 'Download test data'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-        arguments: --test_data_url $(TestDataUrlNoContribOps)
+        arguments: --test_data_url $(TestDataUrlNoContribOps) --build_dir $(Build.BinariesDirectory)
         pythonInterpreter: '/usr/bin/python3'
         workingDirectory: $(Build.BinariesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/mac-nocontribops-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-nocontribops-ci-pipeline.yml
@@ -19,7 +19,7 @@ jobs:
       displayName: 'Download test data'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-        arguments: --test_data_url $(TestDataUrlNoContribOps) --azure_region centralus
+        arguments: --test_data_url $(TestDataUrlNoContribOps) --azure_region centralus --build_dir $(Build.BinariesDirectory)
         pythonInterpreter: '/usr/local/bin/python3'
         workingDirectory: $(Build.BinariesDirectory)
     - script: |

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-mklml.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-mklml.yml
@@ -12,7 +12,7 @@ jobs:
   parameters:
     AgentPool : $(AgentPoolWin)
     JobName: 'Windows_CI_Dev'
-    BuildCommand:  '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_mklml --build_shared_lib --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum)'
+    BuildCommand:  '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_mklml --build_shared_lib --build_csharp --enable_onnx_tests'
     DoDebugBuild: 'false'
     DoNugetPack : 'true'
     DoCompliance: 'false'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-nocontribops-arm64.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-nocontribops-arm64.yml
@@ -12,7 +12,7 @@ jobs:
   parameters:
     AgentPool : $(AgentPoolWin)
     JobName: 'Windows_CI_Dev'
-    BuildCommand:  '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --disable_contrib_ops --enable_msvc_static_runtime --build_shared_lib --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum)'
+    BuildCommand:  '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --disable_contrib_ops --enable_msvc_static_runtime --build_shared_lib --build_csharp --enable_onnx_tests'
     DoDebugBuild: 'false'
     DoNugetPack : 'true'
     DoCompliance: 'false'
@@ -26,7 +26,7 @@ jobs:
   parameters:
     AgentPool : $(AgentPoolWin)
     JobName: 'Windows_CI_Dev_x86'
-    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --disable_contrib_ops --enable_msvc_static_runtime --build_shared_lib  --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --x86'
+    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --disable_contrib_ops --enable_msvc_static_runtime --build_shared_lib  --build_csharp --enable_onnx_tests --x86'
     DoDebugBuild: 'false'
     DoNugetPack : 'true'
     DoCompliance: 'false'
@@ -41,7 +41,7 @@ jobs:
   parameters:
     AgentPool : $(AgentPoolWin)
     JobName: 'Windows_Arm64_Dev'
-    BuildCommand:  '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --disable_contrib_ops --enable_msvc_static_runtime --build_shared_lib --arm64 --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum)'
+    BuildCommand:  '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --disable_contrib_ops --enable_msvc_static_runtime --build_shared_lib --arm64'
     DoDebugBuild: 'false'
     DoNugetPack : 'true'
     DoCompliance: 'false'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-nocontribops.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-nocontribops.yml
@@ -12,7 +12,7 @@ jobs:
   parameters:
     AgentPool : $(AgentPoolWin)
     JobName: 'Windows_CI_Dev'
-    BuildCommand:  '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --disable_contrib_ops --enable_msvc_static_runtime --build_shared_lib --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum)'
+    BuildCommand:  '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --disable_contrib_ops --enable_msvc_static_runtime --build_shared_lib --build_csharp --enable_onnx_tests'
     DoDebugBuild: 'false'
     DoNugetPack : 'true'
     DoCompliance: 'false'
@@ -26,7 +26,7 @@ jobs:
   parameters:
     AgentPool : $(AgentPoolWin)
     JobName: 'Windows_CI_Dev_x86'
-    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --disable_contrib_ops --enable_msvc_static_runtime --build_shared_lib  --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --x86'
+    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --disable_contrib_ops --enable_msvc_static_runtime --build_shared_lib  --build_csharp --enable_onnx_tests --x86'
     DoDebugBuild: 'false'
     DoNugetPack : 'true'
     DoCompliance: 'false'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu.yml
@@ -13,7 +13,7 @@ jobs:
   parameters:
     AgentPool : $(AgentPoolWin)
     JobName: 'Windows_CI_Dev'
-    BuildCommand:  '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_openmp --build_shared_lib --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum)'
+    BuildCommand:  '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_openmp --build_shared_lib --build_csharp --enable_onnx_tests'
     DoDebugBuild: 'false'
     DoNugetPack : 'true'
     DoCompliance: ${{ parameters.DoCompliance }}
@@ -27,7 +27,7 @@ jobs:
   parameters:
     AgentPool : $(AgentPoolWin)
     JobName: 'Windows_CI_Dev_x86'
-    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_openmp --build_shared_lib  --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --x86'
+    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_openmp --build_shared_lib  --build_csharp --enable_onnx_tests --x86'
     DoDebugBuild: 'false'
     DoNugetPack : 'true'
     DoCompliance: 'false'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
@@ -13,7 +13,7 @@ jobs:
   parameters:
     AgentPool : $(AgentPoolWin)
     JobName: 'Windows_CI_GPU_Dev'
-    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe  --enable_pybind --use_openmp --build_shared_lib  --build_csharp --enable_onnx_tests --use_cuda --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --msvc_toolset=14.11'
+    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe  --enable_pybind --use_openmp --build_shared_lib  --build_csharp --enable_onnx_tests --use_cuda --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --msvc_toolset=14.11'
     DoDebugBuild: 'false'
     DoNugetPack : 'true'
     DoCompliance: 'false'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -25,7 +25,7 @@ jobs:
 
   - script: |
      @echo "Running build.py --update"
-     $(Build.BinariesDirectory)\packages\python\python.exe $(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --config Debug --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe  --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --update --download_test_data  --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum)
+     $(Build.BinariesDirectory)\packages\python\python.exe $(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --config Debug --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe  --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --update --download_test_data 
 
     displayName: 'Download Test Data'
 

--- a/tools/ci_build/github/azure-pipelines/templates/linux-set-variables-and-download.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-set-variables-and-download.yml
@@ -24,7 +24,7 @@ steps:
   displayName: 'Download test data'
   inputs:
     scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-    arguments: --test_data_url $(TestDataUrl)
+    arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
     pythonInterpreter: '/usr/bin/python3'
     workingDirectory: $(Build.BinariesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/templates/mac-set-variables-and-download.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-set-variables-and-download.yml
@@ -13,6 +13,6 @@ steps:
   displayName: 'Download test data'
   inputs:
     scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-    arguments: --test_data_url $(TestDataUrl) --azure_region centralus
+    arguments: --test_data_url $(TestDataUrl) --azure_region centralus --build_dir $(Build.BinariesDirectory)
     pythonInterpreter: '/usr/local/bin/python3'
     workingDirectory: $(Build.BinariesDirectory)

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-and-test-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-and-test-steps.yml
@@ -11,7 +11,7 @@ steps:
       displayName: 'Download test data and generate cmake config'
       inputs:
         script: |
-          $(Build.BinariesDirectory)\packages\python\python.exe $(Build.SourcesDirectory)\tools\ci_build\build.py --config ${{parameters.buildConfig}} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --update ${{parameters.buildAdditionalParams}}
+          $(Build.BinariesDirectory)\packages\python\python.exe $(Build.SourcesDirectory)\tools\ci_build\build.py --config ${{parameters.buildConfig}} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --enable_onnx_tests --update ${{parameters.buildAdditionalParams}}
         workingDirectory: '$(Build.BinariesDirectory)'
     
     - task: VSBuild@1
@@ -29,7 +29,7 @@ steps:
       displayName: 'Test ${{parameters.buildConfig}}'
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config ${{parameters.buildConfig}} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe  --build_shared_lib  --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --test ${{parameters.buildAdditionalParams}}'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config ${{parameters.buildConfig}} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe  --build_shared_lib  --enable_onnx_tests --test ${{parameters.buildAdditionalParams}}'
         workingFolder: '$(Build.BinariesDirectory)'
 
     - task: PublishTestResults@2

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -26,30 +26,17 @@ steps:
     #     downloadDirectory: '$(Build.BinariesDirectory)\python'
 
     # Temporary bypass of artifacts permission issue
+    - task: CmdLine@1
+      displayName: 'Run python installer'
+      filename: 'AzCopy.exe'
+      arguments: '/Y /Source:https://onnxruntimetestdata.blob.core.windows.net/models/azcopy.exe /Dest:$(Build.BinariesDirectory)\azcopy.exe'
+      
     - task: PowerShell@2
       displayName: 'Download python'
       inputs:
         targetType: 'inline'
         script: 'Invoke-WebRequest -OutFile installer.exe  https://onnxruntimeinstaller.blob.core.windows.net/conda-installer/installer.exe'
-        workingDirectory: '$(Build.BinariesDirectory)'
-
-    - task: PowerShell@2
-      displayName: 'Download azcopy'
-      inputs:
-        targetType: 'inline'
-        script: 'Invoke-WebRequest -OutFile azcopy.zip  https://aka.ms/downloadazcopy-v10-windows'
-        workingDirectory: '$(Build.BinariesDirectory)'
-
-    - task: ExtractFiles@1
-      inputs:
-        archiveFilePatterns: '$(Build.BinariesDirectory)\azcopy.zip'
-        destinationFolder: '$(Build.BinariesDirectory)\azcopy'
-        
-    - task: CopyFiles@2
-      inputs:
-        sourceFolder: '$(Build.BinariesDirectory)\azcopy'
-        contents: '**\*.exe' 
-        destinationFolder: '$(Build.BinariesDirectory)'
+        workingDirectory: '$(Build.BinariesDirectory)'           
   
     - task: CmdLine@1
       displayName: 'Run python installer'

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -64,20 +64,7 @@ steps:
         scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
         arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
         pythonInterpreter: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        workingDirectory: $(Build.BinariesDirectory)   
-    
-    - task: PowerShell@2
-      displayName: 'Download OpenCppCoverage installer'
-      continueOnError: true
-      inputs:
-        targetType: 'inline'
-        script: '
-          New-Item -Path "$(Build.BinariesDirectory)\installer" -ItemType "directory"
-
-          New-Item -Path "$(Build.BinariesDirectory)\installer\opencppcoverage" -ItemType "directory"
-
-          Invoke-WebRequest -OutFile $(Build.BinariesDirectory)\installer\opencppcoverage\installer.exe https://onnxruntimeinstaller.blob.core.windows.net/opencppcovergae-installer/OpenCppCoverageSetup-x64-0.9.7.0.exe
-          '
+        workingDirectory: $(Build.BinariesDirectory)
 
     - task: CmdLine@1
       continueOnError: true

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -63,17 +63,9 @@ steps:
       displayName: 'Download test data'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-        arguments: --test_data_url $(TestDataUrl)
+        arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
         pythonInterpreter: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        workingDirectory: $(Build.BinariesDirectory)
-    
-    - task: PythonScript@0
-      displayName: 'Download cmake'
-      inputs:
-        pythonInterpreter: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\windows\download_cmake.py'
-        arguments: --build_dir $(Build.BinariesDirectory)
-    
+        workingDirectory: $(Build.BinariesDirectory)   
     
     - task: PowerShell@2
       displayName: 'Download OpenCppCoverage installer'

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -30,8 +30,20 @@ steps:
       displayName: 'Download python'
       inputs:
         targetType: 'inline'
-        script: 'Invoke-WebRequest -OutFile installer.exe  https://onnxruntimeinstaller.blob.core.windows.net/conda-installer/installer.exe'
+        script: 'Invoke-WebRequest --MaximumRetryCount 10 -OutFile installer.exe  https://onnxruntimeinstaller.blob.core.windows.net/conda-installer/installer.exe'
         workingDirectory: '$(Build.BinariesDirectory)'
+
+    - task: PowerShell@2
+      displayName: 'Download azcopy'
+      inputs:
+        targetType: 'inline'
+        script: 'Invoke-WebRequest --MaximumRetryCount 10 -OutFile azcopy.zip  https://aka.ms/downloadazcopy-v10-windows'
+        workingDirectory: '$(Build.BinariesDirectory)'
+
+    - task: ExtractFiles@1
+      inputs:
+        archiveFilePatterns: '$(Build.BinariesDirectory)\azcopy.zip'
+        destinationFolder: $(Build.BinariesDirectory)\azcopy
 
     - task: CmdLine@1
       displayName: 'Run python installer'

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -30,21 +30,27 @@ steps:
       displayName: 'Download python'
       inputs:
         targetType: 'inline'
-        script: 'Invoke-WebRequest -MaximumRetryCount 10 -OutFile installer.exe  https://onnxruntimeinstaller.blob.core.windows.net/conda-installer/installer.exe'
+        script: 'Invoke-WebRequest -OutFile installer.exe  https://onnxruntimeinstaller.blob.core.windows.net/conda-installer/installer.exe'
         workingDirectory: '$(Build.BinariesDirectory)'
 
     - task: PowerShell@2
       displayName: 'Download azcopy'
       inputs:
         targetType: 'inline'
-        script: 'Invoke-WebRequest -MaximumRetryCount 10 -OutFile azcopy.zip  https://aka.ms/downloadazcopy-v10-windows'
+        script: 'Invoke-WebRequest -OutFile azcopy.zip  https://aka.ms/downloadazcopy-v10-windows'
         workingDirectory: '$(Build.BinariesDirectory)'
 
     - task: ExtractFiles@1
       inputs:
         archiveFilePatterns: '$(Build.BinariesDirectory)\azcopy.zip'
-        destinationFolder: $(Build.BinariesDirectory)\azcopy
-
+        destinationFolder: '$(Build.BinariesDirectory)\azcopy'
+        
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: '$(Build.BinariesDirectory)\azcopy'
+        contents: '**\*.exe' 
+        destinationFolder: '$(Build.BinariesDirectory)'
+  
     - task: CmdLine@1
       displayName: 'Run python installer'
       inputs:
@@ -64,11 +70,21 @@ steps:
         arguments: 'install -q --insecure -y pyopenssl setuptools wheel numpy'
       timeoutInMinutes: 10
 
-    - task: CmdLine@1
+    - task: PythonScript@0
+      displayName: 'Download test data'
+      inputs:
+        scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
+        arguments: --test_data_url $(TestDataUrl)
+        pythonInterpreter: '$(Build.BinariesDirectory)\packages\python\python.exe'
+        workingDirectory: $(Build.BinariesDirectory)
+    
+    - task: PythonScript@0
       displayName: 'Download cmake'
       inputs:
-        filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\github\windows\download_cmake.py --build_dir $(Build.BinariesDirectory)'
+        pythonInterpreter: '$(Build.BinariesDirectory)\packages\python\python.exe'
+        scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\windows\download_cmake.py'
+        arguments: --build_dir $(Build.BinariesDirectory)
+    
     
     - task: PowerShell@2
       displayName: 'Download OpenCppCoverage installer'

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -27,22 +27,21 @@ steps:
 
     # Temporary bypass of artifacts permission issue
     - task: CmdLine@1
-      displayName: 'Run python installer'
+      displayName: 'Download azcopy'
       inputs:
         filename: 'AzCopy.exe'
         arguments: '/Y /Source:https://onnxruntimetestdata.blob.core.windows.net/models/azcopy.exe /Dest:$(Build.BinariesDirectory)\azcopy.exe'
-      
-    - task: PowerShell@2
+        
+    - task: CmdLine@1
       displayName: 'Download python'
       inputs:
-        targetType: 'inline'
-        script: 'Invoke-WebRequest -OutFile installer.exe  https://onnxruntimeinstaller.blob.core.windows.net/conda-installer/installer.exe'
-        workingDirectory: '$(Build.BinariesDirectory)'           
+        filename: 'AzCopy.exe'
+        arguments: '/Y /Source:https://onnxruntimetestdata.blob.core.windows.net/models/Anaconda3-2019.07-Windows-x86_64.exe /Dest:$(Build.BinariesDirectory)\Anaconda3-2019.07-Windows-x86_64.exe'               
   
     - task: CmdLine@1
       displayName: 'Run python installer'
       inputs:
-        filename: '$(Build.BinariesDirectory)\installer.exe'
+        filename: '$(Build.BinariesDirectory)\Anaconda3-2019.07-Windows-x86_64.exe'
         arguments: '/S /NoRegistry=1 /AddToPath=0 /RegisterPython=0 /D=$(Build.BinariesDirectory)\packages\python'
       timeoutInMinutes: 10
 

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -30,14 +30,14 @@ steps:
       displayName: 'Download python'
       inputs:
         targetType: 'inline'
-        script: 'Invoke-WebRequest --MaximumRetryCount 10 -OutFile installer.exe  https://onnxruntimeinstaller.blob.core.windows.net/conda-installer/installer.exe'
+        script: 'Invoke-WebRequest -MaximumRetryCount 10 -OutFile installer.exe  https://onnxruntimeinstaller.blob.core.windows.net/conda-installer/installer.exe'
         workingDirectory: '$(Build.BinariesDirectory)'
 
     - task: PowerShell@2
       displayName: 'Download azcopy'
       inputs:
         targetType: 'inline'
-        script: 'Invoke-WebRequest --MaximumRetryCount 10 -OutFile azcopy.zip  https://aka.ms/downloadazcopy-v10-windows'
+        script: 'Invoke-WebRequest -MaximumRetryCount 10 -OutFile azcopy.zip  https://aka.ms/downloadazcopy-v10-windows'
         workingDirectory: '$(Build.BinariesDirectory)'
 
     - task: ExtractFiles@1

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -36,12 +36,12 @@ steps:
       displayName: 'Download python'
       inputs:
         filename: 'AzCopy.exe'
-        arguments: '/Y /Source:https://onnxruntimetestdata.blob.core.windows.net/models/Anaconda3-2019.07-Windows-x86_64.exe /Dest:$(Build.BinariesDirectory)\Anaconda3-2019.07-Windows-x86_64.exe'               
+        arguments: '/Y /Source:https://onnxruntimetestdata.blob.core.windows.net/models/Miniconda3-4.7.10-Windows-x86_64.exe /Dest:$(Build.BinariesDirectory)\Miniconda3-4.7.10-Windows-x86_64.exe'               
   
     - task: CmdLine@1
       displayName: 'Run python installer'
       inputs:
-        filename: '$(Build.BinariesDirectory)\Anaconda3-2019.07-Windows-x86_64.exe'
+        filename: '$(Build.BinariesDirectory)\Miniconda3-4.7.10-Windows-x86_64.exe'
         arguments: '/S /NoRegistry=1 /AddToPath=0 /RegisterPython=0 /D=$(Build.BinariesDirectory)\packages\python'
       timeoutInMinutes: 10
 

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -28,8 +28,9 @@ steps:
     # Temporary bypass of artifacts permission issue
     - task: CmdLine@1
       displayName: 'Run python installer'
-      filename: 'AzCopy.exe'
-      arguments: '/Y /Source:https://onnxruntimetestdata.blob.core.windows.net/models/azcopy.exe /Dest:$(Build.BinariesDirectory)\azcopy.exe'
+      inputs:
+        filename: 'AzCopy.exe'
+        arguments: '/Y /Source:https://onnxruntimetestdata.blob.core.windows.net/models/azcopy.exe /Dest:$(Build.BinariesDirectory)\azcopy.exe'
       
     - task: PowerShell@2
       displayName: 'Download python'
@@ -44,6 +45,7 @@ steps:
         filename: '$(Build.BinariesDirectory)\installer.exe'
         arguments: '/S /NoRegistry=1 /AddToPath=0 /RegisterPython=0 /D=$(Build.BinariesDirectory)\packages\python'
       timeoutInMinutes: 10
+
     - task: BatchScript@1
       displayName: 'setup env'
       inputs:

--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -4,7 +4,7 @@ jobs:
     AgentPool : 'Win-CPU'
     DoDebugBuild: 'true'
     DoCompliance: 'false'
-    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_tvm --enable_pybind --use_mkldnn --use_openmp --build_shared_lib --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --gen_doc'
+    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_tvm --enable_pybind --use_mkldnn --use_openmp --build_shared_lib --build_csharp --enable_onnx_tests --gen_doc'
     JobName: 'Windows_CI_Dev'
     DoNugetPack:  'false'
     NuPackScript : ''

--- a/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
@@ -4,7 +4,7 @@ jobs:
     AgentPool : 'Win-GPU-CUDA10'
     DoDebugBuild: 'true'
     DoCompliance: 'false'
-    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe  --enable_pybind --use_openmp --use_mkldnn --use_mkldnn --build_shared_lib  --build_csharp --enable_onnx_tests --use_cuda --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --msvc_toolset=14.11'
+    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe  --enable_pybind --use_openmp --use_mkldnn --use_mkldnn --build_shared_lib  --build_csharp --enable_onnx_tests --use_cuda --cuda_version=10.0 --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --msvc_toolset=14.11'
     JobName: 'Windows_CI_GPU_Dev'
     DoNugetPack:  'false'
     NuPackScript : ''

--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -28,7 +28,7 @@ jobs:
       displayName: 'Download test data and generate cmake config'
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug Release --build_dir $(Build.BinariesDirectory) --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe  --enable_pybind --use_openmp --use_mkldnn --build_shared_lib  --enable_onnx_tests --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --use_tensorrt --tensorrt_home="C:\local\TensorRT-5.0.4.3" --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --update --msvc_toolset=14.11'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug Release --build_dir $(Build.BinariesDirectory) --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe  --enable_pybind --use_openmp --use_mkldnn --build_shared_lib  --enable_onnx_tests --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --use_tensorrt --tensorrt_home="C:\local\TensorRT-5.0.4.3" --update --msvc_toolset=14.11'
         workingDirectory: "$(Build.BinariesDirectory)"
 
     - task: VSBuild@1
@@ -45,7 +45,7 @@ jobs:
       displayName: 'Test Debug'
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug --build_dir $(Build.BinariesDirectory) --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe  --enable_pybind --use_openmp --use_mkldnn --build_shared_lib  --enable_onnx_tests --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --use_tensorrt --tensorrt_home="C:\local\TensorRT-5.0.4.3" --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --test'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug --build_dir $(Build.BinariesDirectory) --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe  --enable_pybind --use_openmp --use_mkldnn --build_shared_lib  --enable_onnx_tests --cuda_version=10.0 --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --use_tensorrt --tensorrt_home="C:\local\TensorRT-5.0.4.3" --test'
         workingFolder: '$(Build.BinariesDirectory)'
     - task: VSBuild@1
       displayName: 'Build C# Debug'
@@ -81,7 +81,7 @@ jobs:
       displayName: 'Test Release'
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Release --build_dir $(Build.BinariesDirectory) --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe  --enable_pybind --use_openmp --use_mkldnn --build_shared_lib  --enable_onnx_tests --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --use_tensorrt --tensorrt_home="C:\local\TensorRT-5.0.4.3" --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --test'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Release --build_dir $(Build.BinariesDirectory) --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe  --enable_pybind --use_openmp --use_mkldnn --build_shared_lib  --enable_onnx_tests --cuda_version=10.0 --cuda_home="C:\local\cuda_10.0.130_win10" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --use_tensorrt --tensorrt_home="C:\local\TensorRT-5.0.4.3" --test'
         workingFolder: "$(Build.BinariesDirectory)"
 
     - task: VSBuild@1

--- a/tools/ci_build/github/azure-pipelines/win-mklml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-mklml-ci-pipeline.yml
@@ -14,7 +14,7 @@ jobs:
       displayName: 'Download test data and generate cmake config'
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug Release --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_mklml --build_shared_lib --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --update'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug Release --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_mklml --build_shared_lib --build_csharp --enable_onnx_tests --update'
         workingDirectory: "$(Build.BinariesDirectory)"
 
     - task: VSBuild@1
@@ -31,7 +31,7 @@ jobs:
       displayName: 'Test Debug'
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_mklml --use_openmp --build_shared_lib  --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --test'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_mklml --use_openmp --build_shared_lib  --build_csharp --enable_onnx_tests --test'
         workingFolder: '$(Build.BinariesDirectory)'
     - task: VSBuild@1
       displayName: 'Build C# Debug'
@@ -66,7 +66,7 @@ jobs:
       displayName: 'Test Release'
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Release --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_mklml --use_openmp --build_shared_lib  --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --test'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Release --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_mklml --use_openmp --build_shared_lib  --build_csharp --enable_onnx_tests --test'
         workingFolder: "$(Build.BinariesDirectory)"
 
     - task: VSBuild@1

--- a/tools/ci_build/github/azure-pipelines/win-ngraph-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ngraph-ci-pipeline.yml
@@ -17,7 +17,7 @@ jobs:
       displayName: 'Download test data and generate cmake config'
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug Release --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --enable_pybind --use_openmp --use_ngraph --use_full_protobuf --build_shared_lib  --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --gen_doc --update'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug Release --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --enable_pybind --use_openmp --use_ngraph --use_full_protobuf --build_shared_lib --gen_doc --update'
         workingDirectory: "$(Build.BinariesDirectory)"
     - task: VSBuild@1
       displayName: 'Build Debug'
@@ -33,7 +33,7 @@ jobs:
       displayName: 'Test Debug'
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --enable_pybind --use_ngraph --use_full_protobuf --build_shared_lib  --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --gen_doc --test'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --enable_pybind --use_ngraph --use_full_protobuf --build_shared_lib --gen_doc --test'
         workingFolder: '$(Build.BinariesDirectory)'
     - task: VSBuild@1
       displayName: 'Build Release'
@@ -49,7 +49,7 @@ jobs:
       displayName: 'Test Release'
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Release --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --enable_pybind --use_openmp --use_ngraph --use_full_protobuf --build_shared_lib  --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --test'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Release --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --enable_pybind --use_openmp --use_ngraph --use_full_protobuf --build_shared_lib  --enable_onnx_tests --test'
         workingFolder: "$(Build.BinariesDirectory)"
 
     - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/tools/ci_build/github/azure-pipelines/win-nocontribops-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-nocontribops-ci-pipeline.yml
@@ -8,7 +8,7 @@ jobs:
     AgentPool : 'Win-CPU'
     DoDebugBuild: 'true'
     DoCompliance: 'false'
-    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --disable_contrib_ops --enable_msvc_static_runtime --build_shared_lib --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrlNoContribOps) --test_data_checksum $(TestDataChecksum)'
+    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --disable_contrib_ops --enable_msvc_static_runtime --build_shared_lib --build_csharp --enable_onnx_tests'
     JobName: 'Windows_CI_Dev'
     DoNugetPack:  'false'
     NuPackScript : ''

--- a/tools/ci_build/github/azure-pipelines/win-x86-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-x86-ci-pipeline.yml
@@ -4,7 +4,7 @@ jobs:
     AgentPool : 'Win-CPU'
     DoDebugBuild: 'true'
     DoCompliance: 'false'
-    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_openmp --build_shared_lib  --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrl) --test_data_checksum $(TestDataChecksum) --x86'
+    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_openmp --build_shared_lib  --build_csharp --enable_onnx_tests --x86'
     JobName: 'Windows_CI_Dev_x86'
     DoNugetPack:  'false'
     NuPackScript : ''

--- a/tools/ci_build/github/azure-pipelines/win-x86-nocontribops-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-x86-nocontribops-ci-pipeline.yml
@@ -9,7 +9,7 @@ jobs:
     AgentPool : 'Win-CPU'
     DoDebugBuild: 'true'
     DoCompliance: 'false'
-    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_openmp --build_shared_lib  --build_csharp --enable_onnx_tests --test_data_url $(TestDataUrlNoContribOps) --test_data_checksum $(TestDataChecksum) --disable_contrib_ops --enable_msvc_static_runtime --x86'
+    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_openmp --build_shared_lib  --build_csharp --enable_onnx_tests --disable_contrib_ops --enable_msvc_static_runtime --x86'
     JobName: 'Windows_CI_Dev_x86'
     DoNugetPack:  'false'
     NuPackScript : ''

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -39,7 +39,17 @@ args = parse_arguments()
 hostname=get_server_hostname(args.azure_region)
 url=args.test_data_url.replace('onnxruntimetestdata', hostname)
 print('data url=%s' % url)
-subprocess.run(['./azcopy','cp', '--log-level','ERROR', url,'.'],check=True)
+BUILD_BINARIESDIRECTORY = os.environ.get('BUILD_BINARIESDIRECTORY')
+subprocess.run([os.path.join(BUILD_BINARIESDIRECTORY,'azcopy'),'cp', '--log-level','ERROR', url,'.'],check=True)
 os.makedirs('models',exist_ok=True)
 local_file_name = os.path.basename(urlparse(url).path)
-subprocess.run(['unzip', '-qd','models',local_file_name])
+if is_windows():
+  if shutil.which('7z'):  # 7-Zip
+      run_subprocess(['7z','x', local_file_name, '-y', '-o models'])
+  elif shutil.which('7za'):  # 7-Zip standalone
+      run_subprocess(['7za', 'x', local_file_name, '-y', '-o models'])
+  else:
+      log.error("No unzip tool for use")   
+      sys.exit(1)
+else:
+   subprocess.run(['unzip','-qd', 'models',local_file_name], check=True)

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -3,6 +3,7 @@ import urllib.request
 import json
 import subprocess
 import os
+import sys
 import argparse
 from urllib.parse import urlparse
 

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -47,9 +47,9 @@ def download_and_unzip(build_dir, url, dest_folder):
     local_file_name = os.path.basename(urlparse(url).path)
     if is_windows():
       if shutil.which('7z'):  # 7-Zip
-          subprocess.run(['7z','x', local_file_name, '-y', '-o', dest_folder], check=True)
+          subprocess.run(['7z','x', local_file_name, '-y', '-o' + dest_folder], check=True)
       elif shutil.which('7za'):  # 7-Zip standalone
-          subprocess.run(['7za', 'x', local_file_name, '-y', '-o', dest_folder], check=True)
+          subprocess.run(['7za', 'x', local_file_name, '-y', '-o'+ dest_folder], check=True)
       else:
           log.error("No unzip tool for use")   
           sys.exit(1)

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -78,6 +78,6 @@ if is_windows():
     url = url.replace('onnxruntimetestdata', hostname)
     dest_folder = os.path.join(args.build_dir, 'installer','opencppcoverage')
     os.makedirs(dest_folder,exist_ok=True)
-    subprocess.run([os.path.join(build_dir,'azcopy'),'cp', '--log-level','ERROR', url, build_dir],check=True)
+    subprocess.run([os.path.join(args.build_dir,'azcopy'),'cp', '--log-level','ERROR', url, build_dir],check=True)
 
 

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -78,4 +78,4 @@ if is_windows():
     url = url.replace('onnxruntimetestdata', hostname)
     dest_folder = os.path.join(args.build_dir, 'installer','opencppcoverage')
     os.makedirs(dest_folder,exist_ok=True)
-    subprocess.run([os.path.join(args.build_dir,'azcopy'),'cp', '--log-level','ERROR', url, dest_folder],check=True)
+    subprocess.run([os.path.join(args.build_dir,'azcopy'),'cp', '--log-level','ERROR', url, os.path.join(dest_folder,'installer.exe')],check=True)

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -44,7 +44,7 @@ def get_server_hostname(azure_location):
 def download_and_unzip(build_dir, url, dest_folder):
     subprocess.run([os.path.join(build_dir,'azcopy'),'cp', '--log-level','ERROR', url, build_dir],check=True)
     os.makedirs(dest_folder,exist_ok=True)
-    local_file_name = os.path.basename(urlparse(url).path)
+    local_file_name = os.path.join(build_dir, os.path.basename(urlparse(url).path))
     if is_windows():
       if shutil.which('7z'):  # 7-Zip
           subprocess.run(['7z','x', local_file_name, '-y', '-o' + dest_folder], check=True)
@@ -55,6 +55,7 @@ def download_and_unzip(build_dir, url, dest_folder):
           sys.exit(1)
     else:
        subprocess.run(['unzip','-qd', dest_folder ,local_file_name], check=True)
+    os.unlink(local_file_name)
 
 args = parse_arguments()
 hostname = get_server_hostname(args.azure_region)
@@ -69,6 +70,6 @@ if is_windows():
     if os.path.exists(dest_dir):
         print('deleting %s' % dest_dir)
         shutil.rmtree(dest_dir)
-    shutil.move(os.path.join(args.build_dir,'cmake_temp','cmake-3.13.2-win64-x64'),dest_dir)
+    shutil.move(os.path.join(args.build_dir,'cmake_temp','cmake-3.15.1-win64-x64'),dest_dir)
 
 

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -67,7 +67,7 @@ print('data url=%s' % url)
 download_and_unzip(args.build_dir, url, 'models')
 if is_windows():
     url = 'https://onnxruntimetestdata.blob.core.windows.net/models/cmake-3.15.1-win64-x64.zip'
-    url = args.test_data_url.replace('onnxruntimetestdata', hostname)
+    url = url.replace('onnxruntimetestdata', hostname)
     download_and_unzip(args.build_dir, url, 'cmake_temp')
     dest_dir = os.path.join(args.build_dir,'cmake')
     if os.path.exists(dest_dir):

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -52,7 +52,7 @@ def download_and_unzip(build_dir, url, dest_folder):
       if shutil.which('7z'):  # 7-Zip
           subprocess.run(['7z','x', local_file_name, '-y', '-o' + dest_folder], check=True)
       elif shutil.which('7za'):  # 7-Zip standalone
-          subprocess.run(['7za', 'x', local_file_name, '-y', '-o'+ dest_folder], check=True)
+          subprocess.run(['7za', 'x', local_file_name, '-y', '-o' + dest_folder], check=True)
       else:
           log.error("No unzip tool for use")   
           sys.exit(1)
@@ -78,6 +78,4 @@ if is_windows():
     url = url.replace('onnxruntimetestdata', hostname)
     dest_folder = os.path.join(args.build_dir, 'installer','opencppcoverage')
     os.makedirs(dest_folder,exist_ok=True)
-    subprocess.run([os.path.join(args.build_dir,'azcopy'),'cp', '--log-level','ERROR', url, build_dir],check=True)
-
-
+    subprocess.run([os.path.join(args.build_dir,'azcopy'),'cp', '--log-level','ERROR', url, dest_folder],check=True)

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 import os
 import sys
+import shutil
 import argparse
 from urllib.parse import urlparse
 

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -76,7 +76,7 @@ if is_windows():
     shutil.move(os.path.join(args.build_dir,'cmake_temp','cmake-3.15.1-win64-x64'),dest_dir)
     url = 'https://onnxruntimetestdata.blob.core.windows.net/models/OpenCppCoverageSetup-x64-0.9.7.0.exe'
     url = url.replace('onnxruntimetestdata', hostname)
-    dest_folder = os.path.join(build_dir, 'installer','opencppcoverage')
+    dest_folder = os.path.join(args.build_dir, 'installer','opencppcoverage')
     os.makedirs(dest_folder,exist_ok=True)
     subprocess.run([os.path.join(build_dir,'azcopy'),'cp', '--log-level','ERROR', url, build_dir],check=True)
 

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -42,10 +42,13 @@ def get_server_hostname(azure_location):
 
 
 def download_and_unzip(build_dir, url, dest_folder):
+    print("Downloading %s" % url)
+    dest_folder = os.path.join(build_dir, dest_folder)
     subprocess.run([os.path.join(build_dir,'azcopy'),'cp', '--log-level','ERROR', url, build_dir],check=True)
     os.makedirs(dest_folder,exist_ok=True)
     local_file_name = os.path.join(build_dir, os.path.basename(urlparse(url).path))
     if is_windows():
+      print("unzip %s" % local_file_name)
       if shutil.which('7z'):  # 7-Zip
           subprocess.run(['7z','x', local_file_name, '-y', '-o' + dest_folder], check=True)
       elif shutil.which('7za'):  # 7-Zip standalone

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -1,11 +1,13 @@
 #!/usr/bin/python3
-
 import urllib.request
 import json
 import subprocess
 import os
 import argparse
 from urllib.parse import urlparse
+
+def is_windows():
+    return sys.platform.startswith("win")
 
 def get_azure_region():
     req = urllib.request.Request('http://169.254.169.254/metadata/instance?api-version=2018-10-01')
@@ -18,38 +20,53 @@ def parse_arguments():
     parser = argparse.ArgumentParser(description="ONNXRuntime Data Downloader.")
     parser.add_argument("--test_data_url", help="Test data URL.")
     parser.add_argument("--azure_region", help="Azure region")
+    parser.add_argument("--build_dir", required=True, help="Path to the build directory.")
     return parser.parse_args()
 
 
 def get_server_hostname(azure_location):
     if azure_location is None:
       #should be northcentralus or centralus
-      azure_location=get_azure_region()
+      azure_location = get_azure_region()
     print("This VM is in azure location: %s" % azure_location)
     if azure_location == 'centralus':
-        hostname='onnxruntimetestdata'
+        hostname = 'onnxruntimetestdata'
     elif azure_location == 'northcentralus':
-        hostname='onnxruntimetestdata2'
+        hostname = 'onnxruntimetestdata2'
     else:
         print('warning: no local data cache for azure region %s' % azure_location)
-        hostname='onnxruntimetestdata2'
+        hostname = 'onnxruntimetestdata2'
     return hostname
 
+
+def download_and_unzip(build_dir, url, dest_folder):
+    subprocess.run([os.path.join(build_dir,'azcopy'),'cp', '--log-level','ERROR', url, build_dir],check=True)
+    os.makedirs(dest_folder,exist_ok=True)
+    local_file_name = os.path.basename(urlparse(url).path)
+    if is_windows():
+      if shutil.which('7z'):  # 7-Zip
+          run_subprocess(['7z','x', local_file_name, '-y', '-o', dest_folder])
+      elif shutil.which('7za'):  # 7-Zip standalone
+          run_subprocess(['7za', 'x', local_file_name, '-y', '-o', dest_folder])
+      else:
+          log.error("No unzip tool for use")   
+          sys.exit(1)
+    else:
+       subprocess.run(['unzip','-qd', dest_folder ,local_file_name], check=True)
+
 args = parse_arguments()
-hostname=get_server_hostname(args.azure_region)
-url=args.test_data_url.replace('onnxruntimetestdata', hostname)
+hostname = get_server_hostname(args.azure_region)
+url = args.test_data_url.replace('onnxruntimetestdata', hostname)
 print('data url=%s' % url)
-BUILD_BINARIESDIRECTORY = os.environ.get('BUILD_BINARIESDIRECTORY')
-subprocess.run([os.path.join(BUILD_BINARIESDIRECTORY,'azcopy'),'cp', '--log-level','ERROR', url,'.'],check=True)
-os.makedirs('models',exist_ok=True)
-local_file_name = os.path.basename(urlparse(url).path)
+download_and_unzip(args.build_dir, url, 'models')
 if is_windows():
-  if shutil.which('7z'):  # 7-Zip
-      run_subprocess(['7z','x', local_file_name, '-y', '-o models'])
-  elif shutil.which('7za'):  # 7-Zip standalone
-      run_subprocess(['7za', 'x', local_file_name, '-y', '-o models'])
-  else:
-      log.error("No unzip tool for use")   
-      sys.exit(1)
-else:
-   subprocess.run(['unzip','-qd', 'models',local_file_name], check=True)
+    url = 'https://onnxruntimetestdata.blob.core.windows.net/models/cmake-3.15.1-win64-x64.zip'
+    url = args.test_data_url.replace('onnxruntimetestdata', hostname)
+    download_and_unzip(args.build_dir, url, 'cmake_temp')
+    dest_dir = os.path.join(args.build_dir,'cmake')
+    if os.path.exists(dest_dir):
+        print('deleting %s' % dest_dir)
+        shutil.rmtree(dest_dir)
+    shutil.move(os.path.join(args.build_dir,'cmake_temp','cmake-3.13.2-win64-x64'),dest_dir)
+
+

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -74,5 +74,10 @@ if is_windows():
         print('deleting %s' % dest_dir)
         shutil.rmtree(dest_dir)
     shutil.move(os.path.join(args.build_dir,'cmake_temp','cmake-3.15.1-win64-x64'),dest_dir)
+    url = 'https://onnxruntimetestdata.blob.core.windows.net/models/OpenCppCoverageSetup-x64-0.9.7.0.exe'
+    url = url.replace('onnxruntimetestdata', hostname)
+    dest_folder = os.path.join(build_dir, 'installer','opencppcoverage')
+    os.makedirs(dest_folder,exist_ok=True)
+    subprocess.run([os.path.join(build_dir,'azcopy'),'cp', '--log-level','ERROR', url, build_dir],check=True)
 
 

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -47,9 +47,9 @@ def download_and_unzip(build_dir, url, dest_folder):
     local_file_name = os.path.basename(urlparse(url).path)
     if is_windows():
       if shutil.which('7z'):  # 7-Zip
-          run_subprocess(['7z','x', local_file_name, '-y', '-o', dest_folder])
+          subprocess.run(['7z','x', local_file_name, '-y', '-o', dest_folder], check=True)
       elif shutil.which('7za'):  # 7-Zip standalone
-          run_subprocess(['7za', 'x', local_file_name, '-y', '-o', dest_folder])
+          subprocess.run(['7za', 'x', local_file_name, '-y', '-o', dest_folder], check=True)
       else:
           log.error("No unzip tool for use")   
           sys.exit(1)


### PR DESCRIPTION
**Description**: 
Avoid downloading test data into C:\

**Motivation and Context**
- Why is this change required? What problem does it solve?
We don't have enough disk space to cache the test data. 

- If it fixes an open issue, please link to the issue here.
