### PR TITLE
define private version of dxcore enum that is added in 19H1 SDK.

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -129,6 +129,8 @@ namespace Dml
         }
     }
 
+#define D3D_FEATURE_LEVEL_1_0_CORE_PRIVATE ((D3D_FEATURE_LEVEL)0x1000)
+
     ExecutionProviderImpl::ExecutionProviderImpl(IDMLDevice* dmlDevice, ID3D12Device* d3d12Device, ID3D12CommandQueue* queue, bool enableMetacommands)
         : m_d3d12Device(d3d12Device),
           m_dmlDevice(dmlDevice),
@@ -138,7 +140,7 @@ namespace Dml
         D3D12_FEATURE_DATA_FEATURE_LEVELS featureLevels = {};
 
         D3D_FEATURE_LEVEL featureLevelsList[] = {
-            D3D_FEATURE_LEVEL_1_0_CORE,
+            D3D_FEATURE_LEVEL_1_0_CORE_PRIVATE,
             D3D_FEATURE_LEVEL_11_0,
             D3D_FEATURE_LEVEL_11_1,
             D3D_FEATURE_LEVEL_12_0,
@@ -153,7 +155,7 @@ namespace Dml
             sizeof(featureLevels)
             ));
 
-        m_isMcdmDevice = (featureLevels.MaxSupportedFeatureLevel == D3D_FEATURE_LEVEL_1_0_CORE);
+        m_isMcdmDevice = (featureLevels.MaxSupportedFeatureLevel == D3D_FEATURE_LEVEL_1_0_CORE_PRIVATE);
 
         m_context = std::make_shared<ExecutionContext>(m_d3d12Device.Get(), m_dmlDevice.Get(), queue);
 


### PR DESCRIPTION
Use a privately defined enum value for the dxcore feature level so that we can build on a pool without 19H1 SDK.

In future iterations, onnxruntime build definitions will be reworked to allow for building with vs2019 which will allow us to update the release agent pool VM bootstrap scripts to pull down 19H1. For now this PR will allow us to run release pipelines in the meantime.