### PR TITLE
DML EP Convolution - support 1D and ignore output_padding

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
@@ -159,6 +159,7 @@ namespace Dml
                     *m_kernelInputIndices[i],
                     TensorAxis::DoNotCoerce,
                     TensorAxis::W,
+                    TensorAxis::RightAligned,
                     inputShape,
                     NchwDimensionCount));
             }
@@ -180,6 +181,7 @@ namespace Dml
                     *m_kernelOutputIndices[i],
                     TensorAxis::DoNotCoerce,
                     TensorAxis::W,
+                    TensorAxis::RightAligned,
                     outputShape));
             }
         }
@@ -357,7 +359,8 @@ namespace Dml
         const MLOperatorKernelCreationContext& kernelInfo,
         uint32_t index,
         uint32_t coerceAxis,
-        uint32_t placement,
+        int32_t placement,
+        int32_t leftAlignedDimensionCount,
         std::optional<gsl::span<const uint32_t>> tensorShape,
         uint32_t minDimensionCount
         ) const
@@ -388,6 +391,7 @@ namespace Dml
             actualTensorShape,
             coerceAxis,
             placement,
+            leftAlignedDimensionCount,
             minDimensionCount,
             0
             );
@@ -397,7 +401,8 @@ namespace Dml
         const MLOperatorKernelCreationContext& kernelInfo,
         uint32_t index,
         uint32_t coerceAxis,
-        uint32_t placement,
+        int32_t placement,
+        int32_t leftAlignedDimensionCount,
         std::optional<gsl::span<const uint32_t>> tensorShape,
         uint32_t minDimensionCount
         ) const
@@ -432,6 +437,7 @@ namespace Dml
             tensorShape ? *tensorShape : outputShape,
             coerceAxis,
             placement,
+            leftAlignedDimensionCount,
             minDimensionCount,
             0
             );

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.h
@@ -81,7 +81,8 @@ namespace Dml
             const MLOperatorKernelCreationContext& kernelInfo,
             uint32_t index,
             uint32_t coerceAxis = TensorAxis::DoNotCoerce,
-            uint32_t placement = TensorAxis::W,
+            int32_t placement = TensorAxis::W,
+            int32_t leftAlignedDimensionCount = TensorAxis::RightAligned,
             std::optional<gsl::span<const uint32_t>> tensorShape = std::nullopt,
             uint32_t minDimensionCount = NchwDimensionCount
             ) const;
@@ -90,7 +91,8 @@ namespace Dml
             const MLOperatorKernelCreationContext& kernelInfo,
             uint32_t index,
             uint32_t coerceAxis = TensorAxis::DoNotCoerce,
-            uint32_t placement = TensorAxis::W,
+            int32_t placement = TensorAxis::W,
+            int32_t leftAlignedDimensionCount = TensorAxis::RightAligned,
             std::optional<gsl::span<const uint32_t>> tensorShape = std::nullopt,
             uint32_t minDimensionCount = NchwDimensionCount
             ) const;

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorActivation.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorActivation.cpp
@@ -113,7 +113,7 @@ public:
             // PRelu is unique and accepts its parameters as a second input tensor.
 
             // The slope tensor is unidirectionally broadcastable. Reshape it based on the desired output sizes.
-            m_inputTensorDescs[1] = CreateTensorDescFromInput(kernelCreationContext, 1, TensorAxis::DoNotCoerce, TensorAxis::W, outputSizes);
+            m_inputTensorDescs[1] = CreateTensorDescFromInput(kernelCreationContext, 1, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, outputSizes);
 
             inputDescs = GetDmlInputDescs();
             outputDescs = GetDmlOutputDescs();

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorBatchNormalization.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorBatchNormalization.cpp
@@ -34,12 +34,12 @@ public:
         const std::optional<ActivationOperatorDesc> fusedActivation = FusionHelpers::TryGetFusedActivationDesc(kernelCreationContext);
         DML_OPERATOR_DESC fusedActivationDmlDesc = fusedActivation ? fusedActivation->GetDmlDesc() : DML_OPERATOR_DESC();
 
