### PR TITLE
Dnnl related test failure workaround

### DIFF
--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -854,6 +854,7 @@ int main(int argc, char* argv[]) {
     fprintf(stderr, "%s\n", ex.what());
     retval = -1;
   }
+  std::cout << "*** Shutting down protobuf\r\n";
   ::google::protobuf::ShutdownProtobufLibrary();
   std::cout << "*** Exiting Test Runner\r\n";
   return retval;


### PR DESCRIPTION
Adding an extra diagnostic line, which amusingly makes the problem go away.