### PR TITLE
Add exception check in training_runner when worker runs into error, and misc check on nccl and mpi calls

### DIFF
--- a/orttraining/orttraining/core/framework/mpi_setup.h
+++ b/orttraining/orttraining/core/framework/mpi_setup.h
@@ -11,6 +11,19 @@
 namespace onnxruntime {
 namespace training {
 
+#define MPI_CHECK(condition)                                 \
+  do {                                                       \
+    int error = (condition);                                 \
+    ORT_ENFORCE(                                             \
+        error == MPI_SUCCESS,                                \
+        "MPI Error at: ",                                    \
+        __FILE__,                                            \
+        ":",                                                 \
+        __LINE__,                                            \
+        ": ",                                                \
+        error);                                              \
+  } while (0)
+
 struct MPIContext {
   MPIContext(int world_rank = 0, int local_rank = 0, int world_size = 1, int local_size = 1);
   int world_rank;

--- a/orttraining/orttraining/models/runner/pipeline.h
+++ b/orttraining/orttraining/models/runner/pipeline.h
@@ -214,6 +214,7 @@ struct PipelineWorkerState {
   std::vector<MLValue> feeds;
   std::vector<std::string> fetch_names;
   std::vector<MLValue> fetches;
+  std::exception_ptr execution_exception{nullptr};
 };
 
 struct PipelineWorkerPool {

--- a/orttraining/orttraining/models/runner/training_runner.cc
+++ b/orttraining/orttraining/models/runner/training_runner.cc
@@ -683,7 +683,7 @@ void TrainingRunner::RunWithUpdate(VectorString& feed_names,
           &(pipeline_worker_pool_.worker_states[worker_id].fetches));
 
       ORT_THROW_IF_ERROR(status);
-    } catch (std::exception& e) {
+    } catch (std::exception&) {
       // If exception happens during worker execution, propogate the exception to main thread.
       pipeline_worker_pool_.worker_states[worker_id].execution_exception = std::current_exception();
     }
@@ -782,7 +782,7 @@ void TrainingRunner::RunWithoutUpdate(VectorString& feed_names,
           pipeline_worker_pool_.worker_states[worker_id].fetch_names,
           &(pipeline_worker_pool_.worker_states[worker_id].fetches));
       ORT_THROW_IF_ERROR(status);
-    } catch (std::exception& e) {
+    } catch (std::exception&) {
       pipeline_worker_pool_.worker_states[worker_id].execution_exception = std::current_exception();
     }
   },

--- a/orttraining/orttraining/models/runner/training_runner.cc
+++ b/orttraining/orttraining/models/runner/training_runner.cc
@@ -631,6 +631,19 @@ Status TrainingRunner::PrepareFetchNamesAndFetches(const SessionMode mode,
   return Status::OK();
 }
 
+// If any exceptions happen during worker execution, it means there is an error
+// during training. The worker thread propagates the exception to the main thread so
+// we can properly cleanup and exit the execution.
+void TrainingRunner::CheckWorkerException(const std::exception_ptr& p) {
+  try {
+    if (p) {
+      std::rethrow_exception(p);
+    }
+  } catch (const std::exception& e) {
+    ORT_THROW("Error in worker thread: ", e.what());
+  }
+}
+
 // Launch synced session.Run on the main thread.
 void TrainingRunner::RunWithUpdate(VectorString& feed_names,
                                    VectorString& fetch_names,
@@ -642,6 +655,7 @@ void TrainingRunner::RunWithUpdate(VectorString& feed_names,
   // Wait for the previous work to finish its job.
   // Its resource cannot be overrided when it's still working.
   pipeline_worker_pool_.Join(worker_id);
+  CheckWorkerException(pipeline_worker_pool_.worker_states[worker_id].execution_exception);
 
   // Copy thread-used variable to thread-specific buffer to maintain their life.
   pipeline_worker_pool_.worker_states[worker_id].feed_names = feed_names;
@@ -649,25 +663,30 @@ void TrainingRunner::RunWithUpdate(VectorString& feed_names,
   pipeline_worker_pool_.worker_states[worker_id].fetch_names = fetch_names;
   pipeline_worker_pool_.worker_states[worker_id].fetches = std::vector<MLValue>();
 
-  Status status = Status::OK();
-  pipeline_worker_pool_.workers[worker_id] = std::thread([&](
-                                                             const size_t worker_id, const size_t step) {
+  pipeline_worker_pool_.workers[worker_id] = std::thread([&](const size_t worker_id, const size_t step) {
+    try {
 #ifdef ENABLE_NVTX_PROFILE
-    // Store the tag for the thread which runs session_.Run(...).
-    // It will be used to name range in Nvidia's visual profiler.
-    auto& profile_context = profile::Context::GetInstance();
-    profile_context.SetThreadTag(
-        std::this_thread::get_id(), std::to_string(step));
+      // Store the tag for the thread which runs session_.Run(...).
+      // It will be used to name range in Nvidia's visual profiler.
+      auto& profile_context = profile::Context::GetInstance();
+      profile_context.SetThreadTag(
+          std::this_thread::get_id(), std::to_string(step));
 #else
-    ORT_UNUSED_PARAMETER(step);
+      ORT_UNUSED_PARAMETER(step);
 #endif
-    RunOptions run_options;
-    status = session_.Run(
-        run_options,
-        pipeline_worker_pool_.worker_states[worker_id].feed_names,
-        pipeline_worker_pool_.worker_states[worker_id].feeds,
-        pipeline_worker_pool_.worker_states[worker_id].fetch_names,
-        &(pipeline_worker_pool_.worker_states[worker_id].fetches));
+      RunOptions run_options;
+      auto status = session_.Run(
+          run_options,
+          pipeline_worker_pool_.worker_states[worker_id].feed_names,
+          pipeline_worker_pool_.worker_states[worker_id].feeds,
+          pipeline_worker_pool_.worker_states[worker_id].fetch_names,
+          &(pipeline_worker_pool_.worker_states[worker_id].fetches));
+
+      ORT_THROW_IF_ERROR(status);
+    } catch (std::exception& e) {
+      // If exception happens during worker execution, propogate the exception to main thread.
+      pipeline_worker_pool_.worker_states[worker_id].execution_exception = std::current_exception();
+    }
   },
                                                          worker_id, step_);
 
@@ -676,9 +695,9 @@ void TrainingRunner::RunWithUpdate(VectorString& feed_names,
   // We must join here because main thread needs to access thread-produced
   // fetches and those fetches must be ready.
   pipeline_worker_pool_.JoinAll();
-
-  // If the updating thread fails, we return with its error status.
-  ORT_THROW_IF_ERROR(status);
+  for(auto& status : pipeline_worker_pool_.worker_states){
+    CheckWorkerException(status.execution_exception);
+  }
 
   // Copy back from thread-specific buffer to main thread's memory.
   fetches = pipeline_worker_pool_.worker_states[worker_id].fetches;
@@ -711,6 +730,9 @@ void TrainingRunner::RunWithUpdate(VectorString& feed_names,
   // Wait all workers to finish this around of pipeline parallism.
   // The last batch in a pipeline collects gradient and update the model.
   pipeline_worker_pool_.JoinAll();
+  for(auto& status : pipeline_worker_pool_.worker_states){
+    CheckWorkerException(status.execution_exception);
+  }
 
   // Add one after process one batch.
   ++step_;
@@ -729,6 +751,7 @@ void TrainingRunner::RunWithoutUpdate(VectorString& feed_names,
   // Wait for the previous work to finish its job.
   // Its resource cannot be overrided when it's still working.
   pipeline_worker_pool_.Join(worker_id);
+  CheckWorkerException(pipeline_worker_pool_.worker_states[worker_id].execution_exception);
 
   // Prepare async launch of session.
   // All used variables have to be copied to a buffer object to maintain their lifetime.
@@ -738,27 +761,30 @@ void TrainingRunner::RunWithoutUpdate(VectorString& feed_names,
   pipeline_worker_pool_.worker_states[worker_id].fetches = std::vector<MLValue>();
 
   // Async launch of a session.
-  pipeline_worker_pool_.workers[worker_id] = std::thread([&](
-                                                             const size_t worker_id, const size_t step) {
+  pipeline_worker_pool_.workers[worker_id] = std::thread([&](const size_t worker_id, const size_t step) {
+    try {
 #ifdef ENABLE_NVTX_PROFILE
-    // Store the tag for the thread which runs session_.Run(...).
-    // It will be used to name range in Nvidia's visual profiler.
-    auto& profile_context = profile::Context::GetInstance();
-    profile_context.SetThreadTag(
-        std::this_thread::get_id(), std::to_string(step));
+      // Store the tag for the thread which runs session_.Run(...).
+      // It will be used to name range in Nvidia's visual profiler.
+      auto& profile_context = profile::Context::GetInstance();
+      profile_context.SetThreadTag(
+          std::this_thread::get_id(), std::to_string(step));
 #else
-    ORT_UNUSED_PARAMETER(step);
+      ORT_UNUSED_PARAMETER(step);
 #endif
-    RunOptions run_options;
-    run_options.only_execute_path_to_fetches = true;
-    run_options.training_mode = true;
-    auto status = session_.Run(
-        run_options,
-        pipeline_worker_pool_.worker_states[worker_id].feed_names,
-        pipeline_worker_pool_.worker_states[worker_id].feeds,
-        pipeline_worker_pool_.worker_states[worker_id].fetch_names,
-        &(pipeline_worker_pool_.worker_states[worker_id].fetches));
-    ORT_THROW_IF_ERROR(status);
+      RunOptions run_options;
+      run_options.only_execute_path_to_fetches = true;
+      run_options.training_mode = true;
+      auto status = session_.Run(
+          run_options,
+          pipeline_worker_pool_.worker_states[worker_id].feed_names,
+          pipeline_worker_pool_.worker_states[worker_id].feeds,
+          pipeline_worker_pool_.worker_states[worker_id].fetch_names,
+          &(pipeline_worker_pool_.worker_states[worker_id].fetches));
+      ORT_THROW_IF_ERROR(status);
+    } catch (std::exception& e) {
+      pipeline_worker_pool_.worker_states[worker_id].execution_exception = std::current_exception();
+    }
   },
                                                          worker_id, step_);
 

--- a/orttraining/orttraining/models/runner/training_runner.h
+++ b/orttraining/orttraining/models/runner/training_runner.h
@@ -213,6 +213,7 @@ class TrainingRunner {
                         VectorString& fetch_names,
                         std::vector<MLValue>& feeds,
                         size_t& gradient_accumulation_step_count);
+  void CheckWorkerException(const std::exception_ptr& p);
   Status TrainingLoop(IDataLoader& training_data_loader, IDataLoader* test_data_loader,
     const MapStringToString& mapped_dimensions);
   Status Evaluate(TrainingSession& session, IDataLoader& data_loader);


### PR DESCRIPTION
**Description**: This change adds more check on nccl communicator creation, updates mpi error handling in send/recv and adds a check in training_runner to better handle if worker thread runs into exception.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
