### PR TITLE
Handle corner case in Resize op

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -599,6 +599,11 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
 
   Tensor* Y = context->Output(0, output_dims);
 
+  // Return early if the output tensor is going to be of size 0
+  if (Y->Shape().Size() == 0) {
+    return Status::OK();
+  }
+
   if (dims.size() != scales.size())
     return Status(ONNXRUNTIME, INVALID_ARGUMENT,
                   is_resize_ ? "Resize: input tensor's dimension does not match the scales."

--- a/onnxruntime/core/providers/cpu/tensor/upsample.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.h
@@ -313,8 +313,8 @@ class UpsampleBase {
         // result in any non-zero value
         ORT_ENFORCE(output_dims[i] == 0,
                     "Input dim is zero but "
-                    " required output dim is non-zero. "
-                    "Cannot scale 0 by any factor to generate a non-zero value."
+                    "required output dim is non-zero. "
+                    "Cannot scale 0 by any factor to generate a non-zero value. "
                     "Input dims: ",
                     input_dims,
                     " Output dims: ",

--- a/onnxruntime/core/providers/cpu/tensor/upsample.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.h
@@ -315,10 +315,10 @@ class UpsampleBase {
                     "Input dim is zero but "
                     "required output dim is non-zero. "
                     "Cannot scale 0 by any factor to generate a non-zero value. "
-                    "Input dims: ",
-                    input_dims,
-                    " Output dims: ",
-                    output_dims);
+                    "Input dim value: ",
+                    input_dims[i],
+                    " Output dim value: ",
+                    output_dims[i]);
         // Scale can be any arbitrary value as technically scaling 0 by any factor
         // results in 0. Keeping scale as 1 is more intuitive given that input_dim == output_dim.
         scales[i] = 1.f;

--- a/onnxruntime/core/providers/cpu/tensor/upsample.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.h
@@ -312,13 +312,9 @@ class UpsampleBase {
         // Enforce that output_dim is 0, given that we cannot scale 0 by any factor to
         // result in any non-zero value
         ORT_ENFORCE(output_dims[i] == 0,
-                    "Input dim is zero but "
-                    "required output dim is non-zero. "
-                    "Cannot scale 0 by any factor to generate a non-zero value. "
-                    "Input dim value: ",
-                    input_dims[i],
-                    " Output dim value: ",
-                    output_dims[i]);
+                    "Input dim is zero but required output dim is non-zero. ",
+                    "Cannot scale 0 by any factor to generate a non-zero value. ",
+                    "Dimension: ", i, " Input dim value: ", input_dims[i], " Output dim value: ", output_dims[i]);
         // Scale can be any arbitrary value as technically scaling 0 by any factor
         // results in 0. Keeping scale as 1 is more intuitive given that input_dim == output_dim.
         scales[i] = 1.f;

--- a/onnxruntime/core/providers/cpu/tensor/upsample.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.h
@@ -307,7 +307,24 @@ class UpsampleBase {
                                      const std::vector<int64_t>& input_dims,
                                      std::vector<float>& scales) const {
     for (size_t i = 0, end = input_dims.size(); i < end; ++i) {
-      scales[i] = static_cast<float>(output_dims[i]) / static_cast<float>(input_dims[i]);
+      // Handle corner case to avoid dividing by zero in the next step
+      if (input_dims[i] == 0) {
+        // Enforce that output_dim is 0, given that we cannot scale 0 by any factor to
+        // result in any non-zero value
+        ORT_ENFORCE(output_dims[i] == 0,
+                    "Input dim is zero but "
+                    " required output dim is non-zero. "
+                    "Cannot scale 0 by any factor to generate a non-zero value."
+                    "Input dims: ",
+                    input_dims,
+                    " Output dims: ",
+                    output_dims);
+        // Scale can be any arbitrary value as technically scaling 0 by any factor
+        // results in 0. Keeping scale as 1 is more intuitive given that input_dim == output_dim.
+        scales[i] = 1.f;
+      } else {
+        scales[i] = static_cast<float>(output_dims[i]) / static_cast<float>(input_dims[i]);
+      }
     }
     ScalesValidation(scales, mode_);
   }

--- a/onnxruntime/core/providers/cuda/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cuda/tensor/upsample.cc
@@ -51,6 +51,12 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
                   "Resize: size of roi array should be 2 * N where N is the rank of input tensor X.");
 
   Tensor* Y = context->Output(0, output_dims);
+
+  // Return early if the output tensor is going to be of size 0
+  if (Y->Shape().Size() == 0) {
+    return Status::OK();
+  }
+
   typedef typename ToCudaType<T>::MappedType CudaT;
 
   // kernel


### PR DESCRIPTION
**Description**: Handle a corner case in the resize operator where-in an input dim (and the corresponding output dim) could be 0 and proceeding to divide the output dim by the input dim to compute the scale for the dimension results in a NaN.  There are some cases where-in a dimension can be legitimately zero (zero bounding boxes in an object detection model, no keypoints extractable from an image, etc.) and the resize op needs to be able to handle this.

**Motivation and Context**
Noticed while debugging a model run failure. 
