### PR TITLE
Permit higher performance from Python FE by outputting all_finite on CPU and toggling GeluApproximation

### DIFF
--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -45,6 +45,7 @@ struct TrainingParameters {
   int horizontal_parallel_size = 1;
   int deepspeed_zero_stage = 0;
   bool enable_grad_norm_clip = true;
+  bool enable_gelu_approximation = false;
   bool set_gradients_as_graph_outputs = false;
   bool use_invertible_layernorm_grad = false;
 };
@@ -130,6 +131,8 @@ TrainingConfigurationResult ConfigureSessionForTraining(
   config.gradient_graph_config.use_invertible_layernorm_grad = parameters.use_invertible_layernorm_grad;
   config.gradient_graph_config.set_gradients_as_graph_outputs = parameters.set_gradients_as_graph_outputs;
 
+  config.graph_transformer_config.enable_gelu_approximation = parameters.enable_gelu_approximation;
+
   training::TrainingSession::TrainingConfigurationResult config_result{};
 
   OrtPybindThrowIfError(sess->ConfigureForTraining(config, config_result));
@@ -185,6 +188,7 @@ void addObjectMethodsForTraining(py::module& m) {
       .def_readwrite("gradient_accumulation_steps", &TrainingParameters::gradient_accumulation_steps)
       .def_readwrite("deepspeed_zero_stage", &TrainingParameters::deepspeed_zero_stage)
       .def_readwrite("enable_grad_norm_clip", &TrainingParameters::enable_grad_norm_clip)
+      .def_readwrite("enable_gelu_approximation", &TrainingParameters::enable_gelu_approximation)
       .def_readwrite("set_gradients_as_graph_outputs", &TrainingParameters::set_gradients_as_graph_outputs)
       .def_readwrite("use_invertible_layernorm_grad", &TrainingParameters::use_invertible_layernorm_grad);
 

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -824,6 +824,6 @@ class ORTTrainer(object):
 
     def _select_device_if_general_or_cpu_if_allfinite(self, device, name):
         if self.options.mixed_precision.enabled:
-            if output_name == self.model_desc.all_finite.name:
+            if name == self.model_desc.all_finite.name:
                 return torch.device('cpu')
         return device

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -174,6 +174,10 @@ class ORTTrainerOptions(object):
                             'type' : 'boolean',
                             'default' : True
                         }
+                        'enable_gelu_approximation' : {
+                            'type' : 'boolean',
+                            'default' : False
+                        }
                     }
                 }
              }
@@ -486,6 +490,10 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
             'enable_onnx_contrib_ops' : {
                 'type' : 'boolean',
                 'default' : True
+            },
+            'enable_gelu_approximation' : {
+                'type' : 'boolean',
+                'default' : False
             }
         }
     }


### PR DESCRIPTION
Enable higher performance from Python FE:
- Request 'all_finite' output tensor is bound to CPU
- Propagate GeluApproximation via option __internal_use.enable_gelu_approximation_.
(It's a holding place. Something like _graph_optimizations.enable_gelu_approximation_ would be more appropriate.)

**Motivation and Context**
The  'all_finite' tensor is bound to GPU by Python FE despite being output to CPU by IsAllFinite kernel. This causes the Python FE to block the CPU until the session is complete. It also causes needless CPU => GPU => CPU transfers. Also provide a means to propagate GeluApproximation to C++ backend.

As suggested, split into two PRs:
- https://github.com/microsoft/onnxruntime/pull/5372
- https://github.com/microsoft/onnxruntime/pull/5371