### PR TITLE
Fix detection of protobuf with onnxruntime_PREFER_SYSTEM_LIB on Linux

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -376,7 +376,7 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/external)
 
 if(onnxruntime_PREFER_SYSTEM_LIB)
   set(protobuf_MODULE_COMPATIBLE ON)
-  find_package(protobuf)
+  find_package(Protobuf)
 endif()
 
 


### PR DESCRIPTION
**Description**: Describe your changes.

The CMake module is `FindProtobuf.cmake` [1]. Thus the name should be
capitalized so that protobuf can be found on case-sensitive file
systems.

[1] https://github.com/Kitware/CMake/blob/v3.17.3/Modules/FindProtobuf.cmake

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

I'm working on an unofficial package for Arch Linux called `python-onnxruntime` [1]. In general, files in Arch Linux packages link to system libraries and use system headers if possible. This PR is for protobuf, and patches for other libraries can be found in [1]. I will do some cleanups and propose other PRs in the future.

[1] https://aur.archlinux.org/cgit/aur.git/tree/?h=python-onnxruntime