### PR TITLE
Handle nullptr for NodeArg.Shape()

### DIFF
--- a/onnxruntime/core/optimizer/gelu_fusion.cc
+++ b/onnxruntime/core/optimizer/gelu_fusion.cc
@@ -13,6 +13,11 @@ namespace onnxruntime {
 
 static bool CheckConstantInput(const Graph& graph, const NodeArg& input_arg, float expected_value) {
   auto shape = input_arg.Shape();
+  if (shape == nullptr) {
+    // shape inferencing wasn't able to populate shape information for this NodeArg
+    return false;
+  }
+
   auto dim_size = shape->dim_size();
   if (dim_size != 0) {
     // only check scalar.


### PR DESCRIPTION
**Description**: 
Gelu optimizer needs to handle a NodeArg with no shape information

**Motivation and Context**
Fixes crash.
