### PR TITLE
skip gpt2 test on x86

### DIFF
--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -796,6 +796,7 @@ TEST_P(ModelTest, Run) {
                                                     ORT_TSTR("vgg19"),
                                                     ORT_TSTR("zfnet512"),
                                                     ORT_TSTR("GPT2_LM_HEAD"),
+                                                    ORT_TSTR("GPT2"),
                                                     ORT_TSTR("ssd"),
                                                     ORT_TSTR("coreml_VGG16_ImageNet")};
     all_disabled_tests.insert(std::begin(x86_disabled_tests), std::end(x86_disabled_tests));


### PR DESCRIPTION
This test was added recently and needs to be skipped on x86 Onnxruntime model tests.