### PR TITLE
save data to and load data from an hdf5 file for checkpointing

### DIFF
--- a/orttraining/orttraining/python/training/_checkpoint_storage.py
+++ b/orttraining/orttraining/python/training/_checkpoint_storage.py
@@ -1,0 +1,81 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# _checkpoint_storage.py
+
+import h5py
+from collections.abc import Mapping
+
+def _dfs_save(group, save_obj):
+    """Recursively go over each level in the save_obj dictionary and save values to a hdf5 group"""
+
+    for key, value in save_obj.items():
+        if isinstance(value, Mapping):
+            subgroup = group.create_group(key)
+            _dfs_save(subgroup, value)
+        else:
+            group[key] = value
+
+def save(save_obj: dict, path):
+    """Persists the input dictionary to a file specified by path.
+
+    Saves an hdf5 representation of the save_obj dictionary to a file or a file-like object specified by path.
+    Values are saved in a format supported by h5py. For example, a PyTorch tensor is saved and loaded as a
+    numpy object. So, user types may be converted from their original types to numpy equivalent types.
+
+    Args:
+        save_obj: dictionary that needs to be saved.
+            save_obj should consist of types supported by hdf5 file format.
+            if hdf5 does not recognize a type, an exception is raised.
+            if save_obj is not a dictionary, a ValueError is raised.
+        path: string representation to a file path or a python file-like object.
+            if file already exists at path, an exception is raised.
+    """
+    if not isinstance(save_obj, Mapping):
+        raise ValueError("Object to be saved must be a dictionary")
+
+    with h5py.File(path, 'w-') as f:
+        _dfs_save(f, save_obj)
+
+def _dfs_load(group, load_obj):
+    """Recursively go over each level in the hdf5 group and load the values into the given dictionary"""
+
+    for key in group:
+        if isinstance(group[key], h5py.Group):
+            load_obj[key] = {}
+            _dfs_load(group[key], load_obj[key])
+        else:
+            load_obj[key] = group[key][()]
+
+def load(path, key=None):
+    """Loads the data stored in the binary file specified at the given path into a dictionary and returns it.
+
+    Loads the data from an hdf5 file specified at the given path into a python dictionary.
+    Loaded dictionary contains numpy equivalents of python data types. For example:
+        PyTorch tensor -> saved as a numpy array and loaded as a numpy array.
+        bool -> saved as a numpy bool and loaded as a numpy bool
+    If a '/' separated key is provided, the value at that hierarchical level in the hdf5 group is returned.
+
+    Args:
+        path: string representation to a file path or a python file-like object.
+            if file does not already exist at path, an exception is raised.
+        key: '/' separated representation of the hierarchy level value that needs to be returned/
+            for example, if the saved binary file has structure {a: {b: x, c:y}} and the user would like
+            to query the value for c, the key provided should be 'a/c'.
+            the default value of None for key implies that the entire hdf5 file structure needs to be loaded into a dictionary and returned.
+
+    Returns:
+        a dictionary loaded from the specified binary hdf5 file.
+    """
+    if not h5py.is_hdf5(path):
+        raise ValueError(f"{path} is not an hdf5 file or a python file-like object.")
+
+    load_obj = {}
+    with h5py.File(path, 'r') as f:
+        if key:
+            f = f[key]
+        if isinstance(f, h5py.Dataset):
+            return f[()]
+
+        _dfs_load(f, load_obj)
+
+    return load_obj

