### PR TITLE
Java OrtEnvironment didn't close properly if there were multiple references

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
+++ b/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
@@ -248,7 +248,6 @@ public class OrtEnvironment implements AutoCloseable {
      */
     @Override
     public synchronized void close() throws OrtException {
-        closed = true;
         synchronized (refCount) {
             int curCount = refCount.get();
             if (curCount != 0) {
@@ -256,6 +255,7 @@ public class OrtEnvironment implements AutoCloseable {
             }
             if (curCount == 1) {
                 close(OnnxRuntime.ortApiHandle, nativeHandle);
+                closed = true;
                 INSTANCE = null;
             }
         }

--- a/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
+++ b/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
@@ -125,7 +125,7 @@ public class OrtEnvironment implements AutoCloseable {
 
     final OrtAllocator defaultAllocator;
 
-    private boolean closed = false;
+    private volatile boolean closed = false;
 
     /**
      * Create an OrtEnvironment using a default name.

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -794,7 +794,7 @@ public class InferenceTest {
             String inputName = session.getInputNames().iterator().next();
 
             Map<String,OnnxTensor> container = new HashMap<>();
-            String[][] tensorIn = new String[][]{new String[] {"this", "is"}, new String[] {"identity", "test"}};
+            String[][] tensorIn = new String[][]{new String[] {"this", "is"}, new String[] {"identity", "test \u263A"}};
             OnnxTensor ov = OnnxTensor.createTensor(env,tensorIn);
             container.put(inputName,ov);
 
@@ -809,14 +809,14 @@ public class InferenceTest {
                 assertEquals("this", labelOutput[0]);
                 assertEquals("is", labelOutput[1]);
                 assertEquals("identity", labelOutput[2]);
-                assertEquals("test", labelOutput[3]);
+                assertEquals("test \u263A", labelOutput[3]);
                 assertEquals(4, labelOutput.length);
 
                 OnnxValue.close(container);
                 container.clear();
             }
 
-            String[] tensorInFlatArr = new String[]{"this", "is", "identity", "test"};
+            String[] tensorInFlatArr = new String[]{"this", "is", "identity", "test \u263A"};
             ov = OnnxTensor.createTensor(env,tensorInFlatArr, new long[]{2,2});
             container.put(inputName,ov);
 
@@ -831,7 +831,7 @@ public class InferenceTest {
                 assertEquals("this", labelOutput[0]);
                 assertEquals("is", labelOutput[1]);
                 assertEquals("identity", labelOutput[2]);
-                assertEquals("test", labelOutput[3]);
+                assertEquals("test \u263A", labelOutput[3]);
                 assertEquals(4, labelOutput.length);
             }
         }

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -68,6 +69,17 @@ public class InferenceTest {
             resourcePath = Paths.get("csharp","testdata");
             otherTestPath = Paths.get("onnxruntime","test", "testdata");
         }
+    }
+
+    @Test
+    public void repeatedCloseTest() throws OrtException {
+        OrtEnvironment env = OrtEnvironment.getEnvironment("repeatedCloseTest");
+        try (OrtEnvironment otherEnv = OrtEnvironment.getEnvironment()) {
+            assertFalse(otherEnv.isClosed());
+        }
+        assertFalse(env.isClosed());
+        env.close();
+        assertTrue(env.isClosed());
     }
 
     @Test


### PR DESCRIPTION
**Description**: I moved the setting of the closed variable inside the synchronized block so it only closes after all references are exhausted (as it was supposed to). There's now a unit test which keeps two environment references and checks the behaviour.

I also pulled in a slight modification to one of the String tests to test for issue #2690 which affected the C# interface.

**Motivation and Context**
- Why is this change required? What problem does it solve? If a user had two OrtEnvironments in the same process then closing one would close all of them.