### PR TITLE
Update GPT2 Model Benchmark Script to Support IO Binding

### DIFF
--- a/onnxruntime/ReformatSourcePython.bat
+++ b/onnxruntime/ReformatSourcePython.bat
@@ -6,7 +6,7 @@
 
 :: If you use Visual Studio Code, you can configure like the following:
 ::    "python.formatting.provider": "yapf"
-::    "python.formatting.yapfArgs": ["--style", "{based_on_style: google, column_limit: 120}"]
+::    "python.formatting.yapfArgs": ["--style", "{based_on_style: pep8, column_limit: 120}"]
 :: See https://code.visualstudio.com/docs/python/editing for more info
 
 :: The style configuration file is .style.yapf in current directory.

--- a/onnxruntime/python/tools/transformers/benchmark_gpt2.py
+++ b/onnxruntime/python/tools/transformers/benchmark_gpt2.py
@@ -76,26 +76,73 @@ def onnxruntime_inference(ort_session, input_ids, past=None, total_runs=100):
 
     return ort_outputs, average_latency
 
+def onnxruntime_inference_with_binded_io(ort_session, input_ids, last_state, last_state_shape, past=None, present=None, present_shape=None, total_runs=100):
+    # Bind inputs and outputs to onnxruntime session        
+    io_binding = ort_session.io_binding()
+    # Bind inputs
+    io_binding.bind_input('input_ids', input_ids.device.type, 0, numpy.longlong, 
+        list(input_ids.size()), input_ids.data_ptr())
+    if past is not None:
+        for i, past_i in enumerate(past):
+            io_binding.bind_input(f'past_{i}', past[i].device.type, 0, numpy.float32, 
+                list(past[i].size()), past[i].data_ptr())
+    
+    # Bind outputs
+    io_binding.bind_output("last_state", last_state.device.type, 0, numpy.float32,
+        last_state_shape, last_state.data_ptr())
+    if present is not None:
+        for i, present_i in enumerate(present):
+            io_binding.bind_output(f'present_{i}', present[i].device.type, 0, numpy.float32,
+                present_shape, present[i].data_ptr())
+    
+    latency = []
+    for _ in range(total_runs):
+        start = time.time()
+        # Run onnxruntime with io binding
+        ort_session.run_with_iobinding(io_binding)
+        latency.append(time.time() - start)
 
-def inference(model, ort_session, input_ids, past=None, total_runs=100, verify_outputs=True):
+    average_latency = sum(latency) * 1000 / len(latency)
+    logger.debug("OnnxRuntime with IO binding inference time = {} ms".format(format(average_latency, '.2f')))
+
+    # Copy results to cpu
+    ort_outputs = [last_state[0:numpy.prod(last_state_shape)].reshape(last_state_shape).cpu()]
+    if present is not None:
+        for i, present_i in enumerate(present):
+            ort_outputs.append(present[i][0:numpy.prod(present_shape)].reshape(present_shape).cpu())
+    return ort_outputs, average_latency
+
+def inference(model, ort_session, input_ids, past=None, last_state=None, present=None, 
+        last_state_shape=None, present_shape=None, total_runs=100, verify_outputs=True, 
+        with_io_binding=False):
     outputs, torch_latency = pytorch_inference(model, input_ids, past, total_runs)
     ort_outputs, ort_latency = onnxruntime_inference(ort_session, input_ids, past, total_runs)
+    latencies = [torch_latency, ort_latency]
+    if with_io_binding: 
+        ort_io_outputs, ort_io_latency = onnxruntime_inference_with_binded_io(ort_session, 
+            input_ids, last_state, last_state_shape, past, present, present_shape, total_runs)
+        latencies.append(ort_io_latency)
     if verify_outputs:
+        logger.debug('Verifying Pytorch and ONNX Runtime outputs.')
+        verify_ort_outputs(model, outputs, ort_outputs)
+        if with_io_binding:
+            logger.debug('Verifying Pytorch and ONNX Runtime with io binding outputs.')
+            verify_ort_outputs(model, outputs, ort_io_outputs)
 