--- a/orttraining/orttraining/test/python/orttraining_test_checkpoint_storage.py
+++ b/orttraining/orttraining/test/python/orttraining_test_checkpoint_storage.py
@@ -1,0 +1,230 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# orttraining_test_checkpoint_storage.py
+
+import pytest
+import torch
+import numpy as np
+import os
+import shutil
+import pickle
+import binascii
+
+from onnxruntime.training import _checkpoint_storage
+
+# Helper functions
+
+def _equals(a, b):
+    """Checks recursively if two dictionaries are equal"""
+    if isinstance(a, dict):
+        for key in a:
+            if key not in b or not _equals(a[key], b[key]):
+                return False
+        return True
+    else:
+        if isinstance(a, bytes):
+            a = a.decode()
+        if isinstance(b, bytes):
+            b = b.decode()
+        are_equal = a == b
+        return are_equal if isinstance(are_equal, bool) else are_equal.all()
+
+    return False
+
+def _numpy_types(obj_value):
+    """Return a bool indicating whether or not the input obj_value is a numpy type object
+
+    Recursively checks if the obj_value (could be a dictionary) is a numpy type object.
+    Exceptions are str and bytes.
+
+    Returns true if object is numpy type, str, or bytes
+    False if any other type
+    """
+    if not isinstance(obj_value, dict):
+        return type(obj_value).__module__ == np.__name__ or isinstance(obj_value, str) or isinstance(obj_value, bytes)
+
+    for _, value in obj_value.items():
+        if not _numpy_types(value):
+            return False
+    return True
+
+def _get_dict(separated_key):
+    """Create dummy dictionary with different datatypes
+
+    Returns the tuple of the entire dummy dictionary created, key argument as a dictionary for _checkpoint_storage.load
+    function and the value for that key in the original dictionary
+
+    For example the complete dictionary is represented by:
+    {
+        'int1':1,
+        'int2': 2,
+        'int_list': [1,2,3,5,6],
+        'dict1': {
+            'np_array': np.arange(100),
+            'dict2': {'int3': 3, 'int4': 4},
+            'str1': "onnxruntime"
+        },
+        'bool1': bool(True),
+        'int5': 5,
+        'float1': 2.345,
+        'np_array_float': np.array([1.234, 2.345, 3.456]),
+        'np_array_float_3_dim': np.array([[[1,2],[3,4]], [[5,6],[7,8]]])
+    }
+
+    if the input key is ['dict1', 'str1'], then the key argument returned is 'dict1/str1'
+    and the value corresponding to that is "onnxruntime"
+
+    so, for the above example, the returned tuple is:
+    (original_dict, {'key': 'dict1/str1', "onnxruntime")
+    """
+    test_dict = {
+        'int1':1,
+        'int2': 2,
+        'int_list': [1,2,3,5,6],
+        'dict1': {
+            'np_array': np.arange(100),
+            'dict2': {'int3': 3, 'int4': 4},
+            'str1': "onnxruntime"
+        },
+        'bool1': bool(True),
+        'int5': 5,
+        'float1': 2.345,
+        'np_array_float': np.array([1.234, 2.345, 3.456]),
+        'np_array_float_3_dim': np.array([[[1,2],[3,4]], [[5,6],[7,8]]])
+    }
+    key = ''
+    expected_val = test_dict
+    for single_key in separated_key:
+        key += single_key + '/'
+        expected_val = expected_val[single_key]
+    return test_dict, {'key': key} if len(separated_key) > 0 else dict(), expected_val
+
+class _CustomClass(object):
+    """Custom object that encpsulates dummy values for loss, epoch and train_step"""
+
+    def __init__(self):
+        self._loss = 1.23
+        self._epoch = 12000
+        self._train_step = 25
+
+    def __eq__(self, other):
+        if isinstance(other, _CustomClass):
+            return self._loss == other._loss and self._epoch == other._epoch and self._train_step == other._train_step
+
+# Test fixtures
+
+@pytest.yield_fixture(scope="function")
+def checkpoint_storage_test_setup():
+    checkpoint_dir = os.path.abspath('checkpoint_dir/')
+    if not os.path.exists(checkpoint_dir):
+        os.makedirs(checkpoint_dir, exist_ok = True)
+    pytest.checkpoint_path = os.path.join(checkpoint_dir, 'checkpoint.ortcp')
+    yield 'checkpoint_storage_test_setup'
+    shutil.rmtree(checkpoint_dir)
+
+@pytest.yield_fixture(scope="function")
+def checkpoint_storage_test_parameterized_setup(request, checkpoint_storage_test_setup):
+    yield request.param
+
+# Tests
+
+@pytest.mark.parametrize("checkpoint_storage_test_parameterized_setup", [
+    _get_dict([]),
+    _get_dict(['int1']),
+    _get_dict(['dict1']),
+    _get_dict(['dict1', 'dict2']),
+    _get_dict(['dict1', 'dict2', 'int4']),
+    _get_dict(['dict1', 'str1']),
+    _get_dict(['bool1']),
+    _get_dict(['float1']),
+    _get_dict(['np_array_float'])], indirect=True)
+def test_checkpoint_storage_saved_dict_matches_loaded(checkpoint_storage_test_parameterized_setup):
+    to_save = checkpoint_storage_test_parameterized_setup[0]
+    key_arg = checkpoint_storage_test_parameterized_setup[1]
+    expected = checkpoint_storage_test_parameterized_setup[2]
+    _checkpoint_storage.save(to_save, pytest.checkpoint_path)
+    loaded = _checkpoint_storage.load(pytest.checkpoint_path, **key_arg)
+    assert _equals(loaded, expected)
+    assert _numpy_types(loaded)
+
+@pytest.mark.parametrize("checkpoint_storage_test_parameterized_setup", [
+    {'int_set': {1, 2, 3, 4, 5}},
+    {'str_set': {'one', 'two'}},
+    [1, 2, 3],
+    2.352], indirect=True)
+def test_checkpoint_storage_saving_non_supported_types_fails(checkpoint_storage_test_parameterized_setup):
+    to_save = checkpoint_storage_test_parameterized_setup
+    with pytest.raises(Exception):
+        _checkpoint_storage.save(to_save, pytest.checkpoint_path)
+
+@pytest.mark.parametrize("checkpoint_storage_test_parameterized_setup", [
+    ({'int64_tensor': torch.tensor(np.arange(100))}, 'int64_tensor', torch.int64, np.int64),
+    ({'int32_tensor': torch.tensor(np.arange(100), dtype=torch.int32)}, 'int32_tensor', torch.int32, np.int32),
+    ({'int16_tensor': torch.tensor(np.arange(100), dtype=torch.int16)}, 'int16_tensor', torch.int16, np.int16),
+    ({'int8_tensor': torch.tensor(np.arange(100), dtype=torch.int8)}, 'int8_tensor', torch.int8, np.int8),
+    ({'float64_tensor': torch.tensor(np.array([1.0, 2.0]))}, 'float64_tensor', torch.float64, np.float64),
+    ({'float32_tensor': torch.tensor(np.array([1.0, 2.0]), dtype=torch.float32)}, 'float32_tensor', torch.float32, np.float32),
+    ({'float16_tensor': torch.tensor(np.array([1.0, 2.0]), dtype=torch.float16)}, 'float16_tensor', torch.float16, np.float16)], indirect=True)
+def test_checkpoint_storage_saving_tensor_datatype(checkpoint_storage_test_parameterized_setup):
+    tensor_dict = checkpoint_storage_test_parameterized_setup[0]
+    tensor_name = checkpoint_storage_test_parameterized_setup[1]
+    tensor_dtype = checkpoint_storage_test_parameterized_setup[2]
+    np_dtype = checkpoint_storage_test_parameterized_setup[3]
+
+    _checkpoint_storage.save(tensor_dict, pytest.checkpoint_path)
+
+    loaded = _checkpoint_storage.load(pytest.checkpoint_path)
+    assert isinstance(loaded[tensor_name], np.ndarray)
+    assert tensor_dict[tensor_name].dtype == tensor_dtype
+    assert loaded[tensor_name].dtype == np_dtype
+    assert (tensor_dict[tensor_name].numpy() == loaded[tensor_name]).all()
+
+@pytest.mark.parametrize("checkpoint_storage_test_parameterized_setup", [
+    ({'two_dim': torch.ones([2, 4], dtype=torch.float64)}, 'two_dim'),
+    ({'three_dim': torch.ones([2, 4, 6], dtype=torch.float64)}, 'three_dim'),
+    ({'four_dim': torch.ones([2, 4, 6, 8], dtype=torch.float64)}, 'four_dim')], indirect=True)
+def test_checkpoint_storage_saving_multiple_dimension_tensors(checkpoint_storage_test_parameterized_setup):
+    tensor_dict = checkpoint_storage_test_parameterized_setup[0]
+    tensor_name = checkpoint_storage_test_parameterized_setup[1]
+
+    _checkpoint_storage.save(tensor_dict, pytest.checkpoint_path)
+
+    loaded = _checkpoint_storage.load(pytest.checkpoint_path)
+    assert isinstance(loaded[tensor_name], np.ndarray)
+    assert (tensor_dict[tensor_name].numpy() == loaded[tensor_name]).all()
+
+@pytest.mark.parametrize("checkpoint_storage_test_parameterized_setup", [
+    {},
+    {'a': {}},
+    {'a': {'b': {}}}], indirect=True)
+def test_checkpoint_storage_saving_and_loading_empty_dictionaries_succeeds(checkpoint_storage_test_parameterized_setup):
+    saved = checkpoint_storage_test_parameterized_setup
+    _checkpoint_storage.save(saved, pytest.checkpoint_path)
+
+    loaded = _checkpoint_storage.load(pytest.checkpoint_path)
+    assert _equals(saved, loaded)
+
+def test_checkpoint_storage_load_file_that_does_not_exist_fails(checkpoint_storage_test_setup):
+    with pytest.raises(Exception):
+        _checkpoint_storage.load(pytest.checkpoint_path)
+
+def test_checkpoint_storage_for_custom_user_dict_succeeds(checkpoint_storage_test_setup):
+    custom_class = _CustomClass()
+    user_dict = {
+        'tensor1': torch.tensor(np.arange(100), dtype=torch.float32),
+        'custom_class': custom_class
+    }
+
+    pickled_bytes = binascii.b2a_hex(pickle.dumps(user_dict))
+    to_save = {
+        'a': torch.tensor(np.array([1.0, 2.0]), dtype=torch.float32),
+        'user_dict': pickled_bytes
+    }
+    _checkpoint_storage.save(to_save, pytest.checkpoint_path)
+
+    loaded_dict = _checkpoint_storage.load(pytest.checkpoint_path)
+    assert (loaded_dict['a'] == to_save['a'].numpy()).all()
+    loaded_obj = pickle.loads(binascii.a2b_hex(loaded_dict['user_dict']))
+
+    assert torch.all(loaded_obj['tensor1'].eq(user_dict['tensor1']))
+    assert loaded_obj['custom_class'] == custom_class

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1279,6 +1279,8 @@ def run_training_python_frontend_tests(cwd):
 
     run_subprocess([sys.executable, '-m', 'pytest', '-sv', 'orttraining_test_orttrainer_bert_toy_onnx.py'], cwd=cwd)
 
