### PR TITLE
Make TArray safer to use and update method name for consistency.

### DIFF
--- a/onnxruntime/core/providers/cuda/cu_inc/binary_elementwise_impl.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/binary_elementwise_impl.cuh
@@ -34,7 +34,7 @@ __global__ void _BinaryElementWise(
       // compute indexes with broadcasting rules: https://github.com/onnx/onnx/blob/master/docs/Broadcasting.md
       CUDA_LONG offset = id;
 #pragma unroll
-      for (auto dim = 0; dim < fdm_output_strides.GetCapacity(); dim++) {
+      for (auto dim = 0; dim < fdm_output_strides.Capacity(); dim++) {
         if (dim >= output_rank) {
           break;
         }

--- a/onnxruntime/core/providers/cuda/shared_inc/cuda_utils.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/cuda_utils.h
@@ -57,6 +57,7 @@ struct TArray {
   }
 
   TArray(const std::vector<T>& vec) : TArray(static_cast<int32_t>(vec.size())) {
+    static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable.");
     memcpy(data_, vec.data(), vec.size() * sizeof(T));
   }
 
@@ -87,9 +88,9 @@ struct TArray {
     return data_;
   }
 
-  static constexpr int32_t GetCapacity() { return capacity; };
+  static constexpr int32_t Capacity() { return capacity; };
 
- public:  // TODO make these private
+ private:
   int32_t size_;
   T data_[capacity];
 };

--- a/onnxruntime/core/providers/cuda/tensor/expand_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/expand_impl.cu
@@ -63,7 +63,7 @@ __global__ void ExpandKernel(
       CUDA_LONG index = 0;
       CUDA_LONG offset = id;
 #pragma unroll
-      for (auto dim = 0; dim < output_strides.GetCapacity(); dim++) {
+      for (auto dim = 0; dim < output_strides.Capacity(); dim++) {
         if (dim >= rank) {
           break;
         }
@@ -143,7 +143,7 @@ Status ExpandImpl(
     void* output_data,
     const TArray<fast_divmod>& output_strides,
     const TArray<int64_t>& input_strides) {
-  const int rank = static_cast<int>(output_strides.size_);
+  const int rank = static_cast<int>(output_strides.Size());
   if (rank == 1) {
     if (N_input == N_output) {
       CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(output_data, input_data, N_output * element_size, cudaMemcpyDeviceToDevice));
@@ -159,12 +159,12 @@ Status ExpandImpl(
 
   int blocksPerGrid = gsl::narrow_cast<int>(CeilDiv(N_output, GridDim::maxThreadsPerBlock * GridDim::maxElementsPerThread));
 
-#define EXPAND_ON(TYPE)                                                                                  \
-  case sizeof(TYPE):                                                                                     \
-    ExpandKernel<TYPE, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>                       \
-                <<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(                                     \
-        rank, N_output, reinterpret_cast<const TYPE*>(input_data), reinterpret_cast<TYPE*>(output_data), \
-        output_strides, input_strides);                                                                  \
+#define EXPAND_ON(TYPE)                                                                                      \
+  case sizeof(TYPE):                                                                                         \
+    ExpandKernel<TYPE, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>                           \
+        <<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(                                                 \
+            rank, N_output, reinterpret_cast<const TYPE*>(input_data), reinterpret_cast<TYPE*>(output_data), \
+            output_strides, input_strides);                                                                  \
     break
 
   switch (element_size) {

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -467,7 +467,7 @@ void ResizeNearestImpl(
 
   bool could2d = rank >= 2 &&
                  transform_coordinate != GetDeviceOriginalCoordinateFunc(ResizeCoordinateTransformationMode::TF_CROP_AND_RESIZE) &&
-                 std::all_of(scales_vals.data_, scales_vals.data_ + (rank - 2), [](float v) { return v == 1.0; });
+                 std::all_of(scales_vals.Data(), scales_vals.Data() + (rank - 2), [](float v) { return v == 1.0; });
   if (could2d) {
     int64_t output_height = output_shape[rank - 2];
     int64_t output_width = output_shape[rank - 1];
@@ -502,7 +502,7 @@ void ResizeNearestImpl(
     return;
   }
 
-  int64_t total_dim_sum = std::accumulate(output_shape.data_, output_shape.data_ + rank, 0);
+  int64_t total_dim_sum = std::accumulate(output_shape.Data(), output_shape.Data() + rank, 0);
   int blocksPerDimsMappingGrid = (int)(ceil(static_cast<double>(total_dim_sum) / 32));
   _ResizeNearestMappingKernel<T><<<blocksPerDimsMappingGrid, 32, 0>>>(
       rank, input_shape, output_shape,
@@ -540,7 +540,7 @@ void ResizeImpl(
     ResizeCoordinateTransformationMode coordinate_transform_mode,
     ResizeNearestMode nearest_mode,
     void* dims_mapping) {
-  bool isSame = std::all_of(scales_vals.data_, scales_vals.data_ + rank, [](float v) { return v == 1.0f; }) &&
+  bool isSame = std::all_of(scales_vals.Data(), scales_vals.Data() + rank, [](float v) { return v == 1.0f; }) &&
                 (coordinate_transform_mode != ResizeCoordinateTransformationMode::TF_CROP_AND_RESIZE);
   if (isSame) {
     cudaMemcpyAsync(output_data, input_data, N * sizeof(T), cudaMemcpyDeviceToDevice);
@@ -606,12 +606,12 @@ void ResizeImpl(
   template void ResizeImpl<T>(                                      \
       const UpsampleMode upsample_mode,                             \
       const int rank,                                               \
-      TArray<int64_t>& input_shape,            \
-      TArray<int64_t>& output_shape,           \
-      TArray<int64_t>& input_strides,          \
-      TArray<fast_divmod>& output_div_pitches, \
-      TArray<float>& scales_vals,              \
-      TArray<float>& roi_vals,                 \
+      TArray<int64_t>& input_shape,                                 \
+      TArray<int64_t>& output_shape,                                \
+      TArray<int64_t>& input_strides,                               \
+      TArray<fast_divmod>& output_div_pitches,                      \
+      TArray<float>& scales_vals,                                   \
+      TArray<float>& roi_vals,                                      \
       const T* input_data,                                          \
       T* output_data,                                               \
       const size_t N,                                               \

--- a/onnxruntime/core/providers/cuda/tensor/scatter_elements_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_elements_impl.cu
@@ -192,7 +192,7 @@ Status ScatterElementsImplInternal(
     std::vector<int64_t> eff_input_dims;
     std::vector<int64_t> eff_indices_dims;
     int new_axis = CompactInputIndicesDims(
-        rank, axis, buffer_input_dims.data_, buffer_indices_dims.data_, eff_input_dims, eff_indices_dims);
+        rank, axis, buffer_input_dims.Data(), buffer_indices_dims.Data(), eff_input_dims, eff_indices_dims);
     if (eff_input_dims.size() == 2) {
       return ScatterElementsImpl2D(
           input_data, eff_input_dims, indices_data, indices_size, eff_indices_dims, updates, new_axis, output_data,

--- a/onnxruntime/core/providers/cuda/tensor/slice.cc
+++ b/onnxruntime/core/providers/cuda/tensor/slice.cc
@@ -101,7 +101,7 @@ Status Slice<dynamic>::ComputeInternal(OpKernelContext* ctx) const {
   TArray<int64_t> starts_buffer(starts);
   TArray<int64_t> steps_buffer(steps);
   TArray<int64_t> input_strides(gsl::narrow_cast<int32_t>(dimension_count));
-  const gsl::span<int64_t> input_strides_span = gsl::make_span(input_strides.data_, input_strides.size_);
+  const gsl::span<int64_t> input_strides_span = gsl::make_span(input_strides.Data(), input_strides.Size());
   if (p_flattened_output_dims != nullptr) {
     // we were able to flatten the innermost dimensions as they're being copied in full to the output.
     // do the same flattening to the innermost input dimensions in order to calculate pitches that match

--- a/onnxruntime/core/providers/cuda/tensor/slice_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/slice_impl.cu
@@ -24,16 +24,16 @@ __global__ void _SliceKernel(const int32_t dimension_count,
   int value = id;
   int dim = 0;
 #pragma unroll
-  for (; dim < starts.GetCapacity(); ++dim) {
+  for (; dim < starts.Capacity(); ++dim) {
     if (dim >= dimension_count - 1) {
       break;
     }
 
-    output_strides.data_[dim].divmod(value, div, mod);
-    input_index += (starts.data_[dim] + div * steps.data_[dim]) * input_strides.data_[dim];
+    output_strides[dim].divmod(value, div, mod);
+    input_index += (starts[dim] + div * steps[dim]) * input_strides[dim];
     value = mod;
   }
-  input_index += starts.data_[dim] + mod * steps.data_[dim];
+  input_index += starts[dim] + mod * steps[dim];
   if (is_grad)
     output_data[input_index] = input_data[id];
   else

--- a/onnxruntime/core/providers/cuda/tensor/where.cc
+++ b/onnxruntime/core/providers/cuda/tensor/where.cc
@@ -68,10 +68,10 @@ struct TernaryElementwisePreparation {
   const Tensor* a_tensor = nullptr;
   const Tensor* b_tensor = nullptr;
   const Tensor* c_tensor = nullptr;
-  size_t output_rank_or_simple_broadcast = 0;             // for no_broadcast cases, output_rank uses SimpleBroadcast enums
-  TArray<int64_t> a_padded_strides;  // for a shape == output shape, this is nullptr
-  TArray<int64_t> b_padded_strides;  // for b shape == output shape, this is nullptr
-  TArray<int64_t> c_padded_strides;  // for c shape == output shape, this is nullptr
+  size_t output_rank_or_simple_broadcast = 0;  // for no_broadcast cases, output_rank uses SimpleBroadcast enums
+  TArray<int64_t> a_padded_strides;            // for a shape == output shape, this is nullptr
+  TArray<int64_t> b_padded_strides;            // for b shape == output shape, this is nullptr
+  TArray<int64_t> c_padded_strides;            // for c shape == output shape, this is nullptr
   TArray<fast_divmod> fdm_output_strides;
   BroadcastIndexType a_index_type = BroadcastIndexType::NoBroadcast;
   BroadcastIndexType b_index_type = BroadcastIndexType::NoBroadcast;
@@ -98,7 +98,7 @@ struct TernaryElementwisePreparation {
     output_rank_or_simple_broadcast = out_rank;
 
     auto padder = [out_rank](int32_t rank, const TensorShape& shape, TArray<int64_t>& padded_strides) {
-      padded_strides.size_ = out_rank;
+      padded_strides.SetSize(out_rank);
       if (rank > 0) {
         TensorPitches pitches(shape.GetDims());
         auto offset = out_rank - rank;
@@ -142,7 +142,7 @@ struct TernaryElementwisePreparation {
     }
 
     TensorPitches output_pitches(output_shape.GetDims());
-    fdm_output_strides.size_ = out_rank;
+    fdm_output_strides.SetSize(out_rank);
     for (auto i = 0; i < out_rank; ++i) {
       fdm_output_strides[i] = fast_divmod(static_cast<int32_t>(output_pitches[i]));
     }

--- a/onnxruntime/core/providers/cuda/tensor/where_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/where_impl.cu
@@ -37,7 +37,7 @@ __global__ void _TenaryElementWise(
       CUDA_LONG y_index = (YIndexType == BroadcastIndexType::NoBroadcast ? id : 0);
       CUDA_LONG offset = id;
 #pragma unroll
-      for (auto dim = 0; dim < fdm_output_strides.GetCapacity(); dim++) {
+      for (auto dim = 0; dim < fdm_output_strides.Capacity(); dim++) {
         if (dim >= output_rank) {
           break;
         }
@@ -111,73 +111,73 @@ __global__ void _TenaryElementWiseSimple(
   }
 }
 
-#define HANDLE_Y_INDEX_TYPE_SIMPLE(COND_INDEX_TYPE, X_INDEX_TYPE, Y_INDEX_TYPE)   \
-  case Y_INDEX_TYPE: {                                                            \
-    _TenaryElementWiseSimple<T,                                                   \
-                             COND_INDEX_TYPE,                                     \
-                             X_INDEX_TYPE,                                        \
-                             Y_INDEX_TYPE,                                        \
-                             GridDim::maxThreadsPerBlock,                         \
-                             GridDim::maxElementsPerThread>                       \
-        <<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(cond_data,            \
-                                                            x_data,               \
-                                                            y_data,               \
-                                                            output_data,          \
-                                                            N);                   \
+#define HANDLE_Y_INDEX_TYPE_SIMPLE(COND_INDEX_TYPE, X_INDEX_TYPE, Y_INDEX_TYPE) \
+  case Y_INDEX_TYPE: {                                                          \
+    _TenaryElementWiseSimple<T,                                                 \
+                             COND_INDEX_TYPE,                                   \
+                             X_INDEX_TYPE,                                      \
+                             Y_INDEX_TYPE,                                      \
+                             GridDim::maxThreadsPerBlock,                       \
+                             GridDim::maxElementsPerThread>                     \
+        <<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(cond_data,          \
+                                                            x_data,             \
+                                                            y_data,             \
+                                                            output_data,        \
+                                                            N);                 \
   } break
 
-#define HANDLE_X_INDEX_TYPE_SIMPLE(COND_INDEX_TYPE, X_INDEX_TYPE, Y_INDEX_TYPE_VAL)                     \
-  case X_INDEX_TYPE: {                                                                                  \
-    switch(Y_INDEX_TYPE_VAL) {                                                                          \
-      HANDLE_Y_INDEX_TYPE_SIMPLE(COND_INDEX_TYPE, X_INDEX_TYPE, BroadcastIndexType::NoBroadcast);       \
-      HANDLE_Y_INDEX_TYPE_SIMPLE(COND_INDEX_TYPE, X_INDEX_TYPE, BroadcastIndexType::Scalar);            \
-    }                                                                                                   \
+#define HANDLE_X_INDEX_TYPE_SIMPLE(COND_INDEX_TYPE, X_INDEX_TYPE, Y_INDEX_TYPE_VAL)               \
+  case X_INDEX_TYPE: {                                                                            \
+    switch (Y_INDEX_TYPE_VAL) {                                                                   \
+      HANDLE_Y_INDEX_TYPE_SIMPLE(COND_INDEX_TYPE, X_INDEX_TYPE, BroadcastIndexType::NoBroadcast); \
+      HANDLE_Y_INDEX_TYPE_SIMPLE(COND_INDEX_TYPE, X_INDEX_TYPE, BroadcastIndexType::Scalar);      \
+    }                                                                                             \
   } break
 
-#define HANDLE_COND_INDEX_TYPE_SIMPLE(COND_INDEX_TYPE, X_INDEX_TYPE_VAL, Y_INDEX_TYPE_VAL)              \
-  case COND_INDEX_TYPE: {                                                                               \
-    switch(X_INDEX_TYPE_VAL) {                                                                          \
-      HANDLE_X_INDEX_TYPE_SIMPLE(COND_INDEX_TYPE, BroadcastIndexType::NoBroadcast, Y_INDEX_TYPE_VAL);   \
-      HANDLE_X_INDEX_TYPE_SIMPLE(COND_INDEX_TYPE, BroadcastIndexType::Scalar, Y_INDEX_TYPE_VAL);        \
-    }                                                                                                   \
+#define HANDLE_COND_INDEX_TYPE_SIMPLE(COND_INDEX_TYPE, X_INDEX_TYPE_VAL, Y_INDEX_TYPE_VAL)            \
+  case COND_INDEX_TYPE: {                                                                             \
+    switch (X_INDEX_TYPE_VAL) {                                                                       \
+      HANDLE_X_INDEX_TYPE_SIMPLE(COND_INDEX_TYPE, BroadcastIndexType::NoBroadcast, Y_INDEX_TYPE_VAL); \
+      HANDLE_X_INDEX_TYPE_SIMPLE(COND_INDEX_TYPE, BroadcastIndexType::Scalar, Y_INDEX_TYPE_VAL);      \
+    }                                                                                                 \
   } break
 
-#define HANDLE_Y_INDEX_TYPE(COND_INDEX_TYPE, X_INDEX_TYPE, Y_INDEX_TYPE)                        \
-  case Y_INDEX_TYPE: {                                                                          \
-    _TenaryElementWise<T,                                                                       \
-                       COND_INDEX_TYPE,                                                         \
-                       X_INDEX_TYPE,                                                            \
-                       Y_INDEX_TYPE,                                                            \
-                       GridDim::maxThreadsPerBlock,                                             \
-                       GridDim::maxElementsPerThread>                                           \
-        <<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(output_rank_or_simple_broadcast,    \
-                                                            cond_padded_strides,                \
-                                                            cond_data,                          \
-                                                            x_padded_strides,                   \
-                                                            x_data,                             \
-                                                            y_padded_strides,                   \
-                                                            y_data,                             \
-                                                            fdm_output_strides,                 \
-                                                            output_data,                        \
-                                                            N);                                 \
+#define HANDLE_Y_INDEX_TYPE(COND_INDEX_TYPE, X_INDEX_TYPE, Y_INDEX_TYPE)                     \
+  case Y_INDEX_TYPE: {                                                                       \
+    _TenaryElementWise<T,                                                                    \
+                       COND_INDEX_TYPE,                                                      \
+                       X_INDEX_TYPE,                                                         \
+                       Y_INDEX_TYPE,                                                         \
+                       GridDim::maxThreadsPerBlock,                                          \
+                       GridDim::maxElementsPerThread>                                        \
+        <<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(output_rank_or_simple_broadcast, \
+                                                            cond_padded_strides,             \
+                                                            cond_data,                       \
+                                                            x_padded_strides,                \
+                                                            x_data,                          \
+                                                            y_padded_strides,                \
+                                                            y_data,                          \
+                                                            fdm_output_strides,              \
+                                                            output_data,                     \
+                                                            N);                              \
   } break
 
-#define HANDLE_X_INDEX_TYPE(COND_INDEX_TYPE, X_INDEX_TYPE, Y_INDEX_TYPE_VAL)                    \
-  case X_INDEX_TYPE: {                                                                          \
-    switch(Y_INDEX_TYPE_VAL) {                                                                  \
-      HANDLE_Y_INDEX_TYPE(COND_INDEX_TYPE, X_INDEX_TYPE, BroadcastIndexType::NoBroadcast);      \
-      HANDLE_Y_INDEX_TYPE(COND_INDEX_TYPE, X_INDEX_TYPE, BroadcastIndexType::Scalar);           \
-      HANDLE_Y_INDEX_TYPE(COND_INDEX_TYPE, X_INDEX_TYPE, BroadcastIndexType::NeedCompute);      \
-    }                                                                                           \
+#define HANDLE_X_INDEX_TYPE(COND_INDEX_TYPE, X_INDEX_TYPE, Y_INDEX_TYPE_VAL)               \
+  case X_INDEX_TYPE: {                                                                     \
+    switch (Y_INDEX_TYPE_VAL) {                                                            \
+      HANDLE_Y_INDEX_TYPE(COND_INDEX_TYPE, X_INDEX_TYPE, BroadcastIndexType::NoBroadcast); \
+      HANDLE_Y_INDEX_TYPE(COND_INDEX_TYPE, X_INDEX_TYPE, BroadcastIndexType::Scalar);      \
+      HANDLE_Y_INDEX_TYPE(COND_INDEX_TYPE, X_INDEX_TYPE, BroadcastIndexType::NeedCompute); \
+    }                                                                                      \
   } break
 
-#define HANDLE_COND_INDEX_TYPE(COND_INDEX_TYPE, X_INDEX_TYPE_VAL, Y_INDEX_TYPE_VAL)             \
-  case COND_INDEX_TYPE: {                                                                       \
-    switch(X_INDEX_TYPE_VAL) {                                                                  \
-      HANDLE_X_INDEX_TYPE(COND_INDEX_TYPE, BroadcastIndexType::NoBroadcast, Y_INDEX_TYPE_VAL);  \
-      HANDLE_X_INDEX_TYPE(COND_INDEX_TYPE, BroadcastIndexType::Scalar, Y_INDEX_TYPE_VAL);       \
-      HANDLE_X_INDEX_TYPE(COND_INDEX_TYPE, BroadcastIndexType::NeedCompute, Y_INDEX_TYPE_VAL);  \
-    }                                                                                           \
+#define HANDLE_COND_INDEX_TYPE(COND_INDEX_TYPE, X_INDEX_TYPE_VAL, Y_INDEX_TYPE_VAL)            \
+  case COND_INDEX_TYPE: {                                                                      \
+    switch (X_INDEX_TYPE_VAL) {                                                                \
+      HANDLE_X_INDEX_TYPE(COND_INDEX_TYPE, BroadcastIndexType::NoBroadcast, Y_INDEX_TYPE_VAL); \
+      HANDLE_X_INDEX_TYPE(COND_INDEX_TYPE, BroadcastIndexType::Scalar, Y_INDEX_TYPE_VAL);      \
+      HANDLE_X_INDEX_TYPE(COND_INDEX_TYPE, BroadcastIndexType::NeedCompute, Y_INDEX_TYPE_VAL); \
+    }                                                                                          \
   } break
 
 template <typename T>
@@ -198,12 +198,12 @@ void WhereImpl(
   int blocksPerGrid = static_cast<int>(CeilDiv(count, GridDim::maxThreadsPerBlock * GridDim::maxElementsPerThread));
   CUDA_LONG N = static_cast<CUDA_LONG>(count);
   if (output_rank_or_simple_broadcast == static_cast<size_t>(SimpleBroadcast::NoBroadcast)) {
-    switch(cond_index_type) {
+    switch (cond_index_type) {
       HANDLE_COND_INDEX_TYPE_SIMPLE(BroadcastIndexType::NoBroadcast, x_index_type, y_index_type);
       HANDLE_COND_INDEX_TYPE_SIMPLE(BroadcastIndexType::Scalar, x_index_type, y_index_type);
     }
   } else {
-    switch(cond_index_type) {
+    switch (cond_index_type) {
       HANDLE_COND_INDEX_TYPE(BroadcastIndexType::NoBroadcast, x_index_type, y_index_type);
       HANDLE_COND_INDEX_TYPE(BroadcastIndexType::Scalar, x_index_type, y_index_type);
       HANDLE_COND_INDEX_TYPE(BroadcastIndexType::NeedCompute, x_index_type, y_index_type);


### PR DESCRIPTION
**Description**
Update TArray:
- make size_ and data_ data members private
- rename GetCapacity() to Capacity() to be consistent (e.g., with Size())
- add static_assert for trivially copyable T because it is copied with memcpy

**Motivation and Context**
The original potential issue was that size_ could be set to any value, including beyond the capacity of the TArray. This could result in out of bounds memory access. Now the invariant that size_ <= capacity is enforced.
