### PR TITLE
Improve fast_divmod

### DIFF
--- a/onnxruntime/core/providers/cuda/shared_inc/fast_divmod.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/fast_divmod.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <iostream>
 #include <limits>
 #include <cuda_runtime.h>
 #include <cmath>
@@ -20,13 +21,13 @@ namespace cuda {
 struct fast_divmod {
   fast_divmod(int d = 1) {
     d_ = d == 0 ? 1 : d;
-    ORT_ENFORCE(d_ >= 1 && d_ <= std::numeric_limits<int>::max());
+    ORT_ENFORCE(d_ >= 1 && d_ <= static_cast<uint32_t>(std::numeric_limits<int>::max()));
 
     for (l_ = 0; l_ < 32; l_++) if ((1U << l_) >= d_) break;
 
     uint64_t one = 1;
     uint64_t m = ((one << 32) * ((one << l_) - d_)) / d_ + 1;
-    M_ = m;
+    M_ = static_cast<uint32_t>(m);
     // according to paper, the value of m' should fit in a unsigned integer.
     ORT_ENFORCE(M_ > 0 && M_ == m);
   }
@@ -38,7 +39,7 @@ struct fast_divmod {
 #else
     // Using uint64_t for t, then t + n won't overflow.
     uint64_t t = ((uint64_t) M_ * n) >> 32;
-    return (t + n) >> l_;
+    return static_cast<int>((t + n) >> l_);
 #endif
   }
 

--- a/onnxruntime/core/providers/cuda/shared_inc/fast_divmod.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/fast_divmod.h
@@ -5,126 +5,55 @@
 
 #pragma once
 
+#include <limits>
 #include <cuda_runtime.h>
 #include <cmath>
+#include "core/common/common.h"
 
 namespace onnxruntime {
 namespace cuda {
 
-__host__ __device__ __inline__ int mulhi(const int M, const int n) {
+// The code below is based on section 4 Unsigned division of paper https://gmplib.org/~tege/divcnst-pldi94.pdf
+// In current ORT, fast_divmod is used for calculating the position of a element in tensor,
+// so unsigned integer division from the paper is good enough for ORT. The advantage is that div is very simple,
+// then GPU compiler can do loop unroll easilly when divmod is called in a loop.
+struct fast_divmod {
+  fast_divmod(int d = 1) {
+    d_ = d == 0 ? 1 : d;
+    ORT_ENFORCE(d_ >= 1 && d_ <= std::numeric_limits<int>::max());
+
+    for (l_ = 0; l_ < 32; l_++) if ((1U << l_) >= d_) break;
+
+    uint64_t one = 1;
+    uint64_t m = ((one << 32) * ((one << l_) - d_)) / d_ + 1;
+    M_ = m;
+    // according to paper, the value of m' should fit in a unsigned integer.
+    ORT_ENFORCE(M_ > 0 && M_ == m);
+  }
+
+  __host__ __device__ inline int div(int n) const {
 #ifdef __CUDA_ARCH__
-  return __mulhi(M, n);
+    uint32_t t = __umulhi(M_, n);
+    return (t + n) >> l_;
 #else
-  return (((unsigned long long)((long long)M * (long long)n)) >> 32);
+    // Using uint64_t for t, then t + n won't overflow.
+    uint64_t t = ((uint64_t) M_ * n) >> 32;
+    return (t + n) >> l_;
 #endif
-}
-
-// Based on code from Chapter 10 of "Hacker's Delight, 2nd ed."
-class fast_divmod {
- public:
-  fast_divmod(int d = 1) : d_(d), a_(0) { find_magic_numbers(); }
-
-  fast_divmod(const fast_divmod& other) : d_(other.d_), M_(other.M_), s_(other.s_), a_(other.a_){};
-
-  __host__ __device__ __inline__ int div(int n) const {
-    // get high 32 bits of M * n
-    int q = mulhi(M_, n);
-
-    // deal with add / subs if needed
-    q += a_ * n;
-
-    // shift if necessary
-    if (s_ >= 0) {
-      q >>= s_;
-      q += ((unsigned int)q >> 31);
-    }
-
-    return q;
   }
 
-  __host__ __device__ __inline__ void divmod(int n, int& q, int& r) const {
-    // handle special cases
-    if (d_ == 1) {
-      q = n;
-      r = 0;
-    } else if (d_ == -1) {
-      q = -n;
-      r = 0;
-    } else {
-      // general case
-      q = div(n);
-      r = n - q * d_;
-    }
+  __host__ __device__ inline int mod(int n) const {
+    return n - div(n) * d_;
   }
 
- public:
-  int d_, M_, s_, a_;
-
- private:
-  // Based on code from Hacker's delight 2.ed
-  // Chapter 10, figure 10-1
-  void find_magic_numbers() {
-    // special case for d = 1, -1
-    if (d_ == 1) {
-      M_ = 0;
-      s_ = 0;
-      a_ = 1;
-      return;
-    } else if (d_ == -1) {
-      M_ = 0;
-      s_ = -1;
-      a_ = -1;
-      return;
-    }
-    // general case
-    const unsigned two31 = 0x80000000;
-    unsigned abs_d = (d_ == 0) ? 1 : abs(d_);
-    unsigned t = two31 + ((unsigned)d_ >> 31);  // t = 2^31 + (d < 0) ? 1 : 0
-    unsigned abs_nc = t - 1 - (t % abs_d);      // |n_c| = t - 1 - rem(t, |d|)
-    int p = 31;
-    unsigned q1 = two31 / abs_nc;       // Init q_1 = 2^31 / |n_c|
-    unsigned r1 = two31 - q1 * abs_nc;  // Init r_1 = rem(q_1, |n_c|)
-    unsigned q2 = two31 / abs_d;        // Init q_2 = 2^31 / |d|
-    unsigned r2 = two31 - q2 * abs_d;   // Init r_2 = rem(q_2, |d|)
-
-    unsigned delta;
-    // iterate p until
-    // 2^p < n_c * (d - rem(2^p, d)) is satisfied
-    do {
-      ++p;
-      q1 *= 2;
-      r1 *= 2;
-
-      if (r1 >= abs_nc) {
-        q1 += 1;
-        r1 -= abs_nc;
-      }
-      q2 *= 2;
-      r2 *= 2;
-
-      if (r2 >= abs_d) {
-        q2 += 1;
-        r2 -= abs_d;
-      }
-      delta = abs_d - r2;
-    } while (q1 < delta ||
-             (q1 == delta && r1 == 0));
-
-    // store magic numbers
-    M_ = q2 + 1;
-    if (d_ < 0) M_ = -M_;
-    s_ = p - 32;
-
-    // generate sentinel for correct adds / subs
-    // "generate the add if d > 0 and M < 0"
-    if ((d_ > 0) && (M_ < 0)) a_ = 1;
-    //  "generate the sub if d < 0 and M > 0"
-    else if ((d_ < 0) && (M_ > 0))
-      a_ = -1;
-    // Otherwise no add / sub needed
-    else
-      a_ = 0;
+  __host__ __device__ inline void divmod(int n, int& q, int& r) const {
+    q = div(n);
+    r = n - q * d_;
   }
+
+  uint32_t d_;  // divisor
+  uint32_t M_;  // m' in the paper.
+  uint32_t l_;  // l_ = ceil(log2(d_))
 };
 
 }  // namespace cuda


### PR DESCRIPTION
The control flow in function such as div and divmod will prevent loop unroll when divmod is called in the loop of cuda kernel. With the new implementation based on section 4 Unsigned division of paper https://gmplib.org/~tege/divcnst-pldi94.pdf,  the generated kernel code will be more efficient. For example, the throughput of BERT-L training will be improved about ~1.8%.

**Let's use _TransposeKernel from transpose_impl.cu as an example.**  

__global__ void TransposeKernel(const TArray<int64_t> input_strides, const float* input_data,
                                 const TArray<fast_divmod> output_strides, float* output_data,
                                 int32_t rank, int32_t N) {
  int32_t id = blockDim.x * blockIdx.x + threadIdx.x;

  int32_t input_index = 0;
  int32_t output_index = id;

  #pragma unroll
  for (auto dim = 0; dim < input_strides.GetCapacity(); ++dim) {
    if (dim >= rank) {
      break;
    }
    int q, r;
    output_strides[dim].divmod(output_index, q, r);
    output_index = r;
    input_index += input_strides[dim] * q;
  }
  output_data[id] = input_data[input_index];
}

**- PTX code for _TransposeKernel with new fast_divmod implementation.**  

// .globl	_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii
.visible .entry _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii(
	.param .align 8 .b8 _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0[72],
	.param .u64 _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_1,
	.param .align 4 .b8 _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2[100],
	.param .u64 _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_3,
	.param .u32 _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_4,
	.param .u32 _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_5
)
{
	.reg .pred 	%p<9>;
	.reg .f32 	%f<2>;
	.reg .b32 	%r<70>;
	.reg .b64 	%rd<51>;


	ld.param.u64 	%rd17, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+64];
	ld.param.u64 	%rd16, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+56];
	ld.param.u64 	%rd15, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+48];
	ld.param.u64 	%rd14, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+40];
	ld.param.u64 	%rd13, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+32];
	ld.param.u64 	%rd12, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+24];
	ld.param.u64 	%rd11, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+16];
	ld.param.u64 	%rd10, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+8];
	ld.param.u64 	%rd18, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_1];
	ld.param.u32 	%r34, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+96];
	ld.param.u32 	%r33, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+92];
	ld.param.u32 	%r31, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+84];
	ld.param.u32 	%r30, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+80];
	ld.param.u32 	%r29, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+76];
	ld.param.u32 	%r28, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+72];
	ld.param.u32 	%r27, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+68];
	ld.param.u32 	%r26, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+64];
	ld.param.u32 	%r25, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+60];
	ld.param.u32 	%r24, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+56];
	ld.param.u32 	%r23, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+52];
	ld.param.u32 	%r22, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+48];
	ld.param.u32 	%r21, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+44];
	ld.param.u32 	%r20, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+40];
	ld.param.u32 	%r19, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+36];
	ld.param.u32 	%r18, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+32];
	ld.param.u32 	%r17, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+28];
	ld.param.u32 	%r16, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+24];
	ld.param.u32 	%r15, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+20];
	ld.param.u32 	%r14, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+16];
	ld.param.u32 	%r13, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+12];
	ld.param.u32 	%r12, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+8];
	ld.param.u32 	%r11, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+4];
	ld.param.u64 	%rd19, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_3];
	ld.param.u32 	%r35, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_4];
	mov.u32 	%r36, %ctaid.x;
	mov.u32 	%r37, %ntid.x;
	mov.u32 	%r38, %tid.x;
	mad.lo.s32 	%r1, %r36, %r37, %r38;
	mov.u64 	%rd50, 0;
	setp.lt.s32	%p1, %r35, 1;
	@%p1 bra 	BB1_9;

	mul.hi.u32 	%r39, %r12, %r1;
	add.s32 	%r40, %r39, %r1;
	shr.u32 	%r2, %r40, %r13;
	cvt.u64.u32	%rd21, %r2;
	mul.lo.s64 	%rd22, %rd10, %rd21;
	cvt.s64.s32 	%rd50, %rd22;
	setp.lt.s32	%p2, %r35, 2;
	@%p2 bra 	BB1_9;

	mul.lo.s32 	%r41, %r2, %r11;
	sub.s32 	%r42, %r1, %r41;
	mul.hi.u32 	%r43, %r15, %r42;
	add.s32 	%r44, %r43, %r42;
	shr.u32 	%r45, %r44, %r16;
	mul.lo.s32 	%r46, %r45, %r14;
	sub.s32 	%r3, %r42, %r46;
	cvt.u64.u32	%rd23, %r45;
	mul.lo.s64 	%rd24, %rd11, %rd23;
	add.s64 	%rd25, %rd24, %rd50;
	cvt.s64.s32 	%rd50, %rd25;
	setp.lt.s32	%p3, %r35, 3;
	@%p3 bra 	BB1_9;

	mul.hi.u32 	%r47, %r18, %r3;
	add.s32 	%r48, %r47, %r3;
	shr.u32 	%r49, %r48, %r19;
	mul.lo.s32 	%r50, %r49, %r17;
	sub.s32 	%r4, %r3, %r50;
	cvt.u64.u32	%rd26, %r49;
	mul.lo.s64 	%rd27, %rd12, %rd26;
	add.s64 	%rd28, %rd27, %rd50;
	cvt.s64.s32 	%rd50, %rd28;
	setp.lt.s32	%p4, %r35, 4;
	@%p4 bra 	BB1_9;

	mul.hi.u32 	%r51, %r21, %r4;
	add.s32 	%r52, %r51, %r4;
	shr.u32 	%r53, %r52, %r22;
	mul.lo.s32 	%r54, %r53, %r20;
	sub.s32 	%r5, %r4, %r54;
	cvt.u64.u32	%rd29, %r53;
	mul.lo.s64 	%rd30, %rd13, %rd29;
	add.s64 	%rd31, %rd30, %rd50;
	cvt.s64.s32 	%rd50, %rd31;
	setp.lt.s32	%p5, %r35, 5;
	@%p5 bra 	BB1_9;

	mul.hi.u32 	%r55, %r24, %r5;
	add.s32 	%r56, %r55, %r5;
	shr.u32 	%r57, %r56, %r25;
	mul.lo.s32 	%r58, %r57, %r23;
	sub.s32 	%r6, %r5, %r58;
	cvt.u64.u32	%rd32, %r57;
	mul.lo.s64 	%rd33, %rd14, %rd32;
	add.s64 	%rd34, %rd33, %rd50;
	cvt.s64.s32 	%rd50, %rd34;
	setp.lt.s32	%p6, %r35, 6;
	@%p6 bra 	BB1_9;

	mul.hi.u32 	%r59, %r27, %r6;
	add.s32 	%r60, %r59, %r6;
	shr.u32 	%r61, %r60, %r28;
	mul.lo.s32 	%r62, %r61, %r26;
	sub.s32 	%r7, %r6, %r62;
	cvt.u64.u32	%rd35, %r61;
	mul.lo.s64 	%rd36, %rd15, %rd35;
	add.s64 	%rd37, %rd36, %rd50;
	cvt.s64.s32 	%rd50, %rd37;
	setp.lt.s32	%p7, %r35, 7;
	@%p7 bra 	BB1_9;

	mul.hi.u32 	%r63, %r30, %r7;
	add.s32 	%r64, %r63, %r7;
	shr.u32 	%r65, %r64, %r31;
	mul.lo.s32 	%r66, %r65, %r29;
	sub.s32 	%r8, %r7, %r66;
	cvt.u64.u32	%rd38, %r65;
	mul.lo.s64 	%rd39, %rd16, %rd38;
	add.s64 	%rd40, %rd39, %rd50;
	cvt.s64.s32 	%rd50, %rd40;
	setp.lt.s32	%p8, %r35, 8;
	@%p8 bra 	BB1_9;

	mul.hi.u32 	%r67, %r33, %r8;
	add.s32 	%r68, %r67, %r8;
	shr.u32 	%r69, %r68, %r34;
	cvt.u64.u32	%rd41, %r69;
	mul.lo.s64 	%rd42, %rd17, %rd41;
	add.s64 	%rd43, %rd42, %rd50;
	cvt.s64.s32 	%rd50, %rd43;

