### PR TITLE
Fix ACL EP pooling build breakage [v2]

### DIFF
--- a/onnxruntime/core/providers/acl/acl_execution_provider.cc
+++ b/onnxruntime/core/providers/acl/acl_execution_provider.cc
@@ -29,13 +29,12 @@ class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOn
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 1, Conv);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 7, 9, float, AveragePool);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 1, 7, float, MaxPool);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 8, 9, float, MaxPool);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 8, 11, float, MaxPool);
 
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 1, 8, float, GlobalAveragePool);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 1, 8, float, GlobalMaxPool);
 
 // Opset 10
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 10, 10, float, MaxPool);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 10, 10, float, AveragePool);
 
 static void RegisterACLKernels(KernelRegistry& kernel_registry) {
@@ -52,13 +51,12 @@ static void RegisterACLKernels(KernelRegistry& kernel_registry) {
 
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 7, 9, float, AveragePool)>());
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 1, 7, float, MaxPool)>());
-  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 8, 9, float, MaxPool)>());
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 8, 11, float, MaxPool)>());
 
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 1, 8, float, GlobalAveragePool)>());
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 1, 8, float, GlobalMaxPool)>());
 
   // Opset 10
-  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 10, 10, float, MaxPool)>());
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 10, 10, float, AveragePool)>());
 }
 

