### PR TITLE
Revert "Remove DeviceAllocatorRegistry  class"

### DIFF
--- a/onnxruntime/core/framework/allocatormgr.cc
+++ b/onnxruntime/core/framework/allocatormgr.cc
@@ -29,4 +29,9 @@ AllocatorPtr CreateAllocator(DeviceAllocatorRegistrationInfo info, int device_id
   return AllocatorPtr(std::move(device_allocator));
 }
 
+DeviceAllocatorRegistry& DeviceAllocatorRegistry::Instance() {
+  static DeviceAllocatorRegistry s_instance;
+  return s_instance;
+}
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/allocatormgr.h
+++ b/onnxruntime/core/framework/allocatormgr.h
@@ -18,4 +18,25 @@ struct DeviceAllocatorRegistrationInfo {
 
 AllocatorPtr CreateAllocator(DeviceAllocatorRegistrationInfo info, int device_id = 0);
 
+class DeviceAllocatorRegistry {
+ public:
+  void RegisterDeviceAllocator(std::string&& name, DeviceAllocatorFactory factory, size_t max_mem,
+                               OrtMemType mem_type = OrtMemTypeDefault) {
+    DeviceAllocatorRegistrationInfo info({mem_type, factory, max_mem});
+    device_allocator_registrations_.emplace(std::move(name), std::move(info));
+  }
+
+  const std::map<std::string, DeviceAllocatorRegistrationInfo>& AllRegistrations() const {
+    return device_allocator_registrations_;
+  }
+
+  static DeviceAllocatorRegistry& Instance();
+
+ private:
+  DeviceAllocatorRegistry() = default;
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(DeviceAllocatorRegistry);
+
+  std::map<std::string, DeviceAllocatorRegistrationInfo> device_allocator_registrations_;
+};
+
 }  // namespace onnxruntime


### PR DESCRIPTION
Reverts microsoft/onnxruntime#2451 to unblock Brian Martin. Because it is used in Windows AI.

Eventually, we should delete this class and move the object to InferenceSession or some Environment class.  We shouldn't have a singleton here.