BB1_9:
	cvta.to.global.u64 	%rd44, %rd19;
	cvta.to.global.u64 	%rd45, %rd18;
	shl.b64 	%rd46, %rd50, 2;
	add.s64 	%rd47, %rd45, %rd46;
	ld.global.f32 	%f1, [%rd47];
	mul.wide.s32 	%rd48, %r1, 4;
	add.s64 	%rd49, %rd44, %rd48;
	st.global.f32 	[%rd49], %f1;
	ret;
}

**- PTX code for _TransposeKernel with old fast_divmod implementation.**  

// .globl	_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii
.visible .entry _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii(
	.param .align 8 .b8 _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0[72],
	.param .u64 _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_1,
	.param .align 4 .b8 _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2[132],
	.param .u64 _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_3,
	.param .u32 _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_4,
	.param .u32 _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_5
)
{
	.reg .pred 	%p<33>;
	.reg .f32 	%f<2>;
	.reg .b32 	%r<164>;
	.reg .b64 	%rd<53>;


	ld.param.u64 	%rd18, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+64];
	ld.param.u64 	%rd17, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+56];
	ld.param.u64 	%rd16, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+48];
	ld.param.u64 	%rd15, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+40];
	ld.param.u64 	%rd14, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+32];
	ld.param.u64 	%rd13, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+24];
	ld.param.u64 	%rd12, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+16];
	ld.param.u64 	%rd11, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_0+8];
	ld.param.u64 	%rd19, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_1];
	mov.b64	%rd22, _Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2;
	ld.param.u64 	%rd20, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_3];
	ld.param.u32 	%r74, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_4];
	mov.u64 	%rd1, %rd22;
	ld.param.u32 	%r1, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+4];
	ld.param.u32 	%r2, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+20];
	ld.param.u32 	%r3, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+36];
	ld.param.u32 	%r4, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+52];
	ld.param.u32 	%r5, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+68];
	ld.param.u32 	%r6, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+84];
	ld.param.u32 	%r7, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+100];
	ld.param.u32 	%r8, [_Z15TransposeKernel6TArrayIlLi8EEPKfS_I11fast_divmodLi8EEPfii_param_2+124];
	mov.u64 	%rd52, 0;
	setp.lt.s32	%p1, %r74, 1;
	@%p1 bra 	BB1_48;

	ld.param.u32 	%r9, [%rd1+8];
	ld.param.u32 	%r10, [%rd1+12];
	ld.param.u32 	%r11, [%rd1+16];
	ld.param.u32 	%r12, [%rd1+24];
	ld.param.u32 	%r13, [%rd1+28];
	ld.param.u32 	%r14, [%rd1+32];
	ld.param.u32 	%r15, [%rd1+40];
	ld.param.u32 	%r16, [%rd1+44];
	ld.param.u32 	%r17, [%rd1+48];
	ld.param.u32 	%r18, [%rd1+56];
	ld.param.u32 	%r19, [%rd1+60];
	ld.param.u32 	%r20, [%rd1+64];
	ld.param.u32 	%r21, [%rd1+72];
	ld.param.u32 	%r22, [%rd1+76];
	ld.param.u32 	%r23, [%rd1+80];
	ld.param.u32 	%r24, [%rd1+88];
	ld.param.u32 	%r25, [%rd1+92];
	ld.param.u32 	%r26, [%rd1+96];
	ld.param.u32 	%r27, [%rd1+104];
	ld.param.u32 	%r28, [%rd1+108];
	ld.param.u32 	%r29, [%rd1+112];
	ld.param.u32 	%r30, [%rd1+116];
	ld.param.u32 	%r31, [%rd1+120];
	ld.param.u32 	%r32, [%rd1+128];
	mov.u32 	%r76, %ctaid.x;
	mov.u32 	%r77, %ntid.x;
	mov.u32 	%r78, %tid.x;
	mad.lo.s32 	%r149, %r76, %r77, %r78;
	mov.u32 	%r38, 0;
	setp.eq.s32	%p2, %r1, 1;
	@%p2 bra 	BB1_5;

	setp.ne.s32	%p3, %r1, -1;
	@%p3 bra 	BB1_4;

	mad.lo.s32 	%r83, %r76, %r77, %r78;
	neg.s32 	%r149, %r83;
	bra.uni 	BB1_5;

