### PR TITLE
Fix inbox telemetry 

### DIFF
--- a/cmake/onnxruntime_common.cmake
+++ b/cmake/onnxruntime_common.cmake
@@ -135,3 +135,7 @@ if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     target_link_libraries(onnxruntime_common rt)
   endif()
 endif()
+
+if (onnxruntime_WINML_NAMESPACE_OVERRIDE STREQUAL "Windows")
+  target_compile_definitions(onnxruntime_common PRIVATE "BUILD_INBOX=1")
+endif()

--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -102,7 +102,10 @@ void WindowsTelemetry::LogProcessInfo() const {
   // did we already log the process info?  we only need to log it once
   if (process_info_logged.exchange(true))
     return;
-
+  bool isRedist = false;
+#if WINML_ROOT_NS == Microsoft
+  isRedist = true;
+#endif
   TraceLoggingWrite(telemetry_provider_handle,
                     "ProcessInfo",
                     TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
@@ -111,7 +114,7 @@ void WindowsTelemetry::LogProcessInfo() const {
                     // Telemetry info
                     TraceLoggingUInt8(0, "schemaVersion"),
                     TraceLoggingString(ORT_VERSION, "runtimeVersion"),
-                    TraceLoggingBool(true, "isRedist"));
+                    TraceLoggingBool(isRedist, "isRedist"));
 
   process_info_logged = true;
 }

--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -102,9 +102,9 @@ void WindowsTelemetry::LogProcessInfo() const {
   // did we already log the process info?  we only need to log it once
   if (process_info_logged.exchange(true))
     return;
-  bool isRedist = false;
-#if WINML_ROOT_NS == Microsoft
-  isRedist = true;
+  bool isRedist = true;
+#if BUILD_INBOX
+  isRedist = false;
 #endif
   TraceLoggingWrite(telemetry_provider_handle,
                     "ProcessInfo",


### PR DESCRIPTION
Inbox builds shouldn't have Onnxruntime telemetry reporting "isRedist" as true.

This change makes it so that inbox builds report "isRedist" as false.

If onnxruntime_WINML_NAMESPACE_OVERRIDE  equals "Windows" then it should be building inbox. I am following the same format as here : https://github.com/microsoft/onnxruntime/blob/75d994f1940444022bc22127c87f56636df884a6/cmake/winml.cmake#L210