### PR TITLE
Fix Android build

### DIFF
--- a/onnxruntime/core/platform/posix/stacktrace.cc
+++ b/onnxruntime/core/platform/posix/stacktrace.cc
@@ -3,7 +3,9 @@
 
 #include "core/common/common.h"
 
+#ifndef __ANDROID__
 #include <execinfo.h>
+#endif
 #include <vector>
 
 namespace onnxruntime {
@@ -11,7 +13,7 @@ namespace onnxruntime {
 std::vector<std::string> GetStackTrace() {
   std::vector<std::string> stack;
 
-#ifndef NDEBUG
+#if !defined(NDEBUG) && !defined(__ANDROID__)
   constexpr int kCallstackLimit = 64;  // Maximum depth of callstack
 
   void* array[kCallstackLimit];


### PR DESCRIPTION
**Description**: Disable stacktrace on Android

**Motivation and Context**
- Why is this change required? What problem does it solve?
Android build failed because of execinfo.h doesn't exist on Android
- If it fixes an open issue, please link to the issue here.
