### PR TITLE
Make winml_test_common free of test macros

### DIFF
--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -59,9 +59,16 @@ add_dependencies(winml_test_common
   winml_api
   winml_dll
 )
-target_compile_definitions(winml_test_common PRIVATE BUILD_GOOGLE_TEST)
-set_winml_target_properties(winml_test_common)
 
+# if using google test, include google test specific definitions
+if(NOT winml_NO_GOOGLE_TEST)
+  target_compile_definitions(winml_test_common PRIVATE BUILD_GOOGLE_TEST)
+  target_sources(winml_test_common PRIVATE ${WINML_TEST_SRC_DIR}/common/googletest/main.cpp)
+else()
+  target_compile_definitions(winml_test_common PRIVATE ${winml_TEST_TYPE})
+endif()
+
+set_winml_target_properties(winml_test_common)
 file(GLOB winml_test_api_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/api/*.cpp")
 add_winml_test(
   TARGET winml_test_api

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -62,7 +62,7 @@ add_dependencies(winml_test_common
 
 set_winml_target_properties(winml_test_common)
 file(GLOB winml_test_api_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/api/*.cpp")
-# set global variable for the scenario source list for other test cmake files to use
+# set global variable for the api test source list for other test cmake files to use
 set(winml_test_api_src_list ${winml_test_api_src} PARENT_SCOPE)
 add_winml_test(
   TARGET winml_test_api
@@ -74,7 +74,7 @@ target_precompiled_header(winml_test_api testPch.h)
 
 if (onnxruntime_USE_DML)
   file(GLOB winml_test_scenario_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/*.cpp")
-  # set global variable for the scenario source list for other test cmake files to use
+  # set global variable for the scenario test source list for other test cmake files to use
   set(winml_test_scenario_src_list ${winml_test_scenario_src} PARENT_SCOPE)
   set(winml_test_scenario_libs "onnxruntime_providers_dml")
 else()

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -36,7 +36,7 @@ function(add_winml_test)
     list(REMOVE_DUPLICATES _UT_DEPENDS)
   endif()
 
-  add_executable(${_UT_TARGET} ${_UT_SOURCES})
+  add_executable(${_UT_TARGET} ${_UT_SOURCES} ${WINML_TEST_SRC_DIR}/common/googletest/main.cpp)
   source_group(TREE ${WINML_TEST_SRC_DIR} FILES ${_UT_SOURCES})
   set_winml_target_properties(${_UT_TARGET})
 
@@ -60,16 +60,10 @@ add_dependencies(winml_test_common
   winml_dll
 )
 
-# if using google test, include google test specific definitions
-if(NOT winml_NO_GOOGLE_TEST)
-  target_compile_definitions(winml_test_common PRIVATE BUILD_GOOGLE_TEST)
-  target_sources(winml_test_common PRIVATE ${WINML_TEST_SRC_DIR}/common/googletest/main.cpp)
-else()
-  target_compile_definitions(winml_test_common PRIVATE ${winml_TEST_TYPE})
-endif()
-
 set_winml_target_properties(winml_test_common)
 file(GLOB winml_test_api_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/api/*.cpp")
+# set global variable for the scenario source list for other test cmake files to use
+set(winml_test_api_src_list ${winml_test_api_src} PARENT_SCOPE)
 add_winml_test(
   TARGET winml_test_api
   SOURCES ${winml_test_api_src}
@@ -80,6 +74,8 @@ target_precompiled_header(winml_test_api testPch.h)
 
 if (onnxruntime_USE_DML)
   file(GLOB winml_test_scenario_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/*.cpp")
+  # set global variable for the scenario source list for other test cmake files to use
+  set(winml_test_scenario_src_list ${winml_test_scenario_src} PARENT_SCOPE)
   set(winml_test_scenario_libs "onnxruntime_providers_dml")
 else()
   set(winml_test_scenario_src "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/scenariotestscppwinrt.cpp")

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -36,14 +36,14 @@ function(add_winml_test)
     list(REMOVE_DUPLICATES _UT_DEPENDS)
   endif()
 
-  add_executable(${_UT_TARGET} ${_UT_SOURCES} ${WINML_TEST_SRC_DIR}/common/googletest/main.cpp)
+  add_executable(${_UT_TARGET} ${_UT_SOURCES})
   source_group(TREE ${WINML_TEST_SRC_DIR} FILES ${_UT_SOURCES})
   set_winml_target_properties(${_UT_TARGET})
 
   if (_UT_DEPENDS)
     add_dependencies(${_UT_TARGET} ${_UT_DEPENDS})
   endif()
-  target_link_libraries(${_UT_TARGET} PRIVATE ${_UT_LIBS} gtest ${onnxruntime_EXTERNAL_LIBRARIES} winml_lib_common onnxruntime)
+  target_link_libraries(${_UT_TARGET} PRIVATE ${_UT_LIBS} gtest winml_google_test_lib ${onnxruntime_EXTERNAL_LIBRARIES} winml_lib_common onnxruntime)
 
   add_test(NAME ${_UT_TARGET}
     COMMAND ${_UT_TARGET}
@@ -81,6 +81,9 @@ add_dependencies(winml_test_common
   winml_api
   winml_dll
 )
+
+add_library(winml_google_test_lib STATIC ${WINML_TEST_SRC_DIR}/common/googletest/main.cpp)
+set_winml_target_properties(winml_google_test_lib)
 
 set_winml_target_properties(winml_test_common)
 get_winml_test_api_src(${REPO_ROOT} winml_test_api_src)

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -58,6 +58,7 @@ function(get_winml_test_scenario_src
   set(WINML_TEST_SRC_DIR ${lotus_root_dir}/winml/test)
   if (onnxruntime_USE_DML)
     file(GLOB winml_test_scenario_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/*.cpp")
+    set(winml_test_scenario_libs "onnxruntime_providers_dml" PARENT_SCOPE)
   else()
     set(winml_test_scenario_src "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/scenariotestscppwinrt.cpp")
   endif()

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -52,13 +52,12 @@ function(add_winml_test)
 endfunction()
 
 function(get_winml_test_scenario_src
-  lotus_root_dir
   output_winml_test_scenario_src
+  output_winml_test_scenario_libs
 )
-  set(WINML_TEST_SRC_DIR ${lotus_root_dir}/winml/test)
   if (onnxruntime_USE_DML)
     file(GLOB winml_test_scenario_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/*.cpp")
-    set(winml_test_scenario_libs "onnxruntime_providers_dml" PARENT_SCOPE)
+    set(${output_winml_test_scenario_libs} "onnxruntime_providers_dml" PARENT_SCOPE)
   else()
     set(winml_test_scenario_src "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/scenariotestscppwinrt.cpp")
   endif()
@@ -66,10 +65,8 @@ function(get_winml_test_scenario_src
 endfunction()
 
 function(get_winml_test_api_src
-  lotus_root_dir
   output_winml_test_api_src
 )
-  set(WINML_TEST_SRC_DIR ${lotus_root_dir}/winml/test)
   file(GLOB winml_test_api_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/api/*.cpp")
   set(${output_winml_test_api_src} ${winml_test_api_src} PARENT_SCOPE)
 endfunction()
@@ -86,7 +83,7 @@ add_library(winml_google_test_lib STATIC ${WINML_TEST_SRC_DIR}/common/googletest
 set_winml_target_properties(winml_google_test_lib)
 
 set_winml_target_properties(winml_test_common)
-get_winml_test_api_src(${REPO_ROOT} winml_test_api_src)
+get_winml_test_api_src(winml_test_api_src)
 add_winml_test(
   TARGET winml_test_api
   SOURCES ${winml_test_api_src}
@@ -95,7 +92,7 @@ add_winml_test(
 target_compile_definitions(winml_test_api PRIVATE BUILD_GOOGLE_TEST)
 target_precompiled_header(winml_test_api testPch.h)
 
-get_winml_test_scenario_src(${REPO_ROOT} winml_test_scenario_src)
+get_winml_test_scenario_src(winml_test_scenario_src winml_test_scenario_libs)
 add_winml_test(
   TARGET winml_test_scenario
   SOURCES ${winml_test_scenario_src}

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -51,6 +51,27 @@ function(add_winml_test)
   )
 endfunction()
 
+function(get_winml_test_scenario_src
+  lotus_root_dir
+  output_winml_test_scenario_src
+)
+  set(WINML_TEST_SRC_DIR ${lotus_root_dir}/winml/test)
+  if (onnxruntime_USE_DML)
+    file(GLOB winml_test_scenario_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/*.cpp")
+  else()
+    set(winml_test_scenario_src "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/scenariotestscppwinrt.cpp")
+  endif()
+  set(${output_winml_test_scenario_src} ${winml_test_scenario_src} PARENT_SCOPE)
+endfunction()
+
+function(get_winml_test_api_src
+  lotus_root_dir
+  output_winml_test_api_src
+)
+  set(WINML_TEST_SRC_DIR ${lotus_root_dir}/winml/test)
+  file(GLOB winml_test_api_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/api/*.cpp")
+  set(${output_winml_test_api_src} ${winml_test_api_src} PARENT_SCOPE)
+endfunction()
 
 file(GLOB winml_test_common_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/common/*.cpp")
 add_library(winml_test_common STATIC ${winml_test_common_src})
@@ -61,9 +82,7 @@ add_dependencies(winml_test_common
 )
 
 set_winml_target_properties(winml_test_common)
-file(GLOB winml_test_api_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/api/*.cpp")
-# set global variable for the api test source list for other test cmake files to use
-set(winml_test_api_src_list ${winml_test_api_src} PARENT_SCOPE)
+get_winml_test_api_src(${REPO_ROOT} winml_test_api_src)
 add_winml_test(
   TARGET winml_test_api
   SOURCES ${winml_test_api_src}
@@ -72,14 +91,7 @@ add_winml_test(
 target_compile_definitions(winml_test_api PRIVATE BUILD_GOOGLE_TEST)
 target_precompiled_header(winml_test_api testPch.h)
 
-if (onnxruntime_USE_DML)
-  file(GLOB winml_test_scenario_src CONFIGURE_DEPENDS "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/*.cpp")
-  # set global variable for the scenario test source list for other test cmake files to use
-  set(winml_test_scenario_src_list ${winml_test_scenario_src} PARENT_SCOPE)
-  set(winml_test_scenario_libs "onnxruntime_providers_dml")
-else()
-  set(winml_test_scenario_src "${WINML_TEST_SRC_DIR}/scenario/cppwinrt/scenariotestscppwinrt.cpp")
-endif()
+get_winml_test_scenario_src(${REPO_ROOT} winml_test_scenario_src)
 add_winml_test(
   TARGET winml_test_scenario
   SOURCES ${winml_test_scenario_src}

--- a/winml/test/api/LearningModelBindingAPITest.cpp
+++ b/winml/test/api/LearningModelBindingAPITest.cpp
@@ -40,7 +40,7 @@ static void CpuSqueezeNetEmptyOutputs()
             /*dataTolerance*/ 0.00001f,
             false,
             OutputBindingStrategy::Empty);
