### PR TITLE
Remove evaluate telemetry due to redundancy

### DIFF
--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -127,8 +127,7 @@ void WindowsTelemetry::LogEvaluationStop() const {
     return;
 
   TraceLoggingWrite(telemetry_provider_handle,
-                    "EvaluationStop",
-                    TraceLoggingBool(true, "UTCReplace_AppSessionGuid"));
+                    "EvaluationStop");
 }
 
 void WindowsTelemetry::LogEvaluationStart() const {
@@ -136,8 +135,7 @@ void WindowsTelemetry::LogEvaluationStart() const {
     return;
 
   TraceLoggingWrite(telemetry_provider_handle,
-                    "EvaluationStart",
-                    TraceLoggingBool(true, "UTCReplace_AppSessionGuid"));
+                    "EvaluationStart");
 }
 
 void WindowsTelemetry::LogSessionCreation(uint32_t session_id, int64_t ir_version, const std::string& model_producer_name,

--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -128,9 +128,7 @@ void WindowsTelemetry::LogEvaluationStop() const {
 
   TraceLoggingWrite(telemetry_provider_handle,
                     "EvaluationStop",
-                    TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-                    TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-                    TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+                    TraceLoggingBool(true, "UTCReplace_AppSessionGuid"));
 }
 
 void WindowsTelemetry::LogEvaluationStart() const {
@@ -139,9 +137,7 @@ void WindowsTelemetry::LogEvaluationStart() const {
 
   TraceLoggingWrite(telemetry_provider_handle,
                     "EvaluationStart",
-                    TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-                    TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-                    TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+                    TraceLoggingBool(true, "UTCReplace_AppSessionGuid"));
 }
 
 void WindowsTelemetry::LogSessionCreation(uint32_t session_id, int64_t ir_version, const std::string& model_producer_name,

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1133,14 +1133,8 @@ Status InferenceSession::Run(const RunOptions& run_options,
       return Status(common::ONNXRUNTIME, common::FAIL, "Session not initialized.");
     }
 
-    // check the frequency to send Evalutaion Stop event
-    if (TimeDiffMicroSeconds(telemetry_.time_sent_last_evalutation_start_) >
-        telemetry_.kDurationBetweenSendingEvaluationStart) {
-      env.GetTelemetryProvider().LogEvaluationStart();
-      // reset counters
-      telemetry_.time_sent_last_evalutation_start_ = std::chrono::high_resolution_clock::now();
-      telemetry_.isEvaluationStart = true;
-    }
+    env.GetTelemetryProvider().LogEvaluationStart();
+
 
     ORT_RETURN_IF_ERROR_SESSIONID_(ValidateInputs(feed_names, feeds));
     ORT_RETURN_IF_ERROR_SESSIONID_(ValidateOutputs(output_names, p_fetches));
@@ -1225,11 +1219,8 @@ Status InferenceSession::Run(const RunOptions& run_options,
     telemetry_.total_run_duration_since_last_ = 0;
   }
 
-  // check the frequency to send Evalutaion Stop event
-  if (telemetry_.isEvaluationStart) {
-    env.GetTelemetryProvider().LogEvaluationStop();
-    telemetry_.isEvaluationStart = false;
-  }
+  env.GetTelemetryProvider().LogEvaluationStop();
+
   // send out profiling events (optional)
   if (session_profiler_.IsEnabled()) {
     session_profiler_.EndTimeAndRecordEvent(profiling::SESSION_EVENT, "model_run", tp);

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1133,8 +1133,8 @@ Status InferenceSession::Run(const RunOptions& run_options,
       return Status(common::ONNXRUNTIME, common::FAIL, "Session not initialized.");
     }
 
+    // log evaluation start to trace logging provider
     env.GetTelemetryProvider().LogEvaluationStart();
-
 
     ORT_RETURN_IF_ERROR_SESSIONID_(ValidateInputs(feed_names, feeds));
     ORT_RETURN_IF_ERROR_SESSIONID_(ValidateOutputs(output_names, p_fetches));
@@ -1219,6 +1219,7 @@ Status InferenceSession::Run(const RunOptions& run_options,
     telemetry_.total_run_duration_since_last_ = 0;
   }
 
+  // log evaluation stop to trace logging provider
   env.GetTelemetryProvider().LogEvaluationStop();
 
   // send out profiling events (optional)

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -574,12 +574,8 @@ class InferenceSession {
     std::string event_name_;                       // where the model is loaded from: ["model_loading_uri", "model_loading_proto", "model_loading_istream"]
 
     TimePoint time_sent_last_;  // the TimePoint of the last report
-    TimePoint time_sent_last_evalutation_start_;
     // Event Rate per provider < 20 peak events per second
     constexpr static long long kDurationBetweenSending = 1000 * 1000 * 60 * 10;     // duration in (us).  send a report every 10 mins
-    constexpr static long long kDurationBetweenSendingEvaluationStart = 1000 * 50;  // duration in (us). send a EvaluationStop Event every 50 ms;
-
-    bool isEvaluationStart = false;
   } telemetry_;
 
 #ifdef ONNXRUNTIME_ENABLE_INSTRUMENT

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -568,7 +568,7 @@ class InferenceSession {
   uint32_t session_id_;                             // the current session's id
 
   struct Telemetry {
-    Telemetry() : time_sent_last_(), time_sent_last_evalutation_start_() {}
+    Telemetry() : time_sent_last_() {}
     uint32_t total_runs_since_last_ = 0;           // the total number of Run() calls since the last report
     long long total_run_duration_since_last_ = 0;  // the total duration (us) of Run() calls since the last report
     std::string event_name_;                       // where the model is loaded from: ["model_loading_uri", "model_loading_proto", "model_loading_istream"]


### PR DESCRIPTION
LogRuntimeError sends telemetry for failed evaluations. All exceptions path in evaluation call should be covered by RuntimeError event due to WINML_THROW_IF_FAILED macro which calls LogRuntimeError.

 LogRuntimePerf sends telemetry for succeeded evaluations.

LogRuntimeError and LogRuntimePerf makes LogEvaluate start / stop redundant in terms of telemetry but trace logging event will still remain for debugging purposes.