### PR TITLE
Docker image release build updates

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-docker-release-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-docker-release-pipeline.yml
@@ -6,7 +6,8 @@ parameters:
 
 variables:
   docker_image_prefix: onnxruntime-training
-  linux_gpu_dockerfile: dockerfiles/Dockerfile.training
+  linux_gpu_dockerfile: '$(Build.SourcesDirectory)/dockerfiles/Dockerfile.training'
+  docker_build_context: '$(Build.SourcesDirectory)/dockerfiles'
   build_config: Release
 
 name: $(Date:yyyyMMdd)$(Rev:.r)
@@ -28,7 +29,8 @@ jobs:
           --no-cache \
           --build-arg COMMIT="$(Build.SourceVersion)" \
           --build-arg BUILD_CONFIG="${{ variables.build_config }}" \
-          -f ${{ variables.linux_gpu_dockerfile }} .
+          -f ${{ variables.linux_gpu_dockerfile }} \
+          ${{ variables.docker_build_context }}
       workingDirectory: $(Build.SourcesDirectory)
 
   - task: CmdLine@2
@@ -53,7 +55,8 @@ jobs:
       containerRegistry: 'ortrelease'
       repository: 'onnxruntime-training'
       arguments: --build-arg COMMIT="$(Build.SourceVersion)" --build-arg BUILD_CONFIG="${{ variables.build_config }}"
-      Dockerfile: ${{ variables.linux_gpu_dockerfile }}
+      Dockerfile: '${{ variables.linux_gpu_dockerfile }}'
+      buildContext: '${{ variables.docker_build_context }}'
       tags: |
         $(Build.BuildNumber)
         ${{ parameters.image_tag }}

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-docker-release-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-docker-release-pipeline.yml
@@ -1,8 +1,4 @@
 parameters:
-- name: commit
-  displayName: Commit (Default to master or use sha1)
-  type: string
-  default: master
 - name: image_tag
   displayName: Image Tag
   type: string
@@ -30,7 +26,7 @@ jobs:
           -t ${{ variables.docker_image_prefix }}-manylinux-gpu-release-stage1 \
           --target builder \
           --no-cache \
-          --build-arg COMMIT="${{ parameters.commit }}" \
+          --build-arg COMMIT="$(Build.SourceVersion)" \
           --build-arg BUILD_CONFIG="${{ variables.build_config }}" \
           -f ${{ variables.linux_gpu_dockerfile }} .
       workingDirectory: $(Build.SourcesDirectory)
@@ -56,7 +52,7 @@ jobs:
       command: build
       containerRegistry: 'ortrelease'
       repository: 'onnxruntime-training'
-      arguments: --build-arg COMMIT="${{ parameters.commit }}" --build-arg BUILD_CONFIG="${{ variables.build_config }}"
+      arguments: --build-arg COMMIT="$(Build.SourceVersion)" --build-arg BUILD_CONFIG="${{ variables.build_config }}"
       Dockerfile: ${{ variables.linux_gpu_dockerfile }}
       tags: |
         $(Build.BuildNumber)

--- a/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
@@ -2,7 +2,7 @@
 parameters:
 - name: condition
   type: string
-  default: '' # could be 'ci_only', 'always', 'succeeded'
+  default: 'succeeded' # could be 'ci_only', 'always', 'succeeded'
 
 steps:
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0


### PR DESCRIPTION
**Description**
- Update docker image release build to use build commit.
- Use valid default in component governance detection step.
- Use smaller docker build context.

**Motivation and Context**
- Make the build easier to configure by using a single commit.
- Address component governance step warning.
