### PR TITLE
Revert "Improves performance  of operator Transpose (#5550)"

### DIFF
--- a/onnxruntime/test/providers/cpu/tensor/transpose_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/transpose_test.cc
@@ -246,39 +246,6 @@ TEST(TransposeOpTest, ThreeDimSuffix) {
   TransposeTest(input_shape, input_vals, &perm, expected_shape, expected_vals, false);  //TensorRT: illegal error
 }
 
-TEST(TransposeOpTest, TransposeReshape) {
-  std::vector<int64_t> input_shape({1, 4, 2, 1, 3});
-  std::vector<float> input_vals = {
-      1.0f, 2.0f, 3.0f,
-      4.0f, 5.0f, 6.0f,
-
-      1.1f, 2.1f, 3.1f,
-      4.1f, 5.1f, 6.1f,
-
-      1.2f, 2.2f, 3.2f,
-      4.2f, 5.2f, 6.2f,
-
-      1.3f, 2.3f, 3.3f,
-      4.3f, 5.3f, 6.3f};
-
-  std::vector<int64_t> perm = {1, 3, 2, 4, 0};
-  std::vector<int64_t> expected_shape({4, 1, 2, 3, 1});
-  auto expected_vals = {
-      1.0f, 2.0f, 3.0f,
-      4.0f, 5.0f, 6.0f,
-
-      1.1f, 2.1f, 3.1f,
-      4.1f, 5.1f, 6.1f,
-
-      1.2f, 2.2f, 3.2f,
-      4.2f, 5.2f, 6.2f,
-
-      1.3f, 2.3f, 3.3f,
-      4.3f, 5.3f, 6.3f};
-
-  TransposeTest(input_shape, input_vals, &perm, expected_shape, expected_vals, false);  //TensorRT: illegal error
-}
-
 TEST(TransposeOpTest, ThreeDimStr) {
   std::vector<int64_t> input_shape({4, 2, 3});
   std::vector<std::string> input_vals = {


### PR DESCRIPTION
This reverts commit e5c8040c52b67b3f4bfd4df792c0bbb99b39f631.

**Description**: 

Pointer read/write out of bound. The TypedDoTransposeEltWise function doesn't really work. If you want to copy the array 8 bytes a time, at least you should have code to deal with the case that the size of data is not a multiple of 8.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
