### PR TITLE
[OPENVINO EP] disable MEMLEAK CHECKER in Debug builds.

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -816,7 +816,7 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home,
             cmake_args + [
                 "-Donnxruntime_ENABLE_MEMLEAK_CHECKER="
                 + ("ON" if config.lower() == 'debug' and not args.use_tvm
-                   and not args.use_ngraph and
+                   and not args.use_ngraph and not args.use_openvino and
                    not args.enable_msvc_static_runtime
                    else "OFF"), "-DCMAKE_BUILD_TYPE={}".format(config)],
             cwd=config_build_dir)


### PR DESCRIPTION
memleak checker doesn't work with OpenVINO EP.  (OpenVINO EP 2.0 now uses nGraph internally)