### PR TITLE
Support OuterStride for QGemm when MLAS_SUPPORTS_GEMM_U8X8 undefined

### DIFF
--- a/onnxruntime/core/util/gemmlowp_common.cc
+++ b/onnxruntime/core/util/gemmlowp_common.cc
@@ -40,9 +40,19 @@ MakeOutputPipelineWithOutBias(std::int32_t result_offset,
   return std::make_tuple(quantize_down_stage, saturating_cast_stage);
 }
 
-void GemmlowpMultiplyu8u8_u8(const uint8_t* lhs_data, const uint8_t* rhs_data, uint8_t* result_data,
-                        const int lhs_offset, const int rhs_offset, const int result_offset,
-                        int m, int n, int k, int32_t int_multiplier, int32_t right_shift, const int32_t* bias) {
+void GemmlowpMultiplyu8u8_u8(
+    const uint8_t* lhs_data,
+    const uint8_t* rhs_data,
+    uint8_t* result_data,
+    const int lhs_offset,
+    const int rhs_offset,
+    const int result_offset,
+    int m,
+    int n,
+    int k,
+    int32_t int_multiplier,
+    int32_t right_shift,
+    const int32_t* bias) {
   // TODO exp ColMajor order for rhs and result. That may be faster
   const auto matOrder = gemmlowp::MapOrder::RowMajor;
   gemmlowp::MatrixMap<const uint8_t, matOrder> lhs(lhs_data, m, k);
@@ -64,13 +74,23 @@ void GemmlowpMultiplyu8u8_u8(const uint8_t* lhs_data, const uint8_t* rhs_data, u
   }
 }
 
-void GemmlowpMultiplyu8u8_s32(const uint8_t* lhs_data, const uint8_t* rhs_data, int32_t* result_data,
-                                const int lhs_offset, const int rhs_offset, int m, int n, int k, concurrency::ThreadPool* ) {
-
+void GemmlowpMultiplyu8u8_s32(
+    const uint8_t* lhs_data,
+    const uint8_t* rhs_data,
+    int32_t* result_data,
+    const int lhs_offset,
+    const int rhs_offset,
+    int m,
+    int n,
+    int k,
+    int lda,
+    int ldb,
+    int ldc,
+    concurrency::ThreadPool*) {
   const auto matOrder = gemmlowp::MapOrder::RowMajor;
-  gemmlowp::MatrixMap<const uint8_t, matOrder> lhs(lhs_data, m, k);
-  gemmlowp::MatrixMap<const uint8_t, matOrder> rhs(rhs_data, k, n);
-  gemmlowp::MatrixMap<std::int32_t, matOrder> result(result_data, m, n);
+  gemmlowp::MatrixMap<const uint8_t, matOrder> lhs(lhs_data, m, k, lda);
+  gemmlowp::MatrixMap<const uint8_t, matOrder> rhs(rhs_data, k, n, ldb);
+  gemmlowp::MatrixMap<std::int32_t, matOrder> result(result_data, m, n, ldc);
 
   gemmlowp::GemmContext gemm_context;
 
@@ -80,4 +100,4 @@ void GemmlowpMultiplyu8u8_s32(const uint8_t* lhs_data, const uint8_t* rhs_data, 
       &gemm_context, lhs, rhs, &result, -lhs_offset, -rhs_offset, empty_pipeline);
 }
 
-}
+}  // namespace onnxruntime

--- a/onnxruntime/core/util/gemmlowp_common.h
+++ b/onnxruntime/core/util/gemmlowp_common.h
@@ -29,11 +29,12 @@ void inline QuantizeMultiplier(float fp_multiplier, std::int32_t* integer_multip
 }
 
 void GemmlowpMultiplyu8u8_u8(const uint8_t* lhs_data, const uint8_t* rhs_data, uint8_t* result_data,
-                        const int lhs_offset, const int rhs_offset, const int result_offset,
-                        int m, int n, int k, int32_t int_multiplier, int32_t right_shift, const int32_t* bias = nullptr);
+                             const int lhs_offset, const int rhs_offset, const int result_offset,
+                             int m, int n, int k, int32_t int_multiplier, int32_t right_shift, const int32_t* bias = nullptr);
 
 void GemmlowpMultiplyu8u8_s32(const uint8_t* lhs_data, const uint8_t* rhs_data, int32_t* result_data,
-                             const int lhs_offset, const int rhs_offset, int m, int n, int k, concurrency::ThreadPool*);
+                              const int lhs_offset, const int rhs_offset,
+                              int m, int n, int k, int lda, int ldb, int ldc, concurrency::ThreadPool*);
 
 }  // namespace onnxruntime
 

--- a/onnxruntime/core/util/math_cpuonly.h
+++ b/onnxruntime/core/util/math_cpuonly.h
@@ -63,24 +63,41 @@ namespace onnxruntime {
 // common Eigen types that we will often use
 template <typename T>
 using EigenMatrixMap = Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>;
+
 template <typename T>
 using EigenArrayMap = Eigen::Map<Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic>>;
+
 template <typename T>
 using EigenVectorMap = Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>>;
+
 template <typename T>
 using EigenVectorArrayMap = Eigen::Map<Eigen::Array<T, Eigen::Dynamic, 1>>;
+
 template <typename T>
 using ConstEigenMatrixMap = Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>;
+
 template <typename T>
 using ConstEigenArrayMap = Eigen::Map<const Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic>>;
+
 template <typename T>
 using ConstEigenVectorMap = Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>>;
+
 template <typename T>
 using ConstEigenVectorArrayMap = Eigen::Map<const Eigen::Array<T, Eigen::Dynamic, 1>>;
+
 template <typename T>
 using EigenMatrixMapRowMajor = Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+
 template <typename T>
 using ConstEigenMatrixMapRowMajor = Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+
+template <typename T>
+using EigenMatrixMapRowMajorOuterStride =
+    Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>, 0, Eigen::OuterStride<>>;
+
+template <typename T>
+using ConstEigenMatrixMapRowMajorOuterStride =
+    Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>, 0, Eigen::OuterStride<>>;
 
 template <typename T>
 auto EigenMap(Tensor& t) -> EigenVectorMap<T> {


### PR DESCRIPTION
**Description**: Describe your changes.
Quantized GEMM on ARM doesn't support the case that leading dimension is not equal to column size. The PR adds support of this case.
