### PR TITLE
Use built-in wstring_convert on Android

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
@@ -9,7 +9,7 @@
 #ifdef _MSC_VER
 #include <codecvt>
 #include <locale.h>
-#elif (defined __APPLE__)
+#elif defined (__APPLE__) or defined (__ANDROID__)
 #include <codecvt>
 #else
 #include <limits>
@@ -105,7 +105,7 @@ class Locale {
   std::locale loc_;
 };
 
-#ifdef __APPLE__
+#if defined(__APPLE__) or defined(__ANDROID__)
 using Utf8Converter = std::wstring_convert<std::codecvt_utf8<wchar_t>>;
 #else
 


### PR DESCRIPTION
**Description**: Android build is broken since 627f853a44, Android NDK doesn't have `iconv_open`