### PR TITLE
Provide means to toggle Gelu approximation from Python FE

### DIFF
--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -45,6 +45,7 @@ struct TrainingParameters {
   int horizontal_parallel_size = 1;
   int deepspeed_zero_stage = 0;
   bool enable_grad_norm_clip = true;
+  bool enable_gelu_approximation = false;
   bool set_gradients_as_graph_outputs = false;
   bool use_invertible_layernorm_grad = false;
 };
@@ -130,6 +131,8 @@ TrainingConfigurationResult ConfigureSessionForTraining(
   config.gradient_graph_config.use_invertible_layernorm_grad = parameters.use_invertible_layernorm_grad;
   config.gradient_graph_config.set_gradients_as_graph_outputs = parameters.set_gradients_as_graph_outputs;
 
+  config.graph_transformer_config.enable_gelu_approximation = parameters.enable_gelu_approximation;
+
   training::TrainingSession::TrainingConfigurationResult config_result{};
 
   OrtPybindThrowIfError(sess->ConfigureForTraining(config, config_result));
@@ -185,6 +188,7 @@ void addObjectMethodsForTraining(py::module& m) {
       .def_readwrite("gradient_accumulation_steps", &TrainingParameters::gradient_accumulation_steps)
       .def_readwrite("deepspeed_zero_stage", &TrainingParameters::deepspeed_zero_stage)
       .def_readwrite("enable_grad_norm_clip", &TrainingParameters::enable_grad_norm_clip)
+      .def_readwrite("enable_gelu_approximation", &TrainingParameters::enable_gelu_approximation)
       .def_readwrite("set_gradients_as_graph_outputs", &TrainingParameters::set_gradients_as_graph_outputs)
       .def_readwrite("use_invertible_layernorm_grad", &TrainingParameters::use_invertible_layernorm_grad);
 

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -623,6 +623,7 @@ class ORTTrainer(object):
         ort_parameters.allreduce_post_accumulation = self.options.distributed.allreduce_post_accumulation
         ort_parameters.deepspeed_zero_stage = self.options.distributed.deepspeed_zero_optimization.stage
         ort_parameters.enable_grad_norm_clip = self.options.utils.grad_norm_clip
+        ort_parameters.enable_gelu_approximation = self.options._internal_use.enable_gelu_approximation
         ort_parameters.set_gradients_as_graph_outputs = False
         ort_parameters.use_invertible_layernorm_grad = self.options.utils.invertible_layer_norm_gradient
         ort_parameters.training_optimizer_name = self.optim_config.name

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -174,6 +174,10 @@ class ORTTrainerOptions(object):
                             'type' : 'boolean',
                             'default' : True
                         }
+                        'enable_gelu_approximation' : {
+                            'type' : 'boolean',
+                            'default' : False
+                        }
                     }
                 }
              }
@@ -486,6 +490,10 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
             'enable_onnx_contrib_ops' : {
                 'type' : 'boolean',
                 'default' : True
+            },
+            'enable_gelu_approximation' : {
+                'type' : 'boolean',
+                'default' : False
             }
         }
     }

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -248,6 +248,9 @@ class ORTTrainerOptions(object):
         _internal_use.enable_onnx_contrib_ops (bool, default is True)
             enable PyTorch to export nodes as contrib ops in ONNX.
             This flag may be removed anytime in the future.
+        _internal_use.enable_gelu_approximation (bool, default is False)
+            enable approximation on gelu activations for speed up.
+            This flag may be removed anytime in the future.
 
     Example:
         .. code-block:: python


### PR DESCRIPTION
Split from https://github.com/microsoft/onnxruntime/pull/5354

**Description**:
Propagate GeluApproximation via option _internal_use.enable_gelu_approximation.
(It's a holding place. Something like graph_optimizations.enable_gelu_approximation would be more appropriate.)

**Motivation and Context**
- Why is this change required? What problem does it solve?
Enable higher performance from Python FE for transformer models using Gelu activations.