### PR TITLE
avoid using LocalFree on FormatMessageA buffer

### DIFF
--- a/onnxruntime/core/platform/path_lib.h
+++ b/onnxruntime/core/platform/path_lib.h
@@ -179,11 +179,9 @@ inline OrtFileType DTToFileType(DWORD dwFileAttributes) {
 }
 inline std::string FormatErrorCode(DWORD dw) {
   static const DWORD bufferLength = 64 * 1024;
-  char * lpMsgBuf = new char[bufferLength];
+  std::string s(bufferLength, '\0');
   FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, dw,
-                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)lpMsgBuf, bufferLength / sizeof(TCHAR), NULL);
-  std::string s(lpMsgBuf);
-  delete[] lpMsgBuf;
+                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)s.data(), bufferLength / sizeof(TCHAR), NULL);
   return s;
 }
 template <typename T>

--- a/onnxruntime/core/platform/path_lib.h
+++ b/onnxruntime/core/platform/path_lib.h
@@ -178,11 +178,12 @@ inline OrtFileType DTToFileType(DWORD dwFileAttributes) {
   return OrtFileType::TYPE_REG;
 }
 inline std::string FormatErrorCode(DWORD dw) {
-  static const DWORD bufferLength = 1024;
-  char lpMsgBuf[bufferLength * sizeof(TCHAR)];
+  static const DWORD bufferLength = 64 * 1024;
+  char * lpMsgBuf = new char[bufferLength];
   FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, dw,
-                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&lpMsgBuf, bufferLength, NULL);
+                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)lpMsgBuf, bufferLength / sizeof(TCHAR), NULL);
   std::string s(lpMsgBuf);
+  delete[] lpMsgBuf;
   return s;
 }
 template <typename T>

--- a/onnxruntime/core/platform/path_lib.h
+++ b/onnxruntime/core/platform/path_lib.h
@@ -178,9 +178,10 @@ inline OrtFileType DTToFileType(DWORD dwFileAttributes) {
   return OrtFileType::TYPE_REG;
 }
 inline std::string FormatErrorCode(DWORD dw) {
-  char lpMsgBuf[1024 * sizeof(TCHAR)];
+  static const DWORD bufferLength = 1024;
+  char lpMsgBuf[bufferLength * sizeof(TCHAR)];
   FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, dw,
-                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&lpMsgBuf, 1024, NULL);
+                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&lpMsgBuf, bufferLength, NULL);
   std::string s(lpMsgBuf);
   return s;
 }

--- a/onnxruntime/core/platform/path_lib.h
+++ b/onnxruntime/core/platform/path_lib.h
@@ -178,11 +178,10 @@ inline OrtFileType DTToFileType(DWORD dwFileAttributes) {
   return OrtFileType::TYPE_REG;
 }
 inline std::string FormatErrorCode(DWORD dw) {
-  char* lpMsgBuf;
-  FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, dw,
-                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&lpMsgBuf, 0, NULL);
+  char lpMsgBuf[1024 * sizeof(TCHAR)];
+  FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, dw,
+                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&lpMsgBuf, 1024, NULL);
   std::string s(lpMsgBuf);
-  LocalFree(lpMsgBuf);
   return s;
 }
 template <typename T>


### PR DESCRIPTION
**Description**: Pass in preallocated buffer to FormatMessageA to avoid using LocalFree.

**Motivation and Context**
LocalFree is introduced in Windows 10. Since 1.2 release, LoopDir which ends up calling LocalFree is being compiled into production code, not just test code so this breaks downlevel support contracts for WinML and OnnxRuntime.