### PR TITLE
Support more C# APIs 

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
@@ -275,6 +275,7 @@ namespace Microsoft.ML.OnnxRuntime
             OrtAllocatorFree = (DOrtAllocatorFree)Marshal.GetDelegateForFunctionPointer(api_.AllocatorFree, typeof(DOrtAllocatorFree));
             OrtAllocatorGetInfo = (DOrtAllocatorGetInfo)Marshal.GetDelegateForFunctionPointer(api_.AllocatorGetInfo, typeof(DOrtAllocatorGetInfo));
             OrtAddFreeDimensionOverride = (DOrtAddFreeDimensionOverride)Marshal.GetDelegateForFunctionPointer(api_.AddFreeDimensionOverride, typeof(DOrtAddFreeDimensionOverride));
+            OrtAddFreeDimensionOverrideByName = (DOrtAddFreeDimensionOverrideByName)Marshal.GetDelegateForFunctionPointer(api_.AddFreeDimensionOverrideByName, typeof(DOrtAddFreeDimensionOverrideByName));
 
             OrtCreateIoBinding = (DOrtCreateIoBinding)Marshal.GetDelegateForFunctionPointer(api_.CreateIoBinding, typeof(DOrtCreateIoBinding));
             OrtReleaseIoBinding = (DOrtReleaseIoBinding)Marshal.GetDelegateForFunctionPointer(api_.ReleaseIoBinding, typeof(DOrtReleaseIoBinding));
@@ -321,9 +322,11 @@ namespace Microsoft.ML.OnnxRuntime
             OrtModelMetadataLookupCustomMetadataMap = (DOrtModelMetadataLookupCustomMetadataMap)Marshal.GetDelegateForFunctionPointer(api_.ModelMetadataLookupCustomMetadataMap, typeof(DOrtModelMetadataLookupCustomMetadataMap));
             OrtReleaseModelMetadata = (DOrtReleaseModelMetadata)Marshal.GetDelegateForFunctionPointer(api_.ReleaseModelMetadata, typeof(DOrtReleaseModelMetadata));
 
+            OrtGetAvailableProviders = (DOrtGetAvailableProviders)Marshal.GetDelegateForFunctionPointer(api_.GetAvailableProviders, typeof(DOrtGetAvailableProviders));
+            OrtReleaseAvailableProviders = (DOrtReleaseAvailableProviders)Marshal.GetDelegateForFunctionPointer(api_.ReleaseAvailableProviders, typeof(DOrtReleaseAvailableProviders));
         }
 
-        [DllImport(nativeLib, CharSet = charSet)]
+        [DllImport("F:\\onnxruntime6\\build\\Windows\\Debug\\Debug\\onnxruntime.dll", CharSet = charSet)]
         public static extern ref OrtApiBase OrtGetApiBase();
 
         #region Runtime/Environment API
@@ -564,13 +567,16 @@ namespace Microsoft.ML.OnnxRuntime
         //[DllImport(nativeLib, CharSet = charSet)]
         //public static extern void OrtAddCustomOp(IntPtr /*(OrtSessionOptions*)*/ options, string custom_op_path);
 
-        public delegate IntPtr /*(OrtStatus*)*/DOrtAddFreeDimensionOverride(IntPtr /*(OrtSessionOptions*) */ options, string /*(const char*)*/ symbolic_dim, int dim_override);
+        public delegate IntPtr /*(OrtStatus*)*/DOrtAddFreeDimensionOverride(IntPtr /*(OrtSessionOptions*) */ options, string /*(const char*)*/ dimDenotation, long dimValue);
         public static DOrtAddFreeDimensionOverride OrtAddFreeDimensionOverride;
