### PR TITLE
Remove IDeviceAllocator class as it doesn't extend IAllocator

### DIFF
--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -135,33 +135,21 @@ bool IAllocator::CalcMemSizeForArrayWithAlignment(size_t nmemb, size_t size, siz
   return CalcMemSizeForArrayWithAlignment(nmemb, size, alignment, out);
 }
 
-/**
-   The resource allocator on a physical device.
-   This allocator will directly allocate resource from system call
-*/
-class IDeviceAllocator : public IAllocator {
+class CPUAllocator : public IAllocator {
  public:
-  IDeviceAllocator(const OrtMemoryInfo& info) : IAllocator(info) {}
-  ~IDeviceAllocator() override = default;
-  void* Alloc(size_t size) override = 0;
-  void Free(void* p) override = 0;
-};
+  explicit CPUAllocator(const OrtMemoryInfo& memory_info) : IAllocator(memory_info) {}
 
-class CPUAllocator : public IDeviceAllocator {
- public:
-  explicit CPUAllocator(const OrtMemoryInfo& memory_info) : IDeviceAllocator(memory_info) {}
-
-  CPUAllocator() : IDeviceAllocator(OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator)) {}
+  CPUAllocator() : IAllocator(OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator)) {}
 
   void* Alloc(size_t size) override;
   void Free(void* p) override;
 };
 
 #if defined(USE_MIMALLOC_ARENA_ALLOCATOR)
-class MiMallocAllocator : public IDeviceAllocator {
+class MiMallocAllocator : public IAllocator {
  public:
-  explicit MiMallocAllocator(const OrtMemoryInfo& memory_info) : IDeviceAllocator(memory_info) {}
-  MiMallocAllocator() : IDeviceAllocator(OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator)) {}
+  explicit MiMallocAllocator(const OrtMemoryInfo& memory_info) : IAllocator(memory_info) {}
+  MiMallocAllocator() : IAllocator(OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator)) {}
 
   void* Alloc(size_t size) override;
   void Free(void* p) override;