BB1_4:
	mad.lo.s32 	%r87, %r76, %r77, %r78;
	mul.hi.s32 	%r88, %r9, %r87;
	mad.lo.s32 	%r89, %r11, %r87, %r88;
	shr.s32 	%r90, %r89, %r10;
	shr.u32 	%r91, %r89, 31;
	add.s32 	%r92, %r91, %r90;
	setp.gt.s32	%p4, %r10, -1;
	selp.b32	%r149, %r92, %r89, %p4;
	mul.lo.s32 	%r93, %r1, %r149;
	sub.s32 	%r38, %r87, %r93;

BB1_5:
	cvt.u64.u32	%rd23, %r149;
	mul.lo.s64 	%rd24, %rd11, %rd23;
	cvt.s64.s32 	%rd52, %rd24;
	setp.lt.s32	%p5, %r74, 2;
	@%p5 bra 	BB1_48;

	mov.u32 	%r43, 0;
	setp.eq.s32	%p6, %r2, 1;
	@%p6 bra 	BB1_7;
	bra.uni 	BB1_8;

BB1_7:
	mov.u32 	%r151, %r38;
	bra.uni 	BB1_11;

BB1_8:
	setp.ne.s32	%p7, %r2, -1;
	@%p7 bra 	BB1_10;

	neg.s32 	%r151, %r38;
	bra.uni 	BB1_11;

