### PR TITLE
Issue #356: The result of TensorFloat.GetReference() can't be disposed

### DIFF
--- a/winml/lib/Api/impl/TensorMemoryBufferReference.h
+++ b/winml/lib/Api/impl/TensorMemoryBufferReference.h
@@ -58,6 +58,7 @@ template <typename T>
 class TensorMemoryBufferReference : public winrt::implements<
                                         TensorMemoryBufferReference<T>,
                                         wf::IMemoryBufferReference,
+                                        wf::IClosable,
                                         Windows::Foundation::IMemoryBufferByteAccess> {
   using ClosedDelegate = wf::TypedEventHandler<wf::IMemoryBufferReference, wf::IInspectable>;
 


### PR DESCRIPTION
[Issue #356: The result of TensorFloat.GetReference() can't be disposed](https://github.com/microsoft/Windows-Machine-Learning/issues/356)

Fix: The problem is that the Iclosable interface was implemented but is not present in the list of interfaces on the TensorMemoryBufferReference object. Added wf::IClosable as interface.