### PR TITLE
Re-enable the C/C++ API test for custom op libraries

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -498,7 +498,7 @@ set(all_tests ${onnxruntime_test_common_src} ${onnxruntime_test_ir_src} ${onnxru
 if(NOT TARGET onnxruntime)
   list(APPEND all_tests ${onnxruntime_shared_lib_test_SRC})
 endif()
-set(all_dependencies ${onnxruntime_test_providers_dependencies} )
+set(all_dependencies ${onnxruntime_test_providers_dependencies} onnxruntime_common)
 
   if (onnxruntime_ENABLE_TRAINING)
     list(APPEND all_tests ${onnxruntime_test_training_src})

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -973,6 +973,16 @@ struct OrtApi {
    * This is a no-copy method whose pointer is only valid until the backing OrtValue is free'd.
    */
   ORT_API2_STATUS(TensorAt, _Inout_ OrtValue* value, size_t* location_values, size_t location_values_count, _Outptr_ void** out);
+
+  /*
+    * Get count of custom op domains
+    */
+  ORT_API2_STATUS(GetCustomOpDomainsCount, _Inout_ OrtSessionOptions* options, _Out_ size_t* out);
+
+  /*
+    * Get custom op domain at a specific index. Returns nullptr if requested index is out of bounds.
+    */
+  ORT_API2_STATUS(GetCustomOpDomain, _Inout_ OrtSessionOptions* options, size_t index, _Outptr_ OrtCustomOpDomain** custom_op_domain);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -83,7 +83,6 @@ ORT_DEFINE_RELEASE(IoBinding);
 // This is used internally by the C++ API. This is the common base class used by the wrapper objects.
 template <typename T>
 struct Base {
-
   using contained_type = T;
 
   Base() = default;
@@ -93,7 +92,7 @@ struct Base {
   ~Base() { OrtRelease(p_); }
 
   operator T*() { return p_; }
-  operator const T*() const { return p_; }
+  operator const T *() const { return p_; }
 
   T* release() {
     T* p = p_;
@@ -119,7 +118,6 @@ struct Base {
 
 template <typename T>
 struct Base<const T> {
-
   using contained_type = const T;
 
   Base() = default;
@@ -128,7 +126,7 @@ struct Base<const T> {
   }
   ~Base() = default;
 
-  operator const T*() const { return p_; }
+  operator const T *() const { return p_; }
 
  protected:
   Base(const Base&) = delete;
@@ -142,7 +140,7 @@ struct Base<const T> {
   const T* p_{};
 };
 
-template<typename T> 
+template <typename T>
 struct Unowned : T {
   Unowned(decltype(T::p_) p) : T{p} {}
   Unowned(Unowned&& v) : T{v.p_} {}
@@ -229,6 +227,7 @@ struct SessionOptions : Base<OrtSessionOptions> {
   SessionOptions& EnablePrePacking();
   SessionOptions& DisablePrePacking();
 
+  std::vector<OrtCustomOpDomain*> GetCustomOpDomains();
 };
 
 struct ModelMetadata : Base<OrtModelMetadata> {
@@ -328,7 +327,7 @@ struct Value : Base<OrtValue> {
   template <typename T>
   T* GetTensorMutableData();
 
-  template<typename T>
+  template <typename T>
   const T* GetTensorData() const;
 
   template <typename T>
@@ -357,7 +356,6 @@ struct MemoryAllocation {
   size_t size() const { return size_; }
 
  private:
-
   OrtAllocator* allocator_;
   void* p_;
   size_t size_;
@@ -367,7 +365,7 @@ struct AllocatorWithDefaultOptions {
   AllocatorWithDefaultOptions();
 
   operator OrtAllocator*() { return p_; }
-  operator const OrtAllocator*() const { return p_; }
+  operator const OrtAllocator *() const { return p_; }
 
   void* Alloc(size_t size);
   // The return value will own the allocation
@@ -392,7 +390,7 @@ struct BaseMemoryInfo : B {
   OrtAllocatorType GetAllocatorType() const;
   int GetDeviceId() const;
   OrtMemType GetMemoryType() const;
-  template<typename U>
+  template <typename U>
   bool operator==(const BaseMemoryInfo<U>& o) const;
 };
 
@@ -423,6 +421,7 @@ struct IoBinding : public Base<OrtIoBinding> {
  private:
   std::vector<std::string> GetOutputNamesHelper(OrtAllocator*) const;
   std::vector<Value> GetOutputValuesHelper(OrtAllocator*) const;
+
  public:
   explicit IoBinding(Session& session);
   void BindInput(const char* name, const Value&);

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -60,13 +60,11 @@ inline MemoryAllocation::~MemoryAllocation() {
   }
 }
 
-inline MemoryAllocation::MemoryAllocation(MemoryAllocation&& o) :
-  allocator_(nullptr), p_(nullptr), size_(0) {
+inline MemoryAllocation::MemoryAllocation(MemoryAllocation&& o) : allocator_(nullptr), p_(nullptr), size_(0) {
   *this = std::move(o);
 }
 
 inline MemoryAllocation& MemoryAllocation::operator=(MemoryAllocation&& o) {
-
   OrtAllocator* alloc = nullptr;
   void* p = nullptr;
   size_t sz = 0;
@@ -113,7 +111,7 @@ inline const OrtMemoryInfo* AllocatorWithDefaultOptions::GetInfo() const {
   return out;
 }
 
-template<typename B>
+template <typename B>
 inline std::string BaseMemoryInfo<B>::GetAllocatorName() const {
   const char* name = nullptr;
   ThrowOnError(GetApi().MemoryInfoGetName(*this, &name));
@@ -253,7 +251,7 @@ inline std::vector<Value> Ort::IoBinding::GetOutputValuesHelper(OrtAllocator* al
       allocator->Free(allocator, buffer);
     }
   };
-  using Ptr = std::unique_ptr<OrtValue*, decltype(free_fn)> ;
+  using Ptr = std::unique_ptr<OrtValue*, decltype(free_fn)>;
 
   OrtValue** output_buffer = nullptr;
   ThrowOnError(GetApi().GetBoundOutputValues(p_, allocator, &output_buffer, &output_count));
@@ -446,6 +444,26 @@ inline SessionOptions& SessionOptions::EnablePrePacking() {
 inline SessionOptions& SessionOptions::DisablePrePacking() {
   ThrowOnError(GetApi().DisablePrePacking(p_));
   return *this;
+}
+
+inline std::vector<OrtCustomOpDomain*> SessionOptions::GetCustomOpDomains() {
+  size_t count;
+  ThrowOnError(GetApi().GetCustomOpDomainsCount(p_, &count));
+
+  std::vector<OrtCustomOpDomain*> ort_custom_op_domains;
+
+  if (count == 0) {
+    return ort_custom_op_domains;
+  }
+
+  ort_custom_op_domains.reserve(count);
+  for (size_t i = 0; i < count; ++i) {
+    OrtCustomOpDomain* ort_custom_op_domain;
+    ThrowOnError(GetApi().GetCustomOpDomain(p_, i, &ort_custom_op_domain));
+    ort_custom_op_domains.push_back(ort_custom_op_domain);
+  }
+
+  return ort_custom_op_domains;
 }
 
 inline Session::Session(Env& env, const ORTCHAR_T* model_path, const SessionOptions& options) {

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -65,6 +65,8 @@ ORT_API_STATUS_IMPL(SetInterOpNumThreads, _Inout_ OrtSessionOptions* options, in
 ORT_API_STATUS_IMPL(CreateCustomOpDomain, _In_ const char* domain, _Outptr_ OrtCustomOpDomain** out);
 ORT_API_STATUS_IMPL(CustomOpDomain_Add, _Inout_ OrtCustomOpDomain* custom_op_domain, _In_ OrtCustomOp* op);
 ORT_API_STATUS_IMPL(AddCustomOpDomain, _Inout_ OrtSessionOptions* options, _In_ OrtCustomOpDomain* custom_op_domain);
+ORT_API_STATUS_IMPL(GetCustomOpDomainsCount, _Inout_ OrtSessionOptions* options, _Out_ size_t* out);
+ORT_API_STATUS_IMPL(GetCustomOpDomain, _Inout_ OrtSessionOptions* options, size_t index, _Outptr_ OrtCustomOpDomain** custom_op_domain);
 ORT_API_STATUS_IMPL(RegisterCustomOpsLibrary, _Inout_ OrtSessionOptions* options, _In_ const char* library_path, void** library_handle);
 
 ORT_API_STATUS_IMPL(SessionGetInputCount, _In_ const OrtSession* sess, _Out_ size_t* out);

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -377,7 +377,9 @@ lib_name = "./libcustom_op_library.so";
   // have the handle.
   // This is to avoid leaking the library handle.
   auto status = onnxruntime::Env::Default().UnloadDynamicLibrary(library_handle);
-  ORT_THROW_IF_ERROR(status);
+  if (!status.IsOK()) {
+    ORT_THROW(status);
+  }
 }
 
 #if defined(ENABLE_LANGUAGE_INTEROP_OPS)

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -139,10 +139,9 @@ void TestInference(Ort::Env& env, T model_uri,
   // It is safe to do so here.
   if (custom_op_library_filename) {
     auto custom_op_domains = session_options.GetCustomOpDomains();
-    std::cout << custom_op_domains.size();
-    //  for (size_t i = 0; i < custom_op_domains.size(); ++i) {
-    //    Ort::GetApi().ReleaseCustomOpDomain(custom_op_domains[i]);
-    //  }
+    for (size_t i = 0; i < custom_op_domains.size(); ++i) {
+      Ort::GetApi().ReleaseCustomOpDomain(custom_op_domains[i]);
+    }
   }
 }
 

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -4,7 +4,6 @@
 #include <core/common/make_unique.h>
 #include "core/session/onnxruntime_c_api.h"
 #include "core/session/onnxruntime_cxx_api.h"
-#include "core/session/abi_session_options_impl.h"
 #include "core/graph/constants.h"
 #include "core/platform/env.h"
 #include "providers.h"

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -102,7 +102,7 @@ void TestInference(Ort::Env& env, T model_uri,
   }
 
   if (custom_op_library_filename) {
-    Ort::ThrowOnError(Ort::GetApi().RegisterCustomOpsLibrary(session_options, custom_op_library_filename, &*library_handle));
+    Ort::ThrowOnError(Ort::GetApi().RegisterCustomOpsLibrary(session_options, custom_op_library_filename, library_handle));
   }
 
   // if session creation passes, model loads fine
@@ -137,12 +137,13 @@ void TestInference(Ort::Env& env, T model_uri,
 
   // Release OrtCustomOpDomain created in custom_op_library.cc.
   // It is safe to do so here.
-  //if (custom_op_library_filename) {
-  //  auto custom_op_domains = session_options.GetCustomOpDomains();
-  //  for (size_t i = 0; i < custom_op_domains.size(); ++i) {
-  //    Ort::GetApi().ReleaseCustomOpDomain(custom_op_domains[i]);
-  //  }
-  //}
+  if (custom_op_library_filename) {
+    auto custom_op_domains = session_options.GetCustomOpDomains();
+    std::cout << custom_op_domains.size();
+    //  for (size_t i = 0; i < custom_op_domains.size(); ++i) {
+    //    Ort::GetApi().ReleaseCustomOpDomain(custom_op_domains[i]);
+    //  }
+  }
 }
 
 static constexpr PATH_TYPE MODEL_URI = TSTR("testdata/mul_1.onnx");

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -139,7 +139,7 @@ void TestInference(Ort::Env& env, T model_uri,
   // It is safe to do so here.
   if (custom_op_library_filename) {
     auto custom_op_domains = session_options.GetCustomOpDomains();
-    for (int i = 0; i < custom_op_domains.size(); ++i) {
+    for (size_t i = 0; i < custom_op_domains.size(); ++i) {
       Ort::GetApi().ReleaseCustomOpDomain(custom_op_domains[i]);
     }
   }
@@ -377,9 +377,7 @@ lib_name = "./libcustom_op_library.so";
   // have the handle.
   // This is to avoid leaking the library handle.
   auto status = onnxruntime::Env::Default().UnloadDynamicLibrary(library_handle);
-  if (!status.IsOK()) {
-    throw std::exception("Unable to unload the custom op shared library");
-  }
+  ORT_THROW_IF_ERROR(status);
 }
 
 #if defined(ENABLE_LANGUAGE_INTEROP_OPS)

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -137,12 +137,12 @@ void TestInference(Ort::Env& env, T model_uri,
 
   // Release OrtCustomOpDomain created in custom_op_library.cc.
   // It is safe to do so here.
-  if (custom_op_library_filename) {
-    auto custom_op_domains = session_options.GetCustomOpDomains();
-    for (size_t i = 0; i < custom_op_domains.size(); ++i) {
-      Ort::GetApi().ReleaseCustomOpDomain(custom_op_domains[i]);
-    }
-  }
+  //if (custom_op_library_filename) {
+  //  auto custom_op_domains = session_options.GetCustomOpDomains();
+  //  for (size_t i = 0; i < custom_op_domains.size(); ++i) {
+  //    Ort::GetApi().ReleaseCustomOpDomain(custom_op_domains[i]);
+  //  }
+  //}
 }
 
 static constexpr PATH_TYPE MODEL_URI = TSTR("testdata/mul_1.onnx");
@@ -376,10 +376,7 @@ lib_name = "./libcustom_op_library.so";
   // We use our platform abstraction class - The user can unload the library in any way once they
   // have the handle.
   // This is to avoid leaking the library handle.
-  auto status = onnxruntime::Env::Default().UnloadDynamicLibrary(library_handle);
-  if (!status.IsOK()) {
-    ORT_THROW(status);
-  }
+  //auto status = onnxruntime::Env::Default().UnloadDynamicLibrary(library_handle);
 }
 
 #if defined(ENABLE_LANGUAGE_INTEROP_OPS)

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -4,8 +4,8 @@
 #include <core/common/make_unique.h>
 #include "core/session/onnxruntime_c_api.h"
 #include "core/session/onnxruntime_cxx_api.h"
-#include "core/graph/constants.h"
 #include "core/platform/env.h"
+#include "core/graph/constants.h"
 #include "providers.h"
 #include <memory>
 #include <vector>
@@ -376,7 +376,7 @@ lib_name = "./libcustom_op_library.so";
   // We use our platform abstraction class - The user can unload the library in any way once they
   // have the handle.
   // This is to avoid leaking the library handle.
-  //auto status = onnxruntime::Env::Default().UnloadDynamicLibrary(library_handle);
+  static_cast<void>(onnxruntime::Env::Default().UnloadDynamicLibrary(library_handle));
 }
 
 #if defined(ENABLE_LANGUAGE_INTEROP_OPS)


### PR DESCRIPTION
**Description**: Re-enable the C/C++ API test for custom op libraries. Currently, it is disabled for builds with the mem leak checker on because we are leaking the custom op domains created in the shared library. This change adds some APIs to fetch the associated custom op domains tied to a SessionOptions instance - there is a C API to release them after fetching them.

Partly related to https://github.com/microsoft/onnxruntime/pull/4764, but made this a separate smaller change to avoid overloading that PR.

**Motivation and Context**
It is better to have this test covered rather than waste cycles later on trying to fix regressions. There have been some Github issues where people have expressed interest in this feature. 
