### PR TITLE
Handle dummy mask in Attention operators

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_base.h
@@ -12,10 +12,11 @@ namespace contrib {
 class AttentionBase {
  protected:
   AttentionBase(const OpKernelInfo& info);
+
   Status CheckInputs(const TensorShape& input_shape,
                      const TensorShape& weights_shape,
                      const TensorShape& bias_shape,
-                     const Tensor* mask_index,
+                     const Tensor*& mask_index,  // For dummy mask with shape (1, 1) or (batch_size, 1), it will be updated to nullptr.
                      const Tensor* past) const;
 
   Tensor* GetPresent(OpKernelContext* context,

--- a/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
@@ -107,7 +107,7 @@ Status QAttention<T>::Compute(OpKernelContext* context) const {
   //   Input  2 - bias              : (3 * hidden_size)
   //   Input  3 - input_scale       : scalar
   //   Input  4 - weight_scale      : scalar
-  //   Input  5 - mask_index        : (batch_size)
+  //   Input  5 - mask_index        : nullptr, (batch_size), (2 * batch_size), (batch_size, 1), (1, 1) or (batch_size, past_sequence_length + sequence_length)
   //   Input  6 - input_zero_point  : scalar
   //   Input  7 - weight_zero_point : scalar
   //   Input  8 - past              : (2, batch_size, num_heads, past_sequence_length, head_size)

--- a/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.cc
@@ -45,7 +45,7 @@ Status QAttention<T, int8_t>::CheckInputs(const Tensor* input,
                                           const Tensor* bias,
                                           const Tensor* input_scale_tensor,
                                           const Tensor* weight_scale_tensor,
-                                          const Tensor* mask_index,
+                                          const Tensor*& mask_index,
                                           const Tensor* i_zp_tensor,
                                           const Tensor* w_zp_tensor,
                                           const Tensor* past_tensor) const {
@@ -55,7 +55,7 @@ Status QAttention<T, int8_t>::CheckInputs(const Tensor* input,
   //   Input 2 - bias              : (3 * hidden_size)
   //   Input 3 - input_scale       : scalar
   //   Input 4 - weight_scale      : scalar
-  //   Input 5 - mask_index        : (batch_size)
+  //   Input 5 - mask_index        : nullptr, (batch_size), (2 * batch_size), (batch_size, 1), (1, 1) or (batch_size, past_sequence_length + sequence_length)
   //   Input 6 - input_zero_point  : scalar
   //   Input 7 - weight_zero_point : scalar
   //   Output                      : (batch_size, sequence_length, hidden_size)

--- a/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.h
+++ b/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.h
@@ -34,7 +34,7 @@ class QAttention<T, int8_t> final : public CudaKernel, public AttentionBase {
                      const Tensor* bias,
                      const Tensor* input_scale_tensor,
                      const Tensor* weight_scale_tensor,
-                     const Tensor* mask_index,
+                     const Tensor*& mask_index,
                      const Tensor* i_zp_tensor,
                      const Tensor* w_zp_tensor,
                      const Tensor* past_tensor) const;


### PR DESCRIPTION
**Description**:  Some old model use dummy attention mask with shape (1, 1) or (batch_size, 1). It could be propagated by Add operator. The effect is same as no attention mask.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

Models from some users has dummy mask.