### PR TITLE
Fix the test failure of Reduced Ops CI

### DIFF
--- a/onnxruntime/test/testdata/reduced_ops_via_config.config
+++ b/onnxruntime/test/testdata/reduced_ops_via_config.config
@@ -1,2 +1,3 @@
 ai.onnx.ml;1;Normalizer
+ai.onnx;8;Gemm
 ai.onnx;11;ReduceProd,ReduceSums,ReduceMean,Greater,If


### PR DESCRIPTION
**Description**: Fix the test failure of Reduced Ops CI

**Motivation and Context**
- The reduced ops CI has test failure since the .ort format model in InternalTestingEP has Ops which is not included in the required_ops list, since we do not scan .ort format model in the script
- Add the missing Gemm op in the reduced_ops_via_config.config

