### PR TITLE
add test for LearningModel creation from missing model path

### DIFF
--- a/winml/test/api/LearningModelAPITest.cpp
+++ b/winml/test/api/LearningModelAPITest.cpp
@@ -26,6 +26,17 @@ static void CreateModelFromFilePath() {
   WINML_EXPECT_NO_THROW(APITest::LoadModel(L"squeezenet_modifiedforruntimestests.onnx", learningModel));
 }
 
+static void CreateModelFileNotFound() {
+  LearningModel learningModel = nullptr;
+
+  WINML_EXPECT_THROW_SPECIFIC(
+    APITest::LoadModel(L"missing_model.onnx", learningModel);,
+    winrt::hresult_error,
+    [](const winrt::hresult_error& e) -> bool {
+          return e.code() == __HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
+    });
+}
+
 static void CreateModelFromIStorage() {
   std::wstring path = FileHelpers::GetModulePath() + L"squeezenet_modifiedforruntimestests.onnx";
   auto storageFile = ws::StorageFile::GetFileFromPathAsync(path).get();
@@ -255,6 +266,7 @@ const LearningModelApiTestsApi& getapi() {
     LearningModelAPITestsClassSetup,
     LearningModelAPITestsGpuMethodSetup,
     CreateModelFromFilePath,
+    CreateModelFileNotFound,
     CreateModelFromIStorage,
     CreateModelFromIStorageOutsideCwd,
     CreateModelFromIStream,

--- a/winml/test/api/LearningModelAPITest.cpp
+++ b/winml/test/api/LearningModelAPITest.cpp
@@ -30,7 +30,7 @@ static void CreateModelFileNotFound() {
   LearningModel learningModel = nullptr;
 
   WINML_EXPECT_THROW_SPECIFIC(
-    APITest::LoadModel(L"missing_model.onnx", learningModel);,
+    APITest::LoadModel(L"missing_model.onnx", learningModel),
     winrt::hresult_error,
     [](const winrt::hresult_error& e) -> bool {
           return e.code() == __HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
@@ -253,7 +253,7 @@ static void CloseModelNoNewSessions() {
   WINML_EXPECT_NO_THROW(learningModel.Close());
   LearningModelSession session = nullptr;
   WINML_EXPECT_THROW_SPECIFIC(
-      session = LearningModelSession(learningModel);,
+      session = LearningModelSession(learningModel),
       winrt::hresult_error,
       [](const winrt::hresult_error& e) -> bool {
             return e.code() == E_INVALIDARG;

--- a/winml/test/api/LearningModelAPITest.h
+++ b/winml/test/api/LearningModelAPITest.h
@@ -7,6 +7,7 @@ struct LearningModelApiTestsApi
   SetupClass LearningModelAPITestsClassSetup;
   SetupTest LearningModelAPITestsGpuMethodSetup;
   VoidTest CreateModelFromFilePath;
+  VoidTest CreateModelFileNotFound;
   VoidTest CreateModelFromIStorage;
   VoidTest CreateModelFromIStorageOutsideCwd;
   VoidTest CreateModelFromIStream;
@@ -27,6 +28,7 @@ WINML_TEST_CLASS_BEGIN(LearningModelAPITests)
 WINML_TEST_CLASS_SETUP_CLASS(LearningModelAPITestsClassSetup)
 WINML_TEST_CLASS_BEGIN_TESTS
 WINML_TEST(LearningModelAPITests, CreateModelFromFilePath)
+WINML_TEST(LearningModelAPITests, CreateModelFileNotFound)
 WINML_TEST(LearningModelAPITests, CreateModelFromIStorage)
 WINML_TEST(LearningModelAPITests, CreateModelFromIStorageOutsideCwd)
 WINML_TEST(LearningModelAPITests, CreateModelFromIStream)


### PR DESCRIPTION
Ensure the proper error code is propagated when creating a LearningModel from a model path that does not exist.