### PR TITLE
Implement cuda scatter op.

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -547,6 +547,9 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, double, Gemm);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, MLFloat16, Gemm);
 
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 9, 10, Scatter);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, ScatterElements);
+
 static void RegisterCudaKernels(KernelRegistry& kernel_registry) {
   static const BuildKernelCreateInfoFn function_table[] = {
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MemcpyFromHost)>,
@@ -891,6 +894,9 @@ static void RegisterCudaKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, MLFloat16, Gemm)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, float, Gemm)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, double, Gemm)>,
+
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 9, 10, Scatter)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, ScatterElements)>,
   };
 
   for (auto& function_table_entry : function_table) {

--- a/onnxruntime/core/providers/cuda/tensor/scatter_elements.cc
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_elements.cc
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "scatter_elements.h"
+#include "scatter_elements_impl.h"
+#include "core/providers/cpu/tensor/utils.h"
+#include "core/providers/common.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
+    Scatter,
+    kOnnxDomain,
+    9,
+    10,
+    kCudaExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("Tind", std::vector<MLDataType>{
+                                    DataTypeImpl::GetTensorType<int32_t>(),
+                                    DataTypeImpl::GetTensorType<int64_t>()}),
+    ScatterElements);
+
+ONNX_OPERATOR_KERNEL_EX(
+    ScatterElements,
+    kOnnxDomain,
+    11,
+    kCudaExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("Tind", std::vector<MLDataType>{
+                                    DataTypeImpl::GetTensorType<int32_t>(),
+                                    DataTypeImpl::GetTensorType<int64_t>()}),
+    ScatterElements);
+
+#define TYPED_FUNCTION_CALL(T)                                                \
+  if (T_type == DataTypeImpl::GetType<T>()) {                                 \
+    T* output_data = output_tensor->template MutableData<T>();                \
+    const T* input_data = data_tensor->template Data<T>();                    \
+    const T* update_data = updates_tensor->template Data<T>();                \
+    if (Tin_type == DataTypeImpl::GetType<int32_t>()) {                       \
+      const int32_t* indices_data = indices_tensor->template Data<int32_t>(); \
+      ScatterElementsImpl(                                                    \
+          rank,                                                               \
+          reinterpret_cast<const ToCudaType<T>::MappedType*>(input_data),     \
+          input_data_size,                                                    \
+          gpu_input_dims.GpuPtr(),                                            \
+          gpu_input_strides.GpuPtr(),                                         \
+          indices_data,                                                       \
+          indices_size,                                                       \
+          gpu_indices_dims.GpuPtr(),                                          \
+          fdm_indices_strides.GpuPtr(),                                       \
+          reinterpret_cast<const ToCudaType<T>::MappedType*>(update_data),    \
+          axis,                                                               \
+          reinterpret_cast<ToCudaType<T>::MappedType*>(output_data));         \
+      return Status::OK();                                                    \
+    }                                                                         \
+    if (Tin_type == DataTypeImpl::GetType<int64_t>()) {                       \
+      const int64_t* indices_data = indices_tensor->template Data<int64_t>(); \
+      ScatterElementsImpl(                                                    \
+          rank,                                                               \
+          reinterpret_cast<const ToCudaType<T>::MappedType*>(input_data),     \
+          input_data_size,                                                    \
+          gpu_input_dims.GpuPtr(),                                            \
+          gpu_input_strides.GpuPtr(),                                         \
+          indices_data,                                                       \
+          indices_size,                                                       \
+          gpu_indices_dims.GpuPtr(),                                          \
+          fdm_indices_strides.GpuPtr(),                                       \
+          reinterpret_cast<const ToCudaType<T>::MappedType*>(update_data),    \
+          axis,                                                               \
+          reinterpret_cast<ToCudaType<T>::MappedType*>(output_data));         \
+      return Status::OK();                                                    \
+    }                                                                         \
+  }
+
+Status ScatterElements::ComputeInternal(OpKernelContext* context) const {
+  const auto* data_tensor = context->Input<Tensor>(0);
+  const auto& input_data_shape = data_tensor->Shape();
+  const int64_t input_data_size = input_data_shape.Size();
+  const auto axis = HandleNegativeAxis(axis_, input_data_shape.NumDimensions());
+
+  const auto* indices_tensor = context->Input<Tensor>(1);
+  const auto* updates_tensor = context->Input<Tensor>(2);
+
+  if (data_tensor->DataType() != updates_tensor->DataType()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "data type is different from updates type");
+  }
+
+  const auto& indices_dims = indices_tensor->Shape().GetDims();
+  const int64_t indices_size = indices_tensor->Shape().Size();
+  const auto& updates_dims = updates_tensor->Shape().GetDims();
+  if (indices_dims.size() != updates_dims.size()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Indices and updates must have the same rank");
+  }
+
+  for (size_t i = 0; i < indices_dims.size(); ++i) {
+    if (indices_dims[i] != updates_dims[i]) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Indices vs updates dimensions differs at position=", i,
+                             " ", indices_dims[i], " vs ", updates_dims[i]);
+    }
+  }
+
+  // According to the spec the rank of ind/upd shall be the same as input(data)
+  // and we also want to make sure that the dimensions of the of the ind/upd do not
+  // exceed that of the input
+  const auto& input_dims = input_data_shape.GetDims();
+  if (input_dims.size() != indices_dims.size()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Indices must have the same rank as Input. Indices rank=",
+                           indices_dims.size(), ". Input rank=", input_dims.size());
+  }
+
+  for (size_t i = 0; i < input_dims.size(); ++i) {
+    if (input_dims[i] < indices_dims[i]) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Indices dim=", indices_dims[i], " at pos=", i,
+                             " is greater than input dim=", input_dims[i]);
+    }
+  }
+
+  int rank = (int)input_dims.size();
+  auto* output_tensor = context->Output(0, input_data_shape);
+
+  CudaAsyncBuffer<int64_t> gpu_input_dims(this, input_dims);
+  TensorPitches input_strides(input_dims);
+  CudaAsyncBuffer<int64_t> gpu_input_strides(this, input_strides);
+
+  CudaAsyncBuffer<int64_t> gpu_indices_dims(this, indices_dims);
+  CudaAsyncBuffer<fast_divmod> fdm_indices_strides(this, rank);
+  ORT_ENFORCE(CalculateFdmStrides(fdm_indices_strides.CpuSpan(), indices_dims));
+
+  ORT_RETURN_IF_ERROR(gpu_input_dims.CopyToGpu());
+  ORT_RETURN_IF_ERROR(gpu_input_strides.CopyToGpu());
+  ORT_RETURN_IF_ERROR(gpu_indices_dims.CopyToGpu());
+  ORT_RETURN_IF_ERROR(fdm_indices_strides.CopyToGpu());
+
+  MLDataType Tin_type = indices_tensor->DataType();
+  MLDataType T_type = data_tensor->DataType();
+
+  TYPED_FUNCTION_CALL(float)
+  else TYPED_FUNCTION_CALL(MLFloat16)
+  else TYPED_FUNCTION_CALL(int16_t)
+  else TYPED_FUNCTION_CALL(int8_t)
+  else TYPED_FUNCTION_CALL(int32_t)
+  else TYPED_FUNCTION_CALL(int64_t)
+  else TYPED_FUNCTION_CALL(uint8_t)
+  else TYPED_FUNCTION_CALL(uint16_t)
+  else TYPED_FUNCTION_CALL(uint32_t)
+  else TYPED_FUNCTION_CALL(uint64_t)
+  else TYPED_FUNCTION_CALL(double)
+  else TYPED_FUNCTION_CALL(bool)
+
+  return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED, "Type for T is not supported yet in ScatterElements.");
+}
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/tensor/scatter_elements.cc
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_elements.cc
@@ -79,7 +79,7 @@ Status ScatterElements::ComputeInternal(OpKernelContext* context) const {
   const auto* data_tensor = context->Input<Tensor>(0);
   const auto& input_data_shape = data_tensor->Shape();
   const int64_t input_data_size = input_data_shape.Size();
-  const auto axis = HandleNegativeAxis(axis_, input_data_shape.NumDimensions());
+  const int axis = static_cast<int>(HandleNegativeAxis(axis_, input_data_shape.NumDimensions()));
 
   const auto* indices_tensor = context->Input<Tensor>(1);
   const auto* updates_tensor = context->Input<Tensor>(2);

--- a/onnxruntime/core/providers/cuda/tensor/scatter_elements.h
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_elements.h
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include "core/common/common.h"
+#include "core/framework/op_kernel.h"
+#include "core/providers/cuda/cuda_common.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+class ScatterElements final : public CudaKernel {
+ public:
+  ScatterElements(const OpKernelInfo& info) : CudaKernel(info) {
+    ORT_ENFORCE(info.GetAttr<int64_t>("axis", &axis_).IsOK(),
+                "Missing/Invalid 'axis' attribute value");
+  }
+  ~ScatterElements() = default;
+  Status ComputeInternal(OpKernelContext* context) const override;
+
+ private:
+  int64_t axis_;
+};
+
+}  // namespace cuda
+}  // namespace onnxruntime
+

