### PR TITLE
Remove the requirement of reading CUDA's version.txt in CI

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -946,7 +946,8 @@ def setup_cuda_vars(args):
                 .format(
                     cuda_home, cuda_home_valid, cudnn_home, cudnn_home_valid))
 
-        if is_windows():
+        # Our CI build machines already have the env vars setup
+        if is_windows() and 'AGENT_VERSION' not in os.environ:
             # Validate that the cudnn_home is pointing at
             # the right level.
             if not os.path.exists(os.path.join(cudnn_home, "bin")):


### PR DESCRIPTION
**Description**: 

Sometimes there is a file named "version.txt" in your CUDA installation dir, but sometimes there isn't one.  I couldn't figure out it why, but the latest CUDA 11 on our CI build machines doesn't have this file. As the file is not needed for building onnxruntime, so I removed the check.


**Motivation and Context**
- Why is this change required? What problem does it solve?

To make TensorRT's CUDA 11 build pass.

- If it fixes an open issue, please link to the issue here.
