### PR TITLE
Fixing data loading in MNIST

### DIFF
--- a/orttraining/orttraining/models/mnist/main.cc
+++ b/orttraining/orttraining/models/mnist/main.cc
@@ -191,12 +191,11 @@ int main(int argc, char* args[]) {
   setup_training_params(params);
 
   // setup data
-  auto device_count = MPIContext::GetInstance().GetWorldSize();
   std::vector<string> feeds{"X", "labels"};
   auto trainingData = std::make_shared<DataSet>(feeds);
   auto testData = std::make_shared<DataSet>(feeds);
   std::string mnist_data_path = ToMBString(params.train_data_dir);
-  PrepareMNISTData(mnist_data_path, IMAGE_DIMS, LABEL_DIMS, *trainingData, *testData, MPIContext::GetInstance().GetWorldRank() /* shard_to_load */, device_count /* total_shards */);
+  PrepareMNISTData(mnist_data_path, IMAGE_DIMS, LABEL_DIMS, *trainingData, *testData);
 
   if (testData->NumSamples() == 0) {
     printf("Warning: No data loaded - run cancelled.\n");


### PR DESCRIPTION
If we parallelize MNIST with pipeline parallelism (e.g., PP=2), as in the PR https://github.com/microsoft/onnxruntime/pull/5315, it will not converge. 

When we pass device id and number of devices to PrepareMNISTData, it will load only part of the data in each rank.
https://github.com/microsoft/onnxruntime/blob/master/orttraining/orttraining/models/mnist/mnist_data_provider.cc#L46