### PR TITLE
Exclude weight related types/shapes from bert loss.

### DIFF
--- a/orttraining/orttraining/models/bert/main.cc
+++ b/orttraining/orttraining/models/bert/main.cc
@@ -700,14 +700,12 @@ static Status RunPerformanceTest(const BertParameters& params, const Environment
                                             {batch_size, params.max_sequence_length},
                                             {batch_size, params.max_predictions_per_sequence},
                                             {batch_size, params.max_predictions_per_sequence},
-                                            {batch_size, params.max_predictions_per_sequence},
                                             {batch_size}};
   std::vector<onnx::TensorProto_DataType> tensor_types = {onnx::TensorProto_DataType_INT64,
                                                           onnx::TensorProto_DataType_INT64,
                                                           onnx::TensorProto_DataType_INT64,
                                                           onnx::TensorProto_DataType_INT64,
                                                           onnx::TensorProto_DataType_INT64,
-                                                          onnx::TensorProto_DataType_FLOAT,
                                                           onnx::TensorProto_DataType_INT64};
   const size_t num_of_perf_samples = params.num_train_steps * params.batch_size;
   auto random_perf_data = std::make_shared<RandomDataSet>(num_of_perf_samples, tensor_names, tensor_shapes, tensor_types);


### PR DESCRIPTION
Fixes **run_batch_size_test.py** e2e pipeline.
