### PR TITLE
MLAS: change quantized GEMM to parameter struct

### DIFF
--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -147,21 +147,25 @@ MlasGemm(
     MLAS_THREADPOOL* ThreadPool
     );
 
-template<typename AType, typename BType>
+struct MLAS_GEMM_U8X8_PARAMETERS {
+    size_t M;
+    size_t N;
+    size_t K;
+    const uint8_t* A;
+    size_t lda;
+    const uint8_t* B;
+    size_t ldb;
+    int32_t* C;
+    size_t ldc;
+    uint8_t offa;
+    uint8_t offb;
+    bool BTypeIsSigned;
+};
+
 void
 MLASCALL
 MlasGemm(
-    size_t M,
-    size_t N,
-    size_t K,
-    const AType* A,
-    size_t lda,
-    AType offa,
-    const BType* B,
-    size_t ldb,
-    BType offb,
-    int32_t* C,
-    size_t ldc,
+    const MLAS_GEMM_U8X8_PARAMETERS* Parameters,
     MLAS_THREADPOOL* ThreadPool
     );
 

--- a/onnxruntime/core/mlas/lib/amd64/QgemmU8S8KernelAvx2.asm
+++ b/onnxruntime/core/mlas/lib/amd64/QgemmU8S8KernelAvx2.asm
@@ -946,8 +946,8 @@ ENDIF
 ;
 ;   C (r8) - Supplies the address of matrix C.
 ;
-;   QuadCountK (r9) - Supplies the number of quad columns from matrix A and the
-;       number of quad rows from matrix B to iterate over.
+;   PackedCountK (r9) - Supplies the number of packed columns from matrix A and
+;       the number of packed rows from matrix B to iterate over.
 ;
 ;   CountM - Supplies the maximum number of rows that can be processed for
 ;       matrix A and matrix C. The actual number of rows handled for this

--- a/onnxruntime/core/mlas/lib/amd64/QgemmU8U8KernelAvx2.asm
+++ b/onnxruntime/core/mlas/lib/amd64/QgemmU8U8KernelAvx2.asm
@@ -840,8 +840,8 @@ ComputeBlockLoopExit:
 ;
 ;   C (r8) - Supplies the address of matrix C.
 ;
-;   PairCountK (r9) - Supplies the number of pair columns from matrix A and the
-;       number of pair rows from matrix B to iterate over.
+;   PackedCountK (r9) - Supplies the number of packed columns from matrix A and
+;       the number of packed rows from matrix B to iterate over.
 ;
 ;   CountM - Supplies the maximum number of rows that can be processed for
 ;       matrix A and matrix C. The actual number of rows handled for this

--- a/onnxruntime/core/mlas/lib/amd64/QgemmU8X8KernelAvx512Common.inc
+++ b/onnxruntime/core/mlas/lib/amd64/QgemmU8X8KernelAvx512Common.inc
@@ -309,8 +309,8 @@ GemmU8X8KernelAvx512Function MACRO Type, Isa
 ;
 ;   C (r8) - Supplies the address of matrix C.
 ;
-;   QuadCountK (r9) - Supplies the number of quad columns from matrix A and the
-;       number of quad rows from matrix B to iterate over.
+;   PackedCountK (r9) - Supplies the number of packed columns from matrix A and
+;       the number of packed rows from matrix B to iterate over.
 ;
 ;   CountM - Supplies the maximum number of rows that can be processed for
 ;       matrix A and matrix C. The actual number of rows handled for this

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -254,18 +254,12 @@ typedef MLAS_SGEMM_TRANSPOSE_PACKB_BLOCK_ROUTINE* PMLAS_SGEMM_TRANSPOSE_PACKB_BL
 typedef
 void
 (MLASCALL MLAS_GEMM_U8X8_OPERATION)(
-    const struct MLAS_GEMM_U8X8_WORK_BLOCK* WorkBlock,
+    const MLAS_GEMM_U8X8_PARAMETERS* Parameters,
     size_t M,
     size_t N,
-    size_t K,
     const uint8_t* A,
-    size_t lda,
-    int16_t offa,
     const uint8_t* B,
-    size_t ldb,
-    int16_t offb,
-    int32_t* C,
-    size_t ldc
+    int32_t* C
     );
 
 typedef MLAS_GEMM_U8X8_OPERATION* PMLAS_GEMM_U8X8_OPERATION;
@@ -274,9 +268,9 @@ typedef
 size_t
 (MLASCALL MLAS_GEMM_U8S8_KERNEL)(
     const uint8_t* A,
-    const int8_t* B,
+    const uint8_t* B,
     int32_t* C,
-    size_t QuadCountK,
+    size_t PackedCountK,
     size_t CountM,
     size_t CountN,
     size_t ldc,
@@ -292,7 +286,7 @@ typedef
 size_t
 (MLASCALL MLAS_GEMV_U8S8_KERNEL)(
     const uint8_t* A,
-    const int8_t* B,
+    const uint8_t* B,
     int32_t* C,
     size_t CountK,
     size_t CountN,
@@ -307,7 +301,7 @@ size_t
     const int16_t* A,
     const uint8_t* B,
     int32_t* C,
-    size_t PairCountK,
+    size_t PackedCountK,
     size_t CountM,
     size_t CountN,
     size_t ldc,

--- a/onnxruntime/core/mlas/lib/qgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm.cpp
@@ -698,7 +698,6 @@ struct MLAS_GEMM_U8X8_KERNEL_SSE
     typedef int8_t OffsetBType;
 
     static constexpr size_t PackedK = 2;
-
     static constexpr size_t StrideM = 12;
     static constexpr size_t StrideN = 128;
     static constexpr size_t StrideK = 128;
@@ -763,6 +762,11 @@ struct MLAS_GEMM_U8X8_KERNEL_SSE
         return 1;
     }
 };
+
+constexpr size_t MLAS_GEMM_U8X8_KERNEL_SSE::PackedK;
+constexpr size_t MLAS_GEMM_U8X8_KERNEL_SSE::StrideM;
+constexpr size_t MLAS_GEMM_U8X8_KERNEL_SSE::StrideN;
+constexpr size_t MLAS_GEMM_U8X8_KERNEL_SSE::StrideK;
 
 void
 MLASCALL
@@ -880,7 +884,6 @@ struct MLAS_GEMM_U8S8_KERNEL_AVX2
     typedef int8_t OffsetBType;
 
     static constexpr size_t PackedK = 4;
-
     static constexpr size_t StrideM = 24;
     static constexpr size_t StrideN = 256;
     static constexpr size_t StrideK = 128;
@@ -941,6 +944,11 @@ struct MLAS_GEMM_U8S8_KERNEL_AVX2
     }
 };
 
+constexpr size_t MLAS_GEMM_U8S8_KERNEL_AVX2::PackedK;
+constexpr size_t MLAS_GEMM_U8S8_KERNEL_AVX2::StrideM;
+constexpr size_t MLAS_GEMM_U8S8_KERNEL_AVX2::StrideN;
+constexpr size_t MLAS_GEMM_U8S8_KERNEL_AVX2::StrideK;
+
 void
 MLASCALL
 MlasGemmU8S8OperationAvx2(
@@ -998,7 +1006,6 @@ struct MLAS_GEMM_U8U8_KERNEL_AVX2
     typedef uint8_t OffsetBType;
 
     static constexpr size_t PackedK = 2;
-
     static constexpr size_t StrideM = 24;
     static constexpr size_t StrideN = 256;
     static constexpr size_t StrideK = 128;
@@ -1059,6 +1066,11 @@ struct MLAS_GEMM_U8U8_KERNEL_AVX2
             ldc, RowSumVector, ColumnSumVector, DepthValue, ZeroMode);
     }
 };
