### PR TITLE
Fix a few errors in the NuGet pipeline (still broken)

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/esrp_dll.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/esrp_dll.yml
@@ -8,7 +8,7 @@ steps:
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: ${{ parameters.DisplayName }}
     inputs:
-      ConnectedServiceName: 'OnnxRuntime CodeSign 20171127'
+      ConnectedServiceName: 'OnnxRuntime CodeSign 20190817'
       FolderPath: ${{ parameters.FolderPath }}
       Pattern: '*.dll'
       signConfigType: inlineSignParams

--- a/tools/ci_build/github/azure-pipelines/templates/esrp_nuget.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/esrp_nuget.yml
@@ -8,7 +8,7 @@ steps:
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: ${{ parameters.DisplayName }}
     inputs:
-      ConnectedServiceName: 'OnnxRuntime CodeSign 20171127'
+      ConnectedServiceName: 'OnnxRuntime CodeSign 20190817'
       FolderPath: ${{ parameters.FolderPath }}
       Pattern: '*.nupkg'
       signConfigType: inlineSignParams

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -19,13 +19,20 @@ steps:
     #     downloadDirectory: '$(Build.BinariesDirectory)\python'
 
     # Temporary bypass of artifacts permission issue
-        
-    - task: CmdLine@1
-      displayName: 'Download python'
+    - task: PowerShell@2
+      displayName: 'Download AzCopy (used for download test data script)'
       inputs:
-        filename: 'C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe'
-        arguments: '/Y /Source:https://onnxruntimetestdata.blob.core.windows.net/models/Miniconda3-4.7.10-Windows-x86_64.exe /Dest:$(Build.BinariesDirectory)\Miniconda3-4.7.10-Windows-x86_64.exe'               
-  
+        targetType: 'inline'
+        script: |
+          Invoke-WebRequest -OutFile $(Build.BinariesDirectory)\azcopy.exe https://onnxruntimetestdata.blob.core.windows.net/models/azcopy.exe
+
+    - task: PowerShell@2
+      displayName: 'Download Python'
+      inputs:
+        targetType: 'inline'
+        script: |
+          Invoke-WebRequest -OutFile $(Build.BinariesDirectory)\Miniconda3-4.7.10-Windows-x86_64.exe https://onnxruntimetestdata.blob.core.windows.net/models/Miniconda3-4.7.10-Windows-x86_64.exe
+
     - task: CmdLine@1
       displayName: 'Run python installer'
       inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -19,16 +19,11 @@ steps:
     #     downloadDirectory: '$(Build.BinariesDirectory)\python'
 
     # Temporary bypass of artifacts permission issue
-    - task: CmdLine@1
-      displayName: 'Download azcopy'
-      inputs:
-        filename: 'AzCopy.exe'
-        arguments: '/Y /Source:https://onnxruntimetestdata.blob.core.windows.net/models/azcopy.exe /Dest:$(Build.BinariesDirectory)\azcopy.exe'
         
     - task: CmdLine@1
       displayName: 'Download python'
       inputs:
-        filename: 'AzCopy.exe'
+        filename: 'C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe'
         arguments: '/Y /Source:https://onnxruntimetestdata.blob.core.windows.net/models/Miniconda3-4.7.10-Windows-x86_64.exe /Dest:$(Build.BinariesDirectory)\Miniconda3-4.7.10-Windows-x86_64.exe'               
   
     - task: CmdLine@1

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -31,7 +31,7 @@ steps:
       inputs:
         targetType: 'inline'
         script: |
-          Invoke-WebRequest -OutFile $(Build.BinariesDirectory)\Miniconda3-4.7.10-Windows-x86_64.exe https://onnxruntimetestdata.blob.core.windows.net/models/Miniconda3-4.7.10-Windows-x86_64.exe
+          Invoke-WebRequest -RetryIntervalSec 10 -MaximumRetryCount 2 -OutFile $(Build.BinariesDirectory)\Miniconda3-4.7.10-Windows-x86_64.exe https://onnxruntimetestdata.blob.core.windows.net/models/Miniconda3-4.7.10-Windows-x86_64.exe
 
     - task: CmdLine@1
       displayName: 'Run python installer'

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -24,14 +24,14 @@ steps:
       inputs:
         targetType: 'inline'
         script: |
