### PR TITLE
add pipeline graph split script

### DIFF
--- a/orttraining/tools/scripts/pipeline_model_split.py
+++ b/orttraining/tools/scripts/pipeline_model_split.py
@@ -18,9 +18,11 @@ def add_expand_shape(model, name, shape):
     expand_edge.type.CopyFrom(shape)
 
 # Add wait/record/send/recv nodes and split the graph into disconnected subgraphs
-def split_graph(model, edgeIds):
+def split_graph(model, split_edge_groups):
     ms_domain = 'com.microsoft'
 
+    new_send_nodes = []
+    new_recv_nodes = []
     # Add wait for initial inputs. This needs to be done first before new inputs
     # are introduced from split
     initializer_lists = [a.name for a in model.graph.initializer]
@@ -42,121 +44,128 @@ def split_graph(model, edgeIds):
         for node in model.graph.node:
             for j in range(len(node.input)):
                 if node.input[j] == i:
-                    print(node.input[j])
                     node.input[j] = i + '_sync'
 
     input_wait.input.extend(input_tensors)
     input_wait.output.extend([i + '_sync' for i in input_tensors])
 
-    # split the graph based on edgeIds
-    upstream_nodes = []
-    output_shapes =[]
+    for cut_index in range(len(split_edge_groups)):
+        edgeIds = split_edge_groups[cut_index]
 
-    for id in edgeIds:
-        for node in model.graph.node:
-            if len(node.output) >=1 and node.output[0] == id:
-                upstream_nodes.append(node)
-                for info in model.graph.value_info:
-                    if info.name == id:
-                        output_shapes.append(info.type)
+        # split the graph based on edgeIds
+        upstream_nodes = []
+        output_shapes =[]
 
-    record_signal = model.graph.input.add()
-    record_signal.CopyFrom(helper.make_tensor_value_info(
-        'record_signal', onnx.TensorProto.INT64, None))
+        for id in edgeIds:
+            for node in model.graph.node:
+                if len(node.output) >=1 and node.output[0] == id:
+                    upstream_nodes.append(node)
+                    for info in model.graph.value_info:
+                        if info.name == id:
+                            output_shapes.append(info.type)
 
-    wait_signal = model.graph.input.add()
-    wait_signal.CopyFrom(helper.make_tensor_value_info(
-        'wait_signal', onnx.TensorProto.INT64, None))
+        record_signal = model.graph.input.add()
+        record_signal.CopyFrom(helper.make_tensor_value_info(
+            'record_input_signal' + str(cut_index), onnx.TensorProto.INT64, None))
 
-    send_signal = model.graph.input.add()
-    send_signal.CopyFrom(helper.make_tensor_value_info(
-        'send_signal', onnx.TensorProto.BOOL, None))
+        wait_signal = model.graph.input.add()
+        wait_signal.CopyFrom(helper.make_tensor_value_info(
+            'wait_input_signal' + str(cut_index), onnx.TensorProto.INT64, None))
 
-    recv_signal = model.graph.input.add()
-    recv_signal.CopyFrom(helper.make_tensor_value_info(
-        'recv_signal', onnx.TensorProto.BOOL, None))
+        send_signal = model.graph.input.add()
+        send_signal.CopyFrom(helper.make_tensor_value_info(
+            'send_input_signal' + str(cut_index), onnx.TensorProto.BOOL, None))
 
-    # output signal from send after cut
-    send_output_signal = model.graph.output.add()
-    send_output_signal.CopyFrom(helper.make_tensor_value_info(
-        'send_output_signal', onnx.TensorProto.BOOL, None))
+        recv_signal = model.graph.input.add()
+        recv_signal.CopyFrom(helper.make_tensor_value_info(
+            'recv_input_signal' + str(cut_index), onnx.TensorProto.BOOL, None))
 
-    # output signal from receive after cut
-    receive_output_signal = model.graph.output.add()
-    receive_output_signal.CopyFrom(helper.make_tensor_value_info(
-        'receive_output_signal', onnx.TensorProto.BOOL, None))
+        # output signal from send after cut
+        send_output_signal = model.graph.output.add()
+        send_output_signal.CopyFrom(helper.make_tensor_value_info(
+            'send_output_signal' + str(cut_index), onnx.TensorProto.BOOL, None))
 
-    new_send = model.graph.node.add()
-    new_send.CopyFrom(helper.make_node(
-        'Send',
-        inputs=['send_signal'],
-        outputs=['send_output_signal'],
-        tag=0,
-        src=0, # todo：change it when split more than 2 parts
-        dst=1,
-        domain=ms_domain,
-        element_type=1, # assuming all tensors are of type float
-        name='send'))
+        # output signal from receive after cut
+        receive_output_signal = model.graph.output.add()
+        receive_output_signal.CopyFrom(helper.make_tensor_value_info(
+            'receive_output_signal' + str(cut_index), onnx.TensorProto.BOOL, None))
 
