### PR TITLE
Support training_mode flag in eval

### DIFF
--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -250,7 +250,7 @@ class InferenceSession {
     *        This should not be changed during execution of this function.
     * @return OK if success.
     */
-  common::Status Run(const NameMLValMap& feeds, const std::vector<std::string>& output_names,
+  virtual common::Status Run(const NameMLValMap& feeds, const std::vector<std::string>& output_names,
                      std::vector<OrtValue>* p_fetches) ORT_MUST_USE_RESULT;
 
   /**

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -296,8 +296,8 @@ Status TrainingSession::ConfigureForTraining(
     }
   }
 
-  // Set eval feed names for Dropout ratio.
-  ORT_RETURN_IF_ERROR(SetDropoutEvalFeedNames());
+  // Set eval feed names for nodes that differ between training and inferencing.
+  ORT_RETURN_IF_ERROR(SetEvalFeedNames());
 
   // add Tensorboard
   if (config.tensorboard_config.has_value()) {
@@ -799,16 +799,38 @@ bool TrainingSession::IsGraphOutputFp32Node(const std::string& output_name) cons
 common::Status TrainingSession::Run(const RunOptions& run_options, IOBinding& io_binding) {
   // Override initializers in eval mode.
   if (!run_options.training_mode) {
-    // override all dropout raiots to 0
-    for (auto& drop_ratio : dropout_eval_feeds_) {
-      OrtValue feed_value;
-      // We allocate on CPU first, copy will be taken care off downstream.
-      auto cpu_allocator = session_state_->GetExecutionProviders()
-                           .Get(onnxruntime::kCpuExecutionProvider)
-                           ->GetAllocator(0, OrtMemTypeDefault);
-      feed_value = onnxruntime::MakeScalarMLValue<float>(cpu_allocator, 0.f, true /*is_1d*/);
+    std::vector<std::pair<std::string, OrtValue>> new_feeds;
+    if (!dropout_eval_feeds_.empty()) {
+      // override all dropout ratios to 0
+      for (auto& drop_ratio : dropout_eval_feeds_) {
+        OrtValue feed_value;
+        // We allocate on CPU first, copy will be taken care of downstream.
+        auto cpu_allocator = session_state_->GetExecutionProviders()
+                            .Get(onnxruntime::kCpuExecutionProvider)
+                            ->GetAllocator(0, OrtMemTypeDefault);
+        feed_value = onnxruntime::MakeScalarMLValue<float>(cpu_allocator, 0.f, true /*is_1d*/);
+        // Bind new feed to graph input.
+        new_feeds.emplace_back(drop_ratio, feed_value);
+      }
+    }
+    else {
+      const ONNX_NAMESPACE::TensorProto* exist_initializer = nullptr;
+      auto& input_names = io_binding.GetInputNames();
+      if (model_->MainGraph().GetInitializedTensor(training_mode_string_, exist_initializer) &&
+          std::find(input_names.begin(), input_names.end(), training_mode_string_) == input_names.end()) {
+        // Set training_mode input to false
+        OrtValue training_mode_feed_value;
+        // We allocate on CPU first, copy will be taken care of downstream.
+        auto cpu_allocator = session_state_->GetExecutionProviders()
+                            .Get(onnxruntime::kCpuExecutionProvider)
+                            ->GetAllocator(0, OrtMemTypeDefault);
+        training_mode_feed_value = onnxruntime::MakeScalarMLValue<bool>(cpu_allocator, false, true /*is_1d*/);
+        new_feeds.emplace_back(training_mode_string_, training_mode_feed_value);
+      }
+    }
+    for (auto& new_feed : new_feeds) {
       // Bind new feed to graph input.
-      ORT_RETURN_IF_ERROR(io_binding.BindInput(drop_ratio, feed_value));
+      ORT_RETURN_IF_ERROR(io_binding.BindInput(new_feed.first, new_feed.second));
     }
   }
 
