### PR TITLE
update protoc path to match protobuf version

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -391,7 +391,7 @@ The DirectML execution provider supports building for both x64 and x86 architect
 
 ---
 
-### ARM Compute Library 
+### ARM Compute Library
 See more information on the ACL Execution Provider [here](./docs/execution_providers/ACL-ExecutionProvider.md).
 
 #### Prerequisites
@@ -515,7 +515,7 @@ See the instructions for the the Dockerfile [here](./dockerfiles/README.md#arm-3
     ```
 3. Get a pre-compiled protoc:
 
-   You may get it from https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip . Please unzip it after downloading.
+   You may get it from https://github.com/protocolbuffers/protobuf/releases/download/v3.11.2/protoc-3.11.2-linux-x86_64.zip . Please unzip it after downloading.
 4. (optional) Setup sysroot for enabling python extension. (TODO: will add details later)
 5. Save the following content as tool.cmake
     ```


### PR DESCRIPTION
**Description**: Update BUILD.md to point at the matching prebuilt protoc binary corresponding to the version of protobuf used by the project.

**Motivation and Context**
I needed to update my binaries for a cross compilation scenario. Using the binaries from this path allowed the build to continue.