### PR TITLE
Add d2FH4- flag to cuda

### DIFF
--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -146,6 +146,8 @@ if (onnxruntime_USE_CUDA)
             "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:-Wno-reorder>")
     target_compile_options(onnxruntime_providers_cuda PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wno-error=sign-compare>"
             "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:-Wno-error=sign-compare>")
+  elseif(HAS_D2FH4)
+    target_compile_options(onnxruntime_providers_cuda PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /d2FH4->")
   endif()
   onnxruntime_add_include_to_target(onnxruntime_providers_cuda onnxruntime_common onnxruntime_framework onnx onnx_proto protobuf::libprotobuf)
   add_dependencies(onnxruntime_providers_cuda ${onnxruntime_EXTERNAL_DEPENDENCIES} ${onnxruntime_tvm_dependencies})


### PR DESCRIPTION
**Description**: 

Add d2FH4- flag to cuda


After the change, ORT DLL has the following dependencies:

    advapi32.dll
    api-ms-win-crt-convert-l1-1-0
    api-ms-win-crt-environment-l1-1-0
    api-ms-win-crt-filesystem-l1-1-0
    api-ms-win-crt-heap-l1-1-0
    api-ms-win-crt-locale-l1-1-0
    api-ms-win-crt-math-l1-1-0
    api-ms-win-crt-runtime-l1-1-0
    api-ms-win-crt-stdio-l1-1-0
    api-ms-win-crt-string-l1-1-0
    api-ms-win-crt-time-l1-1-0
    kernel32.dll
    msvcp140.dll
    shlwapi.dll
    vcruntime140.dll


**Motivation and Context**
- Why is this change required? What problem does it solve?

To avoid depending on VS2019 redist

- If it fixes an open issue, please link to the issue here.
