### PR TITLE
apply eigen patch only for ACL.

### DIFF
--- a/cmake/external/eigen.cmake
+++ b/cmake/external/eigen.cmake
@@ -5,8 +5,8 @@ if (onnxruntime_USE_PREINSTALLED_EIGEN)
     file(TO_CMAKE_PATH ${eigen_SOURCE_PATH} eigen_INCLUDE_DIRS)
     target_include_directories(eigen INTERFACE ${eigen_INCLUDE_DIRS})
 else ()
-    execute_process(COMMAND  git apply --ignore-space-change --ignore-whitespace ${PROJECT_SOURCE_DIR}/patches/eigen/Fix_Eigen_Build_Break.patch
-                    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-                   )
+    if (onnxruntime_USE_ACL)
+        execute_process(COMMAND  git apply --ignore-space-change --ignore-whitespace ${PROJECT_SOURCE_DIR}/patches/eigen/Fix_Eigen_Build_Break.patch WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    endif()
     set(eigen_INCLUDE_DIRS  "${PROJECT_SOURCE_DIR}/external/eigen")
 endif()


### PR DESCRIPTION
re-builds fail because it applies patch which may be already applied.
disabling for now via check for onnxruntime_USE_ACL