### PR TITLE
Filter initializers for GraphViewer with IndexedSubGraph

### DIFF
--- a/include/onnxruntime/core/graph/graph_viewer.h
+++ b/include/onnxruntime/core/graph/graph_viewer.h
@@ -95,7 +95,7 @@ class GraphViewer {
   */
   const ConstGraphNodes& Nodes() const noexcept;
 
-  /** Gets the number of valid nodes in the Graph. 
+  /** Gets the number of valid nodes in the Graph.
   @remarks Returns the number of nodes in filter_info_ if set.
   */
   int NumberOfNodes() const noexcept;
@@ -103,7 +103,7 @@ class GraphViewer {
   /** Gets the maximum NodeIndex value used by Nodes in the Graph. */
   int MaxNodeIndex() const noexcept;
 
-  /** Gets the NodeIndex values for the Graph nodes, sorted into topological order.  
+  /** Gets the NodeIndex values for the Graph nodes, sorted into topological order.
   @remarks Filtered using filter_info_ if set.
   */
   const std::vector<NodeIndex>& GetNodesInTopologicalOrder(ExecutionOrder order = ExecutionOrder::DEFAULT) const;
@@ -138,7 +138,7 @@ class GraphViewer {
 
   /**
   returns true if 'name' is an initializer, and is constant and cannot be overridden at runtime.
-  @param check_outer_scope If true and the 'graph_' is a subgraph, check parent graph/s for 'name' 
+  @param check_outer_scope If true and the 'graph_' is a subgraph, check parent graph/s for 'name'
                            if the name is not found in 'graph_'.
   */
   bool IsConstantInitializer(const std::string& name, bool check_outer_scope) const;
@@ -188,5 +188,6 @@ class GraphViewer {
   std::vector<const NodeArg*> filtered_node_inputs_;
   std::vector<const NodeArg*> filtered_node_inputs_including_initializers_;
   std::vector<const NodeArg*> filtered_node_outputs_;
+  InitializedTensorSet filtered_initializers_;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/graph/graph_viewer.cc
+++ b/onnxruntime/core/graph/graph_viewer.cc
@@ -129,14 +129,14 @@ GraphViewer::GraphViewer(const Graph& graph, const IndexedSubGraph* filter_info)
       const ONNX_NAMESPACE::TensorProto* tensor = nullptr;
       for (const auto* node_input : node->InputDefs()) {
         if (graph.GetInitializedTensor(node_input->Name(), tensor)) {
-          filtered_initializers_.emplace(node_input->Name(), tensor);
+          filtered_initializers_.insert(node_input->Name(), tensor);
         }
       }
 
       // The implicit inputs for subgraphs (if any)
       for (const auto* node_input : node->ImplicitInputDefs()) {
         if (graph.GetInitializedTensor(node_input->Name(), tensor)) {
-          filtered_initializers_.emplace(node_input->Name(), tensor);
+          filtered_initializers_.insert(node_input->Name(), tensor);
         }
       }
     }

--- a/onnxruntime/core/graph/graph_viewer.cc
+++ b/onnxruntime/core/graph/graph_viewer.cc
@@ -122,12 +122,15 @@ GraphViewer::GraphViewer(const Graph& graph, const IndexedSubGraph* filter_info)
                  [this](NodeIndex idx) { return filtered_node_indices_.count(idx) != 0; });
 
     // Filter the initializers also
-    // Get the names of all the inputs of all the nodes in the subgraph
+    // Get the names of all the inputs and implicit inputs of all the nodes in this subgraph
     std::unordered_set<std::string> filtered_node_input_names;
     for (const auto node_idx : filtered_node_indices_) {
       const auto* node = GetNode(node_idx);
       ORT_ENFORCE(node, "Mismatch between Graph and IndexedSubGraph. Node not found:", node_idx);
       for (const auto* node_input : node->InputDefs()) {
+        filtered_node_input_names.insert(node_input->Name());
+      }
+      for (const auto* node_input : node->ImplicitInputDefs()) {
         filtered_node_input_names.insert(node_input->Name());
       }
     }

--- a/onnxruntime/core/graph/graph_viewer.cc
+++ b/onnxruntime/core/graph/graph_viewer.cc
@@ -129,14 +129,14 @@ GraphViewer::GraphViewer(const Graph& graph, const IndexedSubGraph* filter_info)
       const ONNX_NAMESPACE::TensorProto* tensor = nullptr;
       for (const auto* node_input : node->InputDefs()) {
         if (graph.GetInitializedTensor(node_input->Name(), tensor)) {
-          filtered_initializers_.insert(node_input->Name(), tensor);
+          filtered_initializers_.insert({node_input->Name(), tensor});
         }
       }
 
       // The implicit inputs for subgraphs (if any)
       for (const auto* node_input : node->ImplicitInputDefs()) {
         if (graph.GetInitializedTensor(node_input->Name(), tensor)) {
-          filtered_initializers_.insert(node_input->Name(), tensor);
+          filtered_initializers_.insert({node_input->Name(), tensor});
         }
       }
     }

--- a/onnxruntime/core/graph/graph_viewer.cc
+++ b/onnxruntime/core/graph/graph_viewer.cc
@@ -133,7 +133,7 @@ GraphViewer::GraphViewer(const Graph& graph, const IndexedSubGraph* filter_info)
     }
 
     // Now filtered the initializers
