### PR TITLE
Cleanup some test infrastructure

### DIFF
--- a/onnxruntime/test/framework/execution_frame_test.cc
+++ b/onnxruntime/test/framework/execution_frame_test.cc
@@ -11,6 +11,7 @@
 #include "test_utils.h"
 #include "test/test_environment.h"
 #include "test/framework/TestAllocatorManager.h"
+#include "test/util/include/inference_session_wrapper.h"
 #include "asserts.h"
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
@@ -137,7 +138,7 @@ TEST_F(ExecutionFrameTest, FeedInDataTest) {
                      DefaultLoggingManager().DefaultLogger(), profiler);
 
   ASSERT_STATUS_OK(state.FinalizeSessionState(ORT_TSTR(""), kernel_registry_manager));
-  
+
   const OrtValueNameIdxMap& mlvalue_name_idx_map = state.GetOrtValueNameIdxMap();
   int x_idx = -1, y_idx = -1;
   ASSERT_TRUE(mlvalue_name_idx_map.GetIdx("X", x_idx).IsOK());
@@ -323,17 +324,7 @@ TEST(ExecutionFrameTestInit, InitializerAsOutput) {
 
   // test that if no pre-allocated fetch is provided a new OrtValue is allocated for the results
   {
-    class TestInferenceSesssion : public InferenceSession {
-     public:
-      TestInferenceSesssion(const SessionOptions& session_options,
-                            const Environment& session_env)
-          : InferenceSession(session_options, session_env) {
-      }
-
-      const SessionState& GetSessionState() const { return InferenceSession::GetSessionState(); }
-    };
-
-    TestInferenceSesssion session(so, GetEnvironment());
+    InferenceSessionWrapper session(so, GetEnvironment());
     ASSERT_STATUS_OK(session.Load(ORT_TSTR("testdata/initializer_as_output.onnx")));
     ASSERT_STATUS_OK(session.Initialize());
 

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -42,6 +42,7 @@
 #include "test/providers/provider_test_utils.h"
 #include "test/optimizer/dummy_graph_transformer.h"
 #include "test/util/include/default_providers.h"
+#include "test/util/include/inference_session_wrapper.h"
 
 #include "gtest/gtest.h"
 
@@ -129,18 +130,6 @@ class FuseExecutionProvider : public IExecutionProvider {
     // throw if the registry failed to initialize
     ORT_THROW_IF_ERROR(k.st);
     return k.kernel_registry;
-  }
-};
-
-// InferenceSession wrapper to expose loaded graph.
-class InferenceSessionGetGraphWrapper : public InferenceSession {
- public:
-  explicit InferenceSessionGetGraphWrapper(const SessionOptions& session_options,
-                                           const Environment& env) : InferenceSession(session_options, env) {
-  }
-
-  const Graph& GetGraph() {
-    return model_->MainGraph();
   }
 };
 
@@ -408,7 +397,7 @@ TEST(InferenceSessionTests, TestModelSerialization) {
   const string test_model = "testdata/transform/abs-id-max.onnx";
   so.session_logid = "InferenceSessionTests.TestModelSerialization";
   so.graph_optimization_level = TransformerLevel::Default;
-  InferenceSessionGetGraphWrapper session_object_noopt{so, GetEnvironment()};
+  InferenceSessionWrapper session_object_noopt{so, GetEnvironment()};
   ASSERT_TRUE(session_object_noopt.Load(test_model).IsOK());
   ASSERT_TRUE(session_object_noopt.Initialize().IsOK());
 
@@ -420,7 +409,7 @@ TEST(InferenceSessionTests, TestModelSerialization) {
   // Load model with level 1 transform level.
   so.graph_optimization_level = TransformerLevel::Level1;
   so.optimized_model_filepath = ToWideString(test_model + "-TransformLevel-" + std::to_string(static_cast<uint32_t>(so.graph_optimization_level)));
-  InferenceSessionGetGraphWrapper session_object{so, GetEnvironment()};
+  InferenceSessionWrapper session_object{so, GetEnvironment()};
   ASSERT_TRUE(session_object.Load(test_model).IsOK());
   ASSERT_STATUS_OK(session_object.Initialize());
 
@@ -681,11 +670,13 @@ TEST(InferenceSessionTests, CheckRunProfilerStartTime) {
   ASSERT_STATUS_OK(session_object.Initialize());
 
   uint64_t before_start_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
-      std::chrono::high_resolution_clock::now().time_since_epoch()).count(); // get current time
+                                   std::chrono::high_resolution_clock::now().time_since_epoch())
+                                   .count();  // get current time
   session_object.StartProfiling("onnxruntime_profile_start");
   uint64_t profiling_start_time = session_object.GetProfiling().GetStartTime();
   uint64_t after_start_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
-      std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+                                  std::chrono::high_resolution_clock::now().time_since_epoch())
+                                  .count();
 
   // the profiler's start time needs to be between before_time and after_time
   ASSERT_TRUE(before_start_time <= profiling_start_time && profiling_start_time <= after_start_time);
@@ -2158,21 +2149,13 @@ TEST(InferenceSessionTests, LoadModelWithEnvVarSetToUnsupportedVal) {
 #endif
 }
 
-struct InferenceSessionExposingSessionState : public InferenceSession {
-  InferenceSessionExposingSessionState(const SessionOptions& session_options,
-                                       const Environment& env)
-      : InferenceSession(session_options, env) {
-  }
-  const SessionState& GetSessionState() const { return InferenceSession::GetSessionState(); }
-};
-
 // Global threadpool related tests
 // We test for 4 combinations
-class InferenceSessionTestGlobalThreadPools : public InferenceSessionExposingSessionState {
+class InferenceSessionTestGlobalThreadPools : public InferenceSessionWrapper {
  public:
   InferenceSessionTestGlobalThreadPools(const SessionOptions& session_options,
                                         const Environment& env)
-      : InferenceSessionExposingSessionState(session_options, env) {
+      : InferenceSessionWrapper(session_options, env) {
   }
 
   onnxruntime::concurrency::ThreadPool* GetIntraOpThreadPoolToUse() const {
@@ -2337,11 +2320,11 @@ TEST(InferenceSessionTests, InvalidSessionEnvCombination) {
 }
 
 // Tests for sharing allocators between sessions
-class InferenceSessionTestSharingAllocator : public InferenceSessionExposingSessionState {
+class InferenceSessionTestSharingAllocator : public InferenceSessionWrapper {
  public:
   InferenceSessionTestSharingAllocator(const SessionOptions& session_options,
                                        const Environment& env)
-      : InferenceSessionExposingSessionState(session_options, env) {
+      : InferenceSessionWrapper(session_options, env) {
   }
 };
 
@@ -2435,11 +2418,11 @@ TEST(InferenceSessionTests, AllocatorSharing_EnsureSessionsDontUseSameOrtCreated
             sess2.GetSessionState().GetAllocator(mem_info).get());
 }
 
-class InferenceSessionTestSharingInitializer : public InferenceSessionExposingSessionState {
+class InferenceSessionTestSharingInitializer : public InferenceSessionWrapper {
  public:
   InferenceSessionTestSharingInitializer(const SessionOptions& session_options,
                                          const Environment& env)
-      : InferenceSessionExposingSessionState(session_options, env) {
+      : InferenceSessionWrapper(session_options, env) {
   }
 };
 

--- a/onnxruntime/test/framework/ort_model_only_test.cc
+++ b/onnxruntime/test/framework/ort_model_only_test.cc
@@ -12,7 +12,7 @@
 #include "test/test_environment.h"
 #include "test_utils.h"
 #include "test/util/include/asserts.h"
-
+#include "test/util/include/inference_session_wrapper.h"
 #include "core/flatbuffers/schema/ort.fbs.h"
 #include "flatbuffers/idl.h"
 #include "flatbuffers/util.h"
@@ -24,23 +24,6 @@ using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::logging;
 
 namespace onnxruntime {
-
-// InferenceSession wrapper to expose loaded graph.
-class InferenceSessionGetGraphWrapper : public InferenceSession {
- public:
-  explicit InferenceSessionGetGraphWrapper(const SessionOptions& session_options,
-                                           const Environment& env) : InferenceSession(session_options, env) {
-  }
-
-  const Graph& GetGraph() const {
-    return model_->MainGraph();
-  }
-
-  const SessionState& GetSessionState() const {
-    return InferenceSession::GetSessionState();
-  }
-};
-
 namespace test {
 
 struct OrtModelTestInfo {
@@ -60,7 +43,7 @@ static void RunOrtModel(const OrtModelTestInfo& test_info) {
     so.AddConfigEntry(config.first.c_str(), config.second.c_str());
 
   std::vector<char> model_data;
-  InferenceSessionGetGraphWrapper session_object{so, GetEnvironment()};
+  InferenceSessionWrapper session_object{so, GetEnvironment()};
   if (test_info.run_use_buffer) {
     // Load the file into a buffer and use the buffer to create inference session
     size_t num_bytes = 0;
@@ -154,8 +137,8 @@ static void CompareValueInfos(const ValueInfoProto& left, const ValueInfoProto& 
   // CompareTypeProtos(left.type(), right.type());
 }
 
-static void CompareGraphAndSessionState(const InferenceSessionGetGraphWrapper& session_object_1,
-                                        const InferenceSessionGetGraphWrapper& session_object_2) {
+static void CompareGraphAndSessionState(const InferenceSessionWrapper& session_object_1,
+                                        const InferenceSessionWrapper& session_object_2) {
   const auto& graph_1 = session_object_1.GetGraph();
   const auto& graph_2 = session_object_2.GetGraph();
 
@@ -213,7 +196,7 @@ static void SaveAndCompareModels(const std::string& onnx_file, const std::basic_
   so.optimized_model_filepath = ort_file;
   // not strictly necessary - type should be inferred from the filename
   so.AddConfigEntry(kOrtSessionOptionsConfigSaveModelFormat, "ORT");
-  InferenceSessionGetGraphWrapper session_object{so, GetEnvironment()};
+  InferenceSessionWrapper session_object{so, GetEnvironment()};
 
   // create .ort file during Initialize due to values in SessionOptions
   ASSERT_STATUS_OK(session_object.Load(onnx_file));
@@ -226,7 +209,7 @@ static void SaveAndCompareModels(const std::string& onnx_file, const std::basic_
   so2.AddConfigEntry(kOrtSessionOptionsConfigLoadModelFormat, "ORT");
 
   // load serialized version
-  InferenceSessionGetGraphWrapper session_object2{so2, GetEnvironment()};
+  InferenceSessionWrapper session_object2{so2, GetEnvironment()};
   ASSERT_STATUS_OK(session_object2.Load(ort_file));
   ASSERT_STATUS_OK(session_object2.Initialize());
 

--- a/onnxruntime/test/framework/test_utils.cc
+++ b/onnxruntime/test/framework/test_utils.cc
@@ -52,12 +52,13 @@ IExecutionProvider* TestRknpuExecutionProvider() {
 }
 #endif
 
-static void CountOpsInGraphImpl(
-    const Graph& graph, bool recurse_into_subgraphs, std::map<std::string, int>& ops) {
+static void CountOpsInGraphImpl(const Graph& graph, bool recurse_into_subgraphs, std::map<std::string, int>& ops) {
   for (auto& node : graph.Nodes()) {
-    auto pos = ops.find(node.OpType());
+    std::string key = node.Domain() + (node.Domain().empty() ? "" : ".") + node.OpType();
+
+    auto pos = ops.find(key);
     if (pos == ops.end()) {
-      ops[node.OpType()] = 1;
+      ops[key] = 1;
     } else {
       ++pos->second;
     }

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -711,7 +711,7 @@ TEST_F(GraphTransformationTests, TransposeMatmulFusion) {
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Transpose"] == 0);
   ASSERT_TRUE(op_to_count["MatMul"] == 0);
-  ASSERT_TRUE(op_to_count["FusedMatMul"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.FusedMatMul"] == 1);
 }
 
 TEST_F(GraphTransformationTests, TransposeMatmulFusionOnTwoTranspose) {
@@ -728,7 +728,7 @@ TEST_F(GraphTransformationTests, TransposeMatmulFusionOnTwoTranspose) {
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Transpose"] == 0);
   ASSERT_TRUE(op_to_count["MatMul"] == 0);
-  ASSERT_TRUE(op_to_count["FusedMatMul"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.FusedMatMul"] == 1);
 
   auto& node = *graph.Nodes().begin();
   ASSERT_TRUE(node.OpType() == "FusedMatMul");
@@ -750,7 +750,7 @@ TEST_F(GraphTransformationTests, TransposeMatmulFusionOnThreeTranspose) {
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Transpose"] == 0);
   ASSERT_TRUE(op_to_count["MatMul"] == 0);
-  ASSERT_TRUE(op_to_count["FusedMatMul"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.FusedMatMul"] == 1);
 
   auto& node = *graph.Nodes().begin();
   ASSERT_TRUE(node.OpType() == "FusedMatMul");
@@ -776,7 +776,7 @@ TEST_F(GraphTransformationTests, TransposeMatmulNoFusionOnInvalidPerm) {
     std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
     ASSERT_EQ(op_to_count["Transpose"], 1);
     ASSERT_EQ(op_to_count["MatMul"], 1);
-    ASSERT_EQ(op_to_count["FusedMatMul"], 0);
+    ASSERT_EQ(op_to_count["com.microsoft.FusedMatMul"], 0);
   }
 }
 
@@ -804,7 +804,7 @@ TEST_F(GraphTransformationTests, TransposeMatmulFusionFromTransposeMatMul) {
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_EQ(op_to_count["Transpose"], 0);
   ASSERT_EQ(op_to_count["MatMul"], 0);
-  ASSERT_EQ(op_to_count["FusedMatMul"], 1);
+  ASSERT_EQ(op_to_count["com.microsoft.FusedMatMul"], 1);
 
   auto& transpose_scale_matmul_node = *graph.Nodes().begin();
   ASSERT_EQ(transpose_scale_matmul_node.OpType(), "FusedMatMul");
@@ -827,7 +827,7 @@ TEST_F(GraphTransformationTests, TransposeMatmulFusionWithPreservedTranspose) {
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_EQ(op_to_count["Transpose"], 1);
   ASSERT_EQ(op_to_count["MatMul"], 0);
-  ASSERT_EQ(op_to_count["FusedMatMul"], 1);
+  ASSERT_EQ(op_to_count["com.microsoft.FusedMatMul"], 1);
 
   ASSERT_FALSE(graph.GraphResolveNeeded());
 }
@@ -846,7 +846,7 @@ TEST_F(GraphTransformationTests, Gemm_LeakyRelu_Fusion) {
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["LeakyRelu"] == 0);
   ASSERT_TRUE(op_to_count["Gemm"] == 0);
-  ASSERT_TRUE(op_to_count["FusedGemm"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.FusedGemm"] == 1);
 }
 #endif
 
@@ -1763,7 +1763,7 @@ TEST_F(GraphTransformationTests, AttentionFusionInt32Test) {
   EXPECT_EQ(op_to_count["Transpose"], 0);
   EXPECT_EQ(op_to_count["Reshape"], 0);
   EXPECT_EQ(op_to_count["Cast"], 0);
-  EXPECT_EQ(op_to_count["Attention"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 1);
 
   ValidateAttention(graph);
 }
@@ -1786,7 +1786,7 @@ TEST_F(GraphTransformationTests, AttentionFusionInt64Test) {
   EXPECT_EQ(op_to_count["Transpose"], 0);
   EXPECT_EQ(op_to_count["Reshape"], 0);
   EXPECT_EQ(op_to_count["Cast"], 1);  // Cast for int64 mask to int32
-  EXPECT_EQ(op_to_count["Attention"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 1);
 
   ValidateAttention(graph);
 }
@@ -1812,7 +1812,7 @@ TEST_F(GraphTransformationTests, AttentionFusionFloat32Test) {
   EXPECT_EQ(op_to_count["Div"], 0);
   EXPECT_EQ(op_to_count["Sub"], 0);
   EXPECT_EQ(op_to_count["Unsqueeze"], 0);
-  EXPECT_EQ(op_to_count["Attention"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 1);
 
   ValidateAttention(graph);
 }
@@ -1832,7 +1832,7 @@ TEST_F(GraphTransformationTests, AttentionFusionGPTWithPastAndMaskTest) {
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["Transpose"], 0);
   EXPECT_EQ(op_to_count["Softmax"], 0);
-  EXPECT_EQ(op_to_count["Attention"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 1);
 }
 
 // Test GPT-2 Attention Fusion without input mask
@@ -1850,7 +1850,7 @@ TEST_F(GraphTransformationTests, AttentionFusionGPTWithPastNoMaskTest) {
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["Transpose"], 0);
   EXPECT_EQ(op_to_count["Softmax"], 0);
-  EXPECT_EQ(op_to_count["Attention"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 1);
 }
 
 // Test GPT-2 Attention Fusion without input mask and past state
@@ -1868,7 +1868,7 @@ TEST_F(GraphTransformationTests, AttentionFusionGPTTest) {
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["Transpose"], 0);
   EXPECT_EQ(op_to_count["Softmax"], 0);
-  EXPECT_EQ(op_to_count["Attention"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 1);
 }
 
 TEST_F(GraphTransformationTests, AttentionFusionDistilBertTest) {
@@ -1884,7 +1884,7 @@ TEST_F(GraphTransformationTests, AttentionFusionDistilBertTest) {
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["ReduceSum"], 0);
-  EXPECT_EQ(op_to_count["Attention"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 1);
   EXPECT_EQ(op_to_count["Gather"], 0);
   EXPECT_EQ(op_to_count["Unsqueeze"], 0);
   EXPECT_EQ(op_to_count["Concat"], 0);
@@ -1909,7 +1909,7 @@ TEST_F(GraphTransformationTests, GeluFusionTest) {
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["Erf"] == 0);
   ASSERT_TRUE(op_to_count["Mul"] == 0);
-  ASSERT_TRUE(op_to_count["Gelu"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.Gelu"] == 1);
 }
 
 TEST_F(GraphTransformationTests, GeluFusionTestSwitchOrderFormat2) {
@@ -1928,7 +1928,7 @@ TEST_F(GraphTransformationTests, GeluFusionTestSwitchOrderFormat2) {
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["Erf"] == 0);
   ASSERT_TRUE(op_to_count["Mul"] == 0);
-  ASSERT_TRUE(op_to_count["Gelu"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.Gelu"] == 1);
 }
 
 TEST_F(GraphTransformationTests, GeluFusionTestFormat2) {
@@ -1947,7 +1947,7 @@ TEST_F(GraphTransformationTests, GeluFusionTestFormat2) {
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["Erf"] == 0);
   ASSERT_TRUE(op_to_count["Mul"] == 0);
-  ASSERT_TRUE(op_to_count["Gelu"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.Gelu"] == 1);
 }
 
 TEST_F(GraphTransformationTests, GeluFusionTestFormat2GraphInput) {
@@ -1966,7 +1966,7 @@ TEST_F(GraphTransformationTests, GeluFusionTestFormat2GraphInput) {
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["Erf"] == 0);
   ASSERT_TRUE(op_to_count["Mul"] == 0);
-  ASSERT_TRUE(op_to_count["Gelu"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.Gelu"] == 1);
 }
 
 TEST_F(GraphTransformationTests, GeluFusionTestFormat2GraphOutput) {
@@ -1982,8 +1982,8 @@ TEST_F(GraphTransformationTests, GeluFusionTestFormat2GraphOutput) {
   ASSERT_TRUE(ret.IsOK());
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
-  ASSERT_TRUE(op_to_count["Gelu"] == 0);
-  ASSERT_TRUE(op_to_count["BiasGelu"] == 0);
+  ASSERT_TRUE(op_to_count["com.microsoft.Gelu"] == 0);
+  ASSERT_TRUE(op_to_count["com.microsoft.BiasGelu"] == 0);
 }
 
 TEST_F(GraphTransformationTests, BiasGeluTest) {
@@ -2002,8 +2002,8 @@ TEST_F(GraphTransformationTests, BiasGeluTest) {
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["Erf"] == 0);
   ASSERT_TRUE(op_to_count["Mul"] == 0);
-  ASSERT_TRUE(op_to_count["Gelu"] == 0);
-  ASSERT_TRUE(op_to_count["BiasGelu"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.Gelu"] == 0);
+  ASSERT_TRUE(op_to_count["com.microsoft.BiasGelu"] == 1);
 }
 
 // BiasGelu allows input switching based on input dimensions.
@@ -2069,8 +2069,8 @@ TEST_F(GraphTransformationTests, GeluApproximation_Gelu) {
   ASSERT_TRUE(ret.IsOK());
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
-  EXPECT_EQ(op_to_count["Gelu"], 0);
-  EXPECT_EQ(op_to_count["FastGelu"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Gelu"], 0);
+  EXPECT_EQ(op_to_count["com.microsoft.FastGelu"], 1);
 }
 
 // Test AddGeluFusion -> FastGelu
@@ -2086,8 +2086,8 @@ TEST_F(GraphTransformationTests, GeluApproximation_Gelu_Add_Bias) {
   ASSERT_TRUE(ret.IsOK());
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
-  EXPECT_EQ(op_to_count["BiasGelu"], 0);
-  EXPECT_EQ(op_to_count["FastGelu"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.BiasGelu"], 0);
+  EXPECT_EQ(op_to_count["com.microsoft.FastGelu"], 1);
 }
 
 // Test MatMul & AddGeluFusion -> MatMul & FastGelu
@@ -2103,9 +2103,9 @@ TEST_F(GraphTransformationTests, GeluApproximation_Gelu_Add_MatMul) {
   ASSERT_TRUE(ret.IsOK());
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
-  EXPECT_EQ(op_to_count["BiasGelu"], 0);
+  EXPECT_EQ(op_to_count["com.microsoft.BiasGelu"], 0);
   EXPECT_EQ(op_to_count["MatMul"], 1);
-  EXPECT_EQ(op_to_count["FastGelu"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.FastGelu"], 1);
 }
 
 TEST_F(GraphTransformationTests, FastGeluFusionTest) {
@@ -2125,7 +2125,7 @@ TEST_F(GraphTransformationTests, FastGeluFusionTest) {
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["Tanh"] == 0);
   ASSERT_TRUE(op_to_count["Mul"] == 0);
-  ASSERT_TRUE(op_to_count["FastGelu"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.FastGelu"] == 1);
 }
 
 TEST_F(GraphTransformationTests, FastGeluUseGraphInputFusionTest) {
@@ -2144,7 +2144,7 @@ TEST_F(GraphTransformationTests, FastGeluUseGraphInputFusionTest) {
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["Tanh"] == 0);
   ASSERT_TRUE(op_to_count["Mul"] == 0);
-  ASSERT_TRUE(op_to_count["FastGelu"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.FastGelu"] == 1);
 }
 
 TEST_F(GraphTransformationTests, FastGeluWithBiasFusionTest) {
@@ -2164,7 +2164,7 @@ TEST_F(GraphTransformationTests, FastGeluWithBiasFusionTest) {
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["Tanh"] == 0);
   ASSERT_TRUE(op_to_count["Mul"] == 0);
-  ASSERT_TRUE(op_to_count["FastGelu"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.FastGelu"] == 1);
 }
 
 TEST_F(GraphTransformationTests, FastGeluWithBiasUseGraphInputFusionTest) {
@@ -2184,7 +2184,7 @@ TEST_F(GraphTransformationTests, FastGeluWithBiasUseGraphInputFusionTest) {
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["Tanh"] == 0);
   ASSERT_TRUE(op_to_count["Mul"] == 0);
-  ASSERT_TRUE(op_to_count["FastGelu"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.FastGelu"] == 1);
 }
 
 TEST_F(GraphTransformationTests, FastGeluFusionTest2) {
@@ -2203,7 +2203,7 @@ TEST_F(GraphTransformationTests, FastGeluFusionTest2) {
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["Tanh"] == 0);
   ASSERT_TRUE(op_to_count["Mul"] == 0);
-  ASSERT_TRUE(op_to_count["FastGelu"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.FastGelu"] == 1);
 }
 
 TEST_F(GraphTransformationTests, FastGeluUseGraphInputFusionTest2) {
@@ -2222,7 +2222,7 @@ TEST_F(GraphTransformationTests, FastGeluUseGraphInputFusionTest2) {
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["Tanh"] == 0);
   ASSERT_TRUE(op_to_count["Mul"] == 0);
-  ASSERT_TRUE(op_to_count["FastGelu"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.FastGelu"] == 1);
 }
 
 TEST_F(GraphTransformationTests, FastGeluWithBiasFusionTest2) {
@@ -2242,7 +2242,7 @@ TEST_F(GraphTransformationTests, FastGeluWithBiasFusionTest2) {
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["Tanh"] == 0);
   ASSERT_TRUE(op_to_count["Mul"] == 0);
-  ASSERT_TRUE(op_to_count["FastGelu"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.FastGelu"] == 1);
 }
 
 TEST_F(GraphTransformationTests, FastGeluWithBiasUseGraphInputFusionTest2) {
@@ -2262,7 +2262,7 @@ TEST_F(GraphTransformationTests, FastGeluWithBiasUseGraphInputFusionTest2) {
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["Tanh"] == 0);
   ASSERT_TRUE(op_to_count["Mul"] == 0);
-  ASSERT_TRUE(op_to_count["FastGelu"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.FastGelu"] == 1);
 }
 
 struct BiasSoftmaxFusionTester {
@@ -2316,7 +2316,7 @@ struct BiasSoftmaxFusionTester {
 
     ASSERT_EQ(op_to_count["Add"], 0);
     ASSERT_EQ(op_to_count["Softmax"], 0);
-    ASSERT_EQ(op_to_count["BiasSoftmax"], 1);
+    ASSERT_EQ(op_to_count["com.microsoft.BiasSoftmax"], 1);
 
     int actual_softmax_axis, actual_broadcast_axis;
     ASSERT_TRUE(GetAxis("BiasSoftmax", "softmax_axis", &actual_softmax_axis));
@@ -2335,7 +2335,7 @@ struct BiasSoftmaxFusionTester {
     std::map<std::string, int> op_to_count = CountOpsInGraph(p_model_->MainGraph());
     ASSERT_EQ(op_to_count["Add"], 1);
     ASSERT_EQ(op_to_count["Softmax"], 1);
-    ASSERT_EQ(op_to_count["BiasSoftmax"], 0);
+    ASSERT_EQ(op_to_count["com.microsoft.BiasSoftmax"], 0);
   }
 };
 
@@ -2534,7 +2534,7 @@ static void TestSkipLayerNormFusion(const std::basic_string<ORTCHAR_T>& file_pat
   ASSERT_TRUE(op_to_count["Pow"] == 0);
   ASSERT_TRUE(op_to_count["Sqrt"] == 0);
   ASSERT_TRUE(op_to_count["LayerNormalization"] == ln_count);
-  ASSERT_TRUE(op_to_count["SkipLayerNormalization"] == skip_ln_count);
+  ASSERT_TRUE(op_to_count["com.microsoft.SkipLayerNormalization"] == skip_ln_count);
 }
 
 TEST_F(GraphTransformationTests, SkipLayerNormFusionTest) {
@@ -2603,9 +2603,9 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat1) {
   ASSERT_TRUE(op_to_count["Gather"] == 0);
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["ReduceSum"] == 1);
-  ASSERT_TRUE(op_to_count["Attention"] == 1);
-  ASSERT_TRUE(op_to_count["SkipLayerNormalization"] == 0);
-  ASSERT_TRUE(op_to_count["EmbedLayerNormalization"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.Attention"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.SkipLayerNormalization"] == 0);
+  ASSERT_TRUE(op_to_count["com.microsoft.EmbedLayerNormalization"] == 1);
 }
 
 TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat2) {
@@ -2630,9 +2630,9 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat2) {
   ASSERT_TRUE(op_to_count["Squeeze"] == 0);
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["ReduceSum"] == 1);
-  ASSERT_TRUE(op_to_count["Attention"] == 1);
-  ASSERT_TRUE(op_to_count["SkipLayerNormalization"] == 0);
-  ASSERT_TRUE(op_to_count["EmbedLayerNormalization"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.Attention"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.SkipLayerNormalization"] == 0);
+  ASSERT_TRUE(op_to_count["com.microsoft.EmbedLayerNormalization"] == 1);
 }
 
 TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat3) {
@@ -2652,13 +2652,13 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat3) {
   EXPECT_EQ(op_to_count["Gather"], 0);
   EXPECT_EQ(op_to_count["Unsqueeze"], 0);
   EXPECT_EQ(op_to_count["LayerNormalization"], 0);
-  EXPECT_EQ(op_to_count["SkipLayerNormalization"], 0);
+  EXPECT_EQ(op_to_count["com.microsoft.SkipLayerNormalization"], 0);
   EXPECT_EQ(op_to_count["ReduceSum"], 1);
   EXPECT_EQ(op_to_count["MatMul"], 1);
   EXPECT_EQ(op_to_count["Add"], 2);
   EXPECT_EQ(op_to_count["Cast"], 3);
-  EXPECT_EQ(op_to_count["Attention"], 1);
-  EXPECT_EQ(op_to_count["EmbedLayerNormalization"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.EmbedLayerNormalization"], 1);
 }
 
 TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat3NoCast) {
@@ -2678,13 +2678,13 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat3NoCast) {
   EXPECT_EQ(op_to_count["Gather"], 0);
   EXPECT_EQ(op_to_count["Unsqueeze"], 0);
   EXPECT_EQ(op_to_count["LayerNormalization"], 0);
-  EXPECT_EQ(op_to_count["SkipLayerNormalization"], 0);
+  EXPECT_EQ(op_to_count["com.microsoft.SkipLayerNormalization"], 0);
   EXPECT_EQ(op_to_count["ReduceSum"], 1);
   EXPECT_EQ(op_to_count["MatMul"], 1);
   EXPECT_EQ(op_to_count["Add"], 2);
   EXPECT_EQ(op_to_count["Cast"], 3);
-  EXPECT_EQ(op_to_count["Attention"], 1);
-  EXPECT_EQ(op_to_count["EmbedLayerNormalization"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.EmbedLayerNormalization"], 1);
 }
 
 TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat4) {
@@ -2710,9 +2710,9 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat4) {
   ASSERT_TRUE(op_to_count["Squeeze"] == 0);
   ASSERT_TRUE(op_to_count["Add"] == 0);
   ASSERT_TRUE(op_to_count["ReduceSum"] == 1);
-  ASSERT_TRUE(op_to_count["Attention"] == 1);
-  ASSERT_TRUE(op_to_count["SkipLayerNormalization"] == 0);
-  ASSERT_TRUE(op_to_count["EmbedLayerNormalization"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.Attention"] == 1);
+  ASSERT_TRUE(op_to_count["com.microsoft.SkipLayerNormalization"] == 0);
+  ASSERT_TRUE(op_to_count["com.microsoft.EmbedLayerNormalization"] == 1);
 }
 
 TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat5) {
@@ -2729,13 +2729,13 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat5) {
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["Gather"], 0);
   EXPECT_EQ(op_to_count["LayerNormalization"], 0);
-  EXPECT_EQ(op_to_count["SkipLayerNormalization"], 0);
+  EXPECT_EQ(op_to_count["com.microsoft.SkipLayerNormalization"], 0);
   EXPECT_EQ(op_to_count["ReduceSum"], 1);
   EXPECT_EQ(op_to_count["MatMul"], 1);
   EXPECT_EQ(op_to_count["Add"], 2);
   EXPECT_EQ(op_to_count["Cast"], 3);
-  EXPECT_EQ(op_to_count["Attention"], 1);
-  EXPECT_EQ(op_to_count["EmbedLayerNormalization"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.EmbedLayerNormalization"], 1);
 
   // Validate the position embedding input.
   for (const Node& node : graph.Nodes()) {
@@ -2777,13 +2777,13 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat6) {
   EXPECT_EQ(op_to_count["Equal"], 0);
   EXPECT_EQ(op_to_count["Where"], 0);
   EXPECT_EQ(op_to_count["LayerNormalization"], 0);
-  EXPECT_EQ(op_to_count["SkipLayerNormalization"], 0);
+  EXPECT_EQ(op_to_count["com.microsoft.SkipLayerNormalization"], 0);
   EXPECT_EQ(op_to_count["ReduceSum"], 1);
   EXPECT_EQ(op_to_count["MatMul"], 1);
   EXPECT_EQ(op_to_count["Add"], 2);
   EXPECT_EQ(op_to_count["Cast"], 3);
-  EXPECT_EQ(op_to_count["Attention"], 1);
-  EXPECT_EQ(op_to_count["EmbedLayerNormalization"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.EmbedLayerNormalization"], 1);
 }
 
 static void TestEmbedLayerNormFusionDistilBert(const std::basic_string<ORTCHAR_T>& model_uri,
@@ -2805,8 +2805,8 @@ static void TestEmbedLayerNormFusionDistilBert(const std::basic_string<ORTCHAR_T
 TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat7) {
   std::map<std::string, int> op_to_count;
   TestEmbedLayerNormFusionDistilBert(MODEL_FOLDER "fusion/embed_layer_norm_format7.onnx", op_to_count, logger_.get());
-  EXPECT_EQ(op_to_count["EmbedLayerNormalization"], 1);
-  EXPECT_EQ(op_to_count["Attention"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.EmbedLayerNormalization"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 1);
   EXPECT_EQ(op_to_count["Cast"], 2);
   EXPECT_EQ(op_to_count["Shape"], 0);
   EXPECT_EQ(op_to_count["Gather"], 0);
@@ -2817,8 +2817,8 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat7) {
 TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat8) {
   std::map<std::string, int> op_to_count;
   TestEmbedLayerNormFusionDistilBert(MODEL_FOLDER "fusion/embed_layer_norm_format8.onnx", op_to_count, logger_.get());
-  EXPECT_EQ(op_to_count["EmbedLayerNormalization"], 1);
-  EXPECT_EQ(op_to_count["Attention"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.EmbedLayerNormalization"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 1);
   EXPECT_EQ(op_to_count["Cast"], 2);
   EXPECT_EQ(op_to_count["Shape"], 0);
   EXPECT_EQ(op_to_count["Gather"], 0);
@@ -2829,8 +2829,8 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat8) {
 TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat9) {
   std::map<std::string, int> op_to_count;
   TestEmbedLayerNormFusionDistilBert(MODEL_FOLDER "fusion/embed_layer_norm_format9.onnx", op_to_count, logger_.get());
-  EXPECT_EQ(op_to_count["EmbedLayerNormalization"], 1);
-  EXPECT_EQ(op_to_count["Attention"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.EmbedLayerNormalization"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 1);
   EXPECT_EQ(op_to_count["Cast"], 2);
   EXPECT_EQ(op_to_count["Shape"], 1);
   EXPECT_EQ(op_to_count["Gather"], 2);
@@ -2855,13 +2855,13 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionMultiple) {
   EXPECT_EQ(op_to_count["Gather"], 0);
   EXPECT_EQ(op_to_count["Unsqueeze"], 0);
   EXPECT_EQ(op_to_count["LayerNormalization"], 0);
-  EXPECT_EQ(op_to_count["SkipLayerNormalization"], 0);
+  EXPECT_EQ(op_to_count["com.microsoft.SkipLayerNormalization"], 0);
   EXPECT_EQ(op_to_count["ReduceSum"], 2);
   EXPECT_EQ(op_to_count["MatMul"], 2);
   EXPECT_EQ(op_to_count["Add"], 5);
   EXPECT_EQ(op_to_count["Cast"], 6);
-  EXPECT_EQ(op_to_count["Attention"], 2);
-  EXPECT_EQ(op_to_count["EmbedLayerNormalization"], 2);
+  EXPECT_EQ(op_to_count["com.microsoft.Attention"], 2);
+  EXPECT_EQ(op_to_count["com.microsoft.EmbedLayerNormalization"], 2);
 }
 
 TEST_F(GraphTransformationTests, DynamicQuantizeMatMulTest) {
@@ -2880,7 +2880,7 @@ TEST_F(GraphTransformationTests, DynamicQuantizeMatMulTest) {
   EXPECT_EQ(op_to_count["MatMulInteger"], 0);
   EXPECT_EQ(op_to_count["Cast"], 0);
   EXPECT_EQ(op_to_count["Mul"], 0);
-  EXPECT_EQ(op_to_count["DynamicQuantizeMatMul"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.DynamicQuantizeMatMul"], 1);
 }
 
 TEST_F(GraphTransformationTests, DynamicQuantizeMatMulTest_With_Bias) {
@@ -2899,7 +2899,7 @@ TEST_F(GraphTransformationTests, DynamicQuantizeMatMulTest_With_Bias) {
   EXPECT_EQ(op_to_count["MatMulInteger"], 0);
   EXPECT_EQ(op_to_count["Cast"], 0);
   EXPECT_EQ(op_to_count["Mul"], 0);
-  EXPECT_EQ(op_to_count["DynamicQuantizeMatMul"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.DynamicQuantizeMatMul"], 1);
 }
 
 TEST_F(GraphTransformationTests, DynamicQuantizeMatMulTest_With_ND_bias) {
@@ -2918,7 +2918,7 @@ TEST_F(GraphTransformationTests, DynamicQuantizeMatMulTest_With_ND_bias) {
   EXPECT_EQ(op_to_count["MatMulInteger"], 0);
   EXPECT_EQ(op_to_count["Cast"], 0);
   EXPECT_EQ(op_to_count["Mul"], 0);
-  EXPECT_EQ(op_to_count["DynamicQuantizeMatMul"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.DynamicQuantizeMatMul"], 1);
   EXPECT_EQ(op_to_count["Add"], 1);
 }
 
@@ -2938,7 +2938,7 @@ TEST_F(GraphTransformationTests, DynamicQuantizeMatMulTest_With_Bias_No_B_ZP) {
   EXPECT_EQ(op_to_count["MatMulInteger"], 0);
   EXPECT_EQ(op_to_count["Cast"], 0);
   EXPECT_EQ(op_to_count["Mul"], 0);
-  EXPECT_EQ(op_to_count["DynamicQuantizeMatMul"], 1);
+  EXPECT_EQ(op_to_count["com.microsoft.DynamicQuantizeMatMul"], 1);
 }
 
 TEST_F(GraphTransformationTests, MatMulIntegerToFloatTest) {
@@ -2957,7 +2957,7 @@ TEST_F(GraphTransformationTests, MatMulIntegerToFloatTest) {
   EXPECT_EQ(op_to_count["MatMulInteger"], 0);
   EXPECT_EQ(op_to_count["Cast"], 0);
   EXPECT_EQ(op_to_count["Mul"], 0);
-  EXPECT_EQ(op_to_count["MatMulIntegerToFloat"], 3);
+  EXPECT_EQ(op_to_count["com.microsoft.MatMulIntegerToFloat"], 3);
   EXPECT_EQ(op_to_count["Add"], 1);
 }
 
@@ -3210,13 +3210,13 @@ TEST_F(GraphTransformationTests, MatMulScaleFusionFusableModels) {
           EXPECT_EQ(transformed_op_counts["Mul"], 0);
           EXPECT_EQ(transformed_op_counts["Div"], 0);
           EXPECT_EQ(transformed_op_counts["MatMul"], 0);
-          EXPECT_EQ(transformed_op_counts["FusedMatMul"], 1);
+          EXPECT_EQ(transformed_op_counts["com.microsoft.FusedMatMul"], 1);
 
           // check combined scale, individual scales should all have the same value
           const float scale_value = 3.0f;
 
           const int num_scales =
-              original_op_counts["Mul"] + original_op_counts["Div"] + original_op_counts["FusedMatMul"];
+              original_op_counts["Mul"] + original_op_counts["Div"] + original_op_counts["com.microsoft.FusedMatMul"];
 
           auto fused_node = std::find_if(
               graph.Nodes().cbegin(), graph.Nodes().cend(),
@@ -3258,7 +3258,7 @@ TEST_F(GraphTransformationTests, MatMulScaleFusionReusedInputScale) {
         EXPECT_EQ(transformed_op_counts["Mul"], 0);
         EXPECT_EQ(transformed_op_counts["Div"], 0);
         EXPECT_EQ(transformed_op_counts["MatMul"], 0);
-        EXPECT_EQ(transformed_op_counts["FusedMatMul"], 2);
+        EXPECT_EQ(transformed_op_counts["com.microsoft.FusedMatMul"], 2);
       });
 }
 

--- a/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
@@ -1,50 +1,26 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#include "core/graph/onnx_protobuf.h"
 
-#include "core/session/inference_session.h"
 #include "core/graph/model.h"
-#include "test/test_environment.h"
-#include "test/framework/test_utils.h"
-#include "test/compare_ortvalue.h"
-#include "gtest/gtest.h"
+#include "core/graph/onnx_protobuf.h"
 #include "core/mlas/inc/mlas.h"
 #include "core/session/environment.h"
+#include "core/session/inference_session.h"
+#include "test/compare_ortvalue.h"
+#include "test/test_environment.h"
+#include "test/framework/test_utils.h"
+#include "test/util/include/inference_session_wrapper.h"
+
+#include "gtest/gtest.h"
 
 namespace onnxruntime {
 namespace test {
-
-// InferenceSession wrapper in order to gain access to the loaded graph.
-class NchwcInferenceSession : public InferenceSession {
- public:
-  explicit NchwcInferenceSession(const SessionOptions& session_options,
-                                 const Environment& env) : InferenceSession(session_options, env) {
-  }
-
-  std::unordered_map<std::string, int> CountOpsInGraph() {
-    std::unordered_map<std::string, int> op_to_count;
-    if (model_.get() != nullptr) {
-      for (auto& node : model_->MainGraph().Nodes()) {
-        std::string key = node.OpType();
-        if (node.Domain() == kMSNchwcDomain) {
-          key = "nchwc." + key;
-        }
-        op_to_count[key] = op_to_count[key] + 1;
-      }
-    }
-    return op_to_count;
-  }
-
-  const Graph& GetGraph() {
-    return model_->MainGraph();
-  }
-};
 
 struct NchwcTestHelper {
   NchwcTestHelper(Graph& graph) : graph_(graph), fill_value_(0), per_sample_tolerance_(0.0) {
   }
 
-  template<typename T>
+  template <typename T>
   NodeArg* MakeInput(const std::vector<int64_t>& shape, const ONNX_NAMESPACE::TypeProto& type_proto) {
     int64_t num_elements = 1;
     for (auto& dim : shape) {
@@ -60,7 +36,7 @@ struct NchwcTestHelper {
     return &graph_.GetOrCreateNodeArg(name, &type_proto);
   }
 
-  template<typename T>
+  template <typename T>
   NodeArg* MakeInput(const std::vector<int64_t>& shape) {
     ONNX_NAMESPACE::TypeProto type_proto;
     type_proto.mutable_tensor_type()->set_elem_type(utils::ToTensorProtoElementType<T>());
@@ -163,7 +139,7 @@ struct NchwcTestHelper {
     return AddTransposeNode(input_arg, output_arg, {1, 0, 2, 3});
   }
 
-  template<typename T>
+  template <typename T>
   std::vector<T> FillRandomData(size_t count) {
     constexpr int min_fill_value = -23;
     constexpr int max_fill_value = 23;
@@ -188,7 +164,7 @@ struct NchwcTestHelper {
 };
 
 void NchwcOptimizerTester(const std::function<void(NchwcTestHelper& helper)>& build_test_case,
-                          const std::function<void(NchwcInferenceSession& session)>& check_nchwc_graph,
+                          const std::function<void(InferenceSessionWrapper& session)>& check_nchwc_graph,
                           int opset_version = 12) {
   // Ignore the test if NCHWc is not supported by the platform.
   if (MlasNchwcGetBlockSize() <= 1) {
@@ -212,7 +188,7 @@ void NchwcOptimizerTester(const std::function<void(NchwcTestHelper& helper)>& bu
     SessionOptions session_options;
     session_options.graph_optimization_level = level;
     session_options.session_logid = "NchwcOptimizerTests";
-    NchwcInferenceSession session{session_options, GetEnvironment()};
+    InferenceSessionWrapper session{session_options, GetEnvironment()};
     ASSERT_TRUE(session.Load(model_data.data(), static_cast<int>(model_data.size())).IsOK());
     ASSERT_TRUE(session.Initialize().IsOK());
 
@@ -272,11 +248,11 @@ TEST(NchwcOptimizerTests, ConvNchw) {
       conv_node.AddAttribute("strides", std::vector<int64_t>{2, 2});
     };
 
-    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-      auto op_to_count = session.CountOpsInGraph();
-      EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 0);
-      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 0);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
       if (!activation_op_type.empty()) {
         EXPECT_EQ(op_to_count[activation_op_type], 0);
       }
@@ -310,11 +286,11 @@ TEST(NchwcOptimizerTests, ConvNchwc) {
       helper.AddConvNode(input_arg, conv_output_arg, {127, 64, 3, 3});
     };
 
-    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-      auto op_to_count = session.CountOpsInGraph();
-      EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
       if (!activation_op_type.empty()) {
         EXPECT_EQ(op_to_count[activation_op_type], 0);
       }
@@ -345,11 +321,11 @@ TEST(NchwcOptimizerTests, ConvNchwcGrouped) {
       conv_node.AddAttribute("group", static_cast<int64_t>(3));
     };
 
-    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-      auto op_to_count = session.CountOpsInGraph();
-      EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
       if (!activation_op_type.empty()) {
         EXPECT_EQ(op_to_count[activation_op_type], 0);
       }
@@ -380,11 +356,11 @@ TEST(NchwcOptimizerTests, ConvDepthwise) {
       conv_node.AddAttribute("group", static_cast<int64_t>(96));
     };
 
-    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-      auto op_to_count = session.CountOpsInGraph();
-      EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
       if (!activation_op_type.empty()) {
         EXPECT_EQ(op_to_count[activation_op_type], 0);
       }
@@ -414,11 +390,11 @@ TEST(NchwcOptimizerTests, ConvPointwise) {
       helper.AddConvNode(input_arg, conv_output_arg, {128, 64, 1, 1});
     };
 
-    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-      auto op_to_count = session.CountOpsInGraph();
-      EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
       if (!activation_op_type.empty()) {
         EXPECT_EQ(op_to_count[activation_op_type], 0);
       }
@@ -446,12 +422,12 @@ TEST(NchwcOptimizerTests, ConvMaxPool) {
     pool_node.AddAttribute("kernel_shape", std::vector<int64_t>{5, 5});
   };
 
-  auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-    auto op_to_count = session.CountOpsInGraph();
-    EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
-    EXPECT_EQ(op_to_count["nchwc.MaxPool"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.MaxPool"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
   };
 
   NchwcOptimizerTester(build_test_case, check_nchwc_graph);
@@ -470,12 +446,12 @@ TEST(NchwcOptimizerTests, ConvMaxPoolDilations) {
     pool_node.AddAttribute("dilations", std::vector<int64_t>{2, 2});
   };
 
-  auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-    auto op_to_count = session.CountOpsInGraph();
-    EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
-    EXPECT_EQ(op_to_count["nchwc.MaxPool"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.MaxPool"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
   };
 
   NchwcOptimizerTester(build_test_case, check_nchwc_graph);
@@ -498,12 +474,12 @@ TEST(NchwcOptimizerTests, ConvAveragePool) {
       }
     };
 
-    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-      auto op_to_count = session.CountOpsInGraph();
-      EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
-      EXPECT_EQ(op_to_count["nchwc.AveragePool"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.AveragePool"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
     };
 
     NchwcOptimizerTester(build_test_case, check_nchwc_graph);
@@ -526,12 +502,12 @@ TEST(NchwcOptimizerTests, ConvGlobalPool) {
       helper.AddNode(op_type, {conv_output_arg}, {output_arg});
     };
 
-    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-      auto op_to_count = session.CountOpsInGraph();
-      EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
-      EXPECT_EQ(op_to_count["nchwc." + op_type], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc." + op_type], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
     };
 
     NchwcOptimizerTester(build_test_case, check_nchwc_graph);
@@ -563,11 +539,11 @@ TEST(NchwcOptimizerTests, ConvAddFusion) {
       }
     };
 
-    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-      auto op_to_count = session.CountOpsInGraph();
-      EXPECT_EQ(op_to_count["nchwc.Conv"], 2);
-      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 2);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
       EXPECT_EQ(op_to_count[op_type], 0);
       EXPECT_EQ(op_to_count["Relu"], 0);
     };
@@ -599,11 +575,11 @@ TEST(NchwcOptimizerTests, ConvNoBiasAddFusion) {
     helper.AddNode("Add", {conv1_output_arg, conv2_output_arg}, {output_arg});
   };
 
-  auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-    auto op_to_count = session.CountOpsInGraph();
-    EXPECT_EQ(op_to_count["nchwc.Conv"], 2);
-    EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 2);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
     EXPECT_EQ(op_to_count["Add"], 0);
   };
 
@@ -637,11 +613,11 @@ TEST(NchwcOptimizerTests, FusedConvAddFusion) {
       helper.AddNode("Add", {add1_input_arg, add2_input_arg}, {output_arg});
     };
 
-    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-      auto op_to_count = session.CountOpsInGraph();
-      EXPECT_EQ(op_to_count["nchwc.Conv"], 2);
-      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 2);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
       EXPECT_EQ(op_to_count["Add"], add_count);
       EXPECT_EQ(op_to_count["Relu"], 0);
     };
@@ -677,11 +653,11 @@ TEST(NchwcOptimizerTests, ConvBinary) {
       helper.AddNode(op_type, {relu1_output_arg, relu2_output_arg}, {output_arg});
     };
 
-    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-      auto op_to_count = session.CountOpsInGraph();
-      EXPECT_EQ(op_to_count["nchwc.Conv"], 2);
-      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 2);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
       EXPECT_EQ(op_to_count[op_type], 1);
       EXPECT_EQ(op_to_count["Relu"], 0);
     };
@@ -714,11 +690,11 @@ TEST(NchwcOptimizerTests, ConvConcat) {
       concat_node.AddAttribute("axis", static_cast<int64_t>(axis));
     };
 
-    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-      auto op_to_count = session.CountOpsInGraph();
-      EXPECT_EQ(op_to_count["nchwc.Conv"], 3);
-      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], reorder_output_count);
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 3);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], reorder_output_count);
     };
 
     NchwcOptimizerTester(build_test_case, check_nchwc_graph);
@@ -750,11 +726,11 @@ TEST(NchwcOptimizerTests, ConvReuseWeightsOIHWBiBo) {
     helper.AddNode("Conv", {input_arg, weights_arg, biases_arg}, {output3_arg});
   };
 
-  auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-    auto op_to_count = session.CountOpsInGraph();
-    EXPECT_EQ(op_to_count["nchwc.Conv"], 3);
-    EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 3);
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 3);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 3);
 
     // Verify that the weights and biases were converted once and reused.
     std::unordered_set<const NodeArg*> weight_args;
@@ -800,11 +776,11 @@ TEST(NchwcOptimizerTests, ConvReuseWeightsOIHWBo) {
     helper.AddNode("Conv", {input4_arg, weights_arg, biases_arg}, {output4_arg});
   };
 
-  auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-    auto op_to_count = session.CountOpsInGraph();
-    EXPECT_EQ(op_to_count["nchwc.Conv"], 4);
-    EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 2);
-    EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 4);
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 4);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 2);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 4);
 
     // Verify that the weights and biases were converted once and reused.
     std::unordered_set<const NodeArg*> weight_args;
@@ -864,12 +840,12 @@ TEST(NchwcOptimizerTests, ShapeInferencing) {
     helper.AddNode("Add", {conv3a_output_arg, conv3b_output_arg}, {output_arg});
   };
 
-  auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-    auto op_to_count = session.CountOpsInGraph();
-    EXPECT_EQ(op_to_count["nchwc.Conv"], 3);
-    EXPECT_EQ(op_to_count["nchwc.MaxPool"], 2);
-    EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 0);
-    EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 3);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.MaxPool"], 2);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 0);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
     EXPECT_EQ(op_to_count["Add"], 0);
   };
 
@@ -912,11 +888,11 @@ TEST(NchwcOptimizerTests, ShapeInferencing2) {
     helper.AddNode("Add", {conv2a_output_arg, conv2b_output_arg}, {output_arg});
   };
 
-  auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-    auto op_to_count = session.CountOpsInGraph();
-    EXPECT_EQ(op_to_count["nchwc.Conv"], 4);
-    EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 0);
-    EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 4);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 0);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
     EXPECT_EQ(op_to_count["Add"], 0);
   };
 
@@ -946,11 +922,11 @@ TEST(NchwcOptimizerTests, MixedOutputUsage) {
     helper.AddNode("Add", {conv2_output_arg, neg_output_arg}, {output_arg});
   };
 
-  auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-    auto op_to_count = session.CountOpsInGraph();
-    EXPECT_EQ(op_to_count["nchwc.Conv"], 2);
-    EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 0);
-    EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 2);
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 2);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 0);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 2);
   };
 
   // Verify that mixed NCHWc/NCHW usages of NCHWc nodes.
@@ -983,14 +959,14 @@ TEST(NchwcOptimizerTests, TensorAlignment) {
     pool_node.AddAttribute("kernel_shape", std::vector<int64_t>{2, 2});
   };
 
-  auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-    auto op_to_count = session.CountOpsInGraph();
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
     EXPECT_EQ(op_to_count["Conv"], 3);
     EXPECT_EQ(op_to_count["MaxPool"], 1);
-    EXPECT_EQ(op_to_count["nchwc.Conv"], 0);
-    EXPECT_EQ(op_to_count["nchwc.MaxPool"], 0);
-    EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 0);
-    EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 0);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 0);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.MaxPool"], 0);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 0);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 0);
   };
 
   // Verify that convolutions with unaligned inputs are not transformed.
@@ -1015,12 +991,12 @@ TEST(NchwcOptimizerTests, IntermediatesAsGraphOutputs) {
     helper.graph_.SetOutputs({output_arg, conv_output_arg});
   };
 
-  auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-    auto op_to_count = session.CountOpsInGraph();
-    EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
-    EXPECT_EQ(op_to_count["nchwc.MaxPool"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 2);
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.MaxPool"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 2);
   };
 
   // Verify that intermediates used inside the graph but that are also graph
@@ -1079,19 +1055,19 @@ TEST(NchwcOptimizerTests, BatchNormalization) {
       helper.per_sample_tolerance_ = .00025;
     };
 
-    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-      auto op_to_count = session.CountOpsInGraph();
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
       if (training_outputs) {
-        EXPECT_EQ(op_to_count["nchwc.Conv"], 2);
+        EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 2);
         EXPECT_EQ(op_to_count["BatchNormalization"], 1);
         EXPECT_EQ(op_to_count["Relu"], 1);
       } else {
-        EXPECT_EQ(op_to_count["nchwc.Conv"], 3);
+        EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 3);
         EXPECT_EQ(op_to_count["BatchNormalization"], 0);
         EXPECT_EQ(op_to_count["Relu"], 0);
       }
-      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 0);
-      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 0);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
     };
 
     NchwcOptimizerTester(build_test_case, check_nchwc_graph);
@@ -1115,11 +1091,11 @@ TEST(NchwcOptimizerTests, ConvReorderOutputNhwc) {
     helper.AddTransposeToNhwcNode(conv_output_arg, nhwc_output_arg);
   };
 
-  auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-    auto op_to_count = session.CountOpsInGraph();
-    EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
     EXPECT_EQ(op_to_count["Transpose"], 0);
   };
 
@@ -1139,11 +1115,11 @@ TEST(NchwcOptimizerTests, ConvReorderOutputBoth) {
     helper.AddNode("Neg", {conv_output_arg}, {nchw_output_arg});
   };
 
-  auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-    auto op_to_count = session.CountOpsInGraph();
-    EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 2);
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 2);
     EXPECT_EQ(op_to_count["Transpose"], 0);
   };
 
@@ -1162,11 +1138,11 @@ TEST(NchwcOptimizerTests, ConvReorderOutputCnhw) {
     helper.AddTransposeToCnhwNode(conv_output_arg, nhwc_output_arg);
   };
 
-  auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-    auto op_to_count = session.CountOpsInGraph();
-    EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
     EXPECT_EQ(op_to_count["Transpose"], 1);
   };
 
@@ -1200,12 +1176,12 @@ TEST(NchwcOptimizerTests, Upsample) {
       }
     };
 
-    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-      auto op_to_count = session.CountOpsInGraph();
-      EXPECT_EQ(op_to_count["nchwc.Conv"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
-      EXPECT_EQ(op_to_count["nchwc.Upsample"], 1);
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Upsample"], 1);
       EXPECT_EQ(op_to_count["Resize"] + op_to_count["Upsample"], 0);
     };
 
@@ -1237,11 +1213,11 @@ TEST(NchwcOptimizerTests, Activation) {
       helper.AddConvNode(mul_output_arg, output_arg, {16, 32, 1, 1});
     };
 
-    auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-      auto op_to_count = session.CountOpsInGraph();
-      EXPECT_EQ(op_to_count["nchwc.Conv"], 2);
-      EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-      EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 2);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
       EXPECT_EQ(op_to_count[activation_op_type], 1);
       EXPECT_EQ(op_to_count["Add"], 1);
     };
@@ -1271,12 +1247,12 @@ TEST(NchwcOptimizerTests, MaxPoolTypeCheck) {
     add_pool_node(helper, helper.MakeInput<uint8_t>(input_shape));
   };
 
-  auto check_nchwc_graph = [&](NchwcInferenceSession& session) {
-    auto op_to_count = session.CountOpsInGraph();
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
     EXPECT_EQ(op_to_count["MaxPool"], 1);
-    EXPECT_EQ(op_to_count["nchwc.MaxPool"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderInput"], 1);
-    EXPECT_EQ(op_to_count["nchwc.ReorderOutput"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.MaxPool"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderInput"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.ReorderOutput"], 1);
   };
 
   // Verify that the optimizer checks the type of the MaxPool node.

--- a/onnxruntime/test/util/include/inference_session_wrapper.h
+++ b/onnxruntime/test/util/include/inference_session_wrapper.h
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/session/inference_session.h"
+#include "core/graph/model.h"
+
+namespace onnxruntime {
+namespace test {
+
+// InferenceSession wrapper class for use in tests where we need access to the Graph and SessionState
+class InferenceSessionWrapper : public InferenceSession {
+ public:
+  explicit InferenceSessionWrapper(const SessionOptions& session_options,
+                                   const Environment& env) : InferenceSession(session_options, env) {
+  }
+
+  const Graph& GetGraph() const {
+    return model_->MainGraph();
+  }
+
+  const SessionState& GetSessionState() const {
+    return InferenceSession::GetSessionState();
+  }
+};
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/orttraining/orttraining/test/graph/gradient_graph_builder_test.cc
+++ b/orttraining/orttraining/test/graph/gradient_graph_builder_test.cc
@@ -187,8 +187,8 @@ TEST(GradientGraphBuilderTest, BuildConcatGradientGraphTest) {
 
   ASSERT_EQ(op_to_count["Concat"], 0);
   ASSERT_EQ(op_to_count["Split"], 0);
-  ASSERT_EQ(op_to_count["ConcatTraining"], 1);
-  ASSERT_EQ(op_to_count["SplitTraining"], 1);
+  ASSERT_EQ(op_to_count["com.microsoft.ConcatTraining"], 1);
+  ASSERT_EQ(op_to_count["com.microsoft.SplitTraining"], 1);
 }
 
 TEST(GradientGraphBuilderTest, TrainingSession_Basic) {

--- a/orttraining/orttraining/test/graph/optimizer_graph_builder_test.cc
+++ b/orttraining/orttraining/test/graph/optimizer_graph_builder_test.cc
@@ -111,16 +111,10 @@ OptimizerBuilderRegistry& GetOptimizerBuilderRegistry() {
   return OptimizerBuilderRegistry::GetInstance();
 }
 
-int GetOpCount(const std::map<std::string, int>& op_counts, const std::string& op_type) {
-  static std::string ms_domain_prefix{std::string(kMsDomain) + '.'};
+static int GetOpCount(const std::map<std::string, int>& op_counts, const std::string& op_type) {
+  static std::string ms_domain_prefix{std::string(kMSDomain) + '.'};
 
-  std::string key;
-  if (op_type != std::string(k_horovod_all_reduce_op_name)) {
-    key = ms_domain_prefix;
-  }
-  key += op_type;
-
-  auto op_count_it = op_counts.find(op_type);
+  auto op_count_it = op_counts.find(ms_domain_prefix + op_type);
   return op_count_it != op_counts.end() ? op_count_it->second : 0;
 }
 

--- a/orttraining/orttraining/test/graph/optimizer_graph_builder_test.cc
+++ b/orttraining/orttraining/test/graph/optimizer_graph_builder_test.cc
@@ -112,6 +112,14 @@ OptimizerBuilderRegistry& GetOptimizerBuilderRegistry() {
 }
 
 int GetOpCount(const std::map<std::string, int>& op_counts, const std::string& op_type) {
+  static std::string ms_domain_prefix{std::string(kMsDomain) + '.'};
+
+  std::string key;
+  if (op_type != std::string(k_horovod_all_reduce_op_name)) {
+    key = ms_domain_prefix;
+  }
+  key += op_type;
+
   auto op_count_it = op_counts.find(op_type);
   return op_count_it != op_counts.end() ? op_count_it->second : 0;
 }

--- a/orttraining/orttraining/test/optimizer/graph_transform_test.cc
+++ b/orttraining/orttraining/test/optimizer/graph_transform_test.cc
@@ -63,7 +63,7 @@ static void TestBiasDropoutFusion(const PathString& file_path, const logging::Lo
   ASSERT_EQ(op_to_count["Add"], add_count);
   ASSERT_EQ(op_to_count["Dropout"], 0);
   ASSERT_EQ(op_to_count["TrainableDropout"], 0);
-  ASSERT_EQ(op_to_count["BiasDropout"], 1);
+  ASSERT_EQ(op_to_count["com.microsoft.BiasDropout"], 1);
 }
 
 TEST_F(GraphTransformationTests, BiasDropoutFusionTest) {
@@ -128,7 +128,7 @@ TEST_F(GraphTransformationTests, ConcatReplacement) {
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
 
   ASSERT_EQ(op_to_count["Concat"], 0);
-  ASSERT_EQ(op_to_count["ConcatTraining"], 1);
+  ASSERT_EQ(op_to_count["com.microsoft.ConcatTraining"], 1);
 }
 
 TEST_F(GraphTransformationTests, MegatronMLPPartitionRank0) {


### PR DESCRIPTION
**Description**: 
Created shared version of InferenceSession wrapper class and update relevant tests to use it.

Include domain in the ops counting helper so it's more generic and we don't need to duplicate it in the nchwc tests. Update tests to include domain in key being checked.

**Motivation and Context**
Reduce duplicated code.