### PR TITLE
Remove hardcoded desktop lib

### DIFF
--- a/cmake/onnxruntime_common.cmake
+++ b/cmake/onnxruntime_common.cmake
@@ -30,8 +30,10 @@ if(WIN32)
          "${ONNXRUNTIME_ROOT}/core/platform/windows/logging/*.h"
          "${ONNXRUNTIME_ROOT}/core/platform/windows/logging/*.cc"
     )
-    # wndows platform adapter code uses advapi32
-    list(APPEND onnxruntime_EXTERNAL_LIBRARIES advapi32)
+    # Windows platform adapter code uses advapi32, which isn't linked in by default in desktop ARM
+    if (NOT WINDOWS_STORE)
+        list(APPEND onnxruntime_EXTERNAL_LIBRARIES advapi32)
+    endif()
 else()
     list(APPEND onnxruntime_common_src_patterns
          "${ONNXRUNTIME_ROOT}/core/platform/posix/*.h"


### PR DESCRIPTION
**Description**: Link to advapi32 in desktop only. In WCOS it should be resolved by the umbrella lib.