### PR TITLE
Fix IS_ANDROID Issue 

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
@@ -11,7 +11,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
-import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -117,10 +116,7 @@ final class OnnxRuntime {
    * @return True if the property java.vendor equals The Android Project, false otherwise.
    */
   static boolean isAndroid() {
-    if ( System.getProperty("java.vendor", "generic").equals("The Android Project")) {
-      return true;
-    }
-    return false;
+    return System.getProperty("java.vendor", "generic").equals("The Android Project");
   }
 
   /**

--- a/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
+import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -37,8 +38,6 @@ final class OnnxRuntime {
 
   private static boolean loaded = false;
 
-  private static final boolean IS_ANDROID = isAndroid();
-
   /** The API handle. */
   static long ortApiHandle;
 
@@ -54,7 +53,7 @@ final class OnnxRuntime {
       detectedOS = "win";
     } else if (os.contains("nux")) {
       detectedOS = "linux";
-    } else if (IS_ANDROID) {
+    } else if (isAndroid()) {
       detectedOS = "android";
     } else {
       throw new IllegalStateException("Unsupported os:" + os);
@@ -65,7 +64,7 @@ final class OnnxRuntime {
       detectedArch = "x64";
     } else if (arch.indexOf("x86") == 0) {
       detectedArch = "x86";
-    } else if (IS_ANDROID) {
+    } else if (isAndroid()) {
       detectedArch = arch;
     } else {
       throw new IllegalStateException("Unsupported arch:" + arch);
@@ -82,14 +81,14 @@ final class OnnxRuntime {
     if (loaded) {
       return;
     }
-    Path tempDirectory = IS_ANDROID ? null : Files.createTempDirectory("onnxruntime-java");
+    Path tempDirectory = isAndroid() ? null : Files.createTempDirectory("onnxruntime-java");
     try {
       load(tempDirectory, ONNXRUNTIME_LIBRARY_NAME);
       load(tempDirectory, ONNXRUNTIME_JNI_LIBRARY_NAME);
       ortApiHandle = initialiseAPIBase(ORT_API_VERSION_3);
       loaded = true;
     } finally {
-      if (!IS_ANDROID) {
+      if (!isAndroid()) {
         cleanUp(tempDirectory.toFile());
       }
     }
@@ -115,15 +114,13 @@ final class OnnxRuntime {
   /**
    * Check if we're running on Android.
    *
-   * @return True if the {@code android.app.Activity} class can be loaded, false otherwise.
+   * @return True if the property java.vendor equals The Android Project, false otherwise.
    */
   static boolean isAndroid() {
-    try {
-      Class.forName("android.app.Activity");
+    if ( System.getProperty("java.vendor", "generic").equals("The Android Project")) {
       return true;
-    } catch (ClassNotFoundException e) {
-      return false;
     }
+    return false;
   }
 
   /**
@@ -135,7 +132,7 @@ final class OnnxRuntime {
    */
   private static void load(Path tempDirectory, String library) throws IOException {
     // On Android, we simply use System.loadLibrary
-    if (IS_ANDROID) {
+    if (isAndroid()) {
       System.loadLibrary("onnxruntime4j_jni");
       return;
     }


### PR DESCRIPTION
**Description**:  Removed final static IS_ANDROID in OnnxRuntime.java & modified isAndroid() method 


**Motivation and Context**
final static IS_ANDROID is causing an _Error Unsupport arch:aarch64_, so removed IS_ANDROID & replaced with IS_ANDROID with isAndroid(). Discussed with @gwang-msft offline, Guoyu suggested to use java.vendor instead of load class for isAndroid().
