### PR TITLE
[NNAPI] Split OPBuilder IsOpSupported into a separated class

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
@@ -9,6 +9,7 @@
 #include <core/common/safeint.h>
 #include <core/common/logging/logging.h>
 #include <core/graph/graph.h>
+#include <core/providers/common.h>
 
 #include "helper.h"
 
@@ -218,6 +219,19 @@ bool GetClipMinMax(const InitializerMap& initializers, const Node& node, float& 
   }
 
   return true;
+}
+
+void GetFlattenOutputShape(const Node& node, const Shape& input_shape, int32_t& dim_1, int32_t& dim_2) {
+  int32_t rank = static_cast<int>(input_shape.size());
+  NodeAttrHelper helper(node);
+  int32_t axis = helper.Get("axis", 1);
+  // axis == rank is a valid input, but invalid for HandleNegativeAxis
+  // Skip non-negative axis here
+  if (axis < 0)
+    axis = static_cast<int32_t>(HandleNegativeAxis(axis, rank));
+
+  dim_1 = std::accumulate(input_shape.cbegin(), input_shape.cbegin() + axis, 1, std::multiplies<int32_t>());
+  dim_2 = std::accumulate(input_shape.cbegin() + axis, input_shape.cend(), 1, std::multiplies<int32_t>());
 }
 
 std::string Shape2String(const std::vector<uint32_t>& shape) {

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
@@ -70,12 +70,12 @@ bool IsQLinearBinaryOp(QLinearOpType qlinear_op_type) {
 
 bool HasValidBinaryOpQuantizedInputs(const Node& node) {
   int32_t a_input_type, b_input_type;
-  const auto input_defs(node.InputDefs());
-  if (input_defs.size() < 4) {
-    LOGS_DEFAULT(VERBOSE) << "[" << node.OpType() << "] has only " << input_defs.size() << " inputs";
+  if (!IsQLinearBinaryOp(GetQLinearOpType(node))) {
+    LOGS_DEFAULT(VERBOSE) << "[" << node.OpType() << "] is not a binary qlinear op";
     return false;
   }
 
+  const auto input_defs(node.InputDefs());
   if (!GetType(*input_defs[0], a_input_type))
     return false;
   if (!GetType(*input_defs[3], b_input_type))
@@ -92,13 +92,13 @@ bool HasValidBinaryOpQuantizedInputs(const Node& node) {
   return true;
 }
 
-bool HasValidQuantizationScale(const InitializerMap& initializers, const Node& node,
-                               const std::vector<size_t>& indices) {
+bool HasValidQuantizationScales(const InitializerMap& initializers, const Node& node,
+                                const std::vector<size_t>& indices) {
   const auto& op = node.OpType();
   const auto input_defs(node.InputDefs());
   for (const auto idx : indices) {
     if (idx >= input_defs.size()) {
-      LOGS_DEFAULT(VERBOSE) << "HasValidQuantizationScale, Input index,  " << idx
+      LOGS_DEFAULT(VERBOSE) << "HasValidQuantizationScales, Input index,  " << idx
                             << " >= input number, " << input_defs.size();
       return false;
     }
@@ -118,13 +118,13 @@ bool HasValidQuantizationScale(const InitializerMap& initializers, const Node& n
   return true;
 }
 
-bool HasValidQuantizationZeroPoint(const InitializerMap& initializers, const Node& node,
-                                   const std::vector<size_t>& indices) {
+bool HasValidQuantizationZeroPoints(const InitializerMap& initializers, const Node& node,
+                                    const std::vector<size_t>& indices) {
   const auto& op = node.OpType();
   const auto input_defs(node.InputDefs());
   for (const auto idx : indices) {
     if (idx >= input_defs.size()) {
-      LOGS_DEFAULT(VERBOSE) << "HasValidQuantizationZeroPoint, Input index,  " << idx
+      LOGS_DEFAULT(VERBOSE) << "HasValidQuantizationZeroPoints, Input index,  " << idx
                             << " >= input number, " << input_defs.size();
       return false;
     }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
@@ -2,10 +2,13 @@
 // Created by daquexian on 8/3/18.
 //
 
-#include <core/common/safeint.h>
 #include <iostream>
 #include <string>
 #include <vector>
+
+#include <core/common/safeint.h>
+#include <core/common/logging/logging.h>
+#include <core/graph/graph.h>
 
 #include "helper.h"
 
@@ -63,6 +66,168 @@ bool IsQLinearBinaryOp(QLinearOpType qlinear_op_type) {
   return qlinear_op_type == QLinearOpType::QLinearConv ||
          qlinear_op_type == QLinearOpType::QLinearMatMul ||
          qlinear_op_type == QLinearOpType::QLinearAdd;
+}
+
+bool HasValidBinaryOpQuantizedInputs(const Node& node) {
+  int32_t a_input_type, b_input_type;
+  const auto input_defs(node.InputDefs());
+  if (input_defs.size() < 4) {
+    LOGS_DEFAULT(VERBOSE) << "[" << node.OpType() << "] has only " << input_defs.size() << " inputs";
+    return false;
+  }
+
+  if (!GetType(*input_defs[0], a_input_type))
+    return false;
+  if (!GetType(*input_defs[3], b_input_type))
+    return false;
+
+  if (a_input_type != ONNX_NAMESPACE::TensorProto_DataType_UINT8 || a_input_type != b_input_type) {
+    LOGS_DEFAULT(VERBOSE) << "[" << node.OpType()
+                          << "] A Input type: [" << a_input_type
+                          << "] B Input type: [" << b_input_type
+                          << "] is not supported for now";
+    return false;
+  }
+
+  return true;
+}
+
+bool HasValidQuantizationScale(const InitializerMap& initializers, const Node& node,
+                               const std::vector<size_t>& indices) {
+  const auto& op = node.OpType();
+  const auto input_defs(node.InputDefs());
+  for (const auto idx : indices) {
+    if (idx >= input_defs.size()) {
+      LOGS_DEFAULT(VERBOSE) << "HasValidQuantizationScale, Input index,  " << idx
+                            << " >= input number, " << input_defs.size();
+      return false;
+    }
+    const auto scale_name = input_defs[idx]->Name();
+    if (Contains(initializers, scale_name)) {
+      const auto& tensor = initializers.at(scale_name);
+      if (!tensor.dims().empty() && tensor.dims()[0] != 1) {
+        LOGS_DEFAULT(VERBOSE) << op << " does not support per-channel quantization";
+        return false;
+      }
+    } else {
+      LOGS_DEFAULT(VERBOSE) << "The scale of " << op << " must be known";
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool HasValidQuantizationZeroPoint(const InitializerMap& initializers, const Node& node,
+                                   const std::vector<size_t>& indices) {
+  const auto& op = node.OpType();
+  const auto input_defs(node.InputDefs());
+  for (const auto idx : indices) {
+    if (idx >= input_defs.size()) {
+      LOGS_DEFAULT(VERBOSE) << "HasValidQuantizationZeroPoint, Input index,  " << idx
+                            << " >= input number, " << input_defs.size();
+      return false;
+    }
+    const auto zero_point_name = node.InputDefs()[idx]->Name();
+    if (Contains(initializers, zero_point_name)) {
+      const auto& tensor = initializers.at(zero_point_name);
+      if (!tensor.dims().empty() && tensor.dims()[0] != 1) {
+        LOGS_DEFAULT(VERBOSE) << op << " does not support per-channel quantization";
+        return false;
+      }
+      if (tensor.data_type() != ONNX_NAMESPACE::TensorProto_DataType_UINT8) {
+        LOGS_DEFAULT(VERBOSE) << op << " does not support zero point data type "
+                              << std::to_string(tensor.data_type());
+        return false;
+      }
+    } else {
+      LOGS_DEFAULT(VERBOSE) << "The zero point of " << op << " must be known";
+      return false;
+    }
+  }
+
+  return true;
+}
+
+#define GET_TENSOR_DATA(FUNC_NAME, ELEMENT_TYPE, DATA)                                  \
+  const ELEMENT_TYPE* GetTensor##FUNC_NAME(const ONNX_NAMESPACE::TensorProto& tensor) { \
+    return tensor.DATA().empty()                                                        \
+               ? reinterpret_cast<const ELEMENT_TYPE*>(tensor.raw_data().data())        \
+               : tensor.DATA().data();                                                  \
+  }
+
+GET_TENSOR_DATA(FloatData, float, float_data)
+GET_TENSOR_DATA(Int32Data, int32_t, int32_data)
+GET_TENSOR_DATA(Int64Data, int64_t, int64_data)
+
+#undef GET_TENSOR_DATA
+
+bool GetShape(const NodeArg& node_arg, Shape& shape) {
+  shape.clear();
+  const auto* shape_proto = node_arg.Shape();
+
+  if (!shape_proto) {
+    LOGS_DEFAULT(WARNING) << "NodeArg [" << node_arg.Name() << "] has no shape info";
+    return false;
+  }
+
+  // NNAPI uses 0 for dynamic dimension, which is the default value for dim.dim_value()
+  for (const auto& dim : shape_proto->dim())
+    shape.push_back(SafeInt<uint32_t>(dim.dim_value()));
+
+  return true;
+}
+
+bool GetType(const NodeArg& node_arg, int32_t& type) {
+  type = ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED;
+  const auto* type_proto = node_arg.TypeAsProto();
+  if (!type_proto || !type_proto->has_tensor_type() || !type_proto->tensor_type().has_elem_type()) {
+    LOGS_DEFAULT(WARNING) << "NodeArg [" << node_arg.Name() << "] has no input type";
+    return false;
+  }
+
+  type = type_proto->tensor_type().elem_type();
+  return true;
+}
+
+bool GetClipMinMax(const InitializerMap& initializers, const Node& node, float& min, float& max) {
+  min = std::numeric_limits<float>::lowest();
+  max = std::numeric_limits<float>::max();
+  if (node.SinceVersion() < 11) {  // Clip opset 1, 6 is using attributes for min/max
+    NodeAttrHelper helper(node);
+    min = helper.Get("min", std::numeric_limits<float>::lowest());
+    max = helper.Get("max", std::numeric_limits<float>::max());
+  } else {
+    if (node.InputDefs().size() > 1) {  // we have input min
+      const auto& min_name = node.InputDefs()[1]->Name();
+      if (!Contains(initializers, min_name)) {
+        LOGS_DEFAULT(VERBOSE) << "Input min of Clip must be known";
+        return false;
+      }
+      min = GetTensorFloatData(initializers.at(min_name))[0];
+    }
+
+    if (node.InputDefs().size() > 2) {  // we have input max
+      const auto& max_name = node.InputDefs()[2]->Name();
+      if (!Contains(initializers, max_name)) {
+        LOGS_DEFAULT(VERBOSE) << "Input max of Clip must be known";
+        return false;
+      }
+      max = GetTensorFloatData(initializers.at(max_name))[0];
+    }
+  }
+
+  return true;
+}
+
+std::string Shape2String(const std::vector<uint32_t>& shape) {
+  std::ostringstream os;
+  os << "[ ";
+  for (const auto& dim : shape)
+    os << dim << " ";
+
+  os << "]";
+  return os.str();
 }
 
 NodeAttrHelper::NodeAttrHelper(const onnxruntime::Node& node)

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
@@ -3,12 +3,18 @@
 //
 #pragma once
 
-#include <core/graph/graph.h>
 #include <string>
-
+#include "core/graph/basic_types.h"
 #include "core/providers/nnapi/nnapi_builtin/nnapi_lib/NeuralNetworksTypes.h"
 
 namespace onnxruntime {
+
+using Shape = std::vector<uint32_t>;
+using InitializerMap = std::unordered_map<std::string, const ONNX_NAMESPACE::TensorProto&>;
+
+class Node;
+class NodeArg;
+
 namespace nnapi {
 
 #define THROW_ON_ERROR(val)                  \
@@ -68,6 +74,25 @@ QLinearOpType GetQLinearOpType(const onnxruntime::Node& node);
 // This qlinear op is an operator takes 2 input and produces 1 output
 // Such as QLinearConv, QLinearMatMul, QLinearAdd, ...
 bool IsQLinearBinaryOp(QLinearOpType qlinear_op_type);
+
+bool HasValidBinaryOpQuantizedInputs(const Node& node);
+bool HasValidQuantizationScale(const InitializerMap& initializers, const Node& node,
+                               const std::vector<size_t>& indices);
+bool HasValidQuantizationZeroPoint(const InitializerMap& initializers, const Node& node,
+                                   const std::vector<size_t>& indices);
+
+const float* GetTensorFloatData(const ONNX_NAMESPACE::TensorProto& tensor);
+const int32_t* GetTensorInt32Data(const ONNX_NAMESPACE::TensorProto& tensor);
+const int64_t* GetTensorInt64Data(const ONNX_NAMESPACE::TensorProto& tensor);
+
+bool GetShape(const NodeArg& node_arg, Shape& shape);
+bool GetType(const NodeArg& node_arg, int32_t& type);
+
+// Get the min/max value from Clip op
+// If the min/max are inputs be not initializers (value not preset), will return false
+bool GetClipMinMax(const InitializerMap& initializers, const Node& node, float& min, float& max);
+
+std::string Shape2String(const std::vector<uint32_t>& shape);
 
 /**
  * Wrapping onnxruntime::Node for retrieving attribute values

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
@@ -98,6 +98,9 @@ bool GetType(const NodeArg& node_arg, int32_t& type);
 // If the min/max are inputs be not initializers (value not preset), will return false
 bool GetClipMinMax(const InitializerMap& initializers, const Node& node, float& min, float& max);
 
+// Get the output shape of Flatten Op
+void GetFlattenOutputShape(const Node& node, const Shape& input_shape, int32_t& dim_1, int32_t& dim_2);
+
 // Get string representation of a Shape
 std::string Shape2String(const std::vector<uint32_t>& shape);
 

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
@@ -75,16 +75,22 @@ QLinearOpType GetQLinearOpType(const onnxruntime::Node& node);
 // Such as QLinearConv, QLinearMatMul, QLinearAdd, ...
 bool IsQLinearBinaryOp(QLinearOpType qlinear_op_type);
 
+// Check if a qlinear binary op has valid inputs
 bool HasValidBinaryOpQuantizedInputs(const Node& node);
-bool HasValidQuantizationScale(const InitializerMap& initializers, const Node& node,
-                               const std::vector<size_t>& indices);
-bool HasValidQuantizationZeroPoint(const InitializerMap& initializers, const Node& node,
-                                   const std::vector<size_t>& indices);
+// Check if a qlinear op has valid scales for given indices
+bool HasValidQuantizationScales(const InitializerMap& initializers, const Node& node,
+                                const std::vector<size_t>& indices);
+// Check if a qlinear op has valid zero points for given indices
+bool HasValidQuantizationZeroPoints(const InitializerMap& initializers, const Node& node,
+                                    const std::vector<size_t>& indices);
 
+// Get initialize tensort float/int32/int64 data without unpacking
+// TODO, move to ort framework
 const float* GetTensorFloatData(const ONNX_NAMESPACE::TensorProto& tensor);
 const int32_t* GetTensorInt32Data(const ONNX_NAMESPACE::TensorProto& tensor);
 const int64_t* GetTensorInt64Data(const ONNX_NAMESPACE::TensorProto& tensor);
 
+// Get Shape/Type of a NodeArg
 bool GetShape(const NodeArg& node_arg, Shape& shape);
 bool GetType(const NodeArg& node_arg, int32_t& type);
 
@@ -92,6 +98,7 @@ bool GetType(const NodeArg& node_arg, int32_t& type);
 // If the min/max are inputs be not initializers (value not preset), will return false
 bool GetClipMinMax(const InitializerMap& initializers, const Node& node, float& min, float& max);
 
+// Get string representation of a Shape
 std::string Shape2String(const std::vector<uint32_t>& shape);
 
 /**

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
@@ -8,6 +8,7 @@
 #include "helper.h"
 #include "model_builder.h"
 #include "op_builder.h"
+#include "op_support_checker.h"
 
 namespace onnxruntime {
 namespace nnapi {
@@ -19,6 +20,7 @@ ModelBuilder::ModelBuilder(const GraphViewer& graph_viewer)
     : nnapi_(NnApiImplementation()), graph_viewer_(graph_viewer) {
   GetAllInitializers();
   op_builders_ = CreateOpBuilders();
+  op_support_checkers_ = CreateOpSupportCheckers();
 }
 
 int32_t ModelBuilder::GetAndroidSdkVer() const {
@@ -26,6 +28,16 @@ int32_t ModelBuilder::GetAndroidSdkVer() const {
 }
 
 bool ModelBuilder::IsNodeSupported(const Node& node) {
+  if (auto* op_support_checker = GetOPSupportChecker(node)) {
+    OPSupportCheckParams param{
+        GetAndroidSdkVer(),  // android_sdk_ver
+        UseNCHW(),           // use_nchw
+    };
+    return op_support_checker->IsOpSupported(GetInitializerTensors(), node, param);
+  } else {
+    return false;
+  }
+
   if (auto* op_builder = GetOpBuilder(node)) {
     return op_builder->IsOpSupported(*this, node);
   } else {
@@ -201,7 +213,7 @@ void ModelBuilder::PreprocessActivations() {
       activation_nodes_.emplace(node->Index(), ANEURALNETWORKS_FUSED_RELU);
     } else if (op_type == "Clip") {  // Relu1 or Relu6
       float min, max;
-      if (!GetClipMinMax(*this, *node, min, max))
+      if (!GetClipMinMax(GetInitializerTensors(), *node, min, max))
         continue;
 
       if (min == -1.0f && max == 1.0f) {
@@ -610,6 +622,13 @@ IOpBuilder* ModelBuilder::GetOpBuilder(const Node& node) {
     return nullptr;
 
   return op_builders_[node.OpType()].get();
+}
+
+IOPSupportChecker* ModelBuilder::GetOPSupportChecker(const Node& node) {
+  if (!Contains(op_support_checkers_, node.OpType()))
+    return nullptr;
+
+  return op_support_checkers_[node.OpType()].get();
 }
 
 std::string ModelBuilder::GetUniqueName(const std::string& base_name) {

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
@@ -21,6 +21,8 @@ ModelBuilder::ModelBuilder(const GraphViewer& graph_viewer)
   GetAllInitializers();
   op_builders_ = CreateOpBuilders();
   op_support_checkers_ = CreateOpSupportCheckers();
+  ORT_ENFORCE(op_builders_.size() == op_support_checkers_.size(),
+              "We should have same number of OpBuilder and OpSupportChecker");
 }
 
 int32_t ModelBuilder::GetAndroidSdkVer() const {

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
@@ -620,7 +620,7 @@ IOpBuilder* ModelBuilder::GetOpBuilder(const Node& node) {
   return op_builders_[node.OpType()].get();
 }
 
-IOPSupportChecker* ModelBuilder::GetOPSupportChecker(const Node& node) {
+IOpSupportChecker* ModelBuilder::GetOPSupportChecker(const Node& node) {
   if (!Contains(op_support_checkers_, node.OpType()))
     return nullptr;
 

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
@@ -37,12 +37,6 @@ bool ModelBuilder::IsNodeSupported(const Node& node) {
   } else {
     return false;
   }
-
-  if (auto* op_builder = GetOpBuilder(node)) {
-    return op_builder->IsOpSupported(*this, node);
-  } else {
-    return false;
-  }
 }
 
 bool IsValidSupportedNodesVec(const std::vector<int>& supported_node_vec, const GraphViewer& graph_viewer) {

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.h
@@ -19,7 +19,7 @@ namespace onnxruntime {
 namespace nnapi {
 
 class IOpBuilder;
-class IOPSupportChecker;
+class IOpSupportChecker;
 
 class ModelBuilder {
  public:
@@ -145,7 +145,7 @@ class ModelBuilder {
   std::unordered_map<NodeIndex, int32_t> activation_nodes_;
 
   std::unordered_map<std::string, std::shared_ptr<IOpBuilder>> op_builders_;
-  std::unordered_map<std::string, std::shared_ptr<IOPSupportChecker>> op_support_checkers_;
+  std::unordered_map<std::string, std::shared_ptr<IOpSupportChecker>> op_support_checkers_;
 
   // Operands in nhwc
   std::unordered_set<std::string> nhwc_operands_;
@@ -192,7 +192,7 @@ class ModelBuilder {
                        uint32_t& index) ORT_MUST_USE_RESULT;
 
   IOpBuilder* GetOpBuilder(const Node& node);
-  IOPSupportChecker* GetOPSupportChecker(const Node& node);
+  IOpSupportChecker* GetOPSupportChecker(const Node& node);
 };
 
 }  // namespace nnapi

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.h
@@ -19,6 +19,7 @@ namespace onnxruntime {
 namespace nnapi {
 
 class IOpBuilder;
+class IOPSupportChecker;
 
 class ModelBuilder {
  public:
@@ -114,6 +115,9 @@ class ModelBuilder {
   Status SetNCHWToNHWCOperandMap(const std::string& nchw_name,
                                  const std::string& nhwc_name) ORT_MUST_USE_RESULT;
 
+  // Is the given node supported by NNAPI
+  bool IsNodeSupported(const Node& node);
+
  private:
   const NnApi* nnapi_{nullptr};
   const GraphViewer& graph_viewer_;
@@ -141,6 +145,7 @@ class ModelBuilder {
   std::unordered_map<NodeIndex, int32_t> activation_nodes_;
 
   std::unordered_map<std::string, std::shared_ptr<IOpBuilder>> op_builders_;
+  std::unordered_map<std::string, std::shared_ptr<IOPSupportChecker>> op_support_checkers_;
 
   // Operands in nhwc
   std::unordered_set<std::string> nhwc_operands_;
@@ -158,8 +163,6 @@ class ModelBuilder {
   std::vector<ANeuralNetworksDevice*> nnapi_target_devices_;
 
   uint32_t next_index_ = 0;
-
-  bool IsNodeSupported(const Node& node);
 
   // Convert the onnx model to ANeuralNetworksModel
   Status Prepare() ORT_MUST_USE_RESULT;
@@ -189,6 +192,7 @@ class ModelBuilder {
                        uint32_t& index) ORT_MUST_USE_RESULT;
 
   IOpBuilder* GetOpBuilder(const Node& node);
+  IOPSupportChecker* GetOPSupportChecker(const Node& node);
 };
 
 }  // namespace nnapi

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
@@ -528,82 +528,11 @@ class BaseOpBuilder : public IOpBuilder {
  public:
   virtual ~BaseOpBuilder() = default;
   virtual void AddInitializersToSkip(ModelBuilder& /* model_builder */, const Node& /* node */) override {}
-
-  bool IsOpSupported(ModelBuilder& model_builder, const Node& node) override final;
-
   Status AddToModelBuilder(ModelBuilder& model_builder, const Node& node) override final ORT_MUST_USE_RESULT;
 
  protected:
-  virtual bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node);
-
-  virtual int32_t GetMinSupportedSdkVer(ModelBuilder& /* model_builder */,
-                                        const Node& /* node */) const { return 27; }
-
-  virtual bool HasSupportedInputs(const Node& node);
-
   virtual Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) ORT_MUST_USE_RESULT = 0;
-
-  bool HasExternalInitializer(ModelBuilder& model_builder, const Node& node);
-
-  virtual int GetMinSupportedOpSet(const Node& /* node */) { return 1; }
-  virtual int GetMaxSupportedOpSet(const Node& /* node */) { return 13; }
-
-  bool HasSupportedOpSet(const Node& node);
 };
-
-bool BaseOpBuilder::IsOpSupported(ModelBuilder& model_builder, const Node& node) {
-#ifdef __ANDROID__
-  int32_t android_sdk_ver = model_builder.GetAndroidSdkVer();
-  int32_t required_sdk_ver = GetMinSupportedSdkVer(model_builder, node);
-  if (required_sdk_ver > android_sdk_ver) {
-    LOGS_DEFAULT(VERBOSE) << "Current Android API level [" << android_sdk_ver
-                          << "], Operator [" << node.OpType()
-                          << "] is only supported on API >" << required_sdk_ver;
-    return false;
-  }
-#endif
-
-  if (!HasSupportedInputs(node))
-    return false;
-
-  // We do not support external initializers for now
-  if (HasExternalInitializer(model_builder, node))
-    return false;
-
-  if (!HasSupportedOpSet(node))
-    return false;
-
-  return IsOpSupportedImpl(model_builder, node);
-}
-
-bool BaseOpBuilder::HasSupportedInputs(const Node& node) {
-  // We only check the type of input 0 by default
-  // specific op builder can override this
-  const auto& input = *node.InputDefs()[0];
-
-  if (nullptr == input.Shape()) {
-    LOGS_DEFAULT(VERBOSE) << "[" << node.OpType()
-                          << "] Input shape is null";
-    return false;
-  }
-
-  int32_t input_type;
-  if (!GetType(input, input_type))
-    return false;
-
-  if (input_type != ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
-    LOGS_DEFAULT(VERBOSE) << "[" << node.OpType()
-                          << "] Input type: [" << input_type
-                          << "] is not supported for now";
-    return false;
-  }
-
-  return true;
-}
-
-bool BaseOpBuilder::IsOpSupportedImpl(ModelBuilder& /* model_builder */, const Node& /* node */) {
-  return true;
-}
 
 Status BaseOpBuilder::AddToModelBuilder(ModelBuilder& model_builder, const Node& node) {
   ORT_RETURN_IF_NOT(model_builder.IsNodeSupported(node), "Unsupported operator ", node.OpType());
@@ -611,37 +540,6 @@ Status BaseOpBuilder::AddToModelBuilder(ModelBuilder& model_builder, const Node&
   LOGS_DEFAULT(VERBOSE) << "Operator name: [" << node.Name()
                         << "] type: [" << node.OpType() << "] was added";
   return Status::OK();
-}
-
-bool BaseOpBuilder::HasExternalInitializer(ModelBuilder& model_builder, const Node& node) {
-  const auto& initializers(model_builder.GetOnnxGraph().GetAllInitializedTensors());
-  for (const auto* node_arg : node.InputDefs()) {
-    const auto& input_name(node_arg->Name());
-    if (!Contains(initializers, input_name))
-      continue;
-
-    const auto* tensor = initializers.at(input_name);
-    if (tensor->has_data_location() &&
-        tensor->data_location() == ONNX_NAMESPACE::TensorProto_DataLocation_EXTERNAL) {
-      LOGS_DEFAULT(VERBOSE) << "Initializer [" << input_name
-                            << "] with external data location are not currently supported";
-      return true;
-    }
-  }
-
-  return false;
-}
-
-bool BaseOpBuilder::HasSupportedOpSet(const Node& node) {
-  auto since_version = node.SinceVersion();
-  if (since_version < GetMinSupportedOpSet(node) || since_version > GetMaxSupportedOpSet(node)) {
-    LOGS_DEFAULT(VERBOSE) << node.OpType() << "is only supported for opset ["
-                          << GetMinSupportedOpSet(node) << ", "
-                          << GetMaxSupportedOpSet(node) << "]";
-    return false;
-  }
-
-  return true;
 }
 
 #pragma endregion op_base
@@ -653,11 +551,7 @@ class BinaryOpBuilder : public BaseOpBuilder {
   void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) override;
 
  private:
-  int32_t GetMinSupportedSdkVer(ModelBuilder& model_builder, const Node& node) const override;
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
-  bool HasSupportedInputs(const Node& node) override;
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
-  int GetMinSupportedOpSet(const Node& node) override;
 };
 
 void BinaryOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) {
@@ -665,84 +559,6 @@ void BinaryOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const N
   if (op == "QLinearAdd") {
     AddBinaryOpQuantizationScaleAndZeroPointToSkip(model_builder, node);
   }
-}
-
-int32_t BinaryOpBuilder::GetMinSupportedSdkVer(ModelBuilder& /* model_builder */, const Node& node) const {
-  const auto& op(node.OpType());
-  if (op == "Sub" || op == "Div") {
-    return 28;
-  }
-
-  return 27;
-}
-
-int BinaryOpBuilder::GetMinSupportedOpSet(const Node& node) {
-  const auto& op(node.OpType());
-
-  // Add/Sub/Mul/Div opset 6- has broadcast attributes we do not support now
-  if (op != "QLinearAdd")
-    return 7;
-
-  return 1;
-}
-
-bool BinaryOpBuilder::HasSupportedInputs(const Node& node) {
-  if (node.OpType() != "QLinearAdd")
-    return BaseOpBuilder::HasSupportedInputs(node);
-
-  // QLinearAdd
-  if (!HasValidBinaryOpQuantizedInputs(node))
-    return false;
-
-  return true;
-}
-
-bool BinaryOpBuilder::IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) {
-  const auto& op_type(node.OpType());
-  const auto input_defs(node.InputDefs());
-  bool op_is_qlinear = op_type == "QLinearAdd";
-  size_t a_idx = 0, b_idx = 1;
-  if (op_is_qlinear) {
-    b_idx = 3;
-  }
-  Shape input1_shape, input2_shape;
-  if (!GetShape(*input_defs[a_idx], input1_shape) ||
-      !GetShape(*input_defs[b_idx], input2_shape))
-    return false;
-
-  const auto input1_size = input1_shape.size();
-  const auto input2_size = input2_shape.size();
-  if (input1_size > 4 || input2_size > 4) {
-    LOGS_DEFAULT(VERBOSE) << node.OpType() << " only support up to 4d shape, input1 is "
-                          << input1_size << "d shape, input 2 is "
-                          << input2_size << "d shape";
-    return false;
-  }
-
-  if (op_is_qlinear) {
-    // For QLinearAdd, we only support uint8 output now
-    int32_t output_type;
-    if (!GetType(*node.OutputDefs()[0], output_type))
-      return false;
-
-    if (output_type != ONNX_NAMESPACE::TensorProto_DataType_UINT8) {
-      LOGS_DEFAULT(VERBOSE) << "[" << op_type
-                            << "] output type: [" << output_type
-                            << "] is not supported for now";
-      return false;
-    }
-
-    // All scale/zero points are initializer scalars
-    // a/b/y_scale
-    if (!HasValidQuantizationScale(model_builder.GetInitializerTensors(), node, {1, 4, 6}))
-      return false;
-
-    // a/b/y_zero_point
-    if (!HasValidQuantizationZeroPoint(model_builder.GetInitializerTensors(), node, {2, 5, 7}))
-      return false;
-  }
-
-  return true;
 }
 
 Status BinaryOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
@@ -851,29 +667,8 @@ Status ReluOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
 
 class TransposeOpBuilder : public BaseOpBuilder {
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
-
-  int32_t GetMinSupportedSdkVer(ModelBuilder& /* model_builder */, const Node& /* node */) const override {
-    return 28;
-  }
-
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
 };
-
-bool TransposeOpBuilder::IsOpSupportedImpl(ModelBuilder& /* model_builder */, const Node& node) {
-  Shape input_shape;
-  if (!GetShape(*node.InputDefs()[0], input_shape))
-    return false;
-
-  const auto input_size = input_shape.size();
-  if (input_size > 4 || input_size == 0) {
-    LOGS_DEFAULT(VERBOSE) << "Transpose only supports 1-4d shape, input is "
-                          << input_size << "d shape";
-    return false;
-  }
-
-  return true;
-}
 
 Status TransposeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
   auto& shaper(model_builder.GetShaper());
@@ -921,12 +716,8 @@ class ReshapeOpBuilder : public BaseOpBuilder {
                                    const std::string& input, const std::vector<int32_t>& shape) ORT_MUST_USE_RESULT;
 
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
   static bool CanSkipReshape(const Node& node, size_t input_rank, size_t output_rank);
-
-  // Reshape opset 4- uses attributes for new shape which we do not support for now
-  int GetMinSupportedOpSet(const Node& /* node */) override { return 5; }
 };
 
 void ReshapeOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) {
@@ -1027,39 +818,6 @@ void ReshapeOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const 
   return Status::OK();
 }
 
-bool ReshapeOpBuilder::IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) {
-  const auto& initializers(model_builder.GetInitializerTensors());
-  const auto& perm_name = node.InputDefs()[1]->Name();
-  if (!Contains(initializers, perm_name)) {
-    LOGS_DEFAULT(VERBOSE) << "New shape of reshape must be known";
-    return false;
-  }
-
-  Shape input_shape;
-  if (!GetShape(*node.InputDefs()[0], input_shape))
-    return false;
-
-  if (input_shape.size() > 4 || input_shape.empty()) {
-    LOGS_DEFAULT(VERBOSE) << "Reshape only supports up to 1-4d shape, input is "
-                          << input_shape.size() << "d shape";
-    return false;
-  }
-
-  const auto& shape_tensor = initializers.at(perm_name);
-  const int64_t* rawShape = GetTensorInt64Data(shape_tensor);
-  const auto size = SafeInt<uint32_t>(shape_tensor.dims()[0]);
-
-  for (uint32_t i = 0; i < size; i++) {
-    // NNAPI reshape does not support 0 as dimension
-    if (rawShape[i] == 0 && i < input_shape.size() && input_shape[i] == 0) {
-      LOGS_DEFAULT(VERBOSE) << "Reshape doesn't suppport 0 reshape dimension on a dynamic dimension";
-      return false;
-    }
-  }
-
-  return true;
-}
-
 Status ReshapeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
   auto& shaper(model_builder.GetShaper());
   const auto& initializers(model_builder.GetInitializerTensors());
@@ -1094,12 +852,7 @@ class BatchNormalizationOpBuilder : public BaseOpBuilder {
   void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) override;
 
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
-
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
-
-  // BatchNormalization opset 6- has unsupported attributes
-  int GetMinSupportedOpSet(const Node& /* node */) override { return 7; }
 };
 
 void BatchNormalizationOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) {
@@ -1108,57 +861,6 @@ void BatchNormalizationOpBuilder::AddInitializersToSkip(ModelBuilder& model_buil
   model_builder.AddInitializerToSkip(node.InputDefs()[2]->Name());  // B
   model_builder.AddInitializerToSkip(node.InputDefs()[3]->Name());  // mean
   model_builder.AddInitializerToSkip(node.InputDefs()[4]->Name());  //var
-}
-
-bool BatchNormalizationOpBuilder::IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) {
-  if (node.OutputDefs().size() != 1) {
-    LOGS_DEFAULT(VERBOSE) << "Your onnx model may be in training mode, please export "
-                             "it in test mode.";
-    return false;
-  }
-
-  const auto& input_defs = node.InputDefs();
-  Shape input_shape;
-  if (!GetShape(*input_defs[0], input_shape))
-    return false;
-
-  const auto input_size = input_shape.size();
-  if (input_size > 4) {
-    LOGS_DEFAULT(VERBOSE) << "BN only support up to 4d shape, input is "
-                          << input_size << "d shape";
-    return false;
-  }
-
-  NodeAttrHelper helper(node);
-  const auto spatial = helper.Get("spatial", 1);
-  if (spatial != 1) {
-    LOGS_DEFAULT(VERBOSE) << "Non-spatial BN is not supported";
-    return false;
-  }
-
-  const auto& initializers(model_builder.GetInitializerTensors());
-  const auto& scale_name = input_defs[1]->Name();
-  const auto& b_name = input_defs[2]->Name();
-  const auto& mean_name = input_defs[3]->Name();
-  const auto& var_name = input_defs[4]->Name();
-  if (!Contains(initializers, scale_name)) {
-    LOGS_DEFAULT(VERBOSE) << "Scale of BN must be known";
-    return false;
-  }
-  if (!Contains(initializers, b_name)) {
-    LOGS_DEFAULT(VERBOSE) << "B of BN must be known";
-    return false;
-  }
-  if (!Contains(initializers, mean_name)) {
-    LOGS_DEFAULT(VERBOSE) << "Mean of BN must be known";
-    return false;
-  }
-  if (!Contains(initializers, var_name)) {
-    LOGS_DEFAULT(VERBOSE) << "Var of BN must be known";
-    return false;
-  }
-
-  return true;
 }
 
 Status BatchNormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
@@ -1247,71 +949,8 @@ Status BatchNormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_bu
 
 class PoolOpBuilder : public BaseOpBuilder {
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
-
-  int32_t GetMinSupportedSdkVer(ModelBuilder& model_builder, const Node& /* node */) const override {
-    return model_builder.UseNCHW() ? 29 : 28;
-  }
-
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
 };
-
-bool PoolOpBuilder::IsOpSupportedImpl(ModelBuilder& /* model_builder */, const Node& node) {
-  const auto& op_type = node.OpType();
-  Shape input_shape;
-  if (!GetShape(*node.InputDefs()[0], input_shape))
-    return false;
-
-  const auto input_size = input_shape.size();
-  if (input_size != 4) {
-    LOGS_DEFAULT(VERBOSE)
-        << op_type << " only supports rank-4 tensor, input ["
-        << node.InputDefs()[0]->Name() << "] has actual dim count " << input_size;
-    return false;
-  }
-
-  if (op_type == "AveragePool" || op_type == "MaxPool") {
-    NodeAttrHelper helper(node);
-
-    const auto count_include_pad = helper.Get("count_include_pad", 0);
-    if (count_include_pad == 1) {
-      LOGS_DEFAULT(VERBOSE) << "count_include_pad == 1 is not supported";
-      return false;
-    }
-
-    const auto storage_order = helper.Get("storage_order", 0);
-    if (storage_order == 1) {
-      LOGS_DEFAULT(VERBOSE) << "storage_order == 1 is not supported";
-      return false;
-    }
-
-    if (helper.Get("kernel_shape", std::vector<int32_t>{1, 1}).size() != 2) {
-      LOGS_DEFAULT(VERBOSE) << "Only pooling 2d is supported";
-      return false;
-    }
-
-    if (helper.Get("ceil_mode", 0) == 1) {
-      LOGS_DEFAULT(VERBOSE) << "ceil_mode == 1 is not supported for pooling";
-      return false;
-    }
-
-    if (helper.Get("dilations", std::vector<int32_t>{1, 1}) !=
-        std::vector<int32_t>{1, 1}) {
-      LOGS_DEFAULT(VERBOSE) << "Dilations of pooling is not supported";
-      return false;
-    }
-
-    if (node.OutputDefs().size() != 1) {
-      LOGS_DEFAULT(VERBOSE) << "Argmax in maxpooling is not supported";
-      return false;
-    }
-  } else if (op_type != "GlobalAveragePool" && op_type != "GlobalMaxPool") {
-    LOGS_DEFAULT(VERBOSE) << "PoolOpBuilder, unknown op: " << op_type;
-    return false;
-  }
-
-  return true;
-}
 
 Status PoolOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
   auto& shaper(model_builder.GetShaper());
@@ -1415,26 +1054,8 @@ class ConvOpBuilder : public BaseOpBuilder {
   void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) override;
 
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
-
-  int32_t GetMinSupportedSdkVer(ModelBuilder& model_builder, const Node& /* node */) const override {
-    return model_builder.UseNCHW() ? 29 : 28;
-  }
-
-  bool HasSupportedInputs(const Node& node) override;
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
 };
-
-bool ConvOpBuilder::HasSupportedInputs(const Node& node) {
-  if (node.OpType() != "QLinearConv")
-    return BaseOpBuilder::HasSupportedInputs(node);
-
-  // QLinearConv only supports input of uint8 for now
-  if (!HasValidBinaryOpQuantizedInputs(node))
-    return false;
-
-  return true;
-}
 
 void ConvOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) {
   const auto& op = node.OpType();
@@ -1449,72 +1070,6 @@ void ConvOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Nod
   } else {
     model_builder.AddInitializerToSkip(input_defs[1]->Name());  // w
   }
-}
-
-bool ConvOpBuilder::IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) {
-  const auto& op_type = node.OpType();
-  const auto input_defs = node.InputDefs();
-  const auto& initializers(model_builder.GetInitializerTensors());
-  NodeAttrHelper helper(node);
-
-  bool is_qlinear_conv = (op_type == "QLinearConv");
-  size_t w_idx = is_qlinear_conv ? 3 : 1;
-  const auto group = helper.Get("group", 1);
-  const auto weight_name = input_defs[w_idx]->Name();
-  if (Contains(initializers, weight_name)) {
-    const auto& tensor = initializers.at(weight_name);
-    if (tensor.dims().size() != 4) {
-      LOGS_DEFAULT(VERBOSE) << "Only conv 2d is supported.";
-      return false;
-    }
-
-    const auto onnx_dilations = helper.Get("dilations", vector<int>{1, 1});
-    if (onnx_dilations != vector<int>{1, 1}) {
-      if (group != 1 && tensor.dims()[1] != 1) {
-        LOGS_DEFAULT(VERBOSE) << "dilation is not supported on grouped conv";
-        return false;
-      }
-
-      const auto android_sdk_ver = model_builder.GetAndroidSdkVer();
-      if (android_sdk_ver < 29) {
-        LOGS_DEFAULT(VERBOSE) << op_type << " dilations is only supported on Android API level 29+, "
-                              << "actual API level: " << android_sdk_ver;
-        return false;
-      }
-    }
-  } else {
-    LOGS_DEFAULT(VERBOSE) << "The weight of convolution must be known";
-    return false;
-  }
-
-  if (is_qlinear_conv) {
-    // For QLinearConv, we only support uint8 output now
-    int32_t output_type;
-    if (!GetType(*node.OutputDefs()[0], output_type))
-      return false;
-
-    if (output_type != ONNX_NAMESPACE::TensorProto_DataType_UINT8) {
-      LOGS_DEFAULT(VERBOSE) << "[" << op_type
-                            << "] output type: [" << output_type
-                            << "] is not supported for now";
-      return false;
-    }
-
-    if (input_defs.size() > 8 && !Contains(initializers, input_defs[8]->Name())) {
-      LOGS_DEFAULT(VERBOSE) << "Bias of QLinearConv must be known";
-      return false;
-    }
-
-    // a/b/y_scale
-    if (!HasValidQuantizationScale(model_builder.GetInitializerTensors(), node, {1, 4, 6}))
-      return false;
-
-    // a/b/y_zero_point
-    if (!HasValidQuantizationZeroPoint(model_builder.GetInitializerTensors(), node, {2, 5, 7}))
-      return false;
-  }
-
-  return true;
 }
 
 Status ConvOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
