### PR TITLE
skip the check for A channel

### DIFF
--- a/winml/test/image/imageTestHelper.cpp
+++ b/winml/test/image/imageTestHelper.cpp
@@ -273,8 +273,9 @@ namespace ImageTestHelper {
         // Even given two same ImageFeatureValues, the comparison cannot exactly match.
         // So we use error rate.
         UINT errors = 0;
-        // Only the check the first three channels, which are (B, G, R)
-        for (uint32_t i = 0; i < size && (i + 1) % 4; i++, pActualByte++, pExpectedByte++) {
+        for (uint32_t i = 0; i < size; i++, pActualByte++, pExpectedByte++) {
+            // Only the check the first three channels, which are (B, G, R)
+            if((i + 1) % 4 == 0) continue;
             auto diff = (*pActualByte - *pExpectedByte);
             if (diff > epsilon) {
                 errors++;

--- a/winml/test/image/imageTestHelper.cpp
+++ b/winml/test/image/imageTestHelper.cpp
@@ -273,7 +273,8 @@ namespace ImageTestHelper {
         // Even given two same ImageFeatureValues, the comparison cannot exactly match.
         // So we use error rate.
         UINT errors = 0;
-        for (uint32_t i = 0; i < size; i++, pActualByte++, pExpectedByte++) {
+        // Only the check the first three channels, which are (B, G, R)
+        for (uint32_t i = 0; i < size && (i + 1) % 4; i++, pActualByte++, pExpectedByte++) {
             auto diff = (*pActualByte - *pExpectedByte);
             if (diff > epsilon) {
                 errors++;

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -768,10 +768,10 @@ bool VerifyHelper(ImageFeatureValue actual, ImageFeatureValue expected) {
   // hard code, might need to be modified later.
   const float cMaxErrorRate = 0.06f;
   byte epsilon = 20;
-
   UINT errors = 0;
-  // Only the check the first three channels, which are (B, G, R)
-  for (uint32_t i = 0; i < size && (i + 1) % 4; i++, pActualByte++, pExpectedByte++) {
+  for (uint32_t i = 0; i < size; i++, pActualByte++, pExpectedByte++) {
+    // Only the check the first three channels, which are (B, G, R)
+    if((i + 1) % 4 == 0) continue;
     auto diff = std::abs(*pActualByte - *pExpectedByte);
     if (diff > epsilon) {
       errors++;

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -770,7 +770,8 @@ bool VerifyHelper(ImageFeatureValue actual, ImageFeatureValue expected) {
   byte epsilon = 20;
 
   UINT errors = 0;
-  for (uint32_t i = 0; i < size; i++, pActualByte++, pExpectedByte++) {
+  // Only the check the first three channels, which are (B, G, R)
+  for (uint32_t i = 0; i < size && (i + 1) % 4; i++, pActualByte++, pExpectedByte++) {
     auto diff = std::abs(*pActualByte - *pExpectedByte);
     if (diff > epsilon) {
       errors++;


### PR DESCRIPTION
**Description**: 
Skipped the comparison for the fourth channel of softwarebitmap in VerifyHelper function

**Motivation and Context**
- This is to fix the ImageTests failure while binding unsupported directX format, like DirectXPixelFormat::B8G8R8X8UIntNormalized.

The fourth channel of the generated output will be 255, while the benchmark is 0, which caused the failure in image tests.
Since we don't care about the fourth channel in WinML while either tensorizing or detensorizing, so it's safe to skip the check for the fourth channel.
