### PR TITLE
Symbolic shape inference: fix a bug in shape merge

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1203,10 +1203,10 @@ class SymbolicShapeInference:
                                 if out_shape[idx] is not None:
                                     continue
                                 # note that the broadcasting rule aligns from right to left
-                                # if a tensor has a lower rank, it would automatically broadcast and need no merge
-                                dim_idx = [len(s) - len(out_shape) + idx for s in shapes if len(s) >= len(out_shape) - idx]
+                                # if a tensor has a lower rank (dim_idx[idx] < 0), it would automatically broadcast and need no merge
+                                dim_idx = [len(s) - len(out_shape) + idx for s in shapes]
                                 if len(dim_idx) > 0:
-                                    self._add_suggested_merge([s[i] if is_literal(s[i]) else str(s[i]) for s, i in zip(shapes, dim_idx)])
+                                    self._add_suggested_merge([s[i] if is_literal(s[i]) else str(s[i]) for s, i in zip(shapes, dim_idx) if i >= 0])
                             self.run_ = True
                         else:
                             self.run_ = False


### PR DESCRIPTION
**Description**: This change fixes auto merge when broadcasting

**Motivation and Context**
OpType Where:
input0: ['mt_src_tokens_batch', 1, 1, 'mt_src_tokens_len']
input1: []
input2: ['mt_prev_output_tokens_batch', 12, 'mt_prev_output_tokens_len', 'floor(mt_src_tokens_batch*mt_src_tokens_len/mt_prev_output_tokens_batch)'] 1
output: [None, 12, 'mt_prev_output_tokens_len', None]
