### PR TITLE
Fix leaking memory allocator

### DIFF
--- a/winml/adapter/WinMLAdapter.cpp
+++ b/winml/adapter/WinMLAdapter.cpp
@@ -638,11 +638,18 @@ class WinMLAdapter : public Microsoft::WRL::RuntimeClass<
       onnxruntime::IExecutionProvider* provider,
       OrtAllocator** allocator) override try {
     auto allocator_ptr = provider->GetAllocator(0, ::OrtMemType::OrtMemTypeDefault);
-    *allocator = new AllocatorWrapper(allocator_ptr);
+    *allocator = new (std::nothrow) AllocatorWrapper(allocator_ptr);
     if (*allocator == nullptr) {
       return E_OUTOFMEMORY;
     }
 
+    return S_OK;
+  }
+  WINML_CATCH_ALL_COM
+
+  HRESULT STDMETHODCALLTYPE FreeProviderAllocator(
+      OrtAllocator* allocator) override try {
+    delete static_cast<AllocatorWrapper*>(allocator);
     return S_OK;
   }
   WINML_CATCH_ALL_COM

--- a/winml/adapter/WinMLAdapter.h
+++ b/winml/adapter/WinMLAdapter.h
@@ -101,6 +101,7 @@ MIDL_INTERFACE("b19385e7-d9af-441a-ba7f-3993c7b1c9db") IWinMLAdapter : IUnknown 
     // proposed adapter. uses the cross plat ABI currencies
     virtual HRESULT STDMETHODCALLTYPE GetProviderMemoryInfo(onnxruntime::IExecutionProvider * provider, OrtMemoryInfo** memory_info) = 0;
     virtual HRESULT STDMETHODCALLTYPE GetProviderAllocator(onnxruntime::IExecutionProvider * provider, OrtAllocator** allocator) = 0;
+    virtual HRESULT STDMETHODCALLTYPE FreeProviderAllocator(OrtAllocator* allocator) = 0;
     virtual HRESULT STDMETHODCALLTYPE GetValueMemoryInfo(const OrtValue * value, OrtMemoryInfo** memory_info) = 0;
     virtual HRESULT STDMETHODCALLTYPE GetMapType(const OrtValue * ort_value, ONNXTensorElementDataType * key_type, ONNXTensorElementDataType * value_type) = 0;
     virtual HRESULT STDMETHODCALLTYPE GetVectorMapType(const OrtValue * ort_value, ONNXTensorElementDataType * key_type, ONNXTensorElementDataType * value_type) = 0;

--- a/winml/lib/Api/ImageFeatureValue.cpp
+++ b/winml/lib/Api/ImageFeatureValue.cpp
@@ -173,6 +173,12 @@ ImageFeatureValue::ImageFeatureValue(IVectorView<Windows::Media::VideoFrame> con
   Initialize();
 }
 
