### PR TITLE
make ort server can build with mkl or ngraph ep

### DIFF
--- a/cmake/onnxruntime_server.cmake
+++ b/cmake/onnxruntime_server.cmake
@@ -175,7 +175,7 @@ target_link_libraries(onnxruntime_server_lib PRIVATE
   onnxruntime_server_http_core_lib
   PUBLIC
   protobuf::libprotobuf
-  ${onnxruntime_EXTERNAL_DEPENDENCIES}
+  ${onnxruntime_EXTERNAL_LIBRARIES}
   spdlog::spdlog
   onnxruntime
 )

--- a/dockerfiles/Dockerfile.server
+++ b/dockerfiles/Dockerfile.server
@@ -28,7 +28,7 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 
 WORKDIR /
 RUN mkdir -p /onnxruntime/build && \
-    python3 /onnxruntime/tools/ci_build/build.py --build_dir /onnxruntime/build --config Release --build_server --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER)
+    python3 /onnxruntime/tools/ci_build/build.py --build_dir /onnxruntime/build --config Release --build_server --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER)
 
 FROM minimal AS final
 WORKDIR /onnxruntime/server/

--- a/dockerfiles/Dockerfile.server.mkldnn
+++ b/dockerfiles/Dockerfile.server.mkldnn
@@ -1,0 +1,40 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#--------------------------------------------------------------------------
+# Official docker container for ONNX Runtime Server
+# Ubuntu 16.04, CPU version, Python 3.
+#--------------------------------------------------------------------------
+
+FROM ubuntu:16.04 AS build
+ARG PYTHON_VERSION=3.5
+ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
+ARG ONNXRUNTIME_SERVER_BRANCH=master
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+    apt-get install -y sudo git bash
+
+ENV PATH="/opt/cmake/bin:${PATH}"
+RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime
+RUN /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh -p ${PYTHON_VERSION} && \
+    /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_deps.sh -p ${PYTHON_VERSION} && \
+    /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
+
+RUN /bin/sh /onnxruntime/dockerfiles/scripts/install_common_deps.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+WORKDIR /
+RUN mkdir -p /onnxruntime/build
+RUN python3 /onnxruntime/tools/ci_build/build.py --build_dir /onnxruntime/build --config Release --use_mkldnn --build_server --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER)
+
+
+FROM ubuntu:16.04 AS minimal
+WORKDIR /onnxruntime/server/
+COPY --from=build /onnxruntime/build/Release/onnxruntime_server /onnxruntime/server/
+COPY --from=build /onnxruntime/build/Release/libonnxruntime.so.* /lib/
+COPY --from=build /onnxruntime/build/Release/mkl-dnn/install/lib/libmkldnn.so* /lib/
+RUN apt-get update && apt-get install -y libgomp1
+ENTRYPOINT ["/onnxruntime/server/onnxruntime_server"]
+

