### PR TITLE
Exclude a few python tests for the DML EP

### DIFF
--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -87,6 +87,23 @@ def create_backend_test(testname=None):
                 '^test_softmax_cross_entropy'
             ]
 
+        if c2.supports_device('DML'):
+            current_failing_tests += [
+                '^test_negative_log_likelihood_loss_input_shape_is_NCd1d2d3_none_no_weight_negative_ignore_index_cpu',
+                '^test_negative_log_likelihood_loss_input_shape_is_NCd1d2d3_none_no_weight_negative_ignore_index_expanded_cpu',
+                '^test_softmax_cross_entropy_input_shape_is_NCd1d2d3_none_no_weight_negative_ignore_index_cpu',
+                '^test_softmax_cross_entropy_input_shape_is_NCd1d2d3_none_no_weight_negative_ignore_index_expanded_cpu',
+                '^test_softmax_cross_entropy_input_shape_is_NCd1d2d3_none_no_weight_negative_ignore_index_log_prob_cpu',
+                '^test_softmax_cross_entropy_input_shape_is_NCd1d2d3_none_no_weight_negative_ignore_index_log_prob_expanded_cpu',
+                '^test_asin_example_cpu',
+                '^test_dynamicquantizelinear_expanded_cpu',
+                '^test_resize_downsample_scales_linear_cpu',
+                '^test_resize_downsample_sizes_linear_pytorch_half_pixel_cpu',
+                '^test_resize_downsample_sizes_nearest_cpu',
+                '^test_resize_upsample_sizes_nearest_cpu',
+                '^test_roialign_cpu'
+            ]
+
         filters = current_failing_tests + \
             filters['tests_with_pre_opset7_dependencies'] + \
             filters['unsupported_usages'] + \

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -87,7 +87,10 @@ def create_backend_test(testname=None):
                 '^test_softmax_cross_entropy'
             ]
 
-        if c2.supports_device('DML'):
+        # Skip these tests for a "pure" DML onnxruntime python wheel. We keep these tests enabled for instances where both DML and CUDA
+        # EPs are available (Windows GPU CI pipeline has this config) - these test will pass because CUDA has higher precendence than DML
+        # and the nodes are assigned to only the CUDA EP (which supports these tests)
+        if c2.supports_device('DML') and not c2.supports_device('GPU'):
             current_failing_tests += [
                 '^test_negative_log_likelihood_loss_input_shape_is_NCd1d2d3_none_no_weight_negative_ignore_index_cpu',
                 '^test_negative_log_likelihood_loss_input_shape_is_NCd1d2d3_none_no_weight_negative_ignore_index_expanded_cpu',

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -284,7 +284,7 @@ class TestInferenceSession(unittest.TestCase):
         # EPs are available (Windows GPU CI pipeline has this config) - this test will pass because CUDA has higher precendence than DML
         # and the nodes are assigned to only the CUDA EP (which supports this test)
         if ('DmlExecutionProvider' in available_providers and not 'CUDAExecutionProvider' in available_providers):
-            print("Skipping testRunModelMultipleThreads as the DML EP doesn not support calling Run() on different threads using the same session object ")
+            print("Skipping testRunModelMultipleThreads as the DML EP does not support calling Run() on different threads using the same session object ")
         else:
             so = onnxrt.SessionOptions()
             so.log_verbosity_level = 1

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -278,20 +278,28 @@ class TestInferenceSession(unittest.TestCase):
         np.testing.assert_allclose(output_expected, rescontiguous[0], rtol=1e-05, atol=1e-08)
 
     def testRunModelMultipleThreads(self):
-        so = onnxrt.SessionOptions()
-        so.log_verbosity_level = 1
-        so.logid = "MultiThreadsTest"
-        sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so)
-        ro1 = onnxrt.RunOptions()
-        ro1.logid = "thread1"
-        t1 = threading.Thread(target=self.run_model, args=(sess, ro1))
-        ro2 = onnxrt.RunOptions()
-        ro2.logid = "thread2"
-        t2 = threading.Thread(target=self.run_model, args=(sess, ro2))
-        t1.start()
-        t2.start()
-        t1.join()
-        t2.join()
+        available_providers = onnxrt.get_available_providers()
+
+        # Skip this test for a "pure" DML onnxruntime python wheel. We keep this test enabled for instances where both DML and CUDA
+        # EPs are available (Windows GPU CI pipeline has this config) - this test will pass because CUDA has higher precendence than DML
+        # and the nodes are assigned to only the CUDA EP (which supports this test)
+        if ('DmlExecutionProvider' in available_providers and not 'CUDAExecutionProvider' in available_providers):
+            print("Skipping testRunModelMultipleThreads as the DML EP doesn not support calling Run() on different threads using the same session object ")
+        else:
+            so = onnxrt.SessionOptions()
+            so.log_verbosity_level = 1
+            so.logid = "MultiThreadsTest"
+            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so)
+            ro1 = onnxrt.RunOptions()
+            ro1.logid = "thread1"
+            t1 = threading.Thread(target=self.run_model, args=(sess, ro1))
+            ro2 = onnxrt.RunOptions()
+            ro2.logid = "thread2"
+            t2 = threading.Thread(target=self.run_model, args=(sess, ro2))
+            t1.start()
+            t2.start()
+            t1.join()
+            t2.join()
 
     def testListAsInput(self):
         sess = onnxrt.InferenceSession(get_name("mul_1.onnx"))


### PR DESCRIPTION
**Description**: 

Some Python tests need to be disabled for an ORT wheel built with DML (and not CUDA) support because they are not supported by the DML EP or they don't pass some tests. 

We keep these tests covered for cases where both the DML EP and CUDA EP are built into the wheel (to have them covered in the CI pipelines which uses the combination). The tests will pass in CI because the CUDA EP has higher precedence than the DML EP and when all nodes are assigned to CUDA, these tests run fine. 

The problem is that there in nothing in CI that tests a "pure" DML only Python wheel (a real world user would build only this) and hence we won't catch any failures. Opened a backlog task (897037) to address this.

**Motivation and Context**
Fix https://github.com/microsoft/onnxruntime/issues/5130
