### PR TITLE
Add long type support for SplitToSequence operator

### DIFF
--- a/onnxruntime/core/providers/cpu/sequence/sequence_ops.cc
+++ b/onnxruntime/core/providers/cpu/sequence/sequence_ops.cc
@@ -334,6 +334,7 @@ ONNX_CPU_OPERATOR_KERNEL(
                                           DataTypeImpl::GetTensorType<float>(),
                                           DataTypeImpl::GetTensorType<double>(),
                                           DataTypeImpl::GetTensorType<int32_t>(),
+                                          DataTypeImpl::GetTensorType<int64_t>(),
                                           DataTypeImpl::GetTensorType<std::string>()})
         .TypeConstraint("S", DataTypeImpl::AllSequenceTensorTypes())
         .TypeConstraint("I", std::vector<MLDataType>{
@@ -358,6 +359,8 @@ Status SplitToSequence::Compute(OpKernelContext* context) const {
     status = ComputeImpl<double>(*context, input, p_split_input);
   else if (input.IsDataType<int32_t>())
     status = ComputeImpl<int32_t>(*context, input, p_split_input);
+  else if (input.IsDataType<int64_t>())
+    status = ComputeImpl<int64_t>(*context, input, p_split_input);
   else if (input.IsDataTypeString())
     status = ComputeImpl<std::string>(*context, input, p_split_input);
   else

--- a/onnxruntime/test/providers/cpu/sequence/sequence_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/sequence/sequence_ops_test.cc
@@ -317,6 +317,17 @@ TEST(SequenceOpsTest, SplitToSequence_DefaultAxis0EqualSplitFloat) {
   test.Run();
 }
 
+TEST(SequenceOpsTest, SplitToSequence_DefaultAxis0EqualSplitLong) {
+  OpTester test("SplitToSequence", 11);
+  test.AddInput<int64_t>("input", {4, 2}, GetConsequtiveVector<int64_t>(1, 8));
+  test.AddInput<int64_t>("split", {1, 2}, {2, 2});
+  SeqTensors<int64_t> output;
+  output.AddTensor({2, 2}, {1, 2, 3, 4});
+  output.AddTensor({2, 2}, {5, 6, 7, 8});
+  test.AddSeqOutput("S2", output);
+  test.Run();
+}
+
 TEST(SequenceOpsTest, SplitToSequence_DefaultAxis0EqualSplitFloatScalarSplit) {
   OpTester test("SplitToSequence", 11);
   test.AddInput<float>("input", {4, 2}, GetConsequtiveVector<float>(1.f, 8));


### PR DESCRIPTION
**Description**: Add long type support for SplitToSequence operator.

**Motivation and Context**
PyTorch exported model calls this operator on LongTensor.
