### PR TITLE
Add a script to convert gpt2 to onnx

### DIFF
--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -252,7 +252,8 @@ def export_onnx_model(model_name, cache_dir, onnx_dir, input_names, use_gpu, pre
 
     example_outputs = model(**example_inputs)
 
-    assert isinstance(example_outputs, (list, tuple))
+    assert isinstance(example_outputs, (list, tuple)), f"type of output is not list or tuple: {type(example_outputs)}"
+
     # Flatten is needed for gpt2 and distilgpt2.
     example_outputs_flatten = flatten(example_outputs)
     example_outputs_flatten = update_flatten_list(example_outputs_flatten, [])

--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -50,7 +50,6 @@ import os
 import psutil
 import onnx
 from enum import Enum
-from packaging import version
 from transformers.modeling_utils import Conv1D
 from benchmark_helper import create_onnxruntime_session, Precision
 from gpt2_helper import GPT2ModelNoPastState

--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -40,20 +40,19 @@
 
 import argparse
 import logging
-import coloredlogs
-import csv
 import timeit
 from datetime import datetime
 import numpy
-import sys
+
 import os
 import psutil
 import onnx
 from enum import Enum
-from transformers.modeling_utils import Conv1D
-from benchmark_helper import create_onnxruntime_session, Precision
-from gpt2_helper import GPT2ModelNoPastState
+from benchmark_helper import (create_onnxruntime_session, Precision, setup_logger, get_latency_result, output_details,
+                              output_summary, output_fusion_statistics, inference_ort, inference_ort_with_io_binding,
+                              allocateOutputBuffers)
 from quantize_helper import QuantizeHelper
+from onnx_exporter import create_onnxruntime_input, load_pretrained_model, export_onnx_model
 
 logger = logging.getLogger('')
 
@@ -88,295 +87,9 @@ import torch
 from transformers import (AutoConfig, AutoTokenizer, AutoModel, GPT2Model)
 
 
-def load_pretrained_model(model_name, config, cache_dir):
-    if model_name in ["gpt2", "distilgpt2", "gpt2-large"]:
-        return GPT2ModelNoPastState.from_pretrained(model_name, config=config, cache_dir=cache_dir)
-    return AutoModel.from_pretrained(model_name, config=config, cache_dir=cache_dir)
-
-
-def create_onnxruntime_input(vocab_size, batch_size, sequence_length, input_names):
-    input_ids = numpy.random.randint(low=0, high=vocab_size - 1, size=(batch_size, sequence_length), dtype=numpy.int64)
-
-    inputs = {'input_ids': input_ids}
-
-    if "attention_mask" in input_names:
-        attention_mask = numpy.ones([batch_size, sequence_length], dtype=numpy.int64)
-        inputs['attention_mask'] = attention_mask
-
-    if "token_type_ids" in input_names:
-        segment_ids = numpy.zeros([batch_size, sequence_length], dtype=numpy.int64)
-        inputs['token_type_ids'] = segment_ids
-
-    return inputs
-
-
-def filter_inputs(inputs, input_names):
-    remaining_model_inputs = {}
-    for input_name in input_names:
-        remaining_model_inputs[input_name] = inputs[input_name]
-    return remaining_model_inputs
-
-
-def flatten(inputs):
-    return [[flatten(i) for i in inputs] if isinstance(inputs, (list, tuple)) else inputs]
-
-
-def update_flatten_list(inputs, res_list):
-    for i in inputs:
-        res_list.append(i) if not isinstance(i, (list, tuple)) else update_flatten_list(i, res_list)
-    return res_list
-
-
-def build_dynamic_axes(example_inputs, outputs_flatten):
-    sequence_length = example_inputs["input_ids"].shape[-1]
-
-    dynamic_axes = {key: {0: 'batch_size', 1: 'seq_len'} for key in example_inputs.keys()}
-
-    output_names = ['output_' + str(i + 1) for i in range(len(outputs_flatten))]
-    for i, output_name in enumerate(output_names):
-        dynamic_axes[output_name] = {0: 'batch_size'}
-        dims = outputs_flatten[i].shape
-        for j, dim in enumerate(dims):
-            if dim == sequence_length:
-                dynamic_axes[output_name].update({j: 'seq_len'})
-    return dynamic_axes, output_names
-
-
-def validate_onnx_model(onnx_model_path, example_inputs, example_outputs_flatten, use_gpu, fp16):
-    test_session = create_onnxruntime_session(onnx_model_path, use_gpu, enable_all_optimization=False)
-    if test_session is None:
-        logger.error(f"{onnx_model_path} is an invalid ONNX model")
-        return False
-
-    logger.info(f"{onnx_model_path} is a valid ONNX model")
-
-    # Compare the inference result with PyTorch
-    example_ort_inputs = {k: t.cpu().numpy() for k, t in example_inputs.items()}
-    example_ort_outputs = test_session.run(None, example_ort_inputs)
-    if len(example_outputs_flatten) != len(example_ort_outputs):
-        logger.error(
-            f"Number of output tensors expected {len(example_outputs_flatten)}, got {len(example_ort_outputs)}")
-        return False
-
-    for i in range(len(example_outputs_flatten)):
-        abs_diff = numpy.amax(numpy.abs(example_ort_outputs[i] - example_outputs_flatten[i].cpu().numpy()))
-        if abs_diff > 1e-4:
-            logger.info(f"Max absolute diff={abs_diff} for output tensor {i}")
-
-        rtol = 5e-02 if fp16 else 1e-4
-        atol = 1e-01 if fp16 else 1e-4
-        if not numpy.allclose(example_ort_outputs[i], example_outputs_flatten[i].cpu(), rtol=rtol, atol=atol):
-            logger.error(f"Output tensor {i} is not close: rtol={rtol}, atol={atol}")
-            return False
-
-    logger.info(f"inference result of onnxruntime is validated on {onnx_model_path}")
-    return True
-
-
-model_fusion_statistics = {}
-
-
-def get_onnx_file_path(onnx_dir: str, model_name: str, input_count: int, optimized_by_script: bool, use_gpu: bool,
-                       precision: Precision, optimized_by_onnxruntime: bool):
-    if not optimized_by_script:
-        filename = f"{model_name}_{input_count}"
-    else:
-        device = "gpu" if use_gpu else "cpu"
-        filename = f"{model_name}_{input_count}_{precision}_{device}"
-
-    if optimized_by_onnxruntime:
-        filename += f"_ort"
-
-    use_external_data = MODELS[model_name][2]
-    directory = os.path.join(onnx_dir, filename) if use_external_data else onnx_dir
-    if not os.path.exists(directory):
-        os.makedirs(directory)
-
-    return os.path.join(directory, f"{filename}.onnx")
-
-
-def optimize_onnx_model_by_ort(onnx_model_path, ort_model_path, use_gpu, overwrite):
-    if overwrite or not os.path.exists(ort_model_path):
-        from optimizer import optimize_by_onnxruntime, get_fusion_statistics
-        # Use onnxruntime to optimize model, which will be saved to *_ort.onnx
-        opt_model = optimize_by_onnxruntime(onnx_model_path,
-                                            use_gpu=use_gpu,
-                                            optimized_model_path=ort_model_path,
-                                            opt_level=99)
-        model_fusion_statistics[ort_model_path] = get_fusion_statistics(ort_model_path)
-    else:
-        logger.info(f"Skip optimization since model existed: {ort_model_path}")
-
-
-def optimize_onnx_model(onnx_model_path, optimized_model_path, model_type, num_attention_heads, hidden_size, use_gpu,
-                        fp16, use_raw_attention_mask, overwrite):
-    if overwrite or not os.path.exists(optimized_model_path):
-        from optimizer import optimize_model
-        from onnx_model_bert import BertOptimizationOptions
-        optimization_options = BertOptimizationOptions(model_type)
-        if use_raw_attention_mask:
-            optimization_options.use_raw_attention_mask()
-        if fp16:
-            optimization_options.enable_gelu_approximation = True
-
-        # Use script to optimize model.
-        # Use opt_level <= 1 for models to be converted to fp16, because some fused op (like FusedGemm) has only fp32 and no fp16.
-        # It is better to be conservative so we use opt_level=0 here, in case MemcpyFromHost is added to the graph by OnnxRuntime.
-        opt_model = optimize_model(onnx_model_path,
-                                   model_type,
-                                   num_heads=num_attention_heads,
-                                   hidden_size=hidden_size,
-                                   opt_level=0,
-                                   optimization_options=optimization_options,
-                                   use_gpu=use_gpu,
-                                   only_onnxruntime=False)
-        model_fusion_statistics[optimized_model_path] = opt_model.get_fused_operator_statistics()
-
-        if fp16:
-            opt_model.convert_model_float32_to_float16()
-        opt_model.save_model_to_file(optimized_model_path)
-    else:
-        logger.info(f"Skip optimization since model existed: {optimized_model_path}")
-
-
-def export_onnx_model(model_name, cache_dir, onnx_dir, input_names, use_gpu, precision, optimize_onnx, validate_onnx,
-                      use_raw_attention_mask, overwrite):
-    config = AutoConfig.from_pretrained(model_name, cache_dir=cache_dir)
-    model = load_pretrained_model(model_name, config=config, cache_dir=cache_dir)
-    model.cpu()
-
-    tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=cache_dir)
-    example_inputs = tokenizer.encode_plus("This is a sample input", return_tensors="pt")
-
-    example_inputs = filter_inputs(example_inputs, input_names)
-
-    example_outputs = model(**example_inputs)
-
-    assert isinstance(example_outputs, (list, tuple)), f"type of output is not list or tuple: {type(example_outputs)}"
-
-    # Flatten is needed for gpt2 and distilgpt2.
-    example_outputs_flatten = flatten(example_outputs)
-    example_outputs_flatten = update_flatten_list(example_outputs_flatten, [])
-
-    onnx_model_path = get_onnx_file_path(onnx_dir, model_name, len(input_names), False, use_gpu, precision, False)
-
-    if overwrite or not os.path.exists(onnx_model_path):
-        logger.info("Exporting ONNX model to {}".format(onnx_model_path))
-
-        dynamic_axes, output_names = build_dynamic_axes(example_inputs, example_outputs_flatten)
-
-        torch.onnx.export(model=model,
-                          args=tuple(example_inputs.values()),
-                          f=onnx_model_path,
-                          input_names=list(example_inputs.keys()),
-                          output_names=output_names,
-                          example_outputs=example_outputs,
-                          dynamic_axes=dynamic_axes,
-                          do_constant_folding=True,
-                          opset_version=MODELS[model_name][1],
-                          use_external_data_format=MODELS[model_name][2])
-    else:
-        logger.info(f"Skip export since model existed: {onnx_model_path}")
-
-    is_valid_onnx_model = True
-    if validate_onnx:
-        is_valid_onnx_model = validate_onnx_model(onnx_model_path, example_inputs, example_outputs_flatten, use_gpu,
-                                                  False)
-
-    if optimize_onnx or precision == Precision.FLOAT16 or precision == Precision.INT8:  # Use script (optimizer.py) to optimize
-        model_type = MODELS[model_name][3]
-        optimized_model_path = get_onnx_file_path(onnx_dir, model_name, len(input_names), True, use_gpu, precision,
-                                                  False)
-        optimize_onnx_model(onnx_model_path, optimized_model_path, model_type, config.num_attention_heads,
-                            config.hidden_size, use_gpu, precision == Precision.FLOAT16, use_raw_attention_mask,
-                            overwrite)
-
-        onnx_model_path = optimized_model_path
-        if validate_onnx:
-            is_valid_onnx_model = validate_onnx_model(onnx_model_path, example_inputs, example_outputs_flatten, use_gpu,
-                                                      precision == Precision.FLOAT16)
-
-        if precision == Precision.INT8:
-            logger.info(f"Quantizing model: {onnx_model_path}")
-            QuantizeHelper.quantize_onnx_model(onnx_model_path, onnx_model_path)
-            logger.info(f"Finished quantizing model: {onnx_model_path}")
-
-    else:  # Use OnnxRuntime to optimize
-        if is_valid_onnx_model:
-            ort_model_path = get_onnx_file_path(onnx_dir, model_name, len(input_names), False, use_gpu, precision, True)
-            optimize_onnx_model_by_ort(onnx_model_path, ort_model_path, use_gpu, overwrite)
-
-    return onnx_model_path, is_valid_onnx_model, config.vocab_size, tokenizer.max_model_input_sizes[model_name]
-
-
-def get_latency_result(runtimes, batch_size):
-    latency_ms = sum(runtimes) / float(len(runtimes)) * 1000.0
-    latency_variance = numpy.var(runtimes, dtype=numpy.float64) * 1000.0
-    throughput = batch_size * (1000.0 / latency_ms)
-
-    return {
-        "test_times": len(runtimes),
-        "latency_variance": "{:.2f}".format(latency_variance),
-        "latency_90_percentile": "{:.2f}".format(numpy.percentile(runtimes, 90) * 1000.0),
-        "latency_95_percentile": "{:.2f}".format(numpy.percentile(runtimes, 95) * 1000.0),
-        "latency_99_percentile": "{:.2f}".format(numpy.percentile(runtimes, 99) * 1000.0),
-        "average_latency_ms": "{:.2f}".format(latency_ms),
-        "QPS": "{:.2f}".format(throughput),
-    }
-
-
-def inference_ort(ort_session, ort_inputs, result_template, repeat_times, batch_size):
-    result = {}
-    runtimes = timeit.repeat(lambda: ort_session.run(None, ort_inputs), number=1, repeat=repeat_times)
-    result.update(result_template)
-    result.update({"io_binding": False})
-    result.update(get_latency_result(runtimes, batch_size))
-    return result
-
-
-def inference_ort_with_io_binding(ort_session, ort_inputs, result_template, repeat_times, ort_output_names, ort_outputs,
-                                  output_buffers, max_last_state_size, max_pooler_size, batch_size, device):
-    result = {}
-
-    # Bind inputs and outputs to onnxruntime session
-    io_binding = ort_session.io_binding()
-    # Bind inputs to device
-    for name in ort_inputs.keys():
-        np_input = torch.from_numpy(ort_inputs[name]).to(device)
-        io_binding.bind_input(name, np_input.device.type, 0, numpy.longlong, np_input.shape, np_input.data_ptr())
-    has_pooler = True if len(ort_output_names) == 2 else False
-    # Bind outputs buffers with the sizes needed if not allocated already
-    if output_buffers["last_state"] is None:
-        allocateOutputBuffers(output_buffers, max_last_state_size, max_pooler_size, device, has_pooler)
-    last_state_buffer = output_buffers["last_state"]
-    pooler_buffer = output_buffers["pooler"]
-    io_binding.bind_output(ort_output_names[0], last_state_buffer.device.type, 0, numpy.float32, ort_outputs[0].shape,
-                           last_state_buffer.data_ptr())
-    if has_pooler:
-        io_binding.bind_output(ort_output_names[1], pooler_buffer.device.type, 0, numpy.float32, ort_outputs[1].shape,
-                               pooler_buffer.data_ptr())
-
-    runtimes = timeit.repeat(lambda: ort_session.run_with_iobinding(io_binding), number=1, repeat=repeat_times)
-    result.update(result_template)
-    result.update({"io_binding": True})
-    result.update(get_latency_result(runtimes, batch_size))
-    return result
-
-
-def allocateOutputBuffers(output_buffers, max_last_state_size, max_pooler_size, device, has_pooler=False):
-    # Allocate output tensors with the largest test size needed. So the allocated memory can be reused
-    # for each test run.
-    # dummy last state
-    if output_buffers["last_state"] is None:
-        output_buffers["last_state"] = torch.empty(max_last_state_size, dtype=torch.float32, device=device)
-    # create dummy pooler
-    if output_buffers["pooler"] is None and has_pooler:
-        output_buffers["pooler"] = torch.empty(max_pooler_size, dtype=torch.float32, device=device)
-
-
 def run_onnxruntime(use_gpu, model_names, precision, batch_sizes, sequence_lengths, repeat_times, input_counts,
                     optimize_onnx, validate_onnx, cache_dir, onnx_dir, verbose, overwrite, disable_ort_io_binding,
-                    use_raw_attention_mask, thread_num):
+                    use_raw_attention_mask, thread_num, model_fusion_statistics):
     import onnxruntime
 
     results = []
