### PR TITLE
Foward ORT error messages on the C-ABI to exceptions thrown in winml

### DIFF
--- a/winml/lib/Api.Ort/OnnxruntimeErrors.h
+++ b/winml/lib/Api.Ort/OnnxruntimeErrors.h
@@ -46,8 +46,9 @@ inline HRESULT OrtErrorCodeToHRESULT(OrtErrorCode status) noexcept {
       auto error_message = ort_api->GetErrorMessage(_status);                                                  \
       HRESULT hresult = OrtErrorCodeToHRESULT(error_code);                                                     \
       telemetry_helper.LogRuntimeError(hresult, std::string(error_message), __FILE__, __FUNCTION__, __LINE__); \
-      RETURN_HR_MSG(hresult,                                                                                   \
-                    error_message);                                                                            \
+      auto message = WinML::Strings::HStringFromUTF8(error_message);                                           \
+      RoOriginateError(hresult, reinterpret_cast<HSTRING>(winrt::get_abi(message)));                           \
+      return hresult;                                                                                          \
     }                                                                                                          \
   } while (0)
 
@@ -59,7 +60,7 @@ inline HRESULT OrtErrorCodeToHRESULT(OrtErrorCode status) noexcept {
       auto error_message = ort_api->GetErrorMessage(_status);                                                  \
       HRESULT hresult = OrtErrorCodeToHRESULT(error_code);                                                     \
       telemetry_helper.LogRuntimeError(hresult, std::string(error_message), __FILE__, __FUNCTION__, __LINE__); \
-      winrt::hstring errorMessage(WinML::Strings::HStringFromUTF8(error_message));                             \
-      throw winrt::hresult_error(hresult, errorMessage);                                                       \
+      auto message = WinML::Strings::HStringFromUTF8(error_message);                                           \
+      throw winrt::hresult_error(hresult, message);                                                            \
     }                                                                                                          \
   } while (0)

--- a/winml/lib/Common/inc/errors.h
+++ b/winml/lib/Common/inc/errors.h
@@ -44,7 +44,7 @@
   {                                                                                  \
     auto _result = hr;                                                               \
     telemetry_helper.LogRuntimeError(_result, "", __FILE__, __FUNCTION__, __LINE__); \
-    throw winrt::hresult_error(_result);                                             \
+    throw winrt::hresult_error(_result, winrt::hresult_error::from_abi);             \
   }
 
 #define WINML_THROW_IF_FAILED(hr)                                                  \
@@ -52,7 +52,7 @@
     HRESULT _hr = hr;                                                              \
     if (FAILED(_hr)) {                                                             \
       telemetry_helper.LogRuntimeError(_hr, "", __FILE__, __FUNCTION__, __LINE__); \
-      throw winrt::hresult_error(_hr);                                             \
+      throw winrt::hresult_error(_hr, winrt::hresult_error::from_abi);             \
     }                                                                              \
   } while (0)
 


### PR DESCRIPTION
When layering was done, errors that occur on the c-abi boundary that are wrapped by OrtStatuses were not forwarded properly to winml exceptions, and only the translated HRESULT was surfaced, and not the message.

Fix: When a failing c-abi call is made, the RETURN_HR_IF_NOT_OK_MSG macro needs to set an issue an originateerror call to save the error string at the point of failure. The corresponding throw that occurs downstream needs to reuse that error message when creating the exception. This is done by calling winrt::hresult_error with from_abi_t, which will check to get the error message from there instead of clobbering it.