### PR TITLE
Check return value from CreateFeedsFetchesManager.

### DIFF
--- a/onnxruntime/core/providers/cpu/controlflow/loop.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/loop.cc
@@ -257,7 +257,6 @@ Status LoopImpl::CreateFeedsFetchesManager(std::unique_ptr<FeedsFetchesManager>&
     feed_names.push_back(entry.first);
   }
 
-  FeedsFetchesInfo ffi(feed_names, subgraph_output_names_);
   auto status =
       FeedsFetchesManager::Create(feed_names, subgraph_output_names_, session_state_.GetOrtValueNameIdxMap(), ffm);
 

--- a/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
@@ -125,7 +125,6 @@ Status CreateFeedsFetchesManager(const GraphViewer& subgraph, int num_variadic_i
     feed_names.push_back(entry.first);
   }
 
-  FeedsFetchesInfo ffi(feed_names, subgraph_output_names);
   auto status = FeedsFetchesManager::Create(feed_names, subgraph_output_names, ort_value_name_idx_map, ffm);
 
   return status;

--- a/onnxruntime/core/providers/cpu/controlflow/utils.h
+++ b/onnxruntime/core/providers/cpu/controlflow/utils.h
@@ -26,7 +26,8 @@ common::Status SubgraphExecuteHelper(std::unique_ptr<FeedsFetchesManager>& cache
   } else {
     // use a local instance until we know we're successful, and cache if it is
     std::unique_ptr<FeedsFetchesManager> new_ffm;
-    impl.CreateFeedsFetchesManager(new_ffm);
+    ORT_RETURN_IF_ERROR(impl.CreateFeedsFetchesManager(new_ffm));
+
     status = impl.Execute(&*new_ffm, nullptr);
     if (status.IsOK()) {
       cached_feeds_fetches_manager = std::move(new_ffm);


### PR DESCRIPTION
**Description**: 
Check return value from CreateFeedsFetchesManager so that we don't attempt to execute the subgraph if it fails.
Cleanup a couple of unused variables.

**Motivation and Context**
Investigating intermittent failure of mlperf ssd_mobilenet model on one CI build. Based on a couple of different failure reasons it looks like the feeds for subgraph execution aren't being setup correctly, which should only happen if CreateFeedsFetchesManager fails.