### PR TITLE
Replace std::regex with re2 bc CentOS std::regex is broken

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -508,13 +508,14 @@ endif()
 add_library(onnx_test_runner_common ${onnx_test_runner_common_srcs})
 onnxruntime_add_include_to_target(onnx_test_runner_common onnxruntime_common onnxruntime_framework onnxruntime_test_utils onnx onnx_proto)
 add_dependencies(onnx_test_runner_common onnx_test_data_proto ${onnxruntime_EXTERNAL_DEPENDENCIES})
-target_include_directories(onnx_test_runner_common PRIVATE ${eigen_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/onnx ${ONNXRUNTIME_ROOT})
+target_include_directories(onnx_test_runner_common PRIVATE ${eigen_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/onnx ${ONNXRUNTIME_ROOT} ${REPO_ROOT}/cmake/external/re2)
 set_target_properties(onnx_test_runner_common PROPERTIES FOLDER "ONNXRuntimeTest")
 
 set(onnx_test_libs
   onnxruntime_test_utils
   ${ONNXRUNTIME_TEST_LIBS}
-  onnx_test_data_proto)
+  onnx_test_data_proto
+  re2)
 
 list(APPEND onnx_test_libs ${onnxruntime_EXTERNAL_LIBRARIES} libprotobuf) # test code uses delimited parsing and hence needs to link with the full protobuf
 

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -590,7 +590,7 @@ if (WIN32)
 endif()
 
 if (onnxruntime_BUILD_SHARED_LIB)
-  set(onnxruntime_perf_test_libs onnxruntime_test_utils onnx_test_runner_common onnxruntime_common
+  set(onnxruntime_perf_test_libs onnxruntime_test_utils onnx_test_runner_common onnxruntime_common re2
           onnx_test_data_proto onnx_proto libprotobuf ${GETOPT_LIB_WIDE} onnxruntime
           ${SYS_PATH_LIB} ${CMAKE_DL_LIBS})
   if(onnxruntime_USE_NSYNC)

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -5,6 +5,7 @@
 #include "tensorprotoutils.h"
 
 #include "TestCase.h"
+#include <cctype>
 #include <fstream>
 #include <memory>
 #include "core/common/logging/logging.h"
@@ -14,6 +15,7 @@
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/framework/path_lib.h"
 #include "core/framework/allocator.h"
+#include "re2/re2.h"
 #include <sstream>
 #include <map>
 #include <regex>
@@ -210,11 +212,16 @@ class OnnxModelInfo : public TestModelInfo {
       ORT_THROW("Failed to load model because protobuf parsing failed.");
     }
 #ifdef __GNUG__
-    std::smatch match;
-    std::string url_string{model_url};
-    const std::regex onnx_tag_regex("onnx[0-9a-z]{3}");  //e.g. onnx141, onnx150, onnxtip
-    if (std::regex_search(url_string, match, onnx_tag_regex)) {
-      onnx_commit_tag_ = match[0].str();
+    const RE2::Anchor re2_anchor = RE2::UNANCHORED;
+    re2::StringPiece text(model_url);
+    re2::StringPiece submatch;
+    re2::RE2 regex("onnx[0-9a-z]{3}", re2::RE2::Options());  //e.g. onnx141, onnx150, onnxtip
+    if (!regex.ok()) {
+      ORT_THROW("Failed to parse regex: onnx[0-9a-z]{3}");
+    }
+    bool match = regex.Match(text, 0, text.length(), re2_anchor, &submatch, 1);
+    if (match) {
+      onnx_commit_tag_.assign(submatch.data(), submatch.length());
     } else {
       onnx_commit_tag_ = TestModelInfo::unknown_version;
     }
@@ -459,10 +466,28 @@ Status OnnxTestCase::GetPostProcessing(bool* value) {
   return Status::OK();
 }
 
-static std::string trim_str(const std::string& s) {
-  std::string ltrim = std::regex_replace(s, std::regex("^\\s+"), std::string(""));
-  std::string result = std::regex_replace(ltrim, std::regex("\\s+$"), std::string(""));
-  return result;
+// CentOS lacks find_if
+template<class Iter, class Pred>
+inline Iter find_with_pred (Iter first, Iter last, Pred p) {
+  while (first != last) {
+    if (p(*first)) {
+      break;
+    }
+    ++first;
+  }
+  return first;
+}
+
+static std::string trim_str(const std::string& in) {
+  std::string s = in;
+  s.erase(s.begin(), find_with_pred(s.begin(), s.end(), [](int ch) {
+            return !std::isspace(ch);
+          }));
+  s.erase(find_with_pred(s.rbegin(), s.rend(), [](int ch) {
+            return !std::isspace(ch);
+          }).base(),
+          s.end());
+  return s;
 }
 
 static bool read_config_file(const std::basic_string<PATH_CHAR_TYPE>& path, std::map<std::string, std::string>& fc) {


### PR DESCRIPTION
**Description**: Make use of re2 for regex

**Motivation and Context**
Test utilizes throw as CentOS std::regex can not process some of the our regex.