### PR TITLE
Not use OpenMP for android build

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -525,7 +525,7 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home,
         "-Donnxruntime_USE_NNAPI=" + ("ON" if args.use_dnnlibrary else "OFF"),
         "-Donnxruntime_USE_OPENMP=" + (
             "ON" if args.use_openmp and not args.use_dnnlibrary and
-            not args.use_mklml and not args.use_ngraph else "OFF"),
+            not args.use_mklml and not args.use_ngraph and not args.android else "OFF"),
         "-Donnxruntime_USE_TVM=" + ("ON" if args.use_tvm else "OFF"),
         "-Donnxruntime_USE_LLVM=" + ("ON" if args.use_llvm else "OFF"),
         "-Donnxruntime_ENABLE_MICROSOFT_INTERNAL=" + (


### PR DESCRIPTION
**Description**: Load the Android lib in an Android Project will throw error on "library "libomp.so" not found" 

There is an issue in Android NDK (https://github.com/android/ndk/issues/1028) for OpenMP you would have to static link the OpenMP lib,
This is to disable OpenMP for android build


