### PR TITLE
[C++ API] add SessionOptions::SetLogSeverityLevel()

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -101,7 +101,9 @@ struct Base {
   Base& operator=(const Base&) = delete;
   Base(Base&& v) noexcept : p_{v.p_} { v.p_ = nullptr; }
   void operator=(Base&& v) noexcept {
-    OrtRelease(p_);
+    if (p_) {
+      OrtRelease(p_);
+    }
     p_ = v.p_;
     v.p_ = nullptr;
   }
@@ -190,6 +192,7 @@ struct SessionOptions : Base<OrtSessionOptions> {
   SessionOptions& SetExecutionMode(ExecutionMode execution_mode);
 
   SessionOptions& SetLogId(const char* logid);
+  SessionOptions& SetLogSeverityLevel(int level);
 
   SessionOptions& Add(OrtCustomOpDomain* custom_op_domain);
 

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -101,9 +101,7 @@ struct Base {
   Base& operator=(const Base&) = delete;
   Base(Base&& v) noexcept : p_{v.p_} { v.p_ = nullptr; }
   void operator=(Base&& v) noexcept {
-    if (p_) {
-      OrtRelease(p_);
-    }
+    OrtRelease(p_);
     p_ = v.p_;
     v.p_ = nullptr;
   }

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -218,6 +218,12 @@ inline SessionOptions& SessionOptions::SetLogId(const char* logid) {
   ThrowOnError(GetApi().SetSessionLogId(p_, logid));
   return *this;
 }
+
+inline SessionOptions& SessionOptions::SetLogSeverityLevel(int level) {
+  ThrowOnError(GetApi().SetSessionLogSeverityLevel(p_, level));
+  return *this;
+}
+
 inline SessionOptions& SessionOptions::Add(OrtCustomOpDomain* custom_op_domain) {
   ThrowOnError(GetApi().AddCustomOpDomain(p_, custom_op_domain));
   return *this;
@@ -620,7 +626,7 @@ inline SessionOptions& SessionOptions::DisablePerSessionThreads() {
 
 inline std::vector<std::string> GetAvailableProviders() {
   int len;
-  char **providers;
+  char** providers;
   const OrtApi& api = GetApi();
   ThrowOnError(api.GetAvailableProviders(&providers, &len));
   std::vector<std::string> available_providers(providers, providers + len);


### PR DESCRIPTION
**Description**: several fixes to C++ API

~~1. nullptr check~~
2. add function to set log level