+
+        public delegate IntPtr /*(OrtStatus*)*/DOrtAddFreeDimensionOverrideByName(IntPtr /*(OrtSessionOptions*) */ options, string /*(const char*)*/ dimName, long dimValue);
+        public static DOrtAddFreeDimensionOverrideByName OrtAddFreeDimensionOverrideByName;
 
         public delegate IntPtr /*(OrtStatus*)*/DOrtRegisterCustomOpsLibrary(IntPtr /*(OrtSessionOptions*) */ options, string /*(const char*)*/ library_path, out IntPtr /* (void**) */ library_handle);
         public static DOrtRegisterCustomOpsLibrary OrtRegisterCustomOpsLibrary;
 
-        public delegate IntPtr /*(OrtStatus*)*/DOrtAddInitializer(IntPtr /*(OrtSessionOptions*) */ options, string /*(const char*)*/ name, IntPtr /* OrtValue* */ ort_value);
+        public delegate IntPtr /*(OrtStatus*)*/DOrtAddInitializer(IntPtr /*(OrtSessionOptions*) */ options, string /*(const char*)*/ name, IntPtr /* OrtValue* */ ortValue);
         public static DOrtAddInitializer OrtAddInitializer;
 
         #endregion
@@ -1046,6 +1052,27 @@ namespace Microsoft.ML.OnnxRuntime
         public delegate void DOrtReleaseValue(IntPtr /*(OrtValue*)*/ value);
         public static DOrtReleaseValue OrtReleaseValue;
 
+        #endregion
+
+        #region Misc API
+
+        /// <summary>
+        /// Queries all the execution providers supported in the native onnxruntime shared library
+        /// </summary>
+        /// <param name="providers">(output) all execution providers (strings) supported in the native onnxruntime shared library</param>
+        /// <param name="numProviders">(output) number of execution providers (strings)</param>
+
+        public delegate IntPtr /* (OrtStatus*) */ DOrtGetAvailableProviders(out IntPtr /* (char***) */ providers, out int /* (int*) */ numProviders);
+        public static DOrtGetAvailableProviders OrtGetAvailableProviders;
+
+        /// <summary>
+        /// Releases all execution provider strings allocated and returned by OrtGetAvailableProviders
+        /// </summary>
+        /// <param name="providers">all execution providers (strings) returned by OrtGetAvailableProviders</param>
+        /// <param name="numProviders">number of execution providers (strings)</param>
+
+        public delegate IntPtr /* (OrtStatus*) */ DOrtReleaseAvailableProviders(IntPtr /* (char**) */ providers, int /* (int) */ numProviders);
+        public static DOrtReleaseAvailableProviders OrtReleaseAvailableProviders;
         #endregion
 
         public static byte[] GetPlatformSerializedString(string str)

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
@@ -526,7 +526,7 @@ namespace Microsoft.ML.OnnxRuntime
         public static DOrtSetSessionGraphOptimizationLevel OrtSetSessionGraphOptimizationLevel;
 
         /// <summary>
-        /// Add session config entry (by denotation)
+        /// Add session config entry
         /// </summary>
         /// <param name="options">Native SessionOptions instance</param>
         /// <param name="configKey">Config key</param>
@@ -541,7 +541,7 @@ namespace Microsoft.ML.OnnxRuntime
         //  * on your most preferred execution provider first followed by the less preferred ones.
         //  * Calling this API is optional in which case onnxruntime will use its internal CPU execution provider.
         //  */
-        [DllImport("F:\\onnxruntime6\\build\\Windows\\Debug\\Debug\\onnxruntime.dll", CharSet = charSet)]
+        [DllImport(nativeLib, CharSet = charSet)]
         public static extern IntPtr /*(OrtStatus*)*/ OrtSessionOptionsAppendExecutionProvider_CPU(IntPtr /*(OrtSessionOptions*) */ options, int use_arena);
 
         [DllImport(nativeLib, CharSet = charSet)]
@@ -590,7 +590,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// Free Dimension override (by name)
         /// </summary>
         /// <param name="options">Native SessionOptions instance</param>
