### PR TITLE
Fix build for Python 3.8

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -173,7 +173,12 @@ def is_windows():
     return sys.platform.startswith("win")
 
 def is_ubuntu_1604():
-    return platform.linux_distribution()[0] == 'Ubuntu' and platform.linux_distribution()[1] == '16.04'
+    try:
+        with open('/etc/os-release', 'r') as f:
+            dist_info = dict(line.strip().split('=', 1) for line in f.readlines())
+        return dist_info.get('NAME', '').strip('"') == 'Ubuntu' and dist_info.get('VERSION', '').strip('"').startswith('16.04')
+    except:
+        return False
 
 def get_config_build_dir(build_dir, config):
     # build directory per configuration

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -172,13 +172,17 @@ def resolve_executable_path(command_or_path):
 def is_windows():
     return sys.platform.startswith("win")
 
-def is_ubuntu_1604():
+def get_linux_distro():
     try:
         with open('/etc/os-release', 'r') as f:
             dist_info = dict(line.strip().split('=', 1) for line in f.readlines())
-        return dist_info.get('NAME', '').strip('"') == 'Ubuntu' and dist_info.get('VERSION', '').strip('"').startswith('16.04')
+        return dist_info.get('NAME', '').strip('"'), dist_info.get('VERSION', '').strip('"')
     except:
-        return False
+        return '', ''
+
+def is_ubuntu_1604():
+    dist, ver = get_linux_distro()
+    return dist == 'Ubuntu' and ver.startswith('16.04')
 
 def get_config_build_dir(build_dir, config):
     # build directory per configuration


### PR DESCRIPTION
**Description**:
This patch fixes build on Python 3.8 by replacing deprecated `linux_distribution` with `get_linux_distro()`, which reads [`/etc/os-release`](http://manpages.ubuntu.com/manpages/xenial/man5/os-release.5.html).
Any distribution with `systemd` would provide the file - including Ubuntu 16.04.

**Motivation and Context**
- `platform.linux_distribution` is deprecated since Python 3.5 and removed in Python 3.8
- This fixes #2664 
