### PR TITLE
Update build.md for building using Xcode 12 on Mac

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -58,12 +58,18 @@ Open Developer Command Prompt for Visual Studio version you are going to use. Th
 The default Windows CMake Generator is Visual Studio 2017, but you can also use the newer Visual Studio 2019 by passing `--cmake_generator "Visual Studio 16 2019"` to `.\build.bat`
 
 
-#### Linux/Mac OS X
+#### Linux/macOS
 ```
 ./build.sh --config RelWithDebInfo --build_shared_lib --parallel
 ```
 By default, ORT is configured to be built for a minimum target Mac OS X version of 10.12.
 The shared library in the release Nuget(s) and the Python wheel may be installed on Mac OS X versions of 10.12+.
+
+##### Bulid using Xcode 12 for x86_64 macOS
+```
+./build.sh --config RelWithDebInfo --build_shared_lib --parallel \
+           --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=x86_64
+```
 
 #### Notes
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -62,12 +62,12 @@ The default Windows CMake Generator is Visual Studio 2017, but you can also use 
 ```
 ./build.sh --config RelWithDebInfo --build_shared_lib --parallel
 ```
-By default, ORT is configured to be built for a minimum target Mac OS X version of 10.12.
-The shared library in the release Nuget(s) and the Python wheel may be installed on Mac OS X versions of 10.12+.
+By default, ORT is configured to be built for a minimum target macOS version of 10.12.
+The shared library in the release Nuget(s) and the Python wheel may be installed on macOS versions of 10.12+.
 
 ##### Bulid using Xcode 12 for x86_64 macOS
 ```
-./build.sh --config RelWithDebInfo --build_shared_lib --parallel \
+./build.sh --config RelWithDebInfo --build_shared_lib --parallel --use_xcode \
            --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=x86_64
 ```
 
@@ -95,7 +95,7 @@ The shared library in the release Nuget(s) and the Python wheel may be installed
 |-----------|:------------:|:------------:|:------------:|:------------:|
 |Windows    | YES          | YES          |  YES         | YES          |
 |Linux      | YES          | YES          |  YES         | YES          |
-|Mac OS X   | NO           | YES          |  NO          | NO           |
+|macOS      | NO           | YES          |  NO          | NO           |
 
 ### Environments
 
@@ -104,7 +104,7 @@ The shared library in the release Nuget(s) and the Python wheel may be installed
 |Windows 10   | YES          | YES         | VS2019 through the latest VS2015 are supported |
 |Windows 10 <br/> Subsystem for Linux | YES         | NO        |         |
 |Ubuntu 16.x  | YES          | YES         | Also supported on ARM32v7 (experimental) |
-|Mac OS X  | YES          | NO         |    |
+|macOS        | YES          | NO         |    |
 
 GCC 4.x and below are not supported.
 
@@ -114,7 +114,7 @@ GCC 4.x and below are not supported.
 |-------------|:------------:|:----------------:|:----------------:|
 |Windows 10   | YES          | Not tested       | Not tested       |
 |Linux        | NO           | YES(gcc>=4.8)    | Not tested       |
-|Mac OS X     | NO           | Not tested       | YES (Minimum version required not ascertained)|
+|macOS        | NO           | Not tested       | YES (Minimum version required not ascertained)|
 
 
 ---
@@ -611,7 +611,7 @@ The Vitis-AI execution provider is only supported on Linux.
 .\build.bat --use_openmp
 ```
 
-##### Linux/Mac OS X
+##### Linux/macOS
 ```
 ./build.sh --use_openmp
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -62,14 +62,20 @@ The default Windows CMake Generator is Visual Studio 2017, but you can also use 
 ```
 ./build.sh --config RelWithDebInfo --build_shared_lib --parallel
 ```
+##### macOS
 By default, ORT is configured to be built for a minimum target macOS version of 10.12.
 The shared library in the release Nuget(s) and the Python wheel may be installed on macOS versions of 10.12+.
 
-##### Bulid using Xcode 12 for x86_64 macOS
-```
-./build.sh --config RelWithDebInfo --build_shared_lib --parallel --use_xcode \
-           --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=x86_64
-```
+If you would like to use [Xcode](https://developer.apple.com/xcode/) to build the onnxruntime for x86_64 macOS, use
+* With Xcode 11
+   ```
+   ./build.sh --config RelWithDebInfo --build_shared_lib --parallel --use_xcode
+   ```
+* With Xcode 12
+   ```
+   ./build.sh --config RelWithDebInfo --build_shared_lib --parallel --use_xcode \
+              --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=x86_64
+   ```
 
 #### Notes
 


### PR DESCRIPTION
**Description**: Update build.md for building using Xcode 12 on Mac

**Motivation and Context**
- Xcode 12 (recently released in 09/2020)  and CMake <3.18 will mark CMAKE_OSX_ARCHITECTURES default to arm64 (if CMAKE_OSX_ARCHITECTURES is not specified), this will cause build break for macOS x86_64 build
- Cmake issue, https://gitlab.kitware.com/cmake/cmake/-/issues/20893
- A similar issue fixed for iOS ORT build, https://github.com/microsoft/onnxruntime/pull/5246
- Unlike the iOS issue above, this issue can be easily worked around using --cmake_extra_defines of the building script, so we are only updating the build.md