-        is_close = numpy.allclose(ort_outputs[0], outputs[0].cpu(), rtol=1e-05, atol=1e-04)
-        logger.debug(f'PyTorch and OnnxRuntime output 0 (last_state) are close: {is_close}')
+    return latencies
 
-        is_all_close = is_close
-        for layer in range(model.config.n_layer):
-            is_close = numpy.allclose(ort_outputs[1 + layer], outputs[1][layer].cpu(), rtol=1e-05, atol=1e-04)
-            logger.debug(f'PyTorch and OnnxRuntime layer {layer} state (present_{layer}) are close:{is_close}')
-            is_all_close = is_all_close and is_close
+def verify_ort_outputs(model, torch_outputs, ort_outputs):
+    is_close = numpy.allclose(ort_outputs[0], torch_outputs[0].cpu(), rtol=1e-05, atol=1e-04)
+    logger.debug(f'PyTorch and OnnxRuntime output 0 (last_state) are close: {is_close}')
 
-        if not is_all_close:
-            logger.warning(f'PyTorch and OnnxRuntime results are not all close.')
+    is_all_close = is_close
+    for layer in range(model.config.n_layer):
+        is_close = numpy.allclose(ort_outputs[1 + layer], torch_outputs[1][layer].cpu(), rtol=1e-05, atol=1e-04)
+        logger.debug(f'PyTorch and OnnxRuntime layer {layer} state (present_{layer}) are close:{is_close}')
+        is_all_close = is_all_close and is_close
 
-    return torch_latency, ort_latency
-
+    if not is_all_close:
+        logger.warning(f'PyTorch and OnnxRuntime results are not all close.')
 
 def parse_arguments():
     parser = argparse.ArgumentParser()
@@ -127,7 +174,11 @@ def parse_arguments():
                         type=int,
                         help='Number of repeat times to get average inference latency.')
 
-    parser.add_argument('-v', '--validate_onnx', required=False, action='store_true', help='Validate ONNX model')
+    parser.add_argument('-v', 
+                        '--validate_onnx', 
+                        required=False, 
+                        action='store_true', 
+                        help='Validate ONNX model')
 
     parser.add_argument('-o',
                         '--optimize_onnx',
@@ -135,6 +186,12 @@ def parse_arguments():
                         action='store_true',
                         help='Use optimizer.py to optimize onnx model')
     parser.set_defaults(optimize_onnx=False)
+
+    parser.add_argument('--with_io_binding', 
+                        required=False, 
+                        action='store_true',
+                        help='Run ONNX Runtime with binded inputs and outputs. ')
+    parser.set_defaults(with_io_binding=False)
 
     parser.add_argument('--use_gpu', required=False, action='store_true')
     parser.set_defaults(use_gpu=False)
@@ -289,6 +346,24 @@ def main():
     logger.info(f"Start inferencing onnx model: {onnx_model_path}")
     session = onnxruntime.InferenceSession(onnx_model_path, sess_options)
 
+    dummy_present = None
+    dummy_last_state = None
+    max_batch_size = max(args.batch_sizes)
+    max_seq_len = max(args.sequence_lengths)
+    if args.with_io_binding:
+        # Allocate output tensors with the largest test size needed. So the allocated memory can be reused 
+        # for each test run. 
+        # create dummy present    
+        present_state_size = numpy.prod([
+            2, max_batch_size, config.num_attention_heads, max_seq_len + 1, 
+            int(config.hidden_size / config.num_attention_heads)
+            ])
+        dummy_present = [torch.empty(present_state_size, dtype=torch.float32, device=device) for _ in range(config.n_layer)]
+
+        # dummy last state
+        last_state_size = numpy.prod([max_batch_size, 1, config.hidden_size])
+        dummy_last_state = torch.empty(last_state_size).to(device)
+                
     for batch_size in args.batch_sizes:
         for sequence_length in args.sequence_lengths:
             past_shape = [
@@ -301,14 +376,30 @@ def main():
                                             size=(batch_size, 1),
                                             dtype=torch.int64,
                                             device=device)
