### PR TITLE
Not to call NVTX when not available

### DIFF
--- a/orttraining/orttraining/training_ops/cuda/communication/nccl_service.cc
+++ b/orttraining/orttraining/training_ops/cuda/communication/nccl_service.cc
@@ -172,17 +172,18 @@ int NcclService::FindNextCommunicationTime() const {
 void NcclService::SubmitSendAndWait(void* ptr, size_t size, int peer) {
   // Wait until NCCL service is launched.
   WaitForLaunch();
-  auto& profile_context = profile::Context::GetInstance();
-  const auto tag = profile_context.GetThreadTagOrDefault(std::this_thread::get_id());
-
   // Pointer to enqueued task.
   const NcclTask* task;
 
   // Submit task.
   {
     std::lock_guard<std::mutex> guard(mutex_);
+#ifdef ENABLE_NVTX_PROFILE
     auto& profile_context = profile::Context::GetInstance();
-    const auto tag = profile_context.GetThreadTagOrDefault(std::this_thread::get_id());
+    const std::string tag = profile_context.GetThreadTagOrDefault(std::this_thread::get_id());
+#else
+    const std::string tag = "";
+#endif
     task = schedule_[time_].EqueueTask(NcclTask::Type::SEND, std::vector<int>{peer}, ptr, size, tag);
   }
 
@@ -201,8 +202,12 @@ void NcclService::SubmitRecvAndWait(void* ptr, size_t size, int peer) {
   const NcclTask* task;
   {
     std::lock_guard<std::mutex> guard(mutex_);
+#ifdef ENABLE_NVTX_PROFILE
     auto& profile_context = profile::Context::GetInstance();
-    const auto tag = profile_context.GetThreadTagOrDefault(std::this_thread::get_id());
+    const auto std::string = profile_context.GetThreadTagOrDefault(std::this_thread::get_id());
+#else
+    const auto std::string tag = "";
+#endif
     task = schedule_[time_].EqueueTask(NcclTask::Type::RECV, std::vector<int>{peer}, ptr, size, tag);
   }
 

--- a/orttraining/orttraining/training_ops/cuda/communication/nccl_service.cc
+++ b/orttraining/orttraining/training_ops/cuda/communication/nccl_service.cc
@@ -204,9 +204,9 @@ void NcclService::SubmitRecvAndWait(void* ptr, size_t size, int peer) {
     std::lock_guard<std::mutex> guard(mutex_);
 #ifdef ENABLE_NVTX_PROFILE
     auto& profile_context = profile::Context::GetInstance();
-    const auto std::string = profile_context.GetThreadTagOrDefault(std::this_thread::get_id());
+    const std::string = profile_context.GetThreadTagOrDefault(std::this_thread::get_id());
 #else
-    const auto std::string tag = "";
+    const std::string tag = "";
 #endif
     task = schedule_[time_].EqueueTask(NcclTask::Type::RECV, std::vector<int>{peer}, ptr, size, tag);
   }

--- a/orttraining/orttraining/training_ops/cuda/communication/nccl_service.cc
+++ b/orttraining/orttraining/training_ops/cuda/communication/nccl_service.cc
@@ -204,7 +204,7 @@ void NcclService::SubmitRecvAndWait(void* ptr, size_t size, int peer) {
     std::lock_guard<std::mutex> guard(mutex_);
 #ifdef ENABLE_NVTX_PROFILE
     auto& profile_context = profile::Context::GetInstance();
-    const std::string = profile_context.GetThreadTagOrDefault(std::this_thread::get_id());
+    const std::string tag = profile_context.GetThreadTagOrDefault(std::this_thread::get_id());
 #else
     const std::string tag = "";
 #endif


### PR DESCRIPTION
When `ENABLE_NVTX_PROFILE=0`, we can't call NVTX-related functions, so we put related code into `#ifdef ENABLE_NVTX_PROFILE`.
