### PR TITLE
Stop gradient flowing to the `k` input of TopK

### DIFF
--- a/orttraining/orttraining/core/framework/gradient_graph_builder.h
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.h
@@ -60,7 +60,8 @@ static std::unordered_map<std::string, std::unordered_set<size_t>>
         {"Where", {0}},
         {"Range", {0, 1, 2}},
         {"Tile", {1}},
-        {"BroadcastGradientArgs", {0, 1}}};
+        {"BroadcastGradientArgs", {0, 1}},
+        {"TopK", {1}}};
 
 class GradientGraphBuilder {
  public:


### PR DESCRIPTION
**Description**: Add the `k` input of TopK to the `STOP_GRADIENT` list.

**Motivation and Context**
- Prevents an invalid gradient graph from being created when the TopK op is included.
