### PR TITLE
Add node and op type info to error message if there's a type or shape inferencing exception thrown by the ONNX checker

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -1599,7 +1599,7 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op) {
   try {
     context.RunInferencing();
   } catch (const std::exception& ex) {
-    return Status(ONNXRUNTIME, FAIL, ex.what());
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Node (", node.Name(), ") Op (", node.OpType(), ") ", ex.what());
   }
 
   const auto& onnx_inferred_types(context.InferredOutputTypes());

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -989,8 +989,7 @@ TEST(GraphUpdateTest, ReplaceInitializedTensor) {
     status = graph.ReplaceInitializedTensor(valid_replacement);
     ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
 
-    auto tensor_data_matches = [](
-                                   const ONNX_NAMESPACE::TensorProto& a, const ONNX_NAMESPACE::TensorProto& b) {
+    auto tensor_data_matches = [](const ONNX_NAMESPACE::TensorProto& a, const ONNX_NAMESPACE::TensorProto& b) {
       if (a.int32_data_size() != b.int32_data_size()) return false;
       for (int i = 0; i < a.int32_data_size(); ++i) {
         if (a.int32_data(i) != b.int32_data(i)) return false;

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -108,7 +108,7 @@ static bool RegisterCustomSchemas() {
       .SetDoc("Throw shape inference error.")
       .Input(0, "input_1", "docstr for input_1.", "tensor(int32)")
       .Output(0, "output_1", "docstr for output_1.", "tensor(int32)")
-      .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+      .TypeAndShapeInferenceFunction([](InferenceContext&) {
         fail_shape_inference("try harder");
       });
 


### PR DESCRIPTION
**Description**: 
Provide info on the node that had a type/shape inferencing error.

**Motivation and Context**
#2264 