### PR TITLE
Add WaitForGpuCompletion

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/inc/DmlExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/inc/DmlExecutionProvider.h
@@ -35,6 +35,7 @@ namespace Dml
     void SetDefaultRoundingMode(onnxruntime::IExecutionProvider* provider, AllocatorRoundingMode roundingMode);
     void ReleaseCompletedReferences(onnxruntime::IExecutionProvider* provider);
     void TrimUploadHeap(onnxruntime::IExecutionProvider * provider);
+    void WaitForGpuCompletion(onnxruntime::IExecutionProvider * provider);
     
     onnxruntime::common::Status CopyTensor(
         onnxruntime::IExecutionProvider* provider, 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -483,7 +483,7 @@ namespace Dml
         return onnxruntime::common::Status::OK();
     }
 
-    Status ExecutionProviderImpl::Sync()
+    Status ExecutionProviderImpl::WaitForGpuCompletion()
     {
         assert(!m_closed);
 
@@ -683,7 +683,13 @@ namespace Dml
         ExecutionProvider* dmlexecutionprovider = static_cast<Dml::ExecutionProvider*>(provider);
         dmlexecutionprovider->TrimUploadHeap();
     }
-    
+
+    void WaitForGpuCompletion(onnxruntime::IExecutionProvider * provider)
+    {
+        ExecutionProvider* dmlexecutionprovider = static_cast<Dml::ExecutionProvider*>(provider);
+        dmlexecutionprovider->WaitForGpuCompletion();
+    }
+
     onnxruntime::common::Status CopyTensor(
         onnxruntime::IExecutionProvider* provider, 
         const onnxruntime::Tensor& src, 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
@@ -94,7 +94,7 @@ namespace Dml
         uint32_t GetSuppportedDeviceDataTypeMask() const;
 
         onnxruntime::common::Status CopyTensor(const onnxruntime::Tensor& src, onnxruntime::Tensor& dst) const;
-        onnxruntime::common::Status Sync();
+        onnxruntime::common::Status WaitForGpuCompletion();
 
         // IWinmlExecutionProvider methods
         void QueueReference(IUnknown* object) override;
@@ -239,9 +239,12 @@ namespace Dml
             GetCapability(const onnxruntime::GraphViewer& graph,
                 const std::vector<const onnxruntime::KernelRegistry*>& kernel_registries) const final;
 
-        onnxruntime::common::Status Sync()
+        // Not to be confused with IExecutionProvider::Sync() const.  The DML provider handles 
+        // synchronization when copying inputs and outputs, therefore doesn't override the 
+        // default ORT method, which does nothin.
+        onnxruntime::common::Status WaitForGpuCompletion()
         {
-            return m_impl->Sync();
+            return m_impl->WaitForGpuCompletion();
         }
 
         void Flush()


### PR DESCRIPTION
**Description**: Add WaitForGpuCompletion method and rename Sync method in DML EP to avoid confusion with non-const base class method.

**Motivation and Context**
Enable callers to flush and wait for GPU work to complete, so caches can be subsequently freed completely