### PR TITLE
Remove Unused Initializer in Graph After Embed Fusion

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2298,7 +2298,7 @@ void Graph::AddInitializedTensor(const TensorProto& tensor) {
   const gsl::not_null<TensorProto*> tensor_added{graph_proto_->add_initializer()};
   *(tensor_added) = tensor;
   name_to_initial_tensor_[tensor.name()] = tensor_added;
-
+  SetGraphResolveNeeded();
   if (!is_loaded_from_model_file_ && GetNodeArg(tensor.name()) == nullptr) {
     // make sure there is a NodeArg for the initializer as SetGraphInputsOutputs may add it to the graph inputs.
     // the shape will be set to the correct value in TypeCheckInputsAndInitializers as we don't yet know whether there

--- a/onnxruntime/core/optimizer/embed_layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/embed_layer_norm_fusion.cc
@@ -423,7 +423,8 @@ static NodeArg* ExtractEmbedding(Graph& graph,
                                  int64_t batch_size,
                                  int64_t sequence_length,
                                  int64_t hidden_size,
-                                 const ONNX_NAMESPACE::TensorProto* tensor) {
+                                 const ONNX_NAMESPACE::TensorProto* tensor,
+                                 bool& modified) {
   assert(nullptr != tensor);
   assert(batch_size > 0);
   assert(sequence_length > 0);
@@ -456,6 +457,7 @@ static NodeArg* ExtractEmbedding(Graph& graph,
   }
 
   NodeArg& node_arg = graph_utils::AddInitializer(graph, initializer);
+  modified = true;
   return &node_arg;
 }
 
@@ -599,7 +601,7 @@ Status EmbedLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int graph_l
       }
 
       // The tensor has same data for all batches, and we extract only one batch data as position embedding.
-      position_embedding = ExtractEmbedding(graph, batch_size, sequence_length, hidden_size, position_embed_tensor);
+      position_embedding = ExtractEmbedding(graph, batch_size, sequence_length, hidden_size, position_embed_tensor, modified);
     } else {
       if (!MatchPositionEmbeddingSubgraph(graph, add_node, input_ids, logger, nodes_to_remove, position_embedding)) {
         DEBUG_LOG("Failed to match position embedding subgraph.");


### PR DESCRIPTION
**Description**: Describe your changes.
Trigger graph.resolve() and remove unused initializers by setting "modified" to true right after a new initializer is created in EmbedLayerNormalization fusion. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
Previously unused initializers are not removed when an initializer is created in the middle of an unsuccessful fusion. 

