### PR TITLE
Remove redundant lines of code in framework utils

### DIFF
--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -400,9 +400,6 @@ common::Status CopyOneInputAcrossDevices(const SessionState& session_state, cons
   }
 
   MLValueCopyInfo copy_info;
-  std::vector<SessionState::NodeInfo> node_info_vec;
-  ORT_RETURN_IF_ERROR(session_state.GetInputNodeInfo(input_name, node_info_vec));
-
   ORT_RETURN_IF_ERROR(CalculateStaticCopyInfoForFeed(session_state, input_name, copy_info));
   copy_info.source_device = orig_mlvalue.Get<Tensor>().Location().device;
 


### PR DESCRIPTION
**Description**: Remove a couple of lines of code that are unnecessary. They exist in the `CalculateStaticCopyInfoForFeed()` and results are consumed within that method which renders calling them before `CalculateStaticCopyInfoForFeed()` unnecessary. 