-        /// <param name="dimDenotation">Dimension name</param>
+        /// <param name="dimName">Dimension name</param>
         /// <param name="dimValue">Dimension value</param>
         public delegate IntPtr /*(OrtStatus*)*/DOrtAddFreeDimensionOverrideByName(IntPtr /*(OrtSessionOptions*)*/ options, 
                                                                                   IntPtr /*(const char*)*/ dimName, 
@@ -602,7 +602,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// Register custom op library
         /// </summary>
         /// <param name="options">Native SessionOptions instance</param>
-        /// <param name="libraryName">Library path</param>
+        /// <param name="libraryPath">Library path</param>
         /// <param name="libraryHandle">(out) Native library handle</param>
         public delegate IntPtr /*(OrtStatus*)*/DOrtRegisterCustomOpsLibrary(IntPtr /*(OrtSessionOptions*) */ options, 
                                                                             IntPtr /*(const char*)*/ libraryPath, 
@@ -617,7 +617,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// <param name="ortValue">Native OrtValue instnce</param>
         public delegate IntPtr /*(OrtStatus*)*/DOrtAddInitializer(IntPtr /*(OrtSessionOptions*)*/ options, 
                                                                   IntPtr /*(const char*)*/ name, 
-                                                                  IntPtr /* OrtValue* */ ortValue);
+                                                                  IntPtr /*(OrtValue*)*/ ortValue);
         public static DOrtAddInitializer OrtAddInitializer;
 
         #endregion

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
@@ -326,7 +326,7 @@ namespace Microsoft.ML.OnnxRuntime
             OrtReleaseAvailableProviders = (DOrtReleaseAvailableProviders)Marshal.GetDelegateForFunctionPointer(api_.ReleaseAvailableProviders, typeof(DOrtReleaseAvailableProviders));
         }
 
-        [DllImport("F:\\onnxruntime6\\build\\Windows\\Debug\\Debug\\onnxruntime.dll", CharSet = charSet)]
+        [DllImport(nativeLib, CharSet = charSet)]
         public static extern ref OrtApiBase OrtGetApiBase();
 
         #region Runtime/Environment API

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.cs
@@ -525,7 +525,15 @@ namespace Microsoft.ML.OnnxRuntime
         public delegate IntPtr /*(OrtStatus*)*/ DOrtSetSessionGraphOptimizationLevel(IntPtr /* OrtSessionOptions* */ options, GraphOptimizationLevel graphOptimizationLevel);
         public static DOrtSetSessionGraphOptimizationLevel OrtSetSessionGraphOptimizationLevel;
 
-        public delegate IntPtr /*(OrtStatus*)*/ DOrtAddSessionConfigEntry(IntPtr /* OrtSessionOptions* */ options, string configKey, string configValue);
+        /// <summary>
+        /// Add session config entry (by denotation)
+        /// </summary>
+        /// <param name="options">Native SessionOptions instance</param>
+        /// <param name="configKey">Config key</param>
+        /// <param name="configValue">Config value</param>
+        public delegate IntPtr /*(OrtStatus*)*/ DOrtAddSessionConfigEntry(IntPtr /* OrtSessionOptions* */ options, 
+                                                                          IntPtr /* const char* */configKey, 
+                                                                          IntPtr /* const char* */ configValue);
         public static DOrtAddSessionConfigEntry OrtAddSessionConfigEntry;
 
         ///**
@@ -533,7 +541,7 @@ namespace Microsoft.ML.OnnxRuntime
         //  * on your most preferred execution provider first followed by the less preferred ones.
         //  * Calling this API is optional in which case onnxruntime will use its internal CPU execution provider.
         //  */
-        [DllImport(nativeLib, CharSet = charSet)]
+        [DllImport("F:\\onnxruntime6\\build\\Windows\\Debug\\Debug\\onnxruntime.dll", CharSet = charSet)]
         public static extern IntPtr /*(OrtStatus*)*/ OrtSessionOptionsAppendExecutionProvider_CPU(IntPtr /*(OrtSessionOptions*) */ options, int use_arena);
 
         [DllImport(nativeLib, CharSet = charSet)]
