### PR TITLE
Allow Upper case letters in RHS of einsum equations.

### DIFF
--- a/onnxruntime/core/providers/cpu/math/einsum_utils/einsum_compute_preprocessor.cc
+++ b/onnxruntime/core/providers/cpu/math/einsum_utils/einsum_compute_preprocessor.cc
@@ -369,13 +369,12 @@ Status EinsumComputePreprocessor::CalculateOutputShape() {
         return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Found '.' not part of an ellipsis in the output subscript provided");
       }
 
-      if (!(subscript_label >= 'a' && subscript_label <= 'z')) {
+      auto letter_index = EinsumOp::LetterToIndex(subscript_label);
+      if (letter_index == -1) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                               "The only subscript labels allowed in the output subscript "
-                               "are lowercase letters (a-z)");
+                              "The only subscript labels allowed are lower-cased letters (a-z) and "
+                              "upper-cased letters (A-Z)");
       }
-
-      auto letter_index = static_cast<int64_t>(subscript_label - 'a');
 
       if (output_letter_to_count[letter_index] != 0) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,

--- a/onnxruntime/test/providers/cpu/math/einsum_test.cc
+++ b/onnxruntime/test/providers/cpu/math/einsum_test.cc
@@ -187,6 +187,16 @@ TEST(Einsum, ExplicitEinsumAsMatmulWithUpperCasedLabel) {
   test.Run();
 }
 
+TEST(Einsum, ExplicitEinsumAsMatmulWithUpperCasedOutputLabel) {
+  OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
+  // Einsum should handle be able to handle upper case on both LHS and RHS
+  test.AddAttribute<std::string>("equation", "Ki,ik->Kk");
+  test.AddInput<float>("x", {2, 1}, {1.f, 2.f});
+  test.AddInput<float>("y", {1, 2}, {1.f, 2.f});
+  test.AddOutput<float>("o", {2, 2}, {1.f, 2.f, 2.f, 4.f});
+  test.Run();
+}
+
 TEST(Einsum, ExplicitEinsumAsMatmul_Multi_Input) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute<std::string>("equation", "ij,jk,kl->li");


### PR DESCRIPTION
**Description**: Update the Einsum operator to allow for upper case letters in the right hand side of the equation.

**Motivation and Context**
Einsum was updated [here](https://github.com/microsoft/onnxruntime/pull/4964/commits/daa71eff9bdf311ae1af5105f85ef2caa88acce0) to allow for upper case letters in the left hand side of the equation, but the right hand side still required lower case letters only.

Addresses a missed case in the closed issue:
https://github.com/microsoft/onnxruntime/issues/4944