### PR TITLE
Add basic stacktrace output for posix debug builds.

### DIFF
--- a/onnxruntime/core/platform/posix/stacktrace.cc
+++ b/onnxruntime/core/platform/posix/stacktrace.cc
@@ -3,10 +3,44 @@
 
 #include "core/common/common.h"
 
+#include <execinfo.h>
+#include <vector>
+
 namespace onnxruntime {
 
 std::vector<std::string> GetStackTrace() {
-  return {"<stacktrace not implemented>"};
-}
+  std::vector<std::string> stack;
 
+#ifndef NDEBUG
+  constexpr int kCallstackLimit = 64;  // Maximum depth of callstack
+
+  void* array[kCallstackLimit];
+  char** strings = nullptr;
+
+  size_t size = backtrace(array, kCallstackLimit);
+  stack.reserve(size);
+  strings = backtrace_symbols(array, size);
+
+  // NOTE: To get meaningful info from the output, addr2line (or atos on osx) would need to be used.
+  // See https://gist.github.com/jvranish/4441299 for an example.
+  //
+  // To manually translate the output, use the value in the '()' after the executable name with addr2line
+  // e.g.
+  //   Stacktrace:
+  //    /home/me/src/github/onnxruntime/build/Linux/Debug/onnxruntime_test_all(+0x3f46cc) [0x559543faf6cc]
+  //
+  // >addr2line -f -C -e /home/me/src/github/onnxruntime/build/Linux/Debug/onnxruntime_test_all  +0x3f46cc
+
+  // hide GetStackTrace so the output starts with the 'real' location
+  constexpr size_t start_frame = 1;
+  for (size_t i = start_frame; i < size; i++) {
+    stack.push_back(strings[i]);
+  }
+
+  free(strings);
+
+#endif
+
+  return stack;
+}
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**: 
Add basic stacktrace for exceptions on Linux/OS X. 

**Motivation and Context**
Lack of stacktrace made debugging an error during static cleanup impossible. 
We have stacktrace info for Windows so this makes Linux/OS X more consistent.