### PR TITLE
Explicitly set C++ standard to 11

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -16,7 +16,7 @@ include(CheckLanguage)
 # such as lambda captures and they are convinient
 # On the other hand it does not allow some others.
 # So we cant' regulate simply with the standard.
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 11)
 
 # General C# prperties
 if (onnxruntime_BUILD_CSHARP)
@@ -589,7 +589,7 @@ if (onnxruntime_USE_CUDA)
   endif()
   string(APPEND CMAKE_CUDA_FLAGS "-cudart shared")
   enable_language(CUDA)
-  set(CMAKE_CUDA_STANDARD 14)
+  set(CMAKE_CUDA_STANDARD 11)
   file(TO_CMAKE_PATH ${onnxruntime_CUDNN_HOME} onnxruntime_CUDNN_HOME)
   set(ONNXRUNTIME_CUDA_LIBRARIES ${CUDA_LIBRARIES})
   list(APPEND ONNXRUNTIME_CUDA_LIBRARIES cublas cudnn)


### PR DESCRIPTION
**Description**: 

Explicitly set C++ standard to 11

**Motivation and Context**
- Why is this change required? What problem does it solve?
Required by manylinux1 gpu build, otherwise the cuda provider can't be built.

- If it fixes an open issue, please link to the issue here.
