### PR TITLE
remove training warning message

### DIFF
--- a/onnxruntime/python/training/__init__.py
+++ b/onnxruntime/python/training/__init__.py
@@ -4,4 +4,3 @@
 #--------------------------------------------------------------------------
 
 # This is a placeholder file. It is deployed with inference only wheel.
-print("An inference only version of ONNX Runtime is installed. Training functionalities are unavailable.")


### PR DESCRIPTION
remove warning message. we currently only publish inference packages so 
the warning isn't actionable and may cause confusion.
