### PR TITLE
support data parallel + pipeline parallel

### DIFF
--- a/orttraining/orttraining/core/framework/distributed_run_context.cc
+++ b/orttraining/orttraining/core/framework/distributed_run_context.cc
@@ -47,9 +47,9 @@ DistributedRunContext::DistributedRunContext(int32_t world_rank,
   params_.pipeline_stage_size = pipeline_stage_size;
   groups_.resize(static_cast<size_t>(WorkerGroupType::WorkerGroupTypeCount));
 
-  // Consider distributed training forms three axis, data parallel, horizontal parallel and pipeline parallel.
-  // The three axis are pependicular to each other and like x, y, z axis in 3D space (but only the positive directions).
-  // Now the world ranks are numbers filling in this 3D space alone the three axis. It will try fill alone the
+  // Consider distributed training forms three axes, data parallel, horizontal parallel and pipeline parallel.
+  // The three axes are pependicular to each other and like x, y, z axes in 3D space (but only the positive directions).
+  // Now the world ranks are numbers filling in this 3D space alone the three axes. It will try fill alone the
   // horizontal axis first, then data parallel axis, and last pipeline parallel axis.
   //
   // Ranks that are aligned with a specific axis forms a group. For example, for a 3D cube with size

--- a/orttraining/orttraining/core/framework/distributed_run_context.cc
+++ b/orttraining/orttraining/core/framework/distributed_run_context.cc
@@ -56,19 +56,19 @@ DistributedRunContext::DistributedRunContext(int32_t world_rank,
   // horizontal_parallel x data_parallel x pipeline_parallel equal to 4x3x2, there are 24 rank numbers fill into the
   // cubic. It will have 6 horizontal groups, 8 data parallel groups and 12 pipeline groups, as shown below.
   //
-  //          pipeline
+  //          pipeline (z)
   //            ^
   //            | 12, 16, 20,
   //            |  13, 17, 21,
   //            |   14, 18, 22,
   //            |    15, 19, 23,
-  //            |__________________> data
+  //            |__________________> data (y)
   //             \ 0, 4, 8,
   //              \ 1, 5, 9,
   //               \ 2, 6, 10,
   //                \ 3, 7, 11,
   //                 v
-  //                horizontal
+  //                horizontal (x)
   //
   // For a given world rank, say 11, it will be in the 3th data parallel group (3, 7, 11), with in-group index 2,
   // and be in the 2th horizontal parallel group (8, 9, 10, 11) with in-group index 3; and be in the 11th pipeline
@@ -77,41 +77,55 @@ DistributedRunContext::DistributedRunContext(int32_t world_rank,
   // The calculation below is for a given world_rank, calculating its group index, in-group index and all ranks in this
   // particular group.
   //
-  // Initialize Data Parallel Group
-  const int32_t data_group_id = world_rank / horizontal_parallel_size / data_parallel_size * horizontal_parallel_size + world_rank % horizontal_parallel_size;
-  const int32_t a = world_rank / horizontal_parallel_size / data_parallel_size * horizontal_parallel_size * data_parallel_size + world_rank % horizontal_parallel_size;
-  const int32_t rank_in_owning_data_group = (world_rank - a) / horizontal_parallel_size;
+  // Calculate current rank's coordinate in the 3D space.
+  const int32_t x = world_rank % horizontal_parallel_size;
+  const int32_t y = (world_rank / horizontal_parallel_size) % data_parallel_size;
+  const int32_t z = (world_rank / (horizontal_parallel_size * data_parallel_size)) % pipeline_stage_size;
 
+  // lambda function to convert a 3-D coordinates back to its linear 1D representation.
+  auto calculate_linear_index = [](const int32_t hori_parallel_size,
+                                   const int32_t data_parallel_size,
+                                   const int32_t xx,
+                                   const int32_t yy,
+                                   const int32_t zz) {
+    return xx + yy * hori_parallel_size + zz * hori_parallel_size * data_parallel_size;
+  };
+
+  // Calculate the id of a group the current rank belongs to.
+  const int32_t hori_group_id = calculate_linear_index(1, data_parallel_size, 0, y, z);
+  const int32_t data_group_id = calculate_linear_index(horizontal_parallel_size, 1, x, 0, z);
+  const int32_t pipe_group_id = calculate_linear_index(horizontal_parallel_size, data_parallel_size, x, y, 0);
+
+  // Initialize Data Parallel Group
+  const int32_t data_group_start_index = calculate_linear_index(horizontal_parallel_size, data_parallel_size, x, 0, z);
   std::vector<int32_t> data_group_ranks;
   for (auto r = 0; r < data_parallel_size; r++) {
-    data_group_ranks.push_back(a + r * horizontal_parallel_size);
+    data_group_ranks.push_back(data_group_start_index + r * horizontal_parallel_size);
   }
   groups_[WorkerGroupType::DataParallel] = {data_group_ranks, data_group_id,
-                                            WorkerGroupType::DataParallel, rank_in_owning_data_group};
+                                            WorkerGroupType::DataParallel, y};
 
   // Horizontal Model Parallel Group
-  const int32_t hori_group_id = world_rank / horizontal_parallel_size;
-  const int32_t rank_in_owning_hori_group = world_rank % horizontal_parallel_size;
+  const int32_t hori_group_start_index = calculate_linear_index(horizontal_parallel_size, data_parallel_size, 0, y, z);
   std::vector<int32_t> hori_group_ranks;
   for (auto r = 0; r < horizontal_parallel_size; r++) {
-    hori_group_ranks.push_back(world_rank - rank_in_owning_hori_group + r);
+    hori_group_ranks.push_back(hori_group_start_index + r);
   }
   groups_[WorkerGroupType::HorizontalParallel] = {hori_group_ranks, hori_group_id,
-                                                  WorkerGroupType::HorizontalParallel, rank_in_owning_hori_group};
+                                                  WorkerGroupType::HorizontalParallel, x};
 
   // Model Parallel Group
   // Note: Pipeline parallel group is different than Data and horizontal parallel in a way that ranks in the same
   // pipeline group belongs to different pipeline stage. In another word, each pipeline group is composed of one and
   // only one rank from each pipeline stage.
   //
-  const int32_t pipeline_group_id = world_rank % (data_parallel_size * horizontal_parallel_size);
-  const int32_t rank_in_owning_pipeline_group = world_rank / (data_parallel_size * horizontal_parallel_size);
+  const int32_t pipe_group_start_index = calculate_linear_index(horizontal_parallel_size, data_parallel_size, x, y, 0);
   std::vector<int32_t> pipeline_group_ranks;
   for (auto r = 0; r < pipeline_stage_size; r++) {
-    pipeline_group_ranks.push_back(pipeline_group_id + r * (data_parallel_size * horizontal_parallel_size));
+    pipeline_group_ranks.push_back(pipe_group_start_index + r * (data_parallel_size * horizontal_parallel_size));
   }
-  groups_[WorkerGroupType::ModelParallel] = {pipeline_group_ranks, pipeline_group_id,
-                                             WorkerGroupType::ModelParallel, rank_in_owning_pipeline_group};
+  groups_[WorkerGroupType::ModelParallel] = {pipeline_group_ranks, pipe_group_id,
+                                             WorkerGroupType::ModelParallel, z};
 }
 
 }  // namespace training

--- a/orttraining/orttraining/core/framework/distributed_run_context.h
+++ b/orttraining/orttraining/core/framework/distributed_run_context.h
@@ -82,8 +82,8 @@ class DistributedRunContext {
     return DistributedRunContext::GetInstance().GetWorkerGroup(group_type).group_id;
   }
 
