### PR TITLE
Additional search paths for Featurizer data files when invoked from python

### DIFF
--- a/onnxruntime/featurizers_ops/cpu/date_time_transformer.cc
+++ b/onnxruntime/featurizers_ops/cpu/date_time_transformer.cc
@@ -84,6 +84,9 @@ std::string GetDateTimeTransformerDataDir(void) {
             // Search relative to the executable
             dirname + "lib",
 
+            // The python executable might be in a 'bin' dir that is a sibling with 'lib'
+            dirname + "../lib",
+
             // Search in the user's local path
             [](void) -> std::string {
               char const * const var(std::getenv("HOME"));
@@ -92,7 +95,9 @@ std::string GetDateTimeTransformerDataDir(void) {
                 return var;
 
               return "";
-            }() + "/.local/lib"
+            }() + "/.local/lib",
+
+            "/usr/local/lib"
       };
 
       for(auto const &potentialDir : potentialDirs) {


### PR DESCRIPTION
**Description**: 
Data files must be read by the featurizer library DateTimeSplitter kernel, but the python site-packages directory is different on different systems. These updates address locations when the code is tested via Nimbus and on MacOS.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
