### PR TITLE
Adjustments to MPI and NCCL library discovery on build

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -963,7 +963,7 @@ if (onnxruntime_ENABLE_TRAINING)
     if (MPI_FOUND)
       if(NOT DEFINED onnxruntime_MPI_HOME)
         execute_process(COMMAND mpirun --version OUTPUT_VARIABLE MPIRUN_OUTPUT)
-      else
+      else()
         execute_process(COMMAND ${onnxruntime_MPI_HOME}/bin/mpirun --version OUTPUT_VARIABLE MPIRUN_OUTPUT) 
       endif(NOT DEFINED onnxruntime_MPI_HOME)
       string( REGEX MATCH "[0-9]+.[0-9]+.[0-9]" MPI_VERSION ${MPIRUN_OUTPUT})

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -961,7 +961,11 @@ if (onnxruntime_ENABLE_TRAINING)
     find_package_handle_standard_args(MPI DEFAULT_MSG MPI_INCLUDE_DIR MPI_LIBRARY)
 
     if (MPI_FOUND)
-      execute_process(COMMAND mpirun --version OUTPUT_VARIABLE MPIRUN_OUTPUT)
+      if(NOT DEFINED onnxruntime_MPI_HOME)
+        execute_process(COMMAND mpirun --version OUTPUT_VARIABLE MPIRUN_OUTPUT)
+      else
+        execute_process(COMMAND ${onnxruntime_MPI_HOME}/bin/mpirun --version OUTPUT_VARIABLE MPIRUN_OUTPUT) 
+      endif(NOT DEFINED onnxruntime_MPI_HOME)
       string( REGEX MATCH "[0-9]+.[0-9]+.[0-9]" MPI_VERSION ${MPIRUN_OUTPUT})
       message( STATUS "MPI Version: ${MPI_VERSION}")
 
@@ -991,6 +995,7 @@ if (onnxruntime_ENABLE_TRAINING)
         NAMES ${NCCL_LIBNAME}
         HINTS
         ${onnxruntime_NCCL_HOME}/lib/x86_64-linux-gnu
+        ${onnxruntime_NCCL_HOME}/lib
         $ENV{CUDA_ROOT}/lib64)
 
       include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
**Description**: 
- When --mpi_home is specified, parse MPI version from $MPI_HOME/bin/mpirun.
- When --nccl_home is specified, also search for libnccl.so at $NCCL_HOME/lib.

**Motivation and Context**
When more than one MPI version is available, the build will incorrectly parse the MPI version found on PATH. Rather it should expect and use _mpirun_ at $MPI_HOME/bin/mpirun.

When using the NVIDIA CUDA 10.2 base image, the NCCL header and libraries are at
- /usr/local/cuda-10.2/targets/x86_64-linux/lib/libnccl.so.2
- /usr/local/cuda-10.2/targets/x86_64-linux/include/nccl.h

This does not match expectation of existing hint, and NCCL discovery fails.

This change is needed to change base image for examples repository to NVIDIA CUDA 10.2 from PyTorch 20.03.