### PR TITLE
Allow providers to be set for InferenceSession at construction

### DIFF
--- a/onnxruntime/python/session.py
+++ b/onnxruntime/python/session.py
@@ -13,14 +13,16 @@ class InferenceSession:
     """
     This is the main class used to run a model.
     """
-    def __init__(self, path_or_bytes, sess_options=None):
+    def __init__(self, path_or_bytes, sess_options=None, providers=[]):
         """
         :param path_or_bytes: filename or serialized model in a byte string
         :param sess_options: session options
+        :param providers: providers to use for session. If empty, will use
+            all available providers.
         """
         self._path_or_bytes = path_or_bytes
         self._sess_options = sess_options
-        self._load_model()
+        self._load_model(providers)
         self._enable_fallback = True
 
     def _load_model(self, providers=[]):

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -66,6 +66,13 @@ class TestInferenceSession(unittest.TestCase):
         self.assertTrue('[\'InvalidProvider\'] does not contain a subset of available providers' in str(
             context.exception))
 
+    def testSessionProviders(self):
+        if 'CUDAExecutionProvider' in onnxrt.get_available_providers():
+            # create session from scratch, but constrain it to only use the CPU.
+            sess = onnxrt.InferenceSession(
+                self.get_name("mul_1.onnx"), providers=['CPUExecutionProvider'])
+            self.assertEqual(['CPUExecutionProvider'], sess.get_providers())
+
     def testRunModel(self):
         sess = onnxrt.InferenceSession(self.get_name("mul_1.onnx"))
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)


### PR DESCRIPTION
**Description**: Exposes`InferenceSession(..., providers=...)` for specifying provider at construction time.

**Motivation and Context**
I am testing some different backends (e.g. CUDA, TensorRT). If I build `onnxruntime` with TensorRT enabled, it is the default backend that is used, and loading the model takes significantly longer than with CUDA.
I would like to select my providers before I start my session, so that way I can quickly test features with CUDA without paying the overhead of TensorRT loading (I presume due to TensorRT's optimizations?).

I will later try to investigate how to optimize the model file for TensorRT, but for now, this is relatively easy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/onnxruntime/2606)
<!-- Reviewable:end -->
