### PR TITLE
Fix nuphar docker file build break

### DIFF
--- a/dockerfiles/Dockerfile.nuphar
+++ b/dockerfiles/Dockerfile.nuphar
@@ -23,7 +23,7 @@ WORKDIR /
 
 RUN mkdir -p /onnxruntime/build && \
     pip3 install sympy packaging cpufeature jupyter && \
-    python3 /onnxruntime/tools/ci_build/build.py --build_dir /onnxruntime/build --update --build --config Release --build_shared_lib --skip_submodule_sync --build_wheel --parallel --use_nuphar --use_mklml && \
+    python3 /onnxruntime/tools/ci_build/build.py --build_dir /onnxruntime/build --update --build --config Release --build_shared_lib --skip_submodule_sync --build_wheel --parallel --use_nuphar && \
     rm -rf /tmp/* && \
     rm -rf /home/root/* && \
     pip3 install /onnxruntime/build/Release/dist/onnxruntime_nuphar-*.whl && \


### PR DESCRIPTION
**Description**: 

Fix nuphar docker file build break. It is because I removed the "use_mklml" build option but I forgot to cleanup the usages in dockerfiles.

**Motivation and Context**
- Why is this change required? What problem does it solve?
Currently it doesn't build.
- If it fixes an open issue, please link to the issue here.
