### PR TITLE
Rename inner-scoped variable to avoid MSVC warning

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/vadm_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/vadm_backend.cc
@@ -64,10 +64,10 @@ VADMBackend::VADMBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
       exe_networks.push_back(exe_network);
     }
     LOGS_DEFAULT(INFO) << log_tag << "Loaded model to the plugin";
-    for(size_t i = 0; i < num_inf_reqs_; i++) {
+    for(size_t j = 0; j < num_inf_reqs_; j++) {
       InferenceEngine::InferRequest::Ptr infRequest;
       try {
-        infRequest = exe_networks[i].CreateInferRequestPtr();
+        infRequest = exe_networks[j].CreateInferRequestPtr();
       } catch(InferenceEngine::details::InferenceEngineException e) {
         ORT_THROW(log_tag + "Exception while creating InferRequest object: " + e.what());
       } catch (...) {


### PR DESCRIPTION
**Description**: Renames inner scoped variable differently from outer scoped variable to avoid build failure due to compiler warning.

**Motivation and Context**
- Certain version of MSVC compilers throw a warning if the inner-scoped name is same as the outer scoped name, which are treated as errors and cause build failure.