-        m_inputTensorDescs[0] = CreateTensorDescFromInput(kernelCreationContext, 0, TensorAxis::DoNotCoerce, TensorAxis::N);
+        m_inputTensorDescs[0] = CreateTensorDescFromInput(kernelCreationContext, 0, TensorAxis::DoNotCoerce, TensorAxis::N, TensorAxis::LeftAligned);
 
         // Massage each of these 1D tensors (of length C) into 4D tensors of the form [1,C,1,1].
         for (uint32_t i = Scale; i < OnnxInputIndex::Count; ++i)
         {
-            m_inputTensorDescs[i] = CreateTensorDescFromInput(kernelCreationContext, i, TensorAxis::DoNotCoerce, TensorAxis::C);
+            m_inputTensorDescs[i] = CreateTensorDescFromInput(kernelCreationContext, i, TensorAxis::DoNotCoerce, TensorAxis::C, TensorAxis::LeftAligned);
         }
 
         std::vector<DML_TENSOR_DESC> inputDescs = GetDmlInputDescs();

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorConvolution.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorConvolution.cpp
@@ -37,7 +37,7 @@ public:
             uint32_t inputDimSize = kernelInfo.GetTensorShapeDescription().GetInputTensorDimensionCount(0);
             ML_CHECK_VALID_ARGUMENT(
                 inputDimSize >= 3 && inputDimSize <= 5,
-                "Bias can only be used with 4D or 5D tensors."
+                "Bias can only be used with 3D/4D/5D tensors."
                 );
             uint32_t dmlDimSize = m_inputTensorDescs[0].GetDimensionCount();
 
@@ -66,8 +66,8 @@ public:
         // so that all output tensor size computations are correct.
         KernelArgs kernelArgs(m_kernel, NchwSpatialDimensionCount);
 
-        // Output padding wasn't implemented based on PyTorch compatible semantics
-        // and should just be ignored. So pass zeroes instead.
+        // Zero the output padding before sending to DirectML. Although it was needed to compute
+        // the output size, we don't want DML to see the values, which should just be ignored.
         memset(kernelArgs.outputPadding, 0, sizeof(kernelArgs.outputPadding));
 
         DML_CONVOLUTION_OPERATOR_DESC convDesc = {};

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorConvolution.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorConvolution.cpp
@@ -24,30 +24,51 @@ public:
         std::vector<std::optional<uint32_t>> kernelInputIndices = {0, 1, 2};
         DmlOperator::Initialize(kernelInfo, kernelInputIndices);
 
+        // Vibranium DirectML is limited to handle only 2D and 3D convolution (4D and 5D tensors). So for 1D tensors,
+        // massage the tensor descriptions. By default, the TensorDesc simply right aligns all the values up to 4D
+        // (padding the leading dimensions with 1's), but 1D tensors actually need to insert the 1 between C and W.
+        // e.g. [2,3,4] becomes [2,3,1,4]
+        m_inputTensorDescs[0] = CreateTensorDescFromInput(kernelInfo, 0, TensorAxis::DoNotCoerce, TensorAxis::NoPlacementAdjustment, NonspatialDimensionCount, std::nullopt);
+        m_inputTensorDescs[1] = CreateTensorDescFromInput(kernelInfo, 1, TensorAxis::DoNotCoerce, TensorAxis::NoPlacementAdjustment, NonspatialDimensionCount, std::nullopt);
+
         // Bias is optional so only adjust it if it exists.
         if (kernelInfo.GetInputCount() > 2)
         {
             uint32_t inputDimSize = kernelInfo.GetTensorShapeDescription().GetInputTensorDimensionCount(0);
             ML_CHECK_VALID_ARGUMENT(
-                inputDimSize == NcdhwDimensionCount || inputDimSize == NchwDimensionCount,
+                inputDimSize >= 3 && inputDimSize <= 5,
                 "Bias can only be used with 4D or 5D tensors."
                 );
+            uint32_t dmlDimSize = m_inputTensorDescs[0].GetDimensionCount();
 
-            // Resize the bias to be the same dimension as the input tensor
+            // Resize the bias to be the same dimension as the input tensor.
+            // The 1D tensor needs to be moved to the C channel.
             m_inputTensorDescs[2] = CreateTensorDescFromInput(
                 kernelInfo, 
                 2, 
                 TensorAxis::DoNotCoerce, 
-                TensorAxis::C, 
+                TensorAxis::C,
+                TensorAxis::LeftAligned,
                 std::nullopt,
-                inputDimSize
+                dmlDimSize
                 );
         }
