### PR TITLE
Add MaskIndex op

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/mask_index.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/mask_index.cc
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/framework/tensor.h"
+#include "core/util/math_cpuonly.h"
+#include "core/providers/common.h"
+#include "core/platform/threadpool.h"
+#include "mask_index.h"
+#include "mask_index_helper.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+#define REGISTER_KERNEL_TYPED(T)                                  \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
+      MaskIndex,                                                  \
+      kMSDomain,                                                  \
+      1,                                                          \
+      T,                                                          \
+      kCpuExecutionProvider,                                      \
+      KernelDefBuilder()                                          \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      MaskIndex<T>);
+
+REGISTER_KERNEL_TYPED(int32_t)
+REGISTER_KERNEL_TYPED(int64_t)
+REGISTER_KERNEL_TYPED(float)
+
+template <typename T>
+MaskIndex<T>::MaskIndex(const OpKernelInfo& op_kernel_info)
+    : OpKernel(op_kernel_info) {
+}
+
+template <typename T>
+Status MaskIndex<T>::Compute(OpKernelContext* context) const {
+  const Tensor* mask = context->Input<Tensor>(0);
+
+  const auto input_dims = mask->Shape().GetDims();
+  if (input_dims.size() != 2) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "attention mask is expected to have 2 dimensions, got ", input_dims.size());
+  }
+
+  std::vector<int64_t> mask_index_dims;
+  mask_index_dims.push_back(2 * input_dims[0]);
+  TensorShape mask_index_shape(mask_index_dims);
+  Tensor* mask_index = context->Output(0, mask_index_shape);
+
+  int batch_size = static_cast<int>(input_dims[0]);
+  int sequence_length = static_cast<int>(input_dims[1]);
+
+  return ComputeMaskIndex<T>(mask->template Data<T>(), mask_index->template MutableData<int32_t>(), batch_size, sequence_length);
+}
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/bert/mask_index.h
+++ b/onnxruntime/contrib_ops/cpu/bert/mask_index.h
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/framework/op_kernel.h"
+#include "core/framework/tensor.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+template <typename T>
+class MaskIndex final : public OpKernel {
+ public:
+  MaskIndex(const OpKernelInfo& op_kernel_info);
+  Status Compute(OpKernelContext* context) const override;
+};
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/bert/mask_index_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/mask_index_helper.h
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+template <typename T>
+Status ComputeMaskIndex(const T* mask,        // input mask, NULL when no mask input.
+                        int* mask_index,      // output mask index
+                        int batch_size,       // batch size
+                        int sequence_length)  // sequence length
+{
+  if (nullptr == mask) {
+    for (int i = 0; i < batch_size; i++) {
+      *mask_index++ = sequence_length;
+    }
+    for (int i = 0; i < batch_size; i++) {
+      *mask_index++ = 0;
+    }
+  } else {
+    const T* m = mask;
+    for (int i = 0; i < batch_size; i++) {
+      int min_index = sequence_length;
+      for (int j = 0; j < sequence_length; j++) {
+        if (m[j] > T(0)) {
+          min_index = j;
+          break;
+        }
+      }
+
+      int max_index = -1;
+      for (int j = sequence_length - 1; j >= 0; j--) {
+        if (m[j] > T(0)) {
+          max_index = j;
+          break;
+        }
+      }
+
+      if (max_index >= 0) {
+        for (int k = min_index + 1; k < max_index; k++) {
+          if (m[k] == T(0)) {
+            return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                                   "MaskIndex only support attention mask with one contiguous block of 1 in a batch.");
+          }
+        }
+      }
+
+      mask_index[i] = max_index + 1;
+      mask_index[batch_size + i] = min_index;
+      m += sequence_length;
+    }
+  }
+
+  return Status::OK();
+}
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -9,9 +9,6 @@ namespace onnxruntime {
 namespace contrib {
 
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SampleOp);
-
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, Attention);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, ExpandDims);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedConv);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedGemm);
@@ -29,9 +26,19 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, CropAndResize);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, CDist);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, double, CDist);
+
+// ******** Start: Transformers ******************* //
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, Attention);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int32_t, MaskIndex);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int64_t, MaskIndex);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, MaskIndex);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, Gelu);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, BiasGelu);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, FastGelu);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, double, SkipLayerNormalization);
+// ******** End: Transformers ******************* //
 
 // ******** Start: Quantization ******************* //
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MatMulInteger16);
@@ -70,8 +77,6 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomai
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, Upsample);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, float, LayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, double, LayerNormalization);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, double, SkipLayerNormalization);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, Inverse);
 
 Status RegisterNchwcKernels(KernelRegistry& kernel_registry) {
@@ -84,6 +89,26 @@ Status RegisterNchwcKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, AveragePool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, GlobalAveragePool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, Upsample)>};
+
+  for (auto& function_table_entry : function_table) {
+    ORT_RETURN_IF_ERROR(kernel_registry.Register(function_table_entry()));
+  }
+  return Status::OK();
+}
+
+Status RegisterTransformerKernels(KernelRegistry& kernel_registry) {
+  static const BuildKernelCreateInfoFn function_table[] = {
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, Attention)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int32_t, MaskIndex)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int64_t, MaskIndex)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, MaskIndex)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, BiasGelu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, Gelu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, FastGelu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, double, SkipLayerNormalization)>,
+  };
 
   for (auto& function_table_entry : function_table) {
     ORT_RETURN_IF_ERROR(kernel_registry.Register(function_table_entry()));
@@ -117,8 +142,6 @@ Status RegisterCpuContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SampleOp)>,
 
       // add more kernels here
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, Attention)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, ExpandDims)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedConv)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedGemm)>,
@@ -136,9 +159,6 @@ Status RegisterCpuContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, CropAndResize)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, CDist)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, double, CDist)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, BiasGelu)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, Gelu)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, FastGelu)>,
 
       // These ops were experimental ops in onnx domain which have been removed now. We add them here as
       // contrib ops to main backward compatibility
