### PR TITLE
bias quantization

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -14,125 +14,10 @@ import onnx
 import onnxruntime
 from onnx import helper, TensorProto
 from quantize import quantize, QuantizationMode
-#from smooth_average import smooth_average
 
 import re
 import subprocess
 import json
-
-# Originally from process_images_with_debug_op.bat
-def preprocess_images_with_debug_op(model_file, image_files):
-    """
-    Carries out inference in an instrumented model that can log
-    outputs of quantizable operators *or* using an unmodified model
-    but through a suitably instrumented inference engine that can
-    log outputs of quantizable operators.
-    """
-    for img in image_files:
-        # FIXME: Can we do this asynchronously?
-        subprocess.call([r'debug-operator-sample.exe', model_file, img])
-
-def cleanup_images_from_debug_op_run():
-    # TODO -- implement cleanup phase
-    pass
-
-def calibrate_loop(image_directory):
-    """
-    Loops through the images in `image_directory` and collects
-    distribution of outputs on relevant nodes for each inference.
-    """
-    logs_directory = os.getcwd() # log files location  # TODO -- Make this an argument?
-    # image_directory = os.path.join(logs_directory , "images") # dataset images location
-    # loop through all the images in a directory
-    for image in os.listdir(image_directory):
-        image_file = os.path.join(image_directory, image)
-
-        #call the batch file to process the image[i] in the location and generate output log files
-        # --> TODO <--
-        preprocess_images_with_debug_op(image_file)
-
-    sfacs, zpts = process_logfiles(logs_directory)
-    # quantized_model = quantize(model, per_channel=False, nbits=8, quantization_mode=QuantizationMode.QLinearOps_Dynamic,
-# 		asymmetric_input_types=False, input_quantization_params=sfacs,
-# 		output_quantization_params=zpts)
-
-def process_logfiles(logs_directory):
-    """
-    Open each log file in :param logs_directory: and read through it line
-    by line and ignore 'labels' file
-    """
-    rx_dict = {
-        'dimensions': re.compile(r'dimensions: (.*)\n'),
-        'data type': re.compile(r'data type: (\d+)\n'),
-        'data': re.compile(r'(?<=data:).*'),
-    }
-
-    def _parse_line(line):
-        """
-        Do a regex search against all defined regexes and
-        return the key and match result of the first matching regex
-        """
-        for key, rx in rx_dict.items():
-            match = rx.search(line)
-            if match:
-                return key, match
-        # if there are no matches
-        return None, None
-
-    data = []  # temp empty list to collect the data
-    spaces_removed_data = [] # temp empty list to collect float outputs
-    scale = 0.05
-    zero_point = 0
-
-    maxvalue = {} # dictionary to store max values
-    minvalue = {} # dictionary to store min values
-
-    if not(os.path.exists(logs_directory)):
-        raise ValueError(f"Log directory ${logs_directory} not found!")
-
-    for filename in os.listdir(logs_directory):
-        if (not filename.endswith(".txt")) or filename.startswith("labels.txt"):
-            next
-
-        # FIXME -- maybe log this
-        # print(f"Processing: {filename}.")
-
-        with open(os.path.join(logs_directory, filename), 'r') as file_object:
-            spaces_removed_data = []
-            for line in file_object:
-                # at each line check for a match with a regex
-                key, match = _parse_line(line)
-                if key != 'data':
-                    continue
-                data = match.group(0)
-                for i in data.split(','):
-                    try:
-                        if i != '':
-                            spaces_removed_data.append(float(i.strip()))
-                    except ValueError:
-                        pass  # Ignore errors
-
-                # Add min and max values to the dictionary
-                fname_key = filename.split(".")[0]
-                if (fname_key not in maxvalue) or (max(spaces_removed_data) > maxvalue[fname_key]):
-                    maxvalue[fname_key] = max(spaces_removed_data)
-                if (fname_key not in minvalue) or (min(spaces_removed_data) < minvalue[filename.split(".")[0]]):
-                    minvalue[fname_key] = min(spaces_removed_data)
-
-    #clean up the log files to repeat steps for the next image
-    cleanup_images_from_debug_op_run()
-
-    scalefacs = {}
-    zpoints = {}
-
-    for conv_output in maxvalue:
-        scalefacs[conv_output] = (maxvalue[conv_output] - minvalue[conv_output]) / 255 if minvalue[conv_output] !=maxvalue[conv_output] else 1
-        zpoints[conv_output] = round((0 - minvalue[conv_output]) / scale)
-
-    return (scalefacs, zpoints)
-
-# Adding ability to record intermediate graph outputs
-selected_types = ['Conv', 'MatMul'] # node types to extend
 
 def augment_graph(model):
     '''
@@ -274,7 +159,7 @@ def calculate_scale_zeropoint(node, next_node, rmin, rmax):
     zp_and_scale.append(scale)
     return zp_and_scale
 
-def calculate_output_quantization_params(model, nbits=8, output_quantization_thresholds=None):
+def calculate_quantization_params(model, nbits=8, quantization_thresholds=None):
     '''
         Given a model and quantization thresholds, calculates the quantization params.
     :param model: ModelProto to quantize
