### PR TITLE
support pipeline partition with shared initializer

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -647,15 +647,6 @@ class Graph {
     return *(result.first->second);
   }
 
-  /** Creates a mutable NodeArg owned by this graph with mirrored base_arg's TypeProto and name
-  @param base_arg The NodeArg the newly created NodeArg is mirrored based off.
-  @returns NodeArg reference that contains the same TypeProto info as base_arg with generated different names.
-  */
-  NodeArg& CreateNodeArg(const NodeArg* base_arg) {
-    ONNX_NAMESPACE::TypeProto type_proto(*(base_arg->TypeAsProto()));
-    return GetOrCreateNodeArg(GenerateNodeArgName(base_arg->Name()), &type_proto);
-  }
-
   /** Generate a unique name in this Graph for a NodeArg */
   std::string GenerateNodeArgName(const std::string& base_name);
 

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -493,6 +493,9 @@ class Graph {
   /** Remove the initializer tensor with the provided name from the Graph. */
   void RemoveInitializedTensor(const std::string& tensor_name);
 
+  /** Check if a given name is a initializer tensor's name in this graph. */
+  bool IsInitializerTensor(const std::string& name);
+
   /** Replaces the initializer tensor with the same name as the given initializer tensor.
   The replacement initializer tensor must have the same type and shape as the existing initializer tensor.
 

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -493,7 +493,7 @@ class Graph {
   /** Remove the initializer tensor with the provided name from the Graph. */
   void RemoveInitializedTensor(const std::string& tensor_name);
 
-  /** Check if a given name is a initializer tensor's name in this graph. */
+  /** Check if a given name is an initializer tensor's name in this graph. */
   bool IsInitializerTensor(const std::string& name) const;
 
   /** Replaces the initializer tensor with the same name as the given initializer tensor.

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -513,7 +513,7 @@ class Graph {
   void RemoveInitializedTensor(const std::string& tensor_name);
 
   /** Check if a given name is an initializer tensor's name in this graph. */
-  bool IsInitializerTensor(const std::string& name) const;
+  bool IsInitializedTensor(const std::string& name) const;
 
   /** Replaces the initializer tensor with the same name as the given initializer tensor.
   The replacement initializer tensor must have the same type and shape as the existing initializer tensor.

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -494,7 +494,7 @@ class Graph {
   void RemoveInitializedTensor(const std::string& tensor_name);
 
   /** Check if a given name is a initializer tensor's name in this graph. */
-  bool IsInitializerTensor(const std::string& name);
+  bool IsInitializerTensor(const std::string& name) const;
 
   /** Replaces the initializer tensor with the same name as the given initializer tensor.
   The replacement initializer tensor must have the same type and shape as the existing initializer tensor.

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -126,6 +126,14 @@ class Node {
     return common::Status::OK();
   }
 
+  /**
+  Helper to iterate through the container returned by #MutableInputDefs() or #MutableOutputDefs() and call the provided function.
+  @param node_args Collection of NodeArgs returned by #MutableInputDefs() or #MutableOutputDefs()
+  @param func Function to call for each valid NodeArg in the node_args. The function is called with the NodeArg
+              and the index number in the container.
+  @returns common::Status with success or error information.
+  @remarks Returns immediately on error.
+  */
   static common::Status ForEachMutableWithIndex(std::vector<NodeArg*>& node_args,
                                                 std::function<common::Status(NodeArg& arg, size_t index)> func) {
     for (size_t index = 0; index < node_args.size(); ++index) {

--- a/onnxruntime/core/common/path.cc
+++ b/onnxruntime/core/common/path.cc
@@ -253,6 +253,21 @@ Path& Path::Append(const Path& other) {
   return *this;
 }
 
+Path& Path::Concat(const PathString& string) {
+  components_.back() += string;
+  return *this;
+}
+
+Path& Path::ConcatIndex(const int index) {
+#ifdef _WIN32
+  auto index_str = std::to_wstring(index);
+#else
+  auto index_str = std::to_string(index);
+#endif
+  components_.back() += index_str;
+  return *this;
+}
+
 Status RelativePath(const Path& src, const Path& dst, Path& rel) {
   ORT_RETURN_IF_NOT(
       src.GetRootPathString() == dst.GetRootPathString(),

--- a/onnxruntime/core/common/path.h
+++ b/onnxruntime/core/common/path.h
@@ -61,6 +61,19 @@ class Path {
    * The algorithm should model that of std::filesystem::path::append().
    */
   Path& Append(const Path& other);
+
+  /**
+   * Concatenates the current path and the argument string.
+   * Unlike with Append() or operator/=, additional directory separators are never introduced.
+   */
+  Path& Concat(const PathString& string);
+
+  /**
+   * Concatenates an index by the end of current path.
+   * Similar to Concat() except the argument is an index.
+   */
+  Path& ConcatIndex(const int index);
+
   /** Equivalent to this->Append(other). */
   Path& operator/=(const Path& other) {
     return Append(other);

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -178,8 +178,8 @@ bool NodeArg::HasTensorOrScalarShape() const {
   const auto type_case = type->value_case();
   switch (type_case) {
     case TypeProto::kTensorType:
-    case TypeProto::kSparseTensorType: 
-      // Standard tensor has a valid shape field while 
+    case TypeProto::kSparseTensorType:
+      // Standard tensor has a valid shape field while
       // scalar's shape is empty. Thus, we don't need to
       // check shape here.
       return true;
@@ -2307,6 +2307,11 @@ static void RemoveRepeatedFieldEntry(T& repeated_field, const TIter& entry_to_re
   } else {
     repeated_field.erase(entry_to_remove);
   }
+}
+
+bool Graph::IsInitializerTensor(const std::string& name){
+  auto iter = name_to_initial_tensor_.find(name);
+  return iter != name_to_initial_tensor_.end();
 }
 
 void Graph::RemoveInitializedTensor(const std::string& tensor_name) {

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2309,7 +2309,7 @@ static void RemoveRepeatedFieldEntry(T& repeated_field, const TIter& entry_to_re
   }
 }
 
-bool Graph::IsInitializerTensor(const std::string& name) const {
+bool Graph::IsInitializedTensor(const std::string& name) const {
   return name_to_initial_tensor_.count(name) > 0;
 }
 

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2309,9 +2309,8 @@ static void RemoveRepeatedFieldEntry(T& repeated_field, const TIter& entry_to_re
   }
 }
 
-bool Graph::IsInitializerTensor(const std::string& name){
-  auto iter = name_to_initial_tensor_.find(name);
-  return iter != name_to_initial_tensor_.end();
+bool Graph::IsInitializerTensor(const std::string& name) const {
+  return name_to_initial_tensor_.count(name) > 0;
 }
 
 void Graph::RemoveInitializedTensor(const std::string& tensor_name) {

--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -181,7 +181,7 @@ static void RemoveGraphEdges(Graph& graph, const std::vector<GraphEdge>& edges) 
 }
 
 /** Given a graph, a list of edges, and a NodeArg name, checks if each of the edges provides an implicit input
-    to a subgraph. If so, it checks if there is no clash of the given NodeArg name in each of the subgraphs. 
+    to a subgraph. If so, it checks if there is no clash of the given NodeArg name in each of the subgraphs.
     This is important when removing a node with this NodeArg as input. */
 static bool CanUpdateImplicitInputNameInSubgraphs(const Graph& graph,
                                                   const std::vector<GraphEdge>& output_edges,
@@ -321,7 +321,7 @@ const ONNX_NAMESPACE::AttributeProto* GetNodeAttribute(const Node& node, const s
   return iter == attrs.end() ? nullptr : &iter->second;
 }
 
-/** Checks for nodes with >= 1 outputs, if only one of the outputs is input to downstream Operators. 
+/** Checks for nodes with >= 1 outputs, if only one of the outputs is input to downstream Operators.
 Returns the name of the single used output in output_name. */
 static bool IsOnlyOneOutputUsed(const Graph& graph, const Node& node, const std::string*& output_name) {
   const int unassigned = -1;
@@ -807,5 +807,10 @@ bool RemoveNodesWithOneOutputBottomUp(Graph& graph, const Node& start_node) {
   }
   return true;
 }
+
+NodeArg& CreateNodeArg(Graph& graph, const NodeArg& base_arg) {
+  return graph.GetOrCreateNodeArg(graph.GenerateNodeArgName(base_arg.Name()), base_arg.TypeAsProto());
+}
+
 }  // namespace graph_utils
 }  // namespace onnxruntime

--- a/onnxruntime/core/graph/graph_utils.h
+++ b/onnxruntime/core/graph/graph_utils.h
@@ -34,27 +34,27 @@ bool IsOutputUsed(const Node& node, int index);
 /** Returns true if the graph has the given input.*/
 bool IsGraphInput(const Graph& graph, const NodeArg* input);
 
-/** returns true if 'name' is an initializer in 'graph', or an ancestor graph if check_outer_scope is true. 
+/** returns true if 'name' is an initializer in 'graph', or an ancestor graph if check_outer_scope is true.
 @param check_outer_scope If true and 'graph' is a subgraph, check ancestor graph/s for 'name' if not found in 'graph'.
 */
 bool IsInitializer(const Graph& graph, const std::string& name, bool check_outer_scope);
 
-/** returns true if 'name' is an initializer, and is constant and cannot be overridden at runtime. 
+/** returns true if 'name' is an initializer, and is constant and cannot be overridden at runtime.
 @param check_outer_scope If true and 'graph' is a subgraph, check ancestor graph/s for 'name' if not found in 'graph'.
 */
 bool IsConstantInitializer(const Graph& graph, const std::string& name, bool check_outer_scope = true);
 
-/** returns the initializer's TensorProto if 'name' is an initializer, is constant and 
+/** returns the initializer's TensorProto if 'name' is an initializer, is constant and
 cannot be overridden at runtime. If the initializer is not found or is not constant, a nullptr is returned.
 @param check_outer_scope If true and the graph is a subgraph, check ancestor graph/s for 'name' if not found in 'graph'.
 */
 const ONNX_NAMESPACE::TensorProto* GetConstantInitializer(const Graph& graph, const std::string& name,
                                                           bool check_outer_scope = true);
 
-/** Add a new initializer to 'graph'. 
+/** Add a new initializer to 'graph'.
 Checks that new_initializer does not already exist in 'graph' before adding it.
-@returns The NodeArg for the new initializer. 
-@remarks No matching graph input is created, so the initializer will be constant. 
+@returns The NodeArg for the new initializer.
+@remarks No matching graph input is created, so the initializer will be constant.
 */
 NodeArg& AddInitializer(Graph& graph, const ONNX_NAMESPACE::TensorProto& new_initializer);
 
@@ -127,7 +127,7 @@ bool RemoveNode(Graph& graph, Node& node);
 
 /** Tests if we can remove a node and replace its output with an initializer.
 Conditions:
- - Only one of the node's outputs is used by downstream operators or as a graph output 
+ - Only one of the node's outputs is used by downstream operators or as a graph output
    - multiple edges for the single used output are allowed
  - If the node produces a graph output the initializer_name must be the same as the node's output name
    - otherwise the required graph output will not be produced
@@ -140,20 +140,20 @@ bool CanReplaceNodeWithInitializer(const Graph& graph, const Node& node, const s
 See CanReplaceNodeWithInitializer for the conditions that must be satisfied in order to remove the node.*/
 bool ReplaceNodeWithInitializer(Graph& graph, Node& node, NodeArg& replacement);
 
-/** Removes all output edges from the given Node of the Graph. 
+/** Removes all output edges from the given Node of the Graph.
     This should probably be elevated to the Graph API eventually. */
 size_t RemoveNodeOutputEdges(Graph& graph, Node& node);
 
-/** Replaces the input to nodes that are downstream from 'node', which was being provided by an output of 'node', 
+/** Replaces the input to nodes that are downstream from 'node', which was being provided by an output of 'node',
     with an output from a different node. Moves the output edges from 'node' for 'output_idx' to the replacement node.
 @param replacement The node providing the replacement output.
-@param replacement_output_idx The index of the output from 'replacement' to use. 
+@param replacement_output_idx The index of the output from 'replacement' to use.
 
-e.g. Node A produces outputs A1 and A2. 
-     Node B consumes A2 (edge between A and B for A2) and produces B1. 
+e.g. Node A produces outputs A1 and A2.
+     Node B consumes A2 (edge between A and B for A2) and produces B1.
      Node C consumes B1 (edge between B and C for B1).
-     
-     If Node B was determined to not be needed, you would call ReplaceDownstreamNodeInput(graph, B, 0, A, 1) 
+
+     If Node B was determined to not be needed, you would call ReplaceDownstreamNodeInput(graph, B, 0, A, 1)
      to replace B1 (output index 0 for node B) with A2 (output index 1 for node A) as input to the downstream node C.
      The edge that existed between B and C for B1 will be removed, and replaced with an edge between A and C for A2.
 */
@@ -161,29 +161,29 @@ void ReplaceDownstreamNodeInput(Graph& graph, Node& node, int output_idx, Node& 
 
 /** Replace the input to a node with a NodeArg.
 @remarks The replacement only updates the node's input definition and does not create any edges,
-         as typically this function is used to replace an input with an initializer or graph input 
+         as typically this function is used to replace an input with an initializer or graph input
          (there is no edge between an initializer or graph input and a Node).
 */
 void ReplaceNodeInput(Node& target, int target_input_idx, NodeArg& new_input);
 
 /** Add an input to a node with a NodeArg for an initializer or graph input.
-@remarks target_input_idx must be the next input slot. 
-           e.g. if a Node has 2 inputs, AddNodeInput can only add input 3 and not 4. 
-         There is no edge between an initializer or graph input and a Node, so the replacement only updates the 
+@remarks target_input_idx must be the next input slot.
+           e.g. if a Node has 2 inputs, AddNodeInput can only add input 3 and not 4.
+         There is no edge between an initializer or graph input and a Node, so the replacement only updates the
          node's input definition and does not create any new edges.
 */
 void AddNodeInput(Node& target, int target_input_idx, NodeArg& new_input);
 
-/** Finalize the fusion of second_node into first_node. 
+/** Finalize the fusion of second_node into first_node.
     The output definitions and edges from the second_node are moved to first_node. second_node is deleted.
     e.g. Conv + Add fusion fuses the 'Add' into the Conv.
 */
 void FinalizeNodeFusion(Graph& graph, Node& first_node, Node& second_node);
 
-/** Finalize the fusion of two or more nodes which are being replaced with a single node. 
+/** Finalize the fusion of two or more nodes which are being replaced with a single node.
     The first and last entries in 'nodes' are assumed to be the first and last nodes in a chain of nodes being fused.
 
-    Conceptually multiple nodes are being combined into one, and post-fusion will produce output/s with the same names 
+    Conceptually multiple nodes are being combined into one, and post-fusion will produce output/s with the same names
     as the last node in 'nodes', and be connected to the same downstream nodes.
 
     The input edges to the first node in 'nodes' will be moved to replacement_node. No other input edges are moved.
@@ -229,7 +229,7 @@ struct EdgeEndToMatch {
 @param edges_to_match has information of a sequence of adjacent edges in the path to be matched one by one.
 @param result stores edges that are found.
 @returns false when one edge has multiple candidates, or not all edges are found.
-@remarks matching an EdgeEndToMatch might get multiple candidates in output edges. 
+@remarks matching an EdgeEndToMatch might get multiple candidates in output edges.
     When such case is encountered, this function will return false. This is by design to reduce complexity.
     Here is an example graph:
                   Add
@@ -237,7 +237,7 @@ struct EdgeEndToMatch {
                Mul     Mul
                  \    /
                   Sub
-    For example, you want to match path from top to bottom: Add-->Mul-->Sub. 
+    For example, you want to match path from top to bottom: Add-->Mul-->Sub.
     When matching the first edge Add-->Mul, the algorithm found two matches.
     Then it returns false, and output a warning log entry.
 
@@ -252,9 +252,15 @@ bool FindPath(Graph& graph, const Node& node, bool is_input_edge, const std::vec
 
 /**
  * Remove nodes with only one output edge using bottom-up bfs traversal.
- * @param node: The node to start with. 
+ * @param node: The node to start with.
  * @returns true if there is one or more node(s) removed by this function. Otherwise return false.
 */
 bool RemoveNodesWithOneOutputBottomUp(Graph& graph, const Node& node);
+
+/** Creates a mutable NodeArg owned by the graph with mirrored base_arg's TypeProto and name
+ * @param base_arg The NodeArg the newly created NodeArg is mirrored based off.
+ * @returns NodeArg reference that contains the same TypeProto info as base_arg with generated different names.
+*/
+NodeArg& CreateNodeArg(Graph& graph, const NodeArg& base_arg);
 }  // namespace graph_utils
 }  // namespace onnxruntime

--- a/onnxruntime/test/common/path_test.cc
+++ b/onnxruntime/test/common/path_test.cc
@@ -222,5 +222,34 @@ TEST(PathTest, RelativePathFailure) {
 #endif
 }
 
+TEST(PathTest, Concat) {
+  auto check_concat =
+      [](const std::string& a, const std::string& b, const std::string& expected_a) {
+        Path p_a{}, p_expected_a{};
+        ASSERT_STATUS_OK(Path::Parse(ToPathString(a), p_a));
+        ASSERT_STATUS_OK(Path::Parse(ToPathString(expected_a), p_expected_a));
+
+        EXPECT_EQ(p_a.Concat(b).ToPathString(), p_expected_a.ToPathString());
+      };
+
+  check_concat("/a/b", "c", "/a/bc");
+  check_concat("a/b", "cd", "a/bcd");
+}
+
+TEST(PathTest, ConcatIndex) {
+  auto check_concat_index =
+      [](const std::string& a, const int i, const std::string& expected_a) {
+        Path p_a{}, p_expected_a{};
+        ASSERT_STATUS_OK(Path::Parse(ToPathString(a), p_a));
+        ASSERT_STATUS_OK(Path::Parse(ToPathString(expected_a), p_expected_a));
+
+        EXPECT_EQ(p_a.ConcatIndex(i).ToPathString(), p_expected_a.ToPathString());
+      };
+
+  check_concat_index("/a/b", 0, "/a/b0");
+  check_concat_index("a/b", 123, "a/b123");
+  check_concat_index("a/b", -1, "a/b-1");
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/common/path_test.cc
+++ b/onnxruntime/test/common/path_test.cc
@@ -229,7 +229,7 @@ TEST(PathTest, Concat) {
         ASSERT_STATUS_OK(Path::Parse(ToPathString(a), p_a));
         ASSERT_STATUS_OK(Path::Parse(ToPathString(expected_a), p_expected_a));
 
-        EXPECT_EQ(p_a.Concat(b).ToPathString(), p_expected_a.ToPathString());
+        EXPECT_EQ(p_a.Concat(ToPathString(b)).ToPathString(), p_expected_a.ToPathString());
       };
 
   check_concat("/a/b", "c", "/a/bc");

--- a/orttraining/orttraining/core/graph/pipeline_transformer.cc
+++ b/orttraining/orttraining/core/graph/pipeline_transformer.cc
@@ -78,17 +78,15 @@ std::vector<NodeArg*> FindBackwardLeafNodes(Graph& graph) {
 // The newly created boolean scalar may be appended to signal_args. If
 // signal_args is empty, the source of signal_args[i] would be tensor_args[i].
 void ConvertTensorToBoolSignal(
-  Graph& graph,
-  const std::vector<NodeArg*>& tensor_args,
-  std::vector<NodeArg*>& signal_args) {
-
-  for (auto tensor_arg: tensor_args) {
+    Graph& graph,
+    const std::vector<NodeArg*>& tensor_args,
+    std::vector<NodeArg*>& signal_args) {
+  for (auto tensor_arg : tensor_args) {
     // Declare the scalar signal this "tensor_arg" will be converted into.
     auto signal_arg = &CreateTypedNodeArg(
-      graph,
-      ONNX_NAMESPACE::TensorProto_DataType_BOOL,
-      "signal_" + tensor_arg->Name()
-    );
+        graph,
+        ONNX_NAMESPACE::TensorProto_DataType_BOOL,
+        "signal_" + tensor_arg->Name());
 
     // Add the new scalar to user-specified vector.
     signal_args.push_back(signal_arg);
@@ -98,13 +96,13 @@ void ConvertTensorToBoolSignal(
     std::vector<NodeArg*> input_args{tensor_arg};
     std::vector<NodeArg*> output_args{signal_arg};
     graph.AddNode(
-      name,
-      "Group",
-      "",
-      input_args,
-      output_args,
-      nullptr,
-      kMSDomain);
+        name,
+        "Group",
+        "",
+        input_args,
+        output_args,
+        nullptr,
+        kMSDomain);
   }
 }
 
@@ -121,12 +119,12 @@ NodeArg& CreateNodeArg(Graph& graph, const NodeArg* base_arg) {
 // Return mirror variables for node_args.
 // The i-th output element mirrors node_args[i] but with a different name.
 std::vector<NodeArg*> CreateMirrorNodeArgs(
-  Graph& graph,
-  const std::vector<NodeArg*>& node_args) {
+    Graph& graph,
+    const std::vector<NodeArg*>& node_args) {
   // Declare output.
   std::vector<NodeArg*> new_node_args;
 
-  for (auto& node_arg: node_args) {
+  for (auto& node_arg : node_args) {
     // new_node_arg is a mirror variable of node_arg. They have the same type.
     auto new_node_arg = &CreateNodeArg(graph, node_arg);
     new_node_args.push_back(new_node_arg);
@@ -138,33 +136,33 @@ std::vector<NodeArg*> CreateMirrorNodeArgs(
 // Create a node with input schema [event, input1, input2, ..., inputN] and
 // output schema [input1, input2, ..., inputN]
 Node& CreateBottleneckNode(Graph& graph,
-                          const std::string& op_type,
-                          const std::string& op_name,
-                          const std::string& description,
-                          NodeArg* event,
-                          std::vector<NodeArg*> input_node_args,
-                          std::vector<NodeArg*> output_node_args) {
+                           const std::string& op_type,
+                           const std::string& op_name,
+                           const std::string& description,
+                           NodeArg* event,
+                           std::vector<NodeArg*> input_node_args,
+                           std::vector<NodeArg*> output_node_args) {
   const auto name = graph.GenerateNodeName(op_name);
   if (event) {
     input_node_args.insert(input_node_args.begin(), event);
   }
 
   return graph.AddNode(
-    name,
-    op_type,
-    description,
-    input_node_args,
-    output_node_args,
-    nullptr /* assume all bottleneck node have no attributes */,
-    kMSDomain);
+      name,
+      op_type,
+      description,
+      input_node_args,
+      output_node_args,
+      nullptr /* assume all bottleneck node have no attributes */,
+      kMSDomain);
 }
 
 Node* AddBackwardRecord(Graph& graph,
                         Node* backward_send,
                         std::vector<std::string>& new_input_names,
                         std::vector<std::string>& new_output_names,
-                        std::string &event_id_tensor_name,
-                        std::string &output_tensor_name) {
+                        std::string& event_id_tensor_name,
+                        std::string& output_tensor_name) {
   std::vector<NodeArg*> input_args;
   AddNewNodeArg(graph, "backward_recorded_event_id", ONNX_NAMESPACE::TensorProto_DataType_INT64,
                 input_args, new_input_names);
@@ -194,13 +192,13 @@ Node* AddBackwardRecord(Graph& graph,
   // Optimizer will be added after applying pipeline transformer. To support partial graph evaluation,
   // the added Record backward op will have its first passthrough input as output.
   ORT_ENFORCE(input_args.size() >= 2, "RecordEvent backward op at least have two inputs.");
-  auto& new_output = CreateNodeArg(graph, input_args[1]); // the first input is signal, not passing through
+  auto& new_output = CreateNodeArg(graph, input_args[1]);  // the first input is signal, not passing through
   output_args.push_back(&new_output);
   new_output_names.push_back(new_output.Name());
 
   Node* record_node = &CreateBottleneckNode(
-    graph, "RecordEvent", "backward_record", "Backward pass", nullptr,
-    input_args, output_args);
+      graph, "RecordEvent", "backward_record", "Backward pass", nullptr,
+      input_args, output_args);
 
   // First input argument is the recorded event ID tensor.
   event_id_tensor_name = input_args.front()->Name();
@@ -212,10 +210,10 @@ Node* AddBackwardRecord(Graph& graph,
 }
 
 Node* AddForwardWait(Graph& graph,
-                      Node* /* forward_recv */,
-                      std::vector<std::string>& new_input_names,
-                      std::string& forward_waited_event_name,
-                      std::string& output_tensor_name) {
+                     Node* /* forward_recv */,
+                     std::vector<std::string>& new_input_names,
+                     std::string& forward_waited_event_name,
+                     std::string& output_tensor_name) {
   // Append old_input to input_args and return its pass-through value. Note that
   // input_args and output_args are Wait's inputs and outputs, respectively.
   auto update_wait_input_output = [&](NodeArg* old_input,
@@ -257,8 +255,8 @@ Node* AddForwardWait(Graph& graph,
   }
 
   Node* wait_node = &CreateBottleneckNode(
-    graph, "WaitEvent", "backward_record", "", nullptr,
-    input_args, output_args);
+      graph, "WaitEvent", "backward_record", "", nullptr,
+      input_args, output_args);
 
   forward_waited_event_name = input_args.front()->Name();
   output_tensor_name = output_args.front()->Name();
@@ -276,13 +274,15 @@ Status AddOrSkipForwardRecordBackwardWait(Graph& graph,
                                           std::string& backward_waited_event_name,
                                           std::string& forward_output_name,
                                           std::string& backward_output_name) {
-  if (!forward_send != !backward_recv){
-    ORT_THROW("Graph requires either having both send forward node "
-      "and recv backword node, or none of them. Currently the graph "
-      "has send forward: ", forward_send, " and recv backward: ", backward_recv);
+  if (!forward_send != !backward_recv) {
+    ORT_THROW(
+        "Graph requires either having both send forward node "
+        "and recv backword node, or none of them. Currently the graph "
+        "has send forward: ",
+        forward_send, " and recv backward: ", backward_recv);
   }
 
-  if (!forward_send && !backward_recv){
+  if (!forward_send && !backward_recv) {
     // Last partition doesn't have send forwrad and recv backward. No insert
     // needed.
     return Status::OK();
@@ -308,8 +308,8 @@ Status AddOrSkipForwardRecordBackwardWait(Graph& graph,
     }
 
     record_node = &CreateBottleneckNode(
-      graph, "RecordEvent", "forward_record", "", nullptr,
-      input_args, output_args);
+        graph, "RecordEvent", "forward_record", "", nullptr,
+        input_args, output_args);
 
     forward_recorded_event_name = record_node->InputDefs()[0]->Name();
     forward_output_name = record_node->OutputDefs()[0]->Name();
@@ -332,8 +332,8 @@ Status AddOrSkipForwardRecordBackwardWait(Graph& graph,
     input = &new_output;
 
     wait_node = &CreateBottleneckNode(
-      graph, "WaitEvent", "backward_wait", "Backward pass", nullptr,
-      input_args, output_args);
+        graph, "WaitEvent", "backward_wait", "Backward pass", nullptr,
+        input_args, output_args);
 
     backward_waited_event_name = wait_node->InputDefs()[0]->Name();
     backward_output_name = wait_node->OutputDefs()[0]->Name();
@@ -352,8 +352,8 @@ void ReplaceNodeArgs(std::vector<Node*>& nodes,
     ORT_ENFORCE(node_args[i]->Name() != new_node_args[i]->Name());
     ORT_ENFORCE(node_args[i]->Type() == new_node_args[i]->Type());
 
-    for (auto& node: nodes) {
-      for (auto& node_arg: node->MutableInputDefs()) {
+    for (auto& node : nodes) {
+      for (auto& node_arg : node->MutableInputDefs()) {
         // Only replace when node's input name matches node_args[i].
         if (node_arg->Name().compare(node_args[i]->Name()) != 0) {
           continue;
@@ -371,11 +371,11 @@ void ReplaceNodeArgs(std::vector<Node*>& nodes,
 }
 
 std::string AddEventBeforeNode(
-  Graph& graph,
-  Node* node,
-  const std::string& event_op_type,
-  const std::string& event_op_name,
-  const std::string& event_id_name) {
+    Graph& graph,
+    Node* node,
+    const std::string& event_op_type,
+    const std::string& event_op_name,
+    const std::string& event_id_name) {
   if (!node) {
     // No event operator is be inserted, so we don't have its input event name.
     return "";
@@ -410,11 +410,11 @@ std::string AddEventBeforeNode(
 }
 
 std::string AddEventAfterNode(
-  Graph& graph,
-  Node* node,
-  const std::string& event_op_type,
-  const std::string& event_op_name,
-  const std::string& event_id_name) {
+    Graph& graph,
+    Node* node,
+    const std::string& event_op_type,
+    const std::string& event_op_name,
+    const std::string& event_id_name) {
   if (!node) {
     // No event operator is be inserted, so we don't have its input event name.
     return "";
@@ -431,7 +431,7 @@ std::string AddEventAfterNode(
   for (size_t i = 0; i < node_args.size(); ++i) {
     // Find consumer of "node"'s i-th output.
     std::vector<Node*> consumer_nodes = graph.GetMutableConsumerNodes(
-      node_args[i]->Name());
+        node_args[i]->Name());
     // Replace node_args[i] with new_node_args[i] in nodes.
     ReplaceNodeArgs(consumer_nodes, {node_args[i]}, {new_node_args[i]});
   }
@@ -457,9 +457,9 @@ Status AddForwardWaitAfterRecv(
     std::vector<std::string>& new_input_names,
     std::string& event_name) {
   event_name = AddEventAfterNode(
-    graph, comm_node,
-    "WaitEvent", "forward_wait_after_recv",
-    "forward_wait_after_recv_event_id");
+      graph, comm_node,
+      "WaitEvent", "forward_wait_after_recv",
+      "forward_wait_after_recv_event_id");
   if (event_name.empty()) {
     return Status::OK();
   } else {
@@ -474,9 +474,9 @@ Status AddForwardRecordBeforeSend(
     std::vector<std::string>& new_input_names,
     std::string& event_name) {
   event_name = AddEventBeforeNode(
-    graph, comm_node,
-    "RecordEvent", "forward_record_before_send",
-    "forward_record_before_send_event_id");
+      graph, comm_node,
+      "RecordEvent", "forward_record_before_send",
+      "forward_record_before_send_event_id");
   if (event_name.empty()) {
     return Status::OK();
   } else {
@@ -491,9 +491,9 @@ Status AddBackwardWaitAfterRecv(
     std::vector<std::string>& new_input_names,
     std::string& event_name) {
   event_name = AddEventAfterNode(
-    graph, comm_node,
-    "WaitEvent", "backward_wait_after_recv",
-    "backward_wait_after_recv_event_id");
+      graph, comm_node,
+      "WaitEvent", "backward_wait_after_recv",
+      "backward_wait_after_recv_event_id");
   if (event_name.empty()) {
     return Status::OK();
   } else {
@@ -508,9 +508,9 @@ Status AddBackwardRecordBeforeSend(
     std::vector<std::string>& new_input_names,
     std::string& event_name) {
   event_name = AddEventBeforeNode(
-    graph, comm_node,
-    "RecordEvent", "backward_record_before_send",
-    "backward_record_before_send_event_id");
+      graph, comm_node,
+      "RecordEvent", "backward_record_before_send",
+      "backward_record_before_send_event_id");
   if (event_name.empty()) {
     return Status::OK();
   } else {
@@ -605,20 +605,20 @@ Status SetInputsOutputsAndResolve(Graph& graph,
 //   Record-2: Tell others that backward pass is done.
 //   Record-3: Tell others that backward result has been passed to another stage.
 Status TransformGraphForPipeline(
-  Graph& graph,
-  const std::unordered_set<std::string>& weights_to_train,
-  std::string& forward_waited_event_name,
-  std::string& forward_recorded_event_name,
-  std::string& backward_waited_event_name,
-  std::string& backward_recorded_event_name,
-  std::string& forward_wait_output_name,
-  std::string& forward_record_output_name,
-  std::string& backward_wait_output_name,
-  std::string& backward_record_output_name,
-  std::string& forward_waited_event_after_recv_name,
-  std::string& forward_recorded_event_before_send_name,
-  std::string& backward_waited_event_after_recv_name,
-  std::string& backward_recorded_event_before_send_name) {
+    Graph& graph,
+    const std::unordered_set<std::string>& weights_to_train,
+    std::string& forward_waited_event_name,
+    std::string& forward_recorded_event_name,
+    std::string& backward_waited_event_name,
+    std::string& backward_recorded_event_name,
+    std::string& forward_wait_output_name,
+    std::string& forward_record_output_name,
+    std::string& backward_wait_output_name,
+    std::string& backward_record_output_name,
+    std::string& forward_waited_event_after_recv_name,
+    std::string& forward_recorded_event_before_send_name,
+    std::string& backward_waited_event_after_recv_name,
+    std::string& backward_recorded_event_before_send_name) {
   // Declare nodes according to their topological order.
   Node* forward_wait{nullptr};
   Node* forward_send{nullptr};
@@ -650,27 +650,27 @@ Status TransformGraphForPipeline(
   std::vector<std::string> new_output_names;
 
   backward_record = AddBackwardRecord(
-    graph,
-    backward_send,
-    new_input_names,
-    new_output_names,
-    backward_recorded_event_name,
-    backward_record_output_name);
+      graph,
+      backward_send,
+      new_input_names,
+      new_output_names,
+      backward_recorded_event_name,
+      backward_record_output_name);
   forward_wait = AddForwardWait(
-    graph,
-    forward_recv,
-    new_input_names,
-    forward_waited_event_name,
-    forward_wait_output_name);
+      graph,
+      forward_recv,
+      new_input_names,
+      forward_waited_event_name,
+      forward_wait_output_name);
   ORT_RETURN_IF_ERROR(AddOrSkipForwardRecordBackwardWait(
-    graph,
-    forward_send,
-    backward_recv,
-    new_input_names,
-    forward_recorded_event_name,
-    backward_waited_event_name,
-    forward_record_output_name,
-    backward_wait_output_name));
+      graph,
+      forward_send,
+      backward_recv,
+      new_input_names,
+      forward_recorded_event_name,
+      backward_waited_event_name,
+      forward_record_output_name,
+      backward_wait_output_name));
 
   // Different stages have different patterns of Send & Recv.
   // For different patterns, we add different WaitEvent and Record.
@@ -694,11 +694,11 @@ Status TransformGraphForPipeline(
   // One and only one of is_first_stage, is_middle_stage, and is_last_stage can be true.
   const unsigned int stage_flag_sum = is_first_stage + is_middle_stage + is_last_stage;
   ORT_RETURN_IF_NOT(stage_flag_sum == 1u,
-    "The processed graph should be classified into a stage, "
-    "but we see more than one true's in the following statements. ",
-    "Is first stage? ", is_first_stage, ". ",
-    "Is middle stage? ", is_middle_stage, ". ",
-    "Is last stage? ", is_last_stage, ".");
+                    "The processed graph should be classified into a stage, "
+                    "but we see more than one true's in the following statements. ",
+                    "Is first stage? ", is_first_stage, ". ",
+                    "Is middle stage? ", is_middle_stage, ". ",
+                    "Is last stage? ", is_last_stage, ".");
 
   // Now, we add Wait's in parentheses shown below.
   // 1. First stage:
@@ -713,19 +713,17 @@ Status TransformGraphForPipeline(
   if (is_first_stage) {
     // If first stage, insert after forward WaitEvent.
     ORT_RETURN_IF_ERROR(AddForwardWaitAfterRecv(
-      graph,
-      forward_wait,
-      new_input_names,
-      forward_waited_event_after_recv_name
-    ));
+        graph,
+        forward_wait,
+        new_input_names,
+        forward_waited_event_after_recv_name));
   } else if (is_middle_stage || is_last_stage) {
     // If middle stage or last stage, insert after forward Recv.
     ORT_RETURN_IF_ERROR(AddForwardWaitAfterRecv(
-      graph,
-      forward_recv,
-      new_input_names,
-      forward_waited_event_after_recv_name
-    ));
+        graph,
+        forward_recv,
+        new_input_names,
+        forward_waited_event_after_recv_name));
   }
 
   // Now, we add Record's in parentheses shown below.
@@ -740,11 +738,10 @@ Status TransformGraphForPipeline(
   //  ----------------------> BW -> Record -> Send -> Record
   if (is_first_stage || is_middle_stage) {
     ORT_RETURN_IF_ERROR(AddForwardRecordBeforeSend(
-      graph,
-      forward_send,
-      new_input_names,
-      forward_recorded_event_before_send_name
-    ));
+        graph,
+        forward_send,
+        new_input_names,
+        forward_recorded_event_before_send_name));
   }
 
   // Now, we add Wait's in parentheses shown below.
@@ -759,11 +756,10 @@ Status TransformGraphForPipeline(
   //  ----------------------> BW -> Record -> Send -> Record
   if (is_first_stage || is_middle_stage) {
     ORT_RETURN_IF_ERROR(AddBackwardWaitAfterRecv(
-      graph,
-      backward_recv,
-      new_input_names,
-      backward_waited_event_after_recv_name
-    ));
+        graph,
+        backward_recv,
+        new_input_names,
+        backward_waited_event_after_recv_name));
   }
 
   // Now, we add Record's in parentheses shown below.
@@ -778,18 +774,16 @@ Status TransformGraphForPipeline(
   //  ----------------------> BW -> (Record) -> Send -> Record
   if (is_first_stage) {
     ORT_RETURN_IF_ERROR(AddBackwardRecordBeforeSend(
-      graph,
-      backward_record,
-      new_input_names,
-      backward_recorded_event_before_send_name
-    ));
+        graph,
+        backward_record,
+        new_input_names,
+        backward_recorded_event_before_send_name));
   } else if (is_middle_stage || is_last_stage) {
     ORT_RETURN_IF_ERROR(AddBackwardRecordBeforeSend(
-      graph,
-      backward_send,
-      new_input_names,
-      backward_recorded_event_before_send_name
-    ));
+        graph,
+        backward_send,
+        new_input_names,
+        backward_recorded_event_before_send_name));
   }
 
   ORT_RETURN_IF_ERROR(SetInputsOutputsAndResolve(graph, weights_to_train, new_input_names, new_output_names));
@@ -801,11 +795,11 @@ Status TransformGraphForPipeline(
 // It also cerates an initializer to store its value.
 template <typename T>
 void AddNewScalarNodeArgAndInitializer(Graph& graph,
-                                 const std::string& op_name,
-                                 onnx::TensorProto_DataType type,
-                                 T data,
-                                 std::vector<NodeArg*>& new_node_args,
-                                 std::vector<std::string>& new_names) {
+                                       const std::string& op_name,
+                                       onnx::TensorProto_DataType type,
+                                       T data,
+                                       std::vector<NodeArg*>& new_node_args,
+                                       std::vector<std::string>& new_names) {
   AddNewNodeArg(graph, op_name, type, new_node_args, new_names);
 
   ONNX_NAMESPACE::TensorProto proto_data;
@@ -823,6 +817,208 @@ void AddNewScalarNodeArgAndInitializer(Graph& graph,
       ORT_THROW("pipeline partition unsupported 'type' value: ", type);
   }
   graph.AddInitializedTensor(proto_data);
+}
+
+Status FindAllConnectedNodes(Graph& graph,
+                             const Node* node,
+                             std::vector<const Node*>& connected_nodes,
+                             std::set<const NodeArg*>& connected_inputs,
+                             std::set<const NodeArg*>& connected_outputs
+                             ) {
+  ORT_THROW_IF_ERROR(node->ForEachWithIndex(
+      node->InputDefs(),
+      [&](const NodeArg& node_arg, size_t /*index*/) {
+        if (graph.IsInputsIncludingInitializers(&node_arg)) {
+          connected_inputs.insert(&node_arg);
+        } else {
+          const Node* producer_node = graph.GetProducerNode(node_arg.Name());
+          if (producer_node == nullptr) {
+            // got nullptr as producer node. This could be because the input is a constant op which will be optimized
+            // away. Print out this information and continue.
+            // LOGS_DEFAULT(WARNING) << "Cannot find producer node for node_arg: " << node_arg.Name() << ". Skipping this node.";
+          } else {
+            connected_nodes.push_back(producer_node);
+          }
+        }
+        return Status::OK();
+      }));
+
+  ORT_THROW_IF_ERROR(node->ForEachWithIndex(
+      node->OutputDefs(),
+      [&](const NodeArg& node_arg, size_t /*index*/) {
+        if (!graph.IsOutput(&node_arg)) {
+          std::vector<const Node*> consumer_nodes = graph.GetConsumerNodes(node_arg.Name());
+          connected_nodes.insert(std::end(connected_nodes), consumer_nodes.begin(), consumer_nodes.end());
+
+        } else {
+          connected_outputs.insert(&node_arg);
+        }
+        return Status::OK();
+      }));
+  return Status::OK();
+}
+
+// PipelineStageNodeGroup groups nodes that share the same input initializer and belong to the same stage.
+// It is used to distinguish other nodes that share the same input initializer but belong to
+// other pipeline partitions after split.
+struct PipelineStageNodeGroup {
+  const size_t stage_id;
+
+  // Vector of nodes that have the same initializer input and belong to the same stage. Noted that
+  // the consumer nodes of a particular initializer can be more than one, so we need a vector to store those
+  // nodes.
+  std::vector<Node*> nodes;
+  PipelineStageNodeGroup(const size_t stage, std::vector<Node*>& node) : stage_id(stage), nodes(std::move(node)){};
+};
+
+common::Status AddPassthroughInitializer(Graph& graph,
+                                         const NodeArg* initializer,
+                                         const std::vector<PipelineStageNodeGroup>& node_groups,
+                                         const std::vector<Node*>& send_nodes,
+                                         const std::vector<Node*>& recv_nodes) {
+  ORT_ENFORCE(node_groups.size() >= 2, "Initializer ", initializer->Name(),
+              " is not shared across stages. It only exits in partition: ", node_groups[0].stage_id);
+
+  const size_t from_stage = node_groups.front().stage_id;
+  const size_t to_stage = node_groups.back().stage_id;
+
+  ORT_ENFORCE(from_stage < to_stage, "Pass through from_stage (", from_stage,
+              ") is not less than the to_stage (", to_stage, ").");
+
+  auto dtype = initializer->TypeAsProto()->tensor_type().elem_type();
+
+  // new_node_args tracks newly created node_args in the pass through stages
+  std::vector<NodeArg*> new_node_args;
+  auto current_node_arg = const_cast<NodeArg*>(initializer);
+
+  for (auto i = from_stage; i < to_stage; ++i) {
+    // processing send node in cut i
+    auto& send_attributes = send_nodes[i]->GetMutableAttributes();
+    auto& send_element_types = send_attributes["element_types"];
+    send_element_types.add_ints(static_cast<int64_t>(dtype));
+    send_nodes[i]->MutableInputDefs().push_back(current_node_arg);
+    send_nodes[i]->MutableInputArgsCount().back()++;
+
+    // Create a new node_arg for the recv, as the new node_arg from recv node should possess a differnet id
+    // than the one in send
+    auto& new_node_arg = CreateNodeArg(graph, current_node_arg);
+    new_node_args.push_back(&new_node_arg);
+    current_node_arg = &new_node_arg;
+
+    // process recv node in cut i
+    auto& recv_attributes = recv_nodes[i]->GetMutableAttributes();
+    auto& recv_element_types = recv_attributes["element_types"];
+    recv_element_types.add_ints(static_cast<int64_t>(dtype));
+    recv_nodes[i]->MutableOutputDefs().push_back(current_node_arg);
+  }
+
+  // update the consumer node's input if the node's group is not in the first partition
+  for (size_t i = 1u; i < node_groups.size(); ++i) {
+    ORT_ENFORCE(node_groups[i].stage_id > from_stage, "node group id (", node_groups[i].stage_id,
+                ") is less than first stage id (", from_stage, "). ");
+    size_t new_node_arg_index = node_groups[i].stage_id - from_stage - 1;
+    for(auto node : node_groups[i].nodes){
+      for (auto& input_node : node->MutableInputDefs()) {
+        if (input_node == initializer) {
+          input_node = new_node_args[new_node_arg_index];
+          break;
+        }
+      }
+    }
+  }
+  return Status::OK();
+}
+
+void TraverseGraphWithConnectedElement(Graph& graph,
+                                       const Node* startNode,
+                                       std::set<const Node*>& visited_nodes,
+                                       std::set<const NodeArg*>& visited_inputs,
+                                       std::set<const NodeArg*>& visited_outputs) {
+  visited_nodes.clear();
+  visited_inputs.clear();
+  visited_outputs.clear();
+
+  std::queue<const Node*> node_queue;
+  node_queue.push(startNode);
+
+  while (!node_queue.empty()) {
+    auto node = node_queue.front();
+    node_queue.pop();
+    if (visited_nodes.count(node) == 0) {
+      visited_nodes.insert(node);
+      std::vector<const Node*> connected_nodes;
+      ORT_THROW_IF_ERROR(FindAllConnectedNodes(graph, node, connected_nodes, visited_inputs, visited_outputs));
+
+      for (auto n : connected_nodes) {
+        ORT_ENFORCE(n != nullptr, "Found nullptr in searching for connected nodes");
+        node_queue.push(n);
+      }
+    }
+  }
+}
+
+// If an initializer is shared across partitions, instead of creating a separate all_reduce op to
+// sync with those tensors in selected partitions, we save only one copy of that initializer in
+// the very first partition it appears, and pass that data down to all following partitions
+// where this initializer is used.
+common::Status HandleSharedInitializer(Graph& graph,
+                                       const std::vector<Node*>& send_nodes,
+                                       const std::vector<Node*>& recv_nodes) {
+  // Map an given initializer to all the partitions that its consumer nodes reside. The size of
+  // the mapped vector reflects how many partitions this initializer's consumer nodes distribute.
+  // If its size is greater than 1, it means this initializer is being used in more than one partition and
+  // we need to proceed those cases.
+  std::map<const NodeArg*, std::vector<PipelineStageNodeGroup>> input_consumer_stage_map;
+
+  for (size_t stage = 0; stage <= send_nodes.size(); ++stage) {
+    std::set<const Node*> visited_nodes;
+    std::set<const NodeArg*> visited_inputs;
+    std::set<const NodeArg*> visited_outputs;
+
+    if (stage < send_nodes.size()) {
+      TraverseGraphWithConnectedElement(graph, send_nodes[stage],
+                                        visited_nodes, visited_inputs, visited_outputs);
+    } else {
+      TraverseGraphWithConnectedElement(graph, recv_nodes.back(),
+                                        visited_nodes, visited_inputs, visited_outputs);
+    }
+
+    for (const auto input : visited_inputs) {
+      // If the node is an input instead of an initializer, continue
+      if (!graph.IsInitializerTensor(input->Name())){
+        continue;
+      }
+
+      // group all consumer nodes that shares the same input initializer in visited_consumer_nodes
+      std::vector<Node*> consumer_nodes = graph.GetMutableConsumerNodes(input->Name());
+      std::vector<Node*> visited_consumer_nodes;
+      for(auto consumer_node : consumer_nodes){
+        if (visited_nodes.count(consumer_node) != 0){
+          visited_consumer_nodes.push_back(consumer_node);
+        }
+      }
+
+      if (input_consumer_stage_map.count(input) == 0) {
+        std::vector<PipelineStageNodeGroup> stage_node_group{PipelineStageNodeGroup(stage, visited_consumer_nodes)};
+        input_consumer_stage_map[input] = std::move(stage_node_group);
+      } else {
+        input_consumer_stage_map[input].push_back({stage, visited_consumer_nodes});
+      }
+    }
+  }
+
+  for (const auto entry : input_consumer_stage_map) {
+    // If any initializer is shared, handle the logic of passing it from the first seen stage all
+    // the way to last seen stage.
+    if (entry.second.size() > 1) {
+      ORT_RETURN_IF_ERROR(AddPassthroughInitializer(graph,
+                                entry.first, // initializer node_arg
+                                entry.second, // initializer consumer node groups
+                                send_nodes,
+                                recv_nodes));
+    }
+  }
+  return Status::OK();
 }
 
 // split the graph into disconnected subgraph based on provided CutInfo
@@ -869,30 +1065,30 @@ common::Status SplitGraph(Graph& graph,
     auto cut_index_str = std::to_string(index);
     // add input node_arg and initializer for send/recv
     AddNewScalarNodeArgAndInitializer<bool>(graph,
-                                      "send_input_signal" + cut_index_str,
-                                      ONNX_NAMESPACE::TensorProto_DataType_BOOL,
-                                      true, /* initializer data */
-                                      send_input_args,
-                                      new_input_names);
+                                            "send_input_signal" + cut_index_str,
+                                            ONNX_NAMESPACE::TensorProto_DataType_BOOL,
+                                            true, /* initializer data */
+                                            send_input_args,
+                                            new_input_names);
     AddNewScalarNodeArgAndInitializer<bool>(graph,
-                                      "recv_input_signal" + cut_index_str,
-                                      ONNX_NAMESPACE::TensorProto_DataType_BOOL,
-                                      true, /* initializer data */
-                                      recv_input_args,
-                                      new_input_names);
+                                            "recv_input_signal" + cut_index_str,
+                                            ONNX_NAMESPACE::TensorProto_DataType_BOOL,
+                                            true, /* initializer data */
+                                            recv_input_args,
+                                            new_input_names);
 
     AddNewScalarNodeArgAndInitializer<size_t>(graph,
-                                      "send_dst_rank" + cut_index_str,
-                                      ONNX_NAMESPACE::TensorProto_DataType_INT64,
-                                      index + 1, /* initializer data */
-                                      send_input_args,
-                                      new_input_names);
+                                              "send_dst_rank" + cut_index_str,
+                                              ONNX_NAMESPACE::TensorProto_DataType_INT64,
+                                              index + 1, /* initializer data */
+                                              send_input_args,
+                                              new_input_names);
     AddNewScalarNodeArgAndInitializer<size_t>(graph,
-                                      "recv_src_rank" + cut_index_str,
-                                      ONNX_NAMESPACE::TensorProto_DataType_INT64,
-                                      index, /* initializer data */
-                                      recv_input_args,
-                                      new_input_names);
+                                              "recv_src_rank" + cut_index_str,
+                                              ONNX_NAMESPACE::TensorProto_DataType_INT64,
+                                              index, /* initializer data */
+                                              recv_input_args,
+                                              new_input_names);
     // add output node_arg for send/recv
     AddNewNodeArg(graph, "send_output_signal" + cut_index_str, ONNX_NAMESPACE::TensorProto_DataType_BOOL,
                   send_output_args, new_output_names);
@@ -973,7 +1169,7 @@ common::Status SplitGraph(Graph& graph,
       // deal with updating the consumer's input node_args
       std::vector<Node*> consumer_nodes;
       if (id.consumer_nodes.has_value()) {
-        for(auto& consumer_node_id : id.consumer_nodes.value()){
+        for (auto& consumer_node_id : id.consumer_nodes.value()) {
           consumer_nodes.push_back(graph.GetMutableProducerNode(consumer_node_id));
         }
       } else {
@@ -1019,68 +1215,17 @@ common::Status SplitGraph(Graph& graph,
   return Status::OK();
 }
 
-Status FindAllConnectedNodes(Graph& graph,
-                             const Node* node,
-                             std::vector<const Node*>& connected_nodes,
-                             std::set<const NodeArg*>& connected_inputs,
-                             std::set<const NodeArg*>& connected_outputs) {
-  ORT_THROW_IF_ERROR(node->ForEachWithIndex(
-      node->InputDefs(),
-      [&](const NodeArg& node_arg, size_t /*index*/) {
-        if (graph.IsInputsIncludingInitializers(&node_arg)) {
-          connected_inputs.insert(&node_arg);
-        } else {
-          const Node* producer_node = graph.GetProducerNode(node_arg.Name());
-          if (producer_node == nullptr) {
-            // got nullptr as producer node. This could be because the input is a constant op which will be optimized
-            // away. Print out this information and continue.
-            LOGS_DEFAULT(WARNING) << "Cannot find producer node for node_arg: " << node_arg.Name() << ". Skipping this node.";
-          } else {
-            connected_nodes.push_back(producer_node);
-          }
-        }
-        return Status::OK();
-      }));
-
-  ORT_THROW_IF_ERROR(node->ForEachWithIndex(
-      node->OutputDefs(),
-      [&](const NodeArg& node_arg, size_t /*index*/) {
-        if (!graph.IsOutput(&node_arg)) {
-          std::vector<const Node*> consumer_nodes = graph.GetConsumerNodes(node_arg.Name());
-          connected_nodes.insert(std::end(connected_nodes), consumer_nodes.begin(), consumer_nodes.end());
-
-        } else {
-          connected_outputs.insert(&node_arg);
-        }
-        return Status::OK();
-      }));
-  return Status::OK();
-}
-
 // traverse the graph from start_node to get the set of nodes contains in this disconnected subgraph
 common::Status GenerateSubgraph(Graph& graph, const Node* start_node) {
-  std::queue<const Node*> node_queue;
-  node_queue.push(start_node);
 
   std::set<const Node*> visited_nodes;
   std::set<const NodeArg*> visited_inputs;
   std::set<const NodeArg*> visited_outputs;
 
   // BFS graph traverse
-  while (!node_queue.empty()) {
-    auto node = node_queue.front();
-    node_queue.pop();
-    if (visited_nodes.count(node) == 0) {
-      visited_nodes.insert(node);
-      std::vector<const Node*> connected_nodes;
-      ORT_THROW_IF_ERROR(FindAllConnectedNodes(graph, node, connected_nodes, visited_inputs, visited_outputs));
+  TraverseGraphWithConnectedElement(graph, start_node,
+                                    visited_nodes, visited_inputs, visited_outputs);
 
-      for (auto n : connected_nodes) {
-        ORT_ENFORCE(n!=nullptr, "Found nullptr in searching for connected nodes");
-        node_queue.push(n);
-      }
-    }
-  }
   std::set<NodeIndex> visited_node_index;
   for (auto n : visited_nodes) {
     visited_node_index.insert(n->Index());
@@ -1090,8 +1235,8 @@ common::Status GenerateSubgraph(Graph& graph, const Node* start_node) {
   const auto& node_topology_list = graph_viewer.GetNodesInTopologicalOrder();
 
   // reverse iterate the nodes in tolopogical order, and delete those not visited
-  for (auto it = node_topology_list.rbegin(); it != node_topology_list.rend(); it++){
-    if (visited_node_index.count(*it)==0){
+  for (auto it = node_topology_list.rbegin(); it != node_topology_list.rend(); it++) {
+    if (visited_node_index.count(*it) == 0) {
       graph.RemoveNode(*it);
     }
   }
@@ -1133,9 +1278,11 @@ Status ApplyPipelinePartitionToMainGraph(
   recv_nodes.reserve(split_count);
   ORT_RETURN_IF_ERROR(SplitGraph(graph, cut_info, send_nodes, recv_nodes));
 
+  ORT_RETURN_IF_ERROR(HandleSharedInitializer(graph, send_nodes, recv_nodes));
+
   if (send_nodes.size() != split_count || recv_nodes.size() != split_count) {
     ORT_THROW("Split error: not all cut has Send and Recv inserted. Send node count: ",
-    send_nodes.size(), ", Recv node count: ", recv_nodes.size(), ", split count: ", split_count);
+              send_nodes.size(), ", Recv node count: ", recv_nodes.size(), ", split count: ", split_count);
   }
 
   if (pipeline_stage_id < split_count) {

--- a/orttraining/orttraining/core/graph/pipeline_transformer.cc
+++ b/orttraining/orttraining/core/graph/pipeline_transformer.cc
@@ -831,7 +831,7 @@ Status FindAllConnectedNodes(Graph& graph,
   ORT_THROW_IF_ERROR(node->ForEachMutableWithIndex(
       node->MutableInputDefs(),
       [&](NodeArg& node_arg, size_t /*index*/) {
-        if (graph.IsInputsIncludingInitializers(&node_arg) || graph.IsInitializerTensor(node_arg.Name())) {
+        if (graph.IsInputsIncludingInitializers(&node_arg) || graph.IsInitializedTensor(node_arg.Name())) {
           connected_inputs.insert(&node_arg);
         } else {
           Node* producer_node = graph.GetMutableProducerNode(node_arg.Name());
@@ -993,7 +993,7 @@ common::Status HandleSharedInitializer(Graph& graph,
 
     for (const auto input : visited_inputs) {
       // If the node is an input instead of an initializer, continue
-      if (!graph.IsInitializerTensor(input->Name())){
+      if (!graph.IsInitializedTensor(input->Name())){
         continue;
       }
 

--- a/orttraining/orttraining/core/graph/pipeline_transformer.cc
+++ b/orttraining/orttraining/core/graph/pipeline_transformer.cc
@@ -935,6 +935,8 @@ common::Status AddPassthroughInitializer(Graph& graph,
   return Status::OK();
 }
 
+// Traverse the graph to find out all connected elements in the graph from start_node. The traverse treats the graph as an
+// undirected graph.
 void TraverseGraphWithConnectedElement(Graph& graph,
                                        Node* start_node,
                                        std::set<Node*>& visited_nodes,

--- a/orttraining/orttraining/test/graph/gradient_graph_builder_test.cc
+++ b/orttraining/orttraining/test/graph/gradient_graph_builder_test.cc
@@ -1140,14 +1140,14 @@ TEST(GradientGraphBuilderTest, PipelineOnlinePartition_bert_tiny) {
   // 2 test variations - full precision and mixed precision
   const std::vector<bool> test_with_fp32{true, false};
   for (auto is_fp32 : test_with_fp32) {
-    // graph is partitioned into 4 parts.
+    // graph is partitioned into 3 parts.
     for (int i = 0; i < static_cast<int>(total_partition_count); ++i) {
 #ifdef _WIN32
-      auto surfix = std::to_wstring(i);
+      auto suffix = std::to_wstring(i);
 #else
-      auto surfix = std::to_string(i);
+      auto suffix = std::to_string(i);
 #endif
-      PathString output_file = ORT_TSTR("pipeline_partition_") + surfix + ORT_TSTR("_back.onnx");
+      PathString output_file = ORT_TSTR("pipeline_partition_") + suffix + ORT_TSTR("_back.onnx");
 
       auto config = MakeBasicTrainingConfig();
 
@@ -1165,12 +1165,6 @@ TEST(GradientGraphBuilderTest, PipelineOnlinePartition_bert_tiny) {
                               /*mlm_loss*/ "mlm_loss",
                               /*nsp_loss*/ "nsp_loss"});
       }
-
-      config.immutable_weights = {
-          {"Div", {{1, 8.0f}, {1, 1.4142135381698608f}}},
-          {"Add", {{1, 1.0f}, {1, 9.999999960041972e-13f}}},
-          {"Mul", {{1, 0.5f}, {1, -10000.0f}}},
-          {"Sub", {{0, 1.0f}}}};
 
       config.pipeline_config = pipe;
       config.distributed_config.world_rank = i;
@@ -1242,11 +1236,11 @@ TEST(GradientGraphBuilderTest, PipelineOnlinePartition_MLP) {
     // graph is partitioned into 3 parts.
     for (int i = 0; i < 3; ++i) {
 #ifdef _WIN32
-      auto surfix = std::to_wstring(i);
+      auto suffix = std::to_wstring(i);
 #else
-      auto surfix = std::to_string(i);
+      auto suffix = std::to_string(i);
 #endif
-      PathString output_file = ORT_TSTR("pipeline_partition_") + surfix + ORT_TSTR("_back.onnx");
+      PathString output_file = ORT_TSTR("pipeline_partition_") + suffix + ORT_TSTR("_back.onnx");
 
       auto config = MakeBasicTrainingConfig();
 
@@ -1392,12 +1386,12 @@ TEST(GradientGraphBuilderTest, TrainingSession_PipelineTransform_base) {
 
   for (int i = 0; i < 3; ++i) {
 #ifdef _WIN32
-    auto surfix = std::to_wstring(i);
+    auto suffix = std::to_wstring(i);
 #else
-    auto surfix = std::to_string(i);
+    auto suffix = std::to_string(i);
 #endif
-    PathString input_file = filename_base + surfix + ORT_TSTR(".onnx");
-    PathString output_file = filename_base + surfix + ORT_TSTR("_back.onnx");
+    PathString input_file = filename_base + suffix + ORT_TSTR(".onnx");
+    PathString output_file = filename_base + suffix + ORT_TSTR("_back.onnx");
     load_and_check_gradient_graph(i, input_file, output_file);
   }
 }

--- a/orttraining/orttraining/test/graph/gradient_graph_builder_test.cc
+++ b/orttraining/orttraining/test/graph/gradient_graph_builder_test.cc
@@ -1513,7 +1513,7 @@ TEST(GradientGraphBuilderTest, TrainingSession_WithPipeline) {
   for (size_t sub_id = 0; sub_id < num_subs; ++sub_id) {
     auto& sub_sess = subs[sub_id];
     sub_sess.so.enable_profiling = true;
-    sub_sess.so.profile_file_prefix = GenerateFileNameWithIndex(ORT_TSTR("pipeline"), sub_id, ORT_TSTR(""));
+    sub_sess.so.profile_file_prefix = GenerateFileNameWithIndex(ORT_TSTR("pipeline"), static_cast<int>(sub_id), ORT_TSTR(""));
 
     sub_sess.run_options.run_log_verbosity_level = sub_sess.so.session_log_verbosity_level;
     sub_sess.run_options.run_tag = sub_sess.so.session_logid;


### PR DESCRIPTION
**Description**: when partitioning a model, some of its initializers can be used in multiple partitions thus each partition possess a copy of that tensor and cause difficulty on gradient syncing. This change does a post split check to identify any shared initializers. If sharing exist, we will keep the first initializer and pass it down to downstream partitions through Send/Recv​ ops.

A new test is also added to guard this change.

**Motivation and Context**
- Why is this change required? What problem does it solve?
Bert model has a word embedding initializer that is being used in the first and last partition. In order to obtain the correct training result, this change keeps the embedding in the first partition and pass it down to last partition for correct gradient calculation.

