### PR TITLE
Solve name conflict in TensorRT engine caching

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -56,12 +56,12 @@
 [submodule "cmake/external/libprotobuf-mutator"]
 	path = cmake/external/libprotobuf-mutator
 	url = https://github.com/google/libprotobuf-mutator.git
-[submodule "cmake/external/onnx-tensorrt"]
-	path = cmake/external/onnx-tensorrt
-	url = https://github.com/onnx/onnx-tensorrt.git
 [submodule "cmake/external/flatbuffers"]
 	path = cmake/external/flatbuffers
 	url = https://github.com/google/flatbuffers.git
 [submodule "cmake/external/SafeInt/safeint"]
 	path = cmake/external/SafeInt/safeint
 	url = https://github.com/gwang-msft/SafeInt.git
+[submodule "cmake/external/onnx-tensorrt"]
+	path = cmake/external/onnx-tensorrt
+	url = https://github.com/onnx/onnx-tensorrt.git

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -47,9 +47,9 @@ std::string GetEnginePath(const ::std::string& root, const std::string& name) {
 }
 
 std::string GetVecHash(const ::std::vector<int>& vec) {
-  std::size_t ret = 0;
-  for (auto& i : vec) {
-    ret += std::hash<uint32_t>()(i);
+  std::size_t ret = vec.size();
+  for(auto& i : vec) {
+    ret ^= i + 0x9e3779b9 + (ret << 6) + (ret >> 2);
   }
   return std::to_string(ret);
 }

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -49,7 +49,7 @@ std::string GetEnginePath(const ::std::string& root, const std::string& name) {
 std::string GetVecHash(const ::std::vector<int>& vec) {
   std::size_t ret = 0;
   for (auto& i : vec) {
-    ret ^= std::hash<uint32_t>()(i);
+    ret += std::hash<uint32_t>()(i);
   }
   return std::to_string(ret);
 }

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1026,15 +1026,15 @@ common::Status TensorrtExecutionProvider::Provider_Compile(const std::vector<onn
         std::string trt_node_name_with_precision_shape = trt_state->trt_node_name_with_precision + "_" + GetVecHash(input_shapes);
         std::string cached_path = GetEnginePath(trt_state->engine_cache_path, trt_node_name_with_precision_shape);
         std::ifstream plan_file(cached_path, std::ios::binary | std::ios::in);
+        trt_state->context->reset();
+        trt_state->engine->reset();
         if (plan_file && trt_state->engine_cache_enable) {
           plan_file.seekg(0, std::ios::end);
           int engine_size = plan_file.tellg();
           plan_file.seekg(0, std::ios::beg);
           std::unique_ptr<char[]> engine_buf{new char[engine_size]};
           plan_file.read((char*)engine_buf.get(), engine_size);
-
           auto runtime_ = trt_state->runtime;
-          trt_state->engine->reset();
           *(trt_state->engine) = tensorrt_ptr::unique_pointer<nvinfer1::ICudaEngine>(
               runtime_->deserializeCudaEngine(engine_buf.get(), engine_size, nullptr));
           if (trt_state->engine->get() == nullptr) {
@@ -1042,7 +1042,6 @@ common::Status TensorrtExecutionProvider::Provider_Compile(const std::vector<onn
           }
           LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] DeSerialized " + cached_path;
           trt_engine = trt_state->engine->get();
-
         } else {
           auto trt_config = tensorrt_ptr::unique_pointer<nvinfer1::IBuilderConfig>(trt_builder->createBuilderConfig());
           trt_config->setMaxWorkspaceSize(*(trt_state->max_workspace_size_ptr));
@@ -1050,7 +1049,6 @@ common::Status TensorrtExecutionProvider::Provider_Compile(const std::vector<onn
           if (*(trt_state->fp16_enable_ptr) && trt_builder->platformHasFastFp16()) {
             trt_config->setFlag(nvinfer1::BuilderFlag::kFP16);
           }
-          trt_state->engine->reset();
           *(trt_state->engine) = tensorrt_ptr::unique_pointer<nvinfer1::ICudaEngine>(
               trt_builder->buildEngineWithConfig(*trt_state->network, *trt_config));
 
@@ -1066,7 +1064,6 @@ common::Status TensorrtExecutionProvider::Provider_Compile(const std::vector<onn
             LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Serialized " + cached_path;
           }
         }
-        trt_state->context->reset();
         *(trt_state->context) = tensorrt_ptr::unique_pointer<nvinfer1::IExecutionContext>(
             trt_state->engine->get()->createExecutionContext());
         if (trt_state->context->get() == nullptr) {

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1034,9 +1034,6 @@ common::Status TensorrtExecutionProvider::Provider_Compile(const std::vector<onn
           plan_file.read((char*)engine_buf.get(), engine_size);
 
           auto runtime_ = trt_state->runtime;
-          if (trt_state->engine->get() != nullptr) {
-            trt_state->engine->get()->destroy();
-          }
           trt_state->engine->reset();
           *(trt_state->engine) = tensorrt_ptr::unique_pointer<nvinfer1::ICudaEngine>(
               runtime_->deserializeCudaEngine(engine_buf.get(), engine_size, nullptr));
@@ -1052,9 +1049,6 @@ common::Status TensorrtExecutionProvider::Provider_Compile(const std::vector<onn
           trt_config->addOptimizationProfile(trt_profile);
           if (*(trt_state->fp16_enable_ptr) && trt_builder->platformHasFastFp16()) {
             trt_config->setFlag(nvinfer1::BuilderFlag::kFP16);
-          }
-          if (trt_state->engine->get() != nullptr) {
-            trt_state->engine->get()->destroy();
           }
           trt_state->engine->reset();
           *(trt_state->engine) = tensorrt_ptr::unique_pointer<nvinfer1::ICudaEngine>(
@@ -1072,10 +1066,6 @@ common::Status TensorrtExecutionProvider::Provider_Compile(const std::vector<onn
             LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Serialized " + cached_path;
           }
         }
-        
-        if (trt_state->context->get() != nullptr) {
-          trt_state->context->get()->destroy();
-        }    
         trt_state->context->reset();
         *(trt_state->context) = tensorrt_ptr::unique_pointer<nvinfer1::IExecutionContext>(
             trt_state->engine->get()->createExecutionContext());

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -48,7 +48,7 @@ std::string GetEnginePath(const ::std::string& root, const std::string& name) {
 
 std::string GetVecHash(const ::std::vector<int>& vec) {
   std::size_t ret = vec.size();
-  for(auto& i : vec) {
+  for (auto& i : vec) {
     ret ^= i + 0x9e3779b9 + (ret << 6) + (ret >> 2);
   }
   return std::to_string(ret);


### PR DESCRIPTION
1. Fix hash conflict issue in engine cache naming
2. Add more verbose log in engine caching
3. Move engine/context release to right location
4. Update onnx-tensorrt parser to include latest fix
