### PR TITLE
NHWC transformation for ACL and ArmNN EPs

### DIFF
--- a/include/onnxruntime/core/graph/constants.h
+++ b/include/onnxruntime/core/graph/constants.h
@@ -19,6 +19,7 @@ constexpr const char* kOnnxDomainAlias = "ai.onnx";
 constexpr const char* kMLDomain = "ai.onnx.ml";
 constexpr const char* kMSDomain = "com.microsoft";
 constexpr const char* kMSNchwcDomain = "com.microsoft.nchwc";
+constexpr const char* kMSNhwcDomain = "com.microsoft.nhwc";
 constexpr const char* kMSFeaturizersDomain = "com.microsoft.mlfeaturizers";
 constexpr const char* kMSDmlDomain = "com.microsoft.dml";
 constexpr const char* kNGraphDomain = "com.intel.ai";

--- a/include/onnxruntime/core/optimizer/graph_transformer_utils.h
+++ b/include/onnxruntime/core/optimizer/graph_transformer_utils.h
@@ -25,7 +25,8 @@ std::vector<std::unique_ptr<RewriteRule>> GenerateRewriteRules(TransformerLevel 
     and the transformers_and_rules_to_enable. */
 std::vector<std::unique_ptr<GraphTransformer>> GenerateTransformers(TransformerLevel level,
                                                                     gsl::span<const FreeDimensionOverride> free_dimension_overrides,
-                                                                    const std::vector<std::string>& rules_and_transformers_to_enable = {});
+                                                                    const std::vector<std::string>& rules_and_transformers_to_enable = {},
+                                                                    const std::vector<std::string>& registered_execution_providers = {});
 
 /** Given a TransformerLevel, this method generates a name for the rule-based graph transformer of that level. */
 std::string GenerateRuleBasedTransformerName(TransformerLevel level);

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -6,6 +6,7 @@
 #include "core/graph/contrib_ops/attn_lstm_schema_defs.h"
 #include "core/graph/contrib_ops/contrib_defs.h"
 #include "core/graph/contrib_ops/nchwc_schema_defs.h"
+#include "core/graph/contrib_ops/nhwc_schema_defs.h"
 #include "core/graph/contrib_ops/range_schema_defs.h"
 #include "core/graph/op.h"
 #include "onnx/defs/schema.h"
@@ -2666,6 +2667,10 @@ Example 4:
   if (MlasNchwcGetBlockSize() > 1) {
     RegisterNchwcSchemas();
   }
+
+#if defined(USE_ACL) || defined(USE_ARMNN)
+  RegisterNhwcSchemas();
+#endif
 
   static const char* Gelu_ver1_doc =
       R"DOC(Gaussian Error Linear Unit.

