### PR TITLE
fix model load test. fi from master changed the constructor

### DIFF
--- a/onnxruntime/test/ir/onnx_model_test.cc
+++ b/onnxruntime/test/ir/onnx_model_test.cc
@@ -64,11 +64,12 @@ TEST(ONNXModelsTest, non_existing_model) {
 }
 
 TEST(ONNXModelsTest, future_opset) {
-    // NOTE: this requires the current directory to be where onnxruntime_ir_UT.exe is located
-    std::shared_ptr<Model> model;
-    common::Status st = Model::Load("./testdata/add_opset_314159.onnx", model);
-    ASSERT_FALSE(st.IsOK());
-    ASSERT_EQ(st.Code(), common::INVALID_GRAPH);
+  // NOTE: this requires the current directory to be where onnxruntime_ir_UT.exe is located
+  std::shared_ptr<Model> model;
+  common::Status st = Model::Load(ORT_TSTR("./testdata/add_opset_314159.onnx"), model, nullptr,
+                                DefaultLoggingManager().DefaultLogger());
+  ASSERT_FALSE(st.IsOK());
+  ASSERT_EQ(st.Code(), common::INVALID_GRAPH);
 }
 
 #ifdef ORT_RUN_EXTERNAL_ONNX_TESTS


### PR DESCRIPTION
model::load constructor was changed in master. there's a test that's only in windowsAI that needs to update to use the new constructor.