### PR TITLE
Extend workaround with input name matching in DML fused graph kernel

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
@@ -205,6 +205,14 @@ namespace Dml::GraphDescBuilder
                 if (arg->Exists())
                 {
                     auto iter = nameToFusedNodeInputIndex.find(arg->Name());
+
+                    // The graph input could be missing the suffix, so try to match without it.
+                    // This is part of a temporary workaround; see comments in GetFusedNodeArgNameMatchingGraph.
+                    if (iter == nameToFusedNodeInputIndex.end())
+                    {
+                        iter = nameToFusedNodeInputIndex.find(GetFusedNodeArgNameMatchingGraph(arg->Name()));
+                    }
+
                     if (iter != nameToFusedNodeInputIndex.end())
                     {
                         // This is a graph input


### PR DESCRIPTION
This extends a temporary workaround to match node inputs to graph inputs within the DirectML kernel for fused graph partitions.

This is needed to fix a customer model following the below change.
https://github.com/microsoft/onnxruntime/pull/3649

While this workaround should still be removed, a low-risk change is needed for the 1.3 release.
