### PR TITLE
modify calibration tool

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -8,284 +8,224 @@
 
 import os
 import sys
-import argparse
 import numpy as np
-from PIL import Image
 import onnx
 import onnxruntime
 from onnx import helper, TensorProto, numpy_helper
 from quantize import quantize, QuantizationMode
-from data_preprocess import load_batch
+
+#user-implement preprocess function
+from data_preprocess import preprocess_func
 
 import re
 import subprocess
 import json
 
+import abc
 
-def augment_graph(model, quantization_candidates=['Conv', 'MatMul'], black_nodes=[], white_nodes=[]):
-    '''
-    Adds ReduceMin and ReduceMax nodes to all quantization_candidates op type nodes in
-    model and ensures their outputs are stored as part of the graph output
-        parameter model: loaded FP32 ONNX model to quantize
-        parameter quantization_candidates: node op types for nodes to be quantized.
-                                           Calibraton will be done for them.
-        parameter black_nodes: nodes with these names will be force ignored by this
-                               calibration augmentation, no mather what's their op type.
-        parameter white_nodes: nodes with these names will be force to be calibration augmented.
-        return: augmented ONNX model
-    '''
+class DataRetrieverInterface(metaclass=abc.ABCMeta):
+    @classmethod
+    def __subclasshook__(cls,subclass):
+        return (hasattr(subclass,'get_next') and callable(subclass.get_next) or NotImplemented)
 
-    added_nodes = []
-    added_outputs = []
-    for node in model.graph.node:
-        should_be_calibrate = ((node.op_type in quantization_candidates) and
-                               (node.name not in black_nodes)) or (node.name in white_nodes)
-        if should_be_calibrate:
-            input_name = node.output[0]
-            # Adding ReduceMin nodes
-            reduce_min_name = ''
-            if node.name != '':
-                reduce_min_name = node.name + '_ReduceMin'
-            reduce_min_node = onnx.helper.make_node('ReduceMin', [input_name], [input_name + '_ReduceMin'],
-                                                    reduce_min_name,
-                                                    keepdims=0)
-            added_nodes.append(reduce_min_node)
-            added_outputs.append(helper.make_tensor_value_info(reduce_min_node.output[0], TensorProto.FLOAT, ()))
+    @abc.abstractmethod
+    def get_next(self) -> dict:
+        """generate the input data dict for ONNXinferenceSession run"""
+        raise NotImplementedError
 
-            # Adding ReduceMax nodes
-            reduce_max_name = ''
-            if node.name != '':
-                reduce_max_name = node.name + '_ReduceMax'
-            reduce_max_node = onnx.helper.make_node('ReduceMax', [input_name], [input_name + '_ReduceMax'],
-                                                    reduce_max_name,
-                                                    keepdims=0)
-            added_nodes.append(reduce_max_node)
-            added_outputs.append(helper.make_tensor_value_info(reduce_max_node.output[0], TensorProto.FLOAT, ()))
-    model.graph.node.extend(added_nodes)
-    model.graph.output.extend(added_outputs)
-    return model
+class ONNXCalibrater:
+    def __init__(self,
+                 model_path,
+                 data_retriever,
+                 calibrate_op_types,
+                 black_nodes,
+                 white_nodes,
+                 augmented_model_path):
+        self.model_path = model_path
+        self.data_retriever = data_retriever
+        self.calibrate_op_types = calibrate_op_types
+        self.black_nodes = black_nodes
+        self.white_nodes = white_nodes
+        self.augmented_model_path = augmented_model_path
+     
+    def augment_graph(self):
+        '''
+        Adds ReduceMin and ReduceMax nodes to all quantization_candidates op type nodes in
+        model and ensures their outputs are stored as part of the graph output
+        :return: augmented ONNX model
+        '''
 
