### PR TITLE
Fix softmax_warp_backward math when is_log_softmax = True and register LogSoftmax CUDA kernel

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -378,6 +378,9 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain,
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 10, float, Softmax);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 10, double, Softmax);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 10, MLFloat16, Softmax);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 10, float, LogSoftmax);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 10, double, LogSoftmax);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 10, MLFloat16, LogSoftmax);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, 11, float, Pow);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, 11, double, Pow);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, 11, MLFloat16, Pow);
@@ -735,6 +738,9 @@ class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kO
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, float, Softmax);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, double, Softmax);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, MLFloat16, Softmax);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, float, LogSoftmax);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, double, LogSoftmax);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, MLFloat16, LogSoftmax);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, Split);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, Squeeze);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, TopK);
@@ -925,6 +931,9 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, float, Softmax);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, double, Softmax);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, MLFloat16, Softmax);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, float, LogSoftmax);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, double, LogSoftmax);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, MLFloat16, LogSoftmax);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, Split);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, Squeeze);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, Unsqueeze);
@@ -1052,6 +1061,9 @@ static Status RegisterCudaKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 10, float, Softmax)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 10, double, Softmax)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 10, MLFloat16, Softmax)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 10, float, LogSoftmax)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 10, double, LogSoftmax)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 10, MLFloat16, LogSoftmax)>, 
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, 11, float, Pow)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, 11, double, Pow)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 7, 11, MLFloat16, Pow)>,
@@ -1412,6 +1424,9 @@ static Status RegisterCudaKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, float, Softmax)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, double, Softmax)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, MLFloat16, Softmax)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, float, LogSoftmax)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, double, LogSoftmax)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, MLFloat16, LogSoftmax)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, Split)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, 12, Squeeze)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 11, TopK)>,
@@ -1598,6 +1613,9 @@ static Status RegisterCudaKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, float, Softmax)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, double, Softmax)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, MLFloat16, Softmax)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, float, LogSoftmax)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, double, LogSoftmax)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, MLFloat16, LogSoftmax)>, 
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, Split)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, Squeeze)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, Unsqueeze)>,

