### PR TITLE
Fix lto bug for protobuf and ubuntu

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -279,6 +279,12 @@ else()
   add_library(protobuf::libprotobuf ALIAS libprotobuf-lite)
 endif()
 add_executable(protobuf::protoc ALIAS protoc)
+
+if(UNIX AND onnxruntime_ENABLE_LTO)
+  #https://github.com/protocolbuffers/protobuf/issues/5923
+  target_link_options(protoc PRIVATE "-Wl,--no-as-needed")
+endif()
+
 include(protobuf_function.cmake)
 
 if (onnxruntime_DISABLE_CONTRIB_OPS)


### PR DESCRIPTION
**Description**: 

see #2060

Before my change, protoc was built as:
/usr/lib/ccache/c++   -flto -O3 -DNDEBUG -march=native -mtune=native -flto -fno-fat-lto-objects  -rdynamic CMakeFiles/protoc.dir/__/src/google/protobuf/compiler/main.cc.o  -o protoc libprotobuf.a libprotoc.a libprotobuf.a -lpthread /usr/lib/x86_64-linux-gnu/libz.so

But if you run ldd, you'll find pthread is missing.

$ ldd ./external/protobuf/cmake/protoc
        linux-vdso.so.1 (0x00007ffc7bec0000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f5c78d0e000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f5c78b2c000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f5c78b12000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f5c7925b000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f5c789c4000)



**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
