### PR TITLE
Disable Attention fusion tests when DISABLE_CONTRIB_OPS is defined

### DIFF
--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -929,6 +929,8 @@ TEST(GraphTransformationTests, ReshapeFusionOneConstTest) {
   }
 }
 
+#ifndef DISABLE_CONTRIB_OPS
+
 static void ValidateAttention(Graph& graph) {
   // Validate the merged weights (initializer) input for Attention node.
   for (const Node& node : graph.Nodes()) {
@@ -1089,7 +1091,6 @@ TEST(GraphTransformationTests, AttentionFusionInt64Test) {
   ValidateAttention(graph);
 }
 
-#ifndef DISABLE_CONTRIB_OPS
 TEST(GraphTransformationTests, GeluFusionTest) {
   auto model_uri = MODEL_FOLDER "fusion/gelu.onnx";
   std::shared_ptr<Model> p_model;


### PR DESCRIPTION
**Description**: Enable attention fusion tests only when DISABLE_CONTRIB_OPS is not defined.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

When a build pipeline has contrib op disabled, the tests will fail since it uses a contrib op in test model. This is needed to enable such pipeline.