### PR TITLE
Fix a warning found in the latest VS release

### DIFF
--- a/onnxruntime/test/perftest/performance_runner.cc
+++ b/onnxruntime/test/perftest/performance_runner.cc
@@ -143,9 +143,6 @@ Status PerformanceRunner::ForkJoinRepeat() {
   std::condition_variable cv;
 
   // Fork
-  counter.load(std::memory_order_seq_cst);
-  requests.load(std::memory_order_seq_cst);
-
   for (size_t i = 0; i != run_config.concurrent_session_runs; ++i) {
     counter++;
     tpool->Schedule([this, &counter, &requests, &m, &cv, &run_config]() {


### PR DESCRIPTION
**Description**: 

Fix a warning found in the latest VS release

         D:\1\s\onnxruntime\test\perftest\performance_runner.cc(146,15): warning C4834: discarding return value of function with 'nodiscard' attribute [D:\1\b\RelWithDebInfo\onnxruntime_perf_test.vcxproj]


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
