### PR TITLE
Filter CPU case for IsFloat16Supported

### DIFF
--- a/winml/lib/Api.Image/DeviceHelpers.cpp
+++ b/winml/lib/Api.Image/DeviceHelpers.cpp
@@ -133,6 +133,9 @@ static HRESULT IsFloat16Blocked(ID3D12Device& device, bool* isBlocked) {
 }
 
 bool IsFloat16Supported(const winrt::Windows::AI::MachineLearning::LearningModelDevice& device) {
+  if (device.AdapterId().HighPart == 0 && device.AdapterId().LowPart == 0) {
+    return true;
+  }
   winrt::com_ptr<ID3D12Device> d3d12Device;
   if (FAILED(GetD3D12Device(device, d3d12Device.put()))) {
     return false;

--- a/winml/lib/Api.Image/DeviceHelpers.cpp
+++ b/winml/lib/Api.Image/DeviceHelpers.cpp
@@ -9,6 +9,7 @@
 #include <d3d11on12.h>
 #include <wil/winrt.h>
 #include "inc/DeviceHelpers.h"
+#include "LearningModelDevice.h"
 
 namespace DeviceHelpers {
 constexpr uint32_t c_intelVendorId = 0x8086;
@@ -133,7 +134,8 @@ static HRESULT IsFloat16Blocked(ID3D12Device& device, bool* isBlocked) {
 }
 
 bool IsFloat16Supported(const winrt::Windows::AI::MachineLearning::LearningModelDevice& device) {
-  if (device.AdapterId().HighPart == 0 && device.AdapterId().LowPart == 0) {
+  auto modelImpl = device.as<winmlp::LearningModelDevice>();
+  if (modelImpl->IsCpuDevice()) {
     return true;
   }
   winrt::com_ptr<ID3D12Device> d3d12Device;


### PR DESCRIPTION
**Description**: Handle CPU devices in IsFloat16Supported(LearningModelDevice). IsFloat16Supported will return true for CPU devices.

**Motivation and Context**
- Although there are no cases currently where IsFloat16Supported would be called with a LearningModelDevicethat was initialized with Cpu or Default, the API should still handle this case to be robust and avoid unintended crashes by potential future callers. Currently it would crash, but now it would just return true.