+    run_subprocess([sys.executable, '-m', 'pytest', '-sv', 'orttraining_test_checkpoint_storage.py'], cwd=cwd)
+
 
 def run_training_python_frontend_e2e_tests(cwd):
     # frontend tests are to be added here:


### PR DESCRIPTION
**Description**: Implementation of internal utility functions for saving to and loading from hdf5 file. These functions are useful for ```ORTTrainer``` checkpointing functionality.

**Motivation and Context**
- Why is this change required? What problem does it solve?
These changes are required to save and load an ```ORTTrainer``` checkpoint to and from an hdf5 file. 
  - More details on why hdf5 file format is required for ```ORTTrainer``` checkpointing:

    The main reason for a special file format is related to distributed training. In a distributed training scenario, each worker (or process) would write its own states to an output file. It is important to map each checkpoint file to its original rank along with the distributed environment training configuration, such as world size and type of distributed training. The existing checkpoint design embeds such information on filenames (e.g. common prefix along with world_rank, workd_size and other such parameters (encoded as strings) on the file name). This is necessary in order to correctly identify the rank of the file being loaded so it can be loaded into the corresponding trainer or to aggregate all checkpoints in proper order. But naming the files as such has certain drawbacks:
    - File names cannot be changed, affecting future extensions and BC concerns.
    - All checkpoint files need to reside in the same folder.
    - Since there is a default prefix name is hardcoded in the API, the file can be easily mistakenly overwritten.
    - Rank, world size and other ZeRO information is embedded in the file name.

    The proposal is to embed relevant metadata inside the file, which could have any friendly name as per the users liking. While loading, each file is partially read to build a map. Using pickle is avoided because it would require loading the entire checkpoint file (which could be huge) and discarding it in case it does not align with the one we are looking for. Here is where hdf5 comes into play. Hdf5 file format allows us to read only a part of the file (relevant metadata). This should enable us to build the rank to file name map fast and easily.