### PR TITLE
Add Mixed precision/LossScaler + several fixes

### DIFF
--- a/orttraining/orttraining/python/training/_utils.py
+++ b/orttraining/orttraining/python/training/_utils.py
@@ -4,11 +4,10 @@ import os
 import sys
 import torch
 
-LEARNING_RATE_IO_DESCRIPTION_NAME = "__learning_rate"
-IS_FINITE_IO_DESCRIPTION_NAME = "__is_finite"
-LOSS_SCALE_INPUT_IO_DESCRIPTION_NAME = "__loss_scale_input_name"
 
 def get_device_index(device):
+    '''Returns device index from a device'''
+
     if type(device) == str:
         # Could be 'cuda:0', 'cuda:1', or 'cpu'. with cpu, set index=0
         device = torch.device(device)
@@ -16,6 +15,8 @@ def get_device_index(device):
 
 
 def get_device_index_from_input(input):
+    '''Returns device index from a input PyTorch Tensor'''
+
     if isinstance(input, (list, tuple)):
         device_index = get_device_index(input[0].device)
     else:
@@ -24,9 +25,20 @@ def get_device_index_from_input(input):
 
 
 def get_all_gradients_finite_name_from_session(session):
+    '''Find all_gradients_finite node on Session graph and return its name'''
+
     nodes = [x for x in session._outputs_meta if 'all_gradients_finite' in x.name]
     if len(nodes) != 1:
         raise RuntimeError("'all_gradients_finite' node not found within training session")
+    return nodes[0].name
+
+
+def get_gradient_accumulation_name_from_session(session):
+    '''Find Group_Accumulated_Gradients node on Session graph and return its name'''
+
+    nodes = [x for x in session._outputs_meta if 'Group_Accumulated_Gradients' in x.name]
+    if len(nodes) != 1:
+        raise RuntimeError("'Group_Accumulated_Gradients' node not found within training session")
     return nodes[0].name
 
 
@@ -150,6 +162,8 @@ def static_vars(**kwargs):
 
 
 def import_module_from_file(file_path, module_name):
+    '''Import a Python module from a file into interpreter'''
+
     assert isinstance(file_path, str) and os.path.exists(file_path),\
         "'file_path' must be a full path string with the python file to load"
     assert isinstance(module_name, str) and module_name,\

--- a/orttraining/orttraining/python/training/_utils.py
+++ b/orttraining/orttraining/python/training/_utils.py
@@ -4,6 +4,9 @@ import os
 import sys
 import torch
 
+LEARNING_RATE_IO_DESCRIPTION_NAME = "__learning_rate"
+IS_FINITE_IO_DESCRIPTION_NAME = "__is_finite"
+LOSS_SCALE_INPUT_IO_DESCRIPTION_NAME = "__loss_scale_input_name"
 
 def get_device_index(device):
     if type(device) == str:
@@ -18,6 +21,13 @@ def get_device_index_from_input(input):
     else:
         device_index = get_device_index(input.device)
     return device_index
+
+
+def get_all_gradients_finite_name_from_session(session):
+    nodes = [x for x in session._outputs_meta if 'all_gradients_finite' in x.name]
+    if len(nodes) != 1:
+        raise RuntimeError("'all_gradients_finite' node not found within training session")
+    return nodes[0].name
 
 
 def dtype_torch_to_numpy(torch_dtype):

--- a/orttraining/orttraining/python/training/amp/__init__.py
+++ b/orttraining/orttraining/python/training/amp/__init__.py
@@ -1,1 +1,1 @@
-from . import loss_scaler
+from .loss_scaler import LossScaler, DynamicLossScaler

--- a/orttraining/orttraining/python/training/amp/loss_scaler.py
+++ b/orttraining/orttraining/python/training/amp/loss_scaler.py
@@ -18,7 +18,7 @@ class LossScaler(object):
     @input_name.setter
     def input_name(self, input_name):
         assert isinstance(input_name, str), "'input_name' must be a string"
-        assert not input_name, "'input_name' cannot be empty"
+        assert input_name is None or len(input_name) > 0, "'input_name' cannot be empty"
         self._input_name = input_name
 
     @property

