### PR TITLE
fix the compilation issue with change in hip

### DIFF
--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -716,7 +716,7 @@ if (onnxruntime_USE_HIP)
   set(CMAKE_MODULE_PATH "${onnxruntime_HIP_HOME}/hip/cmake" ${CMAKE_MODULE_PATH})
   find_package(HIP)
 
-  find_library(HIP_LIB hip_hcc REQUIRED)
+  find_library(HIP_LIB amdhip64 REQUIRED)
   find_library(HIP_BLAS hipblas REQUIRED)
   find_library(MIOPEN_LIB MIOpen REQUIRED)
   find_library(RCCL_LIB rccl REQUIRED)


### PR DESCRIPTION
Update the old HIP runtime library hip_hcc to amdhip64. With transition to hipclang, the HIP runtime library name was changed. A symlink was added to ease the transition, but will be removed from ROCm3.7. Need to update hip_hcc to amdhip64 to fix the compilation issue in Rocm3.7 and the later rocm version. Note that this commit is verified for both ROCm3.5 and Rocm3.7, it won't break onnxruntime on ROCm3.5.