-  static std::vector<int32_t> GetPipelineRanks(){
-    return DistributedRunContext::GetInstance().GetWorkerGroup(WorkerGroupType::ModelParallel).ranks;
+  static std::vector<int32_t> GetRanks(WorkerGroupType group_type){
+    return DistributedRunContext::GetInstance().GetWorkerGroup(group_type).ranks;
   }
 
   // Get total rank of specified group.

--- a/orttraining/orttraining/core/framework/distributed_run_context.h
+++ b/orttraining/orttraining/core/framework/distributed_run_context.h
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 #pragma once
+
+#include <cassert>
+
 #include "core/common/common.h"
 
 namespace onnxruntime {
@@ -9,6 +12,8 @@ namespace training {
 enum WorkerGroupType {
   DataParallel = 0,
   HorizontalParallel = 1,
+  ModelParallel = 2,
+  WorkerGroupTypeCount = 3,
 };
 
 struct WorkerGroup {
@@ -33,6 +38,13 @@ struct DistributedRunConfig {
   int32_t horizontal_parallel_size{1};
   int32_t pipeline_stage_size{1};
 };
+
+// This function returns the corresponding pipeline stage id for the given world rank.
+inline int32_t GetPipelineStageId(const int32_t world_rank,
+                                  const int32_t horizontal_parallel_size,
+                                  const int32_t data_parallel_size) {
+  return world_rank / (data_parallel_size * horizontal_parallel_size);
+}
 
 // Context managing global distribute run config, also responsible for splitting workers into groups
 // using passed-in's parallel sizes.
@@ -66,6 +78,14 @@ class DistributedRunContext {
     return DistributedRunContext::GetInstance().GetWorkerGroup(group_type).rank_in_group;
   }
 
+  static int32_t GroupId(WorkerGroupType group_type) {
+    return DistributedRunContext::GetInstance().GetWorkerGroup(group_type).group_id;
+  }
+
+  static std::vector<int32_t> GetPipelineRanks(){
+    return DistributedRunContext::GetInstance().GetWorkerGroup(WorkerGroupType::ModelParallel).ranks;
+  }
+
   // Get total rank of specified group.
   static int32_t GroupSize(WorkerGroupType group_type) {
     return static_cast<int32_t>(DistributedRunContext::GetInstance().GetWorkerGroup(group_type).ranks.size());
@@ -79,6 +99,7 @@ class DistributedRunContext {
 
   // Get specified worker group.
   WorkerGroup& GetWorkerGroup(WorkerGroupType group_type) {
+    assert(group_type < WorkerGroupTypeCount);
     return groups_[group_type];
   }
 

--- a/orttraining/orttraining/core/graph/pipeline_transformer.cc
+++ b/orttraining/orttraining/core/graph/pipeline_transformer.cc
@@ -903,7 +903,7 @@ common::Status SplitGraph(Graph& graph,
   // source and destination rank.
   // Noted: currently assume each stage has the same number of data parallel size. Variable data parallel
   // size between different pipeline stages is not supported.
-  auto ranks = DistributedRunContext::GetPipelineRanks();
+  auto ranks = DistributedRunContext::GetRanks(WorkerGroupType::ModelParallel);
 
   for (size_t index = 0; index < split_edge_groups.size(); ++index) {
     // each entry in split_edge_groups represents a partition cut. Each cut can contain the split of

--- a/orttraining/orttraining/core/graph/pipeline_transformer.cc
+++ b/orttraining/orttraining/core/graph/pipeline_transformer.cc
@@ -5,6 +5,7 @@
 #include <queue>
 
 #include "core/graph/graph_utils.h"
+#include "orttraining/core/framework/distributed_run_context.h"
 
 using namespace onnxruntime::common;
 using namespace onnxruntime::graph_utils;
@@ -750,7 +751,7 @@ common::Status AddPassthroughInitializer(Graph& graph,
     recv_nodes[i]->MutableOutputDefs().push_back(current_node_arg);
 
     // update the consumer node's input if the node's group is not in the first partition
-    if (i > from_stage && node_groups[node_group_index].stage_id == (i + 1)) {
+    if (node_groups[node_group_index].stage_id == (i + 1)) {
       for (auto node : node_groups[node_group_index].nodes) {
         for (auto& input_node : node->MutableInputDefs()) {
           if (input_node == initializer) {
@@ -763,7 +764,9 @@ common::Status AddPassthroughInitializer(Graph& graph,
     }
   }
 
-  ORT_ENFORCE(node_group_index == node_groups.size(), "Not all nodes are updated with new initializer.");
+  ORT_ENFORCE(node_group_index == node_groups.size(),
+              "Not all nodes are updated with new initializer. Updated: ", node_group_index,
+              ", expected: ", node_groups.size());
 
   return Status::OK();
 }
@@ -894,6 +897,14 @@ common::Status SplitGraph(Graph& graph,
   //    newly inserted send's input. Also, to keep this on going for any following cut, we create an updated_node_arg_v2,
   //    and update updated_node_args with updated_node_args[original_node_arg] = updated_node_arg_v2
   std::map<NodeArg*, NodeArg*> updated_node_args;
+
+  // Retrieve all ranks in this particular pipeline group that the current rank belongs to.
+  // We will use this data to figure out, for each inserted send/recv pair, what's the corresponding
+  // source and destination rank.
+  // Noted: currently assume each stage has the same number of data parallel size. Variable data parallel
+  // size between different pipeline stages is not supported.
+  auto ranks = DistributedRunContext::GetPipelineRanks();
+
   for (size_t index = 0; index < split_edge_groups.size(); ++index) {
     // each entry in split_edge_groups represents a partition cut. Each cut can contain the split of
     // several edges.
@@ -921,17 +932,18 @@ common::Status SplitGraph(Graph& graph,
                                             new_input_names);
 
     AddNewScalarNodeArgAndInitializer<size_t>(graph,
-                                              "send_dst_rank" + cut_index_str,
-                                              ONNX_NAMESPACE::TensorProto_DataType_INT64,
-                                              index + 1, /* initializer data */
-                                              send_input_args,
-                                              new_input_names);
+                                      "send_dst_rank" + cut_index_str,
+                                      ONNX_NAMESPACE::TensorProto_DataType_INT64,
+                                      ranks[index + 1], /* initializer data */
+                                      send_input_args,
+                                      new_input_names);
     AddNewScalarNodeArgAndInitializer<size_t>(graph,
-                                              "recv_src_rank" + cut_index_str,
-                                              ONNX_NAMESPACE::TensorProto_DataType_INT64,
-                                              index, /* initializer data */
-                                              recv_input_args,
-                                              new_input_names);
+                                      "recv_src_rank" + cut_index_str,
+                                      ONNX_NAMESPACE::TensorProto_DataType_INT64,
+                                      ranks[index], /* initializer data */
+                                      recv_input_args,
+                                      new_input_names);
+
     // add output node_arg for send/recv
     AddNewNodeArg(graph, "send_output_signal" + cut_index_str, ONNX_NAMESPACE::TensorProto_DataType_BOOL,
                   send_output_args, new_output_names);

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -152,7 +152,7 @@ Status TrainingSession::ConfigureForTraining(
                                          config.distributed_config.horizontal_parallel_size,
                                          config.distributed_config.pipeline_parallel_size});
 
-  int32_t pipeline_stage_id = config.pipeline_config.has_value() ?
+  const int32_t pipeline_stage_id = config.pipeline_config.has_value() ?
                               DistributedRunContext::RankInGroup(WorkerGroupType::ModelParallel) :
                               -1;
 

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -152,13 +152,28 @@ Status TrainingSession::ConfigureForTraining(
                                          config.distributed_config.horizontal_parallel_size,
                                          config.distributed_config.pipeline_parallel_size});
 
+  int32_t pipeline_stage_id = config.pipeline_config.has_value() ?
+                              DistributedRunContext::RankInGroup(WorkerGroupType::ModelParallel) :
+                              -1;
+
   if (config.pipeline_config.has_value() && config.pipeline_config.value().do_partition) {
     // Apply online pipeline partition to graph obj. This needs to be done first before any graph
     // transportation which may alter node_arg and invalidate cut_list info from the original graph.
+    ORT_ENFORCE(pipeline_stage_id >= 0, "invalid pipelie stage id (", pipeline_stage_id, ") before doing online partition.");
+
     ORT_RETURN_IF_ERROR(ApplyPipelinePartitionToMainGraph(model_->MainGraph(),
                                                           config.pipeline_config.value().cut_list,
-                                                          config.distributed_config.world_rank,
-                                                          config.distributed_config.world_size));
+                                                          pipeline_stage_id,
+                                                          config.distributed_config.pipeline_parallel_size));
+
+    if (config.pipeline_config.value().partitioned_model_path.has_value()) {
+      // Save the partitioned file out.
+      // To avoid writing conflict, only the ranks in first pipeline group write the partition file out.
+      if (DistributedRunContext::GroupId(WorkerGroupType::ModelParallel) == 0) {
+        ORT_IGNORE_RETURN_VALUE(Save(
+            config.pipeline_config.value().partitioned_model_path.value(), SaveOption::NO_RELOAD));
+      }
+    }
   }
 
   is_mixed_precision_enabled_ = config.mixed_precision_config.has_value();
@@ -170,7 +185,7 @@ Status TrainingSession::ConfigureForTraining(
   // enabled, we need to devise another way to check MP stages.
   bool enable_loss_scale = is_mixed_precision_enabled_ &&
                            (!config.pipeline_config.has_value() ||
-                            (config.distributed_config.world_rank + 1 == config.distributed_config.world_size));
+                            (pipeline_stage_id + 1 == config.distributed_config.pipeline_parallel_size));
   optional<std::string> loss_scale_input_name =
       enable_loss_scale ? optional<std::string>{""} : optional<std::string>{};
   if (config.pipeline_config.has_value()) {
@@ -353,9 +368,12 @@ Status TrainingSession::ConfigureForTraining(
   // If the current node is in rank0 or if the current session is running pipeline (in which case different rank would
   // store different model partition), and if model_with_training_graph_path is specified, save the model.
   // Note: in the pipeline case, different ranks may resident in the same node. This could lead to a potential write
-  // conflict. It is user's responsibility to make sure different rank is passed in with different
+  // conflict. It is user's responsibility to make sure different rank is passed in with different. Also, to avoid
+  // writing conflict, only the ranks in first pipeline group write the partition file out.
   // model_with_training_graph_path value.
-  if ((IsRootNode(config) || config.pipeline_config.has_value()) && config.model_with_training_graph_path.has_value()) {
+  if ((IsRootNode(config) || (config.pipeline_config.has_value() &&
+                              DistributedRunContext::GroupId(WorkerGroupType::ModelParallel) == 0)) &&
+      config.model_with_training_graph_path.has_value()) {
     ORT_IGNORE_RETURN_VALUE(Save(
         config.model_with_training_graph_path.value(), SaveOption::NO_RELOAD));
   }

--- a/orttraining/orttraining/core/session/training_session.h
+++ b/orttraining/orttraining/core/session/training_session.h
@@ -65,6 +65,8 @@ class TrainingSession : public InferenceSession {
       int horizontal_parallel_size{1};
       // The number of pipeline stages.
       int pipeline_parallel_size{1};
+
+      int pipeline_stage_id{0};
     };
     // The distributed training configuration.
     DistributedConfiguration distributed_config{};
@@ -170,6 +172,9 @@ class TrainingSession : public InferenceSession {
       // cut_list contains the list of CutInfo to make the graph partitions.
       // cut_list[i] contains the CutInfo to make the partition between stage i and stage i+1
       std::vector<CutInfo> cut_list;
+
+      // The base path at which to save the intermediate partitioned input model (forward pass only).
+      optional<PathString> partitioned_model_path{};
     };
 
     // If pipeline is enabled, this field's has_value() returns true.

--- a/orttraining/orttraining/models/runner/training_runner.cc
+++ b/orttraining/orttraining/models/runner/training_runner.cc
@@ -21,6 +21,7 @@
 #include "orttraining/models/runner/training_util.h"
 #include "single_include/nlohmann/json.hpp"
 #include "test/perftest/utils.h"
+#include "orttraining/core/framework/distributed_run_context.h"
 
 using json = nlohmann::json;
 
@@ -114,8 +115,12 @@ Status TrainingRunner::Initialize() {
     config.mixed_precision_config = mp;
   }
 
-  // always configure the loss function
-  if (params_.pipeline_parallel_size == 1 || MPIContext::GetInstance().GetWorldRank() == MPIContext::GetInstance().GetWorldSize() - 1) {
+  // configure the loss function if no pipeline is used or it's the last stage of pipeline
+  auto pipeline_stage_id = GetPipelineStageId(MPIContext::GetInstance().GetWorldRank(),
+                                              params_.horizontal_parallel_size,
+                                              params_.data_parallel_size);
+  if (params_.pipeline_parallel_size == 1 ||
+      (pipeline_stage_id + 1) == params_.pipeline_parallel_size) {
     TrainingSession::TrainingConfiguration::LossFunctionConfiguration lf{};
     lf.loss_function_info = params_.loss_func_info;
 
@@ -163,6 +168,7 @@ Status TrainingRunner::Initialize() {
     pipe.do_partition = params_.pipeline_stage_paths.empty() ? true : false;
     pipe.fetch_names = params_.fetch_names;
     pipe.cut_list = params_.pipeline_partition_cut_list;
+    pipe.partitioned_model_path = params_.pipeline_partitioned_model_path;
     // Do not assign value to config.pipeline_config if pipeline is not used.
     config.pipeline_config = pipe;
   }

--- a/orttraining/orttraining/models/runner/training_runner.cc
+++ b/orttraining/orttraining/models/runner/training_runner.cc
@@ -17,11 +17,11 @@
 #endif
 #include "core/session/environment.h"
 #include "orttraining/core/framework/checkpointing.h"
+#include "orttraining/core/framework/distributed_run_context.h"
 #include "orttraining/core/graph/optimizer_graph_builder.h"
 #include "orttraining/models/runner/training_util.h"
 #include "single_include/nlohmann/json.hpp"
 #include "test/perftest/utils.h"
-#include "orttraining/core/framework/distributed_run_context.h"
 
 using json = nlohmann::json;
 

--- a/orttraining/orttraining/models/runner/training_runner.h
+++ b/orttraining/orttraining/models/runner/training_runner.h
@@ -27,6 +27,10 @@ class TrainingRunner {
     PathString model_with_training_graph_path;   // To save the model after adding loss func and backward graph.
     PathString model_actual_running_graph_path;  // To save the model with the actual running graph after transformations.
     PathString model_gist_encode_path;           // To save the model with gist encoding.
+    PathString pipeline_partitioned_model_path;  // To save the model after pipeline partition. Note: in the pipeline case,
+                                                 // different ranks may resident in the same node. This could lead to a
+                                                 // potential write conflict. It is user's responsibility to make sure
+                                                 // different rank is passed in with different pipeline_partitioned_model_path value.
 
     PathString train_data_dir;
     PathString test_data_dir;
@@ -173,6 +177,7 @@ class TrainingRunner {
     bool attn_dropout_checkpoint = false;
     // Enable checkpointing of Gelu activation output to save memory
     bool gelu_checkpoint = false;
+
     // Use invertible layernorm grad
     bool use_invertible_layernorm_grad = false;
   };

--- a/orttraining/orttraining/test/framework/distributed_run_context_test.cc
+++ b/orttraining/orttraining/test/framework/distributed_run_context_test.cc
@@ -27,18 +27,24 @@ class DistributedRunTestContext : public DistributedRunContext {
   }
 };
 
-// IMPORTANT NOTES: PLEASE DON'T call static functions like RunConfig() because it will
-// try creating a singleton instance, we cannot use to run a set of unit tests.
-
-TEST(DistributedRunContextTest, SingleGPUTest) {
-  DistributedRunConfig config = {0, 1, 0, 1, 1, 1};
-  DistributedRunTestContext ctx(config);
+void CheckRunConfig(DistributedRunTestContext& ctx, const DistributedRunConfig& config){
   ASSERT_EQ(ctx.GetRunConfig().world_rank, config.world_rank);
   ASSERT_EQ(ctx.GetRunConfig().world_size, config.world_size);
   ASSERT_EQ(ctx.GetRunConfig().local_rank, config.local_rank);
   ASSERT_EQ(ctx.GetRunConfig().local_size, config.local_size);
   ASSERT_EQ(ctx.GetRunConfig().data_parallel_size, config.data_parallel_size);
   ASSERT_EQ(ctx.GetRunConfig().horizontal_parallel_size, config.horizontal_parallel_size);
+  ASSERT_EQ(ctx.GetRunConfig().pipeline_stage_size, config.pipeline_stage_size);
+}
+
+// IMPORTANT NOTES: PLEASE DON'T call static functions like RunConfig() because it will
+// try creating a singleton instance, we cannot use to run a set of unit tests.
+
+TEST(DistributedRunContextTest, SingleGPUTest) {
+  DistributedRunConfig config = {0, 1, 0, 1, 1, 1};
+  DistributedRunTestContext ctx(config);
+
+  CheckRunConfig(ctx, config);
 
   auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
   ASSERT_EQ(data_group.group_id, 0);
@@ -55,17 +61,19 @@ TEST(DistributedRunContextTest, SingleGPUTest) {
   ASSERT_EQ(hori_group.rank_in_group, 0);
   ASSERT_EQ(hori_group.ranks.size(), 1);
   ASSERT_EQ(hori_group.ranks[0], 0);
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 0);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 1);
+  ASSERT_EQ(pipeline_group.ranks[0], 0);
 }
 
 TEST(DistributedRunContextTest, SingleNodeTest) {
   DistributedRunConfig config = {1, 4, 1, 4, 4, 1};
   DistributedRunTestContext ctx(config);
-  ASSERT_EQ(ctx.GetRunConfig().world_rank, config.world_rank);
-  ASSERT_EQ(ctx.GetRunConfig().world_size, config.world_size);
-  ASSERT_EQ(ctx.GetRunConfig().local_rank, config.local_rank);
-  ASSERT_EQ(ctx.GetRunConfig().local_size, config.local_size);
-  ASSERT_EQ(ctx.GetRunConfig().data_parallel_size, config.data_parallel_size);
-  ASSERT_EQ(ctx.GetRunConfig().horizontal_parallel_size, config.horizontal_parallel_size);
+  CheckRunConfig(ctx, config);
 
   auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
   ASSERT_EQ(data_group.group_id, 0);
@@ -82,17 +90,20 @@ TEST(DistributedRunContextTest, SingleNodeTest) {
   ASSERT_EQ(hori_group.rank_in_group, 0);
   ASSERT_EQ(hori_group.ranks.size(), 1);
   ASSERT_EQ(hori_group.ranks[0], 1);
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 1);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 1);
+  ASSERT_EQ(pipeline_group.ranks[0], 1);
 }
 
 TEST(DistributedRunContextTest, SingleNodeTest2) {
   DistributedRunConfig config = {1, 4, 1, 4, 2, 2};
   DistributedRunTestContext ctx(config);
-  ASSERT_EQ(ctx.GetRunConfig().world_rank, config.world_rank);
-  ASSERT_EQ(ctx.GetRunConfig().world_size, config.world_size);
-  ASSERT_EQ(ctx.GetRunConfig().local_rank, config.local_rank);
-  ASSERT_EQ(ctx.GetRunConfig().local_size, config.local_size);
-  ASSERT_EQ(ctx.GetRunConfig().data_parallel_size, config.data_parallel_size);
-  ASSERT_EQ(ctx.GetRunConfig().horizontal_parallel_size, config.horizontal_parallel_size);
+
+  CheckRunConfig(ctx, config);
 
   auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
   ASSERT_EQ(data_group.group_id, 1);
@@ -110,17 +121,19 @@ TEST(DistributedRunContextTest, SingleNodeTest2) {
   for (auto i = 0; i < 1; i++) {
     ASSERT_EQ(hori_group.ranks[i], i);
   }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 1);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 1);
+  ASSERT_EQ(pipeline_group.ranks[0], 1);
 }
 
 TEST(DistributedRunContextTest, SingleNodeTest3) {
   DistributedRunConfig config = {1, 4, 1, 4, 1, 4};
   DistributedRunTestContext ctx(config);
-  ASSERT_EQ(ctx.GetRunConfig().world_rank, config.world_rank);
-  ASSERT_EQ(ctx.GetRunConfig().world_size, config.world_size);
-  ASSERT_EQ(ctx.GetRunConfig().local_rank, config.local_rank);
-  ASSERT_EQ(ctx.GetRunConfig().local_size, config.local_size);
-  ASSERT_EQ(ctx.GetRunConfig().data_parallel_size, config.data_parallel_size);
-  ASSERT_EQ(ctx.GetRunConfig().horizontal_parallel_size, config.horizontal_parallel_size);
+  CheckRunConfig(ctx, config);
 
   auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
   ASSERT_EQ(data_group.group_id, 1);
@@ -137,17 +150,78 @@ TEST(DistributedRunContextTest, SingleNodeTest3) {
   for (auto i = 0; i < 1; i++) {
     ASSERT_EQ(hori_group.ranks[i], i);
   }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 1);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 1);
+  ASSERT_EQ(pipeline_group.ranks[0], 1);
+}
+
+TEST(DistributedRunContextTest, SingleNodeTest4) {
+  DistributedRunConfig config = {1, 4, 1, 4, 2, 1, 2};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 0);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 1);
+  ASSERT_EQ(data_group.ranks.size(), 2);
+  for (auto i = 0; i < 2; i++) {
+    ASSERT_EQ(data_group.ranks[i], i);
+  }
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 1);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 0);
+  ASSERT_EQ(hori_group.ranks.size(), 1);
+  ASSERT_EQ(hori_group.ranks[0], 1);
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 1);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 2);
+  ASSERT_EQ(pipeline_group.ranks[0], 1);
+  ASSERT_EQ(pipeline_group.ranks[1], 3);
+}
+
+TEST(DistributedRunContextTest, SingleNodeTest5) {
+  DistributedRunConfig config = {1, 4, 1, 4, 1, 1, 4};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 1);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 0);
+  ASSERT_EQ(data_group.ranks.size(), 1);
+  ASSERT_EQ(data_group.ranks[0], 1);
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 1);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 0);
+  ASSERT_EQ(hori_group.ranks.size(), 1);
+  ASSERT_EQ(hori_group.ranks[0], 1);
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 0);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 1);
+  ASSERT_EQ(pipeline_group.ranks.size(), 4);
+  for (auto i = 0; i < 1; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], i);
+  }
 }
 
 TEST(DistributedRunContextTest, FullDataParallelTest) {
   DistributedRunConfig config = {0, 64, 0, 4, 64, 1};
   DistributedRunTestContext ctx(config);
-  ASSERT_EQ(ctx.GetRunConfig().world_rank, config.world_rank);
-  ASSERT_EQ(ctx.GetRunConfig().world_size, config.world_size);
-  ASSERT_EQ(ctx.GetRunConfig().local_rank, config.local_rank);
-  ASSERT_EQ(ctx.GetRunConfig().local_size, config.local_size);
-  ASSERT_EQ(ctx.GetRunConfig().data_parallel_size, config.data_parallel_size);
-  ASSERT_EQ(ctx.GetRunConfig().horizontal_parallel_size, config.horizontal_parallel_size);
+  CheckRunConfig(ctx, config);
 
   auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
   ASSERT_EQ(data_group.group_id, 0);
@@ -164,17 +238,19 @@ TEST(DistributedRunContextTest, FullDataParallelTest) {
   ASSERT_EQ(hori_group.rank_in_group, 0);
   ASSERT_EQ(hori_group.ranks.size(), 1);
   ASSERT_EQ(hori_group.ranks[0], 0);
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 0);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 1);
+  ASSERT_EQ(pipeline_group.ranks[0], 0);
 }
 
 TEST(DistributedRunContextTest, FullDataParallelTest2) {
   DistributedRunConfig config = {2, 64, 2, 4, 64, 1};
   DistributedRunTestContext ctx(config);
-  ASSERT_EQ(ctx.GetRunConfig().world_rank, config.world_rank);
-  ASSERT_EQ(ctx.GetRunConfig().world_size, config.world_size);
-  ASSERT_EQ(ctx.GetRunConfig().local_rank, config.local_rank);
-  ASSERT_EQ(ctx.GetRunConfig().local_size, config.local_size);
-  ASSERT_EQ(ctx.GetRunConfig().data_parallel_size, config.data_parallel_size);
-  ASSERT_EQ(ctx.GetRunConfig().horizontal_parallel_size, config.horizontal_parallel_size);
+  CheckRunConfig(ctx, config);
 
   auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
   ASSERT_EQ(data_group.group_id, 0);
@@ -191,17 +267,19 @@ TEST(DistributedRunContextTest, FullDataParallelTest2) {
   ASSERT_EQ(hori_group.rank_in_group, 0);
   ASSERT_EQ(hori_group.ranks.size(), 1);
   ASSERT_EQ(hori_group.ranks[0], 2);
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 2);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 1);
+  ASSERT_EQ(pipeline_group.ranks[0], 2);
 }
 
 TEST(DistributedRunContextTest, FullDataParallelTest3) {
   DistributedRunConfig config = {58, 64, 2, 4, 64, 1};
   DistributedRunTestContext ctx(config);
-  ASSERT_EQ(ctx.GetRunConfig().world_rank, config.world_rank);
-  ASSERT_EQ(ctx.GetRunConfig().world_size, config.world_size);
-  ASSERT_EQ(ctx.GetRunConfig().local_rank, config.local_rank);
-  ASSERT_EQ(ctx.GetRunConfig().local_size, config.local_size);
-  ASSERT_EQ(ctx.GetRunConfig().data_parallel_size, config.data_parallel_size);
-  ASSERT_EQ(ctx.GetRunConfig().horizontal_parallel_size, config.horizontal_parallel_size);
+  CheckRunConfig(ctx, config);
 
   auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
   ASSERT_EQ(data_group.group_id, 0);
@@ -218,17 +296,19 @@ TEST(DistributedRunContextTest, FullDataParallelTest3) {
   ASSERT_EQ(hori_group.rank_in_group, 0);
   ASSERT_EQ(hori_group.ranks.size(), 1);
   ASSERT_EQ(hori_group.ranks[0], 58);
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 58);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 1);
+  ASSERT_EQ(pipeline_group.ranks[0], 58);
 }
 
 TEST(DistributedRunContextTest, FullHoriParallelTest) {
   DistributedRunConfig config = {0, 16, 0, 4, 1, 16};
   DistributedRunTestContext ctx(config);
-  ASSERT_EQ(ctx.GetRunConfig().world_rank, config.world_rank);
-  ASSERT_EQ(ctx.GetRunConfig().world_size, config.world_size);
-  ASSERT_EQ(ctx.GetRunConfig().local_rank, config.local_rank);
-  ASSERT_EQ(ctx.GetRunConfig().local_size, config.local_size);
-  ASSERT_EQ(ctx.GetRunConfig().data_parallel_size, config.data_parallel_size);
-  ASSERT_EQ(ctx.GetRunConfig().horizontal_parallel_size, config.horizontal_parallel_size);
+  CheckRunConfig(ctx, config);
 
   auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
   ASSERT_EQ(data_group.group_id, 0);
@@ -245,17 +325,19 @@ TEST(DistributedRunContextTest, FullHoriParallelTest) {
   for (auto i = 0; i < 16; i++) {
     ASSERT_EQ(hori_group.ranks[i], i);
   }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 0);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 1);
