### PR TITLE
[Vitis-AI EP] Fix to enable multi-output subgraphs inside Vitis-AI EP

### DIFF
--- a/dockerfiles/scripts/docker_run_vitisai.sh
+++ b/dockerfiles/scripts/docker_run_vitisai.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # --------------------------------------------------------------
 # Copyright(C) Xilinx Inc.
 # Licensed under the MIT License.

--- a/onnxruntime/core/providers/vitisai/vitisai_custom_op.h
+++ b/onnxruntime/core/providers/vitisai/vitisai_custom_op.h
@@ -46,7 +46,6 @@ class VitisAICustomOp {
   }
 
  private:
-  Status Initialize(const OrtApi* api, OrtKernelContext* context) const;
 
   std::vector<std::string> in_tensor_names_;
   std::vector<std::string> out_tensor_names_;


### PR DESCRIPTION
This PR adds a fix to the Vitis-AI execution provider to correctly handle models where the subgraph that can be executed using Vitis-AI hardware acceleration has multiple outputs.

In addition, this PR adds more information to the Vitis-AI execution provider documentation page.