### PR TITLE
Fix trtlogger segfault. re-enable SoftPlus unit test for TRT. add doc…

### DIFF
--- a/docs/execution_providers/TensorRT-ExecutionProvider.md
+++ b/docs/execution_providers/TensorRT-ExecutionProvider.md
@@ -22,3 +22,12 @@ When using the python wheel from the ONNX Runtime build with TensorRT execution 
 
 ### Using onnxruntime_perf_test
 You can test the performance for your ONNX Model with the TensorRT execution provider. Use the flag `-e tensorrt` in [onnxruntime_perf_test](https://github.com/Microsoft/onnxruntime/tree/master/onnxruntime/test/perftest#onnxruntime-performance-test).
+
+### Configuring Engine Max Batch Size and Workspace Size.
+By default TensorRT execution provider builds an ICudaEngine with max batch size = 1 and max workspace size = 1 GB
+One can override these defaults by setting environment variables ORT_TENSORRT_MAX_BATCH_SIZE and ORT_TENSORRT_MAX_WORKSPACE_SIZE.
+e.g. on Linux
+# override default batch size to 10
+export ORT_TENSORRT_MAX_BATCH_SIZE=10
+# override default max workspace size to 2GB
+export ORT_TENSORRT_MAX_WORKSPACE_SIZE=2147483648

--- a/docs/execution_providers/TensorRT-ExecutionProvider.md
+++ b/docs/execution_providers/TensorRT-ExecutionProvider.md
@@ -27,7 +27,7 @@ You can test the performance for your ONNX Model with the TensorRT execution pro
 By default TensorRT execution provider builds an ICudaEngine with max batch size = 1 and max workspace size = 1 GB
 One can override these defaults by setting environment variables ORT_TENSORRT_MAX_BATCH_SIZE and ORT_TENSORRT_MAX_WORKSPACE_SIZE.
 e.g. on Linux
-# override default batch size to 10
+#### override default batch size to 10
 export ORT_TENSORRT_MAX_BATCH_SIZE=10
-# override default max workspace size to 2GB
+#### override default max workspace size to 2GB
 export ORT_TENSORRT_MAX_WORKSPACE_SIZE=2147483648

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -25,6 +25,12 @@ using namespace ::onnxruntime::logging;
 
 namespace onnxruntime {
 
+// Per TensorRT documentation, logger needs to be a singleton.
+TensorrtLogger& GetTensorrtLogger() {
+  static TensorrtLogger trt_logger(nvinfer1::ILogger::Severity::kWARNING);
+  return trt_logger;
+}
+
 #define CHECK_CUDA(call)                                        \
   do {                                                          \
     cudaError_t status = call;                                  \
@@ -197,7 +203,7 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
 
         // Get supported node list recursively
         SubGraphCollection_t parser_nodes_list;
-        TensorrtLogger trt_logger(nvinfer1::ILogger::Severity::kWARNING);
+        TensorrtLogger& trt_logger = GetTensorrtLogger();
         auto trt_builder = unique_pointer<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(trt_logger));
         auto trt_network = unique_pointer<nvinfer1::INetworkDefinition>(trt_builder->createNetwork());
         auto trt_parser = unique_pointer<nvonnxparser::IParser>(nvonnxparser::createParser(*trt_network, trt_logger));
@@ -255,7 +261,7 @@ TensorrtExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
 
   // Get supported node list
   SubGraphCollection_t parser_nodes_vector;
-  TensorrtLogger trt_logger(nvinfer1::ILogger::Severity::kWARNING);
+  TensorrtLogger& trt_logger = GetTensorrtLogger();
   auto trt_builder = unique_pointer<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(trt_logger));
   auto trt_network = unique_pointer<nvinfer1::INetworkDefinition>(trt_builder->createNetwork());
   auto trt_parser = unique_pointer<nvonnxparser::IParser>(nvonnxparser::createParser(*trt_network, trt_logger));
@@ -323,7 +329,7 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<onnxruntime:
     model_proto.SerializeToString(&string_buf);
 
     // Create TensorRT engine
-    TensorrtLogger trt_logger(nvinfer1::ILogger::Severity::kWARNING);
+    TensorrtLogger& trt_logger = GetTensorrtLogger();
     auto trt_builder = unique_pointer<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(trt_logger));
     auto trt_network = unique_pointer<nvinfer1::INetworkDefinition>(trt_builder->createNetwork());
     auto trt_parser = unique_pointer<nvonnxparser::IParser>(nvonnxparser::createParser(*trt_network, trt_logger));
@@ -490,7 +496,14 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<onnxruntime:
 
       // Run TRT inference
       std::lock_guard<OrtMutex> lock(*(trt_state->tensorrt_mu_ptr));
-      trt_state->context->enqueue(batch_size, &buffers[0], nullptr, nullptr);
+      bool ret = trt_state->context->enqueue(batch_size, &buffers[0], nullptr, nullptr);
+      if (!ret) {
+        if (trt_state->context->getEngine().getMaxBatchSize() < batch_size) {
+	  return common::Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
+			        "TRT enqueue failed: Set ORT_TRT_MAX_BATCH_SIZE environment variable to at least " + to_string(batch_size));
+        }
+        return common::Status(common::ONNXRUNTIME, common::FAIL, "Failed to enqueue to TRT execution context.");
+      }
 
       return Status::OK();
     };

--- a/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
+++ b/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
@@ -200,8 +200,7 @@ TEST(ActivationOpTest, Softplus) {
                              return x + logf(expf(-x) + 1);
                            else
                              return logf(expf(x) + 1);
-                         },
-                         {}, false);  // Disable TensorRT because result mismatches
+                         });
 }
 
 TEST(ActivationOpTest, Softsign) {


### PR DESCRIPTION
-Re-enable Softplus unit test on TensorRT provider
-Add documentation for ORT_TENSORRT* environment variables.
-check return status of TRT execution context enqueue.
-Check for Engine max batch size and return error and user suggestion to increase batch size by setting ORT_TENSORRT_MAX_BATCH_SIZE env variable.

-Fix for TRTLogger segfault. This is due to TRT expecting logger to be singleton.
reproduced by running onnxruntime_test_all (unit tests)
stack trace looks like this:
d 1 "onnxruntime_tes" received signal SIGSEGV, Segmentation fault.
0x00007fffd2001fdd in nvinfer1::LogStream<(nvinfer1::ILogger::Severity)1>::Buf::sync() ()
   from /usr/lib/x86_64-linux-gnu/libnvinfer.so.5
(gdb) bt
#0  0x00007fffd2001fdd in nvinfer1::LogStream<(nvinfer1::ILogger::Severity)1>::Buf::sync() ()
   from /usr/lib/x86_64-linux-gnu/libnvinfer.so.5
#1  0x00007fffd179be3e in std::ostream::flush() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#2  0x00007fffd2015237 in nvinfer1::rt::ExecutionContext::enqueue(int, void**, CUstream_st*, CUevent_st**) ()
   from /usr/lib/x86_64-linux-gnu/libnvinfer.so.5
#3  0x0000000000b1a1cf in onnxruntime::TensorrtExecutionProvider::<lambda(onnxruntime::FunctionState, const OrtCustomOpApi*, OrtKernelContext*)>::operator()(onnxruntime::FunctionState, const OrtCustomOpApi *, OrtKernelContext *) const (
    __closure=0x2617bd00, state=0xb1fcfa0, api=0x2b8dc00 <g_custom_op_api>, context=0x7fffffff9a70)
    at /code/onnxruntime/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc:493