+        added_nodes = []
+        added_outputs = []
+        model = onnx.load(self.model_path)
+        for node in model.graph.node:
+            should_be_calibrate = ((node.op_type in self.calibrate_op_types) and
+                                (node.name not in self.black_nodes)) or (node.name in self.white_nodes)
+            if should_be_calibrate:
+                input_name = node.output[0]
+                # Adding ReduceMin nodes
+                reduce_min_name = ''
+                if node.name != '':
+                    reduce_min_name = node.name + '_ReduceMin'
+                reduce_min_node = onnx.helper.make_node('ReduceMin', [input_name], [input_name + '_ReduceMin'],
+                                                        reduce_min_name,
+                                                        keepdims=0)
+                added_nodes.append(reduce_min_node)
+                added_outputs.append(helper.make_tensor_value_info(reduce_min_node.output[0], TensorProto.FLOAT, ()))
 
-# Using augmented outputs to generate inputs to quantize.py
+                # Adding ReduceMax nodes
+                reduce_max_name = ''
+                if node.name != '':
+                    reduce_max_name = node.name + '_ReduceMax'
+                reduce_max_node = onnx.helper.make_node('ReduceMax', [input_name], [input_name + '_ReduceMax'],
+                                                        reduce_max_name,
+                                                        keepdims=0)
+                added_nodes.append(reduce_max_node)
+                added_outputs.append(helper.make_tensor_value_info(reduce_max_node.output[0], TensorProto.FLOAT, ()))
 
+        model.graph.node.extend(added_nodes)
+        model.graph.output.extend(added_outputs)
+        return model
 
-def get_intermediate_outputs(model_path, session, inputs, calib_mode='naive'):
-    '''
-    Gather intermediate model outputs after running inference
-        parameter model_path: path to augmented FP32 ONNX model
-        parameter inputs: list of loaded test inputs (or image matrices)
-        parameter calib_mode: type 'naive' gives (ReduceMin, ReduceMax) pairs
+    #Using augmented outputs to generate inputs for quantization
+    def get_intermediate_outputs(self,calib_mode='naive'):
+        ''' 
+            Gather intermediate model outputs after running inference
+            parameter calib_mode: type 'naive' gives (ReduceMin, ReduceMax) pairs
                                 for each augmented node across test data sets, where
                                 the first element is a minimum of all ReduceMin values
                                 and the second element is a maximum of all ReduceMax
