### PR TITLE
Task 23998197: add winml_lib_core into onnnxruntime.dll

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -697,14 +697,17 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Android")
 endif()
 
 if (onnxruntime_USE_WINML)
-  if (NOT onnxruntime_USE_DML)
+  # WINML uses and depends on the shared lib.  Note:  You can build WINML without DML and you will get a 
+  # CPU only WINML
+  if (NOT onnxruntime_BUILD_SHARED_LIB)
     message(
         FATAL_ERROR 
-        "Option onnxruntime_USE_WINML can only be used when onnxruntime_USE_DML is also enabled")
+        "Option onnxruntime_USE_WINML can only be used when onnxruntime_BUILD_SHARED_LIB is also enabled")
   endif()
   include(wil.cmake)
   include(winml.cmake)
 endif() # if(onnxruntime_USE_WINML)
+
 #The following files may use the 'onnxruntime_libs' and 'onnxruntime_EXTERNAL_LIBRARIES' vars
 
 if (onnxruntime_BUILD_SHARED_LIB)

--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -66,6 +66,7 @@ target_link_libraries(onnxruntime PRIVATE
     ${PROVIDERS_NUPHAR}
     ${PROVIDERS_DML}
     ${PROVIDERS_ACL}
+	${onnxruntime_winml}
     onnxruntime_optimizer
     onnxruntime_providers
     onnxruntime_util

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -201,8 +201,7 @@ target_link_libraries(winml_lib_core PRIVATE wil)
 target_link_libraries(winml_lib_core PRIVATE onnxruntime_providers_dml)
 
 # add it to the onnxruntime shared library
-list(APPEND onnxruntime_EXTERNAL_LIBRARIES -WHOLEARCHIVE:$<TARGET_FILE:winml_lib_core>)
-list(APPEND onnxruntime_EXTERNAL_LIBRARIES windowsapp.lib)
+set(onnxruntime_winml windowsapp.lib -WHOLEARCHIVE:$<TARGET_FILE:winml_lib_core>)
 list(APPEND onnxruntime_EXTERNAL_DEPENDENCIES winml_lib_core)
 
 ###########################

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -201,9 +201,9 @@ target_link_libraries(winml_lib_core PRIVATE wil)
 target_link_libraries(winml_lib_core PRIVATE onnxruntime_providers_dml)
 
 # add it to the onnxruntime shared library
-#list(APPEND onnxruntime_EXTERNAL_LIBRARIES -WHOLEARCHIVE:$<TARGET_FILE:winml_lib_core>)
-#list(APPEND onnxruntime_EXTERNAL_LIBRARIES windowsapp.lib)
-#list(APPEND onnxruntime_EXTERNAL_DEPENDENCIES winml_lib_core)
+list(APPEND onnxruntime_EXTERNAL_LIBRARIES -WHOLEARCHIVE:$<TARGET_FILE:winml_lib_core>)
+list(APPEND onnxruntime_EXTERNAL_LIBRARIES windowsapp.lib)
+list(APPEND onnxruntime_EXTERNAL_DEPENDENCIES winml_lib_core)
 
 ###########################
 # Add winml_lib_image

--- a/winml/api/Windows.AI.MachineLearning.idl
+++ b/winml/api/Windows.AI.MachineLearning.idl
@@ -20,7 +20,7 @@ import "windows.storage.idl";
 
 namespace Windows.AI.MachineLearning 
 {
-    [contractversion(3)]
+    [contractversion(4)]
     apicontract MachineLearningContract{};
 
     //! Forward declarations
@@ -334,6 +334,18 @@ namespace Windows.AI.MachineLearning
         TensorKind KeyKind{ get; };
         //! Returns the properties of the map's value.
         ILearningModelFeatureDescriptor  ValueDescriptor{ get; };
+
+        [contract(MachineLearningContract, 4)]
+        {
+            //! allows creation of feature descriptors outside the runtime (immutable)
+            [method_name("Create")] MapFeatureDescriptor(
+                String Name,
+                String Description,
+                Boolean IsRequired,
+                TensorKind KeyKind,
+                ILearningModelFeatureDescriptor ValueDescriptor
+            );
+        }
     }
 
     //! \class SequenceFeatureDescriptor
@@ -346,6 +358,17 @@ namespace Windows.AI.MachineLearning
     {
         //! Gets the properties of the specified feature.
         ILearningModelFeatureDescriptor  ElementDescriptor{ get; };
+
+        [contract(MachineLearningContract, 4)]
+        {
+            //! allows creation of feature descriptors outside the runtime (immutable)
+            [method_name("Create")] SequenceFeatureDescriptor(
+                String Name,
+                String Description,
+                Boolean IsRequired,
+                ILearningModelFeatureDescriptor ElementDescriptor
+            );
+        }
     }
 
     //! \class TensorFeatureDescriptor
@@ -360,6 +383,23 @@ namespace Windows.AI.MachineLearning
         TensorKind TensorKind{ get; };
         //! Returns the count and size of each dimension.
         Windows.Foundation.Collections.IVectorView<Int64> Shape{ get; };
+
+        [contract(MachineLearningContract, 4)]
+        {
+            //! allows creation of feature descriptors outside the runtime (immutable)
+            [method_name("Create")] TensorFeatureDescriptor(
+                String Name,
+                String Description,
+                Boolean IsRequired,
+                TensorKind TensorKind,
+                Int64[] Shape,
+                Boolean HasUnsupportedImageMetadata
+            );
+            //! if this feature is an image but has unsupport image metadata (like a BitmapPixelFormat) 
+            //! you can still use the runtime but without image conversion support.
+            //! this settig will be 'true'
+            Boolean HasUnsupportedImageMetadata{ get; } ;
+        }
     }
 
     //! \class ImageFeatureDescriptor
