### PR TITLE
[Debuggability] Add feature to ORTTrainer Frontend

### DIFF
--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -312,14 +312,11 @@ class ORTTrainer(object):
             ratio_node.attribute[0].name = "value"
             
         _inference_sess = ort.InferenceSession(onnx_model_copy.SerializeToString())
-        # look to see if we pass option of training mode is true
         inf_inputs = {}
         for i, input_elem in enumerate(input):
             inf_inputs[_inference_sess.get_inputs()[i].name] = input_elem.cpu().numpy()
         _inference_outs = _inference_sess.run(None, inf_inputs)
         for torch_item, ort_item in zip(self.torch_sample_outputs, _inference_outs):
-            denom = ((torch_item + ort_item) * 0.5) * 100
-            numer = np.absolute(torch_item - ort_item)
             assert_allclose(torch_item, ort_item, rtol=1e-2, atol=1e-6)
 
     def train_step(self, *args, **kwargs):

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -312,7 +312,7 @@ class ORTTrainer(object):
             ratio_node.attribute[0].name = "value"
             
         _inference_sess = ort.InferenceSession(onnx_model_copy.SerializeToString())
-        # look to see if we pass otpion of training mode is true
+        # look to see if we pass option of training mode is true
         inf_inputs = {}
         for i, input_elem in enumerate(input):
             inf_inputs[_inference_sess.get_inputs()[i].name] = input_elem.cpu().numpy()

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -229,6 +229,9 @@ class ORTTrainerOptions(object):
             debug options
         debug.deterministic_compute (bool, default is False)
             forces compute to be deterministic accross runs
+        debug.check_model_export (bool, default is False)
+            compares PyTorch outputs with InferenceSession outputs before the first
+            train step to ensure successful model export
         _internal_use (dict):
             internal options, possibly undocumented, that might be removed without notice
         _internal_use.enable_internal_postprocess (bool, default is True):

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -144,6 +144,10 @@ class ORTTrainerOptions(object):
                             'type' : 'boolean',
                             'default' : False
                         },
