### PR TITLE
Update test data

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -328,7 +328,8 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 { "mlperf_ssd_mobilenet_300", "Could not find file output_0.pb" },
                 { "tf_resnet_v1_50", "result mismatch when Conv BN Fusion is applied" },
                 { "tf_resnet_v1_101", "result mismatch when Conv BN Fusion is applied" },
-                { "tf_resnet_v1_152", "result mismatch when Conv BN Fusion is applied" }
+                { "tf_resnet_v1_152", "result mismatch when Conv BN Fusion is applied" },
+                { "mask_rcnn_keras", "Model should be edited to remove the extra outputs" },
             };
 
             // The following models fails on nocontribops win CI

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -437,83 +437,85 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     {
                         testDataDirNamePattern = "seq_lens*"; // discrepency in data directory
                     }
-                    var testDataDir = modelDir.EnumerateDirectories(testDataDirNamePattern).First();
-                    var inputContainer = new List<NamedOnnxValue>();
-                    var outputContainer = new List<NamedOnnxValue>();
-                    foreach (var f in testDataDir.EnumerateFiles("input_*.pb"))
+                    foreach (var testDataDir in modelDir.EnumerateDirectories(testDataDirNamePattern))
                     {
-                        inputContainer.Add(LoadTensorFromFilePb(f.FullName, inMeta));
-                    }
-                    foreach (var f in testDataDir.EnumerateFiles("output_*.pb"))
-                    {
-                        outputContainer.Add(LoadTensorFromFilePb(f.FullName, session.OutputMetadata));
-                    }
-
-                    using (var resultCollection = session.Run(inputContainer))
-                    {
-                        foreach (var result in resultCollection)
+                        var inputContainer = new List<NamedOnnxValue>();
+                        var outputContainer = new List<NamedOnnxValue>();
+                        foreach (var f in testDataDir.EnumerateFiles("input_*.pb"))
                         {
-                            Assert.True(session.OutputMetadata.ContainsKey(result.Name));
-                            var outputMeta = session.OutputMetadata[result.Name];
-                            NamedOnnxValue outputValue = null;
-                            foreach (var o in outputContainer)
+                            inputContainer.Add(LoadTensorFromFilePb(f.FullName, inMeta));
+                        }
+                        foreach (var f in testDataDir.EnumerateFiles("output_*.pb"))
+                        {
+                            outputContainer.Add(LoadTensorFromFilePb(f.FullName, session.OutputMetadata));
+                        }
+
+                        using (var resultCollection = session.Run(inputContainer))
+                        {
+                            foreach (var result in resultCollection)
                             {
-                                if (o.Name == result.Name)
+                                Assert.True(session.OutputMetadata.ContainsKey(result.Name));
+                                var outputMeta = session.OutputMetadata[result.Name];
+                                NamedOnnxValue outputValue = null;
+                                foreach (var o in outputContainer)
                                 {
-                                    outputValue = o;
-                                    break;
+                                    if (o.Name == result.Name)
+                                    {
+                                        outputValue = o;
+                                        break;
+                                    }
                                 }
-                            }
-                            if (outputValue == null)
-                            {
-                                outputValue = outputContainer.First(); // in case the output data file does not contain the name
-                            }
-                            if (outputMeta.IsTensor)
-                            {
-                                if (outputMeta.ElementType == typeof(float))
+                                if (outputValue == null)
                                 {
-                                    Assert.Equal(result.AsTensor<float>(), outputValue.AsTensor<float>(), new floatComparer());
+                                    outputValue = outputContainer.First(); // in case the output data file does not contain the name
                                 }
-                                else if (outputMeta.ElementType == typeof(int))
+                                if (outputMeta.IsTensor)
                                 {
-                                    Assert.Equal(result.AsTensor<int>(), outputValue.AsTensor<int>(), new ExactComparer<int>());
-                                }
-                                else if (outputMeta.ElementType == typeof(uint))
-                                {
-                                    Assert.Equal(result.AsTensor<uint>(), outputValue.AsTensor<uint>(), new ExactComparer<uint>());
-                                }
-                                else if (outputMeta.ElementType == typeof(short))
-                                {
-                                    Assert.Equal(result.AsTensor<short>(), outputValue.AsTensor<short>(), new ExactComparer<short>());
-                                }
-                                else if (outputMeta.ElementType == typeof(ushort))
-                                {
-                                    Assert.Equal(result.AsTensor<ushort>(), outputValue.AsTensor<ushort>(), new ExactComparer<ushort>());
-                                }
-                                else if (outputMeta.ElementType == typeof(long))
-                                {
-                                    Assert.Equal(result.AsTensor<long>(), outputValue.AsTensor<long>(), new ExactComparer<long>());
-                                }
-                                else if (outputMeta.ElementType == typeof(ulong))
-                                {
-                                    Assert.Equal(result.AsTensor<ulong>(), outputValue.AsTensor<ulong>(), new ExactComparer<ulong>());
-                                }
-                                else if (outputMeta.ElementType == typeof(byte))
-                                {
-                                    Assert.Equal(result.AsTensor<byte>(), outputValue.AsTensor<byte>(), new ExactComparer<byte>());
-                                }
-                                else if (outputMeta.ElementType == typeof(bool))
-                                {
-                                    Assert.Equal(result.AsTensor<bool>(), outputValue.AsTensor<bool>(), new ExactComparer<bool>());
+                                    if (outputMeta.ElementType == typeof(float))
+                                    {
+                                        Assert.Equal(result.AsTensor<float>(), outputValue.AsTensor<float>(), new floatComparer());
+                                    }
+                                    else if (outputMeta.ElementType == typeof(int))
+                                    {
+                                        Assert.Equal(result.AsTensor<int>(), outputValue.AsTensor<int>(), new ExactComparer<int>());
+                                    }
+                                    else if (outputMeta.ElementType == typeof(uint))
+                                    {
+                                        Assert.Equal(result.AsTensor<uint>(), outputValue.AsTensor<uint>(), new ExactComparer<uint>());
+                                    }
+                                    else if (outputMeta.ElementType == typeof(short))
+                                    {
+                                        Assert.Equal(result.AsTensor<short>(), outputValue.AsTensor<short>(), new ExactComparer<short>());
+                                    }
+                                    else if (outputMeta.ElementType == typeof(ushort))
+                                    {
+                                        Assert.Equal(result.AsTensor<ushort>(), outputValue.AsTensor<ushort>(), new ExactComparer<ushort>());
+                                    }
+                                    else if (outputMeta.ElementType == typeof(long))
+                                    {
+                                        Assert.Equal(result.AsTensor<long>(), outputValue.AsTensor<long>(), new ExactComparer<long>());
+                                    }
+                                    else if (outputMeta.ElementType == typeof(ulong))
+                                    {
+                                        Assert.Equal(result.AsTensor<ulong>(), outputValue.AsTensor<ulong>(), new ExactComparer<ulong>());
+                                    }
+                                    else if (outputMeta.ElementType == typeof(byte))
+                                    {
+                                        Assert.Equal(result.AsTensor<byte>(), outputValue.AsTensor<byte>(), new ExactComparer<byte>());
+                                    }
+                                    else if (outputMeta.ElementType == typeof(bool))
+                                    {
+                                        Assert.Equal(result.AsTensor<bool>(), outputValue.AsTensor<bool>(), new ExactComparer<bool>());
+                                    }
+                                    else
+                                    {
+                                        Assert.True(false, "The TestPretrainedModels does not yet support output of type " + nameof(outputMeta.ElementType));
+                                    }
                                 }
                                 else
                                 {
-                                    Assert.True(false, "The TestPretrainedModels does not yet support output of type " + nameof(outputMeta.ElementType));
+                                    Assert.True(false, "TestPretrainedModel cannot handle non-tensor outputs yet");
                                 }
-                            }
-                            else
-                            {
-                                Assert.True(false, "TestPretrainedModel cannot handle non-tensor outputs yet");
                             }
                         }
                     }

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -357,7 +357,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     static const ORTCHAR_T* cuda_flaky_tests[] = {
         ORT_TSTR("fp16_inception_v1"),
         ORT_TSTR("fp16_shufflenet"), ORT_TSTR("fp16_tiny_yolov2")};
