### PR TITLE
Log telemetry for tracking usage of WinML Native API for setting IntraOpNumThreadsOverride

### DIFF
--- a/winml/lib/Api/LearningModelSessionOptions.cpp
+++ b/winml/lib/Api/LearningModelSessionOptions.cpp
@@ -38,6 +38,7 @@ uint32_t LearningModelSessionOptions::GetIntraOpNumThreads() {
 
 STDMETHODIMP LearningModelSessionOptions::SetIntraOpNumThreadsOverride(uint32_t intraOpNumThreads) noexcept {
   intra_op_num_threads_override_ = intraOpNumThreads;
+  telemetry_helper.SetIntraOpNumThreadsOverride(intraOpNumThreads);
   return S_OK;
 }
 }  // namespace WINMLP

--- a/winml/lib/Common/inc/WinMLTelemetryHelper.h
+++ b/winml/lib/Common/inc/WinMLTelemetryHelper.h
@@ -34,6 +34,7 @@ class Profiler;
 #define WINML_TLM_MODEL_CREATION_VERSION 0
 #define WINML_TLM_RUNTIME_ERROR_VERSION 0
 #define WINML_TLM_RUNTIME_PERF_VERSION 0
+#define WINML_TLM_NATIVE_API_INTRAOP_THREADS_VERSION 0
 
 #define WinMLTraceLoggingWrite(hProvider, EventName, ...)                \
   TraceLoggingWrite(hProvider,                                           \
@@ -94,7 +95,8 @@ class WinMLTelemetryHelper {
       uint32_t type_constraint_count,
       uint32_t attribute_count,
       uint32_t default_attribute_count);
-
+  void SetIntraOpNumThreadsOverride(
+      uint32_t num_threads);
   void EndRuntimeSession() { ++runtime_session_id_; };
   bool IsMeasureSampled();
 

--- a/winml/lib/Common/inc/common.h
+++ b/winml/lib/Common/inc/common.h
@@ -21,6 +21,7 @@
 #include <utility>
 #include <variant>
 #include <vector>
+#include <thread>
 
 // WIL
 #include <wil/cppwinrt.h>

--- a/winml/lib/Telemetry/WinMLTelemetryHelper.cpp
+++ b/winml/lib/Telemetry/WinMLTelemetryHelper.cpp
@@ -107,3 +107,20 @@ void WinMLTelemetryHelper::RegisterOperatorSetSchema(
       TraceLoggingInt32(runtime_session_id_, "runtime_session_id_"),
       TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
 }
+
+void WinMLTelemetryHelper::SetIntraOpNumThreadsOverride(
+    uint32_t num_threads_override) {
+  if (!telemetry_enabled_)
+    return;
+  WinMLTraceLoggingWrite(
+      provider_,
+      "SetIntraOpNumThreadsOverride",
+      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+      //Telemetry info
+      TraceLoggingUInt8(WINML_TLM_NATIVE_API_INTRAOP_THREADS_VERSION, "schemaVersion"),
+      // num threads info
+      TraceLoggingInt32(num_threads_override, "numThreadsOverride"),
+      TraceLoggingInt32(std::thread::hardware_concurrency(), "maxThreadsOnMachine"),
+      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+}


### PR DESCRIPTION
This change sends telemetry to monitor API usage of SetIntraOpNumThreadsOverride Native API.