-                                values; more techniques can be added based on further experimentation
-                                to improve the selection of the min max values. For example: some kind
-                                of noise reduction can be applied before taking the min and max values.
-        return: dictionary mapping added node names to (ReduceMin, ReduceMax) pairs
+                                values;
+            :return: dictionary mapping: {added node names: (ReduceMin, ReduceMax) pairs }
+        '''
+
+        #conduct inference session and get intermediate outputs
+        session = onnxruntime.InferenceSession(self.augmented_model_path, None)
+
+        intermediate_outputs = []
+        while True:
+            inputs = self.data_retriever.get_next()
+            if not inputs:
+                break
+            intermediate_outputs.append(session.run(None, inputs))
+        node_output_names = [session.get_outputs()[i].name for i in range(len(intermediate_outputs[0]))]
+        output_dicts_list = [dict(zip(node_output_names, intermediate_outputs[i])) for i in range(self.data_retriever.datasize)]
+        
+        #number of outputs in original model
+        model = onnx.load(self.model_path)
+        num_model_outputs = len(model.graph.output)
+        merged_dict = {}
+        for d in output_dicts_list:
+            for k, v in d.items():
+                merged_dict.setdefault(k, []).append(v)
+        added_node_output_names = node_output_names[num_model_outputs:]
+        node_names = [added_node_output_names[i].rpartition('_')[0]
+                    for i in range(0, len(added_node_output_names), 2)]  #output names
+
+        # Characterizing distribution of a node's values across test data sets
+        clean_merged_dict = dict((i, merged_dict[i]) for i in merged_dict if i != list(merged_dict.keys())[0])
+        if calib_mode == 'naive':
+            pairs = [
+                tuple([
+                    float(min(clean_merged_dict[added_node_output_names[i]])),
+                    float(max(clean_merged_dict[added_node_output_names[i + 1]]))
+                ]) for i in range(0, len(added_node_output_names), 2)
+            ]
+        else:
+            raise ValueError('Unknown value for calib_mode. Currently only naive mode is supported.')
+
+        final_dict = dict(zip(node_names, pairs))
+        return final_dict
+    
+    def calculate_scale_zeropoint(self, node, next_node, rmin, rmax):
+        zp_and_scale = []
+        # adjust rmin and rmax such that 0 is included in the range. This is required
+        # to make sure zero can be uniquely represented.
+        rmin = min(rmin, 0)
+        rmax = max(rmax, 0)
+
+        # We update the output range min and max when next node is clip or relu
+        # With this technique we can remove these 2 ops and
+        # reduce the output range which in turn helps to improve accuracy
+        if next_node.op_type == 'Clip':
+            clip_min = next_node.attribute[0].f
+            clip_max = next_node.attribute[1].f
+            if rmin < clip_min:
+                rmin = clip_min
+            if rmax > clip_max:
+                rmax = clip_max
+        if next_node.op_type == 'Relu':
+            if rmin < 0:
+                rmin = 0
+
+        scale = np.float32((rmax - rmin) / 255 if rmin != rmax else 1)
+        initial_zero_point = (0 - rmin) / scale
+        zero_point = np.uint8(round(max(0, min(255, initial_zero_point))))
+
+        zp_and_scale.append(zero_point)
+        zp_and_scale.append(scale)
+        return zp_and_scale
+
+    def calculate_quantization_params(self,quantization_thresholds):
+        '''
+            Given quantization thresholds, calculate the quantization params.
+        :param quantization_thresholds:
+            Dictionary specifying the min and max values for outputs of conv and matmul nodes.
+            The quantization_thresholds should be specified in the following format:
+                {
+                    "param_name": [min, max]
+                }
+            example:
+                {
+                    'Conv_3:0': [np.float32(0), np.float32(0.5)],
+                    'Conv_4:0': [np.float32(1), np.float32(3.5)]
+                }
+        :return: Dictionary containing the zero point and scale values for outputs of conv and matmul nodes.
+            The dictionary format is
+                {
+                    "param_name": [zero_point, scale]
+                }
+        '''
+        if quantization_thresholds is None:
+            raise ValueError('quantization thresholds is required to calculate quantization params (zero point and scale)')
+    
+        quantization_params = {}
+        model = onnx.load(self.model_path)
+        for index, node in enumerate(model.graph.node):
+            node_output_name = node.output[0]
+            if node_output_name in quantization_thresholds:
+                node_thresholds = quantization_thresholds[node_output_name]
+                node_params = self.calculate_scale_zeropoint(node, model.graph.node[index + 1], node_thresholds[0],node_thresholds[1])
+                quantization_params[node_output_name] = node_params
+
+        return quantization_params
+
+
+def calibrate(model_path,
+              data_retriever,
+              op_types='Conv,MatMul',
+              black_nodes='',
+              white_nodes='',
+              augmented_model_path ='augmented_model.onnx'):   
     '''
-    model = onnx.load(model_path)
-    # number of outputs in original model
-    num_model_outputs = len(model.graph.output)
-    num_inputs = len(inputs)
-    input_name = session.get_inputs()[0].name
-    intermediate_outputs = [session.run([], {input_name: inputs[i]}) for i in range(num_inputs)]
+        Given an onnx model, augment and run the augmented model on calibration data set, aggregate and calculate the quantization parameters.
 
