### PR TITLE
Add options to bert optimization script: --enable_gelu_approxmation, --disable_layer_norm and --disable_gelu

### DIFF
--- a/onnxruntime/python/tools/bert/README.md
+++ b/onnxruntime/python/tools/bert/README.md
@@ -55,7 +55,7 @@ See below for description of some options of bert_model_optimization.py:
 - **input**: input model path
 - **output**: output model path
 - **model_type**: (*defaul: bert*)
-    There are 4 model types: *bert* (exported by PyTorch), *bert_tf* (BERT exported by PyTorch), *bert_keras* (BERT exported by keras2onnx) and *gpt2* (exported by PyTorch) respectively.
+    There are 4 model types: *bert* (exported by PyTorch), *bert_tf* (BERT exported by tf2onnx), *bert_keras* (BERT exported by keras2onnx) and *gpt2* (exported by PyTorch) respectively.
 - **num_heads**: (*default: 12*)
     Number of attention heads. BERT-base and BERT-large has 12 and 16 respectively.
 - **hidden_size**: (*default: 768*)

--- a/onnxruntime/python/tools/bert/bert_model_optimization.py
+++ b/onnxruntime/python/tools/bert/bert_model_optimization.py
@@ -156,6 +156,24 @@ def parse_arguments():
                         help="disable Add Bias and Gelu/FastGelu fusion")
     parser.set_defaults(disable_bias_gelu=False)
 
+    parser.add_argument('--disable_layer_norm',
+                        required=False,
+                        action='store_true',
+                        help="disable LayerNormalization fusion")
+    parser.set_defaults(disable_layer_norm=False)
+
+    parser.add_argument('--disable_gelu',
+                        required=False,
+                        action='store_true',
+                        help="disable Gelu fusion")
+    parser.set_defaults(disable_gelu=False)
+
+    parser.add_argument('--enable_gelu_approximation',
+                        required=False,
+                        action='store_true',
+                        help="enable Gelu/BiasGelu to FastGelu conversion")
+    parser.set_defaults(enable_gelu_approximation=False)
+
     parser.add_argument('--verbose', required=False, action='store_true')
     parser.set_defaults(verbose=False)
 
@@ -173,6 +191,10 @@ def parse_arguments():
 
 def get_optimization_options(args):
     optimization_options = BertOptimizationOptions(args.model_type)
+    if args.disable_gelu:
+        optimization_options.enable_gelu = False
+    if args.disable_layer_norm:
+        optimization_options.enable_layer_norm = False
     if args.disable_attention:
         optimization_options.enable_attention = False
     if args.disable_skip_layer_norm:
@@ -183,6 +205,8 @@ def get_optimization_options(args):
         optimization_options.enable_bias_skip_layer_norm = False
     if args.disable_bias_gelu:
         optimization_options.enable_bias_gelu = False
+    if args.enable_gelu_approximation:
+        optimization_options.enable_gelu_approximation = True
     return optimization_options
 
 


### PR DESCRIPTION
**Description**: 
Add three options:
--disable_layer_norm and --disable_gelu for performance analysis.
--enable_gelu_approxmation for Gelu/BiasGelu to FastGelu converison.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

Gelu approximation is disabled by default in ORT. Add an option in script so that user could try it.