### PR TITLE
Support custom ops targeting the CUDA EP

### DIFF
--- a/docs/AddingCustomOp.md
+++ b/docs/AddingCustomOp.md
@@ -8,7 +8,7 @@ Note: These APIs are experimental and will change in the next release. They're r
 * Create an OrtCustomOp structure for each op and add them to the OrtCustomOpDomain with OrtCustomOpDomain_Add
 * Call OrtAddCustomOpDomain to add the custom domain of ops to the session options
 See [this](../onnxruntime/test/shared_lib/test_inference.cc) for an example called MyCustomOp that uses the C++ helper API (onnxruntime_cxx_api.h).
-Currently, the only supported Execution Providers (EPs) for custom ops registered via this approach are  the `CUDA` and the `CPU` EPs. 
+Currently, the only supported Execution Providers (EPs) for custom ops registered via this approach are the `CUDA` and the `CPU` EPs. 
 
 ### 2. Using RegisterCustomRegistry API
 * Implement your kernel and schema (if required) using the OpKernel and OpSchema APIs (headers are in the include folder).

--- a/docs/AddingCustomOp.md
+++ b/docs/AddingCustomOp.md
@@ -8,6 +8,7 @@ Note: These APIs are experimental and will change in the next release. They're r
 * Create an OrtCustomOp structure for each op and add them to the OrtCustomOpDomain with OrtCustomOpDomain_Add
 * Call OrtAddCustomOpDomain to add the custom domain of ops to the session options
 See [this](../onnxruntime/test/shared_lib/test_inference.cc) for an example called MyCustomOp that uses the C++ helper API (onnxruntime_cxx_api.h).
+Currently, the only supported Execution Providers (EPs) for custom ops registered via this approach are  the `CUDA` and the `CPU` EPs. 
 
 ### 2. Using RegisterCustomRegistry API
 * Implement your kernel and schema (if required) using the OpKernel and OpSchema APIs (headers are in the include folder).

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -1329,6 +1329,7 @@ CUDAExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
           break;
     }
 
+    // none of the provided registries has a CUDA kernel for this node  
     if (cuda_kernel_def == nullptr) {
       // node is not in cuda exeuction provider if no kernel def found,
       // or if other execution provider already assigned to it

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -3,6 +3,7 @@
 
 #include <core/common/make_unique.h>
 #include "core/session/onnxruntime_cxx_api.h"
+#include "core/graph/constants.h"
 #include "providers.h"
 #include <memory>
 #include <vector>
@@ -185,8 +186,8 @@ TEST(CApiTest, dim_param) {
 }
 
 INSTANTIATE_TEST_SUITE_P(CApiTestWithProviders,
-                        CApiTestWithProvider,
-                        ::testing::Values(0, 1, 2, 3, 4));
+                         CApiTestWithProvider,
+                         ::testing::Values(0, 1, 2, 3, 4));
 
 struct OrtTensorDimensions : std::vector<int64_t> {
   OrtTensorDimensions(Ort::CustomOpApi ort, const OrtValue* value) {
@@ -233,6 +234,11 @@ struct MyCustomKernel {
 struct MyCustomOp : Ort::CustomOpBase<MyCustomOp, MyCustomKernel> {
   void* CreateKernel(Ort::CustomOpApi api, const OrtKernelInfo* info) { return new MyCustomKernel(api, info); };
   const char* GetName() const { return "Foo"; };
+
+#ifdef USE_CUDA
+  // Make the kernel run on CUDA for CUDA builds
+  const char* GetExecutionProviderType() const { return onnxruntime::kCudaExecutionProvider; };
+#endif
 
   size_t GetInputTypeCount() const { return 2; };
   ONNXTensorElementDataType GetInputType(size_t /*index*/) const { return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT; };

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -264,7 +264,12 @@ TEST(CApiTest, custom_op_handler) {
   Ort::CustomOpDomain custom_op_domain("");
   custom_op_domain.Add(&custom_op);
 
+#ifdef USE_CUDA
+  TestInference<PATH_TYPE, float>(*ort_env, CUSTOM_OP_MODEL_URI, inputs, "Y", expected_dims_y, expected_values_y, 1, custom_op_domain, nullptr);
+#else
   TestInference<PATH_TYPE, float>(*ort_env, CUSTOM_OP_MODEL_URI, inputs, "Y", expected_dims_y, expected_values_y, 0, custom_op_domain, nullptr);
+#endif
+
 }
 
 TEST(CApiTest, DISABLED_test_custom_op_library) {


### PR DESCRIPTION
Currently, the CUDA GetCapability() method ignores all other (custom) kernel registries apart from the CUDA kernel registry when trying to assign a node to the CUDA EP. This prevents users of the custom op API to target the CUDA EP. 

Resolve https://github.com/microsoft/onnxruntime/issues/3138
