### PR TITLE
Do not link onnxruntime jni output with JNI_LIBRARIES

### DIFF
--- a/cmake/onnxruntime_java.cmake
+++ b/cmake/onnxruntime_java.cmake
@@ -54,7 +54,7 @@ file(GLOB onnxruntime4j_native_src
 add_library(onnxruntime4j_jni SHARED ${onnxruntime4j_native_src} ${onnxruntime4j_generated})
 onnxruntime_add_include_to_target(onnxruntime4j_jni onnxruntime_session)
 target_include_directories(onnxruntime4j_jni PRIVATE ${REPO_ROOT}/include ${REPO_ROOT}/java/src/main/native)
-target_link_libraries(onnxruntime4j_jni PUBLIC ${JNI_LIBRARIES} onnxruntime onnxruntime4j_generated)
+target_link_libraries(onnxruntime4j_jni PUBLIC onnxruntime onnxruntime4j_generated)
 
 # Now the jar, jni binary and shared lib binary have been built, now to build the jar with the binaries added.
 


### PR DESCRIPTION
**Description**: Remove unnecessary link with JNI_LIBRARIES

- Linking onnxruntime with JNI_LIBRARIES includes some unnecessary links to native libraries (e.g. libawt) which are not actually used or required by the output onnx library. This causes unsatisfied link exceptions when trying to load the onnx library without including these libraries.

**Motivation and Context**
- Why is this change required? What problem does it solve?

When I tried to build the library locally and tried to use it elsewhere I noticed that it failed due to an unsatisfied link to libawt (and others), upon investigations and looking at other JNI libraries I am using (I used `ldd` command to figure out links), none of them had links to JNI libraries as they are not required (at least in these simple JNI scenarios)

- If it fixes an open issue, please link to the issue here.

N/A (Couldn't find an issue related to this, happy to open one if that's a requirement)