### PR TITLE
Update post_binary_sizes_to_dashboard.py to remove the retention

### DIFF
--- a/tools/ci_build/github/windows/post_binary_sizes_to_dashboard.py
+++ b/tools/ci_build/github/windows/post_binary_sizes_to_dashboard.py
@@ -54,13 +54,6 @@ def write_to_db(binary_size_data, args):
     try:
         cursor = cnx.cursor()
 
-        #delete old records
-        delete_query = ('DELETE FROM onnxruntime.binary_size '
-            'WHERE build_time < DATE_SUB(Now(), INTERVAL 180 DAY);'
-        )
-        
-        cursor.execute(delete_query)
-
         #insert current records
         for row in binary_size_data:
             insert_query = ('INSERT INTO onnxruntime.binary_size '


### PR DESCRIPTION
**Description**: 
Discussed with Faith, because the data size is very small and changes are gradual, there is no need to delete the old data. We want to keep all the history.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
