### PR TITLE
Fix a bug in TLS refcount that may destabilized CUDA CI

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -123,6 +123,7 @@ CUDAExecutionProvider::PerThreadContext& CUDAExecutionProvider::GetPerThreadCont
         ptc = retired_context_pool_.back();
         retired_context_pool_.pop_back();
       }
+      inuse_contexts_.insert(std::make_pair(tid, ptc));
     } else {
       ptc = inuse_iter->second;
     }


### PR DESCRIPTION
**Description**: This may fix intermittent CUDA CI failures

**Motivation and Context**
- Missed a line in previous TLS change to refcount the TLS in provider size