@@ -567,16 +575,49 @@ namespace Microsoft.ML.OnnxRuntime
         //[DllImport(nativeLib, CharSet = charSet)]
         //public static extern void OrtAddCustomOp(IntPtr /*(OrtSessionOptions*)*/ options, string custom_op_path);
 
-        public delegate IntPtr /*(OrtStatus*)*/DOrtAddFreeDimensionOverride(IntPtr /*(OrtSessionOptions*) */ options, string /*(const char*)*/ dimDenotation, long dimValue);
+        /// <summary>
+        /// Free Dimension override (by denotation)
+        /// </summary>
+        /// <param name="options">Native SessionOptions instance</param>
+        /// <param name="dimDenotation">Dimension denotation</param>
+        /// <param name="dimValue">Dimension value</param>
+        public delegate IntPtr /*(OrtStatus*)*/DOrtAddFreeDimensionOverride(IntPtr /*(OrtSessionOptions*)*/ options, 
+                                                                            IntPtr /*(const char*)*/ dimDenotation, 
+                                                                            long dimValue);
         public static DOrtAddFreeDimensionOverride OrtAddFreeDimensionOverride;
 
-        public delegate IntPtr /*(OrtStatus*)*/DOrtAddFreeDimensionOverrideByName(IntPtr /*(OrtSessionOptions*) */ options, string /*(const char*)*/ dimName, long dimValue);
+        /// <summary>
+        /// Free Dimension override (by name)
+        /// </summary>
+        /// <param name="options">Native SessionOptions instance</param>
+        /// <param name="dimDenotation">Dimension name</param>
+        /// <param name="dimValue">Dimension value</param>
+        public delegate IntPtr /*(OrtStatus*)*/DOrtAddFreeDimensionOverrideByName(IntPtr /*(OrtSessionOptions*)*/ options, 
+                                                                                  IntPtr /*(const char*)*/ dimName, 
+                                                                                  long dimValue);
         public static DOrtAddFreeDimensionOverrideByName OrtAddFreeDimensionOverrideByName;
 
-        public delegate IntPtr /*(OrtStatus*)*/DOrtRegisterCustomOpsLibrary(IntPtr /*(OrtSessionOptions*) */ options, string /*(const char*)*/ library_path, out IntPtr /* (void**) */ library_handle);
+
+        /// <summary>
+        /// Register custom op library
+        /// </summary>
+        /// <param name="options">Native SessionOptions instance</param>
+        /// <param name="libraryName">Library path</param>
+        /// <param name="libraryHandle">(out) Native library handle</param>
+        public delegate IntPtr /*(OrtStatus*)*/DOrtRegisterCustomOpsLibrary(IntPtr /*(OrtSessionOptions*) */ options, 
+                                                                            IntPtr /*(const char*)*/ libraryPath, 
+                                                                            out IntPtr /*(void**)*/ libraryHandle);
         public static DOrtRegisterCustomOpsLibrary OrtRegisterCustomOpsLibrary;
 
-        public delegate IntPtr /*(OrtStatus*)*/DOrtAddInitializer(IntPtr /*(OrtSessionOptions*) */ options, string /*(const char*)*/ name, IntPtr /* OrtValue* */ ortValue);
+        /// <summary>
+        /// Add initializer that is shared across Sessions using this SessionOptions (by denotation)
+        /// </summary>
+        /// <param name="options">Native SessionOptions instance</param>
+        /// <param name="name">Name of the initializer</param>
+        /// <param name="ortValue">Native OrtValue instnce</param>
+        public delegate IntPtr /*(OrtStatus*)*/DOrtAddInitializer(IntPtr /*(OrtSessionOptions*)*/ options, 
+                                                                  IntPtr /*(const char*)*/ name, 
+                                                                  IntPtr /* OrtValue* */ ortValue);
         public static DOrtAddInitializer OrtAddInitializer;
 
         #endregion

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.cs
@@ -123,7 +123,9 @@ namespace Microsoft.ML.OnnxRuntime
 
             finally
             {
-                // TODO: What if OrtReleaseAvailableProviders() throws ?
+                // Looks a bit weird that we might throw in finally(...)
+                // But the native method OrtReleaseAvailableProviders actually doesn't return a failure status
+                // If it does, it is BUG and we would like to propagate that to the user in the form of an exception
                 NativeApiStatus.VerifySuccess(NativeMethods.OrtReleaseAvailableProviders(availableProvidersHandle, numProviders));
             }
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.cs
@@ -101,6 +101,34 @@ namespace Microsoft.ML.OnnxRuntime
             NativeApiStatus.VerifySuccess(NativeMethods.OrtDisableTelemetryEvents(Handle));
         }
 
