### PR TITLE
[Vitis-AI EP] Fix Vitis-AI EP for memory info into IAllocator move

### DIFF
--- a/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
@@ -24,7 +24,7 @@ using namespace ::onnxruntime::logging;
 
 namespace onnxruntime {
 
-constexpr const char* PREFIX = "VITISAI";
+constexpr const char* VITISAI = "VITISAI";
 
 typedef std::shared_ptr<pyxir::graph::XGraph> XGraphHolder;
 typedef std::shared_ptr<pyxir::graph::XLayer> XLayerHolder;
@@ -33,14 +33,11 @@ VitisAIExecutionProvider::VitisAIExecutionProvider(const VitisAIExecutionProvide
     : IExecutionProvider{onnxruntime::kVitisAIExecutionProvider}, backend_type_(info.backend_type),
       device_id_(info.device_id) {
 
-  auto default_allocator_factory = [](int) {
-    auto memory_info = onnxruntime::make_unique<OrtMemoryInfo>(PREFIX, OrtAllocatorType::OrtDeviceAllocator);
-    return onnxruntime::make_unique<CPUAllocator>(std::move(memory_info));
-  };
-
   DeviceAllocatorRegistrationInfo default_memory_info{
     OrtMemTypeDefault,
-    std::move(default_allocator_factory),
+    [](int) {
+        return onnxruntime::make_unique<CPUAllocator>(OrtMemoryInfo(VITISAI, OrtAllocatorType::OrtDeviceAllocator));
+    },
     std::numeric_limits<size_t>::max()
   };
 


### PR DESCRIPTION
Fix in Vitis-AI EP for internal Allocator API changes created in commit 175983c which moved memory info into IAllocator and cleaned up the CreateAllocator.

To avoid future inconsistencies being introduced, would it be possible to add the Vitis-AI EP docker build into the CI and how to go about that?

Note that various other EPs seem to be still using the old APIs, for example:
https://github.com/microsoft/onnxruntime/blob/3bb6a865ccb1ffd011c03d1ba28179988f0850f6/onnxruntime/core/providers/armnn/armnn_execution_provider.cc#L78
https://github.com/microsoft/onnxruntime/blob/3bb6a865ccb1ffd011c03d1ba28179988f0850f6/onnxruntime/core/providers/rknpu/rknpu_execution_provider.cc#L55
I didn't try to fix those as I don't have a setup for testing those flows at the moment.