### PR TITLE
add start and stop events for modelload and sessionCreation

### DIFF
--- a/winml/dll/module.cpp
+++ b/winml/dll/module.cpp
@@ -34,6 +34,7 @@ extern "C" BOOL WINAPI DllMain(_In_ HINSTANCE hInstance, DWORD dwReason, _In_ vo
       break;
     case DLL_PROCESS_DETACH:
       // Unregister Trace Logging Provider feeding telemetry
+      telemetry_helper.LogWinMLShutDown();
       telemetry_helper.UnRegister();
 
 #ifdef NDEBUG
@@ -68,7 +69,8 @@ STDAPI DllCanUnloadNow() {
   // CoFreeUnusedLibraries since there can be outstanding COM object
   // references to many objects (AbiCustomRegistry, IMLOperatorKernelContext,
   // IMLOperatorTensor, etc) that are not reference counted in this path.
-  //
+  
+  
   // In order to implement DllCanUnloadNow we would need to reference count
   // all of the instances of non-WinRT COM objects that have been shared
   // across the dll boundary or harden the boundary APIs to make sure to

--- a/winml/lib/Api/LearningModel.cpp
+++ b/winml/lib/Api/LearningModel.cpp
@@ -21,7 +21,7 @@ WINML_CATCH_ALL
 LearningModel::LearningModel(
     const std::string& path,
     const winml::ILearningModelOperatorProvider operator_provider) try : operator_provider_(operator_provider) {
-  _winmlt::TelemetryEvent loadModel_event(_winmlt::EventCategory::kModelLoad);
+  _winmlt::TelemetryEvent loadModel_event(_winmlt::EventCategory::kModelLoad, true);
   WINML_THROW_IF_FAILED(OrtGetWinMLAdapter(adapter_.put()));
   WINML_THROW_IF_FAILED(adapter_->OverrideSchemaInferenceFunctions());
   WINML_THROW_IF_FAILED(adapter_->CreateModelProto(path.c_str(), model_proto_.put()));
@@ -34,7 +34,7 @@ WINML_CATCH_ALL
 LearningModel::LearningModel(
     const wss::IRandomAccessStreamReference stream,
     const winml::ILearningModelOperatorProvider operator_provider) try : operator_provider_(operator_provider) {
-  _winmlt::TelemetryEvent loadModel_event(_winmlt::EventCategory::kModelLoad);
+  _winmlt::TelemetryEvent loadModel_event(_winmlt::EventCategory::kModelLoad, true);
   WINML_THROW_IF_FAILED(OrtGetWinMLAdapter(adapter_.put()));
   WINML_THROW_IF_FAILED(adapter_->OverrideSchemaInferenceFunctions());
   WINML_THROW_IF_FAILED(adapter_->CreateModelProto(

--- a/winml/lib/Api/LearningModelBinding.cpp
+++ b/winml/lib/Api/LearningModelBinding.cpp
@@ -150,7 +150,7 @@ void LearningModelBinding::Bind(
     hstring const& name,
     Windows::Foundation::IInspectable const& value,
     Windows::Foundation::Collections::IPropertySet const& properties) try {
-  _winmlt::TelemetryEvent binding_event(_winmlt::EventCategory::kBinding);
+  _winmlt::TelemetryEvent binding_event(_winmlt::EventCategory::kBinding, false);
 
   BindingType bindingType;
   std::string bindingName;
@@ -486,7 +486,7 @@ STDMETHODIMP LearningModelBinding::Bind(
     UINT32 cchName,
     IUnknown* value) {
   try {
-    _winmlt::TelemetryEvent binding_event(_winmlt::EventCategory::kBinding);
+    _winmlt::TelemetryEvent binding_event(_winmlt::EventCategory::kBinding, false);
     BindingType bindingType;
     std::string bindingName;
     OrtValue* binding_value_ptr = nullptr;

--- a/winml/lib/Api/LearningModelSession.cpp
+++ b/winml/lib/Api/LearningModelSession.cpp
@@ -91,7 +91,7 @@ LearningModelSession::GetOptimizedModel(bool should_close_model) {
 void LearningModelSession::Initialize() {
   // Begin recording session creation telemetry
   _winmlt::TelemetryEvent session_creation_event(
-    _winmlt::EventCategory::kSessionCreation);
+    _winmlt::EventCategory::kSessionCreation, true);
   // Get the optimized model proto from the learning model
   com_ptr<winmla::IModelProto> model_proto; 
   model_proto.attach(GetOptimizedModel());
@@ -307,7 +307,15 @@ wf::IAsyncOperation<winml::LearningModelEvaluationResult>
 LearningModelSession::EvaluateAsync(
     winml::LearningModelBinding binding,
     hstring const correlation_id) {
-  _winmlt::TelemetryEvent kEvaluateModel_event(_winmlt::EventCategory::kEvaluation);
+  auto end_time = std::chrono::high_resolution_clock::now();
+  bool sendTelemetry = (std::chrono::duration_cast<std::chrono::microseconds>(end_time - time_sent_last_).count() > kDurationBetweenSending);
+  // Begin recording session creation telemetry
+  _winmlt::TelemetryEvent session_creation_event(
+      _winmlt::EventCategory::kEvaluation, sendTelemetry);
+
+  if (sendTelemetry) {
+    time_sent_last_ = std::chrono::high_resolution_clock::now();
+  }
   auto device = device_.as<LearningModelDevice>();
 
   // Get the ORT binding collection
@@ -355,7 +363,15 @@ LearningModelSession::Evaluate(
     winml::LearningModelBinding binding,
     hstring const& correlation_id) try {
   ToggleProfiler();
-  _winmlt::TelemetryEvent kEvaluateModel_event(_winmlt::EventCategory::kEvaluation);
+  auto end_time = std::chrono::high_resolution_clock::now();
+  bool sendTelemetry = (std::chrono::duration_cast<std::chrono::microseconds>(end_time - time_sent_last_).count() > kDurationBetweenSending);
+  // Begin recording session creation telemetry
+  _winmlt::TelemetryEvent session_creation_event(
+      _winmlt::EventCategory::kEvaluation, sendTelemetry);
+
+  if (sendTelemetry) {
+    time_sent_last_ = std::chrono::high_resolution_clock::now();
+  }
 
   ApplyEvaluationProperties();
 

--- a/winml/lib/Api/LearningModelSession.h
+++ b/winml/lib/Api/LearningModelSession.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <chrono>
+
 #include "LearningModelSession.g.h"
 
 #include "LearningModelBinding.h"
@@ -125,6 +127,10 @@ struct LearningModelSession : LearningModelSessionT<LearningModelSession> {
   // is_first_evaluate_ is used as a heuristic to determine
   // when the dml upload heap can be trimmed.
   bool is_first_evaluate_ = true;
+
+  // used to counter time to send up evaluation stop telemetry event
+  const long long kDurationBetweenSending = 1000 * 50;  // duration in (us).  send a event every 50ms
+  std::chrono::high_resolution_clock::time_point time_sent_last_;
 };
 
 }  // namespace winrt::Windows::AI::MachineLearning::implementation

--- a/winml/lib/Common/inc/WinMLTelemetryHelper.h
+++ b/winml/lib/Common/inc/WinMLTelemetryHelper.h
@@ -79,6 +79,7 @@ class WinMLTelemetryHelper {
   void UnRegister() {
     TraceLoggingUnregister(provider_);
   }
+  void LogWinMLShutDown();
   void LogRuntimeError(HRESULT hr, std::string message, PCSTR file, PCSTR function, int line);
   void LogRuntimeError(HRESULT hr, PCSTR message, PCSTR file, PCSTR function, int line);
   void LogRegisterOperatorKernel(

--- a/winml/lib/Telemetry/TelemetryEvent.cpp
+++ b/winml/lib/Telemetry/TelemetryEvent.cpp
@@ -27,42 +27,43 @@ EventCategoryToString(
 }
 
 TelemetryEvent::TelemetryEvent(
-    EventCategory category) {
-    category_ = category;
-    event_id_ = InterlockedIncrement(&s_event_id);
+  EventCategory category, bool sendTelemetry) {
+  category_ = category;
+  event_id_ = InterlockedIncrement(&s_event_id);
+  sendTelemetry_ = sendTelemetry;
 
-    if (category_ == EventCategory::kModelLoad || 
-      category_ == EventCategory::kSessionCreation) {
-      WinMLTraceLoggingWrite(
-          winml_trace_logging_provider,
-          "started event",
-          TraceLoggingString(EventCategoryToString(category_), "event"),
-          TraceLoggingInt64(event_id_.value(), "eventId"),
-          TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-          TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
-          TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_START_STOP));
-    } else {
-      WinMLTraceLoggingWrite(
-          winml_trace_logging_provider,
-          "started event",
-          TraceLoggingString(EventCategoryToString(category_), "event"),
-          TraceLoggingInt64(event_id_.value(), "eventId"),
-          TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_START_STOP));
-    }
-}
-
-TelemetryEvent::~TelemetryEvent() {
-  if (event_id_.has_value()) {
-    if (category_ == EventCategory::kModelLoad ||
-        category_ == EventCategory::kSessionCreation) {
+  if (sendTelemetry_) {
+    // send start telemtry events for ModelLoad and SessionCreation
     WinMLTraceLoggingWrite(
         winml_trace_logging_provider,
-        "stopped event",
+        "started event",
         TraceLoggingString(EventCategoryToString(category_), "event"),
         TraceLoggingInt64(event_id_.value(), "eventId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_START_STOP));
+  } else {
+    // sent tracelogging events
+    WinMLTraceLoggingWrite(
+        winml_trace_logging_provider,
+        "started event",
+        TraceLoggingString(EventCategoryToString(category_), "event"),
+        TraceLoggingInt64(event_id_.value(), "eventId"),
+        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_START_STOP));
+  }
+}
+
+TelemetryEvent::~TelemetryEvent() {
+  if (event_id_.has_value()) {
+    if (sendTelemetry_) {
+        WinMLTraceLoggingWrite(
+          winml_trace_logging_provider,
+          "stopped event",
+          TraceLoggingString(EventCategoryToString(category_), "event"),
+          TraceLoggingInt64(event_id_.value(), "eventId"),
+          TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
+          TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+          TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_START_STOP));
     } else {
       WinMLTraceLoggingWrite(
           winml_trace_logging_provider,

--- a/winml/lib/Telemetry/WinMLTelemetryHelper.cpp
+++ b/winml/lib/Telemetry/WinMLTelemetryHelper.cpp
@@ -16,7 +16,15 @@ WinMLTelemetryHelper::WinMLTelemetryHelper()
 WinMLTelemetryHelper::~WinMLTelemetryHelper() {
 }
 
-
+void WinMLTelemetryHelper::LogWinMLShutDown() {
+  WinMLTraceLoggingWrite(
+      provider_,
+      "ShutDownWinML",
+      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+      TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
+      TraceLoggingString("windows.ai.machinelearning.dll is unloaded", "message"),
+      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+}
 void WinMLTelemetryHelper::LogRuntimeError(HRESULT hr, PCSTR message, PCSTR file, PCSTR function, int line) {
   if (!telemetry_enabled_)
     return;

--- a/winml/lib/Telemetry/inc/TelemetryEvent.h
+++ b/winml/lib/Telemetry/inc/TelemetryEvent.h
@@ -12,16 +12,20 @@ enum class EventCategory {
   kEvaluation,
 };
 
+
+
 class TelemetryEvent {
  public:
   TelemetryEvent(
-      EventCategory eventCategory);
+      EventCategory eventCategory, bool sendTelemetry);
 
   ~TelemetryEvent();
 
  private:
   EventCategory category_;
   std::optional<int64_t> event_id_;
+  bool isEvalutionStartEventSend = false;
+  bool sendTelemetry_ = true;
 };
 
 }  // namespace Windows::AI::MachineLearning::Telemetry


### PR DESCRIPTION
**Description**: This PR is to add start and stop telemetry events for modelLoad and sessionCreation
![image](https://user-images.githubusercontent.com/17421593/71043749-7ec9ad00-20e4-11ea-94f0-ff9e1e067bc4.png)
