### PR TITLE
Fix divide-by-zero for SSCE kernel when normalize factor is zero.

### DIFF
--- a/orttraining/orttraining/training_ops/cuda/loss/softmaxcrossentropy_impl.cu
+++ b/orttraining/orttraining/training_ops/cuda/loss/softmaxcrossentropy_impl.cu
@@ -100,11 +100,10 @@ __global__ void _SparseSoftmaxCrossEntropy(
     CUDA_LONG N,
     CUDA_LONG D) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(i, N);
-  CUDA_KERNEL_ASSERT(label_data[i] >= 0 && label_data[i] < D);
-  
-  if(*normalize_factor_data == 0){
+  CUDA_KERNEL_ASSERT(label_data[i] >= 0 && label_data[i] < D);  
+  if (*normalize_factor_data == 0) {
      output_data[i] = 0;
-  }else{
+  } else {
      output_data[i] = -log_prob_data[i * D + label_data[i]] / (*normalize_factor_data);
   }
 }
@@ -119,11 +118,10 @@ __global__ void _WeightedSparseSoftmaxCrossEntropy(
     CUDA_LONG N,
     CUDA_LONG D) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(i, N);
-  CUDA_KERNEL_ASSERT(label_data[i] >= 0 && label_data[i] < D);
-  
-  if(*normalize_factor_data == 0){
+  CUDA_KERNEL_ASSERT(label_data[i] >= 0 && label_data[i] < D);  
+  if (*normalize_factor_data == 0) {
       output_data[i] = 0;
-  }else{
+  } else {
       output_data[i] = -log_prob_data[i * D + label_data[i]] * weight_data[i] / (*normalize_factor_data);
   }
 }
@@ -184,12 +182,10 @@ __global__ void _SparseSoftmaxCrossEntropyGrad(
     CUDA_LONG D) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(i, N * D);
   int row = i / D;
-  int d = i % D;
-  
-  if(*normalize_factor == 0){
+  int d = i % D;  
+  if (*normalize_factor == 0) {
       output_data[i] = 0;
-  }else{
-
+  } else {
      output_data[i] = (*dY) * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
   }
 }
@@ -206,11 +202,10 @@ __global__ void _WeightedSparseSoftmaxCrossEntropyGrad(
     CUDA_LONG D) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(i, N * D);
   int row = i / D;
-  int d = i % D;
- 
-  if(*normalize_factor == 0){
+  int d = i % D; 
+  if (*normalize_factor == 0) {
       output_data[i] = 0;
-  }else{
+  } else {
     output_data[i] = (*dY) * weight[row] * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
   }
 }

--- a/orttraining/orttraining/training_ops/cuda/loss/softmaxcrossentropy_impl.cu
+++ b/orttraining/orttraining/training_ops/cuda/loss/softmaxcrossentropy_impl.cu
@@ -101,7 +101,12 @@ __global__ void _SparseSoftmaxCrossEntropy(
     CUDA_LONG D) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(i, N);
   CUDA_KERNEL_ASSERT(label_data[i] >= 0 && label_data[i] < D);
-  output_data[i] = -log_prob_data[i * D + label_data[i]] / (*normalize_factor_data);
+  
+  if(*normalize_factor_data == 0){
+     output_data[i] = 0;
+  }else{
+     output_data[i] = -log_prob_data[i * D + label_data[i]] / (*normalize_factor_data);
+  }
 }
 
 template <typename T, typename Tin>
@@ -115,7 +120,12 @@ __global__ void _WeightedSparseSoftmaxCrossEntropy(
     CUDA_LONG D) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(i, N);
   CUDA_KERNEL_ASSERT(label_data[i] >= 0 && label_data[i] < D);
-  output_data[i] = -log_prob_data[i * D + label_data[i]] * weight_data[i] / (*normalize_factor_data);
+  
+  if(*normalize_factor_data == 0){
+      output_data[i] = 0;
+  }else{
+      output_data[i] = -log_prob_data[i * D + label_data[i]] * weight_data[i] / (*normalize_factor_data);
+  }
 }
 
 template <typename T, typename Tin>
