### PR TITLE
WinML Adapter should be built against v2 of the ORT C-API

### DIFF
--- a/winml/adapter/winml_adapter_c_api.cpp
+++ b/winml/adapter/winml_adapter_c_api.cpp
@@ -83,7 +83,7 @@ static constexpr WinmlAdapterApi winml_adapter_api_1 = {
 };
 
 const WinmlAdapterApi* ORT_API_CALL OrtGetWinMLAdapter(const OrtApi* ort_api) NO_EXCEPTION {
-  if (OrtApis::GetApi(1) == ort_api) {
+  if (OrtApis::GetApi(2) == ort_api) {
     return &winml_adapter_api_1;
   }
 

--- a/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
@@ -14,7 +14,7 @@
 using namespace WinML;
 
 static const OrtApi* GetVersionedOrtApi() {
-  static const uint32_t ort_version = 1;
+  static const uint32_t ort_version = 2;
   const auto ort_api_base = OrtGetApiBase();
   return ort_api_base->GetApi(ort_version);
 }


### PR DESCRIPTION
The WinML Adapter should extend the v2 of the ORT C-API and not v1.

This is because some adapter methods were promoted into v2 of the C-ABI and WinML needs these to function properly.

Currently things just work, because v2 and v1 of the API point to the same struct. If the structs diverge due to reordering/api deletions this would stop working correctly.

As a side note, based on the comments regarding updating the c-abi version, if breaking changes are introduced, the recommendation is to create a new OrtApi struct. This struct would point to the latest API and the old one would be renamed. With this scheme, the GetApi would not be able to return the correct type as requesting older versions (ie: 1) would return the latest API pointer? This should probably return a void* or a common base (but one doesnt exist).