### PR TITLE
Fix segmentation fault caused by invalid tensor type

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -842,6 +842,10 @@ Graph::Graph(const Model& owning_model,
     NodeArg* matching_graph_input = GetNodeArg(tensor.name());
     TypeProto t{TypeProtoFromTensorProto(tensor)};
 
+    if (t.tensor_type().elem_type() == ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED) {
+        ORT_THROW("This is an invalid model. Tensor does not have type information.");
+    }
+
     if (ir_version_ < 4) {
       // initializers can have matching graph inputs but are treated as constant,
       // so we prefer the shape from the initializer

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -842,8 +842,8 @@ Graph::Graph(const Model& owning_model,
     NodeArg* matching_graph_input = GetNodeArg(tensor.name());
     TypeProto t{TypeProtoFromTensorProto(tensor)};
 
-    if (t.tensor_type().elem_type() == ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED) {
-        ORT_THROW("This is an invalid model. Tensor does not have type information.");
+    if (!utils::HasElemType(t.tensor_type())) {
+      ORT_THROW("This is an invalid model. Tensor does not have type information.");
     }
 
     if (ir_version_ < 4) {


### PR DESCRIPTION
**Description**: This would fix segmentation fault caused by models(invalid) having nodes(that need input) with no inputs.

**Motivation and Context**
- Why is this change required? What problem does it solve? Explained above in description.
- If it fixes an open issue, please link to the issue here. https://github.com/microsoft/onnxruntime/issues/4349
