### PR TITLE
A small improvement to the parallel_for  when task count > thread count

### DIFF
--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -39,9 +39,23 @@ void ThreadPool::ParallelFor(int32_t total, std::function<void(int32_t)> fn) {
     fn(0);
     return;
   }
-
   // TODO: Eigen supports a more efficient ThreadPoolDevice mechanism
   // We will simply rely on the work queue and stealing in the short term.
+  if (total > NumThreads()) {
+    //The dispatcher thread will be idle at here
+    Barrier barrier(static_cast<unsigned int>(total));
+    std::function<void(int32_t)> handle_iteration = [&barrier, &fn](int iteration) {
+      fn(iteration);
+      barrier.Notify();
+    };
+
+    for (int32_t id = 0; id < total; ++id) {
+      Schedule([=, &handle_iteration]() { handle_iteration(id); });
+    }
+
+    barrier.Wait();
+    return;
+  }
   Barrier barrier(static_cast<unsigned int>(total - 1));
   std::function<void(int32_t)> handle_iteration = [&barrier, &fn](int iteration) {
     fn(iteration);
@@ -51,7 +65,7 @@ void ThreadPool::ParallelFor(int32_t total, std::function<void(int32_t)> fn) {
   for (int32_t id = 1; id < total; ++id) {
     Schedule([=, &handle_iteration]() { handle_iteration(id); });
   }
-
+  //reuse the current thread for one task
   fn(0);
   barrier.Wait();
 }

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -545,7 +545,7 @@ MlasGetMaximumThreadCount(
     MLAS_UNREFERENCED_PARAMETER(ThreadPool);
 #else
     if (ThreadPool != nullptr) {
-        return ThreadPool->NumThreads() + 1;
+        return ThreadPool->NumThreads();
     }
 #endif
 


### PR DESCRIPTION
**Description**: 

A small improvement to the parallel_for  when task count > thread count

Before this change: The recommended thread pool size is  number of cpu cores minus one.
After this change: The recommended thread pool size is  number of cpu cores

The new code is more like the parallelFor in Eigen::ThreadPoolDevice. Especially the " if (total > NumThreads()) " logic is the same.


**Motivation and Context**
- Why is this change required? What problem does it solve?

If you have 4 cores, and 4 tasks, that's fine.
But if you have 4 cores, but 8 tasks, if one task need 1 unit time, the old code need 3 unit time, but the new code only need 2. 

- If it fixes an open issue, please link to the issue here.


Related PR:
#947
#1646

