### PR TITLE
Fix build error when DEBUG_NODE_INPUTS_OUTPUTS is on

### DIFF
--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -14,6 +14,10 @@
 #include "core/framework/session_state.h"
 #include "core/framework/op_kernel_context_internal.h"
 
+#if defined DEBUG_NODE_INPUTS_OUTPUTS
+#include "core/framework/utils.h"
+#endif
+
 // #define TRACE_EXECUTION
 
 // Define this symbol to create Concurrency Visualizer markers.


### PR DESCRIPTION
**Description**: 
Fix build error when DEBUG_NODE_INPUTS_OUTPUTS is on

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.