--- a/onnxruntime/core/graph/contrib_ops/nhwc_schema_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/nhwc_schema_defs.cc
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/framework/tensorprotoutils.h"
+#include "core/graph/constants.h"
+#include "core/graph/contrib_ops/contrib_defs.h"
+#include "core/graph/contrib_ops/nchwc_schema_defs.h"
+
+namespace ONNX_NAMESPACE {
+void convPoolShapeInference(
+    ONNX_NAMESPACE::InferenceContext& ctx,
+    bool use_dilation, bool require_kernel_shape,
+    int input1Idx,
+    int input2Idx);
+void globalPoolTypeShapeInference(ONNX_NAMESPACE::InferenceContext& ctx);
+}  // namespace ONNX_NAMESPACE
+
+namespace onnxruntime {
+namespace contrib {
+
+using ONNX_NAMESPACE::AttributeProto;
+using ONNX_NAMESPACE::InferenceContext;
+using ONNX_NAMESPACE::OpSchema;
+using ONNX_NAMESPACE::OPTIONAL_VALUE;
+
+void NhwcPoolOpSchemaGenerator(OpSchema& schema) {
+  schema.SetDomain(kMSNhwcDomain);
+  schema.SinceVersion(1);
+  schema.SetDoc(R"DOC(For internal use.)DOC");
+  schema.Attr("auto_pad", "", AttributeProto::STRING, std::string("NOTSET"));
+  schema.Attr("kernel_shape", "", AttributeProto::INTS);
+  schema.Attr("dilations", "", AttributeProto::INTS, OPTIONAL_VALUE);
+  schema.Attr("strides", "", AttributeProto::INTS, OPTIONAL_VALUE);
+  schema.Attr("pads", "", AttributeProto::INTS, OPTIONAL_VALUE);
+  schema.Attr("ceil_mode", "", AttributeProto::INT, static_cast<int64_t>(0));
+  schema.Input(0, "X", "", "T");
+  schema.Output(0, "Y", "", "T");
+  schema.TypeConstraint("T", {"tensor(float)"}, "Constrain input and output types to float tensors");
+  schema.TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+    ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
+    ONNX_NAMESPACE::convPoolShapeInference(ctx, true, true, 0, 1);
+  });
+}
+
+void NhwcGlobalPoolOpSchemaGenerator(OpSchema& schema) {
+  schema.SetDomain(kMSNhwcDomain);
+  schema.SinceVersion(1);
+  schema.SetDoc(R"DOC(For internal use.)DOC");
+  schema.Input(0, "X", "", "T");
+  schema.Output(0, "Y", "", "T");
+  schema.TypeConstraint("T", {"tensor(float)"}, "Constrain input and output types to float tensors");
+  schema.TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+    ONNX_NAMESPACE::globalPoolTypeShapeInference(ctx);
+  });
+}
+
+
+void RegisterNhwcSchemas() {
+  ONNX_CONTRIB_OPERATOR_SCHEMA(ReorderInput)
+      .SetDomain(kMSNhwcDomain)
+      .SinceVersion(1)
+      .SetDoc(R"DOC(For internal use.)DOC")
+      .Input(0, "X", "", "T")
+      .Output(0, "Y", "", "T")
+       .TypeConstraint(
+          "T",
+          {"tensor(float)", "tensor(int8)", "tensor(uint8)"},
+          "Constrain input and output types to float/quantized tensors")
+      .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput);
+
+  ONNX_CONTRIB_OPERATOR_SCHEMA(ReorderOutput)
+      .SetDomain(kMSNhwcDomain)
+      .SinceVersion(1)
+      .SetDoc(R"DOC(For internal use.)DOC")
+      .Attr("channels", "", AttributeProto::INT, static_cast<int64_t>(0))
+      .Input(0, "X", "", "T")
+      .Output(0, "Y", "", "T")
+      .TypeConstraint(
+          "T",
+          {"tensor(float)", "tensor(int8)", "tensor(uint8)"},
+          "Constrain input and output types to float/quantized tensors")
+      .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput);
+
+  ONNX_CONTRIB_OPERATOR_SCHEMA(Conv)
+      .SetDomain(kMSNhwcDomain)
+      .SinceVersion(1)
+      .SetDoc(R"DOC(For internal use.)DOC")
+      .Attr("auto_pad", "", AttributeProto::STRING, std::string("NOTSET"))
+      .Attr("kernel_shape", "", AttributeProto::INTS, OPTIONAL_VALUE)
+      .Attr("dilations", "", AttributeProto::INTS, OPTIONAL_VALUE)
+      .Attr("strides", "", AttributeProto::INTS, OPTIONAL_VALUE)
+      .Attr("pads", "", AttributeProto::INTS, OPTIONAL_VALUE)
+      .Attr("group", "", AttributeProto::INT, static_cast<int64_t>(1))
+      .Attr("activation", "", AttributeProto::STRING, OPTIONAL_VALUE)
+      .Attr("activation_params", "", AttributeProto::FLOATS, OPTIONAL_VALUE)
+      .Input(0, "X", "", "T")
+      .Input(1, "W", "", "T")
+      .Input(2, "B", "", "T", OpSchema::Optional)
+      .Output(0, "Y", "", "T")
+      .TypeConstraint("T", {"tensor(float)"}, "Constrain input and output types to float tensors")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        ONNX_NAMESPACE::convPoolShapeInference(ctx, true, false, 0, 1);
+      });
+
+ ONNX_CONTRIB_OPERATOR_SCHEMA(FusedConv)
+       .SetDomain(kMSNhwcDomain)
+      .SinceVersion(1)
+      .SetDoc(R"DOC(For internal use.)DOC")
+      .Attr("auto_pad", "", AttributeProto::STRING, std::string("NOTSET"))
+      .Attr("kernel_shape", "", AttributeProto::INTS, OPTIONAL_VALUE)
+      .Attr("dilations", "", AttributeProto::INTS, OPTIONAL_VALUE)
+      .Attr("strides", "", AttributeProto::INTS, OPTIONAL_VALUE)
+      .Attr("pads", "", AttributeProto::INTS, OPTIONAL_VALUE)
+      .Attr("group", "", AttributeProto::INT, static_cast<int64_t>(1))
+      .Attr("activation", "", AttributeProto::STRING, OPTIONAL_VALUE)
+      .Attr("activation_params", "", AttributeProto::FLOATS, OPTIONAL_VALUE)
+      .Input(0, "X", "", "T")
+      .Input(1, "W", "", "T")
+      .Input(2, "B", "", "T", OpSchema::Optional)
+      .Output(0, "Y", "", "T")
+      .TypeConstraint("T", {"tensor(float)"}, "Constrain input and output types to float tensors")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        ONNX_NAMESPACE::convPoolShapeInference(ctx, true, false, 0, 1);
+      });
+
+
+  ONNX_CONTRIB_OPERATOR_SCHEMA(MaxPool)
+      .FillUsing(NhwcPoolOpSchemaGenerator)
+      .Attr("storage_order", "", AttributeProto::INT, static_cast<int64_t>(0));
+
+  ONNX_CONTRIB_OPERATOR_SCHEMA(AveragePool)
+      .FillUsing(NhwcPoolOpSchemaGenerator)
+      .Attr("count_include_pad", "", AttributeProto::INT, static_cast<int64_t>(0));
+
+  ONNX_CONTRIB_OPERATOR_SCHEMA(GlobalMaxPool)
+      .FillUsing(NhwcGlobalPoolOpSchemaGenerator);
+
+  ONNX_CONTRIB_OPERATOR_SCHEMA(GlobalAveragePool)
+      .FillUsing(NhwcGlobalPoolOpSchemaGenerator);
+}
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/core/graph/contrib_ops/nhwc_schema_defs.h
+++ b/onnxruntime/core/graph/contrib_ops/nhwc_schema_defs.h
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+namespace onnxruntime {
+namespace contrib {
+
+void RegisterNhwcSchemas();
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/nhwc_transformer.cc
+++ b/onnxruntime/core/optimizer/nhwc_transformer.cc
@@ -1,0 +1,366 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) 2020, NXP Semiconductor, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+#if defined(USE_ACL) || defined(USE_ARMNN)
+
+#include <deque>
+#include "core/graph/graph_utils.h"
+#include "core/optimizer/initializer.h"
+#include "core/optimizer/nhwc_transformer.h"
+
+#include "core/providers/acl/acl_common.h"
+
+// ACL
+#include "arm_compute/runtime/Tensor.h"
+#include "arm_compute/runtime/TensorAllocator.h"
+
+// NEON
+#include "arm_compute/runtime/NEON/functions/NEPermute.h"
+
+using namespace ONNX_NAMESPACE;
+using namespace ::onnxruntime::common;
+namespace onnxruntime {
+
+enum DataLayout {
+  NchwLayout,
+  NhwcLayout,
+  InheritLayout
+};
+
+class NhwcTransformerImpl {
+ public:
+  NhwcTransformerImpl(Graph& graph, std::string provider, const logging::Logger& _logger) noexcept :
+    graph_(graph), provider_(provider), logger(_logger) {};
+  void Transform(Node& node);
+  void Finalize(bool& modified);
+
+ private:
+  NodeIndex InsertPermuteParentNode(Node& node, const Node::EdgeEnd* edge, bool bNHWC);
+  NodeIndex InsertPermuteChildNode(Node& node, bool bNHWC);
+  NodeIndex ReplaceNode(Node& node);
+  void PermuteWeights(NodeArg* src, NodeArg** dst, const std::string&);
+
+  DataLayout RequiredLayout(const Node& node);
+  bool SuportsReplacementNHWC(const Node& node);
+  bool RequiresWeightsPermutation(const Node& node);
+
+  std::map<NodeIndex, bool> nodes_layout;
+  Graph& graph_;
+  std::string provider_;
+  const logging::Logger& logger;
+};
+
+NodeIndex NhwcTransformerImpl::InsertPermuteParentNode(Node& node, const Node::EdgeEnd* edge, bool bNHWC) {
+
+  const Node* parent_node = NULL;
+  int srcIdx = 0, dstIdx = 0;
+  if (edge) {
+    parent_node = &edge->GetNode();
+    srcIdx = edge->GetSrcArgIndex();
+    dstIdx = edge->GetDstArgIndex();
+  }
+
+  LOGS(logger, VERBOSE) << "NHWC Insert: "
+      << (parent_node ? parent_node->OpType() : "*")
+      << ":" << srcIdx
+      << (bNHWC ? " [ReorderInput:0] " : " [ReorderOutput:0] ")
+      << node.OpType()
+      << ":" << dstIdx;
+
+  auto& input_defs = node.MutableInputDefs();
+  std::string new_input_def_name = graph_.GenerateNodeArgName("input");
+  auto* new_input_arg = &graph_.GetOrCreateNodeArg(new_input_def_name, input_defs[0]->TypeAsProto());
+
+  Node& permute_node = graph_.AddNode(graph_.GenerateNodeName(bNHWC ? "PermuteNHWC" : "PermuteNCHW"),
+                                     bNHWC ? "ReorderInput" : "ReorderOutput",
+                                     bNHWC ? "ReorderIntput" : "ReorderOutput",
+                                     {input_defs[dstIdx]},
+                                     {new_input_arg},
+                                     nullptr,
+                                     kMSNhwcDomain);
+  permute_node.SetExecutionProviderType(provider_);
+
+  if (parent_node) {
+    graph_.RemoveEdge(parent_node->Index(), node.Index(), srcIdx, dstIdx);
+  }
+  input_defs[dstIdx] = new_input_arg;
+
+  graph_.AddEdge(permute_node.Index(), node.Index(), 0, dstIdx);
+  if (parent_node) {
+    graph_.AddEdge(parent_node->Index(), permute_node.Index(), srcIdx, 0);
+  }
+
+  return permute_node.Index();
+}
+
+NodeIndex NhwcTransformerImpl::InsertPermuteChildNode(Node& node, bool bNHWC) {
+
+  LOGS(logger, VERBOSE) << "NHWC Insert: " << node.OpType()
+    << (bNHWC ? " [ReorderInput] " : " [ReorderOutput] ") << "*:0";
+
+  auto& output_defs = node.MutableOutputDefs();
+  std::string new_output_def_name = graph_.GenerateNodeArgName("output");
+  auto* new_output_arg = &graph_.GetOrCreateNodeArg(new_output_def_name, output_defs[0]->TypeAsProto());
+
+  Node& permute_node = graph_.AddNode(graph_.GenerateNodeName(bNHWC ? "PermuteNCHW" : "PermuteNHWC"),
+                                     bNHWC ? "ReorderIntput" : "ReorderOutput",
+                                     bNHWC ? "ReorderIntput" : "ReorderOutput",
+                                     {new_output_arg},
+                                     {output_defs[0]},
+                                     nullptr,
+                                     kMSNhwcDomain);
+  permute_node.SetExecutionProviderType(provider_);
+  output_defs[0] = new_output_arg;
+  graph_.AddEdge(node.Index(), permute_node.Index(), 0, 0);
+
+  return permute_node.Index();
+}
+
+bool NhwcTransformerImpl::RequiresWeightsPermutation(const Node& node) {
+   return ((node.GetExecutionProviderType() == kAclExecutionProvider ||
+            node.GetExecutionProviderType() == kArmNNExecutionProvider) &&
+           (node.OpType() == "Conv" ||
+            node.OpType() == "FusedConv"));
+}
+
+NodeIndex NhwcTransformerImpl::ReplaceNode(Node& node) {
+
+  auto& input_defs = node.MutableInputDefs();
+  auto& output_defs = node.MutableOutputDefs();
+
+  LOGS(logger, VERBOSE) << "NHWC >> Replace " << node.OpType();
+
+  Node& newNode = graph_.AddNode(graph_.GenerateNodeName(node.Name()),
+                                     node.OpType(),
+                                     node.OpType(),
+                                     input_defs,
+                                     output_defs,
+                                     &node.GetAttributes(),
+                                     kMSNhwcDomain);
+  newNode.SetExecutionProviderType(node.GetExecutionProviderType());
+
+  // Permute weights
+  if (RequiresWeightsPermutation(node))
+    PermuteWeights(input_defs[1], &newNode.MutableInputDefs()[1], node.GetExecutionProviderType());
+
+  NodeIndex oldIndex = node.Index();
+  const std::vector<std::reference_wrapper<Node>> replacedNode({node});
+  graph_utils::FinalizeNodeFusion(graph_, replacedNode, newNode);
+  nodes_layout.erase(oldIndex);
+
+  return newNode.Index();
+}
+
+void NhwcTransformerImpl::PermuteWeights(NodeArg *input_def, NodeArg** nhwc_conv_W_arg, __attribute__ ((unused)) const std::string& execution_provider) {
+  // Require that the weights tensor be static.
+  const ONNX_NAMESPACE::TensorProto* conv_W_tensor_proto = nullptr;
+  if (!graph_.GetInitializedTensor(input_def->Name(), conv_W_tensor_proto) ||
+      (conv_W_tensor_proto->data_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT) ||
+      (conv_W_tensor_proto->dims_size() != 4) ||
+      (execution_provider == kArmNNExecutionProvider && conv_W_tensor_proto->dims(1) == 1)) {
+
+    return;
+  }
+
+  Initializer conv_W{*conv_W_tensor_proto, graph_.ModelPath()};
+
+  arm_compute::Tensor weights;
+  arm_compute::Tensor new_weights;
+
+  arm_compute::TensorShape initial_shape(conv_W.dims()[3], conv_W.dims()[2], conv_W.dims()[1], conv_W.dims()[0]);
+
+  weights.allocator()->init(arm_compute::TensorInfo(initial_shape, arm_compute::Format::F32));
+
+  arm_compute::NEPermute permutationLayer;
+  permutationLayer.configure(&weights, &new_weights,
+    (conv_W_tensor_proto->dims(1) == 1) ? arm_compute::PermutationVector(3,2,0,1) : arm_compute::PermutationVector(2,0,1));
+
+  weights.allocator()->import_memory(conv_W.data<float>());
+
+  new_weights.allocator()->allocate();
+
+  permutationLayer.run();
+
+  weights.allocator()->free();
+
+  float* reordered_filter = reinterpret_cast<float*>(new_weights.buffer());
+
+  ONNX_NAMESPACE::TensorProto nhwc_conv_W_tensor_proto;
+
+  nhwc_conv_W_tensor_proto.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  nhwc_conv_W_tensor_proto.set_name(graph_.GenerateNodeArgName("nhwc_conv_W_arg"));
+  nhwc_conv_W_tensor_proto.set_raw_data(reordered_filter, new_weights.info()->tensor_shape().total_size() * sizeof(float));
+
+  for (size_t i = 0; i < 4; i++) {
+    nhwc_conv_W_tensor_proto.add_dims(conv_W.dims()[i]);
+  }
+
+  new_weights.allocator()->free();
+
+  graph_.AddInitializedTensor(nhwc_conv_W_tensor_proto);
+
+  *nhwc_conv_W_arg = &graph_.GetOrCreateNodeArg(nhwc_conv_W_tensor_proto.name(), nullptr);
+}
+
+
+bool NhwcTransformerImpl::SuportsReplacementNHWC(const Node& node) {
+   return ((node.GetExecutionProviderType() == kAclExecutionProvider ||
+            node.GetExecutionProviderType() == kArmNNExecutionProvider) &&
+           (node.OpType() == "Conv" ||
+            node.OpType() == "FusedConv" ||
+            node.OpType() == "MaxPool" ||
+            node.OpType() == "AveragePool" ||
+            node.OpType() == "GlobalMaxPool" ||
+            node.OpType() == "GlobalAveragePool"));
+}
+
+DataLayout NhwcTransformerImpl::RequiredLayout(const Node& node) {
+  // Default to NCHW to cover all cases
+  DataLayout layout = NchwLayout;
+
+  if (SuportsReplacementNHWC(node)) {
+     layout = NhwcLayout;
+  } else if (node.OpType() == "Add" ||
+             node.OpType() == "Sum") {
+     for (auto it = node.InputNodesBegin(), end = node.InputNodesEnd(); it != end && layout == NchwLayout; ++it) {
+       auto itLayout = nodes_layout.find(it->Index());
+       if (itLayout != nodes_layout.end())
+         layout = itLayout->second ? NhwcLayout : NchwLayout;
+     }
+  } else {
+     if (node.OpType() == "Clip" ||
+         node.OpType() == "Elu" ||
+         node.OpType() == "HardSigmoid" ||
+         node.OpType() == "LeakyRelu" ||
+         node.OpType() == "Relu" ||
+         node.OpType() == "Selu" ||
+         node.OpType() == "Sigmoid" ||
+         node.OpType() == "Softplus" ||
+         node.OpType() == "Softsign" ||
+         node.OpType() == "Tanh" ||
+         node.OpType() == "PRelu" ||
+         node.OpType() == "RandomNormal" ||
+         node.OpType() == "RandomUniform" ||
+         node.OpType() == "RandomNormalLike" ||
+         node.OpType() == "RandomUniformLike" ||
+         node.OpType() == "Multinomial")
+       layout = InheritLayout;
+  }
+
+  return layout;
+}
+
+void NhwcTransformerImpl::Transform(Node& node) {
+  long unsigned int node_idx = node.Index();
+
+  LOGS(logger, VERBOSE) << "NHWC " << node.OpType() << " "  << node.GetExecutionProviderType();
+
+  DataLayout required_layout = RequiredLayout(node);
+  bool bRequiresNHWC = (required_layout == NhwcLayout);
+  bool bNodeNHWC = false;
+
+  // create temporary container to allow inseration without alteration
+  std::vector<const Node::EdgeEnd*> inputEdges;
+  for (auto it = node.InputEdgesBegin(), end = node.InputEdgesEnd(); it != end; ++it)
+    inputEdges.push_back(&(*it));
+
+  for (std::vector<const Node::EdgeEnd*>::iterator it = inputEdges.begin(), end = inputEdges.end(); it != end; ++it) {
+    const Node::EdgeEnd* edge = *it;
+
+    bool bParentNHWC = true;
+
+    auto itParentLayout = nodes_layout.find(edge->GetNode().Index());
+    if (itParentLayout != nodes_layout.end())
+      bParentNHWC = itParentLayout->second;
+
+    switch (required_layout) {
+    case InheritLayout:
+        bNodeNHWC = bParentNHWC;
+        break;
+    case NhwcLayout:
+    case NchwLayout: {
+        if (bRequiresNHWC != bParentNHWC) {
+          NodeIndex permute_index = InsertPermuteParentNode(node, edge, bRequiresNHWC);
+          nodes_layout.insert(std::make_pair(permute_index, bRequiresNHWC));
+        }
+        bNodeNHWC = bRequiresNHWC;
+        break;
+      }
+    }
+  }
+
+  // first node
+  if (node.InputNodesBegin() == node.InputNodesEnd()) {
+    switch (required_layout) {
+    case InheritLayout:
+      bNodeNHWC = false;
+      break;
+    case NhwcLayout:
+    case NchwLayout:
+        if (bRequiresNHWC) {
+          NodeIndex permute_index = InsertPermuteParentNode(node, NULL, true);
+          nodes_layout.insert(std::make_pair(permute_index, true));
+        }
+        bNodeNHWC = bRequiresNHWC;
+        break;
+    }
+  }
+
+  // Replace specific ops
+  if (SuportsReplacementNHWC(node)) {
+    node_idx = ReplaceNode(node);
+    nodes_layout.insert(std::make_pair(node_idx, true));
+    bNodeNHWC = true;
+  }
+
+  nodes_layout.insert(std::make_pair(node_idx, bNodeNHWC));
+
+  Node& latest_node = *graph_.GetNode(node_idx);
+
+  if (latest_node.OutputNodesBegin() == latest_node.OutputNodesEnd() &&
+      bNodeNHWC) {
+    NodeIndex perute_index = InsertPermuteChildNode(latest_node, false);
+    nodes_layout.insert(std::make_pair(perute_index, false));
+  }
+}
+
+void NhwcTransformerImpl::Finalize(__attribute__ ((unused)) bool& modified) {
+  modified = false;
+}
+
+Status NhwcTransformer::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
+
+  std::string provider;
+  modified = false;
+
+  for(auto it = registered_execution_providers_.begin(); it != registered_execution_providers_.end(); ++it) {
+    if (*it == kAclExecutionProvider || *it == kArmNNExecutionProvider) {
+      provider = *it;
+      break;
+    }
+  }
+
+  if (!provider.empty()) {
+    NhwcTransformerImpl impl(graph, provider, logger);
+    GraphViewer graph_viewer(graph);
+
+    for (auto index : graph_viewer.GetNodesInTopologicalOrder()) {
+      Node* node = graph.GetNode(index);
+
+      // check that node hasn't already been removed
+      if (!node)
+        continue;
+
+      ORT_RETURN_IF_ERROR(Recurse(*node, modified, graph_level, logger));
+      impl.Transform(*node);
+    }
+
+    impl.Finalize(modified);
+  }
+
+  return Status::OK();
+}
+
+}  // namespace onnxruntime
+#endif

--- a/onnxruntime/core/optimizer/nhwc_transformer.h
+++ b/onnxruntime/core/optimizer/nhwc_transformer.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) 2020, NXP Semiconductor, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+#if defined(USE_ACL) || defined(USE_ARMNN)
+#pragma once
+
+#include "core/common/common.h"
+#include "core/optimizer/graph_transformer.h"
+
+namespace onnxruntime {
+
+/**
+@Class NhwcTransformer
+
+Transformer that optimizes the graph by using NHWC nodes instead of NCHW nodes
+and inserts nodes to reorder tensors as needed.
+*/
+class NhwcTransformer : public GraphTransformer {
+ public:
+  NhwcTransformer(const std::vector<std::string>& registered_execution_providers) noexcept :
+	GraphTransformer("NhwcTransformer"),  registered_execution_providers_(registered_execution_providers) {}
+
+ private:
+  Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
+  const std::vector<std::string>& registered_execution_providers_;
+};
+
+}  // namespace onnxruntime
+#endif

