### PR TITLE
Address various issues discussed in #2436

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_python_keras.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_keras.py
@@ -61,7 +61,7 @@ class TestInferenceSessionKeras(unittest.TestCase):
         # runtime
         content = converted_model.SerializeToString()
         rt = onnxrt.InferenceSession(content)
-        input = {'conv2d_1_input_0': x}
+        input = {rt.get_inputs()[0].name: x}
         actual_rt = rt.run(None, input)
         self.assertEqual(len(actual_rt), 1)
         np.testing.assert_allclose(actual, actual_rt[0], rtol=1e-05, atol=1e-08)

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,9 @@ try:
                     logger.info('removing %s', file)
                     remove(file)
 
-except ImportError:
+except ImportError as error:
+    print("Error importing dependencies:")
+    print(error)
     bdist_wheel = None
 
 # Additional binaries
@@ -182,6 +184,11 @@ if nightly_build:
     date_suffix = str(datetime.datetime.now().date().strftime("%m%d"))
     version_number = version_number + ".dev" + date_suffix
 
+cmd_classes = {}
+if bdist_wheel is not None :
+    cmd_classes['bdist_wheel'] = bdist_wheel
+cmd_classes['build_ext'] = build_ext
+
 # Setup
 setup(
     name=package_name,
@@ -190,7 +197,7 @@ setup(
     long_description=long_description,
     author='Microsoft Corporation',
     author_email='onnx@microsoft.com',
-    cmdclass={'bdist_wheel': bdist_wheel, 'build_ext': build_ext},
+    cmdclass=cmd_classes,
     license="MIT License",
     packages=['onnxruntime',
               'onnxruntime.backend',


### PR DESCRIPTION
**Description**: 
  - build.py changes
    - Add --skip_tests option to build.py based on github feedback
    - Add debug output at end of run_subprocess so it's clearer when the output is from a different process running
    - Add check for scipy as it's required by gen_test_models.py for the onnx tests
    - Use log.warning instead of warnings.warn for consistency. We use the logger almost everywhere and somewhat randomly used warnings.warn in two places.

  - Add check for 'wheel' dependency not being found in setup.py and handle more gracefully
  - Fix invalid input name in Keras tests

**Motivation and Context**
Improve user experience based on #2436 feedback