### PR TITLE
Update dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .git
 .gitignore
 .gitattributes
-docs
 

--- a/dockerfiles/Dockerfile.cuda
+++ b/dockerfiles/Dockerfile.cuda
@@ -6,27 +6,19 @@
 
 # nVidia cuda 10.2 Base Image
 FROM nvidia/cuda:10.2-cudnn8-devel
-MAINTAINER Vinitra Swamy "viswamy@microsoft.com"
+MAINTAINER Changming Sun "chasun@microsoft.com"
+ADD . /code
 
-ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
-ARG ONNXRUNTIME_BRANCH=master
-
-RUN apt-get update &&\
-    apt-get install -y sudo git bash unattended-upgrades
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-certificates g++ python3-numpy gcc make git python3-setuptools python3-wheel python3-pip unattended-upgrades
 RUN unattended-upgrade
 
-WORKDIR /code
-ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/code/cmake-3.14.3-Linux-x86_64/bin:/opt/miniconda/bin:${PATH}
-ENV LD_LIBRARY_PATH /opt/miniconda/lib:$LD_LIBRARY_PATH
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-certificates g++ python3-numpy gcc make git python3-setuptools python3-wheel python3-pip aria2 && aria2c -q -d /tmp -o cmake-3.18.2-Linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-Linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.18.2-Linux-x86_64.tar.gz --strip=1 -C /usr
 