BB1_10:
	mul.hi.s32 	%r96, %r12, %r38;
	mad.lo.s32 	%r97, %r14, %r38, %r96;
	shr.s32 	%r98, %r97, %r13;
	shr.u32 	%r99, %r97, 31;
	add.s32 	%r100, %r99, %r98;
	setp.gt.s32	%p8, %r13, -1;
	selp.b32	%r151, %r100, %r97, %p8;
	mul.lo.s32 	%r101, %r2, %r151;
	sub.s32 	%r43, %r38, %r101;

BB1_11:
	cvt.u64.u32	%rd25, %r151;
	mul.lo.s64 	%rd26, %rd12, %rd25;
	add.s64 	%rd27, %rd26, %rd52;
	cvt.s64.s32 	%rd52, %rd27;
	setp.lt.s32	%p9, %r74, 3;
	@%p9 bra 	BB1_48;

	mov.u32 	%r48, 0;
	setp.eq.s32	%p10, %r3, 1;
	@%p10 bra 	BB1_13;
	bra.uni 	BB1_14;

BB1_13:
	mov.u32 	%r153, %r43;
	bra.uni 	BB1_17;

BB1_14:
	setp.ne.s32	%p11, %r3, -1;
	@%p11 bra 	BB1_16;

	neg.s32 	%r153, %r43;
	bra.uni 	BB1_17;