+        /// <summary>
+        /// Queries all the execution providers supported in the native onnxruntime shared library
+        /// </summary>
+        public string[] GetAvailableProviders()
+        {
+            IntPtr availableProvidersHandle = IntPtr.Zero;
+            int numProviders;
+
+            NativeApiStatus.VerifySuccess(NativeMethods.OrtGetAvailableProviders(out availableProvidersHandle, out numProviders));
+
+            var availableProviders = new string[numProviders];
+
+            try
+            {
+                for(int i=0; i<numProviders; ++i)
+                {
+                    availableProviders[i] = NativeOnnxValueHelper.StringFromNativeUtf8(Marshal.ReadIntPtr(availableProvidersHandle, IntPtr.Size * i));
+                }
+            }
+
+            finally
+            {
+                // TODO: What if OrtReleaseAvailableProviders() throws ?
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtReleaseAvailableProviders(availableProvidersHandle, numProviders));
+            }
+
+            return availableProviders;
+        }
         #endregion
 
         #region SafeHandle

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.cs
@@ -120,7 +120,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// However, it re-uses managed memory if possible.
         /// </summary>
         /// <param name="value">Tensor object</param>
-        /// <param name="memoryHandle">For all tensor types but string tensors we endevour to use managed memory
+        /// <param name="memoryHandle">For all tensor types but string tensors we endeavor to use managed memory
         ///  to avoid additional allocation and copy. This out parameter represents a chunk of pinned memory
         /// </param>
         /// <param name="elementType">discovered tensor element type</param>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.cs
@@ -194,8 +194,9 @@ namespace Microsoft.ML.OnnxRuntime
         /// OrtStatus* RegisterCustomOps(OrtSessionOptions* options, const OrtApiBase* api);
         /// It then passes in the provided session options to this function along with the api base.
         /// The handle to the loaded library is returned in 'libraryHandle'. 
-        /// It can be freed by the caller after all sessions using the passed in
+        /// It can be unloaded by the caller after all sessions using the passed in
         /// session options are destroyed, or if an error occurs and it is non null.
+        /// Hint: .NET Core 3.1 has a 'NativeLibrary' class that can be used to free the library handle
         /// </summary>
         public void RegisterCustomOpLibraryV2(string libraryPath, out IntPtr libraryHandle)
         {

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.cs
@@ -181,7 +181,11 @@ namespace Microsoft.ML.OnnxRuntime
         public void RegisterCustomOpLibrary(string libraryPath)
         {
             IntPtr libraryHandle = IntPtr.Zero;
-            NativeApiStatus.VerifySuccess(NativeMethods.OrtRegisterCustomOpsLibrary(handle, libraryPath, out libraryHandle));
+            var libraryPathPinned = GCHandle.Alloc(NativeOnnxValueHelper.StringToZeroTerminatedUtf8(libraryPath), GCHandleType.Pinned);
+            using (var pinnedlibraryPath = new PinnedGCHandle(libraryPathPinned))
+            {
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtRegisterCustomOpsLibrary(handle, pinnedlibraryPath.Pointer, out libraryHandle));
+            }
         }
 
         /// <summary>
