### PR TITLE
Fix Provider Allocator Bug

### DIFF
--- a/onnxruntime/core/framework/provider_bridge_ort.cc
+++ b/onnxruntime/core/framework/provider_bridge_ort.cc
@@ -187,6 +187,13 @@ struct Provider_IExecutionProvider_Router_Impl : Provider_IExecutionProvider_Rou
     return std::make_shared<Provider_IAllocator_Impl>(IExecutionProvider::GetAllocator(id, mem_type));
   }
 
+  AllocatorPtr GetAllocator(int id, OrtMemType mem_type) const override {
+    auto allocator = outer_->Provider_GetAllocator(id, mem_type);
+    if (!allocator)
+      return nullptr;
+    return static_cast<Provider_IAllocator_Impl*>(allocator.get())->p_;
+  }
+
   std::unique_ptr<Provider_IDataTransfer> Provider_GetDataTransfer() const override {
     return std::unique_ptr<Provider_IDataTransfer>(reinterpret_cast<Provider_IDataTransfer*>(IExecutionProvider::GetDataTransfer().release()));
   }


### PR DESCRIPTION
**Description**: Was missing an override for the provider layer's GetAllocator function.

Without this, it will cause various failures (like no allocator when using multiple devices, etc..)