### PR TITLE
Added public Value variable to NamedOnnxValue

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.cs
@@ -29,6 +29,7 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         public string Name { get { return _name; } set { _name = value; } }
+        public Object Value { get { return _value; } set { _value = value; } }
 
         /// <summary>
         /// Try-get value as a Tensor&lt;T&gt;.


### PR DESCRIPTION
**Description**: Made the Value on the NamedOnnxValue accessible. Currently only the Name was available and the value had the actual inference result.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

I couldn't access the value to parse the result of the inference.