### PR TITLE
ERROR_NOT_SUPPORTED doesn't trigger Failed Hresult. Need E_NOTIMPL

### DIFF
--- a/winml/lib/Common/CommonDeviceHelpers.cpp
+++ b/winml/lib/Common/CommonDeviceHelpers.cpp
@@ -154,7 +154,7 @@ bool IsFloat16Supported(const winrt::Windows::AI::MachineLearning::LearningModel
 
 bool IsFloat16Supported(ID3D12Device* device) {
 #ifndef USE_DML
-    throw winrt::hresult_error(ERROR_NOT_SUPPORTED, L"IsFloat16Supported is not implemented for WinML only build."); 
+    throw winrt::hresult_error(E_NOTIMPL, L"IsFloat16Supported is not implemented for WinML only build."); 
 #else
   bool isBlocked;
   if (FAILED(IsFloat16Blocked(*device, &isBlocked)) || isBlocked) {


### PR DESCRIPTION
**Description**: "ERROR_NOT_SUPPORTED " isn't an "error" - it doesn't return true for an if(FAILED()) check because it's value is 0x50, and failures are negative. So the session fails to be created but returns success, and the caller is left with a null session object.
