### PR TITLE
revert attention input_swap

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/attention.cc
@@ -48,7 +48,6 @@ AttentionBase::AttentionBase(const OpKernelInfo& info) {
   num_heads_ = static_cast<int>(num_heads);
 
   is_unidirectional_ = info.GetAttrOrDefault<int64_t>("unidirectional", 0) == 1;
-  is_input_dim_swapped_ = info.GetAttrOrDefault<int64_t>("input_dimension_swapped", 0) == 1;
 }
 
 Status AttentionBase::CheckInputs(const TensorShape& input_shape,
@@ -57,7 +56,7 @@ Status AttentionBase::CheckInputs(const TensorShape& input_shape,
                                   const Tensor*& mask_index,
                                   const Tensor* past) const {
   // Input shapes:
-  //   input       : (batch_size, sequence_length, hidden_size) or (sequence_length, batch_size, hidden_size)
+  //   input       : (batch_size, sequence_length, hidden_size)
   //   weights     : (hidden_size, 3 * hidden_size)
   //   bias        : (3 * hidden_size)
   //   mask_index  : nullptr, (batch_size), (2 * batch_size), (batch_size, 1), (1, 1) or (batch_size, past_sequence_length + sequence_length)
@@ -68,8 +67,8 @@ Status AttentionBase::CheckInputs(const TensorShape& input_shape,
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'input' is expected to have 3 dimensions, got ",
                            dims.size());
   }
-  int batch_size = is_input_dim_swapped_ ? static_cast<int>(dims[1]) : static_cast<int>(dims[0]);
-  int sequence_length = is_input_dim_swapped_ ? static_cast<int>(dims[0]) : static_cast<int>(dims[1]);
+  int batch_size = static_cast<int>(dims[0]);
+  int sequence_length = static_cast<int>(dims[1]);
   int hidden_size = static_cast<int>(dims[2]);
   if (hidden_size % num_heads_ != 0) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
@@ -239,8 +238,8 @@ Status Attention<T>::Compute(OpKernelContext* context) const {
                                   past));
 
   const auto& shape = input->Shape().GetDims();
-  const int batch_size = is_input_dim_swapped_ ? static_cast<int>(shape[1]) : static_cast<int>(shape[0]);
-  const int sequence_length = is_input_dim_swapped_ ? static_cast<int>(shape[0]) : static_cast<int>(shape[1]);
+  const int batch_size = static_cast<int>(shape[0]);
+  const int sequence_length = static_cast<int>(shape[1]);
   const int hidden_size = static_cast<int>(shape[2]);
   const int head_size = hidden_size / num_heads_;
 

--- a/onnxruntime/contrib_ops/cpu/bert/attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_base.h
@@ -28,7 +28,6 @@ class AttentionBase {
 
   int num_heads_;             // number of attention heads
   bool is_unidirectional_;    // whether every token can only attend to previous tokens.
-  bool is_input_dim_swapped_;  // whether the input_shape is (S, B, NH) instead of (B, S, NH)
 };
 
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cuda/bert/attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/attention.cc
@@ -42,11 +42,11 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
   ORT_RETURN_IF_ERROR(CheckInputs(input->Shape(), weights->Shape(), bias->Shape(), mask_index, past));
 
   // Input and output shapes:
-  //   Input 0 - input       : (batch_size, sequence_length, hidden_size) or (sequence_length, batch_size, hidden_size)
-  //   Output 0 - output     : (batch_size, sequence_length, hidden_size) or (sequence_length, batch_size, hidden_size)
+  //   Input 0 - input       : (batch_size, sequence_length, hidden_size)
+  //   Output 0 - output     : (batch_size, sequence_length, hidden_size)
   const auto& shape = input->Shape();
