### PR TITLE
Add noexcept to various OrtCallback utility class methods to fix warnings.

### DIFF
--- a/onnxruntime/core/framework/callback.h
+++ b/onnxruntime/core/framework/callback.h
@@ -19,16 +19,16 @@ void OrtRunCallback(OrtCallback* f) noexcept;
  * Useful for something like a std::unique_ptr<> deleter.
  */
 struct OrtCallbackInvoker {
-  OrtCallbackInvoker()
+  OrtCallbackInvoker() noexcept
       : callback{nullptr, nullptr} {}
 
-  OrtCallbackInvoker(OrtCallback callback_to_invoke)
+  OrtCallbackInvoker(OrtCallback callback_to_invoke) noexcept
       : callback(callback_to_invoke) {}
 
   OrtCallback callback;
 
   template <typename T>
-  void operator()(T) {
+  void operator()(T) noexcept {
     if (callback.f) {
       callback.f(callback.param);
     }
@@ -40,16 +40,16 @@ struct OrtCallbackInvoker {
  */
 class ScopedOrtCallbackInvoker {
  public:
-  explicit ScopedOrtCallbackInvoker(OrtCallback callback)
+  explicit ScopedOrtCallbackInvoker(OrtCallback callback) noexcept
       : callback_(callback) {}
 
-  ScopedOrtCallbackInvoker(ScopedOrtCallbackInvoker&& other)
+  ScopedOrtCallbackInvoker(ScopedOrtCallbackInvoker&& other) noexcept
       : callback_(other.callback_) {
     other.callback_.f = nullptr;
     other.callback_.param = nullptr;
   }
 
-  ScopedOrtCallbackInvoker& operator=(ScopedOrtCallbackInvoker&& other) {
+  ScopedOrtCallbackInvoker& operator=(ScopedOrtCallbackInvoker&& other) noexcept {
     if (callback_.f) {
       callback_.f(callback_.param);
     }
@@ -61,7 +61,7 @@ class ScopedOrtCallbackInvoker {
     return *this;
   }
 
-  ~ScopedOrtCallbackInvoker() {
+  ~ScopedOrtCallbackInvoker() noexcept {
     if (callback_.f) {
       callback_.f(callback_.param);
     }


### PR DESCRIPTION
**Description**
Add noexcept to various OrtCallback utility class methods to fix warnings.

**Motivation and Context**
Fixes warnings like this one:
onnxruntime\core\framework\callback.h(46,0): Warning C26439: This kind of function may not throw. Declare it 'noexcept' (f.6).
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=161733&view=logs&j=0c0c570a-fc92-5ebc-bc7b-8fef68d9a271&t=1fc0a3b5-075f-5ff5-b04f-77c0e7cc68f6&l=1761
