### PR TITLE
Split the shared ComputePadAndOutputShape into 2 separated functions ComputePad and ComputeOutputShape

### DIFF
--- a/onnxruntime/core/providers/common.h
+++ b/onnxruntime/core/providers/common.h
@@ -69,51 +69,64 @@ inline AutoPadType StringToAutoPadType(const std::string& str) {
 }
 
 // helper function
+
 template <bool ForceSymmetricAutoPadding>
-Status ComputePadAndOutputShape(
-    const int64_t in_dim,
-    const int64_t stride,
-    const int64_t kernel,
-    const int64_t dilation,
-    AutoPadType pad_type,
-    int64_t* pad_head,
-    int64_t* pad_tail,
-    int64_t* out_dim) {
-  const int64_t dkernel = dilation * (kernel - 1) + 1;
+Status ComputePad(const int64_t in_dim,
+                  const int64_t stride, const int64_t kernel, const int64_t dilation,
+                  AutoPadType pad_type,
+                  int64_t* pad_head, int64_t* pad_tail) {
+  switch (pad_type) {
+    case AutoPadType::NOTSET:
+      break;
+    case AutoPadType::VALID: {
+      *pad_head = 0;
+      *pad_tail = 0;
+    } break;
+    case AutoPadType::SAME_UPPER:
+    case AutoPadType::SAME_LOWER: {
+      if (1 != dilation)
+        return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
+                      "Dilation not supported for AutoPadType::SAME_UPPER or AutoPadType::SAME_LOWER.");
 
-  if (pad_type == AutoPadType::NOTSET) {
-    *out_dim = static_cast<int64_t>(static_cast<float>(in_dim + *pad_head + *pad_tail - dkernel) / stride + 1);
-  } else {
-    switch (pad_type) {
-      case AutoPadType::VALID:
-        *pad_head = 0;
-        *pad_tail = 0;
-        *out_dim = (in_dim - dkernel) / stride + 1;
-        break;
-      case AutoPadType::SAME_UPPER:
-      case AutoPadType::SAME_LOWER: {
-        ORT_ENFORCE(dilation == 1, "Dilation not supported for AutoPadType::SAME_UPPER or AutoPadType::SAME_LOWER.");
-        int64_t legacy_target_size = (in_dim + stride - 1) / stride;
-        int64_t pad_needed = (legacy_target_size - 1) * stride + kernel - in_dim;
-        *out_dim = (in_dim + pad_needed - dkernel) / stride + 1;
+      int64_t legacy_target_size = (in_dim + stride - 1) / stride;
+      int64_t pad_needed = (legacy_target_size - 1) * stride + kernel - in_dim;
+      // make sure padding is symmetric
+      if (ForceSymmetricAutoPadding) {
+        // Inlining math::roundUpPow2() from util/math.h to avoid bringing in the transitive dependencies.
+        pad_needed = (pad_needed + 1) & ~1;
+      }
 
-        // make sure padding is symmetric
-        if (ForceSymmetricAutoPadding) {
-          // Inlining math::roundUpPow2() from util/math.h to avoid bringing in the transitive dependencies.
-          pad_needed = (pad_needed + 1) & ~1;
-        }
+      if (pad_type == AutoPadType::SAME_LOWER)
+        *pad_head = (pad_needed + 1) / 2;
+      else
+        *pad_head = pad_needed / 2;
 
-        if (pad_type == AutoPadType::SAME_LOWER) {
-          *pad_head = (pad_needed + 1) / 2;
-        } else {
-          *pad_head = pad_needed / 2;
-        }
-        *pad_tail = pad_needed - *pad_head;
-      } break;
-      default:
-        return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, "pad type not supported.");
-    }
+      *pad_tail = pad_needed - *pad_head;
+    } break;
+    default:
+      return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, "ComputePad: pad type not supported.");
   }
