### PR TITLE
MLAS: more code cleanup

### DIFF
--- a/onnxruntime/core/mlas/lib/activate.cpp
+++ b/onnxruntime/core/mlas/lib/activate.cpp
@@ -109,7 +109,7 @@ struct MLAS_ACTIVATION_FUNCTION<MlasReluActivation>
 #if defined(MLAS_SSE2_INTRINSICS)
         return _mm_cvtss_f32(Activate(_mm_set_ss(Value)));
 #else
-        return (std::max)(Value, 0.0f);
+        return std::max(Value, 0.0f);
 #endif
     }
 };
@@ -140,12 +140,11 @@ struct MLAS_ACTIVATION_FUNCTION<MlasLeakyReluActivation>
 #elif defined(MLAS_AVX_INTRINSICS)
         return _mm_blendv_ps(ValueTimesAlpha, Value, _mm_cmple_ps(ZeroFloat32x4, Value));
 #elif defined(MLAS_SSE2_INTRINSICS)
-        __m128 Selection = _mm_cmple_ps(ZeroFloat32x4, Value);
-        return _mm_or_ps(_mm_and_ps(Value, Selection), _mm_andnot_ps(Selection, ValueTimesAlpha));
+        return MlasBlendFloat32x4(ValueTimesAlpha, Value, _mm_cmple_ps(ZeroFloat32x4, Value));
 #elif defined(MLAS_VSX_INTRINSICS)
         return vec_sel(ValueTimesAlpha, Value, vec_cmple(ZeroFloat32x4, Value));
 #else
-#error Unsupported architecture.
+        return MlasBlendFloat32x4(ValueTimesAlpha, Value, ZeroFloat32x4 < Value);
 #endif
     }
 
@@ -186,8 +185,8 @@ struct MLAS_ACTIVATION_FUNCTION<MlasClipActivation>
 #if defined(MLAS_SSE2_INTRINSICS)
         return _mm_cvtss_f32(Activate(_mm_set_ss(Value)));
 #else
-        Value = (std::max)(Value, MlasExtractLaneFloat32x4<0>(MinimumBroadcast));
-        Value = (std::min)(Value, MlasExtractLaneFloat32x4<0>(MaximumBroadcast));
+        Value = std::max(Value, MlasExtractLaneFloat32x4<0>(MinimumBroadcast));
+        Value = std::min(Value, MlasExtractLaneFloat32x4<0>(MaximumBroadcast));
 
         return Value;
 #endif

