### PR TITLE
Exclude the maxpool uint8 test for OpenVINO GPU build

### DIFF
--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -536,8 +536,10 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
 #ifdef OPENVINO_CONFIG_GPU_FP32
     broken_tests.insert({"tiny_yolov2", "accuracy mismatch"});
     broken_tests.insert({"div", "will be fixed in the next release"});
+    broken_tests.insert({"maxpool_2d_uint8", "The plugin does not support output U8 precision"});
 #ifdef OPENVINO_CONFIG_GPU_FP16
     broken_tests.insert({"div", "will be fixed in the next release"});
+    broken_tests.insert({"maxpool_2d_uint8", "The plugin does not support output U8 precision"});
 #endif
 #endif
   }

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -296,7 +296,13 @@ TEST(PoolTest, MaxPool2D_uint8) {
     21, 22, 23, 24, 25});
 
   test.AddOutput<uint8_t>("Output", output_shape, output);
-  test.Run();
+
+#if defined(OPENVINO_CONFIG_GPU_FP32) || defined(OPENVINO_CONFIG_GPU_FP16)
+  //openvino_2019.3.376/deployment_tools/inference_engine/include/details/ie_exception_conversion.hpp:71 The plugin does not support output U8 precision
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});
+#else
+  test.Run();	  test.Run();
+#endif
 }
 
 TEST(PoolTest, MaxPool_10_Dilation_1d) {

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -301,7 +301,7 @@ TEST(PoolTest, MaxPool2D_uint8) {
   //openvino_2019.3.376/deployment_tools/inference_engine/include/details/ie_exception_conversion.hpp:71 The plugin does not support output U8 precision
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});
 #else
-  test.Run();	  test.Run();
+  test.Run();
 #endif
 }
 

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -202,8 +202,9 @@ def create_backend_test(testname=None):
             current_failing_tests.append('^test_div_cpu*')
             # temporarily exclude vgg19 test which comsumes too much memory, run out of memory on Upsquared device.
             # single test pass for vgg19, need furture investigation
+            current_failing_tests.append('^test_vgg19_cpu*')
             # exception for maxpool_2d_uint8 "The plugin does not support output U8 precision"
-            current_failing_tests.append('^test_vgg19_cpu*', '^test_maxpool_2d_uint8_cpu*')
+            current_failing_tests.append('^test_maxpool_2d_uint8_cpu*')
 
         if c2.supports_device('OPENVINO_CPU_FP32'):
             current_failing_tests += [

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -202,7 +202,8 @@ def create_backend_test(testname=None):
             current_failing_tests.append('^test_div_cpu*')
             # temporarily exclude vgg19 test which comsumes too much memory, run out of memory on Upsquared device.
             # single test pass for vgg19, need furture investigation
-            current_failing_tests.append('^test_vgg19_cpu*')
+            # exception for maxpool_2d_uint8 "The plugin does not support output U8 precision"
+            current_failing_tests.append('^test_vgg19_cpu*', '^test_maxpool_2d_uint8_cpu*')
 
         if c2.supports_device('OPENVINO_CPU_FP32'):
             current_failing_tests += [


### PR DESCRIPTION
Exclude the maxpool uint8 test for OpenVINO GPU build since it's not supported
