### PR TITLE
Port phoenix singleton lotus environment through WinML adapter

### DIFF
--- a/winml/lib/Api.Core/WinMLAdapter.cpp
+++ b/winml/lib/Api.Core/WinMLAdapter.cpp
@@ -6,7 +6,7 @@
 #include "inc/CustomRegistryHelper.h"
 #include "inc/LotusEnvironment.h"
 #include "core/providers/dml/DmlExecutionProvider/inc/DmlExecutionProvider.h"
-
+#include "PheonixSingleton.h"
 #include "LearningModelDevice.h"
 #include "TensorFeatureDescriptor.h"
 #include "ImageFeatureDescriptor.h"
@@ -179,5 +179,17 @@ onnxruntime::Tensor* STDMETHODCALLTYPE CreateTensor(
       provider->GetAllocator(0, ::OrtMemType::OrtMemTypeDefault));
   return pTensor;
 }
+
+WinML::LotusEnvironment* STDMETHODCALLTYPE CreateLotusEnvironment()
+{
+  return PheonixSingleton<WinML::LotusEnvironment>().get();
+}
+
+void __stdcall ReleaseLotusEnvironment(WinML::LotusEnvironment* lotusEnvironment)
+{
+  delete lotusEnvironment;
+}
+
+
 
 }  // namespace Windows::AI::MachineLearning::Adapter

--- a/winml/lib/Api.Core/inc/LotusEnvironment.h
+++ b/winml/lib/Api.Core/inc/LotusEnvironment.h
@@ -43,10 +43,12 @@ inline onnxruntime::logging::LoggingManager& DefaultLoggingManager() {
 }
 
 static void OnSuspending(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::ApplicationModel::SuspendingEventArgs const& args) {
+#ifdef LAYERING_DONE
   if (!profiler.IsStillReset())  //If profiler is still reset, then don't log RuntimePerf
   {
     telemetry_helper.LogRuntimePerf(profiler, true);
   }
+#endif
 }
 
 class LotusEnvironment {

--- a/winml/lib/Api.Core/inc/WinMLAdapter.h
+++ b/winml/lib/Api.Core/inc/WinMLAdapter.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include "LotusEnvironment.h"
 
 namespace Windows::AI::MachineLearning::Adapter {
 
@@ -25,9 +26,13 @@ __declspec(dllexport) ID3D12Resource* STDMETHODCALLTYPE GetD3D12ResourceFromAllo
 
 __declspec(dllexport) onnxruntime::Tensor* STDMETHODCALLTYPE CreateTensor(
     winml::TensorKind kind,
-    const int64_t * shape,
+    const int64_t* shape,
     uint32_t shape_count,
     onnxruntime::IExecutionProvider* provider);
+
+__declspec(dllexport) WinML::LotusEnvironment* STDMETHODCALLTYPE CreateLotusEnvironment();
+
+__declspec(dllexport) void STDMETHODCALLTYPE ReleaseLotusEnvironment(WinML::LotusEnvironment* lotusEnvironment);
 
 // header only code to enable smart pointers on abstract ort objects
 template <typename T>
@@ -51,5 +56,19 @@ class OrtObject {
 };
 using ModelProto = OrtObject<onnx::ModelProto>;
 using IOBinding = OrtObject<onnxruntime::IOBinding>;
+
+class LotusEnvironment {
+ public:
+  LotusEnvironment() {
+    lotusEnvironment = WinML::Adapter::CreateLotusEnvironment();
+  }
+
+  ~LotusEnvironment() {
+    WinML::Adapter::ReleaseLotusEnvironment(lotusEnvironment);
+  }
+
+ private:
+  WinML::LotusEnvironment* lotusEnvironment;
+};
 
 }  // namespace Windows::AI::MachineLearning::Adapter

--- a/winml/lib/Api/LearningModel.cpp
+++ b/winml/lib/Api/LearningModel.cpp
@@ -11,8 +11,6 @@
 #include "PheonixSingleton.h"
 #include "TelemetryEvent.h"
 
-#include "LotusEnvironment.h"
-
 #include "MapFeatureDescriptor.h"
 #include "SequenceFeatureDescriptor.h"
 #include "TensorFeatureDescriptor.h"
@@ -26,7 +24,7 @@ WINML_CATCH_ALL
 
 LearningModel::LearningModel(
     const std::string& path,
-    const winml::ILearningModelOperatorProvider operator_provider) try : lotus_environment_(PheonixSingleton<WinML::LotusEnvironment>()),
+    const winml::ILearningModelOperatorProvider operator_provider) try : lotus_environment_(PheonixSingleton<_winmla::LotusEnvironment>()),
                                                                          operator_provider_(operator_provider) {
   _winmlt::PerformanceTelemetryEvent kLoadModel_event(
       WinMLRuntimePerf::kLoadModel);
@@ -43,7 +41,7 @@ WINML_CATCH_ALL
 
 LearningModel::LearningModel(
     const wss::IRandomAccessStreamReference stream,
-    const winml::ILearningModelOperatorProvider operator_provider) try : lotus_environment_(PheonixSingleton<WinML::LotusEnvironment>()),
+    const winml::ILearningModelOperatorProvider operator_provider) try : lotus_environment_(PheonixSingleton<_winmla::LotusEnvironment>()),
                                                                          operator_provider_(operator_provider) {
   _winmlt::PerformanceTelemetryEvent kLoadModel_event(
       WinMLRuntimePerf::kLoadModel);

--- a/winml/lib/Api/LearningModel.h
+++ b/winml/lib/Api/LearningModel.h
@@ -7,7 +7,6 @@
 #include "WinMLAdapter.h"
 
     namespace Windows::AI::MachineLearning {
-  class LotusEnvironment;
   class ModelInfo;
 }  // namespace Windows::AI::MachineLearning
 
@@ -125,8 +124,8 @@ struct LearningModel : LearningModelT<LearningModel> {
   OverrideShapeInferenceMethods();
 
  private:
-  std::shared_ptr<WinML::LotusEnvironment> lotus_environment_;
-  std::unique_ptr<WinML::Adapter::ModelProto> model_proto_;
+  std::shared_ptr<_winmla::LotusEnvironment> lotus_environment_;
+  std::unique_ptr<_winmla::ModelProto> model_proto_;
   std::unique_ptr<WinML::ModelInfo> model_info_;
   ILearningModelOperatorProvider operator_provider_;
 };


### PR DESCRIPTION
This change makes the construction of Lotus environment phoenix singleton through a class in the WinML adapter