### PR TITLE
change additional warning suppress link flag to not override earlier link flags

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -107,3 +107,23 @@ install(TARGETS onnxruntime
         RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 set_target_properties(onnxruntime PROPERTIES FOLDER "ONNXRuntime")
+
+if (onnxruntime_ENABLE_WCOS)
+  if (NOT onnxruntime_BUILD_SHARED_LIB)
+  message(
+      FATAL_ERROR 
+      "Option onnxruntime_ENABLE_WCOS can only be used when onnxruntime_BUILD_SHARED_LIB is also enabled")
+  endif()
+  # The default libraries to link with in Windows are kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib
+  # Remove them and use the onecore umbrella library instead
+  foreach(default_lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdgl32.lib advapi32.lib)
+    set(removed_libs "${removed_libs} /NODEFAULTLIB:${default_lib}")
+  endforeach()
+  set(CMAKE_C_STANDARD_LIBRARIES "${removed_libs} windowsapp.lib")
+  set(CMAKE_CXX_STANDARD_LIBRARIES "${removed_libs} windowsapp.lib")
+  if (onnxruntime_USE_DML)
+    set_property(TARGET onnxruntime APPEND_STRING PROPERTY LINK_FLAGS " /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:directml.dll")
+  else()
+    set_property(TARGET onnxruntime APPEND_STRING PROPERTY LINK_FLAGS " /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll")
+  endif()
+endif()

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -562,11 +562,12 @@ foreach(default_lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib o
 endforeach()
 set(CMAKE_C_STANDARD_LIBRARIES "${removed_libs} onecoreuap.lib")
 set(CMAKE_CXX_STANDARD_LIBRARIES "${removed_libs} onecoreuap.lib")
-set_target_properties(winml_dll
-    PROPERTIES
-    LINK_FLAGS
-    "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll ${delayload_dml}")
+#set_target_properties(winml_dll
+#    PROPERTIES
+#    LINK_FLAGS
+#    "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:api-ms-win-core-winrt-error-l1-1-1.dll /DELAYLOAD:api-ms-win-core-com-l1-1-1.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:directml.dll ${delayload_dml}")
 
+target_link_options(winml_dll PRIVATE /DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:api-ms-win-core-winrt-error-l1-1-1.dll /DELAYLOAD:api-ms-win-core-com-l1-1-1.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:directml.dll /DELAYLOAD:dxcore.dll ${delayload_dml})
 
 set_target_properties(winml_dll
   PROPERTIES
@@ -616,5 +617,4 @@ endif()
 # When cuda is enabled in the pipeline, it sets CMAKE_SHARED_LINKER_FLAGS which affects all targets including winml_dll.
 # However, there are no cuda imports in winml_dll, and the linker throws the 4199 warning.
 # This is needed to allow winml_dll build with cuda enabled.
-#set_property(TARGET winml_dll APPEND_STRING PROPERTY LINK_FLAGS " /ignore:4199")
-target_link_options(winml_dll PRIVATE " /ignore:4199")
+target_link_options(winml_dll PRIVATE /ignore:4199)

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -562,7 +562,12 @@ foreach(default_lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib o
 endforeach()
 set(CMAKE_C_STANDARD_LIBRARIES "${removed_libs} onecoreuap.lib")
 set(CMAKE_CXX_STANDARD_LIBRARIES "${removed_libs} onecoreuap.lib")
-set_target_properties(winml_dll PROPERTIES LINK_FLAGS "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll ${delayload_dml}")
+set_target_properties(winml_dll
+    PROPERTIES
+    LINK_FLAGS
+    "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll ${delayload_dml}")
+
+
 set_target_properties(winml_dll
   PROPERTIES
   FOLDER

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -555,13 +555,6 @@ if (onnxruntime_USE_DML)
   set(delayload_dml "/DELAYLOAD:directml.dll")
 endif(onnxruntime_USE_DML)
 
-# The default libraries to link with in Windows are kernel32.lib;user32.lib;gdi32.lib;winspool.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comdlg32.lib;advapi32.lib
-# Remove them and use the onecore umbrella library instead
-foreach(default_lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdgl32.lib advapi32.lib)
-  set(removed_libs "${removed_libs} /NODEFAULTLIB:${default_lib}")
-endforeach()
-set(CMAKE_C_STANDARD_LIBRARIES "${removed_libs} windowsapp.lib")
-set(CMAKE_CXX_STANDARD_LIBRARIES "${removed_libs} windowsapp.lib")
 
 target_link_options(winml_dll PRIVATE /DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:api-ms-win-core-threadpool-legacy-l1-1-0.dll /DELAYLOAD:api-ms-win-core-processtopology-obsolete-l1-1-0.dll /DELAYLOAD:api-ms-win-core-kernel32-legacy-l1-1-0.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll ${delayload_dml})
 

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -560,14 +560,10 @@ endif(onnxruntime_USE_DML)
 foreach(default_lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdgl32.lib advapi32.lib)
   set(removed_libs "${removed_libs} /NODEFAULTLIB:${default_lib}")
 endforeach()
-set(CMAKE_C_STANDARD_LIBRARIES "${removed_libs} onecoreuap.lib")
-set(CMAKE_CXX_STANDARD_LIBRARIES "${removed_libs} onecoreuap.lib")
-#set_target_properties(winml_dll
-#    PROPERTIES
-#    LINK_FLAGS
-#    "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:api-ms-win-core-winrt-error-l1-1-1.dll /DELAYLOAD:api-ms-win-core-com-l1-1-1.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:directml.dll ${delayload_dml}")
+set(CMAKE_C_STANDARD_LIBRARIES "${removed_libs} windowsapp.lib")
+set(CMAKE_CXX_STANDARD_LIBRARIES "${removed_libs} windowsapp.lib")
 
-target_link_options(winml_dll PRIVATE /DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:api-ms-win-core-winrt-error-l1-1-1.dll /DELAYLOAD:api-ms-win-core-com-l1-1-1.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:directml.dll /DELAYLOAD:dxcore.dll ${delayload_dml})
+target_link_options(winml_dll PRIVATE /DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:api-ms-win-core-winrt-error-l1-1-1.dll /DELAYLOAD:api-ms-win-core-com-l1-1-1.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll ${delayload_dml})
 
 set_target_properties(winml_dll
   PROPERTIES

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -563,7 +563,7 @@ endforeach()
 set(CMAKE_C_STANDARD_LIBRARIES "${removed_libs} windowsapp.lib")
 set(CMAKE_CXX_STANDARD_LIBRARIES "${removed_libs} windowsapp.lib")
 
-target_link_options(winml_dll PRIVATE /DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:api-ms-win-core-winrt-error-l1-1-1.dll /DELAYLOAD:api-ms-win-core-com-l1-1-1.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll ${delayload_dml})
+target_link_options(winml_dll PRIVATE /DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:api-ms-win-core-threadpool-legacy-l1-1-0.dll /DELAYLOAD:api-ms-win-core-processtopology-obsolete-l1-1-0.dll /DELAYLOAD:api-ms-win-core-kernel32-legacy-l1-1-0.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll ${delayload_dml})
 
 set_target_properties(winml_dll
   PROPERTIES

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -562,12 +562,7 @@ foreach(default_lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib o
 endforeach()
 set(CMAKE_C_STANDARD_LIBRARIES "${removed_libs} onecoreuap.lib")
 set(CMAKE_CXX_STANDARD_LIBRARIES "${removed_libs} onecoreuap.lib")
-set_target_properties(winml_dll
-    PROPERTIES
-    LINK_FLAGS
-    "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll ${delayload_dml}")
-
-
+set_target_properties(winml_dll PROPERTIES LINK_FLAGS "/DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll ${delayload_dml}")
 set_target_properties(winml_dll
   PROPERTIES
   FOLDER
@@ -616,7 +611,5 @@ endif()
 # When cuda is enabled in the pipeline, it sets CMAKE_SHARED_LINKER_FLAGS which affects all targets including winml_dll.
 # However, there are no cuda imports in winml_dll, and the linker throws the 4199 warning.
 # This is needed to allow winml_dll build with cuda enabled.
-set_target_properties(winml_dll
-  PROPERTIES
-  LINK_FLAGS
-  "/ignore:4199")
+#set_property(TARGET winml_dll APPEND_STRING PROPERTY LINK_FLAGS " /ignore:4199")
+target_link_options(winml_dll PRIVATE " /ignore:4199")

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -89,12 +89,12 @@ get_winml_test_api_src(${WINML_TEST_SRC_DIR} winml_test_api_src)
 add_winml_test(
   TARGET winml_test_api
   SOURCES ${winml_test_api_src}
-  LIBS winml_test_common
+  LIBS winml_test_common delayimp.lib
 )
 target_compile_definitions(winml_test_api PRIVATE BUILD_GOOGLE_TEST)
 target_precompiled_header(winml_test_api testPch.h)
 
-target_link_options(winml_test_api PRIVATE /DELAYLOAD:d3d12.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll)
+target_link_options(winml_test_api PRIVATE /DELAYLOAD:d3d12.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll)
 
 get_winml_test_scenario_src(${WINML_TEST_SRC_DIR} winml_test_scenario_src winml_test_scenario_libs)
 add_winml_test(
@@ -105,7 +105,7 @@ add_winml_test(
 target_precompiled_header(winml_test_scenario testPch.h)
 target_compile_definitions(winml_test_scenario PRIVATE BUILD_GOOGLE_TEST)
 
-target_link_options(winml_test_scenario PRIVATE /DELAYLOAD:d2d1.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll)
+target_link_options(winml_test_scenario PRIVATE /DELAYLOAD:d2d1.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll)
 
 # During build time, copy any modified collaterals.
 # configure_file(source destination COPYONLY), which configures CMake to copy the file whenever source is modified,

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -94,7 +94,7 @@ add_winml_test(
 target_compile_definitions(winml_test_api PRIVATE BUILD_GOOGLE_TEST)
 target_precompiled_header(winml_test_api testPch.h)
 
-target_link_options(winml_test_api PRIVATE /DELAYLOAD:d3d12.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll)
+target_link_options(winml_test_api PRIVATE /DELAYLOAD:d3d12.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll /DELAYLOAD:api-ms-win-core-winrt-error-l1-*.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-*.dll)
 
 get_winml_test_scenario_src(${WINML_TEST_SRC_DIR} winml_test_scenario_src winml_test_scenario_libs)
 add_winml_test(
@@ -105,7 +105,7 @@ add_winml_test(
 target_precompiled_header(winml_test_scenario testPch.h)
 target_compile_definitions(winml_test_scenario PRIVATE BUILD_GOOGLE_TEST)
 
-target_link_options(winml_test_scenario PRIVATE /DELAYLOAD:d2d1.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll)
+target_link_options(winml_test_scenario PRIVATE /DELAYLOAD:d2d1.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll /DELAYLOAD:api-ms-win-core-winrt-error-l1-*.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-*.dll)
 
 # During build time, copy any modified collaterals.
 # configure_file(source destination COPYONLY), which configures CMake to copy the file whenever source is modified,

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -94,6 +94,8 @@ add_winml_test(
 target_compile_definitions(winml_test_api PRIVATE BUILD_GOOGLE_TEST)
 target_precompiled_header(winml_test_api testPch.h)
 
+target_link_options(winml_test_api PRIVATE /DELAYLOAD:d3d12.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll)
+
 get_winml_test_scenario_src(${WINML_TEST_SRC_DIR} winml_test_scenario_src winml_test_scenario_libs)
 add_winml_test(
   TARGET winml_test_scenario
@@ -102,9 +104,8 @@ add_winml_test(
 )
 target_precompiled_header(winml_test_scenario testPch.h)
 target_compile_definitions(winml_test_scenario PRIVATE BUILD_GOOGLE_TEST)
-set_target_properties(winml_test_scenario PROPERTIES LINK_FLAGS
-  "/DELAYLOAD:d2d1.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll"
-)
+
+target_link_options(winml_test_scenario PRIVATE /DELAYLOAD:d2d1.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll)
 
 # During build time, copy any modified collaterals.
 # configure_file(source destination COPYONLY), which configures CMake to copy the file whenever source is modified,

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -94,8 +94,10 @@ add_winml_test(
 target_compile_definitions(winml_test_api PRIVATE BUILD_GOOGLE_TEST)
 target_precompiled_header(winml_test_api testPch.h)
 
-target_link_options(winml_test_api PRIVATE /DELAYLOAD:d3d12.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:api-ms-win-core-file-l1-2-2.dll /DELAYLOAD:api-ms-win-core-synch-l1-2-1.dll /DELAYLOAD:api-ms-win-core-threadpool-legacy-l1-1-0.dll /DELAYLOAD:api-ms-win-core-processtopology-obsolete-l1-1-0.dll /DELAYLOAD:api-ms-win-core-kernel32-legacy-l1-1-0.dll)
-
+target_link_options(winml_test_api PRIVATE /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll /DELAYLOAD:api-ms-win-core-file-l1-2-2.dll /DELAYLOAD:api-ms-win-core-synch-l1-2-1.dll)
+if (onnxruntime_USE_DML)
+  target_link_options(winml_test_api PRIVATE /DELAYLOAD:directml.dll)
+endif()
 get_winml_test_scenario_src(${WINML_TEST_SRC_DIR} winml_test_scenario_src winml_test_scenario_libs)
 add_winml_test(
   TARGET winml_test_scenario
@@ -105,7 +107,10 @@ add_winml_test(
 target_precompiled_header(winml_test_scenario testPch.h)
 target_compile_definitions(winml_test_scenario PRIVATE BUILD_GOOGLE_TEST)
 
-target_link_options(winml_test_scenario PRIVATE /DELAYLOAD:d2d1.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:api-ms-win-core-file-l1-2-2.dll /DELAYLOAD:api-ms-win-core-synch-l1-2-1.dll)
+target_link_options(winml_test_scenario PRIVATE /DELAYLOAD:d2d1.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll /DELAYLOAD:api-ms-win-core-file-l1-2-2.dll /DELAYLOAD:api-ms-win-core-synch-l1-2-1.dll)
+if (onnxruntime_USE_DML)
+  target_link_options(winml_test_scenario PRIVATE /DELAYLOAD:directml.dll)
+endif()
 
 # During build time, copy any modified collaterals.
 # configure_file(source destination COPYONLY), which configures CMake to copy the file whenever source is modified,

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -94,7 +94,7 @@ add_winml_test(
 target_compile_definitions(winml_test_api PRIVATE BUILD_GOOGLE_TEST)
 target_precompiled_header(winml_test_api testPch.h)
 
-target_link_options(winml_test_api PRIVATE /DELAYLOAD:d3d12.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll /DELAYLOAD:api-ms-win-core-winrt-error-l1-*.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-*.dll)
+target_link_options(winml_test_api PRIVATE /DELAYLOAD:d3d12.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:api-ms-win-core-file-l1-2-2.dll /DELAYLOAD:api-ms-win-core-synch-l1-2-1.dll /DELAYLOAD:api-ms-win-core-threadpool-legacy-l1-1-0.dll /DELAYLOAD:api-ms-win-core-processtopology-obsolete-l1-1-0.dll /DELAYLOAD:api-ms-win-core-kernel32-legacy-l1-1-0.dll)
 
 get_winml_test_scenario_src(${WINML_TEST_SRC_DIR} winml_test_scenario_src winml_test_scenario_libs)
 add_winml_test(
@@ -105,7 +105,7 @@ add_winml_test(
 target_precompiled_header(winml_test_scenario testPch.h)
 target_compile_definitions(winml_test_scenario PRIVATE BUILD_GOOGLE_TEST)
 
-target_link_options(winml_test_scenario PRIVATE /DELAYLOAD:d2d1.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll /DELAYLOAD:api-ms-win-core-winrt-error-l1-*.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-*.dll)
+target_link_options(winml_test_scenario PRIVATE /DELAYLOAD:d2d1.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:directml.dll /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:api-ms-win-core-file-l1-2-2.dll /DELAYLOAD:api-ms-win-core-synch-l1-2-1.dll)
 
 # During build time, copy any modified collaterals.
 # configure_file(source destination COPYONLY), which configures CMake to copy the file whenever source is modified,

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -155,6 +155,7 @@ Use the individual flags to only run the specified stages.
     parser.add_argument("--use_dml", action='store_true', help="Build with DirectML.")
     parser.add_argument("--use_winml", action='store_true', help="Build with WinML.")
     parser.add_argument("--use_telemetry", action='store_true', help="Only official builds can set this flag to enable telemetry.")
+    parser.add_argument("--enable_wcos", action='store_true', help="Build for Windows Core OS.")
     return parser.parse_args()
 
 def resolve_executable_path(command_or_path):
@@ -333,6 +334,7 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
                  "-Donnxruntime_USE_DML=" + ("ON" if args.use_dml else "OFF"),
                  "-Donnxruntime_USE_WINML=" + ("ON" if args.use_winml else "OFF"),
                  "-Donnxruntime_USE_TELEMETRY=" + ("ON" if args.use_telemetry else "OFF"),
+                 "-Donnxruntime_ENABLE_WCOS=" + ("ON" if args.enable_wcos else "OFF")
                  ]
 
     # nGraph and TensorRT providers currently only supports full_protobuf option.

--- a/winml/test/common/dllload.cpp
+++ b/winml/test/common/dllload.cpp
@@ -32,7 +32,7 @@ HRESULT __stdcall WINRT_RoGetActivationFactory(HSTRING classId_hstring, GUID con
     if (starts_with(name, L"Windows.AI.MachineLearning."))
     {
         const wchar_t* libPath = winmlDllPath.c_str();
-        library = LoadLibraryW(libPath);
+        library = LoadLibraryExW(libPath, nullptr, 0);
     }
     else
     {


### PR DESCRIPTION

**Description**: Change the ignore warnings link command to use target_link_options

**Motivation and Context**
The previous command was overriding the earlier set_target_properties LINK_FLAGS command
