### PR TITLE
Use OrtMutex and OrtCondVar everywhere 

### DIFF
--- a/onnxruntime/core/framework/random_generator.h
+++ b/onnxruntime/core/framework/random_generator.h
@@ -4,9 +4,10 @@
 #pragma once
 
 #include <atomic>
-#include <mutex>
 #include <stdint.h>
 #include <utility>
+
+#include "core/platform/ort_mutex.h"
 
 namespace onnxruntime {
 
@@ -56,7 +57,7 @@ class PhiloxGenerator {
    * Resets the seed and offset.
    */
   void SetSeed(uint64_t seed) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<OrtMutex> lock(mutex_);
     seed_ = seed;
     offset_ = 0;
   }
@@ -65,7 +66,7 @@ class PhiloxGenerator {
    * Gets the seed and offset pair, incrementing the offset by the specified count.
    */
   std::pair<uint64_t, uint64_t> NextPhiloxSeeds(uint64_t count) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<OrtMutex> lock(mutex_);
     auto seeds = std::make_pair(seed_, offset_);
     offset_ += count;
     return seeds;
@@ -78,7 +79,7 @@ class PhiloxGenerator {
   static PhiloxGenerator& Default();
 
  private:
-  std::mutex mutex_;
+  OrtMutex mutex_;
   uint64_t seed_;
   uint64_t offset_;
 };

--- a/onnxruntime/core/profile/context.h
+++ b/onnxruntime/core/profile/context.h
@@ -4,16 +4,17 @@
 #pragma once
 
 #include <thread>
-#include <mutex>
 #include <string>
 #include <unordered_map>
+
+#include "core/platform/ort_mutex.h"
 
 #ifdef ENABLE_NVTX_PROFILE
 
 namespace onnxruntime {
 namespace profile {
 
-// Singleton class of managing global NVTX profiling information. 
+// Singleton class of managing global NVTX profiling information.
 class Context {
  public:
   static Context& GetInstance() {
@@ -24,14 +25,14 @@ class Context {
   // Return tag for the specified thread.
   // If the thread's tag doesn't exist, this function returns an empty string.
   std::string GetThreadTagOrDefault(const std::thread::id& thread_id) {
-    const std::lock_guard<std::mutex> lock(mtx_);
+    const std::lock_guard<OrtMutex> lock(mtx_);
     return thread_tag_[thread_id];
   }
 
   // Set tag for the specified thread.
   void SetThreadTag(
       const std::thread::id& thread_id, const std::string& tag) {
-    const std::lock_guard<std::mutex> lock(mtx_);
+    const std::lock_guard<OrtMutex> lock(mtx_);
     thread_tag_[thread_id] = tag;
   }
 
@@ -43,7 +44,7 @@ class Context {
 
   // map from thread's id to its human-readable tag.
   std::unordered_map<std::thread::id, std::string> thread_tag_;
-  std::mutex mtx_;
+  OrtMutex mtx_;
 };
 
 }  // namespace profile

--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_aggregator.h
+++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_aggregator.h
@@ -41,9 +41,9 @@ struct ScoreValue {
 };
 
 enum MissingTrack {
-  NONE,
-  TRUE,
-  FALSE
+  kNone,
+  kTrue,
+  kFalse
 };
 
 template <typename T>

--- a/onnxruntime/test/perftest/performance_runner.h
+++ b/onnxruntime/test/perftest/performance_runner.h
@@ -7,7 +7,6 @@
 #include <string>
 #include <vector>
 #include <algorithm>
-#include <mutex>
 #include <iostream>
 #include <random>
 #include <chrono>
@@ -15,6 +14,7 @@
 #include <core/common/common.h>
 #include <core/common/status.h>
 #include <core/platform/env.h>
+#include <core/platform/ort_mutex.h>
 #include <core/session/onnxruntime_cxx_api.h>
 #include "test_configuration.h"
 #include "heap_buffer.h"
@@ -108,7 +108,7 @@ class PerformanceRunner {
     }
 
     if (!isWarmup) {
-      std::lock_guard<std::mutex> guard(results_mutex_);
+      std::lock_guard<OrtMutex> guard(results_mutex_);
       performance_result_.time_costs.emplace_back(duration_seconds.count());
       performance_result_.total_time_cost += duration_seconds.count();
       if (performance_test_config_.run_config.f_verbose) {
@@ -148,8 +148,7 @@ class PerformanceRunner {
   onnxruntime::test::HeapBuffer b_;
   std::unique_ptr<ITestCase> test_case_;
 
-  // TODO: Convert to OrtMutex
-  std::mutex results_mutex_;
+  OrtMutex results_mutex_;
 };
 }  // namespace perftest
 }  // namespace onnxruntime

--- a/onnxruntime/test/platform/threadpool_test.cc
+++ b/onnxruntime/test/platform/threadpool_test.cc
@@ -3,6 +3,7 @@
 
 #include "core/platform/threadpool.h"
 #include "core/platform/EigenNonBlockingThreadPool.h"
+#include "core/platform/ort_mutex.h"
 
 #include <core/common/make_unique.h>
 
@@ -10,7 +11,6 @@
 #include <algorithm>
 #include <memory>
 #include <functional>
-#include <mutex>
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -24,7 +24,7 @@ struct TestData {
   explicit TestData(int num) : data(num, 0) {
   }
   std::vector<int> data;
-  std::mutex mutex;
+  onnxruntime::OrtMutex mutex;
 };
 
 // This unittest tests ThreadPool function by counting the number of calls to function with each index.
@@ -35,7 +35,7 @@ std::unique_ptr<TestData> CreateTestData(int num) {
 }
 
 void IncrementElement(TestData& test_data, ptrdiff_t i) {
-  std::lock_guard<std::mutex> lock(test_data.mutex);
+  std::lock_guard<onnxruntime::OrtMutex> lock(test_data.mutex);
   test_data.data[i]++;
 }
 


### PR DESCRIPTION
**Description**:
A few usages of std::mutex/std::condition_variable remained or had crept in. Update those to use OrtMutex and OrtCondVar. 

Needed to change the MissingTrack enum naming due to ort_mutex.h including Windows.h which #defines TRUE and FALSE (via inclusion of fdi_fci_types.h), breaking usage of MissingTrack::TRUE and MissingTrack::FALSE.

**Motivation and Context**
Improve consistency. 