### PR TITLE
Java - Switching JNI_VERSION to 1_6

### DIFF
--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -10,7 +10,9 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     // To silence unused-parameter error.
     // This function must exist according to the JNI spec, but the arguments aren't necessary for the library to request a specific version.
     (void)vm; (void) reserved;
-    return JNI_VERSION_1_8;
+    // Requesting 1.6 to support Android. Will need to be bumped to a later version to call interface default methods
+    // from native code, or to access other new Java features.
+    return JNI_VERSION_1_6;
 }
 
 /**


### PR DESCRIPTION
**Description**: Originally the JNI binding requests 1.8 as that's the minimum Java version for the Java bits, but it doesn't call any native methods that are enabled by that feature, so we can relax it to 1.6. Note the Java code still requires Java 8.

**Motivation and Context**
- Why is this change required? What problem does it solve? It will help make the Java bindings usable from Android if people want to use them.
- If it fixes an open issue, please link to the issue here. It will resolve #2925.
