### PR TITLE
fix bugs in quantization and calibration tools

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -38,7 +38,9 @@ def augment_graph(model):
         if node.op_type in quantization_candidates:
             input_name = node.output[0]
             # Adding ReduceMin nodes
-            reduce_min_name = node.name + '_ReduceMin'
+            reduce_min_name = ''
+            if node.name != '':
+                reduce_min_name = node.name + '_ReduceMin'
             reduce_min_node = onnx.helper.make_node('ReduceMin', [input_name], [input_name + '_ReduceMin'],
                                                     reduce_min_name,
                                                     keepdims=0)
@@ -46,7 +48,9 @@ def augment_graph(model):
             added_outputs.append(helper.make_tensor_value_info(reduce_min_node.output[0], TensorProto.FLOAT, ()))
 
             # Adding ReduceMax nodes
-            reduce_max_name = node.name + '_ReduceMax'
+            reduce_max_name = ''
+            if node.name!='':
+                reduce_max_name = node.name + '_ReduceMax'
             reduce_max_node = onnx.helper.make_node('ReduceMax', [input_name], [input_name + '_ReduceMax'],
                                                     reduce_max_name,
                                                     keepdims=0)

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -352,8 +352,12 @@ class ONNXQuantizer:
         return weights
 
     def _is_valid_quantize_value(self, value_name):
-        value_info = self.value_infos[value_name]
-        return value_info is not None and value_info.type.HasField('tensor_type') and value_info.type.tensor_type.elem_type == 1
+        if value_name in self.value_infos:
+            value_info = self.value_infos[value_name]
+            return value_info.type.HasField('tensor_type') and value_info.type.tensor_type.elem_type == 1
+        weight = _find_by_name(value_name, self.model.graph.initializer)
+        return weight is not None and weight.data_type == 1
+
 
     def _remove_quantized_weights(self):
         ''' Remove the weights which are already quantized from graph initializer list.

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -354,9 +354,9 @@ class ONNXQuantizer:
     def _is_valid_quantize_value(self, value_name):
         if value_name in self.value_infos:
             value_info = self.value_infos[value_name]
-            return value_info.type.HasField('tensor_type') and value_info.type.tensor_type.elem_type == 1
+            return value_info.type.HasField('tensor_type') and value_info.type.tensor_type.elem_type == onnx_proto.TensorProto.FLOAT
         weight = _find_by_name(value_name, self.model.graph.initializer)
-        return weight is not None and weight.data_type == 1
+        return weight is not None and weight.data_type == onnx_proto.TensorProto.FLOAT
 
 
     def _remove_quantized_weights(self):
@@ -935,7 +935,7 @@ class ONNXQuantizer:
 
     def _dequantize_value(self, value_name, new_nodes_list):
         '''
-        Given a value (input/output) which is quantized, add a DequantizeLinear node todequantize
+        Given a value (input/output) which is quantized, add a DequantizeLinear node to dequantize
         it back to float32
 
             parameter value_name: value to dequantize


### PR DESCRIPTION
Fix 3 bugs:
1. node names duplicate in calibration augment_graph if the name of node to quantize is empty.
2. If output nodes are quantized, output value are quantized and not dequantized back
3. Gather with data type int64 should not be quantized