### PR TITLE
Jignparm/upgrade macos vm image

### DIFF
--- a/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
@@ -280,7 +280,7 @@ jobs:
   workspace:
     clean: all
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
   strategy:
     matrix:
       Python35:

--- a/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
   workspace:
     clean: all
   pool: 
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
   steps:
     - template: templates/mac-set-variables-and-download.yml
     - template: templates/set-version-number-variables-step.yml

--- a/tools/ci_build/github/azure-pipelines/mac-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ci-pipeline.yml
@@ -1,6 +1,5 @@
 jobs:
 - template: templates/mac-ci.yml
   parameters:
-    AgentPool : 'Hosted macOS High Sierra'
     DoNugetPack: 'false'
     BuildCommand: 'python3 $(Build.SourcesDirectory)/tools/ci_build/build.py --use_openmp --build_dir $(Build.BinariesDirectory) --build_wheel --skip_submodule_sync --use_featurizers --parallel --build_shared_lib --build_java --enable_language_interop_ops --enable_onnx_tests --config Debug RelWithDebInfo'

--- a/tools/ci_build/github/azure-pipelines/mac-nocontribops-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-nocontribops-ci-pipeline.yml
@@ -1,6 +1,5 @@
 jobs:
 - template: templates/mac-ci.yml
   parameters:
-    AgentPool : 'Hosted macOS High Sierra'
     DoNugetPack: 'false'
     BuildCommand: 'python3 $(Build.SourcesDirectory)/tools/ci_build/build.py --use_openmp --build_dir $(Build.BinariesDirectory) --build_wheel --skip_submodule_sync --parallel --build_shared_lib --disable_contrib_ops --enable_onnx_tests --config Debug RelWithDebInfo'

--- a/tools/ci_build/github/azure-pipelines/nuget/cpu-esrp-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/cpu-esrp-pipeline.yml
@@ -1,8 +1,3 @@
-# Defined as pipeline variables
-# variables:
-#   AgentPoolLinux : 'Linux-CPU'
-#   AgentPoolMacOS : 'macOS-10.13'
-
 schedules:
 - cron: "0 8 * * *"
   displayName: Daily Build

--- a/tools/ci_build/github/azure-pipelines/nuget/cpu-mklml-esrp-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/cpu-mklml-esrp-pipeline.yml
@@ -1,8 +1,3 @@
-# Defined as pipeline variables
-# variables:
-#   AgentPoolLinux : 'Linux-CPU'
-#   AgentPoolMacOS : 'macOS-10.13'
-
 schedules:
 - cron: "0 10 * * *"
   displayName: Daily Build

--- a/tools/ci_build/github/azure-pipelines/nuget/cpu-mklml-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/cpu-mklml-pipeline.yml
@@ -1,8 +1,3 @@
-# Defined as pipeline variables
-# variables:
-#   AgentPoolLinux : 'Linux-CPU'
-#   AgentPoolMacOS : 'macOS-10.13'
-
 variables:
   PackageName: 'Microsoft.ML.OnnxRuntime.MKLML'
 

--- a/tools/ci_build/github/azure-pipelines/nuget/cpu-nocontribops-arm64-esrp-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/cpu-nocontribops-arm64-esrp-pipeline.yml
@@ -1,8 +1,3 @@
-# Defined as pipeline variables
-# variables:
-#   AgentPoolLinux : 'Linux-CPU'
-#   AgentPoolMacOS : 'macOS-10.13'
-
 schedules:
 - cron: "0 14 * * *"
   displayName: Daily Build

--- a/tools/ci_build/github/azure-pipelines/nuget/cpu-nocontribops-arm64-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/cpu-nocontribops-arm64-pipeline.yml
@@ -1,8 +1,3 @@
-# Defined as pipeline variables
-# variables:
-#   AgentPoolLinux : 'Linux-CPU'
-#   AgentPoolMacOS : 'macOS-10.13'
-
 variables:
   DisableContribOps: 'ON'
 

