### PR TITLE
remove references to dxcore related attributes when building redist package

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -133,8 +133,6 @@ namespace Dml
         }
     }
 
-
-
     ExecutionProviderImpl::ExecutionProviderImpl(IDMLDevice* dmlDevice, ID3D12Device* d3d12Device, ID3D12CommandQueue* queue, bool enableMetacommands)
         : m_d3d12Device(d3d12Device),
           m_dmlDevice(dmlDevice),

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -27,6 +27,10 @@
 #include <wil/wrl.h>
 #include <dxgi1_6.h>
 
+#if __has_include("dxcore.h")
+#define ENABLE_DXCORE 1
+#endif
+
 #define ENABLE_GRAPH_COMPILATION
 
 using namespace Windows::AI::MachineLearning::Adapter;
@@ -129,6 +133,8 @@ namespace Dml
         }
     }
 
+
+
     ExecutionProviderImpl::ExecutionProviderImpl(IDMLDevice* dmlDevice, ID3D12Device* d3d12Device, ID3D12CommandQueue* queue, bool enableMetacommands)
         : m_d3d12Device(d3d12Device),
           m_dmlDevice(dmlDevice),
@@ -138,7 +144,9 @@ namespace Dml
         D3D12_FEATURE_DATA_FEATURE_LEVELS featureLevels = {};
 
         D3D_FEATURE_LEVEL featureLevelsList[] = {
+#ifdef ENABLE_DXCORE
             D3D_FEATURE_LEVEL_1_0_CORE,
+#endif
             D3D_FEATURE_LEVEL_11_0,
             D3D_FEATURE_LEVEL_11_1,
             D3D_FEATURE_LEVEL_12_0,
@@ -152,8 +160,9 @@ namespace Dml
             &featureLevels,
             sizeof(featureLevels)
             ));
-
+#ifdef ENABLE_DXCORE
         m_isMcdmDevice = (featureLevels.MaxSupportedFeatureLevel == D3D_FEATURE_LEVEL_1_0_CORE);
+#endif
 
         m_context = std::make_shared<ExecutionContext>(m_d3d12Device.Get(), m_dmlDevice.Get(), queue);
 


### PR DESCRIPTION
the winml redist package will be built on agent pools without the latest prerelease sdk that contains the new Dxcore APIs. Therefore, currently this release pipeline fails because it cannot recognize references to D3D_FEATURE_LEVEL_1_0_CORE. To fix this we need to ifdef out references to these APIs when building redist. The assumption here is that redist customers will not expect prerelease features to be available.

References to Dxcore have already been handled at preprocessor time in WinML, this PR addresses DML EP.