### PR TITLE
Add Features to ForecastingPivot Transformer for ONNX Export

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -450,7 +450,7 @@
       {
          "component": {
             "git": {
-               "commitHash": "7922489c1e7e7baf20c4b1557743d6c7ea72647d",
+               "commitHash": "f01d8beeac92b54bf93df8053a2acb6a8a10f03c",
                "repositoryUrl": "https://github.com/microsoft/FeaturizersLibrary.git"
             },
             "type": "git"

--- a/onnxruntime/core/graph/featurizers_ops/featurizers_defs.cc
+++ b/onnxruntime/core/graph/featurizers_ops/featurizers_defs.cc
@@ -494,6 +494,7 @@ void RegisterForecastingPivotFeaturizerVer1(){
   MS_FEATURIZERS_OPERATOR_SCHEMA(ForecastingPivotTransformer)
       .SinceVersion(1)
       .SetDomain(kMSFeaturizersDomain)
+      .Attr("num_pivot_columns", "The first num_pivot_columns input in Input1 are pivoted", AttributeProto::INT)
       .Input(
           0,
           "State",
@@ -509,7 +510,8 @@ void RegisterForecastingPivotFeaturizerVer1(){
           0,
           "Output",
           "No information is available",
-          "T")
+          "T",
+          ONNX_NAMESPACE::OpSchema::FormalParameterOption::Variadic)
       .TypeConstraint(
           "T0",
           {"tensor(uint8)"},
@@ -533,6 +535,7 @@ void RegisterForecastingPivotFeaturizerVer1(){
               }
             }
             ONNX_NAMESPACE::TensorShapeProto shape;
+            shape.add_dim();
             shape.add_dim();
             shape.add_dim();
             ONNX_NAMESPACE::updateOutputShape(ctx, 0, shape);

--- a/onnxruntime/core/graph/featurizers_ops/featurizers_defs.cc
+++ b/onnxruntime/core/graph/featurizers_ops/featurizers_defs.cc
@@ -522,12 +522,12 @@ void RegisterForecastingPivotFeaturizerVer1(){
           "No information is available")
       .TypeAndShapeInferenceFunction(
           [](ONNX_NAMESPACE::InferenceContext& ctx) {
-            auto input_elem_type = ctx.getInputType(1)->tensor_type().elem_type();
-            if (input_elem_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
-              propagateElemTypeFromDtypeToOutput(ctx, ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 0);
-            } else if (input_elem_type == ONNX_NAMESPACE::TensorProto_DataType_DOUBLE) {
-              propagateElemTypeFromDtypeToOutput(ctx, ONNX_NAMESPACE::TensorProto_DataType_DOUBLE, 0);
-            }
+            // auto input_elem_type = ctx.getInputType(1)->tensor_type().elem_type();
+            // if (input_elem_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
+            //   propagateElemTypeFromDtypeToOutput(ctx, ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 0);
+            // } else if (input_elem_type == ONNX_NAMESPACE::TensorProto_DataType_DOUBLE) {
+            //   propagateElemTypeFromDtypeToOutput(ctx, ONNX_NAMESPACE::TensorProto_DataType_DOUBLE, 0);
+            // }
             if (hasInputShape(ctx, 1)) {
               const auto& input_shape = getInputShape(ctx, 1);
               if (input_shape.dim_size() != 3) {
@@ -535,7 +535,6 @@ void RegisterForecastingPivotFeaturizerVer1(){
               }
             }
             ONNX_NAMESPACE::TensorShapeProto shape;
-            shape.add_dim();
             shape.add_dim();
             shape.add_dim();
             ONNX_NAMESPACE::updateOutputShape(ctx, 0, shape);

--- a/onnxruntime/core/graph/featurizers_ops/featurizers_defs.cc
+++ b/onnxruntime/core/graph/featurizers_ops/featurizers_defs.cc
@@ -528,8 +528,8 @@ void RegisterForecastingPivotFeaturizerVer1(){
             //The first num_pivot_columns inputs of Input(1) only support float & double
             if (hasInputShape(ctx, 1)) {
               const auto& input_shape = getInputShape(ctx, 1);
-              if (input_shape.dim_size() != 3) {
-                fail_shape_inference("Expecting Inputs to have 3 dimensions");
+              if (input_shape.dim_size() < 2) {
+                fail_shape_inference("Expecting Inputs to have more than 2 dimensions");
               }
             }
             ONNX_NAMESPACE::TensorShapeProto shape;

--- a/onnxruntime/core/graph/featurizers_ops/featurizers_defs.cc
+++ b/onnxruntime/core/graph/featurizers_ops/featurizers_defs.cc
@@ -505,29 +505,27 @@ void RegisterForecastingPivotFeaturizerVer1(){
           "Inputs",
           "Variadic number of Input containing tensors of different size",
           "T",
-          ONNX_NAMESPACE::OpSchema::FormalParameterOption::Variadic)
+          ONNX_NAMESPACE::OpSchema::FormalParameterOption::Variadic,
+          false)
       .Output(
           0,
           "Output",
           "No information is available",
           "T",
-          ONNX_NAMESPACE::OpSchema::FormalParameterOption::Variadic)
+          ONNX_NAMESPACE::OpSchema::FormalParameterOption::Variadic,
+          false)
       .TypeConstraint(
           "T0",
           {"tensor(uint8)"},
           "No information is available")
       .TypeConstraint(
           "T",
-          {"tensor(float)", "tensor(double)"},
+          {"tensor(int8)", "tensor(int16)", "tensor(int32)", "tensor(int64)", "tensor(uint8)", "tensor(uint16)", "tensor(uint32)", "tensor(uint64)",
+           "tensor(float)", "tensor(double)", "tensor(bool)", "tensor(string)"},
           "No information is available")
       .TypeAndShapeInferenceFunction(
           [](ONNX_NAMESPACE::InferenceContext& ctx) {
-            // auto input_elem_type = ctx.getInputType(1)->tensor_type().elem_type();
-            // if (input_elem_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
-            //   propagateElemTypeFromDtypeToOutput(ctx, ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 0);
-            // } else if (input_elem_type == ONNX_NAMESPACE::TensorProto_DataType_DOUBLE) {
-            //   propagateElemTypeFromDtypeToOutput(ctx, ONNX_NAMESPACE::TensorProto_DataType_DOUBLE, 0);
-            // }
+            //The first num_pivot_columns inputs of Input(1) only support float & double
             if (hasInputShape(ctx, 1)) {
               const auto& input_shape = getInputShape(ctx, 1);
               if (input_shape.dim_size() != 3) {

--- a/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
@@ -95,6 +95,7 @@ struct ForecastingPivotTransformerImpl {
     transformer.flush(callback_fn);
 
     // Prepare the number of output rows
+    ORT_ENFORCE(!output.empty(), "All rows dropped is an exception");
     int num_output_rows = static_cast<int>(output.size());
     ORT_ENFORCE(static_cast<int>(row_idx_record.size()) == num_output_rows, "row_idx_record.size() == num_output_rows");
 

--- a/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
@@ -194,9 +194,18 @@ ONNX_OPERATOR_KERNEL_EX(
     kCpuExecutionProvider,
     KernelDefBuilder()
         .TypeConstraint("T0", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
-                              DataTypeImpl::GetTensorType<double>()
-                              }),
+        .TypeConstraint("T", {DataTypeImpl::GetTensorType<int8_t>(),
+                              DataTypeImpl::GetTensorType<uint8_t>(),
+                              DataTypeImpl::GetTensorType<int16_t>(),
+                              DataTypeImpl::GetTensorType<uint16_t>(),
+                              DataTypeImpl::GetTensorType<int32_t>(),
+                              DataTypeImpl::GetTensorType<uint32_t>(),
+                              DataTypeImpl::GetTensorType<int64_t>(),
+                              DataTypeImpl::GetTensorType<uint64_t>(),
+                              DataTypeImpl::GetTensorType<float>(),
+                              DataTypeImpl::GetTensorType<double>(),
+                              DataTypeImpl::GetTensorType<bool>(),
+                              DataTypeImpl::GetTensorType<std::string>()}),
     ForecastingPivotTransformer);
 
 }  // namespace featurizers

--- a/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
@@ -95,7 +95,7 @@ struct ForecastingPivotTransformerImpl {
     transformer.flush(callback_fn);
 
     // Prepare the number of output rows
-    int num_output_rows = output.size();
+    int num_output_rows = static_cast<int>(output.size());
     ORT_ENFORCE(static_cast<int>(row_idx_record.size()) == num_output_rows, "row_idx_record.size() == num_output_rows");
 
     // Prepare the pivoted Output
@@ -143,7 +143,7 @@ struct ForecastingPivotTransformerImpl {
       }
     }
     TensorShape output_shape_horizon({static_cast<int64_t>(num_output_rows), 1});
-    Tensor* output_tensor_horizon(ctx->Output(input_node_1_count + num_pivot_output_columns - num_pivot_columns, output_shape_horizon));
+    Tensor* output_tensor_horizon(ctx->Output(input_node_1_count + num_pivot_output_columns - static_cast<int>(num_pivot_columns), output_shape_horizon));
     int32_t* output_data_horizon = output_tensor_horizon->MutableData<int32_t>();
 
     std::copy(horizon_output_helper.begin(), horizon_output_helper.end(), output_data_horizon);

--- a/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
@@ -15,7 +15,7 @@ namespace featurizers {
 
 template <typename T>
 struct ForecastingPivotTransformerImpl {
-  void operator()(OpKernelContext* ctx, int num_pivot_columns) const {
+  void operator()(OpKernelContext* ctx, int64_t num_pivot_columns) const {
     using MatrixT = NS::RowMajMatrix<typename NS::Traits<T>::nullable_type>;
     using InputType = std::vector<Eigen::Map<const MatrixT>>;
     using OutputType = std::vector<T>;
@@ -87,7 +87,7 @@ struct ForecastingPivotTransformerImpl {
 
     // Prepare the imputed Output
     for (int i = 0; i < input_node_1_count - num_pivot_columns; i++) {
-      const auto* input_tensor(ctx->Input<Tensor>(input_node_0_count + num_pivot_columns + i));
+      const auto* input_tensor(ctx->Input<Tensor>(input_node_0_count + static_cast<int>(num_pivot_columns) + i));
       const T* input_data(input_tensor->template Data<T>());
 
       const int64_t input_dim_1 = input_tensor->Shape()[1];

--- a/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
@@ -15,7 +15,7 @@ namespace featurizers {
 
 template <typename T>
 struct ForecastingPivotTransformerImpl {
-  void operator()(OpKernelContext* ctx) const {
+  void operator()(OpKernelContext* ctx, int num_pivot_columns) const {
     using MatrixT = NS::RowMajMatrix<typename NS::Traits<T>::nullable_type>;
     using InputType = std::vector<Eigen::Map<const MatrixT>>;
     using OutputType = std::vector<T>;
@@ -33,21 +33,25 @@ struct ForecastingPivotTransformerImpl {
 
     //Get the output for whole rows is inevitable because there is conceptually no way to determine the shape of output for each row
     std::vector<OutputType> output;
+    std::vector<int64_t> row_idx_record;
+    int64_t row_idx = 0;
     std::function<void(OutputType const & value)> callback_fn;
-    callback_fn = [&output](OutputType const & value) -> void {
+    callback_fn = [&output, &row_idx_record, &row_idx](OutputType const & value) -> void {
       output.emplace_back(value);
+      row_idx_record.push_back(row_idx);
     };
 
     // Transform
     const int input_node_0_count = ctx->NumVariadicInputs(0);
     const int input_node_1_count = ctx->NumVariadicInputs(1);
+
     InputType input;
-    input.reserve(input_node_1_count);
+    input.reserve(num_pivot_columns);
     std::unordered_map<int, std::tuple<const T*,int64_t, int64_t>> dataPtrMap;
-    for (int64_t row_idx = 0; row_idx < row_num; ++row_idx) {
+    for (row_idx = 0; row_idx < row_num; ++row_idx) {
       //Prepare Input and Output
       input.clear();
-      for (int index = input_node_0_count; index < input_node_0_count + input_node_1_count; ++index) {
+      for (int index = input_node_0_count; index < input_node_0_count + num_pivot_columns; ++index) {
         if (row_idx == 0) {
           //Get the Input
           const auto* input_tensor(ctx->Input<Tensor>(index));
@@ -72,28 +76,53 @@ struct ForecastingPivotTransformerImpl {
     }
     transformer.flush(callback_fn);
 
-    // Prepare the Output
-    TensorShape output_shape({static_cast<int64_t>(output.size()), static_cast<int64_t>(output[0].size())});
+    // Prepare the pivoted Output
+    TensorShape output_shape({static_cast<int64_t>(output.size()), 1, static_cast<int64_t>(output[0].size())});
     Tensor* output_tensor(ctx->Output(0, output_shape));
     T* output_data = output_tensor->MutableData<T>();
 
-    for (OutputType const & row : output)
+    for (OutputType const & row : output) {
       output_data = std::copy(row.begin(), row.end(), output_data);
+    }
+
+    // Prepare the imputed Output
+    for (int i = 0; i < input_node_1_count - num_pivot_columns; i++) {
+      const auto* input_tensor(ctx->Input<Tensor>(input_node_0_count + num_pivot_columns + i));
+      const T* input_data(input_tensor->template Data<T>());
+
+      const int64_t input_dim_1 = input_tensor->Shape()[1];
+      const int64_t input_dim_2 = input_tensor->Shape()[2];
+      const int64_t input_matrix_size = input_dim_1 * input_dim_2;
+
+      TensorShape output_shape_imputed({static_cast<int64_t>(row_idx_record.size()), input_dim_1, input_dim_2});
+      Tensor* output_tensor_imputed(ctx->Output(i + 1, output_shape_imputed));
+      T* output_data_imputed = output_tensor_imputed->MutableData<T>();
+
+      for (int j = 0; j < static_cast<int>(row_idx_record.size()); j++) {
+        output_data_imputed = std::copy(input_data + row_idx_record[j] * input_matrix_size,
+                                        input_data + (row_idx_record[j] + 1) * input_matrix_size,
+                                        output_data_imputed);
+      }
+    }
+
   }
 };
 
 class ForecastingPivotTransformer final : public OpKernel {
  public:
-  explicit ForecastingPivotTransformer(const OpKernelInfo& info) : OpKernel(info) {
+  explicit ForecastingPivotTransformer(const OpKernelInfo& info) :
+    OpKernel(info), _num_pivot_columns(info.GetAttrOrDefault("num_pivot_columns", static_cast<int64_t>(0))) {
   }
 
   Status Compute(OpKernelContext* ctx) const override {
     utils::MLTypeCallDispatcher<ForecastingPivotTransformerImpl, float, double>
         t_disp(ctx->Input<Tensor>(1)->GetElementType());
-    t_disp.Invoke(ctx);
+    t_disp.Invoke(ctx, _num_pivot_columns);
 
     return Status::OK();
   }
+ private:
+  const int64_t _num_pivot_columns;
 };
 
 ONNX_OPERATOR_KERNEL_EX(

--- a/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
@@ -88,6 +88,7 @@ struct ForecastingPivotTransformerImpl {
         input.push_back(typename InputType::value_type(input_data, input_dim_1, input_dim_2));
         //Increment data pointer
         input_data += input_dim_1 * input_dim_2;
+        std::get<0>(inputTuple) = input_data;
       }
       //Execute
       transformer.execute(std::make_tuple(input.begin(), input.end()), callback_fn);

--- a/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
@@ -109,7 +109,7 @@ struct ForecastingPivotTransformerImpl {
             break;
         }
         if (!has_nan) {
-          horizon_output_helper.push_back(matrix_cols_num - col_idx);
+          horizon_output_helper.push_back(static_cast<uint32_t>(matrix_cols_num - col_idx));
         }
       }
 
@@ -161,13 +161,7 @@ struct ForecastingPivotTransformerImpl {
       t_disp.Invoke(input_tensor, output_tensor_imputed, row_idx_record, input_matrix_size, num_output_rows);
     }
 
-    // Prepare the horizon Output(int32)
-    // std::vector<uint32_t> horizon_output_helper(num_output_rows, 1);
-    // for (int i = 1; i < num_output_rows; i++) {
-    //   if (row_idx_record[num_output_rows - 1 - i] == row_idx_record[num_output_rows - i]) {
-    //     horizon_output_helper[num_output_rows - 1 - i] = horizon_output_helper[num_output_rows - i] + 1;
-    //   }
-    // }
+    // Prepare the horizon Output(uint32)
     TensorShape output_shape_horizon({static_cast<int64_t>(num_output_rows), 1});
     Tensor* output_tensor_horizon(ctx->Output(input_node_1_count + num_pivot_output_columns - static_cast<int>(num_pivot_columns), output_shape_horizon));
     uint32_t* output_data_horizon = output_tensor_horizon->MutableData<uint32_t>();

--- a/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/forecasting_pivot_transformer.cc
@@ -135,8 +135,8 @@ struct ForecastingPivotTransformerImpl {
       t_disp.Invoke(input_tensor, output_tensor_imputed, row_idx_record, input_matrix_size, num_output_rows);
     }
 
-    // Prepare the horizon Output
-    std::vector<int> horizon_output_helper(num_output_rows, 1);
+    // Prepare the horizon Output(int32)
+    std::vector<int32_t> horizon_output_helper(num_output_rows, 1);
     for (int i = 1; i < num_output_rows; i++) {
       if (row_idx_record[num_output_rows - 1 - i] == row_idx_record[num_output_rows - i]) {
         horizon_output_helper[num_output_rows - 1 - i] = horizon_output_helper[num_output_rows - i] + 1;
@@ -144,7 +144,7 @@ struct ForecastingPivotTransformerImpl {
     }
     TensorShape output_shape_horizon({static_cast<int64_t>(num_output_rows), 1});
     Tensor* output_tensor_horizon(ctx->Output(input_node_1_count + num_pivot_output_columns - num_pivot_columns, output_shape_horizon));
-    T* output_data_horizon = output_tensor_horizon->MutableData<T>();
+    int32_t* output_data_horizon = output_tensor_horizon->MutableData<int32_t>();
 
     std::copy(horizon_output_helper.begin(), horizon_output_helper.end(), output_data_horizon);
   }

--- a/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
@@ -29,21 +29,21 @@ std::vector<uint8_t> GetStream() {
 } // namespace
 
 TEST(FeaturizersTests, ForecastingPivotTransformer_2_Inputs) {
-  auto stream = GetStream<float>();
+  auto stream = GetStream<double>();
   auto dim = static_cast<int64_t>(stream.size());
   OpTester test("ForecastingPivotTransformer", 1, onnxruntime::kMSFeaturizersDomain);
   test.AddAttribute<int64_t>("num_pivot_columns", static_cast<int64_t>(2));
   test.AddInput<uint8_t>("State", {dim}, stream);
   test.AddInput<double>("Input_1", {2, 3, 4}, {1, 6, 3, 9,
                                               2, 4, 5, 8,
-                                              NS::Traits<float>::CreateNullValue(), NS::Traits<float>::CreateNullValue(), 7, 10,
+                                              NS::Traits<double>::CreateNullValue(), NS::Traits<double>::CreateNullValue(), 7, 10,
                                               1, 6, 9, 3,
                                               2, 4, 8, 5,
-                                              NS::Traits<float>::CreateNullValue(), NS::Traits<float>::CreateNullValue(), 10, 7});
-  test.AddInput<double>("Input_2", {2, 2, 4}, {2, NS::Traits<float>::CreateNullValue(), 5, 6,
-                                              2, NS::Traits<float>::CreateNullValue(), 3, 4,
-                                              2, NS::Traits<float>::CreateNullValue(), 5, 6,
-                                              2, NS::Traits<float>::CreateNullValue(), 3, 4});
+                                              NS::Traits<double>::CreateNullValue(), NS::Traits<double>::CreateNullValue(), 10, 7});
+  test.AddInput<double>("Input_2", {2, 2, 4}, {2, NS::Traits<double>::CreateNullValue(), 5, 6,
+                                              2, NS::Traits<double>::CreateNullValue(), 3, 4,
+                                              2, NS::Traits<double>::CreateNullValue(), 5, 6,
+                                              2, NS::Traits<double>::CreateNullValue(), 3, 4});
   test.AddOutput<double>("Output_1", {4, 1}, {3, 9, 9, 3});
   test.AddOutput<double>("Output_2", {4, 1}, {5, 8, 8, 5});
   test.AddOutput<double>("Output_3", {4, 1}, {7, 10, 10, 7});
@@ -56,21 +56,21 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_2_Inputs) {
 }
 
 TEST(FeaturizersTests, ForecastingPivotTransformer_4_Inputs) {
-  auto stream = GetStream<float>();
+  auto stream = GetStream<double>();
   auto dim = static_cast<int64_t>(stream.size());
   OpTester test("ForecastingPivotTransformer", 1, onnxruntime::kMSFeaturizersDomain);
   test.AddAttribute<int64_t>("num_pivot_columns", static_cast<int64_t>(2));
   test.AddInput<uint8_t>("State", {dim}, stream);
   test.AddInput<double>("Input_1", {2, 3, 4}, {1, 6, 3, 9,
                                               2, 4, 5, 8,
-                                              NS::Traits<float>::CreateNullValue(), NS::Traits<float>::CreateNullValue(), 7, 10,
+                                              NS::Traits<double>::CreateNullValue(), NS::Traits<double>::CreateNullValue(), 7, 10,
                                               1, 6, 3, 9,
                                               2, 4, 5, 8,
-                                              NS::Traits<float>::CreateNullValue(), NS::Traits<float>::CreateNullValue(), 7, 10});
-  test.AddInput<double>("Input_2", {2, 2, 4}, {2, NS::Traits<float>::CreateNullValue(), 5, 6,
-                                              2, NS::Traits<float>::CreateNullValue(), 3, 4,
-                                              2, NS::Traits<float>::CreateNullValue(), 5, 6,
-                                              2, NS::Traits<float>::CreateNullValue(), 3, 4});
+                                              NS::Traits<double>::CreateNullValue(), NS::Traits<double>::CreateNullValue(), 7, 10});
+  test.AddInput<double>("Input_2", {2, 2, 4}, {2, NS::Traits<double>::CreateNullValue(), 5, 6,
+                                              2, NS::Traits<double>::CreateNullValue(), 3, 4,
+                                              2, NS::Traits<double>::CreateNullValue(), 5, 6,
+                                              2, NS::Traits<double>::CreateNullValue(), 3, 4});
 
   test.AddInput<std::string>("Input_3", {2, 1, 4}, {"7", "7", "7", "7",
                                                "9", "9", "9", "9"});
@@ -99,7 +99,7 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_4_Inputs) {
 }
 
 TEST(FeaturizersTests, ForecastingPivotTransformer_1_Input_1) {
-  auto stream = GetStream<float>();
+  auto stream = GetStream<double>();
   auto dim = static_cast<int64_t>(stream.size());
   OpTester test("ForecastingPivotTransformer", 1, onnxruntime::kMSFeaturizersDomain);
   test.AddAttribute<int64_t>("num_pivot_columns", static_cast<int64_t>(1));
@@ -113,16 +113,51 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_1_Input_1) {
 }
 
 TEST(FeaturizersTests, ForecastingPivotTransformer_1_Input_2) {
-  auto stream = GetStream<float>();
+  auto stream = GetStream<double>();
   auto dim = static_cast<int64_t>(stream.size());
   OpTester test("ForecastingPivotTransformer", 1, onnxruntime::kMSFeaturizersDomain);
   test.AddAttribute<int64_t>("num_pivot_columns", static_cast<int64_t>(1));
   test.AddInput<uint8_t>("State", {dim}, stream);
-  test.AddInput<double>("Input_1", {2, 1, 2}, {1, NS::Traits<float>::CreateNullValue(), 3, 9});
+  test.AddInput<double>("Input_1", {2, 1, 2}, {1, NS::Traits<double>::CreateNullValue(),
+                                               3, 9});
   test.AddOutput<double>("Output_1", {3, 1}, {1, 3, 9});
 
   //horizon output
   test.AddOutput<uint32_t>("Output_2", {3, 1}, {2, 2, 1});
+  test.Run();
+}
+
+TEST(FeaturizersTests, ForecastingPivotTransformer_1_Input_3) {
+  auto stream = GetStream<double>();
+  auto dim = static_cast<int64_t>(stream.size());
+  OpTester test("ForecastingPivotTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+  test.AddAttribute<int64_t>("num_pivot_columns", static_cast<int64_t>(1));
+  test.AddInput<uint8_t>("State", {dim}, stream);
+  test.AddInput<double>("Input_1", {1, 3, 4}, {1, 4, 6, NS::Traits<double>::CreateNullValue(),
+                                               2, 5, NS::Traits<double>::CreateNullValue(), NS::Traits<double>::CreateNullValue(),
+                                               3, NS::Traits<double>::CreateNullValue(), NS::Traits<double>::CreateNullValue(), 7});
+  test.AddOutput<double>("Output_1", {1, 1}, {1});
+  test.AddOutput<double>("Output_2", {1, 1}, {2});
+  test.AddOutput<double>("Output_3", {1, 1}, {3});
+  //horizon output
+  test.AddOutput<uint32_t>("Output_4", {1, 1}, {4});
+
+  test.Run();
+}
+
+TEST(FeaturizersTests, ForecastingPivotTransformer_1_Input_Horizon) {
+  auto stream = GetStream<double>();
+  auto dim = static_cast<int64_t>(stream.size());
+  OpTester test("ForecastingPivotTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+  test.AddAttribute<int64_t>("num_pivot_columns", static_cast<int64_t>(1));
+  test.AddInput<uint8_t>("State", {dim}, stream);
+  test.AddInput<double>("Input_1", {3, 1, 6}, {1, NS::Traits<double>::CreateNullValue(), 3, NS::Traits<double>::CreateNullValue(), 5, NS::Traits<double>::CreateNullValue(),
+                                               NS::Traits<double>::CreateNullValue(), 2, 3, NS::Traits<double>::CreateNullValue(), 5, 6,
+                                               1, 2, 3, NS::Traits<double>::CreateNullValue(), NS::Traits<double>::CreateNullValue(), NS::Traits<double>::CreateNullValue()});
+  test.AddOutput<double>("Output_1", {10, 1}, {1, 3, 5, 2, 3, 5, 6, 1, 2, 3});
+
+  //horizon output
+  test.AddOutput<uint32_t>("Output_2", {10, 1}, {6, 4, 2, 5, 4, 2, 1, 6, 5, 4});
   test.Run();
 }
 

--- a/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
@@ -44,11 +44,13 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_2_Inputs) {
                                               2, NS::Traits<float>::CreateNullValue(), 3, 4,
                                               2, NS::Traits<float>::CreateNullValue(), 5, 6,
                                               2, NS::Traits<float>::CreateNullValue(), 3, 4});
-  test.AddOutput<double>("Output_1", {4, 1, 5}, {3, 9, 3, 9});
-  test.AddOutput<double>("Output_2", {4, 1, 5}, {5, 8, 5, 8});
-  test.AddOutput<double>("Output_3", {4, 1, 5}, {7, 10, 7, 10});
-  test.AddOutput<double>("Output_4", {4, 1, 5}, {5, 6, 5, 6});
-  test.AddOutput<double>("Output_5", {4, 1, 5}, {3, 4, 3, 4});
+  test.AddOutput<double>("Output_1", {4, 1}, {3, 9, 3, 9});
+  test.AddOutput<double>("Output_2", {4, 1}, {5, 8, 5, 8});
+  test.AddOutput<double>("Output_3", {4, 1}, {7, 10, 7, 10});
+  test.AddOutput<double>("Output_4", {4, 1}, {5, 6, 5, 6});
+  test.AddOutput<double>("Output_5", {4, 1}, {3, 4, 3, 4});
+  //horizon output
+  test.AddOutput<double>("Output_6", {4, 1}, {2, 1, 2, 1});
 
   test.Run();
 }
@@ -73,20 +75,23 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_4_Inputs) {
                                                9, 9, 9, 9});
   test.AddInput<double>("Input_4", {2, 1, 4}, {-7, -7, -7, -7,
                                                -9, -9, -9, -9});
-
-  test.AddOutput<double>("Output_1", {4, 1, 5}, {3, 9, 3, 9});
-  test.AddOutput<double>("Output_2", {4, 1, 5}, {5, 8, 5, 8});
-  test.AddOutput<double>("Output_3", {4, 1, 5}, {7, 10, 7, 10});
-  test.AddOutput<double>("Output_4", {4, 1, 5}, {5, 6, 5, 6});
-  test.AddOutput<double>("Output_5", {4, 1, 5}, {3, 4, 3, 4});
-  test.AddOutput<double>("Output_6", {4, 1, 4}, {7, 7, 7, 7,
-                                                 7, 7, 7, 7,
-                                                 9, 9, 9, 9,
-                                                 9, 9, 9, 9});
-  test.AddOutput<double>("Output_7", {4, 1, 4}, {-7, -7, -7, -7,
-                                                 -7, -7, -7, -7,
-                                                 -9, -9, -9, -9,
-                                                 -9, -9, -9, -9});
+  //pivot output
+  test.AddOutput<double>("Output_1", {4, 1}, {3, 9, 3, 9});
+  test.AddOutput<double>("Output_2", {4, 1}, {5, 8, 5, 8});
+  test.AddOutput<double>("Output_3", {4, 1}, {7, 10, 7, 10});
+  test.AddOutput<double>("Output_4", {4, 1}, {5, 6, 5, 6});
+  test.AddOutput<double>("Output_5", {4, 1}, {3, 4, 3, 4});
+  //non-pivot output
+  test.AddOutput<double>("Output_6", {4, 4}, {7, 7, 7, 7,
+                                              7, 7, 7, 7,
+                                              9, 9, 9, 9,
+                                              9, 9, 9, 9});
+  test.AddOutput<double>("Output_7", {4, 4}, {-7, -7, -7, -7,
+                                              -7, -7, -7, -7,
+                                              -9, -9, -9, -9,
+                                              -9, -9, -9, -9});
+  //horizon output
+  test.AddOutput<double>("Output_8", {4, 1}, {2, 1, 2, 1});
 
   test.Run();
 }

--- a/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
@@ -37,16 +37,16 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_2_Inputs) {
   test.AddInput<double>("Input_1", {2, 3, 4}, {1, 6, 3, 9,
                                               2, 4, 5, 8,
                                               NS::Traits<float>::CreateNullValue(), NS::Traits<float>::CreateNullValue(), 7, 10,
-                                              1, 6, 3, 9,
-                                              2, 4, 5, 8,
-                                              NS::Traits<float>::CreateNullValue(), NS::Traits<float>::CreateNullValue(), 7, 10});
+                                              1, 6, 9, 3,
+                                              2, 4, 8, 5,
+                                              NS::Traits<float>::CreateNullValue(), NS::Traits<float>::CreateNullValue(), 10, 7});
   test.AddInput<double>("Input_2", {2, 2, 4}, {2, NS::Traits<float>::CreateNullValue(), 5, 6,
                                               2, NS::Traits<float>::CreateNullValue(), 3, 4,
                                               2, NS::Traits<float>::CreateNullValue(), 5, 6,
                                               2, NS::Traits<float>::CreateNullValue(), 3, 4});
-  test.AddOutput<double>("Output_1", {4, 1}, {3, 9, 3, 9});
-  test.AddOutput<double>("Output_2", {4, 1}, {5, 8, 5, 8});
-  test.AddOutput<double>("Output_3", {4, 1}, {7, 10, 7, 10});
+  test.AddOutput<double>("Output_1", {4, 1}, {3, 9, 9, 3});
+  test.AddOutput<double>("Output_2", {4, 1}, {5, 8, 8, 5});
+  test.AddOutput<double>("Output_3", {4, 1}, {7, 10, 10, 7});
   test.AddOutput<double>("Output_4", {4, 1}, {5, 6, 5, 6});
   test.AddOutput<double>("Output_5", {4, 1}, {3, 4, 3, 4});
   //horizon output
@@ -96,6 +96,34 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_4_Inputs) {
   //horizon output
   test.AddOutput<uint32_t>("Output_8", {4, 1}, {2, 1, 2, 1});
 
+  test.Run();
+}
+
+TEST(FeaturizersTests, ForecastingPivotTransformer_1_Input_1) {
+  auto stream = GetStream<float>();
+  auto dim = static_cast<int64_t>(stream.size());
+  OpTester test("ForecastingPivotTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+  test.AddAttribute<int64_t>("num_pivot_columns", static_cast<int64_t>(1));
+  test.AddInput<uint8_t>("State", {dim}, stream);
+  test.AddInput<double>("Input_1", {2, 1, 2}, {1, 6, 3, 9});
+  test.AddOutput<double>("Output_1", {4, 1}, {1, 6, 3, 9});
+
+  //horizon output
+  test.AddOutput<uint32_t>("Output_2", {4, 1}, {2, 1, 2, 1});
+  test.Run();
+}
+
+TEST(FeaturizersTests, ForecastingPivotTransformer_1_Input_2) {
+  auto stream = GetStream<float>();
+  auto dim = static_cast<int64_t>(stream.size());
+  OpTester test("ForecastingPivotTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+  test.AddAttribute<int64_t>("num_pivot_columns", static_cast<int64_t>(1));
+  test.AddInput<uint8_t>("State", {dim}, stream);
+  test.AddInput<double>("Input_1", {2, 1, 2}, {1, NS::Traits<float>::CreateNullValue(), 3, 9});
+  test.AddOutput<double>("Output_1", {3, 1}, {1, 3, 9});
+
+  //horizon output
+  test.AddOutput<uint32_t>("Output_2", {3, 1}, {1, 2, 1});
   test.Run();
 }
 

--- a/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
@@ -50,7 +50,7 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_2_Inputs) {
   test.AddOutput<double>("Output_4", {4, 1}, {5, 6, 5, 6});
   test.AddOutput<double>("Output_5", {4, 1}, {3, 4, 3, 4});
   //horizon output
-  test.AddOutput<double>("Output_6", {4, 1}, {2, 1, 2, 1});
+  test.AddOutput<int32_t>("Output_6", {4, 1}, {2, 1, 2, 1});
 
   test.Run();
 }
@@ -94,7 +94,7 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_4_Inputs) {
                                               -9, -9, -9, -9,
                                               -9, -9, -9, -9});
   //horizon output
-  test.AddOutput<double>("Output_8", {4, 1}, {2, 1, 2, 1});
+  test.AddOutput<int32_t>("Output_8", {4, 1}, {2, 1, 2, 1});
 
   test.Run();
 }

--- a/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
@@ -32,6 +32,7 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_2_Inputs) {
   auto stream = GetStream<float>();
   auto dim = static_cast<int64_t>(stream.size());
   OpTester test("ForecastingPivotTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+  test.AddAttribute<int64_t>("num_pivot_columns", static_cast<int64_t>(2));
   test.AddInput<uint8_t>("State", {dim}, stream);
   test.AddInput<double>("Input_1", {2, 3, 4}, {1, 6, 3, 9,
                                               2, 4, 5, 8,
@@ -43,7 +44,7 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_2_Inputs) {
                                               2, NS::Traits<float>::CreateNullValue(), 3, 4,
                                               2, NS::Traits<float>::CreateNullValue(), 5, 6,
                                               2, NS::Traits<float>::CreateNullValue(), 3, 4});
-  test.AddOutput<double>("Output", {4, 5}, {3, 5, 7, 5, 3,
+  test.AddOutput<double>("Output_1", {4, 1, 5}, {3, 5, 7, 5, 3,
                                             9, 8, 10, 6, 4,
                                             3, 5, 7, 5, 3,
                                             9, 8, 10, 6, 4});
@@ -55,6 +56,7 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_3_Inputs) {
   auto stream = GetStream<float>();
   auto dim = static_cast<int64_t>(stream.size());
   OpTester test("ForecastingPivotTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+  test.AddAttribute<int64_t>("num_pivot_columns", static_cast<int64_t>(2));
   test.AddInput<uint8_t>("State", {dim}, stream);
   test.AddInput<double>("Input_1", {2, 3, 4}, {1, 6, 3, 9,
                                               2, 4, 5, 8,
@@ -66,12 +68,22 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_3_Inputs) {
                                               2, NS::Traits<float>::CreateNullValue(), 3, 4,
                                               2, NS::Traits<float>::CreateNullValue(), 5, 6,
                                               2, NS::Traits<float>::CreateNullValue(), 3, 4});
-  test.AddInput<double>("Input_3", {2, 1, 4}, {0, 0, 0, 0,
-                                               0, 0, 0, 0});
-  test.AddOutput<double>("Output", {4, 6}, {3, 5, 7, 5, 3, 0,
-                                            9, 8, 10, 6, 4, 0,
-                                            3, 5, 7, 5, 3, 0,
-                                            9, 8, 10, 6, 4, 0});
+  test.AddInput<double>("Input_3", {2, 1, 4}, {7, 7, 7, 7,
+                                               9, 9, 9, 9});
+  test.AddInput<double>("Input_4", {2, 1, 4}, {-7, -7, -7, -7,
+                                               -9, -9, -9, -9});
+  test.AddOutput<double>("Output_1", {4, 1, 5}, {3, 5, 7, 5, 3,
+                                                 9, 8, 10, 6, 4,
+                                                 3, 5, 7, 5, 3,
+                                                 9, 8, 10, 6, 4});
+  test.AddOutput<double>("Output_2", {4, 1, 4}, {7, 7, 7, 7,
+                                                 7, 7, 7, 7,
+                                                 9, 9, 9, 9,
+                                                 9, 9, 9, 9});
+  test.AddOutput<double>("Output_3", {4, 1, 4}, {-7, -7, -7, -7,
+                                                 -7, -7, -7, -7,
+                                                 -9, -9, -9, -9,
+                                                 -9, -9, -9, -9});
 
   test.Run();
 }

--- a/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
@@ -50,7 +50,7 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_2_Inputs) {
   test.AddOutput<double>("Output_4", {4, 1}, {5, 6, 5, 6});
   test.AddOutput<double>("Output_5", {4, 1}, {3, 4, 3, 4});
   //horizon output
-  test.AddOutput<int32_t>("Output_6", {4, 1}, {2, 1, 2, 1});
+  test.AddOutput<uint32_t>("Output_6", {4, 1}, {2, 1, 2, 1});
 
   test.Run();
 }
@@ -74,7 +74,7 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_4_Inputs) {
 
   test.AddInput<std::string>("Input_3", {2, 1, 4}, {"7", "7", "7", "7",
                                                "9", "9", "9", "9"});
-  test.AddInput<double>("Input_4", {2, 1, 4}, {-7, -7, -7, -7,
+  test.AddInput<double>("Input_4", {2, 4}, {-7, -7, -7, -7,
                                                -9, -9, -9, -9});
 
   //pivot output
@@ -94,7 +94,7 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_4_Inputs) {
                                               -9, -9, -9, -9,
                                               -9, -9, -9, -9});
   //horizon output
-  test.AddOutput<int32_t>("Output_8", {4, 1}, {2, 1, 2, 1});
+  test.AddOutput<uint32_t>("Output_8", {4, 1}, {2, 1, 2, 1});
 
   test.Run();
 }

--- a/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
@@ -52,7 +52,7 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_2_Inputs) {
   test.Run();
 }
 
-TEST(FeaturizersTests, ForecastingPivotTransformer_3_Inputs) {
+TEST(FeaturizersTests, ForecastingPivotTransformer_4_Inputs) {
   auto stream = GetStream<float>();
   auto dim = static_cast<int64_t>(stream.size());
   OpTester test("ForecastingPivotTransformer", 1, onnxruntime::kMSFeaturizersDomain);

--- a/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
@@ -44,10 +44,11 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_2_Inputs) {
                                               2, NS::Traits<float>::CreateNullValue(), 3, 4,
                                               2, NS::Traits<float>::CreateNullValue(), 5, 6,
                                               2, NS::Traits<float>::CreateNullValue(), 3, 4});
-  test.AddOutput<double>("Output_1", {4, 1, 5}, {3, 5, 7, 5, 3,
-                                            9, 8, 10, 6, 4,
-                                            3, 5, 7, 5, 3,
-                                            9, 8, 10, 6, 4});
+  test.AddOutput<double>("Output_1", {4, 1, 5}, {3, 9, 3, 9});
+  test.AddOutput<double>("Output_2", {4, 1, 5}, {5, 8, 5, 8});
+  test.AddOutput<double>("Output_3", {4, 1, 5}, {7, 10, 7, 10});
+  test.AddOutput<double>("Output_4", {4, 1, 5}, {5, 6, 5, 6});
+  test.AddOutput<double>("Output_5", {4, 1, 5}, {3, 4, 3, 4});
 
   test.Run();
 }
@@ -72,15 +73,17 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_4_Inputs) {
                                                9, 9, 9, 9});
   test.AddInput<double>("Input_4", {2, 1, 4}, {-7, -7, -7, -7,
                                                -9, -9, -9, -9});
-  test.AddOutput<double>("Output_1", {4, 1, 5}, {3, 5, 7, 5, 3,
-                                                 9, 8, 10, 6, 4,
-                                                 3, 5, 7, 5, 3,
-                                                 9, 8, 10, 6, 4});
-  test.AddOutput<double>("Output_2", {4, 1, 4}, {7, 7, 7, 7,
+
+  test.AddOutput<double>("Output_1", {4, 1, 5}, {3, 9, 3, 9});
+  test.AddOutput<double>("Output_2", {4, 1, 5}, {5, 8, 5, 8});
+  test.AddOutput<double>("Output_3", {4, 1, 5}, {7, 10, 7, 10});
+  test.AddOutput<double>("Output_4", {4, 1, 5}, {5, 6, 5, 6});
+  test.AddOutput<double>("Output_5", {4, 1, 5}, {3, 4, 3, 4});
+  test.AddOutput<double>("Output_6", {4, 1, 4}, {7, 7, 7, 7,
                                                  7, 7, 7, 7,
                                                  9, 9, 9, 9,
                                                  9, 9, 9, 9});
-  test.AddOutput<double>("Output_3", {4, 1, 4}, {-7, -7, -7, -7,
+  test.AddOutput<double>("Output_7", {4, 1, 4}, {-7, -7, -7, -7,
                                                  -7, -7, -7, -7,
                                                  -9, -9, -9, -9,
                                                  -9, -9, -9, -9});

--- a/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
@@ -95,7 +95,6 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_4_Inputs) {
                                               -9, -9, -9, -9});
   //horizon output
   test.AddOutput<uint32_t>("Output_8", {4, 1}, {2, 1, 2, 1});
-
   test.Run();
 }
 
@@ -123,7 +122,7 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_1_Input_2) {
   test.AddOutput<double>("Output_1", {3, 1}, {1, 3, 9});
 
   //horizon output
-  test.AddOutput<uint32_t>("Output_2", {3, 1}, {1, 2, 1});
+  test.AddOutput<uint32_t>("Output_2", {3, 1}, {2, 2, 1});
   test.Run();
 }
 

--- a/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/forecasting_pivot_transformer_test.cc
@@ -71,21 +71,24 @@ TEST(FeaturizersTests, ForecastingPivotTransformer_4_Inputs) {
                                               2, NS::Traits<float>::CreateNullValue(), 3, 4,
                                               2, NS::Traits<float>::CreateNullValue(), 5, 6,
                                               2, NS::Traits<float>::CreateNullValue(), 3, 4});
-  test.AddInput<double>("Input_3", {2, 1, 4}, {7, 7, 7, 7,
-                                               9, 9, 9, 9});
+
+  test.AddInput<std::string>("Input_3", {2, 1, 4}, {"7", "7", "7", "7",
+                                               "9", "9", "9", "9"});
   test.AddInput<double>("Input_4", {2, 1, 4}, {-7, -7, -7, -7,
                                                -9, -9, -9, -9});
+
   //pivot output
   test.AddOutput<double>("Output_1", {4, 1}, {3, 9, 3, 9});
   test.AddOutput<double>("Output_2", {4, 1}, {5, 8, 5, 8});
   test.AddOutput<double>("Output_3", {4, 1}, {7, 10, 7, 10});
   test.AddOutput<double>("Output_4", {4, 1}, {5, 6, 5, 6});
   test.AddOutput<double>("Output_5", {4, 1}, {3, 4, 3, 4});
+
   //non-pivot output
-  test.AddOutput<double>("Output_6", {4, 4}, {7, 7, 7, 7,
-                                              7, 7, 7, 7,
-                                              9, 9, 9, 9,
-                                              9, 9, 9, 9});
+  test.AddOutput<std::string>("Output_6", {4, 4}, {"7", "7", "7", "7",
+                                                   "7", "7", "7", "7",
+                                                   "9", "9", "9", "9",
+                                                   "9", "9", "9", "9"});
   test.AddOutput<double>("Output_7", {4, 4}, {-7, -7, -7, -7,
                                               -7, -7, -7, -7,
                                               -9, -9, -9, -9,


### PR DESCRIPTION
**Description**: add support for non-pivot(imputed) columns and horizon column

**Motivation and Context**
- Why is this change required? What problem does it solve? 
- If it fixes an open issue, please link to the issue here.