--- a/onnxruntime/core/providers/cuda/math/softmax.cc
+++ b/onnxruntime/core/providers/cuda/math/softmax.cc
@@ -26,7 +26,7 @@ Status SoftMaxComputeHelper(
 
   // cudnnSoftmaxForward/Backward is not optimal implementation.
   // TODO: remove cudnn path completely in the future.
-  if (D == input_shape[normalized_axis] && D <= 1024 && D * sizeof(T) <= 4096) {
+  if (D <= 1024 && D * sizeof(T) <= 4096) {
     dispatch_softmax_forward<CudaT, CudaT, AccType<T>, is_log_softmax>(Y_data, X_data, gsl::narrow_cast<int>(D), gsl::narrow_cast<int>(D), gsl::narrow_cast<int>(N));
     return Status::OK();
   }

--- a/orttraining/orttraining/test/training_ops/cuda/softmax_test.cc
+++ b/orttraining/orttraining/test/training_ops/cuda/softmax_test.cc
@@ -26,27 +26,29 @@ static void TestSoftmax(const std::vector<int64_t>& X_dims,
   test.CompareWithCPU(kCudaExecutionProvider, per_sample_tolerance, relative_per_sample_tolerance);
 }
 
+// small tensor to check dispatch_softmax_forward
 TEST(CudaKernelTest, Softmax_SmallTensor) {
-  std::vector<int64_t> X_dims{8, 2, 128, 128};
-  std::vector<int64_t> Y_dims{8, 2, 128, 128};
+  std::vector<int64_t> X_dims{8, 2, 128};
+  std::vector<int64_t> Y_dims{8, 2, 128};
   TestSoftmax(X_dims, Y_dims, false);
 }
 
+// large tensor to check cuda DNN softmax forward
 TEST(CudaKernelTest, Softmax_LargeTensor) {
-  std::vector<int64_t> X_dims{8, 16, 512, 512};
-  std::vector<int64_t> Y_dims{8, 16, 512, 512};
+  std::vector<int64_t> X_dims{8, 16, 512};
+  std::vector<int64_t> Y_dims{8, 16, 512};
   TestSoftmax(X_dims, Y_dims, false);
 }
 
 TEST(CudaKernelTest, LogSoftmax_SmallTensor) {
-  std::vector<int64_t> X_dims{8, 2, 128, 128};
-  std::vector<int64_t> Y_dims{8, 2, 128, 128};
+  std::vector<int64_t> X_dims{8, 2, 128};
+  std::vector<int64_t> Y_dims{8, 2, 128};
   TestSoftmax(X_dims, Y_dims, true);
 }
 
 TEST(CudaKernelTest, LogSoftmax_LargeTensor) {
-  std::vector<int64_t> X_dims{8, 16, 512, 512};
-  std::vector<int64_t> Y_dims{8, 16, 512, 512};
+  std::vector<int64_t> X_dims{8, 16, 512};
+  std::vector<int64_t> Y_dims{8, 16, 512};
   TestSoftmax(X_dims, Y_dims, true);
 }
 
@@ -75,31 +77,33 @@ static void TestSoftmaxGrad(const std::vector<int64_t>& dY_dims,
   test.CompareWithCPU(kCudaExecutionProvider, per_sample_tolerance, relative_per_sample_tolerance);
 }
 
+// small tensor to check dispatch_softmax_backward
 TEST(CudaKernelTest, SoftmaxGrad_SmallTensor) {
-  std::vector<int64_t> dY_dims{8, 2, 128, 128};
-  std::vector<int64_t> Y_dims{8, 2, 128, 128};
-  std::vector<int64_t> dX_dims{8, 2, 128, 128};
+  std::vector<int64_t> dY_dims{8, 2, 128};
+  std::vector<int64_t> Y_dims{8, 2, 128};
+  std::vector<int64_t> dX_dims{8, 2, 128};
   TestSoftmaxGrad(dY_dims, Y_dims, dX_dims);
 }
 
+// large tensor to check cuda DNN softmax backward
 TEST(CudaKernelTest, SoftmaxGrad_LargeTensor) {
-  std::vector<int64_t> dY_dims{8, 16, 512, 512};
-  std::vector<int64_t> Y_dims{8, 16, 512, 512};
-  std::vector<int64_t> dX_dims{8, 16, 512, 512};
+  std::vector<int64_t> dY_dims{8, 16, 512};
+  std::vector<int64_t> Y_dims{8, 16, 512};
+  std::vector<int64_t> dX_dims{8, 16, 512};
   TestSoftmaxGrad(dY_dims, Y_dims, dX_dims);
 }
 
 TEST(CudaKernelTest, LogSoftmaxGrad_SmallTensor) {
-  std::vector<int64_t> dY_dims{8, 2, 128, 128};
-  std::vector<int64_t> Y_dims{8, 2, 128, 128};
-  std::vector<int64_t> dX_dims{8, 2, 128, 128};
+  std::vector<int64_t> dY_dims{8, 2, 128};
+  std::vector<int64_t> Y_dims{8, 2, 128};
+  std::vector<int64_t> dX_dims{8, 2, 128};
   TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, true);
 }
 
 TEST(CudaKernelTest, LogSoftmaxGrad_LargeTensor) {
-  std::vector<int64_t> dY_dims{8, 16, 512, 512};
-  std::vector<int64_t> Y_dims{8, 16, 512, 512};
-  std::vector<int64_t> dX_dims{8, 16, 512, 512};
+  std::vector<int64_t> dY_dims{8, 16, 512};
+  std::vector<int64_t> Y_dims{8, 16, 512};
+  std::vector<int64_t> dX_dims{8, 16, 512};
   TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, true);
 }
 

