### PR TITLE
Check status of element-wise op prepare functions.

### DIFF
--- a/onnxruntime/contrib_ops/cuda/activation/activations.cc
+++ b/onnxruntime/contrib_ops/cuda/activation/activations.cc
@@ -26,7 +26,7 @@ namespace cuda {
   template <>                                                                                              \
   Status x<T>::ComputeInternal(OpKernelContext* context) const {                                           \
     UnaryElementwisePreparation p;                                                                         \
-    UnaryElementwise::Prepare(context, &p);                                                                \
+    ORT_RETURN_IF_ERROR(UnaryElementwise::Prepare(context, &p));                                           \
     Ctx##x func_ctx = MakeFuncCtx();                                                                       \
     Impl_##x<typename ToCudaType<T>::MappedType>(                                                          \
         reinterpret_cast<const typename ToCudaType<T>::MappedType*>(p.input_tensor->template Data<T>()),   \

--- a/onnxruntime/contrib_ops/cuda/math/complex_mul.cc
+++ b/onnxruntime/contrib_ops/cuda/math/complex_mul.cc
@@ -40,7 +40,7 @@ Status ComplexMul<T, is_conj>::ComputeInternal(OpKernelContext* context) const {
   }
 
   BinaryElementwisePreparation prepare;
-  Prepare(context, &prepare);
+  ORT_RETURN_IF_ERROR(Prepare(context, &prepare));
   ComplexMul_Impl<typename ToCudaType<T>::MappedType>(
       prepare.output_rank_or_simple_broadcast,
       &prepare.lhs_padded_strides,

--- a/onnxruntime/core/providers/cuda/activation/activations.cc
+++ b/onnxruntime/core/providers/cuda/activation/activations.cc
@@ -22,7 +22,7 @@ namespace cuda {
   template <>                                                                                              \
   Status x<T>::ComputeInternal(OpKernelContext* context) const {                                           \
     UnaryElementwisePreparation p;                                                                         \
-    UnaryElementwise::Prepare(context, &p);                                                                \
+    ORT_RETURN_IF_ERROR(UnaryElementwise::Prepare(context, &p));                                           \
     Ctx##x func_ctx = MakeFuncCtx();                                                                       \
     Impl_##x<typename ToCudaType<T>::MappedType>(                                                          \
         reinterpret_cast<const typename ToCudaType<T>::MappedType*>(p.input_tensor->template Data<T>()),   \

--- a/onnxruntime/core/providers/cuda/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/cuda/math/binary_elementwise_ops.cc
@@ -143,7 +143,7 @@ Status BinaryElementwise<ShouldBroadcast>::Prepare(OpKernelContext* context, Bin
   template <>                                                                                                    \
   Status x<T>::ComputeInternal(OpKernelContext* context) const {                                                 \
     BinaryElementwisePreparation prepare;                                                                        \
-    Prepare(context, &prepare);                                                                                  \
+    ORT_RETURN_IF_ERROR(Prepare(context, &prepare));                                                             \
     Impl_##x<typename ToCudaType<T>::MappedType>(                                                                \
         prepare.output_rank_or_simple_broadcast,                                                                 \
         &prepare.lhs_padded_strides,                                                                             \
@@ -337,7 +337,7 @@ Status DispatchOnFirstArg(const BinaryElementwisePreparation& prepare) {
 
 Status Pow::ComputeInternal(OpKernelContext* context) const {
   BinaryElementwisePreparation prepare;
-  Prepare(context, &prepare);
+  ORT_RETURN_IF_ERROR(Prepare(context, &prepare));
   namespace on = ONNX_NAMESPACE;
   using namespace pow12_internal;
 

--- a/onnxruntime/core/providers/cuda/math/unary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/cuda/math/unary_elementwise_ops.cc
@@ -37,7 +37,7 @@ Status UnaryElementwise::Prepare(OpKernelContext* context, UnaryElementwisePrepa
   template <>                                                                                              \
   Status x<T>::ComputeInternal(OpKernelContext* context) const {                                           \
     UnaryElementwisePreparation p;                                                                         \
-    UnaryElementwise::Prepare(context, &p);                                                                \
+    ORT_RETURN_IF_ERROR(UnaryElementwise::Prepare(context, &p));                                           \
     Impl_##x(                                                                                              \
         reinterpret_cast<const typename ToCudaType<T>::MappedType*>(p.input_tensor->template Data<T>()),   \
         reinterpret_cast<typename ToCudaType<T>::MappedType*>(p.output_tensor->template MutableData<T>()), \

--- a/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
@@ -157,7 +157,7 @@ Status ReduceKernel<allow_multi_axes>::ReduceKernelShared(
       auto exp_result = GetScratchBuffer<T>(input_count).get();
       auto log_sum_result = GetScratchBuffer<T>(output_count).get();
       BinaryElementwisePreparation prepare;
-      prepare.BinaryElementwiseBroadcastPrepareHelper(input_shape, rhs_shape, input_shape);
+      ORT_RETURN_IF_ERROR(prepare.BinaryElementwiseBroadcastPrepareHelper(input_shape, rhs_shape, input_shape));
       Impl_Sub<CudaT>(prepare.output_rank_or_simple_broadcast,
                       &prepare.lhs_padded_strides,
                       reinterpret_cast<const CudaT*>(X),
@@ -481,7 +481,7 @@ Status ReduceComputeCore(CUDAExecutionProvider& cuda_ep, const Tensor& input, Pr
       auto log_sum_result_buffer = cuda_ep.GetScratchBuffer<T>(output_count);
       auto log_sum_result = log_sum_result_buffer.get();
       BinaryElementwisePreparation prepare;
-      prepare.BinaryElementwiseBroadcastPrepareHelper(input_shape, output_shape, input_shape);
+      ORT_RETURN_IF_ERROR(prepare.BinaryElementwiseBroadcastPrepareHelper(input_shape, output_shape, input_shape));
       Impl_Sub<CudaT>(prepare.output_rank_or_simple_broadcast,
                       &prepare.lhs_padded_strides,
                       reinterpret_cast<const CudaT*>(input.template Data<T>()),

--- a/orttraining/orttraining/training_ops/cuda/activation/activations_grad.cc
+++ b/orttraining/orttraining/training_ops/cuda/activation/activations_grad.cc
@@ -23,7 +23,7 @@ namespace cuda {
   template <>                                                                                                    \
   Status x<T>::ComputeInternal(OpKernelContext* context) const {                                                 \
     BinaryElementwisePreparation prepare;                                                                        \
-    Prepare(context, &prepare);                                                                                  \
+    ORT_RETURN_IF_ERROR(Prepare(context, &prepare));                                                             \
     CudaAsyncBuffer<Ctx##x> func_ctx(this, MakeFuncCtx(), 1);                                                    \
     if (!std::is_same<CtxNull, Ctx##x>::value) ORT_RETURN_IF_ERROR(func_ctx.CopyToGpu());                        \
     Impl_##x<typename ToCudaType<T>::MappedType>(                                                                \


### PR DESCRIPTION
**Description**
Check status of BinaryElementwise::Prepare(), UnaryElementwise::Prepare(), and BinaryElementwisePreparation::BinaryElementwiseBroadcastPrepareHelper() and fail on error.

**Motivation and Context**
Encountered a segmentation fault later on because the result of a failed operation was ignored. Now, at least there is a more helpful error message.