### PR TITLE
Make grad name unique

### DIFF
--- a/orttraining/orttraining/core/graph/gradient_builder_base.h
+++ b/orttraining/orttraining/core/graph/gradient_builder_base.h
@@ -37,7 +37,7 @@ typedef std::vector<NodeDef> GradientDef;
 class GradientBuilderBase {
  public:
   GradientBuilderBase(const GradientGraphConfiguration& gradient_graph_config,
-                      const Graph* graph,
+                      Graph* graph,
                       const Node* node,
                       const std::unordered_set<std::string>& gradient_inputs,
                       const std::unordered_set<std::string>& gradient_outputs,
@@ -217,13 +217,13 @@ class GradientBuilderBase {
     if (!name.empty()) {
       unique_prefix << name << "_Grad/";
     } else {
-      unique_prefix << node_->OpType() << "_index_" << node_->Index() << "_Grad/";
+      unique_prefix << graph_->GenerateNodeName(node_->OpType()) << "_Grad/";
     }
     return unique_prefix.str();
   }
 
   const GradientGraphConfiguration& gradient_graph_config_;
-  const Graph* graph_;
+  Graph* graph_;
   const Node* node_;
   std::string unique_node_prefix_;
 

--- a/orttraining/orttraining/core/graph/gradient_builder_base.h
+++ b/orttraining/orttraining/core/graph/gradient_builder_base.h
@@ -217,7 +217,7 @@ class GradientBuilderBase {
     if (!name.empty()) {
       unique_prefix << name << "_Grad/";
     } else {
-      unique_prefix << node_->OpType() << "_" << node_->Index() << "_Grad/";
+      unique_prefix << node_->OpType() << "_index_" << node_->Index() << "_Grad/";
     }
     return unique_prefix.str();
   }

--- a/orttraining/orttraining/core/graph/gradient_builder_registry.cc
+++ b/orttraining/orttraining/core/graph/gradient_builder_registry.cc
@@ -9,7 +9,7 @@ namespace onnxruntime {
 namespace training {
 
 GradientDef GetGradientForOp(const GradientGraphConfiguration& gradient_graph_config,
-                             const Graph* graph,
+                             Graph* graph,
                              const Node* node,
                              const std::unordered_set<std::string>& output_args_need_grad,
                              const std::unordered_set<std::string>& input_args_need_grad,

--- a/orttraining/orttraining/core/graph/gradient_builder_registry.h
+++ b/orttraining/orttraining/core/graph/gradient_builder_registry.h
@@ -13,7 +13,7 @@ namespace training {
 
 typedef GenericRegistry<GradientBuilderBase,
                         const GradientGraphConfiguration&,
-                        const Graph*&,                           // graph
+                        Graph*&,                                 // graph
                         const Node*&,                            // node
                         const std::unordered_set<std::string>&,  // gradient_inputs
                         const std::unordered_set<std::string>&,  // gradient_outputs
@@ -35,7 +35,7 @@ class GradientBuilderRegistry : public GradientRegistryType {
 };
 
 GradientDef GetGradientForOp(const GradientGraphConfiguration& gradient_graph_config,
-                             const Graph* graph,
+                             Graph* graph,
                              const Node* node,
                              const std::unordered_set<std::string>& output_args_need_grad,
                              const std::unordered_set<std::string>& input_args_need_grad,


### PR DESCRIPTION
This fixes the bug for TNLRv3, where there was a duplication of node name due to the "node_->OpType() + node_->Index()"
being the same as another node's name.