### PR TITLE
Fix bugs when model nodes have no name.

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -242,11 +242,9 @@ def main():
     args = parser.parse_args()
     calibrate_op_types = args.op_types.split(',')
     black_nodes = args.black_nodes.split(',')
-    while '' in black_nodes:
-        black_nodes.remove('')
+    black_nodes = [x for x in black_nodes if x]
     white_nodes = args.white_nodes.split(',')
-    while '' in white_nodes:
-        white_nodes.remove('')
+    white_nodes = [x for x in white_nodes if x]
     model_path = args.model_path
     output_model_path = args.output_model_path
     images_folder = args.dataset_path

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -242,7 +242,11 @@ def main():
     args = parser.parse_args()
     calibrate_op_types = args.op_types.split(',')
     black_nodes = args.black_nodes.split(',')
+    while '' in black_nodes:
+        black_nodes.remove('')
     white_nodes = args.white_nodes.split(',')
+    while '' in white_nodes:
+        white_nodes.remove('')
     model_path = args.model_path
     output_model_path = args.output_model_path
     images_folder = args.dataset_path


### PR DESCRIPTION
Default white_node list and black_node list after split will be [''], rather than [].
This make model with nodes have no name encounter lot of issues.
