### PR TITLE
Remove almost all of the reinterpret_casts from the provider shared API

### DIFF
--- a/onnxruntime/core/framework/provider_bridge_ort.cc
+++ b/onnxruntime/core/framework/provider_bridge_ort.cc
@@ -24,6 +24,43 @@
 #include "core/providers/cuda/cuda_common.h"
 #endif
 
+namespace onnxruntime {
+// These Provider types are really just internal types, so when we #define PROVIDER_BRIDGE_ORT so that only these definitions are seen by provider_interfaces.h
+// Users of provider_interfaces.h (through provider_api.h) will see the wrappers that call through the provider shared interface which is implemented by this file
+using Provider_AttributeProto = ONNX_NAMESPACE::AttributeProto;
+using Provider_GraphProto = ONNX_NAMESPACE::GraphProto;
+using Provider_ModelProto = ONNX_NAMESPACE::ModelProto;
+using Provider_NodeProto = ONNX_NAMESPACE::NodeProto;
+using Provider_TensorProto = ONNX_NAMESPACE::TensorProto;
+using Provider_TensorProtos = google::protobuf::RepeatedPtrField<ONNX_NAMESPACE::TensorProto>;
+using Provider_TensorShapeProto_Dimension = ONNX_NAMESPACE::TensorShapeProto_Dimension;
+using Provider_TensorShapeProto_Dimensions = google::protobuf::RepeatedPtrField<ONNX_NAMESPACE::TensorShapeProto_Dimension>;
+using Provider_TensorShapeProto = ONNX_NAMESPACE::TensorShapeProto;
+using Provider_TypeProto_Tensor = ONNX_NAMESPACE::TypeProto_Tensor;
+using Provider_TypeProto = ONNX_NAMESPACE::TypeProto;
+using Provider_ValueInfoProto = ONNX_NAMESPACE::ValueInfoProto;
+using Provider_ValueInfoProtos = google::protobuf::RepeatedPtrField<ONNX_NAMESPACE::ValueInfoProto>;
+
+using Provider_ComputeCapability = ComputeCapability;
+using Provider_DataTransferManager = DataTransferManager;
+using Provider_IDataTransfer = IDataTransfer;
+using Provider_IndexedSubGraph = IndexedSubGraph;
+using Provider_IndexedSubGraph_MetaDef = IndexedSubGraph::MetaDef;
+using Provider_KernelDef = KernelDef;
+using Provider_KernelDefBuilder = KernelDefBuilder;
+using Provider_KernelRegistry = KernelRegistry;
+using Provider_Function = Function;
+using Provider_Graph = Graph;
+using Provider_GraphViewer = GraphViewer;
+using Provider_Model = Model;
+using Provider_Node = Node;
+using Provider_NodeArg = NodeArg;
+using Provider_NodeAttributes = NodeAttributes;
+using Provider_OpKernelContext = OpKernelContext;
+using Provider_OpKernelInfo = OpKernelInfo;
+using Provider_Tensor = Tensor;
+}  // namespace onnxruntime
+
 #define PROVIDER_BRIDGE_ORT
 #include "core/providers/shared_library/provider_interfaces.h"
 #include "onnx/common/stl_backports.h"
@@ -90,7 +127,7 @@ struct Provider_TensorShapeProto_Dimension_Iterator_Impl : Provider_TensorShapeP
   bool operator!=(const Provider_TensorShapeProto_Dimension_Iterator& p) const override { return v_ != static_cast<const Provider_TensorShapeProto_Dimension_Iterator_Impl*>(&p)->v_; }
 
   void operator++() override { v_.operator++(); }
-  const Provider_TensorShapeProto_Dimension& operator*() override { return *reinterpret_cast<const Provider_TensorShapeProto_Dimension*>(&v_.operator*()); }
+  const Provider_TensorShapeProto_Dimension& operator*() override { return *v_; }
 
   google::protobuf::internal::RepeatedPtrIterator<const onnx::TensorShapeProto_Dimension> v_;
 };
@@ -102,7 +139,7 @@ struct Provider_NodeAttributes_Iterator_Impl : Provider_NodeAttributes_Iterator 
 
   void operator++() override { v_.operator++(); }
   const std::string& first() const override { return v_->first; }
-  const Provider_AttributeProto& second() override { return *reinterpret_cast<const Provider_AttributeProto*>(static_cast<const ONNX_NAMESPACE::AttributeProto*>(&v_->second)); }
+  const Provider_AttributeProto& second() override { return v_->second; }
 
   NodeAttributes::const_iterator v_;
 };
@@ -113,9 +150,7 @@ struct Provider_Node__NodeIterator_Impl : Provider_Node__NodeIterator {
   bool operator!=(const Provider_Node__NodeIterator& p) const override { return v_ != static_cast<const Provider_Node__NodeIterator_Impl*>(&p)->v_; }
 
   void operator++() override { v_.operator++(); }
-  const Provider_Node& operator*() override {
-    return *reinterpret_cast<const Provider_Node*>(&*v_);
-  }
+  const Provider_Node& operator*() override { return *v_; }
 
   Node::NodeConstIterator v_;
 };
