### PR TITLE
Account for Constant node being versioned in opset-11

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -650,13 +650,6 @@ Graph::Graph(GraphProto* graph_proto, const std::unordered_map<std::string, int>
       continue;
     }
 
-    // 'Constant' nodes support specifying a tensor or sparse_tensor starting Opset-11
-    // Only one of them can be present in a node. Hence enforcing this.
-    ORT_ENFORCE(node.attribute_size() == 1 , "This is an invalid model. " 
-                                             "The model contains an invalid 'Constant' node. "
-                                             "Exactly one of the two attributes - 'value' or "
-                                             "'sparse_value' must be specified in a 'Constant' node. ");
-
     // Copy constant nodes _value to name_to_initial_tensor_
     const gsl::not_null<TensorProto*>
         tensor{graph_proto_->add_initializer()};
@@ -666,7 +659,7 @@ Graph::Graph(GraphProto* graph_proto, const std::unordered_map<std::string, int>
     // An easy way is to implement a method that converts a SparseTensorproto into a TensorProto to use the same downstream flow,
     // but that is going to impact peak memory usage and probably a smarter way is required.
     ORT_ENFORCE(constant_attribute.has_t(), "Only 'value' attribute is supported within a 'Constant' node in ORT");
-    *tensor = node.attribute(0).t();
+    *tensor = constant_attribute.t();
     *(tensor->mutable_name()) = node.output(0);
   }
 

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -656,8 +656,8 @@ Graph::Graph(GraphProto* graph_proto, const std::unordered_map<std::string, int>
     const AttributeProto& constant_attribute = node.attribute(0);
     // TODO: Add support for parsing 'sparse_value' attribute from a 'Constant' node
     // Discussion surrounding handling the SparseTensorProto must be had. 
-    // An easy way is to implement a method that converts a SparseTensorproto into a TensorProto to use the same downstream flow,
-    // but that is going to impact peak memory usage and probably a smarter way is required.
+    // An easy way is to implement a method that converts a SparseTensorproto into a TensorProto 
+    // to use the same downstream flow, but that is going to impact peak memory usage and probably a smarter way is required.
     ORT_ENFORCE(constant_attribute.has_t(), "Only 'value' attribute is supported within a 'Constant' node in ORT");
     *tensor = constant_attribute.t();
     *(tensor->mutable_name()) = node.output(0);

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -644,7 +644,7 @@ Graph::Graph(GraphProto* graph_proto, const std::unordered_map<std::string, int>
   ArgNameToTypeMap name_to_type_map;
 
   // Process 'Constant' nodes
-  // Put the 'tensor' stored in the 'Constant' nodes attribute into the graphs initializer list
+  // Put the 'TensorProto' stored in the 'Constant' nodes attribute into the graphs initializer list
   for (auto& node : graph_proto_->node()) {
     if (node.op_type() != kConstant) {
       continue;

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -643,14 +643,29 @@ Graph::Graph(GraphProto* graph_proto, const std::unordered_map<std::string, int>
   ORT_ENFORCE(graph_proto != nullptr, "graph_proto cannot be null");
   ArgNameToTypeMap name_to_type_map;
 
+  // Process 'Constant' nodes
+  // Put the 'tensor' stored in the 'Constant' nodes attribute into the graphs initializer list
   for (auto& node : graph_proto_->node()) {
     if (node.op_type() != kConstant) {
       continue;
     }
 
+    // 'Constant' nodes support specifying a tensor or sparse_tensor starting Opset-11
+    // Only one of them can be present in a node. Hence enforcing this.
+    ORT_ENFORCE(node.attribute_size() == 1 , "This is an invalid model. " 
+                                             "The model contains an invalid 'Constant' node. "
+                                             "Exactly one of the two attributes - 'value' or "
+                                             "'sparse_value' must be specified in a 'Constant' node. ");
+
     // Copy constant nodes _value to name_to_initial_tensor_
     const gsl::not_null<TensorProto*>
         tensor{graph_proto_->add_initializer()};
+    const AttributeProto& constant_attribute = node.attribute(0);
+    // TODO: Add support for parsing 'sparse_value' attribute from a 'Constant' node
+    // Discussion surrounding handling the SparseTensorProto must be had. 
+    // An easy way is to implement a method that converts a SparseTensorproto into a TensorProto to use the same downstream flow,
+    // but that is going to impact peak memory usage and probably a smarter way is required.
+    ORT_ENFORCE(constant_attribute.has_t(), "Only 'value' attribute is supported within a 'Constant' node in ORT");
     *tensor = node.attribute(0).t();
     *(tensor->mutable_name()) = node.output(0);
   }


### PR DESCRIPTION
**Description**: Opset-11 Constant supports taking in a 'sparse_value'. We are not planning to support this for the upcoming release. So, we handle it within appropriately by providing the appropriate error message.

**Motivation and Context**
Make ORT opset-11 compliant 
