### PR TITLE
Fixes #3071 and adds the version number back to the jar files

### DIFF
--- a/cmake/onnxruntime_java.cmake
+++ b/cmake/onnxruntime_java.cmake
@@ -50,6 +50,30 @@ file(GLOB onnxruntime4j_native_src
     )
 # Build the JNI library
 add_library(onnxruntime4j_jni SHARED ${onnxruntime4j_native_src})
+
+# Tell the JNI code about the requested providers
+if (onnxruntime_USE_CUDA)
+  target_compile_definitions(onnxruntime4j_jni PRIVATE USE_CUDA=1)
+endif()
+if (onnxruntime_USE_DNNL)
+  target_compile_definitions(onnxruntime4j_jni PRIVATE USE_DNNL=1)
+endif()
+if (onnxruntime_USE_NGRAPH)
+  target_compile_definitions(onnxruntime4j_jni PRIVATE USE_NGRAPH=1)
+endif()
+if (onnxruntime_USE_OPENVINO)
+  target_compile_definitions(onnxruntime4j_jni PRIVATE USE_OPENVINO=1)
+endif()
+if (onnxruntime_USE_TENSORRT)
+  target_compile_definitions(onnxruntime4j_jni PRIVATE USE_TENSORRT=1)
+endif()
+if (onnxruntime_USE_NNAPI)
+  target_compile_definitions(onnxruntime4j_jni PRIVATE USE_NNAPI=1)
+endif()
+if (onnxruntime_USE_NUPHAR)
+  target_compile_definitions(onnxruntime4j_jni PRIVATE USE_NUPHAR=1)
+endif()
+
 # depend on java sources. if they change, the JNI should recompile
 add_dependencies(onnxruntime4j_jni onnxruntime4j)
 onnxruntime_add_include_to_target(onnxruntime4j_jni onnxruntime_session)

--- a/java/README.md
+++ b/java/README.md
@@ -33,16 +33,16 @@ The build will generate output in `$REPO_ROOT/build/$OS/$CONFIGURATION/java/buil
 
 * `docs/javadoc/` - HTML javadoc
 * `reports/` - detailed test results and other reports
-* `libs/onnxruntime.jar` - JAR with classes, depends on `onnxruntime-jni.jar` and `onnxruntime-lib.jar `
-* `libs/onnxruntime-jni.jar`- JAR with JNI shared library
-* `libs/onnxruntime-lib.jar` - JAR with onnxruntime shared library
-* `libs/onnxruntime-all.jar` - the 3 preceding jars all combined: JAR with classes, JNI shared library, and onnxruntime shared library
+* `libs/onnxruntime-<version-number>.jar` - JAR with classes, depends on `onnxruntime-<version-number>-jni.jar` and `onnxruntime-<version-number>-lib.jar `
+* `libs/onnxruntime-<version-number>-jni.jar`- JAR with JNI shared library
+* `libs/onnxruntime-<version-number>-lib.jar` - JAR with onnxruntime shared library
+* `libs/onnxruntime-<version-number>-all.jar` - the 3 preceding jars all combined: JAR with classes, JNI shared library, and onnxruntime shared library
 
 The reason the shared libraries are split out like that is that users can mix and match to suit their use case:
 
-* To support a single OS/Architecture without any dependencies, use `libs/onnxruntime-all.jar`.
-* To support cross-platform: bundle a single `libs/onnxruntime.jar` and with all of the respective `libs/onnxruntime-jni.jar` and `libs/onnxruntime-lib.jar` for all of the desired OS/Architectures.
-* To support use case where an onnxruntime shared library will reside in the system's library search path: bundle a single `libs/onnxruntime.jar` and with all of the `libs/onnxruntime-jni.jar`. The onnxruntime shared library should be loaded using one of the other methods described in the "Advanced Loading" section below.
+* To support a single OS/Architecture without any dependencies, use `libs/onnxruntime-<version-number>-all.jar`.
+* To support cross-platform: bundle a single `libs/onnxruntime-<version-number>.jar` and with all of the respective `libs/onnxruntime-<version-number>-jni.jar` and `libs/onnxruntime-<version-number>-lib.jar` for all of the desired OS/Architectures.
+* To support use case where an onnxruntime shared library will reside in the system's library search path: bundle a single `libs/onnxruntime-<version-number>.jar` and with all of the `libs/onnxruntime-<version-number>-jni.jar`. The onnxruntime shared library should be loaded using one of the other methods described in the "Advanced Loading" section below.
 
 #### Build System Overview 
 

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -39,6 +39,8 @@ def cmakeNativeLibDir = "${cmakeJavaDir}/native-lib"
 def cmakeNativeJniDir = "${cmakeJavaDir}/native-jni"
 def cmakeBuildOutputDir = "${cmakeJavaDir}/build"
 
+version = rootProject.file('../VERSION_NUMBER').text.trim()
+
 compileJava {
 	options.compilerArgs += ["-h", "${project.buildDir}/headers/"]
 }


### PR DESCRIPTION
**Description**: Adds the compile time flags which turn on providers back to the JNI compilation step. Also the recent build system change removed the versioning from the jar file name, this adds it back and updates the documentation appropriately.

**Motivation and Context**
- If it fixes an open issue, please link to the issue here. Fixes #3071 
