### PR TITLE
Changes on RollingWindow Transformer

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -450,7 +450,7 @@
       {
          "component": {
             "git": {
-               "commitHash": "f01d8beeac92b54bf93df8053a2acb6a8a10f03c",
+               "commitHash": "fd5fe3de507d4a19f5923c5d4c267e3d730500a9",
                "repositoryUrl": "https://github.com/microsoft/FeaturizersLibrary.git"
             },
             "type": "git"

--- a/onnxruntime/core/graph/featurizers_ops/featurizers_defs.cc
+++ b/onnxruntime/core/graph/featurizers_ops/featurizers_defs.cc
@@ -1503,13 +1503,44 @@ void RegisterPCAFeaturizerVer1() {
 
 void RegisterRobustScalerFeaturizerVer1() {
   //static const char* doc = R"DOC(
-  //      MinMaxScalarEstimator + centering?
+    // Remove the median and scales the data according to the quantile range.
 
-  //      C++-style pseudo signature:
-  //          TODO
+    // C++-style pseudo signature:
+    //     float execute(TInputFloat const &value);
+    //     double execute(TInputDouble const &value);
 
-  //      Examples:
-  //        TODO
+    // Examples:
+    //   Assuming the Training data [[ 1, -2, 2], [-2, 1, 3], [ 4, 1,-2]]
+
+    //   There are 3 columns...
+    //       column 1          column 2          column 3
+    //          1                 -2                2
+    //         -2                  1                3
+    //          4                  1               -2
+
+    //   For each column, we calculate the median value...
+    //       column 1          column 2          column 3
+    //          1                  1                2
+
+    //   Also calculate the range for each column
+    //       column 1          column 2          column 3
+    //     4 - (-2) = 6      1 - (-2) = 3      3 - (-2) = 5
+
+    //   Apply quantile range(QR) to the ranges, assuming the QR is [q_min = 25, q_max = 75], we get the scaling value = range * (q_max% - q_min%) for each column
+    //       column 1          column 2          column 3
+    //     6 * 50% = 3       3 * 50% = 1.5     5 * 50% = 2.5
+
+    //   Remove the median and scales the original data per column
+    //       column 1          column 2          column 3
+    //     ( 1 - 1) / 3     (-2 - 1) / 1.5    ( 2 - 2) / 2.5
+    //     (-2 - 1) / 3     ( 1 - 1) / 1.5    ( 3 - 2) / 2.5
+    //     ( 4 - 1) / 3     ( 1 - 1) / 1.5    (-2 - 2) / 2.5
+
+    //   The final result is
+    //       column 1          column 2          column 3
+    //          0                 -2                0
+    //         -1                  0              0.4
+    //          1                  0             -1.6
   //)DOC";
 
   MS_FEATURIZERS_OPERATOR_SCHEMA(RobustScalerTransformer)
@@ -1605,7 +1636,7 @@ void RegisterRollingWindowFeaturizerVer1() {
   //     +-----------+-------+-------------------+
   //)DOC";
 
-  MS_FEATURIZERS_OPERATOR_SCHEMA(RollingWindowTransformer)
+  MS_FEATURIZERS_OPERATOR_SCHEMA(AnalyticalRollingWindowTransformer)
       .SinceVersion(1)
       .SetDomain(kMSFeaturizersDomain)
       .Input(
@@ -1655,6 +1686,104 @@ void RegisterRollingWindowFeaturizerVer1() {
 
               ONNX_NAMESPACE::TensorShapeProto shape;
               *shape.add_dim() = grains_shape.dim(0);
+              shape.add_dim();
+              shape.add_dim();
+              ONNX_NAMESPACE::updateOutputShape(ctx, 0, shape);
+            }
+            if (hasInputShape(ctx, 2)) {
+              const auto& target_shape = getInputShape(ctx, 2);
+              if (target_shape.dim_size() != 1) {
+                fail_shape_inference("Expecting Target to have 1 dimensions");
+              }
+            }
+          });
+
+  //static const char* doc = R"DOC(
+      // Calculates data based on a rolling window. Currently supports minimum and maximum. Works for any data set that is already sorted.
+      //
+      // Input type for this featurizer is a tuple of the grain columns and target column to find the value. It is assumed that the data is sorted in the correct order.
+      //
+      // C++-style pseudo signature:
+      //   template <typename T> matrix<T> execute(std::tuple<std::vector<std::string> const &, T const &> value);
+      //
+      // Examples:
+      //     A simple example would be horizon = 1, maxWindowSize = 2, and we want to take the minimum.
+      //     +-----------+-------+-------------------+
+      //     | grain     | target| target_minimum    |
+      //     +===========+=======+===================+
+      //     | A         | 10    | [[NAN]]           |
+      //     +-----------+-------+-------------------+
+      //     | A         | 4     | [[10]]            |
+      //     +-----------+-------+-------------------+
+      //     | A         | 6     | [[4]]             |
+      //     +-----------+-------+-------------------+
+      //     | A         | 11    | [[4]]             |
+      //     +-----------+-------+-------------------+
+      //     A more complex example would be, assuming we have horizon = 2, maxWindowSize = 2, minWindowSize = 2, and we want the maximum value
+      //     +-----------+-------+-------------------+
+      //     | grain     | target| target_max        |
+      //     +===========+=======+===================+
+      //     | A         | 10    | [[NAN, NAN]]      |
+      //     +-----------+-------+-------------------+
+      //     | A         | 4     | [[NAN, NAN]]      |
+      //     +-----------+-------+-------------------+
+      //     | A         | 6     | [[NAN, 10]]       |
+      //     +-----------+-------+-------------------+
+      //     | A         | 11    | [[10, 6]]         |
+      //     +-----------+-------+-------------------+
+  //)DOC";
+
+  MS_FEATURIZERS_OPERATOR_SCHEMA(SimpleRollingWindowTransformer)
+      .SinceVersion(1)
+      .SetDomain(kMSFeaturizersDomain)
+      .Input(
+          0,
+          "State",
+          "State generated during training that is used for prediction",
+          "T0")
+      .Input(
+          1,
+          "Grains",
+          "Grains tensor of shape [R][K].",
+          "GrainT")
+      .Input(
+          2,
+          "Target",
+          "Target tensor of shape [R]",
+          "T")
+      .Output(
+          0,
+          "Output",
+          "Output tensor of shape [R][M]",
+          "OutputT")
+      .TypeConstraint(
+          "T0",
+          {"tensor(uint8)"},
+          "No information is available")
+      .TypeConstraint(
+          "GrainT",
+          {"tensor(string)"},
+          "No information is available")
+      .TypeConstraint(
+          "T",
+          {"tensor(float)", "tensor(double)"},
+          "No information is available")
+      .TypeConstraint(
+          "OutputT",
+          {"tensor(double)"},
+          "No information is available")
+      .TypeAndShapeInferenceFunction(
+          [](ONNX_NAMESPACE::InferenceContext& ctx) {
+            propagateElemTypeFromDtypeToOutput(ctx, ONNX_NAMESPACE::TensorProto_DataType_DOUBLE, 0);
+            if (hasInputShape(ctx, 1)) {
+              const auto& grains_shape = getInputShape(ctx, 1);
+              if (grains_shape.dim_size() != 2) {
+                fail_shape_inference("Expecting Grains to have 2 dimensions");
+              }
+
+              ONNX_NAMESPACE::TensorShapeProto shape;
+              *shape.add_dim() = grains_shape.dim(0);
+              shape.add_dim();
               shape.add_dim();
               ONNX_NAMESPACE::updateOutputShape(ctx, 0, shape);
             }
@@ -1730,13 +1859,23 @@ void RegisterNormalizeFeaturizerVer1() {
 
 void RegisterShortGrainDropperFeaturizerVer1() {
   // static const char* doc = R"DOC(
-  //     Drop rows of TimeSeriesDataFrame with short grains
+  //  Returns true to indicate that a row should be dropped if it wasn't encountered during training.
 
-  //     C++-style pseudo signature:
-  //       bool execute(std::vector<std::string> const &value);
+  //  C++-style pseudo signature:
+  //    bool execute(std::vector<std::string> const &value);
 
-  //     Examples:
-  //       todo:
+  //  Examples:
+  //    Consider the training data:
+
+  //    [ ["one"], ["two"], ["two"], ["three"], ["three"], ["three"] ]
+
+  //    and a ShortGrainDropper configured with minPoints set to 2. Grains ["two"] and ["three"] appear
+  //    enough times in the training data to remain, while any other grain should be dropped:
+
+  //    [ "one" ] -> true                         # drop
+  //    [ "two" ] -> false                        # dont' drop
+  //    [ "three" ] -> false                      # don't drop
+  //    [ "never seen during training" ] -> true  # drop
   // )DOC";
   MS_FEATURIZERS_OPERATOR_SCHEMA(ShortGrainDropperTransformer)
       .SinceVersion(1)
@@ -2066,11 +2205,20 @@ void RegisterTimeSeriesImputerFeaturizerVer1() {
           "Keys",
           "Composite keys tensor of shape [R][K]. R is the same as Input(1)",
           "T2")
+      // The first input in Input(3)(a variadic tensor that has multiple output) is the below commented input
+      // for the ONNX requirement that allow 0 size of variadic input
+      // .Input(
+      //     3,
+      //     "Data",
+      //     "It is a data tensor of shape [R][C] where R - rows and C - columns. R must be the same with Input(1)",
+      //     "T2")
       .Input(
           3,
-          "Data",
-          "It is a data tensor of shape [R][C] where R - rows and C - columns. R must be the same with Input(1)",
-          "T2")
+          "Input",
+          "Variadic number of Inputs containing tensors of different type",
+          "T",
+          ONNX_NAMESPACE::OpSchema::FormalParameterOption::Variadic,
+          false)
       .Output(
           0,
           "Added",
@@ -2086,12 +2234,21 @@ void RegisterTimeSeriesImputerFeaturizerVer1() {
           "ImputedKeys",
           "Contains keys along with the imputed keys. Tensor of shape [IR][K].",
           "T2")
+      // The first output in Output(3)(a variadic tensor that has multiple output) is the below commented output
+      // for the ONNX requirement that allow 0 size of variadic output
+      // .Output(
+      //     3,
+      //     "ImputedData",
+      //     "Tensor of shape [IR][C] where IR is the number of rows in the output."
+      //     "C is the number of columns.",
+      //     "T2")
       .Output(
           3,
-          "ImputedData",
-          "Tensor of shape [IR][C] where IR is the number of rows in the output."
-          "C is the number of columns.",
-          "T2")
+          "Output",
+          "Variadic number of Outputs containing tensors of different type",
+          "T",
+          ONNX_NAMESPACE::OpSchema::FormalParameterOption::Variadic,
+          false)
       .TypeConstraint(
           "T0",
           {"tensor(uint8)"},
@@ -2108,6 +2265,11 @@ void RegisterTimeSeriesImputerFeaturizerVer1() {
           "T3",
           {"tensor(bool)"},
           "Boolean Tensor")
+      .TypeConstraint(
+          "T",
+          {"tensor(int8)", "tensor(int16)", "tensor(int32)", "tensor(int64)", "tensor(uint8)", "tensor(uint16)", "tensor(uint32)", "tensor(uint64)",
+           "tensor(float)", "tensor(double)", "tensor(bool)", "tensor(string)"},
+          "No information is available")
       .TypeAndShapeInferenceFunction(
           [](ONNX_NAMESPACE::InferenceContext& ctx) {
             propagateElemTypeFromDtypeToOutput(ctx, ONNX_NAMESPACE::TensorProto_DataType_BOOL, 0);
@@ -2132,12 +2294,12 @@ void RegisterTimeSeriesImputerFeaturizerVer1() {
               ONNX_NAMESPACE::updateOutputShape(ctx, 2, shape);
             }
 
-            // Data shape
+            //Data Shape & Variadic I/O shapes
             propagateElemTypeFromInputToOutput(ctx, 3, 3);
             if (hasInputShape(ctx, 3)) {
               const auto& input3_shape = getInputShape(ctx, 3);
               if (input3_shape.dim_size() != 2) {
-                fail_shape_inference("Expecting data to have 2 dimensions");
+                fail_shape_inference("Expecting data and variadic inputs to have 2 dimensions");
               }
               ONNX_NAMESPACE::TensorShapeProto shape;
               shape.add_dim();

--- a/onnxruntime/featurizers_ops/cpu/rolling_window_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/rolling_window_transformer.cc
@@ -7,105 +7,135 @@
 #include "core/framework/op_kernel.h"
 
 #include "Featurizers/AnalyticalRollingWindowFeaturizer.h"
+#include "Featurizers/SimpleRollingWindowFeaturizer.h"
 #include "Featurizers/../Archive.h"
 
 namespace onnxruntime {
 namespace featurizers {
 
-template <typename T>
-struct RollingWindowTransformerImpl {
-  void operator()(OpKernelContext* ctx) const {
-    // Define the type
-    using GrainT = std::vector<std::string>;
-    using EstimatorT = Microsoft::Featurizer::Featurizers::GrainedAnalyticalRollingWindowEstimator<T>;
-    using GrainedInputType = typename EstimatorT::InputType;
-    using OutputType = typename EstimatorT::TransformedType;
+template <typename T, typename EstimatorT, typename MatrixElementType>
+void RollingWindowTransformerImpl(OpKernelContext* ctx) {
+  // Define the type
+  using GrainT = std::vector<std::string>;
+  using GrainedInputType = typename EstimatorT::InputType;
+  using OutputType = typename EstimatorT::TransformedType;
 
-    //Get the transformer
-    const auto* state_tensor(ctx->Input<Tensor>(0));
-    const uint8_t* const state_data(state_tensor->Data<uint8_t>());
-    Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
-    typename EstimatorT::TransformerType transformer(archive);
+  //Get the transformer
+  const auto* state_tensor(ctx->Input<Tensor>(0));
+  const uint8_t* const state_data(state_tensor->Data<uint8_t>());
+  Microsoft::Featurizer::Archive archive(state_data, state_tensor->Shape().Size());
+  typename EstimatorT::TransformerType transformer(archive);
 
-    // Get the Grains
-    const auto* grains_tensor(ctx->Input<Tensor>(1));
-    const std::string* grains_data(grains_tensor->Data<std::string>());
-    const auto grains_num = grains_tensor->Shape()[1];
+  // Get the Grains
+  const auto* grains_tensor(ctx->Input<Tensor>(1));
+  const std::string* grains_data(grains_tensor->Data<std::string>());
+  const auto grains_num = grains_tensor->Shape()[1];
 
-    // Get the Target
-    const auto* target_tensor(ctx->Input<Tensor>(2));
-    const T* target_data(target_tensor->Data<T>());
+  // Get the Target
+  const auto* target_tensor(ctx->Input<Tensor>(2));
+  const T* target_data(target_tensor->Data<T>());
 
-    // Prepare the output
-    const auto output_dim_0 = grains_tensor->Shape()[0];
+  // Prepare the output
+  const auto output_dim_0 = grains_tensor->Shape()[0];
 
-    double* output_data = nullptr;
-    bool has_allocate_output_data = false;
-    std::function<void(OutputType)> callback_fn;
-    callback_fn = [ctx, &output_data, &has_allocate_output_data, output_dim_0](OutputType value) -> void {
-      //Allocate tensor memory after first output is generated
-      if(!has_allocate_output_data) {
-        TensorShape output_shape({output_dim_0, static_cast<int64_t>(value.size())});
-        Tensor* output_tensor(ctx->Output(0, output_shape));
-        output_data = output_tensor->MutableData<double>();
-        has_allocate_output_data = true;
-      }
-      Eigen::Map<OutputType> output_matrix_mapping(output_data, value.rows(), value.cols());
-      output_matrix_mapping = value;
-      output_data += value.size();
-    };
-
-    // Transform
-    GrainT grains;
-    grains.reserve(grains_num);
-    for (int64_t i = 0; i < output_dim_0; ++i) {
-      //Prepare Input
-      grains.clear();
-      std::copy(grains_data, grains_data + grains_num, std::back_inserter(grains));
-      const GrainedInputType input_tuple(grains, *target_data);
-      //Execute
-      transformer.execute(input_tuple, callback_fn);
-      //Increment Pointer
-      target_data++;
-      grains_data += grains_num;
+  MatrixElementType* output_data = nullptr;
+  bool has_allocate_output_data = false;
+  std::function<void(OutputType)> callback_fn;
+  callback_fn = [ctx, &output_data, &has_allocate_output_data, output_dim_0](OutputType value) -> void {
+    //Allocate tensor memory after first output is generated
+    if(!has_allocate_output_data) {
+      TensorShape output_shape({output_dim_0, 1, static_cast<int64_t>(value.size())});
+      Tensor* output_tensor(ctx->Output(0, output_shape));
+      output_data = output_tensor->MutableData<MatrixElementType>();
+      has_allocate_output_data = true;
     }
-    transformer.flush(callback_fn);
+    Eigen::Map<OutputType> output_matrix_mapping(output_data, value.rows(), value.cols());
+    output_matrix_mapping = value;
+    output_data += value.size();
+  };
+
+  // Transform
+  GrainT grains;
+  grains.reserve(grains_num);
+  for (int64_t i = 0; i < output_dim_0; ++i) {
+    //Prepare Input
+    grains.clear();
+    std::copy(grains_data, grains_data + grains_num, std::back_inserter(grains));
+    const GrainedInputType input_tuple(grains, *target_data);
+    //Execute
+    transformer.execute(input_tuple, callback_fn);
+    //Increment Pointer
+    target_data++;
+    grains_data += grains_num;
+  }
+  transformer.flush(callback_fn);
+}
+
+template <typename T>
+struct AnalyticalRollingWindowTransformerImpl {
+  void operator()(OpKernelContext* ctx) const {
+    RollingWindowTransformerImpl<T, Microsoft::Featurizer::Featurizers::GrainedAnalyticalRollingWindowEstimator<T>, double>(ctx);
   }
 };
 
-class RollingWindowTransformer final : public OpKernel {
- public:
-  explicit RollingWindowTransformer(const OpKernelInfo& info) : OpKernel(info) {
+template <typename T>
+struct SimpleRollingWindowTransformerImpl {
+  void operator()(OpKernelContext* ctx) const {
+    RollingWindowTransformerImpl<T, Microsoft::Featurizer::Featurizers::GrainedSimpleRollingWindowEstimator<T>, T>(ctx);
   }
+};
+
+class AnalyticalRollingWindowTransformer final : public OpKernel {
+ public:
+  explicit AnalyticalRollingWindowTransformer(const OpKernelInfo& info) : OpKernel(info) {
+}
 
   Status Compute(OpKernelContext* ctx) const override {
-    utils::MLTypeCallDispatcher<RollingWindowTransformerImpl, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
-                                int64_t, uint64_t, float, double>
-        t_disp(ctx->Input<Tensor>(2)->GetElementType());
+
+    utils::MLTypeCallDispatcher<AnalyticalRollingWindowTransformerImpl, float, double> t_disp(ctx->Input<Tensor>(2)->GetElementType());
+    t_disp.Invoke(ctx);
+    return Status::OK();
+  }
+};
+
+class SimpleRollingWindowTransformer final : public OpKernel {
+ public:
+  explicit SimpleRollingWindowTransformer(const OpKernelInfo& info) : OpKernel(info) {
+}
+
+  Status Compute(OpKernelContext* ctx) const override {
+
+    utils::MLTypeCallDispatcher<SimpleRollingWindowTransformerImpl, float, double> t_disp(ctx->Input<Tensor>(2)->GetElementType());
     t_disp.Invoke(ctx);
     return Status::OK();
   }
 };
 
 ONNX_OPERATOR_KERNEL_EX(
-    RollingWindowTransformer,
+    AnalyticalRollingWindowTransformer,
     kMSFeaturizersDomain,
     1,
     kCpuExecutionProvider,
     KernelDefBuilder()
         .TypeConstraint("T0", DataTypeImpl::GetTensorType<uint8_t>())
         .TypeConstraint("GrainT", DataTypeImpl::GetTensorType<std::string>())
-        .TypeConstraint("T", {DataTypeImpl::GetTensorType<int8_t>(),
-                              DataTypeImpl::GetTensorType<uint8_t>(),
-                              DataTypeImpl::GetTensorType<int16_t>(),
-                              DataTypeImpl::GetTensorType<uint16_t>(),
-                              DataTypeImpl::GetTensorType<int32_t>(),
-                              DataTypeImpl::GetTensorType<uint32_t>(),
-                              DataTypeImpl::GetTensorType<int64_t>(),
-                              DataTypeImpl::GetTensorType<uint64_t>(),
-                              DataTypeImpl::GetTensorType<float>(),
+        .TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
                               DataTypeImpl::GetTensorType<double>()
                               }),
-    RollingWindowTransformer);
+    AnalyticalRollingWindowTransformer);
+
+ONNX_OPERATOR_KERNEL_EX(
+    SimpleRollingWindowTransformer,
+    kMSFeaturizersDomain,
+    1,
+    kCpuExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T0", DataTypeImpl::GetTensorType<uint8_t>())
+        .TypeConstraint("GrainT", DataTypeImpl::GetTensorType<std::string>())
+        .TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                              DataTypeImpl::GetTensorType<double>()
+                              }),
+    SimpleRollingWindowTransformer);
+
 }  // namespace featurizers
 }  // namespace onnxruntime

--- a/onnxruntime/featurizers_ops/cpu_featurizers_kernels.cc
+++ b/onnxruntime/featurizers_ops/cpu_featurizers_kernels.cc
@@ -30,7 +30,8 @@ class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomai
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, OneHotEncoderTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, PCATransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, RobustScalerTransformer);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, RollingWindowTransformer);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, AnalyticalRollingWindowTransformer);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, SimpleRollingWindowTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, NormalizeTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, ShortGrainDropperTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, StandardScaleWrapperTransformer);
@@ -61,7 +62,8 @@ Status RegisterCpuMSFeaturizersKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, OneHotEncoderTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, PCATransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, RobustScalerTransformer)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, RollingWindowTransformer)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, AnalyticalRollingWindowTransformer)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, SimpleRollingWindowTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, NormalizeTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, ShortGrainDropperTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, StandardScaleWrapperTransformer)>,

--- a/onnxruntime/featurizers_ops/cpu_featurizers_kernels.cc
+++ b/onnxruntime/featurizers_ops/cpu_featurizers_kernels.cc
@@ -10,6 +10,7 @@ namespace onnxruntime {
 namespace featurizers {
 
 // Forward declarations
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, AnalyticalRollingWindowTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, CatImputerTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, CountVectorizerTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, DateTimeTransformer);
@@ -26,14 +27,13 @@ class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomai
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, MinMaxImputerTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, MissingDummiesTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, ModeImputerTransformer);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, NormalizeTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, NumericalizeTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, OneHotEncoderTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, PCATransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, RobustScalerTransformer);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, AnalyticalRollingWindowTransformer);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, SimpleRollingWindowTransformer);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, NormalizeTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, ShortGrainDropperTransformer);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, SimpleRollingWindowTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, StandardScaleWrapperTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, StringTransformer);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, TfidfVectorizerTransformer);
@@ -42,6 +42,7 @@ class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomai
 
 Status RegisterCpuMSFeaturizersKernels(KernelRegistry& kernel_registry) {
   static const BuildKernelCreateInfoFn function_table[] = {
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, AnalyticalRollingWindowTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, CatImputerTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, CountVectorizerTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, DateTimeTransformer)>,
@@ -58,14 +59,13 @@ Status RegisterCpuMSFeaturizersKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, MinMaxScalerTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, MissingDummiesTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, ModeImputerTransformer)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, NormalizeTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, NumericalizeTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, OneHotEncoderTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, PCATransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, RobustScalerTransformer)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, AnalyticalRollingWindowTransformer)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, SimpleRollingWindowTransformer)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, NormalizeTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, ShortGrainDropperTransformer)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, SimpleRollingWindowTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, StandardScaleWrapperTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, StringTransformer)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSFeaturizersDomain, 1, TfidfVectorizerTransformer)>,

