### PR TITLE
Address two issues:

### DIFF
--- a/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.cc
+++ b/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.cc
@@ -306,7 +306,6 @@ DeepCpuLstmOp::Compute(OpKernelContext* context) const {
 }
 
 // #define DUMP_MATRIXES to provide lots of diagnostic output
-#define DUMP_MATRIXES
 #if defined(DUMP_MATRIXES)
 #define DumpMatrix(...) ::onnxruntime::rnn::detail::DumpMatrixImpl(__VA_ARGS__)
 #else

--- a/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.cc
+++ b/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.cc
@@ -794,10 +794,6 @@ void UniDirectionalLstm<T>::Compute(const gsl::span<const T>& inputs_arg,
   // explicitly check just the range for each iteration, however if it's going to run over
   // it should also run over on the last iteration, so this should be good enough to catch any
   // logic errors causing bounds violations.
-  span_T_iter C_prev_end = batched_internal_state_prev_one_step.end();
-  span_T_iter C_prev_clipped_end = batched_internal_state_clipped_one_step.end();
-  span_T_const_iter previous_state_end = batched_hidden_state_one_step.end();
-
   if (batch_parallel_) {
     int fused_hidden_rows = batch_size_ / hidden_num_threads_;
     if (batch_size_ % hidden_num_threads_ != 0)
@@ -805,6 +801,10 @@ void UniDirectionalLstm<T>::Compute(const gsl::span<const T>& inputs_arg,
 
     // lambda to do all processing on fused_hidden_rows rows
     auto hidden_gemm_and_activations = [&](int row) {
+      span_T_iter C_prev_end = batched_internal_state_prev_one_step.end();
+      span_T_iter C_prev_clipped_end = batched_internal_state_clipped_one_step.end();
+      span_T_const_iter previous_state_end = batched_hidden_state_one_step.cend();
+
       //handling boundaries
       int local_fused_hidden_rows = fused_hidden_rows;
       if ((row + fused_hidden_rows) > batch_size_)
@@ -887,6 +887,10 @@ void UniDirectionalLstm<T>::Compute(const gsl::span<const T>& inputs_arg,
     ExecuteLambdaInParallel("Processing batch", hidden_gemm_and_activations, batch_size_, fused_hidden_rows, lstm_tp_, logger_);
 
   } else {
+    span_T_iter C_prev_end = batched_internal_state_prev_one_step.end();
+    span_T_iter C_prev_clipped_end = batched_internal_state_clipped_one_step.end();
+    span_T_const_iter previous_state_end = batched_hidden_state_one_step.cend();
+
     span_T_iter c_prev = batched_internal_state_prev_one_step.begin();
     span_T_iter c_prev_clipped = batched_internal_state_clipped_one_step.begin();
 

--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.h
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.h
@@ -47,8 +47,8 @@ inline Direction MakeDirection(const std::string& direction) {
   if (direction == "bidirectional") {
     return kBidirectional;
   }
-    ORT_THROW("Invalid 'direction' argument of '", direction,
-              "'. Must be one of 'forward', 'reverse', or 'bidirectional'.");
+  ORT_THROW("Invalid 'direction' argument of '", direction,
+            "'. Must be one of 'forward', 'reverse', or 'bidirectional'.");
 }
 
 /** Allocate a unique_ptr using allocator_, and return a span to the allocated memory so usage is safe
@@ -230,17 +230,51 @@ void ExecuteLambdaInParallel(const std::string& name, TLambda lambda, int max, i
   ORT_UNUSED_PARAMETER(name);
   ORT_UNUSED_PARAMETER(logger);
 
-  std::atomic<int> done(0);
-  for (int i = 0; i < max; i += step) {
-    ttp.Schedule([lambda, i, &done]() {
-      lambda(i);
-      ++done;
+  const int total_tasks = max / (step > 0 ? step : 1) + (max % step > 0 ? 1 : 0);
+
+  // ORT_ENFORCE may and does throw at times from within the tasks that run
+  // on a thread-pool. Without propagating exceptions the process exits silently
+  // which will make diagnosing bugs more difficult.
+
+  // \! UGLY
+  // We have a problem here with the current thread-pool is that it takes std::function
+  // by value and copies it more than once (even though it is movable).
+  //
+  // To report status and exceptions properly it's better to use
+  // futures and promises but they are not copyable, so we can't come up with a functor
+  // with a promise member and we are downgrading to C++11 where we can't have captures that moved in.
+  //
+  // At the same time promises MUST live in the child thread so if we throw from the main thread
+  // we don't destroy any promises that are on the main thread stack which children threads may still be using.
+  //
+  // The only solution with the current Eigen that comes to mind is to have shared_ptr to with std::promise.
+  //
+
+  std::vector<std::future<void> > futures;
+  for (int i = 0, t = 0; i < max; i += step, ++t) {
+    auto p_ptr = std::make_shared<std::promise<void> >();
+    futures.push_back(p_ptr->get_future());
+    ttp.Schedule([p_ptr, lambda, i]() {
+      try {
+        lambda(i);
+        p_ptr->set_value();
+      } catch (...) {
+        p_ptr->set_exception(std::current_exception());
+      }
     });
   }
 
-  int totalTasks = max / (step > 0 ? step : 1) + (max % step > 0 ? 1 : 0);
-  while (done != totalTasks)
-    ;
+  // If ORT_ENFORCE is failing multiple threads can throw
+  // we ignore other exceptions but one. Futures with unclaimed
+  // shared states should destruct just fine.
+  for (auto& fut : futures) {
+    try {
+      fut.get();
+    } catch (...) {
+      throw;
+    }
+  }
+
 #endif
 }
 

--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.h
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.h
@@ -230,8 +230,6 @@ void ExecuteLambdaInParallel(const std::string& name, TLambda lambda, int max, i
   ORT_UNUSED_PARAMETER(name);
   ORT_UNUSED_PARAMETER(logger);
 
-  const int total_tasks = max / (step > 0 ? step : 1) + (max % step > 0 ? 1 : 0);
-
   // ORT_ENFORCE may and does throw at times from within the tasks that run
   // on a thread-pool. Without propagating exceptions the process exits silently
   // which will make diagnosing bugs more difficult.

--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.h
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.h
@@ -247,8 +247,10 @@ void ExecuteLambdaInParallel(const std::string& name, TLambda lambda, int max, i
   //
   // The only solution with the current Eigen that comes to mind is to have shared_ptr to with std::promise.
   //
-
+  const int total_tasks = max / (step > 0 ? step : 1) + (max % step > 0 ? 1 : 0);
   std::vector<std::future<void> > futures;
+  futures.reserve(total_tasks);
+
   for (int i = 0, t = 0; i < max; i += step, ++t) {
     auto p_ptr = std::make_shared<std::promise<void> >();
     futures.push_back(p_ptr->get_future());
@@ -262,15 +264,24 @@ void ExecuteLambdaInParallel(const std::string& name, TLambda lambda, int max, i
     });
   }
 
-  // If ORT_ENFORCE is failing multiple threads can throw
-  // we ignore other exceptions but one. Futures with unclaimed
-  // shared states should destruct just fine.
+  // We'd like to wait until all of the tasks have finished
+  // even though one or more have already thrown. We will store
+  // the first exception and then will re-throw at the end.
+  std::exception_ptr pending_exception;
   for (auto& fut : futures) {
     try {
+      // get() will re-throw any exceptions
+      // the running task may throw
       fut.get();
     } catch (...) {
-      throw;
+      if (!pending_exception) {
+        pending_exception = std::current_exception();
+      }
     }
+  }
+
+  if (pending_exception) {
+    std::rethrow_exception(pending_exception);
   }
 
 #endif


### PR DESCRIPTION
**Description**: Address thread-safety bugs in LTSM implementation

**Motivation and Context**
- When LTSM runs several lambdas on a thread-pool they capture shared iterators by reference. Each lambda updates them which results in undefined behavior. Each lambda requires its own copy of iterators.
When upgrading to new GSL library the issue resulted in ORT_ENFORCE failures 8 out 10 times.
- When ORT_ENFORCE throws there is nothing that catches and reports exceptions in RNN helpers that runs lambdas in parallel. Added code that reports such exceptions.
