### PR TITLE
Set spdlog submodule branch to "master" explicitly.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,6 +52,7 @@
 [submodule "server/external/spdlog"]
 	path = server/external/spdlog
 	url = https://github.com/gabime/spdlog.git
+	branch = master
 [submodule "cmake/external/FeaturizersLibrary"]
 	path = cmake/external/FeaturizersLibrary
 	url = https://github.com/microsoft/FeaturizersLibrary.git


### PR DESCRIPTION
**Description**: Updates the `.gitmodules` to use the "master" branch for the spdlog submodule. 

**Motivation and Context**
- The default branch for the spdlog repository on GitHub recently changed from "master"
to "v1.x", which has a different API for `syslog_sink::syslog_sink()`.
- Building with the "v1.x" branch breaks builds of the server for anyone who has checked out the submodules since that change.
- Fixes #4077.
