### PR TITLE
Remove const_cast in ForecastingPivotTransformer

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -450,7 +450,7 @@
       {
          "component": {
             "git": {
-               "commitHash": "83d30a3209a4ff47baa8db9ec4da397f4946854f",
+               "commitHash": "7922489c1e7e7baf20c4b1557743d6c7ea72647d",
                "repositoryUrl": "https://github.com/microsoft/FeaturizersLibrary.git"
             },
             "type": "git"

--- a/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
@@ -17,7 +17,7 @@ template <typename T>
 struct ForecastingPivotTransformerImpl {
   void operator()(OpKernelContext* ctx) const {
     using MatrixT = NS::RowMajMatrix<typename NS::Traits<T>::nullable_type>;
-    using InputType = std::vector<Eigen::Map<MatrixT>>;
+    using InputType = std::vector<Eigen::Map<const MatrixT>>;
     using OutputType = std::vector<T>;
     using TransformerT = Microsoft::Featurizer::Featurizers::ForecastingPivotTransformer<std::tuple<typename InputType::iterator, typename InputType::iterator>>;
 
@@ -62,7 +62,7 @@ struct ForecastingPivotTransformerImpl {
         const T* input_data(std::get<0>(dataPtrMap.at(index)));
         const int64_t input_dim_1(std::get<1>(dataPtrMap.at(index)));
         const int64_t input_dim_2(std::get<2>(dataPtrMap.at(index)));
-        input.push_back(typename InputType::value_type(const_cast<T*>(input_data), input_dim_1, input_dim_2));
+        input.push_back(typename InputType::value_type(input_data, input_dim_1, input_dim_2));
         //Increment data pointer
         input_data += input_dim_1 * input_dim_2;
       }


### PR DESCRIPTION
Update FeaturizersLibrary 
-fix IsIteratorRange<..> and IsMatrix<..>in Traits.h to accept const type

Remove the use of const_cast<..> in Forecasting_pivot_transformer
