### PR TITLE
Fix exception handling in InferenceSession::Run

### DIFF
--- a/onnxruntime/test/perftest/performance_runner.h
+++ b/onnxruntime/test/perftest/performance_runner.h
@@ -99,7 +99,14 @@ class PerformanceRunner {
 
   template <bool isWarmup>
   Status RunOneIteration() {
-    std::chrono::duration<double> duration_seconds = session_->Run();
+    std::chrono::duration<double> duration_seconds;
+
+    try {
+      duration_seconds = session_->Run();
+    } catch (const std::exception& ex) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "PerformanceRunner::RunOneIteration caught exception: ", ex.what());
+    }
+
     if (!isWarmup) {
       std::lock_guard<std::mutex> guard(results_mutex_);
       performance_result_.time_costs.emplace_back(duration_seconds.count());


### PR DESCRIPTION
**Description**: 
InferenceSession::Run needs to call OnRunEnd for any EP that OnRunStart was called for so they can cleanup. Currently it only calls OnRunEnd if the Status is OK. Due to this, if graph execution failed the CUDA EP will throw during shutdown as the per-thread information has not been cleaned up prior to the CUDA library shutting down.

Also update onnxruntime_perf_test to catch the exception from the call to Run and return a Status. Otherwise it exits with an 'unknown exception' error.

**Motivation and Context**
Whilst the exception from graph execution is gracefully returned as a Status, the issue with OnRunEnd not being called leads to an unhandled exception during shutdown. 