### PR TITLE
Expose model_with_training_graph_path to Python ORTTrainer

### DIFF
--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -392,7 +392,8 @@ def create_ort_training_session_with_optimizer(model, device, training_optimizer
                                                enable_grad_norm_clip=True,
                                                frozen_weights=[], opset_version=DEFAULT_OPSET_VERSION,
                                                use_deterministic_compute=False,
-                                               use_invertible_layernorm_grad=False):
+                                               use_invertible_layernorm_grad=False,
+                                               model_with_training_graph_path=""):
     output_name = model.graph.output[0].name
     ort_parameters = ort.TrainingParameters()
     ort_parameters.loss_output_name = output_name
@@ -405,6 +406,7 @@ def create_ort_training_session_with_optimizer(model, device, training_optimizer
     ort_parameters.enable_grad_norm_clip = enable_grad_norm_clip
     ort_parameters.set_gradients_as_graph_outputs = False
     ort_parameters.use_invertible_layernorm_grad = use_invertible_layernorm_grad
+    ort_parameters.model_with_training_graph_path = model_with_training_graph_path
 
     output_types = {}
     for output in model.graph.output:
@@ -547,7 +549,8 @@ class ORTTrainer():
                  global_step=0, get_lr_this_step=None, loss_scaler=None, deepspeed_zero_stage=0,
                  enable_grad_norm_clip=True, frozen_weights=[], _opset_version=DEFAULT_OPSET_VERSION,
                  _enable_internal_postprocess=True, _extra_postprocess=None, _use_deterministic_compute=False,
-                 use_invertible_layernorm_grad=False, run_symbolic_shape_infer=False):
+                 use_invertible_layernorm_grad=False, run_symbolic_shape_infer=False,
+                 model_with_training_graph_path=""):
         super(ORTTrainer, self).__init__()
         """
         Initialize ORTTrainer.
@@ -617,6 +620,8 @@ class ORTTrainer():
                Defaults to False
             run_symbolic_shape_infer: run symbolic shape inference
                Defaults to False
+            model_with_training_graph_path: path to output training graph
+               Defaults to "" (no output)
         """
         warnings.warn('DISCLAIMER: This is an early version of an experimental training API and it is subject to change. DO NOT create production applications with it')
         self.is_train = True
@@ -680,6 +685,7 @@ class ORTTrainer():
         self._use_deterministic_compute = _use_deterministic_compute
         self.use_invertible_layernorm_grad = use_invertible_layernorm_grad
         self.run_symbolic_shape_infer = run_symbolic_shape_infer
+        self.model_with_training_graph_path = model_with_training_graph_path
 
         # use this special string to workaround a corner case that external loss_scale is passed into train_step as kwargs.
         # see prepare_input_and_fetches for more details.
@@ -710,7 +716,8 @@ class ORTTrainer():
                 enable_grad_norm_clip=self.enable_grad_norm_clip_,
                 frozen_weights=self.frozen_weights_, opset_version=self.opset_version_,
                 use_deterministic_compute=self._use_deterministic_compute,
