### PR TITLE
optimize transpose CUDA kernel

### DIFF
--- a/onnxruntime/core/providers/cuda/math/einsum_utils/einsum_auxiliary_ops.cc
+++ b/onnxruntime/core/providers/cuda/math/einsum_utils/einsum_auxiliary_ops.cc
@@ -27,7 +27,8 @@ Status DataCopy(const Tensor& input, Tensor& output) {
 // CUDA EP specific Transpose helper
 Status Transpose(const std::vector<size_t>& permutation, const Tensor& input,
                  Tensor& output, const TensorShape* input_shape_override, void* einsum_cuda_assets) {
-  return cuda::Transpose::DoTranspose(static_cast<EinsumCudaAssets*>(einsum_cuda_assets)->cublas_handle_,
+  return cuda::Transpose::DoTranspose(static_cast<EinsumCudaAssets*>(einsum_cuda_assets)->cuda_ep_->GetDeviceProp(),
+                                      static_cast<EinsumCudaAssets*>(einsum_cuda_assets)->cublas_handle_,
                                       permutation, input, output, input_shape_override);
 }
 

--- a/onnxruntime/core/providers/cuda/tensor/transpose.cc
+++ b/onnxruntime/core/providers/cuda/tensor/transpose.cc
@@ -139,6 +139,9 @@ Status Transpose::DoTranspose(const cudaDeviceProp& prop,
       new_rank--;
     }
   }
+  new_permutations.resize(new_rank);
+  new_input_dims.resize(new_rank);
+  new_output_dims.resize(new_rank);
 
   TensorPitches new_input_strides(new_input_dims);
   TensorPitches new_output_strides(new_output_dims);

--- a/onnxruntime/core/providers/cuda/tensor/transpose.cc
+++ b/onnxruntime/core/providers/cuda/tensor/transpose.cc
@@ -98,20 +98,76 @@ Status Transpose::DoTranspose(const cublasHandle_t cublas_handle,
   const std::vector<int64_t>& output_dims = output.Shape().GetDims();
 
   auto rank = static_cast<int32_t>(input_dims.size());
-  TensorPitches original_input_strides(input_dims);
-  TensorPitches original_output_strides(output_dims);
 
-  TArray<int64_t> input_strides(rank);
-  for (auto i = 0; i < rank; i++) {
-    input_strides[i] = original_input_strides[permutations[i]];
-  }
-  TArray<fast_divmod> output_strides(rank);
-  for (auto i = 0; i < rank; i++) {
-    output_strides[i] = fast_divmod(gsl::narrow_cast<int>(original_output_strides[i]));
+  // flatten some continguous dimensions
+  auto new_rank = rank;
+  std::vector<size_t> new_permutations(permutations);
+  std::vector<int64_t> new_input_dims(input_dims);
+  std::vector<int64_t> new_output_dims(output_dims);
+  // for (auto i = rank - 1; i > 0; i--) {
+  //   auto curr = permutations[i];
+  //   auto prev = permutations[i - 1];
+  //   if (prev + 1 == curr) {
+  //     // all dims bigger than curr need to be reduced by 1 due to the merging.
+  //     for (auto j = 0; j < new_rank; j++) {
+  //       if (new_permutations[j] > curr) {
+  //         new_permutations[j] -= 1;
+  //       }
+  //     }
+  //     for (auto j = i+1; j < new_rank; j++) {
+  //       new_permutations[j-1] = new_permutations[j];
+  //     }
+
+  //     new_input_dims[prev] *= new_input_dims[curr];
+  //     new_input_dims[curr] = 1;
+  //     for (auto j = curr+1; j < new_rank; j++) {
+  //       new_input_dims[j-1] = new_input_dims[j];
+  //     }
+
+  //     new_output_dims[i-1] *= new_output_dims[i];
+  //     new_output_dims[i] = 1;
+  //     for (auto j = i+1; j < new_rank; j++) {
+  //       new_output_dims[j-1] = new_output_dims[j];
+  //     }
+  //     new_rank--;
+  //   }
+  // }
+
+  TensorPitches new_input_strides(new_input_dims);
+  TensorPitches new_output_strides(new_output_dims);
+
+  // Optimize for 4D tensor permutation
+  TArray<int64_t> input_shape(new_input_dims);
+  TArray<int64_t> tmp_input_strides(new_input_strides);
+
+  TArray<int64_t> tmp_output_strides(new_rank);
+  for (auto i = 0; i < new_rank; i++) {
+    tmp_output_strides[i] = new_output_strides[new_permutations[i]];
   }
 
   size_t element_size = input.DataType()->Size();
-  auto status = TransposeImpl(element_size, rank, input_strides, input.DataRaw(),
+  // last dim won't be changed.
+  if (rank == 4 && permutations[3] == 3) {
+    // each cuda thread will process the number of elements = 4 * sizeof(float) / element_size
+    int64_t num_elements = input_shape[2] * input_shape[3] / (4 * sizeof(float) / element_size);
+    // num_elements must be aligned with warp size: 32
+    if (num_elements <= kernel.GetDeviceProp().maxThreadsPerBlock && (num_elements & 0x1F) == 0) {
+      return Transpose4DImpl(element_size, input_shape, tmp_input_strides, input.DataRaw(),
+                             tmp_output_strides, output.MutableDataRaw(), output.Shape().Size());
+    }
+  }
+
+  TArray<int64_t> input_strides(new_rank);
+  for (auto i = 0; i < new_rank; i++) {
+    input_strides[i] = new_input_strides[new_permutations[i]];
+  }
+
+  TArray<fast_divmod> output_strides(new_rank);
+  for (auto i = 0; i < new_rank; i++) {
+    output_strides[i] = fast_divmod(gsl::narrow_cast<int>(new_output_strides[i]));
+  }
+
+  auto status = TransposeImpl(element_size, new_rank, input_strides, input.DataRaw(),
                               output_strides, output.MutableDataRaw(), output.Shape().Size());
 
   return status;

--- a/onnxruntime/core/providers/cuda/tensor/transpose.cc
+++ b/onnxruntime/core/providers/cuda/tensor/transpose.cc
@@ -104,59 +104,58 @@ Status Transpose::DoTranspose(const cublasHandle_t cublas_handle,
   std::vector<size_t> new_permutations(permutations);
   std::vector<int64_t> new_input_dims(input_dims);
   std::vector<int64_t> new_output_dims(output_dims);
-  // for (auto i = rank - 1; i > 0; i--) {
-  //   auto curr = permutations[i];
-  //   auto prev = permutations[i - 1];
-  //   if (prev + 1 == curr) {
-  //     // all dims bigger than curr need to be reduced by 1 due to the merging.
-  //     for (auto j = 0; j < new_rank; j++) {
-  //       if (new_permutations[j] > curr) {
-  //         new_permutations[j] -= 1;
-  //       }
-  //     }
-  //     for (auto j = i+1; j < new_rank; j++) {
-  //       new_permutations[j-1] = new_permutations[j];
-  //     }
+  for (auto i = rank - 1; i > 0; i--) {
+    auto curr = permutations[i];
+    auto prev = permutations[i - 1];
+    if (prev + 1 == curr) {
+      // all dims bigger than curr need to be reduced by 1 due to the merging.
+      for (auto j = 0; j < new_rank; j++) {
+        if (new_permutations[j] > curr) {
+          new_permutations[j] -= 1;
+        }
+      }
+      for (auto j = i+1; j < new_rank; j++) {
+        new_permutations[j-1] = new_permutations[j];
+      }
 
-  //     new_input_dims[prev] *= new_input_dims[curr];
-  //     new_input_dims[curr] = 1;
-  //     for (auto j = curr+1; j < new_rank; j++) {
-  //       new_input_dims[j-1] = new_input_dims[j];
-  //     }
+      new_input_dims[prev] *= new_input_dims[curr];
+      new_input_dims[curr] = 1;
+      for (auto j = curr+1; j < new_rank; j++) {
+        new_input_dims[j-1] = new_input_dims[j];
+      }
+      new_input_dims[new_rank-1] = 1;
 
-  //     new_output_dims[i-1] *= new_output_dims[i];
-  //     new_output_dims[i] = 1;
-  //     for (auto j = i+1; j < new_rank; j++) {
-  //       new_output_dims[j-1] = new_output_dims[j];
-  //     }
-  //     new_rank--;
-  //   }
-  // }
+      new_output_dims[i-1] *= new_output_dims[i];
+      new_output_dims[i] = 1;
+      for (auto j = i+1; j < new_rank; j++) {
+        new_output_dims[j-1] = new_output_dims[j];
+      }
+      new_output_dims[new_rank-1] = 1;;
+      new_rank--;
+    }
+  }
 
   TensorPitches new_input_strides(new_input_dims);
   TensorPitches new_output_strides(new_output_dims);
 
-  // Optimize for 4D tensor permutation
+  // Optimize for 4D/3D tensor permutation
   TArray<int64_t> input_shape(new_input_dims);
   TArray<int64_t> tmp_input_strides(new_input_strides);
 
-  TArray<int64_t> tmp_output_strides(new_rank);
-  for (auto i = 0; i < new_rank; i++) {
-    tmp_output_strides[i] = new_output_strides[new_permutations[i]];
-  }
-
   size_t element_size = input.DataType()->Size();
-  // last dim won't be changed.
-  if (rank == 4 && permutations[3] == 3) {
-    // each cuda thread will process the number of elements = 4 * sizeof(float) / element_size
-    int64_t num_elements = input_shape[2] * input_shape[3] / (4 * sizeof(float) / element_size);
-    // num_elements must be aligned with warp size: 32
-    if (num_elements <= kernel.GetDeviceProp().maxThreadsPerBlock && (num_elements & 0x1F) == 0) {
-      return Transpose4DImpl(element_size, input_shape, tmp_input_strides, input.DataRaw(),
-                             tmp_output_strides, output.MutableDataRaw(), output.Shape().Size());
+  if (canDoTranspose4D(kernel.GetDeviceProp(), element_size, new_rank, new_input_dims, new_permutations)) {
+    TArray<int64_t> tmp_output_strides(new_rank);
+    for (auto i = 0; i < new_rank; i++) {
+      tmp_output_strides[i] = new_output_strides[new_permutations[i]];
     }
+    return Transpose4DImpl(element_size, input_shape, tmp_input_strides, input.DataRaw(),
+                           tmp_output_strides, output.MutableDataRaw(), output.Shape().Size());
+  } else if (canDoTranspose3D(new_rank, new_input_dims, new_permutations)) {
+    return Transpose3DImpl(element_size, input_shape, tmp_input_strides,
+                           input.DataRaw(), output.MutableDataRaw(), output.Shape().Size());
   }
 
+  // General cases
   TArray<int64_t> input_strides(new_rank);
   for (auto i = 0; i < new_rank; i++) {
     input_strides[i] = new_input_strides[new_permutations[i]];

--- a/onnxruntime/core/providers/cuda/tensor/transpose.h
+++ b/onnxruntime/core/providers/cuda/tensor/transpose.h
@@ -23,7 +23,8 @@ class Transpose final : public CudaKernel, public TransposeBase {
                             const std::vector<size_t>& permutations, const Tensor& input, Tensor& output);
 
   //  `input_shape_override` (if provided) overrides the shape of `input` for compute purposes
-  static Status DoTranspose(const cublasHandle_t cublas_handle,
+  static Status DoTranspose(const cudaDeviceProp& prop,
+                            const cublasHandle_t cublas_handle,
                             const std::vector<size_t>& permutations,
                             const Tensor& input, Tensor& output, const TensorShape* input_shape_override = nullptr);
 };

--- a/onnxruntime/core/providers/cuda/tensor/transpose_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/transpose_impl.cu
@@ -10,7 +10,7 @@ namespace cuda {
 constexpr int TILE_DIM = 16;
 
 template <typename T>
-__global__ void _Transpose3DKernel(const TArray<int64_t> input_shape,
+__global__ void Transpose3DKernel(const TArray<int64_t> input_shape,
                                    const TArray<int64_t> input_strides,
                                    const T* input_data, T* output_data) {
   __shared__ T tile[TILE_DIM * (TILE_DIM+1)];
@@ -48,25 +48,25 @@ Status Transpose3DImpl(size_t element_size,
 
   switch (element_size) {
     case sizeof(int8_t):
-      _Transpose3DKernel<int8_t><<<grid_size, block_size, 0>>>(
+      Transpose3DKernel<int8_t><<<grid_size, block_size, 0>>>(
           input_shape, input_strides,
           reinterpret_cast<const ToCudaType<int8_t>::MappedType*>(input_data),
           reinterpret_cast<ToCudaType<int8_t>::MappedType*>(output_data));
       break;
     case sizeof(int16_t):
-      _Transpose3DKernel<int16_t><<<grid_size, block_size, 0>>>(
+      Transpose3DKernel<int16_t><<<grid_size, block_size, 0>>>(
           input_shape, input_strides,
           reinterpret_cast<const ToCudaType<int16_t>::MappedType*>(input_data),
           reinterpret_cast<ToCudaType<int16_t>::MappedType*>(output_data));
       break;
     case sizeof(int32_t):
-      _Transpose3DKernel<int32_t><<<grid_size, block_size, 0>>>(
+      Transpose3DKernel<int32_t><<<grid_size, block_size, 0>>>(
           input_shape, input_strides,
           reinterpret_cast<const ToCudaType<int32_t>::MappedType*>(input_data),
           reinterpret_cast<ToCudaType<int32_t>::MappedType*>(output_data));
       break;
     case sizeof(int64_t):
-      _Transpose3DKernel<int64_t><<<grid_size, block_size, 0>>>(
+      Transpose3DKernel<int64_t><<<grid_size, block_size, 0>>>(
           input_shape, input_strides,
           reinterpret_cast<const ToCudaType<int64_t>::MappedType*>(input_data),
           reinterpret_cast<ToCudaType<int64_t>::MappedType*>(output_data));
@@ -80,7 +80,7 @@ Status Transpose3DImpl(size_t element_size,
 }
 
 template <typename T, int element_size>
-__global__ void _Transpose4DKernel(const TArray<int64_t> input_strides, const T* input_data,
+__global__ void Transpose4DKernel(const TArray<int64_t> input_strides, const T* input_data,
                                    const TArray<int64_t> output_strides, T* output_data,
                                    CUDA_LONG N) {
   // output coordinates will be: blockIdx.y, blockIdx.x, threadIdx.y, threadIdx.x
@@ -136,22 +136,22 @@ Status Transpose4DImpl(size_t element_size, const TArray<int64_t>& input_shape, 
 
   switch (element_size) {
     case sizeof(int8_t):
-      _Transpose4DKernel<int8_t, sizeof(int8_t)><<<grid_size, block_size, 0>>>(
+      Transpose4DKernel<int8_t, sizeof(int8_t)><<<grid_size, block_size, 0>>>(
           input_strides, reinterpret_cast<const ToCudaType<int8_t>::MappedType*>(input_data),
           output_strides, reinterpret_cast<ToCudaType<int8_t>::MappedType*>(output_data), N/num_elements_per_thread);
       break;
     case sizeof(int16_t):
-      _Transpose4DKernel<int16_t, sizeof(int16_t)><<<grid_size, block_size, 0>>>(
+      Transpose4DKernel<int16_t, sizeof(int16_t)><<<grid_size, block_size, 0>>>(
           input_strides, reinterpret_cast<const ToCudaType<int16_t>::MappedType*>(input_data),
           output_strides, reinterpret_cast<ToCudaType<int16_t>::MappedType*>(output_data), N/num_elements_per_thread);
       break;
     case sizeof(int32_t):
-      _Transpose4DKernel<int32_t, sizeof(int32_t)><<<grid_size, block_size, 0>>>(
+      Transpose4DKernel<int32_t, sizeof(int32_t)><<<grid_size, block_size, 0>>>(
           input_strides, reinterpret_cast<const ToCudaType<int32_t>::MappedType*>(input_data),
           output_strides, reinterpret_cast<ToCudaType<int32_t>::MappedType*>(output_data), N/num_elements_per_thread);
       break;
     case sizeof(int64_t):
-      _Transpose4DKernel<int64_t, sizeof(int64_t)><<<grid_size, block_size, 0>>>(
+      Transpose4DKernel<int64_t, sizeof(int64_t)><<<grid_size, block_size, 0>>>(
           input_strides, reinterpret_cast<const ToCudaType<int64_t>::MappedType*>(input_data),
           output_strides, reinterpret_cast<ToCudaType<int64_t>::MappedType*>(output_data), N/num_elements_per_thread);
       break;

--- a/onnxruntime/core/providers/cuda/tensor/transpose_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/transpose_impl.cu
@@ -112,6 +112,7 @@ bool canDoTranspose4D(const cudaDeviceProp& prop,
   int64_t num_threads_per_block = input_dims[2] * input_dims[3] / (4 * sizeof(int) / element_size);
   if (rank == 4 && permutations[3] == 3 &&
       num_threads_per_block <= prop.maxThreadsPerBlock &&
+      num_threads_per_block >= prop.warpSize &&
       // num_threads_per_block must be aligned with warp size: 32
       ((num_threads_per_block & (prop.warpSize - 1)) == 0)) {
     return true;

--- a/onnxruntime/core/providers/cuda/tensor/transpose_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/transpose_impl.cu
@@ -7,6 +7,70 @@
 namespace onnxruntime {
 namespace cuda {
 
+template <typename T, int element_size>
+__global__ void _Transpose4DKernel(const TArray<int64_t> input_strides, const T* input_data,
+                                   const TArray<int64_t> output_strides, T* output_data, CUDA_LONG N) {
+  // output coordinates will be: blockIdx.y, blockIdx.x, threadIdx.y, threadIdx.x
+  CUDA_LONG input_index = (blockIdx.y * input_strides[0] +
+                           blockIdx.x * input_strides[1] +
+                           threadIdx.y * input_strides[2]) / (4 * 4 / element_size) +
+                           threadIdx.x * input_strides[3];
+
+  CUDA_LONG output_index = (blockIdx.y * output_strides[0] +
+                            blockIdx.x * output_strides[1] +
+                            threadIdx.y * output_strides[2]) / (4 * 4 / element_size) +
+                            threadIdx.x * output_strides[3];
+
+  const int4* v_input = reinterpret_cast<const int4*>(input_data);
+  int4* v_output = reinterpret_cast<int4*>(output_data);
+
+  if (input_index < N && output_index < N) {
+    v_output[output_index] = v_input[input_index];
+  }
+}
+
+Status Transpose4DImpl(size_t element_size, const TArray<int64_t>& input_shape, const TArray<int64_t>& input_strides, const void* input_data,
+                       const TArray<int64_t>& output_strides, void* output_data, int64_t N) {
+  dim3 block_size(input_shape[3], input_shape[2]);
+  dim3 grid_size(input_shape[1], input_shape[0]);
+
+  switch (element_size) {
+    case sizeof(int8_t):
+      block_size.x = block_size.x / (4 * 4 / sizeof(int8_t));
+      N /= (4 * 4 / sizeof(int8_t));
+      _Transpose4DKernel<int8_t, sizeof(int8_t)><<<grid_size, block_size, 0>>>(
+          input_strides, reinterpret_cast<const ToCudaType<int8_t>::MappedType*>(input_data),
+          output_strides, reinterpret_cast<ToCudaType<int8_t>::MappedType*>(output_data), N);
+      break;
+    case sizeof(int16_t):
+      block_size.x = block_size.x / (4 * 4 / sizeof(int16_t));
+      N /= (4 * 4 / sizeof(int16_t));
+      _Transpose4DKernel<int16_t, sizeof(int16_t)><<<grid_size, block_size, 0>>>(
+          input_strides, reinterpret_cast<const int16_t*>(input_data),
+          output_strides, reinterpret_cast<int16_t*>(output_data), N);
+      break;
+    case sizeof(int32_t):
+      block_size.x = block_size.x / (4 * 4 / sizeof(int32_t));
+      N /= (4 * 4 / sizeof(int32_t));
+      _Transpose4DKernel<int32_t, sizeof(int32_t)><<<grid_size, block_size, 0>>>(
+          input_strides, reinterpret_cast<const ToCudaType<int32_t>::MappedType*>(input_data),
+          output_strides, reinterpret_cast<ToCudaType<int32_t>::MappedType*>(output_data), N);
+      break;
+    case sizeof(int64_t):
+      block_size.x = block_size.x / (4 * 4 / sizeof(int64_t));
+      N /= (4 * 4 / sizeof(int64_t));
+      _Transpose4DKernel<int64_t, sizeof(int64_t)><<<grid_size, block_size, 0>>>(
+          input_strides, reinterpret_cast<const ToCudaType<int64_t>::MappedType*>(input_data),
+          output_strides, reinterpret_cast<ToCudaType<int64_t>::MappedType*>(output_data), N);
+      break;
+    default:
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Type not supported for transpose on CUDA. Element size was ",
+                              element_size);
+  }
+
+  return Status::OK();
+}
+
 template <typename T>
 __global__ void _TransposeKernel(int32_t shape_rank, const TArray<int64_t> input_strides,
                                  const T* input_data, const TArray<fast_divmod> output_strides, T* output_data, CUDA_LONG N) {

--- a/onnxruntime/core/providers/cuda/tensor/transpose_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/transpose_impl.cu
@@ -7,8 +7,8 @@
 namespace onnxruntime {
 namespace cuda {
 
-constexpr int TILE_DIM = 32;
-constexpr int BLOCK_ROWS = 8;
+constexpr int TILE_DIM = GPU_WARP_SIZE;
+constexpr int BLOCK_ROWS = TILE_DIM / GridDim::maxElementsPerThread;
 
 template <typename T>
 __global__ void _Transpose3DKernel(const TArray<int64_t> input_shape,
@@ -19,24 +19,27 @@ __global__ void _Transpose3DKernel(const TArray<int64_t> input_shape,
   int x = blockIdx.x * TILE_DIM + threadIdx.x;
   int y = blockIdx.y * TILE_DIM + threadIdx.y;
 
-  for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS)
+  for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS) {
     tile[(threadIdx.y+j) * TILE_DIM + threadIdx.x] = input_data[blockIdx.z * input_strides[0] + (y+j)*input_shape[2] + x];
-
+  }
   __syncthreads();
 
   x = blockIdx.y * TILE_DIM + threadIdx.x;
   y = blockIdx.x * TILE_DIM + threadIdx.y;
 
-  for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS)
+  for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS) {
     output_data[blockIdx.z * input_strides[0] + (y+j)*input_shape[1] + x] = tile[threadIdx.x * TILE_DIM + threadIdx.y + j];
+  }
 }
 
 bool canDoTranspose3D(int32_t rank,
                       const std::vector<int64_t>& input_dims,
                       const std::vector<size_t>& permutations) {
   if (rank == 3 &&
-      input_dims[1] % TILE_DIM == 0 && input_dims[2] % TILE_DIM == 0 &&
-      permutations[1] == 2 && permutations[2] == 1) {
+      // permutation is done in the last two dimensions.
+      permutations[rank-2] == (rank-1) && permutations[rank-1] == (rank-2) &&
+      // the last two dimensions are aligned with TILE_DIM.
+      input_dims[rank-2] % TILE_DIM == 0 && input_dims[rank-1] % TILE_DIM == 0) {
     return true;
   }
   return false;
@@ -58,8 +61,8 @@ Status Transpose3DImpl(size_t element_size,
     case sizeof(int16_t):
       _Transpose3DKernel<int16_t><<<grid_size, block_size, 0>>>(
           input_shape, input_strides,
-          reinterpret_cast<const int16_t*>(input_data),
-          reinterpret_cast<int16_t*>(output_data));
+          reinterpret_cast<const ToCudaType<int16_t>::MappedType*>(input_data),
+          reinterpret_cast<ToCudaType<int16_t>::MappedType*>(output_data));
       break;
     case sizeof(int32_t):
       _Transpose3DKernel<int32_t><<<grid_size, block_size, 0>>>(
@@ -83,16 +86,17 @@ Status Transpose3DImpl(size_t element_size,
 
 template <typename T, int element_size>
 __global__ void _Transpose4DKernel(const TArray<int64_t> input_strides, const T* input_data,
-                                   const TArray<int64_t> output_strides, T* output_data, CUDA_LONG N) {
+                                   const TArray<int64_t> output_strides, T* output_data,
+                                   CUDA_LONG N) {
   // output coordinates will be: blockIdx.y, blockIdx.x, threadIdx.y, threadIdx.x
   CUDA_LONG input_index = (blockIdx.y * input_strides[0] +
                            blockIdx.x * input_strides[1] +
-                           threadIdx.y * input_strides[2]) / (4 * 4 / element_size) +
+                           threadIdx.y * input_strides[2]) / (4 * sizeof(int) / element_size) +
                            threadIdx.x * input_strides[3];
 
   CUDA_LONG output_index = (blockIdx.y * output_strides[0] +
                             blockIdx.x * output_strides[1] +
-                            threadIdx.y * output_strides[2]) / (4 * 4 / element_size) +
+                            threadIdx.y * output_strides[2]) / (4 * sizeof(int) / element_size) +
                             threadIdx.x * output_strides[3];
 
   const int4* v_input = reinterpret_cast<const int4*>(input_data);
@@ -108,51 +112,53 @@ bool canDoTranspose4D(const cudaDeviceProp& prop,
                       int32_t rank,
                       const std::vector<int64_t>& input_dims,
                       const std::vector<size_t>& permutations) {
-  // In Tranpose4D, vector of int4 will be used.
-  int64_t num_threads_per_block = input_dims[2] * input_dims[3] / (4 * sizeof(int) / element_size);
-  if (rank == 4 && permutations[3] == 3 &&
-      num_threads_per_block <= prop.maxThreadsPerBlock &&
-      num_threads_per_block >= prop.warpSize &&
-      // num_threads_per_block must be aligned with warp size: 32
-      ((num_threads_per_block & (prop.warpSize - 1)) == 0)) {
-    return true;
+  if (rank == 4 &&
+      // the permutations is not on the last dimension.
+      permutations[rank-1] == (rank - 1)) {
+
+    // The block size will be set based on the last two dimensions of 4D tensor.
+    // the number threads per block will be calculated as below.
+    int num_elements_per_thread = 4 * sizeof(int) / element_size; // int4 is used in the kernel to access data.
+    int64_t num_elements_in_last_two_dimensions = input_dims[rank-2] * input_dims[rank-1];
+    int64_t num_threads_per_block = num_elements_in_last_two_dimensions / num_elements_per_thread;
+
+    if (((num_elements_in_last_two_dimensions & (num_elements_per_thread - 1)) == 0) &&
+        num_threads_per_block <= prop.maxThreadsPerBlock &&
+        num_threads_per_block >= prop.warpSize &&
+        // num_threads_per_block must be aligned with warp size: 32
+        ((num_threads_per_block & (prop.warpSize - 1)) == 0)) {
+      return true;
+    }
   }
   return false;
 }
 
 Status Transpose4DImpl(size_t element_size, const TArray<int64_t>& input_shape, const TArray<int64_t>& input_strides, const void* input_data,
                        const TArray<int64_t>& output_strides, void* output_data, int64_t N) {
-  dim3 block_size(input_shape[3], input_shape[2]);
+  int num_elements_per_thread = 4 * sizeof(int) / element_size; // int4 is used in the kernel to access data.
+  dim3 block_size(input_shape[3]/num_elements_per_thread, input_shape[2]);
   dim3 grid_size(input_shape[1], input_shape[0]);
 
   switch (element_size) {
     case sizeof(int8_t):
-      block_size.x = block_size.x / (4 * 4 / sizeof(int8_t));
-      N /= (4 * 4 / sizeof(int8_t));
       _Transpose4DKernel<int8_t, sizeof(int8_t)><<<grid_size, block_size, 0>>>(
           input_strides, reinterpret_cast<const ToCudaType<int8_t>::MappedType*>(input_data),
-          output_strides, reinterpret_cast<ToCudaType<int8_t>::MappedType*>(output_data), N);
+          output_strides, reinterpret_cast<ToCudaType<int8_t>::MappedType*>(output_data), N/num_elements_per_thread);
       break;
     case sizeof(int16_t):
-      block_size.x = block_size.x / (4 * 4 / sizeof(int16_t));
-      N /= (4 * 4 / sizeof(int16_t));
       _Transpose4DKernel<int16_t, sizeof(int16_t)><<<grid_size, block_size, 0>>>(
-          input_strides, reinterpret_cast<const int16_t*>(input_data),
-          output_strides, reinterpret_cast<int16_t*>(output_data), N);
+          input_strides, reinterpret_cast<const ToCudaType<int16_t>::MappedType*>(input_data),
+          output_strides, reinterpret_cast<ToCudaType<int16_t>::MappedType*>(output_data), N/num_elements_per_thread);
       break;
     case sizeof(int32_t):
-      block_size.x = block_size.x / (4 * 4 / sizeof(int32_t));
-      N /= (4 * 4 / sizeof(int32_t));
       _Transpose4DKernel<int32_t, sizeof(int32_t)><<<grid_size, block_size, 0>>>(
           input_strides, reinterpret_cast<const ToCudaType<int32_t>::MappedType*>(input_data),
-          output_strides, reinterpret_cast<ToCudaType<int32_t>::MappedType*>(output_data), N);
+          output_strides, reinterpret_cast<ToCudaType<int32_t>::MappedType*>(output_data), N/num_elements_per_thread);
       break;
     case sizeof(int64_t):
-      block_size.x = block_size.x / (4 * 4 / sizeof(int64_t));
-      N /= (4 * 4 / sizeof(int64_t));
       _Transpose4DKernel<int64_t, sizeof(int64_t)><<<grid_size, block_size, 0>>>(
           input_strides, reinterpret_cast<const ToCudaType<int64_t>::MappedType*>(input_data),
-          output_strides, reinterpret_cast<ToCudaType<int64_t>::MappedType*>(output_data), N);
+          output_strides, reinterpret_cast<ToCudaType<int64_t>::MappedType*>(output_data), N/num_elements_per_thread);
       break;
     default:
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Type not supported for transpose on CUDA. Element size was ",

--- a/onnxruntime/core/providers/cuda/tensor/transpose_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/transpose_impl.cu
@@ -7,6 +7,80 @@
 namespace onnxruntime {
 namespace cuda {
 
+constexpr int TILE_DIM = 32;
+constexpr int BLOCK_ROWS = 8;
+
+template <typename T>
+__global__ void _Transpose3DKernel(const TArray<int64_t> input_shape,
+                                   const TArray<int64_t> input_strides,
+                                   const T* input_data, T* output_data) {
+  __shared__ T tile[TILE_DIM * (TILE_DIM+1)];
+
+  int x = blockIdx.x * TILE_DIM + threadIdx.x;
+  int y = blockIdx.y * TILE_DIM + threadIdx.y;
+
+  for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS)
+    tile[(threadIdx.y+j) * TILE_DIM + threadIdx.x] = input_data[blockIdx.z * input_strides[0] + (y+j)*input_shape[2] + x];
+
+  __syncthreads();
+
+  x = blockIdx.y * TILE_DIM + threadIdx.x;
+  y = blockIdx.x * TILE_DIM + threadIdx.y;
+
+  for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS)
+    output_data[blockIdx.z * input_strides[0] + (y+j)*input_shape[1] + x] = tile[threadIdx.x * TILE_DIM + threadIdx.y + j];
+}
+
+bool canDoTranspose3D(int32_t rank,
+                      const std::vector<int64_t>& input_dims,
+                      const std::vector<size_t>& permutations) {
+  if (rank == 3 &&
+      input_dims[1] % TILE_DIM == 0 && input_dims[2] % TILE_DIM == 0 &&
+      permutations[1] == 2 && permutations[2] == 1) {
+    return true;
+  }
+  return false;
+}
+
+Status Transpose3DImpl(size_t element_size,
+                       const TArray<int64_t>& input_shape, const TArray<int64_t>& input_strides,
+                       const void* input_data, void* output_data, int64_t N) {
+  dim3 block_size(TILE_DIM, BLOCK_ROWS);
+  dim3 grid_size(input_shape[2]/TILE_DIM, input_shape[1]/TILE_DIM, input_shape[0]);
+
+  switch (element_size) {
+    case sizeof(int8_t):
+      _Transpose3DKernel<int8_t><<<grid_size, block_size, 0>>>(
+          input_shape, input_strides,
+          reinterpret_cast<const ToCudaType<int8_t>::MappedType*>(input_data),
+          reinterpret_cast<ToCudaType<int8_t>::MappedType*>(output_data));
+      break;
+    case sizeof(int16_t):
+      _Transpose3DKernel<int16_t><<<grid_size, block_size, 0>>>(
+          input_shape, input_strides,
+          reinterpret_cast<const int16_t*>(input_data),
+          reinterpret_cast<int16_t*>(output_data));
+      break;
+    case sizeof(int32_t):
+      _Transpose3DKernel<int32_t><<<grid_size, block_size, 0>>>(
+          input_shape, input_strides,
+          reinterpret_cast<const ToCudaType<int32_t>::MappedType*>(input_data),
+          reinterpret_cast<ToCudaType<int32_t>::MappedType*>(output_data));
+      break;
+    case sizeof(int64_t):
+      _Transpose3DKernel<int64_t><<<grid_size, block_size, 0>>>(
+          input_shape, input_strides,
+          reinterpret_cast<const ToCudaType<int64_t>::MappedType*>(input_data),
+          reinterpret_cast<ToCudaType<int64_t>::MappedType*>(output_data));
+      break;
+    default:
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Type not supported for transpose on CUDA. Element size was ",
+                              element_size);
+  }
+
+  return Status::OK();
+}
+
 template <typename T, int element_size>
 __global__ void _Transpose4DKernel(const TArray<int64_t> input_strides, const T* input_data,
                                    const TArray<int64_t> output_strides, T* output_data, CUDA_LONG N) {
@@ -27,6 +101,22 @@ __global__ void _Transpose4DKernel(const TArray<int64_t> input_strides, const T*
   if (input_index < N && output_index < N) {
     v_output[output_index] = v_input[input_index];
   }
+}
+
+bool canDoTranspose4D(const cudaDeviceProp& prop,
+                      size_t element_size,
+                      int32_t rank,
+                      const std::vector<int64_t>& input_dims,
+                      const std::vector<size_t>& permutations) {
+  // In Tranpose4D, vector of int4 will be used.
+  int64_t num_threads_per_block = input_dims[2] * input_dims[3] / (4 * sizeof(int) / element_size);
+  if (rank == 4 && permutations[3] == 3 &&
+      num_threads_per_block <= prop.maxThreadsPerBlock &&
+      // num_threads_per_block must be aligned with warp size: 32
+      ((num_threads_per_block & (prop.warpSize - 1)) == 0)) {
+    return true;
+  }
+  return false;
 }
 
 Status Transpose4DImpl(size_t element_size, const TArray<int64_t>& input_shape, const TArray<int64_t>& input_strides, const void* input_data,

--- a/onnxruntime/core/providers/cuda/tensor/transpose_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/transpose_impl.h
@@ -8,8 +8,10 @@
 namespace onnxruntime {
 namespace cuda {
 
+Status Transpose4DImpl(size_t element_size, const TArray<int64_t>& input_shape, const TArray<int64_t>& input_strides, const void* input_data,
+                       const TArray<int64_t>& output_strides, void* output_data, int64_t N);
+
 Status TransposeImpl(size_t element_size, int32_t shape_rank, const TArray<int64_t>& input_strides,
                      const void* input_data, const TArray<fast_divmod>& fdm_output_strides, void* output_data, int64_t N);
-
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/tensor/transpose_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/transpose_impl.h
@@ -8,10 +8,10 @@
 namespace onnxruntime {
 namespace cuda {
 
-bool canDoTranspose3D(int32_t rank, const std::vector<int64_t>& input_dims, const std::vector<size_t>& permutations);
+bool CanDoTranspose3D(int32_t rank, const std::vector<int64_t>& input_dims, const std::vector<size_t>& permutations);
 Status Transpose3DImpl(size_t element_size, const TArray<int64_t>& input_shape, const TArray<int64_t>& input_strides, const void* input_data,
                        void* output_data, int64_t N);
-bool canDoTranspose4D(const cudaDeviceProp& prop,
+bool CanDoTranspose4D(const cudaDeviceProp& prop,
                       size_t element_size,
                       int32_t rank,
                       const std::vector<int64_t>& input_dims,

--- a/onnxruntime/core/providers/cuda/tensor/transpose_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/transpose_impl.h
@@ -8,9 +8,16 @@
 namespace onnxruntime {
 namespace cuda {
 
+bool canDoTranspose3D(int32_t rank, const std::vector<int64_t>& input_dims, const std::vector<size_t>& permutations);
+Status Transpose3DImpl(size_t element_size, const TArray<int64_t>& input_shape, const TArray<int64_t>& input_strides, const void* input_data,
+                       void* output_data, int64_t N);
+bool canDoTranspose4D(const cudaDeviceProp& prop,
+                      size_t element_size,
+                      int32_t rank,
+                      const std::vector<int64_t>& input_dims,
+                      const std::vector<size_t>& permutations);
 Status Transpose4DImpl(size_t element_size, const TArray<int64_t>& input_shape, const TArray<int64_t>& input_strides, const void* input_data,
                        const TArray<int64_t>& output_strides, void* output_data, int64_t N);
-
 Status TransposeImpl(size_t element_size, int32_t shape_rank, const TArray<int64_t>& input_strides,
                      const void* input_data, const TArray<fast_divmod>& fdm_output_strides, void* output_data, int64_t N);
 }  // namespace cuda

--- a/onnxruntime/test/providers/cpu/tensor/transpose_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/transpose_test.cc
@@ -3,6 +3,7 @@
 
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
+#include "test/providers/compare_provider_test_utils.h"
 
 namespace onnxruntime {
 namespace test {
@@ -409,5 +410,45 @@ TEST(TransposeOpTest, SingleAxisMovingInwardsBlockCopy) {
 
   TransposeTest(input_shape, input_vals, &perm, expected_shape, expected_vals, false);
 }
+
+static void TestTranspose(
+    const std::vector<int64_t>& perm,
+    const std::vector<int64_t>& x_dims,
+    const std::vector<int64_t>& y_dims,
+    double error_tolerance = 1e-4) {
+  CompareOpTester test{"Transpose"};
+
+  RandomValueGenerator random{};
+  const auto X_data = random.Uniform<float>(x_dims, -10.0, 10.0);
+  const auto Y_data = FillZeros<float>(y_dims);
+
+  test.AddAttribute("perm", perm);
+  test.AddInput("X", x_dims, X_data);
+  test.AddOutput("Y", y_dims, Y_data);
+
+  test.CompareWithCPU(kCudaExecutionProvider, error_tolerance);
+}
+
+TEST(TransposeOpTest, Transpose0213) {
+  const std::vector<int64_t> X_dims{64, 128, 16, 64};
+  const std::vector<int64_t> perm{0, 2, 1, 3};
+  const std::vector<int64_t> Y_dims{64, 16, 128, 64};
+  TestTranspose(perm, X_dims, Y_dims);
+}
+
+TEST(TransposeOpTest, Transpose0231) {
+  const std::vector<int64_t> X_dims{64, 128, 16, 64};
+  const std::vector<int64_t> perm{0, 2, 3, 1};
+  const std::vector<int64_t> Y_dims{64, 16, 64, 128};
+  TestTranspose(perm, X_dims, Y_dims);
+}
+
+TEST(TransposeOpTest, Transpose0312) {
+  const std::vector<int64_t> X_dims{64, 16, 64, 128};
+  const std::vector<int64_t> perm{0, 3, 1, 2};
+  const std::vector<int64_t> Y_dims{64, 128, 16, 64};
+  TestTranspose(perm, X_dims, Y_dims);
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/transpose_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/transpose_test.cc
@@ -411,6 +411,7 @@ TEST(TransposeOpTest, SingleAxisMovingInwardsBlockCopy) {
   TransposeTest(input_shape, input_vals, &perm, expected_shape, expected_vals, false);
 }
 
+#ifdef USE_CUDA
 static void TestTranspose(
     const std::vector<int64_t>& perm,
     const std::vector<int64_t>& x_dims,
@@ -449,6 +450,7 @@ TEST(TransposeOpTest, Transpose0312) {
   const std::vector<int64_t> Y_dims{64, 128, 16, 64};
   TestTranspose(perm, X_dims, Y_dims);
 }
+#endif
 
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
In this PR, the following things are done to improve CUDA transpose kernel. With this PR, the throughput of BERT-L is improved by ~1.4%.

1.  Flatten the adjacent dimensions which are contiguous. For example: permutations[0, 2, 3, 1] -> [0, 2, 1], permutations[0, 3, 1, 2] -> [0, 2, 1]. This will make the loop iterations in transpose kernel less.
2.  For 3D tensor, if the permutations are done in last two dimensions, then we can easily use shared memory to improve GPU memory utilization.
3. For 4D tensor, if the permutations are not done in the last dimension, then we can use int4 to access memory. Besides, if the last two dimensions can fit in block size, then the kernel can be simplified by configuring block size with the shape of last two dimensions.

The table below is the improvement for BERT-L tensor with shape [64, 128, 16, 64]

  | Baseline (micro seconds) | Optimization (micro seconds) | Improvement
-- | -- | -- | --
Permutation: [0 2 3 1] | 110.531 | 95.808 | 13%
Permutation: [0 3 1 2] | 187.981 | 89.6352 | 52%
Permutation: [0 2 1 3] | 87.7408 | 31.0208 | 65%

