### PR TITLE
(documentation) Fix DML EP doc link to C API

### DIFF
--- a/docs/execution_providers/DirectML-ExecutionProvider.md
+++ b/docs/execution_providers/DirectML-ExecutionProvider.md
@@ -91,7 +91,7 @@ The DirectML execution provider does not support the use of memory pattern optim
 
 If using the onnxruntime C API, you must call `DisableMemPattern` and `SetSessionExecutionMode` functions to set the options required by the DirectML execution provider.
 
-See [onnxruntime\include\onnxruntime\core\session\onnxruntime_c_api.h](..\..\include\onnxruntime\core\session\onnxruntime_c_api.h).
+See [onnxruntime\include\onnxruntime\core\session\onnxruntime_c_api.h](../../include/onnxruntime/core/session/onnxruntime_c_api.h).
 
     OrtStatus*(ORT_API_CALL* DisableMemPattern)(_Inout_ OrtSessionOptions* options)NO_EXCEPTION;
 


### PR DESCRIPTION
**Description**: Doc path used \ instead of /, which leads to 404.

**Motivation and Context**
- Because the link points to the wrong location.
- No open existing issue.
