### PR TITLE
Fix dangling reference to a temp object

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
@@ -48,7 +48,7 @@ struct ConvTransposeAttributes : public ConvAttributes {
     const Tensor* F = context->Input<Tensor>(1);
     const Tensor* Pads = dynamic_padding ? context->Input<Tensor>(2) : nullptr;
     const Tensor* B = has_bias ? (dynamic_padding ? context->Input<Tensor>(3) : context->Input<Tensor>(2)) : nullptr;
-    const TensorShape& input_shape = X->Shape().Slice(2);
+    const TensorShape input_shape = X->Shape().Slice(2);
 
     const int64_t num_input_channels = X->Shape()[1];
     const int64_t N = X->Shape()[0];


### PR DESCRIPTION
  Taking a ref to a temp object returned by value creates a dangling reference.
  We should receive the result by value.
