### PR TITLE
Some minor updates for ORT mobile

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -143,7 +143,7 @@ Currently only supported on Windows and Linux.
 * dotnet is required for building csharp bindings and creating managed nuget package. Follow the instructions [here](https://dotnet.microsoft.com/download) to download dotnet. Tested with versions 2.1 and 3.1.
 * nuget.exe. Follow the instructions [here](https://docs.microsoft.com/en-us/nuget/install-nuget-client-tools#nugetexe-cli) to download nuget
   * On Windows, downloading nuget is straightforward and simply following the instructions above should work.
-  * On Linux, nuget relies on Mono runtime and therefore this needs to be setup too. Above link has all the information to setup Mono and nuget. The instructions can directly be found [here](https://www.mono-project.com/docs/getting-started/install/). In some cases it is required to run `sudo apt-get install mono-complete` after installing mono. 
+  * On Linux, nuget relies on Mono runtime and therefore this needs to be setup too. Above link has all the information to setup Mono and nuget. The instructions can directly be found [here](https://www.mono-project.com/docs/getting-started/install/). In some cases it is required to run `sudo apt-get install mono-complete` after installing mono.
 
 ### Build Instructions
 #### Windows
@@ -1053,21 +1053,26 @@ Android NNAPI Execution Provider can be built using building commands in [Androi
    * iOS simulator with x86_64 architecture
 
    armv7, armv7s and i386 architectures are not currently supported.
+
+   tvOS and watchOS platforms are not currently supported.
 * apple_deploy_target
 
    Specify the minimum version of the target platform (iOS) on which the target binaries are to be deployed.
+* Code Signing
+
+   The onnxruntime library is not code signed, it may be required or desired to code sign the library for iOS devices. For more information, see [Code Signing](https://developer.apple.com/support/code-signing/).
 
 #### Build Instructions
 Run one of the following build scripts from the ONNX Runtime repository root,
 ##### Cross build for iOS device
 ```
 /build.sh --config <Release|Debug|RelWithDebInfo|MinSizeRel> --use_xcode \
-           --ios --ios_sysroot iphoneos --osx_arch arm64 --apple_deploy_target 12
+           --ios --ios_sysroot iphoneos --osx_arch arm64 --apple_deploy_target <minimal iOS version>
 ```
 ##### Cross build for iOS simulator
 ```
 /build.sh --config <Release|Debug|RelWithDebInfo|MinSizeRel> --use_xcode \
-           --ios --ios_sysroot iphonesimulator --osx_arch x86_64 --apple_deploy_target 12
+           --ios --ios_sysroot iphonesimulator --osx_arch x86_64 --apple_deploy_target <minimal iOS version>
 ```
 ---
 

--- a/onnxruntime/core/flatbuffers/ort.fbs
+++ b/onnxruntime/core/flatbuffers/ort.fbs
@@ -217,7 +217,7 @@ table SessionState {
 }
 
 table InferenceSession {
-  // This is the ort format model version
+  // This is the ORT format model version
   // The version number is defined as kOrtModelVersion in <repo root>/onnxruntime/core/session/inference_session.cc
   // Please update it when there is a change to this schema which will break the compatibilites
   ort_version:string;

--- a/onnxruntime/core/graph/graph_flatbuffers_utils.cc
+++ b/onnxruntime/core/graph/graph_flatbuffers_utils.cc
@@ -124,7 +124,7 @@ static Status SaveTypeInfoOrtFormat(flatbuffers::FlatBufferBuilder& builder,
 Status SaveValueInfoOrtFormat(flatbuffers::FlatBufferBuilder& builder,
                               const ValueInfoProto& value_info_proto,
                               flatbuffers::Offset<fbs::ValueInfo>& fbs_value_info) {
-  auto name = builder.CreateString(value_info_proto.name());
+  auto name = builder.CreateSharedString(value_info_proto.name());
   auto doc_string = builder.CreateString(value_info_proto.doc_string());
   flatbuffers::Offset<fbs::TypeInfo> type_info = 0;  // 0 indicates null
   if (value_info_proto.has_type()) {

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -545,7 +545,7 @@ common::Status Model::SaveToOrtFormat(flatbuffers::FlatBufferBuilder& builder,
                                       flatbuffers::Offset<fbs::Model>& fbs_model) const {
   auto producer_name = builder.CreateString(model_proto_.producer_name());
   auto producer_version = builder.CreateString(model_proto_.producer_version());
-  auto domain = builder.CreateString(model_proto_.domain());
+  auto domain = builder.CreateSharedString(model_proto_.domain());
   auto doc_string = builder.CreateString(model_proto_.doc_string());
 
   std::vector<flatbuffers::Offset<fbs::OperatorSetId>> op_set_ids_vec;


### PR DESCRIPTION
**Description**: Some minor updates for ORT mobile
- Add code signing info and some other minor updates in iOS build instruction
- Change flatbuffers serializing NodeArg name to use shared string 

**Motivation and Context**
- Code signing info of ORT iOS need to be clarified
- NodeArg names usually will be repeatedly used in a model, use shared string to reduce serialized file size
