### PR TITLE
Disable downloading test data on Windows

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -296,7 +296,7 @@ def setup_test_data(build_dir, configs):
             dest_model_dir = os.path.join(config_build_dir, 'models')
             if os.path.exists('C:\\local\\models') and not os.path.exists(dest_model_dir):
                 log.debug("creating shortcut %s -> %s"  % (src_model_dir, dest_model_dir))
-                run_subprocess(['mklink', '/D', '/J', dest_model_dir, src_model_dir], shell=True)            
+                run_subprocess(['mklink', '/D', '/J', dest_model_dir, 'C:\\local\\models'], shell=True)            
             elif os.path.exists(src_model_dir) and not os.path.exists(dest_model_dir):
                 log.debug("creating shortcut %s -> %s"  % (src_model_dir, dest_model_dir))
                 run_subprocess(['mklink', '/D', '/J', dest_model_dir, src_model_dir], shell=True)                

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -290,12 +290,15 @@ def setup_test_data(build_dir, configs):
     # create a shortcut for test models if there is a 'models' folder in build_dir
     if is_windows():
         src_model_dir = os.path.join(build_dir, 'models')
+        if os.path.exists('C:\\local\\models') and not os.path.exists(src_model_dir):
+          log.debug("creating shortcut %s -> %s"  % ('C:\\local\\models', src_model_dir))
+          run_subprocess(['mklink', '/D', '/J', src_model_dir, 'C:\\local\\models'], shell=True)
         for config in configs:
             config_build_dir = get_config_build_dir(build_dir, config)
             os.makedirs(config_build_dir, exist_ok=True)
             dest_model_dir = os.path.join(config_build_dir, 'models')
             if os.path.exists('C:\\local\\models') and not os.path.exists(dest_model_dir):
-                log.debug("creating shortcut %s -> %s"  % (src_model_dir, dest_model_dir))
+                log.debug("creating shortcut %s -> %s"  % ('C:\\local\\models', dest_model_dir))
                 run_subprocess(['mklink', '/D', '/J', dest_model_dir, 'C:\\local\\models'], shell=True)            
             elif os.path.exists(src_model_dir) and not os.path.exists(dest_model_dir):
                 log.debug("creating shortcut %s -> %s"  % (src_model_dir, dest_model_dir))

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -294,9 +294,12 @@ def setup_test_data(build_dir, configs):
             config_build_dir = get_config_build_dir(build_dir, config)
             os.makedirs(config_build_dir, exist_ok=True)
             dest_model_dir = os.path.join(config_build_dir, 'models')
-            if os.path.exists(src_model_dir) and not os.path.exists(dest_model_dir):
+            if os.path.exists('C:\\local\\models') and not os.path.exists(dest_model_dir):
                 log.debug("creating shortcut %s -> %s"  % (src_model_dir, dest_model_dir))
-                run_subprocess(['mklink', '/D', '/J', dest_model_dir, src_model_dir], shell=True)
+                run_subprocess(['mklink', '/D', '/J', dest_model_dir, src_model_dir], shell=True)            
+            elif os.path.exists(src_model_dir) and not os.path.exists(dest_model_dir):
+                log.debug("creating shortcut %s -> %s"  % (src_model_dir, dest_model_dir))
+                run_subprocess(['mklink', '/D', '/J', dest_model_dir, src_model_dir], shell=True)                
 
 def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home, tensorrt_home, path_to_protoc_exe, configs, cmake_extra_defines, args, cmake_extra_args):
     log.info("Generating CMake build tree")

