### PR TITLE
enable the onnxruntime shared library test on iOS

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -106,7 +106,13 @@ function(AddTest)
       ${TEST_SRC_DIR}/xctest/xcgtest.mm
       ${_UT_SOURCES})
 
-    target_link_libraries(${_UT_TARGET}_xc PRIVATE ${_UT_LIBS} GTest::gtest GTest::gmock ${onnxruntime_EXTERNAL_LIBRARIES})
+    if(_UT_DYN)
+      target_link_libraries(${_UT_TARGET}_xc PRIVATE ${_UT_LIBS} GTest::gtest GTest::gmock onnxruntime ${CMAKE_DL_LIBS}
+              Threads::Threads)
+      target_compile_definitions(${_UT_TARGET}_xc PRIVATE -DUSE_ONNXRUNTIME_DLL)
+    else()
+      target_link_libraries(${_UT_TARGET}_xc PRIVATE ${_UT_LIBS} GTest::gtest GTest::gmock ${onnxruntime_EXTERNAL_LIBRARIES})
+    endif()
     onnxruntime_add_include_to_target(${_UT_TARGET}_xc date_interface flatbuffers)
     target_include_directories(${_UT_TARGET}_xc PRIVATE ${TEST_INC_DIR})
     get_target_property(${_UT_TARGET}_DEFS ${_UT_TARGET} COMPILE_DEFINITIONS)
@@ -854,49 +860,54 @@ if (onnxruntime_BUILD_SHARED_LIB)
   if (CMAKE_SYSTEM_NAME STREQUAL "Android")
     list(APPEND onnxruntime_shared_lib_test_LIBS ${android_shared_libs})
   endif()
