### PR TITLE
Inbox builds still try to build redist only tests

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -24,8 +24,7 @@ set(winml_lib_api_ort_dir ${REPO_ROOT}/winml/lib/api.ort)
 set(winml_lib_common_dir ${REPO_ROOT}/winml/lib/common)
 set(winml_lib_telemetry_dir ${REPO_ROOT}/winml/lib/telemetry)
 
-set(winml_is_inbox false)
-
+set(winml_is_inbox OFF)
 if (onnxruntime_WINML_NAMESPACE_OVERRIDE)
   set(output_name "${onnxruntime_WINML_NAMESPACE_OVERRIDE}.AI.MachineLearning")
   set(idl_native_output_name "${onnxruntime_WINML_NAMESPACE_OVERRIDE}.AI.MachineLearning.Native")
@@ -33,7 +32,7 @@ if (onnxruntime_WINML_NAMESPACE_OVERRIDE)
   
   if (onnxruntime_WINML_NAMESPACE_OVERRIDE STREQUAL "Windows")
     set(winml_midl_defines "/DBUILD_INBOX=1")
-    set(winml_is_inbox true)
+    set(winml_is_inbox ON)
   endif()
 
   set(winml_root_ns "${onnxruntime_WINML_NAMESPACE_OVERRIDE}")

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -87,18 +87,23 @@ function(get_winml_test_api_src
       "${winml_test_src_path}/api/LearningModelAPITest.cpp"
       "${winml_test_src_path}/api/LearningModelBindingAPITest.cpp"
       "${winml_test_src_path}/api/LearningModelSessionAPITest.cpp")
-  
-  if (NOT winml_is_inbox)
-      file(GLOB winml_redist_only_api_src CONFIGURE_DEPENDS
-      "${winml_test_src_path}/api/RawApiHelpers.h"
-      "${winml_test_src_path}/api/RawApiTests.h"
-      "${winml_test_src_path}/api/RawApiTestsGpu.h"
-      "${winml_test_src_path}/api/RawApiHelpers.cpp"
-      "${winml_test_src_path}/api/RawApiTests.cpp"
-      "${winml_test_src_path}/api/RawApiTestsGpu.cpp"
-      "${winml_test_src_path}/api/raw/*.h"
-      "${winml_test_src_path}/api/raw/*.cpp")
-  endif()
+
+  set(${output_winml_test_api_src} ${winml_test_api_src} ${winml_redist_only_api_src} PARENT_SCOPE)
+endfunction()
+
+function(get_winml_test_api_redist_only_src
+  winml_test_src_path
+  output_winml_test_api_src
+)
+  file(GLOB winml_redist_only_api_src CONFIGURE_DEPENDS
+  "${winml_test_src_path}/api/RawApiHelpers.h"
+  "${winml_test_src_path}/api/RawApiTests.h"
+  "${winml_test_src_path}/api/RawApiTestsGpu.h"
+  "${winml_test_src_path}/api/RawApiHelpers.cpp"
+  "${winml_test_src_path}/api/RawApiTests.cpp"
+  "${winml_test_src_path}/api/RawApiTestsGpu.cpp"
+  "${winml_test_src_path}/api/raw/*.h"
+  "${winml_test_src_path}/api/raw/*.cpp")
 
   set(${output_winml_test_api_src} ${winml_test_api_src} ${winml_redist_only_api_src} PARENT_SCOPE)
 endfunction()
@@ -153,9 +158,14 @@ set_winml_target_properties(winml_google_test_lib)
 
 set_winml_target_properties(winml_test_common)
 get_winml_test_api_src(${WINML_TEST_SRC_DIR} winml_test_api_src)
+
+if (NOT ${winml_is_inbox})
+  get_winml_test_api_redist_only_src(${WINML_TEST_SRC_DIR} winml_test_api_redist_only_src)
+endif()
+
 add_winml_test(
   TARGET winml_test_api
-  SOURCES ${winml_test_api_src}
+  SOURCES ${winml_test_api_src} ${winml_test_api_redist_only_src}
   LIBS winml_test_common delayimp.lib
 )
 target_link_options(winml_test_api PRIVATE /DELAYLOAD:dxgi.dll /DELAYLOAD:d3d12.dll /DELAYLOAD:api-ms-win-core-file-l1-2-2.dll /DELAYLOAD:api-ms-win-core-synch-l1-2-1.dll)


### PR DESCRIPTION
Issue: winml_is_inbox cmake variable is undefined in function scope and causes redist tests to build in inbox builds

Fix: refactor the if check to global scope.