### PR TITLE
Nuphar: Fix a bug in weight layout where read may go out of bound

### DIFF
--- a/onnxruntime/core/codegen/passes/weight_layout/weight_layout.cc
+++ b/onnxruntime/core/codegen/passes/weight_layout/weight_layout.cc
@@ -78,7 +78,7 @@ void WeightLayout::CreateLayoutMarshallingTVMOp(tvm::Array<tvm::Tensor>& inputs,
           for (size_t dim = 1; dim < input_coord.size(); ++dim)
             in_range = in_range && (input_coord[dim] >= 0) && (input_coord[dim] < placeholder->shape[dim]);
 
-          return tvm::ir::Select::make(in_range, placeholder(input_coord), pad_zero_expr);
+          return tvm::if_then_else(in_range, placeholder(input_coord), pad_zero_expr);
         } else {
           // scalar
           return placeholder(input_coord);


### PR DESCRIPTION
**Description**: This fixes potential crash when applying weight layout with padding

**Motivation and Context**
- The problem is that select executes both true and false code regardless of condition, leading to out-of-bound read when input needs padding.
