### PR TITLE
Fix CUDA PATH

### DIFF
--- a/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
@@ -216,7 +216,7 @@ jobs:
   timeoutInMinutes:  60  
   variables:
     CUDA_VERSION: '10.1'
-    EnvSetupScript: setup_env.bat
+    EnvSetupScript: setup_env_cuda.bat
   strategy:
     matrix:
       Python35:

--- a/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
@@ -165,7 +165,7 @@ jobs:
   pool: 'Win-GPU-2019'
   timeoutInMinutes:  120
   variables:
-    EnvSetupScript: setup_env.bat
+    EnvSetupScript: setup_env_cuda.bat
     buildArch: x64
     msbuildArch: amd64
     msbuildPlatform: x64

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
@@ -11,7 +11,7 @@ jobs:
     BuildCommand: --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests --use_telemetry --cmake_generator "Visual Studio 16 2019" --use_cuda --cuda_version=10.1 --cuda_home="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.1" --cudnn_home="C:\local\cudnn-10.1-windows10-x64-v7.6.5.32\cuda"
     BuildArch: 'x64'
     msbuildArchitecture: 'amd64'
-    EnvSetupScript: 'setup_env.bat'    
+    EnvSetupScript: 'setup_env_cuda.bat'    
     sln_platform: 'x64'
     DoDebugBuild: 'false'
     DoNugetPack : 'true'
@@ -34,7 +34,7 @@ jobs:
     BuildCommand: --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests --use_telemetry --use_dml --use_winml --cmake_generator "Visual Studio 16 2019"
     BuildArch: 'x64'
     msbuildArchitecture: 'amd64'
-    EnvSetupScript: 'setup_env.bat'    
+    EnvSetupScript: 'setup_env_cuda.bat'    
     sln_platform: 'x64'
     DoDebugBuild: 'false'
     DoNugetPack : 'true'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -32,7 +32,7 @@ jobs:
   - task: BatchScript@1
     displayName: 'setup env'
     inputs:
-      filename: '$(Build.SourcesDirectory)\tools\ci_build\github\windows\setup_env.bat'
+      filename: '$(Build.SourcesDirectory)\tools\ci_build\github\windows\setup_env_cuda.bat'
       modifyEnvironment: true
       workingFolder: '$(Build.BinariesDirectory)'
 

--- a/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
@@ -13,7 +13,7 @@ jobs:
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
     OnnxRuntimeBuildDirectory: '$(Build.BinariesDirectory)'
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    EnvSetupScript: setup_env.bat
+    EnvSetupScript: setup_env_cuda.bat
     buildArch: x64
     setVcvars: true    
   timeoutInMinutes: 120

--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -13,7 +13,7 @@ jobs:
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
     OnnxRuntimeBuildDirectory: '$(Build.BinariesDirectory)'
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    EnvSetupScript: setup_env.bat
+    EnvSetupScript: setup_env_trt.bat
     buildArch: x64
     setVcvars: true
   timeoutInMinutes: 120

--- a/tools/ci_build/github/windows/setup_env_cuda.bat
+++ b/tools/ci_build/github/windows/setup_env_cuda.bat
@@ -1,0 +1,2 @@
+set PATH=C:\azcopy;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.1\bin;C:\local\cudnn-10.1-windows10-x64-v7.6.5.32\cuda\bin;%PATH%
+set GRADLE_OPTS=-Dorg.gradle.daemon=false

--- a/tools/ci_build/github/windows/setup_env_trt.bat
+++ b/tools/ci_build/github/windows/setup_env_trt.bat
@@ -1,0 +1,2 @@
+set PATH=C:\azcopy;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\bin;C:\local\cudnn-10.2-windows10-x64-v7.6.5.32\cuda\bin;%PATH%
+set GRADLE_OPTS=-Dorg.gradle.daemon=false


### PR DESCRIPTION
**Description**: 

Fix CUDA PATH

(The problem only affect the C# test, not the C/C++ tests that forked from build.py).

**Motivation and Context**
- Why is this change required? What problem does it solve?

Previously, we put the "bin" folder of all the CUDA verions in the system PATH. And 10.2 is in the front. It's a mess. 
So I've removed all of them from the system PATH env. But I need to add one of them back through build scripts.


- If it fixes an open issue, please link to the issue here.
