### PR TITLE
fix for hetero multi python binding with new shared library

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -663,9 +663,10 @@ static void RegisterExecutionProviders(InferenceSession* sess, const std::vector
       auto it = provider_options_map.find(type);
       if (it != provider_options_map.end()) {
         for (auto option : it->second) {
-          if (option.first == "device_type")
+          if (option.first == "device_type") {
             openvino_device_type = option.second;
-            param.device_type = openvino_device_type.c_str();
+            params.device_type = openvino_device_type.c_str();
+          }  
           else if (option.first == "enable_vpu_fast_compile") {
             if (option.second == "True") {
               params.enable_vpu_fast_compile = true;

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -665,6 +665,7 @@ static void RegisterExecutionProviders(InferenceSession* sess, const std::vector
         for (auto option : it->second) {
           if (option.first == "device_type")
             openvino_device_type = option.second;
+            param.device_type = openvino_device_type.c_str();
           else if (option.first == "enable_vpu_fast_compile") {
             if (option.second == "True") {
               params.enable_vpu_fast_compile = true;


### PR DESCRIPTION
This is a fix for hetero multi bindings for python which were broken with the new shared lib changes 

**Motivation and Context**
- This changes was required because python bindings for hetero and multi were broken with the new shared library changes 
- If it fixes an open issue, please link to the issue here.
