### PR TITLE
Bump ONNX version -- require shape inference fix and test data for Cu…

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -49,7 +49,7 @@
          "component": {
             "type": "git",
             "git": {
-               "commitHash": "568b65aaa2bd94b04d8fdac24b398dc25c507b50",
+               "commitHash": "95252c2adec185e305e34486c6756ece9aa8f57f",
                "repositoryUrl": "https://github.com/onnx/onnx.git"
             }
          }

--- a/tools/ci_build/github/linux/docker/scripts/install_onnx.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_onnx.sh
@@ -13,7 +13,7 @@ version2tag=(5af210ca8a1c73aa6bae8754c9346ec54d0a756e-onnx123
              bae6333e149a59a3faa9c4d9c44974373dcf5256-onnx130
              9e55ace55aad1ada27516038dfbdc66a8a0763db-onnx141
              7d7bc83d29a328233d3e8affa4c4ea8b3e3599ef-onnx150
-             568b65aaa2bd94b04d8fdac24b398dc25c507b50-onnxtip)
+             95252c2adec185e305e34486c6756ece9aa8f57f-onnxtip)
 for v2t in ${version2tag[*]}; do
   onnx_version="$(cut -d'-' -f1<<<${v2t})"
   onnx_tag="$(cut -d'-' -f2<<<${v2t})"


### PR DESCRIPTION
Bump ONNX version -- require shape inference fix and test data for CumSum and Round ops

**Description**: The ONNX spec and test data were updated for 2 operators. Require fixes to propagate to ORT.

**Motivation and Context**
Fixes to shape inference and test model required in ORT to compile new ops correctly.
