### PR TITLE
Fix broken Nuphar docker file by removing stale build options

### DIFF
--- a/dockerfiles/Dockerfile.nuphar
+++ b/dockerfiles/Dockerfile.nuphar
@@ -23,7 +23,7 @@ WORKDIR /
 
 RUN mkdir -p /onnxruntime/build && \
     pip3 install sympy packaging cpufeature jupyter && \
-    python3 /onnxruntime/tools/ci_build/build.py --build_dir /onnxruntime/build --config Release --build_shared_lib --skip_submodule_sync --build_wheel --parallel --use_nuphar --use_mklml --use_tvm --use_llvm && \
+    python3 /onnxruntime/tools/ci_build/build.py --build_dir /onnxruntime/build --config Release --build_shared_lib --skip_submodule_sync --build_wheel --parallel --use_nuphar --use_mklml && \
     rm -rf /tmp/* && \
     rm -rf /home/root/* && \
     pip3 install /onnxruntime/build/Release/dist/onnxruntime_nuphar-*.whl && \


### PR DESCRIPTION
**Description**: --use_tvm --use_llvm is not valid now

**Motivation and Context**
- To keep the Dockerfile.nuphar functional

