### PR TITLE
Add C#API for AddSessionConfigEntry

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.cs
@@ -175,6 +175,10 @@ namespace Microsoft.ML.OnnxRuntime
             NativeApiStatus.VerifySuccess(NativeMethods.OrtRegisterCustomOpsLibrary(handle, libraryPath, out libraryHandle));
         }
 
+        public void AddSessionConfigEntry(string configKey, string configValue)
+        {
+            NativeApiStatus.VerifySuccess(NativeMethods.OrtAddSessionConfigEntry(handle, configKey, configValue));
+        }
         #endregion
 
         internal IntPtr Handle


### PR DESCRIPTION
**Description**: Add C#API for AddSessionConfigEntry

**Motivation and Context**
- AddSessionConfigEntry is not exposed in C#
