### PR TITLE
Put the initializers at the end of the cluster inputs list

### DIFF
--- a/onnxruntime/core/providers/ngraph/ngraph_execution_provider.cc
+++ b/onnxruntime/core/providers/ngraph/ngraph_execution_provider.cc
@@ -438,13 +438,24 @@ static void GetInputsOutputsOfCluster(const GraphViewer& graph_viewer,
   }
 
   const auto& initializers = graph_viewer.GetAllInitializedTensors();
+  std::vector<std::string> const_inputs;
   for (const auto& in_arg : ordered_input_args) {
     if ((initializers.count(in_arg) && !original_graph_inputs.count(in_arg)) ||
         ng_required_initializers.count(in_arg)) {
-      cluster_inputs.push_back(in_arg);
-    } else if (!output_args.count(in_arg)) {
+      const_inputs.push_back(in_arg);
+    }
+  }
+
+  for (const auto& in_arg : ordered_input_args) {
+    if (!output_args.count(in_arg) &&
+        !((initializers.count(in_arg) && !original_graph_inputs.count(in_arg)) ||
+        ng_required_initializers.count(in_arg))) {
       cluster_inputs.push_back(in_arg);
     }
+  }
+
+  for (const auto& in_arg : const_inputs) {
+    cluster_inputs.push_back(in_arg);
   }
 
   std::copy(external_output_args.begin(), external_output_args.end(), std::back_inserter(cluster_outputs));


### PR DESCRIPTION
This PR contains a fix for the Reshape error which was observed when inferencing some models (for example YOLOv3). Only non-const inputs are required by the ngraph::Executable when it gets called and thus, during the partitioning phase, the initializers are placed at the end of the subgraph inputs. This makes it easier to map the tensors provided to the custom op to the ngraph::Executable inputs.