### PR TITLE
Ensure IOBinding is tested on Linux

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -487,7 +487,6 @@ def install_python_deps(numpy_version=""):
 
 # We need to install Torch to test certain functionalities of the ORT Python package
 def install_torch():
-    # Command works for both Windows
     run_subprocess([sys.executable, '-m', 'pip', 'install', '--trusted-host',
                     'files.pythonhosted.org', 'torch===1.5.1+cu101', 'torchvision===0.6.1+cu101',
                     '-f', 'https://download.pytorch.org/whl/torch_stable.html'])
@@ -1238,6 +1237,7 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
                 iobinding_test = True
 
                 # Try install Torch on Windows
+                # On Linux, it is installed via the `install_deps.sh` script
                 if is_windows():
                     log.info("Attempting to install Torch to test ORT's IOBinding feature")
                     install_torch()

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -113,8 +113,14 @@ if [ $DEVICE_TYPE = "Normal" ]; then
     ${PYTHON_EXE} -m pip install sympy==1.1.1
 elif [ $DEVICE_TYPE = "gpu" ]; then
     ${PYTHON_EXE} -m pip install sympy==1.1.1
+    # Inferencing pipelines need Torch installed as well to test IOBinding
+    if [ "$PYTHON_VER" = "3.5" ]; then
+        echo "Python 3.6 and above is needed for installing the nightly Torch package!"
+    else
+        echo "Installing nightly Torch package"
+        ${PYTHON_EXE} -m pip install --upgrade --pre torch==1.6.0.dev20200610 torchvision==0.7.0.dev20200610 -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
+    fi
     if [[ $BUILD_EXTR_PAR = *--enable_training* ]]; then
-      ${PYTHON_EXE} -m pip install --upgrade --pre torch==1.6.0.dev20200610 torchvision==0.7.0.dev20200610 -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
       ${PYTHON_EXE} -m pip install  transformers==v2.10.0
       # transformers requires sklearn
       ${PYTHON_EXE} -m pip install sklearn

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -115,9 +115,9 @@ elif [ $DEVICE_TYPE = "gpu" ]; then
     ${PYTHON_EXE} -m pip install sympy==1.1.1
     # Inferencing pipelines need Torch installed as well to test IOBinding
     if [ "$PYTHON_VER" = "3.5" ]; then
-        echo "Python 3.6 and above is needed for installing the nightly Torch package!"
+        echo "Python 3.6 and above is needed for installing the dev Torch package!"
     else
-        echo "Installing nightly Torch package"
+        echo "Installing the dev Torch package"
         ${PYTHON_EXE} -m pip install --upgrade --pre torch==1.6.0.dev20200610 torchvision==0.7.0.dev20200610 -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
     fi
     if [[ $BUILD_EXTR_PAR = *--enable_training* ]]; then


### PR DESCRIPTION
**Description**: Install Torch in Linux GPU inferencing pipelines  (currently it is installed only on training GPU pipelines). Installing it on inferencing pipelines ensures that IOBinding (via the Python APIs) is tested on Linux.

