### PR TITLE
Delete Ort Allocator in LearningModelBinding

### DIFF
--- a/winml/lib/Api/ImageFeatureValue.cpp
+++ b/winml/lib/Api/ImageFeatureValue.cpp
@@ -509,8 +509,8 @@ HRESULT ImageFeatureValue::GetOrtValue(WinML::BindingContext& context, OrtValue*
     WINML_THROW_IF_FAILED(OrtGetWinMLAdapter(m_adapter.put()));
   }
 
-  OrtAllocator* dml_allocator;
   // create the OrtValue
+  OrtAllocator* dml_allocator;
   WINML_THROW_IF_FAILED(m_adapter->GetProviderAllocator(provider, &dml_allocator));
 
   std::unique_ptr<OrtAllocator>ort_allocator_temp(dml_allocator);

--- a/winml/lib/Api/ImageFeatureValue.h
+++ b/winml/lib/Api/ImageFeatureValue.h
@@ -14,7 +14,6 @@ struct ImageFeatureValue : ImageFeatureValueT<ImageFeatureValue, WinML::ILotusVa
   struct ImageResourceMetadata;
 
   ImageFeatureValue() = delete;
-  ~ImageFeatureValue();
   ImageFeatureValue(Windows::Media::VideoFrame const& image);
   ImageFeatureValue(winrt::Windows::Foundation::Collections::IVector<Windows::Media::VideoFrame> const& images);
   ImageFeatureValue(winrt::Windows::Foundation::Collections::IVectorView<Windows::Media::VideoFrame> const& images);
@@ -45,14 +44,14 @@ struct ImageFeatureValue : ImageFeatureValueT<ImageFeatureValue, WinML::ILotusVa
   std::vector<uint32_t> Widths() { return m_widths; }
   std::vector<uint32_t> Heights() { return m_heights; }
   bool IsBatch() { return m_batchSize > 1; }
-
+  OrtAllocator* GetOrtAllocator() { return m_ort_allocator; }
  private:
   com_ptr<winmla::IWinMLAdapter> m_adapter;
   winrt::Windows::Foundation::Collections::IVector<Windows::Media::VideoFrame> m_videoFrames;
   std::vector<uint32_t> m_widths = {};
   std::vector<uint32_t> m_heights = {};
-  std::vector<OrtAllocator *> m_tensorAllocators;
   uint32_t m_batchSize = 1;
