### PR TITLE
Clean up OPTIONAL name conflict workarounds in ort_training.

### DIFF
--- a/onnxruntime/core/framework/allocator.cc
+++ b/onnxruntime/core/framework/allocator.cc
@@ -4,14 +4,10 @@
 #include "core/common/safeint.h"
 #include "core/framework/allocator.h"
 #include "core/framework/allocatormgr.h"
-#ifdef OPTIONAL
-#undef OPTIONAL
-#endif
 #include "core/framework/utils.h"
 #include "core/session/ort_apis.h"
 #include <cstdlib>
 #include <sstream>
-
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/providers/cpu/cpu_execution_provider.h
+++ b/onnxruntime/core/providers/cpu/cpu_execution_provider.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "core/graph/onnx_protobuf.h"
 #include "core/framework/allocatormgr.h"
 #include "core/framework/execution_provider.h"
 #include "core/graph/constants.h"

--- a/onnxruntime/core/providers/cpu/cpu_provider_factory.cc
+++ b/onnxruntime/core/providers/cpu/cpu_provider_factory.cc
@@ -3,7 +3,6 @@
 
 #include "core/providers/cpu/cpu_provider_factory.h"
 #include <atomic>
-#include "core/graph/onnx_protobuf.h"
 #include "cpu_execution_provider.h"
 #include "core/session/abi_session_options_impl.h"
 #include "core/session/ort_apis.h"

--- a/onnxruntime/core/providers/dnnl/dnnl_provider_factory.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_provider_factory.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/graph/onnx_protobuf.h"
 #include "core/providers/dnnl/dnnl_provider_factory.h"
 #include <atomic>
 #include "dnnl_execution_provider.h"

--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "core/session/environment.h"
-#include "core/graph/onnx_protobuf.h"
 #include "core/framework/allocatormgr.h"
 #include "core/graph/constants.h"
 #include "core/graph/op.h"

--- a/onnxruntime/test/framework/allocator_test.cc
+++ b/onnxruntime/test/framework/allocator_test.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/graph/onnx_protobuf.h"
 #include "core/framework/allocatormgr.h"
 #include "core/framework/allocator.h"
 #include "test_utils.h"

--- a/onnxruntime/test/framework/cuda/allocator_cuda_test.cc
+++ b/onnxruntime/test/framework/cuda/allocator_cuda_test.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/graph/onnx_protobuf.h"
 #include "core/framework/allocatormgr.h"
 #include "test/framework/test_utils.h"
 #include "gtest/gtest.h"

--- a/onnxruntime/test/framework/insert_cast_transformer_test.cc
+++ b/onnxruntime/test/framework/insert_cast_transformer_test.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/graph/onnx_protobuf.h"
 #include "core/framework/allocatormgr.h"
 #include "core/framework/allocator.h"
 #include "core/optimizer/insert_cast_transformer.h"

--- a/onnxruntime/test/framework/test_utils.h
+++ b/onnxruntime/test/framework/test_utils.h
@@ -5,7 +5,6 @@
 #include <map>
 #include <string>
 
-#include "core/graph/onnx_protobuf.h"
 #include "core/framework/allocatormgr.h"
 #include "core/framework/execution_provider.h"
 #include "core/providers/cpu/cpu_execution_provider.h"

--- a/onnxruntime/test/platform/path_lib_test.cc
+++ b/onnxruntime/test/platform/path_lib_test.cc
@@ -6,13 +6,8 @@
 #include "gtest/gtest.h"
 
 #include "core/platform/env.h"
-#include "test/framework/test_utils.h"
-
-// Windows.h reserves the word OPTIONAL in macro, which introduces
-// conflict on variables declared from onnx external library. Currently workaround
-// this by re-ordering the included files.
-// TODO: undefine OPTIONAL in path_lib.h and move path_lib.h to the first include
 #include "core/platform/path_lib.h"
