### PR TITLE
Convert Gelu to use TryParallelFor

### DIFF
--- a/onnxruntime/contrib_ops/cpu/activations.h
+++ b/onnxruntime/contrib_ops/cpu/activations.h
@@ -40,7 +40,9 @@ class Gelu : public OpKernel {
     const auto* X = context->Input<Tensor>(0);
     Tensor* Y = context->Output(0, X->Shape());
     concurrency::ThreadPool* tp = context->GetOperatorThreadPool();
-    std::ptrdiff_t batch_size = X->Shape().Size();
+    const int64_t input_size = X->Shape().Size();
+    std::ptrdiff_t batch_size = static_cast<std::ptrdiff_t>(input_size);
+    //The cost comes from microbenchmark(manual tunning).
     const double cost = 10.0;
     const T* data = X->template Data<T>();
     T* output = Y->template MutableData<T>();

--- a/onnxruntime/contrib_ops/cpu/activations.h
+++ b/onnxruntime/contrib_ops/cpu/activations.h
@@ -40,35 +40,18 @@ class Gelu : public OpKernel {
     const auto* X = context->Input<Tensor>(0);
     Tensor* Y = context->Output(0, X->Shape());
     concurrency::ThreadPool* tp = context->GetOperatorThreadPool();
-    if (nullptr != tp) {
-      const T* input = X->template Data<T>();
-      T* output = Y->template MutableData<T>();
-      int task_count = tp->NumThreads();
-      int64_t elem_count = X->Shape().Size();
-      if (elem_count > task_count) {
-        tp->SimpleParallelFor(task_count, [input,
-                                     output,
-                                     elem_count,
-                                     task_count](std::ptrdiff_t i) {
-          int64_t elem_inx_start = i * elem_count / task_count;
-          int64_t elem_inx_end = (i + 1) * elem_count / task_count;
-          for (int64_t elem_inx = elem_inx_start; elem_inx < elem_inx_end; elem_inx++) {
-            output[elem_inx] = input[elem_inx] * static_cast<float>(M_SQRT1_2);
-          }
-          MlasComputeErf(output + elem_inx_start, output + elem_inx_start, elem_inx_end - elem_inx_start);
-          for (int64_t elem_inx = elem_inx_start; elem_inx < elem_inx_end; elem_inx++) {
-            output[elem_inx] = 0.5f * input[elem_inx] * (output[elem_inx] + 1.0f);
-          }
-        });
-        return Status::OK();
-      }
-    }
-
-    EIGEN_X_VAR(xm);
-    EIGEN_Y_VAR(ym);
-    ym = xm * static_cast<float>(M_SQRT1_2);
-    MlasComputeErf(Y->template MutableData<T>(), Y->template MutableData<T>(), X->Shape().Size());
-    ym = xm * 0.5f * (ym + 1.0f);
+    std::ptrdiff_t batch_size = X->Shape().Size();
+    const double cost = 10.0;
+    const T* data = X->template Data<T>();
+    T* output = Y->template MutableData<T>();
+    concurrency::ThreadPool::TryParallelFor(tp, batch_size, cost, [data, output](ptrdiff_t first, ptrdiff_t last) {
+      ptrdiff_t len = last - first;
+      onnxruntime::ConstEigenVectorArrayMap<T> xm(data + first, len);
+      onnxruntime::EigenVectorArrayMap<T> ym(output + first, len);
+      ym = xm * static_cast<float>(M_SQRT1_2);
+      MlasComputeErf(output, output, len);
+      ym = xm * 0.5f * (ym + 1.0f);
+    });
     return Status::OK();
   }
 };


### PR DESCRIPTION
**Description**: 

Convert Gelu to use TryParallelFor

**Motivation and Context**
- Why is this change required? What problem does it solve?

So that it can also be paralleled by openmp. 

- If it fixes an open issue, please link to the issue here.


In my local test, the kernel can't get benefit from multiple threading when batch size < 40,000. So I wonder if the parallel path will ever be hit in real models. 

