### PR TITLE
Save in EndTraining only if in last rank 

### DIFF
--- a/orttraining/orttraining/models/mnist/main.cc
+++ b/orttraining/orttraining/models/mnist/main.cc
@@ -209,7 +209,5 @@ int main(int argc, char* args[]) {
   auto runner = onnxruntime::make_unique<TrainingRunner>(params, *env);
   RETURN_IF_FAIL(runner->Initialize());
   RETURN_IF_FAIL(runner->Run(training_data_loader.get(), test_data_loader.get()));
-  // if (MPIContext::GetInstance().GetWorldRank() == device_count - 1) {
-    RETURN_IF_FAIL(runner->EndTraining(test_data_loader.get()));
-  // }
+  RETURN_IF_FAIL(runner->EndTraining(test_data_loader.get()));
 }

--- a/orttraining/orttraining/models/mnist/main.cc
+++ b/orttraining/orttraining/models/mnist/main.cc
@@ -71,6 +71,9 @@ Status ParseArguments(int argc, char* argv[], TrainingRunner::Parameters& params
     }
     params.evaluation_period = flags["evaluation_period"].as<size_t>();
 
+    params.shuffle_data = false;
+    params.is_perf_test = false;
+
     auto train_data_dir = flags["train_data_dir"].as<std::string>();
     auto log_dir = flags["log_dir"].as<std::string>();
     params.train_data_dir.assign(train_data_dir.begin(), train_data_dir.end());
@@ -206,5 +209,7 @@ int main(int argc, char* args[]) {
   auto runner = onnxruntime::make_unique<TrainingRunner>(params, *env);
   RETURN_IF_FAIL(runner->Initialize());
   RETURN_IF_FAIL(runner->Run(training_data_loader.get(), test_data_loader.get()));
-  RETURN_IF_FAIL(runner->EndTraining(test_data_loader.get()));
+  // if (MPIContext::GetInstance().GetWorldRank() == device_count - 1) {
+    RETURN_IF_FAIL(runner->EndTraining(test_data_loader.get()));
+  // }
 }

--- a/orttraining/orttraining/models/runner/training_runner.cc
+++ b/orttraining/orttraining/models/runner/training_runner.cc
@@ -1069,7 +1069,8 @@ Status TrainingRunner::EndTraining(IDataLoader* data_loader) {
   }
 
   // We only want to save with WITH_UPDATED_WEIGHTS or WITH_UPDATED_WEIGHTS_AND_LOSS_FUNC
-  // if the Loss Function is configured, or otherwise saving will fail.
+  // if the Loss function is in the graph, or otherwise saving will fail.
+  // Assuming here that the Loss function will be assigned to the last device of the pipeline.
   if (MPIContext::GetInstance().GetWorldRank() == params_.pipeline_parallel_size - 1) {
     printf("\nSaving the trained model.\n");
     const PathString model_base_name = GetLastComponent(params_.model_path);

--- a/orttraining/orttraining/models/runner/training_runner.cc
+++ b/orttraining/orttraining/models/runner/training_runner.cc
@@ -1068,18 +1068,22 @@ Status TrainingRunner::EndTraining(IDataLoader* data_loader) {
     ORT_RETURN_IF_ERROR(Env::Default().CreateFolder(params_.output_dir));
   }
 
-  printf("\nSaving the trained model.\n");
-  const PathString model_base_name = GetLastComponent(params_.model_path);
+  // We only want to save with WITH_UPDATED_WEIGHTS or WITH_UPDATED_WEIGHTS_AND_LOSS_FUNC
+  // if the Loss Function is configured, or otherwise saving will fail.
+  if (MPIContext::GetInstance().GetWorldRank() == params_.pipeline_parallel_size - 1) {
+    printf("\nSaving the trained model.\n");
+    const PathString model_base_name = GetLastComponent(params_.model_path);
 
-  const PathString trained_model_path =
-      params_.output_dir + GetPathSep<PathChar>() + model_base_name + ORT_TSTR("_trained.onnx");
-  ORT_RETURN_IF_ERROR(session_.Save(
-      trained_model_path, TrainingSession::SaveOption::WITH_UPDATED_WEIGHTS));
+    const PathString trained_model_path =
+        params_.output_dir + GetPathSep<PathChar>() + model_base_name + ORT_TSTR("_trained.onnx");
+    ORT_RETURN_IF_ERROR(session_.Save(
+        trained_model_path, TrainingSession::SaveOption::WITH_UPDATED_WEIGHTS));
 
-  const PathString trained_model_with_loss_func_path =
-      params_.output_dir + GetPathSep<PathChar>() + model_base_name + ORT_TSTR("_with_cost_trained.onnx");
-  ORT_RETURN_IF_ERROR(session_.Save(
-      trained_model_with_loss_func_path, TrainingSession::SaveOption::WITH_UPDATED_WEIGHTS_AND_LOSS_FUNC));
+    const PathString trained_model_with_loss_func_path =
+        params_.output_dir + GetPathSep<PathChar>() + model_base_name + ORT_TSTR("_with_cost_trained.onnx");
+    ORT_RETURN_IF_ERROR(session_.Save(
+        trained_model_with_loss_func_path, TrainingSession::SaveOption::WITH_UPDATED_WEIGHTS_AND_LOSS_FUNC));
+  }
 
   return Status::OK();
 }


### PR DESCRIPTION


In EndTraining, the graph is saved with WITH_UPDATED_WEIGHTS and WITH_UPDATED_WEIGHTS_AND_LOSS_FUNC options, which will try to ConfigureLossFunction. However, if the graph is partitioned, only the subgraph running in the last device should have the loss function (training_runner.cc:125).

If we use pipeline parallelism to train mnist, for example, we get the error "ConfigureLossFunctionInternalEither loss function information should be provided or an external loss name should be given." in line training_session.cc:439. If we use the code in branch xuzhu/dist_cpu, we can reproduce this error.

I've also initialized two bool variables in mnist/main.cc just to prevent future odd behaviours. Happy to move this initialization to another PR though. 