### PR TITLE
Add BatchParallelFor, TryParallelFor, TryBatchParallelFor into ThreadPool

### DIFF
--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -47,6 +47,11 @@ class ThreadPool {
   void ParallelFor(int32_t total, std::function<void(int32_t)> fn);
 
   /*
+  Schedule work in the interval [0, total), splitted into the specified batch(es).
+  */
+  void BatchParallelFor(int32_t total, int32_t batch_size, std::function<void(int32_t)> fn);
+
+  /*
   Schedule work in the interval [first, last].
   */
   void ParallelForRange(int64_t first, int64_t last, std::function<void(int64_t, int64_t)> fn);

--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -68,7 +68,7 @@ class ThreadPool {
       if (batch_size <= 0) {
         batch_size = tp->NumThreads() + 1;
       }
-      tp->BatchParallelFor(total, std::move(fn), batch_size);
+      tp->BatchParallelFor(total, std::forward<F>(fn), batch_size);
     } else {
 #ifdef USE_OPENMP
 #pragma omp parallel for
@@ -85,7 +85,7 @@ class ThreadPool {
   template <typename F>
   inline static void TryParallelFor(concurrency::ThreadPool* tp, int32_t total, F&& fn) {
     if (tp != nullptr) {
-      tp->ParallelFor(total, std::move(fn));
+      tp->ParallelFor(total, std::forward<F>(fn));
     } else {
 #ifdef USE_OPENMP
 #pragma omp parallel for

--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -47,7 +47,7 @@ class ThreadPool {
   void ParallelFor(int32_t total, std::function<void(int32_t)> fn);
 
   /*
-  Schedule work in the interval [0, total), splitted into the specified batch(es).
+  Schedule work in the interval [0, total), with calls split into batches of the specified size.
   */
   void BatchParallelFor(int32_t total, std::function<void(int32_t)> fn, int32_t batch_size = 0);
 
@@ -60,7 +60,7 @@ class ThreadPool {
   // void SetStealPartitions(const std::vector<std::pair<unsigned, unsigned>>& partitions);
 
   /**
-  Tries to call the given function parallelly, splitted into specified batch(es).
+  Tries to call the given function in parallel, with calls split into batches of the specified size.
   **/
   template <typename F>
   inline static void TryBatchParallelFor(concurrency::ThreadPool* tp, int32_t total, F&& fn, int32_t batch_size = 0) {
@@ -80,7 +80,7 @@ class ThreadPool {
   }
 
   /**
-  Tries to call the given function parallelly.
+  Tries to call the given function in parallel.
   **/
   template <typename F>
   inline static void TryParallelFor(concurrency::ThreadPool* tp, int32_t total, F&& fn) {

--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -47,9 +47,9 @@ class ThreadPool {
   void ParallelFor(int32_t total, std::function<void(int32_t)> fn);
 
   /*
-  Schedule work in the interval [0, total), with calls split into batches of the specified size.
+  Schedule work in the interval [0, total), with calls split into (num_batches) batches.
   */
-  void BatchParallelFor(int32_t total, std::function<void(int32_t)> fn, int32_t batch_size = 0);
+  void BatchParallelFor(int32_t total, std::function<void(int32_t)> fn, int32_t num_batches = 0);
 
   /*
   Schedule work in the interval [first, last].
@@ -60,15 +60,15 @@ class ThreadPool {
   // void SetStealPartitions(const std::vector<std::pair<unsigned, unsigned>>& partitions);
 
   /**
-  Tries to call the given function in parallel, with calls split into batches of the specified size.
+  Tries to call the given function in parallel, with calls split into (num_batches) batches.
   **/
   template <typename F>
-  inline static void TryBatchParallelFor(concurrency::ThreadPool* tp, int32_t total, F&& fn, int32_t batch_size = 0) {
+  inline static void TryBatchParallelFor(concurrency::ThreadPool* tp, int32_t total, F&& fn, int32_t num_batches = 0) {
     if (tp != nullptr) {
-      if (batch_size <= 0) {
-        batch_size = tp->NumThreads() + 1;
+      if (num_batches <= 0) {
+        num_batches = tp->NumThreads() + 1;
       }
-      tp->BatchParallelFor(total, std::forward<F>(fn), batch_size);
+      tp->BatchParallelFor(total, std::forward<F>(fn), num_batches);
     } else {
 #ifdef USE_OPENMP
 #pragma omp parallel for

--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -68,7 +68,7 @@ class ThreadPool {
       if (batch_size <= 0) {
         batch_size = tp->NumThreads() + 1;
       }
-      tp->BatchParallelFor(total, batch_size, std::move(fn));
+      tp->BatchParallelFor(total, std::move(fn), batch_size);
     } else {
 #ifdef USE_OPENMP
 #pragma omp parallel for

--- a/onnxruntime/contrib_ops/cpu/crop_and_resize.cc
+++ b/onnxruntime/contrib_ops/cpu/crop_and_resize.cc
@@ -60,9 +60,7 @@ void CropAndResizeForward(const TensorShape& output_shape,
   int64_t pooled_height = output_shape[2];
   int64_t pooled_width = output_shape[3];
 
-  // TODO: This should do blocks of work based on the number of threads in the threadpool with each block
-  // being n_rois / num_threads
-  std::function<void(int32_t)> work_object = [&](int32_t n) {
+  ThreadPool::TryBatchParallelFor(ttp, static_cast<int32_t>(n_rois), [&](int32_t n) {
     int64_t index_n = n * channels * pooled_width * pooled_height;
 
     const T* offset_bottom_rois = bottom_rois + n * num_roi_cols;
@@ -171,9 +169,7 @@ void CropAndResizeForward(const TensorShape& output_shape,
         }
       }  // for pw
     }    // for ph
-  };     // for n
-
-  ThreadPool::TryParallelFor(ttp, static_cast<int32_t>(n_rois), std::move(work_object));
+  });    // for n
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cpu/crop_and_resize.cc
+++ b/onnxruntime/contrib_ops/cpu/crop_and_resize.cc
@@ -21,7 +21,7 @@ limitations under the License.
 #include "core/common/common.h"
 #include "core/framework/tensor.h"
 #include "core/framework/op_kernel_context_internal.h"
-#include "core/platform/threadpool.h"
+#include "core/providers/common.h"
 #include "core/providers/cpu/object_detection/roialign.h"
 
 using namespace onnxruntime::concurrency;

--- a/onnxruntime/contrib_ops/cpu/crop_and_resize.cc
+++ b/onnxruntime/contrib_ops/cpu/crop_and_resize.cc
@@ -21,7 +21,7 @@ limitations under the License.
 #include "core/common/common.h"
 #include "core/framework/tensor.h"
 #include "core/framework/op_kernel_context_internal.h"
-#include "core/providers/common.h"
+#include "core/platform/threadpool.h"
 #include "core/providers/cpu/object_detection/roialign.h"
 
 using namespace onnxruntime::concurrency;
@@ -173,7 +173,7 @@ void CropAndResizeForward(const TensorShape& output_shape,
     }    // for ph
   };     // for n
 
-  TryParallelFor(ttp, static_cast<int32_t>(n_rois), work_object);
+  ThreadPool::TryParallelFor(ttp, static_cast<int32_t>(n_rois), std::move(work_object));
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cpu/crop_and_resize.cc
+++ b/onnxruntime/contrib_ops/cpu/crop_and_resize.cc
@@ -44,17 +44,6 @@ namespace contrib {
 ADD_TYPED_CROPANDRESIZE_OP(float);
 
 template <typename T>
-static void TryParallelFor(concurrency::ThreadPool* tp, int32_t total, T&& fn) {
-  if (tp != nullptr)
-    tp->ParallelFor(total, fn);
-  else {
-    for (int32_t i = 0; i != total; ++i) {
-      fn(i);
-    }
-  }
-}
-
-template <typename T>
 void CropAndResizeForward(const TensorShape& output_shape,
                           const T* bottom_data,
                           float extrapolation_value,

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -66,7 +66,7 @@ void ThreadPool::BatchParallelFor(int32_t total, std::function<void(int32_t)> fn
     return;
   }
 
-  if (batch_size == total) {
+  if (batch_size >= total) {
     ParallelFor(total, fn);
     return;
   }

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -57,7 +57,7 @@ void ThreadPool::ParallelFor(int32_t total, std::function<void(int32_t)> fn) {
   barrier.Wait();
 }
 
-void ThreadPool::BatchParallelFor(int32_t total, int32_t batch_size, std::function<void(int32_t)> fn) {
+void ThreadPool::BatchParallelFor(int32_t total, std::function<void(int32_t)> fn, int32_t batch_size) {
   if (total <= 0)
     return;
 

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -57,6 +57,29 @@ void ThreadPool::ParallelFor(int32_t total, std::function<void(int32_t)> fn) {
   barrier.Wait();
 }
 
+void ThreadPool::BatchParallelFor(int32_t total, int32_t batch_size, std::function<void(int32_t)> fn) {
+  if (total <= 0)
+    return;
+
+  if (total == 1 || batch_size <= 1) {
+    fn(0);
+    return;
+  }
+
+  if (batch_size == total) {
+    ParallelFor(total, fn);
+    return;
+  }
+
+  ParallelFor(batch_size, [&](int batch_index) {
+    int start = batch_index * total / batch_size;
+    int end = (batch_index + 1) * total / batch_size;
+    for (int i = start; i < end; i++) {
+      fn(i);
+    }
+  });
+}
+
 void ThreadPool::ParallelForRange(int64_t first, int64_t last, std::function<void(int64_t, int64_t)> fn) {
   if (last <= first) return;
   if (last - first == 1) {

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -61,8 +61,15 @@ void ThreadPool::BatchParallelFor(int32_t total, std::function<void(int32_t)> fn
   if (total <= 0)
     return;
 
-  if (total == 1 || batch_size <= 1) {
+  if (total == 1) {
     fn(0);
+    return;
+  }
+
+  if (batch_size <= 1) {
+    for (int i = 0; i < total; i++) {
+      fn(i);
+    }
     return;
   }
 

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -57,7 +57,7 @@ void ThreadPool::ParallelFor(int32_t total, std::function<void(int32_t)> fn) {
   barrier.Wait();
 }
 
-void ThreadPool::BatchParallelFor(int32_t total, std::function<void(int32_t)> fn, int32_t batch_size) {
+void ThreadPool::BatchParallelFor(int32_t total, std::function<void(int32_t)> fn, int32_t num_batches) {
   if (total <= 0)
     return;
 
@@ -66,21 +66,21 @@ void ThreadPool::BatchParallelFor(int32_t total, std::function<void(int32_t)> fn
     return;
   }
 
-  if (batch_size <= 1) {
+  if (num_batches <= 1) {
     for (int i = 0; i < total; i++) {
       fn(i);
     }
     return;
   }
 
-  if (batch_size >= total) {
+  if (num_batches >= total) {
     ParallelFor(total, fn);
     return;
   }
 
-  ParallelFor(batch_size, [&](int batch_index) {
-    int start = batch_index * total / batch_size;
-    int end = (batch_index + 1) * total / batch_size;
+  ParallelFor(num_batches, [&](int batch_index) {
+    int start = batch_index * total / num_batches;
+    int end = (batch_index + 1) * total / num_batches;
     for (int i = start; i < end; i++) {
       fn(i);
     }

--- a/onnxruntime/core/providers/common.h
+++ b/onnxruntime/core/providers/common.h
@@ -70,7 +70,7 @@ inline void TryBatchParallelFor(concurrency::ThreadPool* tp, int32_t total, F&& 
 #ifdef USE_OPENMP
 #pragma omp parallel for
 #endif
-    for (int32_t i = 0; i != total; ++i) {
+    for (int32_t i = 0; i < total; ++i) {
       fn(i);
     }
   }

--- a/onnxruntime/core/providers/common.h
+++ b/onnxruntime/core/providers/common.h
@@ -5,7 +5,6 @@
 
 #include "core/common/common.h"
 #include "core/framework/tensor.h"
-#include "core/platform/threadpool.h"
 
 namespace onnxruntime {
 
@@ -41,43 +40,6 @@ inline float clamp(float v, float lo, float hi) {
   if (v < lo) return lo;
   if (v > hi) return hi;
   return v;
-}
-
-/**
-Tries to call the given function parallelly, splitted into specified batch(es)
-**/
-template <typename F>
-inline void TryBatchParallelFor(concurrency::ThreadPool* tp, int32_t total, F&& fn, int32_t batch_size = 0) {
-  if (tp != nullptr) {
-    if (batch_size <= 0) {
-      batch_size = NumThreads() + 1;
-    }
-    tp->BatchParallelFor(total, batch_size, fn);
-  } else {
-#ifdef USE_OPENMP
-#pragma omp parallel for
-#endif
-    for (int32_t i = 0; i < total; ++i) {
-      fn(i);
-    }
-  }
-}
-
-/**
-Tries to call the given function parallelly
-**/
-template <typename F>
-inline void TryParallelFor(concurrency::ThreadPool* tp, int32_t total, F&& fn) {
-  if (tp != nullptr) {
-    tp->ParallelFor(total, fn);
-  } else {
-#ifdef USE_OPENMP
-#pragma omp parallel for
-#endif
-    for (int32_t i = 0; i < total; ++i) {
-      fn(i);
-    }
-  }
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/common.h
+++ b/onnxruntime/core/providers/common.h
@@ -50,7 +50,10 @@ template <typename F>
 inline void TryBatchParallelFor(concurrency::ThreadPool* tp, int32_t total, F&& fn, int32_t batch_size = 0) {
   if (tp != nullptr) {
     if (batch_size <= 0) {
-      batch_size = tp->NumThreads();
+      // concurrency::ThreadPool has numThreads worker threads.
+      // the current ParallelFor() implementation will use the calling thread to execute fn(0)
+      // so there are (numThreads + 1) threads to run the tasks.
+      batch_size = tp->NumThreads() + 1;
     }
     if (batch_size == total) {
       tp->ParallelFor(total, fn);

--- a/onnxruntime/core/providers/common.h
+++ b/onnxruntime/core/providers/common.h
@@ -5,6 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/tensor.h"
+#include "core/platform/threadpool.h"
 
 namespace onnxruntime {
 
@@ -47,22 +48,22 @@ Tries to call the given function parallelly, splitted into specified batch(es)
 **/
 template <typename F>
 inline void TryBatchParallelFor(concurrency::ThreadPool* tp, int32_t total, F&& fn, int32_t batch_size = 0) {
-  if (tp != nullptr)
+  if (tp != nullptr) {
     if (batch_size <= 0) {
       batch_size = tp->NumThreads();
     }
-  if (batch_size == total) {
-    tp->ParallelFor(total, fn);
+    if (batch_size == total) {
+      tp->ParallelFor(total, fn);
+    } else {
+      tp->ParallelFor(batch_size, [&](int batch_index) {
+        int start = batch_index * total / batch_size;
+        int end = (batch_index + 1) * total / batch_size;
+        for (int i = start; i < end; i++) {
+          fn(i);
+        }
+      });
+    }
   } else {
-    tp->ParallelFor(batch_size, [&](int batch_index) {
-      int start = batch_index * total / batch_size;
-      int end = (batch_index + 1) * total / batch_size;
-      for (int i = start; i < end; i++) {
-        fn(i);
-      }
-    });
-  }
-  else {
 #ifdef USE_OPENMP
 #pragma omp parallel for
 #endif

--- a/onnxruntime/core/providers/cpu/object_detection/roialign.cc
+++ b/onnxruntime/core/providers/cpu/object_detection/roialign.cc
@@ -41,18 +41,6 @@ namespace onnxruntime {
 ADD_TYPED_ROIALIGN_OP(float);
 ADD_TYPED_ROIALIGN_OP(double);
 
-namespace {
-template <typename T>
-void TryParallelFor(concurrency::ThreadPool* tp, int32_t total, T&& fn) {
-  if (tp != nullptr)
-    tp->ParallelFor(total, fn);
-  else {
-    for (int32_t i = 0; i != total; ++i) {
-      fn(i);
-    }
-  }
-}
-
 template <typename T>
 struct PreCalc {
   int64_t pos1;

--- a/onnxruntime/core/providers/cpu/object_detection/roialign.cc
+++ b/onnxruntime/core/providers/cpu/object_detection/roialign.cc
@@ -22,7 +22,7 @@
 #include "core/common/common.h"
 #include "core/framework/tensor.h"
 #include "core/framework/op_kernel_context_internal.h"
-#include "core/providers/common.h"
+#include "core/platform/threadpool.h"
 
 using namespace onnxruntime::concurrency;
 
@@ -272,7 +272,7 @@ void RoiAlignForward(const TensorShape& output_shape,
     }      // for c
   };       // for n
 
-  TryParallelFor(ttp, static_cast<int32_t>(n_rois), work_object);
+  ThreadPool::TryParallelFor(ttp, static_cast<int32_t>(n_rois), std::move(work_object));
 }
 }  // namespace
 

--- a/onnxruntime/core/providers/cpu/object_detection/roialign.cc
+++ b/onnxruntime/core/providers/cpu/object_detection/roialign.cc
@@ -22,7 +22,7 @@
 #include "core/common/common.h"
 #include "core/framework/tensor.h"
 #include "core/framework/op_kernel_context_internal.h"
-#include "core/platform/threadpool.h"
+#include "core/providers/common.h"
 
 using namespace onnxruntime::concurrency;
 
@@ -41,6 +41,7 @@ namespace onnxruntime {
 ADD_TYPED_ROIALIGN_OP(float);
 ADD_TYPED_ROIALIGN_OP(double);
 
+namespace {
 template <typename T>
 struct PreCalc {
   int64_t pos1;

--- a/onnxruntime/core/providers/cpu/object_detection/roialign.cc
+++ b/onnxruntime/core/providers/cpu/object_detection/roialign.cc
@@ -172,9 +172,7 @@ void RoiAlignForward(const TensorShape& output_shape,
   int64_t pooled_height = output_shape[2];
   int64_t pooled_width = output_shape[3];
 
-  // TODO: This should do blocks of work based on the number of threads in the threadpool with each block
-  // being n_rois / num_threads
-  std::function<void(int32_t)> work_object = [&](int32_t n) {
+  ThreadPool::TryBatchParallelFor(ttp, static_cast<int32_t>(n_rois), [&](int32_t n) {
     int64_t index_n = n * channels * pooled_width * pooled_height;
 
     const T* offset_bottom_rois = bottom_rois + n * num_roi_cols;
@@ -270,9 +268,7 @@ void RoiAlignForward(const TensorShape& output_shape,
         }  // for pw
       }    // for ph
     }      // for c
-  };       // for n
-
-  ThreadPool::TryParallelFor(ttp, static_cast<int32_t>(n_rois), std::move(work_object));
+  });      // for n
 }
 }  // namespace
 

--- a/onnxruntime/test/platform/threadpool_test.cc
+++ b/onnxruntime/test/platform/threadpool_test.cc
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/platform/threadpool.h"
+
+#include "gtest/gtest.h"
+#include <algorithm>
+#include <memory>
+#include <functional>
+#include <mutex>
+
+using namespace onnxruntime::concurrency;
+
+namespace {
+
+struct TestData {
+  explicit TestData(int num) : data(num, 0) {}
+  std::vector<int> data;
+  std::mutex mutex;
+};
+
+// This unittest tests ThreadPool function by counting the number of calls to function with each index.
+// the function should be called exactly once for each element.
+
+std::unique_ptr<TestData> CreateTestData(int num) {
+  return std::make_unique<TestData>(num);
+}
+
+void IncrementElement(TestData& test_data, int i) {
+  std::lock_guard<std::mutex> lock(test_data.mutex);
+  test_data.data[i]++;
+}
+
+void ValidateTestData(TestData& test_data) {
+  ASSERT_TRUE(std::count_if(test_data.data.cbegin(),
+                            test_data.data.cend(),
+                            [](int i) { return i != 1; }) == 0);
+}
+
+void CreateThreadPoolAndTest(const std::string& name, int num_threads, const std::function<void(ThreadPool*)>& test_body) {
+  auto tp = std::make_unique<ThreadPool>(name, num_threads);
+  test_body(tp.get());
+}
+
+void TestParallelFor(const std::string& name, int num_threads, int num_tasks) {
+  auto test_data = CreateTestData(num_tasks);
+  CreateThreadPoolAndTest(name, num_threads, [&](ThreadPool* tp) {
+    tp->ParallelFor(num_tasks, [&](int i) {
+      IncrementElement(*test_data, i);
+    });
+  });
+  ValidateTestData(*test_data);
+}
+
+void TestBatchParallelFor(const std::string& name, int num_threads, int num_tasks, int batch_size) {
+  auto test_data = CreateTestData(num_tasks);
+  CreateThreadPoolAndTest(name, num_threads, [&](ThreadPool* tp) {
+    tp->BatchParallelFor(
+        num_tasks, [&](int i) {
+          IncrementElement(*test_data, i);
+        },
+        batch_size);
+  });
+  ValidateTestData(*test_data);
+}
+
+}  // namespace
+
+TEST(ThreadPoolTest, TestParallelFor_2_Thread_NoTask) {
+  TestParallelFor("TestParallelFor_2_Thread_NoTask", 2, 0);
+}
+
+TEST(ThreadPoolTest, TestParallelFor_2_Thread_50_Task) {
+  TestParallelFor("TestParallelFor_2_Thread_50_Task", 2, 50);
+}
+
+TEST(ThreadPoolTest, TestParallelFor_1_Thread_50_Task) {
+  TestParallelFor("TestParallelFor_1_Thread_50_Task", 1, 50);
+}
+
+TEST(ThreadPoolTest, TestBatchParallelFor_2_Thread_50_Task_10_Batch) {
+  TestBatchParallelFor("TestBatchParallelFor_2_Thread_50_Task_10_Batch", 2, 50, 10);
+}
+
+TEST(ThreadPoolTest, TestBatchParallelFor_2_Thread_50_Task_0_Batch) {
+  TestBatchParallelFor("TestBatchParallelFor_2_Thread_50_Task_0_Batch", 2, 50, 0);
+}
+
+TEST(ThreadPoolTest, TestBatchParallelFor_2_Thread_50_Task_1_Batch) {
+  TestBatchParallelFor("TestBatchParallelFor_2_Thread_50_Task_1_Batch", 2, 50, 1);
+}
+
+TEST(ThreadPoolTest, TestBatchParallelFor_2_Thread_50_Task_100_Batch) {
+  TestBatchParallelFor("TestBatchParallelFor_2_Thread_50_Task_100_Batch", 2, 50, 100);
+}

--- a/onnxruntime/test/platform/threadpool_test.cc
+++ b/onnxruntime/test/platform/threadpool_test.cc
@@ -3,6 +3,8 @@
 
 #include "core/platform/threadpool.h"
 
+#include <core/common/make_unique.h>
+
 #include "gtest/gtest.h"
 #include <algorithm>
 #include <memory>
@@ -23,7 +25,7 @@ struct TestData {
 // the function should be called exactly once for each element.
 
 std::unique_ptr<TestData> CreateTestData(int num) {
-  return std::make_unique<TestData>(num);
+  return onnxruntime::make_unique<TestData>(num);
 }
 
 void IncrementElement(TestData& test_data, int i) {
@@ -38,7 +40,7 @@ void ValidateTestData(TestData& test_data) {
 }
 
 void CreateThreadPoolAndTest(const std::string& name, int num_threads, const std::function<void(ThreadPool*)>& test_body) {
-  auto tp = std::make_unique<ThreadPool>(name, num_threads);
+  auto tp = onnxruntime::make_unique<ThreadPool>(name, num_threads);
   test_body(tp.get());
 }
 
@@ -92,4 +94,8 @@ TEST(ThreadPoolTest, TestBatchParallelFor_2_Thread_50_Task_1_Batch) {
 
 TEST(ThreadPoolTest, TestBatchParallelFor_2_Thread_50_Task_100_Batch) {
   TestBatchParallelFor("TestBatchParallelFor_2_Thread_50_Task_100_Batch", 2, 50, 100);
+}
+
+TEST(ThreadPoolTest, TestBatchParallelFor_2_Thread_81_Task_20_Batch) {
+  TestBatchParallelFor("TestBatchParallelFor_2_Thread_81_Task_20_Batch", 2, 81, 20);
 }


### PR DESCRIPTION
**Description**:

move utility function `TryParallelFor()` into `core/providers/common.h`.
add function `TryBatchParallelFor()` to allow controlling task numbers in parallelization.

** upcoming implementations of several operators will use `TryBatchParallelFor()`.