### PR TITLE
Add ONNX Training Post-Passes to Front-End - Cont

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
+++ b/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
@@ -287,11 +287,18 @@ class MNISTWrapper():
         return model, model_desc
 
     def get_trainer(self, model, model_desc, device, onnx_opset_ver=12, frozen_weights=[],
+<<<<<<< HEAD
                     internal_loss_fn=False, get_lr_this_step=None):
         loss_fn = MNISTWrapper.my_loss if not internal_loss_fn else None
         return ORTTrainer(model, loss_fn, model_desc, "SGDOptimizer", None, IODescription('Learning_Rate', [1, ],
                                 torch.float32), device, _opset_version=onnx_opset_ver, frozen_weights=frozen_weights,
                                 get_lr_this_step=get_lr_this_step)
+=======
+                    internal_loss_fn=False):
+        loss_fn = MNISTWrapper.my_loss if not internal_loss_fn else None
+        return ORTTrainer(model, loss_fn, model_desc, "SGDOptimizer", None, IODescription('Learning_Rate', [1, ],
+                                torch.float32), device, _opset_version=onnx_opset_ver, frozen_weights=frozen_weights)
+>>>>>>> Fix test failures
 
 class TestOrtTrainer(unittest.TestCase):
 
@@ -493,6 +500,7 @@ class TestOrtTrainer(unittest.TestCase):
         train_loader, test_loader = mnist.get_loaders()
         model, model_desc = mnist.get_model_with_internal_loss()
 
+<<<<<<< HEAD
 
         def get_lr_this_step(global_step):
             learningRate = 0.02
@@ -500,13 +508,21 @@ class TestOrtTrainer(unittest.TestCase):
 
         trainer = mnist.get_trainer(model, model_desc, device, internal_loss_fn=True,
                                     get_lr_this_step=get_lr_this_step)
+=======
+        trainer = mnist.get_trainer(model, model_desc, device, internal_loss_fn=True)
+        learningRate = 0.02
+>>>>>>> Fix test failures
         epoch = 0
 
         data, target = next(iter(train_loader))
         data, target = data.to(device), target.to(device)
         data = data.reshape(data.shape[0], -1)
 
+<<<<<<< HEAD
         loss, _ = trainer.train_step(data, target)
+=======
+        loss, _ = trainer.train_step(data, target, torch.tensor([learningRate]))
+>>>>>>> Fix test failures
 
         assert set([n.name for n in trainer.onnx_model_.graph.initializer]) \
             == set([n for n, t in model.named_parameters()])

--- a/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
+++ b/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
@@ -287,18 +287,11 @@ class MNISTWrapper():
         return model, model_desc
 
     def get_trainer(self, model, model_desc, device, onnx_opset_ver=12, frozen_weights=[],
-<<<<<<< HEAD
                     internal_loss_fn=False, get_lr_this_step=None):
         loss_fn = MNISTWrapper.my_loss if not internal_loss_fn else None
         return ORTTrainer(model, loss_fn, model_desc, "SGDOptimizer", None, IODescription('Learning_Rate', [1, ],
                                 torch.float32), device, _opset_version=onnx_opset_ver, frozen_weights=frozen_weights,
                                 get_lr_this_step=get_lr_this_step)
-=======
-                    internal_loss_fn=False):
-        loss_fn = MNISTWrapper.my_loss if not internal_loss_fn else None
-        return ORTTrainer(model, loss_fn, model_desc, "SGDOptimizer", None, IODescription('Learning_Rate', [1, ],
-                                torch.float32), device, _opset_version=onnx_opset_ver, frozen_weights=frozen_weights)
->>>>>>> Fix test failures
 
 class TestOrtTrainer(unittest.TestCase):
 
@@ -500,7 +493,6 @@ class TestOrtTrainer(unittest.TestCase):
         train_loader, test_loader = mnist.get_loaders()
         model, model_desc = mnist.get_model_with_internal_loss()
 
-<<<<<<< HEAD
 
         def get_lr_this_step(global_step):
             learningRate = 0.02
@@ -508,21 +500,13 @@ class TestOrtTrainer(unittest.TestCase):
 
         trainer = mnist.get_trainer(model, model_desc, device, internal_loss_fn=True,
                                     get_lr_this_step=get_lr_this_step)
-=======
-        trainer = mnist.get_trainer(model, model_desc, device, internal_loss_fn=True)
-        learningRate = 0.02
->>>>>>> Fix test failures
         epoch = 0
 
         data, target = next(iter(train_loader))
         data, target = data.to(device), target.to(device)
         data = data.reshape(data.shape[0], -1)
 
-<<<<<<< HEAD
         loss, _ = trainer.train_step(data, target)
-=======
-        loss, _ = trainer.train_step(data, target, torch.tensor([learningRate]))
->>>>>>> Fix test failures
 
         assert set([n.name for n in trainer.onnx_model_.graph.initializer]) \
             == set([n for n, t in model.named_parameters()])
