### PR TITLE
Prevent saving a model containing fused nodes backed by a compiled kernel

### DIFF
--- a/onnxruntime/core/framework/fuse_nodes_funcs.h
+++ b/onnxruntime/core/framework/fuse_nodes_funcs.h
@@ -18,6 +18,8 @@ class FuncManager {
 
   Status GetFuncs(const std::string& name, NodeComputeInfo*& compute_info) const;
 
+  size_t NumFuncs() const { return fused_funcs_->size(); }
+
   void SetFusedFuncs(const FuncManager& func_mgr) {
     fused_funcs_ = func_mgr.fused_funcs_;
   }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1218,6 +1218,13 @@ common::Status InferenceSession::Initialize() {
 
 #if !defined(ORT_MINIMAL_BUILD)
     if (saving_model) {
+      if (session_state_->GetFuncMgr().NumFuncs() > 0) {
+        ORT_RETURN_IF_ERROR_SESSIONID_(
+            ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                            "Unable to serialize model as it contains compiled nodes. "
+                            "Please disable any execution providers which generate compiled nodes."));
+      }
+
       if (session_options_.graph_optimization_level >= TransformerLevel::Level3) {
         LOGS(*session_logger_, WARNING)
             << "Serializing optimized model with Graph Optimization level greater than ORT_ENABLE_EXTENDED. "


### PR DESCRIPTION
**Description**: 
Prevent saving a model containing fused nodes backed by a compiled kernel. We don't have a way to save the compiled kernels so the saved model will be invalid and fail to load.

**Motivation and Context**
Github issue #3802 where optimized model with TensorRT kernels was saved and couldn't be loaded. 
Also addresses PR comment from the change to support compiling EPs in an ORT format model.