### PR TITLE
Fix hipLaunchKernelGGL compilation fails in ROCm 3.5

### DIFF
--- a/onnxruntime/core/providers/hip/cu_inc/binary_elementwise_impl.cuh
+++ b/onnxruntime/core/providers/hip/cu_inc/binary_elementwise_impl.cuh
@@ -190,7 +190,7 @@ void BinaryElementWiseNoBroadcastImpl(
 
   int blocksPerGrid = static_cast<int>(CeilDiv(count, GridDim::maxThreadsPerBlock * GridDim::maxElementsPerThread));
   HIP_LONG N = static_cast<HIP_LONG>(count);
-  hipLaunchKernelGGL(_BinaryElementWiseSimple<true, true, T, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>, dim3(blocksPerGrid), dim3(GridDim::maxThreadsPerBlock), 0, 0, 
+  hipLaunchKernelGGL((_BinaryElementWiseSimple<true, true, T, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>), dim3(blocksPerGrid), dim3(GridDim::maxThreadsPerBlock), 0, 0, 
           lhs_data,
           rhs_data,
           output_data,
@@ -217,7 +217,7 @@ void BinaryElementWiseImpl(
   int blocksPerGrid = static_cast<int>(CeilDiv(count, GridDim::maxThreadsPerBlock * GridDim::maxElementsPerThread));
   HIP_LONG N = static_cast<HIP_LONG>(count);
   if (output_rank_or_simple_broadcast == static_cast<int32_t>(SimpleBroadcast::NoBroadcast)) {
-    hipLaunchKernelGGL(_BinaryElementWiseSimple<true, true, T, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>,
+    hipLaunchKernelGGL((_BinaryElementWiseSimple<true, true, T, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>),
                   dim3(blocksPerGrid), dim3(GridDim::maxThreadsPerBlock), 0, 0, 
                   lhs_data,
                   rhs_data,
@@ -225,7 +225,7 @@ void BinaryElementWiseImpl(
                   func,
                   N);
   } else if (output_rank_or_simple_broadcast == static_cast<int32_t>(SimpleBroadcast::LeftScalar)) {
-    hipLaunchKernelGGL(_BinaryElementWiseSimple<false, true, T, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>,
+    hipLaunchKernelGGL((_BinaryElementWiseSimple<false, true, T, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>),
                   dim3(blocksPerGrid), dim3(GridDim::maxThreadsPerBlock), 0, 0, 
                   lhs_data,
                   rhs_data,
@@ -233,7 +233,7 @@ void BinaryElementWiseImpl(
                   func,
                   N);
   } else if (output_rank_or_simple_broadcast == static_cast<int32_t>(SimpleBroadcast::RightScalar)) {
-    hipLaunchKernelGGL(_BinaryElementWiseSimple<true, false, T, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>,
+    hipLaunchKernelGGL((_BinaryElementWiseSimple<true, false, T, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>),
                   dim3(blocksPerGrid), dim3(GridDim::maxThreadsPerBlock), 0, 0,
                   lhs_data,
                   rhs_data,
@@ -241,7 +241,7 @@ void BinaryElementWiseImpl(
                   func,
                   N);
   } else if (output_rank_or_simple_broadcast == static_cast<int32_t>(SimpleBroadcast::RightPerChannelBatch1)) {
-    hipLaunchKernelGGL(_BinaryElementWiseRhsPerChannelBatch1<T, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>,
+    hipLaunchKernelGGL((_BinaryElementWiseRhsPerChannelBatch1<T, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>),
                   dim3(blocksPerGrid), dim3(GridDim::maxThreadsPerBlock), 0, 0, 
                   lhs_data,
                   rhs_data,
@@ -250,7 +250,7 @@ void BinaryElementWiseImpl(
                   func,
                   N);
   } else if (output_rank_or_simple_broadcast == static_cast<int32_t>(SimpleBroadcast::RightPerChannelBatchN)) {
-    hipLaunchKernelGGL(_BinaryElementWiseRhsPerChannelBatchN<T, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>,
+    hipLaunchKernelGGL((_BinaryElementWiseRhsPerChannelBatchN<T, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>),
                   dim3(blocksPerGrid), dim3(GridDim::maxThreadsPerBlock), 0, 0, 
                   lhs_data,
                   rhs_data,
@@ -261,7 +261,7 @@ void BinaryElementWiseImpl(
                   N);
   } else {
     if (lhs_padded_strides && rhs_padded_strides)
-      hipLaunchKernelGGL(_BinaryElementWise<T, FuncT, true, true, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>,
+      hipLaunchKernelGGL((_BinaryElementWise<T, FuncT, true, true, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>),
                   dim3(blocksPerGrid), dim3(GridDim::maxThreadsPerBlock), 0, 0, 
                   output_rank_or_simple_broadcast,
                   lhs_padded_strides,
@@ -273,7 +273,7 @@ void BinaryElementWiseImpl(
                   func,
                   N);
     else if (lhs_padded_strides)
-      hipLaunchKernelGGL(_BinaryElementWise<T, FuncT, true, false, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>,
+      hipLaunchKernelGGL((_BinaryElementWise<T, FuncT, true, false, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>),
                   dim3(blocksPerGrid), dim3(GridDim::maxThreadsPerBlock), 0, 0, 
                   output_rank_or_simple_broadcast,
                   lhs_padded_strides,
@@ -285,7 +285,7 @@ void BinaryElementWiseImpl(
                   func,
                   N);
     else
-      hipLaunchKernelGGL(_BinaryElementWise<T, FuncT, false, true, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>,
+      hipLaunchKernelGGL((_BinaryElementWise<T, FuncT, false, true, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>),
                   dim3(blocksPerGrid), dim3(GridDim::maxThreadsPerBlock), 0, 0, 
                   output_rank_or_simple_broadcast,
                   lhs_padded_strides,

--- a/onnxruntime/core/providers/hip/reduction/reduction_functions.cu
+++ b/onnxruntime/core/providers/hip/reduction/reduction_functions.cu
@@ -204,7 +204,7 @@ void call_reduce_all_kernel(const TIn *data, TOut *output, int size, TOut *buffe
   }
 
   const int shared_mem_size = sizeof(TOut) * block_size.first * block_size.second / NUM_THREADS_PER_WARP;
-  hipLaunchKernelGGL(reduce_all_kernel<TIn, TOut, TOp, TFinalOp, DivideResultBySize>, dim3(grid), dim3(block), shared_mem_size, 0, size, data, output, buffer);
+  hipLaunchKernelGGL((reduce_all_kernel<TIn, TOut, TOp, TFinalOp, DivideResultBySize>), dim3(grid), dim3(block), shared_mem_size, 0, size, data, output, buffer);
 }
 
 template<typename TIn, typename TOut>
@@ -335,7 +335,7 @@ void call_reduce_matrix_rows(const TIn *input, TOut *output, int m, int n) {
   const dim3 grid(grid_x_dim, grid_y_dim, 1);
   const dim3 block(block_x_dim, block_y_dim, 1);
 
-  hipLaunchKernelGGL(reduce_matrix_rows_kernel<TIn, TOut, TBuf>, dim3(grid), dim3(block), block.y * block.x * sizeof(TBuf), 0, 
+  hipLaunchKernelGGL((reduce_matrix_rows_kernel<TIn, TOut, TBuf>), dim3(grid), dim3(block), block.y * block.x * sizeof(TBuf), 0, 
       input, output, m, n);
 }
 

--- a/onnxruntime/core/providers/hip/tensor/expand_impl.cu
+++ b/onnxruntime/core/providers/hip/tensor/expand_impl.cu
@@ -25,7 +25,7 @@ template <typename T>
 void FillFromDataPtr(T* output_data, const T* input_data, int64_t count) {
   int blocksPerGrid = gsl::narrow_cast<int>(CeilDiv(count, GridDim::maxThreadsPerBlock * GridDim::maxElementsPerThread));
   HIP_LONG N = static_cast<HIP_LONG>(count);
-  hipLaunchKernelGGL(_FillFromDataPtrKernel<T, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>, dim3(blocksPerGrid), dim3(GridDim::maxThreadsPerBlock), 0, 0, output_data, input_data, N);
+  hipLaunchKernelGGL((_FillFromDataPtrKernel<T, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>), dim3(blocksPerGrid), dim3(GridDim::maxThreadsPerBlock), 0, 0, output_data, input_data, N);
 }
 
 template <typename T>


### PR DESCRIPTION
**Description**: 
Add bracket on first parameter of hipLaunchKernelGGL. It won't break ROCm 3.3 so no harm is expected.

**Motivation and Context**
ROCm 3.5 switch compiler from legacy HCC to HIP-CLANG. New parser will fail on some host code refer to hipLaunchKernelGGL.