+  ASSERT_EQ(pipeline_group.ranks[0], 0);
 }
 
 TEST(DistributedRunContextTest, FullHoriParallelTest2) {
   DistributedRunConfig config = {2, 16, 2, 4, 1, 16};
   DistributedRunTestContext ctx(config);
-  ASSERT_EQ(ctx.GetRunConfig().world_rank, config.world_rank);
-  ASSERT_EQ(ctx.GetRunConfig().world_size, config.world_size);
-  ASSERT_EQ(ctx.GetRunConfig().local_rank, config.local_rank);
-  ASSERT_EQ(ctx.GetRunConfig().local_size, config.local_size);
-  ASSERT_EQ(ctx.GetRunConfig().data_parallel_size, config.data_parallel_size);
-  ASSERT_EQ(ctx.GetRunConfig().horizontal_parallel_size, config.horizontal_parallel_size);
+  CheckRunConfig(ctx, config);
 
   auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
   ASSERT_EQ(data_group.group_id, 2);
@@ -272,17 +354,19 @@ TEST(DistributedRunContextTest, FullHoriParallelTest2) {
   for (auto i = 0; i < 16; i++) {
     ASSERT_EQ(hori_group.ranks[i], i);
   }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 2);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 1);
+  ASSERT_EQ(pipeline_group.ranks[0], 2);
 }
 
 TEST(DistributedRunContextTest, FullHoriParallelTest3) {
   DistributedRunConfig config = {10, 16, 2, 4, 1, 16};
   DistributedRunTestContext ctx(config);
-  ASSERT_EQ(ctx.GetRunConfig().world_rank, config.world_rank);
-  ASSERT_EQ(ctx.GetRunConfig().world_size, config.world_size);
-  ASSERT_EQ(ctx.GetRunConfig().local_rank, config.local_rank);
-  ASSERT_EQ(ctx.GetRunConfig().local_size, config.local_size);
-  ASSERT_EQ(ctx.GetRunConfig().data_parallel_size, config.data_parallel_size);
-  ASSERT_EQ(ctx.GetRunConfig().horizontal_parallel_size, config.horizontal_parallel_size);
+  CheckRunConfig(ctx, config);
 
   auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
   ASSERT_EQ(data_group.group_id, 10);
@@ -299,17 +383,106 @@ TEST(DistributedRunContextTest, FullHoriParallelTest3) {
   for (auto i = 0; i < 16; i++) {
     ASSERT_EQ(hori_group.ranks[i], i);
   }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 10);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 1);
