### PR TITLE
Temporarily exclude vgg19 test from Python backend test

### DIFF
--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -148,6 +148,9 @@ def create_backend_test(testname=None):
 
         if c2.supports_device('OPENVINO_GPU_FP32') or c2.supports_device('OPENVINO_GPU_FP16'):
             current_failing_tests.append('^test_div_cpu*')
+            # temporarily exclude vgg19 test which comsumes too much memory, run out of memory on Upsquared device.
+            # single test pass for vgg19, need furture investigation
+            current_failing_tests.append('^test_vgg19_cpu*')
 
         if c2.supports_device('OPENVINO_CPU_FP32'):
             current_failing_tests += ['^test_scan9_sum_cpu',#sum_out output node not defined, temporarily disabling test

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_openvino
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_openvino
@@ -7,7 +7,7 @@ ARG OPENVINO_VERSION=2019_R3.1
 ADD scripts /tmp/scripts
 ENV PATH="/opt/cmake/bin:${PATH}"
 RUN /tmp/scripts/install_ubuntu.sh -p $PYTHON_VERSION -d EdgeDevice && \
-    /tmp/scripts/install_deps.sh -p $PYTHON_VERSION
+    /tmp/scripts/install_deps.sh -p $PYTHON_VERSION -d EdgeDevice
 
 RUN apt update && apt install -y libnuma1 ocl-icd-libopencl1 && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
1. Temporarily exclude vgg19 test from Python backend test, it consumes too much memory, run out of memory on Upsquare device for OpenVINO nightly build. Single test pass for vgg19, need furture investigation
2. Update docker file to decrease the docker image size