### PR TITLE
Add empty tensor support for the DML EP

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphPartitioner.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphPartitioner.cpp
@@ -295,8 +295,10 @@ namespace Dml
 
                     std::optional<uint32_t> requiredInputCount = graphNodeFactorMapIter->second->requiredInputCount;
                     if (requiredCpuInputsConstant &&
-                        TryGetStaticInputShapes( node, graphNodeProperty.first->second.inputShapes) && 
+                        TryGetStaticInputShapes( node, graphNodeProperty.first->second.inputShapes) &&
+                        !ContainsEmptyDimensions(graphNodeProperty.first->second.inputShapes) &&
                         TryGetStaticOutputShapes(node, graphNodeProperty.first->second.outputShapes) &&
+                        !ContainsEmptyDimensions(graphNodeProperty.first->second.outputShapes) &&
                         (requiredInputCount == std::nullopt || *requiredInputCount == node.InputDefs().size()))
                     {
                         *isDmlGraphNode = true;

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h
@@ -621,6 +621,7 @@ onnx::AttributeProto_AttributeType ToProto(MLOperatorAttributeType type);
 
 bool TryGetStaticInputShapes(const onnxruntime::Node& node, EdgeShapes& inputShapes);
 bool TryGetStaticOutputShapes(const onnxruntime::Node& node, EdgeShapes& outputShapes);
+bool ContainsEmptyDimensions(const EdgeShapes& shapes);
 
 std::tuple<std::unique_ptr<std::byte[]>, size_t> UnpackTensor(const onnx::TensorProto& initializer);
 }    // namespace winrt::Windows::AI::MachineLearning::implementation

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
@@ -19,6 +19,24 @@ namespace Dml
         // Initialize should only be called once.
         assert(m_compiledOperator == nullptr);
 
+        // DML doesn't support empty tensors. If an operator is still executable with empty tensors, the empty tensors
+        // should be removed or massaged depending on the definition.
+        for (const TensorDesc& desc : m_inputTensorDescs)
+        {
+            if (OperatorHelper::ContainsEmptyDimensions(desc.GetSizes()))
+            {
+                return;
+            }
+        }
+
+        for (const TensorDesc& desc : m_outputTensorDescs)
+        {
+            if (OperatorHelper::ContainsEmptyDimensions(desc.GetSizes()))
+            {
+                return;
+            }
+        }
+
         // Create and compile the operator.
         ComPtr<IDMLOperator> dmlOperator;
         THROW_IF_FAILED(m_dmlDevice->CreateOperator(&operatorDesc, IID_PPV_ARGS(&dmlOperator)));
@@ -278,7 +296,7 @@ namespace Dml
 
     std::vector<IMLOperatorTensor*> DmlOperator::GetInputTensorsForExecute(const MLOperatorKernelContext& kernelContext)
     {
-        return  GetInputTensors(kernelContext);
+        return GetInputTensors(kernelContext);
     }
 
     std::vector<IMLOperatorTensor*> DmlOperator::GetOutputTensorsForExecute(const MLOperatorKernelContext& kernelContext)

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorMemcpy.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorMemcpy.cpp
@@ -27,10 +27,13 @@ public:
         assert(inputTensors.size() == 1);
         assert(outputTensors.size() == 1);
 
-        THROW_IF_FAILED(m_executionProvider->CopyTensor(
-            outputTensors.front(),
-            inputTensors.front()
-            ));
+        if (!OperatorHelper::ContainsEmptyDimensions(MLOperatorTensor(inputTensors.front()).GetShape()))
+        {
+            THROW_IF_FAILED(m_executionProvider->CopyTensor(
+                outputTensors.front(),
+                inputTensors.front()
+                ));
+        }
     }
 
 private:

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
@@ -9,6 +9,8 @@
 
 namespace OperatorHelper
 {
+bool ContainsEmptyDimensions(gsl::span<const DimensionType> dimensions);
+
 std::vector<DimensionType> BroadcastTensorShape(
     gsl::span<const DimensionType> inputShape0,
     gsl::span<const DimensionType> inputShape1


### PR DESCRIPTION
**Description**: This adds empty tensor support for the DML EP.

**Motivation and Context**
Previously, the EP would just crash if any empty tensor (i.e. one of the dimensions is 0) was produced while evaluating the model. This change is required to support models that have operators like NonZero, which can produce empty tensors. Some models like the RCNN models require this change to work properly with the DML EP.