### PR TITLE
dnnl only run opset 10 model tests to reduce footprint/runtime

### DIFF
--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -58,7 +58,7 @@ TEST_P(ModelTest, Run) {
     // them is enabled here to save CI build time.
     return;
   }
-  if (model_info->GetONNXOpSetVersion() != 12 && provider_name == "dnnl") {
+  if (model_info->GetONNXOpSetVersion() == 10 && provider_name == "dnnl") {
     // DNNL can run most of the model tests, but only part of
     // them is enabled here to save CI build time.
     return;


### PR DESCRIPTION
dnnl ep run only opset 10 models. 
