### PR TITLE
Improve shape inference for OneHot

### DIFF
--- a/onnxruntime/core/providers/nuphar/scripts/symbolic_shape_infer.py
+++ b/onnxruntime/core/providers/nuphar/scripts/symbolic_shape_infer.py
@@ -776,13 +776,13 @@ class SymbolicShapeInference:
         vi.CopyFrom(helper.make_tensor_value_info(node.output[0], vi.type.tensor_type.elem_type, [input_rank, nz_len]))
 
     def _infer_OneHot(self, node):
-        shape = self._get_sympy_shape(node, 0)
+        sympy_shape = self._get_sympy_shape(node, 0)
         depth = self._try_get_value(node, 1)
         axis = get_attribute(node, 'axis', -1)
-        axis = handle_negative_axis(axis, len(shape) + 1)
+        axis = handle_negative_axis(axis, len(sympy_shape) + 1)
         new_shape = get_shape_from_sympy_shape(
-            shape[:axis] + [self._new_symbolic_dim_from_output(node) if not is_literal(depth) else depth] +
-            shape[axis:])
+            sympy_shape[:axis] + [self._new_symbolic_dim_from_output(node) if not is_literal(depth) else depth] +
+            sympy_shape[axis:])
         vi = self.known_vi_[node.output[0]]
         vi.CopyFrom(helper.make_tensor_value_info(node.output[0], self.known_vi_[node.input[2]].type.tensor_type.elem_type, new_shape))
 

--- a/onnxruntime/core/providers/nuphar/scripts/symbolic_shape_infer.py
+++ b/onnxruntime/core/providers/nuphar/scripts/symbolic_shape_infer.py
@@ -776,13 +776,13 @@ class SymbolicShapeInference:
         vi.CopyFrom(helper.make_tensor_value_info(node.output[0], vi.type.tensor_type.elem_type, [input_rank, nz_len]))
 
     def _infer_OneHot(self, node):
-        shape = self._get_shape(node, 0)
+        shape = self._get_sympy_shape(node, 0)
         depth = self._try_get_value(node, 1)
         axis = get_attribute(node, 'axis', -1)
-        axis = handle_negative_axis(axis, len(shape)+1)
-        new_shape = (shape[:axis] +
-                     [self._new_symbolic_dim_from_output(node) if depth is None else depth] +
-                     shape[axis:])
+        axis = handle_negative_axis(axis, len(shape) + 1)
+        new_shape = get_shape_from_sympy_shape(
+            shape[:axis] + [self._new_symbolic_dim_from_output(node) if not is_literal(depth) else depth] +
+            shape[axis:])
         vi = self.known_vi_[node.output[0]]
         vi.CopyFrom(helper.make_tensor_value_info(node.output[0], self.known_vi_[node.input[2]].type.tensor_type.elem_type, new_shape))
 

--- a/onnxruntime/core/providers/nuphar/scripts/symbolic_shape_infer.py
+++ b/onnxruntime/core/providers/nuphar/scripts/symbolic_shape_infer.py
@@ -777,9 +777,12 @@ class SymbolicShapeInference:
 
     def _infer_OneHot(self, node):
         shape = self._get_shape(node, 0)
+        depth = self._try_get_value(node, 1)
         axis = get_attribute(node, 'axis', -1)
         axis = handle_negative_axis(axis, len(shape)+1)
-        new_shape = shape[:axis] + [self._new_symbolic_dim_from_output(node)] + shape[axis:]
+        new_shape = (shape[:axis] +
+                     [self._new_symbolic_dim_from_output(node) if depth is None else depth] +
+                     shape[axis:])
         vi = self.known_vi_[node.output[0]]
         vi.CopyFrom(helper.make_tensor_value_info(node.output[0], self.known_vi_[node.input[2]].type.tensor_type.elem_type, new_shape))
 


### PR DESCRIPTION
**Description**: Attempt to get the depth parameter before adding a new symbolic dimension.

**Motivation and Context**
Previously shape inference for `OneHot` would always add a new symbolic dimension for depth. However, it's sometimes possible to get the depth from the initalizers.
