### PR TITLE
python api's for execution provider registration

### DIFF
--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -18,4 +18,4 @@ __author__ = "Microsoft"
 from onnxruntime.capi import onnxruntime_validation
 onnxruntime_validation.check_distro_info()
 from onnxruntime.capi.session import InferenceSession
-from onnxruntime.capi._pybind_state import get_device, RunOptions, SessionOptions, NodeArg, ModelMetadata, GraphOptimizationLevel
+from onnxruntime.capi._pybind_state import get_all_providers, get_available_providers, get_device, RunOptions, SessionOptions, NodeArg, ModelMetadata, GraphOptimizationLevel

--- a/onnxruntime/core/framework/execution_providers.h
+++ b/onnxruntime/core/framework/execution_providers.h
@@ -48,6 +48,7 @@ class ExecutionProviders {
     }
 
     exec_providers_.push_back(std::move(p_exec_provider));
+    exec_provider_ids_.push_back(provider_id);
 
     return Status::OK();
   }
@@ -95,8 +96,11 @@ class ExecutionProviders {
     return Get(onnxruntime::kCpuExecutionProvider)->GetAllocator(0, OrtMemTypeDefault)->Info();
   }
 
+  const std::vector<std::string>& GetIds() const { return exec_provider_ids_; }
+
  private:
   std::vector<std::unique_ptr<IExecutionProvider>> exec_providers_;