@@ -283,9 +168,9 @@ def calculate_output_quantization_params(model, nbits=8, output_quantization_thr
         False: Weights and inputs/activations are quantized into unsigned integers.
     :param output_quantization_thresholds:
         Dictionary specifying the min and max values for outputs of conv and matmul nodes.
-        The output_quantization_thresholds should be specified in the following format:
+        The quantization_thresholds should be specified in the following format:
             {
-                "output_name": [min, max]
+                "param_name": [min, max]
             }
         example:
             {
@@ -295,25 +180,22 @@ def calculate_output_quantization_params(model, nbits=8, output_quantization_thr
     :return: Dictionary containing the zero point and scale values for outputs of conv and matmul nodes.
         The dictionary format is
             {
-                "output_name": [min, max]
+                "param_name": [min, max]
             }
     '''
     if nbits != 8:
         raise ValueError('Unknown value for nbits. only 8 bit quantization is currently supported')
 
-    if output_quantization_thresholds == None:
+    if quantization_thresholds == None:
         raise ValueError('output quantization threshold is required to calculate quantization thresholds')
 
     quantization_params = {}
     for index, node in enumerate(model.graph.node):
-        #print('Processing node ' + str(model.graph.node[index]))
         node_output_name = node.output[0]
-        if node_output_name in output_quantization_thresholds:
-            node_thresholds = output_quantization_thresholds[node_output_name]
+        if node_output_name in quantization_thresholds:
+            node_thresholds = quantization_thresholds[node_output_name]
             node_params = calculate_scale_zeropoint(node, model.graph.node[index+1], node_thresholds[0], node_thresholds[1])
             quantization_params[node_output_name] = node_params
-        #else:
-            #print('Quantization threshold for node output not present: ' + node_output_name)
 
     return quantization_params
 
@@ -343,11 +225,125 @@ def main():
     # Generating inputs for quantization
     inputs = load_batch(images_folder, height, width, size_limit)
     dict_for_quantization = get_intermediate_outputs(model_path, session, inputs, calib_mode)
-    output_quantization_params = calculate_output_quantization_params(model, output_quantization_thresholds=dict_for_quantization)
-    calibrated_quantized_model = quantize(onnx.load(model_path), quantization_mode=QuantizationMode.QLinearOps, output_quantization_params=output_quantization_params)
+    quantization_params_dict = calculate_quantization_params(model, quantization_thresholds=dict_for_quantization)
+    calibrated_quantized_model = quantize(onnx.load(model_path), quantization_mode=QuantizationMode.QLinearOps, quantization_params=quantization_params_dict)
     onnx.save(calibrated_quantized_model, 'calibrated_quantized_model.onnx')
 
     print("Calibrated, quantized model saved.")
+
+# Originally from process_images_with_debug_op.bat
+def preprocess_images_with_debug_op(model_file, image_files):
+    """
+    Carries out inference in an instrumented model that can log
+    outputs of quantizable operators *or* using an unmodified model
+    but through a suitably instrumented inference engine that can
+    log outputs of quantizable operators.
+    """
+    for img in image_files:
+        # FIXME: Can we do this asynchronously?
+        subprocess.call([r'debug-operator-sample.exe', model_file, img])
+
+def cleanup_images_from_debug_op_run():
+    # TODO -- implement cleanup phase
+    pass
+
+def calibrate_loop(image_directory):
+    """
+    Loops through the images in `image_directory` and collects
+    distribution of outputs on relevant nodes for each inference.
+    """
+    logs_directory = os.getcwd() # log files location  # TODO -- Make this an argument?
+    # image_directory = os.path.join(logs_directory , "images") # dataset images location
+    # loop through all the images in a directory
+    for image in os.listdir(image_directory):
+        image_file = os.path.join(image_directory, image)
+
+        #call the batch file to process the image[i] in the location and generate output log files
+        # --> TODO <--
+        preprocess_images_with_debug_op(image_file)
+
+    sfacs, zpts = process_logfiles(logs_directory)
+    # quantized_model = quantize(model, per_channel=False, nbits=8, quantization_mode=QuantizationMode.QLinearOps_Dynamic,
+# 		asymmetric_input_types=False, input_quantization_params=sfacs,
+# 		output_quantization_params=zpts)
+
+def process_logfiles(logs_directory):
+    """
+    Open each log file in :param logs_directory: and read through it line
+    by line and ignore 'labels' file
+    """
+    rx_dict = {
+        'dimensions': re.compile(r'dimensions: (.*)\n'),
+        'data type': re.compile(r'data type: (\d+)\n'),
+        'data': re.compile(r'(?<=data:).*'),
+    }
+
+    def _parse_line(line):
+        """
+        Do a regex search against all defined regexes and
+        return the key and match result of the first matching regex
+        """
+        for key, rx in rx_dict.items():
+            match = rx.search(line)
+            if match:
+                return key, match
+        # if there are no matches
+        return None, None
+
+    data = []  # temp empty list to collect the data
+    spaces_removed_data = [] # temp empty list to collect float outputs
+    scale = 0.05
+    zero_point = 0
+
+    maxvalue = {} # dictionary to store max values
+    minvalue = {} # dictionary to store min values
+
+    if not(os.path.exists(logs_directory)):
+        raise ValueError(f"Log directory ${logs_directory} not found!")
+
+    for filename in os.listdir(logs_directory):
+        if (not filename.endswith(".txt")) or filename.startswith("labels.txt"):
+            next
+
+        # FIXME -- maybe log this
+        # print(f"Processing: {filename}.")
+
+        with open(os.path.join(logs_directory, filename), 'r') as file_object:
+            spaces_removed_data = []
+            for line in file_object:
+                # at each line check for a match with a regex
+                key, match = _parse_line(line)
+                if key != 'data':
+                    continue
+                data = match.group(0)
+                for i in data.split(','):
+                    try:
+                        if i != '':
+                            spaces_removed_data.append(float(i.strip()))
+                    except ValueError:
+                        pass  # Ignore errors
+
+                # Add min and max values to the dictionary
+                fname_key = filename.split(".")[0]
+                if (fname_key not in maxvalue) or (max(spaces_removed_data) > maxvalue[fname_key]):
+                    maxvalue[fname_key] = max(spaces_removed_data)
+                if (fname_key not in minvalue) or (min(spaces_removed_data) < minvalue[filename.split(".")[0]]):
+                    minvalue[fname_key] = min(spaces_removed_data)
+
+    #clean up the log files to repeat steps for the next image
+    cleanup_images_from_debug_op_run()
+
+    scalefacs = {}
+    zpoints = {}
+
+    for conv_output in maxvalue:
+        scalefacs[conv_output] = (maxvalue[conv_output] - minvalue[conv_output]) / 255 if minvalue[conv_output] !=maxvalue[conv_output] else 1
+        zpoints[conv_output] = round((0 - minvalue[conv_output]) / scale)
+
+    return (scalefacs, zpoints)
+
+# Adding ability to record intermediate graph outputs
+selected_types = ['Conv', 'MatMul'] # node types to extend
 
 if __name__ == '__main__':
     main()

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -41,24 +41,8 @@ class QuantizationMode():
     IntegerOps = 0
     QLinearOps = 1
 
-# Data Quantization mode
-# Linear_NonScaled: Quantize data using linear, non scaled tranformation.
-# Linear_Scaled: Quantize data using linear, scaled transformation.
-class DataQuantizationMode():
-    Linear_NonScaled = 0
-    Linear_Scaled = 1
-
-    @staticmethod
-    def mode_for_data_type(data_type):
-        return DataQuantizationMode.Linear_Scaled if data_type == onnx_proto.TensorProto.INT8\
-            else DataQuantizationMode.Linear_NonScaled
-
-
 quantization_modes = [getattr(QuantizationMode, attr) for attr in dir(QuantizationMode)\
     if not callable(getattr(QuantizationMode, attr)) and not attr.startswith("__")]
-data_quantization_modes = [getattr(DataQuantizationMode, attr) for attr in dir(DataQuantizationMode)\
-    if not callable(getattr(DataQuantizationMode, attr)) and not attr.startswith("__")]
-
 
 class QuantizedInitializer:
     '''
@@ -96,15 +80,15 @@ class QuantizedValue:
         self.axis = axis
         self.qType = qType
 
-def quantize_data(data, quantize_range, mode=DataQuantizationMode.Linear_NonScaled):
+def quantize_data(data, quantize_range, qType):
     '''
         :parameter quantize_range: list of data to weight pack.
-        :parameter mode: mode to quantize data of type DataQuantizationMode
+        :parameter qType: data type to quantize to. Supported types UINT8 and INT8
         :return: minimum, maximum, zero point, scale, and quantized weights
 
         To pack weights, we compute a linear transformation
-            - in non-scaled mode, from [rmin, rmax] -> [0, 2^{b-1}] and
-            - in scaled mode, from [-m , m] -> [-(2^{b-1}-1), 2^{b-1}-1] where
+            - when data type == uint8 mode, from [rmin, rmax] -> [0, 2^{b-1}] and
+            - when data type == int8, from [-m , m] -> [-(2^{b-1}-1), 2^{b-1}-1] where
                 m = max(abs(rmin), abs(rmax))
 
         and add necessary intermediate nodes to trasnform quantized weight to full weight using the equation
@@ -117,15 +101,18 @@ def quantize_data(data, quantize_range, mode=DataQuantizationMode.Linear_NonScal
     rmin = min(min(data), 0)
     rmax = max(max(data), 0)
 
-    if mode == DataQuantizationMode.Linear_Scaled:
+    if qType == onnx_proto.TensorProto.INT8:
         max_range = max(abs(rmin), abs(rmax))
         scale = (float(max_range)*2) / quantize_range
         zero_point = 0
         quantized_data = (np.asarray(data) / scale).round().astype('b') #signed byte type
-    else:
+    elif qType == onnx_proto.TensorProto.UINT8:
         scale = (float(rmax) - rmin) / quantize_range if rmin != rmax else 1
         zero_point = round((0 - rmin) / scale) # round to nearest integer
         quantized_data = ((np.asarray(data) / scale).round() + zero_point).astype('B') # unsigned byte type
+    else:
+        raise ValueError("Unexpected data type {} requested. Only INT8 and UINT8 are supported.")
+
     return rmin, rmax, zero_point, scale, quantized_data
 
 
@@ -243,16 +230,15 @@ def _find_nodes_using_initializer(graph, initializer):
 
 class ONNXQuantizer:
     def __init__(self, model, per_channel, mode, static, fuse_dynamic_quant, weight_qType, input_qType,
-            input_quantization_params, output_quantization_params, nodes_to_quantize):
+            quantization_params, nodes_to_quantize):
         self.model = model
-        self.per_channel = per_channel # weight-pack per channel
-        self.weight_qType = weight_qType  # quantize data type
+        self.per_channel = per_channel # weight-pack per channel        
         self.mode = mode # QuantizationMode.Value
         self.static = static # use static quantization for inputs.
         self.fuse_dynamic_quant = fuse_dynamic_quant
         self.input_qType = input_qType # quantize input type
-        self.input_quantization_params = input_quantization_params # zero point and scale values for node inputs.
-        self.output_quantization_params = output_quantization_params # zero point and scale values for node outputs.
+        self.weight_qType = weight_qType  # quantize data type
+        self.quantization_params = quantization_params
         self.nodes_to_quantize = nodes_to_quantize # specific nodes to quantize
 
         if not self.mode in quantization_modes:
@@ -260,11 +246,11 @@ class ONNXQuantizer:
 
         # QuantizeRange tensor name and zero tensor name for scale and zero point calculation.
         # Used when static is False
-        self.fixed_qrange_non_scaled_name = "fixed_quantization_range_non_scaled"
-        self.fixed_qrange_scaled_name = "fixed_quantization_range_scaled"
-        # In non scaled mode, to compute zero point, we subtract rmin from 0 (represented by fixed_zero_name tensor)
+        self.fixed_qrange_uint8_name = "fixed_quantization_range_uint8"
+        self.fixed_qrange_int8_name = "fixed_quantization_range_int8"
+        # For uint8 data-type, to compute zero point, we subtract rmin from 0 (represented by fixed_zero_name tensor)
         self.fixed_zero_name = "fixed_zero"
-        # In scaled mode, zero point is always zero (respresented by fixed_zero_point_name tensor)
+        # For int8 data-type, zero point is always zero (respresented by fixed_zero_point_name tensor)
         self.fixed_zero_zp_name = "fixed_zero_zp"
 
         # List of quantized weights
@@ -383,7 +369,7 @@ class ONNXQuantizer:
         '''
         weights_data = self.find_weight_data(initializer)
         rmin, rmax, zero_point, scale, quantized_weights_data = quantize_data(weights_data.flatten().tolist(),
-            _get_qrange_for_qType(qType), mode=DataQuantizationMode.mode_for_data_type(qType))
+            _get_qrange_for_qType(qType), qType)
         weight = QuantizedInitializer(initializer.name, initializer, [rmin], [rmax], [zero_point], [scale],
                         weights_data, quantized_weights_data, axis=None, qType=qType)
         
@@ -417,7 +403,7 @@ class ONNXQuantizer:
             # for each channel, compute quantization data. Assuming (M x C/group x kH x kW)
             per_channel_data = np_data[i,:,:,:].flatten()
             rmin, rmax, zero_point, scale, quantized_per_channel_data = quantize_data(per_channel_data.flatten().tolist(),
-                _get_qrange_for_qType(qType), mode=DataQuantizationMode.mode_for_data_type(qType))
+                _get_qrange_for_qType(qType), qType)
             rmin_list.append(rmin)
             rmax_list.append(rmax)
             zero_point_list.append(zero_point)
@@ -450,16 +436,14 @@ class ONNXQuantizer:
             parameter qType: type to quantize to.
             return: scale_name, zero_point_name, scale_shape, zero_point_shape.
         '''
-        mode = DataQuantizationMode.mode_for_data_type(qType)
-        if mode == DataQuantizationMode.Linear_Scaled:
-            return self._get_dynamic_input_quantization_params_scaled(input_name, nodes_list)
+        if qType == onnx_proto.TensorProto.INT8:
+            return self._get_dynamic_input_quantization_params_int8(input_name, nodes_list)
 
-        return self._get_dynamic_input_quantization_params_non_scaled(input_name, nodes_list)
+        return self._get_dynamic_input_quantization_params_uint8(input_name, nodes_list)
 
-    def _get_dynamic_input_quantization_params_scaled(self, input_name, nodes_list):
+    def _get_dynamic_input_quantization_params_int8(self, input_name, nodes_list):
         '''
-        Create nodes for dynamic quantization of input and add them to nodes_list
-        in DataQuantizationMode.Linear_Scaled
+        Create nodes for dynamic quantization of input to nit8 and add them to nodes_list        
             parameter input_name: Name of the input.
             parameter nodes_list: new nodes are appended to this list.
             return: scale_name, zero_point_name, scale_shape, zero_point_shape.
@@ -496,10 +480,10 @@ class ONNXQuantizer:
             [abs_max_name + ":0"], abs_max_name)
         nodes_list.append(abs_max_node)
         #   and divide by (quantize_range/2.0) which will be equal to max(...)*2.0/quantize_range
