### PR TITLE
Use correct protoc tool file name for C# builds

### DIFF
--- a/csharp/tools/Microsoft.ML.OnnxRuntime.PerfTool/Microsoft.ML.OnnxRuntime.PerfTool.csproj
+++ b/csharp/tools/Microsoft.ML.OnnxRuntime.PerfTool/Microsoft.ML.OnnxRuntime.PerfTool.csproj
@@ -16,7 +16,7 @@
     <OnnxRuntimeBuildDirectory Condition="'$(OnnxRuntimeBuildDirectory)'==''">$(OnnxRuntimeCsharpRoot)\..\build\Linux</OnnxRuntimeBuildDirectory>
     <NativeBuildOutputDir>$(OnnxRuntimeBuildDirectory)\$(Configuration)</NativeBuildOutputDir>
     <ProtocDirectory Condition="'$(ProtocDirectory)'==''">$(OnnxRuntimeBuildDirectory)\$(Configuration)\external\protobuf\cmake</ProtocDirectory>
-    <ProtocExe>$(ProtocDirectory)\protoc.exe</ProtocExe>
+    <ProtocExe>$(ProtocDirectory)\protoc</ProtocExe>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsLinuxBuild)'=='false'">


### PR DESCRIPTION
**Description**: Change the Protoc binary name to 'protoc' in Linux builds (without the .exe extension)

**Motivation and Context**
- Fixes C# build failures on Linux with --build_nuget option due to 'protoc.exe' file not found
