### PR TITLE
Enable telemetry on windows zip packages

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
@@ -94,6 +94,8 @@ jobs:
         buildparameter:
 
   steps:
+    - template: templates/enable-telemetry.yml
+    
     - task: UsePythonVersion@0
       inputs: 
         versionSpec: '3.7' 


### PR DESCRIPTION
Issue: Artifacts produced by c-api-packaging-pipelines.yml do not have telemetry enabled (for windows). They should have telemetry enabled.

Fix: Need to add the enable-telemetry.yml template to the windows build steps. In addition the pipeline needs to be configured correctly for enabling the correct telemetry upload ids.