### PR TITLE
Fix issue in construction of DummyArena that was preventing DNNL EP from getting constructed when use_arena was false.

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -151,6 +151,13 @@ file(GLOB_RECURSE onnxruntime_test_providers_cpu_src CONFIGURE_DEPENDS
   )
 list(APPEND onnxruntime_test_providers_src ${onnxruntime_test_providers_cpu_src})
 
+if (onnxruntime_USE_DNNL)
+  file(GLOB_RECURSE onnxruntime_test_providers_dnnl_src CONFIGURE_DEPENDS
+    "${TEST_SRC_DIR}/providers/dnnl/*"
+    )
+  list(APPEND onnxruntime_test_providers_src ${onnxruntime_test_providers_dnnl_src})
+endif()
+
 if (onnxruntime_USE_NGRAPH)
   file(GLOB_RECURSE onnxruntime_test_providers_ngraph_src CONFIGURE_DEPENDS
     "${TEST_SRC_DIR}/providers/ngraph/*"

--- a/onnxruntime/core/framework/arena.h
+++ b/onnxruntime/core/framework/arena.h
@@ -37,7 +37,11 @@ class DummyArena : public IArenaAllocator {
  public:
   explicit DummyArena(std::unique_ptr<IDeviceAllocator> resource_allocator)
       : allocator_(std::move(resource_allocator)),
-        info_(allocator_->Info().name, OrtAllocatorType::OrtArenaAllocator, allocator_->Info().device, allocator_->Info().id) {
+        info_(allocator_->Info().name,
+              OrtAllocatorType::OrtArenaAllocator,
+              allocator_->Info().device,
+              allocator_->Info().id,
+              allocator_->Info().mem_type) {
   }
 
   ~DummyArena() override = default;

--- a/onnxruntime/test/providers/dnnl/dnnl_execution_provider_test.cc
+++ b/onnxruntime/test/providers/dnnl/dnnl_execution_provider_test.cc
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/dnnl/dnnl_execution_provider.h"
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+TEST(DNNLExecutionProviderTest, MetadataTest) {
+  DNNLExecutionProviderInfo info;
+  info.create_arena = false;
+  auto provider = onnxruntime::make_unique<DNNLExecutionProvider>(info);
+  EXPECT_TRUE(provider != nullptr);
+  ASSERT_STREQ(provider->GetAllocator(0, OrtMemTypeCPUOutput)->Info().name, "DnnlCpu");
+}
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
**Description**: Fix issue in construction of DummyArena that was preventing DNNL EP from getting constructed when use_arena was false.

**Motivation and Context**
Reported by an internal customer.
Issue was observed when DNNL EP was being registered with use_area=0. The following exception was thrown: Message: Microsoft.ML.OnnxRuntime.OnnxRuntimeException : [ErrorCode:RuntimeException] C:\onnxruntime\onnxruntime\core\framework\execution_provider.cc:57 onnxruntime::IExecutionProvider::InsertAllocator duplicated allocator
