### PR TITLE
Support custom DML in onnxruntime_providers.cmake

### DIFF
--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -431,19 +431,23 @@ if (onnxruntime_USE_DML)
   add_dependencies(onnxruntime_providers_dml ${onnxruntime_EXTERNAL_DEPENDENCIES})
   target_include_directories(onnxruntime_providers_dml PRIVATE ${ONNXRUNTIME_ROOT} ${ONNXRUNTIME_ROOT}/../cmake/external/wil/include)
 
-  if(NOT onnxruntime_target_platform STREQUAL "x86" AND NOT onnxruntime_target_platform STREQUAL "x64")
-    message(FATAL_ERROR "Target platform ${onnxruntime_target_platform} is not supported by DML")
+  if (NOT onnxruntime_USE_CUSTOM_DIRECTML)
+    if(NOT onnxruntime_target_platform STREQUAL "x86" AND NOT onnxruntime_target_platform STREQUAL "x64")
+      message(FATAL_ERROR "Target platform ${onnxruntime_target_platform} is not supported by DML")
+    endif()
+    foreach(file "DirectML.dll" "DirectML.pdb" "DirectML.Debug.dll" "DirectML.Debug.pdb")
+      add_custom_command(TARGET onnxruntime_providers_dml
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          "${DML_PACKAGE_DIR}/bin/${onnxruntime_target_platform}/${file}" $<TARGET_FILE_DIR:onnxruntime_providers_dml>)
+    endforeach()
   endif()
-  foreach(file "DirectML.dll" "DirectML.pdb" "DirectML.Debug.dll" "DirectML.Debug.pdb")
-    add_custom_command(TARGET onnxruntime_providers_dml
-      POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "${DML_PACKAGE_DIR}/bin/${onnxruntime_target_platform}/${file}" $<TARGET_FILE_DIR:onnxruntime_providers_dml>)
-  endforeach()
 
   function(target_add_dml target)
-    target_link_libraries(${target} PRIVATE "${DML_PACKAGE_DIR}/bin/${onnxruntime_target_platform}/DirectML.lib")
-    target_include_directories(${target} PRIVATE "${DML_PACKAGE_DIR}/include")
+    if (NOT onnxruntime_USE_CUSTOM_DIRECTML)
+      target_link_libraries(${target} PRIVATE "${DML_PACKAGE_DIR}/bin/${onnxruntime_target_platform}/DirectML.lib")
+      target_include_directories(${target} PRIVATE "${DML_PACKAGE_DIR}/include")
+    endif()
   endfunction()
 
   target_add_dml(onnxruntime_providers_dml)


### PR DESCRIPTION
**Description**: Skip linking to default DML path if onnxruntime_USE_CUSTOM_DIRECTML is set