### PR TITLE
remove unnessary include to work around the GPU pipeline break

### DIFF
--- a/onnxruntime/core/providers/cuda/math/topk_impl.cu
+++ b/onnxruntime/core/providers/cuda/math/topk_impl.cu
@@ -5,7 +5,6 @@
 #include "core/providers/cuda/cu_inc/common.cuh"
 #include "device_atomic_functions.h"
 #include "cub/cub.cuh"
-#include "cub/util_type.cuh"
 #include "cub/util_allocator.cuh"
 #include "cub/device/device_radix_sort.cuh"
 #include <limits>


### PR DESCRIPTION
Windows GPU Debug build pipeline fails with error: 
[error]cmake\external\cub\cub\util_type.cuh(898,0): Error C2993: 'T': illegal type for non-type template parameter '__formal'

Looks like removing the util_type.cuh can work around the break. It should be a bug in nvcc. Don’t know how it is triggered recently.
