### PR TITLE
Avoid "infinite" loop in optimizer

### DIFF
--- a/onnxruntime/core/optimizer/free_dim_override_transformer.cc
+++ b/onnxruntime/core/optimizer/free_dim_override_transformer.cc
@@ -57,25 +57,22 @@ Status FreeDimensionOverrideTransformer::ApplyImpl(Graph& graph, bool& modified,
 
         int64_t dimension_override = it->second;
 
-        // If this dimension actually has a value but it doesn't match the override value, return an
-        // error.
-        if (dimension.has_dim_value() && dimension.dim_value() != dimension_override) {
+        if (dimension.has_dim_value()) {
+          // If this dimension actually has a value but it doesn't match the override value, return an
+          // error.
+          if (dimension.dim_value() != dimension_override) {
             LOGS(logger, ERROR) << "The model has input '" << graph_input->Name() << "' "
                                 << "with a fixed dimension denotation '" << dimension.denotation() << "' "
                                 << "but the size of this dimension " << dimension.dim_value() << " "
                                 << "does not equal the specified override of" << dimension_override << ".";
 
-          return Status(ONNXRUNTIME, INVALID_ARGUMENT, "Invalid free dimension override.");
+            return Status(ONNXRUNTIME, INVALID_ARGUMENT, "Invalid free dimension override.");
+          }
+        } else {
+          // Set the dimension override
+          new_dimension->set_dim_value(dimension_override);
+          shape_modified = true;
         }
-
-        if (dimension.has_dim_value() && !dimension.has_dim_param()) {
-          continue;
-        }
-
-        // Set the dimension override
-        new_dimension->clear_dim_param();
-        new_dimension->set_dim_value(dimension_override);
-        shape_modified = true;
       }
     }
 

--- a/onnxruntime/test/optimizer/free_dimension_override_test.cc
+++ b/onnxruntime/test/optimizer/free_dimension_override_test.cc
@@ -58,6 +58,12 @@ TEST(FreeDimensionOverrideTransformerTest, Test) {
   ASSERT_TRUE(input_shape->dim(1).denotation() == onnx::DATA_CHANNEL);
   ASSERT_TRUE(input_shape->dim(1).has_dim_value());
   ASSERT_TRUE(input_shape->dim(1).dim_value() == 42);
+
+  graph_transformer = onnxruntime::make_unique<FreeDimensionOverrideTransformer>(overrides);
+  bool modified = false;
+  ASSERT_TRUE(graph_transformer->Apply(graph, modified,
+    DefaultLoggingManager().DefaultLogger()).IsOK());
+  ASSERT_FALSE(modified); // no overrides apply anymore
 }
 
 }  // namespace test


### PR DESCRIPTION
**Description**: Avoid "infinite" loop in optimizer.

**Motivation and Context**
When symbolic dimensions are present and can be overridden,
FreeDimensionOverrideTransformer always sets modified flag to true. As a
consequence, the optimizer loops until the iteration limit is reached.
