### PR TITLE
Temporarily switch SafeInt to a fork for an option to disable exceptions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -53,9 +53,6 @@
 [submodule "cmake/external/FeaturizersLibrary"]
 	path = cmake/external/FeaturizersLibrary
 	url = https://github.com/microsoft/FeaturizersLibrary.git
-[submodule "cmake/external/SafeInt/safeint"]
-	path = cmake/external/SafeInt/safeint
-	url = https://github.com/dcleblanc/SafeInt.git
 [submodule "cmake/external/libprotobuf-mutator"]
 	path = cmake/external/libprotobuf-mutator
 	url = https://github.com/google/libprotobuf-mutator.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -62,3 +62,6 @@
 [submodule "cmake/external/flatbuffers"]
 	path = cmake/external/flatbuffers
 	url = https://github.com/google/flatbuffers.git
+[submodule "cmake/external/SafeInt/safeint"]
+	path = cmake/external/SafeInt/safeint
+	url = https://github.com/gwang-msft/SafeInt.git

--- a/cgmanifests/submodules/cgmanifest.json
+++ b/cgmanifests/submodules/cgmanifest.json
@@ -35,8 +35,8 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "39de59d5bca3a226a241b29571abe1493d15d07a",
-          "repositoryUrl": "https://github.com/dcleblanc/SafeInt.git"
+          "commitHash": "0ce2bb56e1ce46264333d75507bf99f2e4c07e3b",
+          "repositoryUrl": "https://github.com/gwang-msft/SafeInt.git"
         },
         "comments": "git submodule at cmake/external/SafeInt/safeint"
       }


### PR DESCRIPTION
**Description**: Temporarily switch SafeInt to a fork for an option to disable exceptions

**Motivation and Context**
- We cannot completely disable the internal SafeIntException of SafeInt, which will cause building waring if we try to build without exception handling
- Create a temporary fork of SafeInt (https://github.com/gwang-msft/SafeInt), will switch back if the above issue is resolved in the SafeInt::master repo (tracked by https://github.com/dcleblanc/SafeInt/issues/15)
