### PR TITLE
Allow --cmake_generator to work on macOS

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -314,7 +314,7 @@ def parse_arguments():
     parser.add_argument(
         "--cmake_generator",
         choices=['Visual Studio 15 2017', 'Visual Studio 16 2019', 'Ninja'],
-        default='Visual Studio 15 2017',
+        default='Visual Studio 15 2017' if is_windows() else None,
         help="Specify the generator that CMake invokes. "
         "This is only supported on Windows")
     parser.add_argument(
@@ -692,8 +692,11 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
             "-DANDROID_ABI=" + str(args.android_abi)
         ]
 
-    if is_macOS() and args.use_xcode:
-        cmake_args += ["-GXcode"]
+    if is_macOS():
+        if args.use_xcode:
+            cmake_args += ['-G', 'Xcode']
+        elif args.cmake_generator is not None:
+            cmake_args += ['-G', args.cmake_generator]
 
     if args.ios:
         if is_macOS():
@@ -1513,8 +1516,11 @@ def build_protoc_for_host(cmake_path, source_dir, build_dir, args):
         if not is_ninja:
             cmd_args += ['-T', 'host=x64']
         cmd_args += ['-G', args.cmake_generator]
-    elif is_macOS() and args.use_xcode:
-        cmd_args += ['-G', 'Xcode']
+    elif is_macOS():
+        if args.use_xcode:
+            cmd_args += ['-G', 'Xcode']
+        elif args.cmake_generator is not None:
+            cmd_args += ['-G', args.cmake_generator]
 
     run_subprocess(cmd_args, cwd=protoc_build_dir)
     # Build step


### PR DESCRIPTION
**Description**:

Allows passing `--cmake_generator` as `-G` to `cmake` when building on macOS.

**Motivation and Context**

The default generator was always used on macOS. We want to take advantage of Ninja.