### PR TITLE
Update numpy to 1.18

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -212,10 +212,10 @@ setup(
         'onnxruntime': data + examples + extra,
     },
     py_modules=python_modules_list,
-    install_requires={
+    install_requires=[
         'onnx>=1.2.3',
         'numpy>=1.18.0,<2'
-    },
+    ],
     entry_points= {
         'console_scripts': [
             'onnxruntime_test = onnxruntime.tools.onnxruntime_test:main',

--- a/setup.py
+++ b/setup.py
@@ -212,9 +212,9 @@ setup(
         'onnxruntime': data + examples + extra,
     },
     py_modules=python_modules_list,
-    extras_require={
-        'backend': ['onnx>=1.2.3'],
-        'numpy': ['numpy>=1.15.0']
+    install_requires={
+        'onnx>=1.2.3',
+        'numpy>=1.18.0,<2'
     },
     entry_points= {
         'console_scripts': [
@@ -222,9 +222,10 @@ setup(
         ]
     },
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3 :: Only',

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -244,7 +244,7 @@ def install_ubuntu_deps(args):
 
 def install_python_deps(numpy_version=""):
     dep_packages = ['setuptools', 'wheel', 'pytest']
-    dep_packages.append('numpy=={}'.format(numpy_version) if numpy_version else 'numpy>=1.15.0')
+    dep_packages.append('numpy=={}'.format(numpy_version) if numpy_version else 'numpy>=1.18.0')
     dep_packages.append('sympy>=1.1')
     dep_packages.append('packaging')
     run_subprocess([sys.executable, '-m', 'pip', 'install', '--trusted-host', 'files.pythonhosted.org'] + dep_packages)

--- a/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
@@ -158,7 +158,7 @@ jobs:
       workingFolder: '$(Build.BinariesDirectory)'
 
   - script: |
-     python -m pip install -q pyopenssl setuptools wheel numpy     
+     python -m pip install -q pyopenssl setuptools wheel numpy==1.18
    
     workingDirectory: '$(Build.BinariesDirectory)'
     displayName: 'Install python modules'        
@@ -227,7 +227,7 @@ jobs:
 
 
     - script: |
-       python -m pip install -q pyopenssl setuptools wheel numpy     
+       python -m pip install -q pyopenssl setuptools wheel numpy==1.18
       workingDirectory: '$(Build.BinariesDirectory)'
       displayName: 'Install python modules'
 

--- a/tools/ci_build/github/azure-pipelines/mac-nocontribops-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-nocontribops-ci-pipeline.yml
@@ -1,35 +1,6 @@
-variables:
-  DisableContribOps: ON
-  TestDataUrlNoContribOps : https://onnxruntimetestdata.blob.core.windows.net/models/20181210.zip
-
 jobs:
-- job: MacOS_CI_Dev
-  pool:
-    vmImage: 'macOS-10.13'
-  steps:
-    - template: templates/set-test-data-variables-step.yml
-    - task: CmdLine@2
-      displayName: 'Download azcopy'
-      inputs:
-        script: |
-          curl -so azcopy.tar.gz -L 'https://aka.ms/downloadazcopy-v10-mac'
-          tar -zxvf azcopy.tar.gz --strip 1
-        workingDirectory: $(Build.BinariesDirectory)
-    - task: PythonScript@0
-      displayName: 'Download test data'
-      inputs:
-        scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-        arguments: --test_data_url $(TestDataUrlNoContribOps) --azure_region centralus --build_dir $(Build.BinariesDirectory)
-        pythonInterpreter: '/usr/local/bin/python3'
-        workingDirectory: $(Build.BinariesDirectory)
-    - script: |
-        sudo python3 -m pip install numpy==1.15.0
-        sudo xcode-select --switch /Applications/Xcode_10.app/Contents/Developer
-        python3 $(Build.SourcesDirectory)/tools/ci_build/build.py --build_dir $(Build.BinariesDirectory) --enable_onnx_tests --skip_submodule_sync --parallel --build_shared_lib --disable_contrib_ops --config Debug Release
-      displayName: 'Build and Test OnnxRuntime lib for MacOS'
-
-    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-      displayName: 'Component Detection'
-      condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
-
-    - template: templates/clean-agent-build-directory-step.yml
+- template: templates/mac-ci.yml
+  parameters:
+    AgentPool : 'Hosted macOS High Sierra'
+    DoNugetPack: 'false'
+    BuildCommand: 'python3 $(Build.SourcesDirectory)/tools/ci_build/build.py --use_openmp --build_dir $(Build.BinariesDirectory) --build_wheel --skip_submodule_sync --parallel --build_shared_lib --disable_contrib_ops --enable_onnx_tests --config Debug RelWithDebInfo'

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.15.0
+numpy==1.18.0
 requests==2.21.0
 scipy
 mypy


### PR DESCRIPTION
**Description**: 

Update numpy to 1.18

**Motivation and Context**
- Why is this change required? What problem does it solve?

1. Now we're using numpy 1.15, which is insecure.
An issue was discovered in NumPy 1.16.0 and earlier. It uses the pickle Python module unsafely, which allows remote attackers to execute arbitrary code via a crafted serialized object, as demonstrated by a numpy.load call

2. To support python 3.8. Scipy need a newer version of numpy.

- If it fixes an open issue, please link to the issue here.
