### PR TITLE
Fix fp16 type mismatch when graph output is an fp32-only node

### DIFF
--- a/orttraining/orttraining/core/graph/mixed_precision_transformer.cc
+++ b/orttraining/orttraining/core/graph/mixed_precision_transformer.cc
@@ -36,7 +36,7 @@ static const std::unordered_set<std::string> FP32_Nodes = {
     "SparseSoftmaxCrossEntropy",
     "SparseSoftmaxCrossEntropyGrad"};
 
-static bool IsFP32Node(const Node* node) {
+bool IsFP32Node(const Node* node) {
   return FP32_Nodes.find(node->OpType()) != FP32_Nodes.cend();
 }
 

--- a/orttraining/orttraining/core/graph/mixed_precision_transformer.h
+++ b/orttraining/orttraining/core/graph/mixed_precision_transformer.h
@@ -26,5 +26,12 @@ Status TransformGraphForMixedPrecision(Graph& graph,
                                        bool use_fp16_initializer,
                                        std::unordered_map<std::string, NodeArg*>& fp32_weight_name_to_fp16_node_arg);
 
+/**
+ * Checks if a node is an fp32-only node.
+ *
+ * @param node The node to check.
+ * @return Whether it's an fp32-only node.
+ */
+bool IsFP32Node(const Node* node);
 }  // namespace training
 }  // namespace onnxruntime

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -640,6 +640,16 @@ const DataTransferManager& TrainingSession::GetDataTransferManager() const {
   return session_state_->GetDataTransferMgr();
 }
 
+bool TrainingSession::IsGraphOutputFp32Node(const std::string& output_name) const {
+  std::vector<SessionState::NodeInfo> node_info_list;
+  ORT_THROW_IF_ERROR(session_state_->GetOutputNodeInfo(output_name, node_info_list));
+  // Graph output can only be produced by one node
+  ORT_ENFORCE(node_info_list.size() == 1, "Graph output: " + output_name + " cannot be produced by multiple nodes.");
+  auto& node_info = node_info_list.front();
+  ORT_ENFORCE(node_info.p_node != nullptr, "Node info cannot contain an empty node.");
+  return IsFP32Node(node_info.p_node);
+}
+
 Status TrainingSession::SetStateTensors(const NameMLValMap& state_tensors, bool strict) {
   ORT_RETURN_IF_NOT(IsInitialized(), "Can't update initializers before session has been initialized.");
 

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -641,13 +641,9 @@ const DataTransferManager& TrainingSession::GetDataTransferManager() const {
 }
 
 bool TrainingSession::IsGraphOutputFp32Node(const std::string& output_name) const {
-  std::vector<SessionState::NodeInfo> node_info_list;
-  ORT_THROW_IF_ERROR(session_state_->GetOutputNodeInfo(output_name, node_info_list));
-  // Graph output can only be produced by one node
-  ORT_ENFORCE(node_info_list.size() == 1, "Graph output: " + output_name + " cannot be produced by multiple nodes.");
-  auto& node_info = node_info_list.front();
-  ORT_ENFORCE(node_info.p_node != nullptr, "Node info cannot contain an empty node.");
-  return IsFP32Node(node_info.p_node);
+  auto output_producer_node = model_->MainGraph().GetProducerNode(output_name);
+  ORT_ENFORCE(output_producer_node != nullptr, "Output: " + output_name + " is not produced by any node.");
+  return IsFP32Node(output_producer_node);
 }
 
 Status TrainingSession::SetStateTensors(const NameMLValMap& state_tensors, bool strict) {

--- a/orttraining/orttraining/core/session/training_session.h
+++ b/orttraining/orttraining/core/session/training_session.h
@@ -209,6 +209,9 @@ class TrainingSession : public InferenceSession {
   /** Gets the model location. */
   const PathString& GetModelLocation() const { return model_location_; }
 
+  /** Checks to be see if given graph output is produced by an fp32-only node. */
+  bool IsGraphOutputFp32Node(const std::string& output_name) const;
+
  private:
   /** Configures the loss function.
   The loss function can either be provided externally or built from the provided loss function information.

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -311,7 +311,7 @@ def convert_model_loss_fn_to_onnx(model, loss_fn, model_desc, device, inputs):
     torch.onnx._export(model, tuple(sample_inputs), f,
                        input_names=input_names,
                        output_names=output_names,
-                       opset_version=10,
+                       opset_version=11,
                        dynamic_axes=dynamic_axes,
                        training=True,
                        _retain_param_name=True,

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -311,7 +311,7 @@ def convert_model_loss_fn_to_onnx(model, loss_fn, model_desc, device, inputs):
     torch.onnx._export(model, tuple(sample_inputs), f,
                        input_names=input_names,
                        output_names=output_names,
-                       opset_version=11,
+                       opset_version=10,
                        dynamic_axes=dynamic_axes,
                        training=True,
                        _retain_param_name=True,

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -629,7 +629,7 @@ class ORTTrainer():
 
         # ORT backend has modified model output dtype from float32 to float16.
         for o_desc in self.model_desc_.outputs_:
-            if self.use_mixed_precision and o_desc.dtype_ == torch.float32:
+            if self.use_mixed_precision and o_desc.dtype_ == torch.float32 and not self.session.is_output_fp32_node(o_desc.name_):
                 o_desc.eval_dtype_ = torch.float16
             else:
                 o_desc.eval_dtype_ = o_desc.dtype_

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -277,7 +277,11 @@ void addObjectMethodsForTraining(py::module& m) {
           state_tensors.insert(std::make_pair(initializer.first, ml_value));
         }
         ORT_THROW_IF_ERROR(sess->SetStateTensors(state_tensors, strict));
+      })
+      .def("is_output_fp32_node", [](onnxruntime::training::TrainingSession* sess, const std::string& output_name) {
+        return sess->IsGraphOutputFp32Node(output_name);
       });
+
 }
 }  // namespace python
 }  // namespace onnxruntime

--- a/orttraining/orttraining/python/training/training_session.py
+++ b/orttraining/orttraining/python/training/training_session.py
@@ -38,5 +38,8 @@ class TrainingSession(InferenceSession):
     def get_state(self):
         return self._sess.get_state()
 
+    def load_state(self, dict, strict=False):
+        self._sess.load_state(dict, strict)
+
     def is_output_fp32_node(self, output_name):
         return self._sess.is_output_fp32_node(output_name)

--- a/orttraining/orttraining/python/training/training_session.py
+++ b/orttraining/orttraining/python/training/training_session.py
@@ -38,5 +38,5 @@ class TrainingSession(InferenceSession):
     def get_state(self):
         return self._sess.get_state()
 
-    def load_state(self, dict, strict=False):
-        self._sess.load_state(dict, strict)
+    def is_output_fp32_node(self, output_name):
+        return self._sess.is_output_fp32_node(output_name)


### PR DESCRIPTION
**Description**: 
Fix fp16 type mismatch when graph output is an fp32-only node

**Motivation and Context**
Frontend sets output type to fp16 in mixed precision mode, but if the output node of the graph is an fp32-only node, then kernel will complain about type mismatch.

