### PR TITLE
[NupharEP] fix for Windows build and VS 2019

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -392,6 +392,13 @@ if (onnxruntime_USE_TVM)
   set_target_properties(tvm_runtime PROPERTIES FOLDER "External/tvm")
   set_target_properties(nnvm_compiler PROPERTIES FOLDER "External/tvm")
 
+  if (onnxruntime_USE_MKLML)
+    add_dependencies(tvm project_mklml)
+    add_dependencies(tvm_topi project_mklml)
+    add_dependencies(tvm_runtime project_mklml)
+    add_dependencies(nnvm_compiler project_mklml)
+  endif()
+
   set(TVM_INCLUDES ${PROJECT_SOURCE_DIR}/external/tvm/include
     ${PROJECT_SOURCE_DIR}/external/tvm/3rdparty/dmlc-core/include
     ${PROJECT_SOURCE_DIR}/external/tvm/3rdparty/dlpack/include

--- a/onnxruntime/core/codegen/common/settings.h
+++ b/onnxruntime/core/codegen/common/settings.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include <map>
+#include <string>
 
 namespace onnxruntime {
 namespace codegen {

--- a/onnxruntime/core/providers/nuphar/common/nuphar_tvm_utils.cc
+++ b/onnxruntime/core/providers/nuphar/common/nuphar_tvm_utils.cc
@@ -15,7 +15,9 @@
 #include "gsl/gsl"
 #include <topi/detail/extern.h>
 #include <tvm/ir_pass.h>
+#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING // required by VS 2019
 #include <experimental/filesystem>
+#undef _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
 #include <atomic>
 #include <fstream>
 namespace fs = std::experimental::filesystem;

--- a/onnxruntime/core/providers/nuphar/kernel.cc
+++ b/onnxruntime/core/providers/nuphar/kernel.cc
@@ -180,7 +180,7 @@ ONNX_OPERATOR_KERNEL_EX(
     9,
     kNupharExecutionProvider,
     KernelDefBuilder()
-        .TypeConstraint("T1", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("T1", DataTypeImpl::AllFixedSizeTensorExceptHalfTypes())
         .TypeConstraint("T2", DataTypeImpl::AllFixedSizeTensorExceptHalfTypes()),
     nuphar::NupharKernel);
 


### PR DESCRIPTION
**Description**: Fix for Windows build and VS 2019

**Motivation and Context**
- Fix a VS 2019 warning from <experimental/filesystem>
- Fix dependency on Windows when building TVM with MKL (iomp)
- Fix a test failure on AVX when F16C intrinsics are not available and LLVM build in TVM cannot find float16 conversion function.
