### PR TITLE
Fix target platform of managed OnnxRuntime dll and enable x86 .NET testing

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFramework)' == ''">netcoreapp2.1</TargetFramework>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net461'">win-x64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
     <OnnxRuntimeCsharpRoot>$(MSBuildThisFileDirectory)..\..</OnnxRuntimeCsharpRoot>
     <Platform>AnyCPU</Platform>

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFramework)' == ''">netcoreapp2.1</TargetFramework>
+    <!--<TargetFramework Condition="'$(TargetFramework)' == ''">netcoreapp2.1</TargetFramework>-->
     <IsPackable>false</IsPackable>
     <OnnxRuntimeCsharpRoot>$(MSBuildThisFileDirectory)..\..</OnnxRuntimeCsharpRoot>
     <Platform>AnyCPU</Platform>

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFramework)' == ''">netcoreapp2.1</TargetFramework>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net461'">win-x64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
     <OnnxRuntimeCsharpRoot>$(MSBuildThisFileDirectory)..\..</OnnxRuntimeCsharpRoot>
     <Platform>AnyCPU</Platform>

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!--<TargetFramework Condition="'$(TargetFramework)' == ''">netcoreapp2.1</TargetFramework>-->
+    <TargetFramework Condition="'$(TargetFramework)' == ''">netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <OnnxRuntimeCsharpRoot>$(MSBuildThisFileDirectory)..\..</OnnxRuntimeCsharpRoot>
     <Platform>AnyCPU</Platform>

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
@@ -38,6 +38,7 @@ IF EXIST test\Microsoft.ML.OnnxRuntime.EndToEndTests\bin RMDIR /S /Q test\Micros
 IF EXIST test\Microsoft.ML.OnnxRuntime.EndToEndTests\obj RMDIR /S /Q test\Microsoft.ML.OnnxRuntime.EndToEndTests\obj
 
 @echo %CurrentOnnxRuntimeVersion%
