### PR TITLE
wstring_convert std::codecvt_utf8 add ~200KB to inbox windows.ai.machinelearning.dll binary size 

### DIFF
--- a/winml/lib/Api.Ort/OnnxruntimeEngineBuilder.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngineBuilder.cpp
@@ -43,7 +43,7 @@ STDMETHODIMP OnnxruntimeEngineBuilder::CreateEngine(_winml::IEngine** out) {
   }
   if (named_dimension_overrides_) {
     for (const auto& override : named_dimension_overrides_) {
-      std::string narrow_name = _winml::Strings::UTF8FromHString(override.Key().c_str());
+      std::string narrow_name = _winml::Strings::UTF8FromHString(override.Key());
       ort_api->AddFreeDimensionOverrideByName(session_options.get(), narrow_name.c_str(), override.Value());
     }
   }

--- a/winml/lib/Api.Ort/OnnxruntimeEngineBuilder.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngineBuilder.cpp
@@ -43,7 +43,7 @@ STDMETHODIMP OnnxruntimeEngineBuilder::CreateEngine(_winml::IEngine** out) {
   }
   if (named_dimension_overrides_) {
     for (const auto& override : named_dimension_overrides_) {
-      std::string narrow_name = std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(override.Key().c_str());
+      std::string narrow_name = _winml::Strings::UTF8FromHString(override.Key().c_str());
       ort_api->AddFreeDimensionOverrideByName(session_options.get(), narrow_name.c_str(), override.Value());
     }
   }


### PR DESCRIPTION
Issue: wstring_convert std::codecvt_utf8 add ~200KB to inbox windows.ai.machinelearning.dll binary size.

Fix: Switch to helper api: _winml::Strings::UTF8FromHString