--- a/orttraining/orttraining/test/training_ops/cuda/softmax_test.cc
+++ b/orttraining/orttraining/test/training_ops/cuda/softmax_test.cc
@@ -8,12 +8,14 @@ namespace test {
 
 static void TestSoftmax(const std::vector<int64_t>& X_dims,
                         const std::vector<int64_t>& Y_dims,
+                        int axis = 1,
                         bool is_log_softmax=false,
                         double per_sample_tolerance = 1e-4,
                         double relative_per_sample_tolerance = 1e-4) {
                       
   const char* op = is_log_softmax? "LogSoftmax" : "Softmax";
   CompareOpTester test(op);
+  test.AddAttribute<int64_t>("axis", axis);
 
   // create rand inputs
   RandomValueGenerator random{};
@@ -26,41 +28,72 @@ static void TestSoftmax(const std::vector<int64_t>& X_dims,
   test.CompareWithCPU(kCudaExecutionProvider, per_sample_tolerance, relative_per_sample_tolerance);
 }
 
-// small tensor to check dispatch_softmax_forward
-TEST(CudaKernelTest, Softmax_SmallTensor) {
-  std::vector<int64_t> X_dims{8, 2, 128};
-  std::vector<int64_t> Y_dims{8, 2, 128};
-  TestSoftmax(X_dims, Y_dims, false);
+// small tensor to check softmax_warp_forward
+// note: keep nelem <= 1024 to invoke softmax_warp_forward!
+TEST(CudaKernelTest, Softmax_SmallTensor_LastAxis) {
+  std::vector<int64_t> X_dims{4, 2, 128};
+  std::vector<int64_t> Y_dims{4, 2, 128};
+  TestSoftmax(X_dims, Y_dims, 2, false);
+}
+
+TEST(CudaKernelTest, Softmax_SmallTensor_AllAxis) {
+  std::vector<int64_t> X_dims{4, 2, 128};
+  std::vector<int64_t> Y_dims{4, 2, 128};
+  TestSoftmax(X_dims, Y_dims, 0, false);
+  TestSoftmax(X_dims, Y_dims, 1, false);
 }
 
 // large tensor to check cuda DNN softmax forward
-TEST(CudaKernelTest, Softmax_LargeTensor) {
-  std::vector<int64_t> X_dims{8, 16, 512};
-  std::vector<int64_t> Y_dims{8, 16, 512};
-  TestSoftmax(X_dims, Y_dims, false);
+TEST(CudaKernelTest, Softmax_LargeTensor_LastAxis) {
+  std::vector<int64_t> X_dims{8, 16, 2048};
+  std::vector<int64_t> Y_dims{8, 16, 2048};
+  TestSoftmax(X_dims, Y_dims, 2, false);
 }
 
-TEST(CudaKernelTest, LogSoftmax_SmallTensor) {
-  std::vector<int64_t> X_dims{8, 2, 128};
-  std::vector<int64_t> Y_dims{8, 2, 128};
-  TestSoftmax(X_dims, Y_dims, true);
-}
-
-TEST(CudaKernelTest, LogSoftmax_LargeTensor) {
+TEST(CudaKernelTest, Softmax_LargeTensor_AllAxis) {
   std::vector<int64_t> X_dims{8, 16, 512};
   std::vector<int64_t> Y_dims{8, 16, 512};
-  TestSoftmax(X_dims, Y_dims, true);
+  TestSoftmax(X_dims, Y_dims, 0, false);
+  TestSoftmax(X_dims, Y_dims, 1, false);
+}
+
+TEST(CudaKernelTest, LogSoftmax_SmallTensor_LastAxis) {
+  std::vector<int64_t> X_dims{4, 2, 128};
+  std::vector<int64_t> Y_dims{4, 2, 128};
+  TestSoftmax(X_dims, Y_dims, 2, true);
+}
+
+TEST(CudaKernelTest, LogSoftmax_SmallTensor_AllAxis) {
+  std::vector<int64_t> X_dims{4, 2, 128};
+  std::vector<int64_t> Y_dims{4, 2, 128};
+  TestSoftmax(X_dims, Y_dims, 0, true);
+  TestSoftmax(X_dims, Y_dims, 1, true);
+}
+
+TEST(CudaKernelTest, LogSoftmax_LargeTensor_LastAxis) {
+  std::vector<int64_t> X_dims{8, 16, 2048};
+  std::vector<int64_t> Y_dims{8, 16, 2048};
+  TestSoftmax(X_dims, Y_dims, 2, true);
+}
+
+TEST(CudaKernelTest, LogSoftmax_LargeTensor_AllAxis) {
+  std::vector<int64_t> X_dims{8, 16, 512};
+  std::vector<int64_t> Y_dims{8, 16, 512};
+  TestSoftmax(X_dims, Y_dims, 0, true);
+  TestSoftmax(X_dims, Y_dims, 1, true);
 }
 
 static void TestSoftmaxGrad(const std::vector<int64_t>& dY_dims,
                             const std::vector<int64_t>& Y_dims,
                             const std::vector<int64_t>& dX_dims,
+                            int axis = 1,
                             bool is_log_softmax = false,
                             double per_sample_tolerance = 1e-4,
                             double relative_per_sample_tolerance = 1e-4) {  
 
   const char* op = is_log_softmax? "LogSoftmaxGrad" : "SoftmaxGrad";
   CompareOpTester test(op, 1, kMSDomain);
+  test.AddAttribute<int64_t>("axis", axis);
 
   // create rand inputs
   RandomValueGenerator random{};
@@ -78,33 +111,66 @@ static void TestSoftmaxGrad(const std::vector<int64_t>& dY_dims,
 }
 
 // small tensor to check dispatch_softmax_backward
-TEST(CudaKernelTest, SoftmaxGrad_SmallTensor) {
-  std::vector<int64_t> dY_dims{8, 2, 128};
-  std::vector<int64_t> Y_dims{8, 2, 128};
-  std::vector<int64_t> dX_dims{8, 2, 128};
-  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims);
+TEST(CudaKernelTest, SoftmaxGrad_SmallTensor_LastAxis) {
+  std::vector<int64_t> dY_dims{4, 2, 128};
+  std::vector<int64_t> Y_dims{4, 2, 128};
+  std::vector<int64_t> dX_dims{4, 2, 128};
+  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, 2);
+}
+
+TEST(CudaKernelTest, SoftmaxGrad_SmallTensor_AllAxis) {
+  std::vector<int64_t> dY_dims{4, 2, 128};
+  std::vector<int64_t> Y_dims{4, 2, 128};
+  std::vector<int64_t> dX_dims{4, 2, 128};
+  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, 0);
+  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, 1);
 }
 
 // large tensor to check cuda DNN softmax backward
-TEST(CudaKernelTest, SoftmaxGrad_LargeTensor) {
+TEST(CudaKernelTest, SoftmaxGrad_LargeTensor_LastAxis) {
+  std::vector<int64_t> dY_dims{8, 16, 2048};
+  std::vector<int64_t> Y_dims{8, 16, 2048};
+  std::vector<int64_t> dX_dims{8, 16, 2048};
+  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, 2);
+}
+
+// large tensor to check cuda DNN softmax backward
+TEST(CudaKernelTest, SoftmaxGrad_LargeTensor_AllAxis) {
   std::vector<int64_t> dY_dims{8, 16, 512};
   std::vector<int64_t> Y_dims{8, 16, 512};
   std::vector<int64_t> dX_dims{8, 16, 512};
-  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims);
+  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, 0);
+  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, 1);
 }
 
