### PR TITLE
Create training session + minor improvements

### DIFF
--- a/orttraining/orttraining/python/training/model_desc_validation.py
+++ b/orttraining/orttraining/python/training/model_desc_validation.py
@@ -40,6 +40,9 @@ class _ORTTrainerModelDesc(object):
             else:
                 self._validated['outputs'][idx] = self._OutputDescription(*output)
 
+        # Hard-code learning rate descriptor for the model
+        self._validated['learning_rate'] = self._InputDescriptionTyped('Learning_Rate', [1], torch.float32)
+
         # Convert dict in object
         for k, v in self._validated.items():
             setattr(self, k, self._wrap(v))

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -349,6 +349,7 @@ class ORTTrainer(object):
 
         return onnx_model
 
+
     def _init_onnx_model(self, inputs):
         if self._onnx_model is not None:
             return

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -162,7 +162,6 @@ class ORTTrainer(object):
                 self.model_desc.inputs, None, None, *input, **kwargs)
             self._init_onnx_model(sample_input)
 
-
     def save_as_onnx(self, path):
         r"""Persists ONNX model into :py:attr:`path`
 
@@ -173,27 +172,6 @@ class ORTTrainer(object):
             path (str): Full path, including filename, to save the model in the filesystem
         """
         pass
-
-
-    def _init_onnx_model_(self, *input):
-        if self._onnx_model is not None:
-            return
-
-        if self._torch_model is not None:
-            self.torch_model_.cpu()
-            # convert the model
-            # get input, outputs, export model
-            self.onnx_model = self.convert_model_loss_fn_to_onnx(self._torch_model, self.loss_fn, self.model_desc, torch.device('cpu'), inputs, opset_version=self.opset_version, _enable_internal_postprocess=self._enable_internal_postprocess)
-            
-            # selected tasks from init_sesion
-            if self._enable_internal_postprocess:
-                self._onnx_model_ = postprocess.run_postprocess(self.onnx_model_)
-
-            if self._extra_postprocess:
-                self._extra_postprocess(self.onnx_model_)
-
-            self._verify_fully_optimized_model(self.onnx_model_)
-        
 
     def train_step(self, *input, **kwargs):
         r"""Train step method
@@ -349,7 +327,6 @@ class ORTTrainer(object):
 
         return onnx_model
 
-
     def _init_onnx_model(self, inputs):
         if self._onnx_model is not None:
             return
@@ -392,19 +369,21 @@ class ORTTrainer(object):
             if input_desc[0] in kwargs:
                 input = input + (kwargs[input_desc[0]],)
 
-
         return input
-
 
     def _create_ort_training_session(self):
         # Validating frozen_weights names
-        unused_frozen_weights = [n for n in options.utils.frozen_weights if n not in [i.name for i in model.graph.initializer]]
+        unused_frozen_weights = [n for n in options.utils.frozen_weights if n not in [
+            i.name for i in model.graph.initializer]]
         if unused_frozen_weights:
-            raise RuntimeError("{} params from 'frozen_weights' not found in the ONNX model.".format(unused_frozen_weights))
+            raise RuntimeError("{} params from 'frozen_weights' not found in the ONNX model.".format(
+                unused_frozen_weights))
 
         # Get loss name from model description
-        loss_name = [name for item in self.model_desc.outputs if len(item) == 3 and item[2]]
-        assert len(loss_name) == 1, f"Only one loss output is supported ({len(loss_name)} were specified)"
+        loss_name = [name for item in self.model_desc.outputs if len(
+            item) == 3 and item[2]]
+        assert len(
+            loss_name) == 1, f"Only one loss output is supported ({len(loss_name)} were specified)"
         loss_name = loss[0]
 
         # Parse optimizer parameters
@@ -430,7 +409,8 @@ class ORTTrainer(object):
                     elif isinstance(v, int):
                         optimizer_int_attributes_map[initializer.name][k] = v
                     else:
-                        raise ValueError("Optimizer attributes must be either float or int.")
+                        raise ValueError(
+                            "Optimizer attributes must be either float or int.")
 
         # TrainingParameters
         ort_parameters = ort.TrainingParameters()
@@ -454,7 +434,8 @@ class ORTTrainer(object):
         session_options.use_deterministic_compute = use_deterministic_compute
 
         # TrainingSession
-        self._training_session = ort.TrainingSession(model.SerializeToString(), ort_parameters, session_options)
+        self._training_session = ort.TrainingSession(
+            model.SerializeToString(), ort_parameters, session_options)
 
         # I/O bindings
         self._train_io_binding = session.io_binding()

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -174,6 +174,27 @@ class ORTTrainer(object):
         """
         pass
 