+                        'check_model_export' : {
+                            'type' : 'boolean',
+                            'default' : False
+                        },
                     }
                 },
                 '_internal_use' : {
@@ -447,6 +451,10 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
         'required': False,
         'schema': {
             'deterministic_compute': {
+                'type': 'boolean',
+                'default': False
+            },
+            'check_model_export': {
                 'type': 'boolean',
                 'default': False
             },

--- a/orttraining/orttraining/test/python/debug_test.py
+++ b/orttraining/orttraining/test/python/debug_test.py
@@ -58,11 +58,10 @@ def _load_pytorch_transformer_model(device, dynamic_axes=False, legacy_api=False
 ###############################################################################
 
 
-@pytest.mark.parametrize("seed, device, file_name", [
-    #(0, 'cpu'),
-    (24, 'cuda', 'run_1.pk'),
+@pytest.mark.parametrize("seed, device", [
+    (24, 'cuda'),
 ])
-def testORTTransformerModelExport(seed, device, file_name):
+def testORTTransformerModelExport(seed, device):
     # Common setup
     optim_config = optim.LambConfig()
     opts = orttrainer.ORTTrainerOptions({

--- a/orttraining/orttraining/test/python/debug_test.py
+++ b/orttraining/orttraining/test/python/debug_test.py
@@ -1,0 +1,85 @@
+import inspect
+import onnx
+import os
+import pytest
+import torch
+import torchvision
+
+from numpy.testing import assert_allclose
+
+from onnxruntime import set_seed
+from onnxruntime.capi.ort_trainer import IODescription as Legacy_IODescription,\
+                                         ModelDescription as Legacy_ModelDescription,\
+                                         LossScaler as Legacy_LossScaler,\
+                                         ORTTrainer as Legacy_ORTTrainer
+from onnxruntime.training import _utils, amp, optim, orttrainer, TrainStepInfo,\
+                                      model_desc_validation as md_val,\
+                                      orttrainer_options as orttrainer_options
+import _test_helpers
+
+
+###############################################################################
+# Helper functions ############################################################
+###############################################################################
+
+
+def _load_pytorch_transformer_model(device, dynamic_axes=False, legacy_api=False):
+    # Loads external Pytorch TransformerModel into utils
+    pytorch_transformer_path = os.path.join('..', '..', '..', 'samples', 'python', 'pytorch_transformer')
+    pt_model_path = os.path.join(pytorch_transformer_path, 'pt_model.py')
+    pt_model = _utils.import_module_from_file(pt_model_path)
+    ort_utils_path = os.path.join(pytorch_transformer_path, 'ort_utils.py')
+    ort_utils = _utils.import_module_from_file(ort_utils_path)
+    utils_path = os.path.join(pytorch_transformer_path, 'utils.py')
+    utils = _utils.import_module_from_file(utils_path)
+
+    # Modeling
+    model = pt_model.TransformerModel(28785, 200, 2, 200, 2, 0.2).to(device)
+    my_loss = ort_utils.my_loss
+    if legacy_api:
+        if dynamic_axes:
+            model_desc = ort_utils.legacy_transformer_model_description_dynamic_axes()
+        else:
+            model_desc = ort_utils.legacy_transformer_model_description()
+    else:
+        if dynamic_axes:
+            model_desc = ort_utils.transformer_model_description_dynamic_axes()
+        else:
+            model_desc = ort_utils.transformer_model_description()
+
+
+    # Preparing data
+    train_data, val_data, test_data = utils.prepare_data(device, 20, 20)
+    return model, model_desc, my_loss, utils.get_batch, train_data, val_data, test_data
+
+
+###############################################################################
+# Testing starts here #########################################################
+###############################################################################
+
+
+@pytest.mark.parametrize("seed, device, file_name", [
+    #(0, 'cpu'),
+    (24, 'cuda', 'run_1.pk'),
+])
+def testORTTransformerModelExport(seed, device, file_name):
+    # Common setup
+    optim_config = optim.LambConfig()
+    opts = orttrainer.ORTTrainerOptions({
+        'debug' : {
+            'check_model_export': True,
+        },
+        'device' : {
+            'id' : device,
+        }
+    })
+
+    # Setup for the first ORTTRainer run
+    torch.manual_seed(seed)
+    set_seed(seed)
+    model, model_desc, my_loss, batcher_fn, train_data, val_data, _ = _load_pytorch_transformer_model(device)
+    first_trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=opts)
+    data, targets = batcher_fn(train_data, 0)
+    _ = first_trainer.train_step(data, targets)
+    assert first_trainer._onnx_model is not None
+

--- a/orttraining/orttraining/test/python/orttraining_test_debuggability.py
+++ b/orttraining/orttraining/test/python/orttraining_test_debuggability.py
@@ -15,42 +15,10 @@ from onnxruntime.capi.ort_trainer import IODescription as Legacy_IODescription,\
 from onnxruntime.training import _utils, amp, optim, orttrainer, TrainStepInfo,\
                                       model_desc_validation as md_val,\
                                       orttrainer_options as orttrainer_options
+
+from orttraining_test_orttrainer_frontend import _load_pytorch_transformer_model
+
 import _test_helpers
-
-
-###############################################################################
-# Helper functions ############################################################
-###############################################################################
-
-
-def _load_pytorch_transformer_model(device, dynamic_axes=False, legacy_api=False):
-    # Loads external Pytorch TransformerModel into utils
-    pytorch_transformer_path = os.path.join('..', '..', '..', 'samples', 'python', 'pytorch_transformer')
-    pt_model_path = os.path.join(pytorch_transformer_path, 'pt_model.py')
-    pt_model = _utils.import_module_from_file(pt_model_path)
-    ort_utils_path = os.path.join(pytorch_transformer_path, 'ort_utils.py')
-    ort_utils = _utils.import_module_from_file(ort_utils_path)
-    utils_path = os.path.join(pytorch_transformer_path, 'utils.py')
-    utils = _utils.import_module_from_file(utils_path)
-
-    # Modeling
-    model = pt_model.TransformerModel(28785, 200, 2, 200, 2, 0.2).to(device)
-    my_loss = ort_utils.my_loss
-    if legacy_api:
-        if dynamic_axes:
-            model_desc = ort_utils.legacy_transformer_model_description_dynamic_axes()
-        else:
-            model_desc = ort_utils.legacy_transformer_model_description()
-    else:
-        if dynamic_axes:
-            model_desc = ort_utils.transformer_model_description_dynamic_axes()
-        else:
-            model_desc = ort_utils.transformer_model_description()
-
-
-    # Preparing data
-    train_data, val_data, test_data = utils.prepare_data(device, 20, 20)
-    return model, model_desc, my_loss, utils.get_batch, train_data, val_data, test_data
 
 
 ###############################################################################

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -100,7 +100,8 @@ def testORTTrainerOptionsDefaultValues(test_input):
             'invertible_layer_norm_gradient': False,
         },
         'debug': {
-            'deterministic_compute': False
+            'deterministic_compute': False,
+            'check_model_export': False
         },
         '_internal_use': {
             'enable_internal_postprocess': True,


### PR DESCRIPTION
 - Add check_model_export option to orttrainer_options.py
 - Add relevant code to mute dropout nodes and create an InferenceSession that compares with the PyTorch eval step
 - Add a test of this functionality in debug_test.py
