### PR TITLE
update build instructions to include --build_shared_lib

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -86,7 +86,7 @@ For other system requirements and other dependencies, please see [this section](
 |**Build Shared Library**|--build_shared_lib||
 |**Build Python wheel**|--build_wheel||
 |**Build C# and C packages**|--build_csharp||
-|**Build WindowsML**|--use_winml --use_dml --build_shared_lib|WindowsML depends on DirectML and the OnnxRuntime shared library.|
+|**Build WindowsML**|--use_winml<br>--use_dml<br>--build_shared_lib|WindowsML depends on DirectML and the OnnxRuntime shared library.|
 
 
 # Additional Build Instructions

--- a/BUILD.md
+++ b/BUILD.md
@@ -86,7 +86,7 @@ For other system requirements and other dependencies, please see [this section](
 |**Build Shared Library**|--build_shared_lib||
 |**Build Python wheel**|--build_wheel||
 |**Build C# and C packages**|--build_csharp||
-|**Build WindowsML**|--use_winml --use_dml||
+|**Build WindowsML**|--use_winml --use_dml --build_shared_lib|WindowsML depends on DirectML and the OnnxRuntime shared library.|
 
 
 # Additional Build Instructions


### PR DESCRIPTION
**Description**: update build instructions to include --build_shared_lib

**Motivation and Context**
Windows.AI.MachineLearning.dll requires onnxruntime.dll, so update the build steps to include building that.
