### PR TITLE
Move some vectors out of loops to minimize memory allocations/reallocations

### DIFF
--- a/onnxruntime/core/providers/cpu/ml/linearregressor.cc
+++ b/onnxruntime/core/providers/cpu/ml/linearregressor.cc
@@ -35,9 +35,12 @@ Status LinearRegressor<float>::Compute(OpKernelContext* ctx) const {
   int64_t yindex = 0;
 
   bool useIntercepts = intercepts_.size() == static_cast<size_t>(targets_);
+  std::vector<float> scores;
+  scores.reserve(targets_);
+
   for (int64_t i = 0; i < N; i++)  //for each point
   {
-    std::vector<float> scores;
+    scores.clear();
     int64_t current_weight_0 = i * stride;
     for (int j = 0; j < targets_; j++)  //for each target
     {

--- a/onnxruntime/core/providers/cpu/ml/svmclassifier.cc
+++ b/onnxruntime/core/providers/cpu/ml/svmclassifier.cc
@@ -159,7 +159,7 @@ Status SVMClassifier<T>::Compute(OpKernelContext* ctx) const {
         kernels.push_back(val);
       }
 
-      votes.resize(class_count_, 0);
+      votes.assign(class_count_, 0);
       for (int64_t i = 0; i < class_count_; i++) {        // for each class
         for (int64_t j = i + 1; j < class_count_; j++) {  // for each class
           double sum = 0;


### PR DESCRIPTION
**Description**: 
Move some vectors out of loops to minimize memory allocations/reallocations.
Remove some unused/unnecessary vectors.

**Motivation and Context**
Makes LinearRegressor 4x faster and SVMClassifier 10% faster (figures from perf tests of SKL unit test models). 