### PR TITLE
Move Memcopy to and from host to default stream.

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -39,6 +39,8 @@ ONNX_OPERATOR_KERNEL_EX(
     1,
     kCudaExecutionProvider,
     KernelDefBuilder()
+        // launch on the default compute stream synchronously 
+        // to ensure copy is complete before being accessed by the next node.   
         .InputMemoryType<OrtMemTypeCPUInput>(0)
         .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes()),
     Memcpy);
@@ -49,7 +51,10 @@ ONNX_OPERATOR_KERNEL_EX(
     1,
     kCudaExecutionProvider,
     KernelDefBuilder()
-        .OutputMemoryType<OrtMemTypeCPUOutput>(0)
+        // properly force CPU/GPU synch inside the kernel, 
+        // launch on the default compute stream synchronously 
+        // to ensure copy is complete before being accessed by the next node.      
+        .OutputMemoryType<OrtMemTypeCPUInput>(0)
         .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes()),
     Memcpy);
 

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -40,7 +40,6 @@ ONNX_OPERATOR_KERNEL_EX(
     kCudaExecutionProvider,
     KernelDefBuilder()
         .InputMemoryType<OrtMemTypeCPUInput>(0)
-        .ExecQueueId(kCudaStreamCopyIn)
         .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes()),
     Memcpy);
 
@@ -51,7 +50,6 @@ ONNX_OPERATOR_KERNEL_EX(
     kCudaExecutionProvider,
     KernelDefBuilder()
         .OutputMemoryType<OrtMemTypeCPUOutput>(0)
-        .ExecQueueId(kCudaStreamCopyOut)
         .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes()),
     Memcpy);
 


### PR DESCRIPTION
Temporarily move memcopy to default stream to reduce a chance for memory space being accessed before async memcopy is complete.

Additional explanation by @KeDengMS :
"
GPU op 1 (in compute stream): uses tensor A as input, and then A is released to BFCArena with no reuse
GPU copy 2 (in copy stream): allocate a buffer for the copy output, and put fence on the buffer

From CPU threads point of view, these operations are sequential, but when compute stream and copy stream runs concurrently in GPU, there’s a chance that the copy output of op2 happens at the same time when op1 is running in compute stream.
One solution is to make all copy and compute to be in the same GPU stream, so the CPU execution order and GPU execution order matches. 
"