### PR TITLE
Make CPU QuantizeLinear support optional zero point

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/quantize_linear.cc
+++ b/onnxruntime/core/providers/cpu/tensor/quantize_linear.cc
@@ -102,7 +102,7 @@ template <typename T>
 Status QuantizeLinear<T>::Compute(OpKernelContext* ctx) const {
   auto& x = *ctx->Input<Tensor>(0);
   auto& y_scale = *ctx->Input<Tensor>(1);
-  auto& y_zero_point = *ctx->Input<Tensor>(2);
+  auto* y_zero_point = ctx->Input<Tensor>(2);
   const auto& x_shape = x.Shape();
   auto& y = *ctx->Output(0, x_shape);
 
@@ -110,33 +110,40 @@ Status QuantizeLinear<T>::Compute(OpKernelContext* ctx) const {
   int64_t broadcast_dim;
   int64_t block_size;
 
-  if (has_axis_) {
+  if (has_axis_) {  // custom QuantizeLinear only
     const int64_t axis = HandleNegativeAxis(axis_, x_shape.NumDimensions());
     N = x_shape.SizeToDimension(axis);
     broadcast_dim = x_shape[axis];
     block_size = x_shape.SizeFromDimension(axis + 1);
 
     // if an axis was specified, ensure the scale and zero point are compatible
-    ORT_ENFORCE(y_scale.Shape().NumDimensions() == 1 && y_scale.Shape().Size() == broadcast_dim, "x_scale must be 1D tensor with size ", broadcast_dim);
-    ORT_ENFORCE(y_zero_point.Shape().NumDimensions() == 1 && y_zero_point.Shape().Size() == broadcast_dim, "x_zero_point must be 1D tensor with size ", broadcast_dim);
+    ORT_ENFORCE(y_scale.Shape().NumDimensions() == 1 && y_scale.Shape().Size() == broadcast_dim,
+                "y_scale must be 1D tensor with size ",
+                broadcast_dim);
+    ORT_ENFORCE(y_zero_point != nullptr && y_zero_point->Shape().NumDimensions() == 1 && y_zero_point->Shape().Size() == broadcast_dim,
+                "y_zero_point must be 1D tensor with size ",
+                broadcast_dim);
   } else {
     N = 1;
     broadcast_dim = 1;
     block_size = x_shape.Size();
 
     // if no axis, enforce that scale and zero point are scalars
-    ORT_ENFORCE(IsScalarOr1ElementVector(&y_scale), "x_scale must be a scalar or 1D tensor or size 1.");
-    ORT_ENFORCE(IsScalarOr1ElementVector(&y_zero_point), "x_zero_point must be a scalar or 1D tensor or size 1.");
+    ORT_ENFORCE(IsScalarOr1ElementVector(&y_scale),
+                "y_scale must be a scalar or 1D tensor or size 1.");
+    ORT_ENFORCE(y_zero_point == nullptr || IsScalarOr1ElementVector(y_zero_point),
+                "y_zero_point must be a scalar or 1D tensor or size 1.");
   }
 
-  const T* zero_point = y_zero_point.template Data<T>();
+  const T* zero_point = y_zero_point != nullptr ? y_zero_point->template Data<T>() : nullptr;
   const float* scale = y_scale.template Data<float>();
   const float* input = x.template Data<float>();
   T* output = y.template MutableData<T>();
 
   for (size_t n = 0; n < static_cast<size_t>(N); n++) {
     for (size_t bd = 0; bd < static_cast<size_t>(broadcast_dim); bd++) {
-      MlasQuantizeLinear(input, output, static_cast<size_t>(block_size), scale[bd], zero_point[bd]);
+      T zp = zero_point != nullptr ? zero_point[bd] : 0;
+      MlasQuantizeLinear(input, output, static_cast<size_t>(block_size), scale[bd], zp);
       input += block_size;
       output += block_size;
     }

--- a/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
@@ -141,7 +141,7 @@ TEST(QuantizeLinearOpTest, DISABLED_QuantizeLinear_With_Zero_Point) {
   test.AddInput<float>("x", {}, {3});
   test.AddInput<float>("y_scale", {}, {2.0f});
   test.AddOutput<uint8_t>("y", {}, {2});
-  test.Run();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kNGraphExecutionProvider});
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
@@ -61,7 +61,7 @@ TEST(DequantizeLinearOpTest, DequantizeLinear_Without_Zero_Point) {
   test.AddInput<int8_t>("x", {}, {100});
   test.AddInput<float>("x_scale", {}, {2.0f});
   test.AddOutput<float>("y", {}, {200.0f});
-  test.Run();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kNGraphExecutionProvider});
 }
 
 // quantize with scalar zero point and scale

--- a/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
@@ -136,7 +136,7 @@ TEST(QuantizeLinearOpTest, QuantizeLinear_Scalar) {
 }
 
 // quantize with scalar data
-TEST(QuantizeLinearOpTest, DISABLED_QuantizeLinear_With_Zero_Point) {
+TEST(QuantizeLinearOpTest, DISABLED_QuantizeLinear_Without_Zero_Point) {
   OpTester test("QuantizeLinear", 10);
   test.AddInput<float>("x", {}, {3});
   test.AddInput<float>("y_scale", {}, {2.0f});


### PR DESCRIPTION
**Description**: Describe your changes.
1. Make CPU QuantizeLinear support optional zero poin
2. Disable DequantizeLinear_Without_Zero_Point test for nGraph
**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
