### PR TITLE
switch back order of session_state_ and execution_providers_ member declarations

### DIFF
--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -377,10 +377,6 @@ class InferenceSession {
   // The file path of where the model was loaded. e.g. /tmp/test_squeezenet/model.onnx
   std::basic_string<ORTCHAR_T> model_location_;
 
-  // Immutable state for each op in the model. Shared by all executors.
-  // It has a dependency on execution_providers_.
-  std::unique_ptr<SessionState> session_state_;
-
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(InferenceSession);
 
@@ -457,6 +453,12 @@ class InferenceSession {
   // The list of execution providers.
   ExecutionProviders execution_providers_;
 
+ protected:
+  // Immutable state for each op in the model. Shared by all executors.
+  // It has a dependency on execution_providers_.
+  std::unique_ptr<SessionState> session_state_;
+
+ private:
   // Threadpool for this session
   std::unique_ptr<onnxruntime::concurrency::ThreadPool> thread_pool_;
   std::unique_ptr<onnxruntime::concurrency::ThreadPool> inter_op_thread_pool_;


### PR DESCRIPTION
**Description**: switches back the order of the session_state_ and execution_providers_ member declarations in InferenceSession

**Motivation and Context**
execution_providers_ is being destroyed before session_state_, and in some winml test cases this causes work to be queued on an executioncontext after it had already been closed which results in an assertion failure. It seems like the order of declaration for these member variables were swapped in this PR (https://github.com/microsoft/onnxruntime/pull/2449). This causes the order that these members are constructed and destroyed to swap as well, violating the dependency that session_state_ has on execution_providers_.
