### PR TITLE
update default values for weight quatization

### DIFF
--- a/onnxruntime/python/tools/quantization/README.md
+++ b/onnxruntime/python/tools/quantization/README.md
@@ -62,7 +62,7 @@ onnx.save(quantized_model, 'path/to/the/quantized_model.onnx')
 See below for a description of all the options to quantize():
 
 - **model**: ModelProto to quantize
-- **per_channel**: *default: True*
+- **per_channel**: *default: False*
     If True, weights of Conv nodes are quantized per output channel.
     If False, they are quantized per tensor. Refer [QLinearConv](https://github.com/onnx/onnx/blob/master/docs/Operators.md#qlinearconv) for more information.
 - **nbits**: *default: 8*

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -990,7 +990,7 @@ class ONNXQuantizer:
         return [node]
 
 
-def quantize(model, per_channel=True, nbits=8, quantization_mode=QuantizationMode.IntegerOps,
+def quantize(model, per_channel=False, nbits=8, quantization_mode=QuantizationMode.IntegerOps,
     static=False, asymmetric_input_types=False, input_quantization_params=None, output_quantization_params=None):
     '''
         Given an onnx model, create a quantized onnx model and save it into a file


### PR DESCRIPTION
**Description**: Fixing the default values for quantizing weights

**Motivation and Context**
- Current default value for per_channel quantization is set to true which is not supported by runtime yet. So setting it to false. When false quantization happens per tensor or per layer and not per channel.
Issue: https://github.com/microsoft/onnxruntime/issues/1543