### PR TITLE
Python install requires

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,5 @@ pytest
 pytest-cov
 scikit-learn
 scipy
-six
 sympy
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy >= 1.18.0
 onnx >= 1.2.3
 protobuf
-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-six
-numpy
+numpy >= 1.18.0
+onnx >= 1.2.3
 protobuf
+six

--- a/setup.py
+++ b/setup.py
@@ -201,7 +201,13 @@ if bdist_wheel is not None :
     cmd_classes['bdist_wheel'] = bdist_wheel
 cmd_classes['build_ext'] = build_ext
 
-with open('requirements.txt') as f:
+requirements_path = path.join(getcwd(), "requirements.txt")
+if not path.exists(requirements_path):
+    this = path.dirname(__file__)
+    requirements_path = path.join(this, "requirements.txt")
+if not path.exists(requirements_path):
+    raise FileNotFoundError("Unable to find 'requirements.txt'")
+with open(requirements_path) as f:
     install_requires = f.read().splitlines()
 
 # Setup

--- a/setup.py
+++ b/setup.py
@@ -201,6 +201,9 @@ if bdist_wheel is not None :
     cmd_classes['bdist_wheel'] = bdist_wheel
 cmd_classes['build_ext'] = build_ext
 
+with open('requirements.txt') as f:
+    install_requires = f.read().splitlines()
+
 # Setup
 setup(
     name=package_name,
@@ -222,10 +225,7 @@ setup(
         'onnxruntime': data + examples + extra,
     },
     py_modules=python_modules_list,
-    install_requires=[
-        'onnx>=1.2.3',
-        'numpy>=1.18.0'
-    ],
+    install_requires=install_requires,
     entry_points= {
         'console_scripts': [
             'onnxruntime_test = onnxruntime.tools.onnxruntime_test:main',


### PR DESCRIPTION
This PR ties the `requirements.txt` file directly to `install_requires` in `setup.py`. This is aimed at making it easier to keep the versions up to date, and to avoid either place getting stale. This PR also removes `six` as a requirement, since it does not appear to be used in the package. `protobuf` becomes a required package in `install_requires` based on this change.
