### PR TITLE
Fix pipeline template to include missing headers in tars

### DIFF
--- a/tools/ci_build/github/linux/copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/copy_strip_binary.sh
@@ -32,6 +32,8 @@ then
     ln -s $LIB_NAME $BINARY_DIR/$ARTIFACT_NAME/lib/libonnxruntime.so
 fi
 cp $SOURCE_DIR/include/onnxruntime/core/session/onnxruntime_c_api.h  $BINARY_DIR/$ARTIFACT_NAME/include
+cp $SOURCE_DIR/include/onnxruntime/core/session/onnxruntime_cxx_api.h  $BINARY_DIR/$ARTIFACT_NAME/include
+cp $SOURCE_DIR/include/onnxruntime/core/session/onnxruntime_cxx_inline.h  $BINARY_DIR/$ARTIFACT_NAME/include
 cp $SOURCE_DIR/include/onnxruntime/core/providers/cpu/cpu_provider_factory.h  $BINARY_DIR/$ARTIFACT_NAME/include
 cp $SOURCE_DIR/include/onnxruntime/core/providers/cuda/cuda_provider_factory.h  $BINARY_DIR/$ARTIFACT_NAME/include
 


### PR DESCRIPTION
The Release tars for Linux and Mac were missing onnxruntime_cxx_api.h and onnxruntime_cxx_inline.h. This change rectifies that.

**Description**: Fix pipeline template to include missing headers in tars/zips

**Motivation and Context**
Resolve #1596 
