### PR TITLE
Jeffbloo/fix dml rnn failures

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/AbiCustomRegistry.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/AbiCustomRegistry.cpp
@@ -499,10 +499,17 @@ HRESULT STDMETHODCALLTYPE AbiCustomRegistry::RegisterOperatorKernel(
         registration->requiresFloatFormatsExceptConstInputs = requiresFloatFormatsForGraph;
         registration->requiredConstantCpuInputs = constantCpuInputCapture;
 
-        (*m_graphNodeFactoryMap)[create_info.kernel_def.get()] = registration;
+        // TODO: Propagate errors here once the presence of overlapping built-in DML kernels is addressed
+        if (m_kernelRegistry->RegisterCustomKernel(create_info).IsOK())
+        {
+            (*m_graphNodeFactoryMap)[create_info.kernel_def.get()] = registration;
+        }
     }
-
-    m_kernelRegistry->RegisterCustomKernel(create_info);
+    else
+    {
+        // For backward compatibility, this does not propagate errors
+        m_kernelRegistry->RegisterCustomKernel(create_info);
+    }
 
     return S_OK;
 }

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -545,11 +545,6 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     broken_tests.insert({"fp16_inception_v1", "Temporarily disabled pending investigation"});
     broken_tests.insert({"candy", "Temporarily disabled pending investigation"});
     broken_tests.insert({"BERT_Squad", "Temporarily disabled pending investigation"});
-    broken_tests.insert({"simple_rnn_defaults", "Temporarily disabled pending investigation"});
-    broken_tests.insert({"simple_rnn_with_initial_bias", "Temporarily disabled pending investigation"});
-    broken_tests.insert({"gru_with_initial_bias", "Temporarily disabled pending investigation"});
-    broken_tests.insert({"lstm_with_peephole", "Temporarily disabled pending investigation"});
-    broken_tests.insert({"gru_defaults", "Temporarily disabled pending investigation"});
   }
 #endif
   // clang-format on

--- a/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
@@ -5,7 +5,7 @@ jobs:
     AgentDemands: 'Has19H1WinSDK'
     DoDebugBuild: 'true'
     DoCompliance: 'false'
-    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --enable_pybind --use_mkldnn --build_shared_lib  --build_csharp --enable_onnx_tests --use_cuda --cuda_version=10.0 --cuda_home="C:\local\cuda_10.0.130_win10_trt6015dll" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --gen_doc'
+    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --enable_pybind --use_mkldnn --use_dml --build_shared_lib  --build_csharp --enable_onnx_tests --use_cuda --cuda_version=10.0 --cuda_home="C:\local\cuda_10.0.130_win10_trt6015dll" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.3.1.20\cuda" --gen_doc'
     JobName: 'Windows_CI_GPU_Dev'
     DoNugetPack:  'false'
     NuPackScript : ''


### PR DESCRIPTION
**Description**: 
The DML EP maintain maps between raw ORT KernelDef pointers and the functors used to create its own nodes within DML graph partitions.  This way, it can always let ORT manage resolving registrations, and have more shared code paths.

This was always inherently fragile, because it assumes the lifetime of KernelDefs exceeds that of the DML EP.  There's now a case where this isn’t true.  A separate issue of overlapping DML kernel registrations can result in map entries which key off a pointer that's freed.  This leads to problems for operators which are not expected to have entries in this map (RNN, GRU, LSTM, and ConstantOfShape), if they share an address with that freed pointer.

While addressing the underlying fragility will be nice, this is a scoped fix through better error checking.

**Motivation and Context**
This is believed to have caused sporadic failures with RNN models.  Some of the affected backend test cases were previously disabled, then the DML build was disabled after additional failures were encountered.