### PR TITLE
[C#] enable string-typed FixedBufferOnnxValue in input

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/FixedBufferOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/FixedBufferOnnxValue.cs
@@ -31,16 +31,9 @@ namespace Microsoft.ML.OnnxRuntime
         /// <returns></returns>
         public static FixedBufferOnnxValue CreateFromTensor<T>(Tensor<T> value)
         {
-            if (value is Tensor<string>)
-            {
-                throw new ArgumentException("Only numeric tensors can be used to create FixedBufferOnnxValue.", nameof(value));
-            }
-
             NativeOnnxValueHelper.CreateNativeOnnxValue(value, out IntPtr onnxValue, out MemoryHandle pinnedMemoryHandle, out OnnxValueType onnxValueType, out TensorElementType elementType);
 
-            Debug.Assert(
-                onnxValueType == OnnxValueType.ONNX_TYPE_TENSOR && elementType != TensorElementType.String,
-                "the value should always be a numeric tensor");
+            Debug.Assert(onnxValueType == OnnxValueType.ONNX_TYPE_TENSOR, "the value should always be a tensor");
 
             return new FixedBufferOnnxValue(pinnedMemoryHandle, onnxValue, onnxValueType, elementType);
         }

--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
@@ -366,6 +366,11 @@ namespace Microsoft.ML.OnnxRuntime
             int outputIndex = 0;
             foreach (var output in outputValues)
             {
+                if (output.ElementType == TensorElementType.String)
+                {
+                    throw new NotSupportedException("Using string type FixedBufferOnnxValue in outputs is not supported.");
+                }
+
                 outputValuesArray[outputIndex] = output.Value;
 
                 outputIndex++;
@@ -556,6 +561,11 @@ namespace Microsoft.ML.OnnxRuntime
                 int outputIndex = 0;
                 foreach (var output in outputValues)
                 {
+                    if (output.ElementType == TensorElementType.String)
+                    {
+                        throw new NotSupportedException("Using string type FixedBufferOnnxValue in outputs is not supported.");
+                    }
+
                     outputValuesArray[outputIndex] = output.Value;
 
                     outputIndex++;
@@ -695,7 +705,7 @@ namespace Microsoft.ML.OnnxRuntime
             IntPtr nameHandle = IntPtr.Zero;
             string str = null;
 
-            IntPtr status = NativeMethods.OrtSessionEndProfiling(_nativeHandle, 
+            IntPtr status = NativeMethods.OrtSessionEndProfiling(_nativeHandle,
                                                                   NativeMemoryAllocator.DefaultInstance.Handle,
                                                                   out nameHandle);
 
@@ -708,7 +718,7 @@ namespace Microsoft.ML.OnnxRuntime
             {
                 if (nameHandle != IntPtr.Zero)
                 {
-                  NativeMemoryAllocator.DefaultInstance.FreeMemory(nameHandle);
+                    NativeMemoryAllocator.DefaultInstance.FreeMemory(nameHandle);
                 }
             }
 


### PR DESCRIPTION
**Description**: This change enables C# API the capabilities to pass a string-typed `FixedBufferOnnxValue` as input in `InferenceSession.Run()`. It is still not allowed in output.