### PR TITLE
Change how to set profile for dynamic shape graphs in TensorRT EP

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -995,14 +995,12 @@ common::Status TensorrtExecutionProvider::Provider_Compile(const std::vector<onn
               dimension_update[input_name] = true;
             }
 
-            if (dimension_update[input_name]) {
-              if (trt_profile == nullptr) {
-                trt_profile = trt_builder->createOptimizationProfile();
-              }
-              trt_profile->setShapeValues(input_name.c_str(), nvinfer1::OptProfileSelector::kMIN, &shapes_min[0], shape_size);
-              trt_profile->setShapeValues(input_name.c_str(), nvinfer1::OptProfileSelector::kOPT, &shapes_opt[0], shape_size);
-              trt_profile->setShapeValues(input_name.c_str(), nvinfer1::OptProfileSelector::kMAX, &shapes_max[0], shape_size);
+            if (trt_profile == nullptr) {
+              trt_profile = trt_builder->createOptimizationProfile();
             }
+            trt_profile->setShapeValues(input_name.c_str(), nvinfer1::OptProfileSelector::kMIN, &shapes_min[0], shape_size);
+            trt_profile->setShapeValues(input_name.c_str(), nvinfer1::OptProfileSelector::kOPT, &shapes_opt[0], shape_size);
+            trt_profile->setShapeValues(input_name.c_str(), nvinfer1::OptProfileSelector::kMAX, &shapes_max[0], shape_size);
           } else {  // execution tensor
             nvinfer1::Dims dims_min(dims), dims_opt(dims), dims_max(dims);
             for (int j = 0, end = nb_dims; j < end; ++j) {
@@ -1030,14 +1028,12 @@ common::Status TensorrtExecutionProvider::Provider_Compile(const std::vector<onn
               }
             }
 
-            if (dimension_update[input_name]) {
-              if (trt_profile == nullptr) {
-                trt_profile = trt_builder->createOptimizationProfile();
-              }
-              trt_profile->setDimensions(input_name.c_str(), nvinfer1::OptProfileSelector::kMIN, dims_min);
-              trt_profile->setDimensions(input_name.c_str(), nvinfer1::OptProfileSelector::kOPT, dims_opt);
-              trt_profile->setDimensions(input_name.c_str(), nvinfer1::OptProfileSelector::kMAX, dims_max);
+            if (trt_profile == nullptr) {
+              trt_profile = trt_builder->createOptimizationProfile();
             }
+            trt_profile->setDimensions(input_name.c_str(), nvinfer1::OptProfileSelector::kMIN, dims_min);
+            trt_profile->setDimensions(input_name.c_str(), nvinfer1::OptProfileSelector::kOPT, dims_opt);
+            trt_profile->setDimensions(input_name.c_str(), nvinfer1::OptProfileSelector::kMAX, dims_max);
           }
           ort.ReleaseTensorTypeAndShapeInfo(tensor_info);
         }


### PR DESCRIPTION
When we run one yolov3 model from customer on TRT EP, an issue was found regarding how to set profile for dynamic shape (sub)graphs.
The model has more than one dynamic shape inputs. When the shape of some inputs changed, current way is to set/update profiles only for the changed inputs. However engine build failed on the yolov3 model. It turns out all dynamic shape inputs profiles need to be set even though just one of the inputs changes. This PR fixed the issue. Need to check with Nvidia if that's the right behavior for the profile API.
