### PR TITLE
Increase MLAS_MAXIMUM_THREAD_COUNT to 64

### DIFF
--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -109,7 +109,7 @@ Abstract:
 // Define the maximum number of threads supported by this implementation.
 //
 
-#define MLAS_MAXIMUM_THREAD_COUNT                   16
+#define MLAS_MAXIMUM_THREAD_COUNT                   64
 
 //
 // Define the default strides to step through slices of the input matrices.


### PR DESCRIPTION
**Description**: 

Increase MLAS_MAXIMUM_THREAD_COUNT to 64

**Motivation and Context**
- Why is this change required? What problem does it solve?

Many of our server machines have more than 16 CPUs. 
I'm doing some perf test on a 48 cores machine, so I need to increase this number to a higher value. 

- If it fixes an open issue, please link to the issue here.
