### PR TITLE
Restore Default nature of the CustomLogger.

### DIFF
--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -102,7 +102,7 @@ ORT_API_STATUS_IMPL(OrtApis::CreateEnvWithCustomLogger, OrtLoggingFunction loggi
   std::unique_ptr<ISink> logger = onnxruntime::make_unique<LoggingWrapper>(logging_function, logger_param);
   auto default_logging_manager = onnxruntime::make_unique<LoggingManager>(std::move(logger),
                                                                   static_cast<Severity>(default_warning_level), false,
-                                                                  LoggingManager::InstanceType::Temporal,
+                                                                  LoggingManager::InstanceType::Default,
                                                                   &name);
   std::unique_ptr<Environment> env;
   Status status = Environment::Create(env);


### PR DESCRIPTION
**Description**: CustomLogger was erroneously made Temporal

**Motivation and Context**
Fix the regression and made custom logger default