@@ -399,8 +112,9 @@ def run_onnxruntime(use_gpu, model_names, precision, batch_sizes, sequence_lengt
 
             with torch.no_grad():
                 onnx_model_file, is_valid_onnx_model, vocab_size, max_sequence_length = export_onnx_model(
-                    model_name, cache_dir, onnx_dir, input_names, use_gpu, precision, optimize_onnx, validate_onnx,
-                    use_raw_attention_mask, overwrite)
+                    model_name, MODELS[model_name][1], MODELS[model_name][2], MODELS[model_name][3], cache_dir,
+                    onnx_dir, input_names, use_gpu, precision, optimize_onnx, validate_onnx, use_raw_attention_mask,
+                    overwrite, model_fusion_statistics)
             if not is_valid_onnx_model:
                 continue
 
@@ -530,72 +244,6 @@ def run_pytorch(use_gpu, model_names, precision, batch_sizes, sequence_lengths, 
     return results
 
 
-def output_details(results, csv_filename):
-    with open(csv_filename, mode="a", newline='') as csv_file:
-        column_names = [
-            "engine", "version", "device", "precision", "optimizer", "io_binding", "model_name", "inputs", "batch_size",
-            "sequence_length", "datetime", "test_times", "QPS", "average_latency_ms", "latency_variance",
-            "latency_90_percentile", "latency_95_percentile", "latency_99_percentile"
-        ]
-
-        csv_writer = csv.DictWriter(csv_file, fieldnames=column_names)
-        csv_writer.writeheader()
-        for result in results:
-            csv_writer.writerow(result)
-
-    logger.info(f"Detail results are saved to csv file: {csv_filename}")
-
-
-def output_summary(results, csv_filename, args):
-    with open(csv_filename, mode="a", newline='') as csv_file:
-        header_names = ["model_name", "inputs", "engine", "version", "device", "precision", "optimizer", "io_binding"]
-        data_names = []
-        for batch_size in args.batch_sizes:
-            for sequence_length in args.sequence_lengths:
-                data_names.append(f"b{batch_size}_s{sequence_length}")
-
-        csv_writer = csv.DictWriter(csv_file, fieldnames=header_names + data_names)
-        csv_writer.writeheader()
-        for model_name in args.models:
-            for input_count in [1, 2, 3]:
-                for engine_name in args.engines:
-                    for io_binding in [True, False, ""]:
-                        row = {}
-                        for result in results:
-                            if result["model_name"] == model_name and result["inputs"] == input_count and result[
-                                    "engine"] == engine_name and result["io_binding"] == io_binding:
-                                headers = {k: v for k, v in result.items() if k in header_names}
-                                if not row:
-                                    row.update(headers)
-                                    row.update({k: "" for k in data_names})
-                                else:
-                                    for k in header_names:
-                                        assert row[k] == headers[k]
-                                b = result["batch_size"]
-                                s = result["sequence_length"]
-                                row[f"b{b}_s{s}"] = result["average_latency_ms"]
-                        if row:
-                            csv_writer.writerow(row)
-
-    logger.info(f"Summary results are saved to csv file: {csv_filename}")
-
-
-def output_fusion_statistics(model_fusion_statistics, csv_filename):
-    from transformers import __version__ as transformers_version
-    with open(csv_filename, mode="a", newline='') as csv_file:
-        column_names = ["model_filename", "datetime", "transformers", "torch"] + list(
-            next(iter(model_fusion_statistics.values())).keys())
-        csv_writer = csv.DictWriter(csv_file, fieldnames=column_names)
-        csv_writer.writeheader()
-        for key in model_fusion_statistics.keys():
-            model_fusion_statistics[key]["datetime"] = str(datetime.now())
-            model_fusion_statistics[key]["transformers"] = transformers_version
-            model_fusion_statistics[key]["torch"] = torch.__version__
-            model_fusion_statistics[key]["model_filename"] = key
-            csv_writer.writerow(model_fusion_statistics[key])
-    logger.info(f"Fusion statistics is saved to csv file: {csv_filename}")
-
-
 def parse_arguments():
     parser = argparse.ArgumentParser()
 
@@ -700,14 +348,6 @@ def parse_arguments():
     return args
 
 
-def setup_logger(verbose):
-    if verbose:
-        coloredlogs.install(level='DEBUG', fmt='[%(filename)s:%(lineno)s - %(funcName)20s()] %(message)s')
-    else:
-        coloredlogs.install(fmt='%(message)s')
-        logging.getLogger("transformers").setLevel(logging.WARNING)
-
-
 def main():
     args = parse_arguments()
 
@@ -736,7 +376,7 @@ def main():
     results = []
 
     torch.set_num_threads(cpu_count if args.thread_num <= 0 else args.thread_num)
-    print(torch.__config__.parallel_info())
+    logger.debug(torch.__config__.parallel_info())
 
     if enable_torch or enable_torchscript:
         if args.input_counts != [1]:
@@ -750,12 +390,14 @@ def main():
             results += run_pytorch(args.use_gpu, args.models, args.precision, args.batch_sizes, args.sequence_lengths,
                                    args.test_times, False, args.cache_dir, args.verbose)
 
+    model_fusion_statistics = {}
     if enable_onnxruntime:
         try:
             results += run_onnxruntime(args.use_gpu, args.models, args.precision, args.batch_sizes,
                                        args.sequence_lengths, args.test_times, args.input_counts, args.optimize_onnx,
                                        args.validate_onnx, args.cache_dir, args.onnx_dir, args.verbose, args.overwrite,
-                                       args.disable_ort_io_binding, args.use_raw_attention_mask, args.thread_num)
+                                       args.disable_ort_io_binding, args.use_raw_attention_mask, args.thread_num,
+                                       model_fusion_statistics)
         except:
             logger.error(f"Exception", exc_info=True)
 

--- a/onnxruntime/python/tools/transformers/benchmark_gpt2.py
+++ b/onnxruntime/python/tools/transformers/benchmark_gpt2.py
@@ -9,7 +9,6 @@
 import os
 import sys
 import numpy
-import time
 import csv
 from datetime import datetime
 import psutil
@@ -17,248 +16,14 @@ import argparse
 import logging
 import torch
 import onnx
-from enum import Enum
-from transformers.modeling_utils import Conv1D
-from transformers import GPT2Model, GPT2LMHeadModel, GPT2Tokenizer, AutoConfig
+from transformers import AutoConfig
+from gpt2_helper import Gpt2Helper, MyGPT2Model, MyGPT2LMHeadModel, MODEL_CLASSES, DEFAULT_TOLERANCE
+from quantize_helper import QuantizeHelper
+from benchmark_helper import create_onnxruntime_session, setup_logger, prepare_environment, Precision
 
 logger = logging.getLogger('')
 
-
-# Wrap a class for Onnx model export.
-class MyGPT2Model(GPT2Model):
-    def __init__(self, config):
-        super().__init__(config)
-
-    def forward(self, input_ids, position_ids, attention_mask, *past):
-        return super().forward(input_ids, position_ids=position_ids, attention_mask=attention_mask, past=past)
-
-
-class MyGPT2LMHeadModel(GPT2LMHeadModel):
-    def __init__(self, config):
-        super().__init__(config)
-
-    def forward(self, input_ids, position_ids, attention_mask, *past):
-        return super().forward(input_ids, position_ids=position_ids, attention_mask=attention_mask, past=past)
-
-
-class Precision(Enum):
-    FLOAT32 = 'fp32'
-    FLOAT16 = 'fp16'
-    INT8 = 'int8'
-
-    def __str__(self):
-        return self.value
-
-
 PRETRAINED_MODELS = ['gpt2', 'distilgpt2']
