### PR TITLE
Reduce the number of CI build variants

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
@@ -31,7 +31,7 @@ jobs:
           onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentosgpubuild:ch4 \
             python3 /onnxruntime_src/tools/ci_build/build.py \
               --build_dir /build --cmake_generator Ninja \
-              --config Debug Release \
+              --config Release \
               --skip_submodule_sync \
               --build_shared_lib \
               --parallel \

--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -153,13 +153,6 @@ jobs:
 
 - job: 'x86_build'
   pool: 'Win-CPU-2019'
-  strategy:
-    maxParallel: 2
-    matrix:
-      debug:
-        BuildConfig: 'Debug'
-      release:
-        BuildConfig: 'RelWithDebInfo'
   variables:
     OrtPackageId: 'Microsoft.ML.OnnxRuntime'
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
@@ -168,6 +161,7 @@ jobs:
     EnvSetupScript: setup_env_x86.bat
     buildArch: x86
     setVcvars: true
+    BuildConfig: 'RelWithDebInfo'
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
   timeoutInMinutes: 120
   workspace:
@@ -292,13 +286,6 @@ jobs:
    
 - job: 'x86_no_contrib_ops'
   pool: 'Win-CPU-2019'
-  strategy:
-    maxParallel: 2
-    matrix:
-      debug:
-        BuildConfig: 'Debug'
-      release:
-        BuildConfig: 'RelWithDebInfo'
   variables:
     OrtPackageId: 'Microsoft.ML.OnnxRuntime'
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
@@ -307,6 +294,7 @@ jobs:
     EnvSetupScript: setup_env_x86.bat
     buildArch: x86
     setVcvars: true
+    BuildConfig: 'RelWithDebInfo'
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
   timeoutInMinutes: 120
   workspace:
@@ -420,13 +408,6 @@ jobs:
 
 - job: 'build_x64_no_contrib_ops'
   pool: 'Win-CPU-2019'
-  strategy:
-    maxParallel: 2
-    matrix:
-      debug:
-        BuildConfig: 'Debug'
-      release:
-        BuildConfig: 'RelWithDebInfo'
   variables:
     OrtPackageId: 'Microsoft.ML.OnnxRuntime'
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
@@ -435,6 +416,7 @@ jobs:
     EnvSetupScript: setup_env.bat
     buildArch: x64
     setVcvars: true
+    BuildConfig: 'RelWithDebInfo'
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
   timeoutInMinutes: 120
   workspace:

--- a/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
@@ -1,13 +1,6 @@
 jobs:
 - job: 'build'
   pool: 'Win-GPU-2019'
-  strategy:
-    maxParallel: 2
-    matrix:
-      debug:
-        BuildConfig: 'Debug'
-      release:
-        BuildConfig: 'RelWithDebInfo'
   variables:
     OrtPackageId: 'Microsoft.ML.OnnxRuntime'
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
@@ -16,6 +9,7 @@ jobs:
     EnvSetupScript: setup_env_cuda.bat
     buildArch: x64
     setVcvars: true
+    BuildConfig: 'RelWithDebInfo'
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
   timeoutInMinutes: 120
   workspace:

--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -1,13 +1,6 @@
 jobs:
 - job: 'build'
   pool: 'Win-GPU-2019'
-  strategy:
-    maxParallel: 2
-    matrix:
-      debug:
-        BuildConfig: 'Debug'
-      release:
-        BuildConfig: 'RelWithDebInfo'
   variables:
     OrtPackageId: 'Microsoft.ML.OnnxRuntime'
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
@@ -16,6 +9,7 @@ jobs:
     EnvSetupScript: setup_env_trt.bat
     buildArch: x64
     setVcvars: true
+    BuildConfig: 'RelWithDebInfo'
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '1'
   timeoutInMinutes: 120
   workspace:

--- a/tools/ci_build/github/linux/run_build.sh
+++ b/tools/ci_build/github/linux/run_build.sh
@@ -62,14 +62,14 @@ else
     if [ $BUILD_DEVICE = "gpu" ]; then
         if [ $BUILD_OS = "manylinux2010" ]; then
             python3 $SCRIPT_DIR/../../build.py --build_dir /build \
-                --config Debug Release $COMMON_BUILD_ARGS \
+                --config Release $COMMON_BUILD_ARGS \
                 --use_cuda \
                 --cuda_home /usr/local/cuda \
                 --cudnn_home /usr/local/cuda $BUILD_EXTR_PAR
         else
             _CUDNN_VERSION=$(echo $CUDNN_VERSION | cut -d. -f1-2)
             python3 $SCRIPT_DIR/../../build.py --build_dir /build \
-                --config Debug Release $COMMON_BUILD_ARGS \
+                --config Release $COMMON_BUILD_ARGS \
                 --use_cuda \
                 --cuda_home /usr/local/cuda \
                 --cudnn_home /usr/local/cudnn-$_CUDNN_VERSION/cuda $BUILD_EXTR_PAR


### PR DESCRIPTION
**Description**: 

Reduce the number of CI build variants. Only build and test the release build, because this is what we ship. 

**Motivation and Context**
- Why is this change required? What problem does it solve?

We have too many build pipelines and they take too long. While our team is growing, we can't get more build machines. So I think we should consider to cut down the demand a bit. 

- If it fixes an open issue, please link to the issue here.
