### PR TITLE
Support valid negatives axis values in HardMax and LpNorm

### DIFF
--- a/onnxruntime/core/providers/cpu/math/hardmax.cc
+++ b/onnxruntime/core/providers/cpu/math/hardmax.cc
@@ -4,6 +4,7 @@
 #include "core/providers/cpu/math/hardmax.h"
 #include "core/util/math_cpuonly.h"
 #include "core/util/math.h"
+#include "core/providers/common.h"
 
 namespace onnxruntime {
 
@@ -13,8 +14,9 @@ Status Hardmax<float>::Compute(OpKernelContext* ctx) const {
   const TensorShape& input_shape = X->Shape();
   const auto* Xdata = X->template Data<float>();
 
-  size_t tmpN = input_shape.SizeToDimension(axis_);
-  size_t tmpD = input_shape.SizeFromDimension(axis_);
+  const auto axis_corrected = HandleNegativeAxis(axis_, static_cast<int64_t>(input_shape.NumDimensions()));
+  size_t tmpN = input_shape.SizeToDimension(axis_corrected);
+  size_t tmpD = input_shape.SizeFromDimension(axis_corrected);
 
   // Math::RowwiseMax expects int N and D.
   if (tmpN * tmpD > INT32_MAX || tmpN > INT32_MAX || tmpD > INT32_MAX) {

--- a/onnxruntime/core/providers/cpu/math/hardmax.h
+++ b/onnxruntime/core/providers/cpu/math/hardmax.h
@@ -19,9 +19,6 @@ class Hardmax final : public OpKernel {
     if (status.IsOK()) {
       axis_ = gsl::narrow_cast<int>(axis);
     }
-
-    // if value was provided, make sure it was valid
-    ORT_ENFORCE(axis_ >= 0, "Invalid axis provided.");
   }
 
   Status Compute(OpKernelContext* context) const override;

--- a/onnxruntime/core/providers/cpu/nn/lp_norm.cc
+++ b/onnxruntime/core/providers/cpu/nn/lp_norm.cc
@@ -3,6 +3,7 @@
 
 #include "core/providers/cpu/nn/lp_norm.h"
 #include "core/util/math_cpuonly.h"
+#include "core/providers/common.h"
 
 namespace onnxruntime {
 ONNX_CPU_OPERATOR_KERNEL(
@@ -55,7 +56,7 @@ Status LpNorm<float>::Compute(OpKernelContext* p_op_kernel_context) const {
   const TensorShape& input_shape = input->Shape();
   Tensor* output = p_op_kernel_context->Output(0, input_shape);
 
-  const auto canonical_axis = axis_ != -1 ? axis_ : (input_shape.NumDimensions() - 1);
+  const auto canonical_axis = HandleNegativeAxis(axis_, static_cast<int64_t>(input_shape.NumDimensions()));
   const int64_t m = input_shape.GetDims()[canonical_axis];
   const int64_t n = input_shape.Size() / m;
   const int64_t sf = input_shape.SizeFromDimension(canonical_axis + 1);

--- a/onnxruntime/test/providers/cpu/math/hardmax_test.cc
+++ b/onnxruntime/test/providers/cpu/math/hardmax_test.cc
@@ -23,7 +23,12 @@ static void RunTest(const std::vector<float>& x_vals,
 
   test.AddInput<float>("X", dimensions, x_vals);
   test.AddOutput<float>("Y", dimensions, expected_vals);
-  test.Run(expect_result, expected_err_str);
+
+  std::unordered_set<std::string> excluded_eps;
+  if (axis < 0)
+    excluded_eps.insert(kNGraphExecutionProvider); // NGraph EP cannot handle negative axis values
+
+  test.Run(expect_result, expected_err_str, excluded_eps);
 }
 
 TEST(HardmaxOperator, Simple) {

--- a/onnxruntime/test/providers/cpu/math/hardmax_test.cc
+++ b/onnxruntime/test/providers/cpu/math/hardmax_test.cc
@@ -143,9 +143,17 @@ TEST(HardmaxOperator, InvalidAxis) {
   RunTest(x_vals,
           expected_vals,
           dimensions,
-          /* invalid axis */ -1,
+          /* invalid axis */ -3,
           OpTester::ExpectResult::kExpectFailure,
-          "Invalid axis provided.");
+          "axis -3 is not in valid range [-2,1]");
+}
+
+TEST(HardmaxOperator, NegativeValidAxis) {
+  std::vector<float> x_vals = {-1.0f, 0.0f, 1.0f};
+  std::vector<float> expected_vals = {0.0f, 0.0f, 1.0f};
+  std::vector<int64_t> dimensions = {1, 3};
+
+  RunTest(x_vals, expected_vals, dimensions, -1);
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/cpu/nn/lp_norm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/lp_norm_op_test.cc
@@ -80,5 +80,32 @@ TEST(LpNormalizationTest, LpNormalizationDefaultAxisAndP) {
   test.AddOutput<float>("Y", input_dims, expected_output);
   test.Run();
 }
+
+TEST(LpNormalizationTest, L1NormalizationWithValidNegativeAxis) {
+  OpTester test("LpNormalization");
+  test.AddAttribute("axis", static_cast<int64_t>(-2));
+  test.AddAttribute("p", static_cast<int64_t>(1));
+
+  vector<float> input = {5.93932154F, 7.4367043F, 6.42487038F, 5.90394865F,
+                         4.81289319F, 6.81304702F, 4.9382849F, 9.02595701F,
+                         9.67296484F, 4.45097367F, 8.12552534F, 5.76005428F,
+
+                         6.11240105F, 9.33036974F, 1.63932452F, 1.7841637F,
+                         1.18196558F, 8.49357861F, 8.00341076F, 8.83010933F,
+                         9.80756508F, 8.19242708F, 5.15331426F, 8.02476259F};
+  vector<int64_t> input_dims = {2, 3, 4};
+  test.AddInput<float>("input", input_dims, input);
+
+  vector<float> expected_output = {0.2907843F, 0.3976693F, 0.3296719F, 0.28535331F,
+                                   0.23563529F, 0.36431994F, 0.25339247F, 0.43624816F,
+                                   0.47358041F, 0.23801075F, 0.41693563F, 0.27839852F,
+
+                                   0.35740998F, 0.3586345F, 0.11079474F, 0.09572189F,
+                                   0.06911299F, 0.32647048F, 0.54091538F, 0.47374282F,
+                                   0.57347703F, 0.31489502F, 0.34828988F, 0.43053529F};
+  test.AddOutput<float>("Y", input_dims, expected_output);
+  test.Run();
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**: Support valid negative axis values in HardMax and LpNorm ops

**Motivation and Context**
Resolve #1814 

CC:@fdwr
