### PR TITLE
Disable _tlgPragmaUtf8Begin and _tlgPragmaUtf8End as they force set the execution character set.

### DIFF
--- a/onnxruntime/core/platform/windows/logging/etw_sink.cc
+++ b/onnxruntime/core/platform/windows/logging/etw_sink.cc
@@ -23,10 +23,27 @@
 #include <evntrace.h>
 
 //See: https://developercommunity.visualstudio.com/content/problem/85934/traceloggingproviderh-is-incompatible-with-utf-8.html
+#ifdef _TlgPragmaUtf8Begin
 #undef _TlgPragmaUtf8Begin
-#undef _TlgPragmaUtf8End
 #define _TlgPragmaUtf8Begin
+#endif
+
+#ifdef _TlgPragmaUtf8End
+#undef _TlgPragmaUtf8End
 #define _TlgPragmaUtf8End
+#endif
+
+// Different versions of TraceLoggingProvider.h contain different macro variable names for the utf8 begin and end,
+// and we need to cover the lower case version as well.
+#ifdef _tlgPragmaUtf8Begin
+#undef _tlgPragmaUtf8Begin
+#define _tlgPragmaUtf8Begin
+#endif
+
+#ifdef _tlgPragmaUtf8End
+#undef _tlgPragmaUtf8End
+#define _tlgPragmaUtf8End
+#endif
 
 namespace onnxruntime {
 namespace logging {

--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -21,9 +21,24 @@
 //https://developercommunity.visualstudio.com/content/problem/85934/traceloggingproviderh-is-incompatible-with-utf-8.html
 #ifdef _TlgPragmaUtf8Begin
 #undef _TlgPragmaUtf8Begin
-#undef _TlgPragmaUtf8End
 #define _TlgPragmaUtf8Begin
+#endif
+
+#ifdef _TlgPragmaUtf8End
+#undef _TlgPragmaUtf8End
 #define _TlgPragmaUtf8End
+#endif
+
+// Different versions of TraceLoggingProvider.h contain different macro variable names for the utf8 begin and end,
+// and we need to cover the lower case version as well.
+#ifdef _tlgPragmaUtf8Begin
+#undef _tlgPragmaUtf8Begin
+#define _tlgPragmaUtf8Begin
+#endif
+
+#ifdef _tlgPragmaUtf8End
+#undef _tlgPragmaUtf8End
+#define _tlgPragmaUtf8End
 #endif
 
 namespace onnxruntime {


### PR DESCRIPTION
The onnxruntime targets now set /utf-8 to enforce a utf8 source charset and execution charset.
This conflicts with TraceloggingProvider.h and needs certain macros disabled so that the traceloggingprovider code doesnt attempt to force set the execution charset.
In winml builds which target newer SDK versions, TraceloggingProvider.h has changed the name of this variable and made _Tlg -> _tlg.
Disabling _tlgPragmaUtf8Begin and _tlgPragmaUtf8End as well to enable winml builds.