### PR TITLE
DNNL Test failure fix by using simple thread_local

### DIFF
--- a/onnxruntime/core/providers/dnnl/dnnl_common.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_common.h
@@ -66,9 +66,8 @@ class PrimitivePool {
  private:
   // For thread safety, the map needs to be kept in thread local storage.
   static inline std::unordered_map<std::string, std::unique_ptr<PrimitiveBase>>& GetMap() {
-    using MapType = std::unordered_map<std::string, std::unique_ptr<PrimitiveBase>>;
-    static thread_local DeleteOnUnloadPtr<MapType> map(new MapType());
-    return *map;
+    static thread_local std::unordered_map<std::string, std::unique_ptr<PrimitiveBase>> map;
+    return map;
   }
 };
 

--- a/onnxruntime/core/providers/shared_library/provider_api.h
+++ b/onnxruntime/core/providers/shared_library/provider_api.h
@@ -45,27 +45,6 @@ enum OperatorStatus : int {
 
 namespace onnxruntime {
 
-// The function passed in will be run on provider DLL unload. This is used to free thread_local variables that are in threads we don't own
-// Since these are not destroyed when the DLL unloads we have to do it manually. Search for usage for an example.
-void RunOnUnload(std::function<void()> function);
-
-// A pointer stored in here will be deleted when the DLL gets unloaded, this is really only useful for thread_locals which don't get cleaned up properly otherwise
-template <typename T>
-struct DeleteOnUnloadPtr {
-  DeleteOnUnloadPtr(T* p) : p_(p) {
-    RunOnUnload([p = p_]() {
-      delete p;
-    });
-  }
-
-  operator T*() {
-    return p_;
-  }
-
- private:
-  T* p_;
-};
-
 constexpr const char* kOnnxDomain = "";
 constexpr const char* kDnnlExecutionProvider = "DnnlExecutionProvider";
 

--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -18,30 +18,6 @@ void SetProviderHost(ProviderHost& host) {
   g_host = &host;
 }
 
-static std::unique_ptr<std::vector<std::function<void()>>> s_run_on_unload_;
-
-void RunOnUnload(std::function<void()> function) {
-  static std::mutex mutex;
-  std::lock_guard<std::mutex> guard{mutex};
-  if (!s_run_on_unload_)
-    s_run_on_unload_ = onnxruntime::make_unique<std::vector<std::function<void()>>>();
-  s_run_on_unload_->push_back(std::move(function));
-}
-
-// This object is destroyed as part of the DLL unloading code and handles running all of the RunOnLoad functions
-struct OnUnload {
-  ~OnUnload() {
-    if (!s_run_on_unload_)
-      return;
-
-    for (auto& function : *s_run_on_unload_)
-      function();
-
-    s_run_on_unload_.reset();
-  }
-
-} g_on_unload;
-
 }  // namespace onnxruntime
 
 // Override default new/delete so that we match the host's allocator

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -855,6 +855,5 @@ int main(int argc, char* argv[]) {
     retval = -1;
   }
   ::google::protobuf::ShutdownProtobufLibrary();
-  std::cout << "*** Exiting Test Runner\r\n";
   return retval;
 }


### PR DESCRIPTION
Since the thread_local destruction problem is supposedly fixed in Visual Studio 2019, this might also fix the issue (if it's the cause). Trying it to see.