### PR TITLE
[CMake] Enable generation of compilation database by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ onnxprofile_profile_test_*.json
 /csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.targets
 /csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.props
 cmake/external/FeaturizersLibrary/
+/compile_commands.json
 # Java specific ignores
 java/gradlew
 java/gradlew.bat

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -49,6 +49,10 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose build type: Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
+# Generate a CompilationDatabase (compile_commands.json file).
+# This is used by clang_complete, YouCompleteMe, etc.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Options
 option(onnxruntime_RUN_ONNX_TESTS "Enable ONNX Compatibility Testing" OFF)
 option(onnxruntime_GENERATE_TEST_REPORTS "Enable test report generation" OFF)


### PR DESCRIPTION
**Description**: Describe your changes.

By default export compilation commands to json compilation database. 
The compile_commands.json is used by several code-completion tools: e.g.
clang_complete and YouCompleteMe 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
