### PR TITLE
Parallel DynamicQuantizeLinear, QuantizeLinear and DequantizeLinear

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -632,7 +632,7 @@ install(TARGETS onnx_test_runner
 
 if(onnxruntime_BUILD_BENCHMARKS)
   SET(BENCHMARK_DIR ${TEST_SRC_DIR}/onnx/microbenchmark)
-  add_executable(onnxruntime_benchmark ${BENCHMARK_DIR}/main.cc ${BENCHMARK_DIR}/modeltest.cc ${BENCHMARK_DIR}/pooling.cc ${BENCHMARK_DIR}/batchnorm.cc ${BENCHMARK_DIR}/batchnorm2.cc ${BENCHMARK_DIR}/tptest.cc ${BENCHMARK_DIR}/eigen.cc ${BENCHMARK_DIR}/gelu.cc ${BENCHMARK_DIR}/activation.cc)
+  add_executable(onnxruntime_benchmark ${BENCHMARK_DIR}/main.cc ${BENCHMARK_DIR}/modeltest.cc ${BENCHMARK_DIR}/pooling.cc ${BENCHMARK_DIR}/batchnorm.cc ${BENCHMARK_DIR}/batchnorm2.cc ${BENCHMARK_DIR}/tptest.cc ${BENCHMARK_DIR}/eigen.cc ${BENCHMARK_DIR}/gelu.cc ${BENCHMARK_DIR}/activation.cc ${BENCHMARK_DIR}/quantizelinear.cc)
   target_include_directories(onnxruntime_benchmark PRIVATE ${ONNXRUNTIME_ROOT} ${onnxruntime_graph_header} ${ONNXRUNTIME_ROOT}/core/mlas/inc)
   if(WIN32)
     target_compile_options(onnxruntime_benchmark PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler /wd4141>"

--- a/onnxruntime/core/providers/cpu/tensor/dynamicquantizelinear.cc
+++ b/onnxruntime/core/providers/cpu/tensor/dynamicquantizelinear.cc
@@ -71,7 +71,7 @@ Status DynamicQuantizeLinear<T>::Compute(OpKernelContext* ctx) const {
   auto* output = y.template MutableData<T>();
 
   concurrency::ThreadPool* tp = ctx->GetOperatorThreadPool();
-  concurrency::ThreadPool::TryParallelFor(tp, num_of_elements, 2.0 /*cost*/, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+  concurrency::ThreadPool::TryParallelFor(tp, num_of_elements, 8.0 /*cost*/, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
     MlasQuantizeLinear(x_data + begin, output + begin, end - begin, scale, zero_point);
   });
 

--- a/onnxruntime/core/providers/cpu/tensor/dynamicquantizelinear.cc
+++ b/onnxruntime/core/providers/cpu/tensor/dynamicquantizelinear.cc
@@ -71,9 +71,12 @@ Status DynamicQuantizeLinear<T>::Compute(OpKernelContext* ctx) const {
   auto* output = y.template MutableData<T>();
 
   concurrency::ThreadPool* tp = ctx->GetOperatorThreadPool();
-  concurrency::ThreadPool::TryParallelFor(tp, num_of_elements, 8.0 /*cost*/, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
-    MlasQuantizeLinear(x_data + begin, output + begin, end - begin, scale, zero_point);
-  });
+  concurrency::ThreadPool::TryParallelFor(tp,
+                                          num_of_elements,
+                                          TensorOpCost{4.0, 4.0, 4.0 /*cost*/},
+                                          [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+                                            MlasQuantizeLinear(x_data + begin, output + begin, end - begin, scale, zero_point);
+                                          });
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/tensor/quantize_linear.cc
+++ b/onnxruntime/core/providers/cpu/tensor/quantize_linear.cc
@@ -72,7 +72,7 @@ Status DequantizeLinear<T>::Compute(OpKernelContext* ctx) const {
     concurrency::ThreadPool::TryParallelFor(tp, x_shape.Size(), 2.0 /*cost*/, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
       const T* input_tmp = input + begin;
       float* output_tmp = output + begin;
-      float zp = static_cast<int32_t>(*zero_point);
+      int32_t zp = static_cast<int32_t>(*zero_point);
       float sc = *scale;
       for (; output_tmp != output + end;) {
         *output_tmp++ = static_cast<float>(static_cast<int32_t>(*input_tmp++) - zp) * sc;

--- a/onnxruntime/core/providers/cpu/tensor/quantize_linear.cc
+++ b/onnxruntime/core/providers/cpu/tensor/quantize_linear.cc
@@ -69,7 +69,7 @@ Status DequantizeLinear<T>::Compute(OpKernelContext* ctx) const {
     ORT_ENFORCE(IsScalarOr1ElementVector(&x_scale), "x_scale must be a scalar or 1D tensor or size 1.");
     ORT_ENFORCE(IsScalarOr1ElementVector(&x_zero_point), "x_zero_point must be a scalar or 1D tensor or size 1.");
 
-    concurrency::ThreadPool::TryParallelFor(tp, x_shape.Size(), 2.0 /*cost*/, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+    concurrency::ThreadPool::TryParallelFor(tp, x_shape.Size(), 8.0 /*cost*/, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
       const T* input_tmp = input + begin;
       float* output_tmp = output + begin;
       int32_t zp = static_cast<int32_t>(*zero_point);
@@ -141,7 +141,7 @@ Status QuantizeLinear<T>::Compute(OpKernelContext* ctx) const {
     ORT_ENFORCE(IsScalarOr1ElementVector(&y_scale), "x_scale must be a scalar or 1D tensor or size 1.");
     ORT_ENFORCE(IsScalarOr1ElementVector(&y_zero_point), "x_zero_point must be a scalar or 1D tensor or size 1.");
 
-    concurrency::ThreadPool::TryParallelFor(tp, x_shape.Size(), 2.0 /*cost*/, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+    concurrency::ThreadPool::TryParallelFor(tp, x_shape.Size(), 8.0 /*cost*/, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
       MlasQuantizeLinear(input + begin, output + begin, end - begin, *scale, *zero_point);
     });
   }

--- a/onnxruntime/core/providers/cpu/tensor/quantize_linear.cc
+++ b/onnxruntime/core/providers/cpu/tensor/quantize_linear.cc
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/providers/cpu/tensor/quantize_linear.h"
-#include "core/providers/common.h"
+#include "quantize_linear.h"
+
 #include "core/mlas/inc/mlas.h"
+#include "core/platform/threadpool.h"
+#include "core/providers/common.h"
 
 namespace onnxruntime {
 
@@ -32,43 +34,50 @@ Status DequantizeLinear<T>::Compute(OpKernelContext* ctx) const {
   const auto& x_shape = x.Shape();
   auto& y = *ctx->Output(0, x_shape);
 
-  int64_t N;
-  int64_t broadcast_dim;
-  int64_t block_size;
-
-  if (has_axis_) {
-    const int64_t axis = HandleNegativeAxis(axis_, x_shape.NumDimensions());
-    N = x_shape.SizeToDimension(axis);
-    broadcast_dim = x_shape[axis];
-    block_size = x_shape.SizeFromDimension(axis + 1);
-
-    // if an axis was specified, ensure the scale and zero point are compatible
-    ORT_ENFORCE(x_scale.Shape().NumDimensions() == 1 && x_scale.Shape().Size() == broadcast_dim, "x_scale must be 1D tensor with size ", broadcast_dim);
-    ORT_ENFORCE(x_zero_point.Shape().NumDimensions() == 1 && x_zero_point.Shape().Size() == broadcast_dim, "x_zero_point must be 1D tensor with size ", broadcast_dim);
-  } else {
-    N = 1;
-    broadcast_dim = 1;
-    block_size = static_cast<size_t>(x_shape.Size());
-
-    // if no axis, enforce that scale and zero point are scalars
-    ORT_ENFORCE(IsScalarOr1ElementVector(&x_scale), "x_scale must be a scalar or 1D tensor or size 1.");
-    ORT_ENFORCE(IsScalarOr1ElementVector(&x_zero_point), "x_zero_point must be a scalar or 1D tensor or size 1.");
-  }
-
   const T* zero_point = x_zero_point.template Data<T>();
   const float* scale = x_scale.template Data<float>();
   const T* input = x.template Data<T>();
   float* output = y.template MutableData<float>();
+  concurrency::ThreadPool* tp = ctx->GetOperatorThreadPool();
 
-  for (size_t n = 0; n < static_cast<size_t>(N); n++) {
-    for (size_t bd = 0; bd < static_cast<size_t>(broadcast_dim); bd++) {
-      auto zp = static_cast<int32_t>(zero_point[bd]);
-      auto sc = scale[bd];
+  if (has_axis_) {
+    const int64_t axis = HandleNegativeAxis(axis_, x_shape.NumDimensions());
+    int64_t N = x_shape.SizeToDimension(axis);
+    int64_t broadcast_dim = x_shape[axis];
+    int64_t block_size = x_shape.SizeFromDimension(axis + 1);
 
-      for (size_t bs = 0; bs < static_cast<size_t>(block_size); bs++) {
-        *output++ = static_cast<float>(static_cast<int32_t>(*input++) - zp) * sc;
+    // if an axis was specified, ensure the scale and zero point are compatible
+    ORT_ENFORCE(x_scale.Shape().NumDimensions() == 1 && x_scale.Shape().Size() == broadcast_dim, "x_scale must be 1D tensor with size ", broadcast_dim);
+    ORT_ENFORCE(x_zero_point.Shape().NumDimensions() == 1 && x_zero_point.Shape().Size() == broadcast_dim, "x_zero_point must be 1D tensor with size ", broadcast_dim);
+
+    concurrency::ThreadPool::TryBatchParallelFor(
+        tp, static_cast<int32_t>(N * broadcast_dim),
+        [&](ptrdiff_t task_idx) {
+          const T* input_tmp = input + task_idx * block_size;
+          float* output_tmp = output + task_idx * block_size;
+
+          int32_t zp = static_cast<int32_t>(zero_point[task_idx % broadcast_dim]);
+          float sc = scale[task_idx % broadcast_dim];
+          for (int64_t idx = 0; idx < block_size; idx++) {
+            *output_tmp++ = static_cast<float>(static_cast<int32_t>(*input_tmp++) - zp) * sc;
+          }
+        },
+        0);
+
+  } else {
+    // if no axis, enforce that scale and zero point are scalars
+    ORT_ENFORCE(IsScalarOr1ElementVector(&x_scale), "x_scale must be a scalar or 1D tensor or size 1.");
+    ORT_ENFORCE(IsScalarOr1ElementVector(&x_zero_point), "x_zero_point must be a scalar or 1D tensor or size 1.");
+
+    concurrency::ThreadPool::TryParallelFor(tp, x_shape.Size(), 2.0 /*cost*/, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+      const T* input_tmp = input + begin;
+      float* output_tmp = output + begin;
+      float zp = static_cast<int32_t>(*zero_point);
+      float sc = *scale;
+      for (; output_tmp != output + end;) {
+        *output_tmp++ = static_cast<float>(static_cast<int32_t>(*input_tmp++) - zp) * sc;
       }
-    }
+    });
   }
 
   return Status::OK();
@@ -101,40 +110,40 @@ Status QuantizeLinear<T>::Compute(OpKernelContext* ctx) const {
   const auto& x_shape = x.Shape();
   auto& y = *ctx->Output(0, x_shape);
 
-  int64_t N;
-  int64_t broadcast_dim;
-  int64_t block_size;
-
-  if (has_axis_) {
-    const int64_t axis = HandleNegativeAxis(axis_, x_shape.NumDimensions());
-    N = x_shape.SizeToDimension(axis);
-    broadcast_dim = x_shape[axis];
-    block_size = x_shape.SizeFromDimension(axis + 1);
-
-    // if an axis was specified, ensure the scale and zero point are compatible
-    ORT_ENFORCE(y_scale.Shape().NumDimensions() == 1 && y_scale.Shape().Size() == broadcast_dim, "x_scale must be 1D tensor with size ", broadcast_dim);
-    ORT_ENFORCE(y_zero_point.Shape().NumDimensions() == 1 && y_zero_point.Shape().Size() == broadcast_dim, "x_zero_point must be 1D tensor with size ", broadcast_dim);
-  } else {
-    N = 1;
-    broadcast_dim = 1;
-    block_size = x_shape.Size();
-
-    // if no axis, enforce that scale and zero point are scalars
-    ORT_ENFORCE(IsScalarOr1ElementVector(&y_scale), "x_scale must be a scalar or 1D tensor or size 1.");
-    ORT_ENFORCE(IsScalarOr1ElementVector(&y_zero_point), "x_zero_point must be a scalar or 1D tensor or size 1.");
-  }
-
   const T* zero_point = y_zero_point.template Data<T>();
   const float* scale = y_scale.template Data<float>();
   const float* input = x.template Data<float>();
   T* output = y.template MutableData<T>();
+  concurrency::ThreadPool* tp = ctx->GetOperatorThreadPool();
 
-  for (size_t n = 0; n < static_cast<size_t>(N); n++) {
-    for (size_t bd = 0; bd < static_cast<size_t>(broadcast_dim); bd++) {
-      MlasQuantizeLinear(input, output, static_cast<size_t>(block_size), scale[bd], zero_point[bd]);
-      input += block_size;
-      output += block_size;
-    }
+  if (has_axis_) {
+    const int64_t axis = HandleNegativeAxis(axis_, x_shape.NumDimensions());
+    int64_t N = x_shape.SizeToDimension(axis);
+    int64_t broadcast_dim = x_shape[axis];
+    int64_t block_size = x_shape.SizeFromDimension(axis + 1);
+
+    // if an axis was specified, ensure the scale and zero point are compatible
+    ORT_ENFORCE(y_scale.Shape().NumDimensions() == 1 && y_scale.Shape().Size() == broadcast_dim, "x_scale must be 1D tensor with size ", broadcast_dim);
+    ORT_ENFORCE(y_zero_point.Shape().NumDimensions() == 1 && y_zero_point.Shape().Size() == broadcast_dim, "x_zero_point must be 1D tensor with size ", broadcast_dim);
+
+    concurrency::ThreadPool::TryBatchParallelFor(
+        tp, static_cast<int32_t>(N * broadcast_dim),
+        [&](ptrdiff_t task_idx) {
+          MlasQuantizeLinear(input + task_idx * block_size,
+                             output + task_idx * block_size,
+                             static_cast<size_t>(block_size),
+                             scale[task_idx % broadcast_dim],
+                             zero_point[task_idx % broadcast_dim]);
+        },
+        0);
+  } else {
+    // if no axis, enforce that scale and zero point are scalars
+    ORT_ENFORCE(IsScalarOr1ElementVector(&y_scale), "x_scale must be a scalar or 1D tensor or size 1.");
+    ORT_ENFORCE(IsScalarOr1ElementVector(&y_zero_point), "x_zero_point must be a scalar or 1D tensor or size 1.");
+
+    concurrency::ThreadPool::TryParallelFor(tp, x_shape.Size(), 2.0 /*cost*/, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+      MlasQuantizeLinear(input + begin, output + begin, end - begin, *scale, *zero_point);
+    });
   }
 
   return Status::OK();

--- a/onnxruntime/core/providers/cpu/tensor/quantize_linear.cc
+++ b/onnxruntime/core/providers/cpu/tensor/quantize_linear.cc
@@ -69,15 +69,18 @@ Status DequantizeLinear<T>::Compute(OpKernelContext* ctx) const {
     ORT_ENFORCE(IsScalarOr1ElementVector(&x_scale), "x_scale must be a scalar or 1D tensor or size 1.");
     ORT_ENFORCE(IsScalarOr1ElementVector(&x_zero_point), "x_zero_point must be a scalar or 1D tensor or size 1.");
 
-    concurrency::ThreadPool::TryParallelFor(tp, x_shape.Size(), 8.0 /*cost*/, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
-      const T* input_tmp = input + begin;
-      float* output_tmp = output + begin;
-      int32_t zp = static_cast<int32_t>(*zero_point);
-      float sc = *scale;
-      for (; output_tmp != output + end;) {
-        *output_tmp++ = static_cast<float>(static_cast<int32_t>(*input_tmp++) - zp) * sc;
-      }
-    });
+    concurrency::ThreadPool::TryParallelFor(tp,
+                                            x_shape.Size(),
+                                            TensorOpCost{4.0, 4.0, 4.0 /*cost*/},
+                                            [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+                                              const T* input_tmp = input + begin;
+                                              float* output_tmp = output + begin;
+                                              int32_t zp = static_cast<int32_t>(*zero_point);
+                                              float sc = *scale;
+                                              for (; output_tmp != output + end;) {
+                                                *output_tmp++ = static_cast<float>(static_cast<int32_t>(*input_tmp++) - zp) * sc;
+                                              }
+                                            });
   }
 
   return Status::OK();
@@ -141,9 +144,12 @@ Status QuantizeLinear<T>::Compute(OpKernelContext* ctx) const {
     ORT_ENFORCE(IsScalarOr1ElementVector(&y_scale), "x_scale must be a scalar or 1D tensor or size 1.");
     ORT_ENFORCE(IsScalarOr1ElementVector(&y_zero_point), "x_zero_point must be a scalar or 1D tensor or size 1.");
 
-    concurrency::ThreadPool::TryParallelFor(tp, x_shape.Size(), 8.0 /*cost*/, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
-      MlasQuantizeLinear(input + begin, output + begin, end - begin, *scale, *zero_point);
-    });
+    concurrency::ThreadPool::TryParallelFor(tp,
+                                            x_shape.Size(),
+                                            TensorOpCost{4.0, 4.0, 4.0 /*cost*/},
+                                            [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+                                              MlasQuantizeLinear(input + begin, output + begin, end - begin, *scale, *zero_point);
+                                            });
   }
 
   return Status::OK();

--- a/onnxruntime/test/onnx/microbenchmark/batchnorm2.cc
+++ b/onnxruntime/test/onnx/microbenchmark/batchnorm2.cc
@@ -92,4 +92,9 @@ static void BM_BatchNormOldEigen(benchmark::State& state) {
     }
   }
 }
-BENCHMARK(BM_BatchNormOldEigen)->Arg(1)->Arg(16)->Arg(64)->UseRealTime()->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK(BM_BatchNormOldEigen)
+    ->Arg(1)
+    ->Arg(16)
+    ->Arg(64)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kMicrosecond);

--- a/onnxruntime/test/onnx/microbenchmark/common.h
+++ b/onnxruntime/test/onnx/microbenchmark/common.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdlib>
+#include <malloc.h>
+#include <new>
+#include <random>
+
+// aligned memory allocate and free functions
+inline void* aligned_alloc(size_t size, size_t align) {
+  void* ptr;
+#if _MSC_VER
+  ptr = _aligned_malloc(size, align);
+  if (ptr == nullptr) throw std::bad_alloc();
+#else
+  int ret = posix_memalign(&ptr, align, size);
+  if (ret != 0) throw std::bad_alloc();
+#endif
+  return ptr;
+}
+
+inline void aligned_free(void* p) {
+#ifdef _WIN32
+  _aligned_free((void*)p);
+#else
+  ::free((void*)p);
+#endif /* _WIN32 */
+}
+
+template <typename T>
+T Clamp(T n, T lower, T upper) {
+  return std::max(lower, std::min(n, upper));
+}
+
+template <typename T>
+T* GenerateArrayWithRandomValue(size_t batch_size, T low, T high) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<float> dist(low, high);
+  T* data = (T*)aligned_alloc(sizeof(T) * batch_size, 64);
+  for (size_t i = 0; i != batch_size; ++i) {
+    data[i] = static_cast<T>(dist(gen));
+  }
+  return data;
+}

--- a/onnxruntime/test/onnx/microbenchmark/eigen.cc
+++ b/onnxruntime/test/onnx/microbenchmark/eigen.cc
@@ -44,7 +44,9 @@ static void BM_EigenBroadCast(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_EigenBroadCast)->UseRealTime()->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK(BM_EigenBroadCast)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kMicrosecond);
 
 static void BM_EigenBroadCast_SingleThread(benchmark::State& state) {
   const std::vector<size_t> dims_vec{1, 64, 75, 75};
@@ -61,4 +63,6 @@ static void BM_EigenBroadCast_SingleThread(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_EigenBroadCast_SingleThread)->UseRealTime()->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK(BM_EigenBroadCast_SingleThread)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kMicrosecond);

--- a/onnxruntime/test/onnx/microbenchmark/eigen.cc
+++ b/onnxruntime/test/onnx/microbenchmark/eigen.cc
@@ -11,7 +11,14 @@
 #pragma warning(disable : 4805)
 #pragma warning(disable : 4554)
 #endif
+
+#ifndef EIGEN_USE_THREADS
+#define EIGEN_USE_THREADS
+#endif
+
+#include <unsupported/Eigen/CXX11/ThreadPool>
 #include <unsupported/Eigen/CXX11/Tensor>
+#include <unsupported/Eigen/CXX11/src/Tensor/TensorDeviceThreadPool.h>
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #elif defined(_MSC_VER)

--- a/onnxruntime/test/onnx/microbenchmark/gelu.cc
+++ b/onnxruntime/test/onnx/microbenchmark/gelu.cc
@@ -1,39 +1,28 @@
+#include "common.h"
+
 #include <benchmark/benchmark.h>
 #include <core/util/math_cpuonly.h>
 #include <core/session/onnxruntime_c_api.h>
 #include <core/session/onnxruntime_cxx_api.h>
 #include <core/util/thread_utils.h>
 #include <core/providers/cpu/nn/pool_functors.h>
-
 #include <mlas.h>
-#include <random>
 
 using namespace onnxruntime;
-
-static float* GenerateFloatArray(size_t batch_size, float low, float high) {
-  std::random_device rd;
-  std::mt19937 gen(rd());
-  std::uniform_real_distribution<float> dist(low, high);
-  float* data = (float*)_aligned_malloc(sizeof(float) * batch_size, 64);
-  for (size_t i = 0; i != batch_size; ++i) {
-    data[i] = dist(gen);
-  }
-  return data;
-}
 
 //naive implementation of Gelu
 static void BM_GeluSingleThreadPlainLoop(benchmark::State& state) {
   const size_t batch_size = static_cast<size_t>(state.range(0));
-  float* output = (float*)_aligned_malloc(sizeof(float) * batch_size, 64);
-  float* data = GenerateFloatArray(batch_size, -1, 1);
+  float* output = (float*)aligned_alloc(sizeof(float) * batch_size, 64);
+  float* data = GenerateArrayWithRandomValue<float>(batch_size, -1, 1);
   for (auto _ : state) {
     for (size_t i = 0; i != batch_size; ++i) {
       float x = data[i];
       output[i] = x * 0.5f * (1.0f + std::erf(x * static_cast<float>(M_SQRT1_2)));
     }
   }
-  _aligned_free(data);
-  _aligned_free(output);
+  aligned_free(data);
+  aligned_free(output);
 }
 
 //Use eigen and mlas to implement Gelu, single thread
@@ -41,8 +30,8 @@ BENCHMARK(BM_GeluSingleThreadPlainLoop)->UseRealTime()->UseRealTime()->Unit(benc
 
 static void BM_GeluSingleThreadMlas(benchmark::State& state) {
   const size_t batch_size = static_cast<size_t>(state.range(0));
-  float* output = (float*)_aligned_malloc(sizeof(float) * batch_size, 64);
-  float* data = GenerateFloatArray(batch_size, -1, 1);
+  float* output = (float*)aligned_alloc(sizeof(float) * batch_size, 64);
+  float* data = GenerateArrayWithRandomValue<float>(batch_size, -1, 1);
   for (auto _ : state) {
     onnxruntime::ConstEigenVectorArrayMap<float> xm(data, batch_size);
     onnxruntime::EigenVectorArrayMap<float> ym(output, batch_size);
@@ -50,8 +39,8 @@ static void BM_GeluSingleThreadMlas(benchmark::State& state) {
     MlasComputeErf(output, output, batch_size);
     ym = xm * 0.5f * (ym + 1.0f);
   }
-  _aligned_free(data);
-  _aligned_free(output);
+  aligned_free(data);
+  aligned_free(output);
 }
 
 BENCHMARK(BM_GeluSingleThreadMlas)->UseRealTime()->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100)->Arg(1000)->Arg(10000)->Arg(20000)->Arg(40000);
@@ -60,8 +49,8 @@ BENCHMARK(BM_GeluSingleThreadMlas)->UseRealTime()->UseRealTime()->Unit(benchmark
 static void BM_GeluParallelFor(benchmark::State& state) {
   const size_t batch_size = static_cast<size_t>(state.range(0));
   const int cost = static_cast<int>(state.range(1));
-  float* output = (float*)_aligned_malloc(sizeof(float) * batch_size, 64);
-  float* data = GenerateFloatArray(batch_size, -1, 1);
+  float* output = (float*)aligned_alloc(sizeof(float) * batch_size, 64);
+  float* data = GenerateArrayWithRandomValue<float>(batch_size, -1, 1);
   OrtThreadPoolParams tpo;
   tpo.auto_set_affinity = true;
   std::unique_ptr<concurrency::ThreadPool> tp(
@@ -77,8 +66,8 @@ static void BM_GeluParallelFor(benchmark::State& state) {
       ym = xm * 0.5f * (ym + 1.0f);
     });
   }
-  _aligned_free(data);
-  _aligned_free(output);
+  aligned_free(data);
+  aligned_free(output);
 }
 
 BENCHMARK(BM_GeluParallelFor)->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Args({1000, 1})->Args({1000, 5})->Args({1000, 10})->Args({1000, 40})->Args({2500, 1})->Args({2500, 5})->Args({2500, 10})->Args({2500, 40})->Args({2500, 80})->Args({2500, 160})->Args({5000, 1})->Args({5000, 5})->Args({5000, 10})->Args({5000, 40})->Args({5000, 80})->Args({5000, 160})->Args({10000, 1})->Args({10000, 5})->Args({10000, 10})->Args({10000, 40})->Args({20000, 1})->Args({20000, 5})->Args({20000, 10})->Args({20000, 40})->Args({40000, 1})->Args({40000, 5})->Args({40000, 10})->Args({40000, 40})->Args({98304, 1})->Args({98304, 5})->Args({98304, 10})->Args({98304, 40})->Args({1572864, 1})->Args({1572864, 5})->Args({1572864, 10})->Args({1572864, 40});
@@ -86,8 +75,8 @@ BENCHMARK(BM_GeluParallelFor)->UseRealTime()->Unit(benchmark::TimeUnit::kNanosec
 static void BM_ScaledTanhParallelFor(benchmark::State& state) {
   const size_t batch_size = static_cast<size_t>(state.range(0));
   const int cost = static_cast<int>(state.range(1));
-  float* output = (float*)_aligned_malloc(sizeof(float) * batch_size, 64);
-  float* data = GenerateFloatArray(batch_size, -1, 1);
+  float* output = (float*)aligned_alloc(sizeof(float) * batch_size, 64);
+  float* data = GenerateArrayWithRandomValue<float>(batch_size, -1, 1);
   OrtThreadPoolParams tpo;
   tpo.auto_set_affinity = true;
   std::unique_ptr<concurrency::ThreadPool> tp(
@@ -103,8 +92,8 @@ static void BM_ScaledTanhParallelFor(benchmark::State& state) {
       ym = (xm >= 0).select(xm, alpha_ * (xm.exp() - 1));
     });
   }
-  _aligned_free(data);
-  _aligned_free(output);
+  aligned_free(data);
+  aligned_free(output);
 }
 
 BENCHMARK(BM_ScaledTanhParallelFor)->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Args({1000, 1})->Args({1000, 5})->Args({1000, 10})->Args({1000, 40})->Args({2500, 1})->Args({2500, 5})->Args({2500, 10})->Args({2500, 40})->Args({2500, 80})->Args({2500, 160})->Args({5000, 1})->Args({5000, 5})->Args({5000, 10})->Args({5000, 40})->Args({5000, 80})->Args({5000, 160})->Args({10000, 1})->Args({10000, 5})->Args({10000, 10})->Args({10000, 40})->Args({20000, 1})->Args({20000, 5})->Args({20000, 10})->Args({20000, 40})->Args({40000, 1})->Args({40000, 5})->Args({40000, 10})->Args({40000, 40});
@@ -125,10 +114,9 @@ static void TestPartitionWork(std::ptrdiff_t ThreadId, std::ptrdiff_t ThreadCoun
 
 static void BM_GeluBatchParallelFor(benchmark::State& state) {
   const size_t batch_size = static_cast<size_t>(state.range(0));
-  const int cost = static_cast<int>(state.range(1));
 
-  float* output = (float*)_aligned_malloc(sizeof(float) * batch_size, 64);
-  float* data = GenerateFloatArray(batch_size, -1, 1);
+  float* output = (float*)aligned_alloc(sizeof(float) * batch_size, 64);
+  float* data = GenerateArrayWithRandomValue<float>(batch_size, -1, 1);
   OrtThreadPoolParams tpo;
   tpo.auto_set_affinity = true;
   std::unique_ptr<concurrency::ThreadPool> tp(
@@ -146,8 +134,8 @@ static void BM_GeluBatchParallelFor(benchmark::State& state) {
       ym = xm * 0.5f * (ym + 1.0f);
     });
   }
-  _aligned_free(data);
-  _aligned_free(output);
+  aligned_free(data);
+  aligned_free(output);
 }
 
 BENCHMARK(BM_GeluBatchParallelFor)->UseRealTime()->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100)->Arg(1000)->Arg(10000)->Arg(20000)->Arg(40000);
@@ -155,15 +143,14 @@ BENCHMARK(BM_GeluBatchParallelFor)->UseRealTime()->UseRealTime()->Unit(benchmark
 //The one we're currently using
 static void BM_GeluBatchParallelFor2(benchmark::State& state) {
   const size_t elem_count = static_cast<size_t>(state.range(0));
-  const int cost = static_cast<int>(state.range(1));
 
-  float* output_data = (float*)_aligned_malloc(sizeof(float) * elem_count, 64);
-  float* input_data = GenerateFloatArray(elem_count, -1, 1);
+  float* output_data = (float*)aligned_alloc(sizeof(float) * elem_count, 64);
+  float* input_data = GenerateArrayWithRandomValue<float>(elem_count, -1, 1);
   OrtThreadPoolParams tpo;
   tpo.auto_set_affinity = true;
   std::unique_ptr<concurrency::ThreadPool> tp(
       concurrency::CreateThreadPool(&onnxruntime::Env::Default(), tpo, concurrency::ThreadPoolType::INTRA_OP));
-  const int num_batches = 4;
+
   using T = float;
   static const int64_t length_per_task = 4096;  // this number comes from FastGelu.
   int64_t task_count = (elem_count + length_per_task - 1) / length_per_task;
@@ -189,17 +176,16 @@ static void BM_GeluBatchParallelFor2(benchmark::State& state) {
         },
         0);
   }
-  _aligned_free(input_data);
-  _aligned_free(output_data);
+  aligned_free(input_data);
+  aligned_free(output_data);
 }
 
 BENCHMARK(BM_GeluBatchParallelFor2)->UseRealTime()->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100)->Arg(1000)->Arg(10000)->Arg(20000)->Arg(40000)->Arg(98304)->Arg(1572864);
 
 static void BM_GeluBatchParallelFor3(benchmark::State& state) {
   const size_t batch_size = static_cast<size_t>(state.range(0));
-  const int cost = static_cast<int>(state.range(1));
-  float* output = (float*)_aligned_malloc(sizeof(float) * batch_size, 64);
-  float* data = GenerateFloatArray(batch_size, -1, 1);
+  float* output = (float*)aligned_alloc(sizeof(float) * batch_size, 64);
+  float* data = GenerateArrayWithRandomValue<float>(batch_size, -1, 1);
   OrtThreadPoolParams tpo;
   tpo.auto_set_affinity = true;
   std::unique_ptr<concurrency::ThreadPool> tp(
@@ -216,8 +202,8 @@ static void BM_GeluBatchParallelFor3(benchmark::State& state) {
       ym = xm * 0.5f * (ym + 1.0f);
     });
   }
-  _aligned_free(data);
-  _aligned_free(output);
+  aligned_free(data);
+  aligned_free(output);
 }
 
 BENCHMARK(BM_GeluBatchParallelFor3)->UseRealTime()->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100)->Arg(1000)->Arg(10000)->Arg(20000)->Arg(40000)->Arg(98304)->Arg(1572864);

--- a/onnxruntime/test/onnx/microbenchmark/gelu.cc
+++ b/onnxruntime/test/onnx/microbenchmark/gelu.cc
@@ -26,7 +26,15 @@ static void BM_GeluSingleThreadPlainLoop(benchmark::State& state) {
 }
 
 //Use eigen and mlas to implement Gelu, single thread
-BENCHMARK(BM_GeluSingleThreadPlainLoop)->UseRealTime()->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100)->Arg(1000)->Arg(10000)->Arg(20000)->Arg(40000);
+BENCHMARK(BM_GeluSingleThreadPlainLoop)
+    ->UseRealTime()
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(20000)
+    ->Arg(40000);
 
 static void BM_GeluSingleThreadMlas(benchmark::State& state) {
   const size_t batch_size = static_cast<size_t>(state.range(0));
@@ -43,7 +51,15 @@ static void BM_GeluSingleThreadMlas(benchmark::State& state) {
   aligned_free(output);
 }
 
-BENCHMARK(BM_GeluSingleThreadMlas)->UseRealTime()->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100)->Arg(1000)->Arg(10000)->Arg(20000)->Arg(40000);
+BENCHMARK(BM_GeluSingleThreadMlas)
+    ->UseRealTime()
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(20000)
+    ->Arg(40000);
 
 //Use ParallelFor to implement Gelu, single thread
 static void BM_GeluParallelFor(benchmark::State& state) {
@@ -70,7 +86,45 @@ static void BM_GeluParallelFor(benchmark::State& state) {
   aligned_free(output);
 }
 
-BENCHMARK(BM_GeluParallelFor)->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Args({1000, 1})->Args({1000, 5})->Args({1000, 10})->Args({1000, 40})->Args({2500, 1})->Args({2500, 5})->Args({2500, 10})->Args({2500, 40})->Args({2500, 80})->Args({2500, 160})->Args({5000, 1})->Args({5000, 5})->Args({5000, 10})->Args({5000, 40})->Args({5000, 80})->Args({5000, 160})->Args({10000, 1})->Args({10000, 5})->Args({10000, 10})->Args({10000, 40})->Args({20000, 1})->Args({20000, 5})->Args({20000, 10})->Args({20000, 40})->Args({40000, 1})->Args({40000, 5})->Args({40000, 10})->Args({40000, 40})->Args({98304, 1})->Args({98304, 5})->Args({98304, 10})->Args({98304, 40})->Args({1572864, 1})->Args({1572864, 5})->Args({1572864, 10})->Args({1572864, 40});
+BENCHMARK(BM_GeluParallelFor)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Args({1000, 1})
+    ->Args({1000, 5})
+    ->Args({1000, 10})
+    ->Args({1000, 40})
+    ->Args({2500, 1})
+    ->Args({2500, 5})
+    ->Args({2500, 10})
+    ->Args({2500, 40})
+    ->Args({2500, 80})
+    ->Args({2500, 160})
+    ->Args({5000, 1})
+    ->Args({5000, 5})
+    ->Args({5000, 10})
+    ->Args({5000, 40})
+    ->Args({5000, 80})
+    ->Args({5000, 160})
+    ->Args({10000, 1})
+    ->Args({10000, 5})
+    ->Args({10000, 10})
+    ->Args({10000, 40})
+    ->Args({20000, 1})
+    ->Args({20000, 5})
+    ->Args({20000, 10})
+    ->Args({20000, 40})
+    ->Args({40000, 1})
+    ->Args({40000, 5})
+    ->Args({40000, 10})
+    ->Args({40000, 40})
+    ->Args({98304, 1})
+    ->Args({98304, 5})
+    ->Args({98304, 10})
+    ->Args({98304, 40})
+    ->Args({1572864, 1})
+    ->Args({1572864, 5})
+    ->Args({1572864, 10})
+    ->Args({1572864, 40});
 
 static void BM_ScaledTanhParallelFor(benchmark::State& state) {
   const size_t batch_size = static_cast<size_t>(state.range(0));
@@ -96,7 +150,37 @@ static void BM_ScaledTanhParallelFor(benchmark::State& state) {
   aligned_free(output);
 }
 
-BENCHMARK(BM_ScaledTanhParallelFor)->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Args({1000, 1})->Args({1000, 5})->Args({1000, 10})->Args({1000, 40})->Args({2500, 1})->Args({2500, 5})->Args({2500, 10})->Args({2500, 40})->Args({2500, 80})->Args({2500, 160})->Args({5000, 1})->Args({5000, 5})->Args({5000, 10})->Args({5000, 40})->Args({5000, 80})->Args({5000, 160})->Args({10000, 1})->Args({10000, 5})->Args({10000, 10})->Args({10000, 40})->Args({20000, 1})->Args({20000, 5})->Args({20000, 10})->Args({20000, 40})->Args({40000, 1})->Args({40000, 5})->Args({40000, 10})->Args({40000, 40});
+BENCHMARK(BM_ScaledTanhParallelFor)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Args({1000, 1})
+    ->Args({1000, 5})
+    ->Args({1000, 10})
+    ->Args({1000, 40})
+    ->Args({2500, 1})
+    ->Args({2500, 5})
+    ->Args({2500, 10})
+    ->Args({2500, 40})
+    ->Args({2500, 80})
+    ->Args({2500, 160})
+    ->Args({5000, 1})
+    ->Args({5000, 5})
+    ->Args({5000, 10})
+    ->Args({5000, 40})
+    ->Args({5000, 80})
+    ->Args({5000, 160})
+    ->Args({10000, 1})
+    ->Args({10000, 5})
+    ->Args({10000, 10})
+    ->Args({10000, 40})
+    ->Args({20000, 1})
+    ->Args({20000, 5})
+    ->Args({20000, 10})
+    ->Args({20000, 40})
+    ->Args({40000, 1})
+    ->Args({40000, 5})
+    ->Args({40000, 10})
+    ->Args({40000, 40});
 
 static void TestPartitionWork(std::ptrdiff_t ThreadId, std::ptrdiff_t ThreadCount, std::ptrdiff_t TotalWork,
                               std::ptrdiff_t* WorkIndex, std::ptrdiff_t* WorkRemaining) {
@@ -138,7 +222,15 @@ static void BM_GeluBatchParallelFor(benchmark::State& state) {
   aligned_free(output);
 }
 
-BENCHMARK(BM_GeluBatchParallelFor)->UseRealTime()->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100)->Arg(1000)->Arg(10000)->Arg(20000)->Arg(40000);
+BENCHMARK(BM_GeluBatchParallelFor)
+    ->UseRealTime()
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(20000)
+    ->Arg(40000);
 
 //The one we're currently using
 static void BM_GeluBatchParallelFor2(benchmark::State& state) {
@@ -180,7 +272,17 @@ static void BM_GeluBatchParallelFor2(benchmark::State& state) {
   aligned_free(output_data);
 }
 
-BENCHMARK(BM_GeluBatchParallelFor2)->UseRealTime()->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100)->Arg(1000)->Arg(10000)->Arg(20000)->Arg(40000)->Arg(98304)->Arg(1572864);
+BENCHMARK(BM_GeluBatchParallelFor2)
+    ->UseRealTime()
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(20000)
+    ->Arg(40000)
+    ->Arg(98304)
+    ->Arg(1572864);
 
 static void BM_GeluBatchParallelFor3(benchmark::State& state) {
   const size_t batch_size = static_cast<size_t>(state.range(0));
@@ -206,4 +308,14 @@ static void BM_GeluBatchParallelFor3(benchmark::State& state) {
   aligned_free(output);
 }
 
-BENCHMARK(BM_GeluBatchParallelFor3)->UseRealTime()->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100)->Arg(1000)->Arg(10000)->Arg(20000)->Arg(40000)->Arg(98304)->Arg(1572864);
+BENCHMARK(BM_GeluBatchParallelFor3)
+    ->UseRealTime()
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(20000)
+    ->Arg(40000)
+    ->Arg(98304)
+    ->Arg(1572864);

--- a/onnxruntime/test/onnx/microbenchmark/main.cc
+++ b/onnxruntime/test/onnx/microbenchmark/main.cc
@@ -33,7 +33,9 @@ static void BM_CPUAllocator(benchmark::State& state) {
     cpu_allocator->Free(p);
   }
 }
-BENCHMARK(BM_CPUAllocator)->Arg(4)->Arg(sizeof(Tensor));
+BENCHMARK(BM_CPUAllocator)
+    ->Arg(4)
+    ->Arg(sizeof(Tensor));
 
 static void BM_ResolveGraph(benchmark::State& state) {
   std::shared_ptr<onnxruntime::Model> model_copy;
@@ -70,7 +72,6 @@ BENCHMARK(BM_ResolveGraph);
       abort();                                               \
     }                                                        \
   } while (0);
-
 
 int main(int argc, char** argv) {
   ::benchmark::Initialize(&argc, argv);

--- a/onnxruntime/test/onnx/microbenchmark/pooling.cc
+++ b/onnxruntime/test/onnx/microbenchmark/pooling.cc
@@ -80,10 +80,26 @@ static void BM_MlasPoolNoSpinWithAffinity(benchmark::State& state) {
   RunMlasPool2D(param, batch_size, state);
 }
 
-BENCHMARK(BM_MlasPoolWithSpinAndAffinity)->UseRealTime()->Arg(1)->Arg(4)->Unit(benchmark::TimeUnit::kMicrosecond);
-BENCHMARK(BM_MlasPoolWithSpinNoAffinity)->UseRealTime()->Arg(1)->Arg(4)->Unit(benchmark::TimeUnit::kMicrosecond);
-BENCHMARK(BM_MlasPoolNoSpinWithAffinity)->UseRealTime()->Arg(1)->Arg(4)->Unit(benchmark::TimeUnit::kMicrosecond);
-BENCHMARK(BM_MlasPoolNoSpinNoAffinity)->UseRealTime()->Arg(1)->Arg(4)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK(BM_MlasPoolWithSpinAndAffinity)
+    ->UseRealTime()
+    ->Arg(1)
+    ->Arg(4)
+    ->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK(BM_MlasPoolWithSpinNoAffinity)
+    ->UseRealTime()
+    ->Arg(1)
+    ->Arg(4)
+    ->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK(BM_MlasPoolNoSpinWithAffinity)
+    ->UseRealTime()
+    ->Arg(1)
+    ->Arg(4)
+    ->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK(BM_MlasPoolNoSpinNoAffinity)
+    ->UseRealTime()
+    ->Arg(1)
+    ->Arg(4)
+    ->Unit(benchmark::TimeUnit::kMicrosecond);
 
 static void RunPool2D(const OrtThreadPoolParams& param, int64_t batch_size, benchmark::State& state) {
   std::unique_ptr<ThreadPool> tp = CreateThreadPool(&onnxruntime::Env::Default(), param, onnxruntime::concurrency::ThreadPoolType::INTRA_OP);
@@ -130,5 +146,13 @@ static void BM_PoolSingleThread(benchmark::State& state) {
   RunPool2D(param, batch_size, state);
 }
 
-BENCHMARK(BM_Pool2D)->UseRealTime()->Arg(1)->Arg(4)->Unit(benchmark::TimeUnit::kMicrosecond);
-BENCHMARK(BM_PoolSingleThread)->UseRealTime()->Arg(1)->Arg(4)->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK(BM_Pool2D)
+    ->UseRealTime()
+    ->Arg(1)
+    ->Arg(4)
+    ->Unit(benchmark::TimeUnit::kMicrosecond);
+BENCHMARK(BM_PoolSingleThread)
+    ->UseRealTime()
+    ->Arg(1)
+    ->Arg(4)
+    ->Unit(benchmark::TimeUnit::kMicrosecond);

--- a/onnxruntime/test/onnx/microbenchmark/quantizelinear.cc
+++ b/onnxruntime/test/onnx/microbenchmark/quantizelinear.cc
@@ -33,11 +33,16 @@ BENCHMARK(BM_QuantizeLinearSingleThreadPlainLoop)
     ->UseRealTime()
     ->UseRealTime()
     ->Unit(benchmark::TimeUnit::kNanosecond)
-    ->Arg(100)
     ->Arg(1000)
     ->Arg(10000)
     ->Arg(20000)
-    ->Arg(40000);
+    ->Arg(40000)
+    ->Arg(80000)
+    ->Arg(98304)
+    ->Arg(160000)
+    ->Arg(320000)
+    ->Arg(640000)
+    ->Arg(1280000);
 
 //Use mlas to implement QuantizeLinear
 static void BM_QuantizeLinearSingleThreadMlas(benchmark::State& state) {
@@ -58,14 +63,16 @@ BENCHMARK(BM_QuantizeLinearSingleThreadMlas)
     ->UseRealTime()
     ->UseRealTime()
     ->Unit(benchmark::TimeUnit::kNanosecond)
-    ->Arg(100)
     ->Arg(1000)
     ->Arg(10000)
     ->Arg(20000)
     ->Arg(40000)
     ->Arg(80000)
     ->Arg(98304)
-    ->Arg(1572864);
+    ->Arg(160000)
+    ->Arg(320000)
+    ->Arg(640000)
+    ->Arg(1280000);
 
 //Use ParallelFor to implement Gelu, single thread
 static void BM_QuantizeLinearParallelFor(benchmark::State& state) {
@@ -95,14 +102,15 @@ BENCHMARK(BM_QuantizeLinearParallelFor)
     ->UseRealTime()
     ->Unit(benchmark::TimeUnit::kNanosecond)
     ->Arg(1000)
-    ->Arg(2500)
-    ->Arg(5000)
     ->Arg(10000)
     ->Arg(20000)
     ->Arg(40000)
     ->Arg(80000)
     ->Arg(98304)
-    ->Arg(1572864);
+    ->Arg(160000)
+    ->Arg(320000)
+    ->Arg(640000)
+    ->Arg(1280000);
 
 static void BM_DequantizeLinearSingleThread(benchmark::State& state) {
   const float sc = 0.1f;
@@ -124,14 +132,16 @@ BENCHMARK(BM_DequantizeLinearSingleThread)
     ->UseRealTime()
     ->UseRealTime()
     ->Unit(benchmark::TimeUnit::kNanosecond)
-    ->Arg(100)
     ->Arg(1000)
     ->Arg(10000)
     ->Arg(20000)
     ->Arg(40000)
     ->Arg(80000)
     ->Arg(98304)
-    ->Arg(1572864);
+    ->Arg(160000)
+    ->Arg(320000)
+    ->Arg(640000)
+    ->Arg(1280000);
 
 static void BM_DequantizeLinearParallelFor(benchmark::State& state) {
   const float sc = 0.1f;
@@ -162,11 +172,13 @@ BENCHMARK(BM_DequantizeLinearParallelFor)
     ->UseRealTime()
     ->UseRealTime()
     ->Unit(benchmark::TimeUnit::kNanosecond)
-    ->Arg(100)
     ->Arg(1000)
     ->Arg(10000)
     ->Arg(20000)
     ->Arg(40000)
     ->Arg(80000)
     ->Arg(98304)
-    ->Arg(1572864);
+    ->Arg(160000)
+    ->Arg(320000)
+    ->Arg(640000)
+    ->Arg(1280000);

--- a/onnxruntime/test/onnx/microbenchmark/quantizelinear.cc
+++ b/onnxruntime/test/onnx/microbenchmark/quantizelinear.cc
@@ -1,0 +1,171 @@
+#include "common.h"
+
+#include <benchmark/benchmark.h>
+#include <core/util/math_cpuonly.h>
+#include <core/session/onnxruntime_c_api.h>
+#include <core/session/onnxruntime_cxx_api.h>
+#include <core/util/thread_utils.h>
+#include <core/providers/cpu/nn/pool_functors.h>
+
+#include <mlas.h>
+
+using namespace onnxruntime;
+
+//naive implementation of QuantizeLinear
+static void BM_QuantizeLinearSingleThreadPlainLoop(benchmark::State& state) {
+  const float scale = 0.1f;
+  const uint8_t zero_point = 127;
+
+  const size_t batch_size = static_cast<size_t>(state.range(0));
+  uint8_t* output = (uint8_t*)aligned_alloc(sizeof(uint8_t) * batch_size, 64);
+  float* data = GenerateArrayWithRandomValue<float>(batch_size, -1, 1);
+  for (auto _ : state) {
+    for (size_t i = 0; i != batch_size; ++i) {
+      float x = data[i];
+      output[i] = static_cast<int8_t>(Clamp<int>(static_cast<int>(x / scale + zero_point), 0, 255));
+    }
+  }
+  aligned_free(data);
+  aligned_free(output);
+}
+
+BENCHMARK(BM_QuantizeLinearSingleThreadPlainLoop)
+    ->UseRealTime()
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(20000)
+    ->Arg(40000);
+
+//Use mlas to implement QuantizeLinear
+static void BM_QuantizeLinearSingleThreadMlas(benchmark::State& state) {
+  const float scale = 0.1f;
+  const uint8_t zero_point = 127;
+
+  const size_t batch_size = static_cast<size_t>(state.range(0));
+  uint8_t* output = (uint8_t*)aligned_alloc(sizeof(uint8_t) * batch_size, 64);
+  float* data = GenerateArrayWithRandomValue<float>(batch_size, -1, 1);
+  for (auto _ : state) {
+    MlasQuantizeLinear(data, output, batch_size, scale, zero_point);
+  }
+  aligned_free(data);
+  aligned_free(output);
+}
+
+BENCHMARK(BM_QuantizeLinearSingleThreadMlas)
+    ->UseRealTime()
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(20000)
+    ->Arg(40000)
+    ->Arg(80000)
+    ->Arg(98304)
+    ->Arg(1572864);
+
+//Use ParallelFor to implement Gelu, single thread
+static void BM_QuantizeLinearParallelFor(benchmark::State& state) {
+  const float scale = 0.1f;
+  const uint8_t zero_point = 127;
+
+  const size_t batch_size = static_cast<size_t>(state.range(0));
+  uint8_t* output = (uint8_t*)aligned_alloc(sizeof(uint8_t) * batch_size, 64);
+  float* data = GenerateArrayWithRandomValue<float>(batch_size, -1, 1);
+  OrtThreadPoolParams tpo;
+  tpo.auto_set_affinity = true;
+  std::unique_ptr<concurrency::ThreadPool> tp(
+      concurrency::CreateThreadPool(&onnxruntime::Env::Default(), tpo, concurrency::ThreadPoolType::INTRA_OP));
+  for (auto _ : state) {
+    concurrency::ThreadPool::TryParallelFor(tp.get(), batch_size, 10.0 /*cost*/, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+      MlasQuantizeLinear(data + begin, output + begin, end - begin, scale, zero_point);
+    });
+  }
+  aligned_free(data);
+  aligned_free(output);
+}
+
+BENCHMARK(BM_QuantizeLinearParallelFor)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(1000)
+    ->Arg(2500)
+    ->Arg(5000)
+    ->Arg(10000)
+    ->Arg(20000)
+    ->Arg(40000)
+    ->Arg(80000)
+    ->Arg(98304)
+    ->Arg(1572864);
+
+static void BM_DequantizeLinearSingleThread(benchmark::State& state) {
+  const float sc = 0.1f;
+  const uint8_t zp = 127;
+
+  const size_t batch_size = static_cast<size_t>(state.range(0));
+  float* output = (float*)aligned_alloc(sizeof(float) * batch_size, 64);
+  uint8_t* data = GenerateArrayWithRandomValue<uint8_t>(batch_size, 0, 255);
+  for (auto _ : state) {
+    for (size_t idx = 0; idx < batch_size; idx++) {
+      output[idx] = static_cast<float>(static_cast<int32_t>(data[idx]) - zp) * sc;
+    }
+  }
+  aligned_free(data);
+  aligned_free(output);
+}
+
+BENCHMARK(BM_DequantizeLinearSingleThread)
+    ->UseRealTime()
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(20000)
+    ->Arg(40000)
+    ->Arg(80000)
+    ->Arg(98304)
+    ->Arg(1572864);
+
+static void BM_DequantizeLinearParallelFor(benchmark::State& state) {
+  const float sc = 0.1f;
+  const uint8_t zp = 127;
+
+  const size_t batch_size = static_cast<size_t>(state.range(0));
+  float* output = (float*)aligned_alloc(sizeof(float) * batch_size, 64);
+  uint8_t* data = GenerateArrayWithRandomValue<uint8_t>(batch_size, 0, 255);
+
+  OrtThreadPoolParams tpo;
+  tpo.auto_set_affinity = true;
+  std::unique_ptr<concurrency::ThreadPool> tp(
+      concurrency::CreateThreadPool(&onnxruntime::Env::Default(), tpo, concurrency::ThreadPoolType::INTRA_OP));
+
+  for (auto _ : state) {
+    concurrency::ThreadPool::TryParallelFor(tp.get(), batch_size, 10.0 /*cost*/, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+      const uint8_t* input_tmp = data + begin;
+      float* output_tmp = output + begin;
+      for (; output_tmp != output + end;) {
+        *output_tmp++ = static_cast<float>(static_cast<int32_t>(*input_tmp++) - zp) * sc;
+      }
+    });
+  }
+  aligned_free(data);
+  aligned_free(output);
+}
+
+BENCHMARK(BM_DequantizeLinearParallelFor)
+    ->UseRealTime()
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(20000)
+    ->Arg(40000)
+    ->Arg(80000)
+    ->Arg(98304)
+    ->Arg(1572864);
+

--- a/onnxruntime/test/onnx/microbenchmark/quantizelinear.cc
+++ b/onnxruntime/test/onnx/microbenchmark/quantizelinear.cc
@@ -168,4 +168,3 @@ BENCHMARK(BM_DequantizeLinearParallelFor)
     ->Arg(80000)
     ->Arg(98304)
     ->Arg(1572864);
-

--- a/onnxruntime/test/onnx/microbenchmark/tptest.cc
+++ b/onnxruntime/test/onnx/microbenchmark/tptest.cc
@@ -15,7 +15,9 @@ static void BM_CreateThreadPool(benchmark::State& state) {
     ThreadPool tp(&onnxruntime::Env::Default(), onnxruntime::ThreadOptions(), ORT_TSTR(""), 48, true);
   }
 }
-BENCHMARK(BM_CreateThreadPool)->UseRealTime()->Unit(benchmark::TimeUnit::kMillisecond);
+BENCHMARK(BM_CreateThreadPool)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kMillisecond);
 
 //On Xeon W-2123 CPU, it takes about 2ns for each iteration
 #ifdef _WIN32
@@ -46,7 +48,37 @@ static void BM_ThreadPoolParallelFor(benchmark::State& state) {
     tp->ParallelFor(len, cost, SimpleForLoop);
   }
 }
-BENCHMARK(BM_ThreadPoolParallelFor)->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Args({100, 1})->Args({100, 10})->Args({100, 100})->Args({100, 200})->Args({100, 400})->Args({1000, 1})->Args({1000, 10})->Args({1000, 100})->Args({1000, 200})->Args({1000, 400})->Args({10000, 1})->Args({10000, 10})->Args({10000, 100})->Args({10000, 200})->Args({10000, 400})->Args({15000, 1})->Args({15000, 10})->Args({15000, 100})->Args({15000, 200})->Args({15000, 400})->Args({20000, 1})->Args({20000, 10})->Args({20000, 100})->Args({20000, 200})->Args({20000, 400})->Args({40000, 200})->Args({80000, 200})->Args({160000, 200});
+BENCHMARK(BM_ThreadPoolParallelFor)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Args({100, 1})
+    ->Args({100, 10})
+    ->Args({100, 100})
+    ->Args({100, 200})
+    ->Args({100, 400})
+    ->Args({1000, 1})
+    ->Args({1000, 10})
+    ->Args({1000, 100})
+    ->Args({1000, 200})
+    ->Args({1000, 400})
+    ->Args({10000, 1})
+    ->Args({10000, 10})
+    ->Args({10000, 100})
+    ->Args({10000, 200})
+    ->Args({10000, 400})
+    ->Args({15000, 1})
+    ->Args({15000, 10})
+    ->Args({15000, 100})
+    ->Args({15000, 200})
+    ->Args({15000, 400})
+    ->Args({20000, 1})
+    ->Args({20000, 10})
+    ->Args({20000, 100})
+    ->Args({20000, 200})
+    ->Args({20000, 400})
+    ->Args({40000, 200})
+    ->Args({80000, 200})
+    ->Args({160000, 200});
 
 static void BM_SimpleForLoop(benchmark::State& state) {
   const size_t len = state.range(0);
@@ -54,7 +86,9 @@ static void BM_SimpleForLoop(benchmark::State& state) {
     SimpleForLoop(0, len);
   }
 }
-BENCHMARK(BM_SimpleForLoop)->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100);
+BENCHMARK(BM_SimpleForLoop)
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(100);
 
 static void TestPartitionWork(std::ptrdiff_t ThreadId, std::ptrdiff_t ThreadCount, std::ptrdiff_t TotalWork,
                               std::ptrdiff_t* WorkIndex, std::ptrdiff_t* WorkRemaining) {
@@ -91,7 +125,16 @@ static void BM_SimpleScheduleWait(benchmark::State& state) {
     barrier.Wait();
   }
 }
-BENCHMARK(BM_SimpleScheduleWait)->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100)->Arg(1000)->Arg(10000)->Arg(20000)->Arg(40000)->Arg(80000)->Arg(160000);
+BENCHMARK(BM_SimpleScheduleWait)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(20000)
+    ->Arg(40000)
+    ->Arg(80000)
+    ->Arg(160000);
 
 #ifdef _WIN32
 struct Param {
@@ -127,5 +170,16 @@ static void BM_SimpleScheduleWaitWindowsTP(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_SimpleScheduleWaitWindowsTP)->UseRealTime()->Unit(benchmark::TimeUnit::kNanosecond)->Arg(100)->Arg(1000)->Arg(10000)->Arg(20000)->Arg(40000)->Arg(80000)->Arg(160000)->Arg(320000)->Arg(640000);
+BENCHMARK(BM_SimpleScheduleWaitWindowsTP)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(20000)
+    ->Arg(40000)
+    ->Arg(80000)
+    ->Arg(160000)
+    ->Arg(320000)
+    ->Arg(640000);
 #endif


### PR DESCRIPTION
**Description**: Describe your changes.
I used the MicroBenchmark to tune the TensorOpCost on my local machine with 6 cores. For small size (less than 80000), it uses single thread. For size(80000~100000), I see ~2x speedup. For very large data size, I see up to ~5x speedup.
**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
