### PR TITLE
Reduce IOS shared library size by a symbol file.

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -11,6 +11,7 @@ endif()
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "iOS")
   set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")
+  set(OUTPUT_STYLE xcode)
 endif()
 
 #If you want to verify if there is any extra line in symbols.txt, run
@@ -72,6 +73,7 @@ if (NOT WIN32)
         INSTALL_RPATH_USE_LINK_PATH FALSE
         BUILD_WITH_INSTALL_NAME_DIR TRUE
         INSTALL_NAME_DIR @rpath)
+      set(ONNXRUNTIME_SO_LINK_FLAG " -Wl,-exported_symbols_list,${SYMBOL_FILE}")
     else()
         set_target_properties(onnxruntime PROPERTIES INSTALL_RPATH "@loader_path")
     endif()

--- a/tools/ci_build/gen_def.py
+++ b/tools/ci_build/gen_def.py
@@ -9,7 +9,7 @@ def parse_arguments():
     parser.add_argument("--output", required=True, help="output file")
     parser.add_argument("--output_source", required=True, help="output file")
     parser.add_argument("--version_file", required=True, help="VERSION_NUMBER file")
-    parser.add_argument("--style", required=True, choices=["gcc", "vc"])
+    parser.add_argument("--style", required=True, choices=["gcc", "vc", "xcode"])
     parser.add_argument("--config", required=True, nargs="+")
     return parser.parse_args()
 
@@ -38,6 +38,8 @@ with open(args.output, 'w') as file:
     if args.style == 'vc':
         file.write('LIBRARY "onnxruntime.dll"\n')
         file.write('EXPORTS\n')
+    elif args.style == 'xcode':
+        pass    # xcode compile don't has any header.
     else:
         file.write('VERS_%s {\n' % VERSION_STRING)
         file.write(' global:\n')
@@ -45,6 +47,8 @@ with open(args.output, 'w') as file:
     for symbol in symbols:
         if args.style == 'vc':
             file.write(" %s @%d\n" % (symbol, symbol_index))
+        elif args.style == 'xcode':
+            file.write("_%s\n" % symbol)
         else:
             file.write("  %s;\n" % symbol)
         symbol_index += 1


### PR DESCRIPTION
With this change, the ONNXRuntime binary size will be reduce to ~58K, much smaller than xcode bitcode strip does.