+  ASSERT_EQ(pipeline_group.ranks[0], 10);
 }
 
-TEST(DistributedRunContextTest, MixedParallelTest) {
+TEST(DistributedRunContextTest, FullPipelineParallelTest) {
+  DistributedRunConfig config = {0, 16, 0, 4, 1, 1, 16};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 0);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 0);
+  ASSERT_EQ(data_group.ranks.size(), 1);
+  ASSERT_EQ(data_group.ranks[0], 0);
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 0);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 0);
+  ASSERT_EQ(hori_group.ranks.size(), 1);
+  ASSERT_EQ(hori_group.ranks[0], 0);
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 0);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 16);
+  for (auto i = 0; i < 16; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], i);
+  }
+}
+
+TEST(DistributedRunContextTest, FullPipelineParallelTest2) {
+  DistributedRunConfig config = {2, 16, 2, 4, 1, 1, 16};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 2);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 0);
+  ASSERT_EQ(data_group.ranks.size(), 1);
+  ASSERT_EQ(data_group.ranks[0], 2);
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 2);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 0);
+  ASSERT_EQ(hori_group.ranks.size(), 1);
+  ASSERT_EQ(hori_group.ranks[0], 2);
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 0);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 2);
+  ASSERT_EQ(pipeline_group.ranks.size(), 16);
+  for (auto i = 0; i < 16; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], i);
+  }
+}
+
+TEST(DistributedRunContextTest, FullPipelineParallelTest3) {
+  DistributedRunConfig config = {10, 16, 2, 4, 1, 1, 16};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 10);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 0);
+  ASSERT_EQ(data_group.ranks.size(), 1);
+  ASSERT_EQ(data_group.ranks[0], 10);
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 10);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 0);
+  ASSERT_EQ(hori_group.ranks.size(), 1);
+  ASSERT_EQ(hori_group.ranks[0], 10);
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 0);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 10);
+  ASSERT_EQ(pipeline_group.ranks.size(), 16);
+  for (auto i = 0; i < 16; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], i);
+  }
+}
+
+TEST(DistributedRunContextTest, MixedParallelTest_DxH) {
   DistributedRunConfig config = {0, 64, 0, 4, 16, 4};
   DistributedRunTestContext ctx(config);
-  ASSERT_EQ(ctx.GetRunConfig().world_rank, config.world_rank);
-  ASSERT_EQ(ctx.GetRunConfig().world_size, config.world_size);
-  ASSERT_EQ(ctx.GetRunConfig().local_rank, config.local_rank);
-  ASSERT_EQ(ctx.GetRunConfig().local_size, config.local_size);
-  ASSERT_EQ(ctx.GetRunConfig().data_parallel_size, config.data_parallel_size);
-  ASSERT_EQ(ctx.GetRunConfig().horizontal_parallel_size, config.horizontal_parallel_size);
+  CheckRunConfig(ctx, config);
 
   auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
   ASSERT_EQ(data_group.group_id, 0);
@@ -329,17 +502,19 @@ TEST(DistributedRunContextTest, MixedParallelTest) {
   for (auto i = 0; i < 4; i++) {
     ASSERT_EQ(hori_group.ranks[i], i);
   }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 0);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 1);