--- a/onnxruntime/core/mlas/lib/compute.cpp
+++ b/onnxruntime/core/mlas/lib/compute.cpp
@@ -552,7 +552,7 @@ Return Value:
 
     while (N > 0) {
 
-        Maximum = (std::max)(Maximum, *Input);
+        Maximum = std::max(Maximum, *Input);
 
         Input += 1;
         N -= 1;

--- a/onnxruntime/core/mlas/lib/erf.cpp
+++ b/onnxruntime/core/mlas/lib/erf.cpp
@@ -191,7 +191,7 @@ Return Value:
 
         float r;
         if (AbsValue > MlasErfConstants.ErfSplitBoundary) {
-            AbsValue = (std::min)(MlasErfConstants.ErfUpperAbsRange, AbsValue);
+            AbsValue = std::min(MlasErfConstants.ErfUpperAbsRange, AbsValue);
             float r_big = MlasErfConstants.ErfBIG_P0;
             r_big = r_big * AbsValue + MlasErfConstants.ErfBIG_P1;
             r_big = r_big * AbsValue + MlasErfConstants.ErfBIG_P2;
@@ -201,7 +201,7 @@ Return Value:
             r_big = r_big * AbsValue + MlasErfConstants.ErfBIG_P6_Minus_One;
             r_big = r_big * AbsValue + AbsValue;
 
-            r_big = (std::max)(-r_big, MlasErfConstants.Exp_LowerRange);
+            r_big = std::max(-r_big, MlasErfConstants.Exp_LowerRange);
             r = MlasErfConstants.Exp_Log2Reciprocal * r_big + MlasErfConstants.Exp_C;
             r -= MlasErfConstants.Exp_C;
             float fx = r * MlasErfConstants.Exp_log2_hi + r_big;

--- a/onnxruntime/core/mlas/lib/logistic.cpp
+++ b/onnxruntime/core/mlas/lib/logistic.cpp
@@ -121,7 +121,7 @@ Return Value:
 
         float Value = *Input++;
 
-        Value = (std::min)(MlasLogisticConstants.UpperRange, (std::max)(MlasLogisticConstants.LowerRange, Value));
+        Value = std::min(MlasLogisticConstants.UpperRange, std::max(MlasLogisticConstants.LowerRange, Value));
 
         float ValueSquared = Value * Value;
 

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -25,6 +25,12 @@ Abstract:
 #include <type_traits>
 
 #if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #include <intrin.h>
 #else
@@ -753,8 +759,6 @@ MlasPartitionWork(
 #if defined(__FMA__) || (defined(_MSC_VER) && defined(__AVX2__))
 #define MLAS_FMA3_INTRINSICS
 #endif
-#else
-#error Unsupported architecture.
 #endif
 
 #if defined(MLAS_NEON_INTRINSICS)
@@ -787,6 +791,21 @@ MlasReinterpretAsInt32x4(MLAS_FLOAT32X4 Vector)
 
 MLAS_FORCEINLINE
 MLAS_INT32X4
+MlasCastToInt32x4(MLAS_FLOAT32X4 Vector)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    return vcvtq_s32_f32(Vector);
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return _mm_cvttps_epi32(Vector);
+#elif defined(MLAS_VSX_INTRINSICS)
+    return vec_cts(Vector, 0);
+#else
+    return MLAS_INT32X4{int32_t(Vector[0]), int32_t(Vector[1]), int32_t(Vector[2]), int32_t(Vector[3])};
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_INT32X4
 MlasBroadcastInt32x4(int32_t Value)
 {
 #if defined(MLAS_NEON_INTRINSICS)
@@ -795,6 +814,182 @@ MlasBroadcastInt32x4(int32_t Value)
     return _mm_set1_epi32(Value);
 #else
     return MLAS_INT32X4{Value, Value, Value, Value};
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_INT32X4
+MlasLoadInt32x4(const int32_t* Buffer)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    return vld1q_s32(Buffer);
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return _mm_loadu_si128((const __m128i*)Buffer);
+#elif defined(MLAS_VSX_INTRINSICS)
+    return vec_vsx_ld(0, Buffer);
+#else
+    return *((MLAS_INT32X4*)Buffer);
+#endif
+}
+
+MLAS_FORCEINLINE
+void
+MlasStoreInt32x4(int32_t* Buffer, MLAS_INT32X4 Vector)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    vst1q_s32(Buffer, Vector);
+#elif defined(MLAS_SSE2_INTRINSICS)
+    _mm_storeu_si128((__m128i*)Buffer, Vector);
+#elif defined(MLAS_VSX_INTRINSICS)
+    vec_vsx_st(Vector, 0, Buffer);
+#else
+    *((MLAS_INT32X4*)Buffer) = Vector;
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_INT32X4
+MlasAddInt32x4(MLAS_INT32X4 Vector1, MLAS_INT32X4 Vector2)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    return vaddq_s32(Vector1, Vector2);
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return _mm_add_epi32(Vector1, Vector2);
+#else
+    return Vector1 + Vector2;
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_INT32X4
+MlasSubtractInt32x4(MLAS_INT32X4 Vector1, MLAS_INT32X4 Vector2)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    return vsubq_s32(Vector1, Vector2);
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return _mm_sub_epi32(Vector1, Vector2);
+#else
+    return Vector1 - Vector2;
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_INT32X4
+MlasAndInt32x4(MLAS_INT32X4 Vector1, MLAS_INT32X4 Vector2)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    return vandq_s32(Vector1, Vector2);
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return _mm_and_si128(Vector1, Vector2);
+#else
+    return Vector1 & Vector2;
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_INT32X4
+MlasOrInt32x4(MLAS_INT32X4 Vector1, MLAS_INT32X4 Vector2)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    return vorrq_s32(Vector1, Vector2);
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return _mm_or_si128(Vector1, Vector2);
+#else
+    return Vector1 | Vector2;
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_INT32X4
+MlasAndNotInt32x4(MLAS_INT32X4 VectorNot, MLAS_INT32X4 Vector)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    return vandq_s32(vmvnq_s32(VectorNot), Vector);
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return _mm_andnot_si128(VectorNot, Vector);
+#else
+    return (~VectorNot) & Vector;
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_INT32X4
+MlasXorInt32x4(MLAS_INT32X4 Vector1, MLAS_INT32X4 Vector2)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    return veorq_s32(Vector1, Vector2);
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return _mm_xor_si128(Vector1, Vector2);
+#else
+    return Vector1 ^ Vector2;
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_INT32X4
+MlasBlendInt32x4(MLAS_INT32X4 Vector1, MLAS_INT32X4 Vector2, MLAS_INT32X4 Selection)
+{
+    return MlasOrInt32x4(MlasAndInt32x4(Vector2, Selection), MlasAndNotInt32x4(Selection, Vector1));
+}
+
+template<unsigned ShiftCount>
+MLAS_FORCEINLINE
+MLAS_INT32X4
+MlasShiftLeftInt32x4(MLAS_INT32X4 Vector)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    return vshlq_n_s32(Vector, ShiftCount);
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return _mm_slli_epi32(Vector, ShiftCount);
+#else
+    return Vector << ShiftCount;
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_INT32X4
+MlasMaximumInt32x4(MLAS_INT32X4 Vector1, MLAS_INT32X4 Vector2)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    return vmaxq_s32(Vector1, Vector2);
+#elif defined(MLAS_SSE41_INTRINSICS)
+    return _mm_max_epi32(Vector1, Vector2);
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return MlasBlendInt32x4(Vector2, Vector1, _mm_cmpgt_epi32(Vector1, Vector2));
+#elif defined(MLAS_VSX_INTRINSICS)
+    return vec_vmaxsw(Vector1, Vector2);
+#else
+    return MlasBlendInt32x4(Vector2, Vector1, Vector1 > Vector2);
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_INT32X4
+MlasMinimumInt32x4(MLAS_INT32X4 Vector1, MLAS_INT32X4 Vector2)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    return vminq_s32(Vector1, Vector2);
+#elif defined(MLAS_SSE41_INTRINSICS)
+    return _mm_min_epi32(Vector1, Vector2);
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return MlasBlendInt32x4(Vector2, Vector1, _mm_cmpgt_epi32(Vector2, Vector1));
+#elif defined(MLAS_VSX_INTRINSICS)
+    return vec_vminsw(Vector1, Vector2);
+#else
+    return MlasBlendInt32x4(Vector2, Vector1, Vector2 > Vector1);
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_FLOAT32X4
+MlasReinterpretAsFloat32x4(MLAS_INT32X4 Vector)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    return vreinterpretq_f32_s32(Vector);
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return _mm_castsi128_ps(Vector);
+#else
+    return MLAS_FLOAT32X4(Vector);
 #endif
 }
 
@@ -847,6 +1042,8 @@ MlasLoadFloat32x4(const float* Buffer)
     return _mm_loadu_ps(Buffer);
 #elif defined(MLAS_VSX_INTRINSICS)
     return vec_vsx_ld(0, Buffer);
+#else
+    return *((MLAS_FLOAT32X4*)Buffer);
 #endif
 }
 
@@ -860,6 +1057,8 @@ MlasStoreFloat32x4(float* Buffer, MLAS_FLOAT32X4 Vector)
     _mm_storeu_ps(Buffer, Vector);
 #elif defined(MLAS_VSX_INTRINSICS)
     vec_vsx_st(Vector, 0, Buffer);
+#else
+    *((MLAS_FLOAT32X4*)Buffer) = Vector;
 #endif
 }
 