--- a/onnxruntime/core/providers/cuda/tensor/scatter_elements_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_elements_impl.cu
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cuda/cu_inc/common.cuh"
+#include "scatter_elements_impl.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+template <typename T, typename Tin>
+__global__ void _ScatterElementsKernel(
+    const int rank,
+    const T* input_data,
+    const int64_t* input_dims,
+    const int64_t* input_strides,
+    const Tin* indices_data,
+    const int64_t indices_size,
+    const int64_t* indices_dims,
+    const fast_divmod* indices_strides,
+    const T* updates,
+    const int axis,
+    T* output_data) {
+  CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(indices_index, indices_size);
+  int dim, remain = indices_index;
+  size_t data_idx = 0;
+  for (int i = 0; i < rank; ++i) {
+    indices_strides[i].divmod(remain, dim, remain);
+    if (i == axis) {
+      dim = (int)(indices_data[indices_index]);
+      if (dim < -input_dims[i] || dim >= input_dims[i]) {
+        return; // Invalid index
+      }
+      if (dim < 0) dim += input_dims[i];
+    }
+    data_idx += input_strides[i] * dim;
+  }
+  output_data[data_idx] = updates[indices_index];
+}
+
+template <typename T, typename Tin>
+void ScatterElementsImpl(
+    const int rank,
+    const T* input_data,
+    const int64_t input_size,
+    const int64_t* input_dims,
+    const int64_t* input_strides,
+    const Tin* indices_data,
+    const int64_t indices_size,
+    const int64_t* indices_dims,
+    const fast_divmod* indices_strides,
+    const T* updates,
+    const int axis,
+    T* output_data) {
+
+  if (input_data != output_data) {
+    cudaMemcpyAsync(output_data, input_data, input_size * sizeof(T), cudaMemcpyDeviceToDevice, 0);
+  }
+
+  int blocksPerGrid = (int)((indices_size + GridDim::maxThreadsPerBlock - 1) / GridDim::maxThreadsPerBlock);
+  _ScatterElementsKernel<T, Tin><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(
+      rank, input_data, input_dims, input_strides,
+      indices_data, indices_size, indices_dims, indices_strides,
+      updates, axis, output_data);
+}
+
+#define SPECIALIZED_IMPL(T)                           \
+  template void ScatterElementsImpl<T, int32_t>(      \
+      const int rank,                                 \
+      const T* input_data,                            \
+      const int64_t input_size,                       \
+      const int64_t* input_dims,                      \
+      const int64_t* input_strides,                   \
+      const int32_t* indices_data,                    \
+      const int64_t indices_size,                     \
+      const int64_t* indices_dims,                    \
+      const fast_divmod* indices_strides,             \
+      const T* updates,                               \
+      const int axis,                                 \
+      T* output_data);                                \
+  template void ScatterElementsImpl<T, int64_t>(      \
+      const int rank,                                 \
+      const T* input_data,                            \
+      const int64_t input_size,                       \
+      const int64_t* input_dims,                      \
+      const int64_t* input_strides,                   \
+      const int64_t* indices_data,                    \
+      const int64_t indices_size,                     \
+      const int64_t* indices_dims,                    \
+      const fast_divmod* indices_strides,             \
+      const T* updates,                               \
+      const int axis,                                 \
+      T* output_data);                                \
+
+SPECIALIZED_IMPL(int8_t)
+SPECIALIZED_IMPL(int16_t)
+SPECIALIZED_IMPL(int32_t)
+SPECIALIZED_IMPL(int64_t)
+SPECIALIZED_IMPL(uint8_t)
+SPECIALIZED_IMPL(uint16_t)
+SPECIALIZED_IMPL(uint32_t)
+SPECIALIZED_IMPL(uint64_t)
+SPECIALIZED_IMPL(half)
+SPECIALIZED_IMPL(float)
+SPECIALIZED_IMPL(double)
+SPECIALIZED_IMPL(bool)
+
+}  // namespace cuda
+}  // namespace onnxruntime
+

