### PR TITLE
Remove invalid install line from onnxruntime_flatbuffers.cmake

### DIFF
--- a/cmake/onnxruntime_flatbuffers.cmake
+++ b/cmake/onnxruntime_flatbuffers.cmake
@@ -9,7 +9,6 @@ file(GLOB onnxruntime_flatbuffers_srcs CONFIGURE_DEPENDS
 source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_flatbuffers_srcs})
 
 add_library(onnxruntime_flatbuffers ${onnxruntime_flatbuffers_srcs})
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/../include/onnxruntime/core/flatbuffers  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnxruntime/core)
 onnxruntime_add_include_to_target(onnxruntime_flatbuffers onnx flatbuffers)
 if(onnxruntime_ENABLE_INSTRUMENT)
   target_compile_definitions(onnxruntime_flatbuffers PUBLIC ONNXRUNTIME_ENABLE_INSTRUMENT)


### PR DESCRIPTION
**Description**: Remove invalid install line from onnxruntime_flatbuffers.cmake

**Motivation and Context**
- The change https://github.com/microsoft/onnxruntime/commit/3a3f26f38e049eb0e8b9fbb97281a6e5dd82074f has one invalid install line in onnxruntime_flatbuffers.cmake, this was not caught by CIs, and cause install to fail.
- Removed the invalid line and verified the install passed on Mac and Windows