-    # Creating dictionary with output results from multiple test inputs
-    node_output_names = [session.get_outputs()[i].name for i in range(len(intermediate_outputs[0]))]
-    output_dicts = [dict(zip(node_output_names, intermediate_outputs[i])) for i in range(num_inputs)]
-    merged_dict = {}
-    for d in output_dicts:
-        for k, v in d.items():
-            merged_dict.setdefault(k, []).append(v)
-    added_node_output_names = node_output_names[num_model_outputs:]
-    node_names = [added_node_output_names[i].rpartition('_')[0]
-                  for i in range(0, len(added_node_output_names), 2)]  # output names
-
-    # Characterizing distribution of a node's values across test data sets
-    clean_merged_dict = dict((i, merged_dict[i]) for i in merged_dict if i != list(merged_dict.keys())[0])
-    if calib_mode == 'naive':
-        pairs = [
-            tuple([
-                float(min(clean_merged_dict[added_node_output_names[i]])),
-                float(max(clean_merged_dict[added_node_output_names[i + 1]]))
-            ]) for i in range(0, len(added_node_output_names), 2)
-        ]
-    else:
-        raise ValueError('Unknown value for calib_mode. Currently only naive mode is supported.')
-
-    final_dict = dict(zip(node_names, pairs))
-    return final_dict
-
-
-def calculate_scale_zeropoint(node, next_node, rmin, rmax):
-    zp_and_scale = []
-    # adjust rmin and rmax such that 0 is included in the range. This is required
-    # to make sure zero can be uniquely represented.
-    rmin = min(rmin, 0)
-    rmax = max(rmax, 0)
-
-    # We update the output range min and max when next node is clip or relu
-    # With this technique we can remove these 2 ops and
-    # reduce the output range which in turn helps to improve accuracy
-    if next_node.op_type == 'Clip':
-        clip_min = next_node.attribute[0].f
-        clip_max = next_node.attribute[1].f
-        if rmin < clip_min:
-            rmin = clip_min
-        if rmax > clip_max:
-            rmax = clip_max
-    if next_node.op_type == 'Relu':
-        if rmin < 0:
-            rmin = 0
-
-    scale = np.float32((rmax - rmin) / 255 if rmin != rmax else 1)
-    initial_zero_point = (0 - rmin) / scale
-    zero_point = np.uint8(round(max(0, min(255, initial_zero_point))))
-
-    zp_and_scale.append(zero_point)
-    zp_and_scale.append(scale)
-    return zp_and_scale
-
-
-def calculate_quantization_params(model, quantization_thresholds):
+    :param model_path: ONNX model to calibrate
+    :param data_retriever: user implemented object to retrieve and preprocess calibration dataset
+    :param op_types: operator types to be calibrated and quantized, default = 'Conv,MatMul'
+    :param black_nodes: operator names that should not be quantized, default = ''
+    :param white_nodes: operator names that force to be quantized, default = ''
+    :param augmented_model_path: save augmented_model to this path
     '''
-        Given a model and quantization thresholds, calculates the quantization params.
-    :param model: ModelProto to quantize
-    :param quantization_thresholds:
-        Dictionary specifying the min and max values for outputs of conv and matmul nodes.
-        The quantization_thresholds should be specified in the following format:
-            {
-                "param_name": [min, max]
-            }
-        example:
-            {
-                'Conv_3:0': [np.float32(0), np.float32(0.5)],
-                'Conv_4:0': [np.float32(1), np.float32(3.5)]
-            }
-    :return: Dictionary containing the zero point and scale values for outputs of conv and matmul nodes.
-        The dictionary format is
-            {
-                "param_name": [zero_point, scale]
-            }
-    '''
-    if quantization_thresholds is None:
-        raise ValueError('quantization thresholds is required to calculate quantization params (zero point and scale)')
+    #1. initialize a calibrater
+    calibrater = ONNXCalibrater(model_path,data_retriever,op_types,black_nodes,white_nodes,augmented_model_path)
+    #2. augment
+    augmented_model = calibrater.augment_graph()
+    onnx.save(augmented_model,augmented_model_path)
+    #3. generate quantization thresholds 
+    dict_for_quantization = calibrater.get_intermediate_outputs()
+    #4. generate quantization parameters dict
+    quantization_params_dict = calibrater.calculate_quantization_params(dict_for_quantization)
 