@@ -945,7 +1144,73 @@ MlasExtractLaneFloat32x4<0>(MLAS_FLOAT32X4 Vector)
     return _mm_cvtss_f32(Vector);
 }
 
+template<unsigned Index0, unsigned Index1, unsigned Index2, unsigned Index3>
+MLAS_FORCEINLINE
+MLAS_FLOAT32X4
+MlasShuffleFloat32x4(MLAS_FLOAT32X4 Vector)
+{
+    return _mm_shuffle_ps(Vector, Vector, _MM_SHUFFLE(Index3, Index2, Index1, Index0));
+}
+
+#else
+
+template<unsigned Index0, unsigned Index1, unsigned Index2, unsigned Index3>
+MLAS_FORCEINLINE
+MLAS_FLOAT32X4
+MlasShuffleFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
+{
+#if defined(__GNUC__)
+    return __builtin_shuffle(Vector1, Vector2, MLAS_INT32X4{Index0, Index1, Index2, Index3});
+#else
+    return __builtin_shufflevector(Vector1, Vector2, Index0, Index1, Index2, Index3);
 #endif
+}
+
+template<unsigned Index0, unsigned Index1, unsigned Index2, unsigned Index3>
+MLAS_FORCEINLINE
+MLAS_FLOAT32X4
+MlasShuffleFloat32x4(MLAS_FLOAT32X4 Vector)
+{
+    return MlasShuffleFloat32x4<Index0, Index1, Index2, Index3>(Vector, Vector);
+}
+
+#endif
+
+MLAS_FORCEINLINE
+MLAS_FLOAT32X4
+MlasInterleaveLowFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
+{
+#if defined(MLAS_NEON64_INTRINSICS)
+    return vzip1q_f32(Vector1, Vector2);
+#elif defined(MLAS_NEON32_INTRINSICS)
+    float32x4x2_t zipped = vzipq_f32(Vector1, Vector2);
+    return zipped.val[0];
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return _mm_unpacklo_ps(Vector1, Vector2);
+#elif defined(MLAS_VSX_INTRINSICS)
+    return vec_mergeh(Vector1, Vector2);
+#else
+    return MlasShuffleFloat32x4<0, 4, 1, 5>(Vector1, Vector2);
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_FLOAT32X4
+MlasInterleaveHighFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
+{
+#if defined(MLAS_NEON64_INTRINSICS)
+    return vzip2q_f32(Vector1, Vector2);
+#elif defined(MLAS_NEON32_INTRINSICS)
+    float32x4x2_t zipped = vzipq_f32(Vector1, Vector2);
+    return zipped.val[1];
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return _mm_unpackhi_ps(Vector1, Vector2);
+#elif defined(MLAS_VSX_INTRINSICS)
+    return vec_mergel(Vector1, Vector2);
+#else
+    return MlasShuffleFloat32x4<2, 6, 3, 7>(Vector1, Vector2);
+#endif
+}
 
 MLAS_FORCEINLINE
 MLAS_FLOAT32X4
@@ -1038,6 +1303,70 @@ MlasDivideFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
 
 MLAS_FORCEINLINE
 MLAS_FLOAT32X4
+MlasGreaterThanFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
+{
+#if defined(MLAS_NEON_INTRINSICS)
+    return vreinterpretq_f32_s32(vcgtq_f32(Vector1, Vector2));
+#elif defined(MLAS_SSE2_INTRINSICS)
+    return _mm_cmpgt_ps(Vector1, Vector2);
+#else
+    return Vector1 > Vector2;
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_FLOAT32X4
+MlasAndFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
+{
+#if defined(MLAS_SSE2_INTRINSICS)
+    return _mm_and_ps(Vector1, Vector2);
+#else
+    return MlasReinterpretAsFloat32x4(MlasAndInt32x4(MlasReinterpretAsInt32x4(Vector1), MlasReinterpretAsInt32x4(Vector2)));
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_FLOAT32X4
+MlasOrFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
+{
+#if defined(MLAS_SSE2_INTRINSICS)
+    return _mm_or_ps(Vector1, Vector2);
+#else
+    return MlasReinterpretAsFloat32x4(MlasOrInt32x4(MlasReinterpretAsInt32x4(Vector1), MlasReinterpretAsInt32x4(Vector2)));
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_FLOAT32X4
+MlasAndNotFloat32x4(MLAS_FLOAT32X4 VectorNot, MLAS_FLOAT32X4 Vector)
+{
+#if defined(MLAS_SSE2_INTRINSICS)
+    return _mm_andnot_ps(VectorNot, Vector);
+#else
+    return MlasReinterpretAsFloat32x4(MlasAndNotInt32x4(MlasReinterpretAsInt32x4(VectorNot), MlasReinterpretAsInt32x4(Vector)));
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_FLOAT32X4
+MlasXorFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
+{
+#if defined(MLAS_SSE2_INTRINSICS)
+    return _mm_xor_ps(Vector1, Vector2);
+#else
+    return MlasReinterpretAsFloat32x4(MlasXorInt32x4(MlasReinterpretAsInt32x4(Vector1), MlasReinterpretAsInt32x4(Vector2)));
+#endif
+}
+
+MLAS_FORCEINLINE
+MLAS_FLOAT32X4
+MlasBlendFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2, MLAS_FLOAT32X4 Selection)
+{
+    return MlasOrFloat32x4(MlasAndFloat32x4(Vector2, Selection), MlasAndNotFloat32x4(Selection, Vector1));
+}
+
+MLAS_FORCEINLINE
+MLAS_FLOAT32X4
 MlasMaximumFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
 {
 #if defined(MLAS_NEON_INTRINSICS)
@@ -1047,7 +1376,7 @@ MlasMaximumFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
 #elif defined(MLAS_VSX_INTRINSICS)
     return vec_sel(Vector2, Vector1, vec_cmpgt(Vector1, Vector2));
 #else
-#error Unsupported architecture.
+    return MlasBlendFloat32x4(Vector2, Vector1, Vector1 > Vector2);
 #endif
 }
 
@@ -1062,7 +1391,7 @@ MlasMinimumFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
 #elif defined(MLAS_VSX_INTRINSICS)
     return vec_sel(Vector2, Vector1, vec_cmpgt(Vector2, Vector1));
 #else
-#error Unsupported architecture.
+    return MlasBlendFloat32x4(Vector2, Vector1, Vector2 > Vector1);
 #endif
 }
 
@@ -1080,86 +1409,6 @@ MlasClampFloat32x4(MLAS_FLOAT32X4 Value, float LowerRange, float UpperRange)
 }
 
 MLAS_FORCEINLINE
-MLAS_FLOAT32X4
-MlasGreaterThanFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
-{
-#if defined(MLAS_NEON_INTRINSICS)
-    return vreinterpretq_f32_u32(vcgtq_f32(Vector1, Vector2));
-#elif defined(MLAS_SSE2_INTRINSICS)
-    return _mm_cmpgt_ps(Vector1, Vector2);
-#elif defined(MLAS_VSX_INTRINSICS)
-    return MLAS_FLOAT32X4(vec_cmpgt(Vector1, Vector2));
-#else
-#error Unsupported architecture.
-#endif
-}
-
-MLAS_FORCEINLINE
-MLAS_FLOAT32X4
-MlasAndFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
-{
-#if defined(MLAS_NEON_INTRINSICS)
-    return vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(Vector1), vreinterpretq_u32_f32(Vector2)));
-#elif defined(MLAS_SSE2_INTRINSICS)
-    return _mm_and_ps(Vector1, Vector2);
-#else
-    return MLAS_FLOAT32X4(MLAS_INT32X4(Vector1) & MLAS_INT32X4(Vector2));
-#endif
-}
-
-MLAS_FORCEINLINE
-MLAS_FLOAT32X4
-MlasOrFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
-{
-#if defined(MLAS_NEON_INTRINSICS)
-    return vreinterpretq_f32_u32(vorrq_u32(vreinterpretq_u32_f32(Vector1), vreinterpretq_u32_f32(Vector2)));
-#elif defined(MLAS_SSE2_INTRINSICS)
-    return _mm_or_ps(Vector1, Vector2);
-#else
-    return MLAS_FLOAT32X4(MLAS_INT32X4(Vector1) | MLAS_INT32X4(Vector2));
-#endif
-}
-
-MLAS_FORCEINLINE
-MLAS_FLOAT32X4
-MlasAndNotFloat32x4(MLAS_FLOAT32X4 VectorNot, MLAS_FLOAT32X4 Vector)
-{
-#if defined(MLAS_NEON_INTRINSICS)
-    return vreinterpretq_f32_u32(vandq_u32(vmvnq_u32(vreinterpretq_u32_f32(VectorNot)), vreinterpretq_u32_f32(Vector)));
-#elif defined(MLAS_SSE2_INTRINSICS)
-    return _mm_andnot_ps(VectorNot, Vector);
-#else
-    return MLAS_FLOAT32X4(~MLAS_INT32X4(VectorNot) & MLAS_INT32X4(Vector));
-#endif
-}
-
-MLAS_FORCEINLINE
-MLAS_FLOAT32X4
-MlasXorFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
-{
-#if defined(MLAS_NEON_INTRINSICS)
-    return vreinterpretq_f32_u32(veorq_u32(vreinterpretq_u32_f32(Vector1), vreinterpretq_u32_f32(Vector2)));
-#elif defined(MLAS_SSE2_INTRINSICS)
-    return _mm_xor_ps(Vector1, Vector2);
-#else
-    return MLAS_FLOAT32X4(MLAS_INT32X4(Vector1) ^ MLAS_INT32X4(Vector2));
-#endif
-}
-
-MLAS_FORCEINLINE
-MLAS_FLOAT32X4
-MlasReinterpretAsFloat32x4(MLAS_INT32X4 Vector)
-{
-#if defined(MLAS_NEON_INTRINSICS)
-    return vreinterpretq_f32_s32(Vector);
-#elif defined(MLAS_SSE2_INTRINSICS)
-    return _mm_castsi128_ps(Vector);
-#else
-    return MLAS_FLOAT32X4(Vector);
-#endif
-}
-
-MLAS_FORCEINLINE
 float
 MlasReduceAddFloat32x4(MLAS_FLOAT32X4 Vector)
 {
@@ -1173,16 +1422,14 @@ MlasReduceAddFloat32x4(MLAS_FLOAT32X4 Vector)
     VectorLow = vpadd_f32(VectorLow, VectorHigh);
     VectorLow = vpadd_f32(VectorLow, VectorHigh);
     return vget_lane_f32(VectorLow, 0);
-#elif defined(MLAS_SSE2_INTRINSICS)
-    Vector = MlasAddFloat32x4(Vector, _mm_shuffle_ps(Vector, Vector, _MM_SHUFFLE(3, 2, 3, 2)));
-    Vector = MlasAddFloat32x4(Vector, _mm_shuffle_ps(Vector, Vector, _MM_SHUFFLE(1, 1, 1, 1)));
-    return _mm_cvtss_f32(Vector);
 #elif defined(MLAS_VSX_INTRINSICS)
     Vector = MlasAddFloat32x4(Vector, MLAS_FLOAT32X4(vec_splat((__vector int64_t)Vector, 1)));
     Vector = MlasAddFloat32x4(Vector, vec_splat(Vector, 1));
     return Vector[0];
 #else
-#error Unsupported architecture.
+    Vector = MlasAddFloat32x4(Vector, MlasShuffleFloat32x4<2, 3, 2, 3>(Vector));
+    Vector = MlasAddFloat32x4(Vector, MlasShuffleFloat32x4<1, 1, 1, 1>(Vector));
+    return MlasExtractLaneFloat32x4<0>(Vector);
 #endif
 }
 
