### PR TITLE
Exclude candy from CUDA model tests

### DIFF
--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -526,6 +526,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
 #endif
 
 #ifdef USE_CUDA
+  broken_tests.insert({"candy", "result mismatch"});
   broken_tests.insert({"mask_rcnn_keras", "result mismatch"});
   broken_tests.insert({"mlperf_ssd_mobilenet_300", "unknown error"});
   broken_tests.insert({"mlperf_ssd_resnet34_1200", "unknown error"});


### PR DESCRIPTION
**Description**: 

Exclude candy from CUDA model tests

**Motivation and Context**
- Why is this change required? What problem does it solve?

Because it is flaky.
see: https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=94410&view=logs&j=31d3521d-323c-5c8e-d36c-e0155c8dffe1

- If it fixes an open issue, please link to the issue here.