-    quantization_params = {}
-    for index, node in enumerate(model.graph.node):
-        node_output_name = node.output[0]
-        if node_output_name in quantization_thresholds:
-            node_thresholds = quantization_thresholds[node_output_name]
-            node_params = calculate_scale_zeropoint(node, model.graph.node[index + 1], node_thresholds[0],
-                                                    node_thresholds[1])
-            quantization_params[node_output_name] = node_params
-
-    return quantization_params
-
-
-def load_pb_file(data_file_name, size_limit, samples, channels, height, width):
-    '''
-    Load tensor data from pb files.
-    :param data_file_name: path to the pb file
-    :param dataset_size: number of image-data in the pb file. Default is 0 which means all samples from .pb file.
-    :param samples: number of samples 'N'
-    :param channels: number of channels in the image 'C'
-    :param height: image height for data size check 'H'
-    :param width: image width for data size check 'W'
-    :return input data for the model
-    '''
-    tensor = onnx.TensorProto()
-    inputs = np.empty(0)
-    with open(data_file_name, 'rb') as fin:
-        tensor.ParseFromString(fin.read())
-        inputs = numpy_helper.to_array(tensor)
-        try:
-            shape = inputs.shape
-            dataset_size = 1
-            if len(shape) == 5 and (shape[0] <= size_limit or size_limit == 0):
-                dataset_size = shape[0]
-            elif len(shape) == 5 and shape[0] > size_limit:
-                inputs = inputs[:size_limit]
-                dataset_size = size_limit
-
-            inputs = inputs.reshape(dataset_size, samples, channels, height, width)
-        except:
-            sys.exit(
-                "Input .pb file contains incorrect input size. \nThe required size is: (%s). The real size is: (%s)" %
-                ((dataset_size, samples, channels, height, width), shape))
-
-    return inputs
-
-
-def main():
-    # Parsing command-line arguments
-    parser = argparse.ArgumentParser(description='parsing model and test data set paths')
-    parser.add_argument('--model_path', required=True)
-    parser.add_argument('--dataset_path', required=True)
-    parser.add_argument('--force_fusions', default=False, action='store_true')
-    parser.add_argument('--op_types',
-                        type=str,
-                        default='Conv,MatMul',
-                        help='comma delimited operator types to be calibrated and quantized')
-    parser.add_argument('--black_nodes',
-                        type=str,
-                        default='',
-                        help='comma delimited operator names that should not be quantized')
-    parser.add_argument('--white_nodes',
-                        type=str,
-                        default='',
-                        help='comma delimited operator names force to be quantized')
-    parser.add_argument('--augmented_model_path',
-                        type=str,
-                        default='augmented_model.onnx',
-                        help='save augmented model to this file for verification purpose')
-    parser.add_argument('--output_model_path', type=str, default='calibrated_quantized_model.onnx')
-    parser.add_argument('--dataset_size',
-                        type=int,
-                        default=0,
-                        help="Number of images or tensors to load. Default is 0 which means all samples")
-    parser.add_argument('--data_preprocess',
-                        type=str,
-                        required=True,
-                        choices=['preprocess_method1', 'preprocess_method2', 'None'],
-                        help="Refer to Readme.md for guidance on choosing this option.")
-    args = parser.parse_args()
-    calibrate_op_types = args.op_types.split(',')
-    black_nodes = args.black_nodes.split(',')
-    black_nodes = [x for x in black_nodes if x]
-    white_nodes = args.white_nodes.split(',')
-    white_nodes = [x for x in white_nodes if x]
-    model_path = args.model_path
-    output_model_path = args.output_model_path
-    images_folder = args.dataset_path
-    calib_mode = "naive"
-    size_limit = args.dataset_size
-
-    # Generating augmented ONNX model
-    model = onnx.load(model_path)
-    augmented_model = augment_graph(model, calibrate_op_types, black_nodes, white_nodes)
-    onnx.save(augmented_model, args.augmented_model_path)
-
-    # Conducting inference
-    session = onnxruntime.InferenceSession(args.augmented_model_path, None)
-    (samples, channels, height, width) = session.get_inputs()[0].shape
-
-    # Generating inputs for quantization
-    if args.data_preprocess == "None":
-        inputs = load_pb_file(images_folder, args.dataset_size, samples, channels, height, width)
-    else:
-        inputs = load_batch(images_folder, height, width, args.data_preprocess, size_limit)
-    print(inputs.shape)
-    dict_for_quantization = get_intermediate_outputs(model_path, session, inputs, calib_mode)
-    quantization_params_dict = calculate_quantization_params(model, quantization_thresholds=dict_for_quantization)
-    calibrated_quantized_model = quantize(onnx.load(model_path),
-                                          quantization_mode=QuantizationMode.QLinearOps,
-                                          force_fusions=args.force_fusions,
-                                          quantization_params=quantization_params_dict)
-    onnx.save(calibrated_quantized_model, output_model_path)
-
-    print("Calibrated, quantized model saved.")
-
-
-if __name__ == '__main__':
-    main()
+    print("Calibrated,quantized parameters calculated and returned.")
+    return quantization_params_dict

