### PR TITLE
[Java] Fixes an error allocating large direct byte buffers during OnnxTensor creation

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OnnxTensor.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxTensor.java
@@ -705,11 +705,10 @@ public class OnnxTensor implements OnnxValue {
       OnnxJavaType type, OrtAllocator allocator, Buffer data, long[] shape) throws OrtException {
     int bufferPos;
     long bufferSizeLong = data.remaining() * (long) type.size;
-    if ((bufferSizeLong < 0) || (bufferSizeLong > (Integer.MAX_VALUE - (8 * type.size)))) {
-      // Negative value implies we overflowed and we can't allocate something that big (though overflowing
-      // a long at this point should be tricky),
-      // and the maximum direct byte buffer size is a little below Integer.MAX_VALUE depending
-      // on the JVM, so we check for something 8 elements below the maximum size.
+    if (bufferSizeLong > (Integer.MAX_VALUE - (8 * type.size))) {
+      // The maximum direct byte buffer size is a little below Integer.MAX_VALUE depending
+      // on the JVM, so we check for something 8 elements below the maximum size which
+      // should be allocatable (assuming there is enough memory) on all 64-bit JVMs.
       throw new IllegalStateException(
           "Cannot allocate a direct buffer of the requested size and type, size "
               + data.remaining()

--- a/java/src/main/java/ai/onnxruntime/OnnxTensor.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxTensor.java
@@ -704,15 +704,20 @@ public class OnnxTensor implements OnnxValue {
   private static OnnxTensor createTensor(
       OnnxJavaType type, OrtAllocator allocator, Buffer data, long[] shape) throws OrtException {
     int bufferPos;
-    int bufferSize = data.remaining() * type.size;
-    if ((bufferSize < 0) || (bufferSize > ((Integer.MAX_VALUE / type.size) - 10))) {
-      // overflowed as we can't make a direct byte buffer of that size
+    long bufferSizeLong = data.remaining() * (long) type.size;
+    if ((bufferSizeLong < 0) || (bufferSizeLong > (Integer.MAX_VALUE - (8 * type.size)))) {
+      // Negative value implies we overflowed and we can't allocate something that big (though overflowing
+      // a long at this point should be tricky),
+      // and the maximum direct byte buffer size is a little below Integer.MAX_VALUE depending
+      // on the JVM, so we check for something 8 elements below the maximum size.
       throw new IllegalStateException(
           "Cannot allocate a direct buffer of the requested size and type, size "
               + data.remaining()
               + ", type = "
               + type);
     }
+    // Now we know we're in range
+    int bufferSize = data.remaining() * type.size;
     Buffer tmp;
     if (data.isDirect()) {
       tmp = data;


### PR DESCRIPTION
**Description**: 
The out of bounds logic was incorrect, it took into account the type size twice rather than once, and so artificially limited the tensor size.

**Motivation and Context**
- Why is this change required? What problem does it solve? Fixes #5618.
