### PR TITLE
Remove Keras Mask RCNN from CUDA excluded tests list

### DIFF
--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -525,7 +525,6 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
 #endif
 
 #ifdef USE_CUDA
-  broken_tests.insert({"mask_rcnn_keras", "result mismatch"});
   broken_tests.insert({"mlperf_ssd_mobilenet_300", "unknown error"});
   broken_tests.insert({"mlperf_ssd_resnet34_1200", "unknown error"});
   broken_tests.insert({"tf_inception_v1", "flaky test"}); //TODO: Investigate cause for flakiness


### PR DESCRIPTION
**Description**: Keras Mask RCNN was kept in the CUDA excluded tests list because it was failing those specific CI checks. However, the test seems to pass locally with ORT master (Windows 10 + CUDA 10.0). It is possible that some recent fixes for CUDA ops has solved the issue or the failure perhaps only occurs in the CI environment in which case we need to investigate further.  

**Motivation and Context**
Gaurd against regressions for the Keras Mask RCNN model
