### PR TITLE
Disable LNK4199 winml_dll to enable cuda builds

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -618,3 +618,12 @@ option(onnxruntime_BUILD_WINML_TESTS "Build WinML tests" ON)
 if (onnxruntime_BUILD_WINML_TESTS)
   include(winml_unittests.cmake)
 endif()
+
+# This is needed to suppress warnings that complain that no imports are found for the delayloaded library cublas64*.lib
+# When cuda is enabled in the pipeline, it sets CMAKE_SHARED_LINKER_FLAGS which affects all targets including winml_dll.
+# However, there are no cuda imports in winml_dll, and the linkler throws the 4199 warning.
+# This is needed to allow winml_dll build with cuda enabled.
+set_target_properties(winml_dll
+  PROPERTIES
+  LINK_FLAGS
+  "/ignore:4199")

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -621,7 +621,7 @@ endif()
 
 # This is needed to suppress warnings that complain that no imports are found for the delayloaded library cublas64*.lib
 # When cuda is enabled in the pipeline, it sets CMAKE_SHARED_LINKER_FLAGS which affects all targets including winml_dll.
-# However, there are no cuda imports in winml_dll, and the linkler throws the 4199 warning.
+# However, there are no cuda imports in winml_dll, and the linker throws the 4199 warning.
 # This is needed to allow winml_dll build with cuda enabled.
 set_target_properties(winml_dll
   PROPERTIES


### PR DESCRIPTION
This is needed to suppress linker warnings in winml_dll that complain that no imports are found for the delayloaded library cublas64*.lib.
When --use_cuda is enabled in the pipeline, it sets CMAKE_SHARED_LINKER_FLAGS which affects all targets including winml_dll.
However, there are no cuda imports in winml_dll, and the linkler throws the 4199 warning.
This suppressed the warning to allow winml_dll build with cuda enabled.