### PR TITLE
Avoid duplicated calls of postprocess in training frontend

### DIFF
--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -278,7 +278,7 @@ def wrap_for_input_match(model, loss_fn, input_names):
 
     return model
 
-def convert_model_loss_fn_to_onnx(model, loss_fn, model_desc, device, inputs, opset_version=DEFAULT_OPSET_VERSION, _enable_internal_postprocess=True):
+def convert_model_loss_fn_to_onnx(model, loss_fn, model_desc, device, inputs, opset_version=DEFAULT_OPSET_VERSION):
     # example: {input0:{0:'batch'}, input1:{0:'batch'}}
     dynamic_axes = {}
     for input in model_desc.inputs_:
@@ -609,6 +609,8 @@ class ORTTrainer():
 
         self.torch_model_ = None
         self.onnx_model_ = None
+        self._enable_internal_postprocess = _enable_internal_postprocess
+
         if isinstance(model, torch.nn.Module):
             self.torch_model_ = model
             self.loss_fn_ = loss_fn
@@ -659,7 +661,6 @@ class ORTTrainer():
         self.frozen_weights_ = frozen_weights
         self.opset_version_ = _opset_version
         self.state_dict_ = None
-        self._enable_internal_postprocess = _enable_internal_postprocess
         self._use_deterministic_compute = _use_deterministic_compute
         self.use_invertible_layernorm_grad = use_invertible_layernorm_grad
 
@@ -730,7 +731,7 @@ class ORTTrainer():
             torch_buffers = list(dict(self.torch_model_.named_buffers()).keys())
             self.frozen_weights_ = self.frozen_weights_ + torch_buffers
             self.onnx_model_ = convert_model_loss_fn_to_onnx(
-                self.torch_model_, self.loss_fn_, self.model_desc_, torch.device('cpu'), inputs, opset_version=self.opset_version_, _enable_internal_postprocess=self._enable_internal_postprocess)
+                self.torch_model_, self.loss_fn_, self.model_desc_, torch.device('cpu'), inputs, opset_version=self.opset_version_)
 
             if self._enable_internal_postprocess:
                 postprocess.run_postprocess(self.onnx_model_)

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -610,6 +610,7 @@ class ORTTrainer():
         self.torch_model_ = None
         self.onnx_model_ = None
         self._enable_internal_postprocess = _enable_internal_postprocess
+        self._extra_postprocess = _extra_postprocess
 
         if isinstance(model, torch.nn.Module):
             self.torch_model_ = model
@@ -646,7 +647,6 @@ class ORTTrainer():
         # we use self.global_step_ to count optimizations being performed.
         # it is used to calculate learning rate if self.get_lr_this_step_ is provided.
         self.global_step_ = global_step
-        self._extra_postprocess = _extra_postprocess
         self.get_lr_this_step_ = get_lr_this_step
         self.loss_scaler_ = loss_scaler
 


### PR DESCRIPTION
It is possible that postprocesses are called multiple times where the provided model is not onnx model, while `load_state_dict` is called from user. (The code will first create an onnx model, and apply postprocesses. It will then initialize the session and apply postprocesses again). The update moves the call to postprocesses such that they are only called when `onnx_model_` is created. To ensure that for any given onnx model the postprocesses are only called once.