### PR TITLE
User/orilevari/32bit comparison warning

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -217,7 +217,7 @@ struct OrtApiBase {
 };
 typedef struct OrtApiBase OrtApiBase;
 
-ORT_EXPORT const OrtApiBase* ORT_API_CALL OrtGetApiBase() NO_EXCEPTION;
+ORT_EXPORT const OrtApiBase* ORT_API_CALL OrtGetApiBase(void) NO_EXCEPTION;
 
 struct OrtApi {
   /**

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -361,7 +361,7 @@ template <>
 inline Value Value::CreateTensor<std::string>(const OrtMemoryInfo*, std::string* p_data, size_t p_data_element_count, const int64_t* shape, size_t shape_len) {
   // convert the array of std::string to an array of const char *
   std::vector<const char*> string_vector;
-  for (int i = 0; i < p_data_element_count; ++i) {
+  for (size_t i = 0; i < p_data_element_count; ++i) {
     string_vector.push_back(p_data[i].c_str());
   }
   // now make an empty tensor using the default allocator (strings have to make a copy)

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1463,7 +1463,7 @@ ORT_API(const char*, OrtApis::GetVersionString) {
   return ORT_VERSION;
 }
 
-const OrtApiBase* ORT_API_CALL OrtGetApiBase() NO_EXCEPTION {
+const OrtApiBase* ORT_API_CALL OrtGetApiBase(void) NO_EXCEPTION {
   return &ort_api_base;
 }
 


### PR DESCRIPTION
**Description**: 
1) explicitly adds void as param in definition of OrtGetApiBase
2) fixes signed/unsigned comparison of size_t to int

**Motivation and Context**
1) Previously there was a compiler warning (C4276) because the OrtGetApiBase was being declared to have an unknown number of arguments and this was forcing the compiler to assume the number of parameters in generated_source.c. This issue was only showing up for x86 builds because this compiler warning is only issued for functions with __stdcall.
2) Causing warnings treated as error for x86 and arm