-    new_receive = model.graph.node.add()
-    new_receive.CopyFrom(helper.make_node(
-        'Recv',
-        inputs=['recv_signal'],
-        outputs=['receive_output_signal'],
-        tag=1,
-        src=0, # todo：change it when split more than 2 parts
-        dst=1,
-        domain=ms_domain,
-        element_type=1, # assuming all tensors are of type float
-        name='receive'))
+        new_send = model.graph.node.add()
+        new_send.CopyFrom(helper.make_node(
+            'Send',
+            inputs=['send_input_signal' + str(cut_index)],
+            outputs=['send_output_signal' + str(cut_index)],
+            tag=0,
+            src=cut_index,
+            dst=cut_index + 1,
+            domain=ms_domain,
+            element_type=7, # assuming all tensors are of type float
+            name='send'))
 
-    new_wait = model.graph.node.add()
-    new_wait.CopyFrom(helper.make_node(
-        'WaitEvent',
-        inputs=['wait_signal'],
-        outputs=[],
-        domain=ms_domain))
+        new_receive = model.graph.node.add()
+        new_receive.CopyFrom(helper.make_node(
+            'Recv',
+            inputs=['recv_input_signal' + str(cut_index)],
+            outputs=['receive_output_signal' + str(cut_index)],
+            tag=1,
+            src=cut_index,
+            dst=cut_index + 1,
+            domain=ms_domain,
+            element_type=7, # assuming all tensors are of type float
+            name='receive'))
 
-    new_record = model.graph.node.add()
-    new_record.CopyFrom(helper.make_node(
-        'RecordEvent',
-        inputs=['record_signal'],
-        outputs=[],
-        domain=ms_domain))
+        new_wait = model.graph.node.add()
+        new_wait.CopyFrom(helper.make_node(
+            'WaitEvent',
+            inputs=['wait_input_signal' + str(cut_index)],
+            outputs=[],
+            domain=ms_domain))
 
-    for i in range(len(upstream_nodes)):
-        n = upstream_nodes[i]
-        output_type = output_shapes[i]
+        new_record = model.graph.node.add()
+        new_record.CopyFrom(helper.make_node(
+            'RecordEvent',
+            inputs=['record_input_signal' + str(cut_index)],
+            outputs=[],
+            domain=ms_domain))
 
-        output_nodes = find_all_output_nodes_by_edge(model, n.output[0])
+        for i in range(len(upstream_nodes)):
+            n = upstream_nodes[i]
+            output_type = output_shapes[i]
 
-        # deal with shape inference for newly added edge
-        new_send_input_name = n.output[0] + '_send'
-        add_expand_shape(model, new_send_input_name, output_type)
+            output_nodes = find_all_output_nodes_by_edge(model, n.output[0])
 
-        new_receive_output_name = n.output[0] + '_recv'
-        add_expand_shape(model, new_receive_output_name, output_type)
+            # deal with shape inference for newly added edge
+            new_send_input_name = n.output[0] + '_send' + str(cut_index)
+            add_expand_shape(model, new_send_input_name, output_type)
 
-        new_wait_output_name = n.output[0] + '_wait'
-        add_expand_shape(model, new_wait_output_name, output_type)
+            new_receive_output_name = n.output[0] + '_recv' + str(cut_index)
+            add_expand_shape(model, new_receive_output_name, output_type)
 
-        # the order of data flow is: node-output -> record -> send -> recv -> wait -> node-input
-        new_record.input.extend([n.output[0]])
-        new_record.output.extend([new_send_input_name])
+            new_wait_output_name = n.output[0] + '_wait' + str(cut_index)
+            add_expand_shape(model, new_wait_output_name, output_type)
 
-        new_send.input.extend([new_send_input_name])
-        new_receive.output.extend([new_receive_output_name])
+            # the order of data flow is: node-output -> record -> send -> recv -> wait -> node-input
+            new_record.input.extend([n.output[0]])
+            new_record.output.extend([new_send_input_name])
 
-        new_wait.input.extend([new_receive_output_name])
-        new_wait.output.extend([new_wait_output_name])
+            new_send.input.extend([new_send_input_name])
+            new_receive.output.extend([new_receive_output_name])
 