+
+        m_outputTensorDescs[0] = CreateTensorDescFromOutput(kernelInfo, 0, TensorAxis::DoNotCoerce, TensorAxis::NoPlacementAdjustment, NonspatialDimensionCount, std::nullopt);
 
         std::optional<ActivationOperatorDesc> fusedActivation = FusionHelpers::TryGetFusedActivationDesc(kernelInfo);
         DML_OPERATOR_DESC fusedActivationDmlDesc = fusedActivation ? fusedActivation->GetDmlDesc() : DML_OPERATOR_DESC();
         std::vector<DML_TENSOR_DESC> inputDescs = GetDmlInputDescs();
         std::vector<DML_TENSOR_DESC> outputDescs = GetDmlOutputDescs();
+
+        // Form transient kernel arguments with spatial dimensions padded up to at least 2,
+        // since the DirectML API rejects 1D convolution. Leave the base m_kernel alone
+        // so that all output tensor size computations are correct.
+        KernelArgs kernelArgs(m_kernel, NchwSpatialDimensionCount);
+
+        // Output padding wasn't implemented based on PyTorch compatible semantics
+        // and should just be ignored. So pass zeroes instead.
+        memset(kernelArgs.outputPadding, 0, sizeof(kernelArgs.outputPadding));
 
         DML_CONVOLUTION_OPERATOR_DESC convDesc = {};
         convDesc.InputTensor = &inputDescs[0];
@@ -56,12 +77,12 @@ public:
         convDesc.OutputTensor = &outputDescs[0];
         convDesc.Mode = mode;
         convDesc.Direction = direction;
-        convDesc.DimensionCount = m_kernel.spatialDimensionCount;
-        convDesc.Strides = m_kernel.strides;
-        convDesc.Dilations = m_kernel.dilations;
-        convDesc.StartPadding = m_kernel.startPadding;
-        convDesc.EndPadding = m_kernel.endPadding;
-        convDesc.OutputPadding = m_kernel.outputPadding;
+        convDesc.DimensionCount = kernelArgs.spatialDimensionCount;
+        convDesc.Strides = kernelArgs.strides;
+        convDesc.Dilations = kernelArgs.dilations;
+        convDesc.StartPadding = kernelArgs.startPadding;
+        convDesc.EndPadding = kernelArgs.endPadding;
+        convDesc.OutputPadding = kernelArgs.outputPadding;
         convDesc.GroupCount = m_groupCount;
         convDesc.FusedActivation = fusedActivation ? &fusedActivationDmlDesc : nullptr;
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorElementWise.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorElementWise.cpp
@@ -456,6 +456,7 @@ public:
                     gsl::make_span(adjustedInputTensorShape),
                     TensorAxis::DoNotCoerce,
                     TensorAxis::W,
+                    TensorAxis::RightAligned,
                     NchwDimensionCount, // minDimensionCount
                     0 // guaranteedBaseOffsetAlignment
                 );

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorExpand.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorExpand.cpp
@@ -29,6 +29,7 @@ public:
                 m_inputTensorDescs[0].GetDmlSizes(),
                 TensorAxis::DoNotCoerce,
                 TensorAxis::W,
+                TensorAxis::RightAligned,
                 NchwDimensionCount, // minDimensionCount
                 0);
         
@@ -39,6 +40,7 @@ public:
                 m_outputTensorDescs[0].GetDmlSizes(),
                 TensorAxis::DoNotCoerce,
                 TensorAxis::W,
+                TensorAxis::RightAligned,
                 NchwDimensionCount, // minDimensionCount
                 0
             );

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorGemm.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorGemm.cpp
@@ -23,6 +23,7 @@ public:
             2,
             TensorAxis::DoNotCoerce,
             TensorAxis::W,
