### PR TITLE
Don't change global FPU state during round-half-to-even

### DIFF
--- a/onnxruntime/core/util/qmath.h
+++ b/onnxruntime/core/util/qmath.h
@@ -51,9 +51,7 @@ void QGemm(
     concurrency::ThreadPool* thread_pool);
 
 inline float RoundHalfToEven(float input) {
-  std::fesetround(FE_TONEAREST);
-  auto result = std::nearbyintf(input);
-  return result;
+  return input - std::remainderf(input, 1.f);
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/util/qmath.h
+++ b/onnxruntime/core/util/qmath.h
@@ -51,6 +51,10 @@ void QGemm(
     concurrency::ThreadPool* thread_pool);
 
 inline float RoundHalfToEven(float input) {
+  if (!std::isfinite(input)) {
+    return input;
+  }
+  // std::remainder returns x - n, where n is the integral value nearest to x. When |x - n| = 0.5, n is chosen to be even
   return input - std::remainderf(input, 1.f);
 }
 


### PR DESCRIPTION
**Description**: Do round-half-to-even without affecting global FPU state. There's no need to change global FPU state to do the operation. The change in global FPU state was also being flagged by the osmode CRT.

**Motivation and Context**
- Stop modifying global program state
- Make it build with the osmode CRT
