### PR TITLE
TensorRT dockerfile updates

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -183,6 +183,10 @@ See more information on the TensorRT Execution Provider [here](./docs/execution_
 
 Dockerfile instructions are available [here](./dockerfiles#tensorrt)
 
+#### Jetson (ARM64 Builds)
+
+See [instructions](https://github.com/microsoft/onnxruntime/issues/2684#issuecomment-568548387) for additional information and tips related to building Onnxruntime with TensorRT Execution Provider on Jetson platforms (TX1/TX2, Nano)
+
 ---
 
 ### DNNL and MKLML
@@ -550,13 +554,13 @@ git clone --recursive https://github.com/Microsoft/onnxruntime
 
 # Start the basic build
 cd /code/onnxruntime
-./build.sh --config MinSizeRel --arm --update --build
+./build.sh --config MinSizeRel --update --build
 
 # Build Shared Library
-./build.sh --config MinSizeRel --arm --build_shared_lib
+./build.sh --config MinSizeRel --build_shared_lib
 
 # Build Python Bindings and Wheel
-./build.sh --config MinSizeRel --arm --enable_pybind --build_wheel
+./build.sh --config MinSizeRel --enable_pybind --build_wheel
 
 # Build Output
 ls -l /code/onnxruntime/build/Linux/MinSizeRel/*.so

--- a/dockerfiles/Dockerfile.tensorrt
+++ b/dockerfiles/Dockerfile.tensorrt
@@ -5,7 +5,7 @@
 # Dockerfile to run ONNXRuntime with TensorRT integration
 
 # nVidia TensorRT Base Image
-FROM nvcr.io/nvidia/tensorrt:19.09-py3
+FROM nvcr.io/nvidia/tensorrt:20.01-py3
 MAINTAINER Vinitra Swamy "viswamy@microsoft.com"
 
 ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime

--- a/dockerfiles/scripts/install_common_deps.sh
+++ b/dockerfiles/scripts/install_common_deps.sh
@@ -15,8 +15,7 @@ wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.
 rm ~/miniconda.sh
 /opt/miniconda/bin/conda clean -ya
 
-/opt/miniconda/bin/conda install -y numpy
-/opt/miniconda/bin/conda clean -aqy
+pip install numpy
 rm -rf /opt/miniconda/pkgs
 
 # Dependencies: cmake


### PR DESCRIPTION
-update Dockerfile.tensorrt    TensorRT 7 integration recently added to ORT, update TensorRT base image dependency to 20.01 (TensorRT 7 release)
-fix build issue for Dockerfile. conda install numpy pulls in many additional dependencies which bloat image size  and also causes a build failure for onnx package install. replace with pip install numpy which avoids these issues.
-fix native ARM build instructions remove --arm options which is only for cross compile.
-add section pointing to instruction/tips for Jetson ARM64 builds. 