### PR TITLE
Update python packaging pipeline's docker image

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -181,7 +181,7 @@ stages:
               --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
-              onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecpubuild:ch9j \
+              onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecpubuild:chan \
                 $(python.manylinux.dir)/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
                   --build_dir /build --cmake_generator Ninja \
                   --config Release \


### PR DESCRIPTION
**Description**: 

Update python packaging pipeline's docker image


**Motivation and Context**
- Why is this change required? What problem does it solve?

Currently Openmp build and no-openmp build use different docker images. They should be the same.

- If it fixes an open issue, please link to the issue here.
