### PR TITLE
Fix possible ios build break after update to Xcode 12

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -581,7 +581,7 @@ Status Node::LoadFromOrtFormat(const onnxruntime::experimental::fbs::Node& fbs_n
           bool check_parent_graph = false) -> Status {
     ORT_RETURN_IF(nullptr == fbs_node_arg_names, "fbs_node_arg_names cannot be null");
     node_args.reserve(fbs_node_arg_names->size());
-    for (const auto& node_arg_name : *fbs_node_arg_names) {
+    for (const auto* node_arg_name : *fbs_node_arg_names) {
       ORT_RETURN_IF(nullptr == node_arg_name, "node_arg_name cannot be null");
       auto* node_arg = check_parent_graph ? graph_->GetNodeArgIncludingParentGraphs(node_arg_name->str())
                                           : graph_->GetNodeArg(node_arg_name->str());

--- a/onnxruntime/core/graph/graph_flatbuffers_utils.cc
+++ b/onnxruntime/core/graph/graph_flatbuffers_utils.cc
@@ -292,7 +292,7 @@ Status LoadInitializerOrtFormat(const fbs::Tensor& fbs_tensor,
     ORT_RETURN_IF(nullptr == fbs_str_data, "Missing string data for initializer. Invalid ORT format model.");
     auto mutable_str_data = initializer.mutable_string_data();
     mutable_str_data->Reserve(fbs_str_data->size());
-    for (const auto& fbs_str : *fbs_str_data) {
+    for (const auto* fbs_str : *fbs_str_data) {
       mutable_str_data->Add(fbs_str->str());
     }
   } else {

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1546,10 +1546,13 @@ def build_protoc_for_host(cmake_path, source_dir, build_dir, args):
             cmd_args += ['-T', 'host=x64']
     elif is_macOS():
         if args.use_xcode:
-            cmd_args += [
-                '-G', 'Xcode',
-                '-DCMAKE_OSX_ARCHITECTURES=x86_64'
-            ]
+            cmd_args += ['-G', 'Xcode']
+            # CMake < 3.18 has a bug setting system arch to arm64 (if not specified) for Xcode 12,
+            # protoc for host should be built using host architecture
+            # Explicitly specify the CMAKE_OSX_ARCHITECTURES for x86_64 Mac.
+            import platform
+            if platform.machine() == 'x86_64':
+                cmd_args += ['-DCMAKE_OSX_ARCHITECTURES=x86_64']
 
     run_subprocess(cmd_args, cwd=protoc_build_dir)
     # Build step

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1546,7 +1546,10 @@ def build_protoc_for_host(cmake_path, source_dir, build_dir, args):
             cmd_args += ['-T', 'host=x64']
     elif is_macOS():
         if args.use_xcode:
-            cmd_args += ['-G', 'Xcode']
+            cmd_args += [
+                '-G', 'Xcode',
+                '-DCMAKE_OSX_ARCHITECTURES=x86_64'
+            ]
 
     run_subprocess(cmd_args, cwd=protoc_build_dir)
     # Build step


### PR DESCRIPTION
**Description**: Fix ios build break after update to Xcode 12

**Motivation and Context**
- After update to Xcode 12 (available from this week), the active arch is always set to arm64 (CMake issue https://gitlab.kitware.com/cmake/cmake/-/issues/20893), this will cause the compile failure for host_protoc (should be built using x86_64), in order not to force user to update to latest non-release CMake (3.18), explicitly set the OSX_ARCH to x86_64 for host_protoc

- Also fixed 2 minor compile warning related to ort flatbuffers (only shows after update to Xcode 12) as seen here, https://github.com/microsoft/onnxruntime/pull/5223#discussion_r492280294