+
+constexpr size_t MLAS_GEMM_U8U8_KERNEL_AVX2::PackedK;
+constexpr size_t MLAS_GEMM_U8U8_KERNEL_AVX2::StrideM;
+constexpr size_t MLAS_GEMM_U8U8_KERNEL_AVX2::StrideN;
+constexpr size_t MLAS_GEMM_U8U8_KERNEL_AVX2::StrideK;
 
 void
 MLASCALL

--- a/onnxruntime/core/mlas/lib/qgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm.cpp
@@ -22,33 +22,149 @@ Abstract:
 // threads.
 //
 
-struct MLAS_GEMM_U8X8_WORK_BLOCK
-{
+struct MLAS_GEMM_U8X8_WORK_BLOCK {
     int32_t ThreadCountM;
     int32_t ThreadCountN;
-    size_t M;
-    size_t N;
-    size_t K;
-    const uint8_t* A;
-    size_t lda;
-    const uint8_t* B;
-    size_t ldb;
-    int32_t* C;
-    size_t ldc;
-    int16_t offa;
-    int16_t offb;
-    bool BTypeIsSigned;
+    const MLAS_GEMM_U8X8_PARAMETERS* Parameters;
 };
 
+template<typename KernelType>
+MLAS_FORCEINLINE
+void
+MlasGemmU8X8Operation(
+    const MLAS_GEMM_U8X8_PARAMETERS* Parameters,
+    size_t M,
+    size_t N,
+    const uint8_t* A,
+    const uint8_t* B,
+    int32_t* C
+    )
+/*++
+
+Routine Description:
+
+    This module implements the quantized integer matrix/matrix multiply
+    operation (QGEMM).
+
+Arguments:
+
+    Parameters - Supplies the structure containing the GEMM parameters.
+
+    M - Supplies the number of rows of matrix A and matrix C.
+
+    N - Supplies the number of columns of matrix B and matrix C.
+
+    A - Supplies the address of matrix A.
+
+    B - Supplies the address of matrix B.
+
+    C - Supplies the address of matrix C.
+
+Return Value:
+
+    None.
+
+--*/
+{
+    MLAS_DECLSPEC_ALIGN(typename KernelType::PackedAType PanelA[KernelType::StrideM * KernelType::StrideK], 64);
+    MLAS_DECLSPEC_ALIGN(typename KernelType::PackedBType PanelB[KernelType::StrideN * KernelType::StrideK], 64);
+
+    MLAS_DECLSPEC_ALIGN(int32_t RowSumVector[KernelType::StrideM], 64);
+    MLAS_DECLSPEC_ALIGN(int32_t ColumnSumVector[KernelType::StrideN], 64);
+
+    const size_t lda = Parameters->lda;
+    const size_t ldb = Parameters->ldb;
+    const size_t ldc = Parameters->ldc;
+
+    //
+    // Flip the sign bit of the zero point offset of matrix B if the kernel uses
+    // signed types and the matrix B data is unsigned.
+    //
+
+    int16_t offa = Parameters->offa;
+    int16_t offb = typename KernelType::OffsetBType(Parameters->offb);
+
+    if (std::is_signed<typename KernelType::OffsetBType>::value && !Parameters->BTypeIsSigned) {
+        offb = typename KernelType::OffsetBType(offb ^ 0x80);
+    }
+
+    //
+    // Step through each slice of matrix B along the K dimension.
+    //
+
+    const size_t K = Parameters->K;
+    size_t CountK;
+
+    for (size_t k = 0; k < K; k += CountK) {
+
+        CountK = (std::min)(K - k, KernelType::StrideK);
+
+        //
+        // Step through each slice of matrix B along the N dimension.
+        //
+
+        size_t CountN;
+
+        for (size_t n = 0; n < N; n += CountN) {
+
+            CountN = (std::min)(N - n, KernelType::StrideN);
+
+            //
+            // Copy a panel of matrix B to a local packed buffer.
+            //
+
+            KernelType::CopyPackB(PanelB, B + n + k * ldb, ldb, CountN, CountK,
+                ColumnSumVector, -offa, Parameters->BTypeIsSigned);
+
+            //
+            // Step through each slice of matrix A along the M dimension.
+            //
+
+            const int32_t DepthValue = int32_t(CountK) * offa * offb;
+            const size_t PackedCountK = (CountK + KernelType::PackedK - 1) /
+                KernelType::PackedK;
+
+            int32_t* c = C + n;
+            size_t CountM;
+
+            for (size_t m = 0; m < M; m += CountM) {
+
+                CountM = (std::min)(M - m, KernelType::StrideM);
+
+                //
+                // Copy a panel of matrix A to a local packed buffer.
+                //
+
+                KernelType::CopyPackA(PanelA, A + k + m * lda, lda, CountM,
+                    CountK, RowSumVector, -offb);
+
+                //
+                // Step through the rows of the local packed buffer.
+                //
+
+                typename KernelType::PackedAType* pa = PanelA;
+                int32_t* RowSums = RowSumVector;
+                size_t RowsRemaining = CountM;
+
+                while (RowsRemaining > 0) {
+
+                    size_t RowsHandled;
+
+                    RowsHandled = KernelType::Kernel(pa, PanelB, c, PackedCountK,
+                        RowsRemaining, CountN, ldc, RowSums, ColumnSumVector,
+                        DepthValue, k == 0);
+
+                    c += ldc * RowsHandled;
+                    pa += KernelType::PackedK * PackedCountK * RowsHandled;
+                    RowSums += RowsHandled;
+                    RowsRemaining -= RowsHandled;
+                }
+            }
+        }
+    }
+}
+
 #ifdef MLAS_TARGET_AMD64_IX86
-
-//
-// Define the default strides to step through slices of the input matrices.
-//
-
-#define MLAS_GEMM_U8X8_STRIDEM_SSE          12
-#define MLAS_GEMM_U8X8_STRIDEN_SSE          128
-#define MLAS_GEMM_U8X8_STRIDEK_SSE          128
 
 void
 MlasGemmU8X8CopyPackASse(
@@ -403,7 +519,7 @@ MlasGemmU8X8KernelSse(
     const int16_t* A,
     const int16_t* B,
     int32_t* C,
-    size_t PairCountK,
+    size_t PackedCountK,
     size_t CountN,
     const int32_t* RowSumVector,
     const int32_t* ColumnSumVector,
@@ -427,8 +543,8 @@ Arguments:
 
     C - Supplies the address of matrix C.
 
-    PairCountK - Supplies the number of paired columns from matrix A and the
-        number of paired rows from matrix B to iterate over.
+    PackedCountK - Supplies the number of packed columns from matrix A and the
+        number of packed rows from matrix B to iterate over.
 
     CountN - Supplies the number of columns from matrix B and matrix C to iterate
         over.
@@ -477,7 +593,7 @@ Return Value:
         //
 
         const int16_t* a = A;
-        size_t k = PairCountK;
+        size_t k = PackedCountK;
 
         while (k >= 4) {
 
@@ -575,21 +691,88 @@ Return Value:
     }
 }
 
+struct MLAS_GEMM_U8X8_KERNEL_SSE
+{
+    typedef int16_t PackedAType;
+    typedef int16_t PackedBType;
+    typedef int8_t OffsetBType;
+
+    static constexpr size_t PackedK = 2;
+
+    static constexpr size_t StrideM = 12;
+    static constexpr size_t StrideN = 128;
+    static constexpr size_t StrideK = 128;
+
+    MLAS_FORCEINLINE
+    static
+    void
+    CopyPackA(
+        PackedAType* D,
+        const uint8_t* A,
+        size_t lda,
+        size_t CountM,
+        size_t CountK,
+        int32_t* RowSumVector,
+        int16_t offb
+        )
+    {
+        MlasGemmU8X8CopyPackASse(D, A, lda, CountM, CountK, RowSumVector, offb);
+    }
+
+    MLAS_FORCEINLINE
+    static
+    void
+    CopyPackB(
+        PackedBType* D,
+        const uint8_t* B,
+        size_t ldb,
+        size_t CountN,
+        size_t CountK,
+        int32_t* ColumnSumVector,
+        int16_t offa,
+        bool BTypeIsSigned
+        )
+    {
+        MlasGemmU8X8CopyPackBSse(D, B, ldb, CountN, CountK, ColumnSumVector, offa,
+            BTypeIsSigned);
+    }
+
+    MLAS_FORCEINLINE
+    static
+    size_t
+    Kernel(
+        const PackedAType* A,
+        const PackedBType* B,
+        int32_t* C,
+        size_t PackedCountK,
+        size_t CountM,
+        size_t CountN,
+        size_t ldc,
+        const int32_t* RowSumVector,
+        const int32_t* ColumnSumVector,
+        int32_t DepthValue,
+        bool ZeroMode
+        )
+    {
+        MLAS_UNREFERENCED_PARAMETER(CountM);
+        MLAS_UNREFERENCED_PARAMETER(ldc);
+
+        MlasGemmU8X8KernelSse(A, B, C, PackedCountK, CountN, RowSumVector,
+            ColumnSumVector, DepthValue, ZeroMode);
+
+        return 1;
+    }
+};
+
 void
 MLASCALL
 MlasGemmU8X8OperationSse(
-    const MLAS_GEMM_U8X8_WORK_BLOCK* WorkBlock,
+    const MLAS_GEMM_U8X8_PARAMETERS* Parameters,
     size_t M,
     size_t N,
-    size_t K,
     const uint8_t* A,
-    size_t lda,
-    int16_t offa,
     const uint8_t* B,
-    size_t ldb,
-    int16_t offb,
-    int32_t* C,
-    size_t ldc
+    int32_t* C
     )
 /*++
 
@@ -598,32 +781,21 @@ Routine Description:
     This module implements the quantized integer matrix/matrix multiply
     operation (QGEMM).
 
+    This implementation supports SSE2 U8S8/U8U8.
+
 Arguments:
 
-    WorkBlock - Supplies the structure containing the GEMM parameters.
+    Parameters - Supplies the structure containing the GEMM parameters.
 
     M - Supplies the number of rows of matrix A and matrix C.
 
     N - Supplies the number of columns of matrix B and matrix C.
 
-    K - Supplies the number of columns of matrix A and the number of rows of
-        matrix B.
-
     A - Supplies the address of matrix A.
-
-    lda - Supplies the first dimension of matrix A.
-
-    offa - Supplies the zero point offset of matrix A.
 
     B - Supplies the address of matrix B.
 
-    ldb - Supplies the first dimension of matrix B.
-
-    offb - Supplies the zero point offset of matrix B.
-
     C - Supplies the address of matrix C.
-
-    ldc - Supplies the first dimension of matrix C.
 
 Return Value:
 
@@ -631,104 +803,12 @@ Return Value:
 
 --*/
 {
-    MLAS_DECLSPEC_ALIGN(int16_t PanelA[MLAS_GEMM_U8X8_STRIDEM_SSE * MLAS_GEMM_U8X8_STRIDEK_SSE], 16);
-    MLAS_DECLSPEC_ALIGN(int16_t PanelB[MLAS_GEMM_U8X8_STRIDEN_SSE * MLAS_GEMM_U8X8_STRIDEK_SSE], 16);
-
-    MLAS_DECLSPEC_ALIGN(int32_t RowSumVector[MLAS_GEMM_U8X8_STRIDEM_SSE], 16);
-    MLAS_DECLSPEC_ALIGN(int32_t ColumnSumVector[MLAS_GEMM_U8X8_STRIDEN_SSE], 16);
-
-    size_t StrideM = MLAS_GEMM_U8X8_STRIDEM_SSE;
-    size_t StrideN = MLAS_GEMM_U8X8_STRIDEN_SSE;
-    size_t StrideK = MLAS_GEMM_U8X8_STRIDEK_SSE;
-
-    if (!WorkBlock->BTypeIsSigned) {
-        offb = int8_t(offb ^ 0x80);
-    }
-
-    //
-    // Step through each slice of matrix B along the K dimension.
-    //
-
-    size_t CountK;
-
-    for (size_t k = 0; k < K; k += CountK) {
-
-        CountK = std::min(K - k, StrideK);
-
-        //
-        // Step through each slice of matrix B along the N dimension.
-        //
-
-        size_t CountN;
-
-        for (size_t n = 0; n < N; n += CountN) {
-
-            CountN = std::min(N - n, StrideN);
-
-            //
-            // Copy a panel of matrix B to a local packed buffer.
-            //
-
-            const uint8_t* b = B + n + k * ldb;
-
-            MlasGemmU8X8CopyPackBSse(PanelB, b, ldb, CountN, CountK,
-                ColumnSumVector, -int16_t(offa), WorkBlock->BTypeIsSigned);
-
-            //
-            // Step through each slice of matrix A along the M dimension.
-            //
-
-            const int32_t DepthValue = int32_t(CountK) * offa * offb;
-            const size_t PairCountK = (CountK + 1) / 2;
-
-            int32_t* c = C + n;
-            size_t CountM;
-
-            for (size_t m = 0; m < M; m += CountM) {
-
-                CountM = std::min(M - m, StrideM);
-
-                //
-                // Copy a panel of matrix A to a local packed buffer.
-                //
-
-                MlasGemmU8X8CopyPackASse(PanelA, A + k + m * lda, lda, CountM,
-                    CountK, RowSumVector, -int16_t(offb));
-
-                //
-                // Step through the rows of the local packed buffer.
-                //
-
-                int16_t* pa = PanelA;
-                int32_t* RowSums = RowSumVector;
-                size_t RowsRemaining = CountM;
-
-                while (RowsRemaining > 0) {
-
-                    MlasGemmU8X8KernelSse(pa, PanelB, c, PairCountK, CountN,
-                        RowSums, ColumnSumVector, DepthValue, k == 0);
-
-                    c += ldc;
-                    pa += 2 * PairCountK;
-                    RowSums += 1;
-                    RowsRemaining -= 1;
-                }
-            }
-        }
-    }
+    return MlasGemmU8X8Operation<MLAS_GEMM_U8X8_KERNEL_SSE>(Parameters, M, N, A, B, C);
 }
 
 #endif
 
 #ifdef MLAS_TARGET_AMD64
-
-//
-// Define the default strides to step through slices of the input matrices.
-//
-
-#define MLAS_GEMM_U8X8_STRIDEM_AVX2                 24
-#define MLAS_GEMM_U8X8_STRIDEN_AVX2                 256
-#define MLAS_GEMM_U8X8_STRIDEK_AVX2                 128
 
 //
 // Stores a vector to transpose a 4x4 byte vector using vpshufb.
@@ -752,19 +832,19 @@ extern "C" {
         size_t CountM,
         size_t CountK,
         int32_t* RowSumVector,
-        int32_t offb
+        int16_t offb
         );
 
     void
     MLASCALL
     MlasGemmU8S8CopyPackBAvx2(
-        int8_t* D,
-        const int8_t* B,
+        uint8_t* D,
+        const uint8_t* B,
         size_t ldb,
         size_t CountN,
         size_t CountK,
         int32_t* ColumnSumVector,
-        int32_t offa,
+        int16_t offa,
         bool BTypeIsSigned
         );
 
@@ -777,7 +857,7 @@ extern "C" {
         size_t CountM,
         size_t CountK,
         int32_t* RowSumVector,
-        int32_t offb
+        int16_t offb
         );
 
     void
@@ -789,25 +869,87 @@ extern "C" {
         size_t CountN,
         size_t CountK,
         int32_t* ColumnSumVector,
-        int32_t offa
+        int16_t offa
         );
 }
+
+struct MLAS_GEMM_U8S8_KERNEL_AVX2
+{
+    typedef uint8_t PackedAType;
+    typedef uint8_t PackedBType;
+    typedef int8_t OffsetBType;
+
+    static constexpr size_t PackedK = 4;
+
+    static constexpr size_t StrideM = 24;
+    static constexpr size_t StrideN = 256;
+    static constexpr size_t StrideK = 128;
+
+    MLAS_FORCEINLINE
+    static
+    void
+    CopyPackA(
+        PackedAType* D,
+        const uint8_t* A,
+        size_t lda,
+        size_t CountM,
+        size_t CountK,
+        int32_t* RowSumVector,
+        int16_t offb
+        )
+    {
+        MlasGemmU8S8CopyPackAAvx2(D, A, lda, CountM, CountK, RowSumVector, offb);
+    }
+
+    MLAS_FORCEINLINE
+    static
+    void
+    CopyPackB(
+        PackedBType* D,
+        const uint8_t* B,
+        size_t ldb,
+        size_t CountN,
+        size_t CountK,
+        int32_t* ColumnSumVector,
+        int16_t offa,
+        bool BTypeIsSigned
+        )
+    {
+        MlasGemmU8S8CopyPackBAvx2(D, B, ldb, CountN, CountK, ColumnSumVector, offa,
+            BTypeIsSigned);
+    }
+
+    MLAS_FORCEINLINE
+    static
+    size_t
+    Kernel(
+        const PackedAType* A,
+        const PackedBType* B,
+        int32_t* C,
+        size_t PackedCountK,
+        size_t CountM,
+        size_t CountN,
+        size_t ldc,
+        const int32_t* RowSumVector,
+        const int32_t* ColumnSumVector,
+        int32_t DepthValue,
+        bool ZeroMode
+        )
+    {
+        return MlasPlatform.GemmU8S8Kernel(A, B, C, PackedCountK, CountM, CountN,
+            ldc, RowSumVector, ColumnSumVector, DepthValue, ZeroMode);
+    }
+};
 
 void
 MLASCALL
 MlasGemmU8S8OperationAvx2(
-    const MLAS_GEMM_U8X8_WORK_BLOCK* WorkBlock,
+    const MLAS_GEMM_U8X8_PARAMETERS* Parameters,
     size_t M,
     size_t N,
-    size_t K,
     const uint8_t* A,
-    size_t lda,
-    int16_t offa,
     const uint8_t* B,
-    size_t ldb,
-    int16_t offb,
-    int32_t* C,
-    size_t ldc
+    int32_t* C
     )
 /*++
 
@@ -820,30 +962,17 @@ Routine Description:
 
 Arguments:
 
-    WorkBlock - Supplies the structure containing the GEMM parameters.
+    Parameters - Supplies the structure containing the GEMM parameters.
 
     M - Supplies the number of rows of matrix A and matrix C.
 
     N - Supplies the number of columns of matrix B and matrix C.
 
-    K - Supplies the number of columns of matrix A and the number of rows of
-        matrix B.
-
     A - Supplies the address of matrix A.
-
-    lda - Supplies the first dimension of matrix A.
-
-    offa - Supplies the zero point offset of matrix A.
 
     B - Supplies the address of matrix B.
 
-    ldb - Supplies the first dimension of matrix B.
-
-    offb - Supplies the zero point offset of matrix B.
-
     C - Supplies the address of matrix C.
-
-    ldc - Supplies the first dimension of matrix C.
 
 Return Value:
 
@@ -851,122 +980,95 @@ Return Value:
 
 --*/
 {
-    MLAS_DECLSPEC_ALIGN(uint8_t PanelA[MLAS_GEMM_U8X8_STRIDEM_AVX2 * MLAS_GEMM_U8X8_STRIDEK_AVX2], 64);
-    MLAS_DECLSPEC_ALIGN(int8_t PanelB[MLAS_GEMM_U8X8_STRIDEN_AVX2 * MLAS_GEMM_U8X8_STRIDEK_AVX2], 64);
+    if (M == 1 && Parameters->offa == 0 && Parameters->offb == 0) {
 
-    MLAS_DECLSPEC_ALIGN(int32_t RowSumVector[MLAS_GEMM_U8X8_STRIDEM_AVX2], 16);
-    MLAS_DECLSPEC_ALIGN(int32_t ColumnSumVector[MLAS_GEMM_U8X8_STRIDEN_AVX2], 16);
-
-    size_t StrideM = MLAS_GEMM_U8X8_STRIDEM_AVX2;
-    size_t StrideN = MLAS_GEMM_U8X8_STRIDEN_AVX2;
-    size_t StrideK = MLAS_GEMM_U8X8_STRIDEK_AVX2;
-
-    if (WorkBlock->BTypeIsSigned) {
-
-        if (M == 1 && offa == 0 && offb == 0) {
-
-            if (MlasPlatform.GemvU8S8Kernel != nullptr) {
-                MlasPlatform.GemvU8S8Kernel(A, (const int8_t*)B, C, K, N, ldb);
-                return;
-            }
-        }
-
-    } else {
-
-        offb = int8_t(offb ^ 0x80);
-    }
-
-    //
-    // Step through each slice of matrix B along the K dimension.
-    //
-
-    size_t CountK;
-
-    for (size_t k = 0; k < K; k += CountK) {
-
-        CountK = std::min(K - k, StrideK);
-
-        //
-        // Step through each slice of matrix B along the N dimension.
-        //
-
-        size_t CountN;
-
-        for (size_t n = 0; n < N; n += CountN) {
-
-            CountN = std::min(N - n, StrideN);
-
-            //
-            // Copy a panel of matrix B to a local packed buffer.
-            //
-
-            const int8_t* b = (const int8_t*)B + n + k * ldb;
-
-            MlasGemmU8S8CopyPackBAvx2(PanelB, b, ldb, CountN, CountK,
-                ColumnSumVector, -int16_t(offa), WorkBlock->BTypeIsSigned);
-
-            //
-            // Step through each slice of matrix A along the M dimension.
-            //
-
-            const int32_t DepthValue = int32_t(CountK) * offa * offb;
-            size_t QuadCountK = (CountK + 3) / 4;
-
-            int32_t* c = C + n;
-            size_t CountM;
-
-            for (size_t m = 0; m < M; m += CountM) {
-
-                CountM = std::min(M - m, StrideM);
-
-                //
-                // Copy a panel of matrix A to a local packed buffer.
-                //
-
-                MlasGemmU8S8CopyPackAAvx2(PanelA, A + k + m * lda,
-                    lda, CountM, CountK, RowSumVector, -int16_t(offb));
-
-                //
-                // Step through the rows of the local packed buffer.
-                //
-
-                uint8_t* pa = PanelA;
-                int32_t* RowSums = RowSumVector;
-                size_t RowsRemaining = CountM;
-
-                while (RowsRemaining > 0) {
-
-                    size_t RowsHandled;
-
-                    RowsHandled = MlasPlatform.GemmU8S8Kernel(pa, PanelB, c,
-                        QuadCountK, RowsRemaining, CountN, ldc, RowSums,
-                        ColumnSumVector, DepthValue, k == 0);
-
-                    RowsRemaining -= RowsHandled;
-                    c += ldc * RowsHandled;
-                    pa += 4 * QuadCountK * RowsHandled;
-                    RowSums += RowsHandled;
-                }
-            }
+        if (MlasPlatform.GemvU8S8Kernel != nullptr) {
+            MlasPlatform.GemvU8S8Kernel(A, B, C, Parameters->K, N, Parameters->ldb);
+            return;
         }
     }
+
+    return MlasGemmU8X8Operation<MLAS_GEMM_U8S8_KERNEL_AVX2>(Parameters, M, N, A, B, C);
 }
+
+struct MLAS_GEMM_U8U8_KERNEL_AVX2
+{
+    typedef int16_t PackedAType;
+    typedef uint8_t PackedBType;
+    typedef uint8_t OffsetBType;
+
+    static constexpr size_t PackedK = 2;
+
+    static constexpr size_t StrideM = 24;
+    static constexpr size_t StrideN = 256;
+    static constexpr size_t StrideK = 128;
+
+    MLAS_FORCEINLINE
+    static
+    void
+    CopyPackA(
+        PackedAType* D,
+        const uint8_t* A,
+        size_t lda,
+        size_t CountM,
+        size_t CountK,
+        int32_t* RowSumVector,
+        int16_t offb
+        )
+    {
+        MlasGemmU8U8CopyPackAAvx2(D, A, lda, CountM, CountK, RowSumVector, offb);
+    }
+
+    MLAS_FORCEINLINE
+    static
+    void
+    CopyPackB(
+        PackedBType* D,
+        const uint8_t* B,
+        size_t ldb,
+        size_t CountN,
+        size_t CountK,
+        int32_t* ColumnSumVector,
+        int16_t offa,
+        bool BTypeIsSigned
+        )
+    {
+        MLAS_UNREFERENCED_PARAMETER(BTypeIsSigned);
+
+        MlasGemmU8U8CopyPackBAvx2(D, B, ldb, CountN, CountK, ColumnSumVector, offa);
+    }
+
+    MLAS_FORCEINLINE
+    static
+    size_t
+    Kernel(
+        const PackedAType* A,
+        const PackedBType* B,
+        int32_t* C,
+        size_t PackedCountK,
+        size_t CountM,
+        size_t CountN,
+        size_t ldc,
+        const int32_t* RowSumVector,
+        const int32_t* ColumnSumVector,
+        int32_t DepthValue,
+        bool ZeroMode
+        )
+    {
+        return MlasPlatform.GemmU8U8Kernel(A, B, C, PackedCountK, CountM, CountN,
+            ldc, RowSumVector, ColumnSumVector, DepthValue, ZeroMode);
+    }
+};
 
 void
 MLASCALL
 MlasGemmU8U8OperationAvx2(
-    const MLAS_GEMM_U8X8_WORK_BLOCK* WorkBlock,
+    const MLAS_GEMM_U8X8_PARAMETERS* Parameters,
     size_t M,
     size_t N,
-    size_t K,
     const uint8_t* A,
-    size_t lda,
-    int16_t offa,
     const uint8_t* B,
-    size_t ldb,
-    int16_t offb,
-    int32_t* C,
-    size_t ldc
+    int32_t* C
     )
 /*++
 
@@ -979,30 +1081,17 @@ Routine Description:
 
 Arguments:
 
-    WorkBlock - Supplies the structure containing the GEMM parameters.
+    Parameters - Supplies the structure containing the GEMM parameters.
 
     M - Supplies the number of rows of matrix A and matrix C.
 
     N - Supplies the number of columns of matrix B and matrix C.
 
-    K - Supplies the number of columns of matrix A and the number of rows of
-        matrix B.
-
     A - Supplies the address of matrix A.
-
-    lda - Supplies the first dimension of matrix A.
-
-    offa - Supplies the zero point offset of matrix A.
 
     B - Supplies the address of matrix B.
 
-    ldb - Supplies the first dimension of matrix B.
-
-    offb - Supplies the zero point offset of matrix B.
-
     C - Supplies the address of matrix C.
-
-    ldc - Supplies the first dimension of matrix C.
 
 Return Value:
 
@@ -1010,92 +1099,7 @@ Return Value:
 
 --*/
 {
-    MLAS_DECLSPEC_ALIGN(int16_t PanelA[MLAS_GEMM_U8X8_STRIDEM_AVX2 * MLAS_GEMM_U8X8_STRIDEK_AVX2], 64);
-    MLAS_DECLSPEC_ALIGN(uint8_t PanelB[MLAS_GEMM_U8X8_STRIDEN_AVX2 * MLAS_GEMM_U8X8_STRIDEK_AVX2], 64);
-
-    MLAS_DECLSPEC_ALIGN(int32_t RowSumVector[MLAS_GEMM_U8X8_STRIDEM_AVX2], 16);
-    MLAS_DECLSPEC_ALIGN(int32_t ColumnSumVector[MLAS_GEMM_U8X8_STRIDEN_AVX2], 16);
-
-    size_t StrideM = MLAS_GEMM_U8X8_STRIDEM_AVX2;
-    size_t StrideN = MLAS_GEMM_U8X8_STRIDEN_AVX2;
-    size_t StrideK = MLAS_GEMM_U8X8_STRIDEK_AVX2;
-
-    MLAS_UNREFERENCED_PARAMETER(WorkBlock);
-
-    //
-    // Step through each slice of matrix B along the K dimension.
-    //
-
-    size_t CountK;
-
-    for (size_t k = 0; k < K; k += CountK) {
-
-        CountK = std::min(K - k, StrideK);
-
-        //
-        // Step through each slice of matrix B along the N dimension.
-        //
-
-        size_t CountN;
-
-        for (size_t n = 0; n < N; n += CountN) {
-
-            CountN = std::min(N - n, StrideN);
-
-            //
-            // Copy a panel of matrix B to a local packed buffer.
-            //
-
-            const uint8_t* b = B + n + k * ldb;
-
-            MlasGemmU8U8CopyPackBAvx2(PanelB, b, ldb, CountN, CountK,
-                ColumnSumVector, -int16_t(offa));
-
-            //
-            // Step through each slice of matrix A along the M dimension.
-            //
-
-            const int32_t DepthValue = int32_t(CountK) * offa * offb;
-            size_t PairCountK = (CountK + 1) / 2;
-
-            int32_t* c = C + n;
-            size_t CountM;
-
-            for (size_t m = 0; m < M; m += CountM) {
-
-                CountM = std::min(M - m, StrideM);
-
-                //
-                // Copy a panel of matrix A to a local packed buffer.
-                //
-
-                MlasGemmU8U8CopyPackAAvx2(PanelA, A + k + m * lda, lda, CountM,
-                    CountK, RowSumVector, -int16_t(offb));
-
-                //
-                // Step through the rows of the local packed buffer.
-                //
-
-                int16_t* pa = PanelA;
-                int32_t* RowSums = RowSumVector;
-                size_t RowsRemaining = CountM;
-
-                while (RowsRemaining > 0) {
-
-                    size_t RowsHandled;
-
-                    RowsHandled = MlasPlatform.GemmU8U8Kernel(pa, PanelB, c,
-                        PairCountK, RowsRemaining, CountN, ldc, RowSums,
-                        ColumnSumVector, DepthValue, k == 0);
-
-                    c += ldc * RowsHandled;
-                    pa += 2 * PairCountK * RowsHandled;
-                    RowSums += RowsHandled;
-                    RowsRemaining -= RowsHandled;
-                }
-            }
-        }
-    }
+    return MlasGemmU8X8Operation<MLAS_GEMM_U8U8_KERNEL_AVX2>(Parameters, M, N, A, B, C);
 }
 
 #endif
@@ -1131,6 +1135,8 @@ Return Value:
     const int32_t ThreadCountM = WorkBlock->ThreadCountM;
     const int32_t ThreadCountN = WorkBlock->ThreadCountN;
 
+    const auto* Parameters = WorkBlock->Parameters;
+
     const int32_t ThreadIdM = ThreadId / ThreadCountN;
     const int32_t ThreadIdN = ThreadId % ThreadCountN;
 
@@ -1138,7 +1144,7 @@ Return Value:
     // Partition the operation along the M dimension.
     //
 
-    size_t M = WorkBlock->M;
+    size_t M = Parameters->M;
     size_t m;
     size_t CountM;
 
@@ -1148,7 +1154,7 @@ Return Value:
     // Partition the operation along the N dimension.
     //
 
-    size_t N = WorkBlock->N;
+    size_t N = Parameters->N;
     size_t n;
     size_t CountN;
 
@@ -1168,18 +1174,14 @@ Return Value:
     // Dispatch the partitioned operation.
     //
 
-    const size_t lda = WorkBlock->lda;
-    const size_t ldb = WorkBlock->ldb;
-    const size_t ldc = WorkBlock->ldc;
-
-    const uint8_t* a = WorkBlock->A + m * lda;
-    const uint8_t* b = WorkBlock->B + n;
-    int32_t* c = WorkBlock->C + n + m * ldc;
+    const uint8_t* a = Parameters->A + m * Parameters->lda;
+    const uint8_t* b = Parameters->B + n;
+    int32_t* c = Parameters->C + n + m * Parameters->ldc;
 
     PMLAS_GEMM_U8X8_OPERATION GemmU8X8Operation;
 
 #if defined(MLAS_TARGET_AMD64)
-    if (WorkBlock->BTypeIsSigned) {
+    if (Parameters->BTypeIsSigned) {
         GemmU8X8Operation = MlasPlatform.GemmU8S8Operation;
     } else {
         GemmU8X8Operation = MlasPlatform.GemmU8U8Operation;
@@ -1188,25 +1190,25 @@ Return Value:
     GemmU8X8Operation = MlasGemmU8X8OperationSse;
 #endif
 
-    GemmU8X8Operation(WorkBlock, CountM, CountN, WorkBlock->K, a, lda,
-        WorkBlock->offa, b, ldb, WorkBlock->offb, c, ldc);
+    GemmU8X8Operation(Parameters, CountM, CountN, a, b, c);
 }
 
 void
-MlasGemmU8X8Schedule(
-    MLAS_GEMM_U8X8_WORK_BLOCK* WorkBlock,
+MLASCALL
+MlasGemm(
+    const MLAS_GEMM_U8X8_PARAMETERS* Parameters,
     MLAS_THREADPOOL* ThreadPool
     )
 /*++
 
 Routine Description:
 
-    This module schedules the quantized integer matrix/matrix multiply
-    operation (QGEMM) across one or more threads.
+    This module implements the quantized integer matrix/matrix multiply
+    operation (QGEMM).
 
 Arguments:
 
-    WorkBlock - Supplies the structure containing the GEMM parameters.
+    Parameters - Supplies the structure containing the GEMM parameters.
 
     ThreadPool - Supplies the thread pool object to use, else nullptr if the
         base library threading support should be used.
@@ -1217,16 +1219,18 @@ Return Value:
 
 --*/
 {
-    const size_t M = WorkBlock->M;
-    const size_t N = WorkBlock->N;
-    const size_t K = WorkBlock->K;
+    MLAS_GEMM_U8X8_WORK_BLOCK WorkBlock;
 
     //
     // Compute the number of target threads given the complexity of the SGEMM
     // operation. Small requests should run using the single threaded path.
     //
 
-    double Complexity = double(M) * double(N) * double(K);
+    const size_t M = Parameters->M;
+    const size_t N = Parameters->N;
+    const size_t K = Parameters->K;
+
+    const double Complexity = double(M) * double(N) * double(K);
 
     int32_t TargetThreadCount;
 
@@ -1258,8 +1262,8 @@ Return Value:
             TargetThreadCount = int32_t(BlockedN);
         }
 
-        WorkBlock->ThreadCountM = 1;
-        WorkBlock->ThreadCountN = TargetThreadCount;
+        WorkBlock.ThreadCountM = 1;
+        WorkBlock.ThreadCountN = TargetThreadCount;
 
     } else {
 
@@ -1267,131 +1271,13 @@ Return Value:
             TargetThreadCount = int32_t(M);
         }
 
-        WorkBlock->ThreadCountM = TargetThreadCount;
-        WorkBlock->ThreadCountN = 1;
+        WorkBlock.ThreadCountM = TargetThreadCount;
+        WorkBlock.ThreadCountN = 1;
     }
 
-    MlasExecuteThreaded(MlasGemmU8X8Threaded, WorkBlock, TargetThreadCount, ThreadPool);
+    WorkBlock.Parameters = Parameters;
+
+    MlasExecuteThreaded(MlasGemmU8X8Threaded, &WorkBlock, TargetThreadCount, ThreadPool);
 }
-
-template<typename AType, typename BType>
-void
-MLASCALL
-MlasGemm(
-    size_t M,
-    size_t N,
-    size_t K,
-    const AType* A,
-    size_t lda,
-    AType offa,
-    const BType* B,
-    size_t ldb,
-    BType offb,
-    int32_t* C,
-    size_t ldc,
-    MLAS_THREADPOOL* ThreadPool
-    )
-/*++
-
-Routine Description:
-
-    This module implements the quantized integer matrix/matrix multiply
-    operation (QGEMM).
-
-Arguments:
-
-    M - Supplies the number of rows of matrix A and matrix C.
-
-    N - Supplies the number of columns of matrix B and matrix C.
-
-    K - Supplies the number of columns of matrix A and the number of rows of
-        matrix B.
-
-    A - Supplies the address of matrix A.
-
-    lda - Supplies the first dimension of matrix A.
-
-    offa - Supplies the zero point offset of matrix A.
-
-    B - Supplies the address of matrix B.
-
-    ldb - Supplies the first dimension of matrix B.
-
-    offb - Supplies the zero point offset of matrix B.
-
-    C - Supplies the address of matrix C.
-
-    ldc - Supplies the first dimension of matrix C.
-
-    ThreadPool - Supplies the thread pool object to use, else nullptr if the
-        base library threading support should be used.
-
-Return Value:
-
-    None.
-
---*/
-{
-    MLAS_GEMM_U8X8_WORK_BLOCK WorkBlock;
-
-    //
-    // Capture the GEMM parameters to the work block.
-    //
-
-    WorkBlock.M = M;
-    WorkBlock.N = N;
-    WorkBlock.K = K;
-    WorkBlock.A = A;
-    WorkBlock.lda = lda;
-    WorkBlock.B = (const uint8_t*)B;
-    WorkBlock.ldb = ldb;
-    WorkBlock.C = C;
-    WorkBlock.ldc = ldc;
-    WorkBlock.offa = int16_t(offa);
-    WorkBlock.offb = int16_t(offb);
-    WorkBlock.BTypeIsSigned = std::is_signed<BType>::value;
-
-    //
-    // Schedule the operation across a set of worker threads.
-    //
-
-    MlasGemmU8X8Schedule(&WorkBlock, ThreadPool);
-}
-
-template
-void
-MLASCALL
-MlasGemm(
-    size_t M,
-    size_t N,
-    size_t K,
-    const uint8_t* A,
-    size_t lda,
-    uint8_t offa,
-    const int8_t* B,
-    size_t ldb,
-    int8_t offb,
-    int32_t* C,
-    size_t ldc,
-    MLAS_THREADPOOL* ThreadPool
-    );
-
-template
-void
-MLASCALL
-MlasGemm(
-    size_t M,
-    size_t N,
-    size_t K,
-    const uint8_t* A,
-    size_t lda,
-    uint8_t offa,
-    const uint8_t* B,
-    size_t ldb,
-    uint8_t offb,
-    int32_t* C,
-    size_t ldc,
-    MLAS_THREADPOOL* ThreadPool
-    );
 
 #endif

--- a/onnxruntime/core/mlas/lib/x86_64/QgemmU8S8KernelAvx2.S
+++ b/onnxruntime/core/mlas/lib/x86_64/QgemmU8S8KernelAvx2.S
@@ -872,8 +872,8 @@ Arguments:
 
     C (rdx) - Supplies the address of matrix C.
 
-    QuadCountK (rcx) - Supplies the number of quad columns from matrix A and
-        the number of quad rows from matrix B to iterate over.
+    PackedCountK (rcx) - Supplies the number of packed columns from matrix A
+        and the number of packed rows from matrix B to iterate over.
 
     CountM (r8) - Supplies the maximum number of rows that can be processed for
         matrix A and matrix C. The actual number of rows handled for this

--- a/onnxruntime/core/mlas/lib/x86_64/QgemmU8U8KernelAvx2.S
+++ b/onnxruntime/core/mlas/lib/x86_64/QgemmU8U8KernelAvx2.S
@@ -781,8 +781,8 @@ Arguments:
 
     C (rdx) - Supplies the address of matrix C.
 
-    PairCountK (rcx) - Supplies the number of pair columns from matrix A and
-        the number of pair rows from matrix B to iterate over.
+    PackedCountK (rcx) - Supplies the number of packed columns from matrix A
+        and the number of packed rows from matrix B to iterate over.
 
     CountM (r8) - Supplies the maximum number of rows that can be processed for
         matrix A and matrix C. The actual number of rows handled for this

--- a/onnxruntime/core/mlas/lib/x86_64/QgemmU8X8KernelAvx512Common.h
+++ b/onnxruntime/core/mlas/lib/x86_64/QgemmU8X8KernelAvx512Common.h
@@ -291,8 +291,8 @@ Arguments:
 
     C (rdx) - Supplies the address of matrix C.
 
-    PairedCountK (rcx) - Supplies the number of paired columns from matrix A and
-        the number of paired rows from matrix B to iterate over.
+    PackedCountK (rcx) - Supplies the number of packed columns from matrix A and
+        the number of packed rows from matrix B to iterate over.
 
     CountM (r8) - Supplies the maximum number of rows that can be processed for
         matrix A and matrix C. The actual number of rows handled for this

--- a/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
+++ b/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
@@ -295,8 +295,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t, QuantizeLinear);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, int8_t, QuantizeLinear);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, QLinearMatMul);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t, MatMulInteger);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, int8_t, MatMulInteger);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, MatMulInteger);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, ConvInteger);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, QLinearConv);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 10, Slice);
@@ -926,10 +925,7 @@ Status RegisterOnnxOperatorKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, int8_t,
                                                                   QuantizeLinear)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, QLinearMatMul)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t,