+%dn% clean test\Microsoft.ML.OnnxRuntime.EndToEndTests\Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
 %dn% restore test\Microsoft.ML.OnnxRuntime.EndToEndTests\Microsoft.ML.OnnxRuntime.EndToEndTests.csproj --configfile .\Nuget.CSharp.config --no-cache --packages test\Microsoft.ML.OnnxRuntime.EndToEndTests\packages --source https://api.nuget.org/v3/index.json --source  %LocalNuGetRepo%
 
 IF NOT errorlevel 0 (

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
@@ -1,6 +1,3 @@
-REM Copyright (c) Microsoft Corporation. All rights reserved.
-REM Licensed under the MIT License.
-
 @ECHO ON
 SETLOCAL EnableDelayedExpansion
 
@@ -17,10 +14,19 @@ IF NOT "%4"=="" (
     echo "Usage: runtest.bat LocalNuGetRepoPath TargetFramework TargetArch NuGetPackageVersion"
 )
 
+IF "%TargetArch%"=="AnyCPU" (
+    IF "%TargetFramework%"=="net461" (
+        @echo "Can't build AnyCPU app for .NET Framework"
+        EXIT 1
+    )
+)
+
+IF "%TargetArch%"=="x64" (
+  SET RuntimeIdentifier=win-x64
+)
+
 IF "%TargetArch%"=="x86" (
-  SET dn="C:\Program Files (x86)\dotnet\dotnet"
   SET RuntimeIdentifier=win-x86
-  SET PlatformTarget=x86
 )
 
 ECHO Target Framework is %TargetFramework%

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
@@ -19,11 +19,13 @@ IF NOT "%4"=="" (
 
 IF "%TargetArch%"=="x64" (
   SET RuntimeIdentifier=win-x64
+  SET PlatformTarget=x64
 )
 
 IF "%TargetArch%"=="x86" (
   SET dn="C:\Program Files (x86)\dotnet\dotnet"
   SET RuntimeIdentifier=win-x86
+  SET PlatformTarget=x86
 )
 
 ECHO Target Framework is %TargetFramework%

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
@@ -31,8 +31,10 @@ ECHO Target Framework is %TargetFramework%
 REM Update if CUDA lib paths if set
 SET PATH=%CUDA_PATH%\bin;%CUDNN_PATH%\bin;%PATH%
 
+IF EXIST test\Microsoft.ML.OnnxRuntime.EndToEndTests\packages RMDIR /S /Q test\Microsoft.ML.OnnxRuntime.EndToEndTests\packages
+
 @echo %CurrentOnnxRuntimeVersion%
-%dn% restore test\Microsoft.ML.OnnxRuntime.EndToEndTests\Microsoft.ML.OnnxRuntime.EndToEndTests.csproj --configfile .\Nuget.CSharp.config --no-cache --packages test\Microsoft.ML.OnnxRuntime.EndToEndTests --source https://api.nuget.org/v3/index.json --source  %LocalNuGetRepo%
+%dn% restore test\Microsoft.ML.OnnxRuntime.EndToEndTests\Microsoft.ML.OnnxRuntime.EndToEndTests.csproj --configfile .\Nuget.CSharp.config --no-cache --packages test\Microsoft.ML.OnnxRuntime.EndToEndTests\packages --source https://api.nuget.org/v3/index.json --source  %LocalNuGetRepo%
 
 IF NOT errorlevel 0 (
     @echo "Failed to restore nuget packages for the test project"

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
@@ -34,6 +34,8 @@ REM Update if CUDA lib paths if set
 SET PATH=%CUDA_PATH%\bin;%CUDNN_PATH%\bin;%PATH%
 
 IF EXIST test\Microsoft.ML.OnnxRuntime.EndToEndTests\packages RMDIR /S /Q test\Microsoft.ML.OnnxRuntime.EndToEndTests\packages
+IF EXIST test\Microsoft.ML.OnnxRuntime.EndToEndTests\bin RMDIR /S /Q test\Microsoft.ML.OnnxRuntime.EndToEndTests\bin
+IF EXIST test\Microsoft.ML.OnnxRuntime.EndToEndTests\obj RMDIR /S /Q test\Microsoft.ML.OnnxRuntime.EndToEndTests\obj
 
 @echo %CurrentOnnxRuntimeVersion%
 %dn% restore test\Microsoft.ML.OnnxRuntime.EndToEndTests\Microsoft.ML.OnnxRuntime.EndToEndTests.csproj --configfile .\Nuget.CSharp.config --no-cache --packages test\Microsoft.ML.OnnxRuntime.EndToEndTests\packages --source https://api.nuget.org/v3/index.json --source  %LocalNuGetRepo%

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
@@ -1,3 +1,6 @@
+REM Copyright (c) Microsoft Corporation. All rights reserved.
+REM Licensed under the MIT License.
+
 @ECHO ON
 SETLOCAL EnableDelayedExpansion
 
@@ -14,18 +17,12 @@ IF NOT "%4"=="" (
     echo "Usage: runtest.bat LocalNuGetRepoPath TargetFramework TargetArch NuGetPackageVersion"
 )
 
-IF "%TargetArch%"=="AnyCPU" (
-    IF "%TargetFramework%"=="net461" (
-        @echo "Can't build AnyCPU app for .NET Framework"
-        EXIT 1
-    )
-)
-
 IF "%TargetArch%"=="x64" (
   SET RuntimeIdentifier=win-x64
 )
 
 IF "%TargetArch%"=="x86" (
+  SET dn="C:\Program Files (x86)\dotnet\dotnet"
   SET RuntimeIdentifier=win-x86
 )
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -577,8 +577,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             }
         }
 
-        /*
-        [Fact]
+        [SkipNonPackageTests]
         private void TestRegisterCustomOpLibrary()
         {
             using (var option = new SessionOptions())
@@ -656,7 +655,6 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 }
             }
         }
-        */
 
         [Fact]
         private void TestSymbolicDimsMetadata()
@@ -1459,6 +1457,18 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 if (testOnGpu == null || !testOnGpu.Equals("ON"))
                 {
                     Skip = "GPU testing not enabled";
+                }
+            }
+        }
+
+        private class SkipNonPackageTests : FactAttribute
+        {
+            public SkipNonPackageTests()
+            {
+                var skipNonPackageTests = System.Environment.GetEnvironmentVariable("SKIPNONPACKAGETESTS");
+                if (skipNonPackageTests != null && skipNonPackageTests.Equals("ON"))
+                {
+                    Skip = "Test skipped while testing the package as it is not within the scope";
                 }
             }
         }

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -577,6 +577,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             }
         }
 
+        /*
         [Fact]
         private void TestRegisterCustomOpLibrary()
         {
@@ -655,6 +656,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 }
             }
         }
+        */
 
         [Fact]
         private void TestSymbolicDimsMetadata()

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-mklml.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-mklml.yml
@@ -173,3 +173,5 @@ jobs:
       targetPath: '$(Build.ArtifactStagingDirectory)'
 
 - template: test_all_os.yml
