### PR TITLE
Introduce execution mode for clarity and extensibility; Change Python APIs accordingly; Replace DisableSequentialExecution API with EnableParallelExecution for clarity.

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.OnnxRuntime
         public IntPtr SetOptimizedModelFilePath;
         public IntPtr CloneSessionOptions;
         public IntPtr EnableSequentialExecution;
-        public IntPtr DisableSequentialExecution;
+        public IntPtr EnableParallelExecution;
         public IntPtr EnableProfiling;
         public IntPtr DisableProfiling;
         public IntPtr EnableMemPattern;
@@ -157,7 +157,7 @@ namespace Microsoft.ML.OnnxRuntime
             OrtReleaseSessionOptions = (DOrtReleaseSessionOptions)Marshal.GetDelegateForFunctionPointer(api_.ReleaseSessionOptions, typeof(DOrtReleaseSessionOptions));
             OrtCloneSessionOptions = (DOrtCloneSessionOptions)Marshal.GetDelegateForFunctionPointer(api_.CloneSessionOptions, typeof(DOrtCloneSessionOptions));
             OrtEnableSequentialExecution = (DOrtEnableSequentialExecution)Marshal.GetDelegateForFunctionPointer(api_.EnableSequentialExecution, typeof(DOrtEnableSequentialExecution));
-            OrtDisableSequentialExecution = (DOrtDisableSequentialExecution)Marshal.GetDelegateForFunctionPointer(api_.DisableSequentialExecution, typeof(DOrtDisableSequentialExecution));
+            OrtEnableParallelExecution = (DOrtEnableParallelExecution)Marshal.GetDelegateForFunctionPointer(api_.EnableParallelExecution, typeof(DOrtEnableParallelExecution));
             OrtSetOptimizedModelFilePath = (DOrtSetOptimizedModelFilePath)Marshal.GetDelegateForFunctionPointer(api_.SetOptimizedModelFilePath, typeof(DOrtSetOptimizedModelFilePath));
             OrtEnableProfiling = (DOrtEnableProfiling)Marshal.GetDelegateForFunctionPointer(api_.EnableProfiling, typeof(DOrtEnableProfiling));
             OrtDisableProfiling = (DOrtDisableProfiling)Marshal.GetDelegateForFunctionPointer(api_.DisableProfiling, typeof(DOrtDisableProfiling));
@@ -324,7 +324,7 @@ namespace Microsoft.ML.OnnxRuntime
                                                 UIntPtr index,
                                                 out IntPtr /* (struct OrtTypeInfo**)*/ typeInfo);
         public static DOrtSessionGetOverridableInitializerTypeInfo OrtSessionGetOverridableInitializerTypeInfo;
-        
+
 
         public delegate void DOrtReleaseTypeInfo(IntPtr /*(OrtTypeInfo*)*/session);
         public static DOrtReleaseTypeInfo OrtReleaseTypeInfo;
@@ -348,8 +348,8 @@ namespace Microsoft.ML.OnnxRuntime
         public delegate IntPtr /*(OrtStatus*)*/ DOrtEnableSequentialExecution(IntPtr /*(OrtSessionOptions*)*/ options);
         public static DOrtEnableSequentialExecution OrtEnableSequentialExecution;
 
-        public delegate IntPtr /*(OrtStatus*)*/ DOrtDisableSequentialExecution(IntPtr /*(OrtSessionOptions*)*/ options);
-        public static DOrtDisableSequentialExecution OrtDisableSequentialExecution;
+        public delegate IntPtr /*(OrtStatus*)*/ DOrtEnableParallelExecution(IntPtr /*(OrtSessionOptions*)*/ options);
+        public static DOrtEnableParallelExecution OrtEnableParallelExecution;
 
         public delegate IntPtr /*(OrtStatus*)*/ DOrtSetOptimizedModelFilePath(IntPtr /* OrtSessionOptions* */ options, [MarshalAs(UnmanagedType.LPWStr)]string optimizedModelFilepath);
         public static DOrtSetOptimizedModelFilePath OrtSetOptimizedModelFilePath;

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.cs
@@ -160,7 +160,7 @@ namespace Microsoft.ML.OnnxRuntime
                 }
                 else if (_enableSequentialExecution && !value)
                 {
-                    NativeApiStatus.VerifySuccess(NativeMethods.OrtDisableSequentialExecution(_nativePtr));
+                    NativeApiStatus.VerifySuccess(NativeMethods.OrtEnableParallelExecution(_nativePtr));
                     _enableSequentialExecution = false;
                 }
             }

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -163,14 +163,14 @@ namespace Microsoft.ML.OnnxRuntime.Tests
         [InlineData(GraphOptimizationLevel.ORT_DISABLE_ALL, false)]
         [InlineData(GraphOptimizationLevel.ORT_ENABLE_EXTENDED, true)]
         [InlineData(GraphOptimizationLevel.ORT_ENABLE_EXTENDED, false)]
-        private void CanRunInferenceOnAModel(GraphOptimizationLevel graphOptimizationLevel, bool disableSequentialExecution)
+        private void CanRunInferenceOnAModel(GraphOptimizationLevel graphOptimizationLevel, bool enableParallelExecution)
         {
             string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "squeezenet.onnx");
 
             // Set the graph optimization level for this session.
             SessionOptions options = new SessionOptions();
             options.GraphOptimizationLevel = graphOptimizationLevel;