BB1_16:
	mul.hi.s32 	%r104, %r15, %r43;
	mad.lo.s32 	%r105, %r17, %r43, %r104;
	shr.s32 	%r106, %r105, %r16;
	shr.u32 	%r107, %r105, 31;
	add.s32 	%r108, %r107, %r106;
	setp.gt.s32	%p12, %r16, -1;
	selp.b32	%r153, %r108, %r105, %p12;
	mul.lo.s32 	%r109, %r3, %r153;
	sub.s32 	%r48, %r43, %r109;

BB1_17:
	cvt.u64.u32	%rd28, %r153;
	mul.lo.s64 	%rd29, %rd13, %rd28;
	add.s64 	%rd30, %rd29, %rd52;
	cvt.s64.s32 	%rd52, %rd30;
	setp.lt.s32	%p13, %r74, 4;
	@%p13 bra 	BB1_48;

	mov.u32 	%r53, 0;
	setp.eq.s32	%p14, %r4, 1;
	@%p14 bra 	BB1_19;
	bra.uni 	BB1_20;

BB1_19:
	mov.u32 	%r155, %r48;
	bra.uni 	BB1_23;

BB1_20:
	setp.ne.s32	%p15, %r4, -1;
	@%p15 bra 	BB1_22;

	neg.s32 	%r155, %r48;
	bra.uni 	BB1_23;

