### PR TITLE
Fix race condition creating ConverterResourceStore

### DIFF
--- a/winml/lib/Api/LearningModelDevice.cpp
+++ b/winml/lib/Api/LearningModelDevice.cpp
@@ -53,24 +53,12 @@ Windows::AI::MachineLearning::LearningModelDevice LearningModelDevice::CreateFro
 WINML_CATCH_ALL
 
 std::shared_ptr<::Windows::AI::MachineLearning::ConverterResourceStore> LearningModelDevice::TensorizerStore() {
-  if (m_tensorizerStore) {
-    return m_tensorizerStore;
-  }
-  std::lock_guard<std::mutex> lock(m_tensorizerStoreMutex);
-  if (m_tensorizerStore == nullptr) {
-    m_tensorizerStore = ::Windows::AI::MachineLearning::ConverterResourceStore::Create(5);
-  }
+  std::call_once(m_tensorizerStoreInitialized, [this](){ m_tensorizerStore = ::Windows::AI::MachineLearning::ConverterResourceStore::Create(5); });
   return m_tensorizerStore;
 }
 
 std::shared_ptr<::Windows::AI::MachineLearning::ConverterResourceStore> LearningModelDevice::DetensorizerStore() {
-  if (m_detensorizerStore) {
-    return m_detensorizerStore;
-  }
-  std::lock_guard<std::mutex> lock(m_detensorizerStoreMutex);
-  if (m_detensorizerStore == nullptr) {
-    m_detensorizerStore = ::Windows::AI::MachineLearning::ConverterResourceStore::Create(5);
-  }
+  std::call_once(m_detensorizerStoreInitialized, [this](){ m_detensorizerStore = ::Windows::AI::MachineLearning::ConverterResourceStore::Create(5); });
   return m_detensorizerStore;
 }
 

--- a/winml/lib/Api/LearningModelDevice.cpp
+++ b/winml/lib/Api/LearningModelDevice.cpp
@@ -53,6 +53,10 @@ Windows::AI::MachineLearning::LearningModelDevice LearningModelDevice::CreateFro
 WINML_CATCH_ALL
 
 std::shared_ptr<::Windows::AI::MachineLearning::ConverterResourceStore> LearningModelDevice::TensorizerStore() {
+  if (m_tensorizerStore) {
+    return m_tensorizerStore;
+  }
+  std::lock_guard<std::mutex> lock(m_tensorizerStoreMutex);
   if (m_tensorizerStore == nullptr) {
     m_tensorizerStore = ::Windows::AI::MachineLearning::ConverterResourceStore::Create(5);
   }
@@ -60,6 +64,10 @@ std::shared_ptr<::Windows::AI::MachineLearning::ConverterResourceStore> Learning
 }
 
 std::shared_ptr<::Windows::AI::MachineLearning::ConverterResourceStore> LearningModelDevice::DetensorizerStore() {
+  if (m_detensorizerStore) {
+    return m_detensorizerStore;
+  }
+  std::lock_guard<std::mutex> lock(m_detensorizerStoreMutex);
   if (m_detensorizerStore == nullptr) {
     m_detensorizerStore = ::Windows::AI::MachineLearning::ConverterResourceStore::Create(5);
   }

--- a/winml/lib/Api/LearningModelDevice.h
+++ b/winml/lib/Api/LearningModelDevice.h
@@ -84,7 +84,9 @@ struct LearningModelDevice : LearningModelDeviceT<LearningModelDevice, IMetacomm
   bool m_isCpuDevice;
   bool m_areMetacommandsEnabled = true;
   std::shared_ptr<WinML::ConverterResourceStore> m_detensorizerStore;
+  std::mutex m_detensorizerStoreMutex;
   std::shared_ptr<WinML::ConverterResourceStore> m_tensorizerStore;
+  std::mutex m_tensorizerStoreMutex;
 
   std::unique_ptr<D3DDeviceCache> m_deviceCache;
 };

--- a/winml/lib/Api/LearningModelDevice.h
+++ b/winml/lib/Api/LearningModelDevice.h
@@ -84,9 +84,9 @@ struct LearningModelDevice : LearningModelDeviceT<LearningModelDevice, IMetacomm
   bool m_isCpuDevice;
   bool m_areMetacommandsEnabled = true;
   std::shared_ptr<WinML::ConverterResourceStore> m_detensorizerStore;
-  std::mutex m_detensorizerStoreMutex;
+  std::once_flag m_detensorizerStoreInitialized;
   std::shared_ptr<WinML::ConverterResourceStore> m_tensorizerStore;
-  std::mutex m_tensorizerStoreMutex;
+  std::once_flag m_tensorizerStoreInitialized;
 
   std::unique_ptr<D3DDeviceCache> m_deviceCache;
 };

--- a/winml/test/concurrency/ConcurrencyTests.cpp
+++ b/winml/test/concurrency/ConcurrencyTests.cpp
@@ -323,6 +323,7 @@ void MultiThreadSingleSession() {
 }
 
 void MultiThreadSingleSessionGpu() {
+    GPUTEST
     MultiThreadSingleSessionOnDevice(LearningModelDeviceKind::DirectX);
 }
 }

