### PR TITLE
Update TensorRT parser to fix accuracy issue in some opset11 models

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1337,6 +1337,7 @@ common::Status TensorrtExecutionProvider::Provider_Compile(const std::vector<onn
         }
         return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "TensorRT EP execution context enqueue failed.");
       }
+      cudaDeviceSynchronize();
 
       // Cast INT64 input to INT32 because TensorRT doesn't fully support INT64
       for (int i = 0, end = output_binding_names.size(); i < end; ++i) {
@@ -1355,7 +1356,6 @@ common::Status TensorrtExecutionProvider::Provider_Compile(const std::vector<onn
         }
       }
 
-      cudaDeviceSynchronize();
       for (const auto& binding_index : binding_buffers_to_freeup) {
         cudaFree(buffers[binding_index]);
       }


### PR DESCRIPTION
1. Update Onnx-TensorRT parser to include latest fix
    The fix solved the issue of accuracy loss in some opset11 models, such as yolov4 in onnx model zoo.
    The reason is certain new attributes of opset11 Resize operator are not supported in TensorRT7.1 and also are not handled properly in the parser.
2. Move cudaDeviceSynchronize right after enquenV2 to make sure TRT outputs are synced before fetching
