### PR TITLE
rename CUDA/CUDA_PINNED to GPU/GPU_PINNED to share the code between Nvidia and AMD

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtAllocator.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtAllocator.shared.cs
@@ -22,8 +22,8 @@ namespace Microsoft.ML.OnnxRuntime
     public enum OrtMemType
     {
         CpuInput = -2,                      // Any CPU memory used by non-CPU execution provider
-        CpuOutput = -1,                     // CPU accessible memory outputted by non-CPU execution provider, i.e. CUDA_PINNED
-        Cpu = CpuOutput,                    // temporary CPU accessible memory allocated by non-CPU execution provider, i.e. CUDA_PINNED
+        CpuOutput = -1,                     // CPU accessible memory outputted by non-CPU execution provider, i.e. GPU_PINNED
+        Cpu = CpuOutput,                    // temporary CPU accessible memory allocated by non-CPU execution provider, i.e. GPU_PINNED
         Default = 0,                        // the default allocator for execution provider
     }
 
@@ -160,7 +160,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// Predefined utf8 encoded allocator names. Use them to construct an instance of
         /// OrtMemoryInfo to avoid UTF-16 to UTF-8 conversion costs.
         /// </summary>
-        public static readonly byte[] allocatorCUDA_PINNED = Encoding.UTF8.GetBytes("CudaPinned" + Char.MinValue);
+        public static readonly byte[] allocatorCUDA_PINNED = Encoding.UTF8.GetBytes("GpuPinned" + Char.MinValue);
         /// <summary>
         /// Create an instance of OrtMemoryInfo according to the specification
         /// Memory info instances are usually used to get a handle of a native allocator

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtAllocator.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtAllocator.shared.cs
@@ -155,12 +155,12 @@ namespace Microsoft.ML.OnnxRuntime
         /// Predefined utf8 encoded allocator names. Use them to construct an instance of
         /// OrtMemoryInfo to avoid UTF-16 to UTF-8 conversion costs.
         /// </summary>
-        public static readonly byte[] allocatorCUDA = Encoding.UTF8.GetBytes("Cuda" + Char.MinValue);
+        public static readonly byte[] allocatorGPU = Encoding.UTF8.GetBytes("Gpu" + Char.MinValue);
         /// <summary>
         /// Predefined utf8 encoded allocator names. Use them to construct an instance of
         /// OrtMemoryInfo to avoid UTF-16 to UTF-8 conversion costs.
         /// </summary>