+  ASSERT_EQ(pipeline_group.ranks[0], 0);
 }
 
-TEST(DistributedRunContextTest, MixedParallelTest2) {
+TEST(DistributedRunContextTest, MixedParallelTest2_DxH) {
   DistributedRunConfig config = {2, 64, 2, 4, 16, 4};
   DistributedRunTestContext ctx(config);
-  ASSERT_EQ(ctx.GetRunConfig().world_rank, config.world_rank);
-  ASSERT_EQ(ctx.GetRunConfig().world_size, config.world_size);
-  ASSERT_EQ(ctx.GetRunConfig().local_rank, config.local_rank);
-  ASSERT_EQ(ctx.GetRunConfig().local_size, config.local_size);
-  ASSERT_EQ(ctx.GetRunConfig().data_parallel_size, config.data_parallel_size);
-  ASSERT_EQ(ctx.GetRunConfig().horizontal_parallel_size, config.horizontal_parallel_size);
+  CheckRunConfig(ctx, config);
 
   auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
   ASSERT_EQ(data_group.group_id, 2);
@@ -359,17 +534,19 @@ TEST(DistributedRunContextTest, MixedParallelTest2) {
   for (auto i = 0; i < 4; i++) {
     ASSERT_EQ(hori_group.ranks[i], i);
   }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 2);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 1);
+  ASSERT_EQ(pipeline_group.ranks[0], 2);
 }
 