--- a/onnxruntime/test/featurizers_ops/rolling_window_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/rolling_window_transformer_test.cc
@@ -28,18 +28,21 @@ std::vector<uint8_t> GetStream(EstimatorT& estimator, const std::vector<InputTyp
 
 TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_1_grain_window_size_1_horizon_1) {
   using EstimatorT = NS::Featurizers::GrainedAnalyticalRollingWindowEstimator<double>;
-
-  EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::AnalyticalRollingWindowCalculation::Mean, 1, 1);
   using GrainType = std::vector<std::string>;
   using GrainedInputType = EstimatorT::InputType;
-  GrainType const grain({"one"});
-  double const value1(static_cast<double>(10));
-  GrainedInputType const tup1(grain, value1);
-  std::vector<std::tuple<std::vector<std::string> const &, double const &>> const training_batch = {tup1};
+
+  EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::AnalyticalRollingWindowCalculation::Mean, 1, 1);
+
+  const GrainType grain({"one"});
+  const double value1(static_cast<double>(10));
+  const GrainedInputType tup1(grain, value1);
+  const std::vector<std::tuple<std::vector<std::string> const &, double const &>> training_batch = {tup1};
 
   auto stream = GetStream(estimator, training_batch);
   auto dim = static_cast<int64_t>(stream.size());
