### PR TITLE
Remove use of RTTI in CUDA provider

### DIFF
--- a/onnxruntime/core/providers/acl/nn/batch_norm.h
+++ b/onnxruntime/core/providers/acl/nn/batch_norm.h
@@ -38,7 +38,7 @@ class BatchNorm final : public OpKernel {
     ORT_ENFORCE(st.IsOK(), st.ErrorMessage());
 
     provider_ = (const_cast<ACLExecutionProvider*>(
-        dynamic_cast<const ACLExecutionProvider*>(info.GetExecutionProvider())));
+        static_cast<const ACLExecutionProvider*>(info.GetExecutionProvider())));
   }
 
   ~BatchNorm() {

--- a/onnxruntime/core/providers/acl/nn/conv.h
+++ b/onnxruntime/core/providers/acl/nn/conv.h
@@ -40,7 +40,7 @@ class Conv : public onnxruntime::Conv<T> {
  public:
   explicit Conv(const OpKernelInfo& info) : onnxruntime::Conv<T>(info), conv_attrs_(info) {
     provider_ = (const_cast<ACLExecutionProvider*>(
-        dynamic_cast<const ACLExecutionProvider*>(info.GetExecutionProvider())));
+        static_cast<const ACLExecutionProvider*>(info.GetExecutionProvider())));
   }
 
   ~Conv() {

--- a/onnxruntime/core/providers/acl/nn/pool.h
+++ b/onnxruntime/core/providers/acl/nn/pool.h
@@ -35,7 +35,7 @@ class Pool final : public onnxruntime::Pool<T, PoolType> {
  public:
   explicit Pool(const OpKernelInfo& info) : onnxruntime::Pool<T, PoolType>(info) {
     provider_ = (const_cast<ACLExecutionProvider*>(
-        dynamic_cast<const ACLExecutionProvider*>(info.GetExecutionProvider())));
+        static_cast<const ACLExecutionProvider*>(info.GetExecutionProvider())));
   }
 
   ~Pool() {
@@ -54,7 +54,7 @@ class MaxPoolV8 final : public onnxruntime::MaxPoolV8 {
  public:
   explicit MaxPoolV8(const OpKernelInfo& info) : onnxruntime::MaxPoolV8(info) {
     provider_ = (const_cast<ACLExecutionProvider*>(
-        dynamic_cast<const ACLExecutionProvider*>(info.GetExecutionProvider())));
+        static_cast<const ACLExecutionProvider*>(info.GetExecutionProvider())));
   }
 
   ~MaxPoolV8() {

--- a/onnxruntime/core/providers/acl/tensor/concat.h
+++ b/onnxruntime/core/providers/acl/tensor/concat.h
@@ -29,7 +29,7 @@ class Concat : public onnxruntime::Concat {
   explicit Concat(const OpKernelInfo& info) : onnxruntime::Concat(info) {
 
     provider_ = (const_cast<ACLExecutionProvider*>(
-        dynamic_cast<const ACLExecutionProvider*>(info.GetExecutionProvider())));
+        static_cast<const ACLExecutionProvider*>(info.GetExecutionProvider())));
   }
 
   ~Concat() {}

