### PR TITLE
Handle Scalars in TernaryOps and Where.

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/utils.h
+++ b/onnxruntime/core/providers/cpu/tensor/utils.h
@@ -25,7 +25,11 @@ struct TensorPitches : std::vector<int64_t> {
     if (gsl::narrow_cast<ptrdiff_t>(padded_rank) < 0)
       return false;
 
-    *(p.rbegin()) = 1;  // The innermost axis is 1 (single values)
+    // Guard against Scalars
+    if (pitch_rank > 0) {
+      *(p.rbegin()) = 1;  // The innermost axis is 1 (single values)
+    }
+
     if (tensor_rank > 1) {
       for (size_t i = tensor_rank - 1; i-- > 0;) {
         p.operator[](i + padded_rank) = p.operator[](i + 1 + padded_rank) * dims[i + 1];

--- a/onnxruntime/core/providers/cpu/tensor/utils.h
+++ b/onnxruntime/core/providers/cpu/tensor/utils.h
@@ -26,10 +26,11 @@ struct TensorPitches : std::vector<int64_t> {
       return false;
 
     // Guard against Scalars
-    if (pitch_rank > 0) {
-      *(p.rbegin()) = 1;  // The innermost axis is 1 (single values)
+    if (pitch_rank == 0) {
+      return true;
     }
 
+    *(p.rbegin()) = 1;  // The innermost axis is 1 (single values)
     if (tensor_rank > 1) {
       for (size_t i = tensor_rank - 1; i-- > 0;) {
         p.operator[](i + padded_rank) = p.operator[](i + 1 + padded_rank) * dims[i + 1];

--- a/onnxruntime/core/providers/cuda/tensor/where.cc
+++ b/onnxruntime/core/providers/cuda/tensor/where.cc
@@ -95,37 +95,43 @@ struct TernaryElementwisePreparation {
     output_rank_or_simple_broadcast = out_rank;
 
     if (a_shape != output_shape) {
-      TensorPitches a_pitches(a_shape.GetDims());
       a_padded_strides.size_ = out_rank;
-      auto offset = out_rank - a_rank;
-      for (auto i = offset; i < out_rank; ++i) {
-        // the stride for broadcast dimension is kept as 0
-        if (a_shape.GetDims()[i - offset] != 1) {
-          a_padded_strides[i] = a_pitches[i];
+      if (a_rank > 0) {
+        TensorPitches a_pitches(a_shape.GetDims());
+        auto offset = out_rank - a_rank;
+        for (auto i = offset; i < out_rank; ++i) {
+          // the stride for broadcast dimension is kept as 0
+          if (a_shape.GetDims()[i - offset] != 1) {
+            a_padded_strides[i] = a_pitches[i];
+          }
         }
       }
     }
 
     if (b_shape != output_shape) {
-      TensorPitches b_pitches(b_shape.GetDims());
       b_padded_strides.size_ = out_rank;
-      auto offset = out_rank - b_rank;
-      for (auto i = offset; i < out_rank; ++i) {
-        // the stride for broadcast dimension is kept as 0
-        if (b_shape.GetDims()[i - offset] != 1) {
-          b_padded_strides[i] = b_pitches[i];
+      if (b_rank > 0) {
+        TensorPitches b_pitches(b_shape.GetDims());
+        auto offset = out_rank - b_rank;
+        for (auto i = offset; i < out_rank && b_rank > 0; ++i) {
+          // the stride for broadcast dimension is kept as 0
+          if (b_shape.GetDims()[i - offset] != 1) {
+            b_padded_strides[i] = b_pitches[i];
+          }
         }
       }
     }
 
     if (c_shape != output_shape) {
-      TensorPitches c_pitches(c_shape.GetDims());
       c_padded_strides.size_ = out_rank;
-      auto offset = out_rank - c_rank;
-      for (auto i = offset; i < out_rank; ++i) {
-        // the stride for broadcast dimension is kept as 0
-        if (c_shape.GetDims()[i - offset] != 1) {
-          c_padded_strides[i] = c_pitches[i];
+      if (c_rank > 0) {
+        TensorPitches c_pitches(c_shape.GetDims());
+        auto offset = out_rank - c_rank;
+        for (auto i = offset; i < out_rank && c_rank > 0; ++i) {
+          // the stride for broadcast dimension is kept as 0
+          if (c_shape.GetDims()[i - offset] != 1) {
+            c_padded_strides[i] = c_pitches[i];
+          }
         }
       }
     }

--- a/onnxruntime/core/providers/cuda/tensor/where.cc
+++ b/onnxruntime/core/providers/cuda/tensor/where.cc
@@ -113,7 +113,7 @@ struct TernaryElementwisePreparation {
       if (b_rank > 0) {
         TensorPitches b_pitches(b_shape.GetDims());
         auto offset = out_rank - b_rank;
-        for (auto i = offset; i < out_rank && b_rank > 0; ++i) {
+        for (auto i = offset; i < out_rank; ++i) {
           // the stride for broadcast dimension is kept as 0
           if (b_shape.GetDims()[i - offset] != 1) {
             b_padded_strides[i] = b_pitches[i];
@@ -127,7 +127,7 @@ struct TernaryElementwisePreparation {
       if (c_rank > 0) {
         TensorPitches c_pitches(c_shape.GetDims());
         auto offset = out_rank - c_rank;
-        for (auto i = offset; i < out_rank && c_rank > 0; ++i) {
+        for (auto i = offset; i < out_rank; ++i) {
           // the stride for broadcast dimension is kept as 0
           if (c_shape.GetDims()[i - offset] != 1) {
             c_padded_strides[i] = c_pitches[i];

--- a/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
@@ -122,5 +122,20 @@ TEST(WhereOpTest, BroadcastDimWithZero) {
   // exclude NGraph as this isn't handled by that EP
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kNGraphExecutionProvider});
 }
+
+TEST(WhereOpTest, BroadcastWithScalar) {
+  OpTester test{kOpName, kOpVersion};
+
+  test.AddInput<bool>("condition", {3}, {true, false, true});
+  test.AddInput<int64_t>("X", {1, 3}, {1, 2, 3});
+  test.AddInput<int64_t>("Y", {}, {1});
+
+  test.AddOutput<int64_t>("output", {1, 3}, {1, 1, 3});
+
+  // exclude NGraph as this isn't handled by that EP
+  //test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kNGraphExecutionProvider});
+  test.Run();
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**: 
Properly handle Scalars in TernaryOps utils and Where op on CUDA

**Motivation and Context**
MTDNN model from MS Research reveals Scalar handling shortcomings.