### PR TITLE
Regenerate CI build docker images

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest-docker-gpu.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest-docker-gpu.sh
@@ -27,6 +27,6 @@ docker run --gpus all --rm \
         -e "PackageName=$PackageName" \
         -e "RunTestCsharp=$RunTestCsharp" \
         -e "RunTestNative=$RunTestNative" \
-        onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:char \
+        onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:ch4 \
         /bin/bash /onnxruntime_src/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh \
         /home/onnxruntimedev/$NUGET_REPO_DIRNAME /onnxruntime_src /home/onnxruntimedev $CurrentOnnxRuntimeVersion

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest-docker.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest-docker.sh
@@ -35,6 +35,6 @@ docker run --rm \
         -e "DisableMlOps=$DISABLEMLOPS" \
         -e "RunTestCsharp=$RunTestCsharp" \
         -e "RunTestNative=$RunTestNative" \
-        onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:chaq \
+        onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:ch3 \
         /bin/bash /onnxruntime_src/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh \
         /home/onnxruntimedev/$NUGET_REPO_DIRNAME /onnxruntime_src /home/onnxruntimedev $CurrentOnnxRuntimeVersion

--- a/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
     - task: Docker@2
       displayName: login
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: login
         addPipelineData: false
     - task: CmdLine@2
@@ -18,14 +18,14 @@ jobs:
         script: |
           mkdir -p $HOME/.onnx
           docker run --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro \
-          --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:chaq python3 \
+          --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:ch3 python3 \
           /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release \
           --skip_submodule_sync  --parallel --build_shared_lib --use_openmp
         workingDirectory: $(Build.SourcesDirectory)
     - task: Docker@2
       displayName: logout
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: logout
         addPipelineData: false
     - template: templates/c-api-artifacts-package-and-publish-steps-posix.yml
@@ -50,7 +50,7 @@ jobs:
     - task: Docker@2
       displayName: login
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: login
         addPipelineData: false
     - task: CmdLine@2
@@ -58,14 +58,14 @@ jobs:
         script: |
           mkdir -p $HOME/.onnx
           docker run --gpus all -e NVIDIA_VISIBLE_DEVICES=all --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build \
-          --volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:char \
+          --volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:ch4 \
           python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release \
           --skip_submodule_sync  --parallel --build_shared_lib --use_cuda --cuda_version=10.2 --cuda_home=/usr/local/cuda-10.2 --cudnn_home=/usr/local/cuda-10.2
         workingDirectory: $(Build.SourcesDirectory)
     - task: Docker@2
       displayName: logout
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: logout
         addPipelineData: false
     - template: templates/c-api-artifacts-package-and-publish-steps-posix.yml

--- a/tools/ci_build/github/azure-pipelines/java-api-packaging-pipelines-gpu.yml
+++ b/tools/ci_build/github/azure-pipelines/java-api-packaging-pipelines-gpu.yml
@@ -17,19 +17,19 @@ jobs:
     - task: Docker@2
       displayName: login
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: login
         addPipelineData: false
     - task: CmdLine@2
       inputs:
         script: |
           mkdir -p $HOME/.onnx
-          docker run --gpus all -e NVIDIA_VISIBLE_DEVICES=all --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:char python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync  --parallel --build_java --build_shared_lib --use_cuda --cuda_version=10.2 --cuda_home=/usr/local/cuda-10.2  --cudnn_home=/usr/local/cuda-10.2
+          docker run --gpus all -e NVIDIA_VISIBLE_DEVICES=all --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:ch4 python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync  --parallel --build_java --build_shared_lib --use_cuda --cuda_version=10.2 --cuda_home=/usr/local/cuda-10.2  --cudnn_home=/usr/local/cuda-10.2
         workingDirectory: $(Build.SourcesDirectory)
     - task: Docker@2
       displayName: logout
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: logout
     - template: templates/java-api-artifacts-package-and-publish-steps-posix.yml
       parameters:
@@ -251,19 +251,19 @@ jobs:
   - task: Docker@2
     displayName: login
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: login
       addPipelineData: false
 
   - task: CmdLine@2
     inputs:
       script: |
