### PR TITLE
Prevent registering both DML and CUDA EPs in an ML op test

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -571,6 +571,7 @@ void RegisterExecutionProviders(InferenceSession* sess, const std::vector<std::s
       RegisterExecutionProvider(
           sess, *onnxruntime::CreateExecutionProviderFactory_ArmNN(sess->GetSessionOptions().enable_cpu_mem_arena));
 #endif
+    } else if (type == kDmlExecutionProvider) {
     } else {
       // unknown provider
       throw std::runtime_error("Unknown Provider Type: " + type);


### PR DESCRIPTION
**Description**: Prevent registering both GPU and DML EPs for an ML op test which is breaking in #4630 (because the Windows gpu pipeline is built with DML and CUDA enabled) and there are nodes assigned to both CUDA and DML EPs which ORT currently doesn't handle. 

**Motivation and Context**
Help merge #4630 for 1.5 (This change should ideally be in that PR but I don't have permissions to push to the fork)