@@ -378,6 +418,26 @@ namespace Windows.AI.MachineLearning
         UInt32 Width{ get; };
         //! The height of the image.
         UInt32 Height{ get; };
+
+        [contract(MachineLearningContract, 4)]
+        {
+            //! allows creation of feature descriptors outside the runtime (immutable)
+            [method_name("Create")] ImageFeatureDescriptor(
+                String Name,
+                String Description,
+                Boolean IsRequired,
+                TensorKind TensorKind,
+                Int64[] Shape,
+                Windows.Graphics.Imaging.BitmapPixelFormat BitmapPixelFormat,
+                Windows.Graphics.Imaging.BitmapAlphaMode BitmapAlphaMode,
+                UInt32 Width,
+                UInt32 Height
+            );
+
+            //! Returns the data type of the tensor.  This is useful if you want to know
+            //! if it's fp16 or fp32
+            TensorKind TensorKind{ get; };
+        }
     }
 
     //! \interface ITensor

--- a/winml/api/Windows.AI.MachineLearning.idl
+++ b/winml/api/Windows.AI.MachineLearning.idl
@@ -397,7 +397,7 @@ namespace Windows.AI.MachineLearning
             );
             //! if this feature is an image but has unsupport image metadata (like a BitmapPixelFormat) 
             //! you can still use the runtime but without image conversion support.
-            //! this settig will be 'true'
+            //! this setting will be 'true'
             Boolean HasUnsupportedImageMetadata{ get; } ;
         }
     }

