### PR TITLE
Fix build error when USE_NCCL is defined.

### DIFF
--- a/orttraining/orttraining/test/graph/optimizer_graph_builder_test.cc
+++ b/orttraining/orttraining/test/graph/optimizer_graph_builder_test.cc
@@ -412,7 +412,7 @@ TEST_F(OptimizerGraphBuilderTest, ZeRO_NoGradientAccumulation_NoMixedPrecision) 
   OptimizerGraphConfig config;
   config.data_parallel_group_size = 4;
   config.use_nccl = true;
-  config.deepspeed_config = ZeROConfig{0};
+  config.deepspeed_zero = ZeROConfig{0};
   config.gradient_accumulation_steps = 1;
   config.use_mixed_precision = false;
   TestZeROOptimizerGraphBuilder(config, graph_);
@@ -422,7 +422,7 @@ TEST_F(OptimizerGraphBuilderTest, ZeRO_WithGradientAccumulation_NoMixedPrecision
   OptimizerGraphConfig config;
   config.data_parallel_group_size = 4;
   config.use_nccl = true;
-  config.deepspeed_config = ZeROConfig{0};
+  config.deepspeed_zero = ZeROConfig{0};
   config.gradient_accumulation_steps = 10;
   config.use_mixed_precision = false;
   TestZeROOptimizerGraphBuilder(config, graph_);
@@ -432,7 +432,7 @@ TEST_F(OptimizerGraphBuilderTest, ZeRO_NoGradientAccumulation_WithMixedPrecision
   OptimizerGraphConfig config;
   config.data_parallel_group_size = 4;
   config.use_nccl = true;
-  config.deepspeed_config = ZeROConfig{0};
+  config.deepspeed_zero = ZeROConfig{0};
   config.gradient_accumulation_steps = 1;
   config.use_mixed_precision = true;
   config.loss_scale_input_name = k_loss_scaling_factor_name;
@@ -443,7 +443,7 @@ TEST_F(OptimizerGraphBuilderTest, ZeRO_WithGradientAccumulation_WithMixedPrecisi
   OptimizerGraphConfig config;
   config.data_parallel_group_size = 4;
   config.use_nccl = true;
-  config.deepspeed_config = ZeROConfig{0};
+  config.deepspeed_zero = ZeROConfig{0};
   config.gradient_accumulation_steps = 10;
   config.use_mixed_precision = true;
   config.loss_scale_input_name = k_loss_scaling_factor_name;


### PR DESCRIPTION
**Description**
Fix build errors that happen when USE_NCCL is defined, e.g.:
```
orttraining/orttraining/test/graph/optimizer_graph_builder_test.cc:415:10: error: ‘struct onnxruntime::training::OptimizerGraphConfig’ has no member named ‘deepspeed_config’
```

**Motivation and Context**
Fixes the build when USE_NCCL is defined.
