### PR TITLE
Revert saving optimized model as external data

### DIFF
--- a/onnxruntime/python/tools/transformers/huggingface_models.py
+++ b/onnxruntime/python/tools/transformers/huggingface_models.py
@@ -6,10 +6,17 @@
 
 # Maps model class name to a tuple of model class
 MODEL_CLASSES = [
-    'AutoModel',
-    'AutoModelWithLMHead',
-    'AutoModelForSequenceClassification',
-    'AutoModelForQuestionAnswering'
+    'AutoModel', 'AutoModelWithLMHead', 'AutoModelForSequenceClassification', 'AutoModelForQuestionAnswering'
+]
+
+# List of models that require external data saving for onnx export but do not require it when saving optimized onnx model
+# Very few models in the huggingface list require it for both: albert-xxlarge-v1, albert-xxlarge-v2
+# TODO: most of the models in the below exempt list having runtime issues when saving these optimized onnx models
+# using external data format. Need to address the issue in the future
+EXEMPT_MODELS = [
+    "gpt2-large", "gpt2-xl", "xlm-mlm-en-2048", "xlm-mlm-17-1280", "xlm-mlm-100-1280", "ctrl", "albert-xlarge-v1",
+    "albert-xlarge-v2", "t5-large", "t5-3b", "t5-11b", "xlm-roberta-large", "microsoft/DialoGPT-large",
+    "facebook/mbart-large-en-ro"
 ]
 
 # List of pretrained models: https://huggingface.co/transformers/pretrained_models.html
@@ -83,11 +90,11 @@ MODELS = {
     "albert-base-v1": (["input_ids"], 12, False, "bert"),
     "albert-large-v1": (["input_ids"], 12, False, "bert"),
     "albert-xlarge-v1": (["input_ids"], 12, True, "bert"),
-    "albert-xxlarge-v1": (["input_ids"], 12, True, "bert"),
+    #"albert-xxlarge-v1": (["input_ids"], 12, True, "bert"),
     "albert-base-v2": (["input_ids"], 12, False, "bert"),
     "albert-large-v2": (["input_ids"], 12, False, "bert"),
     "albert-xlarge-v2": (["input_ids"], 12, True, "bert"),
-    "albert-xxlarge-v2": (["input_ids"], 12, True, "bert"),
+    #"albert-xxlarge-v2": (["input_ids"], 12, True, "bert"),
     # T5
     "t5-small": (["input_ids"], 12, False, "bert"),
     "t5-base": (["input_ids"], 12, False, "bert"),

--- a/onnxruntime/python/tools/transformers/onnx_exporter.py
+++ b/onnxruntime/python/tools/transformers/onnx_exporter.py
@@ -13,7 +13,7 @@ from transformers import AutoConfig, AutoTokenizer, AutoModel
 from benchmark_helper import create_onnxruntime_session, Precision
 from gpt2_helper import GPT2ModelNoPastState, PRETRAINED_GPT2_MODELS
 from quantize_helper import QuantizeHelper
-from huggingface_models import MODEL_CLASSES
+from huggingface_models import MODEL_CLASSES, EXEMPT_MODELS
 
 logger = logging.getLogger(__name__)
 
@@ -169,8 +169,8 @@ def optimize_onnx_model_by_ort(onnx_model_path, ort_model_path, use_gpu, overwri
         logger.info(f"Skip optimization since model existed: {ort_model_path}")
 
 
-def optimize_onnx_model(onnx_model_path, optimized_model_path, model_type, num_attention_heads, hidden_size, use_gpu,
-                        precision, use_raw_attention_mask, overwrite, model_fusion_statistics,
+def optimize_onnx_model(model_name, onnx_model_path, optimized_model_path, model_type, num_attention_heads, hidden_size,
+                        use_gpu, precision, use_raw_attention_mask, overwrite, model_fusion_statistics,
                         use_external_data_format):
     if overwrite or not os.path.exists(optimized_model_path):
         Path(optimized_model_path).parent.mkdir(parents=True, exist_ok=True)
@@ -202,7 +202,11 @@ def optimize_onnx_model(onnx_model_path, optimized_model_path, model_type, num_a
 
         if Precision.FLOAT16 == precision:
             opt_model.convert_model_float32_to_float16()
-        opt_model.save_model_to_file(optimized_model_path)
+
+        if model_name in EXEMPT_MODELS:
+            use_external_data_format = False
+
+        opt_model.save_model_to_file(optimized_model_path, use_external_data_format)
     else:
         logger.info(f"Skip optimization since model existed: {optimized_model_path}")
 
@@ -291,7 +295,7 @@ def validate_and_optimize_onnx(model_name, use_external_data_format, model_type,
     if optimize_onnx or precision == Precision.FLOAT16 or precision == Precision.INT8:  # Use script (optimizer.py) to optimize
         optimized_model_path = get_onnx_file_path(onnx_dir, model_name, len(input_names), True, use_gpu, precision,
                                                   False, use_external_data_format)
-        optimize_onnx_model(onnx_model_path, optimized_model_path, model_type, config.num_attention_heads,
+        optimize_onnx_model(model_name, onnx_model_path, optimized_model_path, model_type, config.num_attention_heads,
                             config.hidden_size, use_gpu, precision, use_raw_attention_mask, overwrite,
                             model_fusion_statistics, use_external_data_format)
 
@@ -419,4 +423,3 @@ def export_onnx_model_from_tf(model_name, opset_version, use_external_data_forma
         example_inputs, example_outputs_flatten)
 
     return onnx_model_file, is_valid_onnx_model, vocab_size, max_input_size
-

--- a/onnxruntime/python/tools/transformers/onnx_exporter.py
+++ b/onnxruntime/python/tools/transformers/onnx_exporter.py
@@ -202,7 +202,7 @@ def optimize_onnx_model(onnx_model_path, optimized_model_path, model_type, num_a
 
         if Precision.FLOAT16 == precision:
             opt_model.convert_model_float32_to_float16()
-        opt_model.save_model_to_file(optimized_model_path, use_external_data_format)
+        opt_model.save_model_to_file(optimized_model_path)
     else:
         logger.info(f"Skip optimization since model existed: {optimized_model_path}")
 

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -368,11 +368,6 @@ class OnnxModel:
                 shape_list.append("?")  # shall not happen
         return shape_list
 
-    def convert_list_to_tensor(self, name, type, shape, value):
-        """ Convert list to tensor
-        """
-        return helper.make_tensor(name, type, shape, value)
-
     def change_input_output_float32_to_float16(self):
         """ Change graph input and output data type from FLOAT to FLOAT16
         """


### PR DESCRIPTION
**Description**: Describe your changes.
-keep saving optimized model without using external data for now, as this will cause issues for some models that do not actually need it, and block benchmark script working on a couple of models
-store generated tensor in raw format for potential saving as external data
-need further investigation on why this behaves unexpectedly

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
