### PR TITLE
Don't call UnloadSharedProviders in a minimal build as they are not supported

### DIFF
--- a/onnxruntime/core/session/ort_env.cc
+++ b/onnxruntime/core/session/ort_env.cc
@@ -40,7 +40,10 @@ OrtEnv::OrtEnv(std::unique_ptr<onnxruntime::Environment> value1)
 }
 
 OrtEnv::~OrtEnv() {
+  // we don't support any shared providers in the minimal build yet
+#if !defined(ORT_MINIMAL_BUILD)
   UnloadSharedProviders();
+#endif
 }
 
 OrtEnv* OrtEnv::GetInstance(const OrtEnv::LoggingManagerConstructionInfo& lm_info,


### PR DESCRIPTION
**Description**: 
Exclude call to UnloadSharedProviders as there's no implementation of it in a minimal build

**Motivation and Context**
Fix CI failures.