### PR TITLE
Use Eigen::logistic instead of manually computing values.

### DIFF
--- a/onnxruntime/core/providers/cpu/ml/ml_common.h
+++ b/onnxruntime/core/providers/cpu/ml/ml_common.h
@@ -390,10 +390,9 @@ void batched_update_scores_inplace(gsl::span<T> scores, int64_t num_batches_in, 
         break;
       }
       case POST_EVAL_TRANSFORM::LOGISTIC: {
-        while (s < s_end) {
-          *s = ComputeLogistic(*s);
-          ++s;
-        }
+        // in-place update using Eigen::logistic
+        auto map = EigenVectorArrayMap<float>(scores.data(), scores.length());
+        map = map.logistic();
         break;
       }
       case POST_EVAL_TRANSFORM::SOFTMAX: {

--- a/onnxruntime/core/providers/cpu/ml/ml_common.h
+++ b/onnxruntime/core/providers/cpu/ml/ml_common.h
@@ -5,7 +5,9 @@
 #include "core/common/common.h"
 #include "core/common/safeint.h"
 #include "core/framework/op_kernel.h"
+#include "core/util/math.h"
 #include "core/util/math_cpuonly.h"
+#include "core/mlas/inc/mlas.h"
 #include "core/platform/threadpool.h"
 
 namespace onnxruntime {
@@ -390,9 +392,7 @@ void batched_update_scores_inplace(gsl::span<T> scores, int64_t num_batches_in, 
         break;
       }
       case POST_EVAL_TRANSFORM::LOGISTIC: {
-        // in-place update using Eigen::logistic
-        auto map = EigenVectorArrayMap<float>(scores.data(), scores.length());
-        map = map.logistic();
+        MlasComputeLogistic(s, s, scores.size());
         break;
       }
       case POST_EVAL_TRANSFORM::SOFTMAX: {

--- a/onnxruntime/core/util/math_cpuonly.h
+++ b/onnxruntime/core/util/math_cpuonly.h
@@ -41,13 +41,11 @@
 // warning C4324: structure was padded due to alignment specifier
 // unsupported\eigen\cxx11\src\Tensor\TensorUInt128.h(150,0): Warning C4245: 'initializing': conversion from '__int64'
 // to 'uint64_t', signed/unsigned mismatch
-// cmake\external\eigen\eigen\src/Core/functors/UnaryFunctors.h(935): warning C4305: 'argument': truncation from 'double' to 'const float'
 #pragma warning(push)
 #pragma warning(disable : 4554)
 #pragma warning(disable : 4324)
 #pragma warning(disable : 4245)
 #pragma warning(disable : 4127)
-#pragma warning(disable : 4305)
 #endif
 #include "Eigen/Core"
 

--- a/onnxruntime/core/util/math_cpuonly.h
+++ b/onnxruntime/core/util/math_cpuonly.h
@@ -41,11 +41,13 @@
 // warning C4324: structure was padded due to alignment specifier
 // unsupported\eigen\cxx11\src\Tensor\TensorUInt128.h(150,0): Warning C4245: 'initializing': conversion from '__int64'
 // to 'uint64_t', signed/unsigned mismatch
+// cmake\external\eigen\eigen\src/Core/functors/UnaryFunctors.h(935): warning C4305: 'argument': truncation from 'double' to 'const float'
 #pragma warning(push)
 #pragma warning(disable : 4554)
 #pragma warning(disable : 4324)
 #pragma warning(disable : 4245)
 #pragma warning(disable : 4127)
+#pragma warning(disable : 4305)
 #endif
 #include "Eigen/Core"
 
@@ -87,7 +89,6 @@ auto EigenMap(Tensor& t) -> EigenVectorMap<T> {
 }
 template <typename T>
 auto EigenMap(const Tensor& t) -> ConstEigenVectorMap<T> {
-
   return ConstEigenVectorMap<T>(t.template Data<T>(), t.Shape().Size());
 }
 

--- a/onnxruntime/test/python/onnxruntime_test_python_backend.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_backend.py
@@ -13,6 +13,21 @@ from onnxruntime.backend.backend import OnnxRuntimeBackend as ort_backend
 from onnx import load
 
 
+def check_list_of_map_to_float(testcase, expected_rows, actual_rows):
+    """Validate two list<map<key, float>> instances match closely enough."""
+
+    num_rows = len(expected_rows)
+    sorted_keys = sorted(expected_rows[0].keys())
+    testcase.assertEqual(num_rows, len(actual_rows))
+    testcase.assertEqual(sorted_keys, sorted(actual_rows[0].keys()))
+
+    for i in range(num_rows):
+        # use np.testing.assert_allclose so we can specify the tolerance
+        np.testing.assert_allclose([expected_rows[i][key] for key in sorted_keys],
+                                   [actual_rows[i][key] for key in sorted_keys],
+                                   rtol=1e-05, atol=1e-07)
+
+
 class TestBackend(unittest.TestCase):
 
     def get_name(self, name):
@@ -56,7 +71,8 @@ class TestBackend(unittest.TestCase):
         output_expected = [{0: 0.950599730014801, 1: 0.027834169566631317, 2: 0.02156602405011654},
                            {0: 0.9974970817565918, 1: 5.6299926654901356e-05, 2: 0.0024466661270707846},
                            {0: 0.9997311234474182, 1: 1.1918064757310276e-07, 2: 0.00026869276189245284}]
-        self.assertEqual(output_expected, res[1])
+
+        check_list_of_map_to_float(self, output_expected, res[1])
 
     def testRunModelProtoApi(self):
         name = datasets.get_example("logreg_iris.onnx")
@@ -70,7 +86,8 @@ class TestBackend(unittest.TestCase):
         output_expected = [{0: 0.950599730014801, 1: 0.027834169566631317, 2: 0.02156602405011654},
                            {0: 0.9974970817565918, 1: 5.6299926654901356e-05, 2: 0.0024466661270707846},
                            {0: 0.9997311234474182, 1: 1.1918064757310276e-07, 2: 0.00026869276189245284}]
-        self.assertEqual(output_expected, outputs[1])
+
+        check_list_of_map_to_float(self, output_expected, outputs[1])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description**: 
Use Eigen::logistic instead of ComputeLogistic for LinearClassifier

**Motivation and Context**
Close performance gap with SKL due to ComputeLogistic being slow.

Original changes had Eigen::logistic.

Batch size | v1.1.2 | master + Eigen::logistic | Speed-up
-- | -- | -- | --
100 | 0.0142334 | 0.0102302 | 1.39
1000 | 0.0971161 | 0.0385092 | 2.52
10000 | 0.884861 | 0.392591 | 2.25
100000 | 8.89221 | 3.50334 | 2.54

Latest changes have MlasComputeLogistic

Batch size | v1.1.2 | master + MlasComputeLogistic | Speed-up
-- | -- | -- | --
100 | 0.0141228 | 0.00986273 | 1.43
1000 | 0.0925429 | 0.0345273 | 2.68
10000 | 0.867377 | 0.351056 | 2.47
100000 | 8.56031 | 3.1005 | 2.76

