### PR TITLE
[WIP] Set `GraphResolveNeeded(true)` after adding a node

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2569,7 +2569,7 @@ Node& Graph::AddNode(const std::string& name,
   node->Init(name, op_type, description, inputs, outputs, attributes, domain);
   if (0 != op_type.compare(kNoOp)) {
     GraphProtoSyncNeeded(true);
-  } 
+  }
   GraphResolveNeeded(true);
 
   return *node;

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2569,7 +2569,8 @@ Node& Graph::AddNode(const std::string& name,
   node->Init(name, op_type, description, inputs, outputs, attributes, domain);
   if (0 != op_type.compare(kNoOp)) {
     GraphProtoSyncNeeded(true);
-  }
+  } 
+  GraphResolveNeeded(true);
 
   return *node;
 }

--- a/onnxruntime/core/optimizer/matmul_scale_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_scale_fusion.cc
@@ -256,6 +256,7 @@ Status ProcessNode(
     }
   }
 
+  graph.Resolve();
   modified = true;
 
   return Status::OK();


### PR DESCRIPTION
**Description**: Adds a call to `GraphResolveNeeded(true)` in `Graph::AddNode()`, and calls `Graph::Resolve()` after modifying the graph in `MatMulScaleFusion`.

**Motivation and Context**
- At present, after calling `Graph::AddNode()` (e.g. in an optimization pass) the `Node::op_` field for the added nodes may be nullptr. This can cause segfaults in subsequent code that accesses this field.
- We must also actually resolve the graph during the optimization pass, to ensure that the nodes we access during the same pass are resolved.