-# Prepare onnxruntime repository & build onnxruntime with CUDA
-RUN git clone --single-branch --branch ${ONNXRUNTIME_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime &&\
-    /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh &&\
-    cp onnxruntime/docs/Privacy.md /code/Privacy.md &&\
-    cp onnxruntime/ThirdPartyNotices.txt /code/ThirdPartyNotices.txt &&\
-    cp onnxruntime/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt &&\
-    cd onnxruntime &&\
-    /bin/sh ./build.sh --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_cuda --config Release --build_wheel --update --build --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) &&\
-    pip install /code/onnxruntime/build/Linux/Release/dist/*.whl &&\
-    cd .. &&\
-    rm -rf onnxruntime cmake-3.14.3-Linux-x86_64
+RUN cd /code && /bin/bash ./build.sh --skip_submodule_sync --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_cuda --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 'CMAKE_CUDA_ARCHITECTURES=30;37;50;52;60;70'
+
+FROM nvidia/cuda:10.2-cudnn8-runtime
+COPY --from=0 /code/build/Linux/Release/dist /root
+COPY --from=0 /code/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt
+RUN apt-get update && apt-get install -y --no-install-recommends libstdc++6 ca-certificates python3-setuptools python3-wheel python3-pip && python3 -m pip install /root/*.whl && rm -rf /root/*.whl

--- a/dockerfiles/Dockerfile.source
+++ b/dockerfiles/Dockerfile.source
@@ -4,24 +4,17 @@
 # --------------------------------------------------------------
 # Dockerfile to run ONNXRuntime with source build for CPU
 
-# Ubuntu 16.04 Base Image
-FROM ubuntu:16.04
-MAINTAINER Vinitra Swamy "viswamy@microsoft.com"
+FROM ubuntu:18.04
+MAINTAINER Changming Sun "chasun@microsoft.com"
+ADD . /code
 
-ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
-ARG ONNXRUNTIME_SERVER_BRANCH=master
-
-RUN apt-get update &&\
-    apt-get install -y sudo git bash
-
-WORKDIR /code
-ENV PATH /opt/miniconda/bin:/code/cmake-3.14.3-Linux-x86_64/bin:${PATH}
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-certificates g++ python3-numpy gcc make git python3-setuptools python3-wheel python3-pip aria2 && aria2c -q -d /tmp -o cmake-3.18.2-Linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-Linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.18.2-Linux-x86_64.tar.gz --strip=1 -C /usr
 
 # Prepare onnxruntime repository & build onnxruntime
-RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime &&\
-    /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh &&\
-    cd onnxruntime &&\
-    /bin/sh ./build.sh --use_openmp --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) &&\
-    pip install /code/onnxruntime/build/Linux/Release/dist/*.whl &&\
-    cd .. &&\
-    rm -rf onnxruntime cmake-3.14.3-Linux-x86_64
+RUN cd /code && /bin/bash ./build.sh --skip_submodule_sync --use_openmp --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 
+
+FROM ubuntu:18.04
+COPY --from=0 /code/build/Linux/Release/dist /root
+COPY --from=0 /code/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt
+RUN apt-get update && apt-get install -y --no-install-recommends libstdc++6 libgomp1 ca-certificates python3-setuptools python3-wheel python3-pip && python3 -m pip install /root/*.whl && rm -rf /root/*.whl

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -41,7 +41,7 @@ Use `docker pull` with any of the images and tags below to pull an image and try
 
 1. Build the docker image from the Dockerfile in this repository.
   ```
-  docker build -t onnxruntime-source -f Dockerfile.source .
+  docker build -t onnxruntime-source -f Dockerfile.source ..
   ```
 
 2. Run the Docker image
@@ -51,11 +51,11 @@ Use `docker pull` with any of the images and tags below to pull an image and try
   ```
 
 ## CUDA
-**Ubuntu 16.04, CUDA 10.0, CuDNN 7**
+**Ubuntu 18.04, CUDA 10.2, CuDNN 8**
 
 1. Build the docker image from the Dockerfile in this repository.
   ```
-  docker build -t onnxruntime-cuda -f Dockerfile.cuda .
+  docker build -t onnxruntime-cuda -f Dockerfile.cuda ..
   ```
 
 2. Run the Docker image

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -2013,7 +2013,7 @@ def main():
             is_cpu_only = not(args.use_cuda or args.use_dnnl or args.use_tensorrt
                               or args.use_openvino or args.use_nuphar or args.use_vitisai
                               or args.use_acl or args.use_armnn or args.use_dml)
-            #TODO: Each of the EPs should have a unique name suffix
+            # TODO: Each of the EPs should have a unique name suffix
             wheel_name_suffix = args.wheel_name_suffix
             if not args.use_openmp and wheel_name_suffix is None and is_cpu_only:
                 wheel_name_suffix = 'noopenmp'

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -2010,8 +2010,12 @@ def main():
     if args.build:
         if args.build_wheel:
             nightly_build = bool(os.getenv('NIGHTLY_BUILD') == '1')
+            is_cpu_only = not(args.use_cuda or args.use_dnnl or args.use_tensorrt
+                              or args.use_openvino or args.use_nuphar or args.use_vitisai
+                              or args.use_acl or args.use_armnn or args.use_dml)
+            #TODO: Each of the EPs should have a unique name suffix
             wheel_name_suffix = args.wheel_name_suffix
-            if not args.use_openmp and wheel_name_suffix is None:
+            if not args.use_openmp and wheel_name_suffix is None and is_cpu_only:
                 wheel_name_suffix = 'noopenmp'
 
             build_python_wheel(

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -2010,12 +2010,8 @@ def main():
     if args.build:
         if args.build_wheel:
             nightly_build = bool(os.getenv('NIGHTLY_BUILD') == '1')
-            is_cpu_only = not(args.use_cuda or args.use_dnnl or args.use_tensorrt
-                              or args.use_openvino or args.use_nuphar or args.use_vitisai
-                              or args.use_acl or args.use_armnn or args.use_dml)
-            # TODO: Each of the EPs should have a unique name suffix
             wheel_name_suffix = args.wheel_name_suffix
-            if not args.use_openmp and wheel_name_suffix is None and is_cpu_only:
+            if not args.use_openmp and wheel_name_suffix is None:
                 wheel_name_suffix = 'noopenmp'
 
             build_python_wheel(


### PR DESCRIPTION
**Description**: 

1. Remove conda from the images. Because conda contains a file named /opt/miniconda/lib/libcrypto.so.1.0.0 which can't pass our security scan. Also, it will be easier for us to manage the third party usage registrations. 
2. Remove openssh from the images. Because the official openssh package provided by Ubuntu can't pass our security scan. 
3. Reduce the image size to 1/3 by using stages. Also, because it contains less packages, it will be less often needed to update.
4. Put the LICENSE-IMAGE.txt file in right place. It is missed in current images. You can see it was added to a temp folder "/code" but it got deleted afterwards. 
5. Update the CPU docker image's base image to Ubuntu 18.04. The GPU one is already 18.04. It's better to keep them the same.
6. Remove the build arg ONNXRUNTIME_REPO/ONNXRUNTIME_BRANCH. Instead, the new one always uses the local source. I feel it can reduce confusion. 

TODO:
There is an issue in tools/ci_build/build.py that I wrongly append "noopenmp" to gpu package names. It must be fixed for the new release. I'll handle it separately. 

**Motivation and Context**
- Why is this change required? What problem does it solve?

- If it fixes an open issue, please link to the issue here.
