### PR TITLE
Fix C# layer in the way it handles sequences

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
@@ -209,7 +209,6 @@ namespace Microsoft.ML.OnnxRuntime
                         IntPtr nativeOnnxValueSeq;
                         NativeApiStatus.VerifySuccess(NativeMethods.OrtGetValue(nativeOnnxValue, i, allocator, out nativeOnnxValueSeq));
                         sequence.Add(CreateFromOnnxValue(string.Empty, nativeOnnxValueSeq, allocator));
-                        NativeMethods.OrtReleaseValue(nativeOnnxValueSeq);
                     }
                     return new DisposableNamedOnnxValue(name, sequence, OnnxValueType.ONNX_TYPE_SEQUENCE, TensorElementType.DataTypeMax, null);
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -576,7 +576,6 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             }
         }
 
-        /*
         [Theory]
         [MemberData(nameof(GetModelsForTest))]
         [MemberData(nameof(GetSkippedModelForTest), Skip = "Skipped due to Error, please fix the error and enable the test")]
@@ -712,7 +711,6 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 throw new Exception(msg + "\n" + ex.StackTrace);
             }
         }
-        */
 
         [Fact]
         private void TestOverridableInitializerMetadata()

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -576,7 +576,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             }
         }
 
-
+        /*
         [Theory]
         [MemberData(nameof(GetModelsForTest))]
         [MemberData(nameof(GetSkippedModelForTest), Skip = "Skipped due to Error, please fix the error and enable the test")]
@@ -712,6 +712,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 throw new Exception(msg + "\n" + ex.StackTrace);
             }
         }
+        */
 
         [Fact]
         private void TestOverridableInitializerMetadata()
@@ -1426,6 +1427,65 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     Assert.Equal(0.25938290, map["0"], 6);
                     Assert.Equal(0.40904793, map["1"], 6);
                     Assert.Equal(0.33156919, map["2"], 6);
+                }
+
+            }
+        }
+
+        [Fact]
+        private void TestModelSequenceOfTensors()
+        {
+
+            string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "test_sequence_tensors.onnx");
+
+            using (var session = new InferenceSession(modelPath))
+            {
+                var outMeta = session.OutputMetadata;
+                Assert.Equal(OnnxValueType.ONNX_TYPE_SEQUENCE, outMeta["output_sequence"].OnnxValueType);
+
+                var container = new List<NamedOnnxValue>();
+                var firstInputTensor = new DenseTensor<Int64>(new Int64[] { 1, 2, 3, 4, 5, 6 }, new int[] { 2, 3 });
+                var secondInputTensor = new DenseTensor<Int64>(new Int64[] { 7, 8, 9, 10, 11, 12 }, new int[] { 2, 3 });
+
+                var firstNov = NamedOnnxValue.CreateFromTensor("tensor1", firstInputTensor);
+                var secondNov = NamedOnnxValue.CreateFromTensor("tensor2", secondInputTensor);
+
+                container.Add(firstNov);
+                container.Add(secondNov);
+
+                using (var outputs = session.Run(container))
+                {
+                    // output is a sequence<tensors>
+                    // try-cast to an sequence of NOV
+                    var outNode = outputs.ElementAtOrDefault(0);
+                    Assert.Equal("output_sequence", outNode.Name);
+
+                    // try-cast to an sequence of NOV
+                    var seq = outNode.AsEnumerable<NamedOnnxValue>();
+
+                    // make sure that the sequence holds only 2 elements (tensors)
+                    Assert.True(seq.Count() == 2);
+
+                    // try-cast the elements in sequence to tensor type
+                    var firstTensorInOuputSequence = seq.First().AsTensor<Int64>();
+                    var secondTensorInOuputSequence = seq.Last().AsTensor<Int64>();
+
+                    // make sure the tensors in the output sequence hold the correct values
+                    Assert.True(firstTensorInOuputSequence.GetValue(0) == 1);
+                    Assert.True(firstTensorInOuputSequence.GetValue(1) == 2);
+                    Assert.True(firstTensorInOuputSequence.GetValue(2) == 3);
+                    Assert.True(firstTensorInOuputSequence.GetValue(3) == 4);
+                    Assert.True(firstTensorInOuputSequence.GetValue(4) == 5);
+                    Assert.True(firstTensorInOuputSequence.GetValue(5) == 6);
+
+                    Assert.True(secondTensorInOuputSequence.GetValue(0) == 7);
+                    Assert.True(secondTensorInOuputSequence.GetValue(1) == 8);
+                    Assert.True(secondTensorInOuputSequence.GetValue(2) == 9);
+                    Assert.True(secondTensorInOuputSequence.GetValue(3) == 10);
+                    Assert.True(secondTensorInOuputSequence.GetValue(4) == 11);
+                    Assert.True(secondTensorInOuputSequence.GetValue(5) == 12);
+
+
                 }
             }
         }

--- a/csharp/testdata/test_sequence_tensors.onnx
+++ b/csharp/testdata/test_sequence_tensors.onnx
@@ -1,0 +1,18 @@
+onnx-example:¡
+6
+tensor1
+tensor2output_sequence"SequenceConstruct
+test-modelZ
+tensor1
+
+
+Z
+tensor2
+
+
+b%
+output_sequence"
+
+
+
+B


### PR DESCRIPTION
**Description**: 

Originally wanted to fix https://github.com/microsoft/onnxruntime/issues/3181, but the fix for it was checked-in as part of https://github.com/microsoft/onnxruntime/pull/3171, and hence added a test case to keep it covered. While adding the test case, I realized that the C# layer was releasing the native OrtValue for each element in a sequence tensor. This is okay for a sequence of maps but if it were a sequence of tensors, releasing the OrtValue will mean that underlying native memory holding the tensor data is possibly lost before use by the caller. This change fixes that and adds a test case that keeps this and the bug fix for #3181 covered. 

**Motivation and Context**
#3181 
