### PR TITLE
Upgrade build.py to assert for python 3.6+

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -54,9 +54,9 @@ def _check_python_version():
         raise BuildError(
             "Bad python major version: expecting python 3, found version "
             "'{}'".format(sys.version))
-    if sys.version_info[1] < 5:
+    if sys.version_info[1] < 6:
         raise BuildError(
-            "Bad python minor version: expecting python 3.5+, found version "
+            "Bad python minor version: expecting python 3.6+, found version "
             "'{}'".format(sys.version))
 
 


### PR DESCRIPTION
Upgrade build.py to assert for python 3.6+
as python 3.5 cannot build anymore todays master.

**Description**: Retouch build.py to assert for python 3.6+

**Motivation and Context**
- Why is this change required? What problem does it solve? Avoid weird building failures without user friendly error message
- If it fixes an open issue, please link to the issue here.
https://github.com/microsoft/onnxruntime/issues/5980