--- a/tools/ci_build/github/azure-pipelines/nuget/cpu-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/cpu-pipeline.yml
@@ -1,8 +1,3 @@
-# Defined as pipeline variables
-# variables:
-#   AgentPoolLinux : 'Linux-CPU'
-#   AgentPoolMacOS : 'macOS-10.13'
-
 jobs: 
 - template: templates/cpu.yml
   parameters:

--- a/tools/ci_build/github/azure-pipelines/nuget/gpu-esrp-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/gpu-esrp-pipeline.yml
@@ -1,9 +1,3 @@
-# Defined as pipeline variables
-# variables:
-#   AgentPoolWin : 'Win-CPU-CUDA10'
-#   AgentPoolLinux : 'Linux-CPU'
-#   AgentPoolMacOS : 'macOS-10.13'
-
 schedules:
 - cron: "0 8 * * *"
   displayName: Daily Build

--- a/tools/ci_build/github/azure-pipelines/nuget/gpu-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/gpu-pipeline.yml
@@ -1,8 +1,3 @@
-# Defined as pipeline variables
-# variables:
-#   AgentPoolLinux : 'Linux-CPU'
-#   AgentPoolMacOS : 'macOS-10.13'
-
 variables:
   PackageName: 'Microsoft.ML.OnnxRuntime.Gpu'
   TESTONGPU: 'ON'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-mklml.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-mklml.yml
@@ -1,8 +1,3 @@
-# Defined as pipeline variables
-# variables:
-#   AgentPoolLinux : 'Linux-CPU'
-#   AgentPoolMacOS : 'macOS-10.13'
-
 parameters:
   DoEsrp: 'false'
 

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-nocontribops-arm64.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-nocontribops-arm64.yml
@@ -1,8 +1,3 @@
-# Defined as pipeline variables
-# variables:
-#   AgentPoolLinux : 'Linux-CPU'
-#   AgentPoolMacOS : 'macOS-10.13'
-
 parameters:
   DoEsrp: 'false'
 

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu.yml
@@ -1,8 +1,3 @@
-# Defined as pipeline variables
-# variables:
-#   AgentPoolLinux : 'Linux-CPU'
-#   AgentPoolMacOS : 'macOS-10.13'
-
 parameters:
   DoEsrp: 'false'
   PackageName: 'Microsoft.ML.OnnxRuntime'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
@@ -1,8 +1,3 @@
-# Defined as pipeline variables
-# variables:
-#   AgentPoolLinux : 'Linux-CPU'
-#   AgentPoolMacOS : 'macOS-10.13'
-
 parameters:
   DoEsrp: 'false'
   PackageName: 'Microsoft.ML.OnnxRuntime.Gpu'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
@@ -1,12 +1,12 @@
 parameters:
-  AgentPool : 'Hosted macOS High Sierra'
   IsMacOS : 'true'
 
 jobs:
 - job: NuGet_Test_MacOS
   workspace:
     clean: all
-  pool: ${{ parameters.AgentPool }}
+  pool:
+    vmImage: 'macOS-10.14'
   dependsOn:
   - NuGet_Packaging
   condition: succeeded()

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -1,5 +1,4 @@
 parameters:
-  AgentPool : 'Hosted macOS High Sierra'
   JobName: 'MacOS_CI_Dev'
   BuildCommand: ''
   DoNugetPack: 'false'
@@ -10,7 +9,8 @@ jobs:
   workspace:
     clean: all
   timeoutInMinutes:  120
-  pool: ${{ parameters.AgentPool }}
+  pool:
+    vmImage: 'macOS-10.14'
   variables:
     BuildCommand: ${{ parameters.BuildCommand }}
   steps:


### PR DESCRIPTION
**Description**: Upgrading to MacOS 10.14

**Motivation and Context**
Current pipelines use MacOS 10.13 image, which will be deprecated Mar 23rd.
