### PR TITLE
properly organize and skip GPU tests.

### DIFF
--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -239,7 +239,7 @@ static LearningModelSession CreateSession(LearningModel model)
     return session;
 }
 
-TEST_F(LearningModelSessionAPITests, CreateSessionWithCastToFloat16InModel)
+TEST_F(LearningModelSessionAPITestsGpu, CreateSessionWithCastToFloat16InModel)
 {
     // load a model
     EXPECT_NO_THROW(LoadModel(L"fp16-truncate-with-cast.onnx"));
@@ -247,7 +247,7 @@ TEST_F(LearningModelSessionAPITests, CreateSessionWithCastToFloat16InModel)
     CreateSession(m_model);
 }
 
-TEST_F(LearningModelSessionAPITests, DISABLED_CreateSessionWithFloat16InitializersInModel)
+TEST_F(LearningModelSessionAPITestsGpu, DISABLED_CreateSessionWithFloat16InitializersInModel)
 {
     // Disabled due to https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/21624720:
     // Model fails to resolve due to ORT using incorrect IR version within partition

--- a/winml/test/common/std.h
+++ b/winml/test/common/std.h
@@ -55,12 +55,19 @@
 #define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
 #endif
 
+
+#ifndef USE_DML
+#define GPUTEST \
+    GTEST_SKIP() << "GPU tests disabled because this is a WinML only build (no DML)";
+#else
 #define GPUTEST \
     if (auto noGpuTests = RuntimeParameters::Parameters.find("noGPUtests");             \
         noGpuTests != RuntimeParameters::Parameters.end() && noGpuTests->second != "0") \
     {                                                                                   \
         GTEST_SKIP() << "GPU tests disabled";                                           \
     }
+#endif 
+    
 
 #define SKIP_EDGECORE \
     if (auto isEdgeCore = RuntimeParameters::Parameters.find("EdgeCore");               \

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -68,12 +68,12 @@ protected:
 };
 using ScenarioCppWinrtGpuTestDeathTest = ScenarioCppWinrtGpuTest;
 
-class ScenarioCppWinrtGpuSkipEdgeCoreTest : public ScenarioCppWinrtTest
+class ScenarioCppWinrtGpuSkipEdgeCoreTest : public ScenarioCppWinrtGpuTest
 {
 protected:
     void SetUp() override
     {
-        ScenarioCppWinrtTest::SetUp();
+        ScenarioCppWinrtGpuTest::SetUp();
         SKIP_EDGECORE
     }
 };
@@ -780,15 +780,21 @@ TEST_F(ScenarioCppWinrtTest, Scenario17DevDiagnostics)
     EXPECT_NO_THROW(session.Evaluate(binding, L""));
 }
 
+/** 
+ * Custom Operator Tests are labeled as GPU tests because the DML code is interlaced with the custom op code
+ * even though CPU custom ops shouldn't be dependent on GPU functionality.
+ * These should be reclassed to ScenarioCppWinrtTest once the DML code is decoupled from the custom op code.
+**/ 
+
 // create a session that loads a model with a branch new operator, register the custom operator, and load/bind/eval
-TEST_F(ScenarioCppWinrtTest, Scenario20aLoadBindEvalCustomOperatorCPU)
+TEST_F(ScenarioCppWinrtGpuTest, Scenario20aLoadBindEvalCustomOperatorCPU) 
 {
     std::wstring filePath = FileHelpers::GetModulePath() + L"noisy_relu.onnx";
     LoadBindEval_CustomOperator_CPU(filePath.c_str());
 }
 
 // create a session that loads a model with an overridden operator, register the replacement custom operator, and load/bind/eval
-TEST_F(ScenarioCppWinrtTest, Scenario20bLoadBindEvalReplacementCustomOperatorCPU)
+TEST_F(ScenarioCppWinrtGpuTest, Scenario20bLoadBindEvalReplacementCustomOperatorCPU)
 {
     std::wstring filePath = FileHelpers::GetModulePath() + L"relu.onnx";
     LoadBindEval_CustomOperator_CPU(filePath.c_str());


### PR DESCRIPTION
For now for no-DML builds will not run GPU tests at all. In the future we should adapt the tests to expect the appropiate errors.
