### PR TITLE
Revert to using opset 7 as the default for OpTester. 

### DIFF
--- a/onnxruntime/test/contrib_ops/element_wise_ops_test.cc
+++ b/onnxruntime/test/contrib_ops/element_wise_ops_test.cc
@@ -13,7 +13,7 @@ namespace onnxruntime {
 namespace test {
 
 TEST(MathOpTest, AffineDefaultAttributes) {
-  OpTester test("Affine", 7);
+  OpTester test("Affine");
   std::vector<int64_t> dims{2, 2};
   test.AddInput<float>("A", dims, {0.0f, 1.0f, 2.0f, 3.0f});
   test.AddOutput<float>("B", dims, {0.0f, 1.0f, 2.0f, 3.0f});
@@ -21,7 +21,7 @@ TEST(MathOpTest, AffineDefaultAttributes) {
 }
 
 TEST(MathOpTest, Affine) {
-  OpTester test("Affine", 7);
+  OpTester test("Affine");
   std::vector<int64_t> dims{2, 2};
   test.AddAttribute("alpha", 2.0f);
   test.AddAttribute("beta", 1.0f);
@@ -31,7 +31,7 @@ TEST(MathOpTest, Affine) {
 }
 
 TEST(MathOpTest, Scale) {
-  OpTester test("Scale", 7);
+  OpTester test("Scale");
   std::vector<int64_t> dims{2, 2};
   test.AddAttribute("scale", 2.0f);
   test.AddInput<float>("A", dims, {0.0f, 1.0f, 2.0f, 3.0f});
@@ -40,7 +40,7 @@ TEST(MathOpTest, Scale) {
 }
 
 TEST(MathOpTest, Scale_Default) {
-  OpTester test("Scale", 7);
+  OpTester test("Scale");
   std::vector<int64_t> dims{2, 2};
   test.AddInput<float>("A", dims, {0.0f, 1.0f, 2.0f, 3.0f});
   test.AddOutput<float>("B", dims, {0.0f, 1.0f, 2.0f, 3.0f});

--- a/onnxruntime/test/contrib_ops/tensor_op_test.cc
+++ b/onnxruntime/test/contrib_ops/tensor_op_test.cc
@@ -28,7 +28,7 @@ TEST(CropContribOpTest, CropBorderOnly) {
 
       5.0f, 6.0f};
 
-  OpTester test("Crop", 7);
+  OpTester test("Crop");
   test.AddAttribute("border", border);
   test.AddInput<float>("input", {N, C, H, W}, X);
   test.AddOutput<float>("output", {N, C, (H - border[2] - border[0]), (W - border[3] - border[1])}, output);
@@ -55,7 +55,7 @@ TEST(CropContribOpTest, CropBorderAndScale) {
       4.0f, 5.0f,
       5.0f, 6.0f};
 
-  OpTester test("Crop", 7);
+  OpTester test("Crop");
   test.AddAttribute("border", border);
   test.AddAttribute("scale", scale);
   test.AddInput<float>("input", {N, C, H, W}, X);
@@ -82,7 +82,7 @@ TEST(ImageScalerContribOpTest, ImageScalerTest) {
       8.0f, 12.0f,
       16.0f, 20.0f};
 
-  OpTester test("ImageScaler", 7);
+  OpTester test("ImageScaler");
   test.AddAttribute("scale", scale);
   test.AddAttribute("bias", bias);
   test.AddInput<float>("input", {N, C, H, W}, X);

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -1479,7 +1479,7 @@ TEST(InferenceSessionTests, TestLenientShapeInferencing) {
   std::vector<int64_t> invalid_output_shape{1, 2};  // valid shape is {2} as output data is input_shape
   std::vector<int64_t> output_data{2, 2};
 
-  OpTester latest_opset("Shape");
+  OpTester latest_opset("Shape", -1);  // use latest opset for shape inference errors
   latest_opset.AddInput("data", input_shape, input_data);
   latest_opset.AddOutput<int64_t>("output", invalid_output_shape, output_data);
   latest_opset.Run(OpTester::ExpectResult::kExpectFailure,

--- a/onnxruntime/test/providers/cpu/controlflow/scan_test.cc
+++ b/onnxruntime/test/providers/cpu/controlflow/scan_test.cc
@@ -575,6 +575,7 @@ TEST(Scan9, BadShape) {
       "Node:concat Output:concat_out_1 [ShapeInferenceError] Mismatch between number of source and target dimensions. "
       "Source=2 Target=1");
 }
+
 TEST(Scan8, ShortSequenceTwoInBatchOneLoopStateVar) {
   const int64_t batch_size = 2;
   const int64_t sequence_len = 2;

--- a/onnxruntime/test/providers/cpu/math/clip_test.cc
+++ b/onnxruntime/test/providers/cpu/math/clip_test.cc
@@ -64,7 +64,7 @@ TEST(MathOpTest, Clip) {
 TEST(MathOpTest, ClipDimWithZero) {
   std::vector<int64_t> dims{3, 0};  // dim with value of zero should be handled
 
-  OpTester test("Clip");
+  OpTester test("Clip", -1);  // latest opset
   test.AddInput<float>("X", dims, {});
   test.AddInput<float>("min", {}, {-5});
   test.AddInput<float>("max", {}, {5});
@@ -73,7 +73,7 @@ TEST(MathOpTest, ClipDimWithZero) {
   // nGraph and Tensorrt does not support Clip opset 11 yet.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kNGraphExecutionProvider, kTensorrtExecutionProvider});
 
-  OpTester test1("Clip", 7);  //
+  OpTester test1("Clip");  //
   test1.AddInput<float>("X", dims, {});
   test1.AddAttribute("min", -10.0f);
   test1.AddAttribute("max", 10.0f);

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -46,7 +46,7 @@ TEST(BroadcastingTest, DimWithZeroHandling) {
   run(test3);
 
   // test that BroadcastLoopSpan also works. Mod uses that
-  OpTester test4("Mod");
+  OpTester test4("Mod", 10);
   test4.AddInput<int64_t>("A", {2, 2, 0}, {});
   test4.AddInput<int64_t>("B", {2, 1}, {1, 2});
   test4.AddOutput<int64_t>("C", {2, 2, 0}, {});

--- a/onnxruntime/test/providers/cpu/math/logsoftmax_test.cc
+++ b/onnxruntime/test/providers/cpu/math/logsoftmax_test.cc
@@ -15,8 +15,9 @@ static void RunTest(const std::vector<float>& x_vals,
                     int64_t axis = 1,
                     bool is_tensorrt_supported = true,
                     OpTester::ExpectResult expect_result = OpTester::ExpectResult::kExpectSuccess,
-                    const std::string& error_msg = "") {
-  OpTester tester("LogSoftmax");
+                    const std::string& error_msg = "",
+                    int opset = 7) {
+  OpTester tester("LogSoftmax", opset);
 
   if (axis != 1) {
     tester.AddAttribute("axis", axis);
@@ -196,7 +197,9 @@ TEST(LogSoftmaxOperator, InvalidAxis) {
           OpTester::ExpectResult::kExpectFailure,
           // ONNX has a bug in the error message generation so this is somewhat cryptic until it's fixed. Message should be:
           // "[ShapeInferenceError] 'axis' must be in [-2 , 1]. Its actual value is: -7"
-          ", 1]. Its actual value is: -7");  //TensorRT parser: Assertion failed: axis >= 0 && axis < nbDims
+          ", 1]. Its actual value is: -7",
+          //latest opset so we get shape inferencing errrors
+          -1);  //TensorRT parser: Assertion failed: axis >= 0 && axis < nbDims
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/cpu/math/softmax_test.cc
+++ b/onnxruntime/test/providers/cpu/math/softmax_test.cc
@@ -15,7 +15,7 @@ static void RunTest(const std::vector<float>& x_vals,
                     bool is_tensorrt_supported = true,
                     OpTester::ExpectResult expect_result = OpTester::ExpectResult::kExpectSuccess,
                     const std::string& error_msg = "",
-                    int opset = -1) {
+                    int opset = 7) {
   OpTester test("Softmax", opset);
 
   if (axis != 1) {
@@ -191,7 +191,9 @@ TEST(SoftmaxOperator, InvalidAxis) {
           OpTester::ExpectResult::kExpectFailure,
           // bug in ONNX error message currently. Message should be
           // "[ShapeInferenceError] 'axis' must be in [-2 , 1]. Its actual value is: -10"
-          ", 1]. Its actual value is: -10");
+          ", 1]. Its actual value is: -10",
+          // latest opset so we get shape inferencing errors
+          -1);
 }
 
 TEST(SoftmaxOperator, DimWithZero) {

--- a/onnxruntime/test/providers/cpu/nn/conv_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_op_test.cc
@@ -26,7 +26,7 @@ void TestConvOp(const ConvOpAndTestAttributes& attributes,
                 const vector<int64_t>& expected_output_shape,
                 OpTester::ExpectResult expect_result = OpTester::ExpectResult::kExpectSuccess,
                 const std::string& err_str = "",
-                int opset = -1) {
+                int opset = 7) {
   OpTester test("Conv", opset);
   test.AddAttribute("auto_pad", attributes.auto_pad);
   test.AddAttribute("group", attributes.group);
@@ -219,7 +219,8 @@ TEST(ConvTest, Conv1D_Invalid_Input_Shape) {
   TestConvOp(attrs, {X, dummy_vals}, {X_shape, dummy_shape}, dummy_vals, dummy_shape,
              OpTester::ExpectResult::kExpectFailure,
              "Node:node1 Output:Y [ShapeInferenceError] Can't merge shape info. "
-             "Both source and target dimension have values but they differ. Source=0 Target=2 Dimension=2");
+             "Both source and target dimension have values but they differ. Source=0 Target=2 Dimension=2",
+             -1);  // use latest opset for shape inferencing errors
 }
 
 TEST(ConvTest, Conv2D_Invalid_Input_Shape) {
@@ -241,7 +242,8 @@ TEST(ConvTest, Conv2D_Invalid_Input_Shape) {
   TestConvOp(attrs, {X, dummy_vals}, {X_shape, dummy_shape}, dummy_vals, dummy_shape,
              OpTester::ExpectResult::kExpectFailure,
              "Node:node1 Output:Y [ShapeInferenceError] Can't merge shape info. "
-             "Both source and target dimension have values but they differ. Source=1 Target=2 Dimension=0");
+             "Both source and target dimension have values but they differ. Source=1 Target=2 Dimension=0",
+             -1);  // use latest opset for shape inferencing errors
 }
 
 // Conv30

--- a/onnxruntime/test/providers/cpu/nn/tfidfvectorizer_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/tfidfvectorizer_test.cc
@@ -10,6 +10,8 @@ namespace onnxruntime {
 namespace test {
 namespace tfidfvectorizer_test {
 
+const int opset_ver = 9;
+
 void InitTestAttr(OpTester& test, const std::string& mode,
                   int64_t min_gram_length, int64_t max_gram_length, int64_t max_skip_count,
                   const std::vector<int64_t>& ngram_counts,
@@ -46,7 +48,7 @@ using namespace tfidfvectorizer_test;
 // into consideration or not.With all = false, we only consider N - grams.
 
 TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_Skip0) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=0, Min=Max=2, weights empty, int32
   InitTestAttr(test, "TF", 2, 2, 0,
                {0, 4},
@@ -68,7 +70,7 @@ TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_Skip0) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_Skip0_Empty_Dim1Fail) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", -1);  // latest opset so we get shape inferencing errors
   // s=0, Min=Max=2, weights empty, int32
   InitTestAttr(test, "TF", 2, 2, 0,
                {0, 4},
@@ -92,7 +94,7 @@ TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_Skip0_Empty_Dim1Fail) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_Skip0_Empty_Dim1Success) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=0, Min=Max=2, weights empty, int32
   InitTestAttr(test, "TF", 2, 2, 0,
                {0, 4},
@@ -114,7 +116,7 @@ TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_Skip0_Empty_Dim1Success) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_Skip0_Empty_Dim2) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", -1);  // latest opset so we get shape inferencing errors
   // s=0, Min=Max=2, weights empty, int32
   InitTestAttr(test, "TF", 2, 2, 0,
                {0, 4},
@@ -137,7 +139,7 @@ TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_Skip0_Empty_Dim2) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_Skip01_Empty_Dim2) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", -1);  // latest opset so we get shape inferencing errors
   // s=0, Min=Max=2, weights empty, int32
   InitTestAttr(test, "TF", 2, 2, 0,
                {0, 4},
@@ -160,7 +162,7 @@ TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_Skip01_Empty_Dim2) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_Skip0_Empty_Dim2N) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=0, Min=Max=2, weights empty, int32
   InitTestAttr(test, "TF", 2, 2, 0,
                {0, 4},
@@ -183,7 +185,7 @@ TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_Skip0_Empty_Dim2N) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_TF_BatchOnlyBigrams_Skip0) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=0, Min=Max=2, weights empty, int32
   InitTestAttr(test, "TF", 2, 2, 0,
                {0, 4},
@@ -208,7 +210,7 @@ TEST(TfIdfVectorizerTest, Int32_TF_BatchOnlyBigrams_Skip0) {
 }
 
 TEST(TfIdfVectorizerTest, String_TF_OnlyBigrams_Skip0) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=0, Min=Max=2, weights empty, string
   InitTestAttr(test, "TF", 2, 2, 0,
                {0, 4},
@@ -231,7 +233,7 @@ TEST(TfIdfVectorizerTest, String_TF_OnlyBigrams_Skip0) {
 }
 
 TEST(TfIdfVectorizerTest, String_TF_BatchOnlyBigrams_Skip0) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=0, Min=Max=2, weights empty, string
   InitTestAttr(test, "TF", 2, 2, 0,
                {0, 4},
@@ -258,7 +260,7 @@ TEST(TfIdfVectorizerTest, String_TF_BatchOnlyBigrams_Skip0) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_LevelEmpty) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=0, Min=Max=2, weights empty, int32
   InitTestAttr(test, "TF", 2, 2, 0,
                {0, 0},  // no unigrams, bi-grams start immediately
@@ -284,7 +286,7 @@ TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_LevelEmpty) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, Min=Max=2, weights empty, int32
   InitTestAttr(test, "TF", 2, 2, 5,
                {0, 4},
@@ -308,7 +310,7 @@ TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_TF_BatchOnlyBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, , Min=Max=2, weights empty, int32
   InitTestAttr(test, "TF", 2, 2, 5,
                {0, 4},
@@ -334,7 +336,7 @@ TEST(TfIdfVectorizerTest, Int32_TF_BatchOnlyBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, String_TF_onlyBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, , Min=Max=2, weights empty, string
   InitTestAttr(test, "TF", 2, 2, 5,
                {0, 4},
@@ -359,7 +361,7 @@ TEST(TfIdfVectorizerTest, String_TF_onlyBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, String_TF_BatchOnlyBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, , Min=Max=2, weights empty, string
   InitTestAttr(test, "TF", 2, 2, 5,
                {0, 4},
@@ -383,7 +385,7 @@ TEST(TfIdfVectorizerTest, String_TF_BatchOnlyBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_TF_UniAndBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, , Min=1, Max=2, weights empty, int32
   InitTestAttr(test, "TF", 1, 2, 5,
                {0, 4},
@@ -406,7 +408,7 @@ TEST(TfIdfVectorizerTest, Int32_TF_UniAndBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_TF_BatchUniAndBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, Min=1, Max=2, weights empty, int32
   InitTestAttr(test, "TF", 1, 2, 5,
                {0, 4},
@@ -431,7 +433,7 @@ TEST(TfIdfVectorizerTest, Int32_TF_BatchUniAndBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, String_TF_UniAndBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, Min=1, Max=2, weights empty, string
   InitTestAttr(test, "TF", 1, 2, 5,
                {0, 4},
@@ -454,7 +456,7 @@ TEST(TfIdfVectorizerTest, String_TF_UniAndBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, String_TF_BatchUniAndBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, Min=1, Max=2, weights empty, string
   InitTestAttr(test, "TF", 1, 2, 5,
                {0, 4},
@@ -479,7 +481,7 @@ TEST(TfIdfVectorizerTest, String_TF_BatchUniAndBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_IDF_onlyBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, Min=Max=2, weights empty, int32
   // We change to IDF but do not supply weights so
   // we should get all 1.0f where count is not zero
@@ -503,7 +505,7 @@ TEST(TfIdfVectorizerTest, Int32_IDF_onlyBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, String_IDF_onlyBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, Min=Max=2, weights empty, string
   InitTestAttr(test, "IDF", 2, 2, 5,
                {0, 4},
@@ -526,7 +528,7 @@ TEST(TfIdfVectorizerTest, String_IDF_onlyBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_TFIDF_onlyBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, Min=Max=2, weights empty, int32
   // We change to TFIDF but do not supply weights so
   // we should all get the original values as weights are 1.0f by
@@ -551,7 +553,7 @@ TEST(TfIdfVectorizerTest, Int32_TFIDF_onlyBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, String_TFIDF_onlyBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, Min=Max=2, weights empty, string
   InitTestAttr(test, "TFIDF", 2, 2, 5,
                {0, 4},
@@ -574,7 +576,7 @@ TEST(TfIdfVectorizerTest, String_TFIDF_onlyBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_IDFWeights_onlyBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, Min=Max=2, weights specified, int32
   // We change to IDF with supplied weights. All
   // with non-zero counts must be replaced with the supplied weights
@@ -598,7 +600,7 @@ TEST(TfIdfVectorizerTest, Int32_IDFWeights_onlyBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, String_IDFWeights_onlyBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, Min=Max=2, weights specified, string
   InitTestAttr(test, "IDF", 2, 2, 5,
                {0, 4},
@@ -621,7 +623,7 @@ TEST(TfIdfVectorizerTest, String_IDFWeights_onlyBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, Int32_TFIDFWeights_onlyBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, Min=Max=2, weights specified, int32
   // We change to TFIDF with supplied weights.
   // We should have all counts scaled by weights
@@ -645,7 +647,7 @@ TEST(TfIdfVectorizerTest, Int32_TFIDFWeights_onlyBigrams_Skip5) {
 }
 
 TEST(TfIdfVectorizerTest, String_TFIDFWeights_onlyBigrams_Skip5) {
-  OpTester test("TfIdfVectorizer");
+  OpTester test("TfIdfVectorizer", opset_ver);
   // s=5, Min=Max=2, weights specified, string
   InitTestAttr(test, "TFIDF", 2, 2, 5,
                {0, 4},

--- a/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
@@ -66,7 +66,7 @@ TEST(GatherOpTest, Gather_invalid_axis) {
 }
 
 TEST(GatherOpTest, Gather_invalid_index_cpu) {
-  OpTester test("Gather");
+  OpTester test("Gather", 11);  // added check in opset 11
   // Invalid index 3. data[3] does not exist.
   test.AddAttribute<int64_t>("axis", 0LL);
   test.AddInput<float>("data", {3, 4},
@@ -81,7 +81,7 @@ TEST(GatherOpTest, Gather_invalid_index_cpu) {
 
 #ifdef USE_CUDA
 TEST(GatherOpTest, Gather_invalid_index_gpu) {
-  OpTester test("Gather", 7);  // no GPU Gather for opset 11 yet (change was to add negative axis support)
+  OpTester test("Gather");
   // Invalid index 3. data[3] does not exist.
   test.AddAttribute<int64_t>("axis", 0LL);
   test.AddInput<float>("data", {3, 4},

--- a/onnxruntime/test/providers/cpu/tensor/unsqueeze_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/unsqueeze_op_test.cc
@@ -46,7 +46,7 @@ TEST(TensorOpTest, Unsqueeze_3) {
 }
 
 TEST(TensorOpTest, Unsqueeze_Duplicate) {
-  OpTester test("Unsqueeze");
+  OpTester test("Unsqueeze", -1);  // use latest opset for shape inference errors
 
   test.AddAttribute("axes", std::vector<int64_t>{2, 1, 0, 2});
   test.AddInput<float>("input", {2, 3, 4}, std::vector<float>(2 * 3 * 4, 1.0f));
@@ -57,7 +57,7 @@ TEST(TensorOpTest, Unsqueeze_Duplicate) {
 }
 
 TEST(TensorOpTest, Unsqueeze_OutOfRange) {
-  OpTester test("Unsqueeze");
+  OpTester test("Unsqueeze", -1);  // use latest opset for shape inference errors
 
   test.AddAttribute("axes", std::vector<int64_t>{4});
   test.AddInput<float>("input", {2, 3, 4}, std::vector<float>(2 * 3 * 4, 1.0f));
@@ -67,7 +67,7 @@ TEST(TensorOpTest, Unsqueeze_OutOfRange) {
 }
 
 TEST(TensorOpTest, UnsqueezeNegAxis_3) {
-  OpTester test("Unsqueeze", 11);
+  OpTester test("Unsqueeze", -1);  // use latest opset for shape inference errors
 
   test.AddAttribute("axes", std::vector<int64_t>{-4, 1, -6});
   test.AddInput<float>("input", {2, 3, 4}, std::vector<float>(2 * 3 * 4, 1.0f));

--- a/onnxruntime/test/providers/cpu/tensor/upsample_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/upsample_op_test.cc
@@ -12,7 +12,7 @@ namespace test {
 // and limited data types. Those tests will fallback to other EPs
 
 TEST(UpsampleOpTest, UpsampleOpNearestTest) {
-  OpTester test("Upsample", 7);
+  OpTester test("Upsample");
 
   std::vector<float> scales{1.0f, 1.0f, 2.0f, 3.0f};
   test.AddAttribute("mode", "nearest");
@@ -43,7 +43,7 @@ TEST(UpsampleOpTest, UpsampleOpNearestTest) {
 }
 
 TEST(UpsampleOpTest, UpsampleOpNearestTest_int32) {
-  OpTester test("Upsample", 7);
+  OpTester test("Upsample");
 
   std::vector<float> scales{1.0f, 1.0f, 2.0f, 3.0f};
   test.AddAttribute("mode", "nearest");
@@ -74,7 +74,7 @@ TEST(UpsampleOpTest, UpsampleOpNearestTest_int32) {
 }
 
 TEST(UpsampleOpTest, UpsampleOpNearestTest_uint8) {
-  OpTester test("Upsample", 7);
+  OpTester test("Upsample");
 
   std::vector<float> scales{1.0f, 1.0f, 2.0f, 3.0f};
   test.AddAttribute("mode", "nearest");
@@ -105,7 +105,7 @@ TEST(UpsampleOpTest, UpsampleOpNearestTest_uint8) {
 }
 
 TEST(UpsampleOpTest, UpsampleOpNearest2XTest) {
-  OpTester test("Upsample", 7);
+  OpTester test("Upsample");
 
   std::vector<float> scales{1.0f, 1.0f, 2.0f, 2.0f};
   test.AddAttribute("mode", "nearest");
@@ -136,7 +136,7 @@ TEST(UpsampleOpTest, UpsampleOpNearest2XTest) {
 }
 
 TEST(UpsampleOpTest, UpsampleOpNearest222XTest) {
-  OpTester test("Upsample", 7);
+  OpTester test("Upsample");
 
   std::vector<float> scales{2.0f, 1.0f, 2.0f, 2.0f};
   test.AddAttribute("mode", "nearest");
@@ -177,7 +177,7 @@ TEST(UpsampleOpTest, UpsampleOpNearest222XTest) {
 }
 
 TEST(UpsampleOpTest, UpsampleOpNearest15XTest) {
-  OpTester test("Upsample", 7);
+  OpTester test("Upsample");
 
   std::vector<float> scales{1.0f, 1.0f, 2.0f, 1.5f};
   test.AddAttribute("mode", "nearest");
@@ -208,7 +208,7 @@ TEST(UpsampleOpTest, UpsampleOpNearest15XTest) {
 }
 
 TEST(UpsampleOpTest, UpsampleOpNearestTest_NoScale) {
-  OpTester test("Upsample", 7);
+  OpTester test("Upsample");
 
   std::vector<float> scales{1.0f, 1.0f, 1.0f, 1.0f};
   test.AddAttribute("mode", "nearest");
@@ -234,7 +234,7 @@ TEST(UpsampleOpTest, UpsampleOpNearestTest_NoScale) {
 }
 
 TEST(UpsampleOpTest, UpsampleOpNearest2XTest_int32) {
-  OpTester test("Upsample", 7);
+  OpTester test("Upsample");
 
   std::vector<float> scales{1.0f, 1.0f, 2.0f, 2.0f};
   test.AddAttribute("mode", "nearest");
@@ -265,7 +265,7 @@ TEST(UpsampleOpTest, UpsampleOpNearest2XTest_int32) {
 }
 
 TEST(UpsampleOpTest, UpsampleOp4DBilinearTest) {
-  OpTester test("Upsample", 7);
+  OpTester test("Upsample");
 
   std::vector<float> scales{1.0f, 1.0f, 2.0f, 4.0f};
   test.AddAttribute("mode", "linear");
@@ -296,7 +296,7 @@ TEST(UpsampleOpTest, UpsampleOp4DBilinearTest) {
 }
 
 TEST(UpsampleOpTest, UpsampleOp2DBilinearTest) {
-  OpTester test("Upsample", 7);
+  OpTester test("Upsample");
 
   std::vector<float> scales{2.0f, 4.0f};
   test.AddAttribute("mode", "linear");
@@ -319,7 +319,7 @@ TEST(UpsampleOpTest, UpsampleOp2DBilinearTest) {
 }
 
 TEST(UpsampleOpTest, UpsampleOp4DBilinearTest_ScalesNoOp) {
-  OpTester test("Upsample", 7);
+  OpTester test("Upsample");
 
   std::vector<float> scales{1.0f, 1.0f, 1.0f, 1.0f};
   test.AddAttribute("mode", "linear");
@@ -345,7 +345,7 @@ TEST(UpsampleOpTest, UpsampleOp4DBilinearTest_ScalesNoOp) {
 }
 
 TEST(UpsampleOpTest, UpsampleOp4DBilinearTest_int32) {
-  OpTester test("Upsample", 7);
+  OpTester test("Upsample");
 
   std::vector<float> scales{1.0f, 1.0f, 2.0f, 4.0f};
   test.AddAttribute("mode", "linear");
@@ -376,7 +376,7 @@ TEST(UpsampleOpTest, UpsampleOp4DBilinearTest_int32) {
 }
 
 TEST(UpsampleOpTest, UpsampleOpNearestTest_1D) {
-  OpTester test("Upsample", 7);
+  OpTester test("Upsample");
 
   std::vector<float> scales{2.0f};
   test.AddAttribute("mode", "nearest");


### PR DESCRIPTION
**Description**: 
Revert to using opset 7 as the default for OpTester instead of the latest available version (reverts some changes from #2199). See explanation in provider_test_utils.h changes.
Add comments to OpTester to explain the default. 
Make sure unit tests involving shape inferencing errors use the latest version.

**Motivation and Context**
Due to how kernel matching works, using the latest opset version can result in silent loss of coverage to non-CPU EP implementations of the old version. 
