### PR TITLE
Fixes GTest deprecation warnings

### DIFF
--- a/onnxruntime/test/framework/distance_test.cc
+++ b/onnxruntime/test/framework/distance_test.cc
@@ -15,7 +15,7 @@ class SqeuclideanTest : public ::testing::Test {
 
 using MyTypes = Types<Sqeuclidean<double>, SqeuclideanWithEigen<double> >;
 
-TYPED_TEST_CASE(SqeuclideanTest, MyTypes);
+TYPED_TEST_SUITE(SqeuclideanTest, MyTypes);
 
 TYPED_TEST(SqeuclideanTest, test1) {
   double a = 10;

--- a/onnxruntime/test/framework/math_test.cc
+++ b/onnxruntime/test/framework/math_test.cc
@@ -121,7 +121,7 @@ TEST_P(MathGemmTest, GemmNoTransTrans) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(MathGemmTests, MathGemmTest,
+INSTANTIATE_TEST_SUITE_P(MathGemmTests, MathGemmTest,
                         testing::Values(1, 4));
 
 TEST(MathTest, GemvNoTrans) {

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -151,6 +151,6 @@ TEST_P(SessionStateTestP, TestInitializerProcessing) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(SessionStateTests, SessionStateTestP, testing::ValuesIn(param_list));
+INSTANTIATE_TEST_SUITE_P(SessionStateTests, SessionStateTestP, testing::ValuesIn(param_list));
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/ir/onnx_model_test.cc
+++ b/onnxruntime/test/ir/onnx_model_test.cc
@@ -155,11 +155,11 @@ TEST_P(ONNXModelsTest1, LoadFromProtobuf) {
 }
 
 #ifndef DISABLE_CONTRIB_OPS
-INSTANTIATE_TEST_CASE_P(ONNXModelsTests,
+INSTANTIATE_TEST_SUITE_P(ONNXModelsTests,
                         ONNXModelsTest1,
                         ::testing::Values(ORT_TSTR("bvlc_alexnet"), ORT_TSTR("bvlc_googlenet"), ORT_TSTR("bvlc_reference_caffenet"), ORT_TSTR("bvlc_reference_rcnn_ilsvrc13"), ORT_TSTR("densenet121"), ORT_TSTR("emotion_ferplus"), ORT_TSTR("inception_v1"), ORT_TSTR("inception_v2"), ORT_TSTR("mnist"), ORT_TSTR("resnet50"), ORT_TSTR("shufflenet"), ORT_TSTR("squeezenet"), ORT_TSTR("tiny_yolov2"), ORT_TSTR("vgg19"), ORT_TSTR("zfnet512")));
 #else
-INSTANTIATE_TEST_CASE_P(ONNXModelsTests,
+INSTANTIATE_TEST_SUITE_P(ONNXModelsTests,
                         ONNXModelsTest1,
                         ::testing::Values(ORT_TSTR("bvlc_alexnet"), ORT_TSTR("bvlc_googlenet"), ORT_TSTR("bvlc_reference_caffenet"), ORT_TSTR("bvlc_reference_rcnn_ilsvrc13"), ORT_TSTR("densenet121"), ORT_TSTR("emotion_ferplus"), ORT_TSTR("inception_v1"), ORT_TSTR("inception_v2"), ORT_TSTR("mnist"), ORT_TSTR("resnet50"), ORT_TSTR("shufflenet"), ORT_TSTR("squeezenet"), ORT_TSTR("vgg19"), ORT_TSTR("zfnet512")));
 #endif


### PR DESCRIPTION
**Description**: Updated some tests in order to avoid GTest deprecation warnings

**Motivation and Context**
- Got errors when building with the build.bat script. This pull request fixes those errors.
