### PR TITLE
iOS Sample: Use relative path for HEADER_SEARCH_PATHS

### DIFF
--- a/samples/iOS/ONNXModelRunner.xcodeproj/project.pbxproj
+++ b/samples/iOS/ONNXModelRunner.xcodeproj/project.pbxproj
@@ -342,7 +342,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.0.2;
 				DEVELOPMENT_TEAM = QBMN2BBW3K;
-				HEADER_SEARCH_PATHS = /Users/wenbingl/Project/lotus/include/onnxruntime;
+				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../../include/onnxruntime";
 				INFOPLIST_FILE = "$(SRCROOT)/ModelRunner/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -364,7 +364,7 @@
 				CURRENT_PROJECT_VERSION = 0.0.2;
 				DEVELOPMENT_TEAM = QBMN2BBW3K;
 				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = /Users/wenbingl/Project/lotus/include/onnxruntime;
+				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../../include/onnxruntime";
 				INFOPLIST_FILE = "$(SRCROOT)/ModelRunner/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
**Description**: Describe your changes.
Use relative path for HEADER_SEARCH_PATHS instead of a personal absolute directory path for iOS Sample.

**Motivation and Context**
- Why is this change required? What problem does it solve?
Currently HEADER_SEARCH_PATHS refers a personal directory and it does not work for other users.

- If it fixes an open issue, please link to the issue here.
Could not find an open issue for this.