### PR TITLE
Brianma/breaks

### DIFF
--- a/winml/lib/Api.Core/WinMLAdapter.cpp
+++ b/winml/lib/Api.Core/WinMLAdapter.cpp
@@ -58,7 +58,7 @@ class AbiSafeTensor : public Microsoft::WRL::RuntimeClass<
                           ITensor> {
  private:
   onnxruntime::Tensor& tensor_;  // weak ref
-  ComPtr<IOrtValue> value_;      // strong ref
+  Microsoft::WRL::ComPtr<IOrtValue> value_;  // strong ref
 
  public:
   AbiSafeTensor(onnxruntime::Tensor* tensor,
@@ -793,7 +793,7 @@ class IOBinding : public Microsoft::WRL::RuntimeClass<
  private:
   std::shared_ptr<onnxruntime::IOBinding> binding_;
   std::vector<IOrtValue*> outputs_weak_;
-  std::vector<ComPtr<IOrtValue>> outputs_;
+  std::vector<Microsoft::WRL::ComPtr<IOrtValue>> outputs_;
 
  public:
   IOBinding(onnxruntime::IOBinding* binding) : binding_(binding) {
@@ -883,12 +883,14 @@ InferenceSession::RegisterCustomRegistry(
     IMLOperatorRegistry* registry) {
   RETURN_HR_IF(S_OK, registry == nullptr);
 
+#ifdef USE_DML
   auto custom_registries = GetLotusCustomRegistries(registry);
 
   // Register
   for (auto& custom_registry : custom_registries) {
     ORT_THROW_IF_ERROR(session_->RegisterCustomRegistry(custom_registry));
   }
+#endif USE_DML
 
   return S_OK;
 }

--- a/winml/lib/Api.Core/WinMLAdapter.cpp
+++ b/winml/lib/Api.Core/WinMLAdapter.cpp
@@ -639,7 +639,7 @@ class WinMLAdapter : public Microsoft::WRL::RuntimeClass<
 #ifdef USE_DML
     // Retrieve the "operator abi" registry.
     winrt::com_ptr<IMLOperatorRegistry> operator_registry;
-    operator_provider_native->GetRegistry(operator_registry.put());
+    THROW_IF_FAILED(operator_provider_native->GetRegistry(operator_registry.put()));
     *registry = operator_registry.detach();
     return S_OK;
 #else

--- a/winml/lib/Api.Core/inc/CustomRegistryHelper.h
+++ b/winml/lib/Api.Core/inc/CustomRegistryHelper.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#ifdef USE_DML
 #include "core/providers/dml/DmlExecutionProvider/src/AbiCustomRegistry.h"
 
 namespace Windows::AI::MachineLearning::Adapter {
@@ -25,3 +26,5 @@ GetLotusCustomRegistries(
 }
 
 }  // namespace Windows::AI::MachineLearning::Adapter
+
+#endif USE_DML

--- a/winml/lib/Api.Core/inc/WinMLAdapter.h
+++ b/winml/lib/Api.Core/inc/WinMLAdapter.h
@@ -128,6 +128,7 @@ MIDL_INTERFACE("b19385e7-d9af-441a-ba7f-3993c7b1c9db") IWinMLAdapter : IUnknown 
 
     // custom ops
     virtual HRESULT STDMETHODCALLTYPE GetCustomRegistry(IMLOperatorRegistry** registry) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetOperatorRegistry(ILearningModelOperatorProviderNative * operator_provider_native, IMLOperatorRegistry * *registry) = 0;
 
     // dml ep hooks
     virtual void* STDMETHODCALLTYPE CreateGPUAllocationFromD3DResource(ID3D12Resource* pResource) = 0;

--- a/winml/lib/Api/LearningModel.cpp
+++ b/winml/lib/Api/LearningModel.cpp
@@ -5,9 +5,6 @@
 
 #include "LearningModel.h"
 
-#ifdef USE_DML
-#include "core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h"
-#endif USE_DML
 #include "TelemetryEvent.h"
 
 #include "MapFeatureDescriptor.h"
@@ -161,19 +158,13 @@ LearningModel::GetOperatorRegistry() {
     return nullptr;
   }
 
-#ifdef USE_DML
   // Get the native winrt provider interface out of winrt operator provider.
   auto operator_provider_native =
       operator_provider_.as<ILearningModelOperatorProviderNative>();
 
-  // Retrieve the "operator abi" registry.
-  winrt::com_ptr<IMLOperatorRegistry> operator_registry;
-  operator_provider_native->GetRegistry(operator_registry.put());
-
-  return operator_registry.get();
-#else
-  return nullptr;
-#endif USE_DML
+  IMLOperatorRegistry* registry = nullptr;
+  adapter_->GetOperatorRegistry(operator_provider_native.get(), &registry);
+  return registry;
 }
 
 wfc::IVectorView<winml::ILearningModelFeatureDescriptor>

--- a/winml/lib/Api/LearningModel.cpp
+++ b/winml/lib/Api/LearningModel.cpp
@@ -5,10 +5,10 @@
 
 #include "LearningModel.h"
 
+#ifdef USE_DML
 #include "core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h"
+#endif USE_DML
 #include "TelemetryEvent.h"
-
-#include "LotusEnvironment.h"
 
 #include "MapFeatureDescriptor.h"
 #include "SequenceFeatureDescriptor.h"
@@ -18,7 +18,7 @@ namespace winrt::Windows::AI::MachineLearning::implementation {
 LearningModel::LearningModel(
     const hstring& path,
     const winml::ILearningModelOperatorProvider op_provider) try : LearningModel(WinML::Strings::UTF8FromHString(path),
-                                                                   op_provider) {
+                                                                                 op_provider) {
 }
 WINML_CATCH_ALL
 
@@ -57,7 +57,7 @@ LearningModel::LearningModel(
 WINML_CATCH_ALL
 
 void LearningModel::Initialize() {
-    WINML_THROW_IF_FAILED(adapter_->CreateModelInfo(model_proto_.get(), model_info_.put()));
+  WINML_THROW_IF_FAILED(adapter_->CreateModelInfo(model_proto_.get(), model_info_.put()));
 }
 
 void LearningModel::LogCreationEvent(bool fromStream) {
@@ -161,6 +161,7 @@ LearningModel::GetOperatorRegistry() {
     return nullptr;
   }
 
+#ifdef USE_DML
   // Get the native winrt provider interface out of winrt operator provider.
   auto operator_provider_native =
       operator_provider_.as<ILearningModelOperatorProviderNative>();
@@ -170,6 +171,9 @@ LearningModel::GetOperatorRegistry() {
   operator_provider_native->GetRegistry(operator_registry.put());
 
   return operator_registry.get();
+#else
+  return nullptr;
+#endif USE_DML
 }
 
 wfc::IVectorView<winml::ILearningModelFeatureDescriptor>

--- a/winml/lib/Api/LearningModel.cpp
+++ b/winml/lib/Api/LearningModel.cpp
@@ -163,7 +163,7 @@ LearningModel::GetOperatorRegistry() {
       operator_provider_.as<ILearningModelOperatorProviderNative>();
 
   IMLOperatorRegistry* registry = nullptr;
-  adapter_->GetOperatorRegistry(operator_provider_native.get(), &registry);
+  WINML_THROW_IF_FAILED(adapter_->GetOperatorRegistry(operator_provider_native.get(), &registry));
   return registry;
 }
 


### PR DESCRIPTION
cpu builds still had indirect dependency on DML and learning model doesn't need lotusEnvironment and CPU shouldn't include dmlEP headers.

Also added namespaces to ComPtr.