--- a/orttraining/orttraining/python/training/amp/loss_scaler.py
+++ b/orttraining/orttraining/python/training/amp/loss_scaler.py
@@ -7,8 +7,9 @@ class LossScaler(object):
         This class should never be instantiated, but used as an abstract class for custom loss scaling strategy.
     """
 
-    def __init__(self):
+    def __init__(self, loss_scale):
         self._input_name = None
+        self._loss_scale = loss_scale
 
     @property
     def input_name(self):
@@ -16,9 +17,18 @@ class LossScaler(object):
 
     @input_name.setter
     def input_name(self, input_name):
-        assert isinstance(input_name, str), "'input_name must be a string"
-        assert not input_name, "'input_name cannot be empty"
+        assert isinstance(input_name, str), "'input_name' must be a string"
+        assert not input_name, "'input_name' cannot be empty"
         self._input_name = input_name
+
+    @property
+    def loss_scale(self):
+        return self._loss_scale
+
+    @loss_scale.setter
+    def loss_scale(self, loss_scale):
+        assert isinstance(loss_scale, float) and loss_scale > 0, "'loss_scale' must be a positive float"
+        self._loss_scale = loss_scale
 
     def reset(self):
         r"""Resets loss scaler internal state"""
@@ -78,9 +88,8 @@ class DynamicLossScaler(LossScaler):
                  up_scale_window=2000,
                  min_loss_scale=1.0,
                  max_loss_scale=float(1 << 24)):
-        super().__init__()
+        super().__init__(loss_scale)
         self.automatic_update = automatic_update
-        self.loss_scale = loss_scale
         self.up_scale_window = up_scale_window
         self.min_loss_scale = min_loss_scale
         self.max_loss_scale = max_loss_scale

--- a/orttraining/orttraining/python/training/amp/loss_scaler.py
+++ b/orttraining/orttraining/python/training/amp/loss_scaler.py
@@ -8,7 +8,17 @@ class LossScaler(object):
     """
 
     def __init__(self):
-        pass
+        self._input_name = None
+
+    @property
+    def input_name(self):
+        return self._input_name
+
+    @input_name.setter
+    def input_name(self, input_name):
+        assert isinstance(input_name, str), "'input_name must be a string"
+        assert not input_name, "'input_name cannot be empty"
+        self._input_name = input_name
 
     def reset(self):
         r"""Resets loss scaler internal state"""
@@ -19,6 +29,9 @@ class LossScaler(object):
 
         Args:
             train_step_info (TrainStepInfo): last step state information
+
+        Returns:
+            Updated loss scale (float)
         """
         raise NotImplementedError
 
@@ -89,3 +102,4 @@ class DynamicLossScaler(LossScaler):
         else:
             self.loss_scale = max(self.min_loss_scale, self.loss_scale / 2)
             self._stable_steps_count = 0
+        return self.loss_scale

--- a/orttraining/orttraining/python/training/debug.py
+++ b/orttraining/orttraining/python/training/debug.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import os
 import sys
@@ -8,44 +7,78 @@ from numpy.testing import assert_allclose
 from onnxruntime.capi.training import orttrainer
 from onnxruntime.capi.ort_trainer import ORTTrainer as Legacy_ORTTrainer
 
-def compare_onnx_weights(model_a, model_b, verbose=False, rtol=1e-4):
-    r"""Compare whether weights between 'model_a' and 'model_b' ONNX models are within
-    a certain tolerance 'rtol'
 
-    Compares the weights of two different ONNX models and throws an error when they diverge
+def assert_model_outputs(output_a, output_b, verbose=False, rtol=1e-7, atol=0):
+    r"""Asserts whether output_a and output_b difference is within specified tolerance
+
+    Args:
+        output_a, output_b (list): Two list with of numeric values
+        verbose (bool, default is False): if True, prints absolute difference for each weight
+        rtol (float, default is 1e-7): Max relative difference
+        atol (float, default is 1e-4): Max absolute difference
+    """
+    assert isinstance(output_a, list) and isinstance(output_b, list),\
+        "output_a and output_b must be a list of numbers"
+    assert len(output_a) == len(output_b), "output_a and output_b must have the same length"
+
+    # for idx in range(len(output_a)):
+    assert_allclose(output_a, output_b, rtol=rtol, atol=atol, err_msg=f"Output mismatch at position")
+
+def assert_onnx_weights(model_a, model_b, verbose=False, rtol=1e-7, atol=0):
+    r"""Asserts whether weight difference between models a and b differences are within specified tolerance
+
+    Compares the weights of two different ONNX models (model_a and model_b)
+    and raises AssertError when they diverge by more than atol or rtol
+
     Args:
         model_a, model_b (ORTTrainer): Two instances of ORTTrainer with the same model structure
-        verbose (bool, default is False): Indicates if the max absolute difference for each layer should be
-    calculated and printed for debug information.
-        rtol (float, default is 1e-4): Tolerance for divergence.
+        verbose (bool, default is False): if True, prints absolute difference for each weight
+        rtol (float, default is 1e-7): Max relative difference
+        atol (float, default is 1e-4): Max absolute difference
     """
     assert isinstance(model_a, orttrainer.ORTTrainer) and isinstance(model_b, orttrainer.ORTTrainer)
     state_dict_a, state_dict_b = model_a._training_session.get_state(), model_b._training_session.get_state()
     assert len(state_dict_a.items()) == len(state_dict_b.items())
-    _compare_state_dict_weights(state_dict_a, state_dict_b, verbose, rtol)
+    _assert_state_dict_weights(state_dict_a, state_dict_b, verbose, rtol, atol)
 
 
-def compare_legacy_onnx_weights(model_a, model_b, verbose=False, rtol=1e-4):
-    r"""Compare whether weights between 'model_a' (legacy API ONNX model) and 'model_b' (new API ONNX model)
-    are within a certain tolerance 'rtol'
+def assert_legacy_onnx_weights(model_a, model_b, verbose=False, rtol=1e-7, atol=0):
+    r"""Asserts whether weight difference between models a and b differences are within specified tolerance
 
