### PR TITLE
Fast exit workaround for dnnl test

### DIFF
--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -24,6 +24,8 @@
 
 using namespace onnxruntime;
 
+static bool g_exit_fast = false;
+
 namespace {
 void usage() {
   printf(
@@ -321,6 +323,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     if (enable_dnnl) {
 #ifdef USE_DNNL
       Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(sf, enable_cpu_mem_arena ? 1 : 0));
+      g_exit_fast = true;
 #else
       fprintf(stderr, "DNNL is not supported in this build");
       return -1;
@@ -855,6 +858,7 @@ int main(int argc, char* argv[]) {
     retval = -1;
   }
   ::google::protobuf::ShutdownProtobufLibrary();
-  std::cout << "*** Exiting Test Runner\r\n";
+  if (g_exit_fast)
+    std::_Exit(retval);
   return retval;
 }


### PR DESCRIPTION
Temporary workaround, but use a fast exit command just for the dnnl test.