### PR TITLE
fix build error (unused-result) on ubuntu 18.04

### DIFF
--- a/orttraining/orttraining/models/pipeline_poc/main.cc
+++ b/orttraining/orttraining/models/pipeline_poc/main.cc
@@ -106,7 +106,8 @@ int main(int argc, char* argv[]) {
   InferenceSession session_object{so, *env};
 
   CUDAExecutionProviderInfo xp_info{static_cast<OrtDevice::DeviceId>(world_rank)};
-  session_object.RegisterExecutionProvider(std::make_unique<CUDAExecutionProvider>(xp_info));
+  auto ret = session_object.RegisterExecutionProvider(std::make_unique<CUDAExecutionProvider>(xp_info));
+  ORT_ENFORCE(ret == Status::OK(), "Fail to register execution provider.");
 
   std::string model_at_rank;
   Status st;


### PR DESCRIPTION
**Description**: Fix the build issue when enable_training on Ubuntu 18.04 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

Error Details:

> [ 75%] Building CXX object CMakeFiles/onnxruntime_training_pipeline_poc.dir/code/onnxruntime/orttraining/orttraining/models/pipeline_poc/main.cc.o
> /code/onnxruntime/orttraining/orttraining/models/pipeline_poc/main.cc: In function ‘int main(int, char**)’:
> /code/onnxruntime/orttraining/orttraining/models/pipeline_poc/main.cc:109:93: error: ignoring return value of ‘onnxruntime::common::Status onnxruntime::InferenceSession::RegisterExecutionProvider(std::unique_ptr<onnxruntime::IExecutionProvider>)’, declared with attribute warn_unused_result [-Werror=unused-result]
>    session_object.RegisterExecutionProvider(std::make_unique<CUDAExecutionProvider>(xp_info));
>                                                                                              ^
> In file included from /code/onnxruntime/orttraining/orttraining/core/session/training_session.h:8:0,
>                  from /code/onnxruntime/orttraining/orttraining/models/pipeline_poc/main.cc:11:
> /code/onnxruntime/onnxruntime/core/session/inference_session.h:162:18: note: declared here
>    common::Status RegisterExecutionProvider(std::unique_ptr<IExecutionProvider> p_exec_provider) ORT_MUST_USE_RESULT;
>                   ^~~~~~~~~~~~~~~~~~~~~~~~~
> cc1plus: all warnings being treated as errors
> CMakeFiles/onnxruntime_training_pipeline_poc.dir/build.make:62: recipe for target 'CMakeFiles/onnxruntime_training_pipeline_poc.dir/code/onnxruntime/orttraining/orttraining/models/pipeline_poc/main.cc.o' failed
> make[2]: *** [CMakeFiles/onnxruntime_training_pipeline_poc.dir/code/onnxruntime/orttraining/orttraining/models/pipeline_poc/main.cc.o] Error 1
> CMakeFiles/Makefile2:143: recipe for target 'CMakeFiles/onnxruntime_training_pipeline_poc.dir/all' failed
> make[1]: *** [CMakeFiles/onnxruntime_training_pipeline_poc.dir/all] Error 2
> Makefile:140: recipe for target 'all' failed
> make: *** [all] Error 2
