### PR TITLE
fix python cpu package manylinux1 build break.

### DIFF
--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux1
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux1
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux1_x86_64:latest
+FROM quay.io/pypa/manylinux1_x86_64:2020-04-01-7a4ddf4
 
 ARG PYTHON_VERSION
 ADD scripts /tmp/scripts


### PR DESCRIPTION
python cpu packaging pipelines recently started failing with the following error

```
Installing cmake 
Downloading https://github.com/Kitware/CMake/releases/download/v3.13.5/cmake-3.13.5.tar.gz 
curl: option --retry-delay: expected a positive numerical parameter 
curl: try 'curl --help' for more information 
The command '/bin/sh -c cd /tmp/scripts && /tmp/scripts/install_centos.sh && /tmp/scripts/install_deps.sh -p $PYTHON_VERSION && rm -rf /tmp/scripts' returned a non-zero code: 2 
##[error]Bash exited with code '2'. 
Finishing: CmdLine 
```

debugged and found this is due to something in the base image changing which breaks our build.
previously we pull  quay.io/pypa/manylinux1_x86_64:latest
to work around the issue, we specify the tag of the last working version 2020-04-01-7a4ddf4


