### PR TITLE
Inbox WinML tests fail because Inbox loads binaries from system32

### DIFF
--- a/winml/adapter/winml_adapter_dml.cpp
+++ b/winml/adapter/winml_adapter_dml.cpp
@@ -19,10 +19,31 @@
 namespace winmla = Windows::AI::MachineLearning::Adapter;
 
 #ifdef USE_DML
+
+static bool IsCurrentModuleInSystem32() {
+  wil::unique_hmodule current_module;
+  FAIL_FAST_IF(0 == GetModuleHandleEx(
+                        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+                        (LPCTSTR)IsCurrentModuleInSystem32,
+                        &current_module));
+
+  std::string current_module_path;
+  current_module_path.reserve(MAX_PATH);
+  auto size_module_path = GetModuleFileNameA(current_module.get(), current_module_path.data(), MAX_PATH);
+  FAIL_FAST_IF(size_module_path == 0);
+
+  std::string system32_path;
+  system32_path.reserve(MAX_PATH);
+  auto size_system32_path = GetSystemDirectoryA(system32_path.data(), MAX_PATH);
+  FAIL_FAST_IF(size_system32_path == 0);
+
+  return _strnicmp(system32_path.c_str(), current_module_path.c_str(), size_system32_path) == 0;
+}
+
 Microsoft::WRL::ComPtr<IDMLDevice> CreateDmlDevice(ID3D12Device* d3d12Device) {
   DWORD flags = 0; 
 #ifdef BUILD_INBOX 
-  flags = LOAD_LIBRARY_SEARCH_SYSTEM32; 
+  flags |= IsCurrentModuleInSystem32() ? LOAD_LIBRARY_SEARCH_SYSTEM32 : 0;
 #endif
 
   // Dynamically load DML to avoid WinML taking a static dependency on DirectML.dll

--- a/winml/adapter/winml_adapter_dml.cpp
+++ b/winml/adapter/winml_adapter_dml.cpp
@@ -20,16 +20,12 @@ namespace winmla = Windows::AI::MachineLearning::Adapter;
 
 #ifdef USE_DML
 
-static bool IsCurrentModuleInSystem32() {
-  wil::unique_hmodule current_module;
-  FAIL_FAST_IF(0 == GetModuleHandleEx(
-                        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-                        (LPCTSTR)IsCurrentModuleInSystem32,
-                        &current_module));
+EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
+static bool IsCurrentModuleInSystem32() {
   std::string current_module_path;
   current_module_path.reserve(MAX_PATH);
-  auto size_module_path = GetModuleFileNameA(current_module.get(), current_module_path.data(), MAX_PATH);
+  auto size_module_path = GetModuleFileNameA((HINSTANCE)&__ImageBase, current_module_path.data(), MAX_PATH);
   FAIL_FAST_IF(size_module_path == 0);
 
   std::string system32_path;

--- a/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp
@@ -13,10 +13,31 @@ using namespace _winml;
 
 static bool debug_output_ = false;
 
+
+static bool IsCurrentModuleInSystem32() {
+  wil::unique_hmodule current_module;
+  FAIL_FAST_IF(0 == GetModuleHandleEx(
+                        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+                        (LPCTSTR)IsCurrentModuleInSystem32,
+                        &current_module));
+
+  std::string current_module_path;
+  current_module_path.reserve(MAX_PATH);
+  auto size_module_path = GetModuleFileNameA(current_module.get(), current_module_path.data(), MAX_PATH);
+  FAIL_FAST_IF(size_module_path == 0);
+
+  std::string system32_path;
+  system32_path.reserve(MAX_PATH);
+  auto size_system32_path = GetSystemDirectoryA(system32_path.data(), MAX_PATH);
+  FAIL_FAST_IF(size_system32_path == 0);
+
+  return _strnicmp(system32_path.c_str(), current_module_path.c_str(), size_system32_path) == 0;
+}
+
 static HRESULT GetOnnxruntimeLibrary(HMODULE& module) {
   DWORD flags = 0;
 #ifdef BUILD_INBOX
-  flags = LOAD_LIBRARY_SEARCH_SYSTEM32;
+  flags |= IsCurrentModuleInSystem32() ? LOAD_LIBRARY_SEARCH_SYSTEM32 : 0;
 #endif
 
   auto out_module = LoadLibraryExA("onnxruntime.dll", nullptr, flags);

--- a/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp
@@ -13,17 +13,12 @@ using namespace _winml;
 
 static bool debug_output_ = false;
 
+EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
 static bool IsCurrentModuleInSystem32() {
-  wil::unique_hmodule current_module;
-  FAIL_FAST_IF(0 == GetModuleHandleEx(
-                        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-                        (LPCTSTR)IsCurrentModuleInSystem32,
-                        &current_module));
-
   std::string current_module_path;
   current_module_path.reserve(MAX_PATH);
-  auto size_module_path = GetModuleFileNameA(current_module.get(), current_module_path.data(), MAX_PATH);
+  auto size_module_path = GetModuleFileNameA((HINSTANCE)&__ImageBase, current_module_path.data(), MAX_PATH);
   FAIL_FAST_IF(size_module_path == 0);
 
   std::string system32_path;
@@ -36,9 +31,9 @@ static bool IsCurrentModuleInSystem32() {
 
 static HRESULT GetOnnxruntimeLibrary(HMODULE& module) {
   DWORD flags = 0;
-#ifdef BUILD_INBOX
+//#ifdef BUILD_INBOX
   flags |= IsCurrentModuleInSystem32() ? LOAD_LIBRARY_SEARCH_SYSTEM32 : 0;
-#endif
+//#endif
 
   auto out_module = LoadLibraryExA("onnxruntime.dll", nullptr, flags);
   if (out_module == nullptr) {

--- a/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp
@@ -31,9 +31,9 @@ static bool IsCurrentModuleInSystem32() {
 
 static HRESULT GetOnnxruntimeLibrary(HMODULE& module) {
   DWORD flags = 0;
-//#ifdef BUILD_INBOX
+#ifdef BUILD_INBOX
   flags |= IsCurrentModuleInSystem32() ? LOAD_LIBRARY_SEARCH_SYSTEM32 : 0;
-//#endif
+#endif
 
   auto out_module = LoadLibraryExA("onnxruntime.dll", nullptr, flags);
   if (out_module == nullptr) {


### PR DESCRIPTION
Issue: When Windows.AI.MachineLearning or onnxruntime.dll is loaded Inbox, it should never attempt to load libraries that are binplaced next to the calling process. Instead it should load only libraries from system32. However, tests expect that local libraries are loaded even in the inbox case.

Fix: Only enforce system32 search order when the calling dll is already in system32.