### PR TITLE
Add Threadpool::TrySimpleParallelFor 

### DIFF
--- a/docs/NotesOnThreading.md
+++ b/docs/NotesOnThreading.md
@@ -3,14 +3,15 @@
 This document is intended for ORT developers.
 
 ORT allows the usage of either OpenMP or non-OpenMP (ORT) threads for execution. Threadpool management
-is abstracted behind: (1) ThreadPool class in threadpool.h and (2) functions in thread_utils.h.
+is abstracted behind: (1) ThreadPool class in [threadpool.h](https://github.com/microsoft/onnxruntime/blob/master/include/onnxruntime/core/platform/threadpool.h) and (2) functions in [thread_utils.h](https://github.com/microsoft/onnxruntime/blob/master/onnxruntime/core/util/thread_utils.h).
 
 When developing an op, please use these abstractions to parallelize your code. These abstractions centralize 2 things.
 When OpenMP is enabled, they resort to using OpenMP. When OpenMP is disabled they resort to sequential execution if the threadpool ptr is NULL or schedule the tasks on the threadpool otherwise.
 
-Examples of these abstractions are: (threadpool.h has more documentation for these)
+Examples of these abstractions are: ([threadpool.h](https://github.com/microsoft/onnxruntime/blob/master/include/onnxruntime/core/platform/threadpool.h) has more documentation for these)
 * TryBatchParallelFor
 * TryParallelFor
+* TrySimpleParallelFor
 * static version of NumThreads
 
 **Please do not write #ifdef pragma omp in operator code**.

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -109,7 +109,8 @@ ThreadPool::ThreadPool(Eigen::ThreadPoolInterface* user_threadpool, Eigen::Alloc
 }
 
 ThreadPool::~ThreadPool() = default;
-void ThreadPool::SimpleParallelFor(std::ptrdiff_t total, std::function<void(std::ptrdiff_t)> fn) {
+
+void ThreadPool::SimpleParallelFor(std::ptrdiff_t total, const std::function<void(std::ptrdiff_t)>& fn) {
   if (total <= 0)
     return;
 


### PR DESCRIPTION
**Description**: 
Add Threadpool::TrySimpleParallelFor so that there's a path with OpenMP awareness for SimpleParallelFor. Makes it consistent with [Try]BatchParallelFor and [Try]ParallelFor.

Update TopK to check for the number of threads better, and to use TrySimpleParallelFor.

**Motivation and Context**
Make Threadpool API more consistent and improve perf for TopK with default build that uses OpenMP.