### PR TITLE
NCHWc Upsample/Mul optimizations

### DIFF
--- a/onnxruntime/contrib_ops/cpu/nchwc_ops.h
+++ b/onnxruntime/contrib_ops/cpu/nchwc_ops.h
@@ -52,8 +52,9 @@ class NchwcConv : public OpKernel {
 class NchwcPoolBase : public PoolBase {
  public:
   NchwcPoolBase(const OpKernelInfo& info) : PoolBase(info) {
-    if (!pool_attrs_.global_pooling)
+    if (!pool_attrs_.global_pooling) {
       ORT_ENFORCE(pool_attrs_.kernel_shape.size() == 2, "kernel_shape num_dims is not compatible with X num_dims.");
+    }
   }
 
   Status NchwcPool(OpKernelContext* context, MLAS_POOLING_KIND kind) const;
@@ -73,6 +74,21 @@ class NchwcAveragePool : public OpKernel, public NchwcPoolBase {
   }
 
   Status Compute(OpKernelContext* context) const override;
+};
+
+class NchwcUpsample : public OpKernel {
+ public:
+  NchwcUpsample(const OpKernelInfo& info) : OpKernel(info) {
+    ORT_ENFORCE(info.GetAttrs<int64_t>("scales", scales_).IsOK());
+    ORT_ENFORCE(scales_.size() == 4);
+    // Batch and channel dimensions cannot scale and spatial scaling must be positive.
+    ORT_ENFORCE(scales_[0] == 1 && scales_[1] == 1 && scales_[2] >= 1 && scales_[3] >= 1);
+  }
+
+  Status Compute(OpKernelContext* context) const override;
+
+ private:
+  std::vector<int64_t> scales_;
 };
 
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu_contrib_kernels.cc
@@ -67,6 +67,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomai
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, GlobalMaxPool);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, AveragePool);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, GlobalAveragePool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, Upsample);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, float, LayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, double, LayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization);
@@ -80,7 +81,8 @@ Status RegisterNchwcKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, MaxPool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, GlobalMaxPool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, AveragePool)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, GlobalAveragePool)>};
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, GlobalAveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, Upsample)>};
 
   for (auto& function_table_entry : function_table) {
     ORT_RETURN_IF_ERROR(kernel_registry.Register(function_table_entry()));

--- a/onnxruntime/core/graph/contrib_ops/nchwc_schema_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/nchwc_schema_defs.cc
@@ -174,7 +174,7 @@ void RegisterNchwcSchemas() {
         if (!getRepeatedAttribute(ctx, "scales", scales)) {
           return;
         }
-        if (input_rank != scales.size()) {
+        if (static_cast<size_t>(input_rank) != scales.size()) {
           fail_shape_inference("invalid scales dimension");
         }
 

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -376,7 +376,6 @@ MlasNchwcGetBlockSize(
 void
 MLASCALL
 MlasNchwcConv(
-    size_t Dimensions,
     const int64_t* InputShape,
     const int64_t* KernelShape,
     const int64_t* DilationShape,
@@ -397,7 +396,6 @@ void
 MLASCALL
 MlasNchwcPool(
     MLAS_POOLING_KIND PoolingKind,
-    size_t Dimensions,
     const int64_t* InputShape,
     const int64_t* KernelShape,
     const int64_t* DilationShape,
@@ -407,6 +405,15 @@ MlasNchwcPool(
     const float* Input,
     float* Output,
     MLAS_THREADPOOL* ThreadPool
+    );
+
+void
+MLASCALL
+MlasNchwcUpsample(
+    const int64_t* InputShape,
+    const int64_t* Scales,
+    const float* Input,
+    float* Output
     );
 
 //

--- a/onnxruntime/core/mlas/lib/snchwc.cpp
+++ b/onnxruntime/core/mlas/lib/snchwc.cpp
@@ -26,18 +26,18 @@ struct MLAS_NCHWC_WORK_BLOCK
     int32_t tids;
     size_t BatchCount;
     size_t InputChannels;
-    size_t InputShape[3];
+    size_t InputShape[2];
     size_t InputSize;
     size_t OutputChannels;
-    size_t OutputShape[3];
+    size_t OutputShape[2];
     size_t OutputSize;
-    size_t KernelShape[3];
-    size_t DilationShape[3];
-    size_t Padding[6];
-    size_t StrideShape[3];
-    size_t OutputCountLeftPad[3];
-    size_t OutputCount[3];
-    size_t OutputCountRightPad[3];
+    size_t KernelShape[2];
+    size_t DilationShape[2];
+    size_t Padding[4];
+    size_t StrideShape[2];
+    size_t OutputCountLeftPad[2];
+    size_t OutputCount[2];
+    size_t OutputCountRightPad[2];
 };
 
 //
@@ -111,7 +111,6 @@ Return Value:
 void
 MlasNchwcPrepareWorkBlock(
     MLAS_NCHWC_WORK_BLOCK* WorkBlock,
-    size_t Dimensions,
     const int64_t* InputShape,
     const int64_t* KernelShape,
     const int64_t* DilationShape,
@@ -130,8 +129,6 @@ Arguments:
 
     WorkBlock - Supplies the structure that contains the common convolution
         and pooling parameters.
-
-    Dimensions - Supplies the number of dimensions.
 
     InputShape - Supplies the shape of the input tensor.
 
@@ -169,9 +166,9 @@ Return Value:
 
     size_t InputSize = 1;
     size_t OutputSize = 1;
-    bool CanFlattenShape = (Dimensions == 2);
+    bool CanFlattenShape = true;
 
-    for (size_t dim = 0; dim < Dimensions; dim++) {
+    for (size_t dim = 0; dim < 2; dim++) {
 
         const size_t InputValue = size_t(InputShape[dim]);
         const size_t OutputValue = size_t(OutputShape[dim]);
@@ -198,13 +195,13 @@ Return Value:
 
         if (Padding != nullptr) {
             WorkBlock->Padding[dim] = size_t(Padding[dim]);
-            WorkBlock->Padding[dim + Dimensions] = size_t(Padding[dim + Dimensions]);
+            WorkBlock->Padding[dim + 2] = size_t(Padding[dim + 2]);
         } else {
             WorkBlock->Padding[dim] = 0;
-            WorkBlock->Padding[dim + Dimensions] = 0;
+            WorkBlock->Padding[dim + 2] = 0;
         }
 
-        CanFlattenShape &= (WorkBlock->Padding[dim] == 0 && WorkBlock->Padding[dim + Dimensions] == 0);
+        CanFlattenShape &= (WorkBlock->Padding[dim] == 0 && WorkBlock->Padding[dim + 2] == 0);
 
         if (StrideShape != nullptr) {
             WorkBlock->StrideShape[dim] = size_t(StrideShape[dim]);
@@ -249,7 +246,7 @@ Return Value:
     // Compute the number of output elements affected by left and right padding.
     //
 
-    for (size_t dim = 0; dim < Dimensions; dim++) {
+    for (size_t dim = 0; dim < 2; dim++) {
 
         const size_t SpanValue =
             WorkBlock->DilationShape[dim] * (WorkBlock->KernelShape[dim] - 1) + 1;
@@ -1214,7 +1211,6 @@ const PMLAS_POOL_FLOAT_KERNEL MLAS_NCHWC_POOL_ALGORITHM::PoolKernels[] =
 void
 MLASCALL
 MlasNchwcConv(
-    size_t Dimensions,
     const int64_t* InputShape,
     const int64_t* KernelShape,
     const int64_t* DilationShape,
@@ -1297,7 +1293,7 @@ Return Value:
     // Capture the generic shape parameters to the work block.
     //
 
-    MlasNchwcPrepareWorkBlock(&WorkBlock, Dimensions, InputShape, KernelShape,
+    MlasNchwcPrepareWorkBlock(&WorkBlock, InputShape, KernelShape,
         DilationShape, Padding, StrideShape, OutputShape);
 
     WorkBlock.InputChannels /= GroupCount;
@@ -1340,7 +1336,6 @@ void
 MLASCALL
 MlasNchwcPool(
     MLAS_POOLING_KIND PoolingKind,
-    size_t Dimensions,
     const int64_t* InputShape,
     const int64_t* KernelShape,
     const int64_t* DilationShape,
@@ -1360,8 +1355,6 @@ Routine Description:
 Arguments:
 
     PoolingKind - Supplies the kind of pooling operation to perform.
-
-    Dimensions - Supplies the number of dimensions.
 
     InputShape - Supplies the shape of the input tensor.
 
@@ -1403,7 +1396,7 @@ Return Value:
     // Capture the generic shape parameters to the work block.
     //
 
-    MlasNchwcPrepareWorkBlock(&WorkBlock, Dimensions, InputShape, KernelShape,
+    MlasNchwcPrepareWorkBlock(&WorkBlock, InputShape, KernelShape,
         DilationShape, Padding, StrideShape, OutputShape);
 
     //
@@ -1413,6 +1406,109 @@ Return Value:
     WorkBlock.tids = MlasGetMaximumThreadCount(ThreadPool);
 
     MlasExecuteThreaded(MlasNchwcThreaded<MLAS_NCHWC_POOL_ALGORITHM>, &WorkBlock, WorkBlock.tids, ThreadPool);
+}
+
+void
+MLASCALL
+MlasNchwcUpsample(
+    const int64_t* InputShape,
+    const int64_t* Scales,
+    const float* Input,
+    float* Output
+    )
+/*++
+
+Routine Description:
+
+    This routine implements the NCHWc upsample nearest operation.
+
+Arguments:
+
+    InputShape - Supplies the shape of the input tensor.
+
+    Scales - Supplies the shape of the spatial scaling.
+
+    Input - Supplies the input tensor.
+
+    Output - Supplies the output tensor.
+
+Return Value:
+
+    None.
+
+--*/
+{
+    const size_t BlockSize = MlasNchwcGetBlockSize();
+
+    const size_t BatchCount = size_t(InputShape[0]);
+    const size_t ChannelCount = size_t(InputShape[1]);
+    const size_t InputHeight = size_t(InputShape[2]);
+    const size_t InputWidth = size_t(InputShape[3]);
+
+    const size_t TotalInputHeight = BatchCount * ChannelCount * InputHeight;
+
+    const size_t ScaleHeight = size_t(Scales[0]);
+    const size_t ScaleWidth = size_t(Scales[1]);
+
+    const size_t OutputWidth = InputWidth * ScaleWidth;
+
+    //
+    // Iterate over each line of the input tensor.
+    //
+
+    for (size_t h = 0; h < TotalInputHeight; h += BlockSize) {
+
+        float* OutputBaseRow = Output;
+
+        //
+        // Scale the input tensor across the width dimension.
+        //
+
+        for (size_t w = 0; w < InputWidth; w++) {
+
+            if (BlockSize == 16) {
+
+                MLAS_FLOAT32X4 v0 = MlasLoadFloat32x4(Input);
+                MLAS_FLOAT32X4 v1 = MlasLoadFloat32x4(Input + 4);
+                MLAS_FLOAT32X4 v2 = MlasLoadFloat32x4(Input + 8);
+                MLAS_FLOAT32X4 v3 = MlasLoadFloat32x4(Input + 12);
+
+                for (size_t sw = 0; sw < ScaleWidth; sw++) {
+
+                    MlasStoreFloat32x4(Output, v0);
+                    MlasStoreFloat32x4(Output + 4, v1);
+                    MlasStoreFloat32x4(Output + 8, v2);
+                    MlasStoreFloat32x4(Output + 12, v3);
+
+                    Output += BlockSize;
+                }
+
+            } else {
+
+                MLAS_FLOAT32X4 v0 = MlasLoadFloat32x4(Input);
+                MLAS_FLOAT32X4 v1 = MlasLoadFloat32x4(Input + 4);
+
+                for (size_t sw = 0; sw < ScaleWidth; sw++) {
+
+                    MlasStoreFloat32x4(Output, v0);
+                    MlasStoreFloat32x4(Output + 4, v1);
+
+                    Output += BlockSize;
+                }
+            }
+
+            Input += BlockSize;
+        }
+
+        //
+        // Scale the input tensor across the height dimension by duplicating
+        // the first output line.
+        //
+
+        for (size_t sh = 1; sh < ScaleHeight; sh++) {
+            Output = std::copy_n(OutputBaseRow, OutputWidth * BlockSize, Output);
+        }
+    }
 }
 
 #if !defined(MLAS_TARGET_AMD64)

--- a/onnxruntime/test/mlas/unittest.cpp
+++ b/onnxruntime/test/mlas/unittest.cpp
@@ -1085,8 +1085,7 @@ protected:
         MLAS_ACTIVATION Activation;
         Activation.ActivationKind = MlasIdentityActivation;
 
-        MlasNchwcConv(2,
-                      InputShape,
+        MlasNchwcConv(InputShape,
                       KernelShape,
                       DilationShape,
                       Padding,
@@ -1503,7 +1502,6 @@ protected:
         MlasReorderInput(InputShape, Input, NchwcInput);
 
         MlasNchwcPool(PoolingKind,
-                      2,
                       NchwcInputShape,
                       KernelShape,
                       nullptr,

--- a/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
@@ -90,7 +90,7 @@ struct NchwcTestHelper {
       tensor_proto.add_dims(dim);
     }
 
-    tensor_proto.mutable_float_data()->Resize(static_cast<int>(data.size()), 0.0f);
+    tensor_proto.mutable_float_data()->Resize(static_cast<int>(data.size()), 0.f);
     memcpy(tensor_proto.mutable_float_data()->mutable_data(), data.data(), data.size() * sizeof(float));
 
     graph_.AddInitializedTensor(tensor_proto);
@@ -101,6 +101,10 @@ struct NchwcTestHelper {
   NodeArg* MakeInitializer(const std::vector<int64_t>& shape) {
     int64_t num_elements = std::accumulate(shape.begin(), shape.end(), int64_t(1), std::multiplies<int64_t>{});
     return MakeInitializer(shape, FillRandomData(static_cast<size_t>(num_elements)));
+  }
+
+  NodeArg* Make1DInitializer(const std::vector<float>& data) {
+    return MakeInitializer({static_cast<int64_t>(data.size())}, data);
   }
 
   Node& AddNode(const std::string& op_type,
@@ -115,7 +119,7 @@ struct NchwcTestHelper {
 
   Node& AddConvNode(NodeArg* input_arg, NodeArg* output_arg, const std::vector<int64_t>& weights_shape, bool no_bias = false) {
     auto* weights_arg = MakeInitializer(weights_shape);
-    std::vector<NodeArg*> input_args = {input_arg, weights_arg};
+    std::vector<NodeArg*> input_args{input_arg, weights_arg};
     if (!no_bias) {
       auto* biases_arg = MakeInitializer({weights_shape[0]});
       input_args.push_back(biases_arg);
@@ -125,10 +129,10 @@ struct NchwcTestHelper {
 
   Node& AddClipNode(NodeArg* input_arg, NodeArg* output_arg, float min, float max) {
     int opset_version = graph_.DomainToVersionMap().find(kOnnxDomain)->second;
-    std::vector<NodeArg*> input_args = {input_arg};
+    std::vector<NodeArg*> input_args{input_arg};
     if (opset_version >= 11) {
-      input_args.push_back(MakeInitializer({1}, {min}));
-      input_args.push_back(MakeInitializer({1}, {max}));
+      input_args.push_back(Make1DInitializer({min}));
+      input_args.push_back(Make1DInitializer({max}));
     }
     auto& node = AddNode("Clip", input_args, {output_arg});
     if (opset_version < 11) {
@@ -190,8 +194,8 @@ void NchwcOptimizerTester(const std::function<void(NchwcTestHelper& helper)>& bu
   // Build the model for this test.
   std::unordered_map<std::string, int> domain_to_version;
   domain_to_version[kOnnxDomain] = opset_version;
-  Model model("nchwc", false, ModelMetaData(), PathString(), IOnnxRuntimeOpSchemaRegistryList(), domain_to_version,
-              {}, DefaultLoggingManager().DefaultLogger());
+  Model model("nchwc", false, ModelMetaData(), PathString(), IOnnxRuntimeOpSchemaRegistryList(),
+              domain_to_version, {}, DefaultLoggingManager().DefaultLogger());
   NchwcTestHelper helper(model.MainGraph());
   build_test_case(helper);
   ASSERT_TRUE(model.MainGraph().Resolve().IsOK());
@@ -253,7 +257,7 @@ TEST(NchwcOptimizerTests, ConvNchw) {
       if (!activation_op_type.empty()) {
         conv_output_arg = helper.MakeIntermediate();
         if (activation_op_type == "Clip") {
-          helper.AddClipNode(conv_output_arg, output_arg, 0.0f, 6.0f);
+          helper.AddClipNode(conv_output_arg, output_arg, 0.f, 6.f);
         } else {
           helper.AddNode(activation_op_type, {conv_output_arg}, {output_arg});
         }
@@ -277,7 +281,7 @@ TEST(NchwcOptimizerTests, ConvNchw) {
     NchwcOptimizerTester(build_test_case, check_nchwc_graph);
   };
 
-  std::vector<std::string> activation_op_types = {"", "Relu", "LeakyRelu", "Clip"};
+  std::vector<std::string> activation_op_types{"", "Relu", "LeakyRelu", "Clip"};
   for (auto& activation_op_type : activation_op_types) {
     test_case(activation_op_type);
   }
@@ -293,7 +297,7 @@ TEST(NchwcOptimizerTests, ConvNchwc) {
       if (!activation_op_type.empty()) {
         conv_output_arg = helper.MakeIntermediate();
         if (activation_op_type == "Clip") {
-          helper.AddClipNode(conv_output_arg, output_arg, -6.0f, 6.0f);
+          helper.AddClipNode(conv_output_arg, output_arg, -6.f, 6.f);
         } else {
           helper.AddNode(activation_op_type, {conv_output_arg}, {output_arg});
         }
@@ -315,7 +319,7 @@ TEST(NchwcOptimizerTests, ConvNchwc) {
     NchwcOptimizerTester(build_test_case, check_nchwc_graph);
   };
 
-  std::vector<std::string> activation_op_types = {"", "Relu", "LeakyRelu", "Clip"};
+  std::vector<std::string> activation_op_types{"", "Relu", "LeakyRelu", "Clip"};
   for (auto& activation_op_type : activation_op_types) {
     test_case(activation_op_type);
   }
@@ -350,7 +354,7 @@ TEST(NchwcOptimizerTests, ConvNchwcGrouped) {
     NchwcOptimizerTester(build_test_case, check_nchwc_graph);
   };
 
-  std::vector<std::string> activation_op_types = {"", "Relu", "LeakyRelu"};
+  std::vector<std::string> activation_op_types{"", "Relu", "LeakyRelu"};
   for (auto& activation_op_type : activation_op_types) {
     test_case(activation_op_type);
   }
@@ -385,7 +389,7 @@ TEST(NchwcOptimizerTests, ConvDepthwise) {
     NchwcOptimizerTester(build_test_case, check_nchwc_graph);
   };
 
-  std::vector<std::string> activation_op_types = {"", "Relu", "LeakyRelu"};
+  std::vector<std::string> activation_op_types{"", "Relu", "LeakyRelu"};
   for (auto& activation_op_type : activation_op_types) {
     test_case(activation_op_type);
   }
@@ -419,7 +423,7 @@ TEST(NchwcOptimizerTests, ConvPointwise) {
     NchwcOptimizerTester(build_test_case, check_nchwc_graph);
   };
 
-  std::vector<std::string> activation_op_types = {"", "Relu", "LeakyRelu"};
+  std::vector<std::string> activation_op_types{"", "Relu", "LeakyRelu"};
   for (auto& activation_op_type : activation_op_types) {
     test_case(activation_op_type);
   }
@@ -529,7 +533,7 @@ TEST(NchwcOptimizerTests, ConvGlobalPool) {
     NchwcOptimizerTester(build_test_case, check_nchwc_graph);
   };
 
-  std::vector<std::string> op_types = {"GlobalMaxPool", "GlobalAveragePool"};
+  std::vector<std::string> op_types{"GlobalMaxPool", "GlobalAveragePool"};
   for (auto& op_type : op_types) {
     test_case(op_type);
   }
@@ -569,7 +573,7 @@ TEST(NchwcOptimizerTests, ConvAddFusion) {
 
   // Verify that Add or Sum can be fused into a preceding NCHWc Conv node,
   // with an optional Relu node following.
-  std::vector<std::string> op_types = {"Add", "Sum"};
+  std::vector<std::string> op_types{"Add", "Sum"};
   static const int opset_versions[] = {7, 10, 11};
   for (auto& op_type : op_types) {
     for (auto opset_version : opset_versions) {
@@ -651,6 +655,44 @@ TEST(NchwcOptimizerTests, FusedConvAddFusion) {
   test_case(true, true, 1);
 }
 
+TEST(NchwcOptimizerTests, ConvBinary) {
+  auto test_case = [&](const std::string& op_type) {
+    auto build_test_case = [&](NchwcTestHelper& helper) {
+      auto* input_arg = helper.MakeInput({1, 32, 23, 23});
+      auto* conv1_output_arg = helper.MakeIntermediate();
+      auto* conv2_output_arg = helper.MakeIntermediate();
+      auto* relu1_output_arg = helper.MakeIntermediate();
+      auto* relu2_output_arg = helper.MakeIntermediate();
+      auto* output_arg = helper.MakeOutput();
+
+      helper.AddConvNode(input_arg, conv1_output_arg, {32, 32, 3, 3});
+      helper.AddNode("Relu", {conv1_output_arg}, {relu1_output_arg});
+      helper.AddConvNode(input_arg, conv2_output_arg, {32, 32, 3, 3});
+      helper.AddNode("Relu", {conv2_output_arg}, {relu2_output_arg});
+
+      helper.AddNode(op_type, {relu1_output_arg, relu2_output_arg}, {output_arg});
+    };
+
+    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
+      auto op_to_count = session.CountOpsInGraph();
+      EXPECT_EQ(op_to_count["nchwc.Conv"], 2);
+      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
+      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+      EXPECT_EQ(op_to_count[op_type], 1);
+      EXPECT_EQ(op_to_count["Relu"], 0);
+    };
+
+    NchwcOptimizerTester(build_test_case, check_nchwc_graph);
+  };
+
+  // Verify that the optimizer keeps the inputs to the binary operator as NCHWc
+  // and only reorders the output of the binary operator.
+  std::vector<std::string> op_types{"Add", "Sum", "Mul"};
+  for (auto& op_type : op_types) {
+    test_case(op_type);
+  }
+}
+
 TEST(NchwcOptimizerTests, ConvConcat) {
   auto test_case = [&](int axis, int channel_count, int reorder_output_count) {
     auto build_test_case = [&](NchwcTestHelper& helper) {
@@ -695,7 +737,7 @@ TEST(NchwcOptimizerTests, ConvReuseWeightsOIHWBiBo) {
     auto* output2_arg = helper.MakeOutput();
     auto* output3_arg = helper.MakeOutput();
 
-    std::vector<int64_t> weights_shape = {60, 64, 3, 3};
+    std::vector<int64_t> weights_shape{60, 64, 3, 3};
     auto* weights_arg = helper.MakeInitializer(weights_shape);
     auto* biases_arg = helper.MakeInitializer({weights_shape[0]});
 
@@ -740,7 +782,7 @@ TEST(NchwcOptimizerTests, ConvReuseWeightsOIHWBo) {
     auto* output3_arg = helper.MakeOutput();
     auto* output4_arg = helper.MakeOutput();
 
-    std::vector<int64_t> weights_shape = {64, 1, 3, 3};
+    std::vector<int64_t> weights_shape{64, 1, 3, 3};
     auto* weights_arg = helper.MakeInitializer(weights_shape);
     auto* biases_arg = helper.MakeInitializer({weights_shape[0]});
 
@@ -1010,13 +1052,13 @@ TEST(NchwcOptimizerTests, BatchNormalization) {
         bn_var[i] = static_cast<float>((i % 9) + 1) * 0.001f;
       }
 
-      auto* bn_scale_arg = helper.MakeInitializer({34}, bn_scale);
-      auto* bn_bias_arg = helper.MakeInitializer({34}, bn_bias);
-      auto* bn_mean_arg = helper.MakeInitializer({34}, bn_mean);
-      auto* bn_var_arg = helper.MakeInitializer({34}, bn_var);
+      auto* bn_scale_arg = helper.Make1DInitializer(bn_scale);
+      auto* bn_bias_arg = helper.Make1DInitializer(bn_bias);
+      auto* bn_mean_arg = helper.Make1DInitializer(bn_mean);
+      auto* bn_var_arg = helper.Make1DInitializer(bn_var);
 
       auto* bn_output_arg = helper.MakeIntermediate();
-      std::vector<NodeArg*> bn_output_args = {bn_output_arg};
+      std::vector<NodeArg*> bn_output_args{bn_output_arg};
       if (training_outputs) {
         bn_output_args.push_back(helper.MakeIntermediate());
         bn_output_args.push_back(helper.MakeIntermediate());
@@ -1126,6 +1168,54 @@ TEST(NchwcOptimizerTests, ConvReorderOutputCnhw) {
 
   // Verify that a CNHW transpose is not fused into ReorderOutput.
   NchwcOptimizerTester(build_test_case, check_nchwc_graph);
+}
+
+TEST(NchwcOptimizerTests, Upsample) {
+  auto test_case = [&](int opset_version, float scale_h, float scale_w) {
+    auto build_test_case = [&](NchwcTestHelper& helper) {
+      auto* input_arg = helper.MakeInput({3, 16, 27, 15});
+      auto* conv_output_arg = helper.MakeIntermediate();
+      auto* output_arg = helper.MakeOutput();
+
+      helper.AddConvNode(input_arg, conv_output_arg, {132, 16, 1, 1});
+
+      std::string op_name = opset_version >= 10 ? "Resize" : "Upsample";
+      std::vector<NodeArg*> input_args;
+      input_args.push_back(conv_output_arg);
+      if (opset_version >= 11) {
+        input_args.push_back(helper.Make1DInitializer({0.f, 0.f, 0.f, 0.f, 1.f, 1.f, 1.f, 1.f}));
+      }
+      input_args.push_back(helper.Make1DInitializer({1.f, 1.f, scale_h, scale_w}));
+      Node& resize_node = helper.AddNode(op_name, input_args, {output_arg});
+      if (opset_version >= 11) {
+        resize_node.AddAttribute("coordinate_transformation_mode", "asymmetric");
+        resize_node.AddAttribute("nearest_mode", "floor");
+      } else if (opset_version == 10) {
+        // Explicitly set the mode to nearest as an extra test.
+        resize_node.AddAttribute("mode", "nearest");
+      }
+    };
+
+    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
+      auto op_to_count = session.CountOpsInGraph();
+      EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
+      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
+      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+      EXPECT_EQ(op_to_count["nchwc.Upsample"], 1);
+      EXPECT_EQ(op_to_count["Resize"] + op_to_count["Upsample"], 0);
+    };
+
+    NchwcOptimizerTester(build_test_case, check_nchwc_graph, opset_version);
+  };
+
+  // Verify that upsample nodes can be converted to the NCHWc format for
+  // various versions of the operator.
+  static const int opset_versions[] = {9, 10, 11};
+  for (auto opset_version : opset_versions) {
+    test_case(opset_version, 1.f, 1.f);
+    test_case(opset_version, 2.f, 2.f);
+    test_case(opset_version, 3.f, 5.f);
+  }
 }
 
 #endif


### PR DESCRIPTION
**Description**: Extend the NCHWc layout optimizer to handle Resize(mode=nearest) and Mul.

**Motivation and Context**
Add support for trivial Upsample and Resize ops using nearest mode upsampling with integer scaling in the NCHWc domain. This is meant to handle UNet and YOLOV3 models that have an UpsampleNearest(2x2) node. This avoids unnecessary tensor reordering around the upsampling.

Also reuse the existing Add/Sum support to keep tensors in NCHWc when both inputs of a Mul node are already in NCHWc format.

One internal model using Upsample and Mul went from 27ms->21ms per inference. tinyyolov3 from the model zoo went from 16ms->14ms.