### PR TITLE
Test content is actually under testData directory in WINML_TEST_DATA_PATH environment variable

### DIFF
--- a/winml/test/model/model_tests.cpp
+++ b/winml/test/model/model_tests.cpp
@@ -128,7 +128,7 @@ std::string GetTestDataPath() {
       return hardcodedModelPath;
     }
   }
-  return testDataPath;
+  return testDataPath + "\\testData\\";
 }
 
 // This function returns the list of all test cases inside model test collateral


### PR DESCRIPTION
CopyWinMLTestContent.ps1 puts the model test collateral under WINML_TEST_DATA_PATH but under testData folder. This is shown here : 

https://microsoft.visualstudio.com/windowsai/_git/WindowsAI?path=%2Ftools%2FCopyWinMLTestContent.ps1&version=GBmaster&line=30&lineEnd=30&lineStartColumn=45&lineEndColumn=53&lineStyle=plain