### PR TITLE
Handle -inf in ReduceSumLogExp, fix regression introduced in PR #5370

### DIFF
--- a/onnxruntime/core/mlas/lib/convolve.cpp
+++ b/onnxruntime/core/mlas/lib/convolve.cpp
@@ -146,7 +146,6 @@ Return Value:
 
                 size_t InputX = InitialInputX;
                 const float* InputRow = &Input[InputY * InputWidth];
-                const float* tempInputRow;
 
                 do {
 
@@ -173,28 +172,6 @@ Return Value:
                         }
 
                         CountX -= CountCopyX;
-                        tempInputRow = &InputRow[InputX];
-
-                        while (CountCopyX >= 16) {
-                          MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(tempInputRow));
-                          ColumnBuffer += 4;
-                          tempInputRow += 4;
-
-                          MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(tempInputRow));
-                          ColumnBuffer += 4;
-                          tempInputRow += 4;
-
-                          MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(tempInputRow));
-                          ColumnBuffer += 4;
-                          tempInputRow += 4;
-
-                          MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(tempInputRow));
-                          ColumnBuffer += 4;
-                          tempInputRow += 4;
-
-                          InputX += 16;
-                          CountCopyX -= 16;
-                        }
 
                         while (CountCopyX >= 4) {
                             MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(&InputRow[InputX]));
@@ -232,22 +209,6 @@ Return Value:
                 //
 
                 MLAS_FLOAT32X4 ZeroFloat32x4 = MlasZeroFloat32x4();