| Benchmark                    |batch size        |  Wall Time      | CPU Time |     Iterations      |
|-----------------------------------|----------|-----------|----------------|----------|
| BM_GeluSingleThreadPlainLoop|100   | 622 ns    | 616 ns         | 4182013  |
| BM_GeluSingleThreadPlainLoop|1000  | 6316 ns   | 6314 ns        | 475134   |
| BM_GeluSingleThreadPlainLoop|10000 | 53996 ns  | 53895 ns       | 47546    |
| BM_GeluSingleThreadPlainLoop|20000 | 120745 ns | 120546 ns      | 21387    |
| BM_GeluSingleThreadPlainLoop|40000 | 229224 ns | 228197 ns      | 13215    |
| BM_GeluSingleThread|100            | 143 ns    | 143 ns         | 19278191 |
| BM_GeluSingleThread|1000           | 1091 ns   | 1095 ns        | 2568172  |
| BM_GeluSingleThread|10000          | 11228 ns  | 11228 ns       | 254664   |
| BM_GeluSingleThread|20000          | 21730 ns  | 21778 ns       | 128425   |
| BM_GeluSingleThread|40000          | 43447 ns  | 43615 ns       | 64485    |
| BM_GeluBatchParallelFor|100        | 3567 ns   | 3557 ns        | 777573   |
| BM_GeluBatchParallelFor|1000       | 3591 ns   | 3566 ns        | 775561   |
| BM_GeluBatchParallelFor|10000      | 18992 ns  | 13193 ns       | 152781   |
| BM_GeluBatchParallelFor|20000      | 25244 ns  | 15620 ns       | 111037   |
| BM_GeluBatchParallelFor|40000      | 32736 ns  | 16133 ns       | 79416    |
| BM_GeluParallelFor/1000|1          | 1176 ns   | 1175 ns        | 2472734  |
| BM_GeluParallelFor/1000|5          | 1111 ns   | 1103 ns        | 2494243  |
| BM_GeluParallelFor/1000|10         | 1106 ns   | 1109 ns        | 2521188  |
| BM_GeluParallelFor/10000|1         | 11033 ns  | 11068 ns       | 252705   |
| BM_GeluParallelFor/10000|5         | 11066 ns  | 11060 ns       | 255718   |
| BM_GeluParallelFor/10000|10        | 11038 ns  | 11019 ns       | 255252   |
| BM_GeluParallelFor/20000|1         | 21827 ns  | 21861 ns       | 127939   |
| BM_GeluParallelFor/20000|5         | 21925 ns  | 21858 ns       | 127958   |
| BM_GeluParallelFor/20000|10        | 21927 ns  | 21935 ns       | 127510   |
| BM_GeluParallelFor/40000|1         | 43663 ns  | 43493 ns       | 63947    |
| BM_GeluParallelFor/40000|5         | 43696 ns  | 43697 ns       | 64364    |
| BM_GeluParallelFor/40000|10        | 34294 ns  | 9880 ns        | 83818    |
| BM_GeluParallelFor/100000|1        | 108928 ns | 108418 ns      | 25653    |
| BM_GeluParallelFor/100000|5        | 58607 ns  | 10615 ns       | 48573    |
| BM_GeluParallelFor/100000|10       | 57216 ns  | 10679 ns       | 48284    |
```c++
#include <benchmark/benchmark.h>
#include <core/util/math_cpuonly.h>
#include <core/session/onnxruntime_c_api.h>
#include <core/session/onnxruntime_cxx_api.h>
#include <core/util/thread_utils.h>
#include <core/providers/cpu/nn/pool_functors.h>

#include <mlas.h>
#include <random>

using namespace onnxruntime;

static float* GenerateFloatArray(size_t batch_size, float low, float high) {
	std::random_device rd;
	std::mt19937 gen(rd());
	std::uniform_real_distribution<float> dist(low, high);
	float* data = (float*)_aligned_malloc(sizeof(float) * batch_size, 64);
	for (size_t i = 0; i != batch_size; ++i) {
		data[i] = dist(gen);
	}
	return data;
}

static void BM_GeluSingleThreadPlainLoop(benchmark::State& state) {
	const size_t batch_size = static_cast<size_t>(state.range(0));
	float* output = (float*)_aligned_malloc(sizeof(float) * batch_size, 64);
	float* data = GenerateFloatArray(batch_size, -0.5, -0.5);
	for (auto _ : state) {
		for (size_t i = 0; i != batch_size; ++i) {
			float x = data[i];
			output[i] = x * 0.5f * (1.0f + std::erf(x * static_cast<float>(M_SQRT1_2)));
		}
	}
	_aligned_free(data);
	_aligned_free(output);
}

BENCHMARK(BM_GeluSingleThreadPlainLoop)->UseRealTime()->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100)->Arg(1000)->Arg(10000)->Arg(20000)->Arg(40000);


static void BM_GeluSingleThreadMlas(benchmark::State& state) {
	const size_t batch_size = static_cast<size_t>(state.range(0));
	float* output = (float*)_aligned_malloc(sizeof(float) * batch_size, 64);
	float* data = GenerateFloatArray(batch_size, -1, 1);
	for (auto _ : state) {
		onnxruntime::ConstEigenVectorArrayMap<float> xm(data, batch_size);
		onnxruntime::EigenVectorArrayMap<float> ym(output, batch_size);
		ym = xm * static_cast<float>(M_SQRT1_2);
		MlasComputeErf(output, output, batch_size);
		ym = xm * 0.5f * (ym + 1.0f);
	}
	_aligned_free(data);
	_aligned_free(output);
}

BENCHMARK(BM_GeluSingleThreadMlas)->UseRealTime()->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100)->Arg(1000)->Arg(10000)->Arg(20000)->Arg(40000);



static void BM_GeluParallelFor(benchmark::State& state) {
	const size_t batch_size = static_cast<size_t>(state.range(0));	
    const int cost = static_cast<int>(state.range(1));

	float* output = (float*)_aligned_malloc(sizeof(float) * batch_size, 64);
	float* data = GenerateFloatArray(batch_size, -1, 1);
	OrtThreadPoolParams tpo;
	tpo.auto_set_affinity = true;
    std::unique_ptr<concurrency::ThreadPool> tp(
            concurrency::CreateThreadPool(&onnxruntime::Env::Default(), tpo, nullptr));        
	for (auto _ : state) {
		tp->ParallelFor(batch_size, cost, [data, output](ptrdiff_t first, ptrdiff_t last){
		  ptrdiff_t len = last - first;
		  onnxruntime::ConstEigenVectorArrayMap<float> xm(data + first, len);
		  onnxruntime::EigenVectorArrayMap<float> ym(output + first, len);
		  ym = xm * static_cast<float>(M_SQRT1_2);
		  MlasComputeErf(output, output, len);
		  ym = xm * 0.5f * (ym + 1.0f);
		});		
	}
	_aligned_free(data);
	_aligned_free(output);
}

BENCHMARK(BM_GeluParallelFor)->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)
->Args({1000,1})
->Args({1000,5})
->Args({1000,10})
->Args({10000,1})
->Args({10000,5})
->Args({10000,10})
->Args({20000,1})
->Args({20000,5})
->Args({20000,10})
->Args({40000,1})
->Args({40000,5})
->Args({40000,10})
->Args({100000,1})
->Args({100000,5})
->Args({100000,10});


static void TestPartitionWork(std::ptrdiff_t ThreadId, std::ptrdiff_t ThreadCount, std::ptrdiff_t TotalWork,
	std::ptrdiff_t* WorkIndex, std::ptrdiff_t* WorkRemaining) {
	const std::ptrdiff_t WorkPerThread = TotalWork / ThreadCount;
	const std::ptrdiff_t WorkPerThreadExtra = TotalWork % ThreadCount;

	if (ThreadId < WorkPerThreadExtra) {
		*WorkIndex = (WorkPerThread + 1) * ThreadId;
		*WorkRemaining = WorkPerThread + 1;
	}
	else {
		*WorkIndex = WorkPerThread * ThreadId + WorkPerThreadExtra;
		*WorkRemaining = WorkPerThread;
	}
}

static void BM_GeluBatchParallelFor(benchmark::State& state) {
	const size_t batch_size = static_cast<size_t>(state.range(0));	
    const int cost = static_cast<int>(state.range(1));

	float* output = (float*)_aligned_malloc(sizeof(float) * batch_size, 64);
	float* data = GenerateFloatArray(batch_size, -1, 1);
	OrtThreadPoolParams tpo;
	tpo.auto_set_affinity = true;
    std::unique_ptr<concurrency::ThreadPool> tp(
            concurrency::CreateThreadPool(&onnxruntime::Env::Default(), tpo, nullptr));        
	const int num_batches = 4;
	for (auto _ : state) {
		tp->SimpleParallelFor(num_batches, [&](std::ptrdiff_t batch_index) {
		  std::ptrdiff_t start, work_remaining;
		  TestPartitionWork(batch_index, num_batches, batch_size, &start, &work_remaining);
		  onnxruntime::ConstEigenVectorArrayMap<float> xm(data + start, work_remaining);
		  onnxruntime::EigenVectorArrayMap<float> ym(output + start, work_remaining);
		  ym = xm * static_cast<float>(M_SQRT1_2);
		  MlasComputeErf(output, output, work_remaining);
		  ym = xm * 0.5f * (ym + 1.0f);
		});		
	}
	_aligned_free(data);
	_aligned_free(output);
}

BENCHMARK(BM_GeluBatchParallelFor)->UseRealTime()->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100)->Arg(1000)->Arg(10000)->Arg(20000)->Arg(40000);
```