### PR TITLE
Remove the OrtApiBase base_ member from OrtApi

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
@@ -16,7 +16,6 @@ namespace Microsoft.ML.OnnxRuntime
     [StructLayout(LayoutKind.Sequential)]
     public struct OrtApi
     {
-        public OrtApiBase base_;
         public IntPtr CreateStatus;
         public IntPtr GetErrorCode;
         public IntPtr GetErrorMessage;

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -220,8 +220,6 @@ typedef struct OrtApiBase OrtApiBase;
 ORT_EXPORT const OrtApiBase* ORT_API_CALL OrtGetApiBase() NO_EXCEPTION;
 
 struct OrtApi {
-  OrtApiBase base_;
-
   /**
 * \param msg A null-terminated string. Its content will be copied into the newly created OrtStatus
 */

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1279,8 +1279,6 @@ static constexpr OrtApiBase ort_api_base = {
 };
 
 static constexpr OrtApi ort_api_1 = {
-    ort_api_base,
-
     &OrtApis::CreateStatus,
     &OrtApis::GetErrorCode,
     &OrtApis::GetErrorMessage,


### PR DESCRIPTION
**Description**: This removes the base_ member from OrtApi since it's not needed (can just pass OrtApiBase* for when someone doesn't know what version they require).

This must be in by 1.0 since it breaks the ABI