### PR TITLE
check and fix CUDA kernel launch errors in several OPs

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -42,7 +42,7 @@ class CudaKernel : public OpKernel {
 
     if (s.IsOK()) {
       // ensure no kernel launch error occurred
-      CUDA_RETURN_IF_ERROR(cudaPeekAtLastError());
+      CUDA_RETURN_IF_ERROR(cudaGetLastError());
     }
 
     return s;

--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -39,6 +39,12 @@ class CudaKernel : public OpKernel {
     // use this to precisely locate the node where CUDA failure comes from
     //  if (cudaSuccess != cudaDeviceSynchronize())
     //    __debugbreak();
+
+    if (s.IsOK()) {
+      // ensure no kernel launch error occurred
+      CUDA_RETURN_IF_ERROR(cudaPeekAtLastError());
+    }
+
     return s;
   }
 

--- a/onnxruntime/core/providers/cuda/generator/constant_of_shape.cc
+++ b/onnxruntime/core/providers/cuda/generator/constant_of_shape.cc
@@ -21,29 +21,31 @@ ONNX_OPERATOR_KERNEL_EX(
         .TypeConstraint("T2", DataTypeImpl::AllFixedSizeTensorTypes()),
     ConstantOfShape);
 
-Status ConstantOfShape::Compute(OpKernelContext* ctx) const {
+Status ConstantOfShape::ComputeInternal(OpKernelContext* ctx) const {
   Tensor* output_tensor = nullptr;
   ORT_RETURN_IF_ERROR(PrepareCompute(ctx, &output_tensor));
   auto output_data = output_tensor->MutableDataRaw();
   const auto size = output_tensor->Shape().Size();
   const void* value_ptr = GetValuePtr();
   const auto element_size = output_tensor->DataType()->Size();
-  switch (element_size) {
-    case sizeof(int8_t):
-      cuda::Fill(reinterpret_cast<int8_t*>(output_data), *(reinterpret_cast<const int8_t*>(value_ptr)), size);
-      break;
-    case sizeof(int16_t):
-      cuda::Fill(reinterpret_cast<int16_t*>(output_data), *(reinterpret_cast<const int16_t*>(value_ptr)), size);
-      break;
-    case sizeof(int32_t):
-      cuda::Fill(reinterpret_cast<int32_t*>(output_data), *(reinterpret_cast<const int32_t*>(value_ptr)), size);
-      break;
-    case sizeof(int64_t):
-      cuda::Fill(reinterpret_cast<int64_t*>(output_data), *(reinterpret_cast<const int64_t*>(value_ptr)), size);
-      break;
-    default:
-      ORT_THROW("Unsupported value attribute datatype with sizeof=: ", element_size);
-      break;
+  if (size > 0) {
+    switch (element_size) {
+      case sizeof(int8_t):
+        cuda::Fill(reinterpret_cast<int8_t*>(output_data), *(reinterpret_cast<const int8_t*>(value_ptr)), size);
+        break;
+      case sizeof(int16_t):
+        cuda::Fill(reinterpret_cast<int16_t*>(output_data), *(reinterpret_cast<const int16_t*>(value_ptr)), size);
+        break;
+      case sizeof(int32_t):
+        cuda::Fill(reinterpret_cast<int32_t*>(output_data), *(reinterpret_cast<const int32_t*>(value_ptr)), size);
+        break;
+      case sizeof(int64_t):
+        cuda::Fill(reinterpret_cast<int64_t*>(output_data), *(reinterpret_cast<const int64_t*>(value_ptr)), size);
+        break;
+      default:
+        ORT_THROW("Unsupported value attribute datatype with sizeof=: ", element_size);
+        break;
+    }
   }
 
   return Status::OK();

--- a/onnxruntime/core/providers/cuda/generator/constant_of_shape.cc
+++ b/onnxruntime/core/providers/cuda/generator/constant_of_shape.cc
@@ -28,24 +28,22 @@ Status ConstantOfShape::ComputeInternal(OpKernelContext* ctx) const {
   const auto size = output_tensor->Shape().Size();
   const void* value_ptr = GetValuePtr();
   const auto element_size = output_tensor->DataType()->Size();
-  if (size > 0) {
-    switch (element_size) {
-      case sizeof(int8_t):
-        cuda::Fill(reinterpret_cast<int8_t*>(output_data), *(reinterpret_cast<const int8_t*>(value_ptr)), size);
-        break;
-      case sizeof(int16_t):
-        cuda::Fill(reinterpret_cast<int16_t*>(output_data), *(reinterpret_cast<const int16_t*>(value_ptr)), size);
-        break;
-      case sizeof(int32_t):
-        cuda::Fill(reinterpret_cast<int32_t*>(output_data), *(reinterpret_cast<const int32_t*>(value_ptr)), size);
-        break;
-      case sizeof(int64_t):
-        cuda::Fill(reinterpret_cast<int64_t*>(output_data), *(reinterpret_cast<const int64_t*>(value_ptr)), size);
-        break;
-      default:
-        ORT_THROW("Unsupported value attribute datatype with sizeof=: ", element_size);
-        break;
-    }
+
+#define CASE(TYPE)                                                                                          \
+  case sizeof(TYPE):                                                                                        \
+    if (size > 0) {                                                                                         \
+      cuda::Fill(reinterpret_cast<TYPE*>(output_data), *(reinterpret_cast<const TYPE*>(value_ptr)), size);  \
+    }                                                                                                       \
+    break;
+
+  switch (element_size) {
+    CASE(int8_t)
+    CASE(int16_t)
+    CASE(int32_t)
+    CASE(int64_t)
+    default:
+      ORT_THROW("Unsupported value attribute datatype with sizeof=: ", element_size);
+      break;
   }
 
   return Status::OK();

--- a/onnxruntime/core/providers/cuda/generator/constant_of_shape.h
+++ b/onnxruntime/core/providers/cuda/generator/constant_of_shape.h
@@ -13,13 +13,13 @@
 namespace onnxruntime {
 namespace cuda {
 
-class ConstantOfShape final : public ConstantOfShapeBase, public OpKernel {
+class ConstantOfShape final : public ConstantOfShapeBase, public CudaKernel {
  public:
-  explicit ConstantOfShape(const OpKernelInfo& info) : ConstantOfShapeBase(info), OpKernel(info) {};
+  explicit ConstantOfShape(const OpKernelInfo& info) : ConstantOfShapeBase(info), CudaKernel(info) {};
 
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(ConstantOfShape);
 
-  Status Compute(OpKernelContext* ctx) const override;
+  Status ComputeInternal(OpKernelContext* ctx) const override;
 };
 
 }  // namespace cuda

--- a/onnxruntime/core/providers/cuda/object_detection/roialign.cc
+++ b/onnxruntime/core/providers/cuda/object_detection/roialign.cc
@@ -43,22 +43,24 @@ Status RoiAlign<T>::ComputeInternal(OpKernelContext* context) const {
   auto& Y = *context->Output(0, {num_rois, x_dims[1], this->output_height_, this->output_width_});
   int64_t output_size = Y.Shape().Size();
 
-  RoiAlignImpl(
-      output_size,  // num threads
-      reinterpret_cast<const typename ToCudaType<T>::MappedType*>(X_ptr->template Data<T>()),
-      ToCudaType<T>::FromFloat(this->spatial_scale_),
-      x_dims[1],  // num channels
-      x_dims[2],  // height
-      x_dims[3],  // width
-      this->output_height_,
-      this->output_width_,
-      this->sampling_ratio_,
-      reinterpret_cast<const typename ToCudaType<T>::MappedType*>(rois_ptr->template Data<T>()),
-      num_roi_cols,
-      reinterpret_cast<typename ToCudaType<T>::MappedType*>(Y.template MutableData<T>()),
-      this->mode_ == RoiAlignMode::avg,
-      batch_indices_ptr->template Data<int64_t>()
-  );
+  if (output_size > 0) {
+    RoiAlignImpl(
+        output_size,  // num threads
+        reinterpret_cast<const typename ToCudaType<T>::MappedType*>(X_ptr->template Data<T>()),
+        ToCudaType<T>::FromFloat(this->spatial_scale_),
+        x_dims[1],  // num channels
+        x_dims[2],  // height
+        x_dims[3],  // width
+        this->output_height_,
+        this->output_width_,
+        this->sampling_ratio_,
+        reinterpret_cast<const typename ToCudaType<T>::MappedType*>(rois_ptr->template Data<T>()),
+        num_roi_cols,
+        reinterpret_cast<typename ToCudaType<T>::MappedType*>(Y.template MutableData<T>()),
+        this->mode_ == RoiAlignMode::avg,
+        batch_indices_ptr->template Data<int64_t>()
+    );
+  }
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cuda/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cuda/tensor/cast_op.cc
@@ -54,16 +54,14 @@ Status Cast<SrcT>::ComputeInternal(OpKernelContext* context) const {
   const auto* x_data = reinterpret_cast<const CudaSrcT*>(X->template Data<SrcT>());
   size_t count = shape.Size();
 
-  if (count == 0) {
-    return Status::OK();
-  }
-
-#define CASE(TP_TYPE, DstT)                                                                        \
-  case TP_TYPE:                                                                                    \
-    Impl_Cast<CudaSrcT, typename ToCudaType<DstT>::MappedType>(                                    \
-        x_data,                                                                                    \
-        reinterpret_cast<typename ToCudaType<DstT>::MappedType*>(Y->template MutableData<DstT>()), \
-        count);                                                                                    \
+#define CASE(TP_TYPE, DstT)                                                                          \
+  case TP_TYPE:                                                                                      \
+    if (count > 0) {                                                                                 \
+      Impl_Cast<CudaSrcT, typename ToCudaType<DstT>::MappedType>(                                    \
+          x_data,                                                                                    \
+          reinterpret_cast<typename ToCudaType<DstT>::MappedType*>(Y->template MutableData<DstT>()), \
+          count);                                                                                    \
+    }                                                                                                \
     break;
 
   switch (to_) {

--- a/onnxruntime/core/providers/cuda/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cuda/tensor/cast_op.cc
@@ -54,6 +54,10 @@ Status Cast<SrcT>::ComputeInternal(OpKernelContext* context) const {
   const auto* x_data = reinterpret_cast<const CudaSrcT*>(X->template Data<SrcT>());
   size_t count = shape.Size();
 
+  if (count == 0) {
+    return Status::OK();
+  }
+
 #define CASE(TP_TYPE, DstT)                                                                        \
   case TP_TYPE:                                                                                    \
     Impl_Cast<CudaSrcT, typename ToCudaType<DstT>::MappedType>(                                    \

--- a/onnxruntime/core/providers/cuda/tensor/gather.cc
+++ b/onnxruntime/core/providers/cuda/tensor/gather.cc
@@ -20,41 +20,41 @@ ONNX_OPERATOR_KERNEL_EX(
                                     DataTypeImpl::GetTensorType<int64_t>()}),
     Gather);
 
-#define TYPED_FUNCTION_CALL(T)                                                \
-  if (T_type == DataTypeImpl::GetType<T>()) {                                 \
-    T* output_data = p.output_tensor->template MutableData<T>();              \
-    const T* input_data = p.input_tensor->template Data<T>();                 \
-    if (Tin_type == DataTypeImpl::GetType<int32_t>()) {                       \
-      GatherImpl(                                                             \
-          input_block_size,                                                   \
-          indices_max,                                                        \
-          p.indices_tensor->template Data<int32_t>(),                         \
-          div_strides.GpuPtr(),                                               \
-          reinterpret_cast<const ToCudaType<T>::MappedType*>(input_data),     \
-          reinterpret_cast<typename ToCudaType<T>::MappedType*>(output_data), \
-          p.output_tensor->Shape().Size());                                   \
-      return Status::OK();                                                    \
-    }                                                                         \
-    if (Tin_type == DataTypeImpl::GetType<int64_t>()) {                       \
-      GatherImpl(                                                             \
-          input_block_size,                                                   \
-          indices_max,                                                        \
-          p.indices_tensor->template Data<int64_t>(),                         \
-          div_strides.GpuPtr(),                                               \
-          reinterpret_cast<const ToCudaType<T>::MappedType*>(input_data),     \
-          reinterpret_cast<typename ToCudaType<T>::MappedType*>(output_data), \
-          p.output_tensor->Shape().Size());                                   \
-      return Status::OK();                                                    \
-    }                                                                         \
+#define TYPED_FUNCTION_CALL(T)                                                  \
+  if (T_type == DataTypeImpl::GetType<T>()) {                                   \
+    T* output_data = p.output_tensor->template MutableData<T>();                \
+    const T* input_data = p.input_tensor->template Data<T>();                   \
+    if (Tin_type == DataTypeImpl::GetType<int32_t>()) {                         \
+      if (p.output_tensor->Shape().Size() > 0) {                                \
+        GatherImpl(                                                             \
+            input_block_size,                                                   \
+            indices_max,                                                        \
+            p.indices_tensor->template Data<int32_t>(),                         \
+            div_strides.GpuPtr(),                                               \
+            reinterpret_cast<const ToCudaType<T>::MappedType*>(input_data),     \
+            reinterpret_cast<typename ToCudaType<T>::MappedType*>(output_data), \
+            p.output_tensor->Shape().Size());                                   \
+      }                                                                         \
+      return Status::OK();                                                      \
+    }                                                                           \
+    if (Tin_type == DataTypeImpl::GetType<int64_t>()) {                         \
+      if (p.output_tensor->Shape().Size() > 0) {                                \
+        GatherImpl(                                                             \
+            input_block_size,                                                   \
+            indices_max,                                                        \
+            p.indices_tensor->template Data<int64_t>(),                         \
+            div_strides.GpuPtr(),                                               \
+            reinterpret_cast<const ToCudaType<T>::MappedType*>(input_data),     \
+            reinterpret_cast<typename ToCudaType<T>::MappedType*>(output_data), \
+            p.output_tensor->Shape().Size());                                   \
+      }                                                                         \
+      return Status::OK();                                                      \
+    }                                                                           \
   }
 
 Status Gather::ComputeInternal(OpKernelContext* context) const {
   Prepare p;
   ORT_RETURN_IF_ERROR(PrepareForCompute(context, p));
-
-  if (p.output_tensor->Shape().Size() == 0) {
-    return Status::OK();
-  }
 
   const TensorShape& input_shape = p.input_tensor->Shape();
 

--- a/onnxruntime/core/providers/cuda/tensor/gather.cc
+++ b/onnxruntime/core/providers/cuda/tensor/gather.cc
@@ -52,6 +52,10 @@ Status Gather::ComputeInternal(OpKernelContext* context) const {
   Prepare p;
   ORT_RETURN_IF_ERROR(PrepareForCompute(context, p));
 
+  if (p.output_tensor->Shape().Size() == 0) {
+    return Status::OK();
+  }
+
   const TensorShape& input_shape = p.input_tensor->Shape();
 
   const int64_t block_size = input_shape.SizeFromDimension(p.axis + 1);

--- a/onnxruntime/core/providers/cuda/tensor/scatter_elements_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_elements_impl.cu
@@ -56,11 +56,13 @@ void ScatterElementsImpl(
     cudaMemcpyAsync(output_data, input_data, input_size * sizeof(T), cudaMemcpyDeviceToDevice, 0);
   }
 
-  int blocksPerGrid = (int)((indices_size + GridDim::maxThreadsPerBlock - 1) / GridDim::maxThreadsPerBlock);
-  _ScatterElementsKernel<T, Tin><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(
-      rank, input_data, input_dims, input_strides,
-      indices_data, indices_size, indices_dims, indices_strides,
-      updates, axis, output_data);
+  if (indices_size > 0) {
+    int blocksPerGrid = (int)((indices_size + GridDim::maxThreadsPerBlock - 1) / GridDim::maxThreadsPerBlock);
+    _ScatterElementsKernel<T, Tin><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(
+        rank, input_data, input_dims, input_strides,
+        indices_data, indices_size, indices_dims, indices_strides,
+        updates, axis, output_data);
+  }
 }
 
 #define SPECIALIZED_IMPL(T)                           \

--- a/onnxruntime/core/providers/cuda/tensor/tile.cc
+++ b/onnxruntime/core/providers/cuda/tensor/tile.cc
@@ -58,14 +58,16 @@ Status Tile<T>::ComputeInternal(OpKernelContext* ctx) const {
   ORT_RETURN_IF_ERROR(input_strides.CopyToGpu());
   ORT_RETURN_IF_ERROR(fdm_output_strides.CopyToGpu());
 
-  TileImpl(
-      rank,
-      fdm_input_shape.GpuPtr(),
-      input_strides.GpuPtr(),
-      reinterpret_cast<const typename ToCudaType<T>::MappedType*>(input_data),
-      fdm_output_strides.GpuPtr(),
-      reinterpret_cast<typename ToCudaType<T>::MappedType*>(output_data),
-      output_tensor.Shape().Size());
+  if (output_tensor.Shape().Size() > 0) {
+    TileImpl(
+        rank,
+        fdm_input_shape.GpuPtr(),
+        input_strides.GpuPtr(),
+        reinterpret_cast<const typename ToCudaType<T>::MappedType*>(input_data),
+        fdm_output_strides.GpuPtr(),
+        reinterpret_cast<typename ToCudaType<T>::MappedType*>(output_data),
+        output_tensor.Shape().Size());
+  }
 
   return Status::OK();
 }


### PR DESCRIPTION
**Description**: Check and fix CUDA kernel launch errors

**Motivation and Context**
- Our current CUDA implementation of some operators may raise cuda errors in their implementations. Some of those errors include kernel launch error, which is usually caused by setting up wrong grid/thread for CUDA kernel. Those errors can be detected by calling `cudaPeekAtLastError()`, within trivial perf drawback. (unlike `cudaDeviceSynchronize()`, `cudaPeekAtLastError()` does not wait for any GPU operation)
- fix zero-grid mis-configuration for operators `RoiAlign`, `Cast`, `Gather` and `Tile`.
- (EDIT) fix `ConstantOfShape`.