-            if (disableSequentialExecution) options.EnableSequentialExecution = false;
+            if (enableParallelExecution) options.EnableSequentialExecution = false;
 
             using (var session = new InferenceSession(modelPath, options))
             {

--- a/docs/CSharp_API.md
+++ b/docs/CSharp_API.md
@@ -114,7 +114,7 @@ Sets the graph optimization level for the session. Default is set to 1. Availabl
     EnableSequentialExecution();
 Enable Sequential Execution. By default, it is enabled.
 
-    DisableSequentialExecution();
+    EnableParallelExecution();
 Disable Sequential Execution and enable Parallel Execution.
 
 ### NodeMetadata

--- a/docs/ONNX_Runtime_Perf_Tuning.md
+++ b/docs/ONNX_Runtime_Perf_Tuning.md
@@ -67,12 +67,12 @@ import onnxruntime as rt
 sess_options = rt.SessionOptions()
 
 sess_options.intra_op_num_threads=2
-sess_options.enable_sequential_execution=True
+sess_options.execution_mode=rt.ExecutionMode.SEQUENTIAL
 sess_options.set_graph_optimization_level(2)
 ```
 * sess_options.intra_op_num_threads=2 controls how many thread do you want to use to run your model
-* sess_options.enable_sequential_execution=True controls whether you want to run operators in your graph sequentially or in parallel. Usually when your model has many branches, set this option to false will give you better performance.
-* When sess_options.enable_sequential_execution=False, you can set sess_options.inter_op_num_threads to control the
+* sess_options.execution_mode=rt.ExecutionMode.SEQUENTIAL controls whether you want to run operators in your graph sequentially or in parallel. Usually when your model has many branches, set this option to false will give you better performance.
+* When sess_options.execution_mode=rt.ExecutionMode.PARALLEL, you can set sess_options.inter_op_num_threads to control the
 number of threads used to parallelize the execution of the graph (across nodes).
 * sess_options.set_graph_optimization_level(2). Default is 1. Please see [onnxruntime_c_api.h](../include/onnxruntime/core/session/onnxruntime_c_api.h#L241)  (enum GraphOptimizationLevel) for the full list of all optimization levels.
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -257,7 +257,7 @@ struct OrtApi {
   // create a copy of an existing OrtSessionOptions
   OrtStatus*(ORT_API_CALL* CloneSessionOptions)(_In_ const OrtSessionOptions* in_options, _Outptr_ OrtSessionOptions** out_options)NO_EXCEPTION;
   OrtStatus*(ORT_API_CALL* EnableSequentialExecution)(_Inout_ OrtSessionOptions* options)NO_EXCEPTION;
-  OrtStatus*(ORT_API_CALL* DisableSequentialExecution)(_Inout_ OrtSessionOptions* options)NO_EXCEPTION;
+  OrtStatus*(ORT_API_CALL* EnableParallelExecution)(_Inout_ OrtSessionOptions* options)NO_EXCEPTION;
 
   // Enable profiling for this session.
   OrtStatus*(ORT_API_CALL* EnableProfiling)(_Inout_ OrtSessionOptions* options, _In_ const ORTCHAR_T* profile_file_prefix)NO_EXCEPTION;

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -159,7 +159,7 @@ struct SessionOptions : Base<OrtSessionOptions> {
   SessionOptions& DisableMemPattern();
 
   SessionOptions& EnableSequentialExecution();
-  SessionOptions& DisableSequentialExecution();
+  SessionOptions& EnableParallelExecution();
 
   SessionOptions& SetLogId(const char* logid);
 

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -207,8 +207,8 @@ inline SessionOptions& SessionOptions::EnableSequentialExecution() {
   return *this;
 }
 
-inline SessionOptions& SessionOptions::DisableSequentialExecution() {
-  ThrowOnError(g_api->DisableSequentialExecution(p_));
+inline SessionOptions& SessionOptions::EnableParallelExecution() {
+  ThrowOnError(g_api->EnableParallelExecution(p_));
   return *this;
 }
 

--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -1,7 +1,7 @@
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-#--------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 """
 ONNX Runtime
 enables high-performance evaluation of trained machine learning (ML)
@@ -15,7 +15,7 @@ as Deep Learning algorithms in the
 __version__ = "0.5.0"
 __author__ = "Microsoft"
 
+from onnxruntime.capi.session import InferenceSession
 from onnxruntime.capi import onnxruntime_validation
 onnxruntime_validation.check_distro_info()
-from onnxruntime.capi.session import InferenceSession
-from onnxruntime.capi._pybind_state import get_all_providers, get_available_providers, get_device, RunOptions, SessionOptions, set_default_logger_severity, NodeArg, ModelMetadata, GraphOptimizationLevel
+from onnxruntime.capi._pybind_state import get_all_providers, get_available_providers, get_device, RunOptions, SessionOptions, set_default_logger_severity, NodeArg, ModelMetadata, GraphOptimizationLevel, ExecutionMode

--- a/onnxruntime/core/framework/allocation_planner.h
+++ b/onnxruntime/core/framework/allocation_planner.h
@@ -8,6 +8,8 @@
 #include "core/framework/allocator.h"
 #include "core/framework/sequential_execution_plan.h"
 #include "core/graph/graph_viewer.h"
+#include "core/framework/session_options.h"
+
 namespace ONNX_NAMESPACE {
 class TensorShapeProto;
 }
@@ -29,18 +31,18 @@ class ISequentialPlannerContext {
 
 class SequentialPlannerContext : public ISequentialPlannerContext {
  public:
-  SequentialPlannerContext(bool p_enable_parallel_execution)
-      : m_enable_parallel_execution(p_enable_parallel_execution) {
+  SequentialPlannerContext(onnxruntime::ExecutionMode execution_mode)
+      : m_execution_mode(execution_mode) {
   }
 
   const ONNX_NAMESPACE::TensorShapeProto* GetShape(const onnxruntime::NodeArg& arg) const override {
     return arg.Shape();
   }
 
-  bool IsParallelExecutionEnabled() const override { return m_enable_parallel_execution; }
+  bool IsParallelExecutionEnabled() const override { return m_execution_mode == onnxruntime::ExecutionMode::kParallel; }
 
  private:
-  bool m_enable_parallel_execution{false};
+  onnxruntime::ExecutionMode m_execution_mode = onnxruntime::ExecutionMode::kSequential;
 };
 
 class SequentialPlanner {

--- a/onnxruntime/core/framework/session_options.h
+++ b/onnxruntime/core/framework/session_options.h
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include "core/session/onnxruntime_c_api.h"
+#include "core/optimizer/graph_transformer_level.h"
+
+namespace onnxruntime {
+struct FreeDimensionOverride {
+  std::string dimension_denotation;
+  int64_t dimension_override;
+};
+
+enum class ExecutionMode {
+  kSequential,
+  kParallel,
+};
+
+/**
+  * Configuration information for a session.
+  */
+struct SessionOptions {
+  ExecutionMode execution_mode = ExecutionMode::kSequential;
+
+  // enable profiling for this session.
+  bool enable_profiling = false;
+
+  // non empty filepath enables serialization of the transformed optimized model to the specified filepath.
+  std::basic_string<ORTCHAR_T> optimized_model_filepath;
+
+  // enable the memory pattern optimization.
+  // The idea is if the input shapes are the same, we could trace the internal memory allocation
+  // and generate a memory pattern for future request. So next time we could just do one allocation
+  // with a big chunk for all the internal memory allocation.
+  // See class 'OrtValuePatternPlanner'.
+  bool enable_mem_pattern = true;
+
+  // enable the memory arena on CPU
+  // Arena may pre-allocate memory for future usage.
+  // set this option to false if you don't want it.
+  bool enable_cpu_mem_arena = true;
+
+  // the prefix of the profile file. The current time will be appended to the file name.
+  std::basic_string<ORTCHAR_T> profile_file_prefix = ORT_TSTR("onnxruntime_profile_");
+
+  std::string session_logid;  ///< logger id to use for session output
+
+  /// Log severity for the inference session. Applies to session load, initialization, etc.
+  /// See https://github.com/microsoft/onnxruntime/blob/master/include/onnxruntime/core/common/logging/severity.h
+  /// Default = -1 (use default logger severity)
+  int session_log_severity_level = -1;
+  int session_log_verbosity_level = 0;  ///< VLOG level if debug build and session_log_severity_level is 0 (VERBOSE).
+
+  unsigned max_num_graph_transformation_steps = 5;  // TODO choose a good default here?
+
+  // set graph optimization level
+  TransformerLevel graph_optimization_level = TransformerLevel::Level1;
+
+  // controls the size of the thread pool used to parallelize the execution of tasks within individual nodes (ops)
+  int intra_op_num_threads = 0;
+
+  // controls the size of the thread pool used to parallelize the execution of nodes (ops)
+  // configuring this makes sense only when you're using parallel executor
+  int inter_op_num_threads = 0;
+
+  // For models with free input dimensions (most commonly batch size), specifies a set of values to override those
+  // free dimensions with, keyed by dimension denotation.
+  std::vector<FreeDimensionOverride> free_dimension_overrides;
+};
+}  // namespace onnxruntime

--- a/onnxruntime/core/framework/session_state_initializer.cc
+++ b/onnxruntime/core/framework/session_state_initializer.cc
@@ -58,7 +58,7 @@ SessionStateInitializer::SessionStateInitializer(bool enable_mem_pattern,
 common::Status SessionStateInitializer::CreatePlan(
     const Node* parent_node,
     const ConstPointerContainer<std::vector<NodeArg*>>* outer_scope_node_args,
-    bool enable_sequential_execution) {
+    ExecutionMode execution_mode) {
   session_state_.SetGraph(graph_);
   const GraphViewer* graph_viewer = session_state_.GetGraphViewer();
 
@@ -78,7 +78,7 @@ common::Status SessionStateInitializer::CreatePlan(
   }
 
   std::unique_ptr<SequentialExecutionPlan> exec_plan;
-  SequentialPlannerContext context(!enable_sequential_execution);
+  SequentialPlannerContext context(execution_mode);
   ORT_RETURN_IF_ERROR(SequentialPlanner::CreatePlan(parent_node, *graph_viewer, valid_outer_scope_node_args,
                                                     execution_providers_, kernel_registry_manager_,
                                                     ort_value_name_idx_map, context, exec_plan));

--- a/onnxruntime/core/framework/session_state_initializer.h
+++ b/onnxruntime/core/framework/session_state_initializer.h
@@ -9,6 +9,7 @@
 #include "core/framework/tensor.h"
 #include "core/framework/path_lib.h"
 #include "core/framework/tensor_allocator.h"
+#include "core/framework/session_options.h"
 
 namespace onnxruntime {
 class ExecutionProviders;
@@ -39,7 +40,7 @@ class SessionStateInitializer {
   // Then initialize tensors, and save. save kernels and input/output node mappings
   common::Status CreatePlan(_In_opt_ const Node* parent_node,
                             _In_opt_ const ConstPointerContainer<std::vector<NodeArg*>>* outer_scope_node_args,
-                            bool enable_sequential_execution);
+                            ExecutionMode execution_mode);
 
  private:
   const std::basic_string<PATH_CHAR_TYPE>& graph_loc_;

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -433,12 +433,12 @@ static common::Status ExecuteGraphImpl(const SessionState& session_state,
                                        const FeedsFetchesManager& feeds_fetches_manager,
                                        const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                        const std::unordered_map<size_t, IExecutor::CustomAllocator>& fetch_allocators,
-                                       bool sequential_execution, const bool& terminate_flag,
+                                       ExecutionMode execution_mode, const bool& terminate_flag,
                                        const logging::Logger& logger) {
   std::unique_ptr<IExecutor> p_exec;
-  if (sequential_execution) {
+  if (execution_mode == ExecutionMode::kSequential) {
     p_exec = std::unique_ptr<IExecutor>(new SequentialExecutor(terminate_flag));
-  } else {
+  } else if (execution_mode == ExecutionMode::kParallel) {
     auto* p_inter_op_thread_pool = session_state.GetInterOpThreadPool();
     if (!p_inter_op_thread_pool) {
       LOGS(logger, WARNING) << "Only one thread was configured for parallel execution. Hence will use sequential execution.";
@@ -506,7 +506,7 @@ static common::Status ExecuteGraphImpl(const SessionState& session_state,
 common::Status ExecuteGraph(const SessionState& session_state,
                             FeedsFetchesManager& feeds_fetches_manager,
                             const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                            bool sequential_execution, const bool& terminate_flag,
+                            ExecutionMode execution_mode, const bool& terminate_flag,
                             const logging::Logger& logger) {
   ORT_RETURN_IF_ERROR(utils::InitializeFeedFetchCopyInfo(session_state, feeds_fetches_manager));
 
@@ -514,7 +514,7 @@ common::Status ExecuteGraph(const SessionState& session_state,
   FinalizeFeedFetchCopyInfo(session_state, feeds_fetches_manager, feeds, fetches);
 
   auto status = ExecuteGraphImpl(session_state, feeds_fetches_manager, feeds, fetches, {},
-                                 sequential_execution, terminate_flag, logger);
+                                 execution_mode, terminate_flag, logger);
 
   return status;
 }
@@ -522,9 +522,9 @@ common::Status ExecuteGraph(const SessionState& session_state,
 common::Status ExecuteSubgraph(const SessionState& session_state, const FeedsFetchesManager& feeds_fetches_manager,
                                const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                const std::unordered_map<size_t, IExecutor::CustomAllocator>& fetch_allocators,
-                               bool sequential_execution, const bool& terminate_flag, const logging::Logger& logger) {
+                               ExecutionMode execution_mode, const bool& terminate_flag, const logging::Logger& logger) {
   auto status = ExecuteGraphImpl(session_state, feeds_fetches_manager, feeds, fetches, fetch_allocators,
-                                 sequential_execution, terminate_flag, logger);
+                                 execution_mode, terminate_flag, logger);
   return status;
 }
 

--- a/onnxruntime/core/framework/utils.h
+++ b/onnxruntime/core/framework/utils.h
@@ -9,6 +9,7 @@
 #include "core/framework/framework_common.h"
 #include "core/framework/iexecutor.h"
 #include "core/framework/session_state.h"
+#include "core/framework/session_options.h"
 
 namespace ONNX_NAMESPACE {
 class TensorShapeProto;
@@ -67,14 +68,14 @@ void FinalizeFeedFetchCopyInfo(const SessionState& session_state,
 // Execute the main graph. The feed_fetches_manager will be finalized based on the provided feeds and fetches.
 common::Status ExecuteGraph(const SessionState& session_state, FeedsFetchesManager& feeds_fetches_manager,
                             const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                            bool sequential_execution, const bool& terminate_flag, const logging::Logger& logger);
+                            ExecutionMode execution_mode, const bool& terminate_flag, const logging::Logger& logger);
 
 // Execute a subgraph. The feeds_fetches_manager should have been finalized prior to calling this function.
 // See IControlFlowNode::SetupSubgraphExecutionInfo usage in the control flow kernels.
 common::Status ExecuteSubgraph(const SessionState& session_state, const FeedsFetchesManager& feeds_fetches_manager,
                                const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                const std::unordered_map<size_t, IExecutor::CustomAllocator>& fetch_allocators,
-                               bool sequential_execution, const bool& terminate_flag, const logging::Logger& logger);
+                               ExecutionMode execution_mode, const bool& terminate_flag, const logging::Logger& logger);
 
 #if defined(DEBUG_NODE_INPUTS_OUTPUTS)
 // to create a build with these enabled run the build script with

--- a/onnxruntime/core/optimizer/free_dim_override_transformer.cc
+++ b/onnxruntime/core/optimizer/free_dim_override_transformer.cc
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/common/logging/logging.h"
-#include "core/session/inference_session.h"
+#include "core/framework/session_options.h"
 #include "core/graph/graph_utils.h"
 #include "core/optimizer/free_dim_override_transformer.h"
 
@@ -19,7 +19,7 @@ static std::string ToLower(std::string s) {
 }
 
 /*explicit*/ FreeDimensionOverrideTransformer::FreeDimensionOverrideTransformer(gsl::span<const FreeDimensionOverride> overrides_to_apply)
-  : GraphTransformer("FreeDimensionOverrideTransformer") {
+    : GraphTransformer("FreeDimensionOverrideTransformer") {
   for (const auto& o : overrides_to_apply) {
     // Convert to lowercase to perform case-insensitive comparisons later
     std::string denotation = ToLower(o.dimension_denotation);

--- a/onnxruntime/core/providers/cpu/controlflow/if.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/if.cc
@@ -9,6 +9,7 @@
 #include "core/framework/session_state.h"
 #include "core/framework/tensorprotoutils.h"
 #include "core/framework/utils.h"
+#include "core/framework/session_options.h"
 
 using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::common;
@@ -49,18 +50,18 @@ ONNX_OPERATOR_SET_SCHEMA(
 ONNX_CPU_OPERATOR_VERSIONED_KERNEL(If,
                                    1, 10,
                                    KernelDefBuilder()
-                                     .TypeConstraint("B", DataTypeImpl::GetTensorType<bool>())
-                                     .TypeConstraint("V", DataTypeImpl::AllTensorTypes()),
+                                       .TypeConstraint("B", DataTypeImpl::GetTensorType<bool>())
+                                       .TypeConstraint("V", DataTypeImpl::AllTensorTypes()),
                                    If);
 
 // output shape rules requiring the output shapes of the 'THEN' and 'ELSE'
 // branches to be the same were relaxed in opset-11
 ONNX_CPU_OPERATOR_KERNEL(If,
-                        11,
-                        KernelDefBuilder()
-                            .TypeConstraint("B", DataTypeImpl::GetTensorType<bool>())
-                            .TypeConstraint("V", DataTypeImpl::AllTensorTypes()),
-                        If);
+                         11,
+                         KernelDefBuilder()
+                             .TypeConstraint("B", DataTypeImpl::GetTensorType<bool>())
+                             .TypeConstraint("V", DataTypeImpl::AllTensorTypes()),
+                         If);
 
 struct If::Info {
   Info(const onnxruntime::Node& node, const GraphViewer& subgraph_in) : subgraph(subgraph_in) {
@@ -315,7 +316,7 @@ Status IfImpl::Execute(const FeedsFetchesManager& ffm) {
   }
 
   status = utils::ExecuteSubgraph(session_state_, ffm, feeds, fetches, fetch_allocators,
-                                  /*sequential_execution*/ true, context_.GetTerminateFlag(),
+                                  ExecutionMode::kSequential, context_.GetTerminateFlag(),
                                   context_.Logger());
 
   ORT_RETURN_IF_ERROR(status);

--- a/onnxruntime/core/providers/cpu/controlflow/loop.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/loop.cc
@@ -19,6 +19,7 @@
 #include "core/framework/tensorprotoutils.h"
 #include "core/framework/utils.h"
 #include "core/providers/cpu/tensor/utils.h"
+#include "core/framework/session_options.h"
 
 #include "gsl/gsl"
 
@@ -79,20 +80,20 @@ ONNX_OPERATOR_SET_SCHEMA(
 */
 
 ONNX_CPU_OPERATOR_VERSIONED_KERNEL(Loop,
-                         1, 10,
-                         KernelDefBuilder()
-                             .TypeConstraint("I", DataTypeImpl::GetTensorType<int64_t>())
-                             .TypeConstraint("B", DataTypeImpl::GetTensorType<bool>())
-                             .TypeConstraint("V", DataTypeImpl::AllTensorTypes()),
-                         Loop);
-
-ONNX_CPU_OPERATOR_KERNEL(Loop,
-                                   11,
+                                   1, 10,
                                    KernelDefBuilder()
                                        .TypeConstraint("I", DataTypeImpl::GetTensorType<int64_t>())
                                        .TypeConstraint("B", DataTypeImpl::GetTensorType<bool>())
                                        .TypeConstraint("V", DataTypeImpl::AllTensorTypes()),
                                    Loop);
+
+ONNX_CPU_OPERATOR_KERNEL(Loop,
+                         11,
+                         KernelDefBuilder()
+                             .TypeConstraint("I", DataTypeImpl::GetTensorType<int64_t>())
+                             .TypeConstraint("B", DataTypeImpl::GetTensorType<bool>())
+                             .TypeConstraint("V", DataTypeImpl::AllTensorTypes()),
+                         Loop);
 
 struct Loop::Info {
   Info(const onnxruntime::Node& node, const GraphViewer& subgraph_in)
@@ -287,8 +288,8 @@ template <typename T>
 static OrtValue MakeScalarMLValue(AllocatorPtr& allocator, T value, bool is_1d) {
   auto* data_type = DataTypeImpl::GetType<T>();
   std::unique_ptr<Tensor> p_tensor = onnxruntime::make_unique<Tensor>(data_type,
-                                                              is_1d ? TensorShape({1}) : TensorShape({}),
-                                                              allocator);
+                                                                      is_1d ? TensorShape({1}) : TensorShape({}),
+                                                                      allocator);
 
   *p_tensor->MutableData<T>() = value;
 
@@ -422,7 +423,7 @@ Status LoopImpl::Execute(const FeedsFetchesManager& ffm) {
     }
 
     status = utils::ExecuteSubgraph(session_state_, ffm, feeds, fetches, {},
-                                    /*sequential_execution*/ true, context_.GetTerminateFlag(), context_.Logger());
+                                    ExecutionMode::kSequential, context_.GetTerminateFlag(), context_.Logger());
 
     ORT_RETURN_IF_ERROR(status);
 

--- a/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
@@ -19,6 +19,7 @@
 #include "core/framework/tensorprotoutils.h"
 #include "core/framework/utils.h"
 #include "core/providers/cpu/controlflow/utils.h"
+#include "core/framework/session_options.h"
 
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -245,7 +246,7 @@ Status IterateSequence(OpKernelContextInternal& context, const SessionState& ses
 
     // Create Executor and run graph.
     status = utils::ExecuteSubgraph(session_state, ffm, feeds, fetches, fetch_allocators,
-                                    /*sequential_execution*/ true, context.GetTerminateFlag(), context.Logger());
+                                    ExecutionMode::kSequential, context.GetTerminateFlag(), context.Logger());
 
     ORT_RETURN_IF_ERROR(status);
 
@@ -268,8 +269,8 @@ Status IterateSequence(OpKernelContextInternal& context, const SessionState& ses
 
 OrtValue AllocateTensorInMLValue(const MLDataType data_type, const TensorShape& shape, AllocatorPtr& allocator) {
   auto new_tensor = onnxruntime::make_unique<Tensor>(data_type,
-                                             shape,
-                                             allocator);
+                                                     shape,
+                                                     allocator);
 
   return OrtValue{new_tensor.release(), DataTypeImpl::GetType<Tensor>(),
                   DataTypeImpl::GetType<Tensor>()->GetDeleteFunc()};

--- a/onnxruntime/core/session/abi_session_options.cc
+++ b/onnxruntime/core/session/abi_session_options.cc
@@ -37,12 +37,12 @@ ORT_API_STATUS_IMPL(OrtApis::CloneSessionOptions, const OrtSessionOptions* input
 }
 
 ORT_API_STATUS_IMPL(OrtApis::EnableSequentialExecution, _In_ OrtSessionOptions* options) {
-  options->value.enable_sequential_execution = true;
+  options->value.execution_mode = onnxruntime::ExecutionMode::kSequential;
   return nullptr;
 }
 
-ORT_API_STATUS_IMPL(OrtApis::DisableSequentialExecution, _In_ OrtSessionOptions* options) {
-  options->value.enable_sequential_execution = false;
+ORT_API_STATUS_IMPL(OrtApis::EnableParallelExecution, _In_ OrtSessionOptions* options) {
+  options->value.execution_mode = onnxruntime::ExecutionMode::kParallel;
   return nullptr;
 }
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -99,12 +99,12 @@ InferenceSession::InferenceSession(const SessionOptions& session_options,
       logging_manager_(logging_manager),
       thread_pool_(concurrency::CreateThreadPool("intra_op_thread_pool",
                                                  session_options.intra_op_num_threads)),
-      inter_op_thread_pool_(!session_options.enable_sequential_execution
+      inter_op_thread_pool_(session_options.execution_mode == ExecutionMode::kParallel
                                 ? concurrency::CreateThreadPool("inter_op_thread_pool",
                                                                 session_options.inter_op_num_threads)
                                 : nullptr),
       session_state_(execution_providers_,
-                     session_options.enable_mem_pattern && session_options.enable_sequential_execution,
+                     session_options.enable_mem_pattern && session_options.execution_mode == ExecutionMode::kSequential,
                      thread_pool_.get(),
                      inter_op_thread_pool_.get()),
       insert_cast_transformer_("CastFloat16Transformer") {
@@ -449,7 +449,7 @@ common::Status InferenceSession::InitializeSubgraphSessions(Graph& graph, Sessio
 
       const auto implicit_inputs = node.ImplicitInputDefs();
       ORT_RETURN_IF_ERROR(initializer.CreatePlan(&node, &implicit_inputs,
-                                                 session_options_.enable_sequential_execution));
+                                                 session_options_.execution_mode));
 
       // LOGS(*session_logger_, VERBOSE) << std::make_pair(subgraph_info.session_state->GetExecutionPlan(),
       //                                                   &*subgraph_info.session_state);
@@ -493,7 +493,7 @@ common::Status InferenceSession::Initialize() {
       ORT_RETURN_IF_ERROR(RegisterExecutionProvider(std::move(p_cpu_exec_provider)));
     }
 
-    if (!session_options_.enable_sequential_execution &&
+    if (session_options_.execution_mode == ExecutionMode::kParallel &&
         execution_providers_.Get(onnxruntime::kCudaExecutionProvider)) {
       LOGS(*session_logger_, ERROR) << "Parallel execution is currently not supported "
                                        "for the registered CUDA Execution Provider.";
@@ -542,7 +542,7 @@ common::Status InferenceSession::Initialize() {
       }
     }
 
-    ORT_RETURN_IF_ERROR(session_initializer.CreatePlan(nullptr, nullptr, session_options_.enable_sequential_execution));
+    ORT_RETURN_IF_ERROR(session_initializer.CreatePlan(nullptr, nullptr, session_options_.execution_mode));
 
     // handle any subgraphs
     ORT_RETURN_IF_ERROR(InitializeSubgraphSessions(graph, session_state_));
@@ -743,7 +743,7 @@ Status InferenceSession::Run(const RunOptions& run_options, const std::vector<st
     // execute the graph
     ORT_CHECK_AND_SET_RETVAL(
         utils::ExecuteGraph(session_state_, feeds_fetches_manager, feeds, *p_fetches,
-                            session_options_.enable_sequential_execution,
+                            session_options_.execution_mode,
                             run_options.terminate, run_logger));
 
   } catch (const std::exception& e) {

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -19,6 +19,8 @@
 #include "core/optimizer/graph_transformer_level.h"
 #include "core/optimizer/graph_transformer_mgr.h"
 #include "core/optimizer/insert_cast_transformer.h"
+#include "core/framework/session_options.h"
+
 #ifdef ENABLE_LANGUAGE_INTEROP_OPS
 #include "core/language_interop_ops/language_interop_ops.h"
 #endif
@@ -45,64 +47,6 @@ class Notification;
 namespace logging {
 class LoggingManager;
 }
-
-struct FreeDimensionOverride {
-  std::string dimension_denotation;
-  int64_t dimension_override;
-};
-
-/**
-  * Configuration information for a session.
-  */
-struct SessionOptions {
-  //int num_threads; // not used now until we re-introduce threadpools for async execution
-  bool enable_sequential_execution = true;  // TODO: should we default to sequential execution?
-
-  // enable profiling for this session.
-  bool enable_profiling = false;
-
-  // non empty filepath enables serialization of the transformed optimized model to the specified filepath.
-  std::basic_string<ORTCHAR_T> optimized_model_filepath;
-
-  // enable the memory pattern optimization.
-  // The idea is if the input shapes are the same, we could trace the internal memory allocation
-  // and generate a memory pattern for future request. So next time we could just do one allocation
-  // with a big chunk for all the internal memory allocation.
-  // See class 'OrtValuePatternPlanner'.
-  bool enable_mem_pattern = true;
-
-  // enable the memory arena on CPU
-  // Arena may pre-allocate memory for future usage.
-  // set this option to false if you don't want it.
-  bool enable_cpu_mem_arena = true;
-
-  // the prefix of the profile file. The current time will be appended to the file name.
-  std::basic_string<ORTCHAR_T> profile_file_prefix = ORT_TSTR("onnxruntime_profile_");
-
-  std::string session_logid;  ///< logger id to use for session output
-
-  /// Log severity for the inference session. Applies to session load, initialization, etc.
-  /// See https://github.com/microsoft/onnxruntime/blob/master/include/onnxruntime/core/common/logging/severity.h
-  /// Default = -1 (use default logger severity)
-  int session_log_severity_level = -1;
-  int session_log_verbosity_level = 0;  ///< VLOG level if debug build and session_log_severity_level is 0 (VERBOSE).
-
-  unsigned max_num_graph_transformation_steps = 5;  // TODO choose a good default here?
-
-  // set graph optimization level
-  TransformerLevel graph_optimization_level = TransformerLevel::Level1;
-
-  // controls the size of the thread pool used to parallelize the execution of tasks within individual nodes (ops)
-  int intra_op_num_threads = 0;
-
-  // controls the size of the thread pool used to parallelize the execution of nodes (ops)
-  // configuring this makes sense only when you're using parallel executor
-  int inter_op_num_threads = 0;
-
-  // For models with free input dimensions (most commonly batch size), specifies a set of values to override those
-  // free dimensions with, keyed by dimension denotation.
-  std::vector<FreeDimensionOverride> free_dimension_overrides;
-};
 
 /**
   * Pre-defined and custom metadata about the model.

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1233,7 +1233,7 @@ static constexpr OrtApi ort_api_1 = {
     &OrtApis::SetOptimizedModelFilePath,
     &OrtApis::CloneSessionOptions,
     &OrtApis::EnableSequentialExecution,
-    &OrtApis::DisableSequentialExecution,
+    &OrtApis::EnableParallelExecution,
     &OrtApis::EnableProfiling,
     &OrtApis::DisableProfiling,
     &OrtApis::EnableMemPattern,

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -36,7 +36,7 @@ ORT_API_STATUS_IMPL(Run, _Inout_ OrtSession* sess,
 ORT_API_STATUS_IMPL(CreateSessionOptions, OrtSessionOptions** out);
 ORT_API_STATUS_IMPL(CloneSessionOptions, const OrtSessionOptions* input, OrtSessionOptions** out);
 ORT_API_STATUS_IMPL(EnableSequentialExecution, _In_ OrtSessionOptions* options);
-ORT_API_STATUS_IMPL(DisableSequentialExecution, _In_ OrtSessionOptions* options);
+ORT_API_STATUS_IMPL(EnableParallelExecution, _In_ OrtSessionOptions* options);
 ORT_API_STATUS_IMPL(SetOptimizedModelFilePath, _In_ OrtSessionOptions* options, _In_ const ORTCHAR_T* optimized_model_filepath);
 ORT_API_STATUS_IMPL(EnableProfiling, _In_ OrtSessionOptions* options, _In_ const ORTCHAR_T* profile_file_prefix);
 ORT_API_STATUS_IMPL(DisableProfiling, _In_ OrtSessionOptions* options);

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -12,6 +12,7 @@
 #include "core/graph/graph_viewer.h"
 #include "core/common/logging/logging.h"
 #include "core/common/logging/severity.h"
+#include "core/framework/session_options.h"
 
 #if USE_CUDA
 #define BACKEND_PROC "GPU"
@@ -522,7 +523,12 @@ void addObjectMethods(py::module& m) {
       .value("ORT_ENABLE_EXTENDED", GraphOptimizationLevel::ORT_ENABLE_EXTENDED)
       .value("ORT_ENABLE_ALL", GraphOptimizationLevel::ORT_ENABLE_ALL);
 
-  py::class_<SessionOptions> sess(m, "SessionOptions", R"pbdoc(Configuration information for a session.)pbdoc");
+  py::enum_<ExecutionMode>(m, "ExecutionMode")
+      .value("SEQUENTIAL", ExecutionMode::kSequential)
+      .value("PARALLEL", ExecutionMode::kParallel);
+
+  py::class_<SessionOptions>
+      sess(m, "SessionOptions", R"pbdoc(Configuration information for a session.)pbdoc");
   sess
       .def(py::init())
       .def_readwrite("enable_cpu_mem_arena", &SessionOptions::enable_cpu_mem_arena,
@@ -534,8 +540,6 @@ Set this option to false if you don't want it. Default is True.)pbdoc")
                      R"pbdoc(File path to serialize optimized model. By default, optimized model is not serialized if optimized_model_filepath is not provided.)pbdoc")
       .def_readwrite("enable_mem_pattern", &SessionOptions::enable_mem_pattern,
                      R"pbdoc(Enable the memory pattern optimization. Default is true.)pbdoc")
-      .def_readwrite("enable_sequential_execution", &SessionOptions::enable_sequential_execution,
-                     R"pbdoc(Enables sequential execution, disables parallel execution. Default is true.)pbdoc")
       .def_readwrite("logid", &SessionOptions::session_logid,
                      R"pbdoc(Logger id to use for session output.)pbdoc")
       .def_readwrite("log_severity_level", &SessionOptions::session_log_severity_level,
@@ -548,6 +552,8 @@ Applies to session load, initialization, etc. Default is 0.)pbdoc")
                      R"pbdoc(Sets the number of threads used to parallelize the execution within nodes. Default is 0 to let onnxruntime choose.)pbdoc")
       .def_readwrite("inter_op_num_threads", &SessionOptions::inter_op_num_threads,
                      R"pbdoc(Sets the number of threads used to parallelize the execution of the graph (across nodes). Default is 0 to let onnxruntime choose.)pbdoc")
+      .def_readwrite("execution_mode", &SessionOptions::execution_mode,
+                     R"pbdoc(Sets the execution mode. Default is sequential.)pbdoc")
       .def_property(
           "graph_optimization_level",
           [](const SessionOptions* options) -> GraphOptimizationLevel {

--- a/onnxruntime/test/framework/execution_frame_test.cc
+++ b/onnxruntime/test/framework/execution_frame_test.cc
@@ -69,7 +69,7 @@ TEST_F(ExecutionFrameTest, TensorAllocationTest) {
 
   std::unique_ptr<SequentialExecutionPlan> p_seq_exec_plan;
   // TODO below line is for testing only. In production use SequentialPlanner::CreatePlan()
-  SequentialPlannerContext context(false);
+  SequentialPlannerContext context(ExecutionMode::kSequential);
   status = SequentialPlanner::CreatePlan(nullptr, GraphViewer(graph), {}, execution_providers, kernel_registry_manager,
                                          state.GetOrtValueNameIdxMap(), context, p_seq_exec_plan);
   EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
@@ -221,7 +221,7 @@ TEST_F(ExecutionFrameTest, MemPatternTest) {
                        std::vector<float>(6, 1.0f), &v3);
 
   std::unique_ptr<SequentialExecutionPlan> p_seq_exec_plan = onnxruntime::make_unique<SequentialExecutionPlan>();
-  SequentialPlannerContext context(false);
+  SequentialPlannerContext context(ExecutionMode::kSequential);
   status = SequentialPlanner::CreatePlan(nullptr, GraphViewer(graph), {}, execution_providers, kernel_registry_manager,
                                          mlvalue_name_idx_map, context, p_seq_exec_plan);
   EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -1477,7 +1477,7 @@ TEST(InferenceSessionTests, TestParallelExecutionWithCudaProvider) {
   string model_uri = "testdata/transform/fusion/fuse-conv-bn-mul-add-unsqueeze.onnx";
 
   SessionOptions so;
-  so.enable_sequential_execution = false;
+  so.execution_mode = ExecutionMode::kParallel;
   so.session_logid = "InferenceSessionTests.TestParallelExecutionWithCudaProvider";
   InferenceSession session_object{so};
 

--- a/onnxruntime/test/framework/opaque_kernels_test.cc
+++ b/onnxruntime/test/framework/opaque_kernels_test.cc
@@ -276,7 +276,6 @@ ONNX_NAMESPACE::OpSchema GetFetchSparseShapeSchema() {
 
 TEST_F(OpaqueTypeTests, RunModel) {
   SessionOptions so;
-  so.enable_sequential_execution = true;
   so.session_logid = "SparseTensorTest";
   so.session_log_verbosity_level = 1;
 

--- a/onnxruntime/test/framework/parallel_executor_test.cc
+++ b/onnxruntime/test/framework/parallel_executor_test.cc
@@ -93,7 +93,8 @@ TEST(ParallelExecutor, TestStatusPropagation) {
     tester.AddInput<int64_t>("action", {1}, {/*success*/ 0});
     tester.AddOutput<int64_t>("action_out", {1}, {0});
     // TensorRT doesn't handle a custom op. Possibly it should, but that would be a separate PR
-    tester.Run(OpTester::ExpectResult::kExpectSuccess, {}, {kTensorrtExecutionProvider}, nullptr, nullptr, false);
+    tester.Run(OpTester::ExpectResult::kExpectSuccess, {}, {kTensorrtExecutionProvider}, nullptr, nullptr,
+               ExecutionMode::kParallel);
   }
 
   {  // test failure
@@ -102,7 +103,8 @@ TEST(ParallelExecutor, TestStatusPropagation) {
 
     tester.AddInput<int64_t>("action", {1}, {/*failure*/ 1});
     tester.AddOutput<int64_t>("action_out", {1}, {0});
-    tester.Run(OpTester::ExpectResult::kExpectFailure, "Action was 1", {kTensorrtExecutionProvider}, nullptr, nullptr, false);
+    tester.Run(OpTester::ExpectResult::kExpectFailure, "Action was 1", {kTensorrtExecutionProvider}, nullptr, nullptr,
+               ExecutionMode::kParallel);
   }
 
   {  // test exception
@@ -111,7 +113,7 @@ TEST(ParallelExecutor, TestStatusPropagation) {
 
     tester.AddInput<int64_t>("action", {1}, {/*exception*/ 2});
     tester.AddOutput<int64_t>("action_out", {1}, {0});
-    tester.Run(OpTester::ExpectResult::kExpectFailure, "Throwing as action was 2", {kTensorrtExecutionProvider}, nullptr, nullptr, false);
+    tester.Run(OpTester::ExpectResult::kExpectFailure, "Throwing as action was 2", {kTensorrtExecutionProvider}, nullptr, nullptr, ExecutionMode::kParallel);
   }
 }
 
@@ -133,7 +135,7 @@ TEST(ParallelExecutor, TestNullInterOpThreadPool) {
   onnxruntime::SessionOptions so;
   so.session_logid = "TestOp";
   so.session_log_verbosity_level = 1;
-  so.enable_sequential_execution = false;
+  so.execution_mode = ExecutionMode::kParallel;
   so.inter_op_num_threads = 1;
   tester.Run(so, OpTester::ExpectResult::kExpectSuccess, {}, {kTensorrtExecutionProvider}, nullptr, nullptr);
 }

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -119,7 +119,7 @@ TEST_P(SessionStateTestP, TestInitializerProcessing) {
   status = partitioner.Partition(graph, session_state.ExportDll(), session_state.GetMutableFuncMgr());
   ASSERT_TRUE(status.IsOK()) << status;
 
-  status = session_initializer.CreatePlan(nullptr, nullptr, true);
+  status = session_initializer.CreatePlan(nullptr, nullptr, ExecutionMode::kSequential);
   ASSERT_TRUE(status.IsOK()) << status;
 
   const auto& initialized_tensors = session_state.GetInitializedTensors();

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -20,6 +20,7 @@
 #include "core/framework/path_lib.h"
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/optimizer/graph_transformer_level.h"
+#include "core/framework/session_options.h"
 
 const OrtApi* g_ort = OrtGetApi(ORT_API_VERSION);
 const OrtApi* Ort::g_api = OrtGetApi(ORT_API_VERSION);
@@ -89,7 +90,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   std::vector<std::basic_string<PATH_CHAR_TYPE> > whitelisted_test_cases;
   int concurrent_session_runs = GetNumCpuCores();
   bool enable_cpu_mem_arena = true;
-  bool enable_sequential_execution = true;
+  ExecutionMode execution_mode = ExecutionMode::kSequential;
   int repeat_count = 1;
   int p_models = GetNumCpuCores();
   bool enable_cuda = false;
@@ -166,7 +167,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
           }
           break;
         case 'x':
-          enable_sequential_execution = false;
+          execution_mode = ExecutionMode::kParallel;
           break;
         case 'o': {
           int tmp = static_cast<int>(OrtStrtol<PATH_CHAR_TYPE>(optarg, nullptr));
@@ -246,10 +247,10 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
       sf.EnableMemPattern();
     else
       sf.DisableMemPattern();
-    if (enable_sequential_execution)
+    if (execution_mode == ExecutionMode::kSequential)
       sf.EnableSequentialExecution();
-    else
-      sf.DisableSequentialExecution();
+    else if (execution_mode == ExecutionMode::kParallel)
+      sf.EnableParallelExecution();
 
     if (enable_tensorrt) {
 #ifdef USE_TENSORRT

--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -130,7 +130,7 @@ namespace perftest {
         }
         break;
       case 'P':
-        test_config.run_config.enable_sequential_execution = false;
+        test_config.run_config.execution_mode = ExecutionMode::kParallel;
         break;
       case 'c':
         test_config.run_config.concurrent_session_runs =

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -82,18 +82,18 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
   else
     session_options.DisableCpuMemArena();
   if (performance_test_config.run_config.enable_memory_pattern &&
-      performance_test_config.run_config.enable_sequential_execution)
+      performance_test_config.run_config.execution_mode == ExecutionMode::kSequential)
     session_options.EnableMemPattern();
   else
     session_options.DisableMemPattern();
-  if (performance_test_config.run_config.enable_sequential_execution)
+  if (performance_test_config.run_config.execution_mode == ExecutionMode::kSequential)
     session_options.EnableSequentialExecution();
   else
-    session_options.DisableSequentialExecution();
+    session_options.EnableParallelExecution();
   fprintf(stdout, "Setting intra_op_num_threads to %d\n", performance_test_config.run_config.intra_op_num_threads);
   session_options.SetIntraOpNumThreads(performance_test_config.run_config.intra_op_num_threads);
 
-  if (!performance_test_config.run_config.enable_sequential_execution) {
+  if (performance_test_config.run_config.execution_mode == ExecutionMode::kParallel) {
     fprintf(stdout, "Setting inter_op_num_threads to %d\n", performance_test_config.run_config.inter_op_num_threads);
   }
 

--- a/onnxruntime/test/perftest/test_configuration.h
+++ b/onnxruntime/test/perftest/test_configuration.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "core/graph/constants.h"
+#include "core/framework/session_options.h"
 
 namespace onnxruntime {
 namespace perftest {
@@ -43,7 +44,7 @@ struct RunConfig {
   bool f_verbose{false};
   bool enable_memory_pattern{true};
   bool enable_cpu_mem_arena{true};
-  bool enable_sequential_execution{true};
+  ExecutionMode execution_mode{ExecutionMode::kSequential};
   int intra_op_num_threads{0};
   int inter_op_num_threads{0};
   GraphOptimizationLevel optimization_level{ORT_ENABLE_EXTENDED};

--- a/onnxruntime/test/providers/memcpy_test.cc
+++ b/onnxruntime/test/providers/memcpy_test.cc
@@ -45,7 +45,7 @@ TEST(MemcpyTest, copy1) {
   PutAllNodesOnOneProvider(model.MainGraph(), onnxruntime::kCpuExecutionProvider);
   SessionStateInitializer session_initializer{true, ORT_TSTR(""), model.MainGraph(),
                                               s, execution_providers, kernel_registry_manager};
-  st = session_initializer.CreatePlan(nullptr, {}, true);
+  st = session_initializer.CreatePlan(nullptr, {}, ExecutionMode::kSequential);
   ASSERT_TRUE(st.IsOK()) << st.ErrorMessage();
 
   AllocatorPtr allocator =

--- a/onnxruntime/test/providers/provider_test_utils.cc
+++ b/onnxruntime/test/providers/provider_test_utils.cc
@@ -480,11 +480,11 @@ void OpTester::Run(ExpectResult expect_result,
                    const std::unordered_set<std::string>& excluded_provider_types,
                    const RunOptions* run_options,
                    std::vector<std::unique_ptr<IExecutionProvider>>* execution_providers,
-                   bool sequential_execution) {
+                   ExecutionMode execution_mode) {
   SessionOptions so;
   so.session_logid = op_;
   so.session_log_verbosity_level = 1;
-  so.enable_sequential_execution = sequential_execution;
+  so.execution_mode = execution_mode;
   Run(so, expect_result, expected_failure_string, excluded_provider_types, run_options, execution_providers);
 }
 

--- a/onnxruntime/test/providers/provider_test_utils.h
+++ b/onnxruntime/test/providers/provider_test_utils.h
@@ -17,6 +17,7 @@
 #include "test/test_environment.h"
 #include "test/framework/TestAllocatorManager.h"
 #include "core/framework/TensorSeq.h"
+#include "core/framework/session_options.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -416,7 +417,7 @@ class OpTester {
            const std::unordered_set<std::string>& excluded_provider_types = {},
            const RunOptions* run_options = nullptr,
            std::vector<std::unique_ptr<IExecutionProvider>>* execution_providers = nullptr,
-           bool sequential_execution = true);
+           ExecutionMode execution_mode = ExecutionMode::kSequential);
 
   void Run(const SessionOptions& session_options,
            ExpectResult expect_result = ExpectResult::kExpectSuccess,

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -547,6 +547,16 @@ class TestInferenceSession(unittest.TestCase):
 
         res = sess.run([], {'input1:0': a, 'input:0':b})
 
+    def testExecutionMode(self):
+        opt = onnxrt.SessionOptions()
+        self.assertEqual(opt.execution_mode, onnxrt.ExecutionMode.SEQUENTIAL)
+        opt.execution_mode = onnxrt.ExecutionMode.PARALLEL
+        self.assertEqual(opt.execution_mode, onnxrt.ExecutionMode.PARALLEL)
+        sess = onnxrt.InferenceSession(self.get_name("logicaland.onnx"), sess_options=opt)
+        a = np.array([[True, True], [False, False]], dtype=np.bool)
+        b = np.array([[True, False], [True, False]], dtype=np.bool)
+
+        res = sess.run([], {'input1:0': a, 'input:0':b})
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description**: 
* Introduce execution mode for clarity and extensibility
* Change Python APIs accordingly
* Replace DisableSequentialExecution API with EnableParallelExecution for clarity

**Motivation and Context**
* The current way of enabling parallel execution is by disabling sequential execution which has been reported by various partners as nonintuitive and confusing.
* In a related PR there was a discussion around adding additional execution modes like pipelined executor.
