### PR TITLE
Clean up builds

### DIFF
--- a/tools/ci_build/get_docker_image.py
+++ b/tools/ci_build/get_docker_image.py
@@ -153,7 +153,12 @@ def main():
             "--file", args.dockerfile,
             args.context)
 
-        run(args.docker_path, "push", full_image_name)
+        # avoid pushing if an identically tagged image has been pushed since the last check
+        # there is still a race condition, but this reduces the chance of a redundant push
+        if not container_registry_has_image(full_image_name, args.docker_path):
+            run(args.docker_path, "push", full_image_name)
+        else:
+            log.info("Image now found, skipping push")
 
     # tag so we can refer to the image by repository name
     run(args.docker_path, "tag", full_image_name, args.repository)

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-e2e-test-nightly-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-e2e-test-nightly-pipeline.yml
@@ -36,7 +36,8 @@ jobs:
           --build_wheel \
           --enable_training_python_frontend_e2e_tests \
           --enable_training_pipeline_e2e_tests \
-          "
+          " \
+        -m
       DisplayName: 'Build'
 
   # Hit OOM with run_training_pipeline_e2e_tests.py - slightly above 16GB limit.

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-frontend-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-frontend-test-ci-pipeline.yml
@@ -38,6 +38,7 @@ jobs:
         --enable_training_python_frontend_e2e_tests
         --enable_training_pipeline_e2e_tests
         "
+        -m
       DisplayName: 'Build and run frontend tests'
 
   - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline.yml
@@ -7,11 +7,7 @@ stages:
     enable_linux_cpu: false
     enable_linux_gpu: false
     enable_linux_gpu_training: true
-    # Python 3.5 build has issues with nightly torch and torchvision dependencies
-    enable_linux_gpu_py35: false
     enable_windows_cpu: false
     enable_windows_gpu: false
     enable_mac_cpu: false
     enable_linux_arm: false
-    docker_image_prefix: onnxruntime-training
-    linux_gpu_dockerfile: Dockerfile.manylinux2014_gpu

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -20,13 +20,6 @@ parameters:
   type: boolean
   default: false
 
-- name: enable_linux_gpu_py35
-  displayName: >
-    Whether Linux GPU package is built for Python 3.5.
-    enable_linux_gpu must be true for this to have an effect.
-  type: boolean
-  default: true
-
 - name: enable_windows_cpu
   displayName: 'Whether Windows CPU package is built.'
   type: boolean
@@ -46,18 +39,6 @@ parameters:
   displayName: 'Whether Linux ARM package is built.'
   type: boolean
   default: true
-
-- name: docker_image_prefix
-  displayName: 'Prefix to use for docker image names.'
-  type: string
-  default: 'onnxruntime'
-
-- name: linux_gpu_dockerfile
-  displayName: >
-    Name of the Dockerfile to use for the Linux GPU build.
-    This should refer to a Dockerfile at tools/ci_build/github/linux/docker.
-  type: string
-  default: 'Dockerfile.manylinux2010_gpu'
 
 stages:
 - stage: Python_Packaging
@@ -302,8 +283,9 @@ stages:
             PythonVersion: '3.7'
           Python38:
             PythonVersion: '3.8'
-          Python39:
-            PythonVersion: '3.9'
+          # dependency PyTorch does not support Python 3.9 yet
+          # Python39:
+          #   PythonVersion: '3.9'
       steps:
       - checkout: self
         clean: true
@@ -311,17 +293,16 @@ stages:
 
       - template: set-python-manylinux-variables-step.yml
 
