### PR TITLE
fix output shape calculation for matmul

### DIFF
--- a/onnxruntime/core/providers/cpu/math/matmul_helper.h
+++ b/onnxruntime/core/providers/cpu/math/matmul_helper.h
@@ -29,7 +29,7 @@ class MatMulComputeHelper {
     // A: [M1, M2, ... K], B: [N, K]^T
     // A: [M1, M2, ... K], B: [1, ..., 1, K, N]
     // A: [M1, M2, ... K], B: [1, ..., 1, N, K]^T
-    if (!transa && left_num_dims >= 2 && right_num_dims >= 2 &&
+    if (!transa && left_num_dims >= 2 && right_num_dims >= 2 && left_num_dims >= right_num_dims &&
         right_shape.SizeToDimension(right_num_dims - 1) == right_shape[right_num_dims - 2]) {
       M_ = left_shape.SizeToDimension(left_num_dims - 1);
       K_ = left_shape[left_num_dims - 1];

--- a/onnxruntime/test/providers/cpu/math/matmul_test.cc
+++ b/onnxruntime/test/providers/cpu/math/matmul_test.cc
@@ -77,6 +77,13 @@ std::vector<MatMulTestData<T>> GenerateTestCases()
     {2, 2, 4},
     {20, 23, 26, 29, 56, 68, 80, 92, 92, 113, 134, 155, 128, 158, 188, 218}});
 
+  test_cases.push_back(
+    {"test 2D special 3",
+    {2, 6},
+    {1, 1, 6, 1},
+    {1, 1, 2, 1},
+    {55, 145}});
+
   return test_cases;
 }
 


### PR DESCRIPTION
**Description**: Fixing bug in special case handling for matrices for matmul operator.
The special case is applicable for following cases:
Special cases below for right_shape being 2D and left_shape > 2D by flattening left_shape to 2D
Note that padding 1s in front of the right_shape can be flattened too
A: [M1, M2, ... K], B: [K, N]
A: [M1, M2, ... K], B: [N, K]^T
A: [M1, M2, ... K], B: [1, ..., 1, K, N]
A: [M1, M2, ... K], B: [1, ..., 1, N, K]^T

However we also allow 
A: [M, K], B:[1, ..., 1, K, N]
This causes output dim to be squeezed to rank 2.
 
This PR adds check to not allow special handling for the above mentioned case.

**Motivation and Context**
- This a bug as the behavior deviates from ONNX spec.