-            torch_latency, ort_latency = inference(model,
-                                                   session,
-                                                   dummy_input_ids,
-                                                   dummy_past,
-                                                   args.test_times,
-                                                   verify_outputs=args.validate_onnx)
+                        
+            # Calculate the expected output shapes
+            last_state_shape = [
+                batch_size, 1, config.hidden_size
+            ]
+            present_shape = [
+                2, batch_size, config.num_attention_heads, sequence_length + 1, 
+                int(config.hidden_size / config.num_attention_heads)
+            ]
+
+            latencies = inference(model,
+                                    session,
+                                    dummy_input_ids,
+                                    dummy_past,
+                                    dummy_last_state,
+                                    dummy_present,
+                                    last_state_shape,
+                                    present_shape,
+                                    args.test_times,
+                                    verify_outputs=args.validate_onnx, 
+                                    with_io_binding=args.with_io_binding)
+            ort_io_latency_info = f", ort_io_latency={latencies[2]}" if args.with_io_binding else ""
             logger.info(
-                f"batch_size={batch_size}, sequence_length={sequence_length}, torch_latency={torch_latency}, ort_latency={ort_latency}"
+                f"batch_size={batch_size}, sequence_length={sequence_length}, torch_latency={latencies[0]}, ort_latency={latencies[1]}{ort_io_latency_info}"
             )
 
 

--- a/onnxruntime/python/tools/transformers/benchmark_gpt2.py
+++ b/onnxruntime/python/tools/transformers/benchmark_gpt2.py
@@ -53,17 +53,21 @@ def pytorch_inference(model, input_ids, past=None, total_runs=100):
             latency.append(time.time() - start)
 
     average_latency = sum(latency) * 1000 / len(latency)
-    logger.debug("PyTorch Inference time = {} ms".format(format(average_latency, '.2f')))
+    logger.debug("PyTorch Inference time = {} ms".format(
+        format(average_latency, '.2f')))
     return outputs, average_latency
 
 
 def onnxruntime_inference(ort_session, input_ids, past=None, total_runs=100):
-    ort_inputs = {'input_ids': numpy.ascontiguousarray(input_ids.cpu().numpy())}
+    ort_inputs = {
+        'input_ids': numpy.ascontiguousarray(input_ids.cpu().numpy())
+    }
 
     # TODO: pass input tensor stored in GPU
     if past is not None:
         for i, past_i in enumerate(past):
-            ort_inputs[f'past_{i}'] = numpy.ascontiguousarray(past[i].cpu().numpy())
+            ort_inputs[f'past_{i}'] = numpy.ascontiguousarray(
+                past[i].cpu().numpy())
 
     latency = []
     for _ in range(total_runs):
@@ -72,29 +76,42 @@ def onnxruntime_inference(ort_session, input_ids, past=None, total_runs=100):
         latency.append(time.time() - start)
 
     average_latency = sum(latency) * 1000 / len(latency)
-    logger.debug("OnnxRuntime Inference time = {} ms".format(format(average_latency, '.2f')))
+    logger.debug("OnnxRuntime Inference time = {} ms".format(
+        format(average_latency, '.2f')))
 
     return ort_outputs, average_latency
 
-def onnxruntime_inference_with_binded_io(ort_session, input_ids, last_state, last_state_shape, past=None, present=None, present_shape=None, total_runs=100):
-    # Bind inputs and outputs to onnxruntime session        
+
+def onnxruntime_inference_with_binded_io(ort_session,
+                                         input_ids,
+                                         last_state,
+                                         last_state_shape,
+                                         past=None,
+                                         present=None,
+                                         present_shape=None,
+                                         total_runs=100):
+    # Bind inputs and outputs to onnxruntime session
     io_binding = ort_session.io_binding()
     # Bind inputs
-    io_binding.bind_input('input_ids', input_ids.device.type, 0, numpy.longlong, 
-        list(input_ids.size()), input_ids.data_ptr())
+    io_binding.bind_input('input_ids', input_ids.device.type, 0,
+                          numpy.longlong, list(input_ids.size()),
+                          input_ids.data_ptr())
     if past is not None:
         for i, past_i in enumerate(past):
