### PR TITLE
When using OpenMP, disable ONNX runtime thread pool in MLAS

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -114,7 +114,7 @@ if(onnxruntime_USE_OPENMP)
   if (OPENMP_FOUND)
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    add_definitions(-DUSE_OPENMP)
+    add_definitions(-DUSE_OPENMP -DMLAS_NO_ONNXRUNTIME_THREADPOOL)
     # MKLML and NGraph depend on their own OpenMP library that may be different with the compiler's.
     # Disable the options to build mklml/NGraph and OpenMP together.
     if(onnxruntime_USE_MKLML)


### PR DESCRIPTION
**Description**: It seems MLAS has a macro to use OpenMP, but it is not enabled by default even when USE_OPENMP is defined.

**Motivation and Context**
- The option of USE_OPENMP is to allow global threading controls through OMP_NUM_THREADS, but without this change MLAS does not use OpenMP, so it still uses ORT thread pool.