### PR TITLE
Not fuse SkipLayerNorm when add has initializer input

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
+++ b/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
@@ -24,7 +24,11 @@ class FusionSkipLayerNormalization(Fusion):
 
         # In some models there is input_ids->gather->add->LayerNorm and one of input of the
         # add node is initializer with fixed shape which should not be fused into SkipLayerNorm
-        # The number of input node of add in this case is 1
+        for add_input in add.input:
+            if self.model.get_initializer(add_input) != None:
+                return
+
+        # The number of input node of add should be 2
         if len(self.model.get_parents(add)) != 2:
             return
 

--- a/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
+++ b/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
@@ -24,9 +24,9 @@ class FusionSkipLayerNormalization(Fusion):
 
         # In some models there is input_ids->gather->add->LayerNorm and one of input of the
         # add node is initializer with fixed shape which should not be fused into SkipLayerNorm
-        for add_input in add.input:
-            if self.model.get_initializer(add_input) != None:
-                return
+        # The number of input node of add in this case is 1
+        if len(self.model.get_parents(add)) != 2:
+            return
 
         if add is not None and add.op_type == 'Add' and self.model.is_safe_to_fuse_nodes(
             [add, node], node.output, input_name_to_nodes, output_name_to_node):

--- a/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
+++ b/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
@@ -21,6 +21,13 @@ class FusionSkipLayerNormalization(Fusion):
 
     def fuse(self, node, input_name_to_nodes, output_name_to_node):
         add = self.model.get_parent(node, 0, output_name_to_node)
+
+        # In some models there is input_ids->gather->add->LayerNorm and one of input of the
+        # add node is initializer with fixed shape which should not be fused into SkipLayerNorm
+        for add_input in add.input:
+            if self.model.get_initializer(add_input) != None:
+                return
+
         if add is not None and add.op_type == 'Add' and self.model.is_safe_to_fuse_nodes(
             [add, node], node.output, input_name_to_nodes, output_name_to_node):
             self.nodes_to_remove.extend([add, node])


### PR DESCRIPTION
**Description**: Describe your changes.

The below structure will not be fused into SkipLayerNorm in transformer tool
as SkipLayerNorm kernel requires same shape of two inputs of add node 
                           initializer
                                   |
input_ids->gather->add -> LayerNorm 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

fix https://github.com/microsoft/onnxruntime/issues/4980