-
-MODEL_CLASSES = {'GPT2LMHeadModel': (MyGPT2LMHeadModel, 'logits'), 'GPT2Model': (MyGPT2Model, 'last_state')}
-
-
-def pytorch_inference(model, inputs, total_runs=100):
-    logger.debug(f"start pytorch_inference")
-    input_ids, position_ids, attention_mask, past = inputs
-
-    # Convert it back to fp32 as the PyTroch model cannot deal with half input.
-    if attention_mask is not None:
-        attention_mask = attention_mask.to(dtype=torch.float32)
-    past = [p.to(dtype=torch.float32) for p in past]
-
-    input_list = [input_ids, position_ids, attention_mask] + past
-    latency = []
-    with torch.no_grad():
-        for _ in range(total_runs):
-            start = time.time()
-            outputs = model(*input_list)
-            latency.append(time.time() - start)
-
-    average_latency = sum(latency) * 1000 / len(latency)
-    logger.debug("PyTorch Inference time = {} ms".format(format(average_latency, '.2f')))
-    logger.debug(f"PyTorch output 0 shape={outputs[0].shape}")
-    logger.debug(f"PyTorch outputs[1][0] shape={outputs[1][0].shape}")
-    return outputs, average_latency
-
-
-def onnxruntime_inference(ort_session, inputs, total_runs=100):
-    logger.debug(f"start onnxruntime_inference")
-    input_ids, position_ids, attention_mask, past = inputs
-
-    ort_inputs = {'input_ids': numpy.ascontiguousarray(input_ids.cpu().numpy())}
-
-    if past is not None:
-        for i, past_i in enumerate(past):
-            ort_inputs[f'past_{i}'] = numpy.ascontiguousarray(past[i].cpu().numpy())
-
-    if attention_mask is not None:
-        ort_inputs['attention_mask'] = numpy.ascontiguousarray(attention_mask.cpu().numpy())
-
-    if position_ids is not None:
-        ort_inputs['position_ids'] = numpy.ascontiguousarray(position_ids.cpu().numpy())
-
-    latency = []
-    for _ in range(total_runs):
-        start = time.time()
-        ort_outputs = ort_session.run(None, ort_inputs)
-        latency.append(time.time() - start)
-
-    average_latency = sum(latency) * 1000 / len(latency)
-    logger.debug("OnnxRuntime Inference time = {} ms".format(format(average_latency, '.2f')))
-
-    return ort_outputs, average_latency
-
-
-def get_dummy_inputs(batch_size, past_sequence_length, sequence_length, num_attention_heads, hidden_size, num_layer,
-                     vocab_size, device, float16):
-    float_type = torch.float16 if float16 else torch.float32
-    past_shape = [2, batch_size, num_attention_heads, past_sequence_length, int(hidden_size / num_attention_heads)]
-
-    past = [torch.rand(past_shape, dtype=float_type, device=device) for _ in range(num_layer)]
-    input_ids = torch.randint(low=0,
-                              high=vocab_size - 1,
-                              size=(batch_size, sequence_length),
-                              dtype=torch.int64,
-                              device=device)
-
-    total_sequence_length = past_sequence_length + sequence_length
-    attention_mask = torch.ones([batch_size, total_sequence_length], dtype=float_type, device=device)
-    if total_sequence_length >= 2:
-        attention_mask[:, total_sequence_length - 2] = 0  # set some to 0 for testing mask.
-
-    # Deduce position_ids from attention mask
-    position_ids = (attention_mask.long().cumsum(-1) - 1)
-    position_ids.masked_fill_(position_ids < 0, 0)
-    position_ids = position_ids[:, past_sequence_length:]
-
-    return input_ids, position_ids, attention_mask, past
-
-
-def get_output_shapes(batch_size, past_sequence_length, sequence_length, config, model_class):
-    num_attention_heads = config.num_attention_heads
-    hidden_size = config.hidden_size
-    num_layer = config.n_layer
-    vocab_size = config.vocab_size
-
-    output_name = MODEL_CLASSES[model_class][1]
-
-    last_state_shape = [batch_size, sequence_length, vocab_size if model_class == "GPT2LMHeadModel" else hidden_size]
-    present_state_shape = [
-        2, batch_size, num_attention_heads, past_sequence_length + sequence_length,
-        int(hidden_size / num_attention_heads)
-    ]
-
-    output_shapes = {output_name: last_state_shape}
-    for i in range(num_layer):
-        output_shapes["present_" + str(i)] = present_state_shape
-
-    return output_shapes
-
-
-def get_output_buffers(output_shapes, device, is_float16):
-    data_type = torch.float16 if is_float16 else torch.float32
-
-    output_buffers = {}
-    for name, shape in output_shapes.items():
-        output_buffers[name] = torch.empty(numpy.prod(shape), dtype=data_type, device=device)
-    return output_buffers
-
-
-def onnxruntime_inference_with_binded_io(ort_session, inputs, output_buffers, output_shapes, total_runs=100):
-    logger.debug(f"start onnxruntime_inference_with_binded_io")
-    input_ids, position_ids, attention_mask, past = inputs
-
-    # Bind inputs and outputs to onnxruntime session
-    io_binding = ort_session.io_binding()
-
-    # Bind inputs
-    io_binding.bind_input('input_ids', input_ids.device.type, 0, numpy.longlong, list(input_ids.size()),
-                          input_ids.data_ptr())
-
-    data_type = output_buffers[ort_session.get_outputs()[0].name].dtype
-    float_type = numpy.float16 if data_type == torch.float16 else numpy.float32
-
-    if past is not None:
-        for i, past_i in enumerate(past):
-            io_binding.bind_input(f'past_{i}', past[i].device.type, 0, float_type, list(past[i].size()),
-                                  past[i].data_ptr())
-
-    if attention_mask is not None:
-        io_binding.bind_input('attention_mask', attention_mask.device.type, 0, float_type, list(attention_mask.size()),
-                              attention_mask.data_ptr())
-
-    if position_ids is not None:
-        io_binding.bind_input('position_ids', position_ids.device.type, 0, numpy.longlong, list(position_ids.size()),
-                              position_ids.data_ptr())
-
-    # Bind outputs
-    for output in ort_session.get_outputs():
-        output_name = output.name
-        output_buffer = output_buffers[output_name]
-        logger.debug(f"{output_name} device type={output_buffer.device.type} shape={list(output_buffer.size())}")
-        io_binding.bind_output(output_name, output_buffer.device.type, 0, float_type, output_shapes[output_name],
-                               output_buffer.data_ptr())
-
-    latency = []
-    for _ in range(total_runs):
-        start = time.time()
-        # Run onnxruntime with io binding
-        ort_session.run_with_iobinding(io_binding)
-        latency.append(time.time() - start)
-
-    average_latency = sum(latency) * 1000 / len(latency)
-    logger.debug("OnnxRuntime with IO binding inference time = {} ms".format(format(average_latency, '.2f')))
-
-    # Copy results to cpu for verification
-    ort_outputs = []
-    for output in ort_session.get_outputs():
-        output_name = output.name
-        buffer = output_buffers[output_name]
-        shape = output_shapes[output_name]
-        ort_outputs.append(buffer[0:numpy.prod(shape)].reshape(shape).cpu())
-
-    return ort_outputs, average_latency
-
-
-def inference(model,
-              ort_session,
-              inputs,
-              output_buffers,
-              output_shapes,
-              total_runs=100,
-              verify_outputs=True,
-              disable_ort_io_binding=False):
-    outputs, torch_latency = pytorch_inference(model, inputs, total_runs)
-    ort_outputs, ort_latency = onnxruntime_inference(ort_session, inputs, total_runs)
-    latencies = [torch_latency, ort_latency]
-    if verify_outputs:
-        logger.info('Verifying Pytorch and ONNX Runtime outputs.')
-        verify_ort_outputs(model, outputs, ort_outputs)
-
-    if not disable_ort_io_binding:
-        ort_io_outputs, ort_io_latency = onnxruntime_inference_with_binded_io(ort_session, inputs, output_buffers,
-                                                                              output_shapes, total_runs)
-        latencies.append(ort_io_latency)
-        if verify_outputs:
-            logger.info('Verifying Pytorch and ONNX Runtime with io binding outputs.')
-            verify_ort_outputs(model, outputs, ort_io_outputs)
-
-    return latencies
-
-
-def verify_ort_outputs(model, torch_outputs, ort_outputs):
-    is_close = numpy.allclose(ort_outputs[0], torch_outputs[0].cpu(), rtol=1e-05, atol=1e-04)
-    logger.debug(f'PyTorch and OnnxRuntime output 0 (last_state) are close: {is_close}')
-
-    is_all_close = is_close
-    num_layers = len(ort_outputs) - 1
-    for layer in range(num_layers):
-        is_close = numpy.allclose(ort_outputs[1 + layer], torch_outputs[1][layer].cpu(), rtol=1e-05, atol=1e-04)
-        logger.debug(f'PyTorch and OnnxRuntime layer {layer} state (present_{layer}) are close:{is_close}')
-        is_all_close = is_all_close and is_close
-
-    if not is_all_close:
-        logger.warning(f'Failed: PyTorch and OnnxRuntime results are not all close.')
-    else:
-        logger.info(f'Passed: PyTorch and OnnxRuntime results are all close.')
 
 
 def parse_arguments():
@@ -305,19 +70,12 @@ def parse_arguments():
                         help='Use optimizer.py to optimize onnx model')
     parser.set_defaults(optimize_onnx=False)
 
