### PR TITLE
Include io_win32.h only if builds on windows

### DIFF
--- a/onnxruntime/core/util/protobuf_parsing_utils.cc
+++ b/onnxruntime/core/util/protobuf_parsing_utils.cc
@@ -49,6 +49,9 @@
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/logging.h>
 #include <google/protobuf/stubs/stl_util.h>
+#ifdef _WIN32
+#include <google/protobuf/stubs/io_win32.h>
+#endif
 #include "protobuf_parsing_utils.h"
 #include <string.h>
 
@@ -57,7 +60,6 @@ namespace protobuf {
 namespace io {
 
 #ifdef _WIN32
-#include <google/protobuf/stubs/io_win32.h>
 // Win32 lseek is broken:  If invoked on a non-seekable file descriptor, its
 // return value is undefined.  We re-define it to always produce an error.
 #define lseek(fd, offset, origin) ((off_t)-1)

--- a/onnxruntime/core/util/protobuf_parsing_utils.cc
+++ b/onnxruntime/core/util/protobuf_parsing_utils.cc
@@ -49,7 +49,6 @@
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/logging.h>
 #include <google/protobuf/stubs/stl_util.h>
-#include <google/protobuf/stubs/io_win32.h>
 #include "protobuf_parsing_utils.h"
 #include <string.h>
 
@@ -58,6 +57,7 @@ namespace protobuf {
 namespace io {
 
 #ifdef _WIN32
+#include <google/protobuf/stubs/io_win32.h>
 // Win32 lseek is broken:  If invoked on a non-seekable file descriptor, its
 // return value is undefined.  We re-define it to always produce an error.
 #define lseek(fd, offset, origin) ((off_t)-1)


### PR DESCRIPTION
**Description**: protobuf header `google/protobuf/stubs/io_win32.h` is windows32 specific and it should only be included when building on Windows.

**Motivation and Context**
- While building on CentOS 7 with external Protobuf, I noticed that `google/protobuf/stubs/io_win32.h` header was missing from my protobuf install area. As this header is Windows specific so I propose to include it only when building on Windows. This change allow me to build onnxruntime library on CentOS 7
