### PR TITLE
Add the framework to support prepack

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
@@ -157,6 +157,9 @@ namespace Microsoft.ML.OnnxRuntime
 
         public IntPtr GetAvailableProviders;
         public IntPtr ReleaseAvailableProviders;
+        public IntPtr GetStringTensorElementLength;
+        public IntPtr GetStringTensorElement;
+        public IntPtr FillStringTensorElement;
         public IntPtr EnablePrePacking;
         public IntPtr DisablePrePacking;
     }

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ML.OnnxRuntime
     };
 
     // NOTE: The order of the APIs in this struct should match exactly that in
-    // OrtApi ort_api_1_to_3 (onnxruntime_c_api.cc)
+    // OrtApi ort_api_1_to_4 (onnxruntime_c_api.cc)
     [StructLayout(LayoutKind.Sequential)]
     public struct OrtApi
     {
@@ -138,6 +138,27 @@ namespace Microsoft.ML.OnnxRuntime
         public IntPtr ReleaseMapTypeInfo;
         public IntPtr ReleaseSequenceTypeInfo;
         public IntPtr SessionEndProfiling;
+
+        public IntPtr SessionGetModelMetadata;
+        public IntPtr ModelMetadataGetProducerName;
+        public IntPtr ModelMetadataGetGraphName;
+        public IntPtr ModelMetadataGetDomain;
+        public IntPtr ModelMetadataGetDescription;
+        public IntPtr ModelMetadataLookupCustomMetadataMap;
+        public IntPtr ModelMetadataGetVersion;
+        public IntPtr ReleaseModelMetadata;
+
+        public IntPtr CreateEnvWithGlobalThreadPools;
+        public IntPtr DisablePerSessionThreads;
+        public IntPtr CreateThreadingOptions;
+        public IntPtr ReleaseThreadingOptions;
+        public IntPtr ModelMetadataGetCustomMetadataMapKeys;
+        public IntPtr AddFreeDimensionOverrideByName;
+
+        public IntPtr GetAvailableProviders;
+        public IntPtr ReleaseAvailableProviders;
+        public IntPtr EnablePrePacking;
+        public IntPtr DisablePrePacking;
     }
 
     internal static class NativeMethods
@@ -197,6 +218,8 @@ namespace Microsoft.ML.OnnxRuntime
             OrtSetIntraOpNumThreads = (DOrtSetIntraOpNumThreads)Marshal.GetDelegateForFunctionPointer(api_.SetIntraOpNumThreads, typeof(DOrtSetIntraOpNumThreads));
             OrtSetSessionGraphOptimizationLevel = (DOrtSetSessionGraphOptimizationLevel)Marshal.GetDelegateForFunctionPointer(api_.SetSessionGraphOptimizationLevel, typeof(DOrtSetSessionGraphOptimizationLevel));
             OrtRegisterCustomOpsLibrary = (DOrtRegisterCustomOpsLibrary)Marshal.GetDelegateForFunctionPointer(api_.RegisterCustomOpsLibrary, typeof(DOrtRegisterCustomOpsLibrary));
+            OrtEnablePrePacking = (DOrtEnablePrePacking)Marshal.GetDelegateForFunctionPointer(api_.EnablePrePacking, typeof(DOrtEnablePrePacking));
+            OrtDisablePrePacking = (DOrtDisablePrePacking)Marshal.GetDelegateForFunctionPointer(api_.DisablePrePacking, typeof(DOrtDisablePrePacking));
 
             OrtCreateRunOptions = (DOrtCreateRunOptions)Marshal.GetDelegateForFunctionPointer(api_.CreateRunOptions, typeof(DOrtCreateRunOptions));
             OrtReleaseRunOptions = (DOrtReleaseRunOptions)Marshal.GetDelegateForFunctionPointer(api_.ReleaseRunOptions, typeof(DOrtReleaseRunOptions));
@@ -419,6 +442,12 @@ namespace Microsoft.ML.OnnxRuntime
 
         public delegate IntPtr /*(OrtStatus*)*/ DOrtSetSessionGraphOptimizationLevel(IntPtr /* OrtSessionOptions* */ options, GraphOptimizationLevel graphOptimizationLevel);
         public static DOrtSetSessionGraphOptimizationLevel OrtSetSessionGraphOptimizationLevel;
+
+        public delegate IntPtr /*(OrtStatus*)*/ DOrtEnablePrePacking(IntPtr /* OrtSessionOptions* */ options);
+        public static DOrtEnablePrePacking OrtEnablePrePacking;
+
+        public delegate IntPtr /*(OrtStatus*)*/ DOrtDisablePrePacking(IntPtr /* OrtSessionOptions* */ options);
+        public static DOrtDisablePrePacking OrtDisablePrePacking;
 
         ///**
         //  * The order of invocation indicates the preference order as well. In other words call this method

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.cs
@@ -413,6 +413,32 @@ namespace Microsoft.ML.OnnxRuntime
             }
         }
         private ExecutionMode _executionMode = ExecutionMode.ORT_SEQUENTIAL;
+
+        /// <summary>
+        /// Enables the use of pre-packing. Default = true.
+        /// </summary>
+        public bool EnablePrePacking
+        {
+            get
+            {
+                return _enablePrePacking;
+            }
+            set
+            {
+                if (!_enablePrePacking && value)
+                {
+                    NativeApiStatus.VerifySuccess(NativeMethods.OrtEnablePrePacking(_nativePtr));
+                    _enablePrePacking = true;
+                }
+                else if (_enablePrePacking && !value)
+                {
+                    NativeApiStatus.VerifySuccess(NativeMethods.OrtDisablePrePacking(_nativePtr));
+                    _enablePrePacking = false;
+                }
+            }
+        }
+        private bool _enablePrePacking = true;
+
         #endregion
 
         #region Private Methods

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -43,6 +43,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 Assert.Equal(0, opt.IntraOpNumThreads);
                 Assert.Equal(0, opt.InterOpNumThreads);
                 Assert.Equal(GraphOptimizationLevel.ORT_ENABLE_ALL, opt.GraphOptimizationLevel);
+                Assert.True(opt.EnablePrePacking);
 
                 // try setting options 
                 opt.ExecutionMode = ExecutionMode.ORT_PARALLEL;
@@ -80,6 +81,9 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 Assert.Equal(GraphOptimizationLevel.ORT_ENABLE_EXTENDED, opt.GraphOptimizationLevel);
 
                 Assert.Throws<OnnxRuntimeException>(() => { opt.GraphOptimizationLevel = (GraphOptimizationLevel)10; });
+
+                opt.EnablePrePacking = false;
+                Assert.False(opt.EnablePrePacking);
 
                 opt.AppendExecutionProvider_CPU(1);
 #if USE_DNNL

--- a/include/onnxruntime/core/framework/op_kernel.h
+++ b/include/onnxruntime/core/framework/op_kernel.h
@@ -49,16 +49,17 @@ class OpKernel {
     ORT_NOT_IMPLEMENTED(__FUNCTION__, " is not implemented");
   }
 
-  // Override this function to PrePack the constant Tensor to the format as needed.
+  // Override this function to PrePack initialized constant tensor to the format as needed.
   // For example, MatMul kernel can pack the input B if it is constant like code below.
   //   Status PrePack(const Tensor& tensor, int input_idx, bool& is_packed) override {
   //     is_packed = false;
   //     if (input_idx == 1) {
   //       this.Pack(tensor, this.buffer_);
+  //       is_packed = true;
   //     }
   //     return Status::OK();
   //   }
-
+  // Please refer to MatMulIntegerToFloatBase for a complete example
   // @param tesnor: The initialized constant tensor
   // @param input_idx: The input index of the tensor in this kernel
   // @param is_packed: Set it to true if the kernel packed the tensor or to false

--- a/include/onnxruntime/core/framework/op_kernel.h
+++ b/include/onnxruntime/core/framework/op_kernel.h
@@ -49,6 +49,26 @@ class OpKernel {
     ORT_NOT_IMPLEMENTED(__FUNCTION__, " is not implemented");
   }
 
