### PR TITLE
Fix memory leak in samples and test

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/CXX_Api_Sample.cpp
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/CXX_Api_Sample.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[]) {
 
   // print number of model input nodes
   size_t num_input_nodes = session.GetInputCount();
-  std::vector<const char*> input_node_names(num_input_nodes);
+  std::vector<char*> input_node_names(num_input_nodes);
   std::vector<int64_t> input_node_dims;  // simplify... this model has only 1 input node {1, 3, 224, 224}.
                                          // Otherwise need vector<vector<>>
 
@@ -126,6 +126,9 @@ int main(int argc, char* argv[]) {
   // Score for class[2] = 0.000125
   // Score for class[3] = 0.001180
   // Score for class[4] = 0.001317
+
+  for (size_t i = 0; i < num_input_nodes; i++)
+    allocator.Free(input_node_names[i]);
   printf("Done!\n");
   return 0;
 }

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/C_Api_Sample.cpp
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests.Capi/C_Api_Sample.cpp
@@ -65,7 +65,7 @@ int main(int argc, char* argv[]) {
 
   // print number of model input nodes
   status = g_ort->SessionGetInputCount(session, &num_input_nodes);
-  std::vector<const char*> input_node_names(num_input_nodes);
+  std::vector<char*> input_node_names(num_input_nodes);
   std::vector<int64_t> input_node_dims;  // simplify... this model has only 1 input node {1, 3, 224, 224}.
                                          // Otherwise need vector<vector<>>
 
@@ -160,6 +160,8 @@ int main(int argc, char* argv[]) {
   // Score for class[3] = 0.001180
   // Score for class[4] = 0.001317
 
+  for (size_t i = 0; i < num_input_nodes; i++)
+    g_ort->AllocatorFree(allocator, input_node_names[i]);
   g_ort->ReleaseValue(output_tensor);
   g_ort->ReleaseValue(input_tensor);
   g_ort->ReleaseSession(session);

--- a/onnxruntime/test/opaque_api/test_opaque_api.cc
+++ b/onnxruntime/test/opaque_api/test_opaque_api.cc
@@ -212,11 +212,11 @@ TEST_F(OpaqueApiTest, RunModelWithOpaqueInputOutput) {
     // Expecting one input
     size_t num_input_nodes = session.GetInputCount();
     EXPECT_EQ(num_input_nodes, 1U);
-    const char* input_name = session.GetInputName(0, allocator);
+    char* input_name = session.GetInputName(0, allocator);
 
     size_t num_output_nodes = session.GetOutputCount();
     EXPECT_EQ(num_output_nodes, 1U);
-    const char* output_name = session.GetOutputName(0, allocator);
+    char* output_name = session.GetOutputName(0, allocator);
 
     const char* const input_names[] = {input_name};
     const char* const output_names[] = {output_name};
@@ -266,6 +266,10 @@ TEST_F(OpaqueApiTest, RunModelWithOpaqueInputOutput) {
     str_tensor_value.GetStringTensorContent(actual_result_string.get(), str_len, &offset, 1);
     actual_result_string[str_len] = 0;
     ASSERT_EQ(expected_output.compare(actual_result_string.get()), 0);
+
+    // Free memory
+    allocator.Free(input_name);
+    allocator.Free(output_name);
   } catch (const std::exception& ex) {
     std::cerr << "Exception: " << ex.what() << std::endl;
     ASSERT_TRUE(false);


### PR DESCRIPTION
Fix memory leak related with GetInputName and GetOutName in samples and tests, these functions would malloc memeory，we should free the memory manually