### PR TITLE
Run autopep8 on generate_nuspec_for_native_nuget.py

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -167,6 +167,7 @@ def generate_files(list, args):
                           '" target="build\\native\\include" />')
 
     if includes_winml:
+        mlop_path = 'onnxruntime\\core\\providers\\dml\\dmlexecutionprovider\\inc\\mloperatorauthor.h'
         # Add microsoft.ai.machinelearning headers
         files_list.append('<file src=' + '"' + os.path.join(args.ort_build_path, args.build_config,
                                                             'microsoft.ai.machinelearning.h') +
@@ -183,8 +184,7 @@ def generate_files(list, args):
                           '" target="lib\\uap10.0\\Microsoft.AI.MachineLearning.winmd" />')
         # Add custom operator headers
         files_list.append('<file src=' + '"' +
-                          os.path.join(args.sources_path,
-                                       'onnxruntime\\core\\providers\\dml\\dmlexecutionprovider\\inc\\mloperatorauthor.h') +
+                          os.path.join(args.sources_path, mlop_path) +
                           '" target="build\\native\\include" />')
 
     # Process runtimes


### PR DESCRIPTION
**Description**: 

1. Create new variable opheader_path to resolve the code line too line issue.
2. Run autopep8 on generate_nuspec_for_native_nuget.py. 


**Motivation and Context**
- Why is this change required? What problem does it solve?

The master branch is failing.

         [flake8 PEP8 ERROR] C:/agent/_work/1/s/tools/nuget\generate_nuspec_for_native_nuget.py:187:121: E501 line too long (124 > 120 characters)


- If it fixes an open issue, please link to the issue here.