-        for output_node in output_nodes:
-            for i in range(len(output_node.input)):
-                for edgeId in edgeIds:
-                    if output_node.input[i] == edgeId:
-                        output_node.input[i] = new_wait_output_name
+            new_wait.input.extend([new_receive_output_name])
+            new_wait.output.extend([new_wait_output_name])
 
-    return new_send, new_receive
+            for output_node in output_nodes:
+                for i in range(len(output_node.input)):
+                    for edgeId in edgeIds:
+                        if output_node.input[i] == edgeId:
+                            output_node.input[i] = new_wait_output_name
+
+        new_send_nodes.append(new_send)
+        new_recv_nodes.append(new_receive)
+
+    model = onnx.shape_inference.infer_shapes(model)
+
+    return new_send_nodes, new_recv_nodes
 
 def find_all_input_nodes(model, node):
     nodes = []
@@ -246,79 +255,91 @@ def get_output_index(model, output):
     return None
 
 # traverse the graph, group connected nodes and generate subgraph
-def generate_subgraph(model, start0, start1):
-    stack0 = [start0]
-    stack1 = [start1]
+def generate_subgraph(model, start_nodes):
+    subgraphs = []
 
-    visited0 = []
-    tranversed_node = 0
-    inputs0 = []
-    outputs0 = []
-    while stack0:
-        node = stack0.pop()
-        if not node in visited0:
-            tranversed_node += 1
-            visited0.append(node)
-            connected_nodes, inputs, outputs = find_all_connected_nodes(model, node)
+    main_graph = onnx.ModelProto()
+    main_graph.CopyFrom(model)
 
-            stack0 = stack0 + connected_nodes
-            inputs0 = inputs0 + inputs
-            outputs0 = outputs0 + outputs
+    all_visited_nodes = []
+    model_count = len(start_nodes)
+    for start in reversed(start_nodes):
+        stack0 = [start]
 
-    model0 = onnx.ModelProto()
-    model0.CopyFrom(model)
-    model1 = onnx.ModelProto()
-    model1.CopyFrom(model)
+        visited0 = []
+        tranversed_node = 0
+        inputs0 = []
+        outputs0 = []
+        while stack0:
+            node = stack0.pop()
+            if not node in visited0:
+                tranversed_node += 1
+                visited0.append(node)
+                all_visited_nodes.append(node)
+                connected_nodes, inputs, outputs = find_all_connected_nodes(main_graph, node)
 
-    # gather deleted nodes
-    delete_nodes = []
-    for n in visited0:
-        delete_nodes.append(get_node_index(model, n))
-    delete_nodes.sort(reverse=True)
+                stack0 = stack0 + connected_nodes
+                inputs0 = inputs0 + inputs
+                outputs0 = outputs0 + outputs
 
-    # gather deleted inputs
-    delete_inputs = []
-    for n in inputs0:
-        delete_inputs.append(get_input_index(model, n))
-    delete_inputs.sort(reverse=True)
+        subgraph = onnx.ModelProto()
+        subgraph.CopyFrom(main_graph)
 
-    # gather deleted outputs
-    delete_outputs = []
-    for n in outputs0:
-        delete_outputs.append(get_output_index(model, n))
-    delete_outputs.sort(reverse=True)
+        # gather visited nodes
+        visited_nodes = []
+        for n in visited0:
+            visited_nodes.append(get_node_index(main_graph, n))
+        visited_nodes.sort(reverse=True)
 
-    for i in reversed(range(len(model.graph.node))):
-        try:
-            if i in delete_nodes:
-                del model1.graph.node[i]
-            else:
-                del model0.graph.node[i]
-        except:
-            print("error deleting node", i)
+        # gather visited inputs
+        visited_inputs = []
+        for n in inputs0:
+            visited_inputs.append(get_input_index(main_graph, n))
+        visited_inputs.sort(reverse=True)
 
-    for i in reversed(range(len(model.graph.input))):
-        try:
-            if i in delete_inputs:
-                del model1.graph.input[i]
-            else:
-                del model0.graph.input[i]
-        except:
-            print("error deleting inputs", i)
+        # gather visited outputs
+        visited_outputs = []
+        for n in outputs0:
+            visited_outputs.append(get_output_index(main_graph, n))
+        visited_outputs.sort(reverse=True)
 
-    for i in reversed(range(len(model.graph.output))):
-        try:
-            if i in delete_outputs:
-                del model1.graph.output[i]
-            else:
-                del model0.graph.output[i]
-        except:
-            print("error deleting outputs ", i)
+        for i in reversed(range(len(main_graph.graph.node))):
+            try:
+                if i not in visited_nodes:
+                    del subgraph.graph.node[i]
+                else:
+                    del main_graph.graph.node[i]
+            except:
+                print("error deleting node", i)
 
