### PR TITLE
Fix python packaging pipeline failure

### DIFF
--- a/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/azure-pipelines-py-packaging.yml
@@ -178,10 +178,17 @@ jobs:
       workingFolder: '$(Build.BinariesDirectory)'
 
   - script: |
-     python -m pip install -q pyopenssl setuptools wheel numpy==1.16.6
+     python -m pip install -q pyopenssl setuptools wheel numpy==1.16.6 scipy
 
     workingDirectory: '$(Build.BinariesDirectory)'
     displayName: 'Install python modules'
+
+  - powershell: |
+     $env:Path += ";C:\vcpkg\installed\x64-windows\tools\protobuf"
+     Set-Location (Join-Path -Path C:\vcpkg\buildtrees\protobuf\src -ChildPath (Get-ChildItem -Path C:\vcpkg\buildtrees\protobuf\src | Select-Object -First 1))
+     cd python
+     python -m pip install .
+    displayName: 'Install Protobuf python package from source'
 
   - powershell: |
      $Env:USE_MSVC_STATIC_RUNTIME=1
@@ -253,7 +260,7 @@ jobs:
         workingFolder: '$(Build.BinariesDirectory)'
 
     - script: |
-       python -m pip install -q pyopenssl setuptools wheel numpy==1.16.6
+       python -m pip install -q pyopenssl setuptools wheel numpy==1.16.6 scipy
       workingDirectory: '$(Build.BinariesDirectory)'
       displayName: 'Install python modules'
 


### PR DESCRIPTION
**Description**: 

Fix python packaging pipeline failure

**Motivation and Context**
- Why is this change required? What problem does it solve?

The latest protobuf release(3.12) doesn't have a prebuilt package for python 3.8. We are using an older one with the py files that generated from protobuf 3.12. Then it fails. 

- If it fixes an open issue, please link to the issue here.