@@ -1198,108 +1445,24 @@ MlasReduceMaximumFloat32x4(MLAS_FLOAT32X4 Vector)
     VectorLow = vpmax_f32(VectorLow, VectorHigh);
     VectorLow = vpmax_f32(VectorLow, VectorHigh);
     return vget_lane_f32(VectorLow, 0);
-#elif defined(MLAS_SSE2_INTRINSICS)
-    Vector = MlasMaximumFloat32x4(Vector, _mm_shuffle_ps(Vector, Vector, _MM_SHUFFLE(3, 2, 3, 2)));
-    Vector = MlasMaximumFloat32x4(Vector, _mm_shuffle_ps(Vector, Vector, _MM_SHUFFLE(1, 1, 1, 1)));
-    return _mm_cvtss_f32(Vector);
 #elif defined(MLAS_VSX_INTRINSICS)
     Vector = MlasMaximumFloat32x4(Vector, MLAS_FLOAT32X4(vec_splat((__vector int64_t)Vector, 1)));
     Vector = MlasMaximumFloat32x4(Vector, vec_splat(Vector, 1));
     return Vector[0];
 #else
-#error Unsupported architecture.
+    Vector = MlasMaximumFloat32x4(Vector, MlasShuffleFloat32x4<2, 3, 2, 3>(Vector));
+    Vector = MlasMaximumFloat32x4(Vector, MlasShuffleFloat32x4<1, 1, 1, 1>(Vector));
+    return MlasExtractLaneFloat32x4<0>(Vector);
 #endif
 }
