### PR TITLE
Add GPT-2 test generation to convert_to_onnx.py

### DIFF
--- a/onnxruntime/python/tools/transformers/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/convert_to_onnx.py
@@ -1,4 +1,5 @@
 # -------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation.  All rights reserved.
 # Licensed under the MIT License.  See License.txt in the project root for
 # license information.
@@ -19,8 +20,11 @@ import argparse
 import coloredlogs
 import logging
 import torch
+import numpy
+import json
 from transformers import AutoConfig
 from gpt2_helper import Gpt2Helper, MODEL_CLASSES, DEFAULT_TOLERANCE
+from gpt2_tester import Gpt2Tester
 from quantize_helper import QuantizeHelper
 from benchmark_helper import create_onnxruntime_session, setup_logger, prepare_environment, Precision
 
@@ -70,6 +74,13 @@ def parse_arguments():
                         type=float,
                         default=0,
                         help="the aboslute and relative tolerance for parity verification")
+
+    parser.add_argument('--input_test_file',
+                        '-i',
+                        required=False,
+                        type=str,
+                        default='',
+                        help='Path to the file with inputs to test with')
 
     parser.add_argument(
         "-p",
@@ -146,6 +157,30 @@ def main():
                                rtol=args.tolerance,
                                atol=args.tolerance,
                                model_class=args.model_class)
+
+    if args.input_test_file:
+        test_inputs = []
+        with open(args.input_test_file) as read_f:
+            for i, line in enumerate(read_f):
+                line = line.rstrip()
+                data = json.loads(line)
+                input_ids = torch.from_numpy(numpy.asarray(data["input_ids"], dtype=numpy.int64)).to(device)
+                position_ids = torch.from_numpy(numpy.asarray(data["position_ids"], dtype=numpy.int64)).to(device)
+                numpy_float = numpy.float16 if args.precision == Precision.FLOAT16 else numpy.float32
+                attention_mask = torch.from_numpy(numpy.asarray(data["attention_mask"], dtype=numpy_float)).to(device)
+                inputs = {"input_ids": input_ids, "position_ids": position_ids, "attention_mask": attention_mask}
+                test_inputs.append(inputs)
+        Gpt2Tester.test_generation(session,
+                                   model,
+                                   device,
+                                   test_inputs,
+                                   precision=args.precision,
+                                   model_class=args.model_class,
+                                   top_k=20,
+                                   top_k_no_order=True,
+                                   max_steps=24,
+                                   max_inputs=100,
+                                   verbose=args.verbose)
 
     logger.info(f"Done. Output model: {output_path}")
 

--- a/onnxruntime/python/tools/transformers/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/convert_to_onnx.py
@@ -179,7 +179,7 @@ def main():
                                    top_k=20,
                                    top_k_no_order=True,
                                    max_steps=24,
-                                   max_inputs=100,
+                                   max_inputs=0,
                                    verbose=args.verbose)
 
     logger.info(f"Done. Output model: {output_path}")

