### PR TITLE
set the shareable flag of texture created by CreateTexture2D

### DIFF
--- a/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
+++ b/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
@@ -173,6 +173,8 @@ void VideoFrameToTensorConverter::VideoFrameToDX12Tensor(
 
     D3D11_TEXTURE2D_DESC videoFrameTextureDesc;
     spVideoFrameTexture->GetDesc(&videoFrameTextureDesc);
+    // Try to create shared surface so that the surface can be shared by other DX devices on the same adapter.
+    videoFrameTextureDesc.MiscFlags = D3D11_RESOURCE_MISC_SHARED | D3D11_RESOURCE_MISC_SHARED_NTHANDLE;
 
     if (_winmli::TextureIsOnDevice(spVideoFrameTexture.Get(), pDeviceCache->GetD3D11Device())) {
       // The texture is on our device, so we can just create own texture, share it and cache it


### PR DESCRIPTION

"Winml is grabbing a D3D11 texture from a video frame through IDirect3DDxgiInterfaceAccess, copying its D3D11 texture desc and creating a texture with it, then attempting to share the new texture.   However the texture desc didn’t contain the D3D11 flag making it shareable."

This PR is to set the flag of texturedesc as shareable before creating Texture.