### PR TITLE
Added GetAvailableProviders() to C API

### DIFF
--- a/include/onnxruntime/core/graph/constants.h
+++ b/include/onnxruntime/core/graph/constants.h
@@ -38,4 +38,20 @@ constexpr const char* kDmlExecutionProvider = "DmlExecutionProvider";
 constexpr const char* kMIGraphXExecutionProvider = "MIGraphXExecutionProvider";
 constexpr const char* kAclExecutionProvider = "ACLExecutionProvider";
 constexpr const char* kArmNNExecutionProvider = "ArmNNExecutionProvider";
+constexpr const char *all_providers[] = {
+  kCpuExecutionProvider,
+  kCudaExecutionProvider,
+  kDnnlExecutionProvider,
+  kNGraphExecutionProvider,
+  kOpenVINOExecutionProvider,
+  kNupharExecutionProvider,
+  kVitisAIExecutionProvider,
+  kTensorrtExecutionProvider,
+  kNnapiExecutionProvider,
+  kRknpuExecutionProvider,
+  kDmlExecutionProvider,
+  kMIGraphXExecutionProvider,
+  kAclExecutionProvider,
+  kArmNNExecutionProvider,
+};
 }  // namespace onnxruntime

--- a/include/onnxruntime/core/graph/constants.h
+++ b/include/onnxruntime/core/graph/constants.h
@@ -38,7 +38,7 @@ constexpr const char* kDmlExecutionProvider = "DmlExecutionProvider";
 constexpr const char* kMIGraphXExecutionProvider = "MIGraphXExecutionProvider";
 constexpr const char* kAclExecutionProvider = "ACLExecutionProvider";
 constexpr const char* kArmNNExecutionProvider = "ArmNNExecutionProvider";