@@ -153,8 +173,6 @@ Status RegisterCpuContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, Scale)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, float, LayerNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, double, LayerNormalization)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, double, SkipLayerNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, Inverse)>,
   };
 
@@ -166,6 +184,8 @@ Status RegisterCpuContribKernels(KernelRegistry& kernel_registry) {
   if (MlasNchwcGetBlockSize() > 1) {
     ORT_RETURN_IF_ERROR(RegisterNchwcKernels(kernel_registry));
   }
+
+  RegisterTransformerKernels(kernel_registry);
 
   RegisterQuantizationKernels(kernel_registry);
 

--- a/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm_impl.h
@@ -6,21 +6,19 @@ namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
-bool LaunchEmbedLayerNormKernel(void* output,                     // output tensor
-                                void* mask_index,                 // output mask index
-                                const int* input_ids,             // input word IDs
-                                const int* segment_ids,           // input segment IDs
-                                const int* input_mask,            // input mask
-                                const void* gamma,                // weight for layer normalization
-                                const void* beta,                 // bias for layer normalization
-                                const void* word_embedding,       // weights for word embeddings
-                                const void* position_embedding,   // weights for position embeddings
-                                const void* segment_embedding,    // weights for segment (like sentence) embeddings
-                                float epsilon,                    // epsilon for layer normalization
-                                const int hidden_size,            // hidden size (that is head_size * num_heads)
-                                int batch_size,                   // batch size
-                                int sequence_length,              // sequence length
-                                const size_t element_size);       // size of element in output tensor. 2 for half, 4 for float.
+bool LaunchEmbedLayerNormKernel(void* output,                    // output tensor
+                                const int* input_ids,            // input word IDs
+                                const int* segment_ids,          // input segment IDs
+                                const void* gamma,               // weight for layer normalization
+                                const void* beta,                // bias for layer normalization
+                                const void* word_embedding,      // weights for word embeddings
+                                const void* position_embedding,  // weights for position embeddings
+                                const void* segment_embedding,   // weights for segment (like sentence) embeddings
+                                float epsilon,                   // epsilon for layer normalization
+                                const int hidden_size,           // hidden size (that is head_size * num_heads)
+                                int batch_size,                  // batch size
+                                int sequence_length,             // sequence length
+                                const size_t element_size);      // size of element in output tensor. 2 for half, 4 for float.
 
 }  // namespace cuda
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cuda/bert/mask_index.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/mask_index.cc
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/common.h"
+#include "core/framework/tensorprotoutils.h"
+#include "onnx/defs/tensor_proto_util.h"
+#include "mask_index.h"
+#include "mask_index_impl.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+#define REGISTER_KERNEL_TYPED(T)                                  \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
+      MaskIndex,                                                  \
+      kMSDomain,                                                  \
+      1,                                                          \
+      T,                                                          \
+      kCudaExecutionProvider,                                     \
+      KernelDefBuilder()                                          \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      MaskIndex<T>);
+
+REGISTER_KERNEL_TYPED(int32_t)
+REGISTER_KERNEL_TYPED(int64_t)
+REGISTER_KERNEL_TYPED(float)
+
+using namespace ONNX_NAMESPACE;
+
+template <typename T>
+MaskIndex<T>::MaskIndex(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info) {
+}
+
+template <typename T>
+Status MaskIndex<T>::ComputeInternal(OpKernelContext* context) const {
+  const Tensor* mask = context->Input<Tensor>(0);
+
+  const auto input_dims = mask->Shape().GetDims();
+  if (input_dims.size() != 2) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "input is expected to have 2 dimensions, got ", input_dims.size());
+  }
+
+  std::vector<int64_t> mask_index_dims;
+  mask_index_dims.push_back(2 * input_dims[0]);
+  TensorShape mask_index_shape(mask_index_dims);
+  Tensor* mask_index = context->Output(0, mask_index_shape);
+
+  int batch_size = static_cast<int>(input_dims[0]);
+  int sequence_length = static_cast<int>(input_dims[1]);
+
+  cudaStream_t stream = nullptr;  // use default stream
+  if (!LaunchMaskIndexKernel<T>(
+          stream,
+          mask->template Data<T>(),
+          mask_index->template MutableData<int32_t>(),
+          batch_size,
+          sequence_length)) {
+    // Get last error to reset it to cudaSuccess.
+    CUDA_CALL(cudaGetLastError());
+    return Status(common::ONNXRUNTIME, common::FAIL);
+  }
+
+  return Status::OK();
+}
+
+}  //namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/mask_index.h
+++ b/onnxruntime/contrib_ops/cuda/bert/mask_index.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "core/common/common.h"
+#include "core/framework/op_kernel.h"
+#include "core/providers/cuda/cuda_common.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+using namespace onnxruntime::cuda;
+
+template <typename T>
+class MaskIndex final : public CudaKernel {
+ public:
+  MaskIndex(const OpKernelInfo& op_kernel_info);
+  Status ComputeInternal(OpKernelContext* ctx) const override;
+};
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/mask_index_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/mask_index_impl.cu
@@ -1,0 +1,148 @@
+/*
+ The implementation of this file is based on embLayerNorm plugin in TensorRT demo:
+ https://github.com/NVIDIA/TensorRT/tree/release/5.1/demo/BERT/
+ 
+Copyright 2019 NVIDIA Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "mask_index_impl.h"
+#include "core/providers/cuda/shared_inc/cuda_call.h"
+#include <cub/cub.cuh>
+
+using namespace cub;
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+template <typename T, unsigned TPB>
+__global__ void MaskIndexKernelSmall(int sequence_length, const T* mask, int* mask_index) {
+  using BlockReduce = cub::BlockReduce<int, TPB>;
+  __shared__ typename BlockReduce::TempStorage temp_storage_min;
+  __shared__ typename BlockReduce::TempStorage temp_storage_max;
+
+  const int& batch_size = gridDim.x;
+  const int& batch_index = blockIdx.x;
+
+  // Mask is optional for EmbedLayerNormalization operator
+  if (mask == nullptr) {
+    if (threadIdx.x == 0) {
+      mask_index[batch_index] = sequence_length;
+      mask_index[batch_size + batch_index] = 0;
+    }
+    return;
+  }
+
+  // Find min and max positions of mask value > 0
+  int min_position(sequence_length);
+  int max_position(-1);
+
+  if (threadIdx.x < sequence_length) {
+    const T val = mask[batch_index * sequence_length + threadIdx.x];
+    if (val > static_cast<T>(0))  // mask could be 0 or 1
+    {
+      min_position = threadIdx.x;
+      max_position = threadIdx.x;
+    }
+  }
+
+  const int min_valid = BlockReduce(temp_storage_min).Reduce(min_position, cub::Min());
+  const int max_valid = BlockReduce(temp_storage_max).Reduce(max_position, cub::Max());
+
+  if (threadIdx.x == 0) {
+    mask_index[batch_index] = max_valid + 1;
+    mask_index[batch_size + batch_index] = min_valid;
+  }
+}
+
+template <typename T, unsigned TPB>
+__global__ void MaskIndexKernel(int sequence_length, const T* mask, int* mask_index) {
+  using BlockReduce = cub::BlockReduce<int, TPB>;
+  __shared__ typename BlockReduce::TempStorage temp_storage_min;
+  __shared__ typename BlockReduce::TempStorage temp_storage_max;
+
+  const int& batch_size = gridDim.x;
+  const int& batch_index = blockIdx.x;
+
+  // Mask is optional for EmbedLayerNormalization operator
+  if (mask == nullptr) {
+    if (threadIdx.x == 0) {
+      mask_index[batch_index] = sequence_length;
+      mask_index[batch_size + batch_index] = 0;
+    }
+    return;
+  }
+
+  // Find min and max positions of mask value > 0
+  int min_position(sequence_length);
+  int max_position(-1);
+
+  const int offset = blockIdx.x * sequence_length;
+
+  for (int i = threadIdx.x; i < sequence_length; i += TPB) {
+    const T val = mask[offset + i];
+    if (val > static_cast<T>(0)) {  // mask could be 0 or 1
+      min_position = min(min_position, i);
+      max_position = max(max_position, i);
+    }
+  }
+
+  const int min_valid = BlockReduce(temp_storage_min).Reduce(min_position, cub::Min());
+  const int max_valid = BlockReduce(temp_storage_max).Reduce(max_position, cub::Max());
+
+  if (threadIdx.x == 0) {
+    mask_index[batch_index] = max_valid + 1;
+    mask_index[batch_size + batch_index] = min_valid;
+  }
+}
+
+template <typename T>
+bool LaunchMaskIndexKernel(
+    cudaStream_t stream,
+    const T* mask,
+    int* mask_index,
+    int batch_size,
+    int sequence_length) {
+  // Assume input mask total elements n = batch_size x sequence_length.
+  if (sequence_length <= 32) {
+    MaskIndexKernelSmall<T, 32><<<batch_size, 32, 0, stream>>>(sequence_length, mask, mask_index);
+  } else if (sequence_length <= 64) {
+    MaskIndexKernelSmall<T, 64><<<batch_size, 64, 0, stream>>>(sequence_length, mask, mask_index);
+  } else if (sequence_length <= 128) {
+    MaskIndexKernelSmall<T, 128><<<batch_size, 128, 0, stream>>>(sequence_length, mask, mask_index);
+  } else if (sequence_length <= 256) {
+    MaskIndexKernelSmall<T, 256><<<batch_size, 256, 0, stream>>>(sequence_length, mask, mask_index);
+  } else if (sequence_length <= 512) {
+    MaskIndexKernelSmall<T, 512><<<batch_size, 512, 0, stream>>>(sequence_length, mask, mask_index);
+  } else {
+    MaskIndexKernel<T, 512><<<batch_size, 512, 0, stream>>>(sequence_length, mask, mask_index);
+  }
+
+  return CUDA_CALL(cudaPeekAtLastError());
+}
+
+#define SPECIALIZED_IMPL(T) \
+  template bool LaunchMaskIndexKernel<T>(cudaStream_t stream, const T* input_mask, int* mask_index, int batch_size, int sequence_length);
+
+SPECIALIZED_IMPL(int32_t)  // Needed by EmbedLayerNormalization.
+SPECIALIZED_IMPL(int64_t)
+SPECIALIZED_IMPL(float)
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/mask_index_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/mask_index_impl.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+template <typename T>
+bool LaunchMaskIndexKernel(cudaStream_t stream,   // stream
+                           const T* mask,         // input mask, NULL when no mask input.
+                           int* mask_index,       // output mask index
+                           int batch_size,        // batch size
+                           int sequence_length);  // sequence length
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
@@ -9,6 +9,14 @@ using namespace onnxruntime::common;
 namespace onnxruntime {
 namespace contrib {
 namespace cuda {
+// ******** Start: Transformers ******************* //
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, Attention);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, Attention);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, EmbedLayerNormalization);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, int32_t, MaskIndex);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, int64_t, MaskIndex);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, MaskIndex);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, FastGelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, FastGelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, Gelu);
@@ -17,6 +25,10 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, BiasGelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, BiasGelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, BiasGelu);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, SkipLayerNormalization);
+// ******** End: Transformers ******************* //
+
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, TransposeMatMul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, TransposeMatMul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, TransposeMatMul);
@@ -36,16 +48,14 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, Affine);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, Affine);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, Affine);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, Attention);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, Attention);
+
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, ConvTransposeWithDynamicPads);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, Crop);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, Crop);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, Crop);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, int32_t, DynamicSlice);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, int64_t, DynamicSlice);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, EmbedLayerNormalization);
+
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, ImageScaler);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, ImageScaler);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, ImageScaler);
@@ -55,8 +65,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, ScaledTanh);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, ScaledTanh);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, ScaledTanh);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, SkipLayerNormalization);
+
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, ThresholdedRelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, ThresholdedRelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, ThresholdedRelu);
@@ -73,6 +82,14 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1
 
 Status RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
   static const BuildKernelCreateInfoFn function_table[] = {
+      // ******** Start: Transformers ******************* //
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, Attention)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, Attention)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, EmbedLayerNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, int32_t, MaskIndex)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, int64_t, MaskIndex)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, MaskIndex)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, FastGelu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, FastGelu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, Gelu)>,
@@ -81,6 +98,9 @@ Status RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, BiasGelu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, BiasGelu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, BiasGelu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, SkipLayerNormalization)>,
+      // ******** End: Transformers ******************* //
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, TransposeMatMul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, TransposeMatMul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, TransposeMatMul)>,
@@ -100,16 +120,12 @@ Status RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, Affine)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, Affine)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, Affine)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, Attention)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, Attention)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, ConvTransposeWithDynamicPads)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, Crop)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, Crop)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, Crop)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, int32_t, DynamicSlice)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, int64_t, DynamicSlice)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, EmbedLayerNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, ImageScaler)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, ImageScaler)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, ImageScaler)>,
@@ -119,8 +135,6 @@ Status RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, ScaledTanh)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, ScaledTanh)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, ScaledTanh)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, SkipLayerNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, ThresholdedRelu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, ThresholdedRelu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, ThresholdedRelu)>,

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -447,6 +447,34 @@ and present state are optional. Present state could appear in output even when p
         return;
       });
 
+  ONNX_CONTRIB_OPERATOR_SCHEMA(MaskIndex)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetSupportLevel(OpSchema::SupportType::EXPERIMENTAL)
+      .SetDoc("Mask Index for Attention. It converts attention mask into the end positions and start positions of each sequence.")
+      .Input(0, "attention_mask", "2D attention mask with shape (batch_size, sequence_length)", "T")
+      .Output(0, "mask_index", "1D mask_index tensor with shape (2*batch_size)", "Ti")
+      .TypeConstraint("T", {"tensor(int32)", "tensor(int64)", "tensor(float)"}, "Constrain input integer tensors types")
+      .TypeConstraint("Ti", {"tensor(int32)"}, "Constrain output integer tensors types")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        auto output_data_type = ctx.getOutputType(0)->mutable_tensor_type();
+        output_data_type->set_elem_type(::ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT32);
+
+        if (!hasInputShape(ctx, 0))
+          return;
+
+        auto& mask_shape = getInputShape(ctx, 0);
+        auto& mask_dims = mask_shape.dim();
+        if (mask_dims.size() != 2) {
+          fail_shape_inference("Inputs 0 shall be 2 dimensions");
+        }
+
+        ONNX_NAMESPACE::TensorShapeProto mask_index_shape;
+        mask_index_shape.add_dim();
+        mask_index_shape.mutable_dim(0)->set_dim_value(2 * mask_shape.dim(0).dim_value());
+        updateOutputShape(ctx, 0, mask_index_shape);
+      });
+
   static const char* EmbedLayerNormalization_ver1_doc = R"DOC(
 EmbedLayerNormalization is the fusion of embedding layer in BERT model, with optional mask processing.
 The embedding layer takes input_ids (word IDs) and segment_ids (sentence IDs) to look up word_embedding, position_embedding,

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -497,7 +497,7 @@ will be calculated.)DOC";
       .Input(6, "beta", "1D beta tensor for layer normalization  with shape (hidden_size)", "T")
       .Input(7, "mask", "2D attention mask with shape (batch_size, sequence_length)", "T1", OpSchema::Optional)
       .Output(0, "output", "3D output tensor with shape (batch_size, sequence_length, hidden_size)", "T")
-      .Output(1, "mask_index", "1D mask_index tensor with shape (batch_size)", "T1")
+      .Output(1, "mask_index", "1D mask_index tensor with shape (2 * batch_size)", "T1")
       .TypeConstraint("T1", {"tensor(int32)"}, "Constrain input and output integer tensors types")
       .TypeConstraint("T", {"tensor(float)", "tensor(float16)"}, "Constrain input and output float tensors types.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
@@ -535,9 +535,10 @@ will be calculated.)DOC";
 
         updateOutputShape(ctx, 0, output_shape);
 
-        // mask_index shape is (batch_size)
+        // mask_index shape is (2 * batch_size)
         ONNX_NAMESPACE::TensorShapeProto mask_index_shape;
-        *mask_index_shape.add_dim() = input_ids_dims[0];
+        mask_index_shape.add_dim();
+        mask_index_shape.mutable_dim(0)->set_dim_value(2 * input_ids_shape.dim(0).dim_value());
         updateOutputShape(ctx, 1, mask_index_shape);
       });
 

--- a/onnxruntime/test/contrib_ops/embedlayernorm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/embedlayernorm_op_test.cc
@@ -61,7 +61,7 @@ static void RunTest(
     std::vector<int64_t> gamma_dims = {hidden_size};
     std::vector<int64_t> beta_dims = gamma_dims;
     std::vector<int64_t> output_dims = {batch_size, sequence_length, hidden_size};
-    std::vector<int64_t> mask_index_dims = {batch_size};
+    std::vector<int64_t> mask_index_dims = {2 * batch_size};
 
     OpTester tester("EmbedLayerNormalization", 1, onnxruntime::kMSDomain);
     tester.AddInput<int32_t>("input_ids", input_ids_dims, input_ids_data);
@@ -75,6 +75,8 @@ static void RunTest(
       tester.AddAttribute("epsilon", epsilon);
       if (has_mask) {
         tester.AddInput<int32_t>("mask", mask_dims, mask_data);
+      } else {
+        tester.AddMissingOptionalInput<int32_t>();
       }
       tester.AddOutput<MLFloat16>("output", output_dims, ToFloat16(output_data));
     } else {
@@ -86,6 +88,8 @@ static void RunTest(
       tester.AddAttribute("epsilon", epsilon);
       if (has_mask) {
         tester.AddInput<int32_t>("mask", mask_dims, mask_data);
+      } else {
+        tester.AddMissingOptionalInput<int32_t>();
       }
       tester.AddOutput<float>("output", output_dims, output_data);
     }
@@ -136,7 +140,7 @@ TEST(EmbedLayerNormTest, EmbedLayerNormBatch1) {
       0.74301940202713013, -0.057434864342212677, 0.84324657917022705, -0.85171419382095337};
 
   std::vector<int32_t> mask_index_data = {
-      2};
+      2, 0};
 
   RunTest(input_ids_data,
           segment_ids_data,
@@ -196,7 +200,7 @@ TEST(EmbedLayerNormTest, EmbedLayerNormBatch1_Float16) {
       0.7431640625, -0.057586669921875, 0.84326171875, -0.8525390625};
 
   std::vector<int32_t> mask_index_data = {
-      2};
+      2, 0};
 
   RunTest(input_ids_data,
           segment_ids_data,
@@ -267,7 +271,7 @@ TEST(EmbedLayerNormTest, EmbedLayerNormBatch2) {
       0.64977931976318359, 0.11039737612009048, 1.1869535446166992, 0.14469735324382782};
 
   std::vector<int32_t> mask_index_data = {
-      2, 2, 1};
+      2, 2, 1, 0, 0, 0};
 
   RunTest(input_ids_data,
           segment_ids_data,
@@ -333,7 +337,7 @@ TEST(EmbedLayerNormTest, EmbedLayerNormBatch2_NoMask) {
       0.57668739557266235, 0.2979130744934082, 0.96158987283706665, 0.44627034664154053,
       0.64977931976318359, 0.11039737612009048, 1.1869535446166992, 0.14469735324382782};
 
-  std::vector<int32_t> mask_index_data = {0, 0, 0};
+  std::vector<int32_t> mask_index_data = {2, 2, 2, 0, 0, 0};
 
   RunTest(input_ids_data,
           segment_ids_data,
@@ -350,7 +354,7 @@ TEST(EmbedLayerNormTest, EmbedLayerNormBatch2_NoMask) {
           sequence_length,
           hidden_size,
           false,
-          false); // no mask
+          false);  // no mask
 }
 
 // BatchSize > HiddenSize to reproduce mask processing bug
@@ -416,7 +420,7 @@ TEST(EmbedLayerNormTest, EmbedLayerNormLargeBatchSmallHiddenSize) {
       0.64977931976318359, 0.11039737612009048, 1.1869535446166992, 0.14469735324382782};
 
   std::vector<int32_t> mask_index_data = {
-      2, 2, 1, 2, 1};
+      2, 2, 1, 2, 1, 0, 0, 0, 0, 0};
 
   RunTest(input_ids_data,
           segment_ids_data,
@@ -433,5 +437,6 @@ TEST(EmbedLayerNormTest, EmbedLayerNormLargeBatchSmallHiddenSize) {
           sequence_length,
           hidden_size);
 }
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/mask_index_op_test.cc
+++ b/onnxruntime/test/contrib_ops/mask_index_op_test.cc
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "test/common/tensor_op_test_utils.h"
+#include "test/common/cuda_op_test_utils.h"
+#include "test/providers/provider_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+template <typename T>
+void RunTest(
+    const std::vector<T>& mask_data,
+    const std::vector<int32_t>& mask_index_data,
+    int batch_size,
+    int sequence_length,
+    bool invalid_mask = false) {
+  bool enable_cuda = HasCudaEnvironment(0);
+  bool enable_cpu = (nullptr != DefaultCpuExecutionProvider().get());
+
+  if (enable_cuda || enable_cpu) {
+    // Input and output shapes
+    std::vector<int64_t> mask_dims = {batch_size, sequence_length};
+    std::vector<int64_t> mask_index_dims = {2 * batch_size};
+
+    OpTester tester("MaskIndex", 1, onnxruntime::kMSDomain);
+    tester.AddInput<T>("mask", mask_dims, mask_data);
+    tester.AddOutput<int32_t>("mask_index", mask_index_dims, mask_index_data);
+
+    if (enable_cuda) {
+      std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+      execution_providers.push_back(DefaultCudaExecutionProvider());
+      tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+    }
+
+    if (enable_cpu) {
+      std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+      execution_providers.push_back(DefaultCpuExecutionProvider());
+      if (invalid_mask) {
+        tester.Run(OpTester::ExpectResult::kExpectFailure, "", {}, nullptr, &execution_providers);
+      } else {
+        tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+      }
+    }
+  }
+}
+
+TEST(MaskIndexTest, MaskIndexTest_batch1_int64) {
+  int batch_size = 1;
+  int sequence_length = 2;
+
+  std::vector<int64_t> mask_data = {
+      1, 1};
+
+  std::vector<int32_t> mask_index_data = {
+      2, 0};
+
+  RunTest(mask_data,
+          mask_index_data,
+          batch_size,
+          sequence_length);
+}
+
+TEST(MaskIndexTest, MaskIndexTest_batch4_int32) {
+  int batch_size = 4;
+  int sequence_length = 2;
+
+  std::vector<int32_t> mask_data = {
+      0, 0,   // All 0
+      1, 1,   // All 1
+      1, 0,   // Right padding
+      0, 1};  // Left padding
+
+  std::vector<int32_t> mask_index_data = {
+      0, 2, 1, 2,
+      2, 0, 0, 1};
+
+  RunTest(mask_data,
+          mask_index_data,
+          batch_size,
+          sequence_length);
+}
+
+TEST(MaskIndexTest, MaskIndexTest_batch4_int64) {
+  int batch_size = 4;
+  int sequence_length = 2;
+
+  std::vector<int64_t> mask_data = {
+      0, 0,   // All 0
+      1, 1,   // All 1
+      1, 0,   // Right padding
+      0, 1};  // Left padding
+
+  std::vector<int32_t> mask_index_data = {
+      0, 2, 1, 2,
+      2, 0, 0, 1};
+
+  RunTest(mask_data,
+          mask_index_data,
+          batch_size,
+          sequence_length);
+}
+
+TEST(MaskIndexTest, MaskIndexTest_float) {
+  int batch_size = 4;
+  int sequence_length = 3;
+
+  std::vector<float> mask_data = {
+      0.0, 0.0, 0.0,  // All 0
+      1.0, 1.0, 1.0,  // All 1
+      1.0, 0.0, 0.0,  // Right padding
+      0.0, 1.0, 1.0   // Left padding
+  };
+
+  std::vector<int32_t> mask_index_data = {
+      0, 3, 1, 3,
+      3, 0, 0, 1};
+
+  RunTest(mask_data,
+          mask_index_data,
+          batch_size,
+          sequence_length);
+}
+
+TEST(MaskIndexTest, MaskIndexTest_invalid_mask) {
+  int batch_size = 1;
+  int sequence_length = 3;
+
+  std::vector<float> mask_data = {
+      1.0, 0.0, 1.0  // Middle padding (invalid)
+  };
+
+  std::vector<int32_t> mask_index_data = {
+      3, 0};  // Expected result for cuda.
+
+  RunTest(mask_data,
+          mask_index_data,
+          batch_size,
+          sequence_length,
+          true);  // For CPU, expect failuare.
+}
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
**Description**: 

Add MaskIndex op to output both start and end positions of attention mask. It could be used for experiments later.
Update EmbedLayerNormalization to output same format of mask_index.

Performance is on par for Bert when EmbedLayerNormalization is fused.
For GPT-2 without EmbedLayerNormalization fusion, it seems that adding an extra node of MergeIndex has negative impact on GPU performance.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

Mask index with end position requires input to be right-side padding. New format of mask index could support both left-side and right-side padding. It is more flexible.