-    )
+    );
 }
 
 static void CpuSqueezeNetUnboundOutputs()
@@ -53,7 +53,7 @@ static void CpuSqueezeNetUnboundOutputs()
             /*dataTolerance*/ 0.00001f,
             false,
             OutputBindingStrategy::Unbound);
-    )
+    );
 }
 
 static void CpuSqueezeNetBindInputTensorAsInspectable()
@@ -67,7 +67,7 @@ static void CpuSqueezeNetBindInputTensorAsInspectable()
             false,
             OutputBindingStrategy::Bound /* empty outputs */,
             true /* bind inputs as inspectables */);
-    )
+    );
 }
 
 static void CastMapInt64()
@@ -310,7 +310,7 @@ static void GpuSqueezeNet()
             gpuInstance,
             LearningModelDeviceKind::DirectX,
             /*dataTolerance*/ 0.00001f);
-    )
+    );
 }
 
 static void GpuSqueezeNetEmptyOutputs()
@@ -323,7 +323,7 @@ static void GpuSqueezeNetEmptyOutputs()
             /*dataTolerance*/ 0.00001f,
             false,
             OutputBindingStrategy::Empty);
-    )
+    );
 }
 
 static void GpuSqueezeNetUnboundOutputs()
@@ -336,7 +336,7 @@ static void GpuSqueezeNetUnboundOutputs()
             /*dataTolerance*/ 0.00001f,
             false,
             OutputBindingStrategy::Unbound);
