### PR TITLE
Add legacy vs experimental ORTTrainer accuracy comparison

### DIFF
--- a/orttraining/orttraining/python/training/debug.py
+++ b/orttraining/orttraining/python/training/debug.py
@@ -6,6 +6,7 @@ import torch
 
 from numpy.testing import assert_allclose
 from onnxruntime.capi.training import orttrainer
+from onnxruntime.capi.ort_trainer import ORTTrainer as Legacy_ORTTrainer
 
 def compare_onnx_weights(model_a, model_b, verbose=False, rtol=1e-4):
     r"""Compare whether weights between 'model_a' and 'model_b' ONNX models are within
@@ -21,6 +22,25 @@ def compare_onnx_weights(model_a, model_b, verbose=False, rtol=1e-4):
     assert isinstance(model_a, orttrainer.ORTTrainer) and isinstance(model_b, orttrainer.ORTTrainer)
     state_dict_a, state_dict_b = model_a._training_session.get_state(), model_b._training_session.get_state()
     assert len(state_dict_a.items()) == len(state_dict_b.items())
+    _compare_state_dict_weights(state_dict_a, state_dict_b, verbose, rtol)
+
+def compare_legacy_onnx_weights(model_a, model_b, verbose=False, rtol=1e-4):
+    r"""Compare whether weights between 'model_a' (legacy API ONNX model) and 'model_b' (new API ONNX model)
+    are within a certain tolerance 'rtol'
+
+    Compares the weights of two different ONNX models and throws an error when they diverge
+    Args:
+        model_a, model_b (ORTTrainer): Two instances of ORTTrainer with the same model structure
+        verbose (bool, default is False): Indicates if the max absolute difference for each layer should be
+    calculated and printed for debug information.
+        rtol (float, default is 1e-4): Tolerance for divergence.
+    """
+    assert isinstance(model_a, orttrainer.ORTTrainer) and isinstance(model_b, Legacy_ORTTrainer)
+    state_dict_a, state_dict_b = model_a._training_session.get_state(), model_b.session.get_state()
+    assert len(state_dict_a.items()) == len(state_dict_b.items())
+    _compare_state_dict_weights(state_dict_a, state_dict_b, verbose, rtol)
+
+def _compare_state_dict_weights(state_dict_a, state_dict_b, verbose=False, rtol=1e-4):
     for (a_name, a_val), (b_name, b_val) in zip(state_dict_a.items(), state_dict_b.items()):
         np_a_vals = np.array(a_val).flatten()
         np_b_vals = np.array(b_val).flatten()
@@ -28,4 +48,4 @@ def compare_onnx_weights(model_a, model_b, verbose=False, rtol=1e-4):
         if verbose:
             print(f'Weight name: {a_name}: absolute difference: {np.abs(np_a_vals-np_b_vals).max()}')
         assert_allclose(a_val, b_val, rtol=rtol, err_msg=f"Weight mismatch for {a_name}")
-         
+

--- a/orttraining/orttraining/python/training/debug.py
+++ b/orttraining/orttraining/python/training/debug.py
@@ -24,6 +24,7 @@ def compare_onnx_weights(model_a, model_b, verbose=False, rtol=1e-4):
     assert len(state_dict_a.items()) == len(state_dict_b.items())
     _compare_state_dict_weights(state_dict_a, state_dict_b, verbose, rtol)
 
+
 def compare_legacy_onnx_weights(model_a, model_b, verbose=False, rtol=1e-4):
     r"""Compare whether weights between 'model_a' (legacy API ONNX model) and 'model_b' (new API ONNX model)
     are within a certain tolerance 'rtol'
@@ -48,4 +49,3 @@ def _compare_state_dict_weights(state_dict_a, state_dict_b, verbose=False, rtol=
         if verbose:
             print(f'Weight name: {a_name}: absolute difference: {np.abs(np_a_vals-np_b_vals).max()}')
         assert_allclose(a_val, b_val, rtol=rtol, err_msg=f"Weight mismatch for {a_name}")
-

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -473,7 +473,7 @@ def generate_pytorch_transformer_model_sample(optim_config, options={}, step_fn=
     utils = _utils.import_module_from_file(utils_path, utils_name)
 
     # Modeling
-    model = pt_model.TransformerModel(28785, 200, 2, 200, 2, 0.2).to(device)
+    model = pt_model.TransformerModel(28785, 200, 2, 200, 2, 0.2)
     my_loss = ort_utils.my_loss
     model_desc = ort_utils.transformer_model_description()
    
@@ -671,4 +671,3 @@ def testORTTrainerLegacyAndExperimentalWeightsCheck():
 
     # Compare legacy vs experimental APIs
     debug.compare_legacy_onnx_weights(trainer, legacy_trainer)
-

--- a/samples/python/pytorch_transformer/ort_utils.py
+++ b/samples/python/pytorch_transformer/ort_utils.py
@@ -18,6 +18,7 @@ def transformer_model_description():
                               ('predictions', [bptt, batch_size, ntokens])]}
     return model_desc
 
+
 def legacy_transformer_model_description():
     input_desc = IODescription('input1', [35, 20], torch.float32)
     label_desc = IODescription('label', [35, 20, 28785], torch.int64)

--- a/samples/python/pytorch_transformer/ort_utils.py
+++ b/samples/python/pytorch_transformer/ort_utils.py
@@ -1,4 +1,5 @@
 import torch
+from onnxruntime.capi.ort_trainer import IODescription, ModelDescription
 
 
 def my_loss(x, target):
@@ -16,3 +17,12 @@ def transformer_model_description():
                   'outputs': [('loss', [], True),
                               ('predictions', [bptt, batch_size, ntokens])]}
     return model_desc
+
+def legacy_transformer_model_description():
+    input_desc = IODescription('input1', [35, 20], torch.float32)
+    label_desc = IODescription('label', [35, 20, 28785], torch.int64)
+    loss_desc = IODescription('loss', [], torch.float32)
+    lr = 0.001
+    #return ModelDescription([input_desc, label_desc], [loss_desc]), IODescription('Learning_Rate', [lr,], torch.float32)
+    prediction_desc = IODescription('prediction', [35, 20, 28785], torch.float32)
+    return ModelDescription([input_desc, label_desc], [loss_desc, prediction_desc]), IODescription('Learning_Rate', [lr,], torch.float32)


### PR DESCRIPTION
- Adds a relevant helper function for comparing weights.

- Adds test for legacy vs experimental weights to ensure train step consistency across the new API.