### PR TITLE
Fix GPU memory leak on TensorRT

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1018,6 +1018,8 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<onnxruntime:
       for (int i = 0, end = num_binding_outputs; i < end; ++i) {
         if (output_types[i] == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
           cuda::Impl_Cast<int32_t, int64_t>(reinterpret_cast<int32_t*>(buffers[i + num_binding_inputs]), ort.GetTensorMutableData<int64_t>(output_tensor[i]), output_dim_sizes[i]);
+          cudaDeviceSynchronize();
+          cudaFree(buffers[i + num_binding_inputs]);
         }
       }
 


### PR DESCRIPTION
**Description**: Fixes a memory leak when running models with 64-bit integer input on TensorRT.

**Motivation and Context**
- Running TensorRT on our model creates a memory leak of GPU memory at about 4MB per minute on an RTX2080.  Using CUDA as the runtime provider there is no memory leak.  This fix resolves the leak.

I am passing this fix along which was contributed by Alexandros Koumparoulis