@@ -194,7 +198,11 @@ namespace Microsoft.ML.OnnxRuntime
         /// </summary>
         public void RegisterCustomOpLibraryV2(string libraryPath, out IntPtr libraryHandle)
         {
-            NativeApiStatus.VerifySuccess(NativeMethods.OrtRegisterCustomOpsLibrary(handle, libraryPath, out libraryHandle));
+            var libraryPathPinned = GCHandle.Alloc(NativeOnnxValueHelper.StringToZeroTerminatedUtf8(libraryPath), GCHandleType.Pinned);
+            using (var pinnedlibraryPath = new PinnedGCHandle(libraryPathPinned))
+            {
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtRegisterCustomOpsLibrary(handle, pinnedlibraryPath.Pointer, out libraryHandle));
+            }
         }
 
         /// <summary>
@@ -209,16 +217,28 @@ namespace Microsoft.ML.OnnxRuntime
         /// </summary>
         public void AddInitializer(string name, OrtValue ortValue)
         {
-            NativeApiStatus.VerifySuccess(NativeMethods.OrtAddInitializer(handle, name, ortValue.Handle));
+            var utf8NamePinned = GCHandle.Alloc(NativeOnnxValueHelper.StringToZeroTerminatedUtf8(name), GCHandleType.Pinned);
+            using (var pinnedName = new PinnedGCHandle(utf8NamePinned))
+            {
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtAddInitializer(handle, pinnedName.Pointer, ortValue.Handle));
+            }
         }
 
         /// <summary>
         /// Set a single session configuration entry as a pair of strings
-        /// If a configuration with same key exists, this will overwrite the configuration with the given config_value
+        /// If a configuration with same key exists, this will overwrite the configuration with the given configValue
         /// </summary>
         public void AddSessionConfigEntry(string configKey, string configValue)
         {
-            NativeApiStatus.VerifySuccess(NativeMethods.OrtAddSessionConfigEntry(handle, configKey, configValue));
+            var utf8NameConfigKeyPinned = GCHandle.Alloc(NativeOnnxValueHelper.StringToZeroTerminatedUtf8(configKey), GCHandleType.Pinned);
+            var utf8NameConfigValuePinned = GCHandle.Alloc(NativeOnnxValueHelper.StringToZeroTerminatedUtf8(configValue), GCHandleType.Pinned);
+
+            using (var pinnedConfigKeyName = new PinnedGCHandle(utf8NameConfigKeyPinned))
+            using (var pinnedConfigValueName = new PinnedGCHandle(utf8NameConfigValuePinned))
+            {
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtAddSessionConfigEntry(handle, 
+                                              pinnedConfigKeyName.Pointer, pinnedConfigValueName.Pointer));
+            }
         }
 
         /// <summary>
@@ -227,8 +247,11 @@ namespace Microsoft.ML.OnnxRuntime
         /// </summary>
         public void AddFreeDimensionOverride(string dimDenotation, long dimValue)
         {
-            NativeApiStatus.VerifySuccess(NativeMethods.OrtAddFreeDimensionOverride(handle, dimDenotation, dimValue));
-
+            var utf8DimDenotationPinned = GCHandle.Alloc(NativeOnnxValueHelper.StringToZeroTerminatedUtf8(dimDenotation), GCHandleType.Pinned);
+            using (var pinnedDimDenotation = new PinnedGCHandle(utf8DimDenotationPinned))
+            {
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtAddFreeDimensionOverride(handle, pinnedDimDenotation.Pointer, dimValue));
+            }
         }
 
         /// <summary>
@@ -237,8 +260,11 @@ namespace Microsoft.ML.OnnxRuntime
         /// </summary>
         public void AddFreeDimensionOverrideByName(string dimName, long dimValue)
         {
-            NativeApiStatus.VerifySuccess(NativeMethods.OrtAddFreeDimensionOverrideByName(handle, dimName, dimValue));
-
+            var utf8DimNamePinned = GCHandle.Alloc(NativeOnnxValueHelper.StringToZeroTerminatedUtf8(dimName), GCHandleType.Pinned);
+            using (var pinnedDimName = new PinnedGCHandle(utf8DimNamePinned))
+            {
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtAddFreeDimensionOverrideByName(handle, pinnedDimName.Pointer, dimValue));
+            }
         }
     #endregion
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.cs
@@ -178,6 +178,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// Deprecated in favor of RegisterCustomOpLibraryV2() because it provides users with the library handle 
         /// to release when all sessions relying on it are destroyed
         /// </summary>
