### PR TITLE
Make UpsampleBilinear multithreaded

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -393,7 +393,7 @@ void UpsampleBilinear(int64_t batch_size,
     thread_pool->ParallelFor(static_cast<int32_t>(batch_size * num_channels), interpolate);
   } else {
     for (int64_t i = 0; i < batch_size * num_channels; i++) {
-      interpolate(i);
+      interpolate(static_cast<int32_t>(i));
     }
   }
 }


### PR DESCRIPTION
**Description**: UpsampleBilinear was a bottleneck for being single-threaded. I'm parallelizing it by batch and channel.

UNet model being bottlenecked on Concat and Upsample, which are single-threaded:

![Upsample+Concat](https://user-images.githubusercontent.com/5521887/74491607-fddb2780-4e80-11ea-81ec-28bd861b866d.png)

You can see a lot of time spent using a single CPU. Same model, with parallel upsampled highlighted:

![ParallelUpsample](https://user-images.githubusercontent.com/5521887/74491636-10556100-4e81-11ea-9b0f-f97dde3fecae.png)