### PR TITLE
fixed a warning on an unreferenced local variable

### DIFF
--- a/onnxruntime/test/tvm/tvm_basic_test.cc
+++ b/onnxruntime/test/tvm/tvm_basic_test.cc
@@ -251,7 +251,7 @@ class FuseExecutionProviderX : public CPUExecutionProvider {
         tvm::TVMRetValue rvalue;
         try {
           evaluate_func_.CallPacked(tvm_args, &rvalue);
-        } catch (std::exception& ex) {
+        } catch (std::exception&) {
           return Status(common::ONNXRUNTIME, common::FAIL);  // TODO: Translate exception to error code
         }
         if (rvalue.type_code() != kNull) {


### PR DESCRIPTION
The warning prevented me from building the code with VS 2019,
because it was treated as an error.