@@ -1741,29 +1296,8 @@ Status ConvOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
 
 class CastOpBuilder : public BaseOpBuilder {
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
-
-  int32_t GetMinSupportedSdkVer(ModelBuilder& /* model_builder */, const Node& /* node */) const override {
-    return 29;
-  }
-
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
-
-  // Cast opset 5- uses string attribute for to type, is not supported for now
-  int GetMinSupportedOpSet(const Node& /* node */) override { return 6; }
 };
-
-bool CastOpBuilder::IsOpSupportedImpl(ModelBuilder& /* model_builder */, const Node& node) {
-  NodeAttrHelper helper(node);
-  const auto to = helper.Get("to", 0);
-  if (to != ONNX_NAMESPACE::TensorProto::FLOAT &&
-      to != ONNX_NAMESPACE::TensorProto::INT32) {
-    LOGS_DEFAULT(VERBOSE) << "[Cast] Only support cast to int32 or float, actual to type, " << to;
-    return false;
-  }
-
-  return true;
-}
 
 Status CastOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
   auto& shaper(model_builder.GetShaper());
@@ -1802,41 +1336,8 @@ Status CastOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
 
 class SoftMaxOpBuilder : public BaseOpBuilder {
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
-
-  int32_t GetMinSupportedSdkVer(ModelBuilder& /* model_builder */, const Node& /* node */) const override {
-    return 28;
-  }
-
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
 };