-    parser.add_argument('--disable_ort_io_binding',
-                        required=False,
-                        action='store_true',
-                        help='Disable running ONNX Runtime with binded inputs and outputs. ')
-    parser.set_defaults(disable_ort_io_binding=False)
-
     parser.add_argument('--use_gpu', required=False, action='store_true', help="use GPU for inference")
     parser.set_defaults(use_gpu=False)
 
     parser.add_argument(
         "-p",
         "--precision",
-        required=True,
         type=Precision,
         default=Precision.FLOAT32,
         choices=list(Precision),
@@ -347,147 +105,6 @@ def parse_arguments():
     return args
 
 
-def setup_logger(verbose=True):
-    # output logging to stdout
-    log_handler = logging.StreamHandler(sys.stdout)
-    if verbose:
-        log_handler.setFormatter(logging.Formatter('[%(filename)s:%(lineno)s - %(funcName)20s()] %(message)s'))
-        logging_level = logging.DEBUG
-    else:
-        log_handler.setFormatter(logging.Formatter('%(filename)20s: %(message)s'))
-        logging_level = logging.INFO
-        logging.getLogger("transformers").setLevel(logging.ERROR)
-    log_handler.setLevel(logging_level)
-
-    # Avoid duplicated handlers when runing this script in multiple cells of Jupyter Notebook.
-    if not logger.hasHandlers():
-        logger.addHandler(log_handler)
-
-    logger.setLevel(logging_level)
-
-
-def export_onnx(model, config, device, onnx_model_path, verbose):
-    """ Export GPT-2 model with past state to ONNX model
-    """
-    num_layer = config.n_layer
-    dummy_inputs = get_dummy_inputs(batch_size=1,
-                                    past_sequence_length=1,
-                                    sequence_length=1,
-                                    num_attention_heads=config.num_attention_heads,
-                                    hidden_size=config.hidden_size,
-                                    num_layer=num_layer,
-                                    vocab_size=config.vocab_size,
-                                    device=device,
-                                    float16=False)
-
-    dummy_input_ids, dummy_position_ids, dummy_attention_mask, dummy_past = dummy_inputs
-
-    input_list = [dummy_input_ids, dummy_position_ids, dummy_attention_mask] + dummy_past
-    with torch.no_grad():
-        outputs = model(*input_list)
-
-    past_names = [f'past_{i}' for i in range(num_layer)]
-    present_names = [f'present_{i}' for i in range(num_layer)]
-
-    # GPT2Model outputs last_state; GPT2LMHeadModel outputs logits (prediction_scores)
-    assert outputs[0].shape[2] == config.vocab_size or outputs[0].shape[2] == config.hidden_size
-    output_names = ["logits" if outputs[0].shape[2] == config.vocab_size else "last_state"] + present_names
-
-    # Shape of input tensors:
-    #    input_ids: (batch_size, seq_len)
-    #    past_{i}:  (2, batch_size, num_heads, past_seq_len, hidden_size/num_heads)
-    #    attention_mask: (batch_size, past_seq_len + seq_len)
-    # Shape of output tensors:
-    #    last_state: (batch_size, seq_len, hidden_size)
-    #      or logits: (batch_size, seq_len, vocab_size)
-    #    present_{i}:  (2, batch_size, num_heads, past_seq_len + seq_len, hidden_size/num_heads)
-    dynamic_axes = {'input_ids': {0: 'batch_size', 1: 'seq_len'}, output_names[0]: {0: 'batch_size', 1: 'seq_len'}}
-    for name in past_names:
-        dynamic_axes[name] = {1: 'batch_size', 3: 'past_seq_len'}
-    for name in present_names:
-        dynamic_axes[name] = {1: 'batch_size', 3: 'total_seq_len'}
-
-    dynamic_axes['attention_mask'] = {0: 'batch_size', 1: 'total_seq_len'}
-    dynamic_axes['position_ids'] = {0: 'batch_size', 1: 'seq_len'}
-
-    logger.info(
-        f"Shapes: input_ids={dummy_input_ids.shape} past={dummy_past[0].shape} output={outputs[0].shape} present={outputs[1][0].shape}"
-    )
-
-    torch.onnx.export(model,
-                      args=tuple(input_list),
-                      f=onnx_model_path,
-                      input_names=['input_ids', 'position_ids', 'attention_mask'] + past_names,
-                      output_names=output_names,
-                      example_outputs=outputs,
-                      dynamic_axes=dynamic_axes,
-                      opset_version=11,
-                      do_constant_folding=True,
-                      verbose=verbose)
-    return onnx_model_path
-
-
-def create_onnxruntime_session(onnx_model_path, use_gpu, verbose, thread_num):
-    session = None
-    try:
-        from onnxruntime import SessionOptions, InferenceSession
-        sess_options = SessionOptions()
-        sess_options.intra_op_num_threads = thread_num
-        logger.debug(f"Session option: intra_op_num_threads={sess_options.intra_op_num_threads}")
-
-        if verbose:
-            sess_options.log_severity_level = 0
-
-        logger.debug(f"Create session for onnx model: {onnx_model_path}")
-        execution_providers = ['CPUExecutionProvider'
-                               ] if not use_gpu else ['CUDAExecutionProvider', 'CPUExecutionProvider']
-        session = InferenceSession(onnx_model_path, sess_options, providers=execution_providers)
-    except:
-        logger.error(f"Exception", exc_info=True)
-
-    return session
-
-
-def quantize_onnx_model(onnx_model_path, quantized_model_path):
-    from onnxruntime.quantization import quantize, QuantizationMode
-    onnx_opt_model = onnx.load(onnx_model_path)
-    quantized_onnx_model = quantize(onnx_opt_model,
-                                    quantization_mode=QuantizationMode.IntegerOps,
-                                    symmetric_weight=True,
-                                    force_fusions=True)
-    onnx.save(quantized_onnx_model, quantized_model_path)
-    logger.info(f"quantized model saved to:{quantized_model_path}")
-
-
-def _conv1d_to_linear(module):
-    in_size, out_size = module.weight.shape
-    linear = torch.nn.Linear(in_size, out_size)
-    linear.weight.data = module.weight.data.T.contiguous()
-    linear.bias.data = module.bias.data
-    return linear
-
-
-def conv1d_to_linear(model):
-    '''in-place
-    This is for Dynamic Quantization, as Conv1D is not recognized by PyTorch, convert it to nn.Linear
-    '''
-    for name in list(model._modules):
-        module = model._modules[name]
-        if isinstance(module, Conv1D):
-            linear = _conv1d_to_linear(module)
-            model._modules[name] = linear
-            print(name)
-        else:
-            conv1d_to_linear(module)
-
-
-def quantize_model(model, dtype=torch.qint8):
-    # TODO: mix of in-place and return, but results are different
-    # Usage model = quantize_model(model)
-    conv1d_to_linear(model)
-    return torch.quantization.quantize_dynamic(model, {torch.nn.Linear}, dtype=dtype)
-
-
 def main():
     args = parse_arguments()
     setup_logger(args.verbose)
@@ -503,19 +120,13 @@ def main():
     print(torch.__config__.parallel_info())
 
     cache_dir = args.cache_dir
-    if not os.path.exists(cache_dir):
-        os.makedirs(cache_dir)
-
     output_dir = args.onnx_dir
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+    prepare_environment(cache_dir, output_dir, args.use_gpu)
 
     model_class = MODEL_CLASSES[args.model_class][0]
 
-    model_name = args.model_name
-    config = AutoConfig.from_pretrained(model_name, torchscript=args.torchscript, cache_dir=cache_dir)
-    model = model_class.from_pretrained(model_name, config=config, cache_dir=cache_dir)
-    tokenizer = GPT2Tokenizer.from_pretrained(model_name, cache_dir=cache_dir)
+    config = AutoConfig.from_pretrained(args.model_name, torchscript=args.torchscript, cache_dir=cache_dir)
+    model = model_class.from_pretrained(args.model_name, config=config, cache_dir=cache_dir)
 
     # This scirpt does not support float16 for PyTorch.
     #if args.float16:
@@ -524,70 +135,45 @@ def main():
     device = torch.device("cuda:0" if args.use_gpu else "cpu")
     model.to(device)
 
-    model_name = "{}_{}_past_mask.onnx".format(args.model_name, args.model_class)
-    onnx_model_path = os.path.join(output_dir, model_name)
-    export_onnx(model, config, device, onnx_model_path, args.verbose)
+    onnx_model_paths = Gpt2Helper.get_onnx_paths(output_dir, args.model_name, args.model_class)
 
-    import onnxruntime
+    onnx_model_path = onnx_model_paths["raw"]
+    Gpt2Helper.export_onnx(model, device, onnx_model_path, args.verbose)
 
-    if args.use_gpu:
-        assert 'CUDAExecutionProvider' in onnxruntime.get_available_providers(
-        ), "Please install onnxruntime-gpu package to test GPU inference."
+    if args.optimize_onnx or args.precision != Precision.FLOAT32:
+        onnx_model_path = onnx_model_paths[str(args.precision)]
+        Gpt2Helper.optimize_onnx(onnx_model_paths["raw"], onnx_model_path, args.precision == Precision.FLOAT16,
+                                 model.config.num_attention_heads, model.config.hidden_size)
 
-    if args.optimize_onnx:
-        from optimizer import optimize_model
-        m = optimize_model(onnx_model_path,
-                           model_type='gpt2',
-                           num_heads=config.num_attention_heads,
-                           hidden_size=config.hidden_size,
-                           opt_level=0,
-                           optimization_options=None,
-                           use_gpu=args.use_gpu)
-        if args.precision == Precision.FLOAT16:
-            m.convert_model_float32_to_float16(cast_input_output=False)
-
-        filename_suffix = '_{}_{}.onnx'.format("gpu" if args.use_gpu else "cpu", args.precision)
-        onnx_model_path = onnx_model_path.replace(".onnx", filename_suffix)
-        m.save_model_to_file(onnx_model_path)
-
-    if args.precision == Precision.INT8:
-        print("quantizing model")
-        quantize_onnx_model(onnx_model_path, onnx_model_path)
-        conv1d_to_linear(model)
-        model = torch.quantization.quantize_dynamic(model, {torch.nn.Linear}, dtype=torch.qint8)
-        print("finished")
-
-    session = create_onnxruntime_session(onnx_model_path, args.use_gpu, args.verbose, args.thread_num)
-    if session is None:
-        return
+        if args.precision == Precision.INT8:
+            logger.info("quantizing model...")
+            QuantizeHelper.quantize_onnx_model(onnx_model_path, onnx_model_path)
+            model = QuantizeHelper.quantize_torch_model(model)
+            logger.info("finished quantizing model")
 
     if args.torchscript:
-        dummy_inputs = get_dummy_inputs(batch_size=1,
-                                        past_sequence_length=1,
-                                        sequence_length=1,
-                                        num_attention_heads=config.num_attention_heads,
-                                        hidden_size=config.hidden_size,
-                                        num_layer=config.n_layer,
-                                        vocab_size=config.vocab_size,
-                                        device=device,
-                                        float16=False)
-        dummy_input_ids, dummy_position_ids, dummy_attention_mask, dummy_past = dummy_inputs
-        model = torch.jit.trace(model, [dummy_input_ids, dummy_position_ids, dummy_attention_mask] + dummy_past)
+        model = Gpt2Helper.torchscript(model, config, device)
+
+    session = create_onnxruntime_session(onnx_model_path,
+                                         args.use_gpu,
+                                         enable_all_optimization=False,
+                                         num_threads=args.thread_num,
+                                         verbose=args.verbose)
+    if session is None:
+        return
 
     # One word is generated for each inference. This length does not include that of past state.
     sequence_length = 1
 
     # Allocate output buffers for IO Binding
-    output_buffers = {}
-    if not args.disable_ort_io_binding:
-        max_output_shapes = get_output_shapes(max(args.batch_sizes), max(args.past_sequence_lengths), sequence_length,
-                                              config, args.model_class)
-        output_buffers = get_output_buffers(max_output_shapes, device, args.precision == Precision.FLOAT16)
+    max_output_shapes = Gpt2Helper.get_output_shapes(max(args.batch_sizes), max(args.past_sequence_lengths),
+                                                     sequence_length, config, args.model_class)
+    output_buffers = Gpt2Helper.get_output_buffers(max_output_shapes, device, args.precision == Precision.FLOAT16)
 
     csv_filename = args.result_csv or "benchmark_result_{}.csv".format(datetime.now().strftime("%Y%m%d-%H%M%S"))
     with open(csv_filename, mode="a", newline='') as csv_file:
         column_names = [
-            "model_name", "model_class", "gpu", "precision", "optimizer", "io_binding", "batch_size",
+            "model_name", "model_class", "gpu", "precision", "optimizer", "torchscript", "batch_size",
             "past_sequence_length", "torch_latency", "ort_latency", "ort_io_latency"
         ]
         csv_writer = csv.DictWriter(csv_file, fieldnames=column_names)
@@ -596,24 +182,36 @@ def main():
         for batch_size in args.batch_sizes:
             for past_sequence_length in args.past_sequence_lengths:
                 logger.debug(f"Running test for batch_size={batch_size} past_sequence_length={past_sequence_length}...")
-                dummy_inputs = get_dummy_inputs(batch_size, past_sequence_length, sequence_length,
-                                                config.num_attention_heads, config.hidden_size, config.n_layer,
-                                                config.vocab_size, device, args.precision == Precision.FLOAT16)
-                output_shapes = get_output_shapes(batch_size, past_sequence_length, sequence_length, config,
-                                                  args.model_class)
+                dummy_inputs = Gpt2Helper.get_dummy_inputs(batch_size, past_sequence_length, sequence_length,
+                                                           config.num_attention_heads, config.hidden_size,
+                                                           config.n_layer, config.vocab_size, device,
+                                                           args.precision == Precision.FLOAT16)
+                output_shapes = Gpt2Helper.get_output_shapes(batch_size, past_sequence_length, sequence_length, config,
+                                                             args.model_class)
 
                 try:
-                    latencies = inference(model,
-                                          session,
-                                          dummy_inputs,
-                                          output_buffers,
-                                          output_shapes,
-                                          args.test_times,
-                                          verify_outputs=args.validate_onnx,
-                                          disable_ort_io_binding=args.disable_ort_io_binding)
-                    ort_io_latency_info = f", ort_io_latency={latencies[2]:.2f}" if not args.disable_ort_io_binding else ""
+                    outputs, torch_latency = Gpt2Helper.pytorch_inference(model, dummy_inputs, args.test_times)
+                    ort_outputs, ort_latency = Gpt2Helper.onnxruntime_inference(session, dummy_inputs, args.test_times)
+                    ort_io_outputs, ort_io_latency = Gpt2Helper.onnxruntime_inference_with_binded_io(
+                        session, dummy_inputs, output_buffers, output_shapes, args.test_times)
+                    if args.validate_onnx:
+                        if Gpt2Helper.compare_outputs(outputs,
+                                                      ort_outputs,
+                                                      rtol=DEFAULT_TOLERANCE[args.precision],
+                                                      atol=DEFAULT_TOLERANCE[args.precision]):
+                            logger.info(
+                                f'Pytorch and ONNX Runtime outputs are all close (tolerance={DEFAULT_TOLERANCE[args.precision]}).'
+                            )
+                        if Gpt2Helper.compare_outputs(outputs,
+                                                      ort_io_outputs,
+                                                      rtol=DEFAULT_TOLERANCE[args.precision],
+                                                      atol=DEFAULT_TOLERANCE[args.precision]):
+                            logger.info(
+                                f'Pytorch and ONNX Runtime IO Binding outputs are all close (tolerance={DEFAULT_TOLERANCE[args.precision]}).'
+                            )
+
                     logger.info(
-                        f"batch_size={batch_size}, past_sequence_length={past_sequence_length}, torch_latency={latencies[0]:.2f}, ort_latency={latencies[1]:.2f}{ort_io_latency_info}"
+                        f"batch_size={batch_size}, past_sequence_length={past_sequence_length}, torch_latency={torch_latency:.2f}, ort_latency={ort_latency:.2f}, ort_io_latency={ort_io_latency:.2f}"
                     )
 
                     row = {
@@ -622,16 +220,17 @@ def main():
                         "gpu": args.use_gpu,
                         "precision": args.precision,
                         "optimizer": args.optimize_onnx,
-                        "io_binding": not args.disable_ort_io_binding,
+                        "torchscript": args.torchscript,
                         "batch_size": batch_size,
                         "past_sequence_length": past_sequence_length,
-                        "torch_latency": f"{latencies[0]:.2f}",
-                        "ort_latency": f"{latencies[1]:.2f}",
-                        "ort_io_latency": f"{latencies[2]:.2f}" if not args.disable_ort_io_binding else ""
+                        "torch_latency": f"{torch_latency:.2f}",
+                        "ort_latency": f"{ort_latency:.2f}",
+                        "ort_io_latency": f"{ort_io_latency:.2f}"
                     }
                     csv_writer.writerow(row)
                 except:
                     logger.error(f"Exception", exc_info=True)
+
     logger.info(f"Results are saved to file {csv_filename}")
 
 

--- a/onnxruntime/python/tools/transformers/benchmark_gpt2.py
+++ b/onnxruntime/python/tools/transformers/benchmark_gpt2.py
@@ -17,7 +17,7 @@ import logging
 import torch
 import onnx
 from transformers import AutoConfig
-from gpt2_helper import Gpt2Helper, MyGPT2Model, MyGPT2LMHeadModel, MODEL_CLASSES, DEFAULT_TOLERANCE
+from gpt2_helper import Gpt2Helper, MODEL_CLASSES, DEFAULT_TOLERANCE
 from quantize_helper import QuantizeHelper
 from benchmark_helper import create_onnxruntime_session, setup_logger, prepare_environment, Precision
 

--- a/onnxruntime/python/tools/transformers/benchmark_helper.py
+++ b/onnxruntime/python/tools/transformers/benchmark_helper.py
@@ -1,0 +1,96 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import os
+import sys
+import numpy
+import time
+import argparse
+import logging
+import torch
+import onnx
+from enum import Enum
+
+logger = logging.getLogger('')
+
+
+class Precision(Enum):
+    FLOAT32 = 'fp32'
+    FLOAT16 = 'fp16'
+    INT8 = 'int8'
+
+    def __str__(self):
+        return self.value
+
+
+def create_onnxruntime_session(onnx_model_path, use_gpu, enable_all_optimization=True, num_threads=0, verbose=False):
+    session = None
+    try:
+        from onnxruntime import SessionOptions, InferenceSession, GraphOptimizationLevel
+        sess_options = SessionOptions()
+
+        if enable_all_optimization:
+            sess_options.graph_optimization_level = GraphOptimizationLevel.ORT_ENABLE_ALL
+        else:
+            sess_options.graph_optimization_level = GraphOptimizationLevel.ORT_ENABLE_BASIC
+
+        if num_threads > 0:
+            sess_options.intra_op_num_threads = num_threads
+            logger.debug(f"Session option: intra_op_num_threads={sess_options.intra_op_num_threads}")
+
+        if verbose:
+            sess_options.log_severity_level = 0
+
+        logger.debug(f"Create session for onnx model: {onnx_model_path}")
+        execution_providers = ['CPUExecutionProvider'
+                               ] if not use_gpu else ['CUDAExecutionProvider', 'CPUExecutionProvider']
+        session = InferenceSession(onnx_model_path, sess_options, providers=execution_providers)
+    except:
+        logger.error(f"Exception", exc_info=True)
+
+    return session
+
+
+def setup_logger(verbose=True):
+    # output logging to stdout
+    log_handler = logging.StreamHandler(sys.stdout)
+    if verbose:
+        log_handler.setFormatter(logging.Formatter('[%(filename)s:%(lineno)s - %(funcName)20s()] %(message)s'))
+        logging_level = logging.DEBUG
+    else:
+        log_handler.setFormatter(logging.Formatter('%(filename)20s: %(message)s'))
+        logging_level = logging.INFO
+        logging.getLogger("transformers").setLevel(logging.ERROR)
+    log_handler.setLevel(logging_level)
+
+    # Avoid duplicated handlers when runing this script in multiple cells of Jupyter Notebook.
+    if not logger.hasHandlers():
+        logger.addHandler(log_handler)
+
+    logger.setLevel(logging_level)
+
+
+def prepare_environment(cache_dir, output_dir, use_gpu):
+    if cache_dir and not os.path.exists(cache_dir):
+        os.makedirs(cache_dir)
+
+    if output_dir and not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    import onnxruntime
+    if use_gpu:
+        assert 'CUDAExecutionProvider' in onnxruntime.get_available_providers(
+        ), "Please install onnxruntime-gpu package to test GPU inference."
+
+    import transformers
+    logger.info(f'PyTorch Version:{torch.__version__}')
+    logger.info(f'Transformers Version:{transformers.__version__}')
+    logger.info(f'Onnxruntime Version:{onnxruntime.__version__}')
+
+    from packaging import version
+    assert version.parse(torch.__version__) >= version.parse('1.4.0')
+    assert version.parse(transformers.__version__) >= version.parse('2.11.0')
+    assert version.parse(onnxruntime.__version__) >= version.parse('1.4.0')

--- a/onnxruntime/python/tools/transformers/benchmark_helper.py
+++ b/onnxruntime/python/tools/transformers/benchmark_helper.py
@@ -10,11 +10,11 @@ import numpy
 import time
 import argparse
 import logging
+import coloredlogs
 import torch
 import onnx
 from enum import Enum
 from packaging import version
-
 
 logger = logging.getLogger(__name__)
 
@@ -61,22 +61,11 @@ def create_onnxruntime_session(onnx_model_path, use_gpu, enable_all_optimization
 
 
 def setup_logger(verbose=True):
-    # output logging to stdout
-    log_handler = logging.StreamHandler(sys.stdout)
     if verbose:
-        log_handler.setFormatter(logging.Formatter('[%(filename)s:%(lineno)s - %(funcName)20s()] %(message)s'))
-        logging_level = logging.DEBUG
+        coloredlogs.install(level='DEBUG', fmt='[%(filename)s:%(lineno)s - %(funcName)20s()] %(message)s')
     else:
-        log_handler.setFormatter(logging.Formatter('%(filename)20s: %(message)s'))
-        logging_level = logging.INFO
-        logging.getLogger("transformers").setLevel(logging.ERROR)
-    log_handler.setLevel(logging_level)
-
-    # Avoid duplicated handlers when runing this script in multiple cells of Jupyter Notebook.
-    if not logger.hasHandlers():
-        logger.addHandler(log_handler)
-
-    logger.setLevel(logging_level)
+        coloredlogs.install(fmt='%(message)s')
+        logging.getLogger("transformers").setLevel(logging.WARNING)
 
 
 def prepare_environment(cache_dir, output_dir, use_gpu):

--- a/onnxruntime/python/tools/transformers/benchmark_helper.py
+++ b/onnxruntime/python/tools/transformers/benchmark_helper.py
@@ -6,8 +6,11 @@
 
 import os
 import sys
+import csv
 import numpy
 import time
+import timeit
+from datetime import datetime
 import argparse
 import logging
 import coloredlogs
@@ -89,3 +92,134 @@ def prepare_environment(cache_dir, output_dir, use_gpu):
     assert version.parse(torch.__version__) >= version.parse('1.4.0')
     assert version.parse(transformers.__version__) >= version.parse('2.11.0')
     assert version.parse(onnxruntime.__version__) >= version.parse('1.4.0')
+
+
+def get_latency_result(runtimes, batch_size):
+    latency_ms = sum(runtimes) / float(len(runtimes)) * 1000.0
+    latency_variance = numpy.var(runtimes, dtype=numpy.float64) * 1000.0
+    throughput = batch_size * (1000.0 / latency_ms)
+
+    return {
+        "test_times": len(runtimes),
+        "latency_variance": "{:.2f}".format(latency_variance),
+        "latency_90_percentile": "{:.2f}".format(numpy.percentile(runtimes, 90) * 1000.0),
+        "latency_95_percentile": "{:.2f}".format(numpy.percentile(runtimes, 95) * 1000.0),
+        "latency_99_percentile": "{:.2f}".format(numpy.percentile(runtimes, 99) * 1000.0),
+        "average_latency_ms": "{:.2f}".format(latency_ms),
+        "QPS": "{:.2f}".format(throughput),
+    }
+
+
+def output_details(results, csv_filename):
+    with open(csv_filename, mode="a", newline='') as csv_file:
+        column_names = [
+            "engine", "version", "device", "precision", "optimizer", "io_binding", "model_name", "inputs", "batch_size",
+            "sequence_length", "datetime", "test_times", "QPS", "average_latency_ms", "latency_variance",
+            "latency_90_percentile", "latency_95_percentile", "latency_99_percentile"
+        ]
+
+        csv_writer = csv.DictWriter(csv_file, fieldnames=column_names)
+        csv_writer.writeheader()
+        for result in results:
+            csv_writer.writerow(result)
+
+    logger.info(f"Detail results are saved to csv file: {csv_filename}")
+
+
+def output_summary(results, csv_filename, args):
+    with open(csv_filename, mode="a", newline='') as csv_file:
+        header_names = ["model_name", "inputs", "engine", "version", "device", "precision", "optimizer", "io_binding"]
+        data_names = []
+        for batch_size in args.batch_sizes:
+            for sequence_length in args.sequence_lengths:
+                data_names.append(f"b{batch_size}_s{sequence_length}")
+
+        csv_writer = csv.DictWriter(csv_file, fieldnames=header_names + data_names)
+        csv_writer.writeheader()
+        for model_name in args.models:
+            for input_count in [1, 2, 3]:
+                for engine_name in args.engines:
+                    for io_binding in [True, False, ""]:
+                        row = {}
+                        for result in results:
+                            if result["model_name"] == model_name and result["inputs"] == input_count and result[
+                                    "engine"] == engine_name and result["io_binding"] == io_binding:
+                                headers = {k: v for k, v in result.items() if k in header_names}
+                                if not row:
+                                    row.update(headers)
+                                    row.update({k: "" for k in data_names})
+                                else:
+                                    for k in header_names:
+                                        assert row[k] == headers[k]
+                                b = result["batch_size"]
+                                s = result["sequence_length"]
+                                row[f"b{b}_s{s}"] = result["average_latency_ms"]
+                        if row:
+                            csv_writer.writerow(row)
+
+    logger.info(f"Summary results are saved to csv file: {csv_filename}")
+
+
+def output_fusion_statistics(model_fusion_statistics, csv_filename):
+    from transformers import __version__ as transformers_version
+    with open(csv_filename, mode="a", newline='') as csv_file:
+        column_names = ["model_filename", "datetime", "transformers", "torch"] + list(
+            next(iter(model_fusion_statistics.values())).keys())
+        csv_writer = csv.DictWriter(csv_file, fieldnames=column_names)
+        csv_writer.writeheader()
+        for key in model_fusion_statistics.keys():
+            model_fusion_statistics[key]["datetime"] = str(datetime.now())
+            model_fusion_statistics[key]["transformers"] = transformers_version
+            model_fusion_statistics[key]["torch"] = torch.__version__
+            model_fusion_statistics[key]["model_filename"] = key
+            csv_writer.writerow(model_fusion_statistics[key])
+    logger.info(f"Fusion statistics is saved to csv file: {csv_filename}")
+
+
+def inference_ort(ort_session, ort_inputs, result_template, repeat_times, batch_size):
+    result = {}
+    runtimes = timeit.repeat(lambda: ort_session.run(None, ort_inputs), number=1, repeat=repeat_times)
+    result.update(result_template)
+    result.update({"io_binding": False})
+    result.update(get_latency_result(runtimes, batch_size))
+    return result
+
+
+def inference_ort_with_io_binding(ort_session, ort_inputs, result_template, repeat_times, ort_output_names, ort_outputs,
+                                  output_buffers, max_last_state_size, max_pooler_size, batch_size, device):
+    result = {}
+
+    # Bind inputs and outputs to onnxruntime session
+    io_binding = ort_session.io_binding()
+    # Bind inputs to device
+    for name in ort_inputs.keys():
+        np_input = torch.from_numpy(ort_inputs[name]).to(device)
+        io_binding.bind_input(name, np_input.device.type, 0, numpy.longlong, np_input.shape, np_input.data_ptr())
+    has_pooler = True if len(ort_output_names) == 2 else False
+    # Bind outputs buffers with the sizes needed if not allocated already
+    if output_buffers["last_state"] is None:
+        allocateOutputBuffers(output_buffers, max_last_state_size, max_pooler_size, device, has_pooler)
+    last_state_buffer = output_buffers["last_state"]
+    pooler_buffer = output_buffers["pooler"]
+    io_binding.bind_output(ort_output_names[0], last_state_buffer.device.type, 0, numpy.float32, ort_outputs[0].shape,
+                           last_state_buffer.data_ptr())
+    if has_pooler:
+        io_binding.bind_output(ort_output_names[1], pooler_buffer.device.type, 0, numpy.float32, ort_outputs[1].shape,
+                               pooler_buffer.data_ptr())
+
+    runtimes = timeit.repeat(lambda: ort_session.run_with_iobinding(io_binding), number=1, repeat=repeat_times)
+    result.update(result_template)
+    result.update({"io_binding": True})
+    result.update(get_latency_result(runtimes, batch_size))
+    return result
+
+
+def allocateOutputBuffers(output_buffers, max_last_state_size, max_pooler_size, device, has_pooler=False):
+    # Allocate output tensors with the largest test size needed. So the allocated memory can be reused
+    # for each test run.
+    # dummy last state
+    if output_buffers["last_state"] is None:
+        output_buffers["last_state"] = torch.empty(max_last_state_size, dtype=torch.float32, device=device)
+    # create dummy pooler
+    if output_buffers["pooler"] is None and has_pooler:
+        output_buffers["pooler"] = torch.empty(max_pooler_size, dtype=torch.float32, device=device)

--- a/onnxruntime/python/tools/transformers/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/convert_to_onnx.py
@@ -1,0 +1,138 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import os
+import argparse
+import logging
+import torch
+from transformers import AutoConfig
+from gpt2_helper import Gpt2Helper, MyGPT2Model, MyGPT2LMHeadModel, MODEL_CLASSES, DEFAULT_TOLERANCE
+from quantize_helper import QuantizeHelper
+from benchmark_helper import create_onnxruntime_session, setup_logger, prepare_environment, Precision
+logger = logging.getLogger('')
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-m',
+                        '--model_name_or_path',
+                        required=True,
+                        type=str,
+                        help='Model path, or pretrained model name in the list: ' + ', '.join(['gpt2', 'distilgpt2']))
+
+    parser.add_argument('--model_class',
+                        required=False,
+                        type=str,
+                        default='GPT2LMHeadModel',
+                        choices=list(MODEL_CLASSES.keys()),
+                        help='Model type selected in the list: ' + ', '.join(MODEL_CLASSES.keys()))
+
+    parser.add_argument('--cache_dir',
+                        required=False,
+                        type=str,
+                        default=os.path.join('.', 'cache_models'),
+                        help='Directory to cache pre-trained models')
+
+    parser.add_argument('--output',
+                        required=False,
+                        type=str,
+                        default=os.path.join('.', 'onnx_models'),
+                        help='Output directory, or model path ends with .onnx')
+
+    parser.add_argument('-o',
+                        '--optimize_onnx',
+                        required=False,
+                        action='store_true',
+                        help='Use optimizer.py to optimize onnx model')
+    parser.set_defaults(optimize_onnx=False)
+
+    parser.add_argument('--use_gpu', required=False, action='store_true', help="use GPU for inference")
+    parser.set_defaults(use_gpu=False)
+
+    parser.add_argument('--tolerance',
+                        required=False,
+                        type=float,
+                        default=0,
+                        help="the aboslute and relative tolerance for parity verification")
+
+    parser.add_argument(
+        "-p",
+        "--precision",
+        required=False,
+        type=Precision,
+        default=Precision.FLOAT32,
+        choices=list(Precision),
+        help="Precision of model to run. fp32 for full precision, fp16 for half precision, and int8 for quantization")
+
+    parser.add_argument('--verbose', required=False, action='store_true')
+    parser.set_defaults(verbose=False)
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main():
+    args = parse_arguments()
+    setup_logger(args.verbose)
+
+    if args.tolerance == 0:
+        args.tolerance = DEFAULT_TOLERANCE[args.precision]
+
+    logger.info(f"Arguments:{args}")
+
+    cache_dir = args.cache_dir
+    output_dir = args.output if not args.output.endswith(".onnx") else os.path.dirname(args.output)
+    prepare_environment(cache_dir, output_dir, args.use_gpu)
+
+    if args.precision != Precision.FLOAT32:
+        assert args.optimize_onnx, "fp16/int8 requires --optimize_onnx"
+
+    if args.precision == Precision.FLOAT16:
+        assert args.use_gpu, "fp16 requires --use_gpu"
+
+    if args.precision == Precision.INT8:
+        assert not args.use_gpu, "quantization only supports CPU"
+
+    model_class = MODEL_CLASSES[args.model_class][0]
+    model = model_class.from_pretrained(args.model_name_or_path, cache_dir=cache_dir)
+
+    device = torch.device("cuda:0" if args.use_gpu else "cpu")
+    model.eval().to(device)
+
+    onnx_model_paths = Gpt2Helper.get_onnx_paths(output_dir, args.model_name_or_path, args.model_class)
+    raw_onnx_model = args.output if args.output.endswith('.onnx') else onnx_model_paths["raw"]
+    output_path = raw_onnx_model if (
+        args.output.endswith('.onnx') or
+        (args.precision == Precision.FLOAT32 and not args.optimize_onnx)) else onnx_model_paths[str(args.precision)]
+
+    Gpt2Helper.export_onnx(model, device, raw_onnx_model, args.verbose)
+
+    if args.optimize_onnx or args.precision != Precision.FLOAT32:
+        Gpt2Helper.optimize_onnx(raw_onnx_model, output_path, args.precision == Precision.FLOAT16,
+                                 model.config.num_attention_heads, model.config.hidden_size)
+
+    if args.precision == Precision.INT8:
+        logger.info("quantizing model...")
+        QuantizeHelper.quantize_onnx_model(output_path, output_path)
+        model = QuantizeHelper.quantize_torch_model(model)
+        logger.info("finished quantizing model")
+
+    session = create_onnxruntime_session(output_path, args.use_gpu, enable_optimizations=False, verbose=args.verbose)
+    if session is not None:
+        Gpt2Helper.test_parity(session,
+                               model,
+                               device,
+                               args.precision == Precision.FLOAT16,
+                               rtol=args.tolerance,
+                               atol=args.tolerance)
+
+    logger.info(f"Done. Output model: {output_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/onnxruntime/python/tools/transformers/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/convert_to_onnx.py
@@ -20,7 +20,7 @@ import coloredlogs
 import logging
 import torch
 from transformers import AutoConfig
-from gpt2_helper import Gpt2Helper, MyGPT2Model, MyGPT2LMHeadModel, MODEL_CLASSES, DEFAULT_TOLERANCE
+from gpt2_helper import Gpt2Helper, MODEL_CLASSES, DEFAULT_TOLERANCE
 from quantize_helper import QuantizeHelper
 from benchmark_helper import create_onnxruntime_session, setup_logger, prepare_environment, Precision
 

--- a/onnxruntime/python/tools/transformers/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/convert_to_onnx.py
@@ -3,15 +3,27 @@
 # Licensed under the MIT License.  See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+"""
+This converts GPT2 model to onnx. Examples:
+(1) Convert pretrained model 'gpt2' to ONNX
+   python convert_to_onnx.py -m gpt2 --output gpt2.onnx
+(2) Convert pretrained model 'distilgpt2' to ONNX, and use optimizer to get float16 model.
+   python convert_to_onnx.py -m distilgpt2 --output distilgpt2_fp16.onnx -o -p fp16
+(3) Convert a model check point to ONNX, and run optimization and int8 quantization
+   python convert_to_onnx.py -m ./my_model_checkpoint/ --output my_model_int8.onnx -o -p int8
+
+"""
 
 import os
 import argparse
+import coloredlogs
 import logging
 import torch
 from transformers import AutoConfig
 from gpt2_helper import Gpt2Helper, MyGPT2Model, MyGPT2LMHeadModel, MODEL_CLASSES, DEFAULT_TOLERANCE
 from quantize_helper import QuantizeHelper
 from benchmark_helper import create_onnxruntime_session, setup_logger, prepare_environment, Precision
+
 logger = logging.getLogger('')
 
 
@@ -122,7 +134,7 @@ def main():
         model = QuantizeHelper.quantize_torch_model(model)
         logger.info("finished quantizing model")
 
-    session = create_onnxruntime_session(output_path, args.use_gpu, enable_optimizations=False, verbose=args.verbose)
+    session = create_onnxruntime_session(output_path, args.use_gpu, enable_all_optimization=False, verbose=args.verbose)
     if session is not None:
         Gpt2Helper.test_parity(session,
                                model,

--- a/onnxruntime/python/tools/transformers/dev_benchmark.cmd
+++ b/onnxruntime/python/tools/transformers/dev_benchmark.cmd
@@ -32,7 +32,7 @@ set average_over=100
 REM Enable optimizer (use script instead of OnnxRuntime for graph optimization)
 set use_optimizer=true
 
-set batch_sizes=1 16
+set batch_sizes=1
 set sequence_length=8 128
 
 REM Number of inputs (input_ids, token_type_ids, attention_mask) for ONNX model.
@@ -40,7 +40,7 @@ REM Note that different input count might lead to different performance
 set input_counts=1
 
 REM Pretrained transformers models can be a subset of: bert-base-cased roberta-base gpt2 distilgpt2 distilbert-base-uncased
-set models_to_test=bert-base-cased gpt2
+set models_to_test=bert-base-cased
 
 REM If you have mutliple GPUs, you can choose one GPU for test. Here is an example to use the second GPU:
 REM set CUDA_VISIBLE_DEVICES=1
@@ -61,10 +61,14 @@ if %run_install% == true (
   pip uninstall --yes ort_nightly
   pip uninstall --yes onnxruntime
   pip uninstall --yes onnxruntime-gpu
-  if %run_cpu% == true (
+  if %run_cpu_fp32% == true (
     pip install onnxruntime
   ) else (
-    pip install --upgrade onnxruntime-gpu
+    if %run_cpu_fp32% == true (
+      pip install onnxruntime
+    ) else (
+      pip install --upgrade onnxruntime-gpu
+    )
   )
 
   pip install --upgrade onnxruntime-tools

--- a/onnxruntime/python/tools/transformers/gpt2_helper.py
+++ b/onnxruntime/python/tools/transformers/gpt2_helper.py
@@ -1,0 +1,388 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+# This script benchmarks gpt2 model with past state.
+# For gpt2 model without past state, use benchmark.py to measure performance.
+import os
+import logging
+import torch
+import onnx
+import random
+import numpy
+import time
+from transformers import GPT2Model, GPT2LMHeadModel, GPT2Config
+from benchmark_helper import Precision
+
+logger = logging.getLogger('')
+
+DEFAULT_TOLERANCE = {Precision.FLOAT32: 0.0005, Precision.FLOAT16: 0.2, Precision.INT8: 3.0}
+
+
+# Here we wrap a class to disable past state output.
+class GPT2ModelNoPastState(GPT2Model):
+    def __init__(self, config):
+        super().__init__(config)
+
+    def forward(self, input_ids):
+        return super().forward(input_ids, use_cache=False)
+
+
+# Wrap a class for Onnx model export.
+class MyGPT2Model(GPT2Model):
+    def __init__(self, config):
+        super().__init__(config)
+
+    def forward(self, input_ids, position_ids, attention_mask, *past):
+        return super().forward(input_ids, position_ids=position_ids, attention_mask=attention_mask, past=past)
+
+
+class MyGPT2LMHeadModel(GPT2LMHeadModel):
+    def __init__(self, config):
+        super().__init__(config)
+
+    def forward(self, input_ids, position_ids, attention_mask, *past):
+        return super().forward(input_ids, position_ids=position_ids, attention_mask=attention_mask, past=past)
+
+
+MODEL_CLASSES = {'GPT2LMHeadModel': (MyGPT2LMHeadModel, 'logits'), 'GPT2Model': (MyGPT2Model, 'last_state')}
+
+
+class Gpt2Helper:
+    @staticmethod
+    def get_dummy_inputs(batch_size, past_sequence_length, sequence_length, num_attention_heads, hidden_size, num_layer,
+                         vocab_size, device, float16):
+        float_type = torch.float16 if float16 else torch.float32
+        past_shape = [2, batch_size, num_attention_heads, past_sequence_length, int(hidden_size / num_attention_heads)]
+
+        past = [torch.rand(past_shape, dtype=float_type, device=device) for _ in range(num_layer)]
+        input_ids = torch.randint(low=0,
+                                  high=vocab_size - 1,
+                                  size=(batch_size, sequence_length),
+                                  dtype=torch.int64,
+                                  device=device)
+
+        total_sequence_length = past_sequence_length + sequence_length
+        attention_mask = torch.ones([batch_size, total_sequence_length], dtype=float_type, device=device)
+        if total_sequence_length >= 2:
+            padding_position = random.randint(0, total_sequence_length - 1)  # test input with padding.
+            attention_mask[:, padding_position] = 0
+
+        # Deduce position_ids from attention mask
+        position_ids = (attention_mask.long().cumsum(-1) - 1)
+        position_ids.masked_fill_(position_ids < 0, 0)
+        position_ids = position_ids[:, past_sequence_length:]
+
+        return input_ids, position_ids, attention_mask, past
+
+    @staticmethod
+    def get_output_shapes(batch_size, past_sequence_length, sequence_length, config, model_class):
+        num_attention_heads = config.num_attention_heads
+        hidden_size = config.hidden_size
+        num_layer = config.num_hidden_layers
+        vocab_size = config.vocab_size
+
+        output_name = MODEL_CLASSES[model_class][1]
+
+        last_state_shape = [
+            batch_size, sequence_length, vocab_size if model_class == "GPT2LMHeadModel" else hidden_size
+        ]
+        present_state_shape = [
+            2, batch_size, num_attention_heads, past_sequence_length + sequence_length,
+            int(hidden_size / num_attention_heads)
+        ]
+
+        output_shapes = {output_name: last_state_shape}
+        for i in range(num_layer):
+            output_shapes["present_" + str(i)] = present_state_shape
+
+        return output_shapes
+
+    @staticmethod
+    def get_output_buffers(output_shapes, device, is_float16):
+        data_type = torch.float16 if is_float16 else torch.float32
+
+        output_buffers = {}
+        for name, shape in output_shapes.items():
+            output_buffers[name] = torch.empty(numpy.prod(shape), dtype=data_type, device=device)
+        return output_buffers
+
+    @staticmethod
+    def diff_outputs(torch_outputs, ort_outputs, relative=False):
+        expected_outputs = torch_outputs[0].cpu().numpy()
+        diff = numpy.abs(expected_outputs - ort_outputs[0])
+        if relative:
+            return numpy.amax(diff / (numpy.abs(expected_outputs) + 1e-6))
+        else:
+            return numpy.amax(diff)
+
+    @staticmethod
+    def compare_outputs(torch_outputs, ort_outputs, rtol=1e-03, atol=1e-03):
+        is_close = numpy.allclose(ort_outputs[0], torch_outputs[0].cpu(), rtol=rtol, atol=atol)
+        logger.debug(f'PyTorch and OnnxRuntime output 0 (last_state) are close: {is_close}')
+
+        is_all_close = is_close
+        num_layers = len(ort_outputs) - 1
+        for layer in range(num_layers):
+            is_close = numpy.allclose(ort_outputs[1 + layer], torch_outputs[1][layer].cpu(), rtol=rtol, atol=atol)
+            logger.debug(f'PyTorch and OnnxRuntime layer {layer} state (present_{layer}) are close:{is_close}')
+            is_all_close = is_all_close and is_close
+
+        if not is_all_close:
+            max_abs_diff = Gpt2Helper.diff_outputs(torch_outputs, ort_outputs)
+            logger.info(f'PyTorch and OnnxRuntime results are not all close: max_abs_diff={max_abs_diff:.5f}')
+
+        return is_all_close
+
+    @staticmethod
+    def export_onnx(model, device, onnx_model_path, verbose=False):
+        """ Export GPT-2 model with past state to ONNX model
+        """
+        config: GPT2Config = model.config
+        num_layer = config.n_layer
+        dummy_inputs = Gpt2Helper.get_dummy_inputs(batch_size=1,
+                                                   past_sequence_length=1,
+                                                   sequence_length=1,
+                                                   num_attention_heads=config.num_attention_heads,
+                                                   hidden_size=config.hidden_size,
+                                                   num_layer=num_layer,
+                                                   vocab_size=config.vocab_size,
+                                                   device=device,
+                                                   float16=False)
+
+        dummy_input_ids, dummy_position_ids, dummy_attention_mask, dummy_past = dummy_inputs
+
+        input_list = [dummy_input_ids, dummy_position_ids, dummy_attention_mask] + dummy_past
+        with torch.no_grad():
+            outputs = model(*input_list)
+
+        past_names = [f'past_{i}' for i in range(num_layer)]
+        present_names = [f'present_{i}' for i in range(num_layer)]
+
+        # GPT2Model outputs last_state; GPT2LMHeadModel outputs logits (prediction_scores)
+        assert outputs[0].shape[2] == config.vocab_size or outputs[0].shape[2] == config.hidden_size
+        output_names = ["logits" if outputs[0].shape[2] == config.vocab_size else "last_state"] + present_names
+
+        # Shape of input tensors:
+        #    input_ids: (batch_size, seq_len)
+        #    past_{i}:  (2, batch_size, num_heads, past_seq_len, hidden_size/num_heads)
+        #    attention_mask: (batch_size, past_seq_len + seq_len)
+        # Shape of output tensors:
+        #    last_state: (batch_size, seq_len, hidden_size)
+        #      or logits: (batch_size, seq_len, vocab_size)
+        #    present_{i}:  (2, batch_size, num_heads, past_seq_len + seq_len, hidden_size/num_heads)
+        dynamic_axes = {'input_ids': {0: 'batch_size', 1: 'seq_len'}, output_names[0]: {0: 'batch_size', 1: 'seq_len'}}
+        for name in past_names:
+            dynamic_axes[name] = {1: 'batch_size', 3: 'past_seq_len'}
+        for name in present_names:
+            dynamic_axes[name] = {1: 'batch_size', 3: 'total_seq_len'}
+
+        dynamic_axes['attention_mask'] = {0: 'batch_size', 1: 'total_seq_len'}
+        dynamic_axes['position_ids'] = {0: 'batch_size', 1: 'seq_len'}
+
+        logger.info(
+            f"Shapes: input_ids={dummy_input_ids.shape} past={dummy_past[0].shape} output={outputs[0].shape} present={outputs[1][0].shape}"
+        )
+
+        torch.onnx.export(model,
+                          args=tuple(input_list),
+                          f=onnx_model_path,
+                          input_names=['input_ids', 'position_ids', 'attention_mask'] + past_names,
+                          output_names=output_names,
+                          example_outputs=outputs,
+                          dynamic_axes=dynamic_axes,
+                          opset_version=11,
+                          do_constant_folding=True,
+                          verbose=verbose)
+
+    def optimize_onnx(onnx_model_path, optimized_model_path, is_float16, num_attention_heads, hidden_size):
+        from optimizer import optimize_model
+        m = optimize_model(onnx_model_path,
+                           model_type='gpt2',
+                           num_heads=num_attention_heads,
+                           hidden_size=hidden_size,
+                           opt_level=0,
+                           optimization_options=None,
+                           use_gpu=False)
+        if is_float16:
+            m.convert_model_float32_to_float16(cast_input_output=False)
+
+        m.save_model_to_file(optimized_model_path)
+
+    @staticmethod
+    def pytorch_inference(model, inputs, total_runs=0):
+        logger.debug(f"start pytorch_inference")
+        input_ids, position_ids, attention_mask, past = inputs
+
+        # Convert it back to fp32 as the PyTroch model cannot deal with half input.
+        if attention_mask is not None:
+            attention_mask = attention_mask.to(dtype=torch.float32)
+        past = [p.to(dtype=torch.float32) for p in past]
+
+        input_list = [input_ids, position_ids, attention_mask] + past
+
+        with torch.no_grad():
+            outputs = model(*input_list)
+
+        if total_runs == 0:
+            return ort_outputs
+
+        latency = []
+        with torch.no_grad():
+            for _ in range(total_runs):
+                start = time.time()
+                outputs = model(*input_list)
+                latency.append(time.time() - start)
+
+        average_latency = sum(latency) * 1000 / len(latency)
+        logger.debug("PyTorch inference time = {} ms".format(format(average_latency, '.2f')))
+
+        return outputs, average_latency
+
+    @staticmethod
+    def onnxruntime_inference(ort_session, inputs, total_runs=0):
+        logger.debug(f"start onnxruntime_inference")
+        input_ids, position_ids, attention_mask, past = inputs
+
+        ort_inputs = {'input_ids': numpy.ascontiguousarray(input_ids.cpu().numpy())}
+
+        if past is not None:
+            for i, past_i in enumerate(past):
+                ort_inputs[f'past_{i}'] = numpy.ascontiguousarray(past[i].cpu().numpy())
+
+        if attention_mask is not None:
+            ort_inputs['attention_mask'] = numpy.ascontiguousarray(attention_mask.cpu().numpy())
+
+        if position_ids is not None:
+            ort_inputs['position_ids'] = numpy.ascontiguousarray(position_ids.cpu().numpy())
+
+        ort_outputs = ort_session.run(None, ort_inputs)
+        if total_runs == 0:
+            return ort_outputs
+
+        latency = []
+        for _ in range(total_runs):
+            start = time.time()
+            ort_outputs = ort_session.run(None, ort_inputs)
+            latency.append(time.time() - start)
+
+        average_latency = sum(latency) * 1000 / len(latency)
+        logger.debug("OnnxRuntime Inference time = {} ms".format(format(average_latency, '.2f')))
+
+        return ort_outputs, average_latency
+
+    @staticmethod
+    def onnxruntime_inference_with_binded_io(ort_session, inputs, output_buffers, output_shapes, total_runs=0):
+        logger.debug(f"start onnxruntime_inference_with_binded_io")
+        input_ids, position_ids, attention_mask, past = inputs
+
+        # Bind inputs and outputs to onnxruntime session
+        io_binding = ort_session.io_binding()
+
+        # Bind inputs
+        io_binding.bind_input('input_ids', input_ids.device.type, 0, numpy.longlong, list(input_ids.size()),
+                              input_ids.data_ptr())
+
+        data_type = output_buffers[ort_session.get_outputs()[0].name].dtype
+        float_type = numpy.float16 if data_type == torch.float16 else numpy.float32
+
+        if past is not None:
+            for i, past_i in enumerate(past):
+                io_binding.bind_input(f'past_{i}', past[i].device.type, 0, float_type, list(past[i].size()),
+                                      past[i].data_ptr())
+
+        if attention_mask is not None:
+            io_binding.bind_input('attention_mask', attention_mask.device.type, 0, float_type,
+                                  list(attention_mask.size()), attention_mask.data_ptr())
+
+        if position_ids is not None:
+            io_binding.bind_input('position_ids', position_ids.device.type, 0, numpy.longlong,
+                                  list(position_ids.size()), position_ids.data_ptr())
+
+        # Bind outputs
+        for output in ort_session.get_outputs():
+            output_name = output.name
+            output_buffer = output_buffers[output_name]
+            logger.debug(f"{output_name} device type={output_buffer.device.type} shape={list(output_buffer.size())}")
+            io_binding.bind_output(output_name, output_buffer.device.type, 0, float_type, output_shapes[output_name],
+                                   output_buffer.data_ptr())
+
+        # Copy results to cpu for verification
+        ort_outputs = []
+        for output in ort_session.get_outputs():
+            output_name = output.name
+            buffer = output_buffers[output_name]
+            shape = output_shapes[output_name]
+            ort_outputs.append(buffer[0:numpy.prod(shape)].reshape(shape).cpu())
+
+        if total_runs == 0:
+            return ort_outputs
+
+        latency = []
+        for _ in range(total_runs):
+            start = time.time()
+            # Run onnxruntime with io binding
+            ort_session.run_with_iobinding(io_binding)
+            latency.append(time.time() - start)
+
+        average_latency = sum(latency) * 1000 / len(latency)
+        logger.debug("OnnxRuntime with IO binding inference time = {} ms".format(format(average_latency, '.2f')))
+
+        return ort_outputs, average_latency
+
+    @staticmethod
+    def test_parity(ort_session, model, device, is_float16=False, rtol=5e-4, atol=5e-4, total_test_cases=100):
+        config: GPT2Config = model.config
+
+        passed_test_cases = 0
+        for _ in range(total_test_cases):
+            sequence_length = random.randint(1, 32)
+            past_sequence_length = random.randint(0, 128)
+            batch_size = random.randint(1, 16)
+
+            logger.debug(
+                f"Running parity test for batch_size={batch_size} past_sequence_length={past_sequence_length}...")
+            dummy_inputs = Gpt2Helper.get_dummy_inputs(batch_size, past_sequence_length, sequence_length,
+                                                       config.num_attention_heads, config.hidden_size, config.n_layer,
+                                                       config.vocab_size, device, is_float16)
+            outputs = Gpt2Helper.pytorch_inference(model, dummy_inputs)
+            ort_outputs = Gpt2Helper.onnxruntime_inference(ort_session, dummy_inputs)
+            is_all_close = Gpt2Helper.compare_outputs(outputs, ort_outputs, rtol=rtol, atol=atol)
+            if is_all_close:
+                passed_test_cases += 1
+        logger.info(f"Parity Test Cases={total_test_cases}; Passed={passed_test_cases} (rtol={rtol}, atol={atol})")
+        if passed_test_cases > 0.95 * total_test_cases:
+            logger.info(f"Parity is good: passed rate={int(passed_test_cases*100/total_test_cases):.0f}%")
+        return passed_test_cases == total_test_cases
+
+    @staticmethod
+    def torchscript(model, config, device):
+        dummy_inputs = Gpt2Helper.get_dummy_inputs(batch_size=1,
+                                                   past_sequence_length=1,
+                                                   sequence_length=1,
+                                                   num_attention_heads=config.num_attention_heads,
+                                                   hidden_size=config.hidden_size,
+                                                   num_layer=config.n_layer,
+                                                   vocab_size=config.vocab_size,
+                                                   device=device,
+                                                   float16=False)
+        dummy_input_ids, dummy_position_ids, dummy_attention_mask, dummy_past = dummy_inputs
+        return torch.jit.trace(model, [dummy_input_ids, dummy_position_ids, dummy_attention_mask] + dummy_past)
+
+    @staticmethod
+    def get_onnx_paths(output_dir, model_name_or_path, model_class: str = 'GPT2LMHeadModel', has_past=True):
+        model_name = model_name_or_path if model_name_or_path.isalnum() else os.path.dirname(model_name_or_path)
+
+        if model_class != 'GPT2LMHeadModel':
+            model_name += "_" + model_class
+
+        if has_past:
+            model_name += "_past"
+
+        return {
+            "raw": os.path.join(output_dir, model_name + ".onnx"),
+            "fp32": os.path.join(output_dir, model_name + "_fp32.onnx"),
+            "fp16": os.path.join(output_dir, model_name + "_fp16.onnx"),
+            "int8": os.path.join(output_dir, model_name + "_int8.onnx")
+        }

--- a/onnxruntime/python/tools/transformers/gpt2_helper.py
+++ b/onnxruntime/python/tools/transformers/gpt2_helper.py
@@ -3,8 +3,7 @@
 # Licensed under the MIT License.  See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-# This script benchmarks gpt2 model with past state.
-# For gpt2 model without past state, use benchmark.py to measure performance.
+# This script helps onnx conversion and validation for GPT2 model with past state.
 import os
 import logging
 import torch

--- a/onnxruntime/python/tools/transformers/gpt2_helper.py
+++ b/onnxruntime/python/tools/transformers/gpt2_helper.py
@@ -29,7 +29,7 @@ class GPT2ModelNoPastState(GPT2Model):
         return super().forward(input_ids, use_cache=False)
 
 
-# Wrap a class for Onnx model export.
+# Wrap a class for Onnx model conversion for GPT2 model with past state
 class MyGPT2Model(GPT2Model):
     def __init__(self, config):
         super().__init__(config)
@@ -226,7 +226,7 @@ class Gpt2Helper:
             outputs = model(*input_list)
 
         if total_runs == 0:
-            return ort_outputs
+            return outputs
 
         latency = []
         with torch.no_grad():

--- a/onnxruntime/python/tools/transformers/gpt2_helper.py
+++ b/onnxruntime/python/tools/transformers/gpt2_helper.py
@@ -335,6 +335,8 @@ class Gpt2Helper:
     def test_parity(ort_session, model, device, is_float16=False, rtol=5e-4, atol=5e-4, total_test_cases=100):
         config: GPT2Config = model.config
 
+        logger.info(f"Running parity test (rtol={rtol}, atol={atol}, test_cases={total_test_cases}) ...")
+
         passed_test_cases = 0
         for _ in range(total_test_cases):
             sequence_length = random.randint(1, 32)
@@ -351,7 +353,7 @@ class Gpt2Helper:
             is_all_close = Gpt2Helper.compare_outputs(outputs, ort_outputs, rtol=rtol, atol=atol)
             if is_all_close:
                 passed_test_cases += 1
-        logger.info(f"Parity Test Cases={total_test_cases}; Passed={passed_test_cases} (rtol={rtol}, atol={atol})")
+        logger.info(f"Parity Test Cases={total_test_cases}; Passed={passed_test_cases}")
         if passed_test_cases > 0.95 * total_test_cases:
             logger.info(f"Parity is good: passed rate={int(passed_test_cases*100/total_test_cases):.0f}%")
         return passed_test_cases == total_test_cases

--- a/onnxruntime/python/tools/transformers/gpt2_helper.py
+++ b/onnxruntime/python/tools/transformers/gpt2_helper.py
@@ -15,7 +15,7 @@ import time
 from transformers import GPT2Model, GPT2LMHeadModel, GPT2Config
 from benchmark_helper import Precision
 
-logger = logging.getLogger('')
+logger = logging.getLogger(__name__)
 
 DEFAULT_TOLERANCE = {Precision.FLOAT32: 0.0005, Precision.FLOAT16: 0.2, Precision.INT8: 3.0}
 

--- a/onnxruntime/python/tools/transformers/machine_info.py
+++ b/onnxruntime/python/tools/transformers/machine_info.py
@@ -61,7 +61,7 @@ class MachineInfo():
         """Get CPU info"""
         cpu_info = cpuinfo.get_cpu_info()
         return {
-            "brand": cpu_info["brand"],
+            "brand": cpu_info["brand"] if "brand" in cpu_info else cpu_info["brand_raw"],
             "cores": psutil.cpu_count(logical=False),
             "logical_cores": psutil.cpu_count(logical=True),
             "hz": cpu_info["hz_actual"],

--- a/onnxruntime/python/tools/transformers/onnx_exporter.py
+++ b/onnxruntime/python/tools/transformers/onnx_exporter.py
@@ -1,0 +1,235 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import logging
+import numpy
+import os
+import torch
+from transformers import AutoConfig, AutoTokenizer, AutoModel
+from benchmark_helper import create_onnxruntime_session, Precision
+from gpt2_helper import GPT2ModelNoPastState
+from quantize_helper import QuantizeHelper
+
+logger = logging.getLogger(__name__)
+
+
+def create_onnxruntime_input(vocab_size, batch_size, sequence_length, input_names):
+    input_ids = numpy.random.randint(low=0, high=vocab_size - 1, size=(batch_size, sequence_length), dtype=numpy.int64)
+
+    inputs = {'input_ids': input_ids}
+
+    if "attention_mask" in input_names:
+        attention_mask = numpy.ones([batch_size, sequence_length], dtype=numpy.int64)
+        inputs['attention_mask'] = attention_mask
+
+    if "token_type_ids" in input_names:
+        segment_ids = numpy.zeros([batch_size, sequence_length], dtype=numpy.int64)
+        inputs['token_type_ids'] = segment_ids
+
+    return inputs
+
+
+def filter_inputs(inputs, input_names):
+    remaining_model_inputs = {}
+    for input_name in input_names:
+        remaining_model_inputs[input_name] = inputs[input_name]
+    return remaining_model_inputs
+
+
+def flatten(inputs):
+    return [[flatten(i) for i in inputs] if isinstance(inputs, (list, tuple)) else inputs]
+
+
+def update_flatten_list(inputs, res_list):
+    for i in inputs:
+        res_list.append(i) if not isinstance(i, (list, tuple)) else update_flatten_list(i, res_list)
+    return res_list
+
+
+def build_dynamic_axes(example_inputs, outputs_flatten):
+    sequence_length = example_inputs["input_ids"].shape[-1]
+
+    dynamic_axes = {key: {0: 'batch_size', 1: 'seq_len'} for key in example_inputs.keys()}
+
+    output_names = ['output_' + str(i + 1) for i in range(len(outputs_flatten))]
+    for i, output_name in enumerate(output_names):
+        dynamic_axes[output_name] = {0: 'batch_size'}
+        dims = outputs_flatten[i].shape
+        for j, dim in enumerate(dims):
+            if dim == sequence_length:
+                dynamic_axes[output_name].update({j: 'seq_len'})
+    return dynamic_axes, output_names
+
+
+def validate_onnx_model(onnx_model_path, example_inputs, example_outputs_flatten, use_gpu, fp16):
+    test_session = create_onnxruntime_session(onnx_model_path, use_gpu, enable_all_optimization=False)
+    if test_session is None:
+        logger.error(f"{onnx_model_path} is an invalid ONNX model")
+        return False
+
+    logger.info(f"{onnx_model_path} is a valid ONNX model")
+
+    # Compare the inference result with PyTorch
+    example_ort_inputs = {k: t.cpu().numpy() for k, t in example_inputs.items()}
+    example_ort_outputs = test_session.run(None, example_ort_inputs)
+    if len(example_outputs_flatten) != len(example_ort_outputs):
+        logger.error(
+            f"Number of output tensors expected {len(example_outputs_flatten)}, got {len(example_ort_outputs)}")
+        return False
+
+    for i in range(len(example_outputs_flatten)):
+        abs_diff = numpy.amax(numpy.abs(example_ort_outputs[i] - example_outputs_flatten[i].cpu().numpy()))
+        if abs_diff > 1e-4:
+            logger.info(f"Max absolute diff={abs_diff} for output tensor {i}")
+
+        rtol = 5e-02 if fp16 else 1e-4
+        atol = 1e-01 if fp16 else 1e-4
+        if not numpy.allclose(example_ort_outputs[i], example_outputs_flatten[i].cpu(), rtol=rtol, atol=atol):
+            logger.error(f"Output tensor {i} is not close: rtol={rtol}, atol={atol}")
+            return False
+
+    logger.info(f"inference result of onnxruntime is validated on {onnx_model_path}")
+    return True
+
+
+def get_onnx_file_path(onnx_dir: str, model_name: str, input_count: int, optimized_by_script: bool, use_gpu: bool,
+                       precision: Precision, optimized_by_onnxruntime: bool, use_external_data: bool):
+    if not optimized_by_script:
+        filename = f"{model_name}_{input_count}"
+    else:
+        device = "gpu" if use_gpu else "cpu"
+        filename = f"{model_name}_{input_count}_{precision}_{device}"
+
+    if optimized_by_onnxruntime:
+        filename += f"_ort"
+
+    directory = os.path.join(onnx_dir, filename) if use_external_data else onnx_dir
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+    return os.path.join(directory, f"{filename}.onnx")
+
+
+def optimize_onnx_model_by_ort(onnx_model_path, ort_model_path, use_gpu, overwrite, model_fusion_statistics):
+    if overwrite or not os.path.exists(ort_model_path):
+        from optimizer import optimize_by_onnxruntime, get_fusion_statistics
+        # Use onnxruntime to optimize model, which will be saved to *_ort.onnx
+        opt_model = optimize_by_onnxruntime(onnx_model_path,
+                                            use_gpu=use_gpu,
+                                            optimized_model_path=ort_model_path,
+                                            opt_level=99)
+        model_fusion_statistics[ort_model_path] = get_fusion_statistics(ort_model_path)
+    else:
+        logger.info(f"Skip optimization since model existed: {ort_model_path}")
+
+
+def optimize_onnx_model(onnx_model_path, optimized_model_path, model_type, num_attention_heads, hidden_size, use_gpu,
+                        fp16, use_raw_attention_mask, overwrite, model_fusion_statistics):
+    if overwrite or not os.path.exists(optimized_model_path):
+        from optimizer import optimize_model
+        from onnx_model_bert import BertOptimizationOptions
+        optimization_options = BertOptimizationOptions(model_type)
+        if use_raw_attention_mask:
+            optimization_options.use_raw_attention_mask()
+        if fp16:
+            optimization_options.enable_gelu_approximation = True
+
+        # Use script to optimize model.
+        # Use opt_level <= 1 for models to be converted to fp16, because some fused op (like FusedGemm) has only fp32 and no fp16.
+        # It is better to be conservative so we use opt_level=0 here, in case MemcpyFromHost is added to the graph by OnnxRuntime.
+        opt_model = optimize_model(onnx_model_path,
+                                   model_type,
+                                   num_heads=num_attention_heads,
+                                   hidden_size=hidden_size,
+                                   opt_level=0,
+                                   optimization_options=optimization_options,
+                                   use_gpu=use_gpu,
+                                   only_onnxruntime=False)
+        model_fusion_statistics[optimized_model_path] = opt_model.get_fused_operator_statistics()
+
+        if fp16:
+            opt_model.convert_model_float32_to_float16()
+        opt_model.save_model_to_file(optimized_model_path)
+    else:
+        logger.info(f"Skip optimization since model existed: {optimized_model_path}")
+
+
+def load_pretrained_model(model_name, config, cache_dir):
+    if model_name in ["gpt2", "distilgpt2", "gpt2-large"]:
+        return GPT2ModelNoPastState.from_pretrained(model_name, config=config, cache_dir=cache_dir)
+    return AutoModel.from_pretrained(model_name, config=config, cache_dir=cache_dir)
+
+
+def export_onnx_model(model_name, opset_version, use_external_data_format, model_type, cache_dir, onnx_dir, input_names,
+                      use_gpu, precision, optimize_onnx, validate_onnx, use_raw_attention_mask, overwrite,
+                      model_fusion_statistics):
+    config = AutoConfig.from_pretrained(model_name, cache_dir=cache_dir)
+    model = load_pretrained_model(model_name, config=config, cache_dir=cache_dir)
+    model.cpu()
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=cache_dir)
+    example_inputs = tokenizer.encode_plus("This is a sample input", return_tensors="pt")
+
+    example_inputs = filter_inputs(example_inputs, input_names)
+
+    example_outputs = model(**example_inputs)
+
+    assert isinstance(example_outputs, (list, tuple)), f"type of output is not list or tuple: {type(example_outputs)}"
+
+    # Flatten is needed for gpt2 and distilgpt2.
+    example_outputs_flatten = flatten(example_outputs)
+    example_outputs_flatten = update_flatten_list(example_outputs_flatten, [])
+
+    onnx_model_path = get_onnx_file_path(onnx_dir, model_name, len(input_names), False, use_gpu, precision, False,
+                                         use_external_data_format)
+
+    if overwrite or not os.path.exists(onnx_model_path):
+        logger.info("Exporting ONNX model to {}".format(onnx_model_path))
+
+        dynamic_axes, output_names = build_dynamic_axes(example_inputs, example_outputs_flatten)
+
+        torch.onnx.export(model=model,
+                          args=tuple(example_inputs.values()),
+                          f=onnx_model_path,
+                          input_names=list(example_inputs.keys()),
+                          output_names=output_names,
+                          example_outputs=example_outputs,
+                          dynamic_axes=dynamic_axes,
+                          do_constant_folding=True,
+                          opset_version=opset_version,
+                          use_external_data_format=use_external_data_format)
+    else:
+        logger.info(f"Skip export since model existed: {onnx_model_path}")
+
+    is_valid_onnx_model = True
+    if validate_onnx:
+        is_valid_onnx_model = validate_onnx_model(onnx_model_path, example_inputs, example_outputs_flatten, use_gpu,
+                                                  False)
+
+    if optimize_onnx or precision == Precision.FLOAT16 or precision == Precision.INT8:  # Use script (optimizer.py) to optimize
+        optimized_model_path = get_onnx_file_path(onnx_dir, model_name, len(input_names), True, use_gpu, precision,
+                                                  False, use_external_data_format)
+        optimize_onnx_model(onnx_model_path, optimized_model_path, model_type, config.num_attention_heads,
+                            config.hidden_size, use_gpu, precision == Precision.FLOAT16, use_raw_attention_mask,
+                            overwrite, model_fusion_statistics)
+
+        onnx_model_path = optimized_model_path
+        if validate_onnx:
+            is_valid_onnx_model = validate_onnx_model(onnx_model_path, example_inputs, example_outputs_flatten, use_gpu,
+                                                      precision == Precision.FLOAT16)
+
+        if precision == Precision.INT8:
+            logger.info(f"Quantizing model: {onnx_model_path}")
+            QuantizeHelper.quantize_onnx_model(onnx_model_path, onnx_model_path)
+            logger.info(f"Finished quantizing model: {onnx_model_path}")
+
+    else:  # Use OnnxRuntime to optimize
+        if is_valid_onnx_model:
+            ort_model_path = get_onnx_file_path(onnx_dir, model_name, len(input_names), False, use_gpu, precision, True,
+                                                use_external_data_format)
+            optimize_onnx_model_by_ort(onnx_model_path, ort_model_path, use_gpu, overwrite, model_fusion_statistics)
+
+    return onnx_model_path, is_valid_onnx_model, config.vocab_size, tokenizer.max_model_input_sizes[model_name]

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -206,7 +206,11 @@ class OnnxModel:
                 return i, matched, return_indice
         return -1, None, None
 
-    def match_parent_path(self, node, parent_op_types, parent_input_index, output_name_to_node=None,
+    def match_parent_path(self,
+                          node,
+                          parent_op_types,
+                          parent_input_index,
+                          output_name_to_node=None,
                           return_indice=None):
         '''
         Find a sequence of input edges based on constraints on parent op_type and index.

--- a/onnxruntime/python/tools/transformers/quantize_helper.py
+++ b/onnxruntime/python/tools/transformers/quantize_helper.py
@@ -1,0 +1,57 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import logging
+import torch
+import onnx
+from transformers.modeling_utils import Conv1D
+
+logger = logging.getLogger('')
+
+
+def _conv1d_to_linear(module):
+    in_size, out_size = module.weight.shape
+    linear = torch.nn.Linear(in_size, out_size)
+    linear.weight.data = module.weight.data.T.contiguous()
+    linear.bias.data = module.bias.data
+    return linear
+
+
+def conv1d_to_linear(model):
+    '''in-place
+    This is for Dynamic Quantization, as Conv1D is not recognized by PyTorch, convert it to nn.Linear
+    '''
+    logger.debug("replace Conv1D with Linear")
+    for name in list(model._modules):
+        module = model._modules[name]
+        if isinstance(module, Conv1D):
+            linear = _conv1d_to_linear(module)
+            model._modules[name] = linear
+        else:
+            conv1d_to_linear(module)
+
+
+class QuantizeHelper:
+    @staticmethod
+    def quantize_torch_model(model, dtype=torch.qint8):
+        '''
+        Usage: model = quantize_model(model)
+
+        TODO: mix of in-place and return, but results are different
+        '''
+        conv1d_to_linear(model)
+        return torch.quantization.quantize_dynamic(model, {torch.nn.Linear}, dtype=dtype)
+
+    @staticmethod
+    def quantize_onnx_model(onnx_model_path, quantized_model_path):
+        from onnxruntime.quantization import quantize, QuantizationMode
+        onnx_opt_model = onnx.load(onnx_model_path)
+        quantized_onnx_model = quantize(onnx_opt_model,
+                                        quantization_mode=QuantizationMode.IntegerOps,
+                                        symmetric_weight=True,
+                                        force_fusions=True)
+        onnx.save(quantized_onnx_model, quantized_model_path)
+        logger.info(f"quantized model saved to:{quantized_model_path}")

--- a/onnxruntime/python/tools/transformers/quantize_helper.py
+++ b/onnxruntime/python/tools/transformers/quantize_helper.py
@@ -9,7 +9,7 @@ import torch
 import onnx
 from transformers.modeling_utils import Conv1D
 
-logger = logging.getLogger('')
+logger = logging.getLogger(__name__)
 
 
 def _conv1d_to_linear(module):

--- a/onnxruntime/python/tools/transformers/run_benchmark.sh
+++ b/onnxruntime/python/tools/transformers/run_benchmark.sh
@@ -1,3 +1,8 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
 # This measures the performance of OnnxRuntime, PyTorch and TorchScript on transformer models.
 # Please install PyTorch (see https://pytorch.org/) before running this benchmark. Like the following:
 # GPU:   conda install pytorch torchvision cudatoolkit=10.1 -c pytorch

--- a/onnxruntime/python/tools/transformers/run_benchmark.sh
+++ b/onnxruntime/python/tools/transformers/run_benchmark.sh
@@ -84,7 +84,7 @@ if [ "$run_install" = true ] ; then
     pip install onnxruntime-gpu
   fi
   pip install --upgrade onnxruntime-tools
-  pip install transformers==2.11.0
+  pip install --upgrade transformers
 fi
 
 if [ "$run_cli" = true ] ; then

--- a/onnxruntime/python/tools/transformers/run_benchmark.sh
+++ b/onnxruntime/python/tools/transformers/run_benchmark.sh
@@ -78,7 +78,7 @@ if [ "$run_install" = true ] ; then
   pip uninstall --yes ort_nightly
   pip uninstall --yes onnxruntime
   pip uninstall --yes onnxruntime-gpu
-  if [ "$run_cpu" = true ] ; then
+  if [ "$run_cpu_fp32" = true ] || [ "$run_cpu_int8" = true ]; then
     pip install onnxruntime
   else
     pip install onnxruntime-gpu


### PR DESCRIPTION
**Description**:
Refactor benchmark:
(1) Move gpt2 to onnx conversion to a separate script convert_to_onnx.py
(2) Extract common functions of benchmark.py and benchmark_gpt2.py to benchmark_helper.py
(3) Add an option int run_benchmark.sh to test int8 inference

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
