### PR TITLE
Remove ORTModel from frontend API (cherry-pick #3825)

### DIFF
--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -331,61 +331,6 @@ def convert_model_loss_fn_to_onnx(model, loss_fn, model_desc, device, inputs, op
 
     return model
 
-def generate_node_arg_name(graph, base_name):
-    def find_node_arg(graph, new_node_arg_name):
-        for node in graph.node:
-            for node_arg in node.input:
-                if node_arg == new_node_arg_name:
-                    return True
-            for node_arg in node.output:
-                if node_arg == new_node_arg_name:
-                    return True
-        return False
-
-    generator = 1
-    while True:
-        new_name = base_name + '_' + str(generator)
-        if not find_node_arg(graph, new_name):
-            return new_name
-        generator += 1
-
-def generate_node_name(graph, base_name):
-    def find_node(graph, new_node_name):
-        for node in graph.node:
-            if node.name == new_node_name:
-                return True
-        return False
-
-    generator = 1
-    while True:
-        new_name = base_name + '_' + str(generator)
-        if not find_node(graph, new_name):
-            return new_name
-        generator += 1
-
-def create_and_bind_grad_or_grad_accumulate_buffer(train_io_binding, torch_tensor, param,
-                                                   enable_grad_accumulation, device, device_index):
-    if torch_tensor.grad is None:
-        torch_tensor.grad = torch.zeros(torch_tensor.size(), dtype=torch.float32, device=device)
-    if enable_grad_accumulation:
-        # hardcode grad_accumulate_buffer name
-        grad_buffer_name = param + "_grad_accumulate_buffer"
-        train_io_binding.bind_input(grad_buffer_name,
-                                    torch_tensor.grad.device.type,
-                                    device_index,
-                                    dtype_torch_to_numpy(torch_tensor.grad.dtype),
-                                    list(torch_tensor.grad.size()),
-                                    torch_tensor.grad.data_ptr())
-    else:
-        # hardcode grad name
-        grad_buffer_name = param + "_grad"
-        train_io_binding.bind_output(grad_buffer_name,
-                                     torch_tensor.grad.device.type,
-                                     device_index,
-                                     dtype_torch_to_numpy(torch_tensor.grad.dtype),
-                                     list(torch_tensor.grad.size()),
-                                     torch_tensor.grad.data_ptr())
-
 def create_ort_training_session_with_optimizer(model, device, training_optimizer_name, lr_params_feed_name,
                                                map_optimizer_attributes, world_rank=-1, world_size=1,
                                                gradient_accumulation_steps=1, bind_parameters=False,
@@ -465,58 +410,6 @@ def create_ort_training_session_with_optimizer(model, device, training_optimizer
             eval_io_binding.bind_input(param, torch_tensor.device.type, get_device_index(torch_tensor.device),
                                        dtype_torch_to_numpy(torch_params[param].dtype), list(torch_tensor.size()),
                                        torch_tensor.data_ptr())
-
-    return session, train_io_binding, eval_io_binding, output_name, torch_params, output_types
-
-def create_ort_training_session_bind_parameters(model, device, world_rank=-1, world_size=1,
-                                                gradient_accumulation_steps=1):
-    output_name = model.graph.output[0].name
-    ort_parameters = ort.TrainingParameters()
-    ort_parameters.loss_output_name = output_name
-    ort_parameters.use_mixed_precision = False
-    ort_parameters.world_rank = world_rank
-    ort_parameters.world_size = world_size
-    ort_parameters.gradient_accumulation_steps = gradient_accumulation_steps
-    ort_parameters.set_gradients_as_graph_outputs = True
-
-    torch_params = {}
-    output_types = {}
-    for output in model.graph.output:
-        output_types[output.name] = output.type.tensor_type
-
-    for initializer in model.graph.initializer:
-        torch_tensor = torch.nn.Parameter(torch.as_tensor(numpy_helper.to_array(initializer), device=device))
-        delete_input_with_name(model.graph.input, initializer.name)
-        model.graph.input.extend(
-            [helper.make_tensor_value_info(initializer.name, initializer.data_type, initializer.dims)])
-
-        torch_params[initializer.name] = torch_tensor
-
-    del model.graph.initializer[:]
-
-    ort_parameters.weights_to_train = set(torch_params.keys())
-
-    if device.type == 'cuda' and hasattr(device, "index") and device.index is not None:
-        from onnxruntime.capi._pybind_state import set_cuda_device_id
-        set_cuda_device_id(device.index)
-    session = ort.TrainingSession(model.SerializeToString(), ort_parameters)
-
-    train_io_binding = session.io_binding()
-    eval_io_binding = session.io_binding()
-
-    enable_grad_accumulation = gradient_accumulation_steps > 1
-    for param in torch_params.keys():
-        torch_tensor = torch_params[param]
-
-        train_io_binding.bind_input(param, torch_tensor.device.type, get_device_index(torch_tensor.device),
-                                    dtype_torch_to_numpy(torch_params[param].dtype), list(torch_tensor.size()),
-                                    torch_tensor.data_ptr())
-        eval_io_binding.bind_input(param, torch_tensor.device.type, get_device_index(torch_tensor.device),
-                                   dtype_torch_to_numpy(torch_params[param].dtype), list(torch_tensor.size()),
-                                   torch_tensor.data_ptr())
-
-        device_index = get_device_index(device)
-        create_and_bind_grad_or_grad_accumulate_buffer(train_io_binding, torch_tensor, param, enable_grad_accumulation, device, device_index)
 
     return session, train_io_binding, eval_io_binding, output_name, torch_params, output_types
 
@@ -1007,71 +900,6 @@ class ORTTrainer():
             raise RuntimeError("the first output of a model to run with fully optimized ORT backend must be float types.")
         if len(model.graph.output[0].type.tensor_type.shape.dim) != 0:
             raise RuntimeError("the first output of a model to run with fully optimized ORT backend must be a scaler.")
-
-class ORTModel():
-    def __init__(self, model, loss_fn, model_desc, device, postprocess_model=None, world_rank=-1, world_size=1,
-                 gradient_accumulation_steps=1, _opset_version=DEFAULT_OPSET_VERSION):
-        super(ORTModel, self).__init__()
-        self.model_ = model
-        self.loss_fn_ = loss_fn
-        self.model_desc_ = model_desc
-        self.device_ = device
-        self.world_rank = world_rank
-        self.world_size = world_size
-        self.gradient_accumulation_steps = gradient_accumulation_steps
-        self.opset_version = _opset_version
-    
-        # Adding to not break checkpointing functions for ORTModel
-        self.partition_optimizer_ = False
-
-        model = convert_model_loss_fn_to_onnx(self.model_, self.loss_fn_, self.model_desc_, torch.device(
-            'cpu'), opset_version=self.opset_version)
-        if postprocess_model:
-            postprocess_model(model)
-
-        # onnx.save_model(model, 'bert_model_base_after_postproc.onnx')
-        self.session_, self.train_io_binding, self.eval_io_binding, self.output_name,\
-        self.torch_params, self.output_types =\
-            create_ort_training_session_bind_parameters(model, device, self.world_rank, self.world_size,
-                gradient_accumulation_steps=self.gradient_accumulation_steps)
-
-    def parameters(self):
-        return list(self.torch_params.values())
-
-    def named_parameters(self):
-        return self.torch_params.items()
-
-    def train(self):
-        pass
-
-    def eval(self):
-        pass
-
-    def state_dict(self):
-        return self.torch_params
-
-    def load_state_dict(self, state_dict, strict=False):
-        for name, param in self.torch_params.items():
-            input_param = state_dict[name]
-            param.data.copy_(input_param.data)
-
-    def _train(self, *inputs):
-        # confirm does the grad buffer binded or not
-        enable_grad_accumulation = self.gradient_accumulation_steps > 1
-        for param in self.torch_params.keys():
-            torch_tensor = self.torch_params[param]
-            create_and_bind_grad_or_grad_accumulate_buffer(self.train_io_binding, torch_tensor, param,
-                                                           enable_grad_accumulation, torch_tensor.device, get_device_index(torch_tensor.device))
-
-        return ort_training_session_run_helper(self.session_, self.train_io_binding, inputs,
-                                               self.model_desc_.inputs_, self.model_desc_.outputs_,
-                                               self.device_).values()
-
-    def __call__(self, *inputs):
-        return self._train(*inputs)
-
-    def run(self, *inputs):
-        return self._train(*inputs)
 
 class LossScaler():
     def __init__(self, loss_scale_input_name, is_dynamic_scale,

--- a/orttraining/pytorch_frontend_examples/mnist_training.py
+++ b/orttraining/pytorch_frontend_examples/mnist_training.py
@@ -3,8 +3,6 @@
 ## A private PyTorch build from https://aiinfra.visualstudio.com/Lotus/_git/pytorch (ORTTraining branch) is needed to run the demo.
 ## To run the demo with ORT backend:
 ##      python mnist_training.py --use-ort
-## or
-##      python mnist_training.py --use-ort --use-ort-trainer
 
 ## When "--use-ort" is not given, it will run training with PyTorch as backend.
 ## Model testing is not complete.
@@ -19,7 +17,7 @@ from torchvision import datasets, transforms
 import numpy as np
 import os
 
-from onnxruntime.capi.ort_trainer import IODescription, ModelDescription, ORTTrainer, ORTModel
+from onnxruntime.capi.ort_trainer import IODescription, ModelDescription, ORTTrainer
 from mpi4py import MPI
 from onnxruntime.capi._pybind_state import set_cuda_device_id
 
@@ -38,41 +36,6 @@ class NeuralNet(nn.Module):
 
 def my_loss(x, target):
     return F.nll_loss(F.log_softmax(x, dim=1), target)
-
-def train_with_model(args, model, device, train_loader, optimizer, epoch):
-    model.train()
-    for batch_idx, (data, target) in enumerate(train_loader):
-        data, target = data.to(device), target.to(device)
-        data = data.reshape(data.shape[0], -1)
-        loss, pred = model.run(data, target)
-        if batch_idx % args.log_interval == 0:
-            optimizer.step()
-            optimizer.zero_grad()
-            print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
-                epoch, batch_idx * len(data), len(train_loader.dataset),
-                100. * batch_idx / len(train_loader), loss.item()))
-
-def test_with_model(args, model, device, test_loader, optimizer, epoch):
-    model.eval()
-    test_loss = 0
-    correct = 0
-    with torch.no_grad():
-        for data, target in test_loader:
-            data, target = data.to(device), target.to(device)
-            data = data.reshape(data.shape[0], -1)
-
-            pred = model.run(data, target, )
-
-            output = F.log_softmax(model.eval(data), dim=1)
-            test_loss += F.nll_loss(output, target, reduction='sum').item()     # sum up batch loss
-            pred = output.argmax(dim=1, keepdim=True)   # get the index of the max log-probability
-            correct += pred.eq(target.view_as(pred)).sum().item()
-
-    test_loss /= len(test_loader.dataset)
-
-    print('\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(
-        test_loss, correct, len(test_loader.dataset),
-        100. * correct / len(test_loader.dataset)))
 
 def train_with_trainer(args, trainer, device, train_loader, epoch):
     for batch_idx, (data, target) in enumerate(train_loader):
@@ -140,9 +103,6 @@ def main():
     parser.add_argument('--use-ort', action='store_true', default=False,
                         help='to use onnxruntime as training backend')
 
-    parser.add_argument('--use-ort-trainer', action='store_true', default=False,
-                        help='to use onnxruntime as training backend')
-
     args = parser.parse_args()
     use_cuda = not args.no_cuda and torch.cuda.is_available()
 
@@ -180,25 +140,15 @@ def main():
     model = NeuralNet(input_size, hidden_size, num_classes)
 
     model_desc = mnist_model_description()
-    if args.use_ort_trainer:
-        # use log_interval as gradient accumulate steps
-        trainer = ORTTrainer(model, my_loss, model_desc, "LambOptimizer", None, IODescription('Learning_Rate', [1,], torch.float32), device, 1, None,
-        args.world_rank, args.world_size, use_mixed_precision=False, allreduce_post_accumulation = True)
-        print('\nBuild ort model done.')
+    # use log_interval as gradient accumulate steps
+    trainer = ORTTrainer(model, my_loss, model_desc, "LambOptimizer", None, IODescription('Learning_Rate', [1,], torch.float32), device, 1, None,
+    args.world_rank, args.world_size, use_mixed_precision=False, allreduce_post_accumulation = True)
+    print('\nBuild ort model done.')
 
-        for epoch in range(1, args.epochs + 1):
-            train_with_trainer(args, trainer, device, train_loader, epoch)
-            import pdb
-            test_with_trainer(args, trainer, device, test_loader)
-    else:
-        model = ORTModel(model, my_loss, model_desc, device, None, args.world_rank, args.world_size)
-        print('\nBuild ort model done.')
-
-        optimizer = optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum)
-
-        for epoch in range(1, args.epochs + 1):
-            train_with_model(args, model, device, train_loader, optimizer, epoch)
-            # test(args, model, device, test_loader)
+    for epoch in range(1, args.epochs + 1):
+        train_with_trainer(args, trainer, device, train_loader, epoch)
+        import pdb
+        test_with_trainer(args, trainer, device, test_loader)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Current `ORTModel` API is broken and can confuse users that try to use it assuming it is working

This PR temporarily removes this API until it is supported again

Some other non-used methods were also removed and some docstrings updated