### PR TITLE
[WIP] Bump onnx to latest

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -49,7 +49,7 @@
          "component":{
             "type":"git",
             "git": {
-              "commitHash": "7d90796473295ca3cdf976ed772215c5980ad3e0",
+              "commitHash": "eb139446590ad631b7e6b6782ddf620ac9240295",
               "repositoryUrl": "https://github.com/onnx/onnx.git"
             }
          }

--- a/onnxruntime/core/protobuf/onnx-ml.proto
+++ b/onnxruntime/core/protobuf/onnx-ml.proto
@@ -86,7 +86,13 @@ enum Version {
   // IR VERSION 5 published on March 18, 2019
   // - Add message TensorAnnotation.
   // - Add quantization annotation in GraphProto to map tensor with its scale and zero point quantization parameters.
-  IR_VERSION = 0x0000000000000005;
+  IR_VERSION_2019_3_18 = 0x0000000000000005;
+
+  // IR VERSION 6 published on <TBD>
+  // - Add support for sparse tensor constants stored in model.
+  //   - Add message SparseTensorProto
+  //   - Add sparse initializers
+  IR_VERSION = 0x0000000000000006;
 }
 
 // Attributes
@@ -106,12 +112,14 @@ message AttributeProto {
     STRING = 3;
     TENSOR = 4;
     GRAPH = 5;
+    SPARSE_TENSOR = 11;
 
     FLOATS = 6;
     INTS = 7;
     STRINGS = 8;
     TENSORS = 9;
     GRAPHS = 10;
+    SPARSE_TENSORS = 12;
   }
 
   // The name field MUST be present for this version of the IR.
