### PR TITLE
Optimize CUDA Sum op kernel and refactor CUDA elementwise variadic input op kernels

### DIFF
--- a/include/onnxruntime/core/framework/op_kernel.h
+++ b/include/onnxruntime/core/framework/op_kernel.h
@@ -89,6 +89,14 @@ class OpKernelContext {
     }
   }
 
+  // Fetch a required input, enforcing that it is present.
+  template <typename T>
+  const T& RequiredInput(int index) const {
+    const T* input_ptr = Input<T>(index);
+    ORT_ENFORCE(input_ptr, "Required input at index ", index, " is not present.");
+    return *input_ptr;
+  }
+
   // Fetch output (non-tensor) with specified index.
   template <typename T>
   T* Output(int index) {
@@ -103,6 +111,13 @@ class OpKernelContext {
   // The memory allocation will be done on-the-fly with given tensor shape.
   // Return nullptr if the output is an unused optional output.
   Tensor* Output(int index, const TensorShape& shape);
+
+  // Fetch a required tensor output, enforcing that it is present.
+  Tensor& RequiredOutput(int index, const TensorShape& shape) {
+    Tensor* output_ptr = Output(index, shape);
+    ORT_ENFORCE(output_ptr, "Required output at index ", index, " is not present.");
+    return *output_ptr;
+  }
 
   // Fetch a sparse-tensor output corresponding to the specified index.
   // num_values must specify the number of non-zero values (commonly known as NNZ/nnz),

--- a/onnxruntime/core/providers/cuda/cu_inc/binary_elementwise_impl.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/binary_elementwise_impl.cuh
@@ -255,7 +255,7 @@ void BinaryElementWiseImpl(
         func,
         N);
   } else {
-    if (lhs_padded_strides && rhs_padded_strides && lhs_padded_strides->size_ && rhs_padded_strides->size_)
+    if (lhs_padded_strides && rhs_padded_strides && lhs_padded_strides->Size() && rhs_padded_strides->Size())
       _BinaryElementWise<T, T1, FuncT, true, true, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(
           output_rank_or_simple_broadcast,
           *lhs_padded_strides,
@@ -266,7 +266,7 @@ void BinaryElementWiseImpl(
           output_data,
           func,
           N);
-    else if (lhs_padded_strides && lhs_padded_strides->size_)
+    else if (lhs_padded_strides && lhs_padded_strides->Size())
       _BinaryElementWise<T, T1, FuncT, true, false, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(
           output_rank_or_simple_broadcast,
           *lhs_padded_strides,

--- a/onnxruntime/core/providers/cuda/cu_inc/variadic_elementwise_impl.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/variadic_elementwise_impl.cuh
@@ -14,13 +14,14 @@ __global__ void VariadicElementWiseNoBroadcastInputBatchKernel(
     size_t N,
     TArray<const T*, max_input_batch_size> inputs,
     T* output) {
-  const auto base_idx = num_elements_per_thread * blockDim.x * blockIdx.x + threadIdx.x;
+  const size_t base_idx = num_elements_per_thread * blockDim.x * blockIdx.x + threadIdx.x;
 
   T inputs_buffer[num_elements_per_thread][max_input_batch_size];
 
 #pragma unroll
-  for (size_t element_count = 0; element_count < num_elements_per_thread; ++element_count) {
-    const auto element_idx = base_idx + blockDim.x * element_count;
+  for (size_t element_count = 0, element_idx = base_idx;
+       element_count < num_elements_per_thread;
+       ++element_count, element_idx += blockDim.x) {
     if (element_idx < N) {
 #pragma unroll
       for (size_t input_batch_idx = 0; input_batch_idx < max_input_batch_size; ++input_batch_idx) {
@@ -32,8 +33,9 @@ __global__ void VariadicElementWiseNoBroadcastInputBatchKernel(
   }
 
 #pragma unroll
-  for (size_t element_count = 0; element_count < num_elements_per_thread; ++element_count) {
-    const auto element_idx = base_idx + blockDim.x * element_count;
+  for (size_t element_count = 0, element_idx = base_idx;
+       element_count < num_elements_per_thread;
+       ++element_count, element_idx += blockDim.x) {
     if (element_idx < N) {
       // first and second inputs
       output[element_idx] = func(

--- a/onnxruntime/core/providers/cuda/cu_inc/variadic_elementwise_impl.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/variadic_elementwise_impl.cuh
@@ -16,25 +16,6 @@ __global__ void VariadicElementWiseNoBroadcastInputBatchKernel(
     T* output) {
   const auto base_idx = num_elements_per_thread * blockDim.x * blockIdx.x + threadIdx.x;
 
-#if 1
-#pragma unroll
-  for (size_t element_count = 0; element_count < num_elements_per_thread; ++element_count) {
-    const auto element_idx = base_idx + blockDim.x * element_count;
-    if (element_idx < N) {
-      // first and second inputs
-      output[element_idx] = func(
-          inputs[0][element_idx], inputs[1][element_idx]);
-
-      // remaining inputs
-#pragma unroll
-      for (size_t input_batch_idx = 2; input_batch_idx < max_input_batch_size; ++input_batch_idx) {
-        if (input_batch_idx < inputs.Size()) {
-          output[element_idx] = func(output[element_idx], inputs[input_batch_idx][element_idx]);
-        }
-      }
-    }
-  }
-#else
   T inputs_buffer[num_elements_per_thread][max_input_batch_size];
 
 #pragma unroll
@@ -67,7 +48,6 @@ __global__ void VariadicElementWiseNoBroadcastInputBatchKernel(
       }
     }
   }
-#endif
 }
 
 // assumptions:

--- a/onnxruntime/core/providers/cuda/cu_inc/variadic_elementwise_impl.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/variadic_elementwise_impl.cuh
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "core/providers/cuda/cu_inc/common.cuh"
+#include "core/providers/cuda/shared_inc/cuda_utils.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+template <
+    typename T, typename Func,
+    size_t max_input_batch_size, size_t num_elements_per_thread>
+__global__ void VariadicElementWiseNoBroadcastInputBatchKernel(
+    Func func,
+    size_t N,
+    TArray<const T*, max_input_batch_size> inputs,
+    T* output) {
+  const auto base_idx = num_elements_per_thread * blockDim.x * blockIdx.x + threadIdx.x;
+
+#if 1
+#pragma unroll
+  for (size_t element_count = 0; element_count < num_elements_per_thread; ++element_count) {
+    const auto element_idx = base_idx + blockDim.x * element_count;
+    if (element_idx < N) {
+      // first and second inputs
+      output[element_idx] = func(
+          inputs[0][element_idx], inputs[1][element_idx]);
+
+      // remaining inputs
+#pragma unroll
+      for (size_t input_batch_idx = 2; input_batch_idx < max_input_batch_size; ++input_batch_idx) {
+        if (input_batch_idx < inputs.Size()) {
+          output[element_idx] = func(output[element_idx], inputs[input_batch_idx][element_idx]);
+        }
+      }
+    }
+  }
+#else
+  T inputs_buffer[num_elements_per_thread][max_input_batch_size];
+
+#pragma unroll
+  for (size_t element_count = 0; element_count < num_elements_per_thread; ++element_count) {
+    const auto element_idx = base_idx + blockDim.x * element_count;
+    if (element_idx < N) {
+#pragma unroll
+      for (size_t input_batch_idx = 0; input_batch_idx < max_input_batch_size; ++input_batch_idx) {
+        if (input_batch_idx < inputs.Size()) {
+          inputs_buffer[element_count][input_batch_idx] = inputs[input_batch_idx][element_idx];
+        }
+      }
+    }
+  }
+
+#pragma unroll
+  for (size_t element_count = 0; element_count < num_elements_per_thread; ++element_count) {
+    const auto element_idx = base_idx + blockDim.x * element_count;
+    if (element_idx < N) {
+      // first and second inputs
+      output[element_idx] = func(
+          inputs_buffer[element_count][0], inputs_buffer[element_count][1]);
+
+      // remaining inputs
+#pragma unroll
+      for (size_t input_batch_idx = 2; input_batch_idx < max_input_batch_size; ++input_batch_idx) {
+        if (input_batch_idx < inputs.Size()) {
+          output[element_idx] = func(output[element_idx], inputs_buffer[element_count][input_batch_idx]);
+        }
+      }
+    }
+  }
+#endif
+}
+
+// assumptions:
+// - inputs.Size() > 1 && inputs.Size() <= max_input_batch_size
+// - inputs and output have N elements
+template <typename T, typename Func, size_t max_input_batch_size>
+void VariadicElementWiseNoBroadcastInputBatchImpl(
+    Func func,
+    size_t N,
+    TArray<const T*, max_input_batch_size> inputs,
+    T* output) {
+  const size_t elements_per_thread = 4;
+  const size_t threads_per_block = GridDim::maxThreadsPerBlock;
+  const size_t blocks_per_grid = CeilDiv(N, elements_per_thread * threads_per_block);
+  VariadicElementWiseNoBroadcastInputBatchKernel<T, Func, max_input_batch_size, elements_per_thread>
+      <<<blocks_per_grid, threads_per_block>>>(func, N, inputs, output);
+}
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -357,46 +357,12 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, bool, And);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, bool, Or);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, bool, Xor);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, int32_t, Sum);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, int64_t, Sum);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, uint32_t, Sum);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, uint64_t, Sum);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, float, Sum);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, double, Sum);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, MLFloat16, Sum);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, int32_t, Sum);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, int64_t, Sum);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, uint32_t, Sum);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, uint64_t, Sum);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, float, Sum);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, double, Sum);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, MLFloat16, Sum);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, float, Max);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, double, Max);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, MLFloat16, Max);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, 11, float, Max);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, 11, double, Max);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, 11, MLFloat16, Max);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, int32_t, Max);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, int64_t, Max);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, uint32_t, Max);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, uint64_t, Max);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, float, Max);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, double, Max);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, MLFloat16, Max);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, float, Min);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, double, Min);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, MLFloat16, Min);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, 11, float, Min);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, 11, double, Min);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, 11, MLFloat16, Min);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, int32_t, Min);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, int64_t, Min);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, uint32_t, Min);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, uint64_t, Min);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, float, Min);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, double, Min);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, MLFloat16, Min);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, Sum);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, Sum);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 11, Max);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, Max);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 11, Min);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, Min);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, 8, float, Greater);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, 8, double, Greater);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, 8, MLFloat16, Greater);
@@ -886,46 +852,12 @@ static Status RegisterCudaKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, bool, And)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, bool, Or)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, bool, Xor)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, int32_t, Sum)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, int64_t, Sum)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, uint32_t, Sum)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, uint64_t, Sum)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, float, Sum)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, double, Sum)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, MLFloat16, Sum)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, int32_t, Sum)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, int64_t, Sum)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, uint32_t, Sum)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, uint64_t, Sum)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, float, Sum)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, double, Sum)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, MLFloat16, Sum)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, float, Max)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, double, Max)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, MLFloat16, Max)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, 11, float, Max)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, 11, double, Max)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, 11, MLFloat16, Max)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, int32_t, Max)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, int64_t, Max)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, uint32_t, Max)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, uint64_t, Max)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, float, Max)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, double, Max)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, MLFloat16, Max)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, float, Min)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, double, Min)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, MLFloat16, Min)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, 11, float, Min)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, 11, double, Min)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, 11, MLFloat16, Min)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, int32_t, Min)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, int64_t, Min)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, uint32_t, Min)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, uint64_t, Min)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, float, Min)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, double, Min)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, MLFloat16, Min)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 7, Sum)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 8, Sum)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 11, Max)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, Max)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 6, 11, Min)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, Min)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, 8, float, Greater)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, 8, double, Greater)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, 8, MLFloat16, Greater)>,

