### PR TITLE
Brianma/cpuwinml

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -81,7 +81,8 @@ if (onnxruntime_ENABLE_LANGUAGE_INTEROP_OPS)
   target_link_libraries(onnxruntime PRIVATE onnxruntime_language_interop onnxruntime_pyop)
 endif()
 
-set_property(TARGET onnxruntime APPEND_STRING PROPERTY LINK_FLAGS ${ONNXRUNTIME_SO_LINK_FLAG})
+set_property(TARGET onnxruntime APPEND_STRING PROPERTY LINK_FLAGS "${ONNXRUNTIME_SO_LINK_FLAG} ${ONNXRUNTIME_LINKER_FLAGS}")
+
 set_target_properties(onnxruntime PROPERTIES LINK_DEPENDS ${SYMBOL_FILE})
 if(onnxruntime_ENABLE_LTO)
   set_target_properties(onnxruntime PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -432,7 +432,7 @@ if (onnxruntime_USE_DML)
   
   target_link_libraries(onnxruntime_providers_dml ${CMAKE_CURRENT_BINARY_DIR}/packages/DirectML.0.0.1/build/DirectML.targets)
   target_link_libraries(onnxruntime_providers_dml d3d12.lib dxgi.lib)
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DELAYLOAD:DirectML.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:dxgi.dll")
+  list(APPEND ONNXRUNTIME_LINKER_FLAGS "/DELAYLOAD:DirectML.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:dxgi.dll")
 
   # The DML EP requires C++17
   set_target_properties(onnxruntime_providers_dml PROPERTIES CXX_STANDARD 17)

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -119,26 +119,33 @@ target_link_libraries(winml_lib_telemetry PRIVATE wil)
 ###########################
 
 # Add static library that will be archived/linked for both static/dynamic library
-add_library(winml_lib_core STATIC
-  ${winml_lib_api_core_dir}/inc/AbiCustomRegistryImpl.h
+list(APPEND winml_lib_core_files
   ${winml_lib_api_core_dir}/inc/CustomRegistryHelper.h
   ${winml_lib_api_core_dir}/inc/LotusEnvironment.h
   ${winml_lib_api_core_dir}/inc/MLValueHelpers.h
   ${winml_lib_api_core_dir}/inc/TensorBaseHelpers.h
   ${winml_lib_api_core_dir}/inc/WinMLAdapter.h
   ${winml_lib_api_core_dir}/CpuOrtSessionBuilder.h
-  ${winml_lib_api_core_dir}/DmlOrtSessionBuilder.h
   ${winml_lib_api_core_dir}/FeatureDescriptorFactory.h
   ${winml_lib_api_core_dir}/FeatureDescriptorFactory.cpp
   ${winml_lib_api_core_dir}/ZeroCopyInputStreamWrapper.h
   ${winml_lib_api_core_dir}/pch.h
-  ${winml_lib_api_core_dir}/AbiCustomRegistryImpl.cpp
   ${winml_lib_api_core_dir}/CpuOrtSessionBuilder.cpp
-  ${winml_lib_api_core_dir}/DmlOrtSessionBuilder.cpp
   ${winml_lib_api_core_dir}/LotusEnvironment.cpp
   ${winml_lib_api_core_dir}/WinMLAdapter.cpp
   ${winml_lib_api_core_dir}/ZeroCopyInputStreamWrapper.cpp
 )
+
+if (onnxruntime_USE_DML)
+  list(APPEND winml_lib_core_files
+    ${winml_lib_api_core_dir}/inc/AbiCustomRegistryImpl.h
+    ${winml_lib_api_core_dir}/DmlOrtSessionBuilder.h
+    ${winml_lib_api_core_dir}/AbiCustomRegistryImpl.cpp
+    ${winml_lib_api_core_dir}/DmlOrtSessionBuilder.cpp
+  )
+endif(onnxruntime_USE_DML)
+
+add_library(winml_lib_core STATIC ${winml_lib_core_files})
 
 # Compiler options
 target_compile_features(winml_lib_core PRIVATE cxx_std_17)
@@ -194,7 +201,9 @@ add_dependencies(winml_lib_core winml_api_native_internal)
 
 # Link libraries
 target_link_libraries(winml_lib_core PRIVATE wil)
-target_link_libraries(winml_lib_core PRIVATE onnxruntime_providers_dml)
+if (onnxruntime_USE_DML)
+  target_link_libraries(winml_lib_core PRIVATE onnxruntime_providers_dml)
+endif(onnxruntime_USE_DML)
 
 # add it to the onnxruntime shared library
 set(onnxruntime_winml windowsapp.lib -WHOLEARCHIVE:$<TARGET_FILE:winml_lib_core>)

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/inc/IWinmlExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/inc/IWinmlExecutionProvider.h
@@ -10,6 +10,8 @@
 
 #include "core/framework/op_kernel.h"
 
+#include <DirectML.h>
+
 struct AbstractOperatorDesc;
 interface IMLOperatorTensor;
 
@@ -65,6 +67,8 @@ namespace Windows::AI::MachineLearning::Adapter
         virtual void Close() = 0;
     };
 
+    using MLOperatorTensorGetter = std::function<Microsoft::WRL::ComPtr<IMLOperatorTensor>(uint32_t index)>;
+
     struct DmlOperatorParams
     {
         Microsoft::WRL::ComPtr<IDMLOperator> op;
@@ -86,8 +90,6 @@ namespace Windows::AI::MachineLearning::Adapter
         bool allowHalfPrecisionComputation = false;
     };
 
-    using MLOperatorTensorGetter = std::function<Microsoft::WRL::ComPtr<IMLOperatorTensor>(uint32_t index)>;
-
     using GraphNodeFactory = std::function<void(
         const onnxruntime::Node& node, 
         MLOperatorTensorGetter& constantInputGetter,
@@ -104,4 +106,4 @@ namespace Windows::AI::MachineLearning::Adapter
     };
 
     using GraphNodeFactoryMap = std::unordered_map<onnxruntime::KernelDef*, std::shared_ptr<GraphNodeFactoryRegistration>>;
-}
+}  // namespace Windows::AI::MachineLearning::Adapter

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -373,7 +373,7 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
                  # enable pyop if it is nightly build
                  "-Donnxruntime_ENABLE_LANGUAGE_INTEROP_OPS=" + ("ON" if args.enable_language_interop_ops or (args.config != 'Debug' and bool(os.getenv('NIGHTLY_BUILD') == '1')) else "OFF"),
                  "-Donnxruntime_USE_DML=" + ("ON" if args.use_dml else "OFF"),
