### PR TITLE
Add missig env variables for mac pipeline test

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
@@ -47,6 +47,10 @@ jobs:
          exit 1
      fi
     displayName: 'Run Test'
+    env:
+        OnnxRuntimeBuildDirectory: $(Build.BinariesDirectory)
+        DisableContribOps: $(DisableContribOps)
+        IsReleaseBuild: $(IsReleaseBuild)
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'


### PR DESCRIPTION
**Description**: Add missing env variables for mac pipeline test

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
