### PR TITLE
only use/import pytest if needed (by enable_training)

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 import hashlib
 from logger import log
-import pytest
 
 
 class BaseError(Exception):
@@ -1114,6 +1113,8 @@ def run_orttraining_test_orttrainer_frontend_separately(cwd):
                 if start > 0:
                     test_name = test_name[:start]
                 self.collected.add(test_name)
+
+    import pytest
 
     plugin = TestNameCollecterPlugin()
     test_script_filename = os.path.join(cwd, "orttraining_test_orttrainer_frontend.py")


### PR DESCRIPTION
**Description**:  only to import pytest when running training frontend tests

**Motivation and Context**
Windows pipeline CIs are broken because pytest is not available on may Windows CIs