--- a/onnxruntime/core/providers/acl/nn/pool.cc
+++ b/onnxruntime/core/providers/acl/nn/pool.cc
@@ -24,58 +24,43 @@ namespace acl {
 template <typename T, typename PoolType>
 thread_local std::map<OpKernel*, ACLNEPool> Pool<T, PoolType>::poolLayers;
 
-template <typename T, typename PoolType>
-Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
-  arm_compute::Tensor in, out;
+template <typename T>
+thread_local std::map<OpKernel*, ACLNEPool> MaxPoolV8<T>::maxPoolLayers;
+
+template <typename T>
+ACLNEPool PoolOperation(onnxruntime::OpKernelContext* context,
+                     arm_compute::PoolingType pool_type,
+                     onnxruntime::PoolAttributes pool_attrs,
+                     PoolLayersIterator it,
+                     bool insert){
 
   const Tensor* X = context->Input<Tensor>(0);
   const TensorShape& x_shape = X->Shape();
 
-  std::vector<int64_t> dilations(PoolBase::pool_attrs_.dilations);
-  std::vector<int64_t> aclDilations(2);
-  aclDilations[0] = (dilations.size() == 2) ? dilations[1] : 1;
-  aclDilations[1] = (!dilations.empty()) ? dilations[0] : 1;
+  std::vector<int64_t> pads = pool_attrs.pads;
+  std::vector<int64_t> strides = pool_attrs.strides;
+  std::vector<int64_t> kernel_shape = pool_attrs.kernel_shape;
 
-  if ((X->Shape().NumDimensions() != PREF_DIM) ||
-      (aclDilations[0] * aclDilations[1] > 1)) {
-    Status s = onnxruntime::Pool<T, PoolType>::Compute(context);
-    return s;
-  }
-
-  std::vector<int64_t> pads = PoolBase::pool_attrs_.pads;
-  std::vector<int64_t> strides = PoolBase::pool_attrs_.strides;
-  std::vector<int64_t> kernel_shape = PoolBase::pool_attrs_.kernel_shape;
-
-  if (PoolBase::pool_attrs_.global_pooling) {
+  if (pool_attrs.global_pooling) {
     const auto& input_dims = x_shape.GetDims();
     kernel_shape.assign(input_dims.begin() + 2, input_dims.end());
     pads.assign(kernel_shape.size(), 0);
   }
 
-  std::vector<int64_t> output_dims = PoolBase::pool_attrs_.SetOutputSize(x_shape, x_shape[1], &pads);
+  std::vector<int64_t> output_dims = pool_attrs.SetOutputSize(x_shape, x_shape[1], &pads);
   Tensor* Y = context->Output(0, TensorShape(output_dims));
 
-  ACLNEPool* pPool;
-  PoolLayersIterator it = Pool::poolLayers.find((OpKernel*)this);
-  if (it == Pool::poolLayers.end()) {
+  ACLNEPool tpool;
+  if (insert) {
     auto layer = std::make_shared<arm_compute::NEPoolingLayer>();
 
-    ACLNEPool tpool;
     tpool.in = std::make_shared<arm_compute::Tensor>();
     tpool.out = std::make_shared<arm_compute::Tensor>();
 
     tpool.in->allocator()->init(arm_compute::TensorInfo(ACLTensorShape(X->Shape(), PREF_DIM), arm_compute::Format::F32));
     tpool.out->allocator()->init(arm_compute::TensorInfo(ACLTensorShape(Y->Shape(), PREF_DIM), arm_compute::Format::F32));
 
-    arm_compute::PoolingType pool_type;
-    if (PoolBase::op_name_ == "GlobalAveragePool" || PoolBase::op_name_ == "AveragePool")
-      pool_type = arm_compute::PoolingType::AVG;
-    else if (PoolBase::op_name_ == "GlobalMaxPool" || PoolBase::op_name_ == "MaxPool")
-      pool_type = arm_compute::PoolingType::MAX;
-    else
-      return onnxruntime::Pool<T, PoolType>::Compute(context);
-
-    if (PoolBase::pool_attrs_.global_pooling) {
+    if (pool_attrs.global_pooling) {
       layer->configure(tpool.in.get(), tpool.out.get(), arm_compute::PoolingLayerInfo(pool_type));
     } else {
       std::vector<int64_t> aclStrides(2);
@@ -119,20 +104,16 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
     tpool.in->allocator()->allocate();
 
     tpool.layer = std::move(layer);
-    std::pair<PoolLayersIterator, bool> ret;
-    ret = Pool::poolLayers.insert(std::pair<OpKernel*, ACLNEPool>((OpKernel*)this, tpool));
-    pPool = &ret.first->second;
   } else {
-    pPool = &it->second;
+    tpool = it->second;
   }
-
   const T* x_data = X->template Data<T>();
   arm_compute::Window aclInpuWindow;
-  aclInpuWindow.use_tensor_dimensions(pPool->in->info()->tensor_shape());
+  aclInpuWindow.use_tensor_dimensions(tpool.in->info()->tensor_shape());
 
-  arm_compute::Iterator aclInputIt(pPool->in.get(), aclInpuWindow);
-  const unsigned int aclWidth = pPool->in->info()->dimension(0);
-  const unsigned int aclHeight = pPool->in->info()->dimension(1);
+  arm_compute::Iterator aclInputIt(tpool.in.get(), aclInpuWindow);
+  const unsigned int aclWidth = tpool.in->info()->dimension(0);
+  const unsigned int aclHeight = tpool.in->info()->dimension(1);
 
   // copy input tensor into the larger buffer
   arm_compute::execute_window_loop(
@@ -143,9 +124,71 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
       aclInputIt);
 
   T* y_data = Y->template MutableData<T>();
-  ACLImportMemory(pPool->out->allocator(), (void*)y_data, Y->Shape().Size() * 4);
+  ACLImportMemory(tpool.out->allocator(), (void*)y_data, Y->Shape().Size() * 4);
 
-  pPool->layer->run();
+  tpool.layer->run();
+
+  return tpool;
+}
+
+template <typename T, typename PoolType>
+Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
+  arm_compute::Tensor in, out;
+
+  const Tensor* X = context->Input<Tensor>(0);
+
+  std::vector<int64_t> dilations(PoolBase::pool_attrs_.dilations);
+  std::vector<int64_t> aclDilations(2);
+  aclDilations[0] = (dilations.size() == 2) ? dilations[1] : 1;
+  aclDilations[1] = (!dilations.empty()) ? dilations[0] : 1;
+
+  if ((X->Shape().NumDimensions() != PREF_DIM) ||
+      (aclDilations[0] * aclDilations[1] > 1)) {
+    Status s = onnxruntime::Pool<T, PoolType>::Compute(context);
+    return s;
+  }
+
+  arm_compute::PoolingType pool_type;
+  if (PoolBase::op_name_ == "GlobalAveragePool" || PoolBase::op_name_ == "AveragePool")
+    pool_type = arm_compute::PoolingType::AVG;
+  else if (PoolBase::op_name_ == "GlobalMaxPool" || PoolBase::op_name_ == "MaxPool")
+    pool_type = arm_compute::PoolingType::MAX;
+  else
+    return onnxruntime::Pool<T, PoolType>::Compute(context);
+
+  PoolLayersIterator it = Pool::poolLayers.find((OpKernel*) this);
+  bool insert = it == Pool::poolLayers.end();
+  ACLNEPool pPool = PoolOperation<T>(context, pool_type, PoolBase::pool_attrs_, it, insert);
+  if(insert){
+    std::pair<PoolLayersIterator, bool> ret;
+    ret = Pool::poolLayers.insert(std::pair<OpKernel*, ACLNEPool>((OpKernel*) this, pPool));
+  }
+
+  return Status::OK();
+}
+
+template <typename T>
+Status MaxPoolV8<T>::Compute(OpKernelContext* context) const {
+  const Tensor* X = context->Input<Tensor>(0);
+
+  std::vector<int64_t> dilations(PoolBase::pool_attrs_.dilations);
+  std::vector<int64_t> aclDilations(2);
+  aclDilations[0] = (dilations.size() == 2) ? dilations[1] : 1;
+  aclDilations[1] = (!dilations.empty()) ? dilations[0] : 1;
+
+  if ((X->Shape().NumDimensions() != PREF_DIM) ||
+      (aclDilations[0] * aclDilations[1] > 1)) {
+    Status s = onnxruntime::MaxPoolV8::Compute(context);
+    return s;
+  }
+
+  PoolLayersIterator it = MaxPoolV8::maxPoolLayers.find((OpKernel*) this);
+  bool insert = it == MaxPoolV8::maxPoolLayers.end();
+  ACLNEPool pPool = PoolOperation<T>(context, arm_compute::PoolingType::MAX, PoolBase::pool_attrs_, it, insert);
+  if(insert){
+    std::pair<PoolLayersIterator, bool> ret;
+    ret = MaxPoolV8::maxPoolLayers.insert(std::pair<OpKernel*, ACLNEPool>((OpKernel*) this, pPool));
+  }
 
   return Status::OK();
 }
@@ -162,12 +205,20 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
       Pool<data_type, pool_type>);
 
 POOLING_KERNEL(MaxPool, float, MaxPool<1>, 1, 7)
-POOLING_KERNEL(MaxPool, float, MaxPool<8>, 8, 9)
-POOLING_KERNEL(MaxPool, float, MaxPool<8>, 10, 10)
 POOLING_KERNEL(AveragePool, float, AveragePool, 7, 9)
 POOLING_KERNEL(AveragePool, float, AveragePool, 10, 10)
 POOLING_KERNEL(GlobalAveragePool, float, AveragePool, 1, 8)
 POOLING_KERNEL(GlobalMaxPool, float, MaxPool<1>, 1, 8)
+
+ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                                            \
+      MaxPool,                                                                      \
+      kOnnxDomain,                                                                  \
+      8,                                                                            \
+      11,                                                                           \
+      float,                                                                        \
+      kAclExecutionProvider,                                                        \
+      KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()), \
+      MaxPoolV8<float>);
 
 }  // namespace acl
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/acl/nn/pool.h
+++ b/onnxruntime/core/providers/acl/nn/pool.h
@@ -48,5 +48,24 @@ class Pool final : public onnxruntime::Pool<T, PoolType> {
   static thread_local std::map<OpKernel*, ACLNEPool> poolLayers;
   ACLExecutionProvider* provider_;
 };