+  parameters:
+    Skipx86Tests: 'true'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
@@ -126,6 +126,8 @@ jobs:
 - template: test_win.yml
   parameters:
     AgentPool : 'Win-GPU-2019'
+    Skipx86Tests: 'true'
+
 - template: test_linux.yml
   parameters:
     AgentPool : $(AgentPoolLinux)

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_all_os.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_all_os.yml
@@ -1,8 +1,12 @@
 # test NuGet package on Win, Linux and MacOS
+parameters:
+  Skipx86Tests: 'false'
+
 jobs:
 - template: test_win.yml
   parameters:
     AgentPool : 'Win-CPU-2019'
+    Skipx86Tests : ${{ parameters.Skipx86Tests }}
 - template: test_linux.yml
   parameters:
     AgentPool : $(AgentPoolLinux)

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -11,7 +11,7 @@ jobs:
   - NuGet_Packaging
   condition: succeeded()
   variables:
-    SKIPNONPACKAGETESTS: 'ON'
+  - SKIPNONPACKAGETESTS: 'ON'
   - group: ORT_TEST_DATA_SAS
   - name: OnnxRuntimeBuildDirectory
     value: '$(Build.BinariesDirectory)'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -11,7 +11,7 @@ jobs:
   - NuGet_Packaging
   condition: succeeded()
   variables:
-  - SKIPNONPACKAGETESTS: 'ON'
+  SKIPNONPACKAGETESTS: 'ON'
   - group: ORT_TEST_DATA_SAS
   - name: OnnxRuntimeBuildDirectory
     value: '$(Build.BinariesDirectory)'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -13,7 +13,7 @@ jobs:
   variables:
   - group: ORT_TEST_DATA_SAS
   - name: OnnxRuntimeBuildDirectory
-  - SKIPNONPACKAGETESTS: 'ON'
+  - SKIPNONPACKAGETESTS: ON
     value: '$(Build.BinariesDirectory)'
 
   steps:

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -70,7 +70,6 @@ jobs:
      test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact netcoreapp2.1 x86 $(NuGetPackageVersionNumber)
     workingDirectory: '$(Build.SourcesDirectory)\csharp'
     displayName: 'Run End to End Test (C#) .Net Core x86'
-    enabled: false
 
   - script: |
      @echo "Running Runtest.bat"
@@ -83,7 +82,6 @@ jobs:
      test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact net461 x86 $(NuGetPackageVersionNumber)
     workingDirectory: '$(Build.SourcesDirectory)\csharp'
     displayName: 'Run End to End Test (C#) .NetFramework x86'
-    enabled: false
 
   - script: |
      @echo "Running runtest.bat"

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -91,6 +91,7 @@ jobs:
          test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact net461 x86 $(NuGetPackageVersionNumber)
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
         displayName: 'Run End to End Test (C#) .NetFramework x86'
+        enabled: false
 
   - script: |
      @echo "Running runtest.bat"

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -62,6 +62,8 @@ jobs:
     parameters:
       packageFolder: '$(Build.BinariesDirectory)\nuget-artifact'
 
+  # TODO: Add .Net Core AnyCPU test task
+
   - script: |
      @echo "Running Runtest.bat"
      test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact netcoreapp2.1 x64 $(NuGetPackageVersionNumber)
@@ -74,6 +76,8 @@ jobs:
          test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact netcoreapp2.1 x86 $(NuGetPackageVersionNumber)
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
         displayName: 'Run End to End Test (C#) .Net Core x86'
+
+  # TODO: Add .Net Framework AnyCPU test task
 
   - script: |
      @echo "Running Runtest.bat"

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -13,8 +13,8 @@ jobs:
   variables:
   - group: ORT_TEST_DATA_SAS
   - name: OnnxRuntimeBuildDirectory
+  - SKIPNONPACKAGETESTS: 'ON'
     value: '$(Build.BinariesDirectory)'
-    SKIPNONPACKAGETESTS: 'ON'
 
   steps:
   - task: UsePythonVersion@0

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -66,7 +66,7 @@ jobs:
      @echo "Running Runtest.bat"
      test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact netcoreapp2.1 x64 $(NuGetPackageVersionNumber)
     workingDirectory: '$(Build.SourcesDirectory)\csharp'
-    displayName: 'Run End to End Test (C#) .Net Core'
+    displayName: 'Run End to End Test (C#) .Net Core x64'
 
   - ${{ if ne(parameters['Skipx86Tests'], 'true') }}:
       - script: |