-    print("model0 length ", len(model0.graph.node))
-    print("model1 length ", len(model1.graph.node))
+        for i in reversed(range(len(main_graph.graph.input))):
+            try:
+                if i not in visited_inputs:
+                    del subgraph.graph.input[i]
+                else:
+                    del main_graph.graph.input[i]
+            except:
+                print("error deleting inputs", i)
 
-    return model0, model1
+        for i in reversed(range(len(main_graph.graph.output))):
+            try:
+                if i not in visited_outputs:
+                    del subgraph.graph.output[i]
+                else:
+                    del main_graph.graph.output[i]
+            except:
+                print("error deleting outputs ", i)
+
+        print("model", str(model_count), " length ", len(subgraph.graph.node))
+        subgraphs.append(subgraph)
+        model_count -= 1
+
+    print("model", str(model_count), " length ", len(main_graph.graph.node))
+    subgraphs.append(main_graph)
+
+    # as the subgraphs were added in reverse order (the last split is added first), reverse the order back before return
+    subgraphs.reverse()
+    return subgraphs
 
 def write_model(model, file_name):
     f = open(file_name, "wb")
@@ -329,47 +350,56 @@ def main():
     # temporary hard coded the cutting edge structure
     # TODO: move this info to a file (json?) and load the data from there.
     input_model_name = 'bert-tiny-uncased_L_3_H_128_A_2_V_30528_S_512_Dp_0.1.onnx'
-    layer_output_edge = CutEdge('186')
-    mask_output_edge = CutEdge('71', {'273', '395'})
-    cut_input = {layer_output_edge, mask_output_edge}
+    stage_count = 3
+
+    cut0_input = {CutEdge('186'), CutEdge('71', {'273', '395'})}
+    cut1_input = {CutEdge('308'), CutEdge('71', {'395'})}
+    all_cut_inputs = [cut0_input, cut1_input]
 
     model = onnx.load(input_model_name)
     if len(model.graph.value_info) == 0:
         model = onnx.shape_inference.infer_shapes(model)
 
-    # TODO: support split more than 2 subgraphs
-    output_model_names = [input_model_name[:-5] + '_0.onnx', input_model_name[:-5] + '_1.onnx']
+    print("original model length ", len(model.graph.node))
 
-    split_edges = []
+    output_model_names = [input_model_name[:-5] + '_' + str(i) + '.onnx' for i in range(stage_count)]
+
+    split_edge_groups = []
     count = 0
+    updated_edges = {}
     need_shape_inference = False
     # Sweep the cut edge to see if there are edges feeding into nodes from two sub-graphs. If so,
     # insert identity node after those edges with a new ID to distinguish the rest.
-    for i in cut_input:
-        if i.consumingNodes:
-            new_edge_name = 'identity_output_' + str(count)
-            add_identity(model, i, new_edge_name)
-            count += 1
-            split_edges.append(new_edge_name)
-            need_shape_inference = True
-        else:
-            split_edges.append(i.edgeId)
+    for cut_input in all_cut_inputs:
+        split_edges = []
+        for i in cut_input:
+            if i.consumingNodes:
+                # if this edge has previously been modified, update its edgeId before inserting new identity
+                if i.edgeId in updated_edges:
+                    i.edgeId = updated_edges[i.edgeId]
+
+                new_edge_name = 'identity_output_' + str(count)
+                add_identity(model, i, new_edge_name)
+                count += 1
+                split_edges.append(new_edge_name)
+                updated_edges[i.edgeId] = new_edge_name
+                need_shape_inference = True
+            else:
+                split_edges.append(i.edgeId)
+        split_edge_groups.append(split_edges)
 
     # new edge is being added, need to re-inference shape
     if need_shape_inference:
         model = onnx.shape_inference.infer_shapes(model)
+
     # after all need-to-be-cut edges identified, split the graph
-    new_send, new_receive = split_graph(model, split_edges)
-    model0, model1 = generate_subgraph(model, new_send, new_receive)
+    new_sends, new_receives = split_graph(model, split_edge_groups)
+    sub_graphs = generate_subgraph(model, new_receives)
 
-    model0.opset_import[0].domain = "com.microsoft"
-    model0.opset_import[0].version = 1
 
-    model1.opset_import[0].domain = "com.microsoft"
-    model1.opset_import[0].version = 1
-
-    write_model(model0, output_model_names[0])
-    write_model(model1, output_model_names[1])
+    for i in range(stage_count):
+        sub_graphs[i] = onnx.shape_inference.infer_shapes(sub_graphs[i])
+        write_model(sub_graphs[i], output_model_names[i])
 
 if __name__ == "__main__":
     main()

