### PR TITLE
Disable a few tests that run too long(1 hour) in debug mode

### DIFF
--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -207,7 +207,9 @@ add_winml_test(
   LIBS winml_test_common ${winml_test_image_libs}
 )
 target_precompiled_header(winml_test_image testPch.h)
-
+if(onnxruntime_RUN_MODELTEST_IN_DEBUG_MODE)
+  target_compile_definitions(winml_test_image PUBLIC -DRUN_MODELTEST_IN_DEBUG_MODE)
+endif()
 target_delayload(winml_test_image d3d12.dll api-ms-win-core-file-l1-2-2.dll api-ms-win-core-synch-l1-2-1.dll)
 if (EXISTS ${dxcore_header})
   target_delayload(winml_test_image ext-ms-win-dxcore-l1-*.dll)

--- a/winml/test/image/imagetests.cpp
+++ b/winml/test/image/imagetests.cpp
@@ -347,6 +347,7 @@ INSTANTIATE_TEST_SUITE_P(MnistInputOutput, MnistImageTest,
         std::make_pair(L"RGB_5.png", 5)
     ));
 
+#if defined(NDEBUG) || defined(RUN_MODELTEST_IN_DEBUG_MODE)
 typedef std::tuple<std::tuple<std::wstring, ModelInputOutputType, std::wstring>, std::wstring, std::wstring, InputImageSource, EvaluationStrategy, OutputBindingStrategy, LearningModelDeviceKind> ImageTestParamTuple;
 struct ImageTestParam {
     std::wstring model_file_name, model_pixel_format, image_file_name, input_pixel_format;
@@ -422,6 +423,7 @@ INSTANTIATE_TEST_SUITE_P(ImageTest, ImageTest,
         testing::Values(Bound, Unbound),
         testing::Values(LearningModelDeviceKind::DirectX, LearningModelDeviceKind::Cpu)
     ));
+
 
 typedef std::tuple<std::tuple<std::wstring, ModelInputOutputType, std::vector<std::wstring>, int, bool>, OutputBindingStrategy, EvaluationStrategy, VideoFrameSource, VideoFrameSource, LearningModelDeviceKind> BatchTestParamTuple;
 struct BatchTestParam {
@@ -550,6 +552,8 @@ INSTANTIATE_TEST_SUITE_P(BatchTest, BatchTest,
         testing::Values(FromSoftwareBitmap, FromDirect3DSurface, FromUnsupportedD3DSurface),
         testing::Values(LearningModelDeviceKind::DirectX, LearningModelDeviceKind::Cpu)
     ));
+#endif
+
 TEST_F(ImageTests, LoadBindEvalModelWithoutImageMetadata) {
     GPUTEST;
 


### PR DESCRIPTION
**Description**:

Disable a few tests that run too long(1 hour) in debug mode

**Motivation and Context**
- Why is this change required? What problem does it solve?

It is causing a lot of pipeline failures. 

- If it fixes an open issue, please link to the issue here.
