### PR TITLE
Fix ORT microbenchmark build

### DIFF
--- a/onnxruntime/test/onnx/microbenchmark/activation.cc
+++ b/onnxruntime/test/onnx/microbenchmark/activation.cc
@@ -1,5 +1,6 @@
 #include "common.h"
 
+#include "core/common/status.h"
 #include "core/session/ort_env.h"
 #include "core/graph/model.h"
 #include "core/graph/graph.h"
@@ -15,6 +16,7 @@
 #include <benchmark/benchmark.h>
 #include <random>
 
+using namespace onnxruntime::common;
 using namespace onnxruntime;
 using namespace onnx;
 extern OrtEnv* env;
@@ -380,7 +382,7 @@ static void BM_Powx(benchmark::State& state) {
   f.input2 = input2;
   f.output = output;
   for (auto _ : state) {
-    tp->ParallelFor(batch_size, TensorOpCost{2, 1, static_cast<double>(cost)}, f);
+    concurrency::ThreadPool::TryParallelFor(tp.get(), batch_size, TensorOpCost{2, 1, static_cast<double>(cost)}, f);
   }
   aligned_free(input1);
   aligned_free(input2);

--- a/onnxruntime/test/onnx/microbenchmark/batchnorm.cc
+++ b/onnxruntime/test/onnx/microbenchmark/batchnorm.cc
@@ -1,7 +1,17 @@
 #include "core/platform/threadpool.h"
-#include "core/common/eigen_common_wrapper.h"
 #include "core/util/thread_utils.h"
 #include <benchmark/benchmark.h>
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
+#include "core/common/eigen_common_wrapper.h"
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 using namespace onnxruntime;
 #if 0

--- a/onnxruntime/test/onnx/microbenchmark/eigen.cc
+++ b/onnxruntime/test/onnx/microbenchmark/eigen.cc
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic ignored "-Wignored-attributes"
 #endif
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #elif defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4267)

--- a/onnxruntime/test/onnx/microbenchmark/main.cc
+++ b/onnxruntime/test/onnx/microbenchmark/main.cc
@@ -18,6 +18,7 @@
 #include <core/session/ort_env.h>
 #include <core/util/thread_utils.h>
 
+#include <iostream>
 #include <unordered_map>
 
 const OrtApi* g_ort = OrtGetApiBase()->GetApi(ORT_API_VERSION);
@@ -43,7 +44,7 @@ static void BM_ResolveGraph(benchmark::State& state) {
   auto st =
       onnxruntime::Model::Load(ORT_TSTR("../models/opset8/test_tiny_yolov2/model.onnx"), model_copy, nullptr, *logger);
   if (!st.IsOK()) {
-    printf("Parse model failed: %s", st.ErrorMessage().c_str());
+    ::std::cerr << "Parse model failed: " << st.ErrorMessage().c_str() << ::std::endl;
     abort();
   }
   auto proto = model_copy->ToProto();
@@ -55,7 +56,7 @@ static void BM_ResolveGraph(benchmark::State& state) {
     state.ResumeTiming();
     st = graph.Resolve();
     if (!st.IsOK()) {
-      printf("Resolve graph failed: %s", st.ErrorMessage().c_str());
+      ::std::cerr << "Resolve graph failed: " << st.ErrorMessage().c_str() << ::std::endl;
       abort();
     }
   }
@@ -67,7 +68,7 @@ BENCHMARK(BM_ResolveGraph);
     OrtStatus* onnx_status = (expr);                         \
     if (onnx_status != NULL) {                               \
       const char* msg = g_ort->GetErrorMessage(onnx_status); \
-      fprintf(stderr, "%s\n", msg);                          \
+      ::std::cerr << msg << ::std::endl;                     \
       g_ort->ReleaseStatus(onnx_status);                     \
       abort();                                               \
     }                                                        \


### PR DESCRIPTION
**Description**: Minor updates to the microbenchmarks built optionally with "--build_micro_benchmarks".  These are not built as part of CI, and builds started to fail.  There are three changes:

- I updated the threading-related benchmarks to use the static-method ThreadPool API, and to expose control over the thread pool configuration via constexpr int variables.

- Disable GCC warnings seen with recent compiler versions when including parts of the Eigen headers in batchnorm.cc and eigen.cc files.

- Flush std::cerr on error conditions to avoid buffered messages being lost.

I tested manual builds with Linux (GCC) and Windows (MSVC).