### PR TITLE
Fix error message in Cast op

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -352,7 +352,7 @@ Status Cast<MLFloat16>::Compute(OpKernelContext* context) const {
       st = CastFloat16Data<MLFloat16, int8_t>(X, Y, shape, context);
       break;
     case TensorProto_DataType_STRING:
-      ORT_THROW("Casting to and from strings is not supported yet."); /*break;*/
+      ORT_THROW("Casting from 'float16' to 'string' is not supported yet."); /*break;*/
     case TensorProto_DataType_UNDEFINED:
       ORT_THROW("Cast op must have 'to' argument of type DataType"); /*break;*/
     default:


### PR DESCRIPTION
**Description**: There was an incorrect error message which indicated that ORT didn't support casting to/from strings when in reality ORT doesn't support casting from 'float16' to 'string'. This change fixes this misleading message.

**Motivation and Context**
Takeaway from #1791 