### PR TITLE
expose training session in training runner

### DIFF
--- a/orttraining/orttraining/models/runner/training_runner.h
+++ b/orttraining/orttraining/models/runner/training_runner.h
@@ -169,6 +169,7 @@ class TrainingRunner {
   common::Status ResetLossScaler();
 
   size_t GetRound() const { return round_; }
+  TrainingSession& GetSession() { return session_; }
 
  private:
   Status TrainingLoop(IDataLoader& training_data_loader, IDataLoader* test_data_loader);


### PR DESCRIPTION
**Description**: Expose the training session so the training app could register custom kernels and transformers.

