### PR TITLE
Fix conformance test failures caused by constant folding and shape to initializer

### DIFF
--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -43,6 +43,7 @@ Status ConstantFolding::ApplyImpl(Graph& graph, bool& modified, int graph_level,
         // such as If/Loop/Scan, fall into this category). individual nodes in the subgraph will be processed
         // by the Recurse call above
         node->ContainsSubgraph() ||
+        !graph.GetNodeOutputsInGraphOutputs(*node).empty() ||
         !graph_utils::AllNodeInputsAreConstant(graph, *node, constant_inputs)) {
       continue;
     }

--- a/onnxruntime/core/optimizer/shape_to_initializer.cc
+++ b/onnxruntime/core/optimizer/shape_to_initializer.cc
@@ -74,6 +74,10 @@ bool ShapeToInitializer::SatisfyCondition(const Graph& graph, const Node& node, 
     return false;
   }
 
+  if (!graph.GetNodeOutputsInGraphOutputs(node).empty()) {
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
This fixes test failures we see in WindowsAI due to constant folding and shape to initializer being enabled after merging.  The problems occur when constant folding and shape to initializer transforms remove nodes connected to graph outputs.