+        [ObsoleteAttribute("RegisterCustomOpLibrary(...) is obsolete. Use RegisterCustomOpLibraryV2(...) instead.", false)]
         public void RegisterCustomOpLibrary(string libraryPath)
         {
             IntPtr libraryHandle = IntPtr.Zero;

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -1057,10 +1057,8 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     }
                 }
 
-
                 // Safe to unload the custom op shared library now
                 UnloadLibrary(libraryHandle);
-
             }
         }
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -959,6 +959,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             }
         }
 
+        // Hint: .NET Core 3.1 has a 'NativeLibrary' class that can be used to free the library handle
         private void UnloadLibrary(IntPtr libraryHandle)
         {
             if (libraryHandle != IntPtr.Zero)

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -177,6 +177,20 @@ namespace Microsoft.ML.OnnxRuntime.Tests
         }
 
         [Fact]
+        public void GetAvailableProviders()
+        {
+            var ortEnvInstance = OrtEnv.Instance();
+            string[] providers = ortEnvInstance.GetAvailableProviders();
+
+            Assert.True(providers.Length > 0);
+            Assert.Equal("CPUExecutionProvider", providers[0]);
+
+# if USE_CUDA
+            Assert.True(Array.Exists(providers, provider => provider == "CUDAExecutionProvider"););
+#endif
+        }
+
+        [Fact]
         public void CanCreateAndDisposeSessionWithModelPath()
         {
             string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "squeezenet.onnx");
@@ -407,6 +421,48 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             Assert.True(startTime1 != 0);
             // Chronological profiling's start time
             Assert.True(startTime1 <= startTime2 && startTime2 <= startTime3);
+        }
+
+        [Fact]
+        public void SessionOptionsFreeDimensionOverrides()
+        {
+
+            string modelPath = Path.Combine(Directory.GetCurrentDirectory(), "abs_free_dimensions.onnx");
+
+            // By Name
+            using (SessionOptions options = new SessionOptions())
+            {
+                options.AddFreeDimensionOverrideByName("Dim1", 4);
+                options.AddFreeDimensionOverrideByName("Dim2", 6);
+
+                using (var session = new InferenceSession(modelPath, options))
+                {
+                    var inputMetadata = session.InputMetadata;
+                    var dims = inputMetadata["x"].Dimensions;
+                    Assert.Equal(3, dims.Length);
+                    Assert.Equal(4, dims[0]);
+                    Assert.Equal(6, dims[1]);
+                    Assert.Equal(5, dims[2]);
+                }
+            }
+
+            // By Denotation
+            using (SessionOptions options = new SessionOptions())
+            {
+                options.AddFreeDimensionOverride("DATA_BATCH", 3);
+                options.AddFreeDimensionOverride("DATA_CHANNEL", 5);
+
+                using (var session = new InferenceSession(modelPath, options))
+                {
+                    var inputMetadata = session.InputMetadata;
+                    var dims = inputMetadata["x"].Dimensions;
+                    Assert.Equal(3, dims.Length);
+                    Assert.Equal(3, dims[0]);
+                    Assert.Equal(5, dims[1]);
+                    Assert.Equal(5, dims[2]);
+                }
+            }
+
         }
 
         private void validateRunResults(IReadOnlyCollection<NamedOnnxValue> results)
@@ -903,6 +959,25 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             }
         }
 