--- a/orttraining/tools/scripts/pipeline_model_split.py
+++ b/orttraining/tools/scripts/pipeline_model_split.py
@@ -247,18 +247,8 @@ def find_all_connected_nodes(model, node):
     return connected_nodes, inputs, outputs
 
 
-def get_node_index(model, node):
-    found = [i for i, n in enumerate(model.graph.node) if n == node]
-    return found[0] if found else None
-
-
-def get_input_index(model, input):
-    found = [i for i, n in enumerate(model.graph.input) if n == input]
-    return found[0] if found else None
-
-
-def get_output_index(model, output):
-    found = [i for i, n in enumerate(model.graph.output) if n == output]
+def get_index(node_list, node):
+    found = [i for i, n in enumerate(node_list) if n == node]
     return found[0] if found else None
 
 # traverse the graph, group connected nodes and generate subgraph
@@ -298,19 +288,20 @@ def generate_subgraph(model, start_nodes):
         # gather visited nodes
         visited_nodes = []
         for n in visited0:
-            visited_nodes.append(get_node_index(main_graph, n))
+            visited_nodes.append(get_index(main_graph.graph.node, n))
         visited_nodes.sort(reverse=True)
 
         # gather visited inputs
         visited_inputs = []
         for n in inputs0:
-            visited_inputs.append(get_input_index(main_graph, n))
+            visited_inputs.append(get_index(main_graph.graph.input, n))
         visited_inputs.sort(reverse=True)
 
         # gather visited outputs
         visited_outputs = []
         for n in outputs0:
-            visited_outputs.append(get_output_index(main_graph, n))
+            visited_outputs.append(
+                get_index(main_graph.graph.output, n))
         visited_outputs.sort(reverse=True)
 
         for i in reversed(range(len(main_graph.graph.node))):
@@ -350,10 +341,6 @@ def generate_subgraph(model, start_nodes):
     # as the subgraphs were added in reverse order (the last split is added first), reverse the order back before return
     subgraphs.reverse()
     return subgraphs
-
-
-def write_model(model, file_name):
-    onnx.save(model, file_name)
 
 
 def main():
@@ -409,7 +396,7 @@ def main():
 
     for i in range(stage_count):
         sub_graphs[i] = onnx.shape_inference.infer_shapes(sub_graphs[i])
-        write_model(sub_graphs[i], output_model_names[i])
+        onnx.save(sub_graphs[i], output_model_names[i])
 
 
 if __name__ == "__main__":

