### PR TITLE
[OpenVINO] Upgrade OpenVINO docker base to Ubuntu 18.04

### DIFF
--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 #--------------------------------------------------------------------------
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ARG DEVICE=CPU_FP32
 ARG ONNXRUNTIME_REPO=https://github.com/microsoft/onnxruntime
@@ -30,7 +30,7 @@ ENV LANG en_US.UTF-8
 
 RUN apt update && \
     apt -y install git sudo wget locales \
-    zip x11-apps lsb-core cpio libboost-python-dev libpng-dev zlib1g-dev libnuma1 ocl-icd-libopencl1 clinfo libboost-filesystem1.58.0 libboost-thread1.58.0 protobuf-compiler libprotoc-dev libusb-1.0-0-dev autoconf automake libtool libudev-dev libjson-c-dev && \
+    zip x11-apps lsb-core cpio libboost-python-dev libpng-dev zlib1g-dev libnuma1 ocl-icd-libopencl1 clinfo libboost-filesystem1.65-dev libboost-thread1.65-dev protobuf-compiler libprotoc-dev libusb-1.0-0-dev autoconf automake libtool libudev-dev libjson-c-dev && \
     cd ${MY_ROOT} && \
     git clone --recursive -b $ONNXRUNTIME_BRANCH $ONNXRUNTIME_REPO onnxruntime && \
     cp onnxruntime/docs/Privacy.md /code/Privacy.md && \

--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -48,7 +48,7 @@ RUN apt update && \
     ./install.sh -s silent.cfg && \
     cd - && \
     rm -rf l_openvino_toolkit* && \
-    cd /opt/intel/openvino/install_dependencies && ./_install_all_dependencies.sh && dpkg -i *.deb && \
+    cd /opt/intel/openvino/install_dependencies && ./install_openvino_dependencies.sh && ./install_NEO_OCL_driver.sh && dpkg -i *.deb && \
     cd ${MY_ROOT} && \
     locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8 && \
     cd ${MY_ROOT} && \

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -97,7 +97,7 @@ Use `docker pull` with any of the images and tags below to pull an image and try
 ## OpenVINO
 *Public Preview*
 
-**Ubuntu 16.04, Python Bindings**
+**Ubuntu 18.04, Python Bindings**
 
 1. Build the onnxruntime image for one of the accelerators supported below.
 


### PR DESCRIPTION
**Description**: Change base image in Dockerfile to 18.04 along with necessary lib dependency upgrades. Also upgrade dependency installer script to OpenVINO 2020.3.

**Motivation and Context**
- Ubuntu 18.04 is the recommended base for 18.04 due to package upgrades compared to 16.04. Increasing customer request for 18.04.
