### PR TITLE
Resolve comments and make minor changes to Featurizer transformers

### DIFF
--- a/onnxruntime/featurizers_ops/cpu/cat_imputer_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/cat_imputer_transformer.cc
@@ -36,7 +36,7 @@ struct CatImputerTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::CatImputerTransformer<T>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/count_vectorizer_transfromer.cc
+++ b/onnxruntime/featurizers_ops/cpu/count_vectorizer_transfromer.cc
@@ -19,7 +19,7 @@ void CountVectorizerTransformerImpl(OpKernelContext* ctx) {
         const auto* state_tensor(ctx->Input<Tensor>(0));
         const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-        Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+        Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
         return Microsoft::Featurizer::Featurizers::CountVectorizerTransformer(archive);
       }());
 
@@ -28,8 +28,10 @@ void CountVectorizerTransformerImpl(OpKernelContext* ctx) {
   const std::string* input_data = input_tensor->template Data<std::string>();
   // Prepare the callback that would output directly to output memory
   std::function<void(NS::Featurizers::SparseVectorEncoding<uint32_t>)> callback;
-  callback = [ctx](NS::Featurizers::SparseVectorEncoding<uint32_t> result) {
+  bool callback_allow = true;
+  callback = [ctx, callback_allow](NS::Featurizers::SparseVectorEncoding<uint32_t> result) {
     // Prepare output
+    ORT_ENFORCE(callback_allow, "callback function can only be called during execute() and special flush() when needed");
     ORT_ENFORCE(result.NumElements < static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
         "NumElements in SparseVectorEncoding is GE than max(int64)");
     auto* output_tensor = ctx->Output(0, TensorShape{static_cast<int64_t>(result.NumElements)});
@@ -40,6 +42,9 @@ void CountVectorizerTransformerImpl(OpKernelContext* ctx) {
     }
   };
   transformer.execute(*input_data, callback);
+  // The flush() does nothing but shows Featurizers concept
+  callback_allow = false;
+  transformer.flush(callback);
 };
 
 class CountVectorizerTransformer final : public OpKernel {

--- a/onnxruntime/featurizers_ops/cpu/date_time_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/date_time_transformer.cc
@@ -24,7 +24,7 @@ class DateTimeTransformer final : public OpKernel {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::DateTimeTransformer(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
@@ -24,7 +24,7 @@ struct ForecastingPivotTransformerImpl {
     //Get the transformer
     const auto* state_tensor(ctx->Input<Tensor>(0));
     const uint8_t* const state_data(state_tensor->Data<uint8_t>());
-    Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+    Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
     TransformerT transformer(archive);
 
     // Get the Number of Rows
@@ -59,9 +59,10 @@ struct ForecastingPivotTransformerImpl {
           std::tuple<const T*,int64_t, int64_t> info_tuple(input_data, input_dim_1, input_dim_2);
           dataPtrMap.insert(std::pair<int, std::tuple<const T*,int64_t, int64_t>>(index, info_tuple));
         }
-        const T* input_data(std::get<0>(dataPtrMap.at(index)));
-        const int64_t input_dim_1(std::get<1>(dataPtrMap.at(index)));
-        const int64_t input_dim_2(std::get<2>(dataPtrMap.at(index)));
+        std::tuple<const T*,int64_t, int64_t> &inputTuple(dataPtrMap.at(index));
+        const T* input_data(std::get<0>(inputTuple));
+        const int64_t input_dim_1(std::get<1>(inputTuple));
+        const int64_t input_dim_2(std::get<2>(inputTuple));
         input.push_back(typename InputType::value_type(input_data, input_dim_1, input_dim_2));
         //Increment data pointer
         input_data += input_dim_1 * input_dim_2;

--- a/onnxruntime/featurizers_ops/cpu/from_string_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/from_string_transformer.cc
@@ -21,7 +21,7 @@ struct FromStringTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::FromStringTransformer<T>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/hash_one_hot_vectorizer_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/hash_one_hot_vectorizer_transformer.cc
@@ -21,7 +21,7 @@ struct HashOneHotVectorizerTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::HashOneHotVectorizerTransformer<InputT>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/imputation_marker_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/imputation_marker_transformer.cc
@@ -27,7 +27,7 @@ struct ImputationMarkerTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::ImputationMarkerTransformer<InputT>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/label_encoder_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/label_encoder_transformer.cc
@@ -21,7 +21,7 @@ struct LabelEncoderTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::LabelEncoderTransformer<InputT>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/laglead_operator_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/laglead_operator_transformer.cc
@@ -28,7 +28,7 @@ struct LagLeadOperatorTransformerImpl {
     //Get the transformer
     const auto* state_tensor(ctx->Input<Tensor>(0));
     const uint8_t* const state_data(state_tensor->Data<uint8_t>());
-    Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+    Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
     typename EstimatorT::TransformerType transformer(archive);
 
     // Get the Grains
@@ -52,8 +52,8 @@ struct LagLeadOperatorTransformerImpl {
     bool has_allocate_output_data = false;
     std::function<void(OutputType)> callback_fn;
     callback_fn = [ctx, &output_grains_data, &output_data, &has_allocate_output_data, output_dim_0](OutputType value) -> void {
-      GrainT & output_grains(std::get<GrainT>(value));
-      const OutputMatrixType & output_matrix(std::get<OutputMatrixType>(value));
+      GrainT & output_grains(std::get<0>(value));
+      const OutputMatrixType & output_matrix(std::get<1>(value));
       //Allocate tensor memory after first output is generated
       if (!has_allocate_output_data) {
         TensorShape output_shape({output_dim_0, output_matrix.rows(), output_matrix.cols()});

--- a/onnxruntime/featurizers_ops/cpu/max_abs_scaler_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/max_abs_scaler_transformer.cc
@@ -44,7 +44,7 @@ struct MaxAbsScalerTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::MaxAbsScalerTransformer<InputT, typename OutputTypeMapper<InputT>::type>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/mean_imputer_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/mean_imputer_transformer.cc
@@ -36,7 +36,7 @@ struct MeanImputerTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return MeanImputerTransformerT<InputT>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/median_imputer_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/median_imputer_transformer.cc
@@ -50,7 +50,7 @@ struct MedianImputerTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return MedianImputerTransformerT<InputT>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/min_max_imputer_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/min_max_imputer_transformer.cc
@@ -45,7 +45,7 @@ struct MinMaxImputerTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return MinMaxImputerTransformerT<T>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/min_max_scaler_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/min_max_scaler_transformer.cc
@@ -21,7 +21,7 @@ struct MinMaxScalerTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::MinMaxScalerTransformer<InputT>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/missing_dummies_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/missing_dummies_transformer.cc
@@ -27,7 +27,7 @@ struct MissingDummiesTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::MissingDummiesTransformer<InputT>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/mode_imputer_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/mode_imputer_transformer.cc
@@ -45,7 +45,7 @@ struct ModeImputerTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return ModeImputerTransformerT<T>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/numericalize_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/numericalize_transformer.cc
@@ -21,7 +21,7 @@ struct NumericalizeTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::NumericalizeTransformer<InputT>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/one_hot_encoder_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/one_hot_encoder_transformer.cc
@@ -21,7 +21,7 @@ struct OneHotEncoderTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::OneHotEncoderTransformer<InputT>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/pca_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/pca_transformer.cc
@@ -25,7 +25,7 @@ struct PCATransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::PCATransformer<InputMatrixT>(archive);
         }());
 
@@ -47,10 +47,15 @@ struct PCATransformerImpl {
     Eigen::Map<MatrixT> output_matrix(output_data, dim_0, dim_1);
 
     std::function<void(MatrixT val)> callback;
-    callback = [&output_matrix](MatrixT val) {
+    bool callback_allow = true;
+    callback = [&output_matrix, callback_allow](MatrixT val) {
+      ORT_ENFORCE(callback_allow, "callback function can only be called during execute() and special flush() when needed");
       output_matrix = val;
     };
     transformer.execute(input_matrix, callback);
+    // The flush() does nothing but shows Featurizers concept
+    callback_allow = false;
+    transformer.flush(callback);
   }
 };
 

--- a/onnxruntime/featurizers_ops/cpu/robust_scaler_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/robust_scaler_transformer.cc
@@ -44,7 +44,7 @@ struct RobustScalerTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::RobustScalerTransformer<InputT, typename OutputTypeMapper<InputT>::type>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/rolling_window_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/rolling_window_transformer.cc
@@ -24,7 +24,7 @@ struct RollingWindowTransformerImpl {
     //Get the transformer
     const auto* state_tensor(ctx->Input<Tensor>(0));
     const uint8_t* const state_data(state_tensor->Data<uint8_t>());
-    Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+    Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
     typename EstimatorT::TransformerType transformer(archive);
 
     // Get the Grains
@@ -69,6 +69,7 @@ struct RollingWindowTransformerImpl {
       target_data++;
       grains_data += grains_num;
     }
+    transformer.flush(callback_fn);
   }
 };
 

--- a/onnxruntime/featurizers_ops/cpu/short_grain_dropper_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/short_grain_dropper_transformer.cc
@@ -19,7 +19,7 @@ void ShortGrainDropperTransformerImpl(OpKernelContext* ctx) {
         const auto* state_tensor(ctx->Input<Tensor>(0));
         const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-        Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+        Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
         return Microsoft::Featurizer::Featurizers::ShortGrainDropperTransformer(archive);
       }());
 

--- a/onnxruntime/featurizers_ops/cpu/standard_scale_wrapper_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/standard_scale_wrapper_transformer.cc
@@ -21,7 +21,7 @@ struct StandardScaleWrapperTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::StandardScalerTransformer<InputT, double>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/string_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/string_transformer.cc
@@ -21,7 +21,7 @@ struct StringTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::StringTransformer<InputT>(archive);
         }());
 

--- a/onnxruntime/featurizers_ops/cpu/truncated_svd_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/truncated_svd_transformer.cc
@@ -25,7 +25,7 @@ struct TruncatedSVDTransformerImpl {
           const auto* state_tensor(ctx->Input<Tensor>(0));
           const uint8_t* const state_data(state_tensor->Data<uint8_t>());
 
-          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().GetDims()[0]);
+          Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
           return Microsoft::Featurizer::Featurizers::TruncatedSVDTransformer<InputMatrixT>(archive);
         }());
 
@@ -47,10 +47,15 @@ struct TruncatedSVDTransformerImpl {
     Eigen::Map<MatrixT> output_matrix(output_data, dim_0, dim_1);
 
     std::function<void(MatrixT val)> callback;
-    callback = [&output_matrix](MatrixT val) {
+    bool callback_allow = true;
+    callback = [&output_matrix, callback_allow](MatrixT val) {
+      ORT_ENFORCE(callback_allow, "callback function can only be called during execute() and special flush() when needed");
       output_matrix = val;
     };
     transformer.execute(input_matrix, callback);
+    // The flush() does nothing but shows Featurizers concept
+    callback_allow = false;
+    transformer.flush(callback);
   }
 };
 


### PR DESCRIPTION
Resolve some comments in previous PRs
- https://github.com/microsoft/onnxruntime/pull/3435#discussion_r405112461
- simplify multiple map look-ups in forecasting_pivot_transformer
- add transformer.flush(callback) for intact Featurizer transformer's concept
