### PR TITLE
fix python package linux gpu failure

### DIFF
--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2010
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2010
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2010_x86_64:latest
+FROM quay.io/pypa/manylinux2010_x86_64:2020-04-04-f427f46
 
 ARG PYTHON_VERSION=3.5
 

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2010_gpu
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2010_gpu
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2010_x86_64:latest
+FROM quay.io/pypa/manylinux2010_x86_64:2020-04-04-f427f46
 
 ARG PYTHON_VERSION=3.5
 


### PR DESCRIPTION
work around pip 20.1 conflict with typing module by
using older pip version - pinning base image version used by Dockerfile.manylinux2010
