### PR TITLE
Move flatbuffers to 1.12 release

### DIFF
--- a/cgmanifests/submodules/cgmanifest.json
+++ b/cgmanifests/submodules/cgmanifest.json
@@ -85,7 +85,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "db2aa9b4eca0edc94aea9e2059c21ce8786fc762",
+          "commitHash": "6df40a2471737b27271bdd9b900ab5f3aec746c7",
           "repositoryUrl": "https://github.com/google/flatbuffers.git"
         },
         "comments": "git submodule at cmake/external/flatbuffers"


### PR DESCRIPTION
**Description**: Move flatbuffers to 1.12 release

**Motivation and Context**
- A flatbuffers release branch is preferred by OXO for security review than using master branch
- This change is independent of #5378
