### PR TITLE
Remove public default ctor in PyInferenceSession and replace it with a protected ctor

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state_common.h
+++ b/onnxruntime/python/onnxruntime_pybind_state_common.h
@@ -42,9 +42,6 @@ struct PySessionOptions : public SessionOptions {
 
 // Thin wrapper over internal C++ InferenceSession to accommodate custom op library management for the Python user
 struct PyInferenceSession {
-  // Default ctor is present only to be invoked by the PyTrainingSession class
-  PyInferenceSession() {}
-
   PyInferenceSession(Environment& env, const PySessionOptions& so, const std::string& arg, bool is_arg_file_name) {
     if (is_arg_file_name) {
       // Given arg is the file path. Invoke the corresponding ctor().
@@ -70,6 +67,9 @@ struct PyInferenceSession {
   virtual ~PyInferenceSession() {}
 
  protected:
+  // Default ctor is will be invoked by the PyTrainingSession class
+  PyInferenceSession() {}
+
   // Hold CustomOpLibrary resources so as to tie it to the life cycle of the InferenceSession needing it.
   // NOTE: Declare this above `sess_` so that this is destructed AFTER the InferenceSession instance -
   // this is so that the custom ops held by the InferenceSession gets destroyed prior to the library getting unloaded

--- a/onnxruntime/python/onnxruntime_pybind_state_common.h
+++ b/onnxruntime/python/onnxruntime_pybind_state_common.h
@@ -67,8 +67,9 @@ struct PyInferenceSession {
   virtual ~PyInferenceSession() {}
 
  protected:
-  // Default ctor is will be invoked by the PyTrainingSession class
-  PyInferenceSession() {}
+  PyInferenceSession(std::unique_ptr<InferenceSession> sess) {
+    sess_ = std::move(sess);
+  }
 
   // Hold CustomOpLibrary resources so as to tie it to the life cycle of the InferenceSession needing it.
   // NOTE: Declare this above `sess_` so that this is destructed AFTER the InferenceSession instance -

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -206,9 +206,8 @@ void addObjectMethodsForTraining(py::module& m) {
 
   // Thin wrapper over internal C++ InferenceSession to accommodate custom op library management for the Python user
   struct PyTrainingSession : public PyInferenceSession {
-    PyTrainingSession(Environment& env, const PySessionOptions& so) {
-      // `sess_` is inherited from PyinferenceSession
-      sess_ = onnxruntime::make_unique<onnxruntime::training::TrainingSession>(so, env);
+    PyTrainingSession(Environment& env, const PySessionOptions& so)
+        : PyInferenceSession(onnxruntime::make_unique<TrainingSession>(so, env)) {
     }
   };
 


### PR DESCRIPTION
The public default ctor existed to be invoked by the derived PyTrainingSession ctor but it can instead invoke a protected ctor. 
