### PR TITLE
Workaround for x86 Android MLAS build break

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -176,7 +176,11 @@ else()
     set(mlas_platform_srcs_avx
       ${ONNXRUNTIME_ROOT}/core/mlas/lib/x86/SgemmKernelAvx.S
     )
-    set_source_files_properties(${mlas_platform_srcs_avx} PROPERTIES COMPILE_FLAGS "-mavx")
+    if (CMAKE_SYSTEM_NAME STREQUAL "Android")
+      set_source_files_properties(${mlas_platform_srcs_avx} PROPERTIES COMPILE_FLAGS "-mavx -fno-integrated-as")
+    else()
+      set_source_files_properties(${mlas_platform_srcs_avx} PROPERTIES COMPILE_FLAGS "-mavx")
+    endif()
 
     set(mlas_platform_srcs
       ${mlas_platform_srcs_sse2}


### PR DESCRIPTION
**Description**: Workaround for x86 Android MLAS build break
-  [Android x86 build only] Fall back to GNU assembler instead of the integrated assembler

**Motivation and Context**
- This is a work around for x86 Android build break in MLAS
