### PR TITLE
Remove ONNX from requirements.txt

### DIFF
--- a/onnxruntime/python/backend/backend.py
+++ b/onnxruntime/python/backend/backend.py
@@ -21,6 +21,7 @@ class OnnxRuntimeBackend(Backend):
     multiple runtimes with the same API.
     `Importing models from ONNX to Caffe2 <https://github.com/onnx/tutorials/blob/master/tutorials/OnnxCaffe2Import.ipynb>`_
     shows how to use *caffe2* as a backend for a converted model.
+    Note: This is not the official Python API.
     """  # noqa: E501
 
     @classmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 numpy >= 1.16.6
-onnx >= 1.2.3 ; platform_machine != 'aarch64'
 protobuf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy >= 1.16.6
-onnx >= 1.2.3
+onnx >= 1.2.3 ; platform_machine != 'aarch64'
 protobuf


### PR DESCRIPTION
**Description**: Remove ONNX package from requirements.txt, making it optional when using onnxruntime.

**Motivation and Context**
- Why is this change required? What problem does it solve? You can use onnxruntime to do inferencing without ONNX package installed. Having ONNX as a dependency causes issue on aarch devices as ONNX whl is not there for aarch64 platform and has to be built from source, which has a bunch of dependencies and is very slow on these devices with limited compute.
- If it fixes an open issue, please link to the issue here.
