### PR TITLE
use dml macro not wrapping custom registry code

### DIFF
--- a/winml/adapter/winml_adapter_c_api.cpp
+++ b/winml/adapter/winml_adapter_c_api.cpp
@@ -8,7 +8,6 @@
 
 #include <core/providers/winml/winml_provider_factory.h>
 #include <core/providers/cpu/cpu_provider_factory.h>
-#include <core/providers/dml/dml_provider_factory.h>
 
 const OrtApi* GetVersion1Api();
 

--- a/winml/adapter/winml_adapter_session.cpp
+++ b/winml/adapter/winml_adapter_session.cpp
@@ -170,7 +170,7 @@ GetLotusCustomRegistries(IMLOperatorRegistry* registry) {
 
     // Get the ORT registry
     return abi_custom_registry->GetRegistries();
-#endif USE_DML
+#endif // USE_DML
   }
   return {};
 }
@@ -191,8 +191,10 @@ ORT_API_STATUS_IMPL(winmla::SessionRegisterCustomRegistry, _In_ OrtSession* sess
 
 ORT_API_STATUS_IMPL(winmla::CreateCustomRegistry, _Out_ IMLOperatorRegistry** registry) {
   API_IMPL_BEGIN
+#ifdef USE_DML
   auto impl = wil::MakeOrThrow<winmla::AbiCustomRegistryImpl>();
   *registry = impl.Detach();
+#endif // USE_DML
   return nullptr;
   API_IMPL_END
 }


### PR DESCRIPTION
USE_DML macro needed in more places.