-                                                                  MatMulInteger)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, int8_t,
-                                                                  MatMulInteger)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, MatMulInteger)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, ConvInteger)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, QLinearConv)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 10,

--- a/onnxruntime/core/providers/cpu/math/matmul_integer.cc
+++ b/onnxruntime/core/providers/cpu/math/matmul_integer.cc
@@ -5,76 +5,71 @@
 #include "core/providers/cpu/math/matmul_integer.h"
 #include "core/providers/cpu/math/matmul_helper.h"
 #include "core/util/qmath.h"
+#include "core/mlas/inc/mlas.h"
 #include "core/providers/common.h"
 
 namespace onnxruntime {
 
 // only register this operator if low precision computation is enabled.
-ONNX_OPERATOR_TYPED_KERNEL_EX(
+ONNX_OPERATOR_KERNEL_EX(
     MatMulInteger,
     kOnnxDomain,
     10,
-    uint8_t,
     kCpuExecutionProvider,
     KernelDefBuilder()
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("T2", DataTypeImpl::GetTensorType<uint8_t>())
+        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<int8_t>(),
+                               DataTypeImpl::GetTensorType<uint8_t>()})
         .TypeConstraint("T3", DataTypeImpl::GetTensorType<int32_t>()),
-    MatMulInteger<uint8_t, uint8_t>);
+    MatMulInteger<uint8_t>);
 
