### PR TITLE
Temporary fix for Android CI failure

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
@@ -263,8 +263,12 @@ Status ModelBuilder::RegisterModelInputs() {
       shape.push_back(SafeInt<uint32_t>(dim.dim_value()));
     }
 
-    ORT_RETURN_IF_NOT(GetAndroidSdkVer() >= 29 || !shape.empty(),
-                      "0-rank input is only supported on Android API level 29+");
+    // NNAPI has strict input type requirements which separates tensor inputs and scalar inputs
+    // For ONNX the we do not have clear line between scalar inputs and tensor inputs
+    // Also NNAPI treats a tensor input with empty shape as dynamic shape input
+    // Disable support of the scalar input (tensor input with an empty shape) for now
+    // TODO, add support for ONNX scalar input (tensor input with an empty shape)
+    ORT_RETURN_IF_NOT(!shape.empty(), "0-rank input is not currently supported, input name, ", input_name);
 
     Type type = Type::TENSOR_FLOAT32;
     float scale = 0.0f;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
@@ -312,9 +312,10 @@ common::Status NnapiExecutionProvider::Compile(const std::vector<FusedNodeAndGra
         // Also NNAPI treats a tensor input with empty shape as dynamic shape input
         // Disable support of the scalar input (tensor input with an empty shape) for now
         // TODO, add support for ONNX scalar input (tensor input with an empty shape)
-        if (dimensions.empty())
-          return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "NNAPI does not support scalar input");
-
+        if (dimensions.empty()) {
+          return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                                 "NNAPI does not support scalar input, input name, ", input_name);
+        }
         // it is possible that the input has the detailed size while
         // the model has an operand with unknown size, use the size
         // of the actual input

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -6,7 +6,7 @@ jobs:
   steps:
     - script: brew install coreutils ninja
       displayName: Install coreutils and ninja
-    - script: tools/ci_build/build.py --android --build_dir build --android_sdk_path $ANDROID_HOME --android_ndk_path $ANDROID_HOME/ndk-bundle --android_abi=x86_64 --android_api=29 --skip_submodule_sync --parallel --cmake_generator=Ninja --build_java
+    - script: python3 tools/ci_build/build.py --android --build_dir build --android_sdk_path $ANDROID_HOME --android_ndk_path $ANDROID_HOME/ndk-bundle --android_abi=x86_64 --android_api=29 --skip_submodule_sync --parallel --cmake_generator=Ninja --build_java
       displayName: CPU EP, Build and Test on Android Emulator
-    - script: tools/ci_build/build.py --android --build_dir build_nnapi --android_sdk_path $ANDROID_HOME --android_ndk_path $ANDROID_HOME/ndk-bundle --android_abi=x86_64 --android_api=29 --skip_submodule_sync --parallel --use_nnapi --cmake_generator=Ninja --build_java
+    - script: python3 tools/ci_build/build.py --android --build_dir build_nnapi --android_sdk_path $ANDROID_HOME --android_ndk_path $ANDROID_HOME/ndk-bundle --android_abi=x86_64 --android_api=29 --skip_submodule_sync --parallel --use_nnapi --cmake_generator=Ninja --build_java
       displayName: NNAPI EP, Build and Test on Android Emulator


### PR DESCRIPTION
**Description**: Temporary fix for Android CI failure

**Motivation and Context**
- Since onnx does not have dynamic rank input, ({} shape means input is a scalar), and NNAPI treat input with empty shape as dynamic ranking, the fix is to fail the EP::Compile instead of fail the Compute
- This is a temporary fix to unblock Android CI, the proper fix to support scalar input will require more investigation after 1.6 

