### PR TITLE
Misc fixes to Conv and ConvTranspose CUDA kernels

### DIFF
--- a/onnxruntime/core/providers/cuda/nn/conv_transpose.cc
+++ b/onnxruntime/core/providers/cuda/nn/conv_transpose.cc
@@ -32,11 +32,6 @@ REGISTER_KERNEL_TYPED(MLFloat16)
 
 template <typename T>
 Status ConvTranspose<T>::ComputeInternal(OpKernelContext* context) const {
-  if (OpKernel::Node().Name() == "ConvTranspose_3289") {
-    double a = 1.2;
-    ORT_IGNORE_RETURN_VALUE(std::floor(a));
-  }
-
   return DoConvTranspose(context, false);
 }
 


### PR DESCRIPTION
**Description**: There are some subtle fixes to the `Conv` and `ConvTranspose` CUDA kernels:

1) In ConvTranspose kernel, extend holding onto the mutex until we are done with all CuDNN calls (Similar to #3837 which did that for the Conv CUDA kernel)

2) Fixes corresponding to bailing out too early in the Compute methods if one of the output dim values is 0- 

ConvTranpose kernel:
a) There is logic to bail out early if one of the output dimensions is zero, but this logic resides in an `if` block that only executes for the first run or on a run whose input shape/ filter shape is different from the cached input shape / filter shape from a previous run which meant if the output was empty on one run and the input shape / filter shape remains unchanged on the next run, the logic to bail out early is never hit and will make the CuDNN call resulting in a runtime failure. So fix this.

b) If bailing out early in the very first run, cache the `output shape` and `filter dimensions` for use in subsequent runs

Conv kernel:

a) If bailing out early in the very first run, cache the `filter dimensions` for use in subsequent runs

**Motivation and Context**
Fix #4014
