### PR TITLE
Fix a tiny issue in onnxruntime_unittests.cmake

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -515,7 +515,7 @@ else()
   target_include_directories(onnxruntime_test_utils PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT}
           "${CMAKE_CURRENT_SOURCE_DIR}/external/nsync/public")
 endif()
-onnxruntime_add_include_to_target(onnxruntime_test_utils onnxruntime_common onnxruntime_framework GTest::gtest GTest::gmock onnx onnx_proto flatbuffers)
+onnxruntime_add_include_to_target(onnxruntime_test_utils onnxruntime_common onnxruntime_framework onnxruntime_session GTest::gtest GTest::gmock onnx onnx_proto flatbuffers)
 
 if (onnxruntime_USE_DNNL)
   target_compile_definitions(onnxruntime_test_utils PUBLIC USE_DNNL=1)


### PR DESCRIPTION
**Description**: 

Without the change,  the InferenceSession class may have a different size when it was used in the onnxruntime_test_utils project.

**Motivation and Context**
- Why is this change required? What problem does it solve?

Unitests will crash when the build option onnxruntime_ENABLE_INSTRUMENT is enabled.

- If it fixes an open issue, please link to the issue here.
