### PR TITLE
Add test for If node with conditional branches only containing Constant nodes

### DIFF
--- a/onnxruntime/test/providers/cpu/controlflow/if_test.cc
+++ b/onnxruntime/test/providers/cpu/controlflow/if_test.cc
@@ -392,7 +392,7 @@ class IfOpTesterOnlyConstantNodesInConditionalBranches : public OpTester {
       };
 
       if_node.AddAttribute("then_branch", CreateSubgraphWithConstantNode(true, 10.f, outputs));
-      if_node.AddAttribute("else_branch", CreateSubgraphWithConstantNode(true, 1000.f, outputs));
+      if_node.AddAttribute("else_branch", CreateSubgraphWithConstantNode(false, 1000.f, outputs));
     }
   }
 };

--- a/onnxruntime/test/providers/cpu/controlflow/if_test.cc
+++ b/onnxruntime/test/providers/cpu/controlflow/if_test.cc
@@ -367,7 +367,6 @@ class IfOpTesterOnlyConstantNodesInConditionalBranches : public OpTester {
       auto& if_node = graph.AddNode("if", "If", "If node", inputs, outputs);
 
       auto CreateSubgraphWithConstantNode = [](bool then_branch, float value, std::vector<NodeArg*> outputs) {
-        // Then branch - it has "Constant" node only
         Model model_then(then_branch ? "Then" : "Else", false, DefaultLoggingManager().DefaultLogger());
         auto& graph_then = model_then.MainGraph();
         auto& then_constant_node = graph_then.AddNode(


### PR DESCRIPTION
It seems like 1.2.0 had an issue wherein conditional branches in an `If` node containing only Constant nodes were somehow not getting executed correctly (the output of the `If` node contained a value that neither `Constant` nodes in the conditional branches produced). This seems to have been fixed in master. The core issue that was causing it and the commit that fixed it is not known yet. Adding a test so that we can catch any future regression if any.   

EDIT: The original fix came via https://github.com/microsoft/onnxruntime/pull/3912

**Motivation and Context**
Takeaway from #3900 