### PR TITLE
Place allfinite tensor on CPU when using Python FE

### DIFF
--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -99,12 +99,7 @@ def ort_training_session_run_helper(session, iobinding, inputs, input_descs, out
     output_descs_resolved = resolve_symbolic_dimensions(inputs, input_descs, output_descs)
     torch_outputs = {}
     for output_desc in output_descs_resolved:
-        target_device = self.options.device.id
-        if self.options.mixed_precision.enabled and name == self.model_desc.all_finite.name:
-            # Keep all finite flag on CPU to match backend implementation
-            # This prevents CPU -> GPU -> CPU copies between frontend and backend
-            target_device = 'cpu'
-        torch_tensor = torch.zeros(output_desc.shape_, device=target_device,
+        torch_tensor = torch.zeros(output_desc.shape_, device=device,
                                    dtype=output_desc.eval_dtype_ if hasattr(output_desc, 'eval_dtype_')
                                    else output_desc.dtype_)
         iobinding.bind_output(output_desc.name_, torch_tensor.device.type, get_device_index(device),

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -787,7 +787,12 @@ class ORTTrainer(object):
         outputs_desc_resolved = self._resolve_symbolic_dimensions(inputs, inputs_desc, outputs_desc)
         result = {}
         for output_desc in outputs_desc_resolved:
-            torch_tensor = torch.zeros(output_desc.shape, device=self.options.device.id,
+            target_device = self.options.device.id
+            if self.options.mixed_precision.enabled and output_desc.name == self.model_desc.all_finite.name:
+                # Keep all finite flag on CPU to match backend implementation
+                # This prevents CPU -> GPU -> CPU copies between frontend and backend
+                target_device = 'cpu'
+            torch_tensor = torch.zeros(output_desc.shape, device=target_device,
                                        dtype=output_desc.dtype_amp if output_desc.dtype_amp else output_desc.dtype)
             iobinding.bind_output(output_desc.name, torch_tensor.device.type, _utils.get_device_index(self.options.device.id),
                                   _utils.dtype_torch_to_numpy(torch_tensor.dtype),


### PR DESCRIPTION
Split from https://github.com/microsoft/onnxruntime/pull/5354

**Description**: Describe your changes.
Request 'all_finite' output tensor is bound to CPU

**Motivation and Context**
- Why is this change required? What problem does it solve?
The 'all_finite' tensor is bound to GPU by Python FE despite being output to CPU by IsAllFinite kernel. This causes the Python FE to block the CPU until the session is complete. It also causes needless CPU => GPU => CPU transfers. 