### PR TITLE
ThreadPool fix for roialign and CropAndResize

### DIFF
--- a/onnxruntime/contrib_ops/cpu/crop_and_resize.cc
+++ b/onnxruntime/contrib_ops/cpu/crop_and_resize.cc
@@ -44,6 +44,15 @@ namespace contrib {
 ADD_TYPED_CROPANDRESIZE_OP(float);
 
 template <typename T>
+static void TryParallelFor(concurrency::ThreadPool* tp, int32_t total, T&& fn) {
+  if (tp != nullptr)
+    return tp->ParallelFor(total, fn);
+  for (int32_t i = 0; i != total; ++i) {
+    fn(i);
+  }
+}
+
+template <typename T>
 void CropAndResizeForward(
     int64_t nthreads,
     const T* bottom_data,
@@ -177,7 +186,7 @@ void CropAndResizeForward(
       }  // for pw
     }    // for ph
   };     // for n
-  const_cast<ThreadPool*>(ttp)->ParallelFor(static_cast<int32_t>(n_rois), work_object);
+  TryParallelFor(const_cast<ThreadPool*>(ttp), static_cast<int32_t>(n_rois), work_object);
 }
 
 template <typename T>

--- a/onnxruntime/core/providers/cpu/object_detection/roialign.cc
+++ b/onnxruntime/core/providers/cpu/object_detection/roialign.cc
@@ -43,6 +43,14 @@ ADD_TYPED_ROIALIGN_OP(double);
 
 namespace {
 template <typename T>
+void TryParallelFor(concurrency::ThreadPool* tp, int32_t total, T&& fn) {
+  if (tp != nullptr)
+    return tp->ParallelFor(total, fn);
+  for (int32_t i = 0; i != total; ++i) {
+    fn(i);
+  }
+}
+template <typename T>
 struct PreCalc {
   int64_t pos1;
   int64_t pos2;
@@ -270,7 +278,7 @@ void RoiAlignForward(
       }    // for ph
     }      // for c
   };       // for n
-  if (ttp != nullptr) const_cast<ThreadPool*>(ttp)->ParallelFor(static_cast<int32_t>(n_rois), work_object);
+  TryParallelFor(const_cast<ThreadPool*>(ttp), static_cast<int32_t>(n_rois), work_object);
 }
 }  // namespace
 


### PR DESCRIPTION
**Description**: 

It may crash when the machine only has two cores.

**Motivation and Context**

Fix it now to allow CentOS build pass. (The last failure we have)

- Why is this change required? What problem does it solve?
It may crash when the machine only has two cores.

- If it fixes an open issue, please link to the issue here.

Related #1851 