### PR TITLE
Deprecate frontend layernorm postpass

### DIFF
--- a/orttraining/orttraining/test/python/onnxruntime_test_postprocess.py
+++ b/orttraining/orttraining/test/python/onnxruntime_test_postprocess.py
@@ -102,7 +102,7 @@ class Test_PostPasses(unittest.TestCase):
         count_layer_norm = self.count_nodes(onnx_model, "LayerNormalization")
         count_nodes = self.count_all_nodes(onnx_model)
 
-        assert count_layer_norm == 1
+        assert count_layer_norm == 0
         assert count_nodes == 3
 
     def test_expand(self):
@@ -199,7 +199,7 @@ class Test_PostPasses(unittest.TestCase):
     def _bert_helper(self, onnx_model):
         # count layer_norm
         count_layer_norm = self.count_nodes(onnx_model, "LayerNormalization")
-        assert count_layer_norm == 12
+        assert count_layer_norm == 0
 
         # get expand node and check output shape
         expand_nodes = self.find_nodes(onnx_model, "Expand")


### PR DESCRIPTION
**Description**: Deprecate frontend layernorm postpass. Also update the comment section to reflect more accurately on the subgraph transformed.

**Motivation and Context**
The transform of subgraph to layernorm is now handled in the backend.