### PR TITLE
[Java] Adding missing methods on Session, SessionOptions and RunOptions (v2)

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -794,14 +794,12 @@ set_property(TARGET custom_op_library APPEND_STRING PROPERTY LINK_FLAGS ${ONNXRU
 
 if (onnxruntime_BUILD_JAVA)
     message(STATUS "Running Java tests")
-    # If we're on windows, symlink the custom op test library somewhere we can see it
-    if (WIN32)
-	set(JAVA_NATIVE_TEST_DIR ${JAVA_OUTPUT_DIR}/native-test)
-	file(MAKE_DIRECTORY ${JAVA_NATIVE_TEST_DIR})
-	add_custom_command(TARGET custom_op_library POST_BUILD COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:custom_op_library> ${JAVA_NATIVE_TEST_DIR}/$<TARGET_FILE_NAME:custom_op_library>)
-    endif()
     # delegate to gradle's test runner
     if(WIN32)
+      # If we're on windows, symlink the custom op test library somewhere we can see it
+      set(JAVA_NATIVE_TEST_DIR ${JAVA_OUTPUT_DIR}/native-test)
+      file(MAKE_DIRECTORY ${JAVA_NATIVE_TEST_DIR})
+      add_custom_command(TARGET custom_op_library POST_BUILD COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:custom_op_library> ${JAVA_NATIVE_TEST_DIR}/$<TARGET_FILE_NAME:custom_op_library>)
       # On windows ctest requires a test to be an .exe(.com) file
       # So there are two options 1) Install Chocolatey and its gradle package
       # That package would install gradle.exe shim to its bin so ctest could run gradle.exe
@@ -813,8 +811,8 @@ if (onnxruntime_BUILD_JAVA)
         -DREPO_ROOT=${REPO_ROOT}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/onnxruntime_java_unittests.cmake)
     else()
-        add_test(NAME onnxruntime4j_test COMMAND ${GRADLE_EXECUTABLE} cmakeCheck -DcmakeBuildDir=${CMAKE_CURRENT_BINARY_DIR}
-                 WORKING_DIRECTORY ${REPO_ROOT}/java)
+      add_test(NAME onnxruntime4j_test COMMAND ${GRADLE_EXECUTABLE} cmakeCheck -DcmakeBuildDir=${CMAKE_CURRENT_BINARY_DIR}
+               WORKING_DIRECTORY ${REPO_ROOT}/java)
     endif()
     set_property(TEST onnxruntime4j_test APPEND PROPERTY DEPENDS onnxruntime4j_jni)
 endif()

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -794,6 +794,12 @@ set_property(TARGET custom_op_library APPEND_STRING PROPERTY LINK_FLAGS ${ONNXRU
 
 if (onnxruntime_BUILD_JAVA)
     message(STATUS "Running Java tests")
+    # If we're on windows, symlink the custom op test library somewhere we can see it
+    if (WIN32)
+	set(JAVA_NATIVE_TEST_DIR ${JAVA_OUTPUT_DIR}/native-test)
+	file(MAKE_DIRECTORY ${JAVA_NATIVE_TEST_DIR})
+	add_custom_command(TARGET custom_op_library POST_BUILD COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:custom_op_library> ${JAVA_NATIVE_TEST_DIR}/$<TARGET_FILE_NAME:custom_op_library>)
+    endif()
     # delegate to gradle's test runner
     if(WIN32)
       # On windows ctest requires a test to be an .exe(.com) file

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -67,6 +67,7 @@ def cmakeBuildDir = System.properties['cmakeBuildDir']
 def cmakeJavaDir = "${cmakeBuildDir}/java"
 def cmakeNativeLibDir = "${cmakeJavaDir}/native-lib"
 def cmakeNativeJniDir = "${cmakeJavaDir}/native-jni"
+def cmakeNativeTestDir = "${cmakeJavaDir}/native-test"
 def cmakeBuildOutputDir = "${cmakeJavaDir}/build"
 
 compileJava {
@@ -84,7 +85,8 @@ sourceSets.test {
 		// add compiled native libs
 		resources.srcDirs += [
 			cmakeNativeLibDir,
-			cmakeNativeJniDir
+			cmakeNativeJniDir,
+			cmakeNativeTestDir
 		]
 	}
 }

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -144,6 +144,7 @@ dependencies {
 
 test {
 	useJUnitPlatform()
+	workingDir cmakeBuildDir
 	testLogging {
 		events "passed", "skipped", "failed"
 		showStandardStreams = true

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -144,7 +144,9 @@ dependencies {
 
 test {
 	useJUnitPlatform()
-	workingDir cmakeBuildDir
+	if (cmakeBuildDir != null) {
+		workingDir cmakeBuildDir
+	}
 	testLogging {
 		events "passed", "skipped", "failed"
 		showStandardStreams = true

--- a/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
@@ -78,7 +78,12 @@ final class OnnxRuntime {
     }
   }
 
-  private static boolean isAndroid() {
+  /**
+   * Check if we're running on Android.
+   *
+   * @return True if the {@code android.app.Activity} class can be loaded, false otherwise.
+   */
+  static boolean isAndroid() {
     try {
       Class.forName("android.app.Activity");
       return true;

--- a/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
+++ b/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -14,24 +14,6 @@ import java.util.logging.Logger;
  * specific models.
  */
 public class OrtEnvironment implements AutoCloseable {
-
-  /** The logging level for messages from the environment and session. */
-  public enum LoggingLevel {
-    ORT_LOGGING_LEVEL_VERBOSE(0),
-    ORT_LOGGING_LEVEL_INFO(1),
-    ORT_LOGGING_LEVEL_WARNING(2),
-    ORT_LOGGING_LEVEL_ERROR(3),
-    ORT_LOGGING_LEVEL_FATAL(4);
-    private final int value;
-
-    LoggingLevel(int value) {
-      this.value = value;
-    }
-
-    public int getValue() {
-      return value;
-    }
-  }
 
   private static final Logger logger = Logger.getLogger(OrtEnvironment.class.getName());
 
@@ -49,29 +31,29 @@ public class OrtEnvironment implements AutoCloseable {
 
   private static final AtomicInteger refCount = new AtomicInteger();
 
-  private static volatile LoggingLevel curLogLevel;
+  private static volatile OrtLoggingLevel curLogLevel;
 
   private static volatile String curLoggingName;
 
   /**
    * Gets the OrtEnvironment. If there is not an environment currently created, it creates one using
-   * {@link OrtEnvironment#DEFAULT_NAME} and {@link LoggingLevel#ORT_LOGGING_LEVEL_WARNING}.
+   * {@link OrtEnvironment#DEFAULT_NAME} and {@link OrtLoggingLevel#ORT_LOGGING_LEVEL_WARNING}.
    *
    * @return An onnxruntime environment.
    */
   public static OrtEnvironment getEnvironment() {
-    return getEnvironment(LoggingLevel.ORT_LOGGING_LEVEL_WARNING, DEFAULT_NAME);
+    return getEnvironment(OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING, DEFAULT_NAME);
   }
 
   /**
    * Gets the OrtEnvironment. If there is not an environment currently created, it creates one using
-   * the supplied name and {@link LoggingLevel#ORT_LOGGING_LEVEL_WARNING}.
+   * the supplied name and {@link OrtLoggingLevel#ORT_LOGGING_LEVEL_WARNING}.
    *
    * @param name The logging id of the environment.
    * @return An onnxruntime environment.
    */
   public static OrtEnvironment getEnvironment(String name) {
-    return getEnvironment(LoggingLevel.ORT_LOGGING_LEVEL_WARNING, name);
+    return getEnvironment(OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING, name);
   }
 
   /**
@@ -81,7 +63,7 @@ public class OrtEnvironment implements AutoCloseable {
    * @param logLevel The logging level to use.
    * @return An onnxruntime environment.
    */
-  public static OrtEnvironment getEnvironment(LoggingLevel logLevel) {
+  public static OrtEnvironment getEnvironment(OrtLoggingLevel logLevel) {
     return getEnvironment(logLevel, DEFAULT_NAME);
   }
 
@@ -94,7 +76,8 @@ public class OrtEnvironment implements AutoCloseable {
    * @param name The log id.
    * @return The OrtEnvironment singleton.
    */
-  public static synchronized OrtEnvironment getEnvironment(LoggingLevel loggingLevel, String name) {
+  public static synchronized OrtEnvironment getEnvironment(
+      OrtLoggingLevel loggingLevel, String name) {
     if (INSTANCE == null) {
       try {
         INSTANCE = new OrtEnvironment(loggingLevel, name);
@@ -104,7 +87,7 @@ public class OrtEnvironment implements AutoCloseable {
         throw new IllegalStateException("Failed to create OrtEnvironment", e);
       }
     } else {
-      if ((loggingLevel.value != curLogLevel.value) || (!name.equals(curLoggingName))) {
+      if ((loggingLevel.getValue() != curLogLevel.getValue()) || (!name.equals(curLoggingName))) {
         logger.warning(
             "Tried to change OrtEnvironment's logging level or name while a reference exists.");
       }
@@ -125,7 +108,7 @@ public class OrtEnvironment implements AutoCloseable {
    * @throws OrtException If the environment couldn't be created.
    */
   private OrtEnvironment() throws OrtException {
-    this(LoggingLevel.ORT_LOGGING_LEVEL_WARNING, "java-default");
+    this(OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING, "java-default");
   }
 
   /**
@@ -135,7 +118,7 @@ public class OrtEnvironment implements AutoCloseable {
    * @param name The logging id of the environment.
    * @throws OrtException If the environment couldn't be created.
    */
-  private OrtEnvironment(LoggingLevel loggingLevel, String name) throws OrtException {
+  private OrtEnvironment(OrtLoggingLevel loggingLevel, String name) throws OrtException {
     nativeHandle = createHandle(OnnxRuntime.ortApiHandle, loggingLevel.getValue(), name);
     defaultAllocator = new OrtAllocator(getDefaultAllocator(OnnxRuntime.ortApiHandle), true);
   }

--- a/java/src/main/java/ai/onnxruntime/OrtLoggingLevel.java
+++ b/java/src/main/java/ai/onnxruntime/OrtLoggingLevel.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the MIT License.
+ */
+package ai.onnxruntime;
+
+import java.util.logging.Logger;
+
+/** The logging level for messages from the environment and session. */
+public enum OrtLoggingLevel {
+  ORT_LOGGING_LEVEL_VERBOSE(0),
+  ORT_LOGGING_LEVEL_INFO(1),
+  ORT_LOGGING_LEVEL_WARNING(2),
+  ORT_LOGGING_LEVEL_ERROR(3),
+  ORT_LOGGING_LEVEL_FATAL(4);
+  private final int value;
+
+  private static final Logger logger = Logger.getLogger(OrtLoggingLevel.class.getName());
+  private static final OrtLoggingLevel[] values = new OrtLoggingLevel[5];
+
+  static {
+    for (OrtLoggingLevel ot : OrtLoggingLevel.values()) {
+      values[ot.value] = ot;
+    }
+  }
+
+  OrtLoggingLevel(int value) {
+    this.value = value;
+  }
+
+  /**
+   * Gets the native value associated with this logging level.
+   *
+   * @return The native value.
+   */
+  public int getValue() {
+    return value;
+  }
+
+  /**
+   * Maps from the C API's int enum to the Java enum.
+   *
+   * @param logLevel The index of the Java enum.
+   * @return The Java enum.
+   */
+  public static OrtLoggingLevel mapFromInt(int logLevel) {
+    if ((logLevel > 0) && (logLevel < values.length)) {
+      return values[logLevel];
+    } else {
+      logger.warning("Unknown logging level " + logLevel + " setting to ORT_LOGGING_LEVEL_VERBOSE");
+      return ORT_LOGGING_LEVEL_VERBOSE;
+    }
+  }
+}

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -306,6 +306,7 @@ public class OrtSession implements AutoCloseable {
    *
    * @throws OrtException on failure
    * @return The metadata.
+   * @throws OrtException If the native call failed.
    */
   public OnnxModelMetadata getMetadata() throws OrtException {
     if (metadata == null) {
@@ -653,6 +654,17 @@ public class OrtSession implements AutoCloseable {
     }
 
     /**
+     * Sets the Session's logging verbosity level.
+     *
+     * @param logLevel The logging verbosity to use.
+     * @throws OrtException If there was an error in native code.
+     */
+    public void setSessionLogVerbosityLevel(int logLevel) throws OrtException {
+      checkClosed();
+      setSessionLogVerbosityLevel(OnnxRuntime.ortApiHandle, nativeHandle, logLevel);
+    }
+
+    /**
      * Registers a library of custom ops for use with {@link OrtSession}s using this SessionOptions.
      *
      * @param path The path to the library on disk.
@@ -823,6 +835,9 @@ public class OrtSession implements AutoCloseable {
     private native void setSessionLogLevel(long apiHandle, long nativeHandle, int logLevel)
         throws OrtException;
 
+    private native void setSessionLogVerbosityLevel(long apiHandle, long nativeHandle, int logLevel)
+        throws OrtException;
+
     private native long registerCustomOpLibrary(long apiHandle, long nativeHandle, String path)
         throws OrtException;
 
@@ -910,6 +925,28 @@ public class OrtSession implements AutoCloseable {
     }
 
     /**
+     * Sets the current logging verbosity level on this RunOptions.
+     *
+     * @param level The new logging verbosity level.
+     * @throws OrtException If the native call failed.
+     */
+    public void setLogVerbosityLevel(int level) throws OrtException {
+      checkClosed();
+      setLogVerbosityLevel(OnnxRuntime.ortApiHandle, nativeHandle, level);
+    }
+
+    /**
+     * Gets the current logging verbosity level set on this RunOptions.
+     *
+     * @return The logging verbosity level.
+     * @throws OrtException If the native call failed.
+     */
+    public int getLogVerbosityLevel() throws OrtException {
+      checkClosed();
+      return getLogVerbosityLevel(OnnxRuntime.ortApiHandle, nativeHandle);
+    }
+
+    /**
      * Sets the run tag used in logging.
      *
      * @param runTag The run tag in logging output.
@@ -967,6 +1004,11 @@ public class OrtSession implements AutoCloseable {
         throws OrtException;
 
     private native int getLogLevel(long apiHandle, long nativeHandle) throws OrtException;
+
+    private native void setLogVerbosityLevel(long apiHandle, long nativeHandle, int logLevel)
+        throws OrtException;
+
+    private native int getLogVerbosityLevel(long apiHandle, long nativeHandle) throws OrtException;
 
     private native void setRunTag(long apiHandle, long nativeHandle, String runTag)
         throws OrtException;

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -304,7 +304,6 @@ public class OrtSession implements AutoCloseable {
   /**
    * Gets the metadata for the currently loaded model.
    *
-   * @throws OrtException on failure
    * @return The metadata.
    * @throws OrtException If the native call failed.
    */

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 #include <jni.h>
@@ -16,7 +16,7 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved) {
 }
 
 /**
- * Must be kept in sync with ORT_LOGGING_LEVEL and OrtEnvironment#LoggingLevel
+ * Must be kept in sync with ORT_LOGGING_LEVEL and the OrtLoggingLevel java enum
  */
 OrtLoggingLevel convertLoggingLevel(jint level) {
     switch (level) {

--- a/java/src/main/native/ai_onnxruntime_OrtSession.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession.c
@@ -342,23 +342,6 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_closeSession
 
 /*
  * Class:     ai_onnxruntime_OrtSession
- * Method:    releaseNamesHandle
- * Signature: (JJJ)V
- */
-JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_releaseNamesHandle
-  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong allocatorHandle, jlong namesHandle, jlong length) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
-    const OrtApi* api = (const OrtApi*) apiHandle;
-    OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
-    char** names = (char**) namesHandle;
-    for (uint32_t i = 0; i < length; i++) {
-        checkOrtStatus(jniEnv,api,api->AllocatorFree(allocator,names[i]));
-    }
-    checkOrtStatus(jniEnv,api,api->AllocatorFree(allocator,names));
-}
-
-/*
- * Class:     ai_onnxruntime_OrtSession
  * Method:    constructMetadata
  * Signature: (JJJ)Ljava/lang/String;
  */

--- a/java/src/main/native/ai_onnxruntime_OrtSession_RunOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_RunOptions.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include <jni.h>
+#include <string.h>
+#include "onnxruntime/core/session/onnxruntime_c_api.h"
+#include "OrtJniUtil.h"
+#include "ai_onnxruntime_OrtSession_RunOptions.h"
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_RunOptions
+ * Method:    createRunOptions
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtSession_00024RunOptions_createRunOptions
+  (JNIEnv * jniEnv, jclass jclazz, jlong apiHandle) {
+    (void) jclazz; // Required JNI parameter not needed by functions which don't need to access their host object.
+    const OrtApi* api = (const OrtApi*) apiHandle;
+    OrtRunOptions* opts;
+    checkOrtStatus(jniEnv,api,api->CreateRunOptions(&opts));
+    return (jlong) opts;
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_RunOptions
+ * Method:    setLogLevel
+ * Signature: (JJI)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024RunOptions_setLogLevel
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong nativeHandle, jint logLevel) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  checkOrtStatus(jniEnv,api,api->RunOptionsSetRunLogSeverityLevel((OrtRunOptions*) nativeHandle,logLevel));
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_RunOptions
+ * Method:    getLogLevel
+ * Signature: (JJ)I
+ */
+JNIEXPORT jint JNICALL Java_ai_onnxruntime_OrtSession_00024RunOptions_getLogLevel
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong nativeHandle) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  jint logLevel;
+  checkOrtStatus(jniEnv,api,api->RunOptionsGetRunLogSeverityLevel((OrtRunOptions*) nativeHandle,&logLevel));
+  return logLevel;
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_RunOptions
+ * Method:    setRunTag
+ * Signature: (JJLjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024RunOptions_setRunTag
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong nativeHandle, jstring runTag) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  const char* runTagStr = (*jniEnv)->GetStringUTFChars(jniEnv, runTag, NULL);
+  checkOrtStatus(jniEnv,api,api->RunOptionsSetRunTag((OrtRunOptions*) nativeHandle, runTagStr));
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv,runTag,runTagStr);
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_RunOptions
+ * Method:    getRunTag
+ * Signature: (JJ)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_ai_onnxruntime_OrtSession_00024RunOptions_getRunTag
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong nativeHandle) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  const char* runTagStr;
+  // This is a reference to the C str, and should not be freed.
+  checkOrtStatus(jniEnv,api,api->RunOptionsGetRunTag((OrtRunOptions*)nativeHandle,&runTagStr));
+  jstring runTag = (*jniEnv)->NewStringUTF(jniEnv,runTagStr);
+  return runTag;
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_RunOptions
+ * Method:    setTerminate
+ * Signature: (JJZ)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024RunOptions_setTerminate
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong nativeHandle, jboolean terminate) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  OrtRunOptions* runOptions = (OrtRunOptions*) nativeHandle;
+  if (terminate) {
+    checkOrtStatus(jniEnv,api,api->RunOptionsSetTerminate(runOptions));
+  } else {
+    checkOrtStatus(jniEnv,api,api->RunOptionsUnsetTerminate(runOptions));
+  }
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_RunOptions
+ * Method:    close
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024RunOptions_close
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle) {
+  (void) jniEnv; (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  api->ReleaseRunOptions((OrtRunOptions*) handle);
+}

--- a/java/src/main/native/ai_onnxruntime_OrtSession_RunOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_RunOptions.c
@@ -50,6 +50,32 @@ JNIEXPORT jint JNICALL Java_ai_onnxruntime_OrtSession_00024RunOptions_getLogLeve
 
 /*
  * Class:     ai_onnxruntime_OrtSession_RunOptions
+ * Method:    setLogVerbosityLevel
+ * Signature: (JJI)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024RunOptions_setLogVerbosityLevel
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong nativeHandle, jint logLevel) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  checkOrtStatus(jniEnv,api,api->RunOptionsSetRunLogVerbosityLevel((OrtRunOptions*) nativeHandle,logLevel));
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_RunOptions
+ * Method:    getLogVerbosityLevel
+ * Signature: (JJ)I
+ */
+JNIEXPORT jint JNICALL Java_ai_onnxruntime_OrtSession_00024RunOptions_getLogVerbosityLevel
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong nativeHandle) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  jint logLevel;
+  checkOrtStatus(jniEnv,api,api->RunOptionsGetRunLogVerbosityLevel((OrtRunOptions*) nativeHandle,&logLevel));
+  return logLevel;
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_RunOptions
  * Method:    setRunTag
  * Signature: (JJLjava/lang/String;)V
  */

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -112,7 +112,9 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_creat
     OrtSessionOptions* opts;
     checkOrtStatus(jniEnv,api,api->CreateSessionOptions(&opts));
     checkOrtStatus(jniEnv,api,api->SetInterOpNumThreads(opts, 1));
-    checkOrtStatus(jniEnv,api,api->SetIntraOpNumThreads(opts, 1));
+    // Commented out due to constant OpenMP warning as this API is invalid when running with OpenMP.
+    // Not sure how to detect that from within the C API though.
+    //checkOrtStatus(jniEnv,api,api->SetIntraOpNumThreads(opts, 1));
     return (jlong) opts;
 }
 
@@ -226,6 +228,19 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_setSes
   const OrtApi* api = (const OrtApi*)apiHandle;
   OrtSessionOptions* options = (OrtSessionOptions*) optionsHandle;
   checkOrtStatus(jniEnv,api,api->SetSessionLogSeverityLevel(options,logLevel));
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    setSessionLogVerbosityLevel
+ * Signature: (JJI)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_setSessionLogVerbosityLevel
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong optionsHandle, jint logLevel) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  OrtSessionOptions* options = (OrtSessionOptions*) optionsHandle;
+  checkOrtStatus(jniEnv,api,api->SetSessionLogVerbosityLevel(options,logLevel));
 }
 
 /*

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 #include <jni.h>
@@ -122,10 +122,110 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_creat
  * Signature: (JJ)V
  */
 JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_closeOptions
-  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle) {
-    (void) jniEnv; (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
-    const OrtApi* api = (const OrtApi*) apiHandle;
-    api->ReleaseSessionOptions((OrtSessionOptions*) handle);
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle) {
+  (void)jniEnv; (void)jobj;  // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  api->ReleaseSessionOptions((OrtSessionOptions*)handle);
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    setLoggerId
+ * Signature: (JJLjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_setLoggerId
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong optionsHandle, jstring loggerId) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  OrtSessionOptions* options = (OrtSessionOptions*) optionsHandle;
+  const char* loggerIdStr = (*jniEnv)->GetStringUTFChars(jniEnv, loggerId, NULL);
+  checkOrtStatus(jniEnv,api,api->SetSessionLogId(options, loggerIdStr));
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv,loggerId,loggerIdStr);
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    enableProfiling
+ * Signature: (JJLjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_enableProfiling
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong optionsHandle, jstring pathString) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  OrtSessionOptions* options = (OrtSessionOptions*) optionsHandle;
+#ifdef _WIN32
+  const jchar* path = (*jniEnv)->GetStringChars(jniEnv, pathString, NULL);
+  size_t stringLength = (*jniEnv)->GetStringLength(jniEnv, pathString);
+  wchar_t* newString = (wchar_t*)calloc(stringLength+1,sizeof(jchar));
+  wcsncpy_s(newString, stringLength+1, (const wchar_t*) path, stringLength);
+  checkOrtStatus(jniEnv,(const OrtApi*)apiHandle,api->EnableProfiling(options, (const wchar_t*) newString));
+  free(newString);
+  (*jniEnv)->ReleaseStringChars(jniEnv,pathString,path);
+#else
+  const char* path = (*jniEnv)->GetStringUTFChars(jniEnv, pathString, NULL);
+  checkOrtStatus(jniEnv,(const OrtApi*)apiHandle,api->EnableProfiling(options, path));
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv,pathString,path);
+#endif
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    disableProfiling
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_disableProfiling
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong optionsHandle) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  OrtSessionOptions* options = (OrtSessionOptions*) optionsHandle;
+  checkOrtStatus(jniEnv,api,api->DisableProfiling(options));
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    setMemoryPatternOptimization
+ * Signature: (JJZ)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_setMemoryPatternOptimization
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong optionsHandle, jboolean memPattern) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  OrtSessionOptions* options = (OrtSessionOptions*) optionsHandle;
+  if (memPattern) {
+    checkOrtStatus(jniEnv,api,api->EnableMemPattern(options));
+  } else {
+    checkOrtStatus(jniEnv,api,api->DisableMemPattern(options));
+  }
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    setCPUArenaAllocator
+ * Signature: (JJZ)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_setCPUArenaAllocator
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong optionsHandle, jboolean useArena) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  OrtSessionOptions* options = (OrtSessionOptions*) optionsHandle;
+  if (useArena) {
+    checkOrtStatus(jniEnv,api,api->EnableCpuMemArena(options));
+  } else {
+    checkOrtStatus(jniEnv,api,api->DisableCpuMemArena(options));
+  }
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    setSessionLogLevel
+ * Signature: (JJI)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_setSessionLogLevel
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong optionsHandle, jint logLevel) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  OrtSessionOptions* options = (OrtSessionOptions*) optionsHandle;
+  checkOrtStatus(jniEnv,api,api->SetSessionLogSeverityLevel(options,logLevel));
 }
 
 /*

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -792,6 +792,8 @@ public class InferenceTest {
       assertEquals("monkeys", runOptions.getRunTag());
       runOptions.setLogLevel(OrtLoggingLevel.ORT_LOGGING_LEVEL_FATAL);
       assertEquals(OrtLoggingLevel.ORT_LOGGING_LEVEL_FATAL, runOptions.getLogLevel());
+      runOptions.setLogVerbosityLevel(9000);
+      assertEquals(9000, runOptions.getLogVerbosityLevel());
       runOptions.setTerminate(true);
       String inputName = session.getInputNames().iterator().next();
       Map<String, OnnxTensor> container = new HashMap<>();
@@ -823,6 +825,7 @@ public class InferenceTest {
         options.enableProfiling(tmpPath.getAbsolutePath());
         options.setLoggerId("monkeys");
         options.setSessionLogLevel(OrtLoggingLevel.ORT_LOGGING_LEVEL_FATAL);
+        options.setSessionLogVerbosityLevel(5);
         try (OrtSession session = env.createSession(modelPath, options)) {
           String inputName = session.getInputNames().iterator().next();
           Map<String, OnnxTensor> container = new HashMap<>();
@@ -849,6 +852,7 @@ public class InferenceTest {
         options.setMemoryPatternOptimization(false);
         options.enableProfiling(tmpPath.getAbsolutePath());
         options.disableProfiling();
+        options.setSessionLogVerbosityLevel(0);
         try (OrtSession session = env.createSession(modelPath, options)) {
           String inputName = session.getInputNames().iterator().next();
           Map<String, OnnxTensor> container = new HashMap<>();

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -877,7 +877,9 @@ public class InferenceTest {
       String customLibraryName = "";
       String osName = System.getProperty("os.name").toLowerCase();
       if (osName.contains("windows")) {
-        customLibraryName = "custom_op_library.dll";
+        // In windows we start in the wrong working directory relative to the custom_op_library.dll
+        // So we look it up as a classpath resource and resolve it to a real path
+        customLibraryName = getResourcePath("/custom_op_library.dll").toString();
       } else if (osName.contains("mac")) {
         customLibraryName = "libcustom_op_library.dylib";
       } else if (osName.contains("linux")) {
@@ -885,7 +887,8 @@ public class InferenceTest {
       } else {
         fail("Unknown os/platform '" + osName + "'");
       }
-      String customOpLibraryTestModel = "testdata/custom_op_library/custom_op_test.onnx";
+      String customOpLibraryTestModel =
+          getResourcePath("/custom_op_library/custom_op_test.onnx").toString();
 
       try (OrtEnvironment env = OrtEnvironment.getEnvironment("testLoadCustomLibrary");
           SessionOptions options = new SessionOptions()) {


### PR DESCRIPTION
Description:
The Java API didn't support all the methods available on Session, SessionOptions and it didn't have RunOptions at all. This PR adds support for all the relevant methods. It's a refresh of PR #3577 due to some CI issues.