### PR TITLE
Improve the minimal build size on android and linux

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -215,10 +215,21 @@ endif()
 if(onnxruntime_MINIMAL_BUILD)
   add_compile_definitions(ORT_MINIMAL_BUILD)
   set(onnxruntime_REDUCED_OPS_BUILD ON)
-  set(onnxruntime_DISABLE_RTTI ON)
+
+  if (NOT onnxruntime_ENABLE_PYTHON)
+    # Python bindings use typeid so can't automatically disable RTTI in that case
+    set(onnxruntime_DISABLE_RTTI ON)
+  endif()
 
   if (MSVC)
     # add MSVC specific flags to reduce build size here if needed
+    
+    # undocumented internal flag to allow analysis of a minimal build binary size
+    if (ADD_DEBUG_INFO_TO_MINIMAL_BUILD)
+      string(APPEND CMAKE_CXX_FLAGS " /Zi")
+      string(APPEND CMAKE_C_FLAGS " /Zi")
+      string(APPEND CMAKE_SHARED_LINKER_FLAGS " /debug")
+    endif()
   else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections")
     if (CMAKE_HOST_SYSTEM MATCHES "Darwin")
@@ -227,7 +238,6 @@ if(onnxruntime_MINIMAL_BUILD)
       add_link_options(-Wl,--gc-sections)
     endif()  
   endif()
-
 endif()
 
 if (onnxruntime_REDUCED_OPS_BUILD)

--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -68,7 +68,9 @@ if (NOT WIN32)
   endif()
 endif()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Android")
+
+# strip binary on Android, or for a minimal build on Unix
+if(CMAKE_SYSTEM_NAME STREQUAL "Android" OR (onnxruntime_MINIMAL_BUILD AND UNIX))
   set_target_properties(onnxruntime PROPERTIES LINK_FLAGS_RELEASE -s)
   set_target_properties(onnxruntime PROPERTIES LINK_FLAGS_MINSIZEREL -s)
 endif()

--- a/docs/ONNX_Runtime_for_Mobile_Platforms.md
+++ b/docs/ONNX_Runtime_for_Mobile_Platforms.md
@@ -80,7 +80,7 @@ The follow options can be used to reduce the build size. Enable all options that
 
   - Enable minimal build (`--minimal_build`)
     - A minimal build will ONLY support loading and executing ORT format models. 
-      - RTTI is disabled by default in this build, so adding the `--disable_rtti` build flag is not necessary.
+    - RTTI is disabled by default in this build, unless the Python bindings (`--build_wheel`) are enabled. 
 
   - Disable exceptions (`--disable_exceptions`)
     - Disables support for exceptions in the build.
@@ -92,6 +92,10 @@ The follow options can be used to reduce the build size. Enable all options that
   - ML op support (`--disable_ml_ops`)
     - Whilst the operator kernel reduction script will disable all unused ML operator kernels, additional savings can be achieved by removing support for ML specific types. If you know that your model has no ML ops, or no ML ops that use the Map type, this flag can be provided. 
     - See the specs for the [ONNX ML Operators](https://github.com/onnx/onnx/blob/master/docs/Operators-ml.md) if unsure.
+
+  - Use shared libc++ on Android (`--android_cpp_shared`)
+    - Building using the shared libc++ library instead of the default static libc++ library will result in a smaller libonnxruntime.so library.
+    - See [Android NDK documentation](https://developer.android.com/ndk/guides/cpp-support) for more information.
 
 #### Build Configuration 
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -190,17 +190,13 @@ def parse_arguments():
         "CMake setup. Delete CMakeCache.txt if needed")
     parser.add_argument(
         "--msvc_toolset", help="MSVC toolset to use. e.g. 14.11")
-    parser.add_argument(
-        "--android", action='store_true', help='Build for Android')
-    parser.add_argument(
-        "--android_abi", type=str, default='arm64-v8a', help='')
-    parser.add_argument(
-        "--android_api", type=int, default=27,
-        help='Android API Level, e.g. 21')
-    parser.add_argument(
-        "--android_sdk_path", type=str, help='Path to the Android SDK')
-    parser.add_argument(
-        "--android_ndk_path", default="", help="Path to the Android NDK")
+    parser.add_argument("--android", action='store_true', help='Build for Android')
+    parser.add_argument("--android_abi", type=str, default='arm64-v8a', help='')
+    parser.add_argument("--android_api", type=int, default=27, help='Android API Level, e.g. 21')
+    parser.add_argument("--android_sdk_path", type=str, help='Path to the Android SDK')
+    parser.add_argument("--android_ndk_path", default="", help="Path to the Android NDK")
+    parser.add_argument("--android_cpp_shared", action="store_true",
+                        help="Build with shared libc++ instead of the default static libc++.")
 
     parser.add_argument("--ios", action='store_true', help="build for ios")
     parser.add_argument(
@@ -724,6 +720,9 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
             "-DANDROID_PLATFORM=android-" + str(args.android_api),
             "-DANDROID_ABI=" + str(args.android_abi)
         ]
+
+        if args.android_cpp_shared:
+            cmake_args += ["-DANDROID_STL=c++_shared"]
 
     if args.ios:
         if is_macOS():


### PR DESCRIPTION
**Description**: 
Improve the minimal build size on android and linux
  - allow building using shared libc++ on android
  - strip binary from minimal build on linux

Fix bug where linux build fails when python is enabled and rtti is disabled
  - only automatically disable rtti in a minimal build if python is not enabled

Update doco for new build settings

**Motivation and Context**
Minimal build improvements