### PR TITLE
Include DirectML.pdb in the x86 leg of the Microsoft.ML.OnnxRuntime.DirectML package

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
@@ -191,7 +191,8 @@ jobs:
              move win-x86\runtimes\win-x86\native\onnxruntime.dll %%~ni\runtimes\win-x86\native\onnxruntime.dll
              move win-x86\runtimes\win-x86\native\onnxruntime.lib %%~ni\runtimes\win-x86\native\onnxruntime.lib
              move win-x86\runtimes\win-x86\native\onnxruntime.pdb %%~ni\runtimes\win-x86\native\onnxruntime.pdb
-             move win-x86\runtimes\win-x86\native\directml.dll %%~ni\runtimes\win-x86\native\directml.dll
+             move win-x86\runtimes\win-x86\native\directml.dll %%~ni\runtimes\win-x86\native\DirectML.dll
+             move win-x86\runtimes\win-x86\native\directml.pdb %%~ni\runtimes\win-x86\native\DirectML.pdb
 
              pushd %%~ni
              zip -r ..\%%~ni.zip .


### PR DESCRIPTION
**Description**: 

1) Include `DirectML.pdb` in the x86 leg of Microsoft.ML.OnnxRuntime.DirectML (x64 leg has it)
2) Fix casing of `DirectML.dll` in the x86 leg to be consistent with x64 leg (it is currently `directml.dll` in x86)

Noticed it and hence proposing the fix