### PR TITLE
Missing header for `std::once_flag` and `std::call_once`.

### DIFF
--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <sstream>
 #include <atomic>
+#include <mutex>
 #include <gtest/gtest.h>
 #include "test_allocator.h"
 #include "test_fixture.h"


### PR DESCRIPTION
Resolve https://github.com/microsoft/onnxruntime/issues/5008