### PR TITLE
MLAS: update SGEMM threading parameters

### DIFF
--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -554,21 +554,8 @@ extern "C" {
 // Define the target number of per-thread multiplies before using another
 // thread to perform additional work.
 //
-// The number is derived from performance results running SGEMM across a
-// range of workloads and observing the ideal number of threads to complete
-// that workload.
-//
 
-#if defined(_OPENMP)
 #define MLAS_SGEMM_THREAD_COMPLEXITY                (64 * 1024)
-#else
-#if defined(MLAS_TARGET_AMD64)
-#define MLAS_SGEMM_THREAD_COMPLEXITY                (2 * 1024 * 1024)
-#else
-#define MLAS_SGEMM_THREAD_COMPLEXITY                (1 * 1024 * 1024)
-#endif
-#endif
-
 #define MLAS_DGEMM_THREAD_COMPLEXITY                (64 * 1024)
 
 //


### PR DESCRIPTION
**Description**: Update the defines used to control SGEMM threading.

**Motivation and Context**
The old code was still structured to handle the Win32 thread pool where there was a high cost to starting a new work item, hence the number of items to be fmadd'ed was coarser. This value is no longer appropriate when using the Eigen threadpool. Updated to use the same value as OpenMP which in ad hoc tests yields good performance (certainly better than before). @snnn ran a performance test and most models were neutral (where GEMMs were already large) and a few models were significantly faster (where some GEMMs now use more threads).
