### PR TITLE
Add ability to generate configuration file with required operators.

### DIFF
--- a/docs/Reduced_Operator_Kernel_build.md
+++ b/docs/Reduced_Operator_Kernel_build.md
@@ -69,3 +69,9 @@ python exclude_unused_ops.py --model_path d:\ReduceSize\models --config_path d:\
 
 After running the script build ORT as per the build instructions. Remember to specify `--skip-tests`.
 
+#### Generating configuration file
+
+Note: It is also possible to generate a configuration file for future usage by providing the `--write_combined_config_to` argument to `exclude_unused_ops.py`.
+If run this way it will process the information provided by `--model_path` and/or `--config_path`, and output a configuration file with the combined list of required operators to the provided path. 
+No kernel registration changes will be made when run this way. 
+

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1621,10 +1621,10 @@ def main():
         args.test = False
 
     if args.include_ops_by_model or args.include_ops_by_config:
-        from exclude_unused_ops import exclude_unused_ops, get_provider_path
-        include_ops_by_model = args.include_ops_by_model if args.include_ops_by_model else ''
-        include_ops_by_config = args.include_ops_by_config if args.include_ops_by_config else ''
-        exclude_unused_ops(include_ops_by_model, include_ops_by_config, get_provider_path(use_cuda=args.use_cuda))
+        from exclude_unused_ops import exclude_unused_ops
+        models_path = args.include_ops_by_model if args.include_ops_by_model else ''
+        config_path = args.include_ops_by_config if args.include_ops_by_config else ''
+        exclude_unused_ops(models_path, config_path, use_cuda=args.use_cuda)
 
     if args.use_tensorrt:
         args.use_cuda = True

--- a/tools/ci_build/exclude_unused_ops.py
+++ b/tools/ci_build/exclude_unused_ops.py
@@ -50,6 +50,9 @@ def extract_ops_from_config(file_path, required_ops):
         for stripped_line in [line.strip() for line in
                               file_to_read.readlines()]:
 
+            if not stripped_line:  # skip empty lines
+                continue
+
             if stripped_line.startswith("#"):  # skip comments
                 continue
 

--- a/tools/ci_build/exclude_unused_ops.py
+++ b/tools/ci_build/exclude_unused_ops.py
@@ -382,7 +382,6 @@ if __name__ == "__main__":
     if not ort_root:
         log.info('ort_root was not specified. Inferring ORT root from location of this script.')
 
-
     if not args.write_combined_config_to:
         exclude_unused_ops(models_path, config_path, ort_root, use_cuda=True)
     else:

--- a/tools/ci_build/exclude_unused_ops.py
+++ b/tools/ci_build/exclude_unused_ops.py
@@ -306,6 +306,7 @@ def create_config_file_with_required_ops(required_operators, model_path, config_
     directory, filename = os.path.split(output_file)
     if not filename:
         log.error("Invalid path to write final config to. {}".format(output_file))
+        sys.exit(-1)
 
     if not os.path.exists(directory):
         os.makedirs(directory)

--- a/tools/ci_build/exclude_unused_ops.py
+++ b/tools/ci_build/exclude_unused_ops.py
@@ -349,7 +349,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Script to exclude unused operator kernels by disabling their registration in ONNXRuntime."
                     "See /docs/Reduced_Operator_Kernel_build.md for more information",
-        usage="Provide model_path, config_path, or both, to disabled kernel registration of unused kernels.")
+        usage="Provide model_path, config_path, or both, to disable kernel registration of unused kernels.")
 
     parser.add_argument(
         "--model_path", type=str, help="Path to folder containing one or more ONNX models")


### PR DESCRIPTION
**Description**: 
Add ability to generate configuration file with required operators to use when excluding unused kernels.

Tweak exclusion script to exit if directory or config file name are not valid. Continuing will result in all operators being disabled which is most likely not expected when an explicitly provided input was invalid.

**Motivation and Context**
Partner request. 