### PR TITLE
Add 3.8 classifer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -230,5 +230,7 @@ setup(
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'],
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
     )


### PR DESCRIPTION
Pip fails to install onnxruntime on 3.8 without this qualifier

