### PR TITLE
Spawn child process to run DeviceLostRecovery scenario test

### DIFF
--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -1425,42 +1425,46 @@ TEST_F(ScenarioCppWinrtTest, EncryptedStream)
 
 TEST_F(ScenarioCppWinrtGpuTest, DeviceLostRecovery)
 {
-    // load a model
-    std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
-    LearningModel model = LearningModel::LoadFromFilePath(filePath);
-    // create a session on the DirectX device
-    LearningModelSession session(model, LearningModelDevice(LearningModelDeviceKind::DirectX));
-    // create a binding set
-    LearningModelBinding binding(session);
-    // bind the inputs
-    BindFeatures(binding, model.InputFeatures());
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    EXPECT_EXIT(
+        // load a model
+        std::wstring filePath = FileHelpers::GetModulePath() + L"model.onnx";
+        LearningModel model = LearningModel::LoadFromFilePath(filePath);
+        // create a session on the DirectX device
+        LearningModelSession session(model, LearningModelDevice(LearningModelDeviceKind::DirectX));
+        // create a binding set
+        LearningModelBinding binding(session);
+        // bind the inputs
+        BindFeatures(binding, model.InputFeatures());
 
-    // force device lost here
-    {
-        winrt::com_ptr<ID3D12Device5> d3d12Device;
-        D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_11_0, __uuidof(ID3D12Device5), d3d12Device.put_void());
-        d3d12Device->RemoveDevice();
-    }
+        // force device lost here
+        {
+            winrt::com_ptr<ID3D12Device5> d3d12Device;
+            D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_11_0, __uuidof(ID3D12Device5), d3d12Device.put_void());
+            d3d12Device->RemoveDevice();
+        }
 
-    // evaluate should fail
-    try
-    {
+        // evaluate should fail
+        try
+        {
+            session.Evaluate(binding, L"");
+            FAIL() << "Evaluate should fail after removing the device";
+        }
+        catch(...)
+        {
+        }
+
+        // remove all references to the device by reseting the session and binding.
+        session = nullptr;
+        binding = nullptr;
+
+        // create new session and binding and try again!
+        session = LearningModelSession(model, LearningModelDevice(LearningModelDeviceKind::DirectX));
+        binding = LearningModelBinding(session);
+        BindFeatures(binding, model.InputFeatures());
         session.Evaluate(binding, L"");
-        FAIL() << "Evaluate should fail after removing the device";
-    }
-    catch(...)
-    {
-    }
-
-    // remove all references to the device by reseting the session and binding.
-    session = nullptr;
-    binding = nullptr;
-
-    // create new session and binding and try again!
-    EXPECT_NO_THROW(session = LearningModelSession(model, LearningModelDevice(LearningModelDeviceKind::DirectX)));
-    EXPECT_NO_THROW(binding = LearningModelBinding(session));
-    BindFeatures(binding, model.InputFeatures());
-    EXPECT_NO_THROW(session.Evaluate(binding, L""));
+        exit(0);
+        , ::testing::ExitedWithCode(0), "");
 }
 
 TEST_F(ScenarioCppWinrtGpuSkipEdgeCoreTest, D2DInterop)

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -1444,10 +1444,12 @@ void DeviceLostRecoveryHelper()
   }
 
   // evaluate should fail
-  try {
+  try
+  {
     session.Evaluate(binding, L"");
     FAIL() << "Evaluate should fail after removing the device";
-  } catch (...) {
+  } catch (...)
+  {
   }
 
   // remove all references to the device by reseting the session and binding.

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -1469,8 +1469,10 @@ TEST_F(ScenarioCppWinrtGpuTestDeathTest, DeviceLostRecovery) {
 
     ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     EXPECT_EXIT(
-        DeviceLostRecoveryHelper()
-        , ::testing::ExitedWithCode(0), "");
+        DeviceLostRecoveryHelper(),
+        ::testing::ExitedWithCode(0),
+        ""
+    );
 }
 
 TEST_F(ScenarioCppWinrtGpuSkipEdgeCoreTest, D2DInterop)

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -1448,7 +1448,8 @@ void DeviceLostRecoveryHelper()
   {
     session.Evaluate(binding, L"");
     FAIL() << "Evaluate should fail after removing the device";
-  } catch (...)
+  }
+  catch (...)
   {
   }
 


### PR DESCRIPTION
DeviceLostRecovery scenario test needs to have a clean environment in which previous tests cannot reference the d3d12 device so that the removal of references in line 1457 will be successful.

By using "EXPECT_EXIT" which is a Google Death Test, the test will be spawned in a child process using CreateProcess and "exit(0)" is added at the end of the test code to indicate that the test has suceeded. EXPECT_EXIT will expect that the child process exited with code 0.

According to Google Test guidelines, it is recommended to add "DeathTest" to the test suite name because test suites with a name ending in "DeathTest" are run before all other tests. 