### PR TITLE
Add #include for std::tolower to flatbuffers utils header file

### DIFF
--- a/onnxruntime/core/flatbuffers/flatbuffers_utils.h
+++ b/onnxruntime/core/flatbuffers/flatbuffers_utils.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cctype>
 #include <unordered_map>
 #include <core/common/status.h>
 


### PR DESCRIPTION
**Description**: 
Add #include for std::tolower. 

**Motivation and Context**
Fixes VS2017 build error.