### PR TITLE
remove --use_openmp in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,4 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 #requires python3.6 or higher
-python3 $DIR/tools/ci_build/build.py --use_openmp --build_dir $DIR/build/Linux "$@"
+python3 $DIR/tools/ci_build/build.py --build_dir $DIR/build/Linux "$@"


### PR DESCRIPTION
Remove `--use_openmp` in build.sh to fix build failed problem on Mac.
#3313 