### PR TITLE
Fix nuget package restore

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/props.xml
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/props.xml
@@ -32,9 +32,7 @@
     <DirectMLBinary Condition="Exists('$(MSBuildThisFileDirectory)..\..\runtimes\win-$(EnginePlatform)\native\directml.dll')">$(MSBuildThisFileDirectory)..\..\runtimes\win-$(EnginePlatform)\native\directml.dll</DirectMLBinary>
   </PropertyGroup>
 
-  <ItemGroup Condition="Exists('packages.config') OR
-                        Exists('$(MSBuildProjectName).packages.config') OR
-                        Exists('packages.$(MSBuildProjectName).config')">
+  <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime.dll"
           Condition="'$(PlatformTarget)' == 'x64' OR ('$(PlatformTarget)' == 'AnyCPU' AND '$(Prefer32Bit)' != 'true')">
       <Link>onnxruntime.dll</Link>


### PR DESCRIPTION
**Description**: Removed obsolete condition in nuget package props file.

**Motivation and Context**
- This change is required to allow nuget package consumption on any project file using `PackageReference`s (including .net sdk-style projects)
- Resolves issue #3101
- Resolves issue #116 (which was closed without solving the underlying issue)