### PR TITLE
Add logging to nchwc_optimizer_test.cc

### DIFF
--- a/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
@@ -237,7 +237,7 @@ void NchwcOptimizerTester(const std::function<void(NchwcTestHelper& helper)>& bu
                         helper.per_sample_tolerance_,
                         relative_per_sample_tolerance,
                         false);
-    EXPECT_EQ(ret.first, COMPARE_RESULT::SUCCESS);
+    EXPECT_EQ(ret.first, COMPARE_RESULT::SUCCESS) << ret.second;
   }
 }
 


### PR DESCRIPTION
**Description**: 

Useful for debugging issue.  

Sample output:
```
/home/chasun/src/onnxruntime/onnxruntime/test/optimizer/nchwc_optimizer_test.cc:240: Failure
Expected equality of these values:
  ret.first
    Which is: 4-byte object <01-00 00-00>
  COMPARE_RESULT::SUCCESS
    Which is: 4-byte object <00-00 00-00>
expected 1920.92 (44f01d6e), got 1920.92 (44f01d70), diff: 0.000244141, tol=0.000125. 10 of 13566 differ
```

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
