### PR TITLE
Change ignore_index to 0 in Bert-Loss.

### DIFF
--- a/orttraining/orttraining/core/graph/loss_func/bert_loss.cc
+++ b/orttraining/orttraining/core/graph/loss_func/bert_loss.cc
@@ -122,7 +122,7 @@ GraphAugmenter::GraphDefs BertLoss::operator()(const Graph& graph, const LossFun
                                    "Reshape_label"));
 
     std::vector<AttributeProto> attrs;
-    attrs.push_back(ONNX_NAMESPACE::MakeAttribute("ignore_index", static_cast<int64_t>(-1)));
+    attrs.push_back(ONNX_NAMESPACE::MakeAttribute("ignore_index", static_cast<int64_t>(0)));
     attrs.push_back(ONNX_NAMESPACE::MakeAttribute("reduction", "mean"));
 
     new_nodes.emplace_back(NodeDef("SoftmaxCrossEntropyLoss",


### PR DESCRIPTION
Since training data has zero for examples to ignore and this loss function is used internally on this dataset ONLY.

Fixes e2e convergence test pipeline.