### PR TITLE
remove curand_generator_ related code since it is not used.

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -170,10 +170,6 @@ class CudaKernel : public OpKernel {
   }
 
  protected:
-  inline curandGenerator_t CurandGenerator() const {
-    return provider_->PerThreadCurandGenerator();
-  }
-
   template <typename T>
   inline const T* GetConstOnes(size_t count) const {
     return provider_->template GetConstOnes<T>(count);

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -60,7 +60,6 @@ CUDAExecutionProvider::PerThreadContext::PerThreadContext(OrtDevice::DeviceId de
   CUDA_CALL_THROW(cudaSetDevice(device_id));
   CUBLAS_CALL_THROW(cublasCreate(&cublas_handle_));
   CUDNN_CALL_THROW(cudnnCreate(&cudnn_handle_));
-  CURAND_CALL_THROW(curandCreateGenerator(&curand_generator_, CURAND_RNG_PSEUDO_DEFAULT));
 
   AllocatorCreationInfo default_memory_info(
       [](OrtDevice::DeviceId id) {
@@ -90,12 +89,6 @@ CUDAExecutionProvider::PerThreadContext::~PerThreadContext() {
     CUDNN_CALL(cudnnDestroy(cudnn_handle_));
   } catch (const std::exception& ex) {
     LOGS_DEFAULT(ERROR) << "cudnnDestroy threw:" << ex.what();
-  }
-
-  try {
-    CURAND_CALL_THROW(curandDestroyGenerator(curand_generator_));
-  } catch (const std::exception& ex) {
-    LOGS_DEFAULT(ERROR) << "curandDestroyGenerator threw:" << ex.what();
   }
 }
 

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.h
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.h
@@ -52,9 +52,6 @@ class CUDAExecutionProvider : public IExecutionProvider {
   cudnnHandle_t PerThreadCudnnHandle() {
     return GetPerThreadContext().CudnnHandle();
   }
-  curandGenerator_t PerThreadCurandGenerator() {
-    return GetPerThreadContext().CurandGenerator();
-  }
 
   template <typename T>
   const T* GetConstOnes(size_t count) {
@@ -109,10 +106,6 @@ class CUDAExecutionProvider : public IExecutionProvider {
       return cudnn_handle_;
     }
 
-    curandGenerator_t CurandGenerator() const {
-      return curand_generator_;
-    }
-
     cudaEvent_t& GetCurrentDeferredReleaseEvent() {
       return current_deferred_release_event_;
     }
@@ -146,7 +139,6 @@ class CUDAExecutionProvider : public IExecutionProvider {
    private:
     cublasHandle_t cublas_handle_ = nullptr;
     cudnnHandle_t cudnn_handle_ = nullptr;
-    curandGenerator_t curand_generator_ = nullptr;
 
     // deferred release for temporary CPU pinned memory used in cudaMemcpyAsync
     // note that cudaEvent will be assigned at OnRunEnd() when PerThreadContext destory


### PR DESCRIPTION
I introduced curand_generator_  when implementing dropout kernel, but later we changed the implementation of dropout. The new implementation doesn't depend on curand_generator_, so it is better to remove it.
