### PR TITLE
Add OpKernelContext.Output() type overloads

### DIFF
--- a/include/onnxruntime/core/framework/op_kernel.h
+++ b/include/onnxruntime/core/framework/op_kernel.h
@@ -111,6 +111,8 @@ class OpKernelContext {
   // The memory allocation will be done on-the-fly with given tensor shape.
   // Return nullptr if the output is an unused optional output.
   Tensor* Output(int index, const TensorShape& shape);
+  Tensor* Output(int index, const std::vector<int64_t>& shape);
+  Tensor* Output(int index, const std::initializer_list<int64_t>& shape);
 
   // Fetch a required tensor output, enforcing that it is present.
   Tensor& RequiredOutput(int index, const TensorShape& shape) {

--- a/onnxruntime/core/framework/op_kernel.cc
+++ b/onnxruntime/core/framework/op_kernel.cc
@@ -25,6 +25,14 @@ Tensor* OpKernelContext::Output(int index, const TensorShape& shape) {
   return p_ml_value ? p_ml_value->GetMutable<Tensor>() : nullptr;
 }
 
+Tensor* OpKernelContext::Output(int index, const std::vector<int64_t>& shape) {
+  return Output(index, TensorShape(shape));
+}
+
+Tensor* OpKernelContext::Output(int index, const std::initializer_list<int64_t>& shape) {
+  return Output(index, TensorShape(shape));
+}
+
 SparseTensor* OpKernelContext::Output(int index, size_t nnz, const TensorShape& shape) {
   auto p_ml_value = OutputMLValue(index, shape, nnz);
   return p_ml_value ? p_ml_value->GetMutable<SparseTensor>() : nullptr;

--- a/onnxruntime/core/providers/cpu/generator/random.cc
+++ b/onnxruntime/core/providers/cpu/generator/random.cc
@@ -233,7 +233,7 @@ Status Multinomial::Compute(OpKernelContext* ctx) const {
     return Status(ONNXRUNTIME, INVALID_ARGUMENT, "num_samples is < 1");
   }
 
-  Tensor* Y = ctx->Output(0, TensorShape({batch_size, num_samples_}));
+  Tensor* Y = ctx->Output(0, {batch_size, num_samples_});
 
   Status status = Status::OK();
   std::lock_guard<onnxruntime::OrtMutex> l(generator_mutex_);
@@ -255,9 +255,7 @@ Status Multinomial::Compute(OpKernelContext* ctx) const {
 
 // create output tensor using shape of input tensor
 static Status CreateOutputTensorFromTensorShape(OpKernelContext* ctx, const Tensor& X, Tensor** Y) {
-  const TensorShape& shape = X.Shape();
-
-  *Y = ctx->Output(0, shape);
+  *Y = ctx->Output(0, X.Shape());
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/ml/cast_map.cc
+++ b/onnxruntime/core/providers/cpu/ml/cast_map.cc
@@ -105,7 +105,7 @@ Status CastMap::ComputeImpl(OpKernelContext& context, TTo pad_value) const {
   int64_t num_dims = map_form_ == PACK_MAP::DENSE ? gsl::narrow_cast<int64_t>(X.size()) : max_map_;
 
   // create a span for the output
-  Tensor* Y = context.Output(0, TensorShape({1, num_dims}));
+  Tensor* Y = context.Output(0, {1, num_dims});
   auto out = gsl::make_span(Y->template MutableData<TTo>(), Y->Shape().Size());
   auto out_iter = out.begin();
 

--- a/onnxruntime/core/providers/cpu/ml/category_mapper.cc
+++ b/onnxruntime/core/providers/cpu/ml/category_mapper.cc
@@ -25,7 +25,7 @@ Status CategoryMapper::Compute(OpKernelContext* context) const {
   if (tensor_pointer == nullptr) return Status(common::ONNXRUNTIME, common::FAIL, "input count mismatch");
   const Tensor& X = *tensor_pointer;
   const TensorShape& shape = X.Shape();
-  Tensor& Y = *context->Output(0, TensorShape(shape));
+  Tensor& Y = *context->Output(0, shape);
 
   if (X.IsDataTypeString()) {
     if (!Y.IsDataType<int64_t>())

--- a/onnxruntime/core/providers/cpu/ml/dictvectorizer.h
+++ b/onnxruntime/core/providers/cpu/ml/dictvectorizer.h
@@ -18,8 +18,8 @@ class DictVectorizerOp final : public OpKernel {
     ORT_ENFORCE(info.GetAttrs(std::is_same<AttrType, std::string>::value ? "string_vocabulary" : "int64_vocabulary", vocabulary_).IsOK());
   }
   common::Status Compute(OpKernelContext* ctx) const override {
-    auto map = ctx->Input<std::map<AttrType, TargetType> >(0);
-    auto Y = ctx->Output(0, TensorShape({1, static_cast<int64_t>(vocabulary_.size())}));
+    const auto* map = ctx->Input<std::map<AttrType, TargetType> >(0);
+    auto* Y = ctx->Output(0, {1, static_cast<int64_t>(vocabulary_.size())});
     auto* y_data = Y->template MutableData<TargetType>();
     for (size_t i = 0, end = vocabulary_.size(); i < end; ++i) {
       auto index = map->find(vocabulary_[i]);

--- a/onnxruntime/core/providers/cpu/ml/feature_vectorizer.cc
+++ b/onnxruntime/core/providers/cpu/ml/feature_vectorizer.cc
@@ -41,7 +41,7 @@ Status FeatureVectorizer::Compute(OpKernelContext* context) const {
   int64_t N = X.Shape().NumDimensions() == 1 ? 1 : x_dims[0];
 
   // initialize all the output to 0.f
-  Tensor* Y = context->Output(0, TensorShape({N, total_dimensions_}));
+  Tensor* Y = context->Output(0, {N, total_dimensions_});
   auto Y_data = Y->template MutableData<float>();
 
   auto out = gsl::make_span(Y_data, Y->Shape().Size());

--- a/onnxruntime/core/providers/cpu/ml/label_encoder.cc
+++ b/onnxruntime/core/providers/cpu/ml/label_encoder.cc
@@ -26,7 +26,7 @@ Status LabelEncoder::Compute(OpKernelContext* context) const {
   if (tensor_pointer == nullptr) return Status(common::ONNXRUNTIME, common::FAIL, "input count mismatch");
   const Tensor& X = *tensor_pointer;
   const TensorShape& shape = X.Shape();
-  Tensor& Y = *context->Output(0, TensorShape(shape));
+  Tensor& Y = *context->Output(0, shape);
 
   if (X.IsDataTypeString()) {
     if (!Y.IsDataType<int64_t>())

--- a/onnxruntime/core/providers/cpu/ml/label_encoder.h
+++ b/onnxruntime/core/providers/cpu/ml/label_encoder.h
@@ -73,7 +73,7 @@ class LabelEncoder_2 final : public OpKernel {
     if (tensor_pointer == nullptr) return Status(common::ONNXRUNTIME, common::FAIL, "input count mismatch");
     const Tensor& X = *tensor_pointer;
     const TensorShape& shape = X.Shape();
-    Tensor& Y = *context->Output(0, TensorShape(shape));
+    Tensor& Y = *context->Output(0, shape);
 
     auto input = X.template DataAsSpan<TKey>();
     auto output = Y.template MutableDataAsSpan<TValue>();

--- a/onnxruntime/core/providers/cpu/ml/linearclassifier.cc
+++ b/onnxruntime/core/providers/cpu/ml/linearclassifier.cc
@@ -142,7 +142,7 @@ Status LinearClassifier::Compute(OpKernelContext* ctx) const {
   int64_t num_batches = input_shape.NumDimensions() == 1 ? 1 : input_shape[0];
   int64_t num_features = input_shape.NumDimensions() == 1 ? input_shape[0] : input_shape[1];
 
-  Tensor* Y = ctx->Output(0, TensorShape({num_batches}));
+  Tensor* Y = ctx->Output(0, {num_batches});
 
   int64_t output_classes = class_count_;
   bool add_second_class = false;
@@ -153,7 +153,7 @@ Status LinearClassifier::Compute(OpKernelContext* ctx) const {
     add_second_class = true;
   }
 
-  Tensor* Z = ctx->Output(1, TensorShape({num_batches, output_classes}));
+  Tensor* Z = ctx->Output(1, {num_batches, output_classes});
 
   concurrency::ThreadPool* tp = ctx->GetOperatorThreadPool();
 

--- a/onnxruntime/core/providers/cpu/ml/linearregressor.cc
+++ b/onnxruntime/core/providers/cpu/ml/linearregressor.cc
@@ -81,7 +81,7 @@ Status LinearRegressor::Compute(OpKernelContext* ctx) const {
 
   int64_t num_batches = input_shape.NumDimensions() <= 1 ? 1 : input_shape[0];
   int64_t num_features = input_shape.NumDimensions() <= 1 ? input_shape.Size() : input_shape[1];
-  Tensor& Y = *ctx->Output(0, TensorShape({num_batches, num_targets_}));
+  Tensor& Y = *ctx->Output(0, {num_batches, num_targets_});
   concurrency::ThreadPool* tp = ctx->GetOperatorThreadPool();
 
   auto element_type = X.GetElementType();

--- a/onnxruntime/core/providers/cpu/ml/svmclassifier.cc
+++ b/onnxruntime/core/providers/cpu/ml/svmclassifier.cc
@@ -178,8 +178,8 @@ Status SVMClassifier::ComputeImpl(OpKernelContext& ctx,
   // support_vectors_ : [vector_count_, feature_count_]
 
   // both outputs are required so can't be nullptr
-  Tensor& Y = *ctx.Output(0, TensorShape({num_batches}));
-  Tensor& Z = *ctx.Output(1, TensorShape({num_batches, final_scores_per_batch}));
+  Tensor& Y = *ctx.Output(0, {num_batches});
+  Tensor& Z = *ctx.Output(1, {num_batches, final_scores_per_batch});
 
   auto final_scores = Z.MutableDataAsSpan<float>();
 

--- a/onnxruntime/core/providers/cpu/ml/svmregressor.cc
+++ b/onnxruntime/core/providers/cpu/ml/svmregressor.cc
@@ -49,7 +49,7 @@ Status SVMRegressor<T>::Compute(OpKernelContext* ctx) const {
   // support_vectors_ : [vector_count_, feature_count_]
 
   // Y: [num_batches, 1]
-  Tensor* Y = ctx->Output(0, TensorShape({num_batches, 1}));  // this op outputs for one target only
+  Tensor* Y = ctx->Output(0, {num_batches, 1});  // this op outputs for one target only
   const auto x_data = X->template DataAsSpan<T>();
   auto out = Y->MutableDataAsSpan<T>();
 

--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_classifier.cc
+++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_classifier.cc
@@ -164,15 +164,14 @@ TreeEnsembleClassifier<T>::TreeEnsembleClassifier(const OpKernelInfo& info)
 template <typename T>
 common::Status TreeEnsembleClassifier<T>::Compute(OpKernelContext* context) const {
   const Tensor& X = *context->Input<Tensor>(0);
-  const TensorShape& x_shape = X.Shape();
-  vector<int64_t> x_dims = x_shape.GetDims();
+  const std::vector<int64_t>& x_dims = X.Shape().GetDims();
   if (x_dims.empty()) {
     return Status(ONNXRUNTIME, INVALID_ARGUMENT, "X dims is empty.");
   }
 
   int64_t N = x_dims.size() == 1 ? 1 : x_dims[0];
-  Tensor* Y = context->Output(0, TensorShape({N}));
-  Tensor* Z = context->Output(1, TensorShape({N, tree_ensemble_.get_class_count()}));
+  Tensor* Y = context->Output(0, {N});
+  Tensor* Z = context->Output(1, {N, tree_ensemble_.get_class_count()});
 
   tree_ensemble_.compute(context->GetOperatorThreadPool(), &X, Z, Y);
   return Status::OK();

--- a/onnxruntime/core/providers/cpu/ml/treeregressor.cc
+++ b/onnxruntime/core/providers/cpu/ml/treeregressor.cc
@@ -54,7 +54,7 @@ common::Status TreeEnsembleRegressor<T>::Compute(OpKernelContext* context) const
                   "Input shape needs to be at least a single dimension.");
   }
   int64_t N = X->Shape().NumDimensions() == 1 ? 1 : X->Shape()[0];
-  Tensor* Y = context->Output(0, TensorShape({N, tree_ensemble_.n_targets_or_classes_}));
+  Tensor* Y = context->Output(0, {N, tree_ensemble_.n_targets_or_classes_});
 
   tree_ensemble_.compute(context->GetOperatorThreadPool(), X, Y, NULL);
 

--- a/onnxruntime/core/providers/cpu/ml/zipmap.cc
+++ b/onnxruntime/core/providers/cpu/ml/zipmap.cc
@@ -48,8 +48,7 @@ common::Status ZipMapOp::Compute(OpKernelContext* context) const {
   const auto* tensor_pointer = context->Input<Tensor>(0);
   if (tensor_pointer == nullptr) return Status(common::ONNXRUNTIME, common::FAIL, "input count mismatch");
   const Tensor& X = *tensor_pointer;
-  const TensorShape& x_shape = X.Shape();
-  const vector<int64_t>& x_dims = x_shape.GetDims();
+  const std::vector<int64_t>& x_dims = X.Shape().GetDims();
 
   if (x_dims.empty()) {
     return Status(ONNXRUNTIME,

--- a/onnxruntime/core/providers/cpu/nn/flatten.h
+++ b/onnxruntime/core/providers/cpu/nn/flatten.h
@@ -31,7 +31,7 @@ class Flatten final : public OpKernel {
 
     ORT_ENFORCE(gsl::narrow_cast<int64_t>(X_shape.NumDimensions()) >= axis, "The rank of input tensor must be >= axis");
 
-    Tensor* Y = context->Output(0, TensorShape({X_shape.SizeToDimension(axis), X_shape.SizeFromDimension(axis)}));
+    Tensor* Y = context->Output(0, {X_shape.SizeToDimension(axis), X_shape.SizeFromDimension(axis)});
 
     CopyCpuTensor(X, Y);
 

--- a/onnxruntime/core/providers/cpu/nn/roi_pool.cc
+++ b/onnxruntime/core/providers/cpu/nn/roi_pool.cc
@@ -26,9 +26,7 @@ Status RoiPool<float>::Compute(OpKernelContext* context) const {
   // Each ROI is of the form [batch_index x1 y1 x2 y2]
   ORT_ENFORCE(R->Shape()[1] == 5);
 
-  std::vector<int64_t> output_dims({num_rois, channels, pooled_height_, pooled_width_});
-
-  Tensor* Y = context->Output(0, TensorShape(output_dims));
+  Tensor* Y = context->Output(0, {num_rois, channels, pooled_height_, pooled_width_});
 
   const auto* Xdata = X->template Data<float>();
   const auto* rois = R->template Data<float>();

--- a/onnxruntime/core/providers/cpu/object_detection/non_max_suppression.cc
+++ b/onnxruntime/core/providers/cpu/object_detection/non_max_suppression.cc
@@ -77,8 +77,8 @@ Status NonMaxSuppressionBase::PrepareCompute(OpKernelContext* ctx, PrepareContex
   ORT_RETURN_IF_NOT(boxes_shape.NumDimensions() == 3, "boxes must be a 3D tensor.");
   ORT_RETURN_IF_NOT(scores_shape.NumDimensions() == 3, "scores must be a 3D tensor.");
 
-  auto boxes_dims = boxes_shape.GetDims();
-  auto scores_dims = scores_shape.GetDims();
+  const auto& boxes_dims = boxes_shape.GetDims();
+  const auto& scores_dims = scores_shape.GetDims();
   ORT_RETURN_IF_NOT(boxes_dims[0] == scores_dims[0], "boxes and scores should have same num_batches.");
   ORT_RETURN_IF_NOT(boxes_dims[1] == scores_dims[2], "boxes and scores should have same spatial_dimension.");
   ORT_RETURN_IF_NOT(boxes_dims[2] == 4, "The most inner dimension in boxes must have 4 data.");

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -236,7 +236,7 @@ const std::vector<MLDataType> castOpTypeConstraints{
   Status Cast<in_type>::Compute(OpKernelContext* context) const {                                                                  \
     const Tensor* X = context->Input<Tensor>(0);                                                                                   \
     const TensorShape& shape = X->Shape();                                                                                         \
-    Tensor* Y = context->Output(0, TensorShape(shape));                                                                            \
+    Tensor* Y = context->Output(0, shape);                                                                                         \
                                                                                                                                    \
     switch (to_) {                                                                                                                 \
       case TensorProto_DataType_BOOL:                                                                                              \
@@ -315,7 +315,7 @@ template <>
 Status Cast<MLFloat16>::Compute(OpKernelContext* context) const {
   const auto* X = context->Input<Tensor>(0);
   const TensorShape& shape = X->Shape();
-  Tensor* Y = context->Output(0, TensorShape(shape));
+  Tensor* Y = context->Output(0, shape);
   Status st;
   switch (to_) {
     case TensorProto_DataType_BOOL:
@@ -385,7 +385,7 @@ Status Cast<std::string>::Compute(OpKernelContext* context) const {
   if (X == nullptr) return Status(common::ONNXRUNTIME, common::FAIL,
                                   "Input is missing. The operator Cast expects one and only one input");
   const TensorShape& shape = X->Shape();
-  Tensor* Y = context->Output(0, TensorShape(shape));
+  Tensor* Y = context->Output(0, shape);
   Status st;
   switch (to_) {
     case TensorProto_DataType_INT16:

--- a/onnxruntime/core/providers/cpu/tensor/gather_elements.cc
+++ b/onnxruntime/core/providers/cpu/tensor/gather_elements.cc
@@ -249,7 +249,7 @@ Status GatherElements::Compute(OpKernelContext* context) const {
   if (!status.IsOK())
     return status;
 
-  Tensor* output_tensor = context->Output(0, TensorShape(indices_shape));
+  Tensor* output_tensor = context->Output(0, indices_shape);
 
   const auto& input_data_type = input_tensor->DataType();
   if (input_data_type != output_tensor->DataType())
@@ -260,10 +260,8 @@ Status GatherElements::Compute(OpKernelContext* context) const {
   if (indices_shape.Size() == 0)
     return Status::OK();
 
-
   if (input_tensor->IsDataTypeString())
     core_impl<true, std::string>(input_tensor, indices_tensor, output_tensor, axis);
-
   else
     core_impl<false, int8_t>(input_tensor, indices_tensor, output_tensor, axis);
 

--- a/onnxruntime/core/providers/cpu/tensor/mean_variance_normalization.h
+++ b/onnxruntime/core/providers/cpu/tensor/mean_variance_normalization.h
@@ -35,7 +35,7 @@ class MeanVarianceNormalization_0 : public OpKernel {
     const int64_t H = dims[2];
     const int64_t W = dims[3];
 
-    Tensor* Y = context->Output(0, TensorShape({N, C, H, W}));
+    Tensor* Y = context->Output(0, {N, C, H, W});
     const T* Xdata = X->template Data<T>();
     T* Ydata = Y->template MutableData<T>();
 

--- a/onnxruntime/core/providers/cpu/tensor/nonzero_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/nonzero_op.cc
@@ -94,7 +94,7 @@ Status NonZero<T>::Compute(OpKernelContext* context) const {
       non_zero_indices_buffer.data(),
       num_non_zero_values, coordinate_size};
 
-  Tensor* const Y = context->Output(0, TensorShape{coordinate_size, num_non_zero_values});
+  Tensor* const Y = context->Output(0, {coordinate_size, num_non_zero_values});
   ORT_ENFORCE(Y, "failed to get first output!");
 
   EigenMatrixMapRowMajor<int64_t> y_matrix{
@@ -103,5 +103,6 @@ Status NonZero<T>::Compute(OpKernelContext* context) const {
   y_matrix = non_zero_indices_matrix.transpose();
 
   return Status::OK();
-}  // namespace onnxruntime
+}
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/tensor/scatter_nd.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter_nd.cc
@@ -16,16 +16,16 @@ ONNX_CPU_OPERATOR_KERNEL(
 
 template <typename Tind>
 Status ScatterNDBase::PrepareForCompute(OpKernelContext* context, Prepare& p) const {
-  auto input_tensor = context->Input<Tensor>(0);
-  auto indice_tensor = context->Input<Tensor>(1);
-  auto update_tensor = context->Input<Tensor>(2);
+  const auto* input_tensor = context->Input<Tensor>(0);
+  const auto* indice_tensor = context->Input<Tensor>(1);
+  const auto* update_tensor = context->Input<Tensor>(2);
   ORT_ENFORCE(input_tensor != nullptr);
   ORT_ENFORCE(indice_tensor != nullptr);
   ORT_ENFORCE(update_tensor != nullptr);
 
-  auto input_shape = input_tensor->Shape();
-  auto indice_shape = indice_tensor->Shape();
-  auto update_shape = update_tensor->Shape();
+  const auto& input_shape = input_tensor->Shape();
+  const auto& indice_shape = indice_tensor->Shape();
+  const auto& update_shape = update_tensor->Shape();
   if (indice_shape.NumDimensions() == 0 || input_shape.NumDimensions() == 0) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                            "input tensor and indices tensor must has rank larger than 0. ",
@@ -63,7 +63,7 @@ Status ScatterNDBase::PrepareForCompute(OpKernelContext* context, Prepare& p) co
                            "updates shape: ", update_shape, ", indices shape: ", indice_shape, ", data shape: ", input_shape);
   }
 
-  auto output_tensor = context->Output(0, TensorShape(input_shape));
+  auto output_tensor = context->Output(0, input_shape);
 
   const auto* src_base = input_tensor->DataRaw();
   auto* dst_base = output_tensor->MutableDataRaw();

--- a/onnxruntime/core/providers/cpu/tensor/shape_op.h
+++ b/onnxruntime/core/providers/cpu/tensor/shape_op.h
@@ -22,8 +22,7 @@ class Shape final : public OpKernel {
     const TensorShape& inputShape = input->Shape();
 
     size_t nDims = inputShape.NumDimensions();
-    TensorShape outputShape({gsl::narrow_cast<int64_t>(nDims)});
-    Tensor* output = context->Output(0, TensorShape(outputShape));
+    Tensor* output = context->Output(0, {gsl::narrow_cast<int64_t>(nDims)});
 
     inputShape.CopyDims(output->template MutableData<int64_t>(), nDims);
     return Status::OK();

--- a/onnxruntime/core/providers/cpu/tensor/unique.cc
+++ b/onnxruntime/core/providers/cpu/tensor/unique.cc
@@ -65,7 +65,7 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             OpSchema::all_tensor_types(),
-            "Input can be of any tensor type.")    
+            "Input can be of any tensor type.")
 */
 ONNX_CPU_OPERATOR_KERNEL(
     Unique,
@@ -136,10 +136,10 @@ static void CreateFlattenedOutput(OpKernelContext& context,
                                   const std::vector<int64_t>& inverse_index,         // unsorted
                                   bool sorted) {
   int64_t num_unique = static_cast<int64_t>(indices.size());
-  Tensor& Y = *context.Output(0, TensorShape({num_unique}));
-  Tensor* indices_out = context.Output(1, TensorShape({num_unique}));
-  Tensor* inverse_indices = context.Output(2, TensorShape({static_cast<int64_t>(inverse_index.size())}));
-  Tensor* counts = context.Output(3, TensorShape({num_unique}));
+  Tensor& Y = *context.Output(0, {num_unique});
+  Tensor* indices_out = context.Output(1, {num_unique});
+  Tensor* inverse_indices = context.Output(2, {static_cast<int64_t>(inverse_index.size())});
+  Tensor* counts = context.Output(3, {num_unique});
 
   auto Y_data = Y.MutableDataAsSpan<T>();
   gsl::span<int64_t> indices_data = indices_out != nullptr ? indices_out->MutableDataAsSpan<int64_t>()
@@ -213,9 +213,9 @@ static void CreateOutput(OpKernelContext& context,
   }
 
   Tensor& Y = *context.Output(0, TensorShape(std::move(Y_dims)));
-  Tensor* indices_out = context.Output(1, TensorShape({num_unique}));
-  Tensor* inverse_indices = context.Output(2, TensorShape({static_cast<int64_t>(inverse_index.size())}));
-  Tensor* counts = context.Output(3, TensorShape({num_unique}));
+  Tensor* indices_out = context.Output(1, {num_unique});
+  Tensor* inverse_indices = context.Output(2, {static_cast<int64_t>(inverse_index.size())});
+  Tensor* counts = context.Output(3, {num_unique});
 
   auto Y_data = Y.MutableDataAsSpan<T>();
   gsl::span<int64_t> indices_data = indices_out != nullptr ? indices_out->MutableDataAsSpan<int64_t>()

--- a/onnxruntime/core/providers/cuda/math/gemm.cc
+++ b/onnxruntime/core/providers/cuda/math/gemm.cc
@@ -60,7 +60,7 @@ Status Gemm<T>::ComputeInternal(OpKernelContext* ctx) const {
   int M = gsl::narrow_cast<int>(helper.M());
   int N = gsl::narrow_cast<int>(helper.N());
   int K = gsl::narrow_cast<int>(helper.K());
-  auto* Y = ctx->Output(0, TensorShape(std::vector<int64_t>{M, N}));
+  auto* Y = ctx->Output(0, {M, N});
   CudaT* out_data = reinterpret_cast<CudaT*>(Y->template MutableData<T>());
 
   CudaT one = ToCudaType<T>::FromFloat(1.0f);

--- a/onnxruntime/core/providers/cuda/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cuda/tensor/cast_op.cc
@@ -50,7 +50,7 @@ Status Cast<SrcT>::ComputeInternal(OpKernelContext* context) const {
   typedef typename ToCudaType<SrcT>::MappedType CudaSrcT;
   const Tensor* X = context->Input<Tensor>(0);
   const TensorShape& shape = X->Shape();
-  Tensor* Y = context->Output(0, TensorShape(shape));
+  Tensor* Y = context->Output(0, shape);
   const auto* x_data = reinterpret_cast<const CudaSrcT*>(X->template Data<SrcT>());
   size_t count = shape.Size();
 

--- a/onnxruntime/core/providers/cuda/tensor/flatten.cc
+++ b/onnxruntime/core/providers/cuda/tensor/flatten.cc
@@ -50,7 +50,7 @@ Status Flatten::ComputeInternal(OpKernelContext* ctx) const {
 
   ORT_ENFORCE(gsl::narrow_cast<int64_t>(X_shape.NumDimensions()) >= axis, "The rank of input tensor must be >= axis");
 
-  Tensor* Y = ctx->Output(0, TensorShape({X_shape.SizeToDimension(axis), X_shape.SizeFromDimension(axis)}));
+  Tensor* Y = ctx->Output(0, {X_shape.SizeToDimension(axis), X_shape.SizeFromDimension(axis)});
   //If source and target pointers are not equal (non-inplace operation), we need to copy the data.
   const void* source = X->DataRaw();
   void* target = Y->MutableDataRaw();

--- a/onnxruntime/core/providers/cuda/tensor/gather_elements.cc
+++ b/onnxruntime/core/providers/cuda/tensor/gather_elements.cc
@@ -44,7 +44,7 @@ Status GatherElements::ComputeInternal(OpKernelContext* context) const {
     return status;
 
   // create output tensor
-  auto* output_tensor = context->Output(0, TensorShape(indices_shape));
+  auto* output_tensor = context->Output(0, indices_shape);
 
   // if there are no elements in 'indices' - nothing to process
   if (indices_shape.Size() == 0)


### PR DESCRIPTION
**Description**: Add overloads for OpKernelContext.Output() that take the shape parameter as std::vector or std::initializer_list instead of requiring the construction of a TensorShape at the call site. Fixed several call sites to take advantage of these overloads. Reduces onnxruntime.dll binary size another 30KB.