### PR TITLE
LearningModel metadata case insensitive bug fix

### DIFF
--- a/winml/lib/Api.Ort/OnnxruntimeModel.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeModel.cpp
@@ -148,8 +148,28 @@ STDMETHODIMP ModelInfo::GetVersion(int64_t* out) {
   return S_OK;
 }
 
+struct CaseInsensitiveHash {
+  size_t operator()(const winrt::hstring& key) const {
+    size_t h = 0, i = 0;
+    std::for_each(key.begin(), key.end(), [&](wchar_t c) {
+      i++;
+      h += i * towlower(c);
+    });
+    return h;
+  }
+};
+
+struct CaseInsensitiveEqual {
+  bool operator()(const winrt::hstring& left, const winrt::hstring& right) const {
+    return left.size() == right.size() && std::equal(left.begin(), left.end(), right.begin(),
+                                                     [](wchar_t a, wchar_t b) {
+                                                       return towlower(a) == towlower(b);
+                                                     });
+  }
+};
+
 STDMETHODIMP ModelInfo::GetModelMetadata(ABI::Windows::Foundation::Collections::IMapView<HSTRING, HSTRING>** metadata) {
-  std::unordered_map<winrt::hstring, winrt::hstring> map_copy;
+  std::unordered_map<winrt::hstring, winrt::hstring, CaseInsensitiveHash, CaseInsensitiveEqual> map_copy;
   for (auto& pair : model_metadata_) {
     auto metadata_key = _winml::Strings::HStringFromUTF8(pair.first);
     auto metadata_value = _winml::Strings::HStringFromUTF8(pair.second);

--- a/winml/test/api/LearningModelAPITest.cpp
+++ b/winml/test/api/LearningModelAPITest.cpp
@@ -249,6 +249,14 @@ static void CloseModelNoNewSessions() {
       });
 }
 
+static void CheckMetadataCaseInsensitive() {
+  LearningModel learningModel = nullptr;
+  WINML_EXPECT_NO_THROW(APITest::LoadModel(L"modelWithMetaData.onnx", learningModel));
+  IMapView metadata = learningModel.Metadata();
+  WINML_EXPECT_TRUE(metadata.HasKey(L"tHiSiSaLoNgKeY"));
+  WINML_EXPECT_EQUAL(metadata.Lookup(L"tHiSiSaLoNgKeY"), L"thisisalongvalue");
+}
+
 const LearningModelApiTestsApi& getapi() {
   static constexpr LearningModelApiTestsApi api =
   {
@@ -267,7 +275,8 @@ const LearningModelApiTestsApi& getapi() {
     EnumerateOutputs,
     CloseModelCheckMetadata,
     CloseModelCheckEval,
-    CloseModelNoNewSessions
+    CloseModelNoNewSessions,
+    CheckMetadataCaseInsensitive
   };
   return api;
 }

--- a/winml/test/api/LearningModelAPITest.h
+++ b/winml/test/api/LearningModelAPITest.h
@@ -20,6 +20,7 @@ struct LearningModelApiTestsApi
   VoidTest CloseModelCheckMetadata;
   VoidTest CloseModelCheckEval;
   VoidTest CloseModelNoNewSessions;
+  VoidTest CheckMetadataCaseInsensitive;
 };
 const LearningModelApiTestsApi& getapi();
 
@@ -39,6 +40,7 @@ WINML_TEST(LearningModelAPITests, EnumerateInputs)
 WINML_TEST(LearningModelAPITests, EnumerateOutputs)
 WINML_TEST(LearningModelAPITests, CloseModelCheckMetadata)
 WINML_TEST(LearningModelAPITests, CloseModelNoNewSessions)
+WINML_TEST(LearningModelAPITests, CheckMetadataCaseInsensitive)
 WINML_TEST_CLASS_END()
 
 WINML_TEST_CLASS_BEGIN(LearningModelAPITestsGpu)


### PR DESCRIPTION
**Description**: Return case insensitive map for LearningModel Metadata(). Add test to verify behavior.

**Motivation and Context**
The onnx spec says that Model metadata is case insensitive, but until now our LearningModel api returned a case sensitive map for metadata.
