### PR TITLE
Fix memory usage when loading a model + some other minor fixes to avoid unnecessary heap allocations.

### DIFF
--- a/onnxruntime/core/framework/kernel_def_builder.cc
+++ b/onnxruntime/core/framework/kernel_def_builder.cc
@@ -15,7 +15,7 @@ inline bool AreIntervalsOverlap(int start1, int end1, int start2, int end2) {
 
 template <typename T>
 inline bool AreVectorsOverlap(const std::vector<T>& v1, const std::vector<T>& v2) {
-  for (T type : v1) {
+  for (const T& type : v1) {
     if (std::find(v2.begin(), v2.end(), type) != v2.end()) {
       return true;
     }
@@ -44,7 +44,7 @@ bool KernelDef::IsConflict(const KernelDef& other) const {
   //only one case they don't conflict:
   //There is a type_constraint, it exists in both hands, but they don't overlap
   //check types
-  auto other_types = other.TypeConstraints();
+  const auto& other_types = other.TypeConstraints();
   bool type_has_conflict = true;
   for (const auto& it : type_constraints_) {
     auto iter = other_types.find(it.first);

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -26,8 +26,6 @@ using namespace ONNX_NAMESPACE;
 using namespace onnxruntime;
 using namespace onnxruntime::common;
 
-static constexpr int protobuf_block_size_in_bytes = 4 * 1024 * 1024;
-
 namespace onnxruntime {
 Model::Model(const std::string& graph_name,
              bool is_onnx_domain_only,
@@ -239,7 +237,7 @@ Status Model::Load(std::istream& model_istream, ModelProto* p_model_proto) {
   if (!p_model_proto) {
     return Status(ONNXRUNTIME, INVALID_ARGUMENT, "Null model_proto ptr.");
   }
-  google::protobuf::io::IstreamInputStream zero_copy_input(&model_istream, protobuf_block_size_in_bytes);
+  google::protobuf::io::IstreamInputStream zero_copy_input(&model_istream);
   const bool result = p_model_proto->ParseFromZeroCopyStream(&zero_copy_input) && model_istream.eof();
   if (!result) {
     return Status(ONNXRUNTIME, INVALID_PROTOBUF, "Failed to load model because protobuf parsing failed.");
@@ -449,7 +447,7 @@ Status Model::Load(int fd, ONNX_NAMESPACE::ModelProto& model_proto) {
   }
 
 #if GOOGLE_PROTOBUF_VERSION >= 3002000
-  FileInputStream input(fd, protobuf_block_size_in_bytes);
+  FileInputStream input(fd);
   const bool result = model_proto.ParseFromZeroCopyStream(&input) && input.GetErrno() == 0;
   if (!result) {
     return Status(ONNXRUNTIME, INVALID_PROTOBUF, "Protobuf parsing failed.");


### PR DESCRIPTION
**Description**: Fix memory usage when loading a model + some other minor fixes to avoid unnecessary heap allocations.

**Motivation and Context**
The Edge browser team reported a significant increase in heap allocations with the latest master while testing the changes that removed the traditional ML ops. There are many other things that need to be fixed, but this seemed to stand out. The size of this model on disk is just 13K.

Before this fix:
![image](https://user-images.githubusercontent.com/2732907/85465346-8c616300-b55d-11ea-9107-4ef4e2581e02.png)

After this fix:
![image](https://user-images.githubusercontent.com/2732907/85465427-a307ba00-b55d-11ea-9f4e-60570b6f572f.png)
 