### PR TITLE
LearningModelSessionAPITestGpu.CreateSessionWithCastToFloat16InModel should return DXGI_ERROR_UNSUPPORTED when FP16 not supported

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -618,3 +618,12 @@ option(onnxruntime_BUILD_WINML_TESTS "Build WinML tests" ON)
 if (onnxruntime_BUILD_WINML_TESTS)
   include(winml_unittests.cmake)
 endif()
+
+# This is needed to suppress warnings that complain that no imports are found for the delayloaded library cublas64*.lib
+# When cuda is enabled in the pipeline, it sets CMAKE_SHARED_LINKER_FLAGS which affects all targets including winml_dll.
+# However, there are no cuda imports in winml_dll, and the linkler throws the 4199 warning.
+# This is needed to allow winml_dll build with cuda enabled.
+set_target_properties(winml_dll
+  PROPERTIES
+  LINK_FLAGS
+  "/ignore:4199")

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -621,7 +621,7 @@ endif()
 
 # This is needed to suppress warnings that complain that no imports are found for the delayloaded library cublas64*.lib
 # When cuda is enabled in the pipeline, it sets CMAKE_SHARED_LINKER_FLAGS which affects all targets including winml_dll.
-# However, there are no cuda imports in winml_dll, and the linkler throws the 4199 warning.
+# However, there are no cuda imports in winml_dll, and the linker throws the 4199 warning.
 # This is needed to allow winml_dll build with cuda enabled.
 set_target_properties(winml_dll
   PROPERTIES

--- a/winml/lib/Api.Ort/OnnxruntimeModel.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeModel.cpp
@@ -196,8 +196,9 @@ STDMETHODIMP OnnruntimeModel::GetModelInfo(IModelInfo** info) {
 
 STDMETHODIMP OnnruntimeModel::ModelEnsureNoFloat16() {
   auto winml_adapter_api = engine_factory_->UseWinmlAdapterApi();
-  RETURN_HR_IF_NOT_OK_MSG(winml_adapter_api->ModelEnsureNoFloat16(ort_model_.get()),
-                          engine_factory_->UseOrtApi());
+  if (auto status = winml_adapter_api->ModelEnsureNoFloat16(ort_model_.get())) {
+    return DXGI_ERROR_UNSUPPORTED;
+  }
   return S_OK;
 }
 


### PR DESCRIPTION
LearningModelSessionAPITestGpu.CreateSessionWithCastToFloat16InModel should return DXGI_ERROR_UNSUPPORTED when FP16 not supported