### PR TITLE
Don't use session thread pool if openmp is defined

### DIFF
--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -665,7 +665,7 @@ MlasGetMaximumThreadCount(
     MLAS_THREADPOOL* ThreadPool
     )
 {
-#ifdef MLAS_NO_ONNXRUNTIME_THREADPOOL
+#if defined(MLAS_NO_ONNXRUNTIME_THREADPOOL) || defined(_OPENMP)
     MLAS_UNREFERENCED_PARAMETER(ThreadPool);
 #else
     if (ThreadPool != nullptr) {

--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -50,11 +50,15 @@ Status Environment::Initialize(std::unique_ptr<logging::LoggingManager> logging_
   // create thread pools
   if (create_global_thread_pools) {
     create_global_thread_pools_ = true;
+#ifndef _OPENMP
     OrtThreadPoolParams to = tp_options->intra_op_thread_pool_params;
     if (to.name == nullptr) {
       to.name = ORT_TSTR("intra-op");
     }
     intra_op_thread_pool_ = concurrency::CreateThreadPool(&Env::Default(), to, nullptr);
+#else
+    OrtThreadPoolParams to;
+#endif
     to = tp_options->inter_op_thread_pool_params;
     if (to.name == nullptr) {
       to.name = ORT_TSTR("inter-op");

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -172,6 +172,7 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
 
   if (use_per_session_threads_) {
     LOGS(*session_logger_, INFO) << "Creating and using per session threadpools since use_per_session_threads_ is true";
+#ifndef _OPENMP
     {
       OrtThreadPoolParams to = session_options_.intra_op_param;
       if (to.name == nullptr) {
@@ -185,6 +186,7 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
       thread_pool_ =
           concurrency::CreateThreadPool(&Env::Default(), to, nullptr);
     }
+#endif
     if (session_options_.execution_mode == ExecutionMode::ORT_PARALLEL) {
       OrtThreadPoolParams to = session_options_.inter_op_param;
       // If the thread pool can use all the processors, then


### PR DESCRIPTION
**Description**: 

Don't use session thread pool if openmp is defined

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
