### PR TITLE
fix Openvino GPU nightly build

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-openvino-nightly-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-openvino-nightly-pipeline.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: Linux_OpenVINO_CI_Dev
-  timeoutInMinutes: 240
+  timeoutInMinutes: 360
   pool: OpenVINO
   steps:
     - task: CmdLine@2

--- a/tools/ci_build/github/azure-pipelines/linux-openvino-nightly-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-openvino-nightly-pipeline.yml
@@ -12,14 +12,6 @@ jobs:
         workingDirectory: $(Build.BinariesDirectory)
       continueOnError: true
       condition: always()
-
-    - task: PythonScript@0
-      displayName: 'Unzip test data'
-      inputs:
-        scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/github/download_test_data.py'
-        arguments: --build_dir $(Build.BinariesDirectory) --edge_device
-        pythonInterpreter: '/usr/bin/python3'
-        workingDirectory: $(Build.BinariesDirectory)
         
     - script: 'tools/ci_build/github/linux/run_dockerbuild.sh -o ubuntu16.04 -d openvino -v 2020.2 -r $(Build.BinariesDirectory) -x "--use_openvino GPU_FP32 --build_wheel"'
       displayName: 'Command Line Script'


### PR DESCRIPTION
1. The models folder changed to /data/models
2. Increase the timeout since it take much longer to build openvino and more models are supported
3. Potential issue is it may run out of memory for model testing from CI. I tried on the device directly, it can pass. Need to upgrade to a powerful device in future.
