### PR TITLE
Update function body initialization for ONNX functions

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -779,7 +779,10 @@ class Graph {
   @param node Node with Node::Type of Node::Type::Fused
   @returns Status indicating success or providing an error message.
   */
-  Status InlineFunction(Node& node);
+  Status InlineFunction(Node& node);  
+
+  /** Initialize function body for the given node */
+  void InitFunctionBodyForNode(Node& node);
 
   /** Mark a NodeArg name as coming from the outer scope when programmatically constructing a Graph that will
   be used as a GraphProto attribute in another Node..

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -101,8 +101,9 @@ class Node {
   /** Gets the Node's Node::Type. */
   Node::Type NodeType() const noexcept;
 
-  /** Gets the function body if the #NodeType is fused, or nullptr if not. */
-  const Function* GetFunctionBody() const noexcept;
+  /** Gets the function body if the #NodeType is fused, or nullptr if not. 
+  @remarks Initialization of function body is deferred till the first time it is used. */
+  const Function* GetFunctionBody() noexcept;
 
   /** Gets the node description. */
   const std::string& Description() const noexcept;
@@ -779,7 +780,7 @@ class Graph {
   @param node Node with Node::Type of Node::Type::Fused
   @returns Status indicating success or providing an error message.
   */
-  Status InlineFunction(Node& node);  
+  Status InlineFunction(Node& node); 
 
   /** Initialize function body for the given node */
   void InitFunctionBodyForNode(Node& node);

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -101,9 +101,22 @@ class Node {
   /** Gets the Node's Node::Type. */
   Node::Type NodeType() const noexcept;
 
-  /** Gets the function body if the #NodeType is fused, or nullptr if not. 
-  @remarks Initialization of function body is deferred till the first time it is used. */
-  const Function* GetFunctionBody() noexcept;
+  /** 
+  Gets the function body if applicable otherwise nullptr
+  @param try_init_func_body If not already intialized, initialize the function body
+  (only applicable to operators which are defined as function in ONNX spec).
+  Function body can be initialized in 2 cases : 
+  1. For nodes of type "Fused" 
+  2. For nodes which are defined as functions in ONNX spec (example: DynamicQuantizeLinear)
+  For all other cases this will always return nullptr.
+  Nodes of type "Fused" are created during partitioning and the function body 
+  initialization for such nodes also happens during node creation. Therefore, 
+  initialization of function body will happen via this method only in case 2 mentioned above.
+  */ 
+  const Function* GetFunctionBody(bool try_int_func_body = true) noexcept;
+
+  /** Gets the function body if applicable otherwise nullptr. */
+  const Function* GetFunctionBody() const noexcept;
 
   /** Gets the node description. */
   const std::string& Description() const noexcept;

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -193,22 +193,23 @@ Status GraphPartitioner::Partition(Graph& graph, bool export_dll, FuncManager& f
   std::vector<Node*> nodes_need_inline;
   for (auto& node : graph.Nodes()) {
     if (node.GetExecutionProviderType().empty()) {
+      graph.InitFunctionBodyForNode(node);
       auto node_func = node.GetFunctionBody();
       if (nullptr == node_func) {
         continue;
       }
-      nodes_need_inline.push_back(&node);
+      nodes_need_inline.push_back(&node);      
     }
-  }
+  }  
+
   for (auto* node : nodes_need_inline) {
     // If the node has a functionbody with no kernel and cannot be inlined
-    // it is a invalid function
+    // it is an invalid function
     ORT_RETURN_IF_ERROR(graph.InlineFunction(*node));
   }
 
-  // Resolve and rerun graph partition
+  // Rerun graph partition
   if (!nodes_need_inline.empty()) {
-    ORT_RETURN_IF_ERROR(graph.Resolve());
     ORT_RETURN_IF_ERROR(Partition(graph, export_dll, func_mgr));
   }
 

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -208,8 +208,9 @@ Status GraphPartitioner::Partition(Graph& graph, bool export_dll, FuncManager& f
     ORT_RETURN_IF_ERROR(graph.InlineFunction(*node));
   }
 
-  // Rerun graph partition
+  // Resolve and rerun graph partition
   if (!nodes_need_inline.empty()) {
+    ORT_RETURN_IF_ERROR(graph.Resolve());
     ORT_RETURN_IF_ERROR(Partition(graph, export_dll, func_mgr));
   }
 

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -193,7 +193,6 @@ Status GraphPartitioner::Partition(Graph& graph, bool export_dll, FuncManager& f
   std::vector<Node*> nodes_need_inline;
   for (auto& node : graph.Nodes()) {
     if (node.GetExecutionProviderType().empty()) {
-      graph.InitFunctionBodyForNode(node);
       auto node_func = node.GetFunctionBody();
       if (nullptr == node_func) {
         continue;

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2091,10 +2091,6 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
 }
 
 void Graph::InitFunctionBodyForNode(Node& node) {
-  if (node.GetFunctionBody() != nullptr) {
-      return;
-  }
-
   if (node.op_ && (node.op_->HasFunction() || node.op_->HasContextDependentFunction())) {
     onnx::FunctionProto onnx_function_proto;
     if (node.op_->HasContextDependentFunction()) {

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -439,7 +439,7 @@ const Function* Node::GetFunctionBody() noexcept {
   }
 
   // Initialize function body
-  graph_->InitFunctionBodyForNode(*this);
+  graph_->InitFunctionBodyForNode(*(const_cast<onnxruntime::Node*>(this)));
 
   return func_body_;
 }
@@ -2091,8 +2091,12 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
 }
 
 void Graph::InitFunctionBodyForNode(Node& node) {
+  if (node.GetFunctionBody() != nullptr) {
+      return;
+  }
+
   if (node.op_ && (node.op_->HasFunction() || node.op_->HasContextDependentFunction())) {
-    onnx::FunctionProto onnx_function_proto;    
+    onnx::FunctionProto onnx_function_proto;
     if (node.op_->HasContextDependentFunction()) {
       NodeProto node_proto;
       node.ToProto(node_proto);

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -433,14 +433,20 @@ void Node::SetNodeType(Node::Type node_type) noexcept {
   node_type_ = node_type;
 }
 
-const Function* Node::GetFunctionBody() noexcept {
+const Function* Node::GetFunctionBody(bool try_init_func_body) noexcept {
   if (nullptr != func_body_) {
     return func_body_;
   }
 
   // Initialize function body
-  graph_->InitFunctionBodyForNode(*(const_cast<onnxruntime::Node*>(this)));
+  if (try_init_func_body) {
+    graph_->InitFunctionBodyForNode(*this);
+  }
 
+  return func_body_;
+}
+
+const Function* Node::GetFunctionBody() const noexcept {
   return func_body_;
 }
 

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -178,8 +178,8 @@ bool NodeArg::HasTensorOrScalarShape() const {
   const auto type_case = type->value_case();
   switch (type_case) {
     case TypeProto::kTensorType:
-    case TypeProto::kSparseTensorType: 
-      // Standard tensor has a valid shape field while 
+    case TypeProto::kSparseTensorType:
+      // Standard tensor has a valid shape field while
       // scalar's shape is empty. Thus, we don't need to
       // check shape here.
       return true;
@@ -2021,7 +2021,7 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
                                                                                            *model_function_proto,
                                                                                            logger_));
       node.SetFunctionBody(*function_container_.back());
-    }
+    }    
 
     if (!node.Op()) {
       try {
@@ -2035,22 +2035,6 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
 
       if (node.op_ && node.op_->Deprecated()) {
         node.op_ = nullptr;
-      }
-
-      if (node.op_ && (node.op_->HasFunction() || node.op_->HasContextDependentFunction())) {
-        onnx::FunctionProto onnx_function_proto;
-        onnx::FunctionBodyBuildContextImpl function_body_ctx(node_proto);
-        if (node.op_->HasContextDependentFunction()) {
-          node.op_->BuildContextDependentFunction(function_body_ctx, onnx_function_proto);
-        } else {
-          onnx_function_proto = *(node.op_->GetFunction());
-        }
-
-        auto func_ptr = onnxruntime::make_unique<onnxruntime::FunctionImpl>(*this, node.Index(), onnx_function_proto,
-                                                                            logger_);
-
-        function_container_.emplace_back(std::move(func_ptr));
-        node.SetFunctionBody(*function_container_.back());
       }
 
       if (!node.op_) {
@@ -2098,6 +2082,30 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
   }
 
   return Status::OK();
+}
+
+void Graph::InitFunctionBodyForNode(Node& node) {
+  if (nullptr != node.GetFunctionBody()) {
+    return;
+  }
+  
+  if (node.op_ && (node.op_->HasFunction() || node.op_->HasContextDependentFunction())) {
+    onnx::FunctionProto onnx_function_proto;    
+    if (node.op_->HasContextDependentFunction()) {
+      NodeProto node_proto;
+      node.ToProto(node_proto);
+      onnx::FunctionBodyBuildContextImpl function_body_ctx(node_proto);
+      node.op_->BuildContextDependentFunction(function_body_ctx, onnx_function_proto);
+    } else {
+      onnx_function_proto = *(node.op_->GetFunction());
+    }
+
+    auto func_ptr = onnxruntime::make_unique<onnxruntime::FunctionImpl>(*this, node.Index(), onnx_function_proto,
+                                                                        logger_);
+
+    function_container_.emplace_back(std::move(func_ptr));
+    node.SetFunctionBody(*function_container_.back());
+  }
 }
 
 void Graph::FindAllSubgraphs(std::vector<Graph*>& subgraphs) {
@@ -2398,8 +2406,8 @@ const std::vector<const NodeArg*>& Graph::GetValueInfo() const noexcept {
   return value_info_;
 }
 
-void Graph::AddValueInfo(const NodeArg* new_value_info){
-  for(const auto* info : value_info_){
+void Graph::AddValueInfo(const NodeArg* new_value_info) {
+  for (const auto* info : value_info_) {
     ORT_ENFORCE(info->Name() != new_value_info->Name(), "Error: trying to add an existing value info.");
   }
   value_info_.push_back(new_value_info);

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -433,7 +433,14 @@ void Node::SetNodeType(Node::Type node_type) noexcept {
   node_type_ = node_type;
 }
 
-const Function* Node::GetFunctionBody() const noexcept {
+const Function* Node::GetFunctionBody() noexcept {
+  if (nullptr != func_body_) {
+    return func_body_;
+  }
+
+  // Initialize function body
+  graph_->InitFunctionBodyForNode(*this);
+
   return func_body_;
 }
 
@@ -1314,7 +1321,6 @@ void Graph::ReverseDFSFrom(const std::vector<const Node*>& from,
                            const std::function<void(const Node*)>& enter,
                            const std::function<void(const Node*)>& leave,
                            const std::function<bool(const Node*, const Node*)>& comp) const {
-
   ReverseDFSFrom(from, enter, leave, comp, {});
 }
 
@@ -2021,7 +2027,7 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
                                                                                            *model_function_proto,
                                                                                            logger_));
       node.SetFunctionBody(*function_container_.back());
-    }    
+    }
 
     if (!node.Op()) {
       try {
@@ -2085,10 +2091,6 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
 }
 
 void Graph::InitFunctionBodyForNode(Node& node) {
-  if (nullptr != node.GetFunctionBody()) {
-    return;
-  }
-  
   if (node.op_ && (node.op_->HasFunction() || node.op_->HasContextDependentFunction())) {
     onnx::FunctionProto onnx_function_proto;    
     if (node.op_->HasContextDependentFunction()) {

--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -159,7 +159,7 @@ Status ConstantFolding::ApplyImpl(Graph& graph, bool& modified, int graph_level,
 
           ONNX_NAMESPACE::TensorShapeProto result_shape;
           for (auto& dim : out_tensor.Shape().GetDims()) {
-             result_shape.add_dim()->set_dim_value(dim);
+            result_shape.add_dim()->set_dim_value(dim);
           }
 
           constant_arg_out->SetShape(result_shape);

--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -159,7 +159,7 @@ Status ConstantFolding::ApplyImpl(Graph& graph, bool& modified, int graph_level,
 
           ONNX_NAMESPACE::TensorShapeProto result_shape;
           for (auto& dim : out_tensor.Shape().GetDims()) {
-              result_shape.add_dim()->set_dim_value(dim);
+             result_shape.add_dim()->set_dim_value(dim);
           }
 
           constant_arg_out->SetShape(result_shape);

--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -147,25 +147,20 @@ Status ConstantFolding::ApplyImpl(Graph& graph, bool& modified, int graph_level,
           converted_to_constant = false;
           break;
         }
-      }
 
-      if (converted_to_constant) {
-        for (size_t fetch_idx = 0; fetch_idx < fetches.size(); ++fetch_idx) {
-          OrtValue& ort_value = fetches[fetch_idx];
-          // Build the TensorProto that corresponds to the computed OrtValue and add it as initializer to the graph.
-          auto* constant_arg_out = node->MutableOutputDefs()[fetch_idx];
-          const Tensor& out_tensor = ort_value.Get<Tensor>();
-          ONNX_NAMESPACE::TensorProto out_tensorproto = utils::TensorToTensorProto(out_tensor, constant_arg_out->Name());
+        // Build the TensorProto that corresponds to the computed OrtValue and add it as initializer to the graph.
+        auto* constant_arg_out = node->MutableOutputDefs()[fetch_idx];
+        const Tensor& out_tensor = ort_value.Get<Tensor>();
+        ONNX_NAMESPACE::TensorProto out_tensorproto = utils::TensorToTensorProto(out_tensor, constant_arg_out->Name());
 
-          ONNX_NAMESPACE::TensorShapeProto result_shape;
-          for (auto& dim : out_tensor.Shape().GetDims()) {
-            result_shape.add_dim()->set_dim_value(dim);
-          }
-
-          constant_arg_out->SetShape(result_shape);
-          graph.AddInitializedTensor(out_tensorproto);
+        ONNX_NAMESPACE::TensorShapeProto result_shape;
+        for (auto& dim : out_tensor.Shape().GetDims()) {
+          result_shape.add_dim()->set_dim_value(dim);
         }
-      }
+
+        constant_arg_out->SetShape(result_shape);
+        graph.AddInitializedTensor(out_tensorproto);
+      }      
     }
 
     if (converted_to_constant) {

--- a/orttraining/orttraining/core/graph/mixed_precision_transformer.cc
+++ b/orttraining/orttraining/core/graph/mixed_precision_transformer.cc
@@ -376,7 +376,14 @@ Status TransformGraphForMixedPrecision(Graph& graph,
                                        const std::unordered_set<std::string>& weights_to_train,
                                        bool use_fp16_initializer,
                                        std::unordered_map<std::string, NodeArg*>& fp32_weight_name_to_fp16_node_arg) {
-  // Stag 1: Convert whole graph including forward and backward to FP16
+  // Stage 1: Convert whole graph including forward and backward to FP16
+  // Initialize function body for all function nodes
+  // This is required to make sure after converting inputs\weights to FP16
+  // the new NodeArg updates are correctly propagated to the function body nodes as well.
+  for (auto& node : graph.Nodes()) {
+    graph.InitFunctionBodyForNode(node);
+  }
+
   // Insert Cast node to convert inputs from FP32 to FP16
   for (const NodeArg* input : graph.GetInputs()) {
     if (input->TypeAsProto()->tensor_type().elem_type() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {


### PR DESCRIPTION
**Description**: Today we initialize the function body during graph load regardless whether ort contains a kernel for this function. Therefore in cases when a kernel is available in ort this initialization goes to waste. This PR moves function initialization during partitioning instead of graph load. This way function body is only initialized if a kernel is not available for the function. 

**Motivation and Context**
- One of the models I am testing with contains a lot of DynamicQuantizeLinear functions after quantization. By making this change I see around 4MB reduction in mem consumption.