+  OrtAllocator* m_ort_allocator;
   // Crop the image with desired aspect ratio.
   // This function does not crop image to desried width and height, but crops to center for desired ratio
   Windows::Graphics::Imaging::BitmapBounds CenterAndCropBounds(

--- a/winml/lib/Api/ImageFeatureValue.h
+++ b/winml/lib/Api/ImageFeatureValue.h
@@ -33,7 +33,7 @@ struct ImageFeatureValue : ImageFeatureValueT<ImageFeatureValue, WinML::ILotusVa
 
   // ILotusValueProviderPrivate implementation
   STDMETHOD(GetOrtValue)
-  (WinML::BindingContext& context, OrtValue** ort_value);
+  (WinML::BindingContext& context, OrtValue** ort_value, OrtAllocator** ort_allocator);
   STDMETHOD(IsPlaceholder)
   (bool* pIsPlaceHolder);
   STDMETHOD(UpdateSourceResourceData)
@@ -44,14 +44,12 @@ struct ImageFeatureValue : ImageFeatureValueT<ImageFeatureValue, WinML::ILotusVa
   std::vector<uint32_t> Widths() { return m_widths; }
   std::vector<uint32_t> Heights() { return m_heights; }
   bool IsBatch() { return m_batchSize > 1; }
-  OrtAllocator* GetOrtAllocator() { return m_ort_allocator; }
  private:
   com_ptr<winmla::IWinMLAdapter> m_adapter;
   winrt::Windows::Foundation::Collections::IVector<Windows::Media::VideoFrame> m_videoFrames;
   std::vector<uint32_t> m_widths = {};
   std::vector<uint32_t> m_heights = {};
   uint32_t m_batchSize = 1;
-  OrtAllocator* m_ort_allocator;
   // Crop the image with desired aspect ratio.
   // This function does not crop image to desried width and height, but crops to center for desired ratio
   Windows::Graphics::Imaging::BitmapBounds CenterAndCropBounds(

--- a/winml/lib/Api/LearningModelBinding.cpp
+++ b/winml/lib/Api/LearningModelBinding.cpp
@@ -21,11 +21,6 @@ LearningModelBinding::LearningModelBinding(
 }
 WINML_CATCH_ALL
 
-LearningModelBinding::~LearningModelBinding()
-{
-  Clear();
-}
-
 static Windows::AI::MachineLearning::ILearningModelFeatureDescriptor FindValidBinding(
     winrt::Windows::Foundation::Collections::IIterable<ILearningModelFeatureDescriptor> descriptors,
     const std::wstring& name) {
@@ -130,7 +125,6 @@ std::tuple<std::string, OrtValue*, BindingType, OrtAllocator*> LearningModelBind
         spLotusValueProvider->GetOrtValue(context, value.put(), ort_allocator.put()),
         "The model variable %s failed tensorization.",
         name.c_str());
-    auto spImageFeatureValue = spLotusValueProvider.try_as<ImageFeatureValue>();
   } else {
     WINML_THROW_HR_IF_TRUE_MSG(
         WINML_ERR_INVALID_BINDING,
@@ -626,7 +620,7 @@ void LearningModelBinding::BindUnboundOutputs() {
   // Add all unbound outputs to binding collection
   for (const auto& unbound_output : unbound_output_names) {
     Ort::Value out(nullptr);
-    Ort::Allocator out_allocator(adapter_.get(), nullptr);
+    auto out_allocator = Ort::Allocator();
     WINML_THROW_IF_FAILED(BindOutput(unbound_output, out, out_allocator));
   }
 }

--- a/winml/lib/Api/LearningModelBinding.h
+++ b/winml/lib/Api/LearningModelBinding.h
@@ -22,7 +22,6 @@ struct LearningModelBinding : LearningModelBindingT<LearningModelBinding, ILearn
       Windows::Foundation::Collections::IKeyValuePair<hstring, Windows::Foundation::IInspectable>;
 
   LearningModelBinding() = delete;
-  ~LearningModelBinding();
   LearningModelBinding(Windows::AI::MachineLearning::LearningModelSession const& session);
 
   void Bind(hstring const& name, Windows::Foundation::IInspectable const& value);

--- a/winml/lib/Api/LearningModelBinding.h
+++ b/winml/lib/Api/LearningModelBinding.h
@@ -22,6 +22,7 @@ struct LearningModelBinding : LearningModelBindingT<LearningModelBinding, ILearn
       Windows::Foundation::Collections::IKeyValuePair<hstring, Windows::Foundation::IInspectable>;
 
   LearningModelBinding() = delete;
+  ~LearningModelBinding();
   LearningModelBinding(Windows::AI::MachineLearning::LearningModelSession const& session);
 
   void Bind(hstring const& name, Windows::Foundation::IInspectable const& value);
@@ -54,7 +55,7 @@ struct LearningModelBinding : LearningModelBindingT<LearningModelBinding, ILearn
   std::vector<Ort::Value>& LearningModelBinding::GetOutputs();
   const std::vector<std::string>& LearningModelBinding::GetInputNames() const;
   const std::vector<Ort::Value>& LearningModelBinding::GetInputs() const;
-  HRESULT BindOutput(const std::string& name, Ort::Value& ml_value, Ort::Allocator& ort_allocator);
+  HRESULT BindOutput(const std::string& name, Ort::Value&& ml_value, Ort::Allocator&& ort_allocator);
   void BindUnboundOutputs();
 
  private:
@@ -66,7 +67,7 @@ struct LearningModelBinding : LearningModelBindingT<LearningModelBinding, ILearn
   bool IsOfTensorType(const Ort::Value& ort_value, TensorKind kind);
   bool IsOfMapType(const Ort::Value& ort_value, TensorKind key_kind, TensorKind value_kind);
   bool IsOfVectorMapType(const Ort::Value& ort_value, TensorKind key_kind, TensorKind value_kind);
-  HRESULT BindInput(const std::string& name, Ort::Value& ml_value, Ort::Allocator& ort_allocator);
+  HRESULT BindInput(const std::string& name, Ort::Value&& ml_value, Ort::Allocator&& ort_allocator);
 
  private:
   const Windows::AI::MachineLearning::LearningModelSession m_session;

--- a/winml/lib/Api/LearningModelBinding.h
+++ b/winml/lib/Api/LearningModelBinding.h
@@ -55,7 +55,7 @@ struct LearningModelBinding : LearningModelBindingT<LearningModelBinding, ILearn
   std::vector<Ort::Value>& LearningModelBinding::GetOutputs();
   const std::vector<std::string>& LearningModelBinding::GetInputNames() const;
   const std::vector<Ort::Value>& LearningModelBinding::GetInputs() const;
-  HRESULT BindOutput(const std::string& name, Ort::Value& ml_value, OrtAllocator* ort_allocator);
+  HRESULT BindOutput(const std::string& name, Ort::Value& ml_value, Ort::Allocator& ort_allocator);
   void BindUnboundOutputs();
 
  private:
@@ -67,7 +67,7 @@ struct LearningModelBinding : LearningModelBindingT<LearningModelBinding, ILearn
   bool IsOfTensorType(const Ort::Value& ort_value, TensorKind kind);
   bool IsOfMapType(const Ort::Value& ort_value, TensorKind key_kind, TensorKind value_kind);
   bool IsOfVectorMapType(const Ort::Value& ort_value, TensorKind key_kind, TensorKind value_kind);
-  HRESULT BindInput(const std::string& name, Ort::Value& ml_value, OrtAllocator* ort_allocator);
+  HRESULT BindInput(const std::string& name, Ort::Value& ml_value, Ort::Allocator& ort_allocator);
 
  private:
   const Windows::AI::MachineLearning::LearningModelSession m_session;
@@ -77,10 +77,10 @@ struct LearningModelBinding : LearningModelBindingT<LearningModelBinding, ILearn
   com_ptr<winmla::IWinMLAdapter> adapter_;
   std::vector<std::string> input_names_;
   std::vector<Ort::Value> inputs_;
-  std::vector<OrtAllocator*> input_allocators_;
+  std::vector<Ort::Allocator> input_allocators_;
   std::vector<std::string> output_names_;
   std::vector<Ort::Value> outputs_;
-  std::vector<OrtAllocator*> output_allocators_;
+  std::vector<Ort::Allocator> output_allocators_;
 };
 }  // namespace winrt::Windows::AI::MachineLearning::implementation
 

--- a/winml/lib/Api/LearningModelBinding.h
+++ b/winml/lib/Api/LearningModelBinding.h
@@ -22,7 +22,7 @@ struct LearningModelBinding : LearningModelBindingT<LearningModelBinding, ILearn
       Windows::Foundation::Collections::IKeyValuePair<hstring, Windows::Foundation::IInspectable>;
 
   LearningModelBinding() = delete;
-
+  ~LearningModelBinding();
   LearningModelBinding(Windows::AI::MachineLearning::LearningModelSession const& session);
 
   void Bind(hstring const& name, Windows::Foundation::IInspectable const& value);
@@ -36,7 +36,7 @@ struct LearningModelBinding : LearningModelBindingT<LearningModelBinding, ILearn
       Windows::Foundation::Collections::IMapView<hstring, Windows::Foundation::IInspectable>& first,
       Windows::Foundation::Collections::IMapView<hstring, Windows::Foundation::IInspectable>& second);
 