-
-                while (CountX >= 16) {
-                  MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
-                  ColumnBuffer += 4;
-
-                  MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
-                  ColumnBuffer += 4;
-
-                  MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
-                  ColumnBuffer += 4;
-
-                  MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
-                  ColumnBuffer += 4;
-
-                  CountX -= 16;
-                }
 
                 while (CountX >= 4) {
                     MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
@@ -566,8 +527,6 @@ Return Value:
     const size_t FilterCount = Parameters->FilterCount;
     const size_t OutputSize = Parameters->OutputSize;
     const size_t K = Parameters->K;
-    const size_t K2 = Parameters->K * 2;
-    const size_t SegmentCountN2 = SegmentCountN * 2;
 
     //
     // Compute the strides to step through slices of the local segment.
@@ -580,14 +539,14 @@ Return Value:
 
     if (SegmentCountN >= K) {
 
-        while (StrideK >= K2) {
+        while (StrideK / 2 >= K) {
             StrideN *= 2;
             StrideK /= 2;
         }
 
     } else {
 
-        while (StrideN > 16 && StrideN >= SegmentCountN2) {
+        while (StrideN > 16 && StrideN / 2 >= SegmentCountN) {
             StrideK *= 2;
             StrideN /= 2;
         }
@@ -601,12 +560,11 @@ Return Value:
 
     for (size_t n = 0; n < SegmentCountN; n += CountN) {
 
-        // CountN = SegmentCountN - n;
+        CountN = SegmentCountN - n;
 
-        CountN = SegmentCountN - n > StrideN ? StrideN : SegmentCountN - n;
-        // if (CountN > StrideN) {
-        //    CountN = StrideN;
-        //}
+        if (CountN > StrideN) {
+            CountN = StrideN;
+        }
 
         //
         // Step through each slice of the input tensor along the K dimension.
@@ -618,12 +576,11 @@ Return Value:
 
         for (size_t k = 0; k < K; k += CountK) {
 
-            // CountK = K - k;
+            CountK = K - k;
 
-            CountK = K - k > StrideK ? StrideK : K - k;
-            //if (CountK > StrideK) {
-            //    CountK = StrideK;
-            //}
+            if (CountK > StrideK) {
+                CountK = StrideK;
+            }
 
             if (Parameters->Dimensions == 2) {
                 MlasConvIm2Col(Parameters, Input, ColumnBuffer, k, CountK,

--- a/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
@@ -304,7 +304,7 @@ class ReduceAggregatorLogSumExp : public ReduceAggregator<T, TVAL> {
 
  public:
   inline ReduceAggregatorLogSumExp(int64_t N, const T& init) : ReduceAggregator<T, TVAL>(N, 0) {
-    max_ = reduce_isinf(init) ? accumulator_ : init;
+    max_ = reduce_isinf(init) ? this->accumulator_ : init;
   }
   inline TVAL aggall(const T* from_data) {
     max_ = Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>>(from_data, this->N_).maxCoeff();

--- a/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
@@ -64,6 +64,36 @@ inline int32_t reduce_log<int32_t>(int32_t value) { return static_cast<int32_t>(
 template <typename T>
 inline T reduce_exp(T value) { return static_cast<T>(std::exp(value)); }
 
+template <typename T>
+inline bool reduce_isinf(T value) { return std::isinf(value); }
+
+template <>
+inline bool reduce_isinf<int8_t>(int8_t) { return false; }
+
+template <>
+inline bool reduce_isinf<uint8_t>(uint8_t) { return false; }
+
+template <>
+inline bool reduce_isinf<int32_t>(int32_t) { return false; }
+
+template <>
+inline bool reduce_isinf<int64_t>(int64_t) { return false; }
+
+template <typename T>
+inline bool reduce_isnan(T value) { return std::isnan(value); }
+
+template <>
+inline bool reduce_isnan<int8_t>(int8_t) { return false; }
+
+template <>
+inline bool reduce_isnan<uint8_t>(uint8_t) { return false; }
+
+template <>
+inline bool reduce_isnan<int32_t>(int32_t) { return false; }
+
+template <>
+inline bool reduce_isnan<int64_t>(int64_t) { return false; }
+
 template <typename T, typename TVAL = T>
 class ReduceAggregator {
  public:
@@ -273,7 +303,9 @@ class ReduceAggregatorLogSumExp : public ReduceAggregator<T, TVAL> {
   T max_;
 
  public:
-  inline ReduceAggregatorLogSumExp(int64_t N, const T&) : ReduceAggregator<T, TVAL>(N, 0) { max_ = this->accumulator_; }
+  inline ReduceAggregatorLogSumExp(int64_t N, const T& init) : ReduceAggregator<T, TVAL>(N, 0) {
+    max_ = reduce_isinf(init) ? accumulator_ : init;
+  }
   inline TVAL aggall(const T* from_data) {
     max_ = Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>>(from_data, this->N_).maxCoeff();
     for (int64_t i = 0; i < this->N_; ++i) {
@@ -281,7 +313,9 @@ class ReduceAggregatorLogSumExp : public ReduceAggregator<T, TVAL> {
     }
     return get_value();
   }
-  inline void update0(const T& v) { max_ = v > max_ ? v : max_; }
+  inline void update0(const T& v) {
+    max_ = (reduce_isinf(v) || reduce_isnan(v) || v < max_) ? max_ : v;
+  }
   inline void update(const T& v) { this->accumulator_ += reduce_exp(v - max_); }
   inline TVAL get_value() { return reduce_log<T>(this->accumulator_) + max_; }
   static inline bool two_loops() { return true; }

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -2093,39 +2093,12 @@ TEST(ReductionOpTest, ReduceInfLogSum) {
   test.Run();
 }
 
-TEST(ReductionOpTest, ReduceInfSumLogExp1) {
+TEST(ReductionOpTest, ReduceInfLogSumExp) {
   OpTester test("ReduceLogSumExp");
   test.AddAttribute("axes", std::vector<int64_t>{1});
   test.AddAttribute("keepdims", (int64_t)0);
-  test.AddInput<float>("data", {1, 2}, {1.0f, FLOAT_INF});
-  test.AddOutput<float>("reduced", {1}, {FLOAT_INF});
-  test.Run();
-}
-
-TEST(ReductionOpTest, ReduceInfSumLogExp2) {
-  OpTester test("ReduceLogSumExp");
-  test.AddAttribute("axes", std::vector<int64_t>{1});
-  test.AddAttribute("keepdims", (int64_t)0);
-  test.AddInput<float>("data", {1, 2}, {FLOAT_INF, 1.0f});
-  test.AddOutput<float>("reduced", {1}, {FLOAT_INF});
-  test.Run();
-}
-
-TEST(ReductionOpTest, ReduceInfSumLogExp3) {
-  OpTester test("ReduceLogSumExp");
-  test.AddAttribute("axes", std::vector<int64_t>{1});
-  test.AddAttribute("keepdims", (int64_t)0);
-  test.AddInput<float>("data", {1, 2}, {1.0f, FLOAT_NINF});
-  test.AddOutput<float>("reduced", {1}, {1.0f});
-  test.Run();
-}
-
-TEST(ReductionOpTest, ReduceInfSumLogExp4) {
-  OpTester test("ReduceLogSumExp");
-  test.AddAttribute("axes", std::vector<int64_t>{1});
-  test.AddAttribute("keepdims", (int64_t)0);
-  test.AddInput<float>("data", {1, 2}, {FLOAT_NINF, 1.0f});
-  test.AddOutput<float>("reduced", {1}, {1.0f});
+  test.AddInput<float>("data", {2, 2}, {1.0f, FLOAT_NINF, FLOAT_NINF, 1.0f});
+  test.AddOutput<float>("reduced", {2}, {1.0f, 1.0f});
   test.Run();
 }
 

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -2018,5 +2018,92 @@ TEST(ReductionOpTest, ReduceDimWithZero) {
   run(test3);
 }
 
+TEST(ReductionOpTest, ReduceInfMax) {
+  OpTester test("ReduceMax");
+  test.AddAttribute("axes", std::vector<int64_t>{1});
+  test.AddAttribute("keepdims", (int64_t)0);
+  test.AddInput<float>("data", {6, 2},
+                       {1.0f, -std::numeric_limits<float>::infinity(),
+                        -std::numeric_limits<float>::infinity(), 4.0f,
+                        std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(),
+                        -std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
+                        1.0f, std::numeric_limits<float>::infinity(),
+                        std::numeric_limits<float>::infinity(), 4.0f});
+  test.AddOutput<float>("reduced", {6},
+                        {1.0f, 4.0f,
+                         std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
+                         std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity()});
+  test.Run();
+}
+
+TEST(ReductionOpTest, ReduceInfMin) {
+  OpTester test("ReduceMin");
+  test.AddAttribute("axes", std::vector<int64_t>{1});
+  test.AddAttribute("keepdims", (int64_t)0);
+  test.AddInput<float>("data", {6, 2},
+                       {1.0f, std::numeric_limits<float>::infinity(),
+                        std::numeric_limits<float>::infinity(), 4.0f,
+                        std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(),
+                        -std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
+                        1.0f, -std::numeric_limits<float>::infinity(),
+                        -std::numeric_limits<float>::infinity(), 4.0f});
+  test.AddOutput<float>("reduced", {6},
+                        {1.0f, 4.0f,
+                         -std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(),
+                         -std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity()});
+  test.Run();
+}
+
+TEST(ReductionOpTest, ReduceInfSum) {
+  OpTester test("ReduceSum");
+  test.AddAttribute("axes", std::vector<int64_t>{1});
+  test.AddAttribute("keepdims", (int64_t)0);
+  test.AddInput<float>("data", {6, 2},
+                       {1.0f, std::numeric_limits<float>::infinity(),
+                        std::numeric_limits<float>::infinity(), 4.0f,
+                        std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(),
+                        -std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
+                        1.0f, -std::numeric_limits<float>::infinity(),
+                        -std::numeric_limits<float>::infinity(), 4.0f});
+  test.AddOutput<float>("reduced", {6},
+                        {std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
+                         std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(),
+                         -std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity()});
+  test.Run();
+}
+
+TEST(ReductionOpTest, ReduceInfLogSum) {
+  OpTester test("ReduceLogSum");
+  test.AddAttribute("axes", std::vector<int64_t>{1});
+  test.AddAttribute("keepdims", (int64_t)0);
+  test.AddInput<float>("data", {6, 2},
+                       {1.0f, std::numeric_limits<float>::infinity(),
+                        std::numeric_limits<float>::infinity(), 1.0f,
+                        std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(),
+                        -std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
+                        1.0f, -std::numeric_limits<float>::infinity(),
+                        -std::numeric_limits<float>::infinity(), 1.0f});
+  test.AddOutput<float>("reduced", {6},
+                        {std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
+                         -std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN()});
+  test.Run();
+}
+
+TEST(ReductionOpTest, ReduceInfSumLogExp) {
+  OpTester test("ReduceLogSumExp");
+  test.AddAttribute("axes", std::vector<int64_t>{1});
+  test.AddAttribute("keepdims", (int64_t)0);
+  test.AddInput<float>("data", {4, 2},
+                       {1.0f, std::numeric_limits<float>::infinity(),
+                        std::numeric_limits<float>::infinity(), 1.0f,
+                        1.0f, -std::numeric_limits<float>::infinity(),
+                        -std::numeric_limits<float>::infinity(), 1.0f});
+  test.AddOutput<float>("reduced", {4},
+                        {std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
+                         1.0f, 1.0f});
+  test.Run();
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -15,6 +15,9 @@
 namespace onnxruntime {
 namespace test {
 
+const float FLOAT_INF = std::numeric_limits<float>::infinity();
+const float FLOAT_NINF = -std::numeric_limits<float>::infinity();
+
 // Disable TensorRT on some of the tests because the limit in its parser: axis >=0 && axis < nbDims
 template <typename OutT>
 void TestReduceOp(const std::string& op,
@@ -2023,16 +2026,16 @@ TEST(ReductionOpTest, ReduceInfMax) {
   test.AddAttribute("axes", std::vector<int64_t>{1});
   test.AddAttribute("keepdims", (int64_t)0);
   test.AddInput<float>("data", {6, 2},
-                       {1.0f, -std::numeric_limits<float>::infinity(),
-                        -std::numeric_limits<float>::infinity(), 4.0f,
-                        std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(),
-                        -std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
-                        1.0f, std::numeric_limits<float>::infinity(),
-                        std::numeric_limits<float>::infinity(), 4.0f});
+                       {1.0f, FLOAT_NINF,
+                        FLOAT_NINF, 4.0f,
+                        FLOAT_INF, FLOAT_NINF,
+                        FLOAT_NINF, FLOAT_INF,
+                        1.0f, FLOAT_INF,
+                        FLOAT_INF, 4.0f});
   test.AddOutput<float>("reduced", {6},
                         {1.0f, 4.0f,
-                         std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
-                         std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity()});
+                         FLOAT_INF, FLOAT_INF,
+                         FLOAT_INF, FLOAT_INF});
   test.Run();
 }
 
@@ -2041,16 +2044,16 @@ TEST(ReductionOpTest, ReduceInfMin) {
   test.AddAttribute("axes", std::vector<int64_t>{1});
   test.AddAttribute("keepdims", (int64_t)0);
   test.AddInput<float>("data", {6, 2},
-                       {1.0f, std::numeric_limits<float>::infinity(),
-                        std::numeric_limits<float>::infinity(), 4.0f,
-                        std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(),
-                        -std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
-                        1.0f, -std::numeric_limits<float>::infinity(),
-                        -std::numeric_limits<float>::infinity(), 4.0f});
+                       {1.0f, FLOAT_INF,
+                        FLOAT_INF, 4.0f,
+                        FLOAT_INF, FLOAT_NINF,
+                        FLOAT_NINF, FLOAT_INF,
+                        1.0f, FLOAT_NINF,
+                        FLOAT_NINF, 4.0f});
   test.AddOutput<float>("reduced", {6},
                         {1.0f, 4.0f,
-                         -std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(),
-                         -std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity()});
+                         FLOAT_NINF, FLOAT_NINF,
+                         FLOAT_NINF, FLOAT_NINF});
   test.Run();
 }
 
@@ -2059,16 +2062,16 @@ TEST(ReductionOpTest, ReduceInfSum) {
   test.AddAttribute("axes", std::vector<int64_t>{1});
   test.AddAttribute("keepdims", (int64_t)0);
   test.AddInput<float>("data", {6, 2},
-                       {1.0f, std::numeric_limits<float>::infinity(),
-                        std::numeric_limits<float>::infinity(), 4.0f,
-                        std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(),
-                        -std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
-                        1.0f, -std::numeric_limits<float>::infinity(),
-                        -std::numeric_limits<float>::infinity(), 4.0f});
+                       {1.0f, FLOAT_INF,
+                        FLOAT_INF, 4.0f,
+                        FLOAT_INF, FLOAT_NINF,
+                        FLOAT_NINF, FLOAT_INF,
+                        1.0f, FLOAT_NINF,
+                        FLOAT_NINF, 4.0f});
   test.AddOutput<float>("reduced", {6},
-                        {std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
+                        {FLOAT_INF, FLOAT_INF,
                          std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(),
-                         -std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity()});
+                         FLOAT_NINF, FLOAT_NINF});
   test.Run();
 }
 
@@ -2077,31 +2080,52 @@ TEST(ReductionOpTest, ReduceInfLogSum) {
   test.AddAttribute("axes", std::vector<int64_t>{1});
   test.AddAttribute("keepdims", (int64_t)0);
   test.AddInput<float>("data", {6, 2},
-                       {1.0f, std::numeric_limits<float>::infinity(),
-                        std::numeric_limits<float>::infinity(), 1.0f,
-                        std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(),
-                        -std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
-                        1.0f, -std::numeric_limits<float>::infinity(),
-                        -std::numeric_limits<float>::infinity(), 1.0f});
+                       {1.0f, FLOAT_INF,
+                        FLOAT_INF, 1.0f,
+                        FLOAT_INF, FLOAT_NINF,
+                        FLOAT_NINF, FLOAT_INF,
+                        1.0f, FLOAT_NINF,
+                        FLOAT_NINF, 1.0f});
   test.AddOutput<float>("reduced", {6},
-                        {std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
+                        {FLOAT_INF, FLOAT_INF,
                          -std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(),
                          std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN()});
   test.Run();
 }
 
-TEST(ReductionOpTest, ReduceInfSumLogExp) {
+TEST(ReductionOpTest, ReduceInfSumLogExp1) {
   OpTester test("ReduceLogSumExp");
   test.AddAttribute("axes", std::vector<int64_t>{1});
   test.AddAttribute("keepdims", (int64_t)0);
-  test.AddInput<float>("data", {4, 2},
-                       {1.0f, std::numeric_limits<float>::infinity(),
-                        std::numeric_limits<float>::infinity(), 1.0f,
-                        1.0f, -std::numeric_limits<float>::infinity(),
-                        -std::numeric_limits<float>::infinity(), 1.0f});
-  test.AddOutput<float>("reduced", {4},
-                        {std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(),
-                         1.0f, 1.0f});
+  test.AddInput<float>("data", {1, 2}, {1.0f, FLOAT_INF});
+  test.AddOutput<float>("reduced", {1}, {FLOAT_INF});
+  test.Run();
+}
+
+TEST(ReductionOpTest, ReduceInfSumLogExp2) {
+  OpTester test("ReduceLogSumExp");
+  test.AddAttribute("axes", std::vector<int64_t>{1});
+  test.AddAttribute("keepdims", (int64_t)0);
+  test.AddInput<float>("data", {1, 2}, {FLOAT_INF, 1.0f});
+  test.AddOutput<float>("reduced", {1}, {FLOAT_INF});
+  test.Run();
+}
+
+TEST(ReductionOpTest, ReduceInfSumLogExp3) {
+  OpTester test("ReduceLogSumExp");
+  test.AddAttribute("axes", std::vector<int64_t>{1});
+  test.AddAttribute("keepdims", (int64_t)0);
+  test.AddInput<float>("data", {1, 2}, {1.0f, FLOAT_NINF});
+  test.AddOutput<float>("reduced", {1}, {1.0f});
+  test.Run();
+}
+
+TEST(ReductionOpTest, ReduceInfSumLogExp4) {
+  OpTester test("ReduceLogSumExp");
+  test.AddAttribute("axes", std::vector<int64_t>{1});
+  test.AddAttribute("keepdims", (int64_t)0);
+  test.AddInput<float>("data", {1, 2}, {FLOAT_NINF, 1.0f});
+  test.AddOutput<float>("reduced", {1}, {1.0f});
   test.Run();
 }
 


### PR DESCRIPTION
**Description**:
PR #5370 changes the implemantation of ReduceSumLogExp but did not handle -inf the same way. This PR restores the behavior and add unit tests to check there is no regression.

**Motivation and Context**
Bug fix.
