### PR TITLE
Add flag to _internal_use to control export of contrib ops in ort trainer

### DIFF
--- a/orttraining/orttraining/python/experimental/orttrainer.py
+++ b/orttraining/orttraining/python/experimental/orttrainer.py
@@ -475,9 +475,14 @@ class ORTTrainer(object):
         # Deepcopy inputs, since input values may change after model run.
         sample_inputs_copy = copy.deepcopy(sample_inputs)
 
-        # Enable contrib ops export from PyTorch
         from onnxruntime.experimental import register_custom_ops_pytorch_exporter
-        register_custom_ops_pytorch_exporter.register_custom_op()
+        if self.options._internal_use.enable_onnx_contrib_ops:
+            # Enable contrib ops export from PyTorch
+            register_custom_ops_pytorch_exporter.register_custom_op()
+        else:
+            # unregister contrib ops, if they were registered in previous calls
+            register_custom_ops_pytorch_exporter.unregister_custom_op()
+
 
         torch.onnx._export(model, tuple(sample_inputs_copy), f,
                            input_names=[input.name for input in self.model_desc.inputs],

--- a/orttraining/orttraining/python/experimental/orttrainer_options.py
+++ b/orttraining/orttraining/python/experimental/orttrainer_options.py
@@ -236,7 +236,6 @@ class ORTTrainerOptions(object):
             ONNX opset version used during model exporting.
         _internal_use.enable_onnx_contrib_ops (bool, default is True)
             enable PyTorch to export nodes as contrib ops in ONNX.
-            Note: this flag is only effective at the first run of train_step/eval_step.
             This flag may be removed anytime in the future.
 
     Example:

--- a/orttraining/orttraining/python/experimental/orttrainer_options.py
+++ b/orttraining/orttraining/python/experimental/orttrainer_options.py
@@ -165,6 +165,10 @@ class ORTTrainerOptions(object):
                             'min' : 10,
                             'max' : 12,
                             'default': 12
+                        },
+                        'enable_onnx_contrib_ops' : {
+                            'type' : 'boolean',
+                            'default' : True
                         }
                     }
                 }
@@ -230,6 +234,10 @@ class ORTTrainerOptions(object):
             It does not override :py:attr:`._internal_use.enable_internal_postprocess`, but complement it
         _internal_use.onnx_opset_version (int, default is 12):
             ONNX opset version used during model exporting.
+        _internal_use.enable_onnx_contrib_ops (bool, default is True)
+            enable PyTorch to export nodes as contrib ops in ONNX.
+            Note: this flag is only effective at the first run of train_step/eval_step.
+            This flag may be removed anytime in the future.
 
     Example:
         .. code-block:: python
@@ -464,6 +472,10 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
                 'min' : 10,
                 'max' : 12,
                 'default': 12
+            },
+            'enable_onnx_contrib_ops' : {
+                'type' : 'boolean',
+                'default' : True
             }
         }
     }

--- a/tools/python/register_custom_ops_pytorch_exporter.py
+++ b/tools/python/register_custom_ops_pytorch_exporter.py
@@ -33,3 +33,21 @@ def register_custom_op():
     register_custom_op_symbolic('::gelu', gelu, _onnx_opset_version)
     register_custom_op_symbolic('::triu', triu, _onnx_opset_version)
     register_custom_op_symbolic('::tril', tril, _onnx_opset_version)
+
+def unregister_custom_op():
+    """
+    This function unregisters symbolic functions for
+    custom ops that are implemented as part of ONNX Runtime
+    """
+
+    import torch.onnx.symbolic_registry as sym_registry
+
+    def unregister(name, opset_version):
+        ns, kind = name.split("::")
+        if sym_registry.is_registered_op(kind, ns, opset_version):
+            del sym_registry._registry[(ns, opset_version)][kind]
+
+    unregister('::inverse', _onnx_opset_version)
+    unregister('::gelu', _onnx_opset_version)
+    unregister('::triu', _onnx_opset_version)
+    unregister('::tril', _onnx_opset_version)

--- a/tools/python/register_custom_ops_pytorch_exporter.py
+++ b/tools/python/register_custom_ops_pytorch_exporter.py
@@ -34,6 +34,7 @@ def register_custom_op():
     register_custom_op_symbolic('::triu', triu, _onnx_opset_version)
     register_custom_op_symbolic('::tril', tril, _onnx_opset_version)
 
+
 def unregister_custom_op():
     """
     This function unregisters symbolic functions for


### PR DESCRIPTION
Add `enable_onnx_contrib_ops` flag to `_internal_use` to control if PyTorch should export contrib ops in ort trainer.

This flag may be removed anytime in the future.