### PR TITLE
Single Operator Execution Interface

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -658,6 +658,10 @@ class Graph {
   */
   Node& AddNode(const Node& other);
 
+  // Add node with specified <node_proto>.
+  Node& AddNode(const ONNX_NAMESPACE::NodeProto& node_proto,
+                const ArgNameToTypeMap& name_to_type);
+
   /** Remove a Node from this Graph and free it.
   The output edges of this specified node MUST have been removed before removing the node.
   The input edges of this specified node is removed while removing the node. The process of
@@ -936,9 +940,6 @@ class Graph {
 
   void InitializeStateFromModelFileGraphProto();
 
-  // Add node with specified <node_proto>.
-  Node& AddNode(const ONNX_NAMESPACE::NodeProto& node_proto,
-                const ArgNameToTypeMap& name_to_type);
 
   Version IrVersion() const noexcept {
     return ir_version_;

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -847,7 +847,8 @@ struct OrtApi {
   // TODO check what happens if some inputs aren't set
   ORT_API2_STATUS(ExecutableKernelContext_Compute, _Inout_ OrtExecutableKernelContext* context);
 
-  // TODO Add release API methods
+  ORT_CLASS_RELEASE(KernelSession);
+  ORT_CLASS_RELEASE(ExecutableKernelContext);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -206,13 +206,6 @@ typedef enum ExecutionMode {
   ORT_PARALLEL = 1,
 } ExecutionMode;
 
-// This is just easier for now, if this get's upstreamed we could just add the methods to the providers like it is with
-// the other sessions atm.
-typedef enum ProviderType {
-    ORT_PROVIDER_CPU,
-    ORT_PROVIDER_CUDA
-} OrtProviderType;
-
 struct OrtKernelInfo;
 typedef struct OrtKernelInfo OrtKernelInfo;
 struct OrtKernelContext;
@@ -829,12 +822,13 @@ struct OrtApi {
                   _In_ int64_t dim_value);
 
   // Create a session that can be used to execute single kernels
-  ORT_API2_STATUS(CreateKernelSession, OrtKernelSession** session);
+  // we don't actually read anything from OrtSessionOptions except for the provider factories.
+  ORT_API2_STATUS(CreateKernelSession, _In_ const OrtSessionOptions* options, OrtKernelSession** session);
 
   // Add an node_protobuf to the session for a session, get out an executable kernel context
   ORT_API2_STATUS(CreateExecutableKernelContext,
                   _In_ OrtKernelSession* session,
-                  OrtProviderType providerType,
+                  unsigned int provider_id,
                   _In_ const void* node_proto, // pointer to a c++ NodeProto
                   _In_ const void* arg_to_type_map, // pointer to a ArgToTypeMap (aka std::unordered_map<std::string, onnx::TypeProto>)
                   _Outptr_ OrtExecutableKernelContext** kernel);

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -208,6 +208,13 @@ struct OrtKernelInfo;
 typedef struct OrtKernelInfo OrtKernelInfo;
 struct OrtKernelContext;
 typedef struct OrtKernelContext OrtKernelContext;
+
+struct OrtExecutableKernel;
+typedef struct OrtExecutableKernel OrtExecutableKernel;
+
+struct OrtExecutableKernelContext;
+typedef struct OrtExecutableKernelContext OrtExecutableKernelContext;
+
 struct OrtCustomOp;
 typedef struct OrtCustomOp OrtCustomOp;
 
@@ -817,6 +824,30 @@ struct OrtApi {
   ORT_API2_STATUS(AddFreeDimensionOverrideByName,
                   _Inout_ OrtSessionOptions* options, _In_ const char* dim_name,
                   _In_ int64_t dim_value);
+
+  ORT_API2_STATUS(ExecutableKernelContext_Compute, _Inout_ OrtExecutableKernelContext* context);
+
+  ORT_API2_STATUS(ExecutableKernelContext_AddInput,
+                  _Inout_ OrtExecutableKernelContext* context,
+                  int index,
+                  _In_ OrtValue* value);
+
+  ORT_API2_STATUS(ExecutableKernelContext_AddImplicitInput,
+                  _Inout_ OrtExecutableKernelContext* context,
+                  int index,
+                  _In_ OrtValue* value);
+
+  ORT_API2_STATUS(ExecutableKernelContext_AddOutput,
+                  _Inout_ OrtExecutableKernelContext* context,
+                  int index,
+                  _Inout_ OrtValue* value);
+
+  ORT_API2_STATUS(CreateExecutableKernelContext,
+                  _In_ const OrtExecutableKernel *kernel,
+                  _Outptr_ OrtExecutableKernelContext** context);
+
+  ORT_API2_STATUS(CreateExecutableKernel, _In_ const void* node_proto, _In_ const void* arg_to_type_map, _Outptr_ OrtExecutableKernel** kernel);
+
 };
 
 /*

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -78,6 +78,11 @@ AllocatorPtr IExecutionFrame::GetAllocator(const OrtMemoryInfo& info) const {
 }
 
 Status IExecutionFrame::ReleaseMLValue(int ort_value_idx) { return ReleaseMLValueImpl(ort_value_idx); }
+Status IExecutionFrame::SetOrtValue(OrtValue &value, int ort_value_idx) {
+    ORT_ENFORCE(ort_value_idx >= 0 && static_cast<size_t>(ort_value_idx) < all_values_size_);
+    all_values_[ort_value_idx] = value;
+    return Status::OK();
+}
 
 Status IExecutionFrame::ReleaseMLValueImpl(int ort_value_idx) {
   if (ort_value_idx == NodeIndexInfo::kInvalidEntry || static_cast<size_t>(ort_value_idx) >= all_values_size_) {

--- a/onnxruntime/core/framework/execution_frame.h
+++ b/onnxruntime/core/framework/execution_frame.h
@@ -63,6 +63,8 @@ class IExecutionFrame {
 
   Status ReleaseMLValue(int ort_value_idx);
 
+  Status SetOrtValue(OrtValue &value, int ort_value_idx);
+
  protected:
   // get the ort_value_idx from NodeIndexInfo
   int GetNodeIdxToMLValueIdx(int index) const;

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -18,6 +18,7 @@
 namespace ONNX_NAMESPACE {
 class TensorProto;
 class TensorShapeProto;
+class NodeProto;
 
 /** Test if two TensorShapeProto dimensions are equal. */
 bool operator==(const TensorShapeProto_Dimension& l, const TensorShapeProto_Dimension& r);

--- a/onnxruntime/core/session/abi_kernel_execution.cc
+++ b/onnxruntime/core/session/abi_kernel_execution.cc
@@ -149,3 +149,11 @@ ORT_API_STATUS_IMPL(OrtApis::ExecutableKernelContext_Compute, _Inout_ OrtExecuta
     API_IMPL_END
 }
 
+ORT_API(void, OrtApis::ReleaseKernelSession, _Frees_ptr_opt_ OrtKernelSession* value) {
+    delete reinterpret_cast<KernelSessionImpl*>(value);
+}
+
+ORT_API(void, OrtApis::ReleaseExecutableKernelContext, _Frees_ptr_opt_ OrtExecutableKernelContext * value) {
+    delete reinterpret_cast<ExecutableKernelContextImpl*>(value);
+}
+

--- a/onnxruntime/core/session/abi_kernel_execution.cc
+++ b/onnxruntime/core/session/abi_kernel_execution.cc
@@ -22,178 +22,125 @@
 using namespace onnxruntime;
 
 // taken from OptimizerExecutionFrame
-// Return S_OK and nullptr if index map to an value that is an unused optional input/output
-Status ExecutableKernelContextImpl::CreateNodeOutputMLValueImpl(OrtValue &ort_value, int ort_value_idx,
-                                                                const TensorShape *shape, size_t nnz) {
-    const DataTypeImpl *ml_type = DataTypeImpl::TypeFromProto(*info_.ort_value_idx_nodearg_map_.at(ort_value_idx));
-    if (ml_type == nullptr)
-        return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
-                      "Tried to allocate without valid type information, ort_value index=" +
-                      std::to_string(ort_value_idx));
-    if (ml_type->IsSparseTensorType()) {
-        auto element_type = ml_type->AsSparseTensorType()->GetElementType();
-        auto container_type = DataTypeImpl::GetType<SparseTensor>();
-        auto sparse = onnxruntime::make_unique<SparseTensor>(element_type, *shape, nnz, info_.GetAllocator());
-        ort_value.Init(sparse.release(), container_type, container_type->GetDeleteFunc());
-        return Status::OK();
+Status
+ExecutableKernelContextImpl::CreateNodeOutputMLValueImpl(__attribute__((unused)) OrtValue &ort_value, int ort_value_idx,
+                                                         __attribute__((unused)) const TensorShape *shape,
+                                                         __attribute__((unused)) size_t nnz) {
+    std::string name;
+    Status status = info_->value_name_idx_map_.GetName(ort_value_idx, name);
+    if (!status.IsOK()) {
+        return status;
     }
-
-    if (ml_type->IsTensorSequenceType()) {
-        auto element_type = ml_type->AsSequenceTensorBase()->GetElementType();
-        auto p_sequence = onnxruntime::make_unique<TensorSeq>(element_type);
-        auto ml_tensor_sequence = DataTypeImpl::GetType<TensorSeq>();
-        ort_value.Init(p_sequence.release(), ml_tensor_sequence, ml_tensor_sequence->GetDeleteFunc());
-        return Status::OK();
-    }
-
-    if (!ml_type->IsTensorType()) {
-        assert(ml_type->AsNonTensorTypeBase() != nullptr);
-        const NonTensorTypeBase *non_tensor_type = static_cast<const NonTensorTypeBase *>(ml_type);
-        auto creator = non_tensor_type->GetCreateFunc();
-        ort_value.Init(creator(), non_tensor_type, non_tensor_type->GetDeleteFunc());
-        return Status::OK();
-    }
-
-    // tensors
-    auto element_type = static_cast<const TensorTypeBase *>(ml_type)->GetElementType();
-    AllocatorPtr allocator_ptr = info_.GetAllocator();
-    std::unique_ptr<Tensor> p_tensor = onnxruntime::make_unique<Tensor>(element_type,
-                                                                        *shape,
-                                                                        allocator_ptr);
-
-    auto ml_tensor = DataTypeImpl::GetType<Tensor>();
-    ort_value.Init(p_tensor.release(), ml_tensor, ml_tensor->GetDeleteFunc());
-
-    return Status::OK();
+    return Status(ONNXRUNTIME, RUNTIME_EXCEPTION, "All outputs should already be allocated, but output "
+                                                  + name + " was not");
 }
 
 
-ORT_API_STATUS_IMPL(OrtApis::ExecutableKernelContext_Compute, _Inout_ OrtExecutableKernelContext *context_) {
+ORT_API_STATUS_IMPL(OrtApis::CreateKernelSession,
+                    _Outptr_ OrtKernelSession **session_) {
     API_IMPL_BEGIN
+        ORT_ENFORCE(session_, "OrtKernelSession pointer must not be null");
+        std::unique_ptr<Model> model = std::make_unique<Model>("KernelExecutionModel", true,
+                                                               logging::LoggingManager::DefaultLogger());
 
-        ExecutableKernelContextImpl::Info *info = reinterpret_cast<ExecutableKernelContextImpl::Info *>(context_);
-
-        ExecutableKernelContextImpl context(*info);
-
-
-        std::cout << "Gonna compute! " << std::endl;
-        context.Compute();
+        KernelSessionImpl *session = new KernelSessionImpl(std::move(model));
+        *session_ = reinterpret_cast<OrtKernelSession *>(session);
 
         return ToOrtStatus(Status::OK());
     API_IMPL_END
 }
 
 ORT_API_STATUS_IMPL(OrtApis::CreateExecutableKernelContext,
-                    const OrtExecutableKernel *kernel_,
-                    OrtExecutableKernelContext **context) {
+                    _In_ OrtKernelSession *session_,
+                    OrtProviderType providerType,
+                    _In_ const void *node_proto_, // pointer to a c++ NodeProto
+                    _In_ const void *arg_to_type_map_, // pointer to a ArgToTypeMap (aka std::unordered_map<std::string, onnx::TypeProto>)
+                    _Outptr_ OrtExecutableKernelContext **kernel_context_) {
     API_IMPL_BEGIN
-        const ExecutableKernelImpl *kernel = reinterpret_cast<const ExecutableKernelImpl *>(kernel_);
 
-        std::unique_ptr<CPUExecutionProvider> cpu_execution_provider =
-                make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
+        ORT_ENFORCE(kernel_context_, "OrtExecutableKernelContext pointer must be non-null");
 
-        InitializedTensorSet set;
-
-        ExecutableKernelContextImpl::Info *info = new ExecutableKernelContextImpl::Info(kernel->op_kernel,
-                                                                                        logging::LoggingManager::DefaultLogger());
-
-        *context = reinterpret_cast<OrtExecutableKernelContext *>(info);
-        return ToOrtStatus(Status::OK());
-    API_IMPL_END
-}
-
-
-ORT_API_STATUS_IMPL(OrtApis::ExecutableKernelContext_AddInput, OrtExecutableKernelContext *context_, int index,
-                    OrtValue *value) {
-    API_IMPL_BEGIN
-        ExecutableKernelContextImpl::Info *context = reinterpret_cast<ExecutableKernelContextImpl::Info *>(context_);
-        Status status = context->AddInput(*value, index);
-        return ToOrtStatus(status);
-    API_IMPL_END
-}
-
-ORT_API_STATUS_IMPL(OrtApis::ExecutableKernelContext_AddImplicitInput, OrtExecutableKernelContext *context_, int index,
-                    OrtValue *value) {
-    API_IMPL_BEGIN
-        ExecutableKernelContextImpl::Info *context = reinterpret_cast<ExecutableKernelContextImpl::Info *>(context_);
-        Status status = context->AddImplicitInput(*value, index);
-        return ToOrtStatus(status);
-    API_IMPL_END
-}
-
-ORT_API_STATUS_IMPL(OrtApis::ExecutableKernelContext_AddOutput, OrtExecutableKernelContext *context_, int index,
-                    OrtValue *value) {
-    API_IMPL_BEGIN
-        ExecutableKernelContextImpl::Info *context = reinterpret_cast<ExecutableKernelContextImpl::Info *>(context_);
-        Status status = context->AddOutput(*value, index);
-        return ToOrtStatus(status);
-    API_IMPL_END
-}
-
-ORT_API_STATUS_IMPL(OrtApis::CreateExecutableKernel,
-                    _In_ const void *node_proto_,
-                    _In_ const void *arg_name_to_type_map_,
-                    _Outptr_ OrtExecutableKernel **context) {
-    API_IMPL_BEGIN
+        KernelSessionImpl *session = reinterpret_cast<KernelSessionImpl *>(session_);
         const ONNX_NAMESPACE::NodeProto *node_proto = static_cast<const ONNX_NAMESPACE::NodeProto *>(node_proto_);
-        const ArgNameToTypeMap *arg_name_to_type_map = static_cast<const ArgNameToTypeMap *>(arg_name_to_type_map_);
+        const ArgNameToTypeMap *arg_name_to_type_map = static_cast<const ArgNameToTypeMap *>(arg_to_type_map_);
 
-        ExecutionProviders execution_providers;
-
-        CPUExecutionProviderInfo epi;
-        auto status = execution_providers.Add(kCpuExecutionProvider, make_unique<CPUExecutionProvider>(epi));
-
-        if (!status.IsOK()) {
-            return ToOrtStatus(status);
-        }
-
-        std::cout << "Registered provider!" << std::endl;
-
-        std::cout << node_proto->name() << std::endl;
-
-        // create a fake, one-node model
-        std::unique_ptr<Model> model = std::make_unique<Model>("Model", true, logging::LoggingManager::DefaultLogger());
-        auto &graph = model->MainGraph();
-
+        // add the node
+        auto &graph = session->model->MainGraph();
         Node &node = graph.AddNode(*node_proto, *arg_name_to_type_map);
-
-
-        status = graph.Resolve();
+        Status status = graph.Resolve();
         if (!status.IsOK()) {
             return ToOrtStatus(status);
         }
 
-        node.SetExecutionProviderType(kCpuExecutionProvider);
-
-        std::cout << "Added node!" << std::endl;
-
-        const IExecutionProvider *provider = execution_providers.Get(node);
-        if (!provider) {
-            auto status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "node has no provider");
-            LOGS_DEFAULT(ERROR) << status.ErrorMessage();
-            return ToOrtStatus(status);
+        // set the execution provider
+        std::unique_ptr<IExecutionProvider> execution_provider;
+        switch (providerType) {
+            case ORT_PROVIDER_CPU:
+                node.SetExecutionProviderType(kCpuExecutionProvider);
+                execution_provider = make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
+                break;
+            case ORT_PROVIDER_CUDA:
+                // TODO
+            default:
+                return ToOrtStatus(Status(ONNXRUNTIME,
+                                          INVALID_ARGUMENT,
+                                          "Unsupported provider type (" + std::to_string(providerType) + ")"));
         }
 
-        std::shared_ptr<KernelRegistry> registry = provider->GetKernelRegistry();
-        std::unordered_map<int, OrtValue> constant_initalized_tensors;
-
-        OrtValueNameIdxMap name_idx_map;
-        FuncManager funcs_mgr;
-        DataTransferManager data_transfer_mgr;
-
+        // create the kernel
+        std::shared_ptr<KernelRegistry> registry = execution_provider->GetKernelRegistry();
         std::unique_ptr<OpKernel> op_kernel;
-        status = registry->TryCreateKernel(node, *provider, constant_initalized_tensors, name_idx_map, funcs_mgr,
-                                           data_transfer_mgr, op_kernel);
+        status = registry->TryCreateKernel(node,
+                                           *execution_provider,
+                                           std::unordered_map<int, OrtValue>(),
+                                           OrtValueNameIdxMap(),
+                                           FuncManager(),
+                                           DataTransferManager(),
+                                           op_kernel);
 
         if (!status.IsOK()) {
             return ToOrtStatus(status);
         }
 
+        // create the context info
+        std::unique_ptr<ExecutableKernelContextImpl::Info> info = std::make_unique<ExecutableKernelContextImpl::Info>(
+                std::move(op_kernel),
+                logging::LoggingManager::DefaultLogger());
 
-        ExecutableKernelImpl *context_impl = new ExecutableKernelImpl(std::move(model), std::move(op_kernel));
 
-        *context = reinterpret_cast<OrtExecutableKernel *>(context_impl);
-
+        ExecutableKernelContextImpl *kernel_context = new ExecutableKernelContextImpl(std::move(info));
+        *kernel_context_ = reinterpret_cast<OrtExecutableKernelContext *>(kernel_context);
         return ToOrtStatus(Status::OK());
     API_IMPL_END
 }
+
+ORT_API_STATUS_IMPL(OrtApis::ExecutableKernelContext_SetInput,
+                    OrtExecutableKernelContext *context_,
+                    int index,
+                    OrtValue *value) {
+    API_IMPL_BEGIN
+        ExecutableKernelContextImpl *context = reinterpret_cast<ExecutableKernelContextImpl *>(context_);
+        Status status = context->SetInput(*value, index);
+        return ToOrtStatus(status);
+    API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::ExecutableKernelContext_SetOutput,
+                    OrtExecutableKernelContext *context_,
+                    int index,
+                    OrtValue *value) {
+    API_IMPL_BEGIN
+        ExecutableKernelContextImpl *context = reinterpret_cast<ExecutableKernelContextImpl *>(context_);
+        Status status = context->SetOutput(*value, index);
+        return ToOrtStatus(status);
+    API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::ExecutableKernelContext_Compute, _Inout_ OrtExecutableKernelContext *context_) {
+    API_IMPL_BEGIN
+        ExecutableKernelContextImpl *context = reinterpret_cast<ExecutableKernelContextImpl *>(context_);
+        context->Compute();
+        return ToOrtStatus(Status::OK());
+    API_IMPL_END
+}
+

--- a/onnxruntime/core/session/abi_kernel_execution.cc
+++ b/onnxruntime/core/session/abi_kernel_execution.cc
@@ -1,0 +1,199 @@
+// Licensed under the MIT License.
+
+#include <iostream>
+#include <core/graph/model.h>
+#include <core/framework/mldata_type_utils.h>
+#include "core/graph/onnx_protobuf.h"
+#include "core/optimizer/optimizer_execution_frame.h"
+#include "core/session/abi_kernel_execution.h"
+#include "core/session/inference_session.h"
+#include "core/session/ort_apis.h"
+#include "core/framework/customregistry.h"
+#include "core/framework/data_types.h"
+#include "core/framework/execution_providers.h"
+#include "core/framework/op_kernel_info.h"
+#include "core/framework/op_kernel_context_internal.h"
+#include "core/framework/error_code_helper.h"
+#include "core/framework/tensor_type_and_shape.h"
+#include "core/framework/TensorSeq.h"
+#include "core/providers/cpu/cpu_execution_provider.h"
+#include "core/framework/tensorprotoutils.h"
+
+using namespace onnxruntime;
+
+// taken from OptimizerExecutionFrame
+// Return S_OK and nullptr if index map to an value that is an unused optional input/output
+Status ExecutableKernelContextImpl::CreateNodeOutputMLValueImpl(OrtValue &ort_value, int ort_value_idx,
+                                                                const TensorShape *shape, size_t nnz) {
+    const DataTypeImpl *ml_type = DataTypeImpl::TypeFromProto(*info_.ort_value_idx_nodearg_map_.at(ort_value_idx));
+    if (ml_type == nullptr)
+        return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
+                      "Tried to allocate without valid type information, ort_value index=" +
+                      std::to_string(ort_value_idx));
+    if (ml_type->IsSparseTensorType()) {
+        auto element_type = ml_type->AsSparseTensorType()->GetElementType();
+        auto container_type = DataTypeImpl::GetType<SparseTensor>();
+        auto sparse = onnxruntime::make_unique<SparseTensor>(element_type, *shape, nnz, info_.GetAllocator());
+        ort_value.Init(sparse.release(), container_type, container_type->GetDeleteFunc());
+        return Status::OK();
+    }
+
+    if (ml_type->IsTensorSequenceType()) {
+        auto element_type = ml_type->AsSequenceTensorBase()->GetElementType();
+        auto p_sequence = onnxruntime::make_unique<TensorSeq>(element_type);
+        auto ml_tensor_sequence = DataTypeImpl::GetType<TensorSeq>();
+        ort_value.Init(p_sequence.release(), ml_tensor_sequence, ml_tensor_sequence->GetDeleteFunc());
+        return Status::OK();
+    }
+
+    if (!ml_type->IsTensorType()) {
+        assert(ml_type->AsNonTensorTypeBase() != nullptr);
+        const NonTensorTypeBase *non_tensor_type = static_cast<const NonTensorTypeBase *>(ml_type);
+        auto creator = non_tensor_type->GetCreateFunc();
+        ort_value.Init(creator(), non_tensor_type, non_tensor_type->GetDeleteFunc());
+        return Status::OK();
+    }
+
+    // tensors
+    auto element_type = static_cast<const TensorTypeBase *>(ml_type)->GetElementType();
+    AllocatorPtr allocator_ptr = info_.GetAllocator();
+    std::unique_ptr<Tensor> p_tensor = onnxruntime::make_unique<Tensor>(element_type,
+                                                                        *shape,
+                                                                        allocator_ptr);
+
+    auto ml_tensor = DataTypeImpl::GetType<Tensor>();
+    ort_value.Init(p_tensor.release(), ml_tensor, ml_tensor->GetDeleteFunc());
+
+    return Status::OK();
+}
+
+
+ORT_API_STATUS_IMPL(OrtApis::ExecutableKernelContext_Compute, _Inout_ OrtExecutableKernelContext *context_) {
+    API_IMPL_BEGIN
+
+        ExecutableKernelContextImpl::Info *info = reinterpret_cast<ExecutableKernelContextImpl::Info *>(context_);
+
+        ExecutableKernelContextImpl context(*info);
+
+
+        std::cout << "Gonna compute! " << std::endl;
+        context.Compute();
+
+        return ToOrtStatus(Status::OK());
+    API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::CreateExecutableKernelContext,
+                    const OrtExecutableKernel *kernel_,
+                    OrtExecutableKernelContext **context) {
+    API_IMPL_BEGIN
+        const ExecutableKernelImpl *kernel = reinterpret_cast<const ExecutableKernelImpl *>(kernel_);
+
+        std::unique_ptr<CPUExecutionProvider> cpu_execution_provider =
+                make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
+
+        InitializedTensorSet set;
+
+        ExecutableKernelContextImpl::Info *info = new ExecutableKernelContextImpl::Info(kernel->op_kernel,
+                                                                                        logging::LoggingManager::DefaultLogger());
+
+        *context = reinterpret_cast<OrtExecutableKernelContext *>(info);
+        return ToOrtStatus(Status::OK());
+    API_IMPL_END
+}
+
+
+ORT_API_STATUS_IMPL(OrtApis::ExecutableKernelContext_AddInput, OrtExecutableKernelContext *context_, int index,
+                    OrtValue *value) {
+    API_IMPL_BEGIN
+        ExecutableKernelContextImpl::Info *context = reinterpret_cast<ExecutableKernelContextImpl::Info *>(context_);
+        Status status = context->AddInput(*value, index);
+        return ToOrtStatus(status);
+    API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::ExecutableKernelContext_AddImplicitInput, OrtExecutableKernelContext *context_, int index,
+                    OrtValue *value) {
+    API_IMPL_BEGIN
+        ExecutableKernelContextImpl::Info *context = reinterpret_cast<ExecutableKernelContextImpl::Info *>(context_);
+        Status status = context->AddImplicitInput(*value, index);
+        return ToOrtStatus(status);
+    API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::ExecutableKernelContext_AddOutput, OrtExecutableKernelContext *context_, int index,
+                    OrtValue *value) {
+    API_IMPL_BEGIN
+        ExecutableKernelContextImpl::Info *context = reinterpret_cast<ExecutableKernelContextImpl::Info *>(context_);
+        Status status = context->AddOutput(*value, index);
+        return ToOrtStatus(status);
+    API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::CreateExecutableKernel,
+                    _In_ const void *node_proto_,
+                    _In_ const void *arg_name_to_type_map_,
+                    _Outptr_ OrtExecutableKernel **context) {
+    API_IMPL_BEGIN
+        const ONNX_NAMESPACE::NodeProto *node_proto = static_cast<const ONNX_NAMESPACE::NodeProto *>(node_proto_);
+        const ArgNameToTypeMap *arg_name_to_type_map = static_cast<const ArgNameToTypeMap *>(arg_name_to_type_map_);
+
+        ExecutionProviders execution_providers;
+
+        CPUExecutionProviderInfo epi;
+        auto status = execution_providers.Add(kCpuExecutionProvider, make_unique<CPUExecutionProvider>(epi));
+
+        if (!status.IsOK()) {
+            return ToOrtStatus(status);
+        }
+
+        std::cout << "Registered provider!" << std::endl;
+
+        std::cout << node_proto->name() << std::endl;
+
+        // create a fake, one-node model
+        std::unique_ptr<Model> model = std::make_unique<Model>("Model", true, logging::LoggingManager::DefaultLogger());
+        auto &graph = model->MainGraph();
+
+        Node &node = graph.AddNode(*node_proto, *arg_name_to_type_map);
+
+
+        status = graph.Resolve();
+        if (!status.IsOK()) {
+            return ToOrtStatus(status);
+        }
+
+        node.SetExecutionProviderType(kCpuExecutionProvider);
+
+        std::cout << "Added node!" << std::endl;
+
+        const IExecutionProvider *provider = execution_providers.Get(node);
+        if (!provider) {
+            auto status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "node has no provider");
+            LOGS_DEFAULT(ERROR) << status.ErrorMessage();
+            return ToOrtStatus(status);
+        }
+
+        std::shared_ptr<KernelRegistry> registry = provider->GetKernelRegistry();
+        std::unordered_map<int, OrtValue> constant_initalized_tensors;
+
+        OrtValueNameIdxMap name_idx_map;
+        FuncManager funcs_mgr;
+        DataTransferManager data_transfer_mgr;
+
+        std::unique_ptr<OpKernel> op_kernel;
+        status = registry->TryCreateKernel(node, *provider, constant_initalized_tensors, name_idx_map, funcs_mgr,
+                                           data_transfer_mgr, op_kernel);
+
+        if (!status.IsOK()) {
+            return ToOrtStatus(status);
+        }
+
+
+        ExecutableKernelImpl *context_impl = new ExecutableKernelImpl(std::move(model), std::move(op_kernel));
+
+        *context = reinterpret_cast<OrtExecutableKernel *>(context_impl);
+
+        return ToOrtStatus(Status::OK());
+    API_IMPL_END
+}

--- a/onnxruntime/core/session/abi_kernel_execution.h
+++ b/onnxruntime/core/session/abi_kernel_execution.h
@@ -5,94 +5,96 @@
 
 namespace onnxruntime {
 
-    struct ExecutableKernelImpl {
-        ExecutableKernelImpl(std::unique_ptr<Model> model, std::unique_ptr<OpKernel> op_kernel) : model(
-                std::move(model)), op_kernel(std::move(op_kernel)) {}
+    struct KernelSessionImpl {
+        KernelSessionImpl(std::unique_ptr<Model> model) : model(
+                std::move(model)) {}
 
-        // the model who's MainGraph holds the single node for this op_kernel
+        // the model who's MainGraph holds the nodes for the kernels that we will execute
         std::unique_ptr<Model> model;
-        std::unique_ptr<OpKernel> op_kernel;
     };
 
     // An ExecutionFrame that only executes a single kernel
     class ExecutableKernelContextImpl final : public IExecutionFrame {
     public:
+
+        // the struct OrtExecutableKernelContext actually points to this class
         class Info {
         public:
-            Info(std::unique_ptr<OpKernel> const &kernel, const logging::Logger &logger)
-                    : kernel_(kernel),
+            Info(std::unique_ptr<OpKernel> kernel, const logging::Logger &logger)
+                    : kernel_(std::move(kernel)),
                       logger_(&logger) {
-                ORT_ENFORCE(kernel, "kernel cannot be null");
+                ORT_ENFORCE(kernel_, "kernel cannot be null");
 
-                if (kernel->KernelDef().Provider() == kCpuExecutionProvider) {
+                if (kernel_->KernelDef().Provider() == kCpuExecutionProvider) {
                     provider_ = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
-                    transfer_manager_ = std::make_unique<DataTransferManager>();
-                    transfer_manager_->RegisterDataTransfer(std::make_unique<CPUDataTransfer>());
 
                     // as in OptimizerExectutionFrame
                     allocator_ = provider_->GetAllocator(0, OrtMemTypeDefault);
                 } else {
-                    throw NotImplementedException("Provider type is not supported");
+                    throw NotImplementedException(
+                            "Provider type (" + kernel_->KernelDef().Provider() + ") is not supported");
                 }
+
+                auto &node = kernel_->Node();
+
+                input_index_to_mlvalue_map_ = std::vector<int> (node.InputDefs().size(), -1);
+                output_index_to_mlvalue_map_ = std::vector<int> (node.OutputDefs().size(), -1);
+
+                if (node.ImplicitInputDefs().size()) {
+                    // not sure how to handle this correctly
+                    throw new NotImplementedException("Implicit inputs are not supporterted");
+                }
+
+                // initialize inputs and outputs with null values
+                OrtValue null_value;
+                node.ForEachWithIndex(node.InputDefs(),
+                                      [this](const NodeArg &arg, size_t index) {
+                                          this->AddInput(OrtValue(), index, arg.Name());
+                                          return Status::OK();
+                                      });
+
+                node.ForEachWithIndex(node.OutputDefs(),
+                                      [this](const NodeArg &arg, size_t index) {
+                                          this->AddOutput(OrtValue(), index, arg.Name());
+                                          return Status::OK();
+                                      });
             }
 
             AllocatorPtr GetAllocator() const {
                 return allocator_;
             }
 
-            Status AddOutput(OrtValue &value, int index) {
-                int mlvalue_idx = value_name_idx_map_.Add("output" + std::to_string(index));
+            Status AddOutput(OrtValue value, int index, const std::string &name) {
+                int mlvalue_idx = value_name_idx_map_.Add(name);
                 ort_value_idx_nodearg_map_[mlvalue_idx] = kernel_->Info().GetOutputType(index);
 
-                // TODO check that OrtValue is not too big
+                output_index_to_mlvalue_map_[index] = mlvalue_idx;
                 fetches_.push_back(value);
-
-                // TODO shoudl this be num_args++? or mlvalue_idx? Double check that.
                 fetches_mlvalue_idxs_.push_back(mlvalue_idx);
                 return Status::OK();
             }
 
-            Status AddInput(OrtValue &value, int index) {
-                int mlvalue_idx = value_name_idx_map_.Add("input" + std::to_string(index));
+            Status AddInput(OrtValue value, int index, const std::string &name) {
+                int mlvalue_idx = value_name_idx_map_.Add(name);
 
+                input_index_to_mlvalue_map_[index] = mlvalue_idx;
                 ort_value_idx_nodearg_map_[mlvalue_idx] = kernel_->Info().GetInputType(index);
-                // TODO check that OrtValue is not too big
                 feeds_.push_back(value);
                 feed_mlvalue_idxs_.push_back(mlvalue_idx);
                 return Status::OK();
             }
-
-            Status AddImplicitInput(OrtValue &value, int index) {
-                int mlvalue_idx = value_name_idx_map_.Add("imp_input" + std::to_string(index));
-
-                // TODO, probably need to offset this?
-                ort_value_idx_nodearg_map_[mlvalue_idx] = kernel_->Info().GetInputType(index);
-
-                // TODO check that OrtValue is not too big
-                feeds_.push_back(value);
-                feed_mlvalue_idxs_.push_back(mlvalue_idx);
-                return Status::OK();
-            }
-
 
         protected:
 
-            int num_args = 0;
-
             NodeIndexInfo &GetNodeIndexInfo() {
-
-                std::cout << "All OrtValues:" << std::endl;
-
-                for (auto const &value : value_name_idx_map_) {
-                    std::cout << value.first << " : " << value.second << std::endl;
+                if (!node_index_info_) {
+                    node_index_info_ = std::unique_ptr<NodeIndexInfo>(
+                            new NodeIndexInfo({&kernel_->Node()}, value_name_idx_map_));
                 }
-                node_index_info_ = std::unique_ptr<NodeIndexInfo>(
-                        new NodeIndexInfo({&kernel_->Node()}, value_name_idx_map_));
-
                 return *node_index_info_;
             }
 
-            std::unique_ptr<OpKernel> const &kernel_;
+            std::unique_ptr<OpKernel> kernel_;
             const logging::Logger *const logger_;
 
             friend ExecutableKernelContextImpl;
@@ -102,46 +104,55 @@ namespace onnxruntime {
 
             std::unique_ptr<NodeIndexInfo> node_index_info_;
 
+            std::vector<int> input_index_to_mlvalue_map_;
+            std::vector<int> output_index_to_mlvalue_map_;
             std::vector<int> fetches_mlvalue_idxs_;
             std::vector<OrtValue> fetches_;
             std::vector<int> feed_mlvalue_idxs_;
             std::vector<OrtValue> feeds_;
 
             std::unique_ptr<IExecutionProvider> provider_;
-            std::unique_ptr<DataTransferManager> transfer_manager_;
             AllocatorPtr allocator_;
         };
 
-
-        ExecutableKernelContextImpl(Info &info) :
-                IExecutionFrame(info.value_name_idx_map_, info.GetNodeIndexInfo(), info.fetches_mlvalue_idxs_),
-                info_(info) {
-            Init(info.feed_mlvalue_idxs_, info.feeds_, std::unordered_map<int, OrtValue>(), info.fetches_);
+        ExecutableKernelContextImpl(std::unique_ptr<Info> info) :
+        // Ideally we would remove the NodeIndexInfo from the constructor, since we only have one node
+                IExecutionFrame(info->value_name_idx_map_, info->GetNodeIndexInfo(), info->fetches_mlvalue_idxs_),
+                info_(std::move(info)) {
+            Init(info_->feed_mlvalue_idxs_, info_->feeds_, std::unordered_map<int, OrtValue>(), info_->fetches_);
         };
 
+        Status SetInput(OrtValue &value, int index) {
+            return SetOrtValue(value, info_->input_index_to_mlvalue_map_[index]);
+        }
+
+        Status SetOutput(OrtValue &value, int index) {
+            return SetOrtValue(value, info_->output_index_to_mlvalue_map_[index]);
+        }
+
         Status Compute() {
-            OpKernelContext context(this, info_.kernel_.get(), nullptr, *info_.logger_);
-            Status status = info_.kernel_->Compute(&context);
+            OpKernelContext context(this, info_->kernel_.get(), nullptr, *info_->logger_);
+            Status status = info_->kernel_->Compute(&context);
             return status;
         }
 
 
     protected:
+
         AllocatorPtr GetAllocatorImpl(const OrtMemoryInfo &info) const override {
-            return info_.provider_->GetAllocator(info.id, info.mem_type);
+            return info_->provider_->GetAllocator(info.id, info.mem_type);
         }
 
-        Status CopyTensor(const Tensor &src, Tensor &dest) const override {
-            // TODO throw error
-            return info_.transfer_manager_->CopyTensor(src, dest);
+        Status
+        CopyTensor(__attribute__((unused)) const Tensor &src, __attribute__((unused)) Tensor &dest) const override {
+            return Status(ONNXRUNTIME, NOT_IMPLEMENTED, "CopyTensor is not implemented for Single Kernel Execution.");
         }
-
 
         Status CreateNodeOutputMLValueImpl(OrtValue &ort_value, int ort_value_idx, const TensorShape *shape,
                                            size_t nnz) override;
 
     private:
-        const Info &info_;
+        const std::unique_ptr<const Info> info_;
 
         const int device_id_{0};
         const OrtMemType mem_type_{OrtMemTypeDefault};

--- a/onnxruntime/core/session/abi_kernel_execution.h
+++ b/onnxruntime/core/session/abi_kernel_execution.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#include <core/framework/op_kernel.h>
+#include "core/graph/graph.h"
+
+namespace onnxruntime {
+
+    struct ExecutableKernelImpl {
+        ExecutableKernelImpl(std::unique_ptr<Model> model, std::unique_ptr<OpKernel> op_kernel) : model(
+                std::move(model)), op_kernel(std::move(op_kernel)) {}
+
+        // the model who's MainGraph holds the single node for this op_kernel
+        std::unique_ptr<Model> model;
+        std::unique_ptr<OpKernel> op_kernel;
+    };
+
+    // An ExecutionFrame that only executes a single kernel
+    class ExecutableKernelContextImpl final : public IExecutionFrame {
+    public:
+        class Info {
+        public:
+            Info(std::unique_ptr<OpKernel> const &kernel, const logging::Logger &logger)
+                    : kernel_(kernel),
+                      logger_(&logger) {
+                ORT_ENFORCE(kernel, "kernel cannot be null");
+
+                if (kernel->KernelDef().Provider() == kCpuExecutionProvider) {
+                    provider_ = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
+                    transfer_manager_ = std::make_unique<DataTransferManager>();
+                    transfer_manager_->RegisterDataTransfer(std::make_unique<CPUDataTransfer>());
+
+                    // as in OptimizerExectutionFrame
+                    allocator_ = provider_->GetAllocator(0, OrtMemTypeDefault);
+                } else {
+                    throw NotImplementedException("Provider type is not supported");
+                }
+            }
+
+            AllocatorPtr GetAllocator() const {
+                return allocator_;
+            }
+
+            Status AddOutput(OrtValue &value, int index) {
+                int mlvalue_idx = value_name_idx_map_.Add("output" + std::to_string(index));
+                ort_value_idx_nodearg_map_[mlvalue_idx] = kernel_->Info().GetOutputType(index);
+
+                // TODO check that OrtValue is not too big
+                fetches_.push_back(value);
+
+                // TODO shoudl this be num_args++? or mlvalue_idx? Double check that.
+                fetches_mlvalue_idxs_.push_back(mlvalue_idx);
+                return Status::OK();
+            }
+
+            Status AddInput(OrtValue &value, int index) {
+                int mlvalue_idx = value_name_idx_map_.Add("input" + std::to_string(index));
+
+                ort_value_idx_nodearg_map_[mlvalue_idx] = kernel_->Info().GetInputType(index);
+                // TODO check that OrtValue is not too big
+                feeds_.push_back(value);
+                feed_mlvalue_idxs_.push_back(mlvalue_idx);
+                return Status::OK();
+            }
+
+            Status AddImplicitInput(OrtValue &value, int index) {
+                int mlvalue_idx = value_name_idx_map_.Add("imp_input" + std::to_string(index));
+
+                // TODO, probably need to offset this?
+                ort_value_idx_nodearg_map_[mlvalue_idx] = kernel_->Info().GetInputType(index);
+
+                // TODO check that OrtValue is not too big
+                feeds_.push_back(value);
+                feed_mlvalue_idxs_.push_back(mlvalue_idx);
+                return Status::OK();
+            }
+
+
+        protected:
+
+            int num_args = 0;
+
+            NodeIndexInfo &GetNodeIndexInfo() {
+
+                std::cout << "All OrtValues:" << std::endl;
+
+                for (auto const &value : value_name_idx_map_) {
+                    std::cout << value.first << " : " << value.second << std::endl;
+                }
+                node_index_info_ = std::unique_ptr<NodeIndexInfo>(
+                        new NodeIndexInfo({&kernel_->Node()}, value_name_idx_map_));
+
+                return *node_index_info_;
+            }
+
+            std::unique_ptr<OpKernel> const &kernel_;
+            const logging::Logger *const logger_;
+
+            friend ExecutableKernelContextImpl;
+
+            OrtValueNameIdxMap value_name_idx_map_;
+            std::unordered_map<int, const ONNX_NAMESPACE::TypeProto *> ort_value_idx_nodearg_map_;
+
+            std::unique_ptr<NodeIndexInfo> node_index_info_;
+
+            std::vector<int> fetches_mlvalue_idxs_;
+            std::vector<OrtValue> fetches_;
+            std::vector<int> feed_mlvalue_idxs_;
+            std::vector<OrtValue> feeds_;
+
+            std::unique_ptr<IExecutionProvider> provider_;
+            std::unique_ptr<DataTransferManager> transfer_manager_;
+            AllocatorPtr allocator_;
+        };
+
+
+        ExecutableKernelContextImpl(Info &info) :
+                IExecutionFrame(info.value_name_idx_map_, info.GetNodeIndexInfo(), info.fetches_mlvalue_idxs_),
+                info_(info) {
+            Init(info.feed_mlvalue_idxs_, info.feeds_, std::unordered_map<int, OrtValue>(), info.fetches_);
+        };
+
+        Status Compute() {
+            OpKernelContext context(this, info_.kernel_.get(), nullptr, *info_.logger_);
+            Status status = info_.kernel_->Compute(&context);
+            return status;
+        }
+
+
+    protected:
+        AllocatorPtr GetAllocatorImpl(const OrtMemoryInfo &info) const override {
+            return info_.provider_->GetAllocator(info.id, info.mem_type);
+        }
+
+        Status CopyTensor(const Tensor &src, Tensor &dest) const override {
+            // TODO throw error
+            return info_.transfer_manager_->CopyTensor(src, dest);
+        }
+
+
+        Status CreateNodeOutputMLValueImpl(OrtValue &ort_value, int ort_value_idx, const TensorShape *shape,
+                                           size_t nnz) override;
+
+    private:
+        const Info &info_;
+
+        const int device_id_{0};
+        const OrtMemType mem_type_{OrtMemTypeDefault};
+
+    };
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1568,12 +1568,11 @@ static constexpr OrtApi ort_api_1_to_3 = {
     &OrtApis::ModelMetadataGetCustomMetadataMapKeys,
     &OrtApis::AddFreeDimensionOverrideByName,
 
-    &OrtApis::ExecutableKernelContext_Compute,
-    &OrtApis::ExecutableKernelContext_AddInput,
-    &OrtApis::ExecutableKernelContext_AddImplicitInput,
-    &OrtApis::ExecutableKernelContext_AddOutput,
+    &OrtApis::CreateKernelSession,
     &OrtApis::CreateExecutableKernelContext,
-    &OrtApis::CreateExecutableKernel
+    &OrtApis::ExecutableKernelContext_SetInput,
+    &OrtApis::ExecutableKernelContext_SetOutput,
+    &OrtApis::ExecutableKernelContext_Compute
 };
 
 // Assert to do a limited check to ensure Version 1 of OrtApi never changes (will detect an addition or deletion but not if they cancel out each other)

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1572,7 +1572,9 @@ static constexpr OrtApi ort_api_1_to_3 = {
     &OrtApis::CreateExecutableKernelContext,
     &OrtApis::ExecutableKernelContext_SetInput,
     &OrtApis::ExecutableKernelContext_SetOutput,
-    &OrtApis::ExecutableKernelContext_Compute
+    &OrtApis::ExecutableKernelContext_Compute,
+    &OrtApis::ReleaseKernelSession,
+    &OrtApis::ReleaseExecutableKernelContext
 };
 
 // Assert to do a limited check to ensure Version 1 of OrtApi never changes (will detect an addition or deletion but not if they cancel out each other)

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1566,7 +1566,15 @@ static constexpr OrtApi ort_api_1_to_3 = {
     &OrtApis::CreateThreadingOptions,
     &OrtApis::ReleaseThreadingOptions,
     &OrtApis::ModelMetadataGetCustomMetadataMapKeys,
-    &OrtApis::AddFreeDimensionOverrideByName};
+    &OrtApis::AddFreeDimensionOverrideByName,
+
+    &OrtApis::ExecutableKernelContext_Compute,
+    &OrtApis::ExecutableKernelContext_AddInput,
+    &OrtApis::ExecutableKernelContext_AddImplicitInput,
+    &OrtApis::ExecutableKernelContext_AddOutput,
+    &OrtApis::CreateExecutableKernelContext,
+    &OrtApis::CreateExecutableKernel
+};
 
 // Assert to do a limited check to ensure Version 1 of OrtApi never changes (will detect an addition or deletion but not if they cancel out each other)
 // If this assert hits, read the above 'Rules on how to add a new Ort API version'

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -198,4 +198,29 @@ ORT_API_STATUS_IMPL(ModelMetadataGetCustomMetadataMapKeys, _In_ const OrtModelMe
 
 ORT_API_STATUS_IMPL(AddFreeDimensionOverrideByName, _Inout_ OrtSessionOptions* options, _In_ const char* dim_name, _In_ int64_t dim_value);
 
+// ExecutableKernelContext creation and execution
+ORT_API_STATUS_IMPL(ExecutableKernelContext_Compute, _Inout_ OrtExecutableKernelContext* context);
+
+ORT_API_STATUS_IMPL(ExecutableKernelContext_AddInput,
+                    _Inout_ OrtExecutableKernelContext* context,
+                    int index,
+                    _Inout_ OrtValue* value);
+
+
+ORT_API_STATUS_IMPL(ExecutableKernelContext_AddImplicitInput,
+                    _Inout_ OrtExecutableKernelContext* context,
+                    int index,
+                    _Inout_ OrtValue* value);
+
+ORT_API_STATUS_IMPL(ExecutableKernelContext_AddOutput,
+                        _Inout_ OrtExecutableKernelContext* context,
+                        int index,
+                        _Inout_ OrtValue* value);
+
+ORT_API_STATUS_IMPL(CreateExecutableKernelContext,
+                    _In_ const OrtExecutableKernel *kernel,
+                    _Outptr_ OrtExecutableKernelContext** context);
+
+ORT_API_STATUS_IMPL(CreateExecutableKernel, _In_ const void* node_proto, _In_ const void* arg_to_type_map, _Outptr_ OrtExecutableKernel** kernel);
+
 }  // namespace OrtApis

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -200,11 +200,11 @@ ORT_API_STATUS_IMPL(AddFreeDimensionOverrideByName, _Inout_ OrtSessionOptions* o
 
 
 
-ORT_API_STATUS_IMPL(CreateKernelSession, OrtKernelSession** session);
+ORT_API_STATUS_IMPL(CreateKernelSession, _In_ const OrtSessionOptions* options, OrtKernelSession** session);
 
 ORT_API_STATUS_IMPL(CreateExecutableKernelContext,
                     _In_ OrtKernelSession* session,
-                    OrtProviderType providerType,
+                    unsigned int provider_id,
                     _In_ const void * node_proto,
                     _In_ const void* arg_to_type_map,
                     _Outptr_ OrtExecutableKernelContext** kernel);

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -224,4 +224,6 @@ ORT_API_STATUS_IMPL(ExecutableKernelContext_SetOutput,
 
 ORT_API_STATUS_IMPL(ExecutableKernelContext_Compute, _Inout_ OrtExecutableKernelContext* context);
 
+ORT_API(void, ReleaseKernelSession, _Frees_ptr_opt_ OrtKernelSession*);
+ORT_API(void, ReleaseExecutableKernelContext, _Frees_ptr_opt_ OrtExecutableKernelContext*);
 }  // namespace OrtApis

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -198,29 +198,30 @@ ORT_API_STATUS_IMPL(ModelMetadataGetCustomMetadataMapKeys, _In_ const OrtModelMe
 
 ORT_API_STATUS_IMPL(AddFreeDimensionOverrideByName, _Inout_ OrtSessionOptions* options, _In_ const char* dim_name, _In_ int64_t dim_value);
 
-// ExecutableKernelContext creation and execution
-ORT_API_STATUS_IMPL(ExecutableKernelContext_Compute, _Inout_ OrtExecutableKernelContext* context);
-
-ORT_API_STATUS_IMPL(ExecutableKernelContext_AddInput,
-                    _Inout_ OrtExecutableKernelContext* context,
-                    int index,
-                    _Inout_ OrtValue* value);
 
 
-ORT_API_STATUS_IMPL(ExecutableKernelContext_AddImplicitInput,
-                    _Inout_ OrtExecutableKernelContext* context,
-                    int index,
-                    _Inout_ OrtValue* value);
-
-ORT_API_STATUS_IMPL(ExecutableKernelContext_AddOutput,
-                        _Inout_ OrtExecutableKernelContext* context,
-                        int index,
-                        _Inout_ OrtValue* value);
+ORT_API_STATUS_IMPL(CreateKernelSession, OrtKernelSession** session);
 
 ORT_API_STATUS_IMPL(CreateExecutableKernelContext,
-                    _In_ const OrtExecutableKernel *kernel,
-                    _Outptr_ OrtExecutableKernelContext** context);
+                    _In_ OrtKernelSession* session,
+                    OrtProviderType providerType,
+                    _In_ const void * node_proto,
+                    _In_ const void* arg_to_type_map,
+                    _Outptr_ OrtExecutableKernelContext** kernel);
 
-ORT_API_STATUS_IMPL(CreateExecutableKernel, _In_ const void* node_proto, _In_ const void* arg_to_type_map, _Outptr_ OrtExecutableKernel** kernel);
+ORT_API_STATUS_IMPL(ExecutableKernelContext_SetInput,
+                    _Inout_ OrtExecutableKernelContext* context,
+                    int index,
+                    _Inout_ OrtValue* value);
+ORT_API_STATUS_IMPL(ExecutableKernelContext_SetImplicitInput,
+                    _Inout_ OrtExecutableKernelContext* context,
+                    int index,
+                    _Inout_ OrtValue* value);
+ORT_API_STATUS_IMPL(ExecutableKernelContext_SetOutput,
+                    _Inout_ OrtExecutableKernelContext* context,
+                    int index,
+                    _Inout_ OrtValue* value);
+
+ORT_API_STATUS_IMPL(ExecutableKernelContext_Compute, _Inout_ OrtExecutableKernelContext* context);
 
 }  // namespace OrtApis


### PR DESCRIPTION
**Description**: This PR adds an interface to the C ABI that enables the execution of single ONNX nodes, without the overhead of graph construction and memory allocation

**Motivation and Context**
The alternative way to execute single operators/nodes is to create an ONNX graph containing a single node only. However, this (understandably) adds a lot of overhead, as can be seen in the plot below.

![image](https://user-images.githubusercontent.com/22137236/86919467-915f0e80-c128-11ea-920f-b15cb4d9e4ef.png)

Here is an example of how the API can be used:
```c
    // SETUP KERNEL
    OrtKernelSession *session;
    CheckStatus(g_ort->CreateKernelSession(options, &session));


    // SETUP EXECUTION FRAME
    OrtExecutableKernelContext *context;
    CheckStatus(g_ort->CreateExecutableKernelContext(session, /*provider_index=*/0, &proto_add, &map_add, &context));

    CheckStatus(g_ort->ExecutableKernelContext_SetInput(context, 0, input_tensor1));
    CheckStatus(g_ort->ExecutableKernelContext_SetInput(context, 1, input_tensor2));
    CheckStatus(g_ort->ExecutableKernelContext_SetOutput(context, 0, output_tensor));
    CheckStatus(g_ort->ExecutableKernelContext_Compute(context));
```
It has been tested with the CPU and CUDA execution providers.