### PR TITLE
use idxgifactory4 instead of 6 in getD3D12Device

### DIFF
--- a/winml/lib/Api.Image/DeviceHelpers.cpp
+++ b/winml/lib/Api.Image/DeviceHelpers.cpp
@@ -38,9 +38,9 @@ HRESULT GetDXGIHardwareAdapterWithPreference(DXGI_GPU_PREFERENCE preference, IDX
     RETURN_IF_FAILED(CreateDXGIFactory1(IID_PPV_ARGS(spFactory.put())));
    
     while (spFactory->EnumAdapters1(i, spAdapter.put()) != DXGI_ERROR_NOT_FOUND) {
-      bool* isWarpAdapter;
-      RETURN_IF_FAILED(IsWarpAdapter(spAdapter.get(), isWarpAdapter));
-      if (!(*isWarpAdapter)) {
+      bool isWarpAdapter = false;
+      RETURN_IF_FAILED(IsWarpAdapter(spAdapter.get(), &isWarpAdapter));
+      if (!isWarpAdapter) {
         spAdapter.copy_to(ppAdapter);
         return S_OK;
       }
@@ -53,7 +53,7 @@ HRESULT GetDXGIHardwareAdapterWithPreference(DXGI_GPU_PREFERENCE preference, IDX
     RETURN_IF_FAILED(CreateDXGIFactory1(IID_PPV_ARGS(spFactory.put())));
 
     while (spFactory->EnumAdapterByGpuPreference(i, preference, IID_PPV_ARGS(spAdapter.put())) != DXGI_ERROR_NOT_FOUND) {
-      bool* isWarpAdapter;
+      bool* isWarpAdapter = false;
       RETURN_IF_FAILED(IsWarpAdapter(spAdapter.get(), isWarpAdapter));
       if (!*isWarpAdapter) {
         spAdapter.copy_to(ppAdapter);

--- a/winml/lib/Api.Image/DeviceHelpers.cpp
+++ b/winml/lib/Api.Image/DeviceHelpers.cpp
@@ -53,9 +53,9 @@ HRESULT GetDXGIHardwareAdapterWithPreference(DXGI_GPU_PREFERENCE preference, IDX
     RETURN_IF_FAILED(CreateDXGIFactory1(IID_PPV_ARGS(spFactory.put())));
 
     while (spFactory->EnumAdapterByGpuPreference(i, preference, IID_PPV_ARGS(spAdapter.put())) != DXGI_ERROR_NOT_FOUND) {
-      bool* isWarpAdapter = false;
-      RETURN_IF_FAILED(IsWarpAdapter(spAdapter.get(), isWarpAdapter));
-      if (!*isWarpAdapter) {
+      bool isWarpAdapter = false;
+      RETURN_IF_FAILED(IsWarpAdapter(spAdapter.get(), &isWarpAdapter));
+      if (!isWarpAdapter) {
         spAdapter.copy_to(ppAdapter);
         return S_OK;
       }

--- a/winml/lib/Api.Image/DeviceHelpers.cpp
+++ b/winml/lib/Api.Image/DeviceHelpers.cpp
@@ -13,28 +13,55 @@
 #include "LearningModelDevice.h"
 
 namespace DeviceHelpers {
+
+
+HRESULT IsWarpAdapter(IDXGIAdapter1* pAdapter, bool* isWarpAdapter) {
+  DXGI_ADAPTER_DESC1 pDesc;
+  RETURN_IF_FAILED(pAdapter->GetDesc1(&pDesc));
+
+  // see here for documentation on filtering WARP adapter:
+  // https://docs.microsoft.com/en-us/windows/desktop/direct3ddxgi/d3d10-graphics-programming-guide-dxgi#new-info-about-enumerating-adapters-for-windows-8
+  auto isBasicRenderDriverVendorId = pDesc.VendorId == 0x1414;
+  auto isBasicRenderDriverDeviceId = pDesc.DeviceId == 0x8c;
+  auto isSoftwareAdapter = pDesc.Flags == DXGI_ADAPTER_FLAG_SOFTWARE;
+  *isWarpAdapter = isSoftwareAdapter || (isBasicRenderDriverVendorId && isBasicRenderDriverDeviceId);
+  return S_OK;
+}
+
 HRESULT GetDXGIHardwareAdapterWithPreference(DXGI_GPU_PREFERENCE preference, IDXGIAdapter1** ppAdapter) {
-  winrt::com_ptr<IDXGIFactory6> spFactory;
-  RETURN_IF_FAILED(CreateDXGIFactory1(IID_PPV_ARGS(spFactory.put())));
 
   winrt::com_ptr<IDXGIAdapter1> spAdapter;
   UINT i = 0;
-  while (spFactory->EnumAdapterByGpuPreference(i, preference, IID_PPV_ARGS(spAdapter.put())) != DXGI_ERROR_NOT_FOUND) {
-    DXGI_ADAPTER_DESC1 pDesc;
-    spAdapter->GetDesc1(&pDesc);
-
-    // see here for documentation on filtering WARP adapter:
-    // https://docs.microsoft.com/en-us/windows/desktop/direct3ddxgi/d3d10-graphics-programming-guide-dxgi#new-info-about-enumerating-adapters-for-windows-8
-    auto isBasicRenderDriverVendorId = pDesc.VendorId == 0x1414;
-    auto isBasicRenderDriverDeviceId = pDesc.DeviceId == 0x8c;
-    auto isSoftwareAdapter = pDesc.Flags == DXGI_ADAPTER_FLAG_SOFTWARE;
-    if (!isSoftwareAdapter && !(isBasicRenderDriverVendorId && isBasicRenderDriverDeviceId)) {
-      spAdapter.copy_to(ppAdapter);
-      return S_OK;
+  // Avoids using EnumAdapterByGpuPreference for standard GPU path to enable downlevel to RS3
+  if (preference == DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_UNSPECIFIED) {
+    winrt::com_ptr<IDXGIFactory1> spFactory;
+    RETURN_IF_FAILED(CreateDXGIFactory1(IID_PPV_ARGS(spFactory.put())));
+   
+    while (spFactory->EnumAdapters1(i, spAdapter.put()) != DXGI_ERROR_NOT_FOUND) {
+      bool* isWarpAdapter;
+      RETURN_IF_FAILED(IsWarpAdapter(spAdapter.get(), isWarpAdapter));
+      if (!(*isWarpAdapter)) {
+        spAdapter.copy_to(ppAdapter);
+        return S_OK;
+      }
+      spAdapter = nullptr;
+      ++i;
     }
+  }
+  else {
+    winrt::com_ptr<IDXGIFactory6> spFactory;
+    RETURN_IF_FAILED(CreateDXGIFactory1(IID_PPV_ARGS(spFactory.put())));
 
-    spAdapter = nullptr;
-    ++i;
+    while (spFactory->EnumAdapterByGpuPreference(i, preference, IID_PPV_ARGS(spAdapter.put())) != DXGI_ERROR_NOT_FOUND) {
+      bool* isWarpAdapter;
+      RETURN_IF_FAILED(IsWarpAdapter(spAdapter.get(), isWarpAdapter));
+      if (!*isWarpAdapter) {
+        spAdapter.copy_to(ppAdapter);
+        return S_OK;
+      }
+      spAdapter = nullptr;
+      ++i;
+    }
   }
   return HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
 }

--- a/winml/lib/Common/CommonDeviceHelpers.cpp
+++ b/winml/lib/Common/CommonDeviceHelpers.cpp
@@ -92,7 +92,7 @@ HRESULT GetD3D12Device(const winrt::Windows::AI::MachineLearning::LearningModelD
   RETURN_IF_FAILED(GetAdapterEnumerationSupport(&support));
 
   if (support.has_dxgi) {
-    winrt::com_ptr<IDXGIFactory6> spFactory;
+    winrt::com_ptr<IDXGIFactory4> spFactory;
     RETURN_IF_FAILED(CreateDXGIFactory1(IID_PPV_ARGS(spFactory.put())));
 
     winrt::com_ptr<IDXGIAdapter1> spAdapter;


### PR DESCRIPTION
**Description**: Use IDXGIFactory4 instead of 6 when enumerating adapter by luid in GetD3D12Device.

**Motivation and Context**
IDXGIFactory6 forces a dependency on os >= RS4. 
