### PR TITLE
remove sudo from the cleanup step for Linux

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/clean-agent-build-directory-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/clean-agent-build-directory-step.yml
@@ -4,6 +4,6 @@ steps:
 - script: rd /S /Q $(Agent.BuildDirectory)
   displayName: Clean build files (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT') # and always()
-- script: sudo rm -rf $(Agent.BuildDirectory)
+- script: rm -rf $(Agent.BuildDirectory)
   displayName: Clean build files (POSIX)
   condition: not(eq(variables['Agent.OS'], 'Windows_NT')) # and always()

--- a/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-while getopts p: parameter_Option
+while getopts p:d: parameter_Option
 do case "${parameter_Option}"
 in
 p) PYTHON_VER=${OPTARG};;


### PR DESCRIPTION
1. remove sudo from the cleanup step for Linux so that we don't need the sudo access for vstsagent build user
2. a minor fix in the install_ubuntu.sh to make the image smaller for openvino build
