### PR TITLE
logging related fixes.

### DIFF
--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -18,4 +18,4 @@ __author__ = "Microsoft"
 from onnxruntime.capi import onnxruntime_validation
 onnxruntime_validation.check_distro_info()
 from onnxruntime.capi.session import InferenceSession
-from onnxruntime.capi._pybind_state import get_all_providers, get_available_providers, get_device, RunOptions, SessionOptions, NodeArg, ModelMetadata, GraphOptimizationLevel
+from onnxruntime.capi._pybind_state import get_all_providers, get_available_providers, get_device, RunOptions, SessionOptions, set_default_logger_severity, NodeArg, ModelMetadata, GraphOptimizationLevel

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1007,7 +1007,7 @@ const logging::Logger& InferenceSession::CreateLoggerForRun(const RunOptions& ru
 
 void InferenceSession::InitLogger(logging::LoggingManager* logging_manager) {
   // create logger for session, using provided logging manager if possible
-  if (logging_manager != nullptr && !session_options_.session_logid.empty()) {
+  if (logging_manager != nullptr) {
     logging::Severity severity = logging::Severity::kWARNING;
     if (session_options_.session_log_severity_level == -1) {
       severity = logging::LoggingManager::DefaultLogger().GetSeverity();

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -333,6 +333,14 @@ void addGlobalMethods(py::module& m) {
       "get_device", []() -> std::string { return BACKEND_DEVICE; },
       "Return the device used to compute the prediction (CPU, MKL, ...)");
   m.def(
+      "set_default_logger_severity", [](int severity) {
+        ORT_ENFORCE(severity >= 0 && severity <= 4,
+                    "Invalid logging severity. 0:Verbose, 1:Info, 2:Warning, 3:Error, 4:Fatal");
+        logging::LoggingManager* default_logging_manager = SessionObjectInitializer::Get();
+        default_logging_manager->SetDefaultLoggerSeverity(static_cast<logging::Severity>(severity));
+      },
+      "Sets the default logging severity. 0:Verbose, 1:Info, 2:Warning, 3:Error, 4:Fatal");
+  m.def(
       "get_all_providers", []() -> const std::vector<std::string>& { return GetAllProviders(); },
       "Return list of Execution Providers that this version of Onnxruntime can support.");
   m.def(


### PR DESCRIPTION
-add back python api for set_default_logger_severity() which is useful for configuring default logger. it was removed (by mistake?)

-relax check for creating session_logid when creating logger. otherwise, one can't change log severity/verbosity without specifying a logid, which previously you could do. 
looks like this code was changed recently. 
there is no requirement for run_options.run_tag, so for consistency, session_options.session_logid shouldn't be required either)
