### PR TITLE
Add alternate IsSupportedOptypeVersionAndString signature

### DIFF
--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -293,6 +293,13 @@ bool IsSupportedOptypeVersionAndDomain(const Node& node,
           MatchesOpSinceVersion(node, versions) && MatchesOpSetDomain(node, domain));
 }
 
+bool IsSupportedOptypeVersionAndDomain(const Node& node,
+                                       const char* op_type,
+                                       const std::initializer_list<ONNX_NAMESPACE::OperatorSetVersion>& versions,
+                                       const char* domain) {
+  return IsSupportedOptypeVersionAndDomain(node, std::string(op_type), versions, std::string(domain));
+}
+
 bool MatchesOpSinceVersion(const Node& node, const std::initializer_list<ONNX_NAMESPACE::OperatorSetVersion>& versions) {
   return std::find(versions.begin(), versions.end(), node.SinceVersion()) != versions.end();
 }

--- a/onnxruntime/core/graph/graph_utils.h
+++ b/onnxruntime/core/graph/graph_utils.h
@@ -15,6 +15,10 @@ bool IsSupportedOptypeVersionAndDomain(const Node& node,
                                        const std::string& op_type,
                                        const std::initializer_list<ONNX_NAMESPACE::OperatorSetVersion>& versions,
                                        const std::string& domain = kOnnxDomainAlias);
+bool IsSupportedOptypeVersionAndDomain(const Node& node,
+                                       const char* op_type,
+                                       const std::initializer_list<ONNX_NAMESPACE::OperatorSetVersion>& versions,
+                                       const char* domain = kOnnxDomainAlias);
 
 /** Checks if the node has the same operator since version as the given one. */
 bool MatchesOpSinceVersion(const Node& node, const std::initializer_list<ONNX_NAMESPACE::OperatorSetVersion>& versions);


### PR DESCRIPTION
**Description**: Add a variant of graph_utils::IsSupportedOptypeVersionAndDomain that takes const char* instead of std::string. This removes a bunch of code at the call sites to construct/destruct a temporary std::string and moves it to this helper instead. My onnxruntime.dll shrunk by ~20KB. NchwcTransformer::ApplyImpl went from 4KB->1KB of code.