### PR TITLE
make gemmlowp default for arm

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -334,7 +334,7 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
                  "-Donnxruntime_USE_EIGEN_FOR_BLAS=" + ("OFF" if args.use_openblas else "ON"),
                  "-Donnxruntime_USE_OPENBLAS=" + ("ON" if args.use_openblas else "OFF"),
                  "-Donnxruntime_USE_MKLDNN=" + ("ON" if args.use_mkldnn else "OFF"),
-                 "-Donnxruntime_USE_MKLML=" + ("ON" if args.use_mklml else "OFF"),                 
+                 "-Donnxruntime_USE_MKLML=" + ("ON" if args.use_mklml else "OFF"),
                  "-Donnxruntime_USE_GEMMLOWP=" + ("ON" if args.use_gemmlowp else "OFF"),
                  "-Donnxruntime_USE_NGRAPH=" + ("ON" if args.use_ngraph else "OFF"),
                  "-Donnxruntime_USE_OPENVINO=" + ("ON" if args.use_openvino else "OFF"),


### PR DESCRIPTION
**Description**: Use gemmlowp when explitcitly requested or when building for arm
                

**Motivation and Context**
-  gemmlowp is optimized for arm devices so it should be used by default for arm

