### PR TITLE
fix build error because of api change

### DIFF
--- a/onnxruntime/core/providers/migraphx/hip_allocator.cc
+++ b/onnxruntime/core/providers/migraphx/hip_allocator.cc
@@ -40,10 +40,6 @@ void HIPAllocator::Free(void* p) {
   hipFree(p);  // do not throw error since it's OK for hipFree to fail during shutdown
 }
 
-const OrtMemoryInfo& HIPAllocator::Info() const {
-  return info_;
-}
-
 FencePtr HIPAllocator::CreateFence(const SessionState* session_state) {
  return std::make_shared<HIPFence>(GetGPUDataTransfer(session_state));
 }
@@ -58,10 +54,6 @@ void* HIPPinnedAllocator::Alloc(size_t size) {
 
 void HIPPinnedAllocator::Free(void* p) {
   hipHostFree(p);
-}
-
-const OrtMemoryInfo& HIPPinnedAllocator::Info() const {
-  return info_;
 }
 
 FencePtr HIPPinnedAllocator::CreateFence(const SessionState* session_state) {

--- a/onnxruntime/core/providers/migraphx/hip_allocator.h
+++ b/onnxruntime/core/providers/migraphx/hip_allocator.h
@@ -9,30 +9,32 @@ namespace onnxruntime {
 
 class HIPAllocator : public IDeviceAllocator {
  public:
-  HIPAllocator(int device_id, const char* name) : info_(name, OrtAllocatorType::OrtDeviceAllocator, OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, device_id), device_id, OrtMemTypeDefault) {}
+  HIPAllocator(int device_id, const char* name)
+    : IDeviceAllocator(
+        OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
+                      OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, device_id),
+                      device_id, OrtMemTypeDefault)) {}
+
   virtual void* Alloc(size_t size) override;
   virtual void Free(void* p) override;
-  virtual const OrtMemoryInfo& Info() const override;
   virtual FencePtr CreateFence(const SessionState* session_state) override;
 
  private:
   void CheckDevice() const;
-
- private:
-  const OrtMemoryInfo info_;
 };
 
 //TODO: add a default constructor
 class HIPPinnedAllocator : public IDeviceAllocator {
  public:
-  HIPPinnedAllocator(int device_id, const char* name) : info_(name, OrtAllocatorType::OrtDeviceAllocator, OrtDevice(OrtDevice::CPU, OrtDevice::MemType::HIP_PINNED, device_id), device_id, OrtMemTypeCPUOutput) {}
+  HIPPinnedAllocator(int device_id, const char* name)
+    : IDeviceAllocator(
+          OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
+                        OrtDevice(OrtDevice::CPU, OrtDevice::MemType::HIP_PINNED, device_id),
+                        device_id, OrtMemTypeCPUOutput)) {}
+
   virtual void* Alloc(size_t size) override;
   virtual void Free(void* p) override;
-  virtual const OrtMemoryInfo& Info() const override;
   virtual FencePtr CreateFence(const SessionState* session_state) override;
-
- private:
-  const OrtMemoryInfo info_;
 };
 
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**: Describe your changes.
Fixed a build error related to memory allocator

**Motivation and Context**
- Why is this change required? What problem does it solve?
The is a previous PR that changed the base class IDeviceAllocator, but the PR did not make changes for the HIPAllocator, so caused a build error. Need a fix to avoid build error.

- If it fixes an open issue, please link to the issue here.
