### PR TITLE
Cleanup add/remove of initializer

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -966,7 +966,6 @@ class Graph {
   ONNX_NAMESPACE::GraphProto* graph_proto_;
 
   InitializedTensorSet name_to_initial_tensor_;
-  std::vector<int> removed_initializer_indexes_;
 
   IOnnxRuntimeOpSchemaCollectionPtr schema_registry_;
 

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2029,8 +2029,10 @@ void Graph::SetDescription(const std::string& description) {
 }
 
 void Graph::AddInitializedTensor(const TensorProto& tensor) {
-  if (name_to_initial_tensor_.end() != name_to_initial_tensor_.find(tensor.name())) {
-    return;
+  auto existing = name_to_initial_tensor_.find(tensor.name());
+  if (existing != name_to_initial_tensor_.cend()) {
+    ORT_ENFORCE(existing->second == &tensor,
+                "AddInitializedTensor already has tensor with name ", tensor.name(), " but different TensorProto.");
   }
 
   const gsl::not_null<TensorProto*> tensor_added{graph_proto_->add_initializer()};
@@ -2046,17 +2048,35 @@ void Graph::AddInitializedTensor(const TensorProto& tensor) {
 
     ORT_IGNORE_RETURN_VALUE(GetOrCreateNodeArg(tensor.name(), &t));
   }
-
-  SetGraphProtoSyncNeeded();
-  SetGraphResolveNeeded();
 }
 
 void Graph::RemoveInitializedTensor(const std::string& tensor_name) {
+  bool found = false;
   auto iter = name_to_initial_tensor_.find(tensor_name);
-  if (name_to_initial_tensor_.end() != iter) {
+  found = iter != name_to_initial_tensor_.end();
+  if (found) {
     name_to_initial_tensor_.erase(tensor_name);
-    SetGraphProtoSyncNeeded();
     SetGraphResolveNeeded();
+  }
+
+  auto& mutable_initializers = *(graph_proto_->mutable_initializer());
+  auto proto_entry = std::find_if(mutable_initializers.begin(), mutable_initializers.end(),
+                                  [&tensor_name](const TensorProto& entry) { return entry.name() == tensor_name; });
+
+  if (proto_entry != mutable_initializers.end()) {
+    auto num_entries = mutable_initializers.size();
+    if (num_entries > 1) {
+      // move the last value into the one being removed, and delete the final entry
+      auto slot = proto_entry - mutable_initializers.begin();
+      auto last_entry = mutable_initializers.end() - 1;
+      mutable_initializers[slot] = std::move(*last_entry);
+      mutable_initializers.erase(last_entry);
+    } else {
+      mutable_initializers.erase(proto_entry);
+    }
+  } else {
+    // these should always be in sync as the pointer in name_to_initial_tensor_ is to memory in graph_proto_
+    ORT_ENFORCE(!found, "graph_proto_ is not in sync with name_to_initial_tensor_.");
   }
 }
 
@@ -2064,7 +2084,6 @@ Status Graph::ReplaceInitializedTensor(const ONNX_NAMESPACE::TensorProto& new_in
   // name_to_initial_tensor_ maps from name to const TensorProto*, so we first
   // look up the const pointer by name, then find and modify the mutable
   // pointed-to TensorProto in graph_proto_.
-
   const auto& initializer_name = new_initializer.name();
   const auto name_to_initializer_it = name_to_initial_tensor_.find(initializer_name);
   ORT_RETURN_IF_NOT(name_to_initializer_it != name_to_initial_tensor_.end(),
@@ -2085,13 +2104,15 @@ Status Graph::ReplaceInitializedTensor(const ONNX_NAMESPACE::TensorProto& new_in
                     "Replacement tensor's data type does not match.");
 
   auto& mutable_initializers = *(graph_proto_->mutable_initializer());
-  auto old_mutable_initializer_ptr_it = std::find(
-      mutable_initializers.pointer_begin(), mutable_initializers.pointer_end(), &old_initializer);
-  ORT_ENFORCE(old_mutable_initializer_ptr_it != mutable_initializers.pointer_end(),
-              "graph_proto_ is not in sync with name_to_initial_tensor_");
-  auto& old_mutable_initializer = **old_mutable_initializer_ptr_it;
+  // use cheaper pointer comparison to find old entry
+  auto existing_entry = std::find(mutable_initializers.pointer_begin(), mutable_initializers.pointer_end(),
+                                  &old_initializer);
 
-  old_mutable_initializer = new_initializer;
+  // these should always be in sync as the pointer in name_to_initial_tensor_ is to memory in graph_proto_
+  ORT_ENFORCE(existing_entry != mutable_initializers.pointer_end(),
+              "graph_proto_ is not in sync with name_to_initial_tensor_");
+
+  **existing_entry = new_initializer;
 
   return Status::OK();
 }
@@ -2108,7 +2129,6 @@ bool Graph::GetInitializedTensor(const std::string& tensor_name, const TensorPro
 
 void Graph::CleanAllInitializedTensors() noexcept {
   name_to_initial_tensor_.clear();
-  removed_initializer_indexes_.clear();
 
   // Clearing RepeatedPtrFields does not free objects' memory. The memory is retained
   // and can be reused. Need to explicitly release the cleared objects and free the
@@ -2288,35 +2308,6 @@ const ONNX_NAMESPACE::GraphProto& Graph::ToGraphProto() {
   // Nodes.
   ToGraphProtoInternal(*graph_proto_);
 
-  if (!removed_initializer_indexes_.empty()) {
-    // Move initializers.
-    std::sort(removed_initializer_indexes_.begin(), removed_initializer_indexes_.end());
-    int lastInUseInitializerIndex = graph_proto_->initializer_size() - 1;
-    int start = 0;
-    int end = gsl::narrow_cast<int>(removed_initializer_indexes_.size()) - 1;
-    int lastRemovedInitializerIndex = removed_initializer_indexes_[end];
-
-    for (; start <= end; start++) {
-      // Find a lastInUseInitializer.
-      while (start <= end && lastInUseInitializerIndex == lastRemovedInitializerIndex) {
-        graph_proto_->mutable_initializer()->RemoveLast();
-        lastInUseInitializerIndex--;
-        end--;
-        if (start <= end) {
-          lastRemovedInitializerIndex = removed_initializer_indexes_[end];
-        }
-      }
-
-      if (start <= end) {
-        // Copy the <lastInUseInitializerIndex> initializer in use to the <start> slot which is removed.
-        *graph_proto_->mutable_initializer(removed_initializer_indexes_[start]) = graph_proto_->initializer(lastInUseInitializerIndex);
-        graph_proto_->mutable_initializer()->RemoveLast();
-        lastInUseInitializerIndex--;
-      }
-    }
-    removed_initializer_indexes_.clear();
-  }
-
   GraphProtoSyncNeeded(false);
 
   return *graph_proto_;
@@ -2329,9 +2320,7 @@ ONNX_NAMESPACE::GraphProto Graph::ToGraphProto() const {
   GraphProto result;
   ToGraphProtoInternal(result);
 
-  for (auto initializer : GetAllInitializedTensors()) {
-    *result.add_initializer() = *initializer.second;
-  }
+  *result.mutable_initializer() = graph_proto_->initializer();
 
   return result;
 }

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -960,7 +960,7 @@ TEST(GraphUpdateTest, ReplaceInitializedTensor) {
     ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
 
     auto tensor_data_matches = [](
-        const ONNX_NAMESPACE::TensorProto& a, const ONNX_NAMESPACE::TensorProto& b) {
+                                   const ONNX_NAMESPACE::TensorProto& a, const ONNX_NAMESPACE::TensorProto& b) {
       if (a.int32_data_size() != b.int32_data_size()) return false;
       for (int i = 0; i < a.int32_data_size(); ++i) {
         if (a.int32_data(i) != b.int32_data(i)) return false;
@@ -978,6 +978,52 @@ TEST(GraphUpdateTest, ReplaceInitializedTensor) {
     ASSERT_EQ(graph_proto.initializer_size(), 1);
     ASSERT_TRUE(tensor_data_matches(graph_proto.initializer(0), valid_replacement));
   }
+}
+
+TEST(GraphUpdateTest, AddRemoveInitializerHandling) {
+  Model m{"test_model"};
+  Graph& graph = m.MainGraph();
+
+  auto create_tensor_proto = [](const std::string& name, int32_t value) {
+    ONNX_NAMESPACE::TensorProto init{};
+    init.set_name(name);
+    init.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT32);
+    init.add_dims(1);
+    init.add_int32_data(value);
+
+    return init;
+  };
+
+  auto init = create_tensor_proto("1", 1);
+  auto init2 = create_tensor_proto("2", 2);
+
+  // add both, remove the 1st (moves the second initializer into the first slot), and finally re-add the first
+  graph.AddInitializedTensor(init);
+  graph.AddInitializedTensor(init2);
+  graph.RemoveInitializedTensor(init.name());
+  graph.AddInitializedTensor(init);
+
+  ASSERT_EQ(graph.GetAllInitializedTensors().size(), 2);
+
+  ONNX_NAMESPACE::GraphProto graph_proto_from_const_graph = static_cast<const Graph&>(graph).ToGraphProto();
+  ONNX_NAMESPACE::GraphProto graph_proto_from_graph = graph.ToGraphProto();
+
+  ASSERT_EQ(graph_proto_from_const_graph.initializer_size(), 2);
+  ASSERT_EQ(graph_proto_from_graph.initializer_size(), 2);
+
+  auto validate_proto = [&](const GraphProto& proto) {
+    auto initializers = proto.initializer();
+    // we expect '2' to be before '1' due to the remove moving the last initializer into the slot of the one being
+    // removed in order to free memory and only move one entry
+    EXPECT_EQ(initializers[0].name(), init2.name());
+    EXPECT_EQ(initializers[0].int32_data()[0], 2);
+
+    EXPECT_EQ(initializers[1].name(), init.name());
+    EXPECT_EQ(initializers[1].int32_data()[0], 1);
+  };
+
+  validate_proto(graph_proto_from_const_graph);
+  validate_proto(graph_proto_from_graph);
 }
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -959,8 +959,7 @@ TEST(GraphUpdateTest, ReplaceInitializedTensor) {
     status = graph.ReplaceInitializedTensor(valid_replacement);
     ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
 
-    auto tensor_data_matches = [](
-                                   const ONNX_NAMESPACE::TensorProto& a, const ONNX_NAMESPACE::TensorProto& b) {
+    auto tensor_data_matches = [](const ONNX_NAMESPACE::TensorProto& a, const ONNX_NAMESPACE::TensorProto& b) {
       if (a.int32_data_size() != b.int32_data_size()) return false;
       for (int i = 0; i < a.int32_data_size(); ++i) {
         if (a.int32_data(i) != b.int32_data(i)) return false;
@@ -1005,6 +1004,14 @@ TEST(GraphUpdateTest, AddRemoveInitializerHandling) {
 
   ASSERT_EQ(graph.GetAllInitializedTensors().size(), 2);
 
+  // check the values coming from name_to_initial_tensor_ are good;
+  const TensorProto* i = nullptr;
+  ASSERT_TRUE(graph.GetInitializedTensor(init.name(), i));
+  ASSERT_TRUE(i->int32_data()[0] == 1);
+  ASSERT_TRUE(graph.GetInitializedTensor(init2.name(), i));
+  ASSERT_TRUE(i->int32_data()[0] == 2);
+
+  // check the values in the GraphProto are also correct
   ONNX_NAMESPACE::GraphProto graph_proto_from_const_graph = static_cast<const Graph&>(graph).ToGraphProto();
   ONNX_NAMESPACE::GraphProto graph_proto_from_graph = graph.ToGraphProto();
 


### PR DESCRIPTION
**Description**: 
Cleanup how add/remove of an initializer works. 
 - Keep graph_proto_ in sync with name_to_initial_tensor_ 
   - Remove unused removed_initializer_indexes_ member. not needed when we keep things in sync
   - we don't need to call SetGraphProtoSyncNeeded in a few places
 - Error out if there's an incompatible attempt to add an existing initializer
   - silently returning if the initializer existed with no checks meant potential issues were not detected
 - Avoid attempting to add initializer twice in Function

**Motivation and Context**
Fixes #2232 