### PR TITLE
DirectML.dll is loaded via LoadLibraryW but should use LoadLibraryExA

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -254,6 +254,10 @@ endif()
 
 add_library(winml_adapter ${winml_adapter_files})
 
+if (onnxruntime_WINML_NAMESPACE_OVERRIDE STREQUAL "Windows") 
+  target_compile_definitions(winml_adapter PRIVATE "BUILD_INBOX=1") 
+endif()
+
 # wil requires C++17
 set_target_properties(winml_adapter PROPERTIES CXX_STANDARD 17)
 set_target_properties(winml_adapter PROPERTIES CXX_STANDARD_REQUIRED ON)

--- a/winml/adapter/winml_adapter_dml.cpp
+++ b/winml/adapter/winml_adapter_dml.cpp
@@ -13,14 +13,20 @@
 #include "core/session/abi_session_options_impl.h"
 #include "core/providers/dml/dml_provider_factory.h"
 #include "core/providers/dml/DmlExecutionProvider/inc/DmlExecutionProvider.h"
+#include <windows.h>
 #endif  // USE_DML
 
 namespace winmla = Windows::AI::MachineLearning::Adapter;
 
 #ifdef USE_DML
 Microsoft::WRL::ComPtr<IDMLDevice> CreateDmlDevice(ID3D12Device* d3d12Device) {
+  DWORD flags = 0; 
+#ifdef BUILD_INBOX 
+  flags = LOAD_LIBRARY_SEARCH_SYSTEM32; 
+#endif
+
   // Dynamically load DML to avoid WinML taking a static dependency on DirectML.dll
-  wil::unique_hmodule dmlDll(LoadLibraryW(L"DirectML.dll"));
+  wil::unique_hmodule dmlDll(LoadLibraryExA("DirectML.dll", nullptr, flags));
   THROW_LAST_ERROR_IF(!dmlDll);
 
   auto dmlCreateDevice1Fn = reinterpret_cast<decltype(&DMLCreateDevice1)>(


### PR DESCRIPTION
Issue: Loading DirectML.dll will always use the local directml.dll. Inbox builds should use the system32 version.

Fix: Switch to LoadLibraryExA and search order set to system32 on for inbox builds.