### PR TITLE
Adjust the grouping logic in ThreadPool::TryBatchParallelFor

### DIFF
--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -64,13 +64,14 @@ class ThreadPool {
   // void SetStealPartitions(const std::vector<std::pair<unsigned, unsigned>>& partitions);
 
   /**
-  Tries to call the given function in parallel, with calls split into (num_batches) batches.
-  **/
+   * Tries to call the given function in parallel, with calls split into (num_batches) batches.
+   * If tp is NULL and OpenMP is enabled, no grouping
+   */
   template <typename F>
   inline static void TryBatchParallelFor(concurrency::ThreadPool* tp, int32_t total, F&& fn, int32_t num_batches = 0) {
     if (tp != nullptr) {
       if (num_batches <= 0) {
-        num_batches = tp->NumThreads() + 1;
+        num_batches = std::min(total, tp->NumThreads());
       }
       tp->BatchParallelFor(total, std::forward<F>(fn), num_batches);
     } else {

--- a/onnxruntime/contrib_ops/cpu/activations.h
+++ b/onnxruntime/contrib_ops/cpu/activations.h
@@ -43,7 +43,7 @@ class Gelu : public OpKernel {
     if (nullptr != tp) {
       const T* input = X->template Data<T>();
       T* output = Y->template MutableData<T>();
-      int task_count = tp->NumThreads() + 1;
+      int task_count = tp->NumThreads();
       int64_t elem_count = X->Shape().Size();
       if (elem_count > task_count) {
         tp->ParallelFor(task_count, [input,


### PR DESCRIPTION
**Description**: 

Adjust the grouping logic in ThreadPool::TryBatchParallelFor

1. No more plus 1.
2. Use MlasPartitionWork function to calculate the work index range.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
