### PR TITLE
Symbolic shape inference: fix rank for ConstantOfShape

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -623,7 +623,8 @@ class SymbolicShapeInference:
                 self.sympy_data_[node.output[0]] = np.ones([int(x) for x in sympy_shape], dtype=np.int64) * numpy_helper.to_array(get_attribute(node, 'value', 0))
         else:
             # create new dynamic shape
-            sympy_shape = self._new_symbolic_shape(self._get_shape_rank(node,0), node)
+            # note input0 is a 1D vector of shape, the new symbolic shape has the rank of the shape vector length
+            sympy_shape = self._new_symbolic_shape(self._get_shape(node,0)[0], node)
 
         vi.CopyFrom(helper.make_tensor_value_info(node.output[0],
                                                   vi.type.tensor_type.elem_type,


### PR DESCRIPTION
When dims are dynamic, the rank was incorrect, which leads to failure in certain models.