### PR TITLE
Layer dev dml delayload

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -415,17 +415,17 @@ set_target_properties(winml_dll
   PROPERTIES
   OUTPUT_NAME windows.ai.machinelearning)
 
+set(delayload_link_flags "/DELAYLOAD:d3d12.dll" "/DELAYLOAD:d3d11.dll" "/DELAYLOAD:dxgi.dll")
 if (onnxruntime_USE_DML)
-  set_target_properties(winml_dll
-    PROPERTIES
-    LINK_FLAGS
-    "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:directml.dll")
-else()
-  set_target_properties(winml_dll
-    PROPERTIES
-    LINK_FLAGS
-    "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll")
+  list(APPEND delayload_link_flags "/DELAYLOAD:directml.dll")
 endif(onnxruntime_USE_DML)
+list(JOIN delayload_link_flags " " delayload_link_flags_str)
+
+set_target_properties(winml_dll
+    PROPERTIES
+    LINK_FLAGS
+    "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} ${delayload_link_flags_str}")
+
 
 set_target_properties(winml_dll
   PROPERTIES

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -420,7 +420,7 @@ if (onnxruntime_USE_DML)
     PROPERTIES
     LINK_FLAGS
     "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:directml.dll")
-else
+else()
   set_target_properties(winml_dll
     PROPERTIES
     LINK_FLAGS

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -415,16 +415,14 @@ set_target_properties(winml_dll
   PROPERTIES
   OUTPUT_NAME windows.ai.machinelearning)
 
-set(delayload_link_flags "/DELAYLOAD:d3d12.dll" "/DELAYLOAD:d3d11.dll" "/DELAYLOAD:dxgi.dll")
 if (onnxruntime_USE_DML)
-  list(APPEND delayload_link_flags "/DELAYLOAD:directml.dll")
+  set(delayload_dml "/DELAYLOAD:directml.dll")
 endif(onnxruntime_USE_DML)
-list(JOIN delayload_link_flags " " delayload_link_flags_str)
 
 set_target_properties(winml_dll
     PROPERTIES
     LINK_FLAGS
-    "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} ${delayload_link_flags_str}")
+    "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll ${delayload_dml}")
 
 
 set_target_properties(winml_dll

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -415,10 +415,17 @@ set_target_properties(winml_dll
   PROPERTIES
   OUTPUT_NAME windows.ai.machinelearning)
 
-set_target_properties(winml_dll
-  PROPERTIES
-  LINK_FLAGS
-  "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:directml.dll")
+if (onnxruntime_USE_DML)
+  set_target_properties(winml_dll
+    PROPERTIES
+    LINK_FLAGS
+    "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:directml.dll")
+else
+  set_target_properties(winml_dll
+    PROPERTIES
+    LINK_FLAGS
+    "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll")
+endif(onnxruntime_USE_DML)
 
 set_target_properties(winml_dll
   PROPERTIES


### PR DESCRIPTION
no need to delayload DML when we never reference it for the CPU package.

This is causing a warning treated as an error when running the nuget CPU release pipeline
