### PR TITLE
[Node.js binding] support CentOS 7 in CI

### DIFF
--- a/nodejs/src/tensor_helper.cc
+++ b/nodejs/src/tensor_helper.cc
@@ -232,7 +232,8 @@ Napi::Value OrtValueToNapiValue(Napi::Env env, Ort::Value &value) {
     auto stringArray = Napi::Array::New(env, size);
     if (size > 0) {
       auto tempBufferLength = value.GetStringTensorDataLength();
-      std::vector<char> tempBuffer(tempBufferLength);
+      // create buffer of length (tempBufferLength + 1) to make sure `&tempBuffer[0]` is always valid
+      std::vector<char> tempBuffer(tempBufferLength + 1);
       std::vector<size_t> tempOffsets;
       tempOffsets.resize(size);
       value.GetStringTensorContent(&tempBuffer[0], tempBufferLength, &tempOffsets[0], size);

--- a/nodejs/src/tensor_helper.cc
+++ b/nodejs/src/tensor_helper.cc
@@ -232,15 +232,15 @@ Napi::Value OrtValueToNapiValue(Napi::Env env, Ort::Value &value) {
     auto stringArray = Napi::Array::New(env, size);
     if (size > 0) {
       auto tempBufferLength = value.GetStringTensorDataLength();
-      // create buffer of length (tempBufferLength + 1) to make sure `&tempBuffer[0]` is always valid
-      std::vector<char> tempBuffer(tempBufferLength + 1);
+      std::string tempBufferString(tempBufferLength, 0);
+      auto tempBuffer = const_cast<char *>(tempBufferString.data());
       std::vector<size_t> tempOffsets;
       tempOffsets.resize(size);
-      value.GetStringTensorContent(&tempBuffer[0], tempBufferLength, &tempOffsets[0], size);
+      value.GetStringTensorContent(tempBuffer, tempBufferLength, &tempOffsets[0], size);
 
       for (uint32_t i = 0; i < size; i++) {
         stringArray[i] =
-            Napi::String::New(env, &tempBuffer[0] + tempOffsets[i],
+            Napi::String::New(env, tempBuffer + tempOffsets[i],
                               i == size - 1 ? tempBufferLength - tempOffsets[i] : tempOffsets[i + 1] - tempOffsets[i]);
       }
     }

--- a/nodejs/src/tensor_helper.cc
+++ b/nodejs/src/tensor_helper.cc
@@ -232,15 +232,15 @@ Napi::Value OrtValueToNapiValue(Napi::Env env, Ort::Value &value) {
     auto stringArray = Napi::Array::New(env, size);
     if (size > 0) {
       auto tempBufferLength = value.GetStringTensorDataLength();
-      std::string tempBufferString(tempBufferLength, 0);
-      auto tempBuffer = const_cast<char *>(tempBufferString.data());
+      // create buffer of length (tempBufferLength + 1) to make sure `&tempBuffer[0]` is always valid
+      std::vector<char> tempBuffer(tempBufferLength + 1);
       std::vector<size_t> tempOffsets;
       tempOffsets.resize(size);
-      value.GetStringTensorContent(tempBuffer, tempBufferLength, &tempOffsets[0], size);
+      value.GetStringTensorContent(&tempBuffer[0], tempBufferLength, &tempOffsets[0], size);
 
       for (uint32_t i = 0; i < size; i++) {
         stringArray[i] =
-            Napi::String::New(env, tempBuffer + tempOffsets[i],
+            Napi::String::New(env, &tempBuffer[0] + tempOffsets[i],
                               i == size - 1 ? tempBufferLength - tempOffsets[i] : tempOffsets[i + 1] - tempOffsets[i]);
       }
     }

--- a/nodejs/src/tensor_helper.cc
+++ b/nodejs/src/tensor_helper.cc
@@ -232,14 +232,14 @@ Napi::Value OrtValueToNapiValue(Napi::Env env, Ort::Value &value) {
     auto stringArray = Napi::Array::New(env, size);
     if (size > 0) {
       auto tempBufferLength = value.GetStringTensorDataLength();
-      auto tempBuffer = std::make_unique<char[]>(tempBufferLength);
+      std::vector<char> tempBuffer(tempBufferLength);
       std::vector<size_t> tempOffsets;
       tempOffsets.resize(size);
-      value.GetStringTensorContent(tempBuffer.get(), tempBufferLength, &tempOffsets[0], size);
+      value.GetStringTensorContent(&tempBuffer[0], tempBufferLength, &tempOffsets[0], size);
 
       for (uint32_t i = 0; i < size; i++) {
         stringArray[i] =
-            Napi::String::New(env, tempBuffer.get() + tempOffsets[i],
+            Napi::String::New(env, &tempBuffer[0] + tempOffsets[i],
                               i == size - 1 ? tempBufferLength - tempOffsets[i] : tempOffsets[i + 1] - tempOffsets[i]);
       }
     }

--- a/tools/ci_build/github/azure-pipelines/nodejs/templates/cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nodejs/templates/cpu.yml
@@ -40,12 +40,12 @@ jobs:
     - task: CmdLine@2
       inputs:
         script: |
-          sudo docker build --pull -t onnxruntime-ubuntu --build-arg BUILD_USER=onnxruntimedev --build-arg BUILD_UID=$(id -u) --build-arg PYTHON_VERSION=3.6 -f Dockerfile.ubuntu .
+          sudo docker build --pull -t onnxruntime-centos7 --build-arg BUILD_USER=onnxruntimedev --build-arg BUILD_UID=$(id -u) --build-arg PYTHON_VERSION=3.6 -f Dockerfile.centos .
         workingDirectory: $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker
     - task: CmdLine@2
       inputs:
         script: |
-          sudo --preserve-env docker run --rm --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro -e NIGHTLY_BUILD onnxruntime-ubuntu /bin/bash -c "/usr/bin/python3.6 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync  --parallel --build_nodejs --use_openmp --cmake_path /usr/bin/cmake --ctest_path /usr/bin/ctest --enable_onnx_tests && cd /onnxruntime_src/nodejs && npm pack"
+          sudo --preserve-env docker run --rm --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro -e NIGHTLY_BUILD onnxruntime-centos7 /bin/bash -c "/usr/bin/python3.6 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync  --parallel --build_nodejs --use_openmp --cmake_path /usr/bin/cmake --ctest_path /usr/bin/ctest --enable_onnx_tests && cd /onnxruntime_src/nodejs && npm pack"
         workingDirectory: $(Build.SourcesDirectory)
     - script: |
        set -e -x


### PR DESCRIPTION
**Description**: support CentOS 7 in CI

- Node.js official binary does not run in CentOS 6 and building Node.js requires 7+ for CentOS as well
- do not use std::make_unique as it is not supported under the GCC version.