### PR TITLE
NCHWc: Handle Concat opset version 11

### DIFF
--- a/onnxruntime/core/optimizer/nchwc_transformer.cc
+++ b/onnxruntime/core/optimizer/nchwc_transformer.cc
@@ -684,7 +684,7 @@ void NchwcTransformerImpl::Transform(Node& node) {
     if (graph_utils::IsSupportedOptypeVersionAndDomain(node, "Add", {7}) ||
         graph_utils::IsSupportedOptypeVersionAndDomain(node, "Sum", {6, 8})) {
       TransformAdd(node);
-    } else if (graph_utils::IsSupportedOptypeVersionAndDomain(node, "Concat", {4})) {
+    } else if (graph_utils::IsSupportedOptypeVersionAndDomain(node, "Concat", {4, 11})) {
       TransformConcat(node);
     } else if (graph_utils::IsSupportedOptypeVersionAndDomain(node, "Relu", {6})) {
       TransformActivation(node);


### PR DESCRIPTION
**Description**:
The NCHWc optimization for Concat is not working for opset version 11 models because the list of expected domain versions was not updated.

**Motivation and Context**
Models built to opset version 11 won't have the Concat optimization to avoid extra tensor reorders without this change, so they will be slower than opset version 10.

The NCHWc unit test has been updated to use opset version 11 by default (an existing test already broke doing just this change). As a result of this change, the handling of Clip also needed to be updated.