### PR TITLE
Address onnx_test_runner Android build failures

### DIFF
--- a/onnxruntime/test/onnx/testcase_driver.cc
+++ b/onnxruntime/test/onnx/testcase_driver.cc
@@ -17,25 +17,23 @@ TestCaseDriver::TestCaseDriver(const TestEnv& env, size_t concurrent_runs)
       tests_started_(0),
       tests_inprogress_(0),
       finished_(false) {
-  results_.reserve(env.GetTests().size());
-  CallableFactory<TestCaseDriver, void, std::shared_ptr<TestCaseResult>> f(this);
+  results_.resize(env.GetTests().size());
+  CallableFactory<TestCaseDriver, void, size_t, std::shared_ptr<TestCaseResult>> f(this);
   on_test_case_complete_ = f.GetCallable<&TestCaseDriver::OnTestCaseComplete>();
 }
-
 
 std::vector<std::shared_ptr<TestCaseResult>> TestCaseDriver::Run(const TestEnv& env, size_t concurrent_runs, size_t repeat_count) {
   std::vector<std::shared_ptr<TestCaseResult>> results;
   for (const auto& c : env.GetTests()) {
     auto result = TestCaseRequestContext::Run(env.GetThreadPool(),
-         *c, env.Env(), env.GetSessionOptions(), concurrent_runs, repeat_count);
+                                              *c, env.Env(), env.GetSessionOptions(), concurrent_runs, repeat_count);
     results.push_back(std::move(result));
   }
   return results;
 }
 
-std::vector<std::shared_ptr<TestCaseResult>> TestCaseDriver::RunParallel(const TestEnv& test_env, size_t parallel_models, 
-  size_t concurrent_runs) {
-
+std::vector<std::shared_ptr<TestCaseResult>> TestCaseDriver::RunParallel(const TestEnv& test_env, size_t parallel_models,
+                                                                         size_t concurrent_runs) {
   assert(parallel_models > 1);
   parallel_models = std::min(parallel_models, test_env.GetTests().size());
   LOGF_DEFAULT(ERROR, "Running tests in parallel: at most %u models at any time", static_cast<unsigned int>(parallel_models));
@@ -55,7 +53,7 @@ void TestCaseDriver::RunModelsAsync(size_t parallel_models) {
     }
     tests_inprogress_.fetch_add(1, std::memory_order_relaxed);
     TestCaseRequestContext::Request(on_test_case_complete_, env_.GetThreadPool(), *tests[next_to_run],
-      env_.Env(), env_.GetSessionOptions(), concurrent_runs_);
+                                    env_.Env(), env_.GetSessionOptions(), next_to_run, concurrent_runs_);
   }
   // This thread is not on a threadpool so we are not using it
   // to run anything. Just wait.
@@ -63,10 +61,11 @@ void TestCaseDriver::RunModelsAsync(size_t parallel_models) {
   LOGF_DEFAULT(ERROR, "Running tests finished. Generating report");
 }
 
-void TestCaseDriver::OnTestCaseComplete(std::shared_ptr<TestCaseResult> result) {
+void TestCaseDriver::OnTestCaseComplete(size_t test_case_id, std::shared_ptr<TestCaseResult> result) {
+  assert(test_case_id < results_.size());
   {
     std::lock_guard<std::mutex> g(mut_);
-    results_.push_back(std::move(result));
+    results_ [test_case_id] = std::move(result);
   }
 
   const auto& tests = env_.GetTests();
@@ -75,7 +74,7 @@ void TestCaseDriver::OnTestCaseComplete(std::shared_ptr<TestCaseResult> result) 
   if (next_to_run < total_models) {
     tests_inprogress_.fetch_add(1, std::memory_order_relaxed);
     TestCaseRequestContext::Request(on_test_case_complete_, env_.GetThreadPool(), *tests[next_to_run],
-                                    env_.Env(), env_.GetSessionOptions(), concurrent_runs_);
+                                    env_.Env(), env_.GetSessionOptions(), next_to_run, concurrent_runs_);
   }
 
   auto before_we_done = tests_inprogress_.fetch_sub(1, std::memory_order_acq_rel);

--- a/onnxruntime/test/onnx/testcase_driver.h
+++ b/onnxruntime/test/onnx/testcase_driver.h
@@ -62,7 +62,7 @@ class TestCaseDriver {
     return std::move(results_);
   }
 
-  void OnTestCaseComplete(std::shared_ptr<TestCaseResult>);
+  void OnTestCaseComplete(size_t, std::shared_ptr<TestCaseResult>);
 
   const TestEnv& env_;
   size_t concurrent_runs_;

--- a/onnxruntime/test/onnx/testcase_request.h
+++ b/onnxruntime/test/onnx/testcase_request.h
@@ -32,7 +32,7 @@ namespace test {
 /// </summary>
 class TestCaseRequestContext {
  public:
-  using Callback = Callable<void, std::shared_ptr<TestCaseResult>>;
+  using Callback = Callable<void, size_t, std::shared_ptr<TestCaseResult>>;
 
   /// <summary>
   /// Runs data tests on the model sequentially (concurrent_runs < 2)
@@ -64,7 +64,7 @@ class TestCaseRequestContext {
   /// <param name="concurrent_runs"></param>
   static void Request(const Callback& cb, PThreadPool tpool, const ITestCase& c,
                       Ort::Env& env, const Ort::SessionOptions& sf,
-                      size_t concurrent_runs);
+                      size_t test_case_id, size_t concurrent_runs);
 
   const TIME_SPEC& GetTimeSpend() const {
     return test_case_time_;
@@ -81,7 +81,7 @@ class TestCaseRequestContext {
  private:
 
   TestCaseRequestContext(const Callback& cb, PThreadPool tp, const ITestCase& test_case, Ort::Env& env,
-                         const Ort::SessionOptions& session_opts);
+                         const Ort::SessionOptions& session_opts, size_t test_case_id);
 
   bool SetupSession();
 
@@ -106,6 +106,7 @@ class TestCaseRequestContext {
   Ort::Env& env_;
   Ort::SessionOptions session_opts_;
   Ort::Session session_;
+  size_t test_case_id_;
   MockedOrtAllocator allocator_;
   std::shared_ptr<TestCaseResult> result_;
   TIME_SPEC test_case_time_;


### PR DESCRIPTION
**Description**: 
Preserve relative order of the results and the tests.

**Motivation and Context**
Latest changes broke the order between the tests and reported results.