### PR TITLE
disable onnx_test_runner -x invocations for dnnl on Windows

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -674,13 +674,17 @@ def dnnl_run_onnx_tests(build_dir, configs, onnx_test_data_dir):
           opset10_model_dir = os.path.join(model_dir, 'opset10')
           opset10_cmd = cmd_base + [opset10_model_dir]
           run_subprocess([exe] + opset7_cmd, cwd=cwd)
-          run_subprocess([exe, '-x'] + opset7_cmd, cwd=cwd)
           run_subprocess([exe] + opset8_cmd, cwd=cwd)
-          run_subprocess([exe, '-x'] + opset8_cmd, cwd=cwd)
           run_subprocess([exe] + opset9_cmd, cwd=cwd)
-          run_subprocess([exe, '-x'] + opset9_cmd, cwd=cwd)
           run_subprocess([exe] + opset10_cmd, cwd=cwd)
-          run_subprocess([exe, '-x'] + opset10_cmd, cwd=cwd)
+
+          # temporarily disable -x invocations on Windows as they
+          # are causing instability in CI
+          if not is_windows():
+            run_subprocess([exe, '-x'] + opset7_cmd, cwd=cwd)
+            run_subprocess([exe, '-x'] + opset8_cmd, cwd=cwd)
+            run_subprocess([exe, '-x'] + opset9_cmd, cwd=cwd)
+            run_subprocess([exe, '-x'] + opset10_cmd, cwd=cwd)
 
 
 # nuphar temporary function for running python tests separately as it requires ONNX 1.5.0


### PR DESCRIPTION
windows CPU CI seeing intermittent failures when running onnx_test_runner -x model tests for dnnl.
disable while failures are being investigated. 
