### PR TITLE
[TensorRT] Add slightly faster hash computation for `vector<int>`

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -48,7 +48,7 @@ std::string GetEnginePath(const ::std::string& root, const std::string& name) {
 
 std::string GetVecHash(const ::std::vector<int>& vec) {
   std::size_t ret = vec.size();
-  for (auto& i : vec) {
+  for (const auto i : vec) {
     ret ^= i + 0x9e3779b9 + (ret << 6) + (ret >> 2);
   }
   return std::to_string(ret);

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -48,7 +48,7 @@ std::string GetEnginePath(const ::std::string& root, const std::string& name) {
 
 std::string GetVecHash(const ::std::vector<int>& vec) {
   std::size_t ret = vec.size();
-  for (const auto i : vec) {
+  for (auto i : vec) {
     ret ^= i + 0x9e3779b9 + (ret << 6) + (ret >> 2);
   }
   return std::to_string(ret);


### PR DESCRIPTION
- There is no need to use `int&` (reference) for the loop variable - it adds extra redirection when one can consume the `int` value right-away