### PR TITLE
Bump up API version for 1.6 release.

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -7,7 +7,7 @@
 #include <string.h>
 
 // This value is used in structures passed to ORT so that a newer version of ORT will still work with them
-#define ORT_API_VERSION 5
+#define ORT_API_VERSION 6
 
 #ifdef __cplusplus
 extern "C" {

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2063,7 +2063,6 @@ static constexpr OrtApi ort_api_1_to_6 = {
     &OrtApis::SetGlobalSpinControl,
     // End of Version 5 - DO NOT MODIFY ABOVE (see above text for more information)
 
-    // Version 6 - In development, feel free to add/remove/rearrange here
     &OrtApis::AddInitializer,
     &OrtApis::CreateEnvWithCustomLoggerAndGlobalThreadPools,
     &OrtApis::SessionOptionsAppendExecutionProvider_CUDA,
@@ -2071,6 +2070,9 @@ static constexpr OrtApi ort_api_1_to_6 = {
     &OrtApis::SetGlobalDenormalAsZero,
     &OrtApis::CreateArenaCfg,
     &OrtApis::ReleaseArenaCfg,
+    // End of Version 6 - DO NOT MODIFY ABOVE (see above text for more information)
+
+    // Version 7 - In development, feel free to add/remove/rearrange here
 };
 
 // Assert to do a limited check to ensure Version 1 of OrtApi never changes (will detect an addition or deletion but not if they cancel out each other)


### PR DESCRIPTION
**Description**: Bump up API version for 1.6 release.
This should be cherry-picked into the 1.6 release branch.

**Motivation and Context**
API versioning.