@@ -140,6 +148,7 @@ message AttributeProto {
   optional bytes s = 4;               // UTF-8 string
   optional TensorProto t = 5;         // tensor value
   optional GraphProto g = 6;          // graph
+  optional SparseTensorProto sparse_tensor = 22;  // sparse tensor value
   // Do not use field below, it's deprecated.
   // optional ValueProto v = 12;         // value - subsumes everything but graph
 
@@ -148,6 +157,7 @@ message AttributeProto {
   repeated bytes strings = 9;         // list of UTF-8 strings
   repeated TensorProto tensors = 10;  // list of tensors
   repeated GraphProto graphs = 11;    // list of graph
+  repeated SparseTensorProto sparse_tensors = 23; // list of sparse tensors
 }
 
 // Defines information on value, including the name, the type, and
@@ -276,6 +286,9 @@ message GraphProto {
   // Each TensorProto entry must have a distinct name (within the list) that
   // MAY also appear in the input list.
   repeated TensorProto initializer = 5;
+
+  // Initializers (see above) stored in sparse format.
+  repeated SparseTensorProto sparse_initializer = 15;
 
   // A human-readable documentation for this graph. Markdown is allowed.
   optional string doc_string = 10;
@@ -446,6 +459,28 @@ message TensorProto {
   repeated uint64 uint64_data = 11 [packed = true];
 }
 
+// A serialized sparse-tensor value
+message SparseTensorProto {
+  // The sequence of non-default values are encoded as a tensor of shape [NNZ].
+  // The default-value is zero for numeric tensors, and empty-string for string tensors.
+  optional TensorProto values = 1;
+
+  // The indices of the non-default values, which may be stored in one of two formats.
+  // (a) Indices can be a tensor of shape [NNZ, rank] with the [i,j]-th value
+  // corresponding to the j-th index of the i-th value (in the values tensor).
+  // (b) Indices can be a tensor of shape [NNZ], in which case the i-th value
+  // must be the linearized-index of the i-th value (in the values tensor).
+  // The linearized-index can be converted into an index tuple (k_1,...,k_rank)
+  // using the shape provided below.
+  // The indices must appear in ascending order without duplication.
+  // In the first format, the ordering is lexicographic-ordering:
+  // e.g., index-value [1,4] must appear before [2,1]
+  optional TensorProto indices = 2;
+
+  // The shape of the underlying dense-tensor: [dim_1, dim_2, ... dim_rank]
+  repeated int64 dims = 3;
+}
+
 // Defines a tensor shape. A dimension can be either an integer value
 // or a symbolic variable. A symbolic variable represents an unknown
 // dimension.
@@ -478,6 +513,14 @@ message TypeProto {
     optional TensorShapeProto shape = 2;
   }
 
+  message SparseTensor { 
+    // This field MUST NOT have the value of UNDEFINED 
+    // This field MUST have a valid TensorProto.DataType value
+    // This field MUST be present for this version of the IR. 
+    optional int32 elem_type = 1;
+    optional TensorShapeProto shape = 2;
+  }
+
 
   // repeated T
   message Sequence {
@@ -506,18 +549,12 @@ message TypeProto {
     // repeated TypeProto parameters = 3;
   }
 
-  message SparseTensor { 
-    // This field MUST NOT have the value of UNDEFINED 
-    // This field MUST have a valid TensorProto.DataType value
-    // This field MUST be present for this version of the IR. 
-    optional int32 elem_type = 1;
-    optional TensorShapeProto shape = 2;
-  }
-
 
   oneof value {
     // The type of a tensor.
     Tensor tensor_type = 1;
+
+    SparseTensor sparse_tensor_type = 8;
 
 
     // NOTE:  DNN-only implementations of ONNX MAY elect to not support non-tensor values
@@ -532,8 +569,6 @@ message TypeProto {
     Map map_type = 5;
 
     Opaque opaque_type = 7;
-
-    SparseTensor sparse_tensor_type = 8;
 
   }
 

--- a/onnxruntime/core/protobuf/onnx-ml.proto3
+++ b/onnxruntime/core/protobuf/onnx-ml.proto3
@@ -86,7 +86,13 @@ enum Version {
   // IR VERSION 5 published on March 18, 2019
   // - Add message TensorAnnotation.
   // - Add quantization annotation in GraphProto to map tensor with its scale and zero point quantization parameters.
-  IR_VERSION = 0x0000000000000005;
+  IR_VERSION_2019_3_18 = 0x0000000000000005;
+
+  // IR VERSION 6 published on <TBD>
+  // - Add support for sparse tensor constants stored in model.
+  //   - Add message SparseTensorProto
+  //   - Add sparse initializers
+  IR_VERSION = 0x0000000000000006;
 }
 
 // Attributes
@@ -106,12 +112,14 @@ message AttributeProto {
     STRING = 3;
     TENSOR = 4;
     GRAPH = 5;
+    SPARSE_TENSOR = 11;
 
     FLOATS = 6;
     INTS = 7;
     STRINGS = 8;
     TENSORS = 9;
     GRAPHS = 10;
+    SPARSE_TENSORS = 12;
   }
 
   // The name field MUST be present for this version of the IR.
@@ -140,6 +148,7 @@ message AttributeProto {
   bytes s = 4;               // UTF-8 string
   TensorProto t = 5;         // tensor value
   GraphProto g = 6;          // graph
+  SparseTensorProto sparse_tensor = 22;  // sparse tensor value
   // Do not use field below, it's deprecated.
   // optional ValueProto v = 12;         // value - subsumes everything but graph
 
@@ -148,6 +157,7 @@ message AttributeProto {
   repeated bytes strings = 9;         // list of UTF-8 strings
   repeated TensorProto tensors = 10;  // list of tensors
   repeated GraphProto graphs = 11;    // list of graph
+  repeated SparseTensorProto sparse_tensors = 23; // list of sparse tensors
 }
 
 // Defines information on value, including the name, the type, and
@@ -276,6 +286,9 @@ message GraphProto {
   // Each TensorProto entry must have a distinct name (within the list) that
   // MAY also appear in the input list.
   repeated TensorProto initializer = 5;
+
+  // Initializers (see above) stored in sparse format.
+  repeated SparseTensorProto sparse_initializer = 15;
 
   // A human-readable documentation for this graph. Markdown is allowed.
   string doc_string = 10;
@@ -446,6 +459,28 @@ message TensorProto {
   repeated uint64 uint64_data = 11 [packed = true];
 }
 
+// A serialized sparse-tensor value
+message SparseTensorProto {
+  // The sequence of non-default values are encoded as a tensor of shape [NNZ].
+  // The default-value is zero for numeric tensors, and empty-string for string tensors.
+  TensorProto values = 1;
+
+  // The indices of the non-default values, which may be stored in one of two formats.
+  // (a) Indices can be a tensor of shape [NNZ, rank] with the [i,j]-th value
+  // corresponding to the j-th index of the i-th value (in the values tensor).
+  // (b) Indices can be a tensor of shape [NNZ], in which case the i-th value
+  // must be the linearized-index of the i-th value (in the values tensor).
+  // The linearized-index can be converted into an index tuple (k_1,...,k_rank)
+  // using the shape provided below.
+  // The indices must appear in ascending order without duplication.
+  // In the first format, the ordering is lexicographic-ordering:
+  // e.g., index-value [1,4] must appear before [2,1]
+  TensorProto indices = 2;
+
+  // The shape of the underlying dense-tensor: [dim_1, dim_2, ... dim_rank]
+  repeated int64 dims = 3;
+}
+
 // Defines a tensor shape. A dimension can be either an integer value
 // or a symbolic variable. A symbolic variable represents an unknown
 // dimension.
@@ -478,6 +513,14 @@ message TypeProto {
     TensorShapeProto shape = 2;
   }
 
+  message SparseTensor { 
+    // This field MUST NOT have the value of UNDEFINED 
+    // This field MUST have a valid TensorProto.DataType value
+    // This field MUST be present for this version of the IR. 
+    int32 elem_type = 1;
+    TensorShapeProto shape = 2;
+  }
+
 
   // repeated T
   message Sequence {
@@ -506,18 +549,12 @@ message TypeProto {
     // repeated TypeProto parameters = 3;
   }
 
-  message SparseTensor { 
-    // This field MUST NOT have the value of UNDEFINED 
-    // This field MUST have a valid TensorProto.DataType value
-    // This field MUST be present for this version of the IR. 
-    int32 elem_type = 1;
-    TensorShapeProto shape = 2;
-  }
-
 
   oneof value {
     // The type of a tensor.
     Tensor tensor_type = 1;
+
+    SparseTensor sparse_tensor_type = 8;
 
 
     // NOTE:  DNN-only implementations of ONNX MAY elect to not support non-tensor values
@@ -532,8 +569,6 @@ message TypeProto {
     Map map_type = 5;
 
     Opaque opaque_type = 7;
-
-    SparseTensor sparse_tensor_type = 8;
 
   }
 

--- a/onnxruntime/core/protobuf/onnx.in.proto
+++ b/onnxruntime/core/protobuf/onnx.in.proto
@@ -83,7 +83,13 @@ enum Version {
   // IR VERSION 5 published on March 18, 2019
   // - Add message TensorAnnotation.
   // - Add quantization annotation in GraphProto to map tensor with its scale and zero point quantization parameters.
-  IR_VERSION = 0x0000000000000005;
+  IR_VERSION_2019_3_18 = 0x0000000000000005;
+
+  // IR VERSION 6 published on <TBD>
+  // - Add support for sparse tensor constants stored in model.
+  //   - Add message SparseTensorProto
+  //   - Add sparse initializers
+  IR_VERSION = 0x0000000000000006;
 }
 
 // Attributes
@@ -103,12 +109,14 @@ message AttributeProto {
     STRING = 3;
     TENSOR = 4;
     GRAPH = 5;
+    SPARSE_TENSOR = 11;
 
     FLOATS = 6;
     INTS = 7;
     STRINGS = 8;
     TENSORS = 9;
     GRAPHS = 10;
+    SPARSE_TENSORS = 12;
   }
 
   // The name field MUST be present for this version of the IR.
@@ -137,6 +145,7 @@ message AttributeProto {
   optional bytes s = 4;               // UTF-8 string
   optional TensorProto t = 5;         // tensor value
   optional GraphProto g = 6;          // graph
+  optional SparseTensorProto sparse_tensor = 22;  // sparse tensor value
   // Do not use field below, it's deprecated.
   // optional ValueProto v = 12;         // value - subsumes everything but graph
 
@@ -145,6 +154,7 @@ message AttributeProto {
   repeated bytes strings = 9;         // list of UTF-8 strings
   repeated TensorProto tensors = 10;  // list of tensors
   repeated GraphProto graphs = 11;    // list of graph
+  repeated SparseTensorProto sparse_tensors = 23; // list of sparse tensors
 }
 
 // Defines information on value, including the name, the type, and
@@ -273,6 +283,9 @@ message GraphProto {
   // Each TensorProto entry must have a distinct name (within the list) that
   // MAY also appear in the input list.
   repeated TensorProto initializer = 5;
+
+  // Initializers (see above) stored in sparse format.
+  repeated SparseTensorProto sparse_initializer = 15;
 
   // A human-readable documentation for this graph. Markdown is allowed.
   optional string doc_string = 10;
@@ -443,6 +456,28 @@ message TensorProto {
   repeated uint64 uint64_data = 11 [packed = true];
 }
 
+// A serialized sparse-tensor value
+message SparseTensorProto {
+  // The sequence of non-default values are encoded as a tensor of shape [NNZ].
+  // The default-value is zero for numeric tensors, and empty-string for string tensors.
+  optional TensorProto values = 1;
+
+  // The indices of the non-default values, which may be stored in one of two formats.
+  // (a) Indices can be a tensor of shape [NNZ, rank] with the [i,j]-th value
+  // corresponding to the j-th index of the i-th value (in the values tensor).
+  // (b) Indices can be a tensor of shape [NNZ], in which case the i-th value
+  // must be the linearized-index of the i-th value (in the values tensor).
+  // The linearized-index can be converted into an index tuple (k_1,...,k_rank)
+  // using the shape provided below.
+  // The indices must appear in ascending order without duplication.
+  // In the first format, the ordering is lexicographic-ordering:
+  // e.g., index-value [1,4] must appear before [2,1]
+  optional TensorProto indices = 2;
+
+  // The shape of the underlying dense-tensor: [dim_1, dim_2, ... dim_rank]
+  repeated int64 dims = 3;
+}
+
 // Defines a tensor shape. A dimension can be either an integer value
 // or a symbolic variable. A symbolic variable represents an unknown
 // dimension.
@@ -471,6 +506,14 @@ message TypeProto {
     // This field MUST NOT have the value of UNDEFINED
     // This field MUST have a valid TensorProto.DataType value
     // This field MUST be present for this version of the IR.
+    optional int32 elem_type = 1;
+    optional TensorShapeProto shape = 2;
+  }
+
+  message SparseTensor { 
+    // This field MUST NOT have the value of UNDEFINED 
+    // This field MUST have a valid TensorProto.DataType value
+    // This field MUST be present for this version of the IR. 
     optional int32 elem_type = 1;
     optional TensorShapeProto shape = 2;
   }
@@ -504,19 +547,13 @@ message TypeProto {
     // repeated TypeProto parameters = 3;
   }
 
-  message SparseTensor { 
-    // This field MUST NOT have the value of UNDEFINED 
-    // This field MUST have a valid TensorProto.DataType value
-    // This field MUST be present for this version of the IR. 
-    optional int32 elem_type = 1;
-    optional TensorShapeProto shape = 2;
-  }
-
 // #endif
 
   oneof value {
     // The type of a tensor.
     Tensor tensor_type = 1;
+
+    SparseTensor sparse_tensor_type = 8;
 
 // #if ONNX-ML
 
@@ -532,8 +569,6 @@ message TypeProto {
     Map map_type = 5;
 
     Opaque opaque_type = 7;
-
-    SparseTensor sparse_tensor_type = 8;
 
 // #endif
   }

--- a/tools/ci_build/github/linux/docker/scripts/install_onnx.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_onnx.sh
@@ -13,7 +13,7 @@ version2tag=(5af210ca8a1c73aa6bae8754c9346ec54d0a756e-onnx123
              bae6333e149a59a3faa9c4d9c44974373dcf5256-onnx130
              9e55ace55aad1ada27516038dfbdc66a8a0763db-onnx141
              7d7bc83d29a328233d3e8affa4c4ea8b3e3599ef-onnx150
-             7d90796473295ca3cdf976ed772215c5980ad3e0-onnxtip)
+             eb139446590ad631b7e6b6782ddf620ac9240295-onnxtip)
 for v2t in ${version2tag[*]}; do
   onnx_version="$(cut -d'-' -f1<<<${v2t})"
   onnx_tag="$(cut -d'-' -f2<<<${v2t})"


### PR DESCRIPTION
- Update onnxruntime/protobuf/onnx.in.proto with changes for SparseTensor.
- Bump onnx to latest to include new opset 11 ops (det, scatternd, gathernd, etc.) 