### PR TITLE
Support replacing OrtValue of feed in IOBinding instance

### DIFF
--- a/onnxruntime/core/session/IOBinding.cc
+++ b/onnxruntime/core/session/IOBinding.cc
@@ -77,11 +77,11 @@ common::Status IOBinding::BindOutput(const std::string& name, const OrtValue& ml
   auto rc = Contains(output_names_, name);
   if (rc.first) {
     outputs_[rc.second] = ml_value;
-  } else {
-    output_names_.push_back(name);
-    outputs_.push_back(ml_value);
+    return Status::OK();
   }
 
+  output_names_.push_back(name);
+  outputs_.push_back(ml_value);
   return Status::OK();
 }
 

--- a/onnxruntime/core/session/IOBinding.cc
+++ b/onnxruntime/core/session/IOBinding.cc
@@ -11,17 +11,33 @@ namespace onnxruntime {
 IOBinding::IOBinding(const SessionState& session_state) : session_state_(session_state) {
 }
 
-common::Status IOBinding::BindInput(const std::string& name, const OrtValue& ml_value) {
-  if (!ml_value.IsTensor()) {
-    feed_names_.push_back(name);
-    feeds_.push_back(ml_value);
-    return Status::OK();
+static std::pair<bool, size_t> Contains(const std::vector<std::string>& names, const std::string& name) {
+  auto it = std::find(std::begin(names), std::end(names), name);
+  if (it == std::end(names)) {
+    return {false, 0};
   }
+  return {true, it - std::begin(names)};
+}
 
-  OrtValue new_mlvalue;
-  ORT_RETURN_IF_ERROR(utils::CopyOneInputAcrossDevices(session_state_, name, ml_value, new_mlvalue));
-  feed_names_.push_back(name);
-  feeds_.push_back(new_mlvalue);
+common::Status IOBinding::BindInput(const std::string& name, const OrtValue& ml_value) {
+  auto rc = Contains(feed_names_, name);
+
+  auto add_or_replace = [this, &name](const bool exists, size_t index, const OrtValue& value) {
+    if (exists) {
+      feeds_[index] = value;
+    } else {
+      feed_names_.push_back(name);
+      feeds_.push_back(value);
+    }
+  };
+
+  if (ml_value.IsTensor()) {
+    OrtValue new_mlvalue;
+    ORT_RETURN_IF_ERROR(utils::CopyOneInputAcrossDevices(session_state_, name, ml_value, new_mlvalue));
+    add_or_replace(rc.first, rc.second, new_mlvalue);
+  } else {
+    add_or_replace(rc.first, rc.second, ml_value);
+  }
 
   return Status::OK();
 }
@@ -57,23 +73,15 @@ common::Status IOBinding::SynchronizeOutputs() {
   return Status::OK();
 }
 
-static std::pair<bool, size_t> Contains(const std::vector<std::string>& output_names, const std::string& oname) {
-  auto it = std::find(std::begin(output_names), std::end(output_names), oname);
-  if (it == std::end(output_names)) {
-    return {false, 0};
-  }
-  return {true, it - std::begin(output_names)};
-}
-
 common::Status IOBinding::BindOutput(const std::string& name, const OrtValue& ml_value) {
   auto rc = Contains(output_names_, name);
   if (rc.first) {
     outputs_[rc.second] = ml_value;
-    return Status::OK();
+  } else {
+    output_names_.push_back(name);
+    outputs_.push_back(ml_value);
   }
 
-  output_names_.push_back(name);
-  outputs_.push_back(ml_value);
   return Status::OK();
 }
 

--- a/onnxruntime/core/session/IOBinding.h
+++ b/onnxruntime/core/session/IOBinding.h
@@ -40,6 +40,7 @@ class IOBinding {
  public:
   /**
    * Call repeatedly to bind as many inputs as required.
+   * If called again for the same name will replace an existing value.
    * If the input ort_value is not at the desired location (specified by the execution provider), this will
    * copy it to the desired location. This copy may or may not be async. It depends on the exec provider.
    * If the input ort_value is not at the desired location, it should be preallocated

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -832,7 +832,8 @@ common::Status InferenceSession::NewIOBinding(std::unique_ptr<IOBinding>* io_bin
 common::Status InferenceSession::Run(const RunOptions& run_options, IOBinding& io_binding) {
   // TODO should Run() call io_binding.SynchronizeInputs() or should it let the callers do it?
   // io_binding.SynchronizeInputs();
-  return Run(run_options, io_binding.feed_names_, io_binding.feeds_, io_binding.output_names_, &io_binding.outputs_);
+  return Run(run_options, io_binding.GetInputNames(), io_binding.GetInputs(),
+             io_binding.GetOutputNames(), &io_binding.GetOutputs());
 }
 
 common::Status InferenceSession::Run(IOBinding& io_binding) {

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -233,10 +233,10 @@ void RunModelWithBindingMatMul(InferenceSession& session_object,
   auto input_allocator = io_binding->GetCPUAllocator(0, bind_provider_type);
 
   if (check_replace_feed_value) {
-    // bind a value to X with input that will produce invalid output.
+    // bind a value to A with input that will produce invalid output.
     std::vector<float> values_mul_x_tmp = {12.f, 11.f, 10.f, 9.f, 8.f, 7.f, 6.f, 5.f, 4.f, 3.f, 2.f, 1.f};
-    OrtValue input_tmp;
     std::vector<int64_t> dims_mul_x_A_tmp = {3, 4};
+    OrtValue input_tmp;
     CreateMLValue<float>(input_allocator, dims_mul_x_A_tmp, values_mul_x_tmp, &input_tmp);
     io_binding->BindInput("A", input_tmp);
   }

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -263,7 +263,7 @@ void RunModelWithBindingMatMul(InferenceSession& session_object,
   io_binding->BindInput("B", input_ml_value_B);
 
   // check location of 'A' post-binding has changed to validate that the previous value was replaced
-  ASSERT_TRUE(io_binding->GetInputs()[0].Get<Tensor>().DataRaw() == input_ml_value_A.Get<Tensor>().DataRaw());
+  ASSERT_TRUE(io_binding->GetInputs()[0].Get<Tensor>().DataRaw() != tmp_A);
 
   // prepare outputs
   std::vector<int64_t> expected_output_dims = {3, 3};


### PR DESCRIPTION
**Description**: 
WinML needs to replace and not just add feeds to an IOBinding instance. Re-instate support for doing so and add unit test.

**Motivation and Context**
Lost functionality in change to use vectors for feeds for performance.