### PR TITLE
Update ORTSRV integration test model path

### DIFF
--- a/onnxruntime/test/server/integration_tests/function_tests.py
+++ b/onnxruntime/test/server/integration_tests/function_tests.py
@@ -28,7 +28,7 @@ class HttpJsonPayloadTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        onnx_model = os.path.join(cls.model_path, 'mnist.onnx')
+        onnx_model = os.path.join(cls.model_path, 'model.onnx')
         test_util.prepare_mnist_model(onnx_model)
         cmd = [cls.server_app_path, '--http_port', str(cls.server_port), '--model_path', onnx_model, '--log_level', cls.log_level]
         test_util.test_log('Launching server app: [{0}]'.format(' '.join(cmd)))
@@ -250,7 +250,7 @@ class HttpProtobufPayloadTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        onnx_model = os.path.join(cls.model_path, 'mnist.onnx')
+        onnx_model = os.path.join(cls.model_path, 'model.onnx')
         test_util.prepare_mnist_model(onnx_model)
         cmd = [cls.server_app_path, '--http_port', str(cls.server_port), '--model_path', onnx_model, '--log_level', cls.log_level]
         test_util.test_log('Launching server app: [{0}]'.format(' '.join(cmd)))
@@ -380,7 +380,7 @@ class HttpEndpointTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        onnx_model = os.path.join(cls.model_path, 'mnist.onnx')
+        onnx_model = os.path.join(cls.model_path, 'model.onnx')
         test_util.prepare_mnist_model(onnx_model)
         cmd = [cls.server_app_path, '--http_port', str(cls.server_port), '--model_path', onnx_model, '--log_level', cls.log_level]
         test_util.test_log('Launching server app: [{0}]'.format(' '.join(cmd)))
@@ -416,7 +416,7 @@ class GRPCTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        onnx_model = os.path.join(cls.model_path, 'mnist.onnx')
+        onnx_model = os.path.join(cls.model_path, 'model.onnx')
         test_util.prepare_mnist_model(onnx_model)
         cmd = [cls.server_app_path, '--grpc_port', str(cls.server_port), '--model_path', onnx_model, '--log_level', cls.log_level]
         test_util.test_log('Launching server app: [{0}]'.format(' '.join(cmd)))

--- a/onnxruntime/test/server/integration_tests/test_util.py
+++ b/onnxruntime/test/server/integration_tests/test_util.py
@@ -40,10 +40,10 @@ def is_process_killed(pid):
             return True
 
 def prepare_mnist_model(target_path):
-    # TODO: This need to be replaced by test data on build machine after merged to upstream master. 
     if not os.path.isfile(target_path):
-        test_log('Downloading model from blob storage: https://ortsrvdev.blob.core.windows.net/test-data/mnist.onnx to {0}'.format(target_path))
-        urllib.request.urlretrieve('https://ortsrvdev.blob.core.windows.net/test-data/mnist.onnx', target_path)
+        # Backup path: in case the mnist model is missing, we need to download it from Internet.
+        test_log('Downloading model from blob storage: https://ortsrvdev.blob.core.windows.net/test-data/model.onnx to {0}'.format(target_path))
+        urllib.request.urlretrieve('https://ortsrvdev.blob.core.windows.net/test-data/model.onnx', target_path)
     else:
         test_log('Found mnist model at {0}'.format(target_path))
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -750,8 +750,9 @@ def run_server_tests(build_dir, configs):
             server_app_path = os.path.join(config_build_dir, 'onnxruntime_server')
             python_package_path = config_build_dir
         server_test_folder = os.path.join(config_build_dir, 'server_test')
-        server_test_data_folder = os.path.join(os.path.join(config_build_dir, 'testdata'), 'server')
-        run_subprocess([sys.executable, 'test_main.py', server_app_path, server_test_data_folder, server_test_data_folder, python_package_path, server_test_folder], cwd=server_test_folder, dll_path=None)
+        server_test_model_folder = os.path.join(config_build_dir, 'models', 'opset8', 'test_mnist')
+        server_test_data_folder = os.path.join(config_build_dir, 'testdata', 'server')
+        run_subprocess([sys.executable, 'test_main.py', server_app_path, server_test_model_folder, server_test_data_folder, python_package_path, server_test_folder], cwd=server_test_folder, dll_path=None)
 
 
 def run_server_model_tests(build_dir, configs):

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -750,7 +750,7 @@ def run_server_tests(build_dir, configs):
             server_app_path = os.path.join(config_build_dir, 'onnxruntime_server')
             python_package_path = config_build_dir
         server_test_folder = os.path.join(config_build_dir, 'server_test')
-        server_test_model_folder = os.path.join(config_build_dir, 'models', 'opset8', 'test_mnist')
+        server_test_model_folder = os.path.join(build_dir, 'models', 'opset8', 'test_mnist')
         server_test_data_folder = os.path.join(config_build_dir, 'testdata', 'server')
         run_subprocess([sys.executable, 'test_main.py', server_app_path, server_test_model_folder, server_test_data_folder, python_package_path, server_test_folder], cwd=server_test_folder, dll_path=None)
 


### PR DESCRIPTION
**Description**: Update the build script to use pre-downloaded test models other than download mnist model every times

**Motivation and Context**
- Why is this change required? What problem does it solve?
The blob storage for test model is going to be offline. Need to switch to pre-download test model. Otherwise the test will fail due to missing model file.

- If it fixes an open issue, please link to the issue here.
N/A
