### PR TITLE
Add missing D3D12 resource barriers and fences to Winml

### DIFF
--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -445,6 +445,12 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
     ID3D12DescriptorHeap* ppHeaps[] = {descriptor_heap_.Get()};
     command_list_->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 
+    // This code currently re-uses the same decriptors each execution, which is unsafe if previous executions are in flight.
+    if (fence_completion_value_ > 0)
+    {
+        device_cache.WaitForFenceValue(fence_completion_value_);
+    }
+
     CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(descriptor_heap_->GetGPUDescriptorHandleForHeapStart(), SrvBufferIdx, srvUavDescriptorSize);
     CD3DX12_GPU_DESCRIPTOR_HANDLE uavHandle(descriptor_heap_->GetGPUDescriptorHandleForHeapStart(), UavBufferIdx, srvUavDescriptorSize);
     {
@@ -471,6 +477,7 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
     WINML_THROW_IF_FAILED(command_list_->Close());
     ID3D12CommandList* pComputeToGPUCLs[] = {command_list_.Get()};
     device_cache.GetCommandQueue()->ExecuteCommandLists(ARRAYSIZE(pComputeToGPUCLs), pComputeToGPUCLs);
+    fence_completion_value_ = device_cache.QueueFenceToD3D12();
   }
 }
 

--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -500,6 +500,10 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToSoftwareBitmap(
   }
 
   ResetCommandList(device_cache);
+
+  auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(pInputTensor, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE);
+  command_list_->ResourceBarrier(1, &barrier);
+
   command_list_->CopyBufferRegion(readback_heap_.Get(), 0, pInputTensor, singleVideoFramebufferSize * batchIdx, singleVideoFramebufferSize);
 
   WINML_THROW_IF_FAILED(command_list_->Close());

--- a/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
+++ b/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
@@ -454,8 +454,12 @@ void VideoFrameToTensorConverter::ConvertSoftwareBitmapToGPUTensor(
   upload_heap_->Unmap(0, &CD3DX12_RANGE(0, bufferSize));
 
   ResetCommandList(device_cache);
-  command_list_->CopyBufferRegion(pOutputResource, bufferSize * batchIdx, upload_heap_.Get(), 0, bufferSize);
 
+  auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(pOutputResource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_DEST);
+  command_list_->ResourceBarrier(1, &barrier);
+
+  command_list_->CopyBufferRegion(pOutputResource, bufferSize * batchIdx, upload_heap_.Get(), 0, bufferSize);
+  
   WINML_THROW_IF_FAILED(command_list_->Close());
   ID3D12CommandList* ppCommandLists[] = {command_list_.Get()};
   device_cache.GetCommandQueue()->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);

--- a/winml/lib/Api.Image/inc/ImageConverter.h
+++ b/winml/lib/Api.Image/inc/ImageConverter.h
@@ -52,6 +52,8 @@ class ImageConverter {
   Microsoft::WRL::ComPtr<ID3D12RootSignature> root_signature_;
   Microsoft::WRL::ComPtr<ID3D12PipelineState> pipeline_state_;
   Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> descriptor_heap_;
+  uint64_t fence_completion_value_ = 0;
+
   Microsoft::WRL::ComPtr<ID3D11Texture2D> D3D11_cached_texture_;
   wm::VideoFrame converted_video_frame_;
   CWinMLLock lock_;


### PR DESCRIPTION
This adds missing resource barriers and fences to tensorization code in Winml to make the WinML image tests run cleanly with the D3D debug layer enabled and address sporadic real failures.

Ultimately this code should use a pool of descriptors to avoid the need for the new fence waits.