### PR TITLE
Expose GetOverridableInitializers to public API to allow initializers override

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
@@ -272,7 +272,7 @@ namespace Microsoft.ML.OnnxRuntime
 
             IntPtr status = NativeMethods.OrtSessionGetInputName(
                                                 _nativeHandle,
-                                                inclusion,
+                                                InputInclusion.InputsOnly,
                                                 (UIntPtr)index,
                                                 NativeMemoryAllocator.DefaultInstance.Handle,
                                                 out nameHandle);

--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
@@ -25,6 +25,12 @@ namespace Microsoft.ML.OnnxRuntime
 
         #region Public API
 
+        public enum InputInclusion
+        {
+            InputsOnly = 0,
+            IncludeInitializers = 1
+        }
+
         /// <summary>
         /// Constructs an InferenceSession from a model file
         /// </summary>
@@ -200,7 +206,7 @@ namespace Microsoft.ML.OnnxRuntime
 
                 // get input count
                 UIntPtr inputCount = UIntPtr.Zero;
-                NativeApiStatus.VerifySuccess(NativeMethods.OrtSessionGetInputCount(_nativeHandle, out inputCount));
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtSessionGetInputCount(_nativeHandle, InputInclusion.InputsOnly, out inputCount));
 
                 // get all the output names
                 for (ulong i = 0; i < (ulong)inputCount; i++)
@@ -266,6 +272,7 @@ namespace Microsoft.ML.OnnxRuntime
 
             IntPtr status = NativeMethods.OrtSessionGetInputName(
                                                 _nativeHandle,
+                                                inclusion,
                                                 (UIntPtr)index,
                                                 NativeMemoryAllocator.DefaultInstance.Handle,
                                                 out nameHandle);
@@ -291,7 +298,7 @@ namespace Microsoft.ML.OnnxRuntime
             IntPtr typeInfo = IntPtr.Zero;
             try
             {
-                NativeApiStatus.VerifySuccess(NativeMethods.OrtSessionGetInputTypeInfo(_nativeHandle, (UIntPtr)index, out typeInfo));
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtSessionGetInputTypeInfo(_nativeHandle, InputInclusion.InputsOnly, (UIntPtr)index, out typeInfo));
                 return GetMetadataFromTypeInfo(typeInfo);
             }
             finally

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
@@ -69,6 +69,7 @@ namespace Microsoft.ML.OnnxRuntime
         [DllImport(nativeLib, CharSet = charSet)]
         public static extern IntPtr /*(OrtStatus*)*/ OrtSessionGetInputCount(
                                                 IntPtr /*(OrtSession*)*/ session,
+                                                InputInclusion inclusion,
                                                 out UIntPtr count);
 
 
@@ -80,6 +81,7 @@ namespace Microsoft.ML.OnnxRuntime
         [DllImport(nativeLib, CharSet = charSet)]
         public static extern IntPtr /*(OrtStatus*)*/OrtSessionGetInputName(
                                                 IntPtr /*(OrtSession*)*/ session,
+                                                InputInclusion inclusion,
                                                 UIntPtr index,
                                                 IntPtr /*(OrtAllocator*)*/ allocator,
                                                 out IntPtr /*(char**)*/name);
@@ -95,6 +97,7 @@ namespace Microsoft.ML.OnnxRuntime
         [DllImport(nativeLib, CharSet = charSet)]
         public static extern IntPtr /*(OrtStatus*)*/OrtSessionGetInputTypeInfo(
                                                 IntPtr /*(const OrtSession*)*/ session,
+                                                InputInclusion inclusion,
                                                 UIntPtr index,
                                                 out IntPtr /*(struct OrtTypeInfo**)*/ typeInfo);
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.OnnxRuntime
         [DllImport(nativeLib, CharSet = charSet)]
         public static extern IntPtr /*(OrtStatus*)*/ OrtSessionGetInputCount(
                                                 IntPtr /*(OrtSession*)*/ session,
-                                                InputInclusion inclusion,
+                                                InferenceSession.InputInclusion inclusion,
                                                 out UIntPtr count);
 
 
