### PR TITLE
Remove SchedulingParams variants of ThreadPool::TryParallelFor

### DIFF
--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -52,34 +52,6 @@ class LoopCounter;
 
 class ThreadPool {
  public:
-  // Scheduling strategies for ParallelFor. The strategy governs how the given
-  // units of work are distributed among the available threads in the
-  // threadpool.
-  enum class SchedulingStrategy {
-    // The Adaptive scheduling strategy adaptively chooses the shard sizes based
-    // on the cost of each unit of work, and the cost model of the underlying
-    // threadpool device.
-    //
-    // The 'cost_per_unit' is an estimate of the number of CPU cycles (or
-    // nanoseconds if not CPU-bound) to complete a unit of work. Overestimating
-    // creates too many shards and CPU time will be dominated by per-shard
-    // overhead, such as Context creation. Underestimating may not fully make
-    // use of the specified parallelism, and may also cause inefficiencies due
-    // to load balancing issues and stragglers.
-    kAdaptive,
-    // The Fixed Block Size scheduling strategy shards the given units of work
-    // into shards of fixed size. In case the total number of units is not
-    // evenly divisible by 'block_size', at most one of the shards may be of
-    // smaller size. The exact number of shards may be found by a call to
-    // NumShardsUsedByFixedBlockSizeScheduling.
-    //
-    // Each shard may be executed on a different thread in parallel, depending
-    // on the number of threads available in the pool. Note that when there
-    // aren't enough threads in the pool to achieve full parallelism, function
-    // calls will be automatically queued.
-    kFixedBlockSize
-  };
-
 #ifdef _WIN32
   using NAME_CHAR_TYPE = wchar_t;
 #else

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -242,24 +242,6 @@ int ThreadPool::NumShardsUsedByFixedBlockSizeScheduling(const std::ptrdiff_t tot
   }
 }
 
-void ThreadPool::ParallelFor(std::ptrdiff_t total, const SchedulingParams& scheduling_params,
-                             const std::function<void(std::ptrdiff_t, std::ptrdiff_t)>& fn) {
-  switch (scheduling_params.strategy()) {
-    case SchedulingStrategy::kAdaptive: {
-      if (scheduling_params.cost_per_unit().has_value()) {
-        ParallelFor(total, static_cast<double>(scheduling_params.cost_per_unit().value()), fn);
-      }
-      break;
-    }
-    case SchedulingStrategy::kFixedBlockSize: {
-      if (scheduling_params.block_size().has_value()) {
-        ParallelForFixedBlockSizeScheduling(total, scheduling_params.block_size().value(), fn);
-      }
-      break;
-    }
-  }
-}
-
 using CostModel = Eigen::TensorCostModel<Eigen::ThreadPoolDevice>;
 
 // Calculates block size based on (1) the iteration cost and (2) parallel

--- a/onnxruntime/test/onnx/microbenchmark/common.h
+++ b/onnxruntime/test/onnx/microbenchmark/common.h
@@ -6,6 +6,8 @@
 #include <new>
 #include <random>
 
+#include "core/common/common.h"
+
 // aligned memory allocate and free functions
 inline void* aligned_alloc(size_t size, size_t align) {
   void* ptr;

--- a/onnxruntime/test/onnx/microbenchmark/gelu.cc
+++ b/onnxruntime/test/onnx/microbenchmark/gelu.cc
@@ -292,17 +292,25 @@ static void BM_GeluBatchParallelFor3(benchmark::State& state) {
   tpo.auto_set_affinity = true;
   std::unique_ptr<concurrency::ThreadPool> tp(
       concurrency::CreateThreadPool(&onnxruntime::Env::Default(), tpo, concurrency::ThreadPoolType::INTRA_OP));
-  concurrency::ThreadPool::SchedulingParams p(concurrency::ThreadPool::SchedulingStrategy::kFixedBlockSize, optional<int64_t>(), 4096);
+
+  // Divide work into chunks of 4096 iterations
+  const int64_t length_per_task = 4096;
+  const int64_t task_count = (batch_size + length_per_task - 1) / length_per_task;
+
   for (auto _ : state) {
-    tp->ParallelFor(batch_size, p, [data, output](ptrdiff_t first, ptrdiff_t last) {
-      ptrdiff_t len = last - first;
-      float* output_ptr = output + first;
-      onnxruntime::ConstEigenVectorArrayMap<float> xm(data + first, len);
-      onnxruntime::EigenVectorArrayMap<float> ym(output_ptr, len);
-      ym = xm * static_cast<float>(M_SQRT1_2);
-      MlasComputeErf(output_ptr, output_ptr, len);
-      ym = xm * 0.5f * (ym + 1.0f);
-    });
+    concurrency::ThreadPool::TryBatchParallelFor(
+      tp.get(),
+      static_cast<ptrdiff_t>(task_count),
+      [batch_size, data, length_per_task, output](ptrdiff_t task_idx) {
+        const auto first = task_idx * length_per_task;
+        const ptrdiff_t len = std::min(length_per_task, batch_size - first);
+        float* output_ptr = output + first;
+        onnxruntime::ConstEigenVectorArrayMap<float> xm(data + first, len);
+        onnxruntime::EigenVectorArrayMap<float> ym(output_ptr, len);
+        ym = xm * static_cast<float>(M_SQRT1_2);
+        MlasComputeErf(output_ptr, output_ptr, len);
+        ym = xm * 0.5f * (ym + 1.0f);
+      });
   }
   aligned_free(data);
   aligned_free(output);

--- a/onnxruntime/test/onnx/microbenchmark/gelu.cc
+++ b/onnxruntime/test/onnx/microbenchmark/gelu.cc
@@ -303,14 +303,15 @@ static void BM_GeluBatchParallelFor3(benchmark::State& state) {
       static_cast<ptrdiff_t>(task_count),
       [batch_size, data, length_per_task, output](ptrdiff_t task_idx) {
         const auto first = task_idx * length_per_task;
-        const ptrdiff_t len = std::min(length_per_task, batch_size - first);
+        const ptrdiff_t len = std::min(length_per_task, static_cast<int64_t>(batch_size - first));
         float* output_ptr = output + first;
         onnxruntime::ConstEigenVectorArrayMap<float> xm(data + first, len);
         onnxruntime::EigenVectorArrayMap<float> ym(output_ptr, len);
         ym = xm * static_cast<float>(M_SQRT1_2);
         MlasComputeErf(output_ptr, output_ptr, len);
         ym = xm * 0.5f * (ym + 1.0f);
-      });
+      },
+      0);
   }
   aligned_free(data);
   aligned_free(output);


### PR DESCRIPTION
**Description**: Simplify the range of parallel loops implemented in the thread pool by removing the variants based on SchedulingParams.  This leaves the variant that takes a simple double to express costs, and the variant that takes a TensorOpCost struct.

**Motivation and Context**
The parallel loop variants taking a SchedulingParams were essentially unused, but supporting them introduced complexity in writing and testing other changes to the thread pool implementation.  The single use is in the gelu.cc microbenchmark which uses SchedulingParams to force a fixed 4096-size chunk for work distribution.  I updated the microbenchmark to do this chunking explicitly, following the code in onnxruntime/contrib_ops/cpu/bert/bias_gelu.cc 
