### PR TITLE
Fix WindowsAI build

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -551,7 +551,9 @@ if (onnxruntime_USE_DML)
   set(delayload_dml "/DELAYLOAD:directml.dll")
 endif(onnxruntime_USE_DML)
 
-target_link_options(winml_dll PRIVATE /DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags} /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:api-ms-win-core-threadpool-legacy-l1-1-0.dll /DELAYLOAD:api-ms-win-core-processtopology-obsolete-l1-1-0.dll /DELAYLOAD:api-ms-win-core-kernel32-legacy-l1-1-0.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll ${delayload_dml})
+set(os_component_link_flags_list ${os_component_link_flags})
+separate_arguments(os_component_link_flags_list)
+target_link_options(winml_dll PRIVATE /DEF:${WINML_DIR}/windows.ai.machinelearning.def ${os_component_link_flags_list} /DELAYLOAD:api-ms-win-core-libraryloader-l1-2-1.dll /DELAYLOAD:api-ms-win-core-threadpool-legacy-l1-1-0.dll /DELAYLOAD:api-ms-win-core-processtopology-obsolete-l1-1-0.dll /DELAYLOAD:api-ms-win-core-kernel32-legacy-l1-1-0.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:d3d11.dll /DELAYLOAD:dxgi.dll ${delayload_dml})
 
 if (EXISTS ${dxcore_header})
   target_link_options(winml_dll PRIVATE /DELAYLOAD:ext-ms-win-dxcore-l1-*.dll)


### PR DESCRIPTION
**Description**: Fix internal WindowsAI build break introduced with the delayload flags.

`os_component_link_flags` is set to `"/DEBUGTYPE:CV,FIXUP /INCREMENTAL:NO"` in internal builds. `target_link_options` receives a list of options, and adding the string `"/DEBUGTYPE:CV,FIXUP /INCREMENTAL:NO"` is invalid; it has to be split into two options first.