### PR TITLE
Fix csharp CXX sample

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/CXX_Api_Sample.cpp
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/CXX_Api_Sample.cpp
@@ -6,8 +6,6 @@
 #include <vector>
 #include <onnxruntime_cxx_api.h>
 
-const OrtApi* Ort::g_api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-
 int main(int argc, char* argv[]) {
   //*************************************************************************
   // initialize  enviroment...one enviroment per process


### PR DESCRIPTION
**Description**: The csharp C++ sample file wasn't updated for the recent header simplifications.

Trivial fix, just remove the line that is no longer needed.