-
-MLAS_FORCEINLINE
-MLAS_INT32X4
-MlasAddInt32x4(MLAS_INT32X4 Vector1, MLAS_INT32X4 Vector2)
-{
-#if defined(MLAS_NEON_INTRINSICS)
-    return vaddq_s32(Vector1, Vector2);
-#elif defined(MLAS_SSE2_INTRINSICS)
-    return _mm_add_epi32(Vector1, Vector2);
-#else
-    return Vector1 + Vector2;
-#endif
-}
-
-MLAS_FORCEINLINE
-MLAS_INT32X4
-MlasSubtractInt32x4(MLAS_INT32X4 Vector1, MLAS_INT32X4 Vector2)
-{
-#if defined(MLAS_NEON_INTRINSICS)
-    return vsubq_s32(Vector1, Vector2);
-#elif defined(MLAS_SSE2_INTRINSICS)
-    return _mm_sub_epi32(Vector1, Vector2);
-#else
-    return Vector1 - Vector2;
-#endif
-}
-
-template<unsigned ShiftCount>
-MLAS_FORCEINLINE
-MLAS_INT32X4
-MlasShiftLeftInt32x4(MLAS_INT32X4 Vector)
-{
-#if defined(MLAS_NEON_INTRINSICS)
-    return vshlq_n_s32(Vector, ShiftCount);
-#elif defined(MLAS_SSE2_INTRINSICS)
-    return _mm_slli_epi32(Vector, ShiftCount);
-#else
-    return Vector << ShiftCount;
-#endif
-}
-
-#if !defined(MLAS_SSE2_INTRINSICS) || defined(MLAS_SSE41_INTRINSICS)
-
-MLAS_FORCEINLINE
-MLAS_INT32X4
-MlasMaximumInt32x4(MLAS_INT32X4 Vector1, MLAS_INT32X4 Vector2)
-{
-#if defined(MLAS_NEON_INTRINSICS)
-    return vmaxq_s32(Vector1, Vector2);
-#elif defined(MLAS_SSE41_INTRINSICS)
-    return _mm_max_epi32(Vector1, Vector2);
-#elif defined(MLAS_VSX_INTRINSICS)
-    return vec_vmaxsw(Vector1, Vector2);
-#else
-#error Unsupported architecture.
-#endif
-}
-
-MLAS_FORCEINLINE
-MLAS_INT32X4
-MlasMinimumInt32x4(MLAS_INT32X4 Vector1, MLAS_INT32X4 Vector2)
-{
-#if defined(MLAS_NEON_INTRINSICS)
-    return vminq_s32(Vector1, Vector2);
-#elif defined(MLAS_SSE41_INTRINSICS)
-    return _mm_min_epi32(Vector1, Vector2);
-#elif defined(MLAS_VSX_INTRINSICS)
-    return vec_vminsw(Vector1, Vector2);
-#else
-#error Unsupported architecture.
-#endif
-}
-
-#endif
 
 // calc 2^int(N)
 MLAS_FORCEINLINE
 MLAS_FLOAT32X4
 MlasPowerOf2Float32x4(MLAS_FLOAT32X4 Vector)
 {
-#if defined(MLAS_NEON_INTRINSICS)
-    MLAS_INT32X4 emm0 = vaddq_s32(vcvtq_s32_f32(Vector), MlasBroadcastInt32x4(127));
-    return vreinterpretq_f32_s32(vshlq_n_s32(emm0, 23));
-#elif defined(MLAS_SSE2_INTRINSICS)
-    MLAS_INT32X4 emm0 = _mm_add_epi32(_mm_cvttps_epi32(Vector), MlasBroadcastInt32x4(127));
-    return _mm_castsi128_ps(_mm_slli_epi32(emm0, 23));
-#elif defined(MLAS_VSX_INTRINSICS)
-    MLAS_INT32X4 emm0 = vec_cts(Vector, 0) + MlasBroadcastInt32x4(127);
-    return MLAS_FLOAT32X4(vec_sl(emm0, MLAS_UINT32X4(MlasBroadcastInt32x4(23))));
-#endif
+    MLAS_INT32X4 emm0 = MlasAddInt32x4(MlasCastToInt32x4(Vector), MlasBroadcastInt32x4(127));
+    return MlasReinterpretAsFloat32x4(MlasShiftLeftInt32x4<23>(emm0));
 }
 
 //

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1168,6 +1168,8 @@ MlasShuffleFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
 #endif
 }
 
