### PR TITLE
MLAS: clang u8u8 GEMM fix

### DIFF
--- a/onnxruntime/core/mlas/lib/amd64/QgemmU8U8KernelAvx2.asm
+++ b/onnxruntime/core/mlas/lib/amd64/QgemmU8U8KernelAvx2.asm
@@ -215,7 +215,7 @@ ProcessNextRowM4:
         mov     rdx,rsi
         mov     rcx,rdi
         lea     rsi,[rsi+r8*4]              ; advance next matrix A by 4 rows
-        lea     rdi,[rdi+r11*(2*4)]         ; advance next matrix D by 4 rows
+        lea     rdi,[rdi+r11*8]             ; advance next matrix D by 4 rows
         mov     rbx,r10                     ; reload columns remaining
         sub     rbx,16
         jb      ProcessRemainingColumnsM4

--- a/onnxruntime/core/mlas/lib/x86_64/QgemmU8U8KernelAvx2.S
+++ b/onnxruntime/core/mlas/lib/x86_64/QgemmU8U8KernelAvx2.S
@@ -158,7 +158,7 @@ C_UNDERSCORE(MlasGemmU8U8CopyPackAAvx2):
         mov     rdx,rsi
         mov     rcx,rdi
         lea     rsi,[rsi+r10*4]             # advance next matrix A by 4 rows
-        lea     rdi,[rdi+r12*(2*4)]         # advance next matrix D by 4 rows
+        lea     rdi,[rdi+r12*8]             # advance next matrix D by 4 rows
         mov     rbx,r8                      # reload columns remaining
         sub     rbx,16
         jb      .LCopyPackA.ProcessRemainingColumnsM4


### PR DESCRIPTION
**Description**:
clang silently generates bad code for "lea rdi,[rdi+r12*(2*4)]": it drops the r12 piece and effectively generates "lea rdi,[rdi]". Fix the code to not be fancy and use "lea rdi,[rdi+r12*8]" instead. There are no other instances of this pattern.

This caused the Mac to break when running u8u8 models, but I replicated locally with clang 6.0 on my PC. The MatMulInteger operator unit tests use a combination of parameters that isn't affected by this bug, but onnxruntime_mlas_test hit it right away.
