### PR TITLE
Optionally produce a python wheel that includes featurizers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,11 +205,10 @@ if nightly_build:
     else:
       build_suffix = build_suffix.replace('.','')
 
-    if wheel_name_suffix:
-        build_suffix += ".{}".format(wheel_name_suffix)
-
     version_number = version_number + ".dev" + build_suffix
 
+if wheel_name_suffix:
+    package_name = "{}-{}".format(package_name, wheel_name_suffix)
 
 cmd_classes = {}
 if bdist_wheel is not None :

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ import datetime
 
 nightly_build = False
 package_name = 'onnxruntime'
+wheel_version = None
 
 if '--use_tensorrt' in sys.argv:
     package_name = 'onnxruntime-gpu-tensorrt'
@@ -34,7 +35,7 @@ elif '--use_cuda' in sys.argv:
 elif '--use_ngraph' in sys.argv:
     package_name = 'onnxruntime-ngraph'
     sys.argv.remove('--use_ngraph')
-    
+
 elif '--use_dnnl' in sys.argv:
     package_name = 'onnxruntime-dnnl'
     sys.argv.remove('--use_dnnl')
@@ -50,6 +51,15 @@ if '--nightly_build' in sys.argv:
     package_name = 'ort-nightly'
     nightly_build = True
     sys.argv.remove('--nightly_build')
+
+for arg in sys.argv[1:]:
+    if arg.startswith("--wheel_version="):
+        wheel_version = arg[len("--wheel_version="):]
+        nightly_build = True
+
+        sys.argv.remove(arg)
+
+        break
 
 is_manylinux1 = False
 if environ.get('AUDITWHEEL_PLAT', None) == 'manylinux1_x86_64' or environ.get('AUDITWHEEL_PLAT', None) == 'manylinux2010_x86_64' :
@@ -188,13 +198,13 @@ with open('VERSION_NUMBER') as f:
     version_number = f.readline().strip()
 if nightly_build:
     #https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables
-    date_suffix = environ.get('BUILD_BUILDNUMBER')
-    if date_suffix is None:
+    build_suffix = wheel_version or environ.get('BUILD_BUILDNUMBER')
+    if build_suffix is None:
       #The following line is only for local testing
-      date_suffix = str(datetime.datetime.now().date().strftime("%Y%m%d"))
+      build_suffix = str(datetime.datetime.now().date().strftime("%Y%m%d"))
     else:
-      date_suffix = date_suffix.replace('.','')
-    version_number = version_number + ".dev" + date_suffix
+      build_suffix = build_suffix.replace('.','')
+    version_number = version_number + ".dev" + build_suffix
 
 cmd_classes = {}
 if bdist_wheel is not None :

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import datetime
 
 nightly_build = False
 package_name = 'onnxruntime'
-wheel_version = None
+wheel_name_suffix = None
 
 if '--use_tensorrt' in sys.argv:
     package_name = 'onnxruntime-gpu-tensorrt'
@@ -53,8 +53,8 @@ if '--nightly_build' in sys.argv:
     sys.argv.remove('--nightly_build')
 
 for arg in sys.argv[1:]:
-    if arg.startswith("--wheel_version="):
-        wheel_version = arg[len("--wheel_version="):]
+    if arg.startswith("--wheel_name_suffix="):
+        wheel_name_suffix = arg[len("--wheel_name_suffix="):]
         nightly_build = True
 
         sys.argv.remove(arg)
@@ -198,13 +198,18 @@ with open('VERSION_NUMBER') as f:
     version_number = f.readline().strip()
 if nightly_build:
     #https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables
-    build_suffix = wheel_version or environ.get('BUILD_BUILDNUMBER')
+    build_suffix = environ.get('BUILD_BUILDNUMBER')
     if build_suffix is None:
       #The following line is only for local testing
       build_suffix = str(datetime.datetime.now().date().strftime("%Y%m%d"))
     else:
       build_suffix = build_suffix.replace('.','')
+
+    if wheel_name_suffix:
+        build_suffix += ".{}".format(wheel_name_suffix)
+
     version_number = version_number + ".dev" + build_suffix
