### PR TITLE
TensorRT EP subgraph dump option. 

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -16,6 +16,7 @@ static const std::string kMaxPartitionIterations = "ORT_TENSORRT_MAX_PARTITION_I
 static const std::string kMinSubgraphSize = "ORT_TENSORRT_MIN_SUBGRAPH_SIZE";
 static const std::string kMaxWorkspaceSize = "ORT_TENSORRT_MAX_WORKSPACE_SIZE";
 static const std::string kFP16Enable = "ORT_TENSORRT_FP16_ENABLE";
+static const std::string kDumpSubgraphs = "ORT_TENSORRT_DUMP_SUBGRAPHS";
 }  // namespace tensorrt_env_vars
 
 class TensorrtLogger : public nvinfer1::ILogger {
@@ -86,6 +87,7 @@ class TensorrtExecutionProvider : public IExecutionProvider {
   int max_partition_iterations_ = 1000;
   int min_subgraph_size_ = 1;
   bool fp16_enable_ = false;
+  bool dump_subgraphs_ = false;
 
   struct InferDeleter {
     template <typename T>
@@ -126,7 +128,7 @@ class TensorrtExecutionProvider : public IExecutionProvider {
                                         const onnxruntime::GraphViewer& graph, bool* early_termination) const;
 
   void RemoveTensorRTGraphCycles(SubGraphCollection_t& supported_nodes_vector, const onnxruntime::GraphViewer& graph) const;
-  
+
   AllocatorPtr allocator_;
 };
 


### PR DESCRIPTION
add debug option (controlled via ORT_TENSORRT_DUMP_SUBGRAPHS environment variable)
to dump subgraphs assigned to TensorRT execution provider.
This is useful for debugging TRT Engine build failures. 