### PR TITLE
Fix python gpu build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ try:
                 logger.info('copying %s -> %s', source, dest)
                 copyfile(source, dest)
                 result = subprocess.run(['patchelf', '--print-needed', dest], check=True, stdout=subprocess.PIPE, universal_newlines=True)
-                cuda_dependencies = ['libcublas.so', 'libcudnn.so', 'libcudart.so']
+                cuda_dependencies = ['libcublas.so', 'libcudnn.so', 'libcudart.so', 'libcurand.so']
                 to_preload = []
                 args = ['patchelf', '--debug']
                 for line in result.stdout.split('\n'):


### PR DESCRIPTION
**Description**: 
The problem was introduced in #2999. After that, we can't publish our python wheels to pypi because the package size is too big.


**Motivation and Context**
- Why is this change required? What problem does it solve?

- If it fixes an open issue, please link to the issue here.
