### PR TITLE
Support DisposableNamedOnnxValue inputs in c# Run()

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
@@ -79,8 +79,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// <param name="pinnedMemoryHandle"></param>
         /// <param name="disposeOnnxValueAfterUse"></param>
         internal override void ToNativeOnnxValue(out IntPtr onnxValue, 
-                                                 out MemoryHandle pinnedMemoryHandle,
-                                                 out bool disposeOnnxValueAfterUse)
+                                                 out MemoryHandle pinnedMemoryHandle)
         {
             // Make sure that this instance hasn't been disposed yet
             if (disposedValue)
@@ -96,12 +95,12 @@ namespace Microsoft.ML.OnnxRuntime
                 throw new NotSupportedException("Use of Maps and SequenceTensors is not yet supported");
             }
 
-            // 'disposeOnnxValueAfterUse' is always 'false' for DisposableNamedOnnxValue as the onus
-            // to dispose the onnxValue after use is on the user, not the internal caller
-            disposeOnnxValueAfterUse = false;
-
             // Assign the onnxValue by querying this instance's NativeOnnxTensorMemory instance
             onnxValue = _nativeMemoryManager.Handle;
+
+            // PinnedMemoryHandle holds the default value as DisposableNamedOnnxValue
+            // doesn't hold any managed buffer (that needs to be pinned)
+            pinnedMemoryHandle = default;
         }
 
         internal static DisposableNamedOnnxValue CreateTensorFromOnnxValue(string name, IntPtr nativeOnnxValue)

--- a/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         /// <summary>
-        /// Overrides the base class method. Since the instance already has acccess to the 
+        /// Overrides the base class method. Since the instance already has access to the 
         /// underlying OrtValue handle (if this instance hasn't been disposed), it just assigns
         /// that to the output onnxValue. With respect to pinnedMemoryHandle, it has no operation
         /// to do, as this class doesn't maintain a managed buffer. It doesn't have to maintain it
@@ -82,10 +82,6 @@ namespace Microsoft.ML.OnnxRuntime
                                                  out MemoryHandle pinnedMemoryHandle,
                                                  out bool disposeOnnxValueAfterUse)
         {
-            // 'disposeOnnxValueAfterUse' is always 'false' for DisposableNamedOnnxValue as the onus
-            // to dispose the onnxValue after use is on the user, not the internal caller
-            disposeOnnxValueAfterUse = false;
-
             // Make sure that this instance hasn't been disposed yet
             if (disposedValue)
             {
@@ -99,6 +95,11 @@ namespace Microsoft.ML.OnnxRuntime
                 throw new NotSupportedException("Use of Maps and SequenceTensors is not yet supported");
             }
 
+            // 'disposeOnnxValueAfterUse' is always 'false' for DisposableNamedOnnxValue as the onus
+            // to dispose the onnxValue after use is on the user, not the internal caller
+            disposeOnnxValueAfterUse = false;
+
+            // Assign the onnxValue by querying this instance's NativeOnnxTensorMemory instance
             onnxValue = _nativeMemoryManager.GetOnnxValue();
         }
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using System.Runtime.InteropServices;
@@ -73,20 +72,22 @@ namespace Microsoft.ML.OnnxRuntime
             // make sure that this instance hasn't been disposed yet
             if (disposedValue)
             {
-                throw new Exception("This instance of DisposableNamedOnnxValue has been disposed");
+                throw new Exception("This instance of DisposableNamedOnnxValue has already been disposed");
             }
 
             // If not already disposed, _nativeMemoryManager can only be null
-            // for Map and SequenceTensor types
+            // for Maps and SequenceTensors
             if (_nativeMemoryManager == null)
             {
-                throw new NotSupportedException("TODO");
+                throw new NotSupportedException("Use of Maps and SequenceTensors is not yet supported");
             }
 
             _onnxValue = _nativeMemoryManager.GetOnnxValue();
         }
 
