### PR TITLE
Add package download step before pushing to feeds

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-featurizers.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-featurizers.yml
@@ -181,6 +181,12 @@ jobs:
   - NuGet_Test_Linux
   - NuGet_Test_MacOS
   steps:
+  - task: DownloadPipelineArtifact@0
+    displayName: 'Download Pipeline Artifact - Signed NuGet Package'
+    inputs:
+      artifactName: 'drop-signed-nuget'
+      targetPath: '$(Build.BinariesDirectory)/nuget-artifact/final-package
+
   - task: NuGetCommand@2
     displayName: 'Copy Signed Native NuGet Package to ORT-NIGHTLY'
     condition: ne(variables['IsReleaseBuild'], 'true') # release build has a different package naming scheme

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-featurizers.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-featurizers.yml
@@ -185,7 +185,7 @@ jobs:
     displayName: 'Download Pipeline Artifact - Signed NuGet Package'
     inputs:
       artifactName: 'drop-signed-nuget'
-      targetPath: '$(Build.BinariesDirectory)/nuget-artifact/final-package
+      targetPath: '$(Build.BinariesDirectory)/nuget-artifact/final-package'
 
   - task: NuGetCommand@2
     displayName: 'Copy Signed Native NuGet Package to ORT-NIGHTLY'


### PR DESCRIPTION
**Description**:
Pushing to feeds was done from a binary folder where the package must be downloaded first.

**Motivation and Context**
