### PR TITLE
Expose ACL/ARMNN providers to Python

### DIFF
--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -93,6 +93,8 @@ set(onnxruntime_pybind11_state_libs
     ${PROVIDERS_NNAPI}
     ${PROVIDERS_RKNPU}
     ${PROVIDERS_DML}
+    ${PROVIDERS_ACL}
+    ${PROVIDERS_ARMNN}
     onnxruntime_optimizer
     onnxruntime_providers
     onnxruntime_util

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,12 @@ elif '--use_nuphar' in sys.argv:
 elif '--use_vitisai' in sys.argv:
     package_name = 'onnxruntime-vitisai'
     sys.argv.remove('--use_vitisai')
-# --use_acl is specified in build.py, but not parsed here
+elif '--use_acl' in sys.argv:
+    package_name = 'onnxruntime-acl'
+    sys.argv.remove('--use_acl')
+elif '--use_armnn' in sys.argv:
+    package_name = 'onnxruntime-armnn'
+    sys.argv.remove('--use_armnn')
 
 # PEP 513 defined manylinux1_x86_64 and manylinux1_i686
 # PEP 571 defined manylinux2010_x86_64 and manylinux2010_i686

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1820,9 +1820,9 @@ def main():
                 args.use_openvino,
                 args.use_nuphar,
                 args.use_vitisai,
-                args.wheel_name_suffix,
                 args.use_acl,
                 args.use_armnn,
+                args.wheel_name_suffix,
                 nightly_build=nightly_build,
                 featurizers_build=args.use_featurizers,
                 use_ninja=(args.cmake_generator == 'Ninja')

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1420,8 +1420,8 @@ def run_nodejs_tests(nodejs_binding_dir):
 
 def build_python_wheel(
         source_dir, build_dir, configs, use_cuda, use_ngraph, use_dnnl,
-        use_tensorrt, use_openvino, use_nuphar, use_vitisai, wheel_name_suffix,
-        use_acl, nightly_build=False, featurizers_build=False, use_ninja=False):
+        use_tensorrt, use_openvino, use_nuphar, use_vitisai, use_acl, use_armnn,
+        wheel_name_suffix, nightly_build=False, featurizers_build=False, use_ninja=False):
     for config in configs:
         cwd = get_config_build_dir(build_dir, config)
         if is_windows() and not use_ninja:
@@ -1465,6 +1465,8 @@ def build_python_wheel(
             args.append('--use_vitisai')
         elif use_acl:
             args.append('--use_acl')
+        elif use_armnn:
+            args.append('--use_armnn')
 
         run_subprocess(args, cwd=cwd)
 
@@ -1820,6 +1822,7 @@ def main():
                 args.use_vitisai,
                 args.wheel_name_suffix,
                 args.use_acl,
+                args.use_armnn,
                 nightly_build=nightly_build,
                 featurizers_build=args.use_featurizers,
                 use_ninja=(args.cmake_generator == 'Ninja')


### PR DESCRIPTION
Description: Exposed ACL/ArmNN providers to Python.

Motivation and Context
Previously ACL/ArmNN providers were not exposed to python.
Fixes: https://github.com/microsoft/onnxruntime/issues/4209 https://github.com/microsoft/onnxruntime/issues/4199
