### PR TITLE
[OpenVINO-EP] Optimize MCR Docker image size

### DIFF
--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -16,14 +16,6 @@ ARG ONNXRUNTIME_BRANCH=master
 WORKDIR /code
 ENV PATH /opt/miniconda/bin:/code/cmake-3.14.3-Linux-x86_64/bin:$PATH
 
-RUN git clone --recursive -b $ONNXRUNTIME_BRANCH $ONNXRUNTIME_REPO onnxruntime && \
-    cp onnxruntime/docs/Privacy.md /code/Privacy.md && \
-    cp onnxruntime/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt && \
-    cp onnxruntime/ThirdPartyNotices.txt /code/ThirdPartyNotices.txt && \
-    /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh && \
-    cd onnxruntime/cmake/external/onnx && python3 setup.py install && \
-    pip install azure-iothub-device-client azure-iothub-service-client azure-iot-provisioning-device-client
-
 ENV pattern="COMPONENTS=DEFAULTS"
 ENV replacement="COMPONENTS=intel-openvino-ie-sdk-ubuntu-xenial__x86_64;intel-openvino-ie-rt-cpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-gpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-vpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-hddl-ubuntu-xenial__x86_64;intel-openvino-model-optimizer__x86_64;intel-openvino-opencv-lib-ubuntu-xenial__x86_64"
 COPY l_openvino_*.tgz .