+  std::vector<std::string> exec_provider_ids_;
 
   // maps for fast lookup of an index into exec_providers_
   std::unordered_map<std::string, size_t> provider_idx_map_;

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -569,7 +569,7 @@ void DumpNodeOutputs(OpKernelContext& context, const Node& node, const SessionSt
       if (type) {
         if (type->IsTensorType()) {
           const auto& tensor = *context.Output<Tensor>(i);
-          const auto data_type = tensor.DataType();
+          //const auto data_type = tensor.DataType();
           const auto& shape = tensor.Shape();
 
           std::cout << " Shape: " << shape << "\n";
@@ -579,12 +579,6 @@ void DumpNodeOutputs(OpKernelContext& context, const Node& node, const SessionSt
           auto* provider = execution_providers.Get(tensor_location);
           if (!provider) {
             provider = cpu_execution_provider;
-          }
-
-          if (provider == cpu_execution_provider || tensor_location.mem_type == OrtMemTypeCPUOutput) {
-            DispatchOnTensorType(data_type, DumpTensor, tensor, shape);
-          } else {
-            std::cout << " is not on CPU. Provider=" << provider->Type() << "\n";
           }
         } else {
           std::cout << " is non-tensor type.\n";

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -569,7 +569,7 @@ void DumpNodeOutputs(OpKernelContext& context, const Node& node, const SessionSt
       if (type) {
         if (type->IsTensorType()) {
           const auto& tensor = *context.Output<Tensor>(i);
-          //const auto data_type = tensor.DataType();
+          const auto data_type = tensor.DataType();
           const auto& shape = tensor.Shape();
 
           std::cout << " Shape: " << shape << "\n";
@@ -579,6 +579,12 @@ void DumpNodeOutputs(OpKernelContext& context, const Node& node, const SessionSt
           auto* provider = execution_providers.Get(tensor_location);
           if (!provider) {
             provider = cpu_execution_provider;
+          }
+
+          if (provider == cpu_execution_provider || tensor_location.mem_type == OrtMemTypeCPUOutput) {
+            DispatchOnTensorType(data_type, DumpTensor, tensor, shape);
+          } else {
+            std::cout << " is not on CPU. Provider=" << provider->Type() << "\n";
           }
         } else {
           std::cout << " is non-tensor type.\n";

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -573,6 +573,14 @@ int InferenceSession::GetCurrentNumRuns() const {
   return current_num_runs_.load();
 }
 
+const std::vector<std::string>& InferenceSession::GetRegisteredProviderTypes() const {
+  return execution_providers_.GetIds();
+}
+
+const SessionOptions& InferenceSession::GetSessionOptions() const {
+  return session_options_;
+}
+
 common::Status InferenceSession::CheckShapes(const std::string& input_name,
                                              const TensorShape& input_shape,
                                              const TensorShape& expected_shape) const {

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -280,6 +280,17 @@ class InferenceSession {
   int GetCurrentNumRuns() const;
 
   /**
+    * Get the names of registered Execution Providers. The returned vector is ordered by Execution Provider
+    * priority. The first provider in the vector has the highest priority.
+    */
+  const std::vector<std::string>& GetRegisteredProviderTypes() const;
+
+  /*
+   * Get the options this session was initialized with.
+   */
+  const SessionOptions& GetSessionOptions() const;
+
+  /**
     * Start profiling on this inference session. This simply turns on profiling events to be
     * recorded. A corresponding EndProfiling has to follow to write profiling data to a file.
     *@param file_prefix is the prefix of the profile file. It can include a directory path.

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -266,7 +266,7 @@ const std::vector<std::string>& GetAvailableProviders() {
   return available_providers;
 }
 
-void RegisterExecutionProviders(InferenceSession* sess, std::vector<std::string> provider_types) {
+void RegisterExecutionProviders(InferenceSession* sess, const std::vector<std::string>& provider_types) {
   for (const std::string& type : provider_types) {
     if (type == kCpuExecutionProvider) {
       RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_CPU(sess->GetSessionOptions().enable_cpu_mem_arena));
@@ -307,7 +307,7 @@ void RegisterExecutionProviders(InferenceSession* sess, std::vector<std::string>
   }
 }
 
-void InitializeSession(InferenceSession* sess, std::vector<std::string> provider_types) {
+void InitializeSession(InferenceSession* sess, const std::vector<std::string>& provider_types) {
   if (provider_types.empty()) {
     // use default registration priority.
     RegisterExecutionProviders(sess, GetAllProviders());
@@ -667,7 +667,7 @@ including arg name, arg type (contains both type and shape).)pbdoc")
       .def(py::init<SessionObjectInitializer, SessionObjectInitializer>())
       .def(py::init<SessionOptions, SessionObjectInitializer>())
       .def(
-          "load_model", [](InferenceSession* sess, const std::string& path, std::vector<std::string> provider_types) {
+          "load_model", [](InferenceSession* sess, const std::string& path, std::vector<std::string>& provider_types) {
             auto status = sess->Load(path);
             if (!status.IsOK()) {
               throw std::runtime_error(status.ToString().c_str());
@@ -676,7 +676,7 @@ including arg name, arg type (contains both type and shape).)pbdoc")
           },
           R"pbdoc(Load a model saved in ONNX format.)pbdoc")
       .def(
-          "read_bytes", [](InferenceSession* sess, const py::bytes& serializedModel, std::vector<std::string> provider_types) {
+          "read_bytes", [](InferenceSession* sess, const py::bytes& serializedModel, std::vector<std::string>& provider_types) {
             std::istringstream buffer(serializedModel);
             auto status = sess->Load(buffer);
             if (!status.IsOK()) {

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -228,64 +228,106 @@ inline void RegisterExecutionProvider(InferenceSession* sess, onnxruntime::IExec
   }
 }
 
-void InitializeSession(InferenceSession* sess) {
-  onnxruntime::common::Status status;
+// ordered by default priority. highest to lowest.
+const std::vector<std::string>& GetAllProviders() {
+  static std::vector<std::string> all_providers = {kTensorrtExecutionProvider, kCudaExecutionProvider, kMklDnnExecutionProvider,
+                                                   kNGraphExecutionProvider, kOpenVINOExecutionProvider, kNupharExecutionProvider,
+                                                   kBrainSliceExecutionProvider, kCpuExecutionProvider};
+  return all_providers;
+}
 
+const std::vector<std::string>& GetAvailableProviders() {
+  auto InitializeProviders = []() {
+    std::vector<std::string> available_providers = {kCpuExecutionProvider};
 #ifdef USE_TENSORRT
-  {
-    RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_Tensorrt(0));
-  }
+    available_providers.push_back(kTensorrtExecutionProvider);
 #endif
-
 #ifdef USE_CUDA
-  {
-    RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_CUDA(0));
-  }
+    available_providers.push_back(kCudaExecutionProvider);
 #endif
-
 #ifdef USE_MKLDNN
-  {
-    const bool enable_cpu_mem_arena = true;
-    RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_Mkldnn(enable_cpu_mem_arena ? 1 : 0));
-  }
+    available_providers.push_back(kMklDnnExecutionProvider);
 #endif
-
-#if USE_NGRAPH
-  {
-    RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_NGraph("CPU"));
-  }
+#ifdef USE_NGRAPH
+    available_providers.push_back(kNGraphExecutionProvider);
 #endif
-
 #ifdef USE_OPENVINO
-  {
-    RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_OpenVINO("CPU"));
-  }
+    available_providers.push_back(kOpenVINOExecutionProvider);
 #endif
-
-#if USE_NUPHAR
-  {
-    RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_Nuphar(true, nuphar_settings.c_str()));
-    nuphar_settings.clear();  // clear nuphar_settings after use to avoid it being accidentally passed on to next session
-  }
+#ifdef USE_NUPHAR
+    available_providers.push_back(kNupharExecutionProvider);
 #endif
-
 #ifdef USE_BRAINSLICE
-  {
-    RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_BrainSlice(0, -1, -1, false, "", "", ""));
-  }
+    available_providers.push_back(kBrainSliceExecutionProvider);
 #endif
+    return available_providers;
+  };
+  static std::vector<std::string> available_providers = InitializeProviders();
+  return available_providers;
+}
 
+void RegisterExecutionProviders(InferenceSession* sess, std::vector<std::string> provider_types) {
+  for (const std::string& type : provider_types) {
+    if (type == kCpuExecutionProvider) {
+      RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_CPU(sess->GetSessionOptions().enable_cpu_mem_arena));
+    } else if (type == kTensorrtExecutionProvider) {
+#ifdef USE_TENSORRT
+      RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_Tensorrt(0));
+#endif
+    } else if (type == kCudaExecutionProvider) {
+#ifdef USE_CUDA
+      // device id??
+      RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_CUDA(0));
+#endif
+    } else if (type == kMklDnnExecutionProvider) {
+#ifdef USE_MKLDNN
+      RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_Mkldnn(sess->GetSessionOptions().enable_cpu_mem_arena));
+#endif
+    } else if (type == kNGraphExecutionProvider) {
+#if USE_NGRAPH
+      RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_NGraph("CPU"));
+#endif
+    } else if (type == kOpenVINOExecutionProvider) {
+#ifdef USE_OPENVINO
+      RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_OpenVINO("CPU"));
+#endif
+    } else if (type == kNupharExecutionProvider) {
+#if USE_NUPHAR
+      RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_Nuphar(true, nuphar_settings.c_str()));
+      nuphar_settings.clear();  // clear nuphar_settings after use to avoid it being accidentally passed on to next session
+#endif
+    } else if (type == kBrainSliceExecutionProvider) {
+#ifdef USE_BRAINSLICE
+      RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_BrainSlice(0, -1, -1, false, "", "", ""));
+#endif
+    } else {
+      // unknown provider
+      throw std::runtime_error("Unknown Provider Type: " + type);
+    }
+  }
+}
+
+void InitializeSession(InferenceSession* sess, std::vector<std::string> provider_types) {
+  if (provider_types.empty()) {
+    // use default registration priority.
+    RegisterExecutionProviders(sess, GetAllProviders());
+  } else {
+    RegisterExecutionProviders(sess, provider_types);
+  }
+  onnxruntime::common::Status status;
   status = sess->Initialize();
   if (!status.IsOK()) {
     throw std::runtime_error(status.ToString().c_str());
   }
-}  // namespace python
+}
 
 void addGlobalMethods(py::module& m) {
   m.def("get_session_initializer", &SessionObjectInitializer::Get, "Return a default session object initializer.");
   m.def(
       "get_device", []() -> std::string { return BACKEND_DEVICE; },
       "Return the device used to compute the prediction (CPU, MKL, ...)");
+  m.def("get_all_providers", []() -> const std::vector<std::string>& { return GetAllProviders(); });
+  m.def("get_available_providers", []() -> const std::vector<std::string>& { return GetAvailableProviders(); });
 
 #ifdef USE_NUPHAR
   m.def("set_nuphar_settings", [](const std::string& str) {
@@ -308,77 +350,74 @@ void addGlobalMethods(py::module& m) {
 
         // default logger is needed to create the MklDNNExecutionProvider
         std::string default_logger_id{"DefaultLogger"};
-        std::unique_ptr<onnxruntime::logging::LoggingManager> default_logging_manager = 
-                  std::make_unique<LoggingManager>(
-                          std::unique_ptr<onnxruntime::logging::ISink>{ new onnxruntime::logging::CLogSink {}}, 
-                          onnxruntime::logging::Severity::kWARNING, 
-                          false,
-                          onnxruntime::logging::LoggingManager::InstanceType::Default, 
-                          &default_logger_id, 
-                          /*default_max_vlog_level*/ -1);
-     
+        std::unique_ptr<onnxruntime::logging::LoggingManager> default_logging_manager =
+            std::make_unique<LoggingManager>(
+                std::unique_ptr<onnxruntime::logging::ISink>{new onnxruntime::logging::CLogSink{}},
+                onnxruntime::logging::Severity::kWARNING,
+                false,
+                onnxruntime::logging::LoggingManager::InstanceType::Default,
+                &default_logger_id,
+                /*default_max_vlog_level*/ -1);
+
         std::vector<std::shared_ptr<onnxruntime::IExecutionProviderFactory>> factories = {
-          onnxruntime::CreateExecutionProviderFactory_CPU(0),
+            onnxruntime::CreateExecutionProviderFactory_CPU(0),
 #ifdef USE_CUDA
-          onnxruntime::CreateExecutionProviderFactory_CUDA(0),
+            onnxruntime::CreateExecutionProviderFactory_CUDA(0),
 #endif
 #ifdef USE_MKLDNN
-          onnxruntime::CreateExecutionProviderFactory_Mkldnn(1),
+            onnxruntime::CreateExecutionProviderFactory_Mkldnn(1),
 #endif
 #ifdef USE_NGRAPH
-          onnxruntime::CreateExecutionProviderFactory_NGraph("CPU"),
+            onnxruntime::CreateExecutionProviderFactory_NGraph("CPU"),
 #endif
 #ifdef USE_OPENVINO
-          onnxruntime::CreateExecutionProviderFactory_OpenVINO("CPU"),
-#endif    
-#ifdef  USE_TENSORRT    
-          onnxruntime::CreateExecutionProviderFactory_Tensorrt()
-#endif          
+            onnxruntime::CreateExecutionProviderFactory_OpenVINO("CPU"),
+#endif
+#ifdef USE_TENSORRT
+            onnxruntime::CreateExecutionProviderFactory_Tensorrt()
+#endif
         };
 
-      for (const auto& f: factories){
-        for (const auto& m: f->CreateProvider()
-                       ->GetKernelRegistry()
-                       ->GetKernelCreateMap()){
-          result.emplace_back(*(m.second.kernel_def)); 
+        for (const auto& f : factories) {
+          for (const auto& m : f->CreateProvider()
+                                   ->GetKernelRegistry()
+                                   ->GetKernelCreateMap()) {
+            result.emplace_back(*(m.second.kernel_def));
+          }
         }
-      }
 
-      return result;
-    },
-    "Return a vector of KernelDef for all registered OpKernels"
-  );
-#endif //onnxruntime_PYBIND_EXPORT_OPSCHEMA
+        return result;
+      },
+      "Return a vector of KernelDef for all registered OpKernels");
+#endif  //onnxruntime_PYBIND_EXPORT_OPSCHEMA
 }
 
 #ifdef onnxruntime_PYBIND_EXPORT_OPSCHEMA
 
-void addOpKernelSubmodule(py::module& m){
+void addOpKernelSubmodule(py::module& m) {
   auto opkernel = m.def_submodule("opkernel");
   opkernel.doc() = "OpKernel submodule";
   py::class_<onnxruntime::KernelDef> kernel_def(opkernel, "KernelDef");
   kernel_def.def_property_readonly("op_name", &onnxruntime::KernelDef::OpName)
-            .def_property_readonly("domain", &onnxruntime::KernelDef::Domain)
-            .def_property_readonly("provider", &onnxruntime::KernelDef::Provider)
-            .def_property_readonly("version_range", 
-              [](const onnxruntime::KernelDef& kernelDef) -> std::pair<int, int> {
-                return kernelDef.onnxruntime::KernelDef::SinceVersion();
-              })
-            .def_property_readonly("type_constraints", 
-              [](const onnxruntime::KernelDef& kernelDef) -> std::unordered_map<std::string, std::vector<std::string> > {
-                std::unordered_map<std::string, std::vector<std::string> > result;
-                const auto& tempResult = kernelDef.TypeConstraints();
-                for (const auto& tc: tempResult){
-                  result[tc.first] = std::vector<std::string>();
-                  for (const auto& dt: tc.second){
-                    result[tc.first].emplace_back(onnxruntime::DataTypeImpl::ToString(dt));  
-                  }
-                }
-                return result;
-              })
-            ;
+      .def_property_readonly("domain", &onnxruntime::KernelDef::Domain)
+      .def_property_readonly("provider", &onnxruntime::KernelDef::Provider)
+      .def_property_readonly("version_range",
+                             [](const onnxruntime::KernelDef& kernelDef) -> std::pair<int, int> {
+                               return kernelDef.onnxruntime::KernelDef::SinceVersion();
+                             })
+      .def_property_readonly("type_constraints",
+                             [](const onnxruntime::KernelDef& kernelDef) -> std::unordered_map<std::string, std::vector<std::string>> {
+                               std::unordered_map<std::string, std::vector<std::string>> result;
+                               const auto& tempResult = kernelDef.TypeConstraints();
+                               for (const auto& tc : tempResult) {
+                                 result[tc.first] = std::vector<std::string>();
+                                 for (const auto& dt : tc.second) {
+                                   result[tc.first].emplace_back(onnxruntime::DataTypeImpl::ToString(dt));
+                                 }
+                               }
+                               return result;
+                             });
 }
-
 
 void addOpSchemaSubmodule(py::module& m) {
   auto schemadef = m.def_submodule("schemadef");
@@ -521,7 +560,7 @@ This parameter is unused unless *enable_sequential_execution* is false.)pbdoc")
             }
             return retval;
           },
-          
+
           [](SessionOptions* options, GraphOptimizationLevel level) -> void {
             switch (level) {
               case ORT_DISABLE_ALL:
@@ -539,7 +578,6 @@ This parameter is unused unless *enable_sequential_execution* is false.)pbdoc")
             }
           },
           R"pbdoc(Graph optimization level for this session.)pbdoc");
-
 
   py::class_<RunOptions>(m, "RunOptions", R"pbdoc(Configuration information for a single Run.)pbdoc")
       .def(py::init())
@@ -572,78 +610,81 @@ including arg name, arg type (contains both type and shape).)pbdoc")
             return *(na.Type());
           },
           "node type")
