### PR TITLE
fix type constraint name of operator Resize

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/resize.cc
+++ b/onnxruntime/core/providers/cpu/tensor/resize.cc
@@ -33,21 +33,21 @@ ONNX_CPU_OPERATOR_TYPED_KERNEL(
     Resize,
     11,
     float,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    KernelDefBuilder().TypeConstraint("T1", DataTypeImpl::GetTensorType<float>()),
     Resize<float>);
 
 ONNX_CPU_OPERATOR_TYPED_KERNEL(
     Resize,
     11,
     int32_t,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<int32_t>()),
+    KernelDefBuilder().TypeConstraint("T1", DataTypeImpl::GetTensorType<int32_t>()),
     Resize<int32_t>);
 
 ONNX_CPU_OPERATOR_TYPED_KERNEL(
     Resize,
     11,
     uint8_t,
-    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<uint8_t>()),
+    KernelDefBuilder().TypeConstraint("T1", DataTypeImpl::GetTensorType<uint8_t>()),
     Resize<uint8_t>);
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/tensor/resize.cc
+++ b/onnxruntime/core/providers/cuda/tensor/resize.cc
@@ -5,28 +5,28 @@
 
 namespace onnxruntime {
 namespace cuda {
-#define REGISTER_KERNEL_TYPED(T)                                  \
-  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                        \
-      Resize,                                                     \
-      kOnnxDomain,                                                \
-      10, 10,                                                     \
-      T,                                                          \
-      kCudaExecutionProvider,                                     \
-      KernelDefBuilder()                                          \
-          .InputMemoryType<OrtMemTypeCPUInput>(1)                 \
-          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
-      Resize<T>);                                                 \
-  ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
-      Resize,                                                     \
-      kOnnxDomain,                                                \
-      11,                                                         \
-      T,                                                          \
-      kCudaExecutionProvider,                                     \
-      KernelDefBuilder()                                          \
-          .InputMemoryType<OrtMemTypeCPUInput>(1)                 \
-          .InputMemoryType<OrtMemTypeCPUInput>(2)                 \
-          .InputMemoryType<OrtMemTypeCPUInput>(3)                 \
-          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+#define REGISTER_KERNEL_TYPED(T)                                   \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                         \
+      Resize,                                                      \
+      kOnnxDomain,                                                 \
+      10, 10,                                                      \
+      T,                                                           \
+      kCudaExecutionProvider,                                      \
+      KernelDefBuilder()                                           \
+          .InputMemoryType<OrtMemTypeCPUInput>(1)                  \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()),  \
+      Resize<T>);                                                  \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                   \
+      Resize,                                                      \
+      kOnnxDomain,                                                 \
+      11,                                                          \
+      T,                                                           \
+      kCudaExecutionProvider,                                      \
+      KernelDefBuilder()                                           \
+          .InputMemoryType<OrtMemTypeCPUInput>(1)                  \
+          .InputMemoryType<OrtMemTypeCPUInput>(2)                  \
+          .InputMemoryType<OrtMemTypeCPUInput>(3)                  \
+          .TypeConstraint("T1", DataTypeImpl::GetTensorType<T>()), \
       Resize<T>);
 
 REGISTER_KERNEL_TYPED(float)


### PR DESCRIPTION
**Description**: in opset11, `Resize`'s first type constraint change from `"T"` to `"T1"`, but the current implementation still uses "T". This issue causes a model initialization failure if the type is not `float` (GPU) , or is not one of `uint8`, `int32`, `float` (CPU).