--- a/onnxruntime/core/providers/cuda/math/binary_elementwise_ops_impl.cu
+++ b/onnxruntime/core/providers/cuda/math/binary_elementwise_ops_impl.cu
@@ -5,17 +5,10 @@
 #include "binary_elementwise_ops_impl.h"
 #include "core/providers/cuda/cu_inc/common.cuh"
 #include "core/providers/cuda/cu_inc/binary_elementwise_impl.cuh"
+#include "core/providers/cuda/math/binary_elementwise_ops_impl_functors.cuh"
 
 namespace onnxruntime {
 namespace cuda {
-
-#define OP(name, expr)                                    \
-  template <class T, class T1>                            \
-  struct OP_##name {                                      \
-    __device__ __inline__ T operator()(T a, T1 b) const { \
-      return (expr);                                      \
-    }                                                     \
-  };
 
 #define BINARY_ELEMENTWISE_IMPL(name)                      \
   BINARY_ELEMENTWISE_IMPL_DECLARATION(name) {              \
@@ -78,9 +71,8 @@ namespace cuda {
   SPECIALIZED_BINARY_ELEMENTWISE_IMPL(x, float)    \
   SPECIALIZED_BINARY_ELEMENTWISE_IMPL(x, double)
 
-// create declarations for op and impl
+// create declarations for impl
 #define BINARY_OP_NAME_EXPR(name, expr) \
-  OP(name, expr)                        \
   BINARY_ELEMENTWISE_IMPL(name)
 
 BINARY_OPS()
@@ -117,8 +109,7 @@ SPECIALIZED_BINARY_ELEMENTWISE_IMPL_UZILHFD(Max)
 SPECIALIZED_BINARY_ELEMENTWISE_IMPL_UZILHFD(Min)
 SPECIALIZED_BINARY_ELEMENTWISE_IMPL_UZILHFD(Less)
 
-// create declarations for op and impl for Pow
-OP(Pow, _Pow(a, b))
+// create declarations for impl for Pow
 BINARY_ELEMENTWISE_IMPL_T1(Pow)
 
 SPECIALIZED_BINARY_ELEMENTWISE_IMPL_T1(Pow, int32_t, int32_t)

--- a/onnxruntime/core/providers/cuda/math/binary_elementwise_ops_impl_functors.cuh
+++ b/onnxruntime/core/providers/cuda/math/binary_elementwise_ops_impl_functors.cuh
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/cuda/math/binary_elementwise_ops_impl.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+// define the device functors that perform the computation on scalars
+
+#define OP_FUNCTOR_DEFINITION(name, expr)                 \
+  template <class T, class T1>                            \
+  struct OP_##name {                                      \
+    __device__ __inline__ T operator()(T a, T1 b) const { \
+      return (expr);                                      \
+    }                                                     \
+  };
+
+#define BINARY_OP_NAME_EXPR(name, expr) \
+  OP_FUNCTOR_DEFINITION(name, expr)
+
+BINARY_OPS()
+
+OP_FUNCTOR_DEFINITION(Pow, _Pow(a, b))
+
+#undef BINARY_OP_NAME_EXPR
+#undef OP_FUNCTOR_DEFINITION
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops.cc
+++ b/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops.cc
@@ -148,6 +148,15 @@ Status VariadicElementwiseOp<VariadicElementwiseOpTag, SupportedElementTypes...>
             return first_input_tensor.Shape() == t.get().Shape();
           })) {
     auto& output_tensor = context->RequiredOutput(0, first_input_tensor.Shape());
+
+    // special case for no broadcasting and 2 inputs
+    if (input_count == 2) {
+      utils::MLTypeCallDispatcherRet<Status, BinaryImplDispatchTarget, SupportedElementTypes...> dispatcher(element_type);
+      ORT_RETURN_IF_ERROR(dispatcher.Invoke(input_tensors[0], input_tensors[1], output_tensor));
+
+      return Status::OK();
+    }
+
     utils::MLTypeCallDispatcherRet<Status, NoBroadcastBatchImplDispatchTarget, SupportedElementTypes...> dispatcher(
         element_type);
     ORT_RETURN_IF_ERROR(dispatcher.Invoke(input_tensors, output_tensor));

--- a/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops.cc
+++ b/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops.cc
@@ -141,7 +141,7 @@ Status VariadicElementwiseOp<VariadicElementwiseOpTag, SupportedElementTypes...>
   const auto element_type = first_input_tensor.GetElementType();
 
   // special case for no broadcasting and few enough inputs
-  if (input_count < k_max_input_batch_size &&
+  if (input_count <= k_max_input_batch_size &&
       std::all_of(
           input_tensors.begin() + 1, input_tensors.end(),
           [&first_input_tensor](InputTensorVector::value_type t) {

--- a/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops.cc
+++ b/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops.cc
@@ -1,0 +1,240 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cuda/math/variadic_elementwise_ops.h"
+
+#include <cassert>
+
+#include "core/framework/data_types_internal.h"
+#include "core/providers/cuda/math/binary_elementwise_ops.h"
+#include "core/providers/cuda/math/binary_elementwise_ops_impl.h"
+#include "core/providers/cuda/math/variadic_elementwise_ops_impl.h"
+#include "core/providers/cuda/math/variadic_elementwise_ops_tags.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+template <typename VariadicElementwiseOpTag, typename... SupportedElementTypes>
+template <typename T>
+Status VariadicElementwiseOp<VariadicElementwiseOpTag, SupportedElementTypes...>::
+    NoBroadcastBatchImplDispatchTarget<T>::operator()(const InputTensorVector& inputs, Tensor& output) const {
+  assert(inputs.size() > 1);
+
+  using CudaT = typename ToCudaType<T>::MappedType;
+
+  InputBatchArray<CudaT> input_data_batch{static_cast<int32_t>(inputs.size())};
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    input_data_batch[i] = reinterpret_cast<const CudaT*>(inputs[i].get().template Data<T>());
+  }
+
+  CudaT* output_data = reinterpret_cast<CudaT*>(output.template MutableData<T>());
+
+  Impl_NoBroadcastInputBatch<CudaT, VariadicElementwiseOpTag>(
+      input_data_batch, output_data, output.Shape().Size());
+
+  return Status::OK();
+}
+
+// special case for 2 tensors to avoid memset zero
+template <typename VariadicElementwiseOpTag, typename... SupportedElementTypes>
+template <typename T>
+Status VariadicElementwiseOp<VariadicElementwiseOpTag, SupportedElementTypes...>::
+    BinaryImplDispatchTarget<T>::operator()(const Tensor& lhs, const Tensor& rhs, Tensor& output) const {
+  using CudaT = typename ToCudaType<T>::MappedType;
+
+  BinaryElementwisePreparation prepare;
+  ORT_RETURN_IF_ERROR(BinaryElementwiseBroadcastPrepare(&lhs, &rhs, &output, &prepare));
+
+  Impl_General<CudaT, VariadicElementwiseOpTag>(
+      prepare.output_rank_or_simple_broadcast,
+      &prepare.lhs_padded_strides,
+      reinterpret_cast<const CudaT*>(prepare.lhs_tensor->template Data<T>()),
+      &prepare.rhs_padded_strides,
+      reinterpret_cast<const CudaT*>(prepare.rhs_tensor->template Data<T>()),
+      &prepare.fdm_output_strides,
+      prepare.fdm_H,
+      prepare.fdm_C,
+      reinterpret_cast<CudaT*>(prepare.output_tensor->template MutableData<T>()),
+      prepare.output_tensor->Shape().Size());
+
+  return Status::OK();
+}
+
+// for more than 2 inputs, we need to accumulate into output tensor, as the shape from input0 + input1 might be different from output shape
+template <typename VariadicElementwiseOpTag, typename... SupportedElementTypes>
+template <typename T>
+Status VariadicElementwiseOp<VariadicElementwiseOpTag, SupportedElementTypes...>::
+    GeneralImplDispatchTarget<T>::operator()(const InputTensorVector& inputs, Tensor& output) const {
+  assert(inputs.size() > 1);
+
+  using CudaT = typename ToCudaType<T>::MappedType;
+
+  CUDA_RETURN_IF_ERROR(cudaMemset(output.MutableDataRaw(), 0, output.SizeInBytes()));
+
+  BinaryElementwisePreparation prepare;
+  ORT_RETURN_IF_ERROR(BinaryElementwiseBroadcastPrepare(&output, &inputs[0].get(), &output, &prepare));
+
+  Impl_Add(
+      prepare.output_rank_or_simple_broadcast,
+      &prepare.lhs_padded_strides,
+      reinterpret_cast<const CudaT*>(prepare.lhs_tensor->template Data<T>()),
+      &prepare.rhs_padded_strides,
+      reinterpret_cast<const CudaT*>(prepare.rhs_tensor->template Data<T>()),
+      &prepare.fdm_output_strides,
+      prepare.fdm_H,
+      prepare.fdm_C,
+      reinterpret_cast<CudaT*>(prepare.output_tensor->template MutableData<T>()),
+      prepare.output_tensor->Shape().Size());
+
+  for (size_t index = 1; index < inputs.size(); index++) {
+    ORT_RETURN_IF_ERROR(BinaryElementwiseBroadcastPrepare(&output, &inputs[index].get(), &output, &prepare));
+
+    Impl_General<CudaT, VariadicElementwiseOpTag>(
+        prepare.output_rank_or_simple_broadcast,
+        &prepare.lhs_padded_strides,
+        reinterpret_cast<const CudaT*>(prepare.lhs_tensor->template Data<T>()),
+        &prepare.rhs_padded_strides,
+        reinterpret_cast<const CudaT*>(prepare.rhs_tensor->template Data<T>()),
+        &prepare.fdm_output_strides,
+        prepare.fdm_H,
+        prepare.fdm_C,
+        reinterpret_cast<CudaT*>(prepare.output_tensor->template MutableData<T>()),
+        prepare.output_tensor->Shape().Size());
+  }
+
+  return Status::OK();
+}
+
+template <typename VariadicElementwiseOpTag, typename... SupportedElementTypes>
+Status VariadicElementwiseOp<VariadicElementwiseOpTag, SupportedElementTypes...>::ComputeInternal(
+    OpKernelContext* context) const {
+  const auto& node = Node();
+  const auto& node_name = node.Name();
+  auto input_count = node.InputArgCount().front();
+  ORT_RETURN_IF_NOT(input_count >= 1, "Must have 1 or more inputs");
+
+  const InputTensorVector input_tensors =
+      [&context, input_count]() {
+        InputTensorVector result{};
+        result.reserve(input_count);
+        for (int i = 0; i < input_count; ++i) {
+          const auto& tensor = context->RequiredInput<Tensor>(i);
+          result.push_back(std::cref(tensor));
+        }
+        return result;
+      }();
+
+  const auto& first_input_tensor = input_tensors[0].get();
+
+  // special case for 1 input
+  if (input_count == 1) {
+    auto& output_tensor = context->RequiredOutput(0, first_input_tensor.Shape());
+    if (first_input_tensor.DataRaw() != output_tensor.DataRaw()) {
+      CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(
+          output_tensor.MutableDataRaw(), first_input_tensor.DataRaw(), first_input_tensor.SizeInBytes(),
+          cudaMemcpyDeviceToDevice));
+    }
+
+    return Status::OK();
+  }
+
+  const auto element_type = first_input_tensor.GetElementType();
+
+  // special case for no broadcasting and few enough inputs
+  if (input_count < k_max_input_batch_size &&
+      std::all_of(
+          input_tensors.begin() + 1, input_tensors.end(),
+          [&first_input_tensor](InputTensorVector::value_type t) {
+            return first_input_tensor.Shape() == t.get().Shape();
+          })) {
+    auto& output_tensor = context->RequiredOutput(0, first_input_tensor.Shape());
+    utils::MLTypeCallDispatcherRet<Status, NoBroadcastBatchImplDispatchTarget, SupportedElementTypes...> dispatcher(
+        element_type);
+    ORT_RETURN_IF_ERROR(dispatcher.Invoke(input_tensors, output_tensor));
+
+    return Status::OK();
+  }
+
+  // compute output shape first, using broadcast rule
+  TensorShape output_shape;
+  TensorShape previous_output_shape = first_input_tensor.Shape();
+  for (int index = 1; index < input_count; index++) {
+    ORT_RETURN_IF_ERROR(ComputeOutputShape(
+        node_name, previous_output_shape, input_tensors[index].get().Shape(), output_shape));
+    previous_output_shape = output_shape;
+  }
+  Tensor& output_tensor = context->RequiredOutput(0, output_shape);
+
+  // special case for 2 inputs
+  if (input_count == 2) {
+    utils::MLTypeCallDispatcherRet<Status, BinaryImplDispatchTarget, SupportedElementTypes...> dispatcher(element_type);
+    ORT_RETURN_IF_ERROR(dispatcher.Invoke(input_tensors[0], input_tensors[1], output_tensor));
+
+    return Status::OK();
+  }
+
+  // general case for more than 2 inputs
+  {
+    utils::MLTypeCallDispatcherRet<Status, GeneralImplDispatchTarget, SupportedElementTypes...> dispatcher(
+        element_type);
+    ORT_RETURN_IF_ERROR(dispatcher.Invoke(input_tensors, output_tensor));
+  }
+
+  return Status::OK();
+}
+
+namespace {
+
+using SumOp = VariadicElementwiseOp<
+    variadic_elementwise_ops::Sum,
+    MLFloat16, float, double>;
+
+using MinOp = VariadicElementwiseOp<
+    variadic_elementwise_ops::Min,
+    uint32_t, uint64_t, int32_t, int64_t, MLFloat16, float, double>;
+
+using MaxOp = VariadicElementwiseOp<
+    variadic_elementwise_ops::Max,
+    uint32_t, uint64_t, int32_t, int64_t, MLFloat16, float, double>;
+
+const auto k_uzilhfd_datatypes =
+    BuildKernelDefConstraints<uint32_t, uint64_t, int32_t, int64_t, MLFloat16, float, double>();
+const auto k_hfd_datatypes =
+    BuildKernelDefConstraints<MLFloat16, float, double>();
+
+}  // namespace
+
+// kernel registration
+
+#define REGISTER_KERNEL(name, impl_class, version, datatypes) \
+  ONNX_OPERATOR_KERNEL_EX(                                    \
+      name,                                                   \
+      kOnnxDomain,                                            \
+      version,                                                \
+      kCudaExecutionProvider,                                 \
+      KernelDefBuilder().TypeConstraint("T", datatypes),      \
+      impl_class)
+
+#define REGISTER_VERSIONED_KERNEL(name, impl_class, start_version, end_version, datatypes) \
+  ONNX_OPERATOR_VERSIONED_KERNEL_EX(                                                       \
+      name,                                                                                \
+      kOnnxDomain,                                                                         \
+      start_version, end_version,                                                          \
+      kCudaExecutionProvider,                                                              \
+      KernelDefBuilder().TypeConstraint("T", datatypes),                                   \
+      impl_class)
+
+REGISTER_KERNEL(Sum, SumOp, 8, k_hfd_datatypes)
+REGISTER_VERSIONED_KERNEL(Sum, SumOp, 6, 7, k_hfd_datatypes)
+
+REGISTER_KERNEL(Min, MinOp, 12, k_uzilhfd_datatypes)
+REGISTER_VERSIONED_KERNEL(Min, MinOp, 6, 11, k_hfd_datatypes)
+
+REGISTER_KERNEL(Max, MaxOp, 12, k_uzilhfd_datatypes)
+REGISTER_VERSIONED_KERNEL(Max, MaxOp, 6, 11, k_hfd_datatypes)
+
+#undef REGISTER_VERSIONED_KERNEL
+#undef REGISTER_KERNEL
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops.cc
+++ b/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops.cc
@@ -24,7 +24,7 @@ Status VariadicElementwiseOp<VariadicElementwiseOpTag, SupportedElementTypes...>
 
   InputBatchArray<CudaT> input_data_batch{static_cast<int32_t>(inputs.size())};
   for (size_t i = 0; i < inputs.size(); ++i) {
-    input_data_batch[i] = reinterpret_cast<const CudaT*>(inputs[i].get().template Data<T>());
+    input_data_batch[static_cast<int32_t>(i)] = reinterpret_cast<const CudaT*>(inputs[i].get().template Data<T>());
   }
 
   CudaT* output_data = reinterpret_cast<CudaT*>(output.template MutableData<T>());

--- a/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops.h
+++ b/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops.h
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <functional>
+#include <vector>
+
+#include "core/providers/cuda/cuda_common.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+using InputTensorVector = std::vector<std::reference_wrapper<const Tensor>>;
+
+template <typename VariadicElementwiseOpTag,
+          typename... SupportedElementTypes>
+class VariadicElementwiseOp : public CudaKernel {
+ public:
+  VariadicElementwiseOp(const OpKernelInfo& info) : CudaKernel(info) {}
+
+ private:
+  Status ComputeInternal(OpKernelContext* context) const override;
+
+  template <typename T>
+  struct NoBroadcastBatchImplDispatchTarget {
+    Status operator()(const InputTensorVector& inputs, Tensor& output) const;
+  };
+
+  template <typename T>
+  struct BinaryImplDispatchTarget {
+    Status operator()(const Tensor& lhs, const Tensor& rhs, Tensor& output) const;
+  };
+
+  template <typename T>
+  struct GeneralImplDispatchTarget {
+    Status operator()(const InputTensorVector& inputs, Tensor& output) const;
+  };
+};
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops_impl.cu
+++ b/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops_impl.cu
@@ -121,20 +121,24 @@ void Impl_NoBroadcastInputBatch(
 // D: double
 // O: bool
 
+#define SPECIALIZE_IMPL_HFD(VariadicElementwiseOpTag) \
+  SPECIALIZE_IMPL(half, VariadicElementwiseOpTag)     \
+  SPECIALIZE_IMPL(float, VariadicElementwiseOpTag)    \
+  SPECIALIZE_IMPL(double, VariadicElementwiseOpTag)
+
 #define SPECIALIZE_IMPL_UZILHFD(VariadicElementwiseOpTag) \
   SPECIALIZE_IMPL(uint32_t, VariadicElementwiseOpTag)     \
   SPECIALIZE_IMPL(uint64_t, VariadicElementwiseOpTag)     \
   SPECIALIZE_IMPL(int32_t, VariadicElementwiseOpTag)      \
   SPECIALIZE_IMPL(int64_t, VariadicElementwiseOpTag)      \
-  SPECIALIZE_IMPL(half, VariadicElementwiseOpTag)         \
-  SPECIALIZE_IMPL(float, VariadicElementwiseOpTag)        \
-  SPECIALIZE_IMPL(double, VariadicElementwiseOpTag)
+  SPECIALIZE_IMPL_HFD(VariadicElementwiseOpTag)
 
-SPECIALIZE_IMPL_UZILHFD(variadic_elementwise_ops::Sum)
+SPECIALIZE_IMPL_HFD(variadic_elementwise_ops::Sum)
 SPECIALIZE_IMPL_UZILHFD(variadic_elementwise_ops::Min)
 SPECIALIZE_IMPL_UZILHFD(variadic_elementwise_ops::Max)
 
 #undef SPECIALIZE_IMPL_UZILHFD
+#undef SPECIALIZE_IMPL_HFD
 #undef SPECIALIZE_IMPL
 
 }  // namespace cuda

--- a/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops_impl.cu
+++ b/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops_impl.cu
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cuda/math/variadic_elementwise_ops_impl.h"
+
+#include "core/providers/cuda/cu_inc/variadic_elementwise_impl.cuh"
+#include "core/providers/cuda/math/binary_elementwise_ops_impl.h"
+#include "core/providers/cuda/math/binary_elementwise_ops_impl_functors.cuh"
+#include "core/providers/cuda/math/variadic_elementwise_ops_tags.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+template <typename T, typename VariadicElementwiseOpTag>
+struct VariadicElementwiseOpTraits;
+
+#define DEFINE_TRAITS(VariadicElementwiseOpTag, ImplName)           \
+  template <typename T>                                             \
+  struct VariadicElementwiseOpTraits<T, VariadicElementwiseOpTag> { \
+    using ScalarComputeFunctor = OP_##ImplName<T, T>;               \
+                                                                    \
+    static void ComputeFn(                                          \
+        int32_t output_rank_or_simple_broadcast,                    \
+        const TArray<int64_t>* lhs_padded_strides,                  \
+        const T* lhs_data,                                          \
+        const TArray<int64_t>* rhs_padded_strides,                  \
+        const T* rhs_data,                                          \
+        const TArray<fast_divmod>* fdm_output_strides,              \
+        const fast_divmod& fdm_H,                                   \
+        const fast_divmod& fdm_C,                                   \
+        T* output_data,                                             \
+        size_t count) {                                             \
+      Impl_##ImplName(                                              \
+          output_rank_or_simple_broadcast,                          \
+          lhs_padded_strides,                                       \
+          lhs_data,                                                 \
+          rhs_padded_strides,                                       \
+          rhs_data,                                                 \
+          fdm_output_strides,                                       \
+          fdm_H,                                                    \
+          fdm_C,                                                    \
+          output_data,                                              \
+          count);                                                   \
+    }                                                               \
+  };
+
+DEFINE_TRAITS(variadic_elementwise_ops::Sum, Add)
+DEFINE_TRAITS(variadic_elementwise_ops::Min, Min)
+DEFINE_TRAITS(variadic_elementwise_ops::Max, Max)
+
+#undef DEFINE_TRAITS
+
+template <typename T, typename VariadicElementwiseOpTag>
+void Impl_General(
+    int32_t output_rank_or_simple_broadcast,
+    const TArray<int64_t>* lhs_padded_strides,
+    const T* lhs_data,
+    const TArray<int64_t>* rhs_padded_strides,
+    const T* rhs_data,
+    const TArray<fast_divmod>* fdm_output_strides,
+    const fast_divmod& fdm_H,
+    const fast_divmod& fdm_C,
+    T* output_data,
+    size_t count) {
+  VariadicElementwiseOpTraits<T, VariadicElementwiseOpTag>::ComputeFn(
+      output_rank_or_simple_broadcast,
+      lhs_padded_strides,
+      lhs_data,
+      rhs_padded_strides,
+      rhs_data,
+      fdm_output_strides,
+      fdm_H,
+      fdm_C,
+      output_data,
+      count);
+}
+
+template <typename T, typename VariadicElementwiseOpTag>
+void Impl_NoBroadcastInputBatch(
+    InputBatchArray<T> input_data_batch,
+    T* output_data,
+    size_t count) {
+  VariadicElementWiseNoBroadcastInputBatchImpl<
+      T, typename VariadicElementwiseOpTraits<T, VariadicElementwiseOpTag>::ScalarComputeFunctor,
+      k_max_input_batch_size>(
+      typename VariadicElementwiseOpTraits<T, VariadicElementwiseOpTag>::ScalarComputeFunctor{},
+      count,
+      input_data_batch,
+      output_data);
+}
+
+#define SPECIALIZE_IMPL(T, VariadicElementwiseOpTag)                     \
+  template void Impl_General<T, VariadicElementwiseOpTag>(               \
+      int32_t output_rank_or_simple_broadcast,                           \
+      const TArray<int64_t>* lhs_padded_strides,                         \
+      const T* lhs_data,                                                 \
+      const TArray<int64_t>* rhs_padded_strides,                         \
+      const T* rhs_data,                                                 \
+      const TArray<fast_divmod>* fdm_output_strides,                     \
+      const fast_divmod& fdm_H,                                          \
+      const fast_divmod& fdm_C,                                          \
+      T* output_data,                                                    \
+      size_t count);                                                     \
+                                                                         \
+  template void Impl_NoBroadcastInputBatch<T, VariadicElementwiseOpTag>( \
+      InputBatchArray<T> input_data_batch,                               \
+      T * output_data,                                                   \
+      size_t count);
+
+// the postfix means the types supported by the op:
+// B: uint8_t
+// W: uint16_t
+// U: uint32_t
+// Z: uint64_t
+// C: int8_t
+// S: int16_t
+// I: int32_t
+// L: int64_t
+// H: float16
+// F: float
+// D: double
+// O: bool
+
+#define SPECIALIZE_IMPL_UZILHFD(VariadicElementwiseOpTag) \
+  SPECIALIZE_IMPL(uint32_t, VariadicElementwiseOpTag)     \
+  SPECIALIZE_IMPL(uint64_t, VariadicElementwiseOpTag)     \
+  SPECIALIZE_IMPL(int32_t, VariadicElementwiseOpTag)      \
+  SPECIALIZE_IMPL(int64_t, VariadicElementwiseOpTag)      \
+  SPECIALIZE_IMPL(half, VariadicElementwiseOpTag)         \
+  SPECIALIZE_IMPL(float, VariadicElementwiseOpTag)        \
+  SPECIALIZE_IMPL(double, VariadicElementwiseOpTag)
+
+SPECIALIZE_IMPL_UZILHFD(variadic_elementwise_ops::Sum)
+SPECIALIZE_IMPL_UZILHFD(variadic_elementwise_ops::Min)
+SPECIALIZE_IMPL_UZILHFD(variadic_elementwise_ops::Max)
+
+#undef SPECIALIZE_IMPL_UZILHFD
+#undef SPECIALIZE_IMPL
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops_impl.h
+++ b/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops_impl.h
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "core/providers/cuda/shared_inc/cuda_utils.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+template <typename T, typename VariadicElementwiseOpTag>
+void Impl_General(
+    int32_t output_rank_or_simple_broadcast,
+    const TArray<int64_t>* lhs_padded_strides,
+    const T* lhs_data,
+    const TArray<int64_t>* rhs_padded_strides,
+    const T* rhs_data,
+    const TArray<fast_divmod>* fdm_output_strides,
+    const fast_divmod& fdm_H,
+    const fast_divmod& fdm_C,
+    T* output_data,
+    size_t count);
+
+constexpr int32_t k_max_input_batch_size = 8;
+
+template <typename T>
+using InputBatchArray = TArray<const T*, k_max_input_batch_size>;
+
+template <typename T, typename VariadicElementwiseOpTag>
+void Impl_NoBroadcastInputBatch(
+    InputBatchArray<T> input_data_batch,
+    T* output_data,
+    size_t count);
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops_impl.h
+++ b/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops_impl.h
@@ -23,7 +23,7 @@ void Impl_General(
     T* output_data,
     size_t count);
 
-constexpr int32_t k_max_input_batch_size = 8;
+constexpr int32_t k_max_input_batch_size = 16;
 
 template <typename T>
 using InputBatchArray = TArray<const T*, k_max_input_batch_size>;

--- a/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops_impl.h
+++ b/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops_impl.h
@@ -23,7 +23,7 @@ void Impl_General(
     T* output_data,
     size_t count);
 
-constexpr int32_t k_max_input_batch_size = 16;
+constexpr int32_t k_max_input_batch_size = 8;
 
 template <typename T>
 using InputBatchArray = TArray<const T*, k_max_input_batch_size>;

--- a/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops_tags.h
+++ b/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops_tags.h
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+namespace onnxruntime {
+namespace cuda {
+namespace variadic_elementwise_ops {
+struct Sum {};
+struct Min {};
+struct Max {};
+}  // namespace variadic_elementwise_ops
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/shared_inc/cuda_utils.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/cuda_utils.h
@@ -51,14 +51,27 @@ struct TArray {
   }
 
   TArray(int32_t size) : size_(size), data_() {
-    ORT_ENFORCE(size <= capacity, "TArray size was set to ", size, ", exeeding the capacity limit of ", capacity);
+    ORT_ENFORCE(
+        0 <= size && size <= capacity,
+        "TArray size must be within range [0, ", capacity, "]. Actual: ", size);
   }
 
-  TArray(const std::vector<T>& vec) : TArray(static_cast<int32_t>(vec.size()))  {
+  TArray(const std::vector<T>& vec) : TArray(static_cast<int32_t>(vec.size())) {
     memcpy(data_, vec.data(), vec.size() * sizeof(T));
   }
 
-  T& operator[](int32_t index) {
+  void SetSize(int32_t size) {
+    ORT_ENFORCE(
+        0 <= size && size <= capacity,
+        "TArray size must be within range [0, ", capacity, "]. Actual: ", size);
+    size_ = size;
+  }
+
+  __host__ __device__ int32_t Size() const {
+    return size_;
+  }
+
+  __host__ __device__ T& operator[](int32_t index) {
     return data_[index];
   }
 
@@ -66,8 +79,17 @@ struct TArray {
     return data_[index];
   }
 
+  __host__ __device__ T* Data() {
+    return data_;
+  }
+
+  __host__ __device__ const T* Data() const {
+    return data_;
+  }
+
   static constexpr int32_t GetCapacity() { return capacity; };
 
+ public:  // TODO make these private
   int32_t size_;
   T data_[capacity];
 };

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -880,7 +880,7 @@ static void TestSumMultipleInputsNoBroadcasting(size_t num_inputs, const TensorS
 
 TEST(MathOpTest, SumMultipleInputsNoBroadcasting) {
   const TensorShape shape{3, 3, 3};
-  for (size_t num_inputs = 2; num_inputs < 20; ++num_inputs) {
+  for (size_t num_inputs = 2; num_inputs < 10; ++num_inputs) {
     TestSumMultipleInputsNoBroadcasting(num_inputs, shape);
   }
 }

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -150,11 +150,11 @@ TEST(MathOpTest, Add_Broadcast_MultidirectionalAB) {
                         {4.0f, 5.0f, 6.0f,
                          3.0f, 4.0f, 5.0f,
                          2.0f, 3.0f, 4.0f});
-  #if defined(OPENVINO_CONFIG_GPU_FP32) || defined(OPENVINO_CONFIG_GPU_FP16) || defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M)
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider,kOpenVINOExecutionProvider});  // OpenVINO: disabled temporarily due to accurarcy issues
-  #else
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  //TensorRT: got C with shape [3, 1]
-  #endif
+#if defined(OPENVINO_CONFIG_GPU_FP32) || defined(OPENVINO_CONFIG_GPU_FP16) || defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M)
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // OpenVINO: disabled temporarily due to accurarcy issues
+#else
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  //TensorRT: got C with shape [3, 1]
+#endif
 }
 
 TEST(MathOpTest, Add_Broadcast_MultidirectionalBA) {
@@ -170,11 +170,11 @@ TEST(MathOpTest, Add_Broadcast_MultidirectionalBA) {
                         {4.0f, 5.0f, 6.0f,
                          3.0f, 4.0f, 5.0f,
                          2.0f, 3.0f, 4.0f});
-  #if defined(OPENVINO_CONFIG_GPU_FP32) || defined(OPENVINO_CONFIG_GPU_FP16)
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider,kOpenVINOExecutionProvider});  // OpenVINO: disabled temporarily due to accurarcy issues
-  #else
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  //TensorRT: got C with shape [3, 1]
-  #endif
+#if defined(OPENVINO_CONFIG_GPU_FP32) || defined(OPENVINO_CONFIG_GPU_FP16)
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  // OpenVINO: disabled temporarily due to accurarcy issues
+#else
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  //TensorRT: got C with shape [3, 1]
+#endif
 }
 
 TEST(MathOpTest, Add_Broadcast_0x0) {
@@ -489,7 +489,7 @@ TEST(MathOpTest, Neg_int8) {
 
 // OpenVINO EP: Disabled temporarily
 #if defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M)
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider,kOpenVINOExecutionProvider});  //TensorRT: INT8 is not supported
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  //TensorRT: INT8 is not supported
 #else
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  //TensorRT: INT8 is not supported
 #endif
@@ -814,7 +814,7 @@ TEST(MathOpTest, Sum_8_Test1) {
   //This test runs fine on CPU Plugin
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 #else
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  //TensorRT: Expected output shape [{3,3,3}] did not match run output shape [{3,1,1}] for sum
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});                    //TensorRT: Expected output shape [{3,3,3}] did not match run output shape [{3,1,1}] for sum
 #endif
 }
 
