### PR TITLE
Load provider shared libraries relative to core runtime executable

### DIFF
--- a/onnxruntime/core/framework/provider_bridge_ort.cc
+++ b/onnxruntime/core/framework/provider_bridge_ort.cc
@@ -504,7 +504,9 @@ struct ProviderHostImpl : ProviderHost {
 
 struct ProviderLibrary {
   ProviderLibrary(const char* filename) {
-    Env::Default().LoadDynamicLibrary(filename, &handle_);
+
+    std::string full_path = Env::Default().GetRuntimePath() + std::string(filename);
+    Env::Default().LoadDynamicLibrary(full_path, &handle_);
     if (!handle_)
       return;
 

--- a/onnxruntime/core/platform/env.h
+++ b/onnxruntime/core/platform/env.h
@@ -206,6 +206,12 @@ class Env {
 
   virtual common::Status UnloadDynamicLibrary(void* handle) const = 0;
 
+  // \brief Gets the file path of the onnx runtime code
+  //
+  // Used to help load other shared libraries that live in the same folder as the core code, for example
+  // The DNNL provider shared library. Without this path, the module won't be found on windows in all cases.
+  virtual std::string GetRuntimePath() const { return ""; }
+
   // \brief Get a pointer to a symbol from a dynamic library.
   //
   // "handle" should be a pointer returned from a previous call to LoadDynamicLibrary.

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -447,7 +447,8 @@ class WindowsEnv : public Env {
   }
 
   virtual Status LoadDynamicLibrary(const std::string& library_filename, void** handle) const override {
-    *handle = ::LoadLibraryA(library_filename.c_str());
+    *handle = ::LoadLibraryExA(library_filename.c_str(), nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS|LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+
     if (!handle)
       return common::Status(common::ONNXRUNTIME, common::FAIL, "Failed to load library");
     return common::Status::OK();

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -434,8 +434,8 @@ class WindowsEnv : public Env {
   // possible to load other shared libraries installed next to our core runtime code.
   std::string GetRuntimePath() const override {
     char buffer[MAX_PATH];
-    if(!GetModuleFileNameA(reinterpret_cast<HINSTANCE>(&__ImageBase), buffer, _countof(buffer)))
-        return "";
+    if (!GetModuleFileNameA(reinterpret_cast<HINSTANCE>(&__ImageBase), buffer, _countof(buffer)))
+      return "";
 
     // Remove the filename at the end, but keep the trailing slash
     std::string path(buffer);
@@ -447,9 +447,8 @@ class WindowsEnv : public Env {
   }
 
   virtual Status LoadDynamicLibrary(const std::string& library_filename, void** handle) const override {
-    *handle = ::LoadLibraryExA(library_filename.c_str(), nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS|LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
-
-    if (!handle)
+    *handle = ::LoadLibraryExA(library_filename.c_str(), nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+    if (!*handle)
       return common::Status(common::ONNXRUNTIME, common::FAIL, "Failed to load library");
     return common::Status::OK();
   }

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -346,11 +346,15 @@ TEST(CApiTest, DISABLED_test_custom_op_library) {
 
   std::string lib_name;
 #if defined(_WIN32)
-  lib_name = "custom_op_library.dll";
+  char current_directory[/*MAX_PATH*/ 260];
+  if (_getcwd(current_directory, _countof(current_directory)))
+    lib_name = current_directory;
+  lib_name += "\\custom_op_library.dll";
+
 #elif defined(__APPLE__)
   lib_name = "libcustom_op_library.dylib";
 #else
-  lib_name = "./libcustom_op_library.so";
+lib_name = "./libcustom_op_library.so";
 #endif
 
   TestInference<PATH_TYPE, int32_t>(*ort_env, CUSTOM_OP_LIBRARY_TEST_MODEL_URI, inputs, "output", expected_dims_y, expected_values_y, 0, nullptr, lib_name.c_str());


### PR DESCRIPTION
**Description**: Uses the path of the core runtime executable/shared library to load the provider shared library.

**Motivation and Context**
- Why is this change required? What problem does it solve?
When our core code is loaded by other modules (like python), the core code is not part of the DLL search path on windows and providers will fail to load. This ensures they are loaded from the right place.