### PR TITLE
Add gcc/clang flags to make binary smaller

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -212,6 +212,15 @@ if(onnxruntime_MINIMAL_BUILD)
   add_compile_definitions(ORT_MINIMAL_BUILD)
   set(onnxruntime_REDUCED_OPS_BUILD ON)  # TODO Defaulting to ON. TBD if we should always do that.
   set(onnxruntime_DISABLE_RTTI ON)
+
+  if (MSVC)
+    # add MSVC specific flags to reduce build size here
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections")
+    # TODO: May need to use -dead_strip instead of --gc-sections for iOS(XCode)
+    add_link_options(-Wl,--gc-sections)
+  endif()
+
 endif()
 
 if(onnxruntime_DISABLE_RTTI)

--- a/onnxruntime/core/framework/execution_provider.cc
+++ b/onnxruntime/core/framework/execution_provider.cc
@@ -41,6 +41,8 @@ IExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
     }
   }
 #else
+  ORT_UNUSED_PARAMETER(graph);
+  ORT_UNUSED_PARAMETER(kernel_registries);
   ORT_NOT_IMPLEMENTED("IExecutionProvider::GetCapability is not supported in this build.");
 #endif
 

--- a/onnxruntime/core/framework/kernel_registry.cc
+++ b/onnxruntime/core/framework/kernel_registry.cc
@@ -292,7 +292,7 @@ Status KernelRegistry::TryFindKernel(const onnxruntime::Node& node,
 
   return Status(ONNXRUNTIME, FAIL, "Kernel not found");
 #else
-  ORT_THROW("Kernel hash must be provided in minimal build.")
+  ORT_THROW("Kernel hash must be provided in minimal build.");
 #endif
 }
 


### PR DESCRIPTION
**Description**: 
Add gcc/clang [flags](https://interrupt.memfault.com/blog/best-and-worst-gcc-clang-compiler-flags#-ffunction-sections--fdata-sections----gc-sections) to make binary smaller. ~10% reduction for Android baseline build (minimal build with no ops, no exceptions, no rtti).

Cleanup a couple of build errors.

**Motivation and Context**
Reduce binary size in minimal build.