### PR TITLE
Fix large model (>2g) support limit in quantization tool

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -53,8 +53,8 @@ class ONNXCalibrater:
         :return: augmented ONNX model
         '''
 
+        onnx.shape_inference.infer_shapes(self.model_path)
         model = onnx.load(self.model_path)
-        model = onnx.shape_inference.infer_shapes(model)
         value_infos = {vi.name: vi for vi in model.graph.value_info}
         value_infos.update({ot.name: ot for ot in model.graph.output})
 

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -52,9 +52,15 @@ class ONNXCalibrater:
         model and ensures their outputs are stored as part of the graph output
         :return: augmented ONNX model
         '''
+        #infer shapes of the model
+        if onnx.__version__ < "1.8.0":
+            model = onnx.load(self.model_path)
+            model = onnx.shape_inference.infer_shapes(model)  
 
-        onnx.shape_inference.infer_shapes(self.model_path)
-        model = onnx.load(self.model_path)
+        if onnx.__version__ == "1.8.0":
+            onnx.shape_inference.infer_shapes(self.model_path)
+            model = onnx.load(self.model_path)  
+
         value_infos = {vi.name: vi for vi in model.graph.value_info}
         value_infos.update({ot.name: ot for ot in model.graph.output})
 

--- a/onnxruntime/python/tools/quantization/onnx_model.py
+++ b/onnxruntime/python/tools/quantization/onnx_model.py
@@ -1,5 +1,6 @@
 import onnx
 from .quant_utils import find_by_name
+from pathlib import Path
 
 
 class ONNXModel:
@@ -125,3 +126,13 @@ class ONNXModel:
                 if node_input == initializer.name:
                     nodes.append(node)
         return nodes
+
+    def save_model_to_file(self, output_path, use_external_data_format=False):
+        '''
+        Save model to external data, which is needed for model size > 2GB
+        '''
+        if use_external_data_format:
+            onnx.external_data_helper.convert_model_to_external_data(self.model,
+                                                                    all_tensors_to_one_file=True,
+                                                                    location=Path(output_path).name + ".data")
+        onnx.save_model(self.model, output_path)

--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -75,9 +75,10 @@ def _get_qrange_for_qType(qType, reduce_range=False):
 
 
 class ONNXQuantizer:
-    def __init__(self, model, per_channel, reduce_range, mode, static, weight_qType, input_qType, quantization_params,
+    def __init__(self, model_path, per_channel, reduce_range, mode, static, weight_qType, input_qType, quantization_params,
                  nodes_to_quantize, nodes_to_exclude, op_types_to_quantize):
-        onnx_model = shape_inference.infer_shapes(model)
+        shape_inference.infer_shapes(model_path)
+        onnx_model = onnx.load(model_path)
         self.model = ONNXModel(onnx_model)
         self.value_infos = {vi.name: vi for vi in onnx_model.graph.value_info}
         self.per_channel = per_channel  # weight-pack per channel

--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -75,12 +75,10 @@ def _get_qrange_for_qType(qType, reduce_range=False):
 
 
 class ONNXQuantizer:
-    def __init__(self, model_path, per_channel, reduce_range, mode, static, weight_qType, input_qType, quantization_params,
+    def __init__(self, model, per_channel, reduce_range, mode, static, weight_qType, input_qType, quantization_params,
                  nodes_to_quantize, nodes_to_exclude, op_types_to_quantize):
-        shape_inference.infer_shapes(model_path)
-        onnx_model = onnx.load(model_path)
-        self.model = ONNXModel(onnx_model)
-        self.value_infos = {vi.name: vi for vi in onnx_model.graph.value_info}
+        self.model = ONNXModel(model)  # model: inferred_shape model
+        self.value_infos = {vi.name: vi for vi in model.graph.value_info} 
         self.per_channel = per_channel  # weight-pack per channel
         self.reduce_range = reduce_range
         self.mode = mode  # QuantizationMode.Value


### PR DESCRIPTION
**Description**: Describe your changes.

- Support >2g size large model in quantization tool.  (currently works for quantize_dynamic and quantize_static)

This change should be run and tested with latest onnx version. (with updated onnx shape inference support),


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
