### PR TITLE
Open the door to use libtorch inside ORT

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -129,6 +129,8 @@ option(onnxruntime_FUZZ_TEST "Enable Fuzz testing" OFF)
 # own logics to determine this flag and seems resulting race conditions.
 if (onnxruntime_USE_TORCH)
   add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0 -DUSE_TORCH=1)
+  list(APPEND CMAKE_PREFIX_PATH "${onnxruntime_TORCH_HOME}")
+  find_package(Torch REQUIRED PATHS "${onnxruntime_TORCH_HOME}")
 endif()
 
 # Fuzz test has only been tested with BUILD_SHARED_LIB option,

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -120,6 +120,17 @@ option(onnxruntime_RUN_MODELTEST_IN_DEBUG_MODE "Run model tests even in debug mo
 # build configuration for fuzz testing is in onnxruntime_fuzz_test.cmake
 option(onnxruntime_FUZZ_TEST "Enable Fuzz testing" OFF)
 
+# LIBTORCH_HOME can be either a path to libtorch downloaded from Pytorch website,
+# Pytorch python package installed using Anaconda, Pytorch build folder if you built
+# Pytorch from source, and so on.
+# This D_GLIBCXX_USE_CXX11_ABI flag should match what is used when compiling Pytorch/LibTorch and
+# all other ORT dependencies.
+# Do not build using multi-threading when ABI is set. Some packages have their
+# own logics to determine this flag and seems resulting race conditions.
+if (onnxruntime_USE_TORCH)
+  add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0 -DUSE_TORCH=1)
+endif()
+
 # Fuzz test has only been tested with BUILD_SHARED_LIB option,
 # using the MSVC compiler and on windows OS.
 if(MSVC AND WIN32 AND onnxruntime_FUZZ_TEST AND onnxruntime_BUILD_SHARED_LIB AND onnxruntime_USE_FULL_PROTOBUF)
@@ -975,6 +986,7 @@ if (onnxruntime_USE_DML)
   add_definitions(-DUSE_DML=1)
   include(dml)
 endif()
+
 
 if (onnxruntime_ENABLE_TRAINING)
   add_compile_definitions(ENABLE_TRAINING)

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -229,10 +229,7 @@ if (onnxruntime_USE_CUDA)
 
   # Build GPU execution provider with Pytorch's C++ APIs.
   if (onnxruntime_USE_TORCH)
-    # Hide Caffe2 installed separatedly.
-    list(APPEND CMAKE_PREFIX_PATH "${onnxruntime_TORCH_HOME}")
-    find_package(Torch REQUIRED PATHS "${onnxruntime_TORCH_HOME}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS} -Wno-unused-parameter")
+    target_compile_options(onnxruntime_providers_cuda PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:-Wno-unused-parameter>")
     target_include_directories(onnxruntime_providers_cuda PRIVATE ${TORCH_INCLUDE_DIRS})
     target_link_libraries(onnxruntime_providers_cuda PRIVATE onnxruntime_training ${TORCH_LIBRARIES})
   endif()

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -227,6 +227,16 @@ if (onnxruntime_USE_CUDA)
 
   add_library(onnxruntime_providers_cuda ${onnxruntime_providers_cuda_src})
 
+  # Build GPU execution provider with Pytorch's C++ APIs.
+  if (onnxruntime_USE_TORCH)
+    # Hide Caffe2 installed separatedly.
+    list(APPEND CMAKE_PREFIX_PATH "${onnxruntime_TORCH_HOME}")
+    find_package(Torch REQUIRED PATHS "${onnxruntime_TORCH_HOME}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS} -Wno-unused-parameter")
+    target_include_directories(onnxruntime_providers_cuda PRIVATE ${TORCH_INCLUDE_DIRS})
+    target_link_libraries(onnxruntime_providers_cuda PRIVATE onnxruntime_training ${TORCH_LIBRARIES})
+  endif()
+
   if (UNIX)
     target_compile_options(onnxruntime_providers_cuda PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wno-reorder>"
             "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:-Wno-reorder>")

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -73,6 +73,13 @@ function(AddTest)
             "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:-Wno-error=sign-compare>")
   endif()
 
