### PR TITLE
add pipeline distributed training test

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1152,7 +1152,8 @@ def run_training_pipeline_e2e_tests(cwd):
                '--max_predictions_per_seq=20',
                '--warmup_ratio=0.2843',
                '--warmup_mode=Poly',
-               '--model_name', '/bert_ort/bert_models/nv/bert-large/bert-large-uncased_L_24_H_1024_A_16_V_30528_S_512_Dp_0.1_optimized_layer_norm_opset12',
+               '--model_name', '/bert_ort/bert_models/nv/bert-large/' +
+               'bert-large-uncased_L_24_H_1024_A_16_V_30528_S_512_Dp_0.1_optimized_layer_norm_opset12',
                '--train_data_dir', '/bert_data/128/books_wiki_en_corpus/train',
                '--test_data_dir', '/bert_data/128/books_wiki_en_corpus/test',
                '--display_loss_steps', '1',
@@ -1186,6 +1187,7 @@ def run_training_pipeline_e2e_tests(cwd):
     command_str = ', '.join(pp_dp_command)
     log.debug('RUN: ' + command_str)
     run_subprocess(pp_dp_command, cwd=cwd)
+
 
 def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
     for config in configs:

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1179,11 +1179,11 @@ def run_training_pipeline_e2e_tests(cwd):
     run_subprocess(pp_command, cwd=cwd)
 
     # Test 2-way data parallel + 2-way pipeline parallel
-    pp_dp_command = ['mpirun', '-n', str(ngpus)] +
-    command +
-    ['--data_parallel_size', '2', '--pipeline_parallel_size',
-     '2', '--cut_group_info',
-     '1881:407-1951/2073/2195/2317/2439/2561/2683/2805/2927/3049/3171/3293']
+    pp_dp_command = ['mpirun', '-n', str(ngpus)]
+    pp_dp_command = pp_dp_command + command
+    pp_dp_command = pp_dp_command + ['--data_parallel_size', '2', '--pipeline_parallel_size',
+                                     '2', '--cut_group_info',
+                                     '1881:407-1951/2073/2195/2317/2439/2561/2683/2805/2927/3049/3171/3293']
     command_str = ', '.join(pp_dp_command)
     log.debug('RUN: ' + command_str)
     run_subprocess(pp_dp_command, cwd=cwd)

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -97,6 +97,9 @@ def parse_arguments():
         "--enable_training_python_frontend_e2e_tests", action="store_true",
         help="Enable the pytorch frontend training tests.")
     parser.add_argument(
+        "--enable_training_pipeline_e2e_tests", action="store_true",
+        help="Enable the pipeline c++ e2e tests.")
+    parser.add_argument(
         "--use_horovod", action='store_true', help="Enable Horovod.")
     parser.add_argument(
         "--mpi_home", help="Path to MPI installation dir")
@@ -1134,6 +1137,51 @@ def run_training_python_frontend_e2e_tests(cwd):
         'BertModelTest.test_for_pretraining_mixed_precision_with_gradient_accumulation'], cwd=cwd)
 
 
+def run_training_pipeline_e2e_tests(cwd):
+    # pipeline tests are to be added here:
+    log.info("Running pipeline e2e tests.")
+
+    import torch
+    ngpus = torch.cuda.device_count()
+
+    command = ['./onnxruntime_training_bert',
+               '--ort_log_severity', '1',
+               '--optimizer=Lamb',
+               '--learning_rate=3e-3',
+               '--max_seq_length=128',
+               '--max_predictions_per_seq=20',
+               '--warmup_ratio=0.2843',
+               '--warmup_mode=Poly',
+               '--model_name', '/bert_ort/bert_models/nv/bert-large/bert-large-uncased_L_24_H_1024_A_16_V_30528_S_512_Dp_0.1_optimized_layer_norm_opset12',
+               '--train_data_dir', '/bert_data/128/books_wiki_en_corpus/train',
+               '--test_data_dir', '/bert_data/128/books_wiki_en_corpus/test',
+               '--display_loss_steps', '1',
+               '--use_nccl',
+               '--use_mixed_precision',
+               '--allreduce_in_fp16',
+               '--gradient_accumulation_steps', '48',
+               '--num_train_steps', '96',
+               '--train_batch_size', '50']
+
+    # TODO: currently the CI machine only has 4 GPUs for parallel tests.
+    # Fill in more pipeline partition options when the machine has different GPUs counts.
+    if ngpus != 4:
+        return
+
+    # Test 4-way pipeline parallel
+    pp_command = ['mpirun', '-n', str(ngpus)] + command + ['--pipeline_parallel_size', '4', '--cut_group_info',
+                                                            '1149:407-1219/1341/1463/1585/1707/1829,1881:407-1951/2073/2195/2317/2439/2561,2613:407-2683/2805/2927/3049/3171/3293']
+    command_str = ', '.join(pp_command)
+    log.debug('RUN: ' + command_str)
+    run_subprocess(pp_command, cwd=cwd)
+
+    # Test 2-way data parallel + 2-way pipeline parallel
+    pp_dp_command = ['mpirun', '-n', str(ngpus)] + command + ['--data_parallel_size', '2', '--pipeline_parallel_size',
+                                                                '2', '--cut_group_info', '1881:407-1951/2073/2195/2317/2439/2561/2683/2805/2927/3049/3171/3293']
+    command_str = ', '.join(pp_dp_command)
+    log.debug('RUN: ' + command_str)
+    run_subprocess(pp_dp_command, cwd=cwd)
+
 def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
     for config in configs:
         log.info("Running tests for %s configuration", config)
