### PR TITLE
add session creation time cost to onnxruntime_perf_test output

### DIFF
--- a/onnxruntime/test/perftest/performance_runner.h
+++ b/onnxruntime/test/perftest/performance_runner.h
@@ -132,6 +132,8 @@ class PerformanceRunner {
   }
 
  private:
+  std::chrono::time_point<std::chrono::high_resolution_clock> session_create_start_;
+  std::chrono::time_point<std::chrono::high_resolution_clock> session_create_end_;
   PerformanceResult performance_result_;
   PerformanceTestConfig performance_test_config_;
   TestModelInfo* test_model_info_;


### PR DESCRIPTION
-output session creation time cost.
Some EPs can have high session creation times due to initialization/compilation costs. 
it would be useful to track and potentially optimize. 
-rename other time cost as inference time costs, 
-add "s" to Total inference time cost. previously it was missing/inconsistent with other metric outputs.
