### PR TITLE
C# UWP Apps cannot add Microsoft.AI.MachineLearning nuget package

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -86,6 +86,9 @@ def generate_dependencies(list, package_name, version):
         list.append('<group targetFramework="NETFRAMEWORK">')
         list.append('<dependency id="Microsoft.Windows.SDK.NET"' + ' version="10.0.18362.3-preview"/>')
         list.append('</group>')
+        # UAP10.0.16299, This is the earliest release of the OS that supports .NET Standard apps
+        list.append('<group targetFramework="UAP10.0.16299">')
+        list.append('</group>')
 
         list.append('</dependencies>')
     else:


### PR DESCRIPTION
Issue: Recent Desktop C# .NET Core, .NET Framework, and .NET Standard support regressed C# UWP Apps by preventing the Microsoft.AI.MachineLearning NuGet package from being installable on these project types. This is because Desktop C# Apps require the Microsoft.Windows.SDK.NET package, which only works on desktop apps. On UWP apps they cause type collisions, since SDK metadata is brought in from alternate means. The reason why this happens is because the .NET Standard dependency group is a fallback for apps with the UWP targetFramework.

Impact: Sideloaded C# apps which were creatable in 1.3.0 are no longer possible.

Fix: for UWP apps, create a dependency group that explicitly target the UWP targetFramework that does NOT have the Microsoft.Windows.SDK.NET package dependency.