### PR TITLE
Enable scalar input/output for NNAPI EP

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
@@ -333,7 +333,7 @@ Status ModelBuilder::RegisterModelOutputs() {
 
     // Since for now all the shapes are deterministic for NNAPI, it's impossible we can have unknown output shape
     const auto* shape_proto = node_arg->Shape();
-    ORT_RETURN_IF_NOT(shape_proto != nullptr, "shape_proto cannot be null for output: ", output_name);
+    ORT_RETURN_IF(shape_proto == nullptr, "shape_proto cannot be null for output: ", output_name);
     if (shape_proto->dim_size() == 0) {
       // In NNAPI scalar output must have {1} shape
       const auto& output_shape = shaper_[output_name];
@@ -342,6 +342,8 @@ Status ModelBuilder::RegisterModelOutputs() {
                         " actual shape, ", Shape2String(output_shape));
 
       // Record the scalar output
+      // Since within NNAPI the scalar outputs will have {1} shapes, and for ORT scalar outputs will have {} shapes,
+      // we need to change the shapes of these scalar outputs back to {} when NNAPI EP returns these values to ORT
       nnapi_model_->AddScalarOutput(output_name);
     }
 

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
@@ -331,6 +331,13 @@ Status ModelBuilder::RegisterModelOutputs() {
                              "The output of graph is not registered [", output_name, "]");
     }
 
