### PR TITLE
Adjust the nGraph EP to the newest CI test data

### DIFF
--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -411,7 +411,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
       {"convtranspose_1d", "1d convtranspose not supported yet"},
       {"convtranspose_3d", "3d convtranspose not supported yet"},
       {"cast_STRING_to_FLOAT", "Linux CI has old ONNX python package with bad test data", {"onnx141"}},
-      // Numpy float to string has unexpected rounding for some results given numpy default precision is meant to be 8. 
+      // Numpy float to string has unexpected rounding for some results given numpy default precision is meant to be 8.
       // "e.g. 0.296140194 -> '0.2961402' not '0.29614019'. ORT produces the latter with precision set to 8,
       // which doesn't match the expected output that was generated with numpy.
       {"cast_FLOAT_to_STRING", "Numpy float to string has unexpected rounding for some results."},
@@ -483,6 +483,10 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   broken_tests.insert({"gemm_default_no_bias", "not implemented yet for opset 11"});
   broken_tests.insert({"quantizelinear", "ambiguity in scalar dimensions [] vs [1]", {"onnx150"}});
   broken_tests.insert({"dequantizelinear", "ambiguity in scalar dimensions [] vs [1]", {"onnx150"}});
+  broken_tests.insert({"mlperf_ssd_resnet34_1200", "Results mismatch"});
+  broken_tests.insert({"BERT_Squad", "Invalid Feed Input Name:input4"});
+  broken_tests.insert({"mask_rcnn_keras", "Results mismatch: 8 of 81000"});
+  broken_tests.insert({"candy", "Results mismatch: 2 of 150528"});
 #endif
 
 #ifdef USE_MKLDNN

--- a/tools/ci_build/github/azure-pipelines/linux-ngraph-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ngraph-ci-pipeline.yml
@@ -1,5 +1,6 @@
 jobs:
 - job: Linux_nGraph_CI_Dev
+  timeoutInMinutes: 90
   pool: Linux-CPU
   steps:
     - template: templates/set-test-data-variables-step.yml

--- a/tools/ci_build/github/azure-pipelines/linux-ngraph-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ngraph-ci-pipeline.yml
@@ -26,8 +26,7 @@ jobs:
       displayName: 'Download test data'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-        # nGraph provider fails on the latest 20190729.zip test. revert back to previous zip file until failures can be investigated
-        arguments: --test_data_url https://onnxruntimetestdata.blob.core.windows.net/models/20190419.zip --build_dir $(Build.BinariesDirectory)
+        arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
         pythonInterpreter: '/usr/bin/python3'
         workingDirectory: $(Build.BinariesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/win-ngraph-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ngraph-ci-pipeline.yml
@@ -3,9 +3,6 @@ jobs:
   timeoutInMinutes: 120
   variables:
     buildDirectory: '$(Build.BinariesDirectory)'
-    # nGraph provider fails on the latest 20190729.zip test. revert back to previous zip file until failures can be investigated
-    TestDataUrl: https://onnxruntimetestdata.blob.core.windows.net/models/20190419.zip
-    TestDataChecksum: 3f46c31ee02345dbe707210b339e31fe
   steps:
     - template: templates/set-test-data-variables-step.yml
     - template: templates/windows-build-tools-setup-steps.yml


### PR DESCRIPTION
4 models from the newest zip file fail with nGraph EP. We can discuss what to do about them during the next meeting.

I'm not sure if this PR should be included in the upcoming 1.0 release, it's just something that had to be done anyway.