-                use_invertible_layernorm_grad=self.use_invertible_layernorm_grad)
+                use_invertible_layernorm_grad=self.use_invertible_layernorm_grad,
+                model_with_training_graph_path=self.model_with_training_graph_path)
 
         self.loss_scale_input_name = self.session.loss_scale_input_name
 

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -54,6 +54,9 @@ struct TrainingParameters {
   bool gelu_recompute = false;
   bool transformer_layer_recompute = false;
   int number_recompute_layers = 0;
+
+  // graph dumping
+  std::string model_with_training_graph_path;
 };
 
 struct TrainingConfigurationResult {
@@ -83,6 +86,9 @@ TrainingConfigurationResult ConfigureSessionForTraining(
   }
 
   training::TrainingSession::TrainingConfiguration config{};
+  if (parameters.model_with_training_graph_path.size() > 0) {
+    config.model_with_training_graph_path = parameters.model_with_training_graph_path;
+  }
   config.weight_names_to_train = parameters.weights_to_train;
   config.weight_names_to_not_train = parameters.weights_not_to_train;
   config.immutable_weights = parameters.immutable_weights;
@@ -210,7 +216,8 @@ void addObjectMethodsForTraining(py::module& m) {
       .def_readwrite("number_recompute_layers", &TrainingParameters::number_recompute_layers)
       .def_readwrite("data_parallel_size", &TrainingParameters::data_parallel_size)
       .def_readwrite("horizontal_parallel_size", &TrainingParameters::horizontal_parallel_size)
-      .def_readwrite("pipeline_parallel_size", &TrainingParameters::pipeline_parallel_size);
+      .def_readwrite("pipeline_parallel_size", &TrainingParameters::pipeline_parallel_size)
+      .def_readwrite("model_with_training_graph_path", &TrainingParameters::model_with_training_graph_path);
 
 #if defined(USE_MPI)
   m.def("get_mpi_context_local_rank", []() -> int { return MPIContext::GetInstance().GetLocalRank(); });

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -637,6 +637,7 @@ class ORTTrainer(object):
         ort_parameters.gelu_recompute = self.options.graph_transformer.gelu_recompute
         ort_parameters.transformer_layer_recompute = self.options.graph_transformer.transformer_layer_recompute
         ort_parameters.number_recompute_layers = self.options.graph_transformer.number_recompute_layers
+        ort_parameters.model_with_training_graph_path = self.options.debug.model_with_training_graph_path
 
         # SessionOptions
         session_options = ort.SessionOptions()

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -277,6 +277,8 @@ class ORTTrainerOptions(object):
         debug.check_model_export (bool, default is False)
             compares PyTorch model outputs with ONNX model outputs in inference before the first
             train step to ensure successful model export
+        debug.model_with_training_graph_path (str, default is "")
+            path to export the training onnx graph. No output when it is empty.
         _internal_use (dict):
             internal options, possibly undocumented, that might be removed without notice
         _internal_use.enable_internal_postprocess (bool, default is True):

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -176,6 +176,10 @@ class ORTTrainerOptions(object):
                             'type' : 'boolean',
                             'default' : False
                         },
+                        'model_with_training_graph_path': {
+                            'type': 'string',
+                            'default': ''
+                        }
                     }
                 },
                 '_internal_use' : {
@@ -530,6 +534,10 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
                 'type': 'boolean',
                 'default': False
             },
+            'model_with_training_graph_path': {
+                'type': 'string',
+                'default': ''
+            }
         }
     },
     '_internal_use': {

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -1426,6 +1426,8 @@ def testTrainingGraphExport(device):
         data, targets = batcher_fn(train_data, 0)
         trainer.train_step(data, targets)
         assert os.path.isfile(graph_path)
+        training_graph = onnx.load(graph_path).graph
+        assert any("Grad" in n.name for n in training_graph.node)
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
@@ -1439,3 +1441,5 @@ def testTrainingGraphExportLegacy(device):
         data, targets = batcher_fn(train_data, 0)
         trainer.train_step(data, targets, torch.tensor([0.01]))
         assert os.path.isfile(graph_path)
+        training_graph = onnx.load(graph_path).graph
+        assert any("Grad" in n.name for n in training_graph.node)

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -109,7 +109,8 @@ def testORTTrainerOptionsDefaultValues(test_input):
         },
         'debug': {
             'deterministic_compute': False,
-            'check_model_export': False
+            'check_model_export': False,
+            'model_with_training_graph_path': ''
         },
         '_internal_use': {
             'enable_internal_postprocess': True,


### PR DESCRIPTION
**Description**: Expose model_with_training_graph_path to Python ORTTrainer

**Motivation and Context**
- This PR enables users to specify `model_with_training_graph_path` parameter when they create an `ORTTrainer` in Python. This allows them to examine the exported training graph after various transformations in [TrainingSession::ConfigureForTraining](https://github.com/microsoft/onnxruntime/blob/cdacee6696262d0c5431b6860bb0966afdc6eb0d/orttraining/orttraining/core/session/training_session.cc#L401)