@@ -126,21 +161,11 @@ struct Provider_Node__EdgeIterator_Impl : Provider_Node__EdgeIterator {
   bool operator!=(const Provider_Node__EdgeIterator& p) const override { return v_ != static_cast<const Provider_Node__EdgeIterator_Impl*>(&p)->v_; }
 
   void operator++() override { v_.operator++(); }
-  const Provider_Node& GetNode() const override { return *reinterpret_cast<const Provider_Node*>(&v_->GetNode()); }
-
-  int GetSrcArgIndex() const override {
-    return v_->GetSrcArgIndex();
-  }
-
-  int GetDstArgIndex() const override {
-    return v_->GetDstArgIndex();
-  }
+  const Provider_Node& GetNode() const override { return v_->GetNode(); }
+  int GetSrcArgIndex() const override { return v_->GetSrcArgIndex(); }
+  int GetDstArgIndex() const override { return v_->GetDstArgIndex(); }
 
   Node::EdgeConstIterator v_;
-};
-
-struct Provider_OpKernel_Impl : Provider_OpKernel {
-  OpKernelInfo op_kernel_info_;
 };
 
 struct OpKernel_Translator : OpKernel {
@@ -148,7 +173,7 @@ struct OpKernel_Translator : OpKernel {
   }
 
   Status Compute(OpKernelContext* context) const override {
-    return p_->Compute(reinterpret_cast<Provider_OpKernelContext*>(context), *reinterpret_cast<const Provider_OpKernel_Base*>(static_cast<const OpKernel*>(this)));
+    return p_->Compute(context, *reinterpret_cast<const Provider_OpKernel_Base*>(static_cast<const OpKernel*>(this)));
   }
 
   std::unique_ptr<Provider_OpKernel> p_;
@@ -162,30 +187,21 @@ struct Provider_IExecutionProvider_Router_Impl : Provider_IExecutionProvider_Rou
 
   virtual ~Provider_IExecutionProvider_Router_Impl() {}
 
-  std::shared_ptr<Provider_KernelRegistry> Provider_GetKernelRegistry() const override {
-    auto result = GetKernelRegistry();
-    return *reinterpret_cast<std::shared_ptr<Provider_KernelRegistry>*>(&result);
-  }
-
-  std::shared_ptr<KernelRegistry> GetKernelRegistry() const override {
-    auto result = outer_->Provider_GetKernelRegistry();
-    return *reinterpret_cast<std::shared_ptr<KernelRegistry>*>(&result);
-  }
+  std::shared_ptr<Provider_KernelRegistry> Provider_GetKernelRegistry() const override { return GetKernelRegistry(); }
+  std::shared_ptr<KernelRegistry> GetKernelRegistry() const override { return outer_->Provider_GetKernelRegistry(); }
 
   std::vector<std::unique_ptr<Provider_ComputeCapability>> Provider_GetCapability(const onnxruntime::Provider_GraphViewer& graph,
                                                                                   const std::vector<const Provider_KernelRegistry*>& kernel_registries) const override {
-    auto capabilities_internal = IExecutionProvider::GetCapability(*reinterpret_cast<const GraphViewer*>(&graph), *reinterpret_cast<const std::vector<const KernelRegistry*>*>(&kernel_registries));
-    return std::move(*reinterpret_cast<std::vector<std::unique_ptr<Provider_ComputeCapability>>*>(&capabilities_internal));
+    return IExecutionProvider::GetCapability(graph, kernel_registries);
   }
 
   std::vector<std::unique_ptr<ComputeCapability>> GetCapability(const onnxruntime::GraphViewer& graph,
                                                                 const std::vector<const KernelRegistry*>& kernel_registries) const override {
-    auto provider_result = outer_->Provider_GetCapability(*reinterpret_cast<const Provider_GraphViewer*>(&graph), *reinterpret_cast<const std::vector<const Provider_KernelRegistry*>*>(&kernel_registries));
-    return std::move(*reinterpret_cast<std::vector<std::unique_ptr<ComputeCapability>>*>(&provider_result));
+    return outer_->Provider_GetCapability(graph, kernel_registries);
   }
 
   common::Status Compile(const std::vector<onnxruntime::Node*>& fused_nodes, std::vector<NodeComputeInfo>& node_compute_funcs) override {
-    return outer_->Provider_Compile(*reinterpret_cast<const std::vector<Provider_Node*>*>(&fused_nodes), node_compute_funcs);
+    return outer_->Provider_Compile(fused_nodes, node_compute_funcs);
   }
 
   Provider_AllocatorPtr Provider_GetAllocator(int id, OrtMemType mem_type) const override {
@@ -199,13 +215,8 @@ struct Provider_IExecutionProvider_Router_Impl : Provider_IExecutionProvider_Rou
     return static_cast<Provider_AllocatorPtr_Impl*>(allocator.get())->p_;
   }
 
-  std::unique_ptr<Provider_IDataTransfer> Provider_GetDataTransfer() const override {
-    return std::unique_ptr<Provider_IDataTransfer>(reinterpret_cast<Provider_IDataTransfer*>(IExecutionProvider::GetDataTransfer().release()));
-  }
-
-  std::unique_ptr<IDataTransfer> GetDataTransfer() const override {
-    return std::unique_ptr<IDataTransfer>(reinterpret_cast<IDataTransfer*>(outer_->Provider_GetDataTransfer().release()));
-  }
+  std::unique_ptr<Provider_IDataTransfer> Provider_GetDataTransfer() const override { return IExecutionProvider::GetDataTransfer(); }
+  std::unique_ptr<IDataTransfer> GetDataTransfer() const override { return outer_->Provider_GetDataTransfer(); }
 
   void Provider_InsertAllocator(Provider_AllocatorPtr allocator) override {
     IExecutionProvider::InsertAllocator(static_cast<Provider_AllocatorPtr_Impl*>(allocator.get())->p_);
@@ -263,9 +274,7 @@ struct ProviderHostImpl : ProviderHost {
     return onnxruntime::make_unique<Provider_IAllocator_Impl>(onnxruntime::make_unique<CUDAPinnedAllocator>(device_id, name));
   }
 
-  std::unique_ptr<Provider_IDataTransfer> CreateGPUDataTransfer() override {
-    return std::unique_ptr<Provider_IDataTransfer>(reinterpret_cast<Provider_IDataTransfer*>(new GPUDataTransfer()));
-  }
+  std::unique_ptr<Provider_IDataTransfer> CreateGPUDataTransfer() override { return make_unique<GPUDataTransfer>(); }
 
   void cuda__Impl_Cast(const int64_t* input_data, int32_t* output_data, size_t count) override {
     return cuda::Impl_Cast(input_data, output_data, count);
@@ -307,306 +316,280 @@ struct ProviderHostImpl : ProviderHost {
   }
 
   // Provider_TypeProto_Tensor
-  int32_t Provider_TypeProto_Tensor__elem_type(const Provider_TypeProto_Tensor* p) override { return reinterpret_cast<const ONNX_NAMESPACE::TypeProto_Tensor*>(p)->elem_type(); }
+  int32_t Provider_TypeProto_Tensor__elem_type(const Provider_TypeProto_Tensor* p) override { return p->elem_type(); }
 
   // Provider_TypeProto
-  const Provider_TypeProto_Tensor& Provider_TypeProto__tensor_type(const Provider_TypeProto* p) override { return *reinterpret_cast<const Provider_TypeProto_Tensor*>(&reinterpret_cast<const ONNX_NAMESPACE::TypeProto*>(p)->tensor_type()); }
+  const Provider_TypeProto_Tensor& Provider_TypeProto__tensor_type(const Provider_TypeProto* p) override { return p->tensor_type(); }
 
   // Provider_AttributeProto
-  std::unique_ptr<Provider_AttributeProto> Provider_AttributeProto__construct() override { return std::unique_ptr<Provider_AttributeProto>(reinterpret_cast<Provider_AttributeProto*>(new ONNX_NAMESPACE::AttributeProto())); }
-  void Provider_AttributeProto__operator_delete(Provider_AttributeProto* p) override { delete reinterpret_cast<ONNX_NAMESPACE::AttributeProto*>(p); }
-  void Provider_AttributeProto__operator_assign(Provider_AttributeProto* p, const Provider_AttributeProto& v) override { *reinterpret_cast<ONNX_NAMESPACE::AttributeProto*>(p) = *reinterpret_cast<const ONNX_NAMESPACE::AttributeProto*>(&v); }
+  std::unique_ptr<Provider_AttributeProto> Provider_AttributeProto__construct() override { return onnxruntime::make_unique<ONNX_NAMESPACE::AttributeProto>(); }
+  void Provider_AttributeProto__operator_delete(Provider_AttributeProto* p) override { delete p; }
+  void Provider_AttributeProto__operator_assign(Provider_AttributeProto* p, const Provider_AttributeProto& v) override { *p = v; }
 
-  ONNX_NAMESPACE::AttributeProto_AttributeType Provider_AttributeProto__type(const Provider_AttributeProto* p) override { return reinterpret_cast<const ONNX_NAMESPACE::AttributeProto*>(p)->type(); }
-  int Provider_AttributeProto__ints_size(const Provider_AttributeProto* p) override { return reinterpret_cast<const ONNX_NAMESPACE::AttributeProto*>(p)->ints_size(); }
-  int64_t Provider_AttributeProto__ints(const Provider_AttributeProto* p, int i) override { return reinterpret_cast<const ONNX_NAMESPACE::AttributeProto*>(p)->ints(i); }
-  int64_t Provider_AttributeProto__i(const Provider_AttributeProto* p) override { return reinterpret_cast<const ONNX_NAMESPACE::AttributeProto*>(p)->i(); }
-  float Provider_AttributeProto__f(const Provider_AttributeProto* p) override { return reinterpret_cast<const ONNX_NAMESPACE::AttributeProto*>(p)->f(); }
-  void Provider_AttributeProto__set_s(Provider_AttributeProto* p, const ::std::string& value) override { return reinterpret_cast<ONNX_NAMESPACE::AttributeProto*>(p)->set_s(value); }
-  const ::std::string& Provider_AttributeProto__s(const Provider_AttributeProto* p) override { return reinterpret_cast<const ONNX_NAMESPACE::AttributeProto*>(p)->s(); }
-  void Provider_AttributeProto__set_name(Provider_AttributeProto* p, const ::std::string& value) override { return reinterpret_cast<ONNX_NAMESPACE::AttributeProto*>(p)->set_name(value); }
-  void Provider_AttributeProto__set_type(Provider_AttributeProto* p, ONNX_NAMESPACE::AttributeProto_AttributeType value) override { return reinterpret_cast<ONNX_NAMESPACE::AttributeProto*>(p)->set_type(value); }
-  Provider_TensorProto* Provider_AttributeProto__add_tensors(Provider_AttributeProto* p) override { return reinterpret_cast<Provider_TensorProto*>(reinterpret_cast<ONNX_NAMESPACE::AttributeProto*>(p)->add_tensors()); }
+  ONNX_NAMESPACE::AttributeProto_AttributeType Provider_AttributeProto__type(const Provider_AttributeProto* p) override { return p->type(); }
+  int Provider_AttributeProto__ints_size(const Provider_AttributeProto* p) override { return p->ints_size(); }
+  int64_t Provider_AttributeProto__ints(const Provider_AttributeProto* p, int i) override { return p->ints(i); }
+  int64_t Provider_AttributeProto__i(const Provider_AttributeProto* p) override { return p->i(); }
+  float Provider_AttributeProto__f(const Provider_AttributeProto* p) override { return p->f(); }
+  void Provider_AttributeProto__set_s(Provider_AttributeProto* p, const ::std::string& value) override { return p->set_s(value); }
+  const ::std::string& Provider_AttributeProto__s(const Provider_AttributeProto* p) override { return p->s(); }
+  void Provider_AttributeProto__set_name(Provider_AttributeProto* p, const ::std::string& value) override { return p->set_name(value); }
+  void Provider_AttributeProto__set_type(Provider_AttributeProto* p, ONNX_NAMESPACE::AttributeProto_AttributeType value) override { return p->set_type(value); }
+  Provider_TensorProto* Provider_AttributeProto__add_tensors(Provider_AttributeProto* p) override { return p->add_tensors(); }
 
   // Provider_GraphProto
-  void Provider_GraphProto__operator_delete(Provider_GraphProto* p) override { delete reinterpret_cast<ONNX_NAMESPACE::GraphProto*>(p); }
+  void Provider_GraphProto__operator_delete(Provider_GraphProto* p) override { delete p; }
 
-  Provider_ValueInfoProtos* Provider_GraphProto__mutable_input(Provider_GraphProto* p) override { return reinterpret_cast<Provider_ValueInfoProtos*>(reinterpret_cast<ONNX_NAMESPACE::GraphProto*>(p)->mutable_input()); }
+  Provider_ValueInfoProtos* Provider_GraphProto__mutable_input(Provider_GraphProto* p) override { return p->mutable_input(); }
 
-  const Provider_ValueInfoProtos& Provider_GraphProto__output(const Provider_GraphProto* p) override { return *reinterpret_cast<const Provider_ValueInfoProtos*>(&reinterpret_cast<const ONNX_NAMESPACE::GraphProto*>(p)->output()); }
-  Provider_ValueInfoProtos* Provider_GraphProto__mutable_output(Provider_GraphProto* p) override { return reinterpret_cast<Provider_ValueInfoProtos*>(reinterpret_cast<ONNX_NAMESPACE::GraphProto*>(p)->mutable_output()); }
+  const Provider_ValueInfoProtos& Provider_GraphProto__output(const Provider_GraphProto* p) override { return p->output(); }
+  Provider_ValueInfoProtos* Provider_GraphProto__mutable_output(Provider_GraphProto* p) override { return p->mutable_output(); }
 
-  Provider_ValueInfoProtos* Provider_GraphProto__mutable_value_info(Provider_GraphProto* p) override { return reinterpret_cast<Provider_ValueInfoProtos*>(reinterpret_cast<ONNX_NAMESPACE::GraphProto*>(p)->mutable_value_info()); }
-  Provider_TensorProtos* Provider_GraphProto__mutable_initializer(Provider_GraphProto* p) override { return reinterpret_cast<Provider_TensorProtos*>(reinterpret_cast<ONNX_NAMESPACE::GraphProto*>(p)->mutable_initializer()); }
-  Provider_NodeProto* Provider_GraphProto__add_node(Provider_GraphProto* p) override { return reinterpret_cast<Provider_NodeProto*>(reinterpret_cast<ONNX_NAMESPACE::GraphProto*>(p)->add_node()); }
+  Provider_ValueInfoProtos* Provider_GraphProto__mutable_value_info(Provider_GraphProto* p) override { return p->mutable_value_info(); }
+  Provider_TensorProtos* Provider_GraphProto__mutable_initializer(Provider_GraphProto* p) override { return p->mutable_initializer(); }
+  Provider_NodeProto* Provider_GraphProto__add_node(Provider_GraphProto* p) override { return p->add_node(); }
 
-  void Provider_GraphProto__operator_assign(Provider_GraphProto* p, const Provider_GraphProto& v) override { *reinterpret_cast<ONNX_NAMESPACE::GraphProto*>(p) = *reinterpret_cast<const ONNX_NAMESPACE::GraphProto*>(&v); }
+  void Provider_GraphProto__operator_assign(Provider_GraphProto* p, const Provider_GraphProto& v) override { *p = v; }
 
   // Provider_ModelProto
-  void Provider_ModelProto__operator_delete(Provider_ModelProto* p) override { delete reinterpret_cast<ONNX_NAMESPACE::ModelProto*>(p); }
+  void Provider_ModelProto__operator_delete(Provider_ModelProto* p) override { delete p; }
 
-  bool Provider_ModelProto__SerializeToString(const Provider_ModelProto* p, std::string& string) override { return reinterpret_cast<const ONNX_NAMESPACE::ModelProto*>(p)->SerializeToString(&string); }
-  bool Provider_ModelProto__SerializeToOstream(const Provider_ModelProto* p, std::ostream& output) override { return reinterpret_cast<const ONNX_NAMESPACE::ModelProto*>(p)->SerializeToOstream(&output); }
+  bool Provider_ModelProto__SerializeToString(const Provider_ModelProto* p, std::string& string) override { return p->SerializeToString(&string); }
+  bool Provider_ModelProto__SerializeToOstream(const Provider_ModelProto* p, std::ostream& output) override { return p->SerializeToOstream(&output); }
 
-  const ONNX_NAMESPACE::Provider_GraphProto& Provider_ModelProto__graph(const Provider_ModelProto* p) override { return *reinterpret_cast<const ONNX_NAMESPACE::Provider_GraphProto*>(&reinterpret_cast<const ONNX_NAMESPACE::ModelProto*>(p)->graph()); }
-  ONNX_NAMESPACE::Provider_GraphProto* Provider_ModelProto__mutable_graph(Provider_ModelProto* p) override { return reinterpret_cast<ONNX_NAMESPACE::Provider_GraphProto*>(reinterpret_cast<ONNX_NAMESPACE::ModelProto*>(p)->mutable_graph()); }
+  const Provider_GraphProto& Provider_ModelProto__graph(const Provider_ModelProto* p) override { return p->graph(); }
+  Provider_GraphProto* Provider_ModelProto__mutable_graph(Provider_ModelProto* p) override { return p->mutable_graph(); }
 
-  void Provider_ModelProto__set_ir_version(Provider_ModelProto* p, int64_t value) override { reinterpret_cast<ONNX_NAMESPACE::ModelProto*>(p)->set_ir_version(value); }
+  void Provider_ModelProto__set_ir_version(Provider_ModelProto* p, int64_t value) override { p->set_ir_version(value); }
 
   // Provider_TensorProto
-  void Provider_TensorProto__operator_delete(Provider_TensorProto* p) override { delete reinterpret_cast<ONNX_NAMESPACE::TensorProto*>(p); }
-  void Provider_TensorProto__operator_assign(Provider_TensorProto* p, const Provider_TensorProto& v) override { *reinterpret_cast<ONNX_NAMESPACE::TensorProto*>(p) = *reinterpret_cast<const ONNX_NAMESPACE::TensorProto*>(&v); }
+  void Provider_TensorProto__operator_delete(Provider_TensorProto* p) override { delete p; }
+  void Provider_TensorProto__operator_assign(Provider_TensorProto* p, const Provider_TensorProto& v) override { *p = v; }
 
   // Provider_TensorProtos
-  Provider_TensorProto* Provider_TensorProtos__Add(Provider_TensorProtos* p) override { return reinterpret_cast<Provider_TensorProto*>(reinterpret_cast<google::protobuf::RepeatedPtrField<ONNX_NAMESPACE::TensorProto>*>(p)->Add()); }
+  Provider_TensorProto* Provider_TensorProtos__Add(Provider_TensorProtos* p) override { return p->Add(); }
 
   // Provider_TensorShapeProto_Dimension
   const std::string& Provider_TensorShapeProto_Dimension__dim_param(const Provider_TensorShapeProto_Dimension* p) override {
-    return reinterpret_cast<const ONNX_NAMESPACE::TensorShapeProto_Dimension*>(p)->dim_param();
+    return p->dim_param();
   }
 
   // Provider_TensorShapeProto_Dimensions
   std::unique_ptr<Provider_TensorShapeProto_Dimension_Iterator> Provider_TensorShapeProto_Dimensions__begin(const Provider_TensorShapeProto_Dimensions* p) override {
-    return onnxruntime::make_unique<Provider_TensorShapeProto_Dimension_Iterator_Impl>(reinterpret_cast<const google::protobuf::RepeatedPtrField<::ONNX_NAMESPACE::TensorShapeProto_Dimension>*>(p)->begin());
+    return onnxruntime::make_unique<Provider_TensorShapeProto_Dimension_Iterator_Impl>(p->begin());
   }
 
   std::unique_ptr<Provider_TensorShapeProto_Dimension_Iterator> Provider_TensorShapeProto_Dimensions__end(const Provider_TensorShapeProto_Dimensions* p) override {
-    return onnxruntime::make_unique<Provider_TensorShapeProto_Dimension_Iterator_Impl>(reinterpret_cast<const google::protobuf::RepeatedPtrField<::ONNX_NAMESPACE::TensorShapeProto_Dimension>*>(p)->end());
+    return onnxruntime::make_unique<Provider_TensorShapeProto_Dimension_Iterator_Impl>(p->end());
   }
 
   // Provider_TensorShapeProto
-  int Provider_TensorShapeProto__dim_size(const Provider_TensorShapeProto* p) override { return reinterpret_cast<const ONNX_NAMESPACE::TensorShapeProto*>(p)->dim_size(); }
-  const Provider_TensorShapeProto_Dimensions& Provider_TensorShapeProto__dim(const Provider_TensorShapeProto* p) override { return *reinterpret_cast<const Provider_TensorShapeProto_Dimensions*>(&reinterpret_cast<const ONNX_NAMESPACE::TensorShapeProto*>(p)->dim()); }
+  int Provider_TensorShapeProto__dim_size(const Provider_TensorShapeProto* p) override { return p->dim_size(); }
+  const Provider_TensorShapeProto_Dimensions& Provider_TensorShapeProto__dim(const Provider_TensorShapeProto* p) override { return p->dim(); }
 
   // Provider_ValueInfoProto
-  const Provider_TypeProto& Provider_ValueInfoProto__type(const Provider_ValueInfoProto* p) override { return *reinterpret_cast<const Provider_TypeProto*>(&reinterpret_cast<const ONNX_NAMESPACE::ValueInfoProto*>(p)->type()); }
-  virtual void Provider_ValueInfoProto__operator_assign(Provider_ValueInfoProto* p, const Provider_ValueInfoProto& v) override { *reinterpret_cast<ONNX_NAMESPACE::ValueInfoProto*>(p) = *reinterpret_cast<const ONNX_NAMESPACE::ValueInfoProto*>(&v); }
+  const Provider_TypeProto& Provider_ValueInfoProto__type(const Provider_ValueInfoProto* p) override { return p->type(); }
+  virtual void Provider_ValueInfoProto__operator_assign(Provider_ValueInfoProto* p, const Provider_ValueInfoProto& v) override { *p = v; }
 
   // Provider_ValueInfoProtos
-  Provider_ValueInfoProto* Provider_ValueInfoProtos__Add(Provider_ValueInfoProtos* p) override { return reinterpret_cast<Provider_ValueInfoProto*>(reinterpret_cast<google::protobuf::RepeatedPtrField<ONNX_NAMESPACE::ValueInfoProto>*>(p)->Add()); }
+  Provider_ValueInfoProto* Provider_ValueInfoProtos__Add(Provider_ValueInfoProtos* p) override { return p->Add(); }
 
-  const Provider_ValueInfoProto& Provider_ValueInfoProtos__operator_array(const Provider_ValueInfoProtos* p, int index) override { return *reinterpret_cast<const Provider_ValueInfoProto*>(&(*reinterpret_cast<const google::protobuf::RepeatedPtrField<ONNX_NAMESPACE::ValueInfoProto>*>(p))[index]); }
+  const Provider_ValueInfoProto& Provider_ValueInfoProtos__operator_array(const Provider_ValueInfoProtos* p, int index) override { return (*p)[index]; }
 
   // Provider_ComputeCapability
-  std::unique_ptr<Provider_ComputeCapability> Provider_ComputeCapability__construct(std::unique_ptr<Provider_IndexedSubGraph> t_sub_graph) override { return std::unique_ptr<Provider_ComputeCapability>(reinterpret_cast<Provider_ComputeCapability*>(new ComputeCapability(std::unique_ptr<IndexedSubGraph>(reinterpret_cast<IndexedSubGraph*>(t_sub_graph.release()))))); }
-  void Provider_ComputeCapability__operator_delete(Provider_ComputeCapability* p) override { delete reinterpret_cast<ComputeCapability*>(p); }
-  std::unique_ptr<Provider_IndexedSubGraph>& Provider_ComputeCapability__SubGraph(Provider_ComputeCapability* p) override { return *reinterpret_cast<std::unique_ptr<Provider_IndexedSubGraph>*>(&reinterpret_cast<ComputeCapability*>(p)->sub_graph); }
+  std::unique_ptr<Provider_ComputeCapability> Provider_ComputeCapability__construct(std::unique_ptr<Provider_IndexedSubGraph> t_sub_graph) override { return make_unique<ComputeCapability>(std::move(t_sub_graph)); }
+  void Provider_ComputeCapability__operator_delete(Provider_ComputeCapability* p) override { delete p; }
+  std::unique_ptr<Provider_IndexedSubGraph>& Provider_ComputeCapability__SubGraph(Provider_ComputeCapability* p) override { return p->sub_graph; }
 
   // Provider_DataTransferManager
-  Status Provider_DataTransferManager__CopyTensor(const Provider_DataTransferManager* p, const Provider_Tensor& src, Provider_Tensor& dst, int exec_queue_id) override { return reinterpret_cast<const DataTransferManager*>(p)->CopyTensor(*reinterpret_cast<const Tensor*>(&src), *reinterpret_cast<Tensor*>(&dst), exec_queue_id); }
+  Status Provider_DataTransferManager__CopyTensor(const Provider_DataTransferManager* p, const Provider_Tensor& src, Provider_Tensor& dst, int exec_queue_id) override { return p->CopyTensor(src, dst, exec_queue_id); }
 
   // Provider_IDataTransfer
-  void Provider_IDataTransfer__operator_delete(Provider_IDataTransfer* p) override { delete reinterpret_cast<Provider_IDataTransfer*>(p); }
+  void Provider_IDataTransfer__operator_delete(Provider_IDataTransfer* p) override { delete p; }
 
   // Provider_IndexedSubGraph_MetaDef
-  std::unique_ptr<Provider_IndexedSubGraph_MetaDef> Provider_IndexedSubGraph_MetaDef__construct() override { return std::unique_ptr<Provider_IndexedSubGraph_MetaDef>(reinterpret_cast<Provider_IndexedSubGraph_MetaDef*>(new IndexedSubGraph::MetaDef())); }
-  void Provider_IndexedSubGraph_MetaDef__operator_delete(Provider_IndexedSubGraph_MetaDef* p) override { delete reinterpret_cast<IndexedSubGraph::MetaDef*>(p); }
+  std::unique_ptr<Provider_IndexedSubGraph_MetaDef> Provider_IndexedSubGraph_MetaDef__construct() override { return make_unique<IndexedSubGraph::MetaDef>(); }
+  void Provider_IndexedSubGraph_MetaDef__operator_delete(Provider_IndexedSubGraph_MetaDef* p) override { delete p; }
 
-  std::string& Provider_IndexedSubGraph_MetaDef__name(Provider_IndexedSubGraph_MetaDef* p) override { return reinterpret_cast<IndexedSubGraph::MetaDef*>(p)->name; }
-  std::string& Provider_IndexedSubGraph_MetaDef__domain(Provider_IndexedSubGraph_MetaDef* p) override { return reinterpret_cast<IndexedSubGraph::MetaDef*>(p)->domain; }
-  int& Provider_IndexedSubGraph_MetaDef__since_version(Provider_IndexedSubGraph_MetaDef* p) override { return reinterpret_cast<IndexedSubGraph::MetaDef*>(p)->since_version; }
-  ONNX_NAMESPACE::OperatorStatus& Provider_IndexedSubGraph_MetaDef__status(Provider_IndexedSubGraph_MetaDef* p) override { return reinterpret_cast<IndexedSubGraph::MetaDef*>(p)->status; }
-  std::vector<std::string>& Provider_IndexedSubGraph_MetaDef__inputs(Provider_IndexedSubGraph_MetaDef* p) override { return reinterpret_cast<IndexedSubGraph::MetaDef*>(p)->inputs; }
-  std::vector<std::string>& Provider_IndexedSubGraph_MetaDef__outputs(Provider_IndexedSubGraph_MetaDef* p) override { return reinterpret_cast<IndexedSubGraph::MetaDef*>(p)->outputs; }
-  Provider_NodeAttributes& Provider_IndexedSubGraph_MetaDef__attributes(Provider_IndexedSubGraph_MetaDef* p) override { return *reinterpret_cast<Provider_NodeAttributes*>(&reinterpret_cast<IndexedSubGraph::MetaDef*>(p)->attributes); }
-  std::string& Provider_IndexedSubGraph_MetaDef__doc_string(Provider_IndexedSubGraph_MetaDef* p) override { return reinterpret_cast<IndexedSubGraph::MetaDef*>(p)->doc_string; }
+  std::string& Provider_IndexedSubGraph_MetaDef__name(Provider_IndexedSubGraph_MetaDef* p) override { return p->name; }
+  std::string& Provider_IndexedSubGraph_MetaDef__domain(Provider_IndexedSubGraph_MetaDef* p) override { return p->domain; }
+  int& Provider_IndexedSubGraph_MetaDef__since_version(Provider_IndexedSubGraph_MetaDef* p) override { return p->since_version; }
+  ONNX_NAMESPACE::OperatorStatus& Provider_IndexedSubGraph_MetaDef__status(Provider_IndexedSubGraph_MetaDef* p) override { return p->status; }
+  std::vector<std::string>& Provider_IndexedSubGraph_MetaDef__inputs(Provider_IndexedSubGraph_MetaDef* p) override { return p->inputs; }
+  std::vector<std::string>& Provider_IndexedSubGraph_MetaDef__outputs(Provider_IndexedSubGraph_MetaDef* p) override { return p->outputs; }
+  Provider_NodeAttributes& Provider_IndexedSubGraph_MetaDef__attributes(Provider_IndexedSubGraph_MetaDef* p) override { return p->attributes; }
+  std::string& Provider_IndexedSubGraph_MetaDef__doc_string(Provider_IndexedSubGraph_MetaDef* p) override { return p->doc_string; }
 
   // Provider_IndexedSubGraph
-  std::unique_ptr<Provider_IndexedSubGraph> Provider_IndexedSubGraph__construct() override { return std::unique_ptr<Provider_IndexedSubGraph>(reinterpret_cast<Provider_IndexedSubGraph*>(new IndexedSubGraph())); }
-  void Provider_IndexedSubGraph__operator_delete(Provider_IndexedSubGraph* p) override { delete reinterpret_cast<IndexedSubGraph*>(p); }
+  std::unique_ptr<Provider_IndexedSubGraph> Provider_IndexedSubGraph__construct() override { return make_unique<IndexedSubGraph>(); }
+  void Provider_IndexedSubGraph__operator_delete(Provider_IndexedSubGraph* p) override { delete p; }
 
-  std::vector<onnxruntime::NodeIndex>& Provider_IndexedSubGraph__Nodes(Provider_IndexedSubGraph* p) override { return reinterpret_cast<IndexedSubGraph*>(p)->nodes; }
+  std::vector<onnxruntime::NodeIndex>& Provider_IndexedSubGraph__Nodes(Provider_IndexedSubGraph* p) override { return p->nodes; }
 
-  void Provider_IndexedSubGraph__SetMetaDef(Provider_IndexedSubGraph* p, std::unique_ptr<Provider_IndexedSubGraph_MetaDef>&& meta_def_) override { return reinterpret_cast<IndexedSubGraph*>(p)->SetMetaDef(std::move(*reinterpret_cast<std::unique_ptr<IndexedSubGraph::MetaDef>*>(&meta_def_))); }
-  const Provider_IndexedSubGraph_MetaDef* Provider_IndexedSubGraph__GetMetaDef(const Provider_IndexedSubGraph* p) override { return reinterpret_cast<const Provider_IndexedSubGraph_MetaDef*>(reinterpret_cast<const IndexedSubGraph*>(p)->GetMetaDef()); }
+  void Provider_IndexedSubGraph__SetMetaDef(Provider_IndexedSubGraph* p, std::unique_ptr<Provider_IndexedSubGraph_MetaDef>&& meta_def_) override { return p->SetMetaDef(std::move(meta_def_)); }
+  const Provider_IndexedSubGraph_MetaDef* Provider_IndexedSubGraph__GetMetaDef(const Provider_IndexedSubGraph* p) override { return p->GetMetaDef(); }
 
   // Provider_KernelDef
-  void Provider_KernelDef__operator_delete(Provider_KernelDef* p) override { delete reinterpret_cast<KernelDef*>(p); }
+  void Provider_KernelDef__operator_delete(Provider_KernelDef* p) override { delete p; }
 
   // Provider_KernelDefBuilder
-  std::unique_ptr<Provider_KernelDefBuilder> Provider_KernelDefBuilder__construct() override { return std::unique_ptr<Provider_KernelDefBuilder>(reinterpret_cast<Provider_KernelDefBuilder*>(new KernelDefBuilder())); }
-  void Provider_KernelDefBuilder__operator_delete(Provider_KernelDefBuilder* p) override { delete reinterpret_cast<KernelDefBuilder*>(p); }
+  std::unique_ptr<Provider_KernelDefBuilder> Provider_KernelDefBuilder__construct() override { return make_unique<KernelDefBuilder>(); }
+  void Provider_KernelDefBuilder__operator_delete(Provider_KernelDefBuilder* p) override { delete p; }
 
-  void Provider_KernelDefBuilder__SetName(Provider_KernelDefBuilder* p, const char* op_name) override { reinterpret_cast<KernelDefBuilder*>(p)->SetName(op_name); }
-  void Provider_KernelDefBuilder__SetDomain(Provider_KernelDefBuilder* p, const char* domain) override { reinterpret_cast<KernelDefBuilder*>(p)->SetDomain(domain); }
-  void Provider_KernelDefBuilder__SinceVersion(Provider_KernelDefBuilder* p, int since_version) override { reinterpret_cast<KernelDefBuilder*>(p)->SinceVersion(since_version); }
-  void Provider_KernelDefBuilder__Provider(Provider_KernelDefBuilder* p, const char* provider_type) override { reinterpret_cast<KernelDefBuilder*>(p)->Provider(provider_type); }
-  void Provider_KernelDefBuilder__TypeConstraint(Provider_KernelDefBuilder* p, const char* arg_name, MLDataType supported_type) override { reinterpret_cast<KernelDefBuilder*>(p)->TypeConstraint(arg_name, supported_type); }
-  void Provider_KernelDefBuilder__TypeConstraint(Provider_KernelDefBuilder* p, const char* arg_name, const std::vector<MLDataType>& supported_types) override { reinterpret_cast<KernelDefBuilder*>(p)->TypeConstraint(arg_name, supported_types); }
-  void Provider_KernelDefBuilder__InputMemoryType(Provider_KernelDefBuilder* p, OrtMemType type, int input_index) override { reinterpret_cast<KernelDefBuilder*>(p)->InputMemoryType(type, input_index); }
-  void Provider_KernelDefBuilder__OutputMemoryType(Provider_KernelDefBuilder* p, OrtMemType type, int input_index) override { reinterpret_cast<KernelDefBuilder*>(p)->OutputMemoryType(type, input_index); }
-  void Provider_KernelDefBuilder__ExecQueueId(Provider_KernelDefBuilder* p, int queue_id) override { reinterpret_cast<KernelDefBuilder*>(p)->ExecQueueId(queue_id); }
+  void Provider_KernelDefBuilder__SetName(Provider_KernelDefBuilder* p, const char* op_name) override { p->SetName(op_name); }
+  void Provider_KernelDefBuilder__SetDomain(Provider_KernelDefBuilder* p, const char* domain) override { p->SetDomain(domain); }
+  void Provider_KernelDefBuilder__SinceVersion(Provider_KernelDefBuilder* p, int since_version) override { p->SinceVersion(since_version); }
+  void Provider_KernelDefBuilder__Provider(Provider_KernelDefBuilder* p, const char* provider_type) override { p->Provider(provider_type); }
+  void Provider_KernelDefBuilder__TypeConstraint(Provider_KernelDefBuilder* p, const char* arg_name, MLDataType supported_type) override { p->TypeConstraint(arg_name, supported_type); }
+  void Provider_KernelDefBuilder__TypeConstraint(Provider_KernelDefBuilder* p, const char* arg_name, const std::vector<MLDataType>& supported_types) override { p->TypeConstraint(arg_name, supported_types); }
+  void Provider_KernelDefBuilder__InputMemoryType(Provider_KernelDefBuilder* p, OrtMemType type, int input_index) override { p->InputMemoryType(type, input_index); }
+  void Provider_KernelDefBuilder__OutputMemoryType(Provider_KernelDefBuilder* p, OrtMemType type, int input_index) override { p->OutputMemoryType(type, input_index); }
+  void Provider_KernelDefBuilder__ExecQueueId(Provider_KernelDefBuilder* p, int queue_id) override { p->ExecQueueId(queue_id); }
 
-  std::unique_ptr<Provider_KernelDef> Provider_KernelDefBuilder__Build(Provider_KernelDefBuilder* p) override {
-    return std::unique_ptr<Provider_KernelDef>(reinterpret_cast<Provider_KernelDef*>(reinterpret_cast<KernelDefBuilder*>(p)->Build().release()));
-  }
+  std::unique_ptr<Provider_KernelDef> Provider_KernelDefBuilder__Build(Provider_KernelDefBuilder* p) override { return p->Build(); }
 
   // Provider_KernelRegistry
-  std::shared_ptr<Provider_KernelRegistry> Provider_KernelRegistry__construct() override {
-    auto result = std::make_shared<KernelRegistry>();
-    return *reinterpret_cast<std::shared_ptr<Provider_KernelRegistry>*>(&result);
-  }
-  void Provider_KernelRegistry__operator_delete(Provider_KernelRegistry* p) override { delete reinterpret_cast<KernelRegistry*>(p); }
+  std::shared_ptr<Provider_KernelRegistry> Provider_KernelRegistry__construct() override { return std::make_shared<KernelRegistry>(); }
+  void Provider_KernelRegistry__operator_delete(Provider_KernelRegistry* p) override { delete p; }
   Status Provider_KernelRegistry__Register(Provider_KernelRegistry* p, Provider_KernelCreateInfo&& create_info) override {
-    KernelCreateInfo info_real(std::move(*reinterpret_cast<std::unique_ptr<KernelDef>*>(&create_info.kernel_def)),
+    KernelCreateInfo info_real(std::move(create_info.kernel_def),
                                [kernel_create_func = create_info.kernel_create_func](const OpKernelInfo& info) -> OpKernel* {
-                                 return new OpKernel_Translator(info, kernel_create_func(*reinterpret_cast<const Provider_OpKernelInfo*>(&info)));
+                                 return new OpKernel_Translator(info, kernel_create_func(info));
                                });
-    return reinterpret_cast<KernelRegistry*>(p)->Register(std::move(info_real));
+    return p->Register(std::move(info_real));
   }
 
   // Provider_Function
-  const Provider_Graph& Provider_Function__Body(const Provider_Function* p) override { return *reinterpret_cast<const Provider_Graph*>(&reinterpret_cast<const Function*>(p)->Body()); }
+  const Provider_Graph& Provider_Function__Body(const Provider_Function* p) override { return p->Body(); }
 
   // Provider_Node
-  const std::string& Provider_Node__Name(const Provider_Node* p) noexcept override { return reinterpret_cast<const Node*>(p)->Name(); }
-  const std::string& Provider_Node__Description(const Provider_Node* p) noexcept override { return reinterpret_cast<const Node*>(p)->Description(); }
-  const std::string& Provider_Node__Domain(const Provider_Node* p) noexcept override { return reinterpret_cast<const Node*>(p)->Domain(); }
-  const std::string& Provider_Node__OpType(const Provider_Node* p) noexcept override { return reinterpret_cast<const Node*>(p)->OpType(); }
+  const std::string& Provider_Node__Name(const Provider_Node* p) noexcept override { return p->Name(); }
+  const std::string& Provider_Node__Description(const Provider_Node* p) noexcept override { return p->Description(); }
+  const std::string& Provider_Node__Domain(const Provider_Node* p) noexcept override { return p->Domain(); }
+  const std::string& Provider_Node__OpType(const Provider_Node* p) noexcept override { return p->OpType(); }
 
-  const Provider_Function* Provider_Node__GetFunctionBody(const Provider_Node* p) noexcept override { return reinterpret_cast<const Provider_Function*>(reinterpret_cast<const Node*>(p)->GetFunctionBody()); }
+  const Provider_Function* Provider_Node__GetFunctionBody(const Provider_Node* p) noexcept override { return p->GetFunctionBody(); }
 
-  ConstPointerContainer<std::vector<Provider_NodeArg*>> Provider_Node__ImplicitInputDefs(const Provider_Node* p) noexcept override {
-    auto result = reinterpret_cast<const Node*>(p)->ImplicitInputDefs();
-    return *reinterpret_cast<ConstPointerContainer<std::vector<Provider_NodeArg*>>*>(&result);
-  }
+  ConstPointerContainer<std::vector<Provider_NodeArg*>> Provider_Node__ImplicitInputDefs(const Provider_Node* p) noexcept override { return p->ImplicitInputDefs(); }
+  ConstPointerContainer<std::vector<Provider_NodeArg*>> Provider_Node__InputDefs(const Provider_Node* p) noexcept override { return p->InputDefs(); }
+  ConstPointerContainer<std::vector<Provider_NodeArg*>> Provider_Node__OutputDefs(const Provider_Node* p) noexcept override { return p->OutputDefs(); }
 
-  ConstPointerContainer<std::vector<Provider_NodeArg*>> Provider_Node__InputDefs(const Provider_Node* p) noexcept override {
-    auto result = reinterpret_cast<const Node*>(p)->InputDefs();
-    return *reinterpret_cast<ConstPointerContainer<std::vector<Provider_NodeArg*>>*>(&result);
-  }
-  ConstPointerContainer<std::vector<Provider_NodeArg*>> Provider_Node__OutputDefs(const Provider_Node* p) noexcept override {
-    auto result = reinterpret_cast<const Node*>(p)->OutputDefs();
-    return *reinterpret_cast<ConstPointerContainer<std::vector<Provider_NodeArg*>>*>(&result);
-  }
+  NodeIndex Provider_Node__Index(const Provider_Node* p) noexcept override { return p->Index(); }
 
-  NodeIndex Provider_Node__Index(const Provider_Node* p) noexcept override { return reinterpret_cast<const Node*>(p)->Index(); }
+  void Provider_Node__ToProto(const Provider_Node* p, Provider_NodeProto& proto, bool update_subgraphs = false) override { p->ToProto(proto, update_subgraphs); }
 
-  void Provider_Node__ToProto(const Provider_Node* p, Provider_NodeProto& proto, bool update_subgraphs = false) override { reinterpret_cast<const Node*>(p)->ToProto(*reinterpret_cast<ONNX_NAMESPACE::NodeProto*>(&proto), update_subgraphs); }
+  const Provider_NodeAttributes& Provider_Node__GetAttributes(const Provider_Node* p) noexcept override { return p->GetAttributes(); }
+  size_t Provider_Node__GetInputEdgesCount(const Provider_Node* p) noexcept override { return p->GetInputEdgesCount(); }
+  size_t Provider_Node__GetOutputEdgesCount(const Provider_Node* p) noexcept override { return p->GetOutputEdgesCount(); }
 
-  const Provider_NodeAttributes& Provider_Node__GetAttributes(const Provider_Node* p) noexcept override { return *reinterpret_cast<const Provider_NodeAttributes*>(&reinterpret_cast<const Node*>(p)->GetAttributes()); }
-  size_t Provider_Node__GetInputEdgesCount(const Provider_Node* p) noexcept override { return reinterpret_cast<const Node*>(p)->GetInputEdgesCount(); }
-  size_t Provider_Node__GetOutputEdgesCount(const Provider_Node* p) noexcept override { return reinterpret_cast<const Node*>(p)->GetOutputEdgesCount(); }
+  std::unique_ptr<Provider_Node__NodeIterator> Provider_Node__InputNodesBegin(const Provider_Node* p) noexcept override { return onnxruntime::make_unique<Provider_Node__NodeIterator_Impl>(p->InputNodesBegin()); }
+  std::unique_ptr<Provider_Node__NodeIterator> Provider_Node__InputNodesEnd(const Provider_Node* p) noexcept override { return onnxruntime::make_unique<Provider_Node__NodeIterator_Impl>(p->InputNodesEnd()); }
 
-  std::unique_ptr<Provider_Node__NodeIterator> Provider_Node__InputNodesBegin(const Provider_Node* p) noexcept override { return onnxruntime::make_unique<Provider_Node__NodeIterator_Impl>(reinterpret_cast<const Node*>(p)->InputNodesBegin()); }
-  std::unique_ptr<Provider_Node__NodeIterator> Provider_Node__InputNodesEnd(const Provider_Node* p) noexcept override { return onnxruntime::make_unique<Provider_Node__NodeIterator_Impl>(reinterpret_cast<const Node*>(p)->InputNodesEnd()); }
-
-  std::unique_ptr<Provider_Node__EdgeIterator> Provider_Node__OutputEdgesBegin(const Provider_Node* p) noexcept override { return onnxruntime::make_unique<Provider_Node__EdgeIterator_Impl>(reinterpret_cast<const Node*>(p)->OutputEdgesBegin()); }
-  std::unique_ptr<Provider_Node__EdgeIterator> Provider_Node__OutputEdgesEnd(const Provider_Node* p) noexcept override { return onnxruntime::make_unique<Provider_Node__EdgeIterator_Impl>(reinterpret_cast<const Node*>(p)->OutputEdgesEnd()); }
+  std::unique_ptr<Provider_Node__EdgeIterator> Provider_Node__OutputEdgesBegin(const Provider_Node* p) noexcept override { return onnxruntime::make_unique<Provider_Node__EdgeIterator_Impl>(p->OutputEdgesBegin()); }
+  std::unique_ptr<Provider_Node__EdgeIterator> Provider_Node__OutputEdgesEnd(const Provider_Node* p) noexcept override { return onnxruntime::make_unique<Provider_Node__EdgeIterator_Impl>(p->OutputEdgesEnd()); }
 
   // Provider_NodeArg
-  const std::string& Provider_NodeArg__Name(const Provider_NodeArg* p) noexcept override { return reinterpret_cast<const NodeArg*>(p)->Name(); }
-  const ONNX_NAMESPACE::Provider_TensorShapeProto* Provider_NodeArg__Shape(const Provider_NodeArg* p) override { return reinterpret_cast<const ONNX_NAMESPACE::Provider_TensorShapeProto*>(reinterpret_cast<const NodeArg*>(p)->Shape()); }
-  ONNX_NAMESPACE::DataType Provider_NodeArg__Type(const Provider_NodeArg* p) noexcept override { return reinterpret_cast<const NodeArg*>(p)->Type(); }
-  const Provider_NodeArgInfo& Provider_NodeArg__ToProto(const Provider_NodeArg* p) noexcept override { return *reinterpret_cast<const Provider_NodeArgInfo*>(&reinterpret_cast<const NodeArg*>(p)->ToProto()); }
-  bool Provider_NodeArg__Exists(const Provider_NodeArg* p) const noexcept override { return reinterpret_cast<const NodeArg*>(p)->Exists(); }
-  const ONNX_NAMESPACE::Provider_TypeProto* Provider_NodeArg__TypeAsProto(const Provider_NodeArg* p) noexcept override { return reinterpret_cast<const ONNX_NAMESPACE::Provider_TypeProto*>(reinterpret_cast<const NodeArg*>(p)->TypeAsProto()); }
+  const std::string& Provider_NodeArg__Name(const Provider_NodeArg* p) noexcept override { return p->Name(); }
+  const Provider_TensorShapeProto* Provider_NodeArg__Shape(const Provider_NodeArg* p) override { return p->Shape(); }
+  ONNX_NAMESPACE::DataType Provider_NodeArg__Type(const Provider_NodeArg* p) noexcept override { return p->Type(); }
+  const Provider_NodeArgInfo& Provider_NodeArg__ToProto(const Provider_NodeArg* p) noexcept override { return p->ToProto(); }
+  bool Provider_NodeArg__Exists(const Provider_NodeArg* p) const noexcept override { return p->Exists(); }
+  const Provider_TypeProto* Provider_NodeArg__TypeAsProto(const Provider_NodeArg* p) noexcept override { return p->TypeAsProto(); }
 
   // Provider_NodeAttributes
-  std::unique_ptr<Provider_NodeAttributes> Provider_NodeAttributes__construct() override { return std::unique_ptr<Provider_NodeAttributes>(reinterpret_cast<Provider_NodeAttributes*>(new NodeAttributes())); }
-  void Provider_NodeAttributes__operator_delete(Provider_NodeAttributes* p) noexcept override { delete reinterpret_cast<NodeAttributes*>(p); }
-  size_t Provider_NodeAttributes__size(const Provider_NodeAttributes* p) override { return reinterpret_cast<const NodeAttributes*>(p)->size(); }
-  void Provider_NodeAttributes__clear(Provider_NodeAttributes* p) noexcept override { return reinterpret_cast<NodeAttributes*>(p)->clear(); }
-  Provider_AttributeProto& Provider_NodeAttributes__operator_array(Provider_NodeAttributes* p, const std::string& string) override { return *reinterpret_cast<Provider_AttributeProto*>(&(*reinterpret_cast<NodeAttributes*>(p))[string]); }
-  void Provider_NodeAttributes__operator_assign(Provider_NodeAttributes* p, const Provider_NodeAttributes& v) override { *reinterpret_cast<NodeAttributes*>(p) = *reinterpret_cast<const NodeAttributes*>(&v); }
+  std::unique_ptr<Provider_NodeAttributes> Provider_NodeAttributes__construct() override { return make_unique<NodeAttributes>(); }
+  void Provider_NodeAttributes__operator_delete(Provider_NodeAttributes* p) noexcept override { delete p; }
+  size_t Provider_NodeAttributes__size(const Provider_NodeAttributes* p) override { return p->size(); }
+  void Provider_NodeAttributes__clear(Provider_NodeAttributes* p) noexcept override { return p->clear(); }
+  Provider_AttributeProto& Provider_NodeAttributes__operator_array(Provider_NodeAttributes* p, const std::string& string) override { return (*p)[string]; }
+  void Provider_NodeAttributes__operator_assign(Provider_NodeAttributes* p, const Provider_NodeAttributes& v) override { *p = v; }
 
   std::unique_ptr<Provider_NodeAttributes_Iterator> Provider_NodeAttributes__begin(const Provider_NodeAttributes* p) override {
-    return onnxruntime::make_unique<Provider_NodeAttributes_Iterator_Impl>(reinterpret_cast<const NodeAttributes*>(p)->begin());
+    return onnxruntime::make_unique<Provider_NodeAttributes_Iterator_Impl>(p->begin());
   }
   std::unique_ptr<Provider_NodeAttributes_Iterator> Provider_NodeAttributes__end(const Provider_NodeAttributes* p) override {
-    return onnxruntime::make_unique<Provider_NodeAttributes_Iterator_Impl>(reinterpret_cast<const NodeAttributes*>(p)->end());
+    return onnxruntime::make_unique<Provider_NodeAttributes_Iterator_Impl>(p->end());
   }
   std::unique_ptr<Provider_NodeAttributes_Iterator> Provider_NodeAttributes__find(const Provider_NodeAttributes* p, const std::string& key) override {
-    return onnxruntime::make_unique<Provider_NodeAttributes_Iterator_Impl>(reinterpret_cast<const NodeAttributes*>(p)->find(key));
+    return onnxruntime::make_unique<Provider_NodeAttributes_Iterator_Impl>(p->find(key));
   }
-  void Provider_NodeAttributes__insert(Provider_NodeAttributes* p, const Provider_NodeAttributes& v) override {
-    auto& nodes = *reinterpret_cast<const NodeAttributes*>(&v);
-    return reinterpret_cast<NodeAttributes*>(p)->insert(nodes.begin(), nodes.end());
-  }
+  void Provider_NodeAttributes__insert(Provider_NodeAttributes* p, const Provider_NodeAttributes& v) override { return p->insert(v.begin(), v.end()); }
 
   // Provider_Model
-  void Provider_Model__operator_delete(Provider_Model* p) override { delete reinterpret_cast<Model*>(p); }
-  Provider_Graph& Provider_Model__MainGraph(Provider_Model* p) override { return *reinterpret_cast<Provider_Graph*>(&reinterpret_cast<Model*>(p)->MainGraph()); }
-  std::unique_ptr<Provider_ModelProto> Provider_Model__ToProto(Provider_Model* p) override { return std::unique_ptr<Provider_ModelProto>(reinterpret_cast<Provider_ModelProto*>(new ONNX_NAMESPACE::ModelProto(reinterpret_cast<Model*>(p)->ToProto()))); }
+  void Provider_Model__operator_delete(Provider_Model* p) override { delete p; }
+  Provider_Graph& Provider_Model__MainGraph(Provider_Model* p) override { return p->MainGraph(); }
+  std::unique_ptr<Provider_ModelProto> Provider_Model__ToProto(Provider_Model* p) override { return make_unique<ONNX_NAMESPACE::ModelProto>(p->ToProto()); }
 
   // Provider_Graph
-  std::unique_ptr<Provider_GraphViewer> Provider_Graph__CreateGraphViewer(const Provider_Graph* p) override {
-    return std::unique_ptr<Provider_GraphViewer>(reinterpret_cast<Provider_GraphViewer*>(new GraphViewer(*reinterpret_cast<const Graph*>(p))));
-  }
+  std::unique_ptr<Provider_GraphViewer> Provider_Graph__CreateGraphViewer(const Provider_Graph* p) override { return make_unique<GraphViewer>(*p); }
+  std::unique_ptr<Provider_GraphProto> Provider_Graph__ToGraphProto(const Provider_Graph* p) override { return make_unique<ONNX_NAMESPACE::GraphProto>(p->ToGraphProto()); }
 
-  std::unique_ptr<Provider_GraphProto> Provider_Graph__ToGraphProto(const Provider_Graph* p) override {
-    return std::unique_ptr<Provider_GraphProto>(reinterpret_cast<Provider_GraphProto*>(new ONNX_NAMESPACE::GraphProto(reinterpret_cast<const Graph*>(p)->ToGraphProto())));
-  }
+  Provider_NodeArg& Provider_Graph__GetOrCreateNodeArg(Provider_Graph* p, const std::string& name, const Provider_TypeProto* p_arg_type) override { return p->GetOrCreateNodeArg(name, p_arg_type); }
 
-  Provider_NodeArg& Provider_Graph__GetOrCreateNodeArg(Provider_Graph* p, const std::string& name, const Provider_TypeProto* p_arg_type) override {
-    return *reinterpret_cast<Provider_NodeArg*>(&reinterpret_cast<Graph*>(p)->GetOrCreateNodeArg(name, reinterpret_cast<const ONNX_NAMESPACE::TypeProto*>(p_arg_type)));
-  }
-
-  Status Provider_Graph__Resolve(Provider_Graph* p) override { return reinterpret_cast<Graph*>(p)->Resolve(); }
-  void Provider_Graph__AddInitializedTensor(Provider_Graph* p, const Provider_TensorProto& tensor) override { reinterpret_cast<Graph*>(p)->AddInitializedTensor(*reinterpret_cast<const ONNX_NAMESPACE::TensorProto*>(&tensor)); }
+  Status Provider_Graph__Resolve(Provider_Graph* p) override { return p->Resolve(); }
+  void Provider_Graph__AddInitializedTensor(Provider_Graph* p, const Provider_TensorProto& tensor) override { p->AddInitializedTensor(tensor); }
   Provider_Node& Provider_Graph__AddNode(Provider_Graph* p, const std::string& name, const std::string& op_type, const std::string& description, const std::vector<Provider_NodeArg*>& input_args, const std::vector<Provider_NodeArg*>& output_args, const Provider_NodeAttributes* attributes, const std::string& domain) override {
-    return *reinterpret_cast<Provider_Node*>(&reinterpret_cast<Graph*>(p)->AddNode(name, op_type, description, *reinterpret_cast<const std::vector<NodeArg*>*>(&input_args), *reinterpret_cast<const std::vector<NodeArg*>*>(&output_args), reinterpret_cast<const NodeAttributes*>(attributes), domain));
+    return p->AddNode(name, op_type, description, input_args, output_args, attributes, domain);
   }
 
-  const std::vector<const Provider_NodeArg*>& Provider_Graph__GetOutputs(const Provider_Graph* p) noexcept override { return *reinterpret_cast<const std::vector<const Provider_NodeArg*>*>(&reinterpret_cast<const Graph*>(p)->GetOutputs()); }
-  void Provider_Graph__SetOutputs(Provider_Graph* p, const std::vector<const Provider_NodeArg*>& outputs) override { reinterpret_cast<Graph*>(p)->SetOutputs(*reinterpret_cast<const std::vector<const NodeArg*>*>(&outputs)); }
+  const std::vector<const Provider_NodeArg*>& Provider_Graph__GetOutputs(const Provider_Graph* p) noexcept override { return p->GetOutputs(); }
+  void Provider_Graph__SetOutputs(Provider_Graph* p, const std::vector<const Provider_NodeArg*>& outputs) override { p->SetOutputs(outputs); }
 
-  const std::vector<const Provider_NodeArg*>& Provider_Graph__GetInputs(const Provider_Graph* p) noexcept override { return *reinterpret_cast<const std::vector<const Provider_NodeArg*>*>(&reinterpret_cast<const Graph*>(p)->GetInputs()); }
-  bool Provider_Graph__GetInitializedTensor(const Provider_Graph* p, const std::string& tensor_name, const Provider_TensorProto*& value) override { return reinterpret_cast<const Graph*>(p)->GetInitializedTensor(tensor_name, reinterpret_cast<const ONNX_NAMESPACE::TensorProto*&>(value)); }
+  const std::vector<const Provider_NodeArg*>& Provider_Graph__GetInputs(const Provider_Graph* p) noexcept override { return p->GetInputs(); }
+  bool Provider_Graph__GetInitializedTensor(const Provider_Graph* p, const std::string& tensor_name, const Provider_TensorProto*& value) override { return p->GetInitializedTensor(tensor_name, value); }
 
   // Provider_GraphViewer
-  void Provider_GraphViewer__operator_delete(Provider_GraphViewer* p) override { delete reinterpret_cast<GraphViewer*>(p); }
-  std::unique_ptr<Provider_Model> Provider_GraphViewer__CreateModel(const Provider_GraphViewer* p, const logging::Logger& logger) override {
-    auto& graph_viewer = *reinterpret_cast<const GraphViewer*>(p);
-    return std::unique_ptr<Provider_Model>(reinterpret_cast<Provider_Model*>(new Model(graph_viewer.Name(), true, ModelMetaData(), PathString(),
-                                                                                       IOnnxRuntimeOpSchemaRegistryList(), graph_viewer.DomainToVersionMap(),
-                                                                                       std::vector<ONNX_NAMESPACE::FunctionProto>(), logger)));
+  void Provider_GraphViewer__operator_delete(Provider_GraphViewer* p) override { delete p; }
+  std::unique_ptr<Provider_Model> Provider_GraphViewer__CreateModel(const Provider_GraphViewer* graph_viewer, const logging::Logger& logger) override {
+    return make_unique<Model>(graph_viewer->Name(), true, ModelMetaData(), PathString(),
+                              IOnnxRuntimeOpSchemaRegistryList(), graph_viewer->DomainToVersionMap(),
+                              std::vector<ONNX_NAMESPACE::FunctionProto>(), logger);
   }
 
-  const std::string& Provider_GraphViewer__Name(const Provider_GraphViewer* p) noexcept override { return reinterpret_cast<const GraphViewer*>(p)->Name(); }
+  const std::string& Provider_GraphViewer__Name(const Provider_GraphViewer* p) noexcept override { return p->Name(); }
 
-  const Provider_Node* Provider_GraphViewer__GetNode(const Provider_GraphViewer* p, NodeIndex node_index) override { return reinterpret_cast<const Provider_Node*>(reinterpret_cast<const GraphViewer*>(p)->GetNode(node_index)); }
-  const Provider_NodeArg* Provider_GraphViewer__GetNodeArg(const Provider_GraphViewer* p, const std::string& name) override { return reinterpret_cast<const Provider_NodeArg*>(reinterpret_cast<const GraphViewer*>(p)->GetNodeArg(name)); }
+  const Provider_Node* Provider_GraphViewer__GetNode(const Provider_GraphViewer* p, NodeIndex node_index) override { return p->GetNode(node_index); }
+  const Provider_NodeArg* Provider_GraphViewer__GetNodeArg(const Provider_GraphViewer* p, const std::string& name) override { return p->GetNodeArg(name); }
 
-  bool Provider_GraphViewer__IsSubgraph(const Provider_GraphViewer* p) override { return reinterpret_cast<const GraphViewer*>(p)->IsSubgraph(); }
-  int Provider_GraphViewer__NumberOfNodes(const Provider_GraphViewer* p) noexcept override { return reinterpret_cast<const GraphViewer*>(p)->NumberOfNodes(); }
-  int Provider_GraphViewer__MaxNodeIndex(const Provider_GraphViewer* p) noexcept override { return reinterpret_cast<const GraphViewer*>(p)->MaxNodeIndex(); }
+  bool Provider_GraphViewer__IsSubgraph(const Provider_GraphViewer* p) override { return p->IsSubgraph(); }
+  int Provider_GraphViewer__NumberOfNodes(const Provider_GraphViewer* p) noexcept override { return p->NumberOfNodes(); }
+  int Provider_GraphViewer__MaxNodeIndex(const Provider_GraphViewer* p) noexcept override { return p->MaxNodeIndex(); }
 
-  const std::vector<const Provider_NodeArg*>& Provider_GraphViewer__GetInputs(const Provider_GraphViewer* p) noexcept override { return *reinterpret_cast<const std::vector<const Provider_NodeArg*>*>(&reinterpret_cast<const GraphViewer*>(p)->GetInputs()); }
-  const std::vector<const Provider_NodeArg*>& Provider_GraphViewer__GetOutputs(const Provider_GraphViewer* p) noexcept override { return *reinterpret_cast<const std::vector<const Provider_NodeArg*>*>(&reinterpret_cast<const GraphViewer*>(p)->GetOutputs()); }
-  const std::vector<const Provider_NodeArg*>& Provider_GraphViewer__GetValueInfo(const Provider_GraphViewer* p) noexcept override { return *reinterpret_cast<const std::vector<const Provider_NodeArg*>*>(&reinterpret_cast<const GraphViewer*>(p)->GetValueInfo()); }
+  const std::vector<const Provider_NodeArg*>& Provider_GraphViewer__GetInputs(const Provider_GraphViewer* p) noexcept override { return p->GetInputs(); }
+  const std::vector<const Provider_NodeArg*>& Provider_GraphViewer__GetOutputs(const Provider_GraphViewer* p) noexcept override { return p->GetOutputs(); }
+  const std::vector<const Provider_NodeArg*>& Provider_GraphViewer__GetValueInfo(const Provider_GraphViewer* p) noexcept override { return p->GetValueInfo(); }
 
-  const Provider_InitializedTensorSet& Provider_GraphViewer__GetAllInitializedTensors(const Provider_GraphViewer* p) override { return *reinterpret_cast<const Provider_InitializedTensorSet*>(&reinterpret_cast<const GraphViewer*>(p)->GetAllInitializedTensors()); }
-  bool Provider_GraphViewer__GetInitializedTensor(const Provider_GraphViewer* p, const std::string& tensor_name, const Provider_TensorProto*& value) override { return reinterpret_cast<const GraphViewer*>(p)->GetInitializedTensor(tensor_name, reinterpret_cast<const ONNX_NAMESPACE::TensorProto*&>(value)); }
+  const Provider_InitializedTensorSet& Provider_GraphViewer__GetAllInitializedTensors(const Provider_GraphViewer* p) override { return p->GetAllInitializedTensors(); }
+  bool Provider_GraphViewer__GetInitializedTensor(const Provider_GraphViewer* p, const std::string& tensor_name, const Provider_TensorProto*& value) override { return p->GetInitializedTensor(tensor_name, value); }
 
-  const std::unordered_map<std::string, int>& Provider_GraphViewer__DomainToVersionMap(const Provider_GraphViewer* p) override { return reinterpret_cast<const GraphViewer*>(p)->DomainToVersionMap(); }
+  const std::unordered_map<std::string, int>& Provider_GraphViewer__DomainToVersionMap(const Provider_GraphViewer* p) override { return p->DomainToVersionMap(); }
 
-  const std::vector<NodeIndex>& Provider_GraphViewer__GetNodesInTopologicalOrder(const Provider_GraphViewer* p) override { return reinterpret_cast<const GraphViewer*>(p)->GetNodesInTopologicalOrder(); }
+  const std::vector<NodeIndex>& Provider_GraphViewer__GetNodesInTopologicalOrder(const Provider_GraphViewer* p) override { return p->GetNodesInTopologicalOrder(); }
 
   // Provider_OpKernel_Base
-  const Provider_OpKernelInfo& Provider_OpKernel_Base__GetInfo(const Provider_OpKernel_Base* p) override { return *reinterpret_cast<const Provider_OpKernelInfo*>(&reinterpret_cast<const OpKernel*>(p)->Info()); }
+  const Provider_OpKernelInfo& Provider_OpKernel_Base__GetInfo(const Provider_OpKernel_Base* p) override { return reinterpret_cast<const OpKernel*>(p)->Info(); }
 
   // Provider_OpKernelContext
-  const Provider_Tensor* Provider_OpKernelContext__Input_Tensor(const Provider_OpKernelContext* p, int index) override { return reinterpret_cast<const Provider_Tensor*>(reinterpret_cast<const OpKernelContext*>(p)->Input<Tensor>(index)); }
-  Provider_Tensor* Provider_OpKernelContext__Output(Provider_OpKernelContext* p, int index, const TensorShape& shape) override { return reinterpret_cast<Provider_Tensor*>(reinterpret_cast<OpKernelContext*>(p)->Output(index, shape)); }
+  const Provider_Tensor* Provider_OpKernelContext__Input_Tensor(const Provider_OpKernelContext* p, int index) override { return p->Input<Tensor>(index); }
+  Provider_Tensor* Provider_OpKernelContext__Output(Provider_OpKernelContext* p, int index, const TensorShape& shape) override { return p->Output(index, shape); }
 
   // Provider_OpKernelInfo
-  Status Provider_OpKernelInfo__GetAttr_int64(const Provider_OpKernelInfo* p, const std::string& name, int64_t* value) override { return reinterpret_cast<const OpKernelInfo*>(p)->GetAttr(name, value); }
-  Status Provider_OpKernelInfo__GetAttr_float(const Provider_OpKernelInfo* p, const std::string& name, float* value) override { return reinterpret_cast<const OpKernelInfo*>(p)->GetAttr(name, value); }
+  Status Provider_OpKernelInfo__GetAttr_int64(const Provider_OpKernelInfo* p, const std::string& name, int64_t* value) override { return p->GetAttr(name, value); }
+  Status Provider_OpKernelInfo__GetAttr_float(const Provider_OpKernelInfo* p, const std::string& name, float* value) override { return p->GetAttr(name, value); }
 
-  const Provider_DataTransferManager& Provider_OpKernelInfo__GetDataTransferManager(const Provider_OpKernelInfo* p) noexcept override { return *reinterpret_cast<const Provider_DataTransferManager*>(&reinterpret_cast<const OpKernelInfo*>(p)->GetDataTransferManager()); }
-  int Provider_OpKernelInfo__GetKernelDef_ExecQueueId(const Provider_OpKernelInfo* p) noexcept override { return reinterpret_cast<const OpKernelInfo*>(p)->GetKernelDef().ExecQueueId(); }
+  const Provider_DataTransferManager& Provider_OpKernelInfo__GetDataTransferManager(const Provider_OpKernelInfo* p) noexcept override { return p->GetDataTransferManager(); }
+  int Provider_OpKernelInfo__GetKernelDef_ExecQueueId(const Provider_OpKernelInfo* p) noexcept override { return p->GetKernelDef().ExecQueueId(); }
 
   // Provider_Tensor
-  float* Provider_Tensor__MutableData_float(Provider_Tensor* p) override { return reinterpret_cast<Tensor*>(p)->MutableData<float>(); }
-  const float* Provider_Tensor__Data_float(const Provider_Tensor* p) override { return reinterpret_cast<const Tensor*>(p)->Data<float>(); }
+  float* Provider_Tensor__MutableData_float(Provider_Tensor* p) override { return p->MutableData<float>(); }
+  const float* Provider_Tensor__Data_float(const Provider_Tensor* p) override { return p->Data<float>(); }
 
-  void* Provider_Tensor__MutableDataRaw(Provider_Tensor* p) noexcept override { return reinterpret_cast<Tensor*>(p)->MutableDataRaw(); }
-  const void* Provider_Tensor__DataRaw(const Provider_Tensor* p) const noexcept override { return reinterpret_cast<const Tensor*>(p)->DataRaw(); }
+  void* Provider_Tensor__MutableDataRaw(Provider_Tensor* p) noexcept override { return p->MutableDataRaw(); }
+  const void* Provider_Tensor__DataRaw(const Provider_Tensor* p) const noexcept override { return p->DataRaw(); }
 
-  const TensorShape& Provider_Tensor__Shape(const Provider_Tensor* p) override { return reinterpret_cast<const Tensor*>(p)->Shape(); }
-  size_t Provider_Tensor__SizeInBytes(const Provider_Tensor* p) override { return reinterpret_cast<const Tensor*>(p)->SizeInBytes(); }
-  const OrtMemoryInfo& Provider_Tensor__Location(const Provider_Tensor* p) override { return reinterpret_cast<const Tensor*>(p)->Location(); }
+  const TensorShape& Provider_Tensor__Shape(const Provider_Tensor* p) override { return p->Shape(); }
+  size_t Provider_Tensor__SizeInBytes(const Provider_Tensor* p) override { return p->SizeInBytes(); }
+  const OrtMemoryInfo& Provider_Tensor__Location(const Provider_Tensor* p) override { return p->Location(); }
 
 } provider_host_;
 

--- a/onnxruntime/core/framework/provider_bridge_ort.cc
+++ b/onnxruntime/core/framework/provider_bridge_ort.cc
@@ -274,7 +274,7 @@ struct ProviderHostImpl : ProviderHost {
     return onnxruntime::make_unique<Provider_IAllocator_Impl>(onnxruntime::make_unique<CUDAPinnedAllocator>(device_id, name));
   }
 
-  std::unique_ptr<Provider_IDataTransfer> CreateGPUDataTransfer() override { return make_unique<GPUDataTransfer>(); }
+  std::unique_ptr<Provider_IDataTransfer> CreateGPUDataTransfer() override { return onnxruntime::make_unique<GPUDataTransfer>(); }
 
   void cuda__Impl_Cast(const int64_t* input_data, int32_t* output_data, size_t count) override {
     return cuda::Impl_Cast(input_data, output_data, count);
@@ -397,7 +397,7 @@ struct ProviderHostImpl : ProviderHost {
   const Provider_ValueInfoProto& Provider_ValueInfoProtos__operator_array(const Provider_ValueInfoProtos* p, int index) override { return (*p)[index]; }
 
   // Provider_ComputeCapability
-  std::unique_ptr<Provider_ComputeCapability> Provider_ComputeCapability__construct(std::unique_ptr<Provider_IndexedSubGraph> t_sub_graph) override { return make_unique<ComputeCapability>(std::move(t_sub_graph)); }
+  std::unique_ptr<Provider_ComputeCapability> Provider_ComputeCapability__construct(std::unique_ptr<Provider_IndexedSubGraph> t_sub_graph) override { return onnxruntime::make_unique<ComputeCapability>(std::move(t_sub_graph)); }
   void Provider_ComputeCapability__operator_delete(Provider_ComputeCapability* p) override { delete p; }
   std::unique_ptr<Provider_IndexedSubGraph>& Provider_ComputeCapability__SubGraph(Provider_ComputeCapability* p) override { return p->sub_graph; }
 
@@ -408,7 +408,7 @@ struct ProviderHostImpl : ProviderHost {
   void Provider_IDataTransfer__operator_delete(Provider_IDataTransfer* p) override { delete p; }
 
   // Provider_IndexedSubGraph_MetaDef
-  std::unique_ptr<Provider_IndexedSubGraph_MetaDef> Provider_IndexedSubGraph_MetaDef__construct() override { return make_unique<IndexedSubGraph::MetaDef>(); }
+  std::unique_ptr<Provider_IndexedSubGraph_MetaDef> Provider_IndexedSubGraph_MetaDef__construct() override { return onnxruntime::make_unique<IndexedSubGraph::MetaDef>(); }
   void Provider_IndexedSubGraph_MetaDef__operator_delete(Provider_IndexedSubGraph_MetaDef* p) override { delete p; }
 
   std::string& Provider_IndexedSubGraph_MetaDef__name(Provider_IndexedSubGraph_MetaDef* p) override { return p->name; }
@@ -421,7 +421,7 @@ struct ProviderHostImpl : ProviderHost {
   std::string& Provider_IndexedSubGraph_MetaDef__doc_string(Provider_IndexedSubGraph_MetaDef* p) override { return p->doc_string; }
 
   // Provider_IndexedSubGraph
-  std::unique_ptr<Provider_IndexedSubGraph> Provider_IndexedSubGraph__construct() override { return make_unique<IndexedSubGraph>(); }
+  std::unique_ptr<Provider_IndexedSubGraph> Provider_IndexedSubGraph__construct() override { return onnxruntime::make_unique<IndexedSubGraph>(); }
   void Provider_IndexedSubGraph__operator_delete(Provider_IndexedSubGraph* p) override { delete p; }
 
   std::vector<onnxruntime::NodeIndex>& Provider_IndexedSubGraph__Nodes(Provider_IndexedSubGraph* p) override { return p->nodes; }
@@ -433,7 +433,7 @@ struct ProviderHostImpl : ProviderHost {
   void Provider_KernelDef__operator_delete(Provider_KernelDef* p) override { delete p; }
 
   // Provider_KernelDefBuilder
-  std::unique_ptr<Provider_KernelDefBuilder> Provider_KernelDefBuilder__construct() override { return make_unique<KernelDefBuilder>(); }
+  std::unique_ptr<Provider_KernelDefBuilder> Provider_KernelDefBuilder__construct() override { return onnxruntime::make_unique<KernelDefBuilder>(); }
   void Provider_KernelDefBuilder__operator_delete(Provider_KernelDefBuilder* p) override { delete p; }
 
   void Provider_KernelDefBuilder__SetName(Provider_KernelDefBuilder* p, const char* op_name) override { p->SetName(op_name); }
@@ -497,7 +497,7 @@ struct ProviderHostImpl : ProviderHost {
   const Provider_TypeProto* Provider_NodeArg__TypeAsProto(const Provider_NodeArg* p) noexcept override { return p->TypeAsProto(); }
 
   // Provider_NodeAttributes
-  std::unique_ptr<Provider_NodeAttributes> Provider_NodeAttributes__construct() override { return make_unique<NodeAttributes>(); }
+  std::unique_ptr<Provider_NodeAttributes> Provider_NodeAttributes__construct() override { return onnxruntime::make_unique<NodeAttributes>(); }
   void Provider_NodeAttributes__operator_delete(Provider_NodeAttributes* p) noexcept override { delete p; }
   size_t Provider_NodeAttributes__size(const Provider_NodeAttributes* p) override { return p->size(); }
   void Provider_NodeAttributes__clear(Provider_NodeAttributes* p) noexcept override { return p->clear(); }
@@ -518,11 +518,11 @@ struct ProviderHostImpl : ProviderHost {
   // Provider_Model
   void Provider_Model__operator_delete(Provider_Model* p) override { delete p; }
   Provider_Graph& Provider_Model__MainGraph(Provider_Model* p) override { return p->MainGraph(); }
-  std::unique_ptr<Provider_ModelProto> Provider_Model__ToProto(Provider_Model* p) override { return make_unique<ONNX_NAMESPACE::ModelProto>(p->ToProto()); }
+  std::unique_ptr<Provider_ModelProto> Provider_Model__ToProto(Provider_Model* p) override { return onnxruntime::make_unique<ONNX_NAMESPACE::ModelProto>(p->ToProto()); }
 
   // Provider_Graph
-  std::unique_ptr<Provider_GraphViewer> Provider_Graph__CreateGraphViewer(const Provider_Graph* p) override { return make_unique<GraphViewer>(*p); }
-  std::unique_ptr<Provider_GraphProto> Provider_Graph__ToGraphProto(const Provider_Graph* p) override { return make_unique<ONNX_NAMESPACE::GraphProto>(p->ToGraphProto()); }
+  std::unique_ptr<Provider_GraphViewer> Provider_Graph__CreateGraphViewer(const Provider_Graph* p) override { return onnxruntime::make_unique<GraphViewer>(*p); }
+  std::unique_ptr<Provider_GraphProto> Provider_Graph__ToGraphProto(const Provider_Graph* p) override { return onnxruntime::make_unique<ONNX_NAMESPACE::GraphProto>(p->ToGraphProto()); }
 
   Provider_NodeArg& Provider_Graph__GetOrCreateNodeArg(Provider_Graph* p, const std::string& name, const Provider_TypeProto* p_arg_type) override { return p->GetOrCreateNodeArg(name, p_arg_type); }
 
@@ -541,9 +541,9 @@ struct ProviderHostImpl : ProviderHost {
   // Provider_GraphViewer
   void Provider_GraphViewer__operator_delete(Provider_GraphViewer* p) override { delete p; }
   std::unique_ptr<Provider_Model> Provider_GraphViewer__CreateModel(const Provider_GraphViewer* graph_viewer, const logging::Logger& logger) override {
-    return make_unique<Model>(graph_viewer->Name(), true, ModelMetaData(), PathString(),
-                              IOnnxRuntimeOpSchemaRegistryList(), graph_viewer->DomainToVersionMap(),
-                              std::vector<ONNX_NAMESPACE::FunctionProto>(), logger);
+    return onnxruntime::make_unique<Model>(graph_viewer->Name(), true, ModelMetaData(), PathString(),
+                                           IOnnxRuntimeOpSchemaRegistryList(), graph_viewer->DomainToVersionMap(),
+                                           std::vector<ONNX_NAMESPACE::FunctionProto>(), logger);
   }
 
   const std::string& Provider_GraphViewer__Name(const Provider_GraphViewer* p) noexcept override { return p->Name(); }

--- a/onnxruntime/core/framework/provider_bridge_ort.cc
+++ b/onnxruntime/core/framework/provider_bridge_ort.cc
@@ -25,7 +25,7 @@
 #endif
 
 namespace onnxruntime {
-// These Provider types are really just internal types, so when we #define PROVIDER_BRIDGE_ORT so that only these definitions are seen by provider_interfaces.h
+// These Provider types are really just internal types, so we #define PROVIDER_BRIDGE_ORT so that only these definitions are seen by provider_interfaces.h
 // Users of provider_interfaces.h (through provider_api.h) will see the wrappers that call through the provider shared interface which is implemented by this file
 using Provider_AttributeProto = ONNX_NAMESPACE::AttributeProto;
 using Provider_GraphProto = ONNX_NAMESPACE::GraphProto;

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -25,7 +25,8 @@ using DataType = const std::string*;
 
 namespace onnxruntime {
 
-// onnx Protobuf types
+// onnx Protobuf types (all of these are actually just Provider_<type> -> ONNX_NAMESPACE::<type>)
+#ifndef PROVIDER_BRIDGE_ORT
 struct Provider_AttributeProto;
 struct Provider_GraphProto;
 struct Provider_ModelProto;
@@ -39,16 +40,15 @@ struct Provider_TypeProto_Tensor;
 struct Provider_TypeProto;
 struct Provider_ValueInfoProto;
 struct Provider_ValueInfoProtos;
+#endif
 
-// OnnxRuntime Types
-struct ProviderHost;
+// OnnxRuntime Types (all of these are actually just Provider_<type> -> <type>)
+#ifndef PROVIDER_BRIDGE_ORT
 struct Provider_ComputeCapability;
 struct Provider_DataTransferManager;
 struct Provider_IDataTransfer;
-struct Provider_IExecutionProvider;
 struct Provider_IndexedSubGraph;
 struct Provider_IndexedSubGraph_MetaDef;
-struct Provider_KernelCreateInfo;
 struct Provider_KernelDef;
 struct Provider_KernelDefBuilder;
 struct Provider_KernelRegistry;
@@ -59,10 +59,15 @@ struct Provider_Model;
 struct Provider_Node;
 struct Provider_NodeArg;
 struct Provider_NodeAttributes;
-struct Provider_OpKernel_Base;
 struct Provider_OpKernelContext;
 struct Provider_OpKernelInfo;
 struct Provider_Tensor;
+#endif
+
+struct Provider_IExecutionProvider;
+struct Provider_KernelCreateInfo;
+struct Provider_OpKernel_Base;
+struct ProviderHost;
 class TensorShape;
 
 template <typename T, typename TResult>
@@ -177,7 +182,7 @@ using Provider_NodeArgInfo = Provider_ValueInfoProto;
 // We can't just reinterpret_cast this one, since it's an unordered_map of object BY VALUE (can't do anything by value on the real types)
 //using Provider_NodeAttributes = std::unordered_map<std::string, ONNX_NAMESPACE::Provider_AttributeProto_Copyable>;
 
-using Provider_InitializedTensorSet = std::unordered_map<std::string, const ONNX_NAMESPACE::Provider_TensorProto*>;
+using Provider_InitializedTensorSet = std::unordered_map<std::string, const Provider_TensorProto*>;
 
 struct Provider_Node__NodeIterator {
   virtual ~Provider_Node__NodeIterator() {}
@@ -466,7 +471,7 @@ struct ProviderHost {
   virtual ONNX_NAMESPACE::DataType Provider_NodeArg__Type(const Provider_NodeArg* p) noexcept = 0;
   virtual const Provider_NodeArgInfo& Provider_NodeArg__ToProto(const Provider_NodeArg* p) noexcept = 0;
   virtual bool Provider_NodeArg__Exists(const Provider_NodeArg* p) const noexcept = 0;
-  virtual const ONNX_NAMESPACE::Provider_TypeProto* Provider_NodeArg__TypeAsProto(const Provider_NodeArg* p) noexcept = 0;
+  virtual const Provider_TypeProto* Provider_NodeArg__TypeAsProto(const Provider_NodeArg* p) noexcept = 0;
 
   // Provider_NodeAttributes
   virtual std::unique_ptr<Provider_NodeAttributes> Provider_NodeAttributes__construct() = 0;
@@ -554,6 +559,8 @@ struct ProviderHost {
 
 extern ProviderHost* g_host;
 
+#ifndef PROVIDER_BRIDGE_ORT
+
 struct Provider_TypeProto_Tensor {
   int32_t elem_type() const { return g_host->Provider_TypeProto_Tensor__elem_type(this); }
 
@@ -609,8 +616,8 @@ struct Provider_ModelProto {
   bool SerializeToString(std::string& string) const { return g_host->Provider_ModelProto__SerializeToString(this, string); }
   bool SerializeToOstream(std::ostream& output) const { return g_host->Provider_ModelProto__SerializeToOstream(this, output); }
 
-  const ONNX_NAMESPACE::Provider_GraphProto& graph() const { return g_host->Provider_ModelProto__graph(this); }
-  ONNX_NAMESPACE::Provider_GraphProto* mutable_graph() { return g_host->Provider_ModelProto__mutable_graph(this); }
+  const Provider_GraphProto& graph() const { return g_host->Provider_ModelProto__graph(this); }
+  Provider_GraphProto* mutable_graph() { return g_host->Provider_ModelProto__mutable_graph(this); }
 
   void set_ir_version(int64_t value) { return g_host->Provider_ModelProto__set_ir_version(this, value); }
 
@@ -741,6 +748,7 @@ struct Provider_KernelDef {
   Provider_KernelDef(const Provider_KernelDef*) = delete;
   void operator=(const Provider_KernelDef&) = delete;
 };
+#endif
 
 using Provider_KernelCreateFn = std::function<Provider_OpKernel*(const Provider_OpKernelInfo& info)>;
 using Provider_KernelCreatePtrFn = std::add_pointer<Provider_OpKernel*(const Provider_OpKernelInfo& info)>::type;
@@ -761,6 +769,7 @@ struct Provider_KernelCreateInfo {
 
 using Provider_BuildKernelCreateInfoFn = Provider_KernelCreateInfo (*)();
 
+#ifndef PROVIDER_BRIDGE_ORT
 struct Provider_KernelDefBuilder {
   static std::unique_ptr<Provider_KernelDefBuilder> Create() { return g_host->Provider_KernelDefBuilder__construct(); }
   static void operator delete(void* p) { g_host->Provider_KernelDefBuilder__operator_delete(reinterpret_cast<Provider_KernelDefBuilder*>(p)); }
@@ -972,6 +981,7 @@ struct Provider_GraphViewer {
   Provider_GraphViewer(const Provider_GraphViewer&) = delete;
   void operator=(const Provider_GraphViewer&) = delete;
 };
+#endif
 
 struct Provider_OpKernel_Base {
   const Provider_OpKernelInfo& GetInfo() const { return g_host->Provider_OpKernel_Base__GetInfo(this); }
@@ -979,6 +989,7 @@ struct Provider_OpKernel_Base {
   PROVIDER_DISALLOW_ALL(Provider_OpKernel_Base)
 };
 
+#ifndef PROVIDER_BRIDGE_ORT
 struct Provider_OpKernelContext {
   const Provider_Tensor* Input_Tensor(int index) const { return g_host->Provider_OpKernelContext__Input_Tensor(this, index); }
 
@@ -1043,5 +1054,6 @@ inline float* Provider_Tensor::MutableData<float>() { return MutableData_float()
 
 template <>
 inline const float* Provider_Tensor::Data<float>() const { return Data_float(); }
+#endif
 
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**: The reinterpret_casts are confusing, verbose, dangerous, and with this change, unnecessary.

**Motivation and Context**
To preserve my sanity and everyone else's I realized I could remove them by having the public header see one set of types and the internal implementation the internal set (through a list of using declarations).

With this it's much more type safe and massively simpler.