### PR TITLE
Calling WinML enables telemetry by default for 1.2

### DIFF
--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -112,6 +112,9 @@ void WindowsTelemetry::LogProcessInfo() const {
 }
 
 void WindowsTelemetry::LogSessionCreationStart() const {
+  if (global_register_count_ == 0 || enabled_ == false)
+    return;
+
   TraceLoggingWrite(telemetry_provider_handle,
                     "SessionCreationStart",
                     TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
@@ -120,6 +123,9 @@ void WindowsTelemetry::LogSessionCreationStart() const {
 }
 
 void WindowsTelemetry::LogEvaluationStop() const {
+  if (global_register_count_ == 0 || enabled_ == false)
+    return;
+
   TraceLoggingWrite(telemetry_provider_handle,
                     "EvaluationStop",
                     TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
@@ -128,6 +134,9 @@ void WindowsTelemetry::LogEvaluationStop() const {
 }
 
 void WindowsTelemetry::LogEvaluationStart() const {
+  if (global_register_count_ == 0 || enabled_ == false)
+    return;
+
   TraceLoggingWrite(telemetry_provider_handle,
                     "EvaluationStart",
                     TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),

--- a/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
@@ -1259,6 +1259,7 @@ const WinmlAdapterApi* OnnxruntimeEngineFactory::UseWinmlAdapterApi() {
 HRESULT OnnxruntimeEngineFactory::GetOrtEnvironment(OrtEnv** ort_env) {
   RETURN_IF_FAILED(EnsureEnvironment());
   RETURN_IF_FAILED(environment_->GetOrtEnvironment(ort_env));
+  RETURN_HR_IF_NOT_OK_MSG(ort_api_->EnableTelemetryEvents(*ort_env), ort_api_);
   return S_OK;
 }
 


### PR DESCRIPTION
 
This PR is to enable telemetry collection for winml calling by default, keep ort telemetry collection off by default.

![image](https://user-images.githubusercontent.com/17421593/73991293-98c38700-4900-11ea-90be-affdd4076167.png)
