### PR TITLE
Disable optimizers for OpTester operator unit tests 

### DIFF
--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -1486,7 +1486,7 @@ TEST(InferenceSessionTests, TestLenientShapeInferencing) {
                    "Mismatch between number of source and target dimensions. Source=1 Target=2");
 
   // older opset should allow the mismatch with a warning.
-  // we also need for the output to be valid so OpTester doesn't throw so add an Unsqueeze after the Shape. 
+  // we also need for the output to be valid so OpTester doesn't throw so add an Unsqueeze after the Shape.
   // This should result in a warning log message but successful run.
   class OpTesterWithReshape : public OpTester {
    public:
@@ -1518,7 +1518,8 @@ TEST(InferenceSessionTests, TestLenientShapeInferencing) {
 
   old_opset.AddInput("data", input_shape, input_data);
   old_opset.AddOutput<int64_t>("output", invalid_output_shape, output_data);
-  old_opset.Run();
+  // TensorRT doesn't handle Unsqueeze
+  old_opset.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
 #ifdef USE_CUDA

--- a/onnxruntime/test/providers/provider_test_utils.cc
+++ b/onnxruntime/test/providers/provider_test_utils.cc
@@ -514,14 +514,11 @@ void OpTester::Run(ExpectResult expect_result,
   so.session_logid = op_;
   so.session_log_verbosity_level = 1;
   so.execution_mode = execution_mode;
-  // TODO: Optimizers should be off by default so we test the operator as is, however currently
-  // Scan9.OuterScopeAccess_ShapeInMainGraph_NoTypeAndShapeInSubgraph fails with nuphar. See Bug 525222.
-  // Uncomment this line once that is addressed.
-  // so.graph_optimization_level = TransformerLevel::Default;  // 'Default' == off
+  so.graph_optimization_level = TransformerLevel::Default;  // 'Default' == off
   Run(so, expect_result, expected_failure_string, excluded_provider_types, run_options, execution_providers);
 }
 
-void OpTester::Run(SessionOptions so, // Take the SessionOptions by value (i.e. make a copy) because we may need to modify it
+void OpTester::Run(SessionOptions so,  // Take the SessionOptions by value (i.e. make a copy) because we may need to modify it
                    ExpectResult expect_result,
                    const std::string& expected_failure_string,
                    const std::unordered_set<std::string>& excluded_provider_types,
@@ -574,8 +571,7 @@ void OpTester::Run(SessionOptions so, // Take the SessionOptions by value (i.e. 
         kBrainSliceExecutionProvider,
         kTensorrtExecutionProvider,
         kOpenVINOExecutionProvider,
-        kDmlExecutionProvider
-    };
+        kDmlExecutionProvider};
 
     bool has_run = false;
 


### PR DESCRIPTION
**Description**: 
If optimizers run they can modify the node being tested, which would be an unexpected background change in the context of the operator unit tests. Disable the optimizers in OpTester. 

Disable TensorRT for Scan9 unit tests that fails when optimizers are enabled. Bug 525222 tracks that.

**Motivation and Context**
Prevent unexpected changes happening in the background when unit testing operators.