### PR TITLE
Change the way java home is set on Mac OS for CI and Java publishing pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/java-api-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/java-api-packaging-pipelines.yml
@@ -45,9 +45,7 @@ jobs:
     - template: templates/set-version-number-variables-step.yml
 
     - script: |
-        export JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home
-        java --version
-        javac --version
+        export JAVA_HOME=$(java_home -v 11)
         sudo python3 -m pip install -r '$(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/requirements.txt'
         sudo xcode-select --switch /Applications/Xcode_10.app/Contents/Developer
         python3 $(Build.SourcesDirectory)/tools/ci_build/build.py --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --parallel --build_java --build_shared_lib --config RelWithDebInfo

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -24,7 +24,7 @@ jobs:
       inputs:
         versionSpec: '12.x'
     - script: |
-        export JAVA_HOME=$(java_home -v 11) 
+        export JAVA_HOME=$(java_home -v 11)
 
         sudo python3 -m pip install -r '$(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/requirements.txt'
         sudo xcode-select --switch /Applications/Xcode_10.app/Contents/Developer

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -24,9 +24,7 @@ jobs:
       inputs:
         versionSpec: '12.x'
     - script: |
-        export JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home
-        java --version
-        javac --version
+        export JAVA_HOME=$(java_home -v 11) 
 
         sudo python3 -m pip install -r '$(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/requirements.txt'
         sudo xcode-select --switch /Applications/Xcode_10.app/Contents/Developer


### PR DESCRIPTION
**Description**: 
Detect JAVA_HOME in the environment with multiple Java installations on MacOS

**Motivation and Context**
Recent changes in MacOS broke our pipelines.
We want to set java_home in a path independent way.