### PR TITLE
Fix condition of running tests in win CI

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-2019.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-2019.yml
@@ -151,15 +151,16 @@ jobs:
           arguments: '--configuration $(BuildConfig) -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=${{ parameters.OrtPackageId }}'
           workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
-    - ${{ if and(eq(parameters.BuildCSharp, true), in(parameters['sln_platform'], 'Win32', 'x64')) }}:
-      - task: DotNetCoreCLI@2
-        displayName: 'Test C#'
-        inputs:
-          command: test
-          projects: '$(Build.SourcesDirectory)\csharp\test\Microsoft.ML.OnnxRuntime.Tests\Microsoft.ML.OnnxRuntime.Tests.csproj'
-          configuration: '$(BuildConfig)'
-          arguments: '--configuration $(BuildConfig) -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=${{ parameters.OrtPackageId }}'
-          workingDirectory: '$(Build.SourcesDirectory)\csharp'
+    - ${{ if in(parameters['sln_platform'], 'Win32', 'x64') }}:      
+      - ${{ if eq(parameters.BuildCSharp, true) }}:
+        - task: DotNetCoreCLI@2
+          displayName: 'Test C#'
+          inputs:
+            command: test
+            projects: '$(Build.SourcesDirectory)\csharp\test\Microsoft.ML.OnnxRuntime.Tests\Microsoft.ML.OnnxRuntime.Tests.csproj'
+            configuration: '$(BuildConfig)'
+            arguments: '--configuration $(BuildConfig) -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=${{ parameters.OrtPackageId }}'
+            workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
       - ${{ if eq(parameters.RunTests, true) }}:
         - script: |


### PR DESCRIPTION
**Description**:

Currently, if `BuildCSharp` is set to false, the tests ('Run tests') will not run. This is not the expected behavior and should be fixed.

This change fixes this issue introduced in previous change: https://github.com/microsoft/onnxruntime/commit/647a8865871d0860bfea9564567dc0ae183a96f4#diff-2b5432276603f2e45b4e2aa626c57758R149