### PR TITLE
Add java API for AddSessionConfigEntry

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -676,6 +676,18 @@ public class OrtSession implements AutoCloseable {
     }
 
     /**
+     * Set a single session configuration entry as a pair of strings.
+     *
+     * @param configKey The config key string.
+     * @param configValue The config value string.
+     * @throws OrtException If there was an error in native code.
+     */
+    public void addConfigEntry(String configKey, String configValue) throws OrtException {
+      checkClosed();
+      addConfigEntry(OnnxRuntime.ortApiHandle, nativeHandle, configKey, configValue);
+    }
+
+    /**
      * Add CUDA as an execution backend, using device 0.
      *
      * @throws OrtException If there was an error in native code.
@@ -843,6 +855,9 @@ public class OrtSession implements AutoCloseable {
     private native void closeCustomLibraries(long[] nativeHandle);
 
     private native void closeOptions(long apiHandle, long nativeHandle);
+
+    private native void addConfigEntry(long apiHandle, long nativeHandle, String configKey, String configValue)
+        throws OrtException;
 
     /*
      * To use additional providers, you must build ORT with the extra providers enabled. Then call one of these

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -692,7 +692,7 @@ public class OrtSession implements AutoCloseable {
       configEntries.put(configKey, configValue);
     }
 
-    /** Returns an unmodifiable map contains all session configuration entries. */
+    /** Returns an unmodifiable view of the map contains all session configuration entries. */
     public Map<String, String> getConfigEntries() {
       checkClosed();
       return Collections.unmodifiableMap(configEntries);

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -7,6 +7,7 @@ package ai.onnxruntime;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -495,12 +496,15 @@ public class OrtSession implements AutoCloseable {
 
     private final List<Long> customLibraryHandles;
 
+    private Map<String, String> configEntries;
+
     private boolean closed = false;
 
     /** Create an empty session options. */
     public SessionOptions() {
       nativeHandle = createOptions(OnnxRuntime.ortApiHandle);
       customLibraryHandles = new ArrayList<>();
+      configEntries = new LinkedHashMap<String, String>();
     }
 
     /** Closes the session options, releasing any memory acquired. */
@@ -676,7 +680,7 @@ public class OrtSession implements AutoCloseable {
     }
 
     /**
-     * Set a single session configuration entry as a pair of strings.
+     * Adds a single session configuration entry as a pair of strings.
      *
      * @param configKey The config key string.
      * @param configValue The config value string.
@@ -685,6 +689,13 @@ public class OrtSession implements AutoCloseable {
     public void addConfigEntry(String configKey, String configValue) throws OrtException {
       checkClosed();
       addConfigEntry(OnnxRuntime.ortApiHandle, nativeHandle, configKey, configValue);
+      configEntries.put(configKey, configValue);
+    }
+
+    /** Returns an unmodifiable map contains all session configuration entries. */
+    public Map<String, String> getConfigEntries() {
+      checkClosed();
+      return Collections.unmodifiableMap(configEntries);
     }
 
     /**

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -856,7 +856,8 @@ public class OrtSession implements AutoCloseable {
 
     private native void closeOptions(long apiHandle, long nativeHandle);
 
-    private native void addConfigEntry(long apiHandle, long nativeHandle, String configKey, String configValue)
+    private native void addConfigEntry(
+        long apiHandle, long nativeHandle, String configKey, String configValue)
         throws OrtException;
 
     /*

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -297,6 +297,23 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_closeC
 
 /*
  * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    addConfigEntry
+ * Signature: (JJLjava/lang/String;Ljava/lang/String;)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_addConfigEntry
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong optionsHandle, jstring configKey, jstring configValue) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  OrtSessionOptions* options = (OrtSessionOptions*) optionsHandle;
+  const char* configKeyStr = (*jniEnv)->GetStringUTFChars(jniEnv, configKey, NULL);
+  const char* configValueStr = (*jniEnv)->GetStringUTFChars(jniEnv, configValue, NULL);
+  checkOrtStatus(jniEnv,api,api->AddSessionConfigEntry(options, configKeyStr, configValueStr));
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv, configKey, configKeyStr);
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv, configValue, configValueStr);
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
  * Method:    addCPU
  * Signature: (JJI)V
  */

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -852,6 +852,13 @@ public class InferenceTest {
         options.setLoggerId("monkeys");
         options.setSessionLogLevel(OrtLoggingLevel.ORT_LOGGING_LEVEL_FATAL);
         options.setSessionLogVerbosityLevel(5);
+        options.addConfigEntry("key", "value");
+        try {
+          options.addConfigEntry("", "invalid key");
+          fail("Add config entry with empty key should have failed");
+        } catch (OrtException e) {
+          assertTrue(e.getMessage().contains("Config key is empty"));
+        }
         try (OrtSession session = env.createSession(modelPath, options)) {
           String inputName = session.getInputNames().iterator().next();
           Map<String, OnnxTensor> container = new HashMap<>();

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -858,6 +858,7 @@ public class InferenceTest {
           fail("Add config entry with empty key should have failed");
         } catch (OrtException e) {
           assertTrue(e.getMessage().contains("Config key is empty"));
+          assertEquals(OrtException.OrtErrorCode.ORT_INVALID_ARGUMENT, e.getCode());
         }
         try (OrtSession session = env.createSession(modelPath, options)) {
           String inputName = session.getInputNames().iterator().next();

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -852,7 +852,10 @@ public class InferenceTest {
         options.setLoggerId("monkeys");
         options.setSessionLogLevel(OrtLoggingLevel.ORT_LOGGING_LEVEL_FATAL);
         options.setSessionLogVerbosityLevel(5);
+        Map<String, String> configEntries = options.getConfigEntries();
+        assertTrue(configEntries.isEmpty());
         options.addConfigEntry("key", "value");
+        assertEquals("value", configEntries.get("key"));
         try {
           options.addConfigEntry("", "invalid key");
           fail("Add config entry with empty key should have failed");


### PR DESCRIPTION
**Description**: Add java API for AddSessionConfigEntry
For better support of ORT file format using java on Android

**Motivation and Context**
- For Android, we cannot get absolute path of the model (as an App raw resource), there is a workaround to copy model file to a temp file and use the path of the temp file, however you will need to do this every time. Using the byte array to create session is more efficient. For ORT format, this will require the "session.load_model_format" session config to be set to "ORT". So it is necessary to add the java API of AddSessionConfigEntry.
