### PR TITLE
Cosmetic change in non tensor tests

### DIFF
--- a/onnxruntime/test/shared_lib/test_nontensor_types.cc
+++ b/onnxruntime/test/shared_lib/test_nontensor_types.cc
@@ -179,7 +179,7 @@ TEST(CApiTest, TypeInfoMap) {
 #if !defined(DISABLE_ML_OPS)
   Ort::Value map_ort = Ort::Value::CreateMap(keys_tensor, values_tensor);
   Ort::TypeInfo type_info = map_ort.GetTypeInfo();
-  Ort::MapTypeInfo map_type_info = type_info.GetMapTypeInfo();
+  auto map_type_info = type_info.GetMapTypeInfo();
 
   //Check key type
   ASSERT_EQ(map_type_info.GetMapKeyType(), ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
@@ -192,8 +192,7 @@ TEST(CApiTest, TypeInfoMap) {
   // ASSERT_EQ(map_value_type_info.GetTensorTypeAndShapeInfo().GetShape(), dims);
   ASSERT_EQ(map_value_type_info.GetTensorTypeAndShapeInfo().GetElementType(), ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT);
 
-  map_value_type_info.release();
-  map_type_info.release();
+  //map_type_info.release();
 #else
 
 #if !defined(ORT_NO_EXCEPTIONS)
@@ -294,7 +293,7 @@ TEST(CApiTest, TypeInfoSequence) {
 
   Ort::Value seq_ort = Ort::Value::CreateSequence(in);
   Ort::TypeInfo type_info = seq_ort.GetTypeInfo();
-  Ort::SequenceTypeInfo seq_type_info = type_info.GetSequenceTypeInfo();
+  auto seq_type_info = type_info.GetSequenceTypeInfo();
 
   ASSERT_EQ(seq_type_info.GetSequenceElementType().GetONNXType(), ONNX_TYPE_TENSOR);
   // No shape present, as sequence allows different shapes for each element
@@ -302,5 +301,5 @@ TEST(CApiTest, TypeInfoSequence) {
   ASSERT_EQ(seq_type_info.GetSequenceElementType().GetTensorTypeAndShapeInfo().GetElementType(),
             ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
 
-  seq_type_info.release();
+  //seq_type_info.release();
 }

--- a/onnxruntime/test/shared_lib/test_nontensor_types.cc
+++ b/onnxruntime/test/shared_lib/test_nontensor_types.cc
@@ -296,6 +296,9 @@ TEST(CApiTest, TypeInfoSequence) {
 
   Ort::Value seq_ort = Ort::Value::CreateSequence(in);
   Ort::TypeInfo type_info = seq_ort.GetTypeInfo();
+
+  //It doesn't own the pointer -
+  //The destructor of the "Unowned" struct will release the ownership (and thus prevent the pointer from being double freed)
   auto seq_type_info = type_info.GetSequenceTypeInfo();
 
   ASSERT_EQ(seq_type_info.GetSequenceElementType().GetONNXType(), ONNX_TYPE_TENSOR);


### PR DESCRIPTION
**Description**: very minor cosmetic refinement to the memory leak fix in #5312  

**Motivation and Context**
Follow the usage pattern of GetTensorTypeAndShapeInfo() for both GetMapTypeInfo() and GetSequenceTypeInfo() and keep everything consistent