-      - task: CmdLine@2
-        inputs:
-          script: |
-            docker build --pull \
-              -t ${{ parameters.docker_image_prefix }}-manylinux-gpu-$(PythonVersion) \
-              --build-arg BUILD_USER=onnxruntimedev \
-              --build-arg BUILD_UID=$(id -u) \
-              --build-arg PYTHON_VERSION=$(PythonVersion) \
-              --build-arg BUILD_EXTR_PAR="${{ parameters.build_py_parameters }}" \
-              -f ${{ parameters.linux_gpu_dockerfile }} .
-          workingDirectory: $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker
+      - template: get-docker-image-steps.yml
+        parameters:
+          Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_gpu
+          Context: tools/ci_build/github/linux/docker
+          DockerBuildArgs: >-
+            --build-arg PYTHON_VERSION=$(PythonVersion)
+            --build-arg INSTALL_DEPS_EXTRA_ARGS=-t
+            --build-arg BUILD_UID=$(id -u)
+          Repository: onnxruntimegpubuild
+
       - task: CmdLine@2
         inputs:
           script: |
@@ -335,7 +316,7 @@ stages:
               -e NVIDIA_VISIBLE_DEVICES=all \
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
-              ${{ parameters.docker_image_prefix }}-manylinux-gpu-$(PythonVersion) \
+              onnxruntimegpubuild \
                 $(PythonManylinuxDir)/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
                   --build_dir /build \
                   --config Release \

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -283,9 +283,8 @@ stages:
             PythonVersion: '3.7'
           Python38:
             PythonVersion: '3.8'
-          # dependency PyTorch does not support Python 3.9 yet
-          # Python39:
-          #   PythonVersion: '3.9'
+          Python39:
+            PythonVersion: '3.9'
       steps:
       - checkout: self
         clean: true

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_gpu
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_gpu
@@ -25,14 +25,14 @@ ENV SSL_CERT_FILE=/opt/_internal/certs.pem
 
 #Build manylinux2014 docker image end
 
-ARG PYTHON_VERSION=3.5
-ARG BUILD_EXTR_PAR
+ARG PYTHON_VERSION=3.6
+ARG INSTALL_DEPS_EXTRA_ARGS
 
 #Add our own dependencies
 ADD scripts /tmp/scripts
 RUN cd /tmp/scripts && \
     /tmp/scripts/install_centos.sh && \
-    /tmp/scripts/install_deps.sh -d gpu -p $PYTHON_VERSION -x "$BUILD_EXTR_PAR" && \
+    /tmp/scripts/install_deps.sh -d gpu -p $PYTHON_VERSION $INSTALL_DEPS_EXTRA_ARGS && \
     rm -rf /tmp/scripts
 
 ARG BUILD_UID=1001

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_gpu
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_gpu
@@ -1,12 +1,11 @@
 FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04
 
 ARG PYTHON_VERSION=3.6
-ARG BUILD_EXTR_PAR
 ARG INSTALL_DEPS_EXTRA_ARGS
 
 ADD scripts /tmp/scripts
 RUN /tmp/scripts/install_ubuntu.sh -p $PYTHON_VERSION && \
-    /tmp/scripts/install_deps.sh -p $PYTHON_VERSION -d gpu -x "$BUILD_EXTR_PAR" $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_deps.sh -p $PYTHON_VERSION -d gpu $INSTALL_DEPS_EXTRA_ARGS && \
     rm -rf /tmp/scripts
 
 WORKDIR /root
@@ -27,4 +26,3 @@ ARG BUILD_UID=1000
 RUN adduser --gecos 'onnxruntime Build User' --disabled-password $BUILD_USER --uid $BUILD_UID
 WORKDIR /home/$BUILD_USER
 USER $BUILD_USER
-

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -2,15 +2,16 @@
 set -e -x
 
 SCRIPT_DIR="$( dirname "${BASH_SOURCE[0]}" )"
+INSTALL_DEPS_TRAINING=false
 INSTALL_DEPS_DISTRIBUTED_SETUP=false
 
-while getopts p:d:x:m parameter_Option
+while getopts p:d:tm parameter_Option
 do case "${parameter_Option}"
 in
 p) PYTHON_VER=${OPTARG};;
 d) DEVICE_TYPE=${OPTARG};;
-x) BUILD_EXTR_PAR=${OPTARG};;
-m) INSTALL_DEPS_DISTRIBUTED_SETUP=true
+t) INSTALL_DEPS_TRAINING=true;;
+m) INSTALL_DEPS_DISTRIBUTED_SETUP=true;;
 esac
 done
 
