### PR TITLE
Fix the nuget gpu pipeline

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest-docker-gpu.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest-docker-gpu.sh
@@ -35,6 +35,6 @@ sudo --preserve-env docker run -h $HOSTNAME \
         -e "PackageName=$PackageName" \
         -e "RunTestCsharp=$RunTestCsharp" \
         -e "RunTestNative=$RunTestNative" \
-        "onnxruntime-$IMAGE" \
+        onnxruntime-ubuntu16.04-cuda10.1-cudnn7.6 \
         /bin/bash /onnxruntime_src/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh \
         /home/onnxruntimedev/$NUGET_REPO_DIRNAME /onnxruntime_src /home/onnxruntimedev $CurrentOnnxRuntimeVersion


### PR DESCRIPTION
**Description**: 
The $IMAGE doesn't exist anymore. It is undefined so the "docker run" command would fail.  It was a mistake when I made the PR #4084. I merged the PR #4084 first so that at least this night we'll see one of the nuget pipelines become green. 

The no-contrib op nuget pipeline will still fail. We need a better way to filter out the test models.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