+        private void UnloadLibrary(IntPtr libraryHandle)
+        {
+            if (libraryHandle != IntPtr.Zero)
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    if(!FreeLibrary(libraryHandle))
+                    {
+                        throw new Exception("Could not unload the provided shared library using its handle");
+                    }
+                }
+
+                else
+                {
+                    // TODO: Deal with non-Windows platforms for the .NET Core use-case
+                }
+            }
+        }
+
         [SkipNonPackageTests]
         private void TestRegisterCustomOpLibrary()
         {
@@ -926,9 +1001,11 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 string libFullPath = Path.Combine(Directory.GetCurrentDirectory(), libName);
                 Assert.True(File.Exists(libFullPath), $"Expected lib {libFullPath} does not exist.");
 
+                IntPtr libraryHandle = IntPtr.Zero;
                 try
                 {
-                    option.RegisterCustomOpLibrary(libFullPath);
+
+                    option.RegisterCustomOpLibraryV2(libFullPath, out libraryHandle);
                 }
                 catch (Exception ex)
                 {
@@ -979,6 +1056,11 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                         Assert.True(tensorOut.SequenceEqual(expectedOut));
                     }
                 }
+
+
+                // Safe to unload the custom op shared library now
+                UnloadLibrary(libraryHandle);
+
             }
         }
 
@@ -1962,6 +2044,9 @@ namespace Microsoft.ML.OnnxRuntime.Tests
         [DllImport("kernel32", CharSet = CharSet.Ansi)]
         static extern UIntPtr GetProcAddress(IntPtr hModule, string procName);
 
+        [DllImport("kernel32.dll", CharSet = CharSet.Ansi)]
+        private static extern bool FreeLibrary(IntPtr hModule);
+
         [Fact]
         private void VerifyNativeMethodsExist()
         {
@@ -1996,12 +2081,20 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             ,"OrtSessionOptionsAppendExecutionProvider_Nnapi"
 #endif
     };
-
-            var hModule = LoadLibrary(module);
-            foreach (var ep in entryPointNames)
+            IntPtr libraryHandle = IntPtr.Zero;
+            try
             {
-                var x = GetProcAddress(hModule, ep);
-                Assert.False(x == UIntPtr.Zero, $"Entrypoint {ep} not found in module {module}");
+                libraryHandle = LoadLibrary(module);
+                foreach (var ep in entryPointNames)
+                {
+                    var x = GetProcAddress(libraryHandle, ep);
+                    Assert.False(x == UIntPtr.Zero, $"Entrypoint {ep} not found in module {module}");
+                }
+            }
+
+            finally
+            {
+                UnloadLibrary(libraryHandle);
             }
         }
 

--- a/csharp/testdata/abs_free_dimensions.onnx
+++ b/csharp/testdata/abs_free_dimensions.onnx
@@ -1,0 +1,14 @@
+backend-test:s
+
+xy"Abstest_absZ9
+x4
+2.
+Dim1
+DATA_BATCH
+Dim2DATA_CHANNEL
+b
+y
+
+Dim1
+Dim2
+B	

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <atomic>
 #include <mutex>
+#include <algorithm>
 #include <gtest/gtest.h>
 #include "test_allocator.h"
 #include "test_fixture.h"
@@ -1008,6 +1009,11 @@ TEST(CApiTest, get_available_providers_cpp) {
   std::vector<std::string> providers = Ort::GetAvailableProviders();
   ASSERT_TRUE(providers.size() > 0);
   ASSERT_TRUE(providers[0] == std::string("CPUExecutionProvider"));
+
+#ifdef USE_CUDA
+  // CUDA EP will exist in the list but its position may vary based on other EPs included in the build
+  ASSERT_TRUE(std::find(providers.begin(), providers.end(), std::string("CUDAExecutionProvider")) != providers.end());
+#endif
 }
 
 // This test uses the CreateAndRegisterAllocator API to register an allocator with the env,


### PR DESCRIPTION
**Description**:

Adding:
1) SessionOptions: AddFreeDimension
2) SessionOptions: AddFreeDimensionByName
3) SessionOptions: RegisterCustomOpLibraryV2 (V1 doesn't return the library handle back to the user - essentially leaking it)
4) OrtEnv: GetAvailableProviders

**Motivation and Context**
C# <-> C/C++ <-> Python API parity
