### PR TITLE
Remove python 3.8 Windows GPU build from python packaging pipeline

### DIFF
--- a/onnxruntime/python/_pybind_state.py
+++ b/onnxruntime/python/_pybind_state.py
@@ -5,22 +5,8 @@
 
 import os
 import platform
-import sys
 import warnings
 import onnxruntime.capi._ld_preload  # noqa: F401
-
-# Python 3.8 (and later) on Windows doesn't search system PATH when loading DLLs,
-# so CUDA location needs to be specified explicitly.
-if platform.system() == "Windows" and sys.version_info >= (3, 8):
-    CUDA_VERSION = "10.2"
-    CUDNN_VERSION = "8"
-    cuda_env_variable = "CUDA_PATH_V" + CUDA_VERSION.replace(".", "_")
-    if cuda_env_variable not in os.environ:
-        raise ImportError("CUDA Toolkit %s not installed on the machine." % CUDA_VERSION)
-    cuda_bin_dir = os.path.join(os.environ[cuda_env_variable], "bin")
-    if not os.path.isfile(os.path.join(cuda_bin_dir, "cudnn64_%s.dll" % CUDNN_VERSION)):
-        raise ImportError("cuDNN %s not installed on the machine." % CUDNN_VERSION)
-    os.add_dll_directory(cuda_bin_dir)
 
 try:
     from onnxruntime.capi.onnxruntime_pybind11_state import *  # noqa
@@ -35,6 +21,6 @@ except ImportError as e:
     # TODO: Add a guard against False Positive error message
     # As a proxy for checking if the 2019 VC Runtime is installed,
     # we look for a specific dll only shipped with the 2019 VC Runtime
-    if platform.system() == "Windows" and not os.path.isfile("C:\\Windows\\System32\\vcruntime140_1.dll"):
+    if platform.system().lower() == 'windows' and not os.path.isfile('c:\\Windows\\System32\\vcruntime140_1.dll'):
         warnings.warn("Unless you have built the wheel using VS 2017, "
-                      "please install the 2019 Visual C++ runtime and then try again.")
+                      "please install the 2019 Visual C++ runtime and then try again")

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -625,10 +625,6 @@ stages:
             PythonVersion: '3.6'
           Python37:
             PythonVersion: '3.7'
-          Python38:
-            PythonVersion: '3.8'
-          Python39:
-            PythonVersion: '3.9'
       steps:
       - checkout: self
         clean: true


### PR DESCRIPTION
**Description**: 

Revert the last a few changes to get the pipeline back to a normal state.

**Motivation and Context**
- Why is this change required? What problem does it solve?

#6051

- If it fixes an open issue, please link to the issue here.
