### PR TITLE
Create WindowsAI zip files automatically as part of the pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nuget/templates/windowsai.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/windowsai.yml
@@ -270,6 +270,7 @@ jobs:
         }
 
         $merged_nuget = [System.IO.Path]::Combine($merged_nuget_path, $x64_nuget_package_name)
+        $merged_nuget_as_zip = [System.IO.Path]::ChangeExtension($merged_nuget, '.zip')
 
         $zip_tool_directory = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory_root, 'ziptool')
         if (!(Test-Path $zip_tool_directory)) {
@@ -280,6 +281,8 @@ jobs:
 
         Invoke-WebRequest http://stahlworks.com/dev/zip.exe -OutFile $zip_tool
         Start-Process -FilePath $zip_tool -ArgumentList "-r $merged_nuget ." -WorkingDirectory $x64_nupkg_unzipped_directory -NoNewWindow -Wait
+
+        Copy-Item -Path $merged_nuget -Destination $merged_nuget_as_zip
       workingDirectory: $(Build.BinariesDirectory)\nuget-artifact-x64
 
   - template: ../../templates/esrp_nuget.yml

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/windowsai.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/windowsai.yml
@@ -200,6 +200,7 @@ jobs:
         }
 
         $merged_nuget = [System.IO.Path]::Combine($merged_nuget_path, $x64_nuget_package_name)
+        $merged_nuget_as_zip = [System.IO.Path]::ChangeExtension($merged_nuget, '.zip')
 
         $zip_tool_directory = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory_root, 'ziptool')
         if (!(Test-Path $zip_tool_directory)) {
@@ -210,6 +211,8 @@ jobs:
 
         Invoke-WebRequest http://stahlworks.com/dev/zip.exe -OutFile $zip_tool
         Start-Process -FilePath $zip_tool -ArgumentList "-r $merged_nuget ." -WorkingDirectory $x64_nupkg_unzipped_directory -NoNewWindow -Wait
+        
+        Copy-Item -Path $merged_nuget -Destination $merged_nuget_as_zip
       workingDirectory: $(Build.BinariesDirectory)\nuget-artifact-x64
 
   - task: PowerShell@2
@@ -270,7 +273,7 @@ jobs:
         }
 
         $merged_nuget = [System.IO.Path]::Combine($merged_nuget_path, $x64_nuget_package_name)
-        $merged_nuget_as_zip = [System.IO.Path]::ChangeExtension($merged_nuget, '.zip')
+        $merged_nuget_as_zip = [System.IO.Path]::ChangeExtension($merged_nuget, '.symbols.zip')
 
         $zip_tool_directory = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory_root, 'ziptool')
         if (!(Test-Path $zip_tool_directory)) {


### PR DESCRIPTION
Issue: During onnxruntime releases, the windows ai package must be manually renamed to create the corresponding zip file upload on the nuget release page.

Fix: The nupkg was split into binaries and symbols. Each build produces a nupkg, and a snupkg. These pacakges are automatically renamed to:
.nupkg => .zip
.snupkg => .symbols.zip