### PR TITLE
Add OpenVINO EP shared lib to Py Wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,14 +158,13 @@ except ImportError as error:
 # Additional binaries
 if platform.system() == 'Linux':
   libs = ['onnxruntime_pybind11_state.so', 'libdnnl.so.1', 'libmklml_intel.so', 'libmklml_gnu.so', 'libiomp5.so', 'mimalloc.so']
-  # DNNL & TensorRT EPs are built as shared libs
+  # DNNL, TensorRT & OpenVINO EPs are built as shared libs
   libs.extend(['libonnxruntime_providers_shared.so'])
   libs.extend(['libonnxruntime_providers_dnnl.so'])
   libs.extend(['libonnxruntime_providers_tensorrt.so'])
-  # OpenVINO Libs
-  if package_name == 'onnxruntime-openvino':
-    libs.extend(['libonnxruntime_providers_openvino.so'])
-    libs.extend(['libovep_ngraph.so'])
+  libs.extend(['libonnxruntime_providers_openvino.so'])
+  # OpenVINO libs
+  libs.extend(['libovep_ngraph.so'])
   # Nuphar Libs
   libs.extend(['libtvm.so.0.5.1'])
   if nightly_build:
@@ -180,14 +179,13 @@ elif platform.system() == "Darwin":
     libs.extend(['libonnxruntime_pywrapper.dylib'])
 else:
   libs = ['onnxruntime_pybind11_state.pyd', 'dnnl.dll', 'mklml.dll', 'libiomp5md.dll']
-  # DNNL & TensorRT EPs are built as shared libs
+  # DNNL, TensorRT & OpenVINO EPs are built as shared libs
   libs.extend(['onnxruntime_providers_shared.dll'])
   libs.extend(['onnxruntime_providers_dnnl.dll'])
   libs.extend(['onnxruntime_providers_tensorrt.dll'])
+  libs.extend(['onnxruntime_providers_openvino.dll'])
   # DirectML Libs
   libs.extend(['directml.dll'])
-  # OpenVINO Libs
-  libs.extend(['onnxruntime_providers_openvino.dll'])
   # Nuphar Libs
   libs.extend(['tvm.dll'])
   if nightly_build:

--- a/setup.py
+++ b/setup.py
@@ -164,8 +164,8 @@ if platform.system() == 'Linux':
   libs.extend(['libonnxruntime_providers_tensorrt.so'])
   # OpenVINO Libs
   if package_name == 'onnxruntime-openvino':
-    if platform.system() == 'Linux':
-      libs.extend(['libovep_ngraph.so'])
+    libs.extend(['libonnxruntime_providers_openvino.so'])
+    libs.extend(['libovep_ngraph.so'])
   # Nuphar Libs
   libs.extend(['libtvm.so.0.5.1'])
   if nightly_build:
@@ -186,6 +186,8 @@ else:
   libs.extend(['onnxruntime_providers_tensorrt.dll'])
   # DirectML Libs
   libs.extend(['directml.dll'])
+  # OpenVINO Libs
+  libs.extend(['onnxruntime_providers_openvino.dll'])
   # Nuphar Libs
   libs.extend(['tvm.dll'])
   if nightly_build:


### PR DESCRIPTION
**Description**: Include the libonnxruntime_providers_openvino.so/.dll to the whl package.

**Motivation and Context**
- OpenVINO EP is now built as a separate shared library, and needs to be explicitly included in the .whl package for python builds
