### PR TITLE
Update install_deps.sh to use relative path from script directory to symbolic_opset10.py.

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-set -e
+set -e -x
 
+SCRIPT_DIR="$( dirname "${BASH_SOURCE[0]}" )"
 
 while getopts p:d:x: parameter_Option
 do case "${parameter_Option}"
@@ -114,8 +115,7 @@ elif [ $DEVICE_TYPE = "gpu" ]; then
 
       # patch pytorch onnx export opset version 10 to export nll_loss
       PATH_TO_SYMBOLIC10=$(${PYTHON_EXE} -c 'import torch; import os; print(os.path.join(os.path.dirname(torch.__file__), "onnx/"))')
-      echo "cp ../scripts/pyt_patch/symbolic_opset10.py ${PATH_TO_SYMBOLIC10}"
-      cp ../scripts/pyt_patch/symbolic_opset10.py ${PATH_TO_SYMBOLIC10}
+      cp "${SCRIPT_DIR}/pyt_patch/symbolic_opset10.py" "${PATH_TO_SYMBOLIC10}"
     fi
     if [[ $BUILD_EXTR_PAR = *--enable_training_python_frontend_e2e_tests* ]]; then
       ${PYTHON_EXE} -m pip install transformers


### PR DESCRIPTION
**Description**
Update install_deps.sh to use relative path from script directory to symbolic_opset10.py. This allows install_deps.sh to be called from different working directories.

**Motivation and Context**
Fix Dockerfile.manylinux2014_gpu build with training enabled.