### PR TITLE
Add #pragma once to core/providers/providers.h

### DIFF
--- a/include/onnxruntime/core/providers/providers.h
+++ b/include/onnxruntime/core/providers/providers.h
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#pragma once
+
 namespace onnxruntime {
 class IExecutionProvider;
 


### PR DESCRIPTION
**Description**:
Add #pragma once to providers.h, to avoid 'struct' redefinition error when including the header from multiple places.