+            TensorAxis::RightAligned,
             kernelInfo.GetTensorShapeDescription().GetOutputTensorShape(0)
             );
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorInstanceNormalization.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorInstanceNormalization.cpp
@@ -26,7 +26,7 @@ class DmlOperatorInstanceNormalization : public DmlOperator
             gsl::span<const uint32_t> lastDimension = sizes.last(1);
             ML_CHECK_VALID_ARGUMENT(tensorDesc.GetDimensionCount() == OperatorHelper::NchwDimensionCount);
             ML_CHECK_VALID_ARGUMENT(sizes.size() >=4 && sizes[N] == 1 && sizes[C] == 1 && sizes[H] == 1);
-            m_inputTensorDescs[i] = CreateTensorDescFromInput(kernelCreationContext, i, TensorAxis::DoNotCoerce, TensorAxis::C, lastDimension);
+            m_inputTensorDescs[i] = CreateTensorDescFromInput(kernelCreationContext, i, TensorAxis::DoNotCoerce, TensorAxis::C, TensorAxis::LeftAligned, lastDimension);
         }
     }
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorMatMul.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorMatMul.cpp
@@ -45,11 +45,11 @@ public:
         inputShape1.insert(inputShape1.begin(), outputShape.begin(), outputShape.end() - 2);
 
         // Initialize the input descriptions with broadcasting
-        m_inputTensorDescs[0] = CreateTensorDescFromInput(kernelInfo, 0, TensorAxis::DoNotCoerce, TensorAxis::W, inputShape0);
-        m_inputTensorDescs[1] = CreateTensorDescFromInput(kernelInfo, 1, TensorAxis::DoNotCoerce, TensorAxis::W, inputShape1);
+        m_inputTensorDescs[0] = CreateTensorDescFromInput(kernelInfo, 0, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, inputShape0);
+        m_inputTensorDescs[1] = CreateTensorDescFromInput(kernelInfo, 1, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, inputShape1);
 
         // Initialize the output description while overriding the shape
-        m_outputTensorDescs[0] = CreateTensorDescFromOutput(kernelInfo, 0, TensorAxis::DoNotCoerce, TensorAxis::W, outputShape);
+        m_outputTensorDescs[0] = CreateTensorDescFromOutput(kernelInfo, 0, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, outputShape);
 
         std::vector<DML_TENSOR_DESC> inputDescs = GetDmlInputDescs();
         std::vector<DML_TENSOR_DESC> outputDescs = GetDmlOutputDescs();

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorOneHot.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorOneHot.cpp
@@ -36,6 +36,7 @@ public:
                 gsl::make_span(indicesDimensions),
                 TensorAxis::DoNotCoerce,
                 TensorAxis::W,
+                TensorAxis::RightAligned,
                 NchwDimensionCount, // minDimensionCount
                 0
             );
@@ -47,6 +48,7 @@ public:
                 gsl::make_span(m_outputDimensions),
                 TensorAxis::DoNotCoerce,
                 TensorAxis::W,
+                TensorAxis::RightAligned,
                 NchwDimensionCount, // minDimensionCount
                 0
             );

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorReduce.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorReduce.cpp
@@ -55,6 +55,7 @@ public:
                 0, 
                 TensorAxis::DoNotCoerce, 
                 TensorAxis::W, 
+                TensorAxis::RightAligned,
                 reducedDims);
         }
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorResize.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorResize.cpp
@@ -39,8 +39,8 @@ public:
 
         // Update the tensor descriptions.
         MLOperatorTensorDataType inputTensorDataType = kernelCreationContext.GetInputEdgeDescription(0).tensorDataType;
-        auto inputTensorDesc = TensorDesc(inputTensorDataType, squeezedInputShape, squeezedInputShape, TensorAxis::DoNotCoerce, TensorAxis::W, NchwDimensionCount, 0);
-        auto outputTensorDesc = TensorDesc(inputTensorDataType, squeezedOutputShape, squeezedOutputShape, TensorAxis::DoNotCoerce, TensorAxis::W, NchwDimensionCount, 0);
+        auto inputTensorDesc = TensorDesc(inputTensorDataType, squeezedInputShape, squeezedInputShape, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, NchwDimensionCount, 0);
+        auto outputTensorDesc = TensorDesc(inputTensorDataType, squeezedOutputShape, squeezedOutputShape, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, NchwDimensionCount, 0);
         m_inputTensorDescs[0] = inputTensorDesc;
         m_outputTensorDescs[0] = outputTensorDesc;
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorTile.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorTile.cpp
@@ -39,8 +39,8 @@ public:
 
         // Update the tensor descriptions.
         MLOperatorTensorDataType inputTensorDataType = kernelCreationContext.GetInputEdgeDescription(0).tensorDataType;