-        public static readonly byte[] allocatorCUDA_PINNED = Encoding.UTF8.GetBytes("GpuPinned" + Char.MinValue);
+        public static readonly byte[] allocatorGPU_PINNED = Encoding.UTF8.GetBytes("GpuPinned" + Char.MinValue);
         /// <summary>
         /// Create an instance of OrtMemoryInfo according to the specification
         /// Memory info instances are usually used to get a handle of a native allocator

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
@@ -1548,7 +1548,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
         void TestCUDAAllocatorInternal(InferenceSession session)
         {
             int device_id = 0;
-            using (var info_cuda = new OrtMemoryInfo(OrtMemoryInfo.allocatorCUDA, OrtAllocatorType.ArenaAllocator, device_id, OrtMemType.Default))
+            using (var info_cuda = new OrtMemoryInfo(OrtMemoryInfo.allocatorGPU, OrtAllocatorType.ArenaAllocator, device_id, OrtMemType.Default))
             {
                 Assert.Equal("Gpu", info_cuda.Name);
                 Assert.Equal(device_id, info_cuda.Id);

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
@@ -1550,7 +1550,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             int device_id = 0;
             using (var info_cuda = new OrtMemoryInfo(OrtMemoryInfo.allocatorCUDA, OrtAllocatorType.ArenaAllocator, device_id, OrtMemType.Default))
             {
-                Assert.Equal("Cuda", info_cuda.Name);
+                Assert.Equal("Gpu", info_cuda.Name);
                 Assert.Equal(device_id, info_cuda.Id);
                 Assert.Equal(OrtAllocatorType.ArenaAllocator, info_cuda.GetAllocatorType());
                 Assert.Equal(OrtMemType.Default, info_cuda.GetMemoryType());

--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -35,6 +35,7 @@ struct OrtArenaCfg {
 
 namespace onnxruntime {
 constexpr const char* CPU = "Cpu";
+constexpr const char* CUDA = "Cuda"; // This is used for device type
 constexpr const char* GPU = "Gpu";
 constexpr const char* GPU_PINNED = "GpuPinned";
 constexpr const char* DML = "DML";

--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -35,8 +35,8 @@ struct OrtArenaCfg {
 
 namespace onnxruntime {
 constexpr const char* CPU = "Cpu";
-constexpr const char* CUDA = "Cuda";
-constexpr const char* CUDA_PINNED = "CudaPinned";
+constexpr const char* GPU = "Gpu";
+constexpr const char* GPU_PINNED = "GpuPinned";
 constexpr const char* DML = "DML";
 constexpr const char* OpenVINO_CPU = "OpenVINO_CPU";
 constexpr const char* OpenVINO_GPU = "OpenVINO_GPU";

--- a/include/onnxruntime/core/framework/ortdevice.h
+++ b/include/onnxruntime/core/framework/ortdevice.h
@@ -19,7 +19,7 @@ struct OrtDevice {
   struct MemType {
     // Pre-defined memory types.
     static const MemoryType DEFAULT = 0;
-    static const MemoryType CUDA_PINNED = 1;
+    static const MemoryType GPU_PINNED = 1;
     static const MemoryType HIP_PINNED = 2;
   };
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -329,8 +329,8 @@ typedef enum OrtAllocatorType {
 // Whenever this struct is updated, please also update the MakeKey function in onnxruntime / core / framework / execution_provider.cc
 typedef enum OrtMemType {
   OrtMemTypeCPUInput = -2,              ///< Any CPU memory used by non-CPU execution provider
-  OrtMemTypeCPUOutput = -1,             ///< CPU accessible memory outputted by non-CPU execution provider, i.e. CUDA_PINNED
-  OrtMemTypeCPU = OrtMemTypeCPUOutput,  ///< Temporary CPU accessible memory allocated by non-CPU execution provider, i.e. CUDA_PINNED
+  OrtMemTypeCPUOutput = -1,             ///< CPU accessible memory outputted by non-CPU execution provider, i.e. GPU_PINNED
+  OrtMemTypeCPU = OrtMemTypeCPUOutput,  ///< Temporary CPU accessible memory allocated by non-CPU execution provider, i.e. GPU_PINNED
   OrtMemTypeDefault = 0,                ///< The default allocator for execution provider
 } OrtMemType;
 

--- a/onnxruntime/core/framework/allocator.cc
+++ b/onnxruntime/core/framework/allocator.cc
@@ -120,13 +120,13 @@ ORT_API_STATUS_IMPL(OrtApis::CreateMemoryInfo, _In_ const char* name1, enum OrtA
                     enum OrtMemType mem_type1, _Outptr_ OrtMemoryInfo** out) {
   if (strcmp(name1, onnxruntime::CPU) == 0) {
     *out = new OrtMemoryInfo(onnxruntime::CPU, type, OrtDevice(), id1, mem_type1);
-  } else if (strcmp(name1, onnxruntime::CUDA) == 0) {
+  } else if (strcmp(name1, onnxruntime::GPU) == 0) {
     *out = new OrtMemoryInfo(
-        onnxruntime::CUDA, type, OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, static_cast<OrtDevice::DeviceId>(id1)), id1,
+        onnxruntime::GPU, type, OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, static_cast<OrtDevice::DeviceId>(id1)), id1,
         mem_type1);
-  } else if (strcmp(name1, onnxruntime::CUDA_PINNED) == 0) {
+  } else if (strcmp(name1, onnxruntime::GPU_PINNED) == 0) {
     *out = new OrtMemoryInfo(
-        onnxruntime::CUDA_PINNED, type, OrtDevice(OrtDevice::CPU, OrtDevice::MemType::CUDA_PINNED, static_cast<OrtDevice::DeviceId>(id1)),
+        onnxruntime::GPU_PINNED, type, OrtDevice(OrtDevice::CPU, OrtDevice::MemType::GPU_PINNED, static_cast<OrtDevice::DeviceId>(id1)),
         id1, mem_type1);
   } else if (strcmp(name1, onnxruntime::OpenVINO_GPU) == 0) {
     *out = new OrtMemoryInfo(

--- a/onnxruntime/core/providers/cuda/cuda_allocator.h
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.h
@@ -56,7 +56,7 @@ class CUDAPinnedAllocator : public IAllocator {
   CUDAPinnedAllocator(OrtDevice::DeviceId device_id, const char* name)
       : IAllocator(
             OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
-                          OrtDevice(OrtDevice::CPU, OrtDevice::MemType::CUDA_PINNED, device_id),
+                          OrtDevice(OrtDevice::CPU, OrtDevice::MemType::GPU_PINNED, device_id),
                           device_id, OrtMemTypeCPUOutput)) {}
 
   void* Alloc(size_t size) override;

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -99,7 +99,7 @@ AllocatorPtr CUDAExecutionProvider::CreateCudaAllocator(OrtDevice::DeviceId devi
   if (external_allocator_info.UseExternalAllocator()) {
     AllocatorCreationInfo default_memory_info(
         [external_allocator_info](OrtDevice::DeviceId id) {
-          return std::make_unique<CUDAExternalAllocator>(id, CUDA, external_allocator_info.alloc, external_allocator_info.free, external_allocator_info.empty_cache);
+          return std::make_unique<CUDAExternalAllocator>(id, onnxruntime::GPU, external_allocator_info.alloc, external_allocator_info.free, external_allocator_info.empty_cache);
         },
         device_id,
         false);
@@ -109,7 +109,7 @@ AllocatorPtr CUDAExecutionProvider::CreateCudaAllocator(OrtDevice::DeviceId devi
   } else {
     AllocatorCreationInfo default_memory_info(
         [](OrtDevice::DeviceId id) {
-          return std::make_unique<CUDAAllocator>(id, CUDA);
+          return std::make_unique<CUDAAllocator>(id, onnxruntime::GPU);
         },
         device_id,
         true,
@@ -2312,7 +2312,7 @@ void CUDAExecutionProvider::RegisterAllocator(std::shared_ptr<AllocatorManager> 
   if (nullptr == cuda_pinned_alloc) {
     AllocatorCreationInfo pinned_memory_info(
         [](OrtDevice::DeviceId device_id) {
-          return std::make_unique<CUDAPinnedAllocator>(device_id, CUDA_PINNED);
+          return std::make_unique<CUDAPinnedAllocator>(device_id, onnxruntime::GPU_PINNED);
         },
         DEFAULT_CPU_ALLOCATOR_DEVICE_ID);
 

--- a/onnxruntime/core/providers/cuda/gpu_data_transfer.cc
+++ b/onnxruntime/core/providers/cuda/gpu_data_transfer.cc
@@ -33,8 +33,8 @@ GPUDataTransfer::~GPUDataTransfer() {
 }
 
 bool GPUDataTransfer::CanCopy(const OrtDevice& src_device, const OrtDevice& dst_device) const {
-  return src_device.Type() == OrtDevice::GPU || src_device.MemType() == OrtDevice::MemType::CUDA_PINNED ||
-         dst_device.Type() == OrtDevice::GPU || dst_device.MemType() == OrtDevice::MemType::CUDA_PINNED;
+  return src_device.Type() == OrtDevice::GPU || src_device.MemType() == OrtDevice::MemType::GPU_PINNED ||
+         dst_device.Type() == OrtDevice::GPU || dst_device.MemType() == OrtDevice::MemType::GPU_PINNED;
 }
 
 common::Status GPUDataTransfer::CopyTensor(const Tensor& src, Tensor& dst, int exec_queue_id) const {
@@ -46,7 +46,7 @@ common::Status GPUDataTransfer::CopyTensor(const Tensor& src, Tensor& dst, int e
   auto& dst_device = dst.Location().device;
 
   if (dst_device.Type() == OrtDevice::GPU) {
-    if (src_device.Type() == OrtDevice::CPU && src_device.MemType() == OrtDevice::MemType::CUDA_PINNED) {
+    if (src_device.Type() == OrtDevice::CPU && src_device.MemType() == OrtDevice::MemType::GPU_PINNED) {
       // copy from pinned memory to GPU, this is non-blocking
       CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(dst_data, src_data, bytes, cudaMemcpyHostToDevice, GetStream(exec_queue_id)));
     } else if (src_device.Type() == OrtDevice::GPU) {
@@ -61,7 +61,7 @@ common::Status GPUDataTransfer::CopyTensor(const Tensor& src, Tensor& dst, int e
       CUDA_RETURN_IF_ERROR(cudaStreamSynchronize(GetStream(kCudaStreamDefault)));
     }
   } else if (src_device.Type() == OrtDevice::GPU) {
-    if (dst_device.Type() == OrtDevice::CPU && dst_device.MemType() == OrtDevice::MemType::CUDA_PINNED) {
+    if (dst_device.Type() == OrtDevice::CPU && dst_device.MemType() == OrtDevice::MemType::GPU_PINNED) {
       // copying from GPU to pinned memory, this is non-blocking
       CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(dst_data, src_data, bytes, cudaMemcpyDeviceToHost, GetStream(exec_queue_id)));
     } else {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -128,7 +128,7 @@ void MIGraphXExecutionProvider::RegisterAllocator(std::shared_ptr<AllocatorManag
   allocator_ = allocator_manager->GetAllocator(device_id_, OrtMemTypeDefault);
   if (nullptr == allocator_) {
     AllocatorCreationInfo default_memory_info(
-        [](OrtDevice::DeviceId device_id) { return CreateROCMAllocator(device_id, onnxruntime::CUDA); }, device_id_);
+        [](OrtDevice::DeviceId device_id) { return CreateROCMAllocator(device_id, onnxruntime::GPU); }, device_id_);
     allocator_ = CreateAllocator(default_memory_info);
     allocator_manager->InsertAllocator(allocator_);
   }
@@ -141,7 +141,7 @@ void MIGraphXExecutionProvider::RegisterAllocator(std::shared_ptr<AllocatorManag
   if (nullptr == hip_pinned_alloc) {
     AllocatorCreationInfo pinned_allocator_info(
         [](OrtDevice::DeviceId device_id) {
-          return CreateROCMPinnedAllocator(device_id, onnxruntime::CUDA_PINNED);
+          return CreateROCMPinnedAllocator(device_id, onnxruntime::GPU_PINNED);
         },
         DEFAULT_CPU_ALLOCATOR_DEVICE_ID);
     hip_pinned_alloc = CreateAllocator(pinned_allocator_info);

--- a/onnxruntime/core/providers/rocm/gpu_data_transfer.cc
+++ b/onnxruntime/core/providers/rocm/gpu_data_transfer.cc
@@ -33,8 +33,8 @@ GPUDataTransfer::~GPUDataTransfer() {
 }
 
 bool GPUDataTransfer::CanCopy(const OrtDevice& src_device, const OrtDevice& dst_device) const {
-  return src_device.Type() == OrtDevice::GPU || src_device.MemType() == OrtDevice::MemType::CUDA_PINNED ||
-         dst_device.Type() == OrtDevice::GPU || dst_device.MemType() == OrtDevice::MemType::CUDA_PINNED;
+  return src_device.Type() == OrtDevice::GPU || src_device.MemType() == OrtDevice::MemType::GPU_PINNED ||
+         dst_device.Type() == OrtDevice::GPU || dst_device.MemType() == OrtDevice::MemType::GPU_PINNED;
 }
 
 common::Status GPUDataTransfer::CopyTensor(const Tensor& src, Tensor& dst, int exec_queue_id) const {
@@ -46,7 +46,7 @@ common::Status GPUDataTransfer::CopyTensor(const Tensor& src, Tensor& dst, int e
   auto& dst_device = dst.Location().device;
 
   if (dst_device.Type() == OrtDevice::GPU) {
-    if (src_device.Type() == OrtDevice::CPU && src_device.MemType() == OrtDevice::MemType::CUDA_PINNED) {
+    if (src_device.Type() == OrtDevice::CPU && src_device.MemType() == OrtDevice::MemType::GPU_PINNED) {
       // copy from pinned memory to GPU, this is non-blocking
       HIP_RETURN_IF_ERROR(hipMemcpyAsync(dst_data, src_data, bytes, hipMemcpyHostToDevice, GetStream(exec_queue_id)));
     } else if (src_device.Type() == OrtDevice::GPU) {
@@ -61,7 +61,7 @@ common::Status GPUDataTransfer::CopyTensor(const Tensor& src, Tensor& dst, int e
       HIP_RETURN_IF_ERROR(hipStreamSynchronize(GetStream(kHipStreamDefault)));
     }
   } else if (src_device.Type() == OrtDevice::GPU) {
-    if (dst_device.Type() == OrtDevice::CPU && dst_device.MemType() == OrtDevice::MemType::CUDA_PINNED) {
+    if (dst_device.Type() == OrtDevice::CPU && dst_device.MemType() == OrtDevice::MemType::GPU_PINNED) {
       // copying from GPU to pinned memory, this is non-blocking
       HIP_RETURN_IF_ERROR(hipMemcpyAsync(dst_data, src_data, bytes, hipMemcpyDeviceToHost, GetStream(exec_queue_id)));
     } else {

--- a/onnxruntime/core/providers/rocm/rocm_allocator.h
+++ b/onnxruntime/core/providers/rocm/rocm_allocator.h
@@ -56,7 +56,7 @@ class ROCMPinnedAllocator : public IAllocator {
   ROCMPinnedAllocator(OrtDevice::DeviceId device_id, const char* name)
       : IAllocator(
             OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
-                          OrtDevice(OrtDevice::CPU, OrtDevice::MemType::CUDA_PINNED, device_id),
+                          OrtDevice(OrtDevice::CPU, OrtDevice::MemType::GPU_PINNED, device_id),
                           device_id, OrtMemTypeCPUOutput)) {}
 
   void* Alloc(size_t size) override;

--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
@@ -98,7 +98,7 @@ AllocatorPtr ROCMExecutionProvider::CreateRocmAllocator(OrtDevice::DeviceId devi
   if (external_allocator_info.UseExternalAllocator()) {
     AllocatorCreationInfo default_memory_info(
         [external_allocator_info](OrtDevice::DeviceId id) {
-          return std::make_unique<ROCMExternalAllocator>(id, CUDA, external_allocator_info.alloc, external_allocator_info.free, external_allocator_info.empty_cache);
+          return std::make_unique<ROCMExternalAllocator>(id, onnxruntime::GPU, external_allocator_info.alloc, external_allocator_info.free, external_allocator_info.empty_cache);
         },
         device_id,
         false);
@@ -108,7 +108,7 @@ AllocatorPtr ROCMExecutionProvider::CreateRocmAllocator(OrtDevice::DeviceId devi
   } else {
     AllocatorCreationInfo default_memory_info(
         [](OrtDevice::DeviceId id) {
-          return std::make_unique<ROCMAllocator>(id, CUDA);
+          return std::make_unique<ROCMAllocator>(id, onnxruntime::GPU);
         },
         device_id,
         true,
@@ -2191,7 +2191,7 @@ void ROCMExecutionProvider::RegisterAllocator(std::shared_ptr<AllocatorManager> 
   if (nullptr == rocm_pinned_alloc) {
     AllocatorCreationInfo pinned_memory_info(
         [](OrtDevice::DeviceId device_id) {
-          return std::make_unique<ROCMPinnedAllocator>(device_id, CUDA_PINNED);
+          return std::make_unique<ROCMPinnedAllocator>(device_id, onnxruntime::GPU_PINNED);
         },
         DEFAULT_CPU_ALLOCATOR_DEVICE_ID);
 

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -602,7 +602,7 @@ void TensorrtExecutionProvider::RegisterAllocator(std::shared_ptr<AllocatorManag
   allocator_ = allocator_manager->GetAllocator(device_id_, OrtMemTypeDefault);
   if (nullptr == allocator_) {
     AllocatorCreationInfo default_memory_info(
-        [](OrtDevice::DeviceId device_id) { return CreateCUDAAllocator(device_id, onnxruntime::CUDA); }, device_id_);
+        [](OrtDevice::DeviceId device_id) { return CreateCUDAAllocator(device_id, onnxruntime::GPU); }, device_id_);
     allocator_ = CreateAllocator(default_memory_info);
     allocator_manager->InsertAllocator(allocator_);
   }
@@ -615,7 +615,7 @@ void TensorrtExecutionProvider::RegisterAllocator(std::shared_ptr<AllocatorManag
   if (nullptr == cuda_pinned_alloc) {
     AllocatorCreationInfo pinned_allocator_info(
         [](OrtDevice::DeviceId device_id) {
-          return CreateCUDAPinnedAllocator(device_id, onnxruntime::CUDA_PINNED);
+          return CreateCUDAPinnedAllocator(device_id, onnxruntime::GPU_PINNED);
         },
         DEFAULT_CPU_ALLOCATOR_DEVICE_ID);
     cuda_pinned_alloc = CreateAllocator(pinned_allocator_info);

--- a/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
@@ -91,7 +91,7 @@ void addOrtValueMethods(pybind11::module& m) {
         AllocatorPtr allocator;
         if (strcmp(GetDeviceName(device), CPU) == 0) {
           allocator = GetAllocator();
-        } else if (strcmp(GetDeviceName(device), CUDA) == 0) {
+        } else if (strcmp(GetDeviceName(device), GPU) == 0) {
 #ifdef USE_CUDA
           if (!IsCudaDeviceIdValid(logging::LoggingManager::DefaultLogger(), device.Id())) {
             throw std::runtime_error("The provided device id doesn't match any available GPUs on the machine.");

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -181,7 +181,7 @@ const char* GetDeviceName(const OrtDevice& device) {
     case OrtDevice::CPU:
       return CPU;
     case OrtDevice::GPU:
-      return GPU;
+      return CUDA;
     case OrtDevice::FPGA:
       return "FPGA";
     default:

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -181,7 +181,7 @@ const char* GetDeviceName(const OrtDevice& device) {
     case OrtDevice::CPU:
       return CPU;
     case OrtDevice::GPU:
-      return CUDA;
+      return GPU;
     case OrtDevice::FPGA:
       return "FPGA";
     default:
@@ -1037,13 +1037,13 @@ void addObjectMethods(py::module& m, Environment& env, ExecutionProviderRegistra
   ort_memory_info_binding.def(py::init([](const char* name, OrtAllocatorType type, int id, OrtMemType mem_type) {
     if (strcmp(name, onnxruntime::CPU) == 0) {
       return std::make_unique<OrtMemoryInfo>(onnxruntime::CPU, type, OrtDevice(), id, mem_type);
-    } else if (strcmp(name, onnxruntime::CUDA) == 0) {
+    } else if (strcmp(name, onnxruntime::GPU) == 0) {
       return std::make_unique<OrtMemoryInfo>(
-          onnxruntime::CUDA, type, OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, static_cast<OrtDevice::DeviceId>(id)), id,
+          onnxruntime::GPU, type, OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, static_cast<OrtDevice::DeviceId>(id)), id,
           mem_type);
-    } else if (strcmp(name, onnxruntime::CUDA_PINNED) == 0) {
+    } else if (strcmp(name, onnxruntime::GPU_PINNED) == 0) {
       return std::make_unique<OrtMemoryInfo>(
-          onnxruntime::CUDA_PINNED, type, OrtDevice(OrtDevice::CPU, OrtDevice::MemType::CUDA_PINNED, static_cast<OrtDevice::DeviceId>(id)),
+          onnxruntime::GPU_PINNED, type, OrtDevice(OrtDevice::CPU, OrtDevice::MemType::GPU_PINNED, static_cast<OrtDevice::DeviceId>(id)),
           id, mem_type);
     } else {
       throw std::runtime_error("Specified device is not supported.");

--- a/onnxruntime/test/framework/cuda/allocator_cuda_test.cc
+++ b/onnxruntime/test/framework/cuda/allocator_cuda_test.cc
@@ -19,13 +19,13 @@ TEST(AllocatorTest, CUDAAllocatorTest) {
   CUDA_CALL_THROW(cudaSetDevice(cuda_device_id));
 
   AllocatorCreationInfo default_memory_info(
-      {[](OrtDevice::DeviceId id) { return std::make_unique<CUDAAllocator>(id, CUDA); }, cuda_device_id});
+      {[](OrtDevice::DeviceId id) { return std::make_unique<CUDAAllocator>(id, GPU); }, cuda_device_id});
 
   auto cuda_arena = CreateAllocator(default_memory_info);
 
   size_t size = 1024;
 
-  EXPECT_STREQ(cuda_arena->Info().name, CUDA);
+  EXPECT_STREQ(cuda_arena->Info().name, GPU);
   EXPECT_EQ(cuda_arena->Info().id, cuda_device_id);
   EXPECT_EQ(cuda_arena->Info().mem_type, OrtMemTypeDefault);
   EXPECT_EQ(cuda_arena->Info().alloc_type, OrtArenaAllocator);
@@ -35,11 +35,11 @@ TEST(AllocatorTest, CUDAAllocatorTest) {
   EXPECT_TRUE(cuda_addr);
 
   AllocatorCreationInfo pinned_memory_info(
-      [](int) { return std::make_unique<CUDAPinnedAllocator>(static_cast<OrtDevice::DeviceId>(0), CUDA_PINNED); });
+      [](int) { return std::make_unique<CUDAPinnedAllocator>(static_cast<OrtDevice::DeviceId>(0), GPU_PINNED); });
 
   auto pinned_allocator = CreateAllocator(pinned_memory_info);
 
-  EXPECT_STREQ(pinned_allocator->Info().name, CUDA_PINNED);
+  EXPECT_STREQ(pinned_allocator->Info().name, GPU_PINNED);
   EXPECT_EQ(pinned_allocator->Info().id, 0);
   EXPECT_EQ(pinned_allocator->Info().mem_type, OrtMemTypeCPUOutput);
   EXPECT_EQ(pinned_allocator->Info().alloc_type, OrtArenaAllocator);
@@ -89,7 +89,7 @@ TEST(AllocatorTest, CUDAAllocatorFallbackTest) {
   EXPECT_NE(free, total) << "All memory is free. Test logic does not handle this.";
 
   AllocatorCreationInfo default_memory_info(
-      {[](OrtDevice::DeviceId id) { return std::make_unique<CUDAAllocator>(id, CUDA); },
+      {[](OrtDevice::DeviceId id) { return std::make_unique<CUDAAllocator>(id, GPU); },
        cuda_device_id});
 
   auto cuda_arena = CreateAllocator(default_memory_info);

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1038,7 +1038,7 @@ TEST(CApiTest, io_binding_cuda) {
 #endif
   Ort::Session session(*ort_env, MODEL_URI, session_options);
 
-  Ort::MemoryInfo info_cuda("Cuda", OrtAllocatorType::OrtArenaAllocator, 0, OrtMemTypeDefault);
+  Ort::MemoryInfo info_cuda("Gpu", OrtAllocatorType::OrtArenaAllocator, 0, OrtMemTypeDefault);
 
   Ort::Allocator cuda_allocator(session, info_cuda);
   auto allocator_info = cuda_allocator.GetInfo();

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -930,7 +930,7 @@ TEST(CApiTest, get_allocator_cuda) {
   Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_CUDA(session_options, 0));
   Ort::Session session(*ort_env, NAMED_AND_ANON_DIM_PARAM_URI, session_options);
 
-  Ort::MemoryInfo info_cuda("Cuda", OrtAllocatorType::OrtArenaAllocator, 0, OrtMemTypeDefault);
+  Ort::MemoryInfo info_cuda("Gpu", OrtAllocatorType::OrtArenaAllocator, 0, OrtMemTypeDefault);
   Ort::Allocator cuda_allocator(session, info_cuda);
 
   auto allocator_info = cuda_allocator.GetInfo();

--- a/orttraining/orttraining/models/bert/main.cc
+++ b/orttraining/orttraining/models/bert/main.cc
@@ -621,7 +621,7 @@ void setup_training_params(BertParameters& params) {
     info.cudnn_conv_algo_search = OrtCudnnConvAlgoSearchExhaustive;
 
     params.providers.emplace(kCudaExecutionProvider, CreateExecutionProviderFactory_Cuda(&info));
-    params.input_allocator = CreateCUDAPinnedAllocator(info.device_id, CUDA_PINNED);
+    params.input_allocator = CreateCUDAPinnedAllocator(info.device_id, GPU_PINNED);
   }
 #endif
 
@@ -637,7 +637,7 @@ void setup_training_params(BertParameters& params) {
     info.miopen_conv_exhaustive_search = true; // true, exhaustive search (slow)
 
     params.providers.emplace(kRocmExecutionProvider, CreateExecutionProviderFactory_Rocm(&info));
-    params.input_allocator = CreateROCMPinnedAllocator(info.device_id, CUDA_PINNED);
+    params.input_allocator = CreateROCMPinnedAllocator(info.device_id, GPU_PINNED);
   }
 #endif
 

--- a/orttraining/orttraining/models/gpt2/main.cc
+++ b/orttraining/orttraining/models/gpt2/main.cc
@@ -362,7 +362,7 @@ void setup_training_params(GPT2Parameters& params) {
     info.device_id=gsl::narrow<OrtDevice::DeviceId>(MPIContext::GetInstance().GetLocalRank());
     info.do_copy_in_default_stream=true;
     params.providers.emplace(kCudaExecutionProvider, CreateExecutionProviderFactory_Cuda(&info));
-    params.input_allocator = CreateCUDAPinnedAllocator(info.device_id, CUDA_PINNED);
+    params.input_allocator = CreateCUDAPinnedAllocator(info.device_id, GPU_PINNED);
   }
 #endif
 
@@ -372,7 +372,7 @@ void setup_training_params(GPT2Parameters& params) {
     info.device_id=gsl::narrow<OrtDevice::DeviceId>(MPIContext::GetInstance().GetLocalRank());
     info.do_copy_in_default_stream=true;
     params.providers.emplace(kRocmExecutionProvider, CreateExecutionProviderFactory_Rocm(&info));
-    params.input_allocator = CreateROCMPinnedAllocator(info.device_id, CUDA_PINNED);
+    params.input_allocator = CreateROCMPinnedAllocator(info.device_id, GPU_PINNED);
   }
 #endif
 


### PR DESCRIPTION
Nvidia GPU and AMD GPU both have on-device memory and pinned memory. Thus, it is better to have a neutral or generic name which can be shared  for both CUDA and AMD backend. Otherwise, if a new different name is introduced for AMD, then the code change in this PR need to be duplicated.
