### PR TITLE
Enable onnxruntime_perf_test for ORT minimal build

### DIFF
--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -284,11 +284,11 @@ void LoopDataFile(int test_data_pb_fd, bool is_input, const TestModelInfo& model
 
 }  // namespace
 
+#if !defined(ORT_MINIMAL_BUILD)
 std::unique_ptr<TestModelInfo> TestModelInfo::LoadOnnxModel(_In_ const PATH_CHAR_TYPE* model_url) {
   return std::unique_ptr<TestModelInfo>(new OnnxModelInfo(model_url));
 }
-
-#if defined(ORT_MINIMAL_BUILD)
+#else
 std::unique_ptr<TestModelInfo> TestModelInfo::LoadOrtModel(_In_ const PATH_CHAR_TYPE* model_url) {
   return std::unique_ptr<TestModelInfo>(new OrtModelInfo(model_url));
 }

--- a/onnxruntime/test/onnx/TestCase.h
+++ b/onnxruntime/test/onnx/TestCase.h
@@ -58,8 +58,9 @@ class TestModelInfo {
   virtual std::string GetModelVersion() const { return ""; }
   virtual ~TestModelInfo() = default;
 
+#if !defined(ORT_MINIMAL_BUILD)
   static std::unique_ptr<TestModelInfo> LoadOnnxModel(_In_ const PATH_CHAR_TYPE* model_url);
-#if defined(ORT_MINIMAL_BUILD)
+#else
   static std::unique_ptr<TestModelInfo> LoadOrtModel(_In_ const PATH_CHAR_TYPE* model_url);
 #endif
   static const std::string unknown_version;

--- a/onnxruntime/test/onnx/onnx_model_info.h
+++ b/onnxruntime/test/onnx/onnx_model_info.h
@@ -40,12 +40,12 @@ class BaseModelInfo : public TestModelInfo {
   const std::string& GetOutputName(size_t i) const override { return output_value_info_[i].name(); }
 };
 
+#if !defined(ORT_MINIMAL_BUILD)
 class OnnxModelInfo : public BaseModelInfo {
  public:
   OnnxModelInfo(_In_ const PATH_CHAR_TYPE* model_url);
 };
-
-#if defined(ORT_MINIMAL_BUILD)
+#else
 class OrtModelInfo : public BaseModelInfo {
  public:
   OrtModelInfo(_In_ const PATH_CHAR_TYPE* model_url);

--- a/onnxruntime/test/perftest/performance_runner.cc
+++ b/onnxruntime/test/perftest/performance_runner.cc
@@ -232,7 +232,16 @@ Status PerformanceRunner::ForkJoinRepeat() {
 
 static std::unique_ptr<TestModelInfo> CreateModelInfo(const PerformanceTestConfig& performance_test_config_) {
   if (CompareCString(performance_test_config_.backend.c_str(), ORT_TSTR("ort")) == 0) {
-    return TestModelInfo::LoadOnnxModel(performance_test_config_.model_info.model_file_path.c_str());
+    const auto& file_path = performance_test_config_.model_info.model_file_path;
+#if !defined(ORT_MINIMAL_BUILD)
+    if (HasExtensionOf(file_path, ORT_TSTR("onnx"))) {
+      return TestModelInfo::LoadOnnxModel(performance_test_config_.model_info.model_file_path.c_str());
+    }
+#else
+    if (HasExtensionOf(file_path, ORT_TSTR("ort"))) {
+      return TestModelInfo::LoadOrtModel(performance_test_config_.model_info.model_file_path.c_str());
+    }
+#endif
   }
 
   if (CompareCString(performance_test_config_.backend.c_str(), ORT_TSTR("tf")) == 0) {

--- a/onnxruntime/test/perftest/performance_runner.cc
+++ b/onnxruntime/test/perftest/performance_runner.cc
@@ -242,6 +242,8 @@ static std::unique_ptr<TestModelInfo> CreateModelInfo(const PerformanceTestConfi
       return TestModelInfo::LoadOrtModel(performance_test_config_.model_info.model_file_path.c_str());
     }
 #endif
+
+    ORT_NOT_IMPLEMENTED(ToMBString(file_path), " is not supported");
   }
 
   if (CompareCString(performance_test_config_.backend.c_str(), ORT_TSTR("tf")) == 0) {


### PR DESCRIPTION
**Description**: Enable onnxruntime_perf_test for ORT minimal build

**Motivation and Context**
- To measure ort minimal build perf on device