-
-bool SoftMaxOpBuilder::IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) {
-  Shape input_shape;
-  if (!GetShape(*node.InputDefs()[0], input_shape))
-    return false;
-
-  const auto input_size = input_shape.size();
-  if (input_size != 2 && input_size != 4) {
-    LOGS_DEFAULT(VERBOSE) << "SoftMax only support 2d/4d shape, input is "
-                          << input_size << "d shape";
-    return false;
-  }
-
-  const auto android_sdk_ver = model_builder.GetAndroidSdkVer();
-  if (android_sdk_ver < 29) {
-    NodeAttrHelper helper(node);
-    int32_t axis = helper.Get("axis", 1);
-    if (axis != 1) {
-      LOGS_DEFAULT(VERBOSE)
-          << "SoftMax only support axis 1 on Android API level: " << android_sdk_ver
-          << " input axis: " << axis;
-      return false;
-    }
-  }
-
-  return true;
-}
 
 Status SoftMaxOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
   auto& shaper(model_builder.GetShaper());
@@ -1918,136 +1419,8 @@ class GemmOpBuilder : public BaseOpBuilder {
   void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) override;
 
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
-  bool HasSupportedInputs(const Node& node) override;
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
-  int GetMinSupportedOpSet(const Node& node) override;
 };
-
-bool GemmOpBuilder::HasSupportedInputs(const Node& node) {
-  if (node.OpType() != "QLinearMatMul")
-    return BaseOpBuilder::HasSupportedInputs(node);
-
-  // QLinearMatMul
-  if (!HasValidBinaryOpQuantizedInputs(node))
-    return false;
-
-  return true;
-}
-
-int GemmOpBuilder::GetMinSupportedOpSet(const Node& node) {
-  const auto& op(node.OpType());
-
-  // Gemm opset 6- has broadcast attributes we do not support now
-  if (op == "Gemm")
-    return 7;
-
-  return 1;
-}
-
-bool GemmOpBuilder::IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) {
-  const auto& op_type = node.OpType();
-  const auto input_defs(node.InputDefs());
-  const auto& initializers(model_builder.GetInitializerTensors());
-  size_t a_idx = 0, b_idx = 1, c_idx = 2;  // A*B+C
-  bool is_qlinear_matmul = op_type == "QLinearMatMul";
-  if (is_qlinear_matmul) {
-    a_idx = 0;
-    b_idx = 3;
-  }
-
-  Shape a_shape;
-  {
-    if (!GetShape(*input_defs[a_idx], a_shape))
-      return false;
-
-    if (a_shape.size() != 2) {
-      LOGS_DEFAULT(VERBOSE) << "A must be 2D";
-      return false;
-    }
-  }
-
-  Shape b_shape;
-  {
-    if (!GetShape(*input_defs[b_idx], b_shape))
-      return false;
-
-    if (b_shape.size() != 2) {
-      LOGS_DEFAULT(VERBOSE) << "B must be 2D";
-      return false;
-    }
-  }
-
-  if (op_type == "Gemm") {
-    // Only support
-    // 1. A*B'+C
-    // 2. A*B+C and B is an initializer
-    NodeAttrHelper helper(node);
-    const auto transA = helper.Get("transA", 0);
-    const auto transB = helper.Get("transB", 0);
-    const auto alpha = helper.Get("alpha", 1.0f);
-    const auto beta = helper.Get("beta", 1.0f);
-
-    if (!(transA == 0 && alpha == 1.f && beta == 1.f)) {
-      LOGS_DEFAULT(VERBOSE) << "Only transA == 0, alpha == 1.0 "
-                            << "and beta == 1.0 is supported.";
-      return false;
-    }
-
-    if (transB == 0 && !Contains(initializers, input_defs[b_idx]->Name())) {
-      LOGS_DEFAULT(VERBOSE) << "B of Gemm must be known if transB != 1";
-      return false;
-    }
-
-    if (input_defs.size() == 3) {
-      Shape c_shape;
-      if (!GetShape(*input_defs[c_idx], c_shape))
-        return false;
-
-      if (c_shape.size() != 1 ||
-          c_shape[0] != (transB == 0 ? b_shape[1] : b_shape[0])) {
-        LOGS_DEFAULT(VERBOSE) << "C of Gemm must be a vector of b_shape[0]"
-                              << " b_shape: " << Shape2String(b_shape)
-                              << " c_shape: " << Shape2String(c_shape);
-
-        return false;
-      }
-    }
-  } else if (op_type == "MatMul" || is_qlinear_matmul) {
-    // Only support A*B B is an initializer
-    if (!Contains(initializers, input_defs[b_idx]->Name())) {
-      LOGS_DEFAULT(VERBOSE) << "B of MatMul must be known";
-      return false;
-    }
-
-    if (is_qlinear_matmul) {
-      // For QLinearMatMul, we only support uint8 output now
-      int32_t output_type;
-      if (!GetType(*node.OutputDefs()[0], output_type))
-        return false;
-
-      if (output_type != ONNX_NAMESPACE::TensorProto_DataType_UINT8) {
-        LOGS_DEFAULT(VERBOSE) << "[" << op_type
-                              << "] output type: [" << output_type
-                              << "] is not supported for now";
-        return false;
-      }
-
-      // All scale/zero points are initializer scalars
-      // a/b/y_scale
-      if (!HasValidQuantizationScale(model_builder.GetInitializerTensors(), node, {1, 4, 6}))
-        return false;
-
-      // a/b/y_zero_point
-      if (!HasValidQuantizationZeroPoint(model_builder.GetInitializerTensors(), node, {2, 5, 7}))
-        return false;
-    }
-  } else {
-    LOGS_DEFAULT(VERBOSE) << "GemmOpBuilder, unknown op: " << op_type;
-  }
-
-  return true;
-}
 
 void GemmOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) {
   const auto& op = node.OpType();
@@ -2167,28 +1540,8 @@ Status GemmOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
 
 class UnaryOpBuilder : public BaseOpBuilder {
  private:
-  int32_t GetMinSupportedSdkVer(ModelBuilder& model_builder, const Node& node) const override;
-
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
-
-  // All ops except "Sin" opset 5- uses consumed_inputs attribute which is not supported for now
-  // "Sin" op has support from opset 7, return 6 here for all ops
-  int GetMinSupportedOpSet(const Node& /* node */) override { return 6; }
 };
-
-int32_t UnaryOpBuilder::GetMinSupportedSdkVer(ModelBuilder& /* model_builder */, const Node& node) const {
-  const auto& op(node.OpType());
-  if (op == "Abs" ||
-      op == "Exp" ||
-      op == "Neg" ||
-      op == "Sin" ||
-      op == "Sqrt" ||
-      op == "Log") {
-    return 29;
-  }
-
-  return 27;
-}
 
 Status UnaryOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
   auto& shaper(model_builder.GetShaper());
@@ -2238,25 +1591,8 @@ Status UnaryOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const 
 
 class ConcatOpBuilder : public BaseOpBuilder {
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
-
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
 };
-
-bool ConcatOpBuilder::IsOpSupportedImpl(ModelBuilder& /* model_builder */, const Node& node) {
-  Shape input_shape;
-  if (!GetShape(*node.InputDefs()[0], input_shape))
-    return false;
-
-  const auto input_size = input_shape.size();
-  if (input_size > 4 || input_size == 0) {
-    LOGS_DEFAULT(VERBOSE) << "Concat only supports up to 1-4d shape, input is "
-                          << input_size << "d shape";
-    return false;
-  }
-
-  return true;
-}
 
 Status ConcatOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
   auto& shaper(model_builder.GetShaper());
@@ -2328,33 +1664,8 @@ Status ConcatOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const
 
 class SqueezeOpBuilder : public BaseOpBuilder {
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
-
-  int32_t GetMinSupportedSdkVer(ModelBuilder& /* model_builder */, const Node& /* node */) const override {
-    return 28;
-  }
-
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
-
-  // Squeeze opset 13+ uses input for axes, which is not supported yet
-  // TODO add support for squeeze opset 13+
-  int GetMaxSupportedOpSet(const Node& /* node */) override { return 12; }
 };
-
-bool SqueezeOpBuilder::IsOpSupportedImpl(ModelBuilder& /* model_builder */, const Node& node) {
-  Shape input_shape;
-  if (!GetShape(*node.InputDefs()[0], input_shape))
-    return false;
-
-  const auto input_size = input_shape.size();
-  if (input_size > 4 || input_size == 0) {
-    LOGS_DEFAULT(VERBOSE) << "Squeeze only supports 1-4d shape, input is "
-                          << input_size << "d shape";
-    return false;
-  }
-
-  return true;
-}
 
 Status SqueezeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
   auto& shaper(model_builder.GetShaper());
@@ -2409,12 +1720,6 @@ class QuantizeLinearOpBuilder : public BaseOpBuilder {
   void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) override;
 
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
-
-  int32_t GetMinSupportedSdkVer(ModelBuilder& /* model_builder */, const Node& /* node */) const override {
-    return 27;
-  }
-
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
 };
 
