### PR TITLE
TensorString, Sequences and Maps use the first allocator, but should use the cpu default allocator.

### DIFF
--- a/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
@@ -11,6 +11,10 @@
 
 using namespace WinML;
 
+static OrtStatus* __stdcall NoopDeleter(OrtAllocator* ptr) {
+  return nullptr;
+}
+
 static const OrtApi* GetVersionedOrtApi() {
   static const uint32_t ort_version = 1;
   const auto ort_api_base = OrtGetApiBase();
@@ -514,6 +518,19 @@ OnnxruntimeEngineFactory* OnnxruntimeEngine::GetEngineFactory() {
   return engine_factory_.Get();
 }
 
+HRESULT OnnxruntimeEngine::CreateTensorValue(const int64_t* shape, size_t count, winml::TensorKind kind,
+                                             OrtAllocator* ort_allocator, _Out_ IValue** out) {
+  auto ort_api = engine_factory_->UseOrtApi();
+  auto winml_adapter_api = engine_factory_->UseWinmlAdapterApi();
+
+  OrtValue* ort_value;
+  RETURN_HR_IF_NOT_OK_MSG(ort_api->CreateTensorAsOrtValue(ort_allocator, shape, count, ONNXTensorElementDataTypeFromTensorKind(kind), &ort_value),
+                          ort_api);
+  auto unique_value = UniqueOrtValue(ort_value, ort_api->ReleaseValue);
+  RETURN_IF_FAILED(Microsoft::WRL::MakeAndInitialize<OnnxruntimeValue>(out, this, std::move(unique_value), UniqueOrtAllocator(nullptr, nullptr)));
+  return S_OK;
+}
+
 /*
 * OnnxruntimeEngine::CreateTensorValue
 * 
@@ -626,7 +643,11 @@ HRESULT OnnxruntimeEngine::CreateTensorValueFromExternalD3DResource(ID3D12Resour
 */
 HRESULT OnnxruntimeEngine::CreateStringTensorValueFromDataWithCopy(const char* const* data, size_t num_elements, const int64_t* shape, size_t count, _Out_ IValue** out) {
   auto ort_api = engine_factory_->UseOrtApi();
-  RETURN_IF_FAILED(CreateTensorValue(shape, count, winml::TensorKind::String, out));
+
+  OrtAllocator* ort_allocator;
+  RETURN_HR_IF_NOT_OK_MSG(ort_api->GetAllocatorWithDefaultOptions(&ort_allocator), ort_api);  // This should not be freed as this owned by ort
+
+  RETURN_IF_FAILED(CreateTensorValue(shape, count, winml::TensorKind::String, ort_allocator, out));
 
   auto ort_value = reinterpret_cast<WinML::OnnxruntimeValue*>(*out)->UseOrtValue();
   RETURN_HR_IF_NOT_OK_MSG(ort_api->FillStringTensor(ort_value, reinterpret_cast<const char* const*>(data), num_elements),
@@ -861,12 +882,15 @@ HRESULT CreateMapValue(OnnxruntimeEngine* engine, IInspectable* map_insp, winml:
   auto map = CastToWinrtMap<TAbiKey, TAbiValue>(map_insp);
   std::vector<int64_t> shape = {static_cast<int64_t>(map.Size())};
 
+  OrtAllocator* ort_allocator;
+  RETURN_HR_IF_NOT_OK_MSG(ort_api->GetAllocatorWithDefaultOptions(&ort_allocator), ort_api);  // This should not be freed as this owned by ort
+
   winrt::com_ptr<WinML::IValue> key_value;
-  RETURN_IF_FAILED(engine->CreateTensorValue(shape.data(), shape.size(), key_kind, key_value.put()));
+  RETURN_IF_FAILED(engine->CreateTensorValue(shape.data(), shape.size(), key_kind, ort_allocator, key_value.put()));
   auto keys_ort_value = static_cast<OnnxruntimeValue*>(key_value.get())->UseOrtValue();
 
   winrt::com_ptr<WinML::IValue> value_value;
-  RETURN_IF_FAILED(engine->CreateTensorValue(shape.data(), shape.size(), value_kind, value_value.put()));
+  RETURN_IF_FAILED(engine->CreateTensorValue(shape.data(), shape.size(), value_kind, ort_allocator, value_value.put()));
   auto values_ort_value = static_cast<OnnxruntimeValue*>(value_value.get())->UseOrtValue();
 
   auto hr = FillMapTensors<TAbiKey, TAbiValue>::Run(ort_api, map_insp, keys_ort_value, values_ort_value);
@@ -1192,7 +1216,7 @@ HRESULT OnnxruntimeEngineFactory::EnsureEnvironment() {
     std::lock_guard lock(mutex_);
     if (environment_ == nullptr) {
       environment_ = PheonixSingleton<OnnxruntimeEnvironment>(ort_api_);
-	}
+    }
   }
   return S_OK;
 }

--- a/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
@@ -11,10 +11,6 @@
 
 using namespace WinML;
 
-static OrtStatus* __stdcall NoopDeleter(OrtAllocator* ptr) {
-  return nullptr;
-}
-
 static const OrtApi* GetVersionedOrtApi() {
   static const uint32_t ort_version = 1;
   const auto ort_api_base = OrtGetApiBase();
@@ -518,10 +514,11 @@ OnnxruntimeEngineFactory* OnnxruntimeEngine::GetEngineFactory() {
   return engine_factory_.Get();
 }
 
-HRESULT OnnxruntimeEngine::CreateTensorValue(const int64_t* shape, size_t count, winml::TensorKind kind,
-                                             OrtAllocator* ort_allocator, _Out_ IValue** out) {
+HRESULT OnnxruntimeEngine::CreateTensorValueFromDefaultAllocator(const int64_t* shape, size_t count, winml::TensorKind kind, _Out_ IValue** out) {
   auto ort_api = engine_factory_->UseOrtApi();
-  auto winml_adapter_api = engine_factory_->UseWinmlAdapterApi();
+
+  OrtAllocator* ort_allocator;
+  RETURN_HR_IF_NOT_OK_MSG(ort_api->GetAllocatorWithDefaultOptions(&ort_allocator), ort_api);  // This should not be freed as this owned by ort
 
   OrtValue* ort_value;
   RETURN_HR_IF_NOT_OK_MSG(ort_api->CreateTensorAsOrtValue(ort_allocator, shape, count, ONNXTensorElementDataTypeFromTensorKind(kind), &ort_value),
@@ -644,10 +641,7 @@ HRESULT OnnxruntimeEngine::CreateTensorValueFromExternalD3DResource(ID3D12Resour
 HRESULT OnnxruntimeEngine::CreateStringTensorValueFromDataWithCopy(const char* const* data, size_t num_elements, const int64_t* shape, size_t count, _Out_ IValue** out) {
   auto ort_api = engine_factory_->UseOrtApi();
 
-  OrtAllocator* ort_allocator;
-  RETURN_HR_IF_NOT_OK_MSG(ort_api->GetAllocatorWithDefaultOptions(&ort_allocator), ort_api);  // This should not be freed as this owned by ort
-
-  RETURN_IF_FAILED(CreateTensorValue(shape, count, winml::TensorKind::String, ort_allocator, out));
+  RETURN_IF_FAILED(CreateTensorValueFromDefaultAllocator(shape, count, winml::TensorKind::String, out));
 
   auto ort_value = reinterpret_cast<WinML::OnnxruntimeValue*>(*out)->UseOrtValue();
   RETURN_HR_IF_NOT_OK_MSG(ort_api->FillStringTensor(ort_value, reinterpret_cast<const char* const*>(data), num_elements),
@@ -882,15 +876,12 @@ HRESULT CreateMapValue(OnnxruntimeEngine* engine, IInspectable* map_insp, winml:
   auto map = CastToWinrtMap<TAbiKey, TAbiValue>(map_insp);
   std::vector<int64_t> shape = {static_cast<int64_t>(map.Size())};
 
-  OrtAllocator* ort_allocator;
-  RETURN_HR_IF_NOT_OK_MSG(ort_api->GetAllocatorWithDefaultOptions(&ort_allocator), ort_api);  // This should not be freed as this owned by ort
-
   winrt::com_ptr<WinML::IValue> key_value;
-  RETURN_IF_FAILED(engine->CreateTensorValue(shape.data(), shape.size(), key_kind, ort_allocator, key_value.put()));
+  RETURN_IF_FAILED(engine->CreateTensorValueFromDefaultAllocator(shape.data(), shape.size(), key_kind, key_value.put()));
   auto keys_ort_value = static_cast<OnnxruntimeValue*>(key_value.get())->UseOrtValue();
 
   winrt::com_ptr<WinML::IValue> value_value;
-  RETURN_IF_FAILED(engine->CreateTensorValue(shape.data(), shape.size(), value_kind, ort_allocator, value_value.put()));
+  RETURN_IF_FAILED(engine->CreateTensorValueFromDefaultAllocator(shape.data(), shape.size(), value_kind, value_value.put()));
   auto values_ort_value = static_cast<OnnxruntimeValue*>(value_value.get())->UseOrtValue();
 
   auto hr = FillMapTensors<TAbiKey, TAbiValue>::Run(ort_api, map_insp, keys_ort_value, values_ort_value);

--- a/winml/lib/Api.Ort/OnnxruntimeEngine.h
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.h
@@ -105,6 +105,7 @@ class OnnxruntimeEngine : public Microsoft::WRL::RuntimeClass<
   OrtSession* UseOrtSession();
   const OrtApi* UseOrtApi();
   OnnxruntimeEngineFactory* GetEngineFactory();
+  HRESULT CreateTensorValue(const int64_t* shape, size_t count, winml::TensorKind kind, OrtAllocator* ort_allocator, _Out_ IValue** out);
 
  private:
   Microsoft::WRL::ComPtr<OnnxruntimeEngineFactory> engine_factory_;

--- a/winml/lib/Api.Ort/OnnxruntimeEngine.h
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.h
@@ -105,7 +105,7 @@ class OnnxruntimeEngine : public Microsoft::WRL::RuntimeClass<
   OrtSession* UseOrtSession();
   const OrtApi* UseOrtApi();
   OnnxruntimeEngineFactory* GetEngineFactory();
-  HRESULT CreateTensorValue(const int64_t* shape, size_t count, winml::TensorKind kind, OrtAllocator* ort_allocator, _Out_ IValue** out);
+  HRESULT CreateTensorValueFromDefaultAllocator(const int64_t* shape, size_t count, winml::TensorKind kind, _Out_ IValue** out);
 
  private:
   Microsoft::WRL::ComPtr<OnnxruntimeEngineFactory> engine_factory_;


### PR DESCRIPTION
TensorString, Sequences and Maps use the first allocator, but should use the cpu default allocator.

This is causing wide spread model test failures.

If this does not happen, then when models with tensorstring/map/sequence are run with dml then the ort values are allocated using the wrong EP allocator!