### PR TITLE
Use MlasConv for 1D convolutions

### DIFF
--- a/onnxruntime/core/mlas/lib/convolve.cpp
+++ b/onnxruntime/core/mlas/lib/convolve.cpp
@@ -1037,7 +1037,7 @@ Arguments:
     Parameters - Supplies the structure that stores the provided and computed
         parameters for the convolution operation.
 
-    Dimensions - Supplies the number of dimensions (must be 2 or 3).
+    Dimensions - Supplies the number of dimensions (must be between 1 and 3).
 
     BatchCount - Supplies the number of batches to the processed.
 
@@ -1080,7 +1080,6 @@ Return Value:
     //
 
     Parameters->Activation = Activation;
-    Parameters->Dimensions = Dimensions;
     Parameters->BatchCount = BatchCount;
     Parameters->GroupCount = GroupCount;
     Parameters->InputChannels = InputChannels;
@@ -1116,6 +1115,32 @@ Return Value:
     Parameters->InputSize = InputSize;
     Parameters->OutputSize = OutputSize;
     Parameters->K = K;
+
+    //
+    // Promote 1D convolutions to 2D convolutions.
+    //
+
+    if (Dimensions == 1) {
+
+        Parameters->InputShape[1] = Parameters->InputShape[0];
+        Parameters->InputShape[0] = 1;
+        Parameters->OutputShape[1] = Parameters->OutputShape[0];
+        Parameters->OutputShape[0] = 1;
+        Parameters->KernelShape[1] = Parameters->KernelShape[0];
+        Parameters->KernelShape[0] = 1;
+        Parameters->DilationShape[1] = Parameters->DilationShape[0];
+        Parameters->DilationShape[0] = 1;
+        Parameters->Padding[3] = Parameters->Padding[1];
+        Parameters->Padding[2] = 0;
+        Parameters->Padding[1] = Parameters->Padding[0];
+        Parameters->Padding[0] = 0;
+        Parameters->StrideShape[1] = Parameters->StrideShape[0];
+        Parameters->StrideShape[0] = 1;
+
+        Dimensions = 2;
+    }
+
+    Parameters->Dimensions = Dimensions;
 
     //
     // Evaluate how the convolution will be performed.

--- a/onnxruntime/core/providers/cpu/nn/conv.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv.cc
@@ -207,7 +207,7 @@ Status Conv<float>::Compute(OpKernelContext* context) const {
   const size_t kernel_rank = kernel_shape.size();
   concurrency::ThreadPool* thread_pool = context->GetOperatorThreadPool();
 
-  if (kernel_rank == 2 || kernel_rank == 3) {
+  if (kernel_rank >= 1 && kernel_rank <= 3) {
     MLAS_CONV_PARAMETERS Parameters;
     size_t WorkingBufferSize;
     MlasConvPrepare(&Parameters,


### PR DESCRIPTION
**Description**: Use the existing 2D convolution code in MlasConv to also handle 1D convolutions. This avoids the overhead of the generic ND im2col path as well as inheriting the threaded im2col implementation.

**Motivation and Context**
This improves the situation described in #3418. That model now runs with the same performance as an equivalent model using 2D convolutions with "-o 2". Internally, MLAS just runs the convolution as a 2D convolution with height=1. On one AVX2 system running single-threaded, old was 900+ms, new was 225ms.

Using "-o 99", a 2D model can still run faster thanks to the NCHWc layout optimizer. This optimizer does not support reordering 1D tensors. With NCHWc, execution time drops to 185ms.