### PR TITLE
add missing deps in Dockerfile.openvino

### DIFF
--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -7,7 +7,7 @@ FROM ubuntu:16.04
 
 RUN apt update && \
     apt -y install git sudo wget \
-    zip x11-apps lsb-core cpio libboost-python-dev libpng-dev zlib1g-dev libnuma1 ocl-icd-libopencl1 clinfo libboost-filesystem1.58.0 libboost-thread1.58.0 protobuf-compiler libprotoc-dev libusb-1.0-0-dev
+    zip x11-apps lsb-core cpio libboost-python-dev libpng-dev zlib1g-dev libnuma1 ocl-icd-libopencl1 clinfo libboost-filesystem1.58.0 libboost-thread1.58.0 protobuf-compiler libprotoc-dev libusb-1.0-0-dev autoconf automake libtool
 
 ARG DEVICE=CPU_FP32
 ARG ONNXRUNTIME_REPO=https://github.com/microsoft/onnxruntime


### PR DESCRIPTION
current Dockerfile doesn't build

+ autoreconf -f -i -Wall,no-obsolete
./autogen.sh: 37: ./autogen.sh: autoreconf: not found
CMakeFiles/ext_protobuf.dir/build.make:107: recipe for target 'protobuf/stamp/ext_protobuf-configure' failed
make[5]: *** [protobuf/stamp/ext_protobuf-configure] Error 127
CMakeFiles/Makefile2:168: recipe for target 'CMakeFiles/ext_protobuf.dir/all' failed
make[4]: *** [CMakeFiles/ext_protobuf.dir/all] Error 2
make[3]: *** [all] Error 2
Makefile:151: recipe for target 'all' failed
make[2]: *** [ngraph/src/project_ngraph-stamp/project_ngraph-build] Error 2
CMakeFiles/project_ngraph.dir/build.make:114: recipe for target 'ngraph/src/project_ngraph-stamp/project_ngraph-build' failed
make[1]: *** [CMakeFiles/project_ngraph.dir/all] Error 2
CMakeFiles/Makefile2:655: recipe for target 'CMakeFiles/project_ngraph.dir/all' failed
make: *** [all] Error 2
Makefile:140: recipe for target 'all' failed