-        _add_initializer_if_not_present(self.model.graph, self.fixed_qrange_scaled_name,
+        _add_initializer_if_not_present(self.model.graph, self.fixed_qrange_int8_name,
             [_get_qrange_for_qType(qType)/2.0], [], onnx_proto.TensorProto.FLOAT)
         scale_div_name = input_name + "scale_Div"
-        scale_div_node = onnx.helper.make_node("Div", [abs_max_node.output[0], self.fixed_qrange_scaled_name],
+        scale_div_node = onnx.helper.make_node("Div", [abs_max_node.output[0], self.fixed_qrange_int8_name],
             [input_scale_name], scale_div_name)
         nodes_list.append(scale_div_node)
 
@@ -509,10 +493,9 @@ class ONNXQuantizer:
 
         return input_scale_name, self.fixed_zero_zp_name, [], []
 
-    def _get_dynamic_input_quantization_params_non_scaled(self, input_name, nodes_list):
+    def _get_dynamic_input_quantization_params_uint8(self, input_name, nodes_list):
         '''
-        Create nodes for dynamic quantization of input and add them to nodes_list
-        in DataQuantizationMode.Linear_NonScaled
+        Create nodes for dynamic quantization of input to uint8 and add them to nodes_list
             parameter input_name: Name of the input.
             parameter nodes_list: new nodes are appended to this list.
             return: scale_name, zero_point_name, scale_shape, zero_point_shape.
@@ -533,7 +516,7 @@ class ONNXQuantizer:
         nodes_list.append(reduce_max_node)
 
         # Add tensors for quantize range and zero value.
-        _add_initializer_if_not_present(self.model.graph, self.fixed_qrange_non_scaled_name,
+        _add_initializer_if_not_present(self.model.graph, self.fixed_qrange_uint8_name,
             [_get_qrange_for_qType(qType)], [], onnx_proto.TensorProto.FLOAT)
         _add_initializer_if_not_present(self.model.graph, self.fixed_zero_name,
             [0.0], [], onnx_proto.TensorProto.FLOAT)
@@ -546,7 +529,7 @@ class ONNXQuantizer:
         nodes_list.append(scale_sub_node)
         #   and divide by quantize range
         scale_div_name = input_name + "_scale_Div"
-        scale_div_node = onnx.helper.make_node("Div", [scale_sub_node.output[0], self.fixed_qrange_non_scaled_name],
+        scale_div_node = onnx.helper.make_node("Div", [scale_sub_node.output[0], self.fixed_qrange_uint8_name],
             [input_scale_name], scale_div_name)
         nodes_list.append(scale_div_node)
 
@@ -574,67 +557,17 @@ class ONNXQuantizer:
 
         return input_scale_name, input_zp_name, [], []
 
-    def _get_static_input_quantization_params(self, input_name, qType):
-        '''
-        Create initializers and inputs in the graph for static quantization of input.
-
-        Zero point and scale values are obtained from self.input_quantization_params if specified.
-        ValueError is thrown otherwise.
-
-            parameter input_name: Name of the input.
-            parameter qType: type to quantize to.
-            return: scale_name, zero_point_name, scale_shape, zero_point_shape.
-        '''
-        if self.input_quantization_params is None or input_name not in self.input_quantization_params:
-            raise ValueError("Quantization parameters are not specified for input {}.".format(input_name))
-        params = self.input_quantization_params[input_name]
-        if params is None or len(params) != 2:
-            raise ValueError("Quantization parameters should contain zero point and scale. "
-                "Specified values for input {}: {}".format(input_name, params))
-
-        if not np.isscalar(params[0]):
-            raise ValueError("Zero point for input {} should be a scalar value. Value specified: {}".format(
-                input_name, params[0]))
-        if not np.isscalar(params[1]):
-            raise ValueError("Scale for input {} should be a scalar value. Value specified: {}".format(
-                input_name, params[1]))
-
-        zero_point_values = [params[0].item()]
-        zero_point_shape = []
-        zero_point_name = input_name + "_zero_point"
-
-        zero_point_type = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[params[0].dtype]
-        if zero_point_type != qType:
-            raise ValueError("Zero point and input data types should be the same. "
-                "Zero point for input {} is specified as {}, but input is being quantized to {}."
-                .format(input_name, params[0].dtype, onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[qType]))
-
-        scale_values = [params[1].item()]
-        scale_shape = []
-        scale_name = input_name + "_scale"
-
-        # Add initializers
-        _add_initializer_if_not_present(self.model.graph, zero_point_name, zero_point_values,
-            zero_point_shape, qType)
-        _add_initializer_if_not_present(self.model.graph, scale_name, scale_values,
-            scale_shape, onnx_proto.TensorProto.FLOAT)
-
-        return scale_name, zero_point_name, scale_shape, zero_point_shape
-
-    def _get_output_quantization_params(self, output_name):
+    def _get_quantization_params(self, param_name):
         '''
         Create initializers and inputs in the graph for zero point and scale of output.
-        Used when mode is QuantizationMode.QLinearOps.
-
-        Zero point and scale values are obtained from self.output_quantization_params if specified.
-        ValueError is thrown otherwise.
+        Zero point and scale values are obtained from self.quantization_params if specified.
 
             parameter output_name: Name of the output.
             return: scale_name, zero_point_name, scale_shape, zero_point_shape.
-        '''
-        if self.output_quantization_params is None or output_name not in self.output_quantization_params:            
-            raise ValueError("Quantization parameters are not specified for output {}.".format(output_name))
-        params = self.output_quantization_params[output_name]
+        '''        
+        if self.quantization_params is None or param_name not in self.quantization_params:
+            return False, "", "", "", ""
+        params = self.quantization_params[param_name]
         if params is None or len(params) != 2:
             raise ValueError("Quantization parameters should contain zero point and scale. "
                 "Specified values for output {}: {}".format(output_name, params))
@@ -648,12 +581,12 @@ class ONNXQuantizer:
 
         zero_point_values = [params[0].item()]
         zero_point_shape = []
-        zero_point_name = output_name + "_zero_point"
+        zero_point_name = param_name + "_zero_point"
         zero_point_type = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[params[0].dtype]
 
         scale_values = [params[1].item()]
         scale_shape = []
-        scale_name = output_name + "_scale"
+        scale_name = param_name + "_scale"
 
         # Add initializers
         _add_initializer_if_not_present(self.model.graph, zero_point_name, zero_point_values, zero_point_shape,
@@ -661,7 +594,7 @@ class ONNXQuantizer:
         _add_initializer_if_not_present(self.model.graph, scale_name, scale_values, scale_shape,
             onnx_proto.TensorProto.FLOAT)
 
-        return scale_name, zero_point_name, scale_shape, zero_point_shape
+        return True, scale_name, zero_point_name, scale_shape, zero_point_shape
 
     def _get_quantize_input_nodes(self, node, input_index, qType):
         '''
@@ -675,11 +608,15 @@ class ONNXQuantizer:
             return: List of newly created nodes in NodeProto format.
         '''
         input_name = node.input[input_index]
-        output_name = input_name + "_quantized"        
+        output_name = input_name + "_quantized"
+
+        data_found, scale_name, zp_name, scale_shape, zp_shape = \
+                self._get_quantization_params(input_name)
 
         if self.static:
-            scale_name, zp_name, scale_shape, zp_shape = \
-                self._get_static_input_quantization_params(input_name, qType)
+            if data_found == False:
+                raise ValueError("Quantization parameters are not specified for param {}."
+                "In static mode quantization params for inputs and outputs of odes to be quantized are required.".format(input_name))
 
             qlinear_node = onnx.helper.make_node("QuantizeLinear", [input_name, scale_name, zp_name], 
                 [output_name], input_name + "_QuantizeLinear")
@@ -687,26 +624,26 @@ class ONNXQuantizer:
             return [qlinear_node]
             
         else:
-            if self.fuse_dynamic_quant and qType == onnx_proto.TensorProto.UINT8:
-                scale_name = input_name + "_scale"
-                zeropoint_name = input_name + "_zero_point"
-                qlinear_node = onnx.helper.make_node("DynamicQuantizeLinear", [input_name],
-                    [output_name, scale_name, zeropoint_name], input_name + "_QuantizeLinear")
-                return [qlinear_node]
-                
-            else:
-                nodes = []
-                scale_name, zp_name, scale_shape, zp_shape = \
-                    self._get_dynamic_input_quantization_params(input_name, nodes, qType)
+            if data_found == True:
                 qlinear_node = onnx.helper.make_node("QuantizeLinear", [input_name, scale_name, zp_name], 
                     [output_name], input_name + "_QuantizeLinear")
+            else:
+                # Scale and Zero Points not available for this input. Add nodes to dynamically compute it
+                if self.fuse_dynamic_quant and qType == onnx_proto.TensorProto.UINT8:
+                    scale_name = input_name + "_scale"
+                    zeropoint_name = input_name + "_zero_point"
+                    qlinear_node = onnx.helper.make_node("DynamicQuantizeLinear", [input_name],
+                        [output_name, scale_name, zeropoint_name], input_name + "_QuantizeLinear")
+                    return [qlinear_node]
+                
+                else:
+                    nodes = []
+                    scale_name, zp_name, scale_shape, zp_shape = \
+                        self._get_dynamic_input_quantization_params(input_name, nodes, qType)
+                    qlinear_node = onnx.helper.make_node("QuantizeLinear", [input_name, scale_name, zp_name], 
+                        [output_name], input_name + "_QuantizeLinear")
             
-                return nodes + [qlinear_node]
-
-        # Add QuantizeLinear Node        
-        qlinear_node = onnx.helper.make_node("QuantizeLinear", [input_name, scale_name, zp_name],
-            [output_name], input_name + "_QuantizeLinear")
-        return nodes + [qlinear_node]    
+                    return nodes + [qlinear_node]           
 
     def _update_unsupported_nodes_using_weight(self, weight, new_nodes_list):        
         '''Find all nodes using a weight that do not support quantization and
@@ -739,7 +676,91 @@ class ONNXQuantizer:
 
         return nodes_list
 
-    def _quantize_inputs(self, node, indices, weight_index, new_nodes_list):
+    def _dynamic_quantize_bias(self, input_name, weight_scale_name, bias_name, quantized_bias_name, new_node_list):
+        '''
+        Adds series of nodes required to quantize the bias dynamically.
+            parameter input_name: Input name
+            parameter weight_scale_name: Weight scale.
+            parameter bias_scale_name: Bias to quantize.
+            parameter quantied_bias_name: Output name to use for quantized bias.
+        '''
+        qType = onnx_proto.TensorProto.INT32
+        
+        input_scale_name = input_name + "_scale"
+        bias_scale_node = onnx.helper.make_node("Mul", [input_scale_name, weight_scale_name], [bias_name + "_scale"], bias_name + "_scale_node")
+        new_node_list.append(bias_scale_node)
+
+        quantize_bias_node = onnx.helper.make_node("Div", [bias_name, bias_scale_node.output[0]],
+            [bias_name + "_tmp_quant:0"], bias_name + "_tmp_qaunt")
+        new_node_list.append(quantize_bias_node)
+
+        bias_rounded_node = onnx.helper.make_node("Floor", quantize_bias_node.output,
+            [bias_name + "_quant_rounded:0"], bias_name + "_quant_rounded")
+        new_node_list.append(bias_rounded_node)
+        
+        bias_cast_node = onnx.helper.make_node("Cast", bias_rounded_node.output,
+            [quantized_bias_name], quantized_bias_name + "_node", to=qType)
+        new_node_list.append(bias_cast_node)
+        
+        return 
+
+
+    def _quantize_bias(self, node, new_node_list):
+        '''
+        Quantized the bias. Zero Point == 0 and Scale == Input_Scale * Weight_Scale 
+        '''
+
+         # get scale for weight 
+        weight_scale_name = self.quantized_value_map[node.input[1]].scale_name
+        weight_initializer = _find_by_name(weight_scale_name, self.model.graph.initializer)
+        weight_scale = self.find_weight_data(weight_initializer)  
+
+        # get bias
+        bias_name = node.input[2]
+        bias_initializer = _find_by_name(bias_name, self.model.graph.initializer)
+        bias_data = self.find_weight_data(bias_initializer)
+        quantized_bias_name = bias_name + "_quantized"      
+
+        # input scale is not provided and this input is dynamically quantized so it is not pre-computed at this point
+        # so resort to dynamic quantization for bias
+        if node.input[0] not in self.quantization_params and node.input[0] not in self.quantized_value_map:
+            self._dynamic_quantize_bias(node.input[0], weight_scale_name, bias_name, quantized_bias_name, new_node_list)
+        else:
+            # get scale for input
+            input_scale_name = self.quantized_value_map[node.input[0]].scale_name
+            inputscale_initializer = _find_by_name(input_scale_name, self.model.graph.initializer)
+            input_scale = self.find_weight_data(inputscale_initializer)        
+
+            # calcuate scale for bias
+            bias_scale_name = node.input[2] + "_scale"
+            bias_scale = input_scale * weight_scale
+            print(bias_scale)
+     
+            # quantize bias
+            quantized_data = (np.asarray(bias_data) / bias_scale).round().astype(np.int32)
+            print(quantized_data)
+
+            #update bias initializer        
+            bias_np_data = np.asarray(quantized_data, dtype=np.int32).reshape(bias_initializer.dims)
+            packed_bias_initializer = onnx.numpy_helper.from_array(bias_np_data, quantized_bias_name)
+            self.model.graph.initializer.extend([packed_bias_initializer])
+
+            bias_value_info = onnx.helper.make_tensor_value_info(quantized_bias_name, onnx_proto.TensorProto.INT32, bias_initializer.dims)
+            self.model.graph.input.extend([bias_value_info])
+
+            # log entries for this quantized bias value
+            quantized_bias_entry = QuantizedInitializer(bias_name, bias_initializer, [0], [0], [0], [bias_scale],
+                            bias_data, quantized_data, qType=onnx_proto.TensorProto.INT32)
+            self._quantized_weights.append(quantized_bias_entry)
+        
+            assert(bias_name not in self.quantized_value_map)
+            quantized_value = QuantizedValue(bias_name, quantized_bias_name, "", "", QuantizedValueType.Initializer, None, onnx_proto.TensorProto.INT32)
+            self.quantized_value_map[bias_name] = quantized_value
+
+        return quantized_bias_name
+
+
+    def _quantize_inputs(self, node, indices, new_nodes_list):
         '''
         Given a node, this function quantizes the inputs as follows:
             - If input is a initializer, quantize the initializer data, replace old initializer
@@ -748,8 +769,6 @@ class ONNXQuantizer:
 
             parameter node: node being quantized in NodeProto format.
             parameter indices: input indices to quantize.
-            parameter weight_index: index of weight input.
-                                    In Asymmetric mode, this input is quantized into signed integer.
             parameter new_nodes_list: List of new nodes created before processing this node. This is used to
                                       check that two QuantizeLinear nodes are not being added for same input.
             return: (List of quantized input names,
@@ -783,7 +802,7 @@ class ONNXQuantizer:
             # Quantize the input
             initializer = _find_by_name(node_input, self.model.graph.initializer)
             if initializer is not None:
-                if node.op_type == "Conv" and input_index == weight_index:
+                if node.op_type == "Conv":
                     weight = self._get_quantized_weight_convolution(initializer, self.weight_qType)
                 else:
                     weight = self._get_quantized_weight(initializer, self.weight_qType)
@@ -874,7 +893,7 @@ class ONNXQuantizer:
     def _quantize_gather_ops(self, node, new_nodes_list):
         assert (node.op_type == "Gather")
         (quantized_input_names, zero_point_names, scale_names, nodes) = \
-            self._quantize_inputs(node, [0], 0, new_nodes_list)
+            self._quantize_inputs(node, [0], new_nodes_list)
         
         gather_new_output = node.output[0] + "_quantized"
 
@@ -899,7 +918,7 @@ class ONNXQuantizer:
         assert (node.op_type == "Conv")
 
         (quantized_input_names, zero_point_names, scale_names, nodes) = \
-            self._quantize_inputs(node, [0, 1], 1, new_nodes_list)
+            self._quantize_inputs(node, [0, 1], new_nodes_list)
 
         conv_integer_output = node.output[0] + "_quantized"
         conv_integer_name = ""
@@ -951,7 +970,7 @@ class ONNXQuantizer:
         assert (node.op_type == "MatMul")
 
         (quantized_input_names, zero_point_names, scale_names, nodes) = \
-            self._quantize_inputs(node, [0, 1], 1, new_nodes_list)
+            self._quantize_inputs(node, [0, 1], new_nodes_list)
 
         matmul_integer_output = node.output[0] + "_quantized"
         matmul_integer_name = ""
@@ -1000,10 +1019,18 @@ class ONNXQuantizer:
         assert (node.op_type == "Conv")
 
         (quantized_input_names, zero_point_names, scale_names, nodes) = \
-            self._quantize_inputs(node, [0, 1], 1, new_nodes_list)
+            self._quantize_inputs(node, [0, 1], new_nodes_list)
+        
+        quantized_bias_name = ""
+        bias_present = False
+        if len(node.input) == 3:
+            quantized_bias_name = self._quantize_bias(node, nodes)
+            bias_present = True        
 
-        output_scale_name, output_zp_name, output_scale_shape, output_zp_shape = \
-            self._get_output_quantization_params(node.output[0])
+        data_found, output_scale_name, output_zp_name, output_scale_shape, output_zp_shape = \
+            self._get_quantization_params(node.output[0])
+
+        assert(data_found)
 
         qlinear_conv_output = node.output[0] + "_quantized"
         qlinear_conv_name = ""
@@ -1021,9 +1048,13 @@ class ONNXQuantizer:
         qlinear_conv_inputs.append(quantized_input_names[1])
         qlinear_conv_inputs.append(scale_names[1])
         qlinear_conv_inputs.append(zero_point_names[1])
+
         # Output
         qlinear_conv_inputs.append(output_scale_name)
         qlinear_conv_inputs.append(output_zp_name)
+
+        if bias_present:
+            qlinear_conv_inputs.append(quantized_bias_name)
 
         qlinear_conv_node = onnx.helper.make_node("QLinearConv", qlinear_conv_inputs,
             [qlinear_conv_output], qlinear_conv_name, **kwargs)
@@ -1045,10 +1076,12 @@ class ONNXQuantizer:
         assert (node.op_type == "MatMul")
 
         (quantized_input_names, zero_point_names, scale_names, nodes) = \
-            self._quantize_inputs(node, [0, 1], 1, new_nodes_list)
+            self._quantize_inputs(node, [0, 1], new_nodes_list)
 
-        output_scale_name, output_zp_name, output_scale_shape, output_zp_shape = \
-            self._get_output_quantization_params(node.output[0])
+        data_found, output_scale_name, output_zp_name, output_scale_shape, output_zp_shape = \
+            self._get_quantization_params(node.output[0])
+        
+        assert(data_found)
 
         qlinear_matmul_output = node.output[0] + "_quantized"
         qlinear_matmul_name = ""
@@ -1087,7 +1120,7 @@ class ONNXQuantizer:
         '''
         assert (node.op_type == "Conv")
 
-        if self.mode == QuantizationMode.IntegerOps:
+        if self.mode == QuantizationMode.IntegerOps and len(node.input) == 2:
             return self._quantize_convolution_integer_ops(node, new_nodes_list)
 
         if self.mode == QuantizationMode.QLinearOps:
@@ -1115,7 +1148,7 @@ class ONNXQuantizer:
 
 def quantize(model, per_channel=False, nbits=8, quantization_mode=QuantizationMode.IntegerOps,
     static=False, fuse_dynamic_quant=True, asymmetric_input_types=False, 
-    input_quantization_params=None, output_quantization_params=None, nodes_to_quantize=None):
+    quantization_params=None, nodes_to_quantize=None):
     '''
         Given an onnx model, create a quantized onnx model and save it into a file
 
@@ -1129,7 +1162,7 @@ def quantize(model, per_channel=False, nbits=8, quantization_mode=QuantizationMo
             the function will use QLinear ops. Only QLinearConv and QLinearMatMul ops are supported now.
     :param static:
         True: The inputs/activations are quantized using static scale and zero point values
-              specified through input_quantization_params.
+              specified through quantization_params.
         False: The inputs/activations are quantized using dynamic scale and zero point values
                computed while running the model.
     :param fuse_dynamic_quant:
@@ -1139,7 +1172,7 @@ def quantize(model, per_channel=False, nbits=8, quantization_mode=QuantizationMo
     :param asymmetric_input_types:
         True: Weights are quantized into signed integers and inputs/activations into unsigned integers.
         False: Weights and inputs/activations are quantized into unsigned integers.
-    :param input_quantization_params:
+    :param quantization_params:
         Dictionary to specify the zero point and scale values for inputs to conv and matmul nodes.
         Should be specified when static is set to True.
         The input_quantization_params should be specified in the following format:
@@ -1151,20 +1184,7 @@ def quantize(model, per_channel=False, nbits=8, quantization_mode=QuantizationMo
             {
                 'resnet_model/Relu_1:0': [np.uint8(0), np.float32(0.019539741799235344)],
                 'resnet_model/Relu_2:0': [np.uint8(0), np.float32(0.011359662748873234)]
-            }
-    :param output_quantization_params:
-        Dictionary to specify the zero point and scale values for outputs of conv and matmul nodes.
-        Should be specified in QuantizationMode.QLinearOps mode.
-        The output_quantization_params should be specified in the following format:
-            {
-                "output_name": [zero_point, scale]
-            }
-        zero_point can be of type np.uint8/np.int8 and scale should be of type np.float32.
-        example:
-            {
-                'resnet_model/Relu_3:0': [np.int8(0), np.float32(0.011359662748873234)],
-                'resnet_model/Relu_4:0': [np.uint8(0), np.float32(0.011359662748873234)]
-            }
+            }    
     :return: ModelProto with quantization
     :param nodes_to quantize:
         List of nodes names to quantize. When this list is not None only the nodes in this list
@@ -1182,7 +1202,7 @@ def quantize(model, per_channel=False, nbits=8, quantization_mode=QuantizationMo
         copy_model = onnx_proto.ModelProto()
         copy_model.CopyFrom(model)
         quantizer = ONNXQuantizer(copy_model, per_channel, mode, static, fuse_dynamic_quant, weight_qType, input_qType,
-                        input_quantization_params, output_quantization_params, nodes_to_quantize)
+                        quantization_params, nodes_to_quantize)
         quantizer.quantize_model()
         quantizer.model.producer_name = __producer__
         quantizer.model.producer_version = __version__


### PR DESCRIPTION
**Description**: Enable quantizing bias when using Qlinear quantization ops.

**Motivation and Context**
- Earlier quantization script was not quantizing the bias for Conv nodes, bias quantization is necessary to quantize models which have conv node with bias otherwise these nodes have to be skipped.