-          docker run --gpus all -e NVIDIA_VISIBLE_DEVICES=all --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build -e NIGHTLY_BUILD onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:char /onnxruntime_src/tools/ci_build/github/linux/java_linux_final_test.sh -v $(OnnxRuntimeVersion) -r /build
+          docker run --gpus all -e NVIDIA_VISIBLE_DEVICES=all --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build -e NIGHTLY_BUILD onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:ch4 /onnxruntime_src/tools/ci_build/github/linux/java_linux_final_test.sh -v $(OnnxRuntimeVersion) -r /build
       workingDirectory: $(Build.BinariesDirectory)/final-jar
 
   - task: Docker@2
     displayName: logout
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: logout
       addPipelineData: false

--- a/tools/ci_build/github/azure-pipelines/java-api-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/java-api-packaging-pipelines.yml
@@ -19,20 +19,20 @@ jobs:
     - task: Docker@2
       displayName: login
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: login
         addPipelineData: false
     - task: CmdLine@2
       inputs:
         script: |
           mkdir -p $HOME/.onnx
-          docker run --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:chaq /bin/bash -c "python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync  --parallel --build_shared_lib --build_java --use_openmp --enable_onnx_tests && cd /build/Release && make install DESTDIR=/build/linux-x64"
+          docker run --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:ch3 /bin/bash -c "python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync  --parallel --build_shared_lib --build_java --use_openmp --enable_onnx_tests && cd /build/Release && make install DESTDIR=/build/linux-x64"
         workingDirectory: $(Build.SourcesDirectory)
         displayName: 'Run build and test'
     - task: Docker@2
       displayName: logout
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: logout
         addPipelineData: false
     - template: templates/java-api-artifacts-package-and-publish-steps-posix.yml

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -12,7 +12,7 @@ jobs:
   - task: Docker@2
     displayName: login
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: login
       addPipelineData: false
   - task: CmdLine@2
@@ -28,7 +28,7 @@ jobs:
           -e ALLOW_RELEASED_ONNX_OPSET_ONLY=0 \
           -e NIGHTLY_BUILD \
           -e BUILD_BUILDNUMBER \
-          onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:chaq \
+          onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:ch3 \
             python3 /onnxruntime_src/tools/ci_build/build.py \
               --build_dir /build --cmake_generator Ninja \
               --config Debug Release \
@@ -44,7 +44,7 @@ jobs:
   - task: Docker@2
     displayName: logout
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: logout
       addPipelineData: false
   - task: PublishTestResults@2

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -23,7 +23,7 @@ jobs:
   - task: Docker@2
     displayName: login
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: login
       addPipelineData: false
   - task: CmdLine@2
@@ -39,7 +39,7 @@ jobs:
           -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
           -e NIGHTLY_BUILD \
           -e BUILD_BUILDNUMBER \
-          onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:chaq \
+          onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:ch3 \
             /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_full_ort_and_create_ort_files.sh
       workingDirectory: $(Build.SourcesDirectory)
   - task: CmdLine@2
@@ -54,7 +54,7 @@ jobs:
           -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
           -e NIGHTLY_BUILD \
           -e BUILD_BUILDNUMBER \
-          onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:chaq \
+          onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:ch3 \
             python3 /onnxruntime_src/tools/ci_build/build.py \
               --build_dir /build --cmake_generator Ninja \
               --config Debug\
@@ -76,7 +76,7 @@ jobs:
           -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
           -e NIGHTLY_BUILD \
           -e BUILD_BUILDNUMBER \
-          onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:chaq \
+          onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:ch3 \
             /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_and_run_tests.sh
       workingDirectory: $(Build.SourcesDirectory)
   - task: CmdLine@2
@@ -96,13 +96,13 @@ jobs:
           -e BUILD_SOURCEVERSION=$(Build.SourceVersion) \
           -e BUILD_ID=$(Build.BuildId) \
           -e DASHBOARD_MYSQL_ORT_PASSWORD=$(dashboard-mysql-ort-password) \
-          onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:chaq \
+          onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:ch3 \
             /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
       workingDirectory: $(Build.SourcesDirectory)
   - task: Docker@2
     displayName: logout
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: logout
       addPipelineData: false
   - task: PublishTestResults@2

