### PR TITLE
[server] Add supposed for model_name and model_version as cli parameter

### DIFF
--- a/onnxruntime/server/main.cc
+++ b/onnxruntime/server/main.cc
@@ -63,7 +63,7 @@ int main(int argc, char* argv[]) {
   logger->info("Model path: {}", config.model_path);
 
   try {
-    env->InitializeModel(config.model_path, "default", "1");
+    env->InitializeModel(config.model_path, config.model_name, config.model_version);
     logger->debug("Initialize Model Successfully!");
   } catch (const Ort::Exception& ex) {
     logger->critical("Initialize Model Failed: {} ---- Error: [{}]", ex.GetOrtErrorCode(), ex.what());

--- a/onnxruntime/server/main.cc
+++ b/onnxruntime/server/main.cc
@@ -60,7 +60,9 @@ int main(int argc, char* argv[]) {
 
   const auto env = std::make_shared<server::ServerEnvironment>(config.logging_level, spdlog::sinks_init_list{std::make_shared<spdlog::sinks::stdout_sink_mt>(), std::make_shared<spdlog::sinks::syslog_sink_mt>()});
   auto logger = env->GetAppLogger();
-  logger->info("Model path: {}", config.model_path);
+  logger->info("Model path: {}, ", config.model_path);
+  logger->info("Model name: {}", config.model_name);
+  logger->info("Model version: {}", config.model_version);
 
   try {
     env->InitializeModel(config.model_path, config.model_name, config.model_version);

--- a/onnxruntime/server/server_configuration.h
+++ b/onnxruntime/server/server_configuration.h
@@ -39,6 +39,8 @@ class ServerConfiguration {
  public:
   const std::string full_desc = "ONNX Server: host an ONNX model with ONNX Runtime";
   std::string model_path;
+  std::string model_name = "default";
+  std::string model_version = "1";
   std::string address = "0.0.0.0";
   unsigned short http_port = 8001;
   unsigned short grpc_port = 50051;
@@ -49,6 +51,8 @@ class ServerConfiguration {
     desc.add_options()("help,h", "Shows a help message and exits");
     desc.add_options()("log_level", po::value(&log_level_str)->default_value(log_level_str), "Logging level. Allowed options (case sensitive): verbose, info, warning, error, fatal");
     desc.add_options()("model_path", po::value(&model_path)->required(), "Path to ONNX model");
+    desc.add_options()("model_name", po::value(&model_name)->default_value(model_name), "ONNX model name; default: default");
+    desc.add_options()("model_version", po::value(&model_version)->default_value(model_version), "ONNX model version; default: 1");
     desc.add_options()("address", po::value(&address)->default_value(address), "The base HTTP address");
     desc.add_options()("http_port", po::value(&http_port)->default_value(http_port), "HTTP port to listen to requests");
     desc.add_options()("num_http_threads", po::value(&num_http_threads)->default_value(num_http_threads), "Number of http threads");

--- a/onnxruntime/server/server_configuration.h
+++ b/onnxruntime/server/server_configuration.h
@@ -51,8 +51,8 @@ class ServerConfiguration {
     desc.add_options()("help,h", "Shows a help message and exits");
     desc.add_options()("log_level", po::value(&log_level_str)->default_value(log_level_str), "Logging level. Allowed options (case sensitive): verbose, info, warning, error, fatal");
     desc.add_options()("model_path", po::value(&model_path)->required(), "Path to ONNX model");
-    desc.add_options()("model_name", po::value(&model_name)->default_value(model_name), "ONNX model name; default: default");
-    desc.add_options()("model_version", po::value(&model_version)->default_value(model_version), "ONNX model version; default: 1");
+    desc.add_options()("model_name", po::value(&model_name)->default_value(model_name), "ONNX model name");
+    desc.add_options()("model_version", po::value(&model_version)->default_value(model_version), "ONNX model version");
     desc.add_options()("address", po::value(&address)->default_value(address), "The base HTTP address");
     desc.add_options()("http_port", po::value(&http_port)->default_value(http_port), "HTTP port to listen to requests");
     desc.add_options()("num_http_threads", po::value(&num_http_threads)->default_value(num_http_threads), "Number of http threads");

--- a/onnxruntime/test/server/unit_tests/server_configuration_test.cc
+++ b/onnxruntime/test/server/unit_tests/server_configuration_test.cc
@@ -14,6 +14,8 @@ TEST(ConfigParsingTests, AllArgs) {
   char* test_argv[] = {
       const_cast<char*>("/path/to/binary"),
       const_cast<char*>("--model_path"), const_cast<char*>("testdata/mul_1.onnx"),
+      const_cast<char*>("--model_name"), const_cast<char*>("mul_1"),
+      const_cast<char*>("--model_version"), const_cast<char*>("2"),
       const_cast<char*>("--address"), const_cast<char*>("4.4.4.4"),
       const_cast<char*>("--http_port"), const_cast<char*>("80"),
       const_cast<char*>("--num_http_threads"), const_cast<char*>("1"),
@@ -23,6 +25,8 @@ TEST(ConfigParsingTests, AllArgs) {
   Result res = config.ParseInput(11, test_argv);
   EXPECT_EQ(res, Result::ContinueSuccess);
   EXPECT_EQ(config.model_path, "testdata/mul_1.onnx");
+  EXPECT_EQ(config.model_name, "mul_1");
+  EXPECT_EQ(config.model_version, "2);
   EXPECT_EQ(config.address, "4.4.4.4");
   EXPECT_EQ(config.http_port, 80);
   EXPECT_EQ(config.num_http_threads, 1);
@@ -39,6 +43,8 @@ TEST(ConfigParsingTests, Defaults) {
   Result res = config.ParseInput(5, test_argv);
   EXPECT_EQ(res, Result::ContinueSuccess);
   EXPECT_EQ(config.model_path, "testdata/mul_1.onnx");
+  EXPECT_EQ(config.model_name, "default");
+  EXPECT_EQ(config.model_version, "1");
   EXPECT_EQ(config.address, "0.0.0.0");
   EXPECT_EQ(config.http_port, 8001);
   EXPECT_EQ(config.num_http_threads, 3);

--- a/onnxruntime/test/server/unit_tests/server_configuration_test.cc
+++ b/onnxruntime/test/server/unit_tests/server_configuration_test.cc
@@ -26,7 +26,7 @@ TEST(ConfigParsingTests, AllArgs) {
   EXPECT_EQ(res, Result::ContinueSuccess);
   EXPECT_EQ(config.model_path, "testdata/mul_1.onnx");
   EXPECT_EQ(config.model_name, "mul_1");
-  EXPECT_EQ(config.model_version, "2);
+  EXPECT_EQ(config.model_version, "2");
   EXPECT_EQ(config.address, "4.4.4.4");
   EXPECT_EQ(config.http_port, 80);
   EXPECT_EQ(config.num_http_threads, 1);

--- a/onnxruntime/test/server/unit_tests/server_configuration_test.cc
+++ b/onnxruntime/test/server/unit_tests/server_configuration_test.cc
@@ -15,7 +15,7 @@ TEST(ConfigParsingTests, AllArgs) {
       const_cast<char*>("/path/to/binary"),
       const_cast<char*>("--model_path"), const_cast<char*>("testdata/mul_1.onnx"),
       const_cast<char*>("--model_name"), const_cast<char*>("mul_1"),
-      const_cast<char*>("--model_version"), const_cast<char*>("2"),
+      const_cast<char*>("--model_version"), const_cast<char*>("1"),
       const_cast<char*>("--address"), const_cast<char*>("4.4.4.4"),
       const_cast<char*>("--http_port"), const_cast<char*>("80"),
       const_cast<char*>("--num_http_threads"), const_cast<char*>("1"),
@@ -26,7 +26,7 @@ TEST(ConfigParsingTests, AllArgs) {
   EXPECT_EQ(res, Result::ContinueSuccess);
   EXPECT_EQ(config.model_path, "testdata/mul_1.onnx");
   EXPECT_EQ(config.model_name, "mul_1");
-  EXPECT_EQ(config.model_version, "2");
+  EXPECT_EQ(config.model_version, "1");
   EXPECT_EQ(config.address, "4.4.4.4");
   EXPECT_EQ(config.http_port, 80);
   EXPECT_EQ(config.num_http_threads, 1);
@@ -36,7 +36,7 @@ TEST(ConfigParsingTests, AllArgs) {
 TEST(ConfigParsingTests, Defaults) {
   char* test_argv[] = {
       const_cast<char*>("/path/to/binary"),
-      const_cast<char*>("--model"), const_cast<char*>("testdata/mul_1.onnx"),
+      const_cast<char*>("--model_path"), const_cast<char*>("testdata/mul_1.onnx"),
       const_cast<char*>("--num_http_threads"), const_cast<char*>("3")};
 
   onnxruntime::server::ServerConfiguration config{};

--- a/onnxruntime/test/server/unit_tests/server_configuration_test.cc
+++ b/onnxruntime/test/server/unit_tests/server_configuration_test.cc
@@ -22,7 +22,7 @@ TEST(ConfigParsingTests, AllArgs) {
       const_cast<char*>("--log_level"), const_cast<char*>("info")};
 
   onnxruntime::server::ServerConfiguration config{};
-  Result res = config.ParseInput(11, test_argv);
+  Result res = config.ParseInput(15, test_argv);
   EXPECT_EQ(res, Result::ContinueSuccess);
   EXPECT_EQ(config.model_path, "testdata/mul_1.onnx");
   EXPECT_EQ(config.model_name, "mul_1");


### PR DESCRIPTION
**Description**: Allow to pass model_name and model_version as options for cli command

**Motivation and Context**
- Removes the need for route rewrite when running multiple models under same hostname