+
 
 cmd_classes = {}
 if bdist_wheel is not None :

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,7 @@ if nightly_build:
     version_number = version_number + ".dev" + build_suffix
 
 if wheel_name_suffix:
-    package_name = "{}-{}".format(package_name, wheel_name_suffix)
+    package_name = "{}_{}".format(package_name, wheel_name_suffix)
 
 cmd_classes = {}
 if bdist_wheel is not None :

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -91,8 +91,8 @@ Use the individual flags to only run the specified stages.
     # Python bindings
     parser.add_argument("--enable_pybind", action='store_true', help="Enable Python Bindings.")
     parser.add_argument("--build_wheel", action='store_true', help="Build Python Wheel. ")
-    parser.add_argument("--wheel_version", help="Version number to use when creating the Wheel."
-                                                "This value is currently only used for nightly builds; official builds use the value stored in the file 'VERSION_NUMBER'.")
+    parser.add_argument("--wheel_name_suffix", help="Suffix to append to created wheel names."
+                                                "This value is currently only used for nightly builds.")
     parser.add_argument("--numpy_version", help="Installs a specific version of numpy "
                         "before building the python binding.")
     parser.add_argument("--skip-keras-test", action='store_true', help="Skip tests with Keras if keras is installed")
@@ -807,7 +807,7 @@ def nuphar_run_python_tests(build_dir, configs):
         run_subprocess([sys.executable, 'onnxruntime_test_python_nuphar.py'], cwd=cwd, dll_path=dll_path)
 
 
-def build_python_wheel(source_dir, build_dir, configs, use_cuda, use_ngraph, use_dnnl, use_tensorrt, use_openvino, use_nuphar, wheel_version, nightly_build = False):
+def build_python_wheel(source_dir, build_dir, configs, use_cuda, use_ngraph, use_dnnl, use_tensorrt, use_openvino, use_nuphar, wheel_name_suffix, nightly_build = False):
     for config in configs:
         cwd = get_config_build_dir(build_dir, config)
         if is_windows():
@@ -827,8 +827,8 @@ def build_python_wheel(source_dir, build_dir, configs, use_cuda, use_ngraph, use
             args.append('--use_openvino')
         elif use_nuphar:
             args.append('--use_nuphar')
-        if wheel_version:
-            args.append('--wheel_version={}'.format(wheel_version))
+        if wheel_name_suffix:
+            args.append('--wheel_name_suffix={}'.format(wheel_name_suffix))
 
         run_subprocess(args, cwd=cwd)
 
@@ -1094,7 +1094,7 @@ def main():
                 args.use_tensorrt,
                 args.use_openvino,
                 args.use_nuphar,
-                args.wheel_version,
+                args.wheel_name_suffix,
                 nightly_build=nightly_build,
             )
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -91,6 +91,8 @@ Use the individual flags to only run the specified stages.
     # Python bindings
     parser.add_argument("--enable_pybind", action='store_true', help="Enable Python Bindings.")
     parser.add_argument("--build_wheel", action='store_true', help="Build Python Wheel. ")
+    parser.add_argument("--wheel_version", help="Version number to use when creating the Wheel."
+                                                "This value is currently only used for nightly builds; official builds use the value stored in the file 'VERSION_NUMBER'.")
     parser.add_argument("--numpy_version", help="Installs a specific version of numpy "
                         "before building the python binding.")
     parser.add_argument("--skip-keras-test", action='store_true', help="Skip tests with Keras if keras is installed")
@@ -805,7 +807,7 @@ def nuphar_run_python_tests(build_dir, configs):
         run_subprocess([sys.executable, 'onnxruntime_test_python_nuphar.py'], cwd=cwd, dll_path=dll_path)
 
 
-def build_python_wheel(source_dir, build_dir, configs, use_cuda, use_ngraph, use_dnnl, use_tensorrt, use_openvino, use_nuphar, nightly_build = False):
+def build_python_wheel(source_dir, build_dir, configs, use_cuda, use_ngraph, use_dnnl, use_tensorrt, use_openvino, use_nuphar, wheel_version, nightly_build = False):
     for config in configs:
         cwd = get_config_build_dir(build_dir, config)
         if is_windows():
