### PR TITLE
Add NNAPI in the exclude list

### DIFF
--- a/onnxruntime/core/optimizer/transformer_memcpy.cc
+++ b/onnxruntime/core/optimizer/transformer_memcpy.cc
@@ -74,6 +74,7 @@ common::Status MemcpyTransformer::ApplyImpl(Graph& graph, bool& modified, int gr
         provider != onnxruntime::kNGraphExecutionProvider &&
         provider != onnxruntime::kNupharExecutionProvider &&
         provider != onnxruntime::kOpenVINOExecutionProvider &&
+        provider != onnxruntime::kNnapiExecutionProvider &&
         provider != onnxruntime::kAclExecutionProvider) {
       TransformerMemcpyImpl copy_impl(graph, provider);
       auto current_modified = copy_impl.ModifyGraph(registry_manager_);


### PR DESCRIPTION
**Description**:  Add NNAPI Execution Provider in the exclude list of transformer_memcpy  

**Motivation and Context**
- NNAPI have it own way to handle the data movement, so it don't need to add the MemcpyFromHost and MemcpyToHost node to the graph
