### PR TITLE
Add bias correction in Adam & Lamb for C++ frontend & python frontend

### DIFF
--- a/orttraining/orttraining/core/graph/gradient_schema_defs.cc
+++ b/orttraining/orttraining/core/graph/gradient_schema_defs.cc
@@ -108,6 +108,11 @@ OpSchema& RegisterLambOpSchema(OpSchema&& op_schema) {
           "Small scalar to avoid dividing by zero.",
           AttributeProto::FLOATS,
           std::vector<float>(1024, 1e-6f))
+      .Attr(
+          "do_bias_correction",
+          "Compute unbiased 1st and 2nd momentums.",
+          AttributeProto::INT,
+          static_cast<int64_t>(1))
       .TypeConstraint(
           "T1",
           {"tensor(float16)", "tensor(float)", "tensor(double)"},

--- a/orttraining/orttraining/core/graph/gradient_schema_defs.cc
+++ b/orttraining/orttraining/core/graph/gradient_schema_defs.cc
@@ -473,6 +473,11 @@ void RegisterGradientSchemas() {
           "Small scalar to avoid dividing by zero.",
           AttributeProto::FLOAT,
           1e-8f)
+      .Attr(
+          "do_bias_correction",
+          "Compute unbiased 1st and 2nd momentums.",
+          AttributeProto::INT,
+          static_cast<int64_t>(1))
       .TypeConstraint(
           "T1",
           {"tensor(float16)", "tensor(float)", "tensor(double)"},

--- a/orttraining/orttraining/core/graph/optimizer/adam_optimizer_builder.h
+++ b/orttraining/orttraining/core/graph/optimizer/adam_optimizer_builder.h
@@ -11,7 +11,7 @@ namespace training {
 class AdamOptimizerBuilder final : public OptimizerBuilder {
  public:
   AdamOptimizerBuilder() : OptimizerBuilder("AdamOptimizer",
-                                            {"alpha", "beta", "lambda", "epsilon"}) {}
+                                            {"alpha", "beta", "lambda", "epsilon", "do_bias_correction"}) {}
 
   virtual Status Build(
       const std::vector<ArgDef>& weight_argdefs,

--- a/orttraining/orttraining/core/graph/optimizer/lamb_optimizer_builder.cc
+++ b/orttraining/orttraining/core/graph/optimizer/lamb_optimizer_builder.cc
@@ -95,6 +95,7 @@ Status LambOptimizerBuilder::Build(
   float ratio_max = std::numeric_limits<float>::infinity();
   int64_t do_bias_correction = 0;
 
+  // Set global float attributes.
   {
     // Read the first weight's min and max ratios.
     const auto& attrs = opt_configs.front().attributes;
@@ -104,8 +105,13 @@ Status LambOptimizerBuilder::Build(
     auto ratio_max_iter = attrs.find("ratio_max");
     if (ratio_max_iter != attrs.end())
       ratio_max = ratio_max_iter->second;
-    auto do_bias_correction_iter = attrs.find("do_bias_correction");
-    if (do_bias_correction_iter != attrs.end())
+  }
+
+  // Set global int attributes.
+  {
+    const auto& int_attrs = opt_configs.front().int_attributes;
+    auto do_bias_correction_iter = int_attrs.find("do_bias_correction");
+    if (do_bias_correction_iter != int_attrs.end())
       do_bias_correction = do_bias_correction_iter->second;
   }
 
@@ -119,6 +125,7 @@ Status LambOptimizerBuilder::Build(
     const std::string& gradient_new_name = gradient_name + "_Lamb_out";
 
     const auto& attrs = opt_configs[i].attributes;
+    const auto& int_attrs = opt_configs[i].int_attributes;
 
     // Return either the input gradient/weight/fp16-weight or updated gradient/weight/fp16-weight.
     ArgDef output_gradient_argdef = gradient_argdefs[i];
@@ -164,8 +171,8 @@ Status LambOptimizerBuilder::Build(
         ORT_ENFORCE(ratio_max_iter->second == ratio_max);
       }
 
-      auto do_bias_correction_iter = attrs.find("do_bias_correction");
-      if (do_bias_correction_iter != attrs.end()) {
+      auto do_bias_correction_iter = int_attrs.find("do_bias_correction");
+      if (do_bias_correction_iter != int_attrs.end()) {
         // All weight tensors should have the same bias correction flag.
         ORT_ENFORCE(do_bias_correction_iter->second == do_bias_correction);
       }

--- a/orttraining/orttraining/core/graph/optimizer/lamb_optimizer_builder.cc
+++ b/orttraining/orttraining/core/graph/optimizer/lamb_optimizer_builder.cc
@@ -93,6 +93,7 @@ Status LambOptimizerBuilder::Build(
   std::vector<float> epsilon;
   float ratio_min = -std::numeric_limits<float>::infinity();
   float ratio_max = std::numeric_limits<float>::infinity();
+  int64_t do_bias_correction = 0;
 
   {
     // Read the first weight's min and max ratios.
@@ -103,6 +104,9 @@ Status LambOptimizerBuilder::Build(
     auto ratio_max_iter = attrs.find("ratio_max");
     if (ratio_max_iter != attrs.end())
       ratio_max = ratio_max_iter->second;
+    auto do_bias_correction_iter = attrs.find("do_bias_correction");
+    if (do_bias_correction_iter != attrs.end())
+      do_bias_correction = do_bias_correction_iter->second;
   }
 
   // Each iteration handles the associated inputs and outputs of a weight tensor.
@@ -158,6 +162,12 @@ Status LambOptimizerBuilder::Build(
       if (ratio_max_iter != attrs.end()) {
         // All weight tensors should have the same max ratio.
         ORT_ENFORCE(ratio_max_iter->second == ratio_max);
+      }
+
+      auto do_bias_correction_iter = attrs.find("do_bias_correction");
+      if (do_bias_correction_iter != attrs.end()) {
+        // All weight tensors should have the same bias correction flag.
+        ORT_ENFORCE(do_bias_correction_iter->second == do_bias_correction);
       }
 
       // Extract weight's type and shape information.
@@ -236,6 +246,7 @@ Status LambOptimizerBuilder::Build(
   attribute_protos.emplace_back(ONNX_NAMESPACE::MakeAttribute("epsilon", epsilon));
   attribute_protos.emplace_back(ONNX_NAMESPACE::MakeAttribute("ratio_min", ratio_min));
   attribute_protos.emplace_back(ONNX_NAMESPACE::MakeAttribute("ratio_max", ratio_max));
+  attribute_protos.emplace_back(ONNX_NAMESPACE::MakeAttribute("do_bias_correction", do_bias_correction));
 
   graph_defs.AddNodeDefs({NodeDef(OpType(),
                                   input_argdefs,

--- a/orttraining/orttraining/core/graph/optimizer/lamb_optimizer_builder.h
+++ b/orttraining/orttraining/core/graph/optimizer/lamb_optimizer_builder.h
@@ -17,7 +17,8 @@ class LambOptimizerBuilder final : public OptimizerBuilder {
                       "lambda",
                       "epsilon",
                       "ratio_min",
-                      "ratio_max"}) {}
+                      "ratio_max",
+                      "do_bias_correction"}) {}
 
   virtual Status Build(
       const std::vector<ArgDef>& weight_argdefs,

--- a/orttraining/orttraining/core/graph/optimizer_builder.h
+++ b/orttraining/orttraining/core/graph/optimizer_builder.h
@@ -43,7 +43,10 @@ class OptimizerBuilder {
  public:
   OptimizerBuilder(const std::string& name, const std::vector<std::string>& attribute_names = {})
       : name_(name),
-        attr_names_(attribute_names) {}
+        attr_names_(attribute_names) {
+
+
+        }
 
   virtual ~OptimizerBuilder() {}
 
@@ -133,8 +136,13 @@ class OptimizerBuilder {
   std::vector<ONNX_NAMESPACE::AttributeProto> BuildAttributeProto(const OptimizerNodeConfig& opt_config) const {
     std::vector<ONNX_NAMESPACE::AttributeProto> attribute_protos;
     for (auto attr_name : attr_names_) {
+      // Search dictionary of float attributes.
       if (opt_config.attributes.count(attr_name)) {
         attribute_protos.push_back(ONNX_NAMESPACE::MakeAttribute(attr_name, opt_config.attributes.at(attr_name)));
+      }
+      // Search dictionary of int attributes.
+      if (opt_config.int_attributes.count(attr_name)) {
+        attribute_protos.push_back(ONNX_NAMESPACE::MakeAttribute(attr_name, opt_config.int_attributes.at(attr_name)));
       }
     }
     return attribute_protos;

--- a/orttraining/orttraining/core/graph/optimizer_builder.h
+++ b/orttraining/orttraining/core/graph/optimizer_builder.h
@@ -43,10 +43,7 @@ class OptimizerBuilder {
  public:
   OptimizerBuilder(const std::string& name, const std::vector<std::string>& attribute_names = {})
       : name_(name),
-        attr_names_(attribute_names) {
-
-
-        }
+        attr_names_(attribute_names) {}
 
   virtual ~OptimizerBuilder() {}
 

--- a/orttraining/orttraining/core/graph/optimizer_config.h
+++ b/orttraining/orttraining/core/graph/optimizer_config.h
@@ -25,6 +25,7 @@ struct OptimizerNodeConfig {
   const NodeArg* fp16_weight_arg{};
   std::string lr_feed_name{};
   std::unordered_map<std::string, float> attributes{};
+  std::unordered_map<std::string, int64_t> int_attributes{};
   std::string loss_scale_input_name{};
   bool use_fp16_moments{false};
   bool update_weight{true};  // indicates whether Optimizer should do weight update, or output new gradient

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -50,11 +50,19 @@ Status SetupOptimizerParams(
     OptimizerNodeConfig opt_node_config{};
     opt_node_config.name = optimizer_config.name;
     opt_node_config.lr_feed_name = optimizer_config.learning_rate_input_name;
+
     try {
       opt_node_config.attributes = optimizer_config.weight_attributes_generator(weight_name);
     } catch (const std::exception& ex) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, ex.what());
     }
+
+    try {
+      opt_node_config.int_attributes = optimizer_config.weight_int_attributes_generator(weight_name);
+    } catch (const std::exception& ex) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, ex.what());
+    }
+
     opt_node_config.loss_scale_input_name = loss_scale_input_name;
     opt_node_config.use_fp16_moments = optimizer_config.use_fp16_moments;
 

--- a/orttraining/orttraining/core/session/training_session.h
+++ b/orttraining/orttraining/core/session/training_session.h
@@ -119,6 +119,8 @@ class TrainingSession : public InferenceSession {
       // The per-weight attribute map generator.
       // It should accept a weight name and return the appropriate attribute map.
       std::function<std::unordered_map<std::string, float>(const std::string&)> weight_attributes_generator{};
+      std::function<std::unordered_map<std::string, int64_t>(const std::string&)> weight_int_attributes_generator{};
+
       // Whether to use FP16 moments.
       bool use_fp16_moments{};
       // Whether to use FP16 for the all reduce.

--- a/orttraining/orttraining/models/bert/main.cc
+++ b/orttraining/orttraining/models/bert/main.cc
@@ -136,6 +136,11 @@ Status ParseArguments(int argc, char* argv[], BertParameters& params, OrtParamet
       ("beta", "Adam/Lamb beta parameter", cxxopts::value<float>()->default_value("0.999"))
       ("lambda", "Adam/Lamb lambda parameter", cxxopts::value<float>()->default_value("0.01"))
       ("epsilon", "Adam/Lamb epsilon parameter", cxxopts::value<float>()->default_value("1e-6"))
+      ("do_bias_correction",
+        "A flag controls if Adam/Lamb should do bias correction. "
+        "Default is 0, which means no bias correction. "
+        "Use 1 to enable bias correction.",
+        cxxopts::value<int64_t>()->default_value("0"))
       ("ratio_min", "Lamb min ratio parameter", cxxopts::value<float>()->default_value("0.05"))
       ("ratio_max", "Lamb max ratio parameter", cxxopts::value<float>()->default_value("5.0"))
       ("cuda_mem_limit_in_gb", "Max cuda memory ort can use, in GB", cxxopts::value<float>()->default_value("-1.0"))
@@ -312,10 +317,13 @@ Status ParseArguments(int argc, char* argv[], BertParameters& params, OrtParamet
     float beta = flags["beta"].as<float>();
     float lambda = flags["lambda"].as<float>();
     float epsilon = flags["epsilon"].as<float>();
+    int64_t do_bias_correction = flags["do_bias_correction"].as<int64_t>();
     float ratio_min = flags["ratio_min"].as<float>();
     float ratio_max = flags["ratio_max"].as<float>();
     ORT_RETURN_IF_NOT(alpha >= 0.f && alpha <= 1.f, "alpha is not in valid range [0.0, 1.0]");
     ORT_RETURN_IF_NOT(beta >= 0.f && beta <= 1.f, "alpha is not in valid range [0.0, 1.0]");
+    ORT_RETURN_IF_NOT(do_bias_correction == 0 || do_bias_correction == 1, "Bias correction can be either 0 or 1.");
+    ORT_RETURN_IF_NOT(epsilon >= 0.f, "epsilon should be non-negative.");
     ORT_RETURN_IF_NOT(epsilon >= 0.f, "epsilon should be non-negative.");
     ORT_RETURN_IF_NOT(ratio_min >= 0.f, "ratio_min should be non-negative.");
     ORT_RETURN_IF_NOT(ratio_max >= 0.f, "ratio_max should be non-negative.");
@@ -334,7 +342,8 @@ Status ParseArguments(int argc, char* argv[], BertParameters& params, OrtParamet
           {"lambda", zero_lambda ? 0.f : lambda},
           {"epsilon", epsilon},
           {"ratio_min", ratio_min},
-          {"ratio_max", ratio_max}
+          {"ratio_max", ratio_max},
+          {"do_bias_correction", do_bias_correction}
       };
     };
 

--- a/orttraining/orttraining/models/bert/main.cc
+++ b/orttraining/orttraining/models/bert/main.cc
@@ -138,9 +138,9 @@ Status ParseArguments(int argc, char* argv[], BertParameters& params, OrtParamet
       ("epsilon", "Adam/Lamb epsilon parameter", cxxopts::value<float>()->default_value("1e-6"))
       ("do_bias_correction",
         "A flag controls if Adam/Lamb should do bias correction. "
-        "Default is 0, which means no bias correction. "
-        "Use 1 to enable bias correction.",
-        cxxopts::value<int64_t>()->default_value("0"))
+        "Default is false, which means no bias correction. "
+        "Use true to enable bias correction.",
+        cxxopts::value<bool>()->default_value("false"))
       ("ratio_min", "Lamb min ratio parameter", cxxopts::value<float>()->default_value("0.05"))
       ("ratio_max", "Lamb max ratio parameter", cxxopts::value<float>()->default_value("5.0"))
       ("cuda_mem_limit_in_gb", "Max cuda memory ort can use, in GB", cxxopts::value<float>()->default_value("-1.0"))
@@ -317,12 +317,10 @@ Status ParseArguments(int argc, char* argv[], BertParameters& params, OrtParamet
     float beta = flags["beta"].as<float>();
     float lambda = flags["lambda"].as<float>();
     float epsilon = flags["epsilon"].as<float>();
-    int64_t do_bias_correction = flags["do_bias_correction"].as<int64_t>();
     float ratio_min = flags["ratio_min"].as<float>();
     float ratio_max = flags["ratio_max"].as<float>();
     ORT_RETURN_IF_NOT(alpha >= 0.f && alpha <= 1.f, "alpha is not in valid range [0.0, 1.0]");
     ORT_RETURN_IF_NOT(beta >= 0.f && beta <= 1.f, "alpha is not in valid range [0.0, 1.0]");
-    ORT_RETURN_IF_NOT(do_bias_correction == 0 || do_bias_correction == 1, "Bias correction can be either 0 or 1.");
     ORT_RETURN_IF_NOT(epsilon >= 0.f, "epsilon should be non-negative.");
     ORT_RETURN_IF_NOT(epsilon >= 0.f, "epsilon should be non-negative.");
     ORT_RETURN_IF_NOT(ratio_min >= 0.f, "ratio_min should be non-negative.");
@@ -330,6 +328,9 @@ Status ParseArguments(int argc, char* argv[], BertParameters& params, OrtParamet
     ORT_RETURN_IF_NOT(ratio_max >= ratio_min, "ratio_max should be greater than or equal to ratio_min.");
     std::vector<std::string> no_decay{"bias", "gamma", "beta", "LayerNorm"};
 
+    bool do_bias_correction = flags["do_bias_correction"].as<bool>();
+
+    // Optimizer's float attributes.
     params.optimizer_attributes = [=](const std::string& weight) {
       // Set lambda attribute to zero if we don't want decay on this weight.
       bool zero_lambda = std::any_of(no_decay.begin(), no_decay.end(), [&](const std::string& name) {
@@ -342,8 +343,14 @@ Status ParseArguments(int argc, char* argv[], BertParameters& params, OrtParamet
           {"lambda", zero_lambda ? 0.f : lambda},
           {"epsilon", epsilon},
           {"ratio_min", ratio_min},
-          {"ratio_max", ratio_max},
-          {"do_bias_correction", do_bias_correction}
+          {"ratio_max", ratio_max}
+      };
+    };
+
+    // Optimizer's int attributes.
+    params.optimizer_int_attributes = [=](const std::string& /*weight*/) {
+      return std::unordered_map<std::string, int64_t>{
+          {"do_bias_correction", do_bias_correction ? static_cast<int64_t>(1) : static_cast<int64_t>(0)}
       };
     };
 

--- a/orttraining/orttraining/models/runner/training_runner.cc
+++ b/orttraining/orttraining/models/runner/training_runner.cc
@@ -104,6 +104,7 @@ Status TrainingRunner::Initialize() {
     opt.name = params_.training_optimizer_name;
     opt.learning_rate_input_name = params_.lr_params.feed_name;
     opt.weight_attributes_generator = params_.optimizer_attributes;
+    opt.weight_int_attributes_generator = params_.optimizer_int_attributes;
     opt.use_fp16_moments = params_.use_fp16_moments;
     opt.do_all_reduce_in_fp16 = params_.allreduce_in_fp16;
     opt.use_nccl = params_.use_nccl;

--- a/orttraining/orttraining/models/runner/training_runner.h
+++ b/orttraining/orttraining/models/runner/training_runner.h
@@ -39,6 +39,8 @@ class TrainingRunner {
     std::string training_optimizer_name = "SGDOptimizer";
     std::function<std::unordered_map<std::string, float>(const std::string& weight)> optimizer_attributes =
         [](const std::string&) { return std::unordered_map<std::string, float>(); };
+    std::function<std::unordered_map<std::string, int64_t>(const std::string& weight)> optimizer_int_attributes =
+        [](const std::string&) { return std::unordered_map<std::string, int64_t>(); };
     LearningRateParameters lr_params;
     int gradient_accumulation_steps = 1;
 

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -431,8 +431,10 @@ def create_ort_training_session_with_optimizer(model, device, training_optimizer
             for k, v in attributes.items():
                 if isinstance(v, float):
                     optimizer_attributes_map[initializer.name][k] = v
-                else:
+                elif isinstance(v, int):
                     optimizer_int_attributes_map[initializer.name][k] = v
+                else:
+                    raise ValueError("Optimizer attributes must be either float or int.")
         else:
             optimizer_attributes_map[initializer.name] = {}
             optimizer_int_attributes_map[initializer.name] = {}

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -420,14 +420,22 @@ def create_ort_training_session_with_optimizer(model, device, training_optimizer
     # Have to work around by using a temporary weights_to_train.
     torch_params = {}
     optimizer_attributes_map = {}
+    optimizer_int_attributes_map = {}
     weights_to_train = set()
     for initializer in model.graph.initializer:
         weights_to_train.add(initializer.name)
         if map_optimizer_attributes is not None:
             attributes = map_optimizer_attributes(initializer.name)
-            optimizer_attributes_map[initializer.name] = attributes
+            optimizer_attributes_map[initializer.name] = {}
+            optimizer_int_attributes_map[initializer.name] = {}
+            for k, v in attributes.items():
+                if isinstance(v, float):
+                    optimizer_attributes_map[initializer.name][k] = v
+                else:
+                    optimizer_int_attributes_map[initializer.name][k] = v
         else:
             optimizer_attributes_map[initializer.name] = {}
+            optimizer_int_attributes_map[initializer.name] = {}
 
     if bind_parameters:
         for initializer in model.graph.initializer:
@@ -443,6 +451,7 @@ def create_ort_training_session_with_optimizer(model, device, training_optimizer
     ort_parameters.training_optimizer_name = training_optimizer_name
     ort_parameters.lr_params_feed_name = lr_params_feed_name
     ort_parameters.optimizer_attributes_map = optimizer_attributes_map
+    ort_parameters.optimizer_int_attributes_map = optimizer_int_attributes_map
 
     session = ort.TrainingSession(model.SerializeToString(), ort_parameters)
     train_io_binding = session.io_binding()

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -38,6 +38,7 @@ struct TrainingParameters {
   std::string scaled_loss_output_name;
   std::string lr_params_feed_name = "Learning_Rate";
   std::unordered_map<std::string, std::unordered_map<std::string, float>> optimizer_attributes_map;
+  std::unordered_map<std::string, std::unordered_map<std::string, int64_t>> optimizer_int_attributes_map;
   bool use_fp16_moments = false;
 
   bool use_mixed_precision = false;
@@ -125,6 +126,13 @@ void ConfigureSessionForTraining(
           "Failed to find attribute map for weight ", weight_name);
       return it->second;
     };
+    opt.weight_int_attributes_generator = [&parameters](const std::string& weight_name) {
+      const auto it = parameters.optimizer_int_attributes_map.find(weight_name);
+      ORT_ENFORCE(
+          it != parameters.optimizer_int_attributes_map.end(),
+          "Failed to find int attribute map for weight ", weight_name);
+      return it->second;
+    };
     opt.use_fp16_moments = parameters.use_fp16_moments;
     opt.do_all_reduce_in_fp16 = true;
     // TODO: this mapping is temporary.
@@ -163,6 +171,7 @@ void addObjectMethodsForTraining(py::module& m) {
       .def_readwrite("training_optimizer_name", &TrainingParameters::training_optimizer_name)
       .def_readwrite("lr_params_feed_name", &TrainingParameters::lr_params_feed_name)
       .def_readwrite("optimizer_attributes_map", &TrainingParameters::optimizer_attributes_map)
+      .def_readwrite("optimizer_int_attributes_map", &TrainingParameters::optimizer_int_attributes_map)
       .def_readwrite("use_fp16_moments", &TrainingParameters::use_fp16_moments)
       .def_readwrite("use_mixed_precision", &TrainingParameters::use_mixed_precision)
       .def_readwrite("allreduce_post_accumulation", &TrainingParameters::allreduce_post_accumulation)

--- a/orttraining/orttraining/test/gradient/gradient_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/gradient_ops_test.cc
@@ -1196,6 +1196,8 @@ TEST(OptimizerTest, AdamOptimizerTest) {
   test.AddOutput<float>("Moment_2_Out", {3}, data.m2_new);
   test.AddOutput<float>("W_Out", {3}, data.w_new);
 
+  test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
+
   test.Run();
 }
 
@@ -1217,8 +1219,32 @@ TEST(OptimizerTest, AdamOptimizerTest_Gradient) {
   test.AddMissingOptionalOutput<float>();
   test.AddOutput<float>("G_Out", {3}, data.g_new);
 
+  test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
+
   test.Run();
 }
+
+TEST(OptimizerTest, AdamBiasCorrection) {
+  OpTester test("AdamOptimizer", 9, onnxruntime::kOnnxDomain);
+  AdamOptimizerInputOutput data;
+
+  test.AddInput<float>("ETA", {}, {1.f});
+  test.AddInput<int64_t>("Update_Count", {}, {1});
+  test.AddInput<float>("W", {3}, {-0.4634f,  0.3584f, -0.2121f});
+  test.AddInput<float>("G", {3}, {0.4171f, 0.9485f, 1.2289f});
+  test.AddInput<float>("Moment_1", {3}, {0.f, 0.f, 0.f});
+  test.AddInput<float>("Moment_2", {3}, {0.f, 0.f, 0.f});
+
+  test.AddOutput<int64_t>("Update_Count_Out", {}, {2});
+  test.AddOutput<float>("Moment_1_Out", {3}, {0.0417f, 0.0949f, 0.1229f});
+  test.AddOutput<float>("Moment_2_Out", {3}, {1.7400e-04f, 8.9966e-04f, 1.5102e-03f});
+  test.AddOutput<float>("W_Out", {3}, {-1.4634f, -0.6416f, -1.2121f});
+
+  test.AddAttribute("do_bias_correction", static_cast<int64_t>(1));
+
+  test.Run();
+}
+
 
 TEST(GradientCheckerTest, GatherGrad) {
   float max_error;
@@ -1490,6 +1516,8 @@ TEST(OptimizerTest, AdamOptimizerMixPrecisionTest) {
   test.AddOutput<MLFloat16>("Moment_2_Out", {3}, data.m2_new_half);
   test.AddOutput<float>("W_Out", {3}, data.w_new);
 
+  test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
+
   test.Run();
 }
 
@@ -1512,6 +1540,8 @@ TEST(OptimizerTest, AdamOptimizerMixPrecision_FP16Weight_Test) {
   test.AddOutput<float>("W_Out", {3}, data.w_new);
   test.AddMissingOptionalOutput<MLFloat16>();
   test.AddOutput<MLFloat16>("FP16_W_Out", {3}, data.w_new_half);
+
+  test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
 
   test.Run();
 }
@@ -1540,6 +1570,8 @@ TEST(OptimizerTest, AdamOptimizerMixPrecision_FP16Weight_SkipUpdate_Test) {
   test.AddMissingOptionalOutput<MLFloat16>();
   test.AddOutput<MLFloat16>("FP16_W_Out", {3}, data.w_half);
 
+  test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
+
   test.Run();
 }
 
@@ -1559,6 +1591,8 @@ TEST(OptimizerTest, AdamOptimizerMixPrecisionTestFloatEta) {
   test.AddOutput<MLFloat16>("Moment_1_Out", {3}, data.m1_new_half);
   test.AddOutput<MLFloat16>("Moment_2_Out", {3}, data.m2_new_half);
   test.AddOutput<float>("W_Out", {3}, data.w_new);
+
+  test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
 
   test.Run();
 }
@@ -1580,6 +1614,8 @@ TEST(OptimizerTest, AdamOptimizerMixPrecisionTest_Gradient) {
   test.AddOutput<MLFloat16>("Moment_2_Out", {3}, data.m2_new_half);
   test.AddMissingOptionalOutput<float>();
   test.AddOutput<MLFloat16>("G_Out", {3}, data.g_new_half);
+
+  test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
 
   test.Run();
 }

--- a/orttraining/orttraining/training_ops/cpu/optimizer/common.h
+++ b/orttraining/orttraining/training_ops/cpu/optimizer/common.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cmath>
+
+namespace onnxruntime {
+namespace contrib {
+
+template <typename TS, typename TC>
+TC compute_bias_correction_coefficient(
+  const TC momentum_update_coefficient,
+  const TS step) {
+  if (step > 0) {
+    return TC(1.0 - std::pow(static_cast<double>(momentum_update_coefficient), static_cast<double>(step)));
+  } else {
+    return TC(1.f);
+  }
+}
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/orttraining/orttraining/training_ops/cpu/optimizer/optimizers.cc
+++ b/orttraining/orttraining/training_ops/cpu/optimizer/optimizers.cc
@@ -65,9 +65,14 @@ Status AdamOptimizer<T>::Compute(OpKernelContext* ctx) const {
   // Update exponentially-averaged historical squared gradient
   MakeEigenArrayMap<T>(NM2) = beta_ * MakeEigenArrayMap<T>(M2) + ((1 - beta_) * MakeEigenArrayMap<T>(G) * MakeEigenArrayMap<T>(G));
 
+  const float alpha_correction = do_bias_correction_ != 0 ?
+    compute_bias_correction_coefficient(alpha_, step) : 1.f;
+  const float beta_correction = do_bias_correction_ != 0 ?
+    compute_bias_correction_coefficient(beta_, step) : 1.f;
+
   // Compute weight update.
-  const auto& denom = MakeEigenArrayMap<T>(NM2).sqrt() + epsilon_;
-  const auto& update = (MakeEigenArrayMap<T>(NM1) / denom) + (lambda_ * MakeEigenArrayMap<T>(W));
+  const auto& denom = (MakeEigenArrayMap<T>(NM2) / beta_correction).sqrt() + epsilon_;
+  const auto& update = ( (MakeEigenArrayMap<T>(NM1) / alpha_correction) / denom) + (lambda_ * MakeEigenArrayMap<T>(W));
   const auto& delta = -eta * update;
 
   // Weight, gradient, and step update.

--- a/orttraining/orttraining/training_ops/cpu/optimizer/optimizers.cc
+++ b/orttraining/orttraining/training_ops/cpu/optimizer/optimizers.cc
@@ -65,9 +65,9 @@ Status AdamOptimizer<T>::Compute(OpKernelContext* ctx) const {
   // Update exponentially-averaged historical squared gradient
   MakeEigenArrayMap<T>(NM2) = beta_ * MakeEigenArrayMap<T>(M2) + ((1 - beta_) * MakeEigenArrayMap<T>(G) * MakeEigenArrayMap<T>(G));
 
-  const float alpha_correction = do_bias_correction_ != 0 ?
+  const float alpha_correction = do_bias_correction_ ?
     compute_bias_correction_coefficient(alpha_, step) : 1.f;
-  const float beta_correction = do_bias_correction_ != 0 ?
+  const float beta_correction = do_bias_correction_ ?
     compute_bias_correction_coefficient(beta_, step) : 1.f;
 
   // Compute weight update.

--- a/orttraining/orttraining/training_ops/cpu/optimizer/optimizers.h
+++ b/orttraining/orttraining/training_ops/cpu/optimizer/optimizers.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "common.h"
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
 
@@ -25,6 +26,12 @@ class AdamOptimizer final : public OpKernel {
     info.GetAttrOrDefault("beta", &beta_, 0.999f);
     info.GetAttrOrDefault("lambda", &lambda_, 0.0f);
     info.GetAttrOrDefault("epsilon", &epsilon_, 1e-8f);
+    info.GetAttrOrDefault("do_bias_correction", &do_bias_correction_, static_cast<int64_t>(1));
+    ORT_ENFORCE(alpha_ >= 0);
+    ORT_ENFORCE(beta_ >= 0);
+    ORT_ENFORCE(lambda_ >= 0);
+    ORT_ENFORCE(epsilon_ >= 0);
+    ORT_ENFORCE(do_bias_correction_ == 0 || do_bias_correction_ == 1);
   }
 
   Status Compute(OpKernelContext* context) const override;
@@ -34,6 +41,7 @@ class AdamOptimizer final : public OpKernel {
   float beta_;
   float lambda_;
   float epsilon_;
+  int64_t do_bias_correction_;
 };
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/orttraining/orttraining/training_ops/cpu/optimizer/optimizers.h
+++ b/orttraining/orttraining/training_ops/cpu/optimizer/optimizers.h
@@ -26,12 +26,15 @@ class AdamOptimizer final : public OpKernel {
     info.GetAttrOrDefault("beta", &beta_, 0.999f);
     info.GetAttrOrDefault("lambda", &lambda_, 0.0f);
     info.GetAttrOrDefault("epsilon", &epsilon_, 1e-8f);
-    info.GetAttrOrDefault("do_bias_correction", &do_bias_correction_, static_cast<int64_t>(1));
     ORT_ENFORCE(alpha_ >= 0);
     ORT_ENFORCE(beta_ >= 0);
     ORT_ENFORCE(lambda_ >= 0);
     ORT_ENFORCE(epsilon_ >= 0);
-    ORT_ENFORCE(do_bias_correction_ == 0 || do_bias_correction_ == 1);
+
+    int64_t tmp_flag = static_cast<int64_t>(0);
+    ORT_ENFORCE(info.GetAttr<int64_t>("do_bias_correction", &tmp_flag).IsOK(), "Missing/Invalid do_bias_correction");
+    ORT_ENFORCE(tmp_flag == 0 || tmp_flag == 1, "do_bias_correction must be either 0 or 1.");
+    do_bias_correction_ = tmp_flag != 0 ? true : false;
   }
 
   Status Compute(OpKernelContext* context) const override;
@@ -41,7 +44,7 @@ class AdamOptimizer final : public OpKernel {
   float beta_;
   float lambda_;
   float epsilon_;
-  int64_t do_bias_correction_;
+  bool do_bias_correction_;
 };
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/orttraining/orttraining/training_ops/cuda/optimizer/adam.cc
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/adam.cc
@@ -121,6 +121,7 @@ Status AdamOptimizer<T1, T2, T3, T4, T_GRAD, T_GRAD_NORM>::ComputeInternal(OpKer
       return Status::OK();
     }
   }
+
   AdamOptimizerImpl(
       reinterpret_cast<const CudaT1*>(ETA.template Data<T1>()),
       *S_in,
@@ -134,6 +135,7 @@ Status AdamOptimizer<T1, T2, T3, T4, T_GRAD, T_GRAD_NORM>::ComputeInternal(OpKer
       ToCudaType<T4>::FromFloat(beta_),
       ToCudaType<T4>::FromFloat(lambda_),
       ToCudaType<T4>::FromFloat(epsilon_),
+      do_bias_correction_,
       reinterpret_cast<CudaT4*>(NM1.template MutableData<T4>()),
       reinterpret_cast<CudaT4*>(NM2.template MutableData<T4>()),
       NW != nullptr ? reinterpret_cast<CudaT3*>(NW->template MutableData<T3>()) : nullptr,

--- a/orttraining/orttraining/training_ops/cuda/optimizer/adam.cu
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/adam.cu
@@ -5,6 +5,7 @@
 #include "core/providers/cuda/cu_inc/common.cuh"
 #include "orttraining/training_ops/cuda/optimizer/common.cuh"
 #include "adam.h"
+#include "common.h"
 
 namespace onnxruntime {
 namespace cuda {
@@ -21,6 +22,8 @@ __global__ void _AdamOptimizer(
     const T4 beta,
     const T4 lambda,
     const T4 epsilon,
+    const T4 alpha_correction,
+    const T4 beta_correction,
     T4* moment_1_out,
     T4* moment_2_out,
     T3* weights_out,
@@ -37,13 +40,15 @@ __global__ void _AdamOptimizer(
 
   // Compute exponentially-averaged historical gradient.
   const T4 m1o = alpha * moment_1[id] + (one - alpha) * g;
+  const T4 m1o_corrected = m1o / alpha_correction;
 
   // Compute exponentially-averaged historical squared gradient.
   const T4 m2o = beta * moment_2[id] + (one - beta) * g * g;
+  const T4 m2o_corrected = m2o / beta_correction;
 
   // Compute weight update.
-  const T4 denom = _Sqrt(m2o) + epsilon;
-  const T4 update = (m1o / denom) + (lambda * T4(weights[id]));
+  const T4 denom = _Sqrt(m2o_corrected) + epsilon;
+  const T4 update = (m1o_corrected / denom) + (lambda * T4(weights[id]));
   const T4 delta = -T4(*eta) * update;
 
   // Compute the new gradient.
@@ -67,7 +72,7 @@ __global__ void _AdamOptimizer(
 template <typename T1, typename T2, typename T3, typename T4, typename T_GRAD, typename T_GRAD_NORM>
 void AdamOptimizerImpl(
     const T1* eta,
-    const T2 /*update_count*/,
+    const T2 update_count,
     const T3* weights,
     const T_GRAD* grads,
     const T4* moment_1,
@@ -86,6 +91,8 @@ void AdamOptimizerImpl(
     size_t count) {
   int blocksPerGrid = (int)(ceil(static_cast<float>(count) / GridDim::maxThreadsPerBlock));
   CUDA_LONG N = static_cast<CUDA_LONG>(count);
+  T4 alpha_correction = compute_bias_correction_coefficient(alpha, update_count);
+  T4 beta_correction = compute_bias_correction_coefficient(beta, update_count);
   _AdamOptimizer<T1, T3, T4, T_GRAD, T_GRAD_NORM><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(
       eta,
       weights,
@@ -98,6 +105,8 @@ void AdamOptimizerImpl(
       beta,
       lambda,
       epsilon,
+      alpha_correction,
+      beta_correction,
       moment_1_out,
       moment_2_out,
       weights_out,

--- a/orttraining/orttraining/training_ops/cuda/optimizer/adam.cu
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/adam.cu
@@ -79,10 +79,11 @@ void AdamOptimizerImpl(
     const T4* moment_2,
     const T3* loss_scale,
     const T_GRAD_NORM* grad_norm,
-    T4 alpha,
-    T4 beta,
-    T4 lambda,
-    T4 epsilon,
+    const T4 alpha,
+    const T4 beta,
+    const T4 lambda,
+    const T4 epsilon,
+    const bool do_bias_correction,
     T4* moment_1_out,
     T4* moment_2_out,
     T3* weights_out,
@@ -91,8 +92,9 @@ void AdamOptimizerImpl(
     size_t count) {
   int blocksPerGrid = (int)(ceil(static_cast<float>(count) / GridDim::maxThreadsPerBlock));
   CUDA_LONG N = static_cast<CUDA_LONG>(count);
-  T4 alpha_correction = compute_bias_correction_coefficient(alpha, update_count);
-  T4 beta_correction = compute_bias_correction_coefficient(beta, update_count);
+  // If bias correction coefficients are set to 1s, it's equivalent to disabling bias correction. 
+  const T4 alpha_correction = do_bias_correction ? onnxruntime::contrib::compute_bias_correction_coefficient(alpha, update_count) : T4(1.f);
+  const T4 beta_correction = do_bias_correction ? onnxruntime::contrib::compute_bias_correction_coefficient(beta, update_count) : T4(1.f);
   _AdamOptimizer<T1, T3, T4, T_GRAD, T_GRAD_NORM><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(
       eta,
       weights,
@@ -125,10 +127,11 @@ void AdamOptimizerImpl(
       const T4* moment_2,                                                  \
       const T3* loss_scale,                                                \
       const T_GRAD_NORM* grad_norm,                                        \
-      T4 alpha,                                                            \
-      T4 beta,                                                             \
-      T4 lambda,                                                           \
-      T4 epsilon,                                                          \
+      const T4 alpha,                                                      \
+      const T4 beta,                                                       \
+      const T4 lambda,                                                     \
+      const T4 epsilon,                                                    \
+      const bool do_bias_correction,                                       \
       T4* moment_1_out,                                                    \
       T4* moment_2_out,                                                    \
       T3* weights_out,                                                     \

--- a/orttraining/orttraining/training_ops/cuda/optimizer/adam.cu
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/adam.cu
@@ -93,8 +93,10 @@ void AdamOptimizerImpl(
   int blocksPerGrid = (int)(ceil(static_cast<float>(count) / GridDim::maxThreadsPerBlock));
   CUDA_LONG N = static_cast<CUDA_LONG>(count);
   // If bias correction coefficients are set to 1s, it's equivalent to disabling bias correction. 
-  const T4 alpha_correction = do_bias_correction ? onnxruntime::contrib::compute_bias_correction_coefficient(alpha, update_count) : T4(1.f);
-  const T4 beta_correction = do_bias_correction ? onnxruntime::contrib::compute_bias_correction_coefficient(beta, update_count) : T4(1.f);
+  const T4 alpha_correction = do_bias_correction ? 
+    onnxruntime::contrib::compute_bias_correction_coefficient(alpha, update_count) : T4(1.f);
+  const T4 beta_correction = do_bias_correction ?
+    onnxruntime::contrib::compute_bias_correction_coefficient(beta, update_count) : T4(1.f);
   _AdamOptimizer<T1, T3, T4, T_GRAD, T_GRAD_NORM><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(
       eta,
       weights,

--- a/orttraining/orttraining/training_ops/cuda/optimizer/adam.h
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/adam.h
@@ -19,10 +19,11 @@ void AdamOptimizerImpl(
     const T4* moment_2,
     const T3* loss_scale,
     const T_GRAD_NORM* grad_norm,
-    T4 alpha,
-    T4 beta,
-    T4 lambda,
-    T4 epsilon,
+    const T4 alpha,
+    const T4 beta,
+    const T4 lambda,
+    const T4 epsilon,
+    const bool do_bias_correction,
     T4* moment_1_out,
     T4* moment_2_out,
     T3* weights_out,
@@ -38,6 +39,7 @@ class AdamOptimizer final : public CudaKernel {
     info.GetAttrOrDefault("beta", &beta_, 0.999f);
     info.GetAttrOrDefault("lambda", &lambda_, 0.0f);
     info.GetAttrOrDefault("epsilon", &epsilon_, 1e-8f);
+    info.GetAttrOrDefault("do_bias_correction", &do_bias_correction_, static_cast<int64_t>(1));
   }
 
   Status ComputeInternal(OpKernelContext* context) const override;
@@ -47,6 +49,7 @@ class AdamOptimizer final : public CudaKernel {
   float beta_;
   float lambda_;
   float epsilon_;
+  int64_t do_bias_correction_; 
 };
 
 }  // namespace cuda

--- a/orttraining/orttraining/training_ops/cuda/optimizer/adam.h
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/adam.h
@@ -39,7 +39,11 @@ class AdamOptimizer final : public CudaKernel {
     info.GetAttrOrDefault("beta", &beta_, 0.999f);
     info.GetAttrOrDefault("lambda", &lambda_, 0.0f);
     info.GetAttrOrDefault("epsilon", &epsilon_, 1e-8f);
-    ORT_ENFORCE(info.GetAttr<int64_t>("do_bias_correction", &do_bias_correction_).IsOK(), "Missing/Invalid do_bias_correction");
+
+    int64_t tmp_flag = static_cast<int64_t>(0);
+    ORT_ENFORCE(info.GetAttr<int64_t>("do_bias_correction", &tmp_flag).IsOK(), "Missing/Invalid do_bias_correction");
+    ORT_ENFORCE(tmp_flag == 0 || tmp_flag == 1, "do_bias_correction must be either 0 or 1.");
+    do_bias_correction_ = tmp_flag != 0 ? true : false;
   }
 
   Status ComputeInternal(OpKernelContext* context) const override;
@@ -49,7 +53,7 @@ class AdamOptimizer final : public CudaKernel {
   float beta_;
   float lambda_;
   float epsilon_;
-  int64_t do_bias_correction_; 
+  bool do_bias_correction_; 
 };
 
 }  // namespace cuda

--- a/orttraining/orttraining/training_ops/cuda/optimizer/adam.h
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/adam.h
@@ -39,7 +39,7 @@ class AdamOptimizer final : public CudaKernel {
     info.GetAttrOrDefault("beta", &beta_, 0.999f);
     info.GetAttrOrDefault("lambda", &lambda_, 0.0f);
     info.GetAttrOrDefault("epsilon", &epsilon_, 1e-8f);
-    info.GetAttrOrDefault("do_bias_correction", &do_bias_correction_, static_cast<int64_t>(1));
+    ORT_ENFORCE(info.GetAttr<int64_t>("do_bias_correction", &do_bias_correction_).IsOK(), "Missing/Invalid do_bias_correction");
   }
 
   Status ComputeInternal(OpKernelContext* context) const override;

--- a/orttraining/orttraining/training_ops/cuda/optimizer/common.h
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/common.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include "core/providers/cuda/cuda_common.h"
+#include "orttraining/training_ops/cpu/optimizer/common.h"
 
 namespace onnxruntime {
 namespace cuda {
@@ -15,17 +16,6 @@ Status CopyIfNotSameBuffer(const Tensor& source_tensor, Tensor& target_tensor) {
     CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(target, source, source_tensor.SizeInBytes(), cudaMemcpyDeviceToDevice));
   }
   return Status::OK();
-}
-
-template <typename TS, typename TC>
-TC compute_bias_correction_coefficient(
-  const TC momentum_update_coefficient,
-  const TS step) {
-  if (step > 0) {
-    return TC(1.0 - std::pow(static_cast<double>(momentum_update_coefficient), static_cast<double>(step)));
-  } else {
-    return TC(1.f);
-  }
 }
 
 }  // namespace cuda

--- a/orttraining/orttraining/training_ops/cuda/optimizer/common.h
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/common.h
@@ -17,5 +17,16 @@ Status CopyIfNotSameBuffer(const Tensor& source_tensor, Tensor& target_tensor) {
   return Status::OK();
 }
 
+template <typename TS, typename TC>
+TC compute_bias_correction_coefficient(
+  const TC momentum_update_coefficient,
+  const TS step) {
+  if (step > 0) {
+    return TC(1.0 - std::pow(static_cast<double>(momentum_update_coefficient), static_cast<double>(step)));
+  } else {
+    return TC(1.f);
+  }
+}
+
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/orttraining/orttraining/training_ops/cuda/optimizer/lamb.cc
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/lamb.cc
@@ -203,8 +203,10 @@ Status launch_lamb_compute_direction(
   for (int i = 0; i < group_count; ++i) {
     if (tensor_sizes[i] > max_tensor_size) {
       // For the first iteration (indexed by 0), the update count should be 2.
-      const float alpha_correction = compute_bias_correction_coefficient(alphas[i], update_count);
-      const float beta_correction = compute_bias_correction_coefficient(betas[i], update_count);
+      const float alpha_correction =
+        onnxruntime::contrib::compute_bias_correction_coefficient(alphas[i], update_count);
+      const float beta_correction =
+        onnxruntime::contrib::compute_bias_correction_coefficient(betas[i], update_count);
 
       LambComputeDirection(
           p_ws[i],
@@ -244,8 +246,10 @@ Status launch_lamb_compute_direction(
     std::tie(alpha, beta, lambda, epsilon) = key;
 
     // For the first iteration (indexed by 0), the update count should be 1.
-    const float alpha_correction = compute_bias_correction_coefficient(alpha, update_count);
-    const float beta_correction = compute_bias_correction_coefficient(beta, update_count);
+    const float alpha_correction =
+      onnxruntime::contrib::compute_bias_correction_coefficient(alpha, update_count);
+    const float beta_correction =
+      onnxruntime::contrib::compute_bias_correction_coefficient(beta, update_count);
 
     typedef LambMultiTensorComputeDirectionFunctor<CudaT2, CudaT3, CudaT4, CudaT_GRAD_NORM> LambStage1;
     LambStage1 lamb_stage1;

--- a/orttraining/orttraining/training_ops/cuda/optimizer/lamb.cc
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/lamb.cc
@@ -204,9 +204,9 @@ Status launch_lamb_compute_direction(
   for (int i = 0; i < group_count; ++i) {
     if (tensor_sizes[i] > max_tensor_size) {
       // For the first iteration (indexed by 0), the update count should be 2.
-      const float alpha_correction = do_bias_correction != 0 ?
+      const float alpha_correction = do_bias_correction ?
         onnxruntime::contrib::compute_bias_correction_coefficient(alphas[i], update_count) : 1.f;
-      const float beta_correction = do_bias_correction != 0 ?
+      const float beta_correction = do_bias_correction ?
         onnxruntime::contrib::compute_bias_correction_coefficient(betas[i], update_count) : 1.f;
 
       LambComputeDirection(
@@ -248,9 +248,9 @@ Status launch_lamb_compute_direction(
 
     // For the first iteration (indexed by 0), the update count should be 1.
     const float alpha_correction =
-      do_bias_correction != 0 ? onnxruntime::contrib::compute_bias_correction_coefficient(alpha, update_count) : 1.f;
+      do_bias_correction ? onnxruntime::contrib::compute_bias_correction_coefficient(alpha, update_count) : 1.f;
     const float beta_correction =
-      do_bias_correction != 0 ? onnxruntime::contrib::compute_bias_correction_coefficient(beta, update_count) : 1.f;
+      do_bias_correction ? onnxruntime::contrib::compute_bias_correction_coefficient(beta, update_count) : 1.f;
 
     typedef LambMultiTensorComputeDirectionFunctor<CudaT2, CudaT3, CudaT4, CudaT_GRAD_NORM> LambStage1;
     LambStage1 lamb_stage1;

--- a/orttraining/orttraining/training_ops/cuda/optimizer/lamb.cc
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/lamb.cc
@@ -161,16 +161,6 @@ Status copy_inputs_to_outputs(
   return Status::OK();
 }
 
-float compute_bias_correction_coefficient(
-  const float momentum_update_coefficient,
-  const int64_t step) {
-  if (step > 0) {
-    return 1.f - std::pow(momentum_update_coefficient, static_cast<float>(step));
-  } else {
-    return 1.f;
-  }
-}
-
 template <typename CudaT2, typename CudaT3, typename CudaT4, typename CudaT_GRAD_NORM>
 Status launch_lamb_compute_direction(
     const int64_t update_count,

--- a/orttraining/orttraining/training_ops/cuda/optimizer/lamb.h
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/lamb.h
@@ -20,7 +20,11 @@ class LambOptimizer final : public CudaKernel {
     epsilon_ = info.GetAttrsOrDefault("epsilon", std::vector<float>(1024, 1e-6f));
     ORT_ENFORCE(info.GetAttr<float>("ratio_min", &ratio_min_).IsOK(), "Missing/Invalid 'ratio_min' attribute value");
     ORT_ENFORCE(info.GetAttr<float>("ratio_max", &ratio_max_).IsOK(), "Missing/Invalid 'ratio_max' attribute value");
-    ORT_ENFORCE(info.GetAttr<int64_t>("do_bias_correction", &do_bias_correction_).IsOK(), "Missing/Invalid do_bias_correction");
+
+    int64_t tmp_flag = static_cast<int64_t>(0);
+    ORT_ENFORCE(info.GetAttr<int64_t>("do_bias_correction", &tmp_flag).IsOK(), "Missing/Invalid do_bias_correction");
+    ORT_ENFORCE(tmp_flag == 0 || tmp_flag == 1, "do_bias_correction must be either 0 or 1.");
+    do_bias_correction_ = tmp_flag != 0 ? true : false;
   }
 
   Status ComputeInternal(OpKernelContext* context) const override;
@@ -32,7 +36,7 @@ class LambOptimizer final : public CudaKernel {
   std::vector<float> epsilon_;
   float ratio_min_;
   float ratio_max_;
-  int64_t do_bias_correction_;
+  bool do_bias_correction_;
 };
 
 // Implementation can be found in cuda file, optimizers_impl.cu

--- a/orttraining/orttraining/training_ops/cuda/optimizer/lamb.h
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/lamb.h
@@ -20,6 +20,7 @@ class LambOptimizer final : public CudaKernel {
     epsilon_ = info.GetAttrsOrDefault("epsilon", std::vector<float>(1024, 1e-6f));
     ORT_ENFORCE(info.GetAttr<float>("ratio_min", &ratio_min_).IsOK(), "Missing/Invalid 'ratio_min' attribute value");
     ORT_ENFORCE(info.GetAttr<float>("ratio_max", &ratio_max_).IsOK(), "Missing/Invalid 'ratio_max' attribute value");
+    ORT_ENFORCE(info.GetAttr<int64_t>("do_bias_correction", &do_bias_correction_).IsOK(), "Missing/Invalid do_bias_correction");
   }
 
   Status ComputeInternal(OpKernelContext* context) const override;
@@ -31,6 +32,7 @@ class LambOptimizer final : public CudaKernel {
   std::vector<float> epsilon_;
   float ratio_min_;
   float ratio_max_;
+  int64_t do_bias_correction_;
 };
 
 // Implementation can be found in cuda file, optimizers_impl.cu


### PR DESCRIPTION
Adam with bias correction is used many places ([an example](https://github.com/NVIDIA/apex/blob/80b90b9d43e343c7d4df7f6081a4ceaee2d3c348/csrc/multi_tensor_adam.cu#L98)), so we implement it in ORT.

In the first commit, we change Adam to always use bias correction. In the next commit, we will allow user to enable it or not.