### PR TITLE
Fix a problem in StacktraceTests::BasicTests

### DIFF
--- a/onnxruntime/test/platform/windows/stacktrace_test.cc
+++ b/onnxruntime/test/platform/windows/stacktrace_test.cc
@@ -28,9 +28,6 @@ TEST(StacktraceTests, BasicTests) {
     // this method name should be the first on the stack as we hide the calls to the infrastructure that
     // creates the stack trace
     EXPECT_THAT(result[0], HasSubstr("BasicTests"));
-  else
-    // check that we have
-    EXPECT_THAT(result[0], HasSubstr("Unknown symbol"));
 
   try {
     ORT_THROW("Testing");


### PR DESCRIPTION
**Description**: 

Fix a problem in StacktraceTests::BasicTests

**Motivation and Context**
- Why is this change required? What problem does it solve?

result.size() could be zero, in this case, we shouldn't access result[0]
- If it fixes an open issue, please link to the issue here.