@@ -2425,32 +1730,6 @@ void QuantizeLinearOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder,
 
   if (input_defs.size() == 3)  // has zero_point input
     model_builder.AddInitializerToSkip(input_defs[2]->Name());
-}
-
-bool QuantizeLinearOpBuilder::IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) {
-  const auto input_defs(node.InputDefs());
-  const auto output_defs(node.OutputDefs());
-
-  int32_t output_type;
-  if (!GetType(*output_defs[0], output_type))
-    return false;
-
-  if (output_type != ONNX_NAMESPACE::TensorProto_DataType_UINT8) {
-    LOGS_DEFAULT(VERBOSE) << "[" << node.OpType()
-                          << "] output type: [" << output_type
-                          << "] is not supported for now";
-    return false;
-  }
-
-  if (!HasValidQuantizationScale(model_builder.GetInitializerTensors(), node, {1}))
-    return false;
-
-  if (input_defs.size() == 3) {  // has zero_point input
-    if (!HasValidQuantizationZeroPoint(model_builder.GetInitializerTensors(), node, {2}))
-      return false;
-  }
-
-  return true;
 }
 
 Status QuantizeLinearOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
@@ -2488,30 +1767,8 @@ class DequantizeLinearOpBuilder : public BaseOpBuilder {
   void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) override;
 
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
-
-  int32_t GetMinSupportedSdkVer(ModelBuilder& /* model_builder */, const Node& /* node */) const override {
-    return 29;
-  }
-
-  bool HasSupportedInputs(const Node& node) override;
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
 };
-
-bool DequantizeLinearOpBuilder::HasSupportedInputs(const Node& node) {
-  int32_t input_type;
-  if (!GetType(*node.InputDefs()[0], input_type))
-    return false;
-
-  if (input_type != ONNX_NAMESPACE::TensorProto_DataType_UINT8) {
-    LOGS_DEFAULT(VERBOSE) << "[" << node.OpType()
-                          << "] Input type: [" << input_type
-                          << "] is not supported for now";
-    return false;
-  }
-
-  return true;
-}
 
 void DequantizeLinearOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) {
   const auto input_defs(node.InputDefs());
@@ -2520,20 +1777,6 @@ void DequantizeLinearOpBuilder::AddInitializersToSkip(ModelBuilder& model_builde
 
   if (input_defs.size() == 3)  // has zero_point input
     model_builder.AddInitializerToSkip(input_defs[2]->Name());
-}
-
-bool DequantizeLinearOpBuilder::IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) {
-  const auto input_defs(node.InputDefs());
-
-  if (!HasValidQuantizationScale(model_builder.GetInitializerTensors(), node, {1}))
-    return false;
-
-  if (input_defs.size() == 3) {  // has zero_point input
-    if (!HasValidQuantizationZeroPoint(model_builder.GetInitializerTensors(), node, {2}))
-      return false;
-  }
-
-  return true;
 }
 
 Status DequantizeLinearOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
@@ -2569,29 +1812,8 @@ Status DequantizeLinearOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_buil
 
 class LRNOpBuilder : public BaseOpBuilder {
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
-
-  int32_t GetMinSupportedSdkVer(ModelBuilder& /* model_builder */, const Node& /* node */) const override {
-    return 28;
-  }
-
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
 };
-
-bool LRNOpBuilder::IsOpSupportedImpl(ModelBuilder& /* model_builder */, const Node& node) {
-  Shape input_shape;
-  if (!GetShape(*node.InputDefs()[0], input_shape))
-    return false;
-
-  const auto input_size = input_shape.size();
-  if (input_size != 4) {
-    LOGS_DEFAULT(VERBOSE) << "LRN only support 4d shape, input is "
-                          << input_size << "d shape";
-    return false;
-  }
-
-  return true;
-}
 
 Status LRNOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
   auto& shaper(model_builder.GetShaper());
@@ -2651,7 +1873,6 @@ class ClipOpBuilder : public BaseOpBuilder {
   void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) override;
 
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
 };
 
@@ -2661,24 +1882,6 @@ void ClipOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Nod
 
   if (node.InputDefs().size() > 2)
     model_builder.AddInitializerToSkip(node.InputDefs()[2]->Name());  // max
-}
-
-bool ClipOpBuilder::IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) {
-  float min, max;
-  if (!GetClipMinMax(model_builder.GetInitializerTensors(), node, min, max))
-    return false;
-
-  // We only supoort relu6 or relu1
-  // TODO, support clip between 2 arbitrary numbers
-  if ((min == 0.0f && max == 6.0f) || (min == -1.0f && max == 1.0f)) {
-    return true;
-  } else {
-    LOGS_DEFAULT(VERBOSE) << "Clip only supports [min, max] = [0, 6] or [-1, 1], the input is ["
-                          << min << ", " << max << "]";
-    return false;
-  }
-
-  return true;
 }
 
 Status ClipOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
@@ -2727,20 +1930,8 @@ class ResizeOpBuilder : public BaseOpBuilder {
   void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) override;
 
  private:
-  bool IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) override;
-
-  int32_t GetMinSupportedSdkVer(ModelBuilder& model_builder, const Node& node) const override;
-
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
-
-  // Resize opset 10- is very different than Resize opset 11+, with many key attributes missing
-  // We only support Resize opset 11+ here
-  int GetMinSupportedOpSet(const Node& /* node */) override { return 11; }
 };