-            io_binding.bind_input(f'past_{i}', past[i].device.type, 0, numpy.float32, 
-                list(past[i].size()), past[i].data_ptr())
-    
+            io_binding.bind_input(f'past_{i}',
+                                  past[i].device.type, 0, numpy.float32,
+                                  list(past[i].size()), past[i].data_ptr())
+
     # Bind outputs
-    io_binding.bind_output("last_state", last_state.device.type, 0, numpy.float32,
-        last_state_shape, last_state.data_ptr())
+    io_binding.bind_output("last_state", last_state.device.type, 0,
+                           numpy.float32, last_state_shape,
+                           last_state.data_ptr())
     if present is not None:
         for i, present_i in enumerate(present):
-            io_binding.bind_output(f'present_{i}', present[i].device.type, 0, numpy.float32,
-                present_shape, present[i].data_ptr())
-    
+            io_binding.bind_output(f'present_{i}', present[i].device.type, 0,
+                                   numpy.float32, present_shape,
+                                   present[i].data_ptr())
+
     latency = []
     for _ in range(total_runs):
         start = time.time()
@@ -103,46 +120,75 @@ def onnxruntime_inference_with_binded_io(ort_session, input_ids, last_state, las
         latency.append(time.time() - start)
 
     average_latency = sum(latency) * 1000 / len(latency)
-    logger.debug("OnnxRuntime with IO binding inference time = {} ms".format(format(average_latency, '.2f')))
+    logger.debug("OnnxRuntime with IO binding inference time = {} ms".format(
+        format(average_latency, '.2f')))
 
     # Copy results to cpu
-    ort_outputs = [last_state[0:numpy.prod(last_state_shape)].reshape(last_state_shape).cpu()]
+    ort_outputs = [
+        last_state[0:numpy.prod(last_state_shape)].reshape(
+            last_state_shape).cpu()
+    ]
     if present is not None:
         for i, present_i in enumerate(present):
-            ort_outputs.append(present[i][0:numpy.prod(present_shape)].reshape(present_shape).cpu())
+            ort_outputs.append(present[i][0:numpy.prod(present_shape)].reshape(
+                present_shape).cpu())
     return ort_outputs, average_latency
 
-def inference(model, ort_session, input_ids, past=None, last_state=None, present=None, 
-        last_state_shape=None, present_shape=None, total_runs=100, verify_outputs=True, 
-        with_io_binding=False):
-    outputs, torch_latency = pytorch_inference(model, input_ids, past, total_runs)
-    ort_outputs, ort_latency = onnxruntime_inference(ort_session, input_ids, past, total_runs)
+
+def inference(model,
+              ort_session,
+              input_ids,
+              past=None,
+              last_state=None,
+              present=None,
+              last_state_shape=None,
+              present_shape=None,
+              total_runs=100,
+              verify_outputs=True,
+              with_io_binding=False):
+    outputs, torch_latency = pytorch_inference(model, input_ids, past,
+                                               total_runs)
+    ort_outputs, ort_latency = onnxruntime_inference(ort_session, input_ids,
+                                                     past, total_runs)
     latencies = [torch_latency, ort_latency]
-    if with_io_binding: 
-        ort_io_outputs, ort_io_latency = onnxruntime_inference_with_binded_io(ort_session, 
-            input_ids, last_state, last_state_shape, past, present, present_shape, total_runs)
+    if with_io_binding:
+        ort_io_outputs, ort_io_latency = onnxruntime_inference_with_binded_io(
+            ort_session, input_ids, last_state, last_state_shape, past,
+            present, present_shape, total_runs)
         latencies.append(ort_io_latency)
     if verify_outputs:
         logger.debug('Verifying Pytorch and ONNX Runtime outputs.')
         verify_ort_outputs(model, outputs, ort_outputs)
         if with_io_binding:
-            logger.debug('Verifying Pytorch and ONNX Runtime with io binding outputs.')
+            logger.debug(
+                'Verifying Pytorch and ONNX Runtime with io binding outputs.')
             verify_ort_outputs(model, outputs, ort_io_outputs)
 
     return latencies
 
+
 def verify_ort_outputs(model, torch_outputs, ort_outputs):
-    is_close = numpy.allclose(ort_outputs[0], torch_outputs[0].cpu(), rtol=1e-05, atol=1e-04)
-    logger.debug(f'PyTorch and OnnxRuntime output 0 (last_state) are close: {is_close}')
+    is_close = numpy.allclose(ort_outputs[0],
+                              torch_outputs[0].cpu(),
+                              rtol=1e-05,
+                              atol=1e-04)
+    logger.debug(
+        f'PyTorch and OnnxRuntime output 0 (last_state) are close: {is_close}')
 
     is_all_close = is_close
     for layer in range(model.config.n_layer):
-        is_close = numpy.allclose(ort_outputs[1 + layer], torch_outputs[1][layer].cpu(), rtol=1e-05, atol=1e-04)
-        logger.debug(f'PyTorch and OnnxRuntime layer {layer} state (present_{layer}) are close:{is_close}')
+        is_close = numpy.allclose(ort_outputs[1 + layer],
+                                  torch_outputs[1][layer].cpu(),
+                                  rtol=1e-05,
+                                  atol=1e-04)
+        logger.debug(
+            f'PyTorch and OnnxRuntime layer {layer} state (present_{layer}) are close:{is_close}'
+        )
         is_all_close = is_all_close and is_close
 
     if not is_all_close:
         logger.warning(f'PyTorch and OnnxRuntime results are not all close.')
+
 
 def parse_arguments():
     parser = argparse.ArgumentParser()
@@ -152,7 +198,8 @@ def parse_arguments():
                         required=True,
                         type=str,
                         choices=list(MODEL_CLASSES.keys()),
-                        help='Model type selected in the list: ' + ', '.join(MODEL_CLASSES.keys()))
+                        help='Model type selected in the list: ' +
+                        ', '.join(MODEL_CLASSES.keys()))
 
     parser.add_argument('-c',
                         '--cache_dir',
@@ -167,17 +214,18 @@ def parse_arguments():
                         default='./onnx_models',
                         help='Directory to store onnx models')
 
