### PR TITLE
If building inbox, hook up winrt_activation_handler for WinML Tests

### DIFF
--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -55,6 +55,11 @@ function(add_winml_test)
   target_link_libraries(${_UT_TARGET} PRIVATE ${_UT_LIBS} gtest winml_google_test_lib ${onnxruntime_EXTERNAL_LIBRARIES} winml_lib_common onnxruntime windowsapp.lib)
   target_compile_options(${_UT_TARGET} PRIVATE /wd5205)  # workaround cppwinrt SDK bug https://github.com/microsoft/cppwinrt/issues/584
 
+  # if building inbox
+  if (onnxruntime_WINML_NAMESPACE_OVERRIDE STREQUAL "Windows")
+    target_compile_definitions(${_UT_TARGET} PRIVATE "BUILD_INBOX=1")
+  endif()
+
   add_test(NAME ${_UT_TARGET}
     COMMAND ${_UT_TARGET}
     WORKING_DIRECTORY $<TARGET_FILE_DIR:${_UT_TARGET}>

--- a/winml/test/adapter/AdapterDmlEpTest.cpp
+++ b/winml/test/adapter/AdapterDmlEpTest.cpp
@@ -27,6 +27,9 @@ void AdapterDmlEpTestSetup() {
   ort_api = OrtGetApiBase()->GetApi(2);
   winml_adapter_api = OrtGetWinMLAdapter(ort_api);
   ort_api->CreateEnv(OrtLoggingLevel::ORT_LOGGING_LEVEL_VERBOSE, "Default", &ort_env);
+#ifdef BUILD_INBOX
+  winrt_activation_handler = WINRT_RoGetActivationFactory;
+#endif
 }
 
 void AdapterDmlEpTestTeardown() {

--- a/winml/test/adapter/AdapterSessionTest.cpp
+++ b/winml/test/adapter/AdapterSessionTest.cpp
@@ -33,6 +33,9 @@ OrtEnv* ort_env;
 
 void AdapterSessionTestSetup() {
   winrt::init_apartment();
+#ifdef BUILD_INBOX
+  winrt_activation_handler = WINRT_RoGetActivationFactory;
+#endif
   WINML_EXPECT_HRESULT_SUCCEEDED(Microsoft::WRL::MakeAndInitialize<_winml::OnnxruntimeEngineFactory>(engine_factory.put()));
   WINML_EXPECT_HRESULT_SUCCEEDED(engine_factory->GetOrtEnvironment(&ort_env));
   WINML_EXPECT_NOT_EQUAL(nullptr, winml_adapter_api = engine_factory->UseWinmlAdapterApi());

--- a/winml/test/adapter/adapter_test.cpp
+++ b/winml/test/adapter/adapter_test.cpp
@@ -8,6 +8,9 @@ using namespace ws;
 using namespace wss;
 
 static void AdapterTestSetup() {
+#ifdef BUILD_INBOX
+  winrt_activation_handler = WINRT_RoGetActivationFactory;
+#endif
   ort_api = OrtGetApiBase()->GetApi(2);
   winml_adapter_api = OrtGetWinMLAdapter(ort_api);
   

--- a/winml/test/api/LearningModelAPITest.cpp
+++ b/winml/test/api/LearningModelAPITest.cpp
@@ -15,6 +15,9 @@ using namespace wss;
 
 static void LearningModelAPITestsClassSetup() {
   init_apartment();
+#ifdef BUILD_INBOX
+  winrt_activation_handler = WINRT_RoGetActivationFactory;
+#endif
 }
 
 static void CreateModelFromFilePath() {

--- a/winml/test/api/LearningModelBindingAPITest.cpp
+++ b/winml/test/api/LearningModelBindingAPITest.cpp
@@ -18,6 +18,9 @@ using namespace ws;
 
 static void LearningModelBindingAPITestsClassSetup() {
   init_apartment();
+#ifdef BUILD_INBOX
+  winrt_activation_handler = WINRT_RoGetActivationFactory;
+#endif
 }
 
 static void CpuSqueezeNet()

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -21,6 +21,9 @@ using wf::IPropertyValue;
 
 static void LearningModelSessionAPITestsClassSetup() {
   init_apartment();
+#ifdef BUILD_INBOX
+  winrt_activation_handler = WINRT_RoGetActivationFactory;
+#endif
 }
 
 static void CreateSessionDeviceDefault()

--- a/winml/test/common/dllload.cpp
+++ b/winml/test/common/dllload.cpp
@@ -4,6 +4,7 @@
 #include "Std.h"
 #include "fileHelpers.h"
 #include <winstring.h>
+#include "dllload.h"
 
 extern "C"
 {

--- a/winml/test/common/dllload.h
+++ b/winml/test/common/dllload.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "Std.h"
+
+int32_t __stdcall WINRT_RoGetActivationFactory(void* classId, winrt::guid const& iid, void** factory) noexcept;

--- a/winml/test/common/dllload.h
+++ b/winml/test/common/dllload.h
@@ -1,4 +1,5 @@
 #pragma once
 #include "Std.h"
+#include "winrt/base.h"
 
 int32_t __stdcall WINRT_RoGetActivationFactory(void* classId, winrt::guid const& iid, void** factory) noexcept;

--- a/winml/test/common/testPch.h
+++ b/winml/test/common/testPch.h
@@ -16,5 +16,5 @@
 #include <wrl/implements.h>
 
 #include "fileHelpers.h"
-
+#include "dllload.h"
 #include <thread>

--- a/winml/test/concurrency/ConcurrencyTests.cpp
+++ b/winml/test/concurrency/ConcurrencyTests.cpp
@@ -39,6 +39,9 @@ void LoadBindEvalSqueezenetRealDataWithValidationConcurrently() {
 void ConcurrencyTestsClassSetup() {
     init_apartment();
     std::srand(static_cast<unsigned>(std::time(nullptr)));
+#ifdef BUILD_INBOX
+    winrt_activation_handler = WINRT_RoGetActivationFactory;
+#endif
 }
 
 struct EvaluationUnit {

--- a/winml/test/image/imagetests.cpp
+++ b/winml/test/image/imagetests.cpp
@@ -37,6 +37,9 @@ protected:
 
     static void SetUpTestSuite() {
       init_apartment();
+#ifdef BUILD_INBOX
+      winrt_activation_handler = WINRT_RoGetActivationFactory;
+#endif
     }
 
     void LoadModel(const std::wstring& model_path) {

--- a/winml/test/model/model_tests.cpp
+++ b/winml/test/model/model_tests.cpp
@@ -22,6 +22,9 @@ std::vector<std::unique_ptr<ITestCase>> ownedTests;
 class ModelTest : public testing::TestWithParam<std::tuple<ITestCase*, winml::LearningModelDeviceKind>> {
  protected:
   void SetUp() override {
+#ifdef BUILD_INBOX
+    winrt_activation_handler = WINRT_RoGetActivationFactory;
+#endif
     std::tie(m_testCase, m_deviceKind) = GetParam();
     WINML_EXPECT_NO_THROW(m_testCase->GetPerSampleTolerance(&m_perSampleTolerance));
     WINML_EXPECT_NO_THROW(m_testCase->GetRelativePerSampleTolerance(&m_relativePerSampleTolerance));

--- a/winml/test/scenario/cppwinrt/CustomOps.cpp
+++ b/winml/test/scenario/cppwinrt/CustomOps.cpp
@@ -31,6 +31,9 @@ using namespace wss;
 static void CustomOpsScenarioTestsClassSetup()
 {
   winrt::init_apartment();
+  #ifdef BUILD_INBOX
+    winrt_activation_handler = WINRT_RoGetActivationFactory;
+  #endif
 }
 
 // Tests that the execution provider correctly fuses operators together when custom ops are involved.

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -48,6 +48,9 @@ using namespace Windows::Graphics::DirectX::Direct3D11;
 
 static void ScenarioCppWinrtTestsClassSetup() {
   winrt::init_apartment();
+#ifdef BUILD_INBOX
+  winrt_activation_handler = WINRT_RoGetActivationFactory;
+#endif
 }
 
 static void Sample1() {


### PR DESCRIPTION
The previous way to hook up Winrt RoGetActivation factory has been replaced with this way to set winrt_activation_handler in the NuGet cppwinrt. This functionality was added in this change in cppwinrt : **https://github.com/microsoft/cppwinrt/pull/477**

This change updates all of WinML's tests to use winrt_activation_handler to use local WinML binaries instead of WinML binaries from system32.