-TEST(DistributedRunContextTest, MixedParallelTest3) {
+TEST(DistributedRunContextTest, MixedParallelTest3_DxH) {
   DistributedRunConfig config = {58, 64, 2, 4, 16, 4};
   DistributedRunTestContext ctx(config);
-  ASSERT_EQ(ctx.GetRunConfig().world_rank, config.world_rank);
-  ASSERT_EQ(ctx.GetRunConfig().world_size, config.world_size);
-  ASSERT_EQ(ctx.GetRunConfig().local_rank, config.local_rank);
-  ASSERT_EQ(ctx.GetRunConfig().local_size, config.local_size);
-  ASSERT_EQ(ctx.GetRunConfig().data_parallel_size, config.data_parallel_size);
-  ASSERT_EQ(ctx.GetRunConfig().horizontal_parallel_size, config.horizontal_parallel_size);
+  CheckRunConfig(ctx, config);
 
   auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
   ASSERT_EQ(data_group.group_id, 2);
@@ -389,17 +566,19 @@ TEST(DistributedRunContextTest, MixedParallelTest3) {
   for (auto i = 0; i < 4; i++) {
     ASSERT_EQ(hori_group.ranks[i], 14 * 4 + i);
   }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 58);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 1);
+  ASSERT_EQ(pipeline_group.ranks[0], 58);
 }
 
