### PR TITLE
Fix warning as error for purposes of Code Coverage CI pipeline

### DIFF
--- a/onnxruntime/test/contrib_ops/bias_softmax_op_test.cc
+++ b/onnxruntime/test/contrib_ops/bias_softmax_op_test.cc
@@ -85,13 +85,13 @@ class BiasSoftmaxTester {
     in_data_.resize(len);
     for (int64_t b = 0; b < nbatches_; b++)
       for (int64_t i = 0; i < nelements_; i++)
-        in_data_[i] = allow_fill(i) ? -5.0f + 10.0f * ((float)rand() / (RAND_MAX)) : -10000.0f;
+        in_data_[i] = allow_fill(i) ? -5.0f + 10.0f * ((float)rand() / float(RAND_MAX)) : -10000.0f;
 
     len = nelements_ * nbatches_ / broadcast_size_;
     bias_data_.resize(len);
     for (int64_t b = 0; b < nbatches_ / broadcast_size_; b++)
       for (int64_t i = 0; i < nelements_; i++)
-        bias_data_[i] = allow_fill(i) ? -5.0f + 10.0f * ((float)rand() / (RAND_MAX)) : 0.0f;
+        bias_data_[i] = allow_fill(i) ? -5.0f + 10.0f * ((float)rand() / float(RAND_MAX)) : 0.0f;
   }
 
   void ComputeInternal() {

--- a/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
@@ -2,7 +2,7 @@ jobs:
 - job: CodeCoverage
   workspace:
     clean: all
-  timeoutInMinutes:  120
+  timeoutInMinutes:  150
   variables:
     skipComponentGovernanceDetection: true
   pool: 'Linux-CPU'


### PR DESCRIPTION
Fix warning treated as error causing Code Coverage CI pipeline to fail:
https://aiinfra.visualstudio.com/Lotus/_build?definitionId=845&_a=summary

With this fix it passes:
https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=133483&view=results