### PR TITLE
build: split nodejs binding build and test to avoid timeout issue

### DIFF
--- a/cmake/onnxruntime_nodejs.cmake
+++ b/cmake/onnxruntime_nodejs.cmake
@@ -30,7 +30,6 @@ endif()
 add_custom_target(nodejs_binding_wrapper ALL
     COMMAND ${NPM_CLI} ci --ort-skip-build
     COMMAND ${NPM_CLI} run build -- --onnxruntime-build-dir=${CMAKE_CURRENT_BINARY_DIR} --config=${CMAKE_BUILD_TYPE}
-    COMMAND ${NPM_CLI} test -- --timeout=10000
     WORKING_DIRECTORY ${NODEJS_BINDING_ROOT}
     COMMENT "Using cmake-js to build OnnxRuntime Node.js binding")
 add_dependencies(nodejs_binding_wrapper onnxruntime)

--- a/nodejs/test/e2e/inference-session-run.ts
+++ b/nodejs/test/e2e/inference-session-run.ts
@@ -22,5 +22,5 @@ describe('E2E Tests - InferenceSession.run()', async () => {
       const result = await session!.run({'data_0': input0}, ['softmaxout_1']);
       assertTensorEqual(result.softmaxout_1, expectedOutput0);
     }
-  }).timeout('1200s');
+  }).timeout('120s');
 });

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -296,6 +296,9 @@ def parse_arguments():
         "--skip_winml_tests", action='store_true',
         help="Explicitly disable all WinML related tests")
     parser.add_argument(
+        "--skip_nodejs_tests", action='store_true',
+        help="Explicitly disable all Node.js binding tests")
+    parser.add_argument(
         "--enable_msvc_static_runtime", action='store_true',
         help="Enable static linking of MSVC runtimes.")
     parser.add_argument(
@@ -1400,6 +1403,13 @@ def nuphar_run_python_tests(build_dir, configs):
             cwd=cwd, dll_path=dll_path)
 
 
+def run_nodejs_tests(nodejs_binding_dir):
+    args = ['npm', 'test', '--', '--timeout=2000']
+    if is_windows():
+        args = ['cmd', '/c'] + args
+    run_subprocess(args, cwd=nodejs_binding_dir)
+
+
 def build_python_wheel(
         source_dir, build_dir, configs, use_cuda, use_ngraph, use_dnnl,
         use_tensorrt, use_openvino, use_nuphar, use_vitisai, wheel_name_suffix,
@@ -1777,6 +1787,11 @@ def main():
         # run nuphar python tests last, as it installs ONNX 1.5.0
         if args.enable_pybind and not args.skip_onnx_tests and args.use_nuphar:
             nuphar_run_python_tests(build_dir, configs)
+
+        # run node.js binding tests
+        if args.build_nodejs and not args.skip_nodejs_tests:
+            nodejs_binding_dir = os.path.normpath(os.path.join(source_dir, "nodejs"))
+            run_nodejs_tests(nodejs_binding_dir)
 
     if args.build:
         if args.build_wheel:

--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -129,7 +129,7 @@ jobs:
      del wheel_filename_file
      python.exe -m pip install -q --upgrade %WHEEL_FILENAME%
      set PATH=$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig);%PATH%
-     python $(Build.SourcesDirectory)\tools\ci_build\build.py --config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --test --cmake_generator "Visual Studio 16 2019"  --use_dnnl --build_wheel --enable_onnx_tests
+     python $(Build.SourcesDirectory)\tools\ci_build\build.py --config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --build_nodejs --test --cmake_generator "Visual Studio 16 2019"  --use_dnnl --build_wheel --enable_onnx_tests
    
     workingDirectory: '$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)'
     displayName: 'Run tests'


### PR DESCRIPTION
**Description**: split build and test for node.js binding. this resolves the random build failure caused by test timeout (when it is building and linking)