### PR TITLE
Make some string optional for save to/load from flatbuffers

### DIFF
--- a/onnxruntime/core/flatbuffers/flatbuffers_utils.h
+++ b/onnxruntime/core/flatbuffers/flatbuffers_utils.h
@@ -46,10 +46,12 @@ onnxruntime::common::Status SaveValueInfoOrtFormat(
 
 void LoadStringFromOrtFormat(std::string& dst, const flatbuffers::String* fbs_string);
 
-#define LOAD_STR_FROM_ORT_FORMAT(dst, name, fbs_string) \
-  {                                                     \
-    if (fbs_string)                                     \
-      dst.set_##name(fbs_string->c_str());              \
+// This macro is to be used on a protobuf message (protobug_msg), which will not create an empty string field (str_field)
+// if fbs_string is null
+#define LOAD_STR_FROM_ORT_FORMAT(protobug_msg, str_field, fbs_string) \
+  {                                                                   \
+    if (fbs_string)                                                   \
+      protobug_msg.set_##str_field(fbs_string->c_str());              \
   }
 
 onnxruntime::common::Status LoadValueInfoOrtFormat(

--- a/onnxruntime/core/flatbuffers/flatbuffers_utils.h
+++ b/onnxruntime/core/flatbuffers/flatbuffers_utils.h
@@ -33,6 +33,10 @@ struct ValueInfo;
 
 namespace utils {
 
+// Will only create string in flatbuffers when has_string is true
+flatbuffers::Offset<flatbuffers::String> SaveStringToOrtFormat(flatbuffers::FlatBufferBuilder& builder,
+                                                               bool has_string, const std::string& src);
+
 // TODO, add ORT_MUST_USE_RESULT when it is moved to a different header
 onnxruntime::common::Status SaveValueInfoOrtFormat(
     flatbuffers::FlatBufferBuilder& builder, const ONNX_NAMESPACE::ValueInfoProto& value_info_proto,
@@ -41,6 +45,12 @@ onnxruntime::common::Status SaveValueInfoOrtFormat(
 #if defined(ENABLE_ORT_FORMAT_LOAD)
 
 void LoadStringFromOrtFormat(std::string& dst, const flatbuffers::String* fbs_string);
+
+#define LOAD_STR_FROM_ORT_FORMAT(dst, name, fbs_string) \
+  {                                                     \
+    if (fbs_string)                                     \
+      dst.set_##name(fbs_string->c_str());              \
+  }
 
 onnxruntime::common::Status LoadValueInfoOrtFormat(
     const fbs::ValueInfo& fbs_value_info, ONNX_NAMESPACE::ValueInfoProto& value_info_proto);

--- a/onnxruntime/core/graph/graph_flatbuffers_utils.cc
+++ b/onnxruntime/core/graph/graph_flatbuffers_utils.cc
@@ -21,8 +21,8 @@ namespace utils {
 Status SaveInitializerOrtFormat(flatbuffers::FlatBufferBuilder& builder,
                                 const TensorProto& initializer,
                                 flatbuffers::Offset<fbs::Tensor>& fbs_tensor) {
-  auto name = builder.CreateString(initializer.name());
-  auto doc_string = builder.CreateString(initializer.doc_string());
+  auto name = SaveStringToOrtFormat(builder, initializer.has_name(), initializer.name());
+  auto doc_string = SaveStringToOrtFormat(builder, initializer.has_doc_string(), initializer.doc_string());
   std::vector<int64_t> dims_data(initializer.dims().size());
   std::copy(initializer.dims().cbegin(), initializer.dims().cend(), dims_data.begin());
   auto dims = builder.CreateVector(dims_data);
@@ -72,8 +72,8 @@ Status SaveAttributeOrtFormat(flatbuffers::FlatBufferBuilder& builder,
                               const AttributeProto& attr_proto,
                               flatbuffers::Offset<fbs::Attribute>& fbs_attr,
                               const onnxruntime::Graph* graph) {
-  auto name = builder.CreateString(attr_proto.name());
-  auto doc_string = builder.CreateString(attr_proto.doc_string());
+  auto name = SaveStringToOrtFormat(builder, attr_proto.has_name(), attr_proto.name());
+  auto doc_string = SaveStringToOrtFormat(builder, attr_proto.has_doc_string(), attr_proto.doc_string());
   auto type = static_cast<fbs::AttributeType>(attr_proto.type());
   switch (type) {
     case fbs::AttributeType::FLOAT: {
@@ -145,8 +145,8 @@ Status LoadInitializerOrtFormat(const fbs::Tensor& fbs_tensor,
                                 TensorProto& initializer) {
   initializer.Clear();
 
-  LoadStringFromOrtFormat(*initializer.mutable_name(), fbs_tensor.name());
-  LoadStringFromOrtFormat(*initializer.mutable_doc_string(), fbs_tensor.doc_string());
+  LOAD_STR_FROM_ORT_FORMAT(initializer, name, fbs_tensor.name());
+  LOAD_STR_FROM_ORT_FORMAT(initializer, doc_string, fbs_tensor.doc_string());
 
   auto fbs_dims = fbs_tensor.dims();
   ORT_RETURN_IF(nullptr == fbs_dims, "Missing dimensions for initializer. Invalid ORT format model.");
@@ -179,8 +179,9 @@ Status LoadAttributeOrtFormat(const fbs::Attribute& fbs_attr,
                               Graph& graph, Node& node,
                               const logging::Logger& logger) {
   attr_proto.Clear();
-  LoadStringFromOrtFormat(*attr_proto.mutable_name(), fbs_attr.name());
-  LoadStringFromOrtFormat(*attr_proto.mutable_doc_string(), fbs_attr.doc_string());
+  LOAD_STR_FROM_ORT_FORMAT(attr_proto, name, fbs_attr.name());
+  LOAD_STR_FROM_ORT_FORMAT(attr_proto, doc_string, fbs_attr.doc_string());
+
   auto type = static_cast<AttributeProto_AttributeType>(fbs_attr.type());
   attr_proto.set_type(type);
   switch (type) {

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -544,10 +544,13 @@ Status Model::Save(Model& model, int p_fd) {
 
 common::Status Model::SaveToOrtFormat(flatbuffers::FlatBufferBuilder& builder,
                                       flatbuffers::Offset<fbs::Model>& fbs_model) const {
-  auto producer_name = builder.CreateString(model_proto_.producer_name());
-  auto producer_version = builder.CreateString(model_proto_.producer_version());
+  auto producer_name = experimental::utils::SaveStringToOrtFormat(
+      builder, model_proto_.has_producer_name(), model_proto_.producer_name());
+  auto producer_version = experimental::utils::SaveStringToOrtFormat(
+      builder, model_proto_.has_producer_version(), model_proto_.producer_version());
   auto domain = builder.CreateSharedString(model_proto_.domain());
-  auto doc_string = builder.CreateString(model_proto_.doc_string());
+  auto doc_string = experimental::utils::SaveStringToOrtFormat(
+      builder, model_proto_.has_doc_string(), model_proto_.doc_string());
 
   std::vector<flatbuffers::Offset<fbs::OperatorSetId>> op_set_ids_vec;
   op_set_ids_vec.reserve(model_proto_.opset_import().size());
@@ -591,10 +594,10 @@ common::Status Model::LoadFromOrtFormat(const fbs::Model& fbs_model,
   model.reset(new Model());
 
 #if !defined(ORT_MINIMAL_BUILD)
-  experimental::utils::LoadStringFromOrtFormat(*model->model_proto_.mutable_producer_name(), fbs_model.producer_name());
-  experimental::utils::LoadStringFromOrtFormat(*model->model_proto_.mutable_producer_version(), fbs_model.producer_version());
-  experimental::utils::LoadStringFromOrtFormat(*model->model_proto_.mutable_domain(), fbs_model.domain());
-  experimental::utils::LoadStringFromOrtFormat(*model->model_proto_.mutable_doc_string(), fbs_model.doc_string());
+  LOAD_STR_FROM_ORT_FORMAT(model->model_proto_, producer_name, fbs_model.producer_name());
+  LOAD_STR_FROM_ORT_FORMAT(model->model_proto_, producer_version, fbs_model.producer_version());
+  LOAD_STR_FROM_ORT_FORMAT(model->model_proto_, domain, fbs_model.domain());
+  LOAD_STR_FROM_ORT_FORMAT(model->model_proto_, doc_string, fbs_model.doc_string());
   model->model_proto_.set_model_version(fbs_model.model_version());
   model->model_proto_.set_ir_version(fbs_model.ir_version());
 #else

--- a/onnxruntime/test/framework/ort_model_only_test.cc
+++ b/onnxruntime/test/framework/ort_model_only_test.cc
@@ -89,7 +89,7 @@ static void CompareTensors(const OrtValue& left_value, const OrtValue& right_val
   }
 }
 
-// Keep the CompareTypeProtos in case we need to debug the difference
+// Keep the CompareTypeProtos in case we need debug the difference
 /*
 static void CompareTypeProtos(const TypeProto& left_type_proto, const TypeProto& right_type_proto) {
   ASSERT_EQ(left_type_proto.denotation(), right_type_proto.denotation());
@@ -134,6 +134,7 @@ static void CompareValueInfos(const ValueInfoProto& left, const ValueInfoProto& 
   const auto str_right = right.SerializeAsString();
   ASSERT_EQ(str_left, str_right);
 
+  // Keep the ValueInfoProto content comparison in case we need debug the difference
   // ASSERT_EQ(left.name(), right.name());
   // ASSERT_EQ(left.doc_string(), right.doc_string());
   // CompareTypeProtos(left.type(), right.type());

--- a/onnxruntime/test/framework/ort_model_only_test.cc
+++ b/onnxruntime/test/framework/ort_model_only_test.cc
@@ -89,6 +89,8 @@ static void CompareTensors(const OrtValue& left_value, const OrtValue& right_val
   }
 }
 
+// Keep the CompareTypeProtos in case we need to debug the difference
+/*
 static void CompareTypeProtos(const TypeProto& left_type_proto, const TypeProto& right_type_proto) {
   ASSERT_EQ(left_type_proto.denotation(), right_type_proto.denotation());
 
@@ -125,12 +127,16 @@ static void CompareTypeProtos(const TypeProto& left_type_proto, const TypeProto&
     FAIL();  // We do not support SparseTensor and Opaque for now
   }
 }
+*/
 
 static void CompareValueInfos(const ValueInfoProto& left, const ValueInfoProto& right) {
-  ASSERT_EQ(left.name(), right.name());
-  ASSERT_EQ(left.doc_string(), right.doc_string());
+  const auto str_left = left.SerializeAsString();
+  const auto str_right = right.SerializeAsString();
+  ASSERT_EQ(str_left, str_right);
 
-  CompareTypeProtos(left.type(), right.type());
+  // ASSERT_EQ(left.name(), right.name());
+  // ASSERT_EQ(left.doc_string(), right.doc_string());
+  // CompareTypeProtos(left.type(), right.type());
 }
 
 static void CompareGraphAndSessionState(const InferenceSessionGetGraphWrapper& session_object_1,


### PR DESCRIPTION
**Description**: Make some string optional for save to/load from flatbuffers

**Motivation and Context**
- In the current ort format,
-- Save a proto part to fbs, we will save a string regardless if the proto has the string defined (such as doc_string), if a string field does not exist on proto, we will save an empty string
-- Load a fbs part to proto, we will create the string field in proto regardless if the fbs part has the string field, and create empty string if fbs part does not have certain string field

- Changed save/load flatfuffers code to only save/load when the string field actual exist
- Benefits, 
-- Can round trip valueinfo, 
-- Make test comparing valueinfo simpler.
-- Reduce the size of ort format file
