### PR TITLE
Turn off peak memory logging and fix memory pattern generation bug.

### DIFF
--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -787,7 +787,7 @@ class PlannerImpl {
         for (size_t index = 0; index < current_plan.program_counter_start.size(); index += 1) {
           ORT_ENFORCE((current_plan.program_counter_start[index] > start) || (start == 0));
           ORT_ENFORCE(current_plan.program_counter_start[index] <= current_plan.program_counter_end[index]);
-          ORT_ENFORCE((current_plan.program_counter_start[index] < SIZE_MAX) || (index == 0));
+          ORT_ENFORCE(current_plan.program_counter_start[index] < SIZE_MAX);
           ORT_ENFORCE((current_plan.program_counter_end[index] > 0) || (index == 0));
 
           start = current_plan.program_counter_start[index];

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -292,7 +292,7 @@ ExecutionFrame::ExecutionFrame(const std::vector<int>& feed_mlvalue_idxs, const 
             }
 
             // log size of activation. Keep it commented out for now to avoid log flooding.
-            VLOGS(session_state_.Logger(), 1) << "**** Allocated memory for activations, size: " <<mem_patterns_->patterns[i].PeakSize();
+            // VLOGS(session_state_.Logger(), 1) << "**** Allocated memory for activations, size: " <<mem_patterns_->patterns[i].PeakSize();
           }
         }
       }

--- a/onnxruntime/core/framework/mem_pattern_planner.h
+++ b/onnxruntime/core/framework/mem_pattern_planner.h
@@ -59,34 +59,6 @@ class MemPatternPlanner {
     return false;
   }
 
-  // Returns true if there is an intersection between two time schedules.
-  // ASSUMES EACH TIME SCHEDULE IS SORTED. THIS IS VALIDATED AT THE END OF MEMORY PLANNING.
-  bool OverlappingTimeSchedules2(const std::vector<size_t>& program_counter_start_1, const std::vector<size_t>& program_counter_end_1,
-                                 const std::vector<size_t>& program_counter_start_2, const std::vector<size_t>& program_counter_end_2) {
-    ORT_ENFORCE(program_counter_start_1.size() > 0);
-    ORT_ENFORCE(program_counter_start_2.size() > 0);
-    ORT_ENFORCE(program_counter_start_1.size() == program_counter_end_1.size());
-    ORT_ENFORCE(program_counter_start_2.size() == program_counter_end_2.size());
-
-    size_t index_1 = 0;
-    size_t index_2 = 0;
-    while ((index_1 < program_counter_start_1.size()) && (index_2 < program_counter_start_2.size())) {
-      if (program_counter_start_1[index_1] <= program_counter_start_2[index_2]) {
-        if (program_counter_end_1[index_1] >= program_counter_start_2[index_2]) {
-          return true;
-        }
-        index_1 += 1;
-      } else {
-        if (program_counter_end_2[index_2] >= program_counter_start_1[index_1]) {
-          return true;
-        }
-        index_2 += 1;
-      }
-    }
-
-    return false;
-  }
-
   void TraceAllocation(int ml_value_idx, const std::vector<size_t>& program_counter_start, const std::vector<size_t>& program_counter_end, size_t size) {
     std::lock_guard<OrtMutex> lock(lock_);
 
@@ -128,7 +100,7 @@ class MemPatternPlanner {
       }
     }
 
-    if(!best_offset_found) {
+    if (!best_offset_found) {
       best_offset = current;
     }
 
@@ -185,7 +157,7 @@ class MemPatternPlanner {
       }
     }
 
-    if(!best_offset_found) {
+    if (!best_offset_found) {
       best_offset = current;
     }
 
@@ -242,8 +214,8 @@ class MemPatternPlanner {
 
         if (((alloc_1_start >= alloc_2_start) && (alloc_1_start <= alloc_2_end)) ||
             ((alloc_2_start >= alloc_1_start) && (alloc_2_start <= alloc_1_end))) {
-          ORT_ENFORCE(!OverlappingTimeSchedules2(allocs_[index_1].program_counter_start_, allocs_[index_1].program_counter_end_,
-                                                 allocs_[index_2].program_counter_start_, allocs_[index_2].program_counter_end_));
+          ORT_ENFORCE(!OverlappingTimeSchedules(allocs_[index_1].program_counter_start_, allocs_[index_1].program_counter_end_,
+                                                allocs_[index_2].program_counter_start_, allocs_[index_2].program_counter_end_));
         }
       }
     }


### PR DESCRIPTION
[Fixes](https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=136977&view=logs&j=d4eb0f0c-ce69-5b22-6bda-59ebb65bd573&t=e258b615-ecbc-5091-444a-3753c64d3019) nightly e2e batch_size test and stops interfering with internal perf test tool.