--- a/orttraining/tools/scripts/pipeline_model_split.py
+++ b/orttraining/tools/scripts/pipeline_model_split.py
@@ -1,0 +1,320 @@
+import sys
+import onnx
+from onnx import helper
+from onnx import TensorProto
+from onnx import OperatorSetIdProto
+
+# Edge that needs to be cut for the split.
+# If the edge is feeding into more than one nodes, and not all the nodes belong to the same cut,
+# specify those consuming nodes that need to be cut
+class CutEdge:
+    def __init__(self, edgeId, consumingNodes=None):
+        self.edgeId = edgeId
+        self.consumingNodes = consumingNodes
+
+# Add wait/record/send/recv nodes and split the graph into disconnected subgraphs
+def split_graph(model, edgeIds):
+    upstream_nodes = []
+    for id in edgeIds:
+        for node in model.graph.node:
+            if len(node.output) >=1 and node.output[0] == id:
+                upstream_nodes.append(node)
+
+    record_signal = model.graph.input.add()
+    record_signal.CopyFrom(helper.make_tensor_value_info('record_signal', onnx.TensorProto.INT64, [1]))
+
+    wait_signal = model.graph.input.add()
+    wait_signal.CopyFrom(helper.make_tensor_value_info('wait_signal', onnx.TensorProto.INT64, [1]))
+
+    send_dst_rank = model.graph.input.add()
+    send_dst_rank.CopyFrom(helper.make_tensor_value_info('send_dst_rank', onnx.TensorProto.INT64, [1]))
+
+    recv_src_rank = model.graph.input.add()
+    recv_src_rank.CopyFrom(helper.make_tensor_value_info('recv_src_rank', onnx.TensorProto.INT64, [1]))
+
+    send_signal = model.graph.input.add()
+    send_signal.CopyFrom(helper.make_tensor_value_info('send_signal', onnx.TensorProto.BOOL, [1]))
+
+    recv_signal = model.graph.input.add()
+    recv_signal.CopyFrom(helper.make_tensor_value_info('recv_signal', onnx.TensorProto.BOOL, [1]))
+
+    ms_domain = 'com.microsoft'
+
+    new_send = model.graph.node.add()
+    new_send.CopyFrom(helper.make_node(
+        'Send',
+        inputs=['send_signal', 'send_dst_rank'],
+        outputs=[],
+        tag=0,
+        domain=ms_domain))
+
+    new_receive = model.graph.node.add()
+    new_receive.CopyFrom(helper.make_node(
+        'Recv',
+        inputs=['recv_signal', 'recv_src_rank'],
+        outputs=[],
+        tag=1,
+        domain=ms_domain))
+
+    new_wait = model.graph.node.add()
+    new_wait.CopyFrom(helper.make_node(
+        'WaitEvent',
+        inputs=['wait_signal'],
+        outputs=[],
+        domain=ms_domain))
+
+    new_record = model.graph.node.add()
+    new_record.CopyFrom(helper.make_node(
+        'RecordEvent',
+        inputs=['record_signal'],
+        outputs=[],
+        domain=ms_domain))
+
+    for i in range(len(upstream_nodes)):
+        n = upstream_nodes[i]
+
+        output_nodes = find_all_output_nodes_by_edge(model, n.output[0])
+
+        # new output from send after cut
+        send_output = model.graph.output.add()
+        send_output.name = n.output[0] + '_send_sync'
+
+        # new input from receive after cut
+        receive_input = model.graph.input.add()
+        receive_input.name =  n.output[0] + '_recv_sync'
+
+        new_send_input = n.output[0] + '_send'
+        new_receive_output = n.output[0] + '_recv'
+        new_wait_output = n.output[0] + '_wait'
+
+        # the order of data flow is: node-output -> record -> send -> recv -> wait -> node-input
+        new_record.input.extend([n.output[0]])
+        new_record.output.extend([new_send_input])
+
+        new_send.input.extend([new_send_input])
+        new_send.output.extend([send_output.name])
+
+        new_receive.input.extend([receive_input.name])
+        new_receive.output.extend([new_receive_output])
+
+        new_wait.input.extend([new_receive_output])
+        new_wait.output.extend([new_wait_output])
+
+        for output_node in output_nodes:
+            for i in range(len(output_node.input)):
+                for edgeId in edgeIds:
+                    if output_node.input[i] == edgeId:
+                        output_node.input[i] = new_wait_output
+
+    return new_send, new_receive
+
+def find_all_input_nodes(model, node):
+    nodes = []
+    inputs = []
+
+    if node:
+        for inputId in node.input:
+            for node in model.graph.node:
+                for output in node.output:
+                    if output == inputId:
+                        nodes.append(node)
+            for input in model.graph.input:
+                if input.name == inputId:
+                    inputs.append(input)
+    return nodes, inputs
+
+def find_all_output_nodes(model, node):
+    nodes = []
+    outputs = []
+    if node:
+        for outputId in node.output:
+            for node in model.graph.node:
+                for input in node.input:
+                    if input == outputId:
+                        nodes.append(node)
+            for output in model.graph.output:
+                if output.name == outputId:
+                    outputs.append(output)
+    return nodes, outputs
+
+def find_all_output_nodes_by_edge(model, arg):
+    result = []
+    for node in model.graph.node:
+        for input in node.input:
+            if input == arg:
+                result.append(node)
+    return result
+
+# Insert identity nodes to separate same output edge which feeds into different sub-graph.
+def add_identity(model, cuttingEdge, newEdgeIdName):
+    output_nodes = None
+    edgeId = cuttingEdge.edgeId
+    for node in model.graph.node:
+        if len(node.output) >=1 and node.output[0] == edgeId:
+            output_nodes = find_all_output_nodes_by_edge(model, node.output[0])
+            break
+
+    assert output_nodes, "no output node"
+
+    new_identity = model.graph.node.add()
+    new_identity.op_type = 'Identity'
+
+    new_identity.input.extend([edgeId])
+    new_identity.output.extend([newEdgeIdName])
+
+    for i in range(len(output_nodes)):
+        if output_nodes[i].output[0] in cuttingEdge.consumingNodes:
+            for j in range(len(output_nodes[i].input)):
+                if output_nodes[i].input[j] == edgeId:
+                    output_nodes[i].input[j] = newEdgeIdName
+
+    return newEdgeIdName
+
+def find_all_connected_nodes(model, node):
+    nodes0, inputs = find_all_input_nodes(model, node)
+    nodes1, outputs = find_all_output_nodes(model, node)
+
+    connected_nodes = nodes0 + nodes1
+    return connected_nodes, inputs, outputs
+
+def get_node_index(model, node):
+    for i in range(len(model.graph.node)):
+        if model.graph.node[i] == node:
+            return i
+    return None
+
+def get_input_index(model, input):
+    for i in range(len(model.graph.input)):
+        if model.graph.input[i] == input:
+            return i
+    return None
+
+def get_output_index(model, output):
+    for i in range(len(model.graph.output)):
+        if model.graph.output[i] == output:
+            return i
+    return None
+
+# traverse the graph, group connected nodes and generate subgraph
+def generate_subgraph(model, start0, start1):
+    stack0 = [start0]
+    stack1 = [start1]
+
+    visited0 = []
+    tranversed_node = 0
+    inputs0 = []
+    outputs0 = []
+    while stack0:
+        node = stack0.pop()
+        if not node in visited0:
+            tranversed_node += 1
+            visited0.append(node)
+            connected_nodes, inputs, outputs = find_all_connected_nodes(model, node)
+
+            stack0 = stack0 + connected_nodes
+            inputs0 = inputs0 + inputs
+            outputs0 = outputs0 + outputs
+
+    model0 = onnx.ModelProto()
+    model0.CopyFrom(model)
+    model1 = onnx.ModelProto()
+    model1.CopyFrom(model)
+
+    # gather deleted nodes
+    delete_nodes = []
+    for n in visited0:
+        delete_nodes.append(get_node_index(model, n))
+    delete_nodes.sort(reverse=True)
+
+    # gather deleted inputs
+    delete_inputs = []
+    for n in inputs0:
+        delete_inputs.append(get_input_index(model, n))
+    delete_inputs.sort(reverse=True)
+
+    # gather deleted outputs
+    delete_outputs = []
+    for n in outputs0:
+        delete_outputs.append(get_output_index(model, n))
+    delete_outputs.sort(reverse=True)
+
+    for i in reversed(range(len(model.graph.node))):
+        try:
+            if i in delete_nodes:
+                del model1.graph.node[i]
+            else:
+                del model0.graph.node[i]
+        except:
+            print("error deleting node", i)
+
+    for i in reversed(range(len(model.graph.input))):
+        try:
+            if i in delete_inputs:
+                del model1.graph.input[i]
+            else:
+                del model0.graph.input[i]
+        except:
+            print("error deleting inputs", i)
+
+    for i in reversed(range(len(model.graph.output))):
+        try:
+            if i in delete_outputs:
+                del model1.graph.output[i]
+            else:
+                del model0.graph.output[i]
+        except:
+            print("error deleting outputs ", i)
+
+    print("model0 length ", len(model0.graph.node))
+    print("model1 length ", len(model1.graph.node))
+
+    return model0, model1
+
+def write_model(model, file_name):
+    f = open(file_name, "wb")
+    f.write(model.SerializeToString())
+    f.close()
+
+def main():
+    # temporary hard coded the cutting edge structure
+    # TODO: move this info to a file (json?) and load the data from there.
+    input_model_name = 'bert-tiny-uncased_L_3_H_128_A_2_V_30528_S_512_Dp_0.1.onnx'
+    layer_output_edge = CutEdge('186')
+    mask_output_edge = CutEdge('71', {'273', '395'})
+    cut_input = {layer_output_edge, mask_output_edge}
+
+    model = onnx.load(input_model_name)
+    print("input model length: ", len(model.graph.node))
+
+    # TODO: support split more than 2 subgraphs
+    output_model_names = [input_model_name[:-5] + '_0.onnx', input_model_name[:-5] + '_1.onnx']
+
+    split_edges = []
+    count = 0
+    # Sweep the cut edge to see if there are edges feeding into nodes from two sub-graphs. If so,
+    # insert identity node after those edges with a new ID to distinguish the rest.
+    for i in cut_input:
+        if i.consumingNodes:
+            new_edge_name = 'identity_output_' + str(count)
+            add_identity(model, i, new_edge_name)
+            count += 1
+            split_edges.append(new_edge_name)
+        else:
+            split_edges.append(i.edgeId)
+
+    # after all need-to-be-cut edges identified, split the graph
+    new_send, new_receive = split_graph(model, split_edges)
+    model0, model1 = generate_subgraph(model, new_send, new_receive)
+
+    model0.opset_import[0].domain = "com.microsoft"
+    model0.opset_import[0].version = 1
+
+    model1.opset_import[0].domain = "com.microsoft"
+    model1.opset_import[0].version = 1
+
+    write_model(model0, output_model_names[0])
+    write_model(model1, output_model_names[1])
+
+if __name__ == "__main__":
+    main()
+