-        auto inputTensorDesc = TensorDesc(inputTensorDataType, squeezedInputShape, squeezedInputShape, TensorAxis::DoNotCoerce, TensorAxis::W, NchwDimensionCount, 0);
-        auto outputTensorDesc = TensorDesc(inputTensorDataType, squeezedOutputShape, squeezedOutputShape, TensorAxis::DoNotCoerce, TensorAxis::W, NchwDimensionCount, 0);
+        auto inputTensorDesc = TensorDesc(inputTensorDataType, squeezedInputShape, squeezedInputShape, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, NchwDimensionCount, 0);
+        auto outputTensorDesc = TensorDesc(inputTensorDataType, squeezedOutputShape, squeezedOutputShape, TensorAxis::DoNotCoerce, TensorAxis::W, TensorAxis::RightAligned, NchwDimensionCount, 0);
         m_inputTensorDescs[0] = inputTensorDesc;
         m_outputTensorDescs[0] = outputTensorDesc;
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.h
@@ -26,7 +26,8 @@ namespace Dml
             gsl::span<const uint32_t> dimensions, // Desired dimensions of tensor (after any broadcasting).
             gsl::span<const uint32_t> nonBroadcastDimensions, // Original dimensions (before any broadcasting). Usually same as 'dimensions'.
             uint32_t coerceAxis,
-            uint32_t placement,
+            int32_t placement, // Adjustment offset of the passed dimensions within the minDimensionCount.
+            int32_t leftAlignedDimensionCount, // Number of dimensions that are left aligned (INT32_MAX means all, 0 means all right aligned).
             uint32_t minDimensionCount,
             uint32_t guaranteedBaseOffsetAlignment
             );
@@ -104,6 +105,12 @@ namespace Dml
             return *this;
         }
 
+        inline TensorDescBuilder& SetLeftAlignedDimensionCount(uint32_t leftAlignedDimensionCount)
+        {
+            m_leftAlignedDimensionCount = leftAlignedDimensionCount;
+            return *this;
+        }
+
         inline TensorDesc Create()
         {
             return TensorDesc(
@@ -112,8 +119,10 @@ namespace Dml
                 m_nonBroadcastDimensions.size() > 0 ? m_nonBroadcastDimensions : m_dimensions,
                 m_coerceAxis,
                 m_placement,
+                m_leftAlignedDimensionCount,
                 m_minDimensionCount,
-                m_guaranteedBaseOffsetAlignment);
+                m_guaranteedBaseOffsetAlignment
+                );
         }
 
     private:
@@ -121,7 +130,8 @@ namespace Dml
         gsl::span<const uint32_t> m_dimensions = {};
         gsl::span<const uint32_t> m_nonBroadcastDimensions = {};
         TensorAxis m_coerceAxis = TensorAxis::DoNotCoerce;
-        TensorAxis m_placement = TensorAxis::W;
+        TensorAxis m_placement = TensorAxis::NoPlacementAdjustment;
+        int32_t m_leftAlignedDimensionCount = TensorAxis::RightAligned;
         uint32_t m_minDimensionCount = NchwDimensionCount;
         uint32_t m_guaranteedBaseOffsetAlignment = 0;
     };

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.h
@@ -27,7 +27,7 @@ namespace Dml
             gsl::span<const uint32_t> nonBroadcastDimensions, // Original dimensions (before any broadcasting). Usually same as 'dimensions'.
             uint32_t coerceAxis,
             int32_t placement, // Adjustment offset of the passed dimensions within the minDimensionCount.
