### PR TITLE
fix build: pin pipeline Node.js version to 12.16.3

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -20,7 +20,7 @@ jobs:
         submodules: ${{ parameters.SubmoduleCheckoutMode }}
     - task: NodeTool@0
       inputs:
-        versionSpec: '12.x'
+        versionSpec: '12.16.3'
     - script: |
         export JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home
         java --version

--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -28,7 +28,7 @@ jobs:
 
   - task: NodeTool@0
     inputs:
-      versionSpec: '12.x'
+      versionSpec: '12.16.3'
 
   - task: BatchScript@1
     displayName: 'setup env'


### PR DESCRIPTION
pin Node.js version to 12.16.3 to fix build break.

This is a quick fix to unblock the build pipeline. There will be a complete fix to enable pipeline work with latest Node.js LTS.

why it broke the build?
- since 12.17, NAPI v6 is officially supported and the old macro `NAPI_EXPERIMENT` is removed and replaced by `NAPI_VERSION` 6. This cause the node.js binding to fail the build.

why not using NAPI v6?
- NAPI v6 is a very new API version so that onnxruntime would not work on some old Node.js version. **We are not really using any v6 features that implemented in Node.js recently.** The only feature we used in v6 is BigInt, which is already supported in Node.js 2 years ago. (the reason why BigInt is added in v6 is another story)

can current node.js binding work on latest and future Node.js without any code change?
- YES, it can. In our case, the NAPI v6 release only affect the typed array element type definition in `napi.h`. As explained above, the node.js already supported bigint 2 years ago and bigint64/biguint64 is already supported since then.

what is the plan for a complete fix?
- The goal is to make nodejs binding work with both old/new `napi.h` without declare the binding it self requires NAPI v6. This is kind of tricky but we want to support the current major node.js version. Details is still to be figured out.