-  int batch_size = is_input_dim_swapped_ ? static_cast<int>(shape[1]) : static_cast<int>(shape[0]);
-  int sequence_length = is_input_dim_swapped_ ? static_cast<int>(shape[0]) : static_cast<int>(shape[1]);
+  int batch_size = static_cast<int>(shape[0]);
+  int sequence_length = static_cast<int>(shape[1]);
   int hidden_size = static_cast<int>(shape[2]);
   int head_size = hidden_size / num_heads_;
 

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -282,8 +282,7 @@ we also support other two formats: When input has right-side padding, mask_index
 where value of each element is the end position, or valid length of actual sequence excluding padding. When input has
 left-side padding, mask_index has shape (2 * batch_size), where the values are the exclusive end positions followed by
 the inclusive start positions. When unidirectional is 1, and each token only attend to previous tokens. For GPT-2, both past
-and present state are optional. Present state could appear in output even when past state is not in input. When
-input_dimension_swapped is 1, the input shape is (sequence_length, batch_size, hidden_size) which happens in Bart models, etc.
+and present state are optional. Present state could appear in output even when past state is not in input.
 )DOC";
 
   ONNX_CONTRIB_OPERATOR_SCHEMA(Attention)
@@ -295,16 +294,12 @@ input_dimension_swapped is 1, the input shape is (sequence_length, batch_size, h
             "Whether every token can only attend to previous tokens. Default value is 0.",
             AttributeProto::INT,
             static_cast<int64_t>(0))
-      .Attr("input_dimension_swapped",
-            "Whether input shape is (sequence_length, batch_size, hidden_size) instead of (batch_size, sequence_length, hidden_size). Default value is 0.",
-            AttributeProto::INT,
-            static_cast<int64_t>(0))
-      .Input(0, "input", "3D input tensor with shape (batch_size, sequence_length, hidden_size) or (sequence_length, batch_size, hidden_size), hidden_size = num_heads * head_size", "T")
+      .Input(0, "input", "3D input tensor with shape (batch_size, sequence_length, hidden_size), hidden_size = num_heads * head_size", "T")
       .Input(1, "weight", "2D input tensor with shape (hidden_size, 3 * hidden_size)", "T")
       .Input(2, "bias", "1D input tensor with shape (3 * hidden_size)", "T")
       .Input(3, "mask_index", "Attention mask with shape (batch_size, past_sequence_length + sequence_length), or index with shape (batch_size) or (2 * batch_size).", "M", OpSchema::Optional)
       .Input(4, "past", "past state for key and value with shape (2, batch_size, num_heads, past_sequence_length, head_size).", "T", OpSchema::Optional)
-      .Output(0, "output", "3D output tensor with shape (batch_size, append_length, hidden_size) or (sequence_length, batch_size, hidden_size)", "T")
+      .Output(0, "output", "3D output tensor with shape (batch_size, append_length, hidden_size)", "T")
       .Output(1, "present", "present state for key and value with shape (2, batch_size, num_heads, past_sequence_length + sequence_length, head_size)", "T", OpSchema::Optional)
       .TypeConstraint("T", {"tensor(float)", "tensor(float16)"}, "Constrain input and output types to float tensors.")
       .TypeConstraint("M", {"tensor(int32)"}, "Constrain mask index to integer types")
@@ -332,9 +327,6 @@ input_dimension_swapped is 1, the input shape is (sequence_length, batch_size, h
               }
 
               if (past_dims[3].has_dim_value() && input_dims[1].has_dim_value()) {
-                if (ctx.getAttribute("input_dimension_swapped")->i() != 0) {
-                  fail_shape_inference("Past shall be work with input_dimension_swapped=0. aka when input shape equals to (B,S,NH)");
-                }
                 auto all_sequence_length = past_shape.dim(3).dim_value() + input_shape.dim(1).dim_value();
 
                 ONNX_NAMESPACE::TensorShapeProto present_shape;


### PR DESCRIPTION
revert attention input_swap for now as it needs todo in handling multi-batches. This function is not targeting 1.6 release.