-            int32_t leftAlignedDimensionCount, // Number of dimensions that are left aligned (INT32_MAX means all, 0 means all right aligned).
+            int32_t leftAlignedDimensionCount, // Number of dimensions that remain left aligned when expanded to minimum count (INT32_MAX means all, 0 means all right aligned).
             uint32_t minDimensionCount,
             uint32_t guaranteedBaseOffsetAlignment
             );

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/Common.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/Common.h
@@ -22,14 +22,15 @@
 
 namespace OperatorHelper
 {
-    enum TensorAxis { N, C, H, W, DoNotCoerce = UINT_MAX };
+    enum TensorAxis { N, C, H, W, DoNotCoerce = UINT_MAX, LeftAligned = INT_MAX, RightAligned = INT_MIN, NoPlacementAdjustment = 0 };
     enum BroadcastMode { NoBroadcast, UnidirectionalBroadcast, MultidirectionalBroadcast };
 
     using DimensionType = uint32_t;
 
-    static const uint32_t NchwDimensionCount = 4; // Some operators only handle 4 dimensions.
-    static const uint32_t NchwSpatialDimensionCount = 2;
-    static const uint32_t NcdhwDimensionCount = 5;
-    static const uint32_t NcdhwSpatialDimensionCount = 3;
+    static constexpr uint32_t NchwDimensionCount = 4; // Some operators only handle 4 dimensions.
+    static constexpr uint32_t NchwSpatialDimensionCount = 2;
+    static constexpr uint32_t NcdhwDimensionCount = 5;
+    static constexpr uint32_t NcdhwSpatialDimensionCount = 3;
+    static constexpr uint32_t NonspatialDimensionCount = 2; // The batch and channel dimensions of NCW, NCHW, NCDHW....
 
 } // namespace OperatorHelper

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
@@ -125,10 +125,11 @@ struct KernelArgs
         fillCount = std::min(fillCount, gsl::narrow_cast<uint32_t>(output.size()));
         std::fill_n(output.data(), fillCount, value);
         size_t copyCount = std::min(output.size() - fillCount, input.size());
-        memcpy(output.data() + fillCount, input.data(), copyCount * sizeof(input[0]));
+        std::copy_n(input.data(), copyCount, output.data() + fillCount);
     }
 
-    // Create a copy of an existing kernel args with a minimum dimension count.
+    // Create a copy of an existing kernel args with a minimum dimension count,
+    // filling the leading attribute values with 1's or 0's respectively.
     KernelArgs(KernelArgs const& kernelArgs, uint32_t minimumDimensionCount) :
         autoPad(kernelArgs.autoPad),
         autoPadSameUpper(kernelArgs.autoPadSameUpper),
@@ -322,7 +323,7 @@ public:
         const std::vector<DimensionType> filterDims = shapeInfo.GetInputTensorShape(1);
 
         ML_CHECK_VALID_ARGUMENT(
-            inputDimensions.size() == 3 || inputDimensions.size() == NchwDimensionCount || inputDimensions.size() == NcdhwDimensionCount,
+            inputDimensions.size() >= 3 && inputDimensions.size() <= 5,
             "Input dimensions must be: 3, 4, 5."
         );
         
@@ -349,7 +350,7 @@ public:
         const std::vector<DimensionType> inputDimensions = shapeInfo.GetInputTensorShape(0);
         const std::vector<DimensionType> filterDims = shapeInfo.GetInputTensorShape(1);
 