-
-int32_t ResizeOpBuilder::GetMinSupportedSdkVer(ModelBuilder& /* model_builder */, const Node& /* node */) const {
-  return 28;
-}
 
 void ResizeOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) {
   // We will still add scales to the skipped list even sizes are present
@@ -2749,95 +1940,6 @@ void ResizeOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const N
 
   if (node.InputDefs().size() > 3)
     model_builder.AddInitializerToSkip(node.InputDefs()[3]->Name());  // sizes
-}
-
-bool ResizeOpBuilder::IsOpSupportedImpl(ModelBuilder& model_builder, const Node& node) {
-  Shape input_shape;
-  if (!GetShape(*node.InputDefs()[0], input_shape))
-    return false;
-
-  const auto input_size = input_shape.size();
-  if (input_size != 4) {
-    LOGS_DEFAULT(VERBOSE) << "Resize only support 4d shape, input is "
-                          << input_size << "d shape";
-    return false;
-  }
-
-  {  // check attributes
-    const auto android_sdk_ver = model_builder.GetAndroidSdkVer();
-
-    NodeAttrHelper helper(node);
-    const auto mode = helper.Get("mode", "nearest");
-    if (mode != "linear") {
-      LOGS_DEFAULT(VERBOSE) << "Resize unsupported input mode, " << mode;
-      return false;
-    }
-
-    const auto coord_trans_mode = helper.Get("coordinate_transformation_mode", "half_pixel");
-    bool using_half_pixel = coord_trans_mode == "half_pixel";
-    bool using_align_corners = coord_trans_mode == "align_corners";
-    if (!using_half_pixel && !using_align_corners && coord_trans_mode != "asymmetric") {
-      LOGS_DEFAULT(VERBOSE) << "Resize, unsupported coord_trans_mode, " << coord_trans_mode;
-      return false;
-    }
-
-    if (android_sdk_ver < 30 && (using_half_pixel || using_align_corners)) {
-      LOGS_DEFAULT(VERBOSE) << "Resize only support half_pixel/align_corners on API level 30+, current API level is "
-                            << android_sdk_ver;
-      return false;
-    }
-
-    const auto exclude_outside = helper.Get("exclude_outside", 0);
-    if (exclude_outside != 0) {
-      LOGS_DEFAULT(VERBOSE) << "Resize does not support exclude_outside for now";
-      return false;
-    }
-  }
-
-  {  // scales and sizes (if present) must be initializers
-    const auto& initializers(model_builder.GetInitializerTensors());
-    const auto input_defs = node.InputDefs();
-    // scales
-    if (input_defs.size() < 3 || !Contains(initializers, input_defs[2]->Name())) {
-      LOGS_DEFAULT(VERBOSE) << "Input scales of Resize must be known";
-      return false;
-    }
-
-    // sizes
-    if (input_defs.size() > 3 && !Contains(initializers, input_defs[3]->Name())) {
-      LOGS_DEFAULT(VERBOSE) << "Input sizes of Resize must be known";
-      return false;
-    }
-
-    // We want to check if the scales or sizes are not trying to resize on N/C channels here
-    if (input_defs.size() == 3) {  // we are using scales
-      const auto& scales_tensor = initializers.at(input_defs[2]->Name());
-      const float* scales_data = GetTensorFloatData(scales_tensor);
-      float scale_n = scales_data[0];
-      float scale_c = scales_data[1];
-      if (scale_n != 1.0f || scale_c != 1.0f) {
-        LOGS_DEFAULT(VERBOSE) << "Scales of N/C channel should be 1"
-                              << "Resize of N/C channels are not supported"
-                              << ", scale_n, " << scale_n << ", scale_c, " << scale_c;
-        return false;
-      }
-    } else {
-      // we are using sizes
-      const auto& sizes_name = input_defs[3]->Name();
-      const auto& sizes_tensor = initializers.at(sizes_name);
-      const int64_t* sizes_data = GetTensorInt64Data(sizes_tensor);
-      uint32_t size_n = SafeInt<uint32_t>(sizes_data[0]);
-      uint32_t size_c = SafeInt<uint32_t>(sizes_data[1]);
-      if (size_n != input_shape[0] || size_c != input_shape[1]) {
-        LOGS_DEFAULT(VERBOSE) << "Output sizes of N/C chanel should match the input sizes, "
-                              << "Resize of N/C channels are not supported"
-                              << ", input_size_n, " << input_shape[0] << ", output_size_n, " << size_n
-                              << ". input_size_c, " << input_shape[1] << ", output_size_c, " << size_c;
-        return false;
-      }
-    }
-  }
-  return true;
 }
 
 Status ResizeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {
@@ -2919,7 +2021,6 @@ Status ResizeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const
 
 class FlattenOpBuilder : public BaseOpBuilder {
  private:
-  bool IsOpSupportedImpl(ModelBuilder& /* model_builder */, const Node& node) override;
   static void GetFlattenShape(const Node& node, const Shape& input_shape, int32_t& dim_1, int32_t& dim_2);
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) override ORT_MUST_USE_RESULT;
 };
@@ -2935,30 +2036,6 @@ class FlattenOpBuilder : public BaseOpBuilder {
 
   dim_1 = std::accumulate(input_shape.cbegin(), input_shape.cbegin() + axis, 1, std::multiplies<int32_t>());
   dim_2 = std::accumulate(input_shape.cbegin() + axis, input_shape.cend(), 1, std::multiplies<int32_t>());
-}
-
-bool FlattenOpBuilder::IsOpSupportedImpl(ModelBuilder& /* model_builder */, const Node& node) {
-  Shape input_shape;
-  if (!GetShape(*node.InputDefs()[0], input_shape))
-    return false;
-
-  if (input_shape.size() > 4 || input_shape.empty()) {
-    LOGS_DEFAULT(VERBOSE) << "Flatten only supports up to 1-4d shape, input is "
-                          << input_shape.size() << "d shape";
-    return false;
-  }
-
-  int32_t dim_1 = 1;
-  int32_t dim_2 = 1;
-  GetFlattenShape(node, input_shape, dim_1, dim_2);
-
-  if (dim_1 == 0 && dim_2 == 0) {
-    LOGS_DEFAULT(VERBOSE) << "The dynamical input shape " << Shape2String(input_shape)
-                          << " is not supported";
-    return false;
-  }
-
-  return true;
 }
 
 Status FlattenOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node) {

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.h
@@ -36,9 +36,5 @@ Status GetQuantizedInputScaleAndZeroPoint(const ModelBuilder& model_builder,
                                           const Node& node, const std::string& input_name,
                                           float& scale, int32_t& zero_point) ORT_MUST_USE_RESULT;
 
-// Get the min/max value from Clip op
-// If the min/max are inputs be not initializers (value not preset), will return false
-bool GetClipMinMax(const ModelBuilder& model_builder, const Node& node, float& min, float& max);
-
 }  // namespace nnapi
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.h
@@ -20,8 +20,9 @@ class IOpBuilder {
   virtual Status AddToModelBuilder(ModelBuilder& model_builder, const Node& node) ORT_MUST_USE_RESULT = 0;
 };
 
-// Generate a lookup table with IOpBuilder delegates
-// for different onnx operators
+// Generate a lookup table with IOpBuilder delegates for different onnx operators
+// Note, the lookup table should have same number of entries as the result of CreateOpSupportCheckers()
+// in op_support_checker.h
 std::unordered_map<std::string, std::shared_ptr<IOpBuilder>> CreateOpBuilders();
 
 // Transpose the NHWC input to NCHW output

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.h
@@ -12,9 +12,6 @@ class IOpBuilder {
  public:
   virtual ~IOpBuilder() = default;
 
-  // Check if an operator is supported
-  virtual bool IsOpSupported(ModelBuilder& model_builder, const Node& node) = 0;
-
   // Check if the initializers of this operator need preprocess
   // which will not be copied
   virtual void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) = 0;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.h
@@ -14,10 +14,10 @@ class IOpBuilder {
 
   // Check if the initializers of this operator need preprocess
   // which will not be copied
-  virtual void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) = 0;
+  virtual void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) const = 0;
 
   // Add the operator to NNAPI model
-  virtual Status AddToModelBuilder(ModelBuilder& model_builder, const Node& node) ORT_MUST_USE_RESULT = 0;
+  virtual Status AddToModelBuilder(ModelBuilder& model_builder, const Node& node) const ORT_MUST_USE_RESULT = 0;
 };
 
 // Generate a lookup table with IOpBuilder delegates for different onnx operators

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -47,7 +47,9 @@ class BaseOPSupportChecker : public IOPSupportChecker {
 
  protected:
   virtual bool IsOpSupportedImpl(const InitializerMap& /* initializers */, const Node& /* node */,
-                                 const OPSupportCheckParams& /* params */) { return true; }
+                                 const OPSupportCheckParams& /* params */) {
+    return true;
+  }
   virtual int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const {
     return 27;
   }
