### PR TITLE
bug fix in build.py which prevents running some unit tests

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1457,7 +1457,7 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
 
             # Disable python tests in a reduced build as we don't know which ops have been included and which
             # models can run
-            if args.include_ops_by_model or args.include_ops_by_config or args.minimal_build:
+            if args.include_ops_by_model or args.include_ops_by_config or args.minimal_build != 'off':
                 return
 
             if is_windows():


### PR DESCRIPTION
**Description**: 
Argument to ```build.py``` ```--minimal_build``` is a string argument. But it is being used as a ```bool``` where there is a bug. So, some of the tests are not being run as they should be in the ci pipelines.