### PR TITLE
Add CLI parameters to test runner, build WinML in ARM and x86 CI

### DIFF
--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -66,17 +66,19 @@ add_winml_test(
 )
 target_precompiled_header(winml_test_api testPch.h)
 
-file(GLOB winml_test_scenario_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/*.cpp")
-add_winml_test(
-  TARGET winml_test_scenario
-  SOURCES ${winml_test_scenario_src}
-  LIBS winml_test_common onnxruntime_providers_dml
-  DEPENDS winml_api
-)
-target_precompiled_header(winml_test_scenario testPch.h)
-set_target_properties(winml_test_scenario PROPERTIES LINK_FLAGS
-  "/DELAYLOAD:d2d1.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll"
-)
+if (onnxruntime_USE_DML)
+  file(GLOB winml_test_scenario_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/*.cpp")
+  add_winml_test(
+    TARGET winml_test_scenario
+    SOURCES ${winml_test_scenario_src}
+    LIBS winml_test_common onnxruntime_providers_dml
+    DEPENDS winml_api
+  )
+  target_precompiled_header(winml_test_scenario testPch.h)
+  set_target_properties(winml_test_scenario PROPERTIES LINK_FLAGS
+    "/DELAYLOAD:d2d1.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll"
+  )
+endif()
 
 # During build time, copy any modified collaterals.
 # configure_file(source destination COPYONLY), which configures CMake to copy the file whenever source is modified,

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -68,17 +68,19 @@ target_precompiled_header(winml_test_api testPch.h)
 
 if (onnxruntime_USE_DML)
   file(GLOB winml_test_scenario_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/*.cpp")
-  add_winml_test(
-    TARGET winml_test_scenario
-    SOURCES ${winml_test_scenario_src}
-    LIBS winml_test_common onnxruntime_providers_dml
-    DEPENDS winml_api
-  )
-  target_precompiled_header(winml_test_scenario testPch.h)
-  set_target_properties(winml_test_scenario PROPERTIES LINK_FLAGS
-    "/DELAYLOAD:d2d1.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll"
-  )
+else()
+  set(winml_test_scenario_src "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/scenariotestscppwinrt.cpp")
 endif()
+add_winml_test(
+  TARGET winml_test_scenario
+  SOURCES ${winml_test_scenario_src}
+  LIBS winml_test_common
+  DEPENDS winml_api
+)
+target_precompiled_header(winml_test_scenario testPch.h)
+set_target_properties(winml_test_scenario PROPERTIES LINK_FLAGS
+  "/DELAYLOAD:d2d1.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll"
+)
 
 # During build time, copy any modified collaterals.
 # configure_file(source destination COPYONLY), which configures CMake to copy the file whenever source is modified,

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -44,7 +44,7 @@ function(add_winml_test)
   if (_UT_DEPENDS)
     add_dependencies(${_UT_TARGET} ${_UT_DEPENDS})
   endif()
-  target_link_libraries(${_UT_TARGET} PRIVATE ${_UT_LIBS} gtest_main windowsapp winml_lib_image ${onnxruntime_EXTERNAL_LIBRARIES})
+  target_link_libraries(${_UT_TARGET} PRIVATE ${_UT_LIBS} gtest windowsapp winml_lib_image ${onnxruntime_EXTERNAL_LIBRARIES})
 
   add_test(NAME ${_UT_TARGET}
     COMMAND ${_UT_TARGET}

--- a/tools/ci_build/github/azure-pipelines/win-arm-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-arm-crosscompile-ci-pipeline.yml
@@ -34,15 +34,15 @@ jobs:
       displayName: 'Generate cmake config and build Debug'
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --arm'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --arm --use_winml'
         workingDirectory: "$(Build.BinariesDirectory)"
     - task: CmdLine@1
       displayName: 'Generate cmake config and build Release'
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Release --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --arm'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Release --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --arm --use_winml'
         workingDirectory: "$(Build.BinariesDirectory)"
     - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
       displayName: 'Component Detection'
-      condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))   
+      condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
     - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/win-arm64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-arm64-crosscompile-ci-pipeline.yml
@@ -34,15 +34,15 @@ jobs:
       displayName: 'Generate cmake config and build Debug'
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --arm64'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --arm64 --use_winml'
         workingDirectory: "$(Build.BinariesDirectory)"
     - task: CmdLine@1
       displayName: 'Generate cmake config and build Release'
       inputs:
         filename: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Release --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --arm64'
+        arguments: '$(Build.SourcesDirectory)\tools\ci_build\build.py --config Release --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --arm64 --use_winml'
         workingDirectory: "$(Build.BinariesDirectory)"
     - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
       displayName: 'Component Detection'
-      condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))        
+      condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
     - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -4,7 +4,7 @@ jobs:
     AgentPool : 'Win-CPU'
     DoDebugBuild: 'true'
     DoCompliance: 'false'
-    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_tvm --use_automl --enable_pybind --use_mkldnn --use_openmp --use_dml --use_winml --build_shared_lib --build_csharp --enable_onnx_tests'
+    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_tvm --use_automl --enable_pybind --use_mkldnn --use_openmp --use_winml --build_shared_lib --build_csharp --enable_onnx_tests'
     JobName: 'Windows_CI_Dev'
     DoNugetPack:  'false'
     NuPackScript : ''

--- a/tools/ci_build/github/azure-pipelines/win-x86-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-x86-ci-pipeline.yml
@@ -4,7 +4,7 @@ jobs:
     AgentPool : 'Win-CPU'
     DoDebugBuild: 'true'
     DoCompliance: 'false'
-    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_openmp --build_shared_lib  --build_csharp --enable_onnx_tests --x86'
+    BuildCommand: '$(Build.SourcesDirectory)\tools\ci_build\build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_path $(Build.BinariesDirectory)\cmake\bin\cmake.exe --ctest_path $(Build.BinariesDirectory)\cmake\bin\ctest.exe --use_openmp --use_winml --build_shared_lib  --build_csharp --enable_onnx_tests --x86'
     JobName: 'Windows_CI_Dev_x86'
     DoNugetPack:  'false'
     NuPackScript : ''

--- a/winml/test/api/LearningModelAPITest.cpp
+++ b/winml/test/api/LearningModelAPITest.cpp
@@ -1,4 +1,5 @@
 #include "testPch.h"
+
 #include "APITest.h"
 
 #include <winrt/Windows.Graphics.Imaging.h>
@@ -26,7 +27,12 @@ protected:
 };
 
 class LearningModelAPITestGpu : public LearningModelAPITest
-{};
+{
+protected:
+    void SetUp() override {
+        GPUTEST
+    }
+};
 
 TEST_F(LearningModelAPITest, CreateModelFromFilePath)
 {
@@ -227,6 +233,7 @@ TEST_F(LearningModelAPITest, CloseModelCheckMetadata)
 
 TEST_F(LearningModelAPITestGpu, CloseModelCheckEval)
 {
+    GPUTEST
     EXPECT_NO_THROW(LoadModel(L"model.onnx"));
     LearningModelSession session = nullptr;
     EXPECT_NO_THROW(session = LearningModelSession(m_model));

--- a/winml/test/api/LearningModelAPITest.cpp
+++ b/winml/test/api/LearningModelAPITest.cpp
@@ -29,7 +29,8 @@ protected:
 class LearningModelAPITestGpu : public LearningModelAPITest
 {
 protected:
-    void SetUp() override {
+    void SetUp() override
+    {
         GPUTEST
     }
 };

--- a/winml/test/api/LearningModelAPITest.cpp
+++ b/winml/test/api/LearningModelAPITest.cpp
@@ -234,7 +234,6 @@ TEST_F(LearningModelAPITest, CloseModelCheckMetadata)
 
 TEST_F(LearningModelAPITestGpu, CloseModelCheckEval)
 {
-    GPUTEST
     EXPECT_NO_THROW(LoadModel(L"model.onnx"));
     LearningModelSession session = nullptr;
     EXPECT_NO_THROW(session = LearningModelSession(m_model));

--- a/winml/test/api/LearningModelBindingAPITest.cpp
+++ b/winml/test/api/LearningModelBindingAPITest.cpp
@@ -1,4 +1,5 @@
 #include "testPch.h"
+
 #include "APITest.h"
 #include "SqueezeNetValidator.h"
 
@@ -18,7 +19,12 @@ class LearningModelBindingAPITest : public APITest
 {};
 
 class LearningModelBindingAPITestGpu : public LearningModelBindingAPITest
-{};
+{
+protected:
+    void SetUp() override {
+        GPUTEST
+    }
+};
 
 TEST_F(LearningModelBindingAPITest, CpuSqueezeNet)
 {
@@ -289,7 +295,7 @@ TEST_F(LearningModelBindingAPITest, ZipMapString)
 
 TEST_F(LearningModelBindingAPITestGpu, GpuSqueezeNet)
 {
-
+    GPUTEST
     std::string gpuInstance("GPU");
     WinML::Engine::Test::ModelValidator::SqueezeNet(
         gpuInstance,
@@ -299,7 +305,7 @@ TEST_F(LearningModelBindingAPITestGpu, GpuSqueezeNet)
 
 TEST_F(LearningModelBindingAPITestGpu, GpuSqueezeNetEmptyOutputs)
 {
-
+    GPUTEST
     std::string gpuInstance("GPU");
     WinML::Engine::Test::ModelValidator::SqueezeNet(
         gpuInstance,
@@ -311,7 +317,7 @@ TEST_F(LearningModelBindingAPITestGpu, GpuSqueezeNetEmptyOutputs)
 
 TEST_F(LearningModelBindingAPITestGpu, GpuSqueezeNetUnboundOutputs)
 {
-
+    GPUTEST
     std::string gpuInstance("GPU");
     WinML::Engine::Test::ModelValidator::SqueezeNet(
         gpuInstance,
@@ -324,6 +330,7 @@ TEST_F(LearningModelBindingAPITestGpu, GpuSqueezeNetUnboundOutputs)
 // Validates that when the input image is the same as the model expects, the binding step is executed correctly.
 TEST_F(LearningModelBindingAPITestGpu, ImageBindingDimensions)
 {
+    GPUTEST
     LearningModelBinding m_binding = nullptr;
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     // load a model with expected input size: 224 x 224
@@ -357,7 +364,7 @@ TEST_F(LearningModelBindingAPITestGpu, ImageBindingDimensions)
 
 TEST_F(LearningModelBindingAPITestGpu, VerifyInvalidBindExceptions)
 {
-
+    GPUTEST
     EXPECT_NO_THROW(LoadModel(L"zipmap-int64.onnx"));
 
     LearningModelSession session(m_model);
@@ -471,6 +478,7 @@ TEST_F(LearningModelBindingAPITestGpu, VerifyInvalidBindExceptions)
 // Verify that it throws an error when binding an invalid name.
 TEST_F(LearningModelBindingAPITestGpu, BindInvalidInputName)
 {
+    GPUTEST
     LearningModelBinding m_binding = nullptr;
     std::wstring modelPath = FileHelpers::GetModulePath() + L"Add_ImageNet1920.onnx";
     EXPECT_NO_THROW(m_model = LearningModel::LoadFromFilePath(modelPath));

--- a/winml/test/api/LearningModelBindingAPITest.cpp
+++ b/winml/test/api/LearningModelBindingAPITest.cpp
@@ -296,7 +296,6 @@ TEST_F(LearningModelBindingAPITest, ZipMapString)
 
 TEST_F(LearningModelBindingAPITestGpu, GpuSqueezeNet)
 {
-    GPUTEST
     std::string gpuInstance("GPU");
     WinML::Engine::Test::ModelValidator::SqueezeNet(
         gpuInstance,
@@ -306,7 +305,6 @@ TEST_F(LearningModelBindingAPITestGpu, GpuSqueezeNet)
 
 TEST_F(LearningModelBindingAPITestGpu, GpuSqueezeNetEmptyOutputs)
 {
-    GPUTEST
     std::string gpuInstance("GPU");
     WinML::Engine::Test::ModelValidator::SqueezeNet(
         gpuInstance,
@@ -318,7 +316,6 @@ TEST_F(LearningModelBindingAPITestGpu, GpuSqueezeNetEmptyOutputs)
 
 TEST_F(LearningModelBindingAPITestGpu, GpuSqueezeNetUnboundOutputs)
 {
-    GPUTEST
     std::string gpuInstance("GPU");
     WinML::Engine::Test::ModelValidator::SqueezeNet(
         gpuInstance,
@@ -331,7 +328,6 @@ TEST_F(LearningModelBindingAPITestGpu, GpuSqueezeNetUnboundOutputs)
 // Validates that when the input image is the same as the model expects, the binding step is executed correctly.
 TEST_F(LearningModelBindingAPITestGpu, ImageBindingDimensions)
 {
-    GPUTEST
     LearningModelBinding m_binding = nullptr;
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     // load a model with expected input size: 224 x 224
@@ -365,7 +361,6 @@ TEST_F(LearningModelBindingAPITestGpu, ImageBindingDimensions)
 
 TEST_F(LearningModelBindingAPITestGpu, VerifyInvalidBindExceptions)
 {
-    GPUTEST
     EXPECT_NO_THROW(LoadModel(L"zipmap-int64.onnx"));
 
     LearningModelSession session(m_model);
@@ -479,7 +474,6 @@ TEST_F(LearningModelBindingAPITestGpu, VerifyInvalidBindExceptions)
 // Verify that it throws an error when binding an invalid name.
 TEST_F(LearningModelBindingAPITestGpu, BindInvalidInputName)
 {
-    GPUTEST
     LearningModelBinding m_binding = nullptr;
     std::wstring modelPath = FileHelpers::GetModulePath() + L"Add_ImageNet1920.onnx";
     EXPECT_NO_THROW(m_model = LearningModel::LoadFromFilePath(modelPath));

--- a/winml/test/api/LearningModelBindingAPITest.cpp
+++ b/winml/test/api/LearningModelBindingAPITest.cpp
@@ -21,7 +21,8 @@ class LearningModelBindingAPITest : public APITest
 class LearningModelBindingAPITestGpu : public LearningModelBindingAPITest
 {
 protected:
-    void SetUp() override {
+    void SetUp() override
+    {
         GPUTEST
     }
 };

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -22,7 +22,8 @@ class LearningModelSessionAPITests : public APITest
 class LearningModelSessionAPITestsGpu : public APITest
 {
 protected:
-    void SetUp() override {
+    void SetUp() override
+    {
         GPUTEST
     }
 };
@@ -30,7 +31,8 @@ protected:
 class LearningModelSessionAPITestsSkipEdgeCore : public LearningModelSessionAPITestsGpu
 {
 protected:
-    void SetUp() override {
+    void SetUp() override
+    {
         LearningModelSessionAPITestsGpu::SetUp();
         SKIP_EDGECORE
     }

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -20,10 +20,21 @@ class LearningModelSessionAPITests : public APITest
 {};
 
 class LearningModelSessionAPITestsGpu : public APITest
-{};  // TODO create a constructor that calls GTEST_SKIP when GPU tests are disabled
+{
+protected:
+    void SetUp() override {
+        GPUTEST
+    }
+};
 
 class LearningModelSessionAPITestsSkipEdgeCore : public LearningModelSessionAPITestsGpu
-{};  // TODO create a constructor that calls GTEST_SKIP when on EdgeCore
+{
+protected:
+    void SetUp() override {
+        LearningModelSessionAPITestsGpu::SetUp();
+        SKIP_EDGECORE
+    }
+};
 
 TEST_F(LearningModelSessionAPITests, CreateSessionDeviceDefault)
 {
@@ -60,7 +71,7 @@ TEST_F(LearningModelSessionAPITests, CreateSessionWithModelLoadedFromStream)
 
 TEST_F(LearningModelSessionAPITestsGpu, CreateSessionDeviceDirectX)
 {
-
+    GPUTEST
     EXPECT_NO_THROW(LoadModel(L"model.onnx"));
 
     EXPECT_NO_THROW(m_device = LearningModelDevice(LearningModelDeviceKind::DirectX));
@@ -69,7 +80,7 @@ TEST_F(LearningModelSessionAPITestsGpu, CreateSessionDeviceDirectX)
 
 TEST_F(LearningModelSessionAPITestsGpu, CreateSessionDeviceDirectXHighPerformance)
 {
-
+    GPUTEST
     EXPECT_NO_THROW(LoadModel(L"model.onnx"));
 
     EXPECT_NO_THROW(m_device = LearningModelDevice(LearningModelDeviceKind::DirectXHighPerformance));
@@ -78,7 +89,7 @@ TEST_F(LearningModelSessionAPITestsGpu, CreateSessionDeviceDirectXHighPerformanc
 
 TEST_F(LearningModelSessionAPITestsGpu, CreateSessionDeviceDirectXMinimumPower)
 {
-
+    GPUTEST
     EXPECT_NO_THROW(LoadModel(L"model.onnx"));
 
     EXPECT_NO_THROW(m_device = LearningModelDevice(LearningModelDeviceKind::DirectXMinPower));
@@ -87,6 +98,8 @@ TEST_F(LearningModelSessionAPITestsGpu, CreateSessionDeviceDirectXMinimumPower)
 
 TEST_F(LearningModelSessionAPITestsSkipEdgeCore, AdapterIdAndDevice)
 {
+    GPUTEST
+    SKIP_EDGECORE
     EXPECT_NO_THROW(LoadModel(L"model.onnx"));
 
     com_ptr<IDXGIFactory6> factory;

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -73,7 +73,6 @@ TEST_F(LearningModelSessionAPITests, CreateSessionWithModelLoadedFromStream)
 
 TEST_F(LearningModelSessionAPITestsGpu, CreateSessionDeviceDirectX)
 {
-    GPUTEST
     EXPECT_NO_THROW(LoadModel(L"model.onnx"));
 
     EXPECT_NO_THROW(m_device = LearningModelDevice(LearningModelDeviceKind::DirectX));
@@ -82,7 +81,6 @@ TEST_F(LearningModelSessionAPITestsGpu, CreateSessionDeviceDirectX)
 
 TEST_F(LearningModelSessionAPITestsGpu, CreateSessionDeviceDirectXHighPerformance)
 {
-    GPUTEST
     EXPECT_NO_THROW(LoadModel(L"model.onnx"));
 
     EXPECT_NO_THROW(m_device = LearningModelDevice(LearningModelDeviceKind::DirectXHighPerformance));
@@ -91,7 +89,6 @@ TEST_F(LearningModelSessionAPITestsGpu, CreateSessionDeviceDirectXHighPerformanc
 
 TEST_F(LearningModelSessionAPITestsGpu, CreateSessionDeviceDirectXMinimumPower)
 {
-    GPUTEST
     EXPECT_NO_THROW(LoadModel(L"model.onnx"));
 
     EXPECT_NO_THROW(m_device = LearningModelDevice(LearningModelDeviceKind::DirectXMinPower));
@@ -100,8 +97,6 @@ TEST_F(LearningModelSessionAPITestsGpu, CreateSessionDeviceDirectXMinimumPower)
 
 TEST_F(LearningModelSessionAPITestsSkipEdgeCore, AdapterIdAndDevice)
 {
-    GPUTEST
-    SKIP_EDGECORE
     EXPECT_NO_THROW(LoadModel(L"model.onnx"));
 
     com_ptr<IDXGIFactory6> factory;

--- a/winml/test/common/main.cpp
+++ b/winml/test/common/main.cpp
@@ -9,22 +9,42 @@ namespace RuntimeParameters
     std::unordered_map<std::string, std::string> Parameters;
 }
 
+namespace
+{
+    void usage(char **argv, int failedArgument)
+    {
+        std::cerr << "Unrecognized argument: " << argv[failedArgument] << "\n"
+            << "Usage:\n\t"
+            << argv[0] << " [/p:parameterName=parameterValue ...]\n";
+    }
+
+    bool parseArgument(const std::string& argument)
+    {
+        if (argument.rfind("/p:", 0) == 0)
+        {
+            // Parse argument in the form of /p:parameterName=parameterValue
+            auto separatorIndex = argument.find('=');
+            if (separatorIndex == std::string::npos || separatorIndex == 3)
+            {
+                return false;
+            }
+            auto parameterName = argument.substr(3, separatorIndex - 3);
+            auto parameterValue = argument.substr(separatorIndex + 1);
+            RuntimeParameters::Parameters[parameterName] = parameterValue;
+            return true;
+        }
+        return false;
+    }
+}
+
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
     for (int i = 1; i < argc; i++)
     {
-        std::string argument(argv[i]);
-        if (argument.rfind("/p:", 0) == 0)
+        if (!parseArgument(argv[i]))
         {
-            auto separatorIndex = argument.find('=');
-            auto parameterName = argument.substr(3, separatorIndex - 3);
-            auto parameterValue = argument.substr(separatorIndex + 1);
-            RuntimeParameters::Parameters[parameterName] = parameterValue;
-        }
-        else
-        {
-            std::cerr << "Unrecognized argument " << argument << "\n";
+            usage(argv, i);
             return -1;
         }
     }

--- a/winml/test/common/main.cpp
+++ b/winml/test/common/main.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include <unordered_map>
+#include <gtest/gtest.h>
+
+#include "runtimeParameters.h"
+
+namespace RuntimeParameters
+{
+    std::unordered_map<std::string, std::string> Parameters;
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    for (int i = 1; i < argc; i++)
+    {
+        std::string argument(argv[i]);
+        if (argument.rfind("/p:", 0) == 0)
+        {
+            auto separatorIndex = argument.find('=');
+            auto parameterName = argument.substr(3, separatorIndex - 3);
+            auto parameterValue = argument.substr(separatorIndex + 1);
+            RuntimeParameters::Parameters[parameterName] = parameterValue;
+        }
+        else
+        {
+            std::cerr << "Unrecognized argument " << argument << "\n";
+            return -1;
+        }
+    }
+    return RUN_ALL_TESTS();
+}

--- a/winml/test/common/runtimeParameters.h
+++ b/winml/test/common/runtimeParameters.h
@@ -1,0 +1,11 @@
+//-----------------------------------------------------------------------------
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//
+//-----------------------------------------------------------------------------
+
+#pragma once
+namespace RuntimeParameters
+{
+    extern std::unordered_map<std::string, std::string> Parameters;
+}

--- a/winml/test/common/runtimeParameters.h
+++ b/winml/test/common/runtimeParameters.h
@@ -1,11 +1,9 @@
-//-----------------------------------------------------------------------------
-//
-//  Copyright (c) Microsoft Corporation. All rights reserved.
-//
-//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 namespace RuntimeParameters
 {
+    // Runtime parameters passed through CLI arguments
     extern std::unordered_map<std::string, std::string> Parameters;
 }

--- a/winml/test/common/std.h
+++ b/winml/test/common/std.h
@@ -30,6 +30,8 @@
 // WinML
 #include "Windows.AI.MachineLearning.Native.h"
 
+#include "runtimeParameters.h"
+
 #define EXPECT_THROW_SPECIFIC(statement, exception, condition)  \
     EXPECT_THROW(                                               \
         try {                                                   \
@@ -42,10 +44,26 @@
 
 // For old versions of gtest without GTEST_SKIP, stream the message and return success instead
 #ifndef GTEST_SKIP
-#define GTEST_SKIP(message) return GTEST_MESSAGE_(message, ::testing::TestPartResult::kSuccess)
+#define GTEST_SKIP_(message) \
+    return GTEST_MESSAGE_(message, ::testing::TestPartResult::kSuccess)
+#define GTEST_SKIP GTEST_SKIP_("")
 #endif
 
 #ifndef INSTANTIATE_TEST_SUITE_P
 // Use the old name, removed in newer versions of googletest
 #define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
 #endif
+
+#define GPUTEST \
+    if (auto noGpuTests = RuntimeParameters::Parameters.find("noGPUtests");             \
+        noGpuTests != RuntimeParameters::Parameters.end() && noGpuTests->second != "0") \
+    {                                                                                   \
+        GTEST_SKIP << "GPU tests disabled";                                             \
+    }
+
+#define SKIP_EDGECORE \
+    if (auto isEdgeCore = RuntimeParameters::Parameters.find("EdgeCore");               \
+        isEdgeCore != RuntimeParameters::Parameters.end() && isEdgeCore->second != "0") \
+    {                                                                                   \
+        GTEST_SKIP << "Test can't be run in EdgeCore";                                  \
+    }

--- a/winml/test/common/std.h
+++ b/winml/test/common/std.h
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 
+#include <gtest/gtest.h>
 
 // IUnknown must be declared before winrt/base.h is included to light up support for native COM
 // interfaces with C++/WinRT types (e.g. winrt::com_ptr<ITensorNative>).
@@ -58,12 +59,12 @@
     if (auto noGpuTests = RuntimeParameters::Parameters.find("noGPUtests");             \
         noGpuTests != RuntimeParameters::Parameters.end() && noGpuTests->second != "0") \
     {                                                                                   \
-        GTEST_SKIP << "GPU tests disabled";                                             \
+        GTEST_SKIP() << "GPU tests disabled";                                           \
     }
 
 #define SKIP_EDGECORE \
     if (auto isEdgeCore = RuntimeParameters::Parameters.find("EdgeCore");               \
         isEdgeCore != RuntimeParameters::Parameters.end() && isEdgeCore->second != "0") \
     {                                                                                   \
-        GTEST_SKIP << "Test can't be run in EdgeCore";                                  \
+        GTEST_SKIP() << "Test can't be run in EdgeCore";                                \
     }

--- a/winml/test/scenario/cppwinrt/CustomOps.cpp
+++ b/winml/test/scenario/cppwinrt/CustomOps.cpp
@@ -173,8 +173,6 @@ struct LocalCustomOperatorProvider :
 {
     LocalCustomOperatorProvider()
     {
-        using namespace OperatorHelper;
-
         EXPECT_HRESULT_SUCCEEDED(MLCreateOperatorRegistry(m_registry.put()));
     }
 

--- a/winml/test/scenario/cppwinrt/CustomOps.cpp
+++ b/winml/test/scenario/cppwinrt/CustomOps.cpp
@@ -11,8 +11,8 @@
 #include <winrt/Windows.Storage.Streams.h>
 #include <MemoryBuffer.h>
 #include <gsl/gsl>
-// #include "dml/api/DirectML.h"
 #include "CustomOperatorProvider.h"
+#include "runtimeParameters.h"
 
 // For custom operator and shape inferencing support
 #include "core/providers/dml/DmlExecutionProvider/inc/MLOperatorAuthor.h"
@@ -41,6 +41,11 @@ protected:
 
 class CustomOpsScenarioGpuTest : public CustomOpsScenarioTest
 {
+protected:
+    void SetUp() override
+    {
+        GPUTEST
+    }
 };
 
 // Tests that the execution provider correctly fuses operators together when custom ops are involved.

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -3,31 +3,33 @@
 #include <d3dx12.h>
 #include <gtest/gtest.h>
 
-#include "winrt/Windows.Media.h"
+#include "winrt/Windows.Devices.Enumeration.Pnp.h"
+#include "winrt/Windows.Graphics.DirectX.Direct3D11.h"
 #include "winrt/Windows.Media.Capture.h"
+#include "winrt/Windows.Media.h"
+#include "winrt/Windows.Security.Cryptography.Core.h"
+#include "winrt/Windows.Security.Cryptography.h"
 #include "winrt/Windows.Storage.h"
 #include "winrt/Windows.Storage.Streams.h"
-#include "winrt/Windows.Devices.Enumeration.Pnp.h"
-#include "winrt/Windows.Security.Cryptography.h"
-#include "winrt/Windows.Security.Cryptography.Core.h"
-#include "winrt/Windows.Graphics.DirectX.Direct3D11.h"
+
 // lame, but WinBase.h redefines this, which breaks winrt headers later
 #ifdef GetCurrentTime
 #undef GetCurrentTime
 #endif
-#include "winrt/Windows.UI.Xaml.Controls.h"
-#include "winrt/Windows.UI.Xaml.Media.Imaging.h"
-#include "Windows.Graphics.DirectX.Direct3D11.interop.h"
-#include "windows.ui.xaml.media.dxinterop.h"
-#include "Windows.AI.MachineLearning.Native.h"
+#include "CustomOperatorProvider.h"
+#include "DeviceHelpers.h"
 #include "filehelpers.h"
 #include "robuffer.h"
-#include "CustomOperatorProvider.h"
+#include "runtimeParameters.h"
+#include "Windows.AI.MachineLearning.Native.h"
+#include "Windows.Graphics.DirectX.Direct3D11.interop.h"
+#include "windows.ui.xaml.media.dxinterop.h"
+#include "winrt/Windows.UI.Xaml.Controls.h"
+#include "winrt/Windows.UI.Xaml.Media.Imaging.h"
+#include <d2d1.h>
 #include <d3d11.h>
 #include <initguid.h>
 #include <MemoryBuffer.h>
-#include "DeviceHelpers.h"
-#include <d2d1.h>
 
 #if __has_include("dxcore.h")
 #define ENABLE_DXCORE 1
@@ -50,17 +52,29 @@ using namespace winrt::Windows::UI::Xaml::Media::Imaging;
 class ScenarioCppWinrtTest : public ::testing::Test
 {
 protected:
-    ScenarioCppWinrtTest() {
+    ScenarioCppWinrtTest()
+    {
         init_apartment();
     }
 };
 
 class ScenarioCppWinrtGpuTest : public ScenarioCppWinrtTest
 {
+protected:
+    void SetUp() override {
+    {
+        GPUTEST
+    }
 };
 
 class ScenarioCppWinrtGpuSkipEdgeCoreTest : public ScenarioCppWinrtTest
 {
+protected:
+    void SetUp() override {
+    {
+        ScenarioCppWinrtTest::SetUp();
+        SKIP_EDGECORE
+    }
 };
 
 TEST_F(ScenarioCppWinrtTest, Sample1)
@@ -198,6 +212,7 @@ TEST_F(ScenarioCppWinrtTest, Scenario2_LoadModelFromStream)
 //! Scenario3: pass a SoftwareBitmap into a model
 TEST_F(ScenarioCppWinrtGpuTest, Scenario3_SoftwareBitmapInputBinding)
 {
+    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -260,6 +275,7 @@ TEST_F(ScenarioCppWinrtTest, Scenario5_AsyncEval)
 // to the image value when that is checked in.
 TEST_F(ScenarioCppWinrtGpuTest, Scenario6_BindWithProperties)
 {
+    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -350,6 +366,7 @@ TEST_F(ScenarioCppWinrtTest, Scenario8_SetDeviceSample_CPU)
 // create a session on the default DML device
 TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_DefaultDirectX)
 {
+    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -361,6 +378,7 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_DefaultDirectX)
 // create a session on the DML device that provides best power
 TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_MinPower)
 {
+    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -372,6 +390,7 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_MinPower)
 // create a session on the DML device that provides best perf
 TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_MaxPerf)
 {
+    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -383,6 +402,7 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_MaxPerf)
 // create a session on the same device my camera is on
 TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_MyCameraDevice)
 {
+    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -407,13 +427,15 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_MyCameraDevice)
     }
     else
     {
-        GTEST_SKIP("Test skipped because video capture device is missing");
+        GTEST_SKIP << "Test skipped because video capture device is missing";
     }
 }
 
 // create a device from D3D11 Device
 TEST_F(ScenarioCppWinrtGpuSkipEdgeCoreTest, Scenario8_SetDeviceSample_D3D11Device)
 {
+    GPUTEST
+    SKIP_EDGECORE
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -426,7 +448,7 @@ TEST_F(ScenarioCppWinrtGpuSkipEdgeCoreTest, Scenario8_SetDeviceSample_D3D11Devic
         D3D11_SDK_VERSION, pD3D11Device.put(), &fl, pContext.put());
     if (FAILED(result))
     {
-        GTEST_SKIP("Test skipped because d3d11 device is missing");
+        GTEST_SKIP << "Test skipped because d3d11 device is missing";
     }
 
     // get dxgiDevice from d3ddevice
@@ -444,6 +466,7 @@ TEST_F(ScenarioCppWinrtGpuSkipEdgeCoreTest, Scenario8_SetDeviceSample_D3D11Devic
 // create a session on the a specific dx device that I chose some other way , note we have to use native interop here and pass a cmd queue
 TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_CustomCommandQueue)
 {
+    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -477,7 +500,7 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_CustomCommandQueue)
 
     if (FAILED(result))
     {
-        GTEST_SKIP("Test skipped because d3d12 device is missing");
+        GTEST_SKIP << "Test skipped because d3d12 device is missing";
         return;
     }
     com_ptr<ID3D12CommandQueue> dxQueue = nullptr;
@@ -497,6 +520,7 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_CustomCommandQueue)
 //pass a Tensor in as an input GPU
 TEST_F(ScenarioCppWinrtGpuTest, DISABLED_Scenario9_LoadBindEval_InputTensorGPU)
 {
+    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"fns-candy.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -581,6 +605,7 @@ TEST_F(ScenarioCppWinrtGpuTest, DISABLED_Scenario9_LoadBindEval_InputTensorGPU)
 
 TEST_F(ScenarioCppWinrtGpuTest, Scenario13_SingleModelOnCPUandGPU)
 {
+    GPUTEST
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
     LearningModelSession cpuSession(model, LearningModelDevice(LearningModelDeviceKind::Cpu));
@@ -608,6 +633,7 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario13_SingleModelOnCPUandGPU)
 // Validates when binding input image with free dimensions, the binding step is executed correctly.
 TEST_F(ScenarioCppWinrtGpuTest, Scenario11_FreeDimenions_tensor)
 {
+    GPUTEST
     std::wstring filePath = FileHelpers::GetModulePath() + L"free_dimensional_image_input.onnx";
     // load a model with expected input size: -1 x -1
     auto model = LearningModel::LoadFromFilePath(filePath);
@@ -627,6 +653,7 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario11_FreeDimenions_tensor)
 
 TEST_F(ScenarioCppWinrtGpuTest, Scenario11_FreeDimenions_image)
 {
+    GPUTEST
     std::wstring filePath = FileHelpers::GetModulePath() + L"free_dimensional_imageDes.onnx";
     // load a model with expected input size: -1 x -1
     auto model = LearningModel::LoadFromFilePath(filePath);
@@ -679,6 +706,7 @@ void SubmitEval(LearningModel model, SwapChainEntry *sessionBindings, int swapch
 //Scenario14:Load single model, run it mutliple times on a single gpu device using a fast swapchain pattern
 TEST_F(ScenarioCppWinrtGpuTest, Scenario14_RunModelSwapchain)
 {
+    GPUTEST
     const int swapchainentrycount = 3;
     SwapChainEntry sessionBindings[swapchainentrycount];
 
@@ -779,6 +807,7 @@ TEST_F(ScenarioCppWinrtTest, Scenario20b_LoadBindEval_ReplacementCustomOperator_
 //! Scenario21: Load two models, set them up to run chained after one another on the same gpu hardware device
 TEST_F(ScenarioCppWinrtGpuTest, DISABLED_Scenario21_RunModel2ChainZ)
 {
+    GPUTEST
     // load a model, TODO: get a model that has an image descriptor
     std::wstring filePath = FileHelpers::GetModulePath() + L"fns-candy.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -933,7 +962,9 @@ TEST_F(ScenarioCppWinrtTest, DISABLED_Scenario22_ImageBindingAsCPUTensor)
 }
 
 TEST_F(ScenarioCppWinrtGpuTest, DISABLED_Scenario22_ImageBindingAsGPUTensor)
-{    std::wstring modulePath = FileHelpers::GetModulePath();
+{
+    GPUTEST
+    std::wstring modulePath = FileHelpers::GetModulePath();
     std::wstring inputImagePath = modulePath + L"fish_720.png";
     std::wstring bmImagePath = modulePath + L"bm_fish_720.jpg";
     std::wstring modelPath = modulePath + L"fns-candy.onnx";
@@ -1128,7 +1159,9 @@ TEST_F(ScenarioCppWinrtTest, QuantizedModels)
 }
 
 TEST_F(ScenarioCppWinrtGpuTest, MsftQuantizedModels)
-{    // load a model
+{
+    GPUTEST
+    // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"coreml_Resnet50_ImageNet-dq.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
     LearningModelSession session(model, LearningModelDevice(LearningModelDeviceKind::DirectX));
@@ -1154,6 +1187,7 @@ TEST_F(ScenarioCppWinrtGpuTest, MsftQuantizedModels)
 
 TEST_F(ScenarioCppWinrtGpuTest, DISABLED_SyncVsAsync)
 {
+    GPUTEST
     // create model, device and session
     LearningModel model = nullptr;
     EXPECT_NO_THROW(model = LearningModel::LoadFromFilePath(FileHelpers::GetModulePath() + L"fns-candy.onnx"));
@@ -1222,6 +1256,7 @@ TEST_F(ScenarioCppWinrtGpuTest, DISABLED_SyncVsAsync)
 
 TEST_F(ScenarioCppWinrtGpuTest, DISABLED_CustomCommandQueueWithFence)
 {
+    GPUTEST
     static const wchar_t* const modelFileName = L"fns-candy.onnx";
     static const wchar_t* const inputDataImageFileName = L"fish_720.png";
 
@@ -1304,6 +1339,7 @@ TEST_F(ScenarioCppWinrtGpuTest, DISABLED_CustomCommandQueueWithFence)
 
 TEST_F(ScenarioCppWinrtGpuTest, DISABLED_ReuseVideoFrame)
 {
+    GPUTEST
     std::wstring modulePath = FileHelpers::GetModulePath();
     std::wstring inputImagePath = modulePath + L"fish_720.png";
     std::wstring bmImagePath = modulePath + L"bm_fish_720.jpg";
@@ -1409,6 +1445,7 @@ TEST_F(ScenarioCppWinrtTest, EncryptedStream)
 
 TEST_F(ScenarioCppWinrtGpuTest, DeviceLostRecovery)
 {
+    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -1449,6 +1486,8 @@ TEST_F(ScenarioCppWinrtGpuTest, DeviceLostRecovery)
 
 TEST_F(ScenarioCppWinrtGpuSkipEdgeCoreTest, D2DInterop)
 {
+    GPUTEST
+    SKIP_EDGECORE
     // load a model (model.onnx == squeezenet[1,3,224,224])
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -212,7 +212,6 @@ TEST_F(ScenarioCppWinrtTest, Scenario2_LoadModelFromStream)
 //! Scenario3: pass a SoftwareBitmap into a model
 TEST_F(ScenarioCppWinrtGpuTest, Scenario3_SoftwareBitmapInputBinding)
 {
-    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -275,7 +274,6 @@ TEST_F(ScenarioCppWinrtTest, Scenario5_AsyncEval)
 // to the image value when that is checked in.
 TEST_F(ScenarioCppWinrtGpuTest, Scenario6_BindWithProperties)
 {
-    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -366,7 +364,6 @@ TEST_F(ScenarioCppWinrtTest, Scenario8_SetDeviceSample_CPU)
 // create a session on the default DML device
 TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_DefaultDirectX)
 {
-    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -378,7 +375,6 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_DefaultDirectX)
 // create a session on the DML device that provides best power
 TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_MinPower)
 {
-    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -390,7 +386,6 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_MinPower)
 // create a session on the DML device that provides best perf
 TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_MaxPerf)
 {
-    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -402,7 +397,6 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_MaxPerf)
 // create a session on the same device my camera is on
 TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_MyCameraDevice)
 {
-    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -427,15 +421,13 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_MyCameraDevice)
     }
     else
     {
-        GTEST_SKIP << "Test skipped because video capture device is missing";
+        GTEST_SKIP() << "Test skipped because video capture device is missing";
     }
 }
 
 // create a device from D3D11 Device
 TEST_F(ScenarioCppWinrtGpuSkipEdgeCoreTest, Scenario8_SetDeviceSample_D3D11Device)
 {
-    GPUTEST
-    SKIP_EDGECORE
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -448,7 +440,7 @@ TEST_F(ScenarioCppWinrtGpuSkipEdgeCoreTest, Scenario8_SetDeviceSample_D3D11Devic
         D3D11_SDK_VERSION, pD3D11Device.put(), &fl, pContext.put());
     if (FAILED(result))
     {
-        GTEST_SKIP << "Test skipped because d3d11 device is missing";
+        GTEST_SKIP() << "Test skipped because d3d11 device is missing";
     }
 
     // get dxgiDevice from d3ddevice
@@ -466,7 +458,6 @@ TEST_F(ScenarioCppWinrtGpuSkipEdgeCoreTest, Scenario8_SetDeviceSample_D3D11Devic
 // create a session on the a specific dx device that I chose some other way , note we have to use native interop here and pass a cmd queue
 TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_CustomCommandQueue)
 {
-    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -500,7 +491,7 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_CustomCommandQueue)
 
     if (FAILED(result))
     {
-        GTEST_SKIP << "Test skipped because d3d12 device is missing";
+        GTEST_SKIP() << "Test skipped because d3d12 device is missing";
         return;
     }
     com_ptr<ID3D12CommandQueue> dxQueue = nullptr;
@@ -520,7 +511,6 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario8_SetDeviceSample_CustomCommandQueue)
 //pass a Tensor in as an input GPU
 TEST_F(ScenarioCppWinrtGpuTest, DISABLED_Scenario9_LoadBindEval_InputTensorGPU)
 {
-    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"fns-candy.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -605,7 +595,6 @@ TEST_F(ScenarioCppWinrtGpuTest, DISABLED_Scenario9_LoadBindEval_InputTensorGPU)
 
 TEST_F(ScenarioCppWinrtGpuTest, Scenario13_SingleModelOnCPUandGPU)
 {
-    GPUTEST
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
     LearningModelSession cpuSession(model, LearningModelDevice(LearningModelDeviceKind::Cpu));
@@ -633,7 +622,6 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario13_SingleModelOnCPUandGPU)
 // Validates when binding input image with free dimensions, the binding step is executed correctly.
 TEST_F(ScenarioCppWinrtGpuTest, Scenario11_FreeDimenions_tensor)
 {
-    GPUTEST
     std::wstring filePath = FileHelpers::GetModulePath() + L"free_dimensional_image_input.onnx";
     // load a model with expected input size: -1 x -1
     auto model = LearningModel::LoadFromFilePath(filePath);
@@ -653,7 +641,6 @@ TEST_F(ScenarioCppWinrtGpuTest, Scenario11_FreeDimenions_tensor)
 
 TEST_F(ScenarioCppWinrtGpuTest, Scenario11_FreeDimenions_image)
 {
-    GPUTEST
     std::wstring filePath = FileHelpers::GetModulePath() + L"free_dimensional_imageDes.onnx";
     // load a model with expected input size: -1 x -1
     auto model = LearningModel::LoadFromFilePath(filePath);
@@ -706,7 +693,6 @@ void SubmitEval(LearningModel model, SwapChainEntry *sessionBindings, int swapch
 //Scenario14:Load single model, run it mutliple times on a single gpu device using a fast swapchain pattern
 TEST_F(ScenarioCppWinrtGpuTest, Scenario14_RunModelSwapchain)
 {
-    GPUTEST
     const int swapchainentrycount = 3;
     SwapChainEntry sessionBindings[swapchainentrycount];
 
@@ -807,7 +793,6 @@ TEST_F(ScenarioCppWinrtTest, Scenario20b_LoadBindEval_ReplacementCustomOperator_
 //! Scenario21: Load two models, set them up to run chained after one another on the same gpu hardware device
 TEST_F(ScenarioCppWinrtGpuTest, DISABLED_Scenario21_RunModel2ChainZ)
 {
-    GPUTEST
     // load a model, TODO: get a model that has an image descriptor
     std::wstring filePath = FileHelpers::GetModulePath() + L"fns-candy.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -963,7 +948,6 @@ TEST_F(ScenarioCppWinrtTest, DISABLED_Scenario22_ImageBindingAsCPUTensor)
 
 TEST_F(ScenarioCppWinrtGpuTest, DISABLED_Scenario22_ImageBindingAsGPUTensor)
 {
-    GPUTEST
     std::wstring modulePath = FileHelpers::GetModulePath();
     std::wstring inputImagePath = modulePath + L"fish_720.png";
     std::wstring bmImagePath = modulePath + L"bm_fish_720.jpg";
@@ -1160,7 +1144,6 @@ TEST_F(ScenarioCppWinrtTest, QuantizedModels)
 
 TEST_F(ScenarioCppWinrtGpuTest, MsftQuantizedModels)
 {
-    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"coreml_Resnet50_ImageNet-dq.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -1187,7 +1170,6 @@ TEST_F(ScenarioCppWinrtGpuTest, MsftQuantizedModels)
 
 TEST_F(ScenarioCppWinrtGpuTest, DISABLED_SyncVsAsync)
 {
-    GPUTEST
     // create model, device and session
     LearningModel model = nullptr;
     EXPECT_NO_THROW(model = LearningModel::LoadFromFilePath(FileHelpers::GetModulePath() + L"fns-candy.onnx"));
@@ -1256,7 +1238,6 @@ TEST_F(ScenarioCppWinrtGpuTest, DISABLED_SyncVsAsync)
 
 TEST_F(ScenarioCppWinrtGpuTest, DISABLED_CustomCommandQueueWithFence)
 {
-    GPUTEST
     static const wchar_t* const modelFileName = L"fns-candy.onnx";
     static const wchar_t* const inputDataImageFileName = L"fish_720.png";
 
@@ -1339,7 +1320,6 @@ TEST_F(ScenarioCppWinrtGpuTest, DISABLED_CustomCommandQueueWithFence)
 
 TEST_F(ScenarioCppWinrtGpuTest, DISABLED_ReuseVideoFrame)
 {
-    GPUTEST
     std::wstring modulePath = FileHelpers::GetModulePath();
     std::wstring inputImagePath = modulePath + L"fish_720.png";
     std::wstring bmImagePath = modulePath + L"bm_fish_720.jpg";
@@ -1445,7 +1425,6 @@ TEST_F(ScenarioCppWinrtTest, EncryptedStream)
 
 TEST_F(ScenarioCppWinrtGpuTest, DeviceLostRecovery)
 {
-    GPUTEST
     // load a model
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);
@@ -1486,8 +1465,6 @@ TEST_F(ScenarioCppWinrtGpuTest, DeviceLostRecovery)
 
 TEST_F(ScenarioCppWinrtGpuSkipEdgeCoreTest, D2DInterop)
 {
-    GPUTEST
-    SKIP_EDGECORE
     // load a model (model.onnx == squeezenet[1,3,224,224])
     std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
     LearningModel model = LearningModel::LoadFromFilePath(filePath);

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -61,7 +61,7 @@ protected:
 class ScenarioCppWinrtGpuTest : public ScenarioCppWinrtTest
 {
 protected:
-    void SetUp() override {
+    void SetUp() override
     {
         GPUTEST
     }
@@ -70,7 +70,7 @@ protected:
 class ScenarioCppWinrtGpuSkipEdgeCoreTest : public ScenarioCppWinrtTest
 {
 protected:
-    void SetUp() override {
+    void SetUp() override
     {
         ScenarioCppWinrtTest::SetUp();
         SKIP_EDGECORE


### PR DESCRIPTION
**Description**: Support CLI parameters to disable GPU tests, add `--use_winml` to ARM and x86 CI

* Add a main function to test runners instead of using the one provided with googletest and add our own parameter parsing
* Add GPUTEST / SKIP_EDGECORE macros
    * Currently, they are added to each test instead of only to the fixture. The googletest submodule version is outdated and doesn't support GTEST_SKIP, which would let us skip tests in the fixture setup and avoid duplicating the GPUTEST macro everywhere. GPUTEST can be removed from each test once we update googletest

I'll keep it as a draft PR and run it through the x86 and ARM pipelines, if the builds look good I'll make it a proper PR.