### PR TITLE
Report arm64 minimal baseline binary size only for continuous integration

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -95,6 +95,7 @@ jobs:
           -e BUILD_BUILDNUMBER \
           -e BUILD_SOURCEVERSION=$(Build.SourceVersion) \
           -e BUILD_ID=$(Build.BuildId) \
+          -e BUILD_REASON=$(Build.Reason) \
           -e DASHBOARD_MYSQL_ORT_PASSWORD=$(dashboard-mysql-ort-password) \
           onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntimecentoscpubuild:ch3 \
             /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh

--- a/tools/ci_build/github/linux/ort_minimal/build_full_ort_and_create_ort_files.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_full_ort_and_create_ort_files.sh
@@ -4,6 +4,7 @@
 # and the exclude ops config file, which will be used in the build_minimal_ort_and_run_tests.sh
 
 set -e
+set -x
 
 # Validate the operator kernel registrations. The ORT model uses hashes for kernel registrations, so if these
 # are incorrect we will produce a model that will break when the registrations are fixed.

--- a/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_and_run_tests.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_and_run_tests.sh
@@ -7,6 +7,7 @@
 # Extra E2E test cases (converted by build_full_ort_and_create_ort_files.sh) will be run by onnx_test_runner
 
 set -e
+set -x
 
 # Clear the previous build
 rm -rf /build/Debug

--- a/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
@@ -34,7 +34,7 @@ python3 -m pip install --user mysql-connector-python
 
 # Post the binary size info to ort mysql DB
 # The report script's DB connection failure will not fail the pipeline
-if [ $BUILD_REASON="IndividualCI" ] OR [ $BUILD_REASON="BatchedCI" ]; then
+if [[ $BUILD_REASON == "IndividualCI" || $BUILD_REASON == "BatchedCI" ]]; then
     python3 /onnxruntime_src/tools/ci_build/github/windows/post_binary_sizes_to_dashboard.py \
         --ignore_db_error \
         --commit_hash=$BUILD_SOURCEVERSION \

--- a/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
@@ -4,6 +4,7 @@
 # and report the binary size to the ort mysql DB
 
 set -e
+set -x
 
 # Create an empty file to be used with build --include_ops_by_config, which will include no operators at all
 echo -n > /home/onnxruntimedev/.test_data/include_no_operators.config
@@ -33,12 +34,18 @@ python3 -m pip install --user mysql-connector-python
 
 # Post the binary size info to ort mysql DB
 # The report script's DB connection failure will not fail the pipeline
-python3 /onnxruntime_src/tools/ci_build/github/windows/post_binary_sizes_to_dashboard.py \
-    --ignore_db_error \
-    --commit_hash=$BUILD_SOURCEVERSION \
-    --size_data_file=/build/MinSizeRel/binary_size_data.txt \
-    --build_project=onnxruntime \
-    --build_id=$BUILD_ID
+if [ $BUILD_REASON="IndividualCI" ] OR [ $BUILD_REASON="BatchedCI" ]; then
+    python3 /onnxruntime_src/tools/ci_build/github/windows/post_binary_sizes_to_dashboard.py \
+        --ignore_db_error \
+        --commit_hash=$BUILD_SOURCEVERSION \
+        --size_data_file=/build/MinSizeRel/binary_size_data.txt \
+        --build_project=onnxruntime \
+        --build_id=$BUILD_ID
+else
+    echo "No binary size report for build reason: $BUILD_REASON"
+    echo "The content of binary_size_data.txt"
+    cat /build/MinSizeRel/binary_size_data.txt
+fi
 
 # Clear the build
 rm -rf /build/MinSizeRel

--- a/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
@@ -34,6 +34,7 @@ python3 -m pip install --user mysql-connector-python
 
 # Post the binary size info to ort mysql DB
 # The report script's DB connection failure will not fail the pipeline
+# To reduce noise, we only report binary size for Continuous integration (a merge to master or rel-*)
 if [[ $BUILD_REASON == "IndividualCI" || $BUILD_REASON == "BatchedCI" ]]; then
     python3 /onnxruntime_src/tools/ci_build/github/windows/post_binary_sizes_to_dashboard.py \
         --ignore_db_error \


### PR DESCRIPTION
**Description**: Report binary size only for continuous integration

**Motivation and Context**
- Right now we report arm64 baseline binary size for every PR commit, which is a bit noisy and hard to pin-point the exact merge causing binary size change.
- Make the size reporting only for  continuous integration, the rest triggered job will have the size data printed on console of CI