+#if !defined(MLAS_SSE2_INTRINSICS)
+
 template<unsigned Index0, unsigned Index1, unsigned Index2, unsigned Index3>
 MLAS_FORCEINLINE
 MLAS_FLOAT32X4
@@ -1175,6 +1177,8 @@ MlasShuffleFloat32x4(MLAS_FLOAT32X4 Vector)
 {
     return MlasShuffleFloat32x4<Index0, Index1, Index2, Index3>(Vector, Vector);
 }
+
+#endif
 
 #endif
 

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1152,17 +1152,19 @@ MlasShuffleFloat32x4(MLAS_FLOAT32X4 Vector)
     return _mm_shuffle_ps(Vector, Vector, _MM_SHUFFLE(Index3, Index2, Index1, Index0));
 }
 
-#else
+#endif
+
+#if !defined(_MSC_VER)
 
 template<unsigned Index0, unsigned Index1, unsigned Index2, unsigned Index3>
 MLAS_FORCEINLINE
 MLAS_FLOAT32X4
 MlasShuffleFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
 {
-#if defined(__GNUC__)
-    return __builtin_shuffle(Vector1, Vector2, MLAS_INT32X4{Index0, Index1, Index2, Index3});
-#else
+#if defined(__clang__)
     return __builtin_shufflevector(Vector1, Vector2, Index0, Index1, Index2, Index3);
+#else
+    return __builtin_shuffle(Vector1, Vector2, MLAS_INT32X4{Index0, Index1, Index2, Index3});
 #endif
 }
 
@@ -1306,7 +1308,7 @@ MLAS_FLOAT32X4
 MlasGreaterThanFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
 {
 #if defined(MLAS_NEON_INTRINSICS)
-    return vreinterpretq_f32_s32(vcgtq_f32(Vector1, Vector2));
+    return vreinterpretq_f32_u32(vcgtq_f32(Vector1, Vector2));
 #elif defined(MLAS_SSE2_INTRINSICS)
     return _mm_cmpgt_ps(Vector1, Vector2);
 #else

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1154,7 +1154,7 @@ MlasShuffleFloat32x4(MLAS_FLOAT32X4 Vector)
 
 #endif
 
-#if !defined(_MSC_VER)
+#if !defined(MLAS_SSE2_INTRINSICS) && !defined(_MSC_VER)
 
 template<unsigned Index0, unsigned Index1, unsigned Index2, unsigned Index3>
 MLAS_FORCEINLINE
@@ -1168,8 +1168,6 @@ MlasShuffleFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
 #endif
 }
 
-#if !defined(MLAS_SSE2_INTRINSICS)
-
 template<unsigned Index0, unsigned Index1, unsigned Index2, unsigned Index3>
 MLAS_FORCEINLINE
 MLAS_FLOAT32X4
@@ -1177,8 +1175,6 @@ MlasShuffleFloat32x4(MLAS_FLOAT32X4 Vector)
 {
     return MlasShuffleFloat32x4<Index0, Index1, Index2, Index3>(Vector, Vector);
 }
-
-#endif
 
 #endif
 

--- a/onnxruntime/core/mlas/lib/pooling.cpp
+++ b/onnxruntime/core/mlas/lib/pooling.cpp
@@ -80,7 +80,7 @@ struct MLAS_MAXIMUM_POOLING
 
     static float Reduce(float Reduction, float Value)
     {
-        return (std::max)(Reduction, Value);
+        return std::max(Reduction, Value);
     }
 
     static MLAS_FLOAT32X4 Reduce(MLAS_FLOAT32X4 Reduction, MLAS_FLOAT32X4 Value)
@@ -293,8 +293,8 @@ Return Value:
             const int64_t iwStart64 = pw * StrideWidth - PaddingLeftWidth;
             const int64_t iwEnd64 = iwStart64 + KernelWidth;
 
