### PR TITLE
Fix py-packaging pipeline

### DIFF
--- a/orttraining/orttraining/training_ops/cpu/tensor/split.cc
+++ b/orttraining/orttraining/training_ops/cpu/tensor/split.cc
@@ -57,7 +57,7 @@ Status PrepareForTrainingCompute(const TensorShape& input_shape, int num_outputs
                              " Num entries in 'split' (must equal number of outputs) was ", split_sizes_values.size(),
                              " Sum of sizes in 'split' (must equal size of selected axis) was ", split_size_sum);
 
-      split_sizes = split_sizes_values;
+    split_sizes = split_sizes_values;
   }
 
   return Status::OK();


### PR DESCRIPTION
Fix build error in split.cc: 
/onnxruntime_src/orttraining/orttraining/training_ops/cpu/tensor/split.cc

abandoning as this is dup of:
https://github.com/microsoft/onnxruntime/pull/4629