### PR TITLE
Disable DML EP on software adapter, fix float16 fallback bug, re-enable DML in CI

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/inc/DmlExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/inc/DmlExecutionProvider.h
@@ -47,9 +47,4 @@ namespace Dml
 
     void RegisterDmlOperators(IMLOperatorRegistry* registry);
 
-    onnxruntime::common::Status RegisterDmlGraphTransformer(
-        onnxruntime::InferenceSession* session, 
-        std::shared_ptr<onnxruntime::KernelRegistry> dmlRegistry
-    );
-
 } // namespace Dml

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -674,6 +674,12 @@ namespace Dml
         return m_areMetacommandsEnabled;
     }
 
+    std::shared_ptr<const winrt::Windows::AI::MachineLearning::implementation::InternalRegistrationInfoMap> 
+    ExecutionProviderImpl::GetInternalRegInfoMap() const
+    {
+        return m_internalRegInfoMap;
+    }
+
     std::shared_ptr<onnxruntime::IAllocator> ExecutionProviderImpl::GetGpuAllocator()
     {
         return m_allocator;
@@ -753,12 +759,6 @@ namespace Dml
     {
         ComPtr<AllocationInfo> allocInfo;
         allocInfo.Attach(static_cast<AllocationInfo*>(ptr));
-    }
-
-    onnxruntime::common::Status RegisterDmlGraphTransformer(onnxruntime::InferenceSession* session, std::shared_ptr<onnxruntime::KernelRegistry> dmlRegistry)
-    {
-        auto graphTransformer = std::make_unique<Dml::GraphTransformer>(std::string(onnxruntime::kDmlExecutionProvider), dmlRegistry);
-        return session->RegisterGraphTransformer(std::move(graphTransformer), onnxruntime::TransformerLevel::Level1);
     }
 
 } // namespace Dml

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -675,7 +675,7 @@ namespace Dml
     }
 
     std::shared_ptr<const winrt::Windows::AI::MachineLearning::implementation::InternalRegistrationInfoMap> 
-    ExecutionProviderImpl::GetInternalRegInfoMap() const
+    ExecutionProviderImpl::GetInternalRegistrationInfoMap() const
     {
         return m_internalRegInfoMap;
     }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
@@ -159,7 +159,7 @@ namespace Dml
         std::shared_ptr<onnxruntime::IAllocator> GetCpuOutputAllocator();
 
         std::shared_ptr<const winrt::Windows::AI::MachineLearning::implementation::InternalRegistrationInfoMap> 
-        GetInternalRegInfoMap() const;
+        GetInternalRegistrationInfoMap() const;
 
     private:
         void Initialize(ID3D12CommandQueue* queue, ExecutionProvider& executionProvider);

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
@@ -158,6 +158,9 @@ namespace Dml
         std::shared_ptr<onnxruntime::IAllocator> GetCpuInputAllocator();
         std::shared_ptr<onnxruntime::IAllocator> GetCpuOutputAllocator();
 
+        std::shared_ptr<const winrt::Windows::AI::MachineLearning::implementation::InternalRegistrationInfoMap> 
+        GetInternalRegInfoMap() const;
+
     private:
         void Initialize(ID3D12CommandQueue* queue, ExecutionProvider& executionProvider);
 
@@ -268,6 +271,11 @@ namespace Dml
         }
         
         ExecutionProviderImpl* GetImpl()
+        {
+            return m_impl.Get();
+        }
+
+        const ExecutionProviderImpl* GetImpl() const
         {
             return m_impl.Get();
         }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphPartitioner.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphPartitioner.cpp
