### PR TITLE
Add default params to Env C++ constructor

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -114,7 +114,7 @@ struct Value;
 
 struct Env : Base<OrtEnv> {
   Env(std::nullptr_t) {}
-  Env(OrtLoggingLevel default_logging_level, _In_ const char* logid);
+  Env(OrtLoggingLevel default_logging_level = ORT_LOGGING_LEVEL_WARNING, _In_ const char* logid = "");
   Env(OrtLoggingLevel default_logging_level, const char* logid, OrtLoggingFunction logging_function, void* logger_param);
   explicit Env(OrtEnv* p) : Base<OrtEnv>{p} {}
 


### PR DESCRIPTION
**Description**: Very straightforward, just adds default parameters so that users have an example they can follow when first creating the Env. This makes our C++ API easier to use.