+
+  return Status::OK();
+}
+
+inline void ComputeOutputShape(const int64_t in_dim,
+                               const int64_t stride, const int64_t kernel, const int64_t dilation,
+                               const int64_t pad_head, const int64_t pad_tail,
+                               int64_t* out_dim) {
+  const int64_t dkernel = dilation * (kernel - 1) + 1;
+  *out_dim = static_cast<int64_t>(static_cast<float>(in_dim + pad_head + pad_tail - dkernel) / stride + 1);
+}
+
+template <bool ForceSymmetricAutoPadding>
+Status ComputePadAndOutputShape(const int64_t in_dim,
+                                const int64_t stride, const int64_t kernel, const int64_t dilation,
+                                AutoPadType pad_type,
+                                int64_t* pad_head, int64_t* pad_tail,
+                                int64_t* out_dim) {
+  ORT_RETURN_IF_ERROR(
+      ComputePad<ForceSymmetricAutoPadding>(in_dim, stride, kernel, dilation, pad_type, pad_head, pad_tail));
+  ComputeOutputShape(in_dim, stride, kernel, dilation, *pad_head, *pad_tail, out_dim);
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/cpu/nn/conv_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_attributes.h
@@ -125,9 +125,9 @@ struct ConvAttributes {
           kernel_shape[dim],
           dilations_p[dim],
           auto_pad,
-          &pads_p->at(dim),
-          &pads_p->at(input_shape.NumDimensions() + dim),
-          &dim_size));
+          pads_p->at(dim),
+          pads_p->at(input_shape.NumDimensions() + dim),
+          dim_size));
       if (dim_size <= 0) {
         return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, "Invalid input shape: " + input_shape.ToString());
       }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/shaper.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/shaper.cc
@@ -1,3 +1,4 @@
+#include "core/providers/common.h"
 #include "core/providers/nnapi/nnapi_builtin/nnapi_lib/NeuralNetworksWrapper.h"
 
 #include "helper.h"
