### PR TITLE
Fix post merge test. This doesn't get triggered as part of gated PR checks.

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -360,9 +360,6 @@ set_target_properties(onnxruntime_test_utils PROPERTIES FOLDER "ONNXRuntimeTest"
 set(all_tests ${onnxruntime_test_common_src} ${onnxruntime_test_ir_src} ${onnxruntime_test_optimizer_src} ${onnxruntime_test_framework_src} ${onnxruntime_test_providers_src})
 if(NOT TARGET onnxruntime)
   list(APPEND all_tests ${onnxruntime_shared_lib_test_SRC})
-  if (NOT onnxruntime_USE_NNAPI)
-    list(APPEND all_tests ${onnxruntime_global_thread_pools_test_SRC})
-  endif()
 endif()
 set(all_dependencies ${onnxruntime_test_providers_dependencies} )
 


### PR DESCRIPTION
**Description**: Fix post merge test. This doesn't get triggered as part of gated PR checks..

**Motivation and Context**
The post merge test combines all test sources in one big exe onnxruntime_test_all.exe and this breaks the global threadpool test that expects to be run in a separate process that creates an env with support for global threadpools.

Example https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=123651