### PR TITLE
Remove Publish Build Symbols from pre-checkin  CI build

### DIFF
--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -72,13 +72,6 @@ jobs:
       workingFolder: '$(Build.BinariesDirectory)\$(BuildConfig)'
       createLogFile: true
 
-  - task: PublishSymbols@2
-    displayName: 'Publish Build Symbols'
-    inputs:
-      symbolsFolder: $(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)
-      searchPattern: '**/*.pdb'
-      symbolServerType: teamServices
-
   - task: PythonScript@0
     displayName: 'Build wheel'
     inputs:


### PR DESCRIPTION
**Description**: 

Remove Publish Build Symbols from pre-checkin  CI build.

It spent 400+ GB storage in the last 20 days.  I'm afraid we can't afford that. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