-        ML_CHECK_VALID_ARGUMENT(inputDimensions.size() > NonspatialDimensionCount, "Input dimensions must be > 2");
+        ML_CHECK_VALID_ARGUMENT(inputDimensions.size() > NonspatialDimensionCount, "Input dimensions must be >= 3");
 
         ResolvingPadding(inputDimensions);
         m_outputShapes.resize(1);

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
@@ -102,8 +102,9 @@ private:
 
 struct KernelArgs
 {
-    // Initialize arrays with NcdhwSpatialDimensionCount to avoid vectors, but it's important to use
-    // spatialDimensionCount when iterating through them
+    // Initialize arrays up to NcdhwSpatialDimensionCount to avoid vector allocations,
+    // but it's important to use .spatialDimensionCount when accessing them because
+    // values beyond that may be bogus.
     uint32_t strides[NcdhwSpatialDimensionCount];
     uint32_t dilations[NcdhwSpatialDimensionCount];
     uint32_t windowSize[NcdhwSpatialDimensionCount];
@@ -114,7 +115,35 @@ struct KernelArgs
     KernelArgs(uint32_t spatialDimensionCount) :
         autoPad(false),
         autoPadSameUpper(false),
-        spatialDimensionCount(spatialDimensionCount) {}
+        spatialDimensionCount(spatialDimensionCount)
+    {
+        ML_CHECK_VALID_ARGUMENT(spatialDimensionCount <= NcdhwSpatialDimensionCount);
+    }
+
+    void FillWithLeadingValues(gsl::span<const uint32_t> input, gsl::span<uint32_t> output, uint32_t fillCount, uint32_t value)
+    {
+        fillCount = std::min(fillCount, gsl::narrow_cast<uint32_t>(output.size()));
+        std::fill_n(output.data(), fillCount, value);
+        size_t copyCount = std::min(output.size() - fillCount, input.size());
+        memcpy(output.data() + fillCount, input.data(), copyCount * sizeof(input[0]));
+    }
+
+    // Create a copy of an existing kernel args with a minimum dimension count.
+    KernelArgs(KernelArgs const& kernelArgs, uint32_t minimumDimensionCount) :
+        autoPad(kernelArgs.autoPad),
+        autoPadSameUpper(kernelArgs.autoPadSameUpper),
+        spatialDimensionCount(std::max(kernelArgs.spatialDimensionCount, minimumDimensionCount))
+    {
+        ML_CHECK_VALID_ARGUMENT(spatialDimensionCount <= NcdhwSpatialDimensionCount);
+
+        uint32_t fillCount = (minimumDimensionCount > kernelArgs.spatialDimensionCount) ? minimumDimensionCount - kernelArgs.spatialDimensionCount : 0;
+        FillWithLeadingValues(kernelArgs.strides, this->strides, fillCount, 1u);
+        FillWithLeadingValues(kernelArgs.dilations, this->dilations, fillCount, 1u);
+        FillWithLeadingValues(kernelArgs.windowSize, this->windowSize, fillCount, 1u);
+        FillWithLeadingValues(kernelArgs.startPadding, this->startPadding, fillCount, 0u);
+        FillWithLeadingValues(kernelArgs.endPadding, this->endPadding, fillCount, 0u);
+        FillWithLeadingValues(kernelArgs.outputPadding, this->outputPadding, fillCount, 0u);
+    }
 
     // This is true if padding must be automatically computed based on input sizes.
     // ResolveAutoPadding must happen during Compute rather than initialization.
@@ -293,8 +322,8 @@ public:
         const std::vector<DimensionType> filterDims = shapeInfo.GetInputTensorShape(1);
 
         ML_CHECK_VALID_ARGUMENT(
-            inputDimensions.size() == NchwDimensionCount || inputDimensions.size() == NcdhwDimensionCount,
-            "Input dimensions must be 4 or 5."
+            inputDimensions.size() == 3 || inputDimensions.size() == NchwDimensionCount || inputDimensions.size() == NcdhwDimensionCount,
+            "Input dimensions must be: 3, 4, 5."
         );
         
         ResolvingPadding(inputDimensions);
@@ -312,19 +341,20 @@ public:
         if (!outputShape.empty())
         {
             ML_CHECK_VALID_ARGUMENT(
-                outputShape.size() >= 2,
-                "The output shape must have two or more dimensions"
+                outputShape.size() >= m_kernel.spatialDimensionCount,
+                "The output shape must equal the number of spatial dimensions"
             );
         }
 
         const std::vector<DimensionType> inputDimensions = shapeInfo.GetInputTensorShape(0);
         const std::vector<DimensionType> filterDims = shapeInfo.GetInputTensorShape(1);
 
-        ML_CHECK_VALID_ARGUMENT(inputDimensions.size() > NchwSpatialDimensionCount, "Input dimensions must be > 2");
+        ML_CHECK_VALID_ARGUMENT(inputDimensions.size() > NonspatialDimensionCount, "Input dimensions must be > 2");
 
         ResolvingPadding(inputDimensions);
         m_outputShapes.resize(1);
         m_outputShapes[0] = InitializeKernelOutputDimsTranspose(inputDimensions, m_kernel);
+        static_assert(C < NonspatialDimensionCount);
         assert(m_outputShapes[0].GetShape().size() > C);
         m_outputShapes[0].GetShape()[C] = filterDims[C] * m_groupCount;
 

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -560,21 +560,6 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     broken_tests.insert({"resize_downsample_linear", "ORT 0.4 uses asymmetric but will conform to half_pixel in the next ONNX version."});
     broken_tests.insert({"resize_upsample_linear", "ORT 0.4 uses asymmetric but will conform to half_pixel in the next ONNX version."});
     broken_tests.insert({"resize_upsample_linear", "ORT 0.4 uses asymmetric but will conform to half_pixel in the next ONNX version."});
-
-    // These tests are temporarily disabled pending a fix to the DML EP for Convolution when 3D tensors are supplied
-    broken_tests.insert({"Conv1d", "Temporarily disabled due to EP bug"});
-    broken_tests.insert({"Conv1d_dilated", "Temporarily disabled due to EP bug"});
-    broken_tests.insert({"Conv1d_groups", "Temporarily disabled due to EP bug"});
-    broken_tests.insert({"Conv1d_pad1", "Temporarily disabled due to EP bug"});
-    broken_tests.insert({"Conv1d_pad1size1", "Temporarily disabled due to EP bug"});
-    broken_tests.insert({"Conv1d_pad2", "Temporarily disabled due to EP bug"});
-    broken_tests.insert({"Conv1d_pad2size1", "Temporarily disabled due to EP bug"});
-    broken_tests.insert({"Conv1d_stride", "Temporarily disabled due to EP bug"});
-
-    // These tests are temporarily disabled pending a fix to the DML EP for handling of the output_padding attribute
-    broken_tests.insert({"ConvTranspose2d", "Temporarily disabled due to EP bug"});
-    broken_tests.insert({"ConvTranspose2d_no_bias", "Temporarily disabled due to EP bug"});
-    broken_tests.insert({"operator_convtranspose", "Temporarily disabled due to EP bug"});
   }
 #endif
   // clang-format on

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -560,6 +560,11 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     broken_tests.insert({"resize_downsample_linear", "ORT 0.4 uses asymmetric but will conform to half_pixel in the next ONNX version."});
     broken_tests.insert({"resize_upsample_linear", "ORT 0.4 uses asymmetric but will conform to half_pixel in the next ONNX version."});
     broken_tests.insert({"resize_upsample_linear", "ORT 0.4 uses asymmetric but will conform to half_pixel in the next ONNX version."});
