### PR TITLE
Fix leaking ModelProto in LearningModel

### DIFF
--- a/winml/lib/Api/LearningModel.cpp
+++ b/winml/lib/Api/LearningModel.cpp
@@ -46,6 +46,10 @@ LearningModel::LearningModel(
 }
 WINML_CATCH_ALL
 
+LearningModel::~LearningModel() {
+  DetachModelProto();
+}
+
 void LearningModel::Initialize() {
   WINML_THROW_IF_FAILED(adapter_->CreateModelInfo(model_proto_.get(), model_info_.put()));
 }

--- a/winml/lib/Api/LearningModel.h
+++ b/winml/lib/Api/LearningModel.h
@@ -23,6 +23,7 @@ struct LearningModel : LearningModelT<LearningModel> {
   LearningModel(
       const std::string& path,
       const winml::ILearningModelOperatorProvider operator_provider);
+  ~LearningModel();
 
   /* LearningModel properties (MachineLearningContract 1). */
   hstring


### PR DESCRIPTION
Fix https://microsoft.visualstudio.com/OS/_workitems/edit/24356109

This was allocated at LearningModel.cpp:27, which called WinMLAdapter.cpp:304.