### PR TITLE
Update centos-ci-pipeline.yml

### DIFF
--- a/tools/ci_build/github/azure-pipelines/centos-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/centos-ci-pipeline.yml
@@ -1,5 +1,7 @@
 jobs:
 - job: linux_centos_ci
+  workspace:
+    clean: all
   timeoutInMinutes:  60
   pool: 'Linux-CPU'
   strategy:
@@ -20,3 +22,4 @@ jobs:
         script: |
           docker run --rm --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build -e NIGHTLY_BUILD onnxruntime-centos7 /usr/bin/python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config $(BuildType) --skip_submodule_sync  --parallel --build_shared_lib --use_openmp --cmake_path /usr/bin/cmake --ctest_path /usr/bin/ctest --build_wheel
         workingDirectory: $(Build.SourcesDirectory)
+    - template: ../../templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/centos-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/centos-ci-pipeline.yml
@@ -22,4 +22,5 @@ jobs:
         script: |
           docker run --rm --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build -e NIGHTLY_BUILD onnxruntime-centos7 /usr/bin/python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config $(BuildType) --skip_submodule_sync  --parallel --build_shared_lib --use_openmp --cmake_path /usr/bin/cmake --ctest_path /usr/bin/ctest --build_wheel
         workingDirectory: $(Build.SourcesDirectory)
-    - template: ../../templates/clean-agent-build-directory-step.yml
+
+    - template: templates/clean-agent-build-directory-step.yml


### PR DESCRIPTION
**Description**: 

When it was moved from a hosted pool to our private pool(in training branch), it need this flag.

**Motivation and Context**
- Why is this change required? What problem does it solve?
We should delete the folders before starting a new build
- If it fixes an open issue, please link to the issue here.
