### PR TITLE
Fix double free in test case

### DIFF
--- a/winml/adapter/winml_adapter_dml.cpp
+++ b/winml/adapter/winml_adapter_dml.cpp
@@ -146,6 +146,7 @@ ORT_API_STATUS_IMPL(winmla::DmlGetD3D12ResourceFromAllocation, _In_ OrtExecution
       Dml::GetD3D12ResourceFromAllocation(
           dml_provider_internal->GetAllocator(0, ::OrtMemType::OrtMemTypeDefault).get(),
           allocation);
+  (*d3d_resource)->AddRef();
 #endif  // USE_DML USE_DML
   return nullptr;
   API_IMPL_END

--- a/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
@@ -179,11 +179,11 @@ HRESULT OnnxruntimeValue::GetResource(_winml::Resource& out) {
 
   bool is_cpu = false;
   if (SUCCEEDED(IsCpu(&is_cpu)) && !is_cpu) {
-    void* resource;
+    winrt::com_ptr<ID3D12Resource> resource;
     RETURN_HR_IF_NOT_OK_MSG(winml_adapter_api->DmlGetD3D12ResourceFromAllocation(ort_provider, mutable_data,
-                                                                                 reinterpret_cast<ID3D12Resource**>(&resource)),
+                                                                                 resource.put()),
                             ort_api);
-    out = _winml::Resource(resource, [](void*) { /*do nothing, as this pointer is actually a com pointer! */ });
+    out = _winml::Resource(resource.get(), [](void*) { /*do nothing, as this pointer is actually a com pointer! */ });
   } else {
     int is_tensor;
     RETURN_HR_IF_NOT_OK_MSG(ort_api->IsTensor(value_.get(), &is_tensor),

--- a/winml/test/adapter/AdapterDmlEpTest.cpp
+++ b/winml/test/adapter/AdapterDmlEpTest.cpp
@@ -135,6 +135,7 @@ winrt::com_ptr<ID3D12Resource> CreateD3D12Resource(ID3D12Device& device) {
   return d3d12_resource;
 }
 
+
 void DmlCreateAndFreeGPUAllocationFromD3DResource() {
   GPUTEST;
   winrt::com_ptr<ID3D12Device> device;


### PR DESCRIPTION
**Description**: `d3d12_resource` and `d3d12_resource_from_allocation` have the same value and get freed twice when using smart pointers. This was causing intermittent failures in pipelines.