### PR TITLE
update MKLML to version which contains fix for thread hang.

### DIFF
--- a/cmake/external/mkldnn.cmake
+++ b/cmake/external/mkldnn.cmake
@@ -3,7 +3,7 @@ include (ExternalProject)
 set(MKLDNN_URL https://github.com/intel/mkl-dnn.git)
 # If MKLDNN_TAG is updated, check if MKLML_VERSION and platform.cmake.patch need to be updated.
 set(MKLDNN_TAG v0.18.1)
-set(MKLML_VERSION 2020.0.20190813)
+set(MKLML_VERSION 2019.0.5.20190502)
 
 if(WIN32)
   set(MKLML_OS_VERSION_STR "win")
@@ -11,6 +11,8 @@ if(WIN32)
   set(MKLDNN_SHARED_LIB mkldnn.dll)
   set(MKLDNN_IMPORT_LIB mkldnn.lib)
   if(onnxruntime_USE_MKLML)
+    # Windows-only updated MKLML binary which contains fix for thread cleanup hang.
+    set(MKLML_VERSION 2020.0.20190813)
     set(MKLML_SHARED_LIB mklml.dll)
     set(MKLML_IMPORT_LIB mklml.lib)
     set(IOMP5MD_SHARED_LIB libiomp5md.dll)

--- a/cmake/external/mkldnn.cmake
+++ b/cmake/external/mkldnn.cmake
@@ -3,7 +3,7 @@ include (ExternalProject)
 set(MKLDNN_URL https://github.com/intel/mkl-dnn.git)
 # If MKLDNN_TAG is updated, check if MKLML_VERSION and platform.cmake.patch need to be updated.
 set(MKLDNN_TAG v0.18.1)
-set(MKLML_VERSION 2019.0.5.20190502)
+set(MKLML_VERSION 2020.0.20190813)
 
 if(WIN32)
   set(MKLML_OS_VERSION_STR "win")
@@ -59,15 +59,15 @@ if (onnxruntime_USE_MKLDNN)
     set(MKLDNN_DLL_PATH ${MKLDNN_LIB_DIR}/${MKLDNN_SHARED_LIB})
   endif()
   set(MKLDNN_INCLUDE_DIR ${MKLDNN_INSTALL}/include)
-  set (MKLDNN_CMAKE_EXTRA_ARGS)
+  set(MKLDNN_CMAKE_EXTRA_ARGS)
+  set(MKLDNN_PATCH_COMMAND1 git apply ${CMAKE_SOURCE_DIR}/patches/mkldnn/mem-patch.cmake.patch)
+  # discard prior changes due to patching in mkldnn source to unblock incremental builds.
+  set(MKLDNN_PATCH_DISCARD_COMMAND cd ${MKLDNN_SOURCE} && git checkout -- .)
   if(NOT onnxruntime_BUILD_FOR_NATIVE_MACHINE)
     # pre-v1.0
     list(APPEND MKLDNN_CMAKE_EXTRA_ARGS "-DARCH_OPT_FLAGS=")
     # v1.0
     list(APPEND MKLDNN_CMAKE_EXTRA_ARGS "-DMKLDNN_ARCH_OPT_FLAGS=")
-    set(MKLDNN_PATCH_COMMAND1 git apply ${CMAKE_SOURCE_DIR}/patches/mkldnn/mem-patch.cmake.patch)
-    # discard prior changes due to patching in mkldnn source to unblock incremental builds.
-    set(MKLDNN_PATCH_DISCARD_COMMAND cd ${MKLDNN_SOURCE} && git checkout -- .)
   endif()
   ExternalProject_Add(project_mkldnn
     PREFIX mkl-dnn


### PR DESCRIPTION
-update MKLML to 2020.0.20190813.zip (Windows only)
It contains fix for thread hang issue which can happen during cleanup.
(tested onnx_test_runner onnx\onnx\backend\test\data\pytorch-converted many times and did not encounter a hang with the new version)

-move MKLDNN PATCH* commands to outside the onnxruntime_BUILD_FOR_NATIVE_MACHINE check.
the commands should be performed when BUILD_FOR_NATIVE_MACHINE option is set as well.