### PR TITLE
Ignore some gcc warnings

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -442,6 +442,7 @@ else()
   check_cxx_compiler_flag(-Wmissing-braces HAS_MISSING_BRACES)
   check_cxx_compiler_flag(-Wignored-attributes HAS_IGNORED_ATTRIBUTES)
   check_cxx_compiler_flag(-Wdeprecated-copy HAS_DEPRECATED_COPY)
+  check_cxx_compiler_flag(-Wclass-memaccess HAS_CLASS_MEMACCESS)
 
   if(HAS_TAUTOLOGICAL_POINTER_COMPARE)
     #we may have extra null pointer checkings in debug build, it's not an issue
@@ -452,6 +453,11 @@ else()
     #we may have extra null pointer checkings in debug build, it's not an issue
     string(APPEND CMAKE_CXX_FLAGS_DEBUG " -Wno-nonnull-compare")
     string(APPEND CMAKE_C_FLAGS_DEBUG " -Wno-nonnull-compare")
+  endif()
+  if(HAS_DEPRECATED_COPY)
+    #too many such errors in eigen and gemmlowp
+    string(APPEND CMAKE_CXX_FLAGS_DEBUG " -Wno-deprecated-copy")
+    string(APPEND CMAKE_C_FLAGS_DEBUG " -Wno-deprecated-copy")
   endif()
   if(HAS_PARENTHESES)
     string(APPEND CMAKE_CXX_FLAGS " -Wno-parentheses")

--- a/cmake/onnxruntime_config.h.in
+++ b/cmake/onnxruntime_config.h.in
@@ -11,4 +11,5 @@
 #cmakedefine HAS_USELESS_CAST
 #cmakedefine HAS_IGNORED_ATTRIBUTES
 #cmakedefine HAS_DEPRECATED_COPY
+#cmakedefine HAS_CLASS_MEMACCESS
 #cmakedefine ORT_VERSION "@ORT_VERSION@"

--- a/onnxruntime/core/providers/cpu/tensor/gather_elements.cc
+++ b/onnxruntime/core/providers/cpu/tensor/gather_elements.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "gather_elements.h"
+#include "onnxruntime_config.h"
 
 namespace onnxruntime {
 
@@ -124,7 +125,12 @@ static std::vector<int64_t> parse_and_validate_indices_tensor(const Tensor* indi
 
   return indices_data;
 }
-
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#ifdef HAS_CLASS_MEMACCESS
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
+#endif
 template<bool is_string, typename T>
 static void core_impl(const Tensor* input_tensor, const Tensor* indices_tensor,
                                       Tensor* output_tensor, int64_t axis) {
@@ -203,7 +209,9 @@ static void core_impl(const Tensor* input_tensor, const Tensor* indices_tensor,
     }
   }
 }
-
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 Status GatherElements::Compute(OpKernelContext* context) const {
   const Tensor* input_tensor = context->Input<Tensor>(0);
   const TensorShape& input_data_shape = input_tensor->Shape();

--- a/onnxruntime/core/util/gemmlowp_common.h
+++ b/onnxruntime/core/util/gemmlowp_common.h
@@ -3,6 +3,13 @@
 #pragma once
 #include "core/util/gemmlowp_common_wrapper.h"
 #include "core/platform/threadpool.h"
+#include "onnxruntime_config.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#ifdef HAS_DEPRECATED_COPY
+#pragma GCC diagnostic ignored "-Wdeprecated-copy"
+#endif
+#endif
 
 namespace onnxruntime {
 
@@ -63,3 +70,7 @@ void GemmlowpMultiplyu8u8_s32(const uint8_t* lhs_data, const uint8_t* rhs_data, 
                              const int lhs_offset, const int rhs_offset, int m, int n, int k, concurrency::ThreadPool*);
 
 }  // namespace onnxruntime
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/onnxruntime/core/util/gemmlowp_common_wrapper.h
+++ b/onnxruntime/core/util/gemmlowp_common_wrapper.h
@@ -10,6 +10,9 @@
 #ifdef HAS_IGNORED_ATTRIBUTES
 #pragma GCC diagnostic ignored "-Wignored-attributes"
 #endif
+#ifdef HAS_DEPRECATED_COPY
+#pragma GCC diagnostic ignored "-Wdeprecated-copy"
+#endif
 #else
 #pragma warning(push)
 #pragma warning(disable : 4100)  //'identifier' : unreferenced formal parameter


### PR DESCRIPTION
**Description**: 

Ignore some gcc warnings

**Motivation and Context**
- Why is this change required? What problem does it solve?

To support the latest gcc.

- If it fixes an open issue, please link to the issue here.