-TEST(DistributedRunContextTest, MixedParallelTest4) {
+TEST(DistributedRunContextTest, MixedParallelTest4_DxH) {
   DistributedRunConfig config = {63, 64, 3, 4, 16, 4};
   DistributedRunTestContext ctx(config);
-  ASSERT_EQ(ctx.GetRunConfig().world_rank, config.world_rank);
-  ASSERT_EQ(ctx.GetRunConfig().world_size, config.world_size);
-  ASSERT_EQ(ctx.GetRunConfig().local_rank, config.local_rank);
-  ASSERT_EQ(ctx.GetRunConfig().local_size, config.local_size);
-  ASSERT_EQ(ctx.GetRunConfig().data_parallel_size, config.data_parallel_size);
-  ASSERT_EQ(ctx.GetRunConfig().horizontal_parallel_size, config.horizontal_parallel_size);
+  CheckRunConfig(ctx, config);
 
   auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
   ASSERT_EQ(data_group.group_id, 3);
@@ -418,6 +597,389 @@ TEST(DistributedRunContextTest, MixedParallelTest4) {
   ASSERT_EQ(hori_group.ranks.size(), 4);
   for (auto i = 0; i < 4; i++) {
     ASSERT_EQ(hori_group.ranks[i], 15 * 4 + i);
+  }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 63);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 1);
+  ASSERT_EQ(pipeline_group.ranks[0], 63);
+}
+
+TEST(DistributedRunContextTest, MixedParallelTest_DxP) {
+  DistributedRunConfig config = {0, 64, 0, 4, 16, 1, 4};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 0);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 0);
+  ASSERT_EQ(data_group.ranks.size(), 16);
+  for (auto i = 0; i < 16; i++) {
+    ASSERT_EQ(data_group.ranks[i], i);
+  }
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 0);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 0);
+  ASSERT_EQ(hori_group.ranks.size(), 1);
+  ASSERT_EQ(hori_group.ranks[0], 0);
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 0);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 4);
+  for (auto i = 0; i < 4; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], i * 16);
+  }
+}
+
+TEST(DistributedRunContextTest, MixedParallelTest2_DxP) {
+  DistributedRunConfig config = {2, 64, 2, 4, 16, 1, 4};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 0);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 2);
+  ASSERT_EQ(data_group.ranks.size(), 16);
+  for (auto i = 0; i < 16; i++) {
+    ASSERT_EQ(data_group.ranks[i], i);
+  }
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 2);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 0);
+  ASSERT_EQ(hori_group.ranks.size(), 1);
+  ASSERT_EQ(hori_group.ranks[0], 2);
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 2);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 4);
+  for (auto i = 0; i < 4; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], 2 + i * 16);
+  }
+}
+
+TEST(DistributedRunContextTest, MixedParallelTest3_DxP) {
+  DistributedRunConfig config = {58, 64, 2, 4, 16, 1, 4};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 3);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 10);
+  ASSERT_EQ(data_group.ranks.size(), 16);
+  for (auto i = 0; i < 16; i++) {
+    ASSERT_EQ(data_group.ranks[i], i + 48);
+  }
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 58);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 0);
+  ASSERT_EQ(hori_group.ranks.size(), 1);
+  ASSERT_EQ(hori_group.ranks[0], 58);
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 10);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 3);
+  ASSERT_EQ(pipeline_group.ranks.size(), 4);
+  for (auto i = 0; i < 4; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], 10 + i * 16);
+  }
+}
+
+TEST(DistributedRunContextTest, MixedParallelTest4_DxP) {
+  DistributedRunConfig config = {63, 64, 3, 4, 16, 1, 4};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 3);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 15);
+  ASSERT_EQ(data_group.ranks.size(), 16);
+  for (auto i = 0; i < 16; i++) {
+    ASSERT_EQ(data_group.ranks[i], i + 48);
+  }
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 63);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 0);
+  ASSERT_EQ(hori_group.ranks.size(), 1);
+  ASSERT_EQ(hori_group.ranks[0], 63);
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 15);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 3);
+  ASSERT_EQ(pipeline_group.ranks.size(), 4);
+  for (auto i = 0; i < 4; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], 15 + i * 16);
+  }
+}
+
+TEST(DistributedRunContextTest, MixedParallelTest_HxP) {
+  DistributedRunConfig config = {0, 64, 0, 4, 1, 16, 4};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 0);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 0);
+  ASSERT_EQ(data_group.ranks.size(), 1);
+  ASSERT_EQ(data_group.ranks[0], 0);
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 0);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 0);
+  ASSERT_EQ(hori_group.ranks.size(), 16);
+  for (auto i = 0; i < 16; i++) {
+    ASSERT_EQ(hori_group.ranks[i], i);
+  }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 0);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 4);
+  for (auto i = 0; i < 4; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], i * 16);
+  }
+}
+
+TEST(DistributedRunContextTest, MixedParallelTest2_HxP) {
+  DistributedRunConfig config = {2, 64, 2, 4, 1, 16, 4};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 2);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 0);
+  ASSERT_EQ(data_group.ranks.size(), 1);
+  ASSERT_EQ(data_group.ranks[0], 2);
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 0);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 2);
+  ASSERT_EQ(hori_group.ranks.size(), 16);
+  for (auto i = 0; i < 16; i++) {
+    ASSERT_EQ(hori_group.ranks[i], i);
+  }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 2);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 4);
+  for (auto i = 0; i < 4; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], 2 + i * 16);
+  }
+}
+
+TEST(DistributedRunContextTest, MixedParallelTest3_HxP) {
+  DistributedRunConfig config = {58, 64, 2, 4, 1, 16, 4};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 58);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 0);
+  ASSERT_EQ(data_group.ranks.size(), 1);
+  ASSERT_EQ(data_group.ranks[0], 58);
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 3);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 10);
+  ASSERT_EQ(hori_group.ranks.size(), 16);
+  for (auto i = 0; i < 16; i++) {
+    ASSERT_EQ(hori_group.ranks[i], i + 48);
+  }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 10);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 3);
+  ASSERT_EQ(pipeline_group.ranks.size(), 4);
+  for (auto i = 0; i < 4; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], 10 + i * 16);
+  }
+}
+
+TEST(DistributedRunContextTest, MixedParallelTest4_HxP) {
+  DistributedRunConfig config = {63, 64, 3, 4, 1, 16, 4};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 63);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 0);
+  ASSERT_EQ(data_group.ranks.size(), 1);
+  ASSERT_EQ(data_group.ranks[0], 63);
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 3);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 15);
+  ASSERT_EQ(hori_group.ranks.size(), 16);
+  for (auto i = 0; i < 16; i++) {
+    ASSERT_EQ(hori_group.ranks[i], i + 48);
+  }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 15);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 3);
+  ASSERT_EQ(pipeline_group.ranks.size(), 4);
+  for (auto i = 0; i < 4; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], 15 + i * 16);
+  }
+}
+
+TEST(DistributedRunContextTest, MixedParallelTest_DxHxP) {
+  DistributedRunConfig config = {0, 24, 0, 4, 2, 3, 4};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 0);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 0);
+  ASSERT_EQ(data_group.ranks.size(), 2);
+  ASSERT_EQ(data_group.ranks[0], 0);
+  ASSERT_EQ(data_group.ranks[1], 3);
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 0);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 0);
+  ASSERT_EQ(hori_group.ranks.size(), 3);
+  for (auto i = 0; i < 3; i++) {
+    ASSERT_EQ(hori_group.ranks[i], i);
+  }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 0);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 4);
+  for (auto i = 0; i < 4; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], i * 6);
+  }
+}
+
+TEST(DistributedRunContextTest, MixedParallelTest2_DxHxP) {
+  DistributedRunConfig config = {2, 24, 2, 4, 2, 3, 4};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 2);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 0);
+  ASSERT_EQ(data_group.ranks.size(), 2);
+  ASSERT_EQ(data_group.ranks[0], 2);
+  ASSERT_EQ(data_group.ranks[1], 5);
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 0);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 2);
+  ASSERT_EQ(hori_group.ranks.size(), 3);
+  for (auto i = 0; i < 3; i++) {
+    ASSERT_EQ(hori_group.ranks[i], i);
+  }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 2);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 0);
+  ASSERT_EQ(pipeline_group.ranks.size(), 4);
+  for (auto i = 0; i < 4; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], 2 + i * 6);
+  }
+}
+
+TEST(DistributedRunContextTest, MixedParallelTest3_DxHxP) {
+  DistributedRunConfig config = {17, 24, 2, 4, 2, 3, 4};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 8);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 1);
+  ASSERT_EQ(data_group.ranks.size(), 2);
+  ASSERT_EQ(data_group.ranks[0], 14);
+  ASSERT_EQ(data_group.ranks[1], 17);
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 5);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 2);
+  ASSERT_EQ(hori_group.ranks.size(), 3);
+  for (auto i = 0; i < 3; i++) {
+    ASSERT_EQ(hori_group.ranks[i], i + 15);
+  }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 5);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 2);
+  ASSERT_EQ(pipeline_group.ranks.size(), 4);
+  for (auto i = 0; i < 4; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], 5 + i * 6);
+  }
+}
+
+TEST(DistributedRunContextTest, MixedParallelTest4_DxHxP) {
+  DistributedRunConfig config = {23, 24, 3, 4, 2, 3, 4};
+  DistributedRunTestContext ctx(config);
+  CheckRunConfig(ctx, config);
+
+  auto data_group = ctx.GetWorkerGroup(WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.group_id, 11);
+  ASSERT_EQ(data_group.group_type, WorkerGroupType::DataParallel);
+  ASSERT_EQ(data_group.rank_in_group, 1);
+  ASSERT_EQ(data_group.ranks.size(), 2);
+  ASSERT_EQ(data_group.ranks[0], 20);
+  ASSERT_EQ(data_group.ranks[1], 23);
+
+  auto hori_group = ctx.GetWorkerGroup(WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.group_id, 7);
+  ASSERT_EQ(hori_group.group_type, WorkerGroupType::HorizontalParallel);
+  ASSERT_EQ(hori_group.rank_in_group, 2);
+  ASSERT_EQ(hori_group.ranks.size(), 3);
+  for (auto i = 0; i < 3; i++) {
+    ASSERT_EQ(hori_group.ranks[i], i + 21);
+  }
+
+  auto pipeline_group = ctx.GetWorkerGroup(WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.group_id, 5);
+  ASSERT_EQ(pipeline_group.group_type, WorkerGroupType::ModelParallel);
+  ASSERT_EQ(pipeline_group.rank_in_group, 3);
+  ASSERT_EQ(pipeline_group.ranks.size(), 4);
+  for (auto i = 0; i < 4; i++) {
+    ASSERT_EQ(pipeline_group.ranks[i], 5 + i * 6);
   }
 }
 

