### PR TITLE
Fix a crash in deep_cpu_gru_op_test.cc

### DIFF
--- a/onnxruntime/test/providers/cpu/rnn/deep_cpu_gru_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/deep_cpu_gru_op_test.cc
@@ -12,6 +12,8 @@ using namespace std;
 namespace onnxruntime {
 namespace test {
 
+static const std::vector<string> default_activations = {"sigmoid", "tanh"};
+
 static void RunGruTest(const std::vector<float>& X_data,
                        const std::vector<float>& W_data,
                        const std::vector<float>& R_data,
@@ -29,7 +31,7 @@ static void RunGruTest(const std::vector<float>& X_data,
                        bool output_sequence = true,
                        bool linear_before_reset = false,
                        // copy the following vectors as we may modify them
-                       std::vector<string> activations = {"sigmoid", "tanh"},
+                       std::vector<string> activations = default_activations,
                        std::vector<float> activation_alphas = {},
                        std::vector<float> activation_betas = {}) {
   OpTester test("GRU");


### PR DESCRIPTION
**Description**: 
Fix a crash in deep_cpu_gru_op_test.cc. The crash only occurs in manylinux1 docker.

**Motivation and Context**
- Why is this change required? What problem does it solve?
See the backtrace below:
```
[ RUN      ] GRUTest.BidirectionalDefaultActivationsSimpleWeightsNoBiasTwoRows
==14021== Invalid read of size 8
==14021==    at 0x496D008: _M_data (basic_string.h:3359)
==14021==    by 0x496D008: _M_rep (basic_string.h:3367)
==14021==    by 0x496D008: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (basic_string.h:3706)
==14021==    by 0x42DBEB: void std::_Destroy<std::string>(std::string*) (stl_construct.h:93)
==14021==    by 0x42D10D: void std::_Destroy_aux<false>::__destroy<std::string*>(std::string*, std::string*) (stl_construct.h:103)
==14021==    by 0x42BEFE: void std::_Destroy<std::string*>(std::string*, std::string*) (stl_construct.h:126)
==14021==    by 0x42A2DA: void std::_Destroy<std::string*, std::string>(std::string*, std::string*, std::allocator<std::string>&) (stl_construct.h:151)
==14021==    by 0x427F80: std::vector<std::string, std::allocator<std::string> >::~vector() (stl_vector.h:415)
==14021==    by 0x82F248: onnxruntime::test::DefaultActivationsSimpleWeightsNoBias(std::string, std::vector<float, std::allocator<float> > const&, std::vector<float, std::allocator<float> > const&) (deep_cpu_gru_op_test.cc:126)
==14021==    by 0x82FCCF: onnxruntime::test::GRUTest_BidirectionalDefaultActivationsSimpleWeightsNoBiasTwoRows_Test::TestBody() (deep_cpu_gru_op_test.cc:195)
==14021==    by 0xEED53B: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2411)
==14021==    by 0xEE8679: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2447)
==14021==    by 0xED0446: testing::Test::Run() (gtest.cc:2486)
==14021==    by 0xED0C8F: testing::TestInfo::Run() (gtest.cc:2661)
==14021==  Address 0x577d380 is 0 bytes inside a block of size 16 free'd
==14021==    at 0x4839EFC: operator delete(void*) (vg_replace_malloc.c:586)
==14021==    by 0x42D0E5: __gnu_cxx::new_allocator<std::string>::deallocate(std::string*, unsigned long) (new_allocator.h:110)
==14021==    by 0x42BED9: std::_Vector_base<std::string, std::allocator<std::string> >::_M_deallocate(std::string*, unsigned long) (stl_vector.h:174)
==14021==    by 0x5E8A90: std::vector<std::string, std::allocator<std::string> >::reserve(unsigned long) (vector.tcc:78)
==14021==    by 0x82DFAC: onnxruntime::test::RunGruTest(std::vector<float, std::allocator<float> > const&, std::vector<float, std::allocator<float> > const&, std::vector<float, std::allocator<float> > const&, std::vector<float, std::allocator<float> > const&, std::vector<float, std::allocator<float> > const&, long, int, long, long, std::vector<float, std::allocator<float> > const*, std::vector<float, std::allocator<float> > const*, std::vector<int, std::allocator<int> > const*, std::string const&, float, bool, bool, std::vector<std::string, std::allocator<std::string> >, std::vector<float, std::allocator<float> >, std::vector<float, std::allocator<float> >) (deep_cpu_gru_op_test.cc:42)
==14021==    by 0x82F239: onnxruntime::test::DefaultActivationsSimpleWeightsNoBias(std::string, std::vector<float, std::allocator<float> > const&, std::vector<float, std::allocator<float> > const&) (deep_cpu_gru_op_test.cc:126)
==14021==    by 0x82FCCF: onnxruntime::test::GRUTest_BidirectionalDefaultActivationsSimpleWeightsNoBiasTwoRows_Test::TestBody() (deep_cpu_gru_op_test.cc:195)
==14021==    by 0xEED53B: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2411)
==14021==    by 0xEE8679: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2447)
==14021==    by 0xED0446: testing::Test::Run() (gtest.cc:2486)
==14021==    by 0xED0C8F: testing::TestInfo::Run() (gtest.cc:2661)
==14021==    by 0xED12DF: testing::TestCase::Run() (gtest.cc:2779)
==14021==  Block was alloc'd at
==14021==    at 0x4838E86: operator new(unsigned long) (vg_replace_malloc.c:344)
==14021==    by 0x42DC2D: __gnu_cxx::new_allocator<std::string>::allocate(unsigned long, void const*) (new_allocator.h:104)
==14021==    by 0x42D184: std::_Vector_base<std::string, std::allocator<std::string> >::_M_allocate(unsigned long) (stl_vector.h:168)
==14021==    by 0x43EE79: void std::vector<std::string, std::allocator<std::string> >::_M_range_initialize<std::string const*>(std::string const*, std::string const*, std::forward_iterator_tag) (stl_vector.h:1201)
==14021==    by 0x43E52A: std::vector<std::string, std::allocator<std::string> >::vector(std::initializer_list<std::string>, std::allocator<std::string> const&) (stl_vector.h:368)
==14021==    by 0x82F111: onnxruntime::test::DefaultActivationsSimpleWeightsNoBias(std::string, std::vector<float, std::allocator<float> > const&, std::vector<float, std::allocator<float> > const&) (deep_cpu_gru_op_test.cc:126)
==14021==    by 0x82FCCF: onnxruntime::test::GRUTest_BidirectionalDefaultActivationsSimpleWeightsNoBiasTwoRows_Test::TestBody() (deep_cpu_gru_op_test.cc:195)
==14021==    by 0xEED53B: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2411)
==14021==    by 0xEE8679: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2447)
==14021==    by 0xED0446: testing::Test::Run() (gtest.cc:2486)
==14021==    by 0xED0C8F: testing::TestInfo::Run() (gtest.cc:2661)
==14021==    by 0xED12DF: testing::TestCase::Run() (gtest.cc:2779)
==14021==
==14021== Invalid free() / delete / delete[] / realloc()
==14021==    at 0x4839EFC: operator delete(void*) (vg_replace_malloc.c:586)
==14021==    by 0x42D0E5: __gnu_cxx::new_allocator<std::string>::deallocate(std::string*, unsigned long) (new_allocator.h:110)
==14021==    by 0x42BED9: std::_Vector_base<std::string, std::allocator<std::string> >::_M_deallocate(std::string*, unsigned long) (stl_vector.h:174)
==14021==    by 0x42A296: std::_Vector_base<std::string, std::allocator<std::string> >::~_Vector_base() (stl_vector.h:160)
==14021==    by 0x427F8C: std::vector<std::string, std::allocator<std::string> >::~vector() (stl_vector.h:416)
==14021==    by 0x82F248: onnxruntime::test::DefaultActivationsSimpleWeightsNoBias(std::string, std::vector<float, std::allocator<float> > const&, std::vector<float, std::allocator<float> > const&) (deep_cpu_gru_op_test.cc:126)
==14021==    by 0x82FCCF: onnxruntime::test::GRUTest_BidirectionalDefaultActivationsSimpleWeightsNoBiasTwoRows_Test::TestBody() (deep_cpu_gru_op_test.cc:195)
==14021==    by 0xEED53B: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2411)
==14021==    by 0xEE8679: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2447)
==14021==    by 0xED0446: testing::Test::Run() (gtest.cc:2486)
==14021==    by 0xED0C8F: testing::TestInfo::Run() (gtest.cc:2661)
==14021==    by 0xED12DF: testing::TestCase::Run() (gtest.cc:2779)
==14021==  Address 0x577d380 is 0 bytes inside a block of size 16 free'd
==14021==    at 0x4839EFC: operator delete(void*) (vg_replace_malloc.c:586)
==14021==    by 0x42D0E5: __gnu_cxx::new_allocator<std::string>::deallocate(std::string*, unsigned long) (new_allocator.h:110)
==14021==    by 0x42BED9: std::_Vector_base<std::string, std::allocator<std::string> >::_M_deallocate(std::string*, unsigned long) (stl_vector.h:174)
==14021==    by 0x5E8A90: std::vector<std::string, std::allocator<std::string> >::reserve(unsigned long) (vector.tcc:78)
==14021==    by 0x82DFAC: onnxruntime::test::RunGruTest(std::vector<float, std::allocator<float> > const&, std::vector<float, std::allocator<float> > const&, std::vector<float, std::allocator<float> > const&, std::vector<float, std::allocator<float> > const&, std::vector<float, std::allocator<float> > const&, long, int, long, long, std::vector<float, std::allocator<float> > const*, std::vector<float, std::allocator<float> > const*, std::vector<int, std::allocator<int> > const*, std::string const&, float, bool, bool, std::vector<std::string, std::allocator<std::string> >, std::vector<float, std::allocator<float> >, std::vector<float, std::allocator<float> >) (deep_cpu_gru_op_test.cc:42)
==14021==    by 0x82F239: onnxruntime::test::DefaultActivationsSimpleWeightsNoBias(std::string, std::vector<float, std::allocator<float> > const&, std::vector<float, std::allocator<float> > const&) (deep_cpu_gru_op_test.cc:126)
==14021==    by 0x82FCCF: onnxruntime::test::GRUTest_BidirectionalDefaultActivationsSimpleWeightsNoBiasTwoRows_Test::TestBody() (deep_cpu_gru_op_test.cc:195)
==14021==    by 0xEED53B: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2411)
==14021==    by 0xEE8679: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2447)
==14021==    by 0xED0446: testing::Test::Run() (gtest.cc:2486)
==14021==    by 0xED0C8F: testing::TestInfo::Run() (gtest.cc:2661)
==14021==    by 0xED12DF: testing::TestCase::Run() (gtest.cc:2779)
==14021==  Block was alloc'd at
==14021==    at 0x4838E86: operator new(unsigned long) (vg_replace_malloc.c:344)
==14021==    by 0x42DC2D: __gnu_cxx::new_allocator<std::string>::allocate(unsigned long, void const*) (new_allocator.h:104)
==14021==    by 0x42D184: std::_Vector_base<std::string, std::allocator<std::string> >::_M_allocate(unsigned long) (stl_vector.h:168)
==14021==    by 0x43EE79: void std::vector<std::string, std::allocator<std::string> >::_M_range_initialize<std::string const*>(std::string const*, std::string const*, std::forward_iterator_tag) (stl_vector.h:1201)
==14021==    by 0x43E52A: std::vector<std::string, std::allocator<std::string> >::vector(std::initializer_list<std::string>, std::allocator<std::string> const&) (stl_vector.h:368)
==14021==    by 0x82F111: onnxruntime::test::DefaultActivationsSimpleWeightsNoBias(std::string, std::vector<float, std::allocator<float> > const&, std::vector<float, std::allocator<float> > const&) (deep_cpu_gru_op_test.cc:126)
==14021==    by 0x82FCCF: onnxruntime::test::GRUTest_BidirectionalDefaultActivationsSimpleWeightsNoBiasTwoRows_Test::TestBody() (deep_cpu_gru_op_test.cc:195)
==14021==    by 0xEED53B: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2411)
==14021==    by 0xEE8679: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2447)
==14021==    by 0xED0446: testing::Test::Run() (gtest.cc:2486)
==14021==    by 0xED0C8F: testing::TestInfo::Run() (gtest.cc:2661)
==14021==    by 0xED12DF: testing::TestCase::Run() (gtest.cc:2779)
```
- If it fixes an open issue, please link to the issue here.
