### PR TITLE
Inbox build breaks trying to reference Microsoft

### DIFF
--- a/winml/dll/module.cpp
+++ b/winml/dll/module.cpp
@@ -103,7 +103,7 @@ STDAPI DllGetExperimentalActivationFactory(void* classId, void** factory) noexce
     std::wostringstream dummy_class;
     dummy_class << XSTRINGIFY(WINML_ROOT_NS) << ".AI.MachineLearning.Experimental.Dummy";
     if (requal(name, dummy_class.str())) {
-      *factory = winrt::detach_abi(winrt::make<winrt::Microsoft::AI::MachineLearning::Experimental::factory_implementation::Dummy>());
+      *factory = winrt::detach_abi(winrt::make<WINML_EXPERIMENTAL::factory_implementation::Dummy>());
       return 0;
     }
 


### PR DESCRIPTION
issue: new experimental idl has types referenced explicityly with Microsoft namespace in inbox build.

fix: use namespace alias.