### PR TITLE
Improve error logging when a kernel cannot be found.

### DIFF
--- a/onnxruntime/core/framework/kernel_registry.cc
+++ b/onnxruntime/core/framework/kernel_registry.cc
@@ -171,7 +171,7 @@ bool KernelRegistry::VerifyKernelDef(const onnxruntime::Node& node,
     // valid names (of types or parameters) at the time that kernels are registered.
     if (nullptr != actual_type) {
       bool is_type_compatible = std::any_of(allowed_types.begin(), allowed_types.end(),
-                                            [actual_type, &node, &error_str](const DataTypeImpl* expected_type) {
+                                            [actual_type](const DataTypeImpl* expected_type) {
                                               bool rc = expected_type->IsCompatible(*actual_type);  // for easier debugging
                                               return rc;
                                             });


### PR DESCRIPTION
**Description**: Improve error logging when a kernel cannot be found.

**Motivation and Context**
This has come up multiple times. We don't implement all types for ops. Hence when a kernel cannot be found for this op, we report an error saying 'Could not find an implementation for the node'. Even in verbose logging we only log 'Incompatible types'. This is hardly useful.
Fixes [this](https://msdata.visualstudio.com/Vienna/_workitems/edit/634477).