### PR TITLE
Fix ORTSRV docker build

### DIFF
--- a/dockerfiles/Dockerfile.ngraph
+++ b/dockerfiles/Dockerfile.ngraph
@@ -17,7 +17,7 @@ RUN apt-get update && \
 ENV PATH="/opt/cmake/bin:${PATH}"
 RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime
 RUN /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh -p ${PYTHON_VERSION} && \
-    /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+    /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_deps.sh -p ${PYTHON_VERSION}
 
 WORKDIR /
 RUN mkdir -p /onnxruntime/build && \

--- a/dockerfiles/Dockerfile.nuphar
+++ b/dockerfiles/Dockerfile.nuphar
@@ -17,7 +17,7 @@ RUN apt-get update && \
 ENV PATH="/opt/cmake/bin:${PATH}"
 RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime
 RUN /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh -p ${PYTHON_VERSION} && \
-    /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+    /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_deps.sh -p ${PYTHON_VERSION}
 
 WORKDIR /
 

--- a/dockerfiles/Dockerfile.server
+++ b/dockerfiles/Dockerfile.server
@@ -21,7 +21,7 @@ RUN apt-get update && \
 ENV PATH="/opt/cmake/bin:${PATH}"
 RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime
 RUN /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh -p ${PYTHON_VERSION} && \
-    /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_deps.sh && \
+    /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_deps.sh -p ${PYTHON_VERSION} && \
     /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
 
 ENV PATH="/usr/local/go/bin:${PATH}"


### PR DESCRIPTION
**Description**: The current docker build for ONNX Runtime Server is broken due to a change recently in `install_deps.sh`. The script requires an additional parameter to indicate the python version. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
Without this change the Docker build will fail in master branch.

- If it fixes an open issue, please link to the issue here.
N/A