--- a/orttraining/tools/scripts/pipeline_model_split.py
+++ b/orttraining/tools/scripts/pipeline_model_split.py
@@ -15,28 +15,37 @@ class CutEdge:
 # Add wait/record/send/recv nodes and split the graph into disconnected subgraphs
 def split_graph(model, edgeIds):
     upstream_nodes = []
+    element_types = []
+
     for id in edgeIds:
         for node in model.graph.node:
             if len(node.output) >=1 and node.output[0] == id:
                 upstream_nodes.append(node)
+                element_types.append(1) # assuming all tensors are of type float
 
     record_signal = model.graph.input.add()
-    record_signal.CopyFrom(helper.make_tensor_value_info('record_signal', onnx.TensorProto.INT64, [1]))
+    record_signal.CopyFrom(helper.make_tensor_value_info(
+        'record_signal', onnx.TensorProto.INT64, None))
 
     wait_signal = model.graph.input.add()
-    wait_signal.CopyFrom(helper.make_tensor_value_info('wait_signal', onnx.TensorProto.INT64, [1]))
+    wait_signal.CopyFrom(helper.make_tensor_value_info(
+        'wait_signal', onnx.TensorProto.INT64, None))
 
     send_dst_rank = model.graph.input.add()
-    send_dst_rank.CopyFrom(helper.make_tensor_value_info('send_dst_rank', onnx.TensorProto.INT64, [1]))
+    send_dst_rank.CopyFrom(helper.make_tensor_value_info(
+        'send_dst_rank', onnx.TensorProto.INT64, None))
 
     recv_src_rank = model.graph.input.add()
