### PR TITLE
Fix cross compile bug

### DIFF
--- a/onnxruntime/core/codegen/common/utils.cc
+++ b/onnxruntime/core/codegen/common/utils.cc
@@ -70,7 +70,7 @@ TargetFeature GetTargetInfo(const codegen::CodeGenSettings& settings) {
   TargetFeature feature;
 
   std::string target_str = "";
-  if (settings.HasOption(nuphar::kNupharCodeGenTarget) && settings.HasOption(nuphar::kNupharCachePath)) {
+  if (settings.HasOption(nuphar::kNupharCodeGenTarget)) {
     target_str = settings.GetOptionValue(nuphar::kNupharCodeGenTarget);
   }
 


### PR DESCRIPTION
**Description**: Fix cross compile bug.

**Motivation and Context**
- Allow cross compile when no cache path set.
