### PR TITLE
Add Experimental WinRT API IDL as placeholder for adding new winrt features

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -427,10 +427,6 @@ add_library(winml_lib_api STATIC
   ${winml_lib_api_dir}/TensorFeatureDescriptor.cpp
   ${winml_lib_api_dir}/TensorFeatureDescriptor.h
   ${winml_lib_api_dir}/pch/pch.h
-
-  ## WinML.Experimental
-  #${winml_lib_api_dir}/Experimental.Dummy.cpp
-  #${winml_lib_api_dir}/Experimental.Dummy.h
 )
 
 # Compiler options

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -20,6 +20,7 @@ set(winml_api_root ${REPO_ROOT}/winml/api)
 set(winml_dll_dir ${REPO_ROOT}/winml/dll)
 set(winml_lib_dir ${REPO_ROOT}/winml/lib)
 set(winml_lib_api_dir ${REPO_ROOT}/winml/lib/api)
+set(winml_lib_api_experimental_dir ${REPO_ROOT}/winml/lib/api.experimental)
 set(winml_lib_api_image_dir ${REPO_ROOT}/winml/lib/api.image)
 set(winml_lib_api_ort_dir ${REPO_ROOT}/winml/lib/api.ort)
 set(winml_lib_common_dir ${REPO_ROOT}/winml/lib/common)
@@ -28,6 +29,7 @@ set(winml_lib_telemetry_dir ${REPO_ROOT}/winml/lib/telemetry)
 set(winml_is_inbox OFF)
 if (onnxruntime_WINML_NAMESPACE_OVERRIDE)
   set(output_name "${onnxruntime_WINML_NAMESPACE_OVERRIDE}.AI.MachineLearning")
+  set(experimental_output_name "${onnxruntime_WINML_NAMESPACE_OVERRIDE}.AI.MachineLearning.Experimental")
   set(idl_native_output_name "${onnxruntime_WINML_NAMESPACE_OVERRIDE}.AI.MachineLearning.Native")
   set(idl_native_internal_output_name "${onnxruntime_WINML_NAMESPACE_OVERRIDE}.AI.MachineLearning.Native.Internal")
   
@@ -41,6 +43,7 @@ if (onnxruntime_WINML_NAMESPACE_OVERRIDE)
   set(winml_api_use_ns_prefix false)
 else()
   set(output_name "Microsoft.AI.MachineLearning")
+  set(experimental_output_name "Microsoft.AI.MachineLearning.Experimental")
   set(idl_native_output_name "Microsoft.AI.MachineLearning.Native")
   set(idl_native_internal_output_name "Microsoft.AI.MachineLearning.Native.Internal")
   set(winml_midl_defines "/DROOT_NS=Microsoft")
@@ -62,6 +65,7 @@ convert_forward_slashes_to_back(${exclusions} CPPWINRT_COMPONENT_EXCLUSION_LIST)
 #
 # For native idl files there are no casing restrictions.
 get_filename_component(winrt_idl "${winml_api_root}/Windows.AI.MachineLearning.idl" ABSOLUTE)
+get_filename_component(winrt_experimental_idl "${winml_api_root}/Microsoft.AI.MachineLearning.Experimental.idl" ABSOLUTE)
 get_filename_component(idl_native "${winml_api_root}/windows.ai.machineLearning.native.idl" ABSOLUTE)
 get_filename_component(idl_native_internal "${winml_api_root}/windows.ai.machineLearning.native.internal.idl" ABSOLUTE)
 
@@ -85,6 +89,19 @@ target_cppwinrt(winml_api
   "${winml_midl_defines}"    # the midl compiler defines
   ${winml_api_use_ns_prefix} # set ns_prefix
 )
