### PR TITLE
[OpenVINO-EP] Limit the number of models run on OpenVINO

### DIFF
--- a/docs/execution_providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution_providers/OpenVINO-ExecutionProvider.md
@@ -17,7 +17,7 @@ sess = onnxruntime.InferenceSession(<path_to_model_file>, options)
 
 2. C++ API
 ```
-SessionOptions::SetGraphOptimizationLevel(ORT_DISABLE_ALL); 
+SessionOptions::SetGraphOptimizationLevel(ORT_DISABLE_ALL);
 ```
 
 ## Dynamic device selection
@@ -71,7 +71,6 @@ VPUs as well as Intel<sup>®</sup> Vision accelerator Design with Intel Movidiu
 | MaxPool | Yes | Yes | Yes |
 | Min | Yes | Yes | Yes |
 | Mul | Yes | Yes | Yes |
-| NonMaxSuppression | Yes | Yes | Yes |
 | Pad | Yes | Yes | Yes |
 | Pow | Yes | Yes | Yes |
 | PRelu | Yes | Yes | Yes |

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1193,7 +1193,7 @@ def openvino_run_onnx_tests(build_dir, configs, onnx_test_data_dir,
             model_dir_opset8, "test_*"))
         model_dir_opset10 = os.path.join(model_dir, "opset10")
         model_dir_opset10 = glob.glob(os.path.join(
-            model_dir_opset10, "tf_*"))
+            model_dir_opset10, "*v1*"))
         for dir_path in itertools.chain(model_dir_opset8,
                                         model_dir_opset10):
           model_test_cmd = cmd + [dir_path]


### PR DESCRIPTION
* Removed NMS from supported list

**Description**: Limiting the number of models run on OpenVINO

**Motivation and Context**
- To keep the runtime of CI less than 90 mins
- If it fixes an open issue, please link to the issue here.