-    )
+    );
 }
 
 // Validates that when the input image is the same as the model expects, the binding step is executed correctly.

--- a/winml/test/api/LearningModelBindingAPITest.cpp
+++ b/winml/test/api/LearningModelBindingAPITest.cpp
@@ -27,41 +27,47 @@ static void LearningModelBindingAPITestGpuSetup() {
 static void CpuSqueezeNet()
 {
     std::string cpuInstance("CPU");
-    WinML::Engine::Test::ModelValidator::SqueezeNet(cpuInstance, LearningModelDeviceKind::Cpu, /*dataTolerance*/ 0.00001f, false);
+    WINML_EXPECT_NO_THROW(WinML::Engine::Test::ModelValidator::SqueezeNet(cpuInstance, LearningModelDeviceKind::Cpu, /*dataTolerance*/ 0.00001f, false));
 }
 
 static void CpuSqueezeNetEmptyOutputs()
 {
     std::string cpuInstance("CPU");
-    WinML::Engine::Test::ModelValidator::SqueezeNet(
-        cpuInstance,
-        LearningModelDeviceKind::Cpu,
-        /*dataTolerance*/ 0.00001f,
-        false,
-        OutputBindingStrategy::Empty);
+    WINML_EXPECT_NO_THROW(
+        WinML::Engine::Test::ModelValidator::SqueezeNet(
+            cpuInstance,
+            LearningModelDeviceKind::Cpu,
+            /*dataTolerance*/ 0.00001f,
+            false,
+            OutputBindingStrategy::Empty);
+    )
 }
 
 static void CpuSqueezeNetUnboundOutputs()
 {
     std::string cpuInstance("CPU");
-    WinML::Engine::Test::ModelValidator::SqueezeNet(
-        cpuInstance,
-        LearningModelDeviceKind::Cpu,
-        /*dataTolerance*/ 0.00001f,
-        false,
-        OutputBindingStrategy::Unbound);
+    WINML_EXPECT_NO_THROW(
+        WinML::Engine::Test::ModelValidator::SqueezeNet(
+            cpuInstance,
+            LearningModelDeviceKind::Cpu,
+            /*dataTolerance*/ 0.00001f,
+            false,
+            OutputBindingStrategy::Unbound);
+    )
 }
 
 static void CpuSqueezeNetBindInputTensorAsInspectable()
 {
     std::string cpuInstance("CPU");
-    WinML::Engine::Test::ModelValidator::SqueezeNet(
-        cpuInstance,
-        LearningModelDeviceKind::Cpu,
-        /*dataTolerance*/ 0.00001f,
-        false,
-        OutputBindingStrategy::Bound /* empty outputs */,
-        true /* bind inputs as inspectables */);
+    WINML_EXPECT_NO_THROW(
+        WinML::Engine::Test::ModelValidator::SqueezeNet(
+            cpuInstance,
+            LearningModelDeviceKind::Cpu,
+            /*dataTolerance*/ 0.00001f,
+            false,
+            OutputBindingStrategy::Bound /* empty outputs */,
+            true /* bind inputs as inspectables */);
+    )
 }
 
 static void CastMapInt64()
@@ -299,32 +305,38 @@ static void ZipMapString()
 static void GpuSqueezeNet()
 {
     std::string gpuInstance("GPU");
-    WinML::Engine::Test::ModelValidator::SqueezeNet(
-        gpuInstance,
-        LearningModelDeviceKind::DirectX,
-        /*dataTolerance*/ 0.00001f);
+    WINML_EXPECT_NO_THROW(
+        WinML::Engine::Test::ModelValidator::SqueezeNet(
+            gpuInstance,
+            LearningModelDeviceKind::DirectX,
+            /*dataTolerance*/ 0.00001f);
+    )
 }
 
 static void GpuSqueezeNetEmptyOutputs()
 {
     std::string gpuInstance("GPU");
-    WinML::Engine::Test::ModelValidator::SqueezeNet(
-        gpuInstance,
-        LearningModelDeviceKind::DirectX,
-        /*dataTolerance*/ 0.00001f,
-        false,
-        OutputBindingStrategy::Empty);
+    WINML_EXPECT_NO_THROW(
+        WinML::Engine::Test::ModelValidator::SqueezeNet(
+            gpuInstance,
+            LearningModelDeviceKind::DirectX,
+            /*dataTolerance*/ 0.00001f,
+            false,
+            OutputBindingStrategy::Empty);
+    )
 }
 
 static void GpuSqueezeNetUnboundOutputs()
 {
     std::string gpuInstance("GPU");
-    WinML::Engine::Test::ModelValidator::SqueezeNet(
-        gpuInstance,
-        LearningModelDeviceKind::DirectX,
-        /*dataTolerance*/ 0.00001f,
-        false,
-        OutputBindingStrategy::Unbound);
+    WINML_EXPECT_NO_THROW(
+        WinML::Engine::Test::ModelValidator::SqueezeNet(
+            gpuInstance,
+            LearningModelDeviceKind::DirectX,
+            /*dataTolerance*/ 0.00001f,
+            false,
+            OutputBindingStrategy::Unbound);
+    )
 }
 
 // Validates that when the input image is the same as the model expects, the binding step is executed correctly.

--- a/winml/test/common/SqueezeNetValidator.cpp
+++ b/winml/test/common/SqueezeNetValidator.cpp
@@ -279,10 +279,10 @@ void ModelValidator::SqueezeNet(
         float delta = std::abs(outDataActual.GetAt(i) - outDataExpected.GetAt(i));
         if (delta > dataTolerance)
         {
-          std::stringstream ss;
+          std::wstringstream ss;
           ss << "EXPECTED: " << outDataExpected.GetAt(i) << " , ACTUAL: " << outDataActual.GetAt(i)
-                << "instance " << instance << ", element " << i;
-          throw winrt::hresult_error(E_UNEXPECTED, std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(ss.str()));
+                << "instance " << instance.c_str() << ", element " << i;
+          throw winrt::hresult_error(E_UNEXPECTED, ss.str());
         }
     }
 }

