### PR TITLE
Deprecate opsets <12 for training.

### DIFF
--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -194,7 +194,7 @@ class ORTTrainerOptions(object):
                         },
                         'onnx_opset_version': {
                             'type': 'integer',
-                            'min' : 10,
+                            'min' : 12,
                             'max' : 12,
                             'default': 12
                         },
@@ -486,7 +486,7 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
             'transformer_layer_recompute': {
                 'type': 'boolean',
                 'default': False
-            }, 
+            },
             'number_recompute_layers': {
                 'type': 'integer',
                 'min': 0,
@@ -548,7 +548,7 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
             },
             'onnx_opset_version': {
                 'type': 'integer',
-                'min' : 10,
+                'min' : 12,
                 'max' : 12,
                 'default': 12
             },


### PR DESCRIPTION
After https://github.com/microsoft/onnxruntime/pull/5793 is merged, opsets before 12 (10 and 11) will not be supported for training.

This change explicitly removes the deprecated opsets from the frontend.