### PR TITLE
Use onnx.numpy_helper.from_array instead of make_tensor to create tensor

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_attention.py
@@ -129,7 +129,7 @@ class FusionAttention(Fusion):
 
         attention_node_name = self.model.create_node_name('Attention')
 
-        weight = transformerutils.make_initializer(name=attention_node_name + '_qkv_weight',
+        weight = TransformerUtils.make_initializer(name=attention_node_name + '_qkv_weight',
                                                    data_type=TensorProto.FLOAT,
                                                    dims=[self.hidden_size, 3 * self.hidden_size],
                                                    vals=qkv_weight.flatten().tolist())

--- a/onnxruntime/python/tools/transformers/fusion_embedlayer.py
+++ b/onnxruntime/python/tools/transformers/fusion_embedlayer.py
@@ -9,6 +9,7 @@ from onnx import helper
 from onnx_model import OnnxModel
 from fusion_base import Fusion
 from fusion_utils import FusionUtils
+from transformer_utils import TransformerUtils
 
 logger = getLogger(__name__)
 
@@ -79,7 +80,7 @@ class FusionEmbedLayerNoMask(Fusion):
                     helper.make_node('ConstantOfShape',
                                      inputs=["input_shape"],
                                      outputs=["zeros_for_input_shape"],
-                                     value=helper.make_tensor("value", onnx.TensorProto.INT32, [1], [1])))
+                                     value=TransformerUtils.make_initializer("value", onnx.TensorProto.INT32, [1], [1])))
                 segment_ids = "zeros_for_input_shape"
 
         return segment_ids, segment_embedding_gather

--- a/onnxruntime/python/tools/transformers/fusion_reshape.py
+++ b/onnxruntime/python/tools/transformers/fusion_reshape.py
@@ -8,6 +8,7 @@ from onnx import helper, numpy_helper, TensorProto
 from onnx_model import OnnxModel
 from fusion_base import Fusion
 import numpy as np
+from transformer_utils import TransformerUtils
 
 logger = getLogger(__name__)
 
@@ -123,11 +124,10 @@ class FusionReshape(Fusion):
         new_node = helper.make_node('Constant',
                                     inputs=[],
                                     outputs=[constant_shape_name],
-                                    value=helper.make_tensor(name='const_tensor',
-                                                             data_type=TensorProto.INT64,
-                                                             dims=shape_value.shape,
-                                                             vals=bytes(shape_value),
-                                                             raw=True))
+                                    value=TransformerUtils.make_initializer(name='const_tensor',
+                                                                            data_type=TensorProto.INT64,
+                                                                            dims=shape_value.shape,
+                                                                            vals=shape_value))
         reshape_node.input[1] = constant_shape_name
         reshape_node.name = self.model.create_node_name('Reshape', 'Reshape_Fuse')
         self.nodes_to_remove.extend([concat_node])

--- a/onnxruntime/python/tools/transformers/onnx_model_bert_tf.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert_tf.py
@@ -11,6 +11,7 @@ import numpy as np
 from collections import deque
 from onnx import ModelProto, TensorProto, numpy_helper, helper
 from onnx_model_bert import BertOnnxModel
+from transformer_utils import TransformerUtils
 
 logger = logging.getLogger(__name__)
 
@@ -434,7 +435,7 @@ class BertOnnxModelTF(BertOnnxModel):
                 if parent.op_type == 'Reshape':
                     # Temporary work around: we require the skiplayernorm and attention op be fed with 3-d input
                     hidden_size = numpy_helper.to_array(self.get_initializer(parent.input[1]))[1]
-                    tensor = helper.make_tensor(
+                    tensor = TransformerUtils.make_initializer(
                         name=parent.name + "_modified",
                         data_type=TensorProto.INT64,
                         dims=[3],

--- a/onnxruntime/python/tools/transformers/shape_optimizer.py
+++ b/onnxruntime/python/tools/transformers/shape_optimizer.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from onnx import ModelProto, TensorProto, numpy_helper
 import onnxruntime
 from onnx_model import OnnxModel
+from transformer_utils import TransformerUtils
 
 logger = logging.getLogger(__name__)
 
@@ -43,10 +44,10 @@ class BertOnnxModelShapeOptimizer(OnnxModel):
         """
         shape_value = np.asarray(shape, dtype=np.int64)
         constant_shape_name = self.create_node_name('Constant', CONSTANT_SHAPE_NAME_PREFIX)
-        tensor = onnx.helper.make_tensor(name=constant_shape_name,
-                                         data_type=TensorProto.INT64,
-                                         dims=shape_value.shape,
-                                         vals=shape_value)
+        tensor = TransformerUtils.make_initializer(name=constant_shape_name,
+                                                   data_type=TensorProto.INT64,
+                                                   dims=shape_value.shape,
+                                                   vals=shape_value)
         self.add_initializer(tensor)
         return tensor
 

--- a/onnxruntime/python/tools/transformers/transformer_utils.py
+++ b/onnxruntime/python/tools/transformers/transformer_utils.py
@@ -1,0 +1,6 @@
+class TransformerUtils:
+    @staticmethod
+    def make_initializer(name, data_type, dims, vals):
+    data_arry = np.asarray(vals,
+                            dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[data_type])
+    return onnx.numpy_helper.from_array(data_arry.reshape(dims), name)

--- a/onnxruntime/python/tools/transformers/transformer_utils.py
+++ b/onnxruntime/python/tools/transformers/transformer_utils.py
@@ -1,6 +1,8 @@
+import onnx
+import numpy as np
 class TransformerUtils:
     @staticmethod
     def make_initializer(name, data_type, dims, vals):
-    data_arry = np.asarray(vals,
-                            dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[data_type])
-    return onnx.numpy_helper.from_array(data_arry.reshape(dims), name)
+        data_arry = np.asarray(vals,
+                                dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[data_type])
+        return onnx.numpy_helper.from_array(data_arry.reshape(dims), name)


### PR DESCRIPTION
**Description**: Describe your changes.
ONNX cannot save model with tensor that doesn't save data in raw filed in external data format because of bug:  https://github.com/onnx/onnx/pull/2332. 

This PR make the transformer tool and quantization tool to use from_array that always save tensor data in raw filed to work around this issue. 