--- a/dockerfiles/Dockerfile.server.mkldnn_mklml
+++ b/dockerfiles/Dockerfile.server.mkldnn_mklml
@@ -1,0 +1,42 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#--------------------------------------------------------------------------
+# Official docker container for ONNX Runtime Server
+# Ubuntu 16.04, CPU version, Python 3.
+#--------------------------------------------------------------------------
+
+FROM ubuntu:16.04 AS build
+ARG PYTHON_VERSION=3.5
+ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
+ARG ONNXRUNTIME_SERVER_BRANCH=master
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+    apt-get install -y sudo git bash
+
+ENV PATH="/opt/cmake/bin:${PATH}"
+RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime
+RUN /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh -p ${PYTHON_VERSION} && \
+    /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_deps.sh -p ${PYTHON_VERSION} && \
+    /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
+
+RUN /bin/sh /onnxruntime/dockerfiles/scripts/install_common_deps.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+WORKDIR /
+RUN mkdir -p /onnxruntime/build
+RUN python3 /onnxruntime/tools/ci_build/build.py --build_dir /onnxruntime/build --config Release --use_mkldnn --use_mklml \
+    --build_server --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER)
+
+
+FROM ubuntu:16.04 AS minimal
+WORKDIR /onnxruntime/server/
+RUN apt-get update && apt-get install -y libgomp1
+COPY --from=build /onnxruntime/build/Release/onnxruntime_server /onnxruntime/server/
+COPY --from=build /onnxruntime/build/Release/libonnxruntime.so.* /lib/
+COPY --from=build /onnxruntime/build/Release/mkl-dnn/install/lib/libmkldnn.so* /lib/
+COPY --from=build /onnxruntime/build/Release/mklml/src/project_mklml/lib/*.so* /lib/
+ENTRYPOINT ["/onnxruntime/server/onnxruntime_server"]
+

--- a/dockerfiles/Dockerfile.server.ngraph
+++ b/dockerfiles/Dockerfile.server.ngraph
@@ -1,0 +1,39 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#--------------------------------------------------------------------------
+# Official docker container for ONNX Runtime Server
+# Ubuntu 16.04, CPU version, Python 3.
+#--------------------------------------------------------------------------
+
+FROM ubuntu:16.04 AS minimal
+
+FROM ubuntu:16.04 AS build
+ARG PYTHON_VERSION=3.5
+ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
+ARG ONNXRUNTIME_SERVER_BRANCH=master
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+    apt-get install -y sudo git bash
+
+ENV PATH="/opt/cmake/bin:${PATH}"
+RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime
+RUN /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh -p ${PYTHON_VERSION} && \
+    /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_deps.sh -p ${PYTHON_VERSION} && \
+    /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+WORKDIR /
+RUN mkdir -p /onnxruntime/build && \
+    python3 /onnxruntime/tools/ci_build/build.py --build_dir /onnxruntime/build --config Release --use_ngraph --build_server --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER)
+
+FROM minimal AS final
+WORKDIR /onnxruntime/server/
+COPY --from=build /onnxruntime/build/Release/onnxruntime_server /onnxruntime/server/
+COPY --from=build /onnxruntime/build/Release/libonnxruntime.so.* /lib/
+COPY --from=build /onnxruntime/build/Release/external/ngraph/lib/*.so* /lib/
+RUN apt-get update \
+    && apt-get install -y libgomp1
+ENTRYPOINT ["/onnxruntime/server/onnxruntime_server"]

--- a/dockerfiles/Dockerfile.server.nuphar
+++ b/dockerfiles/Dockerfile.server.nuphar
@@ -1,0 +1,41 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#--------------------------------------------------------------------------
+
+FROM ubuntu:16.04 as build
+
+ARG PYTHON_VERSION=3.5
+ARG ONNXRUNTIME_REPO=https://github.com/zhijxu-MS/onnxruntime
+ARG ONNXRUNTIME_SERVER_BRANCH=master
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+    apt-get install -y sudo git bash
+
+ENV PATH="/opt/cmake/bin:${PATH}"
+RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime
+RUN /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh -p ${PYTHON_VERSION} && \
+    /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_deps.sh -p ${PYTHON_VERSION} && \
+    /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+WORKDIR /
+
+RUN mkdir -p /onnxruntime/build && \
+    pip3 install sympy packaging && \
+    python3 /onnxruntime/tools/ci_build/build.py --build_dir /onnxruntime/build --config Release --build_shared_lib --skip_submodule_sync \
+        --build_server \
+        --parallel --use_nuphar --use_mklml --use_tvm --use_llvm
+
+
+FROM ubuntu:16.04 AS final
+WORKDIR /onnxruntime/server/
+COPY --from=build /onnxruntime/build/Release/onnxruntime_server /onnxruntime/server/
+COPY --from=build /onnxruntime/build/Release/libonnxruntime.so.* /lib/
+COPY --from=build /onnxruntime/build/Release/mklml/src/project_mklml/lib/*.so* /lib/
+COPY --from=build /onnxruntime/build/Release/external/tvm/*.so* /lib/
+ENTRYPOINT ["/onnxruntime/server/onnxruntime_server"]
+

--- a/dockerfiles/Dockerfile.source
+++ b/dockerfiles/Dockerfile.source
@@ -22,7 +22,7 @@ RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive 
     /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh
 
 RUN cd onnxruntime &&\
-    /bin/sh ./build.sh --config Release --build_wheel --update --build --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) &&\
+    /bin/sh ./build.sh --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) &&\
     pip install /code/onnxruntime/build/Linux/Release/dist/*.whl &&\
     cd .. &&\
     rm -rf onnxruntime cmake-3.14.3-Linux-x86_64

--- a/dockerfiles/Dockerfile.source
+++ b/dockerfiles/Dockerfile.source
@@ -19,8 +19,9 @@ ENV PATH /opt/miniconda/bin:/code/cmake-3.14.3-Linux-x86_64/bin:${PATH}
 
 # Prepare onnxruntime repository & build onnxruntime
 RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime &&\
-    /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh &&\
-    cd onnxruntime &&\
+    /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh
+
+RUN cd onnxruntime &&\
     /bin/sh ./build.sh --config Release --build_wheel --update --build --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) &&\
     pip install /code/onnxruntime/build/Linux/Release/dist/*.whl &&\
     cd .. &&\

--- a/onnxruntime/server/environment.cc
+++ b/onnxruntime/server/environment.cc
@@ -5,6 +5,24 @@
 #include "environment.h"
 #include "core/session/onnxruntime_cxx_api.h"
 
+#ifdef USE_MKLDNN
+
+#include "core/providers/mkldnn/mkldnn_provider_factory.h"
+
+#endif
+
+#ifdef USE_NGRAPH
+
+#include "core/providers/ngraph/ngraph_provider_factory.h"
+
+#endif
+
+#ifdef USE_NUPHAR
+
+#include "core/providers/nuphar/nuphar_provider_factory.h"
+
+#endif
+
 namespace onnxruntime {
 namespace server {
 
@@ -42,8 +60,23 @@ ServerEnvironment::ServerEnvironment(OrtLoggingLevel severity, spdlog::sinks_ini
   spdlog::initialize_logger(default_logger_);
 }
 
+void ServerEnvironment::RegisterEexcutionProviders(){
+  #ifdef USE_MKLDNN
+  Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Mkldnn(options_, 1));
+  #endif
+
+  #ifdef USE_NGRAPH
+  Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_NGraph(options_, "CPU"));
+  #endif
+
+  #ifdef USE_NUPHAR
+  Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Nuphar(options_, 1, ""));
+  #endif
+}
+
 void ServerEnvironment::InitializeModel(const std::string& model_path, const std::string& model_name, const std::string& model_version) {
-  auto result = sessions_.emplace(std::piecewise_construct, std::forward_as_tuple(model_name, model_version), std::forward_as_tuple(runtime_environment_, model_path.c_str(), Ort::SessionOptions()));
+  RegisterEexcutionProviders();
+  auto result = sessions_.emplace(std::piecewise_construct, std::forward_as_tuple(model_name, model_version), std::forward_as_tuple(runtime_environment_, model_path.c_str(), options_));
 
   if (!result.second) {
     throw Ort::Exception("Model of that name already loaded.", ORT_INVALID_ARGUMENT);

--- a/onnxruntime/server/environment.h
+++ b/onnxruntime/server/environment.h
@@ -28,6 +28,7 @@ class ServerEnvironment {
   std::shared_ptr<spdlog::logger> GetLogger(const std::string& request_id) const;
   std::shared_ptr<spdlog::logger> GetAppLogger() const;
   void UnloadModel(const std::string& model_name, const std::string& model_version);
+  void RegisterEexcutionProviders();
 
  private:
   const OrtLoggingLevel severity_;


### PR DESCRIPTION
**Description**: let ort server can support mkldnn and ngraph execution provider

- Why is this change required? What problem does it solve?
 other execution providers  may have better performance than default cpu

