### PR TITLE
MLAS: Apply 'small-M' optimization for column-vectors

### DIFF
--- a/onnxruntime/core/mlas/lib/sgemm.cpp
+++ b/onnxruntime/core/mlas/lib/sgemm.cpp
@@ -850,12 +850,13 @@ Return Value:
 
     }
 
-    if (N == 1 && ldb == 1 && ldc == 1 && alpha == 1.0f && (beta == 0.0f || beta == 1.0f))
-    {
-        // Both B and C are column-vectors that are contiguous in memory.
-        // Because transposition of such vectors doesn't change their layout, and
-        // Transpose(A*B) = Transpose(B) * Transpose(A), we can apply the same 'small-M'
-        // optimization as above, with A and B flipped.
+    //
+    // Handle the case when both B and C are column-vectors that are contiguous in memory.
+    // Because transposition of such vectors doesn't change their layout, and
+    // Transpose(A*B) = Transpose(B) * Transpose(A), we can apply the same 'small-M'
+    // optimization as above, with A and B flipped.
+    //
+    if (N == 1 && ldb == 1 && ldc == 1 && alpha == 1.0f && (beta == 0.0f || beta == 1.0f)) {
 
 #if defined(MLAS_TARGET_AMD64)
 

--- a/onnxruntime/test/mlas/unittest.cpp
+++ b/onnxruntime/test/mlas/unittest.cpp
@@ -396,6 +396,7 @@ public:
                 for (size_t a = 0; a < _countof(multipliers); a++) {
                     for (size_t b = 0; b < _countof(multipliers); b++) {
                         Test(1, N, K, multipliers[a], multipliers[b]);
+                        Test(N, 1, K, multipliers[a], multipliers[b]);
                     }
                 }
             }


### PR DESCRIPTION
**Description**: Apply 'small-M' optimization for column-vectors in MlasSgemmOperation

**Motivation and Context**
This improves performance for the case of multiplication of a matrix by a column-vector. In a synthetic test (one 1000 by 5000 layer, single thread), CPU usage is reduced by half, and latency by 20-30% depending on percentile.
