### PR TITLE
Fixed typo in ORT_RETURN_IF_NOT() message.

### DIFF
--- a/include/onnxruntime/core/common/common.h
+++ b/include/onnxruntime/core/common/common.h
@@ -121,7 +121,7 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 // Check condition. if not met, return status.
 #define ORT_RETURN_IF_NOT(condition, ...)                                                 \
   if (!(condition)) {                                                                     \
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Not satsified: " #condition "\n",          \
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Not satisfied: " #condition "\n",          \
                            ORT_WHERE.ToString(), ::onnxruntime::MakeString(__VA_ARGS__)); \
   }
 


### PR DESCRIPTION
**Description**: Fixed a typo: "satsified" -> "satisfied".

**Motivation and Context**: Correct spelling.