### PR TITLE
Exclude non-trainable torch buffers from trainable weights

### DIFF
--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -959,30 +959,5 @@ std::unordered_set<std::string> TrainingSession::GetTrainableModelInitializers(
 
   return trainable_initializers;
 }
-
-std::unordered_set<std::string> TrainingSession::FilterTrainableModelInitializers(
-    const ImmutableWeights& immutable_weights) const {
-  const Graph& graph = model_->MainGraph();
-  const auto& initialized_tensors = graph.GetAllInitializedTensors();
-  std::unordered_set<std::string> model_initializers;
-  std::transform(initialized_tensors.begin(),
-                 initialized_tensors.end(),
-                 std::inserter(model_initializers, model_initializers.end()),
-                 [](const auto& pair) { return pair.first; });
-
-  std::unordered_set<std::string> trainable_initializers(model_initializers);
-  for (const std::string& initializer_name : model_initializers) {
-    const auto& nodes = graph.GetConsumerNodes(initializer_name);
-    for (const Node* node : nodes) {
-      if (IsUntrainable(node, initializer_name, session_logger_) ||
-          IsImmutableWeight(immutable_weights, node, initialized_tensors.at(initializer_name), session_logger_)) {
-        trainable_initializers.erase(initializer_name);
-      }
-    }
-  }
-
-  return trainable_initializers;
-}
-
 }  // namespace training
 }  // namespace onnxruntime

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -960,5 +960,29 @@ std::unordered_set<std::string> TrainingSession::GetTrainableModelInitializers(
   return trainable_initializers;
 }
 
+std::unordered_set<std::string> TrainingSession::FilterTrainableModelInitializers(
+    const ImmutableWeights& immutable_weights) const {
+  const Graph& graph = model_->MainGraph();
+  const auto& initialized_tensors = graph.GetAllInitializedTensors();
+  std::unordered_set<std::string> model_initializers;
+  std::transform(initialized_tensors.begin(),
+                 initialized_tensors.end(),
+                 std::inserter(model_initializers, model_initializers.end()),
+                 [](const auto& pair) { return pair.first; });
+
+  std::unordered_set<std::string> trainable_initializers(model_initializers);
+  for (const std::string& initializer_name : model_initializers) {
+    const auto& nodes = graph.GetConsumerNodes(initializer_name);
+    for (const Node* node : nodes) {
+      if (IsUntrainable(node, initializer_name, session_logger_) ||
+          IsImmutableWeight(immutable_weights, node, initialized_tensors.at(initializer_name), session_logger_)) {
+        trainable_initializers.erase(initializer_name);
+      }
+    }
+  }
+
+  return trainable_initializers;
+}
+
 }  // namespace training
 }  // namespace onnxruntime

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -959,5 +959,6 @@ std::unordered_set<std::string> TrainingSession::GetTrainableModelInitializers(
 
   return trainable_initializers;
 }
+
 }  // namespace training
 }  // namespace onnxruntime

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -651,7 +651,7 @@ class ORTTrainer():
             self.torch_model_.cpu()
             # torch buffers created using 'register_buffer' are not meant to be trainable.
             torch_buffers = list(dict(self.torch_model_.named_buffers()).keys())
-            self.frozen_weights_.expand(torch_buffers)
+            self.frozen_weights_.extend(torch_buffers)
             self.onnx_model_ = convert_model_loss_fn_to_onnx(
                 self.torch_model_, self.loss_fn_, self.model_desc_, torch.device('cpu'), inputs, opset_version=self.opset_version_)
 

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -649,6 +649,9 @@ class ORTTrainer():
         if self.torch_model_ is not None:
             # NOTE: pt model is moved to cpu to conserve gpu memory.
             self.torch_model_.cpu()
+            # torch buffers created using 'register_buffer' are not meant to be trainable.
+            torch_buffers = list(dict(self.torch_model_.named_buffers()).keys())
+            self.frozen_weights_.expand(torch_buffers)
             self.onnx_model_ = convert_model_loss_fn_to_onnx(
                 self.torch_model_, self.loss_fn_, self.model_desc_, torch.device('cpu'), inputs, opset_version=self.opset_version_)
 


### PR DESCRIPTION
Non-trainable torch buffers must not be trained in ORT. This can be achieved by adding them to frozen weights.