### PR TITLE
Optimizer shouldn't depend on inference session

### DIFF
--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -28,7 +28,6 @@
 #include "core/optimizer/reshape_fusion.h"
 #include "core/optimizer/attention_fusion.h"
 #include "core/mlas/inc/mlas.h"
-#include "core/session/inference_session.h"
 
 namespace onnxruntime {
 


### PR DESCRIPTION
**Description**: 

Optimizer shouldn't depend on inference session because inference session must depend on optimizers. 

No circular dependency!

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