-  std::tuple<std::string, OrtValue*, WinML::BindingType> CreateBinding(
+  std::tuple<std::string, OrtValue*, WinML::BindingType, OrtAllocator*> CreateBinding(
       const std::string& name,
       const Windows::Foundation::IInspectable& value,
       Windows::Foundation::Collections::IPropertySet const& properties);
@@ -55,7 +55,7 @@ struct LearningModelBinding : LearningModelBindingT<LearningModelBinding, ILearn
   std::vector<Ort::Value>& LearningModelBinding::GetOutputs();
   const std::vector<std::string>& LearningModelBinding::GetInputNames() const;
   const std::vector<Ort::Value>& LearningModelBinding::GetInputs() const;
-  HRESULT BindOutput(const std::string& name, Ort::Value& ml_value);
+  HRESULT BindOutput(const std::string& name, Ort::Value& ml_value, OrtAllocator* ort_allocator);
   void BindUnboundOutputs();
 
  private:
@@ -67,7 +67,7 @@ struct LearningModelBinding : LearningModelBindingT<LearningModelBinding, ILearn
   bool IsOfTensorType(const Ort::Value& ort_value, TensorKind kind);
   bool IsOfMapType(const Ort::Value& ort_value, TensorKind key_kind, TensorKind value_kind);
   bool IsOfVectorMapType(const Ort::Value& ort_value, TensorKind key_kind, TensorKind value_kind);
-  HRESULT BindInput(const std::string& name, Ort::Value& ml_value);
+  HRESULT BindInput(const std::string& name, Ort::Value& ml_value, OrtAllocator* ort_allocator);
 
  private:
   const Windows::AI::MachineLearning::LearningModelSession m_session;
@@ -77,8 +77,10 @@ struct LearningModelBinding : LearningModelBindingT<LearningModelBinding, ILearn
   com_ptr<winmla::IWinMLAdapter> adapter_;
   std::vector<std::string> input_names_;
   std::vector<Ort::Value> inputs_;
+  std::vector<OrtAllocator*> input_allocators_;
   std::vector<std::string> output_names_;
   std::vector<Ort::Value> outputs_;
+  std::vector<OrtAllocator*> output_allocators_;
 };
 }  // namespace winrt::Windows::AI::MachineLearning::implementation
 