+
   OpTester test("AnalyticalRollingWindowTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+
   test.AddInput<uint8_t>("State", {dim}, stream);
   test.AddInput<std::string>("Grains", {3, 1}, {"one", "one", "one"});
   test.AddInput<double>("Target", {3}, {1, 2, 3});
@@ -51,18 +54,21 @@ TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_1_grain_
 
 TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_1_grain_window_size_2_horizon_2_min_window_size_2) {
   using EstimatorT = NS::Featurizers::GrainedAnalyticalRollingWindowEstimator<double>;
-
-  EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::AnalyticalRollingWindowCalculation::Mean, 2, 2, 2);
   using GrainType = std::vector<std::string>;
   using GrainedInputType = EstimatorT::InputType;
-  GrainType const grain({"one"});
-  double const value1(static_cast<double>(1));
-  GrainedInputType const tup1(grain, value1);
-  std::vector<std::tuple<std::vector<std::string> const &, double const &>> const training_batch = {tup1};
+
+  EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::AnalyticalRollingWindowCalculation::Mean, 2, 2, 2);
+
+  const GrainType grain({"one"});
+  const double value1(static_cast<double>(1));
+  const GrainedInputType tup1(grain, value1);
+  const std::vector<std::tuple<std::vector<std::string> const &, double const &>> training_batch = {tup1};
 
   auto stream = GetStream(estimator, training_batch);
   auto dim = static_cast<int64_t>(stream.size());
