### PR TITLE
csharp build documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -124,8 +124,7 @@ GCC 4.x and below are not supported.
 |API|Command|Additional details|
 |-----------|-----------|-----------|
 |**Python**|--build_wheel||
-|**C# and C packages**|--build_nuget|Builds C# bindings and creates nuget package. Currently supported on Windows and Linux only. Implies `--build_shared_lib`.
-Requires [dotnet](https://dotnet.microsoft.com/download) and [nuget.exe](https://docs.microsoft.com/en-us/nuget/install-nuget-client-tools#nugetexe-cli). Detailed instructions can be found below.|
+|**C# and C packages**|--build_nuget|Builds C# bindings and creates nuget package. Currently supported on Windows and Linux only. Implies `--build_shared_lib` <br> Detailed instructions can be found [below](./BUILD.md#build-nuget-packages).|
 |**WindowsML**|--use_winml<br>--use_dml<br>--build_shared_lib|WindowsML depends on DirectML and the OnnxRuntime shared library|
 |**Java**|--build_java|Creates an onnxruntime4j.jar in the build directory, implies `--build_shared_lib`<br>Compiling the Java API requires [gradle](https://gradle.org) v6.1+ to be installed in addition to the usual requirements.|
 |**Node.js**|--build_nodejs|Build Node.js binding. Implies `--build_shared_lib`|

--- a/BUILD.md
+++ b/BUILD.md
@@ -142,7 +142,7 @@ Currently only supported on Windows and Linux.
 ### Prerequisites
 * dotnet is required for building csharp bindings and creating managed nuget package. Follow the instructions [here]((https://dotnet.microsoft.com/download) to download dotnet. Tested with versions 2.1 and 3.1.
 * nuget.exe. Follow the instructions [here](https://docs.microsoft.com/en-us/nuget/install-nuget-client-tools#nugetexe-cli) to download nuget
-  * On windows, downloading nuget is straightforward and simply following the instructions above should work.
+  * On Windows, downloading nuget is straightforward and simply following the instructions above should work.
   * On Linux, nuget relies on Mono runtime and therefore this needs to be setup too. Above link has all the information to setup Mono and nuget. The instructions can directly be found [here](https://www.mono-project.com/docs/getting-started/install/). In some cases it is required to run `sudo apt-get install mono-complete` after installing mono. 
 
 ### Build Instructions
@@ -155,6 +155,8 @@ Currently only supported on Windows and Linux.
 ```
 ./build.sh --build_nuget
 ```
+Nuget packages are created under <native_build_dir>\nuget-artifacts
+
 ---
 
 ## Execution Providers

--- a/BUILD.md
+++ b/BUILD.md
@@ -124,8 +124,8 @@ GCC 4.x and below are not supported.
 |API|Command|Additional details|
 |-----------|-----------|-----------|
 |**Python**|--build_wheel||
-|**C# and C packages**|--build_nuget|Builds C# bindings and creates nuget package. Currently supported on Windows and Linux only. Implies `--build_shared_lib` <br>
-Requires [dotnet](https://dotnet.microsoft.com/download) for building csharp bindings and [nuget.exe](https://docs.microsoft.com/en-us/nuget/install-nuget-client-tools#nugetexe-cli) for creating nuget package.|
+|**C# and C packages**|--build_nuget|Builds C# bindings and creates nuget package. Currently supported on Windows and Linux only. Implies `--build_shared_lib`.
+Requires [dotnet](https://dotnet.microsoft.com/download) and [nuget.exe](https://docs.microsoft.com/en-us/nuget/install-nuget-client-tools#nugetexe-cli). Detailed instructions can be found below.|
 |**WindowsML**|--use_winml<br>--use_dml<br>--build_shared_lib|WindowsML depends on DirectML and the OnnxRuntime shared library|
 |**Java**|--build_java|Creates an onnxruntime4j.jar in the build directory, implies `--build_shared_lib`<br>Compiling the Java API requires [gradle](https://gradle.org) v6.1+ to be installed in addition to the usual requirements.|
 |**Node.js**|--build_nodejs|Build Node.js binding. Implies `--build_shared_lib`|
@@ -137,6 +137,24 @@ Read more about ONNX Runtime Server [here](./docs/ONNX_Runtime_Server_Usage.md).
 
 Build instructions are [here](./docs/Server.md)
 
+## Build Nuget packages
+Currently only supported on Windows and Linux.
+### Prerequisites
+* dotnet is required for building csharp bindings and creating managed nuget package. Follow the instructions [here]((https://dotnet.microsoft.com/download) to download dotnet. Tested with versions 2.1 and 3.1.
+* nuget.exe. Follow the instructions [here](https://docs.microsoft.com/en-us/nuget/install-nuget-client-tools#nugetexe-cli) to download nuget
+  * On windows, downloading nuget is straightforward and simply following the instructions above should work.
+  * On Linux, nuget relies on Mono runtime and therefore this needs to be setup too. Above link has all the information to setup Mono and nuget. The instructions can directly be found [here](https://www.mono-project.com/docs/getting-started/install/). In some cases it is required to run `sudo apt-get install mono-complete` after installing mono. 
+
+### Build Instructions
+#### Windows
+```
+.\build.bat --build_nuget
+```
+
+#### Linux
+```
+./build.sh --build_nuget
+```
 ---
 
 ## Execution Providers

--- a/BUILD.md
+++ b/BUILD.md
@@ -139,7 +139,7 @@ Build instructions are [here](./docs/Server.md)
 ## Build Nuget packages
 Currently only supported on Windows and Linux.
 ### Prerequisites
-* dotnet is required for building csharp bindings and creating managed nuget package. Follow the instructions [here]((https://dotnet.microsoft.com/download) to download dotnet. Tested with versions 2.1 and 3.1.
+* dotnet is required for building csharp bindings and creating managed nuget package. Follow the instructions [here](https://dotnet.microsoft.com/download) to download dotnet. Tested with versions 2.1 and 3.1.
 * nuget.exe. Follow the instructions [here](https://docs.microsoft.com/en-us/nuget/install-nuget-client-tools#nugetexe-cli) to download nuget
   * On Windows, downloading nuget is straightforward and simply following the instructions above should work.
   * On Linux, nuget relies on Mono runtime and therefore this needs to be setup too. Above link has all the information to setup Mono and nuget. The instructions can directly be found [here](https://www.mono-project.com/docs/getting-started/install/). In some cases it is required to run `sudo apt-get install mono-complete` after installing mono. 

--- a/docs/execution_providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution_providers/OpenVINO-ExecutionProvider.md
@@ -176,8 +176,4 @@ Below topologies from ONNX open model zoo are fully supported on OpenVINO Execut
 
 ## CSharp API
 
-To use csharp api for openvino execution provider create a custom nuget package. Two nuget packages will be created
-Microsoft.ML.OnnxRuntime.Managed and Microsoft.ML.OnnxRuntime.Openvino.
-
-Detailed instructions for building nuget packages can be found [here](./../../Build.md)
-
+To use csharp api for openvino execution provider create a custom nuget package. Follow the instructions [here](../../BUILD.md##build-nuget-packages) to install prerequisites for nuget creation. Once prerequisites are installed follow the instructions to [build openvino](../../BUILD.md#openvino) and add an extra flag `--build_nuget` to create nuget packages. Two nuget packages will be created Microsoft.ML.OnnxRuntime.Managed and Microsoft.ML.OnnxRuntime.Openvino.

--- a/docs/execution_providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution_providers/OpenVINO-ExecutionProvider.md
@@ -181,32 +181,3 @@ Microsoft.ML.OnnxRuntime.Managed and Microsoft.ML.OnnxRuntime.Openvino.
 
 Detailed instructions for building nuget packages can be found [here](./../../Build.md)
 
-1. Windows
-
-Build a custom nuget package for windows.
-```
-.\build.bat --config Debug --build --use_openvino $Device --build_csharp
-msbuild csharp\OnnxRuntime.CSharp.proj /p:OrtPackageId=Microsoft.ML.OnnxRuntime.Openvino /p:Configuration=Debug /t:CreatePackage
-```
-The msbuild log will show the paths of the nuget packages created. 
-
-2. Linux
-
-We currently do not have a process to build directly in Linux. But we can
-copy shared library <ORT linux repo>/build/Linux/<config>/libonnxruntime.so
-to onnxruntime source repository in windows and execute the same commands 
-above to get custom nuget package for linux. Two nuget packages will be 
-created Microsoft.ML.OnnxRuntime.Managed and Microsoft.ML.OnnxRuntime.Openvino.
-
-On Linux Machine
-```
-./build.sh --config Debug --build_shared_lib --use_openvino $Device 
-```
-
-On Windows Machine
-```
-cp libonnxruntime.so onnxruntime/ 
-.\build.bat --config Debug --build --use_openvino $Device --build_csharp
-msbuild csharp\OnnxRuntime.CSharp.proj /p:OrtPackageId=Microsoft.ML.OnnxRuntime.Openvino /p:Configuration=Debug /t:CreatePackage
-```
-The msbuild log will show the path of the nuget packages created. 

--- a/docs/execution_providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution_providers/OpenVINO-ExecutionProvider.md
@@ -179,6 +179,8 @@ Below topologies from ONNX open model zoo are fully supported on OpenVINO Execut
 To use csharp api for openvino execution provider create a custom nuget package. Two nuget packages will be created
 Microsoft.ML.OnnxRuntime.Managed and Microsoft.ML.OnnxRuntime.Openvino.
 
+Detailed instructions for building nuget packages can be found [here](./../../Build.md)
+
 1. Windows
 
 Build a custom nuget package for windows.


### PR DESCRIPTION
**Description**: Add details for installing prereqs for building nuget packages

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