--- a/onnxruntime/core/framework/allocatormgr.cc
+++ b/onnxruntime/core/framework/allocatormgr.cc
@@ -14,7 +14,7 @@ namespace onnxruntime {
 using namespace common;
 
 AllocatorPtr CreateAllocator(const AllocatorCreationInfo& info) {
-  auto device_allocator = std::unique_ptr<IDeviceAllocator>(info.device_alloc_factory(info.device_id));
+  auto device_allocator = std::unique_ptr<IAllocator>(info.device_alloc_factory(info.device_id));
 
   if (info.use_arena) {
     size_t max_mem = info.arena_cfg.max_mem == 0 ? BFCArena::DEFAULT_MAX_MEM : info.arena_cfg.max_mem;

--- a/onnxruntime/core/framework/allocatormgr.h
+++ b/onnxruntime/core/framework/allocatormgr.h
@@ -10,10 +10,10 @@
 
 namespace onnxruntime {
 
-using DeviceAllocatorFactory = std::function<std::unique_ptr<IDeviceAllocator>(OrtDevice::DeviceId)>;
+using AllocatorFactory = std::function<std::unique_ptr<IAllocator>(OrtDevice::DeviceId)>;
 
 struct AllocatorCreationInfo {
-  AllocatorCreationInfo(DeviceAllocatorFactory device_alloc_factory0,
+  AllocatorCreationInfo(AllocatorFactory device_alloc_factory0,
                         OrtDevice::DeviceId device_id0 = 0,
                         bool use_arena0 = true,
                         OrtArenaCfg arena_cfg0 = {0, -1, -1, -1})
@@ -23,7 +23,7 @@ struct AllocatorCreationInfo {
         arena_cfg(arena_cfg0) {
   }
 
-  DeviceAllocatorFactory device_alloc_factory;
+  AllocatorFactory device_alloc_factory;
   OrtDevice::DeviceId device_id;
   bool use_arena;
   OrtArenaCfg arena_cfg;

--- a/onnxruntime/core/framework/bfc_arena.cc
+++ b/onnxruntime/core/framework/bfc_arena.cc
@@ -5,7 +5,7 @@
 #include <type_traits>
 
 namespace onnxruntime {
-BFCArena::BFCArena(std::unique_ptr<IDeviceAllocator> resource_allocator,
+BFCArena::BFCArena(std::unique_ptr<IAllocator> resource_allocator,
                    size_t total_memory,
                    ArenaExtendStrategy arena_extend_strategy,
                    int initial_chunk_size_bytes,

--- a/onnxruntime/core/framework/bfc_arena.h
+++ b/onnxruntime/core/framework/bfc_arena.h
@@ -59,7 +59,7 @@ class BFCArena : public IArenaAllocator {
   static const int DEFAULT_MAX_DEAD_BYTES_PER_CHUNK = 128 * 1024 * 1024;
   static const size_t DEFAULT_MAX_MEM = std::numeric_limits<size_t>::max();
 
-  BFCArena(std::unique_ptr<IDeviceAllocator> resource_allocator,
+  BFCArena(std::unique_ptr<IAllocator> resource_allocator,
            size_t total_memory,
            ArenaExtendStrategy arena_extend_strategy = DEFAULT_ARENA_EXTEND_STRATEGY,
            int initial_chunk_size_bytes = DEFAULT_INITIAL_CHUNK_SIZE_BYTES,
@@ -433,7 +433,7 @@ class BFCArena : public IArenaAllocator {
   // The size of the current region allocation.
   SafeInt<size_t> curr_region_allocation_bytes_;
 
-  std::unique_ptr<IDeviceAllocator> device_allocator_;
+  std::unique_ptr<IAllocator> device_allocator_;
 
   mutable OrtMutex lock_;
 

--- a/onnxruntime/core/framework/mimalloc_arena.cc
+++ b/onnxruntime/core/framework/mimalloc_arena.cc
@@ -3,48 +3,48 @@
 #include "core/framework/mimalloc_arena.h"
 
 namespace onnxruntime {
-    MiMallocArena::MiMallocArena(std::unique_ptr<IDeviceAllocator> resource_allocator,
-                   size_t total_memory)
+MiMallocArena::MiMallocArena(std::unique_ptr<IAllocator> resource_allocator,
+                             size_t total_memory)
     : info_(resource_allocator->Info().name, OrtAllocatorType::OrtArenaAllocator, resource_allocator->Info().device, resource_allocator->Info().id, resource_allocator->Info().mem_type) {
-        stats_.bytes_limit = total_memory;
-    }
-
-    void* MiMallocArena::Alloc(size_t size) {
-#if (MI_STAT>1)
-        stats_.num_allocs++;
-#endif
-        return mi_malloc(size);
-    }
-
-    void MiMallocArena::Free(void* p) {
-        mi_free(p);
-    }
-
-    void* MiMallocArena::Reserve(size_t size) {
-        return mi_malloc(size);
-    }
-
-    // mimalloc only maintains stats when compiled under debug (which in turn sets MI_STAT)
-    void MiMallocArena::GetStats(AllocatorStats* stats) {
-#if (MI_STAT>1)
-        auto current_stats = mi_heap_get_default()->tld->stats;
-        stats_.bytes_in_use = current_stats.malloc.current;
-        stats_.total_allocated_bytes = current_stats.reserved.current;
-        stats_.max_bytes_in_use = current_stats.reserved.peak;
-#endif
-        *stats = stats_;
-    }
-
-    size_t MiMallocArena::Used() const {
-#if (MI_STAT>1)
-        return mi_heap_get_default()->tld->stats.malloc.current;
-#else
-        return 0;
-#endif
-    }
-
-    size_t MiMallocArena::AllocatedSize(const void* ptr) {
-        return mi_usable_size(ptr);
-    }
+  stats_.bytes_limit = total_memory;
 }
+
+void* MiMallocArena::Alloc(size_t size) {
+#if (MI_STAT > 1)
+  stats_.num_allocs++;
+#endif
+  return mi_malloc(size);
+}
+
+void MiMallocArena::Free(void* p) {
+  mi_free(p);
+}
+
+void* MiMallocArena::Reserve(size_t size) {
+  return mi_malloc(size);
+}
+
+// mimalloc only maintains stats when compiled under debug (which in turn sets MI_STAT)
+void MiMallocArena::GetStats(AllocatorStats* stats) {
+#if (MI_STAT > 1)
+  auto current_stats = mi_heap_get_default()->tld->stats;
+  stats_.bytes_in_use = current_stats.malloc.current;
+  stats_.total_allocated_bytes = current_stats.reserved.current;
+  stats_.max_bytes_in_use = current_stats.reserved.peak;
+#endif
+  *stats = stats_;
+}
+
+size_t MiMallocArena::Used() const {
+#if (MI_STAT > 1)
+  return mi_heap_get_default()->tld->stats.malloc.current;
+#else
+  return 0;
+#endif
+}
+
+size_t MiMallocArena::AllocatedSize(const void* ptr) {
+  return mi_usable_size(ptr);
+}
+}  // namespace onnxruntime
 #endif

--- a/onnxruntime/core/framework/mimalloc_arena.h
+++ b/onnxruntime/core/framework/mimalloc_arena.h
@@ -5,32 +5,32 @@
 
 namespace onnxruntime {
 class MiMallocArena : public IArenaAllocator {
-    public:
-    MiMallocArena(std::unique_ptr<IDeviceAllocator> resource_allocator, size_t total_memory);
+ public:
+  MiMallocArena(std::unique_ptr<IAllocator> resource_allocator, size_t total_memory);
 
-    void* Alloc(size_t size) override;
+  void* Alloc(size_t size) override;
 
-    void Free(void* p) override;
+  void Free(void* p) override;
 
-    // mimalloc only maintains stats when compiled under debug, or when MI_STAT >= 2
-    void GetStats(AllocatorStats* stats);
+  // mimalloc only maintains stats when compiled under debug, or when MI_STAT >= 2
+  void GetStats(AllocatorStats* stats);
 
-    void* Reserve(size_t size) override;
+  void* Reserve(size_t size) override;
 
-    size_t Used() const override;
+  size_t Used() const override;
 
-    size_t Max() const override {
-        return stats_.bytes_limit;
-    }
+  size_t Max() const override {
+    return stats_.bytes_limit;
+  }
 
-    const OrtMemoryInfo& Info() const override {
-        return info_;
-    }
+  const OrtMemoryInfo& Info() const override {
+    return info_;
+  }
 
-    size_t AllocatedSize(const void* ptr);
+  size_t AllocatedSize(const void* ptr);
 
-    OrtMemoryInfo info_;
-    AllocatorStats stats_;
+  OrtMemoryInfo info_;
+  AllocatorStats stats_;
 };
 }  // namespace onnxruntime
 #endif

--- a/onnxruntime/core/providers/cuda/cuda_allocator.h
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.h
@@ -7,10 +7,10 @@
 
 namespace onnxruntime {
 
-class CUDAAllocator : public IDeviceAllocator {
+class CUDAAllocator : public IAllocator {
  public:
   CUDAAllocator(OrtDevice::DeviceId device_id, const char* name)
-      : IDeviceAllocator(
+      : IAllocator(
             OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
                           OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, device_id),
                           device_id, OrtMemTypeDefault)) {}
@@ -23,10 +23,10 @@ class CUDAAllocator : public IDeviceAllocator {
 };
 
 //TODO: add a default constructor
-class CUDAPinnedAllocator : public IDeviceAllocator {
+class CUDAPinnedAllocator : public IAllocator {
  public:
   CUDAPinnedAllocator(OrtDevice::DeviceId device_id, const char* name)
-      : IDeviceAllocator(
+      : IAllocator(
             OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
                           OrtDevice(OrtDevice::CPU, OrtDevice::MemType::CUDA_PINNED, device_id),
                           device_id, OrtMemTypeCPUOutput)) {}

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.cpp
@@ -226,7 +226,7 @@ namespace Dml
     }
 
     CPUAllocator::CPUAllocator(OrtMemType memType)
-        : onnxruntime::IDeviceAllocator(
+        : onnxruntime::IAllocator(
               OrtMemoryInfo("DML CPU",
                             OrtAllocatorType::OrtDeviceAllocator,
                             OrtDevice(OrtDevice::CPU, OrtDevice::MemType::DEFAULT, 0),

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.h
@@ -9,7 +9,7 @@
 namespace Dml
 {
     
-    class CPUAllocator : public onnxruntime::IDeviceAllocator
+    class CPUAllocator : public onnxruntime::IAllocator
     {
     public:
         explicit CPUAllocator(OrtMemType memType);

--- a/onnxruntime/core/providers/migraphx/hip_allocator.h
+++ b/onnxruntime/core/providers/migraphx/hip_allocator.h
@@ -7,10 +7,10 @@
 
 namespace onnxruntime {
 
-class HIPAllocator : public IDeviceAllocator {
+class HIPAllocator : public IAllocator {
  public:
   HIPAllocator(int device_id, const char* name)
-    : IDeviceAllocator(
+    : IAllocator(
         OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
                       OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, device_id),
                       device_id, OrtMemTypeDefault)) {}
@@ -24,10 +24,10 @@ class HIPAllocator : public IDeviceAllocator {
 };
 
 //TODO: add a default constructor
-class HIPPinnedAllocator : public IDeviceAllocator {
+class HIPPinnedAllocator : public IAllocator {
  public:
   HIPPinnedAllocator(int device_id, const char* name)
-    : IDeviceAllocator(
+    : IAllocator(
           OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
                         OrtDevice(OrtDevice::CPU, OrtDevice::MemType::HIP_PINNED, device_id),
                         device_id, OrtMemTypeCPUOutput)) {}

--- a/onnxruntime/core/providers/shared_library/provider_api.h
+++ b/onnxruntime/core/providers/shared_library/provider_api.h
@@ -103,7 +103,7 @@ class DataTypeImpl {
 template <typename T>
 using IAllocatorUniquePtr = std::unique_ptr<T, std::function<void(T*)>>;
 
-std::unique_ptr<Provider_IDeviceAllocator> Provider_CreateCPUAllocator(const OrtMemoryInfo& memory_info);
+std::unique_ptr<Provider_IAllocator> Provider_CreateCPUAllocator(const OrtMemoryInfo& memory_info);
 Provider_AllocatorPtr CreateAllocator(const Provider_AllocatorCreationInfo& info);
 
 std::string GetEnvironmentVar(const std::string& var_name);

--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -142,7 +142,7 @@ Provider_AllocatorPtr CreateAllocator(Provider_AllocatorCreationInfo info) {
   return g_host->CreateAllocator(info);
 }
 
-std::unique_ptr<Provider_IDeviceAllocator> Provider_CreateCPUAllocator(const OrtMemoryInfo& info) {
+std::unique_ptr<Provider_IAllocator> Provider_CreateCPUAllocator(const OrtMemoryInfo& info) {
   return g_host->CreateCPUAllocator(info);
 }
 

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -145,16 +145,12 @@ struct Provider_IAllocator {
   void operator=(const Provider_IAllocator&) = delete;
 };
 
-struct Provider_IDeviceAllocator : Provider_IAllocator {
-  Provider_IDeviceAllocator(const OrtMemoryInfo& info) : Provider_IAllocator{info} {}
-};
-
 using Provider_AllocatorPtr = std::shared_ptr<Provider_IAllocator>;
-using Provider_DeviceAllocatorFactory = std::function<std::unique_ptr<Provider_IDeviceAllocator>(int)>;
+using Provider_AllocatorFactory = std::function<std::unique_ptr<Provider_IAllocator>(int)>;
 
 using DeviceId = int16_t;
 struct Provider_AllocatorCreationInfo {
-  Provider_AllocatorCreationInfo(Provider_DeviceAllocatorFactory device_alloc_factory0,
+  Provider_AllocatorCreationInfo(Provider_AllocatorFactory device_alloc_factory0,
                                  DeviceId device_id0 = 0,
                                  bool use_arena0 = true,
                                  OrtArenaCfg arena_cfg0 = {0, -1, -1, -1})
@@ -164,7 +160,7 @@ struct Provider_AllocatorCreationInfo {
         arena_cfg(arena_cfg0) {
   }
 
-  Provider_DeviceAllocatorFactory factory;
+  Provider_AllocatorFactory factory;
   DeviceId device_id;
   bool use_arena;
   OrtArenaCfg arena_cfg;
@@ -288,7 +284,7 @@ struct ProviderHost {
 
   virtual logging::Logger* LoggingManager_GetDefaultLogger() = 0;
 
-  virtual std::unique_ptr<Provider_IDeviceAllocator> CreateCPUAllocator(const OrtMemoryInfo& memory_info) = 0;
+  virtual std::unique_ptr<Provider_IAllocator> CreateCPUAllocator(const OrtMemoryInfo& memory_info) = 0;
 
   virtual std::unique_ptr<Provider_IExecutionProvider_Router> Create_IExecutionProvider_Router(Provider_IExecutionProvider* outer, const std::string& type) = 0;
 

--- a/onnxruntime/core/providers/tensorrt/cuda_allocator.h
+++ b/onnxruntime/core/providers/tensorrt/cuda_allocator.h
@@ -5,10 +5,10 @@
 
 namespace onnxruntime {
 
-class CUDAAllocator : public Provider_IDeviceAllocator {
+class CUDAAllocator : public Provider_IAllocator {
  public:
   CUDAAllocator(OrtDevice::DeviceId device_id, const char* name)
-      : Provider_IDeviceAllocator(
+      : Provider_IAllocator(
             OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
                           OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, device_id),
                           device_id, OrtMemTypeDefault)) {}
@@ -21,10 +21,10 @@ class CUDAAllocator : public Provider_IDeviceAllocator {
 };
 
 //TODO: add a default constructor
-class CUDAPinnedAllocator : public Provider_IDeviceAllocator {
+class CUDAPinnedAllocator : public Provider_IAllocator {
  public:
   CUDAPinnedAllocator(OrtDevice::DeviceId device_id, const char* name)
-      : Provider_IDeviceAllocator(
+      : Provider_IAllocator(
             OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
                           OrtDevice(OrtDevice::CPU, OrtDevice::MemType::CUDA_PINNED, device_id),
                           device_id, OrtMemTypeCPUOutput)) {}

--- a/onnxruntime/test/framework/TestAllocatorManager.cc
+++ b/onnxruntime/test/framework/TestAllocatorManager.cc
@@ -13,7 +13,7 @@ namespace test {
 // Dummy Arena which just call underline device allocator directly.
 class DummyArena : public IArenaAllocator {
  public:
-  explicit DummyArena(std::unique_ptr<IDeviceAllocator> resource_allocator)
+  explicit DummyArena(std::unique_ptr<IAllocator> resource_allocator)
       : IArenaAllocator(OrtMemoryInfo(resource_allocator->Info().name,
                                       OrtAllocatorType::OrtArenaAllocator,
                                       resource_allocator->Info().device,
@@ -49,7 +49,7 @@ class DummyArena : public IArenaAllocator {
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(DummyArena);
 
-  std::unique_ptr<IDeviceAllocator> allocator_;
+  std::unique_ptr<IAllocator> allocator_;
 };
 
 static std::string GetAllocatorId(const std::string& name, const int id, const bool isArena) {
@@ -63,7 +63,7 @@ static std::string GetAllocatorId(const std::string& name, const int id, const b
 }
 
 static Status RegisterAllocator(std::unordered_map<std::string, AllocatorPtr>& map,
-                                std::unique_ptr<IDeviceAllocator> allocator, size_t /*memory_limit*/,
+                                std::unique_ptr<IAllocator> allocator, size_t /*memory_limit*/,
                                 bool use_arena) {
   auto& info = allocator->Info();
   auto allocator_id = GetAllocatorId(info.name, info.id, use_arena);

--- a/onnxruntime/test/framework/bfc_arena_test.cc
+++ b/onnxruntime/test/framework/bfc_arena_test.cc
@@ -19,7 +19,7 @@ static void CheckStats(BFCArena* a, int64_t num_allocs, int64_t bytes_in_use,
 }
 
 TEST(BFCArenaTest, NoDups) {
-  BFCArena a(std::unique_ptr<IDeviceAllocator>(new CPUAllocator()), 1 << 30);
+  BFCArena a(std::unique_ptr<IAllocator>(new CPUAllocator()), 1 << 30);
   CheckStats(&a, 0, 0, 0, 0);
 
   // Allocate a lot of raw pointers
@@ -48,7 +48,7 @@ TEST(BFCArenaTest, NoDups) {
 }
 
 TEST(BFCArenaTest, AllocationsAndDeallocations) {
-  BFCArena a(std::unique_ptr<IDeviceAllocator>(new CPUAllocator()), 1 << 30);
+  BFCArena a(std::unique_ptr<IAllocator>(new CPUAllocator()), 1 << 30);
   // Allocate 256 raw pointers of sizes between 100 bytes and about a meg
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
 
@@ -104,7 +104,7 @@ TEST(BFCArenaTest, AllocationsAndDeallocations) {
 }
 
 TEST(BFCArenaTest, ExerciseCoalescing) {
-  BFCArena a(std::unique_ptr<IDeviceAllocator>(new CPUAllocator()), 1 << 30);
+  BFCArena a(std::unique_ptr<IAllocator>(new CPUAllocator()), 1 << 30);
   CheckStats(&a, 0, 0, 0, 0);
 
   void* first_ptr = a.Alloc(4096);
@@ -139,13 +139,13 @@ TEST(BFCArenaTest, ExerciseCoalescing) {
 }
 
 TEST(BFCArenaTest, AllocateZeroBufSize) {
-  BFCArena a(std::unique_ptr<IDeviceAllocator>(new CPUAllocator()), 1 << 30);
+  BFCArena a(std::unique_ptr<IAllocator>(new CPUAllocator()), 1 << 30);
   void* ptr = a.Alloc(0);
   EXPECT_EQ(nullptr, ptr);
 }
 
 TEST(BFCArenaTest, AllocatedVsRequested) {
-  BFCArena a(std::unique_ptr<IDeviceAllocator>(new CPUAllocator()), 1 << 30);
+  BFCArena a(std::unique_ptr<IAllocator>(new CPUAllocator()), 1 << 30);
   void* t1 = a.Alloc(4);
   EXPECT_EQ(4u, a.RequestedSize(t1));
   EXPECT_EQ(256u, a.AllocatedSize(t1));
@@ -165,7 +165,7 @@ void TestCustomMemoryLimit_ProcessException(const OnnxRuntimeException& ex) {
 TEST(BFCArenaTest, TestCustomMemoryLimit) {
   {
     // Configure a 1MiB byte limit
-    BFCArena a(std::unique_ptr<IDeviceAllocator>(new CPUAllocator()), 1 << 20);
+    BFCArena a(std::unique_ptr<IAllocator>(new CPUAllocator()), 1 << 20);
 
     void* first_ptr = a.Alloc(sizeof(float) * (1 << 6));
     EXPECT_NE(nullptr, first_ptr);
@@ -189,7 +189,7 @@ TEST(BFCArenaTest, TestCustomMemoryLimit) {
   {
     // allow for the maximum amount of memory less 5MiB
     constexpr size_t available = std::numeric_limits<size_t>::max() - (5 * 1024 * 1024);
-    BFCArena b(std::unique_ptr<IDeviceAllocator>(new CPUAllocator()), available,
+    BFCArena b(std::unique_ptr<IAllocator>(new CPUAllocator()), available,
                ArenaExtendStrategy::kSameAsRequested);  // need this strategy. kNextPowerOfTwo would overflow size_t
 
     void* first_ptr = b.Alloc(sizeof(float) * (1 << 6));
@@ -215,7 +215,7 @@ TEST(BFCArenaTest, TestCustomMemoryLimit) {
 
 TEST(BFCArenaTest, AllocationsAndDeallocationsWithGrowth) {
   // Max of 2GiB, but starts out small.
-  BFCArena a(std::unique_ptr<IDeviceAllocator>(new CPUAllocator()), 1LL << 31);
+  BFCArena a(std::unique_ptr<IAllocator>(new CPUAllocator()), 1LL << 31);
 
   // Allocate 10 raw pointers of sizes between 100 bytes and about
   // 64 megs.
@@ -273,7 +273,7 @@ TEST(BFCArenaTest, AllocationsAndDeallocationsWithGrowth) {
 
 TEST(BFCArenaTest, TestReserve) {
   // Configure a 1MiB byte limit
-  BFCArena a(std::unique_ptr<IDeviceAllocator>(new CPUAllocator()), 1 << 30);
+  BFCArena a(std::unique_ptr<IAllocator>(new CPUAllocator()), 1 << 30);
 
   void* first_ptr = a.Alloc(sizeof(float) * (1 << 6));
   void* second_ptr = a.Reserve(sizeof(float) * (1 << 20));


### PR DESCRIPTION
IDeviceAllocator used to have some methods specific to devices, but now it does nothing. Removing it to simplify the code.