### PR TITLE
Another try to stabilize CUDA CI

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_allocator.cc
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.cc
@@ -22,7 +22,7 @@ void CUDAAllocator::CheckDevice(bool throw_when_fail) const {
   // if it's expected to change, call cudaSetDevice instead of the check
   int current_device;
   auto cuda_err = cudaGetDevice(&current_device);
-  if (cuda_err == CUDA_SUCCESS) {
+  if (cuda_err == cudaSuccess) {
     ORT_ENFORCE(current_device == info_.id);
   } else if (throw_when_fail) {
     CUDA_CALL_THROW(cuda_err);

--- a/onnxruntime/core/providers/cuda/cuda_allocator.cc
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.cc
@@ -16,18 +16,23 @@ static const GPUDataTransfer* GetGPUDataTransfer(const SessionState* session_sta
   return dynamic_cast<const GPUDataTransfer*>(session_state->GetDataTransferMgr().GetDataTransfer(gpu_device, cpu_device));
 }
 
-void CUDAAllocator::CheckDevice() const {
+void CUDAAllocator::CheckDevice(bool ignore_failure) const {
 #ifndef NDEBUG
   // check device to match at debug build
   // if it's expected to change, call cudaSetDevice instead of the check
   int current_device;
-  CUDA_CALL_THROW(cudaGetDevice(&current_device));
-  ORT_ENFORCE(current_device == info_.id);
+  auto cuda_err = cudaGetDevice(&current_device);
+  if (cuda_err == CUDA_SUCCESS) {
+    ORT_ENFORCE(current_device == info_.id);
+  } else {
+    if (!ignore_failure)
+      CUDA_CALL_THROW(cuda_err);
+  }
 #endif
 }
 
 void* CUDAAllocator::Alloc(size_t size) {
-  CheckDevice();
+  CheckDevice(false);
   void* p = nullptr;
   if (size > 0) {
     CUDA_CALL_THROW(cudaMalloc((void**)&p, size));
@@ -36,8 +41,8 @@ void* CUDAAllocator::Alloc(size_t size) {
 }
 
 void CUDAAllocator::Free(void* p) {
-  CheckDevice();
-  cudaFree(p);  // do not throw error since it's OK for cudaFree to fail during shutdown
+  CheckDevice(true);  // ignore CUDA failure when free
+  cudaFree(p);        // do not throw error since it's OK for cudaFree to fail during shutdown
 }
 
 const OrtMemoryInfo& CUDAAllocator::Info() const {

--- a/onnxruntime/core/providers/cuda/cuda_allocator.cc
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.cc
@@ -27,6 +27,8 @@ void CUDAAllocator::CheckDevice(bool throw_when_fail) const {
   } else if (throw_when_fail) {
     CUDA_CALL_THROW(cuda_err);
   }
+#else
+  ORT_UNUSED_PARAMETER(throw_when_fail);
 #endif
 }
 

--- a/onnxruntime/core/providers/cuda/cuda_allocator.h
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.h
@@ -16,7 +16,7 @@ class CUDAAllocator : public IDeviceAllocator {
   virtual FencePtr CreateFence(const SessionState* session_state) override;
 
  private:
-  void CheckDevice() const;
+  void CheckDevice(bool ignore_failure) const;
 
  private:
   const OrtMemoryInfo info_;

--- a/onnxruntime/core/providers/cuda/cuda_allocator.h
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.h
@@ -16,7 +16,7 @@ class CUDAAllocator : public IDeviceAllocator {
   virtual FencePtr CreateFence(const SessionState* session_state) override;
 
  private:
-  void CheckDevice(bool ignore_failure) const;
+  void CheckDevice(bool throw_when_fail) const;
 
  private:
   const OrtMemoryInfo info_;

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -113,7 +113,6 @@ CUDAExecutionProvider::PerThreadContext& CUDAExecutionProvider::GetPerThreadCont
   auto* p = per_thread_context_map_.get();
   if (p->count(this) == 0) {
     std::lock_guard<OrtMutex> lock(context_pool_mutex_);
-    unsigned int tid = logging::GetThreadId();
     std::shared_ptr<PerThreadContext> ptc;
     if (retired_context_pool_.empty()) {
       ptc = std::make_shared<PerThreadContext>(device_id_);

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.h
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.h
@@ -138,8 +138,6 @@ class CUDAExecutionProvider : public IExecutionProvider {
   // thread local context during execution
   using PerThreadContextMap = std::unordered_map<const CUDAExecutionProvider*, std::shared_ptr<PerThreadContext>>;
   static thread_local std::unique_ptr<PerThreadContextMap> per_thread_context_map_;
-  // in some compilers, TLS may not be accessible in EP's dtor, so hold ownership in here
-  mutable std::unordered_map<unsigned int, std::shared_ptr<PerThreadContext>> inuse_contexts_;
 
   // reuse thread local context
   mutable std::deque<std::shared_ptr<PerThreadContext>> retired_context_pool_;


### PR DESCRIPTION
**Description**: To avoid intermittent test failure in CUDA CI
**Motivation and Context**
- cudaFree is supposed to happen when shutting down, and error from cuda should be ignored then