-  if (NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+  AddTest(DYN
+          TARGET onnxruntime_shared_lib_test
+          SOURCES ${onnxruntime_shared_lib_test_SRC} ${TEST_SRC_DIR}/providers/test_main.cc
+          LIBS ${onnxruntime_shared_lib_test_LIBS}
+          DEPENDS ${all_dependencies}
+  )
+  if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    add_custom_command(
+      TARGET onnxruntime_shared_lib_test POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_directory
+      ${TEST_DATA_DES}
+      $<TARGET_FILE_DIR:onnxruntime_shared_lib_test>/testdata)
+  endif()
+
+  # test inference using global threadpools
+  if (NOT CMAKE_SYSTEM_NAME MATCHES "Android|iOS" AND NOT onnxruntime_MINIMAL_BUILD)
     AddTest(DYN
-            TARGET onnxruntime_shared_lib_test
-            SOURCES ${onnxruntime_shared_lib_test_SRC} ${TEST_SRC_DIR}/providers/test_main.cc
+            TARGET onnxruntime_global_thread_pools_test
+            SOURCES ${onnxruntime_global_thread_pools_test_SRC}
             LIBS ${onnxruntime_shared_lib_test_LIBS}
             DEPENDS ${all_dependencies}
     )
   endif()
 
-  # test inference using global threadpools
-  if (NOT CMAKE_SYSTEM_NAME MATCHES "Android|iOS" AND NOT onnxruntime_MINIMAL_BUILD)
-  AddTest(DYN
-          TARGET onnxruntime_global_thread_pools_test
-          SOURCES ${onnxruntime_global_thread_pools_test_SRC}
-          LIBS ${onnxruntime_shared_lib_test_LIBS}
-          DEPENDS ${all_dependencies}
-  )
-  endif()
-
  # A separate test is needed to test the APIs that don't rely on the env being created first.
   if (NOT CMAKE_SYSTEM_NAME MATCHES "Android|iOS")
-  AddTest(DYN
-          TARGET onnxruntime_api_tests_without_env
-          SOURCES ${onnxruntime_api_tests_without_env_SRC}
-          LIBS ${onnxruntime_shared_lib_test_LIBS}
-          DEPENDS ${all_dependencies}
-  )
+    AddTest(DYN
+            TARGET onnxruntime_api_tests_without_env
+            SOURCES ${onnxruntime_api_tests_without_env_SRC}
+            LIBS ${onnxruntime_shared_lib_test_LIBS}
+            DEPENDS ${all_dependencies}
+    )
   endif()
 endif()
 
 #some ETW tools
 if(WIN32 AND onnxruntime_ENABLE_INSTRUMENT)
-    add_executable(generate_perf_report_from_etl ${ONNXRUNTIME_ROOT}/tool/etw/main.cc
-            ${ONNXRUNTIME_ROOT}/tool/etw/eparser.h ${ONNXRUNTIME_ROOT}/tool/etw/eparser.cc
-            ${ONNXRUNTIME_ROOT}/tool/etw/TraceSession.h ${ONNXRUNTIME_ROOT}/tool/etw/TraceSession.cc)
-    target_compile_definitions(generate_perf_report_from_etl PRIVATE "_CONSOLE" "_UNICODE" "UNICODE")
-    target_link_libraries(generate_perf_report_from_etl PRIVATE tdh Advapi32)
+  add_executable(generate_perf_report_from_etl ${ONNXRUNTIME_ROOT}/tool/etw/main.cc
+          ${ONNXRUNTIME_ROOT}/tool/etw/eparser.h ${ONNXRUNTIME_ROOT}/tool/etw/eparser.cc
+          ${ONNXRUNTIME_ROOT}/tool/etw/TraceSession.h ${ONNXRUNTIME_ROOT}/tool/etw/TraceSession.cc)
+  target_compile_definitions(generate_perf_report_from_etl PRIVATE "_CONSOLE" "_UNICODE" "UNICODE")
+  target_link_libraries(generate_perf_report_from_etl PRIVATE tdh Advapi32)
 
-    add_executable(compare_two_sessions ${ONNXRUNTIME_ROOT}/tool/etw/compare_two_sessions.cc
-            ${ONNXRUNTIME_ROOT}/tool/etw/eparser.h ${ONNXRUNTIME_ROOT}/tool/etw/eparser.cc
-            ${ONNXRUNTIME_ROOT}/tool/etw/TraceSession.h ${ONNXRUNTIME_ROOT}/tool/etw/TraceSession.cc)
-    target_compile_definitions(compare_two_sessions PRIVATE "_CONSOLE" "_UNICODE" "UNICODE")
-    target_link_libraries(compare_two_sessions PRIVATE ${GETOPT_LIB_WIDE} tdh Advapi32)
+  add_executable(compare_two_sessions ${ONNXRUNTIME_ROOT}/tool/etw/compare_two_sessions.cc
+          ${ONNXRUNTIME_ROOT}/tool/etw/eparser.h ${ONNXRUNTIME_ROOT}/tool/etw/eparser.cc
+          ${ONNXRUNTIME_ROOT}/tool/etw/TraceSession.h ${ONNXRUNTIME_ROOT}/tool/etw/TraceSession.cc)
+  target_compile_definitions(compare_two_sessions PRIVATE "_CONSOLE" "_UNICODE" "UNICODE")
+  target_link_libraries(compare_two_sessions PRIVATE ${GETOPT_LIB_WIDE} tdh Advapi32)
 endif()
 
 add_executable(onnxruntime_mlas_test ${TEST_SRC_DIR}/mlas/unittest.cpp)

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -109,7 +109,7 @@ function(AddTest)
     if(_UT_DYN)
       target_link_libraries(${_UT_TARGET}_xc PRIVATE ${_UT_LIBS} GTest::gtest GTest::gmock onnxruntime ${CMAKE_DL_LIBS}
               Threads::Threads)
-      target_compile_definitions(${_UT_TARGET}_xc PRIVATE -DUSE_ONNXRUNTIME_DLL)
+      target_compile_definitions(${_UT_TARGET}_xc PRIVATE USE_ONNXRUNTIME_DLL)
     else()
       target_link_libraries(${_UT_TARGET}_xc PRIVATE ${_UT_LIBS} GTest::gtest GTest::gmock ${onnxruntime_EXTERNAL_LIBRARIES})
     endif()

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1096,12 +1096,12 @@ def run_android_tests(args, source_dir, config, cwd):
 
 def run_ios_tests(args, source_dir, config, cwd):
     cpr = run_subprocess(["xcodebuild", "test", "-project", "./onnxruntime.xcodeproj",
-                          "-configuration", "RelWithDebInfo",
+                          "-configuration", config,
                           "-scheme",  "onnxruntime_test_all_xc",
                           "-destination", "platform=iOS Simulator,OS=latest,name=iPhone SE (2nd generation)"], cwd=cwd)
     if cpr.returncode == 0:
         run_subprocess(["xcodebuild", "test", "-project", "./onnxruntime.xcodeproj",
-                        "-configuration", "RelWithDebInfo",
+                        "-configuration", config,
                         "-scheme",  "onnxruntime_shared_lib_test_xc",
                         "-destination", "platform=iOS Simulator,OS=latest,name=iPhone SE (2nd generation)"], cwd=cwd)
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1097,13 +1097,14 @@ def run_android_tests(args, source_dir, config, cwd):
 def run_ios_tests(args, source_dir, config, cwd):
     cpr = run_subprocess(["xcodebuild", "test", "-project", "./onnxruntime.xcodeproj",
                           "-configuration", config,
-                          "-scheme",  "onnxruntime_test_all_xc",
-                          "-destination", "platform=iOS Simulator,OS=latest,name=iPhone SE (2nd generation)"], cwd=cwd)
+                          "-scheme",  "onnxruntime_test_all_xc", "-destination",
+                          "platform=iOS Simulator,OS=latest,name=iPhone SE (2nd generation)"], cwd=cwd)
     if cpr.returncode == 0:
