### PR TITLE
Suppress maybe uninitialized warning in gcc-9

### DIFF
--- a/onnxruntime/core/common/path.cc
+++ b/onnxruntime/core/common/path.cc
@@ -140,7 +140,7 @@ Status Path::Parse(const PathString& original_path_str, Path& path) {
   const PathString path_str = NormalizePathSeparators(original_path_str);
 
   // parse root
-  size_t root_length;
+  size_t root_length = 0;
   ORT_RETURN_IF_ERROR(ParsePathRoot(
       path_str, result.root_name_, result.has_root_dir_, root_length));
 


### PR DESCRIPTION
**Description**: Describe your changes.
```
[75%] Built target onnxruntime_providers
dev/onnxruntime/onnxruntime/core/common/path.cc: In static member function ‘static onnxruntime::common::Status onnxruntime::Path::Parse(const PathString&, onnxruntime::Path&)’:
dev/onnxruntime/onnxruntime/core/common/path.cc:143:10: error: ‘root_length’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  143 |   size_t root_length;
      |          ^~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