@@ -79,7 +79,7 @@ jobs:
      @echo "Running Runtest.bat"
      test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact net461 x64 $(NuGetPackageVersionNumber)
     workingDirectory: '$(Build.SourcesDirectory)\csharp'
-    displayName: 'Run End to End Test (C#) .NetFramework'
+    displayName: 'Run End to End Test (C#) .NetFramework x64'
 
   - ${{ if ne(parameters['Skipx86Tests'], 'true') }}:
       - script: |

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -11,9 +11,9 @@ jobs:
   - NuGet_Packaging
   condition: succeeded()
   variables:
+    SKIPNONPACKAGETESTS: 'ON'
   - group: ORT_TEST_DATA_SAS
   - name: OnnxRuntimeBuildDirectory
-  - SKIPNONPACKAGETESTS: ON
     value: '$(Build.BinariesDirectory)'
 
   steps:

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -11,10 +11,11 @@ jobs:
   - NuGet_Packaging
   condition: succeeded()
   variables:
-  SKIPNONPACKAGETESTS: 'ON'
   - group: ORT_TEST_DATA_SAS
   - name: OnnxRuntimeBuildDirectory
     value: '$(Build.BinariesDirectory)'
+  - name: SKIPNONPACKAGETESTS
+    value: 'ON'
 
   steps:
   - task: UsePythonVersion@0

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -1,5 +1,6 @@
 parameters:
   AgentPool : 'Win-CPU'
+  Skipx86Tests: 'false'
 
 jobs:
 - job: NuGet_Test_Win
@@ -13,6 +14,7 @@ jobs:
   - group: ORT_TEST_DATA_SAS
   - name: OnnxRuntimeBuildDirectory
     value: '$(Build.BinariesDirectory)'
+    SKIPNONPACKAGETESTS: 'ON'
 
   steps:
   - task: UsePythonVersion@0
@@ -65,11 +67,12 @@ jobs:
     workingDirectory: '$(Build.SourcesDirectory)\csharp'
     displayName: 'Run End to End Test (C#) .Net Core'
 
-  - script: |
-     @echo "Running Runtest.bat"
-     test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact netcoreapp2.1 x86 $(NuGetPackageVersionNumber)
-    workingDirectory: '$(Build.SourcesDirectory)\csharp'
-    displayName: 'Run End to End Test (C#) .Net Core x86'
+  - ${{ if ne(parameters['Skipx86Tests'], 'true') }}:
+      - script: |
+         @echo "Running Runtest.bat"
+         test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact netcoreapp2.1 x86 $(NuGetPackageVersionNumber)
+        workingDirectory: '$(Build.SourcesDirectory)\csharp'
+        displayName: 'Run End to End Test (C#) .Net Core x86'
 
   - script: |
      @echo "Running Runtest.bat"
@@ -77,11 +80,12 @@ jobs:
     workingDirectory: '$(Build.SourcesDirectory)\csharp'
     displayName: 'Run End to End Test (C#) .NetFramework'
 
-  - script: |
-     @echo "Running Runtest.bat"
-     test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact net461 x86 $(NuGetPackageVersionNumber)
-    workingDirectory: '$(Build.SourcesDirectory)\csharp'
-    displayName: 'Run End to End Test (C#) .NetFramework x86'
+  - ${{ if ne(parameters['Skipx86Tests'], 'true') }}:
+      - script: |
+         @echo "Running Runtest.bat"
+         test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact net461 x86 $(NuGetPackageVersionNumber)
+        workingDirectory: '$(Build.SourcesDirectory)\csharp'
+        displayName: 'Run End to End Test (C#) .NetFramework x86'
 
   - script: |
      @echo "Running runtest.bat"

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-2019.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-2019.yml
@@ -30,8 +30,6 @@ jobs:
     DotNetExe: 'dotnet.exe'
     CUDA_VERSION: ${{ parameters.CudaVersion }}
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    PlatformTarget: ${{ parameters.BuildArch }}
-    RuntimeIdentifier: win-${{ parameters.BuildArch }}
 
   steps:
     - powershell: |


### PR DESCRIPTION
This change has two parts:
     1) Building the manged assembly `Microsoft.ML.OnnxRuntime.dll` for the platform "Any CPU". With #2711, the managed assembly was being built for the x64 platform and this will break x86 projects.
     2) Enabling x86 testing so as to prevent such regressions in the future