### PR TITLE
Add sudo --preserve-env option to allow environment to go through to docker commands.

### DIFF
--- a/tools/ci_build/github/linux/run_dockerbuild.sh
+++ b/tools/ci_build/github/linux/run_dockerbuild.sh
@@ -37,7 +37,7 @@ echo "bo=$BUILD_OS bd=$BUILD_DEVICE bdir=$BUILD_DIR pv=$PYTHON_VER bex=$BUILD_EX
 if id -Gnz | grep -zq "^docker$" ; then
     DOCKER_CMD=docker
 else
-    DOCKER_CMD="sudo docker"
+    DOCKER_CMD="sudo --preserve-env docker"
 fi
 
 cd $SCRIPT_DIR/docker


### PR DESCRIPTION
**Description**
In run_dockerbuild.sh, add sudo --preserve-env option to allow environment to go through to docker commands.

**Motivation and Context**
For at least one case, docker run, environment variables set by name only with -e might not make it through in the case where docker is run with sudo. Adding the sudo --preserve-env option will make current environment variables available to the command.