### PR TITLE
Allow turning off printing of shape when compiled with onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS.

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -699,7 +699,7 @@ Set onnxruntime_DEBUG_NODE_INPUTS_OUTPUT to build with this enabled.
 
 #### Configuration
 The debug dump behavior can be controlled with several environment variables.
-See [onnxruntime/core/framework/debug_node_inputs_outputs_utils.h](./onnxruntime/core/framework/debug_node_inputs_outputs_utils.h) for details.
+See [onnxruntime/core/framework/debug_node_inputs_outputs_utils.h](./onnxruntime/core/framework/debug_node_inputs_outputs_utils.h) for details. Shape is printed by default unless it's turned OFF by setting environment variable ORT_DEBUG_NODE_IO_DUMP_SHAPE_DATA to 0.
 
 ##### Examples
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -699,7 +699,7 @@ Set onnxruntime_DEBUG_NODE_INPUTS_OUTPUT to build with this enabled.
 
 #### Configuration
 The debug dump behavior can be controlled with several environment variables.
-See [onnxruntime/core/framework/debug_node_inputs_outputs_utils.h](./onnxruntime/core/framework/debug_node_inputs_outputs_utils.h) for details. Shape is printed by default unless it's turned OFF by setting environment variable ORT_DEBUG_NODE_IO_DUMP_SHAPE_DATA to 0.
+See [onnxruntime/core/framework/debug_node_inputs_outputs_utils.h](./onnxruntime/core/framework/debug_node_inputs_outputs_utils.h) for details.
 
 ##### Examples
 

--- a/onnxruntime/core/framework/debug_node_inputs_outputs_utils.h
+++ b/onnxruntime/core/framework/debug_node_inputs_outputs_utils.h
@@ -18,6 +18,8 @@ namespace utils {
 
 // environment variables that control debug node dumping behavior
 namespace debug_node_inputs_outputs_env_vars {
+// set to non-zero to dump shape data
+constexpr const char* kDumpShapeData = "ORT_DEBUG_NODE_IO_DUMP_SHAPE_DATA";
 // set to non-zero to dump node input data
 constexpr const char* kDumpInputData = "ORT_DEBUG_NODE_IO_DUMP_INPUT_DATA";
 // set to non-zero to dump node output data
@@ -43,10 +45,10 @@ constexpr char kFilterPatternDelimiter = ';';
 
 struct NodeDumpOptions {
   enum DumpFlags {
-    ShapeOnly = 0,
-    InputData = 1 << 0,
-    OutputData = 1 << 1,
-    AllData = InputData | OutputData,
+    ShapeOnly = 1 << 0,
+    InputData = 1 << 1,
+    OutputData = 1 << 2,
+    AllData = ShapeOnly | InputData | OutputData,
   };
 
   // specifies the information to dump per node

--- a/onnxruntime/core/framework/debug_node_inputs_outputs_utils.h
+++ b/onnxruntime/core/framework/debug_node_inputs_outputs_utils.h
@@ -18,6 +18,8 @@ namespace utils {
 
 // environment variables that control debug node dumping behavior
 namespace debug_node_inputs_outputs_env_vars {
+// Shape is printed by default unless it's turned OFF by setting environment
+// variable ORT_DEBUG_NODE_IO_DUMP_SHAPE_DATA to 0.
 // set to non-zero to dump shape data
 constexpr const char* kDumpShapeData = "ORT_DEBUG_NODE_IO_DUMP_SHAPE_DATA";
 // set to non-zero to dump node input data
@@ -45,10 +47,11 @@ constexpr char kFilterPatternDelimiter = ';';
 
 struct NodeDumpOptions {
   enum DumpFlags {
-    ShapeOnly = 1 << 0,
+    None = 0,
+    Shape = 1 << 0,
     InputData = 1 << 1,
     OutputData = 1 << 2,
-    AllData = ShapeOnly | InputData | OutputData,
+    AllData = Shape | InputData | OutputData,
   };
 
   // specifies the information to dump per node
@@ -56,7 +59,7 @@ struct NodeDumpOptions {
   // Note:
   // When dumping every node, dumping both input and output may be redundant.
   // Doing that may be more useful when dumping a subset of all nodes.
-  int dump_flags{DumpFlags::ShapeOnly};
+  int dump_flags{DumpFlags::Shape};
 
   // filters the nodes that are dumped
   // Note:


### PR DESCRIPTION
**Description**: Allow turning off printing of shape when compiled with onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS.
This preserves the existing behavior of printing shape by default.

**Motivation and Context**
Reported by a customer.