-        public override void UnpinBufferAndReleaseNativeValue()
+        // Call Dispose() to dispose the native OrtValue
+        // This method is kept as a no-op override to the base class method 
+        internal override void UnpinBufferAndReleaseNativeValue()
         {
             // This is a no-op for DisposableNamedOnnxValue as
             // 1) This doesn't maintain a pinned memory buffer

--- a/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using System.Runtime.InteropServices;
@@ -58,13 +59,28 @@ namespace Microsoft.ML.OnnxRuntime
         #endregion
     }
 
-    public class DisposableNamedOnnxValue : NamedOnnxValue, IDisposable
+    public class DisposableNamedOnnxValue : NamedOnnxValue
     {
-        protected IDisposable _nativeMemoryManager;
-        protected DisposableNamedOnnxValue(string name, Object value, IDisposable nativeMemoryManager)
+        protected NativeMemoryHandler _nativeMemoryManager;
+        protected DisposableNamedOnnxValue(string name, Object value, NativeMemoryHandler nativeMemoryManager)
             : base(name, value)
         {
             _nativeMemoryManager = nativeMemoryManager;
+        }
+
+        internal override void ToNativeOnnxValue(out IntPtr onnxValue, out MemoryHandle pinnedMemoryHandle)
+        {
+            if (disposedValue)
+            {
+
+            }
+
+            if (_nativeMemoryManager == null)
+            {
+
+            }
+
+            onnxValue = _nativeMemoryManager.GetNativeMemoryHandle();
         }
 
         internal static DisposableNamedOnnxValue CreateTensorFromOnnxValue(string name, IntPtr nativeOnnxValue)

--- a/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
@@ -85,7 +85,8 @@ namespace Microsoft.ML.OnnxRuntime
             // Make sure that this instance hasn't been disposed yet
             if (disposedValue)
             {
-                throw new Exception("This instance of DisposableNamedOnnxValue has already been disposed");
+                throw new ObjectDisposedException(nameof(DisposableNamedOnnxValue),
+                                                  "This instance of DisposableNamedOnnxValue has already been disposed");
             }
 
             // If not already disposed, _nativeMemoryManager can only be null
@@ -100,7 +101,7 @@ namespace Microsoft.ML.OnnxRuntime
             disposeOnnxValueAfterUse = false;
 
             // Assign the onnxValue by querying this instance's NativeOnnxTensorMemory instance
-            onnxValue = _nativeMemoryManager.GetOnnxValue();
+            onnxValue = _nativeMemoryManager.Handle;
         }
 
         internal static DisposableNamedOnnxValue CreateTensorFromOnnxValue(string name, IntPtr nativeOnnxValue)

--- a/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
@@ -61,8 +61,8 @@ namespace Microsoft.ML.OnnxRuntime
 
     public class DisposableNamedOnnxValue : NamedOnnxValue, IDisposable
     {
-        protected IDisposable _nativeMemoryManager;
-        protected DisposableNamedOnnxValue(string name, Object value, IDisposable nativeMemoryManager)
+        protected NativeMemoryHandler _nativeMemoryManager;
+        protected DisposableNamedOnnxValue(string name, Object value, NativeMemoryHandler nativeMemoryManager)
             : base(name, value)
         {
             _nativeMemoryManager = nativeMemoryManager;
@@ -76,16 +76,14 @@ namespace Microsoft.ML.OnnxRuntime
                 throw new Exception("This instance of DisposableNamedOnnxValue has been disposed");
             }
 
-            // If not disposed,_nativeMemoryManager can only be null
+            // If not already disposed, _nativeMemoryManager can only be null
             // for Map and SequenceTensor types
             if (_nativeMemoryManager == null)
             {
                 throw new NotSupportedException("TODO");
             }
 
-            // After the checks, this is a no-op for DisposableNamedOnnxValue as
-            // it is still holding onto its _onnxValue from when this instance 
-            // was created
+            _onnxValue = _nativeMemoryManager.GetOnnxValue();
         }
 
         public override void UnpinBufferAndReleaseNativeValue()

--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
@@ -144,7 +144,8 @@ namespace Microsoft.ML.OnnxRuntime
                 // as the code is not equipped to handle that
                 if (input is DisposableNamedOnnxValue)
                 {
-                    throw new NotSupportedException("Input of type 'DisposableNamedOnnxValue' is not supported");
+                    throw new NotSupportedException(
+                    "Input type 'DisposableNamedOnnxValue' is not supported. Use 'NamedOnnxValue' type instead.");
                 }
 
                 inputNames[inputIndex] = input.Name;

