### PR TITLE
Bug Fix: NodeArg class has a move constructor but doesn't have a move assignment operator

### DIFF
--- a/include/onnxruntime/core/graph/node_arg.h
+++ b/include/onnxruntime/core/graph/node_arg.h
@@ -39,6 +39,7 @@ class NodeArg {
           const ONNX_NAMESPACE::TypeProto* p_arg_type);
 
   NodeArg(NodeArg&&) = default;
+  NodeArg& operator=(NodeArg&& other) = default;
 
   /** Gets the name. */
   const std::string& Name() const noexcept;
@@ -88,8 +89,6 @@ class NodeArg {
 
   void SetType(ONNX_NAMESPACE::DataType p_type);
   void SetType(const ONNX_NAMESPACE::TypeProto& type_proto);
-
-  NodeArg& operator=(NodeArg&& other) = delete;
 
   // Node arg PType.
   ONNX_NAMESPACE::DataType type_;


### PR DESCRIPTION

**Description**: 

Bug Fix: NodeArg class has a move constructor but doesn't have a move assignment operator
**Motivation and Context**
- Why is this change required? What problem does it solve?

To resolve #2271

- If it fixes an open issue, please link to the issue here.