-    recv_src_rank.CopyFrom(helper.make_tensor_value_info('recv_src_rank', onnx.TensorProto.INT64, [1]))
+    recv_src_rank.CopyFrom(helper.make_tensor_value_info(
+        'recv_src_rank', onnx.TensorProto.INT64, None))
 
     send_signal = model.graph.input.add()
-    send_signal.CopyFrom(helper.make_tensor_value_info('send_signal', onnx.TensorProto.BOOL, [1]))
+    send_signal.CopyFrom(helper.make_tensor_value_info(
+        'send_signal', onnx.TensorProto.BOOL, None))
 
     recv_signal = model.graph.input.add()
-    recv_signal.CopyFrom(helper.make_tensor_value_info('recv_signal', onnx.TensorProto.BOOL, [1]))
+    recv_signal.CopyFrom(helper.make_tensor_value_info(
+        'recv_signal', onnx.TensorProto.BOOL, None))
 
     ms_domain = 'com.microsoft'
 
@@ -46,7 +55,10 @@ def split_graph(model, edgeIds):
         inputs=['send_signal', 'send_dst_rank'],
         outputs=[],
         tag=0,
-        domain=ms_domain))
+        domain=ms_domain,
+        version=12,
+        element_types=element_types,
+        name='send'))
 
     new_receive = model.graph.node.add()
     new_receive.CopyFrom(helper.make_node(
@@ -54,7 +66,10 @@ def split_graph(model, edgeIds):
         inputs=['recv_signal', 'recv_src_rank'],
         outputs=[],
         tag=1,
-        domain=ms_domain))
+        domain=ms_domain,
+        version=12,
+        element_types=element_types,
+        name='receive'))
 
     new_wait = model.graph.node.add()
     new_wait.CopyFrom(helper.make_node(
@@ -77,11 +92,13 @@ def split_graph(model, edgeIds):
 
         # new output from send after cut
         send_output = model.graph.output.add()
-        send_output.name = n.output[0] + '_send_sync'
+        send_output.CopyFrom(helper.make_tensor_value_info(
+            n.output[0] + '_send_sync', onnx.TensorProto.FLOAT, None)) #TODO: how to infer the send tensor size?
 
         # new input from receive after cut
         receive_input = model.graph.input.add()
-        receive_input.name =  n.output[0] + '_recv_sync'
+        receive_input.CopyFrom(helper.make_tensor_value_info(
+            n.output[0] + '_recv_sync', onnx.TensorProto.FLOAT, None)) #TODO: how to infer the receive tensor size?
 
         new_send_input = n.output[0] + '_send'
         new_receive_output = n.output[0] + '_recv'


### PR DESCRIPTION
Add a script to split graph and insert corresponding send/recv/wait/record nodes.

Based on the cut edge information, it first idenfity if new identity nodes need to be added, then cut the edge, insert new nodes, and traverse the graph to group sub-graph nodes, and finally modify the 
graph and save it into split onnx files.

This is a very early version of the script, future work includes support multiple split, reading cut info from input files, add input wait/record etc.