### PR TITLE
update Dockerfile.openvino and Dockerfile.jetson

### DIFF
--- a/dockerfiles/Dockerfile.jetson
+++ b/dockerfiles/Dockerfile.jetson
@@ -23,8 +23,9 @@ RUN apt update && \
         libpython3.6-dev \
         python3-pip \
         python3-dev \
-	cmake
-
+        cmake \
+        unattended-upgrades
+RUN unattended-upgrade
 RUN pip3 install --upgrade pip
 RUN pip3 install setuptools
 RUN pip3 install wheel pybind11 pytest

--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -26,7 +26,8 @@ ENV LD_LIBRARY_PATH=${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/exte
 ENV LANG en_US.UTF-8
 
 RUN apt update && \
-    apt -y install apt-transport-https ca-certificates python3 python3-pip zip x11-apps lsb-core wget cpio sudo libboost-python-dev libpng-dev zlib1g-dev git libnuma1 ocl-icd-libopencl1 clinfo libboost-filesystem1.65-dev libboost-thread1.65-dev protobuf-compiler libprotoc-dev autoconf automake libtool libjson-c-dev && \
+    apt -y install apt-transport-https ca-certificates python3 python3-pip zip x11-apps lsb-core wget cpio sudo libboost-python-dev libpng-dev zlib1g-dev git libnuma1 ocl-icd-libopencl1 clinfo libboost-filesystem1.65-dev libboost-thread1.65-dev protobuf-compiler libprotoc-dev autoconf automake libtool libjson-c-dev unattended-upgrades && \
+    unattended-upgrade && \
     rm -rf /var/lib/apt/lists/*  && \
 # Install OpenVINO
     cd ${MY_ROOT} && \


### PR DESCRIPTION
follow up to https://github.com/microsoft/onnxruntime/pull/4804
Dockerfile.openvino and Dockerfile.jetson need to install and run unattended-upgrade to ensure latest security updates are installed. 
tested and confirmed security updates were installed (e.g. libc-bin 2.27-3ubuntu1.2) 