-    for (const auto pair : GetAllInitializedTensors()) {
+    for (const auto pair : graph.GetAllInitializedTensors()) {
       const auto& tensor_name = pair.first;
       if (filtered_node_input_names.count(tensor_name)) {
         filtered_initializers_.emplace(tensor_name, pair.second);

--- a/onnxruntime/test/ir/graph_viewer_test.cc
+++ b/onnxruntime/test/ir/graph_viewer_test.cc
@@ -92,6 +92,8 @@ TEST(GraphViewer, FilteredGraph) {
   EXPECT_EQ(viewer.GetOutputs().size(), final_metadef->outputs.size());
   EXPECT_EQ(viewer.IsSubgraph(), false)
       << "GraphViewer is for a filtered set of nodes of a single graph and not a nested subgraph";
+  EXPECT_EQ(viewer.GetAllInitializedTensors().size(), initializers.size());
+  EXPECT_LT(viewer.GetAllInitializedTensors().size(), graph.GetAllInitializedTensors().size());
 }
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/ir/graph_viewer_test.cc
+++ b/onnxruntime/test/ir/graph_viewer_test.cc
@@ -92,8 +92,14 @@ TEST(GraphViewer, FilteredGraph) {
   EXPECT_EQ(viewer.GetOutputs().size(), final_metadef->outputs.size());
   EXPECT_EQ(viewer.IsSubgraph(), false)
       << "GraphViewer is for a filtered set of nodes of a single graph and not a nested subgraph";
-  EXPECT_EQ(viewer.GetAllInitializedTensors().size(), initializers.size());
-  EXPECT_LT(viewer.GetAllInitializedTensors().size(), graph.GetAllInitializedTensors().size());
+
+  // Verify the viewer's initializers are filtered as well
+  const auto& viewer_initializers = viewer.GetAllInitializedTensors();
+  EXPECT_EQ(viewer_initializers.size(), initializers.size());
+  // We should have less initializers in the viewer than the underlying graph
+  EXPECT_LT(viewer_initializers.size(), graph.GetAllInitializedTensors().size());
+  // Pick a initializers which is not in the viewer, and check it is not part of the viewer's initializers
+  EXPECT_TRUE(viewer_initializers.count("Constant15770PastValue16469") == 0);
 }
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**: Filter initializers for GraphViewer with IndexedSubGraph

**Motivation and Context**
- Currently the initializers of GraphViewer with IndexedSubGraph is not filtered, it may include unnecessary initializers as part of the subgraph to EP , which may not be able to handle
- Add filtered initializers if the GraphViewer has a filter
- Modifed UT
- GraphViewer::IsConstantInitializer is not updated with filtered initializers, since you still need to get the initializer name from the graph viewer