### PR TITLE
make (de)tensorization events measure level events

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -367,6 +367,7 @@ target_include_directories(winml_lib_image PRIVATE ${ONNXRUNTIME_INCLUDE_DIR})  
 target_include_directories(winml_lib_image PRIVATE ${REPO_ROOT}/cmake/external/gsl/include)
 target_include_directories(winml_lib_image PRIVATE ${REPO_ROOT}/cmake/external/onnx)
 target_include_directories(winml_lib_image PRIVATE ${REPO_ROOT}/cmake/external/protobuf/src)
+target_include_directories(winml_lib_image PRIVATE ${ONNXRUNTIME_INCLUDE_DIR}/core/platform/windows)
 
 # Properties
 set_target_properties(winml_lib_image

--- a/winml/lib/Api.Image/EventTimer.h
+++ b/winml/lib/Api.Image/EventTimer.h
@@ -24,6 +24,6 @@ public:
 private:
   bool _started = false;
   std::chrono::steady_clock::time_point _startTime;
-  constexpr static long long _kDurationBetweenSendingEvents = 1000 * 50;  // duration in (us). send a EvaluationStop Event every 50 ms;
+  constexpr static long long _kDurationBetweenSendingEvents = 1000 * 50;  // duration in (us). send an Event every 50 ms;
 };
 

