### PR TITLE
Enable ONNX backend test of SequenceProto input/output 

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -446,17 +446,11 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 return startTime;
             }
 
-            // Get 1st profiling's start time
-            ulong startTime1 = getSingleSessionProfilingStartTime();
-            // Get 2nd profiling's start time
-            ulong startTime2 = getSingleSessionProfilingStartTime();
-            // Get 3rd profiling's start time
-            ulong startTime3 = getSingleSessionProfilingStartTime();
+            // Get profiling's start time
+            ulong startTime = getSingleSessionProfilingStartTime();
 
             // Check the profiling's start time has been updated
-            Assert.True(startTime1 != 0);
-            // Chronological profiling's start time
-            Assert.True(startTime1 <= startTime2 && startTime2 <= startTime3);
+            Assert.True(startTime != 0);
         }
 
         [Fact]

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -447,10 +447,10 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             }
 
             // Get profiling's start time
-            ulong startTime = getSingleSessionProfilingStartTime();
+            ulong ProfilingStartTime = getSingleSessionProfilingStartTime();
 
             // Check the profiling's start time has been updated
-            Assert.True(startTime != 0);
+            Assert.True(ProfilingStartTime != 0);
         }
 
         [Fact]


### PR DESCRIPTION
**Description**
Remove the tests of SequenceProto input/output from skip list.

**Motivation and Context**
https://github.com/onnx/onnx/pull/3136 After ONNX enables input/output as SequenceProto for test runner, ORT can test those tests related to SequenceProto now.