### PR TITLE
Add MaskIndex cuda op

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm_impl.cu
@@ -182,7 +182,7 @@ bool LaunchEmbedLayerNormKernel(
     const size_t element_size) {
   const cudaStream_t stream = nullptr;  // default stream
 
-  if (!ComputeMaskIndex(stream, sequence_length, hidden_size, input_mask, static_cast<int*>(mask_index))) {
+  if (!ComputeMaskIndex(stream, sequence_length, batch_size, input_mask, static_cast<int*>(mask_index))) {
     return false;
   }
 

--- a/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm_impl.cu
@@ -30,78 +30,6 @@ namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
-template <unsigned TPB>
-__global__ void MaskIndexKernelSmall(int sequence_length, const int* mask, int* mask_index) {
-  using BlockReduce = cub::BlockReduce<int, TPB>;
-  __shared__ typename BlockReduce::TempStorage temp_storage;
-
-  // blockIdx.x is b
-  const int offset = blockIdx.x * sequence_length;  // batch strides of sequence_length
-
-  cub::Min min;
-  int thread_data(sequence_length);
-
-  const int idx = offset + threadIdx.x;
-  if (threadIdx.x < sequence_length) {
-    const int val = mask[idx];
-    if (val == 0)  // masked position: report thread idx
-    {
-      thread_data = threadIdx.x;
-    }
-  }
-
-  const auto min_index = BlockReduce(temp_storage).Reduce(thread_data, min);
-
-  if (threadIdx.x == 0) {
-    mask_index[blockIdx.x] = min_index;
-  }
-}
-
-template <unsigned TPB>
-__global__ void MaskIndexKernel(int sequence_length, const int* mask, int* mask_index) {
-  using BlockReduce = cub::BlockReduce<int, TPB>;
-  __shared__ typename BlockReduce::TempStorage temp_storage;
-
-  // blockIdx.x is b
-  const int offset = blockIdx.x * sequence_length;  // batch strides of sequence_length
-
-  cub::Min min;
-  int thread_data(sequence_length);
-
-  for (int i = threadIdx.x; i < sequence_length; i += TPB) {
-    const int idx = offset + i;
-    const int val = mask[idx];
-    if (val == 0)  // masked position: report thread idx
-    {
-      thread_data = min(thread_data, i);
-    }
-  }
-
-  const auto min_index = BlockReduce(temp_storage).Reduce(thread_data, min);
-
-  if (threadIdx.x == 0) {
-    mask_index[blockIdx.x] = min_index;
-  }
-}
-
-inline bool ComputeMaskIndex(cudaStream_t stream, const int sequence_length, const int batch_size, const int* mask, int* mask_index) {
-  // Mask idx is of length batch_size and assumes the valid region is contiguous starting
-  // from the beginning of the sequence
-
-  // Assume n = batch_size x sequence_length
-  if (sequence_length <= 32) {
-    MaskIndexKernelSmall<32><<<batch_size, 32, 0, stream>>>(sequence_length, mask, mask_index);
-  } else if (sequence_length <= 128) {
-    MaskIndexKernelSmall<128><<<batch_size, 128, 0, stream>>>(sequence_length, mask, mask_index);
-  } else if (sequence_length == 384) {
-    MaskIndexKernelSmall<384><<<batch_size, 384, 0, stream>>>(sequence_length, mask, mask_index);
-  } else {
-    MaskIndexKernel<256><<<batch_size, 256, 0, stream>>>(sequence_length, mask, mask_index);
-  }
-
-  return CUDA_CALL(cudaPeekAtLastError());
-}
-
 template <typename T, unsigned TPB>
 __global__ void EmbedLayerNormKernel(
     int hidden_size, const int* input_ids, const int* segment_ids, const T* beta, const T* gamma,
@@ -167,10 +95,8 @@ bool EmbedSkipLayerNorm(
 
 bool LaunchEmbedLayerNormKernel(
     void* output,
-    void* mask_index,
     const int* input_ids,
     const int* segment_ids,
-    const int* input_mask,
     const void* gamma,
     const void* beta,
     const void* word_embedding,
@@ -181,10 +107,6 @@ bool LaunchEmbedLayerNormKernel(
     int sequence_length,
     const size_t element_size) {
   const cudaStream_t stream = nullptr;  // default stream
-
-  if (!ComputeMaskIndex(stream, sequence_length, batch_size, input_mask, static_cast<int*>(mask_index))) {
-    return false;
-  }
 
   if (element_size == 2) {
     return EmbedSkipLayerNorm<half>(
@@ -200,6 +122,7 @@ bool LaunchEmbedLayerNormKernel(
         reinterpret_cast<float*>(output));
   }
 }
+
 
 }  // namespace cuda
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm_impl.h
@@ -7,10 +7,8 @@ namespace contrib {
 namespace cuda {
 
 bool LaunchEmbedLayerNormKernel(void* output,                     // output tensor
-                                void* mask_index,                 // output mask index
                                 const int* input_ids,             // input word IDs
                                 const int* segment_ids,           // input segment IDs
-                                const int* input_mask,            // input mask
                                 const void* gamma,                // weight for layer normalization
                                 const void* beta,                 // bias for layer normalization
                                 const void* word_embedding,       // weights for word embeddings

--- a/onnxruntime/contrib_ops/cuda/bert/mask_index.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/mask_index.cc
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/common.h"
+#include "core/framework/tensorprotoutils.h"
+#include "onnx/defs/tensor_proto_util.h"
+#include "mask_index.h"
+#include "mask_index_impl.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+#define REGISTER_KERNEL_TYPED(T)                                  \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
+      MaskIndex,                                                  \
+      kMSDomain,                                                  \
+      1,                                                          \
+      T,                                                          \
+      kCudaExecutionProvider,                                     \
+      KernelDefBuilder()                                          \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      MaskIndex<T>);
+
+REGISTER_KERNEL_TYPED(int32_t)
+REGISTER_KERNEL_TYPED(int64_t)
+
+using namespace ONNX_NAMESPACE;
+
+template <typename T>
+MaskIndex<T>::MaskIndex(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info) {
+}
+
+template <typename T>
+Status MaskIndex<T>::ComputeInternal(OpKernelContext* context) const {
+  const Tensor* mask = context->Input<Tensor>(0);
+
+  const auto input_dims = mask->Shape().GetDims();
+  if (input_dims.size() != 2) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "input is expected to have 2 dimensions, got ", input_dims.size());
+  }
+
+  std::vector<int64_t> mask_index_dims;
+  mask_index_dims.push_back(input_dims[0]);
+  TensorShape mask_index_shape(mask_index_dims);
+  Tensor* mask_index = context->Output(0, mask_index_shape);
+
+  int batch_size = static_cast<int>(input_dims[0]);
+  int sequence_length = static_cast<int>(input_dims[1]);
+  cudaStream_t stream = nullptr; // use default stream
+
+  if (!LaunchMaskIndexKernel<T>(
+          stream,
+          mask->template Data<T>(),
+          mask_index->template MutableData<int32_t>(),
+          batch_size,
+          sequence_length)) {
+    // Get last error to reset it to cudaSuccess.
+    CUDA_CALL(cudaGetLastError());
+    return Status(common::ONNXRUNTIME, common::FAIL);
+  }
+
+  return Status::OK();
+}
+
+}  //namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/mask_index.h
+++ b/onnxruntime/contrib_ops/cuda/bert/mask_index.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "core/common/common.h"
+#include "core/framework/op_kernel.h"
+#include "core/providers/cuda/cuda_common.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+using namespace onnxruntime::cuda;
+
+template <typename T>
+class MaskIndex final : public CudaKernel {
+ public:
+  MaskIndex(const OpKernelInfo& op_kernel_info);
+  Status ComputeInternal(OpKernelContext* ctx) const override;
+};
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/mask_index_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/mask_index_impl.cu
@@ -1,0 +1,118 @@
+/*
+ The implementation of this file is based on embLayerNorm plugin in TensorRT demo:
+ https://github.com/NVIDIA/TensorRT/tree/release/5.1/demo/BERT/
+ 
+Copyright 2019 NVIDIA Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "mask_index_impl.h"
+#include "core/providers/cuda/shared_inc/cuda_call.h"
+#include <cub/cub.cuh>
+
+using namespace cub;
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+template <typename T, unsigned TPB>
+__global__ void MaskIndexKernelSmall(int sequence_length, const T* mask, int* mask_index) {
+  using BlockReduce = cub::BlockReduce<int, TPB>;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+
+  // blockIdx.x is b
+  const int offset = blockIdx.x * sequence_length;  // batch strides of sequence_length
+
+  cub::Min min;
+  int thread_data(sequence_length);
+
+  const int idx = offset + threadIdx.x;
+  if (threadIdx.x < sequence_length) {
+    const T val = mask[idx];
+    if (val == 0)  // masked position: report thread idx
+    {
+      thread_data = threadIdx.x;
+    }
+  }
+
+  const auto min_index = BlockReduce(temp_storage).Reduce(thread_data, min);
+
+  if (threadIdx.x == 0) {
+    mask_index[blockIdx.x] = min_index;
+  }
+}
+
+template <typename T, unsigned TPB>
+__global__ void MaskIndexKernel(int sequence_length, const T* mask, int* mask_index) {
+  using BlockReduce = cub::BlockReduce<int, TPB>;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+
+  // blockIdx.x is b
+  const int offset = blockIdx.x * sequence_length;  // batch strides of sequence_length
+
+  cub::Min min;
+  int thread_data(sequence_length);
+
+  for (int i = threadIdx.x; i < sequence_length; i += TPB) {
+    const int idx = offset + i;
+    const T val = mask[idx];
+    if (val == 0)
+    {
+      thread_data = min(thread_data, i);
+    }
+  }
+
+  const auto min_index = BlockReduce(temp_storage).Reduce(thread_data, min);
+
+  if (threadIdx.x == 0) {
+    mask_index[blockIdx.x] = min_index;
+  }
+}
+
+template <typename T>
+bool LaunchMaskIndexKernel(
+    cudaStream_t stream,
+    const T* mask,
+    int* mask_index,
+    int batch_size,
+    int sequence_length)
+{
+  // Assume input mask total elements n = batch_size x sequence_length.
+  // mask_index is of length batch_size, and the value is the index of first mask (0) within each batch.
+  if (sequence_length <= 32) {
+    MaskIndexKernelSmall<T, 32><<<batch_size, 32, 0, stream>>>(sequence_length, mask, mask_index);
+  } else if (sequence_length <= 128) {
+    MaskIndexKernelSmall<T, 128><<<batch_size, 128, 0, stream>>>(sequence_length, mask, mask_index);
+  } else if (sequence_length == 384) {
+    MaskIndexKernelSmall<T, 384><<<batch_size, 384, 0, stream>>>(sequence_length, mask, mask_index);
+  } else {
+    MaskIndexKernel<T, 256><<<batch_size, 256, 0, stream>>>(sequence_length, mask, mask_index);
+  }
+
+  return CUDA_CALL(cudaPeekAtLastError());
+}
+
+#define SPECIALIZED_IMPL(T) \
+  template bool LaunchMaskIndexKernel<T>(cudaStream_t stream, const T * input_mask, int* mask_index, int batch_size, int sequence_length);
+
+SPECIALIZED_IMPL(int32_t)
+SPECIALIZED_IMPL(int64_t)
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/mask_index_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/mask_index_impl.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+template <typename T>
+bool LaunchMaskIndexKernel(cudaStream_t stream,   // stream
+                           const T* mask,         // input mask
+                           int* mask_index,       // output mask index
+                           int batch_size,        // batch size
+                           int sequence_length);  // sequence length
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cuda_contrib_kernels.cc
@@ -9,25 +9,29 @@ using namespace onnxruntime::common;
 namespace onnxruntime {
 namespace contrib {
 namespace cuda {
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, Attention);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, Attention);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, EmbedLayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, Gelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, Gelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, Gelu);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, int32_t, MaskIndex);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, int64_t, MaskIndex);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, SkipLayerNormalization);
 
 // These ops were experimental ops in onnx domain which have been removed now. We add them here as
 // contrib ops to maintain backward compatibility
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, Affine);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, Affine);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, Affine);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, Attention);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, Attention);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, ConvTransposeWithDynamicPads);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, Crop);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, Crop);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, Crop);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, int32_t, DynamicSlice);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, int64_t, DynamicSlice);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, EmbedLayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, ImageScaler);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, ImageScaler);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, ImageScaler);
@@ -37,8 +41,6 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, ScaledTanh);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, ScaledTanh);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, ScaledTanh);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, SkipLayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, ThresholdedRelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, ThresholdedRelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, ThresholdedRelu);
@@ -48,25 +50,29 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain,
 
 void RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
   static const BuildKernelCreateInfoFn function_table[] = {
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, Attention)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, Attention)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, EmbedLayerNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, Gelu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, Gelu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, Gelu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, int32_t, MaskIndex)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, int64_t, MaskIndex)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, SkipLayerNormalization)>,
 
       // These ops were experimental ops in onnx domain which have been removed now. We add them here as
       // contrib ops to maintain backward compatibility
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, Affine)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, Affine)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, Affine)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, Attention)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, Attention)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, ConvTransposeWithDynamicPads)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, Crop)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, Crop)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, Crop)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, int32_t, DynamicSlice)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, int64_t, DynamicSlice)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, EmbedLayerNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, ImageScaler)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, ImageScaler)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, ImageScaler)>,
@@ -76,8 +82,6 @@ void RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, ScaledTanh)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, ScaledTanh)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, ScaledTanh)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, SkipLayerNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, ThresholdedRelu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, ThresholdedRelu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, ThresholdedRelu)>,

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -314,6 +314,32 @@ void RegisterBertSchemas() {
         updateOutputShape(ctx, 1, mask_index_shape);
       });
 
+  ONNX_CONTRIB_OPERATOR_SCHEMA(MaskIndex)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetSupportLevel(OpSchema::SupportType::EXPERIMENTAL)
+      .SetDoc("Mask Index for BERT")
+      .Input(0, "mask", "2D attention mask with shape (batch_size, sequence_length)", "T")
+      .Output(0, "mask_index", "1D mask_index tensor with shape (batch_size)", "Ti")
+      .TypeConstraint("T", {"tensor(int32)", "tensor(int64)"}, "Constrain input integer tensors types")
+      .TypeConstraint("Ti", {"tensor(int32)"}, "Constrain output integer tensors types")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        if (!hasInputShape(ctx, 0))
+          return;
+
+        auto& mask_shape = getInputShape(ctx, 0);
+        auto& mask_dims = mask_shape.dim();
+
+        if (mask_dims.size() != 2) {
+          fail_shape_inference("Inputs 0 shall be 2 dimensions");
+        }
+
+        // mask_index shape is (batch_size)
+        ONNX_NAMESPACE::TensorShapeProto mask_index_shape;
+        *mask_index_shape.add_dim() = mask_shape.dim(0);
+        updateOutputShape(ctx, 0, mask_index_shape);
+      });
+
   ONNX_CONTRIB_OPERATOR_SCHEMA(SkipLayerNormalization)
       .SetDomain(kMSDomain)
       .SinceVersion(1)

--- a/onnxruntime/test/contrib_ops/embedlayernorm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/embedlayernorm_op_test.cc
@@ -269,5 +269,86 @@ TEST(EmbedLayerNormTest, EmbedLayerNormBatch2) {
           sequence_length,
           hidden_size);
 }
+
+// BatchSize > HiddenSize to reproduce mask processing bug
+TEST(EmbedLayerNormTest, EmbedLayerNormLargeBatchSmallHiddenSize) {
+  int batch_size = 5;
+  int sequence_length = 2;
+  int hidden_size = 4;
+
+  std::vector<int32_t> input_ids_data = {
+      1, 3,
+      1, 3,
+      2, 0,
+      1, 3,
+      2, 0};
+
+  std::vector<int32_t> segment_ids_data = {
+      0, 1,
+      0, 1,
+      0, 0,
+      0, 1,
+      0, 0};
+
+  std::vector<int32_t> mask_data = {
+      1, 1,
+      1, 1,
+      1, 0,
+      1, 1,
+      1, 0};
+
+  std::vector<float> word_embedding_data = {
+      0.2f, 0.1f, 0.4f, -0.6f,
+      0.3f, 0.2f, 0.5f, 0.6f,
+      0.6f, 0.7f, 0.0f, -0.1f,
+      0.8f, 0.6f, 0.9f, 1.2f,
+      0.1f, 0.3f, 0.5f, 0.9f,
+      1.0f, -2.0f, 1.1f, 0.8f};
+
+  std::vector<float> position_embedding_data = {
+      0.1f, 0.1f, 0.4f, 0.6f,
+      0.6f, 0.0f, 0.8f, 0.6f,
+      0.3f, 0.9f, -2.0f, 0.8f};
+
+  std::vector<float> segment_embedding_data = {
+      0.3f, 0.4f, 0.9f, 0.1f,
+      0.7f, 0.3f, 0.5f, 0.2f};
+
+  std::vector<float> gamma_data = {
+      0.25f, 0.15f, 0.45f, -0.66f};
+
+  std::vector<float> beta_data = {
+      0.6f, 0.2f, 0.5f, -0.6f};
+
+  std::vector<float> output_data = {
+      0.36917170882225037, 0.061503000557422638, 1.1598974466323853, -0.85092413425445557,
+      0.74301940202713013, -0.057434864342212677, 0.84324657917022705, -0.85171419382095337,
+      0.36917170882225037, 0.061503000557422638, 1.1598974466323853, -0.85092413425445557,
+      0.74301940202713013, -0.057434864342212677, 0.84324657917022705, -0.85171419382095337,
+      0.57668739557266235, 0.2979130744934082, 0.96158987283706665, 0.44627034664154053,
+      0.64977931976318359, 0.11039737612009048, 1.1869535446166992, 0.14469735324382782,
+      0.36917170882225037, 0.061503000557422638, 1.1598974466323853, -0.85092413425445557,
+      0.74301940202713013, -0.057434864342212677, 0.84324657917022705, -0.85171419382095337,
+      0.57668739557266235, 0.2979130744934082, 0.96158987283706665, 0.44627034664154053,
+      0.64977931976318359, 0.11039737612009048, 1.1869535446166992, 0.14469735324382782
+  };
+
+  std::vector<int32_t> mask_index_data = {
+      2, 2, 1, 2, 1};
+
+  RunTest(input_ids_data,
+          segment_ids_data,
+          mask_data,
+          word_embedding_data,
+          position_embedding_data,
+          segment_embedding_data,
+          gamma_data,
+          beta_data,
+          output_data,
+          mask_index_data,
+          batch_size,
+          sequence_length,
+          hidden_size);
+}
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/mask_index_op_test.cc
+++ b/onnxruntime/test/contrib_ops/mask_index_op_test.cc
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "test/common/tensor_op_test_utils.h"
+#include "test/common/cuda_op_test_utils.h"
+#include "test/providers/provider_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+template<typename T>
+void RunTest(
+    const std::vector<T>& mask_data,
+    const std::vector<int32_t>& mask_index_data,
+    int batch_size,
+    int sequence_length) {
+  if (HasCudaEnvironment(0)) { // MaskIndex has only Cuda implementation right now.
+    // Input and output shapes
+    std::vector<int64_t> mask_dims = {batch_size, sequence_length};
+    std::vector<int64_t> mask_index_dims = {batch_size};
+
+    OpTester tester("MaskIndex", 1, onnxruntime::kMSDomain);
+    tester.AddInput<T>("mask", mask_dims, mask_data);
+    tester.AddOutput<int32_t>("mask_index", mask_index_dims, mask_index_data);
+
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
+TEST(MaskIndexTest, MaskIndexTest_batch1_int32) {
+  int batch_size = 1;
+  int sequence_length = 2;
+
+  std::vector<int32_t> mask_data = {
+      1, 1};
+
+  std::vector<int32_t> mask_index_data = {
+      2};
+
+  RunTest(mask_data,
+          mask_index_data,
+          batch_size,
+          sequence_length);
+}
+
+TEST(MaskIndexTest, MaskIndexTest_batch1_int64) {
+  int batch_size = 1;
+  int sequence_length = 2;
+
+  std::vector<int64_t> mask_data = {
+      1, 1};
+
+  std::vector<int32_t> mask_index_data = {
+      2};
+
+  RunTest(mask_data,
+          mask_index_data,
+          batch_size,
+          sequence_length);
+}
+
+TEST(MaskIndexTest, MaskIndexTest_batch3_int32) {
+  int batch_size = 3;
+  int sequence_length = 2;
+
+  std::vector<int32_t> mask_data = {
+      1, 1,
+      1, 1,
+      1, 0};
+
+  std::vector<int32_t> mask_index_data = {
+      2, 2, 1};
+
+  RunTest(mask_data,
+          mask_index_data,
+          batch_size,
+          sequence_length);
+}
+
+
+TEST(MaskIndexTest, MaskIndexTest_batch5_int64) {
+  int batch_size = 5;
+  int sequence_length = 2;
+
+  std::vector<int64_t> mask_data = {
+      0, 0,  // All 0
+      1, 1,  // All 1
+      1, 0,
+      1, 1,
+      1, 0};
+
+  std::vector<int32_t> mask_index_data = {
+      0, 2, 1, 2, 1};
+
+  RunTest(mask_data,
+          mask_index_data,
+          batch_size,
+          sequence_length);
+}
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
**Description**: Add MaskIndex cuda op for BERT optimization

**Motivation and Context**
- Why is this change required? What problem does it solve?

MaskIndex was in EmbedLayerNormalization, which makes the embed layer coupling with mask processing. Here, we add a new op for mask_index calculation to decouple them later.