### PR TITLE
Publish unit test results from Linux and Mac builds

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/linux-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-ci.yml
@@ -31,7 +31,7 @@ jobs:
     - task: PublishTestResults@2
       displayName: 'Publish unit test results'
       inputs:
-        testResultsFiles: '**\*.results.xml'
+        testResultsFiles: '**/*.results.xml'
         searchFolder: '$(Build.BinariesDirectory)'
         testRunTitle: 'Unit Test Run'
       condition: succeededOrFailed()

--- a/tools/ci_build/github/azure-pipelines/templates/linux-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-ci.yml
@@ -28,6 +28,13 @@ jobs:
     - template: linux-set-variables-and-download.yml
     - script: ${{ parameters.BuildCommand }}
       displayName: 'Command Line Script'
+    - task: PublishTestResults@2
+      displayName: 'Publish unit test results'
+      inputs:
+        testResultsFiles: '**\*.results.xml'
+        searchFolder: '$(Build.BinariesDirectory)'
+        testRunTitle: 'Unit Test Run'
+      condition: succeededOrFailed()
     - ${{ if eq(parameters['DoNugetPack'], 'true') }}:
       - script: |
          ${{ parameters.NuPackScript }}

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -31,7 +31,7 @@ jobs:
     - task: PublishTestResults@2
       displayName: 'Publish unit test results'
       inputs:
-        testResultsFiles: '**\*.results.xml'
+        testResultsFiles: '**/*.results.xml'
         searchFolder: '$(Build.BinariesDirectory)'
         testRunTitle: 'Unit Test Run'
       condition: succeededOrFailed()

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -28,6 +28,13 @@ jobs:
         sudo xcode-select --switch /Applications/Xcode_10.app/Contents/Developer
         ${{ parameters.BuildCommand }}
       displayName: 'Build and Test OnnxRuntime lib for MacOS'
+    - task: PublishTestResults@2
+      displayName: 'Publish unit test results'
+      inputs:
+        testResultsFiles: '**\*.results.xml'
+        searchFolder: '$(Build.BinariesDirectory)'
+        testRunTitle: 'Unit Test Run'
+      condition: succeededOrFailed()
     - ${{ if eq(parameters['DoNugetPack'], 'true') }}:
       - script: |
          ${{ parameters.NuPackScript }}


### PR DESCRIPTION
**Description**
Add publishing of unit test results from Linux and Mac builds.

**Motivation and Context**
Publishing the test results makes it easier to observe test failures.