### PR TITLE
Correctly handle implicit inputs for fused nodes

### DIFF
--- a/onnxruntime/core/codegen/common/common.cc
+++ b/onnxruntime/core/codegen/common/common.cc
@@ -152,7 +152,8 @@ std::unique_ptr<ComputeCapability> ToCapacity(const onnxruntime::GraphViewer& gr
       };
     // handle current graph's inputs
     node.ForEachWithIndex(node.InputDefs(), process_input_fn);
-    // nodes' implicit inputs also need to be collected.
+    // nodes' implicit inputs also need to be collected. They need to
+    // be promoted to being explicit inputs for everything to work.
     node.ForEachWithIndex(node.ImplicitInputDefs(), process_input_fn);
 
     // Handle outouts

--- a/onnxruntime/core/codegen/common/common.cc
+++ b/onnxruntime/core/codegen/common/common.cc
@@ -140,18 +140,20 @@ std::unique_ptr<ComputeCapability> ToCapacity(const onnxruntime::GraphViewer& gr
 
   for (const auto& node_index : subgraph->nodes) {
     const auto& node = *graph.GetNode(node_index);
+    auto process_input_fn = 
+      [&meta_def, &node, &node_indices](const onnxruntime::NodeArg& def, size_t) {
+        const onnxruntime::Node* input_node = GetInputNode(node, &def);
+        bool input_from_subgraph = (input_node && node_indices.count(input_node->Index()));
+        if (!input_from_subgraph) {
+          // input is from weights or outside of graph
+          meta_def->inputs.push_back(def.Name());
+        }
+        return Status::OK();
+      };
     // handle current graph's inputs
-    node.ForEachWithIndex(
-        node.InputDefs(),
-        [&meta_def, &node, &node_indices](const onnxruntime::NodeArg& def, size_t) {
-          const onnxruntime::Node* input_node = GetInputNode(node, &def);
-          bool input_from_subgraph = (input_node && node_indices.count(input_node->Index()));
-          if (!input_from_subgraph) {
-            // input is from weights or outside of graph
-            meta_def->inputs.push_back(def.Name());
-          }
-          return Status::OK();
-        });
+    node.ForEachWithIndex(node.InputDefs(), process_input_fn);
+    // nodes' implicit inputs also need to be collected.
+    node.ForEachWithIndex(node.ImplicitInputDefs(), process_input_fn);
 
     // Handle outouts
     // two cases are considerd as outputs
@@ -211,15 +213,16 @@ std::unique_ptr<ComputeCapability> ToCapacity(const onnxruntime::GraphViewer& gr
     // Therefore, the all inner nested subgraph's initializers should be already in the immediate nested subgraph's inputs.
     if (nullptr != immediate_nested_subgraph) {
       for (auto& n : immediate_nested_subgraph->Nodes()) {
-        n.ForEachWithIndex(
-            n.InputDefs(),
-            [&meta_def, &all_initializers](const onnxruntime::NodeArg& def, size_t) {
-              auto iter = all_initializers.find(def.Name());
-              if (iter != all_initializers.end()) {
-                meta_def->inputs.push_back(def.Name());
-              }
-              return Status::OK();
-            });
+        auto add_input_fn = 
+          [&meta_def, &all_initializers](const onnxruntime::NodeArg& def, size_t) {
+            auto iter = all_initializers.find(def.Name());
+            if (iter != all_initializers.end()) {
+              meta_def->inputs.push_back(def.Name());
+            }
+            return Status::OK();
+          };
+        n.ForEachWithIndex(n.InputDefs(), add_input_fn);
+        n.ForEachWithIndex(n.ImplicitInputDefs(), add_input_fn);
       }
     }
   }

--- a/onnxruntime/test/providers/cpu/controlflow/scan_test.cc
+++ b/onnxruntime/test/providers/cpu/controlflow/scan_test.cc
@@ -536,12 +536,6 @@ static void OuterScopeAccess_ShapeInMainGraph_NoTypeAndShapeInSubgraph(bool is_v
 
   options.include_outer_scope_add = true;
 
-  // Scan9.OuterScopeAccess_ShapeInMainGraph_NoTypeAndShapeInSubgraph fails with nuphar. See Bug 525222.
-  // Remove this once that is fixed.
-  if (is_v8 == false) {
-    options.excluded_provider_types.insert(kNupharExecutionProvider);
-  }
-
   ShortSequenceOneInBatchOneLoopStateVar(options);
 }
 


### PR DESCRIPTION
Previously, nuphar's partitioning function didn't include
node's implicit inputs into the inputs list of MetaDef, and hence
a crash was triggered in the onnx graph checker.

This commit fixed the issue. Furthermore, it also fixed a related
issue where we didn't add implicit inputs into
graph_inputs_excluding_initializers_ in Graph::SetGraphInputsOutputs.

the issue was that graph_inputs_including_initializers_ populated by
SetInputs (e.g. called by FunctionImpl::FunctionImpl) may contain
implicit inputs which were not of any node's initializers in the graph.
Because they were not part of any initializers, these implicit inputs
couldn't be visited by going through all nodes' inputs.
Consequently, they would *not* be added into graph_inputs_excluding_initializers_.

We fixed the issue by first copying the populated graph_inputs_including_initializers_
into graph_inputs_excluding_initalizers_, which then had both initializers and
non-initializers as its initial content. Later, we erase initializers from the
list. In this way, we can ensure all implicit inputs to remain in
graph_inputs_excluding_initializers_.

