### PR TITLE
Integrate ACL EP into the build script

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -415,6 +415,45 @@ The DirectML execution provider supports building for both x64 and x86 architect
 
 ---
 
+### ACL
+See more information on the ACL execution provider [here](./docs/execution_providers/ACL-ExecutionProvider.md).
+
+#### Pre-Requisites
+Arm Compute Library execution provider is supported only for arm64 architectures. You need an arm64 device
+and the associated BSP.
+
+##### Validated BSP
+* NXP i.MX BSP for i.MX device family
+   * i.MX BSP Warrior with kernel 4.19 and ACL 19.05 or
+   * i.MX BSP Sumo with kernel 4.14 and ACL 19.02
+
+Instal the BSP:
+```
+source fsl-imx-xwayland-glibc-x86_64-fsl-image-qt5-aarch64-toolchain-4*.sh
+```
+
+Setup build environment:
+```
+source /opt/fsl-imx-xwayland/4.*/environment-setup-aarch64-poky-linux
+alias cmake="/usr/bin/cmake -DCMAKE_TOOLCHAIN_FILE=$OECORE_NATIVE_SYSROOT/usr/share/cmake/OEToolchainConfig.cmake"
+
+#### Build Instructions
+##### Linux
+```
+export CMAKE_ARGS="-DONNX_CUSTOM_PROTOC_EXECUTABLE=/PROTOC_PATH/protoc"
+build.sh --path_to_protoc_exe /PROTOC_PATH/protoc --config RelWithDebInfo --build_shared_lib --use_acl --use_openmp --update --build
+```
+
+Options
+`
+--use_acl=ACL_1902
+`
+
+##### Notes
+The ACL execution provider supports building for arm64 architectures. ACL is only supported on Linux.
+
+---
+
 ### DebugNodeInputsOutputs
 OnnxRuntime supports build options for enabling debugging of intermediate tensor shapes and data.
 #### Build Instructions

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -340,6 +340,10 @@ set(onnxruntime_EXTERNAL_DEPENDENCIES onnx_proto re2)
 
 # ACL
 if (onnxruntime_USE_ACL)
+    if(onnxruntime_USE_ACL_1902)
+	add_definitions(-DACL_1902=1)
+    endif()
+
   list(APPEND onnxruntime_EXTERNAL_LIBRARIES arm_compute acl arm_compute_graph arm_compute_core)
 endif()
 

--- a/docs/execution_providers/ACL-ExecutionProvider.md
+++ b/docs/execution_providers/ACL-ExecutionProvider.md
@@ -18,15 +18,13 @@ source /opt/fsl-imx-xwayland/4.*/environment-setup-aarch64-poky-linux
 alias cmake="/usr/bin/cmake -DCMAKE_TOOLCHAIN_FILE=$OECORE_NATIVE_SYSROOT/usr/share/cmake/OEToolchainConfig.cmake"
 ```
 
-Confiure ONNX Runtime with ACL support:
+Confiure and build ONNX Runtime with ACL support:
 ```
-cmake ../onnxruntime-arm-upstream/cmake -DONNX_CUSTOM_PROTOC_EXECUTABLE=/usr/bin/protoc -Donnxruntime_RUN_ONNX_TESTS=OFF -Donnxruntime_GENERATE_TEST_REPORTS=ON -Donnxruntime_DEV_MODE=ON -DPYTHON_EXECUTABLE=/usr/bin/python3 -Donnxruntime_USE_CUDA=OFF -Donnxruntime_USE_NSYNC=OFF -Donnxruntime_CUDNN_HOME= -Donnxruntime_USE_JEMALLOC=OFF -Donnxruntime_ENABLE_PYTHON=OFF -Donnxruntime_BUILD_CSHARP=OFF -Donnxruntime_BUILD_SHARED_LIB=ON -Donnxruntime_USE_EIGEN_FOR_BLAS=ON -Donnxruntime_USE_OPENBLAS=OFF -Donnxruntime_USE_ACL=ON -Donnxruntime_USE_MKLDNN=OFF -Donnxruntime_USE_MKLML=OFF -Donnxruntime_USE_OPENMP=ON -Donnxruntime_USE_TVM=OFF -Donnxruntime_USE_LLVM=OFF -Donnxruntime_ENABLE_MICROSOFT_INTERNAL=OFF -Donnxruntime_USE_BRAINSLICE=OFF -Donnxruntime_USE_NUPHAR=OFF -Donnxruntime_USE_EIGEN_THREADPOOL=OFF -Donnxruntime_BUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
+export CMAKE_ARGS="-DONNX_CUSTOM_PROTOC_EXECUTABLE=/PROTOC_PATH/protoc"
+build.sh --path_to_protoc_exe /PROTOC_PATH/protoc --config RelWithDebInfo --build_shared_lib --use_openmp --update --build
 ```
 
-Build ONNX Runtime library, test and performance application:
-```
-make -j 6
-```
+--use_acl=ACL_1902
 
 Deploy ONNX runtime on the i.MX 8QM board
 ```

--- a/onnxruntime/core/providers/acl/acl_common.cc
+++ b/onnxruntime/core/providers/acl/acl_common.cc
@@ -11,8 +11,6 @@
 #include "arm_compute/runtime/PoolManager.h"
 #include "arm_compute/runtime/BlobLifetimeManager.h"
 
-#undef ACL_1902
-
 namespace onnxruntime {
 namespace acl {
 


### PR DESCRIPTION
Integrate ACL EP into the build script and expose ACL_1902 compile option.

The build was validated with the following commands:

$ export CMAKE_ARGS="-DONNX_CUSTOM_PROTOC_EXECUTABLE=/PROTOC_PATH/protoc"
$ ../onnxruntime-arm-upstreamv2/build.sh --path_to_protoc_exe /PROTOC_PATH/protoc --config RelWithDebInfo
  --use_acl=ACL_1902 --build_shared_lib --use_openmp --update
$ ../onnxruntime-arm-upstreamv2/build.sh --path_to_protoc_exe /PROTOC_PATH/protoc --config RelWithDebInfo
  --use_acl=ACL_1902 --build_shared_lib --use_openmp --build --parallel

**Description**: Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
