### PR TITLE
Fix int64 incorrect narrow_cast by clamping values to INT32 range

### DIFF
--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorHelper.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorHelper.h
@@ -276,7 +276,8 @@ class MLOperatorAttributes
         {
             auto vector64Bit = GetAttributeVector<int64_t>(attributeName);
             vector32Bit.resize(vector64Bit.size());
-            std::transform(vector64Bit.begin(), vector64Bit.end(), /*out*/vector32Bit.begin(), [](auto i) {return gsl::narrow_cast<int32_t>(i); });
+            std::transform(vector64Bit.begin(), vector64Bit.end(), /*out*/vector32Bit.begin(), [](auto i) 
+                                    {return gsl::narrow_cast<int32_t>(std::clamp<int64_t>(i, INT32_MIN, INT32_MAX)); });
         }
         return vector32Bit;
     }


### PR DESCRIPTION
This is a Fix for int64_t range error in GetOptionalAttributeVectorInt32.

DML EP narrow_casts 64bit integers to 32bit ones using gsl::narrow_cast. However when the value exceeds the INT32 range, we get incorrect behavior, leading to model evaluation errors. For e.g.
gsl::narrow_cast<int32_t>(9223372036854775807) returns -1, which is incorrect.

Treating int64_t values as int32_t is inherently incorrect.

However in this particular case since the number of dimensions of tensor are not expected to be greater than INT_MAX for the forseable future, we remedy the situation by clamping the int64_t value to the int32_t range before narrow casting it.