### PR TITLE
fix some warnings in concurrency tests

### DIFF
--- a/winml/test/concurrency/ConcurrencyTests.cpp
+++ b/winml/test/concurrency/ConcurrencyTests.cpp
@@ -211,12 +211,12 @@ void MultiThreadMultiSessionOnDevice(const LearningModelDevice& device) {
             modelSessions[i] = LearningModelSession(model, device);
         }
         // start all the threads
-        for (unsigned i = 0; i < NUM_THREADS; ++i) {
-            LearningModelSession &model_session = modelSessions[i];
-            pool.SubmitWork([&model_session,&ivfs,&max_indices,&max_values,tolerance,i]() {
+        for (unsigned i_thread = 0; i_thread < NUM_THREADS; ++i_thread) {
+            LearningModelSession &model_session = modelSessions[i_thread];
+            pool.SubmitWork([&model_session,&ivfs,&max_indices,&max_values,tolerance,i_thread]() {
                 DWORD start_time = GetTickCount();
                 while (((GetTickCount() - start_time) / 1000) < NUM_SECONDS) {
-                    auto j = i % ivfs.size();
+                    auto j = i_thread % ivfs.size();
                     auto input = ivfs[j];
                     auto expected_index = max_indices[j];
                     auto expected_value = max_values[j];
@@ -244,7 +244,7 @@ void MultiThreadMultiSessionOnDevice(const LearningModelDevice& device) {
         }
     }
     catch (...) {
-        WINML_EXPECT_HRESULT_SUCCEEDED(E_FAIL, L"Failed to create session concurrently.");
+        WINML_LOG_ERROR("Failed to create session concurrently.");
     }
 }
 


### PR DESCRIPTION
**Description**: There's a couple compiler warnings in concurrency tests (local variable overrides variable at higher scope and too many args for macro function).
