### PR TITLE
build fix _WIN32 in scoped_env_vars.cc

### DIFF
--- a/onnxruntime/test/util/scoped_env_vars.cc
+++ b/onnxruntime/test/util/scoped_env_vars.cc
@@ -3,9 +3,9 @@
 
 #include "test/util/include/scoped_env_vars.h"
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <stdlib.h>
-#else  // WIN32
+#else  // _WIN32
 #include <Windows.h>
 #endif
 
@@ -13,7 +13,7 @@ namespace onnxruntime {
 namespace test {
 
 namespace {
-#ifndef WIN32
+#ifndef _WIN32
 Status SetEnvironmentVar(const std::string& name, const optional<std::string>& value) {
   if (value.has_value()) {
     ORT_RETURN_IF_NOT(
@@ -32,7 +32,7 @@ Status GetEnvironmentVar(const std::string& name, optional<std::string>& value) 
   value = val == nullptr ? optional<std::string>{} : optional<std::string>{std::string{val}};
   return Status::OK();
 }
-#else  // WIN32
+#else  // _WIN32
 Status SetEnvironmentVar(const std::string& name, const optional<std::string>& value) {
   ORT_RETURN_IF_NOT(
       SetEnvironmentVariableA(name.c_str(), value.has_value() ? value.value().c_str() : nullptr) != 0,


### PR DESCRIPTION
on Windows machine, encounter build failure if using cmake to build (rather than build.bat)

C:\onnxruntime-debug\onnxruntime\test\util\scoped_env_vars.cc(19,1): error C3861: 'setenv': identifier not found [C:\on
nxruntime-debug\build\windows\release\onnxruntime_test_utils.vcxproj]
C:\onnxruntime-debug\onnxruntime\test\util\scoped_env_vars.cc(23,1): error C3861: 'unsetenv': identifier not found [C:\
onnxruntime-debug\build\windows\release\onnxruntime_test_utils.vcxproj]
C:\onnxruntime-debug\onnxruntime\test\util\scoped_env_vars.cc(31,21): warning C4996: 'getenv': This function or variabl
e may be unsafe. Consider using _dupenv_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help
 for details. [C:\onnxruntime-debug\build\windows\release\onnxruntime_test_utils.vcxproj]