### PR TITLE
Fix deadlocks in thread pools.

### DIFF
--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -61,7 +61,22 @@ class ThreadPool {
   Eigen::ThreadPool& GetHandler() { return impl_; }
 
  private:
-  Eigen::ThreadPool impl_;
+  class EigenExtendedBarrier : public Eigen::Barrier {
+  public:
+   EigenExtendedBarrier(unsigned int count) : Eigen::Barrier(count) {}
+   bool Done();
+  };
+
+  class EigenExtendedThreadPool : public Eigen::ThreadPool {
+  public:
+   EigenExtendedThreadPool(int num_threads, Eigen::StlThreadEnvironment env = Eigen::StlThreadEnvironment())
+       : Eigen::ThreadPool(num_threads, env) {}
+   EigenExtendedThreadPool(int num_threads, bool allow_spinning, Eigen::StlThreadEnvironment env = Eigen::StlThreadEnvironment())
+       : Eigen::ThreadPool(num_threads, allow_spinning, env) {}
+   void Help(int thread_id);
+  };
+
+  EigenExtendedThreadPool impl_;
 };
 
 }  // namespace concurrency

--- a/onnxruntime/core/framework/parallel_executor.cc
+++ b/onnxruntime/core/framework/parallel_executor.cc
@@ -25,8 +25,6 @@ ParallelExecutor::ParallelExecutor(const SessionState& session_state, const bool
   for (auto& node : graph_viewer->Nodes()) {
     node_refs_[node.Index()] = node.GetInputEdgesCount();
   }
-
-  executor_pool_ = std::make_unique<onnxruntime::concurrency::ThreadPool>("EXECUTOR", 32);
 }
 
 Status ParallelExecutor::Execute(const SessionState& session_state, const std::vector<int>& feed_mlvalue_idxs,
@@ -282,7 +280,7 @@ void ParallelExecutor::EnqueueNode(size_t p_node_index, const SessionState& sess
     out_standings_++;
   }
 
-  executor_pool_->Schedule([this, p_node_index, &session_state, &logger]() {
+  session_state.GetThreadPool()->Schedule([this, p_node_index, &session_state, &logger]() {
     auto create_exception_message = [p_node_index, &session_state](const std::exception* ex) {
       const auto* node = session_state.GetGraphViewer()->GetNode(p_node_index);
 

--- a/onnxruntime/core/framework/parallel_executor.h
+++ b/onnxruntime/core/framework/parallel_executor.h
@@ -61,7 +61,5 @@ class ParallelExecutor : public IExecutor {
   std::vector<Status> errors_;
 
   const bool& terminate_flag_;
-  // TODO: Temporary threadpool for the executor.  This is a costly way to handle the problem.
-  std::unique_ptr<onnxruntime::concurrency::ThreadPool> executor_pool_;
 };
 }  // namespace onnxruntime


### PR DESCRIPTION
We use ORT in a very resource constrained environment with a small number of threads available. For this reason we can't keep the static `ThreadPool` of size 32 in the `ParallelExecutor` ([here](https://github.com/microsoft/onnxruntime/blob/master/onnxruntime/core/framework/parallel_executor.cc#L29)). Also, going by the comments ([here](https://github.com/microsoft/onnxruntime/blob/master/onnxruntime/core/framework/parallel_executor.h#L64)) this seems not to be desired anyway. When we switch to using the thread pool in the `SessionState`, we run into deadlocks.

As far as I can see, the only problem with having a single, unified thread pool are deadlocks caused by the barriers in `ThreadPool::ParallelFor` and `ThreadPool::ParallelForRange`. When called from within a thread that belongs to the same `TheadPool`, deadlocks will occur because all threads in the pool will wait for others to finish their tasks. Thus, they need to continue working on tasks in the queue instead of just waiting at the barrier. (In our case, those functions were called by MLAS.)

I fixed this problem by adding a `Help` function to `Eigen::ThreadPool` in a derived class and a `Done` property to `Eigen::Barrier`, so that the threads can keep working on Tasks while waiting for the barrier. However, this required me to change `Eigen::ThreadPool` and `Eigen::Barrier` so that I have access to their internal state. In both of them I replaced (a single occurrence of) `private:` by `protected:`. I couldn't find a way to do this without modifying Eigen.

What's the best way to handle this? Is such a minimal modification of Eigen acceptable or should we find a different solution to this problem?

@letmaik @snnn @shschaefer @jessebenson