@@ -50,5 +42,11 @@ ENV LD_LIBRARY_PATH=${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/exte
 RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8
 ENV LANG en_US.UTF-8
 
-RUN cd onnxruntime && ./build.sh --config RelWithDebInfo --update --build --parallel --use_openvino $DEVICE --build_wheel --use_full_protobuf && \
-    pip install build/Linux/RelWithDebInfo/dist/*-linux_x86_64.whl && rm -rf /code/onnxruntime /code/cmake-3.14.3-Linux-x86_64
+RUN git clone --recursive -b $ONNXRUNTIME_BRANCH $ONNXRUNTIME_REPO onnxruntime && \
+    cp onnxruntime/docs/Privacy.md /code/Privacy.md && \
+    cp onnxruntime/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt && \
+    cp onnxruntime/ThirdPartyNotices.txt /code/ThirdPartyNotices.txt && \
+    /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh && \
+    cd onnxruntime/cmake/external/onnx && python3 setup.py install && \
+    pip install azure-iothub-device-client azure-iothub-service-client azure-iot-provisioning-device-client && cd onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino $DEVICE --build_wheel --use_full_protobuf && \
+    pip install build/Linux/Release/dist/*-linux_x86_64.whl && rm -rf /code/onnxruntime /code/cmake-3.14.3-Linux-x86_64

--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -5,31 +5,18 @@
 
 FROM ubuntu:16.04
 
-RUN apt update && \
-    apt -y install git sudo wget \
-    zip x11-apps lsb-core cpio libboost-python-dev libpng-dev zlib1g-dev libnuma1 ocl-icd-libopencl1 clinfo libboost-filesystem1.58.0 libboost-thread1.58.0 protobuf-compiler libprotoc-dev libusb-1.0-0-dev autoconf automake libtool
-
 ARG DEVICE=CPU_FP32
 ARG ONNXRUNTIME_REPO=https://github.com/microsoft/onnxruntime
 ARG ONNXRUNTIME_BRANCH=master
 
 WORKDIR /code
+ARG MY_ROOT=/code
 ENV PATH /opt/miniconda/bin:/code/cmake-3.14.3-Linux-x86_64/bin:$PATH
+
 
 ENV pattern="COMPONENTS=DEFAULTS"
 ENV replacement="COMPONENTS=intel-openvino-ie-sdk-ubuntu-xenial__x86_64;intel-openvino-ie-rt-cpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-gpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-vpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-hddl-ubuntu-xenial__x86_64;intel-openvino-model-optimizer__x86_64;intel-openvino-opencv-lib-ubuntu-xenial__x86_64"
 COPY l_openvino_*.tgz .
-RUN tar -xzf l_openvino_toolkit*.tgz && \
-    rm -rf l_openvino_toolkit*.tgz && \
-    cd l_openvino_toolkit* && \
-    sed -i "s/$pattern/$replacement/" silent.cfg && \
-    sed -i 's/decline/accept/g' silent.cfg && \
-    ./install.sh -s silent.cfg && \
-    cd - && \
-    rm -rf l_openvino_toolkit* && \
-    cd /opt/intel/openvino/install_dependencies && ./_install_all_dependencies.sh && dpkg -i *.deb && \
-    pip install networkx==2.3 test-generator==0.1.1 defusedxml>=0.5.0
-
 ENV LD_LIBRARY_PATH=/opt/miniconda/lib:/usr/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 ENV INTEL_OPENVINO_DIR=/opt/intel/openvino_2020.2.120
 ENV InferenceEngine_DIR=${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/share
@@ -39,14 +26,31 @@ ENV OpenCV_DIR=${INTEL_OPENVINO_DIR}/opencv/share/OpenCV
 ENV LD_LIBRARY_PATH=${INTEL_OPENVINO_DIR}/opencv/lib:${INTEL_OPENVINO_DIR}/opencv/share/OpenCV/3rdparty/lib:${LD_LIBRARY_PATH}
 ENV HDDL_INSTALL_DIR=${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/external/hddl
 ENV LD_LIBRARY_PATH=${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/external/hddl/lib:$LD_LIBRARY_PATH
-RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8
 ENV LANG en_US.UTF-8
 
-RUN git clone --recursive -b $ONNXRUNTIME_BRANCH $ONNXRUNTIME_REPO onnxruntime && \
+RUN apt update && \
+    apt -y install git sudo wget locales \
+    zip x11-apps lsb-core cpio libboost-python-dev libpng-dev zlib1g-dev libnuma1 ocl-icd-libopencl1 clinfo libboost-filesystem1.58.0 libboost-thread1.58.0 protobuf-compiler libprotoc-dev libusb-1.0-0-dev autoconf automake libtool && \
+    cd ${MY_ROOT} && \
+    git clone --recursive -b $ONNXRUNTIME_BRANCH $ONNXRUNTIME_REPO onnxruntime && \
     cp onnxruntime/docs/Privacy.md /code/Privacy.md && \
     cp onnxruntime/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt && \
     cp onnxruntime/ThirdPartyNotices.txt /code/ThirdPartyNotices.txt && \
     /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh && \
     cd onnxruntime/cmake/external/onnx && python3 setup.py install && \
-    pip install azure-iothub-device-client azure-iothub-service-client azure-iot-provisioning-device-client && cd onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino $DEVICE --build_wheel --use_full_protobuf && \
+    pip install azure-iothub-device-client azure-iothub-service-client azure-iot-provisioning-device-client && \
+    cd ${MY_ROOT} && \
+    tar -xzf l_openvino_toolkit*.tgz && \
+    rm -rf l_openvino_toolkit*.tgz && \
+    cd l_openvino_toolkit* && \
+    sed -i "s/$pattern/$replacement/" silent.cfg && \
+    sed -i 's/decline/accept/g' silent.cfg && \
+    ./install.sh -s silent.cfg && \
+    cd - && \
+    rm -rf l_openvino_toolkit* && \
+    cd /opt/intel/openvino/install_dependencies && ./_install_all_dependencies.sh && dpkg -i *.deb && \
+    cd ${MY_ROOT} && \
+    locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8 && \
+    cd ${MY_ROOT} && \
+    cd onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino $DEVICE --build_wheel --use_full_protobuf && \
     pip install build/Linux/Release/dist/*-linux_x86_64.whl && rm -rf /code/onnxruntime /code/cmake-3.14.3-Linux-x86_64

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -102,9 +102,9 @@ Use `docker pull` with any of the images and tags below to pull an image and try
 
    Retrieve your docker image in one of the following ways.
 
-    -  To build your docker image, download the OpenVINO online installer version **2020.2** for Linux from [this link](https://software.intel.com/en-us/openvino-toolkit/choose-download) and copy the OpenVINO tar file to the same directory before building the Docker image. The online installer size is 16MB and the components needed for the accelerators are mentioned in the dockerfile. Providing the docker build argument DEVICE enables the onnxruntime build for that particular device. You can also provide arguments ONNXRUNTIME_REPO and ONNXRUNTIME_BRANCH to test that particular repo and branch. Default repository is http://github.com/microsoft/onnxruntime and default branch is master.
+    -  To build your docker image, download the OpenVINO **online installer** package for version **2020.2** for Linux from [this link](https://software.intel.com/en-us/openvino-toolkit/choose-download) and copy the OpenVINO tar file to the same directory before building the Docker image. The online installer size is 16MB and the components needed for the accelerators are mentioned in the dockerfile. Providing the docker build argument DEVICE enables the onnxruntime build for that particular device. You can also provide arguments ONNXRUNTIME_REPO and ONNXRUNTIME_BRANCH to test that particular repo and branch. Default repository is http://github.com/microsoft/onnxruntime and default branch is master.
        ```
-       docker build -t onnxruntime --build-arg DEVICE=$DEVICE .
+       docker build --rm -t onnxruntime --build-arg DEVICE=$DEVICE .
        ```
     - Pull the official image from DockerHub.
 
@@ -121,16 +121,10 @@ Use `docker pull` with any of the images and tags below to pull an image and try
 
 ### OpenVINO on CPU
 
-1. Retrieve your docker image in one of the following ways.
-
-   - Build the docker image from the DockerFile in this repository.
+1. Build the docker image from the DockerFile in this repository.
 
      ```
-     docker build -t onnxruntime-cpu --build-arg DEVICE=CPU_FP32 --network host .
-     ```
-   - Pull the official image from DockerHub.
-     ```
-     # Will be available with next release
+     docker build --rm -t onnxruntime-cpu --build-arg DEVICE=CPU_FP32 --network host .
      ```
 2. Run the docker image
     ```
@@ -139,32 +133,22 @@ Use `docker pull` with any of the images and tags below to pull an image and try
 
 ### OpenVINO on GPU
 
-1. Retrieve your docker image in one of the following ways.
-   - Build the docker image from the DockerFile in this repository.
+1. Build the docker image from the DockerFile in this repository.
      ```
-      docker build -t onnxruntime-gpu --build-arg DEVICE=GPU_FP32 --network host .
+      docker build --rm -t onnxruntime-gpu --build-arg DEVICE=GPU_FP32 --network host .
      ```
-   - Pull the official image from DockerHub.
-     ```
-       # Will be available with next release
-     ```
-
 2. Run the docker image
     ```
     docker run -it --device /dev/dri:/dev/dri onnxruntime-gpu:latest
     ```
 ### OpenVINO on Myriad VPU Accelerator
 
-1. Retrieve your docker image in one of the following ways.
-   - Build the docker image from the DockerFile in this repository.
+1. Build the docker image from the DockerFile in this repository.
      ```
-      docker build -t onnxruntime-myriad --build-arg DEVICE=MYRIAD_FP16 --network host .
-     ```
-   - Pull the official image from DockerHub.
-     ```
-      # Will be available with next release
+      docker build --rm -t onnxruntime-myriad --build-arg DEVICE=MYRIAD_FP16 --network host .
      ```
 2. Install the Myriad rules drivers on the host machine according to the reference in [here](https://docs.openvinotoolkit.org/latest/_docs_install_guides_installing_openvino_linux.html#additional-NCS-steps)
+
 3. Run the docker image by mounting the device drivers
     ```
     docker run -it --network host --privileged -v /dev:/dev  onnxruntime-myriad:latest
@@ -173,16 +157,12 @@ Use `docker pull` with any of the images and tags below to pull an image and try
 
 ### OpenVINO on VAD-M Accelerator Version
 
-1. Retrieve your docker image in one of the following ways.
-   - Build the docker image from the DockerFile in this repository.
+1. Build the docker image from the DockerFile in this repository.
      ```
-      docker build -t onnxruntime-vadr --build-arg DEVICE=VAD-M_FP16 --network host .
-     ```
-   - Pull the official image from DockerHub.
-     ```
-      # Will be available with next release
+      docker build --rm -t onnxruntime-vadr --build-arg DEVICE=VAD-M_FP16 --network host .
      ```
 2. Install the HDDL drivers on the host machine according to the reference in [here](https://docs.openvinotoolkit.org/latest/_docs_install_guides_installing_openvino_linux_ivad_vpu.html)
+
 3. Run the docker image by mounting the device drivers
     ```
     docker run -it --device --mount type=bind,source=/var/tmp,destination=/var/tmp --device /dev/ion:/dev/ion  onnxruntime-hddl:latest


### PR DESCRIPTION
**Description**:
1. Aggregate all RUN commands into a single RUN command to single RUN command to avoid size bloat due to docker layer caching.
2. Remove Model Optimizer related libraries
3. Update documentation to use _Online Installer_ package for docker build
4. Change ORT build type to 'Release' to avoid debug symbols that consume extra storage.

**Motivation and Context**
- Reduces the MCR docker image size from ~ 5GB to ~2 GB
