### PR TITLE
Change group id to com.microsoft.onnxruntime per requirements.

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -12,7 +12,7 @@ allprojects {
 	}
 }
 
-project.group = "ai.onnxruntime"
+project.group = "com.microsoft.onnxruntime"
 version = rootProject.file('../VERSION_NUMBER').text.trim()
 
 java {


### PR DESCRIPTION
**Description**: 
Change groupId for maven publishing to com.microsoft.onnxruntime

**Motivation and Context**
Group id must match repo name created.