BB1_22:
	mul.hi.s32 	%r112, %r18, %r48;
	mad.lo.s32 	%r113, %r20, %r48, %r112;
	shr.s32 	%r114, %r113, %r19;
	shr.u32 	%r115, %r113, 31;
	add.s32 	%r116, %r115, %r114;
	setp.gt.s32	%p16, %r19, -1;
	selp.b32	%r155, %r116, %r113, %p16;
	mul.lo.s32 	%r117, %r4, %r155;
	sub.s32 	%r53, %r48, %r117;

BB1_23:
	cvt.u64.u32	%rd31, %r155;
	mul.lo.s64 	%rd32, %rd14, %rd31;
	add.s64 	%rd33, %rd32, %rd52;
	cvt.s64.s32 	%rd52, %rd33;
	setp.lt.s32	%p17, %r74, 5;
	@%p17 bra 	BB1_48;

	mov.u32 	%r58, 0;
	setp.eq.s32	%p18, %r5, 1;
	@%p18 bra 	BB1_25;
	bra.uni 	BB1_26;

BB1_25:
	mov.u32 	%r157, %r53;
	bra.uni 	BB1_29;

BB1_26:
	setp.ne.s32	%p19, %r5, -1;
	@%p19 bra 	BB1_28;

	neg.s32 	%r157, %r53;
	bra.uni 	BB1_29;

BB1_28:
	mul.hi.s32 	%r120, %r21, %r53;
	mad.lo.s32 	%r121, %r23, %r53, %r120;
	shr.s32 	%r122, %r121, %r22;
	shr.u32 	%r123, %r121, 31;
	add.s32 	%r124, %r123, %r122;
	setp.gt.s32	%p20, %r22, -1;
	selp.b32	%r157, %r124, %r121, %p20;
	mul.lo.s32 	%r125, %r5, %r157;
	sub.s32 	%r58, %r53, %r125;

BB1_29:
	cvt.u64.u32	%rd34, %r157;
	mul.lo.s64 	%rd35, %rd15, %rd34;
	add.s64 	%rd36, %rd35, %rd52;
	cvt.s64.s32 	%rd52, %rd36;
	setp.lt.s32	%p21, %r74, 6;
	@%p21 bra 	BB1_48;

	mov.u32 	%r63, 0;
	setp.eq.s32	%p22, %r6, 1;
	@%p22 bra 	BB1_31;
	bra.uni 	BB1_32;

