### PR TITLE
Create N-1 threads in intra-op pool, given main thread now active

### DIFF
--- a/docs/NotesOnThreading.md
+++ b/docs/NotesOnThreading.md
@@ -12,7 +12,7 @@ Examples of these abstractions are: ([threadpool.h](https://github.com/microsoft
 * TryBatchParallelFor
 * TryParallelFor
 * TrySimpleParallelFor
-* static version of NumThreads
+* DegreeOfParallelism
 
 **Please do not write #ifdef pragma omp in operator code**.
 

--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -48,7 +48,7 @@ class ThreadPoolTempl;
 namespace concurrency {
 
 class ExtendedThreadPoolInterface;
-class BatchHandle;
+class LoopCounter;
 
 class ThreadPool {
  public:
@@ -118,27 +118,30 @@ class ThreadPool {
 #else
   using NAME_CHAR_TYPE = char;
 #endif
-  // Constructs a pool that contains "num_threads" threads with specified
-  // "name". env->StartThread() is used to create individual threads with the
-  // given ThreadOptions. If "low_latency_hint" is true the thread pool
+  // Constructs a pool for running with with "degree_of_parallelism" threads with
+  // specified "name". env->StartThread() is used to create individual threads
+  // with the given ThreadOptions. If "low_latency_hint" is true the thread pool
   // implementation may use it as a hint that lower latency is preferred at the
   // cost of higher CPU usage, e.g. by letting one or more idle threads spin
   // wait. Conversely, if the threadpool is used to schedule high-latency
   // operations like I/O the hint should be set to false.
   //
-  // REQUIRES: num_threads > 0
+  // REQUIRES: degree_of_parallelism > 0
   // The allocator parameter is only used for creating a Eigen::ThreadPoolDevice to be used with Eigen Tensor classes.
   ThreadPool(Env* env,
              const ThreadOptions& thread_options,
              const NAME_CHAR_TYPE* name,
-             int num_threads,
+             int degree_of_parallelism,
              bool low_latency_hint);
 
   // Waits until all scheduled work has finished and then destroy the
   // set of threads.
   ~ThreadPool();
 
-  // Schedules fn() for execution in the pool of threads.
+  // Schedules fn() for execution in the pool of threads.  The function may run
+  // synchronously if it cannot be enqueued.  This will occur if the thread pool's
+  // degree-of-parallelism is 1, but it may also occur for implementation-dependent
+  // reasons such as if queues used for buffering work are full.
   void Schedule(std::function<void()> fn);
 
   // Returns the number of shards used by ParallelForFixedBlockSizeScheduling
@@ -171,7 +174,7 @@ class ThreadPool {
                              const std::function<void(std::ptrdiff_t first, std::ptrdiff_t last)>& fn) {
 #ifdef _OPENMP
     ORT_UNUSED_PARAMETER(cost_per_unit);
-    std::ptrdiff_t num_threads = concurrency::ThreadPool::NumThreads(tp);
+    std::ptrdiff_t num_threads = concurrency::ThreadPool::DegreeOfParallelism(tp);
     if (total < num_threads) {
       num_threads = total;
     }
@@ -199,7 +202,7 @@ class ThreadPool {
                              const std::function<void(std::ptrdiff_t first, std::ptrdiff_t last)>& fn) {
 #ifdef _OPENMP
     ORT_UNUSED_PARAMETER(scheduling_params);
-    std::ptrdiff_t num_threads = concurrency::ThreadPool::NumThreads(tp);
+    std::ptrdiff_t num_threads = concurrency::ThreadPool::DegreeOfParallelism(tp);
     if (total < num_threads) {
       num_threads = total;
     }
@@ -217,16 +220,15 @@ class ThreadPool {
 #endif
   }
 
-  // Prefer using this API to get the number of threads unless you know what you're doing.
-  // This API takes into account if openmp is enabled/disabled and if the thread pool ptr is nullptr.
-  static int NumThreads(const concurrency::ThreadPool* tp);
-
-  // Returns the number of threads in the pool. Preferably use the static version of this API instead.
-  int NumThreads() const;
-
-  // Returns current thread id between 0 and NumThreads() - 1, if called from a
-  // thread in the pool. Returns -1 otherwise.
-  int CurrentThreadId() const;
+  // Return the degree of parallelism that code should assume when using the thread pool.
+  // This API takes into account if OpenMP is enabled/disabled, and if the thread pool ptr is
+  // nullptr.  It decouples the degree of parallelism for use with the thread pool from
+  // the implementation choice of whether this matches the number of threads created in
+  // the pool.
+  //
+  // Currently, a loop with degree-of-parlalelism N is supported by a pool of N-1 threads
+  // working in combination with the thread initiating the loop.
+  static int DegreeOfParallelism(const concurrency::ThreadPool* tp);
 
   // Directly schedule the 'total' tasks to the underlying threadpool, without
   // cutting them by halves
@@ -254,7 +256,7 @@ class ThreadPool {
 
   /**
    * Tries to call the given function in parallel, with calls split into (num_batches) batches.
-   *\param num_batches If it is zero, it will be replaced to the value of NumThreads().
+   *\param num_batches If it is zero, it will be replaced to the value of DegreeOfParallelism().
    *\param fn A std::function or STL style functor with signature of "void f(int32_t);"
    * Pitfall: Caller should cap `num_batches` to a reasonable value based on the cost of `fn` and the value of `total`.
    *For example, if fn is as simple as: int sum=0; fn = [&](int i){sum +=i;} and `total` is 100, then num_batches should
@@ -288,7 +290,7 @@ class ThreadPool {
     }
 
     if (num_batches <= 0) {
-      num_batches = std::min<ptrdiff_t>(total, tp->NumThreads());
+      num_batches = std::min<ptrdiff_t>(total, DegreeOfParallelism(tp));
     }
 
     if (num_batches <= 1) {
@@ -334,6 +336,16 @@ class ThreadPool {
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(ThreadPool);
 
  private:
+  friend class LoopCounter;
+
+  // Returns the number of threads created in the pool.  This may be different from the
+  // value returned by DegreeOfParallelism to code using the pool.
+  int NumThreads() const;
+
+  // Returns current thread id between 0 and NumThreads() - 1, if called from a
+  // thread in the pool. Returns -1 otherwise.
+  int CurrentThreadId() const;
+
   // Run fn with up to n degree-of-parallelism enlisting the thread pool for
   // help.  The degree-of-parallelism includes the caller, and so if n==1
   // then the function will run directly in the caller.  The fork-join
@@ -359,11 +371,14 @@ class ThreadPool {
                              const std::ptrdiff_t block_size = 1) const;
 
   ThreadOptions thread_options_;
-  // underlying_threadpool_ is the user_threadpool if user_threadpool is
-  // provided in the constructor. Otherwise it is the eigen_threadpool_.
-  ExtendedThreadPoolInterface* underlying_threadpool_;
-  // eigen_threadpool_ is instantiated and owned by thread::ThreadPool if
-  // user_threadpool is not in the constructor.
+
+  // If a thread pool is created with degree_of_parallelism != 1 then an underlying
+  // EigenThreadPool is used to create OS threads and handle work distribution to them.
+  // If degree_of_parallelism == 1 then underlying_threadpool_ is left as nullptr
+  // and parallel work is run directly by the caller.
+  ExtendedThreadPoolInterface* underlying_threadpool_ = nullptr;
+
+  // If used, underlying_threadpool_ is instantiated and owned by the ThreadPool.
   std::unique_ptr<ThreadPoolTempl<Env> > extended_eigen_threadpool_;
 };
 

--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -226,7 +226,7 @@ class ThreadPool {
   // the implementation choice of whether this matches the number of threads created in
   // the pool.
   //
-  // Currently, a loop with degree-of-parlalelism N is supported by a pool of N-1 threads
+  // Currently, a loop with degree-of-parallelism N is supported by a pool of N-1 threads
   // working in combination with the thread initiating the loop.
   static int DegreeOfParallelism(const concurrency::ThreadPool* tp);
 

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -74,19 +74,19 @@ public:
     // does not need to be unique, but we aim for a good distribution, particularly in the case where
     // most/all of the thread pool's threads are active in the loop.  Threads outside the pool may
     // also be claiming work, with CurrentThreadId -1.
-    int num_threads = _tp.NumThreads();
-    int my_thread_idx = (_tp.CurrentThreadId() + 1) % num_threads;
-    assert(my_thread_idx >= 0 && my_thread_idx < num_threads);
+    int d_of_p = _tp.DegreeOfParallelism();
+    int my_thread_idx = (_tp.CurrentThreadId() + 1) % d_of_p;
+    assert(my_thread_idx >= 0 && my_thread_idx < d_of_p);
 
     int home_shard;
-    if (num_threads >= NUM_SHARDS) {
+    if (d_of_p >= NUM_SHARDS) {
       // More threads than shards => allocate them home shards round-robin, aiming to sprace the load across
       // the shards
       home_shard = my_thread_idx % NUM_SHARDS;
     } else {
       // Fewer threads than shards => spread the threads evenly across the shards, so each will work
       // on a run of successive shards before contention
-      home_shard = (my_thread_idx * NUM_SHARDS) / num_threads;
+      home_shard = (my_thread_idx * NUM_SHARDS) / d_of_p;
     }
     assert(home_shard >= 0 && home_shard < NUM_SHARDS);
     return home_shard;

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -74,7 +74,7 @@ public:
     // does not need to be unique, but we aim for a good distribution, particularly in the case where
     // most/all of the thread pool's threads are active in the loop.  Threads outside the pool may
     // also be claiming work, with CurrentThreadId -1.
-    int d_of_p = _tp.DegreeOfParallelism();
+    int d_of_p = ThreadPool::DegreeOfParallelism();
     int my_thread_idx = (_tp.CurrentThreadId() + 1) % d_of_p;
     assert(my_thread_idx >= 0 && my_thread_idx < d_of_p);
 

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -74,7 +74,7 @@ public:
     // does not need to be unique, but we aim for a good distribution, particularly in the case where
     // most/all of the thread pool's threads are active in the loop.  Threads outside the pool may
     // also be claiming work, with CurrentThreadId -1.
-    int d_of_p = ThreadPool::DegreeOfParallelism();
+    int d_of_p = ThreadPool::DegreeOfParallelism(&_tp);
     int my_thread_idx = (_tp.CurrentThreadId() + 1) % d_of_p;
     assert(my_thread_idx >= 0 && my_thread_idx < d_of_p);
 

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -377,7 +377,7 @@ int ThreadPool::CurrentThreadId() const {
   } else {
     return -1;
   }
-}  // namespace concurrency
+}
 
 }  // namespace concurrency
 }  // namespace onnxruntime

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -166,7 +166,7 @@ void ThreadPool::ParallelForFixedBlockSizeScheduling(const std::ptrdiff_t total,
 
   // Split the work across threads in the pool.  Each work item will run a loop claiming iterations,
   // hence we need at most one for each thread, even if the numberof blocks of iterations is larger.
-  int d_of_p = DegreeOfParallelism();
+  auto d_of_p = DegreeOfParallelism(this);
   int num_work_items = static_cast<int>(std::min(static_cast<std::ptrdiff_t>(d_of_p), total));
   assert(num_work_items > 0);
 

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -774,7 +774,7 @@ MlasGetMaximumThreadCount(
     return 1;
 #endif
 #else
-	return onnxruntime::concurrency::ThreadPool::NumThreads(ThreadPool);
+	return onnxruntime::concurrency::ThreadPool::DegreeOfParallelism(ThreadPool);
 #endif
 }
 

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -774,7 +774,7 @@ MlasGetMaximumThreadCount(
     return 1;
 #endif
 #else
-	return onnxruntime::concurrency::ThreadPool::DegreeOfParallelism(ThreadPool);
+    return onnxruntime::concurrency::ThreadPool::DegreeOfParallelism(ThreadPool);
 #endif
 }
 

--- a/onnxruntime/core/providers/cpu/math/top_k.cc
+++ b/onnxruntime/core/providers/cpu/math/top_k.cc
@@ -164,7 +164,7 @@ static void FindTopKElements(const Tensor* input, const TensorShape& input_shape
   const int64_t num_blocks = input_shape[axis_parsed];
   const int64_t block_slice = reduced_cols / k;
 
-  int64_t tp_threads = concurrency::ThreadPool::NumThreads(threadpool);
+  int64_t tp_threads = concurrency::ThreadPool::DegreeOfParallelism(threadpool);
   int64_t num_threads = std::min(tp_threads, rows);  // split on rows so can't have more threads than rows
 
   // rough attempt to make sure there's enough work for each thread. if there's insufficient work the usage of

--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_common.h
+++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_common.h
@@ -326,7 +326,7 @@ void TreeEnsembleCommon<ITYPE, OTYPE>::ComputeAgg(concurrency::ThreadPool* ttp, 
       } else {
         // split the work into one block per thread so we can re-use the 'private_scores' vector as much as possible
         // TODO: Refine the number of threads used
-        auto num_threads = std::min<int32_t>(concurrency::ThreadPool::NumThreads(ttp), SafeInt<int32_t>(n_trees_));
+        auto num_threads = std::min<int32_t>(concurrency::ThreadPool::DegreeOfParallelism(ttp), SafeInt<int32_t>(n_trees_));
         OrtMutex merge_mutex;
         concurrency::ThreadPool::TrySimpleParallelFor(
             ttp,
@@ -361,7 +361,7 @@ void TreeEnsembleCommon<ITYPE, OTYPE>::ComputeAgg(concurrency::ThreadPool* ttp, 
       } else {
         // split the work into one block per thread so we can re-use the 'scores' vector as much as possible
         // TODO: Refine the number of threads used.
-        auto num_threads = std::min<int32_t>(concurrency::ThreadPool::NumThreads(ttp), SafeInt<int32_t>(N));
+        auto num_threads = std::min<int32_t>(concurrency::ThreadPool::DegreeOfParallelism(ttp), SafeInt<int32_t>(N));
         concurrency::ThreadPool::TrySimpleParallelFor(
             ttp,
             num_threads,

--- a/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.cc
+++ b/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.cc
@@ -1069,7 +1069,7 @@ void UniDirectionalLstm<T>::GateComputations(
 
 template <typename T>
 void UniDirectionalLstm<T>::SetNumThreads() {
-  int threads = concurrency::ThreadPool::NumThreads(thread_pool_);
+  int threads = concurrency::ThreadPool::DegreeOfParallelism(thread_pool_);
 
   if (threads < 1)
     threads = 1;


### PR DESCRIPTION
**Description**: Create N-1 threads in a thread pool when configured with intra-op parallelism of N.  This ensures we have N active threads, given that the main thread also runs work.  To avoid ambiguity on the value returned, rename ThreadPool::NumThreads method to ThreadPool::DegreeOfParallelism, and make corresponding updates in MLAS and operators.

**Motivation and Context**
Prior commit #4236 created a thread pool of N threads, and aimed to keep at most N-1 of them _active_ when the main thread was being used.  On some workloads, including resnet50 on Windows, all N threads in the pool would be active, leading to contention. 