+
+template <typename T>
+class MaxPoolV8 final : public onnxruntime::MaxPoolV8 {
+ public:
+  explicit MaxPoolV8(const OpKernelInfo& info) : onnxruntime::MaxPoolV8(info) {
+    provider_ = (const_cast<ACLExecutionProvider*>(
+        dynamic_cast<const ACLExecutionProvider*>(info.GetExecutionProvider())));
+  }
+
+  ~MaxPoolV8() {
+    maxPoolLayers.erase(this);
+  }
+
+  Status Compute(OpKernelContext* context) const override;
+
+ private:
+  static thread_local std::map<OpKernel*, ACLNEPool> maxPoolLayers;
+  ACLExecutionProvider* provider_;
+};
 }  // namespace acl
 }

--- a/onnxruntime/core/providers/cpu/nn/pool.cc
+++ b/onnxruntime/core/providers/cpu/nn/pool.cc
@@ -131,119 +131,99 @@ Status Pool<float, AveragePool>::Compute(OpKernelContext* context) const {
                            pool_attrs_.count_include_pad ? MlasAveragePoolingIncludePad : MlasAveragePoolingExcludePad);
 }
 
-// For maxpool v8 and beyond
-// version 8: Added storage_order And Indices
-// version 10: Added ceil_mode
-// version 11: Added dilations
-// version 12: Added int8/uint8 support
 
