### PR TITLE
Mark the dX and dB outputs of ConvGrad as OpSchema::Optional.

### DIFF
--- a/orttraining/orttraining/core/graph/training_op_defs.cc
+++ b/orttraining/orttraining/core/graph/training_op_defs.cc
@@ -420,7 +420,7 @@ void RegisterTrainingOpSchemas() {
       .Input(2, "W", "Weight tensor", "T")
       .Output(0, "dX", "Gradient of input X", "T")
       .Output(1, "dW", "Gradient of W", "T")
-      .Output(2, "dB", "Gradient of B", "T")
+      .Output(2, "dB", "Gradient of B", "T", OpSchema::Optional)
       .AllowUncheckedAttributes()
       .TypeConstraint(
           "T",

--- a/orttraining/orttraining/core/graph/training_op_defs.cc
+++ b/orttraining/orttraining/core/graph/training_op_defs.cc
@@ -418,7 +418,7 @@ void RegisterTrainingOpSchemas() {
       .Input(0, "dY", "Gradient of output Y", "T")
       .Input(1, "X", "Input tensor", "T")
       .Input(2, "W", "Weight tensor", "T")
-      .Output(0, "dX", "Gradient of input X", "T")
+      .Output(0, "dX", "Gradient of input X", "T", OpSchema::Optional)
       .Output(1, "dW", "Gradient of W", "T")
       .Output(2, "dB", "Gradient of B", "T", OpSchema::Optional)
       .AllowUncheckedAttributes()


### PR DESCRIPTION
**Description**: Mark the dX and dB outputs of ConvGrad as OpSchema::Optional.

**Motivation and Context**
- The gradient builder for Conv will only add an output for `dX` or `dB` if a gradient is required; the implementation only produces those outputs if they are required.
- The current schema for ConvGrad implicitly treats these outputs as mandatory.