--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
@@ -140,6 +140,13 @@ namespace Microsoft.ML.OnnxRuntime
             int inputIndex = 0;
             foreach (var input in inputs)
             {
+                // guard against accidental DisposableNamedOnnxValue inputs flowing through
+                // as the code is not equipped to handle that
+                if (input is DisposableNamedOnnxValue)
+                {
+                    throw new NotSupportedException("Input of type 'DisposableNamedOnnxValue' is not supported");
+                }
+
                 inputNames[inputIndex] = input.Name;
 
                 // create Tensor from the input if feasible, else throw notsupported exception for now

--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
@@ -193,6 +193,7 @@ namespace Microsoft.ML.OnnxRuntime
                     input.UnpinBufferAndReleaseNativeValue();
                 }
             }
+
         }
 
         //TODO: kept internal until implemented

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.cs
@@ -290,7 +290,7 @@ namespace Microsoft.ML.OnnxRuntime
 
         }
 
-        public IntPtr GetOnnxValue()
+        internal IntPtr GetOnnxValue()
         {
             return _onnxValue;
         }
@@ -298,7 +298,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// <summary>
         /// Will unpin the memory buffer and delete the underlying native OrtValue 
         /// </summary>
-        public virtual void UnpinBufferAndReleaseNativeValue()
+        internal virtual void UnpinBufferAndReleaseNativeValue()
         {
             if (_onnxValue != IntPtr.Zero)
             {

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.cs
@@ -71,7 +71,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// </summary>
         /// <param name="onnxValue"></param>
         /// <param name="pinnedMemoryHandle"></param>
-        internal void ToNativeOnnxValue(out IntPtr onnxValue, out MemoryHandle pinnedMemoryHandle)
+        internal virtual void ToNativeOnnxValue(out IntPtr onnxValue, out MemoryHandle pinnedMemoryHandle)
         {
             //try to cast _value to Tensor<T>
             TensorElementType nativeElementType = TensorElementType.DataTypeMax; //invalid

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.cs
@@ -73,13 +73,8 @@ namespace Microsoft.ML.OnnxRuntime
         /// <param name="pinnedMemoryHandle"></param>
         /// <param name="disposeOnnxValueAfterUse"></param>
         internal virtual void ToNativeOnnxValue(out IntPtr onnxValue, 
-                                                out MemoryHandle pinnedMemoryHandle,
-                                                out bool disposeOnnxValueAfterUse)
+                                                out MemoryHandle pinnedMemoryHandle)
         {
-            // 'disposeOnnxValueAfterUse' is always 'true' for NamedOnnxValue as the onus
-            // to dispose the onnxValue after use is on the internal caller
-            disposeOnnxValueAfterUse = true;
-
             //try to cast _value to Tensor<T>
             TensorElementType nativeElementType = TensorElementType.DataTypeMax; //invalid
             IntPtr dataBufferPointer = IntPtr.Zero;

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
@@ -12,8 +12,12 @@ using System.Threading;
 
 namespace Microsoft.ML.OnnxRuntime
 {
+    public interface NativeMemoryHandler : IDisposable
+    {
+        IntPtr GetOnnxValue();
+    }
 
-    internal class NativeOnnxTensorMemory<T> : MemoryManager<T>
+    internal class NativeOnnxTensorMemory<T> : MemoryManager<T>, NativeMemoryHandler 
     {
         private bool _disposed;
         private int _referenceCount;
@@ -121,6 +125,11 @@ namespace Microsoft.ML.OnnxRuntime
                     NativeMethods.OrtReleaseTensorTypeAndShapeInfo(typeAndShape);
                 }
             }
+        }
+
+        public IntPtr GetOnnxValue()
+        {
+            return _onnxValueHandle;
         }
 
         ~NativeOnnxTensorMemory()

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
@@ -12,7 +12,7 @@ using System.Threading;
 
 namespace Microsoft.ML.OnnxRuntime
 {
-    public interface NativeMemoryHandler : IDisposable
+    internal interface NativeMemoryHandler : IDisposable
     {
         IntPtr GetOnnxValue();
     }

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
@@ -12,7 +12,13 @@ using System.Threading;
 
 namespace Microsoft.ML.OnnxRuntime
 {
-    internal class NativeOnnxTensorMemory<T> : MemoryManager<T>
+    public interface NativeMemoryHandler : IDisposable
+    {
+        IntPtr GetNativeMemoryHandle();
+
+    }
+
+    internal class NativeOnnxTensorMemory<T> : MemoryManager<T>, NativeMemoryHandler
     {
         private bool _disposed;
         private int _referenceCount;
@@ -120,6 +126,11 @@ namespace Microsoft.ML.OnnxRuntime
                     NativeMethods.OrtReleaseTensorTypeAndShapeInfo(typeAndShape);
                 }
             }
+        }
+
+        public IntPtr GetNativeMemoryHandle()
+        {
+            return _onnxValueHandle;
         }
 
         ~NativeOnnxTensorMemory()

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
@@ -12,9 +12,12 @@ using System.Threading;
 
 namespace Microsoft.ML.OnnxRuntime
 {
+    /// <summary>
+    /// A non-public interface detailing the contract to be honored by NativeOnnxTensorMemory
+    /// </summary>
     internal interface NativeMemoryHandler : IDisposable
     {
-        IntPtr GetOnnxValue();
+        IntPtr Handle { get;}
     }
 
     internal class NativeOnnxTensorMemory<T> : MemoryManager<T>, NativeMemoryHandler 
@@ -131,6 +134,8 @@ namespace Microsoft.ML.OnnxRuntime
         {
             return _onnxValueHandle;
         }
+
+        public IntPtr Handle { get { return _onnxValueHandle; } }
 
         ~NativeOnnxTensorMemory()
         {

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
@@ -130,11 +130,6 @@ namespace Microsoft.ML.OnnxRuntime
             }
         }
 
-        public IntPtr GetOnnxValue()
-        {
-            return _onnxValueHandle;
-        }
-
         public IntPtr Handle { get { return _onnxValueHandle; } }
 
         ~NativeOnnxTensorMemory()

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.cs
@@ -12,13 +12,8 @@ using System.Threading;
 
 namespace Microsoft.ML.OnnxRuntime
 {
-    public interface NativeMemoryHandler : IDisposable
-    {
-        IntPtr GetNativeMemoryHandle();
 
-    }
-
-    internal class NativeOnnxTensorMemory<T> : MemoryManager<T>, NativeMemoryHandler
+    internal class NativeOnnxTensorMemory<T> : MemoryManager<T>
     {
         private bool _disposed;
         private int _referenceCount;
@@ -126,11 +121,6 @@ namespace Microsoft.ML.OnnxRuntime
                     NativeMethods.OrtReleaseTensorTypeAndShapeInfo(typeAndShape);
                 }
             }
-        }
-
-        public IntPtr GetNativeMemoryHandle()
-        {
-            return _onnxValueHandle;
         }
 
         ~NativeOnnxTensorMemory()

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -752,13 +752,11 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 { 
                     using (var res2 = session.Run(res1))
                     {
-                        GC.Collect();
                         var tensorOut = res2.First().AsTensor<bool>();
                         Assert.True(tensorOut.SequenceEqual(tensorIn));
                     }
                 }
 
-                /*
                 // Dispose the result tensor
                 res1.First().Dispose();
 
@@ -771,7 +769,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     session.Run(res1);
                 }
 
-                catch(Exception e)
+                catch(ObjectDisposedException e)
                 {
                     var errorString = "This instance of DisposableNamedOnnxValue has already been disposed";
 
@@ -781,7 +779,6 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 }
 
                 Assert.True(succeeded);
-                */
             }
         }
 
