### PR TITLE
add domain check for nodes before quantization + update documentation

### DIFF
--- a/onnxruntime/python/tools/quantization/README.md
+++ b/onnxruntime/python/tools/quantization/README.md
@@ -1,6 +1,6 @@
 # Quantization tool Overview
 This tool supports 8 bit linear quantization of an onnx model. quantize() takes a model in ModelProto format and returns the quantized model in ModelProto format.
-Today ORT does not guarantee support for E2E model quantization, meaning all ONNX ops do not have support for 8 bit data types therefore only the supported ops in the model are quantized. For rest of the ops inputs are reconverted to FP32.
+Today ORT does not guarantee support for E2E model quantization, meaning since not all ONNX ops have support for 8 bit data types therefore only the supported ops in the model are quantized. For rest of the ops inputs are reconverted to FP32.
 
 List of Supported Quantized Ops:
 The following ops were chosen as phase 1 ops because in most of the CNN models these ops consume most amount of compute and power and therefore there is benefit in quantizing these ops to get perf benefits.
@@ -25,6 +25,21 @@ The following ops were chosen as phase 1 ops because in most of the CNN models t
 
  Zero point represents zero in quantization space. It is important that floating point zero value be exactly representable in quantization space. This is because in lot of CNNs, zero padding is used and if after quantization it is not possible to represent 0 uniquely then it will lead to accuracy errors.
 
+## Quantization and model opset versions
+Quantization is fairly new in ONNX and ONNXRuntime. Quantization ops were introduced in ONNX opset version 10. Therefore it is important that the model which is being quantized be opset 10 or higher. In case the model opset version is < 10 then it is recommended that the model should be reconverted to ONNX from its original framework using the latest opset.
+
+Quantization tool displays a warning when the model opset version is < 10 and still goes ahead and quantizes the model and at the end changes the opset version to 10. It is the responsibility of the model owner to run model checker and make sure the model is valid. If the model is not valid then use the above recommended way i.e. reconvert the model from original framework.
+
+## Quantization and Graph Optimization
+Please note quantization and graph optimizations may not always work together.
+
+### Quantizing an optimized model
+If a model is optimized using level 99 (i.e. all possible optimizations are run on that model) then it is possible that after these optimizations are applied the model is converted in a way that quantization cannot be applied on this model anymore and therefore after running quantization script there will be no change in the model. 
+
+### Optimizing a quantized model
+Same goes other way round. After quantizing a model some graph optimizations which otherwise might have been applicable on this model may not be applicable anymore. 
+
+It is advised that the model owner be aware of this and run perf evaluations to understand which technique gives the best performance for their model.
 
 ## Quantize an ONNX model
 ```python


### PR DESCRIPTION
**Description**: Add a check to verify node's domain along with optype before picking it as a candidate for quantization. Also update the documentation to add more details. 

**Motivation and Context**
- After layout optimization the nodes are converted to Nchwc domain however the node op type remains same (convolution and pooling ops). Since quantization script only checks the op type it tries to quantize nchwc domain node and leaves the model in an erroneous state. This change skips nodes which are not in onnx domain. 

