### PR TITLE
re-enable graph optimizations during build phase

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1181,6 +1181,7 @@ def run_onnx_tests(build_dir, configs, onnx_test_data_dir, provider,
         # Temporarily disable optimizers because some
         # of them are failing
         # cmd = ["-o", "0"]
+        cmd = []
         if provider:
             cmd += ["-e", provider]
         if num_parallel_tests != 0:

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1180,7 +1180,7 @@ def run_onnx_tests(build_dir, configs, onnx_test_data_dir, provider,
             model_dir = os.path.join(build_dir, "models")
         # Temporarily disable optimizers because some
         # of them are failing
-        cmd = ["-o", "0"]
+        # cmd = ["-o", "0"]
         if provider:
             cmd += ["-e", provider]
         if num_parallel_tests != 0:

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1060,7 +1060,7 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs,
                 'cd /data/local/tmp && /data/local/tmp/onnxruntime_test_all')
             if args.use_dnnlibrary:
                 adb_shell(
-                    'cd /data/local/tmp && /data/local/tmp/onnx_test_runner -e nnapi -o 0 /data/local/tmp/test')  # noqa
+                    'cd /data/local/tmp && /data/local/tmp/onnx_test_runner -e nnapi /data/local/tmp/test')  # noqa
             else:
                 adb_shell(
                     'cd /data/local/tmp && /data/local/tmp/onnx_test_runner /data/local/tmp/test')  # noqa
@@ -1178,9 +1178,7 @@ def run_onnx_tests(build_dir, configs, onnx_test_data_dir, provider,
         else:
             exe = os.path.join(cwd, 'onnx_test_runner')
             model_dir = os.path.join(build_dir, "models")
-        # Temporarily disable optimizers because some
-        # of them are failing
-        # cmd = ["-o", "0"]
+
         cmd = []
         if provider:
             cmd += ["-e", provider]
@@ -1216,7 +1214,7 @@ def tensorrt_run_onnx_tests(args, build_dir, configs, onnx_test_data_dir,
             exe = os.path.join(cwd, 'onnx_test_runner')
             model_dir = os.path.join(build_dir, "models")
 
-        cmd_base = ['-o', '0']
+        cmd_base = []
         if provider:
             cmd_base += ["-e", provider]
 
@@ -1306,7 +1304,7 @@ def dnnl_run_onnx_tests(build_dir, configs, onnx_test_data_dir):
         else:
             exe = os.path.join(cwd, 'onnx_test_runner')
             model_dir = os.path.join(build_dir, "models")
-        cmd_base = ['-o', '0', '-e', 'dnnl', '-c', '1', '-j', '1']
+        cmd_base = ['-e', 'dnnl', '-c', '1', '-j', '1']
         if os.path.exists(onnx_test_data_dir):
             onnxdata_cmd = cmd_base + [onnx_test_data_dir]
             # /data/onnx


### PR DESCRIPTION
**Description**: Re enabling graph optimizations which were disabled after the recent onnx update
(In progress)

**Motivation and Context**
- After the recent onnx update graph optimizations were disabled for onnx test runner because some tests were failing. This change is to re enable the optimizations.

