### PR TITLE
Optimize Math::Im2col + ConvInteger pointwise

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/conv_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_attributes.h
@@ -183,6 +183,15 @@ struct ConvAttributes {
     return Status::OK();
   }
 
+  bool HasStridesOneAndNoPadding() const {
+    if (std::all_of(strides.begin(), strides.end(), [](int64_t v) { return v == 1; })) {
+      if (std::all_of(pads.begin(), pads.end(), [](int64_t v) { return v == 0; })) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   AutoPadType auto_pad;
   int64_t group;
   bool kernel_shape_specified;

--- a/onnxruntime/core/providers/cpu/nn/conv_integer.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv_integer.cc
@@ -58,18 +58,16 @@ Status ConvInteger::Compute(OpKernelContext* context) const {
     strides.resize(kernel_shape.size(), 1);
   }
 
-  std::vector<int64_t> Y_dims;
-  Y_dims.insert(Y_dims.begin(), {N, M});
+  std::vector<int64_t> Y_dims({N, M});
   TensorShape input_shape = X->Shape().Slice(2);
   ORT_RETURN_IF_ERROR(conv_attrs_.InferOutputShape(input_shape, kernel_shape, strides, dilations, &pads, &Y_dims));
   Tensor* Y = context->Output(0, TensorShape(Y_dims));
   TensorShape output_shape = Y->Shape().Slice(2);
 
-  AllocatorPtr alloc;
-  ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&alloc));
-
-  const auto* Xdata = X->template Data<uint8_t>();
-  auto* Ydata = Y->template MutableData<int32_t>();
+  // Bail out early if one of the dimensions is zero.
+  if (Y->Shape().Size() == 0) {
+    return Status::OK();
+  }
 
   const int64_t input_image_size = input_shape.Size();
   const int64_t output_image_size = output_shape.Size();
@@ -80,53 +78,72 @@ Status ConvInteger::Compute(OpKernelContext* context) const {
   const int64_t kernel_dim = C / conv_attrs_.group * kernel_size;
   const int64_t col_buffer_size = kernel_dim * output_image_size;
 
-  auto col_data = alloc->Alloc(sizeof(uint8_t) * col_buffer_size);
-  BufferUniquePtr col_buffer(col_data, BufferDeleter(alloc));
+  const size_t kernel_rank = kernel_shape.size();
+
+  BufferUniquePtr col_buffer;
+  std::vector<int64_t> col_buffer_shape;
+
+  // Pointwise convolutions can use the original input tensor in place,
+  // otherwise a temporary buffer is required for the im2col transform.
+  if (kernel_size != 1 || !conv_attrs_.HasStridesOneAndNoPadding()) {
+    AllocatorPtr alloc;
+    ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&alloc));
+
+    auto* col_data = alloc->Alloc(sizeof(uint8_t) * col_buffer_size);
+    col_buffer = BufferUniquePtr(col_data, BufferDeleter(alloc));
+
+    if (kernel_rank != 2) {
+      const auto& output_dims = output_shape.GetDims();
+      col_buffer_shape.reserve(1 + output_dims.size());
+      col_buffer_shape.push_back(kernel_dim);
+      col_buffer_shape.insert(col_buffer_shape.end(), output_dims.begin(), output_dims.end());
+    }
+  }
+
   auto* col_buffer_data = static_cast<uint8_t*>(col_buffer.get());
 
-  TensorShape image_shape = X->Shape().Slice(1);
-  std::vector<int64_t> col_buffer_shape{kernel_dim};
-  col_buffer_shape.insert(col_buffer_shape.end(), output_shape.GetDims().begin(),
-                          output_shape.GetDims().end());
-
-  const size_t kernel_rank = kernel_shape.size();
   concurrency::ThreadPool* thread_pool = context->GetOperatorThreadPool();
