### PR TITLE
Add a docker file for CI build CUDA 10.2

### DIFF
--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cuda10_2
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cuda10_2
@@ -1,0 +1,35 @@
+FROM nvcr.io/nvidia/cuda:10.2-cudnn8-devel-centos7
+
+#We need both CUDA and manylinux. But the CUDA Toolkit End User License Agreement says NVIDIA CUDA Driver Libraries(libcuda.so, libnvidia-ptxjitcompiler.so) are only distributable in applications that meet this criteria:
+#1. The application was developed starting from a NVIDIA CUDA container obtained from Docker Hub or the NVIDIA GPU Cloud, and
+#2. The resulting application is packaged as a Docker container and distributed to users on Docker Hub or the NVIDIA GPU Cloud only.
+#So we use CUDA as the base image then add manylinux on top of it.
+
+#Build manylinux2014 docker image begin
+ENV AUDITWHEEL_ARCH x86_64
+ENV AUDITWHEEL_PLAT manylinux2014_$AUDITWHEEL_ARCH
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV DEVTOOLSET_ROOTPATH /opt/rh/devtoolset-9/root
+ENV PATH $DEVTOOLSET_ROOTPATH/usr/bin:$PATH
+ENV LD_LIBRARY_PATH $DEVTOOLSET_ROOTPATH/usr/lib64:$DEVTOOLSET_ROOTPATH/usr/lib:$DEVTOOLSET_ROOTPATH/usr/lib64/dyninst:$DEVTOOLSET_ROOTPATH/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib
+ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
+
+COPY manylinux2014_build_scripts /manylinux2014_build_scripts
+RUN bash /manylinux2014_build_scripts/build.sh && rm -r manylinux2014_build_scripts
+
+ENV SSL_CERT_FILE=/opt/_internal/certs.pem
+
+#Build manylinux2014 docker image end
+
+#Add our own dependencies
+ADD manylinux /tmp/scripts
+RUN cd /tmp/scripts && /tmp/scripts/install_centos.sh && /tmp/scripts/install_deps.sh  && rm -rf /tmp/scripts
+
+ARG BUILD_UID=1000
+ARG BUILD_USER=onnxruntimedev
+RUN adduser --uid $BUILD_UID $BUILD_USER
+WORKDIR /home/$BUILD_USER
+USER $BUILD_USER
+ENV PATH /usr/local/gradle/bin:/usr/local/dotnet:$PATH


### PR DESCRIPTION
**Description**: 

Add a docker file for CI build CUDA 10.2

**Motivation and Context**
- Why is this change required? What problem does it solve?

To help setup a pipeline and validate if ORT supports CUDA 10.2 well.

- If it fixes an open issue, please link to the issue here.