--- a/onnxruntime/core/providers/cuda/tensor/scatter_elements_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_elements_impl.h
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <stdint.h>
+#include "core/providers/cuda/shared_inc/cuda_utils.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+template <typename T, typename Tin>
+void ScatterElementsImpl(
+    const int rank,
+    const T* input_data,
+    const int64_t input_size,
+    const int64_t* input_dims,
+    const int64_t* input_strides,
+    const Tin* indices_data,
+    const int64_t indices_size,
+    const int64_t* indices_dims,
+    const fast_divmod* indices_strides,
+    const T* updates,
+    const int axis,
+    T* output_data);
+
+}  // namespace cuda
+}  // namespace onnxruntime
+

--- a/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
@@ -182,7 +182,9 @@ static void scatter_invalid_index(const char* op_name, int op_version) {
   test.AddInput<int64_t>("indices", {1, 1, 1}, {4});
   test.AddInput<float>("updates", {1, 1, 1}, {5.0f});
   test.AddOutput<float>("y", {4, 2, 1}, {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 5.0f, 0.0f});
-  test.Run(OpTester::ExpectResult::kExpectFailure, "indices element out of data bounds, idx=4 must be within the inclusive range [-4,3]");
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "indices element out of data bounds, idx=4 must be within the inclusive range [-4,3]",
+           {kCudaExecutionProvider});
 }
 
 TEST(Scatter, InvalidIndex) {


### PR DESCRIPTION
**Description**: Describe your changes.
   Cuda Scatter/ScatterElements op implementation.
   Disable scatter invalid index test as no suitable way to raise error in cuda kernel for data value errors currently(To be done in architecture level later).
**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