-    parser.add_argument('-t',
-                        '--test_times',
-                        required=False,
-                        default=100,
-                        type=int,
-                        help='Number of repeat times to get average inference latency.')
+    parser.add_argument(
+        '-t',
+        '--test_times',
+        required=False,
+        default=100,
+        type=int,
+        help='Number of repeat times to get average inference latency.')
 
-    parser.add_argument('-v', 
-                        '--validate_onnx', 
-                        required=False, 
-                        action='store_true', 
+    parser.add_argument('-v',
+                        '--validate_onnx',
+                        required=False,
+                        action='store_true',
                         help='Validate ONNX model')
 
     parser.add_argument('-o',
@@ -187,18 +235,27 @@ def parse_arguments():
                         help='Use optimizer.py to optimize onnx model')
     parser.set_defaults(optimize_onnx=False)
 
-    parser.add_argument('--with_io_binding', 
-                        required=False, 
-                        action='store_true',
-                        help='Run ONNX Runtime with binded inputs and outputs. ')
+    parser.add_argument(
+        '--with_io_binding',
+        required=False,
+        action='store_true',
+        help='Run ONNX Runtime with binded inputs and outputs. ')
     parser.set_defaults(with_io_binding=False)
 
     parser.add_argument('--use_gpu', required=False, action='store_true')
     parser.set_defaults(use_gpu=False)
 
-    parser.add_argument('-b', '--batch_sizes', nargs='+', type=int, default=[1])
+    parser.add_argument('-b',
+                        '--batch_sizes',
+                        nargs='+',
+                        type=int,
+                        default=[1])
 
-    parser.add_argument('-s', '--sequence_lengths', nargs='+', type=int, default=[8, 16, 32, 64, 128, 256])
+    parser.add_argument('-s',
+                        '--sequence_lengths',
+                        nargs='+',
+                        type=int,
+                        default=[8, 16, 32, 64, 128, 256])
 
     parser.add_argument('--verbose', required=False, action='store_true')
     parser.set_defaults(verbose=False)
@@ -212,10 +269,13 @@ def setup_logger(verbose=True):
     # output logging to stdout
     log_handler = logging.StreamHandler(sys.stdout)
     if verbose:
-        log_handler.setFormatter(logging.Formatter('[%(filename)s:%(lineno)s - %(funcName)20s()] %(message)s'))
+        log_handler.setFormatter(
+            logging.Formatter(
+                '[%(filename)s:%(lineno)s - %(funcName)20s()] %(message)s'))
         logging_level = logging.DEBUG
     else:
-        log_handler.setFormatter(logging.Formatter('%(filename)20s: %(message)s'))
+        log_handler.setFormatter(
+            logging.Formatter('%(filename)20s: %(message)s'))
         logging_level = logging.INFO
         logging.getLogger("transformers").setLevel(logging.ERROR)
     log_handler.setLevel(logging_level)
@@ -253,14 +313,26 @@ def export_onnx(model, config, tokenizer, device, output_dir):
     # Shape of output tensors:
     #    last_state: (batch_size, seq_len + 1, hidden_size)
     #    present_{i}:  (2, batch_size, num_heads, seq_len + 1, hidden_size/num_heads)
-    dynamic_axes = {'input_ids': {0: 'batch_size'}, 'last_state': {0: 'batch_size', 1: 'seq_len_plus_1'}}
+    dynamic_axes = {
+        'input_ids': {
+            0: 'batch_size'
+        },
+        'last_state': {
+            0: 'batch_size',
+            1: 'seq_len_plus_1'
+        }
+    }
 
     for name in present_names:
         dynamic_axes[name] = {1: 'batch_size', 3: 'seq_len_plus_1'}
 
     past_names = [f'past_{i}' for i in range(num_layer)]
     input_names = ['input_ids'] + past_names
-    dummy_past = [torch.zeros(list(outputs[1][0].shape), dtype=torch.float32, device=device) for _ in range(num_layer)]
+    dummy_past = [
+        torch.zeros(list(outputs[1][0].shape),
+                    dtype=torch.float32,
+                    device=device) for _ in range(num_layer)
+    ]
     for name in past_names:
         dynamic_axes[name] = {1: 'batch_size', 3: 'seq_len'}
     logger.debug(f"vocab_size:{model.config.vocab_size}")
@@ -309,14 +381,20 @@ def main():
 
     use_torchscript = False
     (model_class, tokenizer_class, model_name) = MODEL_CLASSES[args.model_type]
-    config = AutoConfig.from_pretrained(model_name, torchscript=use_torchscript, cache_dir=cache_dir)
-    model = model_class.from_pretrained(model_name, config=config, cache_dir=cache_dir)
-    tokenizer = tokenizer_class.from_pretrained(model_name, cache_dir=cache_dir)
+    config = AutoConfig.from_pretrained(model_name,
+                                        torchscript=use_torchscript,
+                                        cache_dir=cache_dir)
+    model = model_class.from_pretrained(model_name,
+                                        config=config,
+                                        cache_dir=cache_dir)
+    tokenizer = tokenizer_class.from_pretrained(model_name,
+                                                cache_dir=cache_dir)
     #if use_torchscript:
     #    model = torch.jit.trace(model, (input_ids, past))
 
     device = torch.device("cuda:0" if args.use_gpu else "cpu")
-    export_model_path = export_onnx(model, config, tokenizer, device, output_dir)
+    export_model_path = export_onnx(model, config, tokenizer, device,
+                                    output_dir)
 
     # setup environment variables before importing onnxruntime.
     setup_environment()
@@ -336,12 +414,16 @@ def main():
         onnx_model_path = os.path.join(output_dir, 'gpt2_past_optimized.onnx')
         m.save_model_to_file(onnx_model_path)
 
-    if args.use_gpu and 'CUDAExecutionProvider' not in onnxruntime.get_available_providers():
-        logger.warning("Please install onnxruntime-gpu package to test GPU inference.")
+    if args.use_gpu and 'CUDAExecutionProvider' not in onnxruntime.get_available_providers(
+    ):
+        logger.warning(
+            "Please install onnxruntime-gpu package to test GPU inference.")
 
     sess_options = onnxruntime.SessionOptions()
     sess_options.intra_op_num_threads = psutil.cpu_count(logical=True)
-    logger.info(f"Session option: intra_op_num_threads={sess_options.intra_op_num_threads}")
+    logger.info(
+        f"Session option: intra_op_num_threads={sess_options.intra_op_num_threads}"
+    )
 
     logger.info(f"Start inferencing onnx model: {onnx_model_path}")
     session = onnxruntime.InferenceSession(onnx_model_path, sess_options)
@@ -351,52 +433,56 @@ def main():
     max_batch_size = max(args.batch_sizes)
     max_seq_len = max(args.sequence_lengths)
     if args.with_io_binding:
-        # Allocate output tensors with the largest test size needed. So the allocated memory can be reused 
-        # for each test run. 
-        # create dummy present    
+        # Allocate output tensors with the largest test size needed. So the allocated memory can be reused
+        # for each test run.
+        # create dummy present
         present_state_size = numpy.prod([
-            2, max_batch_size, config.num_attention_heads, max_seq_len + 1, 
+            2, max_batch_size, config.num_attention_heads, max_seq_len + 1,
             int(config.hidden_size / config.num_attention_heads)
-            ])
-        dummy_present = [torch.empty(present_state_size, dtype=torch.float32, device=device) for _ in range(config.n_layer)]
+        ])
+        dummy_present = [
+            torch.empty(present_state_size, dtype=torch.float32, device=device)
+            for _ in range(config.n_layer)
+        ]
 
         # dummy last state
         last_state_size = numpy.prod([max_batch_size, 1, config.hidden_size])
         dummy_last_state = torch.empty(last_state_size).to(device)
