### PR TITLE
Pin typing version for install_onnx.sh

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/install_onnx.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_onnx.sh
@@ -24,7 +24,9 @@ else
    PYTHON_EXE="/usr/bin/python${PYTHON_VER}"
 fi
 
-${PYTHON_EXE} -m pip install protobuf
+# We ping typing to the most recent version that does not deal
+# with Python 3.5 version so we test reasonably modern version
+${PYTHON_EXE} -m pip install protobuf typing==3.7.4.1
 
 version2tag=(5af210ca8a1c73aa6bae8754c9346ec54d0a756e-onnx123
              bae6333e149a59a3faa9c4d9c44974373dcf5256-onnx130


### PR DESCRIPTION
**Description**: 
We explicitly install `typing` with pinned version in `install_onnx.sh`

**Motivation and Context**
Onnx packages require typing as a dependency. 
Most recent controversial change in typing prevents using it with python 3.5 Rather than filtering on Python we decided to stick to the most recent version of typing before the change and see which direction things will work later.