@@ -219,11 +219,14 @@ namespace Dml
 
     bool DoesNodeContainSupportedDataTypes(
         const onnxruntime::Node& node,
-        const std::unordered_map<std::string, GraphPartition*>& nodeNameToPartitionMap,
+        bool allow64BitInputThroughStrides,
+        _In_opt_ const std::unordered_map<std::string, GraphPartition*>* nodeNameToPartitionMap, // Only used when allow64BitInputThroughStrides is true        
         _In_opt_ const InternalRegistrationInfo* regInfo,
         uint32_t supportedDeviceDataTypeMask // Each bit corresponds to each DML_TENSOR_DATA_TYPE.
         )
     {
+        THROW_HR_IF(E_INVALIDARG, allow64BitInputThroughStrides && !nodeNameToPartitionMap);
+
         // Assume data types are supported until proven otherwise.
         bool nodeContainsSupportedDataTypes = true;
 
@@ -249,7 +252,7 @@ namespace Dml
         // Check whether the node uses any data types which are unsupported by the device.
         node.ForEachDef(nodeCallback);
 
-        // DML kernels support int64 and uint64 are expected to not *introduce* values out of range, which allows
+        // DML kernels supporting int64 and uint64 are expected to not *introduce* values out of range, which allows
         // the temporary trick using strides to emulate 64 bit tensors to work.  If the source is a CPU operator, 
         // graph input or initializer, it's not safe to assume the input can be represented with 32 bits.
         if (regInfo)
@@ -265,15 +268,21 @@ namespace Dml
                         // Look up the input partition.  If it's a graph input or initializer it will be missing
                         // from the map.  In this case or if the input comes from a CPU partition, it might be 
                         // out of range.
-                        const std::string& argName = arg->Name();     
-                        auto partitionIter = nodeNameToPartitionMap.find(argName);
-                        if (partitionIter == nodeNameToPartitionMap.end() || !partitionIter->second->IsDmlPartition())
-                        {
-                            // Check if the operator handles the input on the CPU as a constant input
-                            bool isConstantCpuInput = std::find(regInfo->requiredConstantCpuInputs.begin(), regInfo->requiredConstantCpuInputs.end(), i) !=
-                                  regInfo->requiredConstantCpuInputs.end();
+                        const std::string& argName = arg->Name(); 
+                        // Check if the operator handles the input on the CPU as a constant input
+                        bool isConstantCpuInput = std::find(regInfo->requiredConstantCpuInputs.begin(), regInfo->requiredConstantCpuInputs.end(), i) !=
+                                regInfo->requiredConstantCpuInputs.end();
 
-                            if (!isConstantCpuInput)
+                        if (!isConstantCpuInput)
+                        {
+                            if (!allow64BitInputThroughStrides)
+                            {
+                                nodeContainsSupportedDataTypes = false;
+                                break;
+                            }
+
+                            auto partitionIter = nodeNameToPartitionMap->find(argName);
+                            if (partitionIter == nodeNameToPartitionMap->end() || !partitionIter->second->IsDmlPartition())
                             {
                                 nodeContainsSupportedDataTypes = false;
                                 break;
@@ -287,6 +296,45 @@ namespace Dml
         return nodeContainsSupportedDataTypes;
     }
 
+    bool IsNodeSupportedByDml(
+        const onnxruntime::Node& node,    
+        const onnxruntime::KernelRegistry& registry,
+        uint32_t supportedDeviceDataTypeMask, // Each bit corresponds to each DML_TENSOR_DATA_TYPE.
+        const InternalRegistrationInfoMap& internalRegInfoMap,
+
+        bool allow64BitInputThroughStrides,
+        _In_opt_ const std::unordered_map<std::string, GraphPartition*>* nodeNameToPartitionMap
+    )
+    {
+        THROW_HR_IF(E_INVALIDARG, allow64BitInputThroughStrides && !nodeNameToPartitionMap);
+
+        const onnxruntime::KernelCreateInfo* createInfo = registry.TryFindKernel(node, onnxruntime::kDmlExecutionProvider);
+        if (!createInfo)
+        {
+            return false;
+        }
+
+        auto regInfoIter = internalRegInfoMap.find(createInfo->kernel_def.get());
+        std::shared_ptr<InternalRegistrationInfo> internalRegInfo;
+        if (regInfoIter != internalRegInfoMap.end())
+        {
+            internalRegInfo = regInfoIter->second;
+            if (internalRegInfo->supportQuery && !internalRegInfo->supportQuery(node))
+            {
+                return false;
+            }
+        }
+
+        // Check whether the node uses any data types which are unsupported by the device.
+        if (!DoesNodeContainSupportedDataTypes(node, allow64BitInputThroughStrides, nodeNameToPartitionMap, internalRegInfo.get(), supportedDeviceDataTypeMask))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+
     // Gets properties of the registration for a node
     void GetRegistrationProperties(
         const onnxruntime::GraphViewer& graph,
@@ -294,7 +342,7 @@ namespace Dml
         const std::vector<const onnxruntime::KernelRegistry*>& dmlRegistries,
         uint32_t supportedDeviceDataTypeMask, // Each bit corresponds to each DML_TENSOR_DATA_TYPE.
         const InternalRegistrationInfoMap& internalRegInfoMap,
-        const std::unordered_map<std::string, GraphPartition*>& nodeNameToPartitionMap,
+        _In_opt_ const std::unordered_map<std::string, GraphPartition*>* nodeNameToPartitionMap,
         _Inout_ std::unordered_map<const onnxruntime::Node*, GraphNodeProperties>& dmlNodePropertyMap,
         _Inout_ std::unordered_set<std::string>& requiredInitializerMap,
         _Out_ bool* isDmlNode,
@@ -308,27 +356,8 @@ namespace Dml
         // registration.  Determine if that registration supports usage as a graph node.
         for (auto registry : dmlRegistries) 
         {
-            const onnxruntime::KernelCreateInfo* createInfo = registry->TryFindKernel(node, onnxruntime::kDmlExecutionProvider);
-            if (!createInfo)
-            {
-                continue;
-            }
-
-            auto regInfoIter = internalRegInfoMap.find(createInfo->kernel_def.get());
-            std::shared_ptr<InternalRegistrationInfo> internalRegInfo;
-            if (regInfoIter != internalRegInfoMap.end())
-            {
-                internalRegInfo = regInfoIter->second;
-                if (internalRegInfo->supportQuery && !internalRegInfo->supportQuery(node))
-                {
-                    continue;
-                }
-            }
-
-            // Check whether the node uses any data types which are unsupported by the device.
-            bool nodeContainsSupportedDataTypes = DoesNodeContainSupportedDataTypes(node, nodeNameToPartitionMap, internalRegInfo.get(), supportedDeviceDataTypeMask);
-
-            if (nodeContainsSupportedDataTypes)
+            bool allow64BitInputThroughStrides = true;
+            if (IsNodeSupportedByDml(node, *registry, supportedDeviceDataTypeMask, internalRegInfoMap, allow64BitInputThroughStrides, nodeNameToPartitionMap))
             {
                 *isDmlNode = true;
 
@@ -338,39 +367,47 @@ namespace Dml
 
                 // Ensure that shape information is known statically for the inputs and outputs of the node,
                 // which is required for MLGraph compilation.
-                if (internalRegInfo && internalRegInfo->graphNodeFactoryRegistration && 
-                    NodeTensorTypesSupportedInGraph(node, *internalRegInfo))
+                const onnxruntime::KernelCreateInfo* createInfo = registry->TryFindKernel(node, onnxruntime::kDmlExecutionProvider);
+
+                auto regInfoIter = internalRegInfoMap.find(createInfo->kernel_def.get());
+                if (regInfoIter != internalRegInfoMap.end())
                 {
-                    bool requiredCpuInputsConstant = true;
-                    for (uint32_t inputIndex : internalRegInfo->requiredConstantCpuInputs)
+                    auto internalRegInfo = regInfoIter->second;
+
+                    if (internalRegInfo && internalRegInfo->graphNodeFactoryRegistration && 
+                        NodeTensorTypesSupportedInGraph(node, *internalRegInfo))
                     {
-                        if (inputIndex >= node.InputDefs().size() || !node.InputDefs()[inputIndex]->Exists())
+                        bool requiredCpuInputsConstant = true;
+                        for (uint32_t inputIndex : internalRegInfo->requiredConstantCpuInputs)
                         {
-                            continue;
+                            if (inputIndex >= node.InputDefs().size() || !node.InputDefs()[inputIndex]->Exists())
+                            {
+                                continue;
+                            }
+
+                            const onnx::TensorProto* tensor = nullptr;
+                            const std::string& inputName = node.InputDefs()[inputIndex]->Name();
+
+                            if (!graph.GetInitializedTensor(inputName, tensor))
+                            {
+                                requiredCpuInputsConstant = false;
+                                break;
+                            }
+
+                            requiredInitializerMap.insert(inputName);
                         }
 
-                        const onnx::TensorProto* tensor = nullptr;
-                        const std::string& inputName = node.InputDefs()[inputIndex]->Name();
-
-                        if (!graph.GetInitializedTensor(inputName, tensor))
+                        std::optional<uint32_t> requiredInputCount = internalRegInfo->graphNodeFactoryRegistration->requiredInputCount;
+                        if (requiredCpuInputsConstant &&
+                            TryGetStaticInputShapes( node, graphNodeProperty.first->second.inputShapes) &&
+                            !ContainsEmptyDimensions(graphNodeProperty.first->second.inputShapes) &&
+                            TryGetStaticOutputShapes(node, graphNodeProperty.first->second.outputShapes) &&
+                            !ContainsEmptyDimensions(graphNodeProperty.first->second.outputShapes) &&
+                            (requiredInputCount == std::nullopt || *requiredInputCount == node.InputDefs().size()))
                         {
-                            requiredCpuInputsConstant = false;
-                            break;
+                            *isDmlGraphNode = true;
+                             graphNodeProperty.first->second.internalRegInfo = internalRegInfo;
                         }
-
-                        requiredInitializerMap.insert(inputName);
-                    }
-
-                    std::optional<uint32_t> requiredInputCount = internalRegInfo->graphNodeFactoryRegistration->requiredInputCount;
-                    if (requiredCpuInputsConstant &&
-                        TryGetStaticInputShapes( node, graphNodeProperty.first->second.inputShapes) &&
-                        !ContainsEmptyDimensions(graphNodeProperty.first->second.inputShapes) &&
-                        TryGetStaticOutputShapes(node, graphNodeProperty.first->second.outputShapes) &&
-                        !ContainsEmptyDimensions(graphNodeProperty.first->second.outputShapes) &&
-                        (requiredInputCount == std::nullopt || *requiredInputCount == node.InputDefs().size()))
-                    {
-                        *isDmlGraphNode = true;
-                         graphNodeProperty.first->second.internalRegInfo = internalRegInfo;
                     }
                 }
 
@@ -674,7 +711,7 @@ namespace Dml
                 registries,
                 supportedDeviceDataTypeMask,
                 internalRegInfoMap,
-                nodeNameToPartitionMap,
+                &nodeNameToPartitionMap,
                 graphNodePropertyMap,
                 requiredInitializerMap,
                 /*out*/ &isDmlNode,

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphPartitioner.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphPartitioner.h
@@ -60,4 +60,13 @@ namespace Dml
         const std::string& partitionKernelPrefix
     );
 
+    bool IsNodeSupportedByDml(
+        const onnxruntime::Node& node,    
+        const onnxruntime::KernelRegistry& registry,
+        uint32_t supportedDeviceDataTypeMask, // Each bit corresponds to each DML_TENSOR_DATA_TYPE.
+        const winrt::Windows::AI::MachineLearning::implementation::InternalRegistrationInfoMap& internalRegInfoMap,
+        bool allow64BitInputThroughStrides,
+        _In_opt_ const std::unordered_map<std::string, GraphPartition*>* nodeNameToPartitionMap // Only used when allow64BitInputThroughStrides is true
+    );
+
 } // namespace Dml

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphTransformer.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphTransformer.cpp
@@ -5,6 +5,8 @@
 #include "GraphTransformer.h"
 #include "Operators/OperatorRegistration.h"
 #include "Operators/OperatorUtility.h"
+#include "ExecutionProvider.h"
+#include "GraphPartitioner.h"
 #include "core/providers/dml/OperatorAuthorHelper/Attributes.h"
 #include "core/providers/dml/OperatorAuthorHelper/OperatorHelper.h"
 #include "core/providers/dml/OperatorAuthorHelper/OperatorRegistration.h"
@@ -13,9 +15,12 @@
 
 namespace Dml
 {
-    GraphTransformer::GraphTransformer(const std::string& name, std::shared_ptr<onnxruntime::KernelRegistry> dmlRegistry)
+    GraphTransformer::GraphTransformer(
+        const std::string& name, 
+        const onnxruntime::IExecutionProvider* provider
+    )
         : onnxruntime::GraphTransformer(name),
-          m_registry(dmlRegistry)
+          m_providerImpl(static_cast<const ExecutionProvider* >(provider)->GetImpl())
     {
     }
 
@@ -52,6 +57,8 @@ namespace Dml
     
     void GraphTransformer::PerformOperatorFusion(onnxruntime::Graph* graph, bool* modified) const
     {
+        onnxruntime::KernelRegistry* registry = m_providerImpl->GetKernelRegistry().get();
+
         struct NodeToAdd
         {
             std::string name;
@@ -75,7 +82,15 @@ namespace Dml
         {
             // We need to predict whether the nodes will be assigned to the DML transformer by Lotus,
             // which occurs in IExecutionProvider::GetCapability.
-            if (!m_registry->TryFindKernel(node, onnxruntime::kDmlExecutionProvider))
+
+            bool allow64BitInputThroughStrides = false;
+            if (!IsNodeSupportedByDml(
+                node,
+                *registry,
+                m_providerImpl->GetSuppportedDeviceDataTypeMask(),
+                *m_providerImpl->GetInternalRegInfoMap().get(),
+                allow64BitInputThroughStrides,
+                nullptr))
             {
                 // Can't fuse nodes that don't belong to this execution provider
                 continue;
@@ -95,7 +110,7 @@ namespace Dml
 
             // We need to predict whether the nodes will be assigned to the DML transformer by Lotus,
             // which occurs in IExecutionProvider::GetCapability.
-            if (!m_registry->TryFindKernel(outputNode, onnxruntime::kDmlExecutionProvider))
+            if (!registry->TryFindKernel(outputNode, onnxruntime::kDmlExecutionProvider))
             {
                 // Can't fuse nodes that don't belong to this execution provider
                 continue;

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphTransformer.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphTransformer.cpp
@@ -88,7 +88,7 @@ namespace Dml
                 node,
                 *registry,
                 m_providerImpl->GetSuppportedDeviceDataTypeMask(),
-                *m_providerImpl->GetInternalRegInfoMap().get(),
+                *m_providerImpl->GetInternalRegistrationInfoMap().get(),
                 allow64BitInputThroughStrides,
                 nullptr))
             {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphTransformer.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphTransformer.h
@@ -11,12 +11,17 @@
 
 namespace Dml
 {
+    class ExecutionProviderImpl;
+
     // Applies transforms to a Lotus graph. The graph transformer is responsible for setting the execution provider
     // on the graph nodes which DML supports.
     class GraphTransformer : public onnxruntime::GraphTransformer
     {
     public:
-        GraphTransformer(const std::string& name, std::shared_ptr<onnxruntime::KernelRegistry> dmlRegistry);
+        GraphTransformer(
+            const std::string& name, 
+            const onnxruntime::IExecutionProvider* provider
+        );
 
     private:
      onnxruntime::common::Status ApplyImpl(onnxruntime::Graph& graph, bool& modified, int graph_level, const onnxruntime::logging::Logger& logger) const final;
@@ -24,6 +29,8 @@ namespace Dml
     private:
         void PerformOperatorFusion(onnxruntime::Graph* graph, bool* modified) const;
         std::shared_ptr<onnxruntime::KernelRegistry> m_registry;
+        uint32_t m_supportedDataTypeMask = 0;
+        const ExecutionProviderImpl* m_providerImpl = nullptr;
     };
 
 } // namespace Dml

--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -53,14 +53,14 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_DML(ID
 
 bool IsSoftwareAdapter(IDXGIAdapter1* adapter)
 {
-    DXGI_ADAPTER_DESC1 pDesc;
-    adapter->GetDesc1(&pDesc);
+    DXGI_ADAPTER_DESC1 desc;
+    adapter->GetDesc1(&desc);
 
     // see here for documentation on filtering WARP adapter:
     // https://docs.microsoft.com/en-us/windows/desktop/direct3ddxgi/d3d10-graphics-programming-guide-dxgi#new-info-about-enumerating-adapters-for-windows-8
-    auto isBasicRenderDriverVendorId = pDesc.VendorId == 0x1414;
-    auto isBasicRenderDriverDeviceId = pDesc.DeviceId == 0x8c;
-    auto isSoftwareAdapter = pDesc.Flags == DXGI_ADAPTER_FLAG_SOFTWARE;
+    auto isBasicRenderDriverVendorId = desc.VendorId == 0x1414;
+    auto isBasicRenderDriverDeviceId = desc.DeviceId == 0x8c;
+    auto isSoftwareAdapter = desc.Flags == DXGI_ADAPTER_FLAG_SOFTWARE;
     
     return isSoftwareAdapter || (isBasicRenderDriverVendorId && isBasicRenderDriverDeviceId);
 }

--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -12,6 +12,8 @@ using Microsoft::WRL::ComPtr;
 
 #include "core/providers/dml/dml_provider_factory.h"
 #include "core/session/abi_session_options_impl.h"
+#include "core/session/ort_apis.h"
+#include "core/framework/error_code_helper.h"
 #include "DmlExecutionProvider/inc/DmlExecutionProvider.h"
 
 namespace onnxruntime {
@@ -49,12 +51,29 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_DML(ID
   return std::make_shared<onnxruntime::DMLProviderFactory>(dml_device, cmd_queue);
 }
 
+bool IsSoftwareAdapter(IDXGIAdapter1* adapter)
+{
+    DXGI_ADAPTER_DESC1 pDesc;
+    adapter->GetDesc1(&pDesc);
+
+    // see here for documentation on filtering WARP adapter:
+    // https://docs.microsoft.com/en-us/windows/desktop/direct3ddxgi/d3d10-graphics-programming-guide-dxgi#new-info-about-enumerating-adapters-for-windows-8
+    auto isBasicRenderDriverVendorId = pDesc.VendorId == 0x1414;
+    auto isBasicRenderDriverDeviceId = pDesc.DeviceId == 0x8c;
+    auto isSoftwareAdapter = pDesc.Flags == DXGI_ADAPTER_FLAG_SOFTWARE;
+    
+    return isSoftwareAdapter || (isBasicRenderDriverVendorId && isBasicRenderDriverDeviceId);
+}
+
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_DML(int device_id) {
   ComPtr<IDXGIFactory4> dxgi_factory;
   THROW_IF_FAILED(CreateDXGIFactory2(0, IID_PPV_ARGS(&dxgi_factory)));
 
   ComPtr<IDXGIAdapter1> adapter;
   THROW_IF_FAILED(dxgi_factory->EnumAdapters1(device_id, &adapter));
+
+  // Disallow using DML with the software adapter (Microsoft Basic Display Adapter) because CPU evaluations are much faster
+  THROW_HR_IF(E_INVALIDARG, IsSoftwareAdapter(adapter.Get()));
 
   ComPtr<ID3D12Device> d3d12_device;
   THROW_IF_FAILED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&d3d12_device)));
@@ -91,13 +110,17 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_DML(in
 }  // namespace onnxruntime
 
 ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProvider_DML, _In_ OrtSessionOptions* options, int device_id) {
+API_IMPL_BEGIN
   options->provider_factories.push_back(onnxruntime::CreateExecutionProviderFactory_DML(device_id));
+API_IMPL_END
   return nullptr;
 }
 
 ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProviderEx_DML, _In_ OrtSessionOptions* options,
                     IDMLDevice* dml_device, ID3D12CommandQueue* cmd_queue) {
+API_IMPL_BEGIN
   options->provider_factories.push_back(onnxruntime::CreateExecutionProviderFactory_DML(dml_device,
                                                                                         cmd_queue));
+API_IMPL_END
   return nullptr;
 }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -588,8 +588,7 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph,
   // To prevent this from interfering with other EPs, we only apply this transform if the DML EP is the only one that's
   // registered (aside from the CPU EP, which is always registered by default.)
   if (execution_providers_.Get(kDmlExecutionProvider) && execution_providers_.NumProviders() <= 2) {
-    auto dml_registry = execution_providers_.Get(kDmlExecutionProvider)->GetKernelRegistry();
-    Dml::GraphTransformer dml_transformer(onnxruntime::kDmlExecutionProvider, std::move(dml_registry));
+    Dml::GraphTransformer dml_transformer(onnxruntime::kDmlExecutionProvider, execution_providers_.Get(kDmlExecutionProvider));
 
     bool modified = false;
     dml_transformer.Apply(graph, modified, *session_logger_);

--- a/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
@@ -42,7 +42,7 @@ jobs:
     displayName: 'Generate cmake config'
     inputs:
       scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-      arguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --update --cmake_generator "Visual Studio 16 2019" --msvc_toolset 14.16 --build_wheel --use_featurizers --use_dnnl --build_shared_lib --enable_onnx_tests --use_cuda --cuda_version=10.0 --cuda_home="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.6.5.32\cuda" --cmake_extra_defines CMAKE_SYSTEM_VERSION=10.0.18362.0'
+      arguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --update --cmake_generator "Visual Studio 16 2019" --msvc_toolset 14.16 --build_wheel --use_featurizers --use_dnnl --build_shared_lib --enable_onnx_tests --use_dml --use_cuda --cuda_version=10.0 --cuda_home="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.6.5.32\cuda" --cmake_extra_defines CMAKE_SYSTEM_VERSION=10.0.18362.0'
       workingDirectory: '$(Build.BinariesDirectory)'
 
   - task: VSBuild@1
@@ -116,7 +116,7 @@ jobs:
      del wheel_filename_file
      python.exe -m pip install -q --upgrade %WHEEL_FILENAME%
      set PATH=$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig);%PATH%
-     python $(Build.SourcesDirectory)\tools\ci_build\build.py --config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --test --cmake_generator "Visual Studio 16 2019" --msvc_toolset 14.16 --build_wheel --use_featurizers --use_dnnl --build_shared_lib --enable_onnx_tests --use_cuda --cuda_version=10.0 --cuda_home="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.6.5.32\cuda" --cmake_extra_defines CMAKE_SYSTEM_VERSION=10.0.18362.0
+     python $(Build.SourcesDirectory)\tools\ci_build\build.py --config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --test --cmake_generator "Visual Studio 16 2019" --msvc_toolset 14.16 --build_wheel --use_featurizers --use_dnnl --build_shared_lib --enable_onnx_tests --use_dml --use_cuda --cuda_version=10.0 --cuda_home="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0" --cudnn_home="C:\local\cudnn-10.0-windows10-x64-v7.6.5.32\cuda" --cmake_extra_defines CMAKE_SYSTEM_VERSION=10.0.18362.0
    
     workingDirectory: '$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)'
     displayName: 'Run tests'


### PR DESCRIPTION
DML was previously disabled in the CI when VMs were transitioned.  It's believed the failures and timeouts were caused by the software adapter being temporarily used.

Private runs don't reproduce the issue, but did hit a couple of new FP16 model failures.  Using the older GPU appears to expose a DML EP bug with float16 fallback for some models (the fp16 tests are already disabled on CUDA).

This change:
1) Fixes the issue with float16 fallback by using the correct logic to predict partitioning when deciding whether to do DML graph fusions.  Note, the whole approach of doing graph transforms prior to partitioning is temporary.  This will eventually be done during creation of the partition kernel on a mutable subgraph.
2) Disables DML EP from being used on the software adapter, like Winml.  It's much faster to use the CPU EP.
3) Re-enables DML in the CI
