### PR TITLE
Revert PR #1839

### DIFF
--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -39,23 +39,9 @@ void ThreadPool::ParallelFor(int32_t total, std::function<void(int32_t)> fn) {
     fn(0);
     return;
   }
+
   // TODO: Eigen supports a more efficient ThreadPoolDevice mechanism
   // We will simply rely on the work queue and stealing in the short term.
-  if (total > NumThreads()) {
-    //The dispatcher thread will be idle at here
-    Barrier barrier(static_cast<unsigned int>(total));
-    std::function<void(int32_t)> handle_iteration = [&barrier, &fn](int iteration) {
-      fn(iteration);
-      barrier.Notify();
-    };
-
-    for (int32_t id = 0; id < total; ++id) {
-      Schedule([=, &handle_iteration]() { handle_iteration(id); });
-    }
-
-    barrier.Wait();
-    return;
-  }
   Barrier barrier(static_cast<unsigned int>(total - 1));
   std::function<void(int32_t)> handle_iteration = [&barrier, &fn](int iteration) {
     fn(iteration);
@@ -65,7 +51,7 @@ void ThreadPool::ParallelFor(int32_t total, std::function<void(int32_t)> fn) {
   for (int32_t id = 1; id < total; ++id) {
     Schedule([=, &handle_iteration]() { handle_iteration(id); });
   }
-  //reuse the current thread for one task
+
   fn(0);
   barrier.Wait();
 }

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -545,7 +545,7 @@ MlasGetMaximumThreadCount(
     MLAS_UNREFERENCED_PARAMETER(ThreadPool);
 #else
     if (ThreadPool != nullptr) {
-        return ThreadPool->NumThreads();
+        return ThreadPool->NumThreads() + 1;
     }
 #endif
 


### PR DESCRIPTION
This reverts commit 166b1f86db0d9a41189a65b1bfb30110424cc955.

**Description**: 

This reverts commit 166b1f86db0d9a41189a65b1bfb30110424cc955 because our perf dashboard shows it caused great perf degradation. 

| model                    | NEW_CHANGE(With #1839) | OLD      | DIFF | EnableParallelExecutor |
|--------------------------|------------|----------|------|------------------------|
| bvlc_googlenet           | 0.019563   | 0.015691 | 24   | 0                      |
| inception_resnet_v2      | 0.101839   | 0.08823  | 15   | 0                      |
| inception_v2             | 0.015011   | 0.009312 | 61   | 0                      |
| mlperf_mobilenet         | 0.0041     | 0.002606 | 57   | 0                      |
| mlperf_resnet            | 0.023533   | 0.014486 | 62   | 0                      |
| mlperf_ssd_mobilenet_300 | 0.024972   | 0.021661 | 15   | 0                      |
| prod_model11             | 0.002839   | 0.002385 | 19   | 0                      |
| prod_model2              | 0.011392   | 0.007258 | 56   | 0                      |
| resnet50                 | 0.023617   | 0.014324 | 64   | 0                      |
| squeezenet               | 0.003154   | 0.0022   | 43   | 0                      |

Note: 
The second column was run with thread pool size = 4
The third    column was run with thread pool size = 3


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
