### PR TITLE
Add support for DropoutGrad with training_mode=false

### DIFF
--- a/orttraining/orttraining/core/graph/gradient_schema_defs.cc
+++ b/orttraining/orttraining/core/graph/gradient_schema_defs.cc
@@ -1046,6 +1046,12 @@ Example 4:
              "the case during training.",
              "T1",
              OpSchema::Optional)
+      .Input(3, "training_mode",
+            "If set to true then it indicates dropout is being used for training. It is an optional value hence unless "
+            "specified explicitly, it is false. If it is false, ratio is ignored and the operation mimics inference mode where "
+            "nothing will be dropped from the input data and if mask is requested as output it will contain all ones.",
+            "T2",
+            OpSchema::Optional)
       .Output(0, "dx", "Gradient of the input.", "T")
       .TypeConstraint(
           "T",
@@ -1058,7 +1064,7 @@ Example 4:
       .TypeConstraint(
           "T2",
           {"tensor(bool)"},
-          "Constrain 'mask' types to boolean tensors.")
+          "Constrain 'mask' and 'training_mode' types to boolean tensors.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         propagateShapeAndTypeFromFirstInput(ctx);
       });

--- a/orttraining/orttraining/test/training_ops/cpu/nn/dropout_op_test.cc
+++ b/orttraining/orttraining/test/training_ops/cpu/nn/dropout_op_test.cc
@@ -197,7 +197,7 @@ void RunDropoutGradTest(const char* op, float ratio, const std::vector<int64_t>&
 
 TEST(DropoutGradTest, Basic) {
 
-  std::vector<float> training_mode({true, false});
+  const std::vector<bool> training_mode({true, false});
   for (const auto& mode : training_mode) {
     //Ratio 0.2, 1D
     RunDropoutGradTest("DropoutGrad", 0.2f, {16}, mode, false);
@@ -214,15 +214,14 @@ TEST(DropoutGradTest, Basic) {
 }
 
 TEST(DropoutGradTest, RatioLimit) {
-  std::vector<float> training_mode({true, false});
+  const std::vector<bool> training_mode({true, false});
   for (const auto& mode : training_mode) {
     RunDropoutGradTest("DropoutGrad", 0.0f, {16}, mode, false);
   }
 }
 
 TEST(TrainableDropoutGradTest, Basic) {
-
-  std::vector<float> training_mode({true, false});
+  const std::vector<bool> training_mode({true, false});
   for (const auto& mode : training_mode) {    //Ratio 0.2, 1D
     RunDropoutGradTest("TrainableDropoutGrad", 0.2f, {16}, mode, false);
 
@@ -238,7 +237,7 @@ TEST(TrainableDropoutGradTest, Basic) {
 }
 
 TEST(TrainableDropoutGradTest, RatioLimit) {
-  std::vector<float> training_mode({true, false});
+  const std::vector<bool> training_mode({true, false});
   for (const auto& mode : training_mode) {
     RunDropoutGradTest("TrainableDropoutGrad", 0.0f, {16}, mode, false);
   }

--- a/orttraining/orttraining/test/training_ops/cpu/nn/dropout_op_test.cc
+++ b/orttraining/orttraining/test/training_ops/cpu/nn/dropout_op_test.cc
@@ -174,7 +174,7 @@ void RunDropoutGradTest(const char* op, float ratio, const std::vector<int64_t>&
         mask_buffer.get(), mask_buffer.get() + input_shape.Size(), std::back_inserter(dx_data),
         [output_constant](bool mask_value) { return mask_value ? output_constant : 0.0f; });
   } else {
-    dx_data.resize(input_shape.Size(), input_constant);
+    dx_data.assign(input_shape.Size(), input_constant);
   }
 
   test.AddInput<float>("dy", input_shape.GetDims(), dy_data);

--- a/orttraining/orttraining/training_ops/cpu/nn/dropout_op.cc
+++ b/orttraining/orttraining/training_ops/cpu/nn/dropout_op.cc
@@ -108,13 +108,11 @@ Status DropoutGrad<T1, T2>::Compute(OpKernelContext* context) const {
   ORT_ENFORCE(mask->Shape() == dY_shape, "dY and mask should have the same shape");
   ORT_ENFORCE(dX->Shape() == dY_shape, "dY and dX should have the same shape");
 
-  if (ratio_value == 0.0f or !training_mode_value) {
-    std::cout << "CPU INFERENCE MODE (" << ratio_value << "/" << training_mode_value << ") " << std::endl;
+  if (ratio_value == 0.0f || !training_mode_value) {
     if (dY_span.data() != dX_span.data()) {
       std::copy(dY_span.begin(), dY_span.end(), dX_span.begin());
     }
   } else if (ratio_value < 1.0f) {
-    std::cout << "CPU TRAINING MODE (" << ratio_value << "/" << training_mode_value << ") " << std::endl;
 
     ConstEigenVectorArrayMap<T1> dY_arr(dY_span.data(), dY_span.size());
     ConstEigenVectorArrayMap<bool> mask_arr(mask_span.data(), mask_span.size());

--- a/orttraining/orttraining/training_ops/cuda/nn/dropout.cc
+++ b/orttraining/orttraining/training_ops/cuda/nn/dropout.cc
@@ -91,7 +91,6 @@ Status DropoutGrad<T1, T2>::ComputeInternal(OpKernelContext* context) const {
   auto training_mode = context->Input<Tensor>(3); // optional
   bool training_mode_data = false;
   if (training_mode){
-    std::cout << "CUDA DROPOUT BEFORE tensor->template Data<bool>() call" << std::endl;
     ORT_ENFORCE(training_mode->Shape().Size() == 1);
     training_mode_data = *(training_mode->template Data<bool>());
   }
@@ -107,7 +106,6 @@ Status DropoutGrad<T1, T2>::ComputeInternal(OpKernelContext* context) const {
   ORT_ENFORCE(ratio_data >= 0.0f && ratio_data < 1.0f);
 
   const bool* mask_data = mask->template Data<bool>();
-  std::cout << "CUDA DROPOUT: " << training_mode_data << std::endl;
   DropoutGradientKernelImpl(N, dY_data, mask_data, ratio_data, training_mode_data, dX_data);
 
   return Status::OK();

--- a/orttraining/orttraining/training_ops/cuda/nn/dropout_impl.cu
+++ b/orttraining/orttraining/training_ops/cuda/nn/dropout_impl.cu
@@ -41,12 +41,16 @@ void DropoutGradientKernelImpl(
     const T* dY_data,
     const bool* mask_data,
     const float ratio,
+    const bool training_mode,
     T* dX_data) {
-  if (ratio == 0.0f) {
+  if (ratio == 0.0f or !training_mode) {
+    std::cout << "CUDA INFERENCE MODE (" << ratio << "/" << training_mode << ") " << std::endl;
     if (dY_data != dX_data) {
       CUDA_CALL_THROW(cudaMemcpyAsync(dX_data, dY_data, N * sizeof(T), cudaMemcpyDeviceToDevice));
     }
   } else {
+    std::cout << "CUDA TRAINING MODE (" << ratio << "/" << training_mode << ") "  << std::endl;
+
     const float scale = 1.f / (1.f - ratio);
     const int blocksPerGrid = (N + GridDim::maxThreadsPerBlock - 1) / GridDim::maxThreadsPerBlock;
     DropoutGradientKernel<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(N, dY_data, mask_data, T(scale), dX_data);
@@ -59,6 +63,7 @@ void DropoutGradientKernelImpl(
       const T* dY_data,                    \
       const bool* mask_data,               \
       const float scale,                   \
+      const bool training_mode_data,       \
       T* dX_data);
 
 SPECIALIZED_DROPOUT_GRAD_IMPL(float)

--- a/orttraining/orttraining/training_ops/cuda/nn/dropout_impl.cu
+++ b/orttraining/orttraining/training_ops/cuda/nn/dropout_impl.cu
@@ -43,14 +43,11 @@ void DropoutGradientKernelImpl(
     const float ratio,
     const bool training_mode,
     T* dX_data) {
-  if (ratio == 0.0f or !training_mode) {
-    std::cout << "CUDA INFERENCE MODE (" << ratio << "/" << training_mode << ") " << std::endl;
+  if (ratio == 0.0f || !training_mode) {
     if (dY_data != dX_data) {
       CUDA_CALL_THROW(cudaMemcpyAsync(dX_data, dY_data, N * sizeof(T), cudaMemcpyDeviceToDevice));
     }
   } else {
-    std::cout << "CUDA TRAINING MODE (" << ratio << "/" << training_mode << ") "  << std::endl;
-
     const float scale = 1.f / (1.f - ratio);
     const int blocksPerGrid = (N + GridDim::maxThreadsPerBlock - 1) / GridDim::maxThreadsPerBlock;
     DropoutGradientKernel<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(N, dY_data, mask_data, T(scale), dX_data);

--- a/orttraining/orttraining/training_ops/cuda/nn/dropout_impl.h
+++ b/orttraining/orttraining/training_ops/cuda/nn/dropout_impl.h
@@ -14,6 +14,7 @@ void DropoutGradientKernelImpl(
   const T* dY_data,
   const bool* mask_data,
   const float ratio,
+  const bool training_mode,
   T* dX_data);
 
 }  // namespace cuda


### PR DESCRIPTION
Currently DropoutGrad and TrainableDropoutGrad support training_mode=true, only. For completeness, training_mode=false support is also added and the output will be dx = dy

This PR should be merged after https://github.com/microsoft/onnxruntime/pull/4052