### PR TITLE
reset group if it is -1

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/conv_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_attributes.h
@@ -136,16 +136,14 @@ struct ConvAttributes {
                              " W: ", W->Shape().ToString().c_str());
     }
 
-    if (-1 == group) {
-      group = C / W->Shape()[1];
-    } else if (C != W->Shape()[1] * group) {
+    if (-1 != group && C != W->Shape()[1] * group) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Input channels C is not equal to kernel channels * group.",
                              " C: ", C,
                              " kernel channels: ", W->Shape()[1],
                              " group: ", group);
     }
 
-    if (M % group != 0) {
+    if (-1 != group && M % group != 0) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Output channels M is not divisible by group.",
                              " M: ", M,
                              " group: ", group);
@@ -186,7 +184,7 @@ struct ConvAttributes {
   }
 
   AutoPadType auto_pad;
-  mutable int64_t group;
+  int64_t group;
   bool kernel_shape_specified;
   std::vector<int64_t> strides;
   std::vector<int64_t> pads;

--- a/onnxruntime/core/providers/cpu/nn/conv_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_attributes.h
@@ -136,7 +136,9 @@ struct ConvAttributes {
                              " W: ", W->Shape().ToString().c_str());
     }
 
-    if (C != W->Shape()[1] * group) {
+    if (-1 == group) {
+      group = C / W->Shape()[1];
+    } else if (C != W->Shape()[1] * group) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Input channels C is not equal to kernel channels * group.",
                              " C: ", C,
                              " kernel channels: ", W->Shape()[1],
@@ -184,7 +186,7 @@ struct ConvAttributes {
   }
 
   AutoPadType auto_pad;
-  int64_t group;
+  mutable int64_t group;
   bool kernel_shape_specified;
   std::vector<int64_t> strides;
   std::vector<int64_t> pads;


### PR DESCRIPTION
When "group" is -1, conv ops should allow reset of its value.
Otherwise, converted mask_rcnn_inception_v2_coco_2018_01_28 and faster_rcnn_inception_v2_coco_2018_01_28 get ORT error - "Input channels C is not equal to kernel channels * group."