### PR TITLE
Enable onnxruntime_test_all for NNAPI EP

### DIFF
--- a/onnxruntime/test/providers/cpu/math/softmax_test.cc
+++ b/onnxruntime/test/providers/cpu/math/softmax_test.cc
@@ -12,7 +12,7 @@ static void RunTest(const std::vector<float>& x_vals,
                     const std::vector<float>& expected_vals,
                     const std::vector<int64_t>& dimensions,
                     int64_t axis = 1,
-                    bool is_tensorrt_supported = true,
+                    const std::unordered_set<std::string>& excluded_providers = {},
                     OpTester::ExpectResult expect_result = OpTester::ExpectResult::kExpectSuccess,
                     const std::string& error_msg = "",
                     int opset = 7) {
@@ -24,10 +24,6 @@ static void RunTest(const std::vector<float>& x_vals,
 
   test.AddInput<float>("X", dimensions, x_vals);
   test.AddOutput<float>("Y", dimensions, expected_vals);
-  std::unordered_set<std::string> excluded_providers;
-  if (!is_tensorrt_supported) {
-    excluded_providers.insert(kTensorrtExecutionProvider);
-  }
   test.Run(expect_result, error_msg, excluded_providers);
 }
 
@@ -97,7 +93,7 @@ TEST(SoftmaxOperator, ThreeDimsAxis0) {
       0.017545262f, 0.0135920765f, 0.027506188f, 0.010684152f, 0.0049549243f,
       0.01401341f, 0.011721271f, 0.027815264f, 0.021463264f, 0.014014485f};
 
-  RunTest(x_vals_3dims, expected_vals, three_dimensions, /*axis*/ 0, false);  // Axis=0 is not supported by TensorRT
+  RunTest(x_vals_3dims, expected_vals, three_dimensions, /*axis*/ 0, {kTensorrtExecutionProvider});  // Axis=0 is not supported by TensorRT
 }
 
 TEST(SoftmaxOperator, ThreeDimsAxis1) {
@@ -123,7 +119,7 @@ TEST(SoftmaxOperator, ThreeDimsAxis1) {
       0.050680935f, 0.03926183f, 0.079453886f, 0.030862054f, 0.014312706f,
       0.040478885f, 0.033857856f, 0.080346674f, 0.06199841f, 0.040481992f};
 
-  RunTest(x_vals_3dims, expected_vals, three_dimensions, /*axis*/ 1, false);
+  RunTest(x_vals_3dims, expected_vals, three_dimensions, /*axis*/ 1, {kTensorrtExecutionProvider});
 }
 
 TEST(SoftmaxOperator, ThreeDimsAxis2) {
@@ -187,7 +183,7 @@ TEST(SoftmaxOperator, InvalidAxis) {
   RunTest(x_vals,
           expected_vals,
           dimensions,
-          /* invalid axis */ -10, false,
+          /* invalid axis */ -10, {kTensorrtExecutionProvider},
           OpTester::ExpectResult::kExpectFailure,
           // bug in ONNX error message currently. Message should be
           // "[ShapeInferenceError] 'axis' must be in [-2 , 1]. Its actual value is: -10"
@@ -201,7 +197,10 @@ TEST(SoftmaxOperator, DimWithZero) {
   std::vector<float> expected_vals = {};
   std::vector<int64_t> dimensions = {1, 0};  // dim with value of 0 should be handled
 
-  RunTest(x_vals, expected_vals, dimensions, 0, false, OpTester::ExpectResult::kExpectSuccess, "", 10);
+  RunTest(x_vals, expected_vals, dimensions, 0,
+          {kTensorrtExecutionProvider,
+           kNnapiExecutionProvider},  // NNAPI softmax does not support empty input
+          OpTester::ExpectResult::kExpectSuccess, "", 10);
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/cpu/tensor/concat_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/concat_op_test.cc
@@ -62,7 +62,9 @@ TEST(ConcatOpTest, Concat1D_2) {
   test.AddInput<float>("input2", {2}, {2.0f, 3.0f});
   test.AddInput<float>("input3", {0}, {});
   test.AddOutput<float>("concat_result", {3}, {1.0f, 2.0f, 3.0f});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider}); //TensorRT: no support for dynamic shape tensor
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider,  //TensorRT: no support for dynamic shape tensor
+            kNnapiExecutionProvider});   // NNAPI: concat does not support 0 size input
 }
 
 TEST(ConcatOpTest, Concat2D_1) {
@@ -104,7 +106,9 @@ TEST(ConcatOpTest, Concat2D_3) {
   test.AddInput<float>("input2", {1, 0}, {});
   test.AddInput<float>("input3", {1, 0}, {});
   test.AddOutput<float>("concat_result", {1, 0}, {});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider}); //TensorRT: no support for dynamic shape tensor
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider,  //TensorRT: no support for dynamic shape tensor
+            kNnapiExecutionProvider});   // NNAPI: concat does not support 0 size input
 }
 
 TEST(ConcatOpTest, Concat3D_1) {

--- a/onnxruntime/test/providers/provider_test_utils.cc
+++ b/onnxruntime/test/providers/provider_test_utils.cc
@@ -723,6 +723,7 @@ void OpTester::Run(
         kDmlExecutionProvider,
         kAclExecutionProvider,
         kArmNNExecutionProvider,
+        kNnapiExecutionProvider,
     };
 
     bool has_run = false;
@@ -807,7 +808,8 @@ void OpTester::Run(
           if (provider_type == onnxruntime::kNGraphExecutionProvider ||
               provider_type == onnxruntime::kOpenVINOExecutionProvider ||
               provider_type == onnxruntime::kTensorrtExecutionProvider ||
-              provider_type == onnxruntime::kNupharExecutionProvider)
+              provider_type == onnxruntime::kNupharExecutionProvider ||
+              provider_type == onnxruntime::kNnapiExecutionProvider)
             continue;
           auto reg = execution_provider->GetKernelRegistry();
           if (!KernelRegistry::HasImplementationOf(*reg, node, execution_provider->Type())) {


### PR DESCRIPTION
**Description**: 
Enable onnxruntime_test_all for NNAPI EP

**Motivation and Context**
We do not have test coverage for NNAPI EP on Android CI

Disable some tests for NNAPI since NNAPI does not handle scalar as data input (tensor only) for most operators.
Also disabled the NNAPI EP on subgraph since this will need more time to investigate. (opened Task 812756 to track this)
 
