### PR TITLE
Fix warnings in nuphar

### DIFF
--- a/onnxruntime/core/providers/nuphar/partition/graph_partitioner.cc
+++ b/onnxruntime/core/providers/nuphar/partition/graph_partitioner.cc
@@ -49,7 +49,7 @@ bool GraphPartitioner::IsNodeSupported(const Node& node) const {
           }
         }
       });
-      return std::move(symbolic_dimensions);
+      return symbolic_dimensions;
     };
     // if there are any output symbols not in input symbols, fallback to CPU
     auto input_sym = get_symbolic_dimensions(node, true);

--- a/onnxruntime/core/providers/nuphar/partition/partitioner.h
+++ b/onnxruntime/core/providers/nuphar/partition/partitioner.h
@@ -87,7 +87,7 @@ class Partitioner {
       const onnxruntime::GraphViewer& graph,
       const NodeIndex& node_idx);
 
-  virtual void HandleSubgraph(const onnxruntime::GraphViewer& graph) {}
+  virtual void HandleSubgraph(const onnxruntime::GraphViewer&) {}
 
  protected:
   virtual void CreateNewPartition(const Node& node, const std::vector<NodeIndex>& immedidate_rejected_partitions);


### PR DESCRIPTION
**Description**: 
1. onnxruntime/core/providers/nuphar/partition/graph_partitioner.cc:52
 moving a local object in a return statement prevents copy elision [-Werror=pessimizing-move]
   52 |       return std::move(symbolic_dimensions);

2. onnxruntime/core/providers/nuphar/partition/partitioner.h 
unused parameter in HandleSubgraph

**Motivation and Context**
- Why is this change required? What problem does it solve?
Because we treat warnings as error, we should fix them.

- If it fixes an open issue, please link to the issue here.