@@ -13,60 +14,52 @@ void Shaper::Conv(const std::string& input_name,
                   const vector<int32_t>& onnx_dilations,
                   bool nchw,
                   const std::string& output_name) {
-  Shape weight_dimen =
-      shape_map_.at(weight_name);  // num_output, height, width, num_input
+  Shape input_dimen = shape_map_.at(input_name);
+  Shape weight_dimen = shape_map_.at(weight_name);  // num_output, height, width, num_input
 
-  int32_t padding_left = onnx_pads[1];
-  int32_t padding_right = onnx_pads[3];
   int32_t padding_top = onnx_pads[0];
   int32_t padding_bottom = onnx_pads[2];
-  int32_t stride_x = onnx_strides[1];
+  int32_t padding_left = onnx_pads[1];
+  int32_t padding_right = onnx_pads[3];
   int32_t stride_y = onnx_strides[0];
-  int32_t dilation_x = onnx_dilations[1];
+  int32_t stride_x = onnx_strides[1];
   int32_t dilation_y = onnx_dilations[0];
+  int32_t dilation_x = onnx_dilations[1];
 
-  // NHWC
-  Shape input_dimen = shape_map_.at(input_name);
-  Shape outputDimen;
-  if (nchw) {
-    outputDimen =
-        {
-            input_dimen[0],
-            weight_dimen[0],
-            input_dimen[2] == 0
-                ? 0
-                : (input_dimen[2] - ((weight_dimen[1] - 1) * dilation_y + 1) +
-                   padding_top + padding_bottom) /
-                          stride_y +
-                      1,
-            input_dimen[3] == 0
-                ? 0
-                : (input_dimen[3] - ((weight_dimen[2] - 1) * dilation_x + 1) +
-                   padding_left + padding_right) /
-                          stride_x +
-                      1,
-        };
-  } else {  // nhwc
-    outputDimen =
-        {
-            input_dimen[0],
-            input_dimen[1] == 0
-                ? 0
-                : (input_dimen[1] - ((weight_dimen[1] - 1) * dilation_y + 1) +
-                   padding_top + padding_bottom) /
-                          stride_y +
-                      1,
-            input_dimen[2] == 0
-                ? 0
-                : (input_dimen[2] - ((weight_dimen[2] - 1) * dilation_x + 1) +
-                   padding_left + padding_right) /
-                          stride_x +
-                      1,
-            weight_dimen[0],
-        };
+  const auto input_size_y = nchw ? input_dimen[2] : input_dimen[1];
+  const auto input_size_x = nchw ? input_dimen[3] : input_dimen[2];
+  const auto weight_size_y = weight_dimen[1];
+  const auto weight_size_x = weight_dimen[2];
+
+  int64_t output_size_y = 0;
+  if (0 != input_size_y) {
+    onnxruntime::ComputeOutputShape(input_size_y,
+                                    stride_y, weight_size_y, dilation_y,
+                                    padding_top, padding_bottom,
+                                    &output_size_y);
   }
 
-  shape_map_[output_name] = outputDimen;
+  int64_t output_size_x = 0;
+  if (0 != input_size_x) {
+    onnxruntime::ComputeOutputShape(input_size_x,
+                                    stride_x, weight_size_x, dilation_x,
+                                    padding_left, padding_right,
+                                    &output_size_x);
+  }
+
+  Shape output_dimen;
+  if (nchw) {
+    output_dimen = {input_dimen[0],
+                    weight_dimen[0],
+                    static_cast<uint32_t>(output_size_y),
+                    static_cast<uint32_t>(output_size_x)};
+  } else {  // nhwc
+    output_dimen = {input_dimen[0],
+                    static_cast<uint32_t>(output_size_y),
+                    static_cast<uint32_t>(output_size_x),
+                    weight_dimen[0]};
+  }
+  shape_map_[output_name] = output_dimen;
 
   if (!shaper_finalized_) {
     shape_ops_.push_back(
@@ -89,59 +82,52 @@ void Shaper::DepthwiseConv(const std::string& input_name,
                            const std::vector<int32_t>& onnx_dilations,
                            bool nchw,
                            const std::string& output_name) {
-  Shape weight_dimen =
-      shape_map_.at(weight_name);  // 1, height, width, num_output
+  Shape input_dimen = shape_map_.at(input_name);
+  Shape weight_dimen = shape_map_.at(weight_name);  // 1, height, width, num_output
 
-  int32_t padding_left = onnx_pads[1];
-  int32_t padding_right = onnx_pads[3];
   int32_t padding_top = onnx_pads[0];
   int32_t padding_bottom = onnx_pads[2];
-  int32_t stride_x = onnx_strides[1];
+  int32_t padding_left = onnx_pads[1];
+  int32_t padding_right = onnx_pads[3];
   int32_t stride_y = onnx_strides[0];
-  int32_t dilation_x = onnx_dilations[1];
+  int32_t stride_x = onnx_strides[1];
   int32_t dilation_y = onnx_dilations[0];
+  int32_t dilation_x = onnx_dilations[1];
 
-  // NHWC
-  Shape input_dimen = shape_map_.at(input_name);
-  Shape outputDimen;
-  if (nchw) {
-    outputDimen =
-        {
-            input_dimen[0],
-            weight_dimen[3],
-            input_dimen[2] == 0
-                ? 0
-                : (input_dimen[2] - ((weight_dimen[1] - 1) * dilation_y + 1) +
-                   padding_top + padding_bottom) /
-                          stride_y +
-                      1,
-            input_dimen[3] == 0
-                ? 0
-                : (input_dimen[3] - ((weight_dimen[2] - 1) * dilation_x + 1) +
-                   padding_left + padding_right) /
-                          stride_x +
-                      1,
-        };
-  } else {  // nhwc
-    outputDimen =
-        {
-            input_dimen[0],
-            input_dimen[1] == 0
-                ? 0
-                : (input_dimen[1] - ((weight_dimen[1] - 1) * dilation_y + 1) +
-                   padding_top + padding_bottom) /
-                          stride_y +
-                      1,
-            input_dimen[2] == 0
-                ? 0
-                : (input_dimen[2] - ((weight_dimen[2] - 1) * dilation_x + 1) +
-                   padding_left + padding_right) /
-                          stride_x +
-                      1,
-            weight_dimen[3],
-        };
+  const auto input_size_y = nchw ? input_dimen[2] : input_dimen[1];
+  const auto input_size_x = nchw ? input_dimen[3] : input_dimen[2];
+  const auto weight_size_y = weight_dimen[1];
+  const auto weight_size_x = weight_dimen[2];
+
+  int64_t output_size_y = 0;
+  if (0 != input_size_y) {
+    onnxruntime::ComputeOutputShape(input_size_y,
+                                    stride_y, weight_size_y, dilation_y,
+                                    padding_top, padding_bottom,
+                                    &output_size_y);
   }
-  shape_map_[output_name] = outputDimen;
+
+  int64_t output_size_x = 0;
+  if (0 != input_size_x) {
+    onnxruntime::ComputeOutputShape(input_size_x,
+                                    stride_x, weight_size_x, dilation_x,
+                                    padding_left, padding_right,
+                                    &output_size_x);
+  }
+
+  Shape output_dimen;
+  if (nchw) {
+    output_dimen = {input_dimen[0],
+                    weight_dimen[3],
+                    static_cast<uint32_t>(output_size_y),
+                    static_cast<uint32_t>(output_size_x)};
+  } else {  // nhwc
+    output_dimen = {input_dimen[0],
+                    static_cast<uint32_t>(output_size_y),
+                    static_cast<uint32_t>(output_size_x),
+                    weight_dimen[3]};
+  }
+  shape_map_[output_name] = output_dimen;
 
   if (!shaper_finalized_) {
     shape_ops_.push_back(
@@ -165,40 +151,48 @@ void Shaper::Pool(const std::string& input_name,
                   const std::string& output_name) {
   auto input_dimen = shape_map_.at(input_name);
 
-  int32_t padding_left = onnx_pads[1];
-  int32_t padding_right = onnx_pads[3];
   int32_t padding_top = onnx_pads[0];
   int32_t padding_bottom = onnx_pads[2];
-  int32_t stride_x = onnx_strides[1];
+  int32_t padding_left = onnx_pads[1];
+  int32_t padding_right = onnx_pads[3];
   int32_t stride_y = onnx_strides[0];
-  int32_t width = kernel_shape[1];
-  int32_t height = kernel_shape[0];
+  int32_t stride_x = onnx_strides[1];
 
-  Shape outputDimen;
-  if (nchw) {
-    outputDimen = {
-        input_dimen[0],
-        input_dimen[1],
-        input_dimen[2] == 0
-            ? 0
-            : (input_dimen[2] - height + padding_top + padding_bottom) / stride_y + 1,
-        input_dimen[3] == 0
-            ? 0
-            : (input_dimen[3] - width + padding_left + padding_right) / stride_x + 1,
-    };
-  } else {
-    outputDimen = {
-        input_dimen[0],
-        input_dimen[1] == 0
-            ? 0
-            : (input_dimen[1] - height + padding_top + padding_bottom) / stride_y + 1,
-        input_dimen[2] == 0
-            ? 0
-            : (input_dimen[2] - width + padding_left + padding_right) / stride_x + 1,
-        input_dimen[3]};
+  const auto input_size_y = nchw ? input_dimen[2] : input_dimen[1];
+  const auto input_size_x = nchw ? input_dimen[3] : input_dimen[2];
+  int32_t weight_size_y = kernel_shape[0];
+  int32_t weight_size_x = kernel_shape[1];
+
+  int64_t output_size_y = 0;
+  if (0 != input_size_y) {
+    onnxruntime::ComputeOutputShape(input_size_y,
+                                    stride_y, weight_size_y, 1 /* dilation_y */,
+                                    padding_top, padding_bottom,
+                                    &output_size_y);
   }
 
-  shape_map_[output_name] = outputDimen;
+  int64_t output_size_x = 0;
+  if (0 != input_size_x) {
+    onnxruntime::ComputeOutputShape(input_size_x,
+                                    stride_x, weight_size_x, 1 /* dilation_x */,
+                                    padding_left, padding_right,
+                                    &output_size_x);
+  }
+
+  Shape output_dimen;
+  if (nchw) {
+    output_dimen = {input_dimen[0],
+                    input_dimen[1],
+                    static_cast<uint32_t>(output_size_y),
+                    static_cast<uint32_t>(output_size_x)};
+  } else {  // nhwc
+    output_dimen = {input_dimen[0],
+                    static_cast<uint32_t>(output_size_y),
+                    static_cast<uint32_t>(output_size_x),
+                    input_dimen[3]};
+  }
+
+  shape_map_[output_name] = output_dimen;
 
   if (!shaper_finalized_) {
     shape_ops_.push_back(


### PR DESCRIPTION
**Description**: 
Split the shared ComputePadAndOutputShape into 2 separated functions ComputePad and ComputeOutputShape
Update NNAPI output shape compute to use shared ComputeOutputShape

**Motivation and Context**
Replace the NNAPI specific conv output shape compute functionalities with the shared functionalities
