### PR TITLE
Added support for double in batch norm

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/batch_norm.cc
+++ b/onnxruntime/core/providers/cpu/nn/batch_norm.cc
@@ -37,16 +37,16 @@ ONNX_CPU_OPERATOR_KERNEL(
     BatchNormalization,
     9,
     KernelDefBuilder()
-        .TypeConstraint("X", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("scale", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("B", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("mean", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("var", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("X", DataTypeImpl::GetTensorType<double>())
-        .TypeConstraint("scale", DataTypeImpl::GetTensorType<double>())
-        .TypeConstraint("B", DataTypeImpl::GetTensorType<double>())
-        .TypeConstraint("mean", DataTypeImpl::GetTensorType<double>())
-        .TypeConstraint("var", DataTypeImpl::GetTensorType<double>()),
+        .TypeConstraint("X", {DataTypeImpl::GetTensorType<float>(),
+                              DataTypeImpl::GetTensorType<double>()})
+        .TypeConstraint("scale", {DataTypeImpl::GetTensorType<float>(),
+                                  DataTypeImpl::GetTensorType<double>()})
+        .TypeConstraint("B", {DataTypeImpl::GetTensorType<float>(),
+                              DataTypeImpl::GetTensorType<double>()})
+        .TypeConstraint("mean", {DataTypeImpl::GetTensorType<float>(),
+                                 DataTypeImpl::GetTensorType<double>()})
+        .TypeConstraint("var", {DataTypeImpl::GetTensorType<float>(),
+                                DataTypeImpl::GetTensorType<double>()}),
     BatchNorm<float>);
 
 template <>

--- a/onnxruntime/core/providers/cpu/nn/batch_norm.cc
+++ b/onnxruntime/core/providers/cpu/nn/batch_norm.cc
@@ -41,7 +41,12 @@ ONNX_CPU_OPERATOR_KERNEL(
         .TypeConstraint("scale", DataTypeImpl::GetTensorType<float>())
         .TypeConstraint("B", DataTypeImpl::GetTensorType<float>())
         .TypeConstraint("mean", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("var", DataTypeImpl::GetTensorType<float>()),
+        .TypeConstraint("var", DataTypeImpl::GetTensorType<float>())
+        .TypeConstraint("X", DataTypeImpl::GetTensorType<double>())
+        .TypeConstraint("scale", DataTypeImpl::GetTensorType<double>())
+        .TypeConstraint("B", DataTypeImpl::GetTensorType<double>())
+        .TypeConstraint("mean", DataTypeImpl::GetTensorType<double>())
+        .TypeConstraint("var", DataTypeImpl::GetTensorType<double>()),
     BatchNorm<float>);
 
 template <>

--- a/onnxruntime/core/providers/cpu/nn/batch_norm.cc
+++ b/onnxruntime/core/providers/cpu/nn/batch_norm.cc
@@ -37,16 +37,8 @@ ONNX_CPU_OPERATOR_KERNEL(
     BatchNormalization,
     9,
     KernelDefBuilder()
-        .TypeConstraint("X", {DataTypeImpl::GetTensorType<float>(),
-                              DataTypeImpl::GetTensorType<double>()})
-        .TypeConstraint("scale", {DataTypeImpl::GetTensorType<float>(),
-                                  DataTypeImpl::GetTensorType<double>()})
-        .TypeConstraint("B", {DataTypeImpl::GetTensorType<float>(),
-                              DataTypeImpl::GetTensorType<double>()})
-        .TypeConstraint("mean", {DataTypeImpl::GetTensorType<float>(),
-                                 DataTypeImpl::GetTensorType<double>()})
-        .TypeConstraint("var", {DataTypeImpl::GetTensorType<float>(),
-                                DataTypeImpl::GetTensorType<double>()}),
+        .TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                              DataTypeImpl::GetTensorType<double>()}),
     BatchNorm<float>);
 
 template <>


### PR DESCRIPTION
**Description**:
Added double as supported datatype in batch norm op.

**Motivation and Context**
Fixes https://github.com/microsoft/onnxruntime/issues/2874
