### PR TITLE
Fix a warning in global_thread_pools/test_inference.cc

### DIFF
--- a/onnxruntime/core/optimizer/utils.cc
+++ b/onnxruntime/core/optimizer/utils.cc
@@ -139,7 +139,7 @@ bool IsAttributeWithExpectedValue(const Node& node, const std::string& attr_name
 bool IsAttributeWithExpectedValue(const Node& node, const std::string& attr_name, float expected_value, float eps) {
   const auto* attr_proto = graph_utils::GetNodeAttribute(node, attr_name);
   if ((nullptr != attr_proto) && attr_proto->has_f()) {
-    return abs(attr_proto->f() - expected_value) < eps;
+    return std::abs(attr_proto->f() - expected_value) < eps;
   }
   return false;
 }

--- a/onnxruntime/test/global_thread_pools/test_inference.cc
+++ b/onnxruntime/test/global_thread_pools/test_inference.cc
@@ -57,7 +57,7 @@ static void RunSession(OrtAllocator& allocator, Ort::Session& session_object,
 
   OutT* f = output_tensor->GetTensorMutableData<OutT>();
   for (size_t i = 0; i != static_cast<size_t>(5); ++i) {
-    ASSERT_TRUE(std::abs(values_y[i] - f[i]) < 1e-6);
+    ASSERT_NEAR(values_y[i], f[i], 1e-6f);
   }
 }
 


### PR DESCRIPTION
**Description**: 
Fix a warning in global_thread_pools/test_inference.cc

**Motivation and Context**
- Why is this change required? What problem does it solve?

Resolve  #4910


- If it fixes an open issue, please link to the issue here.
