### PR TITLE
QLinearMatMul speed up

### DIFF
--- a/cmake/onnxruntime_util.cmake
+++ b/cmake/onnxruntime_util.cmake
@@ -8,19 +8,12 @@ file(GLOB_RECURSE onnxruntime_util_srcs CONFIGURE_DEPENDS
 
 source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_util_srcs})
 
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" AND NOT MSVC)
-  # For x86 platforms it is important to pass this flag to compiler. Without this gemmlowp will use slow reference code.
-  # These optimizations are not enabled on MSVC so excluding it.
-  message("enabling optimizations for gemmlowp")
-  set_source_files_properties("${ONNXRUNTIME_ROOT}/core/util/gemmlowp_common.cc" PROPERTIES COMPILE_FLAGS "-msse4.1")
-endif()
-
 set(gemmlowp_src ${PROJECT_SOURCE_DIR}/external/gemmlowp)
 
 add_library(onnxruntime_util ${onnxruntime_util_srcs})
 if (MSVC AND NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
    #TODO: fix the warnings, they are dangerous
-   target_compile_options(onnxruntime_util PRIVATE "/wd4244")   
+   target_compile_options(onnxruntime_util PRIVATE "/wd4244")
 endif()
 target_include_directories(onnxruntime_util PRIVATE ${ONNXRUNTIME_ROOT} ${MKLML_INCLUDE_DIR} ${gemmlowp_src} PUBLIC ${eigen_INCLUDE_DIRS})
 onnxruntime_add_include_to_target(onnxruntime_util onnxruntime_common onnxruntime_framework onnx onnx_proto protobuf::libprotobuf)

--- a/onnxruntime/core/providers/cpu/math/quantize_linear_matmul.h
+++ b/onnxruntime/core/providers/cpu/math/quantize_linear_matmul.h
@@ -3,10 +3,7 @@
 
 #pragma once
 
-#include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/util/math_cpuonly.h"
-#include "core/util/gemmlowp_common.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/util/gemmlowp_common.cc
+++ b/onnxruntime/core/util/gemmlowp_common.cc
@@ -6,6 +6,40 @@
 
 namespace onnxruntime {
 
+typedef gemmlowp::VectorMap<const std::int32_t, gemmlowp::VectorShape::Col> ColVectorMap;
+
+inline std::tuple<gemmlowp::OutputStageBiasAddition<ColVectorMap>,
+                  gemmlowp::OutputStageQuantizeDownInt32ByFixedPoint,
+                  gemmlowp::OutputStageSaturatingCastToUint8>
+MakeOutputPipelineWithBias(const int32_t* bias,
+                           int rows,
+                           std::int32_t result_offset,
+                           std::int32_t result_mult_int,
+                           std::int32_t result_shift) {
+  ColVectorMap bias_vector(bias, rows);
+  gemmlowp::OutputStageBiasAddition<ColVectorMap> bias_addition_stage;
+  bias_addition_stage.bias_vector = bias_vector;
+  gemmlowp::OutputStageQuantizeDownInt32ByFixedPoint quantize_down_stage;
+  quantize_down_stage.result_offset_after_shift = result_offset;
+  quantize_down_stage.result_fixedpoint_multiplier = result_mult_int;
+  quantize_down_stage.result_shift = result_shift;
+  gemmlowp::OutputStageSaturatingCastToUint8 saturating_cast_stage;
+  return std::make_tuple(bias_addition_stage, quantize_down_stage, saturating_cast_stage);
+}
+
+inline std::tuple<gemmlowp::OutputStageQuantizeDownInt32ByFixedPoint,
+                  gemmlowp::OutputStageSaturatingCastToUint8>
+MakeOutputPipelineWithOutBias(std::int32_t result_offset,
+                              std::int32_t result_mult_int,
+                              std::int32_t result_shift) {
+  gemmlowp::OutputStageQuantizeDownInt32ByFixedPoint quantize_down_stage;
+  quantize_down_stage.result_offset_after_shift = result_offset;
+  quantize_down_stage.result_fixedpoint_multiplier = result_mult_int;
+  quantize_down_stage.result_shift = result_shift;
+  gemmlowp::OutputStageSaturatingCastToUint8 saturating_cast_stage;
+  return std::make_tuple(quantize_down_stage, saturating_cast_stage);
+}
+
 void GemmlowpMultiplyu8u8_u8(const uint8_t* lhs_data, const uint8_t* rhs_data, uint8_t* result_data,
                         const int lhs_offset, const int rhs_offset, const int result_offset,
                         int m, int n, int k, int32_t int_multiplier, int32_t right_shift, const int32_t* bias) {
@@ -44,6 +78,6 @@ void GemmlowpMultiplyu8u8_s32(const uint8_t* lhs_data, const uint8_t* rhs_data, 
 
   gemmlowp::GemmWithOutputPipeline<std::uint8_t, std::int32_t, gemmlowp::DefaultL8R8BitDepthParams>(
       &gemm_context, lhs, rhs, &result, -lhs_offset, -rhs_offset, empty_pipeline);
-
 }
+
 }

--- a/onnxruntime/core/util/gemmlowp_common.h
+++ b/onnxruntime/core/util/gemmlowp_common.h
@@ -28,40 +28,6 @@ void inline QuantizeMultiplier(float fp_multiplier, std::int32_t* integer_multip
   *right_shift = shift;
 }
 
-typedef gemmlowp::VectorMap<const std::int32_t, gemmlowp::VectorShape::Col> ColVectorMap;
-
-inline std::tuple<gemmlowp::OutputStageBiasAddition<ColVectorMap>,
-                  gemmlowp::OutputStageQuantizeDownInt32ByFixedPoint,
-                  gemmlowp::OutputStageSaturatingCastToUint8>
-MakeOutputPipelineWithBias(const int32_t* bias,
-                           int rows,
-                           std::int32_t result_offset,
-                           std::int32_t result_mult_int,
-                           std::int32_t result_shift) {
-  ColVectorMap bias_vector(bias, rows);
-  gemmlowp::OutputStageBiasAddition<ColVectorMap> bias_addition_stage;
-  bias_addition_stage.bias_vector = bias_vector;
-  gemmlowp::OutputStageQuantizeDownInt32ByFixedPoint quantize_down_stage;
-  quantize_down_stage.result_offset_after_shift = result_offset;
-  quantize_down_stage.result_fixedpoint_multiplier = result_mult_int;
-  quantize_down_stage.result_shift = result_shift;
-  gemmlowp::OutputStageSaturatingCastToUint8 saturating_cast_stage;
-  return std::make_tuple(bias_addition_stage, quantize_down_stage, saturating_cast_stage);
-}
-
-inline std::tuple<gemmlowp::OutputStageQuantizeDownInt32ByFixedPoint,
-                  gemmlowp::OutputStageSaturatingCastToUint8>
-MakeOutputPipelineWithOutBias(std::int32_t result_offset,
-                              std::int32_t result_mult_int,
-                              std::int32_t result_shift) {
-  gemmlowp::OutputStageQuantizeDownInt32ByFixedPoint quantize_down_stage;
-  quantize_down_stage.result_offset_after_shift = result_offset;
-  quantize_down_stage.result_fixedpoint_multiplier = result_mult_int;
-  quantize_down_stage.result_shift = result_shift;
-  gemmlowp::OutputStageSaturatingCastToUint8 saturating_cast_stage;
-  return std::make_tuple(quantize_down_stage, saturating_cast_stage);
-}
-
 void GemmlowpMultiplyu8u8_u8(const uint8_t* lhs_data, const uint8_t* rhs_data, uint8_t* result_data,
                         const int lhs_offset, const int rhs_offset, const int result_offset,
                         int m, int n, int k, int32_t int_multiplier, int32_t right_shift, const int32_t* bias = nullptr);


### PR DESCRIPTION
**Description**: The equivalent of PR#3196 but done for QLinearMatMul. Use MLAS to do a u8u8=s32 GEMM and then requantize this intermediate buffer.

**Motivation and Context**
The existing implementation of QLinearMatMul was using gemmlowp without threading and was restricted to SSE4.1. This changes the kernel to instead use MLAS for threading and scalable instruction set.

The requantization is changed from the gemmlowp fixed point strategy to use FP32 instructions, which is simpler on x86/x64. This makes the results not bit identical to the old version: for results near y.499xx, the gemmlowp version would round up to the next integer. The new version rounds this down instead.

This also removes the special SSE 4.1 flag used to compiler gemmlowp for x86/x64 as this code is no longer used on these platforms.