### PR TITLE
Update ModelDescription and minor fix on ORTTrainer ctor

### DIFF
--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -6,6 +6,7 @@ from . import ORTTrainerOptions
 from . import optim
 from .model_desc_validation import _ORTTrainerModelDesc
 
+
 class TrainStepInfo(object):
     r"""Private class used to store runtime information from current train step.
 
@@ -141,7 +142,10 @@ class ORTTrainer(object):
 
         self.model_desc = _ORTTrainerModelDesc(model_desc)
         self.optim_config = optim_config
-        self.options = ORTTrainerOptions(options)
+        if options:
+            self.options = ORTTrainerOptions(options)
+        else:
+            self.options = ORTTrainerOptions()
 
     def eval_step(self, *input, **kwargs):
         r"""Evaluation step method

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -222,7 +222,7 @@ class ORTTrainerOptions(object):
             fp16_enabled = opts.mixed_precision.enabled
      """
 
-    def __init__(self, options):
+    def __init__(self, options={}):
         # Keep a copy of original input for debug
         self._original_opts = dict(options)
 

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -65,7 +65,7 @@ def testORTTrainerOptionsInvalidMixedPrecisionEnabledSchema():
     assert str(e.value) == expected_msg
 
 
-@pytest.mark.parametrize("test_data,input_dtype,output_dtype", [
+@pytest.mark.parametrize("input_dict,input_dtype,output_dtype", [
     ({'inputs': [('in0', [])],
       'outputs': [('out0', []), ('out1', [])]},(torch.int,),(torch.float,torch.int32,)),
     ({'inputs': [('in0', ['batch', 2, 3])],
@@ -74,22 +74,22 @@ def testORTTrainerOptionsInvalidMixedPrecisionEnabledSchema():
       'outputs': [('out0', [], True), ('out1', [1], False), ('out2', [1, 'dyn_ax1', 3])]},
         (torch.float,torch.uint8,torch.bool,torch.double,torch.half,), (torch.float,torch.float,torch.int64))
 ])
-def testORTTrainerModelDescValidSchemas(test_data, input_dtype, output_dtype):
+def testORTTrainerModelDescValidSchemas(input_dict, input_dtype, output_dtype):
     r''' Test different ways of using default values for incomplete input'''
 
     # Validating model description from user
-    model_description = md_val._ORTTrainerModelDesc(test_data)
+    model_description = md_val._ORTTrainerModelDesc(input_dict)
     for idx, i_desc in enumerate(model_description.inputs):
         assert isinstance(i_desc, model_description._InputDescription)
         assert len(i_desc) == 2
-        assert test_data['inputs'][idx][0] == i_desc.name
-        assert test_data['inputs'][idx][1] == i_desc.shape
+        assert input_dict['inputs'][idx][0] == i_desc.name
+        assert input_dict['inputs'][idx][1] == i_desc.shape
     for idx, o_desc in enumerate(model_description.outputs):
         assert isinstance(o_desc, model_description._OutputDescription)
         assert len(o_desc) == 3
-        assert test_data['outputs'][idx][0] == o_desc.name
-        assert test_data['outputs'][idx][1] == o_desc.shape
-        is_loss = test_data['outputs'][idx][2] if len(test_data['outputs'][idx]) == 3 else False
+        assert input_dict['outputs'][idx][0] == o_desc.name
+        assert input_dict['outputs'][idx][1] == o_desc.shape
+        is_loss = input_dict['outputs'][idx][2] if len(input_dict['outputs'][idx]) == 3 else False
         assert is_loss == o_desc.is_loss
 
     # Append type to inputs/outputs tuples
@@ -109,7 +109,7 @@ def testORTTrainerModelDescValidSchemas(test_data, input_dtype, output_dtype):
         assert output_dtype[idx] == o_desc.dtype
 
 
-@pytest.mark.parametrize("test_data,error_msg", [
+@pytest.mark.parametrize("input_dict,error_msg", [
     ({'inputs': [(True, [])],
       'outputs': [(True, [])]},
       "Invalid model_desc: {'inputs': [{0: ['the first element of the tuple (aka name) must be a string']}], "
@@ -135,10 +135,10 @@ def testORTTrainerModelDescValidSchemas(test_data, input_dtype, output_dtype):
       'outputz': [('out1', [], True)]},
       "Invalid model_desc: {'outputs': ['required field'], 'outputz': ['unknown field']}"),
 ])
-def testORTTrainerModelDescInvalidSchemas(test_data, error_msg):
+def testORTTrainerModelDescInvalidSchemas(input_dict, error_msg):
     r''' Test different ways of using default values for incomplete input'''
     with pytest.raises(ValueError) as e:
-        md_val._ORTTrainerModelDesc(test_data)
+        md_val._ORTTrainerModelDesc(input_dict)
     assert str(e.value) == error_msg
 
 

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -65,20 +65,51 @@ def testORTTrainerOptionsInvalidMixedPrecisionEnabledSchema():
     assert str(e.value) == expected_msg
 
 
-@pytest.mark.parametrize("test_input", [
+@pytest.mark.parametrize("test_data,input_dtype,output_dtype", [
     ({'inputs': [('in0', [])],
-      'outputs': [('out0', []), ('out1', [])]}),
+      'outputs': [('out0', []), ('out1', [])]},(torch.int,),(torch.float,torch.int32,)),
     ({'inputs': [('in0', ['batch', 2, 3])],
-      'outputs': [('out0', [], True)]}),
+      'outputs': [('out0', [], True)]}, (torch.int8,), (torch.int16,)),
     ({'inputs': [('in0', []), ('in1', [1]), ('in2', [1, 2]), ('in3', [1000, 'dyn_ax1']), ('in4', ['dyn_ax1', 'dyn_ax2', 'dyn_ax3'])],
-      'outputs': [('out0', [], True), ('out1', [1], False), ('out2', [1, 'dyn_ax1', 3])]})
+      'outputs': [('out0', [], True), ('out1', [1], False), ('out2', [1, 'dyn_ax1', 3])]},
+        (torch.float,torch.uint8,torch.bool,torch.double,torch.half,), (torch.float,torch.float,torch.int64))
 ])
-def testORTTrainerModelDescValidSchemas(test_input):
+def testORTTrainerModelDescValidSchemas(test_data, input_dtype, output_dtype):
     r''' Test different ways of using default values for incomplete input'''
-    md_val._ORTTrainerModelDesc(test_input)
+
+    # Validating model description from user
+    model_description = md_val._ORTTrainerModelDesc(test_data)
+    for idx, i_desc in enumerate(model_description.inputs):
+        assert isinstance(i_desc, model_description._InputDescription)
+        assert len(i_desc) == 2
+        assert test_data['inputs'][idx][0] == i_desc.name
+        assert test_data['inputs'][idx][1] == i_desc.shape
+    for idx, o_desc in enumerate(model_description.outputs):
+        assert isinstance(o_desc, model_description._OutputDescription)
+        assert len(o_desc) == 3
+        assert test_data['outputs'][idx][0] == o_desc.name
+        assert test_data['outputs'][idx][1] == o_desc.shape
+        is_loss = test_data['outputs'][idx][2] if len(test_data['outputs'][idx]) == 3 else False
+        assert is_loss == o_desc.is_loss
+
+    # Append type to inputs/outputs tuples
+    for idx, i_desc in enumerate(model_description.inputs):
+        model_description.add_type_to_input_description(idx, input_dtype[idx])
+    for idx, o_desc in enumerate(model_description.outputs):
+        model_description.add_type_to_output_description(idx, output_dtype[idx])
+
+    # Verify inputs/outputs tuples are replaced by the typed counterparts
+    for idx, i_desc in enumerate(model_description.inputs):
+        assert len(i_desc) == 3
+        assert isinstance(i_desc, model_description._InputDescriptionTyped)
+        assert input_dtype[idx] == i_desc.dtype
+    for idx, o_desc in enumerate(model_description.outputs):
+        assert len(o_desc) == 4
+        assert isinstance(o_desc, model_description._OutputDescriptionTyped)
+        assert output_dtype[idx] == o_desc.dtype
 
 
-@pytest.mark.parametrize("test_input,error_msg", [
+@pytest.mark.parametrize("test_data,error_msg", [
     ({'inputs': [(True, [])],
       'outputs': [(True, [])]},
       "Invalid model_desc: {'inputs': [{0: ['the first element of the tuple (aka name) must be a string']}], "
@@ -97,11 +128,17 @@ def testORTTrainerModelDescValidSchemas(test_input):
     ({'inputs': [('in1', [])],
       'outputs': [('out1', [], True), ('out2', [], True)]},
       "Invalid model_desc: {'outputs': [{1: ['only one is_loss can bet set to True']}]}"),
+    ({'inputz': [('in1', [])],
+      'outputs': [('out1', [], True)]},
+      "Invalid model_desc: {'inputs': ['required field'], 'inputz': ['unknown field']}"),
+    ({'inputs': [('in1', [])],
+      'outputz': [('out1', [], True)]},
+      "Invalid model_desc: {'outputs': ['required field'], 'outputz': ['unknown field']}"),
 ])
-def testORTTrainerModelDescInvalidSchemas(test_input, error_msg):
+def testORTTrainerModelDescInvalidSchemas(test_data, error_msg):
     r''' Test different ways of using default values for incomplete input'''
     with pytest.raises(ValueError) as e:
-        md_val._ORTTrainerModelDesc(test_input)
+        md_val._ORTTrainerModelDesc(test_data)
     assert str(e.value) == error_msg
 
 


### PR DESCRIPTION
This PR keeps the public API intact, but changes how model description is stored on the backend

Currently, users creates a dict with two lists of tuples. One list called 'inputs' and each tuple has the following format tuple(name, shape). The second list is called 'outputs' and each tuple can be either tuple(name, shape) or tuple(name, shape, is_loss).

With this PR, when this dict is passed in to ORTTrainer, it is fully validated as usual. However, tuples are internally replaced by namedtuples and all output tuples will have tuple(name, shape, is_loss) format instead of is_loss being optionally present.

Additionally to that normalization in the internal representation (which eases coding), two internal methods were created to replace a namedtuple(name, shape) to namedtuple(name, shape, dtype) or namedtuple(name, shape, is_loss, dtype) dependeing whether the tuple is an input or output.

This is necessary as ORTTRainer finds out data types of each input/output during model export to onnx.

Finally, a minor fix was done on ORTTrainer. It could initialize ORTTrainerOptions incorrectly when options=None