### PR TITLE
Pass Model Path to TensorProtoToMLValue from Constant Folding for External Inputs

### DIFF
--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -103,7 +103,19 @@ Status ConstantFolding::ApplyImpl(Graph& graph, bool& modified, int graph_level,
         continue;
       }
 
-      // Create execution frame for executing constant nodes.
+      // Constant folding doesn't support external initializers.
+      bool has_external_input = false;
+      for (InitializedTensorSet::const_iterator it = constant_inputs.cbegin(); it != constant_inputs.cend(); it++) {
+        if (it->second->data_location() == ONNX_NAMESPACE::TensorProto_DataLocation_EXTERNAL) {
+          has_external_input = true;
+          break;
+        }
+      }
+
+      if (has_external_input) {
+        continue;
+      }
+
       // Create execution frame for executing constant nodes.
       OptimizerExecutionFrame::Info info({node}, constant_inputs, execution_provider_);
 

--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -103,21 +103,8 @@ Status ConstantFolding::ApplyImpl(Graph& graph, bool& modified, int graph_level,
         continue;
       }
 
-      // Constant folding doesn't support external initializers.
-      bool has_external_input = false;
-      for (InitializedTensorSet::const_iterator it = constant_inputs.cbegin(); it != constant_inputs.cend(); it++) {
-        if (it->second->data_location() == ONNX_NAMESPACE::TensorProto_DataLocation_EXTERNAL) {
-          has_external_input = true;
-          break;
-        }
-      }
-
-      if (has_external_input) {
-        continue;
-      }
-
       // Create execution frame for executing constant nodes.
-      OptimizerExecutionFrame::Info info({node}, constant_inputs, execution_provider_);
+      OptimizerExecutionFrame::Info info({node}, constant_inputs, graph.ModelPath(), execution_provider_);
 
       std::vector<int> fetch_mlvalue_idxs;
       for (const auto* node_out : node->OutputDefs()) {

--- a/onnxruntime/core/optimizer/optimizer_execution_frame.h
+++ b/onnxruntime/core/optimizer/optimizer_execution_frame.h
@@ -20,7 +20,9 @@ class OptimizerExecutionFrame final : public IExecutionFrame {
  public:
   class Info {
    public:
-    Info(const std::vector<const Node*>& nodes, const InitializedTensorSet& initialized_tensor_set,
+    Info(const std::vector<const Node*>& nodes,
+         const InitializedTensorSet& initialized_tensor_set,
+         const Path& model_path,
          const IExecutionProvider& execution_provider);
     ~Info() {
       for (auto& kvp : deleter_for_initialized_tensors_) {

--- a/onnxruntime/test/optimizer/optimizer_test.cc
+++ b/onnxruntime/test/optimizer/optimizer_test.cc
@@ -66,7 +66,7 @@ TEST(OptimizerTest, Basic) {
 
   std::unique_ptr<CPUExecutionProvider> cpu_execution_provider =
       onnxruntime::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
-  OptimizerExecutionFrame::Info info(nodes, initialized_tensor_set, *cpu_execution_provider.get());
+  OptimizerExecutionFrame::Info info(nodes, initialized_tensor_set, graph.ModelPath(), *cpu_execution_provider.get());
   std::vector<int> fetch_mlvalue_idxs{info.GetMLValueIndex("out")};
   OptimizerExecutionFrame frame(info, fetch_mlvalue_idxs);
   const logging::Logger& logger = DefaultLoggingManager().DefaultLogger();


### PR DESCRIPTION
Pass model_path to TensorProtoToMLValue from constant folding optimizer for external inputs.

**Motivation and Context**
- When working on large GPT-2 when set use_external_data_format=True, the training session cannot be initialized when loading the saved model and report error "/workspace/onnxruntime/onnxruntime/core/optimizer/optimizer_execution_frame.cc:61 onnxruntime::OptimizerExecutionFrame::Info::Info(const std::vector<const onnxruntime::Node*>&, const InitializedTensorSet&, std::unique_ptr<onnxruntime::CPUExecutionProvider>) SystemError : 2." The error comes from constant folding optimizer trying to fold an external initializers.
- Issue https://github.com/microsoft/onnxruntime/issues/4922 may also related to this.
