### PR TITLE
fix the CUDNN_BN_MIN_EPSILON difference issue between cudnn7.3 and cudnn7.6

### DIFF
--- a/onnxruntime/contrib_ops/cuda/layer_norm.cc
+++ b/onnxruntime/contrib_ops/cuda/layer_norm.cc
@@ -32,7 +32,7 @@ LayerNorm<T, U>::LayerNorm(const OpKernelInfo& op_kernel_info) : CudaKernel(op_k
   ORT_ENFORCE(op_kernel_info.GetAttr("axis", &axis_).IsOK());
   float tmp_epsilon;
   ORT_ENFORCE(op_kernel_info.GetAttr<float>("epsilon", &tmp_epsilon).IsOK());
-  epsilon_ = ClampCudnnBatchNormEpsilon(tmp_epsilon);
+  epsilon_ = tmp_epsilon;
 }
 
 template <typename T, typename U>


### PR DESCRIPTION
In cudnn 7.6, CUDNN_BN_MIN_EPSILON is 0.0, however, it is 1e-5 in cudnn 7.3. It leads to the difference in LayerNorm with its original subgraph
cudnn 7.6
#define CUDNN_BN_MIN_EPSILON 0.0 /* Minimum epsilon allowed to be used in the Batch Normalization formula */
cudnn 7.3:
#define CUDNN_BN_MIN_EPSILON 1e-5 /* Minimum epsilon allowed to be used in the Batch Normalization formula */