### PR TITLE
User/brianma/telemetry

### DIFF
--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -28,9 +28,8 @@ class GPUTensorToDX12TextureTelemetryEvent {
     runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
         winml_trace_logging_provider,
-        "GPUTensorToDX12Texture",
+        "GPUTensorToDX12TextureStart",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingOpcode(EVENT_TRACE_TYPE_START),
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
@@ -41,9 +40,8 @@ class GPUTensorToDX12TextureTelemetryEvent {
   ~GPUTensorToDX12TextureTelemetryEvent() {
     TraceLoggingWrite(
         winml_trace_logging_provider,
-        "GPUTensorToDX12Texture",
+        "GPUTensorToDX12TextureStop",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
         TraceLoggingHexInt32(S_OK, "HRESULT"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
@@ -60,9 +58,8 @@ class ConvertGPUTensorToSoftwareBitmapTelemetryEvent {
     runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
         winml_trace_logging_provider,
-        "ConvertGPUTensorToSoftwareBitmap",
+        "ConvertGPUTensorToSoftwareBitmapStart",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingOpcode(EVENT_TRACE_TYPE_START),
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
@@ -73,9 +70,8 @@ class ConvertGPUTensorToSoftwareBitmapTelemetryEvent {
   ~ConvertGPUTensorToSoftwareBitmapTelemetryEvent() {
     TraceLoggingWrite(
         winml_trace_logging_provider,
-        "ConvertGPUTensorToSoftwareBitmap",
+        "ConvertGPUTensorToSoftwareBitmapStop",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
         TraceLoggingHexInt32(S_OK, "HRESULT"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
@@ -92,9 +88,8 @@ class ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent {
     runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
         winml_trace_logging_provider,
-        "ConvertCPUTensorToVideoFrameWithSoftwareBitmap",
+        "ConvertCPUTensorToVideoFrameWithSoftwareBitmapStart",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingOpcode(EVENT_TRACE_TYPE_START),
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
@@ -105,9 +100,8 @@ class ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent {
   ~ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent() {
     TraceLoggingWrite(
         winml_trace_logging_provider,
-        "ConvertCPUTensorToVideoFrameWithSoftwareBitmap",
+        "ConvertCPUTensorToVideoFrameWithSoftwareBitmapStop",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
         TraceLoggingHexInt32(S_OK, "HRESULT"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),

--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -35,6 +35,7 @@ class GPUTensorToDX12TextureTelemetryEvent {
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
   ~GPUTensorToDX12TextureTelemetryEvent() {
@@ -45,6 +46,7 @@ class GPUTensorToDX12TextureTelemetryEvent {
         TraceLoggingHexInt32(S_OK, "HRESULT"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
 
@@ -65,6 +67,7 @@ class ConvertGPUTensorToSoftwareBitmapTelemetryEvent {
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
   ~ConvertGPUTensorToSoftwareBitmapTelemetryEvent() {
@@ -75,6 +78,7 @@ class ConvertGPUTensorToSoftwareBitmapTelemetryEvent {
         TraceLoggingHexInt32(S_OK, "HRESULT"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
 
@@ -95,6 +99,7 @@ class ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent {
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
   ~ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent() {
@@ -105,6 +110,7 @@ class ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent {
         TraceLoggingHexInt32(S_OK, "HRESULT"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
 

--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -25,6 +25,7 @@ using namespace _winml;
 class GPUTensorToDX12TextureTelemetryEvent {
  public:
   GPUTensorToDX12TextureTelemetryEvent(const ImageTensorDescription& tensorDesc) {
+    runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
         winml_trace_logging_provider,
         "GPUTensorToDX12Texture",
@@ -33,6 +34,7 @@ class GPUTensorToDX12TextureTelemetryEvent {
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
@@ -43,14 +45,19 @@ class GPUTensorToDX12TextureTelemetryEvent {
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
         TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
         TraceLoggingHexInt32(S_OK, "HRESULT"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
+
+private:
+  int runtime_session_id_;
 };
 
 class ConvertGPUTensorToSoftwareBitmapTelemetryEvent {
  public:
   ConvertGPUTensorToSoftwareBitmapTelemetryEvent(const ImageTensorDescription& tensorDesc) {
+    runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
         winml_trace_logging_provider,
         "ConvertGPUTensorToSoftwareBitmap",
@@ -59,6 +66,7 @@ class ConvertGPUTensorToSoftwareBitmapTelemetryEvent {
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
@@ -69,14 +77,19 @@ class ConvertGPUTensorToSoftwareBitmapTelemetryEvent {
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
         TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
         TraceLoggingHexInt32(S_OK, "HRESULT"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
+
+private:
+  int runtime_session_id_;
 };
 
 class ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent {
  public:
   ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent(const ImageTensorDescription& tensorDesc) {
+    runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
         winml_trace_logging_provider,
         "ConvertCPUTensorToVideoFrameWithSoftwareBitmap",
@@ -85,6 +98,7 @@ class ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent {
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
@@ -95,9 +109,13 @@ class ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent {
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
         TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
         TraceLoggingHexInt32(S_OK, "HRESULT"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
+
+private:
+  int runtime_session_id_;
 };
 
 void TensorToVideoFrameConverter::DX12TensorToVideoFrame(

--- a/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
+++ b/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
@@ -24,6 +24,7 @@ using namespace _winml;
 class DX12TextureToGPUTensorTelemetryEvent {
  public:
   DX12TextureToGPUTensorTelemetryEvent(const ImageTensorDescription& tensorDesc) {
+    runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
         winml_trace_logging_provider,
         "DX12TextureToGPUTensor",
@@ -32,6 +33,7 @@ class DX12TextureToGPUTensorTelemetryEvent {
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
@@ -42,14 +44,19 @@ class DX12TextureToGPUTensorTelemetryEvent {
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
         TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
         TraceLoggingHexInt32(S_OK, "HRESULT"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
+
+private:
+  int runtime_session_id_;
 };
 
 class SoftwareBitmapToGPUTensorTelemetryEvent {
  public:
   SoftwareBitmapToGPUTensorTelemetryEvent(const ImageTensorDescription& tensorDesc) {
+    runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
         winml_trace_logging_provider,
         "SoftwareBitmapToGPUTensor",
@@ -58,6 +65,7 @@ class SoftwareBitmapToGPUTensorTelemetryEvent {
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
@@ -68,14 +76,19 @@ class SoftwareBitmapToGPUTensorTelemetryEvent {
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
         TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
         TraceLoggingHexInt32(S_OK, "HRESULT"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
+
+private:
+  int runtime_session_id_;
 };
 
 class ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent {
  public:
   ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent(const ImageTensorDescription& tensorDesc) {
+    runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
         winml_trace_logging_provider,
         "ConvertVideoFrameWithSoftwareBitmapToCPUTensor",
@@ -84,6 +97,7 @@ class ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent {
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
@@ -94,9 +108,13 @@ class ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent {
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
         TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
         TraceLoggingHexInt32(S_OK, "HRESULT"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
+
+private:
+  int runtime_session_id_;
 };
 
 void VideoFrameToTensorConverter::VideoFrameToSoftwareTensor(

--- a/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
+++ b/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
@@ -27,9 +27,8 @@ class DX12TextureToGPUTensorTelemetryEvent {
     runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
         winml_trace_logging_provider,
-        "DX12TextureToGPUTensor",
+        "DX12TextureToGPUTensorStart",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingOpcode(EVENT_TRACE_TYPE_START),
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
@@ -40,9 +39,8 @@ class DX12TextureToGPUTensorTelemetryEvent {
   ~DX12TextureToGPUTensorTelemetryEvent() {
     TraceLoggingWrite(
         winml_trace_logging_provider,
-        "DX12TextureToGPUTensor",
+        "DX12TextureToGPUTensorStop",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
         TraceLoggingHexInt32(S_OK, "HRESULT"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
@@ -59,9 +57,8 @@ class SoftwareBitmapToGPUTensorTelemetryEvent {
     runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
         winml_trace_logging_provider,
-        "SoftwareBitmapToGPUTensor",
+        "SoftwareBitmapToGPUTensorStart",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingOpcode(EVENT_TRACE_TYPE_START),
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
@@ -72,9 +69,8 @@ class SoftwareBitmapToGPUTensorTelemetryEvent {
   ~SoftwareBitmapToGPUTensorTelemetryEvent() {
     TraceLoggingWrite(
         winml_trace_logging_provider,
-        "SoftwareBitmapToGPUTensor",
+        "SoftwareBitmapToGPUTensorStop",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
         TraceLoggingHexInt32(S_OK, "HRESULT"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
@@ -91,9 +87,8 @@ class ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent {
     runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
         winml_trace_logging_provider,
-        "ConvertVideoFrameWithSoftwareBitmapToCPUTensor",
+        "ConvertVideoFrameWithSoftwareBitmapToCPUTensorStart",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingOpcode(EVENT_TRACE_TYPE_START),
         TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
         TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
@@ -104,9 +99,8 @@ class ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent {
   ~ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent() {
     TraceLoggingWrite(
         winml_trace_logging_provider,
-        "ConvertVideoFrameWithSoftwareBitmapToCPUTensor",
+        "ConvertVideoFrameWithSoftwareBitmapToCPUTensorStop",
         TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingOpcode(EVENT_TRACE_TYPE_STOP),
         TraceLoggingHexInt32(S_OK, "HRESULT"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),

--- a/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
+++ b/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
@@ -34,6 +34,7 @@ class DX12TextureToGPUTensorTelemetryEvent {
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
   ~DX12TextureToGPUTensorTelemetryEvent() {
@@ -44,6 +45,7 @@ class DX12TextureToGPUTensorTelemetryEvent {
         TraceLoggingHexInt32(S_OK, "HRESULT"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
 
@@ -64,6 +66,7 @@ class SoftwareBitmapToGPUTensorTelemetryEvent {
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
   ~SoftwareBitmapToGPUTensorTelemetryEvent() {
@@ -74,6 +77,7 @@ class SoftwareBitmapToGPUTensorTelemetryEvent {
         TraceLoggingHexInt32(S_OK, "HRESULT"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
 
@@ -94,6 +98,7 @@ class ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent {
         TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
   ~ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent() {
@@ -104,6 +109,7 @@ class ConvertVideoFrameWithSoftwareBitmapToCPUTensorTelemetryEvent {
         TraceLoggingHexInt32(S_OK, "HRESULT"),
         TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
         TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
 

--- a/winml/lib/Common/inc/WinMLTelemetryHelper.h
+++ b/winml/lib/Common/inc/WinMLTelemetryHelper.h
@@ -103,6 +103,7 @@ class WinMLTelemetryHelper {
       uint32_t value);
   void EndRuntimeSession() { ++runtime_session_id_; };
   bool IsMeasureSampled();
+  int GetRuntimeSessionId() { return runtime_session_id_; }
 
  private:
   void RestartTimer() {


### PR DESCRIPTION
(de)tensorization telemetry events had duplicate names for start/stop which makes post-processing difficult, so we're changing the names to be explicitly start/stop. Doing this makes the opcodes unnecessary as well. 
Also, the events were missing the runtime session id property which is needed to correlate events per session. 