--- a/onnxruntime/core/providers/acl/acl_execution_provider.cc
+++ b/onnxruntime/core/providers/acl/acl_execution_provider.cc
@@ -42,6 +42,16 @@ class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDoma
 
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSDomain, 1, float, FusedConv);
 
+// NHwc
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, ReorderInput);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, ReorderOutput);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, Conv);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, FusedConv);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, MaxPool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, GlobalMaxPool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, AveragePool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, GlobalAveragePool);
+
 static void RegisterACLKernels(KernelRegistry& kernel_registry) {
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 6, Relu)>());
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 7, 9, Gemm)>());
@@ -68,6 +78,16 @@ static void RegisterACLKernels(KernelRegistry& kernel_registry) {
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kAclExecutionProvider, kOnnxDomain, 4, 10, Concat)>());
 
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSDomain, 1, float, FusedConv)>());
+
+  // Nhwc
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, ReorderInput)>());
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, ReorderOutput)>());
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, Conv)>()),
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, FusedConv)>()),
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, MaxPool)>()),
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, GlobalMaxPool)>()),
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, AveragePool)>()),
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kAclExecutionProvider, kMSNhwcDomain, 1, float, GlobalAveragePool)>());
 }
 
 std::shared_ptr<KernelRegistry> GetAclKernelRegistry() {

--- a/onnxruntime/core/providers/acl/nhwc/nhwc_fused_conv.cc
+++ b/onnxruntime/core/providers/acl/nhwc/nhwc_fused_conv.cc
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) 2020, NXP Semiconductor, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+#ifdef _WIN32
+#pragma warning(disable : 4244)
+#endif
+
+#include "core/providers/acl/nhwc/nhwc_ops.h"
+#include "core/providers/acl/acl_common.h"
+#include "core/providers/acl/acl_fwd.h"
+#include "core/providers/acl/acl_execution_provider.h"
+#include "contrib_ops/cpu/fused_activation.h"
+
+namespace onnxruntime {
+namespace acl {
+
+class NhwcFusedConv final : public NhwcConv<float> {
+ public:
+  explicit NhwcFusedConv(const OpKernelInfo& info) : NhwcConv<float>(info) {
+    ORT_ENFORCE(info.GetAttr<std::string>("activation", &(NhwcConv::activation_type)).IsOK());
+    ORT_ENFORCE(GetFusedActivationAttr(info, activation_).IsOK());
+  }
+};
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    FusedConv,
+    kMSNhwcDomain,
+    1,
+    float,
+    kAclExecutionProvider,
+    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NhwcFusedConv);
+
+}  // namespace acl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/acl/nhwc/nhwc_ops.cc
+++ b/onnxruntime/core/providers/acl/nhwc/nhwc_ops.cc
@@ -1,0 +1,562 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) 2020, NXP Semiconductor, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/framework/op_kernel_context_internal.h"
+#include "core/providers/acl/acl_common.h"
+#include "core/providers/acl/nhwc/nhwc_ops.h"
+#include "core/providers/acl/acl_fwd.h"
+
+// NEON
+#include "arm_compute/core/Types.h"
+#include "arm_compute/runtime/NEON/functions/NEPermute.h"
+#include "arm_compute/runtime/NEON/functions/NEConvolutionLayer.h"
+#include "arm_compute/runtime/NEON/functions/NEDepthwiseConvolutionLayer.h"
+#include "arm_compute/runtime/NEON/functions/NEPoolingLayer.h"
+
+#define CONV_ACL
+#undef DEPTHWISE_CPU
+
+#define PREF_DIM 4
+
+namespace onnxruntime {
+namespace acl {
+
+template <typename T>
+thread_local std::map<OpKernel*, ACLNEConv> NhwcConv<T>::convLayers;
+
+template <typename T>
+thread_local std::map<OpKernel*, ACLNEPool> NhwcPoolBase<T>::poolLayers;
+
+arm_compute::TensorShape ACL_NCHW2NHWC(arm_compute::TensorShape shape) {
+
+    return arm_compute::TensorShape(shape[2], shape[0], shape[1], shape[3]);
+}
+
+template <typename T>
+Status ReorderInput<T>::Compute(OpKernelContext* context) const {
+
+  const auto* X = context->Input<Tensor>(0);
+  const auto& X_shape = X->Shape();
+  ORT_ENFORCE(X_shape.NumDimensions() == 4);
+
+  auto* Y = context->Output(0, X_shape);
+
+  auto mm_layer = ACLCreateMemoryManager();
+
+  ACLNEPermute* pPerm;
+  ACLNEPermute tperm;
+  tperm.mm_layer = std::move(mm_layer);
+
+  tperm.in = std::make_shared<arm_compute::Tensor>();
+  tperm.out = std::make_shared<arm_compute::Tensor>();
+
+  tperm.in->allocator()->init(arm_compute::TensorInfo(ACLTensorShape(X->Shape(), PREF_DIM), arm_compute::Format::F32));
+  tperm.out->allocator()->init(arm_compute::TensorInfo(ACL_NCHW2NHWC(ACLTensorShape(Y->Shape(), PREF_DIM)), arm_compute::Format::F32));
+
+  tperm.layer = std::make_shared<arm_compute::NEPermute>();
+
+// ONNX NHWC
+// ACL CWHN
+// move to 2 0 1 3
+// new ACL WHCN
+
+  tperm.layer->configure(tperm.in.get(), tperm.out.get(), arm_compute::PermutationVector(2U, 0U, 1U));
+
+  //ToDo cache
+  pPerm = &tperm;
+
+  const T* x_data = X->template Data<T>();
+  ACLImportMemory(pPerm->in->allocator(), (void*)x_data, X->Shape().Size() * 4);
+
+  T* y_data = Y->template MutableData<T>();
+  ACLImportMemory(pPerm->out->allocator(), (void*)y_data, Y->Shape().Size() * 4);
+
+  arm_compute::Allocator alloc_mm{};
+  pPerm->mm_layer->populate(alloc_mm, 1);
+  pPerm->layer->run();
+  pPerm->mm_layer->clear();
+
+  pPerm->in->allocator()->free();
+  pPerm->out->allocator()->free();
+
+  return Status::OK();
+}
+
+template <typename T>
+Status ReorderOutput<T>::Compute(OpKernelContext* context) const {
+
+  const auto* X = context->Input<Tensor>(0);
+  const auto& X_shape = X->Shape();
+  ORT_ENFORCE(X_shape.NumDimensions() == 4);
+
+  auto* Y = context->Output(0, X_shape);
+
+  auto mm_layer = ACLCreateMemoryManager();
+
+  ACLNEPermute* pPerm;
+  ACLNEPermute tperm;
+  tperm.mm_layer = std::move(mm_layer);
+
+  tperm.in = std::make_shared<arm_compute::Tensor>();
+  tperm.out = std::make_shared<arm_compute::Tensor>();
+
+  tperm.in->allocator()->init(arm_compute::TensorInfo(ACL_NCHW2NHWC(ACLTensorShape(X->Shape(), PREF_DIM)), arm_compute::Format::F32));
+  tperm.out->allocator()->init(arm_compute::TensorInfo(ACLTensorShape(Y->Shape(), PREF_DIM), arm_compute::Format::F32));
+
+  tperm.layer = std::make_shared<arm_compute::NEPermute>();
+
+  tperm.layer->configure(tperm.in.get(), tperm.out.get(), arm_compute::PermutationVector(1U, 2U, 0U));
+
+  //ToDo cache
+  pPerm = &tperm;
+
+  const T* x_data = X->template Data<T>();
+  ACLImportMemory(pPerm->in->allocator(), (void*)x_data, X->Shape().Size() * 4);
+
+  T* y_data = Y->template MutableData<T>();
+  ACLImportMemory(pPerm->out->allocator(), (void*)y_data, Y->Shape().Size() * 4);
+
+  arm_compute::Allocator alloc_mm{};
+  pPerm->mm_layer->populate(alloc_mm, 1);
+  pPerm->layer->run();
+  pPerm->mm_layer->clear();
+
+  pPerm->in->allocator()->free();
+  pPerm->out->allocator()->free();
+
+  return Status::OK();
+}
+
+template <typename T>
+arm_compute::TensorShape NhwcConv<T>::ACLReshapeWeightsDepthwise(arm_compute::Tensor* kernel) const {
+  arm_compute::TensorShape shape = arm_compute::TensorShape(kernel->info()->tensor_shape());
+
+  return arm_compute::TensorShape(kernel->info()->tensor_shape()[2] * kernel->info()->tensor_shape()[3],
+                                  kernel->info()->tensor_shape()[0],
+                                  kernel->info()->tensor_shape()[1],
+                                  1);
+}
+
+
+template <typename T>
+Status NhwcConv<T>::Compute(OpKernelContext* context) const {
+
+  size_t num_inputs = OpKernel::Node().InputDefs().size();
+
+  const Tensor* X = context->Input<Tensor>(0);
+  const Tensor* W = context->Input<Tensor>(1);
+  const Tensor* B = num_inputs == 3 ? context->Input<Tensor>(2) : nullptr;
+
+  const int64_t N = X->Shape()[0];
+  const int64_t M = W->Shape()[0];
+
+  LOGS_DEFAULT(VERBOSE) << "X " << X->Shape().ToString().c_str() << std::endl;
+  LOGS_DEFAULT(VERBOSE) << "W " << W->Shape().ToString().c_str() << std::endl;
+  if (B != nullptr) LOGS_DEFAULT(VERBOSE) << "B " << B->Shape().ToString().c_str() << std::endl;
+
+  if (X->Shape().NumDimensions() != PREF_DIM) {
+    ORT_NOT_IMPLEMENTED("Only implemented convolution for 4D input. Number of dimensions found: ", X->Shape().NumDimensions());
+  }
+
+  ORT_RETURN_IF_ERROR(conv_attrs_.ValidateInputShape(X, W));
+
+  std::vector<int64_t> kernel_shape;
+  ORT_RETURN_IF_ERROR(conv_attrs_.ComputeKernelShape(W->Shape(), kernel_shape));
+
+  std::vector<int64_t> pads(conv_attrs_.pads);
+  if (pads.empty()) {
+    pads.resize(kernel_shape.size() * 2, 0);
+  }
+  std::vector<int64_t> dilations(conv_attrs_.dilations);
+  if (dilations.empty()) {
+    dilations.resize(kernel_shape.size(), 1);
+  }
+  std::vector<int64_t> strides(conv_attrs_.strides);
+  if (strides.empty()) {
+    strides.resize(kernel_shape.size(), 1);
+  }
+
+  std::vector<int64_t> Y_dims;
+  Y_dims.insert(Y_dims.begin(), {N, M});
+  TensorShape input_shape = X->Shape().Slice(2);
+  ORT_RETURN_IF_ERROR(conv_attrs_.InferOutputShape(input_shape, kernel_shape, strides, dilations, &pads, &Y_dims));
+  Tensor* Y = context->Output(0, TensorShape(Y_dims));
+  LOGS_DEFAULT(VERBOSE) << "Y " << Y->Shape().ToString().c_str() << std::endl;
+
+  arm_compute::ActivationLayerInfo::ActivationFunction acl_activ_func;
+  bool acl_activ_enabled = false;
+
+  if (activation_type == "Relu") {
+    acl_activ_func = arm_compute::ActivationLayerInfo::ActivationFunction::RELU;
+    acl_activ_enabled = true;
+  } else if (activation_type == "LeakyRelu") {
+    acl_activ_func = arm_compute::ActivationLayerInfo::ActivationFunction::LEAKY_RELU;
+    acl_activ_enabled = true;
+  } else if (activation_type == "Tanh") {
+    acl_activ_func = arm_compute::ActivationLayerInfo::ActivationFunction::TANH;
+    acl_activ_enabled = true;
+  } else if (activation_type == "Sigmoid") {
+    acl_activ_func = arm_compute::ActivationLayerInfo::ActivationFunction::LOGISTIC;
+    acl_activ_enabled = true;
+  } else if (!activation_type.empty()) {
+    ORT_NOT_IMPLEMENTED("Not implemented fused activation: ", activation_type);
+  }
+
+  ACLNEConv* pConv;
+  ConvLayersIterator it = NhwcConv::convLayers.find((OpKernel*)this);
+  if (it == NhwcConv::convLayers.end()) {
+
+    auto mm_layer = ACLCreateMemoryManager();
+
+    ACLNEConv tconv;
+    tconv.mm_layer = std::move(mm_layer);
+
+    tconv.in = std::make_shared<arm_compute::Tensor>();
+    tconv.k = std::make_shared<arm_compute::Tensor>();
+    if (B != nullptr)
+      tconv.b = std::make_shared<arm_compute::Tensor>();
+    tconv.out = std::make_shared<arm_compute::Tensor>();
+
+    bool isDepthwise = (W->Shape()[1] == 1);
+
+    tconv.in->allocator()->init(arm_compute::TensorInfo(ACL_NCHW2NHWC(ACLTensorShape(X->Shape(), PREF_DIM)), arm_compute::Format::F32));
+    if (isDepthwise)
+      tconv.k->allocator()->init(arm_compute::TensorInfo(ACLTensorShape(W->Shape(), PREF_DIM), arm_compute::Format::F32));
+    else
+      tconv.k->allocator()->init(arm_compute::TensorInfo(ACL_NCHW2NHWC(ACLTensorShape(W->Shape(), PREF_DIM)), arm_compute::Format::F32));
+    if (B != nullptr) {
+      tconv.b->allocator()->init(arm_compute::TensorInfo(ACLTensorShape(B->Shape()), arm_compute::Format::F32));
+    }
+    tconv.out->allocator()->init(arm_compute::TensorInfo(ACL_NCHW2NHWC(ACLTensorShape(Y->Shape(), PREF_DIM)), arm_compute::Format::F32));
+
+    tconv.in.get()->info()->set_data_layout(arm_compute::DataLayout::NHWC);
+    tconv.out.get()->info()->set_data_layout(arm_compute::DataLayout::NHWC);
+    tconv.k.get()->info()->set_data_layout(arm_compute::DataLayout::NHWC);
+
+    std::vector<int64_t> aclStrides(2);
+    aclStrides[0] = (strides.size() == 2) ? strides[1] : 1;
+    aclStrides[1] = strides[0];
+
+    std::vector<int64_t> aclPads(4);
+    if (pads.size() == 2) {
+      if (strides.size() == 1) {
+        aclPads[0] = 0;
+        aclPads[1] = 0;
+        aclPads[2] = pads[1];
+        aclPads[3] = pads[0];
+      } else {
+        aclPads[0] = pads[1];
+        aclPads[1] = pads[0];
+        aclPads[2] = pads[1];
+        aclPads[3] = pads[0];
+      }
+    } else {
+      aclPads[0] = pads[1];
+      aclPads[1] = pads[3];
+      aclPads[2] = pads[0];
+      aclPads[3] = pads[2];
+    }
+
+    arm_compute::PadStrideInfo aclPadStride = arm_compute::PadStrideInfo(aclStrides[0], aclStrides[1],
+                                                                         aclPads[0], aclPads[1], aclPads[2], aclPads[3], arm_compute::DimensionRoundingType::FLOOR);
+    unsigned int aclDilation0 = (dilations.size() == 2) ? dilations[1] : 1;
+
+    if (isDepthwise) {
+      tconv.k->info()->set_tensor_shape(ACLReshapeWeightsDepthwise(tconv.k.get()));
+
+      //depthwise convolution
+
+      if((W->Shape().GetDims()[2] != 3 || W->Shape().GetDims()[3] != 3)){
+        auto layer = std::make_shared<arm_compute::NEDepthwiseConvolutionLayer>();
+#ifdef ACL_1902
+        layer->configure(tconv.in.get(), tconv.k.get(), (B != nullptr) ? tconv.b.get() : nullptr, tconv.out.get(),
+                       aclPadStride, 1,
+                       acl_activ_enabled ? arm_compute::ActivationLayerInfo(acl_activ_func, conv_attrs_.alpha) : arm_compute::ActivationLayerInfo());
+#else
+        layer->configure(tconv.in.get(), tconv.k.get(), (B != nullptr) ? tconv.b.get() : nullptr, tconv.out.get(),
+                       aclPadStride, 1,
+                       acl_activ_enabled ? arm_compute::ActivationLayerInfo(acl_activ_func, conv_attrs_.alpha) : arm_compute::ActivationLayerInfo(),
+                       arm_compute::Size2D(aclDilation0, dilations[0]));
+#endif
+        tconv.layer = std::move(layer);
+      } else {
+        auto layer = std::make_shared<arm_compute::NEDepthwiseConvolutionLayer3x3>();
+#ifdef ACL_1902
+        layer->configure(tconv.in.get(), tconv.k.get(), (B != nullptr) ? tconv.b.get() : nullptr, tconv.out.get(),
+                       aclPadStride, 1,
+                       acl_activ_enabled ? arm_compute::ActivationLayerInfo(acl_activ_func, conv_attrs_.alpha) : arm_compute::ActivationLayerInfo());
+#else
+        layer->configure(tconv.in.get(), tconv.k.get(), (B != nullptr) ? tconv.b.get() : nullptr, tconv.out.get(),
+                       aclPadStride, 1,
+                       acl_activ_enabled ? arm_compute::ActivationLayerInfo(acl_activ_func, conv_attrs_.alpha) : arm_compute::ActivationLayerInfo(),
+                       arm_compute::Size2D(aclDilation0, dilations[0]));
+#endif
+        tconv.layer = std::move(layer);
+      }
+
+    } else {
+
+      //convolution
+      auto layer = std::make_shared<arm_compute::NEConvolutionLayer>(mm_layer);
+      layer->configure(tconv.in.get(), tconv.k.get(), (B != nullptr) ? tconv.b.get() : nullptr, tconv.out.get(),
+                       aclPadStride,
+                       arm_compute::WeightsInfo(), arm_compute::Size2D(aclDilation0, dilations[0]),
+                       acl_activ_enabled ? arm_compute::ActivationLayerInfo(acl_activ_func, conv_attrs_.alpha) : arm_compute::ActivationLayerInfo(),
+                       false, conv_attrs_.group);
+      tconv.layer = std::move(layer);
+    }
+
+    tconv.out->info()->set_format(tconv.in->info()->format());
+
+    std::pair<ConvLayersIterator, bool> ret;
+    ret = NhwcConv::convLayers.insert(std::pair<OpKernel*, ACLNEConv>((OpKernel*)this, tconv));
+    pConv = &ret.first->second;
+
+  } else {
+    //TODO: valildate shapes
+    pConv = &it->second;
+  }
+
+  const T* x_data = X->template Data<T>();
+  ACLImportMemory(pConv->in->allocator(), (void*)x_data, X->Shape().Size() * 4);
+
+  const T* k_data = W->template Data<T>();
+  ACLImportMemory(pConv->k->allocator(), (void*)k_data, W->Shape().Size() * 4);
+
+  if (B != nullptr) {
+    const T* b_data = B->template Data<T>();
+    ACLImportMemory(pConv->b->allocator(), (void*)b_data, B->Shape().Size() * 4);
+  }
+
+  T* y_data = Y->template MutableData<T>();
+  ACLImportMemory(pConv->out->allocator(), (void*)y_data, Y->Shape().Size() * 4);
+
+  ACLImportMemory(pConv->out->allocator(), (void*)y_data, Y->Shape().Size() * 4);
+
+  arm_compute::Allocator alloc_mm{};
+  pConv->mm_layer->populate(alloc_mm, 1);
+  pConv->layer->run();
+  pConv->mm_layer->clear();
+
+  pConv->in->allocator()->free();
+  pConv->k->allocator()->free();
+  if (B != nullptr)
+    pConv->b->allocator()->free();
+  pConv->out->allocator()->free();
+
+  return Status::OK();
+}
+
+template <typename T>
+Status NhwcPoolBase<T>::NhwcPool(OpKernelContext* context, MLAS_POOLING_KIND kind) const {
+  const auto* X = context->Input<Tensor>(0);
+
+  const auto& x_shape = X->Shape();
+  ORT_ENFORCE(x_shape.NumDimensions() == 4);
+
+  arm_compute::Tensor in, out;
+
+  std::vector<int64_t> dilations(PoolBase::pool_attrs_.dilations);
+  std::vector<int64_t> aclDilations(2);
+  aclDilations[0] = (dilations.size() == 2) ? dilations[1] : 1;
+  aclDilations[1] = (!dilations.empty()) ? dilations[0] : 1;
+
+  if (X->Shape().NumDimensions() != PREF_DIM) {
+    ORT_NOT_IMPLEMENTED("Only implemented pooling for 4D input. Number of dimensions found: ", X->Shape().NumDimensions());
+  }
+
+  std::vector<int64_t> pads = PoolBase::pool_attrs_.pads;
+  std::vector<int64_t> strides = PoolBase::pool_attrs_.strides;
+  std::vector<int64_t> kernel_shape = PoolBase::pool_attrs_.kernel_shape;
+
+  if (PoolBase::pool_attrs_.global_pooling) {
+    const auto& input_dims = x_shape.GetDims();
+    kernel_shape.assign(input_dims.begin() + 2, input_dims.end());
+    pads.assign(kernel_shape.size(), 0);
+  }
+
+  std::vector<int64_t> output_dims = PoolBase::pool_attrs_.SetOutputSize(x_shape, x_shape[1], &pads);
+  Tensor* Y = context->Output(0, TensorShape(output_dims));
+
+  ACLNEPool* pPool;
+  PoolLayersIterator it = NhwcPoolBase::poolLayers.find((OpKernel*)this);
+  if (it == NhwcPoolBase::poolLayers.end()) {
+    auto layer = std::make_shared<arm_compute::NEPoolingLayer>();
+
+    ACLNEPool tpool;
+    tpool.in = std::make_shared<arm_compute::Tensor>();
+    tpool.out = std::make_shared<arm_compute::Tensor>();
+
+    tpool.in->allocator()->init(arm_compute::TensorInfo(ACL_NCHW2NHWC(ACLTensorShape(X->Shape(), PREF_DIM)), arm_compute::Format::F32));
+    tpool.out->allocator()->init(arm_compute::TensorInfo(ACL_NCHW2NHWC(ACLTensorShape(Y->Shape(), PREF_DIM)), arm_compute::Format::F32));
+
+    tpool.in.get()->info()->set_data_layout(arm_compute::DataLayout::NHWC);
+    tpool.out.get()->info()->set_data_layout(arm_compute::DataLayout::NHWC);
+
+    arm_compute::PoolingType pool_type;
+    if (PoolBase::op_name_ == "GlobalAveragePool" || PoolBase::op_name_ == "AveragePool")
+      pool_type = arm_compute::PoolingType::AVG;
+    else if (PoolBase::op_name_ == "GlobalMaxPool" || PoolBase::op_name_ == "MaxPool")
+      pool_type = arm_compute::PoolingType::MAX;
+    else
+      ORT_NOT_IMPLEMENTED("Not implemented type of pooling: ", PoolBase::op_name_);
+
+    if (PoolBase::pool_attrs_.global_pooling) {
+      layer->configure(tpool.in.get(), tpool.out.get(), arm_compute::PoolingLayerInfo(pool_type));
+    } else {
+      std::vector<int64_t> aclStrides(2);
+      aclStrides[0] = (strides.size() == 2) ? strides[1] : 1;
+      aclStrides[1] = strides[0];
+
+      std::vector<int64_t> aclPads(4);
+      if (pads.size() == 2) {
+        if (strides.size() == 1) {
+          aclPads[0] = 0;
+          aclPads[1] = 0;
+          aclPads[2] = pads[1];
+          aclPads[3] = pads[0];
+        } else {
+          aclPads[0] = pads[1];
+          aclPads[1] = pads[0];
+          aclPads[2] = pads[1];
+          aclPads[3] = pads[0];
+        }
+      } else {
+        aclPads[0] = pads[1];
+        aclPads[1] = pads[3];
+        aclPads[2] = pads[0];
+        aclPads[3] = pads[2];
+      }
+
+      arm_compute::PadStrideInfo aclPadStride = arm_compute::PadStrideInfo(aclStrides[0], aclStrides[1],
+                                                                           aclPads[0], aclPads[1], aclPads[2], aclPads[3], arm_compute::DimensionRoundingType::FLOOR);
+
+      std::vector<int64_t> aclKernelShape(2);
+      aclKernelShape[0] = (kernel_shape.size() > 1) ? kernel_shape[1] : 1;
+      aclKernelShape[1] = kernel_shape[0];
+
+      arm_compute::Size2D aclSize(aclKernelShape[0], aclKernelShape[1]);
+
+      bool excludePadding = (pool_type == arm_compute::PoolingType::AVG && PoolBase::pool_attrs_.count_include_pad) ? false : true;
+      arm_compute::PoolingLayerInfo pool_info(pool_type, aclSize, aclPadStride, excludePadding);
+      layer->configure(tpool.in.get(), tpool.out.get(), pool_info);
+    }
+
+    // allocate space for input tensor to accomodate paddings and strides
+    tpool.in->allocator()->allocate();
+
+    tpool.layer = std::move(layer);
+    std::pair<PoolLayersIterator, bool> ret;
+    ret = NhwcPoolBase::poolLayers.insert(std::pair<OpKernel*, ACLNEPool>((OpKernel*)this, tpool));
+    pPool = &ret.first->second;
+  } else {
+    pPool = &it->second;
+  }
+
+  const T* x_data = X->template Data<T>();
+  arm_compute::Window aclInpuWindow;
+  aclInpuWindow.use_tensor_dimensions(pPool->in->info()->tensor_shape());
+
+  arm_compute::Iterator aclInputIt(pPool->in.get(), aclInpuWindow);
+  int index = 0;
+
+  // copy input tensor into the larger buffer
+  arm_compute::execute_window_loop(
+      aclInpuWindow,
+      [&](const arm_compute::Coordinates& co) {
+        *reinterpret_cast<float*>(aclInputIt.ptr()) = x_data[index];
+        index++;
+      },
+      aclInputIt);
+
+  T* y_data = Y->template MutableData<T>();
+  ACLImportMemory(pPool->out->allocator(), (void*)y_data, Y->Shape().Size() * 4);
+
+  pPool->layer->run();
+
+  return Status::OK();
+}
+
+template <typename T>
+Status NhwcMaxPool<T>::Compute(OpKernelContext* context) const {
+  return NhwcPoolBase<T>::NhwcPool(context, MlasMaximumPooling);
+}
+
+template <typename T>
+Status NhwcAveragePool<T>::Compute(OpKernelContext* context) const {
+  return NhwcPoolBase<T>::NhwcPool(context, PoolBase::pool_attrs_.count_include_pad ? MlasAveragePoolingIncludePad
+                                                                         : MlasAveragePoolingExcludePad);
+}
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    ReorderInput,
+    kMSNhwcDomain,
+    1,
+    float,
+    kAclExecutionProvider,
+    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    ReorderInput<float>);
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    ReorderOutput,
+    kMSNhwcDomain,
+    1,
+    float,
+    kAclExecutionProvider,
+    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    ReorderOutput<float>);
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    Conv,
+    kMSNhwcDomain,
+    1,
+    float,
+    kAclExecutionProvider,
+    KernelDefBuilder()
+        .MayInplace(3, 0)
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NhwcConv<float>);
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    MaxPool,
+    kMSNhwcDomain,
+    1,
+    float,
+    kAclExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NhwcMaxPool<float>);
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    GlobalMaxPool,
+    kMSNhwcDomain,
+    1,
+    float,
+    kAclExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NhwcMaxPool<float>);
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    AveragePool,
+    kMSNhwcDomain,
+    1,
+    float,
+    kAclExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NhwcAveragePool<float>);
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    GlobalAveragePool,
+    kMSNhwcDomain,
+    1,
+    float,
+    kAclExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NhwcAveragePool<float>);
+
+}  // namespace acl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/acl/nhwc/nhwc_ops.h
+++ b/onnxruntime/core/providers/acl/nhwc/nhwc_ops.h
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) 2020, NXP Semiconductor, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/framework/op_kernel.h"
+//#include "core/providers/cpu/nn/conv_attributes.h"
+#include "core/providers/cpu/nn/conv.h"
+#include "core/providers/cpu/nn/pool.h"
+#include "contrib_ops/cpu/fused_activation.h"
+
+#include "core/framework/op_kernel.h"
+#include "core/providers/acl/acl_execution_provider.h"
+
+// ACL
+#include "arm_compute/core/TensorInfo.h"
+#include "arm_compute/runtime/TensorAllocator.h"
+#include "arm_compute/runtime/Allocator.h"
+#include "arm_compute/runtime/PoolManager.h"
+#include "arm_compute/runtime/BlobLifetimeManager.h"
+#include "arm_compute/runtime/MemoryManagerOnDemand.h"
+
+// NEON
+#include "arm_compute/runtime/NEON/functions/NEConvolutionLayer.h"
+#include "arm_compute/runtime/NEON/functions/NEDepthwiseConvolutionLayer.h"
+#include "arm_compute/runtime/NEON/functions/NEPoolingLayer.h"
+
+namespace onnxruntime {
+namespace acl {
+
+typedef struct
+{
+  std::shared_ptr<arm_compute::NEPermute> layer;
+  std::shared_ptr<arm_compute::MemoryManagerOnDemand> mm_layer;
+  std::shared_ptr<arm_compute::Tensor> in;
+  std::shared_ptr<arm_compute::Tensor> out;
+} ACLNEPermute;
+
+typedef struct
+{
+  std::shared_ptr<arm_compute::IFunction> layer;
+  std::shared_ptr<arm_compute::MemoryManagerOnDemand> mm_layer;
+  std::shared_ptr<arm_compute::Tensor> in;
+  std::shared_ptr<arm_compute::Tensor> k;
+  std::shared_ptr<arm_compute::Tensor> b;
+  std::shared_ptr<arm_compute::Tensor> out;
+  bool isDepthwiseCPU;
+} ACLNEConv;
+
+typedef struct {
+  std::shared_ptr<arm_compute::NEPoolingLayer> layer;
+  std::shared_ptr<arm_compute::Tensor> in;
+  std::shared_ptr<arm_compute::Tensor> out;
+} ACLNEPool;
+
+typedef std::map<OpKernel*, ACLNEPool>::iterator PoolLayersIterator;
+
+template <typename T>
+class ReorderInput : public OpKernel {
+ public:
+  ReorderInput(const OpKernelInfo& info) : OpKernel(info) {}
+
+  Status Compute(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class ReorderOutput : public OpKernel {
+ public:
+  ReorderOutput(const OpKernelInfo& info) : OpKernel(info) {}
+
+  Status Compute(OpKernelContext* context) const override;
+
+ private:
+  int64_t channels_;
+};
+
+typedef std::map<OpKernel*, ACLNEConv>::iterator ConvLayersIterator;
+
+template <typename T>
+class NhwcConv : public onnxruntime::Conv<T> {
+ public:
+  explicit NhwcConv(const OpKernelInfo& info) : onnxruntime::Conv<T>(info), conv_attrs_(info) {
+
+    provider_ = (const_cast<ACLExecutionProvider*>(
+        dynamic_cast<const ACLExecutionProvider*>(info.GetExecutionProvider())));
+  }
+
+  ~NhwcConv() {
+    NhwcConv::convLayers.erase(this);
+  }
+
+  Status Compute(OpKernelContext* context) const override;
+
+ protected:
+  static thread_local std::map<OpKernel*, ACLNEConv> convLayers;
+  ConvAttributes conv_attrs_;
+  ACLExecutionProvider* provider_;
+  std::string activation_type;
+
+  arm_compute::TensorShape ACLReshapeWeightsDepthwise(arm_compute::Tensor* kernel) const;
+};
+
+template <typename T>
+class NhwcPoolBase : public PoolBase {
+ public:
+  NhwcPoolBase(const OpKernelInfo& info) : PoolBase(info) {
+    if (!pool_attrs_.global_pooling)
+      ORT_ENFORCE(pool_attrs_.kernel_shape.size() == 2, "kernel_shape num_dims is not compatible with X num_dims.");
+  }
+
+  Status NhwcPool(OpKernelContext* context, MLAS_POOLING_KIND kind) const;
+
+private:
+  static thread_local std::map<OpKernel*, ACLNEPool> poolLayers;
+  ACLExecutionProvider* provider_;
+};
+
+template <typename T>
+class NhwcMaxPool : public OpKernel, public NhwcPoolBase<T> {
+ public:
+  NhwcMaxPool(const OpKernelInfo& info) : OpKernel(info), NhwcPoolBase<T>(info) {}
+
+  Status Compute(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class NhwcAveragePool : public OpKernel, public NhwcPoolBase<T> {
+ public:
+  NhwcAveragePool(const OpKernelInfo& info) : OpKernel(info), NhwcPoolBase<T>(info) {}
+
+  Status Compute(OpKernelContext* context) const override;
+};
+
+}  // namespace acl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/armnn/armnn_common.h
+++ b/onnxruntime/core/providers/armnn/armnn_common.h
@@ -7,7 +7,8 @@
 #include "core/framework/op_kernel.h"
 
 #include "armnn/ArmNN.hpp"
-
+#include <iostream>
+#include <sstream>
 
 namespace onnxruntime {
 namespace armnn_ep {

--- a/onnxruntime/core/providers/armnn/armnn_execution_provider.cc
+++ b/onnxruntime/core/providers/armnn/armnn_execution_provider.cc
@@ -37,6 +37,15 @@ class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, k
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kOnnxDomain, 1, float, GlobalAveragePool);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kOnnxDomain, 1, float, GlobalMaxPool);
 
+//Nhwc
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kMSNhwcDomain, 1, float, ReorderInput);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kMSNhwcDomain, 1, float, ReorderOutput);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kMSNhwcDomain, 1, float, Conv);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kMSNhwcDomain, 1, float, MaxPool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kMSNhwcDomain, 1, float, GlobalMaxPool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kMSNhwcDomain, 1, float, AveragePool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kMSNhwcDomain, 1, float, GlobalAveragePool);
+
 static void RegisterArmNNKernels(KernelRegistry& kernel_registry) {
 
 #ifdef RELU_ARMNN
@@ -58,6 +67,14 @@ static void RegisterArmNNKernels(KernelRegistry& kernel_registry) {
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kOnnxDomain, 1, float, GlobalAveragePool)>());
   kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kOnnxDomain, 1, float, GlobalMaxPool)>());
 
