### PR TITLE
Handle dim with value of zero in ConvTranspose

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/conv_transpose.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose.cc
@@ -49,6 +49,11 @@ Status ConvTranspose<T>::DoConvTranspose(OpKernelContext* context, bool dynamic_
   bool has_bias = dynamic_padding ? num_inputs == 4 : num_inputs == 3;
   ORT_RETURN_IF_ERROR(conv_transpose_attrs_.PrepareForCompute(context, has_bias, p, dynamic_padding));
 
+  // Bail out early if one of the dimensions is zero.
+  if (p.Y->Shape().Size() == 0) {
+    return Status::OK();
+  }
+
   const int64_t input_image_size = p.input_shape.Size();
   const int64_t X_offset = p.num_input_channels / conv_transpose_attrs_.group * input_image_size;
   const int64_t Y_offset = p.Y->Shape().Size() / p.Y->Shape()[0] / conv_transpose_attrs_.group;

--- a/onnxruntime/core/providers/cuda/nn/conv_transpose.cc
+++ b/onnxruntime/core/providers/cuda/nn/conv_transpose.cc
@@ -61,8 +61,8 @@ Status ConvTranspose<T>::DoConvTranspose(OpKernelContext* context, bool dynamic_
 
   CudaT* y_data = nullptr;
   if (x_dimensions == 3) {
-    x_dims.insert(x_dims.begin() + 2,  1);
-    w_dims.insert(w_dims.begin() + 2,  1);
+    x_dims.insert(x_dims.begin() + 2, 1);
+    w_dims.insert(w_dims.begin() + 2, 1);
   }
 
   {
@@ -82,14 +82,19 @@ Status ConvTranspose<T>::DoConvTranspose(OpKernelContext* context, bool dynamic_
       ConvTransposeAttributes::Prepare p;
       ORT_RETURN_IF_ERROR(conv_transpose_attrs_.PrepareForCompute(context, has_bias, p, dynamic_padding));
 
+      // Bail out early if one of the dimensions is zero.
+      if (p.Y->Shape().Size() == 0) {
+        return Status::OK();
+      }
+
       auto y_dims = p.Y->Shape().GetDims();
       if (x_dimensions == 3) {
-        y_dims.insert(y_dims.begin() + 2,  1);
-        p.kernel_shape.insert(p.kernel_shape.begin(),  1);
-        p.pads.insert(p.pads.begin(),  0);
-        p.pads.insert(p.pads.begin() + 2,  0);
+        y_dims.insert(y_dims.begin() + 2, 1);
+        p.kernel_shape.insert(p.kernel_shape.begin(), 1);
+        p.pads.insert(p.pads.begin(), 0);
+        p.pads.insert(p.pads.begin() + 2, 0);
         p.strides.insert(p.strides.begin(), 1);
-        p.dilations.insert(p.dilations.begin(),  1);
+        p.dilations.insert(p.dilations.begin(), 1);
       }
       s_.y_dims = y_dims;
 

--- a/onnxruntime/test/providers/cpu/nn/conv_transpose_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_transpose_op_test.cc
@@ -571,7 +571,9 @@ TEST(ConvTransposeTest, DimWithZero) {
   vector<int64_t> Y_shape = {0, 1, 6, 6};
   initializer_list<float> expected_vals = {};
 
-  TestConvTransposeOp(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape);
+  TestConvTransposeOp(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape,
+                      OpTester::ExpectResult::kExpectSuccess, "",
+                      {kTensorrtExecutionProvider, kNGraphExecutionProvider, kAclExecutionProvider});
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/cpu/nn/conv_transpose_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_transpose_op_test.cc
@@ -552,5 +552,27 @@ TEST(ConvTransposeTest, ConvTranspose_2D_NonDefaultStridesAndDilations) {
   TestConvTransposeOp(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape);
 }
 
+TEST(ConvTransposeTest, DimWithZero) {
+  ConvTransposeOpAttributes attrs = {
+      vector<int64_t>{3, 3},        // kernel_shape
+      vector<int64_t>{1, 1},        // output_padding
+      {},                           // output_shape
+      vector<int64_t>{1, 1, 1, 1},  // pads
+      vector<int64_t>{2, 2},        // strides
+      vector<int64_t>{1, 1},        // dilations
+      1                             // group
+  };
+  vector<float> X = {};
+  vector<int64_t> X_shape = {0, 1, 3, 3};
+  vector<float> W = {-0.06230065f, 0.37932432f, -0.25388849f,
+                     0.33878803f, 0.43709868f, -0.22477469f,
+                     0.04118127f, -0.44696793f, 0.06373066f};
+  vector<int64_t> W_shape = {1, 1, 3, 3};
+  vector<int64_t> Y_shape = {0, 1, 6, 6};
+  initializer_list<float> expected_vals = {};
+
+  TestConvTransposeOp(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape);
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**: 
Add handling in ConvTranspose for input that has dim with value of zero.

**Motivation and Context**
Fixes crash with mask rcnn model. All ops need to handle this as it's a valid scenario (NonZero or Loop can produce output with a dim value of zero).
