### PR TITLE
quantise: Don't error when initializer graph input is missing

### DIFF
--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -309,9 +309,10 @@ class ONNXQuantizer:
             # Removing input weight to a convolution
             try:
                 weight_input = next(val for val in self.model.graph.input if val.name == weight.name)
+                self.model.graph.input.remove(weight_input)
             except StopIteration:
-                raise ValueError('invalid weight name {} found in the graph '.format(weight.name))
-            self.model.graph.input.remove(weight_input)
+                if self.model.ir_version < 4:
+                    raise ValueError('invalid weight name {} found in the graph (not a graph input) '.format(weight.name))
 
 
     def _update_graph(self, weight):


### PR DESCRIPTION
# Description

ONNX IR version 4 and above do not require graph initializers to have corresponding graph inputs.  
This PR fixes a quantization tool error arising when there is no graph input for a graph initializer:

> ValueError: invalid weight name 7 found in the graph

# Python example

```python
import torch
import onnx
import numpy as np

# Create simple model to export from PyTorch
model = torch.nn.Sequential(
    torch.nn.Linear(256, 256),
    torch.nn.ReLU(),
)
model.eval()
torch.onnx.export(
    model,
    torch.ones(256),
    "ff.folded.onnx",
    export_params = True,
    training = False,
    do_constant_folding = True,
    keep_initializers_as_inputs = False,
)

# From https://github.com/microsoft/onnxruntime/blob/master/onnxruntime/python/tools/quantization/README.md

# Load the onnx model
model = onnx.load('ff.folded.onnx')
# Quantize
quantized_model = quantize(
    model,
    per_channel = False,
    nbits = 8,
    quantization_mode = QuantizationMode.IntegerOps,
    static = True,
    asymmetric_input_types = True,
    input_quantization_params={
        'input.1': [np.uint8(113), np.float32(0.05)],
    },
)
# Save the quantized model
onnx.save(quantized_model, 'ff.folded.quantised.onnx')
```

cc @askhade