@@ -846,10 +846,43 @@ TEST(MathOpTest, Sum_8_Test2) {
 
 #if defined(OPENVINO_CONFIG_GPU_FP16) || defined(OPENVINO_CONFIG_GPU_FP32) || defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M)
   // OpenVINO: Disabled temporarily due to accuarcy issues
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider,kOpenVINOExecutionProvider});  //TensorRT: Input batch size is inconsistent
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  //TensorRT: Input batch size is inconsistent
 #else
   test.Run(OpTester::ExpectResult::kExpectSuccess, "Sum is not correct", {kTensorrtExecutionProvider});  //TensorRT: result differs
 #endif
+}
+
+static void TestSumMultipleInputsNoBroadcasting(size_t num_inputs, const TensorShape& shape) {
+  using element_type = float;
+
+  OpTester test{"Sum", 8};
+
+  const auto& dims = shape.GetDims();
+  const std::vector<element_type> input_data(shape.Size(), 1);
+
+  for (size_t i = 0; i < num_inputs; ++i) {
+    test.AddInput<element_type>(MakeString("data_", i).c_str(), dims, input_data);
+  }
+
+  const std::vector<element_type> expected_output_data =
+      [&input_data, num_inputs]() {
+        std::vector<element_type> result;
+        std::transform(
+            input_data.begin(), input_data.end(), std::back_inserter(result),
+            [num_inputs](element_type value) { return num_inputs * value; });
+        return result;
+      }();
+
+  test.AddOutput<element_type>("sum", dims, expected_output_data);
+
+  test.Run();
+}
+
+TEST(MathOpTest, SumMultipleInputsNoBroadcasting) {
+  const TensorShape shape{3, 3, 3};
+  for (size_t num_inputs = 2; num_inputs < 20; ++num_inputs) {
+    TestSumMultipleInputsNoBroadcasting(num_inputs, shape);
+  }
 }
 
 TEST(MathOpTest, Min_6) {
@@ -871,11 +904,11 @@ TEST(MathOpTest, Min_6) {
                         {1.0f, 0.0f, 1.0f,
                          -3.0f, 1.1f, -100.0f,
                          -5.4f, 0.01f, -10000.0f});
-  #if defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M)
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});  // OpenVINO: Disabled due to accuracy mismatch
-  #else
-    test.Run();
-  #endif
+#if defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M)
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});  // OpenVINO: Disabled due to accuracy mismatch
+#else
+  test.Run();
+#endif
 }
 
 TEST(MathOpTest, Min_8) {
@@ -897,11 +930,11 @@ TEST(MathOpTest, Min_8) {
                         {1.0f, 0.0f, 1.0f,
                          -3.0f, 1.1f, -100.0f,
                          -5.4f, 0.01f, -10000.0f});
-  #if defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M)
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});  // OpenVINO: Disabled due to accuracy mismatch
-  #else
-    test.Run();
-  #endif
+#if defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M)
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});  // OpenVINO: Disabled due to accuracy mismatch
+#else
+  test.Run();
+#endif
 }
 
 TEST(MathOpTest, Min_12_Float) {
@@ -1025,11 +1058,11 @@ TEST(MathOpTest, Max_6) {
                         {1.0f, 0.0f, 3.0f,
                          -1.0f, 3.3f, 64.0f,
                          5.4f, 0.03f, 10000.0f});
-  #if defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M)
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});  // OpenVINO: Disabled due to accuracy mismatch
-  #else
-    test.Run();
-  #endif
+#if defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M)
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});  // OpenVINO: Disabled due to accuracy mismatch
+#else
+  test.Run();
+#endif
 }
 
 TEST(MathOpTest, Max_8_Float) {
@@ -1496,12 +1529,12 @@ TEST(MathOpTest, Mean_6) {
                         {1.0f, 0.0f, 2.0f,
                          -2.0f, 2.2f, 10.0f,
                          -3.0f, 0.02f, -4.0f});
-  // OpenVINO: Disabled due to accuracy mismatch
-  #if defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M)
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});
-  #else
-    test.Run();
-  #endif
+// OpenVINO: Disabled due to accuracy mismatch
+#if defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M)
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});
+#else
+  test.Run();
+#endif
 }
 
 TEST(MathOpTest, Mean_8) {
@@ -1517,12 +1550,12 @@ TEST(MathOpTest, Mean_8) {
                         {12.0f / 3.0f, 22.0f / 3.0f, 32.0f / 3.0f,
                          43.0f / 3.0f, 53.0f / 3.0f, 63.0f / 3.0f,
                          74.0f / 3.0f, 84.0f / 3.0f, 94.0f / 3.0f});
-  // OpenVINO: Disabled due to accuracy mismatch
-  #if defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M)
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider,kOpenVINOExecutionProvider});  //TensorRT: Input batch size is inconsistent
-  #else
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  //TensorRT: Input batch size is inconsistent
-  #endif
+// OpenVINO: Disabled due to accuracy mismatch
+#if defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M)
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  //TensorRT: Input batch size is inconsistent
+#else
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  //TensorRT: Input batch size is inconsistent
+#endif
 }
 
 template <float (&op)(float value)>

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -814,7 +814,7 @@ TEST(MathOpTest, Sum_8_Test1) {
   //This test runs fine on CPU Plugin
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 #else
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});                    //TensorRT: Expected output shape [{3,3,3}] did not match run output shape [{3,1,1}] for sum
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  //TensorRT: Expected output shape [{3,3,3}] did not match run output shape [{3,1,1}] for sum
 #endif
 }
 


