### PR TITLE
Use yapf to format python

### DIFF
--- a/onnxruntime/.style.yapf
+++ b/onnxruntime/.style.yapf
@@ -1,0 +1,3 @@
+[style]
+based_on_style = google
+column_limit = 120

--- a/onnxruntime/ReformatSourcePython.bat
+++ b/onnxruntime/ReformatSourcePython.bat
@@ -1,4 +1,16 @@
 :: Copyright (c) Microsoft Corporation. All rights reserved.
 :: Licensed under the MIT License.
 
-autopep8 --in-place -r python
+:: Before running this, please make sure python.exe is in path, and yapf is installed like the following
+::    pip install --upgrade yapf
+
+:: If you use Visual Studio Code, you can configure like the following:
+::    "python.formatting.provider": "yapf"
+::    "python.formatting.yapfArgs": ["--style", "{based_on_style: google, column_limit: 120}"]
+:: See https://code.visualstudio.com/docs/python/editing for more info
+
+:: The style configuration file is .style.yapf in current directory.
+
+yapf -ir ./python
+
+if errorlevel 1 echo please install python, then pip install yapf

--- a/onnxruntime/ReformatSourcePython.bat
+++ b/onnxruntime/ReformatSourcePython.bat
@@ -11,6 +11,11 @@
 
 :: The style configuration file is .style.yapf in current directory.
 
+:: You can setup git pre-commit hook following https://github.com/google/yapf/tree/master/plugins.
+
+:: For more info about YAPF, see https://github.com/google/yapf
+
 yapf -ir ./python
+yapf -ir ./test
 
 if errorlevel 1 echo please install python, then pip install yapf

--- a/onnxruntime/python/backend/backend_rep.py
+++ b/onnxruntime/python/backend/backend_rep.py
@@ -22,7 +22,6 @@ class OnnxRuntimeBackendRep(BackendRep):
         """
         self._session = session
 
-
     def run(self, inputs, **kwargs):  # type: (Any, **Any) -> Tuple[Any, ...]
         """
         Computes the prediction.

--- a/onnxruntime/python/onnxruntime_validation.py
+++ b/onnxruntime/python/onnxruntime_validation.py
@@ -9,6 +9,7 @@ import platform
 import linecache
 import warnings
 
+
 def check_distro_info():
     __my_distro__ = ''
     __my_distro_ver__ = ''
@@ -22,7 +23,8 @@ def check_distro_info():
         __my_distro_ver__ = platform.release().lower()
 
         if __my_distro_ver__ != '10':
-            warnings.warn('Unsupported Windows version (%s). ONNX Runtime supports Windows 10 and above, only.' % __my_distro_ver__)
+            warnings.warn('Unsupported Windows version (%s). ONNX Runtime supports Windows 10 and above, only.' %
+                          __my_distro_ver__)
     elif __my_system__ == 'linux':
         ''' Although the 'platform' python module for getting Distro information works well on standard OS images running on real
         hardware, it is not acurate when running on Azure VMs, Git Bash, Cygwin, etc. The returned values for release and version
@@ -48,6 +50,8 @@ def check_distro_info():
         __my_distro_ver__ = platform.release().lower()
 
         if int(__my_distro_ver__.split('.')[0]) < 11:
-            warnings.warn('Unsupported macOS version (%s). ONNX Runtime supports macOS 11.0 or later.' % (__my_distro_ver__))
+            warnings.warn('Unsupported macOS version (%s). ONNX Runtime supports macOS 11.0 or later.' %
+                          (__my_distro_ver__))
     else:
-        warnings.warn('Unsupported platform (%s). ONNX Runtime supports Linux, macOS and Windows platforms, only.' % __my_system__)
+        warnings.warn('Unsupported platform (%s). ONNX Runtime supports Linux, macOS and Windows platforms, only.' %
+                      __my_system__)

--- a/onnxruntime/python/session.py
+++ b/onnxruntime/python/session.py
@@ -13,6 +13,7 @@ class InferenceSession:
     """
     This is the main class used to run a model.
     """
+
     def __init__(self, path_or_bytes, sess_options=None, providers=[]):
         """
         :param path_or_bytes: filename or serialized model in a byte string
@@ -26,22 +27,22 @@ class InferenceSession:
         self._enable_fallback = True
 
     def _load_model(self, providers=[]):
-        if isinstance(self._path_or_bytes, str): 
+        if isinstance(self._path_or_bytes, str):
             self._sess = C.InferenceSession(
-                self._sess_options if self._sess_options else C.get_default_session_options(), 
-                self._path_or_bytes, True)
+                self._sess_options if self._sess_options else C.get_default_session_options(), self._path_or_bytes,
+                True)
         elif isinstance(self._path_or_bytes, bytes):
             self._sess = C.InferenceSession(
-                self._sess_options if self._sess_options else C.get_default_session_options(), 
-                self._path_or_bytes, False)
+                self._sess_options if self._sess_options else C.get_default_session_options(), self._path_or_bytes,
+                False)
         # elif isinstance(self._path_or_bytes, tuple):
-            # to remove, hidden trick
+        # to remove, hidden trick
         #   self._sess.load_model_no_init(self._path_or_bytes[0], providers)
         else:
             raise TypeError("Unable to load from type '{0}'".format(type(self._path_or_bytes)))
 
         self._sess.load_model(providers)
-        
+
         self._session_options = self._sess.session_options
         self._inputs_meta = self._sess.inputs_meta
         self._outputs_meta = self._sess.outputs_meta
@@ -51,9 +52,9 @@ class InferenceSession:
 
         # Tensorrt can fall back to CUDA. All others fall back to CPU.
         if 'TensorrtExecutionProvider' in C.get_available_providers():
-          self._fallback_providers = ['CUDAExecutionProvider', 'CPUExecutionProvider']
+            self._fallback_providers = ['CUDAExecutionProvider', 'CPUExecutionProvider']
         else:
-          self._fallback_providers = ['CPUExecutionProvider']
+            self._fallback_providers = ['CPUExecutionProvider']
 
     def _reset_session(self):
         "release underlying session object."
@@ -100,7 +101,8 @@ class InferenceSession:
         execute a node using CUDAExecutionProvider if capable, otherwise execute using CPUExecutionProvider.
         """
         if not set(providers).issubset(C.get_available_providers()):
-            raise ValueError("{} does not contain a subset of available providers {}".format(providers, C.get_available_providers()))
+            raise ValueError("{} does not contain a subset of available providers {}".format(
+                providers, C.get_available_providers()))
         self._reset_session()
         self._load_model(providers)
 
@@ -150,7 +152,6 @@ class InferenceSession:
                 return self._sess.run(output_names, input_feed, run_options)
             else:
                 raise
-
 
     def end_profiling(self):
         """

--- a/onnxruntime/python/tools/bert/BertOnnxModel.py
+++ b/onnxruntime/python/tools/bert/BertOnnxModel.py
@@ -14,12 +14,14 @@ from OnnxModel import OnnxModel
 
 logger = logging.getLogger(__name__)
 
+
 class BertOnnxModel(OnnxModel):
+
     def __init__(self, model, num_heads, hidden_size, sequence_length, input_int32, float16, gpu_only):
         assert num_heads > 0
         assert hidden_size % num_heads == 0
         assert sequence_length > 0
-        
+
         super(BertOnnxModel, self).__init__(model)
         self.num_heads = num_heads
         self.sequence_length = sequence_length
@@ -52,7 +54,7 @@ class BertOnnxModel(OnnxModel):
 
     def undo_cast_input_to_int32(self, input_name):
         input_name_to_nodes = self.input_name_to_nodes()
-        nodes =  input_name_to_nodes[input_name]
+        nodes = input_name_to_nodes[input_name]
         for node in nodes:
             if node.op_type == "Cast":
                 is_int32 = False
@@ -77,12 +79,14 @@ class BertOnnxModel(OnnxModel):
         # Add a mask processing node
         output_name = self.create_node_name('mask_index')
         mask_index_node = onnx.helper.make_node('ReduceSum',
-            inputs=[input_name],
-            outputs=[output_name],
-            name=self.create_node_name('ReduceSum', 'MaskReduceSum'))
-        mask_index_node.attribute.extend([onnx.helper.make_attribute("axes", [1]), onnx.helper.make_attribute("keepdims", 0)])
+                                                inputs=[input_name],
+                                                outputs=[output_name],
+                                                name=self.create_node_name('ReduceSum', 'MaskReduceSum'))
+        mask_index_node.attribute.extend(
+            [onnx.helper.make_attribute("axes", [1]),
+             onnx.helper.make_attribute("keepdims", 0)])
         self.add_node(mask_index_node)
-        
+
         self.mask_indice[input] = output_name
         return output_name
 
@@ -104,7 +108,7 @@ class BertOnnxModel(OnnxModel):
         assert vw.shape == (self.hidden_size, self.hidden_size)
 
         qkv_weight = np.stack((qw, kw, vw), axis=-2)
-        
+
         qb = numpy_helper.to_array(q_bias)
         assert qb.shape == (self.hidden_size,)
 
@@ -119,18 +123,19 @@ class BertOnnxModel(OnnxModel):
         attention_node_name = self.create_node_name('Attention')
 
         weight = onnx.helper.make_tensor(name=attention_node_name + '_qkv_weight',
-            data_type=TensorProto.FLOAT,
-            dims=[self.hidden_size, 3 * self.hidden_size],
-            vals=qkv_weight.flatten().tolist())
+                                         data_type=TensorProto.FLOAT,
+                                         dims=[self.hidden_size, 3 * self.hidden_size],
+                                         vals=qkv_weight.flatten().tolist())
         self.add_initializer(weight)
 
-        weight_input = onnx.helper.make_tensor_value_info(weight.name, TensorProto.FLOAT, [self.hidden_size, 3 * self.hidden_size])
+        weight_input = onnx.helper.make_tensor_value_info(weight.name, TensorProto.FLOAT,
+                                                          [self.hidden_size, 3 * self.hidden_size])
         self.add_input(weight_input)
 
         bias = onnx.helper.make_tensor(name=attention_node_name + '_qkv_bias',
-            data_type=TensorProto.FLOAT,
-            dims=[3 * self.hidden_size],
-            vals=qkv_bias.flatten().tolist())
+                                       data_type=TensorProto.FLOAT,
+                                       dims=[3 * self.hidden_size],
+                                       vals=qkv_bias.flatten().tolist())
         self.add_initializer(bias)
 
         bias_input = onnx.helper.make_tensor_value_info(bias.name, TensorProto.FLOAT, [3 * self.hidden_size])
@@ -168,7 +173,9 @@ class BertOnnxModel(OnnxModel):
                 children = input_name_to_nodes[input]
                 children_types = sorted([child.op_type for child in children])
                 if children_types != self.normalize_children_types():
-                    qkv_nodes = self.match_parent_path(normalize_node, ['Add', 'MatMul', 'Reshape', 'Transpose', 'MatMul'], [i, 0, 0, 0, 0])
+                    qkv_nodes = self.match_parent_path(normalize_node,
+                                                       ['Add', 'MatMul', 'Reshape', 'Transpose', 'MatMul'],
+                                                       [i, 0, 0, 0, 0])
                 else:
                     root_input = input
 
@@ -199,7 +206,8 @@ class BertOnnxModel(OnnxModel):
 
             k_nodes = self.match_parent_path(matmul_qk, ['Transpose', 'Reshape', 'Add', 'MatMul'], [1, 0, 0, 0])
             if k_nodes is None:
-                k_nodes = self.match_parent_path(matmul_qk, ['Transpose', 'Transpose', 'Reshape', 'Add', 'MatMul'], [1, 0, 0, 0, 0])
+                k_nodes = self.match_parent_path(matmul_qk, ['Transpose', 'Transpose', 'Reshape', 'Add', 'MatMul'],
+                                                 [1, 0, 0, 0, 0])
                 if k_nodes is None:
                     logger.debug("fuse_attention: failed to match k path")
                     continue
@@ -207,7 +215,8 @@ class BertOnnxModel(OnnxModel):
             else:
                 (transpose_k, reshape_k, add_k, matmul_k) = k_nodes
 
-            mask_nodes = self.match_parent_path(add_qk, ['Mul', 'Sub', 'Cast', 'Unsqueeze', 'Unsqueeze'], [1, 0, 1, 0, 0])
+            mask_nodes = self.match_parent_path(add_qk, ['Mul', 'Sub', 'Cast', 'Unsqueeze', 'Unsqueeze'],
+                                                [1, 0, 1, 0, 0])
             if mask_nodes is None:
                 logger.debug("fuse_attention: failed to match mask path")
                 continue
@@ -215,7 +224,8 @@ class BertOnnxModel(OnnxModel):
 
             if matmul_v.input[0] == root_input and matmul_q.input[0] == root_input and matmul_v.input[0] == root_input:
                 mask_index = self.process_mask(unsqueeze_mask_0.input[0])
-                self.create_attention_node(mask_index, matmul_q, matmul_k, matmul_v, add_q, add_k, add_v, root_input, reshape_qkv.output[0])
+                self.create_attention_node(mask_index, matmul_q, matmul_k, matmul_v, add_q, add_k, add_v, root_input,
+                                           reshape_qkv.output[0])
                 nodes_to_remove.extend([reshape_qkv, transpose_qkv, matmul_qkv])
                 nodes_to_remove.extend(qk_nodes)
                 nodes_to_remove.extend(q_nodes)
@@ -250,6 +260,7 @@ class BertOnnxModel(OnnxModel):
 
      Note that constant input for Add and Mul could be first or second input: like either A=0.5 or B=0.5 is fine.
     """
+
     def fuse_gelu_with_elf(self, gelu_op_name):
         logger.debug(f"start fuse_gelu_with_elf({gelu_op_name})")
         input_name_to_nodes = self.input_name_to_nodes()
@@ -288,7 +299,7 @@ class BertOnnxModel(OnnxModel):
             subgraph_input = div.input[0]
 
             another = 1 if mul_after_erf.input[0] == add_after_erf.output[0] else 0
-            if subgraph_input == mul_after_erf.input[another]: # pattern 2
+            if subgraph_input == mul_after_erf.input[another]:  # pattern 2
                 children = input_name_to_nodes[mul_after_erf.output[0]]
                 if len(children) != 1 or children[0].op_type != 'Mul':
                     continue
@@ -296,11 +307,11 @@ class BertOnnxModel(OnnxModel):
                 if not self.has_constant_input(mul_half, 0.5):
                     continue
                 subgraph_output = mul_half.output[0]
-            else: # pattern 1
+            else:  # pattern 1
                 mul_half = self.match_parent(mul_after_erf, 'Mul', another, output_name_to_node)
                 if mul_half is None:
                     continue
-            
+
                 if not self.has_constant_input(mul_half, 0.5):
                     continue
 
@@ -310,20 +321,20 @@ class BertOnnxModel(OnnxModel):
                 subgraph_output = mul_after_erf.output[0]
 
             subgraph_nodes = [div, erf_node, add_after_erf, mul_after_erf, mul_half]
-            if not self.is_safe_to_fuse_nodes(subgraph_nodes, [subgraph_output], input_name_to_nodes, output_name_to_node):
+            if not self.is_safe_to_fuse_nodes(subgraph_nodes, [subgraph_output], input_name_to_nodes,
+                                              output_name_to_node):
                 continue
 
             nodes_to_remove.extend(subgraph_nodes)
-            gelu_node = onnx.helper.make_node(gelu_op_name,
-                inputs=[subgraph_input],
-                outputs=[subgraph_output])
+            gelu_node = onnx.helper.make_node(gelu_op_name, inputs=[subgraph_input], outputs=[subgraph_output])
             gelu_node.domain = "com.microsoft"
             nodes_to_add.append(gelu_node)
 
         self.remove_nodes(nodes_to_remove)
         self.add_nodes(nodes_to_add)
         if len(nodes_to_add) > 0:
-            logger.info("Fused {} count:{}".format('FastGelu (approximation)' if gelu_op_name == 'FastGelu' else 'Gelu', len(nodes_to_add)))
+            logger.info("Fused {} count:{}".format('FastGelu (approximation)' if gelu_op_name == 'FastGelu' else 'Gelu',
+                                                   len(nodes_to_add)))
 
     """
      Fuse Gelu with tanh into one node:
@@ -336,6 +347,7 @@ class BertOnnxModel(OnnxModel):
           +------> Mul(B=0.5)--------------------------------------------+
      Note that constant input for Add and Mul could be first or second input: like either A=0.5 or B=0.5 is fine.
     """
+
     def fuse_gelu_with_tanh(self, gelu_op_name):
         input_name_to_nodes = self.input_name_to_nodes()
         output_name_to_node = self.output_name_to_node()
@@ -405,20 +417,25 @@ class BertOnnxModel(OnnxModel):
             if pow.input[0] != root_node.output[0]:
                 continue
 
-            subgraph_nodes = [mul_after_tanh, mul_half, add_after_tanh, tanh_node, mul_before_tanh, add_before_tanh, mul_after_pow, pow]
-            if not self.is_safe_to_fuse_nodes(subgraph_nodes, [mul_after_tanh.output[0]], input_name_to_nodes, output_name_to_node):
+            subgraph_nodes = [
+                mul_after_tanh, mul_half, add_after_tanh, tanh_node, mul_before_tanh, add_before_tanh, mul_after_pow,
+                pow
+            ]
+            if not self.is_safe_to_fuse_nodes(subgraph_nodes, [mul_after_tanh.output[0]], input_name_to_nodes,
+                                              output_name_to_node):
                 continue
 
             nodes_to_remove.extend(subgraph_nodes)
             gelu_node = onnx.helper.make_node(gelu_op_name,
-                inputs=[root_node.output[0]],
-                outputs=mul_after_tanh.output,
-                name=self.create_node_name(gelu_op_name))
+                                              inputs=[root_node.output[0]],
+                                              outputs=mul_after_tanh.output,
+                                              name=self.create_node_name(gelu_op_name))
             gelu_node.domain = "com.microsoft"
             nodes_to_add.append(gelu_node)
 
         if len(nodes_to_add) > 0:
-            logger.info("Fused {} count: {}".format('Gelu (FastGelu fits better)' if gelu_op_name == 'Gelu' else 'FastGelu', len(nodes_to_add)))
+            logger.info("Fused {} count: {}".format(
+                'Gelu (FastGelu fits better)' if gelu_op_name == 'Gelu' else 'FastGelu', len(nodes_to_add)))
 
         self.remove_nodes(nodes_to_remove)
         self.add_nodes(nodes_to_add)
@@ -454,14 +471,15 @@ class BertOnnxModel(OnnxModel):
                 continue
 
             subgraph_nodes = [node, add]
-            if not self.is_safe_to_fuse_nodes(subgraph_nodes, [node.output[0]], input_name_to_nodes, output_name_to_node):
+            if not self.is_safe_to_fuse_nodes(subgraph_nodes, [node.output[0]], input_name_to_nodes,
+                                              output_name_to_node):
                 continue
 
             nodes_to_remove.extend(subgraph_nodes)
             gelu_node = onnx.helper.make_node('FastGelu',
-                inputs=[matmul.output[0], add.input[bias_index]],
-                outputs=node.output,
-                name=self.create_node_name('FastGelu', "FastGelu_AddBias_"))
+                                              inputs=[matmul.output[0], add.input[bias_index]],
+                                              outputs=node.output,
+                                              name=self.create_node_name('FastGelu', "FastGelu_AddBias_"))
             gelu_node.domain = "com.microsoft"
             nodes_to_add.append(gelu_node)
 
@@ -510,15 +528,20 @@ class BertOnnxModel(OnnxModel):
                 continue
 
             subgraph_nodes = [node, add]
-            if not self.is_safe_to_fuse_nodes(subgraph_nodes, [node.output[0]], input_name_to_nodes, output_name_to_node):
+            if not self.is_safe_to_fuse_nodes(subgraph_nodes, [node.output[0]], input_name_to_nodes,
+                                              output_name_to_node):
                 logger.debug(f"Skip fusing SkipLayerNormalization with Bias since it is not safe")
                 continue
 
             nodes_to_remove.extend(subgraph_nodes)
             new_node = onnx.helper.make_node("SkipLayerNormalization",
-                inputs=[node.input[1 - add_input_index], matmul.output[0], node.input[2], node.input[3], add.input[bias_index]],
-                outputs=node.output,
-                name=self.create_node_name("SkipLayerNormalization", "SkipLayerNorm_AddBias_"))
+                                             inputs=[
+                                                 node.input[1 - add_input_index], matmul.output[0], node.input[2],
+                                                 node.input[3], add.input[bias_index]
+                                             ],
+                                             outputs=node.output,
+                                             name=self.create_node_name("SkipLayerNormalization",
+                                                                        "SkipLayerNorm_AddBias_"))
             new_node.domain = "com.microsoft"
             nodes_to_add.append(new_node)
 
@@ -543,12 +566,14 @@ class BertOnnxModel(OnnxModel):
             if concat_node.op_type != 'Concat' or len(concat_node.input) < 3 or len(concat_node.input) > 4:
                 continue
 
-            path0 = self.match_parent_path(concat_node, ['Unsqueeze', 'Gather', 'Shape'], [0, 0, 0], output_name_to_node)
+            path0 = self.match_parent_path(concat_node, ['Unsqueeze', 'Gather', 'Shape'], [0, 0, 0],
+                                           output_name_to_node)
             if path0 is None:
                 continue
             (unsqueeze_0, gather_0, shape_0) = path0
 
-            path1 = self.match_parent_path(concat_node, ['Unsqueeze', 'Gather', 'Shape'], [1, 0, 0], output_name_to_node)
+            path1 = self.match_parent_path(concat_node, ['Unsqueeze', 'Gather', 'Shape'], [1, 0, 0],
+                                           output_name_to_node)
             if path1 is None:
                 continue
             (unsqueeze_1, gather_1, shape_1) = path1
@@ -569,8 +594,10 @@ class BertOnnxModel(OnnxModel):
             path3 = []
             shape_nodes = [shape_0, shape_1]
             if len(concat_node.input) == 3 and self.get_initializer(concat_node.input[2]) is None:
-                path2 = self.match_parent_path(concat_node, ['Unsqueeze', 'Mul', 'Gather', 'Shape'], [2, 0, 0, 0], output_name_to_node)
-                path3 = self.match_parent_path(concat_node, ['Unsqueeze', 'Mul', 'Gather', 'Shape'], [2, 0, 1, 0], output_name_to_node)
+                path2 = self.match_parent_path(concat_node, ['Unsqueeze', 'Mul', 'Gather', 'Shape'], [2, 0, 0, 0],
+                                               output_name_to_node)
+                path3 = self.match_parent_path(concat_node, ['Unsqueeze', 'Mul', 'Gather', 'Shape'], [2, 0, 1, 0],
+                                               output_name_to_node)
                 if path2 is None or path3 is None:
                     continue
                 shape_nodes.extend([path2[-1], path3[-1]])
@@ -586,7 +613,8 @@ class BertOnnxModel(OnnxModel):
                     shape.append(concat_value)
 
             if len(concat_node.input) == 4 and self.get_initializer(concat_node.input[3]) is None:
-                path2 = self.match_parent_path(concat_node, ['Unsqueeze', 'Div', 'Gather', 'Shape'], [3, 0, 0, 0], output_name_to_node)
+                path2 = self.match_parent_path(concat_node, ['Unsqueeze', 'Div', 'Gather', 'Shape'], [3, 0, 0, 0],
+                                               output_name_to_node)
                 shape_nodes.extend([path2[-1]])
                 if path2 is None or -1 in shape:
                     continue
@@ -615,12 +643,12 @@ class BertOnnxModel(OnnxModel):
 
             constant_shape_name = self.create_node_name('Constant', 'constant_shape')
             new_node = onnx.helper.make_node('Constant',
-                inputs=[],
-                outputs=[constant_shape_name],
-                value=onnx.helper.make_tensor(name='const_tensor',
-                    data_type=TensorProto.INT64,
-                    dims=shape_value.shape,
-                    vals=shape_value))
+                                             inputs=[],
+                                             outputs=[constant_shape_name],
+                                             value=onnx.helper.make_tensor(name='const_tensor',
+                                                                           data_type=TensorProto.INT64,
+                                                                           dims=shape_value.shape,
+                                                                           vals=shape_value))
             reshape_node.input[1] = constant_shape_name
             reshape_node.name = self.create_node_name('Reshape', 'Reshape_Fuse')
             nodes_to_remove.extend([concat_node])
@@ -657,6 +685,7 @@ class BertOnnxModel(OnnxModel):
                                   v            v
                               SkipLayerNormalization
     """
+
     def fuse_embed_layer(self):
         nodes = self.nodes()
         input_name_to_nodes = self.input_name_to_nodes()
@@ -704,7 +733,8 @@ class BertOnnxModel(OnnxModel):
         if position_embedding_path is None:
             position_embedding_path = self.match_parent_path(add_node, ['Gather', 'Expand', 'Shape'], [1, 1, 1])
             if position_embedding_path is None:
-                position_embedding_path = self.match_parent_path(add_node, ['Gather', 'Expand', 'Concat', 'Unsqueeze', 'Gather', 'Shape'], [1, 1, 1, 1, 0, 0])
+                position_embedding_path = self.match_parent_path(
+                    add_node, ['Gather', 'Expand', 'Concat', 'Unsqueeze', 'Gather', 'Shape'], [1, 1, 1, 1, 0, 0])
                 if position_embedding_path is None:
                     logger.info("Failed to find position embedding")
                     return
@@ -730,11 +760,10 @@ class BertOnnxModel(OnnxModel):
 
         segment_ids = segment_embedding_gather.input[1]
 
-
         if position_embedding_expand:
             subgraph_nodes = self.get_parent_subgraph_nodes(position_embedding_expand, [], output_name_to_node)
             nodes_to_remove.extend(subgraph_nodes)
-        
+
         nodes_to_remove.extend(word_embedding_path)
         nodes_to_remove.extend(position_embedding_path)
         nodes_to_remove.extend(segment_embedding_path)
@@ -757,20 +786,23 @@ class BertOnnxModel(OnnxModel):
         else:
             self.undo_cast_input_to_int32(mask_input_name)
 
-        embed_node = onnx.helper.make_node('EmbedLayerNormalization',
-                        inputs=[input_ids,
-                                segment_ids, 
-                                word_embedding_gather.input[0],
-                                position_embedding_weight_node.input[0],
-                                segment_embedding_gather.input[0],
-                                normalize_node.input[2],
-                                normalize_node.input[3], # gamma and beta
-                                mask_input_name],
-                        outputs=["embed_output", mask_output_name],
-                        name="EmbedLayer")
+        embed_node = onnx.helper.make_node(
+            'EmbedLayerNormalization',
+            inputs=[
+                input_ids,
+                segment_ids,
+                word_embedding_gather.input[0],
+                position_embedding_weight_node.input[0],
+                segment_embedding_gather.input[0],
+                normalize_node.input[2],
+                normalize_node.input[3],  # gamma and beta
+                mask_input_name
+            ],
+            outputs=["embed_output", mask_output_name],
+            name="EmbedLayer")
 
         embed_node.domain = "com.microsoft"
-        
+
         self.replace_input_of_all_nodes(normalize_node.output[0], 'embed_output')
 
         self.remove_nodes(nodes_to_remove)
@@ -796,7 +828,7 @@ class BertOnnxModel(OnnxModel):
                         if (d.HasField("dim_value")):
                             return d.dim_value
                         elif (d.HasField("dim_param")):
-                            return str(d.dim_param)       # unknown dimension with symbolic name
+                            return str(d.dim_param)  # unknown dimension with symbolic name
                         return None
         return None
 
@@ -811,7 +843,8 @@ class BertOnnxModel(OnnxModel):
         bert_inputs = self.get_bert_inputs()
         for input in graph.input:
             if input.name in bert_inputs:
-                int32_input = onnx.helper.make_tensor_value_info(input.name, TensorProto.INT32, [input_batch_size, self.sequence_length])
+                int32_input = onnx.helper.make_tensor_value_info(input.name, TensorProto.INT32,
+                                                                 [input_batch_size, self.sequence_length])
                 new_graph_inputs.append(int32_input)
             else:
                 new_graph_inputs.append(input)
@@ -830,7 +863,6 @@ class BertOnnxModel(OnnxModel):
 
         # restore opset version
         self.model.opset_import[0].version = original_opset_version
-
 
     def use_dynamic_axes(self, dynamic_batch_dim='batch_size', dynamic_seq_len='max_seq_len'):
         """
@@ -905,7 +937,8 @@ class BertOnnxModel(OnnxModel):
                 if div_node is None:
                     continue
 
-                parent_nodes = self.match_parent_path(div_node, ['Sqrt', 'Add', 'ReduceMean', 'Pow', 'Sub'], [1, 0, 0, 0, 0], output_name_to_node)
+                parent_nodes = self.match_parent_path(div_node, ['Sqrt', 'Add', 'ReduceMean', 'Pow', 'Sub'],
+                                                      [1, 0, 0, 0, 0], output_name_to_node)
                 if parent_nodes is None:
                     continue
 
@@ -930,8 +963,10 @@ class BertOnnxModel(OnnxModel):
 
                 subgraph_nodes = [node]
                 subgraph_nodes.extend(children)
-                subgraph_nodes.extend([last_add_node, mul_node, div_node, sqrt_node, second_add_node, reduce_mean_node, pow_node])
-                if not self.is_safe_to_fuse_nodes(subgraph_nodes, last_add_node.output, input_name_to_nodes, output_name_to_node):
+                subgraph_nodes.extend(
+                    [last_add_node, mul_node, div_node, sqrt_node, second_add_node, reduce_mean_node, pow_node])
+                if not self.is_safe_to_fuse_nodes(subgraph_nodes, last_add_node.output, input_name_to_nodes,
+                                                  output_name_to_node):
                     continue
 
                 nodes_to_remove.extend(subgraph_nodes)
@@ -939,8 +974,8 @@ class BertOnnxModel(OnnxModel):
                 weight_input = mul_node.input[1 - self.input_index(div_node.output[0], mul_node)]
                 bias_input = last_add_node.input[1 - self.input_index(mul_node.output[0], last_add_node)]
                 normalize_node = onnx.helper.make_node('LayerNormalization',
-                    inputs=[node.input[0], weight_input, bias_input],
-                    outputs=[last_add_node.output[0]])
+                                                       inputs=[node.input[0], weight_input, bias_input],
+                                                       outputs=[last_add_node.output[0]])
                 normalize_node.attribute.extend([onnx.helper.make_attribute("epsilon", float(add_weight))])
                 layernorm_nodes.extend([normalize_node])
 
@@ -963,9 +998,11 @@ class BertOnnxModel(OnnxModel):
                 if add is None:
                     continue
 
-                if add.op_type == 'Add' and self.is_safe_to_fuse_nodes([add, node], node.output, input_name_to_nodes, output_name_to_node):
+                if add.op_type == 'Add' and self.is_safe_to_fuse_nodes([add, node], node.output, input_name_to_nodes,
+                                                                       output_name_to_node):
                     nodes_to_remove.extend([add, node])
-                    normalize_node = onnx.helper.make_node("SkipLayerNormalization",
+                    normalize_node = onnx.helper.make_node(
+                        "SkipLayerNormalization",
                         inputs=[add.input[0], add.input[1], node.input[1], node.input[2]],
                         outputs=[node.output[0]],
                         name=self.create_node_name("SkipLayerNormalization", name_prefix="SkipLayerNorm"))
@@ -1021,7 +1058,10 @@ class BertOnnxModel(OnnxModel):
         Returns node count of fused operators.
         """
         op_count = {}
-        ops = ['EmbedLayerNormalization', 'Attention', 'Gelu', 'FastGelu', 'BiasGelu', 'LayerNormalization', 'SkipLayerNormalization']
+        ops = [
+            'EmbedLayerNormalization', 'Attention', 'Gelu', 'FastGelu', 'BiasGelu', 'LayerNormalization',
+            'SkipLayerNormalization'
+        ]
         for op in ops:
             nodes = self.get_nodes_by_op_type(op)
             op_count[op] = len(nodes)
@@ -1037,5 +1077,7 @@ class BertOnnxModel(OnnxModel):
         gelu = op_count['Gelu'] + op_count['BiasGelu'] + op_count['FastGelu']
         layer_norm = op_count['LayerNormalization'] + op_count['SkipLayerNormalization']
         is_optimized = (embed > 0) and (attention > 0) and (attention == gelu) and (layer_norm >= 2 * attention)
-        logger.info(f"EmbedLayer={embed}, Attention={attention}, Gelu={gelu}, LayerNormalization={layer_norm}, Succesful={is_optimized}")
+        logger.info(
+            f"EmbedLayer={embed}, Attention={attention}, Gelu={gelu}, LayerNormalization={layer_norm}, Succesful={is_optimized}"
+        )
         return is_optimized

--- a/onnxruntime/python/tools/bert/BertOnnxModelKeras.py
+++ b/onnxruntime/python/tools/bert/BertOnnxModelKeras.py
@@ -14,32 +14,30 @@ from BertOnnxModelTF import BertOnnxModelTF
 
 logger = logging.getLogger(__name__)
 
+
 class BertOnnxModelKeras(BertOnnxModelTF):
+
     def __init(self, model, num_heads, hidden_size, sequence_length, input_int32, float16, gpu_only):
         super().__init__(model, model, num_heads, hidden_size, sequence_length, input_int32, float16, gpu_only)
 
     def match_mask_path(self, add_or_sub_before_softmax):
-        mask_nodes = self.match_parent_path(add_or_sub_before_softmax,
-                                     ['Mul', 'Sub', 'Reshape', 'Cast'],
-                                     [ 1,     None,  1,         0])
+        mask_nodes = self.match_parent_path(add_or_sub_before_softmax, ['Mul', 'Sub', 'Reshape', 'Cast'],
+                                            [1, None, 1, 0])
         if mask_nodes is not None:
             return mask_nodes
 
-        mask_nodes = self.match_parent_path(add_or_sub_before_softmax,
-                                         ['Mul', 'Sub', 'Cast', 'Slice', 'Unsqueeze'],
-                                         [ 1,     1,     1,      0,       0])
+        mask_nodes = self.match_parent_path(add_or_sub_before_softmax, ['Mul', 'Sub', 'Cast', 'Slice', 'Unsqueeze'],
+                                            [1, 1, 1, 0, 0])
         if mask_nodes is not None:
             return mask_nodes
 
-
-        mask_nodes = self.match_parent_path(add_or_sub_before_softmax,
-                                     ['Mul', 'Sub', 'Cast', 'Unsqueeze', 'Unsqueeze'],
-                                     [ 1,     None,  1,      0,           0])
+        mask_nodes = self.match_parent_path(add_or_sub_before_softmax, ['Mul', 'Sub', 'Cast', 'Unsqueeze', 'Unsqueeze'],
+                                            [1, None, 1, 0, 0])
         return mask_nodes
 
     def check_attention_input(self, matmul_q, matmul_k, matmul_v, parent, output_name_to_node):
         reshape_nodes = []
-        
+
         for x in [matmul_q, matmul_k, matmul_v]:
             root_input = x.input[0]
             root_node = output_name_to_node[root_input]
@@ -68,10 +66,12 @@ class BertOnnxModelKeras(BertOnnxModelTF):
                 if parent.op_type == 'Add':
                     parent = self.get_parent(normalize_node, 1)
                     if parent is None or parent.op_type not in ["SkipLayerNormalization", "EmbedLayerNormalization"]:
-                        logger.debug("First input for skiplayernorm: {}".format(parent.op_type if parent is not None else None))
+                        logger.debug(
+                            "First input for skiplayernorm: {}".format(parent.op_type if parent is not None else None))
                         continue
                 else:
-                    logger.debug("First input for skiplayernorm: {}".format(parent.op_type if parent is not None else None))
+                    logger.debug(
+                        "First input for skiplayernorm: {}".format(parent.op_type if parent is not None else None))
                     continue
             else:
                 # TODO: shall we add back the checking of children op types.
@@ -79,16 +79,15 @@ class BertOnnxModelKeras(BertOnnxModelTF):
 
             qkv_nodes = self.match_parent_path(normalize_node,
                                                ['Add', 'Reshape', 'MatMul', 'Reshape', 'Transpose', 'MatMul'],
-                                               [ None,     0,         0,        0,         0,           0])
+                                               [None, 0, 0, 0, 0, 0])
             if qkv_nodes is None:
                 logger.debug("Failed to match qkv nodes")
                 continue
             (add, extra_reshape_0, matmul, reshape_qkv, transpose_qkv, matmul_qkv) = qkv_nodes
             logger.debug("Matched qkv nodes")
 
-            v_nodes = self.match_parent_path(matmul_qkv,
-                                             ['Transpose', 'Reshape', 'Add', 'Reshape', 'MatMul'],
-                                             [ 1,           0,         0,     0,         0])
+            v_nodes = self.match_parent_path(matmul_qkv, ['Transpose', 'Reshape', 'Add', 'Reshape', 'MatMul'],
+                                             [1, 0, 0, 0, 0])
             if v_nodes is None:
                 logger.debug("Failed to match v path")
                 continue
@@ -97,12 +96,11 @@ class BertOnnxModelKeras(BertOnnxModelTF):
             qk_nodes = self.match_parent_path(matmul_qkv, ['Softmax', 'Sub', 'MatMul'], [0, 0, 0])
             if qk_nodes is not None:
                 (softmax_qk, sub_qk, matmul_qk) = qk_nodes
-                q_nodes = self.match_parent_path(matmul_qk,
-                                             ['Mul', 'Transpose', 'Reshape', 'Add', 'Reshape', 'MatMul'],
-                                             [ 0,     None,           0,         0,     0,         0])
-                if q_nodes is not None:                             
+                q_nodes = self.match_parent_path(matmul_qk, ['Mul', 'Transpose', 'Reshape', 'Add', 'Reshape', 'MatMul'],
+                                                 [0, None, 0, 0, 0, 0])
+                if q_nodes is not None:
                     (mul_q, transpose_q, reshape_q, add_q, extra_reshape_2, matmul_q) = q_nodes
-                                             
+
             else:
                 qk_nodes = self.match_parent_path(matmul_qkv, ['Softmax', 'Add', 'Mul', 'MatMul'], [0, 0, 0, None])
                 if qk_nodes is None:
@@ -112,9 +110,8 @@ class BertOnnxModelKeras(BertOnnxModelTF):
                         continue
                 (softmax_qk, add_qk, mul_qk, matmul_qk) = qk_nodes
 
-                q_nodes = self.match_parent_path(matmul_qk,
-                                                 ['Transpose', 'Reshape', 'Add', 'Reshape', 'MatMul'],
-                                                 [ 0,           0,         0,     0,         0])
+                q_nodes = self.match_parent_path(matmul_qk, ['Transpose', 'Reshape', 'Add', 'Reshape', 'MatMul'],
+                                                 [0, 0, 0, 0, 0])
                 if q_nodes is not None:
                     (transpose_q, reshape_q, add_q, extra_reshape_2, matmul_q) = q_nodes
 
@@ -122,14 +119,12 @@ class BertOnnxModelKeras(BertOnnxModelTF):
                 logger.debug("Failed to match q path")
                 continue
 
-            k_nodes = self.match_parent_path(matmul_qk,
-                                             ['Transpose', 'Reshape', 'Add', 'Reshape', 'MatMul'],
-                                             [ 1,           0,         0,     0,         0])
+            k_nodes = self.match_parent_path(matmul_qk, ['Transpose', 'Reshape', 'Add', 'Reshape', 'MatMul'],
+                                             [1, 0, 0, 0, 0])
             if k_nodes is None:
                 logger.debug("Failed to match k path")
                 continue
             (transpose_k, reshape_k, add_k, extra_reshape_3, matmul_k) = k_nodes
-
 
             mask_nodes = self.match_mask_path(qk_nodes[1])
             if mask_nodes is None:
@@ -138,12 +133,14 @@ class BertOnnxModelKeras(BertOnnxModelTF):
             if not self.has_constant_input(mask_nodes[1], 1):
                 logger.debug("Sub node expected to have an input with constant value 1.0.")
                 continue
-      
-            is_same_root, reshape_nodes = self.check_attention_input(matmul_q, matmul_k, matmul_v, parent, output_name_to_node)
+
+            is_same_root, reshape_nodes = self.check_attention_input(matmul_q, matmul_k, matmul_v, parent,
+                                                                     output_name_to_node)
             if is_same_root:
                 mask_index = self.process_mask(mask_nodes[-1].input[0])
                 logger.debug("Create an Attention node.")
-                self.create_attention_node(mask_index, matmul_q, matmul_k, matmul_v, add_q, add_k, add_v, parent.output[0], reshape_qkv.output[0])
+                self.create_attention_node(mask_index, matmul_q, matmul_k, matmul_v, add_q, add_k, add_v,
+                                           parent.output[0], reshape_qkv.output[0])
                 nodes_to_remove.extend([reshape_qkv, transpose_qkv, matmul_qkv])
                 nodes_to_remove.extend(qk_nodes)
                 nodes_to_remove.extend(q_nodes)
@@ -187,11 +184,7 @@ class BertOnnxModelKeras(BertOnnxModelTF):
     def fuse_embedding(self, node, output_name_to_node):
         assert node.op_type == 'LayerNormalization'
         logger.debug(f"start fusing embedding from node with output={node.output[0]}...")
-        word_embed_path = self.match_parent_path(
-            node,
-            ['Add', 'Add', 'Gather'],
-            [ 0,     0,     0],
-            output_name_to_node)
+        word_embed_path = self.match_parent_path(node, ['Add', 'Add', 'Gather'], [0, 0, 0], output_name_to_node)
         if word_embed_path is None:
             logger.debug("failed to match word_embed_path")
             return False
@@ -202,7 +195,7 @@ class BertOnnxModelKeras(BertOnnxModelTF):
         if word_initializer is None:
             logger.debug("failed to get word initializer")
             return False
-            
+
         temp = numpy_helper.to_array(word_initializer)
         if len(temp.shape) == 2:
             logger.info("Found word embedding. name:{}, shape:{}".format(word_initializer.name, temp.shape))
@@ -211,28 +204,24 @@ class BertOnnxModelKeras(BertOnnxModelTF):
             logger.info("Failed to find word embedding. name:{}, shape:{}".format(word_initializer.name, temp.shape))
             return False
 
-
         pos_initializer = self.get_initializer(add_node.input[1])
         if pos_initializer is not None:
             temp = numpy_helper.to_array(pos_initializer)
             if len(temp.shape) == 3 and temp.shape[0] == 1:
-                tensor = numpy_helper.from_array(temp.reshape((temp.shape[1],temp.shape[2])), "position_embedding")
+                tensor = numpy_helper.from_array(temp.reshape((temp.shape[1], temp.shape[2])), "position_embedding")
                 self.add_initializer(tensor)
                 logger.info("Found position embedding. name:{}, shape:{}".format(pos_initializer.name, temp.shape[1:]))
                 position_embedding = "position_embedding"
             else:
-                logger.info("Failed to find position embedding. name:{}, shape:{}".format(pos_initializer.name, temp.shape))
+                logger.info("Failed to find position embedding. name:{}, shape:{}".format(
+                    pos_initializer.name, temp.shape))
                 return False
         else:
-            pos_embed_path = self.match_parent_path(
-                add_node,
-                ['Gather', 'Slice'],
-                [1, 1],
-                output_name_to_node)
+            pos_embed_path = self.match_parent_path(add_node, ['Gather', 'Slice'], [1, 1], output_name_to_node)
             if pos_embed_path is None:
                 logger.debug("failed to match pos_embed_path")
                 return False
-                
+
             pos_gather, pos_slice = pos_embed_path
             pos_initializer = self.get_initializer(pos_gather.input[0])
             if pos_initializer is None:
@@ -244,7 +233,8 @@ class BertOnnxModelKeras(BertOnnxModelTF):
                 logger.info("Found word embedding. name:{}, shape:{}".format(pos_initializer.name, temp.shape))
                 position_embedding = pos_initializer.name
             else:
-                logger.info("Failed to find position embedding. name:{}, shape:{}".format(pos_initializer.name, temp.shape))
+                logger.info("Failed to find position embedding. name:{}, shape:{}".format(
+                    pos_initializer.name, temp.shape))
                 return False
 
         gather = self.get_parent(skip_node, 1, output_name_to_node)
@@ -256,15 +246,16 @@ class BertOnnxModelKeras(BertOnnxModelTF):
         if segment_initializer is None:
             logger.debug("failed to get segment initializer")
             return False
-            
+
         temp = numpy_helper.to_array(segment_initializer)
         if len(temp.shape) == 2:
             logger.info("Found segment embedding. name:{}, shape:{}".format(segment_initializer.name, temp.shape))
             segment_embedding = segment_initializer.name
         else:
-            logger.info("Failed to find segment embedding. name:{}, shape:{}".format(segment_initializer.name, temp.shape))
+            logger.info("Failed to find segment embedding. name:{}, shape:{}".format(
+                segment_initializer.name, temp.shape))
             return False
-        
+
         logger.info("Create Embedding node")
         self.create_embedding_subgraph(node, word_embedding, segment_embedding, position_embedding)
         return True
@@ -285,10 +276,7 @@ class BertOnnxModelKeras(BertOnnxModelTF):
         nodes_to_remove = []
         for node in self.nodes():
             if node.op_type == 'Mul' and self.has_constant_input(node, -10000):
-                mask_path = self.match_parent_path(
-                    node,
-                    ['Sub', 'Cast', 'Slice', 'Unsqueeze'],
-                    [  0,    1,     0,        0])
+                mask_path = self.match_parent_path(node, ['Sub', 'Cast', 'Slice', 'Unsqueeze'], [0, 1, 0, 0])
                 if mask_path is None:
                     continue
                 sub_node, cast_node, slice_node, unsqueeze_node = mask_path
@@ -298,25 +286,22 @@ class BertOnnxModelKeras(BertOnnxModelTF):
                     print("Cast input {} is not mask input{}".format(unsqueeze_node.input[0], mask_input_name))
                     continue
 
-                unsqueeze_added_1 = onnx.helper.make_node(
-                    'Unsqueeze',
-                    inputs=[mask_input_name],
-                    outputs=['mask_fuse_unsqueeze1_output'],
-                    name='Mask_UnSqueeze_1',
-                    axes=[1])
+                unsqueeze_added_1 = onnx.helper.make_node('Unsqueeze',
+                                                          inputs=[mask_input_name],
+                                                          outputs=['mask_fuse_unsqueeze1_output'],
+                                                          name='Mask_UnSqueeze_1',
+                                                          axes=[1])
 
-                unsqueeze_added_2 = onnx.helper.make_node(
-                    'Unsqueeze',
-                    inputs=['mask_fuse_unsqueeze1_output'],
-                    outputs=['mask_fuse_unsqueeze2_output'],
-                    name='Mask_UnSqueeze_2',
-                    axes=[2])
+                unsqueeze_added_2 = onnx.helper.make_node('Unsqueeze',
+                                                          inputs=['mask_fuse_unsqueeze1_output'],
+                                                          outputs=['mask_fuse_unsqueeze2_output'],
+                                                          name='Mask_UnSqueeze_2',
+                                                          axes=[2])
 
                 #self.replace_node_input(cast_node, cast_node.input[0], 'mask_fuse_unsqueeze2_output')
-                cast_node_2 = onnx.helper.make_node(
-                    'Cast',
-                    inputs=['mask_fuse_unsqueeze2_output'],
-                    outputs=['mask_fuse_cast_output'])
+                cast_node_2 = onnx.helper.make_node('Cast',
+                                                    inputs=['mask_fuse_unsqueeze2_output'],
+                                                    outputs=['mask_fuse_cast_output'])
                 cast_node_2.attribute.extend([onnx.helper.make_attribute("to", 1)])
                 self.replace_node_input(sub_node, sub_node.input[1], 'mask_fuse_cast_output')
 
@@ -332,15 +317,15 @@ class BertOnnxModelKeras(BertOnnxModelTF):
             self.prune_graph()
 
         logger.info("Fused mask" if len(nodes_to_remove) > 0 else "Failed to fuse mask")
-        
+
     def remove_extra_reshape(self):
         skiplayernorm_nodes = self.get_nodes_by_op_type("SkipLayerNormalization")
         reshape_removed = 0
         for skiplayernorm_node in skiplayernorm_nodes:
             path = self.match_parent_path(
-                        skiplayernorm_node,
-                        ['Add', 'Reshape', 'MatMul', 'Reshape', 'Gelu', 'Add', 'Reshape', 'MatMul', 'SkipLayerNormalization'],
-                        [ 0,     0,         0,        0,         0,      0,     0,         0,        0])
+                skiplayernorm_node,
+                ['Add', 'Reshape', 'MatMul', 'Reshape', 'Gelu', 'Add', 'Reshape', 'MatMul', 'SkipLayerNormalization'],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0])
             if path is None:
                 continue
 
@@ -359,27 +344,27 @@ class BertOnnxModelKeras(BertOnnxModelTF):
         skiplayernorm_nodes = self.get_nodes_by_op_type("SkipLayerNormalization")
         reshape_removed = 0
         for skiplayernorm_node in skiplayernorm_nodes:
-            path = self.match_parent_path(
-                        skiplayernorm_node,
-                        ['Add', 'Reshape', 'MatMul', 'Reshape', 'Gelu', 'Add', 'Reshape', 'MatMul', 'Reshape', 'SkipLayerNormalization'],
-                        [ None,     0,         0,        0,         0,      0,     0,         0,        0,         0])
+            path = self.match_parent_path(skiplayernorm_node, [
+                'Add', 'Reshape', 'MatMul', 'Reshape', 'Gelu', 'Add', 'Reshape', 'MatMul', 'Reshape',
+                'SkipLayerNormalization'
+            ], [None, 0, 0, 0, 0, 0, 0, 0, 0, 0])
             if path is None:
                 continue
 
             add_1, reshape_1, matmul_1, reshape_2, gelu, add_2, reshape_3, matmul_2, reshape_4, skiplayernorm = path
-            
+
             matmul_2.input[0] = skiplayernorm.output[0]
             self.remove_node(reshape_4)
-            
+
             add_2.input[0] = matmul_2.output[0]
             self.remove_node(reshape_3)
-            
+
             matmul_1.input[0] = gelu.output[0]
             self.remove_node(reshape_2)
-            
+
             add_1.input[0] = matmul_1.output[0]
             self.remove_node(reshape_1)
-            
+
             reshape_removed += 4
 
         return reshape_removed
@@ -400,6 +385,7 @@ class BertOnnxModelKeras(BertOnnxModelTF):
 
      Note that constant input for Add and Mul could be first or second input: like either A=0.5 or B=0.5 is fine.
     """
+
     def fuse_gelu_with_elf(self, gelu_op_name):
         input_name_to_nodes = self.input_name_to_nodes()
         output_name_to_node = self.output_name_to_node()
@@ -460,19 +446,19 @@ class BertOnnxModelKeras(BertOnnxModelTF):
             if sqrt_node:
                 subgraph_nodes.append(sqrt_node)
 
-            if not self.is_safe_to_fuse_nodes(subgraph_nodes, [mul.output[0]], input_name_to_nodes, output_name_to_node):
+            if not self.is_safe_to_fuse_nodes(subgraph_nodes, [mul.output[0]], input_name_to_nodes,
+                                              output_name_to_node):
                 continue
 
             nodes_to_remove.extend(subgraph_nodes)
-            gelu_node = onnx.helper.make_node(gelu_op_name,
-                inputs=[root_node.output[0]],
-                outputs=[mul.output[0]])
+            gelu_node = onnx.helper.make_node(gelu_op_name, inputs=[root_node.output[0]], outputs=[mul.output[0]])
             gelu_node.domain = "com.microsoft"
             nodes_to_add.append(gelu_node)
 
         self.remove_nodes(nodes_to_remove)
         self.add_nodes(nodes_to_add)
         if len(nodes_to_add) > 0:
-            logger.info("Fused {} count:{}".format('FastGelu (approximation)' if gelu_op_name == 'FastGelu' else 'Gelu', len(nodes_to_add)))
+            logger.info("Fused {} count:{}".format('FastGelu (approximation)' if gelu_op_name == 'FastGelu' else 'Gelu',
+                                                   len(nodes_to_add)))
         else:
             super().fuse_gelu_with_elf(gelu_op_name)

--- a/onnxruntime/python/tools/bert/BertOnnxModelKeras.py
+++ b/onnxruntime/python/tools/bert/BertOnnxModelKeras.py
@@ -344,10 +344,10 @@ class BertOnnxModelKeras(BertOnnxModelTF):
         skiplayernorm_nodes = self.get_nodes_by_op_type("SkipLayerNormalization")
         reshape_removed = 0
         for skiplayernorm_node in skiplayernorm_nodes:
-            path = self.match_parent_path(skiplayernorm_node, [
-                'Add', 'Reshape', 'MatMul', 'Reshape', 'Gelu', 'Add', 'Reshape', 'MatMul', 'Reshape',
-                'SkipLayerNormalization'
-            ], [None, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+            path = self.match_parent_path(
+                skiplayernorm_node,
+                ['Add', 'Reshape', 'MatMul', 'Reshape', 'Gelu', 'Add', 'Reshape', 'MatMul', 'Reshape', 'SkipLayerNormalization']
+                [None, 0, 0, 0, 0, 0, 0, 0, 0, 0]) # yapf: disable
             if path is None:
                 continue
 

--- a/onnxruntime/python/tools/bert/MachineInfo.py
+++ b/onnxruntime/python/tools/bert/MachineInfo.py
@@ -20,13 +20,12 @@ from py3nvml.py3nvml import nvmlInit, nvmlSystemGetDriverVersion, nvmlDeviceGetC
 
 class MachineInfo():
     """ Class encapsulating Machine Info logic. """
+
     def __init__(self, silent=False, logger=None):
         self.silent = silent
 
         if logger is None:
-            logging.basicConfig(
-                format="%(asctime)s - %(name)s - %(levelname)s: %(message)s",
-                level=logging.INFO)
+            logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s: %(message)s", level=logging.INFO)
             self.logger = logging.getLogger(__name__)
         else:
             self.logger = logger
@@ -91,8 +90,7 @@ class MachineInfo():
             nvmlShutdown()
         except NVMLError as error:
             if not self.silent:
-                self.logger.error(
-                    "Error fetching GPU information using nvml: %s", error)
+                self.logger.error("Error fetching GPU information using nvml: %s", error)
             return None
 
         result = {"driver_version": driver_version, "devices": gpu_info_list}
@@ -105,11 +103,8 @@ class MachineInfo():
         try:
             import onnxruntime
             return {
-                "version":
-                onnxruntime.__version__,
-                "support_gpu":
-                'CUDAExecutionProvider' in
-                onnxruntime.get_available_providers()
+                "version": onnxruntime.__version__,
+                "support_gpu": 'CUDAExecutionProvider' in onnxruntime.get_available_providers()
             }
         except ImportError as error:
             if not self.silent:
@@ -123,10 +118,7 @@ class MachineInfo():
     def get_pytorch_info(self) -> Dict:
         try:
             import torch
-            return {
-                "version": torch.__version__,
-                "support_gpu": torch.cuda.is_available()
-            }
+            return {"version": torch.__version__, "support_gpu": torch.cuda.is_available()}
         except ImportError as error:
             if not self.silent:
                 self.logger.exception(error)
@@ -157,10 +149,7 @@ class MachineInfo():
 def parse_arguments():
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--silent',
-                        required=False,
-                        action='store_true',
-                        help="Do not print error message")
+    parser.add_argument('--silent', required=False, action='store_true', help="Do not print error message")
     parser.set_defaults(silent=False)
 
     args = parser.parse_args()

--- a/onnxruntime/python/tools/bert/OnnxModel.py
+++ b/onnxruntime/python/tools/bert/OnnxModel.py
@@ -13,7 +13,9 @@ from onnx import ModelProto, TensorProto, numpy_helper
 
 logger = logging.getLogger(__name__)
 
+
 class OnnxModel:
+
     def __init__(self, model):
         self.model = model
         self.node_name_counter = {}
@@ -32,7 +34,7 @@ class OnnxModel:
         output_name_to_node = {}
         for node in self.model.graph.node:
             for output_name in node.output:
-                    output_name_to_node[output_name] = node
+                output_name_to_node[output_name] = node
         return output_name_to_node
 
     def nodes(self):
@@ -57,7 +59,7 @@ class OnnxModel:
 
     def add_initializer(self, tensor):
         self.model.graph.initializer.extend([tensor])
- 
+
     def add_input(self, input):
         self.model.graph.input.extend([input])
 
@@ -95,7 +97,7 @@ class OnnxModel:
     def get_children(self, node, input_name_to_nodes=None):
         if (input_name_to_nodes is None):
             input_name_to_nodes = self.input_name_to_nodes()
-            
+
         children = []
         for output in node.output:
             if output in input_name_to_nodes:
@@ -149,7 +151,13 @@ class OnnxModel:
                     logger.debug(f"To find first {parent_op_type}, current {parent.op_type}")
         return None, None
 
-    def match_parent(self, node, parent_op_type, input_index=None, output_name_to_node=None, exclude=[], return_indice=None):
+    def match_parent(self,
+                     node,
+                     parent_op_type,
+                     input_index=None,
+                     output_name_to_node=None,
+                     exclude=[],
+                     return_indice=None):
         '''
         Find parent node based on constraints on op_type and index.
         When input_index is None, we will find the first parent node based on constraints, and return_indice will be appended the corresponding input index.
@@ -190,7 +198,12 @@ class OnnxModel:
 
         return None
 
-    def match_parent_path(self, node, parent_op_types, parent_input_index, output_name_to_node=None, return_indice=None):
+    def match_parent_path(self,
+                          node,
+                          parent_op_types,
+                          parent_input_index,
+                          output_name_to_node=None,
+                          return_indice=None):
         '''
         Find a sequence of input edges based on constraints on parent op_type and index.
         When input_index is None, we will find the first parent node based on constraints, and return_indice will be appended the corresponding input index.
@@ -205,7 +218,7 @@ class OnnxModel:
         Returns:
             parents: a list of matched parent node.
         '''
-        assert(len(parent_input_index) == len(parent_op_types))
+        assert (len(parent_input_index) == len(parent_op_types))
 
         if output_name_to_node is None:
             output_name_to_node = self.output_name_to_node()
@@ -213,7 +226,12 @@ class OnnxModel:
         current_node = node
         matched_parents = []
         for i, op_type in enumerate(parent_op_types):
-            matched_parent = self.match_parent(current_node, op_type, parent_input_index[i], output_name_to_node, exclude=[], return_indice=return_indice)
+            matched_parent = self.match_parent(current_node,
+                                               op_type,
+                                               parent_input_index[i],
+                                               output_name_to_node,
+                                               exclude=[],
+                                               return_indice=return_indice)
             if matched_parent is None:
                 logger.debug(f"Failed to match index={i} parent_input_index={parent_input_index[i]} op_type={op_type}")
                 return None
@@ -241,7 +259,7 @@ class OnnxModel:
     def find_first_parent_by_type(self, node, parent_type, output_name_to_node=None, recursive=True):
         if output_name_to_node is None:
             output_name_to_node = self.output_name_to_node()
-            
+
         parents = self.get_parents(node, output_name_to_node)
         dq = deque(parents)
         while len(dq) > 0:
@@ -320,13 +338,16 @@ class OnnxModel:
 
         for initializer in initializers:
             if initializer.data_type == 1:
-                initializer.CopyFrom(numpy_helper.from_array(numpy_helper.to_array(initializer).astype(np.float16), initializer.name))
+                initializer.CopyFrom(
+                    numpy_helper.from_array(numpy_helper.to_array(initializer).astype(np.float16), initializer.name))
 
         for node in graph.node:
             if node.op_type == 'Constant':
                 for att in node.attribute:
                     if att.name == 'value' and att.t.data_type == 1:
-                        att.CopyFrom(onnx.helper.make_attribute("value", numpy_helper.from_array(numpy_helper.to_array(att.t).astype(np.float16))))
+                        att.CopyFrom(
+                            onnx.helper.make_attribute(
+                                "value", numpy_helper.from_array(numpy_helper.to_array(att.t).astype(np.float16))))
             if node.op_type == 'Cast':
                 for att in node.attribute:
                     if att.name == 'to' and att.i == 1:
@@ -335,7 +356,7 @@ class OnnxModel:
         for input_value_info in graph.input:
             if input_value_info.type.tensor_type.elem_type == TensorProto.FLOAT:
                 initializer = self.get_initializer(input_value_info.name)
-                if initializer is not None: # for compatibility for old converter/exporter
+                if initializer is not None:  # for compatibility for old converter/exporter
                     input_value_info.type.tensor_type.elem_type = 10
                 else:
                     cast_input = input_value_info.name
@@ -362,7 +383,7 @@ class OnnxModel:
             self.node_name_counter[op_type] = 1
 
         if name_prefix is not None:
-            full_name = name_prefix + str(self.node_name_counter[op_type]) 
+            full_name = name_prefix + str(self.node_name_counter[op_type])
         else:
             full_name = op_type + "_" + str(self.node_name_counter[op_type])
 
@@ -479,7 +500,7 @@ class OnnxModel:
         self.remove_nodes(nodes_to_remove)
 
         # remove outputs not in list
-        output_to_remove=[]
+        output_to_remove = []
         for output in self.model.graph.output:
             if output.name not in outputs:
                 output_to_remove.append(output)
@@ -488,14 +509,15 @@ class OnnxModel:
 
         # remove inputs not used by any node.
         input_name_to_nodes = self.input_name_to_nodes()
-        input_to_remove=[]
+        input_to_remove = []
         for input in self.model.graph.input:
             if input.name not in input_name_to_nodes:
                 input_to_remove.append(input)
         for input in input_to_remove:
             self.model.graph.input.remove(input)
 
-        logger.info("Graph pruned: {} inputs, {} outputs and {} nodes are removed".format(len(input_to_remove), len(output_to_remove), len(nodes_to_remove)))
+        logger.info("Graph pruned: {} inputs, {} outputs and {} nodes are removed".format(
+            len(input_to_remove), len(output_to_remove), len(nodes_to_remove)))
 
         self.update_graph()
 
@@ -509,7 +531,7 @@ class OnnxModel:
                     if input_name not in remaining_input_names:
                         remaining_input_names.append(input_name)
         if verbose:
-            logger.debug(f"remaining input names: {remaining_input_names}" )
+            logger.debug(f"remaining input names: {remaining_input_names}")
 
         # remove graph input that is not used
         inputs_to_remove = []
@@ -521,7 +543,7 @@ class OnnxModel:
 
         names_to_remove = [input.name for input in inputs_to_remove]
         logger.debug(f"remove {len(inputs_to_remove)} unused inputs: {names_to_remove}")
-        
+
         # remove weights that are not used
         weights_to_remove = []
         weights_to_keep = []
@@ -549,7 +571,9 @@ class OnnxModel:
                 if output_to_remove in input_name_to_nodes:
                     for impacted_node in input_name_to_nodes[output_to_remove]:
                         if impacted_node not in nodes_to_remove:
-                            logger.debug(f"it is not safe to remove nodes since output {output_to_remove} is used by {impacted_node}")
+                            logger.debug(
+                                f"it is not safe to remove nodes since output {output_to_remove} is used by {impacted_node}"
+                            )
                             return False
         return True
 

--- a/onnxruntime/python/tools/bert/bert_model_optimization.py
+++ b/onnxruntime/python/tools/bert/bert_model_optimization.py
@@ -39,10 +39,11 @@ logger = logging.getLogger('')
 
 # Map model type to tuple: optimizer class, export tools (pytorch, tf2onnx, keras2onnx) and whether OnnxRuntime has the optimization.
 MODEL_CLASSES = {
-    "bert" : (BertOnnxModel, "pytorch", True),
+    "bert": (BertOnnxModel, "pytorch", True),
     "bert_tf": (BertOnnxModelTF, "tf2onnx", False),
-    "bert_keras" : (BertOnnxModelKeras, "keras2onnx", False)
+    "bert_keras": (BertOnnxModelKeras, "keras2onnx", False)
 }
+
 
 def optimize_by_onnxruntime(onnx_model_path, use_gpu, optimized_model_path=None):
     """
@@ -64,7 +65,7 @@ def optimize_by_onnxruntime(onnx_model_path, use_gpu, optimized_model_path=None)
     sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_EXTENDED
 
     if optimized_model_path is None:
-        path_prefix = onnx_model_path[:-5]   #remove .onnx suffix
+        path_prefix = onnx_model_path[:-5]  #remove .onnx suffix
         optimized_model_path = "{}_ort_{}.onnx".format(path_prefix, "gpu" if use_gpu else "cpu")
 
     sess_options.optimized_model_filepath = optimized_model_path
@@ -73,42 +74,56 @@ def optimize_by_onnxruntime(onnx_model_path, use_gpu, optimized_model_path=None)
         session = onnxruntime.InferenceSession(onnx_model_path, sess_options, providers=['CPUExecutionProvider'])
     else:
         session = onnxruntime.InferenceSession(onnx_model_path, sess_options)
-        assert 'CUDAExecutionProvider' in session.get_providers() # Make sure there is GPU
+        assert 'CUDAExecutionProvider' in session.get_providers()  # Make sure there is GPU
 
     assert os.path.exists(optimized_model_path) and os.path.isfile(optimized_model_path)
     logger.info("Save optimized model by onnxruntime to {}".format(optimized_model_path))
     return optimized_model_path
 
+
 def parse_arguments():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--input', required=True, type=str,
-                        help="input onnx model path")
+    parser.add_argument('--input', required=True, type=str, help="input onnx model path")
 
-    parser.add_argument('--output', required=True, type=str,
-                        help="optimized onnx model path")
+    parser.add_argument('--output', required=True, type=str, help="optimized onnx model path")
 
-    parser.add_argument('--model_type', required=False, type=str.lower, default="bert",
+    parser.add_argument('--model_type',
+                        required=False,
+                        type=str.lower,
+                        default="bert",
                         choices=list(MODEL_CLASSES.keys()),
                         help="Model type selected in the list: " + ", ".join(MODEL_CLASSES.keys()))
 
-    parser.add_argument('--num_heads', required=False, type=int, default=12,
+    parser.add_argument('--num_heads',
+                        required=False,
+                        type=int,
+                        default=12,
                         help="number of attention heads. 12 for bert-base model and 16 for bert-large")
 
-    parser.add_argument('--hidden_size', required=False, type=int, default=768,
+    parser.add_argument('--hidden_size',
+                        required=False,
+                        type=int,
+                        default=768,
                         help="bert model hidden size. 768 for bert-base model and 1024 for bert-large")
 
-    parser.add_argument('--sequence_length', required=False, type=int, default=128,
-                        help="max sequence length")
+    parser.add_argument('--sequence_length', required=False, type=int, default=128, help="max sequence length")
 
-    parser.add_argument('--input_int32', required=False, action='store_true',
-                         help="Use int32 (instead of int64) tensor as input to avoid unnecessary data cast")
+    parser.add_argument('--input_int32',
+                        required=False,
+                        action='store_true',
+                        help="Use int32 (instead of int64) tensor as input to avoid unnecessary data cast")
     parser.set_defaults(input_int32=False)
 
-    parser.add_argument('--float16', required=False, action='store_true',
-                        help="If your target device is V100 or T4 GPU, use this to convert float32 to float16 for best performance")
+    parser.add_argument(
+        '--float16',
+        required=False,
+        action='store_true',
+        help="If your target device is V100 or T4 GPU, use this to convert float32 to float16 for best performance")
     parser.set_defaults(float16=False)
 
-    parser.add_argument('--gpu_only', required=False, action='store_true',
+    parser.add_argument('--gpu_only',
+                        required=False,
+                        action='store_true',
                         help="whether the target device is gpu or not")
     parser.set_defaults(gpu_only=False)
 
@@ -118,6 +133,7 @@ def parse_arguments():
     args = parser.parse_args()
 
     return args
+
 
 def optimize_model(input, model_type, gpu_only, num_heads, hidden_size, sequence_length, input_int32, float16):
     (optimizer_class, producer, run_onnxruntime) = MODEL_CLASSES[model_type]
@@ -132,12 +148,15 @@ def optimize_model(input, model_type, gpu_only, num_heads, hidden_size, sequence
         model.ParseFromString(f.read())
 
     if model.producer_name and producer != model.producer_name:
-        logger.warning(f"Model producer not matched: Expect {producer},  Got {model.producer_name} {model.producer_version}. Please specify correct --model_type parameter.")
+        logger.warning(
+            f"Model producer not matched: Expect {producer},  Got {model.producer_name} {model.producer_version}. Please specify correct --model_type parameter."
+        )
 
     bert_model = optimizer_class(model, num_heads, hidden_size, sequence_length, input_int32, float16, gpu_only)
     bert_model.optimize()
 
     return bert_model
+
 
 def main():
     args = parse_arguments()
@@ -158,7 +177,8 @@ def main():
 
     logger.setLevel(logging_level)
 
-    bert_model = optimize_model(args.input, args.model_type, args.gpu_only, args.num_heads, args.hidden_size, args.sequence_length, args.input_int32, args.float16)
+    bert_model = optimize_model(args.input, args.model_type, args.gpu_only, args.num_heads, args.hidden_size,
+                                args.sequence_length, args.input_int32, args.float16)
 
     bert_model.save_model_to_file(args.output)
 
@@ -166,6 +186,7 @@ def main():
         logger.info("The output model is fully optimized.")
     else:
         logger.warning("The output model is not fully optimized. It might not be usable.")
+
 
 if __name__ == "__main__":
     main()

--- a/onnxruntime/python/tools/bert/bert_perf_test.py
+++ b/onnxruntime/python/tools/bert/bert_perf_test.py
@@ -26,20 +26,24 @@ from datetime import datetime
 import multiprocessing
 from bert_test_data import get_bert_inputs, generate_test_data
 
+
 def create_session(model_path, use_gpu, intra_op_num_threads, graph_optimization_level=None):
     # Import onnxruntime shall be after OpenMP environment variable setting.
     # So we put the import in function to delay importing instead of top of this script.
     import onnxruntime
 
     if use_gpu and ('CUDAExecutionProvider' not in onnxruntime.get_available_providers()):
-        print("Warning: Please install onnxruntime-gpu package instead of onnxruntime, and use a machine with GPU for testing gpu performance.")
+        print(
+            "Warning: Please install onnxruntime-gpu package instead of onnxruntime, and use a machine with GPU for testing gpu performance."
+        )
     elif (not use_gpu) and ('CUDAExecutionProvider' in onnxruntime.get_available_providers()):
         print("Warning: Please install onnxruntime package instead of onnxruntime-gpu to get best cpu performance.")
 
     if intra_op_num_threads is None and graph_optimization_level is None:
         session = onnxruntime.InferenceSession(model_path)
     else:
-        execution_providers = ['CPUExecutionProvider'] if not use_gpu else ['CUDAExecutionProvider', 'CPUExecutionProvider']
+        execution_providers = ['CPUExecutionProvider'
+                              ] if not use_gpu else ['CUDAExecutionProvider', 'CPUExecutionProvider']
         sess_options = onnxruntime.SessionOptions()
         sess_options.execution_mode = onnxruntime.ExecutionMode.ORT_SEQUENTIAL
         if graph_optimization_level is None:
@@ -52,6 +56,7 @@ def create_session(model_path, use_gpu, intra_op_num_threads, graph_optimization
     if use_gpu:
         assert 'CUDAExecutionProvider' in session.get_providers()
     return session
+
 
 def onnxruntime_inference(session, all_inputs, output_names, warmup=True):
     if warmup and len(all_inputs) > 0:
@@ -67,6 +72,7 @@ def onnxruntime_inference(session, all_inputs, output_names, warmup=True):
         results.append(result)
         latency_list.append(latency)
     return results, latency_list
+
 
 def get_contiguous_inputs(all_inputs):
     """
@@ -85,14 +91,18 @@ def get_contiguous_inputs(all_inputs):
     average_latency_ms = latency / len(contiguous_inputs) * 1000
     return contiguous_inputs, average_latency_ms
 
+
 def to_string(model_path, session, test_setting):
     sess_options = session.get_session_options()
     option = "model={}".format(os.path.basename(model_path))
-    option += ",graph_optimization_level={},intra_op_num_threads={}".format(sess_options.graph_optimization_level, sess_options.intra_op_num_threads).replace('GraphOptimizationLevel.ORT_', '')
+    option += ",graph_optimization_level={},intra_op_num_threads={}".format(sess_options.graph_optimization_level,
+                                                                            sess_options.intra_op_num_threads).replace(
+                                                                                'GraphOptimizationLevel.ORT_', '')
     option += ",OMP_NUM_THREADS={}".format(os.environ["OMP_NUM_THREADS"] if "OMP_NUM_THREADS" in os.environ else "")
     option += ",OMP_WAIT_POLICY={}".format(os.environ["OMP_WAIT_POLICY"] if "OMP_WAIT_POLICY" in os.environ else "")
     option += ",{}".format(test_setting)
     return option
+
 
 def setup_openmp_environ(omp_num_threads, omp_wait_policy):
     if omp_num_threads is None:
@@ -108,11 +118,14 @@ def setup_openmp_environ(omp_num_threads, omp_wait_policy):
         assert omp_wait_policy in ["ACTIVE", "PASSIVE"]
         os.environ["OMP_WAIT_POLICY"] = omp_wait_policy
 
-def run_one_test(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases, test_times, contiguous, intra_op_num_threads, omp_num_threads, omp_wait_policy, no_warmup, extra_latency):
+
+def run_one_test(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases, test_times,
+                 contiguous, intra_op_num_threads, omp_num_threads, omp_wait_policy, no_warmup, extra_latency):
     # Environment variable shall be set before import onnxruntime.
     setup_openmp_environ(omp_num_threads, omp_wait_policy)
 
-    test_setting = "batch_size={},sequence_length={},test_cases={},test_times={},contiguous={},use_gpu={},warmup={}".format(batch_size, sequence_length, test_cases, test_times, contiguous, use_gpu, not no_warmup)
+    test_setting = "batch_size={},sequence_length={},test_cases={},test_times={},contiguous={},use_gpu={},warmup={}".format(
+        batch_size, sequence_length, test_cases, test_times, contiguous, use_gpu, not no_warmup)
 
     session = create_session(model_path, use_gpu, intra_op_num_threads)
     output_names = [output.name for output in session.get_outputs()]
@@ -142,31 +155,43 @@ def run_one_test(perf_results, model_path, all_inputs, batch_size, sequence_leng
 
     perf_results[key] = (average_latency, latency_50, latency_75, latency_90, latency_95, latency_99, throughput)
 
-    print("Average latency = {} ms, Throughput = {} QPS".format(format(average_latency, '.2f'), format(throughput, '.2f')))
+    print("Average latency = {} ms, Throughput = {} QPS".format(format(average_latency, '.2f'),
+                                                                format(throughput, '.2f')))
 
-def launch_test(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases, test_times, contiguous, intra_op_num_threads, omp_num_threads, omp_wait_policy, no_warmup, extra_latency):
-    process = multiprocessing.Process(target=run_one_test, args=(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases, test_times, contiguous, intra_op_num_threads, omp_num_threads, omp_wait_policy, no_warmup, extra_latency))
+
+def launch_test(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases, test_times,
+                contiguous, intra_op_num_threads, omp_num_threads, omp_wait_policy, no_warmup, extra_latency):
+    process = multiprocessing.Process(target=run_one_test,
+                                      args=(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu,
+                                            test_cases, test_times, contiguous, intra_op_num_threads, omp_num_threads,
+                                            omp_wait_policy, no_warmup, extra_latency))
     process.start()
     process.join()
 
-def run_perf_tests(perf_results, model_path, batch_size, sequence_length, use_gpu, test_cases, test_times, contiguous, all_inputs, test_all, no_warmup, extra_latency):
+
+def run_perf_tests(perf_results, model_path, batch_size, sequence_length, use_gpu, test_cases, test_times, contiguous,
+                   all_inputs, test_all, no_warmup, extra_latency):
     cpu_count = psutil.cpu_count(logical=False)
     logical_cores = psutil.cpu_count(logical=True)
 
     # Test a setting without any setting as baseline 1.
-    launch_test(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases, test_times, contiguous, None, None, None, no_warmup, extra_latency)
+    launch_test(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases, test_times,
+                contiguous, None, None, None, no_warmup, extra_latency)
 
     if not use_gpu:
         # For CPU: intra_op_num_threads = 1, omp_num_threads=None, omp_wait_policy=None
         # Another setting without environment variable as baseline 2.
-        launch_test(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases, test_times, contiguous, 1, None, None, no_warmup, extra_latency)
+        launch_test(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases, test_times,
+                    contiguous, 1, None, None, no_warmup, extra_latency)
     else:
         # For GPU, we test two more settings by default:
         # (1) intra_op_num_threads = 1, omp_num_threads=cpu_count, omp_wait_policy=PASSIVE
         # (2) intra_op_num_threads = logical_cores, omp_num_threads=1, omp_wait_policy=ACTIVE
-        launch_test(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases, test_times, contiguous, 1, cpu_count, 'PASSIVE', no_warmup, extra_latency)
-        
-        launch_test(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases, test_times, contiguous, logical_cores, 1, 'ACTIVE', no_warmup, extra_latency)
+        launch_test(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases, test_times,
+                    contiguous, 1, cpu_count, 'PASSIVE', no_warmup, extra_latency)
+
+        launch_test(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases, test_times,
+                    contiguous, logical_cores, 1, 'ACTIVE', no_warmup, extra_latency)
 
     # GPU latency is not sensitive to these settings. No need to test many combinations.
     # Skip remaining settings for GPU without --all flag.
@@ -194,18 +219,41 @@ def run_perf_tests(perf_results, model_path, batch_size, sequence_length, use_gp
                     continue
 
             for omp_wait_policy in ['ACTIVE', 'PASSIVE']:
-                launch_test(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases, test_times, contiguous, intra_op_num_threads, omp_num_threads, omp_wait_policy, no_warmup, extra_latency)
+                launch_test(perf_results, model_path, all_inputs, batch_size, sequence_length, use_gpu, test_cases,
+                            test_times, contiguous, intra_op_num_threads, omp_num_threads, omp_wait_policy, no_warmup,
+                            extra_latency)
 
-def run_performance(perf_results, model_path, batch_size, sequence_length, use_gpu, test_cases, test_times, seed, verbose, inclusive, test_all, no_warmup):
+
+def run_performance(perf_results, model_path, batch_size, sequence_length, use_gpu, test_cases, test_times, seed,
+                    verbose, inclusive, test_all, no_warmup):
     # Try deduce input names from model.
     input_ids, segment_ids, input_mask = get_bert_inputs(model_path)
 
     # Do not generate random mask for performance test.
     print(f"Generating {test_cases} samples for batch_size={batch_size} sequence_length={sequence_length}")
-    all_inputs = generate_test_data(batch_size, sequence_length, test_cases, seed, verbose, input_ids, segment_ids, input_mask, random_mask_length=False)
+    all_inputs = generate_test_data(batch_size,
+                                    sequence_length,
+                                    test_cases,
+                                    seed,
+                                    verbose,
+                                    input_ids,
+                                    segment_ids,
+                                    input_mask,
+                                    random_mask_length=False)
 
     contiguous = False
-    run_perf_tests(perf_results, model_path, batch_size, sequence_length, use_gpu, test_cases, test_times, contiguous, all_inputs, test_all, no_warmup, extra_latency=0)
+    run_perf_tests(perf_results,
+                   model_path,
+                   batch_size,
+                   sequence_length,
+                   use_gpu,
+                   test_cases,
+                   test_times,
+                   contiguous,
+                   all_inputs,
+                   test_all,
+                   no_warmup,
+                   extra_latency=0)
 
     # only test contiguous array when the --all flag is set.
     if not test_all:
@@ -216,26 +264,44 @@ def run_performance(perf_results, model_path, batch_size, sequence_length, use_g
     print("Extra latency for converting inputs to contiguous: {} ms".format(format(contiguous_latency, '.2f')))
 
     contiguous = True
-    run_perf_tests(perf_results, model_path, batch_size, sequence_length, use_gpu, test_cases, test_times, contiguous, all_inputs, test_all, no_warmup, extra_latency=contiguous_latency if inclusive else 0)
+    run_perf_tests(perf_results,
+                   model_path,
+                   batch_size,
+                   sequence_length,
+                   use_gpu,
+                   test_cases,
+                   test_times,
+                   contiguous,
+                   all_inputs,
+                   test_all,
+                   no_warmup,
+                   extra_latency=contiguous_latency if inclusive else 0)
+
 
 def parse_arguments():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--model', required=True, type=str,
-                        help="bert onnx model path")
+    parser.add_argument('--model', required=True, type=str, help="bert onnx model path")
 
-    parser.add_argument('--batch_size', required=True, type=int, nargs="+",
+    parser.add_argument('--batch_size',
+                        required=True,
+                        type=int,
+                        nargs="+",
                         help="batch size of input. Allow one or multiple values in the range of [1, 128].")
 
-    parser.add_argument('--sequence_length',  required=True, type=int,
-                        help="maximum sequence length of input")
+    parser.add_argument('--sequence_length', required=True, type=int, help="maximum sequence length of input")
 
-    parser.add_argument('--samples',  required=False, type=int, default=10,
-                        help="number of samples to be generated")
+    parser.add_argument('--samples', required=False, type=int, default=10, help="number of samples to be generated")
 
-    parser.add_argument('--test_times',  required=False, type=int, default=0,
+    parser.add_argument('--test_times',
+                        required=False,
+                        type=int,
+                        default=0,
                         help="number of times to run per sample. By default, the value is 1000 / samples")
 
-    parser.add_argument('--seed',  required=False, type=int, default=3,
+    parser.add_argument('--seed',
+                        required=False,
+                        type=int,
+                        default=3,
                         help="random seed. Use the same seed to make sure test data is same in multiple tests.")
 
     parser.add_argument('--verbose', required=False, action='store_true', help="print verbose information")
@@ -244,7 +310,10 @@ def parse_arguments():
     parser.add_argument('--use_gpu', required=False, action='store_true', help="use GPU")
     parser.set_defaults(use_gpu=False)
 
-    parser.add_argument('--inclusive', required=False, action='store_true', help="include the latency of converting array to contiguous")
+    parser.add_argument('--inclusive',
+                        required=False,
+                        action='store_true',
+                        help="include the latency of converting array to contiguous")
     parser.set_defaults(inclusive=False)
 
     parser.add_argument('--all', required=False, action='store_true', help="test all candidate settings")
@@ -256,6 +325,7 @@ def parse_arguments():
     args = parser.parse_args()
     return args
 
+
 def main():
     args = parse_arguments()
 
@@ -266,23 +336,32 @@ def main():
     perf_results = manager.dict()
 
     batch_size_set = set(args.batch_size)
-    if not min(batch_size_set)>=1 and max(batch_size_set) <= 128:
+    if not min(batch_size_set) >= 1 and max(batch_size_set) <= 128:
         raise Exception("batch_size not in range [1, 128]")
 
     for batch_size in batch_size_set:
-        run_performance(perf_results, args.model, batch_size, args.sequence_length, args.use_gpu, args.samples, args.test_times, args.seed, args.verbose, args.inclusive, args.all, args.no_warmup)
+        run_performance(perf_results, args.model, batch_size, args.sequence_length, args.use_gpu, args.samples,
+                        args.test_times, args.seed, args.verbose, args.inclusive, args.all, args.no_warmup)
 
     # Sort the results so that the first one has smallest latency.
     sorted_results = sorted(perf_results.items(), reverse=False, key=lambda x: x[1])
- 
-    summary_file = os.path.join(Path(args.model).parent, "perf_results_{}_B{}_S{}_{}.txt".format('GPU' if args.use_gpu else 'CPU', "-".join([str(x) for x in sorted(list(batch_size_set))]), args.sequence_length, datetime.now().strftime("%Y%m%d-%H%M%S")))
+
+    summary_file = os.path.join(
+        Path(args.model).parent,
+        "perf_results_{}_B{}_S{}_{}.txt".format('GPU' if args.use_gpu else 'CPU',
+                                                "-".join([str(x) for x in sorted(list(batch_size_set))]),
+                                                args.sequence_length,
+                                                datetime.now().strftime("%Y%m%d-%H%M%S")))
     with open(summary_file, 'w+', newline='') as tsv_file:
         tsv_writer = csv.writer(tsv_file, delimiter='\t', lineterminator='\n')
         headers = None
         for (key, perf_result) in sorted_results:
             params = key.split(',')
             if headers is None:
-                headers = ["Latency(ms)", "Latency_P50", "Latency_P75", "Latency_P90", "Latency_P95", "Latency_P99", "Throughput(QPS)"]
+                headers = [
+                    "Latency(ms)", "Latency_P50", "Latency_P75", "Latency_P90", "Latency_P95", "Latency_P99",
+                    "Throughput(QPS)"
+                ]
                 headers.extend([x.split('=')[0] for x in params])
                 tsv_writer.writerow(headers)
 
@@ -292,8 +371,9 @@ def main():
 
     print("Test summary is saved to", summary_file)
 
+
 if __name__ == "__main__":
     # work around for AnaConda Jupyter. See https://stackoverflow.com/questions/45720153/python-multiprocessing-error-attributeerror-module-main-has-no-attribute
     __spec__ = None
-    
+
     main()

--- a/onnxruntime/python/tools/bert/compare_bert_results.py
+++ b/onnxruntime/python/tools/bert/compare_bert_results.py
@@ -23,6 +23,7 @@ from OnnxModel import OnnxModel
 from bert_test_data import get_bert_inputs, generate_test_data, output_test_data
 from bert_perf_test import create_session, onnxruntime_inference, setup_openmp_environ
 
+
 def run_model(model_path, all_inputs, use_gpu, use_openmp, disable_optimization):
     # Import onnxruntime shall be after OpenMP environment variable setting.
     # So we put import here to delay importing.
@@ -32,13 +33,14 @@ def run_model(model_path, all_inputs, use_gpu, use_openmp, disable_optimization)
     if disable_optimization:
         graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
 
-    intra_op_num_threads =  1 if use_openmp else psutil.cpu_count(logical=False)
+    intra_op_num_threads = 1 if use_openmp else psutil.cpu_count(logical=False)
 
     session = create_session(model_path, use_gpu, intra_op_num_threads, graph_optimization_level)
 
     output_names = [output.name for output in session.get_outputs()]
     results, latency_list = onnxruntime_inference(session, all_inputs, output_names)
     return results, latency_list, output_names
+
 
 def compare(baseline_results, treatment_results, verbose, rtol=1e-3, atol=1e-4):
     # Validate the output of baseline and treatment, to make sure the results are similar.
@@ -62,23 +64,34 @@ def compare(baseline_results, treatment_results, verbose, rtol=1e-3, atol=1e-4):
                         print("case {} output {}".format(test_case_id, i))
                         print("baseline={}\ntreatment={}".format(results[i].tolist(), treatment_output))
                         print("rel_diff={} abs_diff={}".format(rel_diff, abs_diff))
-            
 
     if diff_count == 0:
-        print("100% passed for {} random inputs given thresholds (rtol={}, atol={}).".format(len(baseline_results), rtol, atol))
+        print("100% passed for {} random inputs given thresholds (rtol={}, atol={}).".format(
+            len(baseline_results), rtol, atol))
     else:
-        print("{} out of {} results not passed for thresholds (rtol={}, atol={}).".format(diff_count, len(baseline_results), rtol, atol))
+        print("{} out of {} results not passed for thresholds (rtol={}, atol={}).".format(
+            diff_count, len(baseline_results), rtol, atol))
 
     print("maximum absolute difference={}".format(max_abs_diff))
 
     print("maximum relative difference={}".format(max_rel_diff))
 
-def run_test(baseline_model, optimized_model, output_dir, batch_size, sequence_length, use_gpu, test_cases, seed, use_openmp, verbose, rtol, atol):
+
+def run_test(baseline_model, optimized_model, output_dir, batch_size, sequence_length, use_gpu, test_cases, seed,
+             use_openmp, verbose, rtol, atol):
     # Try deduce input names from optimized model.
     input_ids, segment_ids, input_mask = get_bert_inputs(optimized_model)
 
     # Use random mask length for accuracy test. It might introduce slight inflation in latency reported in this script.
-    all_inputs = generate_test_data(batch_size, sequence_length, test_cases, seed, verbose, input_ids, segment_ids, input_mask, random_mask_length=True)
+    all_inputs = generate_test_data(batch_size,
+                                    sequence_length,
+                                    test_cases,
+                                    seed,
+                                    verbose,
+                                    input_ids,
+                                    segment_ids,
+                                    input_mask,
+                                    random_mask_length=True)
 
     # OpenMP environment variables must be set before the very first "import onnxruntime"
     if use_openmp:
@@ -86,51 +99,60 @@ def run_test(baseline_model, optimized_model, output_dir, batch_size, sequence_l
     else:
         setup_openmp_environ(omp_num_threads=1, omp_wait_policy='ACTIVE')
 
-    baseline_results, baseline_latency, output_names = run_model(baseline_model, all_inputs, use_gpu, use_openmp, disable_optimization=True)
+    baseline_results, baseline_latency, output_names = run_model(baseline_model,
+                                                                 all_inputs,
+                                                                 use_gpu,
+                                                                 use_openmp,
+                                                                 disable_optimization=True)
     if verbose:
-        print("baseline average latency (all optimizations disabled): {} ms".format(statistics.mean(baseline_latency) * 1000))
+        print("baseline average latency (all optimizations disabled): {} ms".format(
+            statistics.mean(baseline_latency) * 1000))
 
     if output_dir is not None:
         for i, inputs in enumerate(all_inputs):
             output_test_data(output_dir, i, inputs)
 
-    treatment_results, treatment_latency, treatment_output_names = run_model(optimized_model, all_inputs, use_gpu, use_openmp, disable_optimization=False)
+    treatment_results, treatment_latency, treatment_output_names = run_model(optimized_model,
+                                                                             all_inputs,
+                                                                             use_gpu,
+                                                                             use_openmp,
+                                                                             disable_optimization=False)
     if verbose:
         print("treatment average latency: {} ms".format(statistics.mean(treatment_latency) * 1000))
 
     # Validate the output of baseline and treatment, to make sure the results are similar.
     compare(baseline_results, treatment_results, verbose, rtol, atol)
 
+
 def parse_arguments():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--baseline_model', required=True, type=str,
-                        help="baseline onnx model path.")
+    parser.add_argument('--baseline_model', required=True, type=str, help="baseline onnx model path.")
 
-    parser.add_argument('--optimized_model', required=True, type=str, default=None,
+    parser.add_argument('--optimized_model',
+                        required=True,
+                        type=str,
+                        default=None,
                         help="path of the optimized model. It shall have same inputs as the baseline model.")
 
-    parser.add_argument('--output_dir', required=False, type=str, default=None,
+    parser.add_argument('--output_dir',
+                        required=False,
+                        type=str,
+                        default=None,
                         help="output test data path. If not specified, test data will not be saved.")
 
-    parser.add_argument('--batch_size', required=True, type=int,
-                        help="batch size of input")
+    parser.add_argument('--batch_size', required=True, type=int, help="batch size of input")
 
-    parser.add_argument('--sequence_length',  required=True, type=int,
-                        help="maximum sequence length of input")
+    parser.add_argument('--sequence_length', required=True, type=int, help="maximum sequence length of input")
 
-    parser.add_argument('--rtol',  required=False, type=float, default=1e-3,
-                        help="relative tolerance")
+    parser.add_argument('--rtol', required=False, type=float, default=1e-3, help="relative tolerance")
 
-    parser.add_argument('--atol',  required=False, type=float, default=1e-4,
-                        help="absolute tolerance")
+    parser.add_argument('--atol', required=False, type=float, default=1e-4, help="absolute tolerance")
 
-    parser.add_argument('--samples',  required=False, type=int, default=100,
-                        help="number of test cases to be generated")
+    parser.add_argument('--samples', required=False, type=int, default=100, help="number of test cases to be generated")
 
-    parser.add_argument('--seed',  required=False, type=int, default=3,
-                        help="random seed")
+    parser.add_argument('--seed', required=False, type=int, default=3, help="random seed")
 
-    parser.add_argument('--use_gpu',  required=False, action='store_true', help="use GPU")
+    parser.add_argument('--use_gpu', required=False, action='store_true', help="use GPU")
     parser.set_defaults(use_gpu=False)
 
     parser.add_argument('--openmp', required=False, action='store_true', help="use openmp")
@@ -142,6 +164,7 @@ def parse_arguments():
     args = parser.parse_args()
     return args
 
+
 def main():
     args = parse_arguments()
 
@@ -150,19 +173,9 @@ def main():
         path = Path(args.output_dir)
         path.mkdir(parents=True, exist_ok=True)
 
-    run_test(
-        args.baseline_model,
-        args.optimized_model,
-        args.output_dir,
-        args.batch_size,
-        args.sequence_length,
-        args.use_gpu,
-        args.samples,
-        args.seed,
-        args.openmp,
-        args.verbose,
-        args.rtol,
-        args.atol)
+    run_test(args.baseline_model, args.optimized_model, args.output_dir, args.batch_size, args.sequence_length,
+             args.use_gpu, args.samples, args.seed, args.openmp, args.verbose, args.rtol, args.atol)
+
 
 if __name__ == "__main__":
     main()

--- a/onnxruntime/python/tools/bert/test_bert_optimization.py
+++ b/onnxruntime/python/tools/bert/test_bert_optimization.py
@@ -20,12 +20,18 @@ from bert_model_optimization import optimize_model, optimize_by_onnxruntime
 from OnnxModel import OnnxModel
 
 BERT_TEST_MODELS = {
-    "bert_pytorch_0": 'test_data\\bert_squad_pytorch1.4_opset11\\BertForQuestionAnswering_0.onnx',
-    "bert_pytorch_1": 'test_data\\bert_squad_pytorch1.4_opset11\\BertForQuestionAnswering_1.onnx',
-    "bert_squad_pytorch1.4_opset10_fp32": 'test_data\\bert_squad_pytorch1.4_opset10_fp32\\BertForQuestionAnswering.onnx',
-    "bert_keras_0": 'test_data\\bert_mrpc_tensorflow2.1_opset10\\TFBertForSequenceClassification_1.onnx',
-    "bert_keras_squad": 'test_data\\bert_squad_tensorflow2.1_keras2onnx_opset11\\TFBertForQuestionAnswering.onnx'
+    "bert_pytorch_0":
+        'test_data\\bert_squad_pytorch1.4_opset11\\BertForQuestionAnswering_0.onnx',
+    "bert_pytorch_1":
+        'test_data\\bert_squad_pytorch1.4_opset11\\BertForQuestionAnswering_1.onnx',
+    "bert_squad_pytorch1.4_opset10_fp32":
+        'test_data\\bert_squad_pytorch1.4_opset10_fp32\\BertForQuestionAnswering.onnx',
+    "bert_keras_0":
+        'test_data\\bert_mrpc_tensorflow2.1_opset10\\TFBertForSequenceClassification_1.onnx',
+    "bert_keras_squad":
+        'test_data\\bert_squad_tensorflow2.1_keras2onnx_opset11\\TFBertForQuestionAnswering.onnx'
 }
+
 
 class TestBertOptimization(unittest.TestCase):
 
@@ -51,7 +57,7 @@ class TestBertOptimization(unittest.TestCase):
             'Gelu': 0,
             'FastGelu': 0,
             'BiasGelu': 12
-            }
+        }
         self.verify_node_count(bert_model, expected_node_count)
 
     def test_pytorch_model_0_gpu_onnxruntime(self):
@@ -72,9 +78,9 @@ class TestBertOptimization(unittest.TestCase):
             'Attention': 12,
             'SkipLayerNormalization': 24,
             'Gelu': 0,
-            'FastGelu': 12, 
+            'FastGelu': 12,
             'BiasGelu': 0
-            }
+        }
         self.verify_node_count(bert_model, expected_node_count)
 
     def test_pytorch_model_1_cpu_onnxruntime(self):
@@ -94,7 +100,7 @@ class TestBertOptimization(unittest.TestCase):
             'Gelu': 0,
             'FastGelu': 0,
             'BiasGelu': 12
-            }
+        }
         self.verify_node_count(bert_model, expected_node_count)
 
     def test_pytorch_model_1_gpu_onnxruntime(self):
@@ -116,16 +122,21 @@ class TestBertOptimization(unittest.TestCase):
             'LayerNormalization': 24,
             'SkipLayerNormalization': 0,
             'Gelu': 0,
-            'FastGelu': 12, 
+            'FastGelu': 12,
             'BiasGelu': 0
-            }
+        }
         self.verify_node_count(bert_model, expected_node_count)
 
     def test_pytorch_model_0_cpu(self):
         input = BERT_TEST_MODELS['bert_pytorch_0']
-        bert_model = optimize_model(input, 'bert', gpu_only=False,
-                                    num_heads=2, hidden_size=8, sequence_length=10,
-                                    input_int32=False, float16=False)
+        bert_model = optimize_model(input,
+                                    'bert',
+                                    gpu_only=False,
+                                    num_heads=2,
+                                    hidden_size=8,
+                                    sequence_length=10,
+                                    input_int32=False,
+                                    float16=False)
 
         expected_node_count = {
             'EmbedLayerNormalization': 1,
@@ -134,7 +145,7 @@ class TestBertOptimization(unittest.TestCase):
             'Gelu': 0,
             'FastGelu': 0,
             'BiasGelu': 12
-            }
+        }
         self.verify_node_count(bert_model, expected_node_count)
 
     def test_pytorch_model_0_gpu(self):
@@ -143,9 +154,14 @@ class TestBertOptimization(unittest.TestCase):
             return
 
         input = BERT_TEST_MODELS['bert_pytorch_0']
-        bert_model = optimize_model(input, 'bert', gpu_only=True,
-                                    num_heads=2, hidden_size=8, sequence_length=10,
-                                    input_int32=False, float16=False)
+        bert_model = optimize_model(input,
+                                    'bert',
+                                    gpu_only=True,
+                                    num_heads=2,
+                                    hidden_size=8,
+                                    sequence_length=10,
+                                    input_int32=False,
+                                    float16=False)
 
         expected_node_count = {
             'EmbedLayerNormalization': 1,
@@ -154,22 +170,32 @@ class TestBertOptimization(unittest.TestCase):
             'FastGelu': 12,
             'Gelu': 0,
             'BiasGelu': 0
-            }
+        }
         self.verify_node_count(bert_model, expected_node_count)
 
     def test_pytorch_model_2_cpu(self):
         input = BERT_TEST_MODELS['bert_squad_pytorch1.4_opset10_fp32']
-        bert_model = optimize_model(input, 'bert', gpu_only=False,
-                                    num_heads=2, hidden_size=8, sequence_length=10,
-                                    input_int32=False, float16=False)
+        bert_model = optimize_model(input,
+                                    'bert',
+                                    gpu_only=False,
+                                    num_heads=2,
+                                    hidden_size=8,
+                                    sequence_length=10,
+                                    input_int32=False,
+                                    float16=False)
         self.assertTrue(bert_model.is_fully_optimized())
 
     def test_keras_model_1_cpu(self):
         input = BERT_TEST_MODELS['bert_keras_0']
 
-        bert_model = optimize_model(input, 'bert_keras', gpu_only=False,
-                                    num_heads=2, hidden_size=8, sequence_length=7,
-                                    input_int32=False, float16=False)
+        bert_model = optimize_model(input,
+                                    'bert_keras',
+                                    gpu_only=False,
+                                    num_heads=2,
+                                    hidden_size=8,
+                                    sequence_length=7,
+                                    input_int32=False,
+                                    float16=False)
 
         expected_node_count = {
             'EmbedLayerNormalization': 1,
@@ -179,17 +205,23 @@ class TestBertOptimization(unittest.TestCase):
             'BiasGelu': 0,
             'Gelu': 12,
             'FastGelu': 0
-            }
+        }
         self.verify_node_count(bert_model, expected_node_count)
 
     def test_keras_squad_model_cpu(self):
         input = BERT_TEST_MODELS['bert_keras_squad']
 
-        bert_model = optimize_model(input, 'bert_keras', gpu_only=False,
-                                    num_heads=2, hidden_size=8, sequence_length=7,
-                                    input_int32=False, float16=False)
+        bert_model = optimize_model(input,
+                                    'bert_keras',
+                                    gpu_only=False,
+                                    num_heads=2,
+                                    hidden_size=8,
+                                    sequence_length=7,
+                                    input_int32=False,
+                                    float16=False)
 
         self.assertTrue(bert_model.is_fully_optimized())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/onnxruntime/python/tools/featurizer_ops/create_test_model.py
+++ b/onnxruntime/python/tools/featurizer_ops/create_test_model.py
@@ -13,79 +13,109 @@ from onnx import helper
 from onnx import utils
 from onnx import AttributeProto, TensorProto, GraphProto
 
+
 def parse_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument("--output_file", required=True, help="Model file name to save")
     return parser.parse_args()
 
+
 def create_model():
-     """
+    """
      This function creates a test feed model that consists of a single node that takes
      Tensors of all inputs
      """
-     args = parse_arguments()
+    args = parse_arguments()
 
-     # bool_identity
-     bool_input = helper.make_tensor_value_info('BoolInput', TensorProto.BOOL, [1,1])
-     # Create output for Identity
-     bool_output = helper.make_tensor_value_info('BoolOutput', TensorProto.BOOL, [1,1])
-     # Create node def
-     bool_identity_def = helper.make_node('Identity', inputs=['BoolInput'], outputs=['BoolOutput'], name='BoolIdentity')
+    # bool_identity
+    bool_input = helper.make_tensor_value_info('BoolInput', TensorProto.BOOL, [1, 1])
+    # Create output for Identity
+    bool_output = helper.make_tensor_value_info('BoolOutput', TensorProto.BOOL, [1, 1])
+    # Create node def
+    bool_identity_def = helper.make_node('Identity', inputs=['BoolInput'], outputs=['BoolOutput'], name='BoolIdentity')
 
-     # Create string_identity
-     string_input = helper.make_tensor_value_info('StringInput', TensorProto.STRING, [1,1])
-     string_output = helper.make_tensor_value_info('StringOutput', TensorProto.STRING, [1,1])
-     string_identity_def = helper.make_node('Identity', inputs=['StringInput'], outputs=['StringOutput'], name='StringIdentity')
+    # Create string_identity
+    string_input = helper.make_tensor_value_info('StringInput', TensorProto.STRING, [1, 1])
+    string_output = helper.make_tensor_value_info('StringOutput', TensorProto.STRING, [1, 1])
+    string_identity_def = helper.make_node('Identity',
+                                           inputs=['StringInput'],
+                                           outputs=['StringOutput'],
+                                           name='StringIdentity')
 
-     # double
-     double_input = helper.make_tensor_value_info('DoubleInput', TensorProto.DOUBLE, [1,1])
-     double_output = helper.make_tensor_value_info('DoubleOutput', TensorProto.DOUBLE, [1,1])
-     double_identity_def = helper.make_node('Identity', inputs=['DoubleInput'], outputs=['DoubleOutput'], name='DoubleIdentity')
+    # double
+    double_input = helper.make_tensor_value_info('DoubleInput', TensorProto.DOUBLE, [1, 1])
+    double_output = helper.make_tensor_value_info('DoubleOutput', TensorProto.DOUBLE, [1, 1])
+    double_identity_def = helper.make_node('Identity',
+                                           inputs=['DoubleInput'],
+                                           outputs=['DoubleOutput'],
+                                           name='DoubleIdentity')
 
-     # int8
-     int8_input = helper.make_tensor_value_info('Int8Input', TensorProto.INT8, [1,1])
-     int8_output = helper.make_tensor_value_info('Int8Output', TensorProto.INT8, [1,1])
-     int8_identity_def = helper.make_node('Identity', inputs=['Int8Input'], outputs=['Int8Output'], name='Int8Identity')
+    # int8
+    int8_input = helper.make_tensor_value_info('Int8Input', TensorProto.INT8, [1, 1])
+    int8_output = helper.make_tensor_value_info('Int8Output', TensorProto.INT8, [1, 1])
+    int8_identity_def = helper.make_node('Identity', inputs=['Int8Input'], outputs=['Int8Output'], name='Int8Identity')
 
-     # int16
-     int16_input = helper.make_tensor_value_info('Int16Input', TensorProto.INT16, [1,1])
-     int16_output = helper.make_tensor_value_info('Int16Output', TensorProto.INT16, [1,1])
-     int16_identity_def = helper.make_node('Identity', inputs=['Int16Input'], outputs=['Int16Output'], name='Int16Identity')
+    # int16
+    int16_input = helper.make_tensor_value_info('Int16Input', TensorProto.INT16, [1, 1])
+    int16_output = helper.make_tensor_value_info('Int16Output', TensorProto.INT16, [1, 1])
+    int16_identity_def = helper.make_node('Identity',
+                                          inputs=['Int16Input'],
+                                          outputs=['Int16Output'],
+                                          name='Int16Identity')
 
-     # int32
-     int32_input = helper.make_tensor_value_info('Int32Input', TensorProto.INT32, [1,1])
-     int32_output = helper.make_tensor_value_info('Int32Output', TensorProto.INT32, [1,1])
-     int32_identity_def = helper.make_node('Identity', inputs=['Int32Input'], outputs=['Int32Output'], name='Int32Identity')
+    # int32
+    int32_input = helper.make_tensor_value_info('Int32Input', TensorProto.INT32, [1, 1])
+    int32_output = helper.make_tensor_value_info('Int32Output', TensorProto.INT32, [1, 1])
+    int32_identity_def = helper.make_node('Identity',
+                                          inputs=['Int32Input'],
+                                          outputs=['Int32Output'],
+                                          name='Int32Identity')
 
-     # int64
-     int64_input = helper.make_tensor_value_info('Int64Input', TensorProto.INT64, [1,1])
-     int64_output = helper.make_tensor_value_info('Int64Output', TensorProto.INT64, [1,1])
-     int64_identity_def = helper.make_node('Identity', inputs=['Int64Input'], outputs=['Int64Output'], name='Int64Identity')
+    # int64
+    int64_input = helper.make_tensor_value_info('Int64Input', TensorProto.INT64, [1, 1])
+    int64_output = helper.make_tensor_value_info('Int64Output', TensorProto.INT64, [1, 1])
+    int64_identity_def = helper.make_node('Identity',
+                                          inputs=['Int64Input'],
+                                          outputs=['Int64Output'],
+                                          name='Int64Identity')
 
-     ##### Optional input as it has initializer. This one is interesting bc it needs float32 which
-     # Pandas do not have
-     # Create Initializer with optional input with default value from the initializer
-     float32_input = helper.make_tensor_value_info('Float32Input', TensorProto.FLOAT, [1,1])
-     float32_output = helper.make_tensor_value_info('Float32Output', TensorProto.FLOAT, [1,1])
-     optional_identity_def = helper.make_node('Identity', inputs=['Float32Input'], outputs=['Float32Output'], name='OptionalIdentity')
+    ##### Optional input as it has initializer. This one is interesting bc it needs float32 which
+    # Pandas do not have
+    # Create Initializer with optional input with default value from the initializer
+    float32_input = helper.make_tensor_value_info('Float32Input', TensorProto.FLOAT, [1, 1])
+    float32_output = helper.make_tensor_value_info('Float32Output', TensorProto.FLOAT, [1, 1])
+    optional_identity_def = helper.make_node('Identity',
+                                             inputs=['Float32Input'],
+                                             outputs=['Float32Output'],
+                                             name='OptionalIdentity')
 
-     # Create a default initializer for float32_input.
-     tensor_float32 = helper.make_tensor(name='Float32Input', data_type=TensorProto.FLOAT, dims=[1,1],
-                                        vals=np.array([[.0]]).astype(np.float32), raw=False)
+    # Create a default initializer for float32_input.
+    tensor_float32 = helper.make_tensor(name='Float32Input',
+                                        data_type=TensorProto.FLOAT,
+                                        dims=[1, 1],
+                                        vals=np.array([[.0]]).astype(np.float32),
+                                        raw=False)
 
-     # Make a graph
-     graph_def = helper.make_graph(nodes=[bool_identity_def, string_identity_def, double_identity_def, int8_identity_def,
-                                          int16_identity_def, int32_identity_def, int64_identity_def, optional_identity_def],
-                                   name='optional_input_graph',
-                                   inputs=[bool_input, string_input, double_input, int8_input, int16_input, int32_input, int64_input, float32_input],
-                                   outputs=[bool_output, string_output, double_output, int8_output, int16_output, int32_output, int64_output, float32_output],
-                                   initializer=[tensor_float32])
+    # Make a graph
+    graph_def = helper.make_graph(nodes=[
+        bool_identity_def, string_identity_def, double_identity_def, int8_identity_def, int16_identity_def,
+        int32_identity_def, int64_identity_def, optional_identity_def
+    ],
+                                  name='optional_input_graph',
+                                  inputs=[
+                                      bool_input, string_input, double_input, int8_input, int16_input, int32_input,
+                                      int64_input, float32_input
+                                  ],
+                                  outputs=[
+                                      bool_output, string_output, double_output, int8_output, int16_output,
+                                      int32_output, int64_output, float32_output
+                                  ],
+                                  initializer=[tensor_float32])
 
-     model_def = helper.make_model(graph_def, producer_name='feed_inputs_test')
-     final_model = onnx.utils.polish_model(model_def)
-     onnx.save(final_model, args.output_file)
+    model_def = helper.make_model(graph_def, producer_name='feed_inputs_test')
+    final_model = onnx.utils.polish_model(model_def)
+    onnx.save(final_model, args.output_file)
+
 
 if __name__ == "__main__":
     sys.exit(create_model())
-
-

--- a/onnxruntime/python/tools/featurizer_ops/data_frame_tool.py
+++ b/onnxruntime/python/tools/featurizer_ops/data_frame_tool.py
@@ -18,26 +18,26 @@ pd_int_set = set(['int64'])
 
 types_dict = {
     'tensor(float16)': np.float16,
-    'tensor(float)'  : np.float32,
-    'tensor(double)' : np.float64,
-
-    'tensor(int8)'   : np.int8,
-    'tensor(uint8)'  : np.uint8,
-    'tensor(int16)'  : np.int16,
-    'tensor(uint16)' : np.uint16,
-    'tensor(int32)'  : np.int32,
-    'tensor(uint32)' : np.uint32,
-    'tensor(int64)'  : np.int64,
-    'tensor(uint64)' : np.uint64,
-
-    'tensor(bool)'   : np.bool,
-    'tensor(string)' : np.object
+    'tensor(float)': np.float32,
+    'tensor(double)': np.float64,
+    'tensor(int8)': np.int8,
+    'tensor(uint8)': np.uint8,
+    'tensor(int16)': np.int16,
+    'tensor(uint16)': np.uint16,
+    'tensor(int32)': np.int32,
+    'tensor(uint32)': np.uint32,
+    'tensor(int64)': np.int64,
+    'tensor(uint64)': np.uint64,
+    'tensor(bool)': np.bool,
+    'tensor(string)': np.object
 }
+
 
 class DataFrameTool():
     """
     This is a utility class used to run a model with pandas.DataFrame input
     """
+
     def __init__(self, model_path, sess_options=None):
         """
         :param model_path: path to the model to be loaded
@@ -75,17 +75,16 @@ class DataFrameTool():
         """
         expected_type = types_dict[input_meta.type]
         if input_meta.type == 'tensor(string)':
-           return
+            return
         elif expected_type == col_type:
-           return
+            return
         elif expected_type in ort_float_set and str(col_type) in pd_float_set:
-           return
+            return
         elif expected_type in ort_int_set and str(col_type) in pd_int_set:
-           return
+            return
 
         raise TypeError("Input {} requires type {} unable to cast column type {} ".format(
             input_meta.name, expected_type, col_type))
-
 
     def _process_input_list(self, df, input_metas, require):
         """
@@ -110,10 +109,10 @@ class DataFrameTool():
                 feeds[input_meta.name] = self._reshape_input(input_array, input_meta.shape)
 
             elif require:
-                raise RuntimeError("This model requires input {} of type {} but it is not found in the DataFrame".format(
-                               input_meta.name, types_dict[input_meta.type]))
+                raise RuntimeError(
+                    "This model requires input {} of type {} but it is not found in the DataFrame".format(
+                        input_meta.name, types_dict[input_meta.type]))
         return feeds
-
 
     def _get_input_feeds(self, df, sess):
         """
@@ -161,6 +160,5 @@ class DataFrameTool():
 
         sess.run([output_name], {input_name: x})
         """
-        input_feed = self._get_input_feeds(df, self._sess);
+        input_feed = self._get_input_feeds(df, self._sess)
         return self._sess.run(output_names, input_feed, run_options)
-

--- a/onnxruntime/python/tools/featurizer_ops/data_frame_tool_test.py
+++ b/onnxruntime/python/tools/featurizer_ops/data_frame_tool_test.py
@@ -11,11 +11,11 @@ from data_frame_tool import DataFrameTool
 import os
 import sys
 
+
 def main():
     parser = argparse.ArgumentParser(description='Test Feed Inputs utility')
     parser.add_argument('model_path', help='model path')
-    parser.add_argument('-profile', action='store_true',
-                        help='enable chrome timeline trace profiling.')
+    parser.add_argument('-profile', action='store_true', help='enable chrome timeline trace profiling.')
     args = parser.parse_args()
 
     # Create options and the tool
@@ -25,11 +25,15 @@ def main():
     df_tool = DataFrameTool(args.model_path, sess_options)
 
     # Create a DataFrame that holds 3 inputs, string, bool, float in their respective columns
-    df = pd.DataFrame([['string_input', 3.25, 8, 16, 32, 64, True, 0.25]], 
-                      columns=['StringInput', 'DoubleInput', 'Int8Input', 'Int16Input', 'Int32Input', 'Int64Input', 'BoolInput', 'Float32Input'])
+    df = pd.DataFrame([['string_input', 3.25, 8, 16, 32, 64, True, 0.25]],
+                      columns=[
+                          'StringInput', 'DoubleInput', 'Int8Input', 'Int16Input', 'Int32Input', 'Int64Input',
+                          'BoolInput', 'Float32Input'
+                      ])
 
     outputs = df_tool.execute(df, [])
     print('Outputs: ', outputs)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/onnxruntime/python/tools/onnxruntime_test.py
+++ b/onnxruntime/python/tools/onnxruntime_test.py
@@ -10,11 +10,7 @@ import os
 import sys
 from timeit import default_timer as timer
 
-float_dict = {
-    'tensor(float16)': 'float16',
-    'tensor(float)': 'float32',
-    'tensor(double)': 'float64'
-}
+float_dict = {'tensor(float16)': 'float16', 'tensor(float)': 'float32', 'tensor(double)': 'float64'}
 
 integer_dict = {
     'tensor(int32)': 'int32',
@@ -32,18 +28,14 @@ integer_dict = {
 def main():
     parser = argparse.ArgumentParser(description='Simple ONNX Runtime Test Tool.')
     parser.add_argument('model_path', help='model path')
-    parser.add_argument('num_iters', nargs='?', type=int,
-                        default=1000, help='model run iterations. default=1000')
-    parser.add_argument('--debug', action='store_true',
-                        help='pause execution to allow attaching a debugger.')
-    parser.add_argument('--profile', action='store_true',
-                        help='enable chrome timeline trace profiling.')
+    parser.add_argument('num_iters', nargs='?', type=int, default=1000, help='model run iterations. default=1000')
+    parser.add_argument('--debug', action='store_true', help='pause execution to allow attaching a debugger.')
+    parser.add_argument('--profile', action='store_true', help='enable chrome timeline trace profiling.')
     args = parser.parse_args()
     iters = args.num_iters
 
     if args.debug:
-        print("Pausing execution ready for debugger to attach to pid: {}".format(
-            os.getpid()))
+        print("Pausing execution ready for debugger to attach to pid: {}".format(os.getpid()))
         print("Press key to continue.")
         sys.stdin.read(1)
 
@@ -61,17 +53,14 @@ def main():
         # replace any symbolic dimensions (value is None) with 1
         shape = [dim if dim else 1 for dim in input_meta.shape]
         if input_meta.type in float_dict:
-            feeds[input_meta.name] = np.random.rand(
-                *shape).astype(float_dict[input_meta.type])
+            feeds[input_meta.name] = np.random.rand(*shape).astype(float_dict[input_meta.type])
         elif input_meta.type in integer_dict:
-            feeds[input_meta.name] = np.random.uniform(
-                high=1000, size=tuple(shape)).astype(integer_dict[input_meta.type])
+            feeds[input_meta.name] = np.random.uniform(high=1000,
+                                                       size=tuple(shape)).astype(integer_dict[input_meta.type])
         elif input_meta.type == 'tensor(bool)':
-            feeds[input_meta.name] = np.random.randint(
-                2, size=tuple(shape)).astype('bool')
+            feeds[input_meta.name] = np.random.randint(2, size=tuple(shape)).astype('bool')
         else:
-            print("unsupported input type {} for input {}".format(
-                input_meta.type, input_meta.name))
+            print("unsupported input type {} for input {}".format(input_meta.type, input_meta.name))
             sys.exit(-1)
 
     # Starting with IR4 some initializers provide default values
@@ -80,17 +69,14 @@ def main():
     for initializer in sess.get_overridable_initializers():
         shape = [dim if dim else 1 for dim in initializer.shape]
         if initializer.type in float_dict:
-            feeds[initializer.name] = np.random.rand(
-                *shape).astype(float_dict[initializer.type])
+            feeds[initializer.name] = np.random.rand(*shape).astype(float_dict[initializer.type])
         elif initializer.type in integer_dict:
-            feeds[initializer.name] = np.random.uniform(
-                high=1000, size=tuple(shape)).astype(integer_dict[initializer.type])
+            feeds[initializer.name] = np.random.uniform(high=1000,
+                                                        size=tuple(shape)).astype(integer_dict[initializer.type])
         elif initializer.type == 'tensor(bool)':
-            feeds[initializer.name] = np.random.randint(
-                2, size=tuple(shape)).astype('bool')
+            feeds[initializer.name] = np.random.randint(2, size=tuple(shape)).astype('bool')
         else:
-            print("unsupported initializer type {} for initializer {}".format(
-                initializer.type, initializer.name))
+            print("unsupported initializer type {} for initializer {}".format(initializer.type, initializer.name))
             sys.exit(-1)
 
     start = timer()
@@ -101,7 +87,7 @@ def main():
     print("model: {}".format(meta.graph_name))
     print("version: {}".format(meta.version))
     print("iterations: {}".format(iters))
-    print("avg latency: {} ms".format(((end - start)*1000)/iters))
+    print("avg latency: {} ms".format(((end - start) * 1000) / iters))
 
     if args.profile:
         trace_file = sess.end_profiling()

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -39,25 +39,19 @@ def augment_graph(model):
             input_name = node.output[0]
             # Adding ReduceMin nodes
             reduce_min_name = node.name + '_ReduceMin'
-            reduce_min_node = onnx.helper.make_node(
-                'ReduceMin', [input_name], [input_name + '_ReduceMin'],
-                reduce_min_name,
-                keepdims=0)
+            reduce_min_node = onnx.helper.make_node('ReduceMin', [input_name], [input_name + '_ReduceMin'],
+                                                    reduce_min_name,
+                                                    keepdims=0)
             added_nodes.append(reduce_min_node)
-            added_outputs.append(
-                helper.make_tensor_value_info(reduce_min_node.output[0],
-                                              TensorProto.FLOAT, ()))
+            added_outputs.append(helper.make_tensor_value_info(reduce_min_node.output[0], TensorProto.FLOAT, ()))
 
             # Adding ReduceMax nodes
             reduce_max_name = node.name + '_ReduceMax'
-            reduce_max_node = onnx.helper.make_node(
-                'ReduceMax', [input_name], [input_name + '_ReduceMax'],
-                reduce_max_name,
-                keepdims=0)
+            reduce_max_node = onnx.helper.make_node('ReduceMax', [input_name], [input_name + '_ReduceMax'],
+                                                    reduce_max_name,
+                                                    keepdims=0)
             added_nodes.append(reduce_max_node)
-            added_outputs.append(
-                helper.make_tensor_value_info(reduce_max_node.output[0],
-                                              TensorProto.FLOAT, ()))
+            added_outputs.append(helper.make_tensor_value_info(reduce_max_node.output[0], TensorProto.FLOAT, ()))
     model.graph.node.extend(added_nodes)
     model.graph.output.extend(added_outputs)
     return model
@@ -85,32 +79,21 @@ def get_intermediate_outputs(model_path, session, inputs, calib_mode='naive'):
     num_model_outputs = len(model.graph.output)
     num_inputs = len(inputs)
     input_name = session.get_inputs()[0].name
-    intermediate_outputs = [
-        session.run([], {input_name: inputs[i]}) for i in range(num_inputs)
-    ]
+    intermediate_outputs = [session.run([], {input_name: inputs[i]}) for i in range(num_inputs)]
 
     # Creating dictionary with output results from multiple test inputs
-    node_output_names = [
-        session.get_outputs()[i].name
-        for i in range(len(intermediate_outputs[0]))
-    ]
-    output_dicts = [
-        dict(zip(node_output_names, intermediate_outputs[i]))
-        for i in range(num_inputs)
-    ]
+    node_output_names = [session.get_outputs()[i].name for i in range(len(intermediate_outputs[0]))]
+    output_dicts = [dict(zip(node_output_names, intermediate_outputs[i])) for i in range(num_inputs)]
     merged_dict = {}
     for d in output_dicts:
         for k, v in d.items():
             merged_dict.setdefault(k, []).append(v)
     added_node_output_names = node_output_names[num_model_outputs:]
-    node_names = [
-        added_node_output_names[i].rpartition('_')[0]
-        for i in range(0, len(added_node_output_names), 2)
-    ]  # output names
+    node_names = [added_node_output_names[i].rpartition('_')[0] for i in range(0, len(added_node_output_names), 2)
+                 ]  # output names
 
     # Characterizing distribution of a node's values across test data sets
-    clean_merged_dict = dict((i, merged_dict[i]) for i in merged_dict
-                             if i != list(merged_dict.keys())[0])
+    clean_merged_dict = dict((i, merged_dict[i]) for i in merged_dict if i != list(merged_dict.keys())[0])
     if calib_mode == 'naive':
         pairs = [
             tuple([
@@ -119,9 +102,7 @@ def get_intermediate_outputs(model_path, session, inputs, calib_mode='naive'):
             ]) for i in range(0, len(added_node_output_names), 2)
         ]
     else:
-        raise ValueError(
-            'Unknown value for calib_mode. Currently only naive mode is supported.'
-        )
+        raise ValueError('Unknown value for calib_mode. Currently only naive mode is supported.')
 
     final_dict = dict(zip(node_names, pairs))
     return final_dict
@@ -179,18 +160,15 @@ def calculate_quantization_params(model, quantization_thresholds):
             }
     '''
     if quantization_thresholds is None:
-        raise ValueError(
-            'quantization thresholds is required to calculate quantization params (zero point and scale)'
-        )
+        raise ValueError('quantization thresholds is required to calculate quantization params (zero point and scale)')
 
     quantization_params = {}
     for index, node in enumerate(model.graph.node):
         node_output_name = node.output[0]
         if node_output_name in quantization_thresholds:
             node_thresholds = quantization_thresholds[node_output_name]
-            node_params = calculate_scale_zeropoint(
-                node, model.graph.node[index + 1], node_thresholds[0],
-                node_thresholds[1])
+            node_params = calculate_scale_zeropoint(node, model.graph.node[index + 1], node_thresholds[0],
+                                                    node_thresholds[1])
             quantization_params[node_output_name] = node_params
 
     return quantization_params
@@ -221,38 +199,30 @@ def load_pb_file(data_file_name, size_limit, samples, channels, height, width):
                 inputs = inputs[:size_limit]
                 dataset_size = size_limit
 
-            inputs = inputs.reshape(dataset_size, samples, channels, height,
-                                    width)
+            inputs = inputs.reshape(dataset_size, samples, channels, height, width)
         except:
             sys.exit(
-                "Input .pb file contains incorrect input size. \nThe required size is: (%s). The real size is: (%s)"
-                % ((dataset_size, samples, channels, height, width), shape))
+                "Input .pb file contains incorrect input size. \nThe required size is: (%s). The real size is: (%s)" %
+                ((dataset_size, samples, channels, height, width), shape))
 
     return inputs
 
 
 def main():
     # Parsing command-line arguments
-    parser = argparse.ArgumentParser(
-        description='parsing model and test data set paths')
+    parser = argparse.ArgumentParser(description='parsing model and test data set paths')
     parser.add_argument('--model_path', required=True)
     parser.add_argument('--dataset_path', required=True)
-    parser.add_argument('--output_model_path',
+    parser.add_argument('--output_model_path', type=str, default='calibrated_quantized_model.onnx')
+    parser.add_argument('--dataset_size',
+                        type=int,
+                        default=0,
+                        help="Number of images or tensors to load. Default is 0 which means all samples")
+    parser.add_argument('--data_preprocess',
                         type=str,
-                        default='calibrated_quantized_model.onnx')
-    parser.add_argument(
-        '--dataset_size',
-        type=int,
-        default=0,
-        help=
-        "Number of images or tensors to load. Default is 0 which means all samples"
-    )
-    parser.add_argument(
-        '--data_preprocess',
-        type=str,
-        required=True,
-        choices=['preprocess_method1', 'preprocess_method2', 'None'],
-        help="Refer to Readme.md for guidance on choosing this option.")
+                        required=True,
+                        choices=['preprocess_method1', 'preprocess_method2', 'None'],
+                        help="Refer to Readme.md for guidance on choosing this option.")
     args = parser.parse_args()
     model_path = args.model_path
     output_model_path = args.output_model_path
@@ -272,20 +242,15 @@ def main():
 
     # Generating inputs for quantization
     if args.data_preprocess == "None":
-        inputs = load_pb_file(images_folder, args.dataset_size, samples,
-                              channels, height, width)
+        inputs = load_pb_file(images_folder, args.dataset_size, samples, channels, height, width)
     else:
-        inputs = load_batch(images_folder, height, width, size_limit,
-                            args.data_preprocess)
+        inputs = load_batch(images_folder, height, width, size_limit, args.data_preprocess)
     print(inputs.shape)
-    dict_for_quantization = get_intermediate_outputs(model_path, session,
-                                                     inputs, calib_mode)
-    quantization_params_dict = calculate_quantization_params(
-        model, quantization_thresholds=dict_for_quantization)
-    calibrated_quantized_model = quantize(
-        onnx.load(model_path),
-        quantization_mode=QuantizationMode.QLinearOps,
-        quantization_params=quantization_params_dict)
+    dict_for_quantization = get_intermediate_outputs(model_path, session, inputs, calib_mode)
+    quantization_params_dict = calculate_quantization_params(model, quantization_thresholds=dict_for_quantization)
+    calibrated_quantized_model = quantize(onnx.load(model_path),
+                                          quantization_mode=QuantizationMode.QLinearOps,
+                                          quantization_params=quantization_params_dict)
     onnx.save(calibrated_quantized_model, output_model_path)
 
     print("Calibrated, quantized model saved.")

--- a/onnxruntime/python/tools/quantization/data_preprocess.py
+++ b/onnxruntime/python/tools/quantization/data_preprocess.py
@@ -17,10 +17,7 @@ def set_preprocess(preprocess_func_name):
         parameter preprocess_func_name: name of the preprocess function 
         return: function pointer 
     '''
-    funcdict = {
-        'preprocess_method1': preprocess_method1,
-        'preprocess_method2': preprocess_method2
-    }
+    funcdict = {'preprocess_method1': preprocess_method1, 'preprocess_method2': preprocess_method2}
     return funcdict[preprocess_func_name]
 
 
@@ -58,11 +55,7 @@ def preprocess_method2(image_filepath, height, width):
     return nchw_data
 
 
-def load_batch(images_folder,
-               height,
-               width,
-               preprocess_func_name,
-               size_limit=0):
+def load_batch(images_folder, height, width, preprocess_func_name, size_limit=0):
     '''
     Loads a batch of images
     parameter images_folder: path to folder storing images
@@ -84,7 +77,5 @@ def load_batch(images_folder,
         image_filepath = images_folder + '/' + image_name
         nchw_data = preprocess_func(image_filepath, height, width)
         unconcatenated_batch_data.append(nchw_data)
-    batch_data = np.concatenate(np.expand_dims(unconcatenated_batch_data,
-                                               axis=0),
-                                axis=0)
+    batch_data = np.concatenate(np.expand_dims(unconcatenated_batch_data, axis=0), axis=0)
     return batch_data

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -45,8 +45,9 @@ class QuantizationMode():
 
 
 quantization_modes = [
-    getattr(QuantizationMode, attr) for attr in dir(QuantizationMode) if
-    not callable(getattr(QuantizationMode, attr)) and not attr.startswith("__")
+    getattr(QuantizationMode, attr)
+    for attr in dir(QuantizationMode)
+    if not callable(getattr(QuantizationMode, attr)) and not attr.startswith("__")
 ]
 
 
@@ -54,6 +55,7 @@ class QuantizedInitializer:
     '''
         Represents a linearly quantized weight input from ONNX operators
     '''
+
     def __init__(self,
                  name,
                  initializer,
@@ -89,6 +91,7 @@ class QuantizedValue:
     '''
     Represents a linearly quantized value (input\output\intializer)
     '''
+
     def __init__(self,
                  name,
                  new_quantized_name,
@@ -136,12 +139,9 @@ def quantize_data(data, quantize_range, qType):
     elif qType == onnx_proto.TensorProto.UINT8:
         scale = (float(rmax) - rmin) / quantize_range if rmin != rmax else 1
         zero_point = round((0 - rmin) / scale)  # round to nearest integer
-        quantized_data = ((np.asarray(data) / scale).round() +
-                          zero_point).astype('B')  # unsigned byte type
+        quantized_data = ((np.asarray(data) / scale).round() + zero_point).astype('B')  # unsigned byte type
     else:
-        raise ValueError(
-            "Unexpected data type {} requested. Only INT8 and UINT8 are supported."
-        )
+        raise ValueError("Unexpected data type {} requested. Only INT8 and UINT8 are supported.")
 
     return rmin, rmax, zero_point, scale, quantized_data
 
@@ -153,8 +153,7 @@ def _attribute_to_kwarg(attribute):
         :return: attribute in {key: value} format.
     '''
     if (attribute.type == 0):
-        raise ValueError('attribute {} does not have type specified.'.format(
-            attribute.name))
+        raise ValueError('attribute {} does not have type specified.'.format(attribute.name))
 
     # Based on attribute type definitions from AttributeProto
     # definition in https://github.com/onnx/onnx/blob/master/onnx/onnx.proto
@@ -179,8 +178,7 @@ def _attribute_to_kwarg(attribute):
     elif (attribute.type == 10):
         value = attribute.graphs
     else:
-        raise ValueError('attribute {} has unsupported type {}.'.format(
-            attribute.name, attribute.type))
+        raise ValueError('attribute {} has unsupported type {}.'.format(attribute.name, attribute.type))
 
     return {attribute.name: value}
 
@@ -266,9 +264,9 @@ def _find_nodes_using_initializer(graph, initializer):
 
 
 class ONNXQuantizer:
-    def __init__(self, model, per_channel, mode, static, fuse_dynamic_quant,
-                 weight_qType, input_qType, quantization_params,
-                 nodes_to_quantize):
+
+    def __init__(self, model, per_channel, mode, static, fuse_dynamic_quant, weight_qType, input_qType,
+                 quantization_params, nodes_to_quantize):
         self.model = model
         self.per_channel = per_channel  # weight-pack per channel
         self.mode = mode  # QuantizationMode.Value
@@ -280,8 +278,7 @@ class ONNXQuantizer:
         self.nodes_to_quantize = nodes_to_quantize  # specific nodes to quantize
 
         if not self.mode in quantization_modes:
-            raise ValueError('unsupported quantization mode {}'.format(
-                self.mode))
+            raise ValueError('unsupported quantization mode {}'.format(self.mode))
 
         # QuantizeRange tensor name and zero tensor name for scale and zero point calculation.
         # Used when static is False
@@ -329,12 +326,10 @@ class ONNXQuantizer:
 
         # update opset.
         opset_info = next(
-            (opset for opset in self.model.opset_import
-             if opset.domain == '' or opset.domain == onnx_domain), None)
+            (opset for opset in self.model.opset_import if opset.domain == '' or opset.domain == onnx_domain), None)
         if opset_info is not None:
             self.model.opset_import.remove(opset_info)
-        self.model.opset_import.extend(
-            [onnx.helper.make_opsetid(onnx_domain, onnx_op_set_version)])
+        self.model.opset_import.extend([onnx.helper.make_opsetid(onnx_domain, onnx_op_set_version)])
 
         return self.model
 
@@ -347,8 +342,8 @@ class ONNXQuantizer:
             weights = onnx.numpy_helper.to_array(initializer)
         else:
             raise ValueError(
-                'Model contains conv operator weights in {}. Only float type quantization is supported.'
-                .format(type_to_name[initializer.data_type]))
+                'Model contains conv operator weights in {}. Only float type quantization is supported.'.format(
+                    type_to_name[initializer.data_type]))
         return weights
 
     def _remove_quantized_weights(self):
@@ -363,14 +358,12 @@ class ONNXQuantizer:
 
             # Removing input weight to a convolution
             try:
-                weight_input = next(val for val in self.model.graph.input
-                                    if val.name == weight.name)
+                weight_input = next(val for val in self.model.graph.input if val.name == weight.name)
                 self.model.graph.input.remove(weight_input)
             except StopIteration:
                 if self.model.ir_version < 4:
-                    raise ValueError(
-                        'invalid weight name {} found in the graph (not a graph input) '
-                        .format(weight.name))
+                    raise ValueError('invalid weight name {} found in the graph (not a graph input) '.format(
+                        weight.name))
 
     def _update_graph(self, weight):
         '''
@@ -386,28 +379,22 @@ class ONNXQuantizer:
         zero_point_name = quantized_value.zp_name
 
         # Update packed weight, zero point, and scale initializers
-        packed_weight_np_data = np.asarray(
-            weight.quantized_data,
-            dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[weight.qType]).reshape(
-                weight.initializer.dims)
-        packed_weight_initializer = onnx.numpy_helper.from_array(
-            packed_weight_np_data, packed_weight_name)
+        packed_weight_np_data = np.asarray(weight.quantized_data,
+                                           dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[weight.qType]).reshape(
+                                               weight.initializer.dims)
+        packed_weight_initializer = onnx.numpy_helper.from_array(packed_weight_np_data, packed_weight_name)
 
         if weight.axis is not None:
             zero_scale_shape = [weight.initializer.dims[weight.axis]]
         else:  # scale and zero point must be scalar
             zero_scale_shape = []
         zero_point_type = weight.qType
-        scale_initializer = onnx.helper.make_tensor(
-            scale_name, onnx_proto.TensorProto.FLOAT, zero_scale_shape,
-            weight.scales)
-        zero_initializer = onnx.helper.make_tensor(zero_point_name,
-                                                   zero_point_type,
-                                                   zero_scale_shape,
+        scale_initializer = onnx.helper.make_tensor(scale_name, onnx_proto.TensorProto.FLOAT, zero_scale_shape,
+                                                    weight.scales)
+        zero_initializer = onnx.helper.make_tensor(zero_point_name, zero_point_type, zero_scale_shape,
                                                    weight.zero_points)
 
-        self.model.graph.initializer.extend(
-            [packed_weight_initializer, scale_initializer, zero_initializer])
+        self.model.graph.initializer.extend([packed_weight_initializer, scale_initializer, zero_initializer])
 
         self._quantized_weights.append(weight)
 
@@ -418,12 +405,10 @@ class ONNXQuantizer:
             :return: Weight class with quantization information
         '''
         weights_data = self.find_weight_data(initializer)
-        rmin, rmax, zero_point, scale, quantized_weights_data = quantize_data(
-            weights_data.flatten().tolist(), _get_qrange_for_qType(qType),
-            qType)
+        rmin, rmax, zero_point, scale, quantized_weights_data = quantize_data(weights_data.flatten().tolist(),
+                                                                              _get_qrange_for_qType(qType), qType)
         weight = QuantizedInitializer(initializer.name,
-                                      initializer, [rmin], [rmax],
-                                      [zero_point], [scale],
+                                      initializer, [rmin], [rmax], [zero_point], [scale],
                                       weights_data,
                                       quantized_weights_data,
                                       axis=None,
@@ -431,12 +416,8 @@ class ONNXQuantizer:
 
         # Log entry for this quantized weight
         assert (weight.name not in self.quantized_value_map)
-        quantized_value = QuantizedValue(weight.name,
-                                         weight.name + "_quantized",
-                                         weight.name + "_scale",
-                                         weight.name + "_zero_point",
-                                         QuantizedValueType.Initializer, None,
-                                         qType)
+        quantized_value = QuantizedValue(weight.name, weight.name + "_quantized", weight.name + "_scale",
+                                         weight.name + "_zero_point", QuantizedValueType.Initializer, None, qType)
         self.quantized_value_map[weight.name] = quantized_value
 
         return weight
@@ -464,8 +445,7 @@ class ONNXQuantizer:
             # for each channel, compute quantization data. Assuming (M x C/group x kH x kW)
             per_channel_data = np_data[i, :, :, :].flatten()
             rmin, rmax, zero_point, scale, quantized_per_channel_data = quantize_data(
-                per_channel_data.flatten().tolist(),
-                _get_qrange_for_qType(qType), qType)
+                per_channel_data.flatten().tolist(), _get_qrange_for_qType(qType), qType)
             rmin_list.append(rmin)
             rmax_list.append(rmax)
             zero_point_list.append(zero_point)
@@ -475,34 +455,24 @@ class ONNXQuantizer:
         # combine per_channel_data into one
         reshape_dims = list(initializer.dims)  # deep copy
         reshape_dims[channel_index] = 1  # only one per channel for reshape
-        quantized_weights = np.asarray(
-            quantized_per_channel_data_list[0]).reshape(reshape_dims)
+        quantized_weights = np.asarray(quantized_per_channel_data_list[0]).reshape(reshape_dims)
         for i in range(1, len(quantized_per_channel_data_list)):
-            channel_weights = np.asarray(
-                quantized_per_channel_data_list[i]).reshape(reshape_dims)
-            quantized_weights = np.concatenate(
-                (quantized_weights, channel_weights), axis=0)
+            channel_weights = np.asarray(quantized_per_channel_data_list[i]).reshape(reshape_dims)
+            quantized_weights = np.concatenate((quantized_weights, channel_weights), axis=0)
 
-        weight = QuantizedInitializer(initializer.name, initializer, rmin_list,
-                                      rmax_list, zero_point_list, scale_list,
+        weight = QuantizedInitializer(initializer.name, initializer, rmin_list, rmax_list, zero_point_list, scale_list,
                                       weights,
-                                      quantized_weights.flatten().tolist(),
-                                      channel_index, qType)
+                                      quantized_weights.flatten().tolist(), channel_index, qType)
 
         # Make entry for this quantized weight
         assert (weight.name not in self.quantized_value_map)
-        quantized_value = QuantizedValue(weight.name,
-                                         weight.name + "_quantized",
-                                         weight.name + "_scale",
-                                         weight.name + "_zero_point",
-                                         QuantizedValueType.Initializer, None,
-                                         qType)
+        quantized_value = QuantizedValue(weight.name, weight.name + "_quantized", weight.name + "_scale",
+                                         weight.name + "_zero_point", QuantizedValueType.Initializer, None, qType)
         self.quantized_value_map[weight.name] = quantized_value
 
         return weight
 
-    def _get_dynamic_input_quantization_params(self, input_name, nodes_list,
-                                               qType):
+    def _get_dynamic_input_quantization_params(self, input_name, nodes_list, qType):
         '''
         Create nodes for dynamic quantization of input and add them to nodes_list.
             parameter input_name: Name of the input.
@@ -511,14 +481,11 @@ class ONNXQuantizer:
             return: scale_name, zero_point_name, scale_shape, zero_point_shape.
         '''
         if qType == onnx_proto.TensorProto.INT8:
-            return self._get_dynamic_input_quantization_params_int8(
-                input_name, nodes_list)
+            return self._get_dynamic_input_quantization_params_int8(input_name, nodes_list)
 
-        return self._get_dynamic_input_quantization_params_uint8(
-            input_name, nodes_list)
+        return self._get_dynamic_input_quantization_params_uint8(input_name, nodes_list)
 
-    def _get_dynamic_input_quantization_params_int8(self, input_name,
-                                                    nodes_list):
+    def _get_dynamic_input_quantization_params_int8(self, input_name, nodes_list):
         '''
         Create nodes for dynamic quantization of input to int8 and add them to nodes_list
             parameter input_name: Name of the input.
@@ -531,15 +498,13 @@ class ONNXQuantizer:
         input_scale_name = input_name + "_scale"
 
         reduce_min_name = input_name + "_ReduceMin"
-        reduce_min_node = onnx.helper.make_node("ReduceMin", [input_name],
-                                                [reduce_min_name + ":0"],
+        reduce_min_node = onnx.helper.make_node("ReduceMin", [input_name], [reduce_min_name + ":0"],
                                                 reduce_min_name,
                                                 keepdims=0)
         nodes_list.append(reduce_min_node)
 
         reduce_max_name = input_name + "_ReduceMax"
-        reduce_max_node = onnx.helper.make_node("ReduceMax", [input_name],
-                                                [reduce_max_name + ":0"],
+        reduce_max_node = onnx.helper.make_node("ReduceMax", [input_name], [reduce_max_name + ":0"],
                                                 reduce_max_name,
                                                 keepdims=0)
         nodes_list.append(reduce_max_node)
@@ -547,43 +512,33 @@ class ONNXQuantizer:
         # Compute scale
         #   Find abs(rmin)
         reduce_min_abs_name = reduce_min_name + "_Abs"
-        reduce_min_abs_node = onnx.helper.make_node(
-            "Abs", [reduce_min_node.output[0]], [reduce_min_abs_name + ":0"],
-            reduce_min_abs_name)
+        reduce_min_abs_node = onnx.helper.make_node("Abs", [reduce_min_node.output[0]], [reduce_min_abs_name + ":0"],
+                                                    reduce_min_abs_name)
         nodes_list.append(reduce_min_abs_node)
         #   Find abs(rmax)
         reduce_max_abs_name = reduce_max_name + "_Abs"
-        reduce_max_abs_node = onnx.helper.make_node(
-            "Abs", [reduce_max_node.output[0]], [reduce_max_abs_name + ":0"],
-            reduce_max_abs_name)
+        reduce_max_abs_node = onnx.helper.make_node("Abs", [reduce_max_node.output[0]], [reduce_max_abs_name + ":0"],
+                                                    reduce_max_abs_name)
         nodes_list.append(reduce_max_abs_node)
         #   Compute max of abs(rmin) and abs(rmax)
         abs_max_name = input_name + "_Abs_Max"
-        abs_max_node = onnx.helper.make_node(
-            "Max",
-            [reduce_min_abs_node.output[0], reduce_max_abs_node.output[0]],
-            [abs_max_name + ":0"], abs_max_name)
+        abs_max_node = onnx.helper.make_node("Max", [reduce_min_abs_node.output[0], reduce_max_abs_node.output[0]],
+                                             [abs_max_name + ":0"], abs_max_name)
         nodes_list.append(abs_max_node)
         #   and divide by (quantize_range/2.0) which will be equal to max(...)*2.0/quantize_range
-        _add_initializer_if_not_present(self.model.graph,
-                                        self.fixed_qrange_int8_name,
-                                        [_get_qrange_for_qType(qType) / 2.0],
-                                        [], onnx_proto.TensorProto.FLOAT)
+        _add_initializer_if_not_present(self.model.graph, self.fixed_qrange_int8_name,
+                                        [_get_qrange_for_qType(qType) / 2.0], [], onnx_proto.TensorProto.FLOAT)
         scale_div_name = input_name + "scale_Div"
-        scale_div_node = onnx.helper.make_node(
-            "Div", [abs_max_node.output[0], self.fixed_qrange_int8_name],
-            [input_scale_name], scale_div_name)
+        scale_div_node = onnx.helper.make_node("Div", [abs_max_node.output[0], self.fixed_qrange_int8_name],
+                                               [input_scale_name], scale_div_name)
         nodes_list.append(scale_div_node)
 
         # Zero point
-        _add_initializer_if_not_present(self.model.graph,
-                                        self.fixed_zero_zp_name, [0], [],
-                                        qType)
+        _add_initializer_if_not_present(self.model.graph, self.fixed_zero_zp_name, [0], [], qType)
 
         return input_scale_name, self.fixed_zero_zp_name, [], []
 
-    def _get_dynamic_input_quantization_params_uint8(self, input_name,
-                                                     nodes_list):
+    def _get_dynamic_input_quantization_params_uint8(self, input_name, nodes_list):
         '''
         Create nodes for dynamic quantization of input to uint8 and add them to nodes_list
             parameter input_name: Name of the input.
@@ -596,68 +551,52 @@ class ONNXQuantizer:
         input_zp_name = input_name + "_zero_point"
 
         reduce_min_name = input_name + "_ReduceMin"
-        reduce_min_node = onnx.helper.make_node("ReduceMin", [input_name],
-                                                [reduce_min_name + ":0"],
+        reduce_min_node = onnx.helper.make_node("ReduceMin", [input_name], [reduce_min_name + ":0"],
                                                 reduce_min_name,
                                                 keepdims=0)
         nodes_list.append(reduce_min_node)
 
         reduce_max_name = input_name + "_ReduceMax"
-        reduce_max_node = onnx.helper.make_node("ReduceMax", [input_name],
-                                                [reduce_max_name + ":0"],
+        reduce_max_node = onnx.helper.make_node("ReduceMax", [input_name], [reduce_max_name + ":0"],
                                                 reduce_max_name,
                                                 keepdims=0)
         nodes_list.append(reduce_max_node)
 
         # Add tensors for quantize range and zero value.
-        _add_initializer_if_not_present(self.model.graph,
-                                        self.fixed_qrange_uint8_name,
-                                        [_get_qrange_for_qType(qType)], [],
-                                        onnx_proto.TensorProto.FLOAT)
-        _add_initializer_if_not_present(self.model.graph, self.fixed_zero_name,
-                                        [0.0], [],
-                                        onnx_proto.TensorProto.FLOAT)
+        _add_initializer_if_not_present(self.model.graph, self.fixed_qrange_uint8_name, [_get_qrange_for_qType(qType)],
+                                        [], onnx_proto.TensorProto.FLOAT)
+        _add_initializer_if_not_present(self.model.graph, self.fixed_zero_name, [0.0], [], onnx_proto.TensorProto.FLOAT)
 
         # Compute Scale
         #   Subtract rmax and rmin
         scale_sub_name = input_name + "_scale_Sub"
-        scale_sub_node = onnx.helper.make_node(
-            "Sub", [reduce_max_node.output[0], reduce_min_node.output[0]],
-            [scale_sub_name + ":0"], scale_sub_name)
+        scale_sub_node = onnx.helper.make_node("Sub", [reduce_max_node.output[0], reduce_min_node.output[0]],
+                                               [scale_sub_name + ":0"], scale_sub_name)
         nodes_list.append(scale_sub_node)
         #   and divide by quantize range
         scale_div_name = input_name + "_scale_Div"
-        scale_div_node = onnx.helper.make_node(
-            "Div", [scale_sub_node.output[0], self.fixed_qrange_uint8_name],
-            [input_scale_name], scale_div_name)
+        scale_div_node = onnx.helper.make_node("Div", [scale_sub_node.output[0], self.fixed_qrange_uint8_name],
+                                               [input_scale_name], scale_div_name)
         nodes_list.append(scale_div_node)
 
         # Compute zero point
         #   Subtract zero and rmin
         zp_sub_name = input_name + "_zero_point_Sub"
-        zp_sub_node = onnx.helper.make_node(
-            "Sub", [self.fixed_zero_name, reduce_min_node.output[0]],
-            [zp_sub_name + ":0"], zp_sub_name)
+        zp_sub_node = onnx.helper.make_node("Sub", [self.fixed_zero_name, reduce_min_node.output[0]],
+                                            [zp_sub_name + ":0"], zp_sub_name)
         nodes_list.append(zp_sub_node)
         #   Divide by scale
         zp_div_name = input_name + "_zero_point_Div"
-        zp_div_node = onnx.helper.make_node(
-            "Div", [zp_sub_node.output[0], input_scale_name],
-            [zp_div_name + ":0"], zp_div_name)
+        zp_div_node = onnx.helper.make_node("Div", [zp_sub_node.output[0], input_scale_name], [zp_div_name + ":0"],
+                                            zp_div_name)
         nodes_list.append(zp_div_node)
         #   Compute floor
         zp_floor_name = input_name + "_zero_point_Floor"
-        zp_floor_node = onnx.helper.make_node("Floor", zp_div_node.output,
-                                              [zp_floor_name + ":0"],
-                                              zp_floor_name)
+        zp_floor_node = onnx.helper.make_node("Floor", zp_div_node.output, [zp_floor_name + ":0"], zp_floor_name)
         nodes_list.append(zp_floor_node)
         #   Cast to integer
         zp_cast_name = input_name + "_zero_point_Cast"
-        zp_cast_node = onnx.helper.make_node("Cast",
-                                             zp_floor_node.output,
-                                             [input_zp_name],
-                                             zp_cast_name,
-                                             to=qType)
+        zp_cast_node = onnx.helper.make_node("Cast", zp_floor_node.output, [input_zp_name], zp_cast_name, to=qType)
         nodes_list.append(zp_cast_node)
 
         return input_scale_name, input_zp_name, [], []
@@ -674,19 +613,15 @@ class ONNXQuantizer:
             return False, "", "", "", ""
         params = self.quantization_params[param_name]
         if params is None or len(params) != 2:
-            raise ValueError(
-                "Quantization parameters should contain zero point and scale. "
-                "Specified values for output {}: {}".format(
-                    output_name, params))
+            raise ValueError("Quantization parameters should contain zero point and scale. "
+                             "Specified values for output {}: {}".format(output_name, params))
 
         if not np.isscalar(params[0]):
-            raise ValueError(
-                "Zero point for output {} should be a scalar value. Value specified: {}"
-                .format(output_name, params[0]))
+            raise ValueError("Zero point for output {} should be a scalar value. Value specified: {}".format(
+                output_name, params[0]))
         if not np.isscalar(params[1]):
-            raise ValueError(
-                "Scale for output {} should be a scalar value. Value specified: {}"
-                .format(output_name, params[1]))
+            raise ValueError("Scale for output {} should be a scalar value. Value specified: {}".format(
+                output_name, params[1]))
 
         zero_point_values = [params[0].item()]
         zero_point_shape = []
@@ -698,11 +633,9 @@ class ONNXQuantizer:
         scale_name = param_name + "_scale"
 
         # Add initializers
-        _add_initializer_if_not_present(self.model.graph, zero_point_name,
-                                        zero_point_values, zero_point_shape,
+        _add_initializer_if_not_present(self.model.graph, zero_point_name, zero_point_values, zero_point_shape,
                                         zero_point_type)
-        _add_initializer_if_not_present(self.model.graph, scale_name,
-                                        scale_values, scale_shape,
+        _add_initializer_if_not_present(self.model.graph, scale_name, scale_values, scale_shape,
                                         onnx_proto.TensorProto.FLOAT)
 
         return True, scale_name, zero_point_name, scale_shape, zero_point_shape
@@ -728,29 +661,26 @@ class ONNXQuantizer:
             if data_found == False:
                 raise ValueError(
                     "Quantization parameters are not specified for param {}."
-                    "In static mode quantization params for inputs and outputs of odes to be quantized are required."
-                    .format(input_name))
+                    "In static mode quantization params for inputs and outputs of odes to be quantized are required.".
+                    format(input_name))
 
-            qlinear_node = onnx.helper.make_node(
-                "QuantizeLinear", [input_name, scale_name, zp_name],
-                [output_name], input_name + "_QuantizeLinear")
+            qlinear_node = onnx.helper.make_node("QuantizeLinear", [input_name, scale_name, zp_name], [output_name],
+                                                 input_name + "_QuantizeLinear")
             return [qlinear_node]
 
         else:
             if data_found == True:
-                qlinear_node = onnx.helper.make_node(
-                    "QuantizeLinear", [input_name, scale_name, zp_name],
-                    [output_name], input_name + "_QuantizeLinear")
+                qlinear_node = onnx.helper.make_node("QuantizeLinear", [input_name, scale_name, zp_name], [output_name],
+                                                     input_name + "_QuantizeLinear")
                 return [qlinear_node]
             else:
                 # Scale and Zero Points not available for this input. Add nodes to dynamically compute it
                 if self.fuse_dynamic_quant and qType == onnx_proto.TensorProto.UINT8:
                     scale_name = input_name + "_scale"
                     zeropoint_name = input_name + "_zero_point"
-                    qlinear_node = onnx.helper.make_node(
-                        "DynamicQuantizeLinear", [input_name],
-                        [output_name, scale_name, zeropoint_name],
-                        input_name + "_QuantizeLinear")
+                    qlinear_node = onnx.helper.make_node("DynamicQuantizeLinear", [input_name],
+                                                         [output_name, scale_name, zeropoint_name],
+                                                         input_name + "_QuantizeLinear")
                     return [qlinear_node]
 
                 else:
@@ -758,14 +688,12 @@ class ONNXQuantizer:
                     scale_name, zp_name, scale_shape, zp_shape = \
                         self._get_dynamic_input_quantization_params(
                             input_name, nodes, qType)
-                    qlinear_node = onnx.helper.make_node(
-                        "QuantizeLinear", [input_name, scale_name, zp_name],
-                        [output_name], input_name + "_QuantizeLinear")
+                    qlinear_node = onnx.helper.make_node("QuantizeLinear", [input_name, scale_name, zp_name],
+                                                         [output_name], input_name + "_QuantizeLinear")
 
                     return nodes + [qlinear_node]
 
-    def _get_bias_add_nodes(self, nodes, node, last_output,
-                            quantized_bias_name):
+    def _get_bias_add_nodes(self, nodes, node, last_output, quantized_bias_name):
         '''
         Given a node, this function handles bias add by adding a "reshape" node on bias and an "add" node
 
@@ -779,22 +707,18 @@ class ONNXQuantizer:
         reshape_input = [quantized_bias_name]
 
         # Add tensors for the shape to be reshaped to
-        _add_initializer_if_not_present(self.model.graph, "reshape_shape",
-                                        [1, -1, 1, 1], [4],
+        _add_initializer_if_not_present(self.model.graph, "reshape_shape", [1, -1, 1, 1], [4],
                                         onnx_proto.TensorProto.INT64)
         reshape_input.append('reshape_shape')
         reshape_op_output = node.output[0] + "_reshape"
-        reshape_node = onnx.helper.make_node("Reshape", reshape_input,
-                                             [reshape_op_output],
+        reshape_node = onnx.helper.make_node("Reshape", reshape_input, [reshape_op_output],
                                              quantized_bias_name + "reshape")
         nodes.append(reshape_node)
 
         bias_add_input = [last_output]
         bias_add_input.append(reshape_op_output)
         add_node_output = node.output[0] + "_bias_add"
-        add_node = onnx.helper.make_node("Add", bias_add_input,
-                                         [add_node_output],
-                                         quantized_bias_name + "bias_add")
+        add_node = onnx.helper.make_node("Add", bias_add_input, [add_node_output], quantized_bias_name + "bias_add")
         nodes.append(add_node)
         return add_node_output
 
@@ -806,12 +730,8 @@ class ONNXQuantizer:
             parameter new_nodes_list: List of new nodes created before processing current node.
             return: List of new nodes created.
         '''
-        nodes_using_weight = _find_nodes_using_initializer(
-            self.model.graph, weight.initializer)
-        unsupported_nodes = [
-            node for node in nodes_using_weight
-            if node.op_type not in ["Conv", "MatMul", "Gather"]
-        ]
+        nodes_using_weight = _find_nodes_using_initializer(self.model.graph, weight.initializer)
+        unsupported_nodes = [node for node in nodes_using_weight if node.op_type not in ["Conv", "MatMul", "Gather"]]
 
         nodes_list = []
         dequantize_linear_name = weight.name + "_DequantizeLinear"
@@ -820,12 +740,8 @@ class ONNXQuantizer:
         # Check if DequantizeLinear node needs to be added to graph.
         if len(unsupported_nodes) != 0 and \
                 _find_node_by_name(dequantize_linear_name, self.model.graph, new_nodes_list) is None:
-            inputs = [
-                weight.name + "_quantized", weight.name + "_scale",
-                weight.name + "_zero_point"
-            ]
-            node = onnx.helper.make_node("DequantizeLinear", inputs,
-                                         [output_name], dequantize_linear_name)
+            inputs = [weight.name + "_quantized", weight.name + "_scale", weight.name + "_zero_point"]
+            node = onnx.helper.make_node("DequantizeLinear", inputs, [output_name], dequantize_linear_name)
             nodes_list.append(node)
 
         # Update unsupported nodes to take dequantized weight as input.
@@ -836,8 +752,7 @@ class ONNXQuantizer:
 
         return nodes_list
 
-    def _dynamic_quantize_bias(self, input_name, weight_scale_name, bias_name,
-                               quantized_bias_name, new_node_list):
+    def _dynamic_quantize_bias(self, input_name, weight_scale_name, bias_name, quantized_bias_name, new_node_list):
         '''
         Adds series of nodes required to quantize the bias dynamically.
             parameter input_name: Input name
@@ -848,24 +763,20 @@ class ONNXQuantizer:
         qType = onnx_proto.TensorProto.INT32
 
         input_scale_name = input_name + "_scale"
-        bias_scale_node = onnx.helper.make_node(
-            "Mul", [input_scale_name, weight_scale_name],
-            [bias_name + "_scale"], bias_name + "_scale_node")
+        bias_scale_node = onnx.helper.make_node("Mul", [input_scale_name, weight_scale_name], [bias_name + "_scale"],
+                                                bias_name + "_scale_node")
         new_node_list.append(bias_scale_node)
 
-        quantize_bias_node = onnx.helper.make_node(
-            "Div", [bias_name, bias_scale_node.output[0]],
-            [bias_name + "_tmp_quant:0"], bias_name + "_tmp_qaunt")
+        quantize_bias_node = onnx.helper.make_node("Div", [bias_name, bias_scale_node.output[0]],
+                                                   [bias_name + "_tmp_quant:0"], bias_name + "_tmp_qaunt")
         new_node_list.append(quantize_bias_node)
 
-        bias_rounded_node = onnx.helper.make_node(
-            "Floor", quantize_bias_node.output,
-            [bias_name + "_quant_rounded:0"], bias_name + "_quant_rounded")
+        bias_rounded_node = onnx.helper.make_node("Floor", quantize_bias_node.output, [bias_name + "_quant_rounded:0"],
+                                                  bias_name + "_quant_rounded")
         new_node_list.append(bias_rounded_node)
 
         bias_cast_node = onnx.helper.make_node("Cast",
-                                               bias_rounded_node.output,
-                                               [quantized_bias_name],
+                                               bias_rounded_node.output, [quantized_bias_name],
                                                quantized_bias_name + "_node",
                                                to=qType)
         new_node_list.append(bias_cast_node)
@@ -879,31 +790,24 @@ class ONNXQuantizer:
 
         # get scale for weight
         weight_scale_name = self.quantized_value_map[node.input[1]].scale_name
-        weight_initializer = _find_by_name(weight_scale_name,
-                                           self.model.graph.initializer)
+        weight_initializer = _find_by_name(weight_scale_name, self.model.graph.initializer)
         weight_scale = self.find_weight_data(weight_initializer)
 
         # get bias
         bias_name = node.input[2]
-        bias_initializer = _find_by_name(bias_name,
-                                         self.model.graph.initializer)
+        bias_initializer = _find_by_name(bias_name, self.model.graph.initializer)
         bias_data = self.find_weight_data(bias_initializer)
         quantized_bias_name = bias_name + "_quantized"
 
         # input scale is not provided and this input is dynamically quantized so it is not pre-computed at this point
         # so resort to dynamic quantization for bias
-        if self.quantization_params is None or node.input[
-                0] not in self.quantization_params and node.input[
-                    0] not in self.quantized_value_map:
-            self._dynamic_quantize_bias(node.input[0], weight_scale_name,
-                                        bias_name, quantized_bias_name,
-                                        new_node_list)
+        if self.quantization_params is None or node.input[0] not in self.quantization_params and node.input[
+                0] not in self.quantized_value_map:
+            self._dynamic_quantize_bias(node.input[0], weight_scale_name, bias_name, quantized_bias_name, new_node_list)
         else:
             # get scale for input
-            input_scale_name = self.quantized_value_map[
-                node.input[0]].scale_name
-            inputscale_initializer = _find_by_name(
-                input_scale_name, self.model.graph.initializer)
+            input_scale_name = self.quantized_value_map[node.input[0]].scale_name
+            inputscale_initializer = _find_by_name(input_scale_name, self.model.graph.initializer)
             input_scale = self.find_weight_data(inputscale_initializer)
 
             # calcuate scale for bias
@@ -912,32 +816,25 @@ class ONNXQuantizer:
             print(bias_scale)
 
             # quantize bias
-            quantized_data = (np.asarray(bias_data) /
-                              bias_scale).round().astype(np.int32)
+            quantized_data = (np.asarray(bias_data) / bias_scale).round().astype(np.int32)
             print(quantized_data)
 
             # update bias initializer
-            bias_np_data = np.asarray(quantized_data, dtype=np.int32).reshape(
-                bias_initializer.dims)
-            packed_bias_initializer = onnx.numpy_helper.from_array(
-                bias_np_data, quantized_bias_name)
+            bias_np_data = np.asarray(quantized_data, dtype=np.int32).reshape(bias_initializer.dims)
+            packed_bias_initializer = onnx.numpy_helper.from_array(bias_np_data, quantized_bias_name)
             self.model.graph.initializer.extend([packed_bias_initializer])
 
             # log entries for this quantized bias value
-            quantized_bias_entry = QuantizedInitializer(
-                bias_name,
-                bias_initializer, [0], [0], [0], [bias_scale],
-                bias_data,
-                quantized_data,
-                qType=onnx_proto.TensorProto.INT32)
+            quantized_bias_entry = QuantizedInitializer(bias_name,
+                                                        bias_initializer, [0], [0], [0], [bias_scale],
+                                                        bias_data,
+                                                        quantized_data,
+                                                        qType=onnx_proto.TensorProto.INT32)
             self._quantized_weights.append(quantized_bias_entry)
 
             assert (bias_name not in self.quantized_value_map)
-            quantized_value = QuantizedValue(bias_name, quantized_bias_name,
-                                             "", "",
-                                             QuantizedValueType.Initializer,
-                                             None,
-                                             onnx_proto.TensorProto.INT32)
+            quantized_value = QuantizedValue(bias_name, quantized_bias_name, "", "", QuantizedValueType.Initializer,
+                                             None, onnx_proto.TensorProto.INT32)
             self.quantized_value_map[bias_name] = quantized_value
 
         return quantized_bias_name
@@ -958,8 +855,7 @@ class ONNXQuantizer:
                      List of scale names used for input quantization,
                      List of new QuantizeLinear nodes created)
         '''
-        assert (node.op_type == "Conv" or node.op_type == "MatMul"
-                or node.op_type == "Gather")
+        assert (node.op_type == "Conv" or node.op_type == "MatMul" or node.op_type == "Gather")
 
         quantized_input_names = []
         zero_point_names = []
@@ -984,20 +880,15 @@ class ONNXQuantizer:
                 continue
 
             # Quantize the input
-            initializer = _find_by_name(node_input,
-                                        self.model.graph.initializer)
+            initializer = _find_by_name(node_input, self.model.graph.initializer)
             if initializer is not None:
                 if node.op_type == "Conv":
-                    weight = self._get_quantized_weight_convolution(
-                        initializer, self.weight_qType)
+                    weight = self._get_quantized_weight_convolution(initializer, self.weight_qType)
                 else:
-                    weight = self._get_quantized_weight(
-                        initializer, self.weight_qType)
+                    weight = self._get_quantized_weight(initializer, self.weight_qType)
 
                 # Update graph
-                nodes.extend(
-                    self._update_unsupported_nodes_using_weight(
-                        weight, new_nodes_list))
+                nodes.extend(self._update_unsupported_nodes_using_weight(weight, new_nodes_list))
                 self._update_graph(weight)
 
                 quantized_input_names.append(weight.name + "_quantized")
@@ -1005,12 +896,9 @@ class ONNXQuantizer:
                 scale_names.append(weight.name + "_scale")
             else:
                 # Add QuantizeLinear node.
-                qlinear_node = _find_node_by_name(
-                    node_input + "_QuantizeLinear", self.model.graph,
-                    new_nodes_list)
+                qlinear_node = _find_node_by_name(node_input + "_QuantizeLinear", self.model.graph, new_nodes_list)
                 if qlinear_node is None:
-                    quantize_input_nodes = self._get_quantize_input_nodes(
-                        node, input_index, self.input_qType)
+                    quantize_input_nodes = self._get_quantize_input_nodes(node, input_index, self.input_qType)
                     nodes.extend(quantize_input_nodes)
                     qlinear_node = quantize_input_nodes[-1]
 
@@ -1043,17 +931,11 @@ class ONNXQuantizer:
                 quantized_value = self.quantized_value_map[input_name]
                 # Add DequantizeLinear Node for this input
                 dqlinear_name = input_name + "_DequantizeLinear"
-                dqlinear_node = _find_node_by_name(dqlinear_name,
-                                                   self.model.graph,
-                                                   new_nodes_list)
+                dqlinear_node = _find_node_by_name(dqlinear_name, self.model.graph, new_nodes_list)
                 if dqlinear_node is None:
-                    dqlinear_inputs = [
-                        quantized_value.q_name, quantized_value.scale_name,
-                        quantized_value.zp_name
-                    ]
-                    dequantize_node = onnx.helper.make_node(
-                        "DequantizeLinear", dqlinear_inputs, [input_name],
-                        dqlinear_name)
+                    dqlinear_inputs = [quantized_value.q_name, quantized_value.scale_name, quantized_value.zp_name]
+                    dequantize_node = onnx.helper.make_node("DequantizeLinear", dqlinear_inputs, [input_name],
+                                                            dqlinear_name)
                     nodes.append(dequantize_node)
                 else:
                     # DQ op is already present, assert it's output matches the input of current node
@@ -1096,8 +978,7 @@ class ONNXQuantizer:
         gather_new_output = node.output[0] + "_quantized"
 
         # Create an entry for this quantized value
-        q_output = QuantizedValue(node.output[0], gather_new_output,
-                                  scale_names[0], zero_point_names[0],
+        q_output = QuantizedValue(node.output[0], gather_new_output, scale_names[0], zero_point_names[0],
                                   QuantizedValueType.Input)
         self.quantized_value_map[node.output[0]] = q_output
 
@@ -1134,20 +1015,17 @@ class ONNXQuantizer:
         kwargs = {}
         for attribute in node.attribute:
             kwargs.update(_attribute_to_kwarg(attribute))
-        conv_integer_node = onnx.helper.make_node(
-            "ConvInteger", quantized_input_names + zero_point_names,
-            [conv_integer_output], conv_integer_name, **kwargs)
+        conv_integer_node = onnx.helper.make_node("ConvInteger", quantized_input_names + zero_point_names,
+                                                  [conv_integer_output], conv_integer_name, **kwargs)
         nodes.append(conv_integer_node)
 
         # Add bias add nodes
         if bias_present:
-            conv_integer_output = self._get_bias_add_nodes(
-                nodes, node, conv_integer_output, quantized_bias_name)
+            conv_integer_output = self._get_bias_add_nodes(nodes, node, conv_integer_output, quantized_bias_name)
 
         # Add cast operation to cast convInteger output to float.
         cast_op_output = conv_integer_output + "_cast_output"
-        cast_node = onnx.helper.make_node("Cast", [conv_integer_output],
-                                          [cast_op_output],
+        cast_node = onnx.helper.make_node("Cast", [conv_integer_output], [cast_op_output],
                                           conv_integer_output + "_cast",
                                           to=onnx_proto.TensorProto.FLOAT)
         nodes.append(cast_node)
@@ -1159,11 +1037,9 @@ class ONNXQuantizer:
         else:
             scales_mul_op = scale_names[0] + "_" + scale_names[1] + "_mul"
 
-        scales_mul_node = _find_node_by_name(scales_mul_op, self.model.graph,
-                                             new_nodes_list)
+        scales_mul_node = _find_node_by_name(scales_mul_op, self.model.graph, new_nodes_list)
         if scales_mul_node is None:
-            scales_mul_node = _get_mul_node(scale_names, scales_mul_op + ":0",
-                                            scales_mul_op)
+            scales_mul_node = _get_mul_node(scale_names, scales_mul_op + ":0", scales_mul_op)
             nodes.append(scales_mul_node)
 
         scales_mul_op_output = scales_mul_node.output[0]
@@ -1173,9 +1049,7 @@ class ONNXQuantizer:
         output_scale_mul_op = ""
         if conv_integer_name != "":
             output_scale_mul_op = conv_integer_name + "_output_scale_mul"
-        nodes.append(
-            _get_mul_node([cast_op_output, scales_mul_op_output],
-                          node.output[0], output_scale_mul_op))
+        nodes.append(_get_mul_node([cast_op_output, scales_mul_op_output], node.output[0], output_scale_mul_op))
 
         return nodes
 
@@ -1195,15 +1069,13 @@ class ONNXQuantizer:
         matmul_integer_name = ""
         if node.name != "":
             matmul_integer_name = node.name + "_quant"
-        matmul_integer_node = onnx.helper.make_node(
-            "MatMulInteger", quantized_input_names + zero_point_names,
-            [matmul_integer_output], matmul_integer_name)
+        matmul_integer_node = onnx.helper.make_node("MatMulInteger", quantized_input_names + zero_point_names,
+                                                    [matmul_integer_output], matmul_integer_name)
         nodes.append(matmul_integer_node)
 
         # Add cast operation to cast matmulInteger output to float.
         cast_op_output = matmul_integer_output + "_cast_output"
-        cast_node = onnx.helper.make_node("Cast", [matmul_integer_output],
-                                          [cast_op_output],
+        cast_node = onnx.helper.make_node("Cast", [matmul_integer_output], [cast_op_output],
                                           matmul_integer_output + "_cast",
                                           to=onnx_proto.TensorProto.FLOAT)
         nodes.append(cast_node)
@@ -1215,11 +1087,9 @@ class ONNXQuantizer:
         else:
             scales_mul_op = scale_names[0] + "_" + scale_names[1] + "_mul"
 
-        scales_mul_node = _find_node_by_name(scales_mul_op, self.model.graph,
-                                             new_nodes_list)
+        scales_mul_node = _find_node_by_name(scales_mul_op, self.model.graph, new_nodes_list)
         if scales_mul_node is None:
-            scales_mul_node = _get_mul_node(scale_names, scales_mul_op + ":0",
-                                            scales_mul_op)
+            scales_mul_node = _get_mul_node(scale_names, scales_mul_op + ":0", scales_mul_op)
             nodes.append(scales_mul_node)
 
         scales_mul_op_output = scales_mul_node.output[0]
@@ -1229,9 +1099,7 @@ class ONNXQuantizer:
         output_scale_mul_op = ""
         if matmul_integer_name != "":
             output_scale_mul_op = matmul_integer_name + "_output_scale_mul"
-        nodes.append(
-            _get_mul_node([cast_op_output, scales_mul_op_output],
-                          node.output[0], output_scale_mul_op))
+        nodes.append(_get_mul_node([cast_op_output, scales_mul_op_output], node.output[0], output_scale_mul_op))
         return nodes
 
     def _quantize_convolution_qlinear_ops(self, node, new_nodes_list):
@@ -1280,15 +1148,12 @@ class ONNXQuantizer:
         if bias_present:
             qlinear_conv_inputs.append(quantized_bias_name)
 
-        qlinear_conv_node = onnx.helper.make_node("QLinearConv",
-                                                  qlinear_conv_inputs,
-                                                  [qlinear_conv_output],
+        qlinear_conv_node = onnx.helper.make_node("QLinearConv", qlinear_conv_inputs, [qlinear_conv_output],
                                                   qlinear_conv_name, **kwargs)
         nodes.append(qlinear_conv_node)
 
         # Create an entry for this quantized value
-        q_output = QuantizedValue(node.output[0], qlinear_conv_output,
-                                  output_scale_name, output_zp_name,
+        q_output = QuantizedValue(node.output[0], qlinear_conv_output, output_scale_name, output_zp_name,
                                   QuantizedValueType.Input)
         self.quantized_value_map[node.output[0]] = q_output
 
@@ -1329,15 +1194,12 @@ class ONNXQuantizer:
         qlinear_matmul_inputs.append(output_scale_name)
         qlinear_matmul_inputs.append(output_zp_name)
 
-        qlinear_matmul_node = onnx.helper.make_node("QLinearMatMul",
-                                                    qlinear_matmul_inputs,
-                                                    [qlinear_matmul_output],
+        qlinear_matmul_node = onnx.helper.make_node("QLinearMatMul", qlinear_matmul_inputs, [qlinear_matmul_output],
                                                     qlinear_matmul_name)
         nodes.append(qlinear_matmul_node)
 
         # Create an entry for this quantized value
-        q_output = QuantizedValue(node.output[0], qlinear_matmul_output,
-                                  output_scale_name, output_zp_name,
+        q_output = QuantizedValue(node.output[0], qlinear_matmul_output, output_scale_name, output_zp_name,
                                   QuantizedValueType.Input)
         self.quantized_value_map[node.output[0]] = q_output
 
@@ -1392,19 +1254,16 @@ def check_opset_version(org_model, force_fusions):
     fuse_dynamic_quant = False
 
     if opset_version < 11 and force_fusions == True:
-        print(
-            "Warning: The original model opset version is {}, which does not support node fusions.\n\
-            Forcing fusions can break other nodes in the model.".format(
-                opset_version))
+        print("Warning: The original model opset version is {}, which does not support node fusions.\n\
+            Forcing fusions can break other nodes in the model.".format(opset_version))
         onnx_op_set_version = 11
         fuse_dynamic_quant = True
         return fuse_dynamic_quant
 
     if opset_version < 10:
-        print(
-            "Warning: The original model opset version is {}, which does not support quantized operators.\n\
+        print("Warning: The original model opset version is {}, which does not support quantized operators.\n\
             The opset version of quantized model will be set to 10. Use onnx model checker to verify model after quantization."
-            .format(opset_version))
+              .format(opset_version))
         onnx_op_set_version = 10
     elif opset_version == 10:
         onnx_op_set_version = 10
@@ -1479,15 +1338,11 @@ def quantize(model,
         copy_model = onnx_proto.ModelProto()
         copy_model.CopyFrom(model)
         fuse_dynamic_quant = check_opset_version(copy_model, force_fusions)
-        quantizer = ONNXQuantizer(copy_model, per_channel, mode, static,
-                                  fuse_dynamic_quant, weight_qType,
-                                  input_qType, quantization_params,
-                                  nodes_to_quantize)
+        quantizer = ONNXQuantizer(copy_model, per_channel, mode, static, fuse_dynamic_quant, weight_qType, input_qType,
+                                  quantization_params, nodes_to_quantize)
         quantizer.quantize_model()
         quantizer.model.producer_name = __producer__
         quantizer.model.producer_version = __version__
         return quantizer.model
     else:
-        raise ValueError(
-            'Unknown value for nbits. only 8 bit quantization is currently supported'
-        )
+        raise ValueError('Unknown value for nbits. only 8 bit quantization is currently supported')

--- a/onnxruntime/python/tools/quantization/test_calibrate.py
+++ b/onnxruntime/python/tools/quantization/test_calibrate.py
@@ -18,6 +18,7 @@ from onnx import numpy_helper
 
 
 class TestCalibrate(unittest.TestCase):
+
     def test_augment_graph(self):
         # Creating graph
         A = helper.make_tensor_value_info('A', TensorProto.FLOAT, [1, 1, 5, 5])
@@ -31,10 +32,8 @@ class TestCalibrate(unittest.TestCase):
                                           kernel_shape=[3, 3],
                                           pads=[1, 1, 1, 1])
         clip_node = onnx.helper.make_node('Clip', ['C'], ['D'], name='Clip')
-        matmul_node = onnx.helper.make_node('MatMul', ['D', 'E'], ['F'],
-                                            name='MatMul')
-        graph = helper.make_graph([conv_node, clip_node, matmul_node],
-                                  'test_graph', [A, B, E], [F])
+        matmul_node = onnx.helper.make_node('MatMul', ['D', 'E'], ['F'], name='MatMul')
+        graph = helper.make_graph([conv_node, clip_node, matmul_node], 'test_graph', [A, B, E], [F])
         model = helper.make_model(graph)
         onnx.save(model, 'test_model.onnx')
 
@@ -43,19 +42,10 @@ class TestCalibrate(unittest.TestCase):
         onnx.save(augmented_model, 'augmented_test_model.onnx')
 
         # Checking if each added ReduceMin and ReduceMax node and its output exists
-        augmented_model_node_names = [
-            node.name for node in augmented_model.graph.node
-        ]
-        augmented_model_outputs = [
-            output.name for output in augmented_model.graph.output
-        ]
-        added_node_names = [
-            'Conv_ReduceMin', 'Conv_ReduceMax', 'MatMul_ReduceMin',
-            'MatMul_ReduceMax'
-        ]
-        added_outputs = [
-            'C_ReduceMin', 'C_ReduceMax', 'F_ReduceMin', 'F_ReduceMax'
-        ]
+        augmented_model_node_names = [node.name for node in augmented_model.graph.node]
+        augmented_model_outputs = [output.name for output in augmented_model.graph.output]
+        added_node_names = ['Conv_ReduceMin', 'Conv_ReduceMax', 'MatMul_ReduceMin', 'MatMul_ReduceMax']
+        added_outputs = ['C_ReduceMin', 'C_ReduceMax', 'F_ReduceMin', 'F_ReduceMax']
         # original 3 nodes with 4 added ones
         self.assertEqual(len(augmented_model_node_names), 7)
         # original single graph output with 4 added ones
@@ -71,12 +61,9 @@ class TestCalibrate(unittest.TestCase):
         I = helper.make_tensor_value_info('I', TensorProto.FLOAT, [1, 1, 5, 1])
         J = helper.make_tensor_value_info('J', TensorProto.FLOAT, [1, 1, 5, 1])
         K = helper.make_tensor_value_info('K', TensorProto.FLOAT, [1, 1, 5, 1])
-        matmul_node_1 = onnx.helper.make_node('MatMul', ['G', 'H'], ['I'],
-                                              name='MatMul_1')
-        matmul_node_2 = onnx.helper.make_node('MatMul', ['I', 'J'], ['K'],
-                                              name='MatMul_2')
-        graph = helper.make_graph([matmul_node_1, matmul_node_2],
-                                  'test_graph_order', [G, H, J], [K])
+        matmul_node_1 = onnx.helper.make_node('MatMul', ['G', 'H'], ['I'], name='MatMul_1')
+        matmul_node_2 = onnx.helper.make_node('MatMul', ['I', 'J'], ['K'], name='MatMul_2')
+        graph = helper.make_graph([matmul_node_1, matmul_node_2], 'test_graph_order', [G, H, J], [K])
         model = helper.make_model(graph)
         onnx.save(model, 'test_model_matmul.onnx')
 
@@ -84,9 +71,7 @@ class TestCalibrate(unittest.TestCase):
         augmented_model = calibrate.augment_graph(model)
         onnx.save(augmented_model, 'augmented_test_model_matmul.onnx')
 
-        augmented_model_outputs = [
-            output.name for output in augmented_model.graph.output
-        ]
+        augmented_model_outputs = [output.name for output in augmented_model.graph.output]
         self.assertEqual(augmented_model_outputs[0], 'K')
         self.assertEqual(augmented_model_outputs[1], 'I_ReduceMin')
         self.assertEqual(augmented_model_outputs[2], 'I_ReduceMax')
@@ -97,11 +82,7 @@ class TestCalibrate(unittest.TestCase):
         images_folder = 'test_images'
         session = onnxruntime.InferenceSession('augmented_test_model.onnx')
         (samples, channels, height, width) = session.get_inputs()[0].shape
-        batch_data = calibrate.load_batch(
-            images_folder,
-            height,
-            width,
-            preprocess_func_name="preprocess_method1")
+        batch_data = calibrate.load_batch(images_folder, height, width, preprocess_func_name="preprocess_method1")
         # for 2D images like the ones in test_images
         self.assertEqual(len(batch_data.shape), 5)
         self.assertEqual(batch_data.shape[0], len(os.listdir(images_folder)))
@@ -149,8 +130,7 @@ class TestCalibrate(unittest.TestCase):
         try:
             os.remove('test_tensor.pb')
         except:
-            print("Warning: Trying to remove test file {} failed.".format(
-                test_file_name))
+            print("Warning: Trying to remove test file {} failed.".format(test_file_name))
 
 
 if __name__ == '__main__':

--- a/onnxruntime/test/contrib_ops/attention_lstm_data_gen.py
+++ b/onnxruntime/test/contrib_ops/attention_lstm_data_gen.py
@@ -17,95 +17,91 @@ am_context_size: int = memDepth
 root_variable_scope = 'LstmAttention'
 
 with tf.variable_scope(root_variable_scope):
-    query = tf.get_variable(
-        "input",
-        initializer=tf.constant([0.25, -1.5, 1.0,   0.25, -0.5, -1.5,   0.1, 1.5, 0.25,  0.0, 0.0, 0.0,
-                                 0.1, -0.125, 0.25, -0.5, 0.25, 0.1,    1.0, 0.5, -1.5,  0.0, 0.0, 0.0],
-                                shape=[batchSize, queryMaxStep, queryDepth]))
+    query = tf.get_variable("input",
+                            initializer=tf.constant([
+                                0.25, -1.5, 1.0, 0.25, -0.5, -1.5, 0.1, 1.5, 0.25, 0.0, 0.0, 0.0, 0.1, -0.125, 0.25,
+                                -0.5, 0.25, 0.1, 1.0, 0.5, -1.5, 0.0, 0.0, 0.0
+                            ],
+                                                    shape=[batchSize, queryMaxStep, queryDepth]))
 
-    querySeqLen = tf.Variable(tf.constant([queryMaxStep-1, queryMaxStep-2], tf.int32), name="query_seq_len")
+    querySeqLen = tf.Variable(tf.constant([queryMaxStep - 1, queryMaxStep - 2], tf.int32), name="query_seq_len")
 
     memory = tf.get_variable(
         "memory",
-        initializer=tf.constant([0.1, -0.25, 1.0,   1.0, -1.0, -1.5,       1.0, 0.25, -0.125,
-                                 0.1, -0.25, 0.5,     -0.25, -1.25, 0.25,   -1.0, 1.5, -1.250],
+        initializer=tf.constant([
+            0.1, -0.25, 1.0, 1.0, -1.0, -1.5, 1.0, 0.25, -0.125, 0.1, -0.25, 0.5, -0.25, -1.25, 0.25, -1.0, 1.5, -1.250
+        ],
                                 shape=[batchSize, memMaxStep, memDepth]))
 
-    memSeqLen = tf.Variable(tf.constant([memMaxStep, memMaxStep-1], dtype=tf.int32), name="mem_seq_len")
+    memSeqLen = tf.Variable(tf.constant([memMaxStep, memMaxStep - 1], dtype=tf.int32), name="mem_seq_len")
 
     with tf.variable_scope("fwBahdanau"):
-        fw_mem_layer_weights = tf.get_variable(
-            "memory_layer/kernel",
-            initializer=tf.constant([4.0, 2.0, 0.5, -8.0, -2.0, -2.0], shape=[memDepth, am_attn_size]))
+        fw_mem_layer_weights = tf.get_variable("memory_layer/kernel",
+                                               initializer=tf.constant([4.0, 2.0, 0.5, -8.0, -2.0, -2.0],
+                                                                       shape=[memDepth, am_attn_size]))
 
     fw_query_layer_weights = tf.get_variable(
         "bidirectional_rnn/fw/attention_wrapper/bahdanau_attention/query_layer/kernel",
-        initializer=tf.constant([-0.125, -0.25, 0.1, -0.125, -0.5, 1.5],
-                                shape=[cell_hidden_size, am_attn_size]))
+        initializer=tf.constant([-0.125, -0.25, 0.1, -0.125, -0.5, 1.5], shape=[cell_hidden_size, am_attn_size]))
 
-    fw_aw_attn_weights = tf.get_variable(
-        "bidirectional_rnn/fw/attention_wrapper/attention_layer/kernel",
-        initializer=tf.constant([1.5, 1.0, 0.1, -0.25, 0.1, 1.0, -0.25, -0.125, -1.5, -1.5, -0.25, 1.5],
-                                shape=[am_context_size + cell_hidden_size, aw_attn_size]))
+    fw_aw_attn_weights = tf.get_variable("bidirectional_rnn/fw/attention_wrapper/attention_layer/kernel",
+                                         initializer=tf.constant(
+                                             [1.5, 1.0, 0.1, -0.25, 0.1, 1.0, -0.25, -0.125, -1.5, -1.5, -0.25, 1.5],
+                                             shape=[am_context_size + cell_hidden_size, aw_attn_size]))
 
-    fw_am_attention_v = tf.get_variable(
-        "bidirectional_rnn/fw/attention_wrapper/bahdanau_attention/attention_v",
-        initializer=tf.constant([-0.25, 0.1], shape=[am_attn_size]))
+    fw_am_attention_v = tf.get_variable("bidirectional_rnn/fw/attention_wrapper/bahdanau_attention/attention_v",
+                                        initializer=tf.constant([-0.25, 0.1], shape=[am_attn_size]))
 
     fw_lstm_cell_kernel = tf.get_variable(
         "bidirectional_rnn/fw/attention_wrapper/lstm_cell/kernel",
         initializer=tf.constant([
-             -1.0, -1.5, -0.5, -1.5, 0.1, -0.5, 0.5, -1.5, -0.25, 1.0, -0.125, -0.25,
-             -1.0, -0.5, 0.25, -0.125, -0.25, -1.0, 1.5, 1.0, -1.5, 0.25, 0.5, 0.5,
-             1.5, -0.5, -1.0, -0.5, 0.1, 1.0, 0.1, -0.5, -0.125, -1.5, 0.1, 1.5,
-             1.0, -0.5, -0.5, -1.5, -0.125, -0.125, 0.25, -0.25, -0.25, 0.1, -0.5, -0.25,
-             0.25, -0.5, 0.1, -0.5, -0.25, 0.25, 0.1, 0.5, -1.5, -0.125, 1.5, 0.5,
-             -1.5, 1.0, 0.1, -0.5, -1.5, 0.5, -1.0, 0.25, -0.25, 1.0, 0.25, 0.5,
-             -0.125, 0.1, -1.0, -1.0, 0.1, 1.5, -1.5, 0.1, 1.5, 0.5, 0.25, 1.0,
-             1.0, -1.5, -0.25, 0.5, -0.25, 1.0, -1.0, 0.25, -0.5, 0.5, -1.5, 0.5],
-             shape=[aw_attn_size + queryDepth + cell_hidden_size, 4 * cell_hidden_size]))
+            -1.0, -1.5, -0.5, -1.5, 0.1, -0.5, 0.5, -1.5, -0.25, 1.0, -0.125, -0.25, -1.0, -0.5, 0.25, -0.125, -0.25,
+            -1.0, 1.5, 1.0, -1.5, 0.25, 0.5, 0.5, 1.5, -0.5, -1.0, -0.5, 0.1, 1.0, 0.1, -0.5, -0.125, -1.5, 0.1, 1.5,
+            1.0, -0.5, -0.5, -1.5, -0.125, -0.125, 0.25, -0.25, -0.25, 0.1, -0.5, -0.25, 0.25, -0.5, 0.1, -0.5, -0.25,
+            0.25, 0.1, 0.5, -1.5, -0.125, 1.5, 0.5, -1.5, 1.0, 0.1, -0.5, -1.5, 0.5, -1.0, 0.25, -0.25, 1.0, 0.25, 0.5,
+            -0.125, 0.1, -1.0, -1.0, 0.1, 1.5, -1.5, 0.1, 1.5, 0.5, 0.25, 1.0, 1.0, -1.5, -0.25, 0.5, -0.25, 1.0, -1.0,
+            0.25, -0.5, 0.5, -1.5, 0.5
+        ],
+                                shape=[aw_attn_size + queryDepth + cell_hidden_size, 4 * cell_hidden_size]))
 
-    fw_lstm_cell_bias = tf.get_variable(
-        "bidirectional_rnn/fw/attention_wrapper/lstm_cell/bias",
-        initializer=tf.constant([0.25, -0.25, 0.1, 1.0, 1.5, -1.5, 1.5, -1.0, -0.25, 1.0, -0.25, 1.0],
-                                shape=[4 * cell_hidden_size]))
+    fw_lstm_cell_bias = tf.get_variable("bidirectional_rnn/fw/attention_wrapper/lstm_cell/bias",
+                                        initializer=tf.constant(
+                                            [0.25, -0.25, 0.1, 1.0, 1.5, -1.5, 1.5, -1.0, -0.25, 1.0, -0.25, 1.0],
+                                            shape=[4 * cell_hidden_size]))
 
     with tf.variable_scope("bwBahdanau"):
-        fw_mem_layer_weights = tf.get_variable(
-            "memory_layer/kernel",
-            initializer=tf.constant([4.0, 2.0, 0.5, -8.0, -2.0, -2.0], shape=[memDepth, am_attn_size]))
+        fw_mem_layer_weights = tf.get_variable("memory_layer/kernel",
+                                               initializer=tf.constant([4.0, 2.0, 0.5, -8.0, -2.0, -2.0],
+                                                                       shape=[memDepth, am_attn_size]))
 
     bw_query_layer_weights = tf.get_variable(
         "bidirectional_rnn/bw/attention_wrapper/bahdanau_attention/query_layer/kernel",
-        initializer=tf.constant([-0.125, -0.25, 0.1, -0.125, -0.5, 1.5],
-                                shape=[cell_hidden_size, am_attn_size]))
+        initializer=tf.constant([-0.125, -0.25, 0.1, -0.125, -0.5, 1.5], shape=[cell_hidden_size, am_attn_size]))
 
-    bw_aw_attn_weights = tf.get_variable(
-        "bidirectional_rnn/bw/attention_wrapper/attention_layer/kernel",
-        initializer=tf.constant([1.5, 1.0, 0.1, -0.25, 0.1, 1.0, -0.25, -0.125, -1.5, -1.5, -0.25, 1.5],
-                                shape=[am_context_size + cell_hidden_size, aw_attn_size]))
+    bw_aw_attn_weights = tf.get_variable("bidirectional_rnn/bw/attention_wrapper/attention_layer/kernel",
+                                         initializer=tf.constant(
+                                             [1.5, 1.0, 0.1, -0.25, 0.1, 1.0, -0.25, -0.125, -1.5, -1.5, -0.25, 1.5],
+                                             shape=[am_context_size + cell_hidden_size, aw_attn_size]))
 
-    bw_am_attention_v = tf.get_variable(
-        "bidirectional_rnn/bw/attention_wrapper/bahdanau_attention/attention_v",
-        initializer=tf.constant([-0.25, 0.1], shape=[am_attn_size]))
+    bw_am_attention_v = tf.get_variable("bidirectional_rnn/bw/attention_wrapper/bahdanau_attention/attention_v",
+                                        initializer=tf.constant([-0.25, 0.1], shape=[am_attn_size]))
 
     bw_lstm_cell_kernel = tf.get_variable(
         "bidirectional_rnn/bw/attention_wrapper/lstm_cell/kernel",
         initializer=tf.constant([
-             -1.0, -1.5, -0.5, -1.5, 0.1, -0.5, 0.5, -1.5, -0.25, 1.0, -0.125, -0.25,
-             -1.0, -0.5, 0.25, -0.125, -0.25, -1.0, 1.5, 1.0, -1.5, 0.25, 0.5, 0.5,
-             1.5, -0.5, -1.0, -0.5, 0.1, 1.0, 0.1, -0.5, -0.125, -1.5, 0.1, 1.5,
-             1.0, -0.5, -0.5, -1.5, -0.125, -0.125, 0.25, -0.25, -0.25, 0.1, -0.5, -0.25,
-             0.25, -0.5, 0.1, -0.5, -0.25, 0.25, 0.1, 0.5, -1.5, -0.125, 1.5, 0.5,
-             -1.5, 1.0, 0.1, -0.5, -1.5, 0.5, -1.0, 0.25, -0.25, 1.0, 0.25, 0.5,
-             -0.125, 0.1, -1.0, -1.0, 0.1, 1.5, -1.5, 0.1, 1.5, 0.5, 0.25, 1.0,
-             1.0, -1.5, -0.25, 0.5, -0.25, 1.0, -1.0, 0.25, -0.5, 0.5, -1.5, 0.5],
-             shape=[aw_attn_size + queryDepth + cell_hidden_size, 4 * cell_hidden_size]))
+            -1.0, -1.5, -0.5, -1.5, 0.1, -0.5, 0.5, -1.5, -0.25, 1.0, -0.125, -0.25, -1.0, -0.5, 0.25, -0.125, -0.25,
+            -1.0, 1.5, 1.0, -1.5, 0.25, 0.5, 0.5, 1.5, -0.5, -1.0, -0.5, 0.1, 1.0, 0.1, -0.5, -0.125, -1.5, 0.1, 1.5,
+            1.0, -0.5, -0.5, -1.5, -0.125, -0.125, 0.25, -0.25, -0.25, 0.1, -0.5, -0.25, 0.25, -0.5, 0.1, -0.5, -0.25,
+            0.25, 0.1, 0.5, -1.5, -0.125, 1.5, 0.5, -1.5, 1.0, 0.1, -0.5, -1.5, 0.5, -1.0, 0.25, -0.25, 1.0, 0.25, 0.5,
+            -0.125, 0.1, -1.0, -1.0, 0.1, 1.5, -1.5, 0.1, 1.5, 0.5, 0.25, 1.0, 1.0, -1.5, -0.25, 0.5, -0.25, 1.0, -1.0,
+            0.25, -0.5, 0.5, -1.5, 0.5
+        ],
+                                shape=[aw_attn_size + queryDepth + cell_hidden_size, 4 * cell_hidden_size]))
 
-    bw_lstm_cell_bias = tf.get_variable(
-        "bidirectional_rnn/bw/attention_wrapper/lstm_cell/bias",
-        initializer=tf.constant([0.25, -0.25, 0.1, 1.0, 1.5, -1.5, 1.5, -1.0, -0.25, 1.0, -0.25, 1.0],
-                                shape=[4 * cell_hidden_size]))
+    bw_lstm_cell_bias = tf.get_variable("bidirectional_rnn/bw/attention_wrapper/lstm_cell/bias",
+                                        initializer=tf.constant(
+                                            [0.25, -0.25, 0.1, 1.0, 1.5, -1.5, 1.5, -1.0, -0.25, 1.0, -0.25, 1.0],
+                                            shape=[4 * cell_hidden_size]))
 
 reuse = tf.AUTO_REUSE  # tf.AUTO_REUSE or TRUE
 with tf.variable_scope(root_variable_scope, reuse=reuse):
@@ -117,14 +113,20 @@ with tf.variable_scope(root_variable_scope, reuse=reuse):
     fw_cell = tf.contrib.rnn.LSTMCell(num_units=cell_hidden_size, forget_bias=0.0)
     bw_cell = tf.contrib.rnn.LSTMCell(num_units=cell_hidden_size, forget_bias=0.0)
 
-    fw_attn_wrapper = tf.contrib.seq2seq.AttentionWrapper(
-        fw_cell, fw_am, attention_layer_size=aw_attn_size, output_attention=False)
-    bw_attn_wrapper = tf.contrib.seq2seq.AttentionWrapper(
-        bw_cell, bw_am, attention_layer_size=aw_attn_size, output_attention=False)
+    fw_attn_wrapper = tf.contrib.seq2seq.AttentionWrapper(fw_cell,
+                                                          fw_am,
+                                                          attention_layer_size=aw_attn_size,
+                                                          output_attention=False)
+    bw_attn_wrapper = tf.contrib.seq2seq.AttentionWrapper(bw_cell,
+                                                          bw_am,
+                                                          attention_layer_size=aw_attn_size,
+                                                          output_attention=False)
 
-    outputs, states = tf.nn.bidirectional_dynamic_rnn(
-        fw_attn_wrapper, bw_attn_wrapper, query, querySeqLen, dtype=tf.float32)
-
+    outputs, states = tf.nn.bidirectional_dynamic_rnn(fw_attn_wrapper,
+                                                      bw_attn_wrapper,
+                                                      query,
+                                                      querySeqLen,
+                                                      dtype=tf.float32)
 
 tensors = tf.get_collection(tf.GraphKeys.GLOBAL_VARIABLES, scope=root_variable_scope)
 
@@ -137,7 +139,7 @@ with tf.Session() as sess:
     tensors.append(outputs[0])
     tensors.append(outputs[1])
 
-    fw_state = states[0]    # output_state_fw
+    fw_state = states[0]  # output_state_fw
     cell = fw_state.cell_state.c
     attention = fw_state.attention
     alignments = fw_state.alignments
@@ -145,7 +147,7 @@ with tf.Session() as sess:
     sess.run(tf.Print(alignments, [alignments], '====Final Alignment(fw)', summarize=10000))
     sess.run(tf.Print(attention, [attention], '====Final Attention Context(fw)', summarize=10000))
 
-    bw_state = states[1]    # output_state_bw
+    bw_state = states[1]  # output_state_bw
     cell = bw_state.cell_state.c
     attention = bw_state.attention
     alignments = bw_state.alignments

--- a/onnxruntime/test/onnx/gen_test_models.py
+++ b/onnxruntime/test/onnx/gen_test_models.py
@@ -19,32 +19,34 @@ def parse_arguments():
 
 
 def write_config(model_dir):
-    with open(os.path.join(model_dir,"config.txt"),"w") as f:
-      f.write("per_sample_tolerance:1e-6\n")
-      f.write("relative_per_sample_tolerance:1e-6\n")
+    with open(os.path.join(model_dir, "config.txt"), "w") as f:
+        f.write("per_sample_tolerance:1e-6\n")
+        f.write("relative_per_sample_tolerance:1e-6\n")
 
-def write_tensor(f, c,input_name=None):
+
+def write_tensor(f, c, input_name=None):
     tensor = numpy_helper.from_array(c)
     if input_name:
-       tensor.name = input_name
+        tensor.name = input_name
     body = tensor.SerializeToString()
     f.write(body)
 
+
 def generate_abs_op_test(type, X, top_test_folder):
     for is_raw in [True, False]:
-        if is_raw:           
-           test_folder = os.path.join(top_test_folder,"raw")
+        if is_raw:
+            test_folder = os.path.join(top_test_folder, "raw")
         else:
-           test_folder = os.path.join(top_test_folder,"not_raw")
-        data_dir = os.path.join(test_folder,"test_data_0")
+            test_folder = os.path.join(top_test_folder, "not_raw")
+        data_dir = os.path.join(test_folder, "test_data_0")
         os.makedirs(data_dir, exist_ok=True)
         # Create one output (ValueInfoProto)
         Y = helper.make_tensor_value_info('Y', type, X.shape)
         X_INFO = helper.make_tensor_value_info('X', type, X.shape)
         if is_raw:
-          tensor_x = onnx.helper.make_tensor(name='X', data_type=type, dims=X.shape, vals=X.tobytes(),raw=True)
+            tensor_x = onnx.helper.make_tensor(name='X', data_type=type, dims=X.shape, vals=X.tobytes(), raw=True)
         else:
-          tensor_x = onnx.helper.make_tensor(name='X', data_type=type, dims=X.shape, vals=X.ravel(),raw=False)
+            tensor_x = onnx.helper.make_tensor(name='X', data_type=type, dims=X.shape, vals=X.ravel(), raw=False)
         # Create a node (NodeProto)
         node_def = helper.make_node('Abs', inputs=['X'], outputs=['Y'])
 
@@ -59,16 +61,17 @@ def generate_abs_op_test(type, X, top_test_folder):
         onnx.save(final_model, os.path.join(test_folder, 'model.onnx'))
         expected_output_array = np.abs(X)
         expected_output_tensor = numpy_helper.from_array(expected_output_array)
-        with open(os.path.join(data_dir,"output_0.pb"),"wb") as f:    
-                f.write(expected_output_tensor.SerializeToString())
+        with open(os.path.join(data_dir, "output_0.pb"), "wb") as f:
+            f.write(expected_output_tensor.SerializeToString())
+
 
 def generate_size_op_test(type, X, test_folder):
-    data_dir = os.path.join(test_folder,"test_data_0")
+    data_dir = os.path.join(test_folder, "test_data_0")
     os.makedirs(data_dir, exist_ok=True)
     # Create one output (ValueInfoProto)
     Y = helper.make_tensor_value_info('Y', TensorProto.INT64, [])
     X_INFO = helper.make_tensor_value_info('X', type, X.shape)
-    tensor_x = onnx.helper.make_tensor(name='X', data_type=type, dims=X.shape, vals=X.ravel(),raw=False)
+    tensor_x = onnx.helper.make_tensor(name='X', data_type=type, dims=X.shape, vals=X.ravel(), raw=False)
     # Create a node (NodeProto)
     node_def = helper.make_node('Size', inputs=['X'], outputs=['Y'])
 
@@ -79,18 +82,19 @@ def generate_size_op_test(type, X, test_folder):
     final_model = onnx.utils.polish_model(model_def)
     onnx.save(final_model, os.path.join(test_folder, 'model.onnx'))
     expected_output_array = np.int64(X.size)
-    expected_output_tensor = numpy_helper.from_array(expected_output_array)    
-    with open(os.path.join(data_dir,"output_0.pb"),"wb") as f:    
+    expected_output_tensor = numpy_helper.from_array(expected_output_array)
+    with open(os.path.join(data_dir, "output_0.pb"), "wb") as f:
         f.write(expected_output_tensor.SerializeToString())
+
 
 def generate_reducesum_op_test(X, test_folder):
     type = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[X.dtype]
-    data_dir = os.path.join(test_folder,"test_data_0")
+    data_dir = os.path.join(test_folder, "test_data_0")
     os.makedirs(data_dir, exist_ok=True)
     # Create one output (ValueInfoProto)
     Y = helper.make_tensor_value_info('Y', type, [])
     X_INFO = helper.make_tensor_value_info('X', type, X.shape)
-    tensor_x = onnx.helper.make_tensor(name='X', data_type=type, dims=X.shape, vals=X.ravel(),raw=False)
+    tensor_x = onnx.helper.make_tensor(name='X', data_type=type, dims=X.shape, vals=X.ravel(), raw=False)
     # Create a node (NodeProto)
     node_def = helper.make_node('ReduceSum', inputs=['X'], outputs=['Y'], keepdims=0)
 
@@ -102,65 +106,83 @@ def generate_reducesum_op_test(X, test_folder):
     onnx.save(final_model, os.path.join(test_folder, 'model.onnx'))
     expected_output_array = np.sum(X)
     expected_output_tensor = numpy_helper.from_array(expected_output_array)
-    with open(os.path.join(data_dir,"output_0.pb"),"wb") as f:
+    with open(os.path.join(data_dir, "output_0.pb"), "wb") as f:
         f.write(expected_output_tensor.SerializeToString())
 
+
 def test_abs(output_dir):
-        generate_abs_op_test(TensorProto.FLOAT, np.random.randn(3, 4, 5).astype(np.float32), os.path.join(output_dir,'test_abs_float'))
-        generate_abs_op_test(TensorProto.DOUBLE, np.random.randn(3, 4, 5).astype(np.float64), os.path.join(output_dir,'test_abs_double'))
-        generate_abs_op_test(TensorProto.INT8, np.int8([-127, -4, 0, 3, 127]), os.path.join(output_dir, 'test_abs_int8'))
-        generate_abs_op_test(TensorProto.UINT8, np.uint8([0, 1, 20, 255]), os.path.join(output_dir, 'test_abs_uint8'))
-        generate_abs_op_test(TensorProto.INT16, np.int16([-32767, -4, 0, 3, 32767]), os.path.join(output_dir, 'test_abs_int16'))
-        generate_abs_op_test(TensorProto.UINT16, np.uint16([-32767, -4, 0, 3, 32767]), os.path.join(output_dir, 'test_abs_uint16'))
-        generate_abs_op_test(TensorProto.INT32, np.int32([-2147483647, -4, 0, 3, 2147483647]), os.path.join(output_dir, 'test_abs_int32'))
-        generate_abs_op_test(TensorProto.UINT32, np.uint32([0, 1, 20, 4294967295]), os.path.join(output_dir, 'test_abs_uint32'))
-        number_info = np.iinfo(np.int64)
-        generate_abs_op_test(TensorProto.INT64, np.int64([-number_info.max, -4, 0, 3, number_info.max]), os.path.join(output_dir, 'test_abs_int64'))
-        number_info = np.iinfo(np.uint64)
-        generate_abs_op_test(TensorProto.UINT64, np.uint64([0, 1, 20, number_info.max]), os.path.join(output_dir, 'test_abs_uint64'))
+    generate_abs_op_test(TensorProto.FLOAT,
+                         np.random.randn(3, 4, 5).astype(np.float32), os.path.join(output_dir, 'test_abs_float'))
+    generate_abs_op_test(TensorProto.DOUBLE,
+                         np.random.randn(3, 4, 5).astype(np.float64), os.path.join(output_dir, 'test_abs_double'))
+    generate_abs_op_test(TensorProto.INT8, np.int8([-127, -4, 0, 3, 127]), os.path.join(output_dir, 'test_abs_int8'))
+    generate_abs_op_test(TensorProto.UINT8, np.uint8([0, 1, 20, 255]), os.path.join(output_dir, 'test_abs_uint8'))
+    generate_abs_op_test(TensorProto.INT16, np.int16([-32767, -4, 0, 3, 32767]),
+                         os.path.join(output_dir, 'test_abs_int16'))
+    generate_abs_op_test(TensorProto.UINT16, np.uint16([-32767, -4, 0, 3, 32767]),
+                         os.path.join(output_dir, 'test_abs_uint16'))
+    generate_abs_op_test(TensorProto.INT32, np.int32([-2147483647, -4, 0, 3, 2147483647]),
+                         os.path.join(output_dir, 'test_abs_int32'))
+    generate_abs_op_test(TensorProto.UINT32, np.uint32([0, 1, 20, 4294967295]),
+                         os.path.join(output_dir, 'test_abs_uint32'))
+    number_info = np.iinfo(np.int64)
+    generate_abs_op_test(TensorProto.INT64, np.int64([-number_info.max, -4, 0, 3, number_info.max]),
+                         os.path.join(output_dir, 'test_abs_int64'))
+    number_info = np.iinfo(np.uint64)
+    generate_abs_op_test(TensorProto.UINT64, np.uint64([0, 1, 20, number_info.max]),
+                         os.path.join(output_dir, 'test_abs_uint64'))
+
 
 def test_reducesum(output_dir):
-    generate_reducesum_op_test(np.random.randn(3, 4, 5).astype(np.float32), os.path.join(output_dir, 'test_reducesum_random'))
+    generate_reducesum_op_test(
+        np.random.randn(3, 4, 5).astype(np.float32), os.path.join(output_dir, 'test_reducesum_random'))
+
 
 def test_size(output_dir):
-    generate_size_op_test(TensorProto.FLOAT, np.random.randn(100, 3000, 10).astype(np.float32), os.path.join(output_dir,'test_size_float'))
-    generate_size_op_test(TensorProto.STRING, np.array(['abc', 'xy'], dtype=np.bytes_), os.path.join(output_dir,'test_size_string'))
+    generate_size_op_test(TensorProto.FLOAT,
+                          np.random.randn(100, 3000, 10).astype(np.float32),
+                          os.path.join(output_dir, 'test_size_float'))
+    generate_size_op_test(TensorProto.STRING, np.array(['abc', 'xy'], dtype=np.bytes_),
+                          os.path.join(output_dir, 'test_size_string'))
 
 
 def gen_cdist_test(output_dir, dtype, M, N, K):
     for mode in ['euclidean', 'sqeuclidean']:
-      test_folder = os.path.join(output_dir,"test_cdist_%s_%s_%d_%d_%d" % (dtype.__name__, mode, M,N,K))
-      data_dir = os.path.join(test_folder, "test_data_0")
-      os.makedirs(data_dir, exist_ok=True)    
-      a = np.random.randn(M, K).astype(dtype)
-      b = np.random.randn(N, K).astype(dtype)
-      type = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[a.dtype]
-      c = distance.cdist(a, b, mode).astype(dtype)
-      node_def = helper.make_node('CDist', inputs=['A','B'], outputs=['C'],domain="com.microsoft", metric=mode)    
-      graph_def = helper.make_graph([node_def], 'test-model', [helper.make_tensor_value_info('A', type, a.shape),
-                                                             helper.make_tensor_value_info('B', type, b.shape)], 
-                                  [helper.make_tensor_value_info('C', type, c.shape)])
-      model_def = helper.make_model(graph_def, producer_name='onnx-example',opset_imports=[helper.make_opsetid("com.microsoft", 1)])
-      onnx.save(model_def, os.path.join(test_folder, 'model.onnx'))    
-      with open(os.path.join(data_dir,"input_0.pb"),"wb") as f:
-        write_tensor(f, a, "A")        
-      with open(os.path.join(data_dir,"input_1.pb"),"wb") as f:
-        write_tensor(f, b, "B")
-      with open(os.path.join(data_dir,"output_0.pb"),"wb") as f:
-        write_tensor(f, c, "C")
-      write_config(test_folder)
+        test_folder = os.path.join(output_dir, "test_cdist_%s_%s_%d_%d_%d" % (dtype.__name__, mode, M, N, K))
+        data_dir = os.path.join(test_folder, "test_data_0")
+        os.makedirs(data_dir, exist_ok=True)
+        a = np.random.randn(M, K).astype(dtype)
+        b = np.random.randn(N, K).astype(dtype)
+        type = onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[a.dtype]
+        c = distance.cdist(a, b, mode).astype(dtype)
+        node_def = helper.make_node('CDist', inputs=['A', 'B'], outputs=['C'], domain="com.microsoft", metric=mode)
+        graph_def = helper.make_graph(
+            [node_def], 'test-model',
+            [helper.make_tensor_value_info('A', type, a.shape),
+             helper.make_tensor_value_info('B', type, b.shape)], [helper.make_tensor_value_info('C', type, c.shape)])
+        model_def = helper.make_model(graph_def,
+                                      producer_name='onnx-example',
+                                      opset_imports=[helper.make_opsetid("com.microsoft", 1)])
+        onnx.save(model_def, os.path.join(test_folder, 'model.onnx'))
+        with open(os.path.join(data_dir, "input_0.pb"), "wb") as f:
+            write_tensor(f, a, "A")
+        with open(os.path.join(data_dir, "input_1.pb"), "wb") as f:
+            write_tensor(f, b, "B")
+        with open(os.path.join(data_dir, "output_0.pb"), "wb") as f:
+            write_tensor(f, c, "C")
+        write_config(test_folder)
+
 
 def test_cdist(output_dir):
-    for dtype in [np.float32, np.float64] :
+    for dtype in [np.float32, np.float64]:
         gen_cdist_test(output_dir, dtype, 1000, 2000, 500)
         gen_cdist_test(output_dir, dtype, 1000, 2000, 1)
         gen_cdist_test(output_dir, dtype, 1, 1, 1)
 
+
 args = parse_arguments()
-os.makedirs(args.output_dir,exist_ok=True)
+os.makedirs(args.output_dir, exist_ok=True)
 test_abs(args.output_dir)
 test_size(args.output_dir)
 test_reducesum(args.output_dir)
 test_cdist(args.output_dir)
-
-

--- a/onnxruntime/test/providers/cpu/reduction/reduction_test_cases_generator.py
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_test_cases_generator.py
@@ -4,6 +4,7 @@
 import os
 import numpy as np
 
+
 def TestReduction(op, data, axes, keepdims):
     if op == "ReduceL1":
         return np.sum(a=np.abs(data), axis=axes, keepdims=keepdims)
@@ -38,85 +39,91 @@ def TestReduction(op, data, axes, keepdims):
             res = np.expand_dims(res, axis)
         return res
 
+
 def PrintResult(op, axes, keepdims, res):
     print("  {\"%s\"," % op)
     print("OpAttributesResult(")
     print("    // ReductionAttribute")
     print("      {")
-    print (" // axes_")
-    print ("{",  end='')
-    print(*axes, sep=", ",  end='') if axes else print("")
-    print ("},")
-    print (" // keep_dims_")
-    print (keepdims, ",")
-    print ("},")
+    print(" // axes_")
+    print("{", end='')
+    print(*axes, sep=", ", end='') if axes else print("")
+    print("},")
+    print(" // keep_dims_")
+    print(keepdims, ",")
+    print("},")
 
-    print (" // expected dims")
-    print ("{",  end='')
-    print(*res.shape, sep=", ",  end='')
-    print ("},")
+    print(" // expected dims")
+    print("{", end='')
+    print(*res.shape, sep=", ", end='')
+    print("},")
 
-    print (" // expected values")
-    print ("{",  end='')
+    print(" // expected values")
+    print("{", end='')
     for i in range(0, res.size):
         print("%5.6ff," % res.item(i))
 
-    print ("})},")
+    print("})},")
+
 
 def PrintDisableOptimizations():
-    print ("// Optimizations are disabled in this file to improve build throughput")
-    print ("#if defined(_MSC_VER) || defined(__INTEL_COMPILER)")
-    print ("#pragma optimize (\"\", off)")
-    print ("#elif defined(__GNUC__)")
-    print ("#if defined(__clang__)")
-    print ("\t#pragma clang optimize off")
-    print ("#else")
-    print ("\t#pragma GCC push_options")
-    print ("\t#pragma GCC optimize (\"O0\")")
-    print ("#endif")
-    print ("#endif")
+    print("// Optimizations are disabled in this file to improve build throughput")
+    print("#if defined(_MSC_VER) || defined(__INTEL_COMPILER)")
+    print("#pragma optimize (\"\", off)")
+    print("#elif defined(__GNUC__)")
+    print("#if defined(__clang__)")
+    print("\t#pragma clang optimize off")
+    print("#else")
+    print("\t#pragma GCC push_options")
+    print("\t#pragma GCC optimize (\"O0\")")
+    print("#endif")
+    print("#endif")
+
 
 def PrintReenableOptimizations():
-    print ("#if defined(_MSC_VER) || defined(__INTEL_COMPILER)")
-    print ("\t#pragma optimize (\"\", on)")
-    print ("#elif defined(__GNUC__)")
-    print ("#if defined(__clang__)")
-    print ("\t#pragma clang optimize on")
-    print ("#else")
-    print ("\t#pragma GCC pop_options")
-    print ("#endif")
-    print ("#endif")
+    print("#if defined(_MSC_VER) || defined(__INTEL_COMPILER)")
+    print("\t#pragma optimize (\"\", on)")
+    print("#elif defined(__GNUC__)")
+    print("#if defined(__clang__)")
+    print("\t#pragma clang optimize on")
+    print("#else")
+    print("\t#pragma GCC pop_options")
+    print("#endif")
+    print("#endif")
+
 
 if __name__ == "__main__":
     from itertools import product
-    input_shape = [2,3,2,2,3]
+    input_shape = [2, 3, 2, 2, 3]
     np.random.seed(0)
     input_data = np.random.uniform(size=input_shape)
-    axes_options = [(-1,3), (2,3), (2, 1, 4), (0,-2,-3), (0, 2, 3), (0,), (2,), (4,), None]
+    axes_options = [(-1, 3), (2, 3), (2, 1, 4), (0, -2, -3), (0, 2, 3), (0,), (2,), (4,), None]
     keepdims_options = [0, 1]
-    ops = ["ReduceL1", "ReduceL2", "ReduceLogSum", "ReduceLogSumExp", "ReduceMax", "ReduceMean", 
-           "ReduceMin", "ReduceProd", "ReduceSum", "ReduceSumSquare", "ArgMax", "ArgMin"]
-    print ("// Please don't manually edit this file. Generated from reduction_test_cases_generator.py")
+    ops = [
+        "ReduceL1", "ReduceL2", "ReduceLogSum", "ReduceLogSumExp", "ReduceMax", "ReduceMean", "ReduceMin", "ReduceProd",
+        "ReduceSum", "ReduceSumSquare", "ArgMax", "ArgMin"
+    ]
+    print("// Please don't manually edit this file. Generated from reduction_test_cases_generator.py")
     PrintDisableOptimizations()
-    print ("ReductionTestCases testcases = {")
-    print ("// input_data")
-    print ("{")
+    print("ReductionTestCases testcases = {")
+    print("// input_data")
+    print("{")
     for i in range(0, input_data.size):
         print("%5.6ff," % input_data.item(i),)
-    print ("},")
-    print ("// input_dims")
-    print ("{", end='')
+    print("},")
+    print("// input_dims")
+    print("{", end='')
     print(*input_shape, sep=", ", end='')
-    print ("},")
+    print("},")
 
     print("  // map_op_attribute_expected")
-    print ("{")
+    print("{")
 
     for config in product(axes_options, keepdims_options, ops):
         axes, keepdims, op = config
-        
+
         #ArgMax and ArgMin only take single axis (default 0)
-        skip = False;
+        skip = False
         if op == "ArgMax" or op == "ArgMin":
             skip = axes is not None and len(axes) > 1
 
@@ -124,6 +131,6 @@ if __name__ == "__main__":
             res = TestReduction(op, input_data, axes, keepdims)
             PrintResult(op, axes, keepdims, res)
 
-    print ("}")
-    print ("};")
+    print("}")
+    print("};")
     PrintReenableOptimizations()

--- a/onnxruntime/test/providers/cpu/rnn/GRU.py
+++ b/onnxruntime/test/providers/cpu/rnn/GRU.py
@@ -4,16 +4,19 @@
 import numpy as np
 
 DebugOutput = False
-np.set_printoptions(suppress=True) #, precision=16, floatmode='maxprec')
+np.set_printoptions(suppress=True)  #, precision=16, floatmode='maxprec')
+
 
 def print_with_shape(name, a, force_output=False):
     if (force_output or DebugOutput):
         print(name + " [shape: ", a.shape, "]\n", a)
 
+
 def print_results(Y):
     print("*************************")
     print_with_shape("Y", Y, True)
     print("*************************")
+
 
 class GRU_Helper():
 
@@ -35,8 +38,10 @@ class GRU_Helper():
         X = params['X']
         W = params['W']
         R = params['R']
-        B = params['B'] if 'B' in params else np.zeros(num_directions * 6 * hidden_size).reshape(num_directions, 6 * hidden_size)
-        H_0 = params['initial_h'] if 'initial_h' in params else np.zeros((num_directions, batch_size, hidden_size)).reshape(num_directions, batch_size, hidden_size)
+        B = params['B'] if 'B' in params else np.zeros(num_directions * 6 *
+                                                       hidden_size).reshape(num_directions, 6 * hidden_size)
+        H_0 = params['initial_h'] if 'initial_h' in params else np.zeros(
+            (num_directions, batch_size, hidden_size)).reshape(num_directions, batch_size, hidden_size)
         LBR = params['linear_before_reset'] if 'linear_before_reset' in params else 0
         self.direction = params['direction'] if 'direction' in params else 'forward'
 
@@ -45,7 +50,7 @@ class GRU_Helper():
                 self.one = OneDirectionGRU(X, W, R, B, H_0, LBR)
             else:
                 # flip input so we process in reverse
-                self.one = OneDirectionGRU(np.flip(X,0), W, R, B, H_0, LBR)
+                self.one = OneDirectionGRU(np.flip(X, 0), W, R, B, H_0, LBR)
 
             self.two = None
 
@@ -87,6 +92,7 @@ class GRU_Helper():
                 output = np.flip(output, 0)
 
         return output
+
 
 class OneDirectionGRU():
 
@@ -156,6 +162,7 @@ class OneDirectionGRU():
 
         return output
 
+
 class ONNXRuntimeTestContext():
 
     @staticmethod
@@ -163,23 +170,32 @@ class ONNXRuntimeTestContext():
 
         hidden_size = 2
 
-        W = np.array([[[-0.494659, 0.0453352],  # Wz
-                       [-0.487793, 0.417264],
-                       [-0.0091708, -0.255364],  # Wr
-                       [-0.106952, -0.266717],
-                       [-0.0888852, -0.428709],  # Wh
-                       [-0.283349, 0.208792]]]).astype(np.float32)
+        W = np.array([[
+            [-0.494659, 0.0453352],  # Wz
+            [-0.487793, 0.417264],
+            [-0.0091708, -0.255364],  # Wr
+            [-0.106952, -0.266717],
+            [-0.0888852, -0.428709],  # Wh
+            [-0.283349, 0.208792]
+        ]]).astype(np.float32)
 
-        R = np.array([[[0.146626, -0.0620289],  # Rz
-                       [-0.0815302, 0.100482],
-                       [-0.228172, 0.405972],  # Rr
-                       [0.31576, 0.281487],
-                       [-0.394864, 0.42111],  # Rh
-                       [-0.386624, -0.390225]]]).astype(np.float32)
+        R = np.array([[
+            [0.146626, -0.0620289],  # Rz
+            [-0.0815302, 0.100482],
+            [-0.228172, 0.405972],  # Rr
+            [0.31576, 0.281487],
+            [-0.394864, 0.42111],  # Rh
+            [-0.386624, -0.390225]
+        ]]).astype(np.float32)
 
-        W_B = np.array([[0.381619, 0.0323954,  # Wbz
-                         -0.258721, 0.45056,  # Wbr
-                         -0.250755, 0.0967895]]).astype(np.float32)  # Wbh
+        W_B = np.array([[
+            0.381619,
+            0.0323954,  # Wbz
+            -0.258721,
+            0.45056,  # Wbr
+            -0.250755,
+            0.0967895
+        ]]).astype(np.float32)  # Wbh
         R_B = np.zeros((1, 3 * hidden_size)).astype(np.float32)
         B = np.concatenate((W_B, R_B), axis=1)
 
@@ -195,9 +211,10 @@ class ONNXRuntimeTestContext():
 
         W = np.tile(W1, (2, 1)).reshape(2, 3 * hidden_size, input_size)
         R = np.tile(R1, (2, 1)).reshape(2, 3 * hidden_size, hidden_size)
-        B = np.tile(B1, (2,1))
+        B = np.tile(B1, (2, 1))
 
         return W, R, B
+
 
 # replicate ONNXRuntime unit tests inputs to validate output
 class GRU_ONNXRuntimeUnitTests():
@@ -218,7 +235,7 @@ class GRU_ONNXRuntimeUnitTests():
         weight_scale = 0.1
         R = weight_scale * np.ones((1, 3 * hidden_size, hidden_size)).astype(np.float32)
 
-        gru = GRU_Helper(X=input,W=W,R=R,direction='forward')
+        gru = GRU_Helper(X=input, W=W, R=R, direction='forward')
         fw_output = gru.run()
         print_results(fw_output)
 
@@ -231,16 +248,14 @@ class GRU_ONNXRuntimeUnitTests():
         batch_size = 2
         input_size = 1
         hidden_size = 3
-        input = np.array([[[1.], [2.]],
-                          [[10.], [11.]]]).astype(np.float32)
-
+        input = np.array([[[1.], [2.]], [[10.], [11.]]]).astype(np.float32)
 
         W = np.array([0.1, 0.2, 0.3, 1, 2, 3, 10, 11, 12]).astype(np.float32).reshape(1, 3 * hidden_size, input_size)
 
         weight_scale = 0.1
         R = weight_scale * np.ones((1, 3 * hidden_size, hidden_size)).astype(np.float32)
 
-        gru = GRU_Helper(X=input,W=W,R=R,direction='reverse')
+        gru = GRU_Helper(X=input, W=W, R=R, direction='reverse')
         fw_output = gru.run()
         print_results(fw_output)
 
@@ -254,8 +269,7 @@ class GRU_ONNXRuntimeUnitTests():
         input_size = 1
         hidden_size = 3
 
-        input = np.array([[[1.], [2.]],
-                          [[10.], [11.]]]).astype(np.float32)
+        input = np.array([[[1.], [2.]], [[10.], [11.]]]).astype(np.float32)
 
         W = np.array([0.1, 0.2, 0.3, 1, 2, 3, 10, 11, 12]).astype(np.float32).reshape(1, 3 * hidden_size, input_size)
 
@@ -264,8 +278,8 @@ class GRU_ONNXRuntimeUnitTests():
 
         # duplicate the W and R inputs so we use the same values for both forward and reverse
         gru = GRU_Helper(X=input,
-                         W=np.tile(W,(2,1)).reshape(2, 3 * hidden_size, input_size),
-                         R=np.tile(R,(2,1)).reshape(2, 3 * hidden_size, hidden_size),
+                         W=np.tile(W, (2, 1)).reshape(2, 3 * hidden_size, input_size),
+                         R=np.tile(R, (2, 1)).reshape(2, 3 * hidden_size, hidden_size),
                          direction='bidirectional')
 
         fw_output = gru.run()
@@ -274,10 +288,8 @@ class GRU_ONNXRuntimeUnitTests():
     @staticmethod
     def DefaultActivationsSimpleWeightsWithBias(rows=2, direction="forward", linear_before_reset=0):
 
-        print(GRU_ONNXRuntimeUnitTests.DefaultActivationsSimpleWeightsWithBias.__name__ +
-              " batch_parallel=" + str(rows != 1) +
-              " direction=" + direction +
-              " linear_before_reset=" + str(linear_before_reset))
+        print(GRU_ONNXRuntimeUnitTests.DefaultActivationsSimpleWeightsWithBias.__name__ + " batch_parallel=" +
+              str(rows != 1) + " direction=" + direction + " linear_before_reset=" + str(linear_before_reset))
 
         seq_length = 2
         batch_size = rows
@@ -291,16 +303,18 @@ class GRU_ONNXRuntimeUnitTests():
 
         input = np.array(input).astype(np.float32).reshape(seq_length, batch_size, input_size)
 
-        W = np.array([0.1, 0.2, 0.3, 0.2, 0.3, 0.1, 0.3, 0.1, 0.2]).astype(np.float32).reshape(1, 3 * hidden_size, input_size)
+        W = np.array([0.1, 0.2, 0.3, 0.2, 0.3, 0.1, 0.3, 0.1,
+                      0.2]).astype(np.float32).reshape(1, 3 * hidden_size, input_size)
 
         weight_scale = 0.1
         R = weight_scale * np.ones((1, 3 * hidden_size, hidden_size)).astype(np.float32)
 
         # Wb[zrh] Rb[zrh]
-        B = np.array([-0.01, 0.1, 0.01, -0.2, -0.02, 0.02, 0.3, -0.3, -0.3,
-                      -0.03, 0.5, -0.7, 0.05, -0.7, 0.3, 0.07, -0.03, 0.5 ]).astype(np.float32).reshape(1, 6 * hidden_size)
+        B = np.array(
+            [-0.01, 0.1, 0.01, -0.2, -0.02, 0.02, 0.3, -0.3, -0.3, -0.03, 0.5, -0.7, 0.05, -0.7, 0.3, 0.07, -0.03,
+             0.5]).astype(np.float32).reshape(1, 6 * hidden_size)
 
-        gru = GRU_Helper(X=input,W=W,R=R, B=B, direction=direction, linear_before_reset=linear_before_reset)
+        gru = GRU_Helper(X=input, W=W, R=R, B=B, direction=direction, linear_before_reset=linear_before_reset)
         fw_output = gru.run()
         print_results(fw_output)
 
@@ -326,15 +340,16 @@ class GRU_ONNXRuntimeUnitTests():
     @staticmethod
     def ReverseDefaultActivationsSimpleWeightsWithBiasLinearBeforeReset(linear_before_reset=0):
 
-        GRU_ONNXRuntimeUnitTests.DefaultActivationsSimpleWeightsWithBias(rows=1, direction="reverse", linear_before_reset=1)
+        GRU_ONNXRuntimeUnitTests.DefaultActivationsSimpleWeightsWithBias(rows=1,
+                                                                         direction="reverse",
+                                                                         linear_before_reset=1)
 
     @staticmethod
     def Legacy_TestGRUOpForwardBasic():
 
         print(GRU_ONNXRuntimeUnitTests.Legacy_TestGRUOpForwardBasic.__name__)
 
-        input = np.array([[[-0.455351, -0.276391]],
-                          [[-0.185934, -0.269585]]]).astype(np.float32)
+        input = np.array([[[-0.455351, -0.276391]], [[-0.185934, -0.269585]]]).astype(np.float32)
 
         W, R, B = ONNXRuntimeTestContext.OneDirectionWeights()
         gru = GRU_Helper(X=input, W=W, R=R, B=B)
@@ -345,8 +360,7 @@ class GRU_ONNXRuntimeUnitTests():
     def Legacy_TestGRUOpBackwardBasic():
         print(GRU_ONNXRuntimeUnitTests.Legacy_TestGRUOpBackwardBasic.__name__)
 
-        input = np.array([[[-0.185934, -0.269585]],
-                          [[-0.455351, -0.276391]]]).astype(np.float32)
+        input = np.array([[[-0.185934, -0.269585]], [[-0.455351, -0.276391]]]).astype(np.float32)
 
         W, R, B = ONNXRuntimeTestContext.OneDirectionWeights()
         gru = GRU_Helper(X=input, W=W, R=R, B=B, direction='reverse')
@@ -358,13 +372,13 @@ class GRU_ONNXRuntimeUnitTests():
 
         print(GRU_ONNXRuntimeUnitTests.Legacy_TestGRUOpBidirectionalBasic.__name__)
 
-        input = np.array([[[-0.455351, -0.276391]],
-                          [[-0.185934, -0.269585]]]).astype(np.float32)
+        input = np.array([[[-0.455351, -0.276391]], [[-0.185934, -0.269585]]]).astype(np.float32)
 
         W, R, B = ONNXRuntimeTestContext.BidirectionalWeights()
         gru = GRU_Helper(X=input, W=W, R=R, B=B, direction='bidirectional')
         output = gru.run()
         print_results(output)
+
 
 GRU_ONNXRuntimeUnitTests.ForwardDefaultActivationsSimpleWeightsNoBiasTwoRows()
 GRU_ONNXRuntimeUnitTests.ReverseDefaultActivationsSimpleWeightsNoBiasTwoRows()

--- a/onnxruntime/test/providers/cpu/rnn/LSTM.py
+++ b/onnxruntime/test/providers/cpu/rnn/LSTM.py
@@ -14,7 +14,8 @@ from typing import Any, Tuple
 #from . import expect
 
 DebugOutput = True
-np.set_printoptions(suppress=True) #, precision=16, floatmode='maxprec')
+np.set_printoptions(suppress=True)  #, precision=16, floatmode='maxprec')
+
 
 def print_with_shape(name, a, force_output=False):
     if (force_output or DebugOutput):
@@ -29,6 +30,7 @@ def print_results(Y, Y_h, Y_c):
     print("---------")
     print_with_shape("Y_c", Y_c, True)
     print("*************************")
+
 
 class LSTM_Helper():
 
@@ -47,10 +49,14 @@ class LSTM_Helper():
         batch_size = X.shape[1]
         hidden_size = R.shape[-1]
 
-        B = params['B'] if 'B' in params else np.zeros(num_directions * 8 * hidden_size).reshape(num_directions, 8 * hidden_size)
-        P = params['P'] if 'P' in params else np.zeros(num_directions * 3 * hidden_size).reshape(num_directions, 3 * hidden_size)
-        h_0 = params['initial_h'] if 'initial_h' in params else np.zeros((num_directions, batch_size, hidden_size)).reshape(num_directions, batch_size, hidden_size)
-        c_0 = params['initial_c'] if 'initial_c' in params else np.zeros((num_directions, batch_size, hidden_size)).reshape(num_directions, batch_size, hidden_size)
+        B = params['B'] if 'B' in params else np.zeros(num_directions * 8 *
+                                                       hidden_size).reshape(num_directions, 8 * hidden_size)
+        P = params['P'] if 'P' in params else np.zeros(num_directions * 3 *
+                                                       hidden_size).reshape(num_directions, 3 * hidden_size)
+        h_0 = params['initial_h'] if 'initial_h' in params else np.zeros(
+            (num_directions, batch_size, hidden_size)).reshape(num_directions, batch_size, hidden_size)
+        c_0 = params['initial_c'] if 'initial_c' in params else np.zeros(
+            (num_directions, batch_size, hidden_size)).reshape(num_directions, batch_size, hidden_size)
 
         f = params['f'] if 'f' in params else ActivationFuncs.sigmoid
         g = params['g'] if 'g' in params else ActivationFuncs.tanh
@@ -116,7 +122,9 @@ class LSTM_Helper():
 
         return output, Y_h, Y_c
 
+
 class ActivationFuncs:
+
     @staticmethod
     def sigmoid(x):
         return 1 / (1 + np.exp(-x))
@@ -125,11 +133,22 @@ class ActivationFuncs:
     def tanh(x):
         return np.tanh(x)
 
+
 class OneDirectionLSTM:
 
-    def __init__(self, X, W, R, B, P, initial_h, initial_c,
-                 f = ActivationFuncs.sigmoid, g = ActivationFuncs.tanh, h = ActivationFuncs.tanh,
-                 input_forget = False, clip = 9999.0):
+    def __init__(self,
+                 X,
+                 W,
+                 R,
+                 B,
+                 P,
+                 initial_h,
+                 initial_c,
+                 f=ActivationFuncs.sigmoid,
+                 g=ActivationFuncs.tanh,
+                 h=ActivationFuncs.tanh,
+                 input_forget=False,
+                 clip=9999.0):
 
         self.X = X
         # remove num_directions axis for W, R, B, P, H_0, C_0
@@ -222,20 +241,17 @@ class LSTM:  # Base):
         hidden_size = 3
         number_of_gates = 4
 
-        input = np.array([[[1.], [2.]],
-                          [[10.], [11.]]]).astype(np.float32)
+        input = np.array([[[1.], [2.]], [[10.], [11.]]]).astype(np.float32)
 
-        W = np.array([0.1, 0.2, 0.3, 0.4,
-                      1, 2, 3, 4,
-                      10, 11, 12, 13]).astype(np.float32).reshape(1, number_of_gates * hidden_size, input_size)
+        W = np.array([0.1, 0.2, 0.3, 0.4, 1, 2, 3, 4, 10, 11, 12,
+                      13]).astype(np.float32).reshape(1, number_of_gates * hidden_size, input_size)
 
         weight_scale = 0.1
         R = weight_scale * np.ones((1, number_of_gates * hidden_size, hidden_size)).astype(np.float32)
 
-
         if (direction == 'bidirectional'):
-            W = W=np.tile(W, (2, 1)).reshape(2, number_of_gates * hidden_size, input_size)
-            R = R=np.tile(R, (2, 1)).reshape(2, number_of_gates * hidden_size, hidden_size)
+            W = W = np.tile(W, (2, 1)).reshape(2, number_of_gates * hidden_size, input_size)
+            R = R = np.tile(R, (2, 1)).reshape(2, number_of_gates * hidden_size, hidden_size)
 
         lstm = LSTM_Helper(X=input, W=W, R=R, direction=direction)
 
@@ -255,11 +271,11 @@ class LSTM:  # Base):
         number_of_gates = 4
 
         # sequentialvalues from 1 to 32
-        input = np.array(range(1,seq_length * batch_size + 1, 1)).astype(np.float32).reshape(seq_length, batch_size, input_size)
+        input = np.array(range(1, seq_length * batch_size + 1,
+                               1)).astype(np.float32).reshape(seq_length, batch_size, input_size)
 
-        W = np.array([0.1, 0.2, 0.3, 0.4,
-                      1, 2, 3, 4,
-                      10, 11, 12, 13]).astype(np.float32).reshape(1, number_of_gates * hidden_size, input_size)
+        W = np.array([0.1, 0.2, 0.3, 0.4, 1, 2, 3, 4, 10, 11, 12,
+                      13]).astype(np.float32).reshape(1, number_of_gates * hidden_size, input_size)
 
         weight_scale = 0.1
         R = weight_scale * np.ones((1, number_of_gates * hidden_size, hidden_size)).astype(np.float32)
@@ -281,8 +297,8 @@ class LSTM:  # Base):
 
         input = np.array([1, 2]).astype(np.float32).reshape(seq_length, batch_size, input_size)
 
-        W = np.array([0.1, 0.2, 0.3, 0.4,
-                      1, 2, 3, 4]).astype(np.float32).reshape(1, number_of_gates * hidden_size, input_size)
+        W = np.array([0.1, 0.2, 0.3, 0.4, 1, 2, 3, 4]).astype(np.float32).reshape(1, number_of_gates * hidden_size,
+                                                                                  input_size)
 
         weight_scale = 0.1
         R = weight_scale * np.ones((1, number_of_gates * hidden_size, hidden_size)).astype(np.float32)
@@ -291,7 +307,6 @@ class LSTM:  # Base):
 
         Y, Y_h, Y_c = lstm.run()
         print_results(Y, Y_h, Y_c)
-
 
     @staticmethod
     def export_initial_bias():  # type: () -> None
@@ -358,6 +373,7 @@ class LSTM:  # Base):
         # expect(node, inputs=[input, W, R, B, seq_lens, init_h, init_c, P], outputs=[Y_h.astype(np.float32)],
         #        name='test_lstm_with_peepholes')
 
+
 class ONNXRuntimeTestContext:
 
     hidden_size = 2
@@ -371,48 +387,39 @@ class ONNXRuntimeTestContext:
         input_size = ONNXRuntimeTestContext.input_size
 
         W = np.array([
-            -0.494659, 0.0453352,
-            -0.487793, 0.417264,
-
-            -0.0175329, 0.489074,
-            -0.446013, 0.414029,
-
-            -0.0091708, -0.255364,
-            -0.106952, -0.266717,
-
-            -0.0888852, -0.428709,
-            -0.283349, 0.208792]).reshape(num_directions, 4 * hidden_size, input_size).astype(np.float32)
+            -0.494659, 0.0453352, -0.487793, 0.417264, -0.0175329, 0.489074, -0.446013, 0.414029, -0.0091708, -0.255364,
+            -0.106952, -0.266717, -0.0888852, -0.428709, -0.283349, 0.208792
+        ]).reshape(num_directions, 4 * hidden_size, input_size).astype(np.float32)
 
         R = np.array([
-            0.146626, -0.0620289,
-            -0.0815302, 0.100482,
+            0.146626, -0.0620289, -0.0815302, 0.100482, -0.219535, -0.306635, -0.28515, -0.314112, -0.228172, 0.405972,
+            0.31576, 0.281487, -0.394864, 0.42111, -0.386624, -0.390225
+        ]).reshape(num_directions, 4 * hidden_size, hidden_size).astype(np.float32)
 
-            -0.219535, -0.306635,
-            -0.28515, -0.314112,
-
-            -0.228172, 0.405972,
-            0.31576, 0.281487,
-
-            -0.394864, 0.42111,
-            -0.386624, -0.390225]).reshape(num_directions, 4 * hidden_size, hidden_size).astype(np.float32)
-
-        P = np.array([
-            0.2345, 0.5235,
-            0.4378, 0.3475,
-            0.8927, 0.3456]).reshape(num_directions, 3 * hidden_size).astype(np.float32)
+        P = np.array([0.2345, 0.5235, 0.4378, 0.3475, 0.8927, 0.3456]).reshape(num_directions,
+                                                                               3 * hidden_size).astype(np.float32)
 
         # // [8*hidden]
         B = np.array([
-            0.381619, 0.0323954,
-            -0.14449, 0.420804,
-            -0.258721, 0.45056,
-            -0.250755, 0.0967895,
+            0.381619,
+            0.0323954,
+            -0.14449,
+            0.420804,
+            -0.258721,
+            0.45056,
+            -0.250755,
+            0.0967895,
 
             # peephole bias
-            0.0, 0.0,
-            0.0, 0.0,
-            0.0, 0.0,
-            0.0, 0.0]).reshape(num_directions, 8 * hidden_size).astype(np.float32)
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0
+        ]).reshape(num_directions, 8 * hidden_size).astype(np.float32)
 
         return W, R, B, P
 
@@ -426,8 +433,8 @@ class ONNXRuntimeTestContext:
 
         W = np.tile(W1, (2, 1)).reshape(2, 4 * hidden_size, input_size)
         R = np.tile(R1, (2, 1)).reshape(2, 4 * hidden_size, hidden_size)
-        B = np.tile(B1, (2,1))
-        P = np.tile(P1, (2,1))
+        B = np.tile(B1, (2, 1))
+        P = np.tile(P1, (2, 1))
 
         return W, R, B, P
 
@@ -442,6 +449,7 @@ class ONNXRuntimeTestContext:
                   .astype(np.float32)
 
         return input
+
 
 class ONNXRuntimeUnitTests:
 
@@ -460,7 +468,7 @@ class ONNXRuntimeUnitTests:
         print(ONNXRuntimeUnitTests.ONNXRuntime_TestLSTMForwardNoBiasUsePeepholes.__name__)
         input = ONNXRuntimeTestContext.DefaultInput()
         W, R, B, P = ONNXRuntimeTestContext.OneDirectionWeights()
-        lstm = LSTM_Helper(X=input, W=W, R=R, P=P) # no bias
+        lstm = LSTM_Helper(X=input, W=W, R=R, P=P)  # no bias
         Y, Y_h, Y_c = lstm.run()
         print_results(Y, Y_h, Y_c)
 
@@ -500,7 +508,7 @@ class ONNXRuntimeUnitTests:
 
         input = ONNXRuntimeTestContext.DefaultInput()
         W, R, B, P = ONNXRuntimeTestContext.OneDirectionWeights()
-        initial_h = np.array([0.34, 0.72]).reshape(1,1,2).astype(np.float32)
+        initial_h = np.array([0.34, 0.72]).reshape(1, 1, 2).astype(np.float32)
         lstm = LSTM_Helper(X=input, W=W, R=R, B=B, initial_h=initial_h)
         Y, Y_h, Y_c = lstm.run()
         print_results(Y, Y_h, Y_c)
@@ -511,8 +519,8 @@ class ONNXRuntimeUnitTests:
 
         input = ONNXRuntimeTestContext.DefaultInput()
         W, R, B, P = ONNXRuntimeTestContext.OneDirectionWeights()
-        initial_h = np.array([0.34, 0.72]).reshape(1,1,2).astype(np.float32)
-        initial_c = np.array([0.63, 0.21]).reshape(1,1,2).astype(np.float32)
+        initial_h = np.array([0.34, 0.72]).reshape(1, 1, 2).astype(np.float32)
+        initial_c = np.array([0.63, 0.21]).reshape(1, 1, 2).astype(np.float32)
         lstm = LSTM_Helper(X=input, W=W, R=R, B=B, initial_h=initial_h, initial_c=initial_c)
         Y, Y_h, Y_c = lstm.run()
         print_results(Y, Y_h, Y_c)
@@ -524,8 +532,13 @@ class ONNXRuntimeUnitTests:
 
         input = ONNXRuntimeTestContext.DefaultInput()
         W, R, B, P = ONNXRuntimeTestContext.OneDirectionWeights()
-        lstm = LSTM_Helper(X=input, W=W, R=R, B=B,
-                           f=ActivationFuncs.tanh, g=ActivationFuncs.sigmoid, h=ActivationFuncs.tanh)
+        lstm = LSTM_Helper(X=input,
+                           W=W,
+                           R=R,
+                           B=B,
+                           f=ActivationFuncs.tanh,
+                           g=ActivationFuncs.sigmoid,
+                           h=ActivationFuncs.tanh)
         Y, Y_h, Y_c = lstm.run()
         print_results(Y, Y_h, Y_c)
 
@@ -539,24 +552,31 @@ class ONNXRuntimeUnitTests:
 
         input = ONNXRuntimeTestContext.DefaultInput()
         W, R, B, P = ONNXRuntimeTestContext.OneDirectionWeights()
-        lstm = LSTM_Helper(X=input, W=W, R=R, B=B,
-                           f=ActivationFuncs.tanh, g=ActivationFuncs.sigmoid, h=ActivationFuncs.tanh)
+        lstm = LSTM_Helper(X=input,
+                           W=W,
+                           R=R,
+                           B=B,
+                           f=ActivationFuncs.tanh,
+                           g=ActivationFuncs.sigmoid,
+                           h=ActivationFuncs.tanh)
         Y, Y_h, Y_c = lstm.run()
         print_results(Y, Y_h, Y_c)
-        print ("===============")
+        print("===============")
 
         batch_size = 3
-        input = np.array([-0.455351, -0.476391,
-                          -0.555351, -0.376391,
-                          -0.655351, -0.276391,
-
-                          -0.185934, -0.869585,
-                          -0.285934, -0.769585,
-                          -0.385934, -0.669585]).reshape(seq_length, batch_size, input_size).astype(np.float32)
+        input = np.array([
+            -0.455351, -0.476391, -0.555351, -0.376391, -0.655351, -0.276391, -0.185934, -0.869585, -0.285934,
+            -0.769585, -0.385934, -0.669585
+        ]).reshape(seq_length, batch_size, input_size).astype(np.float32)
 
         W, R, B, P = ONNXRuntimeTestContext.OneDirectionWeights()
-        lstm = LSTM_Helper(X=input, W=W, R=R, B=B,
-                           f=ActivationFuncs.tanh, g=ActivationFuncs.sigmoid, h=ActivationFuncs.tanh)
+        lstm = LSTM_Helper(X=input,
+                           W=W,
+                           R=R,
+                           B=B,
+                           f=ActivationFuncs.tanh,
+                           g=ActivationFuncs.sigmoid,
+                           h=ActivationFuncs.tanh)
         Y, Y_h, Y_c = lstm.run()
         print_results(Y, Y_h, Y_c)
 
@@ -570,28 +590,36 @@ class ONNXRuntimeUnitTests:
 
         input = ONNXRuntimeTestContext.DefaultInput()
         W, R, B, P = ONNXRuntimeTestContext.BidirectionalWeights()
-        lstm = LSTM_Helper(X=input, W=W, R=R, B=B, direction='bidirectional',
-                           f=ActivationFuncs.tanh, g=ActivationFuncs.sigmoid, h=ActivationFuncs.tanh)
+        lstm = LSTM_Helper(X=input,
+                           W=W,
+                           R=R,
+                           B=B,
+                           direction='bidirectional',
+                           f=ActivationFuncs.tanh,
+                           g=ActivationFuncs.sigmoid,
+                           h=ActivationFuncs.tanh)
         Y, Y_h, Y_c = lstm.run()
         print_results(Y, Y_h, Y_c)
 
-        print ("===============")
+        print("===============")
 
         batch_size = 3
-        input = np.array([-0.455351, -0.776391,
-                          -0.355351, -0.576391,
-                          -0.255351, -0.376391,
-
-                          -0.185934, -0.169585,
-                          -0.285934, -0.469585,
-                          -0.385934, -0.669585]).reshape(seq_length, batch_size, input_size).astype(np.float32)
+        input = np.array([
+            -0.455351, -0.776391, -0.355351, -0.576391, -0.255351, -0.376391, -0.185934, -0.169585, -0.285934,
+            -0.469585, -0.385934, -0.669585
+        ]).reshape(seq_length, batch_size, input_size).astype(np.float32)
 
         W, R, B, P = ONNXRuntimeTestContext.BidirectionalWeights()
-        lstm = LSTM_Helper(X=input, W=W, R=R, B=B, direction='bidirectional',
-                           f=ActivationFuncs.tanh, g=ActivationFuncs.sigmoid, h=ActivationFuncs.tanh)
+        lstm = LSTM_Helper(X=input,
+                           W=W,
+                           R=R,
+                           B=B,
+                           direction='bidirectional',
+                           f=ActivationFuncs.tanh,
+                           g=ActivationFuncs.sigmoid,
+                           h=ActivationFuncs.tanh)
         Y, Y_h, Y_c = lstm.run()
         print_results(Y, Y_h, Y_c)
-
 
 
 DebugOutput = False

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -14,6 +14,7 @@ import onnxruntime.backend as c2
 
 pytest_plugins = 'onnx.backend.test.report',
 
+
 class OrtBackendTest(onnx.backend.test.BackendTest):
 
     def __init__(self, backend, parent_module=None):
@@ -27,56 +28,33 @@ class OrtBackendTest(onnx.backend.test.BackendTest):
             if ref_outputs[i].dtype == np.object:
                 np.testing.assert_array_equal(ref_outputs[i], outputs[i])
             else:
-                np.testing.assert_allclose(
-                    ref_outputs[i],
-                    outputs[i],
-                    rtol=1e-3,
-                    atol=1e-5)
+                np.testing.assert_allclose(ref_outputs[i], outputs[i], rtol=1e-3, atol=1e-5)
 
 
 # ORT first supported opset 7, so models with nodes that require versions prior to opset 7 are not supported
 def tests_with_pre_opset7_dependencies_filters():
-    filters = ['^test_AvgPool1d_cpu',
-               '^test_AvgPool1d_stride_cpu',
-               '^test_AvgPool2d_cpu',
-               '^test_AvgPool2d_stride_cpu',
-               '^test_AvgPool3d_cpu',
-               '^test_AvgPool3d_stride1_pad0_gpu_input_cpu',
-               '^test_AvgPool3d_stride_cpu',
-               '^test_BatchNorm1d_3d_input_eval_cpu',
-               '^test_BatchNorm2d_eval_cpu',
-               '^test_BatchNorm2d_momentum_eval_cpu',
-               '^test_BatchNorm3d_eval_cpu',
-               '^test_BatchNorm3d_momentum_eval_cpu',
-               '^test_GLU_cpu',
-               '^test_GLU_dim_cpu',
-               '^test_Linear_cpu',
-               '^test_PReLU_1d_cpu',
-               '^test_PReLU_1d_multiparam_cpu',
-               '^test_PReLU_2d_cpu',
-               '^test_PReLU_2d_multiparam_cpu',
-               '^test_PReLU_3d_cpu',
-               '^test_PReLU_3d_multiparam_cpu',
-               '^test_PoissonNLLLLoss_no_reduce_cpu',
-               '^test_Softsign_cpu',
-               '^test_operator_add_broadcast_cpu',
-               '^test_operator_add_size1_broadcast_cpu',
-               '^test_operator_add_size1_right_broadcast_cpu',
-               '^test_operator_add_size1_singleton_broadcast_cpu',
-               '^test_operator_addconstant_cpu',
-               '^test_operator_addmm_cpu',
-               '^test_operator_basic_cpu',
-               '^test_operator_mm_cpu',
-               '^test_operator_non_float_params_cpu',
-               '^test_operator_params_cpu',
-               '^test_operator_pow_cpu']
+    filters = [
+        '^test_AvgPool1d_cpu', '^test_AvgPool1d_stride_cpu', '^test_AvgPool2d_cpu', '^test_AvgPool2d_stride_cpu',
+        '^test_AvgPool3d_cpu', '^test_AvgPool3d_stride1_pad0_gpu_input_cpu', '^test_AvgPool3d_stride_cpu',
+        '^test_BatchNorm1d_3d_input_eval_cpu', '^test_BatchNorm2d_eval_cpu', '^test_BatchNorm2d_momentum_eval_cpu',
+        '^test_BatchNorm3d_eval_cpu', '^test_BatchNorm3d_momentum_eval_cpu', '^test_GLU_cpu', '^test_GLU_dim_cpu',
+        '^test_Linear_cpu', '^test_PReLU_1d_cpu', '^test_PReLU_1d_multiparam_cpu', '^test_PReLU_2d_cpu',
+        '^test_PReLU_2d_multiparam_cpu', '^test_PReLU_3d_cpu', '^test_PReLU_3d_multiparam_cpu',
+        '^test_PoissonNLLLLoss_no_reduce_cpu', '^test_Softsign_cpu', '^test_operator_add_broadcast_cpu',
+        '^test_operator_add_size1_broadcast_cpu', '^test_operator_add_size1_right_broadcast_cpu',
+        '^test_operator_add_size1_singleton_broadcast_cpu', '^test_operator_addconstant_cpu',
+        '^test_operator_addmm_cpu', '^test_operator_basic_cpu', '^test_operator_mm_cpu',
+        '^test_operator_non_float_params_cpu', '^test_operator_params_cpu', '^test_operator_pow_cpu'
+    ]
 
     return filters
 
 
 def unsupported_usages_filters():
-    filters = ['^test_convtranspose_1d_cpu',  # ConvTransponse supports 4-D only
-               '^test_convtranspose_3d_cpu']
+    filters = [
+        '^test_convtranspose_1d_cpu',  # ConvTransponse supports 4-D only
+        '^test_convtranspose_3d_cpu'
+    ]
 
     return filters
 
@@ -90,10 +68,8 @@ def other_tests_failing_permanently_filters():
     return filters
 
 
-
 def test_with_types_disabled_due_to_binary_size_concerns_filters():
-    filters = ['^test_bitshift_right_uint16_cpu',
-               '^test_bitshift_left_uint16_cpu']
+    filters = ['^test_bitshift_right_uint16_cpu', '^test_bitshift_left_uint16_cpu']
 
     return filters
 
@@ -108,43 +84,36 @@ def create_backend_test(testname=None):
         backend_test.include(testname + '.*')
     else:
         # Tests that are failing temporarily and should be fixed
-        current_failing_tests = [#'^test_cast_STRING_to_FLOAT_cpu',  # old test data that is bad on Linux CI builds
-                                 '^test_unique_not_sorted_without_axis_cpu', # bad expected data. enable after https://github.com/onnx/onnx/pull/2381 is picked up
-                                 '^test_mod_float_mixed_sign_example_cpu', #onnxruntime::Mod::Compute fmod_ was false. fmod attribute must be true for float, float16 and double types
-                                 '^test_resize_downsample_scales_cubic_align_corners_cpu',  # results mismatch with onnx tests
-                                 '^test_resize_downsample_scales_linear_align_corners_cpu',  # results mismatch with onnx tests
-                                 '^test_resize_tf_crop_and_resize_cpu',  # bad expected data, needs test fix
-                                 '^test_resize_upsample_sizes_nearest_ceil_half_pixel_cpu',  # bad expected data, needs test fix
-                                 '^test_resize_upsample_sizes_nearest_floor_align_corners_cpu',  # bad expected data, needs test fix
-                                 '^test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric_cpu',  # bad expected data, needs test fix
-                                 '^test_maxunpool_export_with_output_shape_cpu', # Invalid output in ONNX test. See https://github.com/onnx/onnx/issues/2398'
-                                ]
+        current_failing_tests = [  #'^test_cast_STRING_to_FLOAT_cpu',  # old test data that is bad on Linux CI builds
+            '^test_unique_not_sorted_without_axis_cpu',  # bad expected data. enable after https://github.com/onnx/onnx/pull/2381 is picked up
+            '^test_mod_float_mixed_sign_example_cpu',  #onnxruntime::Mod::Compute fmod_ was false. fmod attribute must be true for float, float16 and double types
+            '^test_resize_downsample_scales_cubic_align_corners_cpu',  # results mismatch with onnx tests
+            '^test_resize_downsample_scales_linear_align_corners_cpu',  # results mismatch with onnx tests
+            '^test_resize_tf_crop_and_resize_cpu',  # bad expected data, needs test fix
+            '^test_resize_upsample_sizes_nearest_ceil_half_pixel_cpu',  # bad expected data, needs test fix
+            '^test_resize_upsample_sizes_nearest_floor_align_corners_cpu',  # bad expected data, needs test fix
+            '^test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric_cpu',  # bad expected data, needs test fix
+            '^test_maxunpool_export_with_output_shape_cpu',  # Invalid output in ONNX test. See https://github.com/onnx/onnx/issues/2398'
+        ]
 
         # Example of how to disable tests for a specific provider.
         # if c2.supports_device('NGRAPH'):
         #    current_failing_tests.append('^test_operator_repeat_dim_overflow_cpu')
         if c2.supports_device('NGRAPH'):
-            current_failing_tests += ['^test_clip.*',
-                                      '^test_qlinearconv_cpu',
-                                      '^test_depthtospace_crd.*',
-                                      '^test_argmax_negative_axis.*',
-                                      '^test_argmin_negative_axis.*',
-                                      '^test_hardmax_negative_axis.*',
-                                      '^test_gemm_default_no_bias_cpu',
-                                      '^test_flatten_negative_axis.*',
-                                      '^test_reduce_[a-z1-9_]*_negative_axes_.*',
-                                      'test_squeeze_negative_axes_cpu',
-                                      'test_unsqueeze_negative_axes_cpu',
-                                      'test_constant_pad_cpu',
-                                      'test_edge_pad_cpu',
-                                      'test_reflect_pad_cpu']
+            current_failing_tests += [
+                '^test_clip.*', '^test_qlinearconv_cpu', '^test_depthtospace_crd.*', '^test_argmax_negative_axis.*',
+                '^test_argmin_negative_axis.*', '^test_hardmax_negative_axis.*', '^test_gemm_default_no_bias_cpu',
+                '^test_flatten_negative_axis.*', '^test_reduce_[a-z1-9_]*_negative_axes_.*',
+                'test_squeeze_negative_axes_cpu', 'test_unsqueeze_negative_axes_cpu', 'test_constant_pad_cpu',
+                'test_edge_pad_cpu', 'test_reflect_pad_cpu'
+            ]
 
         if c2.supports_device('DNNL'):
-            current_failing_tests += ['^test_range_float_type_positive_delta_expanded_cpu',
-                                      '^test_range_int32_type_negative_delta_expanded_cpu',
-									  '^test_averagepool_2d_ceil_cpu',
-                                      '^test_maxpool_2d_ceil_cpu',
-									  '^test_maxpool_2d_dilations_cpu']
+            current_failing_tests += [
+                '^test_range_float_type_positive_delta_expanded_cpu',
+                '^test_range_int32_type_negative_delta_expanded_cpu', '^test_averagepool_2d_ceil_cpu',
+                '^test_maxpool_2d_ceil_cpu', '^test_maxpool_2d_dilations_cpu'
+            ]
 
         if c2.supports_device('OPENVINO_GPU_FP32') or c2.supports_device('OPENVINO_GPU_FP16'):
             current_failing_tests.append('^test_div_cpu*')
@@ -153,8 +122,10 @@ def create_backend_test(testname=None):
             current_failing_tests.append('^test_vgg19_cpu*')
 
         if c2.supports_device('OPENVINO_CPU_FP32'):
-            current_failing_tests += ['^test_scan9_sum_cpu',#sum_out output node not defined, temporarily disabling test
-                                      '^test_scan_sum_cpu'] #sum_out output node not defined, temporarily disabling test
+            current_failing_tests += [
+                '^test_scan9_sum_cpu',  #sum_out output node not defined, temporarily disabling test
+                '^test_scan_sum_cpu'
+            ]  #sum_out output node not defined, temporarily disabling test
 
         filters = current_failing_tests + \
                   tests_with_pre_opset7_dependencies_filters() + \
@@ -179,8 +150,12 @@ def parse_args():
     # Add an argument to match a single test name, by adding the name to the 'include' filter.
     # Using -k with python unittest (https://docs.python.org/3/library/unittest.html#command-line-options)
     # doesn't work as it filters on the test method name (Runner._add_model_test) rather than inidividual test case names.
-    parser.add_argument('-t', '--test-name', dest='testname', type=str,
-                        help="Only run tests that match this value. Matching is regex based, and '.*' is automatically appended")
+    parser.add_argument(
+        '-t',
+        '--test-name',
+        dest='testname',
+        type=str,
+        help="Only run tests that match this value. Matching is regex based, and '.*' is automatically appended")
 
     # parse just our args. python unittest has its own args and arg parsing, and that runs inside unittest.main()
     args, left = parser.parse_known_args()

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -22,17 +22,14 @@ class TestInferenceSession(unittest.TestCase):
         res = os.path.join(data, name)
         if os.path.exists(res):
             return res
-        raise FileNotFoundError(
-            "Unable to find '{0}' or '{1}' or '{2}'".format(name, rel, res))
+        raise FileNotFoundError("Unable to find '{0}' or '{1}' or '{2}'".format(name, rel, res))
 
     def run_model(self, session_object, run_options):
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         input_name = session_object.get_inputs()[0].name
         res = session_object.run([], {input_name: x}, run_options=run_options)
-        output_expected = np.array(
-            [[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
-        np.testing.assert_allclose(
-            output_expected, res[0], rtol=1e-05, atol=1e-08)
+        output_expected = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
+        np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
     def testModelSerialization(self):
         so = onnxrt.SessionOptions()
@@ -43,8 +40,7 @@ class TestInferenceSession(unittest.TestCase):
         self.assertTrue(os.path.isfile(so.optimized_model_filepath))
 
     def testGetProviders(self):
-        self.assertTrue(
-            'CPUExecutionProvider' in onnxrt.get_available_providers())
+        self.assertTrue('CPUExecutionProvider' in onnxrt.get_available_providers())
         self.assertTrue('CPUExecutionProvider' in onnxrt.get_all_providers())
         sess = onnxrt.InferenceSession(self.get_name("mul_1.onnx"))
         self.assertTrue('CPUExecutionProvider' in sess.get_providers())
@@ -63,14 +59,13 @@ class TestInferenceSession(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             sess = onnxrt.InferenceSession(self.get_name("mul_1.onnx"))
             sess.set_providers(['InvalidProvider'])
-        self.assertTrue('[\'InvalidProvider\'] does not contain a subset of available providers' in str(
-            context.exception))
+        self.assertTrue(
+            '[\'InvalidProvider\'] does not contain a subset of available providers' in str(context.exception))
 
     def testSessionProviders(self):
         if 'CUDAExecutionProvider' in onnxrt.get_available_providers():
             # create session from scratch, but constrain it to only use the CPU.
-            sess = onnxrt.InferenceSession(
-                self.get_name("mul_1.onnx"), providers=['CPUExecutionProvider'])
+            sess = onnxrt.InferenceSession(self.get_name("mul_1.onnx"), providers=['CPUExecutionProvider'])
             self.assertEqual(['CPUExecutionProvider'], sess.get_providers())
 
     def testRunModel(self):
@@ -85,10 +80,8 @@ class TestInferenceSession(unittest.TestCase):
         output_shape = sess.get_outputs()[0].shape
         self.assertEqual(output_shape, [3, 2])
         res = sess.run([output_name], {input_name: x})
-        output_expected = np.array(
-            [[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
-        np.testing.assert_allclose(
-            output_expected, res[0], rtol=1e-05, atol=1e-08)
+        output_expected = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
+        np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
     def testRunModelFromBytes(self):
         with open(self.get_name("mul_1.onnx"), "rb") as f:
@@ -104,10 +97,8 @@ class TestInferenceSession(unittest.TestCase):
         output_shape = sess.get_outputs()[0].shape
         self.assertEqual(output_shape, [3, 2])
         res = sess.run([output_name], {input_name: x})
-        output_expected = np.array(
-            [[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
-        np.testing.assert_allclose(
-            output_expected, res[0], rtol=1e-05, atol=1e-08)
+        output_expected = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
+        np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
     def testRunModel2(self):
         sess = onnxrt.InferenceSession(self.get_name("matmul_1.onnx"))
@@ -122,12 +113,11 @@ class TestInferenceSession(unittest.TestCase):
         self.assertEqual(output_shape, [3, 1])
         res = sess.run([output_name], {input_name: x})
         output_expected = np.array([[5.0], [11.0], [17.0]], dtype=np.float32)
-        np.testing.assert_allclose(
-            output_expected, res[0], rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
     def testRunModel2Contiguous(self):
         sess = onnxrt.InferenceSession(self.get_name("matmul_1.onnx"))
-        x = np.array([[2.0, 1.0], [4.0, 3.0], [6.0, 5.0]], dtype=np.float32)[:,[1,0]]
+        x = np.array([[2.0, 1.0], [4.0, 3.0], [6.0, 5.0]], dtype=np.float32)[:, [1, 0]]
         input_name = sess.get_inputs()[0].name
         self.assertEqual(input_name, "X")
         input_shape = sess.get_inputs()[0].shape
@@ -138,19 +128,16 @@ class TestInferenceSession(unittest.TestCase):
         self.assertEqual(output_shape, [3, 1])
         res = sess.run([output_name], {input_name: x})
         output_expected = np.array([[5.0], [11.0], [17.0]], dtype=np.float32)
-        np.testing.assert_allclose(
-            output_expected, res[0], rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
         xcontiguous = np.ascontiguousarray(x)
         rescontiguous = sess.run([output_name], {input_name: xcontiguous})
-        np.testing.assert_allclose(
-            output_expected, rescontiguous[0], rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(output_expected, rescontiguous[0], rtol=1e-05, atol=1e-08)
 
     def testRunModelMultipleThreads(self):
         so = onnxrt.SessionOptions()
         so.log_verbosity_level = 1
         so.logid = "MultiThreadsTest"
-        sess = onnxrt.InferenceSession(
-            self.get_name("mul_1.onnx"), sess_options=so)
+        sess = onnxrt.InferenceSession(self.get_name("mul_1.onnx"), sess_options=so)
         ro1 = onnxrt.RunOptions()
         ro1.logid = "thread1"
         t1 = threading.Thread(target=self.run_model, args=(sess, ro1))
@@ -167,10 +154,8 @@ class TestInferenceSession(unittest.TestCase):
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         input_name = sess.get_inputs()[0].name
         res = sess.run([], {input_name: x.tolist()})
-        output_expected = np.array(
-            [[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
-        np.testing.assert_allclose(
-            output_expected, res[0], rtol=1e-05, atol=1e-08)
+        output_expected = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
+        np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
     def testStringListAsInput(self):
         sess = onnxrt.InferenceSession(self.get_name("identity_string.onnx"))
@@ -178,7 +163,7 @@ class TestInferenceSession(unittest.TestCase):
         x_name = sess.get_inputs()[0].name
         res = sess.run([], {x_name: x.tolist()})
         np.testing.assert_equal(x, res[0])
-		
+
     def testRunDevice(self):
         device = onnxrt.get_device()
         self.assertTrue('CPU' in device or 'GPU' in device)
@@ -198,8 +183,7 @@ class TestInferenceSession(unittest.TestCase):
         self.assertEqual(output_shape, ['None', 1])
         res = sess.run([output_name], {input_name: x})
         output_expected = np.array([[5.0], [11.0], [17.0]], dtype=np.float32)
-        np.testing.assert_allclose(
-            output_expected, res[0], rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
     def testBooleanInputs(self):
         sess = onnxrt.InferenceSession(self.get_name("logicaland.onnx"))
@@ -229,15 +213,13 @@ class TestInferenceSession(unittest.TestCase):
         output_type = sess.get_outputs()[0].type
         self.assertEqual(output_type, 'tensor(bool)')
 
-        output_expected = np.array(
-            [[True, False], [False, False]], dtype=np.bool)
+        output_expected = np.array([[True, False], [False, False]], dtype=np.bool)
         res = sess.run([output_name], {a_name: a, b_name: b})
         np.testing.assert_equal(output_expected, res[0])
 
     def testStringInput1(self):
         sess = onnxrt.InferenceSession(self.get_name("identity_string.onnx"))
-        x = np.array(['this', 'is', 'identity', 'test'],
-                     dtype=np.str).reshape((2, 2))
+        x = np.array(['this', 'is', 'identity', 'test'], dtype=np.str).reshape((2, 2))
 
         x_name = sess.get_inputs()[0].name
         self.assertEqual(x_name, "input:0")
@@ -258,8 +240,7 @@ class TestInferenceSession(unittest.TestCase):
 
     def testStringInput2(self):
         sess = onnxrt.InferenceSession(self.get_name("identity_string.onnx"))
-        x = np.array(['Olá', '你好', '여보세요', 'hello'],
-                     dtype=np.unicode).reshape((2, 2))
+        x = np.array(['Olá', '你好', '여보세요', 'hello'], dtype=np.unicode).reshape((2, 2))
 
         x_name = sess.get_inputs()[0].name
         self.assertEqual(x_name, "input:0")
@@ -301,8 +282,7 @@ class TestInferenceSession(unittest.TestCase):
 
     def testInputObject(self):
         sess = onnxrt.InferenceSession(self.get_name("identity_string.onnx"))
-        x = np.array(['this', 'is', 'identity', 'test'],
-                     object).reshape((2, 2))
+        x = np.array(['this', 'is', 'identity', 'test'], object).reshape((2, 2))
 
         x_name = sess.get_inputs()[0].name
         self.assertEqual(x_name, "input:0")
@@ -323,8 +303,7 @@ class TestInferenceSession(unittest.TestCase):
 
     def testInputVoid(self):
         sess = onnxrt.InferenceSession(self.get_name("identity_string.onnx"))
-        x = np.array([b'this', b'is', b'identity', b'test'],
-                     np.void).reshape((2, 2))
+        x = np.array([b'this', b'is', b'identity', b'test'], np.void).reshape((2, 2))
 
         x_name = sess.get_inputs()[0].name
         self.assertEqual(x_name, "input:0")
@@ -342,15 +321,13 @@ class TestInferenceSession(unittest.TestCase):
 
         res = sess.run([output_name], {x_name: x})
 
-        expr = np.array([['this\x00\x00\x00\x00', 'is\x00\x00\x00\x00\x00\x00'],
-                         ['identity', 'test\x00\x00\x00\x00']], dtype=object)
+        expr = np.array([['this\x00\x00\x00\x00', 'is\x00\x00\x00\x00\x00\x00'], ['identity', 'test\x00\x00\x00\x00']],
+                        dtype=object)
         np.testing.assert_equal(expr, res[0])
 
     def testZipMapStringFloat(self):
-        sess = onnxrt.InferenceSession(
-            self.get_name("zipmap_stringfloat.onnx"))
-        x = np.array([1.0, 0.0, 3.0, 44.0, 23.0, 11.0],
-                     dtype=np.float32).reshape((2, 3))
+        sess = onnxrt.InferenceSession(self.get_name("zipmap_stringfloat.onnx"))
+        x = np.array([1.0, 0.0, 3.0, 44.0, 23.0, 11.0], dtype=np.float32).reshape((2, 3))
 
         x_name = sess.get_inputs()[0].name
         self.assertEqual(x_name, "X")
@@ -362,15 +339,21 @@ class TestInferenceSession(unittest.TestCase):
         output_type = sess.get_outputs()[0].type
         self.assertEqual(output_type, 'seq(map(string,tensor(float)))')
 
-        output_expected = [{'class2': 0.0, 'class1': 1.0, 'class3': 3.0},
-                           {'class2': 23.0, 'class1': 44.0, 'class3': 11.0}]
+        output_expected = [{
+            'class2': 0.0,
+            'class1': 1.0,
+            'class3': 3.0
+        }, {
+            'class2': 23.0,
+            'class1': 44.0,
+            'class3': 11.0
+        }]
         res = sess.run([output_name], {x_name: x})
         self.assertEqual(output_expected, res[0])
 
     def testZipMapInt64Float(self):
         sess = onnxrt.InferenceSession(self.get_name("zipmap_int64float.onnx"))
-        x = np.array([1.0, 0.0, 3.0, 44.0, 23.0, 11.0],
-                     dtype=np.float32).reshape((2, 3))
+        x = np.array([1.0, 0.0, 3.0, 44.0, 23.0, 11.0], dtype=np.float32).reshape((2, 3))
 
         x_name = sess.get_inputs()[0].name
         self.assertEqual(x_name, "X")
@@ -382,8 +365,7 @@ class TestInferenceSession(unittest.TestCase):
         output_type = sess.get_outputs()[0].type
         self.assertEqual(output_type, 'seq(map(int64,tensor(float)))')
 
-        output_expected = [{10: 1.0, 20: 0.0, 30: 3.0},
-                           {10: 44.0, 20: 23.0, 30: 11.0}]
+        output_expected = [{10: 1.0, 20: 0.0, 30: 3.0}, {10: 44.0, 20: 23.0, 30: 11.0}]
         res = sess.run([output_name], {x_name: x})
         self.assertEqual(output_expected, res[0])
 
@@ -409,8 +391,7 @@ class TestInferenceSession(unittest.TestCase):
     def testProfilerWithSessionOptions(self):
         so = onnxrt.SessionOptions()
         so.enable_profiling = True
-        sess = onnxrt.InferenceSession(
-            self.get_name("mul_1.onnx"), sess_options=so)
+        sess = onnxrt.InferenceSession(self.get_name("mul_1.onnx"), sess_options=so)
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         sess.run([], {'X': x})
         profile_file = sess.end_profiling()
@@ -425,8 +406,7 @@ class TestInferenceSession(unittest.TestCase):
             self.assertTrue(']' in lines[8])
 
     def testDictVectorizer(self):
-        sess = onnxrt.InferenceSession(
-            self.get_name("pipeline_vectorize.onnx"))
+        sess = onnxrt.InferenceSession(self.get_name("pipeline_vectorize.onnx"))
         input_name = sess.get_inputs()[0].name
         self.assertEqual(input_name, "float_input")
         input_type = str(sess.get_inputs()[0].type)
@@ -444,35 +424,30 @@ class TestInferenceSession(unittest.TestCase):
         x = {0: 25.0, 1: 5.13, 2: 0.0, 3: 0.453, 4: 5.966}
         res = sess.run([output_name], {input_name: x})
         output_expected = np.array([[49.752754]], dtype=np.float32)
-        np.testing.assert_allclose(
-            output_expected, res[0], rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
         xwrong = x.copy()
         xwrong["a"] = 5.6
         try:
             res = sess.run([output_name], {input_name: xwrong})
         except RuntimeError as e:
-            self.assertIn(
-                "Unexpected key type  <class 'str'>, it cannot be linked to C type int64_t", str(e))
+            self.assertIn("Unexpected key type  <class 'str'>, it cannot be linked to C type int64_t", str(e))
 
         # numpy type
         x = {np.int64(k): np.float32(v) for k, v in x.items()}
         res = sess.run([output_name], {input_name: x})
         output_expected = np.array([[49.752754]], dtype=np.float32)
-        np.testing.assert_allclose(
-            output_expected, res[0], rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
         x = {np.int64(k): np.float64(v) for k, v in x.items()}
         res = sess.run([output_name], {input_name: x})
         output_expected = np.array([[49.752754]], dtype=np.float32)
-        np.testing.assert_allclose(
-            output_expected, res[0], rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
         x = {np.int32(k): np.float64(v) for k, v in x.items()}
         res = sess.run([output_name], {input_name: x})
         output_expected = np.array([[49.752754]], dtype=np.float32)
-        np.testing.assert_allclose(
-            output_expected, res[0], rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
     def testLabelEncoder(self):
         sess = onnxrt.InferenceSession(self.get_name("LabelEncoder.onnx"))
@@ -493,21 +468,18 @@ class TestInferenceSession(unittest.TestCase):
         x = np.array([['4']])
         res = sess.run([output_name], {input_name: x})
         output_expected = np.array([[3]], dtype=np.int64)
-        np.testing.assert_allclose(
-            output_expected, res[0], rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
         # Python type
         x = np.array(['4'], ndmin=2)
         res = sess.run([output_name], {input_name: x})
         output_expected = np.array([3], ndmin=2, dtype=np.int64)
-        np.testing.assert_allclose(
-            output_expected, res[0], rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
         x = np.array(['4'], ndmin=2, dtype=np.object)
         res = sess.run([output_name], {input_name: x})
         output_expected = np.array([3], ndmin=2, dtype=np.int64)
-        np.testing.assert_allclose(
-            output_expected, res[0], rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
     def test_run_model_mlnet(self):
         sess = onnxrt.InferenceSession(self.get_name("mlnet_encoder.onnx"))
@@ -529,8 +501,7 @@ class TestInferenceSession(unittest.TestCase):
         # (to save space). It does not have this behaviour for void
         # but as a result, numpy does not know anymore the size
         # of each element, they all have the same size.
-        c1 = np.array([b'A\0A\0\0', b"B\0B\0", b"C\0C\0"],
-                      np.void).reshape(1, 3)
+        c1 = np.array([b'A\0A\0\0', b"B\0B\0", b"C\0C\0"], np.void).reshape(1, 3)
         res = sess.run(None, {'C0': c0, 'C1': c1})
         mat = res[1]
         total = mat.sum()
@@ -546,12 +517,14 @@ class TestInferenceSession(unittest.TestCase):
         a = np.array([[True, True], [False, False]], dtype=np.bool)
         b = np.array([[True, False], [True, False]], dtype=np.bool)
 
-        res = sess.run([], {'input1:0': a, 'input:0':b})
+        res = sess.run([], {'input1:0': a, 'input:0': b})
 
     def testSequenceLength(self):
         sess = onnxrt.InferenceSession(self.get_name("sequence_length.onnx"))
-        x = [np.array([1.0, 0.0, 3.0, 44.0, 23.0, 11.0], dtype=np.float32).reshape((2, 3)),
-        np.array([1.0, 0.0, 3.0, 44.0, 23.0, 11.0], dtype=np.float32).reshape((2, 3))]
+        x = [
+            np.array([1.0, 0.0, 3.0, 44.0, 23.0, 11.0], dtype=np.float32).reshape((2, 3)),
+            np.array([1.0, 0.0, 3.0, 44.0, 23.0, 11.0], dtype=np.float32).reshape((2, 3))
+        ]
 
         x_name = sess.get_inputs()[0].name
         self.assertEqual(x_name, "X")
@@ -568,8 +541,7 @@ class TestInferenceSession(unittest.TestCase):
         self.assertEqual(output_expected, res[0])
 
     def testSequenceConstruct(self):
-        sess = onnxrt.InferenceSession(
-            self.get_name("sequence_construct.onnx"))
+        sess = onnxrt.InferenceSession(self.get_name("sequence_construct.onnx"))
 
         self.assertEqual(sess.get_inputs()[0].type, 'tensor(int64)')
         self.assertEqual(sess.get_inputs()[1].type, 'tensor(int64)')
@@ -582,11 +554,16 @@ class TestInferenceSession(unittest.TestCase):
         output_type = sess.get_outputs()[0].type
         self.assertEqual(output_type, 'seq(tensor(int64))')
 
-        output_expected = [np.array([1, 0, 3, 44, 23, 11], dtype=np.int64).reshape((2, 3)),
-                           np.array([1, 2, 3, 4, 5, 6], dtype=np.int64).reshape((2, 3))]
+        output_expected = [
+            np.array([1, 0, 3, 44, 23, 11], dtype=np.int64).reshape((2, 3)),
+            np.array([1, 2, 3, 4, 5, 6], dtype=np.int64).reshape((2, 3))
+        ]
 
-        res = sess.run([output_name], {"tensor1": np.array([1, 0, 3, 44, 23, 11], dtype=np.int64).reshape((2, 3)),
-                                       "tensor2": np.array([1, 2, 3, 4, 5, 6], dtype=np.int64).reshape((2, 3))})
+        res = sess.run(
+            [output_name], {
+                "tensor1": np.array([1, 0, 3, 44, 23, 11], dtype=np.int64).reshape((2, 3)),
+                "tensor2": np.array([1, 2, 3, 4, 5, 6], dtype=np.int64).reshape((2, 3))
+            })
 
         np.testing.assert_array_equal(output_expected, res[0])
 
@@ -606,10 +583,11 @@ class TestInferenceSession(unittest.TestCase):
         output_type = sess.get_outputs()[0].type
         self.assertEqual(output_type, 'seq(tensor(int64))')
 
-        output_expected = [
-            np.array([1, 0, 3, 44, 23, 11], dtype=np.int64).reshape((2, 3))]
-        res = sess.run([output_name], {"tensor": np.array(
-            [1, 0, 3, 44, 23, 11], dtype=np.int64).reshape((2, 3)), "input_seq": []})
+        output_expected = [np.array([1, 0, 3, 44, 23, 11], dtype=np.int64).reshape((2, 3))]
+        res = sess.run([output_name], {
+            "tensor": np.array([1, 0, 3, 44, 23, 11], dtype=np.int64).reshape((2, 3)),
+            "input_seq": []
+        })
         np.testing.assert_array_equal(output_expected, res[0])
 
     def testOrtExecutionMode(self):
@@ -623,23 +601,26 @@ class TestInferenceSession(unittest.TestCase):
             os.environ['ORT_LOAD_CONFIG_FROM_MODEL'] = str(1)
             sess = onnxrt.InferenceSession(self.get_name("model_with_valid_ort_config_json.onnx"))
             session_options = sess.get_session_options()
-            
+
             self.assertEqual(session_options.inter_op_num_threads, 5)  # from the ORT config
-            
+
             self.assertEqual(session_options.intra_op_num_threads, 2)  # from the ORT config
 
-            self.assertEqual(session_options.execution_mode, onnxrt.ExecutionMode.ORT_SEQUENTIAL)  # default option (not from the ORT config)
+            self.assertEqual(session_options.execution_mode,
+                             onnxrt.ExecutionMode.ORT_SEQUENTIAL)  # default option (not from the ORT config)
 
-            self.assertEqual(session_options.graph_optimization_level, onnxrt.GraphOptimizationLevel.ORT_ENABLE_ALL)  # from the ORT config
+            self.assertEqual(session_options.graph_optimization_level,
+                             onnxrt.GraphOptimizationLevel.ORT_ENABLE_ALL)  # from the ORT config
 
             self.assertEqual(session_options.enable_profiling, True)  # from the ORT config
-            
-        except Exception: 
+
+        except Exception:
             raise
 
         finally:
             # Make sure the usage of the feature is disabled after this test
             os.environ['ORT_LOAD_CONFIG_FROM_MODEL'] = str(0)
-        
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/onnxruntime/test/python/onnxruntime_test_python_backend.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_backend.py
@@ -25,7 +25,8 @@ def check_list_of_map_to_float(testcase, expected_rows, actual_rows):
         # use np.testing.assert_allclose so we can specify the tolerance
         np.testing.assert_allclose([expected_rows[i][key] for key in sorted_keys],
                                    [actual_rows[i][key] for key in sorted_keys],
-                                   rtol=1e-05, atol=1e-07)
+                                   rtol=1e-05,
+                                   atol=1e-07)
 
 
 class TestBackend(unittest.TestCase):
@@ -68,9 +69,19 @@ class TestBackend(unittest.TestCase):
         res = rep.run(x)
         output_expected = np.array([0, 0, 0], dtype=np.float32)
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
-        output_expected = [{0: 0.950599730014801, 1: 0.027834169566631317, 2: 0.02156602405011654},
-                           {0: 0.9974970817565918, 1: 5.6299926654901356e-05, 2: 0.0024466661270707846},
-                           {0: 0.9997311234474182, 1: 1.1918064757310276e-07, 2: 0.00026869276189245284}]
+        output_expected = [{
+            0: 0.950599730014801,
+            1: 0.027834169566631317,
+            2: 0.02156602405011654
+        }, {
+            0: 0.9974970817565918,
+            1: 5.6299926654901356e-05,
+            2: 0.0024466661270707846
+        }, {
+            0: 0.9997311234474182,
+            1: 1.1918064757310276e-07,
+            2: 0.00026869276189245284
+        }]
 
         check_list_of_map_to_float(self, output_expected, res[1])
 
@@ -83,9 +94,19 @@ class TestBackend(unittest.TestCase):
 
         output_expected = np.array([0, 0, 0], dtype=np.float32)
         np.testing.assert_allclose(output_expected, outputs[0], rtol=1e-05, atol=1e-08)
-        output_expected = [{0: 0.950599730014801, 1: 0.027834169566631317, 2: 0.02156602405011654},
-                           {0: 0.9974970817565918, 1: 5.6299926654901356e-05, 2: 0.0024466661270707846},
-                           {0: 0.9997311234474182, 1: 1.1918064757310276e-07, 2: 0.00026869276189245284}]
+        output_expected = [{
+            0: 0.950599730014801,
+            1: 0.027834169566631317,
+            2: 0.02156602405011654
+        }, {
+            0: 0.9974970817565918,
+            1: 5.6299926654901356e-05,
+            2: 0.0024466661270707846
+        }, {
+            0: 0.9997311234474182,
+            1: 1.1918064757310276e-07,
+            2: 0.00026869276189245284
+        }]
 
         check_list_of_map_to_float(self, output_expected, outputs[1])
 

--- a/onnxruntime/test/python/onnxruntime_test_python_nuphar.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_nuphar.py
@@ -16,12 +16,14 @@ import tarfile
 import unittest
 import urllib.request
 
+
 class TestNuphar(unittest.TestCase):
+
     def test_bidaf(self):
         # download BiDAF model
         cwd = os.getcwd()
         bidaf_url = 'https://onnxzoo.blob.core.windows.net/models/opset_9/bidaf/bidaf.tar.gz'
-        cache_dir = os.path.join(os.path.expanduser("~"), '.cache','onnxruntime')
+        cache_dir = os.path.join(os.path.expanduser("~"), '.cache', 'onnxruntime')
         os.makedirs(cache_dir, exist_ok=True)
         bidaf_local = os.path.join(cache_dir, 'bidaf.tar.gz')
         if not os.path.exists(bidaf_local):
@@ -35,9 +37,24 @@ class TestNuphar(unittest.TestCase):
         bidaf_scan_model = os.path.join(bidaf_dir, 'bidaf_scan.onnx')
         bidaf_opt_scan_model = os.path.join(bidaf_dir, 'bidaf_opt_scan.onnx')
         bidaf_int8_scan_only_model = os.path.join(bidaf_dir, 'bidaf_int8_scan_only.onnx')
-        subprocess.run([sys.executable, '-m', 'onnxruntime.nuphar.model_editor', '--input', bidaf_model, '--output', bidaf_scan_model, '--mode', 'to_scan'], check=True, cwd=cwd)
-        subprocess.run([sys.executable, '-m', 'onnxruntime.nuphar.model_editor', '--input', bidaf_scan_model, '--output', bidaf_opt_scan_model, '--mode', 'opt_inproj'], check=True, cwd=cwd)
-        subprocess.run([sys.executable, '-m', 'onnxruntime.nuphar.model_quantizer', '--input', bidaf_opt_scan_model, '--output', bidaf_int8_scan_only_model, '--only_for_scan'], check=True, cwd=cwd)
+        subprocess.run([
+            sys.executable, '-m', 'onnxruntime.nuphar.model_editor', '--input', bidaf_model, '--output',
+            bidaf_scan_model, '--mode', 'to_scan'
+        ],
+                       check=True,
+                       cwd=cwd)
+        subprocess.run([
+            sys.executable, '-m', 'onnxruntime.nuphar.model_editor', '--input', bidaf_scan_model, '--output',
+            bidaf_opt_scan_model, '--mode', 'opt_inproj'
+        ],
+                       check=True,
+                       cwd=cwd)
+        subprocess.run([
+            sys.executable, '-m', 'onnxruntime.nuphar.model_quantizer', '--input', bidaf_opt_scan_model, '--output',
+            bidaf_int8_scan_only_model, '--only_for_scan'
+        ],
+                       check=True,
+                       cwd=cwd)
 
         # run onnx_test_runner to verify results
         # use -M to disable memory pattern
@@ -46,7 +63,7 @@ class TestNuphar(unittest.TestCase):
 
         # test AOT on the quantized model
         if os.name not in ['nt', 'posix']:
-            return # don't run the rest of test if AOT is not supported
+            return  # don't run the rest of test if AOT is not supported
 
         cache_dir = os.path.join(cwd, 'nuphar_cache')
         if os.path.exists(cache_dir):
@@ -63,31 +80,36 @@ class TestNuphar(unittest.TestCase):
             nuphar_settings = 'nuphar_cache_path:{}'.format(cache_dir)
             for isa in ['avx', 'avx2', 'avx512']:
                 onnxrt.capi._pybind_state.set_nuphar_settings(nuphar_settings + ', nuphar_codegen_target:' + isa)
-                sess = onnxrt.InferenceSession(model) # JIT cache happens when initializing session
+                sess = onnxrt.InferenceSession(model)  # JIT cache happens when initializing session
 
             cache_dir_content = os.listdir(cache_dir)
             assert len(cache_dir_content) == 1
             cache_versioned_dir = os.path.join(cache_dir, cache_dir_content[0])
             so_name = os.path.basename(model) + '.so'
-            subprocess.run([sys.executable, '-m', 'onnxruntime.nuphar.create_shared', '--input_dir', cache_versioned_dir, '--output_name', so_name], check=True)
+            subprocess.run([
+                sys.executable, '-m', 'onnxruntime.nuphar.create_shared', '--input_dir', cache_versioned_dir,
+                '--output_name', so_name
+            ],
+                           check=True)
 
-            nuphar_settings = 'nuphar_cache_path:{}, nuphar_cache_so_name:{}, nuphar_cache_force_no_jit:{}'.format(cache_dir, so_name, 'on')
+            nuphar_settings = 'nuphar_cache_path:{}, nuphar_cache_so_name:{}, nuphar_cache_force_no_jit:{}'.format(
+                cache_dir, so_name, 'on')
             onnxrt.capi._pybind_state.set_nuphar_settings(nuphar_settings)
             sess = onnxrt.InferenceSession(model)
             sess.run([], feed)
 
             # test avx
-            nuphar_settings = 'nuphar_cache_path:{}, nuphar_cache_so_name:{}, nuphar_cache_force_no_jit:{}, nuphar_codegen_target:{}'.format(cache_dir, so_name, 'on', 'avx')
+            nuphar_settings = 'nuphar_cache_path:{}, nuphar_cache_so_name:{}, nuphar_cache_force_no_jit:{}, nuphar_codegen_target:{}'.format(
+                cache_dir, so_name, 'on', 'avx')
             onnxrt.capi._pybind_state.set_nuphar_settings(nuphar_settings)
             sess = onnxrt.InferenceSession(model)
             sess.run([], feed)
-
 
     def test_bert_squad(self):
         # download BERT_squad model
         cwd = os.getcwd()
         bert_squad_url = 'https://onnxzoo.blob.core.windows.net/models/opset_10/bert_squad/download_sample_10.tar.gz'
-        cache_dir = os.path.join(os.path.expanduser("~"), '.cache','onnxruntime')
+        cache_dir = os.path.join(os.path.expanduser("~"), '.cache', 'onnxruntime')
         os.makedirs(cache_dir, exist_ok=True)
         bert_squad_local = os.path.join(cache_dir, 'bert_squad.tar.gz')
         if not os.path.exists(bert_squad_local):
@@ -99,7 +121,12 @@ class TestNuphar(unittest.TestCase):
         # set int_max to 1,000,000 to simplify symbol computes for things like min(1000000, seq_len) -> seq_len
         bert_squad_dir = os.path.join(cwd, 'download_sample_10')
         bert_squad_model = os.path.join(bert_squad_dir, 'bertsquad10.onnx')
-        subprocess.run([sys.executable, '-m', 'onnxruntime.nuphar.symbolic_shape_infer', '--input', bert_squad_model, '--output', bert_squad_model, '--auto_merge', '--int_max=1000000'], check=True, cwd=cwd)
+        subprocess.run([
+            sys.executable, '-m', 'onnxruntime.nuphar.symbolic_shape_infer', '--input', bert_squad_model, '--output',
+            bert_squad_model, '--auto_merge', '--int_max=1000000'
+        ],
+                       check=True,
+                       cwd=cwd)
 
         # run onnx_test_runner to verify results
         onnx_test_runner = os.path.join(cwd, 'onnx_test_runner')
@@ -107,35 +134,57 @@ class TestNuphar(unittest.TestCase):
 
         # run onnxruntime_perf_test, note that nuphar currently is not integrated with ORT thread pool, so set -x 1 to avoid thread confliction with OpenMP
         onnxruntime_perf_test = os.path.join(cwd, 'onnxruntime_perf_test')
-        subprocess.run([onnxruntime_perf_test, '-e', 'nuphar', '-x', '1', '-t', '20', bert_squad_model, '1.txt'], check=True, cwd=cwd)
-
+        subprocess.run([onnxruntime_perf_test, '-e', 'nuphar', '-x', '1', '-t', '20', bert_squad_model, '1.txt'],
+                       check=True,
+                       cwd=cwd)
 
     def test_rnn_benchmark(self):
         # make sure benchmarking scripts works
         # note: quantized model requires AVX2, otherwise it might be slow
-        avg_rnn, avg_scan, avg_int8 = perf_test('lstm', num_threads=1,
-                                                input_dim=128, hidden_dim=1024, bidirectional=True,
-                                                layers=1, seq_len=16, batch_size=1,
+        avg_rnn, avg_scan, avg_int8 = perf_test('lstm',
+                                                num_threads=1,
+                                                input_dim=128,
+                                                hidden_dim=1024,
+                                                bidirectional=True,
+                                                layers=1,
+                                                seq_len=16,
+                                                batch_size=1,
                                                 min_duration_seconds=1)
-        avg_rnn, avg_scan, avg_int8 = perf_test('gru', num_threads=1,
-                                                input_dim=128, hidden_dim=1024, bidirectional=False,
-                                                layers=2, seq_len=16, batch_size=3,
+        avg_rnn, avg_scan, avg_int8 = perf_test('gru',
+                                                num_threads=1,
+                                                input_dim=128,
+                                                hidden_dim=1024,
+                                                bidirectional=False,
+                                                layers=2,
+                                                seq_len=16,
+                                                batch_size=3,
                                                 min_duration_seconds=1)
-        avg_rnn, avg_scan, avg_int8 = perf_test('rnn', num_threads=1,
-                                                input_dim=128, hidden_dim=1024, bidirectional=False,
-                                                layers=3, seq_len=16, batch_size=2,
+        avg_rnn, avg_scan, avg_int8 = perf_test('rnn',
+                                                num_threads=1,
+                                                input_dim=128,
+                                                hidden_dim=1024,
+                                                bidirectional=False,
+                                                layers=3,
+                                                seq_len=16,
+                                                batch_size=2,
                                                 min_duration_seconds=1)
-
 
     def test_batch_scan(self):
         input_dim = 3
         hidden_dim = 5
         bidirectional = False
         layers = 3
- 
+
         lstm_model_name = 'test_batch_rnn_lstm.onnx'
         # create an LSTM model for generating baseline data
-        generate_model('lstm', input_dim, hidden_dim, bidirectional, layers, lstm_model_name, batch_one=False, has_seq_len=True)
+        generate_model('lstm',
+                       input_dim,
+                       hidden_dim,
+                       bidirectional,
+                       layers,
+                       lstm_model_name,
+                       batch_one=False,
+                       has_seq_len=True)
 
         seq_len = 8
         batch_size = 2
@@ -145,40 +194,51 @@ class TestNuphar(unittest.TestCase):
 
         # run lstm as baseline
         sess = onnxrt.InferenceSession(lstm_model_name)
-        first_lstm_data_output = sess.run([], {'input':data_input[:,0:1,:], 'seq_len':data_seq_len[0:1]})
+        first_lstm_data_output = sess.run([], {'input': data_input[:, 0:1, :], 'seq_len': data_seq_len[0:1]})
 
         lstm_data_output = []
         lstm_data_output = first_lstm_data_output
 
         for b in range(1, batch_size):
-            lstm_data_output = lstm_data_output + sess.run([], {'input':data_input[:,b:(b+1),:], 'seq_len':data_seq_len[b:(b+1)]})
+            lstm_data_output = lstm_data_output + sess.run([], {
+                'input': data_input[:, b:(b + 1), :],
+                'seq_len': data_seq_len[b:(b + 1)]
+            })
         lstm_data_output = np.concatenate(lstm_data_output, axis=1)
 
         # generate a batch scan model
         scan_model_name = 'test_batch_rnn_scan.onnx'
-        subprocess.run([sys.executable, '-m', 'onnxruntime.nuphar.model_editor', '--input', lstm_model_name, '--output', scan_model_name, '--mode', 'to_scan'], check=True)
+        subprocess.run([
+            sys.executable, '-m', 'onnxruntime.nuphar.model_editor', '--input', lstm_model_name, '--output',
+            scan_model_name, '--mode', 'to_scan'
+        ],
+                       check=True)
 
         # run scan_batch with batch size 1
         sess = onnxrt.InferenceSession(scan_model_name)
-        scan_batch_data_output = sess.run([], {'input':data_input[:,0:1,:], 'seq_len':data_seq_len[0:1]})
+        scan_batch_data_output = sess.run([], {'input': data_input[:, 0:1, :], 'seq_len': data_seq_len[0:1]})
         assert np.allclose(first_lstm_data_output, scan_batch_data_output)
 
         # run scan_batch with batch size 2
-        scan_batch_data_output = sess.run([], {'input':data_input, 'seq_len':data_seq_len})
+        scan_batch_data_output = sess.run([], {'input': data_input, 'seq_len': data_seq_len})
         assert np.allclose(lstm_data_output, scan_batch_data_output)
 
         # run scan_batch with batch size 1 again
-        scan_batch_data_output = sess.run([], {'input':data_input[:,0:1,:], 'seq_len':data_seq_len[0:1]})
+        scan_batch_data_output = sess.run([], {'input': data_input[:, 0:1, :], 'seq_len': data_seq_len[0:1]})
         assert np.allclose(first_lstm_data_output, scan_batch_data_output)
-
 
     def test_symbolic_shape_infer(self):
         cwd = os.getcwd()
         test_model_dir = os.path.join(cwd, '..', 'models')
         for filename in Path(test_model_dir).rglob('*.onnx'):
             if filename.name.startswith('.'):
-                continue # skip some bad model files
-            subprocess.run([sys.executable, '-m', 'onnxruntime.nuphar.symbolic_shape_infer', '--input', str(filename), '--auto_merge', '--int_max=100000', '--guess_output_rank'], check=True, cwd=cwd)
+                continue  # skip some bad model files
+            subprocess.run([
+                sys.executable, '-m', 'onnxruntime.nuphar.symbolic_shape_infer', '--input',
+                str(filename), '--auto_merge', '--int_max=100000', '--guess_output_rank'
+            ],
+                           check=True,
+                           cwd=cwd)
 
 
 if __name__ == '__main__':

--- a/onnxruntime/test/testdata/capi_symbolic_dims.py
+++ b/onnxruntime/test/testdata/capi_symbolic_dims.py
@@ -10,21 +10,17 @@ dim = output.type.tensor_type.shape.dim.add()
 print(dim)
 
 graph_def = helper.make_graph(
-    nodes = [
-        helper.make_node(op_type = "Reshape", inputs = ['A', 'B'], outputs = ['C'], name = 'reshape'),
+    nodes=[
+        helper.make_node(op_type="Reshape", inputs=['A', 'B'], outputs=['C'], name='reshape'),
     ],
-    name = 'test-model',
-    inputs = [
+    name='test-model',
+    inputs=[
         # create inputs with symbolic dims
         helper.make_tensor_value_info("A", TensorProto.FLOAT, ['n', 2]),
         helper.make_tensor_value_info("B", TensorProto.INT64, ['m']),
     ],
-    outputs = [
-        output
-    ],
-    initializer = [
-    ]
-)
+    outputs=[output],
+    initializer=[])
 
 model = helper.make_model(graph_def, opset_imports=[helper.make_operatorsetid("", 11)])
 onnx.checker.check_model(model)

--- a/onnxruntime/test/testdata/ngraph/model_gen.py
+++ b/onnxruntime/test/testdata/ngraph/model_gen.py
@@ -2,11 +2,13 @@ import numpy as np
 import onnx
 from onnx import helper, numpy_helper
 
-def save_graph(graph_def, name) :
+
+def save_graph(graph_def, name):
     model_def = helper.make_model(graph_def, producer_name="nGraph EP test model")
     model_def.opset_import[0].version = 7
     model_def.ir_version = 3
     onnx.save_model(model_def, name)
+
 
 A = helper.make_tensor_value_info('A', onnx.TensorProto.FLOAT, [4])
 B = helper.make_tensor_value_info('B', onnx.TensorProto.FLOAT, [4])
@@ -14,94 +16,67 @@ C = helper.make_tensor_value_info('C', onnx.TensorProto.FLOAT, [4])
 Y = helper.make_tensor_value_info('Y', onnx.TensorProto.FLOAT, [4])
 Z = helper.make_tensor_value_info('Z', onnx.TensorProto.FLOAT, [4])
 
-graph_def = helper.make_graph(
-[helper.make_node('Add',['A','A'],['node1_out'], "node_1"),
-helper.make_node('Mul',['node1_out','B'],['Z'], "node_2")],
-"nGraph EP test graph",
-[A,B],
-[Z]
-)
+graph_def = helper.make_graph([
+    helper.make_node('Add', ['A', 'A'], ['node1_out'], "node_1"),
+    helper.make_node('Mul', ['node1_out', 'B'], ['Z'], "node_2")
+], "nGraph EP test graph", [A, B], [Z])
 
 save_graph(graph_def, "Basic_Test.onnx")
 
-
-graph_def = helper.make_graph(
-[helper.make_node('Add',['A','A'],['node1_out'], "node_1"),
-helper.make_node('Mul',['node1_out','B'],['node2_out'], "node_2"),
-helper.make_node('UnSupportedOp',['node2_out'],['Z'], "node_3")],
-"nGraph EP test graph",
-[A,B],
-[Z]
-)
+graph_def = helper.make_graph([
+    helper.make_node('Add', ['A', 'A'], ['node1_out'], "node_1"),
+    helper.make_node('Mul', ['node1_out', 'B'], ['node2_out'], "node_2"),
+    helper.make_node('UnSupportedOp', ['node2_out'], ['Z'], "node_3")
+], "nGraph EP test graph", [A, B], [Z])
 
 save_graph(graph_def, "Graph_with_UnSupportedOp.onnx")
 
-
-graph_def = helper.make_graph(
-[helper.make_node('Add',['A','A'],['node1_out'], "node_1"),
-helper.make_node('Mul',['node1_out','B'],['node2_out'], "node_2"),
-helper.make_node('UnSupportedOp',['node2_out'],['node3_out'], "node_3"),
-helper.make_node('Add',['node3_out','C'],['Z'], "node_4")],
-"nGraph EP test graph",
-[A,B,C],
-[Z]
-)
+graph_def = helper.make_graph([
+    helper.make_node('Add', ['A', 'A'], ['node1_out'], "node_1"),
+    helper.make_node('Mul', ['node1_out', 'B'], ['node2_out'], "node_2"),
+    helper.make_node('UnSupportedOp', ['node2_out'], ['node3_out'], "node_3"),
+    helper.make_node('Add', ['node3_out', 'C'], ['Z'], "node_4")
+], "nGraph EP test graph", [A, B, C], [Z])
 
 save_graph(graph_def, "Two_Subgraphs.onnx")
 
-
-graph_def = helper.make_graph(
-[helper.make_node('Add',['A','A'],['Y'], "node_1"),
-helper.make_node('Mul',['Y','B'],['node2_out'], "node_2"),
-helper.make_node('UnSupportedOp',['node2_out'],['node3_out'], "node_3"),
-helper.make_node('Add',['node3_out','C'],['Z'], "node_4")],
-"nGraph EP test graph",
-[A,B,C],
-[Y,Z]
-)
+graph_def = helper.make_graph([
+    helper.make_node('Add', ['A', 'A'], ['Y'], "node_1"),
+    helper.make_node('Mul', ['Y', 'B'], ['node2_out'], "node_2"),
+    helper.make_node('UnSupportedOp', ['node2_out'], ['node3_out'], "node_3"),
+    helper.make_node('Add', ['node3_out', 'C'], ['Z'], "node_4")
+], "nGraph EP test graph", [A, B, C], [Y, Z])
 
 save_graph(graph_def, "ClusterOut_isAlso_GraphOut.onnx")
 
-
-graph_def = helper.make_graph(
-[helper.make_node('Add',['A','A'],['node1_out'], "node_1"),
-helper.make_node('Mul',['node1_out','B'],['Y'], "node_2"),
-helper.make_node('UnSupportedOp',['Y'],['node3_out'], "node_3"),
-helper.make_node('Add',['node3_out','C'],['Z'], "node_4")],
-"nGraph EP test graph",
-[A,B,C],
-[Y,Z]
-)
+graph_def = helper.make_graph([
+    helper.make_node('Add', ['A', 'A'], ['node1_out'], "node_1"),
+    helper.make_node('Mul', ['node1_out', 'B'], ['Y'], "node_2"),
+    helper.make_node('UnSupportedOp', ['Y'], ['node3_out'], "node_3"),
+    helper.make_node('Add', ['node3_out', 'C'], ['Z'], "node_4")
+], "nGraph EP test graph", [A, B, C], [Y, Z])
 
 save_graph(graph_def, "InOut_isAlso_GraphOut.onnx")
 
-
-graph_def = helper.make_graph(
-[helper.make_node('Add',['A','A'],['node1_out'], "node_1"),
-helper.make_node('Dropout',['node1_out'],['Y','X'], "node_2"),
-helper.make_node('UnSupportedOp',['Y'],['node3_out'], "node_3"),
-helper.make_node('Add',['node3_out','C'],['Z'], "node_4")],
-"nGraph EP test graph",
-[A,C],
-[Z]
-)
+graph_def = helper.make_graph([
+    helper.make_node('Add', ['A', 'A'], ['node1_out'], "node_1"),
+    helper.make_node('Dropout', ['node1_out'], ['Y', 'X'], "node_2"),
+    helper.make_node('UnSupportedOp', ['Y'], ['node3_out'], "node_3"),
+    helper.make_node('Add', ['node3_out', 'C'], ['Z'], "node_4")
+], "nGraph EP test graph", [A, C], [Z])
 
 save_graph(graph_def, "Op_with_Optional_or_Unused_Outputs.onnx")
 
 one_in = helper.make_tensor_value_info('one', onnx.TensorProto.FLOAT, [1])
-one_data = np.array([1],dtype=np.float32)
+one_data = np.array([1], dtype=np.float32)
 one_tensor = numpy_helper.from_array(one_data, "one")
 
-graph_def = helper.make_graph(
-[helper.make_node('Add',['A', "A"],['node1_out'], "node_1"),
-helper.make_node('UnSupportedOp',['node1_out'],['branch_a_out'], "node_2"),
-helper.make_node('Add',["node1_out","one"],["branch_b_out1"], "node_3"),
-helper.make_node('Add',["branch_b_out1","one"],["branch_b_out"],"node_4"),
-helper.make_node('Add',["branch_a_out","branch_b_out"],["Z"], "node_5")],
-"nGraph EP test graph",
-[A, one_in],
-[Z],
-[one_tensor]
-)
+graph_def = helper.make_graph([
+    helper.make_node('Add', ['A', "A"], ['node1_out'], "node_1"),
+    helper.make_node('UnSupportedOp', ['node1_out'], ['branch_a_out'], "node_2"),
+    helper.make_node('Add', ["node1_out", "one"], ["branch_b_out1"], "node_3"),
+    helper.make_node('Add', ["branch_b_out1", "one"], ["branch_b_out"], "node_4"),
+    helper.make_node('Add', ["branch_a_out", "branch_b_out"], ["Z"], "node_5")
+], "nGraph EP test graph", [A, one_in], [Z], [one_tensor])
 
 save_graph(graph_def, "Independent_SubGraphs.onnx")

--- a/onnxruntime/test/testdata/transform/approximation/gelu_approximation_gen.py
+++ b/onnxruntime/test/testdata/transform/approximation/gelu_approximation_gen.py
@@ -3,7 +3,7 @@ from onnx import helper
 from onnx import TensorProto
 
 graph = helper.make_graph(
-    [ # nodes
+    [  # nodes
         # Add node before Gelu
         helper.make_node("Gelu", ["A"], ["C"], "Gelu_1", domain="com.microsoft"),
     ],
@@ -15,14 +15,13 @@ graph = helper.make_graph(
         helper.make_tensor_value_info('C', TensorProto.FLOAT, ['batch', 'seq_len', 3072]),
     ],
     [  # initializers
-    ]
-)
+    ])
 
 model = helper.make_model(graph)
 onnx.save(model, r'gelu.onnx')
 
 graph = helper.make_graph(
-    [ # nodes
+    [  # nodes
         # Add node before Gelu
         helper.make_node("BiasGelu", ["A", "B"], ["C"], "AddGeluFusion_1", domain="com.microsoft"),
     ],
@@ -35,14 +34,13 @@ graph = helper.make_graph(
         helper.make_tensor_value_info('C', TensorProto.FLOAT, ['batch', 'seq_len', 3072]),
     ],
     [  # initializers
-    ]
-)
+    ])
 
 model = helper.make_model(graph)
 onnx.save(model, r'gelu_add_bias.onnx')
 
 graph = helper.make_graph(
-    [ # nodes
+    [  # nodes
         # Add node before Gelu
         helper.make_node("MatMul", ["A", "B"], ["C"], "MatMul_1"),
         helper.make_node("BiasGelu", ["C", "D"], ["E"], "AddGeluFusion_1", domain="com.microsoft"),
@@ -57,9 +55,7 @@ graph = helper.make_graph(
         helper.make_tensor_value_info('E', TensorProto.FLOAT, ['batch', 'seq_len', 3072]),
     ],
     [  # initializers
-    ]
-)
+    ])
 
 model = helper.make_model(graph)
 onnx.save(model, r'gelu_add_matmul.onnx')
-

--- a/onnxruntime/test/testdata/transform/fusion/bias_gelu_gen.py
+++ b/onnxruntime/test/testdata/transform/fusion/bias_gelu_gen.py
@@ -3,10 +3,10 @@ from onnx import helper
 from onnx import TensorProto
 
 graph = helper.make_graph(
-    [ # nodes
+    [  # nodes
         # Add node before Gelu
         helper.make_node("Add", ["A", "B"], ["add0_out"], "add0"),
-        
+
         # Gelu subgraph
         helper.make_node("Div", ["add0_out", "div_const"], ["div_out"], "div"),
         helper.make_node("Mul", ["add0_out", "mul_const"], ["mul_out"], "mul0"),
@@ -26,8 +26,7 @@ graph = helper.make_graph(
         helper.make_tensor('div_const', TensorProto.FLOAT, [], [1.4142135381698608]),
         helper.make_tensor('mul_const', TensorProto.FLOAT, [], [0.5]),
         helper.make_tensor('add_const', TensorProto.FLOAT, [], [1]),
-    ]
-)
+    ])
 
 model = helper.make_model(graph)
 onnx.save(model, r'bias_gelu_fusion.onnx')

--- a/onnxruntime/test/testdata/transform/fusion/create_conv_clip11.py
+++ b/onnxruntime/test/testdata/transform/fusion/create_conv_clip11.py
@@ -3,7 +3,7 @@ from onnx import helper
 from onnx import TensorProto
 
 graph = helper.make_graph(
-    [ # nodes
+    [  # nodes
         # fusable, const_min_negative should be replaced
         helper.make_node("Conv", ["X", "W"], ["conv0_out"], "Conv0"),
         helper.make_node("Clip", ["conv0_out", "const_min", "const_max"], ["clip0_out"], "Clip0"),
@@ -30,8 +30,7 @@ graph = helper.make_graph(
     [  # initializers
         helper.make_tensor('const_min', TensorProto.FLOAT, [1], [-1.0]),
         helper.make_tensor('const_max', TensorProto.FLOAT, [1], [10.0])
-    ]
-)
+    ])
 
 model = helper.make_model(graph)
 onnx.save(model, r'conv_clip11.onnx')

--- a/onnxruntime/test/testdata/transform/fusion/embed_layer_norm_gen.py
+++ b/onnxruntime/test/testdata/transform/fusion/embed_layer_norm_gen.py
@@ -3,8 +3,9 @@ from onnx import helper
 from onnx import TensorProto
 from enum import Enum
 
+
 def GenerateModel3(model_name):
-    nodes = [        # LayerNorm subgraph
+    nodes = [  # LayerNorm subgraph
         helper.make_node("Shape", ["input_ids"], ["shape1_out"], "shape1"),
         helper.make_node("Gather", ["shape1_out", "indices_0"], ["gather0_out"], "gather0"),
         helper.make_node("Unsqueeze", ["gather0_out"], ["unsqueeze0_out"], "unsqueeze0", axes=[0]),
@@ -21,32 +22,38 @@ def GenerateModel3(model_name):
         helper.make_node("Add", ["word_gather_out", "pos_gather_out"], ["word_add_pos_out"], "word_add_pos"),
         helper.make_node("Gather", ["seg_embed", "segment_ids"], ["seg_gather_out"], "seg_gather"),
         helper.make_node("Add", ["word_add_pos_out", "seg_gather_out"], ["add3_out"], "add3"),
-        helper.make_node("LayerNormalization", ["add3_out", "layer_norm_weight", "layer_norm_bias"], ["layernorm_out"], "layernorm", axis=-1, epsion=0.000009999999747378752),
+        helper.make_node("LayerNormalization", ["add3_out", "layer_norm_weight", "layer_norm_bias"], ["layernorm_out"],
+                         "layernorm",
+                         axis=-1,
+                         epsion=0.000009999999747378752),
         helper.make_node("Cast", ["input_mask"], ["mask_cast_out"], "mask_cast", to=6),
         helper.make_node("ReduceSum", ["mask_cast_out"], ["mask_index_out"], "mask_index", axes=[1], keepdims=0),
-        helper.make_node("Attention", ["layernorm_out", "qkv_weights", "qkv_bias", "mask_index_out"], ["att_out"], "att", domain="com.microsoft", num_heads=2),
+        helper.make_node("Attention", ["layernorm_out", "qkv_weights", "qkv_bias", "mask_index_out"], ["att_out"],
+                         "att",
+                         domain="com.microsoft",
+                         num_heads=2),
         helper.make_node("MatMul", ["att_out", "matmul_weight"], ["matmul_out"], "matmul"),
         helper.make_node("Add", ["matmul_out", "add_bias"], ["add_out"], "add"),
         helper.make_node("Add", ["add_out", "layernorm_out"], ["add2_out"], "add2")
-        
     ]
 
     # hidden_size=4, num_heads=2, max_seq_length=3
-    initializers = [ # initializers
+    initializers = [  # initializers
         helper.make_tensor('indices_0', TensorProto.INT64, [], [0]),
         helper.make_tensor('indices_1', TensorProto.INT64, [], [1]),
         helper.make_tensor('start_0', TensorProto.INT64, [], [0]),
         helper.make_tensor('delta_1', TensorProto.INT64, [], [1]),
         helper.make_tensor('word_embed', TensorProto.FLOAT, [2, 4], [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0]),
-        helper.make_tensor('pos_embed', TensorProto.FLOAT, [4, 4], [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0]),
+        helper.make_tensor('pos_embed', TensorProto.FLOAT, [4, 4],
+                           [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0]),
         helper.make_tensor('seg_embed', TensorProto.FLOAT, [2, 4], [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0]),
         helper.make_tensor('layer_norm_weight', TensorProto.FLOAT, [4], [1.0, 2.0, 3.0, 4.0]),
         helper.make_tensor('layer_norm_bias', TensorProto.FLOAT, [4], [0.1, 0.2, 0.3, 0.4]),
-
-        helper.make_tensor('qkv_weights', TensorProto.FLOAT, [4, 4], [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0]),
+        helper.make_tensor('qkv_weights', TensorProto.FLOAT, [4, 4],
+                           [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0]),
         helper.make_tensor('qkv_bias', TensorProto.FLOAT, [4], [0.1, 0.2, 0.3, 0.4]),
-        
-        helper.make_tensor('matmul_weight', TensorProto.FLOAT, [4, 4], [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0]),
+        helper.make_tensor('matmul_weight', TensorProto.FLOAT, [4, 4],
+                           [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0]),
         helper.make_tensor('add_bias', TensorProto.FLOAT, [4], [0.1, 0.2, 0.3, 0.4]),
     ]
 
@@ -61,11 +68,11 @@ def GenerateModel3(model_name):
         [  # outputs
             helper.make_tensor_value_info('add2_out', TensorProto.FLOAT, ['batch', 3, 4]),
         ],
-        initializers
-    )
+        initializers)
 
     model = helper.make_model(graph)
     onnx.save(model, model_name)
+
 
 def GenerateModel5(model_name):
     batch_size = 2
@@ -78,35 +85,43 @@ def GenerateModel5(model_name):
         helper.make_node("Add", ["word_gather_out", "pos_gather_out"], ["word_add_pos_out"], "word_add_pos"),
         helper.make_node("Gather", ["seg_embed", "segment_ids"], ["seg_gather_out"], "seg_gather", axis=0),
         helper.make_node("Add", ["word_add_pos_out", "seg_gather_out"], ["add3_out"], "add3"),
-        helper.make_node("LayerNormalization", ["add3_out", "layer_norm_weight", "layer_norm_bias"], ["layernorm_out"], "layernorm", axis=-1, epsion=0.000009999999747378752),
+        helper.make_node("LayerNormalization", ["add3_out", "layer_norm_weight", "layer_norm_bias"], ["layernorm_out"],
+                         "layernorm",
+                         axis=-1,
+                         epsion=0.000009999999747378752),
         helper.make_node("Cast", ["input_mask"], ["mask_cast_out"], "mask_cast", to=6),
         helper.make_node("ReduceSum", ["mask_cast_out"], ["mask_index_out"], "mask_index", axes=[1], keepdims=0),
-        helper.make_node("Attention", ["layernorm_out", "qkv_weights", "qkv_bias", "mask_index_out"], ["att_out"], "att", domain="com.microsoft", num_heads=attention_heads),
+        helper.make_node("Attention", ["layernorm_out", "qkv_weights", "qkv_bias", "mask_index_out"], ["att_out"],
+                         "att",
+                         domain="com.microsoft",
+                         num_heads=attention_heads),
         helper.make_node("MatMul", ["att_out", "matmul_weight"], ["matmul_out"], "matmul"),
         helper.make_node("Add", ["matmul_out", "add_bias"], ["add_out"], "add"),
         helper.make_node("Add", ["add_out", "layernorm_out"], ["add2_out"], "add2")
     ]
 
-    qkv_weights = [1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0,
-                 1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0,
-                 1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0,
-                 1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0]
+    qkv_weights = [
+        1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0,
+        3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0,
+        1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0
+    ]
 
-    initializers = [# initializers
+    initializers = [  # initializers
         helper.make_tensor('word_embed', TensorProto.FLOAT, [2, hidden_size], [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0]),
-        helper.make_tensor('pos_gather_out', TensorProto.FLOAT, [batch_size, sequence_length, hidden_size],
-                           [1.0, 2.0, 3.0, 4.0,  5.0, 6.0, 7.0, 8.0,  9.0, 8.0, 7.0, 6.0,
-                            1.0, 2.0, 3.0, 4.0,  5.0, 6.0, 7.0, 8.0,  9.0, 8.0, 7.0, 6.0]),
+        helper.make_tensor('pos_gather_out', TensorProto.FLOAT, [batch_size, sequence_length, hidden_size], [
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 8.0, 7.0, 6.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+            8.0, 7.0, 6.0
+        ]),
         helper.make_tensor('seg_embed', TensorProto.FLOAT, [2, hidden_size], [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0]),
         helper.make_tensor('layer_norm_weight', TensorProto.FLOAT, [hidden_size], [1.0, 2.0, 3.0, 4.0]),
         helper.make_tensor('layer_norm_bias', TensorProto.FLOAT, [hidden_size], [0.1, 0.2, 0.3, 0.4]),
         helper.make_tensor('qkv_weights', TensorProto.FLOAT, [hidden_size, 3 * hidden_size], qkv_weights),
-
-        helper.make_tensor('qkv_bias', TensorProto.FLOAT, [3 * hidden_size], [0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4]),
-        
-        helper.make_tensor('matmul_weight', TensorProto.FLOAT, [hidden_size, hidden_size], 
-                           [1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0,  1.0, 2.0, 3.0, 4.0]),
-        helper.make_tensor('add_bias', TensorProto.FLOAT, [hidden_size], [0.1, 0.2, 0.3, 0.4]),]
+        helper.make_tensor('qkv_bias', TensorProto.FLOAT, [3 * hidden_size],
+                           [0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4]),
+        helper.make_tensor('matmul_weight', TensorProto.FLOAT, [hidden_size, hidden_size],
+                           [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0]),
+        helper.make_tensor('add_bias', TensorProto.FLOAT, [hidden_size], [0.1, 0.2, 0.3, 0.4]),
+    ]
 
     graph = helper.make_graph(
         nodes,
@@ -119,11 +134,11 @@ def GenerateModel5(model_name):
         [  # outputs
             helper.make_tensor_value_info('add2_out', TensorProto.FLOAT, [batch_size, sequence_length, hidden_size]),
         ],
-        initializers
-    )
+        initializers)
 
     model = helper.make_model(graph)
     onnx.save(model, model_name)
+
 
 #GenerateModel3('embed_layer_norm_format3.onnx')
 GenerateModel5('embed_layer_norm_format5.onnx')

--- a/onnxruntime/test/testdata/transform/fusion/fast_gelu.py
+++ b/onnxruntime/test/testdata/transform/fusion/fast_gelu.py
@@ -6,8 +6,8 @@ import numpy as np
 
 # Gelu formula: x * 0.5 * (1.0 + tanh(0.7978845608028654 * x * (1.0 + 0.044715 * x * x)))
 
-has_bias = True # change it to True to generate fast_gelu_with_bias.onnx
-gelu_use_graph_input = True # change it to False to let Gelu don't have graph inputs as inputs.
+has_bias = True  # change it to True to generate fast_gelu_with_bias.onnx
+gelu_use_graph_input = True  # change it to False to let Gelu don't have graph inputs as inputs.
 
 X = helper.make_tensor_value_info('input', TensorProto.FLOAT, ["batch", "seqlen", 64])
 Y = helper.make_tensor_value_info('output', TensorProto.FLOAT, ["batch", "seqlen", 64])
@@ -33,123 +33,57 @@ b_bias_initializer = numpy_helper.from_array(b_bias_np_vals, "add2_init")
 nodes = []
 gelu_input = "input"
 if not gelu_use_graph_input:
-    leading_identity = helper.make_node(
-        'Identity', 
-        [gelu_input], 
-        ['identity_leading'], 
-        name="identity_leading"
-    )
+    leading_identity = helper.make_node('Identity', [gelu_input], ['identity_leading'], name="identity_leading")
     gelu_input = "identity_leading"
     nodes.append(leading_identity)
 
 mul_input_name = gelu_input
 if has_bias:
-    add0 = helper.make_node(
-        'Add', 
-        [gelu_input, bias_initializer.name], 
-        ['add0'], 
-        name="add0"
-    )
+    add0 = helper.make_node('Add', [gelu_input, bias_initializer.name], ['add0'], name="add0")
     mul_input_name = "add0"
     nodes.append(add0)
 
-
-mul1 = helper.make_node(
-    'Mul', 
-    [mul_input_name, a_weight_initializer.name], 
-    ['mul1'], 
-    name="mul1"
-)
+mul1 = helper.make_node('Mul', [mul_input_name, a_weight_initializer.name], ['mul1'], name="mul1")
 nodes.append(mul1)
 
-mul2 = helper.make_node(
-    'Mul', 
-    [mul_input_name, 'mul1'], 
-    ['mul2'], 
-    name="mul2"
-)
+mul2 = helper.make_node('Mul', [mul_input_name, 'mul1'], ['mul2'], name="mul2")
 nodes.append(mul2)
 
-add1 = helper.make_node(
-    'Add', 
-    ['mul2', a_bias_initializer.name], 
-    ['add1'], 
-    name="add1"
-)
+add1 = helper.make_node('Add', ['mul2', a_bias_initializer.name], ['add1'], name="add1")
 nodes.append(add1)
 
-mul3 = helper.make_node(
-    'Mul', 
-    [mul_input_name, b_weight_initializer.name], 
-    ['mul3'], 
-    name="mul3"
-)
+mul3 = helper.make_node('Mul', [mul_input_name, b_weight_initializer.name], ['mul3'], name="mul3")
 nodes.append(mul3)
 
-mul4 = helper.make_node(
-    'Mul', 
-    ['mul3', 'add1'], 
-    ['mul4'], 
-    name="mul4"
-)
+mul4 = helper.make_node('Mul', ['mul3', 'add1'], ['mul4'], name="mul4")
 nodes.append(mul4)
 
-tanh = helper.make_node(
-    'Tanh', 
-    ['mul4'], 
-    ['tanh'], 
-    name="tanh"
-)
+tanh = helper.make_node('Tanh', ['mul4'], ['tanh'], name="tanh")
 nodes.append(tanh)
 
-add2 = helper.make_node(
-    'Add', 
-    ['tanh', b_bias_initializer.name], 
-    ['add2'], 
-    name="add2"
-)
+add2 = helper.make_node('Add', ['tanh', b_bias_initializer.name], ['add2'], name="add2")
 nodes.append(add2)
 
-mul5 = helper.make_node(
-    'Mul', 
-    [mul_input_name, c_weight_initializer.name], 
-    ['mul5'], 
-    name="mul5"
-)
+mul5 = helper.make_node('Mul', [mul_input_name, c_weight_initializer.name], ['mul5'], name="mul5")
 nodes.append(mul5)
 
-mul6 = helper.make_node(
-    'Mul', 
-    ['mul5', 'add2'], 
-    ['mul6'], 
-    name="mul6"
-)
-ending_identity = helper.make_node(
-    'Identity', 
-    ['mul6'], 
-    ['output'], 
-    name="identity_ending"
-)
+mul6 = helper.make_node('Mul', ['mul5', 'add2'], ['mul6'], name="mul6")
+ending_identity = helper.make_node('Identity', ['mul6'], ['output'], name="identity_ending")
 nodes.extend([mul6, ending_identity])
 
 initializers = []
 if has_bias:
     initializers = [bias_initializer]
 
-initializers.extend([a_weight_initializer, a_bias_initializer, b_weight_initializer, b_bias_initializer, c_weight_initializer])
+initializers.extend(
+    [a_weight_initializer, a_bias_initializer, b_weight_initializer, b_bias_initializer, c_weight_initializer])
 # Create the graph (GraphProto)
-graph_def = helper.make_graph(
-    nodes,
-    'test-model',
-    [X],
-    [Y],
-    initializers
-)
+graph_def = helper.make_graph(nodes, 'test-model', [X], [Y], initializers)
 
 opsets = []
 onnxdomain = OperatorSetIdProto()
 onnxdomain.version = 10
-onnxdomain.domain = "" # The empty string ("") or absence of this field implies the operator set that is defined as part of the ONNX specification.
+onnxdomain.domain = ""  # The empty string ("") or absence of this field implies the operator set that is defined as part of the ONNX specification.
 opsets.append(onnxdomain)
 
 msdomain = OperatorSetIdProto()
@@ -157,7 +91,7 @@ msdomain.version = 1
 msdomain.domain = "com.microsoft"
 
 opsets.append(msdomain)
-kwargs={}
+kwargs = {}
 kwargs["opset_imports"] = opsets
 
 model_def = helper.make_model(graph_def, producer_name='onnx-example', **kwargs)
@@ -169,4 +103,3 @@ if has_bias:
 if gelu_use_graph_input:
     file_name += "_use_graph_input"
 onnx.save(model_def, file_name + ".onnx")
-

--- a/onnxruntime/test/testdata/transform/fusion/fast_gelu2.py
+++ b/onnxruntime/test/testdata/transform/fusion/fast_gelu2.py
@@ -5,8 +5,8 @@ from onnx import numpy_helper
 import numpy as np
 
 # Gelu formula: x * 0.5 * (1.0 + tanh((sqrt(2 / pi) * (x + 0.044715 * pow(x, 3)))))
-has_bias = False # change it to True to generate fast_gelu_openai_with_bias.onnx
-gelu_use_graph_input = True # change it to False to let Gelu don't have graph inputs/outputs as inputs/outputs.
+has_bias = False  # change it to True to generate fast_gelu_openai_with_bias.onnx
+gelu_use_graph_input = True  # change it to False to let Gelu don't have graph inputs/outputs as inputs/outputs.
 
 X = helper.make_tensor_value_info('input', TensorProto.FLOAT, ["batch", "seqlen", 64])
 Y = helper.make_tensor_value_info('output', TensorProto.FLOAT, ["batch", "seqlen", 64])
@@ -32,115 +32,54 @@ b_bias_initializer = numpy_helper.from_array(b_bias_np_vals, "add2_init")
 nodes = []
 gelu_input = "input"
 if not gelu_use_graph_input:
-    leading_identity = helper.make_node(
-        'Identity', 
-        [gelu_input], 
-        ['identity_leading'], 
-        name="identity_leading"
-    )
+    leading_identity = helper.make_node('Identity', [gelu_input], ['identity_leading'], name="identity_leading")
     gelu_input = "identity_leading"
     nodes.append(leading_identity)
 
 mul_input_name = gelu_input
 if has_bias:
-    add0 = helper.make_node(
-        'Add', 
-        [gelu_input, bias_initializer.name], 
-        ['add0'], 
-        name="add0"
-    )
+    add0 = helper.make_node('Add', [gelu_input, bias_initializer.name], ['add0'], name="add0")
     mul_input_name = "add0"
     nodes.append(add0)
 
-
-pow1 = helper.make_node(
-    'Pow', 
-    [mul_input_name, pow_initializer.name], 
-    ['pow1'], 
-    name="pow1"
-)
+pow1 = helper.make_node('Pow', [mul_input_name, pow_initializer.name], ['pow1'], name="pow1")
 nodes.append(pow1)
 
-mul1 = helper.make_node(
-    'Mul', 
-    ['pow1', a_weight_initializer.name], 
-    ['mul1'], 
-    name="mul1"
-)
+mul1 = helper.make_node('Mul', ['pow1', a_weight_initializer.name], ['mul1'], name="mul1")
 nodes.append(mul1)
 
-add1 = helper.make_node(
-    'Add', 
-    [mul_input_name, "mul1"], 
-    ['add1'], 
-    name="add1"
-)
+add1 = helper.make_node('Add', [mul_input_name, "mul1"], ['add1'], name="add1")
 nodes.append(add1)
 
-mul2 = helper.make_node(
-    'Mul', 
-    ['add1', b_weight_initializer.name], 
-    ['mul2'], 
-    name="mul2"
-)
+mul2 = helper.make_node('Mul', ['add1', b_weight_initializer.name], ['mul2'], name="mul2")
 nodes.append(mul2)
 
-tanh = helper.make_node(
-    'Tanh', 
-    ['mul2'], 
-    ['tanh'], 
-    name="tanh"
-)
+tanh = helper.make_node('Tanh', ['mul2'], ['tanh'], name="tanh")
 nodes.append(tanh)
 
-add2 = helper.make_node(
-    'Add', 
-    ['tanh', b_bias_initializer.name], 
-    ['add2'], 
-    name="add2"
-)
+add2 = helper.make_node('Add', ['tanh', b_bias_initializer.name], ['add2'], name="add2")
 nodes.append(add2)
 
-mul5 = helper.make_node(
-    'Mul', 
-    [mul_input_name, c_weight_initializer.name], 
-    ['mul5'], 
-    name="mul5"
-)
+mul5 = helper.make_node('Mul', [mul_input_name, c_weight_initializer.name], ['mul5'], name="mul5")
 nodes.append(mul5)
 
-mul6 = helper.make_node(
-    'Mul', 
-    ['mul5', 'add2'], 
-    ['mul6'], 
-    name="mul6"
-)
-ending_identity = helper.make_node(
-    'Identity', 
-    ['mul6'], 
-    ['output'], 
-    name="ending_identity"
-)
+mul6 = helper.make_node('Mul', ['mul5', 'add2'], ['mul6'], name="mul6")
+ending_identity = helper.make_node('Identity', ['mul6'], ['output'], name="ending_identity")
 nodes.extend([mul6, ending_identity])
 
 initializers = []
 if has_bias:
     initializers = [bias_initializer]
 
-initializers.extend([pow_initializer, a_weight_initializer, b_weight_initializer, b_bias_initializer, c_weight_initializer])
+initializers.extend(
+    [pow_initializer, a_weight_initializer, b_weight_initializer, b_bias_initializer, c_weight_initializer])
 # Create the graph (GraphProto)
-graph_def = helper.make_graph(
-    nodes,
-    'test-model',
-    [X],
-    [Y],
-    initializers
-)
+graph_def = helper.make_graph(nodes, 'test-model', [X], [Y], initializers)
 
 opsets = []
 onnxdomain = OperatorSetIdProto()
 onnxdomain.version = 10
-onnxdomain.domain = "" # The empty string ("") or absence of this field implies the operator set that is defined as part of the ONNX specification.
+onnxdomain.domain = ""  # The empty string ("") or absence of this field implies the operator set that is defined as part of the ONNX specification.
 opsets.append(onnxdomain)
 
 msdomain = OperatorSetIdProto()
@@ -148,7 +87,7 @@ msdomain.version = 1
 msdomain.domain = "com.microsoft"
 
 opsets.append(msdomain)
-kwargs={}
+kwargs = {}
 kwargs["opset_imports"] = opsets
 
 model_def = helper.make_model(graph_def, producer_name='onnx-example', **kwargs)
@@ -160,4 +99,3 @@ if has_bias:
 if gelu_use_graph_input:
     file_name += "_use_graph_input"
 onnx.save(model_def, file_name + ".onnx")
-

--- a/onnxruntime/test/testdata/transform/fusion/gelu_gen.py
+++ b/onnxruntime/test/testdata/transform/fusion/gelu_gen.py
@@ -3,7 +3,6 @@ from onnx import helper
 from onnx import AttributeProto, TensorProto, GraphProto, OperatorSetIdProto
 from onnx import numpy_helper
 import numpy as np
-
 """
 Generate test model for Gelu subgraph pattern 2:
                    +------------------------------------+
@@ -13,9 +12,9 @@ Generate test model for Gelu subgraph pattern 2:
                           (B=1.4142...)        (1)            (0.5)
 """
 
-has_bias = True # change it to True to generate gelu_format2_*_with_bias.onnx
-gelu_use_graph_input = False # change it to False to let Gelu don't have graph inputs as inputs.
-switch_order = True # switch order of inputs for Mul and Add
+has_bias = True  # change it to True to generate gelu_format2_*_with_bias.onnx
+gelu_use_graph_input = False  # change it to False to let Gelu don't have graph inputs as inputs.
+switch_order = True  # switch order of inputs for Mul and Add
 
 X = helper.make_tensor_value_info('input', TensorProto.FLOAT, ["batch", "seqlen", 64])
 Y = helper.make_tensor_value_info('output', TensorProto.FLOAT, ["batch", "seqlen", 64])
@@ -32,77 +31,40 @@ initializer_0_5 = numpy_helper.from_array(value, "mul3_init")
 value = np.asarray([1.0]).astype(np.float32).reshape(())
 initializer_1 = numpy_helper.from_array(value, "add1_init")
 
-
 nodes = []
 gelu_input = "input"
 if not gelu_use_graph_input:
-    leading_identity = helper.make_node(
-        'Identity', 
-        [gelu_input], 
-        ['identity_leading'], 
-        name="identity_leading"
-    )
+    leading_identity = helper.make_node('Identity', [gelu_input], ['identity_leading'], name="identity_leading")
     gelu_input = "identity_leading"
     nodes.append(leading_identity)
 
 gelu_root = gelu_input
 if has_bias:
     add0 = helper.make_node(
-        'Add', 
-        [gelu_input, bias_initializer.name] if switch_order else [bias_initializer.name, gelu_input],
-        ['add0'], 
-        name="add0_node"
-    )
+        'Add', [gelu_input, bias_initializer.name] if switch_order else [bias_initializer.name, gelu_input], ['add0'],
+        name="add0_node")
     gelu_root = "add0"
     nodes.append(add0)
 
-
-div = helper.make_node(
-    'Div', 
-    [gelu_root, initializer_sqrt_2.name], 
-    ['div'], 
-    name="div_node"
-)
+div = helper.make_node('Div', [gelu_root, initializer_sqrt_2.name], ['div'], name="div_node")
 nodes.append(div)
 
-erf = helper.make_node(
-    'Erf', 
-    ['div'], 
-    ['erf'], 
-    name="erf_node"
-)
+erf = helper.make_node('Erf', ['div'], ['erf'], name="erf_node")
 nodes.append(erf)
 
-add1 = helper.make_node(
-    'Add', 
-    ['erf', initializer_1.name] if switch_order else [initializer_1.name, 'erf'],
-    ['add1'], 
-    name="add1"
-)
+add1 = helper.make_node('Add', ['erf', initializer_1.name] if switch_order else [initializer_1.name, 'erf'], ['add1'],
+                        name="add1")
 nodes.append(add1)
 
-mul = helper.make_node(
-    'Mul', 
-    [gelu_root, 'add1'] if switch_order else ['add1', gelu_root],
-    ['mul'], 
-    name="mul_node"
-)
+mul = helper.make_node('Mul', [gelu_root, 'add1'] if switch_order else ['add1', gelu_root], ['mul'], name="mul_node")
 nodes.append(mul)
 
-mul2 = helper.make_node(
-    'Mul', 
-    ['mul', initializer_0_5.name] if switch_order else [initializer_0_5.name, 'mul'],
-    ['mul2'], 
-    name="mul2_node"
-)
+mul2 = helper.make_node('Mul', ['mul', initializer_0_5.name] if switch_order else [initializer_0_5.name, 'mul'],
+                        ['mul2'],
+                        name="mul2_node")
 nodes.append(mul2)
 
-ending_identity = helper.make_node(
-    'Identity', 
-    ['mul2'], 
-    ['output'], 
-    name="identity_ending"
-)
+ending_identity = helper.make_node('Identity', ['mul2'], ['output'], name="identity_ending")
 nodes.append(ending_identity)
 
 initializers = []
@@ -112,18 +74,12 @@ if has_bias:
 initializers.extend([initializer_sqrt_2, initializer_1, initializer_0_5])
 
 # Create the graph (GraphProto)
-graph_def = helper.make_graph(
-    nodes,
-    'gelu_pattern_2',
-    [X],
-    [Y],
-    initializers
-)
+graph_def = helper.make_graph(nodes, 'gelu_pattern_2', [X], [Y], initializers)
 
 opsets = []
 onnxdomain = OperatorSetIdProto()
 onnxdomain.version = 10
-onnxdomain.domain = "" # The empty string ("") or absence of this field implies the operator set that is defined as part of the ONNX specification.
+onnxdomain.domain = ""  # The empty string ("") or absence of this field implies the operator set that is defined as part of the ONNX specification.
 opsets.append(onnxdomain)
 
 msdomain = OperatorSetIdProto()
@@ -131,7 +87,7 @@ msdomain.version = 1
 msdomain.domain = "com.microsoft"
 
 opsets.append(msdomain)
-kwargs={}
+kwargs = {}
 kwargs["opset_imports"] = opsets
 
 model_def = helper.make_model(graph_def, producer_name='onnx-example', **kwargs)
@@ -146,4 +102,3 @@ if gelu_use_graph_input:
 file_name += ".onnx"
 onnx.save(model_def, file_name)
 print(file_name)
-


### PR DESCRIPTION
**Description**: use yapf instead of autopep8 to format python

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

Some python script is formatted by yapf now. Let's use same tool and configuration to format.