### PR TITLE
Auto upgrade base image dependencies

### DIFF
--- a/dockerfiles/Dockerfile.training
+++ b/dockerfiles/Dockerfile.training
@@ -21,11 +21,11 @@ WORKDIR /stage
 
 # install curl and git
 RUN apt-get -y update &&\
-    apt-get install -y sudo git bash unattended-upgrades && \
     apt-get -y --no-install-recommends install \
         curl \
         git \
-        language-pack-en
+        language-pack-en \
+        unattended-upgrades
 
 RUN unattended-upgrade
 

--- a/dockerfiles/Dockerfile.training
+++ b/dockerfiles/Dockerfile.training
@@ -27,6 +27,7 @@ RUN apt-get -y update &&\
         language-pack-en \
         unattended-upgrades
 
+# update existing packages to minimize security vulnerabilities
 RUN unattended-upgrade
 
 RUN locale-gen en_US.UTF-8 && \

--- a/dockerfiles/Dockerfile.training
+++ b/dockerfiles/Dockerfile.training
@@ -21,10 +21,13 @@ WORKDIR /stage
 
 # install curl and git
 RUN apt-get -y update &&\
+    apt-get install -y sudo git bash unattended-upgrades && \
     apt-get -y --no-install-recommends install \
         curl \
         git \
         language-pack-en
+
+RUN unattended-upgrade
 
 RUN locale-gen en_US.UTF-8 && \
     update-locale LANG=en_US.UTF-8


### PR DESCRIPTION
**Description**: This is for fixing docker image security vulnerabilities. With this, we don't have to upgrade every package individually.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
