### PR TITLE
CalculateTotalInputSizes/CalculateTotalOutputSizes bug

### DIFF
--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -61,7 +61,7 @@ static void CalculateTotalOutputSizes(OpKernelContextInternal* op_kernel_context
   ORT_UNUSED_PARAMETER(node_name);
   for (auto i = 0; i < op_kernel_context->OutputCount(); i++) {
     const OrtValue* p_output = op_kernel_context->GetOutputMLValue(i);
-    if (p_output->IsTensor()) {
+    if (p_output != nullptr && p_output->IsTensor()) {
       const auto& tensor = p_output->Get<Tensor>();
       size_t tensor_size = tensor.SizeInBytes();
 #if defined(TRACE_EXECUTION)
@@ -89,7 +89,7 @@ static void CalculateTotalInputSizes(const OpKernelContextInternal* op_kernel_co
   const int input_count = op_kernel_context->InputCount();
   for (auto i = 0; i < input_count; i++) {
     const OrtValue* p_input = op_kernel_context->GetInputMLValue(i);
-    if (p_input->IsTensor()) {
+    if (p_input != nullptr && p_input->IsTensor()) {
       const OpKernelInfo& op_kernel_info = p_op_kernel->Info();
       const Tensor* p_tensor = nullptr;
       bool is_param = op_kernel_info.TryGetConstantInput(i, &p_tensor);
@@ -270,7 +270,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
 
     const std::string node_name_for_profiling = [&]() -> std::string {
       if (!is_profiler_enabled) return {};
-      // Derive something meaningful for profile traces and logs if node name field is blank in execution graph 
+      // Derive something meaningful for profile traces and logs if node name field is blank in execution graph
       return node.Name().empty() ? MakeString(node.OpType(), "_", node_index) : node.Name();
     }();
 


### PR DESCRIPTION
**Description**: When profiling is enabled, these two functions are called to calculate the total size of the input and output tensors. The routines don't handle nodes with missing optional input or output nodes.

**Motivation and Context**
I hit a crash when attempting to run a model using python where profiling was enabled by default. The model had LSTM nodes with unused edges. This fix the crash.
