### PR TITLE
Add manifest missing comma

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -446,7 +446,7 @@
             },
             "type": "git"
          }
-      }
+      },
       {
          "component": {
             "git": {


### PR DESCRIPTION
**Description**:  Add missing comma

**Motivation and Context**
3rd party manifest is invalid JSON due to a missing comma