--- a/onnxruntime/python/tools/quantization/calibrate_user.py
+++ b/onnxruntime/python/tools/quantization/calibrate_user.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# coding: utf-8
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft, Intel Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import os
+import sys
+import numpy as np
+import re
+import subprocess
+import json
+
+import abc
+
+import onnx
+import onnxruntime
+from onnx import helper, TensorProto, numpy_helper
+from quantize import quantize, QuantizationMode
+from calibrate import calibrate
+
+#user-implement preprocess func
+from data_preprocess import preprocess_func
+
+
+class DataRetrieverInterface(metaclass=abc.ABCMeta):
+    @classmethod
+    def __subclasshook__(cls,subclass):
+        return (hasattr(subclass,'get_next') and callable(subclass.get_next) or NotImplemented)
+
+    @abc.abstractmethod
+    def get_next(self) -> dict:
+        """generate the input data dict for ONNXinferenceSession run"""
+        raise NotImplementedError
+
+class CalibrationDataRetriever(DataRetrieverInterface):
+    def __init__(self,calibration_image_folder,augmented_model_path='augmented_model.onnx'): 
+        self.image_folder = calibration_image_folder
+        self.augmented_model_path = augmented_model_path
+        self.preprocess_flag = True
+        self.enum_data_dicts = []
+        self.datasize = 0
+
+    def get_next(self):
+        if self.preprocess_flag:
+            self.preprocess_flag = False
+            session = onnxruntime.InferenceSession(self.augmented_model_path, None)
+            (_,height,width,_) = session.get_inputs()[0].shape
+            nhwc_data_list = preprocess_func(self.image_folder,height,width,size_limit = 0)
+            input_name = session.get_inputs()[0].name
+            self.datasize = len(nhwc_data_list)           
+            self.enum_data_dicts = iter([{input_name:nhwc_data_list[i]} for i in range(self.datasize)])
+        return next(self.enum_data_dicts,None)
+
+def main():
+    model_path = 'path/to/model.onnx'
+    calibration_dataset_path = 'path/to/calibration_data_set'
+    dr = CalibrationDataRetriever(calibration_dataset_path)
+    #call calibrate to generate quantization dictionary containing the zero point and scale values
+    quantization_params_dict = calibrate(model_path,dr)
+    calibrated_quantized_model = quantize(onnx.load(model_path),
+                                          quantization_mode=QuantizationMode.QLinearOps,
+                                          force_fusions=False,
+                                          quantization_params=quantization_params_dict)
+    output_model_path = 'path/to/output_model.onnx'
+    onnx.save(calibrated_quantized_model, output_model_path)
+    print('Calibrated and quantized model saved.')
+
+if __name__ == '__main__':
+   main()

--- a/onnxruntime/python/tools/quantization/data_preprocess.py
+++ b/onnxruntime/python/tools/quantization/data_preprocess.py
@@ -10,61 +10,15 @@ import os
 import sys
 import numpy as np
 
+#user implement preprocess_func
 
