### PR TITLE
Minor android build fix

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -68,6 +68,11 @@ if (NOT WIN32)
   endif()
 endif()
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Android")
+  set_target_properties(onnxruntime PROPERTIES LINK_FLAGS_RELEASE -s)
+  set_target_properties(onnxruntime PROPERTIES LINK_FLAGS_MINSIZEREL -s)
+endif()
+
 target_link_libraries(onnxruntime PRIVATE
     onnxruntime_session
     ${onnxruntime_libs}

--- a/cmake/onnxruntime_java.cmake
+++ b/cmake/onnxruntime_java.cmake
@@ -101,10 +101,12 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Android")
 endif()
 
 # Set platform and ach for packaging
-if(CMAKE_SIZEOF_VOID_P EQUAL "8")
-    set(JNI_ARCH x64)
+if (CMAKE_SYSTEM_NAME STREQUAL "Android")
+  set(JNI_ARCH ${ANDROID_ABI})
+elseif (CMAKE_SIZEOF_VOID_P EQUAL "8")
+  set(JNI_ARCH x64)
 else()
-    message(FATAL_ERROR "Java is currently not supported for x86 architecture")
+  message(FATAL_ERROR "Java is currently not supported for x86 architecture")
 endif()
 
 if (WIN32)


### PR DESCRIPTION
- The binary size of libonnxruntime.so for all ABIs android cross build is >300M, even for Release config
The fix is to add strip linking flag for Release and MinSizeRel config

- Build for x86 and armeabi-v7a for Android with --build_java option will fail.
The fix is to add special case for JNI_ARCH if it is building for android
