### PR TITLE
Ryanunderhill/packagename test

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -2,23 +2,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-echo "Start of script"
-echo "PACKAGENAME is set to $PACKAGENAME"
-echo "PackageName is set to $PackageName"
-
 LocalNuGetRepo=$1
 SourceRoot=$2
 BuildDir=$3
 export CurrentOnnxRuntimeVersion=$4
 IsMacOS=${5:-false}
+# NOTE: PackageName is not PACKAGENAME since this is being called by other scripts that have already switched to the CamelCase version
+#       It's unfortunate that we don't use the same environment variable '
 PackageName=${PackageName:-Microsoft.ML.OnnxRuntime}
 RunTestCsharp=${RunTestCsharp:-true}
 RunTestNative=${RunTestNative:-true}
-
-echo "After init:"
-echo "PACKAGENAME is set to $PACKAGENAME"
-echo "PackageName is set to $PackageName"
-
 
 set -x
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -2,7 +2,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+echo "Start of script"
 echo "PACKAGENAME is set to $PACKAGENAME"
+echo "PackageName is set to $PackageName"
 
 LocalNuGetRepo=$1
 SourceRoot=$2
@@ -12,6 +14,11 @@ IsMacOS=${5:-false}
 PackageName=${PACKAGENAME:-Microsoft.ML.OnnxRuntime}
 RunTestCsharp=${RunTestCsharp:-true}
 RunTestNative=${RunTestNative:-true}
+
+echo "After init:"
+echo "PACKAGENAME is set to $PACKAGENAME"
+echo "PackageName is set to $PackageName"
+
 
 set -x
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -8,7 +8,6 @@ BuildDir=$3
 export CurrentOnnxRuntimeVersion=$4
 IsMacOS=${5:-false}
 # NOTE: PackageName is not PACKAGENAME since this is being called by other scripts that have already switched to the CamelCase version
-#       It's unfortunate that we don't use the same environment variable '
 PackageName=${PackageName:-Microsoft.ML.OnnxRuntime}
 RunTestCsharp=${RunTestCsharp:-true}
 RunTestNative=${RunTestNative:-true}

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+echo "PACKAGENAME is set to $PACKAGENAME"
+
 LocalNuGetRepo=$1
 SourceRoot=$2
 BuildDir=$3

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -11,7 +11,7 @@ SourceRoot=$2
 BuildDir=$3
 export CurrentOnnxRuntimeVersion=$4
 IsMacOS=${5:-false}
-PackageName=${PACKAGENAME:-Microsoft.ML.OnnxRuntime}
+PackageName=${PackageName:-Microsoft.ML.OnnxRuntime}
 RunTestCsharp=${RunTestCsharp:-true}
 RunTestNative=${RunTestNative:-true}
 


### PR DESCRIPTION
Fixes the CentOS build pipeline failure due to mismatched environment variable names.
