### PR TITLE
[mlas]Detect the target platform via probing the output of `CXX` and not `CC`

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -145,7 +145,7 @@ else()
     endif()
   else()
     execute_process(
-      COMMAND ${CMAKE_C_COMPILER} -dumpmachine
+      COMMAND ${CMAKE_CXX_COMPILER} -dumpmachine
       OUTPUT_VARIABLE dumpmachine_output
       ERROR_QUIET
     )


### PR DESCRIPTION
- `mlas` as a C++ library should use `CMAKE_CXX_COMPILER` in order to detect the target CPU
  - Motivation: Recently, due to lack of `CMAKE_C_COMPILER` override, cross compilation to aarch64 failed.