@@ -81,7 +81,7 @@ namespace Microsoft.ML.OnnxRuntime
         [DllImport(nativeLib, CharSet = charSet)]
         public static extern IntPtr /*(OrtStatus*)*/OrtSessionGetInputName(
                                                 IntPtr /*(OrtSession*)*/ session,
-                                                InputInclusion inclusion,
+                                                InferenceSession.InputInclusion inclusion,
                                                 UIntPtr index,
                                                 IntPtr /*(OrtAllocator*)*/ allocator,
                                                 out IntPtr /*(char**)*/name);
@@ -97,7 +97,7 @@ namespace Microsoft.ML.OnnxRuntime
         [DllImport(nativeLib, CharSet = charSet)]
         public static extern IntPtr /*(OrtStatus*)*/OrtSessionGetInputTypeInfo(
                                                 IntPtr /*(const OrtSession*)*/ session,
-                                                InputInclusion inclusion,
+                                                InferenceSession.InputInclusion inclusion,
                                                 UIntPtr index,
                                                 out IntPtr /*(struct OrtTypeInfo**)*/ typeInfo);
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/C_Api_Sample.cpp
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/C_Api_Sample.cpp
@@ -73,13 +73,13 @@ int main(int argc, char* argv[]) {
   for (size_t i = 0; i < num_input_nodes; i++) {
     // print input node names
     char* input_name;
-    status = OrtSessionGetInputName(session, i, allocator, &input_name);
+    status = OrtSessionGetInputName(session, kInputsOnly, i, allocator, &input_name);
     printf("Input %zu : name=%s\n", i, input_name);
     input_node_names[i] = input_name;
 
     // print input node types
     OrtTypeInfo* typeinfo;
-    status = OrtSessionGetInputTypeInfo(session, i, &typeinfo);
+    status = OrtSessionGetInputTypeInfo(session, kInputsOnly, i, &typeinfo);
     const OrtTensorTypeAndShapeInfo* tensor_info;
     CHECK_STATUS(OrtCastTypeInfoToTensorInfo(typeinfo, &tensor_info));
     ONNXTensorElementDataType type;

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -266,13 +266,19 @@ ORT_API_STATUS(OrtSetSessionThreadPoolSize, _Inout_ OrtSessionOptions* options, 
   * If none are called Ort will use its internal CPU execution provider.
   */
 
-ORT_API_STATUS(OrtSessionGetInputCount, _In_ const OrtSession* sess, _Out_ size_t* out);
+typedef enum ONNXSessionInputInclusion {
+  kInputsOnly = 0, /* Inputs only */
+  kIncludeInitializers = 1 /* Inputs with initializers */
+} ONNXSessionInputInclusion;
+
+ORT_API_STATUS(OrtSessionGetInputCount, _In_ const OrtSession* sess, ONNXSessionInputInclusion inclusion, _Out_ size_t* out);
 ORT_API_STATUS(OrtSessionGetOutputCount, _In_ const OrtSession* sess, _Out_ size_t* out);
+
 
 /**
  * \param out  should be freed by OrtReleaseTypeInfo after use
  */
-ORT_API_STATUS(OrtSessionGetInputTypeInfo, _In_ const OrtSession* sess, size_t index, _Outptr_ OrtTypeInfo** type_info);
+ORT_API_STATUS(OrtSessionGetInputTypeInfo, _In_ const OrtSession* sess, ONNXSessionInputInclusion inclusion, size_t index, _Outptr_ OrtTypeInfo** type_info);
 
 /**
  * \param out  should be freed by OrtReleaseTypeInfo after use
@@ -282,7 +288,7 @@ ORT_API_STATUS(OrtSessionGetOutputTypeInfo, _In_ const OrtSession* sess, size_t 
 /**
  * \param value  is set to a null terminated string allocated using 'allocator'. The caller is responsible in freeing it.
  */
-ORT_API_STATUS(OrtSessionGetInputName, _In_ const OrtSession* sess, size_t index,
+ORT_API_STATUS(OrtSessionGetInputName, _In_ const OrtSession* sess, ONNXSessionInputInclusion inclusion, size_t index,
                _Inout_ OrtAllocator* allocator, _Outptr_ char** value);
 ORT_API_STATUS(OrtSessionGetOutputName, _In_ const OrtSession* sess, size_t index,
                _Inout_ OrtAllocator* allocator, _Outptr_ char** value);

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -172,13 +172,13 @@ struct Session : Base<OrtSession> {
   void Run(const RunOptions& run_options, const char* const* input_names, Value* input_values, size_t input_count,
            const char* const* output_names, Value* output_values, size_t output_count);
 
-  size_t GetInputCount() const;
+  size_t GetInputCount(ONNXSessionInputInclusion) const;
   size_t GetOutputCount() const;
 
-  char* GetInputName(size_t index, OrtAllocator* allocator) const;
+  char* GetInputName(ONNXSessionInputInclusion, size_t index, OrtAllocator* allocator) const;
   char* GetOutputName(size_t index, OrtAllocator* allocator) const;
 
-  TypeInfo GetInputTypeInfo(size_t index) const;
+  TypeInfo GetInputTypeInfo(ONNXSessionInputInclusion, size_t index) const;
   TypeInfo GetOutputTypeInfo(size_t index) const;
 };
 

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -225,9 +225,9 @@ inline void Session::Run(const RunOptions& run_options, const char* const* input
   ORT_THROW_ON_ERROR(OrtRun(p_, run_options, input_names, ort_input_values, input_count, output_names, output_count, ort_output_values));
 }
 
-inline size_t Session::GetInputCount() const {
+inline size_t Session::GetInputCount(ONNXSessionInputInclusion inclusion) const {
   size_t out;
-  ORT_THROW_ON_ERROR(OrtSessionGetInputCount(p_, &out));
+  ORT_THROW_ON_ERROR(OrtSessionGetInputCount(p_, inclusion, &out));
   return out;
 }
 
@@ -237,9 +237,9 @@ inline size_t Session::GetOutputCount() const {
   return out;
 }
 
-inline char* Session::GetInputName(size_t index, OrtAllocator* allocator) const {
+inline char* Session::GetInputName(ONNXSessionInputInclusion inclusion, size_t index, OrtAllocator* allocator) const {
   char* out;
-  ORT_THROW_ON_ERROR(OrtSessionGetInputName(p_, index, allocator, &out));
+  ORT_THROW_ON_ERROR(OrtSessionGetInputName(p_, inclusion, index, allocator, &out));
   return out;
 }
 
@@ -249,9 +249,9 @@ inline char* Session::GetOutputName(size_t index, OrtAllocator* allocator) const
   return out;
 }
 
-inline TypeInfo Session::GetInputTypeInfo(size_t index) const {
+inline TypeInfo Session::GetInputTypeInfo(ONNXSessionInputInclusion inclusion, size_t index) const {
   OrtTypeInfo* out;
-  ORT_THROW_ON_ERROR(OrtSessionGetInputTypeInfo(p_, index, &out));
+  ORT_THROW_ON_ERROR(OrtSessionGetInputTypeInfo(p_, inclusion, index, &out));
   return TypeInfo{out};
 }
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -810,6 +810,20 @@ std::pair<common::Status, const InputDefList*> InferenceSession::GetModelInputs(
   return std::make_pair(common::Status::OK(), &model_->MainGraph().GetInputs());
 }
 
+std::pair<common::Status, const InputDefList*> InferenceSession::GetModelInputsIncludingInitializers() const {
+  {
+    std::lock_guard<onnxruntime::OrtMutex> l(session_mutex_);
+    if (!is_model_loaded_) {
+      LOGS(*session_logger_, ERROR) << "Model was not loaded";
+      return std::make_pair(common::Status(common::ONNXRUNTIME, common::FAIL, "Model was not loaded."),
+                            nullptr);
+    }
+  }
+
+  // return required inputs including any inputs used for overriding initializers
+  return std::make_pair(common::Status::OK(), &model_->MainGraph().GetInputsIncludingInitializers());
+}
+
 std::pair<common::Status, const OutputDefList*> InferenceSession::GetModelOutputs() const {
   {
     std::lock_guard<onnxruntime::OrtMutex> l(session_mutex_);

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -267,6 +267,14 @@ class InferenceSession {
     */
   std::pair<common::Status, const InputDefList*> GetModelInputs() const;
 
+    /**
+    * Get all input definitions of the model, including initializers.
+    * This does not include weights. Use this to get the name/type/shapes of the inputs.
+    * @return pair.first = OK; FAIL otherwise. pair.second is non-NULL when pair.first = OK.
+    * @note lifetime of the returned pointer is valid as long as the Session object is live.
+    */
+  std::pair<common::Status, const InputDefList*> GetModelInputsIncludingInitializers() const;
+
   /**
     * Get all output definitions of the model. Use this to get the name/type/shapes of the outputs.
     * @return pair.first = OK; FAIL otherwise. pair.second is non-NULL when pair.first = OK.

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -757,6 +757,14 @@ including arg name, arg type (contains both type and shape).)pbdoc")
           return *(res.second);
         }
       })
+      .def_property_readonly("inputs_meta_including_initializers", [](const InferenceSession* sess) -> const std::vector<const onnxruntime::NodeArg*>& {
+        auto res = sess->GetModelInputsIncludingInitializers();
+        if (!res.first.IsOK()) {
+          throw std::runtime_error(res.first.ToString().c_str());
+        } else {
+          return *(res.second);
+        }
+      })
       .def_property_readonly("model_meta", [](const InferenceSession* sess) -> const onnxruntime::ModelMetadata& {
         auto res = sess->GetModelMetadata();
         if (!res.first.IsOK()) {

--- a/onnxruntime/python/session.py
+++ b/onnxruntime/python/session.py
@@ -42,6 +42,7 @@ class InferenceSession:
 
         self._inputs_meta = self._sess.inputs_meta
         self._outputs_meta = self._sess.outputs_meta
+        self._inputs_meta_including_initializers = self._sess.inputs_meta_including_initializers
         self._model_meta = self._sess.model_meta
         self._providers = self._sess.get_providers()
 
@@ -62,6 +63,10 @@ class InferenceSession:
     def get_outputs(self):
         "Return the outputs metadata as a list of :class:`onnxruntime.NodeArg`."
         return self._outputs_meta
+
+    def get_inputs_including_initializers(self):
+        "Return the inputs (including initializers) metadata as a list of :class:`onnxruntime.NodeArg`."
+        return self._inputs_meta_including_initializers
 
     def get_modelmeta(self):
         "Return the metadata. See :class:`onnxruntime.ModelMetadata`."

--- a/onnxruntime/python/tools/onnxruntime_test.py
+++ b/onnxruntime/python/tools/onnxruntime_test.py
@@ -57,6 +57,8 @@ def main():
     meta = sess.get_modelmeta()
 
     feeds = {}
+    # Use sess.get_inputs_including_initializers so the initializers
+    # can be overridden (available in IR4)
     for input_meta in sess.get_inputs():
         # replace any symbolic dimensions (value is None) with 1
         shape = [dim if dim else 1 for dim in input_meta.shape]

--- a/onnxruntime/test/opaque_api/test_opaque_api.cc
+++ b/onnxruntime/test/opaque_api/test_opaque_api.cc
@@ -210,9 +210,9 @@ TEST_F(OpaqueApiTest, RunModelWithOpaqueInputOutput) {
     Ort::AllocatorWithDefaultOptions allocator;
 
     // Expecting one input
-    size_t num_input_nodes = session.GetInputCount();
+    size_t num_input_nodes = session.GetInputCount(kInputsOnly);
     EXPECT_EQ(num_input_nodes, 1U);
-    const char* input_name = session.GetInputName(0, allocator);
+    const char* input_name = session.GetInputName(kInputsOnly, 0, allocator);
 
     size_t num_output_nodes = session.GetOutputCount();
     EXPECT_EQ(num_output_nodes, 1U);

--- a/onnxruntime/test/shared_lib/fns_candy_style_transfer.c
+++ b/onnxruntime/test/shared_lib/fns_candy_style_transfer.c
@@ -178,7 +178,7 @@ int run_inference(OrtSession* session, const char* input_file, const char* outpu
 
 void verify_input_output_count(OrtSession* session) {
   size_t count;
-  ORT_ABORT_ON_ERROR(OrtSessionGetInputCount(session, &count));
+  ORT_ABORT_ON_ERROR(OrtSessionGetInputCount(session, kInputsOnly, &count));
   assert(count == 1);
   ORT_ABORT_ON_ERROR(OrtSessionGetOutputCount(session, &count));
   assert(count == 1);

--- a/onnxruntime/test/shared_lib/test_io_types.cc
+++ b/onnxruntime/test/shared_lib/test_io_types.cc
@@ -12,7 +12,7 @@ static void TestModelInfo(const Ort::Session& session, bool is_input, const std:
     input_count = session.GetOutputCount();
   }
   ASSERT_EQ(1, input_count);
-  Ort::TypeInfo input_type_info = is_input ? session.GetInputTypeInfo(0) : session.GetOutputTypeInfo(0);
+  Ort::TypeInfo input_type_info = is_input ? session.GetInputTypeInfo(kInputsOnly, 0) : session.GetOutputTypeInfo(0);
   ASSERT_NE(nullptr, input_type_info);
 
   ONNXType otype = input_type_info.GetONNXType();

--- a/onnxruntime/test/shared_lib/test_io_types.cc
+++ b/onnxruntime/test/shared_lib/test_io_types.cc
@@ -7,7 +7,7 @@
 static void TestModelInfo(const Ort::Session& session, bool is_input, const std::vector<int64_t>& dims) {
   size_t input_count;
   if (is_input) {
-    input_count = session.GetInputCount();
+    input_count = session.GetInputCount(kInputsOnly);
   } else {
     input_count = session.GetOutputCount();
   }

--- a/samples/c_cxx/fns_candy_style_transfer/fns_candy_style_transfer.c
+++ b/samples/c_cxx/fns_candy_style_transfer/fns_candy_style_transfer.c
@@ -204,7 +204,7 @@ int run_inference(OrtSession* session, const ORTCHAR_T* input_file, const ORTCHA
 
 void verify_input_output_count(OrtSession* session) {
   size_t count;
-  ORT_ABORT_ON_ERROR(OrtSessionGetInputCount(session, &count));
+  ORT_ABORT_ON_ERROR(OrtSessionGetInputCount(session, kInputsOnly , &count));
   assert(count == 1);
   ORT_ABORT_ON_ERROR(OrtSessionGetOutputCount(session, &count));
   assert(count == 1);

--- a/samples/c_cxx/imagenet/main.cc
+++ b/samples/c_cxx/imagenet/main.cc
@@ -67,7 +67,7 @@ class Validator : public OutputCollector<TCharString> {
 
   static void VerifyInputOutputCount(OrtSession* session) {
     size_t count;
-    ORT_THROW_ON_ERROR(OrtSessionGetInputCount(session, &count));
+    ORT_THROW_ON_ERROR(OrtSessionGetInputCount(session, kInputsOnly, &count));
     assert(count == 1);
     ORT_THROW_ON_ERROR(OrtSessionGetOutputCount(session, &count));
     assert(count == 1);
@@ -131,7 +131,7 @@ class Validator : public OutputCollector<TCharString> {
     ORT_THROW_ON_ERROR(OrtGetAllocatorWithDefaultOptions(&ort_alloc));
     {
       char* t;
-      ORT_THROW_ON_ERROR(OrtSessionGetInputName(session_, 0, ort_alloc, &t));
+      ORT_THROW_ON_ERROR(OrtSessionGetInputName(session_, kInputsOnly, 0, ort_alloc, &t));
       input_name_ = my_strdup(t);
       OrtAllocatorFree(ort_alloc, t);
       ORT_THROW_ON_ERROR(OrtSessionGetOutputName(session_, 0, ort_alloc, &t));
@@ -140,7 +140,7 @@ class Validator : public OutputCollector<TCharString> {
     }
 
     OrtTypeInfo* info;
-    ORT_THROW_ON_ERROR(OrtSessionGetInputTypeInfo(session_, 0, &info));
+    ORT_THROW_ON_ERROR(OrtSessionGetInputTypeInfo(session_, kInputsOnly, 0, &info));
     const OrtTensorTypeAndShapeInfo* tensor_info;
     ORT_THROW_ON_ERROR(OrtCastTypeInfoToTensorInfo(info, &tensor_info));
     size_t dim_count;


### PR DESCRIPTION
**Description**: 
Enable models with IR4 to have optional inputs and override initializers.
Add GetInputsIncludingInitializers to InferenceSession
Add python InferenceSession get_inputs_including_initializers
Add C/C++ API enum argument kInputsOnly/kIncludeInitializers
 Refactor C# and the rest of the code for compatibility.

**Motivation and Context**
 Clients require this functionality to have optional inputs that are by default initialized. They want to be able to have defaults but to be able to override them as needed.