### PR TITLE
Add re2 to memory leak checker whitelist

### DIFF
--- a/onnxruntime/core/platform/windows/debug_alloc.cc
+++ b/onnxruntime/core/platform/windows/debug_alloc.cc
@@ -215,6 +215,7 @@ Memory_LeakCheck::~Memory_LeakCheck() {
     //     empty_group_names = new std::map<int, string>; });
     if (string.find("RtlRunOnceExecuteOnce") == std::string::npos &&
         string.find("testing::internal::Mutex::ThreadSafeLazyInit") == std::string::npos &&
+        string.find("re2::RE2::Init") == std::string::npos &&
         string.find("testing::internal::ThreadLocalRegistryImpl::GetThreadLocalsMapLocked") == std::string::npos &&
         string.find("testing::internal::ThreadLocalRegistryImpl::GetValueOnCurrentThread") == std::string::npos) {
       if (leaked_bytes == 0)

--- a/onnxruntime/core/platform/windows/debug_alloc.cc
+++ b/onnxruntime/core/platform/windows/debug_alloc.cc
@@ -214,8 +214,8 @@ Memory_LeakCheck::~Memory_LeakCheck() {
     //     empty_named_groups = new std::map<string, int>;
     //     empty_group_names = new std::map<int, string>; });
     if (string.find("RtlRunOnceExecuteOnce") == std::string::npos &&
-        string.find("testing::internal::Mutex::ThreadSafeLazyInit") == std::string::npos &&
         string.find("re2::RE2::Init") == std::string::npos &&
+        string.find("testing::internal::Mutex::ThreadSafeLazyInit") == std::string::npos &&
         string.find("testing::internal::ThreadLocalRegistryImpl::GetThreadLocalsMapLocked") == std::string::npos &&
         string.find("testing::internal::ThreadLocalRegistryImpl::GetValueOnCurrentThread") == std::string::npos) {
       if (leaked_bytes == 0)


### PR DESCRIPTION
**Description**: 

Add re2 to memory leak checker whitelist

**Motivation and Context**
- Why is this change required? What problem does it solve?

I guess the implementation of std::call_once get changed.

- If it fixes an open issue, please link to the issue here.