@@ -823,26 +845,43 @@ common::Status TrainingSession::Run(IOBinding& io_binding) {
   return Run(run_options, io_binding);
 }
 
-static const std::unordered_set<std::string> Dropout_Nodes = {
+common::Status TrainingSession::Run(const NameMLValMap& feeds, const std::vector<std::string>& output_names,
+                                     std::vector<OrtValue>* p_fetches) {
+  RunOptions run_options;
+  run_options.training_mode = true;
+  return Run(run_options, feeds, output_names, p_fetches);
+}
+
+static const std::unordered_set<std::string> Nodes_Need_Eval_Feeds = {
+    // TODO remove this once ONNX TrainableDropout is completely deprecated.
     "TrainableDropout",
+    "Dropout",
 };
-// TODO remove this once ONNX properly supports training_mode input.
-Status TrainingSession::SetDropoutEvalFeedNames() {
+Status TrainingSession::SetEvalFeedNames() {
   Graph& graph = model_->MainGraph();
 
-  // add ratio node to graph input for overriding.
   GraphAugmenter::GraphDefs defs{};
 
   for (const auto& node : graph.Nodes()) {
-    auto it = Dropout_Nodes.find(node.OpType());
-    if(it != Dropout_Nodes.cend()) {
-      auto& ratio_name = node.InputDefs()[1]->Name();
-      dropout_eval_feeds_.insert(ratio_name);
-      ORT_ENFORCE(model_->MainGraph().GetProducerNode(ratio_name) == nullptr,
-      "Input: " + ratio_name + " should not have any producer node.");
-      defs.AddGraphInputs({ratio_name});
+    auto it = Nodes_Need_Eval_Feeds.find(node.OpType());
+    if(it != Nodes_Need_Eval_Feeds.cend()) {
+      // The opset is < 12, add each ratio input to graph inputs for overriding.
+      // Needs to be removed when TrainableDropout is deprecated.
+      if(it->compare("TrainableDropout") == 0) {
+        auto& ratio_name = node.InputDefs()[1]->Name();
+        dropout_eval_feeds_.insert(ratio_name);
+        ORT_ENFORCE(model_->MainGraph().GetProducerNode(ratio_name) == nullptr,
+        "Input: " + ratio_name + " should not have any producer node.");
+        defs.AddGraphInputs({ratio_name});
+        continue;
+      }
+      
+      // Set training_mode as graph input if any node that needs eval feed is found
+      defs.AddGraphInputs({training_mode_string_});
+      break;
     }
   }
+  
   ORT_RETURN_IF_ERROR(GraphAugmenter::AugmentGraph(graph, defs));
   return DoPostLoadProcessing(*model_);
 }

--- a/orttraining/orttraining/core/session/training_session.h
+++ b/orttraining/orttraining/core/session/training_session.h
@@ -294,11 +294,16 @@ class TrainingSession : public InferenceSession {
    * @return The list of feed names.
    */
   std::unordered_set<std::string> GetDropoutEvalFeeds() const { return dropout_eval_feeds_; }
+
   /** Override Run function in InferenceSession to inject some training-specific logics **/
   using InferenceSession::Run; // For overload resolution.
-  common::Status Run(const RunOptions& run_options, IOBinding& io_binding) override;
 
   common::Status Run(IOBinding& io_binding) override;
+
+  common::Status Run(const RunOptions& run_options, IOBinding& io_binding) override;
+
+  common::Status Run(const NameMLValMap& feeds, const std::vector<std::string>& output_names,
+                     std::vector<OrtValue>* p_fetches) override;
 
  private:
   /** Configures the loss function.
@@ -436,7 +441,7 @@ class TrainingSession : public InferenceSession {
 
   std::unordered_set<std::string> GetStateTensorNames() const;
 
-  common::Status SetDropoutEvalFeedNames();
+  common::Status SetEvalFeedNames();
 
   NameMLValMap GetWeights() const;
 
@@ -464,6 +469,7 @@ class TrainingSession : public InferenceSession {
   std::unordered_set<std::string> dropout_eval_feeds_;
   OptimizerGraphConfig opt_graph_config_;
   std::unordered_map<std::string, OptimizerNodeConfig> opt_configs_;
+  const std::string training_mode_string_ = "training_mode";
 };
 }  // namespace training
 }  // namespace onnxruntime

--- a/orttraining/orttraining/models/runner/training_runner.cc
+++ b/orttraining/orttraining/models/runner/training_runner.cc
@@ -659,8 +659,10 @@ void TrainingRunner::RunWithUpdate(VectorString& feed_names,
 #else
     ORT_UNUSED_PARAMETER(step);
 #endif
+    RunOptions run_options;
+    run_options.training_mode = true;
     status = session_.Run(
-      RunOptions(),
+      run_options,
       pipeline_worker_pool_.worker_states[worker_id].feed_names,
       pipeline_worker_pool_.worker_states[worker_id].feeds,
       pipeline_worker_pool_.worker_states[worker_id].fetch_names,
@@ -747,6 +749,7 @@ void TrainingRunner::RunWithoutUpdate(VectorString& feed_names,
 #endif
     RunOptions run_options;
     run_options.only_execute_path_to_fetches = true;
+    run_options.training_mode = true;
     auto status = session_.Run(
       run_options,
       pipeline_worker_pool_.worker_states[worker_id].feed_names,
@@ -1090,7 +1093,7 @@ Status TrainingRunner::EndTraining(IDataLoader* data_loader) {
   return Status::OK();
 }
 
-Status TrainingRunner::Evaluate(InferenceSession& session, IDataLoader& data_loader) {
+Status TrainingRunner::Evaluate(TrainingSession& session, IDataLoader& data_loader) {
   if (params_.skip_evaluation) {
     printf("Skipping evaluation...\n");
     return Status::OK();
@@ -1134,6 +1137,27 @@ Status TrainingRunner::Evaluate(InferenceSession& session, IDataLoader& data_loa
                              batch_idx,
                              feed_names,
                              feeds);
+    if (!session.GetDropoutEvalFeeds().empty()) {
+      float eval_ratio = 0.0f;
+      for (auto& dropout_ratio : session.GetDropoutEvalFeeds()) {
+        feed_names.push_back(dropout_ratio);
+        OrtValue ratio_val;
+        TrainingUtil::CreateCpuMLScalar(eval_ratio, &ratio_val, input_allocator_);
+        feeds.push_back(ratio_val);
+      }
+    }
+    const std::string training_mode_string = "training_mode";
+    auto input_list = session.GetOverridableInitializers().second;
+    for (auto input : *input_list) {
+      if(input->Name().compare(training_mode_string) == 0) {
+        feed_names.push_back("training_mode");
+        OrtValue mode_val;
+        // training_mode is by default false
+        TrainingUtil::CreateCpuMLScalar(run_options.training_mode, &mode_val, input_allocator_);
+        feeds.push_back(mode_val);
+        break;
+      }
+    }
 
     PrepareFetchNamesAndFetches(EvaluateStep,
                                 fetch_names,

--- a/orttraining/orttraining/models/runner/training_runner.h
+++ b/orttraining/orttraining/models/runner/training_runner.h
@@ -206,7 +206,7 @@ class TrainingRunner {
                         size_t& gradient_accumulation_step_count);
   Status TrainingLoop(IDataLoader& training_data_loader, IDataLoader* test_data_loader,
     const MapStringToString& mapped_dimensions);
-  Status Evaluate(InferenceSession& session, IDataLoader& data_loader);
+  Status Evaluate(TrainingSession& session, IDataLoader& data_loader);
 
   Status SaveCheckpoint(const PathString& checkpoint_path);
   Status LoadCheckpoint(const PathString& checkpoint_path);

--- a/orttraining/orttraining/test/graph/gradient_graph_builder_test.cc
+++ b/orttraining/orttraining/test/graph/gradient_graph_builder_test.cc
@@ -97,6 +97,7 @@ static std::unique_ptr<TrainingSession> RunTrainingSessionWithChecks(
   RunOptions run_options;
   run_options.run_log_verbosity_level = so.session_log_verbosity_level;
   run_options.run_tag = so.session_logid;
+  run_options.training_mode = true;
 
   // Create dummy feeds
   std::vector<int64_t> image_dims = {1, 784};
@@ -317,6 +318,7 @@ static void RunBertTrainingWithChecks(
   RunOptions run_options;
   run_options.run_log_verbosity_level = so.session_log_verbosity_level;
   run_options.run_tag = so.session_logid;
+  run_options.training_mode = true;
 
   // Creating feeds
   int batch_size = 13;
@@ -1375,6 +1377,7 @@ TEST(GradientGraphBuilderTest, TrainingSession_WithPipeline) {
 
     sub_sess.run_options.run_log_verbosity_level = sub_sess.so.session_log_verbosity_level;
     sub_sess.run_options.run_tag = sub_sess.so.session_logid;
+    sub_sess.run_options.training_mode = true;
 
     sub_sess.sess = onnxruntime::make_unique<TrainingSession>(sub_sess.so, *env);
     ASSERT_STATUS_OK(sub_sess.sess->Load(sub_model_files[sub_id]));

--- a/orttraining/orttraining/test/optimizer/graph_transform_test.cc
+++ b/orttraining/orttraining/test/optimizer/graph_transform_test.cc
@@ -386,6 +386,7 @@ TEST_F(GraphTransformationTests, MegatronMLPPartitionCorrectnessTest) {
 
     // Now run
     RunOptions run_options;
+    run_options.training_mode = true;
     st = session_object.Run(run_options, feeds, output_names, &expected_ort_values);
 
     EXPECT_TRUE(st.IsOK());
@@ -417,6 +418,7 @@ TEST_F(GraphTransformationTests, MegatronMLPPartitionCorrectnessTest) {
 
     // Now run
     RunOptions run_options;
+    run_options.training_mode = true;
     st = session_object.Run(run_options, feeds, output_names, &actual_ort_values);
 
     EXPECT_TRUE(st.IsOK());
@@ -513,6 +515,7 @@ TEST_F(GraphTransformationTests, MegatronSelfAttentionPartitionCorrectnessTest) 
 
     // Now run
     RunOptions run_options;
+    run_options.training_mode = true;
     st = session_object.Run(run_options, feeds, output_names, &expected_ort_values);
     EXPECT_TRUE(st.IsOK());
   }
@@ -547,6 +550,7 @@ TEST_F(GraphTransformationTests, MegatronSelfAttentionPartitionCorrectnessTest) 
 
     // Now run
     RunOptions run_options;
+    run_options.training_mode = true;
     st = session_object.Run(run_options, feeds, output_names, &actual_ort_values);
     EXPECT_TRUE(st.IsOK());
   }

--- a/orttraining/orttraining/test/training_ops/function_op_test_utils.cc
+++ b/orttraining/orttraining/test/training_ops/function_op_test_utils.cc
@@ -52,6 +52,7 @@ TwoDArray OpFunctionTester::RunFunctionBodyGraphOnCPU() {
   RunOptions run_options;
   run_options.run_tag = op_;
   run_options.run_log_verbosity_level = 1;
+  run_options.training_mode = true;
 
   std::vector<MLValue> cpu_fetches;
   status = cpu_session_object.Run(run_options, feeds, output_names, &cpu_fetches);


### PR DESCRIPTION
opset 12 introduced a new training_mode flag for some nodes. We need to override it when doing evaluation. Legacy dropout ratios are still overridden if opset is < 12. 
I'm testing this on transformer models with opset 12.