### PR TITLE
Fix log message truncation on Windows when printf formatting is used.`

### DIFF
--- a/onnxruntime/core/common/logging/capture.cc
+++ b/onnxruntime/core/common/logging/capture.cc
@@ -31,15 +31,10 @@ void Capture::ProcessPrintf(msvc_printf_check const char* format, va_list args) 
   bool truncated = false;
 
 #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__) && !defined(__GNUC__))
+  errno = 0;
   const int nbrcharacters = vsnprintf_s(message.data(), message.size(), _TRUNCATE, format, args);
   if (nbrcharacters < 0) {
-    // this can fail and return -1 if
-    //   buffer is nullptr (not possible, local buffer),
-    //   format is nullptr (possible),
-    //   count < 0 and != _TRUNCATE (not possible, always == _TRUNCATE)
-    //   or buffer too small and count != _TRUNCATE (not possible, always == _TRUNCATE)
-    // given there's only one possible cause, check that. alternatively we'd have to check errno which isn't threadsafe
-    error = format == nullptr;
+    error = errno != 0;
     truncated = !error;
   }
 #else

--- a/onnxruntime/core/common/logging/capture.cc
+++ b/onnxruntime/core/common/logging/capture.cc
@@ -27,16 +27,31 @@ void Capture::ProcessPrintf(msvc_printf_check const char* format, va_list args) 
   char message_buffer[kMaxMessageSize];
   const auto message = gsl::make_span(message_buffer);
 
+  bool error = false;
+  bool truncated = false;
+
 #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__) && !defined(__GNUC__))
   const int nbrcharacters = vsnprintf_s(message.data(), message.size(), _TRUNCATE, format, args);
+  if (nbrcharacters < 0) {
+    // this can fail and return -1 if
+    //   buffer is nullptr (not possible, local buffer),
+    //   format is nullptr (possible),
+    //   count < 0 and != _TRUNCATE (not possible, always == _TRUNCATE)
+    //   or buffer too small and count != _TRUNCATE (not possible, always == _TRUNCATE)
+    // given there's only one possible cause, check that. alternatively we'd have to check errno which isn't threadsafe
+    error = format == nullptr;
+    truncated = !error;
+  }
 #else
   const int nbrcharacters = vsnprintf(message.data(), message.size(), format, args);
+  error = nbrcharacters < 0;
+  truncated = nbrcharacters > message.size();
 #endif
 
-  if (nbrcharacters <= 0) {
+  if (error) {
     stream_ << "\n\tERROR LOG MSG NOTIFICATION: Failure to successfully parse the message";
     stream_ << '"' << format << '"' << std::endl;
-  } else if (nbrcharacters > message.size()) {
+  } else if (truncated) {
     stream_ << message.data() << kTruncatedWarningText;
   } else {
     stream_ << message.data();


### PR DESCRIPTION
**Description**: 
Fix log message truncation on Windows for printf style formatting and add unit test. 
On Windows vnsprintf_s returns -1 when truncating so we need to differentiate that from a real error.

**Motivation and Context**
Without this change long log messages using printf formatting on Windows are lost.