--- a/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
@@ -219,13 +219,6 @@ jobs:
      Get-ChildItem -Path dist/*.whl | foreach {pip install --upgrade $_.fullname}   
     workingDirectory: '$(Build.SourcesDirectory)\cmake\external\onnx'
     displayName: 'Install ONNX'
-    
-  - task: PythonScript@0
-    displayName: 'Download test data'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-      arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-      workingDirectory: $(Build.BinariesDirectory)
 
   - task: PythonScript@0
     displayName: 'BUILD'
@@ -306,13 +299,6 @@ jobs:
     - template: templates/set-featurizer-build-flag-step.yml
       parameters:
         is_featurizers_build: $(is_featurizers_build)
-
-    - task: PythonScript@0
-      displayName: 'Download test data'
-      inputs:
-        scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-        arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-        workingDirectory: $(Build.BinariesDirectory)
 
     - task: PythonScript@0
       displayName: 'build'

--- a/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
@@ -111,17 +111,17 @@ jobs:
        python -m pip install -q pyopenssl setuptools wheel numpy scipy
       workingDirectory: '$(Build.BinariesDirectory)'
       displayName: 'Install python modules' 
-    
+    - powershell: |
+       $Env:USE_MSVC_STATIC_RUNTIME=1
+       $Env:ONNX_ML=1
+       $Env:CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DProtobuf_USE_STATIC_LIBS=ON -DONNX_USE_LITE_PROTO=ON -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=$(buildArch)-windows-static"
+       python setup.py bdist_wheel
+       Get-ChildItem -Path dist/*.whl | foreach {pip install --upgrade $_.fullname}   
+      workingDirectory: '$(Build.SourcesDirectory)\cmake\external\onnx'      
+      displayName: 'Install ONNX'    
+
     - template: templates/set-test-data-variables-step.yml
     - template: templates/set-version-number-variables-step.yml
-    - task: PythonScript@0
-      displayName: 'Download test data'
-      inputs:
-        scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-        arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-        workingDirectory: $(Build.BinariesDirectory) 
-
-
     - task: PythonScript@0
       displayName: 'Generate cmake config'
       inputs:
@@ -188,16 +188,17 @@ jobs:
        python -m pip install -q pyopenssl setuptools wheel numpy scipy
       workingDirectory: '$(Build.BinariesDirectory)'
       displayName: 'Install python modules' 
-    
+    - powershell: |
+       $Env:USE_MSVC_STATIC_RUNTIME=1
+       $Env:ONNX_ML=1
+       $Env:CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DProtobuf_USE_STATIC_LIBS=ON -DONNX_USE_LITE_PROTO=ON -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=$(buildArch)-windows-static"
+       python setup.py bdist_wheel
+       Get-ChildItem -Path dist/*.whl | foreach {pip install --upgrade $_.fullname}   
+      workingDirectory: '$(Build.SourcesDirectory)\cmake\external\onnx'
+      displayName: 'Install ONNX'
+
     - template: templates/set-test-data-variables-step.yml
     - template: templates/set-version-number-variables-step.yml
-    - task: PythonScript@0
-      displayName: 'Download test data'
-      inputs:
-        scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-        arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-        workingDirectory: $(Build.BinariesDirectory) 
-
 
     - task: PythonScript@0
       displayName: 'Generate cmake config'

--- a/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
@@ -67,12 +67,6 @@ jobs:
 
   - template: templates/set-test-data-variables-step.yml
 
-  - task: PythonScript@0
-    displayName: 'Download test data'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-      arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-      workingDirectory: $(Build.BinariesDirectory)
 
   - task: BatchScript@1
     displayName: 'Setup VS2019 env vars'

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-2019.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-2019.yml
@@ -125,14 +125,7 @@ jobs:
         arguments: '--configuration RelWithDebInfo -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=${{ parameters.OrtPackageId }}'
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
-    - ${{ if in(parameters['sln_platform'], 'Win32', 'x64') }}:
-      - task: PythonScript@0
-        displayName: 'Download test data'
-        inputs:
-          scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-          arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-          workingDirectory: $(Build.BinariesDirectory)
-
+    - ${{ if in(parameters['sln_platform'], 'Win32', 'x64') }}:      
       - task: DotNetCoreCLI@2
         displayName: 'Test C#'
         inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windows-build-tools-setup-steps.yml
@@ -52,14 +52,6 @@ steps:
         arguments: 'install -q --insecure -y pyopenssl setuptools wheel numpy'
       timeoutInMinutes: 10
 
-    - task: PythonScript@0
-      displayName: 'Download test data'
-      condition: ${{parameters.DoDataDownload}}
-      inputs:
-        scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-        arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-        pythonInterpreter: '$(Build.BinariesDirectory)\packages\python\python.exe'
-        workingDirectory: $(Build.BinariesDirectory)
 
     - task: CmdLine@1
       continueOnError: true

--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -16,7 +16,7 @@ jobs:
     EnvSetupScript: setup_env.bat
     buildArch: x64
     setVcvars: true    
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
   workspace:
     clean: all
   steps:    

--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -148,7 +148,7 @@ jobs:
     buildArch: x64
     BuildConfig: 'Debug'
     setVcvars: true
-  timeoutInMinutes: 90
+  timeoutInMinutes: 60
   workspace:
     clean: all
   steps:
@@ -221,7 +221,7 @@ jobs:
     EnvSetupScript: setup_env_x86.bat
     buildArch: x86
     setVcvars: true    
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
   workspace:
     clean: all
   steps:    
@@ -349,7 +349,7 @@ jobs:
     EnvSetupScript: setup_env_x86.bat
     buildArch: x86
     setVcvars: true    
-  timeoutInMinutes: 60
+  timeoutInMinutes: 120
   workspace:
     clean: all
   steps:    
@@ -466,7 +466,7 @@ jobs:
     EnvSetupScript: setup_env.bat
     buildArch: x64
     setVcvars: true    
-  timeoutInMinutes: 60
+  timeoutInMinutes: 120
   workspace:
     clean: all
   steps:    

--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -90,13 +90,6 @@ jobs:
 
   - template: templates/set-test-data-variables-step.yml
 
-  - task: PythonScript@0
-    displayName: 'Download test data'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-      arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-      workingDirectory: $(Build.BinariesDirectory)
-
   - task: DotNetCoreCLI@2
     displayName: 'Restore nuget packages'
     inputs:
@@ -293,14 +286,6 @@ jobs:
     inputs:
       versionSpec: 4.9.4  
 
-   
-
-  - task: PythonScript@0
-    displayName: 'Download test data'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-      arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-      workingDirectory: $(Build.BinariesDirectory)
 
   - task: DotNetCoreCLI@2
     displayName: 'Restore nuget packages'
@@ -428,16 +413,7 @@ jobs:
     displayName: Use Nuget 4.9
     inputs:
       versionSpec: 4.9.4  
-
    
-
-  - task: PythonScript@0
-    displayName: 'Download test data'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-      arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-      workingDirectory: $(Build.BinariesDirectory)
-
   - task: DotNetCoreCLI@2
     displayName: 'Restore nuget packages'
     inputs:
@@ -556,14 +532,6 @@ jobs:
       versionSpec: 4.9.4  
 
    
-
-  - task: PythonScript@0
-    displayName: 'Download test data'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-      arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-      workingDirectory: $(Build.BinariesDirectory)
-
   - task: DotNetCoreCLI@2
     displayName: 'Restore nuget packages'
     inputs:

--- a/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
@@ -72,15 +72,6 @@ jobs:
     inputs:
       versionSpec: 4.9.4  
 
-   
-
-  - task: PythonScript@0
-    displayName: 'Download test data'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-      arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-      workingDirectory: $(Build.BinariesDirectory)
-
   - task: DotNetCoreCLI@2
     displayName: 'Restore nuget packages'
     inputs:

--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -67,12 +67,6 @@ jobs:
 
   - template: templates/set-test-data-variables-step.yml
 
-  - task: PythonScript@0
-    displayName: 'Download test data'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-      arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-      workingDirectory: $(Build.BinariesDirectory)
 
   - script: |
      mklink  /D /J $(Build.BinariesDirectory)\$(BuildConfig)\models $(Build.BinariesDirectory)\models

--- a/tools/ci_build/github/azure-pipelines/win-nocontribops-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-nocontribops-ci-pipeline.yml
@@ -79,16 +79,7 @@ jobs:
   - task: NuGetToolInstaller@0
     displayName: Use Nuget 4.9
     inputs:
-      versionSpec: 4.9.4  
-
-   
-
-  - task: PythonScript@0
-    displayName: 'Download test data'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-      arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-      workingDirectory: $(Build.BinariesDirectory)
+      versionSpec: 4.9.4    
 
   - task: DotNetCoreCLI@2
     displayName: 'Restore nuget packages'

--- a/tools/ci_build/github/azure-pipelines/win-x86-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-x86-ci-pipeline.yml
@@ -81,14 +81,6 @@ jobs:
     inputs:
       versionSpec: 4.9.4  
 
-   
-
-  - task: PythonScript@0
-    displayName: 'Download test data'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-      arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-      workingDirectory: $(Build.BinariesDirectory)
 
   - task: DotNetCoreCLI@2
     displayName: 'Restore nuget packages'

--- a/tools/ci_build/github/azure-pipelines/win-x86-nocontribops-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-x86-nocontribops-ci-pipeline.yml
@@ -80,15 +80,7 @@ jobs:
     displayName: Use Nuget 4.9
     inputs:
       versionSpec: 4.9.4  
-
-   
-
-  - task: PythonScript@0
-    displayName: 'Download test data'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\github\download_test_data.py'
-      arguments: --test_data_url $(TestDataUrl) --build_dir $(Build.BinariesDirectory)
-      workingDirectory: $(Build.BinariesDirectory)
+ 
 
   - task: DotNetCoreCLI@2
     displayName: 'Restore nuget packages'

--- a/tools/ci_build/github/download_test_data.py
+++ b/tools/ci_build/github/download_test_data.py
@@ -151,10 +151,6 @@ else:
         print("Starting test data download %s" % url)
         download_and_unzip(args.build_dir, url, models_folder)
 
-        # On windows download additional data
-        if is_windows():
-            download_additional_data(args.build_dir, azure_region)
-
         all_downloads_done = True
 
     except Exception as e:


### PR DESCRIPTION
**Description**: 

Disable downloading test data on Windows

**Motivation and Context**
- Why is this change required? What problem does it solve?

Because I already preloaded the data in every Windows build machines. 

- If it fixes an open issue, please link to the issue here.
