### PR TITLE
Use exec form of ENTRYPOINT for docker server

### DIFF
--- a/dockerfiles/Dockerfile.server
+++ b/dockerfiles/Dockerfile.server
@@ -32,9 +32,8 @@ RUN mkdir -p /onnxruntime/build && \
 
 FROM minimal AS final
 WORKDIR /onnxruntime/server/
-ENV MODEL_ABSOLUTE_PATH /onnxruntime/model/model.onnx
 COPY --from=build /onnxruntime/build/Release/onnxruntime_server /onnxruntime/server/
 COPY --from=build /onnxruntime/build/Release/libonnxruntime.so.* /lib/
 RUN apt-get update \
     && apt-get install -y libgomp1
-ENTRYPOINT /onnxruntime/server/onnxruntime_server --model_path $MODEL_ABSOLUTE_PATH
+ENTRYPOINT ["/onnxruntime/server/onnxruntime_server"]

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -183,7 +183,7 @@
 2. Run the ONNXRuntime server with the image created in step 1
 
   ```
-  docker run -v {localModelAbsoluteFolder}:{dockerModelAbsoluteFolder} -e MODEL_ABSOLUTE_PATH={dockerModelAbsolutePath} -p {your_local_port}:8001 {imageName}
+  docker run -v {localModelAbsoluteFolder}:{dockerModelAbsoluteFolder} -p {your_local_port}:8001 {imageName} --model_path {dockerModelAbsolutePath}
   ```
 3. Send HTTP requests to the container running ONNX Runtime Server
 


### PR DESCRIPTION
# Issue
The entrypoint currently uses the shell form - this prevents users from passing in any cmdline arguments... also passing a model_path in means the server only works in the envvar is set... however this is not what the error message says!
```
$ docker run -v /home/rakelkar/try/onnxzoo/style:/mnt/models -it   mcr.microsoft.com/onnxruntime/server --model_path /mnt/models/model.onnx
Version: local_build
Commit ID: default

model_path must be the location of a valid file
Allowed options:
  -h [ --help ]               Shows a help message and exits
  --log_level arg (=info)     Logging level. Allowed options (case sensitive): 
                              verbose, info, warning, error, fatal
  --model_path arg            Path to ONNX model
  --address arg (=0.0.0.0)    The base HTTP address
  --http_port arg (=8001)     HTTP port to listen to requests
  --num_http_threads arg (=4) Number of http threads
  --grpc_port arg (=50051)    GRPC port to listen to requests
```
# Fix
1. remove the env var
2. use the exec form

**Description**: Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
