### PR TITLE
fixed "unreachable code" warnings on Windows

### DIFF
--- a/onnxruntime/core/providers/nuphar/mti_x86/quantize/imatmul16_extern.cc
+++ b/onnxruntime/core/providers/nuphar/mti_x86/quantize/imatmul16_extern.cc
@@ -89,9 +89,6 @@ IMatMul16ExternMKL(const tvm::Tensor& B,
   std::string func_str;
 #ifdef NUPHAR_USE_MKL
   func_str = "tvm.contrib.onnxruntime.imatmul16.extern.mkl";
-#else
-  ORT_NOT_IMPLEMENTED("Not implemented. Please set NUPHAR_USE_MKL!");
-#endif
 
   // TODO: instead of calling Promote, we may consider to expose
   // tvm::Tensor and tvm::Expr version of op from topi
@@ -109,6 +106,9 @@ IMatMul16ExternMKL(const tvm::Tensor& B,
                                           embed_dim});
       },
       name, "", {})[0];
+#else
+  ORT_NOT_IMPLEMENTED("Not implemented. Please set NUPHAR_USE_MKL!");
+#endif
 }
 
 tvm::Tensor
@@ -123,9 +123,6 @@ IMatMul16ExternAVX2(const tvm::Tensor& B,
   std::string func_str;
 #ifdef NUPHAR_USE_AVX2
   func_str = "tvm.contrib.onnxruntime.imatmul16.extern.avx2";
-#else
-  ORT_NOT_IMPLEMENTED("Not implemented. Please set NUPHAR_USE_AVX2!");
-#endif
 
   // TODO: instead of calling Promote, we may consider to expose
   // tvm::Tensor and tvm::Expr version of op from topi
@@ -143,6 +140,9 @@ IMatMul16ExternAVX2(const tvm::Tensor& B,
                                           embed_dim});
       },
       name, "", {})[0];
+#else
+  ORT_NOT_IMPLEMENTED("Not implemented. Please set NUPHAR_USE_AVX2!");
+#endif
 }
 
 }  // namespace nuphar

--- a/onnxruntime/core/providers/nuphar/mti_x86/quantize/imatmul_extern.cc
+++ b/onnxruntime/core/providers/nuphar/mti_x86/quantize/imatmul_extern.cc
@@ -87,9 +87,6 @@ IMatMulExternMKL(const tvm::Tensor& B,
   std::string func_str;
 #ifdef NUPHAR_USE_MKL
   func_str = "tvm.contrib.onnxruntime.imatmul.extern.mkl";
-#else
-  ORT_NOT_IMPLEMENTED("Not implemented. Please set NUPHAR_USE_MKL!");
-#endif
 
   return topi::detail::make_extern(
       {output_shape}, {tvm::Int(32)},
@@ -105,6 +102,9 @@ IMatMulExternMKL(const tvm::Tensor& B,
                                           embed_dim});
       },
       name, "", {})[0];
+#else
+  ORT_NOT_IMPLEMENTED("Not implemented. Please set NUPHAR_USE_MKL!");
+#endif
 }
 
 tvm::Tensor
@@ -119,9 +119,6 @@ IMatMulExternAVX2(const tvm::Tensor& B,
   std::string func_str;
 #ifdef NUPHAR_USE_AVX2
   func_str = "tvm.contrib.onnxruntime.imatmul.extern.avx2";
-#else
-  ORT_NOT_IMPLEMENTED("Not implemented. Please set NUPHAR_USE_AVX2!");
-#endif
 
   return topi::detail::make_extern(
       {output_shape}, {tvm::Int(32)},
@@ -137,6 +134,9 @@ IMatMulExternAVX2(const tvm::Tensor& B,
                                           embed_dim});
       },
       name, "", {})[0];
+#else
+  ORT_NOT_IMPLEMENTED("Not implemented. Please set NUPHAR_USE_AVX2!");
+#endif
 }
 
 }  // namespace nuphar


### PR DESCRIPTION
When NUPHAR_USE_MKL or NUPHAR_USE_AVX2 is not defined, we got
"unreachable code" warnings on Windows, which were truned into
errors and broke the build.
