### PR TITLE
Make DML include path global

### DIFF
--- a/cmake/external/dml.cmake
+++ b/cmake/external/dml.cmake
@@ -29,6 +29,7 @@ if (NOT onnxruntime_USE_CUSTOM_DIRECTML)
     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/nuget/src/nuget restore ${PACKAGES_CONFIG} -PackagesDirectory ${PACKAGES_DIR} -ConfigFile ${NUGET_CONFIG}
     VERBATIM)
 
+  include_directories(BEFORE "${DML_PACKAGE_DIR}/include")
   add_custom_target(RESTORE_PACKAGES ALL DEPENDS ${DML_PACKAGE_DIR}/bin/x64/DirectML.lib ${DML_PACKAGE_DIR}/bin/x86/DirectML.lib)
   add_dependencies(RESTORE_PACKAGES nuget)
 else()

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -446,7 +446,6 @@ if (onnxruntime_USE_DML)
   function(target_add_dml target)
     if (NOT onnxruntime_USE_CUSTOM_DIRECTML)
       target_link_libraries(${target} PRIVATE "${DML_PACKAGE_DIR}/bin/${onnxruntime_target_platform}/DirectML.lib")
-      target_include_directories(${target} PRIVATE "${DML_PACKAGE_DIR}/include")
     endif()
   endfunction()
 

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -389,6 +389,7 @@ add_dependencies(winml_lib_common winml_sdk_cppwinrt)
 
 target_include_directories(winml_lib_common PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api)                   # windows machine learning generated component headers
 target_include_directories(winml_lib_common PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api/comp_generated)    # windows machine learning generated component headers
+target_include_directories(winml_lib_common PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml/sdk/cppwinrt/include)  # sdk cppwinrt headers
 target_include_directories(winml_lib_common PRIVATE ${winml_lib_api_dir})
 target_include_directories(winml_lib_common PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 


### PR DESCRIPTION
**Description**: Some projects will `#include` DML without calling `target_add_dml` and either use the system provided one, or fail to compile if the header isn't in the system path.