### PR TITLE
Enable Onnxruntime Telemetry by Default for 1.3

### DIFF
--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -56,7 +56,7 @@ TRACELOGGING_DEFINE_PROVIDER(telemetry_provider_handle, "Microsoft.ML.ONNXRuntim
 
 OrtMutex WindowsTelemetry::mutex_;
 uint32_t WindowsTelemetry::global_register_count_ = 0;
-bool WindowsTelemetry::enabled_ = false;
+bool WindowsTelemetry::enabled_ = true;
 
 
 WindowsTelemetry::WindowsTelemetry() {

--- a/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
@@ -1259,7 +1259,6 @@ const WinmlAdapterApi* OnnxruntimeEngineFactory::UseWinmlAdapterApi() {
 HRESULT OnnxruntimeEngineFactory::GetOrtEnvironment(OrtEnv** ort_env) {
   RETURN_IF_FAILED(EnsureEnvironment());
   RETURN_IF_FAILED(environment_->GetOrtEnvironment(ort_env));
-  RETURN_HR_IF_NOT_OK_MSG(ort_api_->EnableTelemetryEvents(*ort_env), ort_api_);
   return S_OK;
 }
 


### PR DESCRIPTION
This PR is to enable onnxruntime telemetry collection by default by setting bool WindowsTelemetry::enabled_ = true