--- a/winml/test/concurrency/ConcurrencyTests.cpp
+++ b/winml/test/concurrency/ConcurrencyTests.cpp
@@ -250,9 +250,11 @@ void MultiThreadMultiSessionOnDevice(const LearningModelDevice& device) {
 
 void MultiThreadMultiSession() {
     MultiThreadMultiSessionOnDevice(LearningModelDeviceKind::Cpu);
-    if (GPUTEST_ENABLED) {
-        MultiThreadMultiSessionOnDevice(LearningModelDeviceKind::DirectX);
-    }
+}
+
+void MultiThreadMultiSessionGpu() {
+    GPUTEST
+    MultiThreadMultiSessionOnDevice(LearningModelDeviceKind::DirectX);
 }
 
 // Create different sessions for each thread, and evaluate
@@ -318,9 +320,10 @@ void MultiThreadSingleSessionOnDevice(const LearningModelDevice& device) {
 
 void MultiThreadSingleSession() {
     MultiThreadSingleSessionOnDevice(LearningModelDeviceKind::Cpu);
-    if (GPUTEST_ENABLED) {
-        MultiThreadSingleSessionOnDevice(LearningModelDeviceKind::DirectX);
-    }
+}
+
+void MultiThreadSingleSessionGpu() {
+    MultiThreadSingleSessionOnDevice(LearningModelDeviceKind::DirectX);
 }
 }
 
@@ -330,7 +333,9 @@ const ConcurrencyTestsApi& getapi() {
     LoadBindEvalSqueezenetRealDataWithValidationConcurrently,
     MultiThreadLoadModel,
     MultiThreadMultiSession,
+    MultiThreadMultiSessionGpu,
     MultiThreadSingleSession,
+    MultiThreadSingleSessionGpu,
     EvalAsyncDifferentModels,
     EvalAsyncDifferentSessions,
     EvalAsyncDifferentBindings

--- a/winml/test/concurrency/ConcurrencyTests.h
+++ b/winml/test/concurrency/ConcurrencyTests.h
@@ -10,7 +10,9 @@ struct ConcurrencyTestsApi
   VoidTest LoadBindEvalSqueezenetRealDataWithValidationConcurrently;
   VoidTest MultiThreadLoadModel;
   VoidTest MultiThreadMultiSession;
+  VoidTest MultiThreadMultiSessionGpu;
   VoidTest MultiThreadSingleSession;
+  VoidTest MultiThreadSingleSessionGpu;
   VoidTest EvalAsyncDifferentModels;
   VoidTest EvalAsyncDifferentSessions;
   VoidTest EvalAsyncDifferentBindings;
@@ -21,7 +23,9 @@ WINML_TEST_CLASS_BEGIN_WITH_SETUP(ConcurrencyTests, ConcurrencyTestsApiSetup)
 WINML_TEST(ConcurrencyTests, LoadBindEvalSqueezenetRealDataWithValidationConcurrently)
 WINML_TEST(ConcurrencyTests, MultiThreadLoadModel)
 WINML_TEST(ConcurrencyTests, MultiThreadMultiSession)
+WINML_TEST(ConcurrencyTests, MultiThreadMultiSessionGpu)
 WINML_TEST(ConcurrencyTests, MultiThreadSingleSession)
+WINML_TEST(ConcurrencyTests, MultiThreadSingleSessionGpu)
 WINML_TEST(ConcurrencyTests, EvalAsyncDifferentModels)
 WINML_TEST(ConcurrencyTests, EvalAsyncDifferentSessions)
 WINML_TEST(ConcurrencyTests, EvalAsyncDifferentBindings)


### PR DESCRIPTION
**Description**: Creating ConverterResourceStore in parallel sessions in the same device leads to a race condition when both threads overwrite the same ConverterResourceStore shared_prt (which is undefined behavior). To repro, run the MultiThreadMultiSession or MultiThreadMultiSessionGpu test multiple times (keep it looping and it should crash in about 40 min to 1:30).

Bug will show as the old shared_ptr value being destroyed when overwritten by the other thread. Acessing the old ConverterResourceStore will either segfault, call abort() with `d:\agent\_work\8\s\src\vctools\crt\github\stl\src\mutex.cpp(165): unlock of unowned mutex`, or with `d:\agent\_work\8\s\src\vctools\crt\github\stl\src\mutex.cpp(64): mutex destroyed while busy`

Related:

* https://microsoft.visualstudio.com/OS/_sprints/taskboard/WinML/OS/2004/2004-1?workitem=25822488
* https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=128539&view=results

Quote:

> A shared_ptr instance can be "read" (accessed using only const operations) simultaneously by multiple threads. **Different** shared_ptr instances can be "written to" (accessed using mutable operations such as operator= or reset) simultaneously by multiple threads (even when these instances are copies, and share the same reference count underneath.)
**Any other simultaneous accesses result in undefined behavior.**