### PR TITLE
Force return_tuple in transformers for onnx exporter

### DIFF
--- a/onnxruntime/python/tools/transformers/benchmark_gpt2.py
+++ b/onnxruntime/python/tools/transformers/benchmark_gpt2.py
@@ -126,6 +126,8 @@ def main():
     model_class = MODEL_CLASSES[args.model_class][0]
 
     config = AutoConfig.from_pretrained(args.model_name, torchscript=args.torchscript, cache_dir=cache_dir)
+    if hasattr(config, 'return_tuple'):
+        config.return_tuple = True
     model = model_class.from_pretrained(args.model_name, config=config, cache_dir=cache_dir)
 
     # This scirpt does not support float16 for PyTorch.

--- a/onnxruntime/python/tools/transformers/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/convert_to_onnx.py
@@ -111,7 +111,10 @@ def main():
         assert not args.use_gpu, "quantization only supports CPU"
 
     model_class = MODEL_CLASSES[args.model_class][0]
-    model = model_class.from_pretrained(args.model_name_or_path, cache_dir=cache_dir)
+    config = AutoConfig.from_pretrained(args.model_name_or_path, cache_dir=cache_dir)
+    if hasattr(config, 'return_tuple'):
+        config.return_tuple = True
+    model = model_class.from_pretrained(args.model_name_or_path, config=config, cache_dir=cache_dir)
 
     device = torch.device("cuda:0" if args.use_gpu else "cpu")
     model.eval().to(device)

--- a/onnxruntime/python/tools/transformers/onnx_exporter.py
+++ b/onnxruntime/python/tools/transformers/onnx_exporter.py
@@ -167,6 +167,8 @@ def export_onnx_model(model_name, opset_version, use_external_data_format, model
                       use_gpu, precision, optimize_onnx, validate_onnx, use_raw_attention_mask, overwrite,
                       model_fusion_statistics):
     config = AutoConfig.from_pretrained(model_name, cache_dir=cache_dir)
+    if hasattr(config, 'return_tuple'):
+        config.return_tuple = True
     model = load_pretrained_model(model_name, config=config, cache_dir=cache_dir)
     model.cpu()
 


### PR DESCRIPTION
**Description**: 

Huggingface transformers recently added a breaking change that outputs object instead of tuples. That will break existing ONNX conversion. The solution is to set the config attribute torchscript or return_tuple to be True, so that transformers could output tuples. Here we use the later one since the attribute name is more straightforward.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

To avoid ONNX exporter failure in benchmark.
