### PR TITLE
Handle nodes with dtype attribute causing diffs in inferred and actual types of NodeArgs due to InsertCastTransformer

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -1895,27 +1895,11 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op, const Reso
         }
       }
 
-      else {
-        // Make an exception for cases where the inferred type is `float16` and the existing
-        // type is `float` and the node is assigned to the CPU EP.
-        // We allow such cases to pass through without a complaint because there are some ONNX ops
-        // - mostly Generator ops (RandomNormal, RandomNormalLike, EyeLike, etc.) where-in
-        // the output type is inferred based on a static attribute (for example - `dtype`) as opposed
-        // to most other ONNX ops where the-in the type is deduced based on input types.
-        // When we insert cast nodes to the inputs of such operators (when the input type
-        // is float16) to cast the inputs to float so as to use CPU kernels (when there is no EP capable
-        // of running such nodes as is), the output NodeArg(s) are of the type `float` (existing_type) but the
-        // inferred type will be `float16` if such nodes have the output type defining attribute to be `float16`.
-        // We make an exception for this case and use the existing_type.
-        if (*inferred_type != "tensor(float16)" ||
-            *existing_type != "tensor(float)" ||
-            node.GetExecutionProviderType() != kCpuExecutionProvider) {
-          return Status(ONNXRUNTIME, FAIL,
-                        "Type Error: Type (" + *existing_type + ") of output arg (" +
-                            output_def->Name() + ") of node (" + node_name +
-                            ") does not match expected type (" + *inferred_type + ").");
-        }
-      }
+      else
+        return Status(ONNXRUNTIME, FAIL,
+                      "Type Error: Type (" + *existing_type + ") of output arg (" +
+                          output_def->Name() + ") of node (" + node_name +
+                          ") does not match expected type (" + *inferred_type + ").");
     }
 
     if (existing_type == nullptr)

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -1893,9 +1893,7 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op, const Reso
         } else {
           output_def->SetType(inferred_type);
         }
-      }
-
-      else
+      } else
         return Status(ONNXRUNTIME, FAIL,
                       "Type Error: Type (" + *existing_type + ") of output arg (" +
                           output_def->Name() + ") of node (" + node_name +
@@ -2055,7 +2053,7 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
         node.op_ = nullptr;
       }
 
-      InitFunctionBodyForNode(node);
+	  InitFunctionBodyForNode(node);
 
       if (!node.op_) {
         return Status(ONNXRUNTIME, FAIL, "Fatal error: " + node.OpType() + " is not a registered function/op");

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -1893,11 +1893,29 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op, const Reso
         } else {
           output_def->SetType(inferred_type);
         }
-      } else
-        return Status(ONNXRUNTIME, FAIL,
-                      "Type Error: Type (" + *existing_type + ") of output arg (" +
-                          output_def->Name() + ") of node (" + node_name +
-                          ") does not match expected type (" + *inferred_type + ").");
+      }
+
+      else {
+        // Make an exception for cases where the inferred type is `float16` and the existing
+        // type is `float` and the node is assigned to the CPU EP.
+        // We allow such cases to pass through without a complaint because there are some ONNX ops
+        // - mostly Generator ops (RandomNormal, RandomNormalLike, EyeLike, etc.) where-in
+        // the output type is inferred based on a static attribute (for example - `dtype`) as opposed
+        // to most other ONNX ops where the-in the type is deduced based on input types.
+        // When we insert cast nodes to the inputs of such operators (when the input type
+        // is float16) to cast the inputs to float so as to use CPU kernels (when there is no EP capable
+        // of running such nodes as is), the output NodeArg(s) are of the type `float` (existing_type) but the
+        // inferred type will be `float16` if such nodes have the output type defining attribute to be `float16`.
+        // We make an exception for this rare case and use the existing_type.
+        if (*inferred_type != "tensor(float16)" ||
+            *existing_type != "tensor(float)" ||
+            node.GetExecutionProviderType() != kCpuExecutionProvider) {
+          return Status(ONNXRUNTIME, FAIL,
+                        "Type Error: Type (" + *existing_type + ") of output arg (" +
+                            output_def->Name() + ") of node (" + node_name +
+                            ") does not match expected type (" + *inferred_type + ").");
+        }
+      }
     }
 
     if (existing_type == nullptr)
@@ -2053,7 +2071,7 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
         node.op_ = nullptr;
       }
 
