### PR TITLE
Ignore line length error.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+ignore = E501
 max-line-length = 120
 per-file-ignores =
     __init__.py:F401


### PR DESCRIPTION
**Description**: Ignore line length error.

**Motivation and Context**
It seems odd that we throw an error when line length exceeds 120 chars for Python code (build scripts), but not for production C++ code. Error codes are documented here https://pep8.readthedocs.io/en/latest/intro.html#error-codes.