@@ -811,7 +808,6 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     }
                 }
 
-                /*
                 // Dispose the result tensor
                 res1.First().Dispose();
 
@@ -824,7 +820,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     session.Run(res1);
                 }
 
-                catch (Exception e)
+                catch (ObjectDisposedException e)
                 {
                     var errorString = "This instance of DisposableNamedOnnxValue has already been disposed";
 
@@ -834,7 +830,6 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 }
 
                 Assert.True(succeeded);
-                */
             }
 
         }

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -752,6 +752,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 { 
                     using (var res2 = session.Run(res1))
                     {
+                        GC.Collect();
                         var tensorOut = res2.First().AsTensor<bool>();
                         Assert.True(tensorOut.SequenceEqual(tensorIn));
                     }

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -757,6 +757,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     }
                 }
 
+                /*
                 // Dispose the result tensor
                 res1.First().Dispose();
 
@@ -779,6 +780,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 }
 
                 Assert.True(succeeded);
+                */
             }
         }
 
@@ -808,6 +810,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     }
                 }
 
+                /*
                 // Dispose the result tensor
                 res1.First().Dispose();
 
@@ -830,6 +833,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 }
 
                 Assert.True(succeeded);
+                */
             }
 
         }

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -757,7 +757,11 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
                 catch(System.NotSupportedException e)
                 {
-                    Assert.True(e.Message.Contains("Input of type 'DisposableNamedOnnxValue' is not supported"));
+                    var errorString = string.Concat("Input type 'DisposableNamedOnnxValue' is not supported. ",
+                                                    "Use 'NamedOnnxValue' type instead.");
+
+                    Assert.True(e.Message.Contains(errorString));
+
                     succeeded = true;
                 }
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -771,7 +771,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
                 catch(Exception e)
                 {
-                    var errorString = "This instance of DisposableNamedOnnxValue has been disposed";
+                    var errorString = "This instance of DisposableNamedOnnxValue has already been disposed";
 
                     Assert.True(e.Message.Contains(errorString));
 
@@ -822,7 +822,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
                 catch (Exception e)
                 {
-                    var errorString = "This instance of DisposableNamedOnnxValue has been disposed";
+                    var errorString = "This instance of DisposableNamedOnnxValue has already been disposed";
 
                     Assert.True(e.Message.Contains(errorString));
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -756,29 +756,6 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                         Assert.True(tensorOut.SequenceEqual(tensorIn));
                     }
                 }