-    Compares the weights of two different ONNX models and throws an error when they diverge
+    Compares the weights of a legacy model model_a and experimental model_b model
+    and raises AssertError when they diverge by more than atol or rtol.
+
     Args:
-        model_a, model_b (ORTTrainer): Two instances of ORTTrainer with the same model structure
-        verbose (bool, default is False): Indicates if the max absolute difference for each layer should be
-    calculated and printed for debug information.
-        rtol (float, default is 1e-4): Tolerance for divergence.
+        model_a (ORTTrainer): Instance of legacy ORTTrainer
+        model_b (ORTTrainer): Instance of experimental ORTTrainer
+        verbose (bool, default is False): if True, prints absolute difference for each weight.
+        rtol (float, default is 1e-7): Max relative difference
+        atol (float, default is 1e-4): Max absolute difference
     """
     assert isinstance(model_a, orttrainer.ORTTrainer) and isinstance(model_b, Legacy_ORTTrainer)
     state_dict_a, state_dict_b = model_a._training_session.get_state(), model_b.session.get_state()
     assert len(state_dict_a.items()) == len(state_dict_b.items())
-    _compare_state_dict_weights(state_dict_a, state_dict_b, verbose, rtol)
+    _assert_state_dict_weights(state_dict_a, state_dict_b, verbose, rtol, atol)
 
-def _compare_state_dict_weights(state_dict_a, state_dict_b, verbose=False, rtol=1e-4):
+
+def _assert_state_dict_weights(state_dict_a, state_dict_b, verbose, rtol, atol):
+    r"""Asserts whether dicts a and b value differences are within specified tolerance
+
+    Compares the weights of two model's state_dict dicts and raises AssertError
+    when they diverge by more than atol or rtol
+
+    Args:
+        model_a (ORTTrainer): Instance of legacy ORTTrainer
+        model_b (ORTTrainer): Instance of experimental ORTTrainer
+        verbose (bool, default is False): if True, prints absolute difference for each weight.
+        rtol (float, default is 1e-7): Max relative difference
+        atol (float, default is 1e-4): Max absolute difference
+    """
+
     for (a_name, a_val), (b_name, b_val) in zip(state_dict_a.items(), state_dict_b.items()):
         np_a_vals = np.array(a_val).flatten()
         np_b_vals = np.array(b_val).flatten()
         assert np_a_vals.shape == np_b_vals.shape
         if verbose:
             print(f'Weight name: {a_name}: absolute difference: {np.abs(np_a_vals-np_b_vals).max()}')
-        assert_allclose(a_val, b_val, rtol=rtol, err_msg=f"Weight mismatch for {a_name}")
+        assert_allclose(a_val, b_val, rtol=rtol, atol=atol, err_msg=f"Weight mismatch for {a_name}")

--- a/orttraining/orttraining/python/training/model_desc_validation.py
+++ b/orttraining/orttraining/python/training/model_desc_validation.py
@@ -1,9 +1,12 @@
 import cerberus
 from collections import namedtuple
 import torch
-from ._utils import static_vars, LEARNING_RATE_IO_DESCRIPTION_NAME,\
-    IS_FINITE_IO_DESCRIPTION_NAME,\
-    LOSS_SCALE_INPUT_IO_DESCRIPTION_NAME
+from ._utils import static_vars
+
+
+LEARNING_RATE_IO_DESCRIPTION_NAME = "__learning_rate"
+IS_FINITE_IO_DESCRIPTION_NAME = "__is_finite"
+LOSS_SCALE_INPUT_IO_DESCRIPTION_NAME = "__loss_scale_input_name"
 
 
 class _ORTTrainerModelDesc(object):

--- a/orttraining/orttraining/python/training/model_desc_validation.py
+++ b/orttraining/orttraining/python/training/model_desc_validation.py
@@ -1,7 +1,9 @@
 import cerberus
 from collections import namedtuple
 import torch
-from ._utils import static_vars
+from ._utils import static_vars, LEARNING_RATE_IO_DESCRIPTION_NAME,\
+    IS_FINITE_IO_DESCRIPTION_NAME,\
+    LOSS_SCALE_INPUT_IO_DESCRIPTION_NAME
 
 
 class _ORTTrainerModelDesc(object):
@@ -33,38 +35,206 @@ class _ORTTrainerModelDesc(object):
 
         # Normalize outputs to a list of namedtuple(name, shape, is_loss)
         self._OutputDescription = namedtuple('OutputDescription', ['name', 'shape', 'is_loss'])
-        self._OutputDescriptionTyped = namedtuple('OutputDescriptionTyped', ['name', 'shape', 'is_loss', 'dtype'])
+        self._OutputDescriptionTyped = namedtuple('OutputDescriptionTyped',
+                                                  ['name', 'shape', 'is_loss', 'dtype', 'dtype_amp'],
+                                                  defaults=[None])
         for idx, output in enumerate(self._validated['outputs']):
+            # import pdb; pdb.set_trace()
             if len(output) == 2:
                 self._validated['outputs'][idx] = self._OutputDescription(*output, False)
             else:
                 self._validated['outputs'][idx] = self._OutputDescription(*output)
 
-        # Hard-code learning rate descriptor for the model
-        self._validated['learning_rate'] = self._InputDescriptionTyped('Learning_Rate', [1], torch.float32)
+        # Hard-code learning rate, is_finite descriptors
+        self.learning_rate = self._InputDescriptionTyped(LEARNING_RATE_IO_DESCRIPTION_NAME, [1], torch.float32)
 
         # Convert dict in object
         for k, v in self._validated.items():
             setattr(self, k, self._wrap(v))
 
-        # Keep this in the last line
-        # After this point, this class becomes immutable
-        # NOTE: The embedded lists are still muttable
-        self._initialized = True
-
     def __repr__(self):
-        return '{%s}' % str(', '.join("'%s': %s" % (k, repr(v))
-                                      for (k, v) in self.__dict__.items()
-                                      if k not in ['_main_class_name', '_original', '_validated',
-                                                   '_InputDescription', '_InputDescriptionTyped',
-                                                   '_OutputDescription', '_OutputDescriptionTyped']))
+        '''Pretty representation for a model description class'''
 
-    def __setattr__(self, k, v):
-        if hasattr(self, '_initialized'):
-            raise Exception(f"{self._main_class_name} is an immutable class")
-        return super().__setattr__(k, v)
+        pretty_msg = 'Model description:\n'
+
+        # Inputs
+        inputs = []
+        for i_desc in self.inputs:
+            if isinstance(i_desc, self._InputDescription):
+                inputs.append(f'(name={i_desc.name}, shape={i_desc.shape})')
+            elif isinstance(i_desc, self._InputDescriptionTyped):
+                inputs.append(f'(name={i_desc.name}, shape={i_desc.shape}, dtype={i_desc.dtype})')
+            else:
+                raise ValueError(f'Unexpected type {type(i_desc)} for input description')
+
+        pretty_msg += '\nInputs:'
+        for idx, item in enumerate(inputs):
+            pretty_msg += f'\n\t{idx}: {item}'
+
+        # Outputs
+        outputs = []
+        for o_desc in self.outputs:
+            if isinstance(o_desc, self._OutputDescription):
+                outputs.append(f'(name={o_desc.name}, shape={o_desc.shape})')
+            elif isinstance(o_desc, self._OutputDescriptionTyped):
+                outputs.append(f'(name={o_desc.name}, shape={o_desc.shape}, dtype={o_desc.dtype}, dtype_amp={o_desc.dtype_amp})')
+            else:
+                raise ValueError(f'Unexpected type {type(o_desc)} for output description')
+        pretty_msg += '\nOutputs:'
+        for idx, item in enumerate(outputs):
+            pretty_msg += f'\n\t{idx}: {item}'
+
+        # Learning rate
+        if self.learning_rate:
+            pretty_msg += '\nLearning rate: '
+            pretty_msg += f'(name={self.learning_rate.name}, shape={self.learning_rate.shape}, dtype={self.learning_rate.dtype})'
+
+        # Mixed precision
+        if getattr(self, IS_FINITE_IO_DESCRIPTION_NAME, None) or getattr(self, LOSS_SCALE_INPUT_IO_DESCRIPTION_NAME, None):
+            pretty_msg += '\nMixed Precision:'
+            if getattr(self, IS_FINITE_IO_DESCRIPTION_NAME, None):
+                pretty_msg += '\n\tis gradients finite: '
+                pretty_msg += f'(name={self.is_finite.name}, shape={self.is_finite.shape}, dtype={self.is_finite.dtype})'
+            if getattr(self, LOSS_SCALE_INPUT_IO_DESCRIPTION_NAME, None):
+                pretty_msg += '\n\tloss scale input name: '
+                pretty_msg += f'(name={self.loss_scale_input.name}, shape={self.loss_scale_input.shape}, dtype={self.loss_scale_input.dtype})'
+
+        return pretty_msg
+
+    def add_type_to_input_description(self, index, dtype):
+        '''Updates an existing input description at position 'index' with 'dtype' type information
+
+        Args:
+            index (int): position within 'inputs' description
+            dtype (torch.dtype): input data type
+        '''
+
+        assert isinstance(index, int) and index >= 0,\
+            "input 'index' must be a positive int"
+        assert isinstance(dtype, torch.dtype),\
+            "input 'dtype' must be a torch.dtype type"
+        existing_values = (*self.inputs[index],)
+        if isinstance(self.inputs[index], self._InputDescriptionTyped):
+            existing_values = (*existing_values[:-1],)
+        self.inputs[index] = self._InputDescriptionTyped(*existing_values, dtype)
+
+    def add_type_to_output_description(self, index, dtype, dtype_amp=None):
+        '''Updates an existing output description at position 'index' with 'dtype' type information
+
+        Args:
+            index (int): position within 'inputs' description
+            dtype (torch.dtype): input data type
+            dtype_amp (torch.dtype, default is None): input data type for evaluation with mixed precision
+        '''
+
+        assert isinstance(index, int) and index >= 0,\
+            "output 'index' must be a positive int"
+        assert isinstance(dtype, torch.dtype),\
+            "output 'dtype' must be a torch.dtype type"
+        assert dtype_amp is None or isinstance(dtype_amp, torch.dtype),\
+            "output 'dtype_amp' must be either None or torch.dtype type"
+        existing_values = (*self.outputs[index],)
+        if isinstance(self.outputs[index], self._OutputDescriptionTyped):
+            existing_values = (*existing_values[:-2],)
+        self.outputs[index] = self._OutputDescriptionTyped(*existing_values, dtype, dtype_amp)
+
+
+    @property
+    def is_finite(self):
+        return getattr(self, IS_FINITE_IO_DESCRIPTION_NAME, None)
+
+    @is_finite.setter
+    def is_finite(self, name):
+        self._add_output_description(self, name, [1], False, torch.bool, None, IS_FINITE_IO_DESCRIPTION_NAME)
+
+    @property
+    def loss_scale_input(self):
+        return getattr(self, LOSS_SCALE_INPUT_IO_DESCRIPTION_NAME, None)
+
+    @loss_scale_input.setter
+    def loss_scale_input(self, name):
+        self._add_input_description(self, name, [], torch.float32, LOSS_SCALE_INPUT_IO_DESCRIPTION_NAME)
+
+    def _add_input_description(self, node, name, shape, dtype=None, attr_name=None):
+        '''Add a new input description into the node object
+
+        If 'dtype' is specified, a typed input description namedtuple(name, shape, dtype) is created.
+        Otherwise an untyped input description namedtuple(name, shape) is created instead.
+
+        Args:
+            node (list or object): node to append input description to. When 'node' is 'self.inputs',
+                a new input description is appended to the list.
+                Otherwise, a new input description is created as an attribute into 'node' with name 'attr_name'
+            name (str): name of input description
+            shape (list): shape of input description
+            dtype (torch.dtype): input data type
+            attr_name (str, default is None): friendly name to allow direct access to the output description
+        '''
+
+        assert isinstance(name, str) and len(name) > 0, "'name' is an invalid input name"
+        assert isinstance(shape, list) and all([(isinstance(dim, int) or (isinstance(dim, str) and len(dim) > 0))\
+            for dim in shape]), "'shape' must be a list of int or str with length at least 1"
+        if id(node) == id(self.inputs):
+            assert all([name not in i_desc.name for i_desc in node]), f"'name' {name} already exists in the inputs description"
+        else:
+            assert attr_name not in dir(self), f"'attr_name' {attr_name} already exists in the 'node'"
+        assert dtype is None or isinstance(dtype, torch.dtype), "'dtype' must be either None or a torch.dtype type"
+        if dtype:
+            new_input_desc = self._InputDescriptionTyped(name, shape, dtype)
+        else:
+            new_input_desc = self._InputDescription(name, shape)
+
+        if id(node) == id(self.inputs):
+            self.inputs.append(new_input_desc)
+        else:
+            assert isinstance(attr_name, str) and len(attr_name) > 0, "Invalid 'attr_name'"
+            setattr(node, attr_name, new_input_desc)
+
+    def _add_output_description(self, node, name, shape, is_loss, dtype=None, dtype_amp=None, attr_name=None):
+        '''Add a new output description into the node object as a tuple
+
+        When (name, shape, is_loss, dtype) is specified, a typed output description is created
+        Otherwise an untyped output description (name, shape, is_loss) is created instead
+
+        Args:
+            node (list or object): node to append output description to. When 'node' is 'self.outputs',
+                a new output description is appended to the list.
+                Otherwise, a new output description is created as an attribute into 'node' with name 'attr_name'
+            name (str): name of output description
+            shape (list): shape of output description
+            is_loss (bool): specifies whether this output is a loss
+            dtype (torch.dtype): input data type
+            dtype_amp (torch.dtype, default is None): input data type for evaluation with mixed precision.
+            attr_name (str, default is None): friendly name to allow direct access to the output description
+        '''
+
+        assert isinstance(name, str) and len(name) > 0, "'name' is an invalid output name"
+        assert isinstance(shape, list) and all([(isinstance(dim, int) or (isinstance(dim, str) and len(dim) > 0))\
+            for dim in shape]), "'shape' must be a list of int or str with length at least 1"
+        assert isinstance(is_loss, bool), "'is_loss' must be a bool"
+
+        if id(node) == id(self.outputs):
+            assert all([name not in o_desc.name for o_desc in node]), f"'name' {name} already exists in the outputs description"
+            is_loss_count = 1 if is_loss else 0
+            assert all([o_desc.is_loss is False for o_desc in node]) if is_loss else True,\
+                "Only one 'is_loss' is supported at outputs description"
+        else:
+            assert attr_name not in dir(self), f"'attr_name' {attr_name} already exists in the 'node'"
+
+        assert dtype is None or isinstance(dtype, torch.dtype), "'dtype' must be either None or a torch.dtype type"
+        if dtype:
+            new_output_desc = self._OutputDescriptionTyped(name, shape, is_loss, dtype)
+        else:
+            new_output_desc = self._OutputDescription(name, shape, is_loss)
+
+        if id(node) == id(self.outputs):
+            self.outputs.append(new_output_desc)
+        else:
+            assert isinstance(attr_name, str) and len(attr_name) > 0, "Invalid 'attr_name'"
+            setattr(node, attr_name, new_output_desc)
 
     def _wrap(self, v):
+        '''Add 'v' as self's attribute to allow direct access as self.v'''
         if isinstance(v, (list)):
             return type(v)([self._wrap(v) for v in v])
         elif isinstance(v, (self._InputDescription, self._InputDescriptionTyped,
@@ -75,22 +245,8 @@ class _ORTTrainerModelDesc(object):
         elif isinstance(v, (dict, int, float, bool, str)):
             return _ORTTrainerModelDescInternal(self._main_class_name, v) if isinstance(v, dict) else v
         else:
-            raise ValueError("Unsupported type for model_desc."
+            raise ValueError(f"Unsupported type for model_desc ({v})."
                              "Only int, float, bool, str, list, tuple and dict are supported")
-
-    def add_type_to_input_description(self, index, dtype):
-        assert isinstance(index, int) and index >= 0,\
-            "input 'index' must be a positive int"
-        assert isinstance(dtype, torch.dtype),\
-            "input 'dtype' must be a torch.dtype type"
-        self.inputs[index] = self._InputDescriptionTyped(*self.inputs[index], dtype)
-
-    def add_type_to_output_description(self, index, dtype):
-        assert isinstance(index, int) and index >= 0,\
-            "output 'index' must be a positive int"
-        assert isinstance(dtype, torch.dtype),\
-            "output 'dtype' must be a torch.dtype type"
-        self.outputs[index] = self._OutputDescriptionTyped(*self.outputs[index], dtype)
 
 
 class _ORTTrainerModelDescInternal(_ORTTrainerModelDesc):
@@ -106,11 +262,6 @@ class _ORTTrainerModelDescInternal(_ORTTrainerModelDesc):
         # Convert dict in object
         for k, v in dict(model_desc).items():
             setattr(self, k, self._wrap(v))
-
-        # Keep this in the last line
-        # After this point, this class becomes immutable
-        # NOTE: The embedded lists are still muttable
-        self._initialized = True
 
 
 def _model_desc_inputs_validation(field, value, error):

--- a/orttraining/orttraining/python/training/optim/lr_scheduler.py
+++ b/orttraining/orttraining/python/training/optim/lr_scheduler.py
@@ -92,8 +92,8 @@ class ConstantWarmupLRScheduler(_LRScheduler):
         self.warmup = warmup
 
     def _warmup_constant(self, train_step_info):
-        # Adds 1 to train_step_info.step and self.total_steps to prevent zero'ing lr
-        x = (train_step_info.step + 1) / (self.total_steps + 1)
+        # Adds 1 to train_step_info.optimization_step and self.total_steps to prevent zero'ing lr
+        x = (train_step_info.optimization_step + 1) / (self.total_steps + 1)
         if x < self.warmup:
             return x/self.warmup
         return 1.0
@@ -144,8 +144,8 @@ class CosineWarmupLRScheduler(_LRScheduler):
         self.warmup = warmup
 
     def _warmup_cosine(self, train_step_info):
-        # Adds 1 to train_step_info.step and self.total_steps to prevent zero'ing lr
-        x = (train_step_info.step + 1) / (self.total_steps + 1)
+        # Adds 1 to train_step_info.optimization_step and self.total_steps to prevent zero'ing lr
+        x = (train_step_info.optimization_step + 1) / (self.total_steps + 1)
         if x < self.warmup:
             return x/self.warmup
         return 0.5 * (1.0 + math.cos(math.pi * x))
@@ -195,8 +195,8 @@ class LinearWarmupLRScheduler(_LRScheduler):
         self.warmup = warmup
 
     def _warmup_linear(self, train_step_info):
-        # Adds 1 to train_step_info.step and self.total_steps to prevent zero'ing lr
-        x = (train_step_info.step + 1) / (self.total_steps + 1)
+        # Adds 1 to train_step_info.optimization_step and self.total_steps to prevent zero'ing lr
+        x = (train_step_info.optimization_step + 1) / (self.total_steps + 1)
         if x < self.warmup:
             return x / self.warmup
         return max((x - 1.) / (self.warmup - 1.), 0.)
@@ -250,8 +250,8 @@ class PolyWarmupLRScheduler(_LRScheduler):
         self.degree = degree
 
     def _warmup_poly(self, train_step_info):
-        # Adds 1 to train_step_info.step and self.total_steps to prevent zero'ing lr
-        x = (train_step_info.step + 1) / (self.total_steps + 1)
+        # Adds 1 to train_step_info.optimization_step and self.total_steps to prevent zero'ing lr
+        x = (train_step_info.optimization_step + 1) / (self.total_steps + 1)
         if x < self.warmup:
             return x/self.warmup
         return (1.0 - x)**self.degree

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -262,7 +262,7 @@ class ORTTrainerOptions(object):
     def __repr__(self):
         return '{%s}' % str(', '.join("'%s': %s" % (k, repr(v))
                                       for (k, v) in self.__dict__.items()
-                                      if k not in ['_original_opts', '_validated_opts', '_initialized']))
+                                      if k not in ['_original_opts', '_validated_opts', '_initialized', '_main_class_name']))
 
     def __setattr__(self, k, v):
         if hasattr(self, '_initialized'):

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -31,8 +31,8 @@ class ORTTrainerOptions(object):
                     'schema' : {
                         'gradient_accumulation_steps' : {
                             'type' : 'integer',
-                            'min' : 0,
-                            'default' : 0
+                            'min' : 1,
+                            'default' : 1
                         }
                     },
                 },
@@ -43,7 +43,7 @@ class ORTTrainerOptions(object):
                     'schema' : {
                         'id' : {
                             'type' : 'string',
-                            'default' : 'cpu'
+                            'default' : 'cuda'
                         },
                         'mem_limit' : {
                             'type' : 'integer',
@@ -120,7 +120,7 @@ class ORTTrainerOptions(object):
                         },
                         'grad_norm_clip' : {
                             'type' : 'boolean',
-                            'default' : False
+                            'default' : True
                         }
                     }
                 },
@@ -162,11 +162,11 @@ class ORTTrainerOptions(object):
     Keyword arguments:
         batch (dict):
             batch related settings
-        batch.gradient_accumulation_steps (int, 0):
+        batch.gradient_accumulation_steps (int, default is 1):
             number of steps to accumulate before do collective gradient reduction
         device (dict):
             compute device related settings
-        device.id (string, default is 'cpu'):
+        device.id (string, default is 'cuda'):
             device to run training
         device.mem_limit (int):
             maximum memory size (in bytes) used by device.id
@@ -200,7 +200,7 @@ class ORTTrainerOptions(object):
             miscellaneous options
         utils.frozen_weights (list of str, []):
             list of model parameter names to skip training (weights don't change)
-        utils.grad_norm_clip (bool, default is False):
+        utils.grad_norm_clip (bool, default is True):
             enables gradient norm clipping for 'AdamOptimizer' and 'LambOptimizer'
         debug (dict):
             debug options
@@ -211,7 +211,7 @@ class ORTTrainerOptions(object):
         _internal_use.enable_internal_postprocess (bool, default is True):
             enable internal internal post processing of the ONNX model
         _internal_use.extra_postprocess (callable, default is None)
-            a functor to postprocess the ONNX model.
+            a functor to postprocess the ONNX model and return a new ONNX model.
             It does not override :py:attr:`._internal_use.enable_internal_postprocess`, but complement it
         _internal_use.onnx_opset_version (int, default is 12):
             ONNX opset version used during model exporting.
@@ -327,8 +327,8 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
         'schema': {
             'gradient_accumulation_steps': {
                 'type': 'integer',
-                'min': 0,
-                'default': 0
+                'min': 1,
+                'default': 1
             }
         },
     },
@@ -339,7 +339,7 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
         'schema': {
             'id': {
                 'type': 'string',
-                'default': 'cpu'
+                'default': 'cuda'
             },
             'mem_limit': {
                 'type': 'integer',
@@ -417,7 +417,7 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
             },
             'grad_norm_clip': {
                 'type': 'boolean',
-                'default': False
+                'default': True
             }
         }
     },

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -255,19 +255,10 @@ class ORTTrainerOptions(object):
         for k, v in self._validated_opts.items():
             setattr(self, k, self._wrap(v))
 
-        # Keep this in the last line
-        # After this point, this class becomes immutable
-        self._initialized = True
-
     def __repr__(self):
         return '{%s}' % str(', '.join("'%s': %s" % (k, repr(v))
                                       for (k, v) in self.__dict__.items()
-                                      if k not in ['_original_opts', '_validated_opts', '_initialized', '_main_class_name']))
-
-    def __setattr__(self, k, v):
-        if hasattr(self, '_initialized'):
-            raise Exception(f"{self._main_class_name} is an immutable class")
-        return super().__setattr__(k, v)
+                                      if k not in ['_original_opts', '_validated_opts', '_main_class_name']))
 
     def _wrap(self, v):
         if isinstance(v, (tuple, list, set, frozenset)):
@@ -289,10 +280,6 @@ class _ORTTrainerOptionsInternal(ORTTrainerOptions):
         # Convert dict in object
         for k, v in dict(options).items():
             setattr(self, k, self._wrap(v))
-
-        # Keep this in the last line
-        # After this point, this class becomes immutable
-        self._initialized = True
 
 
 class ORTTrainerOptionsValidator(cerberus.Validator):

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -90,7 +90,7 @@ def testORTTrainerModelDescValidSchemas(input_dict, input_dtype, output_dtype):
     model_description = md_val._ORTTrainerModelDesc(input_dict)
 
     # Validating hard-coded learning rate description
-    assert model_description.learning_rate.name == "Learning_Rate"
+    assert model_description.learning_rate.name == _utils.LEARNING_RATE_IO_DESCRIPTION_NAME
     assert model_description.learning_rate.shape == [1]
     assert model_description.learning_rate.dtype == torch.float32
 
@@ -108,6 +108,18 @@ def testORTTrainerModelDescValidSchemas(input_dict, input_dtype, output_dtype):
         is_loss = input_dict['outputs'][idx][2] if len(input_dict['outputs'][idx]) == 3 else False
         assert is_loss == o_desc.is_loss
 
+    # Set is_finite name and check its description
+    model_description.is_finite = _utils.IS_FINITE_IO_DESCRIPTION_NAME
+    assert model_description.is_finite.name == _utils.IS_FINITE_IO_DESCRIPTION_NAME
+    assert model_description.is_finite.shape == [1]
+    assert model_description.is_finite.dtype == torch.bool
+
+    # Set loss_scale_input and check its description
+    model_description.loss_scale_input = _utils.LOSS_SCALE_INPUT_IO_DESCRIPTION_NAME
+    assert model_description.loss_scale_input.name == _utils.LOSS_SCALE_INPUT_IO_DESCRIPTION_NAME
+    assert model_description.loss_scale_input.shape == []
+    assert model_description.loss_scale_input.dtype == torch.float32
+
     # Append type to inputs/outputs tuples
     for idx, i_desc in enumerate(model_description.inputs):
         model_description.add_type_to_input_description(idx, input_dtype[idx])
@@ -116,11 +128,9 @@ def testORTTrainerModelDescValidSchemas(input_dict, input_dtype, output_dtype):
 
     # Verify inputs/outputs tuples are replaced by the typed counterparts
     for idx, i_desc in enumerate(model_description.inputs):
-        assert len(i_desc) == 3
         assert isinstance(i_desc, model_description._InputDescriptionTyped)
         assert input_dtype[idx] == i_desc.dtype
     for idx, o_desc in enumerate(model_description.outputs):
-        assert len(o_desc) == 4
         assert isinstance(o_desc, model_description._OutputDescriptionTyped)
         assert output_dtype[idx] == o_desc.dtype
 

--- a/samples/python/pytorch_transformer/ort_utils.py
+++ b/samples/python/pytorch_transformer/ort_utils.py
@@ -7,11 +7,7 @@ def my_loss(x, target):
     return torch.nn.CrossEntropyLoss()(x, target)
 
 
-def transformer_model_description():
-    bptt = 35
-    ntokens = 28785
-    batch_size = 20
-
+def transformer_model_description(bptt=35, batch_size=20, ntokens=28785):
     model_desc = {'inputs':  [('input1', [bptt, batch_size]),
                               ('label', [bptt, batch_size, ntokens],)],
                   'outputs': [('loss', [], True),
@@ -19,11 +15,10 @@ def transformer_model_description():
     return model_desc
 
 
-def legacy_transformer_model_description():
-    input_desc = IODescription('input1', [35, 20], torch.float32)
-    label_desc = IODescription('label', [35, 20, 28785], torch.int64)
+def legacy_transformer_model_description(bptt=35, batch_size=20, ntokens=28785):
+    input_desc = IODescription('input1', [bptt, batch_size], torch.float32)
+    label_desc = IODescription('label', [bptt, batch_size, ntokens], torch.int64)
     loss_desc = IODescription('loss', [], torch.float32)
-    lr = 0.001
-    #return ModelDescription([input_desc, label_desc], [loss_desc]), IODescription('Learning_Rate', [lr,], torch.float32)
-    prediction_desc = IODescription('prediction', [35, 20, 28785], torch.float32)
-    return ModelDescription([input_desc, label_desc], [loss_desc, prediction_desc]), IODescription('Learning_Rate', [lr,], torch.float32)
+    predictions_desc = IODescription('predictions', [bptt, batch_size, ntokens], torch.float32)
+    return ModelDescription([input_desc, label_desc],[loss_desc, predictions_desc]),\
+           IODescription('__learning_rate', [1], torch.float32)


### PR DESCRIPTION
This PR introduces mixed precision tests with loss scaler support

    Add input_name and loss_scale properties on LossScaler public API
    Fix CUDA training
    Add optimization_step into TrainStepInfo class
    Refactor LRSCheduler to use optimization_step instead of step
    Updated several default values at ORTTrainerOptions
    Add initial Gradient Accumulation supported. Untested
    Fix ONNX model post processing
    Refactor unit tests