@@ -825,6 +827,9 @@ def build_python_wheel(source_dir, build_dir, configs, use_cuda, use_ngraph, use
             args.append('--use_openvino')
         elif use_nuphar:
             args.append('--use_nuphar')
+        if wheel_version:
+            args.append('--wheel_version={}'.format(wheel_version))
+
         run_subprocess(args, cwd=cwd)
 
 def build_protoc_for_host(cmake_path, source_dir, build_dir, args):
@@ -1079,7 +1084,19 @@ def main():
     if args.build:
         if args.build_wheel:
             nightly_build = bool(os.getenv('NIGHTLY_BUILD') == '1')
-            build_python_wheel(source_dir, build_dir, configs, args.use_cuda, args.use_ngraph, args.use_dnnl, args.use_tensorrt, args.use_openvino, args.use_nuphar, nightly_build)
+            build_python_wheel(
+                source_dir,
+                build_dir,
+                configs,
+                args.use_cuda,
+                args.use_ngraph,
+                args.use_dnnl,
+                args.use_tensorrt,
+                args.use_openvino,
+                args.use_nuphar,
+                args.wheel_version,
+                nightly_build=nightly_build,
+            )
 
     if args.gen_doc and (args.build or args.test):
         generate_documentation(source_dir, build_dir, configs)

--- a/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
@@ -1,3 +1,9 @@
+parameters:
+- name: is_featurizers_build
+  displayName: "Is Featurizers Build"
+  type: boolean
+  default: false
+
 jobs:
 - job: Manylinux2010_py_Wheels
   workspace:
@@ -22,7 +28,15 @@ jobs:
         python.dir: '/opt/python/cp38-cp38'
         python.include.dir: '/opt/python/cp38-cp38/include/python3.8'
   steps:
+    - checkout: self
+      clean: true
+      submodules: recursive
+
     - template: templates/set-test-data-variables-step.yml
+
+    - template: templates/set-featurizer-build-flag-step.yml
+      parameters:
+        is_featurizers_build: ${{ parameters.is_featurizers_build }}
 
     - task: CmdLine@2
       displayName: 'Download azcopy'
@@ -47,7 +61,7 @@ jobs:
     - task: CmdLine@2
       inputs:
         script: |
-          docker run --rm --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build -e NIGHTLY_BUILD -e BUILD_BUILDNUMBER onnxruntime-manylinux-$(python.version) $(python.dir)/bin/python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync --parallel  --build_wheel --use_openmp --enable_onnx_tests --cmake_extra_defines PYTHON_INCLUDE_DIR=$(python.include.dir) PYTHON_LIBRARY=/usr/lib64/librt.so
+          docker run --rm --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build -e NIGHTLY_BUILD -e BUILD_BUILDNUMBER onnxruntime-manylinux-$(python.version) $(python.dir)/bin/python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync --parallel  --build_wheel --use_openmp --enable_onnx_tests $(FeaturizerBuildFlag) --cmake_extra_defines PYTHON_INCLUDE_DIR=$(python.include.dir) PYTHON_LIBRARY=/usr/lib64/librt.so
         workingDirectory: $(Build.SourcesDirectory)
 
     - task: CopyFiles@2
@@ -89,7 +103,15 @@ jobs:
         python.dir: '/opt/python/cp38-cp38'
         python.include.dir: '/opt/python/cp38-cp38/include/python3.8'
   steps:
+    - checkout: self
+      clean: true
+      submodules: recursive
+
     - template: templates/set-test-data-variables-step.yml
+
+    - template: templates/set-featurizer-build-flag-step.yml
+      parameters:
+        is_featurizers_build: ${{ parameters.is_featurizers_build }}
 
     - task: CmdLine@2
       displayName: 'Download azcopy'
@@ -114,7 +136,7 @@ jobs:
     - task: CmdLine@2
       inputs:
         script: |
-          docker run --gpus all -e NVIDIA_VISIBLE_DEVICES=all --rm --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build -e NIGHTLY_BUILD -e BUILD_BUILDNUMBER onnxruntime-manylinux-gpu-$(python.version) $(python.dir)/bin/python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync  --parallel   --build_wheel --use_openmp --enable_onnx_tests --cmake_extra_defines PYTHON_INCLUDE_DIR=$(python.include.dir) PYTHON_LIBRARY=/usr/lib64/librt.so --use_cuda --cuda_version=10.1 --cuda_home=/usr/local/cuda-10.1  --cudnn_home=/usr/local/cuda-10.1
+          docker run --gpus all -e NVIDIA_VISIBLE_DEVICES=all --rm --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build -e NIGHTLY_BUILD -e BUILD_BUILDNUMBER onnxruntime-manylinux-gpu-$(python.version) $(python.dir)/bin/python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync  --parallel   --build_wheel --use_openmp --enable_onnx_tests $(FeaturizerBuildFlag) --cmake_extra_defines PYTHON_INCLUDE_DIR=$(python.include.dir) PYTHON_LIBRARY=/usr/lib64/librt.so --use_cuda --cuda_version=10.1 --cuda_home=/usr/local/cuda-10.1  --cudnn_home=/usr/local/cuda-10.1
         workingDirectory: $(Build.SourcesDirectory)
 
     - task: CopyFiles@2
@@ -156,13 +178,22 @@ jobs:
   timeoutInMinutes: 60
   workspace:
     clean: all
-  steps:    
+
+  steps:
+  - checkout: self
+    clean: true
+    submodules: recursive
+
   - task: UsePythonVersion@0
-    inputs: 
-      versionSpec: $(python.version) 
-      addToPath: true 
+    inputs:
+      versionSpec: $(python.version)
+      addToPath: true
       architecture: 'x64'
   - template: templates/set-test-data-variables-step.yml
+
+  - template: templates/set-featurizer-build-flag-step.yml
+    parameters:
+      is_featurizers_build: ${{ parameters.is_featurizers_build }}
 
   - task: BatchScript@1
     displayName: 'setup env'
@@ -173,9 +204,9 @@ jobs:
 
   - script: |
      python -m pip install -q pyopenssl setuptools wheel numpy==1.18
-   
+
     workingDirectory: '$(Build.BinariesDirectory)'
-    displayName: 'Install python modules'        
+    displayName: 'Install python modules'
 
   - task: PythonScript@0
     displayName: 'Download test data'
@@ -188,9 +219,9 @@ jobs:
     displayName: 'BUILD'
     inputs:
       scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-      arguments: '--config RelWithDebInfo --enable_lto --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_generator "Visual Studio 16 2019" --build_wheel --use_openmp --enable_onnx_tests --parallel'
-      workingDirectory: '$(Build.BinariesDirectory)'     
-  
+      arguments: '--config RelWithDebInfo --enable_lto --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_generator "Visual Studio 16 2019" --build_wheel --use_openmp --enable_onnx_tests $(FeaturizerBuildFlag) --parallel'
+      workingDirectory: '$(Build.BinariesDirectory)'
+
   - task: CopyFiles@2
     displayName: 'Copy Python Wheel to: $(Build.ArtifactStagingDirectory)'
     inputs:
@@ -213,7 +244,7 @@ jobs:
   workspace:
     clean: all
   pool: 'Win-GPU-2019'
-  timeoutInMinutes:  60  
+  timeoutInMinutes:  60
   variables:
     CUDA_VERSION: '10.1'
     EnvSetupScript: setup_env_cuda.bat
@@ -226,10 +257,14 @@ jobs:
       Python37:
         python.version: '3.7'
   steps:
+    - checkout: self
+      clean: true
+      submodules: recursive
+
     - task: UsePythonVersion@0
-      inputs: 
-        versionSpec: $(python.version) 
-        addToPath: true 
+      inputs:
+        versionSpec: $(python.version)
+        addToPath: true
         architecture: 'x64'
 
     - task: BatchScript@1
@@ -246,6 +281,11 @@ jobs:
       displayName: 'Install python modules'
 
     - template: templates/set-test-data-variables-step.yml
+
+    - template: templates/set-featurizer-build-flag-step.yml
+      parameters:
+        is_featurizers_build: ${{ parameters.is_featurizers_build }}
+
     - task: PythonScript@0
       displayName: 'Download test data'
       inputs:
@@ -257,8 +297,8 @@ jobs:
       displayName: 'build'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-        arguments: --config RelWithDebInfo --enable_lto --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_generator "Visual Studio 16 2019" --build_wheel --use_openmp --enable_onnx_tests --parallel --use_cuda --cuda_version=$(CUDA_VERSION) --cuda_home="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$(CUDA_VERSION)" --cudnn_home="C:\local\cudnn-$(CUDA_VERSION)-windows10-x64-v7.6.5.32\cuda"
-        workingDirectory: '$(Build.BinariesDirectory)'   
+        arguments: --config RelWithDebInfo --enable_lto --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_generator "Visual Studio 16 2019" --build_wheel --use_openmp --enable_onnx_tests $(FeaturizerBuildFlag) --parallel --use_cuda --cuda_version=$(CUDA_VERSION) --cuda_home="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$(CUDA_VERSION)" --cudnn_home="C:\local\cudnn-$(CUDA_VERSION)-windows10-x64-v7.6.5.32\cuda"
+        workingDirectory: '$(Build.BinariesDirectory)'
 
     - task: CopyFiles@2
       displayName: 'Copy Python Wheel to: $(Build.ArtifactStagingDirectory)'
@@ -275,7 +315,7 @@ jobs:
     - template: templates/component-governance-component-detection-steps.yml
 
     - template: templates/clean-agent-build-directory-step.yml
-    
+
 - job: MacOS_py_Wheels
   workspace:
     clean: all
@@ -292,6 +332,10 @@ jobs:
       Python38:
         python.version: '3.8'
   steps:
+    - checkout: self
+      clean: true
+      submodules: recursive
+
     - task: UsePythonVersion@0
       displayName: 'Use Python'
       inputs:
@@ -301,8 +345,8 @@ jobs:
         sudo python -m pip install -r '$(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/requirements.txt'
         sudo xcode-select --switch /Applications/Xcode_10.app/Contents/Developer
         ./build.sh --config Release --skip_submodule_sync --parallel --build_wheel --use_openmp
-      displayName: 'Command Line Script' 
-      
+      displayName: 'Command Line Script'
+
     - task: CopyFiles@2
       displayName: 'Copy Python Wheel to: $(Build.ArtifactStagingDirectory)'
       inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/set-featurizer-build-flag-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/set-featurizer-build-flag-step.yml
@@ -1,0 +1,17 @@
+parameters:
+  is_featurizers_build: false
+
+steps:
+- task: PythonScript@0
+  displayName: "Set FeaturizerBuildFlag variable"
+  inputs:
+    scriptSource: inline
+    script: |-
+      import os
+
+      if "${{ parameters.is_featurizers_build }}".lower() == "true":
+        flags = "--use_featurizers --wheel_version=%sfeaturizer" % os.getenv("BUILD_BUILDNUMBER")
+      else:
+        flags = " "
+
+      print("##vso[task.setvariable variable=FeaturizerBuildFlag]%s" % flags)

--- a/tools/ci_build/github/azure-pipelines/templates/set-featurizer-build-flag-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/set-featurizer-build-flag-step.yml
@@ -10,8 +10,8 @@ steps:
       import os
 
       if "${{ parameters.is_featurizers_build }}".lower() == "true":
-        flags = "--use_featurizers --wheel_version=%sfeaturizer" % os.getenv("BUILD_BUILDNUMBER")
+        flags = "--use_featurizers --wheel_name_suffix=featurizer"
       else:
-        flags = " "
+        flags = ""
 
       print("##vso[task.setvariable variable=FeaturizerBuildFlag]%s" % flags)


### PR DESCRIPTION
**Description**: This change updates AzureDevOps yaml configurations to optionally produce python wheels that include featurizer builds. This functionality is opt it and will use a standard build by default. Also plumbed command line arguments through `build.py` and `setup.py` to decorate python wheel names associated with nightly builds (to distinguish between standard- and featurizer-based packages).

**Motivation and Context**
- Why is this change required? What problem does it solve?
This change is required to produce python packages that include featurizer code.

- If it fixes an open issue, please link to the issue here.
None
