### PR TITLE
Apply onnx-tensorrt bug fixes

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -335,7 +335,8 @@ std::unique_ptr<IndexedSubGraph> TensorrtExecutionProvider::GetSubGraph(SubGraph
 
   // Assign inputs and outputs to subgraph's meta_def
   auto meta_def = onnxruntime::make_unique<::onnxruntime::IndexedSubGraph::MetaDef>();
-  meta_def->name = "TRTKernel_" + graph.Name() + "_" + std::to_string(kernels_index++);
+  const std::string graph_type = graph.IsSubgraph() ? "subgraph" : "graph";
+  meta_def->name = "TRTKernel_" + graph_type + "_" + graph.Name() + "_" + std::to_string(kernels_index++);
   meta_def->domain = kMSDomain;
 
   for (const auto& input : inputs) {


### PR DESCRIPTION
- Update onnx-tensorrt parser to include several critical bug fixes
  Now Tiny yolov3 and some other customer's models can run on TensorRT EP
- Change TensorRT kernel naming to solve conflicts when main graph has the same name with subgraphs of its control flow ops.