-class MaxPoolV8 : public OpKernel, public PoolBase {
+Status MaxPoolV8::Compute(OpKernelContext* context) const {
+  utils::MLTypeCallDispatcherRet<Status, ComputeHelper, float, double, int8_t, uint8_t>
+      t_disp(context->Input<Tensor>(0)->GetElementType());
+  return t_disp.Invoke(this, context);
+}
 
-  template <typename T>
-  struct ComputeHelper {
-    Status operator()(const MaxPoolV8* inst, OpKernelContext* context) const {
-      return inst->ComputeImpl<T>(context);
-    }
-  };
+template <typename T>
+Status MaxPoolV8::ComputeImpl(OpKernelContext* context) const {
+  concurrency::ThreadPool* tp = context->GetOperatorThreadPool();
+  // Use MLAS pooling if the index output tensor is not used
+  // and also if dilation is not required
 
- public:
-  explicit MaxPoolV8(const OpKernelInfo& info) : OpKernel(info), PoolBase(info) {
+  bool need_dilation = false;
+  for (auto n : pool_attrs_.dilations) {
+    need_dilation |= n > 1;
   }
 
-  Status Compute(OpKernelContext* context) const override {
-    utils::MLTypeCallDispatcherRet<Status, ComputeHelper, float, double, int8_t, uint8_t>
-        t_disp(context->Input<Tensor>(0)->GetElementType());
-    return t_disp.Invoke(this, context);
+  // MLAS implementation currently supports only floats
+  if (std::is_same<T, float>::value) {
+    if (OpKernel::Node().OutputDefs().size() == 1 && pool_attrs_.storage_order == 0 && !need_dilation) {
+      return PoolBase::Compute(context, MlasMaximumPooling);
+    }
   }
 
- private:
-  template <typename T>
-  Status ComputeImpl(OpKernelContext* context) const {
-    concurrency::ThreadPool* tp = context->GetOperatorThreadPool();
-    // Use MLAS pooling if the index output tensor is not used
-    // and also if dilation is not required
+  const auto* X = context->Input<Tensor>(0);
+  const TensorShape& x_shape = X->Shape();
 
-    bool need_dilation = false;
-    for (auto n : pool_attrs_.dilations) {
-      need_dilation |= n > 1;
+  ORT_RETURN_IF_NOT(x_shape.NumDimensions() >= 3, "Input dimension cannot be less than 3.");
+
+  std::vector<int64_t> pads = pool_attrs_.pads;
+  std::vector<int64_t> kernel_shape = pool_attrs_.kernel_shape;
+
+  std::vector<int64_t> output_dims = pool_attrs_.SetOutputSize(x_shape, x_shape[1], &pads);
+  Tensor* Y = context->Output(0, output_dims);
+  Tensor* I = context->Output(1, output_dims);
+
+  const auto* X_data = X->template Data<T>();
+  auto* Y_data = Y->template MutableData<T>();
+  int64_t* I_data = I != nullptr ? I->template MutableData<int64_t>() : nullptr;
+
+  // The main loop
+  int64_t channels = x_shape[1];
+  int64_t height = x_shape[2];
+  int64_t width = kernel_shape.size() > 1 ? x_shape[3] : 1;
+  int64_t depth = kernel_shape.size() > 2 ? x_shape[4] : 1;
+  int64_t pooled_height = output_dims[2];
+  int64_t pooled_width = kernel_shape.size() > 1 ? output_dims[3] : 1;
+  int64_t pooled_depth = kernel_shape.size() > 2 ? output_dims[4] : 1;
+  const int64_t total_channels = x_shape[0] * channels;
+
+  switch (kernel_shape.size()) {
+    case 1: {
+      int64_t x_step = height;
+      int64_t y_step = pooled_height;
+      const int64_t dilation_h = pool_attrs_.dilations[0];
+
+      RunLoop<MaxPool1DTask<T>>(tp, total_channels,
+                                {X_data, Y_data, I_data, x_step, y_step, dilation_h, pooled_height, stride_h(),
+                                 height, kernel_shape, pads});
+      break;
     }
 
-    // MLAS implementation currently supports only floats
-    if (std::is_same<T, float>::value) {
-      if (OpKernel::Node().OutputDefs().size() == 1 && pool_attrs_.storage_order == 0 && !need_dilation) {
-        return PoolBase::Compute(context, MlasMaximumPooling);
-      }
+    case 2: {
+      int64_t x_step = height * width;
+      int64_t y_step = pooled_height * pooled_width;
+      const int64_t dilation_h = pool_attrs_.dilations[0];
+      const int64_t dilation_w = pool_attrs_.dilations[1];
+      RunLoop<MaxPool2DTask<T>>(
+          tp, total_channels,
+          {X_data, Y_data, I_data, x_step, y_step, dilation_h, dilation_w, pooled_height, pooled_width, stride_h(),
+           stride_w(), height, width, kernel_shape, pads, pool_attrs_.storage_order});
+      break;
     }
-
-    const auto* X = context->Input<Tensor>(0);
-    const TensorShape& x_shape = X->Shape();
-
-    ORT_RETURN_IF_NOT(x_shape.NumDimensions() >= 3, "Input dimension cannot be less than 3.");
-
-    std::vector<int64_t> pads = pool_attrs_.pads;
-    std::vector<int64_t> kernel_shape = pool_attrs_.kernel_shape;
-
-    std::vector<int64_t> output_dims = pool_attrs_.SetOutputSize(x_shape, x_shape[1], &pads);
-    Tensor* Y = context->Output(0, output_dims);
-    Tensor* I = context->Output(1, output_dims);
-
-    const auto* X_data = X->template Data<T>();
-    auto* Y_data = Y->template MutableData<T>();
-    int64_t* I_data = I != nullptr ? I->template MutableData<int64_t>() : nullptr;
-
-    // The main loop
-    int64_t channels = x_shape[1];
-    int64_t height = x_shape[2];
-    int64_t width = kernel_shape.size() > 1 ? x_shape[3] : 1;
-    int64_t depth = kernel_shape.size() > 2 ? x_shape[4] : 1;
-    int64_t pooled_height = output_dims[2];
-    int64_t pooled_width = kernel_shape.size() > 1 ? output_dims[3] : 1;
-    int64_t pooled_depth = kernel_shape.size() > 2 ? output_dims[4] : 1;
-    const int64_t total_channels = x_shape[0] * channels;
-
-    switch (kernel_shape.size()) {
-      case 1: {
-        int64_t x_step = height;
-        int64_t y_step = pooled_height;
-        const int64_t dilation_h = pool_attrs_.dilations[0];
-
-        RunLoop<MaxPool1DTask<T>>(tp, total_channels,
-                                  {X_data, Y_data, I_data, x_step, y_step, dilation_h, pooled_height, stride_h(),
-                                   height, kernel_shape, pads});
-        break;
-      }
-
-      case 2: {
-        int64_t x_step = height * width;
-        int64_t y_step = pooled_height * pooled_width;
-        const int64_t dilation_h = pool_attrs_.dilations[0];
-        const int64_t dilation_w = pool_attrs_.dilations[1];
-        RunLoop<MaxPool2DTask<T>>(
-            tp, total_channels,
-            {X_data, Y_data, I_data, x_step, y_step, dilation_h, dilation_w, pooled_height, pooled_width, stride_h(),
-             stride_w(), height, width, kernel_shape, pads, pool_attrs_.storage_order});
-        break;
-      }
-      case 3: {
-        int64_t x_step = height * width * depth;
-        int64_t y_step = pooled_height * pooled_width * pooled_depth;
-        const int64_t dilation_h = pool_attrs_.dilations[0];
-        const int64_t dilation_w = pool_attrs_.dilations[1];
-        const int64_t dilation_d = pool_attrs_.dilations[2];
-        RunLoop<MaxPool3DTask<T>>(tp, total_channels,
-                                  {X_data, Y_data, I_data, x_step, y_step,
-                                   dilation_h, dilation_w, dilation_d, pooled_height, pooled_width,
-                                   pooled_depth, stride_h(), stride_w(), stride_d(), height,
-                                   width, depth, kernel_shape, pads, pool_attrs_.storage_order});
-        break;
-      }
-      default:
-        return Status(ONNXRUNTIME, INVALID_ARGUMENT, "Unsupported pooling size : ");
+    case 3: {
+      int64_t x_step = height * width * depth;
+      int64_t y_step = pooled_height * pooled_width * pooled_depth;
+      const int64_t dilation_h = pool_attrs_.dilations[0];
+      const int64_t dilation_w = pool_attrs_.dilations[1];
+      const int64_t dilation_d = pool_attrs_.dilations[2];
+      RunLoop<MaxPool3DTask<T>>(tp, total_channels,
+                                {X_data, Y_data, I_data, x_step, y_step,
+                                 dilation_h, dilation_w, dilation_d, pooled_height, pooled_width,
+                                 pooled_depth, stride_h(), stride_w(), stride_d(), height,
+                                 width, depth, kernel_shape, pads, pool_attrs_.storage_order});
+      break;
     }
-
-    return Status::OK();
+    default:
+      return Status(ONNXRUNTIME, INVALID_ARGUMENT, "Unsupported pooling size : ");
   }
-};
+
+  return Status::OK();
+}
 
 ONNX_CPU_OPERATOR_VERSIONED_KERNEL(AveragePool, 7, 9,
                                    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),

--- a/onnxruntime/core/providers/cpu/nn/pool.h
+++ b/onnxruntime/core/providers/cpu/nn/pool.h
@@ -24,4 +24,26 @@ class Pool : public OpKernel, public PoolBase {
  private:
   PoolProcessContext pool_context_;
 };
+
+// For maxpool v8 and beyond
+// version 8: Added storage_order And Indices
+// version 10: Added ceil_mode
+// version 11: Added dilations
+// version 12: Added int8/uint8 support
+class MaxPoolV8 : public OpKernel, public PoolBase {
+
+ template <typename T>
+  struct ComputeHelper {
+    Status operator()(const MaxPoolV8* inst, OpKernelContext* context) const {
+      return inst->ComputeImpl<T>(context);
+    }
+  };
+
+ public:
+  MaxPoolV8(const OpKernelInfo& info) : OpKernel(info), PoolBase(info) {}
+  Status Compute(OpKernelContext* context) const override;
+ private:
+  template <typename T>
+  Status ComputeImpl(OpKernelContext* context) const;
+};
 }  // namespace onnxruntime


### PR DESCRIPTION
The commit 06fc9506fdf83082f1ef226324fab31806dce1ce which refactored cpu Pool class broke ACL EP build.
Also worked on the commit a4fe60c4d3fb082d875b5371e7846f42916ea3b8 as it also affects the new class.
- Move the declaration of the new MaxPoolV8 cpu class in the header file.
- Implement MaxPool 8-11 in ACL EP.