@@ -114,13 +115,12 @@ export ONNX_ML=1
 export CMAKE_ARGS="-DONNX_GEN_PB_TYPE_STUBS=OFF -DONNX_WERROR=OFF"
 ${PYTHON_EXE} -m pip install -r ${0/%install_deps\.sh/requirements\.txt}
 if [ $DEVICE_TYPE = "gpu" ]; then
-    if [[ $BUILD_EXTR_PAR = *--enable_training* ]]; then
-      ${PYTHON_EXE} -m pip install -r ${0/%install_deps.sh/training\/requirements.txt}
-
-      if [[ $BUILD_EXTR_PAR = *--enable_training_python_frontend_e2e_tests* || $BUILD_EXTR_PAR = *enable_training_pipeline_e2e_tests* || $INSTALL_DEPS_DISTRIBUTED_SETUP = true ]]; then
-        source ${0/%install_deps.sh/install_openmpi.sh}
-      fi
-    fi
+  if [[ $INSTALL_DEPS_TRAINING = true ]]; then
+    ${PYTHON_EXE} -m pip install -r ${0/%install_deps.sh/training\/requirements.txt}
+  fi
+  if [[ $INSTALL_DEPS_DISTRIBUTED_SETUP = true ]]; then
+    source ${0/%install_deps.sh/install_openmpi.sh}
+  fi
 fi
 
 cd /

--- a/tools/ci_build/github/linux/run_dockerbuild.sh
+++ b/tools/ci_build/github/linux/run_dockerbuild.sh
@@ -84,9 +84,14 @@ else
         if [ $CUDA_VER = "cuda9.1-cudnn7.1" ]; then
             DOCKER_FILE=Dockerfile.ubuntu_gpu_cuda9
         fi
-        [[ $INSTALL_DEPS_DISTRIBUTED_SETUP = true ]] && INSTALL_DEPS_EXTRA_ARGS="-m" || INSTALL_DEPS_EXTRA_ARGS=""
+        if [[ $BUILD_EXTR_PAR = *--enable_training* ]]; then
+            INSTALL_DEPS_EXTRA_ARGS="${INSTALL_DEPS_EXTRA_ARGS} -t"
+        fi
+        if [[ $INSTALL_DEPS_DISTRIBUTED_SETUP = true ]]; then
+            INSTALL_DEPS_EXTRA_ARGS="${INSTALL_DEPS_EXTRA_ARGS} -m"
+        fi
         $GET_DOCKER_IMAGE_CMD --repository "onnxruntime-$IMAGE" \
-            --docker-build-args="--build-arg BUILD_USER=onnxruntimedev --build-arg BUILD_UID=$(id -u) --build-arg PYTHON_VERSION=${PYTHON_VER} --build-arg BUILD_EXTR_PAR=\"${BUILD_EXTR_PAR}\" --build-arg INSTALL_DEPS_EXTRA_ARGS=${INSTALL_DEPS_EXTRA_ARGS}" \
+            --docker-build-args="--build-arg BUILD_USER=onnxruntimedev --build-arg BUILD_UID=$(id -u) --build-arg PYTHON_VERSION=${PYTHON_VER} --build-arg INSTALL_DEPS_EXTRA_ARGS=\"${INSTALL_DEPS_EXTRA_ARGS}\"" \
             --dockerfile $DOCKER_FILE --context .
     elif [ $BUILD_DEVICE = "tensorrt" ]; then
         # TensorRT container release 20.07


### PR DESCRIPTION
**Description**
Update training Python packaging build to use get_docker_image.py.
Remove BUILD_EXTR_PAR docker build argument.
Update get_docker_image.py to check again for the image in the cache after building and before pushing to reduce the chance of a redundant push.

**Motivation and Context**
Use build image cache, reduce number of cached images (previously different values of BUILD_EXTR_PAR would result in distinct cached images).