### PR TITLE
Add bias for DynamicQuantizeMatMul

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
@@ -105,7 +105,7 @@ Status MatMulIntegerToFloatBase::ComputeCommon(OpKernelContext* ctx,
                y_data + helper.OutputOffsets()[i],
                static_cast<size_t>(helper.N()),
                &multiplier,
-               nullptr,
+               bias_data,
                thread_pool);
       continue;
     }


### PR DESCRIPTION
**Description**: Fix bad merge of the packed quantized GEMM with the latest version of DynamicQuantizeMatMul that supports an optional bias tensor.
