### PR TITLE
Add _ORTTrainerModelDesc to perform validation for model description

### DIFF
--- a/orttraining/orttraining/python/training/__init__.py
+++ b/orttraining/orttraining/python/training/__init__.py
@@ -4,4 +4,6 @@
 #--------------------------------------------------------------------------
 from onnxruntime.capi._pybind_state import TrainingParameters
 from onnxruntime.capi.training.training_session import TrainingSession
+
 from .orttrainer_options import ORTTrainerOptions
+from . import model_desc_validation

--- a/orttraining/orttraining/python/training/_utils.py
+++ b/orttraining/orttraining/python/training/_utils.py
@@ -1,0 +1,27 @@
+def static_vars(**kwargs):
+    r'''Decorator to add :py:attr:`kwargs` as static vars to 'func'
+
+        Example:
+
+            .. code-block:: python
+
+                >>> @static_vars(counter=0)
+                ... def myfync():
+                ...     myfync.counter += 1
+                ...     return myfync.counter
+                ...
+                >>> print(myfunc())
+                1
+                >>> print(myfunc())
+                2
+                >>> print(myfunc())
+                3
+                >>> myfunc.counter = 100
+                >>> print(myfunc())
+                101
+    '''
+    def decorate(func):
+        for k in kwargs:
+            setattr(func, k, kwargs[k])
+        return func
+    return decorate

