### PR TITLE
Fix build break in mlas\lib\quantize.cpp: missing nearbyintf

### DIFF
--- a/onnxruntime/core/mlas/lib/erf.cpp
+++ b/onnxruntime/core/mlas/lib/erf.cpp
@@ -23,8 +23,6 @@ Abstract:
 
 #include "mlasi.h"
 
-#include <cmath>
-
 //
 // Bundles the constants for use by kernels written in assembly.
 //

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -21,6 +21,7 @@ Abstract:
 #include <memory.h>
 #include <algorithm>
 #include <limits>
+#include <cmath>
 
 #if defined(_WIN32)
 #include <windows.h>


### PR DESCRIPTION
**Description**: Fix build break in mlas\lib\quantize.cpp for the fallback path that uses std::nearbyintf.

**Motivation and Context**
This pulls over part of tracysh/mlas_powerpc where this error was also observed. It's hitting the ARM build too as described in #3565.