### PR TITLE
MLAS: ARM64 build fix

### DIFF
--- a/onnxruntime/core/mlas/lib/quantize.cpp
+++ b/onnxruntime/core/mlas/lib/quantize.cpp
@@ -176,7 +176,7 @@ MlasQuantizeLinearKernel(
             MinimumValueVector, MaximumValueVector, ZeroPointVector);
 
 #if defined(MLAS_NEON64_INTRINSICS)
-        vst1q_lane_u8((uint8_t*)Output + n, vreinterpretq_s32_u8(IntegerVector), 0);
+        vst1q_lane_u8((uint8_t*)Output + n, vreinterpretq_u8_s32(IntegerVector), 0);
 #else
         *((uint8_t*)Output + n) = (uint8_t)_mm_cvtsi128_si32(IntegerVector);
 #endif


### PR DESCRIPTION
**Description**: 
Fix the non-Windows ARM64 build break in quantize.cpp.

**Motivation and Context**
Fix the non-Windows ARM64 build break where the wrong vector cast intrinsic was used. This didn't matter in the Windows build as all 128-bit vector types are an alias of the same base type.