### PR TITLE
DML packaging pipelines are broken referring to DirectML.0.0.1

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -150,7 +150,7 @@ def generate_files(list, args):
     if includes_directml:
         files_list.append('<file src=' + '"' + os.path.join(args.native_build_path, 'DirectML.dll') + '" target="runtimes\\win-' + args.target_architecture + '\\native" />')
         files_list.append('<file src=' + '"' + os.path.join(args.native_build_path, 'DirectML.pdb') + '" target="runtimes\\win-' + args.target_architecture + '\\native" />')
-        files_list.append('<file src=' + '"' + os.path.join(args.packages_path, 'DirectML.0.0.1\\LICENSE.txt') + '" target="DirectML_LICENSE.txt" />')
+        files_list.append('<file src=' + '"' + os.path.join(args.packages_path, 'DirectML.0.0.2\\LICENSE.txt') + '" target="DirectML_LICENSE.txt" />')
 
     if includes_winml:
         # Process microsoft.ai.machinelearning import lib, dll, and pdb


### PR DESCRIPTION
Issue: The new DML merged into master did not update reference to DirectML.0.0.1 in tools\nuget\generate_nuspec_for_native_nuget.py causing packaging to try to reference the DML Licence.txt file from the wrong location.

Fix: Update S:\work\onnxruntime5\tools\nuget\generate_nuspec_for_native_nuget.py to reference the correct version of DML: DirectML.0.0.2.