+    // Since for now all the shapes are deterministic for NNAPI, it's impossible we can have unknown output shape
+    const auto* shape_proto = node_arg->Shape();
+    ORT_RETURN_IF_NOT(shape_proto != nullptr, "shape_proto cannot be null for output: ", output_name);
+    // Record the scalar output
+    if (shape_proto->dim_size() == 0)
+      nnapi_model_->AddScalarOutput(output_name);
+
     std::string nnapi_output_name = output_name;
     if (IsOperandNHWC(output_name)) {
       // We need to transpose the output still in nhwc back to nchw

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
@@ -181,10 +181,12 @@ Status ModelBuilder::RegisterInitializers() {
       shape.push_back(SafeInt<uint32_t>(dim));
     }
 
-    // If we have an empty shape, this is a scalar initializer, since NNAPI does not allow empty shape,
-    // we will make the scalar initializer a {1} tensor
-    if (shape.empty())
+    // If we have an empty shape, this is a scalar initializer,
+    // since NNAPI will treat empty shape input as dynamic ranking input, (onnx does not support dynamic ranking)
+    // we will make the scalar initializer as a {1} tensor
+    if (shape.empty()) {
       shape.push_back(1);
+    }
 
     Type type = Type::TENSOR_FLOAT32;
     switch (tensor.data_type()) {
@@ -263,12 +265,12 @@ Status ModelBuilder::RegisterModelInputs() {
       shape.push_back(SafeInt<uint32_t>(dim.dim_value()));
     }
 
-    // NNAPI has strict input type requirements which separates tensor inputs and scalar inputs
-    // For ONNX the we do not have clear line between scalar inputs and tensor inputs
-    // Also NNAPI treats a tensor input with empty shape as dynamic shape input
-    // Disable support of the scalar input (tensor input with an empty shape) for now
-    // TODO, add support for ONNX scalar input (tensor input with an empty shape)
-    ORT_RETURN_IF_NOT(!shape.empty(), "0-rank input is not currently supported, input name, ", input_name);
+    // If we have an empty shape, this is a scalar input,
+    // since NNAPI will treat empty shape input as dynamic ranking input, (onnx does not support dynamic ranking)
+    // we will make the scalar input as a {1} tensor
+    if (shape.empty()) {
+      shape.push_back(1);
+    }
 
     Type type = Type::TENSOR_FLOAT32;
     float scale = 0.0f;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/model.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/model.cc
@@ -40,6 +40,14 @@ void Model::AddOutput(const std::string& onnx_output_name,
   operand_types_.emplace(nnapi_output_name, operand_type);
 }
 
+bool Model::IsScalarOutput(const std::string& output_name) const {
+  return Contains(scalar_outputs_, output_name);
+}
+
+void Model::AddScalarOutput(const std::string& output_name) {
+  scalar_outputs_.insert(output_name);
+}
+
 const std::vector<std::string>& Model::GetInputs() const {
   return input_names_;
 }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/model.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/model.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <unordered_set>
+
 #include "builders/shaper.h"
 #include "core/platform/ort_mutex.h"
 #include "nnapi_lib/NeuralNetworksWrapper.h"
@@ -96,6 +98,11 @@ class Model {
   // Mutex for exclusive lock to this model object
   OrtMutex& GetMutex() { return mutex_; }
 
+  // If the given output is a scalar output
+  // Since NNAPI does not support tensor with empty shape (scalar), we use {1} tensor for scalar in NNAPI
+  // this output may need special handling
+  bool IsScalarOutput(const std::string& output_name) const;
+
   Status PrepareForExecution(std::unique_ptr<Execution>& execution) ORT_MUST_USE_RESULT;
 
  private:
@@ -112,6 +119,7 @@ class Model {
   std::vector<std::string> input_names_;
   std::vector<std::string> output_names_;
   std::unordered_map<std::string, android::nn::wrapper::OperandType> operand_types_;
+  std::unordered_set<std::string> scalar_outputs_;
 
   Shaper shaper_;
 
@@ -132,6 +140,8 @@ class Model {
   void AddOutput(const std::string& onnx_output_name,
                  const std::string& nnapi_output_name,
                  const android::nn::wrapper::OperandType& operand_type);
+
+  void AddScalarOutput(const std::string& output_name);
 
   void SetShaper(const Shaper shaper) { shaper_ = shaper; }
 

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
@@ -386,8 +386,7 @@ common::Status NnapiExecutionProvider::Compile(const std::vector<FusedNodeAndGra
           if (!is_dynamic_shape_output) {
             // Since NNAPI use {1} tensor as scalar, if the model output should have empty shape
             // We are going to replace the {1} shape of the output back to {}
-            bool is_scalar_output = model->IsScalarOutput(output_name);
-            if (is_scalar_output)
+            if (model->IsScalarOutput(output_name))
               output_shape.clear();
 
             ORT_RETURN_IF_ERROR(GetOutputBuffer(ort, context,

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
@@ -387,7 +387,7 @@ common::Status NnapiExecutionProvider::Compile(const std::vector<FusedNodeAndGra
             // Since NNAPI use {1} tensor as scalar, if the model output should have empty shape
             // We are going to replace the {1} shape of the output back to {}
             bool is_scalar_output = model->IsScalarOutput(output_name);
-            if (is_scalar_output && output_shape == std::vector<uint32_t>{1})
+            if (is_scalar_output)
               output_shape.clear();
 
             ORT_RETURN_IF_ERROR(GetOutputBuffer(ort, context,

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -285,8 +285,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     double per_sample_tolerance = 1e-3;
     // when cuda is enabled, set it to a larger value for resolving random MNIST test failure
     // when openvino is enabled, set it to a larger value for resolving MNIST accuracy mismatch
-    double relative_per_sample_tolerance = enable_cuda ? 0.017 : enable_openvino ? 0.009
-                                                                                 : 1e-3;
+    double relative_per_sample_tolerance = enable_cuda ? 0.017 : enable_openvino ? 0.009 : 1e-3;
 
     Ort::SessionOptions sf;
 
@@ -739,6 +738,29 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     broken_tests.insert({"nllloss_NCd1_weight_ii_expanded", "wait for investigation"});
     broken_tests.insert({"nllloss_NCd1d2_no_weight_reduction_mean_ii", "wait for investigation"});
     broken_tests.insert({"nllloss_NCd1d2_no_weight_reduction_mean_ii_expanded", "wait for investigation"});
+
+    // Disabled on error: shape mismatch, expect {} got {1}
+    // NNAPI does not support scalar output, all the outputs are tensors, scalar output will be a {1} tensor
+    {
+      broken_tests.insert({"sce_NCd1_mean_weight_negative_ii", "Shape mismatch"});
+      broken_tests.insert({"sce_NCd1_mean_weight_negative_ii_expanded", "Shape mismatch"});
+      broken_tests.insert({"sce_NCd1d2d3d4d5_mean_weight", "Shape mismatch"});
+      broken_tests.insert({"sce_NCd1d2d3d4d5_mean_weight_expanded", "Shape mismatch"});
+      broken_tests.insert({"sce_mean_no_weight_ii", "Shape mismatch"});
+      broken_tests.insert({"sce_mean_no_weight_ii_3d", "Shape mismatch"});
+      broken_tests.insert({"sce_mean_no_weight_ii_3d_expanded", "Shape mismatch"});
+      broken_tests.insert({"sce_mean_no_weight_ii_4d", "Shape mismatch"});
+      broken_tests.insert({"sce_mean_no_weight_ii_4d_expanded", "Shape mismatch"});
+      broken_tests.insert({"sce_mean_no_weight_ii_expanded", "Shape mismatch"});
+      broken_tests.insert({"sce_mean_weight", "Shape mismatch"});
+      broken_tests.insert({"sce_mean_weight_expanded", "Shape mismatch"});
+      broken_tests.insert({"sce_mean_weight_ii", "Shape mismatch"});
+      broken_tests.insert({"sce_mean_weight_ii_3d", "Shape mismatch"});
+      broken_tests.insert({"sce_mean_weight_ii_3d_expanded", "Shape mismatch"});
+      broken_tests.insert({"sce_mean_weight_ii_4d", "Shape mismatch"});
+      broken_tests.insert({"sce_mean_weight_ii_4d_expanded", "Shape mismatch"});
+      broken_tests.insert({"sce_mean_weight_ii_expanded", "Shape mismatch"});
+    }
   }
 
   if (enable_tensorrt) {

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -285,7 +285,8 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     double per_sample_tolerance = 1e-3;
     // when cuda is enabled, set it to a larger value for resolving random MNIST test failure
     // when openvino is enabled, set it to a larger value for resolving MNIST accuracy mismatch
-    double relative_per_sample_tolerance = enable_cuda ? 0.017 : enable_openvino ? 0.009 : 1e-3;
+    double relative_per_sample_tolerance = enable_cuda ? 0.017 : enable_openvino ? 0.009
+                                                                                 : 1e-3;
 
     Ort::SessionOptions sf;
 
@@ -738,29 +739,6 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     broken_tests.insert({"nllloss_NCd1_weight_ii_expanded", "wait for investigation"});
     broken_tests.insert({"nllloss_NCd1d2_no_weight_reduction_mean_ii", "wait for investigation"});
     broken_tests.insert({"nllloss_NCd1d2_no_weight_reduction_mean_ii_expanded", "wait for investigation"});
-
-    // Disabled on error: shape mismatch, expect {} got {1}
-    // NNAPI does not support scalar output, all the outputs are tensors, scalar output will be a {1} tensor
-    {
-      broken_tests.insert({"sce_NCd1_mean_weight_negative_ii", "Shape mismatch"});
-      broken_tests.insert({"sce_NCd1_mean_weight_negative_ii_expanded", "Shape mismatch"});
-      broken_tests.insert({"sce_NCd1d2d3d4d5_mean_weight", "Shape mismatch"});
-      broken_tests.insert({"sce_NCd1d2d3d4d5_mean_weight_expanded", "Shape mismatch"});
-      broken_tests.insert({"sce_mean_no_weight_ii", "Shape mismatch"});
-      broken_tests.insert({"sce_mean_no_weight_ii_3d", "Shape mismatch"});
-      broken_tests.insert({"sce_mean_no_weight_ii_3d_expanded", "Shape mismatch"});
-      broken_tests.insert({"sce_mean_no_weight_ii_4d", "Shape mismatch"});
-      broken_tests.insert({"sce_mean_no_weight_ii_4d_expanded", "Shape mismatch"});
-      broken_tests.insert({"sce_mean_no_weight_ii_expanded", "Shape mismatch"});
-      broken_tests.insert({"sce_mean_weight", "Shape mismatch"});
-      broken_tests.insert({"sce_mean_weight_expanded", "Shape mismatch"});
-      broken_tests.insert({"sce_mean_weight_ii", "Shape mismatch"});
-      broken_tests.insert({"sce_mean_weight_ii_3d", "Shape mismatch"});
-      broken_tests.insert({"sce_mean_weight_ii_3d_expanded", "Shape mismatch"});
-      broken_tests.insert({"sce_mean_weight_ii_4d", "Shape mismatch"});
-      broken_tests.insert({"sce_mean_weight_ii_4d_expanded", "Shape mismatch"});
-      broken_tests.insert({"sce_mean_weight_ii_expanded", "Shape mismatch"});
-    }
   }
 
   if (enable_tensorrt) {

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -205,11 +205,7 @@ TEST(MathOpTest, Add_Broadcast_0x1) {
     test.Run(OpTester::ExpectResult::kExpectSuccess, "");
   };
 
-  // NNAPI only supports scalar initializer, not scalar input
-#ifndef USE_NNAPI
   run(false);
-#endif
-
   run(true);
 }
 
@@ -222,11 +218,8 @@ TEST(MathOpTest, Add_Broadcast_1x0) {
     test.AddOutput<float>("C", {1}, {12.0f});
     test.Run(OpTester::ExpectResult::kExpectSuccess, "");
   };
-  // NNAPI only supports scalar initializer, not scalar input
-#ifndef USE_NNAPI
-  run(false);
-#endif
 
+  run(false);
   run(true);
 }
 
@@ -398,11 +391,7 @@ TEST(MathOpTest, Sub_Broadcast_Scalar) {
     test.Run(OpTester::ExpectResult::kExpectSuccess, "");
   };
 
-  // NNAPI only supports scalar initializer, not scalar input
-#ifndef USE_NNAPI
   run(false);
-#endif
-
   run(true);
 }
 

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -192,7 +192,7 @@ TEST(MathOpTest, Add_Broadcast_0x0) {
   test.AddInput<float>("A", {}, {10.0f});
   test.AddInput<float>("B", {}, {2.0f});
   test.AddOutput<float>("C", {}, {12.0f});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kNnapiExecutionProvider});  // NNAPI: Add does not support scalar input
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "");
 }
 
 TEST(MathOpTest, Add_Broadcast_0x1) {


### PR DESCRIPTION
**Description**: Enable scalar input for NNAPI EP

**Motivation and Context**
- We disabled scalar input for NNAPI before, re-enable it
- Add code to map the shape of the scalar output from NNAPI to ORT ({1} tensor ==> {0} tensor)
- Enable some UTs