### PR TITLE
Disable Python 3.9 for training Python packaging build.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -302,8 +302,9 @@ stages:
             PythonVersion: '3.7'
           Python38:
             PythonVersion: '3.8'
-          Python39:
-            PythonVersion: '3.9'
+          # dependency PyTorch does not support Python 3.9 yet
+          # Python39:
+          #   PythonVersion: '3.9'
       steps:
       - checkout: self
         clean: true


### PR DESCRIPTION
**Description**
Disable Python 3.9 for training Python packaging build. Python 3.9 is not supported by the PyTorch dependency.

**Motivation and Context**
Fix build.
