### PR TITLE
Fix onnx server build server on ubuntu 16 and 18

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
@@ -2,14 +2,14 @@
 set -e
 
 SYS_LONG_BIT=$(getconf LONG_BIT)
-
+apt-get update
 #see: https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore21
 if [ "$OS_VERSION" = "16.04" ]; then
-  apt-get remove -y libprotobuf9v5 libprotobuf-lite9v5
+  apt-get remove libprotobuf9v5 libprotobuf-lite9v5
 else # ubuntu18.04
-  apt-get remove -y libprotobuf-dev libprotobuf10
+  apt-get remove libprotobuf-dev libprotobuf10
 fi
-apt-get update && apt-get install -y --no-install-recommends libre2-dev
+apt-get install -y --no-install-recommends libre2-dev
 rm -rf /var/lib/apt/lists/*
 
 if [ $SYS_LONG_BIT = "64" ]; then

--- a/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
@@ -3,7 +3,12 @@ set -e
 
 SYS_LONG_BIT=$(getconf LONG_BIT)
 
-apt-get remove -y libprotobuf-dev libprotobuf9v5 protobuf-compiler libprotobuf-lite9v5
+#see: https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore21
+if [ "$OS_VERSION" = "16.04" ]; then
+  apt-get remove -y libprotobuf9v5 libprotobuf-lite9v5
+else # ubuntu18.04
+  apt-get remove -y libprotobuf-dev libprotobuf10
+fi
 apt-get update && apt-get install -y --no-install-recommends libre2-dev
 rm -rf /var/lib/apt/lists/*
 

--- a/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-
+OS_VERSION=$(lsb_release -r -s)
 SYS_LONG_BIT=$(getconf LONG_BIT)
 apt-get update
 #see: https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore21


### PR DESCRIPTION
**Description**: Describe your changes.
Following commit broke build for onnxruntime server:
https://github.com/microsoft/onnxruntime/commit/c7a9c6b488c43990a532350cc788478e9585395d

```
2545 Step 13/23 : RUN /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
2546  ---> Running in c920c0db0afa
2547 Reading package lists...
2548 Building dependency tree...
2549 Reading state information...
2550 E: Unable to locate package libprotobuf-dev
2551 E: Unable to locate package protobuf-compiler
2552 The command '/bin/sh -c /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh' returned a non-zero code: 100
```

**Motivation and Context**
- moving `apt-get update` on top fixed the issue 
- added check for OS version