-	  InitFunctionBodyForNode(node);
+      InitFunctionBodyForNode(node);
 
       if (!node.op_) {
         return Status(ONNXRUNTIME, FAIL, "Fatal error: " + node.OpType() + " is not a registered function/op");

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -1906,7 +1906,7 @@ Status Graph::InferAndVerifyTypeMatch(Node& node, const OpSchema& op, const Reso
         // is float16) to cast the inputs to float so as to use CPU kernels (when there is no EP capable
         // of running such nodes as is), the output NodeArg(s) are of the type `float` (existing_type) but the
         // inferred type will be `float16` if such nodes have the output type defining attribute to be `float16`.
-        // We make an exception for this rare case and use the existing_type.
+        // We make an exception for this case and use the existing_type.
         if (*inferred_type != "tensor(float16)" ||
             *existing_type != "tensor(float)" ||
             node.GetExecutionProviderType() != kCpuExecutionProvider) {

--- a/onnxruntime/core/optimizer/insert_cast_transformer.cc
+++ b/onnxruntime/core/optimizer/insert_cast_transformer.cc
@@ -244,10 +244,11 @@ Status InsertCastTransformer::ApplyImpl(onnxruntime::Graph& graph, bool& modifie
 
     auto& outputs = node->MutableOutputDefs();
     for (auto output : outputs) {
-      // todo: check is the kernel available
-      // here is based on the assumption that if we cast a cpu op's input from float16 to float
-      // then this cpu op's output will become float.
-      // not sure is it always correct...
+      // TODO 1: Check if the kernel available
+      // TODO 2: There is an inherent assumption that if we cast a cpu op's input from float16 to float
+      // then this cpu op's output will be float (if it was inferred to be float16 previously).
+      // Not sure if this is always true. Handle any corner case if it does exist.
+
       if (output->Type() &&
           DataTypeImpl::TypeFromProto(*output->TypeAsProto()) == DataTypeImpl::GetTensorType<MLFloat16>() &&
           casted) {

--- a/onnxruntime/core/optimizer/insert_cast_transformer.cc
+++ b/onnxruntime/core/optimizer/insert_cast_transformer.cc
@@ -254,7 +254,7 @@ Status InsertCastTransformer::ApplyImpl(onnxruntime::Graph& graph, bool& modifie
         ORT_ENFORCE(dtype_attribute->second.has_i(),
                     "InsertCastTransformer works on the assumption that `dtype` attribute holds an integer.");
 
-        dtype_attribute->second.set_i(1);  // enum corresponding to FLOAT is 1
+        dtype_attribute->second.set_i(TensorProto_DataType_FLOAT);
       }
     }
 

--- a/onnxruntime/test/framework/insert_cast_transformer_test.cc
+++ b/onnxruntime/test/framework/insert_cast_transformer_test.cc
@@ -135,8 +135,8 @@ TEST(TransformerTest, ThreeInARowRemoval) {
 }
 
 // test a case where the ONNX inferred type (float16) is different from the type bound
-// to the output NodeArg of the "EyeLike" node because of the InsertCaseTransformer
-TEST(TransformerTest, EyeLikeModelWithFloat16Inputs) {
+// to the output NodeArg of the "RandomNormalLike" node because of the InsertCaseTransformer
+TEST(TransformerTest, RandomNormalLikeWithFloat16Inputs) {
   auto model_uri = MODEL_FOLDER ORT_TSTR("random_normal_like_float16.onnx");
   std::shared_ptr<Model> model;
   auto status = Model::Load(model_uri, model, nullptr, DefaultLoggingManager().DefaultLogger());

--- a/onnxruntime/test/framework/insert_cast_transformer_test.cc
+++ b/onnxruntime/test/framework/insert_cast_transformer_test.cc
@@ -134,5 +134,24 @@ TEST(TransformerTest, ThreeInARowRemoval) {
   ASSERT_TRUE(op_to_count["Cast"] == 2);
 }
 
+// test a case where the ONNX inferred type (float16) is different from the type bound
+// to the output NodeArg of the "EyeLike" node because of the InsertCaseTransformer
+TEST(TransformerTest, EyeLikeModelWithFloat16Inputs) {
+  auto model_uri = MODEL_FOLDER ORT_TSTR("random_normal_like_float16.onnx");
+  std::shared_ptr<Model> model;
+  auto status = Model::Load(model_uri, model, nullptr, DefaultLoggingManager().DefaultLogger());
+  ASSERT_TRUE(status.IsOK()) << status;
+
+  Graph& graph = model->MainGraph();
+  InsertCastTransformer transformer("Test");
+
+  bool modified = false;
+  status = transformer.Apply(graph, modified, DefaultLoggingManager().DefaultLogger());
+  EXPECT_TRUE(status.IsOK()) << status;
+  EXPECT_TRUE(modified) << "Transformer should have added some Cast nodes";
+  status = graph.Resolve();
+  EXPECT_TRUE(status.IsOK()) << status;
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/testdata/transform/random_normal_like_float16.onnx
+++ b/onnxruntime/test/testdata/transform/random_normal_like_float16.onnx
@@ -1,0 +1,17 @@
+:Ð
+F
+input_0output_0RandomNormalLike1"RandomNormalLike*
+dtype
+ 
+G
+output_0output_1RandomNormalLike2"RandomNormalLike*
+dtype Reshape_FusionZ
+input_0
+
+
+
+b
+output_1
+
+
+B


### PR DESCRIPTION
**Description**:
 
Generator ONNX ops (RandomNormal, RandomNormalLike, EyeLike, etc.) have the type of the outputs inferred based on a static attribute (`dtype`) and this can cause mismatch between the actual type and the ONNX inferred type of a NodeArg after a pass through the `InsertCastTransformer`. Hence, we mutate the attribute of these nodes in the InsertCastTransformer so as to get a match between the ONNX inferred type and the actual type.

**Motivation and Context**
Fix https://github.com/microsoft/onnxruntime/issues/4405