### PR TITLE
Upgrade packages to avoid docker image security vulnerability

### DIFF
--- a/dockerfiles/Dockerfile.training
+++ b/dockerfiles/Dockerfile.training
@@ -158,6 +158,10 @@ RUN pip install azureml-defaults sentencepiece==0.1.92 transformers==2.11.0 msgp
 FROM nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04
 WORKDIR /stage
 
+# install curl, git, ssh (required by MPI when running ORT tests)
+RUN apt-get -y update &&\
+    apt-get -y upgrade
+
 # install ucx
 # note: launch with --cap-add=sys_nice to avoid 'mbind' warnings
 COPY --from=builder /opt/ucx /opt/ucx


### PR DESCRIPTION
**Description**: Upgrade packages to avoid docker image security vulnerability

**Motivation and Context**
MCR security vulnerability report revealed some packages not up-to-date and could be security concern
- If it fixes an open issue, please link to the issue here.