--- a/orttraining/orttraining/test/graph/gradient_graph_builder_test.cc
+++ b/orttraining/orttraining/test/graph/gradient_graph_builder_test.cc
@@ -9,6 +9,7 @@
 #include "core/common/path_utils.h"
 #include "core/providers/cpu/cpu_execution_provider.h"
 #include "core/session/environment.h"
+#include "orttraining/core/framework/distributed_run_context.h"
 #include "orttraining/models/runner/training_runner.h"
 
 #include "orttraining/training_ops/cpu/controlflow/event_pool.h"  // TODO: move with PipelineBatchPlanner
@@ -1180,6 +1181,20 @@ PathString GenerateFileNameWithIndex(const std::string& base_str, int index, con
   return path_utils::MakePathString(base_str, index, file_suffix);
 }
 
+void OverwritePipelineRank(const TrainingSession::TrainingConfiguration& config, const int pipeline_rank) {
+  // DistributedRunContext is a static global. Create one if it hasn't been created yet.
+  DistributedRunContext::CreateInstance({config.distributed_config.world_rank,
+                                         config.distributed_config.world_size,
+                                         config.distributed_config.local_rank,
+                                         config.distributed_config.local_size,
+                                         config.distributed_config.data_parallel_size,
+                                         config.distributed_config.horizontal_parallel_size,
+                                         config.distributed_config.pipeline_parallel_size});
+
+  // Overwrite the pipeline rank in case the static DistributedRunContext has been created and is stale and not up-to-date.
+  DistributedRunContext::GetInstance().GetWorkerGroup(WorkerGroupType::ModelParallel).rank_in_group = pipeline_rank;
+}
+
 TEST(GradientGraphBuilderTest, PipelineOnlinePartition_bert_tiny) {
   const auto model_path = ORT_TSTR("testdata/bert_toy_optimized.onnx");
 
@@ -1207,7 +1222,7 @@ TEST(GradientGraphBuilderTest, PipelineOnlinePartition_bert_tiny) {
   for (auto is_fp32 : test_with_fp32) {
     // graph is partitioned into 3 parts.
     for (int i = 0; i < static_cast<int>(total_partition_count); ++i) {
-
+      PathString partition_file = GenerateFileNameWithIndex("pipeline_partition_", i, ".onnx");
       PathString output_file = GenerateFileNameWithIndex("pipeline_partition_", i, "_back.onnx");
       auto config = MakeBasicTrainingConfig();
 
@@ -1230,7 +1245,7 @@ TEST(GradientGraphBuilderTest, PipelineOnlinePartition_bert_tiny) {
           "position_01",            // Slice's dat input
           "op_min_ends_expand_10",  //op_min_ends_expand_10
       };
-
+      pipe.partitioned_model_path = partition_file;
       config.pipeline_config = pipe;
       config.distributed_config.world_rank = i;
       config.distributed_config.world_size = total_partition_count;
@@ -1240,6 +1255,8 @@ TEST(GradientGraphBuilderTest, PipelineOnlinePartition_bert_tiny) {
       config.distributed_config.horizontal_parallel_size = 1;
       config.distributed_config.pipeline_parallel_size = total_partition_count;
       config.model_with_training_graph_path = output_file;
+
+      OverwritePipelineRank(config, i);
 
       if (!is_fp32) {
         config.mixed_precision_config = mixed_precision_config;
@@ -1314,6 +1331,8 @@ TEST(GradientGraphBuilderTest, PipelineOnlinePartition_MLP) {
       config.distributed_config.pipeline_parallel_size = 3;
       config.model_with_training_graph_path = output_file;
 
+      OverwritePipelineRank(config, i);
+
       if (!is_fp32) {
         config.mixed_precision_config = mixed_precision_config;
       }
@@ -1359,6 +1378,9 @@ Status RunOnlinePartition(const std::vector<TrainingSession::TrainingConfigurati
     config.distributed_config.data_parallel_size = 1;
     config.distributed_config.horizontal_parallel_size = 1;
     config.distributed_config.pipeline_parallel_size = pipeline_stage_size;
+
+    OverwritePipelineRank(config, i);
+
     config.model_with_training_graph_path = output_file;
 
     PathString backprop_model_file;


### PR DESCRIPTION
**Description**: Describe your changes.
This change adds support to run pipeline parallel together with data parallel. Tested with Bert-L and the corresponding unit tests are added. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
Previously pipeline parallel and data parallel are incompatible. Ort can only run one or the other. Now with a node of m x n GPUs, it can run m data parallel and n pipeline parallel. 

The command to run Bert-Large is as below:

/bert_ort/openmpi/bin/mpirun --report-pid - -n 4 ./onnxruntime_training_bert --model_name /bert_ort/bert_models/nv/bert-large/bert-large-uncased_L_24_H_1024_A_16_V_30528_S_512_Dp_0.1_optimized_layer_norm_opset12 --train_data_dir /bert_data/512/books_wiki_en_corpus/train --test_data_dir /bert_data/512/books_wiki_en_corpus/test --train_batch_size 1 --mode train --display_loss_steps 1 --optimizer lamb --learning_rate 0.006 --gradient_accumulation_steps 5 --num_train_steps 10 --warmup_ratio 0 --warmup_mode Linear --use_nccl --pipeline_parallel_size 2 --cut_group_info 1881:407-1951/2073/2195/2317/2439/2561/2683/2805/2927/3049/3171/3293 --data_parallel_size 2


- If it fixes an open issue, please link to the issue here.