--- a/winml/lib/Api/impl/MapBase.h
+++ b/winml/lib/Api/impl/MapBase.h
@@ -158,7 +158,8 @@ struct MapBase : winrt::implements<
   }
 
   STDMETHOD(GetOrtValue)
-  (WinML::BindingContext& context, OrtValue** ort_value) {
+  (WinML::BindingContext& context, OrtValue** ort_value, OrtAllocator** ort_allocator) {
+    ORT_UNUSED_PARAMETER(ort_allocator);
     ORT_UNUSED_PARAMETER(context);
     // TODO: Tensorized data should be cached so multiple bindings work more efficiently
 

--- a/winml/lib/Api/impl/SequenceBase.h
+++ b/winml/lib/Api/impl/SequenceBase.h
@@ -195,7 +195,9 @@ struct SequenceBase : public winrt::implements<
 
   STDMETHOD(GetOrtValue)(
       WinML::BindingContext& context,
-      OrtValue** ort_value) {
+      OrtValue** ort_value,
+      OrtAllocator** ort_allocator) {
+    ORT_UNUSED_PARAMETER(ort_allocator);
     // TODO: Tensorized data should be cached so multiple bindings work more efficiently
 
     // TODO : we need to handle inputs.   for now only handle outputs and don't pre allocate anything

--- a/winml/lib/Api/impl/TensorBase.h
+++ b/winml/lib/Api/impl/TensorBase.h
@@ -208,7 +208,8 @@ struct TensorBase : TBase {
 
   // ILotusValueProviderPrivate::GetOrtValue
   STDMETHOD(GetOrtValue)
-  (WinML::BindingContext& context, OrtValue** ort_value) {
+  (WinML::BindingContext& context, OrtValue** ort_value, OrtAllocator** ort_allocator) {
+    ORT_UNUSED_PARAMETER(ort_allocator);
     RETURN_HR_IF_NULL_MSG(
         WINML_ERR_INVALID_BINDING,
         m_resources,

--- a/winml/lib/Api/inc/ILotusValueProviderPrivate.h
+++ b/winml/lib/Api/inc/ILotusValueProviderPrivate.h
@@ -24,7 +24,7 @@ struct BindingContext {
 };
 
 struct __declspec(uuid("27e2f437-0112-4693-849e-e04323a620fb")) __declspec(novtable) ILotusValueProviderPrivate : IUnknown {
-  virtual HRESULT __stdcall GetOrtValue(BindingContext& binding_context, OrtValue ** ort_value) = 0;
+  virtual HRESULT __stdcall GetOrtValue(BindingContext& binding_context, OrtValue** ort_value, OrtAllocator** ort_allocator) = 0;
   virtual HRESULT __stdcall IsPlaceholder(bool* is_placeholder) = 0;
   virtual HRESULT __stdcall UpdateSourceResourceData(BindingContext& binding_context, OrtValue* ort_value) = 0;
   virtual HRESULT __stdcall AbiRepresentation(winrt::Windows::Foundation::IInspectable& abi_representation) = 0;


### PR DESCRIPTION
It is an issue to delete OrtAllocators in ImageFeatureValue because LearningModelBinding is the object that holds on the Ort::Value