### PR TITLE
Update dimensions check to enable Cuda 3D Conv Transpose

### DIFF
--- a/onnxruntime/core/providers/cuda/nn/conv_transpose.cc
+++ b/onnxruntime/core/providers/cuda/nn/conv_transpose.cc
@@ -6,7 +6,7 @@
 namespace onnxruntime {
 namespace cuda {
 
-// Op Set 11 for ConvTranspose only update document to clearify default dilations and strides value.
+// Op Set 11 for ConvTranspose only update document to clarify default dilations and strides value.
 // which are already covered by op set 11 cpu version, so simply add declaration.
 #define REGISTER_KERNEL_TYPED(T)                                                \
   ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                                      \
@@ -45,10 +45,10 @@ Status ConvTranspose<T>::DoConvTranspose(OpKernelContext* context, bool dynamic_
   auto x_data = reinterpret_cast<const CudaT*>(X->template Data<T>());
 
   auto x_dimensions = X->Shape().NumDimensions();
-  if (x_dimensions != 4 && x_dimensions != 3) {
+  if (x_dimensions != 5 && x_dimensions != 4 && x_dimensions != 3) {
     // This condition is not true for test_convtranspose_3d in ONNX tests series.
     // TODO: the error message should tell which operator raises it.
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input X must be 3- or 4-dimensional.",
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input X must be 3-, 4- or 5-dimensional.",
                            " X: ", X->Shape().ToString().c_str());
   }
   const Tensor* W = context->Input<Tensor>(1);


### PR DESCRIPTION
**Description**: 
Enable 3D Convolution Transpose for Cuda by updating the dimension check.
Since this check currently prevents the use of ONNXRuntime in many medical applications I would suggest it's quite urgent to enable this.

**Motivation and Context**
- The 3D Convolution Transpose operation of CuDNN can do 3D transpose convolutions, but this is currently prevented by this check. I simply updated the check to allow for 3D data to pass through.
I confirmed the output is the same as for the CPU provider (which already allows for 3D transpose) on a 3D Unet.