+
   OpTester test("AnalyticalRollingWindowTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+
   test.AddInput<uint8_t>("State", {dim}, stream);
   test.AddInput<std::string>("Grains", {4, 1}, {"one", "one", "one", "one"});
   test.AddInput<double>("Target", {4}, {1, 2, 3, 4});
@@ -81,10 +87,11 @@ TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_1_grain_
 
 TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_2_grain_window_size_2_horizon_2_min_window_size_2) {
   using EstimatorT = NS::Featurizers::GrainedAnalyticalRollingWindowEstimator<double>;
-
-  EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::AnalyticalRollingWindowCalculation::Mean, 2, 2);
   using GrainType = std::vector<std::string>;
   using GrainedInputType = EstimatorT::InputType;
+
+  EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::AnalyticalRollingWindowCalculation::Mean, 2, 2);
+
   const GrainType grainOne({"one"});
   const GrainType grainTwo({"two"});
   const double value1(static_cast<double>(1));
@@ -95,7 +102,9 @@ TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_2_grain_
 
   auto stream = GetStream(estimator, training_batch);
   auto dim = static_cast<int64_t>(stream.size());
+
   OpTester test("AnalyticalRollingWindowTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+
   test.AddInput<uint8_t>("State", {dim}, stream);
   test.AddInput<std::string>("Grains", {4, 1}, {"one", "two", "one", "two"});
   test.AddInput<double>("Target", {4}, {1, 1, 2, 2});
@@ -114,10 +123,11 @@ TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_2_grain_
 
 TEST(FeaturizersTests, SimpleRollingWindow_Transformer_Grained_Min_1_grain_window_size_1_horizon_1) {
   using EstimatorT = NS::Featurizers::GrainedSimpleRollingWindowEstimator<double>;
-
-  EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::SimpleRollingWindowCalculation::Min, 1, 1);
   using GrainType = std::vector<std::string>;
   using GrainedInputType = EstimatorT::InputType;
+
+  EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::SimpleRollingWindowCalculation::Min, 1, 1);
+
   const GrainType grainOne({"one"});
   const double value1(static_cast<double>(1));
   const GrainedInputType tup1(grainOne, value1);
