### PR TITLE
Fix a bug in EmbedLayerNorm fusion

### DIFF
--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -752,10 +752,12 @@ bool FindPath(Graph& graph, const Node& node, bool is_input_edge, const std::vec
   return true;
 }
 
-bool RemoveNodesWithOneOutputBottomUp(Graph& graph, const Node& start_node, bool force) {
+bool RemoveNodesWithOneOutputBottomUp(Graph& graph, const Node& start_node) {
   std::queue<NodeIndex> q;
   std::unordered_set<NodeIndex> removed_nodes;
   q.push(start_node.Index());
+
+  bool is_start_node(true);
   // From the current node, remove nodes bottom-up util it reaches a node with multiple outputs/graph output.
   while (!q.empty()) {
     NodeIndex cur_node_index = q.front();
@@ -782,13 +784,13 @@ bool RemoveNodesWithOneOutputBottomUp(Graph& graph, const Node& start_node, bool
       q.push(parent_node->Index());
     }
 
-    if (force || cur_node.GetOutputEdgesCount() == 0) {
+    if (is_start_node || cur_node.GetOutputEdgesCount() == 0) {
       Node* cur_node_p = graph.GetNode(cur_node_index);
       RemoveNodeOutputEdges(graph, *cur_node_p);
       graph.RemoveNode(cur_node_index);
 
       removed_nodes.insert(cur_node_index);
-      force = false;
+      is_start_node = false;
     }
   }
 

--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -757,7 +757,7 @@ bool RemoveNodesWithOneOutputBottomUp(Graph& graph, const Node& start_node, bool
   std::unordered_set<NodeIndex> removed_nodes;
   q.push(start_node.Index());
   // From the current node, remove nodes bottom-up util it reaches a node with multiple outputs/graph output.
-  while (q.size() != 0) {
+  while (!q.empty()) {
     NodeIndex cur_node_index = q.front();
     q.pop();
 

--- a/onnxruntime/core/graph/graph_utils.h
+++ b/onnxruntime/core/graph/graph_utils.h
@@ -255,7 +255,7 @@ bool FindPath(Graph& graph, const Node& node, bool is_input_edge, const std::vec
  * @param node: The node to start with.
  * @returns true if there is one or more node(s) removed by this function. Otherwise return false.
 */
-bool RemoveNodesWithOneOutputBottomUp(Graph& graph, const Node& node);
+bool RemoveNodesWithOneOutputBottomUp(Graph& graph, const Node& node, bool force = true);
 
 /** Creates a mutable NodeArg owned by the graph with mirrored base_arg's TypeProto and name
  * @param base_arg The NodeArg the newly created NodeArg is mirrored based off.

--- a/onnxruntime/core/graph/graph_utils.h
+++ b/onnxruntime/core/graph/graph_utils.h
@@ -253,10 +253,9 @@ bool FindPath(Graph& graph, const Node& node, bool is_input_edge, const std::vec
 /**
  * Remove nodes with only one output edge using bottom-up bfs traversal.
  * @param node: The node to start with.
- * @param force: Forcely remove the started node, default to true.
  * @returns true if there is one or more node(s) removed by this function. Otherwise return false.
 */
-bool RemoveNodesWithOneOutputBottomUp(Graph& graph, const Node& node, bool force = true);
+bool RemoveNodesWithOneOutputBottomUp(Graph& graph, const Node& node);
 
 /** Creates a mutable NodeArg owned by the graph with mirrored base_arg's TypeProto and name
  * @param base_arg The NodeArg the newly created NodeArg is mirrored based off.

--- a/onnxruntime/core/graph/graph_utils.h
+++ b/onnxruntime/core/graph/graph_utils.h
@@ -253,6 +253,7 @@ bool FindPath(Graph& graph, const Node& node, bool is_input_edge, const std::vec
 /**
  * Remove nodes with only one output edge using bottom-up bfs traversal.
  * @param node: The node to start with.
+ * @param force: Forcely remove the started node, default to true.
  * @returns true if there is one or more node(s) removed by this function. Otherwise return false.
 */
 bool RemoveNodesWithOneOutputBottomUp(Graph& graph, const Node& node, bool force = true);

--- a/onnxruntime/core/optimizer/embed_layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/embed_layer_norm_fusion.cc
@@ -65,18 +65,6 @@ static bool CheckInput(NodeArg* input, const logging::Logger& logger) {
   return true;
 }
 
-static void AddNodes(std::vector<NodeIndex>& node_indices,
-                     const std::vector<const Node::EdgeEnd*>& edges) {
-  for (size_t i = 0; i < edges.size(); i++) {
-    auto item = edges[i]->GetNode().Index();
-    // Avoid duplication.
-    if (std::find(node_indices.begin(), node_indices.end(), item) != node_indices.end()) {
-      continue;
-    }
-    node_indices.push_back(item);
-  }
-}
-
 static bool IsNeighborNodeExpectedTypes(Node::NodeConstIterator start, const Node::NodeConstIterator end, const std::vector<std::string>& expected_types) {
   for (const std::string& expected_type : expected_types) {
     if (start == end || (*start).OpType().compare(expected_type) != 0) {
@@ -86,31 +74,6 @@ static bool IsNeighborNodeExpectedTypes(Node::NodeConstIterator start, const Nod
   }
   return start == end;
 }
-
-//static void RemoveWithSharedNodeInTop(Graph& graph, const std::vector<NodeIndex>& nodes_to_remove) {
-//  std::unordered_set<NodeIndex> nodes_to_remove_set(nodes_to_remove.begin(), nodes_to_remove.end());
-//
-//  for (const NodeIndex index : nodes_to_remove) {
-//    Node* node = graph.GetNode(index);
-//    int child_node_to_remove_count = 0;
-//    int child_node_to_stay_count = 0;
-//    for (Node::NodeConstIterator it = node->OutputEdgesBegin(), end = node->OutputEdgesEnd(); it != end; ++it) {
-//      std::unordered_set<NodeIndex>::const_iterator got = nodes_to_remove_set.find((*it).Index());
-//      if (got == nodes_to_remove_set.end()) {
-//        child_node_to_stay_count++;
-//      }
-//      if (got != nodes_to_remove_set.end()) {
-//        child_node_to_remove_count++;
-//      }
-//    }
-//    // The node is shared by other graph
-//    if (child_node_to_stay_count > 0 && child_node_to_remove_count > 0) {
-//      continue;
-//    }
-//    graph_utils::RemoveNodeOutputEdges(graph, *node);
-//    graph.RemoveNode(node->Index());
-//  }
-//}
 
 /** Match subgraph like the following:
             (input_ids)
@@ -146,9 +109,7 @@ static bool MatchInputToConcatSubgraph(
     const NodeArg* input_ids,
     const int index,
     const logging::Logger& logger,
-    std::vector<NodeIndex>& subgraph_node_indices,
     const NodeIndex expected_gather_node_1_index) {
-  subgraph_node_indices.clear();
   std::vector<graph_utils::EdgeEndToMatch> expand_parent_path1{
       {0, index, "Concat", {4, 11}, kOnnxDomain},
       {0, 0, "Unsqueeze", {1, 11}, kOnnxDomain},
@@ -181,8 +142,6 @@ static bool MatchInputToConcatSubgraph(
     DEBUG_LOG("Second input of Gather in path 1 of position shape should be a constant with value 0.");
     return false;
   }
-
-  AddNodes(subgraph_node_indices, edges);
 
   std::vector<graph_utils::EdgeEndToMatch> concat_parent_path{
       {0, 1, "Unsqueeze", {1, 11}, kOnnxDomain},
@@ -236,7 +195,6 @@ static bool MatchInputToConcatSubgraph(
     }
   }
 
-  AddNodes(subgraph_node_indices, edges);
   return true;
 }
 
@@ -263,9 +221,7 @@ static bool MatchPositionEmbeddingSubgraphsFromGather(
     Graph& graph,
     const Node& position_gather_node,
     const NodeArg* input_ids,
-    const logging::Logger& logger,
-    std::vector<NodeIndex>& subgraph_node_indices) {
-  subgraph_node_indices.clear();
+    const logging::Logger& logger) {
   std::vector<const Node::EdgeEnd*> pg_edges;
   // Look for Path 1:
   // Shape --> Gather --> Unsqueeze --> ConstantOfShape --> NonZero --> Transpose --> Squeeze
@@ -373,8 +329,6 @@ static bool MatchPositionEmbeddingSubgraphsFromGather(
       DEBUG_LOG("The parent of shape nodes are expected to be input_ids.");
       return false;
     }
-
-    subgraph_node_indices.push_back(shape_node_index);
   } else {  // gather_output_edges_count == 2
     // Match optional Reshape -> Equal -> Where -> Expand
     //                  |                  |
@@ -398,19 +352,16 @@ static bool MatchPositionEmbeddingSubgraphsFromGather(
         return false;
       }
       // Match [input_ids] -> Gather -> Shape -> Unsqueeze from Reshape node.
-      if (!MatchInputToConcatSubgraph(graph, reshape_node, input_ids, 0, logger, subgraph_node_indices, gather_node.Index())) {
+      if (!MatchInputToConcatSubgraph(graph, reshape_node, input_ids, 0, logger, gather_node.Index())) {
         DEBUG_LOG("Failed to match position subgraph.");
         return false;
       }
-      AddNodes(subgraph_node_indices, pg_edges_2);
-    } else if (!MatchInputToConcatSubgraph(graph, expand_node, input_ids, 1, logger, subgraph_node_indices, gather_node.Index())) {
+    } else if (!MatchInputToConcatSubgraph(graph, expand_node, input_ids, 1, logger, gather_node.Index())) {
       // Match [input_ids] -> Gather -> Shape -> Unsqueeze from Expand node.
       DEBUG_LOG("Failed to match position subgraph.");
       return false;
     }
   }
-
-  AddNodes(subgraph_node_indices, pg_edges);
 
   return true;
 }
@@ -463,7 +414,7 @@ static bool MatchPositionEmbeddingSubgraph(
       }
     }
   } else {
-    if (!MatchPositionEmbeddingSubgraphsFromGather(graph, position_gather_node, input_ids, logger, subgraph_node_indices)) {
+    if (!MatchPositionEmbeddingSubgraphsFromGather(graph, position_gather_node, input_ids, logger)) {
       return false;
     }
   }
@@ -729,8 +680,10 @@ static bool FuseSubGraph(Graph& graph,
   CreateEmbedLayernormNode(graph, input_ids, segment_ids, word_embedding, position_embedding, segment_embedding,
                            layer_norm_node);
 
-  if (!nodes_to_remove.empty())
+  if (!nodes_to_remove.empty()) {
     graph_utils::RemoveNodesWithOneOutputBottomUp(graph, *graph.GetNode(nodes_to_remove[0]));
+  }
+
   nodes_to_remove.clear();
 
   nodes_to_remove.push_back(word_gather_node.Index());
@@ -753,7 +706,6 @@ static bool FuseSubGraph(Graph& graph,
 static bool FuseSubGraphDistilBert(Graph& graph,
                                    Node& layer_norm_add_node,
                                    Node& layer_norm_node,
-
                                    const logging::Logger& logger) {
   std::vector<graph_utils::EdgeEndToMatch> word_embedding_path{
       {0, 0, "Gather", {1, 11, 13}, kOnnxDomain}};
@@ -824,7 +776,10 @@ static bool FuseSubGraphDistilBert(Graph& graph,
   CreateEmbedLayernormNode(graph, input_ids, nullptr, word_embedding, position_embedding, nullptr,
                            layer_norm_node);
 
-  graph_utils::RemoveNodesWithOneOutputBottomUp(graph, *graph.GetNode(nodes_to_remove[0]));
+  if (!nodes_to_remove.empty()) {
+    graph_utils::RemoveNodesWithOneOutputBottomUp(graph, *graph.GetNode(nodes_to_remove[0]));
+  }
+
   nodes_to_remove.clear();
 
   nodes_to_remove.push_back(word_gather_node.Index());

--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -264,7 +264,7 @@ def run_tensorflow(use_gpu, model_names, model_class, precision, batch_sizes, se
     for model_name in model_names:
         config = AutoConfig.from_pretrained(model_name, cache_dir=cache_dir)
 
-        model = load_pretrained_model(model_name, config=config, cache_dir=cache_dir, custom_model_class=model_class, if_tf_model=True)
+        model = load_pretrained_model(model_name, config=config, cache_dir=cache_dir, custom_model_class=model_class, is_tf_model=True)
 
         tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=cache_dir)
 

--- a/onnxruntime/python/tools/transformers/onnx_exporter.py
+++ b/onnxruntime/python/tools/transformers/onnx_exporter.py
@@ -211,16 +211,16 @@ def modelclass_dispatcher(model_name, custom_model_class):
     return "AutoModel"
 
 
-def load_pretrained_model(model_name, config, cache_dir, custom_model_class, if_tf_model=False):
+def load_pretrained_model(model_name, config, cache_dir, custom_model_class, is_tf_model=False):
     model_class_name = modelclass_dispatcher(model_name, custom_model_class)
 
     if model_class_name == "GPT2ModelNoPastState":
-        if if_tf_model:
+        if is_tf_model:
             raise NotImplementedError("TFGPT2ModelNoPastState is currently not supported.")
         else:
             return GPT2ModelNoPastState.from_pretrained(model_name, config=config, cache_dir=cache_dir)
 
-    if if_tf_model:
+    if is_tf_model:
         model_class_name = 'TF' + model_class_name
 
     transformers_module = __import__("transformers", fromlist=[model_class_name])
@@ -326,7 +326,7 @@ def export_onnx_model_from_tf(model_name, opset_version, use_external_data_forma
 
     config = AutoConfig.from_pretrained(model_name, cache_dir=cache_dir)
 
-    model = load_pretrained_model(model_name, config=config, cache_dir=cache_dir, custom_model_class=model_class, if_tf_model=True)
+    model = load_pretrained_model(model_name, config=config, cache_dir=cache_dir, custom_model_class=model_class, is_tf_model=True)
 
     model._saved_model_inputs_spec = None
 

--- a/onnxruntime/python/tools/transformers/onnx_exporter.py
+++ b/onnxruntime/python/tools/transformers/onnx_exporter.py
@@ -215,7 +215,7 @@ def load_pretrained_model(model_name, config, cache_dir, custom_model_class, if_
     model_class_name = modelclass_dispatcher(model_name, custom_model_class)
 
     if model_class_name == "GPT2ModelNoPastState":
-        if is_tf_model:
+        if if_tf_model:
             raise NotImplementedError("TFGPT2ModelNoPastState is currently not supported.")
         else:
             return GPT2ModelNoPastState.from_pretrained(model_name, config=config, cache_dir=cache_dir)

--- a/onnxruntime/python/tools/transformers/onnx_exporter.py
+++ b/onnxruntime/python/tools/transformers/onnx_exporter.py
@@ -213,10 +213,7 @@ def modelclass_dispatcher(model_name, custom_model_class):
 
 def load_pretrained_model(model_name, config, cache_dir, custom_model_class, if_tf_model=False):
     model_class_name = modelclass_dispatcher(model_name, custom_model_class)
-    
-    if model_class_name == "GPT2ModelNoPastState":
-        return GPT2ModelNoPastState.from_pretrained(model_name, config=config, cache_dir=cache_dir)
-    
+
     if model_class_name == "GPT2ModelNoPastState":
         if is_tf_model:
             raise NotImplementedError("TFGPT2ModelNoPastState is currently not supported.")

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -2664,7 +2664,7 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat8) {
   EXPECT_EQ(op_to_count["EmbedLayerNormalization"], 1);
   EXPECT_EQ(op_to_count["Attention"], 1);
   EXPECT_EQ(op_to_count["Cast"], 2);
-  EXPECT_EQ(op_to_count["Shape"], 0);
+  EXPECT_EQ(op_to_count["Shape"], 1);
   EXPECT_EQ(op_to_count["Gather"], 0);
   EXPECT_EQ(op_to_count["Unsqueeze"], 0);
   EXPECT_EQ(op_to_count["ReduceSum"], 1);
@@ -2676,7 +2676,7 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat9) {
   EXPECT_EQ(op_to_count["EmbedLayerNormalization"], 1);
   EXPECT_EQ(op_to_count["Attention"], 1);
   EXPECT_EQ(op_to_count["Cast"], 2);
-  EXPECT_EQ(op_to_count["Shape"], 0);
+  EXPECT_EQ(op_to_count["Shape"], 1);
   EXPECT_EQ(op_to_count["Gather"], 2);
   EXPECT_EQ(op_to_count["Unsqueeze"], 2);
   EXPECT_EQ(op_to_count["ReduceSum"], 1);

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -2664,7 +2664,7 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat8) {
   EXPECT_EQ(op_to_count["EmbedLayerNormalization"], 1);
   EXPECT_EQ(op_to_count["Attention"], 1);
   EXPECT_EQ(op_to_count["Cast"], 2);
-  EXPECT_EQ(op_to_count["Shape"], 1);
+  EXPECT_EQ(op_to_count["Shape"], 0);
   EXPECT_EQ(op_to_count["Gather"], 0);
   EXPECT_EQ(op_to_count["Unsqueeze"], 0);
   EXPECT_EQ(op_to_count["ReduceSum"], 1);


### PR DESCRIPTION
**Description**: Describe your changes.
The shape node shall not remove when multiple shape nodes merge into a single node

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
