### PR TITLE
use LOAD_WITH_ALTERED_SEARCH_PATH for LoadLibraryExA

### DIFF
--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -447,7 +447,7 @@ class WindowsEnv : public Env {
   }
 
   virtual Status LoadDynamicLibrary(const std::string& library_filename, void** handle) const override {
-    *handle = ::LoadLibraryExA(library_filename.c_str(), nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+    *handle = ::LoadLibraryExA(library_filename.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
     if (!*handle)
       return common::Status(common::ONNXRUNTIME, common::FAIL, "Failed to load library");
     return common::Status::OK();

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -346,15 +346,11 @@ TEST(CApiTest, DISABLED_test_custom_op_library) {
 
   std::string lib_name;
 #if defined(_WIN32)
-  char current_directory[/*MAX_PATH*/ 260];
-  if (_getcwd(current_directory, _countof(current_directory)))
-    lib_name = current_directory;
-  lib_name += "\\custom_op_library.dll";
-
+  lib_name = "custom_op_library.dll";
 #elif defined(__APPLE__)
   lib_name = "libcustom_op_library.dylib";
 #else
-lib_name = "./libcustom_op_library.so";
+  lib_name = "./libcustom_op_library.so";
 #endif
 
   TestInference<PATH_TYPE, int32_t>(*ort_env, CUSTOM_OP_LIBRARY_TEST_MODEL_URI, inputs, "output", expected_dims_y, expected_values_y, 0, nullptr, lib_name.c_str());


### PR DESCRIPTION
previous use of LOAD_WITH_ALTERED_SEARCH_PATH requires absolute paths.
this required us to change the custom op shared lib test case for windows.

using LOAD_WITH_ALTERED_SEARCH_PATH allows for both absolute paths and filenames (falling back to default search paths) to work. 