### PR TITLE
Update libc min version to 2.12 post c++11 downgrade

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.cs
@@ -104,7 +104,7 @@ namespace Microsoft.ML.OnnxRuntime
                     // trap any obscure exception
                 }
                 throw new OnnxRuntimeException(ErrorCode.RuntimeException,
-                        $"libc.so version={curVersion} does not meet the minimun of 2.23 required by OnnxRuntime. " +
+                        $"libc.so version={curVersion} does not meet the minimun of {minVersion} required by OnnxRuntime. " +
                         "Linux distribution should be similar to Ubuntu 16.04 or higher");
             }
         }

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.cs
@@ -87,8 +87,9 @@ namespace Microsoft.ML.OnnxRuntime
 
         private static void CheckLibcVersionGreaterThanMinimum()
         {
-            // require libc version 2.23 or higher
-            var minVersion = new Version(2, 23);
+            // require libc version 2.12 or higher
+            // Centos 6 libc version is 2.12 which is the min verison onnxruntime supports from 1.0 release onwards
+            var minVersion = new Version(2, 12);
             var curVersion = new Version(0, 0);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.cs
@@ -51,9 +51,6 @@ namespace Microsoft.ML.OnnxRuntime
         private OnnxRuntime()  //Problem: it is not possible to pass any option for a Singleton
             :base(IntPtr.Zero, true)
         {
-            // Check LibC version on Linux, before doing any onnxruntime initialization
-            CheckLibcVersionGreaterThanMinimum();
-
             handle = IntPtr.Zero;
             try
             {
@@ -81,33 +78,5 @@ namespace Microsoft.ML.OnnxRuntime
             Delete(handle);
             return true;
         }
-
-        [DllImport("libc", ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr gnu_get_libc_version();
-
-        private static void CheckLibcVersionGreaterThanMinimum()
-        {
-            // require libc version 2.12 or higher
-            // 1.0 release onwards onnxruntime supports linux distributions similar to CentOS 6 or higher.
-            var minVersion = new Version(2, 12);
-            var curVersion = new Version(0, 0);
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                try
-                {
-                    curVersion = Version.Parse(Marshal.PtrToStringAnsi(gnu_get_libc_version()));
-                    if (curVersion >= minVersion)
-                        return;
-                }
-                catch (Exception)
-                {
-                    // trap any obscure exception
-                }
-                throw new OnnxRuntimeException(ErrorCode.RuntimeException,
-                        $"libc.so version={curVersion} does not meet the minimun of {minVersion} required by OnnxRuntime. " +
-                        "Linux distribution should be similar to CentOS 6 or higher");
-            }
-        }
-
     }
 }

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.cs
@@ -88,7 +88,7 @@ namespace Microsoft.ML.OnnxRuntime
         private static void CheckLibcVersionGreaterThanMinimum()
         {
             // require libc version 2.12 or higher
-            // Centos 6 libc version is 2.12 which is the min verison onnxruntime supports from 1.0 release onwards
+            // 1.0 release onwards onnxruntime supports linux distributions similar to CentOS 6 or higher.
             var minVersion = new Version(2, 12);
             var curVersion = new Version(0, 0);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -105,7 +105,7 @@ namespace Microsoft.ML.OnnxRuntime
                 }
                 throw new OnnxRuntimeException(ErrorCode.RuntimeException,
                         $"libc.so version={curVersion} does not meet the minimun of {minVersion} required by OnnxRuntime. " +
-                        "Linux distribution should be similar to Ubuntu 16.04 or higher");
+                        "Linux distribution should be similar to CentOS 6 or higher");
             }
         }
 


### PR DESCRIPTION
**Description**: Changing the min libc version requirement to match the actual supported one post c++11 downgrade.

**Motivation and Context**
- C# API fails when running on Linux machines with libc version < 2.23. Post 1.0 release ort is compatible with versions as low as 2.12.

