### PR TITLE
skip tests when model opset > released opset

### DIFF
--- a/nodejs/test/test-runner.ts
+++ b/nodejs/test/test-runner.ts
@@ -53,7 +53,7 @@ export function run(testDataFolder: string): void {
     // add cases
     describe(`${model}`, () => {
       let session: InferenceSession|null = null;
-      const skipModel = shouldSkipModel(model, ['cpu'], modelPath);
+      const skipModel = shouldSkipModel(model, ['cpu']);
       if (!skipModel) {
         before(async function () {
           try {

--- a/nodejs/test/test-runner.ts
+++ b/nodejs/test/test-runner.ts
@@ -53,7 +53,7 @@ export function run(testDataFolder: string): void {
     // add cases
     describe(`${model}`, () => {
       let session: InferenceSession;
-      const skipModel = shouldSkipModel(model, ['cpu']);
+      const skipModel = shouldSkipModel(model, ['cpu'], modelPath);
       if (!skipModel) {
         before(async () => {
           session = await InferenceSession.create(modelPath);

--- a/nodejs/test/test-runner.ts
+++ b/nodejs/test/test-runner.ts
@@ -59,6 +59,11 @@ export function run(testDataFolder: string): void {
           try {
             session = await InferenceSession.create(modelPath);
           } catch (e) {
+            // By default ort allows models with opsets from an official onnx release only. If it encounters
+            // a model with opset > than released opset, ValidateOpsetForDomain throws an error and model load fails.
+            // Since this is by design such a failure is acceptable in the context of this test. Therefore we simply
+            // skip this test. Setting env variable ALLOW_RELEASED_ONNX_OPSET_ONLY=0 allows loading a model with 
+            // opset > released onnx opset.
             if (process.env.ALLOW_RELEASED_ONNX_OPSET_ONLY !== '0' && e.message.includes("ValidateOpsetForDomain")) {
               session = null;
               console.log(`Skipping ${model}. To run this test set env variable ALLOW_RELEASED_ONNX_OPSET_ONLY=0`);

--- a/nodejs/test/test-utils.ts
+++ b/nodejs/test/test-utils.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 
 import {binding} from '../lib/binding';
 import {Tensor} from '../lib/tensor';
-import {InferenceSession} from '../lib';
 
 export const TEST_ROOT = __dirname;
 export const TEST_DATA_ROOT = path.join(TEST_ROOT, 'testdata');
@@ -21,7 +20,7 @@ export const SQUEEZENET_INPUT0_DATA: number[] = require(path.join(TEST_DATA_ROOT
 export const SQUEEZENET_OUTPUT0_DATA: number[] = require(path.join(TEST_DATA_ROOT, 'squeezenet.output0.json'));
 
 export const BACKEND_TEST_SERIES_FILTERS: {[name: string]: string[]} =
-    jsonc.readSync(path.join(ORT_ROOT, 'onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc'));
+  jsonc.readSync(path.join(ORT_ROOT, 'onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc'));
 
 
 export const NUMERIC_TYPE_MAP = new Map<Tensor.Type, new (len: number) => Tensor.DataType>([
@@ -106,7 +105,7 @@ export function assertDataEqual(type: Tensor.Type, actual: Tensor.DataType, expe
     case 'float32':
     case 'float64':
       assertFloatEqual(
-          actual as number[] | Float32Array | Float64Array, expected as number[] | Float32Array | Float64Array);
+        actual as number[] | Float32Array | Float64Array, expected as number[] | Float32Array | Float64Array);
       break;
 
     case 'uint8':
@@ -128,7 +127,7 @@ export function assertDataEqual(type: Tensor.Type, actual: Tensor.DataType, expe
 }
 
 export function assertFloatEqual(
-    actual: number[]|Float32Array|Float64Array, expected: number[]|Float32Array|Float64Array): void {
+  actual: number[]|Float32Array|Float64Array, expected: number[]|Float32Array|Float64Array): void {
   const THRESHOLD_ABSOLUTE_ERROR = 1.0e-4;
   const THRESHOLD_RELATIVE_ERROR = 1.000001;
 
@@ -182,19 +181,19 @@ export function loadTensorFromFile(pbFile: string): Tensor {
     return new Tensor('string', tensorProto.stringData.map(i => i.toString()), dims);
   } else {
     switch (tensorProto.dataType) {
-        //     FLOAT = 1,
-        //     UINT8 = 2,
-        //     INT8 = 3,
-        //     UINT16 = 4,
-        //     INT16 = 5,
-        //     INT32 = 6,
-        //     INT64 = 7,
-        //     STRING = 8,
-        //     BOOL = 9,
-        //     FLOAT16 = 10,
-        //     DOUBLE = 11,
-        //     UINT32 = 12,
-        //     UINT64 = 13,
+      //     FLOAT = 1,
+      //     UINT8 = 2,
+      //     INT8 = 3,
+      //     UINT16 = 4,
+      //     INT16 = 5,
+      //     INT32 = 6,
+      //     INT64 = 7,
+      //     STRING = 8,
+      //     BOOL = 9,
+      //     FLOAT16 = 10,
+      //     DOUBLE = 11,
+      //     UINT32 = 12,
+      //     UINT64 = 13,
       case onnx_proto.onnx.TensorProto.DataType.FLOAT:
         transferredTypedArray = new Float32Array(tensorProto.rawData.byteLength / 4);
         type = 'float32';
@@ -243,7 +242,7 @@ export function loadTensorFromFile(pbFile: string): Tensor {
         throw new Error(`not supported tensor type: ${tensorProto.dataType}`);
     }
     const transferredTypedArrayRawDataView =
-        new Uint8Array(transferredTypedArray.buffer, transferredTypedArray.byteOffset, tensorProto.rawData.byteLength);
+      new Uint8Array(transferredTypedArray.buffer, transferredTypedArray.byteOffset, tensorProto.rawData.byteLength);
     transferredTypedArrayRawDataView.set(tensorProto.rawData);
 
     return new Tensor(type, transferredTypedArray, dims);
@@ -267,24 +266,6 @@ export function shouldSkipModel(model: string, eps: string[], modelPath: string)
     const regex = new RegExp(filter);
     for (const ep of eps) {
       if (regex.test(`${model}_${ep}`)) {
-        return true;
-      }
-    }
-  }
-
-  if (process.env.ALLOW_RELEASED_ONNX_OPSET_ONLY !== '0') {
-    try {
-      // create native session wrapper and load the model
-      let options: InferenceSession.SessionOptions = {};
-      const sessionWrapper = new binding.InferenceSession();
-      // load model
-      sessionWrapper.loadModel(modelPath, options);
-    } catch (e) {
-      // Mark this model to be skipped if model load fails because of the opset being out of the range of
-      // supported opsets.
-      // For all other errors ignore as they will be taken care of when the test
-      // for this model executes.
-      if (e.message.includes("ValidateOpsetForDomain")) {
         return true;
       }
     }

--- a/nodejs/test/test-utils.ts
+++ b/nodejs/test/test-utils.ts
@@ -249,7 +249,7 @@ export function loadTensorFromFile(pbFile: string): Tensor {
   }
 }
 
-export function shouldSkipModel(model: string, eps: string[], modelPath: string): boolean {
+export function shouldSkipModel(model: string, eps: string[]): boolean {
   const filters = ['(FLOAT16)'];
   filters.push(...BACKEND_TEST_SERIES_FILTERS.current_failing_tests);
 


### PR DESCRIPTION
**Description**: Skip model tests when ALLOW_RELEASED_ONNX_OPSET_ONLY and model imports latest opset (greater than released onnx opset). 

**Motivation and Context**
- Fix node.js pipeline failures. By default ort does not allow latest onnx opsets. Fixing the test infra to skip models which import latest opsets when ALLOW_RELEASED_ONNX_OPSET_ONLY is set. If ALLOW_RELEASED_ONNX_OPSET_ONLY is explicitly set to 0 then these model tests are not skipped.