@@ -125,7 +135,9 @@ TEST(FeaturizersTests, SimpleRollingWindow_Transformer_Grained_Min_1_grain_windo
 
   auto stream = GetStream(estimator, training_batch);
   auto dim = static_cast<int64_t>(stream.size());
+
   OpTester test("SimpleRollingWindowTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+
   test.AddInput<uint8_t>("State", {dim}, stream);
   test.AddInput<std::string>("Grains", {3, 1}, {"one", "one", "one"});
   test.AddInput<double>("Target", {3}, {1, 2, 3});

--- a/onnxruntime/test/featurizers_ops/rolling_window_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/rolling_window_transformer_test.cc
@@ -13,7 +13,9 @@ namespace test {
 
 namespace {
 
-template<typename EstimatorT, typename InputType>
+using InputType = std::tuple<std::vector<std::string> const &, double const &>;
+
+template<typename EstimatorT>
 std::vector<uint8_t> GetStream(EstimatorT& estimator, const std::vector<InputType>& trainingBatches) {
   NS::TestHelpers::Train<EstimatorT, InputType>(estimator, trainingBatches);
   auto pTransformer = estimator.create_transformer();
@@ -25,7 +27,6 @@ std::vector<uint8_t> GetStream(EstimatorT& estimator, const std::vector<InputTyp
 } // namespace
 
 TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_1_grain_window_size_1_horizon_1) {
-  using InputType = std::tuple<std::vector<std::string> const &, double const &>;
   using EstimatorT = NS::Featurizers::GrainedAnalyticalRollingWindowEstimator<double>;
 
   EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::AnalyticalRollingWindowCalculation::Mean, 1, 1);
@@ -49,7 +50,6 @@ TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_1_grain_
 }
 
 TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_1_grain_window_size_2_horizon_2_min_window_size_2) {
-  using InputType = std::tuple<std::vector<std::string> const &, double const &>;
   using EstimatorT = NS::Featurizers::GrainedAnalyticalRollingWindowEstimator<double>;
 
   EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::AnalyticalRollingWindowCalculation::Mean, 2, 2, 2);
@@ -80,7 +80,6 @@ TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_1_grain_
 }
 
 TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_2_grain_window_size_2_horizon_2_min_window_size_2) {
-  using InputType = std::tuple<std::vector<std::string> const &, double const &>;
   using EstimatorT = NS::Featurizers::GrainedAnalyticalRollingWindowEstimator<double>;
 
   EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::AnalyticalRollingWindowCalculation::Mean, 2, 2);