-ONNX_OPERATOR_TYPED_KERNEL_EX(
-    MatMulInteger,
-    kOnnxDomain,
-    10,
-    int8_t,
-    kCpuExecutionProvider,
-    KernelDefBuilder()
-        .TypeConstraint("T1", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("T2", DataTypeImpl::GetTensorType<int8_t>())
-        .TypeConstraint("T3", DataTypeImpl::GetTensorType<int32_t>()),
-    MatMulInteger<uint8_t, int8_t>);
-
-template <typename T1, typename T2>
-Status MatMulInteger<T1, T2>::Compute(OpKernelContext* ctx) const {
+template <typename T1>
+Status MatMulInteger<T1>::Compute(OpKernelContext* ctx) const {
   concurrency::ThreadPool* thread_pool = ctx->GetOperatorThreadPool();
 
-  auto a = ctx->Input<Tensor>(0);
-  auto b = ctx->Input<Tensor>(1);
-  ORT_ENFORCE(a != nullptr && b != nullptr);
+  const auto* a = ctx->Input<Tensor>(0);
+  const auto* b = ctx->Input<Tensor>(1);
 
   MatMulComputeHelper helper;
   ORT_RETURN_IF_ERROR(helper.Compute(a->Shape(), b->Shape()));
-  Tensor* y = ctx->Output(0, helper.OutputShape());
+  auto* y = ctx->Output(0, helper.OutputShape());
 
-  // validate zero points
-  T1 a_offset = 0;
-  T2 b_offset = 0;
-  if (has_a_zero_point_) {
-    auto a_zero_point = ctx->Input<Tensor>(2);
+  MLAS_GEMM_U8X8_PARAMETERS gemm_parameters = {};
+
+  gemm_parameters.BTypeIsSigned = b->IsDataType<int8_t>();
+
+  gemm_parameters.M = static_cast<size_t>(helper.M());
+  gemm_parameters.N = static_cast<size_t>(helper.N());
+  gemm_parameters.K = static_cast<size_t>(helper.K());
+
+  gemm_parameters.lda = gemm_parameters.K;
+  gemm_parameters.ldb = gemm_parameters.N;
+  gemm_parameters.ldc = gemm_parameters.N;
+
+  // validate optional zero points
+  const auto* a_zero_point = ctx->Input<Tensor>(2);
+  if (a_zero_point != nullptr) {
     ORT_ENFORCE(IsScalarOr1ElementVector(a_zero_point),
                 "MatmulInteger : input1 zero point must be a scalar or 1D tensor of size 1");
-    a_offset = *a_zero_point->template Data<T1>();
+    gemm_parameters.offa = *a_zero_point->template Data<T1>();
   }
-  if (has_b_zero_point_) {
-    auto b_zero_point = ctx->Input<Tensor>(3);
+  const auto* b_zero_point = ctx->Input<Tensor>(3);
+  if (b_zero_point != nullptr) {
     ORT_ENFORCE(IsScalarOr1ElementVector(b_zero_point),
                 "MatmulInteger : input2 zero point must be a scalar or 1D tensor of size 1");
-    b_offset = *b_zero_point->template Data<T2>();
+    gemm_parameters.offb = *static_cast<const uint8_t*>(b_zero_point->DataRaw());
   }
 
+  const auto* a_data = a->template Data<T1>();
+  const auto* b_data = static_cast<const uint8_t*>(b->DataRaw());
+  auto* y_data = y->template MutableData<int32_t>();
+
   for (size_t i = 0; i < helper.OutputOffsets().size(); i++) {
-    QGemm(static_cast<int>(helper.M()),
-          static_cast<int>(helper.N()),
-          static_cast<int>(helper.K()),
-          a->template Data<T1>() + helper.LeftOffsets()[i],
-          static_cast<int>(helper.K()),
-          a_offset,
-          b->template Data<T2>() + helper.RightOffsets()[i],
-          static_cast<int>(helper.N()),
-          b_offset,
-          y->template MutableData<int32_t>() + helper.OutputOffsets()[i],
-          static_cast<int>(helper.N()),
-          thread_pool);
+    gemm_parameters.A = a_data + helper.LeftOffsets()[i];
+    gemm_parameters.B = b_data + helper.RightOffsets()[i];
+    gemm_parameters.C = y_data + helper.OutputOffsets()[i];
+
+    QGemm(gemm_parameters, thread_pool);
   }
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/math/matmul_integer.h
+++ b/onnxruntime/core/providers/cpu/math/matmul_integer.h
@@ -3,30 +3,15 @@
 
 #pragma once
 
-#include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/util/math_cpuonly.h"
 
 namespace onnxruntime {
 
-template <typename T1, typename T2>
+template <typename T1>
 class MatMulInteger final : public OpKernel {
  public:
-  MatMulInteger(const OpKernelInfo& info) : OpKernel(info) {
-    has_a_zero_point_ = false;
-    has_b_zero_point_ = false;
-    if (info.GetInputCount() > 2) {
-      has_a_zero_point_ = true;
-    }
-    if (info.GetInputCount() > 3) {
-      has_b_zero_point_ = true;
-    }
-  }
+  MatMulInteger(const OpKernelInfo& info) : OpKernel(info) {}
 
   Status Compute(OpKernelContext* context) const override;
-
- private:
-  bool has_a_zero_point_;
-  bool has_b_zero_point_;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/util/qmath.h
+++ b/onnxruntime/core/util/qmath.h
@@ -4,12 +4,17 @@
 #pragma once
 
 #include "core/platform/threadpool.h"
+#include "core/mlas/inc/mlas.h"
 
 #if defined(_M_AMD64) || defined(__x86_64__) || defined(_M_IX86) || defined(__i386__)
 #define MLAS_SUPPORTS_GEMM_U8X8
 #endif
 
 namespace onnxruntime {
+
+void QGemm(
+    const MLAS_GEMM_U8X8_PARAMETERS& gemm_parameters,
+    concurrency::ThreadPool* thread_pool);
 
 template <typename LeftScalar, typename RightScalar, typename OutputScalar>
 void QGemm(

--- a/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
@@ -9,6 +9,7 @@
 #include "test/common/tensor_op_test_utils.h"
 #include "test/common/cuda_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"
+#include "core/util/qmath.h"
 
 namespace onnxruntime {
 namespace test {
@@ -134,9 +135,11 @@ void RunQAttention(const std::vector<float>& input_data,         // input:      
     execution_providers.push_back(DefaultCudaExecutionProvider());
     tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
   } else {
+#ifdef MLAS_SUPPORTS_GEMM_U8X8
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     execution_providers.push_back(DefaultCpuExecutionProvider());
     tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+#endif
   }
 }
 
@@ -187,6 +190,7 @@ static void RunQAttentionU8U8(
     qp_uint8.input_zero_point = 128;
     qp_uint8.weight_zero_point = 128;
   }
+
   RunQAttention<uint8_t, uint8_t, EP::CPU>(
       input_data, weights_data, bias_data, mask_index_data, output_data, qp_uint8,
       batch_size, sequence_length, hidden_size, number_of_heads, is_unidirectional);

--- a/onnxruntime/test/mlas/unittest.cpp
+++ b/onnxruntime/test/mlas/unittest.cpp
@@ -507,12 +507,29 @@ private:
         std::fill_n(C, M * N, -1);
         std::fill_n(CReference, M * N, -1);
 
-        MlasGemm(M, N, K, A, lda, offa, B, ldb, offb, C, ldc, threadpool);
+        MLAS_GEMM_U8X8_PARAMETERS Parameters = { };
+
+        Parameters.M = M;
+        Parameters.N = N;
+        Parameters.K = K;
+        Parameters.A = A;
+        Parameters.lda = lda;
+        Parameters.offa = offa;
+        Parameters.B = (const uint8_t*)B;
+        Parameters.ldb = ldb;
+        Parameters.offb = offb;
+        Parameters.BTypeIsSigned = std::is_signed<xint8_t>::value;
+        Parameters.C = C;
+        Parameters.ldc = ldc;
+
+        MlasGemm(&Parameters, threadpool);
+
         ReferenceQgemm(M, N, K, A, lda, offa, B, ldb, offb, CReference, ldc);
 
         for (size_t f = 0; f < M * N; f++) {
             if (C[f] != CReference[f]) {
                 printf("mismatch M=%zd, N=%zd, K=%zd, offa=%d, offb=%d!\n", M, N, K, (int)offa, (int)offb);
+                break;
             }
         }
     }


### PR DESCRIPTION
**Description**: The quantized GEMM routine has changed from taking tons of parameters to a structure containing the same parameters.

**Motivation and Context**:
In order to improve fusions with the core of the quantized GEMM, more parameters are going to be needed. Instead of adding more function wrappers, move all of the parameters to a structure instead. This PR does the initial transform of the existing parameters.

One immediate benefit of the new scheme is that it makes it easier to use a single kernel for MatMulInteger that handles u8u8 and u8s8. The same could also be done for the quantized attention op too.

The outer loops of the quantized GEMM have been templatized to avoid nasty cut/paste of these loops for the various architectures.

Also fixed the quantized attention test to disable the tests on platforms that don't have a MLAS quantized GEMM available. This fixes failing tests seen on ARM64 builds.