### PR TITLE
fix dnnl ep shared lib python packaging.

### DIFF
--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -247,7 +247,8 @@ add_custom_command(
 if (onnxruntime_USE_DNNL)
   add_custom_command(
     TARGET onnxruntime_pybind11_state POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${DNNL_DLL_PATH}
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${DNNL_DLL_PATH} $<TARGET_FILE:onnxruntime_providers_dnnl>
         $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/capi/
   )
 endif()

--- a/onnxruntime/core/framework/provider_bridge_ort.cc
+++ b/onnxruntime/core/framework/provider_bridge_ort.cc
@@ -538,6 +538,8 @@ struct IExecutionProviderFactory_Translator : IExecutionProviderFactory {
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(int device_id) {
 #ifdef _WIN32
   static ProviderLibrary library("onnxruntime_providers_dnnl.dll");
+#elif defined(__APPLE__)
+  static ProviderLibrary library("libonnxruntime_providers_dnnl.dylib");
 #else
   static ProviderLibrary library("libonnxruntime_providers_dnnl.so");
 #endif

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,8 @@ except ImportError as error:
 # Additional binaries
 if platform.system() == 'Linux':
   libs = ['onnxruntime_pybind11_state.so', 'libdnnl.so.1', 'libmklml_intel.so', 'libiomp5.so', 'mimalloc.so']
+  # dnnl EP is built as shared lib
+  libs.extend(['libonnxruntime_providers_dnnl.so'])
   # nGraph Libs
   libs.extend(['libngraph.so', 'libcodegen.so', 'libcpu_backend.so', 'libmkldnn.so', 'libtbb_debug.so', 'libtbb_debug.so.2', 'libtbb.so', 'libtbb.so.2'])
   # OpenVINO Libs
@@ -151,10 +153,14 @@ if platform.system() == 'Linux':
     libs.extend(['libonnxruntime_pywrapper.so'])
 elif platform.system() == "Darwin":
   libs = ['onnxruntime_pybind11_state.so', 'libdnnl.1.dylib', 'mimalloc.so'] # TODO add libmklml and libiomp5 later.
+  # dnnl EP is built as shared lib
+  libs.extend(['libonnxruntime_providers_dnnl.dylib'])
   if nightly_build:
     libs.extend(['libonnxruntime_pywrapper.dylib'])
 else:
   libs = ['onnxruntime_pybind11_state.pyd', 'dnnl.dll', 'mklml.dll', 'libiomp5md.dll']
+  # dnnl EP is built as dll
+  libs.extend(['onnxruntime_providers_dnnl.dll'])
   libs.extend(['ngraph.dll', 'cpu_backend.dll', 'tbb.dll', 'mimalloc-override.dll', 'mimalloc-redirect.dll', 'mimalloc-redirect32.dll'])
   # Nuphar Libs
   libs.extend(['tvm.dll'])


### PR DESCRIPTION
python package was missing the recently created dnnl execution provider shared lib.