--- a/tools/ci_build/github/azure-pipelines/linux-dnnl-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-dnnl-ci-pipeline.yml
@@ -12,7 +12,7 @@ jobs:
   - task: Docker@2
     displayName: login
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: login
       addPipelineData: false
   - task: CmdLine@2
@@ -27,7 +27,7 @@ jobs:
           --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
           -e NIGHTLY_BUILD \
           -e BUILD_BUILDNUMBER \
-          onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecpubuild:chan \
+          onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecpubuild:ch1 \
             /opt/python/cp37-cp37m/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
               --build_dir /build \
               --config Debug Release \
@@ -43,7 +43,7 @@ jobs:
   - task: Docker@2
     displayName: logout
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: logout
       addPipelineData: false
   - task: PublishTestResults@2

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
@@ -12,7 +12,7 @@ jobs:
   - task: Docker@2
     displayName: login
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: login
       addPipelineData: false
   - task: CmdLine@2
@@ -28,7 +28,7 @@ jobs:
           -e ALLOW_RELEASED_ONNX_OPSET_ONLY=0 \
           -e NIGHTLY_BUILD \
           -e BUILD_BUILDNUMBER \
-          onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:char \
+          onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:ch4 \
             python3 /onnxruntime_src/tools/ci_build/build.py \
               --build_dir /build --cmake_generator Ninja \
               --config Debug Release \
@@ -43,7 +43,7 @@ jobs:
   - task: Docker@2
     displayName: logout
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: logout
       addPipelineData: false
   - task: PublishTestResults@2

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-cuda-11-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-cuda-11-pipeline.yml
@@ -12,7 +12,7 @@ jobs:
   - task: Docker@2
     displayName: login
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: login
       addPipelineData: false
   - task: CmdLine@2
@@ -28,7 +28,7 @@ jobs:
           -e ALLOW_RELEASED_ONNX_OPSET_ONLY=0 \
           -e NIGHTLY_BUILD \
           -e BUILD_BUILDNUMBER \
-          onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecuda11build:chas \
+          onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecuda11build:ch5 \
             /opt/python/cp37-cp37m/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
               --build_dir /build --cmake_generator Ninja \
               --config Debug Release \
@@ -44,7 +44,7 @@ jobs:
   - task: Docker@2
     displayName: logout
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: logout
       addPipelineData: false
   - task: PublishTestResults@2

--- a/tools/ci_build/github/azure-pipelines/linux-multi-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-multi-gpu-ci-pipeline.yml
@@ -12,7 +12,7 @@ jobs:
   - task: Docker@2
     displayName: login
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: login
       addPipelineData: false
   - task: CmdLine@2
@@ -27,7 +27,7 @@ jobs:
           --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
           -e NIGHTLY_BUILD \
           -e BUILD_BUILDNUMBER \
-          onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:char \
+          onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:ch4 \
             python3 /onnxruntime_src/tools/ci_build/build.py \
               --build_dir /build --cmake_generator Ninja \
               --config Debug Release \
@@ -41,7 +41,7 @@ jobs:
   - task: Docker@2
     displayName: logout
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: logout
       addPipelineData: false
   - task: PublishTestResults@2

--- a/tools/ci_build/github/azure-pipelines/linux-nocontribops-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-nocontribops-ci-pipeline.yml
@@ -12,7 +12,7 @@ jobs:
   - task: Docker@2
     displayName: login
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: login
       addPipelineData: false
   - task: CmdLine@2
@@ -28,7 +28,7 @@ jobs:
           -e ALLOW_RELEASED_ONNX_OPSET_ONLY=0 \
           -e NIGHTLY_BUILD \
           -e BUILD_BUILDNUMBER \
-          onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:chaq \
+          onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:ch3 \
             python3 /onnxruntime_src/tools/ci_build/build.py \
               --build_dir /build --cmake_generator Ninja \
               --config Debug Release \
@@ -42,7 +42,7 @@ jobs:
   - task: Docker@2
     displayName: logout
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: logout
       addPipelineData: false
   - task: PublishTestResults@2

