### PR TITLE
[Cherry-pick] Fix state_dict and save_as_onnx for training (#3774)

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
+++ b/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
@@ -82,7 +82,7 @@ def create_ort_trainer(gradient_accumulation_steps,
                        use_mixed_precision=use_mixed_precision,
                        allreduce_post_accumulation=allreduce_post_accumulation,
                        partition_optimizer = partition_optimizer)
-    
+
     return model, model_desc, device
 
 def runBertTrainingTest(gradient_accumulation_steps,
@@ -92,7 +92,7 @@ def runBertTrainingTest(gradient_accumulation_steps,
                         use_internel_loss_scale=False):
     torch.manual_seed(1)
     onnxruntime.set_seed(1)
-  
+
     loss_scaler = LossScaler("ort_test_input_loss_scalar", True) if use_internel_loss_scale else None
 
     model, model_desc, device = create_ort_trainer(gradient_accumulation_steps,
@@ -237,7 +237,7 @@ class MNISTWrapper():
         kwargs = {'num_workers': 0, 'pin_memory': True}
         train_loader = torch.utils.data.DataLoader(
             datasets.MNIST('../data', train=True, download=True,
-                        transform=transforms.Compose([transforms.ToTensor(), 
+                        transform=transforms.Compose([transforms.ToTensor(),
                                                         transforms.Normalize((0.1307,), (0.3081,))])),
             batch_size=args_batch_size, shuffle=True, **kwargs)
         test_loader = torch.utils.data.DataLoader(
@@ -259,7 +259,7 @@ class MNISTWrapper():
         return model, model_desc
 
     def get_trainer(self, model, model_desc, device):
-        return ORTTrainer(model, MNISTWrapper.my_loss, model_desc, "SGDOptimizer", None, IODescription('Learning_Rate', [1, ], 
+        return ORTTrainer(model, MNISTWrapper.my_loss, model_desc, "SGDOptimizer", None, IODescription('Learning_Rate', [1, ],
                                 torch.float32), device, _opset_version=12)
 
 class TestOrtTrainer(unittest.TestCase):
@@ -355,6 +355,57 @@ class TestOrtTrainer(unittest.TestCase):
         assert_allclose(expected_test_losses, actual_test_losses, rtol=rtol, err_msg="test loss mismatch")
         assert_allclose(expected_test_accuracies, actual_accuracies, rtol=rtol, err_msg="test accuracy mismatch")
 
+    def testMNISTStateDict(self):
+        torch.manual_seed(1)
+        device = torch.device("cuda")
+
+        mnist = MNISTWrapper()
+        train_loader, test_loader = mnist.get_loaders()
+        model, model_desc = mnist.get_model()
+
+        trainer = mnist.get_trainer(model, model_desc, device)
+        state_dict = trainer.state_dict()
+        assert state_dict == {}
+
+        learningRate = 0.02
+        epoch = 0
+
+        data, target = next(iter(train_loader))
+        data, target = data.to(device), target.to(device)
+        data = data.reshape(data.shape[0], -1)
+
+        loss, _ = trainer.train_step(data, target, torch.tensor([learningRate]))
+
+        state_dict = trainer.state_dict()
+        assert state_dict.keys() == {'model_.fc1.bias', 'model_.fc1.weight', 'model_.fc2.bias', 'model_.fc2.weight'}
+
+    def testMNISTSaveAsONNX(self):
+        torch.manual_seed(1)
+        device = torch.device("cuda")
+        onnx_file_name = 'mnist.onnx'
+        if os.path.exists(onnx_file_name):
+            os.remove(onnx_file_name)
+
+        mnist = MNISTWrapper()
+        train_loader, test_loader = mnist.get_loaders()
+        model, model_desc = mnist.get_model()
+
+        trainer = mnist.get_trainer(model, model_desc, device)
+        trainer.save_as_onnx(onnx_file_name)
+        assert not os.path.exists(onnx_file_name)
+
+        learningRate = 0.02
+        epoch = 0
+
+        data, target = next(iter(train_loader))
+        data, target = data.to(device), target.to(device)
+        data = data.reshape(data.shape[0], -1)
+
+        loss, _ = trainer.train_step(data, target, torch.tensor([learningRate]))
+
+        trainer.save_as_onnx(onnx_file_name)
+        assert os.path.exists(onnx_file_name)
+
     def testBertTrainingBasic(self):
         expected_losses = [
             11.02906322479248, 11.094074249267578, 11.00899887084961, 11.06129264831543,
@@ -379,7 +430,7 @@ class TestOrtTrainer(unittest.TestCase):
             11.02906322479248, 11.094074249267578, 11.008995056152344, 11.061283111572266,
             11.029059410095215, 11.04024887084961, 11.04680347442627, 10.993708610534668]
         expected_eval_loss = [10.959011]
-        
+
         actual_losses, actual_eval_loss = runBertTrainingTest(
             gradient_accumulation_steps=4, use_mixed_precision=False, allreduce_post_accumulation=False)
 
@@ -436,7 +487,7 @@ class TestOrtTrainer(unittest.TestCase):
 
         ckpt_dir = get_name("ort_ckpt")
         load_checkpoint(model, ckpt_dir, 'bert_toy_lamb')
-                
+
         expected_eval_loss = [10.997552871]
 
         input_ids = torch.tensor([[26598],[21379],[19922],[ 5219],[ 5644],[20559],[23777],[25672],[22969],[16824],[16822],[  635],[27399],[20647],[18519],[15546]], device=device)


### PR DESCRIPTION
Cherry-pick from master.

With delayed export, ORTTrainer.session is initialized after the first train_step/eval_step call. Thus it is no longer valid to call state_dict and save_as_onnx before that, since both depends on ORTTrainer.session. This PR updates the two methods to return empty for the above case, and throw a warning.