+
+    // These tests are temporarily disabled pending a fix to the DML EP for handling of the output_padding attribute
+    broken_tests.insert({"ConvTranspose2d", "Temporarily disabled due to EP bug"});
+    broken_tests.insert({"ConvTranspose2d_no_bias", "Temporarily disabled due to EP bug"});
+    broken_tests.insert({"operator_convtranspose", "Temporarily disabled due to EP bug"});
   }
 #endif
   // clang-format on


### PR DESCRIPTION
**Description**: Support 1D convolution and fix output_padding to be compatible with PyTorch.

**Motivation and Context**
- Addresses OS bugs 23499875 and 23500167.
- Support 1D convolution (3D input tensor with N,C,W) is legal. Since DirectML rejects this valid tensor, massage 1D to 2D, by inserting a 1 for height (N, C, 1, W) and set SpatialDimensionCount from 1 -> 2. This is handled by the same TensorDesc class which handles other types of coercion such as multiplicative flattening and tensor alignment to a minimum dimension count. The true output shape must remain correct for propagation throughout the graph, and so the KernelArgs used by the base class keeps all fields true to the actual values ([N, C, W] and SpatialDimensionCount = 1), but they are massaged before being passed to DirectML.
- OutputPadding. "You keep using that word. I do not think it means what you think it means." Use output padding for shape calculation, but do not pass it along to DirectML, since ONNX semantics should conform to PyTorch semantics. The KernelArgs still needs to read the padding for proper size, but it passes 0's to DML.