-      .def("__str__", [](const onnxruntime::NodeArg& na) -> std::string {
-        std::ostringstream res;
-        res << "NodeArg(name='" << na.Name() << "', type='" << *(na.Type()) << "', shape=";
-        auto shape = na.Shape();
-        std::vector<py::object> arr;
-        if (shape == nullptr || shape->dim_size() == 0) {
-          res << "[]";
-        } else {
-          res << "[";
-          for (int i = 0; i < shape->dim_size(); ++i) {
-            if (utils::HasDimValue(shape->dim(i))) {
-              res << shape->dim(i).dim_value();
-            } else if (utils::HasDimParam(shape->dim(i))) {
-              res << "'" << shape->dim(i).dim_param() << "'";
+      .def(
+          "__str__", [](const onnxruntime::NodeArg& na) -> std::string {
+            std::ostringstream res;
+            res << "NodeArg(name='" << na.Name() << "', type='" << *(na.Type()) << "', shape=";
+            auto shape = na.Shape();
+            std::vector<py::object> arr;
+            if (shape == nullptr || shape->dim_size() == 0) {
+              res << "[]";
             } else {
-              res << "None";
+              res << "[";
+              for (int i = 0; i < shape->dim_size(); ++i) {
+                if (utils::HasDimValue(shape->dim(i))) {
+                  res << shape->dim(i).dim_value();
+                } else if (utils::HasDimParam(shape->dim(i))) {
+                  res << "'" << shape->dim(i).dim_param() << "'";
+                } else {
+                  res << "None";
+                }
+
+                if (i < shape->dim_size() - 1) {
+                  res << ", ";
+                }
+              }
+              res << "]";
+            }
+            res << ")";
+
+            return std::string(res.str());
+          },
+          "converts the node into a readable string")
+      .def_property_readonly(
+          "shape", [](const onnxruntime::NodeArg& na) -> std::vector<py::object> {
+            auto shape = na.Shape();
+            std::vector<py::object> arr;
+            if (shape == nullptr || shape->dim_size() == 0) {
+              return arr;
             }
 
-            if (i < shape->dim_size() - 1) {
-              res << ", ";
+            arr.resize(shape->dim_size());
+            for (int i = 0; i < shape->dim_size(); ++i) {
+              if (utils::HasDimValue(shape->dim(i))) {
+                arr[i] = py::cast(shape->dim(i).dim_value());
+              } else if (utils::HasDimParam(shape->dim(i))) {
+                arr[i] = py::cast(shape->dim(i).dim_param());
+              } else {
+                arr[i] = py::none();
+              }
             }
-          }
-          res << "]";
-        }
-        res << ")";
-
-        return std::string(res.str());
-      },
-           "converts the node into a readable string")
-      .def_property_readonly("shape", [](const onnxruntime::NodeArg& na) -> std::vector<py::object> {
-        auto shape = na.Shape();
-        std::vector<py::object> arr;
-        if (shape == nullptr || shape->dim_size() == 0) {
-          return arr;
-        }
-
-        arr.resize(shape->dim_size());
-        for (int i = 0; i < shape->dim_size(); ++i) {
-          if (utils::HasDimValue(shape->dim(i))) {
-            arr[i] = py::cast(shape->dim(i).dim_value());
-          } else if (utils::HasDimParam(shape->dim(i))) {
-            arr[i] = py::cast(shape->dim(i).dim_param());
-          } else {
-            arr[i] = py::none();
-          }
-        }
-        return arr;
-      },
-                             "node shape (assuming the node holds a tensor)");
+            return arr;
+          },
+          "node shape (assuming the node holds a tensor)");
 
   py::class_<SessionObjectInitializer>(m, "SessionObjectInitializer");
   py::class_<InferenceSession>(m, "InferenceSession", R"pbdoc(This is the main class used to run a model.)pbdoc")
       .def(py::init<SessionObjectInitializer, SessionObjectInitializer>())
       .def(py::init<SessionOptions, SessionObjectInitializer>())
       .def(
-          "load_model", [](InferenceSession* sess, const std::string& path) {
+          "load_model", [](InferenceSession* sess, const std::string& path, std::vector<std::string> provider_types) {
             auto status = sess->Load(path);
             if (!status.IsOK()) {
               throw std::runtime_error(status.ToString().c_str());
             }
-            InitializeSession(sess);
+            InitializeSession(sess, provider_types);
           },
           R"pbdoc(Load a model saved in ONNX format.)pbdoc")
-      .def("read_bytes", [](InferenceSession* sess, const py::bytes& serializedModel) {
-        std::istringstream buffer(serializedModel);
-        auto status = sess->Load(buffer);
-        if (!status.IsOK()) {
-          throw std::runtime_error(status.ToString().c_str());
-        }
-        InitializeSession(sess);
-      },
-           R"pbdoc(Load a model serialized in ONNX format.)pbdoc")
+      .def(
+          "read_bytes", [](InferenceSession* sess, const py::bytes& serializedModel, std::vector<std::string> provider_types) {
+            std::istringstream buffer(serializedModel);
+            auto status = sess->Load(buffer);
+            if (!status.IsOK()) {
+              throw std::runtime_error(status.ToString().c_str());
+            }
+            InitializeSession(sess, provider_types);
+          },
+          R"pbdoc(Load a model serialized in ONNX format.)pbdoc")
       .def("run", [](InferenceSession* sess, std::vector<std::string> output_names, std::map<std::string, py::object> pyfeeds, RunOptions* run_options = nullptr) -> std::vector<py::object> {
         NameMLValMap feeds;
         for (auto _ : pyfeeds) {
@@ -697,6 +738,9 @@ including arg name, arg type (contains both type and shape).)pbdoc")
       .def("end_profiling", [](InferenceSession* sess) -> std::string {
         return sess->EndProfiling();
       })
+      .def("get_providers", [](InferenceSession* sess) -> const std::vector<std::string>& {
+        return sess->GetRegisteredProviderTypes();
+      })
       .def_property_readonly("inputs_meta", [](const InferenceSession* sess) -> const std::vector<const onnxruntime::NodeArg*>& {
         auto res = sess->GetModelInputs();
         if (!res.first.IsOK()) {
@@ -722,7 +766,6 @@ including arg name, arg type (contains both type and shape).)pbdoc")
         }
       });
 }
-
 
 PYBIND11_MODULE(onnxruntime_pybind11_state, m) {
   m.doc() = "pybind11 stateful interface to ONNX runtime";

--- a/onnxruntime/python/session.py
+++ b/onnxruntime/python/session.py
@@ -21,9 +21,6 @@ class InferenceSession:
         self._path_or_bytes = path_or_bytes
         self._sess_options = sess_options
         self._load_model()
-        self._inputs_meta = self._sess.inputs_meta
-        self._outputs_meta = self._sess.outputs_meta
-        self._model_meta = self._sess.model_meta
 
     def _load_model(self, providers=[]):
         if self._sess_options:
@@ -43,6 +40,19 @@ class InferenceSession:
         else:
             raise TypeError("Unable to load from type '{0}'".format(type(self._path_or_bytes)))
 
+        self._inputs_meta = self._sess.inputs_meta
+        self._outputs_meta = self._sess.outputs_meta
+        self._model_meta = self._sess.model_meta
+
+    def _reset_session(self):
+        "release underlying session object."
+        # meta data references session internal structures
+        # so they must be set to None to decrement _sess reference count.
+        self._inputs_meta = None
+        self._outputs_meta = None
+        self._model_meta = None
+        self._sess = None
+
     def get_inputs(self):
         "Return the inputs metadata as a list of :class:`onnxruntime.NodeArg`."
         return self._inputs_meta
@@ -61,7 +71,7 @@ class InferenceSession:
 
     def set_providers(self, providers):
         "Register the input list of execution providers. The underlying session is re-created."
-        self._sess = None
+        self._reset_session()
         self._load_model(providers)
 
     def run(self, output_names, input_feed, run_options=None):

--- a/onnxruntime/python/session.py
+++ b/onnxruntime/python/session.py
@@ -43,6 +43,7 @@ class InferenceSession:
         self._inputs_meta = self._sess.inputs_meta
         self._outputs_meta = self._sess.outputs_meta
         self._model_meta = self._sess.model_meta
+        self._providers = self._sess.get_providers()
 
     def _reset_session(self):
         "release underlying session object."
@@ -51,6 +52,7 @@ class InferenceSession:
         self._inputs_meta = None
         self._outputs_meta = None
         self._model_meta = None
+        self._providers = None
         self._sess = None
 
     def get_inputs(self):
@@ -67,10 +69,12 @@ class InferenceSession:
 
     def get_providers(self):
         "Return list of registered execution providers."
-        return self._sess.get_providers()
+        return self._providers
 
     def set_providers(self, providers):
         "Register the input list of execution providers. The underlying session is re-created."
+        if not set(providers).issubset(C.get_available_providers()):
+          raise ValueError("{} does not contain a subset of available providers {}".format(providers, C.get_available_providers()))
         self._reset_session()
         self._load_model(providers)
 

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -47,7 +47,7 @@ class TestInferenceSession(unittest.TestCase):
         sess = onnxrt.InferenceSession(self.get_name("mul_1.onnx"))
         self.assertTrue('CPUExecutionProvider' in sess.get_providers())
 
-    def testGetProviders(self):
+    def testSetProviders(self):
         if 'CUDAExecutionProvider' in onnxrt.get_available_providers():
           sess = onnxrt.InferenceSession(self.get_name("mul_1.onnx"))
           # confirm that CUDA Provider is in list of registered providers.

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -41,6 +41,22 @@ class TestInferenceSession(unittest.TestCase):
         onnxrt.InferenceSession(self.get_name("mul_1.onnx"), sess_options=so)
         self.assertTrue(os.path.isfile(so.optimized_model_filepath))
 
+    def testGetProviders(self):
+        self.assertTrue('CPUExecutionProvider' in onnxrt.get_available_providers())
+        self.assertTrue('CPUExecutionProvider' in onnxrt.get_all_providers())
+        sess = onnxrt.InferenceSession(self.get_name("mul_1.onnx"))
+        self.assertTrue('CPUExecutionProvider' in sess.get_providers())
+
+    def testGetProviders(self):
+        if 'CUDAExecutionProvider' in onnxrt.get_available_providers():
+          sess = onnxrt.InferenceSession(self.get_name("mul_1.onnx"))
+          # confirm that CUDA Provider is in list of registered providers.
+          self.assertTrue('CUDAExecutionProvider' in sess.get_providers())
+          # reset the session and register only CPU Provider.
+          sess.set_providers(['CPUExecutionProvider'])
+          # confirm only CPU Provider is registered now.
+          self.assertEqual(['CPUExecutionProvider'], sess.get_providers())
+
     def testRunModel(self):
         sess = onnxrt.InferenceSession(self.get_name("mul_1.onnx"))
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -57,6 +57,12 @@ class TestInferenceSession(unittest.TestCase):
           # confirm only CPU Provider is registered now.
           self.assertEqual(['CPUExecutionProvider'], sess.get_providers())
 
+    def testInvalidSetProviders(self):
+        with self.assertRaises(ValueError) as context:
+          sess = onnxrt.InferenceSession(self.get_name("mul_1.onnx"))
+          sess.set_providers(['InvalidProvider'])
+        self.assertTrue('[\'InvalidProvider\'] does not contain a subset of available providers' in str(context.exception))
+
     def testRunModel(self):
         sess = onnxrt.InferenceSession(self.get_name("mul_1.onnx"))
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)

--- a/onnxruntime/test/python/onnxruntime_test_python_nuphar.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_nuphar.py
@@ -63,6 +63,7 @@ class TestNuphar(unittest.TestCase):
             feed[tp.name] = numpy_helper.to_array(tp)
 
         sess = onnxrt.InferenceSession(bidaf_int8_scan_only_model) # JIT cache happens when initializing session
+        assert 'NupharExecutionProvider' in sess.get_providers()
         output = sess.run([], feed)
 
         cache_dir_content = os.listdir(cache_dir)
@@ -78,6 +79,7 @@ class TestNuphar(unittest.TestCase):
         nuphar_settings = 'nuphar_cache_path:{}'.format(cache_dir) + ', nuphar_cache_force_no_jit:{}'.format('on')
         onnxrt.capi._pybind_state.set_nuphar_settings(nuphar_settings)
         sess = onnxrt.InferenceSession(bidaf_int8_scan_only_model) # JIT cache happens when initializing session
+        assert 'NupharExecutionProvider' in sess.get_providers()
         sess.run([], feed)
 
 


### PR DESCRIPTION
Add python api's for execution provider registration.
default to the existing static registration priority order. the new api's allow user to override the order.
-global api's
get_all_providers() : returns list of all known ORT execution provider type strings.
get_available_providers(): returns list of available ORT execution provider type strings. (ones that have been enabled in the build/package) This list is ordered by the default execution provider priority.
-session api's
get_providers(): returns list of registered ORT execution provider type strings. the providers are ordered from highest priority to lowest. 
set_providers(): register the list of provider names. the list is ordered from highest priority to lowest.
e.g. 
sess.set_providers(['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider'])
means TensorRT has highest priority, followed by CUDA followed by CPU.

sess.set_providers([]) # empty list means register using default priority order. 

The underlying session is reset and recreated when the set_providers() api is used.

These api's set up the ability to implement a CPU provider fallback retry when there is an underlying Execution Provider runtime failure.  (TBD in upcoming PR)

-added some unit tests. 
tested that no more than one session object is kept in memory at one time to minimize peak memory usage, when using the registration api's.
-documentation for these api's will need to be added to appropriate ORT python api MS docs location. 