@@ -114,7 +113,6 @@ TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_2_grain_
 }
 
 TEST(FeaturizersTests, SimpleRollingWindow_Transformer_Grained_Min_1_grain_window_size_1_horizon_1) {
-  using InputType = std::tuple<std::vector<std::string> const &, double const &>;
   using EstimatorT = NS::Featurizers::GrainedSimpleRollingWindowEstimator<double>;
 
   EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::SimpleRollingWindowCalculation::Min, 1, 1);

--- a/onnxruntime/test/featurizers_ops/rolling_window_transformer_test.cc
+++ b/onnxruntime/test/featurizers_ops/rolling_window_transformer_test.cc
@@ -2,6 +2,7 @@
 #include "test/providers/provider_test_utils.h"
 
 #include "Featurizers/AnalyticalRollingWindowFeaturizer.h"
+#include "Featurizers/SimpleRollingWindowFeaturizer.h"
 #include "Featurizers/../Archive.h"
 #include "Featurizers/TestHelpers.h"
 
@@ -12,9 +13,7 @@ namespace test {
 
 namespace {
 
-using InputType = std::tuple<std::vector<std::string> const &, int32_t const &>;
-using EstimatorT = NS::Featurizers::GrainedAnalyticalRollingWindowEstimator<int32_t>;
-
+template<typename EstimatorT, typename InputType>
 std::vector<uint8_t> GetStream(EstimatorT& estimator, const std::vector<InputType>& trainingBatches) {
   NS::TestHelpers::Train<EstimatorT, InputType>(estimator, trainingBatches);
   auto pTransformer = estimator.create_transformer();
@@ -25,79 +24,115 @@ std::vector<uint8_t> GetStream(EstimatorT& estimator, const std::vector<InputTyp
 
 } // namespace
 
-TEST(FeaturizersTests, RollingWindow_Transformer_Grained_Mean_1_grain_window_size_1_horizon_1) {
+TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_1_grain_window_size_1_horizon_1) {
+  using InputType = std::tuple<std::vector<std::string> const &, double const &>;
+  using EstimatorT = NS::Featurizers::GrainedAnalyticalRollingWindowEstimator<double>;
+
   EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::AnalyticalRollingWindowCalculation::Mean, 1, 1);
   using GrainType = std::vector<std::string>;
   using GrainedInputType = EstimatorT::InputType;
   GrainType const grain({"one"});
-  int32_t const value1(static_cast<int32_t>(10));
+  double const value1(static_cast<double>(10));
   GrainedInputType const tup1(grain, value1);
-  std::vector<std::tuple<std::vector<std::string> const &, std::int32_t const &>> const training_batch = {tup1};
+  std::vector<std::tuple<std::vector<std::string> const &, double const &>> const training_batch = {tup1};
 
   auto stream = GetStream(estimator, training_batch);
   auto dim = static_cast<int64_t>(stream.size());
-  OpTester test("RollingWindowTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+  OpTester test("AnalyticalRollingWindowTransformer", 1, onnxruntime::kMSFeaturizersDomain);
   test.AddInput<uint8_t>("State", {dim}, stream);
   test.AddInput<std::string>("Grains", {3, 1}, {"one", "one", "one"});
-  test.AddInput<int32_t>("Target", {3}, {1, 2, 3});
-  test.AddOutput<double>("Output", {3, 1}, {NS::Traits<double>::CreateNullValue(), 1.0, 2.0});
+  test.AddInput<double>("Target", {3}, {1, 2, 3});
+
+  test.AddOutput<double>("Output", {3, 1,  1}, {NS::Traits<double>::CreateNullValue(), 1.0, 2.0});
 
   test.Run();
 }
 
-TEST(FeaturizersTests, RollingWindow_Transformer_Grained_Mean_1_grain_window_size_2_horizon_2_min_window_size_2) {
+TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_1_grain_window_size_2_horizon_2_min_window_size_2) {
+  using InputType = std::tuple<std::vector<std::string> const &, double const &>;
+  using EstimatorT = NS::Featurizers::GrainedAnalyticalRollingWindowEstimator<double>;
+
   EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::AnalyticalRollingWindowCalculation::Mean, 2, 2, 2);
   using GrainType = std::vector<std::string>;
   using GrainedInputType = EstimatorT::InputType;
   GrainType const grain({"one"});
-  int32_t const value1(static_cast<int32_t>(1));
+  double const value1(static_cast<double>(1));
   GrainedInputType const tup1(grain, value1);
-  std::vector<std::tuple<std::vector<std::string> const &, std::int32_t const &>> const training_batch = {tup1};
+  std::vector<std::tuple<std::vector<std::string> const &, double const &>> const training_batch = {tup1};
 
   auto stream = GetStream(estimator, training_batch);
   auto dim = static_cast<int64_t>(stream.size());
-  OpTester test("RollingWindowTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+  OpTester test("AnalyticalRollingWindowTransformer", 1, onnxruntime::kMSFeaturizersDomain);
   test.AddInput<uint8_t>("State", {dim}, stream);
   test.AddInput<std::string>("Grains", {4, 1}, {"one", "one", "one", "one"});
-  test.AddInput<int32_t>("Target", {4}, {1, 2, 3, 4});
-  test.AddOutput<double>("Output", {4, 2}, {NS::Traits<double>::CreateNullValue(),
-                                            NS::Traits<double>::CreateNullValue(),
-                                            NS::Traits<double>::CreateNullValue(),
-                                            NS::Traits<double>::CreateNullValue(),
-                                            NS::Traits<double>::CreateNullValue(),
-                                            1.5,
-                                            1.5,
-                                            2.5});
+  test.AddInput<double>("Target", {4}, {1, 2, 3, 4});
+
+  test.AddOutput<double>("Output", {4, 1, 2}, {NS::Traits<double>::CreateNullValue(),
+                                               NS::Traits<double>::CreateNullValue(),
+                                               NS::Traits<double>::CreateNullValue(),
+                                               NS::Traits<double>::CreateNullValue(),
+                                               NS::Traits<double>::CreateNullValue(),
+                                               1.5,
+                                               1.5,
+                                               2.5});
 
   test.Run();
 }
 
-TEST(FeaturizersTests, RollingWindow_Transformer_Grained_Mean_2_grain_window_size_2_horizon_2_min_window_size_2) {
+TEST(FeaturizersTests, AnalyticalRollingWindow_Transformer_Grained_Mean_2_grain_window_size_2_horizon_2_min_window_size_2) {
+  using InputType = std::tuple<std::vector<std::string> const &, double const &>;
+  using EstimatorT = NS::Featurizers::GrainedAnalyticalRollingWindowEstimator<double>;
+
   EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::AnalyticalRollingWindowCalculation::Mean, 2, 2);
   using GrainType = std::vector<std::string>;
   using GrainedInputType = EstimatorT::InputType;
   const GrainType grainOne({"one"});
   const GrainType grainTwo({"two"});
-  const int32_t value1(static_cast<int32_t>(1));
-  const int32_t value2(static_cast<int32_t>(1));
+  const double value1(static_cast<double>(1));
+  const double value2(static_cast<double>(1));
   const GrainedInputType tup1(grainOne, value1);
   const GrainedInputType tup2(grainTwo, value2);
-  const std::vector<std::tuple<std::vector<std::string> const &, std::int32_t const &>> training_batch = {tup1, tup2};
+  const std::vector<std::tuple<std::vector<std::string> const &, double const &>> training_batch = {tup1, tup2};
 
   auto stream = GetStream(estimator, training_batch);
   auto dim = static_cast<int64_t>(stream.size());
-  OpTester test("RollingWindowTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+  OpTester test("AnalyticalRollingWindowTransformer", 1, onnxruntime::kMSFeaturizersDomain);
   test.AddInput<uint8_t>("State", {dim}, stream);
   test.AddInput<std::string>("Grains", {4, 1}, {"one", "two", "one", "two"});
-  test.AddInput<int32_t>("Target", {4}, {1, 1, 2, 2});
-  test.AddOutput<double>("Output", {4, 2}, {NS::Traits<double>::CreateNullValue(),
-                                            NS::Traits<double>::CreateNullValue(),
-                                            NS::Traits<double>::CreateNullValue(),
-                                            NS::Traits<double>::CreateNullValue(),
-                                            NS::Traits<double>::CreateNullValue(),
-                                            1.0,
-                                            NS::Traits<double>::CreateNullValue(),
-                                            1.0});
+  test.AddInput<double>("Target", {4}, {1, 1, 2, 2});
+
+  test.AddOutput<double>("Output", {4, 1, 2}, {NS::Traits<double>::CreateNullValue(),
+                                               NS::Traits<double>::CreateNullValue(),
+                                               NS::Traits<double>::CreateNullValue(),
+                                               NS::Traits<double>::CreateNullValue(),
+                                               NS::Traits<double>::CreateNullValue(),
+                                               1.0,
+                                               NS::Traits<double>::CreateNullValue(),
+                                               1.0});
+
+  test.Run();
+}
+
+TEST(FeaturizersTests, SimpleRollingWindow_Transformer_Grained_Min_1_grain_window_size_1_horizon_1) {
+  using InputType = std::tuple<std::vector<std::string> const &, double const &>;
+  using EstimatorT = NS::Featurizers::GrainedSimpleRollingWindowEstimator<double>;
+
+  EstimatorT      estimator(NS::CreateTestAnnotationMapsPtr(1), NS::Featurizers::SimpleRollingWindowCalculation::Min, 1, 1);
+  using GrainType = std::vector<std::string>;
+  using GrainedInputType = EstimatorT::InputType;
+  const GrainType grainOne({"one"});
+  const double value1(static_cast<double>(1));
+  const GrainedInputType tup1(grainOne, value1);
+  const std::vector<std::tuple<std::vector<std::string> const &, double const &>> training_batch = {tup1};
+
+  auto stream = GetStream(estimator, training_batch);
+  auto dim = static_cast<int64_t>(stream.size());
+  OpTester test("SimpleRollingWindowTransformer", 1, onnxruntime::kMSFeaturizersDomain);
+  test.AddInput<uint8_t>("State", {dim}, stream);
+  test.AddInput<std::string>("Grains", {3, 1}, {"one", "one", "one"});
+  test.AddInput<double>("Target", {3}, {1, 2, 3});
+
+  test.AddOutput<double>("Output", {3, 1, 1}, {NS::Traits<double>::CreateNullValue(), 1, 2});
 
   test.Run();
 }


### PR DESCRIPTION
**Description**: 
- change its output tensor dimension from 2 to 3
- use two kernels for analytical & simple rollingwindow featurizer respectively

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
