### PR TITLE
Fix Nuget GPU pipeline on DML License in nuget package

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -288,7 +288,7 @@ def generate_files(list, args):
                           '" target="runtimes\\win-' + args.target_architecture + '\\native" />')
         files_list.append('<file src=' + '"' + os.path.join(args.native_build_path, 'DirectML.pdb') +
                           '" target="runtimes\\win-' + args.target_architecture + '\\native" />')
-        files_list.append('<file src=' + '"' + os.path.join(args.packages_path, 'DirectML.2.1.1\\LICENSE.txt') +
+        files_list.append('<file src=' + '"' + os.path.join(args.packages_path, 'DirectML.3.0.0\\LICENSE.txt') +
                           '" target="DirectML_LICENSE.txt" />')
 
     if includes_winml:


### PR DESCRIPTION
**Description**: Fix Nuget packaging generation for DML license file.

**Motivation and Context**
- _Why is this change required? What problem does it solve?_
Breaks pipeline.
