### PR TITLE
[WIP] Upgrade AzureFileCopy task to v4

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-featurizers.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-featurizers.yml
@@ -168,13 +168,7 @@ jobs:
 - job: Publish_NuGet_Package_And_Report
   workspace:
     clean: all
-  pool: 
-    name: Hosted Windows 2019 with VS2019
-    # AzureFileCopy@3 task has some bug that it depends on a particular version of azure power shell, 
-    # which is not available in OnnxRuntime build VMs, but available in the latest hosted agents. 
-    # So, all the copy/publish jobs are being run on hosted agent
-    # TODO: install the desired azureps on our VMs or use later bugfixed version of AzureFileCopy   
-    demands: azureps
+  pool: 'Win-CPU-2019'
   condition: and (succeeded(), and (${{ parameters.DoEsrp }}, eq(variables['Build.SourceBranch'], 'refs/heads/master')))
   dependsOn:
   - NuGet_Test_Win

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-noopenmp.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu-noopenmp.yml
@@ -269,7 +269,7 @@ jobs:
           $date = $(Get-Date -Format "yyyy-MM-dd")
           Write-Host "##vso[task.setvariable variable=CurrentDate]$date"
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'Copy Signed Native NuGet Package to Blob Store'
     condition: ne(variables['IsReleaseBuild'], 'true') # release build has a different package naming scheme
     inputs:
@@ -281,7 +281,7 @@ jobs:
       blobPrefix: '$(CurrentDate)/'
     continueOnError: true
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'Copy Signed Managed NuGet Package to Blob Store'
     condition: ne(variables['IsReleaseBuild'], 'true') # release build has a different package naming scheme
     inputs:

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/cpu.yml
@@ -265,7 +265,7 @@ jobs:
           $date = $(Get-Date -Format "yyyy-MM-dd")
           Write-Host "##vso[task.setvariable variable=CurrentDate]$date"
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'Copy Signed Native NuGet Package to Blob Store'
     condition: ne(variables['IsReleaseBuild'], 'true') # release build has a different package naming scheme
     inputs:
@@ -277,7 +277,7 @@ jobs:
       blobPrefix: '$(CurrentDate)/'
     continueOnError: true
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'Copy Signed Managed NuGet Package to Blob Store'
     condition: ne(variables['IsReleaseBuild'], 'true') # release build has a different package naming scheme
     inputs:


### PR DESCRIPTION
**Description**: 

Upgrade AzureFileCopy task to v4

**Motivation and Context**
- Why is this change required? What problem does it solve?

To retire the old azcopy binary. The new one is based on azcopy v10.

- If it fixes an open issue, please link to the issue here.
