### PR TITLE
Add GetStringTensorElement, GetStringTensorElementLength and FillStringTensorElement API

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -836,6 +836,29 @@ struct OrtApi {
    */
   ORT_API2_STATUS(ReleaseAvailableProviders, _In_ char **ptr,
                   _In_ int providers_length);
+
+  /**
+     * \param value A tensor created from OrtCreateTensor... function.
+     * \param len element length, not including the trailing '\0' chars.
+     * \param index index of string tensor element, length of element at index will be returned.
+     */
+  ORT_API2_STATUS(GetStringTensorElementLength, _In_ const OrtValue* value, _Out_ size_t* out, size_t index);
+
+  /**
+     * \param s string element contents. The string is NOT null-terminated.
+     * \param value A tensor created from OrtCreateTensor... function.
+     * \param s_len element length, get it from OrtGetStringTensorElementLength.
+     * \param index offset of element of tensor to return.
+     */
+  ORT_API2_STATUS(GetStringTensorElement, _In_ const OrtValue* value, _Out_writes_bytes_all_(s_len) void* s,
+                  size_t s_len, size_t index);
+
+  /**
+     * \param value A tensor created from OrtCreateTensor... function.
+     * \param s A null terminated.
+     * \param index index of string tensor element to fill 
+     */
+  ORT_API2_STATUS(FillStringTensorElement, _Inout_ OrtValue* value, _In_ const char* const* s, size_t index);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -858,7 +858,7 @@ struct OrtApi {
      * \param s A null terminated.
      * \param index index of string tensor element to fill 
      */
-  ORT_API2_STATUS(FillStringTensorElement, _Inout_ OrtValue* value, _In_ const char* const* s, size_t index);
+  ORT_API2_STATUS(FillStringTensorElement, _Inout_ OrtValue* value, _In_ const char* s, size_t index);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -839,10 +839,9 @@ struct OrtApi {
 
   /**
      * \param value A tensor created from OrtCreateTensor... function.
-     * \param len element length, not including the trailing '\0' chars.
      * \param index index of string tensor element, length of element at index will be returned.
      */
-  ORT_API2_STATUS(GetStringTensorElementLength, _In_ const OrtValue* value, _Out_ size_t* out, size_t index);
+  ORT_API2_STATUS(GetStringTensorElementLength, _In_ const OrtValue* value, size_t index, _Out_ size_t* out);
 
   /**
      * \param s string element contents. The string is NOT null-terminated.
@@ -850,12 +849,11 @@ struct OrtApi {
      * \param s_len element length, get it from OrtGetStringTensorElementLength.
      * \param index offset of element of tensor to return.
      */
-  ORT_API2_STATUS(GetStringTensorElement, _In_ const OrtValue* value, _Out_writes_bytes_all_(s_len) void* s,
-                  size_t s_len, size_t index);
+  ORT_API2_STATUS(GetStringTensorElement, _In_ const OrtValue* value, size_t s_len, size_t index, _Out_writes_bytes_all_(s_len) void* s);
 
   /**
      * \param value A tensor created from OrtCreateTensor... function.
-     * \param s A null terminated.
+     * \param s A null terminated string.
      * \param index index of string tensor element to fill 
      */
   ORT_API2_STATUS(FillStringTensorElement, _Inout_ OrtValue* value, _In_ const char* s, size_t index);

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -296,7 +296,7 @@ struct Value : Base<OrtValue> {
   TensorTypeAndShapeInfo GetTensorTypeAndShapeInfo() const;
 
   size_t GetStringTensorElementLength(size_t element_index) const;
-  void GetStringTensorElement(void* buffer, size_t buffer_length, size_t element_index) const;
+  void GetStringTensorElement(size_t buffer_length, size_t element_index, void* buffer) const;
 
   void FillStringTensor(const char* const* s, size_t s_len);
   void FillStringTensorElement(const char* s, size_t index);

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -294,6 +294,12 @@ struct Value : Base<OrtValue> {
 
   TypeInfo GetTypeInfo() const;
   TensorTypeAndShapeInfo GetTensorTypeAndShapeInfo() const;
+
+  size_t GetStringTensorElementLength(size_t element_index) const;
+  void GetStringTensorElement(void* buffer, size_t buffer_length, size_t element_index) const;
+
+  void FillStringTensor(const char* const* s, size_t s_len);
+  void FillStringTensorElement(const char* s, size_t index);
 };
 
 struct AllocatorWithDefaultOptions {

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -481,7 +481,7 @@ inline size_t Value::GetStringTensorDataLength() const {
 
 inline size_t Value::GetStringTensorElementLength(size_t element_index) const {
   size_t out;
-  ThrowOnError(Global<void>::api_.GetStringTensorElementLength(p_, element_index, &out));
+  ThrowOnError(GetApi().GetStringTensorElementLength(p_, element_index, &out));
   return out;
 }
 
@@ -490,15 +490,15 @@ inline void Value::GetStringTensorContent(void* buffer, size_t buffer_length, si
 }
 
 inline void Value::GetStringTensorElement(size_t buffer_length, size_t element_index, void* buffer) const {
-  ThrowOnError(Global<void>::api_.GetStringTensorElement(p_, buffer_length, element_index, buffer));
+  ThrowOnError(GetApi().GetStringTensorElement(p_, buffer_length, element_index, buffer));
 }
 
 inline void Value::FillStringTensor(const char* const* s, size_t s_len) {
-  ThrowOnError(Global<void>::api_.FillStringTensor(p_, s, s_len));
+  ThrowOnError(GetApi().FillStringTensor(p_, s, s_len));
 }
 
 inline void Value::FillStringTensorElement(const char* s, size_t index) {
-  ThrowOnError(Global<void>::api_.FillStringTensorElement(p_, s, index));
+  ThrowOnError(GetApi().FillStringTensorElement(p_, s, index));
 }
 
 template <typename T>

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -479,8 +479,26 @@ inline size_t Value::GetStringTensorDataLength() const {
   return out;
 }
 
+inline size_t Value::GetStringTensorElementLength(size_t element_index) const {
+  size_t out;
+  ThrowOnError(Global<void>::api_.GetStringTensorElementLength(p_, &out, element_index));
+  return out;
+}
+
 inline void Value::GetStringTensorContent(void* buffer, size_t buffer_length, size_t* offsets, size_t offsets_count) const {
   ThrowOnError(GetApi().GetStringTensorContent(p_, buffer, buffer_length, offsets, offsets_count));
+}
+
+inline void Value::GetStringTensorElement(void* buffer, size_t buffer_length, size_t element_index) const {
+  ThrowOnError(Global<void>::api_.GetStringTensorElement(p_, buffer, buffer_length, element_index));
+}
+
+inline void Value::FillStringTensor(const char* const* s, size_t s_len) {
+  ThrowOnError(Global<void>::api_.FillStringTensor(p_, s, s_len));
+}
+
+inline void Value::FillStringTensorElement(const char* s, size_t index) {
+  ThrowOnError(Global<void>::api_.FillStringTensorElement(p_, s, index));
 }
 
 template <typename T>

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -481,7 +481,7 @@ inline size_t Value::GetStringTensorDataLength() const {
 
 inline size_t Value::GetStringTensorElementLength(size_t element_index) const {
   size_t out;
-  ThrowOnError(Global<void>::api_.GetStringTensorElementLength(p_, &out, element_index));
+  ThrowOnError(Global<void>::api_.GetStringTensorElementLength(p_, element_index, &out));
   return out;
 }
 
@@ -489,8 +489,8 @@ inline void Value::GetStringTensorContent(void* buffer, size_t buffer_length, si
   ThrowOnError(GetApi().GetStringTensorContent(p_, buffer, buffer_length, offsets, offsets_count));
 }
 
-inline void Value::GetStringTensorElement(void* buffer, size_t buffer_length, size_t element_index) const {
-  ThrowOnError(Global<void>::api_.GetStringTensorElement(p_, buffer, buffer_length, element_index));
+inline void Value::GetStringTensorElement(size_t buffer_length, size_t element_index, void* buffer) const {
+  ThrowOnError(Global<void>::api_.GetStringTensorElement(p_, buffer_length, element_index, buffer));
 }
 
 inline void Value::FillStringTensor(const char* const* s, size_t s_len) {

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -584,7 +584,7 @@ ORT_API_STATUS_IMPL(OrtApis::GetStringTensorDataLength, _In_ const OrtValue* val
 ORT_API_STATUS_IMPL(OrtApis::GetStringTensorElementLength, _In_ const OrtValue* value, size_t index, _Out_ size_t* out) {
   TENSOR_READ_API_BEGIN
   const auto* src = tensor.Data<std::string>();
-  auto len = tensor.Shape().Size();
+  auto len = static_cast<size_t>(tensor.Shape().Size());
   if (index < len) {
     *out = src[index].size();
   } else

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -599,7 +599,7 @@ ORT_API_STATUS_IMPL(OrtApis::GetStringTensorContent, _In_ const OrtValue* value,
   const auto* input = tensor.Data<std::string>();
   auto len = static_cast<size_t>(tensor.Shape().Size());
   if (offsets_len < len) {
-    return OrtApis::CreateStatus(ORT_FAIL, "space is not enough");
+    return OrtApis::CreateStatus(ORT_FAIL, "offsets buffer is too small");
   }
   {
     size_t ret = 0;
@@ -607,7 +607,7 @@ ORT_API_STATUS_IMPL(OrtApis::GetStringTensorContent, _In_ const OrtValue* value,
       ret += input[i].size();
     }
     if (s_len < ret) {
-      return OrtApis::CreateStatus(ORT_FAIL, "space is not enough");
+      return OrtApis::CreateStatus(ORT_FAIL, "output buffer is too small");
     }
   }
   size_t f = 0;
@@ -632,14 +632,12 @@ ORT_API_STATUS_IMPL(OrtApis::GetStringTensorElement, _In_ const OrtValue* value,
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "element index is out of bounds");
   }
 
-  {
-    size_t ret = input[index].size();
-    if (s_len < ret) {
-      return OrtApis::CreateStatus(ORT_FAIL, "space is not enough");
-    }
+  size_t ret = input[index].size();
+  if (s_len < ret) {
+    return OrtApis::CreateStatus(ORT_FAIL,"buffer size is too small for string");
   }
 
-memcpy(s, input[index].data(), input[index].size());
+  memcpy(s, input[index].data(), input[index].size());
 
   return nullptr;
   API_IMPL_END

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -540,13 +540,27 @@ ORT_API_STATUS_IMPL(OrtApis::FillStringTensor, _Inout_ OrtValue* value, _In_ con
   TENSOR_READWRITE_API_BEGIN
   auto* dst = tensor->MutableData<std::string>();
   auto len = static_cast<size_t>(tensor->Shape().Size());
-  if (s_len < len) {
-    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "input array is too short");
+  if (s_len != len) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "input array doesn't equal tensor size");
   }
   for (size_t i = 0; i != len; ++i) {
     //allocate and copy
     dst[i] = s[i];
   }
+  return nullptr;
+  API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::FillStringTensorElement, _Inout_ OrtValue* value, _In_ const char* s, size_t index) {
+  TENSOR_READWRITE_API_BEGIN
+  auto* dst = tensor->MutableData<std::string>();
+  auto len = static_cast<size_t>(tensor->Shape().Size());
+  if (index >= len) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "element index is out of bounds");
+  }
+
+  dst[index] = s;
+
   return nullptr;
   API_IMPL_END
 }
@@ -561,6 +575,18 @@ ORT_API_STATUS_IMPL(OrtApis::GetStringTensorDataLength, _In_ const OrtValue* val
       ret += src[i].size();
     }
     *out = ret;
+  } else
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "shape is invalid");
+  return nullptr;
+  API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::GetStringTensorElementLength, _In_ const OrtValue* value, _Out_ size_t* out, size_t index) {
+  TENSOR_READ_API_BEGIN
+  const auto* src = tensor.Data<std::string>();
+  auto len = tensor.Shape().Size();
+  if (index < len) {
+    *out = src[index].size();
   } else
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "shape is invalid");
   return nullptr;
@@ -586,12 +612,35 @@ ORT_API_STATUS_IMPL(OrtApis::GetStringTensorContent, _In_ const OrtValue* value,
   }
   size_t f = 0;
   char* p = static_cast<char*>(s);
-  for (size_t i = 0; i != offsets_len; ++i, ++offsets) {
+  for (size_t i = 0; i != len; ++i, ++offsets) {
     memcpy(p, input[i].data(), input[i].size());
     p += input[i].size();
     *offsets = f;
     f += input[i].size();
   }
+  return nullptr;
+  API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::GetStringTensorElement, _In_ const OrtValue* value, _Out_writes_bytes_all_(s_len) void* s,
+                    size_t s_len, size_t index) {
+  TENSOR_READ_API_BEGIN
+  const auto* input = tensor.Data<std::string>();
+  auto len = static_cast<size_t>(tensor.Shape().Size());
+
+  if (index >= len) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "element index is out of bounds");
+  }
+
+  {
+    size_t ret = input[index].size();
+    if (s_len < ret) {
+      return OrtApis::CreateStatus(ORT_FAIL, "space is not enough");
+    }
+  }
+
+memcpy(s, input[index].data(), input[index].size());
+
   return nullptr;
   API_IMPL_END
 }
@@ -1614,6 +1663,9 @@ static constexpr OrtApi ort_api_1_to_4 = {
     // Version 4 - In development, feel free to add/remove/rearrange here
     &OrtApis::GetAvailableProviders,
     &OrtApis::ReleaseAvailableProviders,
+    &OrtApis::GetStringTensorElementLength,
+    &OrtApis::GetStringTensorElement,
+    &OrtApis::FillStringTensorElement,
 };
 
 // Assert to do a limited check to ensure Version 1 of OrtApi never changes (will detect an addition or deletion but not if they cancel out each other)

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -581,7 +581,7 @@ ORT_API_STATUS_IMPL(OrtApis::GetStringTensorDataLength, _In_ const OrtValue* val
   API_IMPL_END
 }
 
-ORT_API_STATUS_IMPL(OrtApis::GetStringTensorElementLength, _In_ const OrtValue* value, _Out_ size_t* out, size_t index) {
+ORT_API_STATUS_IMPL(OrtApis::GetStringTensorElementLength, _In_ const OrtValue* value, size_t index, _Out_ size_t* out) {
   TENSOR_READ_API_BEGIN
   const auto* src = tensor.Data<std::string>();
   auto len = tensor.Shape().Size();
@@ -598,8 +598,8 @@ ORT_API_STATUS_IMPL(OrtApis::GetStringTensorContent, _In_ const OrtValue* value,
   TENSOR_READ_API_BEGIN
   const auto* input = tensor.Data<std::string>();
   auto len = static_cast<size_t>(tensor.Shape().Size());
-  if (offsets_len < len) {
-    return OrtApis::CreateStatus(ORT_FAIL, "offsets buffer is too small");
+  if (offsets_len != len) {
+    return OrtApis::CreateStatus(ORT_FAIL, "offsets buffer is not equal to tensor size");
   }
   {
     size_t ret = 0;
@@ -622,8 +622,7 @@ ORT_API_STATUS_IMPL(OrtApis::GetStringTensorContent, _In_ const OrtValue* value,
   API_IMPL_END
 }
 
-ORT_API_STATUS_IMPL(OrtApis::GetStringTensorElement, _In_ const OrtValue* value, _Out_writes_bytes_all_(s_len) void* s,
-                    size_t s_len, size_t index) {
+ORT_API_STATUS_IMPL(OrtApis::GetStringTensorElement, _In_ const OrtValue* value, size_t s_len, size_t index, _Out_writes_bytes_all_(s_len) void* s) {
   TENSOR_READ_API_BEGIN
   const auto* input = tensor.Data<std::string>();
   auto len = static_cast<size_t>(tensor.Shape().Size());

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -120,11 +120,10 @@ ORT_API_STATUS_IMPL(GetTensorMutableData, _Inout_ OrtValue* value, _Outptr_ void
 ORT_API_STATUS_IMPL(FillStringTensor, _Inout_ OrtValue* value, _In_ const char* const* s, size_t s_len);
 ORT_API_STATUS_IMPL(FillStringTensorElement, _Inout_ OrtValue* value, _In_ const char* s, size_t index);
 ORT_API_STATUS_IMPL(GetStringTensorDataLength, _In_ const OrtValue* value, _Out_ size_t* len);
-ORT_API_STATUS_IMPL(GetStringTensorElementLength, _In_ const OrtValue* value, _Out_ size_t* out, size_t index);
+ORT_API_STATUS_IMPL(GetStringTensorElementLength, _In_ const OrtValue* value, size_t index, _Out_ size_t* out);
 ORT_API_STATUS_IMPL(GetStringTensorContent, _In_ const OrtValue* value, _Out_writes_bytes_all_(s_len) void* s,
                     size_t s_len, _Out_writes_all_(offsets_len) size_t* offsets, size_t offsets_len);
-ORT_API_STATUS_IMPL(GetStringTensorElement, _In_ const OrtValue* value, _Out_writes_bytes_all_(s_len) void* s,
-                    size_t s_len, size_t index);
+ORT_API_STATUS_IMPL(GetStringTensorElement, _In_ const OrtValue* value, size_t s_len, size_t index, _Out_writes_bytes_all_(s_len) void* s);
 ORT_API_STATUS_IMPL(CastTypeInfoToTensorInfo, _In_ const OrtTypeInfo*,
                     _Outptr_result_maybenull_ const OrtTensorTypeAndShapeInfo** out);
 ORT_API_STATUS_IMPL(GetOnnxTypeFromTypeInfo, _In_ const OrtTypeInfo*, _Out_ enum ONNXType* out);

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -118,9 +118,13 @@ ORT_API_STATUS_IMPL(CreateTensorWithDataAsOrtValue, _In_ const OrtMemoryInfo* in
 ORT_API_STATUS_IMPL(IsTensor, _In_ const OrtValue* value, _Out_ int* out);
 ORT_API_STATUS_IMPL(GetTensorMutableData, _Inout_ OrtValue* value, _Outptr_ void** out);
 ORT_API_STATUS_IMPL(FillStringTensor, _Inout_ OrtValue* value, _In_ const char* const* s, size_t s_len);
+ORT_API_STATUS_IMPL(FillStringTensorElement, _Inout_ OrtValue* value, _In_ const char* s, size_t index);
 ORT_API_STATUS_IMPL(GetStringTensorDataLength, _In_ const OrtValue* value, _Out_ size_t* len);
+ORT_API_STATUS_IMPL(GetStringTensorElementLength, _In_ const OrtValue* value, _Out_ size_t* out, size_t index);
 ORT_API_STATUS_IMPL(GetStringTensorContent, _In_ const OrtValue* value, _Out_writes_bytes_all_(s_len) void* s,
                     size_t s_len, _Out_writes_all_(offsets_len) size_t* offsets, size_t offsets_len);
+ORT_API_STATUS_IMPL(GetStringTensorElement, _In_ const OrtValue* value, _Out_writes_bytes_all_(s_len) void* s,
+                    size_t s_len, size_t index);
 ORT_API_STATUS_IMPL(CastTypeInfoToTensorInfo, _In_ const OrtTypeInfo*,
                     _Outptr_result_maybenull_ const OrtTensorTypeAndShapeInfo** out);
 ORT_API_STATUS_IMPL(GetOnnxTypeFromTypeInfo, _In_ const OrtTypeInfo*, _Out_ enum ONNXType* out);

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -418,7 +418,7 @@ TEST(CApiTest, fill_string_tensor) {
 
   Ort::Value tensor = Ort::Value::CreateTensor(default_allocator.get(), &expected_len, 1, ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING);
 
-  for (size_t i = 0; i < expected_len; i++) {
+  for (int64_t i = 0; i < expected_len; i++) {
     
       tensor.FillStringTensorElement(s[i], i);
   }
@@ -440,14 +440,14 @@ TEST(CApiTest, get_string_tensor_element) {
   tensor.FillStringTensor(s, expected_len);
     
   auto expected_string = s[element_index];
-  size_t expected_string_len = expected_string.size();
+  size_t expected_string_len = strlen(expected_string);
 
   std::string result(expected_string_len, '\0');
   tensor.GetStringTensorElement(expected_string_len, element_index, (void*)result.data());
   ASSERT_STREQ(result.c_str(), expected_string);
 
   auto string_len = tensor.GetStringTensorElementLength(element_index);
-  ASSERT_EQ(expected_strlen, string_len);
+  ASSERT_EQ(expected_string_len, string_len);
 }
 
 TEST(CApiTest, create_tensor_with_data) {
@@ -481,7 +481,7 @@ TEST(CApiTest, override_initializer) {
   // Place a string into Tensor OrtValue and assign to the
   Ort::Value f2_input_tensor = Ort::Value::CreateTensor(allocator.get(), dims.data(), dims.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING);
   const char* const input_char_string[] = {f2_data.c_str()};
- f2_input_tensor.FillStringTensor(input_char_string, 1U));
+  f2_input_tensor.FillStringTensor(input_char_string, 1U);
 
   Ort::SessionOptions session_options;
   Ort::Session session(*ort_env, OVERRIDABLE_INITIALIZER_MODEL_URI, session_options);

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -443,7 +443,7 @@ TEST(CApiTest, get_string_tensor_element) {
   size_t expected_string_len = expected_string.size();
 
   std::string result(expected_string_len, '\0');
-  tensor.GetStringTensorElement((void*)result.data(), expected_string_len, element_index);
+  tensor.GetStringTensorElement(expected_string_len, element_index, (void*)result.data());
   ASSERT_STREQ(result.c_str(), expected_string);
 
   auto string_len = tensor.GetStringTensorElementLength(element_index);

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -439,15 +439,15 @@ TEST(CApiTest, get_string_tensor_element) {
 
   tensor.FillStringTensor(s, expected_len);
     
-  auto expected_str = s[element_index];
-  size_t expected_strlen = expected_str.size();
+  auto expected_string = s[element_index];
+  size_t expected_string_len = expected_string.size();
 
   std::string result(expected_string_len, '\0');
-  tensor.GetStringTensorElement((void*)result.data(), expected_strlen, element_index);
-  ASSERT_STREQ(result.c_str(), expected_str);
+  tensor.GetStringTensorElement((void*)result.data(), expected_string_len, element_index);
+  ASSERT_STREQ(result.c_str(), expected_string);
 
-  auto strlen= tensor.GetStringTensorElementLength(element_index);
-  ASSERT_EQ(expected_strlen, strlen);
+  auto string_len = tensor.GetStringTensorElementLength(element_index);
+  ASSERT_EQ(expected_strlen, string_len);
 }
 
 TEST(CApiTest, create_tensor_with_data) {

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -411,6 +411,45 @@ TEST(CApiTest, create_tensor) {
   tensor.GetStringTensorContent((void*)result.data(), data_len, offsets.data(), offsets.size());
 }
 
+TEST(CApiTest, fill_string_tensor) {
+  const char* s[] = {"abc", "kmp"};
+  int64_t expected_len = 2;
+  auto default_allocator = onnxruntime::make_unique<MockedOrtAllocator>();
+
+  Ort::Value tensor = Ort::Value::CreateTensor(default_allocator.get(), &expected_len, 1, ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING);
+
+  for (size_t i = 0; i < expected_len; i++) {
+    
+      tensor.FillStringTensorElement(s[i], i);
+  }
+
+  auto shape_info = tensor.GetTensorTypeAndShapeInfo();
+
+  int64_t len = shape_info.GetElementCount();
+  ASSERT_EQ(len, expected_len);
+}
+
+TEST(CApiTest, get_string_tensor_element) {
+  const char* s[] = {"abc", "kmp"};
+  int64_t expected_len = 2;
+  int64_t element_index = 0;
+  auto default_allocator = onnxruntime::make_unique<MockedOrtAllocator>();
+
+  Ort::Value tensor = Ort::Value::CreateTensor(default_allocator.get(), &expected_len, 1, ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING);
+
+  tensor.FillStringTensor(s, expected_len);
+    
+  auto expected_str = s[element_index];
+  size_t expected_strlen = expected_str.size();
+
+  std::string result(expected_string_len, '\0');
+  tensor.GetStringTensorElement((void*)result.data(), expected_strlen, element_index);
+  ASSERT_STREQ((char*)result, expected_str);
+
+  auto strlen= tensor.GetStringTensorElementLength(element_index);
+  ASSERT_EQ(expected_strlen, strlen);
+}
+
 TEST(CApiTest, create_tensor_with_data) {
   float values[] = {3.0f, 1.0f, 2.f, 0.f};
   constexpr size_t values_length = sizeof(values) / sizeof(values[0]);
@@ -441,9 +480,8 @@ TEST(CApiTest, override_initializer) {
   std::string f2_data{"f2_string"};
   // Place a string into Tensor OrtValue and assign to the
   Ort::Value f2_input_tensor = Ort::Value::CreateTensor(allocator.get(), dims.data(), dims.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING);
-  // No C++ Api to either create a string Tensor or to fill one with string, so we use C
   const char* const input_char_string[] = {f2_data.c_str()};
-  Ort::ThrowOnError(Ort::GetApi().FillStringTensor(static_cast<OrtValue*>(f2_input_tensor), input_char_string, 1U));
+ f2_input_tensor.FillStringTensor(input_char_string, 1U));
 
   Ort::SessionOptions session_options;
   Ort::Session session(*ort_env, OVERRIDABLE_INITIALIZER_MODEL_URI, session_options);

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -444,7 +444,7 @@ TEST(CApiTest, get_string_tensor_element) {
 
   std::string result(expected_string_len, '\0');
   tensor.GetStringTensorElement((void*)result.data(), expected_strlen, element_index);
-  ASSERT_STREQ((char*)result, expected_str);
+  ASSERT_STREQ(result.c_str(), expected_str);
 
   auto strlen= tensor.GetStringTensorElementLength(element_index);
   ASSERT_EQ(expected_strlen, strlen);


### PR DESCRIPTION
**Motivation and Context**
The following string tensor APIs `GetStringDataLength`, `GetStringTensorContent` and `FillStringTensor` take as input or return all the elements of a string tensor. The user therefore needs to provide all the inputs before making a call to `FillStringTensor` or get all string tensor elements in one API call. 
In the scenario that the user doesn’t have all the elements before invoking `FillStringTensor` or only wants a to retrieve a single element from the tensor, the user must maintain a cache. The PR adds APIs to support the functionality to get or set individual elements for string tensors as well as their C++ wrappers.

_Note: These changes are as per the discussion with the QAS team and ONNX team (@pranavsharma)_

**Current Changes**: 
1. Add support for the following string tensor C APIs:
  a. GetStringTensorElement: Get a string tensor element by index
  b. GetStringTensorElementLength: Get the length of a string tensor element by index 
  c. FillStringTensorElement: Set a string tensor element by index

2. Add unit tests for the new C APIs: [onnxruntime/test/shared_lib/test_inference.cc](https://github.com/microsoft/onnxruntime/compare/master...alishasonawalla:alsonawa/add_string_tensor_api?expand=1#diff-4e5e75dedcb775edc4d8289a791a47c3)

3. Add C++ wrappers for the new C APIs implemented above as well as for `FillStringTensor` function: [include/onnxruntime/core/session/onnxruntime_cxx_inline.h](https://github.com/microsoft/onnxruntime/compare/master...alishasonawalla:alsonawa/add_string_tensor_api?expand=1#diff-9a156f8eac4f8ebfe60190e6d53a112a) and [include/onnxruntime/core/session/onnxruntime_cxx_api.h](https://github.com/microsoft/onnxruntime/compare/master...alishasonawalla:alsonawa/add_string_tensor_api?expand=1#diff-f85b3061605b759cf381eecf6d33469a)

4. Other fixes/updates
	a. Update bounds check for `FillStringTensor`: [onnxruntime/core/session/onnxruntime_c_api.cc](https://github.com/microsoft/onnxruntime/compare/master...alishasonawalla:alsonawa/add_string_tensor_api?expand=1#diff-17e1b2dcae1d4db70da44b8f6aab38ba)
	The new check verifies if the input array is both shorter or longer than the tensor. In the current scenario if the input array is longer the tensor size the remaining input will be dropped. _Please let me know if this was the planned design._ 
	
	b. Update loop counter for `GetStringTensorContent` to iterate over `len` instead of `offsets_len` in the scenario where offsets_len may be longer than `len` but that is not a bug: [onnxruntime/core/session/onnxruntime_c_api.cc](https://github.com/microsoft/onnxruntime/compare/master...alishasonawalla:alsonawa/add_string_tensor_api?expand=1#diff-17e1b2dcae1d4db70da44b8f6aab38baL575)
	
	c. Update error messages with more description: [onnxruntime/core/session/onnxruntime_c_api.cc](https://github.com/microsoft/onnxruntime/compare/master...alishasonawalla:alsonawa/add_string_tensor_api?expand=1#diff-17e1b2dcae1d4db70da44b8f6aab38baL576)

    d.  Update unit test to use `FillStringTenor` C++ wrapper: [onnxruntime/test/shared_lib/test_inference.cc](https://github.com/microsoft/onnxruntime/compare/master...alishasonawalla:alsonawa/add_string_tensor_api?expand=1#diff-4e5e75dedcb775edc4d8289a791a47c3L445)


**Examples**
```
for (size_t i = 0; i < expected_len; i++) 
{
	tensor.FillStringTensorElement(s[i], i);
}
```
```
const char* s[] = {"abc", "kmp"};

int64_t expected_len = 2;
int64_t element_index = 0;

auto default_allocator = onnxruntime::make_unique<MockedOrtAllocator>();

Ort::Value tensor = Ort::Value::CreateTensor(default_allocator.get(), &expected_len, 1, ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING);

tensor.FillStringTensor(s, expected_len);

std::string result(expected_string_len, '\0');

auto string_len = tensor.GetStringTensorElementLength(element_index);

tensor.GetStringTensorElement((void*)result.data(), string_len, element_index);
```
