### PR TITLE
--shm-size=1024m to fix nccl shared memory issue

### DIFF
--- a/tools/ci_build/github/linux/run_dockerbuild.sh
+++ b/tools/ci_build/github/linux/run_dockerbuild.sh
@@ -108,7 +108,7 @@ fi
 if [ $BUILD_DEVICE = "cpu" ] || [ $BUILD_DEVICE = "ngraph" ] || [ $BUILD_DEVICE = "openvino" ] || [ $BUILD_DEVICE = "nnapi" ] || [ $BUILD_DEVICE = "arm" ]; then
     RUNTIME=
 elif [[ $BUILD_EXTR_PAR = *--enable_training_python_frontend_e2e_tests* ]]; then
-     RUNTIME="--gpus all --shm-size=1024m"
+     RUNTIME="--gpus all --shm-size=256m"
 else
     RUNTIME="--gpus all"
 fi

--- a/tools/ci_build/github/linux/run_dockerbuild.sh
+++ b/tools/ci_build/github/linux/run_dockerbuild.sh
@@ -107,6 +107,8 @@ fi
 
 if [ $BUILD_DEVICE = "cpu" ] || [ $BUILD_DEVICE = "ngraph" ] || [ $BUILD_DEVICE = "openvino" ] || [ $BUILD_DEVICE = "nnapi" ] || [ $BUILD_DEVICE = "arm" ]; then
     RUNTIME=
+elif [[ $BUILD_EXTR_PAR = *--enable_training_python_frontend_e2e_tests* ]]; then
+     RUNTIME="--gpus all --shm-size=1024m"
 else
     RUNTIME="--gpus all"
 fi


### PR DESCRIPTION
**Description**: Increate shared memory limit of Frontend e2e Nightly Docker to avoid NCCL failure

**Motivation and Context**
To make Frontend e2e Nightly pipeline pass