-
-                // Dispose the result tensor
-                res1.First().Dispose();
-
-                bool succeeded = false;
-
-                // Now try using the disposed output as input to another Run()
-                try
-                {
-                    // Run() should fail with a user friendly error message.
-                    session.Run(res1);
-                }
-
-                catch(ObjectDisposedException e)
-                {
-                    var errorString = "This instance of DisposableNamedOnnxValue has already been disposed";
-
-                    Assert.True(e.Message.Contains(errorString));
-
-                    succeeded = true;
-                }
-
-                Assert.True(succeeded);
             }
         }
 
@@ -807,6 +784,21 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                         Assert.True(tensorOut.SequenceEqual(tensorIn));
                     }
                 }
+            }
+        }
+
+        [Fact]
+        private void TestReusingDisposedRunOutput()
+        {
+            // model takes 1x5 input of fixed type, echoes back
+            string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_types_BOOL.pb");
+            using (var session = new InferenceSession(modelPath))
+            {
+                var container = new List<NamedOnnxValue>();
+                var tensorIn = new DenseTensor<bool>(new bool[] { true, false, true, false, true }, new int[] { 1, 5 });
+                var nov = NamedOnnxValue.CreateFromTensor("input", tensorIn);
+                container.Add(nov);
+                var res1 = session.Run(container);
 
                 // Dispose the result tensor
                 res1.First().Dispose();
@@ -831,7 +823,6 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
                 Assert.True(succeeded);
             }
-
         }
 
         [Fact]


### PR DESCRIPTION
**Description**: `DisposableNamedOnnxValue` inputs in c# Run() inputs are to be supported as  ``DisposableNamedOnnxValue` is `NamedOnnxValue`. 

This change has the following parts:
  1) Add logic to handle `DisposableNamedOnnxValue` inputs to Session Run()
  2) Support a setter for the names of `NamedOnnxValue`/`DisposableNamedOnnxValue`. This is required if someone were to pass in the output of Run() to the input of another Run() as the names of the input feed is likely to be different from the name of the output feed.
  3) Tests


**Motivation and Context**
Resolve #2983
