### PR TITLE
Add dynamic axes support to training

### DIFF
--- a/samples/python/pytorch_transformer/ort_utils.py
+++ b/samples/python/pytorch_transformer/ort_utils.py
@@ -1,5 +1,6 @@
 import torch
-from onnxruntime.capi.ort_trainer import IODescription, ModelDescription
+from onnxruntime.capi.ort_trainer import IODescription as Legacy_IODescription,\
+                                         ModelDescription as Legacy_ModelDescription
 
 
 def my_loss(x, target):
@@ -8,6 +9,7 @@ def my_loss(x, target):
 
 
 def transformer_model_description(bptt=35, batch_size=20, ntokens=28785):
+    # TODO: Update to Dynamic Axis when backend is fixed
     model_desc = {'inputs':  [('input1', [bptt, batch_size]),
                               ('label', [bptt, batch_size, ntokens],)],
                   'outputs': [('loss', [], True),
@@ -16,9 +18,10 @@ def transformer_model_description(bptt=35, batch_size=20, ntokens=28785):
 
 
 def legacy_transformer_model_description(bptt=35, batch_size=20, ntokens=28785):
-    input_desc = IODescription('input1', [bptt, batch_size], torch.float32)
-    label_desc = IODescription('label', [bptt, batch_size, ntokens], torch.int64)
-    loss_desc = IODescription('loss', [], torch.float32)
-    predictions_desc = IODescription('predictions', [bptt, batch_size, ntokens], torch.float32)
-    return ModelDescription([input_desc, label_desc],[loss_desc, predictions_desc]),\
-           IODescription('__learning_rate', [1], torch.float32)
+    # TODO: Update to Dynamic Axis when backend is fixed
+    input_desc = Legacy_IODescription('input1', [bptt, batch_size])
+    label_desc = Legacy_IODescription('label', [bptt, batch_size, ntokens])
+    loss_desc = Legacy_IODescription('loss', [])
+    predictions_desc = Legacy_IODescription('predictions', [bptt, batch_size, ntokens])
+    return Legacy_ModelDescription([input_desc, label_desc],[loss_desc, predictions_desc]),\
+           Legacy_IODescription('__learning_rate', [1])


### PR DESCRIPTION
This PR also includes:

* Refactor current BERT example so that it uses dynamic shape
* Remove **kwargs from train_step/eval_step as data always come from *input only
