### PR TITLE
Update Ubuntu & TensorRT version  in README

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -80,7 +80,7 @@ Use `docker pull` with any of the images and tags below to pull an image and try
   ```
 
 ## TensorRT
-**Ubuntu 16.04, TensorRT 5.0.2**
+**Ubuntu 18.04, CUDA 10.1.243, TensorRT 6.0.1**
 
 1. Build the docker image from the Dockerfile in this repository.
   ```


### PR DESCRIPTION
**Description**: Describe your changes.
Dockerfile.tensorrt is using nvcr.io/nvidia/tensorrt:19.09-py3 as base Image, update Ubuntu and TensorRT version according to
https://docs.nvidia.com/deeplearning/sdk/tensorrt-container-release-notes/rel_19-09.html#rel_19-09


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