--- a/onnxruntime/python/tools/transformers/gpt2_tester.py
+++ b/onnxruntime/python/tools/transformers/gpt2_tester.py
@@ -1,0 +1,374 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+# This script helps evaluation of GPT-2 model.
+import os
+import logging
+import torch
+import onnx
+import random
+import numpy
+import time
+import timeit
+import math
+import statistics
+from gpt2_helper import Gpt2Helper
+from benchmark_helper import Precision
+
+logger = logging.getLogger(__name__)
+
+
+class Gpt2Metric:
+    def __init__(self, treatment_name, baseline_name='Torch', top_k=20):
+        assert top_k > 1 and top_k <= 100
+        self.baseline = baseline_name
+        self.treatment = treatment_name
+        self.name: str = f"{treatment_name} vs {baseline_name}"
+        self.top_k = top_k
+        self.top_1_error: int = 0
+        self.top_k_error: int = 0
+        self.total_samples: int = 0
+        self.max_logits_diff: float = 0  # for non-empty past state
+        self.max_logits_diff_no_past: float = 0  # for empty past state
+        self.batch_top1_error: torch.FloatTensor = None  # top 1 error for current batch
+        self.batch_topk_error: torch.FloatTensor = None  # top k error for current batch
+        self.seq_len_latency = {}
+
+    def print(self):
+        if self.baseline != self.treatment:
+            print("---")
+            print(f"Metrics for {self.treatment} (baseline={self.baseline}):")
+            if self.total_samples > 0:
+                top_1_error_rate = 100.0 * self.top_1_error / self.total_samples
+                top_k_error_rate = 100.0 * self.top_k_error / self.total_samples
+                print(
+                    f"Total={self.total_samples} Top1Error={self.top_1_error} ({top_1_error_rate:.2f}%) Top{self.top_k}Error={self.top_k_error} ({top_k_error_rate:.2f}%)"
+                )
+            print("Max logits diffs:")
+            print(f"\twith past  = {self.max_logits_diff:.6f}")
+            print(f"\tempty past = {self.max_logits_diff_no_past:.6f}")
+        else:
+            print(f"Metrics for {self.treatment} (baseline):")
+
+        if self.seq_len_latency:
+            print("Past sequence length range and average latency:")
+            total = 0
+            count = 0
+            for key in sorted(self.seq_len_latency.keys()):
+                average = statistics.mean(self.seq_len_latency[key]) * 1000.0
+                if key == 0:
+                    print("\t{}:         \t{:.2f} ms".format(key, average))
+                else:
+                    print("\t[{}, {}]:\t{:.2f} ms".format(2**key, 2**(key + 1) - 1, average))
+                total += average * len(self.seq_len_latency[key])
+                count += len(self.seq_len_latency[key])
+            print("Average Latency: {:.2f} ms".format(total / count))
+
+    def diff_logits(self, baseline_logits, treatment_logits, is_empty_past: bool):
+        diff = (baseline_logits - treatment_logits).abs().max()
+        if is_empty_past:
+            self.max_logits_diff_no_past = max(self.max_logits_diff_no_past, diff)
+        else:
+            self.max_logits_diff = max(self.max_logits_diff, diff)
+
+        return diff
+
+    def start_batch(self, batch_size: int):
+        self.total_samples += batch_size
+        self.batch_top1_error = torch.zeros((batch_size, 1), dtype=torch.bool)
+        self.batch_topk_error = torch.zeros((batch_size, 1), dtype=torch.bool)
+
+    def eval_batch(self, baseline, treatment, past_seq_len, verbose=True):
+        self._eval_topk(baseline.top_1_tokens, treatment.top_1_tokens, 1, verbose)
+        self._eval_topk(baseline.top_k_tokens, treatment.top_k_tokens, self.top_k, verbose)
+
+        max_diff = self.diff_logits(baseline.logits, treatment.logits, past_seq_len == 0)
+        if verbose:
+            print(f"Max logits diffs of {self.name}: {max_diff}")
+
+    def _eval_topk(self, baseline_topk, treatment_topk, top_k, verbose=True):
+        if not torch.all(torch.eq(baseline_topk, treatment_topk)):
+            if top_k == 1:
+                if verbose:
+                    print(f"Generated tokens not matched for {self.name}")
+                self.batch_top1_error |= torch.eq(baseline_topk, treatment_topk).logical_not()
+            else:
+                if verbose:
+                    print(
+                        f"Top {top_k} tokens not matched for {self.name}. This will lead to wrong beam search results")
+                self.batch_topk_error |= (torch.eq(baseline_topk, treatment_topk).logical_not().sum(1).unsqueeze(dim=1)
+                                          > 0)
+
+    def end_batch(self):
+        self.top_1_error += self.batch_top1_error.sum()
+        self.top_k_error += self.batch_topk_error.sum()
+
+    def add_latency(self, past_seq_len, latency):
+        key = int(math.log2(past_seq_len)) + 1 if past_seq_len > 0 else 0
+        if key not in self.seq_len_latency:
+            self.seq_len_latency[key] = []
+        self.seq_len_latency[key].append(latency)
+
+
+class Gpt2Tester:
+    def __init__(self,
+                 input_ids,
+                 position_ids,
+                 attention_mask,
+                 num_attention_heads,
+                 hidden_size,
+                 num_layer,
+                 device,
+                 is_fp16=False,
+                 top_k=20,
+                 top_k_required_order=False):
+
+        self.batch_size = input_ids.shape[0]
+        self.input_length = input_ids.shape[1]
+        self.n_layer = num_layer
+
+        self.input_ids = input_ids
+        self.position_ids = position_ids
+        self.attention_mask = attention_mask
+
+        # Emtpy past state for first inference
+        self.past = []
+        past_shape = [2, self.batch_size, num_attention_heads, 0, hidden_size // num_attention_heads]
+        for i in range(num_layer):
+            empty_past = torch.empty(past_shape).type(torch.float16 if is_fp16 else torch.float32)
+            self.past.append(empty_past.to(device))
+
+        self.logits = None
+        self.top_1_tokens = None
+        self.top_k_tokens = None
+        self.top_k = top_k
+        self.top_k_required_order = top_k_required_order
+
+    def get_input_tuple(self):
+        return self.input_ids, self.position_ids, self.attention_mask, self.past
+
+    def update(self, output, step, device):
+        """
+        Update the inputs for next inference.
+        """
+        self.logits = torch.from_numpy(output[0]) if isinstance(output[0],
+                                                                numpy.ndarray) else output[0].clone().detach().cpu()
+
+        self.top_1_tokens = Gpt2Tester.predict_next_token(self.logits)
+        self.top_k_tokens = Gpt2Tester.predict_next_token(self.logits, self.top_k, self.top_k_required_order)
+
+        self.input_ids = self.top_1_tokens.clone().detach().reshape([self.batch_size, 1]).to(device)
+        self.position_ids = torch.tensor([self.input_length + step - 1]).unsqueeze(0).repeat(self.batch_size,
+                                                                                             1).to(device)
+        self.attention_mask = torch.cat(
+            [self.attention_mask, torch.ones([self.batch_size, 1]).type_as(self.attention_mask)], 1).to(device)
+        self.past = []
+
+        if isinstance(output[1], tuple):  # past in torch output is tuple
+            self.past = list(output[1])
+        else:
+            for i in range(self.n_layer):
+                past_i = torch.from_numpy(output[i + 1]) if isinstance(
+                    output[i + 1], numpy.ndarray) else output[i + 1].clone().detach()
+                self.past.append(past_i.to(device))
+
+    def diff(self, baseline):
+        """
+        Compare inputs and logits output.
+        """
+
+        print("start diff...")
+        if self.logits is not None:
+            max_io_diff = (self.logits - baseline.logits).abs().max()
+            if max_io_diff > 1e-4:
+                print(f'Max logits difference is too large: {max_io_diff}')
+
+        if not torch.all(self.input_ids == baseline.input_ids):
+            print(f'Input_ids is different {self.input_ids} vs {baseline.input_ids}')
+
+        if not torch.all(self.position_ids == baseline.position_ids):
+            print(f'position_ids is different')
+
+        if not torch.all(self.attention_mask == baseline.attention_mask):
+            print(f'attention_mask is different')
+
+        if len(self.past) != len(baseline.past):
+            print("length of past not same")
+
+        for i, past_i in enumerate(self.past):
+            if past_i.shape != baseline.past[i].shape:
+                print("shape of past not same", past_i.shape, baseline.past[i].shape)
+            elif past_i.nelement() > 0:
+                max_past_diff = (past_i - baseline.past[i]).abs().max()
+                if max_past_diff > 1e-4:
+                    print(f"max_past_diff[{i}]={max_past_diff}")
+
+    @staticmethod
+    def predict_next_token(logits, top_k=1, required_order=False):
+        """
+        Get top k topkens based on logits.
+        """
+
+        # logits has shape (batch_size, seq_len, vocab_size)
+        # last token logits has shape (batch_size, vocab_size)
+        lastTokenLogits = logits[:, -1]
+        if top_k == 1:
+            generatedTokens = torch.argmax(lastTokenLogits, 1, True)
+            return generatedTokens
+        else:
+            topk = torch.argsort(lastTokenLogits, -1, descending=True)[:, :top_k]
+            if not required_order:
+                sorted_topk, _ = topk.sort()
+                return sorted_topk
+            return topk
+
+    @staticmethod
+    def diff_present(onnx_output, onnx_io_output, n_layer):
+        """
+        Compare the present outputs of two outputs from ONNX Runtime.
+        """
+        present_diff_max = []
+        for i in range(n_layer):
+            onnx_present_i = torch.from_numpy(onnx_output[i + 1]) if isinstance(onnx_output[i + 1],
+                                                                                numpy.ndarray) else onnx_output[i + 1]
+            onnx_io_present_i = torch.from_numpy(onnx_io_output[i + 1]) if isinstance(
+                onnx_io_output[i + 1], numpy.ndarray) else onnx_io_output[i + 1]
+            max_diff = (onnx_present_i - onnx_io_present_i).abs().max()
+            present_diff_max.append(max_diff)
+        print(f"present_diff_max={present_diff_max}")
+
+    @staticmethod
+    def is_quantized_onnx_model(onnx_model_path):
+        """
+        Returns True if the ONNX model is quantized.
+        """
+        import onnx
+        model = onnx.load(onnx_model_path)
+        from onnxruntime.quantization.quantize import __producer__ as quantize_producer
+        return model.producer_name == quantize_producer
+
+    @staticmethod
+    def test_generation(session,
+                        model,
+                        device,
+                        test_inputs,
+                        precision=Precision.FLOAT32,
+                        model_class='Gpt2LMHeadModel',
+                        top_k=20,
+                        top_k_no_order=True,
+                        max_steps=24,
+                        max_inputs=0,
+                        verbose=False):
+        """
+        Test Generation using greedy beam search (without sampling) to compare PyTorch and ONNX model.
+        It will print top 1 and top k errors on the given test inputs.
+        """
+        print(
+            f"start test generation: (top_k={top_k} top_k_no_order={top_k_no_order} max_steps={max_steps} test_inputs={len(test_inputs)} max_inputs={max_inputs})"
+        )
+        n_layer = model.config.n_layer
+        n_head = model.config.n_head
+        n_embd = model.config.n_embd
+        vocab_size = model.config.vocab_size
+        eos_token_id = model.config.eos_token_id
+
+        torch_float = torch.float16 if precision == Precision.FLOAT16 else torch.float32
+        is_float16 = (precision == Precision.FLOAT16)
+        if is_float16:
+            assert 'float16' in session.get_outputs()[0].type
+
+        model.eval().to(device).to(torch_float)
+
+        # Allocate initial buffers for IO Binding of ONNX Runtimne. The buffer size will automatically increase later.
+        init_output_shapes = Gpt2Helper.get_output_shapes(batch_size=4,
+                                                          past_sequence_length=128,
+                                                          sequence_length=32,
+                                                          config=model.config,
+                                                          model_class=model_class)
+        output_buffers = Gpt2Helper.get_output_buffers(init_output_shapes,
+                                                       device,
+                                                       is_float16=(torch_float == torch.float16))
+
+        baseline_name = 'Torch'
+        treatment_name = 'Quantized Onnx' if precision == Precision.INT8 else "Onnx"
+        torch_metric = Gpt2Metric(baseline_name, baseline_name, top_k)
+        onnx_metric = Gpt2Metric(treatment_name, baseline_name, top_k)
+        onnx_io_metric = Gpt2Metric(treatment_name + ' with IO Binding', baseline_name, top_k)
+
+        for i, inputs in enumerate(test_inputs):
+            if (max_inputs > 0 and i == max_inputs):
+                break
+            if i % 10 == 0:
+                print(f"{i}")
+            input_ids = inputs["input_ids"]
+            position_ids = inputs["position_ids"]
+            attention_mask = inputs["attention_mask"]
+
+            onnx_runner = Gpt2Tester(input_ids, position_ids, attention_mask, n_head, n_embd, n_layer, device,
+                                     is_float16, top_k, not top_k_no_order)
+            onnx_io_runner = Gpt2Tester(input_ids, position_ids, attention_mask, n_head, n_embd, n_layer, device,
+                                        is_float16, top_k, not top_k_no_order)
+            torch_runner = Gpt2Tester(input_ids, position_ids, attention_mask, n_head, n_embd, n_layer, device,
+                                      is_float16, top_k, not top_k_no_order)
+
+            batch_size = torch_runner.batch_size
+            onnx_metric.start_batch(batch_size)
+            onnx_io_metric.start_batch(batch_size)
+
+            with torch.no_grad():
+                done = torch.zeros(batch_size, dtype=torch.bool)
+                for step in range(max_steps):
+                    seq_len = list(onnx_runner.input_ids.size())[1]
+                    past_seq_len = list(onnx_runner.past[0].size())[3]
+
+                    start_time = timeit.default_timer()
+                    pytorch_output = Gpt2Helper.pytorch_inference(model, torch_runner.get_input_tuple())
+                    torch_metric.add_latency(past_seq_len, timeit.default_timer() - start_time)
+                    torch_runner.update(pytorch_output, step, device)
+
+                    input_tuple = onnx_runner.get_input_tuple()
+                    onnx_output, avg_latency_ms = Gpt2Helper.onnxruntime_inference(session, input_tuple, total_runs=1)
+                    onnx_metric.add_latency(past_seq_len, avg_latency_ms / 1000.0)
+                    onnx_runner.update(onnx_output, step, device)
+
+                    output_shapes = Gpt2Helper.get_output_shapes(batch_size,
+                                                                 past_seq_len,
+                                                                 seq_len,
+                                                                 model.config,
+                                                                 model_class=model_class)
+                    Gpt2Helper.auto_increase_buffer_size(output_buffers, output_shapes)
+
+                    input_tuple = onnx_io_runner.get_input_tuple()
+                    onnx_io_output, avg_latency_ms = Gpt2Helper.onnxruntime_inference_with_binded_io(session,
+                                                                                                     input_tuple,
+                                                                                                     output_buffers,
+                                                                                                     output_shapes,
+                                                                                                     total_runs=1,
+                                                                                                     return_numpy=False)
+                    onnx_io_metric.add_latency(past_seq_len, avg_latency_ms / 1000.0)
+                    onnx_io_runner.update(onnx_io_output, step, device)
+
+                    if verbose:
+                        onnx_runner.diff(onnx_io_runner)
+                        Gpt2Tester.diff_present(onnx_output, onnx_io_output, n_layer)
+
+                        print("Top 1 tokens:")
+                        print("\tTorch", torch_runner.top_1_tokens)
+                        print("\ONNX", onnx_runner.top_1_tokens)
+                        print("\ONNX with IO binding", onnx_io_runner.top_1_tokens)
+
+                    onnx_metric.eval_batch(torch_runner, onnx_runner, past_seq_len, verbose=verbose)
+                    onnx_io_metric.eval_batch(torch_runner, onnx_io_runner, past_seq_len, verbose=verbose)
+
+                    done = done | (torch_runner.top_1_tokens == eos_token_id).any()
+                    if torch.all(done):
+                        break
+
+            onnx_metric.end_batch()
+            onnx_io_metric.end_batch()
+
+        torch_metric.print()
+        onnx_metric.print()
+        onnx_io_metric.print()


### PR DESCRIPTION
**Description**: 
Add an option to test generation given input file. The test will use greedy method to get top 1 and top 20, and print the error rates compared to PyTorch model.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

This serves as example for gpt-2 generation, and could use to verify parity using user specified inputs.