+
+  const auto* Xdata = X->template Data<uint8_t>();
+  auto* Ydata = Y->template MutableData<int32_t>();
 
   for (int image_id = 0; image_id < N; ++image_id) {
     for (int group_id = 0; group_id < conv_attrs_.group; ++group_id) {
-      if (kernel_rank == 2) {
-        math::Im2col<uint8_t, StorageOrder::NCHW>()(
-            Xdata + group_id * X_offset,
-            C / conv_attrs_.group,
-            input_shape[0],
-            input_shape[1],
-            kernel_shape[0],
-            kernel_shape[1],
-            dilations[0],
-            dilations[1],
-            pads[0],
-            pads[1],
-            pads[2],
-            pads[3],
-            strides[0],
-            strides[1],
-            col_buffer_data,
-            input_offset);
-      } else {
-        math::Im2colNd<uint8_t, StorageOrder::NCHW>()(
-            Xdata + group_id * X_offset,
-            image_shape.GetDims().data(),
-            col_buffer_shape.data(),
-            C * input_image_size,
-            col_buffer_size,
-            kernel_shape.data(),
-            strides.data(),
-            dilations.data(),
-            pads.data(),
-            static_cast<int>(kernel_shape.size()),
-            col_buffer_data,
-            false,
-            input_offset);
+      if (col_buffer_data != nullptr) {
+        if (kernel_rank == 2) {
+          math::Im2col<uint8_t, StorageOrder::NCHW>()(
+              Xdata + group_id * X_offset,
+              C / conv_attrs_.group,
+              input_shape[0],
+              input_shape[1],
+              kernel_shape[0],
+              kernel_shape[1],
+              dilations[0],
+              dilations[1],
+              pads[0],
+              pads[1],
+              pads[2],
+              pads[3],
+              strides[0],
+              strides[1],
+              col_buffer_data,
+              input_offset);
+        } else {
+          math::Im2colNd<uint8_t, StorageOrder::NCHW>()(
+              Xdata + group_id * X_offset,
+              X->Shape().GetDims().data() + 1,
+              col_buffer_shape.data(),
+              C * input_image_size,
+              col_buffer_size,
+              kernel_shape.data(),
+              strides.data(),
+              dilations.data(),
+              pads.data(),
+              static_cast<int>(kernel_rank),
+              col_buffer_data,
+              false,
+              input_offset);
+        }
       }
 
       QGemmu8u8_s32(static_cast<int>(M / conv_attrs_.group),
@@ -135,7 +152,7 @@ Status ConvInteger::Compute(OpKernelContext* context) const {
                     W->template Data<uint8_t>() + group_id * W_offset,
                     static_cast<int>(kernel_dim),
                     filter_offset,
-                    col_buffer_data,
+                    col_buffer_data == nullptr ? Xdata + group_id * X_offset : col_buffer_data,
                     static_cast<int>(output_image_size),
                     input_offset,
                     Ydata + group_id * Y_offset,

--- a/onnxruntime/test/providers/cpu/nn/conv_integer_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_integer_test.cc
@@ -6,7 +6,7 @@
 
 namespace onnxruntime {
 namespace test {
-TEST(ConvIntegerTest, ConvIntegerTest) {
+TEST(ConvIntegerTest, WithoutPadding_2D) {
   OpTester test("ConvInteger", 10);
   std::vector<int64_t> x_dims{1, 1, 3, 3};
   test.AddInput<uint8_t>("x", x_dims,
@@ -25,7 +25,7 @@ TEST(ConvIntegerTest, ConvIntegerTest) {
   test.Run();
 }
 
-TEST(ConvIntegerTest_with_padding, ConvIntegerTest) {
+TEST(ConvIntegerTest, WithPadding_2D) {
   OpTester test("ConvInteger", 10);
   std::vector<int64_t> x_dims{1, 1, 3, 3};
   test.AddInput<uint8_t>("x", x_dims,
@@ -44,6 +44,194 @@ TEST(ConvIntegerTest_with_padding, ConvIntegerTest) {
 	                       5, 12, 16, 9,
                            11, 24, 28, 15,
 	                       7, 15, 17, 9});
+  test.Run();
+}
+
+TEST(ConvIntegerTest, WithGroup_2D) {
+  OpTester test("ConvInteger", 10);
+  std::vector<int64_t> x_dims{1, 3, 3, 3};
+  test.AddInput<uint8_t>("x", x_dims,
+                         {2, 3, 4,
+                          5, 6, 7,
+                          8, 9, 10,
+                          11, 12, 13,
+                          14, 15, 16,
+                          17, 18, 19,
+                          20, 21, 22,
+                          23, 24, 25,
+                          26, 27, 28});
+  std::vector<int64_t> w_dims{3, 1, 2, 2};
+  test.AddInput<uint8_t>("w", w_dims,
+                         {1, 2,
+                          2, 1,
+                          3, 4,
+                          4, 3,
+                          5, 6,
+                          6, 5});
+  test.AddInput<uint8_t>("x_zero_point", {}, {1});
+  test.AddAttribute<std::vector<int64_t>>("pads", {1, 1, 1, 1});
+  test.AddAttribute("group", static_cast<int64_t>(3));
+  std::vector<int64_t> y_dims{1, 3, 4, 4};
+  test.AddOutput<int32_t>("y", y_dims,
+                          {1, 4, 7, 6,
+                           6, 18, 24, 15,
+                           15, 36, 42, 24,
+                           14, 23, 26, 9,
+                           30, 73, 80, 48,
+                           79, 168, 182, 96,
+                           100, 210, 224, 117,
+                           64, 116, 123, 54,
+                           95, 214, 225, 126,
+                           224, 462, 484, 249,
+                           257, 528, 550, 282,
+                           150, 281, 292, 135});
+  test.Run();
+}
+
+TEST(ConvIntegerTest, WithPadding_3D) {
+  OpTester test("ConvInteger", 10);
+  std::vector<int64_t> x_dims{1, 1, 3, 3, 3};
+  test.AddInput<uint8_t>("x", x_dims,
+                         {2, 3, 4,
+                          5, 6, 7,
+                          8, 9, 10,
+                          11, 12, 13,
+                          14, 15, 16,
+                          17, 18, 19,
+                          20, 21, 22,
+                          23, 24, 25,
+                          26, 27, 28});
+  std::vector<int64_t> w_dims{1, 1, 2, 2, 2};
+  test.AddInput<uint8_t>("w", w_dims,
+                         {1, 1,
+                          1, 1,
+                          1, 1,
+                          1, 1});
+  test.AddInput<uint8_t>("x_zero_point", {}, {1});
+  test.AddAttribute<std::vector<int64_t>>("pads", {1, 1, 1, 1, 1, 1});
+  std::vector<int64_t> y_dims{1, 1, 4, 4, 4};
+  test.AddOutput<int32_t>("y", y_dims,
+                          {1, 3, 5, 3,
+                           5, 12, 16, 9,
+                           11, 24, 28, 15,
+                           7, 15, 17, 9,
+                           11, 24, 28, 15,
+                           28, 60, 68, 36,
+                           40, 84, 92, 48,
+                           23, 48, 52, 27,
+                           29, 60, 64, 33,
+                           64, 132, 140, 72,
+                           76, 156, 164, 84,
+                           41, 84, 88, 45,
+                           19, 39, 41, 21,
+                           41, 84, 88, 45,
+                           47, 96, 100, 51,
+                           25, 51, 53, 27});
+  test.Run();
+}
+
+TEST(ConvIntegerTest, Pointwise_2D) {
+  OpTester test("ConvInteger", 10);
+  std::vector<int64_t> x_dims{1, 1, 3, 3};
+  test.AddInput<uint8_t>("x", x_dims,
+                         {2, 3, 4,
+                          5, 6, 7,
+                          8, 9, 10});
+  std::vector<int64_t> w_dims{1, 1, 1, 1};
+  test.AddInput<uint8_t>("w", w_dims, {4});
+  test.AddInput<uint8_t>("x_zero_point", {}, {1});
+  std::vector<int64_t> y_dims{1, 1, 3, 3};
+  test.AddOutput<int32_t>("y", y_dims,
+                          {4, 8, 12,
+	                       16, 20, 24,
+	                       28, 32, 36});
+  test.Run();
+}
+
+TEST(ConvIntegerTest, Pointwise_3D) {
+  OpTester test("ConvInteger", 10);
+  std::vector<int64_t> x_dims{1, 1, 3, 3, 3};
+  test.AddInput<uint8_t>("x", x_dims,
+                         {2, 3, 4,
+                          5, 6, 7,
+                          8, 9, 10,
+                          11, 12, 13,
+                          14, 15, 16,
+                          17, 18, 19,
+                          20, 21, 22,
+                          23, 24, 25,
+                          26, 27, 28});
+  std::vector<int64_t> w_dims{1, 1, 1, 1, 1};
+  test.AddInput<uint8_t>("w", w_dims, {4});
+  test.AddInput<uint8_t>("x_zero_point", {}, {1});
+  std::vector<int64_t> y_dims{1, 1, 3, 3, 3};
+  test.AddOutput<int32_t>("y", y_dims,
+                          {4, 8, 12,
+	                       16, 20, 24,
+	                       28, 32, 36,
+                           40, 44, 48,
+	                       52, 56, 60,
+	                       64, 68, 72,
+                           76, 80, 84,
+	                       88, 92, 96,
+	                       100, 104, 108});
+  test.Run();
+}
+
+TEST(ConvIntegerTest, WithStride2_2D) {
+  OpTester test("ConvInteger", 10);
+  std::vector<int64_t> x_dims{1, 1, 7, 7};
+  test.AddInput<uint8_t>("x", x_dims,
+                         {10, 11, 12, 13, 14, 15, 16,
+                          20, 21, 22, 23, 24, 25, 26,
+                          30, 31, 32, 33, 34, 35, 36,
+                          40, 41, 42, 43, 44, 45, 46,
+                          50, 51, 52, 53, 54, 55, 56,
+                          60, 61, 62, 63, 64, 65, 66,
+                          70, 71, 72, 73, 74, 75, 76});
+  std::vector<int64_t> w_dims{1, 1, 3, 3};
+  test.AddInput<uint8_t>("w", w_dims,
+                         {1, 2, 1,
+                          2, 3, 2,
+                          1, 2, 1});
+  test.AddInput<uint8_t>("x_zero_point", {}, {10});
+  test.AddAttribute<std::vector<int64_t>>("pads", {1, 1, 1, 1});
+  test.AddAttribute<std::vector<int64_t>>("strides", {2, 2});
+  std::vector<int64_t> y_dims{1, 1, 4, 4};
+  test.AddOutput<int32_t>("y", y_dims,
+                          {33, 62, 84, 75,
+	                       224, 330, 360, 282,
+                           444, 630, 660, 502,
+	                       453, 642, 664, 495});
+  // Exercise the (stride_w = 2) path inside Math::Im2col.
+  test.Run();
+}
+
+TEST(ConvIntegerTest, WithStride3_2D) {
+  OpTester test("ConvInteger", 10);
+  std::vector<int64_t> x_dims{1, 1, 7, 7};
+  test.AddInput<uint8_t>("x", x_dims,
+                         {10, 11, 12, 13, 14, 15, 16,
+                          20, 21, 22, 23, 24, 25, 26,
+                          30, 31, 32, 33, 34, 35, 36,
+                          40, 41, 42, 43, 44, 45, 46,
+                          50, 51, 52, 53, 54, 55, 56,
+                          60, 61, 62, 63, 64, 65, 66,
+                          70, 71, 72, 73, 74, 75, 76});
+  std::vector<int64_t> w_dims{1, 1, 3, 3};
+  test.AddInput<uint8_t>("w", w_dims,
+                         {1, 2, 1,
+                          2, 3, 2,
+                          1, 2, 1});
+  test.AddInput<uint8_t>("x_zero_point", {}, {10});
+  test.AddAttribute<std::vector<int64_t>>("pads", {2, 2, 1, 1});
+  test.AddAttribute<std::vector<int64_t>>("strides", {3, 3});
+  std::vector<int64_t> y_dims{1, 1, 3, 3};
+  test.AddOutput<int32_t>("y", y_dims,
+                          {0, 8, 20,
+	                       80, 330, 375,
+                           200, 780, 825});
+  // Exercise the (stride_w > 2) path inside Math::Im2col.
   test.Run();
 }
 


### PR DESCRIPTION
**Description**: Optimize the implementation of Math::Im2col that is currently used for ConvInteger/QLinearConv. Also, avoid Im2col for pointwise convolutions in ConvInteger.

**Motivation and Context**
More incremental work to improve model performance when using ConvInteger/QLinearConv. For ConvInteger, all large percentage of time is spent in the im2col transform. This change simplifies Math::Im2col while speeding up the transform. Most of the observed speed gain is from this part of the change.

This also implements the standard optimization of not needing to do an im2col for a pointwise convolution as the input tensor is already in the correct format for the GEMM.

For a quantized resnet50 based on ConvInteger, the inference time went from 72ms->60ms.

One experiment was to handle the stride_w=2 convolutions by using SSE instructions to load 16 bytes, swizzle to 8 bytes, and write that out. That did help a bit but the resnet50 inference time only went down by <1ms, so this was avoided for now. Multi-threading the im2col with the GEMM would also help (as done for MlasConv for float data), but that can now be evaluated against a more reasonable im2col baseline.

Added more ConvInteger tests that exercise more code paths, including 3D, pointwise, and various strides. The new im2col was also tested in isolation with a larger range of parameters and compared to the old im2col. I also updated the non-MLAS path for Conv<float> to use the same pattern as ConvInteger and verified that the results were identical for several CNNs.
