### PR TITLE
NNAPI add opset version check

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
@@ -58,8 +58,9 @@ std::vector<std::vector<int>> ModelBuilder::GetSupportedNodes() {
   int32_t android_sdk_ver = GetAndroidSdkVer();
 #ifdef __ANDROID__
   if (android_sdk_ver < ORT_NNAPI_MIN_API_LEVEL) {
-    LOGS_DEFAULT(VERBOSE) << "Android API level " << android_sdk_ver
-                          << " is lower than " << ORT_NNAPI_MIN_API_LEVEL;
+    LOGS_DEFAULT(WARNING) << "All ops will fallback to CPU EP, because Android API level [" << android_sdk_ver
+                          << "] is lower than minimal supported API level [" << ORT_NNAPI_MIN_API_LEVEL
+                          << "] of this build for NNAPI";
     return supported_node_vecs;
   }
 #endif

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
@@ -57,10 +57,9 @@ std::vector<std::vector<int>> ModelBuilder::GetSupportedNodes() {
   std::vector<std::vector<int>> supported_node_vecs;
   int32_t android_sdk_ver = GetAndroidSdkVer();
 #ifdef __ANDROID__
-  if (android_sdk_ver < 27) {
-    LOGS_DEFAULT(VERBOSE) << "Android API level "
-                          << android_sdk_ver
-                          << " is lower than 27";
+  if (android_sdk_ver < ORT_NNAPI_MIN_API_LEVEL) {
+    LOGS_DEFAULT(VERBOSE) << "Android API level " << android_sdk_ver
+                          << " is lower than " << ORT_NNAPI_MIN_API_LEVEL;
     return supported_node_vecs;
   }
 #endif

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.h
@@ -10,6 +10,11 @@
 #include "core/providers/nnapi/nnapi_builtin/nnapi_lib/NeuralNetworksWrapper.h"
 #include "shaper.h"
 
+// This is the minimal Android API Level required by ORT NNAPI EP to run
+#ifndef ORT_NNAPI_MIN_API_LEVEL
+#define ORT_NNAPI_MIN_API_LEVEL 27
+#endif
+
 namespace onnxruntime {
 namespace nnapi {
 


### PR DESCRIPTION
**Description**: NNAPI add opset version check

**Motivation and Context**
- Before NNAPI does not have Opset version check, this may cause problem if an onnx file is too old or too new which may contains unspoorted attributes or inputs, such as some op (e.g. squeeze opset 13)  may change spec in new opset to use input instead of attributes,
- Also move hardcoded android_api_level requirement to compile definition
