### PR TITLE
Update install_deps.sh: remove the unnecessary data generating step

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/manylinux/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/install_deps.sh
@@ -100,8 +100,6 @@ export CMAKE_ARGS="-DONNX_GEN_PB_TYPE_STUBS=OFF -DONNX_WERROR=OFF"
 for PYTHON_EXE in "${PYTHON_EXES[@]}"
 do
   ${PYTHON_EXE} -m pip install -r ${0/%install_deps\.sh/requirements\.txt}
-  cd /tmp  
-  ${PYTHON_EXE} -m onnx.backend.test.cmd_tools generate-data -o /data/onnx/onnxtip
 done
 
 cd /tmp/src


### PR DESCRIPTION

**Description**: 

We install onnx python package from this script, so python tests can run the tests for the latest commit which we are importing.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
