### PR TITLE
Benchmark With IO Binding

### DIFF
--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -222,9 +222,13 @@ def get_onnx_file_path(onnx_dir: str, model_name: str, input_count: int, optimiz
 
 def optimize_onnx_model_by_ort(onnx_model_path, ort_model_path, use_gpu, overwrite):
     if overwrite or not os.path.exists(ort_model_path):
-        from optimizer import optimize_by_onnxruntime
+        from optimizer import optimize_model, get_fusion_statistics
         # Use onnxruntime to optimize model, which will be saved to *_ort.onnx
-        optimize_by_onnxruntime(onnx_model_path, use_gpu=use_gpu, optimized_model_path=ort_model_path, opt_level=99)
+        opt_model = optimize_by_onnxruntime(onnx_model_path,
+                                            use_gpu=use_gpu,
+                                            optimized_model_path=ort_model_path,
+                                            opt_level=99)
+        model_fusion_statistics[ort_model_path] = get_fusion_statistics(ort_model_path)
     else:
         logger.info(f"Skip optimization since model existed: {ort_model_path}")
 

--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -222,7 +222,7 @@ def get_onnx_file_path(onnx_dir: str, model_name: str, input_count: int, optimiz
 
 def optimize_onnx_model_by_ort(onnx_model_path, ort_model_path, use_gpu, overwrite):
     if overwrite or not os.path.exists(ort_model_path):
-        from optimizer import optimize_model, get_fusion_statistics
+        from optimizer import optimize_by_onnxruntime, get_fusion_statistics
         # Use onnxruntime to optimize model, which will be saved to *_ort.onnx
         opt_model = optimize_by_onnxruntime(onnx_model_path,
                                             use_gpu=use_gpu,
@@ -521,6 +521,7 @@ def run_pytorch(use_gpu, model_names, fp16, batch_sizes, sequence_lengths, repea
                         "device": "cuda" if use_gpu else "cpu",
                         "optimizer": "",
                         "fp16": fp16,
+                        "io_binding": "",
                         "model_name": model_name,
                         "inputs": 1,
                         "batch_size": batch_size,

--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -343,36 +343,53 @@ def inference_ort(ort_session, ort_inputs, result_template, repeat_times, batch_
     result = {}
     runtimes = timeit.repeat(lambda: ort_session.run(None, ort_inputs), number=1, repeat=repeat_times)
     result.update(result_template)
-    result.update({"engine": "onnxruntime"})
+    result.update({"io_binding": False})
     result.update(get_latency_result(runtimes, batch_size))
     return result
 
 
-def inference_ort_with_io_binding(ort_session, ort_inputs, result_template, repeat_times, ort_output_names,
-                                  last_state_buffer, pooler_buffer, batch_size, sequence_length, hidden_size, device):
+def inference_ort_with_io_binding(ort_session, ort_inputs, result_template, repeat_times, ort_output_names, ort_outputs,
+                                  output_buffers, max_last_state_size, max_pooler_size, batch_size, device):
     result = {}
+
     # Bind inputs and outputs to onnxruntime session
     io_binding = ort_session.io_binding()
     # Bind inputs to device
     for name in ort_inputs.keys():
         np_input = torch.from_numpy(ort_inputs[name]).to(device)
         io_binding.bind_input(name, np_input.device.type, 0, numpy.longlong, np_input.shape, np_input.data_ptr())
-    # Bind outputs buffers with the sizes needed
-    io_binding.bind_output(ort_output_names[0], last_state_buffer.device.type, 0, numpy.float32,
-                           [batch_size, sequence_length, hidden_size], last_state_buffer.data_ptr())
-    if len(ort_output_names) == 2:
-        io_binding.bind_output(ort_output_names[1], pooler_buffer.device.type, 0, numpy.float32,
-                               [batch_size, hidden_size], pooler_buffer.data_ptr())
+    has_pooler = True if len(ort_output_names) == 2 else False
+    # Bind outputs buffers with the sizes needed if not allocated already
+    if output_buffers["last_state"] is None:
+        allocateOutputBuffers(output_buffers, max_last_state_size, max_pooler_size, device, has_pooler)
+    last_state_buffer = output_buffers["last_state"]
+    pooler_buffer = output_buffers["pooler"]
+    io_binding.bind_output(ort_output_names[0], last_state_buffer.device.type, 0, numpy.float32, ort_outputs[0].shape,
+                           last_state_buffer.data_ptr())
+    if has_pooler:
+        io_binding.bind_output(ort_output_names[1], pooler_buffer.device.type, 0, numpy.float32, ort_outputs[1].shape,
+                               pooler_buffer.data_ptr())
 
     runtimes = timeit.repeat(lambda: ort_session.run_with_iobinding(io_binding), number=1, repeat=repeat_times)
     result.update(result_template)
-    result.update({"engine": "onnxruntime_with_io_binding"})
+    result.update({"io_binding": True})
     result.update(get_latency_result(runtimes, batch_size))
     return result
 
 
+def allocateOutputBuffers(output_buffers, max_last_state_size, max_pooler_size, device, has_pooler=False):
+    # Allocate output tensors with the largest test size needed. So the allocated memory can be reused
+    # for each test run.
+    # dummy last state
+    if output_buffers["last_state"] is None:
+        output_buffers["last_state"] = torch.empty(max_last_state_size, dtype=torch.float32, device=device)
+    # create dummy pooler
+    if output_buffers["pooler"] is None and has_pooler:
+        output_buffers["pooler"] = torch.empty(max_pooler_size, dtype=torch.float32, device=device)
+
+
 def run_onnxruntime(use_gpu, model_names, fp16, batch_sizes, sequence_lengths, repeat_times, input_counts,
-                    optimize_onnx, validate_onnx, cache_dir, onnx_dir, verbose, overwrite, run_with_io, run_without_io):
+                    optimize_onnx, validate_onnx, cache_dir, onnx_dir, verbose, overwrite, disable_ort_io_binding):
     import onnxruntime
 
     results = []
@@ -404,24 +421,14 @@ def run_onnxruntime(use_gpu, model_names, fp16, batch_sizes, sequence_lengths, r
             if ort_session is None:
                 continue
 
-            ort_output_names = []
-            last_state_buffer = None
-            pooler_buffer = None
+            ort_output_names = [node_arg.name for node_arg in ort_session.get_outputs()]
+            output_buffers = {"last_state": None, "pooler": None}
             device = "cuda" if use_gpu else "cpu"
             config = AutoConfig.from_pretrained(model_name, cache_dir=cache_dir)
-            if run_with_io:
-                # Allocate output tensors with the largest test size needed. So the allocated memory can be reused
-                # for each test run.
-                max_batch_size = max(batch_sizes)
-                max_seq_len = max(sequence_lengths)
-                ort_output_names = [node_arg.name for node_arg in ort_session.get_outputs()]
-                last_state_buffer = torch.empty(numpy.prod([max_batch_size, max_seq_len, config.hidden_size]),
-                                                dtype=torch.float32,
-                                                device=device)
-                if len(ort_output_names) == 2:
-                    pooler_buffer = torch.empty(numpy.prod([max_batch_size, config.hidden_size]),
-                                                dtype=torch.float32,
-                                                device=device)
+            max_last_state_size = numpy.prod(
+                [max(batch_sizes), max(sequence_lengths),
+                 max(vocab_size, config.hidden_size)])
+            max_pooler_size = numpy.prod([max(batch_sizes), config.hidden_size])
             for batch_size in batch_sizes:
                 if batch_size <= 0:
                     continue
@@ -432,29 +439,32 @@ def run_onnxruntime(use_gpu, model_names, fp16, batch_sizes, sequence_lengths, r
                     ort_inputs = create_onnxruntime_input(vocab_size, batch_size, sequence_length, input_names)
 
                     result_template = {
+                        "engine": "onnxruntime",
                         "version": onnxruntime.__version__,
                         "device": device,
                         "optimizer": optimize_onnx,
                         "fp16": fp16,
+                        "io_binding": False,
                         "model_name": model_name,
                         "inputs": num_inputs,
                         "batch_size": batch_size,
                         "sequence_length": sequence_length,
                         "datetime": str(datetime.now()),
                     }
-                    if run_without_io:
-                        logger.info("Run onnxruntime on {} with input shape {}".format(
-                            model_name, [batch_size, sequence_length]))
-                        result = inference_ort(ort_session, ort_inputs, result_template, repeat_times, batch_size)
-                        logger.info(result)
-                        results.append(result)
+                    logger.info("Run onnxruntime on {} with input shape {}".format(model_name,
+                                                                                   [batch_size, sequence_length]))
+                    result = inference_ort(ort_session, ort_inputs, result_template, repeat_times, batch_size)
+                    logger.info(result)
+                    results.append(result)
 
-                    if run_with_io:
+                    if not disable_ort_io_binding:
                         logger.info("Run onnxruntime with io binding on {} with input shape {}".format(
                             model_name, [batch_size, sequence_length]))
+                        # Get output sizes from a dummy ort run
+                        ort_outputs = ort_session.run(ort_output_names, ort_inputs)
                         result = inference_ort_with_io_binding(ort_session, ort_inputs, result_template, repeat_times,
-                                                               ort_output_names, last_state_buffer, pooler_buffer,
-                                                               batch_size, sequence_length, config.hidden_size, device)
+                                                               ort_output_names, ort_outputs, output_buffers,
+                                                               max_last_state_size, max_pooler_size, batch_size, device)
                         logger.info(result)
                         results.append(result)
 
@@ -530,9 +540,9 @@ def run_pytorch(use_gpu, model_names, fp16, batch_sizes, sequence_lengths, repea
 def output_details(results, csv_filename):
     with open(csv_filename, mode="a", newline='') as csv_file:
         column_names = [
-            "engine", "version", "device", "fp16", "optimizer", "model_name", "inputs", "batch_size", "sequence_length",
-            "datetime", "test_times", "QPS", "average_latency_ms", "latency_variance", "latency_90_percentile",
-            "latency_95_percentile", "latency_99_percentile"
+            "engine", "version", "device", "fp16", "optimizer", "io_binding", "model_name", "inputs", "batch_size",
+            "sequence_length", "datetime", "test_times", "QPS", "average_latency_ms", "latency_variance",
+            "latency_90_percentile", "latency_95_percentile", "latency_99_percentile"
         ]
 
         csv_writer = csv.DictWriter(csv_file, fieldnames=column_names)
@@ -545,7 +555,7 @@ def output_details(results, csv_filename):
 
 def output_summary(results, csv_filename, args):
     with open(csv_filename, mode="a", newline='') as csv_file:
-        header_names = ["model_name", "inputs", "engine", "version", "device", "fp16", "optimizer"]
+        header_names = ["model_name", "inputs", "engine", "version", "device", "fp16", "optimizer", "io_binding"]
         data_names = []
         for batch_size in args.batch_sizes:
             for sequence_length in args.sequence_lengths:
@@ -556,21 +566,23 @@ def output_summary(results, csv_filename, args):
         for model_name in args.models:
             for input_count in [1, 2, 3]:
                 for engine_name in args.engines:
-                    row = {}
-                    for result in results:
-                        if result["model_name"] == model_name and result["inputs"] == input_count and result[
-                                "engine"] == engine_name:
-                            headers = {k: v for k, v in result.items() if k in header_names}
-                            if not row:
-                                row.update(headers)
-                                row.update({k: "" for k in data_names})
-                            else:
-                                for k in header_names:
-                                    assert row[k] == headers[k]
-                            b = result["batch_size"]
-                            s = result["sequence_length"]
-                            row[f"b{b}_s{s}"] = result["average_latency_ms"]
-                    csv_writer.writerow(row)
+                    for io_binding in [True, False, ""]:
+                        row = {}
+                        for result in results:
+                            if result["model_name"] == model_name and result["inputs"] == input_count and result[
+                                    "engine"] == engine_name and result["io_binding"] == io_binding:
+                                headers = {k: v for k, v in result.items() if k in header_names}
+                                if not row:
+                                    row.update(headers)
+                                    row.update({k: "" for k in data_names})
+                                else:
+                                    for k in header_names:
+                                        assert row[k] == headers[k]
+                                b = result["batch_size"]
+                                s = result["sequence_length"]
+                                row[f"b{b}_s{s}"] = result["average_latency_ms"]
+                        if row:
+                            csv_writer.writerow(row)
 
     logger.info(f"Summary results are saved to csv file: {csv_filename}")
 
@@ -609,7 +621,7 @@ def parse_arguments():
                         nargs="+",
                         type=str,
                         default=['onnxruntime'],
-                        choices=['onnxruntime', 'onnxruntime_with_io_binding', 'torch', 'torchscript'],
+                        choices=['onnxruntime', 'torch', 'torchscript'],
                         help="Engines to benchmark")
 
     parser.add_argument("-c",
@@ -671,6 +683,12 @@ def parse_arguments():
 
     parser.add_argument("-s", "--sequence_lengths", nargs="+", type=int, default=[8, 16, 32, 64, 128, 256])
 
+    parser.add_argument('--disable_ort_io_binding',
+                        required=False,
+                        action='store_true',
+                        help='Disable running ONNX Runtime with binded inputs and outputs. ')
+    parser.set_defaults(disable_ort_io_binding=False)
+
     args = parser.parse_args()
     return args
 
@@ -702,9 +720,7 @@ def main():
 
     enable_torch = "torch" in args.engines
     enable_torchscript = "torchscript" in args.engines
-    enable_ort_io_binding = "onnxruntime_with_io_binding" in args.engines
-    enable_ort_wo_io_binding = "onnxruntime" in args.engines
-    enable_onnxruntime = enable_ort_wo_io_binding or enable_ort_io_binding
+    enable_onnxruntime = "onnxruntime" in args.engines
 
     results = []
     if enable_torch or enable_torchscript:
@@ -724,7 +740,7 @@ def main():
             results += run_onnxruntime(args.use_gpu, args.models, args.fp16, args.batch_sizes, args.sequence_lengths,
                                        args.test_times, args.input_counts, args.optimize_onnx, args.validate_onnx,
                                        args.cache_dir, args.onnx_dir, args.verbose, args.overwrite,
-                                       enable_ort_io_binding, enable_ort_wo_io_binding)
+                                       args.disable_ort_io_binding)
         except:
             logger.error(f"Exception", exc_info=True)
 

--- a/onnxruntime/python/tools/transformers/benchmark_gpt2.py
+++ b/onnxruntime/python/tools/transformers/benchmark_gpt2.py
@@ -57,7 +57,7 @@ def pytorch_inference(model, input_ids, past=None, attention_mask=None, total_ru
     return outputs, average_latency
 
 
-def onnxruntime_inference(ort_session, input_ids, past=None, attention_mask=None, total_runs=100):
+def onnxruntime_inference(ort_session, input_ids, past=None, total_runs=100):
     ort_inputs = {'input_ids': numpy.ascontiguousarray(input_ids.cpu().numpy())}
 
     if attention_mask is not None:
@@ -84,7 +84,6 @@ def onnxruntime_inference_with_binded_io(ort_session,
                                          last_state,
                                          last_state_shape,
                                          past=None,
-                                         attention_mask=None,
                                          present=None,
                                          present_shape=None,
                                          total_runs=100):
@@ -93,17 +92,13 @@ def onnxruntime_inference_with_binded_io(ort_session,
     # Bind inputs
     io_binding.bind_input('input_ids', input_ids.device.type, 0, numpy.longlong, list(input_ids.size()),
                           input_ids.data_ptr())
-    if attention_mask is not None:
-        io_binding.bind_input('attention_mask', attention_mask.device.type, 0, numpy.float32, list(attention_mask.size()),
-                              attention_mask.data_ptr())
-
     if past is not None:
         for i, past_i in enumerate(past):
             io_binding.bind_input(f'past_{i}', past[i].device.type, 0, numpy.float32, list(past[i].size()),
                                   past[i].data_ptr())
 
     # Bind outputs
-    io_binding.bind_output(ort_session.get_outputs()[0].name, last_state.device.type, 0, numpy.float32, last_state_shape,
+    io_binding.bind_output("last_state", last_state.device.type, 0, numpy.float32, last_state_shape,
                            last_state.data_ptr())
     if present is not None:
         for i, present_i in enumerate(present):
@@ -132,7 +127,6 @@ def inference(model,
               ort_session,
               input_ids,
               past=None,
-              attention_mask=None,
               last_state=None,
               present=None,
               last_state_shape=None,
@@ -140,12 +134,12 @@ def inference(model,
               total_runs=100,
               verify_outputs=True,
               with_io_binding=False):
-    outputs, torch_latency = pytorch_inference(model, input_ids, past, attention_mask, total_runs)
-    ort_outputs, ort_latency = onnxruntime_inference(ort_session, input_ids, past, attention_mask, total_runs)
+    outputs, torch_latency = pytorch_inference(model, input_ids, past, total_runs)
+    ort_outputs, ort_latency = onnxruntime_inference(ort_session, input_ids, past, total_runs)
     latencies = [torch_latency, ort_latency]
     if with_io_binding:
         ort_io_outputs, ort_io_latency = onnxruntime_inference_with_binded_io(ort_session, input_ids, last_state,
-                                                                              last_state_shape, past, attention_mask, present,
+                                                                              last_state_shape, past, present,
                                                                               present_shape, total_runs)
         latencies.append(ort_io_latency)
     if verify_outputs:
@@ -211,8 +205,7 @@ def parse_arguments():
                         help='Use optimizer.py to optimize onnx model')
     parser.set_defaults(optimize_onnx=False)
 
-    parser.add_argument('-i',
-                        '--with_io_binding',
+    parser.add_argument('--with_io_binding',
                         required=False,
                         action='store_true',
                         help='Run ONNX Runtime with binded inputs and outputs. ')
@@ -283,16 +276,19 @@ def export_onnx(model, config, tokenizer, device, output_dir, use_LMHead=False, 
     #    past_{i}:  (2, batch_size, num_heads, past_seq_len, hidden_size/num_heads)
     #    attention_mask: (batch_size, seq_len)
     # Shape of output tensors:
-    #    last_state: (batch_size, all_seq_len, hidden_size)
-    #    present_{i}:  (2, batch_size, num_heads, all_seq_len, hidden_size/num_heads)
-    dynamic_axes = {'input_ids': {0: 'batch_size', 1 : 'seq_len'}, output_names[0]: {0: 'batch_size', 1: 'all_seq_len'}}
-    for name in past_names:
-        dynamic_axes[name] = {1: 'batch_size', 3: 'past_seq_len'}
+    #    last_state: (batch_size, seq_len + 1, hidden_size)
+    #    present_{i}:  (2, batch_size, num_heads, seq_len + 1, hidden_size/num_heads)
+    dynamic_axes = {'input_ids': {0: 'batch_size'}, 'last_state': {0: 'batch_size', 1: 'seq_len_plus_1'}}
+
     for name in present_names:
         dynamic_axes[name] = {1: 'batch_size', 3: 'all_seq_len'}
 
-    if use_attention_mask:
-        dynamic_axes['attention_mask'] = {0: 'batch_size', 1: 'seq_len'}
+    past_names = [f'past_{i}' for i in range(num_layer)]
+    input_names = ['input_ids'] + past_names
+    dummy_past = [torch.zeros(list(outputs[1][0].shape), dtype=torch.float32, device=device) for _ in range(num_layer)]
+    for name in past_names:
+        dynamic_axes[name] = {1: 'batch_size', 3: 'seq_len'}
+    logger.debug(f"vocab_size:{model.config.vocab_size}")
 
     dummy_input_ids = torch.randint(low=0,
                                     high=model.config.vocab_size - 1,
@@ -338,7 +334,7 @@ def main():
         os.makedirs(output_dir)
 
     use_torchscript = False
-    (model_class, tokenizer_class, model_name, use_LMHead, use_attention_mask) = MODEL_CLASSES[args.model_type]
+    (model_class, tokenizer_class, model_name) = MODEL_CLASSES[args.model_type]
     config = AutoConfig.from_pretrained(model_name, torchscript=use_torchscript, cache_dir=cache_dir)
     model = model_class.from_pretrained(model_name, config=config, cache_dir=cache_dir)
     tokenizer = tokenizer_class.from_pretrained(model_name, cache_dir=cache_dir)
@@ -346,7 +342,7 @@ def main():
     #    model = torch.jit.trace(model, (input_ids, past))
 
     device = torch.device("cuda:0" if args.use_gpu else "cpu")
-    export_model_path = export_onnx(model, config, tokenizer, device, output_dir, use_LMHead, use_attention_mask)
+    export_model_path = export_onnx(model, config, tokenizer, device, output_dir)
 
     # setup environment variables before importing onnxruntime.
     setup_environment()
@@ -393,10 +389,7 @@ def main():
         ]
 
         # dummy last state
-        if use_LMHead:
-            last_state_size = numpy.prod([max_batch_size, 1, config.vocab_size])
-        else:
-            last_state_size = numpy.prod([max_batch_size, 1, config.hidden_size])
+        last_state_size = numpy.prod([max_batch_size, 1, config.hidden_size])
         dummy_last_state = torch.empty(last_state_size).to(device)
 
     for batch_size in args.batch_sizes:
@@ -411,7 +404,6 @@ def main():
                                             size=(batch_size, 1),
                                             dtype=torch.int64,
                                             device=device)
-            dummy_mask = torch.ones([batch_size, 1], dtype=torch.float32, device=device) if use_attention_mask else None
 
             # Calculate the expected output shapes
             last_state_shape = [batch_size, 1, config.hidden_size]
@@ -424,7 +416,6 @@ def main():
                                   session,
                                   dummy_input_ids,
                                   dummy_past,
-                                  dummy_mask,
                                   dummy_last_state,
                                   dummy_present,
                                   last_state_shape,


### PR DESCRIPTION
**Description**: Describe your changes.
Add an option to run onnxruntime benchmark with io binding for bert models in benchmark.py

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
We've seen performance gain when using io binding to run Bert models. Adding such option allows users to fully experience our optimization. 
