### PR TITLE
Handle optional inputs and remove more empty shape nodes in TensorRT EP

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -183,11 +183,10 @@ bool FindCycleHelper(int i, const std::list<int>* adjacency_map,
 
 // Remove nodes with empty shape (for example [1, 0]) because TensorRT 7 doens't support empty shape
 SubGraphCollection_t RemoveEmptyShapeNodes(const onnxruntime::GraphViewer& graph) {
-  // Here only NonZero and NonMaxSuppression related empty shape nodes are removed, particularly for Faster-rcnn and Mask-rcnn models.
+  // Here only NonZero, NonMaxSuppression and TopK related empty shape nodes are removed, particularly for RCNN models.
   // TODO: Remove the code if TensorRT fixed the issue in the future release, or find a better generic way here to work around
   const std::vector<NodeIndex>& node_index = graph.GetNodesInTopologicalOrder();
-  const std::string exclude_dim_name1 = "NonZero";
-  const std::string exclude_dim_name2 = "NonMaxSuppression";
+  const std::vector<std::string> exclude_dim_name{"NonZero", "NonMaxSuppression", "TopK"};  
   SubGraphCollection_t parser_nodes_vector = {{{}, false}};
   std::vector<size_t> nodes_vector(node_index.size());
   std::iota(std::begin(nodes_vector), std::end(nodes_vector), 0);
@@ -201,11 +200,16 @@ SubGraphCollection_t RemoveEmptyShapeNodes(const onnxruntime::GraphViewer& graph
         for (const auto& dim : input_shape->dim()) {
           std::string dim_name = dim.dim_param();
           if (!dim_name.empty()) {
-            if ((dim_name.find(exclude_dim_name1) != std::string::npos) || (dim_name.find(exclude_dim_name2) != std::string::npos)) {
-              exclude_node = true;
+            for (const auto& exclude : exclude_dim_name) {
+              if (dim_name.find(exclude) != std::string::npos) {
+                exclude_node = true;
+                break;
+              }
+            }
+            if (exclude_node) {
               break;
             }
-          }
+		  }	  
         }
       }
 
@@ -322,7 +326,10 @@ std::unique_ptr<IndexedSubGraph> TensorrtExecutionProvider::GetSubGraph(SubGraph
   meta_def->domain = kMSDomain;
 
   for (const auto& input : inputs) {
-    meta_def->inputs.push_back(input.second->Name());
+	auto name = input.second->Name();
+	if (!name.empty()){
+	  meta_def->inputs.push_back(name);
+	}
   }
 
   for (const auto& output : outputs) {
@@ -385,6 +392,12 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
           graph_build.AddNode(node->Name(), node->OpType(), node->Description(), inputs, outputs, &node->GetAttributes(), node->Domain());
         }
 
+        // Add initializers to the subgraph
+        const auto& init_tensors = graph.GetAllInitializedTensors();
+        for (const auto& tensor : init_tensors) {
+          graph_build.AddInitializedTensor(*(tensor.second));
+        }
+		
         ORT_ENFORCE(graph_build.Resolve().IsOK());
 
         // Add parent graph output to the subgraph
@@ -400,13 +413,6 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
         auto& graph_build_outputs = graph_build.GetOutputs();
         subgraph_outputs.insert(subgraph_outputs.begin(), graph_build_outputs.begin(), graph_build_outputs.end());
         graph_build.SetOutputs(graph_build_outputs);
-
-        // Add initializers to the subgraph
-        const auto& init_tensors = graph.GetAllInitializedTensors();
-        for (const auto& tensor : init_tensors) {
-          graph_build.AddInitializedTensor(*(tensor.second));
-        }
-
         ORT_ENFORCE(graph_build.Resolve().IsOK());
 
         // Check if input tensors have shapes

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -209,7 +209,7 @@ SubGraphCollection_t RemoveEmptyShapeNodes(const onnxruntime::GraphViewer& graph
             if (exclude_node) {
               break;
             }
-		  }	  
+          }	  
         }
       }
 
@@ -326,7 +326,7 @@ std::unique_ptr<IndexedSubGraph> TensorrtExecutionProvider::GetSubGraph(SubGraph
   meta_def->domain = kMSDomain;
 
   for (const auto& input : inputs) {
-	auto name = input.second->Name();
+	const auto name = input.second->Name();
 	if (!name.empty()){
 	  meta_def->inputs.push_back(name);
 	}


### PR DESCRIPTION
- Remove optional inputs at (sub)graph level
   When TRT EP partitions a graph for TRT, optional input of operators become subgraph's input, which will cause problem since it doesn't have name/type/values. This PR removed optional inputs from subgraph input list.
- Exclude empty shape related nodes from TRT subgraph
   TRT doesn't support empty shape in current release. When a model has Nonzero op, there is a chance that Nonzero's output has empty shape during runtime. This mostly happened in RCNN models. As a workaround this PR excluded empty shape related nodes from TRT subgraph. New TRT release 7.1 will fix the issue and support empty shape.
