### PR TITLE
revert contrib op version bump and deprecation of TransposeMatMul

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -2088,16 +2088,48 @@ This version of the operator has been available since version 1 of the 'com.micr
 </dl>
 
 
-### <a name="com.microsoft.TransposeMatMul"></a><a name="com.microsoft.transposematmul">**com.microsoft.TransposeMatMul** (deprecated)</a>
+### <a name="com.microsoft.TransposeMatMul"></a><a name="com.microsoft.transposematmul">**com.microsoft.TransposeMatMul**</a>
 
-  Deprecated. Going forward FusedMatMul should be used. This OP will be supported for backward compatibility. 
+  Duplicate of FusedMatMul. Going forward FusedMatMul should be used. This OP will be supported for backward compatibility. 
   Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html
 
 #### Version
 
-This version of the operator has been deprecated since version 2 of the 'com.microsoft' operator set.
+This version of the operator has been available since version 1 of the 'com.microsoft' operator set.
 
-Other versions of this operator: com.microsoft.TransposeMatMul-1
+#### Attributes
+
+<dl>
+<dt><tt>alpha</tt> : float</dt>
+<dd>Scalar multiplier for the product of the input tensors.</dd>
+<dt><tt>transA</tt> : int</dt>
+<dd>Whether A should be transposed on the last two dimensions before doing multiplication</dd>
+<dt><tt>transB</tt> : int</dt>
+<dd>Whether B should be transposed on the last two dimensions before doing multiplication</dd>
+</dl>
+
+#### Inputs
+
+<dl>
+<dt><tt>A</tt> : T</dt>
+<dd>N-dimensional matrix A</dd>
+<dt><tt>B</tt> : T</dt>
+<dd>N-dimensional matrix B</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>Y</tt> : T</dt>
+<dd>Matrix multiply results</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(bfloat16)</dt>
+<dd>Constrain input and output types to float tensors.</dd>
+</dl>
 
 
 ### <a name="com.microsoft.Trilu"></a><a name="com.microsoft.trilu">**com.microsoft.Trilu**</a>

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -1879,7 +1879,7 @@ Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-
       });
 
   static const char* TransposeMatMul_doc = R"DOC(
-Deprecated. Going forward FusedMatMul should be used. This OP will be supported for backward compatibility. 
+Duplicate of FusedMatMul. Going forward FusedMatMul should be used. This OP will be supported for backward compatibility. 
 Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html
 )DOC";
 
@@ -1890,37 +1890,6 @@ Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-
   ONNX_CONTRIB_OPERATOR_SCHEMA(TransposeMatMul)
       .SetDomain(kMSDomain)
       .SinceVersion(1)
-      .Input(0, "A", "N-dimensional matrix A", "T")
-      .Input(1, "B", "N-dimensional matrix B", "T")
-      .Attr(
-          "alpha",
-          "Scalar multiplier for the product of the input tensors.",
-          AttributeProto::FLOAT,
-          1.0f)
-      .Attr(
-          "transA",
-          "Whether A should be transposed on the last two dimensions before doing multiplication",
-          AttributeProto::INT,
-          static_cast<int64_t>(0))
-      .Attr(
-          "transB",
-          "Whether B should be transposed on the last two dimensions before doing multiplication",
-          AttributeProto::INT,
-          static_cast<int64_t>(0))
-      .Output(0, "Y", "Matrix multiply results", "T")
-      .TypeConstraint(
-          "T",
-          {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-          "Constrain input and output types to float tensors.")
-      .SetDoc(TransposeMatMul_doc)
-      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        FusedMatMulShapeInference(ctx);
-      });
-
-  ONNX_CONTRIB_OPERATOR_SCHEMA(TransposeMatMul)
-      .SetDomain(kMSDomain)
-      .SinceVersion(2)
-      .Deprecate()
       .Input(0, "A", "N-dimensional matrix A", "T")
       .Input(1, "B", "N-dimensional matrix B", "T")
       .Attr(

--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -92,7 +92,7 @@ Status Environment::Initialize(std::unique_ptr<logging::LoggingManager> logging_
 #if !defined(ORT_MINIMAL_BUILD)
     // Register Microsoft domain with min/max op_set version as 1/1.
     std::call_once(schemaRegistrationOnceFlag, []() {
-      ONNX_NAMESPACE::OpSchemaRegistry::DomainToVersionRange::Instance().AddDomainToVersion(onnxruntime::kMSDomain, 1, 2);
+      ONNX_NAMESPACE::OpSchemaRegistry::DomainToVersionRange::Instance().AddDomainToVersion(onnxruntime::kMSDomain, 1, 1);
       ONNX_NAMESPACE::OpSchemaRegistry::DomainToVersionRange::Instance().AddDomainToVersion(onnxruntime::kMSNchwcDomain, 1, 1);
       ONNX_NAMESPACE::OpSchemaRegistry::DomainToVersionRange::Instance().AddDomainToVersion(onnxruntime::kMSFeaturizersDomain, 1, 1);
 #ifdef USE_DML

--- a/onnxruntime/test/contrib_ops/fused_matmul_op_test.cc
+++ b/onnxruntime/test/contrib_ops/fused_matmul_op_test.cc
@@ -218,24 +218,6 @@ TEST(TransposeMatMulOpTest, FloatTypeScale) {
   RunFusedMatMulTest<float>("TransposeMatMul", 1, true, true, 4.0f, true);
 }
 
-TEST(TransposeMatMulOpTest, DeprecatedSchema) {
-  OpTester test("TransposeMatMul", 2, onnxruntime::kMSDomain);
-
-  std::vector<int64_t> input0_dims{3, 4};
-  std::vector<float> input0_vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
-
-  std::vector<int64_t> input1_dims{4, 3};
-  std::vector<float> input1_vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
-
-  test.AddInput<float>("A", input0_dims, input0_vals);
-  test.AddInput<float>("B", input1_dims, input1_vals);
-  test.AddOutput<float>("Y", {3, 3}, {42, 48, 54, 114, 136, 158, 186, 224, 262});
-
-  // TransposeMatMul is deprecated from version 2 onwards of ms domain.
-  test.Run(OpTester::ExpectResult::kExpectFailure);
-}
-
-
 }  // namespace transpose_matmul
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**: Reverting the version bump for contrib ops and deprecation of TransposeMatMul op. 

**Motivation and Context**
All contrib ops will always remain at version 1. When a contrib op needs to be updated in a bc breaking manner, a new contrib op should be created (instead of updating the existing op). This was decided to simplify maintenance of contrib ops. 
