### PR TITLE
Added Graph::ReplaceInitializedTensor() function.

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -493,6 +493,14 @@ class Graph {
   /** Remove the initializer tensor with the provided name from the Graph. */
   void RemoveInitializedTensor(const std::string& tensor_name);
 
+  /** Replaces the initializer tensor with the same name as the given initializer tensor.
+  The replacement initializer tensor must have the same type and shape as the existing initializer tensor.
+
+  Note: This currently has linear time complexity. There is room for improvement but it would likely require changes to
+  how initializer tensors are stored and tracked.
+  */
+  common::Status ReplaceInitializedTensor(const ONNX_NAMESPACE::TensorProto& new_initializer);
+
   /** Gets an initializer tensor with the provided name.
   @param[out] value Set to the TensorProto* if the initializer is found, or nullptr if not.
   @returns True if found.

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -6,6 +6,7 @@
 #pragma warning(disable : 4244)
 #endif
 
+#include <cassert>
 #include <fstream>
 #include <iostream>
 #include <numeric>
@@ -2053,6 +2054,39 @@ void Graph::RemoveInitializedTensor(const std::string& tensor_name) {
     SetGraphProtoSyncNeeded();
     SetGraphResolveNeeded();
   }
+}
+
+Status Graph::ReplaceInitializedTensor(const ONNX_NAMESPACE::TensorProto& new_initializer) {
+  const auto& initializer_name = new_initializer.name();
+  auto name_to_initializer_it = name_to_initial_tensor_.find(initializer_name);
+  ORT_RETURN_IF_NOT(name_to_initializer_it != name_to_initial_tensor_.end(),
+                    "Failed to find existing initializer with name ", initializer_name, ".");
+
+  assert(name_to_initializer_it->second);
+  const auto& old_initializer = *(name_to_initializer_it->second);
+
+  auto dims_eq = [&old_initializer, &new_initializer]() {
+    if (old_initializer.dims_size() != new_initializer.dims_size()) return false;
+    for (int i = 0; i < old_initializer.dims_size(); ++i) {
+      if (old_initializer.dims(i) != new_initializer.dims(i)) return false;
+    }
+    return true;
+  };
+
+  ORT_RETURN_IF_NOT(dims_eq(), "Replacement tensor's dimensions do not match.");
+  ORT_RETURN_IF_NOT(old_initializer.data_type() == new_initializer.data_type(),
+                    "Replacement tensor's data type does not match.");
+
+  auto& mutable_initializers = *graph_proto_->mutable_initializer();
+  auto old_mutable_initializer_ptr_it = std::find(
+      mutable_initializers.pointer_begin(), mutable_initializers.pointer_end(), &old_initializer);
+  assert(old_mutable_initializer_ptr_it != mutable_initializers.pointer_end());
+  assert(*old_mutable_initializer_ptr_it);
+  auto& old_mutable_initializer = **old_mutable_initializer_ptr_it;
+
+  old_mutable_initializer = new_initializer;
+
+  return Status::OK();
 }
 
 bool Graph::GetInitializedTensor(const std::string& tensor_name, const TensorProto*& value) const {

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2062,7 +2062,6 @@ Status Graph::ReplaceInitializedTensor(const ONNX_NAMESPACE::TensorProto& new_in
   ORT_RETURN_IF_NOT(name_to_initializer_it != name_to_initial_tensor_.end(),
                     "Failed to find existing initializer with name ", initializer_name, ".");
 
-  assert(name_to_initializer_it->second);
   const auto& old_initializer = *(name_to_initializer_it->second);
 
   auto dims_eq = [&old_initializer, &new_initializer]() {
@@ -2080,7 +2079,7 @@ Status Graph::ReplaceInitializedTensor(const ONNX_NAMESPACE::TensorProto& new_in
   auto& mutable_initializers = *(graph_proto_->mutable_initializer());
   auto old_mutable_initializer_ptr_it = std::find(
       mutable_initializers.pointer_begin(), mutable_initializers.pointer_end(), &old_initializer);
-  assert(old_mutable_initializer_ptr_it != mutable_initializers.pointer_end());
+  ORT_ENFORCE(old_mutable_initializer_ptr_it != mutable_initializers.pointer_end());
   auto& old_mutable_initializer = **old_mutable_initializer_ptr_it;
 
   old_mutable_initializer = new_initializer;

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2083,7 +2083,8 @@ Status Graph::ReplaceInitializedTensor(const ONNX_NAMESPACE::TensorProto& new_in
   auto& mutable_initializers = *(graph_proto_->mutable_initializer());
   auto old_mutable_initializer_ptr_it = std::find(
       mutable_initializers.pointer_begin(), mutable_initializers.pointer_end(), &old_initializer);
-  ORT_ENFORCE(old_mutable_initializer_ptr_it != mutable_initializers.pointer_end());
+  ORT_ENFORCE(old_mutable_initializer_ptr_it != mutable_initializers.pointer_end(),
+              "graph_proto_ is not in sync with name_to_initial_tensor_");
   auto& old_mutable_initializer = **old_mutable_initializer_ptr_it;
 
   old_mutable_initializer = new_initializer;

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2058,7 +2058,7 @@ void Graph::RemoveInitializedTensor(const std::string& tensor_name) {
 
 Status Graph::ReplaceInitializedTensor(const ONNX_NAMESPACE::TensorProto& new_initializer) {
   const auto& initializer_name = new_initializer.name();
-  auto name_to_initializer_it = name_to_initial_tensor_.find(initializer_name);
+  const auto name_to_initializer_it = name_to_initial_tensor_.find(initializer_name);
   ORT_RETURN_IF_NOT(name_to_initializer_it != name_to_initial_tensor_.end(),
                     "Failed to find existing initializer with name ", initializer_name, ".");
 
@@ -2077,11 +2077,10 @@ Status Graph::ReplaceInitializedTensor(const ONNX_NAMESPACE::TensorProto& new_in
   ORT_RETURN_IF_NOT(old_initializer.data_type() == new_initializer.data_type(),
                     "Replacement tensor's data type does not match.");
 
-  auto& mutable_initializers = *graph_proto_->mutable_initializer();
+  auto& mutable_initializers = *(graph_proto_->mutable_initializer());
   auto old_mutable_initializer_ptr_it = std::find(
       mutable_initializers.pointer_begin(), mutable_initializers.pointer_end(), &old_initializer);
   assert(old_mutable_initializer_ptr_it != mutable_initializers.pointer_end());
-  assert(*old_mutable_initializer_ptr_it);
   auto& old_mutable_initializer = **old_mutable_initializer_ptr_it;
 
   old_mutable_initializer = new_initializer;

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2057,6 +2057,10 @@ void Graph::RemoveInitializedTensor(const std::string& tensor_name) {
 }
 
 Status Graph::ReplaceInitializedTensor(const ONNX_NAMESPACE::TensorProto& new_initializer) {
+  // name_to_initial_tensor_ maps from name to const TensorProto*, so we first
+  // look up the const pointer by name, then find and modify the mutable
+  // pointed-to TensorProto in graph_proto_.
+
   const auto& initializer_name = new_initializer.name();
   const auto name_to_initializer_it = name_to_initial_tensor_.find(initializer_name);
   ORT_RETURN_IF_NOT(name_to_initializer_it != name_to_initial_tensor_.end(),


### PR DESCRIPTION
**Description**: Added Graph::ReplaceInitializedTensor() function to support updating existing initializers.

**Motivation and Context**
- Why is this change required? What problem does it solve?
  - The new function allows users to update an existing initializer value directly. A motivating example usage is updating weight values.
