### PR TITLE
[OpenVINO-EP] Add missing dependency libs in Dockerfile

### DIFF
--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -36,7 +36,6 @@ RUN apt update && \
     cp onnxruntime/docs/Privacy.md /code/Privacy.md && \
     cp onnxruntime/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt && \
     cp onnxruntime/ThirdPartyNotices.txt /code/ThirdPartyNotices.txt && \
-    sed -i "s/sudo//" onnxruntime/dockerfiles/scripts/install_common_deps.sh &&\
     /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh && \
     cd onnxruntime/cmake/external/onnx && python3 setup.py install && \
     pip install azure-iothub-device-client azure-iothub-service-client azure-iot-provisioning-device-client && \

--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -30,12 +30,13 @@ ENV LANG en_US.UTF-8
 
 RUN apt update && \
     apt -y install git sudo wget locales \
-    zip x11-apps lsb-core cpio libboost-python-dev libpng-dev zlib1g-dev libnuma1 ocl-icd-libopencl1 clinfo libboost-filesystem1.58.0 libboost-thread1.58.0 protobuf-compiler libprotoc-dev libusb-1.0-0-dev autoconf automake libtool && \
+    zip x11-apps lsb-core cpio libboost-python-dev libpng-dev zlib1g-dev libnuma1 ocl-icd-libopencl1 clinfo libboost-filesystem1.58.0 libboost-thread1.58.0 protobuf-compiler libprotoc-dev libusb-1.0-0-dev autoconf automake libtool libudev-dev libjson-c-dev && \
     cd ${MY_ROOT} && \
     git clone --recursive -b $ONNXRUNTIME_BRANCH $ONNXRUNTIME_REPO onnxruntime && \
     cp onnxruntime/docs/Privacy.md /code/Privacy.md && \
     cp onnxruntime/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt && \
     cp onnxruntime/ThirdPartyNotices.txt /code/ThirdPartyNotices.txt && \
+    sed -i "s/sudo//" onnxruntime/dockerfiles/scripts/install_common_deps.sh &&\
     /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh && \
     cd onnxruntime/cmake/external/onnx && python3 setup.py install && \
     pip install azure-iothub-device-client azure-iothub-service-client azure-iot-provisioning-device-client && \

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -159,11 +159,11 @@ Use `docker pull` with any of the images and tags below to pull an image and try
 
 1.  Download OpenVINO **Full package** for version **2020.2** for Linux on host machine from [this link](https://software.intel.com/en-us/openvino-toolkit/choose-download) and install it with the help of instructions from [this link](https://docs.openvinotoolkit.org/latest/_docs_install_guides_installing_openvino_linux.html)
 
-2. Install the HDDL drivers on the host machine according to the reference in [here](https://docs.openvinotoolkit.org/latest/_docs_install_guides_installing_openvino_linux_ivad_vpu.html)
+2. Install the drivers on the host machine according to the reference in [here](https://docs.openvinotoolkit.org/latest/_docs_install_guides_installing_openvino_linux_ivad_vpu.html)
 
 3. Build the docker image from the DockerFile in this repository.
      ```
-      docker build --rm -t onnxruntime-vadr --build-arg DEVICE=VAD-M_FP16 --network host .
+      docker build --rm -t onnxruntime-vadm --build-arg DEVICE=VAD-M_FP16 --network host .
      ```
 4. Run hddldaemon on the host in a separate terminal session using the following command: 
      ```
@@ -171,7 +171,7 @@ Use `docker pull` with any of the images and tags below to pull an image and try
      ```
 5. Run the docker image by mounting the device drivers
     ```
-    docker run -it --device --mount type=bind,source=/var/tmp,destination=/var/tmp --device /dev/ion:/dev/ion  onnxruntime-hddl:latest
+    docker run -it --device --mount type=bind,source=/var/tmp,destination=/var/tmp --device /dev/ion:/dev/ion  onnxruntime-vadm:latest
 
     ```
 ## ARM 32v7

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -157,13 +157,19 @@ Use `docker pull` with any of the images and tags below to pull an image and try
 
 ### OpenVINO on VAD-M Accelerator Version
 
-1. Build the docker image from the DockerFile in this repository.
+1.  Download OpenVINO **Full package** for version **2020.2** for Linux on host machine from [this link](https://software.intel.com/en-us/openvino-toolkit/choose-download) and install it with the help of instructions from [this link](https://docs.openvinotoolkit.org/latest/_docs_install_guides_installing_openvino_linux.html)
+
+2. Install the HDDL drivers on the host machine according to the reference in [here](https://docs.openvinotoolkit.org/latest/_docs_install_guides_installing_openvino_linux_ivad_vpu.html)
+
+3. Build the docker image from the DockerFile in this repository.
      ```
       docker build --rm -t onnxruntime-vadr --build-arg DEVICE=VAD-M_FP16 --network host .
      ```
-2. Install the HDDL drivers on the host machine according to the reference in [here](https://docs.openvinotoolkit.org/latest/_docs_install_guides_installing_openvino_linux_ivad_vpu.html)
-
-3. Run the docker image by mounting the device drivers
+4. Run hddldaemon on the host in a separate terminal session using the following command: 
+     ```
+      $HDDL_INSTALL_DIR/bin/hddldaemon
+     ```
+5. Run the docker image by mounting the device drivers
     ```
     docker run -it --device --mount type=bind,source=/var/tmp,destination=/var/tmp --device /dev/ion:/dev/ion  onnxruntime-hddl:latest
 

--- a/dockerfiles/scripts/install_common_deps.sh
+++ b/dockerfiles/scripts/install_common_deps.sh
@@ -19,6 +19,6 @@ pip install numpy
 rm -rf /opt/miniconda/pkgs
 
 # Dependencies: cmake
-sudo wget --quiet https://github.com/Kitware/CMake/releases/download/v3.14.3/cmake-3.14.3-Linux-x86_64.tar.gz
+wget --quiet https://github.com/Kitware/CMake/releases/download/v3.14.3/cmake-3.14.3-Linux-x86_64.tar.gz
 tar zxf cmake-3.14.3-Linux-x86_64.tar.gz
 rm -rf cmake-3.14.3-Linux-x86_64.tar.gz


### PR DESCRIPTION
**Description**: 
- Added missing VAD-M hardware dependency libs into Dockerfile.
- Update documentation with instructions on starting HDDL Daemon.

**Motivation and Context**
- Required to be able to run the MCR Docker container on VAD-M hardware