@@ -1144,6 +1192,11 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
             # this is not a PR merge test so skip other non-frontend tests.
             run_training_python_frontend_e2e_tests(cwd=cwd)
             run_training_python_frontend_tests(cwd=cwd)
+            continue
+
+        if args.enable_training and args.use_cuda and args.enable_training_pipeline_e2e_tests:
+            # run distributed pipeline test on 4-GPU CI machine.
+            run_training_pipeline_e2e_tests(cwd=cwd)
             continue
 
         if args.android:

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1171,9 +1171,9 @@ def run_training_pipeline_e2e_tests(cwd):
 
     # Test 4-way pipeline parallel
     pp_command = ['mpirun', '-n', str(ngpus)] + command + ['--pipeline_parallel_size', '4', '--cut_group_info',
-                                                            '1149:407-1219/1341/1463/1585/1707/1829,' +
-                                                            '1881:407-1951/2073/2195/2317/2439/2561,' +
-                                                            '2613:407-2683/2805/2927/3049/3171/3293']
+                                                           '1149:407-1219/1341/1463/1585/1707/1829,' +
+                                                           '1881:407-1951/2073/2195/2317/2439/2561,' +
+                                                           '2613:407-2683/2805/2927/3049/3171/3293']
     command_str = ', '.join(pp_command)
     log.debug('RUN: ' + command_str)
     run_subprocess(pp_command, cwd=cwd)

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1170,14 +1170,19 @@ def run_training_pipeline_e2e_tests(cwd):
 
     # Test 4-way pipeline parallel
     pp_command = ['mpirun', '-n', str(ngpus)] + command + ['--pipeline_parallel_size', '4', '--cut_group_info',
-                                                            '1149:407-1219/1341/1463/1585/1707/1829,1881:407-1951/2073/2195/2317/2439/2561,2613:407-2683/2805/2927/3049/3171/3293']
+                                                            '1149:407-1219/1341/1463/1585/1707/1829,' +
+                                                            '1881:407-1951/2073/2195/2317/2439/2561,' +
+                                                            '2613:407-2683/2805/2927/3049/3171/3293']
     command_str = ', '.join(pp_command)
     log.debug('RUN: ' + command_str)
     run_subprocess(pp_command, cwd=cwd)
 
     # Test 2-way data parallel + 2-way pipeline parallel
-    pp_dp_command = ['mpirun', '-n', str(ngpus)] + command + ['--data_parallel_size', '2', '--pipeline_parallel_size',
-                                                                '2', '--cut_group_info', '1881:407-1951/2073/2195/2317/2439/2561/2683/2805/2927/3049/3171/3293']
+    pp_dp_command = ['mpirun', '-n', str(ngpus)] +
+    command +
+    ['--data_parallel_size', '2', '--pipeline_parallel_size',
+     '2', '--cut_group_info',
+     '1881:407-1951/2073/2195/2317/2439/2561/2683/2805/2927/3049/3171/3293']
     command_str = ', '.join(pp_dp_command)
     log.debug('RUN: ' + command_str)
     run_subprocess(pp_dp_command, cwd=cwd)

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-frontend-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-frontend-test-ci-pipeline.yml
@@ -7,12 +7,12 @@ jobs:
 - job: Onnxruntime_Linux_GPU_Training_FrontEnd
 
   timeoutInMinutes: 240
-  
+
   steps:
   - checkout: self
     clean: true
     submodules: recursive
-  
+
   - template: templates/set-test-data-variables-step.yml
 
   - task: CmdLine@2
@@ -37,6 +37,7 @@ jobs:
       --skip_onnx_tests
       --build_wheel
       --enable_training_python_frontend_e2e_tests
+      --enable_training_pipeline_e2e_tests
       "
     displayName: 'Build and run frontend tests'
 

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -115,7 +115,7 @@ elif [ $DEVICE_TYPE = "gpu" ]; then
       # transformers requires sklearn
       ${PYTHON_EXE} -m pip install sklearn
 
-      if [[ $BUILD_EXTR_PAR = *--enable_training_python_frontend_e2e_tests* ]]; then
+      if [[ $BUILD_EXTR_PAR = *--enable_training_python_frontend_e2e_tests* || $BUILD_EXTR_PAR = *enable_training_pipeline_e2e_tests* ]]; then
         echo "install openmpi"
         curl -fsSL https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.0.tar.gz -O
         tar zxf openmpi-4.0.0.tar.gz

--- a/tools/ci_build/github/linux/run_dockerbuild.sh
+++ b/tools/ci_build/github/linux/run_dockerbuild.sh
@@ -128,6 +128,11 @@ if [[ $BUILD_EXTR_PAR = *--enable_training_python_frontend_e2e_tests* ]]; then
     # DOCKER_RUN_PARAMETER="$DOCKER_RUN_PARAMETER -u0"
 fi
 
+if [[ $BUILD_EXTR_PAR = *--enable_training_pipeline_e2e_tests* ]]; then
+    DOCKER_RUN_PARAMETER="$DOCKER_RUN_PARAMETER --volume /bert_ort:/bert_ort \
+                                                --volume /bert_data:/bert_data"
+fi
+
 $DOCKER_CMD rm -f "onnxruntime-$BUILD_DEVICE" || true
 $DOCKER_CMD run $RUNTIME -h $HOSTNAME $DOCKER_RUN_PARAMETER \
     -e NIGHTLY_BUILD \


### PR DESCRIPTION
**Description**: add pipeline distributed training test to night CI. The test currently is running on a machine with 4 GPUs. So 4-way PP and 2-way DP+2-way PP are tested.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
