### PR TITLE
Add this line to allow collection of AppSessionGuids

### DIFF
--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -275,6 +275,7 @@ void WindowsTelemetry::LogExecutionProviderEvent(LUID* adapterLuid) const {
 
   TraceLoggingWrite(telemetry_provider_handle,
                     "ExecutionProviderEvent",
+                    TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
                     TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                     TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
                     // Telemetry info


### PR DESCRIPTION
The ExecutionProvider event (which has adapterLuid info) doesn't have AppSessionGuids so adding this line will enable that.