### PR TITLE
Prevent divide by zero in CUDA implementation of SoftmaxCrossEntropyLossGrad

### DIFF
--- a/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cu
+++ b/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cu
@@ -117,7 +117,11 @@ __global__ void _WeightedSoftmaxCrossEntropyLossGrad(
   int row = i / C;
   int d = i % C;
   CUDA_KERNEL_ASSERT(weight[row] == 0 || (label[row] >= 0 && label[row] < C));
-  output_data[i] = (*dY) * weight[row] * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
+  if(0 == *normalize_factor){
+    output_data[i] = 0;
+  } else {
+    output_data[i] = (*dY) * weight[row] * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
+  }
 }
 
 template <typename T, typename Tin>
@@ -135,7 +139,11 @@ __global__ void _WeightedReductionNoneSoftmaxCrossEntropyLossGrad(
   int row = i / C;
   int d = i % C;
   CUDA_KERNEL_ASSERT(weight[row] == 0 || (label[row] >= 0 && label[row] < C));
-  output_data[i] = dY[row] * weight[row] * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
+  if(0 == *normalize_factor){
+    output_data[i] = 0;
+  } else {
+    output_data[i] = dY[row] * weight[row] * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
+  }
 }
 
 template <typename T, typename Tin>


### PR DESCRIPTION
Flakiness in SoftmaxCrossEntropyLossGrad_TinySizeTensor test Reported by @wschin on 05/15/2020. In this case `ignore index` is **zero** and all input target values are also **zero**, hence the normalization factor is computed as **zero** which is used as the denominator in gradient calculation equation `output_data[i] = dY[row] * weight[row] * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);` resulting in a -NAN.

```
 [ RUN ] CudaKernelTest.SoftmaxCrossEntropyLossGrad_TinySizeTensor 
 /onnxruntime_src/onnxruntime/test/providers/compare_provider_test_utils.cc:132: Failure 
Expected equality of these values: 
ret.first 
 Which is: 4-byte object <01-00 00-00> 
 COMPARE_RESULT::SUCCESS 
 Which is: 4-byte object <00-00 00-00> 
 expected 0 (0), got -nan (ffc00000), diff: nan, tol=0.0001. 16 of 16 differ 
 Google Test trace: 
 /onnxruntime_src/onnxruntime/test/common/tensor_op_test_utils.cc:12: ORT test random seed: 2039433364 
[ FAILED ] CudaKernelTest.SoftmaxCrossEntropyLossGrad_TinySizeTensor (11 ms)
```