### PR TITLE
Enable TF32 for training on A100

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -226,15 +226,21 @@ inline bool CalculateFdmStrides(gsl::span<fast_divmod> p, const std::vector<int6
 class CublasMathModeSetter {
  public:
   CublasMathModeSetter(const cudaDeviceProp& prop,cublasHandle_t handle, cublasMath_t mode) : prop_(prop), handle_(handle) {
-    if (prop_.major >= 7) {
-      cublasGetMathMode(handle, &mode_);
+    cublasGetMathMode(handle, &mode_);
+#if defined(CUDA_VERSION) && CUDA_VERSION < 11000
+    if (prop.major >= 7 && mode == CUBLAS_TENSOR_OP_MATH) {
       cublasSetMathMode(handle, mode);
     }
-  }
-  ~CublasMathModeSetter() {
-    if (prop_.major >= 7) {
-      cublasSetMathMode(handle_, mode_);
+#endif
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
+    if (prop.major >= 8 && mode == CUBLAS_TF32_TENSOR_OP_MATH) {
+      cublasSetMathMode(handle, mode);
     }
+#endif
+  }
+
+  ~CublasMathModeSetter() {
+    cublasSetMathMode(handle_, mode_);
   }
 
  private:

--- a/onnxruntime/core/providers/cuda/shared_inc/fpgeneric.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/fpgeneric.h
@@ -29,7 +29,11 @@ inline cublasStatus_t cublasGemmHelper(cublasHandle_t handle,
                                        float* C, int ldc,
                                        const cudaDeviceProp& prop) {
 #ifdef ENABLE_TRAINING
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
   onnxruntime::cuda::CublasMathModeSetter math_mode_setter(prop, handle, CUBLAS_TF32_TENSOR_OP_MATH);
+#else
+  ORT_UNUSED_PARAMETER(prop);
+#endif
 #else
   ORT_UNUSED_PARAMETER(prop);
 #endif
@@ -119,7 +123,11 @@ inline cublasStatus_t cublasGemmBatchedHelper(cublasHandle_t handle,
                                               int batch_count,
                                               const cudaDeviceProp& prop) {
 #ifdef ENABLE_TRAINING
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
   onnxruntime::cuda::CublasMathModeSetter math_mode_setter(prop, handle, CUBLAS_TF32_TENSOR_OP_MATH);
+#else
+  ORT_UNUSED_PARAMETER(prop);
+#endif
 #else
   ORT_UNUSED_PARAMETER(prop);
 #endif
@@ -217,7 +225,11 @@ inline cublasStatus_t cublasGemmStridedBatchedHelper(cublasHandle_t handle,
                                                      int batch_count,
                                                      const cudaDeviceProp& prop) {
 #ifdef ENABLE_TRAINING
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
   onnxruntime::cuda::CublasMathModeSetter math_mode_setter(prop, handle, CUBLAS_TF32_TENSOR_OP_MATH);
+#else
+  ORT_UNUSED_PARAMETER(prop);
+#endif
 #else
   ORT_UNUSED_PARAMETER(prop);
 #endif

--- a/onnxruntime/core/providers/cuda/shared_inc/fpgeneric.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/fpgeneric.h
@@ -27,7 +27,13 @@ inline cublasStatus_t cublasGemmHelper(cublasHandle_t handle,
                                        const float* B, int ldb,
                                        const float* beta,
                                        float* C, int ldc,
-                                       const cudaDeviceProp& /*prop*/) {
+                                       const cudaDeviceProp& prop) {
+#ifdef ENABLE_TRAINING
+  onnxruntime::cuda::CublasMathModeSetter math_mode_setter(prop, handle, CUBLAS_TF32_TENSOR_OP_MATH);
+#else
+  ORT_UNUSED_PARAMETER(prop);
+#endif
+
   return cublasSgemm(handle,
                      transa,
                      transb,
@@ -111,7 +117,12 @@ inline cublasStatus_t cublasGemmBatchedHelper(cublasHandle_t handle,
                                               const float* beta,
                                               float* Carray[], int ldc,
                                               int batch_count,
-                                              const cudaDeviceProp& /*prop*/) {
+                                              const cudaDeviceProp& prop) {
+#ifdef ENABLE_TRAINING
+  onnxruntime::cuda::CublasMathModeSetter math_mode_setter(prop, handle, CUBLAS_TF32_TENSOR_OP_MATH);
+#else
+  ORT_UNUSED_PARAMETER(prop);
+#endif
   return cublasSgemmBatched(handle,
                             transa,
                             transb,
@@ -157,6 +168,7 @@ inline cublasStatus_t cublasGemmBatchedHelper(cublasHandle_t handle,
                                               int batch_count,
                                               const cudaDeviceProp& prop) {
   onnxruntime::cuda::CublasMathModeSetter math_mode_setter(prop, handle, CUBLAS_TENSOR_OP_MATH);
+
 #ifdef ENABLE_TRAINING
   float h_a = onnxruntime::math::halfToFloat(*reinterpret_cast<const uint16_t*>(alpha));
   float h_b = onnxruntime::math::halfToFloat(*reinterpret_cast<const uint16_t*>(beta));
@@ -203,7 +215,13 @@ inline cublasStatus_t cublasGemmStridedBatchedHelper(cublasHandle_t handle,
                                                      float* C, int ldc,
                                                      long long int strideC,
                                                      int batch_count,
-                                                     const cudaDeviceProp& /*prop*/) {
+                                                     const cudaDeviceProp& prop) {
+#ifdef ENABLE_TRAINING
+  onnxruntime::cuda::CublasMathModeSetter math_mode_setter(prop, handle, CUBLAS_TF32_TENSOR_OP_MATH);
+#else
+  ORT_UNUSED_PARAMETER(prop);
+#endif
+
   return cublasSgemmStridedBatched(handle,
                                    transa,
                                    transb,
@@ -257,6 +275,7 @@ inline cublasStatus_t cublasGemmStridedBatchedHelper(cublasHandle_t handle,
                                                      int batch_count,
                                                      const cudaDeviceProp& prop) {
   onnxruntime::cuda::CublasMathModeSetter math_mode_setter(prop, handle, CUBLAS_TENSOR_OP_MATH);
+
 #ifdef ENABLE_TRAINING
   float h_a = onnxruntime::math::halfToFloat(*reinterpret_cast<const uint16_t*>(alpha));
   float h_b = onnxruntime::math::halfToFloat(*reinterpret_cast<const uint16_t*>(beta));


### PR DESCRIPTION
It can be disabled by env: NVIDIA_TF32_OVERRIDE = 0
