### PR TITLE
remove unused param in concat impl

### DIFF
--- a/onnxruntime/core/providers/cuda/object_detection/non_max_suppression.cc
+++ b/onnxruntime/core/providers/cuda/object_detection/non_max_suppression.cc
@@ -121,7 +121,6 @@ Status NonMaxSuppression::ComputeInternal(OpKernelContext* ctx) const {
                                    concat_sizes_gpu.GpuPtr(),
                                    concat_sizes_range_gpu.GpuPtr(),
                                    axis_dimension_input_output_mapping_gpu.GpuPtr(),
-                                   static_cast<int>(count),
                                    dst,
                                    input_ptr.GpuPtr(),
                                    static_cast<size_t>(num_elements)));

--- a/onnxruntime/core/providers/cuda/tensor/concat.cc
+++ b/onnxruntime/core/providers/cuda/tensor/concat.cc
@@ -67,7 +67,6 @@ Status Concat::ComputeInternal(OpKernelContext* ctx) const {
                                  concat_sizes_gpu.GpuPtr(),
                                  concat_sizes_range_gpu.GpuPtr(),
                                  axis_dimension_input_output_mapping_gpu.GpuPtr(),
-                                 input_count,
                                  p.output_tensor->MutableDataRaw(),
                                  input_ptr.GpuPtr(),
                                  p.output_num_elements));

--- a/onnxruntime/core/providers/cuda/tensor/concat_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/concat_impl.cu
@@ -14,7 +14,6 @@ __global__ void _ConcatKernel(const fast_divmod block_size_including_axis_dim_di
                               const int64_t* concat_sizes,
                               const int64_t* concat_sizes_range,
                               const int64_t* axis_dimension_input_output_mapping,
-                              const int num_inputs,
                               T* output_data,
                               const void** input_ptr,
                               const CUDA_LONG N) {
@@ -45,7 +44,6 @@ Status ConcatImpl(const size_t element_bytes,
                   const int64_t* concat_sizes,
                   const int64_t* concat_sizes_range,
                   const int64_t* axis_dimension_input_output_mapping,
-                  const int num_inputs,
                   void* output_data,
                   const void** input_ptr,
                   const size_t N) {
@@ -59,7 +57,6 @@ Status ConcatImpl(const size_t element_bytes,
       _ConcatKernel<<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(
           block_size_including_axis_dim_div, block_size_inside_axis_dim_div,
           concat_sizes, concat_sizes_range, axis_dimension_input_output_mapping,
-          num_inputs,
           reinterpret_cast<int8_t*>(output_data),
           input_ptr,
           (CUDA_LONG)N);
@@ -68,7 +65,6 @@ Status ConcatImpl(const size_t element_bytes,
       _ConcatKernel<<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(
           block_size_including_axis_dim_div, block_size_inside_axis_dim_div,
           concat_sizes, concat_sizes_range, axis_dimension_input_output_mapping,
-          num_inputs,
           reinterpret_cast<int16_t*>(output_data),
           input_ptr,
           (CUDA_LONG)N);
@@ -77,7 +73,6 @@ Status ConcatImpl(const size_t element_bytes,
       _ConcatKernel<<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(
           block_size_including_axis_dim_div, block_size_inside_axis_dim_div,
           concat_sizes, concat_sizes_range, axis_dimension_input_output_mapping,
-          num_inputs,
           reinterpret_cast<int32_t*>(output_data),
           input_ptr,
           (CUDA_LONG)N);
@@ -86,7 +81,6 @@ Status ConcatImpl(const size_t element_bytes,
       _ConcatKernel<<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(
           block_size_including_axis_dim_div, block_size_inside_axis_dim_div,
           concat_sizes, concat_sizes_range, axis_dimension_input_output_mapping,
-          num_inputs,
           reinterpret_cast<int64_t*>(output_data),
           input_ptr,
           (CUDA_LONG)N);

--- a/onnxruntime/core/providers/cuda/tensor/concat_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/concat_impl.h
@@ -15,7 +15,6 @@ Status ConcatImpl(const size_t element_bytes,
                   const int64_t* concat_sizes,
                   const int64_t* concat_sizes_range,
                   const int64_t* axis_dimension_input_output_mapping,
-                  const int num_inputs,
                   void* output_data,
                   const void** input_ptr,
                   const size_t N);


### PR DESCRIPTION
Remove the confusing unused param 'num_inputs' in ConcatImpl