### PR TITLE
Miscounted the number of characters in package version of DirectML nuget

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nuget/templates/get-nuget-package-version-as-variable.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/get-nuget-package-version-as-variable.yml
@@ -24,7 +24,7 @@ steps:
       SETLOCAL EnableDelayedExpansion
       FOR /R %%i IN (Microsoft.ML.OnnxRuntime.DirectML*.nupkg) do (
         set filename=%%~ni
-        set ortversion=!filename:~33!
+        set ortversion=!filename:~34!
         @echo DirectMLNuGetPackageVersionNumber is !ortversion!
         @echo ##vso[task.setvariable variable=DirectMLNuGetPackageVersionNumber;]!ortversion!
       )


### PR DESCRIPTION
This change is to output the correct package version for DirectML nuget. 

If the package name is Microsoft.ML.OnnxRuntime.DirectML.1.3.0-dev-20200519-0748-c42867c01

There are 34 characters in Microsoft.ML.OnnxRuntime.DirectML. not 33.

Before this change, 
- .1.3.0-dev-20200519-0748-c42867c01 is being set as the version. It has a period in the beginning.
- 1.3.0-dev-20200519-0748-c42867c is needed. This is without the period.