### PR TITLE
Move GetUseDeterministicCompute() to OpKernelContext to avoid need to downcast to OpKernelContextInternal.

### DIFF
--- a/include/onnxruntime/core/framework/op_kernel.h
+++ b/include/onnxruntime/core/framework/op_kernel.h
@@ -226,6 +226,13 @@ class OpKernelContext {
   */
   _Ret_maybenull_ onnxruntime::concurrency::ThreadPool* GetOperatorThreadPool() const { return threadpool_; }
 
+  /**
+  Returns whether deterministic computation is preferred.
+  */
+  virtual bool GetUseDeterministicCompute() const {
+    return true;
+  }
+
  protected:
   onnxruntime::NodeIndex GetNodeIndex() const;
 
@@ -442,18 +449,18 @@ using BuildKernelCreateInfoFn = KernelCreateInfo (*)();
 #define ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(provider, domain, startver, endver, type1, type2, name) \
   provider##_##name##_##domain##_ver##startver##_##endver##_##type1##_##type2
 
-#define ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_EX(name, domain, startver, endver, type1, type2, provider, builder, ...)                   \
-  class ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(provider, domain, startver, endver, type1, type2, name);                        \
-  template <>                                                                                                                               \
-  KernelCreateInfo                                                                                                                          \
-  BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(provider, domain, startver, endver, type1, type2, name)>() {    \
-    return KernelCreateInfo(                                                                                                                \
-        builder.SetName(#name)                                                                                                              \
-            .SetDomain(domain)                                                                                                              \
-            .SinceVersion(startver, endver)                                                                                                 \
-            .Provider(provider)                                                                                                             \
-            .Build(),                                                                                                                       \
-        static_cast<KernelCreatePtrFn>([](const OpKernelInfo& info) -> OpKernel* { return new __VA_ARGS__(info); }));                       \
+#define ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_EX(name, domain, startver, endver, type1, type2, provider, builder, ...)                \
+  class ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(provider, domain, startver, endver, type1, type2, name);                     \
+  template <>                                                                                                                            \
+  KernelCreateInfo                                                                                                                       \
+  BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(provider, domain, startver, endver, type1, type2, name)>() { \
+    return KernelCreateInfo(                                                                                                             \
+        builder.SetName(#name)                                                                                                           \
+            .SetDomain(domain)                                                                                                           \
+            .SinceVersion(startver, endver)                                                                                              \
+            .Provider(provider)                                                                                                          \
+            .Build(),                                                                                                                    \
+        static_cast<KernelCreatePtrFn>([](const OpKernelInfo& info) -> OpKernel* { return new __VA_ARGS__(info); }));                    \
   }
 
 // Use within macro definitions to create a custom vector of constraints.

--- a/onnxruntime/core/framework/op_kernel_context_internal.h
+++ b/onnxruntime/core/framework/op_kernel_context_internal.h
@@ -37,10 +37,10 @@ class OpKernelContextInternal : public OpKernelContext {
     }
   }
 
-  bool GetUseDeterministicCompute() const {
+  bool GetUseDeterministicCompute() const override {
     return session_state_.GetUseDeterministicCompute();
   }
-  
+
   const SessionState* SubgraphSessionState(const std::string& attribute_name) {
     return session_state_.GetSubgraphSessionState(GetNodeIndex(), attribute_name);
   }

--- a/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
@@ -661,12 +661,7 @@ Status ReduceKernel<allow_multi_axes>::ComputeImpl(OpKernelContext* ctx, cudnnRe
                                        axes,
                                        prepare_reduce_metadata));
   Tensor* Y = ctx->Output(0, prepare_reduce_metadata.squeezed_output_dims);
-  bool fast_reduction = fast_reduction_;
-  if (fast_reduction) {
-    auto ctx_internal = dynamic_cast<OpKernelContextInternal*>(ctx);
-    if (ctx_internal && ctx_internal->GetUseDeterministicCompute())
-      fast_reduction = false;
-  }
+  const bool fast_reduction = fast_reduction_ && !ctx->GetUseDeterministicCompute();
 
   return ReduceComputeCore<T, ReduceTensorIndices>(*cuda_ep_, *X, prepare_reduce_metadata, *Y, cudnn_reduce_op, axes_,
                                                    calculate_log_, calculate_sqt_, log_sum_exp_, fast_reduction);

--- a/orttraining/orttraining/training_ops/cuda/reduction/reduction_all.cc
+++ b/orttraining/orttraining/training_ops/cuda/reduction/reduction_all.cc
@@ -46,8 +46,7 @@ Status ReduceAllL2<TIn, TOut>::ComputeInternal(OpKernelContext* ctx) const {
   CudaTOut* p_output = reinterpret_cast<CudaTOut*>(output->template MutableData<TOut>());
   CUDA_RETURN_IF_ERROR(cudaMemsetAsync(p_output, 0, sizeof(CudaTOut)));
 
-  auto ctx_internal = dynamic_cast<OpKernelContextInternal*>(ctx);
-  bool deterministic = ctx_internal && ctx_internal->GetUseDeterministicCompute();
+  const bool deterministic = ctx->GetUseDeterministicCompute();
 
   if (!deterministic) {
     typedef MultiTensorReduceL2<CudaTIn, CudaTOut> TFunctor;

--- a/orttraining/orttraining/training_ops/cuda/reduction/reduction_ops.cc
+++ b/orttraining/orttraining/training_ops/cuda/reduction/reduction_ops.cc
@@ -57,12 +57,7 @@ Status ReduceKernel<allow_multi_axes>::ComputeImplEx(OpKernelContext* ctx, cudnn
                                        axes,
                                        prepare_reduce_metadata));
   Tensor* Y = ctx->Output(0, prepare_reduce_metadata.squeezed_output_dims);
-  bool fast_reduction = fast_reduction_;
-  if (fast_reduction) {
-    auto ctx_internal = dynamic_cast<OpKernelContextInternal*>(ctx);
-    if (ctx_internal && ctx_internal->GetUseDeterministicCompute())
-      fast_reduction = false;
-  }
+  const bool fast_reduction = fast_reduction_ && !ctx->GetUseDeterministicCompute();
 
   return ReduceComputeCore<T, ReduceTensorIndices>(*cuda_ep_, *X, prepare_reduce_metadata, *Y, cudnn_reduce_op, axes,
                                                    calculate_log_, calculate_sqt_, log_sum_exp_, fast_reduction);

--- a/orttraining/orttraining/training_ops/rocm/reduction/reduction_all.cc
+++ b/orttraining/orttraining/training_ops/rocm/reduction/reduction_all.cc
@@ -55,8 +55,7 @@ Status ReduceAllL2<TIn, TOut>::ComputeInternal(OpKernelContext* ctx) const {
   HipTOut* p_output = reinterpret_cast<HipTOut*>(output->template MutableData<TOut>());
   HIP_RETURN_IF_ERROR(hipMemsetAsync(p_output, 0, sizeof(HipTOut)));
 
-  // auto ctx_internal = static_cast<OpKernelContextInternal*>(ctx);
-  // bool deterministic = ctx_internal && ctx_internal->GetUseDeterministicCompute();
+  // bool deterministic = ctx->GetUseDeterministicCompute();
   bool deterministic = true;
   if (!deterministic) {
 

--- a/orttraining/orttraining/training_ops/rocm/reduction/reduction_ops.cc
+++ b/orttraining/orttraining/training_ops/rocm/reduction/reduction_ops.cc
@@ -57,12 +57,7 @@ Status ReduceKernel<allow_multi_axes>::ComputeImplEx(OpKernelContext* ctx, miope
                                        axes,
                                        prepare_reduce_metadata));
   Tensor* Y = ctx->Output(0, prepare_reduce_metadata.squeezed_output_dims);
-  bool fast_reduction = fast_reduction_;
-  if (fast_reduction) {
-    auto ctx_internal = static_cast<OpKernelContextInternal*>(ctx);
-    if (ctx_internal && ctx_internal->GetUseDeterministicCompute())
-      fast_reduction = false;
-  }
+  const bool fast_reduction = fast_reduction_ && !ctx->GetUseDeterministicCompute();
 
   return ReduceComputeCore<T>(*X, prepare_reduce_metadata, *Y, miopen_reduce_op, axes,
                               calculate_log_, calculate_sqt_, log_sum_exp_, fast_reduction);


### PR DESCRIPTION
**Description**
Move GetUseDeterministicCompute() to OpKernelContext to avoid need to downcast to OpKernelContextInternal.

**Motivation and Context**
Avoid using dynamic_cast (RTTI).