### PR TITLE
Transformer benchmark: add option to use raw attention mask

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_attention.py
@@ -4,12 +4,19 @@
 #--------------------------------------------------------------------------
 import numpy as np
 from logging import getLogger
+from enum import Enum
 from onnx import helper, numpy_helper, TensorProto
 from onnx_model import OnnxModel
 from fusion_base import Fusion
 from fusion_utils import FusionUtils
 
 logger = getLogger(__name__)
+
+
+class AttentionMaskFormat:
+    MaskIndexEnd = 0
+    MaskIndexEndAndStart = 1
+    AttentionMask = 2
 
 
 class AttentionMask():
@@ -23,6 +30,10 @@ class AttentionMask():
         # A lookup table with mask input as key, and cast (to int32) output as value
         self.mask_casted = {}
         self.utils = FusionUtils(model)
+        self.mask_format = AttentionMaskFormat.MaskIndexEnd
+
+    def set_mask_format(self, mask_format: AttentionMaskFormat):
+        self.mask_format = mask_format
 
     def set_mask_indice(self, mask, mask_index):
         if mask in self.mask_indice:
@@ -47,7 +58,12 @@ class AttentionMask():
         if casted:
             self.mask_casted[input] = input_name
 
-        # Add a mask processing node
+        # Attention supports int32 attention mask (2D) since 1.4.0
+        if self.mask_format == AttentionMaskFormat.AttentionMask:
+            self.mask_indice[input] = input_name
+            return input_name
+
+        # Add a mask processing node to convert attention mask to mask index (1D)
         output_name = self.model.create_node_name('mask_index')
         mask_index_node = helper.make_node('ReduceSum',
                                            inputs=[input_name],

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -87,7 +87,7 @@ def optimize_by_onnxruntime(onnx_model_path: str,
         assert 'CUDAExecutionProvider' in session.get_providers()  # Make sure there is GPU
 
     assert os.path.exists(optimized_model_path) and os.path.isfile(optimized_model_path)
-    logger.info("Save optimized model by onnxruntime to {}".format(optimized_model_path))
+    logger.debug("Save optimized model by onnxruntime to {}".format(optimized_model_path))
     return optimized_model_path
 
 
@@ -186,6 +186,12 @@ def _parse_arguments():
                         help="enable Gelu/BiasGelu to FastGelu conversion")
     parser.set_defaults(enable_gelu_approximation=False)
 
+    parser.add_argument('--use_raw_attention_mask',
+                        required=False,
+                        action='store_true',
+                        help="use raw attention mask instead of mask index in attention operator")
+    parser.set_defaults(use_raw_attention_mask=False)
+
     parser.add_argument('--verbose', required=False, action='store_true')
     parser.set_defaults(verbose=False)
 
@@ -225,6 +231,9 @@ def _get_optimization_options(args):
         optimization_options.enable_bias_gelu = False
     if args.enable_gelu_approximation:
         optimization_options.enable_gelu_approximation = True
+    if args.use_raw_attention_mask:
+        optimization_options.use_raw_attention_mask()
+
     return optimization_options
 
 
@@ -258,16 +267,14 @@ def optimize_model(input,
     """
     (optimizer_class, producer, run_onnxruntime) = MODEL_CLASSES[model_type]
 
-    input_model_path = input
-
     if opt_level > 1:  # Optimization specified for an execution provider.
-        input_model_path = optimize_by_onnxruntime(input_model_path, use_gpu=use_gpu, opt_level=opt_level)
+        temp_model_path = optimize_by_onnxruntime(input, use_gpu=use_gpu, opt_level=opt_level)
     elif run_onnxruntime:
         # Use Onnxruntime to do optimizations (like constant folding and cast elimation) that is not specified to exection provider.
         # CPU provider is used here so that there is no extra node for GPU memory copy.
-        input_model_path = optimize_by_onnxruntime(input_model_path, use_gpu=False, opt_level=1)
+        temp_model_path = optimize_by_onnxruntime(input, use_gpu=False, opt_level=1)
 
-    model = load_model(input_model_path, format=None, load_external_data=True)
+    model = load_model(temp_model_path, format=None, load_external_data=True)
 
     if model.producer_name and producer != model.producer_name:
         logger.warning(
@@ -281,6 +288,10 @@ def optimize_model(input,
 
     if not only_onnxruntime:
         optimizer.optimize(optimization_options)
+
+    # Remove the temporary model.
+    #os.remove(temp_model_path)
+    #logger.debug("Remove tempoary model: {}".format(temp_model_path))
 
     return optimizer
 

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -290,8 +290,8 @@ def optimize_model(input,
         optimizer.optimize(optimization_options)
 
     # Remove the temporary model.
-    #os.remove(temp_model_path)
-    #logger.debug("Remove tempoary model: {}".format(temp_model_path))
+    os.remove(temp_model_path)
+    logger.debug("Remove tempoary model: {}".format(temp_model_path))
 
     return optimizer
 


### PR DESCRIPTION
**Description**:
1. Add option to use raw attention mask
2. Remove temporary model generated in model optimization
3. Update message in embed layer normalization

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

Allow benchmark different formats (1D and 2D) of attention mask to find which format is better for performance.
