### PR TITLE
Add modern C++ standards for Ort::Value

### DIFF
--- a/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
@@ -26,14 +26,14 @@ struct Session : Ort::Session {
       : Ort::Session(env, model_data, model_data_length, options){};
 
   // overloaded Run() with sensible defaults
-  std::vector<Value> Run(const std::vector<std::string>& input_names,
-                         const std::vector<Value>& input_values,
+  std::vector<Ort::Value> Run(const std::vector<std::string>& input_names,
+                         const std::vector<Ort::Value>& input_values,
                          const std::vector<std::string>& output_names,
                          const RunOptions& run_options = RunOptions());
   void Run(const std::vector<std::string>& input_names,
-           const std::vector<Value>& input_values,
+           const std::vector<Ort::Value>& input_values,
            const std::vector<std::string>& output_names,
-           std::vector<Value>& output_values,
+           std::vector<Ort::Value>& output_values,
            const RunOptions& run_options = RunOptions());
 
   // convenience methods that simplify common lower-level API calls
@@ -45,6 +45,21 @@ struct Session : Ort::Session {
   std::vector<std::vector<int64_t> > GetInputShapes() const;
   std::vector<std::vector<int64_t> > GetOutputShapes() const;
   std::vector<std::vector<int64_t> > GetOverridableInitializerShapes() const;
+};
+
+struct Value : Ort::Value {
+  Value(OrtValue* p)
+    : Ort::Value(p) {};
+  Value(Value&&) = default;
+  Value& operator=(Value&&) = default;
+
+  template <typename T>
+  static Ort::Value CreateTensor(T* p_data, size_t p_data_element_count, const std::vector<int64_t>& shape);
+  static Ort::Value CreateTensor(void* p_data, size_t p_data_byte_count, const std::vector<int64_t>& shape, ONNXTensorElementDataType type);
+
+  template <typename T>
+  static Ort::Value CreateTensor(const std::vector<int64_t>& shape);
+  static Ort::Value CreateTensor(const std::vector<int64_t>& shape, ONNXTensorElementDataType type);
 };
 
 }  // namespace Ort::Experimental

--- a/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
@@ -51,6 +51,10 @@ struct Value : Ort::Value {
   Value(OrtValue* p)
       : Ort::Value(p){};
 
+  // a convenience function to improve tensor element access
+  template <typename Tp>
+  Tp At(const std::initializer_list<size_t>& location);
+
   template <typename T>
   static Value CreateTensor(T* p_data, size_t p_data_element_count, const std::vector<int64_t>& shape);
   static Value CreateTensor(void* p_data, size_t p_data_byte_count, const std::vector<int64_t>& shape, ONNXTensorElementDataType type);

--- a/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
@@ -6,6 +6,8 @@
 // This C++ API further simplifies usage and provides support for modern C++ syntax/features
 // at the cost of some overhead (i.e. using std::string over char *).
 //
+// Where applicable, default memory allocator options are used unless explicitly set.
+//
 // Experimental components are designed as drop-in replacements of the regular API, requiring
 // minimal code modifications to use.
 //

--- a/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
@@ -52,8 +52,8 @@ struct Value : Ort::Value {
       : Ort::Value(p){};
 
   // a convenience function to improve tensor element access
-  template <typename Tp>
-  Tp At(const std::initializer_list<size_t>& location);
+  template <typename T>
+  T At(const std::initializer_list<size_t>& location);
 
   template <typename T>
   static Value CreateTensor(T* p_data, size_t p_data_element_count, const std::vector<int64_t>& shape);

--- a/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
@@ -27,9 +27,9 @@ struct Session : Ort::Session {
 
   // overloaded Run() with sensible defaults
   std::vector<Ort::Value> Run(const std::vector<std::string>& input_names,
-                         const std::vector<Ort::Value>& input_values,
-                         const std::vector<std::string>& output_names,
-                         const RunOptions& run_options = RunOptions());
+                              const std::vector<Ort::Value>& input_values,
+                              const std::vector<std::string>& output_names,
+                              const RunOptions& run_options = RunOptions());
   void Run(const std::vector<std::string>& input_names,
            const std::vector<Ort::Value>& input_values,
            const std::vector<std::string>& output_names,
@@ -49,7 +49,7 @@ struct Session : Ort::Session {
 
 struct Value : Ort::Value {
   Value(OrtValue* p)
-    : Ort::Value(p) {};
+      : Ort::Value(p){};
 
   template <typename T>
   static Value CreateTensor(T* p_data, size_t p_data_element_count, const std::vector<int64_t>& shape);

--- a/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
@@ -50,16 +50,14 @@ struct Session : Ort::Session {
 struct Value : Ort::Value {
   Value(OrtValue* p)
     : Ort::Value(p) {};
-  Value(Value&&) = default;
-  Value& operator=(Value&&) = default;
 
   template <typename T>
-  static Ort::Value CreateTensor(T* p_data, size_t p_data_element_count, const std::vector<int64_t>& shape);
-  static Ort::Value CreateTensor(void* p_data, size_t p_data_byte_count, const std::vector<int64_t>& shape, ONNXTensorElementDataType type);
+  static Value CreateTensor(T* p_data, size_t p_data_element_count, const std::vector<int64_t>& shape);
+  static Value CreateTensor(void* p_data, size_t p_data_byte_count, const std::vector<int64_t>& shape, ONNXTensorElementDataType type);
 
   template <typename T>
-  static Ort::Value CreateTensor(const std::vector<int64_t>& shape);
-  static Ort::Value CreateTensor(const std::vector<int64_t>& shape, ONNXTensorElementDataType type);
+  static Value CreateTensor(const std::vector<int64_t>& shape);
+  static Value CreateTensor(const std::vector<int64_t>& shape, ONNXTensorElementDataType type);
 };
 
 }  // namespace Ort::Experimental

--- a/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
@@ -51,17 +51,13 @@ struct Value : Ort::Value {
   Value(OrtValue* p)
       : Ort::Value(p){};
 
-  // a convenience function to improve tensor element access
   template <typename T>
-  T At(const std::initializer_list<size_t>& location);
+  static Ort::Value CreateTensor(T* p_data, size_t p_data_element_count, const std::vector<int64_t>& shape);
+  static Ort::Value CreateTensor(void* p_data, size_t p_data_byte_count, const std::vector<int64_t>& shape, ONNXTensorElementDataType type);
 
   template <typename T>
-  static Value CreateTensor(T* p_data, size_t p_data_element_count, const std::vector<int64_t>& shape);
-  static Value CreateTensor(void* p_data, size_t p_data_byte_count, const std::vector<int64_t>& shape, ONNXTensorElementDataType type);
-
-  template <typename T>
-  static Value CreateTensor(const std::vector<int64_t>& shape);
-  static Value CreateTensor(const std::vector<int64_t>& shape, ONNXTensorElementDataType type);
+  static Ort::Value CreateTensor(const std::vector<int64_t>& shape);
+  static Ort::Value CreateTensor(const std::vector<int64_t>& shape, ONNXTensorElementDataType type);
 };
 
 }  // namespace Ort::Experimental

--- a/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
@@ -86,8 +86,8 @@ inline std::vector<std::vector<int64_t>> Session::GetOverridableInitializerShape
   return out;
 }
 
-template <typename Tp>
-Tp Value::At(const std::initializer_list<size_t>& location) {
+template <typename T>
+T Value::At(const std::initializer_list<size_t>& location) {
   std::vector<size_t> location_ = location;
   std::vector<int64_t> shape = this->GetTensorTypeAndShapeInfo().GetShape();
   size_t offset = 0;
@@ -96,7 +96,7 @@ Tp Value::At(const std::initializer_list<size_t>& location) {
     for (int j = i + 1; j <= shape.size(); j++) sum *= shape[j];
     offset += location_[i] * sum;
   }
-  Tp* data_ptr = this->GetTensorMutableData<Tp>();
+  T* data_ptr = this->GetTensorMutableData<T>();
   return data_ptr[offset];
 }
 

--- a/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
@@ -87,41 +87,23 @@ inline std::vector<std::vector<int64_t>> Session::GetOverridableInitializerShape
 }
 
 template <typename T>
-T Value::At(const std::initializer_list<size_t>& location) {
-  std::vector<size_t> location_ = location;
-  std::vector<int64_t> shape = this->GetTensorTypeAndShapeInfo().GetShape();
-  size_t offset = 0;
-  for (int i = 0; i < shape.size(); i++) {
-    int sum = 1;
-    for (int j = i + 1; j <= shape.size(); j++) sum *= shape[j];
-    offset += location_[i] * sum;
-  }
-  T* data_ptr = this->GetTensorMutableData<T>();
-  return data_ptr[offset];
-}
-
-template <typename T>
-inline Value Value::CreateTensor(T* p_data, size_t p_data_element_count, const std::vector<int64_t>& shape) {
+inline Ort::Value Value::CreateTensor(T* p_data, size_t p_data_element_count, const std::vector<int64_t>& shape) {
   return CreateTensor(p_data, p_data_element_count * sizeof(T), shape, TypeToTensorType<T>::type);
 }
 
-inline Value Value::CreateTensor(void* p_data, size_t p_data_byte_count, const std::vector<int64_t>& shape, ONNXTensorElementDataType type) {
+inline Ort::Value Value::CreateTensor(void* p_data, size_t p_data_byte_count, const std::vector<int64_t>& shape, ONNXTensorElementDataType type) {
   Ort::MemoryInfo info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-  OrtValue* out;
-  ThrowOnError(Global<void>::api_.CreateTensorWithDataAsOrtValue(info, p_data, p_data_byte_count, shape.data(), shape.size(), type, &out));
-  return Value{out};
+  return Ort::Value::CreateTensor(info, p_data, p_data_byte_count, shape.data(), shape.size(), type);
 }
 
 template <typename T>
-inline Value Value::CreateTensor(const std::vector<int64_t>& shape) {
+inline Ort::Value Value::CreateTensor(const std::vector<int64_t>& shape) {
   return CreateTensor(shape, TypeToTensorType<T>::type);
 }
 
-inline Value Value::CreateTensor(const std::vector<int64_t>& shape, ONNXTensorElementDataType type) {
+inline Ort::Value Value::CreateTensor(const std::vector<int64_t>& shape, ONNXTensorElementDataType type) {
   Ort::AllocatorWithDefaultOptions allocator;
-  OrtValue* out;
-  ThrowOnError(Global<void>::api_.CreateTensorAsOrtValue(allocator, shape.data(), shape.size(), type, &out));
-  return Value{out};
+  return Ort::Value::CreateTensor(allocator, shape.data(), shape.size(), type);
 }
 
 }  // namespace Ort::Experimental

--- a/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
@@ -86,6 +86,20 @@ inline std::vector<std::vector<int64_t>> Session::GetOverridableInitializerShape
   return out;
 }
 
+template <typename Tp>
+Tp Value::At(const std::initializer_list<size_t>& location) {
+  std::vector<size_t> location_ = location;
+  std::vector<int64_t> shape = this->GetTensorTypeAndShapeInfo().GetShape();
+  size_t offset = 0;
+  for (int i = 0; i < shape.size(); i++) {
+    int sum = 1;
+    for (int j = i + 1; j <= shape.size(); j++) sum *= shape[j];
+    offset += location_[i] * sum;
+  }
+  Tp* data_ptr = this->GetTensorMutableData<Tp>();
+  return data_ptr[offset];
+}
+
 template <typename T>
 inline Value Value::CreateTensor(T* p_data, size_t p_data_element_count, const std::vector<int64_t>& shape) {
   return CreateTensor(p_data, p_data_element_count * sizeof(T), shape, TypeToTensorType<T>::type);

--- a/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
@@ -7,17 +7,17 @@
 // the main C++ file with implementation details.
 namespace Ort::Experimental {
 
-inline std::vector<Value> Session::Run(const std::vector<std::string>& input_names, const std::vector<Value>& input_values,
+inline std::vector<Ort::Value> Session::Run(const std::vector<std::string>& input_names, const std::vector<Ort::Value>& input_values,
                                        const std::vector<std::string>& output_names, const RunOptions& run_options) {
   size_t output_names_count = GetOutputNames().size();
-  std::vector<Value> output_values;
+  std::vector<Ort::Value> output_values;
   for (size_t i = 0; i < output_names_count; i++) output_values.emplace_back(nullptr);
   Run(input_names, input_values, output_names, output_values, run_options);
   return output_values;
 }
 
-inline void Session::Run(const std::vector<std::string>& input_names, const std::vector<Value>& input_values,
-                         const std::vector<std::string>& output_names, std::vector<Value>& output_values, const RunOptions& run_options) {
+inline void Session::Run(const std::vector<std::string>& input_names, const std::vector<Ort::Value>& input_values,
+                         const std::vector<std::string>& output_names, std::vector<Ort::Value>& output_values, const RunOptions& run_options) {
   size_t input_names_count = input_names.size();
   size_t output_names_count = output_names.size();
   std::vector<const char*> input_names_(input_names_count, nullptr);
@@ -84,6 +84,27 @@ inline std::vector<std::vector<int64_t>> Session::GetOverridableInitializerShape
   std::vector<std::vector<int64_t>> out(init_count);
   for (size_t i = 0; i < init_count; i++) out[i] = GetOverridableInitializerTypeInfo(i).GetTensorTypeAndShapeInfo().GetShape();
   return out;
+}
+
+template <typename T>
+inline Ort::Value Value::CreateTensor(T* p_data, size_t p_data_element_count, const std::vector<int64_t>& shape) {
+  return CreateTensor(p_data, p_data_element_count * sizeof(T), shape, TypeToTensorType<T>::type);
+}
+
+inline Ort::Value Value::CreateTensor(void* p_data, size_t p_data_byte_count, const std::vector<int64_t>& shape, ONNXTensorElementDataType type) {
+  Ort::MemoryInfo info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+  Ort::Value out = Ort::Value::CreateTensor(info, p_data, p_data_byte_count, shape.data(), shape.size(), type);
+  return out;
+}
+
+template <typename T>
+inline Ort::Value Value::CreateTensor(const std::vector<int64_t>& shape) {
+  return CreateTensor(shape, TypeToTensorType<T>::type);
+}
+
+inline Ort::Value Value::CreateTensor(const std::vector<int64_t>& shape, ONNXTensorElementDataType type) {
+  Ort::AllocatorWithDefaultOptions allocator;
+  return Ort::Value::CreateTensor(allocator, shape.data(), shape.size(), type);
 }
 
 }  // namespace Ort::Experimental

--- a/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
@@ -87,24 +87,27 @@ inline std::vector<std::vector<int64_t>> Session::GetOverridableInitializerShape
 }
 
 template <typename T>
-inline Ort::Value Value::CreateTensor(T* p_data, size_t p_data_element_count, const std::vector<int64_t>& shape) {
+inline Value Value::CreateTensor(T* p_data, size_t p_data_element_count, const std::vector<int64_t>& shape) {
   return CreateTensor(p_data, p_data_element_count * sizeof(T), shape, TypeToTensorType<T>::type);
 }
 
-inline Ort::Value Value::CreateTensor(void* p_data, size_t p_data_byte_count, const std::vector<int64_t>& shape, ONNXTensorElementDataType type) {
+inline Value Value::CreateTensor(void* p_data, size_t p_data_byte_count, const std::vector<int64_t>& shape, ONNXTensorElementDataType type) {
   Ort::MemoryInfo info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-  Ort::Value out = Ort::Value::CreateTensor(info, p_data, p_data_byte_count, shape.data(), shape.size(), type);
-  return out;
+  OrtValue* out;
+  ThrowOnError(Global<void>::api_.CreateTensorWithDataAsOrtValue(info, p_data, p_data_byte_count, shape.data(), shape.size(), type, &out));
+  return Value{out};
 }
 
 template <typename T>
-inline Ort::Value Value::CreateTensor(const std::vector<int64_t>& shape) {
+inline Value Value::CreateTensor(const std::vector<int64_t>& shape) {
   return CreateTensor(shape, TypeToTensorType<T>::type);
 }
 
-inline Ort::Value Value::CreateTensor(const std::vector<int64_t>& shape, ONNXTensorElementDataType type) {
+inline Value Value::CreateTensor(const std::vector<int64_t>& shape, ONNXTensorElementDataType type) {
   Ort::AllocatorWithDefaultOptions allocator;
-  return Ort::Value::CreateTensor(allocator, shape.data(), shape.size(), type);
+  OrtValue* out;
+  ThrowOnError(Global<void>::api_.CreateTensorAsOrtValue(allocator, shape.data(), shape.size(), type, &out));
+  return Value{out};
 }
 
 }  // namespace Ort::Experimental

--- a/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
@@ -8,7 +8,7 @@
 namespace Ort::Experimental {
 
 inline std::vector<Ort::Value> Session::Run(const std::vector<std::string>& input_names, const std::vector<Ort::Value>& input_values,
-                                       const std::vector<std::string>& output_names, const RunOptions& run_options) {
+                                            const std::vector<std::string>& output_names, const RunOptions& run_options) {
   size_t output_names_count = GetOutputNames().size();
   std::vector<Ort::Value> output_values;
   for (size_t i = 0; i < output_names_count; i++) output_values.emplace_back(nullptr);


### PR DESCRIPTION
**Description**
This PR adds direct support for modern C++ standards to the `Ort::Value` class in the `Experimental` namespace. Specifically it simplifies the `CreateTensor()` functions. so that API callers can focus less on API internal details (like dealing with Ort::MemoryInfo).

@KevinHake Since you commented on my other [PR](https://github.com/microsoft/onnxruntime/pull/4217), I think you might find this contribution helpful too.

**Motivation and Context**
Discussion about this first started [here](https://github.com/microsoft/onnxruntime/issues/4094)

**Code Snippet**
Below is a very basic code snippet to demonstrate how to create a tensor with the new experimental API.

```cpp
#include <algorithm> // std::generate
#include <iostream>
#include <sstream>
#include <vector>
#include <experimental_onnxruntime_cxx_api.h>

// pretty prints a shape dimension vector
std::string print_shape(const std::vector<int64_t> v) {
  std::stringstream ss("");
  for (int i=0; i< v.size()-1; i++)
    ss << v[i] << "x";
  ss << v[v.size()-1];
  return ss.str();
}

int calculate_product(const std::vector<int64_t> v) {
  int total = 1;
  for (auto& i : v) total *= i;
  return total;
}

using namespace std;

int main(int argc, char **argv) {
  if (argc != 1) {
    cout << "Usage: ./onnx-api-example" << endl;
    return -1;
  }
  // Create an Ort tensor of random numbers
  std::vector<int64_t> input_shape = {3,4};
  int total_number_elements = calculate_product(input_shape);
  std::vector<float> input_tensor_values(total_number_elements);
  std::generate(input_tensor_values.begin(), input_tensor_values.end(), [&]{ return rand()%255; }); // generate random numbers in the range [0, 255]
  
  auto input_tensor = Ort::Experimental::Value::CreateTensor<float>(input_tensor_values.data(), input_tensor_values.size(), input_shape);
  cout << "tensor shape: " << print_shape( input_tensor.GetTensorTypeAndShapeInfo().GetShape() ) << endl;
}
```