### PR TITLE
Raise output mismatch error in ort_test_dir_utils.py

### DIFF
--- a/tools/python/ort_test_dir_utils.py
+++ b/tools/python/ort_test_dir_utils.py
@@ -240,4 +240,3 @@ def run_test_dir(model_or_dir):
             raise ValueError('FAILED due to output mismatch.')
         else:
             print('PASS')
-

--- a/tools/python/ort_test_dir_utils.py
+++ b/tools/python/ort_test_dir_utils.py
@@ -236,5 +236,8 @@ def run_test_dir(model_or_dir):
                     if not np.equal(expected, actual).all():
                         print('Mismatch for {}:\nExpected:{}\nGot:{}'.format(output_names[idx], expected, actual))
                         failed = True
+        if failed:
+            raise ValueError('FAILED due to output mismatch.')
+        else:
+            print('PASS')
 
-        print('FAILED' if failed else 'PASS')


### PR DESCRIPTION
**Description**:
Raise the error of output mismatch instead of simply printing message.

**Motivation and Context**
https://github.com/onnx/models/pull/379
To enable ORT backend testing for models from ONNX Model Zoo, use the ORT utility: `ort_test_dir_utils.py`
However, the error of output mismatch hasn't been caught.

cc @askhade