### PR TITLE
Fix incorrect box offset computation in NMS op

### DIFF
--- a/onnxruntime/core/providers/cpu/object_detection/non_max_suppression.cc
+++ b/onnxruntime/core/providers/cpu/object_detection/non_max_suppression.cc
@@ -141,7 +141,7 @@ Status NonMaxSuppression::Compute(OpKernelContext* ctx) const {
   for (int64_t batch_index = 0; batch_index < pc.num_batches_; ++batch_index) {
     for (int64_t class_index = 0; class_index < pc.num_classes_; ++class_index) {
       int64_t box_score_offset = (batch_index * pc.num_classes_ + class_index) * pc.num_boxes_;
-      int64_t box_offset = batch_index * pc.num_classes_ * pc.num_boxes_ * 4;
+      int64_t box_offset = batch_index * pc.num_boxes_ * 4;
       // Filter by score_threshold_
       std::priority_queue<ScoreIndexPair, std::deque<ScoreIndexPair>> sorted_scores_with_index;
       const auto* class_scores = scores_data + box_score_offset;

--- a/onnxruntime/test/providers/cpu/object_detection/non_max_suppression_test.cc
+++ b/onnxruntime/test/providers/cpu/object_detection/non_max_suppression_test.cc
@@ -73,7 +73,7 @@ TEST(NonMaxSuppressionOpTest, TwoClasses) {
   test.Run();
 }
 
-TEST(NonMaxSuppressionOpTest, TwoBathes) {
+TEST(NonMaxSuppressionOpTest, TwoBatches_SingleClass) {
   OpTester test("NonMaxSuppression", 10, kOnnxDomain);
   test.AddInput<float>("boxes", {2, 6, 4},
                        {0.0f, 0.0f, 1.0f, 1.0f,
@@ -94,12 +94,48 @@ TEST(NonMaxSuppressionOpTest, TwoBathes) {
                         0.9f, 0.75f, 0.6f, 0.95f, 0.5f, 0.3f});
   test.AddInput<int64_t>("max_output_boxes_per_class", {}, {2L});
   test.AddInput<float>("iou_threshold", {}, {0.5f});
+
   test.AddInput<float>("score_threshold", {}, {0.0f});
   test.AddOutput<int64_t>("selected_indices", {4, 3},
                           {0L, 0L, 3L,
                            0L, 0L, 0L,
                            1L, 0L, 3L,
                            1L, 0L, 0L});
+  test.Run();
+}
+
+TEST(NonMaxSuppressionOpTest, TwoBatches_TwoClasses) {
+  OpTester test("NonMaxSuppression", 10, kOnnxDomain);
+  test.AddInput<float>("boxes", {2, 5, 4},
+                       {0.0f, 0.0f, 0.3f, 0.3f,
+                        0.0f, 0.0f, 0.4f, 0.4f,
+                        0.0f, 0.0f, 0.5f, 0.5f,
+                        0.5f, 0.5f, 0.9f, 0.9f,
+                        0.5f, 0.5f, 1.0f, 1.0f,
+
+                        0.0f, 0.0f, 0.3f, 0.3f,
+                        0.0f, 0.0f, 0.4f, 0.4f,
+                        0.0f, 0.0f, 0.5f, 0.5f,
+                        0.5f, 0.5f, 0.9f, 0.9f,
+                        0.5f, 0.5f, 1.0f, 1.0f});
+  test.AddInput<float>("scores", {2, 2, 5},
+                       {0.1f, 0.2f, 0.6f, 0.3f, 0.9f,
+                        0.1f, 0.2f, 0.6f, 0.3f, 0.9f,
+
+                        0.1f, 0.2f, 0.6f, 0.3f, 0.9f,
+                        0.1f, 0.2f, 0.6f, 0.3f, 0.9f});
+  test.AddInput<int64_t>("max_output_boxes_per_class", {}, {2L});
+  test.AddInput<float>("iou_threshold", {}, {0.5f});
+  test.AddOutput<int64_t>("selected_indices", {8, 3},
+                          {0L, 0L, 4L,
+                           0L, 0L, 2L,
+                           0L, 1L, 4L,
+                           0L, 1L, 2L,
+
+                           1L, 0L, 4L,
+                           1L, 0L, 2L,
+                           1L, 1L, 4L,
+                           1L, 1L, 2L});
   test.Run();
 }
 

--- a/onnxruntime/test/providers/cpu/object_detection/non_max_suppression_test.cc
+++ b/onnxruntime/test/providers/cpu/object_detection/non_max_suppression_test.cc
@@ -73,7 +73,7 @@ TEST(NonMaxSuppressionOpTest, TwoClasses) {
   test.Run();
 }
 
-TEST(NonMaxSuppressionOpTest, TwoBatches_SingleClass) {
+TEST(NonMaxSuppressionOpTest, TwoBatches_OneClass) {
   OpTester test("NonMaxSuppression", 10, kOnnxDomain);
   test.AddInput<float>("boxes", {2, 6, 4},
                        {0.0f, 0.0f, 1.0f, 1.0f,
@@ -94,7 +94,6 @@ TEST(NonMaxSuppressionOpTest, TwoBatches_SingleClass) {
                         0.9f, 0.75f, 0.6f, 0.95f, 0.5f, 0.3f});
   test.AddInput<int64_t>("max_output_boxes_per_class", {}, {2L});
   test.AddInput<float>("iou_threshold", {}, {0.5f});
-
   test.AddInput<float>("score_threshold", {}, {0.0f});
   test.AddOutput<int64_t>("selected_indices", {4, 3},
                           {0L, 0L, 3L,

--- a/onnxruntime/test/providers/cpu/object_detection/non_max_suppression_test.cc
+++ b/onnxruntime/test/providers/cpu/object_detection/non_max_suppression_test.cc
@@ -115,8 +115,8 @@ TEST(NonMaxSuppressionOpTest, TwoBatches_TwoClasses) {
 
                         0.0f, 0.0f, 0.3f, 0.3f,
                         0.0f, 0.0f, 0.4f, 0.4f,
-                        0.0f, 0.0f, 0.5f, 0.5f,
-                        0.5f, 0.5f, 0.9f, 0.9f,
+                        0.5f, 0.5f, 0.95f, 0.95f,
+                        0.5f, 0.5f, 0.96f, 0.96f,
                         0.5f, 0.5f, 1.0f, 1.0f});
   test.AddInput<float>("scores", {2, 2, 5},
                        {0.1f, 0.2f, 0.6f, 0.3f, 0.9f,
@@ -125,7 +125,7 @@ TEST(NonMaxSuppressionOpTest, TwoBatches_TwoClasses) {
                         0.1f, 0.2f, 0.6f, 0.3f, 0.9f,
                         0.1f, 0.2f, 0.6f, 0.3f, 0.9f});
   test.AddInput<int64_t>("max_output_boxes_per_class", {}, {2L});
-  test.AddInput<float>("iou_threshold", {}, {0.5f});
+  test.AddInput<float>("iou_threshold", {}, {0.8f});
   test.AddOutput<int64_t>("selected_indices", {8, 3},
                           {0L, 0L, 4L,
                            0L, 0L, 2L,
@@ -133,9 +133,9 @@ TEST(NonMaxSuppressionOpTest, TwoBatches_TwoClasses) {
                            0L, 1L, 2L,
 
                            1L, 0L, 4L,
-                           1L, 0L, 2L,
+                           1L, 0L, 1L,
                            1L, 1L, 4L,
-                           1L, 1L, 2L});
+                           1L, 1L, 1L});
   test.Run();
 }
 


### PR DESCRIPTION
**Description**: 
The `boxes` tensor in NMS is of shape [batch_size, num_boxes, 4]. So we don't need to multiply by `num_classes` in order to compute box offset.

This was not captured by any test case, because to trigger an incorrect box offset computation, we need both batch_size > 1 and num_classes > 1 (didn't have such a test case). Even then, it takes a very specific combination of `iou_threshold`, `box coordinates`, and `box scores` to trigger an overall test case failure by selecting wrong boxes (hard to write a test case that fails without this change and succeeds (as expected) with this change).

**Motivation and Context**
Resolve #1610 
