### PR TITLE
Fix WinML namespace build break

### DIFF
--- a/winml/lib/Api.Image/D3DDeviceCache.cpp
+++ b/winml/lib/Api.Image/D3DDeviceCache.cpp
@@ -60,14 +60,11 @@ D3DDeviceCache::D3DDeviceCache(winml::LearningModelDeviceKind const& deviceKind)
     winrt::com_ptr<IDXGIAdapter1> spAdapter;
     WINML_THROW_IF_FAILED_MSG(GetDXGIHardwareAdapterWithPreference(preference, spAdapter.put()), errStr);
     WINML_THROW_IF_FAILED(D3D12CreateDevice(spAdapter.get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(device_.put())));
-  }
-#ifdef ENABLE_DXCORE
-  if (support.has_dxgi == false) {
-    com_ptr<IDXCoreAdapter> spAdapter;
+  } else if constexpr (ENABLE_DXCORE) {
+    winrt::com_ptr<IDXCoreAdapter> spAdapter;
     WINML_THROW_IF_FAILED_MSG(GetDXCoreHardwareAdapterWithPreference(preference, spAdapter.put()), errStr);
     WINML_THROW_IF_FAILED(D3D12CreateDevice(spAdapter.get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(device_.put())));
   }
-#endif
   InitializeCommandQueue(device_.get());
 
   device_luid_ = device_->GetAdapterLuid();

--- a/winml/lib/Api.Image/D3DDeviceCache.cpp
+++ b/winml/lib/Api.Image/D3DDeviceCache.cpp
@@ -60,11 +60,14 @@ D3DDeviceCache::D3DDeviceCache(winml::LearningModelDeviceKind const& deviceKind)
     winrt::com_ptr<IDXGIAdapter1> spAdapter;
     WINML_THROW_IF_FAILED_MSG(GetDXGIHardwareAdapterWithPreference(preference, spAdapter.put()), errStr);
     WINML_THROW_IF_FAILED(D3D12CreateDevice(spAdapter.get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(device_.put())));
-  } else if constexpr (ENABLE_DXCORE) {
+  }
+#ifdef ENABLE_DXCORE
+  if (support.has_dxgi == false) {
     winrt::com_ptr<IDXCoreAdapter> spAdapter;
     WINML_THROW_IF_FAILED_MSG(GetDXCoreHardwareAdapterWithPreference(preference, spAdapter.put()), errStr);
     WINML_THROW_IF_FAILED(D3D12CreateDevice(spAdapter.get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(device_.put())));
   }
+#endif
   InitializeCommandQueue(device_.get());
 
   device_luid_ = device_->GetAdapterLuid();

--- a/winml/lib/Common/inc/CommonDeviceHelpers.h
+++ b/winml/lib/Common/inc/CommonDeviceHelpers.h
@@ -7,6 +7,8 @@
 #include <initguid.h>
 #include <d3d11.h>
 
+#include "NamespaceAliases.h"
+
 #if __has_include("dxcore.h")
 #define ENABLE_DXCORE 1
 #endif

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -29,7 +29,7 @@ static void LearningModelSessionAPITestsGpuMethodSetup() {
 
 static void LearningModelSessionAPITestsGpuSkipEdgeCoreMethodSetup() {
   LearningModelSessionAPITestsGpuMethodSetup();
-  SKIP_EDGECORE
+  SKIP_EDGECORE;
 }
 
 static void CreateSessionDeviceDefault()

--- a/winml/test/common/taefTestMacros.h
+++ b/winml/test/common/taefTestMacros.h
@@ -16,7 +16,7 @@ using namespace WEX::TestExecution;
     TEST_CLASS(test_class_name);
 
 #define WINML_TEST_CLASS_SETUP_CLASS(setup_class) \
-    TEST_CLASS_SETUP(TestMethodSetup) {           \
+    TEST_CLASS_SETUP(TestClassSetup) {           \
       getapi().setup_class();                     \
       return true;                                \
     }

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -55,12 +55,12 @@ static void ScenarioCppWinrtTestsGpuMethodSetup() {
 };
 
 static void ScenarioCppWinrtTestsSkipEdgeCoreMethodSetup() {
-  SKIP_EDGECORE
+  SKIP_EDGECORE;
 };
 
 static void ScenarioCppWinrtTestsGpuSkipEdgeCoreMethodSetup() {
   ScenarioCppWinrtTestsGpuMethodSetup();
-  SKIP_EDGECORE
+  SKIP_EDGECORE;
 };
 
 static void Sample1() {


### PR DESCRIPTION
Fix regression introduced after the namespace refactoring when dxcore is enabled