### PR TITLE
WinML should dynamically link against onnxruntime.dll and only system32 for inbox builds

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -191,7 +191,7 @@ target_compile_definitions(winml_lib_ort PRIVATE WINML_ROOT_NS=${winml_root_ns})
 target_compile_definitions(winml_lib_ort PRIVATE PLATFORM_WINDOWS)
 target_compile_definitions(winml_lib_ort PRIVATE _SCL_SECURE_NO_WARNINGS)                         # remove warnings about unchecked iterators
 if (onnxruntime_WINML_NAMESPACE_OVERRIDE STREQUAL "Windows")
-  target_compile_definitions(winml_lib_ort PRIVATE "/DBUILD_INBOX=1")
+  target_compile_definitions(winml_lib_ort PRIVATE "BUILD_INBOX=1")
 endif()
 
 # Specify the usage of a precompiled header

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -190,6 +190,9 @@ target_compile_options(winml_lib_ort PRIVATE /GR- /await /wd4238)
 target_compile_definitions(winml_lib_ort PRIVATE WINML_ROOT_NS=${winml_root_ns})
 target_compile_definitions(winml_lib_ort PRIVATE PLATFORM_WINDOWS)
 target_compile_definitions(winml_lib_ort PRIVATE _SCL_SECURE_NO_WARNINGS)                         # remove warnings about unchecked iterators
+if (onnxruntime_WINML_NAMESPACE_OVERRIDE STREQUAL "Windows")
+  target_compile_definitions(winml_lib_ort PRIVATE "/DBUILD_INBOX=1")
+endif()
 
 # Specify the usage of a precompiled header
 target_precompiled_header(winml_lib_ort pch.h)
@@ -618,7 +621,6 @@ add_dependencies(winml_dll winml_api_native)
 add_dependencies(winml_dll winml_api_native_internal)
 
 # Link libraries
-target_link_libraries(winml_dll PRIVATE onnxruntime)
 target_link_libraries(winml_dll PRIVATE re2)
 target_link_libraries(winml_dll PRIVATE wil)
 target_link_libraries(winml_dll PRIVATE winml_lib_api)

--- a/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
@@ -13,14 +13,56 @@
 
 using namespace _winml;
 
+static HRESULT GetOnnxruntimeLibrary(HMODULE& module) {
+  std::string system_path(MAX_PATH);
+#ifdef BUILD_INBOX
+  if (0 >= GetSystemDirectoryA(system_path.data(), system_path.size()))
+  {
+    return HRESULT_FROM_WIN32(GetLastError());
+  }
+  system_path += "onnxruntime.dll";
+#else
+  system_path = "onnxruntime.dll";
+#endif
+
+  auto out_module = LoadLibraryA(system_path.data());
+  if (out_module == nullptr)
+  {
+    return HRESULT_FROM_WIN32(GetLastError());
+  }
+  module = out_module;
+  return S_OK;
+}
+
 static const OrtApi* GetVersionedOrtApi() {
+  HMODULE onnxruntime_dll;
+  FAIL_FAST_IF_FAILED(GetOnnxruntimeLibrary(onnxruntime_dll));
+
+  using OrtGetApiBaseSignature = decltype(OrtGetApiBase);
+  auto ort_get_api_base_fn = static_cast<OrtGetApiBaseSignature>(GetProcAddress(onnxruntime_dll, "OrtGetApiBase"));
+  if (ort_get_api_base_fn == nullptr)
+  {
+    FAIL_FAST_HR(HRESULT_FROM_WIN32(GetLastError()));
+  }
+
+  const auto ort_api_base = ort_get_api_base_fn();
+
   static const uint32_t ort_version = 2;
-  const auto ort_api_base = OrtGetApiBase();
   return ort_api_base->GetApi(ort_version);
 }
 
 static const WinmlAdapterApi* GetVersionedWinmlAdapterApi() {
-  return OrtGetWinMLAdapter(GetVersionedOrtApi());
+  HMODULE onnxruntime_dll;
+  FAIL_FAST_IF_FAILED(GetOnnxruntimeLibrary(onnxruntime_dll));
+
+  using OrtGetWinMLAdapterSignature = decltype(OrtGetWinMLAdapter);
+  auto ort_get_winml_adapter_fn = static_cast<OrtGetWinMLAdapterSignature>(GetProcAddress(onnxruntime_dll, "OrtGetWinMLAdapter"));
+  if (ort_get_winml_adapter_fn == nullptr)
+  {
+    FAIL_FAST_HR(HRESULT_FROM_WIN32(GetLastError()));
+  }
+
+  return ort_get_winml_adapter_fn(GetVersionedOrtApi());
 }
 
 static ONNXTensorElementDataType
