### PR TITLE
Support for the Expand op with constant shape inputs

### DIFF
--- a/onnxruntime/core/providers/ngraph/ngraph_execution_provider.cc
+++ b/onnxruntime/core/providers/ngraph/ngraph_execution_provider.cc
@@ -210,6 +210,10 @@ static bool IsUnsupportedOpMode(const Node* node, const onnxruntime::GraphViewer
       return initializers.find(x_zero_point->Name()) == initializers.end() ||
              initializers.find(w_zero_point->Name()) == initializers.end();
     } // else -> xzp & wzp are 0 by default according to ONNX spec
+  } else if (optype == "Expand") {
+    // nGraph only supports constant shape input values
+    const auto& shape_input = node->InputDefs()[1];
+    return initializers.find(shape_input->Name()) == initializers.end();
   }
 
   //Op doesn't fall into known any of unsupported modes.

--- a/onnxruntime/core/providers/ngraph/ngraph_execution_provider.cc
+++ b/onnxruntime/core/providers/ngraph/ngraph_execution_provider.cc
@@ -213,7 +213,7 @@ static bool IsUnsupportedOpMode(const Node* node, const onnxruntime::GraphViewer
   } else if (optype == "Expand") {
     // nGraph only supports constant shape input values
     const auto& shape_input = node->InputDefs()[1];
-    return initializers.find(shape_input->Name()) == initializers.end();
+    return !graph_viewer.IsConstantInitializer(shape_input->Name(), true);
   }
 
   //Op doesn't fall into known any of unsupported modes.


### PR DESCRIPTION
This PR makes the unit tests and model tests pass when compiled with nGraph@master