### PR TITLE
nGraph EP Optimizations

### DIFF
--- a/onnxruntime/core/providers/ngraph/ngraph_custom_op.cc
+++ b/onnxruntime/core/providers/ngraph/ngraph_custom_op.cc
@@ -84,9 +84,19 @@ void NGRAPHCustomOp::Initialize(const OrtCustomOpApi* api, OrtKernelContext* con
 
   // Get cache size from environment
   std::string tempSize;
+  #ifdef _WIN32
+  char *buf{nullptr};
+  size_t bufSize;
+  _dupenv_s(&buf, &bufSize, "ONNXRUNTIME_NGRAPH_LRU_CACHE_SIZE");
+  if(buf) {
+    tempSize = buf;
+  }
+  free(buf);
+  #else
   if (std::getenv("ONNXRUNTIME_NGRAPH_LRU_CACHE_SIZE")) {
     tempSize = std::getenv("ONNXRUNTIME_NGRAPH_LRU_CACHE_SIZE");
   }
+  #endif
   size_t cacheSize = tempSize.empty() ? NGRAPH_EP_LRU_CACHE_DEFAULT_SIZE : std::stoi(tempSize);
 
   // Not in cache

--- a/onnxruntime/core/providers/ngraph/ngraph_custom_op.cc
+++ b/onnxruntime/core/providers/ngraph/ngraph_custom_op.cc
@@ -80,7 +80,29 @@ void NGRAPHCustomOp::Initialize(const OrtCustomOpApi* api, OrtKernelContext* con
     uniq_input_shape.append(reinterpret_cast<const char*>(tensor_shape.data()), ndim * sizeof(int64_t));
   }
 
-  auto it = ng_exe_map_.insert({uniq_input_shape, nullptr});  //TODO: Limit the size of map with configurable size.
+  //auto it = ng_exe_map_.insert({uniq_input_shape, nullptr});  //TODO: Limit the size of map with configurable size.
+  // not present in cache 
+  if (ng_exe_map_.find(uniq_input_shape) == ng_exe_map_.end()) { 
+    // cache is full 
+    if (keyCache.size() == cacheSize) { 
+      // delete least recently used element 
+      std::string last = keyCache.back(); 
+  
+      // Pops the last elmeent 
+      keyCache.pop_back(); 
+  
+      // Erase the last 
+      ng_exe_map_.erase(ng_exe_map_.find(last)); 
+    } 
+  } 
+  
+  // present in cache 
+  else
+    keyCache.remove(uniq_input_shape); 
+  
+  // update reference 
+  keyCache.push_front(uniq_input_shape); 
+  auto it = ng_exe_map_.insert({uniq_input_shape, nullptr});
 
   //ng_exe with current shape already exists
   if (!it.second) {

--- a/onnxruntime/core/providers/ngraph/ngraph_custom_op.h
+++ b/onnxruntime/core/providers/ngraph/ngraph_custom_op.h
@@ -57,7 +57,6 @@ class NGRAPHCustomOp {
 */
   mutable std::unordered_map<std::string, std::shared_ptr<ngraph::runtime::Executable>> ng_exe_map_;
   mutable std::list<std::string> keyCache;
-  const size_t cacheSize = 20;
 
   mutable std::mutex compute_lock_;
 

--- a/onnxruntime/core/providers/ngraph/ngraph_custom_op.h
+++ b/onnxruntime/core/providers/ngraph/ngraph_custom_op.h
@@ -56,6 +56,8 @@ class NGRAPHCustomOp {
   key = [3,1,2,3,2,4,5]
 */
   mutable std::unordered_map<std::string, std::shared_ptr<ngraph::runtime::Executable>> ng_exe_map_;
+  mutable std::list<std::string> keyCache;
+  const size_t cacheSize = 20;
 
   mutable std::mutex compute_lock_;
 

--- a/onnxruntime/core/providers/ngraph/ngraph_custom_op.h
+++ b/onnxruntime/core/providers/ngraph/ngraph_custom_op.h
@@ -57,7 +57,7 @@ class NGRAPHCustomOp {
 */
   mutable std::unordered_map<std::string, std::shared_ptr<ngraph::runtime::Executable>> ng_exe_map_;
   mutable std::list<std::string> keyCache;
-
+  
   mutable std::mutex compute_lock_;
 
   mutable ONNX_NAMESPACE::ModelProto model_proto_;


### PR DESCRIPTION
**Description**: Made several optimizations to the nGraph Execution Provider.

**Motivation and Context**
- Fixed unneeded mutex lock in Compute() function.
- Added check before function initialization to see if function has already been initialized.
- Changed function cache to be LRU with tunable size.
