### PR TITLE
fix crashes caused by test runner

### DIFF
--- a/onnxruntime/test/onnx/runner.cc
+++ b/onnxruntime/test/onnx/runner.cc
@@ -49,14 +49,33 @@ void ORT_CALLBACK RunTestCase(ORT_CALLBACK_INSTANCE pci, void* context, ORT_WORK
   }
 }
 
-void PTestRunner::Start(ORT_CALLBACK_INSTANCE, size_t concurrent_runs) {
-  concurrent_runs = std::min<size_t>(std::max<size_t>(1, concurrent_runs), c_.GetDataCount());
-  next_test_to_run = 0;
-  for (size_t i = 0; i != concurrent_runs; ++i) {
-    if (!ScheduleNew()) {
-      throw std::runtime_error("ScheduleNew task failed");
+void PTestRunner::Start(ORT_CALLBACK_INSTANCE pci, size_t concurrent_runs) noexcept {
+  bool atleast_one_run_scheduled = false;
+  try {
+    concurrent_runs = std::min<size_t>(std::max<size_t>(1, concurrent_runs), c_.GetDataCount());
+    next_test_to_run = 0;
+    for (size_t i = 0; i != concurrent_runs; ++i) {
+      if (!ScheduleNew()) {
+        if (i == 0) {
+          // This should be a rare case.
+		  // Log it. While existing Finish will be called which will take care of the cleanup
+          LOGF_DEFAULT(ERROR, "Could not schedule tasks for test case: %s\n", c_.GetTestCaseName().c_str());
+        }
+        break;
+      }
+      atleast_one_run_scheduled = true;
     }
+  } catch (const std::exception& ex) {
+    LOGF_DEFAULT(ERROR, "Cannot schedule tasks for test %s. Failing with error :%s\n", c_.GetTestCaseName().c_str(), ex.what());
+  } catch (...) {
+    LOGF_DEFAULT(ERROR, "Cannot schedule tasks for test %s. Failing with error :%s\n", c_.GetTestCaseName().c_str());
   }
+
+  // If no task was scheduled then call Finish to perform cleanup
+  // Otherwise the last task to complete will call Finish  
+  if (!atleast_one_run_scheduled) {
+    Finish(pci);
+  }  
 }
 
 bool PTestRunner::ScheduleNew() {
@@ -309,7 +328,7 @@ void DataRunner::RunTask(size_t task_id, ORT_CALLBACK_INSTANCE pci) {
   EXECUTE_RESULT res = EXECUTE_RESULT::UNKNOWN_ERROR;
   try {
     res = RunTaskImpl(task_id);
-  } catch (std::exception& ex) {
+  } catch (const std::exception& ex) {
     res = EXECUTE_RESULT::WITH_EXCEPTION;
     LOGS_DEFAULT(ERROR) << c_.GetTestCaseName() << ":" << ex.what();
   }
@@ -461,12 +480,16 @@ EXECUTE_RESULT DataRunner::RunTaskImpl(size_t task_id) {
   return res;
 }
 
-void SeqTestRunner::Start(ORT_CALLBACK_INSTANCE pci, size_t) {
-  const size_t data_count = c_.GetDataCount();
-  for (size_t idx_repeat = 0; idx_repeat != repeat_count_; ++idx_repeat) {
-    for (size_t idx_data = 0; idx_data != data_count; ++idx_data) {
-      RunTask(idx_data, nullptr);
-    }
+void SeqTestRunner::Start(ORT_CALLBACK_INSTANCE pci, size_t) noexcept {
+  try {
+    const size_t data_count = c_.GetDataCount();
+    for (size_t idx_repeat = 0; idx_repeat != repeat_count_; ++idx_repeat) {
+      for (size_t idx_data = 0; idx_data != data_count; ++idx_data) {
+        RunTask(idx_data, nullptr);
+      }
+    }    
+  } catch (...) {
+    LOGS_DEFAULT(ERROR) << "SeqTestRunner::Start - Encountred exception with running tests" ;
   }
 
   Finish(pci);
@@ -476,9 +499,8 @@ void RunSingleTestCase(const ITestCase& info, Ort::Env& env, const Ort::SessionO
                        size_t concurrent_runs, size_t repeat_count, PThreadPool tpool,
                        ORT_CALLBACK_INSTANCE pci, TestCaseCallBack on_finished) {
   std::shared_ptr<TestCaseResult> ret;
-  size_t data_count = info.GetDataCount();
+  size_t data_count = info.GetDataCount();  
   try {
-    std::unique_ptr<DataRunner> r;
     std::string node_name = info.GetNodeName();
     auto sf2 = sf.Clone();
     sf2.SetLogId(info.GetTestCaseName().c_str());
@@ -489,30 +511,30 @@ void RunSingleTestCase(const ITestCase& info, Ort::Env& env, const Ort::SessionO
       concurrent_runs = 1;
     }
 
+	DataRunner* r;
     if (concurrent_runs > 1 && data_count > 1) {
-      r.reset(new PTestRunner(session_object.release(), info, tpool, on_finished));
+      r = new PTestRunner(session_object.release(), info, tpool, on_finished);
     } else {
-      r.reset(new SeqTestRunner(session_object.release(), info, repeat_count, on_finished));
+      r = new SeqTestRunner(session_object.release(), info, repeat_count, on_finished);
     }
     r->Start(pci, concurrent_runs);
 
-    // DataRunner::Finish will delete itself, so now that we know everything has started without any exceptions
-    // we can release it from the unique_ptr
-    r.release();
+	// Both Parallel and Sequential Test Runners call DataRunner::Finish which will delete itself and call on_finished callback
+	// At this point we know everything has strated without any exceptions so simply return.
     return;
-  } catch (const Ort::Exception& ex) {
-    if (ex.GetOrtErrorCode() != ORT_NOT_IMPLEMENTED) {
-      throw;
-    }
 
+  } catch (const onnxruntime::NotImplementedException& ex) {
     LOGF_DEFAULT(ERROR, "Test %s failed:%s", info.GetTestCaseName().c_str(), ex.what());
     std::string node_name;
     ret = std::make_shared<TestCaseResult>(data_count, EXECUTE_RESULT::NOT_SUPPORT, "");
-  } catch (onnxruntime::NotImplementedException& ex) {
+  } catch (const Ort::Exception& ex) {
     LOGF_DEFAULT(ERROR, "Test %s failed:%s", info.GetTestCaseName().c_str(), ex.what());
     std::string node_name;
     ret = std::make_shared<TestCaseResult>(data_count, EXECUTE_RESULT::NOT_SUPPORT, "");
-  }
+  } 
+
+  // we will land here in case of session creation failures. 
+  // in all other cases DataRunner::Finish will call this.
   on_finished(ret, pci);
 }
 

--- a/onnxruntime/test/onnx/runner.cc
+++ b/onnxruntime/test/onnx/runner.cc
@@ -58,7 +58,7 @@ void PTestRunner::Start(ORT_CALLBACK_INSTANCE pci, size_t concurrent_runs) noexc
       if (!ScheduleNew()) {
         if (i == 0) {
           // This should be a rare case.
-		  // Log it. While existing Finish will be called which will take care of the cleanup
+          // Log it. While existing Finish will be called which will take care of the cleanup
           LOGF_DEFAULT(ERROR, "Could not schedule tasks for test case: %s\n", c_.GetTestCaseName().c_str());
         }
         break;
@@ -68,14 +68,14 @@ void PTestRunner::Start(ORT_CALLBACK_INSTANCE pci, size_t concurrent_runs) noexc
   } catch (const std::exception& ex) {
     LOGF_DEFAULT(ERROR, "Cannot schedule tasks for test %s. Failing with error :%s\n", c_.GetTestCaseName().c_str(), ex.what());
   } catch (...) {
-    LOGF_DEFAULT(ERROR, "Cannot schedule tasks for test %s. Failing with error :%s\n", c_.GetTestCaseName().c_str());
+    LOGF_DEFAULT(ERROR, "Cannot schedule tasks for test %s.\n", c_.GetTestCaseName().c_str());
   }
 
   // If no task was scheduled then call Finish to perform cleanup
-  // Otherwise the last task to complete will call Finish  
+  // Otherwise the last task to complete will call Finish
   if (!atleast_one_run_scheduled) {
     Finish(pci);
-  }  
+  }
 }
 
 bool PTestRunner::ScheduleNew() {
@@ -487,9 +487,9 @@ void SeqTestRunner::Start(ORT_CALLBACK_INSTANCE pci, size_t) noexcept {
       for (size_t idx_data = 0; idx_data != data_count; ++idx_data) {
         RunTask(idx_data, nullptr);
       }
-    }    
+    }
   } catch (...) {
-    LOGS_DEFAULT(ERROR) << "SeqTestRunner::Start - Encountred exception with running tests" ;
+    LOGS_DEFAULT(ERROR) << "SeqTestRunner::Start - Encountred exception with running tests";
   }
 
   Finish(pci);
@@ -499,7 +499,7 @@ void RunSingleTestCase(const ITestCase& info, Ort::Env& env, const Ort::SessionO
                        size_t concurrent_runs, size_t repeat_count, PThreadPool tpool,
                        ORT_CALLBACK_INSTANCE pci, TestCaseCallBack on_finished) {
   std::shared_ptr<TestCaseResult> ret;
-  size_t data_count = info.GetDataCount();  
+  size_t data_count = info.GetDataCount();
   try {
     std::string node_name = info.GetNodeName();
     auto sf2 = sf.Clone();
@@ -511,7 +511,7 @@ void RunSingleTestCase(const ITestCase& info, Ort::Env& env, const Ort::SessionO
       concurrent_runs = 1;
     }
 
-	DataRunner* r;
+    DataRunner* r;
     if (concurrent_runs > 1 && data_count > 1) {
       r = new PTestRunner(session_object.release(), info, tpool, on_finished);
     } else {
@@ -519,8 +519,8 @@ void RunSingleTestCase(const ITestCase& info, Ort::Env& env, const Ort::SessionO
     }
     r->Start(pci, concurrent_runs);
 
-	// Both Parallel and Sequential Test Runners call DataRunner::Finish which will delete itself and call on_finished callback
-	// At this point we know everything has strated without any exceptions so simply return.
+    // both PTestRunner and SeqTestRunner call DataRunner::Finish which will delete itself and call on_finished callback
+    // at this point we know everything has strated without any exceptions so simply return.
     return;
 
   } catch (const onnxruntime::NotImplementedException& ex) {
@@ -531,9 +531,9 @@ void RunSingleTestCase(const ITestCase& info, Ort::Env& env, const Ort::SessionO
     LOGF_DEFAULT(ERROR, "Test %s failed:%s", info.GetTestCaseName().c_str(), ex.what());
     std::string node_name;
     ret = std::make_shared<TestCaseResult>(data_count, EXECUTE_RESULT::NOT_SUPPORT, "");
-  } 
+  }
 
-  // we will land here in case of session creation failures. 
+  // we will land here in case of session creation failures.
   // in all other cases DataRunner::Finish will call this.
   on_finished(ret, pci);
 }

--- a/onnxruntime/test/onnx/runner.h
+++ b/onnxruntime/test/onnx/runner.h
@@ -43,6 +43,9 @@ class DataRunner {
   //Time spent in Session::Run. It only make sense when SeqTestRunner was used
   ::onnxruntime::TIME_SPEC spent_time_;
 
+  // DataRunner destructor should not be made public. DataRunner owns itself and only it knows 
+  // when it can destoy itself. Multiple tasks share the session object owned by DataRunner and only 
+  // when all these tasks complete can it be destroyed.
   virtual ~DataRunner();
 
  private:

--- a/onnxruntime/test/onnx/runner.h
+++ b/onnxruntime/test/onnx/runner.h
@@ -60,7 +60,7 @@ class DataRunner {
   virtual void Start(ORT_CALLBACK_INSTANCE pci, size_t concurrent_runs) noexcept = 0;
 
   void Finish(ORT_CALLBACK_INSTANCE pci) {
-    std::shared_ptr<TestCaseResult> res = result;	
+    std::shared_ptr<TestCaseResult> res = result;
     CALL_BACK on_finished_local = on_finished;
     res->SetSpentTime(spent_time_);
     const std::vector<EXECUTE_RESULT>& er = res->GetExcutionResult();

--- a/onnxruntime/test/onnx/runner.h
+++ b/onnxruntime/test/onnx/runner.h
@@ -43,6 +43,8 @@ class DataRunner {
   //Time spent in Session::Run. It only make sense when SeqTestRunner was used
   ::onnxruntime::TIME_SPEC spent_time_;
 
+  virtual ~DataRunner();
+
  private:
   OrtSession* session;
   CALL_BACK on_finished;
@@ -55,13 +57,11 @@ class DataRunner {
              TestCaseCallBack on_finished1);
   virtual void OnTaskFinished(size_t task_id, EXECUTE_RESULT res, ORT_CALLBACK_INSTANCE pci) noexcept = 0;
   void RunTask(size_t task_id, ORT_CALLBACK_INSTANCE pci);
-  virtual ~DataRunner();
-
-  virtual void Start(ORT_CALLBACK_INSTANCE pci, size_t concurrent_runs) = 0;
+  virtual void Start(ORT_CALLBACK_INSTANCE pci, size_t concurrent_runs) noexcept = 0;
 
   void Finish(ORT_CALLBACK_INSTANCE pci) {
-    std::shared_ptr<TestCaseResult> res = result;
-    CALL_BACK callback = on_finished;
+    std::shared_ptr<TestCaseResult> res = result;	
+    CALL_BACK on_finished_local = on_finished;
     res->SetSpentTime(spent_time_);
     const std::vector<EXECUTE_RESULT>& er = res->GetExcutionResult();
     for (size_t i = 0; i != er.size(); ++i) {
@@ -90,7 +90,7 @@ class DataRunner {
       break;
     }
     delete this;
-    callback(res, pci);
+    on_finished_local(res, pci);
   }
 };
 
@@ -101,7 +101,7 @@ class SeqTestRunner : public DataRunner {
  public:
   SeqTestRunner(OrtSession* session1, const ITestCase& c, size_t repeat_count, TestCaseCallBack on_finished1);
 
-  void Start(ORT_CALLBACK_INSTANCE pci, size_t concurrent_runs) override;
+  void Start(ORT_CALLBACK_INSTANCE pci, size_t concurrent_runs) noexcept override;
   void OnTaskFinished(size_t, EXECUTE_RESULT, ORT_CALLBACK_INSTANCE) noexcept override {}
 };
 
@@ -112,7 +112,7 @@ class PTestRunner : public DataRunner {
   void OnTaskFinished(size_t task_id, EXECUTE_RESULT res, ORT_CALLBACK_INSTANCE pci) noexcept override;
 
  public:
-  void Start(ORT_CALLBACK_INSTANCE pci, size_t concurrent_runs) override;
+  void Start(ORT_CALLBACK_INSTANCE pci, size_t concurrent_runs) noexcept override;
 
   PTestRunner(OrtSession* session1, const ITestCase& c, PThreadPool tpool, TestCaseCallBack on_finished1);
 


### PR DESCRIPTION
**Description**: This PR fixes mem access violation caused by onnx_test_runner parallel tests. 
PTestRunner::Start throws when it cannot schedule a new task and in this case DataRunner is destroyed and so is the session object held by DataRunner. This becomens an issue when there are other threads which are still executing tests. 

**Motivation and Context**
- Fixes crashes in onnx_test_runner



