### PR TITLE
Fix DmlCopyTensor test

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -81,7 +81,7 @@ target_cppwinrt(winml_api
   ${sdk_folder}              # location of sdk folder
   ${sdk_version}             # sdk version
   ${target_folder}           # the folder this target will be placed under
-  ${winml_midl_defines}      # the midl compiler defines
+  "${winml_midl_defines}"    # the midl compiler defines
   ${winml_api_use_ns_prefix} # set ns_prefix
 )
 
@@ -91,7 +91,7 @@ target_midl(winml_api_native
   ${sdk_folder}             # location of sdk folder
   ${sdk_version}            # sdk version
   ${target_folder}          # the folder this target will be placed under
-  ${winml_midl_defines}     # the midl compiler defines
+  "${winml_midl_defines}"   # the midl compiler defines
 )
 
 target_midl(winml_api_native_internal
@@ -100,7 +100,7 @@ target_midl(winml_api_native_internal
   ${sdk_folder}                      # location of sdk folder
   ${sdk_version}                     # sdk version
   ${target_folder}                   # the folder this target will be placed under
-  ${winml_midl_defines}              # the midl compiler defines
+  "${winml_midl_defines}"            # the midl compiler defines
 )
 
 ###########################

--- a/winml/test/adapter/AdapterDmlEpTest.cpp
+++ b/winml/test/adapter/AdapterDmlEpTest.cpp
@@ -99,8 +99,12 @@ void DmlExecutionProviderReleaseCompletedReferences() {
   THROW_IF_NOT_OK_MSG(winml_adapter_api->DmlExecutionProviderReleaseCompletedReferences(ort_provider), ort_api);
 }
 
+constexpr std::array<int64_t, 4> dimensions{1, 3, 720, 720};
+constexpr uint64_t tensor_size = 3 * 720 * 720;
+std::array<float, tensor_size> tensor_values = {};
+
 winrt::com_ptr<ID3D12Resource> CreateD3D12Resource(ID3D12Device& device) {
-  constexpr uint64_t buffer_size = 720 * 720 * 3 * sizeof(float);
+  constexpr uint64_t buffer_size = tensor_size * sizeof(float);
   constexpr D3D12_HEAP_PROPERTIES heap_properties = {
       D3D12_HEAP_TYPE_DEFAULT,
       D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
@@ -163,12 +167,8 @@ void DmlGetD3D12ResourceFromAllocation() {
 }
 
 UniqueOrtValue CreateTensorFromMemoryInfo(OrtMemoryInfo* memory_info) {
-  constexpr std::array<int64_t, 4> dimensions{1, 3, 720, 720};
-  auto input_tensor_size = std::accumulate(begin(dimensions), end(dimensions), static_cast<int64_t>(1), std::multiplies<int64_t>());
-  std::vector<float> input_tensor_values(input_tensor_size);
-
   OrtValue* tensor;
-  THROW_IF_NOT_OK_MSG(ort_api->CreateTensorWithDataAsOrtValue(memory_info, input_tensor_values.data(), input_tensor_size * sizeof(float), dimensions.data(), dimensions.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &tensor), ort_api);
+  THROW_IF_NOT_OK_MSG(ort_api->CreateTensorWithDataAsOrtValue(memory_info, tensor_values.data(), tensor_size * sizeof(float), dimensions.data(), dimensions.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &tensor), ort_api);
   return UniqueOrtValue(tensor, ort_api->ReleaseValue);
 }
 
@@ -225,40 +225,54 @@ void ExecutionProviderSync() {
   THROW_IF_NOT_OK_MSG(winml_adapter_api->ExecutionProviderSync(ort_provider), ort_api);
 }
 
+#define watch(x) std::cerr << (#x) << " = " << (x) << "\n";
+
 void DmlCopyTensor() {
   GPUTEST;
   const auto session_options = CreateUniqueOrtSessionOptions();
   THROW_IF_NOT_OK_MSG(ort_api->DisableMemPattern(session_options.get()), ort_api);
+  watch(session_options.get());
 
   winrt::com_ptr<ID3D12Device> device;
   WINML_EXPECT_NO_THROW(D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL::D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(device.put())));
+  watch(device.get());
 
   winrt::com_ptr<ID3D12CommandQueue> queue;
   D3D12_COMMAND_QUEUE_DESC command_queue_desc = {};
   command_queue_desc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
   WINML_EXPECT_HRESULT_SUCCEEDED(device->CreateCommandQueue(&command_queue_desc, IID_PPV_ARGS(queue.put())));
+  watch(queue.get());
 
   THROW_IF_NOT_OK_MSG(winml_adapter_api->OrtSessionOptionsAppendExecutionProvider_DML(session_options.get(), device.get(), queue.get(), false), ort_api);
+  watch(session_options.get());
   auto session = CreateUniqueOrtSession(FileHelpers::GetModulePath() + L"fns-candy.onnx", session_options);
+  watch(session.get());
 
   OrtExecutionProvider* dml_provider;
   THROW_IF_NOT_OK_MSG(winml_adapter_api->SessionGetExecutionProvider(session.get(), 0, &dml_provider), ort_api);
+  watch(dml_provider);
 
   // CPU to CPU is not supported
   OrtMemoryInfo* cpu_memory_info;
-  THROW_IF_NOT_OK_MSG(ort_api->CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &cpu_memory_info), ort_api);
+  THROW_IF_NOT_OK_MSG(ort_api->CreateCpuMemoryInfo(OrtDeviceAllocator, OrtMemTypeDefault, &cpu_memory_info), ort_api);
   auto cpu_tensor = CreateTensorFromMemoryInfo(cpu_memory_info);
+  watch(cpu_tensor.get());
   auto dst_cpu_tensor = CreateTensorFromMemoryInfo(cpu_memory_info);
+  watch(dst_cpu_tensor.get());
   WINML_EXPECT_NOT_EQUAL(nullptr, winml_adapter_api->DmlCopyTensor(dml_provider, cpu_tensor.get(), dst_cpu_tensor.get()));
+  watch(dml_provider);
 
   // GPU to CPU
   OrtMemoryInfo* dml_memory;
   THROW_IF_NOT_OK_MSG(winml_adapter_api->GetProviderMemoryInfo(dml_provider, &dml_memory), ort_api);
+  watch(dml_memory);
   auto unique_dml_memory = UniqueOrtMemoryInfo(dml_memory, ort_api->ReleaseMemoryInfo);
 
   auto resource = CreateD3D12Resource(*device);
   void* dml_allocator_resource;
+  watch(resource.get());
   THROW_IF_NOT_OK_MSG(winml_adapter_api->DmlCreateGPUAllocationFromD3DResource(resource.get(), &dml_allocator_resource), ort_api);
+  watch(dml_allocator_resource);
 
   std::array<int64_t, 3> shape = {720, 720, 3};
   OrtValue* gpu_value;
@@ -271,19 +285,15 @@ void DmlCopyTensor() {
       ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT,
       &gpu_value),
     ort_api);
-  // Create DML tensor data interface
-  Microsoft::WRL::ComPtr<_winml::OnnxruntimeValue> data_value;
-  WINML_EXPECT_HRESULT_SUCCEEDED(Microsoft::WRL::MakeAndInitialize<_winml::OnnxruntimeValue>(
-      &data_value,
-      nullptr,
-      UniqueOrtValue(gpu_value, ort_api->ReleaseValue),
-      UniqueOrtAllocator(nullptr, nullptr)));
+  watch(gpu_value);
   dst_cpu_tensor = CreateTensorFromMemoryInfo(cpu_memory_info);
+  watch(dst_cpu_tensor.get());
   THROW_IF_NOT_OK_MSG(winml_adapter_api->DmlCopyTensor(dml_provider, gpu_value, dst_cpu_tensor.get()), ort_api);
+  watch(dml_provider);
 
-  // Free the tensor before the allocator
-  data_value = nullptr;
+  watch(dml_allocator_resource);
   THROW_IF_NOT_OK_MSG(winml_adapter_api->DmlFreeGPUAllocation(dml_allocator_resource), ort_api);
+  watch(dml_allocator_resource);
 }
 
 void CreateCustomRegistry() {
@@ -306,7 +316,7 @@ void ValueGetDeviceId() {
   THROW_IF_NOT_OK_MSG(winml_adapter_api->ValueGetDeviceId(gpu_tensor.get(), &device_id), ort_api);
 
   OrtMemoryInfo* cpu_memory_info;
-  THROW_IF_NOT_OK_MSG(ort_api->CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &cpu_memory_info), ort_api);
+  THROW_IF_NOT_OK_MSG(ort_api->CreateCpuMemoryInfo(OrtDeviceAllocator, OrtMemTypeDefault, &cpu_memory_info), ort_api);
   auto unique_cpu_memory_info = UniqueOrtMemoryInfo(memory_info, ort_api->ReleaseMemoryInfo);
   auto cpu_tensor = CreateTensorFromMemoryInfo(unique_cpu_memory_info.get());
   THROW_IF_NOT_OK_MSG(winml_adapter_api->ValueGetDeviceId(cpu_tensor.get(), &device_id), ort_api);


### PR DESCRIPTION
**Description**: Fix test break due to heap corruption. `CreateTensorWithDataAsOrtValue` doesn't copy the data, thus the data it is set to point to must remain valid during the tensor lifetime.