### PR TITLE
Support Fusion for 1 and 2 Inputs Bert Models Converted From tf

### DIFF
--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -156,7 +156,7 @@ def run_onnxruntime(use_gpu, model_names, model_class, precision, num_threads, b
                         # Get output sizes from a dummy ort run
                         ort_outputs = ort_session.run(ort_output_names, ort_inputs)
 
-                        data_type = numpy.longlong if 'pt' in model_source else numpy.int32
+                        data_type = numpy.longlong if 'pt' in model_source else numpy.intc
                         result = inference_ort_with_io_binding(ort_session, ort_inputs, result_template, repeat_times,
                                                                ort_output_names, ort_outputs, output_buffers,
                                                                max_last_state_size, max_pooler_size, batch_size, device,

--- a/onnxruntime/python/tools/transformers/compare_bert_results.py
+++ b/onnxruntime/python/tools/transformers/compare_bert_results.py
@@ -69,7 +69,7 @@ def compare(baseline_results, treatment_results, verbose, rtol=1e-3, atol=1e-4):
         print("100% passed for {} random inputs given thresholds (rtol={}, atol={}).".format(
             len(baseline_results), rtol, atol))
     else:
-        print("{} out of {} results not passed for thresholds (rtol={}, atol={}).".format(
+        print("WARNING: {} out of {} results NOT passed for thresholds (rtol={}, atol={}).".format(
             diff_count, len(baseline_results), rtol, atol))
 
     print("maximum absolute difference={}".format(max_abs_diff))

--- a/onnxruntime/python/tools/transformers/fusion_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_attention.py
@@ -142,12 +142,12 @@ class FusionAttention(Fusion):
                                   raw=True)
         self.model.add_initializer(bias)
 
-        attnetion_inputs = [input, attention_node_name + '_qkv_weight', attention_node_name + '_qkv_bias']
+        attention_inputs = [input, attention_node_name + '_qkv_weight', attention_node_name + '_qkv_bias']
         if mask_index is not None:
-            attnetion_inputs.append(mask_index)
+            attention_inputs.append(mask_index)
 
         attention_node = helper.make_node('Attention',
-                                          inputs=attnetion_inputs,
+                                          inputs=attention_inputs,
                                           outputs=[output],
                                           name=attention_node_name)
         attention_node.domain = "com.microsoft"

--- a/onnxruntime/python/tools/transformers/onnx_exporter.py
+++ b/onnxruntime/python/tools/transformers/onnx_exporter.py
@@ -396,7 +396,7 @@ def export_onnx_model_from_tf(model_name, opset_version, use_external_data_forma
 
     example_inputs = filter_inputs(example_inputs, input_names)
 
-    example_outputs = model(example_inputs, training=False)
+    example_outputs = model(example_inputs, training=False).to_tuple()
 
     # Flatten is needed for gpt2 and distilgpt2.
     example_outputs_flatten = flatten(example_outputs)

--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -57,6 +57,7 @@ class BertOnnxModel(OnnxModel):
 
         self.attention_mask = AttentionMask(self)
         self.attention_fusion = FusionAttention(self, self.hidden_size, self.num_heads, self.attention_mask)
+        self.utils = FusionUtils(self)
 
     def fuse_attention(self):
         self.attention_fusion.apply()
@@ -131,11 +132,11 @@ class BertOnnxModel(OnnxModel):
 
         new_graph_inputs = []
         casted_bert_graph_inputs = self.get_graph_inputs_from_fused_nodes(casted=True)
-        utils = FusionUtils(self)
+        
 
         for input in graph.input:
             if input.name in casted_bert_graph_inputs:
-                utils.remove_cast_int32(input.name)
+                self.utils.remove_cast_int32(input.name)
                 int32_input = helper.make_tensor_value_info(input.name, TensorProto.INT32,
                                                             self.tensor_shape_to_list(input.type.tensor_type))
                 new_graph_inputs.append(int32_input)

--- a/onnxruntime/python/tools/transformers/onnx_model_bert_keras.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert_keras.py
@@ -287,7 +287,7 @@ class BertOnnxModelKeras(BertOnnxModelTF):
 
                 mask_input_name = self.attention_mask.get_first_mask()
                 if unsqueeze_node.input[0] != mask_input_name:
-                    print("Cast input {} is not mask input{}".format(unsqueeze_node.input[0], mask_input_name))
+                    print("Cast input {} is not mask input {}".format(unsqueeze_node.input[0], mask_input_name))
                     continue
 
                 unsqueeze_added_1 = onnx.helper.make_node('Unsqueeze',

--- a/onnxruntime/python/tools/transformers/onnx_model_bert_tf.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert_tf.py
@@ -9,7 +9,7 @@ import sys
 import argparse
 import numpy as np
 from collections import deque
-from onnx import ModelProto, TensorProto, numpy_helper
+from onnx import ModelProto, TensorProto, numpy_helper, helper
 from onnx_model_bert import BertOnnxModel
 
 logger = logging.getLogger(__name__)
@@ -144,7 +144,7 @@ class BertOnnxModelTF(BertOnnxModel):
 
         return initializers
 
-    def find_segment_ids(self, segment_embedding):
+    def find_segment_ids(self, segment_embedding, input_ids):
         input_name_to_nodes = self.input_name_to_nodes()
         if segment_embedding not in input_name_to_nodes:
             return None
@@ -154,11 +154,32 @@ class BertOnnxModelTF(BertOnnxModel):
             return None
 
         graph_inputs = self.get_graph_inputs(nodes[0], recursive=True)
-        if len(graph_inputs) == 1:
+        if len(graph_inputs) > 1:
+            print("Found multiple candidates of segment_ids", graph_inputs)
+            return None
+        # Find segment ids in graph inputs. The segment id input must not be the same as input_ids.
+        if len(graph_inputs) == 1 and graph_inputs[0] != input_ids:
             return graph_inputs[0]
 
-        print("Found multiple candidates of segment_ids", graph_inputs)
-        return None
+        # If the segment id candidate is the same as the input_ids, try to assign alternative segment ids and simplify the graph if needed.
+        segment_ids = nodes[0].input[1]
+        _, segment_id_path, _ = self.match_parent_paths(
+            nodes[0], [(["ConstantOfShape", "Cast", "Concat", "Slice", "Cast", "Shape"], [1, 0, 0, 0, 0, 0]),
+                       (["ConstantOfShape", "Cast", "Concat", "Unsqueeze", "Squeeze", "Slice", "Cast", "Shape"
+                         ], [1, 0, 0, 0, 0, 0, 0, 0])], None)
+
+        if segment_id_path and input_ids and input_ids == segment_id_path[-1].input[0]:
+            logger.debug("Simplify semgent id path...")
+            self.add_node(helper.make_node('Shape', inputs=[input_ids], outputs=["input_shape"]))
+            constantofshape_node = segment_id_path[0]
+            constantofshape_value = helper.get_attribute_value(constantofshape_node.attribute[0])
+            self.add_node(
+                helper.make_node('ConstantOfShape',
+                                 inputs=["input_shape"],
+                                 outputs=["zeros_for_input_shape"],
+                                 value=constantofshape_value))
+            segment_ids = "zeros_for_input_shape"
+        return segment_ids
 
     def find_input_ids(self, word_embedding):
         input_name_to_nodes = self.input_name_to_nodes()
@@ -179,27 +200,49 @@ class BertOnnxModelTF(BertOnnxModel):
     def find_mask_input(self, excluded_graph_inputs):
         for node in self.nodes():
             if node.op_type == 'Softmax':
-                mask_path = self.match_parent_path(node, ['Add', 'Mul', 'Sub'], [0, 1, None])
+                mask_path = self.match_parent_path(node, ['Add', 'Mul', 'Sub', 'Cast', 'Slice', 'Unsqueeze'], [0, 1, None, 1, 0, 0])
                 if mask_path is None:
                     continue
-                add_node, mul_node, sub_node = mask_path
+                add_node, mul_node, sub_node, cast_node, slice_node, unsqueeze_node = mask_path
                 if self.has_constant_input(mul_node, -10000) and self.has_constant_input(sub_node, 1):
                     graph_inputs = self.get_graph_inputs(sub_node, recursive=True)
                     inputs = [input for input in graph_inputs if input not in excluded_graph_inputs]
+                    if len(inputs) > 1:
+                        print("Found multiple candidates of mask input", inputs)
+                        return None
                     if len(inputs) == 1:
                         return inputs[0]
-
+                    # Duplicated input found. Try to simplify the graph.
+                    path_to_be_simplified = self.match_parent_path(
+                        mask_path[-1],
+                        ["ConstantOfShape", "Cast", "Concat", "Unsqueeze", "Squeeze", "Slice", "Cast", "Shape"],
+                        [0, 0, 0, 0, 0, 0, 0, 0])
+                    duplicated_inputs = [input for input in graph_inputs if input in excluded_graph_inputs]
+                    # Simplify graph for dynamic axes.
+                    if path_to_be_simplified and duplicated_inputs and len(
+                            duplicated_inputs) == 1 and duplicated_inputs[0] == path_to_be_simplified[-1].input[0]:
+                        logger.debug("Simplify semgent id path...")
+                        constantofshape_node = path_to_be_simplified[0]
+                        constantofshape_value = helper.get_attribute_value(constantofshape_node.attribute[0])
+                        self.add_node(
+                            helper.make_node('Shape', inputs=[duplicated_inputs[0]], outputs=["input_shape_for_mask"]))
+                        self.add_node(
+                            helper.make_node('ConstantOfShape',
+                                             inputs=["input_shape_for_mask"],
+                                             outputs=[unsqueeze_node.input[0]],
+                                             value=constantofshape_value))
+                    return unsqueeze_node.input[0]
         return None
 
     def create_embedding_subgraph(self, normalize_node, word_embedding, segment_embedding, position_embedding):
-        segment_ids = self.find_segment_ids(segment_embedding)
-        if segment_ids is None:
-            logger.info("Failed to find segment_ids. Cannot fuse embedding layer.")
-            return False
-
         input_ids = self.find_input_ids(word_embedding)
         if input_ids is None:
             logger.info("Failed to find input_ids. Cannot fuse embedding layer.")
+            return False
+
+        segment_ids = self.find_segment_ids(segment_embedding, input_ids)
+        if segment_ids is None:
+            logger.info("Failed to find segment_ids. Cannot fuse embedding layer.")
             return False
 
         mask_input = self.find_mask_input([segment_ids, input_ids])
@@ -213,13 +256,17 @@ class BertOnnxModelTF(BertOnnxModel):
         self.attention_mask.set_mask_indice(mask_input, mask_index)
 
         if self.find_graph_input(input_ids).type.tensor_type.elem_type != TensorProto.INT32:
-            casted, input_ids = self.cast_graph_input_to_int32(input_ids)
+            casted, input_ids = self.utils.cast_graph_input_to_int32(input_ids)
 
-        if self.find_graph_input(segment_ids).type.tensor_type.elem_type != TensorProto.INT32:
-            casted, segment_ids = self.cast_graph_input_to_int32(segment_ids)
+        if self.find_graph_input(segment_ids):
+            casted, segment_ids = self.utils.cast_graph_input_to_int32(segment_ids)
+        else:
+            segment_ids, segment_id_cast_node = self.utils.cast_input_to_int32(segment_ids)
 
-        if self.find_graph_input(mask_input).type.tensor_type.elem_type != TensorProto.INT32:
-            casted, mask_input = self.cast_graph_input_to_int32(mask_input)
+        if self.find_graph_input(mask_input):
+            casted, mask_input = self.utils.cast_graph_input_to_int32(mask_input)
+        else:
+            mask_input, mask_input_cast_node = self.utils.cast_input_to_int32(mask_input)
 
         embed_output = self.create_node_name('embed_output')
         embed_node = onnx.helper.make_node(

--- a/onnxruntime/python/tools/transformers/test_optimizer.py
+++ b/onnxruntime/python/tools/transformers/test_optimizer.py
@@ -54,7 +54,7 @@ class TestBertOptimization(unittest.TestCase):
             self.assertEqual(len(bert_model.get_nodes_by_op_type(op_type)), count)
 
     # add test function for huggingface pytorch model
-    def test_optimizer_on_huggingface_model(self,
+    def _test_optimizer_on_huggingface_model(self,
                                             model_name,
                                             expected_fusion_result_list,
                                             inputs_count=1,
@@ -71,6 +71,33 @@ class TestBertOptimization(unittest.TestCase):
         import torch
         with torch.no_grad():
             _, is_valid_onnx_model, _, _ = export_onnx_model_from_pt(model_name, MODELS[model_name][1],
+                                                                     MODELS[model_name][2], MODELS[model_name][3], None,
+                                                                     './cache_models', './onnx_models',
+                                                                     input_names[:inputs_count], False,
+                                                                     Precision.FLOAT32, True, True, True, True,
+                                                                     model_fusion_statistics)
+
+        onnx_model = list(model_fusion_statistics.keys())[0]
+        fusion_result_list = list(model_fusion_statistics[onnx_model].values())
+
+        if validate_model:
+            self.assertEqual(is_valid_onnx_model, True)
+        self.assertEqual(fusion_result_list, expected_fusion_result_list)
+    
+    def _test_optimizer_on_tf_model(self, model_name, expected_fusion_result_list, inputs_count, validate_model=True):
+        # expect fusion result list have the following keys
+        # EmbedLayerNormalization, Attention, Gelu, FastGelu, BiasGelu, LayerNormalization, SkipLayerNormalization
+        model_fusion_statistics = {}
+        from onnx_exporter import export_onnx_model_from_tf
+        from huggingface_models import MODELS
+        from benchmark_helper import Precision
+        print("testing mode ", model_name)
+        print("testing input number = ", inputs_count)
+        input_names = MODELS[model_name][0]
+
+        import torch
+        with torch.no_grad():
+            _, is_valid_onnx_model, _, _ = export_onnx_model_from_tf(model_name, MODELS[model_name][1],
                                                                      MODELS[model_name][2], MODELS[model_name][3], None,
                                                                      './cache_models', './onnx_models',
                                                                      input_names[:inputs_count], False,
@@ -298,49 +325,53 @@ class TestBertOptimization(unittest.TestCase):
         self.verify_node_count(model, expected_node_count, 'test_multiple_embed')
 
     def test_huggingface_bert_fusion(self):
-        self.test_optimizer_on_huggingface_model("bert-base-uncased", [1, 12, 0, 0, 12, 0, 24], inputs_count=1)
-        self.test_optimizer_on_huggingface_model("bert-base-uncased", [1, 12, 0, 0, 12, 0, 24], inputs_count=2)
-        self.test_optimizer_on_huggingface_model("bert-base-uncased", [1, 12, 0, 0, 12, 0, 24], inputs_count=3)
+        self._test_optimizer_on_huggingface_model("bert-base-uncased", [1, 12, 0, 0, 12, 0, 24], inputs_count=1)
+        self._test_optimizer_on_huggingface_model("bert-base-uncased", [1, 12, 0, 0, 12, 0, 24], inputs_count=2)
+        self._test_optimizer_on_huggingface_model("bert-base-uncased", [1, 12, 0, 0, 12, 0, 24], inputs_count=3)
 
     def test_huggingface_openaigpt_fusion(self):
-        self.test_optimizer_on_huggingface_model("openai-gpt", [0, 12, 0, 12, 0, 24, 0])
+        self._test_optimizer_on_huggingface_model("openai-gpt", [0, 12, 0, 12, 0, 24, 0])
 
     def test_huggingface_gpt2_fusion(self):
-        self.test_optimizer_on_huggingface_model("gpt2", [0, 12, 0, 12, 0, 25, 0])
+        self._test_optimizer_on_huggingface_model("gpt2", [0, 12, 0, 12, 0, 25, 0])
 
     def test_huggingface_xlm_fusion(self):
-        self.test_optimizer_on_huggingface_model("xlm-mlm-ende-1024", [0, 6, 0, 0, 6, 0, 13])
+        self._test_optimizer_on_huggingface_model("xlm-mlm-ende-1024", [0, 6, 0, 0, 6, 0, 13])
 
     def test_huggingface_roberta_fusion(self):
-        self.test_optimizer_on_huggingface_model("roberta-base", [0, 12, 0, 0, 12, 0, 25])
+        self._test_optimizer_on_huggingface_model("roberta-base", [0, 12, 0, 0, 12, 0, 25])
 
     def test_huggingface_distillbert_fusion(self):
-        self.test_optimizer_on_huggingface_model("distilbert-base-uncased", [1, 6, 0, 0, 6, 0, 12], inputs_count=1)
-        self.test_optimizer_on_huggingface_model("distilbert-base-uncased", [1, 6, 0, 0, 6, 0, 12], inputs_count=2)
+        self._test_optimizer_on_huggingface_model("distilbert-base-uncased", [1, 6, 0, 0, 6, 0, 12], inputs_count=1)
+        self._test_optimizer_on_huggingface_model("distilbert-base-uncased", [1, 6, 0, 0, 6, 0, 12], inputs_count=2)
 
     def test_huggingface_camembert_fusion(self):
         # output not close issue
-        self.test_optimizer_on_huggingface_model("camembert-base", [0, 12, 0, 0, 12, 0, 25], validate_model=False)
+        self._test_optimizer_on_huggingface_model("camembert-base", [0, 12, 0, 0, 12, 0, 25], validate_model=False)
 
     def test_huggingface_albert_fusion(self):
-        self.test_optimizer_on_huggingface_model("albert-base-v1", [0, 12, 0, 0, 12, 0, 25])
+        self._test_optimizer_on_huggingface_model("albert-base-v1", [0, 12, 0, 0, 12, 0, 25])
 
     def test_huggingface_t5_fusion(self):
-        self.test_optimizer_on_huggingface_model("t5-small", [0, 0, 0, 0, 0, 0, 0])
+        self._test_optimizer_on_huggingface_model("t5-small", [0, 0, 0, 0, 0, 0, 0])
 
     def test_huggingface_xlmroberta_fusion(self):
-        self.test_optimizer_on_huggingface_model("xlm-roberta-base", [0, 12, 0, 0, 12, 0, 25])
+        self._test_optimizer_on_huggingface_model("xlm-roberta-base", [0, 12, 0, 0, 12, 0, 25])
 
     def test_huggingface_flaubert_fusion(self):
         # output not close issue
-        self.test_optimizer_on_huggingface_model("flaubert/flaubert_base_cased", [0, 12, 0, 0, 12, 0, 25],
+        self._test_optimizer_on_huggingface_model("flaubert/flaubert_base_cased", [0, 12, 0, 0, 12, 0, 25],
                                                  validate_model=False)
-        self.test_optimizer_on_huggingface_model("flaubert/flaubert_small_cased", [0, 6, 0, 0, 6, 12, 1],
+        self._test_optimizer_on_huggingface_model("flaubert/flaubert_small_cased", [0, 6, 0, 0, 6, 12, 1],
                                                  validate_model=False)
 
     def test_huggingface_dialogpt_fusion(self):
-        self.test_optimizer_on_huggingface_model("microsoft/DialoGPT-small", [0, 12, 0, 12, 0, 25, 0])
+        self._test_optimizer_on_huggingface_model("microsoft/DialoGPT-small", [0, 12, 0, 12, 0, 25, 0])
 
+    def test_bert_base_cased_from_tf(self):
+        self._test_optimizer_on_tf_model("bert-base-cased", [1, 12, 0, 0, 12, 0, 24], 1)
+        self._test_optimizer_on_tf_model("bert-base-cased", [1, 12, 0, 0, 12, 0, 24], 2)
+        self._test_optimizer_on_tf_model("bert-base-cased", [1, 12, 0, 0, 12, 0, 24], 3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description**: Describe your changes.
Update transformer model optimization tool to support 1 and 2 inputs models from Tensorflow. Note this fix is intended for fp32 models.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
