### PR TITLE
add dml_ep_lock

### DIFF
--- a/winml/lib/Api/LearningModelBinding.h
+++ b/winml/lib/Api/LearningModelBinding.h
@@ -21,6 +21,8 @@ struct LearningModelBinding : LearningModelBindingT<LearningModelBinding, ILearn
   using KeyValuePair =
       Windows::Foundation::Collections::IKeyValuePair<hstring, Windows::Foundation::IInspectable>;
 
+  ~LearningModelBinding();
+  
   LearningModelBinding() = delete;
   LearningModelBinding(Windows::AI::MachineLearning::LearningModelSession const& session);
 

--- a/winml/lib/Api/LearningModelSession.cpp
+++ b/winml/lib/Api/LearningModelSession.cpp
@@ -27,14 +27,6 @@ static const GUID WINML_PIX_EVAL_CAPTURABLE_WORK_GUID = __uuidof(guid_details::W
 
 namespace winrt::Windows::AI::MachineLearning::implementation {
 
-// Bug 23595718: DML does bad things when called at the same time from multiple sessions
-// there are several issues/bugs when the DML EP does work with the GPU at the same time.
-// even acrosss multiple sessions.
-// until we can fix all of these issues, we are making the lock global for queueing GPU work.
-// you can still pipeline work (queue, go do cpu work, queue some more gpu) - 
-// you just can't queue multuple things concurrently until we fix it all
-CWinMLLock LearningModelSession::dml_ep_lock_;
-
 LearningModelSession::LearningModelSession(
     winml::LearningModel const& model) try : LearningModelSession(model,
                                                                   make<LearningModelDevice>(LearningModelDeviceKind::Default)) {}

--- a/winml/lib/Api/LearningModelSession.h
+++ b/winml/lib/Api/LearningModelSession.h
@@ -74,6 +74,12 @@ struct LearningModelSession : LearningModelSessionT<LearningModelSession> {
   void
   CheckClosed();
 
+  // LearningModelBinding needs to leverage the lock
+  CWinMLLock *
+  GetDMLEPLock()
+  {
+    return &dml_ep_lock_;
+  }
  private:
   void
   Initialize();
@@ -114,11 +120,13 @@ struct LearningModelSession : LearningModelSessionT<LearningModelSession> {
 
   // Synchronization
   CWinMLLock session_creation_lock_;
-  CWinMLLock evaluate_lock_;
+  static CWinMLLock dml_ep_lock_;
 
   // is_first_evaluate_ is used as a heuristic to determine
   // when the dml upload heap can be trimmed.
   bool is_first_evaluate_ = true;
+
+
 };
 
 }  // namespace winrt::Windows::AI::MachineLearning::implementation

--- a/winml/lib/Api/LearningModelSession.h
+++ b/winml/lib/Api/LearningModelSession.h
@@ -120,7 +120,7 @@ struct LearningModelSession : LearningModelSessionT<LearningModelSession> {
 
   // Synchronization
   CWinMLLock session_creation_lock_;
-  static CWinMLLock dml_ep_lock_;
+  CWinMLLock dml_ep_lock_;
 
   // is_first_evaluate_ is used as a heuristic to determine
   // when the dml upload heap can be trimmed.


### PR DESCRIPTION
1. Problem to Solve:
This is to fix the concurrency issue that LearningModeBinding is not thread-safe. Race Condition would happen when multiple Learning binding objects share one LearningModelSession. 

2. How to Solve:
Applied a global dml_ep_lock from LearningModelSession.h before createbinding.

3. Tests:
Tests are added in winmlconcurrency tests https://microsoft.visualstudio.com/_git/WindowsAI/pullrequest/4418329?_a=overview


