### PR TITLE
Move CXX API global into the header

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -25,8 +25,6 @@
 
 namespace Ort {
 
-extern const OrtApi* g_api;
-
 using std::nullptr_t;
 
 // All C++ methods that can fail will throw an exception of this type
@@ -41,9 +39,19 @@ struct Exception : std::exception {
   OrtErrorCode code_;
 };
 
+template <typename T>
+struct Global {
+  static const OrtApi& api_;
+};
+
+template <typename T>
+const OrtApi& Global<T>::api_ = *OrtGetApiBase()->GetApi(ORT_API_VERSION);
+
+inline const OrtApi& GetApi() { return Global<void>::api_; }
+
 // This Macro is to make it easy to generate overloaded methods for all of the various OrtRelease* functions for every Ort* type
 #define ORT_DEFINE_RELEASE(NAME) \
-  inline void OrtRelease(Ort##NAME* ptr) { g_api->Release##NAME(ptr); }
+  inline void OrtRelease(Ort##NAME* ptr) { Global<void>::api_.Release##NAME(ptr); }
 
 ORT_DEFINE_RELEASE(MemoryInfo);
 ORT_DEFINE_RELEASE(CustomOpDomain);

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -94,6 +94,9 @@ struct Base {
   }
 
   T* p_{};
+
+  template <typename>
+  friend struct Unowned;  // This friend line is needed to keep the centos C++ compiler from giving an error
 };
 
 template <typename T>

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -25,8 +25,6 @@
 
 namespace Ort {
 
-using std::nullptr_t;
-
 // All C++ methods that can fail will throw an exception of this type
 struct Exception : std::exception {
   Exception(std::string&& string, OrtErrorCode code) : message_{std::move(string)}, code_{code} {}
@@ -39,6 +37,8 @@ struct Exception : std::exception {
   OrtErrorCode code_;
 };
 
+// This is used internally by the C++ API. This class holds the global variable that points to the OrtApi, it's in a template so that we can define a global variable in a header and make
+// it transparent to the users of the API.
 template <typename T>
 struct Global {
   static const OrtApi& api_;
@@ -47,9 +47,11 @@ struct Global {
 template <typename T>
 const OrtApi& Global<T>::api_ = *OrtGetApiBase()->GetApi(ORT_API_VERSION);
 
+// This returns a reference to the OrtApi interface in use, in case someone wants to use the C API functions
 inline const OrtApi& GetApi() { return Global<void>::api_; }
 
-// This Macro is to make it easy to generate overloaded methods for all of the various OrtRelease* functions for every Ort* type
+// This is used internally by the C++ API. This macro is to make it easy to generate overloaded methods for all of the various OrtRelease* functions for every Ort* type
+// This can't be done in the C API since C doesn't have function overloading.
 #define ORT_DEFINE_RELEASE(NAME) \
   inline void OrtRelease(Ort##NAME* ptr) { Global<void>::api_.Release##NAME(ptr); }
 
@@ -63,6 +65,7 @@ ORT_DEFINE_RELEASE(TensorTypeAndShapeInfo);
 ORT_DEFINE_RELEASE(TypeInfo);
 ORT_DEFINE_RELEASE(Value);
 
+// This is used internally by the C++ API. This is the common base class used by the wrapper objects.
 template <typename T>
 struct Base {
   Base() = default;
@@ -110,7 +113,7 @@ struct TypeInfo;
 struct Value;
 
 struct Env : Base<OrtEnv> {
-  Env(nullptr_t) {}
+  Env(std::nullptr_t) {}
   Env(OrtLoggingLevel default_logging_level, _In_ const char* logid);
   Env(OrtLoggingLevel default_logging_level, const char* logid, OrtLoggingFunction logging_function, void* logger_param);
   explicit Env(OrtEnv* p) : Base<OrtEnv>{p} {}
@@ -122,14 +125,14 @@ struct Env : Base<OrtEnv> {
 };
 
 struct CustomOpDomain : Base<OrtCustomOpDomain> {
-  explicit CustomOpDomain(nullptr_t) {}
+  explicit CustomOpDomain(std::nullptr_t) {}
   explicit CustomOpDomain(const char* domain);
 
   void Add(OrtCustomOp* op);
 };
 
 struct RunOptions : Base<OrtRunOptions> {
-  RunOptions(nullptr_t) {}
+  RunOptions(std::nullptr_t) {}
   RunOptions();
 
   RunOptions& SetRunLogVerbosityLevel(int);
@@ -148,7 +151,7 @@ struct RunOptions : Base<OrtRunOptions> {
 };
 
 struct SessionOptions : Base<OrtSessionOptions> {
-  explicit SessionOptions(nullptr_t) {}
+  explicit SessionOptions(std::nullptr_t) {}
   SessionOptions();
   explicit SessionOptions(OrtSessionOptions* p) : Base<OrtSessionOptions>{p} {}
 
@@ -177,7 +180,7 @@ struct SessionOptions : Base<OrtSessionOptions> {
 };
 
 struct Session : Base<OrtSession> {
-  explicit Session(nullptr_t) {}
+  explicit Session(std::nullptr_t) {}
   Session(Env& env, const ORTCHAR_T* model_path, const SessionOptions& options);
   Session(Env& env, const void* model_data, size_t model_data_length, const SessionOptions& options);
 
@@ -202,7 +205,7 @@ struct Session : Base<OrtSession> {
 };
 
 struct TensorTypeAndShapeInfo : Base<OrtTensorTypeAndShapeInfo> {
-  explicit TensorTypeAndShapeInfo(nullptr_t) {}
+  explicit TensorTypeAndShapeInfo(std::nullptr_t) {}
   explicit TensorTypeAndShapeInfo(OrtTensorTypeAndShapeInfo* p) : Base<OrtTensorTypeAndShapeInfo>{p} {}
 
   ONNXTensorElementDataType GetElementType() const;
@@ -216,7 +219,7 @@ struct TensorTypeAndShapeInfo : Base<OrtTensorTypeAndShapeInfo> {
 };
 
 struct TypeInfo : Base<OrtTypeInfo> {
-  explicit TypeInfo(nullptr_t) {}
+  explicit TypeInfo(std::nullptr_t) {}
   explicit TypeInfo(OrtTypeInfo* p) : Base<OrtTypeInfo>{p} {}
 
   Unowned<TensorTypeAndShapeInfo> GetTensorTypeAndShapeInfo() const;
@@ -241,7 +244,7 @@ struct Value : Base<OrtValue> {
   template <typename T>
   void GetOpaqueData(const char* domain, const char* type_name, T&);
 
-  explicit Value(nullptr_t) {}
+  explicit Value(std::nullptr_t) {}
   explicit Value(OrtValue* p) : Base<OrtValue>{p} {}
   Value(Value&&) = default;
   Value& operator=(Value&&) = default;
@@ -278,7 +281,7 @@ struct AllocatorWithDefaultOptions {
 struct MemoryInfo : Base<OrtMemoryInfo> {
   static MemoryInfo CreateCpu(OrtAllocatorType type, OrtMemType mem_type1);
 
-  explicit MemoryInfo(nullptr_t) {}
+  explicit MemoryInfo(std::nullptr_t) {}
   MemoryInfo(const char* name, OrtAllocatorType type, int id, OrtMemType mem_type);
 
   explicit MemoryInfo(OrtMemoryInfo* p) : Base<OrtMemoryInfo>{p} {}

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -94,9 +94,6 @@ struct Base {
   }
 
   T* p_{};
-
-  template <typename>
-  friend struct Unowned;
 };
 
 template <typename T>

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -185,10 +185,10 @@ struct Session : Base<OrtSession> {
   Session(Env& env, const void* model_data, size_t model_data_length, const SessionOptions& options);
 
   // Run that will allocate the output values
-  std::vector<Value> Run(const RunOptions& run_options, const char* const* input_names, Value* input_values, size_t input_count,
+  std::vector<Value> Run(const RunOptions& run_options, const char* const* input_names, const Value* input_values, size_t input_count,
                          const char* const* output_names, size_t output_count);
   // Run for when there is a list of prealloated outputs
-  void Run(const RunOptions& run_options, const char* const* input_names, Value* input_values, size_t input_count,
+  void Run(const RunOptions& run_options, const char* const* input_names, const Value* input_values, size_t input_count,
            const char* const* output_names, Value* output_values, size_t output_count);
 
   size_t GetInputCount() const;

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -5,28 +5,19 @@
 // These are the inline implementations of the C++ header APIs. They're in this separate file as to not clutter
 // the main C++ file with implementation details.
 
-// TODO: Delete this macro once all uses of it are converted to the inline functions below
-#define ORT_THROW_ON_ERROR(expr)                                              \
-  if (OrtStatus* onnx_status = (expr)) {                                      \
-    std::string ort_error_message = Ort::g_api->GetErrorMessage(onnx_status); \
-    OrtErrorCode ort_error_code = Ort::g_api->GetErrorCode(onnx_status);      \
-    Ort::g_api->ReleaseStatus(onnx_status);                                   \
-    throw Ort::Exception(std::move(ort_error_message), ort_error_code);       \
-  }
-
 namespace Ort {
 
-inline void ThrowOnError(const OrtApi* ort, OrtStatus* status) {
+inline void ThrowOnError(const OrtApi& ort, OrtStatus* status) {
   if (status) {
-    std::string error_message = ort->GetErrorMessage(status);
-    OrtErrorCode error_code = ort->GetErrorCode(status);
-    ort->ReleaseStatus(status);
+    std::string error_message = ort.GetErrorMessage(status);
+    OrtErrorCode error_code = ort.GetErrorCode(status);
+    ort.ReleaseStatus(status);
     throw Ort::Exception(std::move(error_message), error_code);
   }
 }
 
 inline void ThrowOnError(OrtStatus* status) {
-  ThrowOnError(g_api, status);
+  ThrowOnError(Global<void>::api_, status);
 }
 
 // This template converts a C++ type into it's ONNXTensorElementDataType
@@ -56,182 +47,182 @@ template <>
 struct TypeToTensorType<bool> { static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL; };
 
 inline AllocatorWithDefaultOptions::AllocatorWithDefaultOptions() {
-  ThrowOnError(g_api->GetAllocatorWithDefaultOptions(&p_));
+  ThrowOnError(Global<void>::api_.GetAllocatorWithDefaultOptions(&p_));
 }
 
 inline void* AllocatorWithDefaultOptions::Alloc(size_t size) {
   void* out;
-  ThrowOnError(g_api->AllocatorAlloc(p_, size, &out));
+  ThrowOnError(Global<void>::api_.AllocatorAlloc(p_, size, &out));
   return out;
 }
 
 inline void AllocatorWithDefaultOptions::Free(void* p) {
-  ThrowOnError(g_api->AllocatorFree(p_, p));
+  ThrowOnError(Global<void>::api_.AllocatorFree(p_, p));
 }
 
 inline const OrtMemoryInfo* AllocatorWithDefaultOptions::GetInfo() const {
   const OrtMemoryInfo* out;
-  ThrowOnError(g_api->AllocatorGetInfo(p_, &out));
+  ThrowOnError(Global<void>::api_.AllocatorGetInfo(p_, &out));
   return out;
 }
 
 inline MemoryInfo MemoryInfo::CreateCpu(OrtAllocatorType type, OrtMemType mem_type) {
   OrtMemoryInfo* p;
-  ThrowOnError(g_api->CreateCpuMemoryInfo(type, mem_type, &p));
+  ThrowOnError(Global<void>::api_.CreateCpuMemoryInfo(type, mem_type, &p));
   return MemoryInfo(p);
 }
 
 inline MemoryInfo::MemoryInfo(const char* name, OrtAllocatorType type, int id, OrtMemType mem_type) {
-  ThrowOnError(g_api->CreateMemoryInfo(name, type, id, mem_type, &p_));
+  ThrowOnError(Global<void>::api_.CreateMemoryInfo(name, type, id, mem_type, &p_));
 }
 
 inline Env::Env(OrtLoggingLevel default_warning_level, _In_ const char* logid) {
-  ThrowOnError(g_api->CreateEnv(default_warning_level, logid, &p_));
+  ThrowOnError(Global<void>::api_.CreateEnv(default_warning_level, logid, &p_));
 }
 
 inline Env::Env(OrtLoggingLevel default_warning_level, const char* logid, OrtLoggingFunction logging_function, void* logger_param) {
-  ThrowOnError(g_api->CreateEnvWithCustomLogger(logging_function, logger_param, default_warning_level, logid, &p_));
+  ThrowOnError(Global<void>::api_.CreateEnvWithCustomLogger(logging_function, logger_param, default_warning_level, logid, &p_));
 }
 
 inline Env& Env::EnableTelemetryEvents() {
-  ThrowOnError(g_api->EnableTelemetryEvents(p_));
+  ThrowOnError(Global<void>::api_.EnableTelemetryEvents(p_));
   return *this;
 }
 
 inline Env& Env::DisableTelemetryEvents() {
-  ThrowOnError(g_api->DisableTelemetryEvents(p_));
+  ThrowOnError(Global<void>::api_.DisableTelemetryEvents(p_));
   return *this;
 }
 
 inline CustomOpDomain::CustomOpDomain(const char* domain) {
-  ThrowOnError(g_api->CreateCustomOpDomain(domain, &p_));
+  ThrowOnError(Global<void>::api_.CreateCustomOpDomain(domain, &p_));
 }
 
 inline void CustomOpDomain::Add(OrtCustomOp* op) {
-  ThrowOnError(g_api->CustomOpDomain_Add(p_, op));
+  ThrowOnError(Global<void>::api_.CustomOpDomain_Add(p_, op));
 }
 
 inline RunOptions::RunOptions() {
-  ThrowOnError(g_api->CreateRunOptions(&p_));
+  ThrowOnError(Global<void>::api_.CreateRunOptions(&p_));
 }
 
 inline RunOptions& RunOptions::SetRunLogVerbosityLevel(int level) {
-  ThrowOnError(g_api->RunOptionsSetRunLogVerbosityLevel(p_, level));
+  ThrowOnError(Global<void>::api_.RunOptionsSetRunLogVerbosityLevel(p_, level));
   return *this;
 }
 
 inline RunOptions& RunOptions::SetRunLogSeverityLevel(int level) {
-  ThrowOnError(g_api->RunOptionsSetRunLogSeverityLevel(p_, level));
+  ThrowOnError(Global<void>::api_.RunOptionsSetRunLogSeverityLevel(p_, level));
   return *this;
 }
 
 inline int RunOptions::GetRunLogVerbosityLevel() const {
   int out;
-  ThrowOnError(g_api->RunOptionsGetRunLogVerbosityLevel(p_, &out));
+  ThrowOnError(Global<void>::api_.RunOptionsGetRunLogVerbosityLevel(p_, &out));
   return out;
 }
 
 inline RunOptions& RunOptions::SetRunTag(const char* run_tag) {
-  ThrowOnError(g_api->RunOptionsSetRunTag(p_, run_tag));
+  ThrowOnError(Global<void>::api_.RunOptionsSetRunTag(p_, run_tag));
   return *this;
 }
 
 inline const char* RunOptions::GetRunTag() const {
   const char* out;
-  ThrowOnError(g_api->RunOptionsGetRunTag(p_, &out));
+  ThrowOnError(Global<void>::api_.RunOptionsGetRunTag(p_, &out));
   return out;
 }
 
 inline RunOptions& RunOptions::SetTerminate() {
-  ThrowOnError(g_api->RunOptionsSetTerminate(p_));
+  ThrowOnError(Global<void>::api_.RunOptionsSetTerminate(p_));
   return *this;
 }
 
 inline RunOptions& RunOptions::UnsetTerminate() {
-  ThrowOnError(g_api->RunOptionsUnsetTerminate(p_));
+  ThrowOnError(Global<void>::api_.RunOptionsUnsetTerminate(p_));
   return *this;
 }
 
 inline SessionOptions::SessionOptions() {
-  ThrowOnError(g_api->CreateSessionOptions(&p_));
+  ThrowOnError(Global<void>::api_.CreateSessionOptions(&p_));
 }
 
 inline SessionOptions SessionOptions::Clone() const {
   OrtSessionOptions* out;
-  ThrowOnError(g_api->CloneSessionOptions(p_, &out));
+  ThrowOnError(Global<void>::api_.CloneSessionOptions(p_, &out));
   return SessionOptions{out};
 }
 
 inline SessionOptions& SessionOptions::SetIntraOpNumThreads(int intra_op_num_threads) {
-  ThrowOnError(g_api->SetIntraOpNumThreads(p_, intra_op_num_threads));
+  ThrowOnError(Global<void>::api_.SetIntraOpNumThreads(p_, intra_op_num_threads));
   return *this;
 }
 
 inline SessionOptions& SessionOptions::SetInterOpNumThreads(int inter_op_num_threads) {
-  ThrowOnError(g_api->SetInterOpNumThreads(p_, inter_op_num_threads));
+  ThrowOnError(Global<void>::api_.SetInterOpNumThreads(p_, inter_op_num_threads));
   return *this;
 }
 
 inline SessionOptions& SessionOptions::SetGraphOptimizationLevel(GraphOptimizationLevel graph_optimization_level) {
-  ThrowOnError(g_api->SetSessionGraphOptimizationLevel(p_, graph_optimization_level));
+  ThrowOnError(Global<void>::api_.SetSessionGraphOptimizationLevel(p_, graph_optimization_level));
   return *this;
 }
 
 inline SessionOptions& SessionOptions::SetOptimizedModelFilePath(const ORTCHAR_T* optimized_model_filepath) {
-  ThrowOnError(g_api->SetOptimizedModelFilePath(p_, optimized_model_filepath));
+  ThrowOnError(Global<void>::api_.SetOptimizedModelFilePath(p_, optimized_model_filepath));
   return *this;
 }
 
 inline SessionOptions& SessionOptions::EnableProfiling(const ORTCHAR_T* profile_file_prefix) {
-  ThrowOnError(g_api->EnableProfiling(p_, profile_file_prefix));
+  ThrowOnError(Global<void>::api_.EnableProfiling(p_, profile_file_prefix));
   return *this;
 }
 
 inline SessionOptions& SessionOptions::DisableProfiling() {
-  ThrowOnError(g_api->DisableProfiling(p_));
+  ThrowOnError(Global<void>::api_.DisableProfiling(p_));
   return *this;
 }
 
 inline SessionOptions& SessionOptions::EnableMemPattern() {
-  ThrowOnError(g_api->EnableMemPattern(p_));
+  ThrowOnError(Global<void>::api_.EnableMemPattern(p_));
   return *this;
 }
 
 inline SessionOptions& SessionOptions::DisableMemPattern() {
-  ThrowOnError(g_api->DisableMemPattern(p_));
+  ThrowOnError(Global<void>::api_.DisableMemPattern(p_));
   return *this;
 }
 
 inline SessionOptions& SessionOptions::EnableCpuMemArena() {
-  ThrowOnError(g_api->EnableCpuMemArena(p_));
+  ThrowOnError(Global<void>::api_.EnableCpuMemArena(p_));
   return *this;
 }
 
 inline SessionOptions& SessionOptions::DisableCpuMemArena() {
-  ThrowOnError(g_api->DisableCpuMemArena(p_));
+  ThrowOnError(Global<void>::api_.DisableCpuMemArena(p_));
   return *this;
 }
 
 inline SessionOptions& SessionOptions::SetExecutionMode(ExecutionMode execution_mode) {
-  ThrowOnError(g_api->SetSessionExecutionMode(p_, execution_mode));
+  ThrowOnError(Global<void>::api_.SetSessionExecutionMode(p_, execution_mode));
   return *this;
 }
 
 inline SessionOptions& SessionOptions::SetLogId(const char* logid) {
-  ThrowOnError(g_api->SetSessionLogId(p_, logid));
+  ThrowOnError(Global<void>::api_.SetSessionLogId(p_, logid));
   return *this;
 }
 inline SessionOptions& SessionOptions::Add(OrtCustomOpDomain* custom_op_domain) {
-  ThrowOnError(g_api->AddCustomOpDomain(p_, custom_op_domain));
+  ThrowOnError(Global<void>::api_.AddCustomOpDomain(p_, custom_op_domain));
   return *this;
 }
 
 inline Session::Session(Env& env, const ORTCHAR_T* model_path, const SessionOptions& options) {
-  ThrowOnError(g_api->CreateSession(env, model_path, options, &p_));
+  ThrowOnError(Global<void>::api_.CreateSession(env, model_path, options, &p_));
 }
 
 inline Session::Session(Env& env, const void* model_data, size_t model_data_length, const SessionOptions& options) {
-  ThrowOnError(g_api->CreateSessionFromArray(env, model_data, model_data_length, options, &p_));
+  ThrowOnError(Global<void>::api_.CreateSessionFromArray(env, model_data, model_data_length, options, &p_));
 }
 
 inline std::vector<Value> Session::Run(const RunOptions& run_options, const char* const* input_names, Value* input_values, size_t input_count,
@@ -248,87 +239,87 @@ inline void Session::Run(const RunOptions& run_options, const char* const* input
   static_assert(sizeof(Value) == sizeof(OrtValue*), "Value is really just an array of OrtValue* in memory, so we can reinterpret_cast safely");
   auto ort_input_values = reinterpret_cast<OrtValue**>(input_values);
   auto ort_output_values = reinterpret_cast<OrtValue**>(output_values);
-  ThrowOnError(g_api->Run(p_, run_options, input_names, ort_input_values, input_count, output_names, output_count, ort_output_values));
+  ThrowOnError(Global<void>::api_.Run(p_, run_options, input_names, ort_input_values, input_count, output_names, output_count, ort_output_values));
 }
 
 inline size_t Session::GetInputCount() const {
   size_t out;
-  ThrowOnError(g_api->SessionGetInputCount(p_, &out));
+  ThrowOnError(Global<void>::api_.SessionGetInputCount(p_, &out));
   return out;
 }
 
 inline size_t Session::GetOutputCount() const {
   size_t out;
-  ThrowOnError(g_api->SessionGetOutputCount(p_, &out));
+  ThrowOnError(Global<void>::api_.SessionGetOutputCount(p_, &out));
   return out;
 }
 
 inline size_t Session::GetOverridableInitializerCount() const {
   size_t out;
-  ThrowOnError(g_api->SessionGetOverridableInitializerCount(p_, &out));
+  ThrowOnError(Global<void>::api_.SessionGetOverridableInitializerCount(p_, &out));
   return out;
 }
 
 inline char* Session::GetInputName(size_t index, OrtAllocator* allocator) const {
   char* out;
-  ThrowOnError(g_api->SessionGetInputName(p_, index, allocator, &out));
+  ThrowOnError(Global<void>::api_.SessionGetInputName(p_, index, allocator, &out));
   return out;
 }
 
 inline char* Session::GetOutputName(size_t index, OrtAllocator* allocator) const {
   char* out;
-  ThrowOnError(g_api->SessionGetOutputName(p_, index, allocator, &out));
+  ThrowOnError(Global<void>::api_.SessionGetOutputName(p_, index, allocator, &out));
   return out;
 }
 
 inline char* Session::GetOverridableInitializerName(size_t index, OrtAllocator* allocator) const {
   char* out;
-  ThrowOnError(g_api->SessionGetOverridableInitializerName(p_, index, allocator, &out));
+  ThrowOnError(Global<void>::api_.SessionGetOverridableInitializerName(p_, index, allocator, &out));
   return out;
 }
 
 inline TypeInfo Session::GetInputTypeInfo(size_t index) const {
   OrtTypeInfo* out;
-  ThrowOnError(g_api->SessionGetInputTypeInfo(p_, index, &out));
+  ThrowOnError(Global<void>::api_.SessionGetInputTypeInfo(p_, index, &out));
   return TypeInfo{out};
 }
 
 inline TypeInfo Session::GetOutputTypeInfo(size_t index) const {
   OrtTypeInfo* out;
-  ThrowOnError(g_api->SessionGetOutputTypeInfo(p_, index, &out));
+  ThrowOnError(Global<void>::api_.SessionGetOutputTypeInfo(p_, index, &out));
   return TypeInfo{out};
 }
 
 inline TypeInfo Session::GetOverridableInitializerTypeInfo(size_t index) const {
   OrtTypeInfo* out;
-  ThrowOnError(g_api->SessionGetOverridableInitializerTypeInfo(p_, index, &out));
+  ThrowOnError(Global<void>::api_.SessionGetOverridableInitializerTypeInfo(p_, index, &out));
   return TypeInfo{out};
 }
 
 inline ONNXTensorElementDataType TensorTypeAndShapeInfo::GetElementType() const {
   ONNXTensorElementDataType out;
-  ThrowOnError(g_api->GetTensorElementType(p_, &out));
+  ThrowOnError(Global<void>::api_.GetTensorElementType(p_, &out));
   return out;
 }
 
 inline size_t TensorTypeAndShapeInfo::GetElementCount() const {
   size_t out;
-  ThrowOnError(g_api->GetTensorShapeElementCount(p_, &out));
+  ThrowOnError(Global<void>::api_.GetTensorShapeElementCount(p_, &out));
   return static_cast<size_t>(out);
 }
 
 inline size_t TensorTypeAndShapeInfo::GetDimensionsCount() const {
   size_t out;
-  ThrowOnError(g_api->GetDimensionsCount(p_, &out));
+  ThrowOnError(Global<void>::api_.GetDimensionsCount(p_, &out));
   return out;
 }
 
 inline void TensorTypeAndShapeInfo::GetDimensions(int64_t* values, size_t values_count) const {
-  ThrowOnError(g_api->GetDimensions(p_, values, values_count));
+  ThrowOnError(Global<void>::api_.GetDimensions(p_, values, values_count));
 }
 
 inline void TensorTypeAndShapeInfo::GetSymbolicDimensions(const char** values, size_t values_count) const {
-  ThrowOnError(g_api->GetSymbolicDimensions(p_, values, values_count));
+  ThrowOnError(Global<void>::api_.GetSymbolicDimensions(p_, values, values_count));
 }
 
 inline std::vector<int64_t> TensorTypeAndShapeInfo::GetShape() const {
@@ -339,13 +330,13 @@ inline std::vector<int64_t> TensorTypeAndShapeInfo::GetShape() const {
 
 inline Unowned<TensorTypeAndShapeInfo> TypeInfo::GetTensorTypeAndShapeInfo() const {
   const OrtTensorTypeAndShapeInfo* out;
-  ThrowOnError(g_api->CastTypeInfoToTensorInfo(p_, &out));
+  ThrowOnError(Global<void>::api_.CastTypeInfoToTensorInfo(p_, &out));
   return Unowned<TensorTypeAndShapeInfo>{const_cast<OrtTensorTypeAndShapeInfo*>(out)};
 }
 
 inline ONNXType TypeInfo::GetONNXType() const {
   ONNXType out;
-  ThrowOnError(g_api->GetOnnxTypeFromTypeInfo(p_, &out));
+  ThrowOnError(Global<void>::api_.GetOnnxTypeFromTypeInfo(p_, &out));
   return out;
 }
 
@@ -357,7 +348,7 @@ inline Value Value::CreateTensor(const OrtMemoryInfo* info, T* p_data, size_t p_
 inline Value Value::CreateTensor(const OrtMemoryInfo* info, void* p_data, size_t p_data_byte_count, const int64_t* shape, size_t shape_len,
                                  ONNXTensorElementDataType type) {
   OrtValue* out;
-  ThrowOnError(g_api->CreateTensorWithDataAsOrtValue(info, p_data, p_data_byte_count, shape, shape_len, type, &out));
+  ThrowOnError(Global<void>::api_.CreateTensorWithDataAsOrtValue(info, p_data, p_data_byte_count, shape, shape_len, type, &out));
   return Value{out};
 }
 
@@ -368,80 +359,80 @@ inline Value Value::CreateTensor(OrtAllocator* allocator, const int64_t* shape, 
 
 inline Value Value::CreateTensor(OrtAllocator* allocator, const int64_t* shape, size_t shape_len, ONNXTensorElementDataType type) {
   OrtValue* out;
-  ThrowOnError(g_api->CreateTensorAsOrtValue(allocator, shape, shape_len, type, &out));
+  ThrowOnError(Global<void>::api_.CreateTensorAsOrtValue(allocator, shape, shape_len, type, &out));
   return Value{out};
 }
 
 inline Value Value::CreateMap(Value& keys, Value& values) {
   OrtValue* out;
   OrtValue* inputs[2] = {keys, values};
-  ThrowOnError(g_api->CreateValue(inputs, 2, ONNX_TYPE_MAP, &out));
+  ThrowOnError(Global<void>::api_.CreateValue(inputs, 2, ONNX_TYPE_MAP, &out));
   return Value{out};
 }
 
 inline Value Value::CreateSequence(std::vector<Value>& values) {
   OrtValue* out;
   std::vector<OrtValue*> values_ort{values.data(), values.data() + values.size()};
-  ThrowOnError(g_api->CreateValue(values_ort.data(), values_ort.size(), ONNX_TYPE_SEQUENCE, &out));
+  ThrowOnError(Global<void>::api_.CreateValue(values_ort.data(), values_ort.size(), ONNX_TYPE_SEQUENCE, &out));
   return Value{out};
 }
 
 template <typename T>
 inline Value Value::CreateOpaque(const char* domain, const char* type_name, const T& data_container) {
   OrtValue* out;
-  ThrowOnError(g_api->CreateOpaqueValue(domain, type_name, &data_container, sizeof(T), &out));
+  ThrowOnError(Global<void>::api_.CreateOpaqueValue(domain, type_name, &data_container, sizeof(T), &out));
   return Value{out};
 }
 
 template <typename T>
 inline void Value::GetOpaqueData(const char* domain, const char* type_name, T& out) {
-  ThrowOnError(g_api->GetOpaqueValue(domain, type_name, p_, &out, sizeof(T)));
+  ThrowOnError(Global<void>::api_.GetOpaqueValue(domain, type_name, p_, &out, sizeof(T)));
 }
 
 inline bool Value::IsTensor() const {
   int out;
-  ThrowOnError(g_api->IsTensor(p_, &out));
+  ThrowOnError(Global<void>::api_.IsTensor(p_, &out));
   return out != 0;
 }
 
 inline size_t Value::GetCount() const {
   size_t out;
-  ThrowOnError(g_api->GetValueCount(p_, &out));
+  ThrowOnError(Global<void>::api_.GetValueCount(p_, &out));
   return out;
 }
 
 inline Value Value::GetValue(int index, OrtAllocator* allocator) const {
   OrtValue* out;
-  ThrowOnError(g_api->GetValue(p_, index, allocator, &out));
+  ThrowOnError(Global<void>::api_.GetValue(p_, index, allocator, &out));
   return Value{out};
 }
 
 inline size_t Value::GetStringTensorDataLength() const {
   size_t out;
-  ThrowOnError(g_api->GetStringTensorDataLength(p_, &out));
+  ThrowOnError(Global<void>::api_.GetStringTensorDataLength(p_, &out));
   return out;
 }
 
 inline void Value::GetStringTensorContent(void* buffer, size_t buffer_length, size_t* offsets, size_t offsets_count) const {
-  ThrowOnError(g_api->GetStringTensorContent(p_, buffer, buffer_length, offsets, offsets_count));
+  ThrowOnError(Global<void>::api_.GetStringTensorContent(p_, buffer, buffer_length, offsets, offsets_count));
 }
 
 template <typename T>
 T* Value::GetTensorMutableData() {
   T* out;
-  ThrowOnError(g_api->GetTensorMutableData(p_, (void**)&out));
+  ThrowOnError(Global<void>::api_.GetTensorMutableData(p_, (void**)&out));
   return out;
 }
 
 inline TypeInfo Value::GetTypeInfo() const {
   OrtTypeInfo* output;
-  ThrowOnError(g_api->GetTypeInfo(p_, &output));
+  ThrowOnError(Global<void>::api_.GetTypeInfo(p_, &output));
   return TypeInfo{output};
 }
 
 inline TensorTypeAndShapeInfo Value::GetTensorTypeAndShapeInfo() const {
   OrtTensorTypeAndShapeInfo* output;
-  ThrowOnError(g_api->GetTensorTypeAndShape(p_, &output));
+  ThrowOnError(Global<void>::api_.GetTensorTypeAndShape(p_, &output));
   return TensorTypeAndShapeInfo{output};
 }
 
@@ -449,7 +440,7 @@ inline TensorTypeAndShapeInfo Value::GetTensorTypeAndShapeInfo() const {
 // Custom OP API Inlines
 //
 inline void CustomOpApi::ThrowOnError(OrtStatus* status) {
-  Ort::ThrowOnError(&api_, status);
+  Ort::ThrowOnError(api_, status);
 }
 
 template <>

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -225,7 +225,7 @@ inline Session::Session(Env& env, const void* model_data, size_t model_data_leng
   ThrowOnError(Global<void>::api_.CreateSessionFromArray(env, model_data, model_data_length, options, &p_));
 }
 
-inline std::vector<Value> Session::Run(const RunOptions& run_options, const char* const* input_names, Value* input_values, size_t input_count,
+inline std::vector<Value> Session::Run(const RunOptions& run_options, const char* const* input_names, const Value* input_values, size_t input_count,
                                        const char* const* output_names, size_t output_names_count) {
   std::vector<Ort::Value> output_values;
   for (size_t i = 0; i < output_names_count; i++)
@@ -234,10 +234,10 @@ inline std::vector<Value> Session::Run(const RunOptions& run_options, const char
   return output_values;
 }
 
-inline void Session::Run(const RunOptions& run_options, const char* const* input_names, Value* input_values, size_t input_count,
+inline void Session::Run(const RunOptions& run_options, const char* const* input_names, const Value* input_values, size_t input_count,
                          const char* const* output_names, Value* output_values, size_t output_count) {
   static_assert(sizeof(Value) == sizeof(OrtValue*), "Value is really just an array of OrtValue* in memory, so we can reinterpret_cast safely");
-  auto ort_input_values = reinterpret_cast<OrtValue**>(input_values);
+  auto ort_input_values = reinterpret_cast<const OrtValue**>(const_cast<Value*>(input_values));
   auto ort_output_values = reinterpret_cast<OrtValue**>(output_values);
   ThrowOnError(Global<void>::api_.Run(p_, run_options, input_names, ort_input_values, input_count, output_names, output_count, ort_output_values));
 }

--- a/onnxruntime/core/language_interop_ops/language_interop_ops.cc
+++ b/onnxruntime/core/language_interop_ops/language_interop_ops.cc
@@ -38,9 +38,8 @@ void LoadInterOp(const ONNX_NAMESPACE::GraphProto& graph_proto, InterOpDomains& 
     const auto& node_proto = graph_proto.node(i);
     if (node_proto.op_type() == "PyOp") {
       OrtCustomOpDomain* pyop_domain = nullptr;
-      const OrtApi* ort = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-      Ort::ThrowOnError(ort, ort->CreateCustomOpDomain(node_proto.domain().c_str(), &pyop_domain));
-      Ort::ThrowOnError(ort, ort->CustomOpDomain_Add(pyop_domain, LoadPyOp(node_proto, log_func)));
+      Ort::ThrowOnError(Ort::GetApi().CreateCustomOpDomain(node_proto.domain().c_str(), &pyop_domain));
+      Ort::ThrowOnError(Ort::GetApi().CustomOpDomain_Add(pyop_domain, LoadPyOp(node_proto, log_func)));
       auto ort_domain = std::unique_ptr<OrtCustomOpDomain, decltype(&InterOpDomainDeleter)>(pyop_domain, &InterOpDomainDeleter);
       domains.push_back(std::move(ort_domain));
     } else {

--- a/onnxruntime/server/executor.cc
+++ b/onnxruntime/server/executor.cc
@@ -58,7 +58,7 @@ protobufutil::Status Executor::SetNameMLValueMap(std::vector<std::string>& input
   auto logger = env_->GetLogger(request_id_);
 
   OrtMemoryInfo* memory_info = nullptr;
-  auto ort_status = Ort::g_api->CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &memory_info);
+  auto ort_status = Ort::GetApi().CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &memory_info);
 
   if (ort_status != nullptr || memory_info == nullptr) {
     logger->error("OrtCreateCpuMemoryInfo failed");
@@ -72,7 +72,7 @@ protobufutil::Status Executor::SetNameMLValueMap(std::vector<std::string>& input
     Ort::Value ml_value{nullptr};
     auto status = SetMLValue(input.second, buffers, memory_info, ml_value);
     if (status != protobufutil::Status::OK) {
-      Ort::g_api->ReleaseMemoryInfo(memory_info);
+      Ort::GetApi().ReleaseMemoryInfo(memory_info);
       logger->error("SetMLValue() failed! Input name: {}", input.first);
       return status;
     }
@@ -81,7 +81,7 @@ protobufutil::Status Executor::SetNameMLValueMap(std::vector<std::string>& input
     input_values.push_back(std::move(ml_value));
   }
 
-  Ort::g_api->ReleaseMemoryInfo(memory_info);
+  Ort::GetApi().ReleaseMemoryInfo(memory_info);
   return protobufutil::Status::OK;
 }
 

--- a/onnxruntime/server/executor.cc
+++ b/onnxruntime/server/executor.cc
@@ -18,8 +18,6 @@
 #include "executor.h"
 #include "util.h"
 
-const OrtApi* Ort::g_api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-
 namespace onnxruntime {
 namespace server {
 

--- a/onnxruntime/test/common/test_main.cc
+++ b/onnxruntime/test/common/test_main.cc
@@ -4,9 +4,6 @@
 #include "gtest/gtest.h"
 #include "test/test_environment.h"
 
-const OrtApi* g_ort = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-const OrtApi* Ort::g_api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-
 GTEST_API_ int main(int argc, char** argv) {
   int status = 0;
 

--- a/onnxruntime/test/framework/test_main.cc
+++ b/onnxruntime/test/framework/test_main.cc
@@ -6,9 +6,6 @@
 #include "test/test_environment.h"
 #include "core/session/onnxruntime_cxx_api.h"
 
-const OrtApi* g_ort = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-const OrtApi* Ort::g_api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-
 GTEST_API_ int main(int argc, char** argv) {
   int status = 0;
 

--- a/onnxruntime/test/framework/test_tensor_loader.cc
+++ b/onnxruntime/test/framework/test_tensor_loader.cc
@@ -12,7 +12,6 @@
 #endif
 
 const OrtApi* g_ort = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-const OrtApi* Ort::g_api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
 
 namespace onnxruntime {
 namespace test {

--- a/onnxruntime/test/onnx/OrtValueList.h
+++ b/onnxruntime/test/onnx/OrtValueList.h
@@ -4,8 +4,6 @@
 #pragma once
 #include "core/session/onnxruntime_cxx_api.h"
 
-extern const OrtApi* g_ort;
-
 /**
  * A container for OrtValues for RAII
  */
@@ -19,7 +17,7 @@ class OrtValueArray {
   OrtValueArray(int n) : values(static_cast<size_t>(n), nullptr){};
   ~OrtValueArray() {
     for (OrtValue* v : values) {
-      if (v != nullptr) g_ort->ReleaseValue(v);
+      if (v != nullptr) Ort::GetApi().ReleaseValue(v);
     }
   }
   OrtValue* Get(size_t index) {

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -22,9 +22,6 @@
 #include "core/optimizer/graph_transformer_level.h"
 #include "core/framework/session_options.h"
 
-const OrtApi* g_ort = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-const OrtApi* Ort::g_api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-
 using namespace onnxruntime;
 
 namespace {
@@ -50,7 +47,7 @@ void usage() {
       "\t-h: help\n"
       "\n"
       "onnxruntime version: %s\n",
-      g_ort->base_.GetVersionString());
+      OrtGetApiBase()->GetVersionString());
 }
 
 #ifdef _WIN32
@@ -263,8 +260,8 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
 
     if (enable_tensorrt) {
 #ifdef USE_TENSORRT
-      ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_Tensorrt(sf, device_id));
-      ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_CUDA(sf, device_id));
+      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Tensorrt(sf, device_id));
+      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_CUDA(sf, device_id));
 #else
       fprintf(stderr, "TensorRT is not supported in this build");
       return -1;
@@ -273,7 +270,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
 
     if (enable_openvino) {
 #ifdef USE_OPENVINO
-      ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_OpenVINO(sf, "CPU"));
+      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(sf, "CPU"));
 #else
       fprintf(stderr, "OpenVINO is not supported in this build");
       return -1;
@@ -281,7 +278,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     }
     if (enable_cuda) {
 #ifdef USE_CUDA
-      ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_CUDA(sf, device_id));
+      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_CUDA(sf, device_id));
 #else
       fprintf(stderr, "CUDA is not supported in this build");
       return -1;
@@ -289,7 +286,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     }
     if (enable_nuphar) {
 #ifdef USE_NUPHAR
-      ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_Nuphar(sf, /*allow_unaligned_buffers*/ 1, ""));
+      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Nuphar(sf, /*allow_unaligned_buffers*/ 1, ""));
 #else
       fprintf(stderr, "Nuphar is not supported in this build");
       return -1;
@@ -297,7 +294,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     }
     if (enable_mkl) {
 #ifdef USE_MKLDNN
-      ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_Mkldnn(sf, enable_cpu_mem_arena ? 1 : 0));
+      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Mkldnn(sf, enable_cpu_mem_arena ? 1 : 0));
 #else
       fprintf(stderr, "MKL-DNN is not supported in this build");
       return -1;
@@ -305,7 +302,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     }
     if (enable_ngraph) {  // TODO: Re-order the priority?
 #ifdef USE_NGRAPH
-      ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_NGraph(sf, "CPU"));
+      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_NGraph(sf, "CPU"));
 #else
       fprintf(stderr, "nGraph is not supported in this build");
       return -1;
@@ -313,7 +310,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     }
     if (enable_nnapi) {
 #ifdef USE_NNAPI
-      ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_Nnapi(sf));
+      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Nnapi(sf));
 #else
       fprintf(stderr, "DNNLibrary/NNAPI is not supported in this build");
       return -1;
@@ -326,7 +323,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
       sf.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
       p_models = 1;
       concurrent_session_runs = 1;
-      ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_DML(sf, device_id));
+      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_DML(sf, device_id));
 #else
       fprintf(stderr, "DML is not supported in this build");
       return -1;

--- a/onnxruntime/test/onnx/runner.cc
+++ b/onnxruntime/test/onnx/runner.cc
@@ -27,8 +27,6 @@
 using namespace onnxruntime;
 using ::onnxruntime::common::Status;
 
-extern const OrtApi* g_ort;
-
 // Permanently exclude following tests because ORT support only opset staring from 7,
 // Please make no more changes to the list
 const std::set<std::string> immutable_broken_tests =
@@ -330,7 +328,7 @@ DataRunner::DataRunner(OrtSession* session1, const std::string& test_case_name1,
 }
 
 DataRunner::~DataRunner() {
-  g_ort->ReleaseSession(session);
+  Ort::GetApi().ReleaseSession(session);
 }
 
 void DataRunner::RunTask(size_t task_id, ORT_CALLBACK_INSTANCE pci, bool store_result) {
@@ -354,11 +352,11 @@ EXECUTE_RESULT DataRunner::RunTaskImpl(size_t task_id) {
 
   // Create output feed
   size_t output_count = 0;
-  ORT_THROW_ON_ERROR(g_ort->SessionGetOutputCount(session, &output_count));
+  Ort::ThrowOnError(Ort::GetApi().SessionGetOutputCount(session, &output_count));
   std::vector<std::string> output_names(output_count);
   for (size_t i = 0; i != output_count; ++i) {
     char* output_name = nullptr;
-    ORT_THROW_ON_ERROR(g_ort->SessionGetOutputName(session, i, default_allocator.get(), &output_name));
+    Ort::ThrowOnError(Ort::GetApi().SessionGetOutputName(session, i, default_allocator.get(), &output_name));
     assert(output_name != nullptr);
     output_names[i] = output_name;
     default_allocator->Free(output_name);
@@ -384,9 +382,9 @@ EXECUTE_RESULT DataRunner::RunTaskImpl(size_t task_id) {
       output_names_raw_ptr[i] = output_names[i].c_str();
     }
     GetMonotonicTimeCounter(&start_time);
-    ORT_THROW_ON_ERROR(g_ort->Run(session, nullptr, input_names.data(), input_values.Data(),
-                                  static_cast<size_t>(input_values.Length()), output_names_raw_ptr.data(), output_count,
-                                  output_values.Data()));
+    Ort::ThrowOnError(Ort::GetApi().Run(session, nullptr, input_names.data(), input_values.Data(),
+                                        static_cast<size_t>(input_values.Length()), output_names_raw_ptr.data(), output_count,
+                                        output_values.Data()));
   }
   GetMonotonicTimeCounter(&end_time);
   AccumulateTimeSpec(&spent_time_, &start_time, &end_time);
@@ -485,7 +483,7 @@ EXECUTE_RESULT DataRunner::RunTaskImpl(size_t task_id) {
     }
   }
   for (auto& kvp : expected_output_values) {
-    g_ort->ReleaseValue(kvp.second);
+    Ort::GetApi().ReleaseValue(kvp.second);
   }
   return res;
 }

--- a/onnxruntime/test/onnx/tensorprotoutils.cc
+++ b/onnxruntime/test/onnx/tensorprotoutils.cc
@@ -13,8 +13,6 @@
 #include "core/graph/onnx_protobuf.h"
 #include "callback.h"
 
-extern const OrtApi* g_ort;
-
 struct OrtStatus {
   OrtErrorCode code;
   char msg[1];  // a null-terminated string
@@ -319,7 +317,7 @@ OrtStatus* OrtInitializeBufferForTensor(void* input, size_t input_len,
       new (ptr + i) std::string();
     }
   } catch (std::exception& ex) {
-    return g_ort->CreateStatus(ORT_RUNTIME_EXCEPTION, ex.what());
+    return Ort::GetApi().CreateStatus(ORT_RUNTIME_EXCEPTION, ex.what());
   }
   return nullptr;
 }
@@ -431,7 +429,7 @@ Status TensorProtoToMLValue(const onnx::TensorProto& tensor_proto, const MemBuff
           if (preallocated != nullptr) {
             OrtStatus* status = OrtInitializeBufferForTensor(preallocated, preallocated_size, ele_type);
             if (status != nullptr) {
-              g_ort->ReleaseStatus(status);
+              Ort::GetApi().ReleaseStatus(status);
               return Status(common::ONNXRUNTIME, common::FAIL, "initialize preallocated buffer failed");
             }
             deleter.f = UnInitTensor;

--- a/onnxruntime/test/opaque_api/test_opaque_api.cc
+++ b/onnxruntime/test/opaque_api/test_opaque_api.cc
@@ -19,8 +19,6 @@
 using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::common;
 
-const OrtApi* Ort::g_api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-
 // Data container used to ferry data through C API
 extern "C" struct ExperimentalDataContainer {
   // This is a string Tensor
@@ -234,7 +232,7 @@ TEST_F(OpaqueApiTest, RunModelWithOpaqueInputOutput) {
 
     // No C++ Api to either create a string Tensor or to fill one with string, so we use C
     const char* const input_char_string[] = {input_string.c_str()};
-    ORT_THROW_ON_ERROR(Ort::g_api->FillStringTensor(static_cast<OrtValue*>(container_str), input_char_string, 1U));
+    Ort::ThrowOnError(Ort::GetApi().FillStringTensor(static_cast<OrtValue*>(container_str), input_char_string, 1U));
 
     // We put this into our container now
     // This container life-span is supposed to eclipse the model running time

--- a/onnxruntime/test/perftest/main.cc
+++ b/onnxruntime/test/perftest/main.cc
@@ -9,9 +9,6 @@
 
 using namespace onnxruntime;
 
-const OrtApi* g_ort = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-const OrtApi* Ort::g_api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-
 #ifdef _WIN32
 int real_main(int argc, wchar_t* argv[]) {
 #else

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -32,50 +32,50 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
   const std::string& provider_name = performance_test_config.machine_config.provider_type_name;
   if (provider_name == onnxruntime::kMklDnnExecutionProvider) {
 #ifdef USE_MKLDNN
-    ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_Mkldnn(session_options, performance_test_config.run_config.enable_cpu_mem_arena ? 1 : 0));
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Mkldnn(session_options, performance_test_config.run_config.enable_cpu_mem_arena ? 1 : 0));
 #else
     ORT_THROW("MKL-DNN is not supported in this build\n");
 #endif
   } else if (provider_name == onnxruntime::kNGraphExecutionProvider) {
 #ifdef USE_NGRAPH
-    ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_NGraph(session_options, "CPU"));
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_NGraph(session_options, "CPU"));
 #else
     ORT_THROW("nGraph is not supported in this build");
 #endif
   } else if (provider_name == onnxruntime::kCudaExecutionProvider) {
 #ifdef USE_CUDA
-    ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_CUDA(session_options, 0));
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_CUDA(session_options, 0));
 #else
     ORT_THROW("CUDA is not supported in this build\n");
 #endif
   } else if (provider_name == onnxruntime::kNupharExecutionProvider) {
 #ifdef USE_NUPHAR
-    ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_Nuphar(session_options, /*allow_unaligned_buffers*/ 1, ""));
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Nuphar(session_options, /*allow_unaligned_buffers*/ 1, ""));
 #else
     ORT_THROW("Nuphar is not supported in this build\n");
 #endif
   } else if (provider_name == onnxruntime::kTensorrtExecutionProvider) {
 #ifdef USE_TENSORRT
-    ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_Tensorrt(session_options, 0));
-    ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_CUDA(session_options, 0));
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Tensorrt(session_options, 0));
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_CUDA(session_options, 0));
 #else
     ORT_THROW("TensorRT is not supported in this build\n");
 #endif
   } else if (provider_name == onnxruntime::kOpenVINOExecutionProvider) {
 #ifdef USE_OPENVINO
-    ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_OpenVINO(session_options, "CPU"));
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(session_options, "CPU"));
 #else
     ORT_THROW("OpenVINO is not supported in this build\n");
 #endif
   } else if (provider_name == onnxruntime::kNnapiExecutionProvider) {
 #ifdef USE_NNAPI
-    ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_Nnapi(session_options));
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Nnapi(session_options));
 #else
     ORT_THROW("NNAPI is not supported in this build\n");
 #endif
   } else if (provider_name == onnxruntime::kDmlExecutionProvider) {
 #ifdef USE_DML
-    ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_DML(session_options, 0));
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_DML(session_options, 0));
 #else
     ORT_THROW("DirectML is not supported in this build\n");
 #endif

--- a/onnxruntime/test/shared_lib/test_allocator.cc
+++ b/onnxruntime/test/shared_lib/test_allocator.cc
@@ -6,20 +6,17 @@
 #include "core/providers/cpu/cpu_provider_factory.h"
 #include "test_fixture.h"
 
-const OrtApi* g_ort = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-const OrtApi* Ort::g_api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-
 using namespace onnxruntime;
 
 TEST_F(CApiTest, allocation_info) {
   OrtMemoryInfo *info1, *info2;
-  ORT_THROW_ON_ERROR(g_ort->CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &info1));
-  ORT_THROW_ON_ERROR(g_ort->CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &info2));
+  Ort::ThrowOnError(Ort::GetApi().CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &info1));
+  Ort::ThrowOnError(Ort::GetApi().CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &info2));
   int result;
-  ORT_THROW_ON_ERROR(g_ort->CompareMemoryInfo(info1, info2, &result));
+  Ort::ThrowOnError(Ort::GetApi().CompareMemoryInfo(info1, info2, &result));
   ASSERT_EQ(0, result);
-  g_ort->ReleaseMemoryInfo(info1);
-  g_ort->ReleaseMemoryInfo(info2);
+  Ort::GetApi().ReleaseMemoryInfo(info1);
+  Ort::GetApi().ReleaseMemoryInfo(info2);
 }
 
 TEST_F(CApiTest, DefaultAllocator) {
@@ -31,6 +28,6 @@ TEST_F(CApiTest, DefaultAllocator) {
   const OrtMemoryInfo* info1 = default_allocator.GetInfo();
   const OrtMemoryInfo* info2 = static_cast<OrtAllocator*>(default_allocator)->Info(default_allocator);
   int result;
-  ORT_THROW_ON_ERROR(g_ort->CompareMemoryInfo(info1, info2, &result));
+  Ort::ThrowOnError(Ort::GetApi().CompareMemoryInfo(info1, info2, &result));
   ASSERT_EQ(0, result);
 }

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -14,8 +14,6 @@
 #include "test_fixture.h"
 #include "onnx_protobuf.h"
 
-extern const OrtApi* g_ort;
-
 struct Input {
   const char* name;
   std::vector<int64_t> dims;
@@ -66,21 +64,21 @@ void TestInference(Ort::Env& env, T model_uri,
 
   if (provider_type == 1) {
 #ifdef USE_CUDA
-    ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_CUDA(session_options, 0));
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_CUDA(session_options, 0));
     std::cout << "Running simple inference with cuda provider" << std::endl;
 #else
     return;
 #endif
   } else if (provider_type == 2) {
 #ifdef USE_MKLDNN
-    ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_Mkldnn(session_options, 1));
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Mkldnn(session_options, 1));
     std::cout << "Running simple inference with mkldnn provider" << std::endl;
 #else
     return;
 #endif
   } else if (provider_type == 3) {
 #ifdef USE_NUPHAR
-    ORT_THROW_ON_ERROR(OrtSessionOptionsAppendExecutionProvider_Nuphar(session_options, /*allow_unaligned_buffers*/ 1, ""));
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Nuphar(session_options, /*allow_unaligned_buffers*/ 1, ""));
     std::cout << "Running simple inference with nuphar provider" << std::endl;
 #else
     return;
@@ -292,7 +290,7 @@ TEST_F(CApiTest, create_tensor) {
 
   Ort::Value tensor = Ort::Value::CreateTensor(default_allocator.get(), &expected_len, 1, ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING);
 
-  ORT_THROW_ON_ERROR(g_ort->FillStringTensor(tensor, s, expected_len));
+  Ort::ThrowOnError(Ort::GetApi().FillStringTensor(tensor, s, expected_len));
   auto shape_info = tensor.GetTensorTypeAndShapeInfo();
 
   int64_t len = shape_info.GetElementCount();
@@ -337,7 +335,7 @@ TEST_F(CApiTest, override_initializer) {
   Ort::Value f2_input_tensor = Ort::Value::CreateTensor(allocator.get(), dims.data(), dims.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING);
   // No C++ Api to either create a string Tensor or to fill one with string, so we use C
   const char* const input_char_string[] = {f2_data.c_str()};
-  ORT_THROW_ON_ERROR(g_ort->FillStringTensor(static_cast<OrtValue*>(f2_input_tensor), input_char_string, 1U));
+  Ort::ThrowOnError(Ort::GetApi().FillStringTensor(static_cast<OrtValue*>(f2_input_tensor), input_char_string, 1U));
 
   Ort::SessionOptions session_options;
   Ort::Session session(env_, OVERRIDABLE_INITIALIZER_MODEL_URI, session_options);

--- a/onnxruntime/test/util/test_allocator.cc
+++ b/onnxruntime/test/util/test_allocator.cc
@@ -3,18 +3,16 @@
 
 #include "test_allocator.h"
 
-extern const OrtApi* g_ort;
-
 MockedOrtAllocator::MockedOrtAllocator() {
   OrtAllocator::version = ORT_API_VERSION;
   OrtAllocator::Alloc = [](OrtAllocator* this_, size_t size) { return static_cast<MockedOrtAllocator*>(this_)->Alloc(size); };
   OrtAllocator::Free = [](OrtAllocator* this_, void* p) { static_cast<MockedOrtAllocator*>(this_)->Free(p); };
   OrtAllocator::Info = [](const OrtAllocator* this_) { return static_cast<const MockedOrtAllocator*>(this_)->Info(); };
-  ORT_THROW_ON_ERROR(g_ort->CreateCpuMemoryInfo(OrtDeviceAllocator, OrtMemTypeDefault, &cpu_memory_info));
+  Ort::ThrowOnError(Ort::GetApi().CreateCpuMemoryInfo(OrtDeviceAllocator, OrtMemTypeDefault, &cpu_memory_info));
 }
 
 MockedOrtAllocator::~MockedOrtAllocator() {
-	g_ort->ReleaseMemoryInfo(cpu_memory_info);
+  Ort::GetApi().ReleaseMemoryInfo(cpu_memory_info);
 }
 
 void* MockedOrtAllocator::Alloc(size_t size) {

--- a/samples/c_cxx/MNIST/MNIST.cpp
+++ b/samples/c_cxx/MNIST/MNIST.cpp
@@ -37,7 +37,7 @@ struct MNIST {
 
   std::array<float, width_ * height_> input_image_{};
   std::array<float, 10> results_{};
-  int result_{0};
+  int64_t result_{0};
 
  private:
   Ort::Session session_{env, L"model.onnx", Ort::SessionOptions{nullptr}};
@@ -94,7 +94,7 @@ void ConvertDibToMnist() {
 LRESULT CALLBACK WndProc(HWND, UINT, WPARAM, LPARAM);
 
 // The Windows entry point function
-int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPTSTR lpCmdLine,
+int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance*/, _In_ LPTSTR /*lpCmdLine*/,
                       _In_ int nCmdShow) {
   {
     WNDCLASSEX wc{};
@@ -124,7 +124,8 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
   hdc_dib_ = CreateCompatibleDC(nullptr);
   SelectObject(hdc_dib_, dib_);
   SelectObject(hdc_dib_, CreatePen(PS_SOLID, 2, RGB(0, 0, 0)));
-  FillRect(hdc_dib_, &RECT{0, 0, MNIST::width_, MNIST::height_}, (HBRUSH)GetStockObject(WHITE_BRUSH));
+  RECT rect{0, 0, MNIST::width_, MNIST::height_};
+  FillRect(hdc_dib_, &rect, (HBRUSH)GetStockObject(WHITE_BRUSH));
 
   HWND hWnd = CreateWindow(L"ONNXTest", L"ONNX Runtime Sample - MNIST", WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, 512, 256, nullptr, nullptr, hInstance, nullptr);
   if (!hWnd)
@@ -217,9 +218,12 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) 
       return 0;
 
     case WM_RBUTTONDOWN:  // Erase the image
-      FillRect(hdc_dib_, &RECT{0, 0, MNIST::width_, MNIST::height_}, (HBRUSH)GetStockObject(WHITE_BRUSH));
+    {
+      RECT rect{0, 0, MNIST::width_, MNIST::height_};
+      FillRect(hdc_dib_, &rect, (HBRUSH)GetStockObject(WHITE_BRUSH));
       InvalidateRect(hWnd, nullptr, false);
       return 0;
+    }
 
     case WM_DESTROY:
       PostQuitMessage(0);

--- a/samples/c_cxx/imagenet/image_loader.cc
+++ b/samples/c_cxx/imagenet/image_loader.cc
@@ -176,8 +176,8 @@ void InceptionPreprocessing::operator()(_In_ const void* input_data,
   }
   float* float_file_data_pointer;
   int bbox_h_size, bbox_w_size;
-  ORT_THROW_ON_ERROR(LoadImageFromFileAndCrop(image_loader_, file_name.c_str(), central_fraction_,
-                                              &float_file_data_pointer, &bbox_w_size, &bbox_h_size));
+  Ort::ThrowOnError(LoadImageFromFileAndCrop(image_loader_, file_name.c_str(), central_fraction_,
+                                             &float_file_data_pointer, &bbox_w_size, &bbox_h_size));
   auto output_data_ = reinterpret_cast<float*>(output_data);
   ResizeImageInMemory(float_file_data_pointer, output_data_, bbox_h_size, bbox_w_size, out_height_, out_width_,
                       channels_);

--- a/samples/c_cxx/imagenet/image_loader.h
+++ b/samples/c_cxx/imagenet/image_loader.h
@@ -17,7 +17,7 @@ void ResizeImageInMemory(const T* input_data, float* output_data, int in_height,
 template <typename InputType>
 class OutputCollector {
  public:
-  virtual void operator()(const std::vector<InputType>& task_id_list, const OrtValue* tensor) = 0;
+  virtual void operator()(const std::vector<InputType>& task_id_list, const Ort::Value& tensor) = 0;
   // Release the internal cache. It need be called whenever batchsize is changed
   virtual void ResetCache() = 0;
   virtual ~OutputCollector() = default;
@@ -36,6 +36,7 @@ class InceptionPreprocessing : public DataProcessing {
   const int channels_;
   const double central_fraction_ = 0.875;
   void* image_loader_;
+
  public:
   InceptionPreprocessing(int out_height, int out_width, int channels);
 

--- a/samples/c_cxx/imagenet/image_loader_wic.cc
+++ b/samples/c_cxx/imagenet/image_loader_wic.cc
@@ -15,11 +15,10 @@ bool CreateImageLoader(void** out) {
   return true;
 }
 
-void ReleaseImageLoader(void* p){
+void ReleaseImageLoader(void* p) {
   auto piFactory = reinterpret_cast<IWICImagingFactory*>(p);
   piFactory->Release();
 }
-
 
 template <typename T>
 static void PrintErrorDescription(HRESULT hr, std::basic_ostringstream<T>& oss) {
@@ -48,9 +47,9 @@ OrtStatus* LoadImageFromFileAndCrop(void* loader, const ORTCHAR_T* filename, dou
 
     UINT count = 0;
     ATLENSURE_SUCCEEDED(piDecoder->GetFrameCount(&count));
-    if(count != 1){
-	   return OrtCreateStatus(ORT_FAIL, "The image has multiple frames, I don't know which to choose");
-	}
+    if (count != 1) {
+      return Ort::GetApi().CreateStatus(ORT_FAIL, "The image has multiple frames, I don't know which to choose");
+    }
 
     CComPtr<IWICBitmapFrameDecode> piFrameDecode;
     ATLENSURE_SUCCEEDED(piDecoder->GetFrame(0, &piFrameDecode));
@@ -96,11 +95,11 @@ OrtStatus* LoadImageFromFileAndCrop(void* loader, const ORTCHAR_T* filename, dou
   } catch (std::exception& ex) {
     std::ostringstream oss;
     oss << "Load " << filename << " failed:" << ex.what();
-    return OrtCreateStatus(ORT_FAIL, oss.str().c_str());
+    return Ort::GetApi().CreateStatus(ORT_FAIL, oss.str().c_str());
   } catch (const CAtlException& ex) {
     std::ostringstream oss;
     oss << "Load " << filename << " failed:";
     PrintErrorDescription(ex.m_hr, oss);
-    return OrtCreateStatus(ORT_FAIL, oss.str().c_str());
+    return Ort::GetApi().CreateStatus(ORT_FAIL, oss.str().c_str());
   }
 }


### PR DESCRIPTION
This simplifies all of the calling code since nobody needs to declare the Ort::api_ variable anymore. This makes it easier for users to use and understand.

This also fixes the MNIST CXX sample code.

I also added more comments into the CXX header to explain more things.