### PR TITLE
Place Shape's output in CPU memory

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/shape_op.cc
+++ b/onnxruntime/core/providers/cuda/tensor/shape_op.cc
@@ -13,8 +13,9 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     1, 12,
     kCudaExecutionProvider,
     KernelDefBuilder()
-        .OutputMemoryType<OrtMemTypeCPUOutput>(0)
-        .TypeConstraint("T",  DataTypeImpl::AllFixedSizeTensorTypes())
+        // properly force CPU/GPU synch inside the kernel
+        .OutputMemoryType<OrtMemTypeCPUInput>(0)
+        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>()),
     Shape);
 
@@ -24,8 +25,9 @@ ONNX_OPERATOR_KERNEL_EX(
     13,
     kCudaExecutionProvider,
     KernelDefBuilder()
-        .OutputMemoryType<OrtMemTypeCPUOutput>(0)
-        .TypeConstraint("T",  DataTypeImpl::AllFixedSizeTensorTypes())
+        // properly force CPU/GPU synch inside the kernel
+        .OutputMemoryType<OrtMemTypeCPUInput>(0)
+        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>()),
     Shape);
 

--- a/orttraining/orttraining/core/framework/gradient_graph_builder.h
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.h
@@ -60,7 +60,6 @@ static std::unordered_map<std::string, std::unordered_set<size_t>>
         {"Where", {0}},
         {"Range", {0, 1, 2}},
         {"Tile", {1}},
-        {"NonZero", {0}},
         {"BroadcastGradientArgs", {0, 1}}};
 
 class GradientGraphBuilder {


### PR DESCRIPTION
**Description**: 
Shape's output was mistakenly placed at CUDA_PINNED memory. The following memcpy node was wrongly using the async version of cudaMemcpy. 
Instead, the output should be placed in CPU memory. 

![image](https://user-images.githubusercontent.com/9906745/93833838-a3802180-fc2e-11ea-8bd2-114ebba4ca6f.png)
