### PR TITLE
add function initialization back to graph resolve

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2049,6 +2049,8 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
         node.op_ = nullptr;
       }
 
+	  InitFunctionBodyForNode(node);
+
       if (!node.op_) {
         return Status(ONNXRUNTIME, FAIL, "Fatal error: " + node.OpType() + " is not a registered function/op");
       }

--- a/orttraining/orttraining/core/graph/mixed_precision_transformer.cc
+++ b/orttraining/orttraining/core/graph/mixed_precision_transformer.cc
@@ -602,13 +602,6 @@ Status TransformGraphForMixedPrecision(Graph& graph,
   LossSubgraph loss_subgraph(graph);
 
   // Stage 1: Convert whole graph including forward and backward to FP16
-  // Initialize function body for all function nodes
-  // This is required to make sure after converting inputs\weights to FP16
-  // the new NodeArg updates are correctly propagated to the function body nodes as well.
-  for (auto& node : graph.Nodes()) {
-    graph.InitFunctionBodyForNode(node);
-  }
-
   // Insert Cast node to convert inputs from FP32 to FP16
   // If all consumers are from loss graph, don't convert it, and remove it from To-32 loss graph inputs.
   for (const NodeArg* input : graph.GetInputs()) {


### PR DESCRIPTION
**Description**: Reverting a change introduced by PR https://github.com/microsoft/onnxruntime/pull/4332
This is causing failure in building gradient graph for 1 model. More investigation is needed to apply a fix so for now just undoing the change. 
Adding the function initialization back during graph resolve. 

