### PR TITLE
Tiny fix to codegen

### DIFF
--- a/onnxruntime/core/codegen/passes/op_ir_creator/tvm_ir_builder.cc
+++ b/onnxruntime/core/codegen/passes/op_ir_creator/tvm_ir_builder.cc
@@ -70,7 +70,7 @@ Status TVMIRBuilder::Evaluate(
 
 // BEGIN: Generic IR creator classes
 #define ADD_OP_ITEM(name) \
-  op_ir_registry->Register(std::move(onnxruntime::make_unique<GENERIC_OP_IR_CREATOR_CLASS(name)>()));
+  op_ir_registry->Register(onnxruntime::make_unique<GENERIC_OP_IR_CREATOR_CLASS(name)>());
 
 #define BINARY_OP(name) ADD_OP_ITEM(name)
 #define BINARY_CMP_OP(name) ADD_OP_ITEM(name)

--- a/onnxruntime/core/codegen/passes/weight_layout/weight_layout.cc
+++ b/onnxruntime/core/codegen/passes/weight_layout/weight_layout.cc
@@ -31,12 +31,11 @@ const std::string WeightLayout::GetKey(
     ONNX_NAMESPACE::TensorProto_DataType proto_type,
     int input_dim,
     float pad_zero) {
-  std::string key = name;
-  key += "_type_" + std::to_string(static_cast<int>(proto_type));
-  key += "_dim_" + input_dim;
-  key += "_pad_zero_" + std::to_string(pad_zero);
-  key = NormalizeCppName(key);
-  return key;
+  std::ostringstream key(name);
+  key << "_type_" << static_cast<int>(proto_type);
+  key << "_dim_" << input_dim;
+  key << "_pad_zero_" << pad_zero;
+  return NormalizeCppName(key.str());
 }
 
 WeightLayout::WeightLayout(

--- a/onnxruntime/test/tvm/tvm_basic_test.cc
+++ b/onnxruntime/test/tvm/tvm_basic_test.cc
@@ -150,7 +150,7 @@ class FuseExecutionProviderX : public CPUExecutionProvider {
             onnxruntime::make_unique<ComputeCapability>(std::move(sub_graph)));
       }
     }
-    return std::move(result);
+    return result;
   }
 
   common::Status Compile(const std::vector<onnxruntime::Node*>& fused_nodes,

--- a/onnxruntime/test/tvm/tvm_demo/demo_compiler.cc
+++ b/onnxruntime/test/tvm/tvm_demo/demo_compiler.cc
@@ -110,7 +110,7 @@ bool TVM_SCHEDULER_CLASS(AlwaysInline, DemoTVM)::Evaluate(
 // Register the always inline Scheduler to sched_registry
 static void RegisterAlwaysInlineScheduler(tvm_codegen::TVMScheduleRegistry* sched_registry) {
   sched_registry->Register(
-      std::move(onnxruntime::make_unique<TVM_SCHEDULER_CLASS(AlwaysInline, DemoTVM)>()));
+      onnxruntime::make_unique<TVM_SCHEDULER_CLASS(AlwaysInline, DemoTVM)>());
 }
 
 // Declare a schedule dispatcher that always dispatches the always inline Scheduler


### PR DESCRIPTION
**Description**: 

1. Fix a bug in weight_layout.cc.
It tried to add a integer to a "const char *"

2. Avoid calling std::move if the object is temporary. Otherwise the call to std::move prevents copy elision.

**Motivation and Context**
- Why is this change required? What problem does it solve?

- If it fixes an open issue, please link to the issue here.
