### PR TITLE
Disable GPU Timeouts for DirectX/DML sessions in WinML

### DIFF
--- a/winml/lib/Api.Image/D3DDeviceCache.cpp
+++ b/winml/lib/Api.Image/D3DDeviceCache.cpp
@@ -160,6 +160,7 @@ wgdx::Direct3D11::IDirect3DDevice D3DDeviceCache::GetWinrtDevice() {
 void D3DDeviceCache::InitializeCommandQueue(ID3D12Device1* device) {
   D3D12_COMMAND_QUEUE_DESC queueDesc = {};
   queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+  queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_DISABLE_GPU_TIMEOUT;
   WINML_THROW_IF_FAILED(device->CreateCommandQueue(&queueDesc, winrt::guid_of<ID3D12CommandQueue>(), command_queue_.put_void()));
 
   // If possible get the sharing context. If not leave nullptr;


### PR DESCRIPTION
Disable GPU Timeouts for DirectX/DML sessions in WinML

Issue: Long running ML tasks in WinML timeout after 2 seconds. Note, if they are preempted by the gpu, the 2 second time resets, and can afford the ML task more time. This can lead to transient behavior, where ML tasks sometimes complete succesfully, and other times TDR.

Fix: Disable 2 second timeout with queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_DISABLE_GPU_TIMEOUT; when creating the CommandQueue.