--- a/tools/ci_build/github/azure-pipelines/nodejs/templates/cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nodejs/templates/cpu.yml
@@ -41,21 +41,21 @@ jobs:
     - task: Docker@2
       displayName: login
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: login
         addPipelineData: false
     - task: CmdLine@2
       inputs:
         script: |
           mkdir -p $HOME/.onnx && docker run --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro \
-          --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:chaq /bin/bash -c "python3 \
+          --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:ch3 /bin/bash -c "python3 \
           /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --build_nodejs \
           --skip_submodule_sync  --parallel --build_shared_lib --use_openmp && cd /onnxruntime_src/nodejs && npm pack"
         workingDirectory: $(Build.SourcesDirectory)
     - task: Docker@2
       displayName: logout
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: logout
         addPipelineData: false
     - script: |

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-nocontribops-arm64.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-nocontribops-arm64.yml
@@ -75,19 +75,19 @@ jobs:
     - task: Docker@2
       displayName: login
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: login
         addPipelineData: false
     - task: CmdLine@2
       inputs:
         script: |
           mkdir -p $HOME/.onnx
-          docker run --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:chaq /bin/bash -c "python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync --parallel --build_shared_lib --enable_onnx_tests  --disable_contrib_ops --disable_ml_ops && cd /build/Release && make install DESTDIR=/build/linux-x64"
+          docker run --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:ch3 /bin/bash -c "python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync --parallel --build_shared_lib --enable_onnx_tests  --disable_contrib_ops --disable_ml_ops && cd /build/Release && make install DESTDIR=/build/linux-x64"
         workingDirectory: $(Build.SourcesDirectory)
     - task: Docker@2
       displayName: logout
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: logout
         addPipelineData: false
     - script: |

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-noopenmp.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-noopenmp.yml
@@ -102,19 +102,19 @@ jobs:
     - task: Docker@2
       displayName: login
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: login
         addPipelineData: false
     - task: CmdLine@2
       inputs:
         script: |
           mkdir -p $HOME/.onnx
-          docker run --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:chaq /bin/bash -c "python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync --parallel --build_shared_lib --enable_onnx_tests && cd /build/Release && make install DESTDIR=/build/linux-x64"
+          docker run --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:ch3 /bin/bash -c "python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync --parallel --build_shared_lib --enable_onnx_tests && cd /build/Release && make install DESTDIR=/build/linux-x64"
         workingDirectory: $(Build.SourcesDirectory)
     - task: Docker@2
       displayName: logout
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: logout
         addPipelineData: false
     - script: |

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu.yml
@@ -98,19 +98,19 @@ jobs:
     - task: Docker@2
       displayName: login
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: login
         addPipelineData: false
     - task: CmdLine@2
       inputs:
         script: |
           mkdir -p $HOME/.onnx
-          docker run --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:chaq /bin/bash -c "python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync --parallel --build_shared_lib --use_openmp --enable_onnx_tests && cd /build/Release && make install DESTDIR=/build/linux-x64"
+          docker run --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:ch3 /bin/bash -c "python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync --parallel --build_shared_lib --use_openmp --enable_onnx_tests && cd /build/Release && make install DESTDIR=/build/linux-x64"
         workingDirectory: $(Build.SourcesDirectory)
     - task: Docker@2
       displayName: logout
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: logout
         addPipelineData: false
     - script: |

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/gpu.yml
@@ -82,19 +82,19 @@ jobs:
     - task: Docker@2
       displayName: login
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: login
         addPipelineData: false
     - task: CmdLine@2
       inputs:
         script: |
           mkdir -p $HOME/.onnx
-          docker run --gpus all -e NVIDIA_VISIBLE_DEVICES=all --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:char \
+          docker run --gpus all -e NVIDIA_VISIBLE_DEVICES=all --rm --volume /data/onnx:/data/onnx:ro --volume $(Build.SourcesDirectory):/onnxruntime_src --volume $(Build.BinariesDirectory):/build --volume /data/models:/build/models:ro --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:ch4 \
           /bin/bash -c "python3 /onnxruntime_src/tools/ci_build/build.py --build_dir /build --config Release --skip_submodule_sync  --parallel --build_shared_lib --use_cuda --cuda_version=10.2 --cuda_home=/usr/local/cuda-10.2 --cudnn_home=/usr/local/cuda-10.2 --enable_onnx_tests && cd /build/Release && make install DESTDIR=/build/linux-x64"
     - task: Docker@2
       displayName: logout
       inputs:
