### PR TITLE
Parallel windows CI build

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -57,8 +57,9 @@ jobs:
           solution: '$(Build.BinariesDirectory)\Debug\onnxruntime.sln'
           platform: 'x64'
           configuration: 'Debug'
-          msbuildArguments: ${{ parameters.MsbuildArguments }}
+          msbuildArgs: ${{ parameters.MsbuildArguments }}
           msbuildArchitecture: 'x64'
+          maximumCpuCount: true
           logProjectEvents: true
           workingFolder: '$(Build.BinariesDirectory)\Debug'
           createLogFile: true
@@ -79,7 +80,7 @@ jobs:
           restoreNugetPackages: false
           msbuildArchitecture: 'x64'
           workingFolder: '$(Build.SourcesDirectory)\csharp'
-          msbuildArguments: '/m'
+          maximumCpuCount: true
 
       - task: CmdLine@2
         displayName: 'Test C# Debug'
@@ -104,7 +105,7 @@ jobs:
         solution: '$(Build.BinariesDirectory)\RelWithDebInfo\onnxruntime.sln'
         platform: 'x64'
         configuration: 'RelWithDebInfo'
-        msbuildArguments: ${{ parameters.MsbuildArguments }}
+        msbuildArgs: ${{ parameters.MsbuildArguments }}
         msbuildArchitecture: 'x64'
         logProjectEvents: true
         workingFolder: '$(Build.BinariesDirectory)\RelWithDebInfo'
@@ -125,7 +126,7 @@ jobs:
         msbuildArchitecture: 'x64'
         restoreNugetPackages: false
         workingFolder: '$(Build.SourcesDirectory)\csharp'
-        msbuildArguments: '/m'
+        maximumCpuCount: true
 
     - task: CmdLine@2
       displayName: 'Test C# RelWithDebInfo'


### PR DESCRIPTION
**Description**: 
Parallel windows CI build.
The debug build reduced from 21 min to 12 min, almost a half.
Release build reduced from 32 min to 18 min.
End to end pipeline execution time reduced 20%.

**Motivation and Context**
Our windows build is too slow, we should try to make it faster. 

See: https://github.com/MicrosoftDocs/vsts-docs/issues/3676