-        run_subprocess(["xcodebuild", "test", "-project", "./onnxruntime.xcodeproj",
-                        "-configuration", config,
-                        "-scheme",  "onnxruntime_shared_lib_test_xc",
-                        "-destination", "platform=iOS Simulator,OS=latest,name=iPhone SE (2nd generation)"], cwd=cwd)
+        cpr = run_subprocess(["xcodebuild", "test", "-project", "./onnxruntime.xcodeproj",
+                              "-configuration", config,
+                              "-scheme",  "onnxruntime_shared_lib_test_xc", "-destination",
+                              "platform=iOS Simulator,OS=latest,name=iPhone SE (2nd generation)"], cwd=cwd)
+    cpr.check_returncode()
 
 
 def run_orttraining_test_orttrainer_frontend_separately(cwd):

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1095,9 +1095,15 @@ def run_android_tests(args, source_dir, config, cwd):
 
 
 def run_ios_tests(args, source_dir, config, cwd):
-    run_subprocess(["xcodebuild", "test", "-project", "./onnxruntime.xcodeproj",
-                    "-scheme",  "onnxruntime_test_all_xc",
-                    "-destination", "platform=iOS Simulator,OS=latest,name=iPhone SE (2nd generation)"], cwd=cwd)
+    cpr = run_subprocess(["xcodebuild", "test", "-project", "./onnxruntime.xcodeproj",
+                          "-configuration", "RelWithDebInfo",
+                          "-scheme",  "onnxruntime_test_all_xc",
+                          "-destination", "platform=iOS Simulator,OS=latest,name=iPhone SE (2nd generation)"], cwd=cwd)
+    if cpr.returncode == 0:
+        run_subprocess(["xcodebuild", "test", "-project", "./onnxruntime.xcodeproj",
+                        "-configuration", "RelWithDebInfo",
+                        "-scheme",  "onnxruntime_shared_lib_test_xc",
+                        "-destination", "platform=iOS Simulator,OS=latest,name=iPhone SE (2nd generation)"], cwd=cwd)
 
 
 def run_orttraining_test_orttrainer_frontend_separately(cwd):


### PR DESCRIPTION
**Description**: enable the onnxruntime shared library test on iOS

**Motivation and Context**
ONNXRuntime shared library also used in the real scenario, adding the test as well.