-            const size_t iwStart = size_t((std::max)(iwStart64, int64_t(0)));
-            const size_t iwEnd = size_t((std::min)(iwEnd64, int64_t(InputWidth)));
+            const size_t iwStart = size_t(std::max(iwStart64, int64_t(0)));
+            const size_t iwEnd = size_t(std::min(iwEnd64, int64_t(InputWidth)));
 
             float m = PoolingType::InitialValue();
 
@@ -370,16 +370,16 @@ Return Value:
             const int64_t ihStart64 = ph * StrideHeight - PaddingLeftHeight;
             const int64_t ihEnd64 = ihStart64 + KernelHeight;
 
-            const size_t ihStart = size_t((std::max)(ihStart64, int64_t(0)));
-            const size_t ihEnd = size_t((std::min)(ihEnd64, int64_t(InputHeight)));
+            const size_t ihStart = size_t(std::max(ihStart64, int64_t(0)));
+            const size_t ihEnd = size_t(std::min(ihEnd64, int64_t(InputHeight)));
 
             for (size_t pw = 0; pw < OutputWidth; pw++) {
 
                 const int64_t iwStart64 = pw * StrideWidth - PaddingLeftWidth;
                 const int64_t iwEnd64 = iwStart64 + KernelWidth;
 
-                const size_t iwStart = size_t((std::max)(iwStart64, int64_t(0)));
-                const size_t iwEnd = size_t((std::min)(iwEnd64, int64_t(InputWidth)));
+                const size_t iwStart = size_t(std::max(iwStart64, int64_t(0)));
+                const size_t iwEnd = size_t(std::min(iwEnd64, int64_t(InputWidth)));
 
                 float m = PoolingType::InitialValue();
 
@@ -604,14 +604,12 @@ Return Value:
                         break;
                     }
 
-#if defined(MLAS_NEON_INTRINSICS) || defined(MLAS_VSX_INTRINSICS)
-                    MlasStoreLaneFloat32x4<0>(Output, Reduction);
-                    MlasStoreLaneFloat32x4<2>(Output + 1, Reduction);
-#elif defined(MLAS_SSE2_INTRINSICS)
+#if defined(MLAS_SSE2_INTRINSICS)
                     Reduction = _mm_shuffle_ps(Reduction, Reduction, _MM_SHUFFLE(2, 0, 2, 0));
                     MlasStoreLowHalfFloat32x4(Output, Reduction);
 #else
-#error Unsupported architecture.
+                    MlasStoreLaneFloat32x4<0>(Output, Reduction);
+                    MlasStoreLaneFloat32x4<2>(Output + 1, Reduction);
 #endif
 
                     Output += 2;
@@ -688,24 +686,24 @@ Return Value:
             const int64_t idStart64 = pd * StrideDepth - PaddingLeftDepth;
             const int64_t idEnd64 = idStart64 + KernelDepth;
 