+  // Nhwc
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kMSNhwcDomain, 1, float, ReorderInput)>());
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kMSNhwcDomain, 1, float, ReorderOutput)>());
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kMSNhwcDomain, 1, float, Conv)>()),
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kMSNhwcDomain, 1, float, MaxPool)>()),
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kMSNhwcDomain, 1, float, GlobalMaxPool)>()),
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kMSNhwcDomain, 1, float, AveragePool)>()),
+  kernel_registry.Register(BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kArmNNExecutionProvider, kMSNhwcDomain, 1, float, GlobalAveragePool)>());
 }
 
 std::shared_ptr<KernelRegistry> GetArmNNKernelRegistry() {

--- a/onnxruntime/core/providers/armnn/nhwc/conv.cc
+++ b/onnxruntime/core/providers/armnn/nhwc/conv.cc
@@ -1,0 +1,306 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) 2020, NXP Semiconductor, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+#ifdef _WIN32
+#pragma warning(disable : 4244)
+#endif
+#include <thread>
+#include <mutex>
+
+#include "core/common/common.h"
+#include "core/framework/op_kernel.h"
+#include "core/util/math.h"
+#include "core/util/math_cpuonly.h"
+
+#include "core/providers/armnn/nhwc/conv.h"
+#include "core/providers/armnn/armnn_common.h"
+#include "core/providers/armnn/armnn_fwd.h"
+
+#include "armnn/ArmNN.hpp"
+
+#define CONV_ARMNN
+
+#define PREF_DIM 4
+
+namespace onnxruntime {
+namespace armnn_ep {
+
+template <typename T>
+thread_local std::map<OpKernel*, armnn::NetworkId> NHWCConv<T>::convLayers;
+
+template <typename T>
+armnn::IRuntimePtr NHWCConv<T>::run = NHWCConv<T>::initRuntime();
+
+armnn::Convolution2dDescriptor createNHWCConvDescriptor(std::vector<int64_t> pads, std::vector<int64_t> dilations, std::vector<int64_t> strides, bool biasEnabled){
+
+    std::vector<int64_t> armnnStrides(2);
+    armnnStrides[0] = (strides.size() == 2) ? strides[1] : 1;
+    armnnStrides[1] = strides[0];
+
+    std::vector<int64_t> armnnDilations(2);
+    armnnDilations[0] = (dilations.size() == 2) ? dilations[1] : 1;
+    armnnDilations[1] = dilations[0];
+
+    std::vector<int64_t> armnnPads(4);
+    if (pads.size() == 2) {
+      if (strides.size() == 1) {
+        armnnPads[0] = 0;
+        armnnPads[1] = 0;
+        armnnPads[2] = pads[1];
+        armnnPads[3] = pads[0];
+      } else {
+        armnnPads[0] = pads[1];
+        armnnPads[1] = pads[0];
+        armnnPads[2] = pads[1];
+        armnnPads[3] = pads[0];
+      }
+    } else {
+      armnnPads[0] = pads[1];
+      armnnPads[1] = pads[3];
+      armnnPads[2] = pads[0];
+      armnnPads[3] = pads[2];
+    }
+
+    armnn::Convolution2dDescriptor convolutionDescriptor;
+    convolutionDescriptor.m_PadLeft = armnnPads[0];
+    convolutionDescriptor.m_PadRight = armnnPads[1];
+    convolutionDescriptor.m_PadTop = armnnPads[2];
+    convolutionDescriptor.m_PadBottom = armnnPads[3];
+    convolutionDescriptor.m_StrideX = armnnStrides[0];
+    convolutionDescriptor.m_StrideY = armnnStrides[1];
+    convolutionDescriptor.m_DilationX = armnnDilations[0];
+    convolutionDescriptor.m_DilationY = armnnDilations[1];
+    convolutionDescriptor.m_BiasEnabled = biasEnabled;
+    convolutionDescriptor.m_DataLayout = armnn::DataLayout::NHWC;
+
+    return convolutionDescriptor;
+}
+
+armnn::DepthwiseConvolution2dDescriptor createNHWCDepthwiseDescriptor(armnn::Convolution2dDescriptor convolutionDescriptor){
+
+    armnn::DepthwiseConvolution2dDescriptor depthwiseDescriptor;
+    depthwiseDescriptor.m_PadLeft      = convolutionDescriptor.m_PadLeft;
+    depthwiseDescriptor.m_PadRight     = convolutionDescriptor.m_PadRight;
+    depthwiseDescriptor.m_PadTop       = convolutionDescriptor.m_PadTop;
+    depthwiseDescriptor.m_PadBottom    = convolutionDescriptor.m_PadBottom;
+    depthwiseDescriptor.m_StrideX      = convolutionDescriptor.m_StrideX;
+    depthwiseDescriptor.m_StrideY      = convolutionDescriptor.m_StrideY;
+    depthwiseDescriptor.m_DilationX    = convolutionDescriptor.m_DilationX;
+    depthwiseDescriptor.m_DilationY    = convolutionDescriptor.m_DilationY;
+    depthwiseDescriptor.m_BiasEnabled  = convolutionDescriptor.m_BiasEnabled;
+    depthwiseDescriptor.m_DataLayout   = convolutionDescriptor.m_DataLayout;
+
+    return depthwiseDescriptor;
+}
+
+template <typename T>
+Status NHWCConv<T>::Compute(OpKernelContext* context) const {
+
+  size_t num_inputs = OpKernel::Node().InputDefs().size();
+  const Tensor* X = context->Input<Tensor>(0);
+    const Tensor* W = context->Input<Tensor>(1);
+    const Tensor* B = num_inputs == 3 ? context->Input<Tensor>(2) : nullptr;
+
+    const int64_t N = X->Shape()[0];
+    const int64_t M = W->Shape()[0];
+
+    if (X->Shape().NumDimensions() != PREF_DIM) {
+      ORT_NOT_IMPLEMENTED("Only implemented convolution for 4D input. Number of dimensions found: ", X->Shape().NumDimensions());
+    }
+
+    ORT_RETURN_IF_ERROR(conv_attrs_.ValidateInputShape(X, W));
+
+    std::vector<int64_t> kernel_shape;
+    ORT_RETURN_IF_ERROR(conv_attrs_.ComputeKernelShape(W->Shape(), kernel_shape));
+
+    std::vector<int64_t> pads(conv_attrs_.pads);
+    if (pads.empty()) {
+      pads.resize(kernel_shape.size() * 2, 0);
+    }
+    std::vector<int64_t> dilations(conv_attrs_.dilations);
+    if (dilations.empty()) {
+      dilations.resize(kernel_shape.size(), 1);
+    }
+    std::vector<int64_t> strides(conv_attrs_.strides);
+    if (strides.empty()) {
+      strides.resize(kernel_shape.size(), 1);
+    }
+
+    std::vector<int64_t> Y_dims;
+    Y_dims.insert(Y_dims.begin(), {N, M});
+    TensorShape input_shape = X->Shape().Slice(2);
+    ORT_RETURN_IF_ERROR(conv_attrs_.InferOutputShape(input_shape, kernel_shape, strides, dilations, &pads, &Y_dims));
+    Tensor* Y = context->Output(0, TensorShape(Y_dims));
+
+    bool biasEnabled = B != nullptr;
+
+    const T* x_data = X->template Data<T>();
+    const T* k_data = W->template Data<T>();
+
+    const T* b_data;
+    if (biasEnabled) {
+      b_data = B->template Data<T>();
+    }
+
+    T* y_data = Y->template MutableData<T>();
+
+    armnn::NetworkId* pNetworkId;
+    ConvLayersIterator it = NHWCConv::convLayers.find((OpKernel*)this);
+    if (it == NHWCConv::convLayers.end()) {
+
+      armnn::NetworkId networkId;
+      armnn::INetworkPtr myNetwork = armnn::INetwork::Create();
+
+      armnn::Convolution2dDescriptor convolutionDescriptor = createNHWCConvDescriptor(pads, dilations, strides, biasEnabled);
+
+      armnn::IConnectableLayer *convolution_armnn;
+      armnn::TensorShape inputShape = ArmNNTensorShape(X->Shape());
+      inputShape = { inputShape[0],
+                     inputShape[2],
+                     inputShape[3],
+                     inputShape[1] };
+
+      if (conv_attrs_.group > 1) {
+
+        if (conv_attrs_.group == inputShape[3]) {
+          // depthwise convolution
+          armnn::DepthwiseConvolution2dDescriptor depthwiseDescriptor = createNHWCDepthwiseDescriptor(convolutionDescriptor);
+
+          armnn::TensorShape weightShape = ArmNNTensorShape(W->Shape());
+          weightShape[1] = weightShape[0];
+          weightShape[0] = 1;
+          armnn::TensorInfo weightsInfo(weightShape, armnn::DataType::Float32);
+          armnn::ConstTensor weights(weightsInfo, k_data);
+
+          if (biasEnabled) {
+            armnn::TensorInfo biasDesc(ArmNNTensorShape(B->Shape()), armnn::DataType::Float32);
+            armnn::ConstTensor bias(biasDesc, b_data);
+            convolution_armnn = myNetwork->AddDepthwiseConvolution2dLayer(depthwiseDescriptor,
+                                                                          weights,
+                                                                          armnn::Optional<armnn::ConstTensor>(bias),
+                                                                          "depthwise_convolution_armnn");
+          } else {
+            convolution_armnn = myNetwork->AddDepthwiseConvolution2dLayer(depthwiseDescriptor,
+                                                                          weights,
+                                                                          armnn::EmptyOptional(),
+                                                                          "depthwise_convolution_armnn");
+          }
+        } else {
+          // NCHWc convolution
+          ORT_NOT_IMPLEMENTED("The 'group' parameter should be 1 or be equal to the channel of the input shape");
+        }
+      } else {
+        // normal convolution
+        armnn::TensorShape weightShape = ArmNNTensorShape(W->Shape());
+        weightShape = { weightShape[0],
+                        weightShape[2],
+                        weightShape[3],
+                        weightShape[1] };
+        armnn::TensorInfo weightsInfo(weightShape, armnn::DataType::Float32);
+        armnn::ConstTensor weights(weightsInfo, k_data);
+
+        if (biasEnabled) {
+          armnn::TensorInfo biasDesc(ArmNNTensorShape(B->Shape()), armnn::DataType::Float32);
+          armnn::ConstTensor bias(biasDesc, b_data);
+          convolution_armnn = myNetwork->AddConvolution2dLayer(convolutionDescriptor,
+                                                               weights,
+                                                               armnn::Optional<armnn::ConstTensor>(bias),
+                                                               "convolution_armnn");
+        } else {
+          convolution_armnn = myNetwork->AddConvolution2dLayer(convolutionDescriptor,
+                                                               weights,
+                                                               armnn::EmptyOptional(),
+                                                               "convolution_armnn");
+        }
+      }
+
+      bool armnn_activ_enabled = false;
+      armnn::ActivationDescriptor desc;
+      desc.m_A = conv_attrs_.alpha;
+
+      if (activation_type == "Relu") {
+        desc.m_Function = armnn::ActivationFunction::ReLu;
+        armnn_activ_enabled = true;
+      } else if (activation_type == "LeakyRelu") {
+        desc.m_Function = armnn::ActivationFunction::LeakyReLu;
+        armnn_activ_enabled = true;
+      } else if (activation_type == "Tanh") {
+        desc.m_Function = armnn::ActivationFunction::TanH;
+        armnn_activ_enabled = true;
+      } else if (activation_type == "Sigmoid") {
+        desc.m_Function = armnn::ActivationFunction::Sigmoid;
+        armnn_activ_enabled = true;
+      } else if (!activation_type.empty()) {
+        ORT_NOT_IMPLEMENTED("Not implemented fused activation: ", activation_type);
+      }
+
+      armnn::IConnectableLayer* activation = myNetwork->AddActivationLayer(desc, "activation_armnn");
+
+      armnn::IConnectableLayer *InputLayer  = myNetwork->AddInputLayer(0);
+      armnn::IConnectableLayer *OutputLayer = myNetwork->AddOutputLayer(0);
+
+      InputLayer->GetOutputSlot(0).Connect(convolution_armnn->GetInputSlot(0));
+      if (armnn_activ_enabled) {
+        convolution_armnn->GetOutputSlot(0).Connect(activation->GetInputSlot(0));
+        activation->GetOutputSlot(0).Connect(OutputLayer->GetInputSlot(0));
+      }
+      else {
+        convolution_armnn->GetOutputSlot(0).Connect(OutputLayer->GetInputSlot(0));
+      }
+
+      //Set the tensors in the network.
+      armnn::TensorInfo inputTensorInfo(inputShape, armnn::DataType::Float32);
+      InputLayer->GetOutputSlot(0).SetTensorInfo(inputTensorInfo);
+
+      armnn::TensorShape outputShape = ArmNNTensorShape(Y->Shape());
+
+      outputShape = { outputShape[0],
+                      outputShape[2],
+                      outputShape[3],
+                      outputShape[1] };
+
+      armnn::TensorInfo outputTensorInfo(outputShape, armnn::DataType::Float32);
+
+      convolution_armnn->GetOutputSlot(0).SetTensorInfo(outputTensorInfo);
+
+      if (armnn_activ_enabled) {
+        activation->GetOutputSlot(0).SetTensorInfo(outputTensorInfo);
+      }
+
+      // Optimise ArmNN network
+      armnn::IOptimizedNetworkPtr optNet = armnn::Optimize(*myNetwork, {armnn::Compute::CpuAcc}, NHWCConv::run->GetDeviceSpec());
+
+      // Load graph into runtime
+      NHWCConv::run->LoadNetwork(networkId, std::move(optNet));
+
+      std::pair<ConvLayersIterator, bool> ret;
+      ret = NHWCConv::convLayers.insert(std::pair<OpKernel*, armnn::NetworkId>((OpKernel*)this, networkId));
+      pNetworkId = &ret.first->second;
+
+    } else {
+      pNetworkId = &it->second;
+    }
+
+    armnn::InputTensors inputTensors{{0, armnn::ConstTensor(NHWCConv::run->GetInputTensorInfo(*pNetworkId, 0),
+                                                            x_data)}};
+    armnn::OutputTensors outputTensors{{0, armnn::Tensor(NHWCConv::run->GetOutputTensorInfo(*pNetworkId, 0),
+                                                         y_data)}};
+
+    // Execute network
+    NHWCConv::run->EnqueueWorkload(*pNetworkId, inputTensors, outputTensors);
+
+    return Status::OK();
+}
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    Conv,
+    kMSNhwcDomain,
+    1,
+    float,
+    kArmNNExecutionProvider,
+    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NHWCConv<float>);
+
+}  // namespace armnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/armnn/nhwc/conv.h
+++ b/onnxruntime/core/providers/armnn/nhwc/conv.h
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) 2020, NXP Semiconductor, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "core/framework/op_kernel.h"
+#include "core/providers/cpu/nn/conv.h"
+#include "core/providers/armnn/armnn_execution_provider.h"
+
+#include "armnn/ArmNN.hpp"
+
+#include <thread>
+#include <mutex>
+
+namespace onnxruntime {
+namespace armnn_ep{
+
+typedef std::map<OpKernel*, armnn::NetworkId>::iterator ConvLayersIterator;
+
+template <typename T>
+class NHWCConv : public onnxruntime::Conv<T> {
+ public:
+  explicit NHWCConv(const OpKernelInfo& info) : onnxruntime::Conv<T>(info), conv_attrs_(info) {
+    provider_ = (const_cast<ArmNNExecutionProvider*>(
+        dynamic_cast<const ArmNNExecutionProvider*>(info.GetExecutionProvider())));
+  }
+
+  ~NHWCConv() {
+    NHWCConv::convLayers.erase(this);
+  }
+
+  Status Compute(OpKernelContext* context) const override;
+
+  static armnn::IRuntimePtr initRuntime(){
+    if (NHWCConv::run)
+      return std::move(NHWCConv::run);
+    armnn::IRuntime::CreationOptions options;
+    return std::move(armnn::IRuntime::Create(options));
+  }
+
+ protected:
+  static thread_local std::map<OpKernel*, armnn::NetworkId> convLayers;
+  ConvAttributes conv_attrs_;
+  ArmNNExecutionProvider* provider_;
+  static armnn::IRuntimePtr run;
+  std::string activation_type;
+
+};
+
+}  // namespace armnn_ep
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/armnn/nhwc/nhwc_ops.cc
+++ b/onnxruntime/core/providers/armnn/nhwc/nhwc_ops.cc
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/framework/op_kernel_context_internal.h"
+#include "core/providers/armnn/armnn_common.h"
+#include "core/providers/armnn/nhwc/nhwc_ops.h"
+#include "core/providers/armnn/armnn_fwd.h"
+
+#include "armnn/ArmNN.hpp"
+
+#include <thread>
+#include <mutex>
+
+namespace onnxruntime {
+namespace armnn_ep {
+
+const armnn::PermutationVector toNCHW = { 0, 2, 3, 1 };
+const armnn::PermutationVector toNHWC = { 0, 3, 1, 2 };
+
+armnn::TensorShape ARMNN_NCHW2NHWC(armnn::TensorShape shape) {
+
+    return {shape[0], shape[2], shape[3], shape[1]};
+}
+
+template <typename T>
+Status ReorderInput<T>::Compute(OpKernelContext* context) const {
+
+  return ::onnxruntime::acl::ReorderInput<T>::Compute(context);
+
+}
+
+template <typename T>
+Status ReorderOutput<T>::Compute(OpKernelContext* context) const {
+
+  return ::onnxruntime::acl::ReorderOutput<T>::Compute(context);
+}
+
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    ReorderInput,
+    kMSNhwcDomain,
+    1,
+    float,
+    kArmNNExecutionProvider,
+    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    ReorderInput<float>);
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    ReorderOutput,
+    kMSNhwcDomain,
+    1,
+    float,
+    kArmNNExecutionProvider,
+    KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    ReorderOutput<float>);
+
+}  // namespace armnn_ep
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/armnn/nhwc/nhwc_ops.h
+++ b/onnxruntime/core/providers/armnn/nhwc/nhwc_ops.h
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/framework/op_kernel.h"
+#include "core/providers/armnn/armnn_execution_provider.h"
+#include "core/providers/acl/nhwc/nhwc_ops.h"
+
+#include "armnn/ArmNN.hpp"
+
+#include <thread>
+#include <mutex>
+
+namespace onnxruntime {
+namespace armnn_ep {
+
+template <typename T>
+class ReorderInput : public ::onnxruntime::acl::ReorderInput<T> {
+ public:
+  ReorderInput(const OpKernelInfo& info) : onnxruntime::acl::ReorderInput<T>(info) {}
+
+  Status Compute(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class ReorderOutput : public ::onnxruntime::acl::ReorderOutput<T> {
+ public:
+  ReorderOutput(const OpKernelInfo& info) : onnxruntime::acl::ReorderOutput<T>(info) {}
+
+  Status Compute(OpKernelContext* context) const override;
+
+ private:
+  int64_t channels_;
+};
+
+}  // namespace armnn_ep
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/armnn/nhwc/pool.cc
+++ b/onnxruntime/core/providers/armnn/nhwc/pool.cc
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) 2019, NXP Semiconductor, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+#include <cmath>
+
+#include "core/common/common.h"
+#include "core/framework/op_kernel.h"
+#include "core/util/math.h"
+#include "core/util/math_cpuonly.h"
+
+#include "core/providers/armnn/nhwc/pool.h"
+#include "core/providers/armnn/armnn_common.h"
+#include "core/providers/armnn/armnn_fwd.h"
+
+#include "armnn/ArmNN.hpp"
+
+#define PREF_DIM 4
+
+namespace onnxruntime {
+namespace armnn_ep {
+
+template <typename T, typename PoolType>
+thread_local std::map<OpKernel*, armnn::NetworkId> NHWCPool<T, PoolType>::poolLayers;
+
+template <typename T, typename PoolType>
+armnn::IRuntimePtr NHWCPool<T, PoolType>::run = NHWCPool<T, PoolType>::initRuntime();
+
+armnn::Pooling2dDescriptor createNHWCDescriptor(std::vector<int64_t> pads, std::vector<int64_t> strides, std::vector<int64_t> kernel_shape, armnn::PoolingAlgorithm pool_type, onnxruntime::PoolAttributes pool_attrs){
+
+  std::vector<int64_t> armnnStrides(2);
+  armnnStrides[0] = (strides.size() == 2) ? strides[1] : 1;
+  armnnStrides[1] = strides[0];
+
+  std::vector<int64_t> armnnKernelShape(2);
+  armnnKernelShape[0] = (kernel_shape.size() > 1) ? kernel_shape[1] : 1;
+  armnnKernelShape[1] = kernel_shape[0];
+
+  std::vector<int64_t> armnnPads(4);
+  if (pads.size() == 2) {
+    if (strides.size() == 1) {
+      armnnPads[0] = 0;
+      armnnPads[1] = 0;
+      armnnPads[2] = pads[1];
+      armnnPads[3] = pads[0];
+    } else {
+      armnnPads[0] = pads[1];
+      armnnPads[1] = pads[0];
+      armnnPads[2] = pads[1];
+      armnnPads[3] = pads[0];
+    }
+  } else {
+    armnnPads[0] = pads[1];
+    armnnPads[1] = pads[3];
+    armnnPads[2] = pads[0];
+    armnnPads[3] = pads[2];
+  }
+
+  armnn::Pooling2dDescriptor poolDescriptor;
+  poolDescriptor.m_PoolType = pool_type;
+  poolDescriptor.m_PadLeft = armnnPads[0];
+  poolDescriptor.m_PadRight = armnnPads[1];
+  poolDescriptor.m_PadTop = armnnPads[2];
+  poolDescriptor.m_PadBottom = armnnPads[3];
+  poolDescriptor.m_PoolWidth = armnnKernelShape[0];
+  poolDescriptor.m_PoolHeight = armnnKernelShape[1];
+  poolDescriptor.m_StrideX = armnnStrides[0];
+  poolDescriptor.m_StrideY = armnnStrides[1];
+  poolDescriptor.m_OutputShapeRounding = pool_attrs.ceil_mode ? armnn::OutputShapeRounding::Ceiling : armnn::OutputShapeRounding::Floor;
+  poolDescriptor.m_PaddingMethod = armnn::PaddingMethod::Exclude;
+  if (pool_type == armnn::PoolingAlgorithm::Average && pool_attrs.count_include_pad)
+    poolDescriptor.m_PaddingMethod = armnn::PaddingMethod::IgnoreValue;
+  poolDescriptor.m_DataLayout = armnn::DataLayout::NHWC;
+
+  return poolDescriptor;
+}
+
+template <typename T, typename PoolType>
+Status NHWCPool<T, PoolType>::Compute(OpKernelContext* context) const {
+
+  const Tensor* X = context->Input<Tensor>(0);
+  const TensorShape& x_shape = X->Shape();
+
+  std::vector<int64_t> dilations(PoolBase::pool_attrs_.dilations);
+  std::vector<int64_t> armnnDilations(2);
+  armnnDilations[0] = (dilations.size() == 2) ? dilations[1] : 1;
+  armnnDilations[1] = (!dilations.empty()) ? dilations[0] : 1;
+
+  if (X->Shape().NumDimensions() != PREF_DIM) {
+    ORT_NOT_IMPLEMENTED("Only implemented pooling for 4D input. Number of dimensions found: ", X->Shape().NumDimensions());
+  }
+
+  if (armnnDilations[0] * armnnDilations[1] > 1) {
+    ORT_NOT_IMPLEMENTED("ArmNN does not support dilation");
+  }
+
+  std::vector<int64_t> pads = PoolBase::pool_attrs_.pads;
+  std::vector<int64_t> strides = PoolBase::pool_attrs_.strides;
+  std::vector<int64_t> kernel_shape = PoolBase::pool_attrs_.kernel_shape;
+
+  if (PoolBase::pool_attrs_.global_pooling) {
+    const auto& input_dims = x_shape.GetDims();
+    kernel_shape.assign(input_dims.begin() + 2, input_dims.end());
+    strides.assign(kernel_shape.size(), 0);
+    pads.assign(kernel_shape.size(), 0);
+  }
+
+  std::vector<int64_t> output_dims = PoolBase::pool_attrs_.SetOutputSize(x_shape, x_shape[1], &pads);
+  Tensor* Y = context->Output(0, TensorShape(output_dims));
+
+  const T* x_data = X->template Data<T>();
+  T* y_data = Y->template MutableData<T>();
+
+  armnn::NetworkId* pNetworkId;
+  PoolLayersIterator it = NHWCPool::poolLayers.find((OpKernel*)this);
+  if (it == NHWCPool::poolLayers.end()) {
+
+    armnn::PoolingAlgorithm pool_type;
+    if (PoolBase::op_name_ == "GlobalAveragePool" || PoolBase::op_name_ == "AveragePool"){
+      pool_type = armnn::PoolingAlgorithm::Average;
+    } else if (PoolBase::op_name_ == "GlobalMaxPool" || PoolBase::op_name_ == "MaxPool"){
+      pool_type = armnn::PoolingAlgorithm::Max;
+    } else
+      ORT_NOT_IMPLEMENTED("Not implemented type of pooling: ", PoolBase::op_name_);
+
+    armnn::NetworkId networkId;
+
+    armnn::INetworkPtr myNetwork = armnn::INetwork::Create();
+
+    armnn::Pooling2dDescriptor poolDescriptor = createNHWCDescriptor(pads, strides, kernel_shape, pool_type, PoolBase::pool_attrs_);
+
+    armnn::IConnectableLayer *pool_armnn = myNetwork->AddPooling2dLayer(poolDescriptor, "pool_armnn");
+    armnn::TensorShape inputShape = ArmNNTensorShape(X->Shape());
+    armnn::TensorShape outputShape = ArmNNTensorShape(Y->Shape());
+
+    inputShape = { inputShape[0],
+                   inputShape[2],
+                   inputShape[3],
+                   inputShape[1] };
+
+    outputShape = { outputShape[0],
+                    outputShape[2],
+                    outputShape[3],
+                    outputShape[1] };
+
+    armnn::IConnectableLayer *InputLayer  = myNetwork->AddInputLayer(0);
+    armnn::IConnectableLayer *OutputLayer = myNetwork->AddOutputLayer(0);
+
+    InputLayer->GetOutputSlot(0).Connect(pool_armnn->GetInputSlot(0));
+    pool_armnn->GetOutputSlot(0).Connect(OutputLayer->GetInputSlot(0));
+
+    //Set the tensors in the network.
+    armnn::TensorInfo inputTensorInfo(inputShape, armnn::DataType::Float32);
+    InputLayer->GetOutputSlot(0).SetTensorInfo(inputTensorInfo);
+
+    armnn::TensorInfo outputTensorInfo(outputShape, armnn::DataType::Float32);
+    pool_armnn->GetOutputSlot(0).SetTensorInfo(outputTensorInfo);
+
+    // Optimise ArmNN network
+    armnn::IOptimizedNetworkPtr optNet = armnn::Optimize(*myNetwork, {armnn::Compute::CpuAcc}, NHWCPool::run->GetDeviceSpec());
+
+    // Load graph into runtime
+    NHWCPool::run->LoadNetwork(networkId, std::move(optNet));
+
+    std::pair<PoolLayersIterator, bool> ret;
+    ret = NHWCPool::poolLayers.insert(std::pair<OpKernel*, armnn::NetworkId>((OpKernel*)this, networkId));
+    pNetworkId = &ret.first->second;
+
+  } else {
+    pNetworkId = &it->second;
+  }
+
+  armnn::InputTensors inputTensors{{0, armnn::ConstTensor(NHWCPool::run->GetInputTensorInfo(*pNetworkId, 0),
+                                                          x_data)}};
+  armnn::OutputTensors outputTensors{{0, armnn::Tensor(NHWCPool::run->GetOutputTensorInfo(*pNetworkId, 0),
+                                                       y_data)}};
+
+  // Execute network
+  NHWCPool::run->EnqueueWorkload(*pNetworkId, inputTensors, outputTensors);
+
+  return Status::OK();
+}
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    MaxPool,
+    kMSNhwcDomain,
+    1,
+    float,
+    kArmNNExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NHWCPool<float, MaxPool<1>>);
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    GlobalMaxPool,
+    kMSNhwcDomain,
+    1,
+    float,
+    kArmNNExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NHWCPool<float, MaxPool<1>>);
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    AveragePool,
+    kMSNhwcDomain,
+    1,
+    float,
+    kArmNNExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NHWCPool<float, AveragePool>);
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    GlobalAveragePool,
+    kMSNhwcDomain,
+    1,
+    float,
+    kArmNNExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NHWCPool<float, AveragePool>);
+
+}  // namespace armnn_ep
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/armnn/nhwc/pool.h
+++ b/onnxruntime/core/providers/armnn/nhwc/pool.h
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) 2020, NXP Semiconductor, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "core/framework/op_kernel.h"
+#include "core/providers/cpu/nn/pool.h"
+#include "core/providers/armnn/armnn_execution_provider.h"
+
+#include "armnn/ArmNN.hpp"
+
+#include <thread>
+#include <mutex>
+
+namespace onnxruntime {
+namespace armnn_ep {
+
+typedef std::map<OpKernel*, armnn::NetworkId>::iterator PoolLayersIterator;
+
+template <typename T, typename PoolType>
+class NHWCPool final : public onnxruntime::Pool<T, PoolType> {
+ public:
+  explicit NHWCPool(const OpKernelInfo& info) : onnxruntime::Pool<T, PoolType>(info) {
+    provider_ = (const_cast<ArmNNExecutionProvider*>(
+        dynamic_cast<const ArmNNExecutionProvider*>(info.GetExecutionProvider())));
+  }
+
+  ~NHWCPool() {
+    poolLayers.erase(this);
+  }
+
+  Status Compute(OpKernelContext* context) const override;
+
+  static armnn::IRuntimePtr initRuntime(){
+    if (NHWCPool::run)
+      return std::move(NHWCPool::run);
+    armnn::IRuntime::CreationOptions options;
+    return std::move(armnn::IRuntime::Create(options));
+  }
+
+ private:
+  static thread_local std::map<OpKernel*, armnn::NetworkId> poolLayers;
+  ArmNNExecutionProvider* provider_;
+  static armnn::IRuntimePtr run;
+};
+
+}  // namespace armnn_ep
+}  // namespace onnxruntime

