### PR TITLE
Set ElementType to String type of node metadata, instead of byte[]

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
@@ -205,7 +205,7 @@ namespace Microsoft.ML.OnnxRuntime
         {
             if (typeof(T) == typeof(string))
             {
-                var nativeTensorWrapper = new NativeOnnxTensorMemory<byte>(nativeOnnxValue, true);
+                var nativeTensorWrapper = new NativeOnnxTensorMemory<string>(nativeOnnxValue);
                 var dt = new DenseTensor<string>(nativeTensorWrapper.GetBytesAsStringMemory(), nativeTensorWrapper.Dimensions);
                 return new DisposableNamedOnnxValue(name, dt, nativeTensorWrapper);
             }
@@ -225,7 +225,7 @@ namespace Microsoft.ML.OnnxRuntime
             if (typeof(K) == typeof(string))
             {
                 var map = new Dictionary<string, V>();
-                var nativeTensorWrapper = new NativeOnnxTensorMemory<byte>(nativeOnnxValueKeys, true);
+                var nativeTensorWrapper = new NativeOnnxTensorMemory<string>(nativeOnnxValueKeys);
                 var denseTensorKeys = new DenseTensor<string>(nativeTensorWrapper.GetBytesAsStringMemory(), nativeTensorWrapper.Dimensions);
                 for (var i = 0; i < denseTensorKeys.Length; i++)
                 {

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.cs
@@ -471,7 +471,7 @@ namespace Microsoft.ML.OnnxRuntime
                     width = sizeof(sbyte);
                     break;
                 case TensorElementType.String:
-                    type = typeof(byte);
+                    type = typeof(string);
                     width = sizeof(byte);
                     break;
                 case TensorElementType.Bool:

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
@@ -75,7 +75,7 @@ namespace Microsoft.ML.OnnxRuntime
                 }
                 else
                 {
-                   UIntPtr strLen;
+                    UIntPtr strLen;
                     var offsets = new UIntPtr[_elementCount];
                     NativeApiStatus.VerifySuccess(NativeMethods.OrtGetStringTensorDataLength(_onnxValueHandle, out strLen));
                     var dataBuffer = new byte[strLen.ToUInt64()];

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ML.OnnxRuntime
         private int _elementWidth;
         private int[] _dimensions;
 
-        public NativeOnnxTensorMemory(IntPtr onnxValueHandle, bool isStringTensor = false)
+        public NativeOnnxTensorMemory(IntPtr onnxValueHandle)
         {
             IntPtr typeAndShape = IntPtr.Zero;
             try
@@ -69,15 +69,13 @@ namespace Microsoft.ML.OnnxRuntime
                     _dimensions[i] = (int)shape[i];
                 }
 
-                if (!isStringTensor)
+                if (typeof(T) != typeof(string))
                 {
                     NativeApiStatus.VerifySuccess(NativeMethods.OrtGetTensorMutableData(_onnxValueHandle, out _dataBufferPointer));
                 }
                 else
                 {
-                    if (typeof(T) != typeof(byte))
-                        throw new NotSupportedException(nameof(NativeOnnxTensorMemory<T>) + " T = " + nameof(T) + ". Should = byte, when isStringTensor is true");
-                    UIntPtr strLen;
+                   UIntPtr strLen;
                     var offsets = new UIntPtr[_elementCount];
                     NativeApiStatus.VerifySuccess(NativeMethods.OrtGetStringTensorDataLength(_onnxValueHandle, out strLen));
                     var dataBuffer = new byte[strLen.ToUInt64()];
@@ -191,7 +189,7 @@ namespace Microsoft.ML.OnnxRuntime
             if (IsDisposed)
                 throw new ObjectDisposedException(nameof(NativeOnnxTensorMemory<T>));
 
-            if (typeof(T) != typeof(byte))
+            if (typeof(T) != typeof(string))
                 throw new NotSupportedException(nameof(NativeOnnxTensorMemory<T>.GetBytesAsStringMemory) + ": T must be byte");
 
             return (_dataBufferAsString == null) ? new Memory<string>() : new Memory<string>(_dataBufferAsString);


### PR DESCRIPTION
**Description**: Show a models input type correctly as 'string' instead of 'byte[]' when a user inspects the model inputs via the C# API.

**Motivation and Context**
- It's a bug fix for #2315 

