### PR TITLE
Add weight prepacking to LSTM kernel

### DIFF
--- a/onnxruntime/core/providers/cpu/rnn/deep_cpu_gru.cc
+++ b/onnxruntime/core/providers/cpu/rnn/deep_cpu_gru.cc
@@ -272,7 +272,7 @@ Status DeepCpuGruOp::ComputeImpl(OpKernelContext& context) const {
   int batch_size = gsl::narrow<int>(X_shape[1]);
   int input_size = gsl::narrow<int>(X_shape[2]);
 
-  auto status = ValidateCommonRnnInputs(X, W, R, B, 3, sequence_lens, initial_h, num_directions_, hidden_size_);
+  auto status = ValidateCommonRnnInputs(X, W.Shape(), R.Shape(), B, 3, sequence_lens, initial_h, num_directions_, hidden_size_);
   ORT_RETURN_IF_ERROR(status);
 
   // GRU outputs are optional but must be in the same order

--- a/onnxruntime/core/providers/cpu/rnn/rnn.cc
+++ b/onnxruntime/core/providers/cpu/rnn/rnn.cc
@@ -119,7 +119,7 @@ Status RNN<float>::Compute(OpKernelContext* ctx) const {
   int64_t batch_size = X.Shape()[1];
   int64_t input_size = X.Shape()[2];
 
-  auto status = rnn::detail::ValidateCommonRnnInputs(X, W, R, B, 1, sequence_lens, initial_h,
+  auto status = rnn::detail::ValidateCommonRnnInputs(X, W.Shape(), R.Shape(), B, 1, sequence_lens, initial_h,
                                                      num_directions, hidden_size_);
   ORT_RETURN_IF_ERROR(status);
 

--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
@@ -24,8 +24,8 @@ namespace detail {
 using namespace ::onnxruntime::common;
 
 Status ValidateCommonRnnInputs(const Tensor& X,
-                               const Tensor& W,
-                               const Tensor& R,
+                               const TensorShape& W_shape,
+                               const TensorShape& R_shape,
                                const Tensor* B,
                                int WRB_dim_1_multipler,
                                const Tensor* sequence_lens,
@@ -33,8 +33,6 @@ Status ValidateCommonRnnInputs(const Tensor& X,
                                int64_t num_directions,
                                int64_t hidden_size) {
   auto& X_shape = X.Shape();
-  auto& W_shape = W.Shape();
-  auto& R_shape = R.Shape();
 
   int64_t seq_length = X_shape[0];
   int64_t batch_size = X_shape[1];

--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.h
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.h
@@ -12,7 +12,8 @@
 #include "core/framework/allocator.h"
 #include "core/util/math.h"
 #include "core/util/math_cpuonly.h"
-
+#include "core/mlas/inc/mlas.h"
+#include "core/common/safeint.h"
 #include "core/platform/threadpool.h"
 
 #include "gsl/gsl"
@@ -70,8 +71,8 @@ gsl::span<TAlloc> Allocate(std::shared_ptr<IAllocator> allocator,
 
 // validate the common inputs to RNN, LSTM and GRU operators
 Status ValidateCommonRnnInputs(const Tensor& X,
-                               const Tensor& W,
-                               const Tensor& R,
+                               const TensorShape& W_shape,
+                               const TensorShape& R_shape,
                                const Tensor* B,
                                int WRB_dim_1_multipler,  // multiplier used with hidden_size for W, R and B inputs
                                const Tensor* sequence_lens,
@@ -145,7 +146,8 @@ void ComputeGemm(const int M,
                  const float beta,
                  TSpanCIter C,
                  TSpanCIter C_end,
-                 const int ldc, concurrency::ThreadPool* tp) {
+                 const int ldc,
+                 concurrency::ThreadPool* thread_pool) {
   // validate all the inputs
   // need to use the lda/ldb/ldc strides which should be >= the columns for the span
   ORT_ENFORCE(lda >= K && ldb >= K && ldc >= N);
@@ -158,7 +160,64 @@ void ComputeGemm(const int M,
       M, N, K, alpha,
       &*A, lda,
       &*B, ldb, beta,
-      &*C, ldc, tp);
+      &*C, ldc, thread_pool);
+}
+
+struct PackedWeights {
+  BufferUniquePtr buffer_;
+  size_t weights_size_;
+  TensorShape shape_;
+};
+
+template <typename T>
+struct GemmWeights {
+  GemmWeights(int idx, const T* weights_data, size_t weights_size, const PackedWeights& packed_weights) {
+    if (packed_weights.buffer_) {
+      is_prepacked_ = true;
+      buffer_ = static_cast<uint8_t*>(packed_weights.buffer_.get()) + packed_weights.weights_size_ * idx;
+    } else {
+      is_prepacked_ = false;
+      buffer_ = weights_data + weights_size * idx;
+    }
+  }
+
+  bool is_prepacked_;
+  const void* buffer_;
+};
+
+template <typename TSpanAIter, typename TSpanCIter>
+void ComputeGemm(const int M,
+                 const int N,
+                 const int K,
+                 const float alpha,
+                 TSpanAIter A,
+                 TSpanAIter A_end,
+                 const GemmWeights<float>& weights,
+                 const float beta,
+                 TSpanCIter C,
+                 TSpanCIter C_end,
+                 const int ldc,
+                 concurrency::ThreadPool* thread_pool) {
+  // validate all the inputs
+  // need to use the lda/ldb/ldc strides which should be >= the columns for the span
+  ORT_ENFORCE(A + (M * K) <= A_end);
+  ORT_ENFORCE(C + (M * ldc - (ldc - N)) <= C_end);
+
+  if (weights.is_prepacked_) {
+    MlasGemm(
+        CblasNoTrans,
+        M, N, K, alpha,
+        &*A, K,
+        weights.buffer_, beta,
+        &*C, ldc, thread_pool);
+  } else {
+    ::onnxruntime::math::GemmEx<float>(
+        CblasNoTrans, CblasTrans,
+        M, N, K, alpha,
+        &*A, K,
+        static_cast<const float *>(weights.buffer_), K, beta,
+        &*C, ldc, thread_pool);
+  }
 }
 
 // helper to convert a span to a raw pointer


### PR DESCRIPTION
**Description**: Improve the performance of LSTM nodes by prepacking the weight tensors.

**Motivation and Context**
Changed the LSTM operator to use the new GEMM float prepacking support. For one internal test model, inference time for a model running on 4 threads dropped from 37ms to 29ms. Other LSTMs have been showing good gains too.