### PR TITLE
Downgrade numpy requirement to 1.16.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy >= 1.18.0
+numpy >= 1.16.6
 onnx >= 1.2.3
 protobuf

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -413,7 +413,7 @@ def install_ubuntu_deps(args):
 def install_python_deps(numpy_version=""):
     dep_packages = ['setuptools', 'wheel', 'pytest']
     dep_packages.append('numpy=={}'.format(numpy_version) if numpy_version
-                        else 'numpy>=1.18.0')
+                        else 'numpy>=1.16.6')
     dep_packages.append('sympy>=1.1')
     dep_packages.append('packaging')
     run_subprocess([sys.executable, '-m', 'pip', 'install', '--trusted-host',

--- a/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
@@ -178,7 +178,7 @@ jobs:
       workingFolder: '$(Build.BinariesDirectory)'
 
   - script: |
-     python -m pip install -q pyopenssl setuptools wheel numpy==1.18
+     python -m pip install -q pyopenssl setuptools wheel numpy==1.16.6
 
     workingDirectory: '$(Build.BinariesDirectory)'
     displayName: 'Install python modules'
@@ -253,7 +253,7 @@ jobs:
         workingFolder: '$(Build.BinariesDirectory)'
 
     - script: |
-       python -m pip install -q pyopenssl setuptools wheel numpy==1.18
+       python -m pip install -q pyopenssl setuptools wheel numpy==1.16.6
       workingDirectory: '$(Build.BinariesDirectory)'
       displayName: 'Install python modules'
 

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.18.0
+numpy==1.16.6
 requests==2.21.0
 scipy
 mypy


### PR DESCRIPTION
**Description**: 

This PR is similar to #2758 except version number is changed to 1.16.6

**Motivation and Context**
- Why is this change required? What problem does it solve?

Per suggestion from @jywu-msft and @guschmue :
1.18.0 was only released on Dec 22, 2019. Many users wouldn't like requiring such new software. and we don't even use numpy 1.18 specific api's in ORT.

See the discussion at #3003

- If it fixes an open issue, please link to the issue here.
