### PR TITLE
added continue on error for the linux cleanup step, to mitigate the build failure

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/clean-agent-build-directory-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/clean-agent-build-directory-step.yml
@@ -7,3 +7,4 @@ steps:
 - script: rm -rf $(Agent.BuildDirectory)
   displayName: Clean build files (POSIX)
   condition: not(eq(variables['Agent.OS'], 'Windows_NT')) # and always()
+  continueOnError: true  # continuing on error for this step, since linux build folder is somehow getting permission issue


### PR DESCRIPTION
Added continue on error for the linux cleanup step, to mitigate the build failure.
Root cause of why the build folder is getting something with root ownership is unknown. Suspecting some other builds in the Aiinfra pool. 

**Description**: Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