--- a/winml/lib/Api.Image/EventTimer.h
+++ b/winml/lib/Api.Image/EventTimer.h
@@ -3,10 +3,6 @@
 class EventTimer
 {
 public:
-  EventTimer()
-  {
-  }
-  
   bool Start()
   {
     auto now = std::chrono::high_resolution_clock::now();

--- a/winml/lib/Api.Image/EventTimer.h
+++ b/winml/lib/Api.Image/EventTimer.h
@@ -1,0 +1,30 @@
+#include "pch.h"
+
+class EventTimer
+{
+public:
+  EventTimer(long long durationInMicroSeconds)
+    : _durationInMicroSeconds(durationInMicroSeconds)
+  {
+  }
+  
+  bool Start()
+  {
+    auto now = std::chrono::high_resolution_clock::now();
+    if (!_started || 
+         std::chrono::duration_cast<std::chrono::microseconds>(now - _startTime).count() > _durationInMicroSeconds)
+    {
+      _started = true;
+      _startTime = std::chrono::high_resolution_clock::now();
+      return true;
+    }
+
+    return false;
+  }
+
+private:
+  bool _started = false;
+  long long _durationInMicroSeconds;
+  std::chrono::steady_clock::time_point _startTime;
+};
+

--- a/winml/lib/Api.Image/EventTimer.h
+++ b/winml/lib/Api.Image/EventTimer.h
@@ -3,8 +3,7 @@
 class EventTimer
 {
 public:
-  EventTimer(long long durationInMicroSeconds)
-    : _durationInMicroSeconds(durationInMicroSeconds)
+  EventTimer()
   {
   }
   
@@ -12,7 +11,7 @@ public:
   {
     auto now = std::chrono::high_resolution_clock::now();
     if (!_started || 
-         std::chrono::duration_cast<std::chrono::microseconds>(now - _startTime).count() > _durationInMicroSeconds)
+         std::chrono::duration_cast<std::chrono::microseconds>(now - _startTime).count() > _kDurationBetweenSendingEvents)
     {
       _started = true;
       _startTime = std::chrono::high_resolution_clock::now();
@@ -24,7 +23,7 @@ public:
 
 private:
   bool _started = false;
-  long long _durationInMicroSeconds;
   std::chrono::steady_clock::time_point _startTime;
+  constexpr static long long _kDurationBetweenSendingEvents = 1000 * 50;  // duration in (us). send a EvaluationStop Event every 50 ms;
 };
 

--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -5,6 +5,7 @@
 
 #include <winmeta.h>  // winmeta needed for TraceLoggingKeyword
 #include <TraceLoggingProvider.h>
+#include <TraceloggingConfig.h>
 #include <evntrace.h>
 #include <MemoryBuffer.h>
 
@@ -31,7 +32,9 @@ class GPUTensorToDX12TextureTelemetryEvent {
         TraceLoggingOpcode(EVENT_TRACE_TYPE_START),
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
-        TraceLoggingInt64(tensorDesc.sizes[3], "Width"));
+        TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
   ~GPUTensorToDX12TextureTelemetryEvent() {
     TraceLoggingWrite(
@@ -39,7 +42,9 @@ class GPUTensorToDX12TextureTelemetryEvent {
         "GPUTensorToDX12Texture",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
         TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
-        TraceLoggingHexInt32(S_OK, "HRESULT"));
+        TraceLoggingHexInt32(S_OK, "HRESULT"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
 };
 
@@ -53,7 +58,9 @@ class ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent {
         TraceLoggingOpcode(EVENT_TRACE_TYPE_START),
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
-        TraceLoggingInt64(tensorDesc.sizes[3], "Width"));
+        TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
   ~ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent() {
     TraceLoggingWrite(
@@ -61,7 +68,9 @@ class ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent {
         "ConvertCPUTensorToVideoFrameWithSoftwareBitmap",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
         TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
-        TraceLoggingHexInt32(S_OK, "HRESULT"));
+        TraceLoggingHexInt32(S_OK, "HRESULT"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
 };
 

--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -381,12 +381,11 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
   CD3DX12_RECT scissorRect(0, 0, (LONG)outputDesc.Width, outputDesc.Height);
   ComPtr<ID3D12Device> spDx12Device = device_cache.GetD3D12Device();
 
-
-  std::unique_ptr<GPUTensorToDX12TextureTelemetryEvent> telemetryLogger;
   // we're inside a lock from the caller of this function, so it's ok to use this static
   static EventTimer eventTimer;
+  std::optional<GPUTensorToDX12TextureTelemetryEvent> telemetryLogger;
   if (eventTimer.Start()) {
-    telemetryLogger = std::make_unique<GPUTensorToDX12TextureTelemetryEvent>(tensorDesc);
+    telemetryLogger.emplace(tensorDesc);
   }
 
   WINML_THROW_HR_IF_FALSE_MSG(
@@ -532,11 +531,11 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToSoftwareBitmap(
   assert(pInputTensor != nullptr);
   assert(softwareBitmap != nullptr);
 
-  std::unique_ptr<ConvertGPUTensorToSoftwareBitmapTelemetryEvent> telemetryLogger;
   // we're inside a lock from the caller of this function, so it's ok to use this static
   static EventTimer eventTimer;
+  std::optional<ConvertGPUTensorToSoftwareBitmapTelemetryEvent> telemetryLogger;
   if (eventTimer.Start()) {
-    telemetryLogger = std::make_unique<ConvertGPUTensorToSoftwareBitmapTelemetryEvent>(tensorDesc);
+    telemetryLogger.emplace(tensorDesc);
   }
 
   uint32_t tensorElementSize = tensorDesc.dataType == kImageTensorDataTypeFloat32 ? 4 : 2;
@@ -617,11 +616,11 @@ void TensorToVideoFrameConverter::ConvertCPUTensorToSoftwareBitmap(
     _In_ const ImageTensorDescription& tensorDesc,
     _Inout_ wgi::SoftwareBitmap& softwareBitmap) {
 
-  std::unique_ptr<ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent> telemetryLogger;
   // we're inside a lock from the caller of this function, so it's ok to use this static
   static EventTimer eventTimer;
+  std::optional<ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent> telemetryLogger;
   if (eventTimer.Start()) {
-    telemetryLogger = std::make_unique<ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent>(tensorDesc);
+    telemetryLogger.emplace(tensorDesc);
   }
 
   auto height = softwareBitmap.PixelHeight();

--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -48,6 +48,32 @@ class GPUTensorToDX12TextureTelemetryEvent {
   }
 };
 
+class ConvertGPUTensorToSoftwareBitmapTelemetryEvent {
+ public:
+  ConvertGPUTensorToSoftwareBitmapTelemetryEvent(const ImageTensorDescription& tensorDesc) {
+    TraceLoggingWrite(
+        winml_trace_logging_provider,
+        "GPUTensorToDX12Texture",
+        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+        TraceLoggingOpcode(EVENT_TRACE_TYPE_START),
+        TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
+        TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
+        TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+  }
+  ~ConvertGPUTensorToSoftwareBitmapTelemetryEvent() {
+    TraceLoggingWrite(
+        winml_trace_logging_provider,
+        "GPUTensorToDX12Texture",
+        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+        TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
+        TraceLoggingHexInt32(S_OK, "HRESULT"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+  }
+};
+
 class ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent {
  public:
   ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent(const ImageTensorDescription& tensorDesc) {
@@ -506,11 +532,11 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToSoftwareBitmap(
   assert(pInputTensor != nullptr);
   assert(softwareBitmap != nullptr);
 
-  std::unique_ptr<GPUTensorToDX12TextureTelemetryEvent> telemetryLogger;
+  std::unique_ptr<ConvertGPUTensorToSoftwareBitmapTelemetryEvent> telemetryLogger;
   // we're inside a lock from the caller of this function, so it's ok to use this static
   static EventTimer eventTimer;
   if (eventTimer.Start()) {
-    telemetryLogger = std::make_unique<GPUTensorToDX12TextureTelemetryEvent>(tensorDesc);
+    telemetryLogger = std::make_unique<ConvertGPUTensorToSoftwareBitmapTelemetryEvent>(tensorDesc);
   }
 
   uint32_t tensorElementSize = tensorDesc.dataType == kImageTensorDataTypeFloat32 ? 4 : 2;

--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -53,7 +53,7 @@ class ConvertGPUTensorToSoftwareBitmapTelemetryEvent {
   ConvertGPUTensorToSoftwareBitmapTelemetryEvent(const ImageTensorDescription& tensorDesc) {
     TraceLoggingWrite(
         winml_trace_logging_provider,
-        "GPUTensorToDX12Texture",
+        "ConvertGPUTensorToSoftwareBitmap",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
         TraceLoggingOpcode(EVENT_TRACE_TYPE_START),
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
@@ -65,7 +65,7 @@ class ConvertGPUTensorToSoftwareBitmapTelemetryEvent {
   ~ConvertGPUTensorToSoftwareBitmapTelemetryEvent() {
     TraceLoggingWrite(
         winml_trace_logging_provider,
-        "GPUTensorToDX12Texture",
+        "ConvertGPUTensorToSoftwareBitmap",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
         TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
         TraceLoggingHexInt32(S_OK, "HRESULT"),

--- a/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
+++ b/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
@@ -5,6 +5,7 @@
 
 #include <winmeta.h>  // winmeta needed for TraceLoggingKeyword
 #include <TraceLoggingProvider.h>
+#include <TraceloggingConfig.h>
 #include <evntrace.h>
 #include <MemoryBuffer.h>
 
@@ -29,7 +30,9 @@ class DX12TextureToGPUTensorTelemetryEvent {
         TraceLoggingOpcode(EVENT_TRACE_TYPE_START),
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
-        TraceLoggingInt64(tensorDesc.sizes[3], "Width"));
+        TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
   ~DX12TextureToGPUTensorTelemetryEvent() {
     TraceLoggingWrite(
@@ -37,7 +40,9 @@ class DX12TextureToGPUTensorTelemetryEvent {
         "DX12TextureToGPUTensor",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
         TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
-        TraceLoggingHexInt32(S_OK, "HRESULT"));
+        TraceLoggingHexInt32(S_OK, "HRESULT"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
 };
 
@@ -51,7 +56,9 @@ class ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent {
         TraceLoggingOpcode(EVENT_TRACE_TYPE_START),
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
-        TraceLoggingInt64(tensorDesc.sizes[3], "Width"));
+        TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
   ~ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent() {
     TraceLoggingWrite(
@@ -59,7 +66,9 @@ class ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent {
         "ConvertVideoFrameWithSoftwareBitmapToCPUTensor",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
         TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
-        TraceLoggingHexInt32(S_OK, "HRESULT"));
+        TraceLoggingHexInt32(S_OK, "HRESULT"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
 };
 

--- a/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
+++ b/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
@@ -308,7 +308,7 @@ void VideoFrameToTensorConverter::ConvertDX12TextureToGPUTensor(
   // we're inside a lock from the caller of this function, so it's ok to use this static
   static EventTimer eventTimer(kDurationBetweenSendingEvaluationStart);
   if (eventTimer.Start()) {
-    telemetrylogger = std::make_unique<DX12TextureToGPUTensorTelemetryEvent>(tensorDesc);
+    telemetryLogger = std::make_unique<DX12TextureToGPUTensorTelemetryEvent>(tensorDesc);
   }
 
   // Validate input description
@@ -477,7 +477,7 @@ void VideoFrameToTensorConverter::ConvertSoftwareBitmapToGPUTensor(
   // we're inside a lock from the caller of this function, so it's ok to use this static
   static EventTimer eventTimer(kDurationBetweenSendingEvaluationStart);
   if (eventTimer.Start()) {
-    telemetrylogger = std::make_unique<SoftwareBitmapToGPUTensorTelemetryEvent>(tensorDesc);
+    telemetryLogger = std::make_unique<SoftwareBitmapToGPUTensorTelemetryEvent>(tensorDesc);
   }
 
   wgi::SoftwareBitmap convertedSoftwareBitmap = nullptr;
@@ -587,12 +587,12 @@ void VideoFrameToTensorConverter::ConvertSoftwareBitmapToCPUTensor(
     _Inout_ void* pCPUTensor) {
   assert(softwareBitmap != nullptr);
 
-  std::unique_ptr<ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent> telemetrylogger;
+  std::unique_ptr<ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent> telemetryLogger;
 
   // we're inside a lock from the caller of this function, so it's ok to use this static
   static EventTimer eventTimer(kDurationBetweenSendingEvaluationStart);
   if (eventTimer.Start()) {
-    telemetrylogger = std::make_unique<ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent>(tensorDesc);
+    telemetryLogger = std::make_unique<ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent>(tensorDesc);
   }
 
   auto height = softwareBitmap.PixelHeight();

--- a/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
+++ b/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
@@ -280,7 +280,7 @@ void VideoFrameToTensorConverter::ConvertDX12TextureToGPUTensor(
 
   std::unique_ptr<DX12TextureToGPUTensorTelemetryEvent> telemetryLogger;
   // we're inside a lock from the caller of this function, so it's ok to use this static
-  static EventTimer eventTimer(kDurationBetweenSendingEvaluationStart);
+  static EventTimer eventTimer;
   if (eventTimer.Start()) {
     telemetryLogger = std::make_unique<DX12TextureToGPUTensorTelemetryEvent>(tensorDesc);
   }
@@ -449,7 +449,7 @@ void VideoFrameToTensorConverter::ConvertSoftwareBitmapToGPUTensor(
 
   std::unique_ptr<SoftwareBitmapToGPUTensorTelemetryEvent> telemetryLogger;
   // we're inside a lock from the caller of this function, so it's ok to use this static
-  static EventTimer eventTimer(kDurationBetweenSendingEvaluationStart);
+  static EventTimer eventTimer;
   if (eventTimer.Start()) {
     telemetryLogger = std::make_unique<SoftwareBitmapToGPUTensorTelemetryEvent>(tensorDesc);
   }
@@ -564,7 +564,7 @@ void VideoFrameToTensorConverter::ConvertSoftwareBitmapToCPUTensor(
   std::unique_ptr<ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent> telemetryLogger;
 
   // we're inside a lock from the caller of this function, so it's ok to use this static
-  static EventTimer eventTimer(kDurationBetweenSendingEvaluationStart);
+  static EventTimer eventTimer;
   if (eventTimer.Start()) {
     telemetryLogger = std::make_unique<ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent>(tensorDesc);
   }

--- a/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
+++ b/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
@@ -278,11 +278,11 @@ void VideoFrameToTensorConverter::ConvertDX12TextureToGPUTensor(
   D3D12_RESOURCE_DESC outputDesc = pOutputResource->GetDesc();
   ComPtr<ID3D12Device> spDx12Device = device_cache.GetD3D12Device();
 
-  std::unique_ptr<DX12TextureToGPUTensorTelemetryEvent> telemetryLogger;
   // we're inside a lock from the caller of this function, so it's ok to use this static
   static EventTimer eventTimer;
+  std::optional<DX12TextureToGPUTensorTelemetryEvent> telemetryLogger;
   if (eventTimer.Start()) {
-    telemetryLogger = std::make_unique<DX12TextureToGPUTensorTelemetryEvent>(tensorDesc);
+    telemetryLogger.emplace(tensorDesc);
   }
 
   // Validate input description
@@ -447,11 +447,11 @@ void VideoFrameToTensorConverter::ConvertSoftwareBitmapToGPUTensor(
   assert(pOutputResource != nullptr);
   assert(videoFrame.SoftwareBitmap() != nullptr);
 
-  std::unique_ptr<SoftwareBitmapToGPUTensorTelemetryEvent> telemetryLogger;
   // we're inside a lock from the caller of this function, so it's ok to use this static
   static EventTimer eventTimer;
+  std::optional<SoftwareBitmapToGPUTensorTelemetryEvent> telemetryLogger;
   if (eventTimer.Start()) {
-    telemetryLogger = std::make_unique<SoftwareBitmapToGPUTensorTelemetryEvent>(tensorDesc);
+    telemetryLogger.emplace(tensorDesc);
   }
 
   wgi::SoftwareBitmap convertedSoftwareBitmap = nullptr;
@@ -561,12 +561,11 @@ void VideoFrameToTensorConverter::ConvertSoftwareBitmapToCPUTensor(
     _Inout_ void* pCPUTensor) {
   assert(softwareBitmap != nullptr);
 
-  std::unique_ptr<ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent> telemetryLogger;
-
   // we're inside a lock from the caller of this function, so it's ok to use this static
   static EventTimer eventTimer;
+  std::optional<ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent> telemetryLogger;
   if (eventTimer.Start()) {
-    telemetryLogger = std::make_unique<ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent>(tensorDesc);
+    telemetryLogger.emplace(tensorDesc);
   }
 
   auto height = softwareBitmap.PixelHeight();

--- a/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
+++ b/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
@@ -14,38 +14,12 @@
 #include "inc/D3DDeviceCache.h"
 
 #include "LearningModelDevice.h"
+#include "EventTimer.h"
 
 using namespace Microsoft::WRL;
 using namespace Windows::Graphics::DirectX::Direct3D11;
 
 using namespace _winml;
-
-class EventTimer
-{public:
-  EventTimer(long long durationInMicroSeconds)
-    : _durationInMicroSeconds(durationInMicroSeconds)
-  {
-  }
-  
-  bool Start()
-  {
-    auto now = std::chrono::high_resolution_clock::now();
-    if (!_started || 
-         std::chrono::duration_cast<std::chrono::microseconds>(now - _startTime).count() > _durationInMicroSeconds)
-    {
-      _started = true;
-      _startTime = std::chrono::high_resolution_clock::now();
-      return true;
-    }
-
-    return false;
-  }
-
-private:
-  bool _started = false;
-  long long _durationInMicroSeconds;
-  std::chrono::steady_clock::time_point _startTime;
-};
 
 class DX12TextureToGPUTensorTelemetryEvent {
  public:

--- a/winml/lib/Api.Image/inc/VideoFrameToTensorConverter.h
+++ b/winml/lib/Api.Image/inc/VideoFrameToTensorConverter.h
@@ -90,7 +90,5 @@ class VideoFrameToTensorConverter : IVideoFrameToTensorConverter, public ImageCo
       _In_ const ImageTensorDescription& tensor_description,
       _In_ const wgi::BitmapBounds& input_bounds,
       _Inout_ void* CPU_tensor);
-
-    constexpr static long long kDurationBetweenSendingEvaluationStart = 1000 * 50;  // duration in (us). send a EvaluationStop Event every 50 ms;
 };
 }  // namespace _winml

--- a/winml/lib/Api.Image/inc/VideoFrameToTensorConverter.h
+++ b/winml/lib/Api.Image/inc/VideoFrameToTensorConverter.h
@@ -90,5 +90,7 @@ class VideoFrameToTensorConverter : IVideoFrameToTensorConverter, public ImageCo
       _In_ const ImageTensorDescription& tensor_description,
       _In_ const wgi::BitmapBounds& input_bounds,
       _Inout_ void* CPU_tensor);
+
+    constexpr static long long kDurationBetweenSendingEvaluationStart = 1000 * 50;  // duration in (us). send a EvaluationStop Event every 50 ms;
 };
 }  // namespace _winml


### PR DESCRIPTION
We want to track usage of (de)tensorization events, so we need to change them from telemetry to measures. Because they'll be sending events now, we want to make sure they aren't sending too frequently, like we do with the runtimePerf event. So I copied the logic from the runtimePerf event and only send the (de)tensorization events at most once every 50 microseconds. 

Also, two of the events were sharing names with other events, so I made new events to de-duplicate the usages.