### PR TITLE
Use providers_available array from constants.h in python bindings to avoid code duplication

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -313,37 +313,7 @@ const std::vector<std::string>& GetAllProviders() {
 
 const std::vector<std::string>& GetAvailableProviders() {
   auto InitializeProviders = []() {
-    std::vector<std::string> available_providers = {kCpuExecutionProvider};
-#ifdef USE_TENSORRT
-    available_providers.push_back(kTensorrtExecutionProvider);
-#endif
-#ifdef USE_MIGRAPHX
-    available_providers.push_back(kMIGraphXExecutionProvider);
-#endif
-#ifdef USE_CUDA
-    available_providers.push_back(kCudaExecutionProvider);
-#endif
-#ifdef USE_DNNL
-    available_providers.push_back(kDnnlExecutionProvider);
-#endif
-#ifdef USE_NGRAPH
-    available_providers.push_back(kNGraphExecutionProvider);
-#endif
-#ifdef USE_OPENVINO
-    available_providers.push_back(kOpenVINOExecutionProvider);
-#endif
-#ifdef USE_NUPHAR
-    available_providers.push_back(kNupharExecutionProvider);
-#endif
-#ifdef USE_VITISAI
-    available_providers.push_back(kVitisAIExecutionProvider);
-#endif
-#ifdef USE_ACL
-    available_providers.push_back(kAclExecutionProvider);
-#endif
-#ifdef USE_ARMNN
-    available_providers.push_back(kArmNNExecutionProvider);
-#endif
+    std::vector<std::string> available_providers(std::begin(providers_available), std::end(providers_available));
     return available_providers;
   };
   static std::vector<std::string> available_providers = InitializeProviders();


### PR DESCRIPTION
**Description**: Use providers_available array added to constants.h as a part of this PR: https://github.com/microsoft/onnxruntime/pull/4247.

**Motivation and Context**
- Why is this change required? What problem does it solve? Removes duplicate code.
- If it fixes an open issue, please link to the issue here.
