### PR TITLE
Optimize CreateEnv by not creating the logging manager instance if env instance has already been created.

### DIFF
--- a/onnxruntime/core/session/ort_env.cc
+++ b/onnxruntime/core/session/ort_env.cc
@@ -37,30 +37,24 @@ OrtEnv* OrtEnv::GetInstance(const OrtEnv::LoggingManagerConstructionInfo& lm_inf
                             onnxruntime::common::Status& status,
                             const OrtThreadingOptions* tp_options) {
   std::lock_guard<onnxruntime::OrtMutex> lock(m_);
-  if (p_instance_) {
-    ++ref_count_;
-    return p_instance_;
-  }
-
-  std::unique_ptr<LoggingManager> lmgr;
-  std::string name = lm_info.logid;
-  if (lm_info.logging_function) {
-    std::unique_ptr<ISink> logger = onnxruntime::make_unique<LoggingWrapper>(lm_info.logging_function,
-                                                                             lm_info.logger_param);
-    lmgr.reset(new LoggingManager(std::move(logger),
-                                  static_cast<Severity>(lm_info.default_warning_level),
-                                  false,
-                                  LoggingManager::InstanceType::Default,
-                                  &name));
-  } else {
-    lmgr.reset(new LoggingManager(std::unique_ptr<ISink>{new CLogSink{}},
-                                  static_cast<Severity>(lm_info.default_warning_level),
-                                  false,
-                                  LoggingManager::InstanceType::Default,
-                                  &name));
-  }
-
   if (!p_instance_) {
+    std::unique_ptr<LoggingManager> lmgr;
+    std::string name = lm_info.logid;
+    if (lm_info.logging_function) {
+      std::unique_ptr<ISink> logger = onnxruntime::make_unique<LoggingWrapper>(lm_info.logging_function,
+                                                                               lm_info.logger_param);
+      lmgr.reset(new LoggingManager(std::move(logger),
+                                    static_cast<Severity>(lm_info.default_warning_level),
+                                    false,
+                                    LoggingManager::InstanceType::Default,
+                                    &name));
+    } else {
+      lmgr.reset(new LoggingManager(std::unique_ptr<ISink>{new CLogSink{}},
+                                    static_cast<Severity>(lm_info.default_warning_level),
+                                    false,
+                                    LoggingManager::InstanceType::Default,
+                                    &name));
+    }
     std::unique_ptr<onnxruntime::Environment> env;
     if (!tp_options) {
       status = onnxruntime::Environment::Create(std::move(lmgr), env);
@@ -72,6 +66,7 @@ OrtEnv* OrtEnv::GetInstance(const OrtEnv::LoggingManagerConstructionInfo& lm_inf
     }
     p_instance_ = new OrtEnv(std::move(env));
   }
+
   ++ref_count_;
   return p_instance_;
 }

--- a/onnxruntime/core/session/ort_env.cc
+++ b/onnxruntime/core/session/ort_env.cc
@@ -37,6 +37,11 @@ OrtEnv* OrtEnv::GetInstance(const OrtEnv::LoggingManagerConstructionInfo& lm_inf
                             onnxruntime::common::Status& status,
                             const OrtThreadingOptions* tp_options) {
   std::lock_guard<onnxruntime::OrtMutex> lock(m_);
+  if (p_instance_) {
+    ++ref_count_;
+    return p_instance_;
+  }
+
   std::unique_ptr<LoggingManager> lmgr;
   std::string name = lm_info.logid;
   if (lm_info.logging_function) {


### PR DESCRIPTION
**Description**: Optimize CreateEnv by not creating the logging manager instance if env instance has already been created.

**Motivation and Context**
Partially resolves https://github.com/microsoft/onnxruntime/issues/4492