### PR TITLE
Fix crash in releasing TLS from CUDA EP dtor

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -103,7 +103,6 @@ CUDAExecutionProvider::~CUDAExecutionProvider() {
     CUDA_CALL_THROW(cudaEventDestroy(e));
     it = deferred_release_cpu_ptr_.erase(it);
   }
-  ReleasePerThreadStuffs();
 }
 
 CUDAExecutionProvider::PerThreadContext& CUDAExecutionProvider::GetPerThreadContext() const {

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.h
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.h
@@ -138,9 +138,11 @@ class CUDAExecutionProvider : public IExecutionProvider {
   // thread local context during execution
   using PerThreadContextMap = std::unordered_map<const CUDAExecutionProvider*, std::shared_ptr<PerThreadContext>>;
   static thread_local std::unique_ptr<PerThreadContextMap> per_thread_context_map_;
+  // in some compilers, TLS may not be accessible in EP's dtor, so hold ownership in here
+  mutable std::unordered_map<unsigned int, std::shared_ptr<PerThreadContext>> inuse_contexts_;
 
   // reuse thread local context
-  mutable std::deque<std::shared_ptr<PerThreadContext>> context_pool_;
+  mutable std::deque<std::shared_ptr<PerThreadContext>> retired_context_pool_;
   mutable OrtMutex context_pool_mutex_;
 
   PerThreadContext& GetPerThreadContext() const;


### PR DESCRIPTION
**Description**: Fixes crash in CUDA EP dtor in some compilers
**Motivation and Context**
- Seems the TLS dtor happens before EP dtor and may cause issues
- The code was intended to prevent memory leak report, but removing it seems not triggering that.
