### PR TITLE
Replace hardcoded State serialization for Featurizer kernel tests

### DIFF
--- a/onnxruntime/test/featurizers_ops/max_abs_scaler_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/max_abs_scaler_transformer_test.cc
@@ -5,44 +5,50 @@
 #include "test/providers/provider_test_utils.h"
 
 #include "Featurizers/MaxAbsScalerFeaturizer.h"
+#include "Featurizers/TestHelpers.h"
 
-namespace dft = Microsoft::Featurizer::Featurizers;
+namespace NS = Microsoft::Featurizer;
 
 namespace onnxruntime {
 namespace test {
 
-TEST(FeaturizersTests, MaxAbsScaler_int8_values) {
+namespace {
+template <typename InputT, typename TransformedT>
+void TestWrapper() {
+  auto trainingBatches = NS::TestHelpers::make_vector<std::vector<InputT>>(
+      NS::TestHelpers::make_vector<InputT>(static_cast<InputT>(-4)),
+      NS::TestHelpers::make_vector<InputT>(static_cast<InputT>(3)),
+      NS::TestHelpers::make_vector<InputT>(static_cast<InputT>(0)),
+      NS::TestHelpers::make_vector<InputT>(static_cast<InputT>(2)),
+      NS::TestHelpers::make_vector<InputT>(static_cast<InputT>(-1)));
+
+  using EstimatorT = NS::Featurizers::MaxAbsScalerEstimator<InputT, TransformedT>;
+  EstimatorT estimator(NS::CreateTestAnnotationMapsPtr(1), 0);
+  NS::TestHelpers::Train<EstimatorT, InputT>(estimator, trainingBatches);
+
+  auto pTransformer = estimator.create_transformer();
+  NS::Archive ar;
+  pTransformer->save(ar);
+  auto stream = ar.commit();
 
   OpTester test("MaxAbsScalerTransformer", 1, onnxruntime::kMSFeaturizersDomain);
-  
-  // State from when the transformer was trained. Corresponds to Version 1 and a 
-  // scale of 0
-  test.AddInput<uint8_t>("State", {8}, {1, 0, 0, 0, 0, 0, 128, 64});
+  auto dim = static_cast<int64_t>(stream.size());
+  test.AddInput<uint8_t>("State", {dim}, stream);
 
-  // We are adding a scalar Tensor in this instance
-  test.AddInput<int8_t>("X", {5}, {-4,3,0,2,-1});
+  test.AddInput<InputT>("Input", {5}, {-4, 3, 0, 2, -1});
+  test.AddOutput<TransformedT>("Output", {5}, {-1.f, 0.75f, 0.f, 0.5f, -0.25f});
+  test.Run();
+}
+}  // namespace
 
-  // Expected output.
-  test.AddOutput<float>("ScaledValues", {5}, {-1.f,.75f,0.f,.5f,-.25f});
-
-  test.Run(OpTester::ExpectResult::kExpectSuccess);
+TEST(FeaturizersTests, MaxAbsScaler_int8_output_float_double) {
+  TestWrapper<int8_t, float>();
+  TestWrapper<int64_t, double>();
 }
 
-TEST(FeaturizersTests, MaxAbsScaler_double_values) {
-  OpTester test("MaxAbsScalerTransformer", 1, onnxruntime::kMSFeaturizersDomain);
-
-  // State from when the transformer was trained. Corresponds to Version 1 and a
-  // scale of 0
-  test.AddInput<uint8_t>("State", {12}, {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 64});
-
-  // We are adding a scalar Tensor in this instance
-  test.AddInput<double>("X", {5}, {-4, 3, 0, 2, -1});
-
-  // Expected output.
-  test.AddOutput<double>("ScaledValues", {5}, {-1, .75, 0, .5, -.25});
-
-  test.Run(OpTester::ExpectResult::kExpectSuccess);
+TEST(FeaturizersTests, MaxAbsScaler_float_output_float_double) {
+  TestWrapper<float, float>();
+  TestWrapper<double, double>();
 }
-
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/featurizers_ops/min_max_scaler_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/min_max_scaler_transformer_test.cc
@@ -5,56 +5,63 @@
 #include "test/providers/provider_test_utils.h"
 
 #include "Featurizers/MinMaxScalerFeaturizer.h"
+#include "Featurizers/TestHelpers.h"
+#include "Featurizers/../Archive.h"
+
+namespace NS = Microsoft::Featurizer;
 
 namespace onnxruntime {
 namespace test {
 
-TEST(FeaturizersTests, MinMaxScalerTransformer_int8) {
-  OpTester test("MinMaxScalerTransformer", 1, onnxruntime::kMSFeaturizersDomain);
-
-  // Add state input
-  test.AddInput<uint8_t>("State", {6}, {1, 0, 0, 0, 1, 9});
-
-  // We are adding a scalar Tensor in this instance
-  test.AddInput<int8_t>("?1", {1}, {15});
-
-  // Expected output.
-  test.AddOutput<double>("?2", {1}, {1.75});
-
-  test.Run(OpTester::ExpectResult::kExpectSuccess);
+namespace {
+template <typename InputType, typename TransformedType>
+std::vector<uint8_t> GetStream(const std::vector<std::vector<InputType>>& training_batches) {
+  using EstimatorT = NS::Featurizers::MinMaxScalerEstimator<InputType, TransformedType>;
+  EstimatorT estimator(NS::CreateTestAnnotationMapsPtr(1), 0);
+  NS::TestHelpers::Train<EstimatorT, InputType>(estimator, training_batches);
+  auto pTransformer = estimator.create_transformer();
+  NS::Archive ar;
+  pTransformer->save(ar);
+  return ar.commit();
 }
+}  // namespace
 
+TEST(FeaturizersTests, MinMaxScalerTransformer_float) {
+  using InputType = float;
+  using TransformedType = double;
 
-TEST(FeaturizersTests, MinMaxScalerTransformer_float_t) {
+  auto training_batches = NS::TestHelpers::make_vector<std::vector<InputType>>(
+      NS::TestHelpers::make_vector<InputType>(static_cast<InputType>(-1)),
+      NS::TestHelpers::make_vector<InputType>(static_cast<InputType>(-0.5)),
+      NS::TestHelpers::make_vector<InputType>(static_cast<InputType>(0)),
+      NS::TestHelpers::make_vector<InputType>(static_cast<InputType>(1)));
+
+  auto stream = GetStream<InputType, TransformedType>(training_batches);
+
   OpTester test("MinMaxScalerTransformer", 1, onnxruntime::kMSFeaturizersDomain);
-
-  // Add state input
-  test.AddInput<uint8_t>("State", {12}, {1, 0, 0, 0, 0, 0, 128, 191, 0, 0, 128, 63});
-
-  // We are adding a scalar Tensor in this instance
-  test.AddInput<float>("?1", {1}, {2.f});
-
-  // Expected output.
-  test.AddOutput<double>("?2", {1}, {1.5});
-
+  auto dim = static_cast<int64_t>(stream.size());
+  test.AddInput<uint8_t>("State", {dim}, stream);
+  test.AddInput<InputType>("Input", {1}, {2});
+  test.AddOutput<TransformedType>("Output", {1}, {1.5f});
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
 TEST(FeaturizersTests, MinMaxScalerTransformer_only_one_input) {
+  using InputType = int8_t;
+  using TransformedType = double;
+
+  auto training_batches = NS::TestHelpers::make_vector<std::vector<InputType>>(
+      NS::TestHelpers::make_vector<InputType>(static_cast<InputType>(-1)));
+
+  auto stream = GetStream<InputType, TransformedType>(training_batches);
+
   OpTester test("MinMaxScalerTransformer", 1, onnxruntime::kMSFeaturizersDomain);
-
-  // Add state input
-  test.AddInput<uint8_t>("State", {6}, {1, 0, 0, 0, 255, 255});
-
-  // We are adding a scalar Tensor in this instance
-  test.AddInput<int8_t>("?1", {1}, {2});
-
-  // Expected output.
-  test.AddOutput<double>("?2", {1}, {0});
-
+  auto dim = static_cast<int64_t>(stream.size());
+  test.AddInput<uint8_t>("State", {dim}, stream);
+  test.AddInput<InputType>("Input", {1}, {2});
+  test.AddOutput<TransformedType>("Output", {1}, {0.f});
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-
-}
-}
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/featurizers_ops/robust_scaler_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/robust_scaler_transformer_test.cc
@@ -5,105 +5,74 @@
 #include "test/providers/provider_test_utils.h"
 
 #include "Featurizers/RobustScalerFeaturizer.h"
+#include "Featurizers/TestHelpers.h"
+#include "Featurizers/../Archive.h"
+
+namespace NS = Microsoft::Featurizer;
 
 namespace onnxruntime {
 namespace test {
 
-TEST(FeaturizersTests, RobustScalerTransformer_default_with_centering) {
-  OpTester test("RobustScalerTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+namespace {
 
-  // Add state input
-  test.AddInput<uint8_t>("State", {12}, {1, 0, 0, 0, 0, 0, 160, 64, 0, 0, 128, 64});
-
-  // We are adding a scalar Tensor in this instance
-  test.AddInput<int8_t>("?1", {5}, {1, 3, 5, 7, 9});
-
-  // Expected output.
-  test.AddOutput<float>("?2", {5}, {-1.0f,-0.5f, 0.0f, 0.5f, 1.0f});
-
-  test.Run(OpTester::ExpectResult::kExpectSuccess);
+template <typename InputT, typename TransformedT>
+std::vector<uint8_t> GetStream(const std::vector<std::vector<InputT>>& training_batches, bool centering) {
+  using EstimatorT = NS::Featurizers::RobustScalerEstimator<InputT, TransformedT>;
+  auto estimator = EstimatorT::CreateWithDefaultScaling(NS::CreateTestAnnotationMapsPtr(1), 0, centering);
+  NS::TestHelpers::Train<EstimatorT, InputT>(estimator, training_batches);
+  auto pTransformer = estimator.create_transformer();
+  NS::Archive ar;
+  pTransformer->save(ar);
+  return ar.commit();
 }
 
+uint8_t operator"" _ui8(unsigned long long v) {
+  return static_cast<uint8_t>(v);
+}
+
+}  // namespace
+
+TEST(FeaturizersTests, RobustScalerTransformer_input_int8__output_float_centering) {
+  using InputType = uint8_t;
+  using TransformedType = float;
+
+  auto training_batches = NS::TestHelpers::make_vector<std::vector<InputType>>(
+      NS::TestHelpers::make_vector<InputType>(1_ui8),
+      NS::TestHelpers::make_vector<InputType>(7_ui8),
+      NS::TestHelpers::make_vector<InputType>(5_ui8),
+      NS::TestHelpers::make_vector<InputType>(3_ui8),
+      NS::TestHelpers::make_vector<InputType>(9_ui8));
+
+  auto stream = GetStream<InputType, TransformedType>(training_batches, true);
+
+  OpTester test("RobustScalerTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+  auto dim = static_cast<int64_t>(stream.size());
+  test.AddInput<uint8_t>("State", {dim}, stream);
+  test.AddInput<InputType>("Input", {5}, {1_ui8, 3_ui8, 5_ui8, 7_ui8, 9_ui8});
+  test.AddOutput<TransformedType>("Output", {5}, {-1.f, -0.5f, 0.f, 0.5f, 1.f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
 
 TEST(FeaturizersTests, RobustScalarTransformer_default_no_centering) {
+  using InputType = uint8_t;
+  using TransformedType = float;
+
+  auto training_batches = NS::TestHelpers::make_vector<std::vector<InputType>>(
+      NS::TestHelpers::make_vector<InputType>(1_ui8),
+      NS::TestHelpers::make_vector<InputType>(7_ui8),
+      NS::TestHelpers::make_vector<InputType>(5_ui8),
+      NS::TestHelpers::make_vector<InputType>(3_ui8),
+      NS::TestHelpers::make_vector<InputType>(9_ui8));
+
+  auto stream = GetStream<InputType, TransformedType>(training_batches, false);
+
   OpTester test("RobustScalerTransformer", 1, onnxruntime::kMSFeaturizersDomain);
-
-  // Add state input
-  test.AddInput<uint8_t>("State", {12}, {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 64});
-
-  // We are adding a scalar Tensor in this instance
-  test.AddInput<int8_t>("?1", {5}, {1, 3, 5, 7, 9});
-
-  // Expected output.
-  test.AddOutput<float>("?2", {5}, {0.25f, 0.75f, 1.25f, 1.75f, 2.25f});
-
+  auto dim = static_cast<int64_t>(stream.size());
+  test.AddInput<uint8_t>("State", {dim}, stream);
+  test.AddInput<InputType>("Input", {5}, {1_ui8, 3_ui8, 5_ui8, 7_ui8, 9_ui8});
+  test.AddOutput<TransformedType>("Output", {5}, {1.0/4.0, 3./4., 5./4., 7./4., 9./4.});
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
-
-TEST(FeaturizersTests, RobustScalerTransformer_default_no_centering_zero_scale) {
-  OpTester test("RobustScalerTransformer", 1, onnxruntime::kMSFeaturizersDomain);
-
-  // Add state input
-  test.AddInput<uint8_t>("State", {12}, {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
-
-  // We are adding a scalar Tensor in this instance
-  test.AddInput<int8_t>("?1", {3}, {10, 10, 10});
-
-  // Expected output.
-  test.AddOutput<float>("?2", {3}, {10.f, 10.f, 10.f});
-
-  test.Run(OpTester::ExpectResult::kExpectSuccess);
-}
-
-
-TEST(FeaturizersTests, RobustScalarTransformer_default_with_centering_no_scaling) {
-  OpTester test("RobustScalerTransformer", 1, onnxruntime::kMSFeaturizersDomain);
-
-  // Add state input
-  test.AddInput<uint8_t>("State", {12}, {1, 0, 0, 0, 0, 0, 160, 64, 0, 0, 128, 63});
-
-  // We are adding a scalar Tensor in this instance
-  test.AddInput<int8_t>("?1", {5}, {1, 3, 5, 7, 9});
-
-  // Expected output.
-  test.AddOutput<float>("?2", {5}, {-4.f, -2.f, 0.f, 2.f, 4.f});
-
-  test.Run(OpTester::ExpectResult::kExpectSuccess);
-}
-
-
-TEST(FeaturizersTests, RobustScalerTransformer_default_with_centering_custom_scaling) {
-  OpTester test("RobustScalerTransformer", 1, onnxruntime::kMSFeaturizersDomain);
-
-  // Add state input
-  test.AddInput<uint8_t>("State", {12}, {1, 0, 0, 0, 0, 0, 160, 64, 0, 0, 0, 65});
-
-  // We are adding a scalar Tensor in this instance
-  test.AddInput<int8_t>("?1", {5}, {1, 3, 5, 7, 9});
-
-  // Expected output.
-  test.AddOutput<float>("?2", {5}, {-0.5f, -0.25f, 0.f, 0.25f, 0.5f});
-
-  test.Run(OpTester::ExpectResult::kExpectSuccess);
-}
-
-
-TEST(FeaturizersTests, RobustScalerTransformer_default_no_centering_custom_scaling) {
-  OpTester test("RobustScalerTransformer", 1, onnxruntime::kMSFeaturizersDomain);
-
-  // Add state input
-  test.AddInput<uint8_t>("State", {12}, {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 65});
-
-  // We are adding a scalar Tensor in this instance
-  test.AddInput<int8_t>("?1", {5}, {1, 3, 5, 7, 9});
-
-  // Expected output.
-  test.AddOutput<float>("?2", {5}, {0.125f, 0.375f, 0.625f, 0.875f, 1.125f});
-
-  test.Run(OpTester::ExpectResult::kExpectSuccess);
-}
-
-
-}
-}
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
**Description**: 
Obtain serialized transformer state for test purposes dynamically in the tests.

**Motivation and Context**
Some remaining tests feature serialized transformer state hard-coded into the source code. Should the serialization format or the version change the tests would break. This change creates and trains estimators on the fly so the corresponding transformer can be obtained and serialized into an up to date state always suitable for tests to run