--- a/winml/lib/Api.Core/CpuOrtSessionBuilder.cpp
+++ b/winml/lib/Api.Core/CpuOrtSessionBuilder.cpp
@@ -63,7 +63,7 @@ CpuOrtSessionBuilder::CreateSession(
   *pp_provider = cpu_provider.get();
 
   // Register the cpu xp
-  WINML_THROW_IF_NOT_OK(session->RegisterExecutionProvider(std::move(cpu_provider)));
+  ORT_THROW_IF_ERROR(session->RegisterExecutionProvider(std::move(cpu_provider)));
 
   // assign the session to the out parameter
   *p_session = std::move(session);
@@ -76,6 +76,6 @@ CpuOrtSessionBuilder::Initialize(
     onnxruntime::InferenceSession* p_session,
     onnxruntime::IExecutionProvider* /*p_provider*/
 ) {
-  WINML_THROW_IF_NOT_OK(p_session->Initialize());
+    ORT_THROW_IF_ERROR(p_session->Initialize());
   return S_OK;
 }

--- a/winml/lib/Api.Core/DmlOrtSessionBuilder.cpp
+++ b/winml/lib/Api.Core/DmlOrtSessionBuilder.cpp
@@ -60,7 +60,7 @@ RegisterCustomRegistry(
 
     // Register
     for (auto& custom_registry : custom_registries) {
-      WINML_THROW_IF_NOT_OK(p_session->RegisterCustomRegistry(custom_registry));
+        ORT_THROW_IF_ERROR(p_session->RegisterCustomRegistry(custom_registry));
     }
   }
 
@@ -115,7 +115,7 @@ HRESULT DmlOrtSessionBuilder::CreateSession(
   // Cache the provider's raw pointer
   *pp_provider = gpu_provider.get();
 
-  WINML_THROW_IF_NOT_OK(session->RegisterExecutionProvider(std::move(gpu_provider)));
+  ORT_THROW_IF_ERROR(session->RegisterExecutionProvider(std::move(gpu_provider)));
 
   // return the session
   *p_session = std::move(session);
@@ -134,7 +134,7 @@ HRESULT DmlOrtSessionBuilder::Initialize(
   // lifetime and can be large, so shouldn't be rounded.
   Dml::SetDefaultRoundingMode(p_provider, AllocatorRoundingMode::Disabled);
 
-  WINML_THROW_IF_NOT_OK(p_session->Initialize());
+  ORT_THROW_IF_ERROR(p_session->Initialize());
 
   Dml::SetDefaultRoundingMode(p_provider, AllocatorRoundingMode::Enabled);
 

--- a/winml/lib/Api.Core/FeatureDescriptorFactory.cpp
+++ b/winml/lib/Api.Core/FeatureDescriptorFactory.cpp
@@ -324,9 +324,9 @@ GetTensorType(
     const std::unordered_map<std::string, std::string>& metadata) {
   const auto& type_proto = value_info_proto->type();
 
-  WINML_THROW_HR_IF_FALSE_MSG(
+  THROW_HR_IF_MSG(
       E_FAIL,
-      type_proto.has_tensor_type(),
+      type_proto.has_tensor_type() == false,
       "Malformed onnx file.");
 
   auto has_image_denotation = type_proto.denotation() == "IMAGE";
@@ -381,12 +381,14 @@ GetTensorType(
        has_unsupported_image_metadata);
 
   if (is_tensor_improperly_annotated_as_image) {
+#ifdef LAYERING_DONE
     TraceLoggingWrite(winml_trace_logging_provider,
                       "WinMLInputValidation",
                       TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
                       TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
                       TraceLoggingOpcode(EVENT_TRACE_TYPE_INFO),
                       TraceLoggingString(log_stream.str().c_str()));
+#endif
   }
 
   auto is_valid_image_tensor =
@@ -410,12 +412,12 @@ CreateTensorFeatureDescriptor(
   auto kind = WinML::TensorKindFromOnnxDataType(
       onnx::TensorProto_DataType(tensor_type.elem_type()));
 
-  auto descriptor = winrt::make<winmlp::TensorFeatureDescriptor>(
-      value_info_proto->name().c_str(),
-      value_info_proto->doc_string().c_str(),
+  TensorFeatureDescriptor descriptor(
+      WinML::Strings::HStringFromUTF8(value_info_proto->name()),
+      WinML::Strings::HStringFromUTF8(value_info_proto->doc_string()),  // description
+      value_info_proto->name().empty() == false,                        // is_required
       kind,
       shape,
-      value_info_proto->name().empty() == false,  // is_required
       has_unsupported_image_metadata);
 
   return descriptor.as<winml::ILearningModelFeatureDescriptor>();
@@ -429,7 +431,7 @@ CreateImageFeatureDescriptor(
   const auto& tensor_type = type_proto.tensor_type();
   auto shape = WinML::ConvertShapeProtoToVector(tensor_type.shape());
   auto kind = WinML::TensorKindFromOnnxDataType(
-      onnx::TensorProto_DataType(tensor_type.elem_type()));
+  onnx::TensorProto_DataType(tensor_type.elem_type()));
 
   // pixel format and alpha
   auto pixel_format_value = FetchMetadataValueOrNull(metadata, c_bitmap_pixel_format_key);
@@ -438,12 +440,12 @@ CreateImageFeatureDescriptor(
   auto alpha_mode = format_info.second;
 
   // color space gamma value
-  auto color_space_gamma_value = FetchMetadataValueOrNull(metadata, c_color_space_key);
-  auto color_space_gamma = CreateImageColorSpaceGamma(color_space_gamma_value);
+//  auto color_space_gamma_value = FetchMetadataValueOrNull(metadata, c_color_space_key);
+//  auto color_space_gamma = CreateImageColorSpaceGamma(color_space_gamma_value);
 
   // nominal range
-  auto nominal_range_value = FetchMetadataValueOrNull(metadata, c_nominal_range_key);
-  auto nominal_range = CreateImageNominalPixelRange(nominal_range_value);
+//  auto nominal_range_value = FetchMetadataValueOrNull(metadata, c_nominal_range_key);
+//  auto nominal_range = CreateImageNominalPixelRange(nominal_range_value);
 
   // The current code assumes that the shape will be in NCHW.
   // Should the model metadata be read instead???
@@ -451,18 +453,16 @@ CreateImageFeatureDescriptor(
   const int c_width_dimension = 3;
   auto height = static_cast<uint32_t>(shape[c_height_dimension]);
   auto width = static_cast<uint32_t>(shape[c_width_dimension]);
-  auto descriptor = winrt::make<winmlp::ImageFeatureDescriptor>(
-      value_info_proto->name().c_str(),
-      value_info_proto->doc_string().c_str(),
+  ImageFeatureDescriptor descriptor(
+      WinML::Strings::HStringFromUTF8(value_info_proto->name()),
+      WinML::Strings::HStringFromUTF8(value_info_proto->doc_string()),
+      value_info_proto->name().empty() == false,  // is_required
       kind,
       shape,
-      value_info_proto->name().empty() == false,  // is_required
       pixel_format,
       alpha_mode,
       width,
-      height,
-      nominal_range,
-      color_space_gamma);
+      height);
 
   return descriptor.as<winml::ILearningModelFeatureDescriptor>();
 }
@@ -485,9 +485,9 @@ CreateMapFeatureDescriptor(
   auto value_descriptor =
       CreateFeatureDescriptor(&dummy_value_info_proto, metadata);
 
-  auto descriptor = winrt::make<winmlp::MapFeatureDescriptor>(
-      value_info_proto->name().c_str(),
-      value_info_proto->doc_string().c_str(),
+  MapFeatureDescriptor descriptor(
+      WinML::Strings::HStringFromUTF8(value_info_proto->name()),
+      WinML::Strings::HStringFromUTF8(value_info_proto->doc_string()),
       value_info_proto->name().empty() == false,  // is_rRequired
       key_kind,
       value_descriptor);
@@ -510,9 +510,9 @@ CreateSequenceFeatureDescriptor(
   auto element_descriptor =
       CreateFeatureDescriptor(&dummy_value_info_proto, metadata);
 
-  auto descriptor = winrt::make<winmlp::SequenceFeatureDescriptor>(
-      value_info_proto->name().c_str(),
-      value_info_proto->doc_string().c_str(),
+  SequenceFeatureDescriptor descriptor(
+      WinML::Strings::HStringFromUTF8(value_info_proto->name()),
+      WinML::Strings::HStringFromUTF8(value_info_proto->doc_string()),
       value_info_proto->name().empty() == false,  // is_required
       element_descriptor);
 

--- a/winml/lib/Api.Core/FeatureDescriptorFactory.cpp
+++ b/winml/lib/Api.Core/FeatureDescriptorFactory.cpp
@@ -439,13 +439,18 @@ CreateImageFeatureDescriptor(
   auto pixel_format = format_info.first;
   auto alpha_mode = format_info.second;
 
+  // paulm:   commenting this out during layering.    gamma and nominal are never used
+  // since we only support one of them.  if a non support one is set, they all fall back 
+  // to TensorFeatureDescriptor (invalid image metadata)
+#ifdef DONE_LAYERING
   // color space gamma value
-//  auto color_space_gamma_value = FetchMetadataValueOrNull(metadata, c_color_space_key);
-//  auto color_space_gamma = CreateImageColorSpaceGamma(color_space_gamma_value);
+    auto color_space_gamma_value = FetchMetadataValueOrNull(metadata, c_color_space_key);
+    auto color_space_gamma = CreateImageColorSpaceGamma(color_space_gamma_value);
 
   // nominal range
-//  auto nominal_range_value = FetchMetadataValueOrNull(metadata, c_nominal_range_key);
-//  auto nominal_range = CreateImageNominalPixelRange(nominal_range_value);
+    auto nominal_range_value = FetchMetadataValueOrNull(metadata, c_nominal_range_key);
+    auto nominal_range = CreateImageNominalPixelRange(nominal_range_value);
+#endif
 
   // The current code assumes that the shape will be in NCHW.
   // Should the model metadata be read instead???

--- a/winml/lib/Api.Core/ModelInfo.cpp
+++ b/winml/lib/Api.Core/ModelInfo.cpp
@@ -144,7 +144,7 @@ WinML::CreateModelProto(
       _SH_DENYWR,
       _S_IREAD | _S_IWRITE);
 
-  WINML_THROW_HR_IF_TRUE_MSG(
+  THROW_HR_IF_MSG(
       E_FAIL,
       0 > file_descriptor,
       "Failed");  //errno
@@ -153,9 +153,9 @@ WinML::CreateModelProto(
   stream.SetCloseOnDelete(true);
 
   auto model_proto = new onnx::ModelProto();
-  WINML_THROW_HR_IF_FALSE_MSG(
+  THROW_HR_IF_MSG(
       E_INVALIDARG,
-      model_proto->ParseFromZeroCopyStream(&stream),
+      !model_proto->ParseFromZeroCopyStream(&stream) == false,
       "The stream failed to parse.");
 
   return model_proto;
@@ -168,9 +168,9 @@ WinML::CreateModelProto(
   ZeroCopyInputStreamWrapper wrapper(stream_reference);
 
   auto model_proto = new onnx::ModelProto();
-  WINML_THROW_HR_IF_FALSE_MSG(
+  THROW_HR_IF_MSG(
       E_INVALIDARG,
-      model_proto->ParseFromZeroCopyStream(&wrapper),
+      model_proto->ParseFromZeroCopyStream(&wrapper) == false,
       "The stream failed to parse.");
 
   return model_proto;

--- a/winml/lib/Api.Core/inc/WinMLAdapter.h
+++ b/winml/lib/Api.Core/inc/WinMLAdapter.h
@@ -19,7 +19,7 @@ __declspec(dllexport) HRESULT STDMETHODCALLTYPE LoadModel(onnxruntime::Inference
 __declspec(dllexport) HRESULT STDMETHODCALLTYPE EnsureModelDeviceCompatibility(
     winml::LearningModel const& model,
     onnx::ModelProto* p_model_proto,
-    winml::LearningModelDevice const& device);
+    bool is_float16_supported);
 
 __declspec(dllexport) ID3D12Resource* STDMETHODCALLTYPE GetD3D12ResourceFromAllocation(onnxruntime::IExecutionProvider* provider, void* allocation);
 

--- a/winml/lib/Api/ImageFeatureDescriptor.cpp
+++ b/winml/lib/Api/ImageFeatureDescriptor.cpp
@@ -11,9 +11,9 @@ namespace winrt::Windows::AI::MachineLearning::implementation {
 ImageFeatureDescriptor::ImageFeatureDescriptor(
     const char* name,
     const char* description,
+    bool is_required,
     winml::TensorKind tensor_kind,
     const std::vector<int64_t>& shape,
-    bool is_required,
     wgi::BitmapPixelFormat pixel_format,
     wgi::BitmapAlphaMode alpha_mode,
     uint32_t width,
@@ -30,6 +30,28 @@ ImageFeatureDescriptor::ImageFeatureDescriptor(
                                               height_(height),
                                               nominal_pixel_range_(nominal_pixel_range),
                                               color_space_gamma_(color_space_gamma) {
+}
+
+ImageFeatureDescriptor::ImageFeatureDescriptor(
+        hstring const& Name,
+        hstring const& Description,
+        bool IsRequired,
+        Windows::AI::MachineLearning::TensorKind const& TensorKind,
+        array_view<int64_t const> Shape,
+        Windows::Graphics::Imaging::BitmapPixelFormat const& BitmapPixelFormat,
+        Windows::Graphics::Imaging::BitmapAlphaMode const& BitmapAlphaMode,
+        uint32_t Width,
+        uint32_t Height) : name_(Name),
+                           description_(Description),
+                            tensor_kind_(TensorKind),
+                            shape_(Shape.begin(), Shape.end()),
+                            is_required_(IsRequired),
+                            pixel_format_(BitmapPixelFormat),
+                            alpha_mode_(BitmapAlphaMode),
+                            width_(Width),
+                            height_(Height),
+                            nominal_pixel_range_(ImageNominalPixelRange::ImageNominalPixelRange_NominalRange_0_255),
+                            color_space_gamma_(ImageColorSpaceGamma::ImageColorSpaceGamma_SRGB) {
 }
 
 wgi::BitmapPixelFormat

--- a/winml/lib/Api/ImageFeatureDescriptor.h
+++ b/winml/lib/Api/ImageFeatureDescriptor.h
@@ -24,15 +24,26 @@ struct ImageFeatureDescriptor : ImageFeatureDescriptorT<
   ImageFeatureDescriptor(
       const char* name,
       const char* description,
+      bool is_required,
       winml::TensorKind tensor_kind,
       const std::vector<int64_t>& shape,
-      bool is_required,
       wgi::BitmapPixelFormat pixelformat,
       wgi::BitmapAlphaMode alphamode,
       uint32_t width,
       uint32_t height,
       ImageNominalPixelRange nominalPixelRange,
       ImageColorSpaceGamma colorSpaceGamma);
+
+  ImageFeatureDescriptor(
+      hstring const& Name,
+      hstring const& Description,
+      bool IsRequired,
+      Windows::AI::MachineLearning::TensorKind const& TensorKind, 
+      array_view<int64_t const> Shape,
+      Windows::Graphics::Imaging::BitmapPixelFormat const& BitmapPixelFormat,
+      Windows::Graphics::Imaging::BitmapAlphaMode const& BitmapAlphaMode,
+      uint32_t Width,
+      uint32_t Height);
 
   wgi::BitmapPixelFormat
   BitmapPixelFormat();
@@ -94,3 +105,9 @@ struct ImageFeatureDescriptor : ImageFeatureDescriptorT<
   ImageColorSpaceGamma color_space_gamma_;
 };
 }  // namespace winrt::Windows::AI::MachineLearning::implementation
+
+namespace winrt::Windows::AI::MachineLearning::factory_implementation {
+    struct ImageFeatureDescriptor : ImageFeatureDescriptorT<ImageFeatureDescriptor, implementation::ImageFeatureDescriptor> {
+
+    };
+}  // namespace winrt::Windows::AI::MachineLearning::factory_implementation

--- a/winml/lib/Api/LearningModelSession.cpp
+++ b/winml/lib/Api/LearningModelSession.cpp
@@ -65,6 +65,7 @@ WINML_CATCH_ALL
 std::unique_ptr<_winmla::ModelProto>
 LearningModelSession::GetOptimizedModel() {
   // Get the model proto
+
   auto should_close_model =
       session_options_ != nullptr &&
       session_options_.CloseModelOnSessionCreation();
@@ -92,7 +93,7 @@ LearningModelSession::GetOptimizedModel(bool should_close_model) {
   }
 
   // Ensure that the model is runnable on the device
-  WINML_THROW_IF_FAILED(_winmla::EnsureModelDeviceCompatibility(model_, model_proto.get()->p_, device_));
+  WINML_THROW_IF_FAILED(_winmla::EnsureModelDeviceCompatibility(model_, model_proto.get()->p_, device_.as<winmlp::LearningModelDevice>()->GetD3DDeviceCache()->IsFloat16Supported()));
 
   return model_proto;
 }

--- a/winml/lib/Api/MapFeatureDescriptor.cpp
+++ b/winml/lib/Api/MapFeatureDescriptor.cpp
@@ -18,6 +18,19 @@ MapFeatureDescriptor::MapFeatureDescriptor(
                                                          value_kind_(value_kind) {
 }
 
+MapFeatureDescriptor::MapFeatureDescriptor(
+    hstring const& Name,
+    hstring const& Description,
+    bool IsRequired,
+    Windows::AI::MachineLearning::TensorKind const& KeyKind,
+    Windows::AI::MachineLearning::ILearningModelFeatureDescriptor const& ValueDescriptor) : 
+        name_(Name),
+        description_(Description),
+        is_required_(IsRequired),
+        key_kind_(KeyKind),
+        value_kind_(ValueDescriptor) {
+}
+
 winml::TensorKind
 MapFeatureDescriptor::KeyKind() try {
   return key_kind_;

--- a/winml/lib/Api/MapFeatureDescriptor.h
+++ b/winml/lib/Api/MapFeatureDescriptor.h
@@ -17,6 +17,13 @@ struct MapFeatureDescriptor : MapFeatureDescriptorT<
       bool is_required,
       winml::TensorKind keyKind,
       winml::ILearningModelFeatureDescriptor valueKind);
+  
+  MapFeatureDescriptor(
+      hstring const& Name,
+      hstring const& Description,
+      bool IsRequired,
+      Windows::AI::MachineLearning::TensorKind const& KeyKind,
+      Windows::AI::MachineLearning::ILearningModelFeatureDescriptor const& ValueDescriptor);
 
   // IMapDescriptor
   winml::TensorKind
@@ -56,3 +63,9 @@ struct MapFeatureDescriptor : MapFeatureDescriptorT<
   winml::ILearningModelFeatureDescriptor value_kind_;
 };
 }  // namespace winrt::Windows::AI::MachineLearning::implementation
+
+namespace winrt::Windows::AI::MachineLearning::factory_implementation {
+    struct MapFeatureDescriptor : MapFeatureDescriptorT<MapFeatureDescriptor, implementation::MapFeatureDescriptor> {
+
+    };
+}  // namespace winrt::Windows::AI::MachineLearning::factory_implementation

--- a/winml/lib/Api/SequenceFeatureDescriptor.cpp
+++ b/winml/lib/Api/SequenceFeatureDescriptor.cpp
@@ -16,6 +16,17 @@ SequenceFeatureDescriptor::SequenceFeatureDescriptor(
                                                          description_(WinML::Strings::HStringFromUTF8(description)),
                                                          is_required_(is_required),
                                                          element_descriptor_(descriptor) {}
+SequenceFeatureDescriptor::SequenceFeatureDescriptor(
+    hstring const& Name,
+    hstring const& Description,
+    bool IsRequired,
+    Windows::AI::MachineLearning::ILearningModelFeatureDescriptor const& ElementDescriptor) : 
+        name_(Name),
+        description_(Description),
+        is_required_(IsRequired),
+        element_descriptor_(ElementDescriptor) {
+}
+
 
 winml::ILearningModelFeatureDescriptor
 SequenceFeatureDescriptor::ElementDescriptor() try {

--- a/winml/lib/Api/SequenceFeatureDescriptor.h
+++ b/winml/lib/Api/SequenceFeatureDescriptor.h
@@ -15,6 +15,11 @@ struct SequenceFeatureDescriptor : SequenceFeatureDescriptorT<
       const char* description,
       bool is_required,
       winml::ILearningModelFeatureDescriptor element_descriptor);
+  SequenceFeatureDescriptor(
+      hstring const& Name,
+      hstring const& Description,
+      bool IsRequired,
+      Windows::AI::MachineLearning::ILearningModelFeatureDescriptor const& ElementDescriptor);
 
   winml::ILearningModelFeatureDescriptor
   ElementDescriptor();
@@ -49,3 +54,9 @@ struct SequenceFeatureDescriptor : SequenceFeatureDescriptorT<
   winml::ILearningModelFeatureDescriptor element_descriptor_;
 };
 }  // namespace winrt::Windows::AI::MachineLearning::implementation
+
+namespace winrt::Windows::AI::MachineLearning::factory_implementation {
+    struct SequenceFeatureDescriptor : SequenceFeatureDescriptorT<SequenceFeatureDescriptor, implementation::SequenceFeatureDescriptor> {
+
+    };
+}  // namespace winrt::Windows::AI::MachineLearning::factory_implementation

--- a/winml/lib/Api/TensorFeatureDescriptor.cpp
+++ b/winml/lib/Api/TensorFeatureDescriptor.cpp
@@ -11,15 +11,29 @@ namespace winrt::Windows::AI::MachineLearning::implementation {
 TensorFeatureDescriptor::TensorFeatureDescriptor(
     const char* name,
     const char* description,
+    bool is_required,
     winml::TensorKind tensor_kind,
     const std::vector<int64_t>& shape,
-    bool is_required,
     bool has_unsupported_image_metadata) : name_(WinML::Strings::HStringFromUTF8(name)),
                                            description_(WinML::Strings::HStringFromUTF8(description)),
                                            tensor_kind_(tensor_kind),
                                            shape_(shape),
                                            is_required_(is_required),
                                            has_unsupported_image_metadata_(has_unsupported_image_metadata) {
+}
+
+TensorFeatureDescriptor::TensorFeatureDescriptor(
+    hstring const& Name,
+    hstring const& Description,
+    bool IsRequired,
+    winml::TensorKind const& TensorKind,
+    array_view<int64_t const> Shape,
+    bool HasUnsupportedImageMetadata) : name_(Name),
+                                        description_(Description),
+                                        tensor_kind_(TensorKind),
+                                        shape_(Shape.begin(), Shape.end()),
+                                        is_required_(IsRequired),
+                                        has_unsupported_image_metadata_(HasUnsupportedImageMetadata) {
 }
 
 winml::TensorKind
@@ -58,6 +72,11 @@ WINML_CATCH_ALL
 
 bool TensorFeatureDescriptor::IsRequired() try {
   return is_required_;
+}
+WINML_CATCH_ALL
+
+bool TensorFeatureDescriptor::HasUnsupportedImageMetadata() try {
+    return has_unsupported_image_metadata_;
 }
 WINML_CATCH_ALL
 

--- a/winml/lib/Api/TensorFeatureDescriptor.h
+++ b/winml/lib/Api/TensorFeatureDescriptor.h
@@ -13,17 +13,23 @@ struct TensorFeatureDescriptor : TensorFeatureDescriptorT<
   TensorFeatureDescriptor(
       const char* name,
       const char* description,
+      bool is_required,
       winml::TensorKind tensor_kind,
       const std::vector<int64_t>& shape,
-      bool is_required,
       bool has_unsuppored_image_metadata);
 
-  // ITensorDescriptor
-  winml::TensorKind
-  TensorKind();
+  TensorFeatureDescriptor(
+      hstring const& Name,
+      hstring const& Description,
+      bool IsRequired,
+      TensorKind const& TensorKind,
+      array_view<int64_t const> Shape,
+      bool HasUnsupportedImageMetadata);
 
-  wfc::IVectorView<int64_t>
-  Shape();
+  // ITensorDescriptor
+  winml::TensorKind TensorKind();
+  wfc::IVectorView<int64_t> Shape();
+  bool HasUnsupportedImageMetadata();
 
   // IFeatureDescriptor
   winrt::hstring
@@ -60,3 +66,9 @@ struct TensorFeatureDescriptor : TensorFeatureDescriptorT<
   bool has_unsupported_image_metadata_;
 };
 }  // namespace winrt::Windows::AI::MachineLearning::implementation
+
+namespace winrt::Windows::AI::MachineLearning::factory_implementation {
+    struct TensorFeatureDescriptor : TensorFeatureDescriptorT<TensorFeatureDescriptor, implementation::TensorFeatureDescriptor> {
+
+    };
+}  // namespace winrt::Windows::AI::MachineLearning::factory_implementation

--- a/winml/lib/Api/impl/TensorKindFrom.h
+++ b/winml/lib/Api/impl/TensorKindFrom.h
@@ -66,9 +66,9 @@ struct TensorFeatureDescriptorFrom {
     return winrt::make<winmlp::TensorFeatureDescriptor>(
         nullptr /* set to null as values are name-less */,
         nullptr /* set to null as values are description-less */,
+        false /* set to false as values dont have required annotations */,
         TensorKindFrom<T>::Type,
         shape,
-        false /* set to false as values dont have required annotations */,
         false /* set to false as this is not a tensor of unsupported metadata */);
   }
 };


### PR DESCRIPTION
This change *adds* winml_lib_core into the onnxruntime sharelib.

this is a staging step, where we will start use that "core" as the adapter for winml, and it will live inside the ORT dll.

step1 is to add it, but still keep it in both dll's (win.ai.ml.dll AND ort.dll) .    the code needs to be clean such that it can live inside ORT and not have any connections back to WINML.

it also needs to be clean that it follows the ORT system of doing things (errors, telemetry, etc.)