### PR TITLE
add telemetry for named dimension overrides

### DIFF
--- a/winml/lib/Api/LearningModelSessionOptions.cpp
+++ b/winml/lib/Api/LearningModelSessionOptions.cpp
@@ -30,6 +30,7 @@ wfc::IMapView<winrt::hstring, uint32_t> LearningModelSessionOptions::NamedDimens
 
 void LearningModelSessionOptions::OverrideNamedDimension(winrt::hstring name, uint32_t value) {
   named_dim_overrides_.Insert(name, value);
+  telemetry_helper.SetNamedDimensionOverride(name, value);
 }
 
 uint32_t LearningModelSessionOptions::GetIntraOpNumThreads() {

--- a/winml/lib/Common/inc/WinMLTelemetryHelper.h
+++ b/winml/lib/Common/inc/WinMLTelemetryHelper.h
@@ -35,6 +35,7 @@ class Profiler;
 #define WINML_TLM_RUNTIME_ERROR_VERSION 0
 #define WINML_TLM_RUNTIME_PERF_VERSION 0
 #define WINML_TLM_NATIVE_API_INTRAOP_THREADS_VERSION 0
+#define WINML_TLM_NAMED_DIMENSION_OVERRIDE_VERSION 0
 
 #define WinMLTraceLoggingWrite(hProvider, EventName, ...)                \
   TraceLoggingWrite(hProvider,                                           \
@@ -97,6 +98,9 @@ class WinMLTelemetryHelper {
       uint32_t default_attribute_count);
   void SetIntraOpNumThreadsOverride(
       uint32_t num_threads);
+  void SetNamedDimensionOverride(
+      winrt::hstring name,
+      uint32_t value);
   void EndRuntimeSession() { ++runtime_session_id_; };
   bool IsMeasureSampled();
 

--- a/winml/lib/Telemetry/WinMLTelemetryHelper.cpp
+++ b/winml/lib/Telemetry/WinMLTelemetryHelper.cpp
@@ -124,3 +124,20 @@ void WinMLTelemetryHelper::SetIntraOpNumThreadsOverride(
       TraceLoggingInt32(std::thread::hardware_concurrency(), "maxThreadsOnMachine"),
       TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
 }
+
+void WinMLTelemetryHelper::SetNamedDimensionOverride(
+    winrt::hstring name, uint32_t value) {
+  if (!telemetry_enabled_)
+    return;
+  WinMLTraceLoggingWrite(
+      provider_,
+      "SetNamedDimensionOverride",
+      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+      //Telemetry info
+      TraceLoggingUInt8(WINML_TLM_NAMED_DIMENSION_OVERRIDE_VERSION, "schemaVersion"),
+      // num threads info
+      TraceLoggingWideString(name.c_str(), "dimension name"),
+      TraceLoggingInt32(value, "override value"),
+      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+}


### PR DESCRIPTION
**Description**: Add telemetry logging for the new named dimension override session option.

Tested with Telemetry real time tool.
