### PR TITLE
Support for asynchronous exception build

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -95,7 +95,7 @@ option(onnxruntime_USE_TELEMETRY "Build with Telemetry" OFF)
 #If you have already installed protobuf(or the others) in your system at the default system paths(like /usr/include), then it's better to set onnxruntime_PREFER_SYSTEM_LIB ON. Otherwise onnxruntime may see two different protobuf versions and we won't know which one will be used, the worst case could be onnxruntime picked up header files from one of them but the binaries from the other one.
 #It's default OFF because it's experimental now.
 option(onnxruntime_PREFER_SYSTEM_LIB "Experimental: Build with the preinstalled libraries in your system" OFF)
-
+option(onnxruntime_ASYNC_EXCEPTIONS "Enable asynchronous exceptions" OFF)
 
 
 set(protobuf_BUILD_TESTS OFF CACHE BOOL "Build protobuf tests" FORCE)
@@ -206,8 +206,12 @@ if (MSVC)
     set(protobuf_MSVC_STATIC_RUNTIME OFF CACHE BOOL "Link protobuf to static runtime libraries" FORCE)
     set(gtest_force_shared_crt ON CACHE BOOL "Use shared (DLL) run-time lib for gtest" FORCE)
   endif()
-  #Always enable exception handling, even for Windows ARM
-  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
+  if (onnxruntime_ASYNC_EXCEPTIONS)
+    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHa")
+  else ()
+    # Always enable exception handling, even for Windows ARM
+    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
+  endif()
   if (onnxruntime_ENABLE_LTO AND NOT onnxruntime_USE_CUDA)
     SET (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Gw /GL")
     SET (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /Gw /GL")

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -166,6 +166,7 @@ Use the individual flags to only run the specified stages.
     parser.add_argument("--use_telemetry", action='store_true', help="Only official builds can set this flag to enable telemetry.")
     parser.add_argument("--enable_wcos", action='store_true', help="Build for Windows Core OS.")
     parser.add_argument("--enable_lto", action='store_true', help="Enable Link Time Optimization")
+    parser.add_argument("--async-exceptions", action='store_true', help="Enable asynchronous exceptions")
     return parser.parse_args()
 
 def resolve_executable_path(command_or_path):
@@ -300,7 +301,6 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
                  "-Donnxruntime_RUN_ONNX_TESTS=" + ("ON" if args.enable_onnx_tests else "OFF"),
                  "-Donnxruntime_BUILD_WINML_TESTS=" + ("OFF" if args.skip_winml_tests else "ON"),
                  "-Donnxruntime_GENERATE_TEST_REPORTS=ON",
-                 "-Donnxruntime_DEV_MODE=" + ("OFF" if args.android else "ON"),
                  "-DPYTHON_EXECUTABLE=" + sys.executable,
                  "-Donnxruntime_USE_CUDA=" + ("ON" if args.use_cuda else "OFF"),
                  "-Donnxruntime_CUDNN_HOME=" + (cudnn_home if args.use_cuda else ""),
@@ -344,6 +344,7 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
                  "-Donnxruntime_USE_WINML=" + ("ON" if args.use_winml else "OFF"),
                  "-Donnxruntime_USE_TELEMETRY=" + ("ON" if args.use_telemetry else "OFF"),
                  "-Donnxruntime_ENABLE_LTO=" + ("ON" if args.enable_lto else "OFF"),
+                 "-Donnxruntime_ASYNC_EXCEPTIONS=" + ("ON" if args.async_exceptions else "OFF")
                  ]
 
     # nGraph and TensorRT providers currently only supports full_protobuf option.


### PR DESCRIPTION
**Description**: Adds build flags to build with asynchronous exceptions on Windows - MSVC's _/Eha_ option.

**Motivation and Context**
- Why is this change required? What problem does it solve?
The way the onnxruntime is build, nullptr and other similar errors simply crash the hosting process. When /Eha is used, asynchronous exceptions can be caught in catch(...) blocks. This is a good start. In the future, it might be worht adding an exception translator __set_se_translator_.

After adding the flag, here is what I have in the command line options:

![image](https://user-images.githubusercontent.com/1331156/77682617-7b9c5380-6f54-11ea-8775-63f6377f2bb8.png)