+
+# generate winml.experimental headers from idl
+target_cppwinrt(winml_api_experimental
+  ${winrt_experimental_idl}                    # winml winrt idl to compile
+  "Microsoft.AI.MachineLearning.Experimental"  # outputs name
+  ${winml_lib_api_dir}                         # location for cppwinrt generated component sources
+  ${sdk_folder}                                # location of sdk folder
+  ${sdk_version}                               # sdk version
+  ${target_folder}                             # the folder this target will be placed under
+  ${winml_midl_defines}                        # the midl compiler defines
+  ${winml_api_use_ns_prefix}                   # set ns_prefix
+)
+
 
 target_midl(winml_api_native
   ${idl_native}             # winml native idl to compile
@@ -410,6 +427,10 @@ add_library(winml_lib_api STATIC
   ${winml_lib_api_dir}/TensorFeatureDescriptor.cpp
   ${winml_lib_api_dir}/TensorFeatureDescriptor.h
   ${winml_lib_api_dir}/pch/pch.h
+
+  ## WinML.Experimental
+  #${winml_lib_api_dir}/Experimental.Dummy.cpp
+  #${winml_lib_api_dir}/Experimental.Dummy.h
 )
 
 # Compiler options
@@ -431,6 +452,7 @@ target_precompiled_header(winml_lib_api pch.h)
 # Includes
 target_include_directories(winml_lib_api PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api)                   # windows machine learning generated component headers
 target_include_directories(winml_lib_api PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api/comp_generated)    # windows machine learning generated component headers
+target_include_directories(winml_lib_api PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api_experimental/comp_generated) # windows machine learning generated component headers
 target_include_directories(winml_lib_api PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml/sdk/cppwinrt/include)  # sdk cppwinrt headers
 
 target_include_directories(winml_lib_api PRIVATE ${winml_lib_api_dir})
@@ -473,6 +495,82 @@ add_dependencies(winml_lib_api winml_api_native_internal)
 target_link_libraries(winml_lib_api PRIVATE wil winml_lib_telemetry)
 if (onnxruntime_USE_DML)
   target_add_dml(winml_lib_api)
+endif(onnxruntime_USE_DML)
+
+
+###########################
+# Add winml_lib_api_experimental_dir
+###########################
+
+# Add static library that will be archived/linked for both static/dynamic library
+add_library(winml_lib_api_experimental STATIC
+  ${winml_lib_api_experimental_dir}/Dummy.cpp
+  ${winml_lib_api_experimental_dir}/Dummy.h
+)
+
+# Compiler options
+target_compile_features(winml_lib_api_experimental PRIVATE cxx_std_17)
+target_compile_options(winml_lib_api_experimental PRIVATE /GR- /await /bigobj /wd4238)
+
+# Compiler flags
+target_compile_definitions(winml_lib_api_experimental PRIVATE WINML_ROOT_NS=${winml_root_ns})
+target_compile_definitions(winml_lib_api_experimental PRIVATE ONNX_NAMESPACE=onnx)
+target_compile_definitions(winml_lib_api_experimental PRIVATE ONNX_ML)
+target_compile_definitions(winml_lib_api_experimental PRIVATE LOTUS_LOG_THRESHOLD=2)
+target_compile_definitions(winml_lib_api_experimental PRIVATE LOTUS_ENABLE_STDERR_LOGGING)
+target_compile_definitions(winml_lib_api_experimental PRIVATE PLATFORM_WINDOWS)
+target_compile_definitions(winml_lib_api_experimental PRIVATE _SCL_SECURE_NO_WARNINGS)                         # remove warnings about unchecked iterators
+
+# Specify the usage of a precompiled header
+target_precompiled_header(winml_lib_api_experimental pch.h)
+
+# Includes
+target_include_directories(winml_lib_api_experimental PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api)                   # windows machine learning generated component headers
+target_include_directories(winml_lib_api_experimental PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api/comp_generated)    # windows machine learning generated component headers
+target_include_directories(winml_lib_api_experimental PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api_experimental/comp_generated) # windows machine learning generated component headers
+target_include_directories(winml_lib_api_experimental PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml/sdk/cppwinrt/include)  # sdk cppwinrt headers
+
+target_include_directories(winml_lib_api_experimental PRIVATE ${winml_lib_api_dir})
+target_include_directories(winml_lib_api_experimental PRIVATE ${winml_lib_api_dir}/pch)
+target_include_directories(winml_lib_api_experimental PRIVATE ${winml_adapter_dir})
+target_include_directories(winml_lib_api_experimental PRIVATE ${winml_lib_api_image_dir}/inc)
+target_include_directories(winml_lib_api_experimental PRIVATE ${winml_lib_api_ort_dir}/inc)
+target_include_directories(winml_lib_api_experimental PRIVATE ${winml_lib_telemetry_dir}/inc)
+target_include_directories(winml_lib_api_experimental PRIVATE ${winml_lib_common_dir}/inc)
+
+target_include_directories(winml_lib_api_experimental PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(winml_lib_api_experimental PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/external/date/include)
+target_include_directories(winml_lib_api_experimental PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/external/gsl/include)
+target_include_directories(winml_lib_api_experimental PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/external/onnx)
+
+target_include_directories(winml_lib_api_experimental PRIVATE ${ONNXRUNTIME_INCLUDE_DIR})
+target_include_directories(winml_lib_api_experimental PRIVATE ${ONNXRUNTIME_INCLUDE_DIR}/core/graph)
+target_include_directories(winml_lib_api_experimental PRIVATE ${ONNXRUNTIME_ROOT})
+target_include_directories(winml_lib_api_experimental PRIVATE ${ONNXRUNTIME_ROOT}/core/graph)
+target_include_directories(winml_lib_api_experimental PRIVATE ${REPO_ROOT}/cmake/external/eigen)
+target_include_directories(winml_lib_api_experimental PRIVATE ${REPO_ROOT}/cmake/external/onnx)
+target_include_directories(winml_lib_api_experimental PRIVATE ${REPO_ROOT}/cmake/external/protobuf/src)
+target_include_directories(winml_lib_api_experimental PRIVATE ${REPO_ROOT}/cmake/external/gsl/include)
+target_include_directories(winml_lib_api_experimental PRIVATE ${REPO_ROOT}/cmake/external/SafeInt)
+
+# Properties
+set_target_properties(winml_lib_api_experimental
+  PROPERTIES
+  FOLDER
+  ${target_folder})
+
+# Add deps
+add_dependencies(winml_lib_api_experimental onnx)
+add_dependencies(winml_lib_api_experimental winml_sdk_cppwinrt)
+add_dependencies(winml_lib_api_experimental winml_api)
+add_dependencies(winml_lib_api_experimental winml_api_native)
+add_dependencies(winml_lib_api_experimental winml_api_native_internal)
+add_dependencies(winml_lib_api_experimental winml_api_experimental)
+
+# Link libraries
+target_link_libraries(winml_lib_api_experimental PRIVATE wil winml_lib_telemetry)
+if (onnxruntime_USE_DML)
+  target_add_dml(winml_lib_api_experimental)
 endif(onnxruntime_USE_DML)
 
 ###########################
@@ -573,11 +671,13 @@ target_precompiled_header(winml_dll pch.h)
 # Includes
 target_include_directories(winml_dll PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api)                   # windows machine learning generated component headers
 target_include_directories(winml_dll PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api/comp_generated)    # windows machine learning generated component headers
+target_include_directories(winml_dll PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api_experimental/comp_generated)    # windows machine learning generated component headers
 target_include_directories(winml_dll PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml/sdk/cppwinrt/include)  # sdk cppwinrt headers
 
 target_include_directories(winml_dll PRIVATE ${winml_dll_dir})
 target_include_directories(winml_dll PRIVATE ${winml_lib_api_dir})
 target_include_directories(winml_dll PRIVATE ${winml_lib_api_dir}/impl)
+target_include_directories(winml_dll PRIVATE ${winml_lib_api_experimental_dir})
 target_include_directories(winml_dll PRIVATE ${winml_lib_api_ort_dir}/inc)
 target_include_directories(winml_dll PRIVATE ${winml_adapter_dir})
 target_include_directories(winml_dll PRIVATE ${winml_lib_api_image_dir}/inc)
@@ -628,6 +728,7 @@ add_dependencies(winml_dll winml_api_native_internal)
 target_link_libraries(winml_dll PRIVATE re2)
 target_link_libraries(winml_dll PRIVATE wil)
 target_link_libraries(winml_dll PRIVATE winml_lib_api)
+target_link_libraries(winml_dll PRIVATE winml_lib_api_experimental)
 target_link_libraries(winml_dll PRIVATE winml_lib_image)
 target_link_libraries(winml_dll PRIVATE winml_lib_ort)
 target_link_libraries(winml_dll PRIVATE winml_lib_telemetry)

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -93,7 +93,7 @@ target_cppwinrt(winml_api
 # generate winml.experimental headers from idl
 target_cppwinrt(winml_api_experimental
   ${winrt_experimental_idl}                    # winml winrt idl to compile
-  "Microsoft.AI.MachineLearning.Experimental"  # outputs name
+  ${experimental_output_name}                  # outputs name
   ${winml_lib_api_dir}                         # location for cppwinrt generated component sources
   ${sdk_folder}                                # location of sdk folder
   ${sdk_version}                               # sdk version

--- a/cmake/winml_cppwinrt.cmake
+++ b/cmake/winml_cppwinrt.cmake
@@ -115,7 +115,6 @@ function(target_cppwinrt
         convert_forward_slashes_to_back(${target_outputs}/comp_generated generated_dir_back_slash)
         convert_forward_slashes_to_back(${generated_dir_back_slash}/module.g.cpp module_g_cpp_back_slash)
         convert_forward_slashes_to_back(${generated_dir_back_slash}/module.g.excl.cpp module_g_ecxl_cpp_back_slash)
-        
         if (set_ns_prefix)
           set(ns_prefix "/ns_prefix")
         else()
@@ -153,7 +152,7 @@ function(target_cppwinrt
                 ${midl_options}
                 ${renamed_idl_fullpath_back_slash}
             COMMAND
-                    ${cppwinrt_exe} -in ${winmd_filename} -comp ${output_dir_back_slash} -ref ${cmake_current_binary_dir_back_slash} -ref ${sdk_metadata_directory} -out ${generated_dir_back_slash} -verbose
+                    ${cppwinrt_exe} -in ${winmd_filename} -comp ${output_dir_back_slash} -ref ${sdk_metadata_directory} -out ${generated_dir_back_slash} -verbose
             COMMAND
                     # copy the generated component files into a temporary directory where headers exclusions will be applied
                     xcopy ${output_dir_back_slash} ${temp_dir_back_slash}\\ /Y /D

--- a/cmake/winml_cppwinrt.cmake
+++ b/cmake/winml_cppwinrt.cmake
@@ -115,8 +115,7 @@ function(target_cppwinrt
         convert_forward_slashes_to_back(${target_outputs}/comp_generated generated_dir_back_slash)
         convert_forward_slashes_to_back(${generated_dir_back_slash}/module.g.cpp module_g_cpp_back_slash)
         convert_forward_slashes_to_back(${generated_dir_back_slash}/module.g.excl.cpp module_g_ecxl_cpp_back_slash)
-        convert_forward_slashes_to_back(${out_sources_folder} out_sources_folder_back_slash)
-  
+        
         if (set_ns_prefix)
           set(ns_prefix "/ns_prefix")
         else()
@@ -181,9 +180,9 @@ function(target_cppwinrt
                     for /f %I in ('dir /b ${temp_dir_back_slash}') \
                     do \
                     ( \
-                        if not exist ${out_sources_folder_back_slash}\\%I \
+                        if not exist ${out_sources_folder}\\%I \
                         ( \
-                            copy ${temp_dir_back_slash}\\%I ${out_sources_folder_back_slash}\\%I \
+                            copy ${temp_dir_back_slash}\\%I ${out_sources_folder}\\%I \
                         ) \
                     )"
             COMMAND

--- a/cmake/winml_cppwinrt.cmake
+++ b/cmake/winml_cppwinrt.cmake
@@ -107,12 +107,15 @@ function(target_cppwinrt
         # Get directory
         get_filename_component(idl_source_directory ${file} DIRECTORY)
 
+        convert_forward_slashes_to_back(${CMAKE_CURRENT_BINARY_DIR} cmake_current_binary_dir_back_slash)
+
         set(target_outputs ${CMAKE_CURRENT_BINARY_DIR}/${target_name})
         convert_forward_slashes_to_back(${target_outputs}/comp output_dir_back_slash)
         convert_forward_slashes_to_back(${target_outputs}/temp temp_dir_back_slash)
         convert_forward_slashes_to_back(${target_outputs}/comp_generated generated_dir_back_slash)
         convert_forward_slashes_to_back(${generated_dir_back_slash}/module.g.cpp module_g_cpp_back_slash)
         convert_forward_slashes_to_back(${generated_dir_back_slash}/module.g.excl.cpp module_g_ecxl_cpp_back_slash)
+        convert_forward_slashes_to_back(${out_sources_folder} out_sources_folder_back_slash)
   
         if (set_ns_prefix)
           set(ns_prefix "/ns_prefix")
@@ -140,10 +143,10 @@ function(target_cppwinrt
                 /metadata_dir ${sdk_metadata_directory}
                 /W1 /char signed /nomidl /nologo /winrt
                 /no_settings_comment /no_def_idir /target "NT60"
+                /I ${idl_source_directory}
                 /I ${um_sdk_directory}
                 /I ${shared_sdk_directory}
                 /I ${winrt_sdk_directory}
-                /I ${idl_source_directory}
                 /winmd ${winmd_filename}
                 ${ns_prefix}
                 /h ${header_filename}
@@ -151,7 +154,7 @@ function(target_cppwinrt
                 ${midl_options}
                 ${renamed_idl_fullpath_back_slash}
             COMMAND
-                    ${cppwinrt_exe} -in ${winmd_filename} -comp ${output_dir_back_slash} -ref ${sdk_metadata_directory} -out ${generated_dir_back_slash} -verbose
+                    ${cppwinrt_exe} -in ${winmd_filename} -comp ${output_dir_back_slash} -ref ${cmake_current_binary_dir_back_slash} -ref ${sdk_metadata_directory} -out ${generated_dir_back_slash} -verbose
             COMMAND
                     # copy the generated component files into a temporary directory where headers exclusions will be applied
                     xcopy ${output_dir_back_slash} ${temp_dir_back_slash}\\ /Y /D
@@ -178,9 +181,9 @@ function(target_cppwinrt
                     for /f %I in ('dir /b ${temp_dir_back_slash}') \
                     do \
                     ( \
-                        if not exist ${out_sources_folder}\\%I \
+                        if not exist ${out_sources_folder_back_slash}\\%I \
                         ( \
-                            copy ${temp_dir_back_slash}\\%I ${out_sources_folder}\\%I \
+                            copy ${temp_dir_back_slash}\\%I ${out_sources_folder_back_slash}\\%I /Y /D \
                         ) \
                     )"
             COMMAND

--- a/cmake/winml_cppwinrt.cmake
+++ b/cmake/winml_cppwinrt.cmake
@@ -183,7 +183,7 @@ function(target_cppwinrt
                     ( \
                         if not exist ${out_sources_folder_back_slash}\\%I \
                         ( \
-                            copy ${temp_dir_back_slash}\\%I ${out_sources_folder_back_slash}\\%I /Y /D \
+                            copy ${temp_dir_back_slash}\\%I ${out_sources_folder_back_slash}\\%I \
                         ) \
                     )"
             COMMAND

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -15,7 +15,9 @@ set(WINML_TEST_INC_DIR
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}/winml_api
   ${CMAKE_CURRENT_BINARY_DIR}/winml_api/comp_generated
-  ${CMAKE_CURRENT_BINARY_DIR}/winml/sdk/cppwinrt/include)
+  ${CMAKE_CURRENT_BINARY_DIR}/winml/sdk/cppwinrt/include
+  ${CMAKE_CURRENT_BINARY_DIR}/winml_api_experimental/comp_generated
+)
 
 function(set_winml_target_properties target)
   set_target_properties(${target} PROPERTIES

--- a/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
+++ b/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import "Windows.Foundation.idl";
+import "dualapipartitionattribute.idl";
+import "Windows.AI.MachineLearning.idl";
+
+#include <sdkddkver.h>
+
+namespace Microsoft.AI.MachineLearning.Experimental {
+
+  [threading(both)]
+  [marshaling_behavior(agile)]
+  [dualapipartition(1)]
+  runtimeclass Dummy {
+    Dummy();
+
+    void Test();
+  }
+}  // namespace Microsoft.AI.MachineLearning.Experimental

--- a/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
+++ b/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
@@ -7,7 +7,20 @@ import "Windows.AI.MachineLearning.idl";
 
 #include <sdkddkver.h>
 
-namespace Microsoft.AI.MachineLearning.Experimental {
+#ifdef BUILD_INBOX
+#define ROOT_NS Windows
+#define INBOX_ONLY(x) x
+#define OTB_ONLY(x)
+#else
+#define INBOX_ONLY(x)
+#define OTB_ONLY(x) x
+#endif
+
+#ifndef ROOT_NS
+#define ROOT_NS Microsoft
+#endif
+
+namespace ROOT_NS.AI.MachineLearning.Experimental {
 
   [threading(both)]
   [marshaling_behavior(agile)]

--- a/winml/dll/module.cpp
+++ b/winml/dll/module.cpp
@@ -89,7 +89,7 @@ STDAPI DllCanUnloadNow() {
   return S_FALSE;
 }
 
-int32_t WINRT_CALL DllGetExperimentalActivationFactory(void* classId, void** factory) noexcept {
+STDAPI DllGetExperimentalActivationFactory(void* classId, void** factory) noexcept {
   try {
     *factory = nullptr;
     uint32_t length{};

--- a/winml/dll/module.cpp
+++ b/winml/dll/module.cpp
@@ -7,6 +7,7 @@
 
 #include "LearningModelDevice.h"
 #include "OnnxruntimeProvider.h"
+#include "Dummy.h"
 
 using namespace winmlp;
 
@@ -85,6 +86,35 @@ STDAPI DllCanUnloadNow() {
   return S_FALSE;
 }
 
+int32_t WINRT_CALL WinmlMoreGetActivationFactory(void* classId, void** factory) noexcept {
+  try {
+    *factory = nullptr;
+    uint32_t length{};
+    wchar_t const* const buffer = WINRT_WindowsGetStringRawBuffer(classId, &length);
+    std::wstring_view const name{buffer, length};
+
+    auto requal = [](std::wstring_view const& left, std::wstring_view const& right) noexcept {
+      return std::equal(left.rbegin(), left.rend(), right.rbegin(), right.rend());
+    };
+
+    if (requal(name, L"Microsoft.AI.MachineLearning.Experimental.Dummy")) {
+      *factory = winrt::detach_abi(winrt::make<winrt::Microsoft::AI::MachineLearning::Experimental::factory_implementation::Dummy>());
+      return 0;
+    }
+
+#ifdef _WRL_MODULE_H_
+    return ::Microsoft::WRL::Module<::Microsoft::WRL::InProc>::GetModule().GetActivationFactory(static_cast<HSTRING>(classId), reinterpret_cast<::IActivationFactory**>(factory));
+#else
+    return winrt::hresult_class_not_available(name).to_abi();
+#endif
+  } catch (...) {
+    return winrt::to_hresult();
+  }
+}
+
 STDAPI DllGetActivationFactory(HSTRING classId, void** factory) {
-  return WINRT_GetActivationFactory(classId, factory);
+  auto ret = WINRT_GetActivationFactory(classId, factory);
+  if (ret != 0)
+    return WinmlMoreGetActivationFactory(classId, factory);
+  return 0;
 }

--- a/winml/lib/Api.Experimental/Dummy.cpp
+++ b/winml/lib/Api.Experimental/Dummy.cpp
@@ -1,10 +1,12 @@
 ﻿#include "pch.h"
 #include "Dummy.h"
 
-namespace winrt::Microsoft::AI::MachineLearning::Experimental::implementation
+namespace WINML_EXPERIMENTALP {
+
+void Dummy::Test()
 {
-    void Dummy::Test()
-    {
-        throw hresult_not_implemented();
-    }
+    throw hresult_not_implemented();
 }
+
+}  // namespace WINML_EXPERIMENTALP
+

--- a/winml/lib/Api.Experimental/Dummy.cpp
+++ b/winml/lib/Api.Experimental/Dummy.cpp
@@ -1,0 +1,10 @@
+﻿#include "pch.h"
+#include "Dummy.h"
+
+namespace winrt::Microsoft::AI::MachineLearning::Experimental::implementation
+{
+    void Dummy::Test()
+    {
+        throw hresult_not_implemented();
+    }
+}

--- a/winml/lib/Api.Experimental/Dummy.h
+++ b/winml/lib/Api.Experimental/Dummy.h
@@ -2,19 +2,21 @@
 
 #include "Dummy.g.h"
 
-namespace winrt::Microsoft::AI::MachineLearning::Experimental::implementation
-{
-    struct Dummy : DummyT<Dummy>
-    {
-        Dummy() = default;
+namespace WINML_EXPERIMENTALP {
 
-        void Test();
-    };
+struct Dummy : DummyT<Dummy>
+{
+    Dummy() = default;
+
+    void Test();
+};
+
 }
 
-namespace winrt::Microsoft::AI::MachineLearning::Experimental::factory_implementation
+namespace WINML_EXPERIMENTAL::factory_implementation {
+
+struct Dummy : DummyT<Dummy, implementation::Dummy>
 {
-    struct Dummy : DummyT<Dummy, implementation::Dummy>
-    {
-    };
+};
+
 }

--- a/winml/lib/Api.Experimental/Dummy.h
+++ b/winml/lib/Api.Experimental/Dummy.h
@@ -1,0 +1,20 @@
+﻿#pragma once
+
+#include "Dummy.g.h"
+
+namespace winrt::Microsoft::AI::MachineLearning::Experimental::implementation
+{
+    struct Dummy : DummyT<Dummy>
+    {
+        Dummy() = default;
+
+        void Test();
+    };
+}
+
+namespace winrt::Microsoft::AI::MachineLearning::Experimental::factory_implementation
+{
+    struct Dummy : DummyT<Dummy, implementation::Dummy>
+    {
+    };
+}

--- a/winml/lib/Api.Experimental/pch/pch.h
+++ b/winml/lib/Api.Experimental/pch/pch.h
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#pragma warning(push)
+#pragma warning(disable : 26495)
+#pragma warning(disable : 6011)
+
+#pragma warning(disable : 26451)
+#pragma warning(disable : 6387)
+
+#include "cppwinrt_onnx.h"
+#include "dx.h"
+
+#pragma warning(pop)

--- a/winml/lib/Common/inc/NamespaceAliases.h
+++ b/winml/lib/Common/inc/NamespaceAliases.h
@@ -35,6 +35,14 @@ namespace winml = WINML;
 namespace WINMLP {}
 namespace winmlp = WINMLP;
 
+#define WINML_EXPERIMENTAL winrt::WINML_ROOT_NS::AI::MachineLearning::Experimental
+namespace WINML_EXPERIMENTAL {}
+namespace winml_experimental = WINML_EXPERIMENTAL;
+
+#define WINML_EXPERIMENTALP winrt::WINML_ROOT_NS::AI::MachineLearning::Experimental::implementation
+namespace WINML_EXPERIMENTALP {}
+namespace winml_experimentalp = WINML_EXPERIMENTALP;
+
 namespace _winml::Adapter {}
 namespace winmla = ::_winml::Adapter;
 

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -9,8 +9,6 @@
 #include "protobufHelpers.h"
 #include "winrt/Windows.Storage.h"
 
-#include "winrt/Microsoft.AI.MachineLearning.Experimental.h"
-
 #include <D3d11_4.h>
 #include <dxgi1_6.h>
 #include "Psapi.h"
@@ -23,8 +21,6 @@ using wf::IPropertyValue;
 
 static void LearningModelSessionAPITestsClassSetup() {
   init_apartment();
-
-  winml::Experimental::Dummy dummy_api();
 }
 
 static void CreateSessionDeviceDefault()

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -9,6 +9,8 @@
 #include "protobufHelpers.h"
 #include "winrt/Windows.Storage.h"
 
+#include "winrt/Microsoft.AI.MachineLearning.Experimental.h"
+
 #include <D3d11_4.h>
 #include <dxgi1_6.h>
 #include "Psapi.h"
@@ -21,6 +23,8 @@ using wf::IPropertyValue;
 
 static void LearningModelSessionAPITestsClassSetup() {
   init_apartment();
+
+  winml::Experimental::Dummy dummy_api();
 }
 
 static void CreateSessionDeviceDefault()


### PR DESCRIPTION
Issue: There is no place to stage new WinRT APIs for consumption by redist callers.

Fix: Create a WinRT Experimental namespace where new features can be flighted and tested prior to addition to the official api.