### PR TITLE
Adjust the threading logic in ThreadPool::ParallelFor

### DIFF
--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -43,17 +43,16 @@ void ThreadPool::ParallelFor(int32_t total, std::function<void(int32_t)> fn) {
 
   // TODO: Eigen supports a more efficient ThreadPoolDevice mechanism
   // We will simply rely on the work queue and stealing in the short term.
-  Barrier barrier(static_cast<unsigned int>(total - 1));
+  Barrier barrier(static_cast<unsigned int>(total));
   std::function<void(int32_t)> handle_iteration = [&barrier, &fn](int iteration) {
     fn(iteration);
     barrier.Notify();
   };
 
-  for (int32_t id = 1; id < total; ++id) {
+  for (int32_t id = 0; id < total; ++id) {
     Schedule([=, &handle_iteration]() { handle_iteration(id); });
   }
 
-  fn(0);
   barrier.Wait();
 }
 

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -669,7 +669,7 @@ MlasGetMaximumThreadCount(
     MLAS_UNREFERENCED_PARAMETER(ThreadPool);
 #else
     if (ThreadPool != nullptr) {
-        return ThreadPool->NumThreads() + 1;
+        return ThreadPool->NumThreads();
     }
 #endif
 


### PR DESCRIPTION
**Description**: 

1.  Do not reuse the main thread. 
2.  Do not plus one when mlas calculate the number of tasks to schedule. (It was me put the plus one there)

This is the second try of #1839

**Motivation and Context**
- Why is this change required? What problem does it solve?
First, in our current code, the default setting of session thread pool is far from optimal. For example, to make
resnet models get the best perf, you should set thread count to 3, not 4. By default is 4. The default one is 30%-70% slower than the optimal one. 
For example, in the master branch, on my local host, the mlperf resnet50 model's latency is:
4 threads: 23.8403 ms
3 threads: 14.4022 ms

Second, the ThreadPool::ParallelFor implementation doesn't work well when the value of 'total' is larger than number of threads in the thread pool.  It's not necessary to fix but if I only revert the change in mlasi.h without changing the code in ThreadPool::ParallelFor, the perf will drop dramatically.  I don't quite understand why it happens. I guess it's related to the spinlock in Eigen threadpool.

If I change both of them, the perf impact is mostly ok. 

| model             | NEW_CHANGE | OLD      | % DIFF |
|-------------------|------------|----------|------|
| inception_v2      | 0.010315   | 0.009523 | 8    |
| mlperf_mobilenet  | 0.003113   | 0.00281  | 10   |
| squeezenet        | 0.002565   | 0.002291 | 11   |

(The old one is based on thread count=3, not 4. Otherwise all the models get much better.)

It still hurts performance on some of the models, but the others are neutral. 

See more information at #1646 #1873

Regarding to #1873, I'll make it as an option in SessionOptions. 

- If it fixes an open issue, please link to the issue here.
