### PR TITLE
Move variable declaration to avoid unused variable error

### DIFF
--- a/onnxruntime/core/framework/debug_node_inputs_outputs_utils.cc
+++ b/onnxruntime/core/framework/debug_node_inputs_outputs_utils.cc
@@ -139,7 +139,6 @@ void DumpTensor(
     const SessionState& session_state) {
   // check tensor is on CPU before dumping it
   auto& tensor_location = tensor.Location();
-  const auto data_type = tensor.DataType();
   if (tensor_location.device.Type() == OrtDevice::CPU ||
       tensor_location.mem_type == OrtMemTypeCPUInput ||
       tensor_location.mem_type == OrtMemTypeCPUOutput) {
@@ -148,6 +147,7 @@ void DumpTensor(
     std::cout << tensor_location << "\n";
 
 #ifdef USE_CUDA
+    const auto data_type = tensor.DataType();
     // Dumping GPU only when cuda is enabled.
     if (tensor_location.device.Type() == OrtDevice::GPU) {
       const auto& execution_providers = session_state.GetExecutionProviders();


### PR DESCRIPTION
When building with `build.sh --enable_training --config=Debug --build_wheel --skip_tests --parallel --cmake_extra_defines onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS=1`, I got the "unused variable" error for data_type, which only used when running on the GPU. 

Note: when building for the CPU, this fix may be required: https://github.com/microsoft/onnxruntime/pull/5516