-        containerRegistry: onnxruntimeregistry
+        containerRegistry: onnxruntimebuildcache
         command: logout
         addPipelineData: false
     - script: |

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
@@ -37,7 +37,7 @@ jobs:
   - task: Docker@2
     displayName: login
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: login
       addPipelineData: false
 
@@ -61,7 +61,7 @@ jobs:
   - task: Docker@2
     displayName: logout
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: logout
       addPipelineData: false
 

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-ci-pipeline.yml
@@ -12,7 +12,7 @@ jobs:
   - task: Docker@2
     displayName: login
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: login
       addPipelineData: false
   - task: CmdLine@2
@@ -28,7 +28,7 @@ jobs:
           -e ALLOW_RELEASED_ONNX_OPSET_ONLY=0 \
           -e NIGHTLY_BUILD \
           -e BUILD_BUILDNUMBER \
-          onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecpubuild:chan \
+          onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecpubuild:ch1 \
             /opt/python/cp37-cp37m/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
               --build_dir /build --cmake_generator Ninja \
               --config Debug Release \
@@ -44,7 +44,7 @@ jobs:
   - task: Docker@2
     displayName: logout
     inputs:
-      containerRegistry: onnxruntimeregistry
+      containerRegistry: onnxruntimebuildcache
       command: logout
       addPipelineData: false
   - task: PublishTestResults@2

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -89,7 +89,7 @@ stages:
       - task: Docker@2
         displayName: login
         inputs:
-          containerRegistry: onnxruntimeregistry
+          containerRegistry: onnxruntimebuildcache
           command: login
           addPipelineData: false
       - task: CmdLine@2
@@ -104,7 +104,7 @@ stages:
               --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
-              onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecpubuild:chan \
+              onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecpubuild:ch1 \
                 $(python.manylinux.dir)/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
                   --build_dir /build --cmake_generator Ninja \
                   --config Release \
@@ -120,7 +120,7 @@ stages:
       - task: Docker@2
         displayName: logout
         inputs:
-          containerRegistry: onnxruntimeregistry
+          containerRegistry: onnxruntimebuildcache
           command: logout
           addPipelineData: false
       - task: CopyFiles@2
@@ -166,7 +166,7 @@ stages:
       - task: Docker@2
         displayName: login
         inputs:
-          containerRegistry: onnxruntimeregistry
+          containerRegistry: onnxruntimebuildcache
           command: login
           addPipelineData: false
       - task: CmdLine@2
@@ -181,7 +181,7 @@ stages:
               --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
-              onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimecpubuild:chan \
+              onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecpubuild:ch1 \
                 $(python.manylinux.dir)/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
                   --build_dir /build --cmake_generator Ninja \
                   --config Release \
@@ -196,7 +196,7 @@ stages:
       - task: Docker@2
         displayName: logout
         inputs:
-          containerRegistry: onnxruntimeregistry
+          containerRegistry: onnxruntimebuildcache
           command: logout
           addPipelineData: false
       - task: CopyFiles@2
@@ -243,7 +243,7 @@ stages:
       - task: Docker@2
         displayName: login
         inputs:
-          containerRegistry: onnxruntimeregistry
+          containerRegistry: onnxruntimebuildcache
           command: login
           addPipelineData: false
       - task: CmdLine@2
@@ -258,7 +258,7 @@ stages:
               --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
-              onnxruntimeregistry.azurecr.io/internal/azureml/onnxruntimegpubuild:chap \
+              onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimegpubuild:ch2 \
                 $(python.manylinux.dir)/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
                   --build_dir /build --cmake_generator Ninja \
                   --config Release \
@@ -273,7 +273,7 @@ stages:
       - task: Docker@2
         displayName: logout
         inputs:
-          containerRegistry: onnxruntimeregistry
+          containerRegistry: onnxruntimebuildcache
           command: logout
           addPipelineData: false
 


### PR DESCRIPTION
**Description**: 

Regenerate CI build docker images and move them to a new registry

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