-def set_preprocess(preprocess_func_name):
+def preprocess_func(images_folder, height, width, size_limit=0):
     '''
-    Set up the data preprocess function name and function dict. 
-        parameter preprocess_func_name: name of the preprocess function 
-        return: function pointer 
-    '''
-    funcdict = {'preprocess_method1': preprocess_method1, 'preprocess_method2': preprocess_method2}
-    return funcdict[preprocess_func_name]
-
-
-def preprocess_method1(image_filepath, height, width):
-    '''
-    Resizes image to NCHW format. Image is scaled to range [-1, 1].
-    This method is suitable for the mobilenet model from mlperf inference git repo.
-        parameter image_filepath: path to image files
-        parameter height: image height in pixels
-        parameter width: image width in pixels
-        return: matrix characterizing image
-    '''
-    pillow_img = Image.new("RGB", (width, height))
-    pillow_img.paste(Image.open(image_filepath).resize((width, height)))
-    input_data = np.float32(pillow_img) / 127.5 - 1.0  # normalization
-    input_data -= np.mean(input_data)  # normalization
-    nhwc_data = np.expand_dims(input_data, axis=0)
-    nchw_data = nhwc_data.transpose(0, 3, 1, 2)  # ONNX Runtime standard
-    return nchw_data
-
-
-def preprocess_method2(image_filepath, height, width):
-    '''
-    Resizes and normalizes image to NCHW format. 
-    This method is suitable for the resnet50 model from mlperf inference git repo. 
-        parameter image_filepath: path to image files
-        parameter height: image height in pixels
-        parameter width: image width in pixels
-        return: matrix characterizing image
-    '''
-    pillow_img = Image.new("RGB", (width, height))
-    pillow_img.paste(Image.open(image_filepath).resize((width, height)))
-    input_data = np.float32(pillow_img) - \
-        np.array([123.68, 116.78, 103.94], dtype=np.float32)
-    nhwc_data = np.expand_dims(input_data, axis=0)
-    nchw_data = nhwc_data.transpose(0, 3, 1, 2)  # ONNX Runtime standard
-    return nchw_data
-
-
-def load_batch(images_folder, height, width, preprocess_func_name, size_limit=0):
-    '''
-    Loads a batch of images
+    Loads a batch of images and preprocess them
     parameter images_folder: path to folder storing images
     parameter height: image height in pixels
     parameter width: image width in pixels
     parameter size_limit: number of images to load. Default is 0 which means all images are picked.
-    parameter preprocess_func_name: name of the preprocess function
     return: list of matrices characterizing multiple images
     '''
     image_names = os.listdir(images_folder)
@@ -74,10 +28,14 @@ def load_batch(images_folder, height, width, preprocess_func_name, size_limit=0)
         batch_filenames = image_names
     unconcatenated_batch_data = []
 
-    preprocess_func = set_preprocess(preprocess_func_name)
     for image_name in batch_filenames:
         image_filepath = images_folder + '/' + image_name
-        nchw_data = preprocess_func(image_filepath, height, width)
-        unconcatenated_batch_data.append(nchw_data)
+        pillow_img = Image.new("RGB", (width, height))
+        pillow_img.paste(Image.open(image_filepath).resize((width, height)))
+        input_data = np.float32(pillow_img) - \
+        np.array([123.68, 116.78, 103.94], dtype=np.float32)
+        nhwc_data = np.expand_dims(input_data, axis=0)
+        unconcatenated_batch_data.append(nhwc_data)
     batch_data = np.concatenate(np.expand_dims(unconcatenated_batch_data, axis=0), axis=0)
     return batch_data
+


### PR DESCRIPTION
**Description**: Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

- Modify calibration command line tool into a calibrate api, which takes into the original_model_path and a data_retriever object.
- User now has to write 
     1. `CalibrationDataRetriever` object based on `DataRetrieverInterface`
     2. `data_preprocess` file which contains the `preprocess_method()` user needs.
- calibrate_user.py file is an example file for user to call calibrate api and implement its own data_retriever class.
- data_preprocess.py file is an example file for user to write his own preprocess function.