### PR TITLE
Remove reference to winrt/base.h from adapter.

### DIFF
--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -15,7 +15,6 @@
 
 #include <io.h>
 #include <fcntl.h>
-#include <winrt/base.h>
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "core/framework/onnxruntime_typeinfo.h"
 


### PR DESCRIPTION
Issue: Reference to winrt/base.h in the winml_adapter.lib causes onnxruntime to take a dependency on cppwinrt -> WinRT, which should not exist.

Fix: Remove unused header.