-            const size_t idStart = size_t((std::max)(idStart64, int64_t(0)));
-            const size_t idEnd = size_t((std::min)(idEnd64, int64_t(InputDepth)));
+            const size_t idStart = size_t(std::max(idStart64, int64_t(0)));
+            const size_t idEnd = size_t(std::min(idEnd64, int64_t(InputDepth)));
 
             for (size_t ph = 0; ph < OutputHeight; ph++) {
 
                 const int64_t ihStart64 = ph * StrideHeight - PaddingLeftHeight;
                 const int64_t ihEnd64 = ihStart64 + KernelHeight;
 
-                const size_t ihStart = size_t((std::max)(ihStart64, int64_t(0)));
-                const size_t ihEnd = size_t((std::min)(ihEnd64, int64_t(InputHeight)));
+                const size_t ihStart = size_t(std::max(ihStart64, int64_t(0)));
+                const size_t ihEnd = size_t(std::min(ihEnd64, int64_t(InputHeight)));
 
                 for (size_t pw = 0; pw < OutputWidth; pw++) {
 
                     const int64_t iwStart64 = pw * StrideWidth - PaddingLeftWidth;
                     const int64_t iwEnd64 = iwStart64 + KernelWidth;
 
-                    const size_t iwStart = size_t((std::max)(iwStart64, int64_t(0)));
-                    const size_t iwEnd = size_t((std::min)(iwEnd64, int64_t(InputWidth)));
+                    const size_t iwStart = size_t(std::max(iwStart64, int64_t(0)));
+                    const size_t iwEnd = size_t(std::min(iwEnd64, int64_t(InputWidth)));
 
                     float m = PoolingType::InitialValue();
 
@@ -976,14 +974,12 @@ Return Value:
                             break;
                         }
 
-#if defined(MLAS_NEON_INTRINSICS) || defined(MLAS_VSX_INTRINSICS)
-                        MlasStoreLaneFloat32x4<0>(Output, Reduction);
-                        MlasStoreLaneFloat32x4<2>(Output + 1, Reduction);
-#elif defined(MLAS_SSE2_INTRINSICS)
+#if defined(MLAS_SSE2_INTRINSICS)
                         Reduction = _mm_shuffle_ps(Reduction, Reduction, _MM_SHUFFLE(2, 0, 2, 0));
                         MlasStoreLowHalfFloat32x4(Output, Reduction);
 #else
-#error Unsupported architecture.
+                        MlasStoreLaneFloat32x4<0>(Output, Reduction);
+                        MlasStoreLaneFloat32x4<2>(Output + 1, Reduction);
 #endif
 
                         Output += 2;

--- a/onnxruntime/core/mlas/lib/reorder.cpp
+++ b/onnxruntime/core/mlas/lib/reorder.cpp
@@ -213,7 +213,7 @@ Return Value:
 
     for (size_t i = InputChannels; i > 0;) {
 
-        const size_t InputChannelsThisIteration = (std::min)(i, BlockSize);
+        const size_t InputChannelsThisIteration = std::min(i, BlockSize);
         i -= InputChannelsThisIteration;
 
         const float* s = S;
@@ -308,7 +308,7 @@ Return Value:
 
         for (size_t o = OutputChannels; o > 0;) {
 
-            const size_t OutputChannelsThisIteration = (std::min)(o, BlockSize);
+            const size_t OutputChannelsThisIteration = std::min(o, BlockSize);
             const size_t AlignedOutputChannelsThisIteration = OutputChannelsThisIteration & (~3);
             o -= OutputChannelsThisIteration;
 
@@ -415,7 +415,7 @@ Return Value:
 
             for (size_t o = OutputChannels; o > 0;) {
 
-                const size_t OutputChannelsThisIteration = (std::min)(o, BlockSize);
+                const size_t OutputChannelsThisIteration = std::min(o, BlockSize);
                 const size_t AlignedOutputChannelsThisIteration = OutputChannelsThisIteration & (~3);
                 o -= OutputChannelsThisIteration;
 
@@ -523,7 +523,7 @@ Return Value:
 
     for (size_t o = OutputChannels; o > 0;) {
 
-        const size_t OutputChannelsThisIteration = (std::min)(o, BlockSize);
+        const size_t OutputChannelsThisIteration = std::min(o, BlockSize);
         const size_t AlignedOutputChannelsThisIteration = OutputChannelsThisIteration & (~3);
         o -= OutputChannelsThisIteration;
 
@@ -538,7 +538,7 @@ Return Value:
 
         for (size_t i = InputChannels; i > 0;) {
 
-            const size_t InputChannelsThisIteration = (std::min)(i, BlockSize);
+            const size_t InputChannelsThisIteration = std::min(i, BlockSize);
             i -= InputChannelsThisIteration;
 
             //
@@ -671,7 +671,7 @@ Return Value:
 
     for (size_t o = OutputChannels; o > 0;) {
 
-        const size_t OutputChannelsThisIteration = (std::min)(o, BlockSize);
+        const size_t OutputChannelsThisIteration = std::min(o, BlockSize);
         const size_t AlignedOutputChannelsThisIteration = OutputChannelsThisIteration & (~3);
         o -= OutputChannelsThisIteration;
 

--- a/onnxruntime/core/mlas/lib/snchwc.cpp
+++ b/onnxruntime/core/mlas/lib/snchwc.cpp
@@ -539,7 +539,7 @@ struct MLAS_NCHWC_GROUPED_CONV_ALGORITHM : MLAS_NCHWC_CONV_ALGORITHM
 
     void ComputeFilterCount(void)
     {
-        FilterCount = (std::min)(FilterSetSize, (OutputChannels / BlockSize) - FilterSet * FilterSetSize);
+        FilterCount = std::min(FilterSetSize, (OutputChannels / BlockSize) - FilterSet * FilterSetSize);
     }
 
     void PrepareWork(int32_t Index)
@@ -686,7 +686,7 @@ struct MLAS_NCHWC_CONV_NCHWC_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
             // Compute the number of output lines to process in this iteration.
             //
 
-            size_t WorkThisIteration = (std::min)(WorkRemaining, OutputHeight - ph);
+            size_t WorkThisIteration = std::min(WorkRemaining, OutputHeight - ph);
 
             //
             // Walk over each input image organized as a set of NCHWc blocks.
@@ -898,7 +898,7 @@ struct MLAS_NCHWC_CONV_POINTWISE_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
             size_t WorkThisIteration;
 
             if (StrideHeight == 1 && StrideWidth == 1) {
-                WorkThisIteration = (std::min)(WorkRemaining, OutputHeight - ph);
+                WorkThisIteration = std::min(WorkRemaining, OutputHeight - ph);
             } else {
                 WorkThisIteration = 1;
             }
@@ -923,7 +923,7 @@ struct MLAS_NCHWC_CONV_POINTWISE_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
 
                 constexpr size_t MaximumInputChannelBatch = 128;
 
-                InputChannelBatch = (std::min)(InputChannels - ic, MaximumInputChannelBatch);
+                InputChannelBatch = std::min(InputChannels - ic, MaximumInputChannelBatch);
 
                 unsigned KernelFlags = ComputeKernelFlags(ic, InputChannelBatch);
 

--- a/onnxruntime/core/mlas/lib/tanh.cpp
+++ b/onnxruntime/core/mlas/lib/tanh.cpp
@@ -119,7 +119,7 @@ Return Value:
 
         float Value = *Input++;
 
-        Value = (std::min)(MlasTanhConstants.UpperRange, (std::max)(MlasTanhConstants.LowerRange, Value));
+        Value = std::min(MlasTanhConstants.UpperRange, std::max(MlasTanhConstants.LowerRange, Value));
 
         float ValueSquared = Value * Value;
 


### PR DESCRIPTION
Various cleanup changes:
1. Fix up the remaining vector usage to be more "portable" to architectures that have at least the gcc/clang vector language extensions. This allows the code to compile using the RISC-V compiler as an example (but not link as there is not a stock GEMM available yet).
2. Remove the "(std:min)" workaround for windows.h defining min/max macros and go with the NOMINMAX workaround instead. Makes the code a little less weird looking.
3. Reduce the code size of the SSE2 quantized GEMM routine further without affecting performance.