@@ -424,7 +426,8 @@ bool PoolOPSupportChecker::IsOpSupportedImpl(
 
 class ConvOPSupportChecker : public BaseOPSupportChecker {
  private:
-  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node,
+                         const OPSupportCheckParams& params) override;
 
   int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& params) const override {
     return params.use_nchw ? 29 : 28;
@@ -517,6 +520,10 @@ class CastOPSupportChecker : public BaseOPSupportChecker {
  private:
   bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
 
+  int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const override {
+    return 29;
+  }
+
   // Cast opset 5- uses string attribute for to type, is not supported for now
   int GetMinSupportedOpSet(const Node& /* node */) override { return 6; }
 };
@@ -539,7 +546,8 @@ bool CastOPSupportChecker::IsOpSupportedImpl(const InitializerMap& /* initialize
 
 class SoftMaxOPSupportChecker : public BaseOPSupportChecker {
  private:
-  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node,
+                         const OPSupportCheckParams& params) override;
 
   int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const override {
     return 28;
@@ -766,8 +774,9 @@ bool ConcatOPSupportChecker::IsOpSupportedImpl(const InitializerMap& /* initiali
 
 class SqueezeOPSupportChecker : public BaseOPSupportChecker {
  private:
-  bool IsOpSupportedImpl(
-      const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node,
+                         const OPSupportCheckParams& params) override;
+
   int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const override {
     return 28;
   }
@@ -798,8 +807,9 @@ bool SqueezeOPSupportChecker::IsOpSupportedImpl(const InitializerMap& /* initial
 
 class QuantizeLinearOPSupportChecker : public BaseOPSupportChecker {
  private:
-  bool IsOpSupportedImpl(
-      const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node,
+                         const OPSupportCheckParams& params) override;
+
   int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const override {
     return 27;
   }
@@ -838,8 +848,9 @@ bool QuantizeLinearOPSupportChecker::IsOpSupportedImpl(
 
 class DequantizeLinearOPSupportChecker : public BaseOPSupportChecker {
  private:
-  bool IsOpSupportedImpl(
-      const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node,
+                         const OPSupportCheckParams& params) override;
+
   int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const override {
     return 29;
   }
@@ -881,8 +892,9 @@ bool DequantizeLinearOPSupportChecker::HasSupportedInputs(const Node& node) {
 
 class LRNOPSupportChecker : public BaseOPSupportChecker {
  private:
-  bool IsOpSupportedImpl(
-      const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node,
+                         const OPSupportCheckParams& params) override;
+
   int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const override {
     return 28;
   }
@@ -937,8 +949,9 @@ bool ClipOPSupportChecker::IsOpSupportedImpl(
 
 class ResizeOPSupportChecker : public BaseOPSupportChecker {
  private:
-  bool IsOpSupportedImpl(
-      const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node,
+                         const OPSupportCheckParams& params) override;
+
   int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const override {
     return 28;
   }
@@ -1083,6 +1096,8 @@ bool FlattenOPSupportChecker::IsOpSupportedImpl(const InitializerMap& /* initial
 
 #pragma endregion
 
+#pragma region CreateOpSupportCheckers
+
 std::unordered_map<std::string, std::shared_ptr<IOPSupportChecker>> CreateOpSupportCheckers() {
   std::unordered_map<std::string, std::shared_ptr<IOPSupportChecker>> op_map;
 
@@ -1153,6 +1168,8 @@ std::unordered_map<std::string, std::shared_ptr<IOPSupportChecker>> CreateOpSupp
 
   return op_map;
 }
+
+#pragma endregion
 
 }  // namespace nnapi
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -201,11 +201,11 @@ bool BinaryOPSupportChecker::IsOpSupportedImpl(
 
     // All scale/zero points are initializer scalars
     // a/b/y_scale
-    if (!HasValidQuantizationScale(initializers, node, {1, 4, 6}))
+    if (!HasValidQuantizationScales(initializers, node, {1, 4, 6}))
       return false;
 
     // a/b/y_zero_point
-    if (!HasValidQuantizationZeroPoint(initializers, node, {2, 5, 7}))
+    if (!HasValidQuantizationZeroPoints(initializers, node, {2, 5, 7}))
       return false;
   }
 
@@ -501,11 +501,11 @@ bool ConvOPSupportChecker::IsOpSupportedImpl(const InitializerMap& initializers,
     }
 
     // a/b/y_scale
-    if (!HasValidQuantizationScale(initializers, node, {1, 4, 6}))
+    if (!HasValidQuantizationScales(initializers, node, {1, 4, 6}))
       return false;
 
     // a/b/y_zero_point
-    if (!HasValidQuantizationZeroPoint(initializers, node, {2, 5, 7}))
+    if (!HasValidQuantizationZeroPoints(initializers, node, {2, 5, 7}))
       return false;
   }
 
@@ -702,11 +702,11 @@ bool GemmOPSupportChecker::IsOpSupportedImpl(const InitializerMap& initializers,
 
       // All scale/zero points are initializer scalars
       // a/b/y_scale
-      if (!HasValidQuantizationScale(initializers, node, {1, 4, 6}))
+      if (!HasValidQuantizationScales(initializers, node, {1, 4, 6}))
         return false;
 
       // a/b/y_zero_point
-      if (!HasValidQuantizationZeroPoint(initializers, node, {2, 5, 7}))
+      if (!HasValidQuantizationZeroPoints(initializers, node, {2, 5, 7}))
         return false;
     }
   } else {
@@ -831,11 +831,11 @@ bool QuantizeLinearOPSupportChecker::IsOpSupportedImpl(
     return false;
   }
 
-  if (!HasValidQuantizationScale(initializers, node, {1}))
+  if (!HasValidQuantizationScales(initializers, node, {1}))
     return false;
 
   if (input_defs.size() == 3) {  // has zero_point input
-    if (!HasValidQuantizationZeroPoint(initializers, node, {2}))
+    if (!HasValidQuantizationZeroPoints(initializers, node, {2}))
       return false;
   }
 
@@ -860,11 +860,11 @@ class DequantizeLinearOPSupportChecker : public BaseOPSupportChecker {
 bool DequantizeLinearOPSupportChecker::IsOpSupportedImpl(
     const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& /* params */) {
   const auto input_defs(node.InputDefs());
-  if (!HasValidQuantizationScale(initializers, node, {1}))
+  if (!HasValidQuantizationScales(initializers, node, {1}))
     return false;
 
   if (input_defs.size() == 3) {  // has zero_point input
-    if (!HasValidQuantizationZeroPoint(initializers, node, {2}))
+    if (!HasValidQuantizationZeroPoints(initializers, node, {2}))
       return false;
   }
 
@@ -1086,7 +1086,7 @@ bool FlattenOPSupportChecker::IsOpSupportedImpl(const InitializerMap& /* initial
   GetFlattenShape(node, input_shape, dim_1, dim_2);
 
   if (dim_1 == 0 && dim_2 == 0) {
-    LOGS_DEFAULT(VERBOSE) << "The dynamical input shape "  // TODO enable this << Shape2String(input_shape)
+    LOGS_DEFAULT(VERBOSE) << "The dynamical input shape " << Shape2String(input_shape)
                           << " is not supported";
     return false;
   }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -1,0 +1,1158 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <core/common/logging/logging.h>
+#include <core/common/safeint.h>
+#include <core/providers/common.h>
+
+#include <core/graph/graph.h>
+
+#include "helper.h"
+#include "op_support_checker.h"
+
+namespace onnxruntime {
+namespace nnapi {
+
+using std::vector;
+
+#pragma region helpers
+
+bool HasExternalInitializer(const InitializerMap& initializers, const Node& node) {
+  for (const auto* node_arg : node.InputDefs()) {
+    const auto& input_name(node_arg->Name());
+    if (!Contains(initializers, input_name))
+      continue;
+
+    const auto& tensor = initializers.at(input_name);
+    if (tensor.has_data_location() &&
+        tensor.data_location() == ONNX_NAMESPACE::TensorProto_DataLocation_EXTERNAL) {
+      LOGS_DEFAULT(VERBOSE) << "Initializer [" << input_name
+                            << "] with external data location are not currently supported";
+      return true;
+    }
+  }
+
+  return false;
+}
+
+#pragma endregion helpers
+
+#pragma region op_base
+
+class BaseOPSupportChecker : public IOPSupportChecker {
+ public:
+  virtual ~BaseOPSupportChecker() = default;
+  bool IsOpSupported(const InitializerMap& initializers, const Node& node,
+                     const OPSupportCheckParams& params) override;
+
+ protected:
+  virtual bool IsOpSupportedImpl(const InitializerMap& /* initializers */, const Node& /* node */,
+                                 const OPSupportCheckParams& /* params */) { return true; }
+  virtual int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const {
+    return 27;
+  }
+
+  virtual bool HasSupportedInputs(const Node& node);
+
+  virtual int GetMinSupportedOpSet(const Node& /* node */) { return 1; }
+  virtual int GetMaxSupportedOpSet(const Node& /* node */) { return 13; }
+  bool HasSupportedOpSet(const Node& node);
+};
+
+bool BaseOPSupportChecker::IsOpSupported(const InitializerMap& initializers, const Node& node,
+                                         const OPSupportCheckParams& params) {
+  int32_t required_sdk_ver = GetMinSupportedSdkVer(node, params);
+  if (required_sdk_ver > params.android_sdk_ver) {
+    LOGS_DEFAULT(VERBOSE) << "Current Android API level [" << params.android_sdk_ver
+                          << "], Operator [" << node.OpType()
+                          << "] is only supported on API >" << required_sdk_ver;
+    return false;
+  }
+
+  if (!HasSupportedInputs(node))
+    return false;
+
+  // We do not support external initializers for now
+  if (HasExternalInitializer(initializers, node))
+    return false;
+
+  if (!HasSupportedOpSet(node))
+    return false;
+
+  return IsOpSupportedImpl(initializers, node, params);
+}
+
+bool BaseOPSupportChecker::HasSupportedInputs(const Node& node) {
+  // We only check the type of input 0 by default
+  // specific op builder can override this
+  const auto& input = *node.InputDefs()[0];
+
+  if (nullptr == input.Shape()) {
+    LOGS_DEFAULT(VERBOSE) << "[" << node.OpType()
+                          << "] Input shape is null";
+    return false;
+  }
+
+  int32_t input_type;
+  if (!GetType(input, input_type))
+    return false;
+
+  if (input_type != ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
+    LOGS_DEFAULT(VERBOSE) << "[" << node.OpType()
+                          << "] Input type: [" << input_type
+                          << "] is not supported for now";
+    return false;
+  }
+
+  return true;
+}
+
+bool BaseOPSupportChecker::HasSupportedOpSet(const Node& node) {
+  auto since_version = node.SinceVersion();
+  if (since_version < GetMinSupportedOpSet(node) || since_version > GetMaxSupportedOpSet(node)) {
+    LOGS_DEFAULT(VERBOSE) << node.OpType() << "is only supported for opset ["
+                          << GetMinSupportedOpSet(node) << ", "
+                          << GetMaxSupportedOpSet(node) << "]";
+    return false;
+  }
+
+  return true;
+}
+
+#pragma endregion op_base
+
+#pragma region op_binary
+
+class BinaryOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  int32_t GetMinSupportedSdkVer(const Node& node, const OPSupportCheckParams& params) const override;
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  bool HasSupportedInputs(const Node& node) override;
+  int GetMinSupportedOpSet(const Node& node) override;
+};
+
+int32_t BinaryOPSupportChecker::GetMinSupportedSdkVer(
+    const Node& node, const OPSupportCheckParams& /* params */) const {
+  const auto& op(node.OpType());
+  if (op == "Sub" || op == "Div") {
+    return 28;
+  }
+  return 27;
+}
+
+int BinaryOPSupportChecker::GetMinSupportedOpSet(const Node& node) {
+  const auto& op(node.OpType());
+
+  // Add/Sub/Mul/Div opset 6- has broadcast attributes we do not support now
+  if (op != "QLinearAdd")
+    return 7;
+
+  return 1;
+}
+
+bool BinaryOPSupportChecker::HasSupportedInputs(const Node& node) {
+  if (node.OpType() != "QLinearAdd")
+    return BaseOPSupportChecker::HasSupportedInputs(node);
+
+  // QLinearAdd
+  if (!HasValidBinaryOpQuantizedInputs(node))
+    return false;
+
+  return true;
+}
+
+bool BinaryOPSupportChecker::IsOpSupportedImpl(
+    const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& /* params */) {
+  const auto& op_type(node.OpType());
+  const auto input_defs(node.InputDefs());
+  bool op_is_qlinear = op_type == "QLinearAdd";
+  size_t a_idx = 0, b_idx = 1;
+  if (op_is_qlinear) {
+    b_idx = 3;
+  }
+  Shape input1_shape, input2_shape;
+  if (!GetShape(*input_defs[a_idx], input1_shape) ||
+      !GetShape(*input_defs[b_idx], input2_shape))
+    return false;
+
+  const auto input1_size = input1_shape.size();
+  const auto input2_size = input2_shape.size();
+  if (input1_size > 4 || input2_size > 4) {
+    LOGS_DEFAULT(VERBOSE) << node.OpType() << " only support up to 4d shape, input1 is "
+                          << input1_size << "d shape, input 2 is "
+                          << input2_size << "d shape";
+    return false;
+  }
+
+  if (op_is_qlinear) {
+    // For QLinearAdd, we only support uint8 output now
+    int32_t output_type;
+    if (!GetType(*node.OutputDefs()[0], output_type))
+      return false;
+
+    if (output_type != ONNX_NAMESPACE::TensorProto_DataType_UINT8) {
+      LOGS_DEFAULT(VERBOSE) << "[" << op_type
+                            << "] output type: [" << output_type
+                            << "] is not supported for now";
+      return false;
+    }
+
+    // All scale/zero points are initializer scalars
+    // a/b/y_scale
+    if (!HasValidQuantizationScale(initializers, node, {1, 4, 6}))
+      return false;
+
+    // a/b/y_zero_point
+    if (!HasValidQuantizationZeroPoint(initializers, node, {2, 5, 7}))
+      return false;
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_transpose
+
+class TransposeOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(
+      const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+
+  int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const override {
+    return 28;
+  }
+};
+
+bool TransposeOPSupportChecker::IsOpSupportedImpl(const InitializerMap& /* initializers */, const Node& node, const OPSupportCheckParams& /* params */) {
+  Shape input_shape;
+  if (!GetShape(*node.InputDefs()[0], input_shape))
+    return false;
+
+  const auto input_size = input_shape.size();
+  if (input_size > 4 || input_size == 0) {
+    LOGS_DEFAULT(VERBOSE) << "Transpose only supports 1-4d shape, input is "
+                          << input_size << "d shape";
+    return false;
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_reshape
+
+class ReshapeOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+
+  // Reshape opset 4- uses attributes for new shape which we do not support for now
+  int GetMinSupportedOpSet(const Node& /* node */) override { return 5; }
+};
+
+bool ReshapeOPSupportChecker::IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& /* params */) {
+  const auto& perm_name = node.InputDefs()[1]->Name();
+  if (!Contains(initializers, perm_name)) {
+    LOGS_DEFAULT(VERBOSE) << "New shape of reshape must be known";
+    return false;
+  }
+
+  Shape input_shape;
+  if (!GetShape(*node.InputDefs()[0], input_shape))
+    return false;
+
+  if (input_shape.size() > 4 || input_shape.empty()) {
+    LOGS_DEFAULT(VERBOSE) << "Reshape only supports up to 1-4d shape, input is "
+                          << input_shape.size() << "d shape";
+    return false;
+  }
+
+  const auto& shape_tensor = initializers.at(perm_name);
+  const int64_t* rawShape = GetTensorInt64Data(shape_tensor);
+  const auto size = SafeInt<uint32_t>(shape_tensor.dims()[0]);
+
+  for (uint32_t i = 0; i < size; i++) {
+    // NNAPI reshape does not support 0 as dimension
+    if (rawShape[i] == 0 && i < input_shape.size() && input_shape[i] == 0) {
+      LOGS_DEFAULT(VERBOSE) << "Reshape doesn't suppport 0 reshape dimension on a dynamic dimension";
+      return false;
+    }
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_batchnormalization
+
+class BatchNormalizationOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+
+  // BatchNormalization opset 6- has unsupported attributes
+  int GetMinSupportedOpSet(const Node& /* node */) override { return 7; }
+};
+
+bool BatchNormalizationOPSupportChecker::IsOpSupportedImpl(
+    const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& /* params */) {
+  if (node.OutputDefs().size() != 1) {
+    LOGS_DEFAULT(VERBOSE) << "Your onnx model may be in training mode, please export "
+                             "it in test mode.";
+    return false;
+  }
+
+  const auto& input_defs = node.InputDefs();
+  Shape input_shape;
+  if (!GetShape(*input_defs[0], input_shape))
+    return false;
+
+  const auto input_size = input_shape.size();
+  if (input_size > 4) {
+    LOGS_DEFAULT(VERBOSE) << "BN only support up to 4d shape, input is "
+                          << input_size << "d shape";
+    return false;
+  }
+
+  NodeAttrHelper helper(node);
+  const auto spatial = helper.Get("spatial", 1);
+  if (spatial != 1) {
+    LOGS_DEFAULT(VERBOSE) << "Non-spatial BN is not supported";
+    return false;
+  }
+
+  const auto& scale_name = input_defs[1]->Name();
+  const auto& b_name = input_defs[2]->Name();
+  const auto& mean_name = input_defs[3]->Name();
+  const auto& var_name = input_defs[4]->Name();
+  if (!Contains(initializers, scale_name)) {
+    LOGS_DEFAULT(VERBOSE) << "Scale of BN must be known";
+    return false;
+  }
+  if (!Contains(initializers, b_name)) {
+    LOGS_DEFAULT(VERBOSE) << "B of BN must be known";
+    return false;
+  }
+  if (!Contains(initializers, mean_name)) {
+    LOGS_DEFAULT(VERBOSE) << "Mean of BN must be known";
+    return false;
+  }
+  if (!Contains(initializers, var_name)) {
+    LOGS_DEFAULT(VERBOSE) << "Var of BN must be known";
+    return false;
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_pool
+
+class PoolOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(
+      const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+
+  int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& params) const override {
+    return params.use_nchw ? 29 : 28;
+  }
+};
+
+bool PoolOPSupportChecker::IsOpSupportedImpl(
+    const InitializerMap& /* initializers */, const Node& node, const OPSupportCheckParams& /* params */) {
+  const auto& op_type = node.OpType();
+  Shape input_shape;
+  if (!GetShape(*node.InputDefs()[0], input_shape))
+    return false;
+
+  const auto input_size = input_shape.size();
+  if (input_size != 4) {
+    LOGS_DEFAULT(VERBOSE)
+        << op_type << " only supports rank-4 tensor, input ["
+        << node.InputDefs()[0]->Name() << "] has actual dim count " << input_size;
+    return false;
+  }
+
+  if (op_type == "AveragePool" || op_type == "MaxPool") {
+    NodeAttrHelper helper(node);
+
+    const auto count_include_pad = helper.Get("count_include_pad", 0);
+    if (count_include_pad == 1) {
+      LOGS_DEFAULT(VERBOSE) << "count_include_pad == 1 is not supported";
+      return false;
+    }
+
+    const auto storage_order = helper.Get("storage_order", 0);
+    if (storage_order == 1) {
+      LOGS_DEFAULT(VERBOSE) << "storage_order == 1 is not supported";
+      return false;
+    }
+
+    if (helper.Get("kernel_shape", std::vector<int32_t>{1, 1}).size() != 2) {
+      LOGS_DEFAULT(VERBOSE) << "Only pooling 2d is supported";
+      return false;
+    }
+
+    if (helper.Get("ceil_mode", 0) == 1) {
+      LOGS_DEFAULT(VERBOSE) << "ceil_mode == 1 is not supported for pooling";
+      return false;
+    }
+
+    if (helper.Get("dilations", std::vector<int32_t>{1, 1}) !=
+        std::vector<int32_t>{1, 1}) {
+      LOGS_DEFAULT(VERBOSE) << "Dilations of pooling is not supported";
+      return false;
+    }
+
+    if (node.OutputDefs().size() != 1) {
+      LOGS_DEFAULT(VERBOSE) << "Argmax in maxpooling is not supported";
+      return false;
+    }
+  } else if (op_type != "GlobalAveragePool" && op_type != "GlobalMaxPool") {
+    LOGS_DEFAULT(VERBOSE) << "PoolOpBuilder, unknown op: " << op_type;
+    return false;
+  }
+
+  return true;
+}
+
+#pragma endregion op_pool
+
+#pragma region op_conv
+
+class ConvOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+
+  int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& params) const override {
+    return params.use_nchw ? 29 : 28;
+  }
+
+  bool HasSupportedInputs(const Node& node) override;
+};
+
+bool ConvOPSupportChecker::HasSupportedInputs(const Node& node) {
+  if (node.OpType() != "QLinearConv")
+    return BaseOPSupportChecker::HasSupportedInputs(node);
+
+  // QLinearConv only supports input of uint8 for now
+  if (!HasValidBinaryOpQuantizedInputs(node))
+    return false;
+
+  return true;
+}
+
+bool ConvOPSupportChecker::IsOpSupportedImpl(const InitializerMap& initializers, const Node& node,
+                                             const OPSupportCheckParams& params) {
+  const auto& op_type = node.OpType();
+  const auto input_defs = node.InputDefs();
+  NodeAttrHelper helper(node);
+
+  bool is_qlinear_conv = (op_type == "QLinearConv");
+  size_t w_idx = is_qlinear_conv ? 3 : 1;
+  const auto group = helper.Get("group", 1);
+  const auto weight_name = input_defs[w_idx]->Name();
+  if (Contains(initializers, weight_name)) {
+    const auto& tensor = initializers.at(weight_name);
+    if (tensor.dims().size() != 4) {
+      LOGS_DEFAULT(VERBOSE) << "Only conv 2d is supported.";
+      return false;
+    }
+
+    const auto onnx_dilations = helper.Get("dilations", vector<int>{1, 1});
+    if (onnx_dilations != vector<int>{1, 1}) {
+      if (group != 1 && tensor.dims()[1] != 1) {
+        LOGS_DEFAULT(VERBOSE) << "dilation is not supported on grouped conv";
+        return false;
+      }
+
+      if (params.android_sdk_ver < 29) {
+        LOGS_DEFAULT(VERBOSE) << op_type << " dilations is only supported on Android API level 29+, "
+                              << "actual API level: " << params.android_sdk_ver;
+        return false;
+      }
+    }
+  } else {
+    LOGS_DEFAULT(VERBOSE) << "The weight of convolution must be known";
+    return false;
+  }
+
+  if (is_qlinear_conv) {
+    // For QLinearConv, we only support uint8 output now
+    int32_t output_type;
+    if (!GetType(*node.OutputDefs()[0], output_type))
+      return false;
+
+    if (output_type != ONNX_NAMESPACE::TensorProto_DataType_UINT8) {
+      LOGS_DEFAULT(VERBOSE) << "[" << op_type
+                            << "] output type: [" << output_type
+                            << "] is not supported for now";
+      return false;
+    }
+
+    if (input_defs.size() > 8 && !Contains(initializers, input_defs[8]->Name())) {
+      LOGS_DEFAULT(VERBOSE) << "Bias of QLinearConv must be known";
+      return false;
+    }
+
+    // a/b/y_scale
+    if (!HasValidQuantizationScale(initializers, node, {1, 4, 6}))
+      return false;
+
+    // a/b/y_zero_point
+    if (!HasValidQuantizationZeroPoint(initializers, node, {2, 5, 7}))
+      return false;
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_cast
+
+class CastOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+
+  // Cast opset 5- uses string attribute for to type, is not supported for now
+  int GetMinSupportedOpSet(const Node& /* node */) override { return 6; }
+};
+
+bool CastOPSupportChecker::IsOpSupportedImpl(const InitializerMap& /* initializers */, const Node& node, const OPSupportCheckParams& /* params */) {
+  NodeAttrHelper helper(node);
+  const auto to = helper.Get("to", 0);
+  if (to != ONNX_NAMESPACE::TensorProto::FLOAT &&
+      to != ONNX_NAMESPACE::TensorProto::INT32) {
+    LOGS_DEFAULT(VERBOSE) << "[Cast] Only support cast to int32 or float, actual to type, " << to;
+    return false;
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_softmax
+
+class SoftMaxOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+
+  int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const override {
+    return 28;
+  }
+};
+
+bool SoftMaxOPSupportChecker::IsOpSupportedImpl(const InitializerMap& /* initializers */, const Node& node, const OPSupportCheckParams& params) {
+  Shape input_shape;
+  if (!GetShape(*node.InputDefs()[0], input_shape))
+    return false;
+
+  const auto input_size = input_shape.size();
+  if (input_size != 2 && input_size != 4) {
+    LOGS_DEFAULT(VERBOSE) << "SoftMax only support 2d/4d shape, input is "
+                          << input_size << "d shape";
+    return false;
+  }
+
+  if (params.android_sdk_ver < 29) {
+    NodeAttrHelper helper(node);
+    int32_t axis = helper.Get("axis", 1);
+    if (axis != 1) {
+      LOGS_DEFAULT(VERBOSE)
+          << "SoftMax only support axis 1 on Android API level: " << params.android_sdk_ver
+          << " input axis: " << axis;
+      return false;
+    }
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_gemm
+
+class GemmOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  bool HasSupportedInputs(const Node& node) override;
+  int GetMinSupportedOpSet(const Node& node) override;
+};
+
+bool GemmOPSupportChecker::HasSupportedInputs(const Node& node) {
+  if (node.OpType() != "QLinearMatMul")
+    return BaseOPSupportChecker::HasSupportedInputs(node);
+
+  // QLinearMatMul
+  if (!HasValidBinaryOpQuantizedInputs(node))
+    return false;
+
+  return true;
+}
+
+int GemmOPSupportChecker::GetMinSupportedOpSet(const Node& node) {
+  const auto& op(node.OpType());
+
+  // Gemm opset 6- has broadcast attributes we do not support now
+  if (op == "Gemm")
+    return 7;
+
+  return 1;
+}
+
+bool GemmOPSupportChecker::IsOpSupportedImpl(const InitializerMap& initializers,
+                                             const Node& node, const OPSupportCheckParams& /* params */) {
+  const auto& op_type = node.OpType();
+  const auto input_defs(node.InputDefs());
+  size_t a_idx = 0, b_idx = 1, c_idx = 2;  // A*B+C
+  bool is_qlinear_matmul = op_type == "QLinearMatMul";
+  if (is_qlinear_matmul) {
+    a_idx = 0;
+    b_idx = 3;
+  }
+
+  Shape a_shape;
+  {
+    if (!GetShape(*input_defs[a_idx], a_shape))
+      return false;
+
+    if (a_shape.size() != 2) {
+      LOGS_DEFAULT(VERBOSE) << "A must be 2D";
+      return false;
+    }
+  }
+
+  Shape b_shape;
+  {
+    if (!GetShape(*input_defs[b_idx], b_shape))
+      return false;
+
+    if (b_shape.size() != 2) {
+      LOGS_DEFAULT(VERBOSE) << "B must be 2D";
+      return false;
+    }
+  }
+
+  if (op_type == "Gemm") {
+    // Only support
+    // 1. A*B'+C
+    // 2. A*B+C and B is an initializer
+    NodeAttrHelper helper(node);
+    const auto transA = helper.Get("transA", 0);
+    const auto transB = helper.Get("transB", 0);
+    const auto alpha = helper.Get("alpha", 1.0f);
+    const auto beta = helper.Get("beta", 1.0f);
+
+    if (!(transA == 0 && alpha == 1.f && beta == 1.f)) {
+      LOGS_DEFAULT(VERBOSE) << "Only transA == 0, alpha == 1.0 "
+                            << "and beta == 1.0 is supported.";
+      return false;
+    }
+
+    if (transB == 0 && !Contains(initializers, input_defs[b_idx]->Name())) {
+      LOGS_DEFAULT(VERBOSE) << "B of Gemm must be known if transB != 1";
+      return false;
+    }
+
+    if (input_defs.size() == 3) {
+      Shape c_shape;
+      if (!GetShape(*input_defs[c_idx], c_shape))
+        return false;
+
+      if (c_shape.size() != 1 ||
+          c_shape[0] != (transB == 0 ? b_shape[1] : b_shape[0])) {
+        LOGS_DEFAULT(VERBOSE) << "C of Gemm must be a vector of b_shape[0]"
+                              << " b_shape: " << Shape2String(b_shape)
+                              << " c_shape: " << Shape2String(c_shape);
+
+        return false;
+      }
+    }
+  } else if (op_type == "MatMul" || is_qlinear_matmul) {
+    // Only support A*B B is an initializer
+    if (!Contains(initializers, input_defs[b_idx]->Name())) {
+      LOGS_DEFAULT(VERBOSE) << "B of MatMul must be known";
+      return false;
+    }
+
+    if (is_qlinear_matmul) {
+      // For QLinearMatMul, we only support uint8 output now
+      int32_t output_type;
+      if (!GetType(*node.OutputDefs()[0], output_type))
+        return false;
+
+      if (output_type != ONNX_NAMESPACE::TensorProto_DataType_UINT8) {
+        LOGS_DEFAULT(VERBOSE) << "[" << op_type
+                              << "] output type: [" << output_type
+                              << "] is not supported for now";
+        return false;
+      }
+
+      // All scale/zero points are initializer scalars
+      // a/b/y_scale
+      if (!HasValidQuantizationScale(initializers, node, {1, 4, 6}))
+        return false;
+
+      // a/b/y_zero_point
+      if (!HasValidQuantizationZeroPoint(initializers, node, {2, 5, 7}))
+        return false;
+    }
+  } else {
+    LOGS_DEFAULT(VERBOSE) << "GemmOPSupportChecker, unknown op: " << op_type;
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_unary
+
+class UnaryOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  int32_t GetMinSupportedSdkVer(const Node& node, const OPSupportCheckParams& params) const override;
+
+  // All ops except "Sin" opset 5- uses consumed_inputs attribute which is not supported for now
+  // "Sin" op has support from opset 7, return 6 here for all ops
+  int GetMinSupportedOpSet(const Node& /* node */) override { return 6; }
+};
+
+int32_t UnaryOPSupportChecker::GetMinSupportedSdkVer(
+    const Node& node, const OPSupportCheckParams& /* params */) const {
+  const auto& op(node.OpType());
+  if (op == "Abs" ||
+      op == "Exp" ||
+      op == "Neg" ||
+      op == "Sin" ||
+      op == "Sqrt" ||
+      op == "Log") {
+    return 29;
+  }
+
+  return 27;
+}
+
+#pragma endregion
+
+#pragma region op_concat
+
+class ConcatOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+};
+
+bool ConcatOPSupportChecker::IsOpSupportedImpl(const InitializerMap& /* initializers */, const Node& node, const OPSupportCheckParams& /* params */) {
+  Shape input_shape;
+  if (!GetShape(*node.InputDefs()[0], input_shape))
+    return false;
+
+  const auto input_size = input_shape.size();
+  if (input_size > 4 || input_size == 0) {
+    LOGS_DEFAULT(VERBOSE) << "Concat only supports up to 1-4d shape, input is "
+                          << input_size << "d shape";
+    return false;
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_squeeze
+
+class SqueezeOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(
+      const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const override {
+    return 28;
+  }
+
+  // Squeeze opset 13+ uses input for axes, which is not supported yet
+  // TODO add support for squeeze opset 13+
+  int GetMaxSupportedOpSet(const Node& /* node */) override { return 12; }
+};
+
+bool SqueezeOPSupportChecker::IsOpSupportedImpl(const InitializerMap& /* initializers */, const Node& node, const OPSupportCheckParams& /* params */) {
+  Shape input_shape;
+  if (!GetShape(*node.InputDefs()[0], input_shape))
+    return false;
+
+  const auto input_size = input_shape.size();
+  if (input_size > 4 || input_size == 0) {
+    LOGS_DEFAULT(VERBOSE) << "Squeeze only supports 1-4d shape, input is "
+                          << input_size << "d shape";
+    return false;
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_quantizelinear
+
+class QuantizeLinearOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(
+      const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const override {
+    return 27;
+  }
+};
+
+bool QuantizeLinearOPSupportChecker::IsOpSupportedImpl(
+    const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& /* params */) {
+  const auto input_defs(node.InputDefs());
+  const auto output_defs(node.OutputDefs());
+
+  int32_t output_type;
+  if (!GetType(*output_defs[0], output_type))
+    return false;
+
+  if (output_type != ONNX_NAMESPACE::TensorProto_DataType_UINT8) {
+    LOGS_DEFAULT(VERBOSE) << "[" << node.OpType()
+                          << "] output type: [" << output_type
+                          << "] is not supported for now";
+    return false;
+  }
+
+  if (!HasValidQuantizationScale(initializers, node, {1}))
+    return false;
+
+  if (input_defs.size() == 3) {  // has zero_point input
+    if (!HasValidQuantizationZeroPoint(initializers, node, {2}))
+      return false;
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_dequantizelinear
+
+class DequantizeLinearOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(
+      const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const override {
+    return 29;
+  }
+  bool HasSupportedInputs(const Node& node) override;
+};
+
+bool DequantizeLinearOPSupportChecker::IsOpSupportedImpl(
+    const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& /* params */) {
+  const auto input_defs(node.InputDefs());
+  if (!HasValidQuantizationScale(initializers, node, {1}))
+    return false;
+
+  if (input_defs.size() == 3) {  // has zero_point input
+    if (!HasValidQuantizationZeroPoint(initializers, node, {2}))
+      return false;
+  }
+
+  return true;
+}
+
+bool DequantizeLinearOPSupportChecker::HasSupportedInputs(const Node& node) {
+  int32_t input_type;
+  if (!GetType(*node.InputDefs()[0], input_type))
+    return false;
+
+  if (input_type != ONNX_NAMESPACE::TensorProto_DataType_UINT8) {
+    LOGS_DEFAULT(VERBOSE) << "[" << node.OpType()
+                          << "] Input type: [" << input_type
+                          << "] is not supported for now";
+    return false;
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_LRN
+
+class LRNOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(
+      const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const override {
+    return 28;
+  }
+};
+
+bool LRNOPSupportChecker::IsOpSupportedImpl(const InitializerMap& /* initializers */, const Node& node, const OPSupportCheckParams& /* params */) {
+  Shape input_shape;
+  if (!GetShape(*node.InputDefs()[0], input_shape))
+    return false;
+
+  const auto input_size = input_shape.size();
+  if (input_size != 4) {
+    LOGS_DEFAULT(VERBOSE) << "LRN only support 4d shape, input is "
+                          << input_size << "d shape";
+    return false;
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_clip
+
+class ClipOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+};
+
+bool ClipOPSupportChecker::IsOpSupportedImpl(
+    const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& /* params */) {
+  float min, max;
+  if (!GetClipMinMax(initializers, node, min, max))
+    return false;
+
+  // We only supoort relu6 or relu1
+  // TODO, support clip between 2 arbitrary numbers
+  if ((min == 0.0f && max == 6.0f) || (min == -1.0f && max == 1.0f)) {
+    return true;
+  } else {
+    LOGS_DEFAULT(VERBOSE) << "Clip only supports [min, max] = [0, 6] or [-1, 1], the input is ["
+                          << min << ", " << max << "]";
+    return false;
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_Resize
+
+class ResizeOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(
+      const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  int32_t GetMinSupportedSdkVer(const Node& /* node */, const OPSupportCheckParams& /* params */) const override {
+    return 28;
+  }
+
+  // Resize opset 10- is very different than Resize opset 11+, with many key attributes missing
+  // We only support Resize opset 11+ here
+  int GetMinSupportedOpSet(const Node& /* node */) override { return 11; }
+};
+
+bool ResizeOPSupportChecker::IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) {
+  Shape input_shape;
+  if (!GetShape(*node.InputDefs()[0], input_shape))
+    return false;
+
+  const auto input_size = input_shape.size();
+  if (input_size != 4) {
+    LOGS_DEFAULT(VERBOSE) << "Resize only support 4d shape, input is "
+                          << input_size << "d shape";
+    return false;
+  }
+
+  {  // check attributes
+    NodeAttrHelper helper(node);
+    const auto mode = helper.Get("mode", "nearest");
+    if (mode != "linear") {
+      LOGS_DEFAULT(VERBOSE) << "Resize unsupported input mode, " << mode;
+      return false;
+    }
+
+    const auto coord_trans_mode = helper.Get("coordinate_transformation_mode", "half_pixel");
+    bool using_half_pixel = coord_trans_mode == "half_pixel";
+    bool using_align_corners = coord_trans_mode == "align_corners";
+    if (!using_half_pixel && !using_align_corners && coord_trans_mode != "asymmetric") {
+      LOGS_DEFAULT(VERBOSE) << "Resize, unsupported coord_trans_mode, " << coord_trans_mode;
+      return false;
+    }
+
+    if (params.android_sdk_ver < 30 && (using_half_pixel || using_align_corners)) {
+      LOGS_DEFAULT(VERBOSE) << "Resize only support half_pixel/align_corners on API level 30+, current API level is "
+                            << params.android_sdk_ver;
+      return false;
+    }
+
+    const auto exclude_outside = helper.Get("exclude_outside", 0);
+    if (exclude_outside != 0) {
+      LOGS_DEFAULT(VERBOSE) << "Resize does not support exclude_outside for now";
+      return false;
+    }
+  }
+
+  {  // scales and sizes (if present) must be initializers
+    const auto input_defs = node.InputDefs();
+    // scales
+    if (input_defs.size() < 3 || !Contains(initializers, input_defs[2]->Name())) {
+      LOGS_DEFAULT(VERBOSE) << "Input scales of Resize must be known";
+      return false;
+    }
+
+    // sizes
+    if (input_defs.size() > 3 && !Contains(initializers, input_defs[3]->Name())) {
+      LOGS_DEFAULT(VERBOSE) << "Input sizes of Resize must be known";
+      return false;
+    }
+
+    // We want to check if the scales or sizes are not trying to resize on N/C channels here
+    if (input_defs.size() == 3) {  // we are using scales
+      const auto& scales_tensor = initializers.at(input_defs[2]->Name());
+      const float* scales_data = GetTensorFloatData(scales_tensor);
+      float scale_n = scales_data[0];
+      float scale_c = scales_data[1];
+      if (scale_n != 1.0f || scale_c != 1.0f) {
+        LOGS_DEFAULT(VERBOSE) << "Scales of N/C channel should be 1"
+                              << "Resize of N/C channels are not supported"
+                              << ", scale_n, " << scale_n << ", scale_c, " << scale_c;
+        return false;
+      }
+    } else {
+      // we are using sizes
+      const auto& sizes_name = input_defs[3]->Name();
+      const auto& sizes_tensor = initializers.at(sizes_name);
+      const int64_t* sizes_data = GetTensorInt64Data(sizes_tensor);
+      uint32_t size_n = SafeInt<uint32_t>(sizes_data[0]);
+      uint32_t size_c = SafeInt<uint32_t>(sizes_data[1]);
+      if (size_n != input_shape[0] || size_c != input_shape[1]) {
+        LOGS_DEFAULT(VERBOSE) << "Output sizes of N/C chanel should match the input sizes, "
+                              << "Resize of N/C channels are not supported"
+                              << ", input_size_n, " << input_shape[0] << ", output_size_n, " << size_n
+                              << ". input_size_c, " << input_shape[1] << ", output_size_c, " << size_c;
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+#pragma endregion
+
+#pragma region op_flatten
+
+class FlattenOPSupportChecker : public BaseOPSupportChecker {
+ private:
+  bool IsOpSupportedImpl(const InitializerMap& initializers, const Node& node, const OPSupportCheckParams& params) override;
+  static void GetFlattenShape(const Node& node, const Shape& input_shape, int32_t& dim_1, int32_t& dim_2);
+};
+
+/* static */ void FlattenOPSupportChecker::GetFlattenShape(const Node& node, const Shape& input_shape, int32_t& dim_1, int32_t& dim_2) {
+  int32_t rank = static_cast<int>(input_shape.size());
+  NodeAttrHelper helper(node);
+  int32_t axis = helper.Get("axis", 1);
+  // axis == rank is a valid input, but invalid for HandleNegativeAxis
+  // Skip non-negative axis here
+  if (axis < 0)
+    axis = static_cast<int32_t>(HandleNegativeAxis(axis, rank));
+
+  dim_1 = std::accumulate(input_shape.cbegin(), input_shape.cbegin() + axis, 1, std::multiplies<int32_t>());
+  dim_2 = std::accumulate(input_shape.cbegin() + axis, input_shape.cend(), 1, std::multiplies<int32_t>());
+}
+
+bool FlattenOPSupportChecker::IsOpSupportedImpl(const InitializerMap& /* initializers */, const Node& node, const OPSupportCheckParams& /* params */) {
+  Shape input_shape;
+  if (!GetShape(*node.InputDefs()[0], input_shape))
+    return false;
+
+  if (input_shape.size() > 4 || input_shape.empty()) {
+    LOGS_DEFAULT(VERBOSE) << "Flatten only supports up to 1-4d shape, input is "
+                          << input_shape.size() << "d shape";
+    return false;
+  }
+
+  int32_t dim_1 = 1;
+  int32_t dim_2 = 1;
+  GetFlattenShape(node, input_shape, dim_1, dim_2);
+
+  if (dim_1 == 0 && dim_2 == 0) {
+    LOGS_DEFAULT(VERBOSE) << "The dynamical input shape "  // TODO enable this << Shape2String(input_shape)
+                          << " is not supported";
+    return false;
+  }
+
+  return true;
+}
+
+#pragma endregion
+
+std::unordered_map<std::string, std::shared_ptr<IOPSupportChecker>> CreateOpSupportCheckers() {
+  std::unordered_map<std::string, std::shared_ptr<IOPSupportChecker>> op_map;
+
+  // If an OP is always supported, we use BaseOPSupportChecker as default
+  // Relu, Identity are using base_op_support_checker
+  auto base_op_support_checker = std::make_shared<BaseOPSupportChecker>();
+
+  {
+    auto binary_op_support_checker = std::make_shared<BinaryOPSupportChecker>();
+    op_map.emplace("Add", binary_op_support_checker);
+    op_map.emplace("Sub", binary_op_support_checker);
+    op_map.emplace("Mul", binary_op_support_checker);
+    op_map.emplace("Div", binary_op_support_checker);
+    op_map.emplace("QLinearAdd", binary_op_support_checker);
+  }
+
+  op_map.emplace("Relu", base_op_support_checker);
+  op_map.emplace("Transpose", std::make_shared<TransposeOPSupportChecker>());
+  op_map.emplace("Reshape", std::make_shared<ReshapeOPSupportChecker>());
+  op_map.emplace("BatchNormalization", std::make_shared<BatchNormalizationOPSupportChecker>());
+
+  {
+    auto pool_op_support_checker = std::make_shared<PoolOPSupportChecker>();
+    op_map.emplace("GlobalAveragePool", pool_op_support_checker);
+    op_map.emplace("GlobalMaxPool", pool_op_support_checker);
+    op_map.emplace("AveragePool", pool_op_support_checker);
+    op_map.emplace("MaxPool", pool_op_support_checker);
+  }
+
+  {
+    auto conv_op_support_checker = std::make_shared<ConvOPSupportChecker>();
+    op_map.emplace("Conv", conv_op_support_checker);
+    op_map.emplace("QLinearConv", conv_op_support_checker);
+  }
+
+  op_map.emplace("Cast", std::make_shared<CastOPSupportChecker>());
+  op_map.emplace("Softmax", std::make_shared<SoftMaxOPSupportChecker>());
+  op_map.emplace("Identity", base_op_support_checker);
+
+  {
+    auto gemm_op_support_checker = std::make_shared<GemmOPSupportChecker>();
+    op_map.emplace("Gemm", gemm_op_support_checker);
+    op_map.emplace("MatMul", gemm_op_support_checker);
+    op_map.emplace("QLinearMatMul", gemm_op_support_checker);
+  }
+
+  {
+    auto unary_op_support_checker = std::make_shared<UnaryOPSupportChecker>();
+    op_map.emplace("Abs", unary_op_support_checker);
+    op_map.emplace("Exp", unary_op_support_checker);
+    op_map.emplace("Floor", unary_op_support_checker);
+    op_map.emplace("Log", unary_op_support_checker);
+    op_map.emplace("Sigmoid", unary_op_support_checker);
+    op_map.emplace("Neg", unary_op_support_checker);
+    op_map.emplace("Sin", unary_op_support_checker);
+    op_map.emplace("Sqrt", unary_op_support_checker);
+    op_map.emplace("Tanh", unary_op_support_checker);
+  }
+
+  op_map.emplace("Concat", std::make_shared<ConcatOPSupportChecker>());
+  op_map.emplace("Squeeze", std::make_shared<SqueezeOPSupportChecker>());
+  op_map.emplace("QuantizeLinear", std::make_shared<QuantizeLinearOPSupportChecker>());
+  op_map.emplace("DequantizeLinear", std::make_shared<DequantizeLinearOPSupportChecker>());
+  op_map.emplace("LRN", std::make_shared<LRNOPSupportChecker>());
+  op_map.emplace("Clip", std::make_shared<ClipOPSupportChecker>());
+  op_map.emplace("Resize", std::make_shared<ResizeOPSupportChecker>());
+  op_map.emplace("Flatten", std::make_shared<FlattenOPSupportChecker>());
+
+  return op_map;
+}
+
+}  // namespace nnapi
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.h
@@ -13,19 +13,19 @@ struct OPSupportCheckParams {
   bool use_nchw = false;
 };
 
-class IOPSupportChecker {
+class IOpSupportChecker {
  public:
-  virtual ~IOPSupportChecker() = default;
+  virtual ~IOpSupportChecker() = default;
 
   // Check if an operator is supported
   virtual bool IsOpSupported(const std::unordered_map<std::string, const ONNX_NAMESPACE::TensorProto&>& initializers,
-                             const Node& node, const OPSupportCheckParams& params) = 0;
+                             const Node& node, const OPSupportCheckParams& params) const = 0;
 };
 
-// Generate a lookup table with IOPSupportChecker delegates for different onnx operators
+// Generate a lookup table with IOpSupportChecker delegates for different onnx operators
 // Note, the lookup table should have same number of entries as the result of CreateOpBuilders()
 // in op_builder.h
-std::unordered_map<std::string, std::shared_ptr<IOPSupportChecker>> CreateOpSupportCheckers();
+std::unordered_map<std::string, std::shared_ptr<IOpSupportChecker>> CreateOpSupportCheckers();
 
 }  // namespace nnapi
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "helper.h"
+
+namespace onnxruntime {
+namespace nnapi {
+
+struct OPSupportCheckParams {
+  int32_t android_sdk_ver = 0;
+  bool use_nchw = false;
+};
+
+class IOPSupportChecker {
+ public:
+  virtual ~IOPSupportChecker() = default;
+
+  // Check if an operator is supported
+  virtual bool IsOpSupported(const std::unordered_map<std::string, const ONNX_NAMESPACE::TensorProto&>& initializers,
+                             const Node& node, const OPSupportCheckParams& params) = 0;
+};
+
+// Generate a lookup table with IOPSupportChecker delegates
+// for different onnx operators
+std::unordered_map<std::string, std::shared_ptr<IOPSupportChecker>> CreateOpSupportCheckers();
+
+}  // namespace nnapi
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.h
@@ -22,8 +22,9 @@ class IOPSupportChecker {
                              const Node& node, const OPSupportCheckParams& params) = 0;
 };
 
-// Generate a lookup table with IOPSupportChecker delegates
-// for different onnx operators
+// Generate a lookup table with IOPSupportChecker delegates for different onnx operators
+// Note, the lookup table should have same number of entries as the result of CreateOpBuilders()
+// in op_builder.h
 std::unordered_map<std::string, std::shared_ptr<IOPSupportChecker>> CreateOpSupportCheckers();
 
 }  // namespace nnapi

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/shaper.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/shaper.cc
@@ -458,15 +458,5 @@ void Shaper::Clear() {
   shape_ops_.clear();
 }
 
-std::string Shape2String(const Shaper::Shape& shape) {
-  std::ostringstream os;
-  os << "[ ";
-  for (const auto& dim : shape)
-    os << dim << " ";
-
-  os << "]";
-  return os.str();
-}
-
 }  // namespace nnapi
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/shaper.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/shaper.h
@@ -128,7 +128,5 @@ class Shaper {
   std::vector<std::function<Status(Shaper&)>> shape_ops_;
 };
 
-std::string Shape2String(const Shaper::Shape& shape);
-
 }  // namespace nnapi
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
@@ -4,6 +4,7 @@
 #include "nnapi_execution_provider.h"
 
 #include "builders/model_builder.h"
+#include "builders/helper.h"
 #include "core/framework/allocatormgr.h"
 #include "core/framework/compute_capability.h"
 #include "core/graph/model.h"


### PR DESCRIPTION
**Description**: [NNAPI] Split OPBuilder IsOpSupported into a separated class

**Motivation and Context**
- This is the 1st step to enable NNAPI EP GetCapability without actually running on Android
- Split the OPBuilder into 2 classed
1. OpSupportChecker checks if an operator is supported using NNAPI, this part has no dependency on Linux libraries, can be build for Windows and other platforms
2. OpBuilder will add the NNAPI operation into the NNAPI model, this part will still only run on Android for now
- Moved some common used helper functions to helper.h
- Some minor code updates
- Not included in the PR, the actual GetCapability and ModelBuilder changes, will have follow up PR for those changes