+ImageFeatureValue::~ImageFeatureValue() {
+  for (auto allocator : m_tensorAllocators) {
+    m_adapter->FreeProviderAllocator(allocator);
+  }
+}
+
 static std::optional<BitmapPixelFormat> GetBitmapPixelFormatFromMetadata(const IPropertySet& properties) {
   if (properties != nullptr && properties.HasKey(L"BitmapPixelFormat")) {
     if (auto pixelFormatInspectable = properties.Lookup(L"BitmapPixelFormat")) {
@@ -505,12 +511,13 @@ HRESULT ImageFeatureValue::GetOrtValue(WinML::BindingContext& context, OrtValue*
   auto provider = spSession->GetExecutionProvider();
 
   // and the adapter
-  com_ptr<winmla::IWinMLAdapter> adapter;
-  WINML_THROW_IF_FAILED(OrtGetWinMLAdapter(adapter.put()));
+  if (!m_adapter) {
+    WINML_THROW_IF_FAILED(OrtGetWinMLAdapter(m_adapter.put()));
+  }
 
   // create the OrtValue
   OrtAllocator* dml_allocator;
-  WINML_THROW_IF_FAILED(adapter->GetProviderAllocator(provider, &dml_allocator));
+  WINML_THROW_IF_FAILED(m_adapter->GetProviderAllocator(provider, &dml_allocator));
 
   // create the OrtValue as a tensor letting ort know that we own the data buffer
   Ort::Value ort_tensor = Ort::Value::CreateTensor(
@@ -553,8 +560,9 @@ HRESULT ImageFeatureValue::UpdateSourceResourceData(BindingContext& context, Ort
   auto spSession = context.session.as<LearningModelSession>();
   auto spDevice = spSession->Device().as<LearningModelDevice>();
 
-  com_ptr<winmla::IWinMLAdapter> adapter;
-  WINML_THROW_IF_FAILED(OrtGetWinMLAdapter(adapter.put()));
+  if (!m_adapter) {
+    WINML_THROW_IF_FAILED(OrtGetWinMLAdapter(m_adapter.put()));
+  }
 
   // Get the output tensor raw data
   void* pAllocatedResource = nullptr;
@@ -569,7 +577,7 @@ HRESULT ImageFeatureValue::UpdateSourceResourceData(BindingContext& context, Ort
   descriptor.height = static_cast<int>(resourceMetadata.TensorDescriptor.sizes[2]);
 
   Ort::MemoryInfo memory_info(nullptr);
-  adapter->GetValueMemoryInfo(ort_value, memory_info.put());
+  m_adapter->GetValueMemoryInfo(ort_value, memory_info.put());
 
   if (!strcmp(memory_info.Name(), onnxruntime::CPU) ||
       memory_info.MemType()  == ::OrtMemType::OrtMemTypeCPUOutput ||
@@ -597,7 +605,7 @@ HRESULT ImageFeatureValue::UpdateSourceResourceData(BindingContext& context, Ort
     auto pooledConverter = PoolObjectWrapper::Create(spDevice->DetensorizerStore()->Fetch(descriptor));
 
     auto pProvider = spSession->GetExecutionProvider();
-    auto d3dResource = adapter->GetD3D12ResourceFromAllocation(pProvider, pAllocatedResource);
+    auto d3dResource = m_adapter->GetD3D12ResourceFromAllocation(pProvider, pAllocatedResource);
 
     for (uint32_t batchIdx = 0; batchIdx < m_batchSize; ++batchIdx) {
       auto videoFrame = m_videoFrames.GetAt(batchIdx);

--- a/winml/lib/Api/ImageFeatureValue.cpp
+++ b/winml/lib/Api/ImageFeatureValue.cpp
@@ -518,6 +518,7 @@ HRESULT ImageFeatureValue::GetOrtValue(WinML::BindingContext& context, OrtValue*
       &(resourceMetadata.TensorDescriptor.sizes[0]),
       sizeof(resourceMetadata.TensorDescriptor.sizes) / sizeof(resourceMetadata.TensorDescriptor.sizes[0]),
       (resourceMetadata.TensorDescriptor.dataType == kImageTensorDataTypeFloat32) ? ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT : ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16);
+  m_tensorAllocators.emplace_back(dml_allocator);
 
   // Get the tensor raw data
   void* pAllocatedResource = nullptr;

--- a/winml/lib/Api/ImageFeatureValue.h
+++ b/winml/lib/Api/ImageFeatureValue.h
@@ -46,9 +46,17 @@ struct ImageFeatureValue : ImageFeatureValueT<ImageFeatureValue, WinML::ILotusVa
   bool IsBatch() { return m_batchSize > 1; }
 
  private:
+  struct TensorAllocatorDeleter {
+    void operator()(OrtAllocator* allocator) noexcept {
+      com_ptr<winmla::IWinMLAdapter> adapter;
+      if (SUCCEEDED(OrtGetWinMLAdapter(adapter.put())))
+        adapter->FreeProviderAllocator(allocator);
+    }
+  };
   winrt::Windows::Foundation::Collections::IVector<Windows::Media::VideoFrame> m_videoFrames;
   std::vector<uint32_t> m_widths = {};
   std::vector<uint32_t> m_heights = {};
+  std::vector<std::unique_ptr<OrtAllocator, TensorAllocatorDeleter>> m_tensorAllocators;
   uint32_t m_batchSize = 1;
   // Crop the image with desired aspect ratio.
   // This function does not crop image to desried width and height, but crops to center for desired ratio

--- a/winml/lib/Api/ImageFeatureValue.h
+++ b/winml/lib/Api/ImageFeatureValue.h
@@ -14,6 +14,7 @@ struct ImageFeatureValue : ImageFeatureValueT<ImageFeatureValue, WinML::ILotusVa
   struct ImageResourceMetadata;
 
   ImageFeatureValue() = delete;
+  ~ImageFeatureValue();
   ImageFeatureValue(Windows::Media::VideoFrame const& image);
   ImageFeatureValue(winrt::Windows::Foundation::Collections::IVector<Windows::Media::VideoFrame> const& images);
   ImageFeatureValue(winrt::Windows::Foundation::Collections::IVectorView<Windows::Media::VideoFrame> const& images);
@@ -46,17 +47,11 @@ struct ImageFeatureValue : ImageFeatureValueT<ImageFeatureValue, WinML::ILotusVa
   bool IsBatch() { return m_batchSize > 1; }
 
  private:
-  struct TensorAllocatorDeleter {
-    void operator()(OrtAllocator* allocator) noexcept {
-      com_ptr<winmla::IWinMLAdapter> adapter;
-      if (SUCCEEDED(OrtGetWinMLAdapter(adapter.put())))
-        adapter->FreeProviderAllocator(allocator);
-    }
-  };
+  com_ptr<winmla::IWinMLAdapter> m_adapter;
   winrt::Windows::Foundation::Collections::IVector<Windows::Media::VideoFrame> m_videoFrames;
   std::vector<uint32_t> m_widths = {};
   std::vector<uint32_t> m_heights = {};
-  std::vector<std::unique_ptr<OrtAllocator, TensorAllocatorDeleter>> m_tensorAllocators;
+  std::vector<OrtAllocator *> m_tensorAllocators;
   uint32_t m_batchSize = 1;
   // Crop the image with desired aspect ratio.
   // This function does not crop image to desried width and height, but crops to center for desired ratio

--- a/winml/lib/Api/LearningModelBinding.cpp
+++ b/winml/lib/Api/LearningModelBinding.cpp
@@ -158,7 +158,7 @@ void LearningModelBinding::Bind(
 
   auto featureName = WinML::Strings::UTF8FromHString(name);
   std::tie(bindingName, binding_value, bindingType) = CreateBinding(featureName, value, properties);
-  Ort::Value ortValue = binding_value ? Ort::Value(binding_value) : Ort::Value(nullptr);
+  Ort::Value ortValue = Ort::Value(binding_value);
   switch (bindingType) {
     case BindingType::kInput:
       WINML_THROW_IF_FAILED(BindInput(bindingName, ortValue));

--- a/winml/lib/Api/LearningModelBinding.cpp
+++ b/winml/lib/Api/LearningModelBinding.cpp
@@ -158,7 +158,7 @@ void LearningModelBinding::Bind(
 
   auto featureName = WinML::Strings::UTF8FromHString(name);
   std::tie(bindingName, binding_value, bindingType) = CreateBinding(featureName, value, properties);
-  Ort::Value ortValue = Ort::Value(binding_value);
+  Ort::Value ortValue = binding_value ? Ort::Value(binding_value) : Ort::Value(nullptr);
   switch (bindingType) {
     case BindingType::kInput:
       WINML_THROW_IF_FAILED(BindInput(bindingName, ortValue));


### PR DESCRIPTION
**Description**: Fix https://microsoft.visualstudio.com/OS/_workitems/edit/24278761
and https://microsoft.visualstudio.com/OS/_workitems/edit/24330198

I'm open to suggestions for improvement. The provider allocators are getting cleaned when the ImageFeatureValue is destroyed, which is not super clean (I wished I could clean it whenever the Tensor is destroyed, since the Tensor is the entity using it).

This code is meant to be refactored when we get ORT methods to retrieve/free a provider allocator in the C API, which is ABI safe and won't require our AllocatorWrapper (https://microsoft.visualstudio.com/OS/_workitems/edit/24339369).