### PR TITLE
Fix crash in DequantizeLinear with scalar tensor

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantize_ops.cc
+++ b/onnxruntime/contrib_ops/cpu/quantize_ops.cc
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/providers/cpu/tensor/quantize_linear.h"
-#include "core/providers/common.h" 
-
+#include "core/providers/common.h"
 
 namespace onnxruntime {
 namespace contrib {
@@ -13,11 +12,8 @@ ONNX_CPU_OPERATOR_TYPED_MS_KERNEL(
     1,
     uint8_t,
     KernelDefBuilder()
-        .TypeConstraint("axis", DataTypeImpl::GetType<int64_t>())
-        .TypeConstraint("x", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("x_scale", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("x_zero_point", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("y", DataTypeImpl::GetTensorType<float>()),
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<float>())
+        .TypeConstraint("T2", DataTypeImpl::GetTensorType<uint8_t>()),
     DequantizeLinear<uint8_t>);
 
 ONNX_CPU_OPERATOR_TYPED_MS_KERNEL(
@@ -25,11 +21,8 @@ ONNX_CPU_OPERATOR_TYPED_MS_KERNEL(
     1,
     int8_t,
     KernelDefBuilder()
-        .TypeConstraint("axis", DataTypeImpl::GetType<int64_t>())
-        .TypeConstraint("x", DataTypeImpl::GetTensorType<int8_t>())
-        .TypeConstraint("x_scale", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("x_zero_point", DataTypeImpl::GetTensorType<int8_t>())
-        .TypeConstraint("y", DataTypeImpl::GetTensorType<float>()),
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<float>())
+        .TypeConstraint("T2", DataTypeImpl::GetTensorType<int8_t>()),
     DequantizeLinear<int8_t>);
 
 ONNX_CPU_OPERATOR_TYPED_MS_KERNEL(
@@ -37,12 +30,9 @@ ONNX_CPU_OPERATOR_TYPED_MS_KERNEL(
     1,
     uint8_t,
     KernelDefBuilder()
-        .TypeConstraint("axis", DataTypeImpl::GetType<int64_t>())
-        .TypeConstraint("x", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("y_scale", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("y_zero_point", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("y", DataTypeImpl::GetTensorType<uint8_t>()),
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<float>())
+        .TypeConstraint("T2", DataTypeImpl::GetTensorType<uint8_t>()),
     QuantizeLinear<uint8_t>);
 
-} // namespace contrib
+}  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/tensor/quantize_linear.cc
+++ b/onnxruntime/core/providers/cpu/tensor/quantize_linear.cc
@@ -12,10 +12,7 @@ ONNX_CPU_OPERATOR_TYPED_KERNEL(
     10,
     uint8_t,
     KernelDefBuilder()
-        .TypeConstraint("x", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("x_scale", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("x_zero_point", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("y", DataTypeImpl::GetTensorType<float>()),
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<uint8_t>()),
     DequantizeLinear<uint8_t>);
 
 ONNX_CPU_OPERATOR_TYPED_KERNEL(
@@ -23,10 +20,7 @@ ONNX_CPU_OPERATOR_TYPED_KERNEL(
     10,
     int8_t,
     KernelDefBuilder()
-        .TypeConstraint("x", DataTypeImpl::GetTensorType<int8_t>())
-        .TypeConstraint("x_scale", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("x_zero_point", DataTypeImpl::GetTensorType<int8_t>())
-        .TypeConstraint("y", DataTypeImpl::GetTensorType<float>()),
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<int8_t>()),
     DequantizeLinear<int8_t>);
 
 template <typename T>
@@ -35,49 +29,45 @@ Status DequantizeLinear<T>::Compute(OpKernelContext* ctx) const {
   auto& x = *ctx->Input<Tensor>(0);
   auto& x_scale = *ctx->Input<Tensor>(1);
   auto& x_zero_point = *ctx->Input<Tensor>(2);
-  auto& y = *ctx->Output(0, x.Shape());
   const auto& x_shape = x.Shape();
+  auto& y = *ctx->Output(0, x_shape);
 
-  int64_t axis = 0;
-  int64_t broadcastDim = x_shape[axis];
-  size_t stride = 0;
+  int64_t N;
+  int64_t broadcast_dim;
+  int64_t block_size;
 
   if (has_axis_) {
-    axis = HandleNegativeAxis(axis_, x_shape.NumDimensions());
-    broadcastDim = x_shape[axis];
-    stride = 1;
+    const int64_t axis = HandleNegativeAxis(axis_, x_shape.NumDimensions());
+    N = x_shape.SizeToDimension(axis);
+    broadcast_dim = x_shape[axis];
+    block_size = x_shape.SizeFromDimension(axis + 1);
 
     // if an axis was specified, ensure the scale and zero point are compatible
-    ORT_ENFORCE(x_scale.Shape().NumDimensions() == 1 && x_scale.Shape().Size() == broadcastDim, "x_scale must be 1D tensor with size ", broadcastDim);
-    ORT_ENFORCE(x_zero_point.Shape().NumDimensions() == 1 && x_zero_point.Shape().Size() == broadcastDim, "x_zero_point must be 1D tensor with size ", broadcastDim);
+    ORT_ENFORCE(x_scale.Shape().NumDimensions() == 1 && x_scale.Shape().Size() == broadcast_dim, "x_scale must be 1D tensor with size ", broadcast_dim);
+    ORT_ENFORCE(x_zero_point.Shape().NumDimensions() == 1 && x_zero_point.Shape().Size() == broadcast_dim, "x_zero_point must be 1D tensor with size ", broadcast_dim);
   } else {
+    N = 1;
+    broadcast_dim = 1;
+    block_size = static_cast<size_t>(x_shape.Size());
+
     // if no axis, enforce that scale and zero point are scalars
     ORT_ENFORCE(IsScalarOr1ElementVector(&x_scale), "x_scale must be a scalar or 1D tensor or size 1.");
     ORT_ENFORCE(IsScalarOr1ElementVector(&x_zero_point), "x_zero_point must be a scalar or 1D tensor or size 1.");
   }
-
-  size_t N = x_shape.SizeToDimension(axis);
-  size_t block_size = x_shape.SizeFromDimension(axis + 1);
 
   const T* zero_point = x_zero_point.template Data<T>();
   const float* scale = x_scale.template Data<float>();
   const T* input = x.template Data<T>();
   float* output = y.template MutableData<float>();
 
-  for (size_t n = 0; n < N; n++) {
-    const float* current_scale = scale;
-    const T* current_zero_point = zero_point;
+  for (size_t n = 0; n < static_cast<size_t>(N); n++) {
+    for (size_t bd = 0; bd < static_cast<size_t>(broadcast_dim); bd++) {
+      auto zp = static_cast<int32_t>(zero_point[bd]);
+      auto sc = scale[bd];
 
-    for (size_t bd = 0; bd < static_cast<size_t>(broadcastDim); bd++) {
-      auto zp = static_cast<const int>(*current_zero_point);
-      auto sc = *current_scale;
-
-      for (size_t bs = 0; bs < block_size; bs++) {
-        *output++ = static_cast<float>(static_cast<const int>(*input++) - zp) * sc;
+      for (size_t bs = 0; bs < static_cast<size_t>(block_size); bs++) {
+        *output++ = static_cast<float>(static_cast<int32_t>(*input++) - zp) * sc;
       }
-
-      current_scale += stride;
-      current_zero_point += stride;
     }
   }
 
@@ -89,9 +79,8 @@ ONNX_CPU_OPERATOR_TYPED_KERNEL(
     10,
     uint8_t,
     KernelDefBuilder()
-        .TypeConstraint("x", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("y_zero_point", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("y", DataTypeImpl::GetTensorType<uint8_t>()),
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<float>())
+        .TypeConstraint("T2", DataTypeImpl::GetTensorType<uint8_t>()),
     QuantizeLinear<uint8_t>);
 
 ONNX_CPU_OPERATOR_TYPED_KERNEL(
@@ -99,9 +88,8 @@ ONNX_CPU_OPERATOR_TYPED_KERNEL(
     10,
     int8_t,
     KernelDefBuilder()
-        .TypeConstraint("x", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("y_zero_point", DataTypeImpl::GetTensorType<int8_t>())
-        .TypeConstraint("y", DataTypeImpl::GetTensorType<int8_t>()),
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<float>())
+        .TypeConstraint("T2", DataTypeImpl::GetTensorType<int8_t>()),
     QuantizeLinear<int8_t>);
 
 template <typename T>
@@ -110,68 +98,60 @@ Status QuantizeLinear<T>::Compute(OpKernelContext* ctx) const {
   auto& x = *ctx->Input<Tensor>(0);
   auto& y_scale = *ctx->Input<Tensor>(1);
   auto& y_zero_point = *ctx->Input<Tensor>(2);
-  auto& y = *ctx->Output(0, x.Shape());
   const auto& x_shape = x.Shape();
+  auto& y = *ctx->Output(0, x_shape);
 
+  int64_t N;
+  int64_t broadcast_dim;
+  int64_t block_size;
+
+  if (has_axis_) {
+    const int64_t axis = HandleNegativeAxis(axis_, x_shape.NumDimensions());
+    N = x_shape.SizeToDimension(axis);
+    broadcast_dim = x_shape[axis];
+    block_size = x_shape.SizeFromDimension(axis + 1);
+
+    // if an axis was specified, ensure the scale and zero point are compatible
+    ORT_ENFORCE(y_scale.Shape().NumDimensions() == 1 && y_scale.Shape().Size() == broadcast_dim, "x_scale must be 1D tensor with size ", broadcast_dim);
+    ORT_ENFORCE(y_zero_point.Shape().NumDimensions() == 1 && y_zero_point.Shape().Size() == broadcast_dim, "x_zero_point must be 1D tensor with size ", broadcast_dim);
+  } else {
+    N = 1;
+    broadcast_dim = 1;
+    block_size = x_shape.Size();
+
+    // if no axis, enforce that scale and zero point are scalars
+    ORT_ENFORCE(IsScalarOr1ElementVector(&y_scale), "x_scale must be a scalar or 1D tensor or size 1.");
+    ORT_ENFORCE(IsScalarOr1ElementVector(&y_zero_point), "x_zero_point must be a scalar or 1D tensor or size 1.");
+  }
+
+  const T* zero_point = y_zero_point.template Data<T>();
+  const float* scale = y_scale.template Data<float>();
   const float* input = x.template Data<float>();
   T* output = y.template MutableData<T>();
-
-  const float qmax = std::numeric_limits<T>::max();
-  const float qmin_default = std::numeric_limits<T>::min();
-  // adjust qmin for int8 inputs. This is required to keep zero point as zero
-  const float qmin = qmin_default == -128 ? -127 : qmin_default;
 
   // Schema of QuantizeLinearOp changed when it was promoted to onnx domain. In order to maintain backward compatiblity
   // both the versions need to be supported.
   if (ctx->GetOpDomain() != kMSDomain) {
-    ORT_ENFORCE(IsScalarOr1ElementVector(&y_scale), "x_scale must be a scalar or 1D tensor or size 1.");
-    ORT_ENFORCE(IsScalarOr1ElementVector(&y_zero_point), "x_zero_point must be a scalar or 1D tensor or size 1.");
-
-    const T zero_point = *(y_zero_point.template Data<T>());
-    const float scale = *(y_scale.template Data<float>());
-    const auto num_of_elements = x_shape.Size();
-
-    MlasQuantizeLinear(input, output, num_of_elements, scale, zero_point);
-
+    MlasQuantizeLinear(input, output, static_cast<size_t>(block_size), *scale, *zero_point);
   } else {
-    size_t stride = 0;
-    const int64_t axis = HandleNegativeAxis(axis_, x_shape.NumDimensions());
-    const auto& broadcastDim = x_shape[axis];
+    const float qmax = std::numeric_limits<T>::max();
+    const float qmin_default = std::numeric_limits<T>::min();
+    // adjust qmin for int8 inputs. This is required to keep zero point as zero
+    const float qmin = qmin_default == -128 ? -127 : qmin_default;
 
-    if (has_axis_) {
-      // if an axis was specified, ensure the scale and zero point are compatible
-      ORT_ENFORCE(y_scale.Shape().NumDimensions() == 1 && y_scale.Shape().Size() == broadcastDim, "x_scale must be 1D tensor with size ", broadcastDim);
-      ORT_ENFORCE(y_zero_point.Shape().NumDimensions() == 1 && y_zero_point.Shape().Size() == broadcastDim, "x_zero_point must be 1D tensor with size ", broadcastDim);
-      stride = 1;
-    } else {
-      // if no axis, enforce that scale and zero point are scalars
-      ORT_ENFORCE(IsScalarOr1ElementVector(&y_scale), "x_scale must be a scalar or 1D tensor or size 1.");
-      ORT_ENFORCE(IsScalarOr1ElementVector(&y_zero_point), "x_zero_point must be a scalar or 1D tensor or size 1.");
-    }
+    for (size_t n = 0; n < static_cast<size_t>(N); n++) {
+      for (size_t bd = 0; bd < static_cast<size_t>(broadcast_dim); bd++) {
+        float zp = static_cast<float>(zero_point[bd]);
+        auto sc = scale[bd];
 
-    size_t N = x_shape.SizeToDimension(axis);
-    size_t block_size = x_shape.SizeFromDimension(axis + 1);
-    const T* zero_point = y_zero_point.template Data<T>();
-    const float* scale = y_scale.template Data<float>();
-
-    for (size_t n = 0; n < N; n++) {
-      const float* current_scale = scale;
-      const T* current_zero_point = zero_point;
-
-      for (size_t bd = 0; bd < static_cast<size_t>(broadcastDim); bd++) {
-        float zp = *current_zero_point;
-        auto sc = *current_scale;
-
-        for (size_t bs = 0; bs < block_size; bs++) {
+        for (size_t bs = 0; bs < static_cast<size_t>(block_size); bs++) {
           *output++ = static_cast<T>(clamp(std::round(static_cast<float>(*input++) / sc) + zp, qmin, qmax));
         }
-
-        current_scale += stride;
-        current_zero_point += stride;
       }
     }
   }
 
   return Status::OK();
 }
+
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
@@ -29,7 +29,7 @@ TEST(DequantizeLinearOpTest, DequantizeLinear_1) {
 }
 
 // 2d inputs
-TEST(DequantizeLinearOpTest, DequantizeLinear_2) {
+TEST(DequantizeLinearOpTest, DequantizeLinear_2D) {
   OpTester test("DequantizeLinear", 10);
   std::vector<int64_t> dims{3, 4};
   test.AddInput<uint8_t>("X", dims,
@@ -45,6 +45,15 @@ TEST(DequantizeLinearOpTest, DequantizeLinear_2) {
   test.Run();
 }
 
+// dequantize with scalar data
+TEST(DequantizeLinearOpTest, DequantizeLinear_Scalar) {
+  OpTester test("DequantizeLinear", 10);
+  test.AddInput<int8_t>("x", {}, {100});
+  test.AddInput<float>("x_scale", {}, {2.0f});
+  test.AddInput<int8_t>("x_zero_point", {}, {-10});
+  test.AddOutput<float>("y", {}, {220.0f});
+  test.Run();
+}
 
 // quantize with scalar zero point and scale
 TEST(QuantizeLinearOpTest, QuantizeLinear_uint8) {
@@ -91,7 +100,7 @@ TEST(QuantizeLinearOpTest, QuantizeLinear_int8_PositiveZeroPoint) {
 }
 
 // quantize with 2D data
-TEST(QuantizeLinearOpTest, QuantizeLinear_1) {
+TEST(QuantizeLinearOpTest, QuantizeLinear_2D) {
   OpTester test("QuantizeLinear", 10);
   std::vector<int64_t> dims{3, 4};
   test.AddInput<float>("X", dims,
@@ -106,5 +115,16 @@ TEST(QuantizeLinearOpTest, QuantizeLinear_1) {
                            0, 0, 1, 250});
   test.Run();
 }
+
+// quantize with scalar data
+TEST(QuantizeLinearOpTest, QuantizeLinear_Scalar) {
+  OpTester test("QuantizeLinear", 10);
+  test.AddInput<float>("x", {}, {3});
+  test.AddInput<float>("y_scale", {}, {2.0f});
+  test.AddInput<uint8_t>("y_zero_point", {}, {128});
+  test.AddOutput<uint8_t>("y", {}, {130});
+  test.Run();
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**: This fixes the crash describe in #3417 where a scalar tensor crashes in the DequantizeLinear kernel.

**Motivation and Context**
The kernel for DequantizeLinear is shared between the official ONNX definition of the operator and an older contrib op version that supported an axis attribute with some broadcasting semantics. The crash was caused by not checking if the axis value as valid to use. The model from #3417 is now able to load and run and additional unit tests were added for the scalar case.

Also cleaned up the kernel registration to use the type constraints instead of explicitly listing parameter names in order to reduce code size.