### PR TITLE
Fix the type constraints on CUDA If operator to exclude strings.

### DIFF
--- a/onnxruntime/core/providers/cuda/controlflow/if.cc
+++ b/onnxruntime/core/providers/cuda/controlflow/if.cc
@@ -18,7 +18,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(If,
                                   KernelDefBuilder()
                                       .InputMemoryType<OrtMemTypeCPUInput>(0)  // 'cond' needs to be on CPU
                                       .TypeConstraint("B", DataTypeImpl::GetTensorType<bool>())
-                                      .TypeConstraint("V", DataTypeImpl::AllTensorTypes()),
+                                      .TypeConstraint("V", DataTypeImpl::AllFixedSizeTensorTypes()),
                                   If);
 
 // output shape rules requiring the output shapes of the 'THEN' and 'ELSE'
@@ -30,7 +30,7 @@ ONNX_OPERATOR_KERNEL_EX(If,
                         KernelDefBuilder()
                             .InputMemoryType<OrtMemTypeCPUInput>(0)  // 'cond' needs to be on CPU
                             .TypeConstraint("B", DataTypeImpl::GetTensorType<bool>())
-                            .TypeConstraint("V", DataTypeImpl::AllTensorTypes()),
+                            .TypeConstraint("V", DataTypeImpl::AllFixedSizeTensorTypes()),
                         If);
 
 Status If::Compute(OpKernelContext* ctx) const {


### PR DESCRIPTION
**Description**: 
Fix the type constraints for If so the CUDA version can not be selected if the input involves strings. 

**Motivation and Context**
Tensor<string> isn't supported on CUDA.