### PR TITLE
Fix a bug handling negative begin pad values in Pad op

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/pad.cc
+++ b/onnxruntime/core/providers/cpu/tensor/pad.cc
@@ -223,8 +223,8 @@ Status PadCpuImpl(OpKernelContext* ctx,
   std::vector<int64_t> input_extents;
 
   // Calculate output dimensions, and handle any negative padding
-  input_starts.reserve(2 * new_dims_count);
-  input_extents.reserve(2 * new_dims_count);
+  input_starts.reserve(new_dims_count);
+  input_extents.reserve(new_dims_count);
   for (size_t i = 0; i < new_dims_count; i++) {
     input_starts.push_back(-1 * reshaped_slice[i]);
     input_extents.push_back(reshaped_input_dims[i] + reshaped_slice[i] + reshaped_slice[i + new_dims_count]);

--- a/onnxruntime/core/providers/cpu/tensor/pad.cc
+++ b/onnxruntime/core/providers/cpu/tensor/pad.cc
@@ -226,7 +226,7 @@ Status PadCpuImpl(OpKernelContext* ctx,
   input_starts.reserve(2 * new_dims_count);
   input_extents.reserve(2 * new_dims_count);
   for (size_t i = 0; i < new_dims_count; i++) {
-    input_starts.push_back(reshaped_slice[i]);
+    input_starts.push_back(-1 * reshaped_slice[i]);
     input_extents.push_back(reshaped_input_dims[i] + reshaped_slice[i] + reshaped_slice[i + new_dims_count]);
     reshaped_output_dims[i] += reshaped_pad[i] + reshaped_pad[i + new_dims_count] + reshaped_slice[i] + reshaped_slice[i + new_dims_count];
   }

--- a/onnxruntime/test/providers/cpu/tensor/pad_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/pad_test.cc
@@ -154,7 +154,7 @@ TEST(TensorOpTest, Pad_Constant_2D) {
                                 1234.0f, 1234.0f, 1234.0f, 1234.0f, 1234.0f, 1234.0f});
 }
 
-TEST(TensorOpTest, Pad_Constant_2D_negative) {
+TEST(TensorOpTest, Pad_Constant_2D_negative_pads_1) {
   RunAllOpsetAllDomainPadTests({2, 3},
                                {11.0f, 21.0f, 31.0f,
                                 12.0f, 22.0f, 32.0f},
@@ -165,6 +165,54 @@ TEST(TensorOpTest, Pad_Constant_2D_negative) {
                                 1234.0f, 1234.0f, 11.0f, 21.0f,
                                 1234.0f, 1234.0f, 12.0f, 22.0f,
                                 1234.0f, 1234.0f, 1234.0f, 1234.0f});
+}
+
+TEST(TensorOpTest, Pad_Constant_2D_negative_pads_2) {
+  RunAllOpsetAllDomainPadTests({2, 3},
+                               {11.0f, 21.0f, 31.0f,
+                                12.0f, 22.0f, 32.0f},
+                               {-1, 0, 0, 0},
+                               1234.f,
+                               {1, 3},
+                               {12.0f, 22.0f, 32.0f});
+}
+
+TEST(TensorOpTest, Pad_Constant_3D_negative_pads) {
+  RunAllOpsetAllDomainPadTests({1, 1, 3},
+                               {0.f, 1.0f, 2.f},
+                               {0, 0, -1, 0, 0, -1},
+                               0.f,
+                               {1, 1, 1},
+                               {1.f});
+}
+
+TEST(TensorOpTest, Pad_Constant_4D_negative_pads) {
+  // input_vals contains values from 0 to 99 (inclusive)
+  std::vector<float> input_vals;
+  input_vals.reserve(100);
+  for (int i = 0; i < 100; ++i) {
+    input_vals.push_back(static_cast<float>(i));
+  }
+
+  // holder for output_vals (expected)
+  std::vector<float> output_vals;
+  output_vals.reserve(21);
+
+  float seed = 13;
+  for (int i = 0; i < 7; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      output_vals.push_back(static_cast<float>(seed + j));
+    }
+    seed += 10;
+  }
+
+  // run tests
+  RunAllOpsetAllDomainPadTests({1, 1, 10, 10},
+                               input_vals,
+                               {0, 0, -1, -3, 0, 0, -2, -4},
+                               0.f,
+                               {1, 1, 7, 3},
+                               output_vals);
 }
 
 TEST(TensorOpTest, Pad_3D_complex) {


### PR DESCRIPTION
**Description**: Fix a bug handling negative begin pad values that was resulting in garbage being copied over to the output.

**Motivation and Context**
Fix #2433 
