### PR TITLE
Optimised kernel_dot() in SVM op

### DIFF
--- a/onnxruntime/core/providers/cpu/ml/svmclassifier.h
+++ b/onnxruntime/core/providers/cpu/ml/svmclassifier.h
@@ -33,25 +33,30 @@ class SVMCommon {
     double sum = 0;
     const T* pA = A + a;
     const float* pB = B.data() + b;
-    if (k == KERNEL::POLY) {
-      for (int64_t i = len; i > 0; --i, ++pA, ++pB)
-        sum += *pA * *pB;
-      sum = gamma_ * sum + coef0_;
-      sum = std::pow(sum, degree_);
-    } else if (k == KERNEL::SIGMOID) {
-      for (int64_t i = len; i > 0; --i, ++pA, ++pB)
-        sum += *pA * *pB;
-      sum = gamma_ * sum + coef0_;
-      sum = std::tanh(sum);
-    } else if (k == KERNEL::RBF) {
-      for (int64_t i = len; i > 0; --i, ++pA, ++pB) {
-        double val = *pA - *pB;
-        sum += val * val;
-      }
-      sum = std::exp(-gamma_ * sum);
-    } else if (k == KERNEL::LINEAR) {
-      for (int64_t i = len; i > 0; --i, ++pA, ++pB)
-        sum += *pA * *pB;
+    switch(k) {
+        case KERNEL::POLY:
+            for (int64_t i = len; i > 0; --i)
+                sum += *pA++ * *pB++;
+            sum = gamma_ * sum + coef0_;
+            sum = std::pow(sum, degree_);
+            break;
+        case KERNEL::SIGMOID:
+            for (int64_t i = len; i > 0; --i)
+                sum += *pA++ * *pB++;
+            sum = gamma_ * sum + coef0_;
+            sum = std::tanh(sum);
+            break;
+        case KERNEL::RBF:
+            for (int64_t i = len; i > 0; --i) {
+                double val = *pA++ - *pB++;
+                sum += val * val;
+            }
+            sum = std::exp(-gamma_ * sum);
+            break;
+        case KERNEL::LINEAR:
+            for (int64_t i = len; i > 0; --i)
+                sum += *pA++ * *pB++;
+            break;
     }
     return (float)sum;
   }


### PR DESCRIPTION
**Description**:
Replaced if-elsif (which does a linear search) with switch-case(which implements a hash-table for matching) and added pointer increment to the same statement as de-referencing.

**Motivation and Context**
Improve SVMRegressor prediction runtime. Here is a comparison of predicition runtime for scikit's SVR model with different batch sizes.
```
batch size | with my changes | current implementation
1 | 0.1991 | 0.238398
2 | 0.282262 | 0.373498
4 | 0.501656 | 0.726311
8 | 0.987586 | 1.392504
16 | 1.860618 | 2.579112
32 | 3.463295 | 5.044812
64 | 6.991549 | 10.710077
128 | 15.00496 | 21.57884
256 | 28.013964 | 43.655108
512 | 59.990061 | 82.445238
1024 | 115.880736 | 163.359835
2048 | 242.211478 | 332.502717
```

