### PR TITLE
Add check for nullptr in PlannerImpl::FindReusableTensor().

### DIFF
--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -330,7 +330,11 @@ class PlannerImpl {
     for (auto it = freelist_.begin(); it != freelist_.end(); ++it) {
       size_t reusable = static_cast<size_t>(it->ml_value);
       const onnxruntime::NodeArg* p_node_arg = ort_value_info_.at(reusable).p_def_site;
-      if (!p_node_arg) continue;
+      if (!p_node_arg) {
+        // TODO this should be an error case, needs more investigation
+        // https://msdata.visualstudio.com/Vienna/_workitems/edit/724826/
+        continue;
+      }
       auto& available_memory_info = AllocPlan(p_node_arg->Name()).location;
       if (!(available_memory_info == required_memory_info)) continue;
       auto p_available_buffer_shape = context_.GetShape(*p_node_arg);

--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -330,6 +330,7 @@ class PlannerImpl {
     for (auto it = freelist_.begin(); it != freelist_.end(); ++it) {
       size_t reusable = static_cast<size_t>(it->ml_value);
       const onnxruntime::NodeArg* p_node_arg = ort_value_info_.at(reusable).p_def_site;
+      if (!p_node_arg) continue;
       auto& available_memory_info = AllocPlan(p_node_arg->Name()).location;
       if (!(available_memory_info == required_memory_info)) continue;
       auto p_available_buffer_shape = context_.GetShape(*p_node_arg);


### PR DESCRIPTION
**Description**
Add check for nullptr in PlannerImpl::FindReusableTensor().

**Motivation and Context**
Fix ort_training Windows GPU CI build failure, e.g.: https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=137690
Debugging showed that onnx_test_runner crashed due to a null pointer dereference.
