### PR TITLE
Bugfix for Name of Gradient Constant

### DIFF
--- a/orttraining/orttraining/core/graph/gradient_builder_base.h
+++ b/orttraining/orttraining/core/graph/gradient_builder_base.h
@@ -221,15 +221,15 @@ class GradientBuilderBase {
   }
 
   static NodeDef ZeroConstantNode(int elem_type) {
-    return ConstantScalarNode(0.0f, "ZeroConstant", elem_type);
+    return ConstantScalarNode(0.0f, "ZeroConstant_Type" + std::to_string(elem_type), elem_type);
   }
 
   static NodeDef HalfConstantNode(int elem_type) {
-    return ConstantScalarNode(0.5f, "HalfConstant", elem_type);
+    return ConstantScalarNode(0.5f, "HalfConstant_Type" + std::to_string(elem_type), elem_type);
   }
 
   static NodeDef OneConstantNode(int elem_type) {
-    return ConstantScalarNode(1.0f, "OneConstant", elem_type);
+    return ConstantScalarNode(1.0f, "OneConstant_Type" + std::to_string(elem_type), elem_type);
   }
 
   void HandleBroadcasting(const ArgDef& input_grad,


### PR DESCRIPTION
It's possible that multiple nodes' gradient builders are using same constant (e.g., OneConstant) with different element type. Currently the name of the constant node is same for all element types, which will causes graph resolving issue. Need to distinguish the constant name by element type. 