### PR TITLE
Fix initial value of graph optimization level

### DIFF
--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -102,7 +102,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   bool enable_dml = false;
   bool enable_acl = false;
   int device_id = 0;
-  GraphOptimizationLevel graph_optimization_level = ORT_DISABLE_ALL;
+  GraphOptimizationLevel graph_optimization_level = ORT_ENABLE_ALL;
   bool user_graph_optimization_level_set = false;
   int verbosity_option_count = 0;
 


### PR DESCRIPTION
This is a cosmetic change only - Per onnx_test_runner's options, the default graph optimization level is ORT_ENABLE_ALL but the variable corresponding to the graph optimization level is initialized with ORT_DISABLE_ALL and any user given value (if provided) is eventually stored in it. At first glance, it looks like the default value is actually ORT_DISABLE_ALL. One would have to know that internally the wrapped (ORT-internal) SessionOptions' graph_optimization_level has been initialized with ORT_ENABLE_ALL to truly know that the default is ORT_ENABLE_ALL.

**Motivation and Context**
Found while investigating an issue
