### PR TITLE
fix warning treated as error due to ignoring return status

### DIFF
--- a/orttraining/orttraining/models/pipeline_poc/main.cc
+++ b/orttraining/orttraining/models/pipeline_poc/main.cc
@@ -105,11 +105,12 @@ int main(int argc, char* argv[]) {
 
   InferenceSession session_object{so, *env};
 
+  Status st;
   CUDAExecutionProviderInfo xp_info{static_cast<OrtDevice::DeviceId>(world_rank)};
-  session_object.RegisterExecutionProvider(std::make_unique<CUDAExecutionProvider>(xp_info));
+  st = session_object.RegisterExecutionProvider(std::make_unique<CUDAExecutionProvider>(xp_info));
+  ORT_ENFORCE(st == Status::OK(), "MPI rank ", world_rank, ": ", st.ErrorMessage());
 
   std::string model_at_rank;
-  Status st;
   if (world_rank == 0) {
     st = session_object.Load(params.model_stage0_name);
     ORT_ENFORCE(st == Status::OK(), "MPI rank ", world_rank, ": ", st.ErrorMessage());


### PR DESCRIPTION
**Description**: 
Fix warning turned error due to ignoring status of return value.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
