### PR TITLE
[ROCm] Re-enable multi-tensor-apply for LAMB optimizer

### DIFF
--- a/orttraining/orttraining/training_ops/rocm/optimizer/lamb.cc
+++ b/orttraining/orttraining/training_ops/rocm/optimizer/lamb.cc
@@ -196,8 +196,7 @@ Status launch_lamb_compute_direction(
   ORT_ENFORCE(group_count == static_cast<int>(epsilons.size()));
 
   constexpr int tensor_count_per_group = 6;
-  // const int max_tensor_size = compute_max_tensor_size_per_launch<tensor_count_per_group>(4);
-  const int max_tensor_size = 0;
+  const int max_tensor_size = compute_max_tensor_size_per_launch<tensor_count_per_group>(4);
   // Bucketize tensor groups by the associated optimizer configuration.
   // If two tensor groups use different "alpha", they should be put into two distinct buckets.
   std::map<std::tuple<float, float, float, float>, std::vector<std::vector<void*>>> buckets;
@@ -290,8 +289,7 @@ Status launch_lamb_reduction(
   // If two tensor groups use different "alpha", they should be put into two distinct buckets.
   std::vector<std::vector<void*>> buckets;
   std::vector<int> tensor_sizes_in_buckets;
-  // const int max_tensor_size = compute_max_tensor_size_per_launch<tensor_count_per_group>(4);
-  const int max_tensor_size = 0;
+  const int max_tensor_size = compute_max_tensor_size_per_launch<tensor_count_per_group>(4);
   for (int i = 0; i < group_count; ++i) {
     if (tensor_sizes[i] > max_tensor_size) {
       reduce_square_sum(
@@ -368,8 +366,7 @@ Status launch_lamb_update(
   // If two tensor groups use different "alpha", they should be put into two distinct buckets.
   std::vector<std::vector<void*>> buckets;
   std::vector<int> tensor_sizes_in_bucket;
-  // const int max_tensor_size = compute_max_tensor_size_per_launch<tensor_count_per_group>(4);
-  const int max_tensor_size = 0;
+  const int max_tensor_size = compute_max_tensor_size_per_launch<tensor_count_per_group>(4);
   for (int i = 0; i < group_count; ++i) {
     if (tensor_sizes[i] > max_tensor_size) {
       LambUpdate(


### PR DESCRIPTION
**Description**:
ROCm compiler has an issue with passing large structures to kernels, which leads to substantial performance degradation.  From the traces, we see large gaps in the kernel execution on the device:
![image](https://user-images.githubusercontent.com/8907830/99118698-d7335400-25ac-11eb-8bd8-ae3387623298.png)

To workaround this, we disabled multi-tensor-apply in a number of places.  With ROCm 3.9 and setting the environment variable HSA_NO_SCRATCH_RECLAIM=1, we can use multi-tensor-apply again:

![image](https://user-images.githubusercontent.com/8907830/99118858-24172a80-25ad-11eb-8ccc-96c63084bae9.png)

This reduces the number of kernel launches for LAMB (~60%) and Reduction (~38%)