### PR TITLE
Add check to prevent storing nullptr in value_info_ when proto has unused value info

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2530,7 +2530,9 @@ Status Graph::SetGraphInputsOutputs() {
     for (auto& graph_value_info : graph_proto_->value_info()) {
       auto& name = graph_value_info.name();
       const auto* node_arg = GetNodeArg(name);
-      value_info_.push_back(node_arg);
+      if (node_arg != nullptr) {
+        value_info_.push_back(node_arg);
+      }
     }
 
   } else {


### PR DESCRIPTION
See issue #3430, repeated here for convenience:

Consider a model that contains unused value_info entries. When this model is loaded into onnxruntime, the following snippet in graph.cc:2536 will be called

```
    for (auto& graph_value_info : graph_proto_->value_info()) {
      auto& name = graph_value_info.name();
      const auto* node_arg = GetNodeArg(name);
      value_info_.push_back(node_arg);
    }
```
Note that if `name` is never used, `GetNodeArg` will return a `nullptr` which will be pushed into the `value_info_` array. Subsequently, if any graph transform modifies the graph such that a `GraphProtoSync()` is needed (as checked in `ToGraphProto()`), then we call into `ToGraphProtoInternal(ONNX_NAMESPACE::GraphProto& graph_proto)`. In this method we have

```
  for (const auto* value_info : value_info_) {
    *(graph_proto.mutable_value_info()->Add()) = value_info->ToProto();
  }
```
where we will attempt to dereference the `nullptr` we had previously added to the `value_info` array and crash.

Since value_info for an edge that does not exist can be safely removed, a simple null check before adding guards against this.
