### PR TITLE
MLAS: support prepacking APIs for quantized GEMM

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
@@ -14,69 +14,71 @@
 namespace onnxruntime {
 namespace contrib {
 
-class DynamicQuantizeMatMul final : public OpKernel {
+class MatMulIntegerToFloatBase : public OpKernel {
  public:
-  DynamicQuantizeMatMul(const OpKernelInfo& info) : OpKernel(info) {}
+  MatMulIntegerToFloatBase(const OpKernelInfo& info) : OpKernel(info) {
+    TryPackWeights(info);
+  }
 
-  Status Compute(OpKernelContext* context) const override;
+ protected:
+  void TryPackWeights(const OpKernelInfo& info);
+  Status ComputeCommon(OpKernelContext* ctx,
+                       const uint8_t* a_data,
+                       const TensorShape& a_shape,
+                       uint8_t a_zero_point,
+                       const Tensor* b,
+                       uint8_t b_zero_point,
+                       float multiplier,
+                       const Tensor* bias_tensor) const;
+
+#ifdef MLAS_SUPPORTS_PACKED_GEMM_U8X8
+  BufferUniquePtr packed_b_;
+#endif
 };
 
-ONNX_OPERATOR_TYPED_KERNEL_EX(
-    DynamicQuantizeMatMul,
-    kMSDomain,
-    1,
-    float,
-    kCpuExecutionProvider,
-    KernelDefBuilder()
-        .TypeConstraint("T1", DataTypeImpl::GetTensorType<float>())
-        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()}),
-    DynamicQuantizeMatMul);
+void MatMulIntegerToFloatBase::TryPackWeights(const OpKernelInfo& info) {
+#ifdef MLAS_SUPPORTS_PACKED_GEMM_U8X8
+  // Check if the weights tensor is constant.
+  const Tensor* b;
+  if (!info.TryGetConstantInput(1, &b)) {
+    return;
+  }
 
-class MatMulIntegerToFloat final : public OpKernel {
- public:
-  MatMulIntegerToFloat(const OpKernelInfo& info) : OpKernel(info) {}
+  // Only handle the common case of a 2D weight matrix. Additional matrices
+  // could be handled by stacking the packed buffers.
+  const auto& b_shape = b->Shape();
+  if (b_shape.NumDimensions() != 2) {
+    return;
+  }
 
-  Status Compute(OpKernelContext* context) const override;
-};
+  const size_t K = static_cast<size_t>(b_shape[0]);
+  const size_t N = static_cast<size_t>(b_shape[1]);
 
-ONNX_OPERATOR_TYPED_KERNEL_EX(
-    MatMulIntegerToFloat,
-    kMSDomain,
-    1,
-    uint8_t,
-    kCpuExecutionProvider,
-    KernelDefBuilder()
-        .TypeConstraint("T1", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()})
-        .TypeConstraint("T3", DataTypeImpl::GetTensorType<float>()),
-    MatMulIntegerToFloat);
+  const auto* b_data = static_cast<const uint8_t*>(b->DataRaw());
+  const bool b_is_signed = b->IsDataType<int8_t>();
 
-static void GetQuantizationParameter(const float* data, int64_t num_of_elements, float& scale, uint8_t& zp) {
-  // find input range min and max
-  float min, max;
-  MlasFindMinMaxElement(data, &min, &max, num_of_elements);
+  const size_t packed_b_size = MlasGemmPackBSize(N, K, b_is_signed);
+  if (packed_b_size == 0) {
+    return;
+  }
 
-  // ensure the input range includes zero
-  min = std::min(min, 0.0f);
-  max = std::max(max, 0.0f);
-
-  // find scale and zero point
-  uint8_t qmin = 0;
-  uint8_t qmax = 255;
-  scale = max == min ? 1.0f : (max - min) / (qmax - qmin);
-
-  float initial_zero_point = qmin - min / scale;
-  zp = static_cast<uint8_t>(RoundHalfToEven(std::max(float(qmin), std::min(float(qmax), initial_zero_point))));
+  auto alloc = info.GetAllocator(0, OrtMemTypeDefault);
+  auto* packed_b_data = alloc->Alloc(packed_b_size);
+  packed_b_ = BufferUniquePtr(packed_b_data, BufferDeleter(alloc));
+  MlasGemmPackB(N, K, b_data, N, b_is_signed, packed_b_data);
+#else
+  ORT_UNUSED_PARAMETER(info);
+#endif
 }
 
-static Status MatMulIntegerToFloatCommon(OpKernelContext* ctx,
-                                         const uint8_t* a_data,
-                                         const TensorShape& a_shape,
-                                         uint8_t a_zero_point,
-                                         const Tensor* b,
-                                         uint8_t b_zero_point,
-                                         float multiplier,
-                                         const Tensor* bias_tensor) {
+Status MatMulIntegerToFloatBase::ComputeCommon(OpKernelContext* ctx,
+                                               const uint8_t* a_data,
+                                               const TensorShape& a_shape,
+                                               uint8_t a_zero_point,
+                                               const Tensor* b,
+                                               uint8_t b_zero_point,
+                                               float multiplier,
+                                               const Tensor* bias_tensor) const {
   MatMulComputeHelper helper;
   ORT_RETURN_IF_ERROR(helper.Compute(a_shape, b->Shape()));
   Tensor* y = ctx->Output(0, helper.OutputShape());
@@ -89,6 +91,25 @@ static Status MatMulIntegerToFloatCommon(OpKernelContext* ctx,
   concurrency::ThreadPool* thread_pool = ctx->GetOperatorThreadPool();
 
   for (size_t i = 0; i < helper.OutputOffsets().size(); i++) {
+#ifdef MLAS_SUPPORTS_PACKED_GEMM_U8X8
+    if (packed_b_) {
+      MlasGemm(static_cast<size_t>(helper.M()),
+               static_cast<size_t>(helper.N()),
+               static_cast<size_t>(helper.K()),
+               a_data + helper.LeftOffsets()[i],
+               static_cast<size_t>(helper.K()),
+               a_zero_point,
+               packed_b_.get(),
+               b_zero_point,
+               b_is_signed,
+               y_data + helper.OutputOffsets()[i],
+               static_cast<size_t>(helper.N()),
+               &multiplier,
+               nullptr,
+               thread_pool);
+      continue;
+    }
+#endif
     QGemm(static_cast<int>(helper.M()),
           static_cast<int>(helper.N()),
           static_cast<int>(helper.K()),
@@ -109,6 +130,38 @@ static Status MatMulIntegerToFloatCommon(OpKernelContext* ctx,
   return Status::OK();
 }
 
+class DynamicQuantizeMatMul final : public MatMulIntegerToFloatBase {
+ public:
+  DynamicQuantizeMatMul(const OpKernelInfo& info) : MatMulIntegerToFloatBase(info) {}
+
+  Status Compute(OpKernelContext* context) const override;
+};
+
+class MatMulIntegerToFloat final : public MatMulIntegerToFloatBase {
+ public:
+  MatMulIntegerToFloat(const OpKernelInfo& info) : MatMulIntegerToFloatBase(info) {}
+
+  Status Compute(OpKernelContext* context) const override;
+};
+
+static void GetQuantizationParameter(const float* data, int64_t num_of_elements, float& scale, uint8_t& zp) {
+  // find input range min and max
+  float min, max;
+  MlasFindMinMaxElement(data, &min, &max, num_of_elements);
+
+  // ensure the input range includes zero
+  min = std::min(min, 0.0f);
+  max = std::max(max, 0.0f);
+
+  // find scale and zero point
+  uint8_t qmin = 0;
+  uint8_t qmax = 255;
+  scale = max == min ? 1.0f : (max - min) / (qmax - qmin);
+
+  float initial_zero_point = qmin - min / scale;
+  zp = static_cast<uint8_t>(RoundHalfToEven(std::max(float(qmin), std::min(float(qmax), initial_zero_point))));
+}
+
 Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
   const auto* a = ctx->Input<Tensor>(0);
   const auto* b = ctx->Input<Tensor>(1);
@@ -116,7 +169,6 @@ Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
   const auto* b_scale_tensor = ctx->Input<Tensor>(2);
   ORT_ENFORCE(IsScalarOr1ElementVector(b_scale_tensor),
               "DynamicQuantizeMatMul : input B scale must be a scalar or 1D tensor of size 1. Per-Channel is not supported yet.");
-
   float b_scale = *b_scale_tensor->template Data<float>();
 
   const auto* b_zero_point_tensor = ctx->Input<Tensor>(3);
@@ -142,14 +194,14 @@ Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
   // quantize the data
   MlasQuantizeLinear(a_data, a_data_quant, num_of_elements, a_scale, a_zero_point);
 
-  return MatMulIntegerToFloatCommon(ctx,
-                                    a_data_quant,
-                                    a->Shape(),
-                                    a_zero_point,
-                                    b,
-                                    b_zero_point,
-                                    a_scale * b_scale,
-                                    ctx->Input<Tensor>(4));
+  return ComputeCommon(ctx,
+                       a_data_quant,
+                       a->Shape(),
+                       a_zero_point,
+                       b,
+                       b_zero_point,
+                       a_scale * b_scale,
+                       ctx->Input<Tensor>(4));
 }
 
 Status MatMulIntegerToFloat::Compute(OpKernelContext* ctx) const {
@@ -183,15 +235,38 @@ Status MatMulIntegerToFloat::Compute(OpKernelContext* ctx) const {
     b_zero_point = *static_cast<const uint8_t*>(b_zero_point_tensor->DataRaw());
   }
 
-  return MatMulIntegerToFloatCommon(ctx,
-                                    a->Data<uint8_t>(),
-                                    a->Shape(),
-                                    a_zero_point,
-                                    b,
-                                    b_zero_point,
-                                    a_scale * b_scale,
-                                    ctx->Input<Tensor>(6));
+  return ComputeCommon(ctx,
+                       a->Data<uint8_t>(),
+                       a->Shape(),
+                       a_zero_point,
+                       b,
+                       b_zero_point,
+                       a_scale * b_scale,
+                       ctx->Input<Tensor>(6));
 }
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    DynamicQuantizeMatMul,
+    kMSDomain,
+    1,
+    float,
+    kCpuExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<float>())
+        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()}),
+    DynamicQuantizeMatMul);
+
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    MatMulIntegerToFloat,
+    kMSDomain,
+    1,
+    uint8_t,
+    kCpuExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<uint8_t>())
+        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()})
+        .TypeConstraint("T3", DataTypeImpl::GetTensorType<float>()),
+    MatMulIntegerToFloat);
 
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -185,6 +185,65 @@ MlasGemm(
     MLAS_THREADPOOL* ThreadPool
     );
 