-          Invoke-WebRequest -RetryIntervalSec 10 -MaximumRetryCount 2 -OutFile $(Build.BinariesDirectory)\azcopy.exe https://onnxruntimetestdata.blob.core.windows.net/models/azcopy.exe
+          Invoke-WebRequest -OutFile $(Build.BinariesDirectory)\azcopy.exe https://onnxruntimetestdata.blob.core.windows.net/models/azcopy.exe
 
     - task: PowerShell@2
       displayName: 'Download Python'
       inputs:
         targetType: 'inline'
         script: |
-          Invoke-WebRequest -RetryIntervalSec 10 -MaximumRetryCount 2 -OutFile $(Build.BinariesDirectory)\Miniconda3-4.7.10-Windows-x86_64.exe https://onnxruntimetestdata.blob.core.windows.net/models/Miniconda3-4.7.10-Windows-x86_64.exe
+          Invoke-WebRequest -OutFile $(Build.BinariesDirectory)\Miniconda3-4.7.10-Windows-x86_64.exe https://onnxruntimetestdata.blob.core.windows.net/models/Miniconda3-4.7.10-Windows-x86_64.exe
 
     - task: CmdLine@1
       displayName: 'Run python installer'

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -26,12 +26,19 @@ steps:
         script: |
           Invoke-WebRequest -OutFile $(Build.BinariesDirectory)\azcopy.exe https://onnxruntimetestdata.blob.core.windows.net/models/azcopy.exe
 
-    - task: PowerShell@2
+    # - task: PowerShell@2
+    #   displayName: 'Download Python'
+    #   inputs:
+    #     targetType: 'inline'
+    #     script: |
+    #       Invoke-WebRequest -OutFile $(Build.BinariesDirectory)\Miniconda3-4.7.10-Windows-x86_64.exe https://onnxruntimetestdata.blob.core.windows.net/models/Miniconda3-4.7.10-Windows-x86_64.exe
+
+    - task: CmdLine@1
       displayName: 'Download Python'
       inputs:
-        targetType: 'inline'
-        script: |
-          Invoke-WebRequest -OutFile $(Build.BinariesDirectory)\Miniconda3-4.7.10-Windows-x86_64.exe https://onnxruntimetestdata.blob.core.windows.net/models/Miniconda3-4.7.10-Windows-x86_64.exe
+        filename: '$(Build.BinariesDirectory)\azcopy.exe'
+        arguments: 'copy https://onnxruntimetestdata.blob.core.windows.net/models/Miniconda3-4.7.10-Windows-x86_64.exe $(Build.BinariesDirectory)\Miniconda3-4.7.10-Windows-x86_64.exe'
+      timeoutInMinutes: 10
 
     - task: CmdLine@1
       displayName: 'Run python installer'

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -24,7 +24,7 @@ steps:
       inputs:
         targetType: 'inline'
         script: |
-          Invoke-WebRequest -OutFile $(Build.BinariesDirectory)\azcopy.exe https://onnxruntimetestdata.blob.core.windows.net/models/azcopy.exe
+          Invoke-WebRequest -RetryIntervalSec 10 -MaximumRetryCount 2 -OutFile $(Build.BinariesDirectory)\azcopy.exe https://onnxruntimetestdata.blob.core.windows.net/models/azcopy.exe
 
     - task: PowerShell@2
       displayName: 'Download Python'


### PR DESCRIPTION
**Description**: Fix a few errors in NuGet CPU pipeline

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

- AZCopy was not able to access the blob in the blob store, so use Powershell Invoke-WebRequest instead
- The Signing cert was expired, so new cert was obtained and new Service connection created

- Still further errors remain in the end-to-end tests

