### PR TITLE
Reduce BFCArena::FindChunkPtr::kMaxInternalFragmentation.

### DIFF
--- a/onnxruntime/core/framework/bfc_arena.cc
+++ b/onnxruntime/core/framework/bfc_arena.cc
@@ -252,8 +252,7 @@ void BFCArena::GetStats(AllocatorStats* stats) {
   *stats = stats_;
 }
 
-void* BFCArena::FindChunkPtr(BinNum bin_num, size_t rounded_bytes,
-                             size_t num_bytes) {
+void* BFCArena::FindChunkPtr(BinNum bin_num, size_t rounded_bytes, size_t num_bytes) {
   // First identify the first bin that could satisfy rounded_bytes.
   for (; bin_num < kNumBins; bin_num++) {
     // Start searching from the first bin for the smallest chunk that fits
@@ -272,10 +271,9 @@ void* BFCArena::FindChunkPtr(BinNum bin_num, size_t rounded_bytes,
         // If we can break the size of the chunk into two reasonably large
         // pieces, do so.  In any case don't waste more than
         // kMaxInternalFragmentation bytes on padding this alloc.
-        const int64_t kMaxInternalFragmentation = 128 << 20;  // 128mb
+        const int64_t kMaxInternalFragmentation = 1024 * 1024;  // 1MB
         if (chunk->size >= rounded_bytes * 2 ||
-            static_cast<int64_t>(chunk->size) - rounded_bytes >=
-                kMaxInternalFragmentation) {
+            static_cast<int64_t>(chunk->size) - rounded_bytes >= kMaxInternalFragmentation) {
           SplitChunk(h, rounded_bytes);
           chunk = ChunkFromHandle(h);  // Update chunk pointer in case it moved
         }


### PR DESCRIPTION
**Description**: 
Currently we prevent 128MB chunks of memory from the largest bin from being split due to kMaxInternalFragmentation. 
kMaxInternalFragmentation doesn't affect the smaller bins as the test is that the remaining size is > 128MB, and only the largest bin 
(second largest has max of 128MB, so remaining will always be less than 128MB) can possibly satisfy that.

Code involved:

```
void* BFCArena::FindChunkPtr(BinNum bin_num, size_t rounded_bytes, size_t num_bytes) {
  // First identify the first bin that could satisfy rounded_bytes.
  for (; bin_num < kNumBins; bin_num++) {
      ...
      if (chunk->size >= rounded_bytes) {
        ...
        // If we can break the size of the chunk into two reasonably large
        // pieces, do so.  In any case don't waste more than
        // kMaxInternalFragmentation bytes on padding this alloc.
-->     const int64_t kMaxInternalFragmentation = 128 << 20;  // 128mb
        if (chunk->size >= rounded_bytes * 2 ||
-->         static_cast<int64_t>(chunk->size) - rounded_bytes >= kMaxInternalFragmentation) {
          SplitChunk(h, rounded_bytes);
          chunk = ChunkFromHandle(h);  // Update chunk pointer in case it moved
        }
```

We don't prevent breaking any other sized chunk based on kMaxInternalFragmentation, so having a 128+ MB chunk unused seems to be of no meaningful value.

Changing the max to 1MB provides significant overall memory usage savings. Debug output about memory allocations from an arbitrary production model:

128MB kMaxInternalFragmentation |   |   |   |   |  
-- | -- | -- | -- | -- | --
Bin size |   | In-use/Total |   |   |   |   |  
256 | Chunks | 1/1 | Bytes | 256/256 | Requested | 8 |  
512 | Chunks | 1/1 | Bytes | 512/512 | Requested | 496 |  
1024 | Chunks | 1/1 | Bytes | 1024/1024 | Requested | 992 |  
4096 | Chunks | 1/1 | Bytes | 4864/4864 | Requested | 4864 |  
4194304 | Chunks | 1/1 | Bytes | 8192000/8192000 | Requested | 8192000 |  
8388608 | Chunks | 1/1 | Bytes | 12288000/12288000 | Requested | 12288000 |  
67108864 | Chunks | 1/1 | Bytes | 112780800/112780800 | Requested | 73728000 |  
134217728 | Chunks | 1/1 | Bytes | 135168000/135168000 | Requested | 77824000 |  
268435456 | Chunks | 2/2 | Bytes | 805306368/805306368 | Requested | 623770112 |  
Diff between   in-use and requested bytes is 277933352 |   |   |  
  |   |   |   |   |   |   |  
1MB   kMaxInternalFragmentation |   |   |   |   |  
256 | Chunks | 1/1 | Bytes | 256/256 | Requested | 8 |  
512 | Chunks | 1/1 | Bytes | 512/512 | Requested | 496 |  
1024 | Chunks | 1/1 | Bytes | 1024/1024 | Requested | 992 |  
4096 | Chunks | 1/1 | Bytes | 4864/4864 | Requested | 4864 |  
4194304 | Chunks | 1/1 | Bytes | 8192000/8192000 | Requested | 8192000 |  
8388608 | Chunks | 1/1 | Bytes | 12288000/12288000 | Requested | 12288000 |  
33554432 | Chunks | 0/1 | Bytes | 0/59539200 | Requested | 0 | New
67108864 | Chunks | 1/4 | Bytes | 102400000/369945856 | Requested | 102400000 | 3 extra chunks here
134217728 | Chunks | 1/1 | Bytes | 185926144/185926144 | Requested | 185926144 |  
268435456 | Chunks | 1/1 | Bytes | 437843968/437843968 | Requested | 437843968 |  
Diff between   in-use and requested bytes is 296 |   |   |   |  

265MB of memory was saved by allowing breaking up allocations from the largest bin. 

**Motivation and Context**
Reduce wasted memory usage.