### PR TITLE
Add RelWithDebInfo target to the C# projects 

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -21,18 +21,6 @@ include(CheckLanguage)
 # So we cant' regulate simply with the standard.
 set(CMAKE_CXX_STANDARD 14)
 
-# General C# prperties
-if (onnxruntime_BUILD_CSHARP)
-  check_language(CSharp)
-  if (CMAKE_CSharp_COMPILER)
-    enable_language(CSharp)
-    set(CMAKE_CSharp_FLAGS ${CMAKE_CSharp_FLAGS} "/langversion:6")
-    message(STATUS "CMAKE_Csharp_Compiler = ${CMAKE_CSharp_COMPILER}")
-  else()
-    message(WARNING "Language Csharp is not found in the system")
-  endif()
-endif()
-
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # NOTE: POSITION INDEPENDENT CODE hurts performance, and it only make sense on POSIX systems
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -66,6 +54,7 @@ option(onnxruntime_DEV_MODE "Enable developer warnings and treat most of them as
 option(onnxruntime_USE_JEMALLOC "Use jemalloc" OFF)
 option(onnxruntime_MSVC_STATIC_RUNTIME "Compile for the static CRT" OFF)
 option(onnxruntime_BUILD_UNIT_TESTS "Build ONNXRuntime unit tests" ON)
+option(onnxruntime_BUILD_CSHARP "Build C# library" OFF)
 option(onnxruntime_USE_PREINSTALLED_EIGEN "Use pre-installed EIGEN. Need to provide eigen_SOURCE_PATH if turn this on." OFF)
 option(onnxruntime_BUILD_BENCHMARKS "Build ONNXRuntime micro-benchmarks" OFF)
 option(onnxruntime_USE_TVM "Build tvm for code-gen" OFF)
@@ -102,8 +91,6 @@ option(onnxruntime_USE_TELEMETRY "Build with Telemetry" OFF)
 #It's default OFF because it's experimental now.
 option(onnxruntime_PREFER_SYSTEM_LIB "Experimental: Build with the preinstalled libraries in your system" OFF)
 
-
-
 # training options
 option(onnxruntime_ENABLE_TRAINING "Enable training functionality." OFF)
 option(onnxruntime_ENABLE_TRAINING_E2E_TESTS "Enable training end-to-end tests." OFF)
@@ -115,6 +102,18 @@ set(NSYNC_ENABLE_TESTS OFF CACHE BOOL "Build protobuf tests" FORCE)
 set(ONNX_ML 1)
 if(NOT onnxruntime_ENABLE_PYTHON)
   set(onnxruntime_ENABLE_LANGUAGE_INTEROP_OPS OFF)
+endif()
+
+# General C# properties
+if (onnxruntime_BUILD_CSHARP)
+  check_language(CSharp)
+  if (CMAKE_CSharp_COMPILER)
+    enable_language(CSharp)
+    set(CMAKE_CSharp_FLAGS ${CMAKE_CSharp_FLAGS} "/langversion:6")
+    message(STATUS "CMAKE_Csharp_Compiler = ${CMAKE_CSharp_COMPILER}")
+  else()
+    message(WARNING "Language Csharp is not found in the system")
+  endif()
 endif()
 
 if(NOT WIN32)

--- a/csharp/sample/Microsoft.ML.OnnxRuntime.InferenceSample/Microsoft.ML.OnnxRuntime.InferenceSample.csproj
+++ b/csharp/sample/Microsoft.ML.OnnxRuntime.InferenceSample/Microsoft.ML.OnnxRuntime.InferenceSample.csproj
@@ -7,6 +7,7 @@
     <OnnxRuntimeCsharpRoot>..\..</OnnxRuntimeCsharpRoot>
     <OnnxRuntimeBuildDirectory Condition="'$(OnnxRuntimeBuildDirectory)'==''">$(OnnxRuntimeCsharpRoot)\..\build\Windows</OnnxRuntimeBuildDirectory>
     <NativeBuildOutputDir>$(OnnxRuntimeBuildDirectory)\$(Configuration)\$(Configuration)</NativeBuildOutputDir>
+    <Configurations>Debug;Release;RelWithDebInfo</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.csproj
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.csproj
@@ -42,6 +42,7 @@
     <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
     <!--EmbedUntrackedSources>true</EmbedUntrackedSources-->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <Configurations>Debug;Release;RelWithDebInfo</Configurations>
   </PropertyGroup>
 
   <!--TODO: this works for single platform only. Need separate packaging scripts for multi-target packaging -->
@@ -163,18 +164,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <LicenseFile Include="$(OnnxRuntimeCsharpRoot)\..\LICENSE"/>
-    <TargetsFile Include="$(OnnxRuntimeCsharpRoot)\src\Microsoft.ML.OnnxRuntime\targets.xml"/>
+    <LicenseFile Include="$(OnnxRuntimeCsharpRoot)\..\LICENSE" />
+    <TargetsFile Include="$(OnnxRuntimeCsharpRoot)\src\Microsoft.ML.OnnxRuntime\targets.xml" />
   </ItemGroup>
 
   <Target Name="CopyMiscFiles" BeforeTargets="Pack">
-    <Copy SourceFiles="@(LicenseFile)" DestinationFiles="@(LicenseFile->'$(OnnxRuntimeCsharpRoot)\..\%(Filename).txt')"/>
-    <Copy SourceFiles="@(TargetsFile)" DestinationFiles="@(TargetsFile->'$(OnnxRuntimeCsharpRoot)\src\\Microsoft.ML.OnnxRuntime\$(PackageId).targets')"/>
+    <Copy SourceFiles="@(LicenseFile)" DestinationFiles="@(LicenseFile->'$(OnnxRuntimeCsharpRoot)\..\%(Filename).txt')" />
+    <Copy SourceFiles="@(TargetsFile)" DestinationFiles="@(TargetsFile->'$(OnnxRuntimeCsharpRoot)\src\\Microsoft.ML.OnnxRuntime\$(PackageId).targets')" />
 
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/Microsoft.ML.OnnxRuntime.Tests.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/Microsoft.ML.OnnxRuntime.Tests.csproj
@@ -17,6 +17,7 @@
     <SignAssembly>true</SignAssembly> <!-- need signing for friend access to the internals of the Tensors assembly -->
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\OnnxRuntime.snk</AssemblyOriginatorKeyFile>
+    <Configurations>Debug;Release;RelWithDebInfo</Configurations>
     <!-- end -->
   </PropertyGroup>
 
@@ -45,8 +46,8 @@
   </ItemGroup> 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Targets" Version="2.1.0"/>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2"/>
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="2.1.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <PackageReference Include="Google.Protobuf" Version="3.11.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/OnnxMl.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/OnnxMl.cs
@@ -160,7 +160,7 @@ namespace Onnx {
     /// The version field is always serialized and we will use it to store the
     /// version that the  graph is generated from. This helps us set up version
     /// control. 
-    /// For the IR, we are using simple numbers starting with 0x00000001, 
+    /// For the IR, we are using simple numbers starting with 0x00000001,
     /// which was the version we published on Oct 10, 2017.
     /// </summary>
     [pbr::OriginalName("IR_VERSION_2017_10_10")] IrVersion20171010 = 1,
@@ -332,7 +332,7 @@ namespace Onnx {
     /// implementations needed to use has_field heuristics to determine
     /// which value field was in use.  For IR_VERSION 0.0.2 or later, this
     /// field MUST be set and match the f|i|s|t|... field in use.  This
-    /// change was made to accomodate proto3 implementations.
+    /// change was made to accommodate proto3 implementations.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Onnx.AttributeProto.Types.AttributeType Type {
@@ -2858,7 +2858,7 @@ namespace Onnx {
     /// For float and complex64 values
     /// Complex64 tensors are encoded as a single array of floats,
     /// with the real components appearing in odd numbered positions,
-    /// and the corresponding imaginary component apparing in the
+    /// and the corresponding imaginary component appearing in the
     /// subsequent even numbered position. (e.g., [1.0 + 2.0i, 3.0 + 4.0i]
     /// is encoded as [1.0, 2.0 ,3.0 ,4.0]
     /// When this field is present, the data_type field MUST be FLOAT or COMPLEX64.
@@ -3016,7 +3016,7 @@ namespace Onnx {
     /// For double
     /// Complex128 tensors are encoded as a single array of doubles,
     /// with the real components appearing in odd numbered positions,
-    /// and the corresponding imaginary component apparing in the
+    /// and the corresponding imaginary component appearing in the
     /// subsequent even numbered position. (e.g., [1.0 + 2.0i, 3.0 + 4.0i]
     /// is encoded as [1.0, 2.0 ,3.0 ,4.0]
     /// When this field is present, the data_type field MUST be DOUBLE or COMPLEX128

--- a/csharp/tools/Microsoft.ML.OnnxRuntime.PerfTool/Microsoft.ML.OnnxRuntime.PerfTool.csproj
+++ b/csharp/tools/Microsoft.ML.OnnxRuntime.PerfTool/Microsoft.ML.OnnxRuntime.PerfTool.csproj
@@ -8,6 +8,7 @@
     <OnnxRuntimeBuildDirectory Condition="'$(OnnxRuntimeBuildDirectory)'==''">$(OnnxRuntimeCsharpRoot)\..\build\Windows</OnnxRuntimeBuildDirectory>
     <NativeBuildOutputDir>$(OnnxRuntimeBuildDirectory)\$(Configuration)\$(Configuration)</NativeBuildOutputDir>
     <SignAssembly>false</SignAssembly>
+    <Configurations>Debug;Release;RelWithDebInfo</Configurations>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION

**Description**: 
The C# projects didn't have a RelWithDebInfo target defined and failed to find the native build outputs due to this. 
Make the cmake file slightly more consistent for the build c# flag.

**Motivation and Context**
Addresses an issue in #3521 