--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -75,6 +75,7 @@ Status Environment::Initialize(std::unique_ptr<logging::LoggingManager> logging_
     std::call_once(schemaRegistrationOnceFlag, []() {
       ONNX_NAMESPACE::OpSchemaRegistry::DomainToVersionRange::Instance().AddDomainToVersion(onnxruntime::kMSDomain, 1, 1);
       ONNX_NAMESPACE::OpSchemaRegistry::DomainToVersionRange::Instance().AddDomainToVersion(onnxruntime::kMSNchwcDomain, 1, 1);
+      ONNX_NAMESPACE::OpSchemaRegistry::DomainToVersionRange::Instance().AddDomainToVersion(onnxruntime::kMSNhwcDomain, 1, 1);
       ONNX_NAMESPACE::OpSchemaRegistry::DomainToVersionRange::Instance().AddDomainToVersion(onnxruntime::kMSFeaturizersDomain, 1, 1);
 #ifdef USE_DML
       ONNX_NAMESPACE::OpSchemaRegistry::DomainToVersionRange::Instance().AddDomainToVersion(onnxruntime::kMSDmlDomain, 1, 1);

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1469,8 +1469,9 @@ void InferenceSession::AddPredefinedTransformers(GraphTransformerManager& transf
                                                  const std::vector<std::string>& custom_list) {
   auto add_transformers = [&](TransformerLevel level) {
     // Generate and register transformers for level
-    auto transformers_to_register =
-        optimizer_utils::GenerateTransformers(level, session_options_.free_dimension_overrides, custom_list);
+    auto transformers_to_register = optimizer_utils::GenerateTransformers(level, session_options_.free_dimension_overrides,
+       custom_list, GetRegisteredProviderTypes());
+
     for (auto& entry : transformers_to_register) {
       transformer_manager.Register(std::move(entry), level);
     }

--- a/onnxruntime/test/framework/test_utils.cc
+++ b/onnxruntime/test/framework/test_utils.cc
@@ -50,6 +50,14 @@ IExecutionProvider* TestRknpuExecutionProvider() {
 }
 #endif
 
+#ifdef USE_ACL
+IExecutionProvider* TestACLExecutionProvider() {
+  static ACLExecutionProviderInfo info;
+  static ACLExecutionProvider acl_provider(info);
+  return &acl_provider;
+}
+#endif
+
 static void CountOpsInGraphImpl(
     const Graph& graph, bool recurse_into_subgraphs, std::map<std::string, int>& ops) {
   for (auto& node : graph.Nodes()) {

--- a/onnxruntime/test/framework/test_utils.h
+++ b/onnxruntime/test/framework/test_utils.h
@@ -27,6 +27,9 @@
 #ifdef USE_RKNPU
 #include "core/providers/rknpu/rknpu_execution_provider.h"
 #endif
+#ifdef USE_ACL
+#include "core/providers/acl/acl_execution_provider.h"
+#endif
 
 namespace onnxruntime {
 class Graph;
@@ -55,6 +58,10 @@ IExecutionProvider* TestNnapiExecutionProvider();
 
 #ifdef USE_RKNPU
 IExecutionProvider* TestRknpuExecutionProvider();
+#endif
+
+#ifdef USE_ACL
+IExecutionProvider* TestACLExecutionProvider();
 #endif
 
 template <typename T>

--- a/onnxruntime/test/optimizer/nhwc_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/nhwc_optimizer_test.cc
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if defined(USE_ACL)
+
+#include "core/session/inference_session.h"
+#include "core/graph/model.h"
+#include "test/test_environment.h"
+#include "test/framework/test_utils.h"
+#include "test/compare_ortvalue.h"
+#include "gtest/gtest.h"
+#include "test/util/include/default_providers.h"
+
+namespace onnxruntime {
+namespace test {
+
+// InferenceSession wrapper in order to gain access to the loaded graph.
+class NhwcInferenceSession : public InferenceSession {
+ public:
+  explicit NhwcInferenceSession(const SessionOptions& session_options,
+                                 const Environment& env) : InferenceSession(session_options, env) {
+  }
+
+  std::unordered_map<std::string, int> CountOpsInGraph() {
+    std::unordered_map<std::string, int> op_to_count;
+    if (model_.get() != nullptr) {
+      for (auto& node : model_->MainGraph().Nodes()) {
+        std::string key = node.OpType();
+        if (node.Domain() == kMSNhwcDomain) {
+          key = "nhwc." + key;
+        }
+        op_to_count[key] = op_to_count[key] + 1;
+      }
+    }
+    return op_to_count;
+  }
+
+  const Graph& GetGraph() {
+    return model_->MainGraph();
+  }
+};
+
+struct NhwcTestHelper {
+  NhwcTestHelper(Graph& graph) : graph_(graph), fill_value_(0) {
+  }
+
+  NodeArg* MakeInput(const std::vector<int64_t>& shape, const ONNX_NAMESPACE::TypeProto& type_proto) {
+    int64_t num_elements = 1;
+    for (auto& dim : shape) {
+      num_elements *= dim;
+    }
+
+    OrtValue input_value;
+    CreateMLValue<float>(TestACLExecutionProvider()->GetAllocator(0, OrtMemTypeDefault), shape,
+                         FillRandomData(static_cast<size_t>(num_elements)), &input_value);
+    std::string name = graph_.GenerateNodeArgName("input");
+    feeds_.insert(std::make_pair(name, input_value));
+
+    return &graph_.GetOrCreateNodeArg(name, &type_proto);
+  }
+
+  NodeArg* MakeInput(const std::vector<int64_t>& shape) {
+    ONNX_NAMESPACE::TypeProto type_proto;
+    type_proto.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+
+    for (auto& dim : shape) {
+      type_proto.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(dim);
+    }
+
+    return MakeInput(shape, type_proto);
+  }
+
+  NodeArg* MakeOutput() {
+    std::string name = graph_.GenerateNodeArgName("output");
+    output_names_.push_back(name);
+    return &graph_.GetOrCreateNodeArg(name, nullptr);
+  }
+
+  NodeArg* MakeIntermediate() {
+    std::string name = graph_.GenerateNodeArgName("node");
+    return &graph_.GetOrCreateNodeArg(name, nullptr);
+  }
+
+  NodeArg* MakeInitializer(const std::vector<int64_t>& shape, const std::vector<float>& data) {
+    std::string name = graph_.GenerateNodeArgName("constant");
+    ONNX_NAMESPACE::TensorProto tensor_proto;
+    tensor_proto.set_name(name);
+    tensor_proto.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+
+    for (auto& dim : shape) {
+      tensor_proto.add_dims(dim);
+    }
+
+    tensor_proto.mutable_float_data()->Resize(static_cast<int>(data.size()), 0.0f);
+    memcpy(tensor_proto.mutable_float_data()->mutable_data(), data.data(), data.size() * sizeof(float));
+
+    graph_.AddInitializedTensor(tensor_proto);
+
+    return &graph_.GetOrCreateNodeArg(name, nullptr);
+  }
+
+  NodeArg* MakeInitializer(const std::vector<int64_t>& shape) {
+    int64_t num_elements = std::accumulate(shape.begin(), shape.end(), int64_t(1), std::multiplies<int64_t>{});
+    return MakeInitializer(shape, FillRandomData(static_cast<size_t>(num_elements)));
+  }
+
+  Node& AddNode(const std::string& op_type,
+                const std::vector<NodeArg*>& input_args,
+                const std::vector<NodeArg*>& output_args) {
+   Node& node = graph_.AddNode(graph_.GenerateNodeName("node"),
+                          op_type,
+                          "description",
+                          input_args,
+                          output_args,
+                          nullptr,
+                          kOnnxDomain);
+   node.SetExecutionProviderType(kAclExecutionProvider);
+   return node;
+  }
+
+  Node& AddConvNode(NodeArg* input_arg, NodeArg* output_arg, const std::vector<int64_t>& weights_shape, bool no_bias = false) {
+    auto* weights_arg = MakeInitializer(weights_shape);
+    std::vector<NodeArg*> input_args = {input_arg, weights_arg};
+    if (!no_bias) {
+      auto* biases_arg = MakeInitializer({weights_shape[0]});
+      input_args.push_back(biases_arg);
+    }
+
+    return AddNode("Conv", input_args, {output_arg});
+  }
+
+  std::vector<float> FillRandomData(size_t count) {
+    constexpr int min_fill_value = -23;
+    constexpr int max_fill_value = 23;
+
+    std::vector<float> random_data {};
+    random_data.resize(count);
+
+    for (size_t n = 0; n < count; n++) {
+      random_data[n] = static_cast<float>(fill_value_);
+      fill_value_++;
+      if (fill_value_ == max_fill_value) {
+        fill_value_ = min_fill_value;
+      }
+    }
+
+    return random_data;
+  }
+
+  Graph& graph_;
+  NameMLValMap feeds_;
+  std::vector<std::string> output_names_;
+  int fill_value_;
+};
+
+void NhwcOptimizerTester(const std::function<void(NhwcTestHelper& helper)>& build_test_case,
+                          const std::function<void(NhwcInferenceSession& session)>& check_nhwc_graph,
+                          int opset_version = 10) {
+
+#ifndef USE_ACL
+  return;
+#endif
+
+  // Build the model for this test.
+  std::unordered_map<std::string, int> domain_to_version;
+  domain_to_version[kOnnxDomain] = opset_version;
+  Model model("nhwc", false, ModelMetaData(), PathString(), IOnnxRuntimeOpSchemaRegistryList(),
+              domain_to_version, {}, DefaultLoggingManager().DefaultLogger());
+
+  NhwcTestHelper helper(model.MainGraph());
+  build_test_case(helper);
+  ASSERT_TRUE(model.MainGraph().Resolve().IsOK());
+
+  // assign all nodes to ACL. the constant folding should override this to perform the constant folding on cpu
+  for (auto& node : model.MainGraph().Nodes())
+    node.SetExecutionProviderType(kAclExecutionProvider);
+
+  // Serialize the model to a string.
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+
+  auto run_model = [&](TransformerLevel level, std::vector<OrtValue>& fetches) {
+    SessionOptions session_options;
+    session_options.graph_optimization_level = level;
+    session_options.session_logid = "NhwcOptimizerTests";
+
+    NhwcInferenceSession session{session_options, GetEnvironment()};
+    ASSERT_TRUE(session.RegisterExecutionProvider(std::move(DefaultAclExecutionProvider())).IsOK());
+    ASSERT_TRUE(session.Load(model_data.data(), static_cast<int>(model_data.size())).IsOK());
+    ASSERT_TRUE(session.Initialize().IsOK());
+
+    RunOptions run_options;
+    auto status = session.Run(run_options, helper.feeds_, helper.output_names_, &fetches);
+    if (!status.IsOK()) {
+      std::cout << "Run failed with status message: " << status.ErrorMessage() << std::endl;
+    }
+    ASSERT_TRUE(status.IsOK());
+
+    if (level == TransformerLevel::Level3) {
+      check_nhwc_graph(session);
+    }
+  };
+
+  std::vector<OrtValue> level2_fetches;
+  run_model(TransformerLevel::Level2, level2_fetches);
+
+  std::vector<OrtValue> level3_fetches;
+  run_model(TransformerLevel::Level3, level3_fetches);
+
+  size_t num_outputs = level2_fetches.size();
+  ASSERT_TRUE(num_outputs == level3_fetches.size());
+
+  for (size_t i = 0; i < num_outputs; i++) {
+    double per_sample_tolerance = 0.0;
+    double relative_per_sample_tolerance = 0.0;
+    std::pair<COMPARE_RESULT, std::string> ret =
+        CompareOrtValue(level3_fetches[i],
+                        level2_fetches[i],
+                        per_sample_tolerance,
+                        relative_per_sample_tolerance,
+                        false);
+    EXPECT_EQ(ret.first, COMPARE_RESULT::SUCCESS);
+  }
+}
+
+#ifndef DISABLE_CONTRIB_OPS
+TEST(NhwcOptimizerTests, Test1Nhwc) {
+  auto build_test_case = [&](NhwcTestHelper& helper) {
+    auto* input_arg = helper.MakeInput({1, 4, 28, 28});
+    auto* output_arg = helper.MakeOutput();
+
+    helper.AddConvNode(input_arg, output_arg, {2, 4, 3, 3});
+  };
+
+  auto check_nhwc_graph = [&](NhwcInferenceSession& session) {
+    auto op_to_count = session.CountOpsInGraph();
+
+    EXPECT_EQ(op_to_count["nhwc.ReorderInput"], 1);
+    EXPECT_EQ(op_to_count["nhwc.Conv"], 1);
+    EXPECT_EQ(op_to_count["nhwc.ReorderOutput"], 1);
+  };
+
+  NhwcOptimizerTester(build_test_case, check_nhwc_graph);
+}
+#endif
+
+}  // namespace test
+}  // namespace onnxruntime
+#endif


### PR DESCRIPTION
NCHWC transformation is tailored for mlas library and does not accomodate
the simpler NHWC format supported by ACL and ArmNN EPs.

Add NHWC transformation with support to reorder input, output and permute
(fused) convolution weights and enable it for ACL and ArmnNN EPs.

With ACL EPs the optimizaiton improves latency for mobilenets_v2 with 33%,
resnet50_v1 with 24% and vgg19 with 64%. Subsequent pacthes with support
for Concat and BN channel-last operations will further improve performance
with ~20%.