-                 "-Donnxruntime_USE_WINML=" + ("ON" if args.use_winml and args.use_dml else "OFF"),
+                 "-Donnxruntime_USE_WINML=" + ("ON" if args.use_winml else "OFF"),
                  ]
     if args.use_brainslice:
         bs_pkg_name = args.brain_slice_package_name.split('.', 1)

--- a/winml/lib/Api.Core/AbiCustomRegistryImpl.cpp
+++ b/winml/lib/Api.Core/AbiCustomRegistryImpl.cpp
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
+
+#ifdef USE_DML
+
 #include "inc/AbiCustomRegistryImpl.h"
 
 namespace Windows::AI::MachineLearning::Adapter {
@@ -80,3 +83,5 @@ HRESULT STDMETHODCALLTYPE AbiCustomRegistryImpl::RegisterOperatorKernel(
 CATCH_RETURN();
 
 }  // namespace Windows::AI::MachineLearning::Adapter
+
+#endif USE_DML

--- a/winml/lib/Api.Core/inc/AbiCustomRegistryImpl.h
+++ b/winml/lib/Api.Core/inc/AbiCustomRegistryImpl.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#ifdef USE_DML
 #include "core/providers/dml/DmlExecutionProvider/src/AbiCustomRegistry.h"
 
 namespace Windows::AI::MachineLearning::Adapter{
@@ -37,3 +38,4 @@ class AbiCustomRegistryImpl : public AbiCustomRegistry {
 };
 
 }  // namespace winrt::Windows::AI::MachineLearning::Adapter
+#endif USE_DML

--- a/winml/lib/Api.Core/inc/WinMLAdapter.h
+++ b/winml/lib/Api.Core/inc/WinMLAdapter.h
@@ -6,6 +6,7 @@
 #include "core/session/onnxruntime_c_api.h"
 
 namespace Windows::AI::MachineLearning::Adapter {
+TRACELOGGING_DECLARE_PROVIDER(winml_trace_logging_provider);
 
 MIDL_INTERFACE("eaae30b5-7381-432d-9730-322136b02371") IModelInfo : IUnknown{
     // model metadata

--- a/winml/lib/Api.Core/inc/WinMLAdapter.h
+++ b/winml/lib/Api.Core/inc/WinMLAdapter.h
@@ -6,7 +6,6 @@
 #include "core/session/onnxruntime_c_api.h"
 
 namespace Windows::AI::MachineLearning::Adapter {
-TRACELOGGING_DECLARE_PROVIDER(winml_trace_logging_provider);
 
 MIDL_INTERFACE("eaae30b5-7381-432d-9730-322136b02371") IModelInfo : IUnknown{
     // model metadata
@@ -62,13 +61,13 @@ MIDL_INTERFACE("a848faf6-5a2e-4a7f-b622-cc036f71e28a") IModelProto : IUnknown{
 MIDL_INTERFACE("6ec766ef-6365-42bf-b64f-ae85c015adb8") IInferenceSession : IUnknown {
     virtual onnxruntime::InferenceSession* STDMETHODCALLTYPE get() = 0;
     virtual void STDMETHODCALLTYPE RegisterGraphTransformers(bool registerLotusTransforms) = 0;
-    virtual HRESULT STDMETHODCALLTYPE RegisterCustomRegistry(IMLOperatorRegistry* registry) = 0;
+    virtual HRESULT STDMETHODCALLTYPE RegisterCustomRegistry(IMLOperatorRegistry * registry) = 0;
     virtual HRESULT STDMETHODCALLTYPE LoadModel(IModelProto* model_proto) = 0;
     virtual HRESULT STDMETHODCALLTYPE NewIOBinding(IIOBinding** io_binding) = 0;
     virtual HRESULT STDMETHODCALLTYPE Run(const onnxruntime::RunOptions* run_options, IIOBinding* io_binding) = 0;
     virtual HRESULT STDMETHODCALLTYPE StartProfiling() = 0;
     virtual HRESULT STDMETHODCALLTYPE EndProfiling() = 0;
-    virtual void STDMETHODCALLTYPE FlushContext(onnxruntime::IExecutionProvider* dml_provider) = 0;
+    virtual void STDMETHODCALLTYPE FlushContext(onnxruntime::IExecutionProvider * dml_provider) = 0;
     virtual void STDMETHODCALLTYPE TrimUploadHeap(onnxruntime::IExecutionProvider* dml_provider) = 0;
     virtual void STDMETHODCALLTYPE ReleaseCompletedReferences(onnxruntime::IExecutionProvider* dml_provider) = 0;
 };
@@ -100,7 +99,7 @@ MIDL_INTERFACE("b19385e7-d9af-441a-ba7f-3993c7b1c9db") IWinMLAdapter : IUnknown 
         IModelProto* p_model_proto,
         bool is_float16_supported) = 0;
 
-    virtual ID3D12Resource* STDMETHODCALLTYPE GetD3D12ResourceFromAllocation(onnxruntime::IExecutionProvider* provider, void* allocation) = 0;
+    virtual ID3D12Resource* STDMETHODCALLTYPE GetD3D12ResourceFromAllocation(onnxruntime::IExecutionProvider * provider, void* allocation) = 0;
 
 
     // factory method for creating an ortsessionbuilder from a device
@@ -139,6 +138,7 @@ MIDL_INTERFACE("b19385e7-d9af-441a-ba7f-3993c7b1c9db") IWinMLAdapter : IUnknown 
         std::vector<int64_t>* shape,
         onnxruntime::MLDataType data_type,
         IOrtValue ** gpu_value) = 0;
+
     virtual HRESULT STDMETHODCALLTYPE CreateCPUMLValue(
         std::vector<int64_t>* shape,
         onnxruntime::MLDataType data_type,

--- a/winml/lib/Api.Core/pch.h
+++ b/winml/lib/Api.Core/pch.h
@@ -6,3 +6,7 @@
 #include "cppwinrt_onnx.h"
 #include "wil/wrl.h"
 #include "dx.h"
+
+#if USE_DML
+#include <DirectML.h>
+#endif USE_DML

--- a/winml/lib/Api.Image/DeviceHelpers.cpp
+++ b/winml/lib/Api.Image/DeviceHelpers.cpp
@@ -2,8 +2,12 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
+
+#ifdef USE_DML
 #include "DirectML.h"
 #include <d3d11on12.h>
+#endif USE_DML
+
 #include <wil/winrt.h>
 #include "inc/DeviceHelpers.h"
 
@@ -143,6 +147,7 @@ bool IsFloat16Supported(ID3D12Device* device) {
     return false;
   }
 
+#ifdef USE_DML
   winrt::com_ptr<IDMLDevice> dmlDevice;
   winrt::check_hresult(DMLCreateDevice(
       device,
@@ -160,6 +165,9 @@ bool IsFloat16Supported(ID3D12Device* device) {
       &float16Data));
 
   return float16Data.IsSupported;
+#else
+  return false;
+#endif USE_DML
 }
 
 // uses Structured Exception Handling (SEH) to detect for delay load failures of target API.
@@ -293,6 +301,7 @@ HRESULT GetDXCoreHardwareAdapterWithPreference(DXGI_GPU_PREFERENCE preference, I
 #endif
 
 HRESULT CreateD3D11On12Device(ID3D12Device* device12, ID3D11Device** device11) {
+#ifdef USE_DML
   return DeviceHelpers::RunDelayLoadedApi(
       D3D11On12CreateDevice,
       device12,                          // pointer to d3d12 device
@@ -305,6 +314,9 @@ HRESULT CreateD3D11On12Device(ID3D12Device* device12, ID3D11Device** device11) {
       device11,                          // d3d11 device out param
       nullptr,                           // pointer to d3d11 device context (unused)
       nullptr);                          // pointer to the returned feature level (unused)
+#else
+  return E_NOTIMPL;
+#endif USE_DML
 }
 
 HRESULT GetGPUPreference(winrt::Windows::AI::MachineLearning::LearningModelDeviceKind deviceKind, DXGI_GPU_PREFERENCE* preference) noexcept {

--- a/winml/lib/Api/ImageFeatureValue.cpp
+++ b/winml/lib/Api/ImageFeatureValue.cpp
@@ -14,7 +14,7 @@
 #include "ImageConversionTypes.h"
 #include "ConverterResourceStore.h"
 #include "ImageFeatureDescriptor.h"
-#include "core/providers/dml/DmlExecutionProvider/inc/DmlExecutionProvider.h"
+
 #include "core/session/onnxruntime_c_api.h"
 
 #include "D3DDeviceCache.h"
@@ -537,7 +537,8 @@ HRESULT ImageFeatureValue::GetOrtValue(WinML::BindingContext& context, _winmla::
     auto singleFrameBufferSize = bufferByteSize / m_batchSize;
     if (spDevice->IsCpuDevice()) {
       CPUTensorize(m_videoFrames, resourceMetadata.Bounds, resourceMetadata.TensorDescriptor, spSession, pAllocatedResource, static_cast<unsigned int>(singleFrameBufferSize));
-    } else {
+    }
+    else {
       GPUTensorize(m_videoFrames, resourceMetadata.Bounds, resourceMetadata.TensorDescriptor, spSession, pAllocatedResource, context);
     }
   }
@@ -588,7 +589,8 @@ HRESULT ImageFeatureValue::UpdateSourceResourceData(BindingContext& context, _wi
       pooledConverter->Get()->Detensorizer->SoftwareTensorToVideoFrame(context.session, tempPAllocatedResource, resourceMetadata.TensorDescriptor, videoFrame);
       tempPAllocatedResource += bufferByteSize;
     }
-  } else {
+  } 
+  else {
     descriptor.pixel_format = static_cast<DWORD>(DirectXPixelFormat::B8G8R8X8UIntNormalized);
     descriptor.luid = spDevice->GetD3DDevice()->GetAdapterLuid();  // Converted image on GPU
 

--- a/winml/lib/Api/LearningModelBinding.cpp
+++ b/winml/lib/Api/LearningModelBinding.cpp
@@ -246,7 +246,7 @@ ILearningModelFeatureValue LearningModelBinding::CreateUnboundOuputFeatureValue(
     if (IsOfTensorType(tensorValue.get(), TensorKind::Float)) {
       if (descriptor.Kind() == LearningModelFeatureKind::Image) {
         using namespace Windows::Graphics::Imaging;
-        // TODO: this format for unbound ouput needs more discussion
+        // TODO: this format for unbound output needs more discussion
         BitmapPixelFormat format = descriptor.as<ImageFeatureDescriptor>()->BitmapPixelFormat();
         uint32_t width = static_cast<uint32_t>(tensorValue->ShapeGetDims()[3]);
         uint32_t height = static_cast<uint32_t>(tensorValue->ShapeGetDims()[2]);

--- a/winml/lib/Api/LearningModelDevice.cpp
+++ b/winml/lib/Api/LearningModelDevice.cpp
@@ -3,8 +3,7 @@
 
 #include "pch.h"
 #include "LearningModelDevice.h"
-#include "core/providers/dml/DmlExecutionProvider/inc/MLOperatorAuthor.h"
-#include "core/providers/dml/DmlExecutionProvider/inc/DmlExecutionProvider.h"
+
 #include <D3d11_4.h>
 #include <d3d11on12.h>
 #include "D3DDeviceCache.h"

--- a/winml/lib/Api/impl/TensorMemoryBufferReference.h
+++ b/winml/lib/Api/impl/TensorMemoryBufferReference.h
@@ -5,7 +5,7 @@
 
 #include "Tensor.h"
 #include <type_traits>
-#include "core/providers/dml/DmlExecutionProvider/inc/DmlExecutionProvider.h"
+
 #include <Memorybuffer.h>
 #include "WinMLAdapter.h"
 

--- a/winml/lib/Common/inc/onnx.h
+++ b/winml/lib/Common/inc/onnx.h
@@ -16,7 +16,9 @@
 // the C++ ort api
 #include "core/session/onnxruntime_cxx_api.h"
 
+#ifdef USE_DML
 #include <DirectML.h>
+#endif USE_DML
 
 #include "core/framework/customregistry.h"
 #include "core/framework/allocatormgr.h"


### PR DESCRIPTION
**Description**: right now building the winml dll requires using the --use_dml flag, which makes the ort dll build with the dml EP. The CPU flavor should not depend on the dml EP. This change breaks that dependency and allows us to build with and without --use_dml, producing either a CPU EP binary or a cpu/dml binary. 
