### PR TITLE
[OpenVINO]Fix memory leak in `IsDebugEnabled()` under Windows

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_utils.cc
+++ b/onnxruntime/core/providers/openvino/backend_utils.cc
@@ -27,7 +27,7 @@ bool IsDebugEnabled() {
   size_t env_name_len = 0;
   char* env_name = nullptr;
   bool res = (_dupenv_s(&env_name, &env_name_len, "ORT_OPENVINO_ENABLE_DEBUG") == 0 && env_name != nullptr);
-  free(res);
+  free(env_name);
   return res;
 #else
   return (std::getenv("ORT_OPENVINO_ENABLE_DEBUG") != nullptr);

--- a/onnxruntime/core/providers/openvino/backend_utils.cc
+++ b/onnxruntime/core/providers/openvino/backend_utils.cc
@@ -26,7 +26,9 @@ bool IsDebugEnabled() {
 #ifdef _WIN32
   size_t env_name_len = 0;
   char* env_name = nullptr;
-  return (_dupenv_s(&env_name, &env_name_len, "ORT_OPENVINO_ENABLE_DEBUG") == 0 && env_name != nullptr);
+  bool res = (_dupenv_s(&env_name, &env_name_len, "ORT_OPENVINO_ENABLE_DEBUG") == 0 && env_name != nullptr);
+  free(res);
+  return res;
 #else
   return (std::getenv("ORT_OPENVINO_ENABLE_DEBUG") != nullptr);
 #endif


### PR DESCRIPTION
- As per [MSFT doc](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/dupenv-s-wdupenv-s?view=msvc-160), it is the calling program's responsibility to free the memory by calling `free`.