### PR TITLE
Build fix for memcpy_transformer_test.cc

### DIFF
--- a/onnxruntime/test/framework/memcpy_transformer_test.cc
+++ b/onnxruntime/test/framework/memcpy_transformer_test.cc
@@ -245,8 +245,8 @@ TEST(TransformerTest, TestCopyNodeInsertionInitializerInSubgraph) {
   // main graph continued
   // create the 'If' node
   auto& if_node = graph.AddNode("node3", "If", "cpu operator2", ArgMap{&i1_def}, ArgMap{&o1_def, &o2_def});
-  if_node.AddAttribute("then_branch", {subgraph.ToGraphProto()});
-  if_node.AddAttribute("else_branch", {subgraph.ToGraphProto()});
+  if_node.AddAttribute("then_branch", subgraph.ToGraphProto());
+  if_node.AddAttribute("else_branch", subgraph.ToGraphProto());
 
   onnxruntime::Graph* subgraph_1 = if_node.GetMutableGraphAttribute("then_branch");
   for (auto& node : subgraph_1->Nodes()) {


### PR DESCRIPTION
**Description**: 
GCC 4.8.2 can't compile this file

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