+
+    def _init_onnx_model_(self, *input):
+        if self._onnx_model is not None:
+            return
+
+        if self._torch_model is not None:
+            self.torch_model_.cpu()
+            # convert the model
+            # get input, outputs, export model
+            self.onnx_model = self.convert_model_loss_fn_to_onnx(self._torch_model, self.loss_fn, self.model_desc, torch.device('cpu'), inputs, opset_version=self.opset_version, _enable_internal_postprocess=self._enable_internal_postprocess)
+            
+            # selected tasks from init_sesion
+            if self._enable_internal_postprocess:
+                self._onnx_model_ = postprocess.run_postprocess(self.onnx_model_)
+
+            if self._extra_postprocess:
+                self._extra_postprocess(self.onnx_model_)
+
+            self._verify_fully_optimized_model(self.onnx_model_)
+        
+
     def train_step(self, *input, **kwargs):
         r"""Train step method
 

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -375,10 +375,12 @@ class ORTTrainer(object):
 
         return input
 
-
+    # TODO: Test this througly along with train step, including
+    #       various optimizer parameter groups, frozen weights, loss and lr
     def _create_ort_training_session(self, use_deterministic_compute=False):
         # Validating frozen_weights names
-        unused_frozen_weights = [n for n in self.options.utils.frozen_weights if n not in [i.name for i in self._onnx_model.graph.initializer]]
+        unused_frozen_weights = [n for n in self.options.utils.frozen_weights\
+            if n not in [i.name for i in self._onnx_model.graph.initializer]]
         if unused_frozen_weights:
             raise RuntimeError("{} params from 'frozen_weights' not found in the ONNX model.".format(
                 unused_frozen_weights))
@@ -426,9 +428,7 @@ class ORTTrainer(object):
         ort_parameters.enable_grad_norm_clip = self.options.utils.grad_norm_clip
         ort_parameters.set_gradients_as_graph_outputs = False
         ort_parameters.training_optimizer_name = self.optim_config.name
-        
-        ort_parameters.lr_params_feed_name = str(self.optim_config.lr)
-        #ort_parameters.trainable_params = trainable_params
+        ort_parameters.lr_params_feed_name = self.model_desc.learning_rate.name
         ort_parameters.weights_to_train = trainable_params
         ort_parameters.optimizer_attributes_map = optimizer_attributes_map
         ort_parameters.optimizer_int_attributes_map = optimizer_int_attributes_map

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -124,6 +124,17 @@ class ORTTrainerOptions(object):
                         }
                     }
                 },
+                'debug' : {
+                    'type' : 'dict',
+                    'required': False,
+                    'default' : {},
+                    'schema' : {
+                        'deterministic_compute' : {
+                            'type' : 'boolean',
+                            'default' : False
+                        },
+                    }
+                },
                 '_internal_use' : {
                     'type' : 'dict',
                     'required': False,
@@ -191,6 +202,10 @@ class ORTTrainerOptions(object):
             list of model parameter names to skip training (weights don't change)
         utils.grad_norm_clip (bool, default is False):
             enables gradient norm clipping for 'AdamOptimizer' and 'LambOptimizer'
+        debug (dict):
+            debug options
+        debug.deterministic_compute (bool, default is False)
+            forces compute to be deterministic accross runs
         _internal_use (dict):
             internal options, possibly undocumented, that might be removed without notice
         _internal_use.enable_internal_postprocess (bool, default is True):
@@ -404,6 +419,17 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
                 'type': 'boolean',
                 'default': False
             }
+        }
+    },
+    'debug': {
+        'type': 'dict',
+        'default_setter': lambda _: {},
+        'required': False,
+        'schema': {
+            'deterministic_compute': {
+                'type': 'boolean',
+                'default': False
+            },
         }
     },
     '_internal_use': {

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -43,8 +43,7 @@ class ORTTrainerOptions(object):
                     'schema' : {
                         'id' : {
                             'type' : 'string',
-                            'nullable' : True,
-                            'default' : None
+                            'default' : 'cpu'
                         },
                         'mem_limit' : {
                             'type' : 'integer',
@@ -156,7 +155,7 @@ class ORTTrainerOptions(object):
             number of steps to accumulate before do collective gradient reduction
         device (dict):
             compute device related settings
-        device.id (string, default is None):
+        device.id (string, default is 'cpu'):
             device to run training
         device.mem_limit (int):
             maximum memory size (in bytes) used by device.id
@@ -325,8 +324,7 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
         'schema': {
             'id': {
                 'type': 'string',
-                'nullable': True,
-                'default': None
+                'default': 'cpu'
             },
             'mem_limit': {
                 'type': 'integer',

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -28,7 +28,7 @@ def testORTTrainerOptionsDefaultValues(test_input):
             'gradient_accumulation_steps': 0
         },
         'device': {
-            'id': None,
+            'id': 'cpu',
             'mem_limit': 0
         },
         'distributed': {
@@ -81,8 +81,14 @@ def testORTTrainerOptionsInvalidMixedPrecisionEnabledSchema():
 def testORTTrainerModelDescValidSchemas(input_dict, input_dtype, output_dtype):
     r''' Test different ways of using default values for incomplete input'''
 
-    # Validating model description from user
     model_description = md_val._ORTTrainerModelDesc(input_dict)
+
+    # Validating hard-coded learning rate description
+    assert model_description.learning_rate.name == "Learning_Rate"
+    assert model_description.learning_rate.shape == [1]
+    assert model_description.learning_rate.dtype == torch.float32
+
+    # Validating model description from user
     for idx, i_desc in enumerate(model_description.inputs):
         assert isinstance(i_desc, model_description._InputDescription)
         assert len(i_desc) == 2

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -48,6 +48,9 @@ def testORTTrainerOptionsDefaultValues(test_input):
             'frozen_weights': [],
             'grad_norm_clip': False
         },
+        'debug': {
+            'deterministic_compute': False
+        },
         '_internal_use': {
             'enable_internal_postprocess': True,
             'extra_postprocess': None,

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -514,3 +514,4 @@ def testInstantiateORTTrainer(step_fn):
             assert output_dim[dim_idx] == dim.dim_value
             assert output_type == _utils.dtype_onnx_to_torch(
                 trainer._onnx_model.graph.output[i].type.tensor_type.elem_type)
+

--- a/samples/python/pytorch_transformer/README.md
+++ b/samples/python/pytorch_transformer/README.md
@@ -1,0 +1,21 @@
+# TransformerModel example
+
+This example was adapted from Pytorch's [Sequence-to-Sequence Modeling with nn.Transformer and TorchText](https://pytorch.org/tutorials/beginner/transformer_tutorial.html) tutorial
+
+## Requirements
+
+* PyTorch 1.6+
+* TorchText 0.6+
+* ONNX Runtime 1.5+
+
+## Running PyTorch version
+
+```python
+python pt_model.py
+```
+
+## Running ONNX Runtime version
+
+```python
+python ort_model.py
+```

--- a/samples/python/pytorch_transformer/pt_model.py
+++ b/samples/python/pytorch_transformer/pt_model.py
@@ -1,6 +1,3 @@
-'''
-    From https://pytorch.org/tutorials/beginner/transformer_tutorial.html
-'''
 import math
 import torch
 import torch.nn as nn


### PR DESCRIPTION
This PR:

* Creates a training session that will be used by train_step and possibly eval_step
* Hard-code Learning Rate Descriptor on model description class. Current API required this coming from user code
* Added `ORTTrainerOptions.debug.deterministic_compute` flag
* Set Cuda device and GPU memory limit during ORTTrainer init
* Set 'cpu' as default device at `ORTTrainerOptions.device.id`
* Fix ONNX export by passing correct device to the exporter
* Add README.md for TransformerModel sample