@@ -743,7 +727,7 @@ class TestOrtTrainer(unittest.TestCase):
         model_desc = ModelDescription([input_desc, label_desc], [loss_desc, output_desc])
         def loss_fn(x, label):
             return F.nll_loss(F.log_softmax(x, dim=1), label)
-        
+
         def get_lr_this_step(global_step):
             learningRate = 0.02
             return torch.tensor([learningRate])

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -660,7 +660,7 @@ class ORTTrainer():
             self._onnx_model_ = postprocess.run_postprocess(self.onnx_model_)
 
         if self._extra_postprocess:
-            self._extrapostprocess(self.onnx_model_)
+            self._extra_postprocess(self.onnx_model_)
 
         self._verify_fully_optimized_model(self.onnx_model_)
         self.session, self.train_io_binding, self.eval_io_binding, self.output_name, _, self.output_types = \
@@ -720,7 +720,7 @@ class ORTTrainer():
                 self.torch_model_, self.loss_fn_, self.model_desc_, torch.device('cpu'), inputs, opset_version=self.opset_version_, _enable_internal_postprocess=self._enable_internal_postprocess)
 
             if self._extra_postprocess:
-                self._extra_post_process(self.onnx_model_)
+                self._extra_postprocess(self.onnx_model_)
 
         self._init_session()
 

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -353,9 +353,6 @@ def convert_model_loss_fn_to_onnx(model, loss_fn, model_desc, device, inputs, op
             if name in replace_name_dict:
                 n.input[i] = replace_name_dict[name]
 
-    if _enable_internal_postprocess:
-        onnx_model = postprocess.run_postprocess(onnx_model)
-
     # onnx model initializer may contain non-trainable registered buffers that are not part
     # of pytorch model named parameteres.
     named_parameters = model.model_.named_parameters() if hasattr(model, 'model_') else model.named_parameters()
@@ -364,7 +361,8 @@ def convert_model_loss_fn_to_onnx(model, loss_fn, model_desc, device, inputs, op
         "Initializer names do not match between PyTorch model and ONNX model, " \
         "please report a bug to ONNX Runtime."
 
-    onnx_model = FuseSofmaxNLLToSoftmaxCE(onnx_model)
+    if _enable_internal_postprocess:
+        onnx_model = postprocess.run_postprocess(onnx_model)
 
     return onnx_model
 

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -324,17 +324,20 @@ def convert_model_loss_fn_to_onnx(model, loss_fn, model_desc, device, inputs, op
 
     # Other export options to use(this is for backward compatibility).
     other_export_options = {}
+    other_export_options['training'] = True
 
     # This option was added after 1.4 release.
     if LooseVersion(torch.__version__) > LooseVersion('1.4.0'):
         other_export_options['enable_onnx_checker'] = False
+    # This option was added after 1.6 release.
+    if LooseVersion(torch.__version__) >= LooseVersion('1.6.0'):
+        other_export_options['training'] = torch.onnx.TrainingMode.TRAINING
 
     torch.onnx._export(model, tuple(sample_inputs), f,
                        input_names=input_names,
                        output_names=output_names,
                        opset_version=opset_version,
                        dynamic_axes=dynamic_axes,
-                       training=torch.onnx.TrainingMode.TRAINING,
                        _retain_param_name=True,
                        example_outputs=tuple(sample_outputs),
                        do_constant_folding=False,
@@ -523,7 +526,8 @@ class ORTTrainer():
                  learning_rate_description, device, gradient_accumulation_steps=1,
                  world_rank=0, world_size=1, use_mixed_precision=False, allreduce_post_accumulation=False,
                  global_step=0, get_lr_this_step=None, loss_scaler=None, partition_optimizer=False,
-                 enable_grad_norm_clip=True, frozen_weights=[], _opset_version=DEFAULT_OPSET_VERSION, _enable_internal_postprocess=True, _extra_postprocess=None):
+                 enable_grad_norm_clip=True, frozen_weights=[], _opset_version=DEFAULT_OPSET_VERSION,
+                 _enable_internal_postprocess=True, _extra_postprocess=None):
         super(ORTTrainer, self).__init__()
         """
         Initialize ORTTrainer.

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -629,7 +629,7 @@ class ORTTrainer():
         # we use self.global_step_ to count optimizations being performed.
         # it is used to calculate learning rate if self.get_lr_this_step_ is provided.
         self.global_step_ = global_step
-        self.post_process_model_fn_ = _extra_postprocess
+        self._extra_postprocess = _extra_postprocess
         self.get_lr_this_step_ = get_lr_this_step
         self.loss_scaler_ = loss_scaler
 
@@ -658,6 +658,9 @@ class ORTTrainer():
 
         if self._enable_internal_postprocess:
             self._onnx_model_ = postprocess.run_postprocess(self.onnx_model_)
+
+        if self._extra_postprocess:
+            self._extrapostprocess(self.onnx_model_)
 
         self._verify_fully_optimized_model(self.onnx_model_)
         self.session, self.train_io_binding, self.eval_io_binding, self.output_name, _, self.output_types = \
@@ -705,8 +708,6 @@ class ORTTrainer():
 
     def _init_onnx_model(self, inputs):
         if self.onnx_model_ is not None:
-            if self._enable_internal_postprocess:
-                self.onnx_model_ = postprocess.run_postprocess(self.onnx_model_)
             return
 
         if self.torch_model_ is not None:
@@ -718,8 +719,8 @@ class ORTTrainer():
             self.onnx_model_ = convert_model_loss_fn_to_onnx(
                 self.torch_model_, self.loss_fn_, self.model_desc_, torch.device('cpu'), inputs, opset_version=self.opset_version_, _enable_internal_postprocess=self._enable_internal_postprocess)
 
-            if self.post_process_model_fn_:
-                self.post_process_model_fn_(self.onnx_model_)
+            if self._extra_postprocess:
+                self._extra_post_process(self.onnx_model_)
 
         self._init_session()
 

--- a/orttraining/orttraining/python/postprocess.py
+++ b/orttraining/orttraining/python/postprocess.py
@@ -1,0 +1,328 @@
+import sys
+import os.path
+from onnx import *
+import onnx
+import numpy as np
+import struct
+
+from onnx import helper
+from onnx import numpy_helper
+
+# Transpose PostProcess
+
+def find_input_as_initializer(model, arg):
+    for initializer in model.graph.initializer:
+        if initializer.name == arg:
+            return initializer
+    return None
+
+def replace_input_arg(model, arg, new_arg):
+    for node in model.graph.node:
+        i = 0
+        while i < len(node.input):
+            if node.input[i] == arg:
+                node.input[i] = new_arg
+            i += 1
+
+def find_input_node(model, arg):
+    result = []
+    for node in model.graph.node:
+        for output in node.output:
+            if output == arg:
+                result.append(node)
+    return result[0] if len(result)== 1 else None
+
+def find_output_node(model, arg):
+    result = []
+    for node in model.graph.node:
+        for input in node.input:
+            if input == arg:
+                result.append(node)
+    return result[0] if len(result) == 1 else result
+
+def get_node_index(model, node):
+    i = 0
+    while i < len(model.graph.node):
+        if model.graph.node[i] == node:
+            break;
+        i += 1
+    return i if i < len(model.graph.node) else None;
+
+def find_weight_index(model, name):
+    index = 0
+    for w in model.graph.initializer:
+        if w.name == name:
+            return index
+        index += 1
+    return None
+
+def fix_transpose(model):
+    transpose = []
+    for node in model.graph.node:
+        if node.op_type == 'Transpose':
+            weight = find_input_as_initializer(model, node.input[0])
+            if weight is not None:
+                result = []
+                for n in model.graph.node:
+                    for input in n.input:
+                        if input == weight.name:
+                            result.append(n)
+                if len(result) > 1:
+                    continue
+                perm = node.attribute[0]
+                assert perm.name == 'perm'
+                perm = perm.ints
+                if len(perm) == 2 and perm[0] == 1 and perm[1] == 0: ##
+                    weight_array = numpy_helper.to_array(weight)
+                    if len(weight_array.shape) == 2: ##
+                        transpose.append((get_node_index(model, node), weight))
+
+    for t in transpose:
+        node = model.graph.node[t[0]]
+        weight = numpy_helper.to_array(t[1])
+        weight = weight.transpose(perm)
+        new_weight = numpy_helper.from_array(weight, "%s_transposed" % t[1].name)
+        model.graph.initializer.extend([new_weight])
+        replace_input_arg(model, node.output[0], new_weight.name)
+
+    transpose.sort(reverse=True)
+    for t in transpose:
+        del model.graph.node[t[0]]
+
+    old_ws = []
+    for t in transpose:
+        out_node = find_output_node(model, t[1].name) 
+        if out_node is None or len(out_node) == 0: ##
+            old_ws.append(find_weight_index(model, t[1].name))
+    old_ws.sort(reverse=True)
+    for w_i in old_ws:
+        del model.graph.initializer[w_i]
+    return model
+
+# Expand Shape PostProcess
+
+def fix_expand_shape(model):
+    expand_nodes = [n for n in model.graph.node if n.op_type == 'Expand']
+    model_inputs_names = [i.name for i in model.graph.input]
+
+    for expand_node in expand_nodes:
+        shape = find_input_node(model, expand_node.input[1])
+        if shape.op_type == 'Shape':
+            shape_input_name = shape.input[0]
+            if shape_input_name in model_inputs_names:
+                index = model_inputs_names.index(shape_input_name)
+                expand_out = model.graph.value_info.add()
+                expand_out.name = expand_node.output[0]
+                expand_out.type.CopyFrom(model.graph.input[index].type)
+    return model
+
+
+# LayerNorm PostProcess
+ 
+def find_nodes(graph, op_type):
+    nodes = []
+    for node in graph.node:
+        if node.op_type == op_type:
+            nodes.append(node)
+    return nodes
+
+def is_type(node, op_type):
+    if node is None or isinstance(node, list):
+        return False
+    return node.op_type == op_type
+
+def add_const(model, name, output, t_value = None, f_value = None):
+    const_node = model.graph.node.add()
+    const_node.op_type = 'Constant'
+    const_node.name = name
+    const_node.output.extend([output])
+    attr = const_node.attribute.add()
+    attr.name = 'value'
+    if t_value is not None:
+        attr.type = 4
+        attr.t.CopyFrom(t_value)
+    else:
+        attr.type = 1
+        attr.f = f_value
+    return const_node
+
+def layer_norm_transform(model):
+    graph = model.graph
+
+    nodes_ReduceMean = find_nodes(graph, "ReduceMean")
+
+    id = 0
+    layer_norm_nodes = []
+    remove_nodes = []
+    for reduce_mean in nodes_ReduceMean:
+        # check that reduce_mean output is Sub
+        sub = find_output_node(model, reduce_mean.output[0])
+        if not is_type(sub, "Sub"):
+            continue
+
+        # check that sub output[0] is Div and output[1] is Pow
+        pow, div = find_output_node(model, sub.output[0])
+        if not is_type(div, "Div") or not is_type(pow, "Pow"):
+            continue
+
+        # check that pow ouput is ReduceMean
+        reduce_mean2 = find_output_node(model, pow.output[0])
+        if not is_type(reduce_mean2, "ReduceMean"):
+            continue
+
+        # check that reduce_mean2 output is Add
+        add = find_output_node(model, reduce_mean2.output[0])
+        if not is_type(add, "Add"):
+            continue
+
+        # check that add output is Sqrt
+        sqrt = find_output_node(model, add.output[0])
+        if not is_type(sqrt, "Sqrt"):
+            continue
+
+        # check that sqrt output is div
+        if div != find_output_node(model, sqrt.output[0]):
+            continue
+
+        # check if div output is Mul
+        optional_mul = find_output_node(model, div.output[0])
+        if not is_type(optional_mul, "Mul"):
+            optional_mul = None
+
+        # check if mul output is Add
+        if optional_mul is not None:
+            optional_add = find_output_node(model, optional_mul.output[0])
+        else:
+            optional_add = find_output_node(model, div.output[0])
+        if not is_type(optional_add, "Add"):
+            optional_add = None
+
+
+        # add nodes to remove_nodes
+        remove_nodes.extend([reduce_mean, sub, div, pow, reduce_mean2, add, sqrt])
+
+        # create LayerNorm node
+        layer_norm_input = []
+        layer_norm_output = []
+
+        layer_norm_input.append(reduce_mean.input[0])
+
+        if optional_mul is not None:
+            remove_nodes.append(optional_mul)
+            weight = optional_mul.input[1]
+        else:
+            weight = None # add_const(model, "layer_norm_" + str(id) + "_weight_node", "layer_norm_" + str(id) + ".weight", f_value=numpy_helper(np.ones(10, dtype=np.float32))).output[0]
+
+        layer_norm_input.append(weight)
+
+        if optional_add is not None:
+            remove_nodes.append(optional_add)
+            bias = optional_add.input[1]
+        else:
+            bias = None #add_const(model, "layer_norm_" + str(id) + "_bias_node", "layer_norm_" + str(id) + ".bias", f_value=numpy_helper.from_array(np.zeros(10, dtype=np.float32))).output[0]
+
+        layer_norm_input.append(bias)
+        
+        if optional_add is not None:
+            layer_norm_output.append(optional_add.output[0])
+        elif optional_mul is not None:
+            layer_norm_output.append(optional_mul.output[0])
+        else:
+            layer_norm_output.append(div.output[0])
+
+        layer_norm_output.append('saved_mean_' + str(id))
+        layer_norm_output.append('saved_inv_std_var_' + str(id))
+
+        epsilon_node = find_input_node(model, add.input[1])
+        epsilon = epsilon_node.attribute[0].t.raw_data
+        epsilon = struct.unpack('f', epsilon)[0]
+
+        layer_norm = helper.make_node("LayerNormalization",
+                                      layer_norm_input,
+                                      layer_norm_output,
+                                      "LayerNormalization_" + str(id),
+                                      None,
+                                      axis = reduce_mean.attribute[0].ints[0],
+                                      epsilon = epsilon)
+        layer_norm_nodes.append(layer_norm)
+        id += 1
+
+    # remove orphan constant nodes
+    for constant in graph.node:
+        if constant.op_type == "Constant" and constant not in remove_nodes:
+            is_orphan = True
+            for out_name in constant.output:
+                out = find_output_node(model, out_name)
+                if out not in remove_nodes:
+                    is_orphan = False
+            if is_orphan:
+                remove_nodes.append(constant)
+    
+    all_nodes = []
+    for node in graph.node:
+        if node not in remove_nodes:
+            all_nodes.append(node)
+
+    for node in layer_norm_nodes:
+        all_nodes.append(node)
+
+    graph.ClearField("node")
+    graph.node.extend(all_nodes)
+    return model
+
+# Fuse SoftmaxCrossEntropy
+
+def fuse_sofmaxNLL_to_softmaxCE(onnx_model):
+    nll_count = 0
+    while True:
+        nll_count = nll_count + 1
+        nll_loss_node = None
+        nll_loss_node_index = 0
+        for nll_loss_node_index, node in enumerate(onnx_model.graph.node):
+            if node.op_type == "nll_loss" or node.op_type == "NegativeLogLikelihoodLoss":
+                nll_loss_node = node
+                break
+
+        if nll_loss_node is None:
+            break
+
+        softmax_node = None
+        softmax_node_index = 0
+        label_input_name = None
+        weight_input_name = None
+        for softmax_node_index, node in enumerate(onnx_model.graph.node):
+            if node.op_type == "LogSoftmax":
+                # has to be connected to nll_loss
+                if len(nll_loss_node.input) > 2:
+                    weight_input_name = nll_loss_node.input[2]
+                if node.output[0] == nll_loss_node.input[0]:
+                    softmax_node = node
+                    label_input_name = nll_loss_node.input[1]
+                    break
+                elif node.output[0] == nll_loss_node.input[1]:
+                    softmax_node = node
+                    label_input_name = nll_loss_node.input[0]
+                    break
+            else:
+                if softmax_node is not None:
+                    break
+
+        if softmax_node is None:
+            break
+
+        # delete nll_loss and LogSoftmax nodes in order
+        if nll_loss_node_index < softmax_node_index:
+            del onnx_model.graph.node[softmax_node_index]
+            del onnx_model.graph.node[nll_loss_node_index]
+        else:
+            del onnx_model.graph.node[nll_loss_node_index]
+            del onnx_model.graph.node[softmax_node_index]
+
+        probability_output_name = softmax_node.output[0]
+        node = onnx_model.graph.node.add()
+        inputs = [softmax_node.input[0], label_input_name, weight_input_name] if weight_input_name else [softmax_node.input[0], label_input_name]
+        node.CopyFrom(onnx.helper.make_node("SparseSoftmaxCrossEntropy", inputs,
+                                            [nll_loss_node.output[0], probability_output_name],
+                                            "nll_loss_node_" + str(nll_count)))
+
+    return onnx_model

--- a/orttraining/orttraining/python/postprocess.py
+++ b/orttraining/orttraining/python/postprocess.py
@@ -196,6 +196,7 @@ def layer_norm_transform(model):
         optional_mul = find_output_node(model, div.output[0])
         if not is_type(optional_mul, "Mul"):
             optional_mul = None
+            continue # default bias and weight not supported
 
         # check if mul output is Add
         if optional_mul is not None:
@@ -204,6 +205,7 @@ def layer_norm_transform(model):
             optional_add = find_output_node(model, div.output[0])
         if not is_type(optional_add, "Add"):
             optional_add = None
+            continue # default bias and weight not supported
 
 
         # add nodes to remove_nodes

--- a/orttraining/orttraining/test/python/onnxruntime_test_postprocess.py
+++ b/orttraining/orttraining/test/python/onnxruntime_test_postprocess.py
@@ -1,0 +1,240 @@
+import unittest
+import pytest
+import sys
+import os
+import copy
+from numpy.testing import assert_allclose, assert_array_equal
+
+import onnx
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from orttraining_test_utils import map_optimizer_attributes
+from orttraining_test_transformers import BertModelTest, BertForPreTraining
+from orttraining_test_data_loader import create_ort_test_dataloader
+import onnxruntime
+
+from onnxruntime.capi.ort_trainer import ORTTrainer, IODescription, ModelDescription, LossScaler, generate_sample
+
+torch.manual_seed(1)
+onnxruntime.set_seed(1)
+
+class Test_PostPasses(unittest.TestCase):
+    def get_onnx_model(self, model, model_desc, inputs, device):
+        lr_desc = IODescription('Learning_Rate', [1,], torch.float32)
+        model = ORTTrainer(model,
+                           None,
+                           model_desc,
+                           "LambOptimizer",
+                           map_optimizer_attributes,
+                           lr_desc,
+                           device,
+                           world_rank=0,
+                           world_size=1,
+                           _opset_version=12)
+
+        train_output = model.train_step(*inputs)
+        return model.onnx_model_
+
+    def count_all_nodes(self, model):
+        return len(model.graph.node)
+    
+    def count_nodes(self, model, node_type):
+        count = 0
+        for node in model.graph.node:
+            if node.op_type == node_type:
+                count += 1
+        return count
+
+    def find_nodes(self, model, node_type):
+        nodes = []
+        for node in model.graph.node:
+            if node.op_type == node_type:
+                nodes.append(node)
+        return nodes
+
+    def get_name(self, name):
+        if os.path.exists(name):
+            return name
+        rel = os.path.join("testdata", name)
+        if os.path.exists(rel):
+            return rel
+        this = os.path.dirname(__file__)
+        data = os.path.join(this, "..", "..", "..", "..", "onnxruntime", "test", "testdata")
+        res = os.path.join(data, name)
+        if os.path.exists(res):
+            return res
+        raise FileNotFoundError("Unable to find '{0}' or '{1}' or '{2}'".format(name, rel, res))
+
+    def test_layer_norm(self):
+        class LayerNormNet(nn.Module):
+            def __init__(self, target):
+                super(LayerNormNet, self).__init__()
+                self.ln_1 = nn.LayerNorm(10)
+                self.loss = nn.CrossEntropyLoss()
+                self.target = target
+
+            def forward(self, x):
+                output1 = self.ln_1(x)
+                loss = self.loss(output1, self.target)
+                return loss, output1
+
+        device = torch.device("cpu")
+        target = torch.ones(20, 10, 10, dtype=torch.int64).to(device)
+        model = LayerNormNet(target)
+        input = torch.randn(20, 5, 10, 10, dtype=torch.float32).to(device)
+
+        input_desc = IODescription('input', [], "float32")
+        output0_desc = IODescription('output0', [], "float32")
+        output1_desc = IODescription('output1', [20, 5, 10, 10], "float32")
+        output2_desc = IODescription('output2', [20, 5, 10, 10], "float32")
+        model_desc = ModelDescription([input_desc], [output0_desc, output1_desc])
+
+        learning_rate = torch.tensor([1.0000000e+00]).to(device)
+        input_args=[input, learning_rate]
+
+        onnx_model = self.get_onnx_model(model, model_desc, input_args, device)
+
+        count_layer_norm = self.count_nodes(onnx_model, "LayerNormalization")
+        count_nodes = self.count_all_nodes(onnx_model)
+       
+        assert count_layer_norm == 1
+        assert count_nodes == 3
+
+    def test_expand(self):
+        class ExpandNet(nn.Module):
+            def __init__(self, target):
+                super(ExpandNet, self).__init__()
+                self.loss = nn.CrossEntropyLoss()
+                self.target = target
+
+            def forward(self, x, x1):
+                output = x.expand_as(x1)
+                output = output + output
+                loss = self.loss(output, self.target)
+                return loss, output
+
+        device = torch.device("cpu")
+        target = torch.ones(5, 5, 2, dtype=torch.int64).to(device)
+        model = ExpandNet(target).to(device)
+
+        x = torch.randn(5, 3, 1, 2, dtype=torch.float32).to(device)
+        x1 = torch.randn(5, 3, 5, 2, dtype=torch.float32).to(device)
+
+        input0_desc = IODescription('input0', [5, 3, 1, 2], "float32")
+        input1_desc = IODescription('input1', [5, 3, 5, 2], "float32")
+        output0_desc = IODescription('output0', [], "float32")
+        output1_desc = IODescription('output1', [5, 3, 5, 2], "float32")
+        model_desc = ModelDescription([input0_desc, input1_desc], [output0_desc, output1_desc])
+
+        learning_rate = torch.tensor([1.0000000e+00]).to(device)
+        input_args = [x, x1, learning_rate]
+
+        onnx_model = self.get_onnx_model(model, model_desc, input_args, device)
+
+        # check that expand output has shape 
+        expand_nodes = self.find_expand_nodes(onnx_model, "Expand")
+        assert len(expand_nodes) == 1
+
+        model_info = onnx_model.grah.value_info
+        assert model_info[0].name == expand_nodes[0].output[0]
+        assert model_info[0].type == onnx_model.graph.input[1].type
+
+    def test_bert(self):
+        device = torch.device("cpu")
+
+        model_tester = BertModelTest.BertModelTester(self)
+        config, input_ids, token_type_ids, input_mask, sequence_labels, token_labels, choice_labels = model_tester.prepare_config_and_inputs()
+        
+        model = BertForPreTraining(config=config)
+        model.eval()
+
+        loss, prediction_scores, seq_relationship_score = model(input_ids,
+                                                                attention_mask=input_mask,
+                                                                token_type_ids=token_type_ids,
+                                                                masked_lm_labels=token_labels,
+                                                                next_sentence_label=sequence_labels)
+
+        model_desc = ModelDescription([model_tester.input_ids_desc,
+                                       model_tester.attention_mask_desc,
+                                       model_tester.token_type_ids_desc,
+                                       model_tester.masked_lm_labels_desc,
+                                       model_tester.next_sentence_label_desc],
+                                      [model_tester.loss_desc,
+                                       model_tester.prediction_scores_desc,
+                                       model_tester.seq_relationship_scores_desc])
+
+        from collections import namedtuple
+        MyArgs = namedtuple("MyArgs",
+                            "local_rank world_size max_steps learning_rate warmup_proportion batch_size seq_len")
+        args = MyArgs(local_rank=0,
+                      world_size=1,
+                      max_steps=100,
+                      learning_rate=0.00001,
+                      warmup_proportion=0.01,
+                      batch_size=13,
+                      seq_len=7)
+
+        dataloader = create_ort_test_dataloader(model_desc.inputs_,
+                                                args.batch_size,
+                                                args.seq_len,
+                                                device)
+        learning_rate = torch.tensor(1.0e+0, dtype=torch.float32).to(device)
+        for b in dataloader:
+            batch = b
+            break
+        learning_rate = torch.tensor([1.00e+00]).to(device)
+        inputs = batch + [learning_rate,]
+
+        onnx_model = self.get_onnx_model(model, model_desc, inputs, device)
+
+        self._bert_helper(onnx_model)
+
+    def test_bert_from_ONNX(self):
+        device = torch.device("cpu")
+        onnx_model = onnx.load(self.get_name("bert_no_postprocessing.onnx"))
+
+        vocab_size = 30528
+        input_ids_desc = IODescription('input_ids', ['batch', 'max_seq_len_in_batch'], torch.int64, num_classes=vocab_size)
+        segment_ids_desc = IODescription('segment_ids', ['batch', 'max_seq_len_in_batch'], torch.int64, num_classes=2)
+        input_mask_desc = IODescription('input_mask', ['batch', 'max_seq_len_in_batch'], torch.int64, num_classes=2)
+        masked_lm_labels_desc = IODescription('masked_lm_labels', ['batch', 'max_seq_len_in_batch'], torch.int64, num_classes=vocab_size)
+        next_sentence_labels_desc = IODescription('next_sentence_labels', ['batch', ], torch.int64, num_classes=2)
+        loss_desc = IODescription('loss', [], torch.float32)
+
+        model_desc = ModelDescription([input_ids_desc, segment_ids_desc, input_mask_desc, masked_lm_labels_desc, next_sentence_labels_desc], [loss_desc])
+
+
+        map_opimizer_attributes = None
+
+        # verify that the initial model is not processed
+        count_layer_norm = self.count_nodes(onnx_model, "LayerNormalization")
+        assert count_layer_norm == 0
+
+        model_info = onnx_model.graph.value_info
+        assert len(model_info) == 0
+
+        model = ORTTrainer(onnx_model, None, model_desc, "LambOptimizer",
+                           map_optimizer_attributes, IODescription('Learning_Rate', [1,], torch.float32),
+                           device, world_rank=0, world_size=1, _opset_version=12)
+
+        self._bert_helper(model.onnx_model_)
+
+    def _bert_helper(self, onnx_model):
+        # count layer_norm
+        count_layer_norm = self.count_nodes(onnx_model, "LayerNormalization")
+        assert count_layer_norm == 12
+
+        # get expand node and check output shape
+        expand_nodes = self.find_nodes(onnx_model, "Expand")
+        assert len(expand_nodes) == 1
+
+        model_info = onnx_model.graph.value_info
+        assert model_info[0].name == expand_nodes[0].output[0]
+        assert model_info[0].type == onnx_model.graph.input[0].type
+
+
+if __name__ == '__main__':
+    unittest.main(module=__name__, buffer=True)
+

--- a/orttraining/orttraining/test/python/onnxruntime_test_postprocess.py
+++ b/orttraining/orttraining/test/python/onnxruntime_test_postprocess.py
@@ -39,7 +39,7 @@ class Test_PostPasses(unittest.TestCase):
 
     def count_all_nodes(self, model):
         return len(model.graph.node)
-    
+
     def count_nodes(self, model, node_type):
         count = 0
         for node in model.graph.node:
@@ -88,7 +88,6 @@ class Test_PostPasses(unittest.TestCase):
         input_desc = IODescription('input', [], "float32")
         output0_desc = IODescription('output0', [], "float32")
         output1_desc = IODescription('output1', [20, 5, 10, 10], "float32")
-        output2_desc = IODescription('output2', [20, 5, 10, 10], "float32")
         model_desc = ModelDescription([input_desc], [output0_desc, output1_desc])
 
         learning_rate = torch.tensor([1.0000000e+00]).to(device)
@@ -98,7 +97,7 @@ class Test_PostPasses(unittest.TestCase):
 
         count_layer_norm = self.count_nodes(onnx_model, "LayerNormalization")
         count_nodes = self.count_all_nodes(onnx_model)
-       
+
         assert count_layer_norm == 1
         assert count_nodes == 3
 
@@ -133,7 +132,7 @@ class Test_PostPasses(unittest.TestCase):
 
         onnx_model = self.get_onnx_model(model, model_desc, input_args, device)
 
-        # check that expand output has shape 
+        # check that expand output has shape
         expand_nodes = self.find_expand_nodes(onnx_model, "Expand")
         assert len(expand_nodes) == 1
 
@@ -146,7 +145,7 @@ class Test_PostPasses(unittest.TestCase):
 
         model_tester = BertModelTest.BertModelTester(self)
         config, input_ids, token_type_ids, input_mask, sequence_labels, token_labels, choice_labels = model_tester.prepare_config_and_inputs()
-        
+
         model = BertForPreTraining(config=config)
         model.eval()
 

--- a/orttraining/orttraining/test/python/orttraining_test_bert_postprocess.py
+++ b/orttraining/orttraining/test/python/orttraining_test_bert_postprocess.py
@@ -3,5 +3,3 @@ from orttraining_test_layer_norm_transform import layer_norm_transform
 
 def postprocess_model(model):
     add_name(model)
-
-    add_expand_shape(model)

--- a/orttraining/orttraining/test/python/orttraining_test_bert_postprocess.py
+++ b/orttraining/orttraining/test/python/orttraining_test_bert_postprocess.py
@@ -4,9 +4,4 @@ from orttraining_test_layer_norm_transform import layer_norm_transform
 def postprocess_model(model):
     add_name(model)
 
-    # remove transpose node if its input is a 2d weight which only feeds to the node
-    fix_transpose(model)
-
     add_expand_shape(model)
-    
-    layer_norm_transform(model)

--- a/orttraining/orttraining/test/python/orttraining_test_utils.py
+++ b/orttraining/orttraining/test/python/orttraining_test_utils.py
@@ -19,7 +19,7 @@ def warmup_linear(x, warmup=0.002):
     if x < warmup:
         return x/warmup
     return max((x - 1. )/ (warmup - 1.), 0.)
-    
+
 def warmup_poly(x, warmup=0.002, degree=0.5):
     if x < warmup:
         return x/warmup
@@ -49,15 +49,16 @@ def map_optimizer_attributes(name):
         return {"alpha": 0.9, "beta": 0.999, "lambda": 0.01, "epsilon": 1e-6}
 
 def run_test(model, model_desc, device, args, gradient_accumulation_steps, fp16,
-    allreduce_post_accumulation, get_lr_this_step, use_internal_get_lr_this_step, loss_scaler, use_internal_loss_scaler, 
+    allreduce_post_accumulation, get_lr_this_step, use_internal_get_lr_this_step, loss_scaler, use_internal_loss_scaler,
     batch_args_option):
     dataloader = create_ort_test_dataloader(model_desc.inputs_, args.batch_size, args.seq_len, device)
 
     model = ORTTrainer(model, None, model_desc, "LambOptimizer",
         map_optimizer_attributes=map_optimizer_attributes,
         learning_rate_description=IODescription('Learning_Rate', [1,], torch.float32),
-        device=device, postprocess_model=postprocess_model,
-        gradient_accumulation_steps=gradient_accumulation_steps,                
+        device=device, _extra_postprocess=postprocess_model,
+        _enable_internal_postprocess=True,
+        gradient_accumulation_steps=gradient_accumulation_steps,
         # BertLAMB default initial settings: b1=0.9, b2=0.999, e=1e-6
         world_rank=args.local_rank, world_size=args.world_size,
         use_mixed_precision=fp16,

--- a/orttraining/orttraining/test/python/orttraining_test_utils.py
+++ b/orttraining/orttraining/test/python/orttraining_test_utils.py
@@ -56,7 +56,7 @@ def run_test(model, model_desc, device, args, gradient_accumulation_steps, fp16,
     model = ORTTrainer(model, None, model_desc, "LambOptimizer",
         map_optimizer_attributes=map_optimizer_attributes,
         learning_rate_description=IODescription('Learning_Rate', [1,], torch.float32),
-        device=device, _extra_postprocess=postprocess_model,
+        device=device,
         _enable_internal_postprocess=True,
         gradient_accumulation_steps=gradient_accumulation_steps,
         # BertLAMB default initial settings: b1=0.9, b2=0.999, e=1e-6


### PR DESCRIPTION
Replacing #3942

Description: This PR adds ONNX post-process to the PyTorch front-end. The User can disable these passes by setting _enable_internal_postprocess to False (default is True).

Motivation and Context

    These are common training post-passes, by ading them to the front-end, we abstract complexity from the user.

