### PR TITLE
Adding Java support for getAvailableProviders and other small methods

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;

--- a/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
+++ b/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
@@ -6,6 +6,7 @@ package ai.onnxruntime;
 
 import ai.onnxruntime.OrtSession.SessionOptions;
 import java.io.IOException;
+import java.util.EnumSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
@@ -252,6 +253,15 @@ public class OrtEnvironment implements AutoCloseable {
         INSTANCE = null;
       }
     }
+  }
+
+  /**
+   * Gets the providers available in this environment.
+   *
+   * @return An enum set of the available execution providers.
+   */
+  public static EnumSet<OrtProvider> getAvailableProviders() {
+    return OnnxRuntime.providers.clone();
   }
 
   /**

--- a/java/src/main/java/ai/onnxruntime/OrtProvider.java
+++ b/java/src/main/java/ai/onnxruntime/OrtProvider.java
@@ -38,6 +38,21 @@ public enum OrtProvider {
     this.name = name;
   }
 
+  /**
+   * Accessor for the internal name of this provider.
+   *
+   * @return The internal provider name.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Maps from the name string used by ONNX Runtime into the enum.
+   *
+   * @param name The provider name string.
+   * @return The enum constant.
+   */
   public static OrtProvider mapFromName(String name) {
     OrtProvider provider = valueMap.get(name);
     if (provider == null) {

--- a/java/src/main/java/ai/onnxruntime/OrtProvider.java
+++ b/java/src/main/java/ai/onnxruntime/OrtProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the MIT License.
+ */
+package ai.onnxruntime;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** The execution providers available through the Java API. */
+public enum OrtProvider {
+  CPU("CPUExecutionProvider"),
+  CUDA("CUDAExecutionProvider"),
+  DNNL("DnnlExecutionProvider"),
+  NGRAPH("NGRAPHExecutionProvider"),
+  OPEN_VINO("OpenVINOExecutionProvider"),
+  NUPHAR("NupharExecutionProvider"),
+  VITIS_AI("VitisAIExecutionProvider"),
+  TENSOR_RT("TensorrtExecutionProvider"),
+  NNAPI("NnapiExecutionProvider"),
+  RK_NPU("RknpuExecutionProvider"),
+  DIRECT_ML("DmlExecutionProvider"),
+  MI_GRAPH_X("MIGraphXExecutionProvider"),
+  ACL("ACLExecutionProvider"),
+  ARM_NN("ArmNNExecutionProvider");
+
+  private static final Map<String, OrtProvider> valueMap = new HashMap<>(values().length);
+
+  static {
+    for (OrtProvider p : OrtProvider.values()) {
+      valueMap.put(p.name, p);
+    }
+  }
+
+  private final String name;
+
+  OrtProvider(String name) {
+    this.name = name;
+  }
+
+  public static OrtProvider mapFromName(String name) {
+    OrtProvider provider = valueMap.get(name);
+    if (provider == null) {
+      throw new IllegalArgumentException("Unknown execution provider - " + name);
+    } else {
+      return provider;
+    }
+  }
+}

--- a/java/src/main/java/ai/onnxruntime/OrtProvider.java
+++ b/java/src/main/java/ai/onnxruntime/OrtProvider.java
@@ -12,7 +12,6 @@ public enum OrtProvider {
   CPU("CPUExecutionProvider"),
   CUDA("CUDAExecutionProvider"),
   DNNL("DnnlExecutionProvider"),
-  NGRAPH("NGRAPHExecutionProvider"),
   OPEN_VINO("OpenVINOExecutionProvider"),
   NUPHAR("NupharExecutionProvider"),
   VITIS_AI("VitisAIExecutionProvider"),

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -316,6 +316,16 @@ public class OrtSession implements AutoCloseable {
   }
 
   /**
+   * Returns the timestamp that profiling started in nanoseconds.
+   *
+   * @return the profiling start time in ns.
+   * @throws OrtException If the native call failed.
+   */
+  public long getProfilingStartTime() throws OrtException {
+    return getProfilingStartTime(OnnxRuntime.ortApiHandle, nativeHandle);
+  }
+
+  /**
    * Ends the profiling session and returns the output of the profiler.
    *
    * <p>Profiling should be enabled in the {@link SessionOptions} used to construct this {@code
@@ -413,6 +423,8 @@ public class OrtSession implements AutoCloseable {
       long numOutputs,
       long runOptionsHandle)
       throws OrtException;
+
+  private native long getProfilingStartTime(long apiHandle, long nativeHandle) throws OrtException;
 
   private native String endProfiling(long apiHandle, long nativeHandle, long allocatorHandle)
       throws OrtException;
@@ -680,6 +692,32 @@ public class OrtSession implements AutoCloseable {
     }
 
     /**
+     * Sets the value of a symbolic dimension. Fixed dimension computations may have more
+     * optimizations applied to them.
+     *
+     * @param dimensionName The name of the symbolic dimension.
+     * @param dimensionValue The value to set that dimension to.
+     * @throws OrtException If there was an error in native code.
+     */
+    public void setSymbolicDimensionValue(String dimensionName, long dimensionValue)
+        throws OrtException {
+      checkClosed();
+      addFreeDimensionOverrideByName(
+          OnnxRuntime.ortApiHandle, nativeHandle, dimensionName, dimensionValue);
+    }
+
+    /**
+     * Disables the per session thread pools. Must be used in conjunction with an environment
+     * containing global thread pools.
+     *
+     * @throws OrtException If there was an error in native code.
+     */
+    public void disablePerSessionThreads() throws OrtException {
+      checkClosed();
+      disablePerSessionThreads(OnnxRuntime.ortApiHandle, nativeHandle);
+    }
+
+    /**
      * Adds a single session configuration entry as a pair of strings.
      *
      * @param configKey The config key string.
@@ -708,7 +746,6 @@ public class OrtSession implements AutoCloseable {
      * @throws OrtException If there was an error in native code.
      */
     public void addCUDA() throws OrtException {
-      checkClosed();
       addCUDA(0);
     }
 
@@ -870,6 +907,13 @@ public class OrtSession implements AutoCloseable {
     private native void closeCustomLibraries(long[] nativeHandle);
 
     private native void closeOptions(long apiHandle, long nativeHandle);
+
+    private native void addFreeDimensionOverrideByName(
+        long apiHandle, long nativeHandle, String dimensionName, long dimensionValue)
+        throws OrtException;
+
+    private native void disablePerSessionThreads(long apiHandle, long nativeHandle)
+        throws OrtException;
 
     private native void addConfigEntry(
         long apiHandle, long nativeHandle, String configKey, String configValue)

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -321,8 +321,8 @@ public class OrtSession implements AutoCloseable {
    * @return the profiling start time in ns.
    * @throws OrtException If the native call failed.
    */
-  public long getProfilingStartTime() throws OrtException {
-    return getProfilingStartTime(OnnxRuntime.ortApiHandle, nativeHandle);
+  public long getProfilingStartTimeInNs() throws OrtException {
+    return getProfilingStartTimeInNs(OnnxRuntime.ortApiHandle, nativeHandle);
   }
 
   /**
@@ -424,7 +424,8 @@ public class OrtSession implements AutoCloseable {
       long runOptionsHandle)
       throws OrtException;
 
-  private native long getProfilingStartTime(long apiHandle, long nativeHandle) throws OrtException;
+  private native long getProfilingStartTimeInNs(long apiHandle, long nativeHandle)
+      throws OrtException;
 
   private native String endProfiling(long apiHandle, long nativeHandle, long allocatorHandle)
       throws OrtException;

--- a/java/src/main/native/ai_onnxruntime_OrtSession.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession.c
@@ -310,6 +310,24 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OrtSession_run
     return outputArray;
 }
 
+
+/*
+ * Class:     ai_onnxruntime_OrtSession
+ * Method:    getProfilingStartTime
+ * Signature: (JJ)J
+ */
+JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtSession_getProfilingStartTime
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong sessionHandle) {
+  (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  OrtSession* session = (OrtSession*) sessionHandle;
+
+  uint64_t timestamp = 0;
+
+  checkOrtStatus(jniEnv,api,api->SessionGetProfilingStartTimeNs(session,&timestamp));
+  return (jlong) timestamp;
+}
+
 /*
  * Class:     ai_onnxruntime_OrtSession
  * Method:    endProfiling

--- a/java/src/main/native/ai_onnxruntime_OrtSession.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession.c
@@ -313,10 +313,10 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OrtSession_run
 
 /*
  * Class:     ai_onnxruntime_OrtSession
- * Method:    getProfilingStartTime
+ * Method:    getProfilingStartTimeInNs
  * Signature: (JJ)J
  */
-JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtSession_getProfilingStartTime
+JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtSession_getProfilingStartTimeInNs
     (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong sessionHandle) {
   (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
   const OrtApi* api = (const OrtApi*) apiHandle;

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -297,6 +297,39 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_closeC
 
 /*
  * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    addFreeDimensionOverrideByName
+ * Signature: (JJLjava/lang/String;J)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_addFreeDimensionOverrideByName
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong optionsHandle, jstring dimensionName, jlong dimensionValue) {
+  (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  OrtSessionOptions* options = (OrtSessionOptions*) optionsHandle;
+
+  // Extract the string chars
+  const char* cName = (*jniEnv)->GetStringUTFChars(jniEnv, dimensionName, NULL);
+
+  checkOrtStatus(jniEnv,api,api->AddFreeDimensionOverrideByName(options,cName,dimensionValue));
+
+  // Release the string chars
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv,dimensionName,cName);
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    disablePerSessionThreads
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_disablePerSessionThreads
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong optionsHandle) {
+  (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  OrtSessionOptions* options = (OrtSessionOptions*) optionsHandle;
+  checkOrtStatus(jniEnv,api,api->DisablePerSessionThreads(options));
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
  * Method:    addConfigEntry
  * Signature: (JJLjava/lang/String;Ljava/lang/String;)V
  */

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -576,8 +577,52 @@ public class InferenceTest {
   }
 
   @Test
+  public void testProviders() {
+    EnumSet<OrtProvider> providers = OrtEnvironment.getAvailableProviders();
+    int providersSize = providers.size();
+    assertTrue(providersSize > 0);
+    assertTrue(providers.contains(OrtProvider.CPU));
+
+    // Check that the providers are a copy of the original, note this does not enable the DNNL
+    // provider
+    providers.add(OrtProvider.DNNL);
+    assertEquals(providersSize, OrtEnvironment.getAvailableProviders().size());
+  }
+
+
+  @Test
+  public void testSymbolicDimensionAssignment() throws OrtException {
+    // model takes 1x5 input of fixed type, echoes back
+    String modelPath = getResourcePath("/capi_symbolic_dims.onnx").toString();
+
+    try (OrtEnvironment env = OrtEnvironment.getEnvironment("testSymbolicDimensionAssignment")) {
+      // Check the dimension is symbolic
+      try (SessionOptions options = new SessionOptions()) {
+        try (OrtSession session = env.createSession(modelPath, options)) {
+          Map<String, NodeInfo> infoMap = session.getInputInfo();
+          TensorInfo aInfo = (TensorInfo) infoMap.get("A").getInfo();
+          assertArrayEquals(new long[]{-1, 2}, aInfo.shape);
+        }
+      }
+      // Check that when the options are assigned it overrides the symbolic dimension
+      try (SessionOptions options = new SessionOptions()) {
+        options.setSymbolicDimensionValue("n",5);
+        try (OrtSession session = env.createSession(modelPath, options)) {
+          Map<String,NodeInfo> infoMap = session.getInputInfo();
+          TensorInfo aInfo = (TensorInfo) infoMap.get("A").getInfo();
+          assertArrayEquals(new long[]{5,2},aInfo.shape);
+        }
+      }
+    }
+  }
+
+  @Test
   public void testCUDA() throws OrtException {
     if (System.getProperty("USE_CUDA") != null) {
+      EnumSet<OrtProvider> providers = OrtEnvironment.getAvailableProviders();
+      assertTrue(providers.size() > 1);
+      assertTrue(providers.contains(OrtProvider.CPU));
+      assertTrue(providers.contains(OrtProvider.CUDA));
       SqueezeNetTuple tuple = openSessionSqueezeNet(0);
       try (OrtEnvironment env = tuple.env;
           OrtSession session = tuple.session) {
@@ -926,6 +971,10 @@ public class InferenceTest {
             boolean[] resultArray = TestHelpers.flattenBoolean(res.get(0).getValue());
             assertArrayEquals(flatInput, resultArray);
           }
+          // Check that the profiling start time doesn't throw
+          long profilingStartTime = session.getProfilingStartTime();
+
+          // Check the profiling output doesn't throw
           String profilingOutput = session.endProfiling();
           File profilingOutputFile = new File(profilingOutput);
           profilingOutputFile.deleteOnExit();
@@ -1208,6 +1257,7 @@ public class InferenceTest {
         assertEquals(OnnxJavaType.FLOAT, sequenceInfo.mapInfo.valueType);
 
         // try-cast first element in sequence to map/dictionary type
+        @SuppressWarnings("unchecked")
         Map<Long, Float> map = (Map<Long, Float>) ((List<Object>) secondOutput.getValue()).get(0);
         assertEquals(0.25938290, map.get(0L), 1e-6);
         assertEquals(0.40904793, map.get(1L), 1e-6);
@@ -1274,6 +1324,7 @@ public class InferenceTest {
         assertEquals(OnnxJavaType.FLOAT, sequenceInfo.mapInfo.valueType);
 
         // try-cast first element in sequence to map/dictionary type
+        @SuppressWarnings("unchecked")
         Map<String, Float> map =
             (Map<String, Float>) ((List<Object>) secondOutput.getValue()).get(0);
         assertEquals(0.25938290, map.get("0"), 1e-6);

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -589,7 +589,6 @@ public class InferenceTest {
     assertEquals(providersSize, OrtEnvironment.getAvailableProviders().size());
   }
 
-
   @Test
   public void testSymbolicDimensionAssignment() throws OrtException {
     // model takes 1x5 input of fixed type, echoes back
@@ -601,16 +600,16 @@ public class InferenceTest {
         try (OrtSession session = env.createSession(modelPath, options)) {
           Map<String, NodeInfo> infoMap = session.getInputInfo();
           TensorInfo aInfo = (TensorInfo) infoMap.get("A").getInfo();
-          assertArrayEquals(new long[]{-1, 2}, aInfo.shape);
+          assertArrayEquals(new long[] {-1, 2}, aInfo.shape);
         }
       }
       // Check that when the options are assigned it overrides the symbolic dimension
       try (SessionOptions options = new SessionOptions()) {
-        options.setSymbolicDimensionValue("n",5);
+        options.setSymbolicDimensionValue("n", 5);
         try (OrtSession session = env.createSession(modelPath, options)) {
-          Map<String,NodeInfo> infoMap = session.getInputInfo();
+          Map<String, NodeInfo> infoMap = session.getInputInfo();
           TensorInfo aInfo = (TensorInfo) infoMap.get("A").getInfo();
-          assertArrayEquals(new long[]{5,2},aInfo.shape);
+          assertArrayEquals(new long[] {5, 2}, aInfo.shape);
         }
       }
     }

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -971,7 +971,7 @@ public class InferenceTest {
             assertArrayEquals(flatInput, resultArray);
           }
           // Check that the profiling start time doesn't throw
-          long profilingStartTime = session.getProfilingStartTime();
+          long profilingStartTime = session.getProfilingStartTimeInNs();
 
           // Check the profiling output doesn't throw
           String profilingOutput = session.endProfiling();

--- a/java/src/test/java/ai/onnxruntime/TestHelpers.java
+++ b/java/src/test/java/ai/onnxruntime/TestHelpers.java
@@ -166,6 +166,7 @@ class TestHelpers {
     }
   }
 
+  @SuppressWarnings("unchecked")
   static void flattenBase(Object input, List output, Class<?> primitiveClass) {
     if (primitiveClass.equals(boolean.class)) {
       flattenBooleanBase((boolean[]) input, output);


### PR DESCRIPTION
**Description**: 
Adds a Java EnumSet which represents the available providers so the user can query them. This is instantiated on native library load, and made available on the `OrtEnvironment`.

Also this PR adds a few small methods to `OrtSession` and `SessionOptions`:
- OrtSession.getProfilingStartTime
- SessionOptions.setSymbolicDimensionValue
- SessionOptions.disablePerSessionThreads.

The last method doesn't really do anything on it's own, but adding support for threading options to the OrtEnvironment is a larger change I'll do in a separate PR.

**Motivation and Context**
- Why is this change required? What problem does it solve? Passes through new C API methods into the Java API.
