### PR TITLE
Fix bug in the Resize operator kernels

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -114,6 +114,17 @@ Status UpsampleNearest(const T* input,
   auto CalculateInputMapping =
       [n_dim, &input_shape, &output_shape, &input_dim_factor, &scales, &roi, extrapolation_enabled, &get_original_coordinate, &get_nearest_pixel](
           std::vector<int64_t>& input_mapping, const int64_t axis) {
+        // When scale is 1.0, there is a one-to-one mapping between the dimension
+        // in the input and the output and there is no need to apply the co-ordinate
+        // transformation which should only be done when there is "resizing" required
+        if (scales[axis] == 1.0f) {
+          for (int64_t dim = 0; dim < output_shape[axis]; dim++) {
+            input_mapping[dim] = dim * input_dim_factor[axis];
+          }
+          return;
+        }
+
+        // scale = 1.0
         const int64_t input_size = input_dim_factor[0] * input_shape[0];
         for (int64_t dim = 0; dim < output_shape[axis]; dim++) {
           float original_dim = get_original_coordinate(static_cast<float>(dim), scales[axis], static_cast<float>(output_shape[axis]),
@@ -211,7 +222,7 @@ Status UpsampleNearest(const T* input,
         break;
       }
       output_dim_counter[dim_idx] = 0;
-      input_idx += input_mappings[dim_idx][0 /* output_dim_counter[dim_idx] */ ];
+      input_idx += input_mappings[dim_idx][0 /* output_dim_counter[dim_idx] */];
     }
   }
 

--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -124,7 +124,7 @@ Status UpsampleNearest(const T* input,
           return;
         }
 
-        // scale = 1.0
+        // scale != 1.0
         const int64_t input_size = input_dim_factor[0] * input_shape[0];
         for (int64_t dim = 0; dim < output_shape[axis]; dim++) {
           float original_dim = get_original_coordinate(static_cast<float>(dim), scales[axis], static_cast<float>(output_shape[axis]),

--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -342,9 +342,11 @@ void UpsampleBilinear(int64_t batch_size,
   auto roi_y_start = roi.size() / 2 - 2;
   auto roi_y_end = roi.size() - 2;
   for (int64_t y = 0; y < output_height; ++y) {
-    float in_y = get_original_coordinate(static_cast<float>(y), height_scale,
-                                         static_cast<float>(output_height), static_cast<float>(input_height),
-                                         roi[roi_y_start], roi[roi_y_end]);
+    float in_y = height_scale == 1 ? static_cast<float>(y)
+                                   : get_original_coordinate(static_cast<float>(y), height_scale,
+                                                             static_cast<float>(output_height),
+                                                             static_cast<float>(input_height),
+                                                             roi[roi_y_start], roi[roi_y_end]);
     y_original.emplace_back(in_y);
     in_y = std::max(0.0f, std::min(in_y, static_cast<float>(input_height - 1)));
 
@@ -365,9 +367,12 @@ void UpsampleBilinear(int64_t batch_size,
   auto roi_x_start = roi.size() / 2 - 1;
   auto roi_x_end = roi.size() - 1;
   for (int64_t x = 0; x < output_width; ++x) {
-    float in_x = get_original_coordinate(static_cast<float>(x), width_scale,
-                                         static_cast<float>(output_width), static_cast<float>(input_width),
-                                         roi[roi_x_start], roi[roi_x_end]);
+    float in_x = width_scale == 1 ? static_cast<float>(x)
+                                  : get_original_coordinate(static_cast<float>(x),
+                                                            width_scale,
+                                                            static_cast<float>(output_width),
+                                                            static_cast<float>(input_width),
+                                                            roi[roi_x_start], roi[roi_x_end]);
     x_original.emplace_back(in_x);
     in_x = std::max(0.0f, std::min(in_x, static_cast<float>(input_width - 1)));
 
@@ -496,9 +501,11 @@ void ResizeBiCubic(
 
   // generate coefficients in y direction
   for (int64_t y = 0; y < output_height; ++y) {
-    float in_y = get_original_coordinate(static_cast<float>(y), height_scale,
-                                         static_cast<float>(output_height), static_cast<float>(input_height),
-                                         roi[roi_y_start], roi[roi_y_end]);
+    float in_y = height_scale == 1 ? static_cast<float>(y)
+                                   : get_original_coordinate(static_cast<float>(y), height_scale,
+                                                             static_cast<float>(output_height),
+                                                             static_cast<float>(input_height),
+                                                             roi[roi_y_start], roi[roi_y_end]);
     y_original.emplace_back(in_y);
     auto s = y_original[y] - std::floor(y_original[y]);
     if (cubic_coeffs.find(s) == cubic_coeffs.end()) {
@@ -509,9 +516,12 @@ void ResizeBiCubic(
 
   // generate coefficients in x direction
   for (int64_t x = 0; x < output_width; ++x) {
-    float in_x = get_original_coordinate(static_cast<float>(x), width_scale,
-                                         static_cast<float>(output_width), static_cast<float>(input_width),
-                                         roi[roi_x_start], roi[roi_x_end]);
+    float in_x = width_scale == 1 ? static_cast<float>(x)
+                                  : get_original_coordinate(static_cast<float>(x),
+                                                            width_scale,
+                                                            static_cast<float>(output_width),
+                                                            static_cast<float>(input_width),
+                                                            roi[roi_x_start], roi[roi_x_end]);
     x_original.emplace_back(in_x);
     auto s = x_original[x] - std::floor(x_original[x]);
     if (cubic_coeffs.find(s) == cubic_coeffs.end()) {

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -215,7 +215,7 @@ __global__ void _ResizeNearestMappingKernel(
         dim = calc_nearest_pixel(orig_coord, scales[axis] < 1);
         if (dim >= input_shape[axis]) dim = input_shape[axis] - 1;
         if (dim < 0) dim = 0;      
-	  }
+      }
 
       dims_mapping[id].origin_ = dim;
       return;

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -156,7 +156,8 @@ __global__ void _ResizeNearestMappingKernel2D(
     } else {
       float orig_coord = transform_coordinate(static_cast<float>(dim), scales_height, static_cast<float>(output_height),
                                               static_cast<float>(input_height), roi_start_height, roi_end_height);
-      dims_mapping[id].extrapolate_ = (int)(extrapolation_enabled && (orig_coord < 0.f || orig_coord > static_cast<float>(input_height - 1)));
+      dims_mapping[id].extrapolate_ = static_cast<int>(
+          extrapolation_enabled && (orig_coord < 0.f || orig_coord > static_cast<float>(input_height - 1)));
       dim = calc_nearest_pixel(orig_coord, scales_height < 1);
       if (dim >= input_height) dim = input_height - 1;
       if (dim < 0) dim = 0;    
@@ -172,7 +173,8 @@ __global__ void _ResizeNearestMappingKernel2D(
     } else {
       float orig_coord = transform_coordinate(static_cast<float>(dim), scales_width, static_cast<float>(output_width),
                                               static_cast<float>(input_width), roi_start_width, roi_end_width);
-      dims_mapping[id].extrapolate_ = (int)(extrapolation_enabled && (orig_coord < 0.f || orig_coord > static_cast<float>(input_width - 1)));
+      dims_mapping[id].extrapolate_ = static_cast<int>(
+          extrapolation_enabled && (orig_coord < 0.f || orig_coord > static_cast<float>(input_width - 1)));
       dim = calc_nearest_pixel(orig_coord, scales_width < 1);
       if (dim >= input_width) dim = input_width - 1;
       if (dim < 0) dim = 0; 
@@ -211,7 +213,7 @@ __global__ void _ResizeNearestMappingKernel(
       } else {
         float orig_coord = transform_coordinate(static_cast<float>(dim), scales[axis], static_cast<float>(output_shape[axis]),
                                                 static_cast<float>(input_shape[axis]), roi[axis], roi[axis + rank]);
-        dims_mapping[id].extrapolate_ = (int)(extrapolation_enabled && (orig_coord < 0.f || orig_coord > static_cast<float>(input_shape[axis] - 1)));
+        dims_mapping[id].extrapolate_ = static_cast<int>(extrapolation_enabled && (orig_coord < 0.f || orig_coord > static_cast<float>(input_shape[axis] - 1)));
         dim = calc_nearest_pixel(orig_coord, scales[axis] < 1);
         if (dim >= input_shape[axis]) dim = input_shape[axis] - 1;
         if (dim < 0) dim = 0;      


### PR DESCRIPTION
**Description**: 
 When the scale for a particular axis is 1.0, there is one-to-one mapping between the input and the output tensors along that axis and hence the co-ordinate transformation shouldn't be applied as there is no "resizing" along that axis. Applying it may lead to incorrect sampling from the input (illustrated in the unit test).

**Motivation and Context**
Resolve https://github.com/microsoft/onnxruntime/issues/5151
