### PR TITLE
Remove gcc from manylinux1 docker image

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_centos.sh
@@ -7,9 +7,10 @@ os_major_version=$(cat /etc/redhat-release | tr -dc '0-9.'|cut -d \. -f1)
 yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$os_major_version.noarch.rpm
 
 if [ "$os_major_version" == "5" ]; then
- yum install -y redhat-lsb expat-devel libcurl-devel rpmdevtools tar unzip curl zlib-devel make  python2-devel icu  rsync bzip2 git bzip2-devel
+ #Be careful, don't pull gcc into the base system, because we already have one in /opt/rh/devtoolset-2/root/usr/bin
+ yum install -y redhat-lsb expat-devel libcurl-devel tar unzip curl zlib-devel make  python2-devel icu  rsync bzip2 git bzip2-devel
 else
- yum install -y redhat-lsb-core expat-devel libcurl-devel rpmdevtools tar unzip curl zlib-devel make  python2-devel  libunwind icu aria2 rsync bzip2 git bzip2-devel
+ yum install -y redhat-lsb-core expat-devel libcurl-devel tar unzip curl zlib-devel make  python2-devel  libunwind icu aria2 rsync bzip2 git bzip2-devel
 fi
 
 


### PR DESCRIPTION
**Description**:

Remove gcc from manylinux1 docker image

**Motivation and Context**
- Why is this change required? What problem does it solve?
We put two GCCs in the manylinux1 image. It's better to only have one.

- If it fixes an open issue, please link to the issue here.
