### PR TITLE
Add a test for AVX512 compilation before compiling 512 asm

### DIFF
--- a/check_512.s
+++ b/check_512.s
@@ -1,0 +1,7 @@
+.intel_syntax noprefix
+infiniteLoop:
+ jmp main
+main:
+ vxorpd zmm0,zmm0,zmm0
+ jmp infiniteLoop
+

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -161,8 +161,7 @@ Return Value:
             this->PoolFloatKernel[MlasAveragePoolingIncludePad] = MlasPoolAverageIncludePadFloatKernelAvx;
 
             //
-            // Check if the processor supports AVX512F (and the operating
-            // system supports saving AVX512F state) or AVX2/FMA3 features.
+            // Check if the processor supports AVX2/FMA3 features.
             //
 
             unsigned Cpuid7[4];
@@ -180,6 +179,23 @@ Return Value:
                 this->GemmU8U8CopyPackARoutine = MlasGemmU8U8CopyPackAAvx2;
                 this->GemmU8U8CopyPackBRoutine = MlasGemmU8U8CopyPackBAvx2;
                 this->GemmU8U8Kernel = MlasGemmU8U8KernelAvx2;
+
+                this->GemmFloatKernel = MlasGemmFloatKernelFma3;
+                this->GemmDoubleKernel = MlasGemmDoubleKernelFma3;
+                this->ConvNchwFloatKernel = MlasConvNchwFloatKernelFma3;
+                this->ConvNchwcFloatKernel = MlasConvNchwcFloatKernelFma3;
+                this->ConvDepthwiseFloatKernel = MlasConvDepthwiseFloatKernelFma3;
+                this->ConvPointwiseFloatKernel = MlasConvPointwiseFloatKernelFma3;
+                this->LogisticKernelRoutine = MlasLogisticKernelFma3;
+                this->TanhKernelRoutine = MlasTanhKernelFma3;
+                this->ErfKernelRoutine = MlasErfKernelFma3;
+
+#if !defined(MLAS_AVX512_UNSUPPORTED)
+
+                //
+                // Check if the processor supports AVX512F features and the
+                // operating system supports saving AVX512F state.
+                //
 
                 if (((Cpuid7[1] & 0x10000) != 0) && ((xcr0 & 0xE0) == 0xE0)) {
 
@@ -214,20 +230,10 @@ Return Value:
                             this->GemmU8U8Kernel = MlasGemmU8U8KernelAvx512Vnni;
                         }
                     }
-
-                } else {
-
-                    this->GemmFloatKernel = MlasGemmFloatKernelFma3;
-                    this->GemmDoubleKernel = MlasGemmDoubleKernelFma3;
-                    this->ConvNchwFloatKernel = MlasConvNchwFloatKernelFma3;
-                    this->ConvNchwcFloatKernel = MlasConvNchwcFloatKernelFma3;
-                    this->ConvDepthwiseFloatKernel = MlasConvDepthwiseFloatKernelFma3;
-                    this->ConvPointwiseFloatKernel = MlasConvPointwiseFloatKernelFma3;
                 }
 
-                this->LogisticKernelRoutine = MlasLogisticKernelFma3;
-                this->TanhKernelRoutine = MlasTanhKernelFma3;
-                this->ErfKernelRoutine = MlasErfKernelFma3;
+#endif
+
             }
 
 #endif

--- a/onnxruntime/test/contrib_ops/layer_norm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/layer_norm_op_test.cc
@@ -100,7 +100,7 @@ class LayerNormOpTester : public OpTester {
 
     // Compare CPU with original subgraph
     ASSERT_TRUE(cpu_fetches.size() == subgraph_fetches.size());
-    for (auto i = 0; i < cpu_fetches.size(); i++) {
+    for (size_t i = 0; i < cpu_fetches.size(); i++) {
       if (cpu_fetches[i].IsTensor() && subgraph_fetches[i].IsTensor()) {
         VLOGS_DEFAULT(1) << "Checking tensor " << i;
         CheckTensor(subgraph_fetches[i].Get<Tensor>(), cpu_fetches[i].Get<Tensor>(), 1e-3, 1e-3);
@@ -110,7 +110,7 @@ class LayerNormOpTester : public OpTester {
     // Compare GPU with original subgraph
     if (DefaultCudaExecutionProvider()) {
       ASSERT_TRUE(cuda_fetches.size() == subgraph_fetches.size());
-      for (auto i = 0; i < cuda_fetches.size(); i++) {
+      for(size_t i = 0; i < cuda_fetches.size(); i++) {
         if (cuda_fetches[i].IsTensor() && subgraph_fetches[i].IsTensor()) {
           VLOGS_DEFAULT(1) << "Checking tensor " << i;
           CheckTensor(subgraph_fetches[i].Get<Tensor>(), cuda_fetches[i].Get<Tensor>(), 1e-3, 1e-3);


### PR DESCRIPTION
**Description**: This change is necessary for manylinux1 support

**Motivation and Context**
We do not want to compile AVX512 support source code since the toolchain on manylinux1 does not support it.