### PR TITLE
update Dockerfile.cuda and Dockerfile.tensorrt

### DIFF
--- a/dockerfiles/Dockerfile.cuda
+++ b/dockerfiles/Dockerfile.cuda
@@ -12,7 +12,8 @@ ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
 ARG ONNXRUNTIME_BRANCH=master
 
 RUN apt-get update &&\
-    apt-get install -y sudo git bash
+    apt-get install -y sudo git bash unattended-upgrades
+RUN unattended-upgrade
 
 WORKDIR /code
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/code/cmake-3.14.3-Linux-x86_64/bin:/opt/miniconda/bin:${PATH}

--- a/dockerfiles/Dockerfile.tensorrt
+++ b/dockerfiles/Dockerfile.tensorrt
@@ -12,7 +12,8 @@ ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
 ARG ONNXRUNTIME_BRANCH=master
 
 RUN apt-get update &&\
-    apt-get install -y sudo git bash
+    apt-get install -y sudo git bash unattended-upgrades
+RUN unattended-upgrade
 
 WORKDIR /code
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/code/cmake-3.14.3-Linux-x86_64/bin:/opt/miniconda/bin:${PATH}


### PR DESCRIPTION
install unattended-upgrades and run unattended-upgrade to ensure latest security updates are installed.
this needs to be done on Dockerfiles where we derive from a base image that we don't control (e.g. images from Nvidia)