-                
+
     for batch_size in args.batch_sizes:
         for sequence_length in args.sequence_lengths:
             past_shape = [
                 2, batch_size, config.num_attention_heads, sequence_length,
                 int(config.hidden_size / config.num_attention_heads)
             ]
-            dummy_past = [torch.rand(past_shape, dtype=torch.float32, device=device) for _ in range(config.n_layer)]
+            dummy_past = [
+                torch.rand(past_shape, dtype=torch.float32, device=device)
+                for _ in range(config.n_layer)
+            ]
             dummy_input_ids = torch.randint(low=0,
                                             high=model.config.vocab_size - 1,
                                             size=(batch_size, 1),
                                             dtype=torch.int64,
                                             device=device)
-                        
+
             # Calculate the expected output shapes
-            last_state_shape = [
-                batch_size, 1, config.hidden_size
-            ]
+            last_state_shape = [batch_size, 1, config.hidden_size]
             present_shape = [
-                2, batch_size, config.num_attention_heads, sequence_length + 1, 
+                2, batch_size, config.num_attention_heads, sequence_length + 1,
                 int(config.hidden_size / config.num_attention_heads)
             ]
 
             latencies = inference(model,
-                                    session,
-                                    dummy_input_ids,
-                                    dummy_past,
-                                    dummy_last_state,
-                                    dummy_present,
-                                    last_state_shape,
-                                    present_shape,
-                                    args.test_times,
-                                    verify_outputs=args.validate_onnx, 
-                                    with_io_binding=args.with_io_binding)
+                                  session,
+                                  dummy_input_ids,
+                                  dummy_past,
+                                  dummy_last_state,
+                                  dummy_present,
+                                  last_state_shape,
+                                  present_shape,
+                                  args.test_times,
+                                  verify_outputs=args.validate_onnx,
+                                  with_io_binding=args.with_io_binding)
             ort_io_latency_info = f", ort_io_latency={latencies[2]}" if args.with_io_binding else ""
             logger.info(
                 f"batch_size={batch_size}, sequence_length={sequence_length}, torch_latency={latencies[0]}, ort_latency={latencies[1]}{ort_io_latency_info}"


### PR DESCRIPTION
**Description**: Describe your changes.
Add an option to run onnxruntime with io binding for benchmark. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
With IO binding, inputs and outputs are preallocated in memory, and copying across devices is avoided. Therefore for gpt2 model on GPU, the latency of ort is greatly improved . 