+  # Build GPU execution provider with Pytorch's C++ APIs.
+  if (onnxruntime_USE_TORCH)
+    target_compile_options(${_UT_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:-Wno-unused-parameter>")
+    target_include_directories(${_UT_TARGET} PRIVATE ${TORCH_INCLUDE_DIRS})
+    target_link_libraries(${_UT_TARGET} PRIVATE onnxruntime_training ${TORCH_LIBRARIES})
+  endif()
+
   set(TEST_ARGS)
   if (onnxruntime_GENERATE_TEST_REPORTS)
     # generate a report file next to the test program

--- a/onnxruntime/core/providers/cuda/math/matmul.cc
+++ b/onnxruntime/core/providers/cuda/math/matmul.cc
@@ -5,6 +5,7 @@
 #include "core/providers/cpu/math/matmul_helper.h"
 #include "core/providers/cuda/shared_inc/fpgeneric.h"
 #include "core/providers/cuda/cuda_allocator.h"
+#include "core/providers/cuda/torch_wrapper/torch_wrapper.h"
 
 namespace onnxruntime {
 namespace cuda {
@@ -95,6 +96,12 @@ Status MatMul<T>::ComputeInternal(OpKernelContext* ctx) const {
   // Bail out early if the output is going to be empty
   if (Y->Shape().Size() == 0)
     return Status::OK();
+  
+#ifdef USE_TORCH
+  // Invoke Libtorch code from ORT kernel.
+  torch_wrapper::matmul(left_X, right_X, Y, transa, transb, alpha_);
+  return Status::OK();
+#endif
 
   const CudaT alpha = ToCudaType<T>::FromFloat(alpha_);
   const CudaT zero = ToCudaType<T>::FromFloat(0.0f);

--- a/onnxruntime/core/providers/cuda/torch_wrapper/matmul.cc
+++ b/onnxruntime/core/providers/cuda/torch_wrapper/matmul.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#ifdef USE_TORCH
+
 #include "core/providers/cuda/torch_wrapper/torch_wrapper.h"
 #include "torch/torch.h"
 #include "core/framework/tensor.h"
@@ -49,3 +51,5 @@ void matmul(
 }  // namespace torch_wrapper
 }  // namespace cuda
 }  // namespace onnxruntime
+
+#endif // USE_TORCH

--- a/onnxruntime/core/providers/cuda/torch_wrapper/matmul.cc
+++ b/onnxruntime/core/providers/cuda/torch_wrapper/matmul.cc
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cuda/torch_wrapper/torch_wrapper.h"
+#include "torch/torch.h"
+#include "core/framework/tensor.h"
+#include "core/providers/cuda/cuda_pch.h"
+#include "core/providers/cuda/cuda_common.h"
+
+namespace onnxruntime {
+namespace cuda {
+namespace torch_wrapper {
+
+void matmul(
+    const Tensor* left,
+    const Tensor* right,
+    /* output */ Tensor* result,
+    const bool left_transpose,
+    const bool right_transpose,
+    const float alpha) {
+  // This information is needed for creating Torch tensor on the right device.
+  torch::Tensor torch_left = ConvertOrtTensorToTorchTensor(left);
+  torch::Tensor torch_right = ConvertOrtTensorToTorchTensor(right);
+
+  // Transpose left matrix if needed.
+  if (left_transpose) {
+    torch_left = at::transpose(torch_left, left->Shape().NumDimensions() - 2, left->Shape().NumDimensions() - 1);
+  }
+
+  // Transpose right matrix if needed.
+  if (right_transpose) {
+    torch_right = at::transpose(torch_right, right->Shape().NumDimensions() - 2, right->Shape().NumDimensions() - 1);
+  }
+
+  // Torch MatMul.
+  auto torch_result = at::matmul(torch_left, torch_right);
+
+  // Scaling MatMul result when needed.
+  if (alpha != 1.0f) {
+    torch_result = at::mul(torch_result, alpha);
+  }
+
+  // Copy torch result to ORT tensor.
+  CopyTorchTensorToOrtTensor(torch_result, result);
+
+  ORT_ENFORCE(cudaGetLastError() == cudaSuccess, "Torch Matmul fails.");
+}
+
+}  // namespace torch_wrapper
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/torch_wrapper/torch_wrapper.cc
+++ b/onnxruntime/core/providers/cuda/torch_wrapper/torch_wrapper.cc
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cuda/torch_wrapper/torch_wrapper.h"
+#include <stdexcept>
+#include <cstring>
+#include "core/providers/cuda/cuda_common.h"
+
+namespace onnxruntime {
+namespace cuda {
+namespace torch_wrapper {
+
+at::ScalarType GetTorchElementType(const ONNX_NAMESPACE::TensorProto_DataType type) {
+  // See the following header for supported types in Pytorch.
+  // https://pytorch.org/cppdocs/api/program_listing_file_torch_csrc_api_include_torch_types.h.html
+  switch (type) {
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
+      return at::kHalf;
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
+      return at::kFloat;
+    case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE:
+      return at::kDouble;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT8:
+      return at::kChar;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT8:
+      return at::kByte;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT16:
+      return at::kShort;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT32:
+      return at::kInt;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT64:
+      return at::kLong;
+    default:
+      throw std::invalid_argument("Unsupported ONNX-to-Torch type conversion");
+  }
+}
+
+torch::DeviceType GetTorchDeviceType(OrtDevice::DeviceType device_type) {
+  switch (device_type) {
+    case OrtDevice::GPU:
+      return torch::kCUDA;
+    case OrtDevice::CPU:
+      return torch::kCPU;
+    default:
+      throw std::invalid_argument("Unsupported ONNX-to-ORT device type conversion");
+  }
+}
+
+OrtDevice::DeviceType GetOrtDeviceType(torch::DeviceType device_type) {
+  switch (device_type) {
+    case torch::kCUDA:
+      return OrtDevice::GPU;
+    case torch::kCPU:
+      return OrtDevice::CPU;
+    default:
+      throw std::invalid_argument("Unsupported Torch-to-ORT device type conversion");
+  }
+}
+
+torch::Tensor ConvertOrtTensorToTorchTensor(const Tensor* tensor) {
+  const auto& element_type = tensor->GetElementType();
+  const auto torch_element_type = GetTorchElementType(static_cast<ONNX_NAMESPACE::TensorProto_DataType>(element_type));
+
+  const auto location = tensor->Location();
+  const auto torch_device = GetTorchDeviceType(location.device.Type());
+  const auto torch_device_id = location.device.Id();
+
+  const auto torch_tensor_options = torch::TensorOptions().dtype(torch_element_type).device(torch_device, torch_device_id);
+
+  torch::Tensor torch_tensor = torch::zeros(c10::IntArrayRef{tensor->Shape().GetDims()}, torch_tensor_options);
+
+  switch (location.device.Type()) {
+    case OrtDevice::GPU:
+      cudaMemcpy(torch_tensor.data_ptr(), tensor->DataRaw(), tensor->SizeInBytes(), cudaMemcpyDeviceToDevice); break;
+      break;
+    case OrtDevice::CPU:
+      std::memcpy(torch_tensor.data_ptr(), tensor->DataRaw(), tensor->SizeInBytes());
+      break;
+    default:
+      throw std::invalid_argument("Unsupported memory transfer between devices");
+  }
+
+  return torch_tensor;
+}
+
+void CopyTorchTensorToOrtTensor(const torch::Tensor torch_tensor, Tensor* ort_tensor) {
+  void* ort_data = ort_tensor->MutableDataRaw();
+  switch (ort_tensor->Location().device.Type()) {
+    case OrtDevice::GPU:
+      cudaMemcpy(ort_data, torch_tensor.data_ptr(), ort_tensor->SizeInBytes(), cudaMemcpyDeviceToDevice);
+      break;
+    case OrtDevice::CPU:
+      std::memcpy(ort_data, torch_tensor.data_ptr(), ort_tensor->SizeInBytes());
+      break;
+    default:
+      throw std::invalid_argument("Unsupported memory transfer between devices");
+  }
+}
+
+}  // torch_wrapper
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/torch_wrapper/torch_wrapper.cc
+++ b/onnxruntime/core/providers/cuda/torch_wrapper/torch_wrapper.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#ifdef USE_TORCH
+
 #include "core/providers/cuda/torch_wrapper/torch_wrapper.h"
 #include <stdexcept>
 #include <cstring>
@@ -100,3 +102,5 @@ void CopyTorchTensorToOrtTensor(const torch::Tensor torch_tensor, Tensor* ort_te
 }  // torch_wrapper
 }  // namespace cuda
 }  // namespace onnxruntime
+
+#endif // USE_TORCH

--- a/onnxruntime/core/providers/cuda/torch_wrapper/torch_wrapper.h
+++ b/onnxruntime/core/providers/cuda/torch_wrapper/torch_wrapper.h
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#ifdef USE_TORCH
+
 #pragma once
 
 #include "torch/torch.h"
@@ -37,3 +39,5 @@ void matmul(
 }  // torch_wrapper
 }  // namespace cuda
 }  // namespace onnxruntime
+
+#endif // USE_TORCH

--- a/onnxruntime/core/providers/cuda/torch_wrapper/torch_wrapper.h
+++ b/onnxruntime/core/providers/cuda/torch_wrapper/torch_wrapper.h
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "torch/torch.h"
+#include "core/graph/onnx_protobuf.h"
+#include "core/providers/cuda/cuda_common.h"
+// #include "include/onnxruntime/core/framework/allocator.h"
+
+namespace onnxruntime {
+namespace cuda {
+namespace torch_wrapper {
+
+// Convert ONNX tensor element type to the corresponding PyTorch type.
+// Notice that not all ONNX types are supported. 
+at::ScalarType GetTorchElementType(const ONNX_NAMESPACE::TensorProto_DataType type);
+
+torch::DeviceType GetTorchDeviceType(OrtDevice::DeviceType device_type);
+
+// Convert ORT tensor to Torch tensor.
+torch::Tensor ConvertOrtTensorToTorchTensor(const Tensor* tensor);
+
+// Copy content of Torch tensor to ORT tensor.
+void CopyTorchTensorToOrtTensor(const torch::Tensor torch_tensor, Tensor* ort_tensor);
+
+// Compute high-dimension matrix multiplication:
+//   result = left * right
+void matmul(
+    const Tensor* left,
+    const Tensor* right,
+    Tensor* result,
+    const bool left_transpose,
+    const bool right_transpose,
+    const float alpha);
+
+}  // torch_wrapper
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/transpose_scale_matmul_op_test.cc
+++ b/onnxruntime/test/contrib_ops/transpose_scale_matmul_op_test.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "gtest/gtest.h"
+#include "core/providers/cuda/torch_wrapper/torch_wrapper.h"
 #include "test/providers/provider_test_utils.h"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/test/training_ops/cuda/torch_baseline_test.cc
+++ b/orttraining/orttraining/test/training_ops/cuda/torch_baseline_test.cc
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#ifdef USE_TORCH
+
 #include "gtest/gtest.h"
-#include "test/providers/provider_test_utils.h"
 #include "torch/torch.h"
+#include "test/providers/provider_test_utils.h"
 #include "test/providers/compare_provider_test_utils.h"
 
 namespace onnxruntime {
@@ -42,3 +44,5 @@ TEST(TorchBaseline, MatMul) {
 
 }  // namespace test
 }  // namespace onnxruntime
+
+#endif // USE_TORCH

--- a/orttraining/orttraining/test/training_ops/cuda/torch_baseline_test.cc
+++ b/orttraining/orttraining/test/training_ops/cuda/torch_baseline_test.cc
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+#include "torch/torch.h"
+#include "test/providers/compare_provider_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+static void TorchTestMatmul(const std::vector<int64_t>& A_shape,
+                            const std::vector<int64_t>& B_shape) {
+  OpTester test("MatMul");
+
+  // Create inputs.
+  RandomValueGenerator random{};
+  std::vector<float> A = random.Uniform<float>(A_shape, -10.0f, 10.0f);
+  std::vector<float> B = random.Uniform<float>(B_shape, -10.0f, 10.0f);
+
+  // Add inputs to test context.
+  test.AddInput<float>("A", A_shape, A);
+  test.AddInput<float>("B", B_shape, B);
+
+  // Invoke libtorch to compute result.
+  auto torch_tensor_options = torch::TensorOptions().dtype(at::kFloat);
+  torch::Tensor torch_A = torch::from_blob(A.data(), A_shape, torch_tensor_options);
+  torch::Tensor torch_B = torch::from_blob(B.data(), B_shape, torch_tensor_options);
+  torch::Tensor torch_C = at::matmul(torch_A, torch_B);
+
+  // Copy libtorch result to test context.
+  std::vector<int64_t> C_shape = torch_C.sizes().vec();
+  std::vector<float> C((float*)torch_C.data_ptr(), (float*)torch_C.data_ptr() + torch_C.numel());
+  test.AddOutput<float>("Y", C_shape, C);
+
+  test.Run();
+}
+
+TEST(TorchBaseline, MatMul) {
+  TorchTestMatmul({7, 16}, {16, 8});
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -107,6 +107,10 @@ def parse_arguments():
         "--mpi_home", help="Path to MPI installation dir")
     parser.add_argument(
         "--nccl_home", help="Path to NCCL installation dir")
+    parser.add_argument(
+        "--use_torch", action='store_true', help="Build with libtorch C++ APIs")
+    parser.add_argument(
+        "--torch_home", help="Path to Pytorch python package or libtorch dir")
 
     # enable ONNX tests
     parser.add_argument(
@@ -541,7 +545,7 @@ def setup_test_data(build_dir, configs):
 
 
 def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home,
-                        mpi_home, nccl_home, tensorrt_home, migraphx_home,
+                        mpi_home, nccl_home, tensorrt_home, migraphx_home, torch_home,
                         path_to_protoc_exe, configs, cmake_extra_defines, args, cmake_extra_args):
     log.info("Generating CMake build tree")
     cmake_dir = os.path.join(source_dir, "cmake")
@@ -657,6 +661,8 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
         # Training related flags
         "-Donnxruntime_ENABLE_NVTX_PROFILE=" + (
             "ON" if args.enable_nvtx_profile else "OFF"),
+        "-Donnxruntime_USE_TORCH=" + (
+            "ON" if args.use_torch else "OFF"),
         "-Donnxruntime_ENABLE_TRAINING=" + (
             "ON" if args.enable_training else "OFF"),
         "-Donnxruntime_USE_HOROVOD=" + (
@@ -670,6 +676,9 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
 
     if nccl_home and os.path.exists(nccl_home):
         cmake_args += ["-Donnxruntime_NCCL_HOME=" + nccl_home]
+
+    if torch_home and os.path.exists(torch_home):
+        cmake_args += ["-Donnxruntime_TORCH_HOME=" + torch_home]
 
     if args.winml_root_namespace_override:
         cmake_args += ["-Donnxruntime_WINML_NAMESPACE_OVERRIDE=" +
@@ -1543,6 +1552,7 @@ def main():
 
     mpi_home = args.mpi_home
     nccl_home = args.nccl_home
+    torch_home = args.torch_home
 
     # if using tensorrt, setup tensorrt paths
     tensorrt_home = setup_tensorrt_vars(args)
@@ -1634,7 +1644,7 @@ def main():
             setup_test_data(build_dir, configs)
         generate_build_tree(
             cmake_path, source_dir, build_dir, cuda_home, cudnn_home, mpi_home, nccl_home,
-            tensorrt_home, migraphx_home, path_to_protoc_exe, configs, cmake_extra_defines,
+            tensorrt_home, migraphx_home, torch_home, path_to_protoc_exe, configs, cmake_extra_defines,
             args, cmake_extra_args)
 
     if args.clean:


### PR DESCRIPTION
Different kernel implementations sometimes very different results. This PR aims at providing flexibility to switch back to Pytorch code when debugging such issues. We basically

1. Add a flag to indicate the use of pytorch
2. Modify CMake files to build ORT with pytorch library
3. Add some helpers function to bridge ORT tensors and Pytorch tensors
4. Dispath MatMul to pytorch when USE_TORCH is set.
5. Create a test to use pytorch result as its baseline.

This PR doesn't make Pytorch a formal execution provider but shade some light in that direction.

Command to build ORT with Pytorch:
./build.sh --use_cuda --use_full_protobuf --config Debug  --build_wheel --enable_pybind --enable_training --enable_nvtx_profile --use_libtorch --libtorch_home /data/anaconda/envs/wechi37/lib/python3.7/site-packages/torch --use_openmp --parallel

Some exploration code can be found in #4687 and #4657.