### PR TITLE
Exclude registering CUDA EP in the Python wheel if DML is enabled

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -525,7 +525,7 @@ void RegisterExecutionProviders(InferenceSession* sess, const std::vector<std::s
 #endif
     } else if (type == kCudaExecutionProvider) {
 #if (defined USE_CUDA && defined USE_DML)
-      // If both CUDA and DML are requested, just register DML EP - so no op here
+      // If both CUDA and DML are requested, just register DML EP (below) - so no op here
       // as ORT doesn't have semantics of dealing with nodes assigned to multiple
       // device memory based GPU EPs. See comment and static_assert above.
 

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -495,12 +495,11 @@ void UpdateCudaProviderOptions(InferenceSession* sess, onnxruntime::CudaProvider
 }
 #endif
 
-// We don't have provision in ORT to perform data copies across nodes assigned different GPU based
+// We don't have provision in ORT to perform data copies across nodes assigned to different GPU based
 // EPs (which have different device memories associated with each). Using CUDA and TensorRT together
 // is fine as they are associated with the same device memory.
 // Currently we allow DML and CUDA together as we have a CI pipeline using it, but we will only register
-// one of the two below. This is because ORT doesn't have a provision to deal with potentially different device
-// memories involved.
+// one of the two below.
 static_assert(USE_MIGRAPHX && (USE_CUDA || USE_DML), "Including multiple GPU EPs in the build is not supported");
 
 /*
@@ -525,7 +524,7 @@ void RegisterExecutionProviders(InferenceSession* sess, const std::vector<std::s
       RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_MIGraphX(0));
 #endif
     } else if (type == kCudaExecutionProvider) {
-#if (defined USE_CUDA && defined USE_DML) || (defined USE_DML)
+#if (defined USE_CUDA && defined USE_DML)
       // If both CUDA and DML are requested, just register DML EP - so no op here
       // as ORT doesn't have semantics of dealing with nodes assigned to multiple
       // device memory based GPU EPs. See comment and static_assert above.

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -495,6 +495,14 @@ void UpdateCudaProviderOptions(InferenceSession* sess, onnxruntime::CudaProvider
 }
 #endif
 
+// We don't have provision in ORT to perform data copies across nodes assigned different GPU based
+// EPs (which have different device memories associated with each). Using CUDA and TensorRT together
+// is fine as they are associated with the same device memory.
+// Currently we allow DML and CUDA together as we have a CI pipeline using it, but we will only register
+// one of the two below. This is because ORT doesn't have a provision to deal with potentially different device
+// memories involved.
+static_assert(USE_MIGRAPHX && (USE_CUDA || USE_DML), "Including multiple GPU EPs in the build is not supported");
+
 /*
  * Register execution provider with options.
  *
@@ -517,8 +525,12 @@ void RegisterExecutionProviders(InferenceSession* sess, const std::vector<std::s
       RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_MIGraphX(0));
 #endif
     } else if (type == kCudaExecutionProvider) {
-#ifdef USE_CUDA
+#if (defined USE_CUDA && defined USE_DML) || (defined USE_DML)
+      // If both CUDA and DML are requested, just register DML EP - so no op here
+      // as ORT doesn't have semantics of dealing with nodes assigned to multiple
+      // device memory based GPU EPs. See comment and static_assert above.
 
+#elif defined USE_CUDA
       auto it = provider_options_map.find(type);
       if (it != provider_options_map.end()) {
         onnxruntime::CudaProviderOptions cuda_provider_options;

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -495,19 +495,20 @@ void UpdateCudaProviderOptions(InferenceSession* sess, onnxruntime::CudaProvider
 }
 #endif
 
-// We don't have provision in ORT to perform data copies across nodes assigned to different GPU based
-// EPs (which have different device memories associated with each). Using CUDA and TensorRT together
-// is fine as they are associated with the same device memory.
-// Currently we allow DML and CUDA together as we have a CI pipeline using it, but we will only register
-// one of the two below.
-static_assert(!(USE_MIGRAPHX && (USE_CUDA || USE_DML)),
-              "Including multiple GPU EPs in the build is not supported");
-
 /*
  * Register execution provider with options.
  *
  * (note: currently only cuda EP supports this feature and rest of EPs use default options)
  */
+// We don't have provision in ORT to perform data copies across nodes assigned to different GPU based
+// EPs (which have different device memories associated with each). Using CUDA and TensorRT together
+// is fine as they are associated with the same device memory.
+// Currently we allow DML and CUDA together as we have a CI pipeline using it, but we will only register
+// one of the two below.
+#if (defined USE_MIGRAPHX && (defined USE_CUDA || defined USE_DML))
+static_assert(false, "Including multiple GPU EPs in the build is not supported");
+#endif
+
 void RegisterExecutionProviders(InferenceSession* sess, const std::vector<std::string>& provider_types,
                                 ProviderOptionsMap& provider_options_map) {
   PYBIND_UNREFERENCED_PARAMETER(provider_options_map);

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -527,9 +527,16 @@ void RegisterExecutionProviders(InferenceSession* sess, const std::vector<std::s
 #endif
     } else if (type == kCudaExecutionProvider) {
 #if (defined USE_CUDA && defined USE_DML)
-      // If both CUDA and DML are requested, just register DML EP (below) - so no op here
-      // as ORT doesn't have semantics of dealing with nodes assigned to multiple
+      // If both CUDA and DML are requested in this build, just register DML EP (below) -
+      // so no op here as ORT doesn't have semantics of dealing with nodes assigned to multiple
       // device memory based GPU EPs. See comment and static_assert above.
+
+      // Adding logs to indicate that this is a no op as technically a user could try to
+      // register the CUDA EP given that it would be part of the list of available providers
+      // in a build that enables USE_CUDA
+      const logging::Logger& default_logger = logging::LoggingManager::DefaultLogger();
+      LOGS(default_logger, WARNING) << "Unable to register the CUDA EP as this build supports DML "
+                                    << "and ORT doesn't support both DML and CUDA in the same build";
 
 #elif defined USE_CUDA
       auto it = provider_options_map.find(type);

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -500,7 +500,8 @@ void UpdateCudaProviderOptions(InferenceSession* sess, onnxruntime::CudaProvider
 // is fine as they are associated with the same device memory.
 // Currently we allow DML and CUDA together as we have a CI pipeline using it, but we will only register
 // one of the two below.
-static_assert(USE_MIGRAPHX && (USE_CUDA || USE_DML), "Including multiple GPU EPs in the build is not supported");
+static_assert(!(USE_MIGRAPHX && (USE_CUDA || USE_DML)),
+              "Including multiple GPU EPs in the build is not supported");
 
 /*
  * Register execution provider with options.


### PR DESCRIPTION
**Description**: https://github.com/microsoft/onnxruntime/pull/4630 is trying to add support for DML EP in Python. Currently we are allowing registering multiple GPU EPs if the wheel is built with multiple GPU EP options enabled. This is in theory not supported by ORT (with the exception of CUDA and TensorRT) as ORT doesn't have provisions to transfer data across nodes assigned to different GPU EPs (with the above exception). So this change includes 2 parts:

1) Include a static_assert to disallow including multiple GPU EPs' option while building with one exception - USE_DML and USE_CUDA.
2) We allow DML and CUDA alone for now as the Windows GPU pipeline combines both the build options currently. This breaks an ML op test in #4630 because there is a model where one node is assigned to CUDA and a downstream node is assigned to DML and memcpy transformer can't handle it. We could special case the test to only create a session with either DML or CUDA  (based on the build) but this is not scalable I would like to prevent registering both the EPs in the wheel altogether as this could affect any customer model if built with both options enabled. So the logic is:
    * if both DML and CUDA are enabled or only DML is enabled: only support registering DML EP
    * if only CUDA is enabled : support registering CUDA EP    

**Motivation and Context**
Help merge #4630 for 1.5 (This change should ideally be in that PR but I don't have permissions to push to the fork) 
