### PR TITLE
Ensure pt model is set to cpu in ort_trainer

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
+++ b/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
@@ -406,6 +406,26 @@ class TestOrtTrainer(unittest.TestCase):
         trainer.save_as_onnx(onnx_file_name)
         assert os.path.exists(onnx_file_name)
 
+    def testMNISTDevice(self):
+        torch.manual_seed(1)
+        device = torch.device("cuda")
+
+        mnist = MNISTWrapper()
+        train_loader, test_loader = mnist.get_loaders()
+        model, model_desc = mnist.get_model()
+
+        for model_device in [torch.device('cpu'), torch.device('cuda')]:
+            model.to(model_device)
+            trainer = mnist.get_trainer(model, model_desc, device)
+            learningRate = 0.02
+            epoch = 0
+
+            data, target = next(iter(train_loader))
+            data, target = data.to(device), target.to(device)
+            data = data.reshape(data.shape[0], -1)
+
+            loss, _ = trainer.train_step(data, target, torch.tensor([learningRate]))
+
     def testBertTrainingBasic(self):
         expected_losses = [
             11.02906322479248, 11.094074249267578, 11.00899887084961, 11.06129264831543,

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -730,6 +730,7 @@ class ORTTrainer():
             return
 
         if self.torch_model_ is not None:
+            # NOTE: pt model is moved to cpu to conserve gpu memory.
             self.torch_model_.cpu()
             self.onnx_model_ = convert_model_loss_fn_to_onnx(
                 self.torch_model_, self.loss_fn_, self.model_desc_, torch.device('cpu'), inputs, opset_version=self.opset_version_)

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -310,7 +310,7 @@ def convert_model_loss_fn_to_onnx(model, loss_fn, model_desc, device, inputs, op
 
     # Other export options to use(this is for backward compatibility).
     other_export_options = {}
-    
+
     # This option was added after 1.4 release.
     if LooseVersion(torch.__version__) > LooseVersion('1.4.0'):
         other_export_options['enable_onnx_checker'] = False
@@ -730,6 +730,7 @@ class ORTTrainer():
             return
 
         if self.torch_model_ is not None:
+            self.torch_model_.cpu()
             self.onnx_model_ = convert_model_loss_fn_to_onnx(
                 self.torch_model_, self.loss_fn_, self.model_desc_, torch.device('cpu'), inputs, opset_version=self.opset_version_)
 
@@ -811,7 +812,7 @@ class ORTTrainer():
             #   kwargs[model.loss_scale_input_name] = loss_scale
             #   outputs = model.train_step(*args, **kwargs)
             # However, when first time train_step is called model.loss_scale_input_name is not set.
-            # To workaround this problem, we use the special name 'default_loss_scale_input_name' to indicate 
+            # To workaround this problem, we use the special name 'default_loss_scale_input_name' to indicate
             # the loss_scale.
             if 'default_loss_scale_input_name' in kwargs.keys():
                 input = input + (kwargs['default_loss_scale_input_name'],)


### PR DESCRIPTION
ORTTrainer requires pt model to be on cpu, in order to save memory consumption on gpu.
