### PR TITLE
[java] Fixing OrtEnvironment.getEnvironment() so it prints fewer warnings

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
+++ b/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
@@ -40,18 +40,28 @@ public class OrtEnvironment implements AutoCloseable {
    * Gets the OrtEnvironment. If there is not an environment currently created, it creates one using
    * {@link OrtEnvironment#DEFAULT_NAME} and {@link OrtLoggingLevel#ORT_LOGGING_LEVEL_WARNING}.
    *
-   * @return An onnxruntime environment.
+   * @return The OrtEnvironment singleton.
    */
-  public static OrtEnvironment getEnvironment() {
-    return getEnvironment(OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING, DEFAULT_NAME);
+  public static synchronized OrtEnvironment getEnvironment() {
+    if (INSTANCE == null) {
+      // If there's no instance, create one.
+      return getEnvironment(OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING, DEFAULT_NAME);
+    } else {
+      // else return the current one.
+      refCount.incrementAndGet();
+      return INSTANCE;
+    }
   }
 
   /**
    * Gets the OrtEnvironment. If there is not an environment currently created, it creates one using
    * the supplied name and {@link OrtLoggingLevel#ORT_LOGGING_LEVEL_WARNING}.
    *
+   * <p>If the environment already exists then it returns the existing one and logs a warning if the
+   * name or log level is different from the requested one.
+   *
    * @param name The logging id of the environment.
-   * @return An onnxruntime environment.
+   * @return The OrtEnvironment singleton.
    */
   public static OrtEnvironment getEnvironment(String name) {
     return getEnvironment(OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING, name);
@@ -61,8 +71,11 @@ public class OrtEnvironment implements AutoCloseable {
    * Gets the OrtEnvironment. If there is not an environment currently created, it creates one using
    * the {@link OrtEnvironment#DEFAULT_NAME} and the supplied logging level.
    *
+   * <p>If the environment already exists then it returns the existing one and logs a warning if the
+   * name or log level is different from the requested one.
+   *
    * @param logLevel The logging level to use.
-   * @return An onnxruntime environment.
+   * @return The OrtEnvironment singleton.
    */
   public static OrtEnvironment getEnvironment(OrtLoggingLevel logLevel) {
     return getEnvironment(logLevel, DEFAULT_NAME);


### PR DESCRIPTION
**Description**

If the OrtEnvironment singleton already exists then the `getEnvironment()` static method should return it. At the moment it prints a warning saying the name is different and returns it, this PR fixes it so the warning goes away as it's annoying (especially when running tests). The warning is semantically meaningless, it's just that the old code path didn't check to see if it existed, it always tried to make a new environment using the default name and logging level, which isn't right.
