### PR TITLE
Build: Add missing EXCLUDE_FROM_ALL to ONNX submodule

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -744,7 +744,7 @@ else()
 endif()
 
 if (NOT onnxruntime_MINIMAL_BUILD)
-  add_subdirectory(external/onnx)
+  add_subdirectory(external/onnx EXCLUDE_FROM_ALL)
 else()
   include(onnx_minimal)
 endif()


### PR DESCRIPTION
**Description**: 

See: https://cmake.org/cmake/help/latest/prop_dir/EXCLUDE_FROM_ALL.html

**Motivation and Context**
- Why is this change required? What problem does it solve?

Avoid building unnecessary things 

- If it fixes an open issue, please link to the issue here.