### PR DESCRIPTION
**Description**
For the special case where all variadic inputs of a kernel are the same shape (i.e. no broadcasting is required) and there are few enough of them, we can perform the entire computation in a single kernel. The general implementation (which was previously used for this special case) handles broadcasting by repeatedly invoking a binary kernel on successive inputs.

**Motivation and Context**
Performance. The original motivation was to optimize Sum, but after some refactoring Min and Max should get similar benefits.

**Performance tests**
baseline (0349479b19d7735956be3cfb0bc1c8014a214dbb), updated (04f27de6c95d525a0ba2cab672ed44b495526a6d)

CUDA kernel benchmark:
The CUDA Sum op kernel was run 100 times with the specified input shape and number of inputs.
num_calls, average_duration, total_time and total_percentage refer to CUDA kernel calls.
The particular case motivating the optimization has four inputs, shown here. The full data including other input counts can be found in a separate PR comment.

baseline:
input_shape|input_count|num_calls|average_duration|total_time|total_percentage
-|-|-|-|-|-
[1024]|4|400|1.570000us|628.221000us|36.347473
[1024,1024]|4|400|13.243000us|5.297296ms|2.439728
[16,1024,1024]|4|400|0.238441ms|0.095377s|2.263378

updated:
input_shape|input_count|num_calls|average_duration|total_time|total_percentage
-|-|-|-|-|-
[1024]|4|100|2.167000us|216.700000us|19.038917
[1024,1024]|4|100|30.299000us|3.029963ms|1.520693
[16,1024,1024]|4|100|0.416080ms|0.041608s|1.083528

BERT large throughput:
```
./onnxruntime_training_bert --model_name /bert_ort/bert_models/nv/bert-large/bert-large-uncased_L_24_H_1024_A_16_V_30528_S_512_Dp_0.1_optimized_layer_norm --train_data_dir /bert_data/128/books_wiki_en_corpus/train --test_data_dir /bert_data/128/books_wiki_en_corpus/test --train_batch_size 64 --mode train --num_train_steps 400 --display_loss_steps 1 --warmup_ratio=0.2843 --warmup_mode=Poly --optimizer lamb --gradient_accumulation_steps 1 --max_predictions_per_seq=20 --use_nccl --use_mixed_precision --allreduce_in_fp16
```

baseline:
Stabilized Throughput: 180.306 Examples / Second

updated:
Stabilized Throughput: 182.129 Examples / Second

1.01% improvement