### PR TITLE
Fix for initOsArch() always throws when using ORT java on Android

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -16,7 +16,7 @@
     * [Intel DNNL/MKL-ML](#DNNL-and-MKLML)
     * [Intel nGraph](#nGraph)
     * [Intel OpenVINO](#openvino)
-    * [Android NNAPI](#Android-NNAPI)
+    * [Android NNAPI](#Android-NNAPI-Execution-Provider)
     * [Nuphar Model Compiler](#Nuphar)
     * [DirectML](#DirectML)
     * [ARM Compute Library](#ARM-Compute-Library)


### PR DESCRIPTION
**Description**: 
- Add support of Android in initOsArch(),
- Fix a link in the Build.md

**Motivation and Context**
- If it fixes an open issue, please link to the issue here. 
This is to address issue https://github.com/microsoft/onnxruntime/issues/4976
A previous change https://github.com/microsoft/onnxruntime/pull/3849 initOsArch() will throw for ORT java running on Android, add  support of Android in initOsArch(),
