### PR TITLE
Remove Windows GPU tests for Debug build

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -403,11 +403,6 @@ endif()
 set(all_dependencies ${onnxruntime_test_providers_dependencies} )
 
   if (onnxruntime_ENABLE_TRAINING)
-    if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
-      file(GLOB grad_test_src "${ORTTRAINING_SOURCE_DIR}/test/gradient/*.cc")
-      list(REMOVE_ITEM onnxruntime_test_training_src ${grad_test_src})
-    endif()
-
     list(APPEND all_tests ${onnxruntime_test_training_src})
   endif()
 

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -403,7 +403,7 @@ endif()
 set(all_dependencies ${onnxruntime_test_providers_dependencies} )
 
   if (onnxruntime_ENABLE_TRAINING)
-    if(${CMAKE_BUILD_TYPE} MATCHES "Debug" AND NOT onnxruntime_USE_CUDA)
+    if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
       file(GLOB grad_test_src "${ORTTRAINING_SOURCE_DIR}/test/gradient/*.cc")
       list(REMOVE_ITEM onnxruntime_test_training_src ${grad_test_src})
     endif()

--- a/orttraining/orttraining/test/gradient/gradient_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/gradient_ops_test.cc
@@ -18,6 +18,7 @@
 namespace onnxruntime {
 namespace test {
 
+#ifdef NDEBUG
 using ONNX_NAMESPACE::MakeAttribute;
 using training::OpDef;
 
@@ -1562,6 +1563,7 @@ TEST(Synchronization, WaitAndRecordEventMany) {
     }
   }
 }
+#endif
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/tools/ci_build/github/azure-pipelines/orttraining-win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-win-gpu-ci-pipeline.yml
@@ -20,4 +20,4 @@ jobs:
     sln_platform: 'x64'
     CudaVersion: '10.1'
     OrtPackageId: 'Microsoft.ML.OnnxRuntime.Gpu'
-    BuildConfigurations: ['RelWithDebInfo']
+    BuildConfigurations: ['Debug', 'RelWithDebInfo']

--- a/tools/ci_build/github/azure-pipelines/orttraining-win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-win-gpu-ci-pipeline.yml
@@ -20,4 +20,4 @@ jobs:
     sln_platform: 'x64'
     CudaVersion: '10.1'
     OrtPackageId: 'Microsoft.ML.OnnxRuntime.Gpu'
-    BuildConfigurations: ['Debug', 'RelWithDebInfo']
+    BuildConfigurations: ['RelWithDebInfo']


### PR DESCRIPTION
Debug tests are taking too long and ORT team decided to only test for
Release target as Windows Debug is not used for production