### PR TITLE
Support the cross compiling for Apple Silicon

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -60,24 +60,23 @@ Open Developer Command Prompt for Visual Studio version you are going to use. Th
 The default Windows CMake Generator is Visual Studio 2017, but you can also use the newer Visual Studio 2019 by passing `--cmake_generator "Visual Studio 16 2019"` to `.\build.bat`
 
 
-#### Linux/macOS
+#### Linux
 ```
 ./build.sh --config RelWithDebInfo --build_shared_lib --parallel
 ```
+
+
 ##### macOS
 By default, ORT is configured to be built for a minimum target macOS version of 10.12.
 The shared library in the release Nuget(s) and the Python wheel may be installed on macOS versions of 10.12+.
 
-If you would like to use [Xcode](https://developer.apple.com/xcode/) to build the onnxruntime for x86_64 macOS, use
-* With Xcode 11
+If you would like to use [Xcode](https://developer.apple.com/xcode/) to build the onnxruntime for x86_64 macOS, please add the --user_xcode argument in the command line
    ```
    ./build.sh --config RelWithDebInfo --build_shared_lib --parallel --use_xcode
    ```
-* With Xcode 12
-   ```
-   ./build.sh --config RelWithDebInfo --build_shared_lib --parallel --use_xcode \
-              --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=x86_64
-   ```
+While without this flag, the cmake build generator will be Unix makefile by default.
+Also, if you want to try cross compiling for Apple Silicon in a legacy MacOS machine(with Intel CPU), please add the argument --osx_arch arm64, however the unit tests will be skipped due to the incompatible CPU instruction set.
+
 
 #### Notes
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -75,7 +75,7 @@ If you would like to use [Xcode](https://developer.apple.com/xcode/) to build th
    ./build.sh --config RelWithDebInfo --build_shared_lib --parallel --use_xcode
    ```
 While without this flag, the cmake build generator will be Unix makefile by default.
-Also, if you want to try cross compiling for Apple Silicon in a legacy MacOS machine(with Intel CPU), please add the argument --osx_arch arm64, however the unit tests will be skipped due to the incompatible CPU instruction set.
+Also, if you want to try cross compiling for Apple Silicon in an Intel-based MacOS machine, please add the argument --osx_arch arm64, however the unit tests will be skipped due to the incompatible CPU instruction set.
 
 
 #### Notes

--- a/BUILD.md
+++ b/BUILD.md
@@ -75,7 +75,7 @@ If you would like to use [Xcode](https://developer.apple.com/xcode/) to build th
    ./build.sh --config RelWithDebInfo --build_shared_lib --parallel --use_xcode
    ```
 While without this flag, the cmake build generator will be Unix makefile by default.
-Also, if you want to try cross compiling for Apple Silicon in an Intel-based MacOS machine, please add the argument --osx_arch arm64, however the unit tests will be skipped due to the incompatible CPU instruction set.
+Also, if you want to try cross compiling for Apple Silicon in an Intel-based MacOS machine, please add the argument --osx_arch arm64 with a cmake > 3.19, however the unit tests will be skipped due to the incompatible CPU instruction set.
 
 
 #### Notes

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1702,8 +1702,19 @@ def run_csharp_tests(source_dir, build_dir, use_cuda, use_openvino, use_tensorrt
     run_subprocess(cmd_args, cwd=csharp_source_dir)
 
 
+def is_cross_compiling_on_apple(args):
+    if not is_macOS():
+        return False
+    if args.ios:
+        return True
+    if args.osx_arch != platform.machine():
+        return True
+    return False
+
+
 def build_protoc_for_host(cmake_path, source_dir, build_dir, args):
-    if (args.arm or args.arm64 or args.enable_windows_store) and (not is_windows() and not args.ios):
+    if (args.arm or args.arm64 or args.enable_windows_store) and (
+            not is_windows() and not is_cross_compiling_on_apple(args)):
         raise BuildError(
             'Currently only support building protoc for Windows host while '
             'cross-compiling for ARM/ARM64/Store and linux cross-compiling iOS')
@@ -1966,10 +1977,18 @@ def main():
                 cmake_extra_args.append('-DCMAKE_USER_MAKE_RULES_OVERRIDE=wcos_rules_override.cmake')
         elif args.cmake_generator is not None and not (is_macOS() and args.use_xcode):
             cmake_extra_args += ['-G', args.cmake_generator]
-        elif is_macOS() and args.use_xcode:
-            cmake_extra_args += ['-G', 'Xcode']
+        elif is_macOS():
+            if args.use_xcode:
+                cmake_extra_args += ['-G', 'Xcode']
+            if not args.ios and not args.android and \
+                    args.osx_arch == 'arm64' and platform.machine() == 'x86_64':
+                if args.test:
+                    log.info(
+                        "Cannot test ARM64 build on X86_64. Will skip test running after build.")
+                    args.test = False
 
-        if (args.android or args.ios or args.enable_windows_store) and args.path_to_protoc_exe is None:
+        if (args.android or args.ios or args.enable_windows_store
+                or is_cross_compiling_on_apple(args)) and args.path_to_protoc_exe is None:
             # Cross-compiling for Android and iOS
             path_to_protoc_exe = build_protoc_for_host(
                 cmake_path, source_dir, build_dir, args)

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1713,8 +1713,8 @@ def is_cross_compiling_on_apple(args):
 
 
 def build_protoc_for_host(cmake_path, source_dir, build_dir, args):
-    if (args.arm or args.arm64 or args.enable_windows_store) and (
-            not is_windows() and not is_cross_compiling_on_apple(args)):
+    if (args.arm or args.arm64 or args.enable_windows_store) and \
+            not (is_windows() or is_cross_compiling_on_apple(args)):
         raise BuildError(
             'Currently only support building protoc for Windows host while '
             'cross-compiling for ARM/ARM64/Store and linux cross-compiling iOS')
@@ -1943,7 +1943,7 @@ def main():
                 # Cannot test on host build machine for cross-compiled
                 # builds (Override any user-defined behaviour for test if any)
                 if args.test:
-                    log.info(
+                    log.warning(
                         "Cannot test on host build machine for cross-compiled "
                         "ARM(64) builds. Will skip test running after build.")
                     args.test = False
@@ -1983,7 +1983,7 @@ def main():
             if not args.ios and not args.android and \
                     args.osx_arch == 'arm64' and platform.machine() == 'x86_64':
                 if args.test:
-                    log.info(
+                    log.warning(
                         "Cannot test ARM64 build on X86_64. Will skip test running after build.")
                     args.test = False
 


### PR DESCRIPTION
**Description**: 

Support the cross compiling for Apple Silicon

**Motivation and Context**

To build the macos_arm64 binary on a macOS machine with Intel CPU.