BB1_31:
	mov.u32 	%r159, %r58;
	bra.uni 	BB1_35;

BB1_32:
	setp.ne.s32	%p23, %r6, -1;
	@%p23 bra 	BB1_34;

	neg.s32 	%r159, %r58;
	bra.uni 	BB1_35;

BB1_34:
	mul.hi.s32 	%r128, %r24, %r58;
	mad.lo.s32 	%r129, %r26, %r58, %r128;
	shr.s32 	%r130, %r129, %r25;
	shr.u32 	%r131, %r129, 31;
	add.s32 	%r132, %r131, %r130;
	setp.gt.s32	%p24, %r25, -1;
	selp.b32	%r159, %r132, %r129, %p24;
	mul.lo.s32 	%r133, %r6, %r159;
	sub.s32 	%r63, %r58, %r133;

BB1_35:
	cvt.u64.u32	%rd37, %r159;
	mul.lo.s64 	%rd38, %rd16, %rd37;
	add.s64 	%rd39, %rd38, %rd52;
	cvt.s64.s32 	%rd52, %rd39;
	setp.lt.s32	%p25, %r74, 7;
	@%p25 bra 	BB1_48;

	mov.u32 	%r68, 0;
	setp.eq.s32	%p26, %r7, 1;
	@%p26 bra 	BB1_37;
	bra.uni 	BB1_38;

BB1_37:
	mov.u32 	%r161, %r63;
	bra.uni 	BB1_41;

BB1_38:
	setp.ne.s32	%p27, %r7, -1;
	@%p27 bra 	BB1_40;

	neg.s32 	%r161, %r63;
	bra.uni 	BB1_41;

BB1_40:
	mul.hi.s32 	%r136, %r27, %r63;
	mad.lo.s32 	%r137, %r29, %r63, %r136;
	shr.s32 	%r138, %r137, %r28;
	shr.u32 	%r139, %r137, 31;
	add.s32 	%r140, %r139, %r138;
	setp.gt.s32	%p28, %r28, -1;
	selp.b32	%r161, %r140, %r137, %p28;
	mul.lo.s32 	%r141, %r7, %r161;
	sub.s32 	%r68, %r63, %r141;

BB1_41:
	cvt.u64.u32	%rd40, %r161;
	mul.lo.s64 	%rd41, %rd17, %rd40;
	add.s64 	%rd42, %rd41, %rd52;
	cvt.s64.s32 	%rd52, %rd42;
	setp.lt.s32	%p29, %r74, 8;
	@%p29 bra 	BB1_48;

	setp.eq.s32	%p30, %r30, 1;
	@%p30 bra 	BB1_47;

	setp.ne.s32	%p31, %r30, -1;
	@%p31 bra 	BB1_45;

	neg.s32 	%r68, %r68;
	bra.uni 	BB1_47;

BB1_45:
	mul.hi.s32 	%r142, %r31, %r68;
	mad.lo.s32 	%r68, %r32, %r68, %r142;
	setp.lt.s32	%p32, %r8, 0;
	@%p32 bra 	BB1_47;

	shr.s32 	%r143, %r68, %r8;
	shr.u32 	%r144, %r68, 31;
	add.s32 	%r68, %r144, %r143;

BB1_47:
	cvt.u64.u32	%rd43, %r68;
	mul.lo.s64 	%rd44, %rd18, %rd43;
	add.s64 	%rd45, %rd44, %rd52;
	cvt.s64.s32 	%rd52, %rd45;

BB1_48:
	cvta.to.global.u64 	%rd46, %rd19;
	shl.b64 	%rd47, %rd52, 2;
	add.s64 	%rd48, %rd46, %rd47;
	ld.global.f32 	%f1, [%rd48];
	mov.u32 	%r145, %ntid.x;
	mov.u32 	%r146, %ctaid.x;
	mov.u32 	%r147, %tid.x;
	mad.lo.s32 	%r148, %r146, %r145, %r147;
	cvta.to.global.u64 	%rd49, %rd20;
	mul.wide.s32 	%rd50, %r148, 4;
	add.s64 	%rd51, %rd49, %rd50;
	st.global.f32 	[%rd51], %f1;
	ret;
}