### PR TITLE
Codesign validator fixes

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu.yml
@@ -236,6 +236,8 @@ jobs:
     clean: all
   variables:
   - group: Dashboard_MySQL_Secret
+  - name: GDN_CODESIGN_TARGETDIRECTORY
+    value: '$(Build.BinariesDirectory)/nuget-artifact/final-package'
   pool: 'Win-CPU-2019'
   condition: and (succeeded(), and (${{ parameters.DoEsrp }}, eq(variables['Build.SourceBranch'], 'refs/heads/master')))
   dependsOn:

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
@@ -243,6 +243,9 @@ jobs:
   workspace:
     clean: all
   pool: 'Win-CPU-2019'
+  variables:
+  - name: GDN_CODESIGN_TARGETDIRECTORY
+    value: '$(Build.BinariesDirectory)/nuget-artifact/final-package'
   condition: and (succeeded(), and (${{ parameters.DoEsrp }}, eq(variables['Build.SourceBranch'], 'refs/heads/master')))
   dependsOn:
   - NuGet_Test_Win


### PR DESCRIPTION
**Description**: 

Set GDN_CODESIGN_TARGETDIRECTORY variable so that the validator can find the package.

**Motivation and Context**
- Why is this change required? What problem does it solve?

Currently the validator generates an error of :
"No available target files were found and the tool was set to fail under this condition"

- If it fixes an open issue, please link to the issue here.
