### PR TITLE
Fix a crash in Reshape

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/reshape_helper.h
+++ b/onnxruntime/core/providers/cpu/tensor/reshape_helper.h
@@ -34,7 +34,7 @@ class ReshapeHelper {
 
     if (unknown_dim != -1) {
       // calculate unknown dimension
-      ORT_ENFORCE((input_shape.Size() % size) == 0,
+      ORT_ENFORCE(size != 0 && (input_shape.Size() % size) == 0,
                   "The input tensor cannot be reshaped to the requested shape. Input shape:", input_shape, ", requested shape:", TensorShape(requested_shape));
       requested_shape[unknown_dim] = input_shape.Size() / size;
     } else {

--- a/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
@@ -33,6 +33,33 @@ TEST(TensorOpTest, ReshapeWithEmptyDim) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider}); // TensorRT doesn't support empty dimension
 }
 
+TEST(TensorOpTest, ReshapeWithEmptyInput) {
+  OpTester test("Reshape");
+
+  test.AddInput<float>("data", {0, 10}, std::vector<float>());
+  test.AddInput<int64_t>("shape", {3}, {0, 10, 1}, false);
+  test.AddOutput<float>("reshaped", {0, 10, 1}, std::vector<float>());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider}); // TensorRT doesn't support empty dimension
+}
+
+TEST(TensorOpTest, ReshapeWithEmptyInputAndDynamicShape) {
+  {
+    OpTester test("Reshape");
+    test.AddInput<float>("data", {1, 0}, std::vector<float>());
+    test.AddInput<int64_t>("shape", {3}, {1, 0, -1}, false);
+    test.AddOutput<float>("reshaped", {1, 0, 1}, {});
+    test.Run(OpTester::ExpectResult::kExpectFailure, "The input tensor cannot be reshaped to the requested shape", {kTensorrtExecutionProvider}); // TensorRT doesn't support empty dimension
+  }
+
+  {
+    OpTester test("Reshape");
+    test.AddInput<float>("data", {1, 0}, std::vector<float>());
+    test.AddInput<int64_t>("shape", {3}, {1, 1, -1}, false);
+    test.AddOutput<float>("reshaped", {1, 1, 0}, {});
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider}); // TensorRT doesn't support empty dimension
+  }
+}
+
 TEST(TensorOpTest, ReshapeWithInitializer) {
   OpTester test("Reshape");
 

--- a/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
@@ -35,7 +35,6 @@ TEST(TensorOpTest, ReshapeWithEmptyDim) {
 
 TEST(TensorOpTest, ReshapeWithEmptyInput) {
   OpTester test("Reshape");
-
   test.AddInput<float>("data", {0, 10}, std::vector<float>());
   test.AddInput<int64_t>("shape", {3}, {0, 10, 1}, false);
   test.AddOutput<float>("reshaped", {0, 10, 1}, std::vector<float>());


### PR DESCRIPTION
**Description**: Fix a crash in Reshape.

**Motivation and Context**
Reshape doesn't handle 0 input dimension properly, which leads to a
division by zero.