### PR TITLE
Add type inference for BroadcastGradientArgs

### DIFF
--- a/orttraining/orttraining/core/graph/training_op_defs.cc
+++ b/orttraining/orttraining/core/graph/training_op_defs.cc
@@ -1435,8 +1435,10 @@ Example 4:
           {"tensor(int64)"},
           "Constrain input and output types to 64-bit integer.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        updateOutputElemType(ctx, 0, ONNX_NAMESPACE::TensorProto::INT64);
-        updateOutputElemType(ctx, 1, ONNX_NAMESPACE::TensorProto::INT64);
+        // NOTE: Both outputs are optional.
+        for (size_t i = 0; i < ctx.getNumOutputs(); ++i) {
+          updateOutputElemType(ctx, i, ONNX_NAMESPACE::TensorProto::INT64);
+        }
       });
 
   ONNX_CONTRIB_OPERATOR_SCHEMA(GistBinarizeEncoder)

--- a/orttraining/orttraining/core/graph/training_op_defs.cc
+++ b/orttraining/orttraining/core/graph/training_op_defs.cc
@@ -1433,7 +1433,11 @@ Example 4:
       .TypeConstraint(
           "T",
           {"tensor(int64)"},
-          "Constrain input and output types to 64-bit integer.");
+          "Constrain input and output types to 64-bit integer.")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        updateOutputElemType(ctx, 0, ONNX_NAMESPACE::TensorProto::INT64);
+        updateOutputElemType(ctx, 1, ONNX_NAMESPACE::TensorProto::INT64);
+      });
 
   ONNX_CONTRIB_OPERATOR_SCHEMA(GistBinarizeEncoder)
       .SetDomain(kMSDomain)


### PR DESCRIPTION
**Description**: Add a minimal type inference function for BroadcastGradientArgs.

**Motivation and Context**
- Without this change, the dummy inference function is used, and no types are inferred for the output [here](https://github.com/onnx/onnx/blob/531e6dd459003fc8d13b8abb66b29a72a571c865/onnx/shape_inference/implementation.cc#L467-L469), which causes type inference for subsequent ops to fail.