@@ -175,7 +185,13 @@ __global__ void _SparseSoftmaxCrossEntropyGrad(
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(i, N * D);
   int row = i / D;
   int d = i % D;
-  output_data[i] = (*dY) * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
+  
+  if(*normalize_factor == 0){
+      output_data[i] = 0;
+  }else{
+
+     output_data[i] = (*dY) * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
+  }
 }
 
 template <typename T, typename Tin>
@@ -191,7 +207,12 @@ __global__ void _WeightedSparseSoftmaxCrossEntropyGrad(
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(i, N * D);
   int row = i / D;
   int d = i % D;
-  output_data[i] = (*dY) * weight[row] * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
+ 
+  if(*normalize_factor == 0){
+      output_data[i] = 0;
+  }else{
+    output_data[i] = (*dY) * weight[row] * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
+  }
 }
 
 template <typename T, typename Tin>

--- a/orttraining/orttraining/training_ops/cuda/loss/softmaxcrossentropy_impl.cu
+++ b/orttraining/orttraining/training_ops/cuda/loss/softmaxcrossentropy_impl.cu
@@ -100,11 +100,11 @@ __global__ void _SparseSoftmaxCrossEntropy(
     CUDA_LONG N,
     CUDA_LONG D) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(i, N);
-  CUDA_KERNEL_ASSERT(label_data[i] >= 0 && label_data[i] < D);  
+  CUDA_KERNEL_ASSERT(label_data[i] >= 0 && label_data[i] < D);
   if (*normalize_factor_data == 0) {
-     output_data[i] = 0;
+    output_data[i] = 0;
   } else {
-     output_data[i] = -log_prob_data[i * D + label_data[i]] / (*normalize_factor_data);
+    output_data[i] = -log_prob_data[i * D + label_data[i]] / (*normalize_factor_data);
   }
 }
 
@@ -118,11 +118,11 @@ __global__ void _WeightedSparseSoftmaxCrossEntropy(
     CUDA_LONG N,
     CUDA_LONG D) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(i, N);
-  CUDA_KERNEL_ASSERT(label_data[i] >= 0 && label_data[i] < D);  
+  CUDA_KERNEL_ASSERT(label_data[i] >= 0 && label_data[i] < D);
   if (*normalize_factor_data == 0) {
-      output_data[i] = 0;
+    output_data[i] = 0;
   } else {
-      output_data[i] = -log_prob_data[i * D + label_data[i]] * weight_data[i] / (*normalize_factor_data);
+    output_data[i] = -log_prob_data[i * D + label_data[i]] * weight_data[i] / (*normalize_factor_data);
   }
 }
 
@@ -182,11 +182,11 @@ __global__ void _SparseSoftmaxCrossEntropyGrad(
     CUDA_LONG D) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(i, N * D);
   int row = i / D;
-  int d = i % D;  
+  int d = i % D;
   if (*normalize_factor == 0) {
-      output_data[i] = 0;
+    output_data[i] = 0;
   } else {
-     output_data[i] = (*dY) * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
+    output_data[i] = (*dY) * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
   }
 }
 
@@ -202,9 +202,9 @@ __global__ void _WeightedSparseSoftmaxCrossEntropyGrad(
     CUDA_LONG D) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(i, N * D);
   int row = i / D;
-  int d = i % D; 
+  int d = i % D;
   if (*normalize_factor == 0) {
-      output_data[i] = 0;
+    output_data[i] = 0;
   } else {
     output_data[i] = (*dY) * weight[row] * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
   }


### PR DESCRIPTION
**Description**: Sparse softmax cross-entropy kernal was returning NaNs when the input all the input tokens were masked causing the normalize_factor = 0. This caused NaNs in Email only domain adaptation pretraining for TNLR_v2 model.

**Motivation and Context**
- Added a check for the case when normalize_factor = 0.