+void
+MLASCALL
+MlasGemm(
+    size_t M,
+    size_t N,
+    size_t K,
+    const uint8_t* A,
+    size_t lda,
+    uint8_t offa,
+    const void* PackedB,
+    uint8_t offb,
+    bool BIsSigned,
+    int32_t* C,
+    size_t ldc,
+    MLAS_THREADPOOL* ThreadPool
+    );
+
+void
+MLASCALL
+MlasGemm(
+    size_t M,
+    size_t N,
+    size_t K,
+    const uint8_t* A,
+    size_t lda,
+    uint8_t offa,
+    const void* PackedB,
+    uint8_t offb,
+    bool BIsSigned,
+    float* C,
+    size_t ldc,
+    const float* Scale,
+    const float* Bias,
+    MLAS_THREADPOOL* ThreadPool
+    );
+
+//
+// Buffer packing routines.
+//
+
+size_t
+MLASCALL
+MlasGemmPackBSize(
+    size_t N,
+    size_t K,
+    bool BIsSigned
+    );
+
+void
+MLASCALL
+MlasGemmPackB(
+    size_t N,
+    size_t K,
+    const uint8_t* B,
+    size_t ldb,
+    bool BIsSigned,
+    void* PackedB
+    );
+
 //
 // Convolution routines.
 //

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -543,10 +543,6 @@ extern "C" {
     MLAS_SGEMM_TRANSPOSE_PACKB_BLOCK_ROUTINE MlasSgemmTransposePackB16x4Avx;
 #endif
 
-#if defined(MLAS_TARGET_AMD64_IX86)
-    MLAS_GEMM_U8X8_OPERATION MlasGemmU8X8OperationSse;
-    MLAS_GEMM_U8X8_OPERATION MlasGemmU8S8OperationAvx2;
-    MLAS_GEMM_U8X8_OPERATION MlasGemmU8U8OperationAvx2;
 #if defined(MLAS_TARGET_AMD64)
     MLAS_GEMM_U8S8_KERNEL MlasGemmU8S8KernelAvx2;
     MLAS_GEMV_U8S8_KERNEL MlasGemvU8S8KernelAvx2;
@@ -556,7 +552,6 @@ extern "C" {
     MLAS_GEMV_U8S8_KERNEL MlasGemvU8S8KernelAvx512Vnni;
     MLAS_GEMM_U8U8_KERNEL MlasGemmU8U8KernelAvx2;
     MLAS_GEMM_U8U8_KERNEL MlasGemmU8U8KernelAvx512Core;
-#endif
 #endif
 
 #if defined(MLAS_TARGET_AMD64)
@@ -675,6 +670,28 @@ MlasSgemmOperation(
     );
 
 //
+// Quantized integer matrix/matrix multiply operation.
+//
+
+struct MLAS_GEMM_U8X8_KERNEL_SSE;
+struct MLAS_GEMM_U8S8_KERNEL_AVX2;
+struct MLAS_GEMM_U8U8_KERNEL_AVX2;
+
+template<typename KernelType>
+void
+MLASCALL
+MlasGemmU8X8Operation(
+    const MLAS_GEMM_U8X8_WORK_BLOCK* WorkBlock
+    );
+
+template<typename KernelType>
+void
+MLASCALL
+MlasGemmU8X8PackedOperation(
+    const MLAS_GEMM_U8X8_WORK_BLOCK* WorkBlock
+    );
+
+//
 // Environment information class.
 //
 
@@ -684,8 +701,6 @@ struct MLAS_PLATFORM {
 
 #if defined(MLAS_TARGET_AMD64_IX86)
     PMLAS_GEMM_FLOAT_KERNEL GemmFloatKernel;
-    PMLAS_GEMM_U8X8_OPERATION GemmU8S8Operation;
-    PMLAS_GEMM_U8X8_OPERATION GemmU8U8Operation;
 #endif
 
 #if defined(MLAS_TARGET_AMD64)
@@ -693,8 +708,12 @@ struct MLAS_PLATFORM {
     PMLAS_SGEMM_KERNEL_M1_ROUTINE KernelM1TransposeBRoutine;
     PMLAS_SGEMM_TRANSPOSE_PACKB_BLOCK_ROUTINE TransposePackB16x4Routine;
     PMLAS_GEMM_DOUBLE_KERNEL GemmDoubleKernel;
+    PMLAS_GEMM_U8X8_OPERATION GemmU8S8Operation;
+    PMLAS_GEMM_U8X8_OPERATION GemmU8S8PackedOperation;
     PMLAS_GEMM_U8S8_KERNEL GemmU8S8Kernel;
     PMLAS_GEMV_U8S8_KERNEL GemvU8S8Kernel;
+    PMLAS_GEMM_U8X8_OPERATION GemmU8U8Operation;
+    PMLAS_GEMM_U8X8_OPERATION GemmU8U8PackedOperation;
     PMLAS_GEMM_U8U8_KERNEL GemmU8U8Kernel;
     PMLAS_CONV_FLOAT_KERNEL ConvNchwFloatKernel;
     PMLAS_CONV_FLOAT_KERNEL ConvNchwcFloatKernel;

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -115,13 +115,13 @@ Return Value:
     //
 
     this->GemmFloatKernel = MlasGemmFloatKernelSse;
-    this->GemmU8S8Operation = MlasGemmU8X8OperationSse;
-    this->GemmU8U8Operation = MlasGemmU8X8OperationSse;
 
 #if defined(MLAS_TARGET_AMD64)
 
     this->TransposePackB16x4Routine = MlasSgemmTransposePackB16x4Sse;
     this->GemmDoubleKernel = MlasGemmDoubleKernelSse;
+    this->GemmU8S8Operation = MlasGemmU8X8Operation<MLAS_GEMM_U8X8_KERNEL_SSE>;
+    this->GemmU8U8Operation = MlasGemmU8X8Operation<MLAS_GEMM_U8X8_KERNEL_SSE>;
     this->ConvNchwFloatKernel = MlasConvNchwFloatKernelSse;
     this->ConvNchwcFloatKernel = MlasConvNchwcFloatKernelSse;
     this->ConvDepthwiseFloatKernel = MlasConvDepthwiseFloatKernelSse;
@@ -200,10 +200,12 @@ Return Value:
 
             if (((Cpuid1[2] & 0x1000) != 0) && ((Cpuid7[1] & 0x20) != 0)) {
 
-                this->GemmU8S8Operation = MlasGemmU8S8OperationAvx2;
+                this->GemmU8S8Operation = MlasGemmU8X8Operation<MLAS_GEMM_U8S8_KERNEL_AVX2>;
+                this->GemmU8S8PackedOperation = MlasGemmU8X8PackedOperation<MLAS_GEMM_U8S8_KERNEL_AVX2>;
                 this->GemmU8S8Kernel = MlasGemmU8S8KernelAvx2;
                 this->GemvU8S8Kernel = MlasGemvU8S8KernelAvx2;
-                this->GemmU8U8Operation = MlasGemmU8U8OperationAvx2;
+                this->GemmU8U8Operation = MlasGemmU8X8Operation<MLAS_GEMM_U8U8_KERNEL_AVX2>;
+                this->GemmU8U8PackedOperation = MlasGemmU8X8PackedOperation<MLAS_GEMM_U8U8_KERNEL_AVX2>;
                 this->GemmU8U8Kernel = MlasGemmU8U8KernelAvx2;
 
                 this->GemmFloatKernel = MlasGemmFloatKernelFma3;
@@ -262,7 +264,8 @@ Return Value:
 
                         if ((Cpuid7[2] & 0x800) != 0) {
 
-                            this->GemmU8U8Operation = MlasGemmU8S8OperationAvx2;
+                            this->GemmU8U8Operation = MlasGemmU8X8Operation<MLAS_GEMM_U8S8_KERNEL_AVX2>;
+                            this->GemmU8U8PackedOperation = MlasGemmU8X8PackedOperation<MLAS_GEMM_U8S8_KERNEL_AVX2>;
                             this->GemmU8S8Kernel = MlasGemmU8S8KernelAvx512Vnni;
                             this->GemvU8S8Kernel = MlasGemvU8S8KernelAvx512Vnni;
                         }

--- a/onnxruntime/core/util/qmath.h
+++ b/onnxruntime/core/util/qmath.h
@@ -12,6 +12,10 @@
 #define MLAS_SUPPORTS_GEMM_U8X8
 #endif
 
+#if defined(_M_AMD64) || defined(__x86_64__)
+#define MLAS_SUPPORTS_PACKED_GEMM_U8X8
+#endif
+
 namespace onnxruntime {
 
 void QGemm(


### PR DESCRIPTION
**Description**: Add support for prepacking matrix B for use in the quantized GEMMs. Only the quantized contrib ops used for BERT have been updated to use the prepacking routines at this time.

**Motivation and Context**
This removes the CPU time used to pack matrix B for the standard GEMM signature. The prepacking routines also can support longer strides to further improve performance because the packed buffers are no longer contrained to the stack.
