### PR TITLE
remove ENABLE_TELEMETRY macro

### DIFF
--- a/include/onnxruntime/core/platform/windows/TraceLoggingConfig.h
+++ b/include/onnxruntime/core/platform/windows/TraceLoggingConfig.h
@@ -23,7 +23,7 @@ Environment:
 
 // Configuration macro for use in TRACELOGGING_DEFINE_PROVIDER. The definition
 // in this file configures the provider as a normal (non-telemetry) provider.
-#ifndef ENABLE_TELEMETRY
+#ifndef TraceLoggingOptionMicrosoftTelemetry
 #define TraceLoggingOptionMicrosoftTelemetry() \
     TraceLoggingOptionGroup(0000000000, 00000, 00000, 0000, 0000, 0000, 0000, 0000, 000, 0000, 0000)
     // Empty definition for TraceLoggingOptionMicrosoftTelemetry

--- a/tools/ci_build/github/azure-pipelines/templates/telemetry-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/telemetry-steps.yml
@@ -12,7 +12,7 @@ steps:
 
     - powershell: |
         $length = $env:TELEMETRYGUID.length
-        $fileContent = "#define ENABLE_TELEMETRY`n#define TraceLoggingOptionMicrosoftTelemetry() \
+        $fileContent = "#define TraceLoggingOptionMicrosoftTelemetry() \
           TraceLoggingOptionGroup("+$env:TELEMETRYGUID.substring(1, $length-2)+")"
         New-Item -Path "$(Build.SourcesDirectory)\include\onnxruntime\core\platform\windows\TraceLoggingConfigPrivate.h" -ItemType "file" -Value "$fileContent" -Force
       displayName: 'Create TraceLoggingConfigPrivate.h For WinML Telemetry'

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-2019.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-2019.yml
@@ -54,7 +54,7 @@ jobs:
         if($env:TELEMETRYGUID)
         {
           $length = $env:TELEMETRYGUID.length
-          $fileContent = "#define ENABLE_TELEMETRY`n#define TraceLoggingOptionMicrosoftTelemetry() \
+          $fileContent = "#define TraceLoggingOptionMicrosoftTelemetry() \
             TraceLoggingOptionGroup("+$env:TELEMETRYGUID.substring(1, $length-2)+")"
           New-Item -Path "$(Build.SourcesDirectory)\include\onnxruntime\core\platform\windows\TraceLoggingConfigPrivate.h" -ItemType "file" -Value "$fileContent" -Force
           Write-Output "Enabling TELEMETRY"

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-arm.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-arm.yml
@@ -34,7 +34,7 @@ jobs:
         if($env:TELEMETRYGUID)
         {
           $length = $env:TELEMETRYGUID.length
-          $fileContent = "#define ENABLE_TELEMETRY`n#define TraceLoggingOptionMicrosoftTelemetry() \
+          $fileContent = "#define TraceLoggingOptionMicrosoftTelemetry() \
             TraceLoggingOptionGroup("+$env:TELEMETRYGUID.substring(1, $length-2)+")"
           New-Item -Path "$(Build.SourcesDirectory)\include\onnxruntime\core\platform\windows\TraceLoggingConfigPrivate.h" -ItemType "file" -Value "$fileContent" -Force
           Write-Output "Enabling TELEMETRY"


### PR DESCRIPTION
**Description**: This PR is to remove the ENABLE_TELEMETRY macro added in the generated traceloggingconfigprivate.h, which can be replaced by the TraceLoggingOptionMicrosoftTelemetry itself, so to reduce the code needed to be generated. 