--- a/onnxruntime/core/providers/armnn/activation/activations.h
+++ b/onnxruntime/core/providers/armnn/activation/activations.h
@@ -24,7 +24,7 @@ class Relu : public OpKernel {
  public:
   explicit Relu(const OpKernelInfo& info) : OpKernel(info) {
   	provider_ = (const_cast<ArmNNExecutionProvider*>(
-        dynamic_cast<const ArmNNExecutionProvider*>(info.GetExecutionProvider())));
+        static_cast<const ArmNNExecutionProvider*>(info.GetExecutionProvider())));
   }
 
   ~Relu() {

--- a/onnxruntime/core/providers/armnn/nn/conv.h
+++ b/onnxruntime/core/providers/armnn/nn/conv.h
@@ -22,7 +22,7 @@ class Conv : public onnxruntime::Conv<T> {
  public:
   explicit Conv(const OpKernelInfo& info) : onnxruntime::Conv<T>(info), conv_attrs_(info) {
     provider_ = (const_cast<ArmNNExecutionProvider*>(
-        dynamic_cast<const ArmNNExecutionProvider*>(info.GetExecutionProvider())));
+        static_cast<const ArmNNExecutionProvider*>(info.GetExecutionProvider())));
   }
 
   ~Conv() {

--- a/onnxruntime/core/providers/armnn/nn/pool.h
+++ b/onnxruntime/core/providers/armnn/nn/pool.h
@@ -22,7 +22,7 @@ class Pool final : public onnxruntime::Pool<T, PoolType> {
  public:
   explicit Pool(const OpKernelInfo& info) : onnxruntime::Pool<T, PoolType>(info) {
     provider_ = (const_cast<ArmNNExecutionProvider*>(
-        dynamic_cast<const ArmNNExecutionProvider*>(info.GetExecutionProvider())));
+        static_cast<const ArmNNExecutionProvider*>(info.GetExecutionProvider())));
   }
 
   ~Pool() {
@@ -49,7 +49,7 @@ class MaxPoolV8 final : public onnxruntime::MaxPoolV8 {
  public:
   explicit MaxPoolV8(const OpKernelInfo& info) : onnxruntime::MaxPoolV8(info) {
     provider_ = (const_cast<ArmNNExecutionProvider*>(
-        dynamic_cast<const ArmNNExecutionProvider*>(info.GetExecutionProvider())));
+        static_cast<const ArmNNExecutionProvider*>(info.GetExecutionProvider())));
   }
 
   ~MaxPoolV8() {

--- a/onnxruntime/core/providers/cuda/cuda_allocator.cc
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.cc
@@ -13,7 +13,7 @@ namespace onnxruntime {
 static const GPUDataTransfer* GetGPUDataTransfer(const SessionState* session_state) {
   OrtDevice gpu_device(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, 0);
   OrtDevice cpu_device;
-  return dynamic_cast<const GPUDataTransfer*>(session_state->GetDataTransferMgr().GetDataTransfer(gpu_device, cpu_device));
+  return static_cast<const GPUDataTransfer*>(session_state->GetDataTransferMgr().GetDataTransfer(gpu_device, cpu_device));
 }
 
 void CUDAAllocator::CheckDevice(bool throw_when_fail) const {

--- a/onnxruntime/core/providers/cuda/math/einsum.h
+++ b/onnxruntime/core/providers/cuda/math/einsum.h
@@ -19,7 +19,7 @@ class Einsum final : public onnxruntime::Einsum {
     // We need to cast away the const as PerThreadCublasHandle() is currently a non-const method
     // TODO: Clean up the CUDAExecutionProvider interface to avoid this
     cuda_ep_ = const_cast<CUDAExecutionProvider*>(
-        dynamic_cast<const CUDAExecutionProvider*>(info.GetExecutionProvider()));
+        static_cast<const CUDAExecutionProvider*>(info.GetExecutionProvider()));
   }
 
   Status Compute(OpKernelContext* context) const override;

--- a/onnxruntime/core/providers/cuda/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_ops.h
@@ -51,7 +51,7 @@ class ReduceKernel : public CudaKernel, public ReduceKernelBase<allow_multi_axes
         fast_reduction_(false) {
     // We need to cast away the const as PerThreadCudnnHandle() is currently a non-const method
     // TODO: Clean up the CUDAExecutionProvider interface to avoid this
-    cuda_ep_ = const_cast<CUDAExecutionProvider*>(dynamic_cast<const CUDAExecutionProvider*>(info.GetExecutionProvider()));
+    cuda_ep_ = const_cast<CUDAExecutionProvider*>(static_cast<const CUDAExecutionProvider*>(info.GetExecutionProvider()));
   }
 
   // Only Max Min need to set ReduceTensorIndices CUDNN_REDUCE_TENSOR_FLATTENED_INDICES as per cudnn library manual


### PR DESCRIPTION
**Description**: These usages are downcasts/upcasts that can be done without RTTI.

I'm running the zip packaging pipeline here: https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=128375&view=results to ensure it's working.