### PR TITLE
Enable onnx_test_runner for ort format

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -786,8 +786,14 @@ endif()
 
 if (onnxruntime_BUILD_SHARED_LIB)
   set(onnxruntime_perf_test_libs onnx_test_runner_common onnxruntime_test_utils  onnxruntime_common re2::re2
-          onnx_test_data_proto onnx_proto ${PROTOBUF_LIB} ${GETOPT_LIB_WIDE} onnxruntime onnxruntime_graph onnx ${SYS_PATH_LIB}
+          onnx_test_data_proto onnx_proto ${PROTOBUF_LIB} ${GETOPT_LIB_WIDE} onnxruntime ${SYS_PATH_LIB}
           ${CMAKE_DL_LIBS})
+  # We want to enable onnx_test_runner/perf_test for ort minimal builds, which will need the following
+  # ort lib statically linked, this is a temporary solution and is tracked by,
+  # Product Backlog Item 895235: Re-work onnx_test_runner/perf_test for ort/onnx model
+  if (onnxruntime_MINIMAL_BUILD)
+    list(APPEND onnxruntime_perf_test_libs onnxruntime_graph onnx onnxruntime_framework onnxruntime_mlas)
+  endif()
   if(NOT WIN32)
     list(APPEND onnxruntime_perf_test_libs nsync_cpp)
   endif()

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -111,12 +111,12 @@ if(NOT onnxruntime_MINIMAL_BUILD AND NOT onnxruntime_REDUCED_OPS_BUILD)
     "${TEST_SRC_DIR}/ir/*.cc"
     "${TEST_SRC_DIR}/ir/*.h"
     )
- 
+
   file(GLOB onnxruntime_test_optimizer_src CONFIGURE_DEPENDS
     "${TEST_SRC_DIR}/optimizer/*.cc"
     "${TEST_SRC_DIR}/optimizer/*.h"
     )
- 
+
   set(onnxruntime_test_framework_src_patterns
     "${TEST_SRC_DIR}/framework/*.cc"
     "${TEST_SRC_DIR}/framework/*.h"
@@ -130,7 +130,7 @@ else()  # minimal and/or reduced ops build
     )
 
   if (onnxruntime_MINIMAL_BUILD)
