### PR TITLE
Remove code which is not thread-safe.

### DIFF
--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -257,13 +257,6 @@ ExecutionFrame::ExecutionFrame(const std::vector<int>& feed_mlvalue_idxs, const 
               // static_activation_memory_in_bytes_ is max virtual memory size the planner computes 
               auto peak_size = mem_patterns_->patterns[i].PeakSize();
               // Planning of one memory type should only happen once.
-              ORT_ENFORCE(
-                static_activation_memory_sizes_in_byte_.find(location.name) ==
-                static_activation_memory_sizes_in_byte_.end(),
-                "Memory type ",
-                location.name,
-                " should only appear once.");
-              static_activation_memory_sizes_in_byte_[location.name] = peak_size;
               buffer = alloc->Alloc(peak_size);
               // handle allocator that doesn't throw
               if (buffer == nullptr) {
@@ -386,8 +379,6 @@ Status ExecutionFrame::AllocateMLValueTensorSelfOwnBufferHelper(OrtValue& ort_va
   if (!utils::IsDataTypeString(element_type)) {
     TraceAllocate(ort_value_index, size);
   }
-
-  dynamic_activation_memory_sizes_in_byte_[location.name] += size;
 
   return Status::OK();
 }

--- a/onnxruntime/core/framework/execution_frame.h
+++ b/onnxruntime/core/framework/execution_frame.h
@@ -129,18 +129,6 @@ class ExecutionFrame final : public IExecutionFrame {
     return planner_ != nullptr;
   }
 
-  // Return the size of virtual memory allocated in runtime.
-  // The memory is usually used for activations in forward and backward passes.
-  const std::unordered_map<std::string, size_t>& GetDynamicMemorySizeInfo() {
-    return dynamic_activation_memory_sizes_in_byte_;
-  }
-
-  // Return the size of virtual memory allocated before computation.
-  // The memory is usually used for activations in forward and backward passes.
-  const std::unordered_map<std::string, size_t>& GetStaticMemorySizeInfo() {
-    return static_activation_memory_sizes_in_byte_;
-  }
-
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(ExecutionFrame);
 
@@ -180,13 +168,5 @@ class ExecutionFrame final : public IExecutionFrame {
 
   // Big chunks on different locations that will be used by mem_pattern.
   std::map<OrtMemoryInfo, BufferUniquePtr> buffers_;
-
-  // Size of virtual memory allocated before any kernel execution.
-  // This field is not physical memory size.
-  std::unordered_map<std::string, size_t> static_activation_memory_sizes_in_byte_;
-  // Size of virtual memory allocated during kernel execution (i.e., inside a kernel,
-  // we may allocate some memory for its outputs, if not planned.).
-  // This field is not physical memory size.
-  std::unordered_map<std::string, size_t> dynamic_activation_memory_sizes_in_byte_;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/finalize_session_state.cc
+++ b/onnxruntime/core/framework/finalize_session_state.cc
@@ -189,14 +189,8 @@ common::Status SaveInitializedTensors(const Env& env, const std::basic_string<PA
   //2. allocate weight buffer on different locations
   // planned_initializers_memory_size_in_byte is not actual physical size.
   // It's the virtual size computed by planner.
-  std::unordered_map<std::string, size_t> planned_initializers_memory_sizes_in_byte;
   ORT_RETURN_IF_ERROR(
-      planner.FinalizePlan(planned_initializers_memory_sizes_in_byte));
-
-  for (auto i : planned_initializers_memory_sizes_in_byte) {
-    LOGS(logger, INFO) << "[Memory] SessionStateInitializer statically allocates "
-                       << i.second << " bytes for " << i.first << std::endl;
-  }
+      planner.FinalizePlan());
 
   OrtCallback deleter;
 

--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -445,16 +445,6 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
     session_state.Profiler().EndTimeAndRecordEvent(profiling::SESSION_EVENT, "SequentialExecutor::Execute", tp);
   }
 
-  for (auto i: frame.GetStaticMemorySizeInfo()) {
-    LOGS(logger, INFO) << "[Memory] ExecutionFrame statically allocates "
-                       << i.second << " bytes for " << i.first << std::endl;
-  }
-
-  for (auto i: frame.GetDynamicMemorySizeInfo()) {
-    LOGS(logger, INFO) << "[Memory] ExecutionFrame dynamically allocates "
-                       << i.second << " bytes for " << i.first << std::endl;
-  }
-
   return Status::OK();
 }
 

--- a/onnxruntime/core/framework/simple_tensor_allocator.h
+++ b/onnxruntime/core/framework/simple_tensor_allocator.h
@@ -28,10 +28,7 @@ class SimpleTensorAllocator : public ITensorAllocator {
         weights_buffers_(weights_buffers),
         seq_plan_(execution_plan) {}
 
-  common::Status FinalizePlan(std::unordered_map<std::string, size_t>& planned_memory_sizes_in_byte) override {
-    // There is no memory plan to allocate a big block of memory, so
-    // planned memory sizes in different locations are all empty.
-    planned_memory_sizes_in_byte = std::unordered_map<std::string, size_t>();
+  common::Status FinalizePlan() override {
     return Status::OK();
   }
   common::Status GetPreallocatedBuffer(int ort_value_index, const char* name, std::unique_ptr<MemBuffer>& out) override;

--- a/onnxruntime/core/framework/tensor_allocator.h
+++ b/onnxruntime/core/framework/tensor_allocator.h
@@ -25,13 +25,10 @@ class ITensorAllocator {
   AllocatorPtr GetAllocator(const OrtMemoryInfo& memory_info);
 
   /**
-   *
-   * \param planned_memory_size_in_byte The size of memory allocated inside FinalizePlan
-   *
    * When there is no more tensor to trace, call this function to finalize the
    * allocation.
    */
-  virtual common::Status FinalizePlan(std::unordered_map<std::string, size_t>& planned_memory_sizes_in_byte) = 0;
+  virtual common::Status FinalizePlan() = 0;
 
   /**
    *

--- a/onnxruntime/core/framework/tensor_allocator_with_mem_pattern.h
+++ b/onnxruntime/core/framework/tensor_allocator_with_mem_pattern.h
@@ -21,8 +21,7 @@ class TensorAllocatorWithMemPattern : public ITensorAllocator {
   bool is_sealed_ = false;
   const ExecutionPlanBase& seq_plan_;
 
-  common::Status AllocatePlannedBuffersAndReportTotalSize(
-      std::unordered_map<std::string, size_t>& planned_memory_sizes_in_byte) {
+  common::Status AllocatePlannedBuffersAndReportTotalSize() {
     const size_t location_len = mem_patterns_.locations.size();
     for (size_t i = 0; i < location_len; ++i) {
       auto& location = mem_patterns_.locations[i];
@@ -52,8 +51,6 @@ class TensorAllocatorWithMemPattern : public ITensorAllocator {
         alloc->Free(buffer);
         return Status(common::ONNXRUNTIME, common::FAIL, "duplicated location");
       }
-
-      planned_memory_sizes_in_byte[location.name] += peak_size;
     }
     return Status::OK();
   }
@@ -66,9 +63,9 @@ class TensorAllocatorWithMemPattern : public ITensorAllocator {
         weights_buffers_(weights_buffers),
         seq_plan_(execution_plan) {}
 
-  common::Status FinalizePlan(std::unordered_map<std::string, size_t>& planned_memory_sizes_in_byte) override {
+  common::Status FinalizePlan() override {
     ORT_RETURN_IF_ERROR(planner_.GeneratePatterns(&mem_patterns_));
-    ORT_RETURN_IF_ERROR(AllocatePlannedBuffersAndReportTotalSize(planned_memory_sizes_in_byte));
+    ORT_RETURN_IF_ERROR(AllocatePlannedBuffersAndReportTotalSize());
     is_sealed_ = true;
     return Status::OK();
   }


### PR DESCRIPTION
Because of acync access to the memory logger when using parallel executor,
ORT crashes sometime. This PR just removes memory logger, which should be replaced with a thread-safe map.
