### PR TITLE
Handle missing initializers in allocation planner to fix crashes with DML provider

### DIFF
--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -148,7 +148,7 @@ class PlannerImpl {
     // This is initialized to -1 to ensure that if ProcessDef is somehow not called, planning
     // will fail more cleanly.  This is also used as a temporary workaround to detect the
     // case that the DML provider has removed initilizers from the graph during partitioning. 
-    // Removing of initilizers is a temporary measure needed to limit the number of copies of 
+    // Removing initializers is a temporary measure needed to limit the number of copies of 
     // tensors in GPU memory.
     OrtValueIndex reused_buffer_index = -1;  // index of original buffer to reuse
   };


### PR DESCRIPTION
This addresses crashes in certain models while creation sessions with the DML provider.

The problem is related to an optimization for memory size in which the DML graph partitioner transfers protobuf initializers out of the graph to manage itself.  The presence of the initializer though is needed for the allocation planner to call ProcessDef for that value and initialize “reused_buffer_index".  With that field left initialized to zero, the planner thinks it’s decided to reuse the same buffer for that initializer and for another value at index zero, causing that buffer to be freed too many times / too early.

The fix is to initialize reused_buffer_index to -1 and detect this case, as well as make the allocation planner a bit more brittle.