### PR TITLE
Reshape operator is generating wrong shape(!)

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/reshape_helper.h
+++ b/onnxruntime/core/providers/cpu/tensor/reshape_helper.h
@@ -26,7 +26,6 @@ class ReshapeHelper {
           ORT_ENFORCE(i < input_shape.NumDimensions(),
                       "The dimension with value zero exceeds"
                       " the dimension size of the input tensor.");
-          requested_shape[i] = input_shape[i];
         }
         size *= requested_shape[i];
       }


### PR DESCRIPTION
**Description**: Fix a bug

**Motivation and Context**
A first party TF-to-Onnx model hit this  bug in Reshape operator.

The input data shape was:  (1, 20, 0, 512)
The requested shape was:  (  20, 0, 512)

This is a legal request. However, the Reshape op was mangling the requested shape to (20, 20, 512), which becomes an illegal request and causes ORT to error out.




