### PR TITLE
Support easy way to request verbose logging in test runner

### DIFF
--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -107,9 +107,10 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   int device_id = 0;
   GraphOptimizationLevel graph_optimization_level = ORT_ENABLE_ALL;
   bool user_graph_optimization_level_set = false;
-  int verbosity_option_count = 0;
 
   OrtLoggingLevel logging_level = ORT_LOGGING_LEVEL_ERROR;
+  bool verbose_logging_required = false;
+
   bool pause = false;
   {
     int ch;
@@ -119,7 +120,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
           enable_cpu_mem_arena = false;
           break;
         case 'v':
-          verbosity_option_count += 1;
+          verbose_logging_required = true;
           break;
         case 'c':
           concurrent_session_runs = static_cast<int>(OrtStrtol<PATH_CHAR_TYPE>(optarg, nullptr));
@@ -230,10 +231,12 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     }
   }
 
-  // set log level based on number of verbosity options
-  logging_level =
-      static_cast<OrtLoggingLevel>(static_cast<int>(ORT_LOGGING_LEVEL_ERROR) -
-                                   std::min<int>(verbosity_option_count, static_cast<int>(ORT_LOGGING_LEVEL_ERROR)));
+  // TODO: Support specifying all valid levels of logging
+  // Currently the logging level is ORT_LOGGING_LEVEL_ERROR by default and
+  // if the user adds -v, the logging level is ORT_LOGGING_LEVEL_VERBOSE
+  if (verbose_logging_required) {
+    logging_level = ORT_LOGGING_LEVEL_VERBOSE;
+  }
 
   if (concurrent_session_runs > 1 && repeat_count > 1) {
     fprintf(stderr, "when you use '-r [repeat]', please set '-c' to 1\n");


### PR DESCRIPTION
**Description**: Support easy way to request verbose logging in test runner. Currently, we need to add -v -v -v to request verbose logging. 