-    static const ORTCHAR_T* dml_disabled_tests[] = {ORT_TSTR("mlperf_ssd_resnet34_1200"), ORT_TSTR("mlperf_ssd_mobilenet_300"), ORT_TSTR("mask_rcnn_keras"), ORT_TSTR("mask_rcnn"), ORT_TSTR("faster_rcnn")};
+    static const ORTCHAR_T* dml_disabled_tests[] = {ORT_TSTR("mlperf_ssd_resnet34_1200"), ORT_TSTR("mlperf_ssd_mobilenet_300"),  ORT_TSTR("mask_rcnn"), ORT_TSTR("faster_rcnn")};
     static const ORTCHAR_T* dnnl_disabled_tests[] = {ORT_TSTR("test_densenet121"), ORT_TSTR("test_resnet18v2"), ORT_TSTR("test_resnet34v2"), ORT_TSTR("test_resnet50v2"), ORT_TSTR("test_resnet101v2"),
                                                      ORT_TSTR("test_resnet101v2"), ORT_TSTR("test_vgg19"), ORT_TSTR("tf_inception_resnet_v2"), ORT_TSTR("tf_inception_v1"), ORT_TSTR("tf_inception_v3"), ORT_TSTR("tf_inception_v4"), ORT_TSTR("tf_mobilenet_v1_1.0_224"),
                                                      ORT_TSTR("tf_mobilenet_v2_1.0_224"), ORT_TSTR("tf_mobilenet_v2_1.4_224"), ORT_TSTR("tf_nasnet_large"), ORT_TSTR("tf_pnasnet_large"), ORT_TSTR("tf_resnet_v1_50"), ORT_TSTR("tf_resnet_v1_101"), ORT_TSTR("tf_resnet_v1_101"),
@@ -461,7 +461,6 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   broken_tests.insert({"dequantizelinear", "ambiguity in scalar dimensions [] vs [1]", {"onnx150"}});
   broken_tests.insert({"mlperf_ssd_resnet34_1200", "Results mismatch"});
   broken_tests.insert({"BERT_Squad", "Invalid Feed Input Name:input4"});
-  broken_tests.insert({"mask_rcnn_keras", "Results mismatch: 8 of 81000"});
   broken_tests.insert({"candy", "Results mismatch: 2 of 150528"});
   broken_tests.insert({"convtranspose_1d", "1d convtranspose not supported yet"});
 #endif
@@ -529,7 +528,6 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
 
 #ifdef USE_CUDA
   broken_tests.insert({"candy", "result mismatch"});
-  broken_tests.insert({"mask_rcnn_keras", "result mismatch"});
   broken_tests.insert({"mlperf_ssd_mobilenet_300", "unknown error"});
   broken_tests.insert({"mlperf_ssd_resnet34_1200", "unknown error"});
   broken_tests.insert({"tf_inception_v1", "flaky test"}); //TODO: Investigate cause for flakiness

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -357,7 +357,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     static const ORTCHAR_T* cuda_flaky_tests[] = {
         ORT_TSTR("fp16_inception_v1"),
         ORT_TSTR("fp16_shufflenet"), ORT_TSTR("fp16_tiny_yolov2")};
-    static const ORTCHAR_T* dml_disabled_tests[] = {ORT_TSTR("mlperf_ssd_resnet34_1200"), ORT_TSTR("mlperf_ssd_mobilenet_300"),  ORT_TSTR("mask_rcnn"), ORT_TSTR("faster_rcnn")};
+    static const ORTCHAR_T* dml_disabled_tests[] = {ORT_TSTR("mlperf_ssd_resnet34_1200"), ORT_TSTR("mlperf_ssd_mobilenet_300"), ORT_TSTR("mask_rcnn"), ORT_TSTR("faster_rcnn")};
     static const ORTCHAR_T* dnnl_disabled_tests[] = {ORT_TSTR("test_densenet121"), ORT_TSTR("test_resnet18v2"), ORT_TSTR("test_resnet34v2"), ORT_TSTR("test_resnet50v2"), ORT_TSTR("test_resnet101v2"),
                                                      ORT_TSTR("test_resnet101v2"), ORT_TSTR("test_vgg19"), ORT_TSTR("tf_inception_resnet_v2"), ORT_TSTR("tf_inception_v1"), ORT_TSTR("tf_inception_v3"), ORT_TSTR("tf_inception_v4"), ORT_TSTR("tf_mobilenet_v1_1.0_224"),
                                                      ORT_TSTR("tf_mobilenet_v2_1.0_224"), ORT_TSTR("tf_mobilenet_v2_1.4_224"), ORT_TSTR("tf_nasnet_large"), ORT_TSTR("tf_pnasnet_large"), ORT_TSTR("tf_resnet_v1_50"), ORT_TSTR("tf_resnet_v1_101"), ORT_TSTR("tf_resnet_v1_101"),
@@ -398,25 +398,22 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     std::string res = stat.ToString();
     fwrite(res.c_str(), 1, res.size(), stdout);
   }
-  // clang-format off
 
-  struct BrokenTest
-  {
+  struct BrokenTest {
     std::string test_name_;
     std::string reason_;
-    std::set<std::string> broken_versions_ = {}; // apply to all versions if empty
+    std::set<std::string> broken_versions_ = {};  // apply to all versions if empty
     BrokenTest(std::string name, std::string reason) : test_name_(std::move(name)), reason_(std::move(reason)) {}
-    BrokenTest(std::string name, std::string reason, const std::initializer_list<std::string>& versions) :
-      test_name_(std::move(name)), reason_(std::move(reason)), broken_versions_(versions) {}
-    bool operator < (const struct BrokenTest& test) const {
-        return strcmp(test_name_.c_str(), test.test_name_.c_str()) < 0;
+    BrokenTest(std::string name, std::string reason, const std::initializer_list<std::string>& versions) : test_name_(std::move(name)), reason_(std::move(reason)), broken_versions_(versions) {}
+    bool operator<(const struct BrokenTest& test) const {
+      return strcmp(test_name_.c_str(), test.test_name_.c_str()) < 0;
     }
   };
 
   std::set<BrokenTest> broken_tests = {
       {"BERT_Squad", "test data bug"},
-      {"constantofshape_float_ones", "test data bug", {"onnx141","onnx150"}},
-      {"constantofshape_int_zeros", "test data bug", {"onnx141","onnx150"}},
+      {"constantofshape_float_ones", "test data bug", {"onnx141", "onnx150"}},
+      {"constantofshape_int_zeros", "test data bug", {"onnx141", "onnx150"}},
       {"convtranspose_3d", "3d convtranspose not supported yet"},
       {"cast_STRING_to_FLOAT", "Linux CI has old ONNX python package with bad test data", {"onnx141"}},
       // Numpy float to string has unexpected rounding for some results given numpy default precision is meant to be 8.
@@ -443,100 +440,100 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
       {"resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric", "Bad onnx test output. Needs test fix."},
       {"bitshift_right_uint16", "BitShift(11) uint16 support not enabled currently"},
       {"bitshift_left_uint16", "BitShift(11) uint16 support not enabled currently"},
-      {"maxunpool_export_with_output_shape", "Invalid output in ONNX test. See https://github.com/onnx/onnx/issues/2398" },
-};
+      {"maxunpool_export_with_output_shape", "Invalid output in ONNX test. See https://github.com/onnx/onnx/issues/2398"},
+  };
 
-#ifdef USE_NGRAPH
-  broken_tests.insert({"qlinearconv", "ambiguity in scalar dimensions [] vs [1]"});
-  broken_tests.insert({"clip_splitbounds", "not implemented yet for opset 11"});
-  broken_tests.insert({"clip_outbounds", "not implemented yet for opset 11"});
-  broken_tests.insert({"clip_example", "not implemented yet for opset 11"});
-  broken_tests.insert({"clip_default_min", "not implemented yet for opset 11"});
-  broken_tests.insert({"clip_default_max", "not implemented yet for opset 11"});
-  broken_tests.insert({"clip", "not implemented yet for opset 11"});
-  broken_tests.insert({"depthtospace_crd_mode_example", "NGraph does not support CRD mode"});
-  broken_tests.insert({"depthtospace_crd_mode", "NGraph does not support CRD mode"});
-  broken_tests.insert({"gemm_default_no_bias", "not implemented yet for opset 11"});
-  broken_tests.insert({"quantizelinear", "ambiguity in scalar dimensions [] vs [1]", {"onnx150"}});
-  broken_tests.insert({"dequantizelinear", "ambiguity in scalar dimensions [] vs [1]", {"onnx150"}});
-  broken_tests.insert({"mlperf_ssd_resnet34_1200", "Results mismatch"});
-  broken_tests.insert({"BERT_Squad", "Invalid Feed Input Name:input4"});
-  broken_tests.insert({"candy", "Results mismatch: 2 of 150528"});
-  broken_tests.insert({"convtranspose_1d", "1d convtranspose not supported yet"});
-#endif
+  if (enable_ngraph) {
+    broken_tests.insert({"qlinearconv", "ambiguity in scalar dimensions [] vs [1]"});
+    broken_tests.insert({"clip_splitbounds", "not implemented yet for opset 11"});
+    broken_tests.insert({"clip_outbounds", "not implemented yet for opset 11"});
+    broken_tests.insert({"clip_example", "not implemented yet for opset 11"});
+    broken_tests.insert({"clip_default_min", "not implemented yet for opset 11"});
+    broken_tests.insert({"clip_default_max", "not implemented yet for opset 11"});
+    broken_tests.insert({"clip", "not implemented yet for opset 11"});
+    broken_tests.insert({"depthtospace_crd_mode_example", "NGraph does not support CRD mode"});
+    broken_tests.insert({"depthtospace_crd_mode", "NGraph does not support CRD mode"});
+    broken_tests.insert({"gemm_default_no_bias", "not implemented yet for opset 11"});
+    broken_tests.insert({"quantizelinear", "ambiguity in scalar dimensions [] vs [1]", {"onnx150"}});
+    broken_tests.insert({"dequantizelinear", "ambiguity in scalar dimensions [] vs [1]", {"onnx150"}});
+    broken_tests.insert({"mlperf_ssd_resnet34_1200", "Results mismatch"});
+    broken_tests.insert({"BERT_Squad", "Invalid Feed Input Name:input4"});
+    broken_tests.insert({"candy", "Results mismatch: 2 of 150528"});
+    broken_tests.insert({"tf_mobilenet_v2_1.0_224", "Results mismatch"});
+    broken_tests.insert({"tf_mobilenet_v2_1.4_224", "Results mismatch"});
+    broken_tests.insert({"convtranspose_1d", "1d convtranspose not supported yet"});
+  }
 
-#ifdef USE_DNNL
-  broken_tests.insert({"tf_mobilenet_v2_1.0_224", "result mismatch"});
-  broken_tests.insert({"tf_mobilenet_v2_1.4_224", "result mismatch"});
-  broken_tests.insert({"tf_mobilenet_v1_1.0_224", "result mismatch"});
-  broken_tests.insert({"mobilenetv2-1.0", "result mismatch"});
-  broken_tests.insert({"candy", "result mismatch"});
-  broken_tests.insert({"range_float_type_positive_delta_expanded", "get unknown exception from DNNL EP"});
-  broken_tests.insert({"range_int32_type_negative_delta_expanded", "get unknown exception from DNNL EP"});
-  broken_tests.insert({"averagepool_2d_ceil", "maxpool ceiling not supported"});
-  broken_tests.insert({"maxpool_2d_ceil", "maxpool ceiling not supported"});
-  broken_tests.insert({"maxpool_2d_dilations", "maxpool dilations not supported"});
-  broken_tests.insert({"mlperf_ssd_resnet34_1200", "test pass on dev box but fails on CI build"}); 
-  broken_tests.insert({"convtranspose_1d", "1d convtranspose not supported yet"});
-#endif
+  if (enable_dnnl) {
+    broken_tests.insert({"tf_mobilenet_v2_1.0_224", "result mismatch"});
+    broken_tests.insert({"tf_mobilenet_v2_1.4_224", "result mismatch"});
+    broken_tests.insert({"tf_mobilenet_v1_1.0_224", "result mismatch"});
+    broken_tests.insert({"mobilenetv2-1.0", "result mismatch"});
+    broken_tests.insert({"candy", "result mismatch"});
+    broken_tests.insert({"range_float_type_positive_delta_expanded", "get unknown exception from DNNL EP"});
+    broken_tests.insert({"range_int32_type_negative_delta_expanded", "get unknown exception from DNNL EP"});
+    broken_tests.insert({"averagepool_2d_ceil", "maxpool ceiling not supported"});
+    broken_tests.insert({"maxpool_2d_ceil", "maxpool ceiling not supported"});
+    broken_tests.insert({"maxpool_2d_dilations", "maxpool dilations not supported"});
+    broken_tests.insert({"mlperf_ssd_resnet34_1200", "test pass on dev box but fails on CI build"});
+    broken_tests.insert({"convtranspose_1d", "1d convtranspose not supported yet"});
+  }
 
-#ifdef USE_OPENVINO
-  broken_tests.insert({"fp16_shufflenet", "accuracy mismatch with fp16 precision"});
-  broken_tests.insert({"fp16_inception_v1", "accuracy mismatch with fp16 precision"});
-  broken_tests.insert({"fp16_tiny_yolov2", "accuaracy mismatch with fp16 precision"});
-  broken_tests.insert({"scan_sum", "disable temporarily"});
-  broken_tests.insert({"scan9_sum", "disable temporarily"});
-  broken_tests.insert({"convtranspose_1d", "1d convtranspose not supported yet"});
+  if (enable_openvino) {
+    broken_tests.insert({"fp16_shufflenet", "accuracy mismatch with fp16 precision"});
+    broken_tests.insert({"fp16_inception_v1", "accuracy mismatch with fp16 precision"});
+    broken_tests.insert({"fp16_tiny_yolov2", "accuaracy mismatch with fp16 precision"});
+    broken_tests.insert({"scan_sum", "disable temporarily"});
+    broken_tests.insert({"scan9_sum", "disable temporarily"});
+    broken_tests.insert({"convtranspose_1d", "1d convtranspose not supported yet"});
 #ifdef OPENVINO_CONFIG_GPU_FP32
-  broken_tests.insert({"tiny_yolov2", "accuracy mismatch"});
-  broken_tests.insert({"div", "will be fixed in the next release"});
+    broken_tests.insert({"tiny_yolov2", "accuracy mismatch"});
+    broken_tests.insert({"div", "will be fixed in the next release"});
 #ifdef OPENVINO_CONFIG_GPU_FP16
-  broken_tests.insert({"div", "will be fixed in the next release"});
+    broken_tests.insert({"div", "will be fixed in the next release"});
 #endif
 #endif
-#endif
+  }
 
-#ifdef USE_NNAPI
-  broken_tests.insert({"scan9_sum", "Error with the extra graph"});
-  broken_tests.insert({"scan_sum", "Error with the extra graph"});
-  broken_tests.insert({"mvn_expanded", "Failed to find kernel for MemcpyFromHost(1) (node Memcpy_1)"});
-  broken_tests.insert({"dynamicquantizelinear_expanded", "Temporarily disabled pending investigation"});
-  broken_tests.insert({"dynamicquantizelinear_max_adjusted_expanded", "Temporarily disabled pending investigation"});
-  broken_tests.insert({"dynamicquantizelinear_min_adjusted_expanded", "Temporarily disabled pending investigation"});
-  broken_tests.insert({"gemm_transposeB", "Temporarily disabled pending investigation"});
-  broken_tests.insert({"range_float_type_positive_delta_expanded", "Temporarily disabled pending investigation"});
-  broken_tests.insert({"range_int32_type_negative_delta_expanded", "Temporarily disabled pending investigation"});
-  broken_tests.insert({"convtranspose_1d", "1d convtranspose not supported yet"});
-#endif
+  if (enable_nnapi) {
+    broken_tests.insert({"scan9_sum", "Error with the extra graph"});
+    broken_tests.insert({"scan_sum", "Error with the extra graph"});
+    broken_tests.insert({"mvn_expanded", "Failed to find kernel for MemcpyFromHost(1) (node Memcpy_1)"});
+    broken_tests.insert({"dynamicquantizelinear_expanded", "Temporarily disabled pending investigation"});
+    broken_tests.insert({"dynamicquantizelinear_max_adjusted_expanded", "Temporarily disabled pending investigation"});
+    broken_tests.insert({"dynamicquantizelinear_min_adjusted_expanded", "Temporarily disabled pending investigation"});
+    broken_tests.insert({"gemm_transposeB", "Temporarily disabled pending investigation"});
+    broken_tests.insert({"range_float_type_positive_delta_expanded", "Temporarily disabled pending investigation"});
+    broken_tests.insert({"range_int32_type_negative_delta_expanded", "Temporarily disabled pending investigation"});
+    broken_tests.insert({"convtranspose_1d", "1d convtranspose not supported yet"});
+  }
 
-#ifdef USE_TENSORRT
-  broken_tests.insert({"fp16_shufflenet", "TRT EP bug"});
-  broken_tests.insert({"fp16_inception_v1", "TRT EP bug"});
-  broken_tests.insert({"fp16_tiny_yolov2", "TRT EP bug"});
-  broken_tests.insert({"tf_inception_v3", "TRT Engine couldn't be created"});
-  broken_tests.insert({"tf_mobilenet_v1_1.0_224", "TRT Engine couldn't be created"});
-  broken_tests.insert({"tf_mobilenet_v2_1.0_224", "TRT Engine couldn't be created"});
-  broken_tests.insert({"tf_mobilenet_v2_1.4_224", "TRT Engine couldn't be created"});
-  broken_tests.insert({"tf_resnet_v1_101", "TRT Engine couldn't be created"});
-  broken_tests.insert({"tf_resnet_v1_152", "TRT Engine couldn't be created"});
-  broken_tests.insert({"tf_resnet_v1_50", "TRT Engine couldn't be created"});
-  broken_tests.insert({"tf_resnet_v2_101", "TRT Engine couldn't be created"});
-  broken_tests.insert({"tf_resnet_v2_152", "TRT Engine couldn't be created"});
-  broken_tests.insert({"tf_resnet_v2_50", "TRT Engine couldn't be created"});
-  broken_tests.insert({"convtranspose_1d", "1d convtranspose not supported yet"});
-#endif
+  if (enable_tensorrt) {
+    broken_tests.insert({"fp16_shufflenet", "TRT EP bug"});
+    broken_tests.insert({"fp16_inception_v1", "TRT EP bug"});
+    broken_tests.insert({"fp16_tiny_yolov2", "TRT EP bug"});
+    broken_tests.insert({"tf_inception_v3", "TRT Engine couldn't be created"});
+    broken_tests.insert({"tf_mobilenet_v1_1.0_224", "TRT Engine couldn't be created"});
+    broken_tests.insert({"tf_mobilenet_v2_1.0_224", "TRT Engine couldn't be created"});
+    broken_tests.insert({"tf_mobilenet_v2_1.4_224", "TRT Engine couldn't be created"});
+    broken_tests.insert({"tf_resnet_v1_101", "TRT Engine couldn't be created"});
+    broken_tests.insert({"tf_resnet_v1_152", "TRT Engine couldn't be created"});
+    broken_tests.insert({"tf_resnet_v1_50", "TRT Engine couldn't be created"});
+    broken_tests.insert({"tf_resnet_v2_101", "TRT Engine couldn't be created"});
+    broken_tests.insert({"tf_resnet_v2_152", "TRT Engine couldn't be created"});
+    broken_tests.insert({"tf_resnet_v2_50", "TRT Engine couldn't be created"});
+    broken_tests.insert({"convtranspose_1d", "1d convtranspose not supported yet"});
+  }
 
-#ifdef USE_CUDA
-  broken_tests.insert({"candy", "result mismatch"});
-  broken_tests.insert({"mlperf_ssd_mobilenet_300", "unknown error"});
-  broken_tests.insert({"mlperf_ssd_resnet34_1200", "unknown error"});
-  broken_tests.insert({"tf_inception_v1", "flaky test"}); //TODO: Investigate cause for flakiness
-  broken_tests.insert({"convtranspose_1d", "1d convtranspose not supported yet"});
-#endif
+  if (enable_cuda) {
+    broken_tests.insert({"candy", "result mismatch"});
+    broken_tests.insert({"mlperf_ssd_mobilenet_300", "unknown error"});
+    broken_tests.insert({"mlperf_ssd_resnet34_1200", "unknown error"});
+    broken_tests.insert({"tf_inception_v1", "flaky test"});  //TODO: Investigate cause for flakiness
+    broken_tests.insert({"convtranspose_1d", "1d convtranspose not supported yet"});
+  }
 
-#ifdef USE_DML
-  if (enable_dml)
-  {
+  if (enable_dml) {
     broken_tests.insert({"PixelShuffle", "Test requires 6D Reshape, which isn't supported by DirectML"});
     broken_tests.insert({"operator_permute2", "Test requires 6D Transpose, which isn't supported by DirectML"});
     broken_tests.insert({"resize_downsample_linear", "ORT 0.4 uses asymmetric but will conform to half_pixel in the next ONNX version."});
@@ -560,8 +557,6 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     broken_tests.insert({"candy", "Temporarily disabled pending investigation"});
     broken_tests.insert({"BERT_Squad", "Temporarily disabled pending investigation"});
   }
-#endif
-  // clang-format on
 
 #if defined(_WIN32) && !defined(_WIN64)
   broken_tests.insert({"vgg19", "failed: bad allocation"});

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -459,11 +459,14 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     broken_tests.insert({"mlperf_ssd_resnet34_1200", "Results mismatch"});
     broken_tests.insert({"BERT_Squad", "Invalid Feed Input Name:input4"});
     broken_tests.insert({"candy", "Results mismatch: 2 of 150528"});
+    broken_tests.insert({"tf_mobilenet_v1_1.0_224", "Results mismatch"});    
     broken_tests.insert({"tf_mobilenet_v2_1.0_224", "Results mismatch"});
     broken_tests.insert({"tf_mobilenet_v2_1.4_224", "Results mismatch"});
     broken_tests.insert({"convtranspose_1d", "1d convtranspose not supported yet"});
   }
-
+  if (enable_nuphar) {
+    broken_tests.insert({"cgan", "TVM exception during initialization"});
+  }
   if (enable_dnnl) {
     broken_tests.insert({"tf_mobilenet_v2_1.0_224", "result mismatch"});
     broken_tests.insert({"tf_mobilenet_v2_1.4_224", "result mismatch"});
@@ -527,6 +530,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
 
   if (enable_cuda) {
     broken_tests.insert({"candy", "result mismatch"});
+    broken_tests.insert({"tinyyolov3", "The parameter is incorrect"});    
     broken_tests.insert({"mlperf_ssd_mobilenet_300", "unknown error"});
     broken_tests.insert({"mlperf_ssd_resnet34_1200", "unknown error"});
     broken_tests.insert({"tf_inception_v1", "flaky test"});  //TODO: Investigate cause for flakiness

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -530,7 +530,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
 
   if (enable_cuda) {
     broken_tests.insert({"candy", "result mismatch"});
-    broken_tests.insert({"tinyyolov3", "The parameter is incorrect"});    
+    broken_tests.insert({"tinyyolov3", "The parameter is incorrect"});
     broken_tests.insert({"mlperf_ssd_mobilenet_300", "unknown error"});
     broken_tests.insert({"mlperf_ssd_resnet34_1200", "unknown error"});
     broken_tests.insert({"tf_inception_v1", "flaky test"});  //TODO: Investigate cause for flakiness
@@ -538,6 +538,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   }
 
   if (enable_dml) {
+    broken_tests.insert({"tinyyolov3", "The parameter is incorrect"});
     broken_tests.insert({"PixelShuffle", "Test requires 6D Reshape, which isn't supported by DirectML"});
     broken_tests.insert({"operator_permute2", "Test requires 6D Transpose, which isn't supported by DirectML"});
     broken_tests.insert({"resize_downsample_linear", "ORT 0.4 uses asymmetric but will conform to half_pixel in the next ONNX version."});

--- a/tools/ci_build/github/azure-pipelines/templates/set-test-data-variables-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/set-test-data-variables-step.yml
@@ -1,8 +1,7 @@
-# sets variables $(TestDataUrl) and $(TestDataChecksum)
+# sets variables $(TestDataUrl)
 
 parameters:
-  TestDataUrl: https://onnxruntimetestdata.blob.core.windows.net/models/20190925.zip
-  TestDataChecksum: ae5fb5e3dd5e4937c8343d13e3be680c
+  TestDataUrl: https://onnxruntimetestdata.blob.core.windows.net/models/20191107.zip
 
 steps:
 - task: CmdLine@1
@@ -10,9 +9,3 @@ steps:
   inputs:
     filename: echo
     arguments: '##vso[task.setvariable variable=TestDataUrl;]${{parameters.TestDataUrl}}'
-
-- task: CmdLine@1
-  displayName: 'Set TestDataChecksum variable'
-  inputs:
-    filename: echo
-    arguments: '##vso[task.setvariable variable=TestDataChecksum;]${{parameters.TestDataChecksum}}'


### PR DESCRIPTION
**Description**: 

Update test data

**Motivation and Context**
- Why is this change required? What problem does it solve?

To include the latest models in onnx model zoo and some opset11 models from TF.

- If it fixes an open issue, please link to the issue here.


Full model list:

| opset |                                   |
|---------|-----------------------------------|
| opset11 | tf_nasnet_large                   |
| opset11 | tf_inception_resnet_v2            |
| opset11 | tf_mobilenet_v2_1.4_224           |
| opset11 | tf_nasnet_mobile                  |
| opset11 | tf_resnet_v1_50                   |
| opset11 | tf_resnet_v2_152                  |
| opset11 | tf_inception_v4                   |
| opset11 | tf_mobilenet_v1_1.0_224           |
| opset11 | tf_inception_v1                   |
| opset11 | tf_resnet_v1_101                  |
| opset11 | tf_inception_v2                   |
| opset11 | tf_resnet_v2_50                   |
| opset11 | tf_resnet_v1_152                  |
| opset11 | tf_mobilenet_v2_1.0_224           |
| opset11 | tf_inception_v3                   |
| opset11 | tinyyolov3                        |
| opset11 | tf_resnet_v2_101                  |
| opset11 | tf_pnasnet_large                  |
| opset8  | tf_nasnet_large                   |
| opset8  | test_bvlc_reference_caffenet      |
| opset8  | test_squeezenet                   |
| opset8  | mxnet_arcface                     |
| opset8  | tf_inception_resnet_v2            |
| opset8  | test_emotion_ferplus              |
| opset8  | tf_mobilenet_v2_1.4_224           |
| opset8  | test_densenet121                  |
| opset8  | tf_nasnet_mobile                  |
| opset8  | tf_resnet_v1_50                   |
| opset8  | test_inception_v2                 |
| opset8  | test_bvlc_reference_rcnn_ilsvrc13 |
| opset8  | test_bvlc_alexnet                 |
| opset8  | test_zfnet512                     |
| opset8  | tf_resnet_v2_152                  |
| opset8  | tf_inception_v4                   |
| opset8  | test_tiny_yolov2                  |
| opset8  | tf_mobilenet_v1_1.0_224           |
| opset8  | tf_inception_v1                   |
| opset8  | tf_resnet_v1_101                  |
| opset8  | tf_inception_v2                   |
| opset8  | test_inception_v1                 |
| opset8  | tf_resnet_v2_50                   |
| opset8  | test_resnet50                     |
| opset8  | test_bvlc_googlenet               |
| opset8  | tf_resnet_v1_152                  |
| opset8  | fp16_tiny_yolov2                  |
| opset8  | tf_mobilenet_v2_1.0_224           |
| opset8  | tf_inception_v3                   |
| opset8  | fp16_shufflenet                   |
| opset8  | fp16_inception_v1                 |
| opset8  | test_mnist                        |
| opset8  | test_shufflenet                   |
| opset8  | tf_resnet_v2_101                  |
| opset8  | test_vgg19                        |
| opset8  | tf_pnasnet_large                  |
| opset9  | tf_nasnet_large                   |
| opset9  | tf_inception_resnet_v2            |
| opset9  | tf_mobilenet_v2_1.4_224           |
| opset9  | pointilism                        |
| opset9  | tf_nasnet_mobile                  |
| opset9  | tf_resnet_v1_50                   |
| opset9  | candy                             |
| opset9  | rain_princess                     |
| opset9  | tf_resnet_v2_152                  |
| opset9  | tf_inception_v4                   |
| opset9  | tf_mobilenet_v1_1.0_224           |
| opset9  | tf_inception_v1                   |
| opset9  | tf_resnet_v1_101                  |
| opset9  | tf_inception_v2                   |
| opset9  | LSTM_Seq_lens_unpacked            |
| opset9  | LSTM_Seq_lens_unpacked            |
| opset9  | LSTM_Seq_lens_unpacked            |
| opset9  | tf_resnet_v2_50                   |
| opset9  | tf_resnet_v1_152                  |
| opset9  | mosaic                            |
| opset9  | udnie                             |
| opset9  | tf_mobilenet_v2_1.0_224           |
| opset9  | tf_inception_v3                   |
| opset9  | tf_resnet_v2_101                  |
| opset9  | tf_pnasnet_large                  |
| opset7  | tf_nasnet_large                   |
| opset7  | test_squeezenet1.1                |
| opset7  | test_resnet18v2                   |
| opset7  | test_bvlc_reference_caffenet      |
| opset7  | test_squeezenet                   |
| opset7  | test_resnet50v2                   |
| opset7  | tf_inception_resnet_v2            |
| opset7  | test_emotion_ferplus              |
| opset7  | tf_mobilenet_v2_1.4_224           |
| opset7  | test_densenet121                  |
| opset7  | tf_nasnet_mobile                  |
| opset7  | tf_resnet_v1_50                   |
| opset7  | test_inception_v2                 |
| opset7  | test_bvlc_reference_rcnn_ilsvrc13 |
| opset7  | test_bvlc_alexnet                 |
| opset7  | test_zfnet512                     |
| opset7  | test_mobilenetv2-1.0              |
| opset7  | tf_resnet_v2_152                  |
| opset7  | tf_inception_v4                   |
| opset7  | test_tiny_yolov2                  |
| opset7  | tf_mobilenet_v1_1.0_224           |
| opset7  | tf_inception_v1                   |
| opset7  | tf_resnet_v1_101                  |
| opset7  | tf_inception_v2                   |
| opset7  | test_resnet152v2                  |
| opset7  | test_inception_v1                 |
| opset7  | tf_resnet_v2_50                   |
| opset7  | test_resnet50                     |
| opset7  | test_bvlc_googlenet               |
| opset7  | tf_resnet_v1_152                  |
| opset7  | fp16_tiny_yolov2                  |
| opset7  | tf_mobilenet_v2_1.0_224           |
| opset7  | tf_inception_v3                   |
| opset7  | test_resnet101v2                  |
| opset7  | test_resnet34v2                   |
| opset7  | fp16_shufflenet                   |
| opset7  | fp16_inception_v1                 |
| opset7  | test_mnist                        |
| opset7  | test_shufflenet                   |
| opset7  | tf_resnet_v2_101                  |
| opset7  | test_vgg19                        |
| opset7  | tf_pnasnet_large                  |
| opset10 | tf_nasnet_large                   |
| opset10 | faster_rcnn                       |
| opset10 | tf_inception_resnet_v2            |
| opset10 | yolov3                            |
| opset10 | tf_mobilenet_v2_1.4_224           |
| opset10 | mask_rcnn_keras                   |
| opset10 | tf_nasnet_mobile                  |
| opset10 | tf_resnet_v1_50                   |
| opset10 | mlperf_mobilenet                  |
| opset10 | mlperf_resnet                     |
| opset10 | BERT_Squad                        |
| opset10 | tf_resnet_v2_152                  |
| opset10 | tf_inception_v4                   |
| opset10 | tf_mobilenet_v1_1.0_224           |
| opset10 | tf_inception_v1                   |
| opset10 | tf_resnet_v1_101                  |
| opset10 | tf_inception_v2                   |
| opset10 | mlperf_ssd_mobilenet_300          |
| opset10 | tf_resnet_v2_50                   |
| opset10 | mask_rcnn                         |
| opset10 | tf_resnet_v1_152                  |
| opset10 | mlperf_ssd_resnet34_1200          |
| opset10 | tf_mobilenet_v2_1.0_224           |
| opset10 | tf_inception_v3                   |
| opset10 | tf_resnet_v2_101                  |
| opset10 | tf_pnasnet_large                  |
