### PR TITLE
Exclude GPT2_LM_HEAD from OpenVino's model test list

### DIFF
--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -676,6 +676,7 @@ TEST_P(ModelTest, Run) {
                                                        ORT_TSTR("mlperf_ssd_resnet34_1200"),
                                                        ORT_TSTR("candy"),
                                                        ORT_TSTR("cntk_simple_seg"),
+                                                       ORT_TSTR("GPT2_LM_HEAD"),
                                                        ORT_TSTR("negative_log_likelihood_loss_input_shape_is_NCd1d2d3d4d5_mean_weight"),
                                                        ORT_TSTR("negative_log_likelihood_loss_input_shape_is_NCd1d2d3d4d5_mean_weight_expanded"),
                                                        ORT_TSTR("negative_log_likelihood_loss_input_shape_is_NCd1d2d3d4d5_none_no_weight"),


### PR DESCRIPTION
**Description**: 

Exclude GPT2_LM_HEAD from OpenVino's model test list

**Motivation and Context**

- Why is this change required? What problem does it solve?

GPT2_LM_HEAD is a **new** ONNX model zoo model that OpenVino doesn't support.

1: [ONNXRuntimeError] : 6 : RUNTIME_EXCEPTION : Non-zero status code returned while running OpenVINO-EP-subgraph_1162 node. Name:'OpenVINOExecutionProvider_OpenVINO-EP-subgraph_1162_1' Status Message: _Map_base::at


- If it fixes an open issue, please link to the issue here.
