### PR TITLE
updated reduce_ops for op_ver 11

### DIFF
--- a/onnxruntime/core/providers/nuphar/compiler/x86/op_ir_creator/math/reduce_ops.cc
+++ b/onnxruntime/core/providers/nuphar/compiler/x86/op_ir_creator/math/reduce_ops.cc
@@ -109,6 +109,13 @@ class FuncReduceV {
     ProtoHelperNodeContext ctx(node);
     OpNodeProtoHelper<ProtoHelperNodeContext> info(&ctx);
     axes_ = info.GetAttrsOrDefault<int64_t>("axes");
+    if (axes_.size() == 0) {
+      int64_t sz = static_cast<int64_t>(def->Shape()->dim().size());
+      ORT_ENFORCE(sz > 0);
+      for (int64_t i = 0; i < sz; i++) {
+        axes_.push_back(i);
+      }
+    }
     int64_t keepdims_i = 1;
     ORT_ENFORCE(info.GetAttr("keepdims", &keepdims_i).IsOK());
     keep_dims_ = (keepdims_i == 1);


### PR DESCRIPTION
After enabling op_ver 11 for reduce ops, we need to check axes to
make sure it's not empty due to spec changes.
