### PR TITLE
Fix outputs of Sequences and Maps exposure.

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/DisposableNamedOnnxValue.cs
@@ -5,7 +5,7 @@ using Microsoft.ML.OnnxRuntime.Tensors;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
-
+using System.Diagnostics;
 
 namespace Microsoft.ML.OnnxRuntime
 {
@@ -50,45 +50,65 @@ namespace Microsoft.ML.OnnxRuntime
         #endregion
     }
 
+    /// <summary>
+    /// This class owns an OrtValue that 
+    /// </summary>
     public class DisposableNamedOnnxValue : NamedOnnxValue, IDisposable
     {
-        private NativeMemoryHandler _nativeMemoryManager;
-        private TensorElementType _elementType;
-        private OnnxValueType _onnxValueType;
+        private IOrtValueOwner _ortValueHolder;
         private bool _disposed = false;
 
-        private DisposableNamedOnnxValue(string name, Object value, OnnxValueType onnxValueType, TensorElementType elementType, NativeMemoryHandler nativeMemoryManager)
+        private DisposableNamedOnnxValue(string name, Object value, OnnxValueType onnxValueType, TensorElementType elementType, IOrtValueOwner ortValueHolder)
             : base(name, value)
         {
-            _onnxValueType = onnxValueType;
-            _elementType = elementType;
-            _nativeMemoryManager = nativeMemoryManager;
+            _ortValueHolder = ortValueHolder;
+            ValueType = onnxValueType;
+            ElementType = elementType;
         }
 
         /// <summary>
-        /// Overrides the base class method. Since the instance already has access to the 
-        /// underlying OrtValue handle, it returns an instance of OrtValue that does not own the raw handle
-        /// that to the output onnxValue. With respect to pinnedMemoryHandle, it has no operation
-        /// to do, as this class doesn't maintain a managed buffer. It doesn't have to maintain it
-        /// as it already is associated with the object of interest (native OrtValue)
+        /// Returns OnnxValueType
         /// </summary>
-        /// <param name="pinnedMemoryHandle"></param>
+        public OnnxValueType ValueType { get; }
+
+        /// <summary>
+        /// Only valid if ValueType is Tensor
+        /// </summary>
+        public TensorElementType ElementType { get; }
+
+        /// <summary>
+        /// Overrides the base class method. Since the instance already owns underlying OrtValue handle,
+        /// it returns an instance of OrtValue that does not own the raw handle
+        /// that to the output onnxValue. With respect to pinnedMemoryHandle, it has no operation
+        /// to do, as this class maintains a managed buffer via _nativeMememoryManager and the memory will be
+        /// disposed by it. This is the case when we are dealing with an OrtValue that is backed by native memory
+        /// and not by pinned managed memory
+        /// </summary>
+        /// <param name="pinnedMemoryHandle">always set to null</param>
+        /// <returns>An instance of OrtValue that does not own underlying memory</returns>
         internal override OrtValue ToOrtValue(out MemoryHandle? pinnedMemoryHandle)
         {
             // PinnedMemoryHandle holds the default value as DisposableNamedOnnxValue
             // doesn't hold any managed buffer (that needs to be pinned)
             pinnedMemoryHandle = null;
-            // Assign the onnxValue by querying this instance's NativeOnnxTensorMemory instance
-            return new OrtValue(_nativeMemoryManager.Handle, false);
+            // Return non-owning instance of OrtValue
+            return _ortValueHolder.Value;
         }
 
-        internal static DisposableNamedOnnxValue CreateTensorFromOnnxValue(string name, IntPtr nativeOnnxValue)
+        /// <summary>
+        /// Creates an instance of DisposableNamedOnnxValue and takes ownership of ortValueElement
+        /// on success.
+        /// </summary>
+        /// <param name="name">name of the value</param>
+        /// <param name="ortValue">underlying OrtValue</param>
+        /// <returns></returns>
+        internal static DisposableNamedOnnxValue CreateTensorFromOnnxValue(string name, OrtValue ortValue)
         {
             DisposableNamedOnnxValue result = null;
 
             /* Get Tensor element type */  //TODO: Assumed value is Tensor, need to support non-tensor types in future
             IntPtr typeAndShape = IntPtr.Zero;
-            NativeApiStatus.VerifySuccess(NativeMethods.OrtGetTensorTypeAndShape(nativeOnnxValue, out typeAndShape));
+            NativeApiStatus.VerifySuccess(NativeMethods.OrtGetTensorTypeAndShape(ortValue.Handle, out typeAndShape));
             TensorElementType elemType = TensorElementType.DataTypeMax;
             try
             {
@@ -104,40 +124,40 @@ namespace Microsoft.ML.OnnxRuntime
             switch (elemType)
             {
                 case TensorElementType.Float:
-                    result = DisposableNamedOnnxValueFromNativeTensor<float>(name, nativeOnnxValue);
+                    result = DisposableNamedOnnxValueFromNativeTensor<float>(name, ortValue);
                     break;
                 case TensorElementType.Double:
-                    result = DisposableNamedOnnxValueFromNativeTensor<double>(name, nativeOnnxValue);
+                    result = DisposableNamedOnnxValueFromNativeTensor<double>(name, ortValue);
                     break;
                 case TensorElementType.Int16:
-                    result = DisposableNamedOnnxValueFromNativeTensor<short>(name, nativeOnnxValue);
+                    result = DisposableNamedOnnxValueFromNativeTensor<short>(name, ortValue);
                     break;
                 case TensorElementType.UInt16:
-                    result = DisposableNamedOnnxValueFromNativeTensor<ushort>(name, nativeOnnxValue);
+                    result = DisposableNamedOnnxValueFromNativeTensor<ushort>(name, ortValue);
                     break;
                 case TensorElementType.Int32:
-                    result = DisposableNamedOnnxValueFromNativeTensor<int>(name, nativeOnnxValue);
+                    result = DisposableNamedOnnxValueFromNativeTensor<int>(name, ortValue);
                     break;
                 case TensorElementType.UInt32:
-                    result = DisposableNamedOnnxValueFromNativeTensor<uint>(name, nativeOnnxValue);
+                    result = DisposableNamedOnnxValueFromNativeTensor<uint>(name, ortValue);
                     break;
                 case TensorElementType.Int64:
-                    result = DisposableNamedOnnxValueFromNativeTensor<long>(name, nativeOnnxValue);
+                    result = DisposableNamedOnnxValueFromNativeTensor<long>(name, ortValue);
                     break;
                 case TensorElementType.UInt64:
-                    result = DisposableNamedOnnxValueFromNativeTensor<ulong>(name, nativeOnnxValue);
+                    result = DisposableNamedOnnxValueFromNativeTensor<ulong>(name, ortValue);
                     break;
                 case TensorElementType.UInt8:
-                    result = DisposableNamedOnnxValueFromNativeTensor<byte>(name, nativeOnnxValue);
+                    result = DisposableNamedOnnxValueFromNativeTensor<byte>(name, ortValue);
                     break;
                 case TensorElementType.Int8:
-                    result = DisposableNamedOnnxValueFromNativeTensor<sbyte>(name, nativeOnnxValue);
+                    result = DisposableNamedOnnxValueFromNativeTensor<sbyte>(name, ortValue);
                     break;
                 case TensorElementType.String:
-                    result = DisposableNamedOnnxValueFromNativeTensor<string>(name, nativeOnnxValue);
+                    result = DisposableNamedOnnxValueFromNativeTensor<string>(name, ortValue);
                     break;
                 case TensorElementType.Bool:
-                    result = DisposableNamedOnnxValueFromNativeTensor<bool>(name, nativeOnnxValue);
+                    result = DisposableNamedOnnxValueFromNativeTensor<bool>(name, ortValue);
                     break;
                 default:
                     throw new NotSupportedException("Tensor of element type: " + elemType + " is not supported");
@@ -149,115 +169,226 @@ namespace Microsoft.ML.OnnxRuntime
 
         internal static DisposableNamedOnnxValue CreateFromOrtValue(string name, OrtValue ortValue)
         {
-            var result = CreateFromOnnxValue(name, ortValue.Handle, OrtAllocator.DefaultInstance);
-            ortValue.Disown();
+            return CreateFromOrtValue(name, ortValue, OrtAllocator.DefaultInstance);
+        }
+
+        internal static DisposableNamedOnnxValue CreateFromOrtValue(string name, OrtValue ortValue, OrtAllocator allocator)
+        {
+            DisposableNamedOnnxValue result = null;
+            Debug.Assert(ortValue.IsOwned);
+            using (var ortValueOwned = new OrtValue(ortValue.Disown()))
+            {
+                IntPtr valueType;
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtGetValueType(ortValueOwned.Handle, out valueType));
+                OnnxValueType onnxValueType = (OnnxValueType)valueType;
+                switch (onnxValueType)
+                {
+                    case OnnxValueType.ONNX_TYPE_TENSOR:
+                        result = CreateTensorFromOnnxValue(name, ortValueOwned);
+                        break;
+
+                    case OnnxValueType.ONNX_TYPE_SEQUENCE:
+                        result = DisposableNamedOnnxValueFromSequence(name, ortValueOwned, allocator);
+                        break;
+
+                    case OnnxValueType.ONNX_TYPE_MAP:
+                        result = DisposableNamedOnnxValueFromNativeMap(name, ortValueOwned, allocator);
+                        break;
+                    default:
+                        throw new NotSupportedException("OnnxValueType : " + onnxValueType + " is not supported");
+                }
+            }
             return result;
         }
 
-        internal static DisposableNamedOnnxValue CreateFromOnnxValue(string name, IntPtr nativeOnnxValue, OrtAllocator allocator)
-        {
-            IntPtr valueType;
-            NativeApiStatus.VerifySuccess(NativeMethods.OrtGetValueType(nativeOnnxValue, out valueType));
-            OnnxValueType onnxValueType = (OnnxValueType)valueType;
-            switch (onnxValueType)
-            {
-                case OnnxValueType.ONNX_TYPE_TENSOR:
-                    return CreateTensorFromOnnxValue(name, nativeOnnxValue);
-
-                case OnnxValueType.ONNX_TYPE_SEQUENCE:
-                    IntPtr count = IntPtr.Zero;
-                    NativeApiStatus.VerifySuccess(NativeMethods.OrtGetValueCount(nativeOnnxValue, out count));
-                    var sequence = new DisposableList<DisposableNamedOnnxValue>(count.ToInt32());
-                    for (int i = 0; i < count.ToInt32(); i++)
-                    {
-                        IntPtr nativeOnnxValueSeq;
-                        NativeApiStatus.VerifySuccess(NativeMethods.OrtGetValue(nativeOnnxValue, i, allocator.Pointer, out nativeOnnxValueSeq));
-                        sequence.Add(CreateFromOnnxValue(string.Empty, nativeOnnxValueSeq, allocator));
-                    }
-                    return new DisposableNamedOnnxValue(name, sequence, OnnxValueType.ONNX_TYPE_SEQUENCE, TensorElementType.DataTypeMax, null);
-
-                case OnnxValueType.ONNX_TYPE_MAP:
-                    IntPtr nativeOnnxValueMapKeys = IntPtr.Zero;
-                    IntPtr nativeOnnxValueMapValues = IntPtr.Zero;
-                    NativeApiStatus.VerifySuccess(NativeMethods.OrtGetValue(nativeOnnxValue, 0, allocator.Pointer, out nativeOnnxValueMapKeys));
-                    NativeApiStatus.VerifySuccess(NativeMethods.OrtGetValue(nativeOnnxValue, 1, allocator.Pointer, out nativeOnnxValueMapValues));
-
-                    IntPtr typeAndShape = IntPtr.Zero;
-                    NativeApiStatus.VerifySuccess(NativeMethods.OrtGetTensorTypeAndShape(nativeOnnxValueMapKeys, out typeAndShape));
-                    TensorElementType elemType = TensorElementType.DataTypeMax;
-                    try 
-                    {
-                        IntPtr el_type;
-                        NativeApiStatus.VerifySuccess(NativeMethods.OrtGetTensorElementType(typeAndShape, out el_type));
-                        elemType = (TensorElementType)el_type;
-                    }
-                    finally
-                    {
-                        NativeMethods.OrtReleaseTensorTypeAndShapeInfo(typeAndShape);
-                    }
-
-                    switch (elemType)
-                    {
-                        case TensorElementType.Int64:
-                            return DisposableNamedOnnxValueFromNativeMap<Int64, float>(string.Empty, nativeOnnxValueMapKeys, nativeOnnxValueMapValues);
-                        case TensorElementType.String:
-                            return DisposableNamedOnnxValueFromNativeMap<string, float>(string.Empty, nativeOnnxValueMapKeys, nativeOnnxValueMapValues);
-                        default:
-                            throw new NotSupportedException("Map of element type: " + elemType + " is not supported");
-                    }
-                default:
-                    throw new NotSupportedException("OnnxValueType : " + onnxValueType + " is not supported");
-            }
-        }
-
-        private static DisposableNamedOnnxValue DisposableNamedOnnxValueFromNativeTensor<T>(string name, IntPtr nativeOnnxValue)
+        /// <summary>
+        /// This method creates an instance of DisposableNamedOnnxValue that has possession of ortValueElement
+        /// native memory Tensor and returns it to the caller. The original ortValueElement argument looses
+        /// ownership of the native ortValueElement handle, however, the caller is still responsible for disposing them
+        /// on exception. Disposing of OrtValue that has no ownership is a no-op and fine.
+        /// </summary>
+        /// <typeparam name="T">data type</typeparam>
+        /// <param name="name">name of the output</param>
+        /// <param name="ortValue">native tensor</param>
+        /// <returns>DisposableNamedOnnxValue instance</returns>
+        private static DisposableNamedOnnxValue DisposableNamedOnnxValueFromNativeTensor<T>(string name, OrtValue ortValue)
         {
             if (typeof(T) == typeof(string))
             {
-                var nativeTensorWrapper = new NativeOnnxTensorMemory<string>(nativeOnnxValue);
-                var dt = new DenseTensor<string>(nativeTensorWrapper.GetBytesAsStringMemory(), nativeTensorWrapper.Dimensions);
-                return new DisposableNamedOnnxValue(name, dt, OnnxValueType.ONNX_TYPE_TENSOR, nativeTensorWrapper.ElementType, nativeTensorWrapper);
+                var nativeTensorWrapper = new NativeOnnxTensorMemory<string>(ortValue);
+                try
+                {
+                    var dt = new DenseTensor<string>(nativeTensorWrapper.GetBytesAsStringMemory(), nativeTensorWrapper.Dimensions);
+                    return new DisposableNamedOnnxValue(name, dt, OnnxValueType.ONNX_TYPE_TENSOR, nativeTensorWrapper.ElementType, nativeTensorWrapper);
+                } catch(Exception e)
+                {
+                    nativeTensorWrapper.Dispose();
+                    throw e;
+                }
             }
             else
             {
-                NativeOnnxTensorMemory<T> nativeTensorWrapper = new NativeOnnxTensorMemory<T>(nativeOnnxValue);
-                DenseTensor<T> dt = new DenseTensor<T>(nativeTensorWrapper.Memory, nativeTensorWrapper.Dimensions);
-                return new DisposableNamedOnnxValue(name, dt, OnnxValueType.ONNX_TYPE_TENSOR, nativeTensorWrapper.ElementType, nativeTensorWrapper);
+                NativeOnnxTensorMemory<T> nativeTensorWrapper = new NativeOnnxTensorMemory<T>(ortValue);
+                try
+                {
+                    DenseTensor<T> dt = new DenseTensor<T>(nativeTensorWrapper.Memory, nativeTensorWrapper.Dimensions);
+                    return new DisposableNamedOnnxValue(name, dt, OnnxValueType.ONNX_TYPE_TENSOR, nativeTensorWrapper.ElementType, nativeTensorWrapper);
+                }
+                catch (Exception e)
+                {
+                    nativeTensorWrapper.Dispose();
+                    throw e;
+                }
             }
         }
 
-        private static DisposableNamedOnnxValue DisposableNamedOnnxValueFromNativeMap<K, V>(string name, IntPtr nativeOnnxValueKeys, IntPtr nativeOnnxValueValues)
+        /// <summary>
+        /// This method will create an instance of DisposableNamedOnnxValue that will own ortSequenceValue
+        /// an all disposable native objects that are elements of the sequence
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="ortValueSequence">ortValueElement that has native sequence</param>
+        /// <param name="allocator"> used allocator</param>
+        /// <returns>DisposableNamedOnnxValue</returns>
+        private static DisposableNamedOnnxValue DisposableNamedOnnxValueFromSequence(string name, OrtValue ortValueSequence, OrtAllocator allocator)
         {
-            var nativeTensorWrapperValues = new NativeOnnxTensorMemory<V>(nativeOnnxValueValues);
-            var denseTensorValues = new DenseTensor<V>(nativeTensorWrapperValues.Memory, nativeTensorWrapperValues.Dimensions);
-
-            if (typeof(K) == typeof(string))
+            DisposableNamedOnnxValue result = null;
+            IntPtr count;
+            NativeApiStatus.VerifySuccess(NativeMethods.OrtGetValueCount(ortValueSequence.Handle, out count));
+            var sequence = new DisposableList<DisposableNamedOnnxValue>(count.ToInt32());
+            try
             {
-                var map = new Dictionary<string, V>();
-                var nativeTensorWrapper = new NativeOnnxTensorMemory<string>(nativeOnnxValueKeys);
-                var denseTensorKeys = new DenseTensor<string>(nativeTensorWrapper.GetBytesAsStringMemory(), nativeTensorWrapper.Dimensions);
-                for (var i = 0; i < denseTensorKeys.Length; i++)
+                for (int i = 0; i < count.ToInt32(); i++)
                 {
-                    map.Add(denseTensorKeys.GetValue(i), denseTensorValues.GetValue(i));
+                    IntPtr nativeOnnxValueSeq;
+                    NativeApiStatus.VerifySuccess(NativeMethods.OrtGetValue(ortValueSequence.Handle, i, allocator.Pointer, out nativeOnnxValueSeq));
+                    using (var ortValueElement = new OrtValue(nativeOnnxValueSeq))
+                    {
+                        // Will take ownership or throw
+                        sequence.Add(CreateFromOrtValue(string.Empty, ortValueElement, allocator));
+                    }
                 }
-                // release native memory
-                nativeTensorWrapperValues.Dispose();
-                nativeTensorWrapper.Dispose();
-                return new DisposableNamedOnnxValue(string.Empty, map, OnnxValueType.ONNX_TYPE_MAP, TensorElementType.DataTypeMax, null);
+                // NativeOrtValueCollectionOwner will take ownership of ortValySequence and will make sure sequence
+                // is also disposed.
+                var nativeCollectionManager = new NativeOrtValueCollectionOwner(ortValueSequence, sequence);
+                result = new DisposableNamedOnnxValue(name, sequence, OnnxValueType.ONNX_TYPE_SEQUENCE, TensorElementType.DataTypeMax, nativeCollectionManager);
             }
-            else
+            catch (Exception e)
             {
-                var map = new Dictionary<K, V>();
-                var nativeTensorWrapper = new NativeOnnxTensorMemory<K>(nativeOnnxValueKeys);
-                var denseTensorKeys = new DenseTensor<K>(nativeTensorWrapper.Memory, nativeTensorWrapper.Dimensions);
-                for (var i = 0; i < denseTensorKeys.Length; i++)
+                sequence.Dispose();
+                throw e;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Will extract keys and values from the map and create a DisposableNamedOnnxValue from it
+        /// </summary>
+        /// <param name="name">name of the output</param>
+        /// <param name="ortValueMap">ortValue that represents a map. 
+        /// This function does not take ownership of the map as it we copy all keys an values into a dictionary. We let the caller dispose of it</param>
+        /// <param name="allocator"></param>
+        /// <returns>DisposableNamedOnnxValue</returns>
+        private static DisposableNamedOnnxValue DisposableNamedOnnxValueFromNativeMap(string name, OrtValue ortValueMap, OrtAllocator allocator)
+        {
+            DisposableNamedOnnxValue result = null;
+            // Map processing is currently not recursing. It is assumed to contain
+            // only primitive types and strings tensors. No sequences or maps.
+            // The data is being copied to a dictionary and all ortValues are being disposed.
+            // not mapped for client consumption.
+            using (var cleanUpList = new DisposableList<IDisposable>())
+            {
+                // Take possession of the map ortValueElement
+                IntPtr nativeOnnxValueMapKeys = IntPtr.Zero;
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtGetValue(ortValueMap.Handle, 0, allocator.Pointer, out nativeOnnxValueMapKeys));
+                var ortValueKeys = new OrtValue(nativeOnnxValueMapKeys);
+                cleanUpList.Add(ortValueKeys);
+
+                IntPtr nativeOnnxValueMapValues = IntPtr.Zero;
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtGetValue(ortValueMap.Handle, 1, allocator.Pointer, out nativeOnnxValueMapValues));
+                var ortValueValues = new OrtValue(nativeOnnxValueMapValues);
+                cleanUpList.Add(ortValueValues);
+
+                IntPtr typeAndShape = IntPtr.Zero;
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtGetTensorTypeAndShape(nativeOnnxValueMapKeys, out typeAndShape));
+                TensorElementType elemType = TensorElementType.DataTypeMax;
+                try
                 {
-                    map.Add(denseTensorKeys.GetValue(i), denseTensorValues.GetValue(i));
+                    IntPtr el_type;
+                    NativeApiStatus.VerifySuccess(NativeMethods.OrtGetTensorElementType(typeAndShape, out el_type));
+                    elemType = (TensorElementType)el_type;
                 }
-                // release native memory
-                nativeTensorWrapperValues.Dispose();
-                nativeTensorWrapper.Dispose();
-                return new DisposableNamedOnnxValue(string.Empty, map, OnnxValueType.ONNX_TYPE_MAP, TensorElementType.DataTypeMax, null);
+                finally
+                {
+                    NativeMethods.OrtReleaseTensorTypeAndShapeInfo(typeAndShape);
+                }
+
+                /// XXX: This code always assumes that the value type is float and makes no checks
+                /// similar to that of the key. Also Map type in general can also be another sequence or map,
+                /// not just a tensor
+                switch (elemType)
+                {
+                    case TensorElementType.Int64:
+                        result = DisposableNamedOnnxValueFromNativeMapElements<Int64, float>(string.Empty, ortValueKeys, ortValueValues);
+                        break;
+                    case TensorElementType.String:
+                        result = DisposableNamedOnnxValueFromNativeMapElements<string, float>(string.Empty, ortValueKeys, ortValueValues);
+                        break;
+                    default:
+                        throw new NotSupportedException("Map of element type: " + elemType + " is not supported");
+                }
+            }
+            return result;
+        }
+
+
+        /// <summary>
+        /// This method maps keys and values of the map and copies them into a Dictionary
+        /// and returns as an instance of DisposableNamedOnnxValue that does not own or dispose
+        /// any onnx/ortValueElement. The method takes possession of ortValueTensorKeys and ortValueTensorValues
+        /// and disposes of them. The original ortValueElement looses ownership of the Tensor. The caller is still responsible
+        /// for disposing these arguments. Disposing ortValueElement that does not have ownership is a no-op, however, either
+        /// of the arguments may still need to be disposed on exception.
+        /// </summary>
+        /// <typeparam name="K">key type</typeparam>
+        /// <typeparam name="V">value type</typeparam>
+        /// <param name="name">name of the output parameter</param>
+        /// <param name="ortValueTensorKeys">tensor with map keys.</param>
+        /// <param name="nativeOnnxValueValues">tensor with map values</param>
+        /// <returns>instance of DisposableNamedOnnxValue with Dictionary</returns>
+        private static DisposableNamedOnnxValue DisposableNamedOnnxValueFromNativeMapElements<K, V>(string name,
+            OrtValue ortValueTensorKeys, OrtValue ortValueTensorValues)
+        {
+            using (var nativeTensorWrapperValues = new NativeOnnxTensorMemory<V>(ortValueTensorValues))
+            {
+                var denseTensorValues = new DenseTensor<V>(nativeTensorWrapperValues.Memory, nativeTensorWrapperValues.Dimensions);
+
+                if (typeof(K) == typeof(string))
+                {
+                    var map = new Dictionary<string, V>();
+                    using (var nativeTensorWrapper = new NativeOnnxTensorMemory<string>(ortValueTensorKeys))
+                    {
+                        var denseTensorKeys = new DenseTensor<string>(nativeTensorWrapper.GetBytesAsStringMemory(), nativeTensorWrapper.Dimensions);
+                        for (var i = 0; i < denseTensorKeys.Length; i++)
+                        {
+                            map.Add(denseTensorKeys.GetValue(i), denseTensorValues.GetValue(i));
+                        }
+                        return new DisposableNamedOnnxValue(name, map, OnnxValueType.ONNX_TYPE_MAP, TensorElementType.DataTypeMax, null);
+                    }
+                }
+                else
+                {
+                    var map = new Dictionary<K, V>();
+                    using (var nativeTensorWrapper = new NativeOnnxTensorMemory<K>(ortValueTensorKeys))
+                    {
+                        var denseTensorKeys = new DenseTensor<K>(nativeTensorWrapper.Memory, nativeTensorWrapper.Dimensions);
+                        for (var i = 0; i < denseTensorKeys.Length; i++)
+                        {
+                            map.Add(denseTensorKeys.GetValue(i), denseTensorValues.GetValue(i));
+                        }
+                        return new DisposableNamedOnnxValue(name, map, OnnxValueType.ONNX_TYPE_MAP, TensorElementType.DataTypeMax, null);
+                    }
+                }
             }
         }
 
@@ -273,10 +404,11 @@ namespace Microsoft.ML.OnnxRuntime
             // dispose managed state (managed objects).
             if (disposing)
             {
-                if (_nativeMemoryManager != null)
+                // _ortValueHolder can be null when no native memory is involved
+                if (_ortValueHolder != null)
                 {
-                    _nativeMemoryManager.Dispose();
-                    _nativeMemoryManager = null;
+                    _ortValueHolder.Dispose();
+                    _ortValueHolder = null;
                 }
             }
             _disposed = true;

--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
@@ -502,8 +502,7 @@ namespace Microsoft.ML.OnnxRuntime
                     for (int i = 0; i < outputNames.Length; ++i)
                     {
                         var ortValue = ortValues.ElementAt(i);
-                        result.Add(DisposableNamedOnnxValue.CreateTensorFromOnnxValue(outputNames[i], ortValue.Handle));
-                        ortValue.Disown();
+                        result.Add(DisposableNamedOnnxValue.CreateTensorFromOnnxValue(outputNames[i], ortValue));
                     }
                 } catch(Exception e)
                 {
@@ -696,7 +695,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// <summary>
         /// Initializes the session object with a native session handle
         /// </summary>
-        /// <param name="session">Handle of a native session object</param>
+        /// <param name="session">Value of a native session object</param>
         /// <param name="options">Session options</param>
         private void InitWithSessionHandle(IntPtr session, SessionOptions options)
         {

--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
@@ -502,7 +502,7 @@ namespace Microsoft.ML.OnnxRuntime
                     for (int i = 0; i < outputNames.Length; ++i)
                     {
                         var ortValue = ortValues.ElementAt(i);
-                        result.Add(DisposableNamedOnnxValue.CreateTensorFromOnnxValue(outputNames[i], ortValue));
+                        result.Add(DisposableNamedOnnxValue.CreateFromOrtValue(outputNames[i], ortValue));
                     }
                 } catch(Exception e)
                 {

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NamedOnnxValue.cs
@@ -5,13 +5,13 @@ using Microsoft.ML.OnnxRuntime.Tensors;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.Runtime.InteropServices.ComTypes;
 
 namespace Microsoft.ML.OnnxRuntime
 {
     /// <summary>
-    /// The name of the class is a misnomer, it does not hold any
-    /// Onnx values
+    /// The class associates a name with an Object. Currently it supports Tensor<T>
+    /// as possible objects. The name of the class is a misnomer, it does not hold any
+    /// Onnx values.
     /// </summary>
     public class NamedOnnxValue
     {
@@ -24,6 +24,14 @@ namespace Microsoft.ML.OnnxRuntime
             _value = value;
         }
 
+        /// <summary>
+        /// This is a factory method that instantiates NamedOnnxValue
+        /// and associated name with an instance of a Tensor<typeparamref name="T"/>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="name">name</param>
+        /// <param name="value">Tensor<typeparamref name="T"/></param>
+        /// <returns></returns>
         public static NamedOnnxValue CreateFromTensor<T>(string name, Tensor<T> value)
         {
             return new NamedOnnxValue(name, value);
@@ -65,11 +73,12 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         /// <summary>
-        /// Pin the underlying memory and create native onnx value
+        /// Pin the underlying memory and create an instance of OrtValue
+        /// based on the pinned managed memory. The caller is responsible for Disposing
+        /// both OrtValue and pinnedMemoryHandle
         /// </summary>
-        /// <param name="onnxValue"></param>
-        /// <param name="pinnedMemoryHandle"></param>
-        /// <param name="disposeOnnxValueAfterUse"></param>
+        /// <param name="pinnedMemoryHandle">dispose after returned OrtValus is disposed</param>
+        /// <returns>an instance of OrtValue. The lifespan of OrtValue must overlap pinnedMemoryHandle</returns>
         internal virtual OrtValue ToOrtValue(out MemoryHandle? pinnedMemoryHandle)
         {
             return OrtValue.CreateFromTensorObject(_value, out pinnedMemoryHandle, out TensorElementType elementType);

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -1577,27 +1577,35 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 using (var outputs = session.Run(container))
                 {
                     // first output is a tensor containing label
-                    var outNode1 = outputs.ElementAtOrDefault(0);
-                    Assert.Equal("label", outNode1.Name);
+                    var outNode0 = outputs.ElementAtOrDefault(0);
+                    Assert.Equal("label", outNode0.Name);
+                    Assert.Equal(OnnxValueType.ONNX_TYPE_TENSOR, outNode0.ValueType);
+                    Assert.Equal(TensorElementType.Int64, (TensorElementType)outNode0.ElementType);
 
                     // try-cast as a tensor
-                    var outLabelTensor = outNode1.AsTensor<Int64>();
+                    var outLabelTensor = outNode0.AsTensor<long>();
+                    Assert.NotNull(outLabelTensor);
 
-                    // Label 1 should have highest probaility
+                    // Label 1 should have highest probability
                     Assert.Equal(1, outLabelTensor[0]);
 
                     // second output is a sequence<map<int64, float>>
                     // try-cast to an sequence of NOV
-                    var outNode2 = outputs.ElementAtOrDefault(1);
-                    Assert.Equal("probabilities", outNode2.Name);
+                    var outNode1 = outputs.ElementAtOrDefault(1);
+                    Assert.Equal("probabilities", outNode1.Name);
+                    Assert.Equal(OnnxValueType.ONNX_TYPE_SEQUENCE, outNode1.ValueType);
 
                     // try-cast to an sequence of NOV
-                    var seq = outNode2.AsEnumerable<NamedOnnxValue>();
+                    var seq = outNode1.AsEnumerable<NamedOnnxValue>();
+                    Assert.NotNull(seq);
+                    // Try-cast into DisposableNov so we can control and check the process
+
 
                     // try-cast first element in sequence to map/dictionary type
                     if (System.Environment.Is64BitProcess)
                     {
                         var map = seq.First().AsDictionary<Int64, float>();
+                        Assert.NotNull(map);
                         Assert.Equal(0.25938290, map[0], 6);
                         Assert.Equal(0.40904793, map[1], 6);
                         Assert.Equal(0.33156919, map[2], 6);
@@ -1605,6 +1613,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     else // 32-bit
                     {
                         var map = seq.First().AsDictionary<long, float>();
+                        Assert.NotNull(map);
                         Assert.Equal(0.25938290, map[0], 6);
                         Assert.Equal(0.40904793, map[1], 6);
                         Assert.Equal(0.33156919, map[2], 6);
@@ -1638,25 +1647,30 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 using (var outputs = session.Run(container))
                 {
                     // first output is a tensor containing label
-                    var outNode1 = outputs.ElementAtOrDefault(0);
-                    Assert.Equal("label", outNode1.Name);
+                    var outNode0 = outputs.ElementAtOrDefault(0);
+                    Assert.Equal("label", outNode0.Name);
+                    Assert.Equal(OnnxValueType.ONNX_TYPE_TENSOR, outNode0.ValueType);
+                    Assert.Equal(TensorElementType.Int64, (TensorElementType)outNode0.ElementType);
 
                     // try-cast as a tensor
-                    var outLabelTensor = outNode1.AsTensor<string>();
+                    var outLabelTensor = outNode0.AsTensor<string>();
+                    Assert.NotNull(outLabelTensor);
 
-                    // Label 1 should have highest probaility
+                    // Label 1 should have highest probability
                     Assert.Equal("1", outLabelTensor[0]);
 
                     // second output is a sequence<map<int64, float>>
                     // try-cast to an sequence of NOV
-                    var outNode2 = outputs.ElementAtOrDefault(1);
-                    Assert.Equal("probabilities", outNode2.Name);
+                    var outNode1 = outputs.ElementAtOrDefault(1);
+                    Assert.Equal("probabilities", outNode1.Name);
+                    Assert.Equal(OnnxValueType.ONNX_TYPE_SEQUENCE, outNode1.ValueType);
 
                     // try-cast to an sequence of NOV
-                    var seq = outNode2.AsEnumerable<NamedOnnxValue>();
+                    var seq = outNode1.AsEnumerable<NamedOnnxValue>();
 
                     // try-cast first element in sequence to map/dictionary type
                     var map = seq.First().AsDictionary<string, float>();
+                    Assert.NotNull(map);
                     //verify values are valid
                     Assert.Equal(0.25938290, map["0"], 6);
                     Assert.Equal(0.40904793, map["1"], 6);
@@ -1693,6 +1707,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     // try-cast to an sequence of NOV
                     var outNode = outputs.ElementAtOrDefault(0);
                     Assert.Equal("output_sequence", outNode.Name);
+                    Assert.Equal(OnnxValueType.ONNX_TYPE_SEQUENCE, outNode.ValueType);
 
                     // try-cast to an sequence of NOV
                     var seq = outNode.AsEnumerable<NamedOnnxValue>();
@@ -1703,6 +1718,8 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     // try-cast the elements in sequence to tensor type
                     var firstTensorInOuputSequence = seq.First().AsTensor<Int64>();
                     var secondTensorInOuputSequence = seq.Last().AsTensor<Int64>();
+                    Assert.NotNull(firstTensorInOuputSequence);
+                    Assert.NotNull(secondTensorInOuputSequence);
 
                     // make sure the tensors in the output sequence hold the correct values
                     Assert.True(firstTensorInOuputSequence.GetValue(0) == 1);

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -1650,7 +1650,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                     var outNode0 = outputs.ElementAtOrDefault(0);
                     Assert.Equal("label", outNode0.Name);
                     Assert.Equal(OnnxValueType.ONNX_TYPE_TENSOR, outNode0.ValueType);
-                    Assert.Equal(TensorElementType.Int64, (TensorElementType)outNode0.ElementType);
+                    Assert.Equal(TensorElementType.String, (TensorElementType)outNode0.ElementType);
 
                     // try-cast as a tensor
                     var outLabelTensor = outNode0.AsTensor<string>();


### PR DESCRIPTION
**Description**:
Make sure that all OrtValues are properly disposed of. This includes map and sequence ortvalues as well as sequence elements that are currently leaked as the DisposableList is currently assigned to NamedOnnxValue member which does not dispose anything.

**Motivation and Context**
