### PR TITLE
Disable openmp for the nocontribops pipeline.

### DIFF
--- a/tools/ci_build/github/linux/run_build.sh
+++ b/tools/ci_build/github/linux/run_build.sh
@@ -42,7 +42,13 @@ elif [ $BUILD_OS = "yocto" ]; then
     
     make -j$(nproc)
 else
-    COMMON_BUILD_ARGS="--skip_submodule_sync --enable_onnx_tests --parallel --build_shared_lib --use_openmp --cmake_path /usr/bin/cmake --ctest_path /usr/bin/ctest"
+    COMMON_BUILD_ARGS="--skip_submodule_sync --enable_onnx_tests --parallel --build_shared_lib --cmake_path /usr/bin/cmake --ctest_path /usr/bin/ctest"
+    # For the nocontribops pipeline we don't need openmp as it is used by the Edge browser team and
+    # (going forward) the vscode team. Both these teams don't want their users to install any external dependency to use
+    # ORT.
+    if [[ $BUILD_EXTR_PAR != *--disable_contrib_ops* ]]; then
+        COMMON_BUILD_ARGS="${COMMON_BUILD_ARGS} --use_openmp "
+    fi
     if [ $BUILD_OS = "manylinux2010" ]; then
         # FindPython3 does not work on manylinux2010 image, define things manually
         # ask python where to find includes


### PR DESCRIPTION
**Description**: Disable openmp for the nocontribops pipeline.

**Motivation and Context**
The nocontribops pipeline is used by the Edge browser team and (going forward) the vscode team. Both these teams don't want their users to install any external dependency to use ORT.
