### PR TITLE
Add SafeInt include to WinML targets

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -406,6 +406,7 @@ target_include_directories(winml_lib_api PRIVATE ${REPO_ROOT}/cmake/external/eig
 target_include_directories(winml_lib_api PRIVATE ${REPO_ROOT}/cmake/external/onnx)
 target_include_directories(winml_lib_api PRIVATE ${REPO_ROOT}/cmake/external/protobuf/src)
 target_include_directories(winml_lib_api PRIVATE ${REPO_ROOT}/cmake/external/gsl/include)
+target_include_directories(winml_lib_api PRIVATE ${REPO_ROOT}/cmake/external/SafeInt/safeint)
 
 # Properties
 set_target_properties(winml_lib_api

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -542,6 +542,7 @@ target_include_directories(winml_dll PRIVATE ${REPO_ROOT}/cmake/external/onnx)
 target_include_directories(winml_dll PRIVATE ${REPO_ROOT}/cmake/external/protobuf/src)
 target_include_directories(winml_dll PRIVATE ${REPO_ROOT}/cmake/external/gsl/include)
 target_include_directories(winml_dll PRIVATE ${REPO_ROOT}/cmake/external/eigen)
+target_include_directories(winml_dll PRIVATE ${REPO_ROOT}/cmake/external/SafeInt)
 
 # Properties
 set_target_properties(winml_dll

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -406,7 +406,7 @@ target_include_directories(winml_lib_api PRIVATE ${REPO_ROOT}/cmake/external/eig
 target_include_directories(winml_lib_api PRIVATE ${REPO_ROOT}/cmake/external/onnx)
 target_include_directories(winml_lib_api PRIVATE ${REPO_ROOT}/cmake/external/protobuf/src)
 target_include_directories(winml_lib_api PRIVATE ${REPO_ROOT}/cmake/external/gsl/include)
-target_include_directories(winml_lib_api PRIVATE ${REPO_ROOT}/cmake/external/SafeInt/safeint)
+target_include_directories(winml_lib_api PRIVATE ${REPO_ROOT}/cmake/external/SafeInt)
 
 # Properties
 set_target_properties(winml_lib_api

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -10,6 +10,7 @@ set(WINML_TEST_INC_DIR
   ${REPO_ROOT}/cmake/external/googletest/googletest/include
   ${REPO_ROOT}/cmake/external/protobuf/src
   ${REPO_ROOT}/cmake/external/wil/include
+  ${REPO_ROOT}/cmake/external/SafeInt
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}/winml_api
   ${CMAKE_CURRENT_BINARY_DIR}/winml_api/comp_generated


### PR DESCRIPTION
**Description**
Added SafeInt includes to WinML targets.

**Motivation and Context**
Fixing Windows builds on the ort_training branch in preparation for the merge to master.
SafeInt (included via onnxruntime/core/common/safeint.h), was recently made a dependency of onnxruntime/core/framework/bfc_arena.h. That requires consumers of bfc_arena to compile with the SafeInt include directory.