+  // Override this function to PrePack the constant Tensor to the format as needed.
+  // For example, MatMul kernel can pack the input B if it is constant like code below.
+  //   Status PrePack(const Tensor& tensor, int input_idx, bool& is_packed) override {
+  //     is_packed = false;
+  //     if (input_idx == 1) {
+  //       this.Pack(tensor, this.buffer_);
+  //     }
+  //     return Status::OK();
+  //   }
+
+  // @param tesnor: The initialized constant tensor
+  // @param input_idx: The input index of the tensor in this kernel
+  // @param is_packed: Set it to true if the kernel packed the tensor or to false
+  //                   The kernel is responsible keep the packed data and related metadata if is_packed is set to true
+  //                   And the original intialized constant tensor will be released and not accessible anymore in Compute function.
+  virtual Status PrePack(const Tensor& /*tensor*/, int /*input_idx*/, bool& is_packed) {
+    is_packed = false;
+    return Status::OK();
+  }
+
   const OrtMemoryInfo& Allocator(int id, OrtMemType mem_type) const {
     return op_kernel_info_.GetMemoryInfo(id, mem_type);
   }

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -826,15 +826,15 @@ struct OrtApi {
    * The caller is responsible for freeing each char * and the pointer
    * array by calling ReleaseAvailableProviders().
    */
-  ORT_API2_STATUS(GetAvailableProviders, _Outptr_ char ***out_ptr,
-                  _In_ int *provider_length);
+  ORT_API2_STATUS(GetAvailableProviders, _Outptr_ char*** out_ptr,
+                  _In_ int* provider_length);
 
   /**
    * \param ptr is the pointer to an array of available providers you
    * get after calling GetAvailableProviders().
    * \param providers_length is the number of available providers.
    */
-  ORT_API2_STATUS(ReleaseAvailableProviders, _In_ char **ptr,
+  ORT_API2_STATUS(ReleaseAvailableProviders, _In_ char** ptr,
                   _In_ int providers_length);
 
   /**
@@ -857,6 +857,10 @@ struct OrtApi {
      * \param index index of string tensor element to fill 
      */
   ORT_API2_STATUS(FillStringTensorElement, _Inout_ OrtValue* value, _In_ const char* s, size_t index);
+  
+  // Control pre-packing of initialized constant tensors
+  ORT_API2_STATUS(EnablePrePacking, _Inout_ OrtSessionOptions* options);
+  ORT_API2_STATUS(DisablePrePacking, _Inout_ OrtSessionOptions* options);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -195,6 +195,10 @@ struct SessionOptions : Base<OrtSessionOptions> {
   SessionOptions& Add(OrtCustomOpDomain* custom_op_domain);
 
   SessionOptions& DisablePerSessionThreads();
+
+  SessionOptions& EnablePrePacking();
+  SessionOptions& DisablePrePacking();
+
 };
 
 struct ModelMetadata : Base<OrtModelMetadata> {

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -229,6 +229,15 @@ inline SessionOptions& SessionOptions::Add(OrtCustomOpDomain* custom_op_domain) 
   return *this;
 }
 
+inline SessionOptions& SessionOptions::EnablePrePacking() {
+  ThrowOnError(GetApi().EnablePrePacking(p_));
+  return *this;
+}
+inline SessionOptions& SessionOptions::DisablePrePacking() {
+  ThrowOnError(GetApi().DisablePrePacking(p_));
+  return *this;
+}
+
 inline Session::Session(Env& env, const ORTCHAR_T* model_path, const SessionOptions& options) {
   ThrowOnError(GetApi().CreateSession(env, model_path, options, &p_));
 }

--- a/onnxruntime/contrib_ops/cpu/bert/attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_base.h
@@ -12,9 +12,9 @@ namespace contrib {
 class AttentionBase {
  protected:
   AttentionBase(const OpKernelInfo& info);
-  Status CheckInputs(const Tensor* input,
-                     const Tensor* weights,
-                     const Tensor* bias,
+  Status CheckInputs(const TensorShape& input_shape,
+                     const TensorShape& weights_shape,
+                     const TensorShape& bias_shape,
                      const Tensor* mask_index,
                      const Tensor* past) const;
 

--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
@@ -20,37 +20,7 @@ class MatMulIntegerToFloatBase : public OpKernel {
   }
 
 #ifdef MLAS_SUPPORTS_PACKED_GEMM_U8X8
-  Status PrePack(const Tensor& tensor, int input_idx, bool& is_packed) override {
-    is_packed = false;
-
-    // only pack Matrix B
-    if (input_idx == 1) {
-      // Only handle the common case of a 2D weight matrix. Additional matrices
-      // could be handled by stacking the packed buffers.
-      b_shape_ = tensor.Shape();
-      if (b_shape_.NumDimensions() != 2) {
-        return Status::OK();
-      }
-
-      const size_t K = static_cast<size_t>(b_shape_[0]);
-      const size_t N = static_cast<size_t>(b_shape_[1]);
-
-      const auto* b_data = static_cast<const uint8_t*>(tensor.DataRaw());
-      b_is_signed_ = tensor.IsDataType<int8_t>();
-
-      const size_t packed_b_size = MlasGemmPackBSize(N, K, b_is_signed_);
-      if (packed_b_size == 0) {
-        return Status::OK();
-      }
-
-      auto alloc = Info().GetAllocator(0, OrtMemTypeDefault);
-      auto* packed_b_data = alloc->Alloc(packed_b_size);
-      packed_b_ = BufferUniquePtr(packed_b_data, BufferDeleter(alloc));
-      MlasGemmPackB(N, K, b_data, N, b_is_signed_, packed_b_data);
-      is_packed = true;
-    }
-    return Status::OK();
-  }
+  Status PrePack(const Tensor& tensor, int input_idx, bool& is_packed) override;
 #endif
 
  protected:
@@ -63,12 +33,44 @@ class MatMulIntegerToFloatBase : public OpKernel {
                        float multiplier,
                        const Tensor* bias_tensor) const;
 
-#ifdef MLAS_SUPPORTS_PACKED_GEMM_U8X8
   bool b_is_signed_;
   TensorShape b_shape_;
   BufferUniquePtr packed_b_;
-#endif
 };
+
+#ifdef MLAS_SUPPORTS_PACKED_GEMM_U8X8
+Status MatMulIntegerToFloatBase::PrePack(const Tensor& tensor, int input_idx, bool& is_packed) {
+  is_packed = false;
+
+  // only pack Matrix B
+  if (input_idx == 1) {
+    // Only handle the common case of a 2D weight matrix. Additional matrices
+    // could be handled by stacking the packed buffers.
+    b_shape_ = tensor.Shape();
+    if (b_shape_.NumDimensions() != 2) {
+      return Status::OK();
+    }
+
+    const size_t K = static_cast<size_t>(b_shape_[0]);
+    const size_t N = static_cast<size_t>(b_shape_[1]);
+
+    const auto* b_data = static_cast<const uint8_t*>(tensor.DataRaw());
+    b_is_signed_ = tensor.IsDataType<int8_t>();
+
+    const size_t packed_b_size = MlasGemmPackBSize(N, K, b_is_signed_);
+    if (packed_b_size == 0) {
+      return Status::OK();
+    }
+
+    auto alloc = Info().GetAllocator(0, OrtMemTypeDefault);
+    auto* packed_b_data = alloc->Alloc(packed_b_size);
+    packed_b_ = BufferUniquePtr(packed_b_data, BufferDeleter(alloc));
+    MlasGemmPackB(N, K, b_data, N, b_is_signed_, packed_b_data);
+    is_packed = true;
+  }
+  return Status::OK();
+}
+#endif
 
 Status MatMulIntegerToFloatBase::ComputeCommon(OpKernelContext* ctx,
                                                const uint8_t* a_data,

--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
@@ -17,11 +17,43 @@ namespace contrib {
 class MatMulIntegerToFloatBase : public OpKernel {
  public:
   MatMulIntegerToFloatBase(const OpKernelInfo& info) : OpKernel(info) {
-    TryPackWeights(info);
   }
 
+#ifdef MLAS_SUPPORTS_PACKED_GEMM_U8X8
+  Status PrePack(const Tensor& tensor, int input_idx, bool& is_packed) override {
+    is_packed = false;
+
+    // only pack Matrix B
+    if (input_idx == 1) {
+      // Only handle the common case of a 2D weight matrix. Additional matrices
+      // could be handled by stacking the packed buffers.
+      b_shape_ = tensor.Shape();
+      if (b_shape_.NumDimensions() != 2) {
+        return Status::OK();
+      }
+
+      const size_t K = static_cast<size_t>(b_shape_[0]);
+      const size_t N = static_cast<size_t>(b_shape_[1]);
+
+      const auto* b_data = static_cast<const uint8_t*>(tensor.DataRaw());
+      b_is_signed_ = tensor.IsDataType<int8_t>();
+
+      const size_t packed_b_size = MlasGemmPackBSize(N, K, b_is_signed_);
+      if (packed_b_size == 0) {
+        return Status::OK();
+      }
+
+      auto alloc = Info().GetAllocator(0, OrtMemTypeDefault);
+      auto* packed_b_data = alloc->Alloc(packed_b_size);
+      packed_b_ = BufferUniquePtr(packed_b_data, BufferDeleter(alloc));
+      MlasGemmPackB(N, K, b_data, N, b_is_signed_, packed_b_data);
+      is_packed = true;
+    }
+    return Status::OK();
+  }
+#endif
+
  protected:
-  void TryPackWeights(const OpKernelInfo& info);
   Status ComputeCommon(OpKernelContext* ctx,
                        const uint8_t* a_data,
                        const TensorShape& a_shape,
@@ -32,44 +64,11 @@ class MatMulIntegerToFloatBase : public OpKernel {
                        const Tensor* bias_tensor) const;
 
 #ifdef MLAS_SUPPORTS_PACKED_GEMM_U8X8
+  bool b_is_signed_;
+  TensorShape b_shape_;
   BufferUniquePtr packed_b_;
 #endif
 };
-
-void MatMulIntegerToFloatBase::TryPackWeights(const OpKernelInfo& info) {
-#ifdef MLAS_SUPPORTS_PACKED_GEMM_U8X8
-  // Check if the weights tensor is constant.
-  const Tensor* b;
-  if (!info.TryGetConstantInput(1, &b)) {
-    return;
-  }
-
-  // Only handle the common case of a 2D weight matrix. Additional matrices
-  // could be handled by stacking the packed buffers.
-  const auto& b_shape = b->Shape();
-  if (b_shape.NumDimensions() != 2) {
-    return;
-  }
-
-  const size_t K = static_cast<size_t>(b_shape[0]);
-  const size_t N = static_cast<size_t>(b_shape[1]);
-
-  const auto* b_data = static_cast<const uint8_t*>(b->DataRaw());
-  const bool b_is_signed = b->IsDataType<int8_t>();
-
-  const size_t packed_b_size = MlasGemmPackBSize(N, K, b_is_signed);
-  if (packed_b_size == 0) {
-    return;
-  }
-
-  auto alloc = info.GetAllocator(0, OrtMemTypeDefault);
-  auto* packed_b_data = alloc->Alloc(packed_b_size);
-  packed_b_ = BufferUniquePtr(packed_b_data, BufferDeleter(alloc));
-  MlasGemmPackB(N, K, b_data, N, b_is_signed, packed_b_data);
-#else
-  ORT_UNUSED_PARAMETER(info);
-#endif
-}
 
 Status MatMulIntegerToFloatBase::ComputeCommon(OpKernelContext* ctx,
                                                const uint8_t* a_data,
@@ -80,15 +79,13 @@ Status MatMulIntegerToFloatBase::ComputeCommon(OpKernelContext* ctx,
                                                float multiplier,
                                                const Tensor* bias_tensor) const {
   MatMulComputeHelper helper;
-  ORT_RETURN_IF_ERROR(helper.Compute(a_shape, b->Shape()));
+  ORT_RETURN_IF_ERROR(helper.Compute(a_shape, packed_b_ ? b_shape_ : b->Shape()));
   Tensor* y = ctx->Output(0, helper.OutputShape());
 
   // Bail out early if the output is going to be empty
   if (y->Shape().Size() == 0)
     return Status::OK();
 
-  const auto* b_data = static_cast<const uint8_t*>(b->DataRaw());
-  const bool b_is_signed = b->IsDataType<int8_t>();
   auto* y_data = y->template MutableData<float>();
   const auto* bias_data = bias_tensor != nullptr ? bias_tensor->Data<float>() : nullptr;
 
@@ -105,7 +102,7 @@ Status MatMulIntegerToFloatBase::ComputeCommon(OpKernelContext* ctx,
                a_zero_point,
                packed_b_.get(),
                b_zero_point,
-               b_is_signed,
+               b_is_signed_,
                y_data + helper.OutputOffsets()[i],
                static_cast<size_t>(helper.N()),
                &multiplier,
@@ -114,6 +111,8 @@ Status MatMulIntegerToFloatBase::ComputeCommon(OpKernelContext* ctx,
       continue;
     }
 #endif
+    const auto* b_data = static_cast<const uint8_t*>(b->DataRaw());
+    const bool b_is_signed = b->IsDataType<int8_t>();
     QGemm(static_cast<int>(helper.M()),
           static_cast<int>(helper.N()),
           static_cast<int>(helper.K()),
@@ -167,15 +166,15 @@ static void GetQuantizationParameter(const float* data, int64_t num_of_elements,
 }
 
 Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
-  const auto* a = ctx->Input<Tensor>(0);
-  const auto* b = ctx->Input<Tensor>(1);
+  const Tensor* a = ctx->Input<Tensor>(0);
+  const Tensor* b = packed_b_ ? nullptr : ctx->Input<Tensor>(1);
 
-  const auto* b_scale_tensor = ctx->Input<Tensor>(2);
+  const Tensor* b_scale_tensor = ctx->Input<Tensor>(2);
   ORT_ENFORCE(IsScalarOr1ElementVector(b_scale_tensor),
               "DynamicQuantizeMatMul : input B scale must be a scalar or 1D tensor of size 1. Per-Channel is not supported yet.");
   float b_scale = *b_scale_tensor->template Data<float>();
 
-  const auto* b_zero_point_tensor = ctx->Input<Tensor>(3);
+  const Tensor* b_zero_point_tensor = ctx->Input<Tensor>(3);
   uint8_t b_zero_point = 0;
   if (b_zero_point_tensor != nullptr) {
     ORT_ENFORCE(IsScalarOr1ElementVector(b_zero_point_tensor),
@@ -184,7 +183,7 @@ Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
   }
 
   // calculate quantization parameter of a
-  const auto* a_data = a->template Data<float>();
+  const float* a_data = a->template Data<float>();
   int64_t num_of_elements = a->Shape().Size();
 
   float a_scale;
@@ -210,7 +209,7 @@ Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
 
 Status MatMulIntegerToFloat::Compute(OpKernelContext* ctx) const {
   const Tensor* a = ctx->Input<Tensor>(0);
-  const Tensor* b = ctx->Input<Tensor>(1);
+  const Tensor* b = packed_b_ ? nullptr : ctx->Input<Tensor>(1);
 
   const Tensor* a_scale_tensor = ctx->Input<Tensor>(2);
   ORT_ENFORCE(IsScalarOr1ElementVector(a_scale_tensor),

--- a/onnxruntime/contrib_ops/cuda/bert/attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/attention.cc
@@ -39,7 +39,7 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
   const Tensor* bias = context->Input<Tensor>(2);
   const Tensor* mask_index = context->Input<Tensor>(3);
   const Tensor* past = context->Input<Tensor>(4);
-  ORT_RETURN_IF_ERROR(CheckInputs(input, weights, bias, mask_index, past));
+  ORT_RETURN_IF_ERROR(CheckInputs(input->Shape(), weights->Shape(), bias->Shape(), mask_index, past));
 
   // Input and output shapes:
   //   Input 0 - input       : (batch_size, sequence_length, hidden_size)

--- a/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.cc
@@ -60,7 +60,7 @@ Status QAttention<T, int8_t>::CheckInputs(const Tensor* input,
   //   Input 7 - weight_zero_point : scalar
   //   Output                      : (batch_size, sequence_length, hidden_size)
 
-  ORT_RETURN_IF_ERROR(AttentionBase::CheckInputs(input, weights, bias, mask_index, past_tensor));
+  ORT_RETURN_IF_ERROR(AttentionBase::CheckInputs(input->Shape(), weights->Shape(), bias->Shape(), mask_index, past_tensor));
 
   ORT_RETURN_IF_NOT(IsScalarOr1ElementVector(input_scale_tensor),
                     "input scale must be a scalar or 1D tensor of size 1");

--- a/onnxruntime/core/framework/finalize_session_state.cc
+++ b/onnxruntime/core/framework/finalize_session_state.cc
@@ -45,7 +45,7 @@ Status FinalizeSessionState(SessionState& session_state,
                             const std::basic_string<PATH_CHAR_TYPE>& graph_location,
                             KernelRegistryManager& kernel_registry_manager,
                             _In_opt_ const Node* parent_node,
-                            ExecutionMode execution_mode) {
+                            const SessionOptions& session_options) {
   session_state.CreateGraphInfo();
 
   const GraphViewer& graph_viewer = session_state.GetGraphViewer();
@@ -70,7 +70,7 @@ Status FinalizeSessionState(SessionState& session_state,
   }
 
   std::unique_ptr<SequentialExecutionPlan> exec_plan;
-  SequentialPlannerContext context(execution_mode);
+  SequentialPlannerContext context(session_options.execution_mode);
   ORT_RETURN_IF_ERROR(SequentialPlanner::CreatePlan(parent_node, graph_viewer, valid_outer_scope_node_args,
                                                     session_state.GetExecutionProviders(), kernel_registry_manager,
                                                     ort_value_name_idx_map, context, exec_plan));
@@ -99,7 +99,9 @@ Status FinalizeSessionState(SessionState& session_state,
   session_state.CleanInitializedTensorsFromGraph();
 
   ORT_RETURN_IF_ERROR(session_state.CreateKernels(kernel_registry_manager));
-  ORT_RETURN_IF_ERROR(session_state.PrepackInitializedConstantTensors());
+  if (session_options.use_prepacking) {
+    ORT_RETURN_IF_ERROR(session_state.PrepackInitializedConstantTensors());
+  }
 
   ORT_RETURN_IF_ERROR(SaveInputOutputNamesToNodeMapping(graph_viewer, kernel_registry_manager, session_state,
                                                         valid_outer_scope_node_args));

--- a/onnxruntime/core/framework/finalize_session_state.cc
+++ b/onnxruntime/core/framework/finalize_session_state.cc
@@ -99,7 +99,7 @@ Status FinalizeSessionState(SessionState& session_state,
   session_state.CleanInitializedTensorsFromGraph();
 
   ORT_RETURN_IF_ERROR(session_state.CreateKernels(kernel_registry_manager));
-  ORT_RETURN_IF_ERROR(session_state.PrepackConstantInitializedTensors());
+  ORT_RETURN_IF_ERROR(session_state.PrepackInitializedConstantTensors());
 
   ORT_RETURN_IF_ERROR(SaveInputOutputNamesToNodeMapping(graph_viewer, kernel_registry_manager, session_state,
                                                         valid_outer_scope_node_args));

--- a/onnxruntime/core/framework/finalize_session_state.cc
+++ b/onnxruntime/core/framework/finalize_session_state.cc
@@ -99,6 +99,8 @@ Status FinalizeSessionState(SessionState& session_state,
   session_state.CleanInitializedTensorsFromGraph();
 
   ORT_RETURN_IF_ERROR(session_state.CreateKernels(kernel_registry_manager));
+  ORT_RETURN_IF_ERROR(session_state.PrepackConstantInitializedTensors());
+
   ORT_RETURN_IF_ERROR(SaveInputOutputNamesToNodeMapping(graph_viewer, kernel_registry_manager, session_state,
                                                         valid_outer_scope_node_args));
   return Status::OK();

--- a/onnxruntime/core/framework/finalize_session_state.h
+++ b/onnxruntime/core/framework/finalize_session_state.h
@@ -20,6 +20,6 @@ Status FinalizeSessionState(SessionState& session_state,
                             const std::basic_string<PATH_CHAR_TYPE>& graph_loc,
                             KernelRegistryManager& kernel_registry_manager,
                             _In_opt_ const Node* parent_node,
-                            ExecutionMode execution_mode = ORT_SEQUENTIAL);
+                            const SessionOptions& session_options);
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/sequential_execution_plan.h
+++ b/onnxruntime/core/framework/sequential_execution_plan.h
@@ -19,7 +19,6 @@ using OrtValueName = std::string;
 
 class SessionState;
 
-// AllocPlanPerValue: (a simplified form of AllocationPlanPerValue above)
 // Captures information required to allocate/reuse buffer for a ml-value
 struct AllocPlanPerValue {
   AllocKind alloc_kind{AllocKind::kAllocate};

--- a/onnxruntime/core/framework/session_options.h
+++ b/onnxruntime/core/framework/session_options.h
@@ -81,5 +81,8 @@ struct SessionOptions {
 
   // Deterministic compute is likely not as performant. This option is default to false.
   bool use_deterministic_compute = false;
+
+  // Control the pre-packing of initialized constant tensors
+  bool use_prepacking = true;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -214,7 +214,7 @@ void SessionState::CleanInitializedTensorsFromGraph() {
   graph_.CleanAllInitializedTensors();
 }
 
-Status SessionState::PrepackConstantInitializedTensors() {
+Status SessionState::PrepackInitializedConstantTensors() {
   // calculate the use count of each value
   std::unordered_map<std::string, size_t> node_arg_use_count;
   for (const auto& node : GetGraphViewer().Nodes()) {
@@ -238,7 +238,7 @@ Status SessionState::PrepackConstantInitializedTensors() {
           bool is_packed = false;
           const Tensor& const_initialized_tensor = constant_initialized_tensors_[ort_value_idx].Get<Tensor>();
           ORT_RETURN_IF_ERROR(kernel->PrePack(const_initialized_tensor, input_idx, is_packed));
-          if (is_packed && node_arg_use_count.count(input_name) && node_arg_use_count[input_name] == 1) {
+          if (is_packed && node_arg_use_count.count(input_name) && --node_arg_use_count[input_name] == 0) {
             // release the constant intialized tensor
             initialized_tensors_[ort_value_idx] = OrtValue();
             constant_initialized_tensors_[ort_value_idx] = OrtValue();

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -240,8 +240,8 @@ Status SessionState::PrepackInitializedConstantTensors() {
           ORT_RETURN_IF_ERROR(kernel->PrePack(const_initialized_tensor, input_idx, is_packed));
           if (is_packed && node_arg_use_count.count(input_name) && --node_arg_use_count[input_name] == 0) {
             // release the constant intialized tensor
-            initialized_tensors_[ort_value_idx] = OrtValue();
-            constant_initialized_tensors_[ort_value_idx] = OrtValue();
+            initialized_tensors_.erase(ort_value_idx);
+            constant_initialized_tensors_.erase(ort_value_idx);
           }
         }
       }

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -214,6 +214,44 @@ void SessionState::CleanInitializedTensorsFromGraph() {
   graph_.CleanAllInitializedTensors();
 }
 
+Status SessionState::PrepackConstantInitializedTensors() {
+  // calculate the use count of each value
+  std::unordered_map<std::string, size_t> node_arg_use_count;
+  for (const auto& node : GetGraphViewer().Nodes()) {
+    node.ForEachDef([&](const onnxruntime::NodeArg& node_arg, bool is_input) {
+      if (is_input) {
+        node_arg_use_count[node_arg.Name()]++;
+      }
+    });
+  }
+
+  for (auto& node : GetGraphViewer().Nodes()) {
+    auto kernel = GetMutableKernel(node.Index());
+    int input_idx = 0;
+    for (auto& input_def : node.InputDefs()) {
+      if (input_def->Exists()) {
+        const std::string& input_name = input_def->Name();
+        int ort_value_idx;
+        ORT_RETURN_IF_ERROR(ort_value_name_idx_map_.GetIdx(input_name, ort_value_idx));
+        if (constant_initialized_tensors_.count(ort_value_idx) &&
+            constant_initialized_tensors_[ort_value_idx].IsTensor()) {
+          bool is_packed = false;
+          const Tensor& const_initialized_tensor = constant_initialized_tensors_[ort_value_idx].Get<Tensor>();
+          ORT_RETURN_IF_ERROR(kernel->PrePack(const_initialized_tensor, input_idx, is_packed));
+          if (is_packed && node_arg_use_count.count(input_name) && node_arg_use_count[input_name] == 1) {
+            // release the constant intialized tensor
+            initialized_tensors_[ort_value_idx] = OrtValue();
+            constant_initialized_tensors_[ort_value_idx] = OrtValue();
+          }
+        }
+      }
+      input_idx++;
+    }
+  }
+
+  return Status::OK();
+}
+
 static int64_t CalculateMemoryPatternsKey(const std::vector<std::reference_wrapper<const TensorShape>>& shapes) {
   int64_t key = 0;
   for (auto shape : shapes) {

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -151,7 +151,7 @@ class SessionState {
   * Prepack the constant initialized tensors for better performance.
   * The original constant initialized tensors will be removed to save memory.
   */
-  Status PrepackConstantInitializedTensors();
+  Status PrepackInitializedConstantTensors();
 
 #ifdef ENABLE_TRAINING
   /**

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -147,6 +147,12 @@ class SessionState {
   */
   void CleanInitializedTensorsFromGraph();
 
+  /**
+  * Prepack the constant initialized tensors for better performance.
+  * The original constant initialized tensors will be removed to save memory.
+  */
+  Status PrepackConstantInitializedTensors();
+
 #ifdef ENABLE_TRAINING
   /**
   Get some initialized tensors (weights).
@@ -197,7 +203,7 @@ class SessionState {
   Status UpdateMemoryPatternGroupCache(const std::vector<std::reference_wrapper<const TensorShape>>& input_shape,
                                        std::unique_ptr<MemoryPatternGroup> mem_patterns) const;
 
-  bool GetUseDeterministicCompute() const {return use_deterministic_compute_;}
+  bool GetUseDeterministicCompute() const { return use_deterministic_compute_; }
 
   /**
   Get enable memory pattern flag

--- a/onnxruntime/core/session/abi_session_options.cc
+++ b/onnxruntime/core/session/abi_session_options.cc
@@ -179,3 +179,13 @@ ORT_API_STATUS_IMPL(OrtApis::DisablePerSessionThreads, _In_ OrtSessionOptions* o
   options->value.use_per_session_threads = false;
   return nullptr;
 }
+
+ORT_API_STATUS_IMPL(OrtApis::EnablePrePacking, _In_ OrtSessionOptions* options) {
+  options->value.use_prepacking = true;
+  return nullptr;
+}
+
+ORT_API_STATUS_IMPL(OrtApis::DisablePrePacking, _In_ OrtSessionOptions* options) {
+  options->value.use_prepacking = false;
+  return nullptr;
+}

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -761,9 +761,11 @@ common::Status InferenceSession::InitializeSubgraphSessions(Graph& graph, Sessio
       SessionState* subgraph_session_state = session_state.GetMutableSubgraphSessionState(node.Index(), name);
       ORT_ENFORCE(subgraph_session_state, "CreateSubgraphSessionState should have created an entry earlier.");
 
-      ORT_RETURN_IF_ERROR_SESSIONID_(FinalizeSessionState(*subgraph_session_state, model_location_,
-                                                          kernel_registry_manager_, &node,
-                                                          session_options_.execution_mode));
+      ORT_RETURN_IF_ERROR_SESSIONID_(FinalizeSessionState(*subgraph_session_state,
+                                                          model_location_,
+                                                          kernel_registry_manager_,
+                                                          &node,
+                                                          session_options_));
 
       // LOGS(*session_logger_, VERBOSE) << std::make_pair(subgraph_info.session_state->GetExecutionPlan(),
       //                                                   &*subgraph_info.session_state);
@@ -937,8 +939,11 @@ common::Status InferenceSession::Initialize() {
       }
     }
 
-    ORT_RETURN_IF_ERROR_SESSIONID_(FinalizeSessionState(*session_state_, model_location_, kernel_registry_manager_,
-                                                        nullptr, session_options_.execution_mode));
+    ORT_RETURN_IF_ERROR_SESSIONID_(FinalizeSessionState(*session_state_,
+                                                        model_location_,
+                                                        kernel_registry_manager_,
+                                                        nullptr /*parent_node*/,
+                                                        session_options_));
 
     // handle any subgraphs
     ORT_RETURN_IF_ERROR_SESSIONID_(InitializeSubgraphSessions(graph, *session_state_));

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1663,6 +1663,8 @@ static constexpr OrtApi ort_api_1_to_4 = {
     &OrtApis::GetStringTensorElementLength,
     &OrtApis::GetStringTensorElement,
     &OrtApis::FillStringTensorElement,
+    &OrtApis::EnablePrePacking,
+    &OrtApis::DisablePrePacking,
 };
 
 // Assert to do a limited check to ensure Version 1 of OrtApi never changes (will detect an addition or deletion but not if they cancel out each other)

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -205,4 +205,8 @@ ORT_API_STATUS_IMPL(GetAvailableProviders, _Outptr_ char ***out_ptr,
                     _In_ int *providers_length);
 ORT_API_STATUS_IMPL(ReleaseAvailableProviders, _In_ char **ptr,
                     _In_ int providers_length);
+
+ORT_API_STATUS_IMPL(EnablePrePacking, _Inout_ OrtSessionOptions * options);
+ORT_API_STATUS_IMPL(DisablePrePacking, _Inout_ OrtSessionOptions * options);
+
 }  // namespace OrtApis

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1035,7 +1035,9 @@ Applies to session load, initialization, etc. Default is 0.)pbdoc")
                                 dim_name,
                                 onnxruntime::FreeDimensionOverrideType::Name,
                                 dim_value}); },
-          "Rpbdoc(Specify values of named dimensions within model inputs.)pbdoc");
+          "Rpbdoc(Specify values of named dimensions within model inputs.)pbdoc")
+      .def_readwrite("use_prepacking", &SessionOptions::use_prepacking,
+                     R"pbdoc(Whether to use prepacking. Default is true.)pbdoc");
 
   py::class_<RunOptions>(m, "RunOptions", R"pbdoc(Configuration information for a single Run.)pbdoc")
       .def(py::init())

--- a/onnxruntime/test/contrib_ops/dynamic_quantize_matmul_test.cc
+++ b/onnxruntime/test/contrib_ops/dynamic_quantize_matmul_test.cc
@@ -24,6 +24,7 @@ template <typename T>
 void TestDynamicQuantizeMatMul(const std::vector<int64_t>& A_dims,
                                std::vector<int64_t> B_dims,
                                const std::string& reference_model,
+                               bool is_matrix_b_constant,
                                bool has_zp = true,
                                bool has_bias = false) {
   // create rand inputs
@@ -44,7 +45,7 @@ void TestDynamicQuantizeMatMul(const std::vector<int64_t>& A_dims,
 
   OpTester test("DynamicQuantizeMatMul", 1, onnxruntime::kMSDomain);
   test.AddInput<float>("A", A_dims, A_data);
-  test.AddInput<T>("B", B_dims, B_data);
+  test.AddInput<T>("B", B_dims, B_data, is_matrix_b_constant);
   test.AddInput<float>("b_scale", {1}, B_scale);
 
   if (has_zp) {
@@ -68,7 +69,15 @@ TEST(DynamicQuantizeMatMul, Int8_test) {
   std::vector<int64_t> B_dims{128, 128};
   std::vector<int64_t> Y_dims{4, 128};
 
-  TestDynamicQuantizeMatMul<int8_t>(A_dims, B_dims, "testdata/dynamic_quantize_matmul_int8.onnx");
+  TestDynamicQuantizeMatMul<int8_t>(A_dims,
+                                    B_dims,
+                                    "testdata/dynamic_quantize_matmul_int8.onnx",
+                                    false /*is_matrix_b_constant*/);
+
+  TestDynamicQuantizeMatMul<int8_t>(A_dims,
+                                    B_dims,
+                                    "testdata/dynamic_quantize_matmul_int8.onnx",
+                                    true /*is_matrix_b_constant*/);
 }
 
 TEST(DynamicQuantizeMatMul, Int8_test_bias) {
@@ -77,7 +86,19 @@ TEST(DynamicQuantizeMatMul, Int8_test_bias) {
   std::vector<int64_t> B_dims{128, 128};
   std::vector<int64_t> Y_dims{4, 128};
 
-  TestDynamicQuantizeMatMul<int8_t>(A_dims, B_dims, "testdata/dynamic_quantize_matmul_int8_bias.onnx", false, true);
+  TestDynamicQuantizeMatMul<int8_t>(A_dims,
+                                    B_dims,
+                                    "testdata/dynamic_quantize_matmul_int8_bias.onnx",
+                                    false /*is_matrix_b_constant*/,
+                                    false, /*has_zp*/
+                                    true /*has_bias*/);
+
+  TestDynamicQuantizeMatMul<int8_t>(A_dims,
+                                    B_dims,
+                                    "testdata/dynamic_quantize_matmul_int8_bias.onnx",
+                                    true /*is_matrix_b_constant*/,
+                                    false, /*has_zp*/
+                                    true /*has_bias*/);
 #endif
 }
 
@@ -86,7 +107,15 @@ TEST(DynamicQuantizeMatMul, UInt8_test) {
   std::vector<int64_t> B_dims{128, 128};
   std::vector<int64_t> Y_dims{4, 128};
 
-  TestDynamicQuantizeMatMul<uint8_t>(A_dims, B_dims, "testdata/dynamic_quantize_matmul_uint8.onnx");
+  TestDynamicQuantizeMatMul<uint8_t>(A_dims,
+                                     B_dims,
+                                     "testdata/dynamic_quantize_matmul_uint8.onnx",
+                                     false /*is_matrix_b_constant*/);
+
+  TestDynamicQuantizeMatMul<uint8_t>(A_dims,
+                                     B_dims,
+                                     "testdata/dynamic_quantize_matmul_uint8.onnx",
+                                     true /*is_matrix_b_constant*/);
 }
 
 TEST(DynamicQuantizeMatMul, UInt8_test_with_empty_input) {
@@ -94,14 +123,34 @@ TEST(DynamicQuantizeMatMul, UInt8_test_with_empty_input) {
   std::vector<int64_t> B_dims{128, 128};
   std::vector<int64_t> Y_dims{0, 128};
 
-  TestDynamicQuantizeMatMul<uint8_t>(A_dims, B_dims, "testdata/dynamic_quantize_matmul_uint8.onnx");
+  TestDynamicQuantizeMatMul<uint8_t>(A_dims,
+                                     B_dims,
+                                     "testdata/dynamic_quantize_matmul_uint8.onnx",
+                                     false /*is_matrix_b_constant*/);
+
+  TestDynamicQuantizeMatMul<uint8_t>(A_dims,
+                                     B_dims,
+                                     "testdata/dynamic_quantize_matmul_uint8.onnx",
+                                     true /*is_matrix_b_constant*/);
 }
 TEST(DynamicQuantizeMatMul, UInt8_test_bias) {
   std::vector<int64_t> A_dims{4, 128};
   std::vector<int64_t> B_dims{128, 128};
   std::vector<int64_t> Y_dims{4, 128};
 
-  TestDynamicQuantizeMatMul<uint8_t>(A_dims, B_dims, "testdata/dynamic_quantize_matmul_uint8_bias.onnx", false, true);
+  TestDynamicQuantizeMatMul<uint8_t>(A_dims,
+                                     B_dims,
+                                     "testdata/dynamic_quantize_matmul_uint8_bias.onnx",
+                                     false /*is_matrix_b_constant*/,
+                                     false, /*has_zp*/
+                                     true /*has_bias*/);
+
+  TestDynamicQuantizeMatMul<uint8_t>(A_dims,
+                                     B_dims,
+                                     "testdata/dynamic_quantize_matmul_uint8_bias.onnx",
+                                     true /*is_matrix_b_constant*/,
+                                     false, /*has_zp*/
+                                     true /*has_bias*/);
 }
 
 }  // namespace test

--- a/onnxruntime/test/contrib_ops/matmul_integer_to_float_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_integer_to_float_test.cc
@@ -24,10 +24,11 @@ namespace test {
 
 template <typename T>
 void TestMatMulIntegerToFloat(const std::vector<int64_t>& A_dims,
-                                std::vector<int64_t> B_dims,
-                                const std::string& reference_model,
-                                bool has_zp = true,
-                                bool has_bias = false) {
+                              std::vector<int64_t> B_dims,
+                              const std::string& reference_model,
+                              bool is_matrix_b_constant,
+                              bool has_zp = true,
+                              bool has_bias = false) {
   // create rand inputs
   RandomValueGenerator random{};
 
@@ -53,7 +54,7 @@ void TestMatMulIntegerToFloat(const std::vector<int64_t>& A_dims,
 
   OpTester test("MatMulIntegerToFloat", 1, onnxruntime::kMSDomain);
   test.AddInput<uint8_t>("A", A_dims, A_data);
-  test.AddInput<T>("B", B_dims, B_data);
+  test.AddInput<T>("B", B_dims, B_data, is_matrix_b_constant);
   test.AddInput<float>("a_scale", {1}, A_scale);
   test.AddInput<float>("b_scale", {1}, B_scale);
 
@@ -81,7 +82,15 @@ TEST(MatMulIntegerToFloat, Int8_test) {
   std::vector<int64_t> B_dims{128, 128};
   std::vector<int64_t> Y_dims{4, 128};
 
-  TestMatMulIntegerToFloat<int8_t>(A_dims, B_dims, "testdata/matmul_integer_to_float_int8.onnx");
+  TestMatMulIntegerToFloat<int8_t>(A_dims,
+                                   B_dims,
+                                   "testdata/matmul_integer_to_float_int8.onnx",
+                                   false /*is_matrix_b_constant*/);
+
+  TestMatMulIntegerToFloat<int8_t>(A_dims,
+                                   B_dims,
+                                   "testdata/matmul_integer_to_float_int8.onnx",
+                                   true /*is_matrix_b_constant*/);
 #endif
 }
 
@@ -91,7 +100,19 @@ TEST(MatMulIntegerToFloat, Int8_bias_test) {
   std::vector<int64_t> B_dims{128, 128};
   std::vector<int64_t> Y_dims{4, 128};
 
-  TestMatMulIntegerToFloat<int8_t>(A_dims, B_dims, "testdata/matmul_integer_to_float_int8_bias.onnx", false, true);
+  TestMatMulIntegerToFloat<int8_t>(A_dims,
+                                   B_dims,
+                                   "testdata/matmul_integer_to_float_int8_bias.onnx",
+                                   false /*is_matrix_b_constant*/,
+                                   false, /*has_zp*/
+                                   true /*has_bias*/);
+
+  TestMatMulIntegerToFloat<int8_t>(A_dims,
+                                   B_dims,
+                                   "testdata/matmul_integer_to_float_int8_bias.onnx",
+                                   true /*is_matrix_b_constant*/,
+                                   false, /*has_zp*/
+                                   true /*has_bias*/);
 #endif
 }
 
@@ -100,7 +121,15 @@ TEST(MatMulIntegerToFloat, UInt8_test) {
   std::vector<int64_t> B_dims{128, 128};
   std::vector<int64_t> Y_dims{4, 128};
 
-  TestMatMulIntegerToFloat<uint8_t>(A_dims, B_dims, "testdata/matmul_integer_to_float_uint8.onnx");
+  TestMatMulIntegerToFloat<uint8_t>(A_dims,
+                                    B_dims,
+                                    "testdata/matmul_integer_to_float_uint8.onnx",
+                                    false /*is_matrix_b_constant*/);
+
+  TestMatMulIntegerToFloat<uint8_t>(A_dims,
+                                    B_dims,
+                                    "testdata/matmul_integer_to_float_uint8.onnx",
+                                    true /*is_matrix_b_constant*/);
 }
 
 TEST(MatMulIntegerToFloat, UInt8_bias_test) {
@@ -108,7 +137,19 @@ TEST(MatMulIntegerToFloat, UInt8_bias_test) {
   std::vector<int64_t> B_dims{128, 128};
   std::vector<int64_t> Y_dims{4, 128};
 
-  TestMatMulIntegerToFloat<uint8_t>(A_dims, B_dims, "testdata/matmul_integer_to_float_uint8_bias.onnx", false, true);
+  TestMatMulIntegerToFloat<uint8_t>(A_dims,
+                                    B_dims,
+                                    "testdata/matmul_integer_to_float_uint8_bias.onnx",
+                                    false /*is_matrix_b_constant*/,
+                                    false, /*has_zp*/
+                                    true /*has_bias*/);
+
+  TestMatMulIntegerToFloat<uint8_t>(A_dims,
+                                    B_dims,
+                                    "testdata/matmul_integer_to_float_uint8_bias.onnx",
+                                    true /*is_matrix_b_constant*/,
+                                    false, /*has_zp*/
+                                    true /*has_bias*/);
 }
 
 }  // namespace test

--- a/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
@@ -710,7 +710,8 @@ void TestQuantizedAttentionPastState(int64_t batch,
                                      int64_t hidden_size,
                                      int64_t head_number,
                                      int64_t head_size,
-                                     const std::string& reference_model) {
+                                     const std::string& reference_model,
+                                     bool is_weight_constant) {
   // create rand inputs
   RandomValueGenerator random{};
 
@@ -747,7 +748,7 @@ void TestQuantizedAttentionPastState(int64_t batch,
   test.AddAttribute<int64_t>("num_heads", head_number);
   test.AddAttribute<int64_t>("unidirectional", 1);
   test.AddInput<InputT>("input", input_dims, input_data);
-  test.AddInput<WeightT>("weight", weight_dims, weight_data);
+  test.AddInput<WeightT>("weight", weight_dims, weight_data, is_weight_constant);
   test.AddInput<float>("bias", bias_dims, bias_data);
   test.AddInput<float>("input_scale", {1}, input_scale);
   test.AddInput<float>("weight_scale", {1}, weight_scale);
@@ -761,11 +762,23 @@ void TestQuantizedAttentionPastState(int64_t batch,
 }
 
 TEST(QAttentionTest, QAttentionPastState_u8u8) {
-  TestQuantizedAttentionPastState<uint8_t, uint8_t>(2, 5, 15, 768, 12, 64, "testdata/attention_past_state.u8u8.onnx");
+  TestQuantizedAttentionPastState<uint8_t, uint8_t>(2, 5, 15, 768, 12, 64,
+                                                    "testdata/attention_past_state.u8u8.onnx",
+                                                    false /*is_weight_constant*/);
+
+  TestQuantizedAttentionPastState<uint8_t, uint8_t>(2, 5, 15, 768, 12, 64,
+                                                    "testdata/attention_past_state.u8u8.onnx",
+                                                    true /*is_weight_constant*/);
 }
 
 TEST(QAttentionTest, QAttentionPastState_u8s8) {
-  TestQuantizedAttentionPastState<uint8_t, int8_t>(2, 5, 15, 768, 12, 64, "testdata/attention_past_state.u8s8.onnx");
+  TestQuantizedAttentionPastState<uint8_t, int8_t>(2, 5, 15, 768, 12, 64,
+                                                   "testdata/attention_past_state.u8s8.onnx",
+                                                   false /*is_weight_constant*/);
+
+  TestQuantizedAttentionPastState<uint8_t, uint8_t>(2, 5, 15, 768, 12, 64,
+                                                    "testdata/attention_past_state.u8u8.onnx",
+                                                    true /*is_weight_constant*/);
 }
 
 }  // namespace test

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -265,7 +265,7 @@ TEST_P(SessionStatePrepackingTest, PrePackingTest) {
                                         sess_options));
   const auto& const_initialized_tensors = session_state.GetConstantInitializedTensors();
   // check prepacking
-  ASSERT_EQ(const_initialized_tensors.size(), sess_options.use_prepacking ? 0 : 1);
+  ASSERT_EQ(const_initialized_tensors.size(), size_t(sess_options.use_prepacking ? 0 : 1));
 }
 
 INSTANTIATE_TEST_SUITE_P(SessionStateTests, SessionStatePrepackingTest, testing::Values(true, false));

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -27,11 +27,11 @@ class TestOpKernel : public OpKernel {
  public:
   TestOpKernel(const OpKernelInfo& p) : OpKernel(p) {
   }
-  Status Compute(OpKernelContext* context) const {
+  Status Compute(OpKernelContext* context) const override {
     ORT_UNUSED_PARAMETER(context);
     return Status::OK();
   }
-  Status ComputeAsync(OpKernelContext* context, DoneCallback done) const {
+  Status ComputeAsync(OpKernelContext* context, DoneCallback done) const override {
     ORT_UNUSED_PARAMETER(context);
     ORT_UNUSED_PARAMETER(done);
     return Status::OK();
@@ -175,7 +175,7 @@ INSTANTIATE_TEST_SUITE_P(SessionStateTests, SessionStateTestP, testing::ValuesIn
 class PrePackingTestOpKernel : public OpKernel {
  public:
   PrePackingTestOpKernel(const OpKernelInfo& info) : OpKernel(info) {}
-  Status Compute(OpKernelContext* context) const {
+  Status Compute(OpKernelContext* context) const override {
     ORT_UNUSED_PARAMETER(context);
     return Status::OK();
   }

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -141,7 +141,7 @@ TEST_P(SessionStateTestP, TestInitializerProcessing) {
   ASSERT_TRUE(status.IsOK()) << status;
 
   session_state.CreateGraphInfo();
-  ASSERT_STATUS_OK(FinalizeSessionState(session_state, oss.str(), krm, nullptr, ExecutionMode::ORT_SEQUENTIAL));
+  ASSERT_STATUS_OK(FinalizeSessionState(session_state, oss.str(), krm, nullptr, SessionOptions()));
 
   const auto& initialized_tensors = session_state.GetInitializedTensors();
   const auto& const_initialized_tensors = session_state.GetConstantInitializedTensors();
@@ -171,5 +171,104 @@ TEST_P(SessionStateTestP, TestInitializerProcessing) {
 }
 
 INSTANTIATE_TEST_SUITE_P(SessionStateTests, SessionStateTestP, testing::ValuesIn(param_list));
+
+class PrePackingTestOpKernel : public OpKernel {
+ public:
+  PrePackingTestOpKernel(const OpKernelInfo& info) : OpKernel(info) {}
+  Status Compute(OpKernelContext* context) const {
+    ORT_UNUSED_PARAMETER(context);
+    return Status::OK();
+  }
+
+  Status PrePack(const Tensor& tensor, int input_idx, bool& is_packed) override {
+    ORT_UNUSED_PARAMETER(tensor);
+    ORT_UNUSED_PARAMETER(input_idx);
+    is_packed = true;
+    return Status::OK();
+  }
+};
+
+class SessionStatePrepackingTest : public testing::TestWithParam<bool> {};
+TEST_P(SessionStatePrepackingTest, PrePackingTest) {
+  OrtThreadPoolParams to;
+  auto tp = concurrency::CreateThreadPool(&onnxruntime::Env::Default(), to, concurrency::ThreadPoolType::INTRA_OP);
+  ONNX_OPERATOR_SCHEMA(PrePackingTest)
+      .SetDoc("Faking Node for PrePacking")
+      .Input(0, "Input_0", "input 0", "tensor(float)")
+      .Input(1, "Input_1", "input 1", "tensor(float)")
+      .Output(0, "output_0", "docstr for output_0.", "tensor(float)");
+
+  onnxruntime::Model model("graph_1", false, DefaultLoggingManager().DefaultLogger());
+  // construct graph
+  auto& graph = model.MainGraph();
+
+  // node creation and placement
+  TypeProto type;
+  type.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  std::vector<onnxruntime::NodeArg*> inputs;
+  onnxruntime::NodeArg input_0_arg("node_0_input_0", &type);
+  onnxruntime::NodeArg input_1_arg("node_0_input_1", &type);
+  inputs.push_back(&input_0_arg);
+  inputs.push_back(&input_1_arg);
+
+  std::vector<onnxruntime::NodeArg*> outputs;
+  onnxruntime::NodeArg output_arg("node_0_output_0", &type);
+  outputs.push_back(&output_arg);
+
+  onnxruntime::Node& node = graph.AddNode("node_0", "PrePackingTest", "node 0", inputs, outputs);
+  node.SetExecutionProviderType(kCpuExecutionProvider);
+
+  // add an initializer
+  ONNX_NAMESPACE::TensorProto tensor;
+  tensor.add_dims(1);
+  tensor.add_float_data(1.0f);
+  tensor.set_data_type(TensorProto_DataType_FLOAT);
+  tensor.set_name("node_0_input_1");
+  graph.AddInitializedTensor(tensor);
+
+  auto status = graph.Resolve();
+  ASSERT_TRUE(status.IsOK());
+
+  ExecutionProviders execution_providers;
+  auto cpu_execution_provider = onnxruntime::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo(false));
+  execution_providers.Add(kCpuExecutionProvider, std::move(cpu_execution_provider));
+
+  DataTransferManager dtm;
+  profiling::Profiler profiler;
+  SessionState session_state(graph,
+                             execution_providers,
+                             true, /*enable_mem_pattern*/
+                             tp.get(),
+                             nullptr, /*inter_op_thread_pool*/
+                             dtm,
+                             DefaultLoggingManager().DefaultLogger(),
+                             profiler);
+
+  KernelRegistryManager kernel_registry_manager;
+  status = kernel_registry_manager.RegisterKernels(execution_providers);
+  ASSERT_TRUE(status.IsOK()) << status.ErrorMessage();
+  std::shared_ptr<KernelRegistry> kernel_registry = std::make_shared<KernelRegistry>();
+  auto kernel_def = KernelDefBuilder().SetName("PrePackingTest").Provider(kCpuExecutionProvider).SinceVersion(1).Build();
+  ASSERT_STATUS_OK(kernel_registry->Register(
+      KernelCreateInfo(std::move(kernel_def),
+                       [](const OpKernelInfo& info) -> OpKernel* { return new PrePackingTestOpKernel(info); })));
+  kernel_registry_manager.RegisterKernelRegistry(kernel_registry);
+
+  SessionOptions sess_options;
+  sess_options.use_prepacking = GetParam();
+  ASSERT_STATUS_OK(FinalizeSessionState(session_state,
+                                        std::basic_string<PATH_CHAR_TYPE>() /*graph_loc*/,
+                                        kernel_registry_manager,
+                                        nullptr /*parent_node*/,
+                                        sess_options));
+  const auto& const_initialized_tensors = session_state.GetConstantInitializedTensors();
+  // check prepacking
+  ASSERT_EQ(const_initialized_tensors.size(), sess_options.use_prepacking ? 0 : 1);
+}
+
+INSTANTIATE_TEST_SUITE_P(SessionStateTests, SessionStatePrepackingTest, testing::Values(true, false));
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/memcpy_test.cc
+++ b/onnxruntime/test/providers/memcpy_test.cc
@@ -53,7 +53,7 @@ TEST(MemcpyTest, copy1) {
                  DefaultLoggingManager().DefaultLogger(), profiler);
 
   s.CreateGraphInfo();
-  ASSERT_STATUS_OK(FinalizeSessionState(s, ORT_TSTR(""), kernel_registry_manager, nullptr));
+  ASSERT_STATUS_OK(FinalizeSessionState(s, ORT_TSTR(""), kernel_registry_manager, nullptr, SessionOptions()));
 
   AllocatorPtr allocator =
       execution_providers.Get(onnxruntime::kCpuExecutionProvider)->GetAllocator(0, OrtMemTypeDefault);

--- a/onnxruntime/test/providers/provider_test_utils.cc
+++ b/onnxruntime/test/providers/provider_test_utils.cc
@@ -880,7 +880,11 @@ void OpTester::AddReferenceOutputs(const std::string& model_path) {
                  [](const onnxruntime::NodeArg* node_arg) -> std::string { return node_arg->Name(); });
 
   NameMLValMap feeds;
-  FillFeeds(feeds);
+  for (size_t i = 0; i < input_data_.size(); ++i) {
+    if (input_data_[i].def_.Exists()) {
+      feeds[input_data_[i].def_.Name()] = input_data_[i].data_;
+    }
+  }
 
   std::vector<MLValue> subgraph_fetches;
   ASSERT_TRUE((status = subgraph_session_object.Run(run_options, feeds, output_names, &subgraph_fetches)).IsOK()) << status;

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -511,6 +511,12 @@ class TestInferenceSession(unittest.TestCase):
 
         res = sess.run([], {'input1:0': a, 'input:0': b})
 
+    def testPrePacking(self):
+        opt = onnxrt.SessionOptions()
+        self.assertTrue(opt.use_prepacking)
+        opt.use_prepacking = False
+        self.assertFalse(opt.use_prepacking)
+
     def testSequenceLength(self):
         sess = onnxrt.InferenceSession(get_name("sequence_length.onnx"))
         x = [

--- a/onnxruntime/test/shared_lib/test_session_options.cc
+++ b/onnxruntime/test/shared_lib/test_session_options.cc
@@ -12,3 +12,9 @@ TEST(CApiTest, session_options_graph_optimization_level) {
   Ort::SessionOptions options;
   options.SetGraphOptimizationLevel(ORT_ENABLE_EXTENDED);
 }
+
+TEST(CApiTest, session_options_pre_packing) {
+  Ort::SessionOptions options;
+  options.DisablePrePacking();
+  options.EnablePrePacking();
+}


### PR DESCRIPTION
**Description**: 
Set up framework to support prepacking
**Motivation and Context**
Prepacking initialized constant tensor can improve performance for some operators, for example, prepacking the constant matrix B for MatMul, weights for GRU&LSTM. However, our current mechanics to support prepack has a drawback: it introduce memory overhead. 
This PR introduces a method to remove the memory overhead. It adds a virtual function PrePack to allow OpKernel to PrePack the tensors. The function is invoked in SessionState initialization stage. If no other Ops using this initialized constant tensor, it will be released.
