### PR TITLE
[NupharEP] fix a race condition in concurrent multiple sessions runs

### DIFF
--- a/onnxruntime/core/providers/nuphar/nuphar_execution_provider.h
+++ b/onnxruntime/core/providers/nuphar/nuphar_execution_provider.h
@@ -154,9 +154,10 @@ class NupharExecutionProvider : public IExecutionProvider {
   mutable std::unordered_map<std::string, std::unique_ptr<Tensor>> constant_initializers_used_in_compiled_nodes_;
   mutable std::unordered_map<std::string, int> domain_versions_;
 
-  // used to create unique fused node name, make it static because
-  // subsession may create multiple instances of EPs
-  static int global_fused_count_;
+  // used to create unique fused node name, make it thread_local because
+  // subsession of a model with subgraph may create multiple instances of EPs,
+  // and there might be multiple inference sessions running different models concurrently
+  static thread_local int per_model_fused_count_;
 };
 
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**: This race condition may cause some intermittent test failures

**Motivation and Context**
- Fix the bug by making the fuse count thread local, so inference sessions in different threads would not have non-deterministic names for fused nodes.