--- a/winml/test/common/SqueezeNetValidator.cpp
+++ b/winml/test/common/SqueezeNetValidator.cpp
@@ -263,7 +263,7 @@ void ModelValidator::SqueezeNet(
     {
         if (result.Outputs().Lookup(outputDataBindingName) != outputTensor)
         {
-            throw winrt::hresult_invalid_argument(L"Evaluation Results lookup don't match LearningModelBinding output tensor.");
+          throw winrt::hresult_error(E_UNEXPECTED, L"Evaluation Results lookup don't match LearningModelBinding output tensor.");
         }
     }
 
@@ -272,7 +272,7 @@ void ModelValidator::SqueezeNet(
 
     if (outDataActual.Size() != outDataExpected.Size())
     {
-      throw winrt::hresult_invalid_argument(L"Actual tensor data size doesn't match expected tensor data size.");
+      throw winrt::hresult_error(E_UNEXPECTED, L"Actual tensor data size doesn't match expected tensor data size.");
     }
     for (uint32_t i = 0; i < outDataActual.Size(); i++)
     {
@@ -282,7 +282,7 @@ void ModelValidator::SqueezeNet(
           std::stringstream ss;
           ss << "EXPECTED: " << outDataExpected.GetAt(i) << " , ACTUAL: " << outDataActual.GetAt(i)
                 << "instance " << instance << ", element " << i;
-          throw winrt::hresult_invalid_argument(std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(ss.str()));
+          throw winrt::hresult_error(E_UNEXPECTED, std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(ss.str()));
         }
     }
 }

--- a/winml/test/common/googletest/main.cpp
+++ b/winml/test/common/googletest/main.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <unordered_map>
-#include <gtest/gtest.h>
+#include "test.h"
 
 #include "runtimeParameters.h"
 

--- a/winml/test/common/googletest/main.cpp
+++ b/winml/test/common/googletest/main.cpp
@@ -1,52 +1,44 @@
+#include "testPch.h"
 #include <iostream>
 #include <unordered_map>
 #include <gtest/gtest.h>
 
 #include "runtimeParameters.h"
 
-namespace RuntimeParameters
-{
-    std::unordered_map<std::string, std::string> Parameters;
+namespace RuntimeParameters {
+std::unordered_map<std::string, std::string> Parameters;
 }
 
-namespace
-{
-    void usage(char **argv, int failedArgument)
-    {
-        std::cerr << "Unrecognized argument: " << argv[failedArgument] << "\n"
+namespace {
+void usage(char** argv, int failedArgument) {
+  std::cerr << "Unrecognized argument: " << argv[failedArgument] << "\n"
             << "Usage:\n\t"
             << argv[0] << " [/p:parameterName=parameterValue ...]\n";
-    }
-
-    bool parseArgument(const std::string& argument)
-    {
-        if (argument.rfind("/p:", 0) == 0)
-        {
-            // Parse argument in the form of /p:parameterName=parameterValue
-            auto separatorIndex = argument.find('=');
-            if (separatorIndex == std::string::npos || separatorIndex == 3)
-            {
-                return false;
-            }
-            auto parameterName = argument.substr(3, separatorIndex - 3);
-            auto parameterValue = argument.substr(separatorIndex + 1);
-            RuntimeParameters::Parameters[parameterName] = parameterValue;
-            return true;
-        }
-        return false;
-    }
 }
 
-int main(int argc, char **argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    for (int i = 1; i < argc; i++)
-    {
-        if (!parseArgument(argv[i]))
-        {
-            usage(argv, i);
-            return -1;
-        }
+bool parseArgument(const std::string& argument) {
+  if (argument.rfind("/p:", 0) == 0) {
+    // Parse argument in the form of /p:parameterName=parameterValue
+    auto separatorIndex = argument.find('=');
+    if (separatorIndex == std::string::npos || separatorIndex == 3) {
+      return false;
     }
-    return RUN_ALL_TESTS();
+    auto parameterName = argument.substr(3, separatorIndex - 3);
+    auto parameterValue = argument.substr(separatorIndex + 1);
+    RuntimeParameters::Parameters[parameterName] = parameterValue;
+    return true;
+  }
+  return false;
+}
+}  // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  for (int i = 1; i < argc; i++) {
+    if (!parseArgument(argv[i])) {
+      usage(argv, i);
+      return -1;
+    }
+  }
+  return RUN_ALL_TESTS();
 }

--- a/winml/test/common/googletest/main.cpp
+++ b/winml/test/common/googletest/main.cpp
@@ -1,4 +1,3 @@
-#include "testPch.h"
 #include <iostream>
 #include <unordered_map>
 #include <gtest/gtest.h>

--- a/winml/test/common/googletest/main.cpp
+++ b/winml/test/common/googletest/main.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <unordered_map>
-#include "test.h"
+#include <gtest/gtest.h>
 
 #include "runtimeParameters.h"
 

--- a/winml/test/common/protobufHelpers.cpp
+++ b/winml/test/common/protobufHelpers.cpp
@@ -1,8 +1,4 @@
-﻿#ifndef _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
-#define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
-#endif
-
-// LotusRT
+﻿// LotusRT
 #include "core/framework/allocatormgr.h"
 #include "core/common/logging/logging.h"
 #include "core/common/logging/sinks/clog_sink.h"

--- a/winml/test/common/protobufHelpers.cpp
+++ b/winml/test/common/protobufHelpers.cpp
@@ -1,4 +1,8 @@
-﻿// LotusRT
+﻿#ifndef _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
+#define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
+#endif
+
+// LotusRT
 #include "core/framework/allocatormgr.h"
 #include "core/common/logging/logging.h"
 #include "core/common/logging/sinks/clog_sink.h"

--- a/winml/test/common/std.h
+++ b/winml/test/common/std.h
@@ -31,7 +31,3 @@
 
 // WinML
 #include "Windows.AI.MachineLearning.Native.h"
-
-#ifndef _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
-#define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
-#endif

--- a/winml/test/common/std.h
+++ b/winml/test/common/std.h
@@ -31,3 +31,7 @@
 
 // WinML
 #include "Windows.AI.MachineLearning.Native.h"
+
+#ifndef _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
+#define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
+#endif

--- a/winml/test/scenario/cppwinrt/CustomOps.cpp
+++ b/winml/test/scenario/cppwinrt/CustomOps.cpp
@@ -4,7 +4,6 @@
 #include <dxgi1_6.h>
 #include "filehelpers.h"
 #include <fstream>
-#include "SqueezeNetValidator.h"
 #include <winrt/Windows.Graphics.Imaging.h>
 #include <winrt/Windows.Media.h>
 #include "winrt/Windows.Storage.h"


### PR DESCRIPTION
This change makes winml_test_common free of any test macros so that this static library can be used across different testing frameworks.