### PR TITLE
Add ort_training build status file.

### DIFF
--- a/ORT_TRAINING_BUILDS.md
+++ b/ORT_TRAINING_BUILDS.md
@@ -1,0 +1,45 @@
+# ort_training Build Status
+
+This is a central place to see the latest build status for ort_training.
+
+**TODO - Delete this file before merging to ort_training to master.**
+
+## Linux
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/11?branchName=ort_training&label=Linux+CPU)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=11)
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/64?branchName=ort_training&label=Linux+CPU+NoContribOps)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=64)
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/12?branchName=ort_training&label=Linux+GPU)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=12)
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/45?branchName=ort_training&label=Linux+GPU+TensorRT)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=45)
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/52?branchName=ort_training&label=Linux+nGraph)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=52)
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/55?branchName=ort_training&label=Linux+OpenVINO)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=55)
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/78?branchName=ort_training&label=CentOS7+CPU)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=78)
+
+## Windows
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/9?branchName=ort_training&label=Win+CPU)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=9)
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/62?branchName=ort_training&label=Win+CPU+NoContribOps)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=62)
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/59?branchName=ort_training&label=Win+CPU+x86)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=59)
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/61?branchName=ort_training&label=Win+CPU+x86+NoContribOps)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=61)
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/10?branchName=ort_training&label=Windows+GPU)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=10)
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/47?branchName=ort_training&label=Win+GPU+TensorRT)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=47)
+
+## Mac
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/13?branchName=ort_training&label=Mac)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=13)
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/65?branchName=ort_training&label=Mac+NoContribOps)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=65)
+
+## Android
+
+[![](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/53?branchName=ort_training&label=Android)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?branchName=ort_training&definitionId=53)


### PR DESCRIPTION
Trying to set up a central place to look at the build statuses. Check out https://github.com/microsoft/onnxruntime/blob/edgchen1/training_build_status/ORT_TRAINING_BUILDS.md.
