### PR TITLE
Implemented GitHub Actions workflow for Docker Images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: Docker builds
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  cpu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build cpu Docker
+        run: docker build -t onnxruntime-source -f dockerfiles/Dockerfile.source .
+
+  cuda:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build cuda Docker
+        run: docker build -t onnxruntime-cuda -f dockerfiles/Dockerfile.cuda .
+
+  nGraph:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build nGraph Docker
+        run: docker build -t onnxruntime-ngraph -f dockerfiles/Dockerfile.ngraph .
+
+  TensorRT:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build TensorRT Docker
+        run: docker build -t onnxruntime-trt -f dockerfiles/Dockerfile.tensorrt .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,15 +27,6 @@ jobs:
       - name: Build cuda Docker
         run: docker build -t onnxruntime-cuda -f dockerfiles/Dockerfile.cuda .
 
-  nGraph:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build nGraph Docker
-        run: docker build -t onnxruntime-ngraph -f dockerfiles/Dockerfile.ngraph .
-
   TensorRT:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**Description**: Implemented GitHub Actions workflow for Docker Images

**Motivation and Context**
- A simple CI to build some of the Docker images.
- Since it takes too long to build all the images, I've implemented just 3 of them for now
- We can have on badge for all of them or one for each, like this one:

![Docker builds](https://github.com/leozz37/onnxruntime/workflows/Docker%20builds/badge.svg)