### PR TITLE
Require minimum flake8 version

### DIFF
--- a/cmake/flake8.cmake
+++ b/cmake/flake8.cmake
@@ -6,11 +6,14 @@
 
 find_program(flake8_BIN NAMES flake8)
 
-if(NOT flake8_BIN)
+if(flake8_BIN)
+    exec_program(${flake8_BIN} ARGS "--version" OUTPUT_VARIABLE FLAKE8_VERSION)
+else()
     # see if we can run the python module instead if there's no executable
     set(FLAKE8_NOT_FOUND false)
     exec_program("${PYTHON_EXECUTABLE}"
                  ARGS "-m flake8 --version"
+                 OUTPUT_VARIABLE FLAKE8_VERSION
                  RETURN_VALUE FLAKE8_NOT_FOUND)
     if(${FLAKE8_NOT_FOUND})
         message(WARNING "Could not find 'flake8' to check python scripts. Please install flake8 using pip.")
@@ -20,34 +23,51 @@ if(NOT flake8_BIN)
 endif()
 
 if(flake8_BIN)
-    # need to exclude a subset of scripts from ${ONNXRUNTIME_ROOT} so create a complete
-    # list and then filter it
-    file(GLOB_RECURSE python_scripts CONFIGURE_DEPENDS
-        "${ONNXRUNTIME_ROOT}/*.py"
-    )
+    # check flake8 version
+    string(REGEX MATCH "^([0-9])+\\.([0-9])+\\.([0-9])+" _flake8_ver_check "${FLAKE8_VERSION}")
+    if(NOT "${_flake8_ver_check}" STREQUAL "")
+        set(FLAKE8_VERSION_MAJOR ${CMAKE_MATCH_1})
+        set(FLAKE8_VERSION_MINOR ${CMAKE_MATCH_2})
+    else()
+        set(FLAKE8_VERSION_MAJOR 0)
+        set(FLAKE8_VERSION_MINOR 0)
+    endif()
 
-    # scripts in these directories still need updating
-    list(FILTER python_scripts EXCLUDE REGEX "onnxruntime/core/providers/nuphar")
-    list(FILTER python_scripts EXCLUDE REGEX "onnxruntime/python/tools")
-    list(FILTER python_scripts EXCLUDE REGEX "onnxruntime/test")
+    math(EXPR FLAKE8_VERSION_DECIMAL "(${FLAKE8_VERSION_MAJOR} * 100) + ${FLAKE8_VERSION_MINOR}")
 
-    # can just add the 'tools' directory and flake8 will recurse into it
-    list(APPEND python_scripts ${REPO_ROOT}/tools/)
+    # require minimum version that we've tested with (3.8)
+    if (${FLAKE8_VERSION_DECIMAL} GREATER_EQUAL 308)
+        # need to exclude a subset of scripts from ${ONNXRUNTIME_ROOT} so create a complete
+        # list and then filter it
+        file(GLOB_RECURSE python_scripts CONFIGURE_DEPENDS
+            "${ONNXRUNTIME_ROOT}/*.py"
+        )
 
-    # Training scripts need updating to make PEP8 compliant.
-    # file(GLOB_RECURSE training_scripts CONFIGURE_DEPENDS
-    #     "${ORTTRAINING_ROOT}/*.py"
-    # )
+        # scripts in these directories still need updating
+        list(FILTER python_scripts EXCLUDE REGEX "onnxruntime/core/providers/nuphar")
+        list(FILTER python_scripts EXCLUDE REGEX "onnxruntime/python/tools")
+        list(FILTER python_scripts EXCLUDE REGEX "onnxruntime/test")
 
-    source_group(TREE ${REPO_ROOT} FILES ${python_scripts})
+        # can just add the 'tools' directory and flake8 will recurse into it
+        list(APPEND python_scripts ${REPO_ROOT}/tools/)
 
-    add_custom_target(pep8_check 
-        ALL 
-        DEPENDS ${python_scripts}
-        WORKING_DIRECTORY 
-        COMMAND echo "Checking python scripts for PEP8 conformance using flake8"
-        #MESSAGE(${python_scripts})
-        COMMAND ${flake8_BIN} "--config" "${REPO_ROOT}/.flake8" ${python_scripts}
-        VERBATIM
-    )
+        # Training scripts need updating to make PEP8 compliant.
+        # file(GLOB_RECURSE training_scripts CONFIGURE_DEPENDS
+        #     "${ORTTRAINING_ROOT}/*.py"
+        # )
+
+        source_group(TREE ${REPO_ROOT} FILES ${python_scripts})
+
+        add_custom_target(pep8_check 
+            ALL 
+            DEPENDS ${python_scripts}
+            WORKING_DIRECTORY 
+            COMMAND echo "Checking python scripts for PEP8 conformance using flake8"
+            #MESSAGE(${python_scripts})
+            COMMAND ${flake8_BIN} "--config" "${REPO_ROOT}/.flake8" ${python_scripts}
+            VERBATIM
+        )
+    else()
+        message(WARNING "'flake8' version is too old. Requires 3.8 or later. Found ${FLAKE8_VERSION}")
+    endif()
 endif()


### PR DESCRIPTION
**Description**: 
Older flake8 versions report false positives and don't handle the same things in the config file.
Require the current flake8 version or later so we get consistent results.

**Motivation and Context**
Fix user issue where build fails due to older flake8 version reporting false positives and ignoring values in the config file. 