### PR TITLE
adjust bs size for fp16/128 to avoid oom 

### DIFF
--- a/orttraining/tools/ci_test/run_bert_perf_test.py
+++ b/orttraining/tools/ci_test/run_bert_perf_test.py
@@ -26,7 +26,7 @@ def main():
 
     Config = namedtuple('Config', ['use_mixed_precision', 'max_seq_length', 'batch_size', 'max_predictions_per_seq'])
     configs = [
-        Config(True, 128, 66, 20),
+        Config(True, 128, 64, 20),
         Config(True, 512, 10, 80),
         Config(False, 128, 33, 20),
         Config(False, 512, 5, 80)


### PR DESCRIPTION
**Description**: The new Bert-L/opset12 model sometimes cause OOM when running fp16/128/bs=66 in perf test pipeline. Adjust bs to 64 (power of 2) to stabilize the pipeline.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
