### PR TITLE
[Java] Add support for map and sequence information on output nodes

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java'
+	id 'jacoco'
 	id 'com.diffplug.gradle.spotless' version '3.26.0'
 }
 
@@ -105,7 +106,6 @@ if (cmakeBuildDir != null) {
 
 }
 
-
 dependencies {
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.1'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.1'
@@ -116,5 +116,13 @@ test {
 	useJUnitPlatform()
 	testLogging {
 		events "passed", "skipped", "failed"
+	}
+}
+
+jacocoTestReport {
+	reports {
+		xml.enabled true
+		csv.enabled true
+		html.destination file("${buildDir}/jacocoHtml")
 	}
 }

--- a/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
@@ -22,6 +22,8 @@ final class OnnxRuntime {
 
   // The initial release of the ORT API.
   private static final int ORT_API_VERSION_1 = 1;
+  // Post 1.0 builds of the ORT API.
+  private static final int ORT_API_VERSION_2 = 2;
 
   /** The short name of the ONNX runtime shared library */
   static final String ONNXRUNTIME_LIBRARY_NAME = "onnxruntime";
@@ -48,7 +50,7 @@ final class OnnxRuntime {
     try {
       load(tempDirectory, ONNXRUNTIME_LIBRARY_NAME);
       load(tempDirectory, ONNXRUNTIME_JNI_LIBRARY_NAME);
-      ortApiHandle = initialiseAPIBase(ORT_API_VERSION_1);
+      ortApiHandle = initialiseAPIBase(ORT_API_VERSION_2);
       loaded = true;
     } finally {
       if (!isAndroid()) {

--- a/java/src/main/java/ai/onnxruntime/SequenceInfo.java
+++ b/java/src/main/java/ai/onnxruntime/SequenceInfo.java
@@ -49,7 +49,7 @@ public class SequenceInfo implements ValueInfo {
   }
 
   /**
-   * Constructs a sequence of known lenght containing maps.
+   * Constructs a sequence of known length containing maps.
    *
    * @param length The length of the sequence.
    * @param keyType The map key type.

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -205,10 +205,14 @@ jobject convertToValueInfo(JNIEnv *jniEnv, const OrtApi * api, OrtTypeInfo * inf
             return convertToTensorInfo(jniEnv, api, (const OrtTensorTypeAndShapeInfo *) tensorInfo);
         }
         case ONNX_TYPE_SEQUENCE: {
-            return createEmptySequenceInfo(jniEnv);
+            const OrtSequenceTypeInfo* sequenceInfo;
+            checkOrtStatus(jniEnv,api,api->CastTypeInfoToSequenceTypeInfo(info,&sequenceInfo));
+            return convertToSequenceInfo(jniEnv, api, sequenceInfo);
         }
         case ONNX_TYPE_MAP: {
-            return createEmptyMapInfo(jniEnv);
+            const OrtMapTypeInfo* mapInfo;
+            checkOrtStatus(jniEnv,api,api->CastTypeInfoToMapTypeInfo(info,&mapInfo));
+            return convertToMapInfo(jniEnv, api, mapInfo);
         }
         case ONNX_TYPE_UNKNOWN:
         case ONNX_TYPE_OPAQUE:
@@ -261,8 +265,56 @@ jobject convertToTensorInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtTensorT
     return tensorInfo;
 }
 
-//jobject convertToMapInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtTypeInfo * info) {
-// As map info isn't available at this point, it creates an empty map info type.
+jobject convertToMapInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtMapTypeInfo * info) {
+    // Create the java methods we need to call.
+    // Get the ONNXTensorType enum static method
+    char *onnxTensorTypeClassName = "ai/onnxruntime/TensorInfo$OnnxTensorType";
+    jclass onnxTensorTypeClazz = (*jniEnv)->FindClass(jniEnv, onnxTensorTypeClassName);
+    jmethodID onnxTensorTypeMapFromInt = (*jniEnv)->GetStaticMethodID(jniEnv,onnxTensorTypeClazz, "mapFromInt", "(I)Lai/onnxruntime/TensorInfo$OnnxTensorType;");
+
+    // Get the ONNXJavaType enum static method
+    char *javaDataTypeClassName = "ai/onnxruntime/OnnxJavaType";
+    jclass onnxJavaTypeClazz = (*jniEnv)->FindClass(jniEnv, javaDataTypeClassName);
+    jmethodID onnxJavaTypeMapFromONNXTensorType = (*jniEnv)->GetStaticMethodID(jniEnv,onnxJavaTypeClazz, "mapFromOnnxTensorType", "(Lai/onnxruntime/TensorInfo$OnnxTensorType;)Lai/onnxruntime/OnnxJavaType;");
+
+    // Get the map info class
+    char *mapInfoClassName = "ai/onnxruntime/MapInfo";
+    jclass mapInfoClazz = (*jniEnv)->FindClass(jniEnv, mapInfoClassName);
+    jmethodID mapInfoConstructor = (*jniEnv)->GetMethodID(jniEnv,mapInfoClazz,"<init>","(ILai/onnxruntime/OnnxJavaType;Lai/onnxruntime/OnnxJavaType;)V");
+
+    // Extract the key type
+    ONNXTensorElementDataType keyType;
+    checkOrtStatus(jniEnv,api,api->GetMapKeyType(info,&keyType));
+
+    // Convert key type to java
+    jint onnxTypeKey = convertFromONNXDataFormat(keyType);
+    jobject onnxTensorTypeJavaKey = (*jniEnv)->CallStaticObjectMethod(jniEnv,onnxTensorTypeClazz,onnxTensorTypeMapFromInt,onnxTypeKey);
+    jobject onnxJavaTypeKey = (*jniEnv)->CallStaticObjectMethod(jniEnv,onnxJavaTypeClazz,onnxJavaTypeMapFromONNXTensorType,onnxTensorTypeJavaKey);
+
+    // according to include/onnxruntime/core/framework/data_types.h only the following values are supported.
+    // string, int64, float, double
+    // So extract the value type, then convert it to a tensor type so we can get it's element type.
+    OrtTypeInfo* valueTypeInfo;
+    checkOrtStatus(jniEnv,api,api->GetMapValueType(info,&valueTypeInfo));
+    const OrtTensorTypeAndShapeInfo* tensorValueInfo;
+    checkOrtStatus(jniEnv,api,api->CastTypeInfoToTensorInfo(valueTypeInfo,&tensorValueInfo));
+    ONNXTensorElementDataType valueType;
+    checkOrtStatus(jniEnv,api,api->GetTensorElementType(tensorValueInfo,&valueType));
+    api->ReleaseTypeInfo(valueTypeInfo);
+    tensorValueInfo = NULL;
+    valueTypeInfo = NULL;
+
+    // Convert value type to java
+    jint onnxTypeValue = convertFromONNXDataFormat(valueType);
+    jobject onnxTensorTypeJavaValue = (*jniEnv)->CallStaticObjectMethod(jniEnv,onnxTensorTypeClazz,onnxTensorTypeMapFromInt,onnxTypeValue);
+    jobject onnxJavaTypeValue = (*jniEnv)->CallStaticObjectMethod(jniEnv,onnxJavaTypeClazz,onnxJavaTypeMapFromONNXTensorType,onnxTensorTypeJavaValue);
+
+    // Construct map info
+    jobject mapInfo = (*jniEnv)->NewObject(jniEnv,mapInfoClazz,mapInfoConstructor,(jint)-1,onnxJavaTypeKey,onnxJavaTypeValue);
+
+    return mapInfo;
+}
+
 jobject createEmptyMapInfo(JNIEnv *jniEnv) {
     // Create the ONNXJavaType enum
     char *onnxJavaTypeClassName = "ai/onnxruntime/OnnxJavaType";
@@ -278,8 +330,72 @@ jobject createEmptyMapInfo(JNIEnv *jniEnv) {
     return mapInfo;
 }
 
-//jobject convertToSequenceInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtTypeInfo * info) {
-// As sequence info isn't available at this point, it creates an empty sequence info type.
+jobject convertToSequenceInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtSequenceTypeInfo * info) {
+    // Get the sequence info class
+    char *sequenceInfoClassName = "ai/onnxruntime/SequenceInfo";
+    jclass sequenceInfoClazz = (*jniEnv)->FindClass(jniEnv, sequenceInfoClassName);
+
+    // according to include/onnxruntime/core/framework/data_types.h the following values are supported.
+    // tensor types, map<string,float> and map<long,float>
+    OrtTypeInfo* elementTypeInfo;
+    checkOrtStatus(jniEnv,api,api->GetSequenceElementType(info,&elementTypeInfo));
+    ONNXType type;
+    checkOrtStatus(jniEnv,api,api->GetOnnxTypeFromTypeInfo(elementTypeInfo,&type));
+
+    jobject sequenceInfo;
+
+    switch (type) {
+        case ONNX_TYPE_TENSOR: {
+            // Figure out element type
+            const OrtTensorTypeAndShapeInfo* elementTensorInfo;
+            checkOrtStatus(jniEnv,api,api->CastTypeInfoToTensorInfo(elementTypeInfo,&elementTensorInfo));
+            ONNXTensorElementDataType element;
+            checkOrtStatus(jniEnv,api,api->GetTensorElementType(elementTensorInfo,&element));
+
+            // Convert element type into ONNXTensorType
+            jint onnxTypeInt = convertFromONNXDataFormat(element);
+            // Get the ONNXTensorType enum static method
+            char *onnxTensorTypeClassName = "ai/onnxruntime/TensorInfo$OnnxTensorType";
+            jclass onnxTensorTypeClazz = (*jniEnv)->FindClass(jniEnv, onnxTensorTypeClassName);
+            jmethodID onnxTensorTypeMapFromInt = (*jniEnv)->GetStaticMethodID(jniEnv,onnxTensorTypeClazz, "mapFromInt", "(I)Lai/onnxruntime/TensorInfo$OnnxTensorType;");
+            jobject onnxTensorTypeJava = (*jniEnv)->CallStaticObjectMethod(jniEnv,onnxTensorTypeClazz,onnxTensorTypeMapFromInt,onnxTypeInt);
+
+            // Get the ONNXJavaType enum static method
+            char *javaDataTypeClassName = "ai/onnxruntime/OnnxJavaType";
+            jclass onnxJavaTypeClazz = (*jniEnv)->FindClass(jniEnv, javaDataTypeClassName);
+            jmethodID onnxJavaTypeMapFromONNXTensorType = (*jniEnv)->GetStaticMethodID(jniEnv,onnxJavaTypeClazz, "mapFromOnnxTensorType", "(Lai/onnxruntime/TensorInfo$OnnxTensorType;)Lai/onnxruntime/OnnxJavaType;");
+            jobject onnxJavaType = (*jniEnv)->CallStaticObjectMethod(jniEnv,onnxJavaTypeClazz,onnxJavaTypeMapFromONNXTensorType,onnxTensorTypeJava);
+
+            // Construct sequence info
+            jmethodID sequenceInfoConstructor = (*jniEnv)->GetMethodID(jniEnv,sequenceInfoClazz,"<init>","(ILai/onnxruntime/OnnxJavaType;)V");
+            sequenceInfo = (*jniEnv)->NewObject(jniEnv,sequenceInfoClazz,sequenceInfoConstructor,(jint)-1,onnxJavaType);
+            break;
+        }
+        case ONNX_TYPE_MAP: {
+            // Extract the map info
+            const OrtMapTypeInfo* mapInfo;
+            checkOrtStatus(jniEnv,api,api->CastTypeInfoToMapTypeInfo(elementTypeInfo,&mapInfo));
+
+            // Convert it using the existing convert function
+            jobject javaMapInfo = convertToMapInfo(jniEnv,api,mapInfo);
+
+            // Construct sequence info
+            jmethodID sequenceInfoConstructor = (*jniEnv)->GetMethodID(jniEnv,sequenceInfoClazz,"<init>","(ILai/onnxruntime/MapInfo;)V");
+            sequenceInfo = (*jniEnv)->NewObject(jniEnv,sequenceInfoClazz,sequenceInfoConstructor,(jint)-1,javaMapInfo);
+            break;
+        }
+        default: {
+            sequenceInfo = createEmptySequenceInfo(jniEnv);
+            throwOrtException(jniEnv,convertErrorCode(ORT_INVALID_ARGUMENT),"Invalid element type found in sequence");
+            break;
+        }
+    }
+    api->ReleaseTypeInfo(elementTypeInfo);
+    elementTypeInfo = NULL;
+
+    return sequenceInfo;
+}
+
 jobject createEmptySequenceInfo(JNIEnv *jniEnv) {
     // Create the ONNXJavaType enum
     char *onnxJavaTypeClassName = "ai/onnxruntime/OnnxJavaType";

--- a/java/src/main/native/OrtJniUtil.h
+++ b/java/src/main/native/OrtJniUtil.h
@@ -31,9 +31,8 @@ jobject convertToValueInfo(JNIEnv *jniEnv, const OrtApi * api, OrtTypeInfo * inf
 
 jobject convertToTensorInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtTensorTypeAndShapeInfo * info);
 
-//TODO when C API supports inspecting the types of map and sequence types from OutputInfos
-//jobject convertToMapInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtTypeInfo * info);
-//jobject convertToSequenceInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtTypeInfo * info);
+jobject convertToMapInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtMapTypeInfo * info);
+jobject convertToSequenceInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtSequenceTypeInfo * info);
 
 jobject createEmptyMapInfo(JNIEnv *jniEnv);
 jobject createEmptySequenceInfo(JNIEnv *jniEnv);

--- a/java/src/main/native/ai_onnxruntime_OrtSession.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession.c
@@ -14,8 +14,8 @@
  * Signature: (JJLjava/lang/String;J)J
  */
 JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtSession_createSession__JJLjava_lang_String_2J
-  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong envHandle, jstring modelPath, jlong optsHandle) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+  (JNIEnv * jniEnv, jclass jclazz, jlong apiHandle, jlong envHandle, jstring modelPath, jlong optsHandle) {
+    (void) jclazz; // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtSession* session;
 
@@ -43,8 +43,8 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtSession_createSession__JJLjava_la
  * Signature: (JJ[BJ)J
  */
 JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtSession_createSession__JJ_3BJ
-  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong envHandle, jbyteArray jModelArray, jlong optsHandle) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+  (JNIEnv * jniEnv, jclass jclazz, jlong apiHandle, jlong envHandle, jbyteArray jModelArray, jlong optsHandle) {
+    (void) jclazz; // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtSession* session;
 

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -917,10 +917,10 @@ public class InferenceTest {
       assertEquals(OnnxJavaType.INT64, ((TensorInfo) firstOutputInfo.getInfo()).type);
       assertTrue(((SequenceInfo) secondOutputInfo.getInfo()).sequenceOfMaps);
       assertEquals(OnnxJavaType.UNKNOWN, ((SequenceInfo) secondOutputInfo.getInfo()).sequenceType);
-      MapInfo mapInfo = ((SequenceInfo)secondOutputInfo.getInfo()).mapInfo;
+      MapInfo mapInfo = ((SequenceInfo) secondOutputInfo.getInfo()).mapInfo;
       assertNotNull(mapInfo);
-      assertEquals(OnnxJavaType.INT64,mapInfo.keyType);
-      assertEquals(OnnxJavaType.FLOAT,mapInfo.valueType);
+      assertEquals(OnnxJavaType.INT64, mapInfo.keyType);
+      assertEquals(OnnxJavaType.FLOAT, mapInfo.valueType);
 
       Map<String, OnnxTensor> container = new HashMap<>();
       long[] shape = new long[] {1, 2};
@@ -983,10 +983,10 @@ public class InferenceTest {
       assertEquals(OnnxJavaType.STRING, ((TensorInfo) firstOutputInfo.getInfo()).type);
       assertTrue(((SequenceInfo) secondOutputInfo.getInfo()).sequenceOfMaps);
       assertEquals(OnnxJavaType.UNKNOWN, ((SequenceInfo) secondOutputInfo.getInfo()).sequenceType);
-      MapInfo mapInfo = ((SequenceInfo)secondOutputInfo.getInfo()).mapInfo;
+      MapInfo mapInfo = ((SequenceInfo) secondOutputInfo.getInfo()).mapInfo;
       assertNotNull(mapInfo);
-      assertEquals(OnnxJavaType.STRING,mapInfo.keyType);
-      assertEquals(OnnxJavaType.FLOAT,mapInfo.valueType);
+      assertEquals(OnnxJavaType.STRING, mapInfo.keyType);
+      assertEquals(OnnxJavaType.FLOAT, mapInfo.valueType);
 
       Map<String, OnnxTensor> container = new HashMap<>();
       long[] shape = new long[] {1, 2};

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -915,6 +915,12 @@ public class InferenceTest {
       assertTrue(firstOutputInfo.getInfo() instanceof TensorInfo);
       assertTrue(secondOutputInfo.getInfo() instanceof SequenceInfo);
       assertEquals(OnnxJavaType.INT64, ((TensorInfo) firstOutputInfo.getInfo()).type);
+      assertTrue(((SequenceInfo) secondOutputInfo.getInfo()).sequenceOfMaps);
+      assertEquals(OnnxJavaType.UNKNOWN, ((SequenceInfo) secondOutputInfo.getInfo()).sequenceType);
+      MapInfo mapInfo = ((SequenceInfo)secondOutputInfo.getInfo()).mapInfo;
+      assertNotNull(mapInfo);
+      assertEquals(OnnxJavaType.INT64,mapInfo.keyType);
+      assertEquals(OnnxJavaType.FLOAT,mapInfo.valueType);
 
       Map<String, OnnxTensor> container = new HashMap<>();
       long[] shape = new long[] {1, 2};
@@ -975,6 +981,12 @@ public class InferenceTest {
       assertTrue(firstOutputInfo.getInfo() instanceof TensorInfo);
       assertTrue(secondOutputInfo.getInfo() instanceof SequenceInfo);
       assertEquals(OnnxJavaType.STRING, ((TensorInfo) firstOutputInfo.getInfo()).type);
+      assertTrue(((SequenceInfo) secondOutputInfo.getInfo()).sequenceOfMaps);
+      assertEquals(OnnxJavaType.UNKNOWN, ((SequenceInfo) secondOutputInfo.getInfo()).sequenceType);
+      MapInfo mapInfo = ((SequenceInfo)secondOutputInfo.getInfo()).mapInfo;
+      assertNotNull(mapInfo);
+      assertEquals(OnnxJavaType.STRING,mapInfo.keyType);
+      assertEquals(OnnxJavaType.FLOAT,mapInfo.valueType);
 
       Map<String, OnnxTensor> container = new HashMap<>();
       long[] shape = new long[] {1, 2};


### PR DESCRIPTION
**Description**: 
The C API now exposes methods to inspect map and sequence output nodes, to figure out the types of the variables. This PR plumbs these methods through into the Java API, replacing the empty SequenceInfo and MapInfo that used to be created when the user asked about the output node information.

The sizes are returned as `-1` as there isn't a way to access length information without having an instance of the type (and it might be dynamic).

It also adds support for the [Jacoco test coverage runner](https://docs.gradle.org/current/userguide/jacoco_plugin.html) into the build.gradle. This can be executed with `gradle -DcmakeBuildDir=$cmakeBuildDir test jacocoTestReport` from within the java directory. It's not plumbed into any of the build pipelines as I'm not sure which one is appropriate.

**Motivation and Context**
- Why is this change required? What problem does it solve? Adds support for new C API features into Java.
