### PR TITLE
Remove chronological starttime assertion in InferenceTest.cs because it is not determined

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -446,17 +446,11 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 return startTime;
             }
 
-            // Get 1st profiling's start time
-            ulong startTime1 = getSingleSessionProfilingStartTime();
-            // Get 2nd profiling's start time
-            ulong startTime2 = getSingleSessionProfilingStartTime();
-            // Get 3rd profiling's start time
-            ulong startTime3 = getSingleSessionProfilingStartTime();
+            // Get profiling's start time
+            ulong startTime = getSingleSessionProfilingStartTime();
 
             // Check the profiling's start time has been updated
-            Assert.True(startTime1 != 0);
-            // Chronological profiling's start time
-            Assert.True(startTime1 <= startTime2 && startTime2 <= startTime3);
+            Assert.True(startTime != 0);
         }
 
         [Fact]

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -447,10 +447,10 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             }
 
             // Get profiling's start time
-            ulong startTime = getSingleSessionProfilingStartTime();
+            ulong ProfilingStartTime = getSingleSessionProfilingStartTime();
 
             // Check the profiling's start time has been updated
-            Assert.True(startTime != 0);
+            Assert.True(ProfilingStartTime != 0);
         }
 
         [Fact]


### PR DESCRIPTION
**Description**
Remove the profiler start time comparison for now because it is not determined. Keep the assertion of single InferenceSession is not zero.
 
**Motivation and Context**
https://github.com/microsoft/onnxruntime/blob/2d9dcc4576f86b3eb6705dba1f8699eb52140b4e/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs#L459
L459 fails occasionally.
L459 is not a proper assertion because it's possible that the chronological InferenceSessions do not start profiler chronologically. 
