### PR TITLE
Make GPUTEST macro consistent among TAEF/googletest

### DIFF
--- a/winml/test/common/googleTestMacros.h
+++ b/winml/test/common/googleTestMacros.h
@@ -72,11 +72,13 @@
   WINML_SKIP_TEST("GPU tests disabled because this is a WinML only build (no DML)")
 #define GPUTEST_ENABLED alwaysFalse()
 #else
-#define GPUTEST                                                                             \
-  if (auto no_gpu_tests = RuntimeParameters::Parameters.find("noGPUtests");                 \
-      no_gpu_tests != RuntimeParameters::Parameters.end() && no_gpu_tests->second != "0") { \
-    WINML_SKIP_TEST("GPU tests disabled");                                                  \
-  }
+#define GPUTEST                                                                               \
+  do {                                                                                        \
+    if (auto no_gpu_tests = RuntimeParameters::Parameters.find("noGPUtests");                 \
+        no_gpu_tests != RuntimeParameters::Parameters.end() && no_gpu_tests->second != "0") { \
+      WINML_SKIP_TEST("GPU tests disabled");                                                  \
+    }                                                                                         \
+  } while (0)
 #define GPUTEST_ENABLED auto _no_gpu_tests = RuntimeParameters::Parameters.find("noGPUtests");    \
       _no_gpu_tests == RuntimeParameters::Parameters.end() || _no_gpu_tests->second == "0"
 #endif

--- a/winml/test/concurrency/ConcurrencyTests.cpp
+++ b/winml/test/concurrency/ConcurrencyTests.cpp
@@ -253,7 +253,7 @@ void MultiThreadMultiSession() {
 }
 
 void MultiThreadMultiSessionGpu() {
-    GPUTEST
+    GPUTEST;
     MultiThreadMultiSessionOnDevice(LearningModelDeviceKind::DirectX);
 }
 
@@ -323,7 +323,7 @@ void MultiThreadSingleSession() {
 }
 
 void MultiThreadSingleSessionGpu() {
-    GPUTEST
+    GPUTEST;
     MultiThreadSingleSessionOnDevice(LearningModelDeviceKind::DirectX);
 }
 }

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -58,7 +58,7 @@ static void ScenarioCppWinrtTestSetup() {
 
 static void ScenarioCppWinrtGpuTestSetup() {
   ScenarioCppWinrtTestSetup();
-  GPUTEST
+  GPUTEST;
 };
 
 static void ScenarioCppWinrtGpuSkipEdgeCoreTestSetup() {


### PR DESCRIPTION
**Description**: Fix TAEF build break and prevent future usage of GPUTEST without a semicolon
