### PR TITLE
Ignore GCC no-deprecated-copy warnings

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -603,7 +603,7 @@ else()
   endif()
   if(HAS_DEPRECATED_COPY)
     #too many such errors in eigen and gemmlowp
-    string(APPEND CMAKE_CXX_FLAGS_DEBUG " -Wno-deprecated-copy")
+    string(APPEND CMAKE_CXX_FLAGS " -Wno-deprecated-copy")
   endif()
   if(HAS_PARENTHESES)
     string(APPEND CMAKE_CXX_FLAGS " -Wno-parentheses")


### PR DESCRIPTION
**Description**: 
For more info, see: https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming)

We should always obey the rule, but some of the ORT dependencies are out of our control. e.g. Eigen, SafeInt.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