-constexpr const char *available_providers[] = {
+constexpr const char *providers_available[] = {
   kCpuExecutionProvider,
 #ifdef USE_CUDA
   kCudaExecutionProvider,

--- a/include/onnxruntime/core/graph/constants.h
+++ b/include/onnxruntime/core/graph/constants.h
@@ -38,20 +38,46 @@ constexpr const char* kDmlExecutionProvider = "DmlExecutionProvider";
 constexpr const char* kMIGraphXExecutionProvider = "MIGraphXExecutionProvider";
 constexpr const char* kAclExecutionProvider = "ACLExecutionProvider";
 constexpr const char* kArmNNExecutionProvider = "ArmNNExecutionProvider";
-constexpr const char *all_providers[] = {
+constexpr const char *available_providers[] = {
   kCpuExecutionProvider,
+#ifdef USE_CUDA
   kCudaExecutionProvider,
+#endif
+#ifdef USE_DNNL
   kDnnlExecutionProvider,
+#endif
+#ifdef USE_NGRAPH
   kNGraphExecutionProvider,
+#endif
+#ifdef USE_OPENVINO
   kOpenVINOExecutionProvider,
+#endif
+#ifdef USE_NUPHAR
   kNupharExecutionProvider,
+#endif
+#ifdef USE_VITISAI
   kVitisAIExecutionProvider,
+#endif
+#ifdef USE_TENSORRT
   kTensorrtExecutionProvider,
+#endif
+#ifdef USE_NNAPI
   kNnapiExecutionProvider,
+#endif
+#ifdef USE_RKNPU
   kRknpuExecutionProvider,
+#endif
+#ifdef USE_DML
   kDmlExecutionProvider,
+#endif
+#ifdef USE_MIGRAPHX
   kMIGraphXExecutionProvider,
+#endif
+#ifdef USE_ACL
   kAclExecutionProvider,
+#endif
+#ifdef USE_ARMNN
   kArmNNExecutionProvider,
+#endif
 };
 }  // namespace onnxruntime

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -834,7 +834,7 @@ struct OrtApi {
    * get after calling GetAvailableProviders().
    * \param providers_length is the number of available providers.
    */
-  ORT_API2_STATUS(ReleaseGetAvailableProviders, _In_ char **ptr,
+  ORT_API2_STATUS(ReleaseAvailableProviders, _In_ char **ptr,
                   _In_ int providers_length);
 };
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -7,7 +7,7 @@
 #include <string.h>
 
 // This value is used in structures passed to ORT so that a newer version of ORT will still work with them
-#define ORT_API_VERSION 3
+#define ORT_API_VERSION 4
 
 #ifdef __cplusplus
 extern "C" {
@@ -824,7 +824,7 @@ struct OrtApi {
    * \param provider_length is a pointer to an int variable where
    * the number of available providers will be added.
    * The caller is responsible for freeing each char * and the pointer
-   * array by calling ReleaseGetAvailableProviders().
+   * array by calling ReleaseAvailableProviders().
    */
   ORT_API2_STATUS(GetAvailableProviders, _Outptr_ char ***out_ptr,
                   _In_ int *provider_length);

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -817,6 +817,25 @@ struct OrtApi {
   ORT_API2_STATUS(AddFreeDimensionOverrideByName,
                   _Inout_ OrtSessionOptions* options, _In_ const char* dim_name,
                   _In_ int64_t dim_value);
+
+  /**
+   * \param out_ptr will hold a pointer to the array of char *
+   * representing available providers.
+   * \param provider_length is a pointer to an int variable where
+   * the number of available providers will be added.
+   * The caller is responsible for freeing each char * and the pointer
+   * array by calling ReleaseGetAvailableProviders().
+   */
+  ORT_API2_STATUS(GetAvailableProviders, _Outptr_ char ***out_ptr,
+                  _In_ int *provider_length);
+
+  /**
+   * \param ptr is the pointer to an array of available providers you
+   * get after calling GetAvailableProviders().
+   * \param providers_length is the number of available providers.
+   */
+  ORT_API2_STATUS(ReleaseGetAvailableProviders, _In_ char **ptr,
+                  _In_ int providers_length);
 };
 
 /*

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -14,6 +14,7 @@
 #include "core/common/logging/logging.h"
 #include "core/common/status.h"
 #include "core/common/safeint.h"
+#include "core/graph/constants.h"
 #include "core/graph/graph.h"
 #include "core/framework/allocator.h"
 #include "core/framework/tensor.h"
@@ -1379,22 +1380,9 @@ ORT_API_STATUS_IMPL(OrtApis::GetAvailableProviders, _Outptr_ char ***out_ptr,
                     _In_ int *providers_length) {
   API_IMPL_BEGIN
   const int MAX_NUM_PROVIDERS = 14, MAX_LEN = 30;
-  char all_providers[MAX_NUM_PROVIDERS][MAX_LEN] = {
-    "CPUExecutionProvider",
-    "CUDAExecutionProvider",
-    "DnnlExecutionProvider",
-    "NGRAPHExecutionProvider",
-    "OpenVINOExecutionProvider",
-    "NupharExecutionProvider",
-    "VitisAIExecutionProvider",
-    "TensorrtExecutionProvider",
-    "NnapiExecutionProvider",
-    "RknpuExecutionProvider",
-    "DmlExecutionProvider",
-    "MIGraphXExecutionProvider",
-    "ACLExecutionProvider",
-    "ArmNNExecutionProvider",
-  };
+  /* Ordering of providers in the following enum should be same as
+   * all_providers array defined in "constants.h".
+   */
   enum providers {cpu, cuda, dnnl, ngraph, openvino, nuphar, vitisai, tensorrt,
                   nnapi, rknpu, dml, migraph, acl, armnn};
   int available_count = 0;

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1379,17 +1379,21 @@ ORT_API_STATUS_IMPL(OrtApis::GetOpaqueValue, _In_ const char* domain_name, _In_ 
 ORT_API_STATUS_IMPL(OrtApis::GetAvailableProviders, _Outptr_ char ***out_ptr,
                     _In_ int *providers_length) {
   API_IMPL_BEGIN
-  const int MAX_LEN = 30;
+  const size_t MAX_LEN = 30;
   int available_count = (int)(sizeof(providers_available) / sizeof(char *));
   char **out = (char **)malloc(available_count * sizeof(char *));
-  for(int i = 0; i < available_count; i++) {
-      out[i] = (char *)malloc(
-        strnlen(providers_available[i], MAX_LEN) * sizeof(char));
+  if(out) {
+    for(int i = 0; i < available_count; i++) {
+      out[i] = (char *)malloc((MAX_LEN + 1) * sizeof(char));
+      if(out[i]) {
 #ifdef _MSC_VER
-      strncpy_s(out[i], MAX_LEN, providers_available[i], MAX_LEN);
+        strncpy_s(out[i], MAX_LEN, providers_available[i], MAX_LEN);
 #else
-      strncpy(out[i], providers_available[i], MAX_LEN);
+        strncpy(out[i], providers_available[i], MAX_LEN);
 #endif
+        out[i][MAX_LEN] = '\0';
+      }
+    }
   }
   *providers_length = available_count;
   *out_ptr = out;
@@ -1400,9 +1404,14 @@ ORT_API_STATUS_IMPL(OrtApis::GetAvailableProviders, _Outptr_ char ***out_ptr,
 ORT_API_STATUS_IMPL(OrtApis::ReleaseAvailableProviders, _In_ char **ptr,
                     _In_ int providers_length) {
   API_IMPL_BEGIN
-    for(int i = 0; i < providers_length; i++)
+  if(ptr) {
+    for(int i = 0; i < providers_length; i++) {
+      if(ptr[i]) {
         free(ptr[i]);
+      }
+    }
     free(ptr);
+  }
   API_IMPL_END
   return NULL;
 }

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1456,7 +1456,7 @@ ORT_API_STATUS_IMPL(OrtApis::GetAvailableProviders, _Outptr_ char ***out_ptr,
   return NULL;
 }
 
-ORT_API_STATUS_IMPL(OrtApis::ReleaseGetAvailableProviders, _In_ char **ptr,
+ORT_API_STATUS_IMPL(OrtApis::ReleaseAvailableProviders, _In_ char **ptr,
                     _In_ int providers_length) {
   API_IMPL_BEGIN
     for(int i = 0; i < providers_length; i++)
@@ -1661,7 +1661,7 @@ static constexpr OrtApi ort_api_1_to_4 = {
 
     // Version 4 - In development, feel free to add/remove/rearrange here
     &OrtApis::GetAvailableProviders,
-    &OrtApis::ReleaseGetAvailableProviders,
+    &OrtApis::ReleaseAvailableProviders,
 };
 
 // Assert to do a limited check to ensure Version 1 of OrtApi never changes (will detect an addition or deletion but not if they cancel out each other)

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1375,6 +1375,105 @@ ORT_API_STATUS_IMPL(OrtApis::GetOpaqueValue, _In_ const char* domain_name, _In_ 
   return nullptr;
 }
 
+ORT_API_STATUS_IMPL(OrtApis::GetAvailableProviders, _Outptr_ char ***out_ptr,
+                    _In_ int *providers_length) {
+  API_IMPL_BEGIN
+  const int MAX_NUM_PROVIDERS = 14, MAX_LEN = 30;
+  char all_providers[MAX_NUM_PROVIDERS][MAX_LEN] = {
+    "CPUExecutionProvider",
+    "CUDAExecutionProvider",
+    "DnnlExecutionProvider",
+    "NGRAPHExecutionProvider",
+    "OpenVINOExecutionProvider",
+    "NupharExecutionProvider",
+    "VitisAIExecutionProvider",
+    "TensorrtExecutionProvider",
+    "NnapiExecutionProvider",
+    "RknpuExecutionProvider",
+    "DmlExecutionProvider",
+    "MIGraphXExecutionProvider",
+    "ACLExecutionProvider",
+    "ArmNNExecutionProvider",
+  };
+  enum providers {cpu, cuda, dnnl, ngraph, openvino, nuphar, vitisai, tensorrt,
+                  nnapi, rknpu, dml, migraph, acl, armnn};
+  int available_count = 1;
+  enum providers available_providers[MAX_NUM_PROVIDERS];
+  available_providers[available_count-1] = cpu;
+#ifdef USE_CUDA
+  available_count++;
+  available_providers[available_count-1] = cuda;
+#endif
+#ifdef USE_DNNL
+  available_count++;
+  available_providers[available_count-1] = dnnl;
+#endif
+#ifdef USE_NGRAPH
+  available_count++;
+  available_providers[available_count-1] = ngraph;
+#endif
+#ifdef USE_OPENVINO
+  available_count++;
+  available_providers[available_count-1] = openvino;
+#endif
+#ifdef USE_NUPHAR
+  available_count++;
+  available_providers[available_count-1] = nuphar;
+#endif
+#ifdef USE_VITISAI
+  available_count++;
+  available_providers[available_count-1] = vitisai;
+#endif
+#ifdef USE_TENSORRT
+  available_count++;
+  available_providers[available_count-1] = tensorrt;
+#endif
+#ifdef USE_NNAPI
+  available_count++;
+  available_providers[available_count-1] = nnapi;
+#endif
+#ifdef USE_RKNPU
+  available_count++;
+  available_providers[available_count-1] = rknpu;
+#endif
+#ifdef USE_DML
+  available_count++;
+  available_providers[available_count-1] = dml;
+#endif
+#ifdef USE_MIGRAPHX
+  available_count++;
+  available_providers[available_count-1] = migraph;
+#endif
+#ifdef USE_ACL
+  available_count++;
+  available_providers[available_count-1] = acl;
+#endif
+#ifdef USE_ARMNN
+  available_count++;
+  available_providers[available_count-1] = armnn;
+#endif
+  char **out = (char **)malloc(available_count * sizeof(char *));
+  for(int i = 0; i < available_count; i++) {
+      out[i] = (char *)malloc(strnlen(
+        all_providers[available_providers[i]], MAX_LEN) * sizeof(char));
+      strncpy(out[i], all_providers[available_providers[i]], MAX_LEN);
+  }
+  *providers_length = available_count;
+  *out_ptr = out;
+  API_IMPL_END
+  return NULL;
+}
+
+ORT_API_STATUS_IMPL(OrtApis::ReleaseGetAvailableProviders, _In_ char **ptr,
+                    _In_ int providers_length) {
+  API_IMPL_BEGIN
+    for(int i = 0; i < providers_length; i++)
+        free(ptr[i]);
+    free(ptr);
+  API_IMPL_END
+  return NULL;
+}
+
 // End support for non-tensor types
 
 static constexpr OrtApiBase ort_api_base = {
@@ -1566,7 +1665,10 @@ static constexpr OrtApi ort_api_1_to_3 = {
     &OrtApis::CreateThreadingOptions,
     &OrtApis::ReleaseThreadingOptions,
     &OrtApis::ModelMetadataGetCustomMetadataMapKeys,
-    &OrtApis::AddFreeDimensionOverrideByName};
+    &OrtApis::AddFreeDimensionOverrideByName,
+    &OrtApis::GetAvailableProviders,
+    &OrtApis::ReleaseGetAvailableProviders,
+};
 
 // Assert to do a limited check to ensure Version 1 of OrtApi never changes (will detect an addition or deletion but not if they cancel out each other)
 // If this assert hits, read the above 'Rules on how to add a new Ort API version'

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -981,7 +981,7 @@ ORT_STATUS_PTR OrtGetValueImplSeqOfTensors(_In_ const OrtValue* p_ml_value, int 
   return t_disp.template InvokeWithUnsupportedPolicy<UnsupportedReturnFailStatus>(allocator, one_tensor, out);
 }
 
-#ifdef _MSVC_VER
+#ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 
@@ -1397,66 +1397,58 @@ ORT_API_STATUS_IMPL(OrtApis::GetAvailableProviders, _Outptr_ char ***out_ptr,
   };
   enum providers {cpu, cuda, dnnl, ngraph, openvino, nuphar, vitisai, tensorrt,
                   nnapi, rknpu, dml, migraph, acl, armnn};
-  int available_count = 1;
+  int available_count = 0;
   enum providers available_providers[MAX_NUM_PROVIDERS];
-  available_providers[available_count-1] = cpu;
+  available_providers[available_count++] = cpu;
 #ifdef USE_CUDA
-  available_count++;
-  available_providers[available_count-1] = cuda;
+  available_providers[available_count++] = cuda;
 #endif
 #ifdef USE_DNNL
-  available_count++;
-  available_providers[available_count-1] = dnnl;
+  available_providers[available_count++] = dnnl;
 #endif
 #ifdef USE_NGRAPH
-  available_count++;
-  available_providers[available_count-1] = ngraph;
+  available_providers[available_count++] = ngraph;
 #endif
 #ifdef USE_OPENVINO
-  available_count++;
-  available_providers[available_count-1] = openvino;
+  available_providers[available_count++] = openvino;
 #endif
 #ifdef USE_NUPHAR
-  available_count++;
-  available_providers[available_count-1] = nuphar;
+  available_providers[available_count++] = nuphar;
 #endif
 #ifdef USE_VITISAI
-  available_count++;
-  available_providers[available_count-1] = vitisai;
+  available_providers[available_count++] = vitisai;
 #endif
 #ifdef USE_TENSORRT
-  available_count++;
-  available_providers[available_count-1] = tensorrt;
+  available_providers[available_count++] = tensorrt;
 #endif
 #ifdef USE_NNAPI
-  available_count++;
-  available_providers[available_count-1] = nnapi;
+  available_providers[available_count++] = nnapi;
 #endif
 #ifdef USE_RKNPU
-  available_count++;
-  available_providers[available_count-1] = rknpu;
+  available_providers[available_count++] = rknpu;
 #endif
 #ifdef USE_DML
-  available_count++;
-  available_providers[available_count-1] = dml;
+  available_providers[available_count++] = dml;
 #endif
 #ifdef USE_MIGRAPHX
-  available_count++;
-  available_providers[available_count-1] = migraph;
+  available_providers[available_count++] = migraph;
 #endif
 #ifdef USE_ACL
-  available_count++;
-  available_providers[available_count-1] = acl;
+  available_providers[available_count++] = acl;
 #endif
 #ifdef USE_ARMNN
-  available_count++;
-  available_providers[available_count-1] = armnn;
+  available_providers[available_count++] = armnn;
 #endif
   char **out = (char **)malloc(available_count * sizeof(char *));
   for(int i = 0; i < available_count; i++) {
       out[i] = (char *)malloc(strnlen(
         all_providers[available_providers[i]], MAX_LEN) * sizeof(char));
+#ifdef _MSC_VER
+      strncpy_s(out[i], MAX_LEN, all_providers[available_providers[i]],
+                MAX_LEN);
+#else
       strncpy(out[i], all_providers[available_providers[i]], MAX_LEN);
+#endif
   }
   *providers_length = available_count;
   *out_ptr = out;
@@ -1520,7 +1512,7 @@ Second example, if we wanted to add and remove some members, we'd do this:
 	In GetApi we now make it return ort_api_3 for version 3.
 */
 
-static constexpr OrtApi ort_api_1_to_3 = {
+static constexpr OrtApi ort_api_1_to_4 = {
     // NOTE: The ordering of these fields MUST not change after that version has shipped since existing binaries depend on this ordering.
 
     // Shipped as version 1 - DO NOT MODIFY (see above text for more information)
@@ -1659,13 +1651,15 @@ static constexpr OrtApi ort_api_1_to_3 = {
     &OrtApis::ReleaseModelMetadata,
     // End of Version 2 - DO NOT MODIFY ABOVE (see above text for more information)
 
-    // Version 3 - In development, feel free to add/remove/rearrange here
     &OrtApis::CreateEnvWithGlobalThreadPools,
     &OrtApis::DisablePerSessionThreads,
     &OrtApis::CreateThreadingOptions,
     &OrtApis::ReleaseThreadingOptions,
     &OrtApis::ModelMetadataGetCustomMetadataMapKeys,
     &OrtApis::AddFreeDimensionOverrideByName,
+    // End of Version 3 - DO NOT MODIFY ABOVE (see above text for more information)
+
+    // Version 4 - In development, feel free to add/remove/rearrange here
     &OrtApis::GetAvailableProviders,
     &OrtApis::ReleaseGetAvailableProviders,
 };
@@ -1675,8 +1669,8 @@ static constexpr OrtApi ort_api_1_to_3 = {
 static_assert(offsetof(OrtApi, ReleaseCustomOpDomain) / sizeof(void*) == 101, "Size of version 1 API cannot change");
 
 ORT_API(const OrtApi*, OrtApis::GetApi, uint32_t version) {
-  if (version >= 1 && version <= 3)
-    return &ort_api_1_to_3;
+  if (version >= 1 && version <= 4)
+    return &ort_api_1_to_4;
 
   return nullptr;  // Unsupported version
 }

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1379,63 +1379,16 @@ ORT_API_STATUS_IMPL(OrtApis::GetOpaqueValue, _In_ const char* domain_name, _In_ 
 ORT_API_STATUS_IMPL(OrtApis::GetAvailableProviders, _Outptr_ char ***out_ptr,
                     _In_ int *providers_length) {
   API_IMPL_BEGIN
-  const int MAX_NUM_PROVIDERS = 14, MAX_LEN = 30;
-  /* Ordering of providers in the following enum should be same as
-   * all_providers array defined in "constants.h".
-   */
-  enum providers {cpu, cuda, dnnl, ngraph, openvino, nuphar, vitisai, tensorrt,
-                  nnapi, rknpu, dml, migraph, acl, armnn};
-  int available_count = 0;
-  enum providers available_providers[MAX_NUM_PROVIDERS];
-  available_providers[available_count++] = cpu;
-#ifdef USE_CUDA
-  available_providers[available_count++] = cuda;
-#endif
-#ifdef USE_DNNL
-  available_providers[available_count++] = dnnl;
-#endif
-#ifdef USE_NGRAPH
-  available_providers[available_count++] = ngraph;
-#endif
-#ifdef USE_OPENVINO
-  available_providers[available_count++] = openvino;
-#endif
-#ifdef USE_NUPHAR
-  available_providers[available_count++] = nuphar;
-#endif
-#ifdef USE_VITISAI
-  available_providers[available_count++] = vitisai;
-#endif
-#ifdef USE_TENSORRT
-  available_providers[available_count++] = tensorrt;
-#endif
-#ifdef USE_NNAPI
-  available_providers[available_count++] = nnapi;
-#endif
-#ifdef USE_RKNPU
-  available_providers[available_count++] = rknpu;
-#endif
-#ifdef USE_DML
-  available_providers[available_count++] = dml;
-#endif
-#ifdef USE_MIGRAPHX
-  available_providers[available_count++] = migraph;
-#endif
-#ifdef USE_ACL
-  available_providers[available_count++] = acl;
-#endif
-#ifdef USE_ARMNN
-  available_providers[available_count++] = armnn;
-#endif
+  const int MAX_LEN = 30;
+  int available_count = (int)(sizeof(available_providers) / sizeof(char *));
   char **out = (char **)malloc(available_count * sizeof(char *));
   for(int i = 0; i < available_count; i++) {
-      out[i] = (char *)malloc(strnlen(
-        all_providers[available_providers[i]], MAX_LEN) * sizeof(char));
+      out[i] = (char *)malloc(
+        strnlen(available_providers[i], MAX_LEN) * sizeof(char));
 #ifdef _MSC_VER
-      strncpy_s(out[i], MAX_LEN, all_providers[available_providers[i]],
-                MAX_LEN);
+      strncpy_s(out[i], MAX_LEN, available_providers[i], MAX_LEN);
 #else
-      strncpy(out[i], all_providers[available_providers[i]], MAX_LEN);
+      strncpy(out[i], available_providers[i], MAX_LEN);
 #endif
   }
   *providers_length = available_count;

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1380,15 +1380,15 @@ ORT_API_STATUS_IMPL(OrtApis::GetAvailableProviders, _Outptr_ char ***out_ptr,
                     _In_ int *providers_length) {
   API_IMPL_BEGIN
   const int MAX_LEN = 30;
-  int available_count = (int)(sizeof(available_providers) / sizeof(char *));
+  int available_count = (int)(sizeof(providers_available) / sizeof(char *));
   char **out = (char **)malloc(available_count * sizeof(char *));
   for(int i = 0; i < available_count; i++) {
       out[i] = (char *)malloc(
-        strnlen(available_providers[i], MAX_LEN) * sizeof(char));
+        strnlen(providers_available[i], MAX_LEN) * sizeof(char));
 #ifdef _MSC_VER
-      strncpy_s(out[i], MAX_LEN, available_providers[i], MAX_LEN);
+      strncpy_s(out[i], MAX_LEN, providers_available[i], MAX_LEN);
 #else
-      strncpy(out[i], available_providers[i], MAX_LEN);
+      strncpy(out[i], providers_available[i], MAX_LEN);
 #endif
   }
   *providers_length = available_count;

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -200,6 +200,6 @@ ORT_API_STATUS_IMPL(AddFreeDimensionOverrideByName, _Inout_ OrtSessionOptions* o
 
 ORT_API_STATUS_IMPL(GetAvailableProviders, _Outptr_ char ***out_ptr,
                     _In_ int *providers_length);
-ORT_API_STATUS_IMPL(ReleaseGetAvailableProviders, _In_ char **ptr,
+ORT_API_STATUS_IMPL(ReleaseAvailableProviders, _In_ char **ptr,
                     _In_ int providers_length);
 }  // namespace OrtApis

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -198,4 +198,8 @@ ORT_API_STATUS_IMPL(ModelMetadataGetCustomMetadataMapKeys, _In_ const OrtModelMe
 
 ORT_API_STATUS_IMPL(AddFreeDimensionOverrideByName, _Inout_ OrtSessionOptions* options, _In_ const char* dim_name, _In_ int64_t dim_value);
 
+ORT_API_STATUS_IMPL(GetAvailableProviders, _Outptr_ char ***out_ptr,
+                    _In_ int *providers_length);
+ORT_API_STATUS_IMPL(ReleaseGetAvailableProviders, _In_ char **ptr,
+                    _In_ int providers_length);
 }  // namespace OrtApis

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <core/common/make_unique.h>
+#include "core/session/onnxruntime_c_api.h"
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/graph/constants.h"
 #include "providers.h"
@@ -580,4 +581,14 @@ TEST(CApiTest, model_metadata) {
     ASSERT_TRUE(num_keys_in_custom_metadata_map == 0);
     ASSERT_TRUE(custom_metadata_map_keys == nullptr);
   }
+}
+
+TEST(CApiTest, get_available_providers) {
+  const OrtApi *g_ort = OrtGetApiBase()->GetApi(ORT_API_VERSION);
+  int len = 0;
+  char **providers;
+  ASSERT_EQ(g_ort->GetAvailableProviders(&providers, &len), nullptr);
+  ASSERT_TRUE(len > 0);
+  ASSERT_EQ(strcmp(providers[0], "CPUExecutionProvider"), 0);
+  ASSERT_EQ(g_ort->ReleaseAvailableProviders(providers, len), nullptr);
 }


### PR DESCRIPTION
**Description**: Added GetAvailableProviders to the C API.

**Motivation and Context**
- Why is this change required? What problem does it solve? Addresses https://github.com/microsoft/onnxruntime/issues/4134.
- If it fixes an open issue, please link to the issue here.

Example usage:
```
#include <stdio.h>
#include <onnxruntime_c_api.h>

void CheckStatus(OrtStatus *status, const OrtApi *g_ort)
{
    if (status != NULL) {
      const char *msg = g_ort->GetErrorMessage(status);
      fprintf(stderr, "%s\n", msg);
      g_ort->ReleaseStatus(status);
      exit(1);
    }   
}

int main()
{
  const OrtApi *g_ort = OrtGetApiBase()->GetApi(ORT_API_VERSION);
  int len;
  char **providers;
  printf("Fetching list of providers.\n");
  CheckStatus(g_ort->GetAvailableProviders(&providers, &len), g_ort);
  printf("Number of available providers = %d\n", len);
  printf("List of providers:\n");
  printf("-----------------\n");
  for(int i = 0; i < len; i++)
      printf("%s\n", providers[i]);
  printf("-----------------\n");
  printf("Cleaning up allocated resources.\n");
  CheckStatus(g_ort->ReleaseGetAvailableProviders(providers, len), g_ort);
  return 0;
}
```
Output:
```
Fetching list of providers.
Number of available providers = 1
List of providers:
-----------------
CPUExecutionProvider
-----------------
Cleaning up allocated resources.
```