### PR TITLE
MKL-DNN EP:  control flow fix

### DIFF
--- a/onnxruntime/core/providers/mkldnn/mkldnn_execution_provider.cc
+++ b/onnxruntime/core/providers/mkldnn/mkldnn_execution_provider.cc
@@ -357,8 +357,8 @@ void MKLDNNExecutionProvider::CreateMetaDef(const onnxruntime::GraphViewer& grap
                                             std::vector<std::unique_ptr<ComputeCapability>>& result) const {
   std::string graph_fused_nodes;
   std::string node_list;
-  std::string subgraph_id = std::to_string(sub_var.subgraph_index);
-  sub_var.subgraph_index++;
+  std::string subgraph_id = std::to_string(subgraph_index_);
+  subgraph_index_++;
 
   // This is a list of initializers that subgraph considers as constants.
   // Example weights, reshape shape etc.
@@ -378,7 +378,7 @@ void MKLDNNExecutionProvider::CreateMetaDef(const onnxruntime::GraphViewer& grap
 
   auto meta_def = std::make_unique<::onnxruntime::IndexedSubGraph::MetaDef>();
   meta_def->attributes["initializers"] = initializers;
-  meta_def->name = "MkldnnCustomOp" + std::to_string(sub_var.subgraph_index);
+  meta_def->name = "MkldnnCustomOp" + std::to_string(subgraph_index_);
   meta_def->domain = kMSDomain;
   meta_def->since_version = 1;
   meta_def->status = ONNX_NAMESPACE::EXPERIMENTAL;

--- a/onnxruntime/core/providers/mkldnn/mkldnn_execution_provider.h
+++ b/onnxruntime/core/providers/mkldnn/mkldnn_execution_provider.h
@@ -147,6 +147,8 @@ class MKLDNNExecutionProvider : public IExecutionProvider {
   }
 
  private:
+  mutable int subgraph_index_ = 0;
+
   // supported MklDnn Operators
   std::set<std::string> mkldnn_ops_ = {"Conv", "BatchNormalization", "Relu", "Sum",
                                        "AveragePool", "GlobalMaxPool", "GlobalAveragePool", "MaxPool", "LRN"};

--- a/onnxruntime/core/providers/mkldnn/subgraph/subgraph.h
+++ b/onnxruntime/core/providers/mkldnn/subgraph/subgraph.h
@@ -48,12 +48,11 @@ struct Subgraph {
     std::vector<std::string> outputs;
     std::vector<std::string> outputs_as_input_other_node;
     std::vector<onnxruntime::NodeIndex> subgraph_node_indexes;
-    int subgraph_index = 0;
 
     SubgraphVariables() {
-      subgraph_index = 0;
     }
-    void Reset() {
+
+	void Reset() {
       subgraph_node_indexes.clear();
       inputs.clear();
       outputs.clear();

--- a/onnxruntime/core/providers/mkldnn/subgraph/subgraph.h
+++ b/onnxruntime/core/providers/mkldnn/subgraph/subgraph.h
@@ -49,9 +49,6 @@ struct Subgraph {
     std::vector<std::string> outputs_as_input_other_node;
     std::vector<onnxruntime::NodeIndex> subgraph_node_indexes;
 
-    SubgraphVariables() {
-    }
-
 	void Reset() {
       subgraph_node_indexes.clear();
       inputs.clear();


### PR DESCRIPTION
Problem: 
Models with control flow operators didn't work as some subgraphs got same id.

Fix:
Moved subgraph_id to MklDnnExecutionProvider class.