### PR TITLE
Expose parameters in clean build Docker image cache build.

### DIFF
--- a/tools/ci_build/clean_docker_image_cache.py
+++ b/tools/ci_build/clean_docker_image_cache.py
@@ -43,7 +43,7 @@ def parse_args():
         "--log-storage-account", required=True,
         help="The storage account name.")
     parser.add_argument(
-        "--log-storage-container", required=True,
+        "--log-storage-account-container", required=True,
         help="The storage account container name.")
     parser.add_argument(
         "--log-storage-path-pattern", default="*.json",

--- a/tools/ci_build/clean_docker_image_cache.py
+++ b/tools/ci_build/clean_docker_image_cache.py
@@ -179,7 +179,7 @@ def main():
     with tempfile.TemporaryDirectory() as tmp_dir:
         log_paths = download_logs(
             args.log_storage_account,
-            args.log_storage_container,
+            args.log_storage_account_container,
             args.log_storage_path_pattern,
             tmp_dir,
             args.az_path)

--- a/tools/ci_build/github/azure-pipelines/clean-build-docker-image-cache-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/clean-build-docker-image-cache-pipeline.yml
@@ -1,3 +1,17 @@
+parameters:
+- name: DryRun
+  type: boolean
+  default: false
+  displayName: "Whether to do a dry-run and not actually clean up the cache."
+- name: CacheLifetimeDays
+  type: number
+  default: 7
+  displayName: "The lifetime of an unused image in the cache, in days."
+
+variables:
+  ${{ if eq(parameters.DryRun, true) }}:
+    DryRunArgument: "--dry-run"
+
 jobs:
 - job: Clean_Build_Docker_Image_Cache
 
@@ -14,6 +28,8 @@ jobs:
       scriptLocation: 'inlineScript'
       inlineScript: |
         tools/ci_build/clean_docker_image_cache.py \
+          ${{ variables.DryRunArgument }} \
           --container-registry $(buildcache-container-registry) \
           --log-storage-account $(buildcache-log-storage-account) \
-          --log-storage-container $(buildcache-log-storage-account-container)
+          --log-storage-account-container $(buildcache-log-storage-account-container) \
+          --cache-lifetime-days ${{ parameters.CacheLifetimeDays }}


### PR DESCRIPTION
**Description**
Expose some parameters in the clean build Docker image cache build. In particular, whether to do a dry-run and the lifetime of unused cache images.

**Motivation and Context**
Allow more to be done with the build definition without needing to manually run the underlying script.