-    list(APPEND onnxruntime_test_framework_src_patterns 
+    list(APPEND onnxruntime_test_framework_src_patterns
       "${TEST_SRC_DIR}/framework/ort_model_only_test.cc"
     )
 
@@ -526,7 +526,7 @@ if (MSVC AND NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
   target_compile_options(onnx_test_runner_common PRIVATE "/wd4244")
 endif()
 onnxruntime_add_include_to_target(onnx_test_runner_common onnxruntime_common onnxruntime_framework
-        onnxruntime_test_utils onnx onnx_proto re2::re2)
+        onnxruntime_test_utils onnx onnx_proto re2::re2 flatbuffers)
 
 add_dependencies(onnx_test_runner_common onnx_test_data_proto ${onnxruntime_EXTERNAL_DEPENDENCIES})
 target_include_directories(onnx_test_runner_common PRIVATE ${eigen_INCLUDE_DIRS} ${RE2_INCLUDE_DIR}

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -786,7 +786,7 @@ endif()
 
 if (onnxruntime_BUILD_SHARED_LIB)
   set(onnxruntime_perf_test_libs onnx_test_runner_common onnxruntime_test_utils  onnxruntime_common re2::re2
-          onnx_test_data_proto onnx_proto ${PROTOBUF_LIB} ${GETOPT_LIB_WIDE} onnxruntime onnxruntime_graph onnx ${SYS_PATH_LIB}
+          onnx_test_data_proto onnx_proto ${PROTOBUF_LIB} ${GETOPT_LIB_WIDE} onnxruntime ${SYS_PATH_LIB}
           ${CMAKE_DL_LIBS})
   if(NOT WIN32)
     list(APPEND onnxruntime_perf_test_libs nsync_cpp)

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -786,7 +786,7 @@ endif()
 
 if (onnxruntime_BUILD_SHARED_LIB)
   set(onnxruntime_perf_test_libs onnx_test_runner_common onnxruntime_test_utils  onnxruntime_common re2::re2
-          onnx_test_data_proto onnx_proto ${PROTOBUF_LIB} ${GETOPT_LIB_WIDE} onnxruntime ${SYS_PATH_LIB}
+          onnx_test_data_proto onnx_proto ${PROTOBUF_LIB} ${GETOPT_LIB_WIDE} onnxruntime onnxruntime_graph onnx ${SYS_PATH_LIB}
           ${CMAKE_DL_LIBS})
   if(NOT WIN32)
     list(APPEND onnxruntime_perf_test_libs nsync_cpp)

--- a/include/onnxruntime/core/graph/node_arg.h
+++ b/include/onnxruntime/core/graph/node_arg.h
@@ -83,10 +83,10 @@ class NodeArg {
   @returns Success unless there is existing type or shape info that can't be successfully updated. */
   common::Status UpdateTypeAndShape(const NodeArg& node_arg, bool strict, bool override_types, const logging::Logger& logger);
 
+#endif  // !defined(ORT_MINIMAL_BUILD)
+
   /** Gets this NodeArg as a ValueInfoProto. */
   const NodeArgInfo& ToProto() const noexcept { return node_arg_info_; }
-
-#endif  // !defined(ORT_MINIMAL_BUILD)
 
   /** Gets a flag indicating whether this NodeArg exists or not.
   Optional inputs are allowed in ONNX and an empty #Name represents a non-existent input argument. */

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -285,12 +285,14 @@ void LoopDataFile(int test_data_pb_fd, bool is_input, const TestModelInfo& model
 }  // namespace
 
 std::unique_ptr<TestModelInfo> TestModelInfo::LoadOnnxModel(_In_ const PATH_CHAR_TYPE* model_url) {
-  return std::unique_ptr<TestModelInfo>(new OnnxModelInfo(model_url, false));
+  return std::unique_ptr<TestModelInfo>(new OnnxModelInfo(model_url));
 }
 
+#if defined(ORT_MINIMAL_BUILD)
 std::unique_ptr<TestModelInfo> TestModelInfo::LoadOrtModel(_In_ const PATH_CHAR_TYPE* model_url) {
-  return std::unique_ptr<TestModelInfo>(new OnnxModelInfo(model_url, true));
+  return std::unique_ptr<TestModelInfo>(new OrtModelInfo(model_url));
 }
+#endif
 
 /**
    * test_case_dir must have contents of:

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -285,11 +285,11 @@ void LoopDataFile(int test_data_pb_fd, bool is_input, const TestModelInfo& model
 }  // namespace
 
 std::unique_ptr<TestModelInfo> TestModelInfo::LoadOnnxModel(_In_ const PATH_CHAR_TYPE* model_url) {
-  return std::unique_ptr<TestModelInfo>(new OnnxModelInfo(model_url, false));
+  return std::unique_ptr<TestModelInfo>(new OnnxModelInfo(model_url));
 }
 
 std::unique_ptr<TestModelInfo> TestModelInfo::LoadOrtModel(_In_ const PATH_CHAR_TYPE* model_url) {
-  return std::unique_ptr<TestModelInfo>(new OnnxModelInfo(model_url, true));
+  return std::unique_ptr<TestModelInfo>(new OrtModelInfo(model_url));
 }
 
 /**

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -288,6 +288,10 @@ std::unique_ptr<TestModelInfo> TestModelInfo::LoadOnnxModel(_In_ const PATH_CHAR
   return std::unique_ptr<TestModelInfo>(new OnnxModelInfo(model_url));
 }
 
+std::unique_ptr<TestModelInfo> TestModelInfo::LoadOrtModel(_In_ const PATH_CHAR_TYPE* model_url) {
+  return std::unique_ptr<TestModelInfo>(new OrtModelInfo(model_url));
+}
+
 /**
    * test_case_dir must have contents of:
    * model.onnx

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -285,11 +285,11 @@ void LoopDataFile(int test_data_pb_fd, bool is_input, const TestModelInfo& model
 }  // namespace
 
 std::unique_ptr<TestModelInfo> TestModelInfo::LoadOnnxModel(_In_ const PATH_CHAR_TYPE* model_url) {
-  return std::unique_ptr<TestModelInfo>(new OnnxModelInfo(model_url));
+  return std::unique_ptr<TestModelInfo>(new OnnxModelInfo(model_url, false));
 }
 
 std::unique_ptr<TestModelInfo> TestModelInfo::LoadOrtModel(_In_ const PATH_CHAR_TYPE* model_url) {
-  return std::unique_ptr<TestModelInfo>(new OrtModelInfo(model_url));
+  return std::unique_ptr<TestModelInfo>(new OnnxModelInfo(model_url, true));
 }
 
 /**

--- a/onnxruntime/test/onnx/TestCase.h
+++ b/onnxruntime/test/onnx/TestCase.h
@@ -59,7 +59,9 @@ class TestModelInfo {
   virtual ~TestModelInfo() = default;
 
   static std::unique_ptr<TestModelInfo> LoadOnnxModel(_In_ const PATH_CHAR_TYPE* model_url);
+#if defined(ORT_MINIMAL_BUILD)
   static std::unique_ptr<TestModelInfo> LoadOrtModel(_In_ const PATH_CHAR_TYPE* model_url);
+#endif
   static const std::string unknown_version;
 };
 

--- a/onnxruntime/test/onnx/TestCase.h
+++ b/onnxruntime/test/onnx/TestCase.h
@@ -59,6 +59,7 @@ class TestModelInfo {
   virtual ~TestModelInfo() = default;
 
   static std::unique_ptr<TestModelInfo> LoadOnnxModel(_In_ const PATH_CHAR_TYPE* model_url);
+  static std::unique_ptr<TestModelInfo> LoadOrtModel(_In_ const PATH_CHAR_TYPE* model_url);
   static const std::string unknown_version;
 };
 

--- a/onnxruntime/test/onnx/onnx_model_info.cc
+++ b/onnxruntime/test/onnx/onnx_model_info.cc
@@ -3,8 +3,6 @@
 
 #include <fstream>
 
-#include "core/common/logging/logging.h"
-#include "core/flatbuffers/ort.fbs.h"
 #include "core/graph/model.h"
 
 #include "onnx_model_info.h"
@@ -24,15 +22,8 @@ static void RepeatedPtrFieldToVector(const ::google::protobuf::RepeatedPtrField<
   }
 }
 
-OnnxModelInfo::OnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url, bool is_ort_model)
-    : model_url_(model_url) {
-  if (is_ort_model)
-    InitOrtModelInfo(model_url);
-  else
-    InitOnnxModelInfo(model_url);
-}
-
-void OnnxModelInfo::InitOnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url) {
+OnnxModelInfo::OnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url)
+    : BaseModelInfo(model_url) {
   // parse model
   int model_fd;
   auto st = Env::Default().FileOpenRd(model_url, model_fd);
@@ -86,7 +77,8 @@ void OnnxModelInfo::InitOnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url) {
   RepeatedPtrFieldToVector(graph.output(), output_value_info_);
 }
 
-void OnnxModelInfo::InitOrtModelInfo(_In_ const PATH_CHAR_TYPE* model_url) {
+OrtModelInfo::OrtModelInfo(_In_ const PATH_CHAR_TYPE* model_url)
+    : BaseModelInfo(model_url) {
   std::vector<uint8_t> bytes;
   size_t num_bytes = 0;
   const auto model_location = ToWideString(model_url);

--- a/onnxruntime/test/onnx/onnx_model_info.cc
+++ b/onnxruntime/test/onnx/onnx_model_info.cc
@@ -3,6 +3,8 @@
 
 #include <fstream>
 
+#include "core/common/logging/logging.h"
+#include "core/flatbuffers/ort.fbs.h"
 #include "core/graph/model.h"
 
 #include "onnx_model_info.h"
@@ -22,8 +24,15 @@ static void RepeatedPtrFieldToVector(const ::google::protobuf::RepeatedPtrField<
   }
 }
 
-OnnxModelInfo::OnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url)
-    : BaseModelInfo(model_url) {
+OnnxModelInfo::OnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url, bool is_ort_model)
+    : model_url_(model_url) {
+  if (is_ort_model)
+    InitOrtModelInfo(model_url);
+  else
+    InitOnnxModelInfo(model_url);
+}
+
+void OnnxModelInfo::InitOnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url) {
   // parse model
   int model_fd;
   auto st = Env::Default().FileOpenRd(model_url, model_fd);
@@ -77,8 +86,7 @@ OnnxModelInfo::OnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url)
   RepeatedPtrFieldToVector(graph.output(), output_value_info_);
 }
 
-OrtModelInfo::OrtModelInfo(_In_ const PATH_CHAR_TYPE* model_url)
-    : BaseModelInfo(model_url) {
+void OnnxModelInfo::InitOrtModelInfo(_In_ const PATH_CHAR_TYPE* model_url) {
   std::vector<uint8_t> bytes;
   size_t num_bytes = 0;
   const auto model_location = ToWideString(model_url);

--- a/onnxruntime/test/onnx/onnx_model_info.h
+++ b/onnxruntime/test/onnx/onnx_model_info.h
@@ -39,3 +39,38 @@ class OnnxModelInfo : public TestModelInfo {
 
   const std::string& GetOutputName(size_t i) const override { return output_value_info_[i].name(); }
 };
+
+class OrtModelInfo : public TestModelInfo {
+ private:
+  std::string node_name_;
+  std::string onnx_commit_tag_;
+  std::vector<ONNX_NAMESPACE::ValueInfoProto> input_value_info_;
+  std::vector<ONNX_NAMESPACE::ValueInfoProto> output_value_info_;
+  std::unordered_map<std::string, int64_t> domain_to_version_;
+  const std::basic_string<PATH_CHAR_TYPE> model_url_;
+
+ public:
+  OrtModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
+
+  bool HasDomain(const std::string& name) const {
+    return domain_to_version_.find(name) != domain_to_version_.end();
+  }
+
+  int64_t GetONNXOpSetVersion() const {
+    auto iter = domain_to_version_.find("");
+    return iter == domain_to_version_.end() ? -1 : iter->second;
+  }
+
+  const PATH_CHAR_TYPE* GetModelUrl() const override { return model_url_.c_str(); }
+  std::string GetModelVersion() const override { return onnx_commit_tag_; }
+
+  const std::string& GetNodeName() const override { return node_name_; }
+  const ONNX_NAMESPACE::ValueInfoProto* GetOutputInfoFromModel(size_t i) const override {
+    return &output_value_info_[i];
+  }
+  int GetInputCount() const override { return static_cast<int>(input_value_info_.size()); }
+  int GetOutputCount() const override { return static_cast<int>(output_value_info_.size()); }
+  const std::string& GetInputName(size_t i) const override { return input_value_info_[i].name(); }
+
+  const std::string& GetOutputName(size_t i) const override { return output_value_info_[i].name(); }
+};

--- a/onnxruntime/test/onnx/onnx_model_info.h
+++ b/onnxruntime/test/onnx/onnx_model_info.h
@@ -5,8 +5,8 @@
 #include "core/graph/onnx_protobuf.h"
 #include "TestCase.h"
 
-class OnnxModelInfo : public TestModelInfo {
- private:
+class BaseModelInfo : public TestModelInfo {
+ protected:
   std::string node_name_;
   std::string onnx_commit_tag_;
   std::vector<ONNX_NAMESPACE::ValueInfoProto> input_value_info_;
@@ -15,8 +15,7 @@ class OnnxModelInfo : public TestModelInfo {
   const std::basic_string<PATH_CHAR_TYPE> model_url_;
 
  public:
-  OnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url, bool is_ort_model = false);
-
+  BaseModelInfo(_In_ const PATH_CHAR_TYPE* model_url) : model_url_(model_url) {}
   bool HasDomain(const std::string& name) const {
     return domain_to_version_.find(name) != domain_to_version_.end();
   }
@@ -36,10 +35,15 @@ class OnnxModelInfo : public TestModelInfo {
   int GetInputCount() const override { return static_cast<int>(input_value_info_.size()); }
   int GetOutputCount() const override { return static_cast<int>(output_value_info_.size()); }
   const std::string& GetInputName(size_t i) const override { return input_value_info_[i].name(); }
-
   const std::string& GetOutputName(size_t i) const override { return output_value_info_[i].name(); }
+};
 
- private:
-  void InitOnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
-  void InitOrtModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
+class OnnxModelInfo : public BaseModelInfo {
+ public:
+  OnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
+};
+
+class OrtModelInfo : public BaseModelInfo {
+ public:
+  OrtModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
 };

--- a/onnxruntime/test/onnx/onnx_model_info.h
+++ b/onnxruntime/test/onnx/onnx_model_info.h
@@ -15,7 +15,7 @@ class OnnxModelInfo : public TestModelInfo {
   const std::basic_string<PATH_CHAR_TYPE> model_url_;
 
  public:
-  OnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
+  OnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url, bool is_ort_model = false);
 
   bool HasDomain(const std::string& name) const {
     return domain_to_version_.find(name) != domain_to_version_.end();
@@ -38,39 +38,8 @@ class OnnxModelInfo : public TestModelInfo {
   const std::string& GetInputName(size_t i) const override { return input_value_info_[i].name(); }
 
   const std::string& GetOutputName(size_t i) const override { return output_value_info_[i].name(); }
-};
 
-class OrtModelInfo : public TestModelInfo {
  private:
-  std::string node_name_;
-  std::string onnx_commit_tag_;
-  std::vector<ONNX_NAMESPACE::ValueInfoProto> input_value_info_;
-  std::vector<ONNX_NAMESPACE::ValueInfoProto> output_value_info_;
-  std::unordered_map<std::string, int64_t> domain_to_version_;
-  const std::basic_string<PATH_CHAR_TYPE> model_url_;
-
- public:
-  OrtModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
-
-  bool HasDomain(const std::string& name) const {
-    return domain_to_version_.find(name) != domain_to_version_.end();
-  }
-
-  int64_t GetONNXOpSetVersion() const {
-    auto iter = domain_to_version_.find("");
-    return iter == domain_to_version_.end() ? -1 : iter->second;
-  }
-
-  const PATH_CHAR_TYPE* GetModelUrl() const override { return model_url_.c_str(); }
-  std::string GetModelVersion() const override { return onnx_commit_tag_; }
-
-  const std::string& GetNodeName() const override { return node_name_; }
-  const ONNX_NAMESPACE::ValueInfoProto* GetOutputInfoFromModel(size_t i) const override {
-    return &output_value_info_[i];
-  }
-  int GetInputCount() const override { return static_cast<int>(input_value_info_.size()); }
-  int GetOutputCount() const override { return static_cast<int>(output_value_info_.size()); }
-  const std::string& GetInputName(size_t i) const override { return input_value_info_[i].name(); }
-
-  const std::string& GetOutputName(size_t i) const override { return output_value_info_[i].name(); }
+  void InitOnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
+  void InitOrtModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
 };

--- a/onnxruntime/test/onnx/onnx_model_info.h
+++ b/onnxruntime/test/onnx/onnx_model_info.h
@@ -5,8 +5,10 @@
 #include "core/graph/onnx_protobuf.h"
 #include "TestCase.h"
 
-class OnnxModelInfo : public TestModelInfo {
- private:
+// This is a temporary solution to enable onnx_test_runner for ort minimal build and ort file format
+// It is tracked by Product Backlog Item 895235: Re-work onnx_test_runner/perf_test for ort/onnx model
+class BaseModelInfo : public TestModelInfo {
+ protected:
   std::string node_name_;
   std::string onnx_commit_tag_;
   std::vector<ONNX_NAMESPACE::ValueInfoProto> input_value_info_;
@@ -15,8 +17,7 @@ class OnnxModelInfo : public TestModelInfo {
   const std::basic_string<PATH_CHAR_TYPE> model_url_;
 
  public:
-  OnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url, bool is_ort_model = false);
-
+  BaseModelInfo(_In_ const PATH_CHAR_TYPE* model_url) : model_url_(model_url) {}
   bool HasDomain(const std::string& name) const {
     return domain_to_version_.find(name) != domain_to_version_.end();
   }
@@ -36,10 +37,17 @@ class OnnxModelInfo : public TestModelInfo {
   int GetInputCount() const override { return static_cast<int>(input_value_info_.size()); }
   int GetOutputCount() const override { return static_cast<int>(output_value_info_.size()); }
   const std::string& GetInputName(size_t i) const override { return input_value_info_[i].name(); }
-
   const std::string& GetOutputName(size_t i) const override { return output_value_info_[i].name(); }
-
- private:
-  void InitOnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
-  void InitOrtModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
 };
+
+class OnnxModelInfo : public BaseModelInfo {
+ public:
+  OnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
+};
+
+#if defined(ORT_MINIMAL_BUILD)
+class OrtModelInfo : public BaseModelInfo {
+ public:
+  OrtModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
+};
+#endif

--- a/onnxruntime/test/onnx/onnx_model_info.h
+++ b/onnxruntime/test/onnx/onnx_model_info.h
@@ -5,8 +5,8 @@
 #include "core/graph/onnx_protobuf.h"
 #include "TestCase.h"
 
-class BaseModelInfo : public TestModelInfo {
- protected:
+class OnnxModelInfo : public TestModelInfo {
+ private:
   std::string node_name_;
   std::string onnx_commit_tag_;
   std::vector<ONNX_NAMESPACE::ValueInfoProto> input_value_info_;
@@ -15,7 +15,8 @@ class BaseModelInfo : public TestModelInfo {
   const std::basic_string<PATH_CHAR_TYPE> model_url_;
 
  public:
-  BaseModelInfo(_In_ const PATH_CHAR_TYPE* model_url) : model_url_(model_url) {}
+  OnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url, bool is_ort_model = false);
+
   bool HasDomain(const std::string& name) const {
     return domain_to_version_.find(name) != domain_to_version_.end();
   }
@@ -35,15 +36,10 @@ class BaseModelInfo : public TestModelInfo {
   int GetInputCount() const override { return static_cast<int>(input_value_info_.size()); }
   int GetOutputCount() const override { return static_cast<int>(output_value_info_.size()); }
   const std::string& GetInputName(size_t i) const override { return input_value_info_[i].name(); }
+
   const std::string& GetOutputName(size_t i) const override { return output_value_info_[i].name(); }
-};
 
-class OnnxModelInfo : public BaseModelInfo {
- public:
-  OnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
-};
-
-class OrtModelInfo : public BaseModelInfo {
- public:
-  OrtModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
+ private:
+  void InitOnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
+  void InitOrtModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
 };

--- a/onnxruntime/test/onnx/runner.cc
+++ b/onnxruntime/test/onnx/runner.cc
@@ -297,10 +297,15 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
       }
 
       std::basic_string<PATH_CHAR_TYPE> filename_str = filename;
-      bool is_onnx_format = HasExtensionOf(filename_str, ORT_TSTR("onnx"));
       bool is_ort_format = HasExtensionOf(filename_str, ORT_TSTR("ort"));
+#if !defined(ORT_MINIMAL_BUILD)
+      bool is_onnx_format = HasExtensionOf(filename_str, ORT_TSTR("onnx"));
       if (!is_onnx_format && !is_ort_format)
         return true;
+#else
+      if( !is_ort_format )
+         return true;
+#endif
 
       std::basic_string<PATH_CHAR_TYPE> test_case_name = my_dir_name;
       if (test_case_name.compare(0, 5, ORT_TSTR("test_")) == 0) test_case_name = test_case_name.substr(5);
@@ -314,10 +319,15 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
       std::basic_string<PATH_CHAR_TYPE> p = ConcatPathComponent<PATH_CHAR_TYPE>(node_data_root_path, filename_str);
 
       std::unique_ptr<TestModelInfo> model_info;
-      if (is_onnx_format)
+#if !defined(ORT_MINIMAL_BUILD)
+      if (is_onnx_format) {
         model_info = TestModelInfo::LoadOnnxModel(p.c_str());
-      else
+      } else {
         model_info = TestModelInfo::LoadOrtModel(p.c_str());
+      }
+#else
+      model_info = TestModelInfo::LoadOrtModel(p.c_str());
+#endif
 
       std::unique_ptr<ITestCase> l = CreateOnnxTestCase(ToMBString(test_case_name), std::move(model_info),
                                                         default_per_sample_tolerance,

--- a/onnxruntime/test/onnx/runner.cc
+++ b/onnxruntime/test/onnx/runner.cc
@@ -297,13 +297,11 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
       }
 
       std::basic_string<PATH_CHAR_TYPE> filename_str = filename;
-      bool is_ort_format = HasExtensionOf(filename_str, ORT_TSTR("ort"));
 #if !defined(ORT_MINIMAL_BUILD)
-      bool is_onnx_format = HasExtensionOf(filename_str, ORT_TSTR("onnx"));
-      if (!is_onnx_format && !is_ort_format)
+      if (!HasExtensionOf(filename_str, ORT_TSTR("onnx")))
         return true;
 #else
-      if( !is_ort_format )
+      if( !HasExtensionOf(filename_str, ORT_TSTR("ort")) )
          return true;
 #endif
 
@@ -320,11 +318,7 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
 
       std::unique_ptr<TestModelInfo> model_info;
 #if !defined(ORT_MINIMAL_BUILD)
-      if (is_onnx_format) {
-        model_info = TestModelInfo::LoadOnnxModel(p.c_str());
-      } else {
-        model_info = TestModelInfo::LoadOrtModel(p.c_str());
-      }
+      model_info = TestModelInfo::LoadOnnxModel(p.c_str());
 #else
       model_info = TestModelInfo::LoadOrtModel(p.c_str());
 #endif

--- a/onnxruntime/test/onnx/runner.cc
+++ b/onnxruntime/test/onnx/runner.cc
@@ -295,8 +295,12 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
         paths.push_back(p);
         return true;
       }
+
       std::basic_string<PATH_CHAR_TYPE> filename_str = filename;
-      if (!HasExtensionOf(filename_str, ORT_TSTR("onnx"))) return true;
+      bool is_onnx_format = HasExtensionOf(filename_str, ORT_TSTR("onnx"));
+      bool is_ort_format = HasExtensionOf(filename_str, ORT_TSTR("ort"));
+      if (!is_onnx_format && !is_ort_format)
+        return true;
 
       std::basic_string<PATH_CHAR_TYPE> test_case_name = my_dir_name;
       if (test_case_name.compare(0, 5, ORT_TSTR("test_")) == 0) test_case_name = test_case_name.substr(5);
@@ -309,7 +313,12 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
 
       std::basic_string<PATH_CHAR_TYPE> p = ConcatPathComponent<PATH_CHAR_TYPE>(node_data_root_path, filename_str);
 
-      std::unique_ptr<TestModelInfo> model_info(TestModelInfo::LoadOnnxModel(p.c_str()));
+      std::unique_ptr<TestModelInfo> model_info;
+      if (is_onnx_format)
+        model_info = TestModelInfo::LoadOnnxModel(p.c_str());
+      else
+        model_info = TestModelInfo::LoadOrtModel(p.c_str());
+
       std::unique_ptr<ITestCase> l = CreateOnnxTestCase(ToMBString(test_case_name), std::move(model_info),
                                                         default_per_sample_tolerance,
                                                         default_relative_per_sample_tolerance);


### PR DESCRIPTION
**Description**: Enable onnx_test_runner for ort format
- This will temporarily enable onnx_test_runner for ort format, however, we may update the test_runner entirely in the future with new design

**Motivation and Context**
- Enable on device testing, such as Android devices, where there is no python available
- Enable ort minimal build CI which can completely disable exceptions and rtti which is required for python