@@ -639,7 +681,7 @@ HRESULT OnnxruntimeEngine::CreateTensorValueFromExternalD3DResource(ID3D12Resour
   auto unique_dml_allocator_resource =
       DmlAllocatorResource(dml_allocator_resource,
                            [](void* ptr) {
-                             GetVersionedWinmlAdapterApi()->DmlFreeGPUAllocation(ptr);
+                             winml_adapter_api->DmlFreeGPUAllocation(ptr);
                            });
 
   // create the OrtValue as a tensor letting ort know that we own the data buffer

--- a/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp
@@ -14,18 +14,12 @@ using namespace _winml;
 static bool debug_output_ = false;
 
 static HRESULT GetOnnxruntimeLibrary(HMODULE& module) {
-  std::string system_path;
+  DWORD flags = 0;
 #ifdef BUILD_INBOX
-  system_path.reserve(MAX_PATH);
-  if (0 >= GetSystemDirectoryA(system_path.data(), system_path.size())) {
-    return HRESULT_FROM_WIN32(GetLastError());
-  }
-  system_path += "\\onnxruntime.dll";
-#else
-  system_path = "onnxruntime.dll";
+  flags = LOAD_LIBRARY_SEARCH_SYSTEM32;
 #endif
 
-  auto out_module = LoadLibraryExA(system_path.data());
+  auto out_module = LoadLibraryExA("onnxruntime.dll", nullptr, flags);
   if (out_module == nullptr) {
     return HRESULT_FROM_WIN32(GetLastError());
   }

--- a/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp
@@ -7,9 +7,64 @@
 #include "core/platform/windows/TraceLoggingConfig.h"
 #include <evntrace.h>
 
+#include <windows.h>
+
 using namespace _winml;
 
 static bool debug_output_ = false;
+
+static HRESULT GetOnnxruntimeLibrary(HMODULE& module) {
+  std::string system_path;
+#ifdef BUILD_INBOX
+  system_path.reserve(MAX_PATH);
+  if (0 >= GetSystemDirectoryA(system_path.data(), system_path.size())) {
+    return HRESULT_FROM_WIN32(GetLastError());
+  }
+  system_path += "onnxruntime.dll";
+#else
+  system_path = "onnxruntime.dll";
+#endif
+
+  auto out_module = LoadLibraryA(system_path.data());
+  if (out_module == nullptr) {
+    return HRESULT_FROM_WIN32(GetLastError());
+  }
+  module = out_module;
+  return S_OK;
+}
+
+const OrtApi* _winml::GetVersionedOrtApi() {
+  HMODULE onnxruntime_dll;
+  FAIL_FAST_IF_FAILED(GetOnnxruntimeLibrary(onnxruntime_dll));
+
+  using OrtGetApiBaseSignature = decltype(OrtGetApiBase);
+  auto ort_get_api_base_fn = reinterpret_cast<OrtGetApiBaseSignature*>(GetProcAddress(onnxruntime_dll, "OrtGetApiBase"));
+  if (ort_get_api_base_fn == nullptr) {
+    FAIL_FAST_HR(HRESULT_FROM_WIN32(GetLastError()));
+  }
+
+  const auto ort_api_base = ort_get_api_base_fn();
+
+  static const uint32_t ort_version = 2;
+  return ort_api_base->GetApi(ort_version);
+}
+
+static const WinmlAdapterApi* GetVersionedWinmlAdapterApi(const OrtApi* ort_api) {
+  HMODULE onnxruntime_dll;
+  FAIL_FAST_IF_FAILED(GetOnnxruntimeLibrary(onnxruntime_dll));
+
+  using OrtGetWinMLAdapterSignature = decltype(OrtGetWinMLAdapter);
+  auto ort_get_winml_adapter_fn = reinterpret_cast<OrtGetWinMLAdapterSignature*>(GetProcAddress(onnxruntime_dll, "OrtGetWinMLAdapter"));
+  if (ort_get_winml_adapter_fn == nullptr) {
+    FAIL_FAST_HR(HRESULT_FROM_WIN32(GetLastError()));
+  }
+
+  return ort_get_winml_adapter_fn(ort_api);
+}
+
+const WinmlAdapterApi* _winml::GetVersionedWinmlAdapterApi() {
+  return GetVersionedWinmlAdapterApi(GetVersionedOrtApi());
+}
 
 static void __stdcall WinmlOrtLoggingCallback(void* param, OrtLoggingLevel severity, const char* category,
                                     const char* logger_id, const char* code_location, const char* message) noexcept {
@@ -128,7 +183,7 @@ OnnxruntimeEnvironment::OnnxruntimeEnvironment(const OrtApi* ort_api) : ort_env_
   ort_env_ = UniqueOrtEnv(ort_env, ort_api->ReleaseEnv);
 
   // Configure the environment with the winml logger
-  auto winml_adapter_api = OrtGetWinMLAdapter(ort_api);
+  auto winml_adapter_api = GetVersionedWinmlAdapterApi(ort_api);
   THROW_IF_NOT_OK_MSG(winml_adapter_api->EnvConfigureCustomLoggerAndProfiler(ort_env_.get(),
                                                                              &WinmlOrtLoggingCallback, &WinmlOrtProfileEventCallback, nullptr,
                                                                              OrtLoggingLevel::ORT_LOGGING_LEVEL_VERBOSE, "Default", &ort_env),

--- a/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp
@@ -25,7 +25,7 @@ static HRESULT GetOnnxruntimeLibrary(HMODULE& module) {
   system_path = "onnxruntime.dll";
 #endif
 
-  auto out_module = LoadLibraryA(system_path.data());
+  auto out_module = LoadLibraryExA(system_path.data());
   if (out_module == nullptr) {
     return HRESULT_FROM_WIN32(GetLastError());
   }

--- a/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp
@@ -20,7 +20,7 @@ static HRESULT GetOnnxruntimeLibrary(HMODULE& module) {
   if (0 >= GetSystemDirectoryA(system_path.data(), system_path.size())) {
     return HRESULT_FROM_WIN32(GetLastError());
   }
-  system_path += "onnxruntime.dll";
+  system_path += "\\onnxruntime.dll";
 #else
   system_path = "onnxruntime.dll";
 #endif

--- a/winml/lib/Api.Ort/OnnxruntimeEnvironment.h
+++ b/winml/lib/Api.Ort/OnnxruntimeEnvironment.h
@@ -19,6 +19,9 @@ class OnnxruntimeEnvironment {
   UniqueOrtEnv ort_env_;
 };
 
+const OrtApi* GetVersionedOrtApi();
+const WinmlAdapterApi* GetVersionedWinmlAdapterApi();
+
 }  // namespace _winml
 
 #pragma warning(pop)


### PR DESCRIPTION
Issue: WinML is layered on top of onnxruntime.dll. On Inbox builds, onnxruntime.dll ships in system32. If the WinML redist is used, a version of onnxruntime (from the redist) is binplaced next to the calling application. This overrides loadlibrary search order, and calls into the Inbox Windows::AI::MachineLearning namespace are redirected to the redist onnxruntime.dll. 

Fix: Onnxruntime calls in inbox builds should always ONLY reference the system32 version of onnxruntimel.dll. To do this, the onnxruntime.dll is dynamically loaded from system32 directly on inbox builds, and using normal loadlibrary search order for redist calls.