### PR TITLE
Run static code analyzer on most of our code

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/compliance.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/compliance.yml
@@ -15,8 +15,9 @@ steps:
   displayName: 'Remove prevoius build output'
   inputs:
     SourceFolder:$(Build.BinariesDirectory)\RelWithDebInfo
-    contents: !(*.exe|*.log)
-
+    contents: |
+      !(*.exe|*.log)
+      
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-prefast.SDLNativeRules@2
   displayName: 'Run the PREfast SDL Native Rules for MSBuild'
   continueOnError: true

--- a/tools/ci_build/github/azure-pipelines/templates/compliance.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/compliance.yml
@@ -16,9 +16,9 @@ steps:
   inputs:
     SourceFolder: '$(Build.BinariesDirectory)\RelWithDebInfo'
     Contents: |
-     *.obj
-     *.pdb
-     *.dll
+     **/*.obj
+     **/*.pdb
+     **/*.dll
       
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-prefast.SDLNativeRules@2
   displayName: 'Run the PREfast SDL Native Rules for MSBuild'

--- a/tools/ci_build/github/azure-pipelines/templates/compliance.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/compliance.yml
@@ -12,11 +12,10 @@ steps:
   continueOnError: true
 
 - task: DeleteFiles@1
-  displayName: 'Remove prevoius build output'
+  displayName: 'Delete files from $(Build.BinariesDirectory)\RelWithDebInfo'
   inputs:
-    SourceFolder:$(Build.BinariesDirectory)\RelWithDebInfo
-    contents: |
-      !(*.exe|*.log)
+    SourceFolder: '$(Build.BinariesDirectory)\RelWithDebInfo'
+    Contents: '!(*.exe|*.log)'
       
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-prefast.SDLNativeRules@2
   displayName: 'Run the PREfast SDL Native Rules for MSBuild'

--- a/tools/ci_build/github/azure-pipelines/templates/compliance.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/compliance.yml
@@ -11,6 +11,12 @@ steps:
     arguments: 'analyze $(Build.BinariesDirectory)\RelWithDebInfo\*.dll  --recurse --verbose'
   continueOnError: true
 
+- task: DeleteFiles@1
+  displayName: 'Remove prevoius build output'
+  inputs:
+    SourceFolder:$(Build.BinariesDirectory)\RelWithDebInfo
+    contents: !(*.exe|*.log)
+
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-prefast.SDLNativeRules@2
   displayName: 'Run the PREfast SDL Native Rules for MSBuild'
   continueOnError: true

--- a/tools/ci_build/github/azure-pipelines/templates/compliance.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/compliance.yml
@@ -15,7 +15,10 @@ steps:
   displayName: 'Delete files from $(Build.BinariesDirectory)\RelWithDebInfo'
   inputs:
     SourceFolder: '$(Build.BinariesDirectory)\RelWithDebInfo'
-    Contents: '!(*.exe|*.log)'
+    Contents: |
+     *.obj
+     *.pdb
+     *.dll
       
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-prefast.SDLNativeRules@2
   displayName: 'Run the PREfast SDL Native Rules for MSBuild'

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-2019.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-2019.yml
@@ -84,7 +84,6 @@ jobs:
         logProjectEvents: true
         workingFolder: '$(Build.BinariesDirectory)\RelWithDebInfo'
         createLogFile: true
-        clean: true
 
     # Build RelWithDebInfo -- this variable required to build C#
     - script: |


### PR DESCRIPTION
**Description**: 

Currently it only runs on mlas. We should delete the existing binaries before starting the analyzer.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
