### PR TITLE
Disable LTO on Windows training CPU build

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-win-ci-pipeline.yml
@@ -18,5 +18,5 @@ jobs:
     BuildArch: 'x64'
     EnvSetupScript: 'setup_env.bat'
     sln_platform: 'x64'
-    #BuildConfigurations: ['Debug', 'RelWithDebInfo']
-    BuildConfigurations: ['RelWithDebInfo']
+    BuildConfigurations: ['Debug', 'RelWithDebInfo']
+    EnableLto: false

--- a/tools/ci_build/github/azure-pipelines/orttraining-win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-win-ci-pipeline.yml
@@ -18,4 +18,5 @@ jobs:
     BuildArch: 'x64'
     EnvSetupScript: 'setup_env.bat'
     sln_platform: 'x64'
-    BuildConfigurations: ['Debug', 'RelWithDebInfo']
+    #BuildConfigurations: ['Debug', 'RelWithDebInfo']
+    BuildConfigurations: ['RelWithDebInfo']

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-2019.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-2019.yml
@@ -87,7 +87,7 @@ jobs:
       displayName: 'Generate cmake config'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-        arguments: '$(BuildCommand) --update --config $(BuildConfig) --enable_lto'
+        arguments: '$(BuildCommand) --update --config $(BuildConfig)'
         workingDirectory: '$(Build.BinariesDirectory)'
 
     - ${{ if notIn(parameters['sln_platform'], 'Win32', 'x64') }}:
@@ -156,7 +156,7 @@ jobs:
            python.exe -m pip install -q --upgrade %WHEEL_FILENAME%
            set PATH=%PATH%;$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)
            @echo %PATH%
-           python $(Build.SourcesDirectory)\tools\ci_build\build.py $(BuildCommand) --test --config $(BuildConfig) --enable_lto
+           python $(Build.SourcesDirectory)\tools\ci_build\build.py $(BuildCommand) --test --config $(BuildConfig)
           workingDirectory: '$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)'
           displayName: 'Run tests'
 

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-2019.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-2019.yml
@@ -17,6 +17,7 @@ parameters:
   OrtPackageId: Microsoft.ML.OnnxRuntime
   BuildConfigurations: ['RelWithDebInfo'] # Options: Debug, RelWithDebInfo
   RunTests : 'true'
+  EnableLto: true
 jobs:
 - job: ${{ parameters.JobName }}
   timeoutInMinutes: 160
@@ -38,6 +39,8 @@ jobs:
     DotNetExe: 'dotnet.exe'
     CUDA_VERSION: ${{ parameters.CudaVersion }}
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    ${{ if eq(parameters.EnableLto, true) }}:
+      build_py_lto_flag: --enable_lto
 
   steps:
     - checkout: self
@@ -87,7 +90,7 @@ jobs:
       displayName: 'Generate cmake config'
       inputs:
         scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-        arguments: '$(BuildCommand) --update --config $(BuildConfig)'
+        arguments: '$(BuildCommand) --update --config $(BuildConfig) ${{ variables.build_py_lto_flag }}'
         workingDirectory: '$(Build.BinariesDirectory)'
 
     - ${{ if notIn(parameters['sln_platform'], 'Win32', 'x64') }}:
@@ -156,7 +159,7 @@ jobs:
            python.exe -m pip install -q --upgrade %WHEEL_FILENAME%
            set PATH=%PATH%;$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)
            @echo %PATH%
-           python $(Build.SourcesDirectory)\tools\ci_build\build.py $(BuildCommand) --test --config $(BuildConfig)
+           python $(Build.SourcesDirectory)\tools\ci_build\build.py $(BuildCommand) --test --config $(BuildConfig) ${{ variables.build_py_lto_flag }}
           workingDirectory: '$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)'
           displayName: 'Run tests'
 


### PR DESCRIPTION
**Description**
Disable LTO on Windows training CPU build. Add a parameter to the win-ci-2019.yml build template for enabling LTO with a default value of true.

**Motivation and Context**
Address intermittent and not infrequent build failures in the Windows training CPU build like this one:
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=157569&view=results