+#include "test/framework/test_utils.h"
 
 namespace onnxruntime {
 namespace test {

--- a/onnxruntime/test/providers/compare_provider_test_utils.cc
+++ b/onnxruntime/test/providers/compare_provider_test_utils.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/graph/onnx_protobuf.h"
 #include "core/session/inference_session.h"
 #include "test/util/include/default_providers.h"
 #include "test/providers/compare_provider_test_utils.h"

--- a/onnxruntime/test/providers/provider_test_utils.h
+++ b/onnxruntime/test/providers/provider_test_utils.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "core/graph/onnx_protobuf.h"
 #include "core/common/logging/logging.h"
 #include "core/common/optional.h"
 #include "core/framework/allocatormgr.h"

--- a/orttraining/orttraining/core/framework/gradient_graph_builder.h
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.h
@@ -15,7 +15,6 @@
 #include "core/graph/constants.h"
 #include "core/graph/graph_nodes.h"
 #include "core/graph/node_arg.h"
-#include "core/graph/onnx_protobuf.h"
 #include "orttraining/core/graph/gradient_schema_defs.h"
 #include "orttraining/core/graph/gradient_builder_base.h"
 #include "core/optimizer/graph_transformer_mgr.h"

--- a/orttraining/orttraining/core/graph/gradient_builder_base.h
+++ b/orttraining/orttraining/core/graph/gradient_builder_base.h
@@ -6,7 +6,6 @@
 #include <vector>
 #include <string>
 #include "core/graph/graph.h"
-#include "core/graph/onnx_protobuf.h"
 #include "orttraining/core/graph/graph_augmenter.h"
 #include "onnx/defs/attr_proto_util.h"
 

--- a/orttraining/orttraining/core/graph/mixed_precision_transformer.cc
+++ b/orttraining/orttraining/core/graph/mixed_precision_transformer.cc
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "orttraining/core/graph/mixed_precision_transformer.h"
-#include "core/graph/onnx_protobuf.h"
 #include "core/graph/graph_utils.h"
 #include "core/graph/graph_viewer.h"
 #include "orttraining/core/graph/gradient_builder_base.h"

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/graph/onnx_protobuf.h"
-
 #include "orttraining/core/session/training_session.h"
 
 #include "core/framework/data_transfer_utils.h"

--- a/orttraining/orttraining/models/mnist/main.cc
+++ b/orttraining/orttraining/models/mnist/main.cc
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "cxxopts.hpp"
-#include "core/graph/onnx_protobuf.h"
 #include "core/common/logging/logging.h"
 #include "core/common/logging/sinks/clog_sink.h"
 #include "core/platform/env.h"

--- a/orttraining/orttraining/models/runner/training_util.h
+++ b/orttraining/orttraining/models/runner/training_util.h
@@ -5,7 +5,6 @@
 #include <vector>
 #include <math.h>
 #include "constant.h"
-#include "core/graph/onnx_protobuf.h"
 #include "core/framework/callback.h"
 #include "core/framework/ml_value.h"
 #include "core/framework/framework_common.h"

--- a/orttraining/orttraining/test/optimizer/graph_transform_test.cc
+++ b/orttraining/orttraining/test/optimizer/graph_transform_test.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/graph/onnx_protobuf.h"
 #include "core/session/inference_session.h"
 #include "core/graph/model.h"
 

--- a/orttraining/orttraining/test/optimizer/graph_transformer_utils_test.cc
+++ b/orttraining/orttraining/test/optimizer/graph_transformer_utils_test.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/graph/onnx_protobuf.h"
 #include "test/framework/test_utils.h"
 #include "test/capturing_sink.h"
 #include "test/test_environment.h"


### PR DESCRIPTION
**Description**
Clean up workarounds for OPTIONAL name conflict.

**Motivation and Context**
Previously, OPTIONAL was both the name of a macro from Windows headers and a constant in onnx. onnx renamed it to OPTIONAL_VALUE so our workarounds are no longer needed.