### PR TITLE
Deprecate testMNISTTrainingAndTestingOpset10

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
+++ b/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
@@ -341,9 +341,6 @@ class TestOrtTrainer(unittest.TestCase):
         assert_allclose(expected_test_losses, actual_test_losses, rtol=rtol, err_msg="test loss mismatch")
         assert_allclose(expected_test_accuracies, actual_accuracies, rtol=rtol, err_msg="test accuracy mismatch")
 
-    def testMNISTTrainingAndTestingOpset10(self):
-        TestOrtTrainer.run_mnist_training_and_testing(onnx_opset_ver = 10)
-
     def testMNISTTrainingAndTestingOpset12(self):
         TestOrtTrainer.run_mnist_training_and_testing(onnx_opset_ver = 12)
 


### PR DESCRIPTION
**Description**: Describe your changes.
Deprecate testMNISTTrainingAndTestingOpset10
**Motivation and Context**
Officially only support models with opset >= 12 