--- a/orttraining/orttraining/python/training/model_desc_validation.py
+++ b/orttraining/orttraining/python/training/model_desc_validation.py
@@ -1,0 +1,164 @@
+import cerberus
+
+from ._utils import static_vars
+
+
+class _ORTTrainerModelDesc(object):
+
+    def __init__(self, model_desc):
+        # Keep a copy of original input for debug
+        self._original = dict(model_desc)
+
+        # Global counter used to validate occurrences of 'is_loss=True' whithin 'model_desc.outputs'
+        #   A stateless validator is used for each tuple, but validation accross the whole list of tuple is needed
+        #       because just one 'is_loss=True' is allowed withing 'model_desc.outputs' list of tuples
+        _model_desc_outputs_validation.loss_counter = 0
+
+        # Used for logging purposes
+        self._main_class_name = self.__class__.__name__
+
+        # Validates user input
+        self._validated = dict(self._original)
+        validator = cerberus.Validator(MODEL_DESC_SCHEMA)
+        self._validated = validator.validated(self._validated)
+        if self._validated is None:
+            raise ValueError(f'Invalid model_desc: {validator.errors}')
+
+        # Convert dict in object
+        for k, v in self._validated.items():
+            setattr(self, k, self._wrap(v))
+
+        # Keep this in the last line
+        # After this point, this class becomes immutable
+        self._initialized = True
+
+    def __repr__(self):
+        return '{%s}' % str(', '.join("'%s': %s" % (k, repr(v))
+                                      for (k, v) in self.__dict__.items()
+                                      if k not in ['_main_class_name', '_original', '_validated', '_initialized']))
+
+    def __setattr__(self, k, v):
+        if hasattr(self, '_initialized'):
+            raise Exception(f"{self._main_class_name} is an immutable class")
+        return super().__setattr__(k, v)
+
+    def _wrap(self, v):
+        if isinstance(v, (tuple, list, set, frozenset)):
+            return type(v)([self._wrap(v) for v in v])
+        else:
+            return _ORTTrainerModelDescInternal(self._main_class_name, v) if isinstance(v, dict) else v
+
+
+class _ORTTrainerModelDescInternal(_ORTTrainerModelDesc):
+    r"""Internal class used by ONNX Runtime training backend for input validation
+
+    NOTE: Users MUST NOT use this class in any way!
+    """
+
+    def __init__(self, main_class_name, model_desc):
+        # Used for logging purposes
+        self._main_class_name = main_class_name
+
+        # Convert dict in object
+        for k, v in dict(model_desc).items():
+            setattr(self, k, self._wrap(v))
+
+        # Keep this in the last line
+        # After this point, this class becomes immutable
+        self._initialized = True
+
+
+def _model_desc_inputs_validation(field, value, error):
+    r'''Cerberus custom check method for 'model_desc.inputs'
+
+    'model_desc.inputs' is a list of tuples.
+    The list has variable length, but each tuple has size 2
+
+    The first element of the tuple is a string which represents the input name
+    The second element is a list of shapes. Each shape must be either an int or string.
+        Empty list represents a scalar output
+
+    Validation is done within each tuple to enforce the schema described above.
+
+    Example:
+
+        .. code-block:: python
+
+            model_desc['inputs'] = [('input1', ['batch', 1024]),
+                                    ('input2', [])
+                                    ('input3', [512])]
+    '''
+
+    if not isinstance(value, tuple) or len(value) != 2:
+        error(field, "must be a tuple with size 2")
+    if not isinstance(value[0], str):
+        error(field, "the first element of the tuple (aka name) must be a string")
+    if not isinstance(value[1], list):
+        error(field, "the second element of the tuple (aka shape) must be a list")
+    else:
+        for shape in value[1]:
+            if not isinstance(shape, str) and not isinstance(shape, int) or isinstance(shape, bool):
+                error(field, "each shape must be either a string or integer")
+
+
+@static_vars(loss_counter=0)
+def _model_desc_outputs_validation(field, value, error):
+    r'''Cerberus custom check method for 'model_desc.outputs'
+
+    'model_desc.outputs' is a list of tuples with variable length.
+    The first element of the tuple is a string which represents the output name
+    The second element is a list of shapes. Each shape must be either an int or string.
+        Empty list represents a scalar output
+    The third element is optional and is a flag that signals whether the output is a loss value
+
+    Validation is done within each tuple to enforce the schema described above, but also
+    throughout the list of tuples to ensure a single 'is_loss=True' occurrence.
+
+    Example:
+
+        .. code-block:: python
+
+            model_desc['outputs'] = [('output1', ['batch', 1024], is_loss=True),
+                                     ('output2', [], is_loss=False)
+                                     ('output3', [512])]
+    '''
+
+    if not isinstance(value, tuple) or len(value) < 2 or len(value) > 3:
+        error(field, "must be a tuple with size 2 or 3")
+    if len(value) == 3 and not isinstance(value[2], bool):
+        error(field, "the third element of the tuple (aka is_loss) must be a boolean")
+    elif len(value) == 3:
+        if value[2]:
+            _model_desc_outputs_validation.loss_counter += 1
+        if _model_desc_outputs_validation.loss_counter > 1:
+            error(field, "only one is_loss can bet set to True")
+    if not isinstance(value[0], str):
+        error(field, "the first element of the tuple (aka name) must be a string")
+    if not isinstance(value[1], list):
+        error(field, "the second element of the tuple (aka shape) must be a list")
+    else:
+        for shape in value[1]:
+            if not isinstance(shape, str) and not isinstance(shape, int) or isinstance(shape, bool):
+                error(field, "each shape must be either a string or integer")
+
+
+# Validation schema for model description dictionary
+MODEL_DESC_SCHEMA = {
+    'inputs': {
+        'type': 'list',
+        'required': True,
+        'minlength': 1,
+        'schema': {
+            'check_with': _model_desc_inputs_validation
+        },
+    },
+    'outputs': {
+        'type': 'list',
+        'required': True,
+        'minlength': 1,
+        'schema': {
+
+            'check_with': _model_desc_outputs_validation
+        },
+    }
+}

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from onnxruntime.capi.training import orttrainer_options as orttrainer_options
+from onnxruntime.capi.training import model_desc_validation as md_val
 
 
 @pytest.mark.parametrize("test_input", [
@@ -56,5 +57,43 @@ def testORTTrainerOptionsInvalidMixedPrecisionEnabledSchema():
 
     expected_msg = "Invalid options: {'mixed_precision': [{'enabled': ['must be of boolean type']}]}"
     with pytest.raises(ValueError) as e:
-        orttrainer_options.ORTTrainerOptions({'mixed_precision': {'enabled': 1}})
+        orttrainer_options.ORTTrainerOptions(
+            {'mixed_precision': {'enabled': 1}})
     assert str(e.value) == expected_msg
+
+
+@pytest.mark.parametrize("test_input", [
+    ({'inputs': [('in0', [])],
+      'outputs': [('out0', []), ('out1', [])]}),
+    ({'inputs': [('in0', ['batch', 2, 3])],
+      'outputs': [('out0', [], True)]}),
+    ({'inputs': [('in0', []), ('in1', [1]), ('in2', [1, 2]), ('in3', [1000, 'dyn_ax1']), ('in4', ['dyn_ax1', 'dyn_ax2', 'dyn_ax3'])],
+      'outputs': [('out0', [], True), ('out1', [1], False), ('out2', [1, 'dyn_ax1', 3])]})
+])
+def testORTTrainerModelDescValidSchemas(test_input):
+    r''' Test different ways of using default values for incomplete input'''
+    md_val._ORTTrainerModelDesc(test_input)
+
+
+@pytest.mark.parametrize("test_input,error_msg", [
+    ({'inputs': [(True, [])],
+      'outputs': [(True, [])]},
+     "Invalid model_desc: {'inputs': [{0: ['the first element of the tuple (aka name) must be a string']}], 'outputs': [{0: ['the first element of the tuple (aka name) must be a string']}]}"),
+    ({'inputs': [('in1', None)],
+      'outputs': [('out1', None)]},
+     "Invalid model_desc: {'inputs': [{0: ['the second element of the tuple (aka shape) must be a list']}], 'outputs': [{0: ['the second element of the tuple (aka shape) must be a list']}]}"),
+    ({'inputs': [('in1', [])],
+      'outputs': [('out1', [], None)]},
+     "Invalid model_desc: {'outputs': [{0: ['the third element of the tuple (aka is_loss) must be a boolean']}]}"),
+    ({'inputs': [('in1', [True])],
+      'outputs': [('out1', [True])]},
+     "Invalid model_desc: {'inputs': [{0: ['each shape must be either a string or integer']}], 'outputs': [{0: ['each shape must be either a string or integer']}]}"),
+    ({'inputs': [('in1', [])],
+      'outputs': [('out1', [], True), ('out2', [], True)]},
+     "Invalid model_desc: {'outputs': [{1: ['only one is_loss can bet set to True']}]}"),
+])
+def testORTTrainerModelDescInvalidSchemas(test_input, error_msg):
+    r''' Test different ways of using default values for incomplete input'''
+    with pytest.raises(ValueError) as e:
+        md_val._ORTTrainerModelDesc(test_input)
+    assert str(e.value) == error_msg


### PR DESCRIPTION
The new frontend will take dependency on a schema validation library called 'cerberus'
This class will hold the model description, which is composed of inputs, outputs and possibly loss