-TEST(CudaKernelTest, LogSoftmaxGrad_SmallTensor) {
-  std::vector<int64_t> dY_dims{8, 2, 128};
-  std::vector<int64_t> Y_dims{8, 2, 128};
-  std::vector<int64_t> dX_dims{8, 2, 128};
-  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, true);
+TEST(CudaKernelTest, LogSoftmaxGrad_SmallTensor_LastAxis) {
+  std::vector<int64_t> dY_dims{4, 2, 128};
+  std::vector<int64_t> Y_dims{4, 2, 128};
+  std::vector<int64_t> dX_dims{4, 2, 128};
+  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, 2, true);
 }
 
-TEST(CudaKernelTest, LogSoftmaxGrad_LargeTensor) {
+TEST(CudaKernelTest, LogSoftmaxGrad_SmallTensor_AllAxis) {
+  std::vector<int64_t> dY_dims{4, 2, 128};
+  std::vector<int64_t> Y_dims{4, 2, 128};
+  std::vector<int64_t> dX_dims{4, 2, 128};
+  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, 0, true);
+  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, 1, true);
+}
+
+TEST(CudaKernelTest, LogSoftmaxGrad_LargeTensor_LastAxis) {
+  std::vector<int64_t> dY_dims{8, 16, 2048};
+  std::vector<int64_t> Y_dims{8, 16, 2048};
+  std::vector<int64_t> dX_dims{8, 16, 2048};
+  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, 2, true);
+}
+
+TEST(CudaKernelTest, LogSoftmaxGrad_LargeTensor_AllAxis) {
   std::vector<int64_t> dY_dims{8, 16, 512};
   std::vector<int64_t> Y_dims{8, 16, 512};
   std::vector<int64_t> dX_dims{8, 16, 512};
-  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, true);
+  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, 0, true);
+  TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, 1, true);
 }
 
 }  // namespace test

--- a/orttraining/orttraining/training_ops/cuda/math/softmax_grad.cc
+++ b/orttraining/orttraining/training_ops/cuda/math/softmax_grad.cc
@@ -29,7 +29,7 @@ Status SoftMaxGradComputeHelper(
   auto Y_data = reinterpret_cast<const CudaT*>(Y);
   auto dX_data = reinterpret_cast<CudaT*>(dX);
 
-  if (D == input_shape[normalized_axis] && D <= 1024 && D * sizeof(T) <= 4096) {
+  if (D <= 1024 && D * sizeof(T) <= 4096) {
     dispatch_softmax_backward<CudaT, CudaT, AccType<T>, is_log_softmax>(dX_data, dY_data, Y_data, gsl::narrow_cast<int>(D), gsl::narrow_cast<int>(D), gsl::narrow_cast<int>(N));
     return Status::OK();
   }


### PR DESCRIPTION
**Description**: 
- Register LogSoftmax CUDA kernel.
- Fix math for _softmax_warp_backward_ when is_log_softmax = true. 
- Fix operator tests to actually invoke _softmax_warp_forward_ and _softmax_warp_backward_ as well as CUDA DNN fallbacks. 
- Remove what seems like unnecessary constraint for axis to be on last dimension? Comment?

**Motivation and Context**
- The LogSoftmax CUDA kernel was not registered and execution was falling back to LogSoftmax CPU kernel.
- The gradient checker was testing LogSoftmaxGrad CPU kernel (not CUDA kernel).
- The _softmax_warp_forward_ and _softmax_warp_backward_ were not being tested.
