### PR TITLE
temporarily fix issue in hardcoding View op's view_count_limit to 1024

### DIFF
--- a/orttraining/orttraining/training_ops/cuda/tensor/view.cc
+++ b/orttraining/orttraining/training_ops/cuda/tensor/view.cc
@@ -8,7 +8,7 @@ namespace cuda {
 
 namespace {
 
-constexpr int view_count_limit = 1024;  // limit of of output count
+constexpr int view_count_limit = 2048;  // limit of of output count
 
 std::vector<std::pair<int, int>> GenerateAliasMapping() {
   std::vector<std::pair<int, int>> alias_pairs{};
@@ -45,6 +45,7 @@ Status View::ComputeInternal(OpKernelContext* context) const {
   size_t bytes_per_elem = X->DataType()->Size();
 
   int view_count = context->InputCount() - 1;
+  ORT_ENFORCE(view_count <= view_count_limit, "please increase view_count_limit's value, otherwise segmentation fault will happen");
   std::vector<TensorShape> y_shapes(view_count);
   std::vector<size_t> y_byte_offsets(view_count);
   size_t byte_offset = 0;


### PR DESCRIPTION
a real model exceed the harded value 1024, so extend to 2048;

also add a checker to abort exectuion instead of trigger seg fault after
continuing exectuion.