### PR TITLE
Hardcode WinML umbrella lib to windowsapp.lib, fix building of NodeJS bindings

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -627,6 +627,7 @@ target_link_libraries(winml_dll PRIVATE winml_lib_ort)
 target_link_libraries(winml_dll PRIVATE winml_lib_telemetry)
 
 target_link_libraries(winml_dll PRIVATE RuntimeObject.lib)
+target_link_libraries(winml_dll PRIVATE windowsapp.lib)
 
 # Any project that links in debug_alloc.obj needs this lib.
 # unresolved external symbol __imp_SymSetOptions


### PR DESCRIPTION
**Description**: Use windowsapp.lib umbrella lib. This is a no-op when building WinML w/ CMAKE_SYSTEM_NAME == WindowsStore, but is required to work around some linking bugs in internal builds. We'll get it removed after some more review and discussion.