### PR TITLE
Reduce amount of compiled CUDA device code

### DIFF
--- a/cmake/onnxruntime_framework.cmake
+++ b/cmake/onnxruntime_framework.cmake
@@ -8,10 +8,12 @@ file(GLOB_RECURSE onnxruntime_framework_srcs CONFIGURE_DEPENDS
 )
 
 if (onnxruntime_MINIMAL_BUILD)
-  file(GLOB onnxruntime_framework_src_exclude
+  set(onnxruntime_framework_src_exclude
     "${ONNXRUNTIME_ROOT}/core/framework/provider_bridge_ort.cc"
     "${ONNXRUNTIME_INCLUDE_DIR}/core/framework/customregistry.h"
     "${ONNXRUNTIME_ROOT}/core/framework/customregistry.cc"
+    "${ONNXRUNTIME_ROOT}/core/framework/fallback_cpu_capability.h"
+    "${ONNXRUNTIME_ROOT}/core/framework/fallback_cpu_capability.cc"
   )
 
   list(REMOVE_ITEM onnxruntime_framework_srcs ${onnxruntime_framework_src_exclude})

--- a/onnxruntime/contrib_ops/cuda/bert/attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention.h
@@ -5,7 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "contrib_ops/cpu/bert/attention_base.h"
 
 namespace onnxruntime {

--- a/onnxruntime/contrib_ops/cuda/bert/attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "contrib_ops/cpu/bert/attention_base.h"
 

--- a/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm.h
+++ b/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm.h
@@ -4,7 +4,7 @@
 #pragma once
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm.h
+++ b/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm.h
@@ -3,7 +3,6 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/contrib_ops/cuda/bert/fast_gelu.h
+++ b/onnxruntime/contrib_ops/cuda/bert/fast_gelu.h
@@ -4,7 +4,7 @@
 #pragma once
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/contrib_ops/cuda/bert/fast_gelu.h
+++ b/onnxruntime/contrib_ops/cuda/bert/fast_gelu.h
@@ -3,7 +3,6 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention.h
@@ -5,7 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "contrib_ops/cpu/bert/longformer_attention_base.h"
 
 namespace onnxruntime {

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "contrib_ops/cpu/bert/longformer_attention_base.h"
 

--- a/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm.h
+++ b/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm.h
@@ -4,7 +4,7 @@
 #pragma once
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm.h
+++ b/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm.h
@@ -3,7 +3,6 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/contrib_ops/cuda/inverse.cc
+++ b/onnxruntime/contrib_ops/cuda/inverse.cc
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/math/unary_elementwise_ops_impl.h"
 
 namespace onnxruntime {

--- a/onnxruntime/contrib_ops/cuda/layer_norm.h
+++ b/onnxruntime/contrib_ops/cuda/layer_norm.h
@@ -4,7 +4,7 @@
 #pragma once
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/contrib_ops/cuda/layer_norm.h
+++ b/onnxruntime/contrib_ops/cuda/layer_norm.h
@@ -3,7 +3,6 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/contrib_ops/cuda/math/bias_softmax.h
+++ b/onnxruntime/contrib_ops/cuda/math/bias_softmax.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "gsl/gsl"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/contrib_ops/cuda/math/fft_ops.h
+++ b/onnxruntime/contrib_ops/cuda/math/fft_ops.h
@@ -4,7 +4,7 @@ Copyright(c) 2016 Facebook Inc.
 /* Modifications Copyright (c) Microsoft. */
 
 #pragma once
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "cufft_plan_cache.h"
 #include "cufft.h"
 #include "cufftXt.h"

--- a/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.h
+++ b/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.h
@@ -5,7 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "contrib_ops/cpu/bert/attention_base.h"
 
 namespace onnxruntime {

--- a/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.h
+++ b/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "contrib_ops/cpu/bert/attention_base.h"
 

--- a/onnxruntime/contrib_ops/cuda/tensor/crop.h
+++ b/onnxruntime/contrib_ops/cuda/tensor/crop.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "contrib_ops/cpu/crop.h"
 
 namespace onnxruntime {

--- a/onnxruntime/contrib_ops/cuda/tensor/image_scaler.h
+++ b/onnxruntime/contrib_ops/cuda/tensor/image_scaler.h
@@ -5,7 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/contrib_ops/cuda/tensor/image_scaler.h
+++ b/onnxruntime/contrib_ops/cuda/tensor/image_scaler.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/framework/fallback_cpu_capability.cc
+++ b/onnxruntime/core/framework/fallback_cpu_capability.cc
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/framework/fallback_cpu_capability.h"
+
+#include <queue>
+
+#include "onnx/defs/data_type_utils.h"
+
+#include "core/framework/op_kernel.h"
+
+using namespace ONNX_NAMESPACE::Utils;
+
+namespace onnxruntime {
+
+namespace {
+const int64_t Small_Initializer_Threshold = 100;
+
+bool IsSmallInitializerWithSingleConsumer(const onnxruntime::GraphViewer& graph, const NodeArg* arg) {
+  const ONNX_NAMESPACE::TensorProto* initializer_tensor;
+  if (!graph.GetInitializedTensor(arg->Name(), initializer_tensor))
+    return false;
+  int64_t size = 1;
+  for (auto& dim : initializer_tensor->dims()) {
+    size *= dim;
+  }
+  return size <= Small_Initializer_Threshold &&
+         graph.GetConsumerNodes(arg->Name()).size() == 1;
+}
+}  // namespace
+
+std::unordered_set<NodeIndex> GetCpuPreferredNodes(const onnxruntime::GraphViewer& graph,
+                                                   const std::string& provider_type,
+                                                   const std::vector<const KernelRegistry*>& kernel_registries,
+                                                   const std::vector<NodeIndex>& tentative_nodes) {
+  const std::vector<NodeIndex>& ordered_nodes = graph.GetNodesInTopologicalOrder();
+  std::vector<size_t> node_id_to_order_map(graph.MaxNodeIndex());
+  for (size_t id = 0; id < ordered_nodes.size(); ++id) {
+    const NodeIndex& node_id = ordered_nodes[id];
+    node_id_to_order_map[node_id] = id;
+  }
+
+  // If return false, n1 will be output first; If return true, n2 will be output first
+  auto greater_order_comp = [&](const NodeIndex n1, const NodeIndex n2) {
+    return node_id_to_order_map[n1] > node_id_to_order_map[n2];
+  };
+
+  std::priority_queue<NodeIndex, std::vector<NodeIndex>, decltype(greater_order_comp)> candidates(greater_order_comp);
+  std::unordered_set<NodeIndex> visited;
+
+  std::unordered_set<const NodeArg*> cpu_output_args;
+  std::unordered_set<NodeIndex> provider_nodes;
+  std::unordered_map<NodeIndex, const KernelCreateInfo*> node_to_kernel;
+
+  for (auto& node_id : tentative_nodes) {
+    provider_nodes.insert(node_id);
+    const Node* node = graph.GetNode(node_id);
+
+    const KernelCreateInfo* kernel_info = nullptr;
+    for (auto registry : kernel_registries) {
+      auto st = registry->TryFindKernel(*node, provider_type, &kernel_info);
+      if (st.IsOK())
+        break;
+    }
+    // at least one registry has a target provider's kernel for this node
+    ORT_ENFORCE(kernel_info != nullptr);
+    node_to_kernel.insert({node_id, kernel_info});
+
+    // first, find all the direct consumer of cpu tensors.
+    ORT_THROW_IF_ERROR(node->ForEachWithIndex(
+        node->OutputDefs(),
+        [&](const NodeArg& node_arg, size_t out_index) {
+          if (kernel_info->kernel_def->IsOutputOnCpu(out_index)) {
+            cpu_output_args.insert(&node_arg);
+            auto consumer_nodes = graph.GetConsumerNodes(node_arg.Name());
+            for (auto& consumer_node : consumer_nodes) {
+              candidates.push(consumer_node->Index());
+              LOGS_DEFAULT(INFO) << "Canditiate for fallback CPU execution: " << consumer_node->Name();
+            }
+          }
+          return Status::OK();
+        }));
+  }
+
+  const std::vector<const NodeArg*>& graph_inputs = graph.GetInputs();
+  std::unordered_set<NodeIndex> cpu_nodes;
+  // The algo below is trying to identity a subgraph that only depends on cpu tensors.
+  // Usually it is a subgraph that doing shape calculation based on a GPU tensor, then reshape it back.
+  // The detail:
+  // for each candidate, if one of its input is a cpu tensor and the Non-CPU kernel doesn't mark it as cpu input,
+  // force the node to CPU to avoid memory cpu and add its output to the small cpu tensors.
+  while (!candidates.empty()) {
+    NodeIndex cur = candidates.top();
+    candidates.pop();
+    if (visited.count(cur) != 0)
+      continue;
+    visited.insert(cur);
+
+    if (provider_nodes.find(cur) == provider_nodes.end())
+      continue;
+
+    auto* node = graph.GetNode(cur);
+    bool place_in_cpu = true;
+    for (size_t i = 0; i < node->InputDefs().size(); ++i) {
+      auto* input = node->InputDefs()[i];
+
+      // skip placing on CPU if the data typs is float16 or bfloat16
+      if (input->Type() == DataTypeUtils::ToType("float16") ||
+          input->Type() == DataTypeUtils::ToType("bfloat16")) {
+        place_in_cpu = false;
+        break;
+      }
+
+      // allow placing on CPU if it's a small initializer or graph input
+      if (IsSmallInitializerWithSingleConsumer(graph, input) ||
+          std::find(graph_inputs.begin(), graph_inputs.end(), input) != graph_inputs.end()) {
+        continue;
+      }
+
+      // the input is not a CPU tensor
+      if (cpu_output_args.find(input) == cpu_output_args.end()) {
+        place_in_cpu = false;
+        break;
+      }
+
+      // input is a CPU tensor, but it's intended to be consumed as CPU input by the target EP
+      if (node_to_kernel[cur]->kernel_def->IsInputOnCpu(i)) {
+        place_in_cpu = false;
+        break;
+      }
+    }
+
+    if (place_in_cpu) {
+      cpu_nodes.insert(cur);
+      LOGS_DEFAULT(WARNING) << "Force fallback to CPU execution for node: " << node->Name();
+      for (auto* output : node->OutputDefs()) {
+        cpu_output_args.insert(output);
+      }
+      for (auto it = node->OutputNodesBegin(); it != node->OutputNodesEnd(); ++it) {
+        candidates.push((*it).Index());
+      }
+    }
+  }
+
+  return cpu_nodes;
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/framework/fallback_cpu_capability.cc
+++ b/onnxruntime/core/framework/fallback_cpu_capability.cc
@@ -75,7 +75,7 @@ std::unordered_set<NodeIndex> GetCpuPreferredNodes(const onnxruntime::GraphViewe
             auto consumer_nodes = graph.GetConsumerNodes(node_arg.Name());
             for (auto& consumer_node : consumer_nodes) {
               candidates.push(consumer_node->Index());
-              LOGS_DEFAULT(INFO) << "Canditiate for fallback CPU execution: " << consumer_node->Name();
+              LOGS_DEFAULT(INFO) << "Candidate for fallback CPU execution: " << consumer_node->Name();
             }
           }
           return Status::OK();

--- a/onnxruntime/core/framework/fallback_cpu_capability.h
+++ b/onnxruntime/core/framework/fallback_cpu_capability.h
@@ -2,152 +2,22 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "core/graph/graph_viewer.h"
-#include "onnx/defs/data_type_utils.h"
-#include <queue>
 
-using namespace ONNX_NAMESPACE::Utils;
+#include "core/graph/graph_viewer.h"
 
 namespace onnxruntime {
 
-namespace {
-const int64_t Small_Initializer_Threshold = 100;
-
-bool IsSmallInitializerWithSingleConsumer(const onnxruntime::GraphViewer& graph, const NodeArg* arg) {
-  const ONNX_NAMESPACE::TensorProto* initializer_tensor;
-  if (!graph.GetInitializedTensor(arg->Name(), initializer_tensor))
-    return false;
-  int64_t size = 1;
-  for (auto& dim : initializer_tensor->dims()) {
-    size *= dim;
-  }
-  return size <= Small_Initializer_Threshold &&
-         graph.GetConsumerNodes(arg->Name()).size() == 1;
-}
-}  // namespace
-
 /**
-  Returns a list of nodes that are prefered on CPU. 
+  Returns a list of nodes that are preferred on CPU.
   They are commonly shape-related computation subgraphs.
-  @param graph Graph viewer 
-  @param provider_type The targe execution provider type
-  @param kernel_registries Kernel registies for the target EP
+  @param graph Graph viewer
+  @param provider_type The target execution provider type
+  @param kernel_registries Kernel registries for the target EP
   @param tentative_nodes Nodes that are tentative to be placed on on target EP
   */
-std::unordered_set<NodeIndex> GetCpuPreferedNodes(const onnxruntime::GraphViewer& graph,
-                                                  const std::string& provider_type,
-                                                  const std::vector<const KernelRegistry*>& kernel_registries,
-                                                  const std::vector<NodeIndex>& tentative_nodes) {
-  const std::vector<NodeIndex>& ordered_nodes = graph.GetNodesInTopologicalOrder();
-  std::vector<size_t> node_id_to_order_map(graph.MaxNodeIndex());
-  for (size_t id = 0; id < ordered_nodes.size(); ++id) {
-    const NodeIndex& node_id = ordered_nodes[id];
-    node_id_to_order_map[node_id] = id;
-  }
-
-  // If return false, n1 will be output first; If return true, n2 will be output first
-  auto greater_order_comp = [&](const NodeIndex n1, const NodeIndex n2) {
-    return node_id_to_order_map[n1] > node_id_to_order_map[n2];
-  };
-
-  std::priority_queue<NodeIndex, std::vector<NodeIndex>, decltype(greater_order_comp)> candidates(greater_order_comp);
-  std::unordered_set<NodeIndex> visited;
-
-  std::unordered_set<const NodeArg*> cpu_output_args;
-  std::unordered_set<NodeIndex> provider_nodes;
-  std::unordered_map<NodeIndex, const KernelCreateInfo*> node_to_kernel;
-
-  for (auto& node_id : tentative_nodes) {
-    provider_nodes.insert(node_id);
-    const Node* node = graph.GetNode(node_id);
-
-    const KernelCreateInfo* kernel_info = nullptr;
-    for (auto registry : kernel_registries) {
-      auto st = registry->TryFindKernel(*node, provider_type, &kernel_info);
-      if (st.IsOK())
-        break;
-    }
-    // at least one registry has a target provider's kernel for this node
-    ORT_ENFORCE(kernel_info != nullptr);
-    node_to_kernel.insert({node_id, kernel_info});
-
-    // first, find all the direct consumer of cpu tensors.
-    ORT_THROW_IF_ERROR(node->ForEachWithIndex(
-        node->OutputDefs(),
-        [&](const NodeArg& node_arg, size_t out_index) {
-          if (kernel_info->kernel_def->IsOutputOnCpu(out_index)) {
-            cpu_output_args.insert(&node_arg);
-            auto consumer_nodes = graph.GetConsumerNodes(node_arg.Name());
-            for (auto& consumer_node : consumer_nodes) {
-              candidates.push(consumer_node->Index());
-              LOGS_DEFAULT(INFO) << "Canditiate for fallback CPU execution: " << consumer_node->Name();
-            }
-          }
-          return Status::OK();
-        }));
-  }
-
-  const std::vector<const NodeArg*>& graph_inputs = graph.GetInputs();
-  std::unordered_set<NodeIndex> cpu_nodes;
-  // The algo below is trying to identity a subgraph that only depends on cpu tensors.
-  // Usually it is a subgraph that doing shape calculation based on a GPU tensor, then reshape it back.
-  // The detail:
-  // for each candidate, if one of its input is a cpu tensor and the Non-CPU kernel doesn't mark it as cpu input,
-  // force the node to CPU to avoid memory cpu and add its output to the small cpu tensors.
-  while (!candidates.empty()) {
-    NodeIndex cur = candidates.top();
-    candidates.pop();
-    if (visited.count(cur) != 0)
-      continue;
-    visited.insert(cur);
-
-    if (provider_nodes.find(cur) == provider_nodes.end())
-      continue;
-
-    auto* node = graph.GetNode(cur);
-    bool place_in_cpu = true;
-    for (size_t i = 0; i < node->InputDefs().size(); ++i) {
-      auto* input = node->InputDefs()[i];
-
-      // skip placing on CPU if the data typs is float16 or bfloat16
-      if (input->Type() == DataTypeUtils::ToType("float16") ||
-          input->Type() == DataTypeUtils::ToType("bfloat16")) {
-        place_in_cpu = false;
-        break;
-      }
-
-      // allow placing on CPU if it's a small initializer or graph input
-      if (IsSmallInitializerWithSingleConsumer(graph, input) ||
-          std::find(graph_inputs.begin(), graph_inputs.end(), input) != graph_inputs.end()) {
-        continue;
-      }
-
-      // the input is not a CPU tensor
-      if (cpu_output_args.find(input) == cpu_output_args.end()) {
-        place_in_cpu = false;
-        break;
-      }
-
-      // input is a CPU tensor, but it's intended to be consumed as CPU input by the target EP
-      if (node_to_kernel[cur]->kernel_def->IsInputOnCpu(i)) {
-        place_in_cpu = false;
-        break;
-      }
-    }
-
-    if (place_in_cpu) {
-      cpu_nodes.insert(cur);
-      LOGS_DEFAULT(WARNING) << "Force fallback to CPU execution for node: " << node->Name();
-      for (auto* output : node->OutputDefs()) {
-        cpu_output_args.insert(output);
-      }
-      for (auto it = node->OutputNodesBegin(); it != node->OutputNodesEnd(); ++it) {
-        candidates.push((*it).Index());
-      }
-    }
-  }
-
-  return cpu_nodes;
-}
+std::unordered_set<NodeIndex> GetCpuPreferredNodes(const GraphViewer& graph,
+                                                   const std::string& provider_type,
+                                                   const std::vector<const KernelRegistry*>& kernel_registries,
+                                                   const std::vector<NodeIndex>& tentative_nodes);
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/fallback_cpu_capability.h
+++ b/onnxruntime/core/framework/fallback_cpu_capability.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "core/framework/kernel_registry.h"
 #include "core/graph/graph_viewer.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/controlflow/if.cc
+++ b/onnxruntime/core/providers/cuda/controlflow/if.cc
@@ -3,7 +3,7 @@
 
 #include "core/providers/cuda/controlflow/if.h"
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_fwd.h"
 
 using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::common;

--- a/onnxruntime/core/providers/cuda/controlflow/loop.cc
+++ b/onnxruntime/core/providers/cuda/controlflow/loop.cc
@@ -3,6 +3,7 @@
 
 #include "core/providers/cuda/controlflow/loop.h"
 #include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_fwd.h"
 
 using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::common;

--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -2,18 +2,13 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "cuda_pch.h"
+
 #include "core/common/status.h"
-#include "core/framework/arena.h"
-#include "core/framework/bfc_arena.h"
-#include "core/framework/data_transfer_manager.h"
-#include "core/framework/op_kernel.h"
-#include "core/graph/graph_viewer.h"
-#include "shared_inc/cuda_call.h"
-#include "cuda_execution_provider.h"
-#include "shared_inc/fast_divmod.h"
+#include "core/providers/cuda/cuda_fwd.h"
+#include "core/providers/cuda/cuda_pch.h"
+#include "core/providers/cuda/shared_inc/cuda_call.h"
+#include "core/providers/cuda/shared_inc/fast_divmod.h"
 #include "core/util/math.h"
-#include "cuda_fwd.h"
 
 namespace onnxruntime {
 namespace cuda {
@@ -52,140 +47,6 @@ namespace cuda {
   ORT_RETURN_IF_ERROR(CUFFT_CALL(expr)           \
                           ? common::Status::OK() \
                           : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CUFFT error executing ", #expr))
-
-// -----------------------------------------------------------------------
-// Base class for CUDA kernels
-// -----------------------------------------------------------------------
-class CudaKernel : public OpKernel {
- public:
-  explicit CudaKernel(const OpKernelInfo& info)
-      : OpKernel(info),
-        // Is this OK to have a non-const execution provider?
-        provider_(const_cast<CUDAExecutionProvider*>(static_cast<const CUDAExecutionProvider*>(info.GetExecutionProvider()))) {
-  }
-
-  Status Compute(OpKernelContext* p_op_kernel_context) const override {
-    auto s = ComputeInternal(p_op_kernel_context);
-    // use this to precisely locate the node where CUDA failure comes from
-    //  if (cudaSuccess != cudaDeviceSynchronize())
-    //    __debugbreak();
-
-    if (s.IsOK()) {
-      auto err = cudaGetLastError();
-      if (err != cudaSuccess) {
-        s = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CUDA error ", cudaGetErrorName(err), ":", cudaGetErrorString(err));
-      }
-    }
-
-    return s;
-  }
-
-  virtual Status ComputeInternal(OpKernelContext* p_op_kernel_context) const = 0;
-
-  template <typename T>
-  inline IAllocatorUniquePtr<T> AllocateBufferOnCPUPinned(size_t count_or_bytes) const {
-    AllocatorPtr allocator = provider_->GetAllocator(CPU_ALLOCATOR_DEVICE_ID, OrtMemTypeCPU);
-    if (!allocator)
-      return nullptr;
-    return IAllocator::MakeUniquePtr<T>(allocator, count_or_bytes);
-  }
-
-  template <typename T>
-  inline IAllocatorUniquePtr<T> GetScratchBuffer(size_t count_or_bytes) const {
-    return provider_->GetScratchBuffer<T>(count_or_bytes);
-  }
-
-  inline void AddDeferredReleaseCPUPtr(void* p) const {
-    provider_->AddDeferredReleaseCPUPtr(p);
-  }
-
-  const cudaDeviceProp& GetDeviceProp() const { return provider_->GetDeviceProp(); };
-
-  // To support cudaMemcpyAsync, the cpu memory should be allocated in pinned memory
-  // and it can only be released after the copy has finished
-  template <typename T>
-  class CudaAsyncBuffer {
-   public:
-    CudaAsyncBuffer(const CudaKernel* op_kernel) : gpu_copy_(nullptr), count_(0), op_kernel_(op_kernel) {}
-
-    CudaAsyncBuffer(const CudaKernel* op_kernel, size_t count) : CudaAsyncBuffer(op_kernel) {
-      AllocCpuPtr(count);
-    }
-
-    CudaAsyncBuffer(const CudaKernel* op_kernel, const T& value, size_t count)
-        : CudaAsyncBuffer(op_kernel, count) {
-      T* p = CpuPtr();
-      for (size_t i = 0; i != count; ++i) {
-        *p++ = value;
-      }
-    }
-
-    CudaAsyncBuffer(const CudaKernel* op_kernel, const std::vector<T>& vec) : CudaAsyncBuffer(op_kernel, vec.size()) {
-      memcpy(CpuPtr(), vec.data(), vec.size() * sizeof(T));
-    }
-
-    void AllocCpuPtr(size_t count) {
-      cpu_pinned_copy_ = op_kernel_->AllocateBufferOnCPUPinned<T>(count);
-      if (cpu_pinned_copy_ == nullptr)
-        throw std::runtime_error("alloc failed");
-      count_ = count;
-    }
-
-    Status CopyToGpu() {
-      if (cpu_pinned_copy_) {
-        gpu_copy_ = op_kernel_->GetScratchBuffer<T>(count_);
-        CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(gpu_copy_.get(), cpu_pinned_copy_.get(), count_ * sizeof(T), cudaMemcpyHostToDevice));
-        op_kernel_->AddDeferredReleaseCPUPtr(cpu_pinned_copy_.release());
-      }
-      return Status::OK();
-    }
-
-    T* CpuPtr() const {
-      return cpu_pinned_copy_.get();
-    }
-
-    gsl::span<T> CpuSpan() const {
-      return gsl::span<T>(CpuPtr(), count_);
-    }
-
-    T* GpuPtr() const {
-      return gpu_copy_.get();
-    }
-
-    size_t count() const {
-      return count_;
-    }
-
-   protected:
-    IAllocatorUniquePtr<T> gpu_copy_;
-    IAllocatorUniquePtr<T> cpu_pinned_copy_;
-    size_t count_;
-    const CudaKernel* op_kernel_;
-  };
-
-  inline cublasHandle_t CublasHandle() const {
-    return provider_->PerThreadCublasHandle();
-  }
-
-  inline cudnnHandle_t CudnnHandle() const {
-    return provider_->PerThreadCudnnHandle();
-  }
-
- protected:
-  template <typename T>
-  inline const T* GetConstOnes(size_t count) const {
-    return provider_->template GetConstOnes<T>(count);
-  }
-
-  inline Status CopyTensor(const Tensor& src, Tensor& dst) const {
-    return Info().GetDataTransferManager().CopyTensor(src, dst);
-  }
-
-  inline int GetDeviceId() const { return provider_->GetDeviceId(); }
-
- private:
-  CUDAExecutionProvider* provider_;
-};
 
 // Type mapping for MLFloat16 to half
 template <typename T>

--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/common/status.h"
-#include "core/providers/cuda/cuda_fwd.h"
 #include "core/providers/cuda/cuda_pch.h"
 #include "core/providers/cuda/shared_inc/cuda_call.h"
 #include "core/providers/cuda/shared_inc/fast_divmod.h"

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -1,15 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "cuda_common.h"
-#include "cuda_execution_provider.h"
-#include "cuda_fence.h"
-#include "cuda_allocator.h"
-#include "core/framework/kernel_registry.h"
+#include "core/providers/cuda/cuda_execution_provider.h"
+
 #include "core/framework/compute_capability.h"
 #include "core/framework/fallback_cpu_capability.h"
+#include "core/framework/kernel_registry.h"
 #include "core/framework/memcpy.h"
 #include "core/graph/graph_utils.h"
+#include "core/providers/cuda/cuda_allocator.h"
+#include "core/providers/cuda/cuda_kernel.h"
+#include "core/providers/cuda/cuda_fence.h"
 #include "core/providers/cuda/gpu_data_transfer.h"
 
 #ifndef DISABLE_CONTRIB_OPS
@@ -1921,7 +1922,7 @@ CUDAExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
   // For CUDA EP, exclude the subgraph that is preferred to be placed in CPU
   // These are usually shape related computation subgraphs
   // Following logic can be extended for other EPs
-  std::unordered_set<NodeIndex> cpu_nodes = GetCpuPreferedNodes(graph, Type(), kernel_registries, candidates);
+  std::unordered_set<NodeIndex> cpu_nodes = GetCpuPreferredNodes(graph, Type(), kernel_registries, candidates);
 
   std::vector<std::unique_ptr<ComputeCapability>> result;
   for (auto& node_index : candidates) {

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -9,8 +9,8 @@
 #include "core/framework/memcpy.h"
 #include "core/graph/graph_utils.h"
 #include "core/providers/cuda/cuda_allocator.h"
-#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/cuda_fence.h"
+#include "core/providers/cuda/cuda_fwd.h"
 #include "core/providers/cuda/gpu_data_transfer.h"
 
 #ifndef DISABLE_CONTRIB_OPS

--- a/onnxruntime/core/providers/cuda/cuda_fence.cc
+++ b/onnxruntime/core/providers/cuda/cuda_fence.cc
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "cuda_common.h"
-#include "cuda_fence.h"
-#include "gpu_data_transfer.h"
+#include "core/providers/cuda/cuda_fence.h"
+
+#include "core/graph/constants.h"
+#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/gpu_data_transfer.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/providers/cuda/cuda_fence.h
+++ b/onnxruntime/core/providers/cuda/cuda_fence.h
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 #pragma once
+
 #include "core/framework/tensor.h"
 #include "core/graph/basic_types.h"
+#include "core/providers/cuda/cuda_common.h"
 
 namespace onnxruntime {
 class GPUDataTransfer;

--- a/onnxruntime/core/providers/cuda/cuda_fwd.h
+++ b/onnxruntime/core/providers/cuda/cuda_fwd.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "core/framework/op_kernel.h"
+
 namespace onnxruntime {
 namespace cuda {
 template <typename T>

--- a/onnxruntime/core/providers/cuda/cuda_kernel.h
+++ b/onnxruntime/core/providers/cuda/cuda_kernel.h
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/status.h"
+#include "core/framework/data_transfer_manager.h"
+#include "core/framework/op_kernel.h"
+#include "core/providers/cuda/cuda_execution_provider.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+// -----------------------------------------------------------------------
+// Base class for CUDA kernels
+// -----------------------------------------------------------------------
+class CudaKernel : public OpKernel {
+ public:
+  explicit CudaKernel(const OpKernelInfo& info)
+      : OpKernel(info),
+        // Is this OK to have a non-const execution provider?
+        provider_(const_cast<CUDAExecutionProvider*>(static_cast<const CUDAExecutionProvider*>(info.GetExecutionProvider()))) {
+  }
+
+  Status Compute(OpKernelContext* p_op_kernel_context) const override {
+    auto s = ComputeInternal(p_op_kernel_context);
+    // use this to precisely locate the node where CUDA failure comes from
+    //  if (cudaSuccess != cudaDeviceSynchronize())
+    //    __debugbreak();
+
+    if (s.IsOK()) {
+      auto err = cudaGetLastError();
+      if (err != cudaSuccess) {
+        s = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CUDA error ", cudaGetErrorName(err), ":", cudaGetErrorString(err));
+      }
+    }
+
+    return s;
+  }
+
+  virtual Status ComputeInternal(OpKernelContext* p_op_kernel_context) const = 0;
+
+  template <typename T>
+  inline IAllocatorUniquePtr<T> AllocateBufferOnCPUPinned(size_t count_or_bytes) const {
+    AllocatorPtr allocator = provider_->GetAllocator(CPU_ALLOCATOR_DEVICE_ID, OrtMemTypeCPU);
+    if (!allocator)
+      return nullptr;
+    return IAllocator::MakeUniquePtr<T>(allocator, count_or_bytes);
+  }
+
+  template <typename T>
+  inline IAllocatorUniquePtr<T> GetScratchBuffer(size_t count_or_bytes) const {
+    return provider_->GetScratchBuffer<T>(count_or_bytes);
+  }
+
+  inline void AddDeferredReleaseCPUPtr(void* p) const {
+    provider_->AddDeferredReleaseCPUPtr(p);
+  }
+
+  const cudaDeviceProp& GetDeviceProp() const { return provider_->GetDeviceProp(); };
+
+  // To support cudaMemcpyAsync, the cpu memory should be allocated in pinned memory
+  // and it can only be released after the copy has finished
+  template <typename T>
+  class CudaAsyncBuffer {
+   public:
+    CudaAsyncBuffer(const CudaKernel* op_kernel) : gpu_copy_(nullptr), count_(0), op_kernel_(op_kernel) {}
+
+    CudaAsyncBuffer(const CudaKernel* op_kernel, size_t count) : CudaAsyncBuffer(op_kernel) {
+      AllocCpuPtr(count);
+    }
+
+    CudaAsyncBuffer(const CudaKernel* op_kernel, const T& value, size_t count)
+        : CudaAsyncBuffer(op_kernel, count) {
+      T* p = CpuPtr();
+      for (size_t i = 0; i != count; ++i) {
+        *p++ = value;
+      }
+    }
+
+    CudaAsyncBuffer(const CudaKernel* op_kernel, const std::vector<T>& vec) : CudaAsyncBuffer(op_kernel, vec.size()) {
+      memcpy(CpuPtr(), vec.data(), vec.size() * sizeof(T));
+    }
+
+    void AllocCpuPtr(size_t count) {
+      cpu_pinned_copy_ = op_kernel_->AllocateBufferOnCPUPinned<T>(count);
+      if (cpu_pinned_copy_ == nullptr)
+        throw std::runtime_error("alloc failed");
+      count_ = count;
+    }
+
+    Status CopyToGpu() {
+      if (cpu_pinned_copy_) {
+        gpu_copy_ = op_kernel_->GetScratchBuffer<T>(count_);
+        CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(gpu_copy_.get(), cpu_pinned_copy_.get(), count_ * sizeof(T), cudaMemcpyHostToDevice));
+        op_kernel_->AddDeferredReleaseCPUPtr(cpu_pinned_copy_.release());
+      }
+      return Status::OK();
+    }
+
+    T* CpuPtr() const {
+      return cpu_pinned_copy_.get();
+    }
+
+    gsl::span<T> CpuSpan() const {
+      return gsl::span<T>(CpuPtr(), count_);
+    }
+
+    T* GpuPtr() const {
+      return gpu_copy_.get();
+    }
+
+    size_t count() const {
+      return count_;
+    }
+
+   protected:
+    IAllocatorUniquePtr<T> gpu_copy_;
+    IAllocatorUniquePtr<T> cpu_pinned_copy_;
+    size_t count_;
+    const CudaKernel* op_kernel_;
+  };
+
+  inline cublasHandle_t CublasHandle() const {
+    return provider_->PerThreadCublasHandle();
+  }
+
+  inline cudnnHandle_t CudnnHandle() const {
+    return provider_->PerThreadCudnnHandle();
+  }
+
+ protected:
+  template <typename T>
+  inline const T* GetConstOnes(size_t count) const {
+    return provider_->template GetConstOnes<T>(count);
+  }
+
+  inline Status CopyTensor(const Tensor& src, Tensor& dst) const {
+    return Info().GetDataTransferManager().CopyTensor(src, dst);
+  }
+
+  inline int GetDeviceId() const { return provider_->GetDeviceId(); }
+
+ private:
+  CUDAExecutionProvider* provider_;
+};
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/cuda_kernel.h
+++ b/onnxruntime/core/providers/cuda/cuda_kernel.h
@@ -6,7 +6,9 @@
 #include "core/common/status.h"
 #include "core/framework/data_transfer_manager.h"
 #include "core/framework/op_kernel.h"
+#include "core/providers/cuda/cuda_common.h"
 #include "core/providers/cuda/cuda_execution_provider.h"
+#include "core/providers/cuda/cuda_fwd.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/cudnn_common.h
+++ b/onnxruntime/core/providers/cuda/cudnn_common.h
@@ -2,9 +2,12 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "cuda_common.h"
-#include "core/framework/tensor.h"
+
 #include <cfloat>
+
+#include "core/common/logging/logging.h"
+#include "core/framework/tensor.h"
+#include "core/providers/cuda/cuda_common.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/generator/constant_of_shape.h
+++ b/onnxruntime/core/providers/cuda/generator/constant_of_shape.h
@@ -6,7 +6,7 @@
 #include "core/common/common.h"
 #include "core/framework/data_types.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/generator/constant_of_shape.h"
 #include "core/providers/cuda/shared_inc/cuda_utils.h"
 

--- a/onnxruntime/core/providers/cuda/generator/constant_of_shape.h
+++ b/onnxruntime/core/providers/cuda/generator/constant_of_shape.h
@@ -5,7 +5,6 @@
 
 #include "core/common/common.h"
 #include "core/framework/data_types.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/generator/constant_of_shape.h"
 #include "core/providers/cuda/shared_inc/cuda_utils.h"

--- a/onnxruntime/core/providers/cuda/generator/range.h
+++ b/onnxruntime/core/providers/cuda/generator/range.h
@@ -3,8 +3,7 @@
 
 #pragma once
 
-#include "core/common/common.h"
-#include "core/framework/op_kernel.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/math/binary_elementwise_ops.h
+++ b/onnxruntime/core/providers/cuda/math/binary_elementwise_ops.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/shared_inc/fast_divmod.h"
 #include "core/providers/cpu/tensor/utils.h"
 

--- a/onnxruntime/core/providers/cuda/math/clip.h
+++ b/onnxruntime/core/providers/cuda/math/clip.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/math/clip.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/math/cumsum.h
+++ b/onnxruntime/core/providers/cuda/math/cumsum.h
@@ -4,7 +4,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/math/cumsum.h
+++ b/onnxruntime/core/providers/cuda/math/cumsum.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/math/gemm.h
+++ b/onnxruntime/core/providers/cuda/math/gemm.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/math/matmul.h
+++ b/onnxruntime/core/providers/cuda/math/matmul.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/math/matmul_integer.h
+++ b/onnxruntime/core/providers/cuda/math/matmul_integer.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/math/softmax.h
+++ b/onnxruntime/core/providers/cuda/math/softmax.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "gsl/gsl"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/math/topk.h
+++ b/onnxruntime/core/providers/cuda/math/topk.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/math/topk_impl.h
+++ b/onnxruntime/core/providers/cuda/math/topk_impl.h
@@ -4,7 +4,7 @@
 #pragma once
 #include <stdint.h>
 #include "core/providers/cuda/shared_inc/cuda_utils.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/common/common.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/math/unary_elementwise_ops.h
+++ b/onnxruntime/core/providers/cuda/math/unary_elementwise_ops.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops.h
+++ b/onnxruntime/core/providers/cuda/math/variadic_elementwise_ops.h
@@ -6,7 +6,7 @@
 #include <functional>
 #include <vector>
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/nn/batch_norm.h
+++ b/onnxruntime/core/providers/cuda/nn/batch_norm.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "gsl/gsl"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/cudnn_common.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/nn/conv.h
+++ b/onnxruntime/core/providers/cuda/nn/conv.h
@@ -5,7 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/platform/ort_mutex.h"
-#include "core/framework/op_kernel.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/cudnn_common.h"
 #include "core/providers/cpu/nn/conv_attributes.h"
 #include <list>

--- a/onnxruntime/core/providers/cuda/nn/conv_transpose.h
+++ b/onnxruntime/core/providers/cuda/nn/conv_transpose.h
@@ -3,9 +3,10 @@
 
 #pragma once
 
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/cudnn_common.h"
+#include "core/providers/cuda/nn/conv.h"
 #include "core/providers/cpu/nn/conv_transpose_attributes.h"
-#include "conv.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/nn/dropout.h
+++ b/onnxruntime/core/providers/cuda/nn/dropout.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/nn/dropout_impl.h"
 #include "core/providers/cuda/nn/dropout.h"
 #include "core/providers/common.h"

--- a/onnxruntime/core/providers/cuda/nn/instance_norm.h
+++ b/onnxruntime/core/providers/cuda/nn/instance_norm.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/cudnn_common.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/nn/lrn.h
+++ b/onnxruntime/core/providers/cuda/nn/lrn.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/framework/op_kernel.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/cudnn_common.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/nn/pool.h
+++ b/onnxruntime/core/providers/cuda/nn/pool.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/cudnn_common.h"
 #include "core/providers/cpu/nn/pool_base.h"
 

--- a/onnxruntime/core/providers/cuda/nn/shrink.h
+++ b/onnxruntime/core/providers/cuda/nn/shrink.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "gsl/gsl"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/object_detection/non_max_suppression.h
+++ b/onnxruntime/core/providers/cuda/object_detection/non_max_suppression.h
@@ -5,7 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/object_detection/non_max_suppression.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/object_detection/non_max_suppression.h
+++ b/onnxruntime/core/providers/cuda/object_detection/non_max_suppression.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/object_detection/non_max_suppression.h"
 

--- a/onnxruntime/core/providers/cuda/object_detection/roialign.h
+++ b/onnxruntime/core/providers/cuda/object_detection/roialign.h
@@ -5,7 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/object_detection/roialign.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/object_detection/roialign.h
+++ b/onnxruntime/core/providers/cuda/object_detection/roialign.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/object_detection/roialign.h"
 

--- a/onnxruntime/core/providers/cuda/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_ops.h
@@ -3,7 +3,7 @@
 
 #pragma once
 #include "core/common/optional.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/reduction/reduction_ops.h"
 #include "core/providers/cuda/reduction/reduction_functions.h"
 

--- a/onnxruntime/core/providers/cuda/rnn/cudnn_rnn_base.h
+++ b/onnxruntime/core/providers/cuda/rnn/cudnn_rnn_base.h
@@ -5,7 +5,7 @@
 
 #include "gsl/gsl"
 #include "core/providers/cuda/cudnn_common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include <cudnn.h>
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/rnn/cudnn_rnn_base.h
+++ b/onnxruntime/core/providers/cuda/rnn/cudnn_rnn_base.h
@@ -4,9 +4,11 @@
 #pragma once
 
 #include "gsl/gsl"
-#include "core/providers/cuda/cudnn_common.h"
-#include "core/providers/cuda/cuda_kernel.h"
+
 #include <cudnn.h>
+
+#include "core/providers/cuda/cuda_kernel.h"
+#include "core/providers/cuda/cudnn_common.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/shared_inc/integer_gemm.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/integer_gemm.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/cast_op.h
+++ b/onnxruntime/core/providers/cuda/tensor/cast_op.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/compress.h
+++ b/onnxruntime/core/providers/cuda/tensor/compress.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/concat.h
+++ b/onnxruntime/core/providers/cuda/tensor/concat.h
@@ -3,7 +3,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/concat.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/concat.h
+++ b/onnxruntime/core/providers/cuda/tensor/concat.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/concat.h"
 

--- a/onnxruntime/core/providers/cuda/tensor/expand.h
+++ b/onnxruntime/core/providers/cuda/tensor/expand.h
@@ -3,7 +3,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/expand.h
+++ b/onnxruntime/core/providers/cuda/tensor/expand.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/eye_like.h
+++ b/onnxruntime/core/providers/cuda/tensor/eye_like.h
@@ -3,7 +3,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/eye_like.h
+++ b/onnxruntime/core/providers/cuda/tensor/eye_like.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/flatten.h
+++ b/onnxruntime/core/providers/cuda/tensor/flatten.h
@@ -3,7 +3,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/flatten.h
+++ b/onnxruntime/core/providers/cuda/tensor/flatten.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/gather.h
+++ b/onnxruntime/core/providers/cuda/tensor/gather.h
@@ -3,7 +3,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/gather.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/gather.h
+++ b/onnxruntime/core/providers/cuda/tensor/gather.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/gather.h"
 

--- a/onnxruntime/core/providers/cuda/tensor/gather_elements.h
+++ b/onnxruntime/core/providers/cuda/tensor/gather_elements.h
@@ -5,7 +5,7 @@
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
 #include "core/providers/cpu/tensor/gather_elements.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/gather_elements.h
+++ b/onnxruntime/core/providers/cuda/tensor/gather_elements.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cpu/tensor/gather_elements.h"
 #include "core/providers/cuda/cuda_kernel.h"
 

--- a/onnxruntime/core/providers/cuda/tensor/gather_nd.h
+++ b/onnxruntime/core/providers/cuda/tensor/gather_nd.h
@@ -5,7 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/gather_nd.h
+++ b/onnxruntime/core/providers/cuda/tensor/gather_nd.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/identity_op.h
+++ b/onnxruntime/core/providers/cuda/tensor/identity_op.h
@@ -4,7 +4,7 @@
 #pragma once
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/identity_op.h
+++ b/onnxruntime/core/providers/cuda/tensor/identity_op.h
@@ -3,7 +3,6 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/nonzero_op.h
+++ b/onnxruntime/core/providers/cuda/tensor/nonzero_op.h
@@ -4,7 +4,7 @@
 #pragma once
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/nonzero_op.h
+++ b/onnxruntime/core/providers/cuda/tensor/nonzero_op.h
@@ -3,7 +3,6 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/onehot.h
+++ b/onnxruntime/core/providers/cuda/tensor/onehot.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/pad.h
+++ b/onnxruntime/core/providers/cuda/tensor/pad.h
@@ -3,7 +3,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/pad.h"
 
 using onnxruntime::PadBase;

--- a/onnxruntime/core/providers/cuda/tensor/pad.h
+++ b/onnxruntime/core/providers/cuda/tensor/pad.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/pad.h"
 

--- a/onnxruntime/core/providers/cuda/tensor/quantize_linear.h
+++ b/onnxruntime/core/providers/cuda/tensor/quantize_linear.h
@@ -5,7 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "gsl/gsl"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/quantize_linear.h
+++ b/onnxruntime/core/providers/cuda/tensor/quantize_linear.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "gsl/gsl"
 

--- a/onnxruntime/core/providers/cuda/tensor/reshape.h
+++ b/onnxruntime/core/providers/cuda/tensor/reshape.h
@@ -5,7 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "gsl/gsl"
 #include "core/providers/cpu/tensor/reshape_helper.h"
 

--- a/onnxruntime/core/providers/cuda/tensor/reshape.h
+++ b/onnxruntime/core/providers/cuda/tensor/reshape.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "gsl/gsl"
 #include "core/providers/cpu/tensor/reshape_helper.h"

--- a/onnxruntime/core/providers/cuda/tensor/reverse_sequence.h
+++ b/onnxruntime/core/providers/cuda/tensor/reverse_sequence.h
@@ -5,7 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/reverse_sequence.h
+++ b/onnxruntime/core/providers/cuda/tensor/reverse_sequence.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/scatter_elements.h
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_elements.h
@@ -4,7 +4,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/scatter_elements.h
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_elements.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/slice.h
+++ b/onnxruntime/core/providers/cuda/tensor/slice.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/slice.h"
 #include "core/providers/cpu/tensor/utils.h"
 

--- a/onnxruntime/core/providers/cuda/tensor/split.h
+++ b/onnxruntime/core/providers/cuda/tensor/split.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/split.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/squeeze.h
+++ b/onnxruntime/core/providers/cuda/tensor/squeeze.h
@@ -3,7 +3,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/squeeze.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/squeeze.h
+++ b/onnxruntime/core/providers/cuda/tensor/squeeze.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/squeeze.h"
 

--- a/onnxruntime/core/providers/cuda/tensor/tile.h
+++ b/onnxruntime/core/providers/cuda/tensor/tile.h
@@ -3,7 +3,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/tile.h
+++ b/onnxruntime/core/providers/cuda/tensor/tile.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/transpose.h
+++ b/onnxruntime/core/providers/cuda/tensor/transpose.h
@@ -6,7 +6,7 @@
 #include "gsl/gsl"
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/transpose.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/transpose.h
+++ b/onnxruntime/core/providers/cuda/tensor/transpose.h
@@ -5,7 +5,6 @@
 
 #include "gsl/gsl"
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/transpose.h"
 

--- a/onnxruntime/core/providers/cuda/tensor/unsqueeze.h
+++ b/onnxruntime/core/providers/cuda/tensor/unsqueeze.h
@@ -3,7 +3,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/unsqueeze.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/unsqueeze.h
+++ b/onnxruntime/core/providers/cuda/tensor/unsqueeze.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/unsqueeze.h"
 

--- a/onnxruntime/core/providers/cuda/tensor/upsample.h
+++ b/onnxruntime/core/providers/cuda/tensor/upsample.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/upsample.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/cuda/tensor/where.h
+++ b/onnxruntime/core/providers/cuda/tensor/where.h
@@ -3,7 +3,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/where.h
+++ b/onnxruntime/core/providers/cuda/tensor/where.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/rocm/math/binary_elementwise_ops.h
+++ b/onnxruntime/core/providers/rocm/math/binary_elementwise_ops.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/providers/rocm/rocm_common.h"
+#include "core/providers/rocm/rocm_kernel.h"
 #include "core/providers/rocm/shared_inc/fast_divmod.h"
 #include "core/providers/cpu/tensor/utils.h"
 

--- a/onnxruntime/core/providers/rocm/math/variadic_elementwise_ops.h
+++ b/onnxruntime/core/providers/rocm/math/variadic_elementwise_ops.h
@@ -6,7 +6,7 @@
 #include <functional>
 #include <vector>
 
-#include "core/providers/rocm/rocm_common.h"
+#include "core/providers/rocm/rocm_kernel.h"
 
 namespace onnxruntime {
 namespace rocm {

--- a/onnxruntime/core/providers/rocm/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/rocm/reduction/reduction_ops.h
@@ -4,7 +4,7 @@
 #pragma once
 #include "core/common/optional.h"
 #include "core/providers/cpu/reduction/reduction_ops.h"
-#include "core/providers/rocm/rocm_common.h"
+#include "core/providers/rocm/rocm_kernel.h"
 #include "core/providers/rocm/reduction/reduction_functions.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/rocm/rocm_common.h
+++ b/onnxruntime/core/providers/rocm/rocm_common.h
@@ -2,16 +2,12 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "rocm_pch.h"
+
 #include "core/common/status.h"
-#include "core/framework/data_transfer_manager.h"
-#include "core/framework/op_kernel.h"
-#include "core/graph/graph_viewer.h"
-#include "shared_inc/rocm_call.h"
-#include "rocm_execution_provider.h"
-#include "shared_inc/fast_divmod.h"
+#include "core/providers/rocm/rocm_pch.h"
+#include "core/providers/rocm/shared_inc/rocm_call.h"
+#include "core/providers/rocm/shared_inc/fast_divmod.h"
 #include "core/util/math.h"
-#include "rocm_fwd.h"
 
 namespace onnxruntime {
 namespace rocm {
@@ -50,138 +46,6 @@ namespace rocm {
   ORT_RETURN_IF_ERROR(HIPFFT_CALL(expr)           \
                           ? common::Status::OK() \
                           : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "HIPFFT error executing ", #expr))
-
-// -----------------------------------------------------------------------
-// Base class for HIP kernels
-// -----------------------------------------------------------------------
-class RocmKernel : public OpKernel {
- public:
-  explicit RocmKernel(const OpKernelInfo& info)
-      : OpKernel(info),
-        // Is this OK to have a non-const execution provider?
-        provider_(const_cast<ROCMExecutionProvider*>(static_cast<const ROCMExecutionProvider*>(info.GetExecutionProvider()))) {
-  }
-
-  Status Compute(OpKernelContext* p_op_kernel_context) const override {
-    auto s = ComputeInternal(p_op_kernel_context);
-
-    if (s.IsOK()) {
-      auto err = hipGetLastError();
-      if (err != hipSuccess) {
-        s = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "HIP error ", hipGetErrorName(err), ":", hipGetErrorString(err));
-      }
-    }
-
-    return s;
-  }
-
-  virtual Status ComputeInternal(OpKernelContext* p_op_kernel_context) const = 0;
-
-  template <typename T>
-  inline IAllocatorUniquePtr<T> AllocateBufferOnCPUPinned(size_t count_or_bytes) const {
-    AllocatorPtr allocator = provider_->GetAllocator(CPU_ALLOCATOR_DEVICE_ID, OrtMemTypeCPU);
-    if (!allocator)
-      return nullptr;
-    return IAllocator::MakeUniquePtr<T>(allocator, count_or_bytes);
-  }
-
-  template <typename T>
-  inline IAllocatorUniquePtr<T> GetScratchBuffer(size_t count_or_bytes) const {
-    return provider_->GetScratchBuffer<T>(count_or_bytes);
-  }
-
-  inline void AddDeferredReleaseCPUPtr(void* p) const {
-    provider_->AddDeferredReleaseCPUPtr(p);
-  }
-
-  const hipDeviceProp_t& GetDeviceProp() const { return provider_->GetDeviceProp(); };
-
-  // To support hipMemcpyAsync, the cpu memory should be allocated in pinned memory
-  // and it can only be released after the copy has finished
-  template <typename T>
-  class RocmAsyncBuffer {
-   public:
-    RocmAsyncBuffer(const RocmKernel* op_kernel) : gpu_copy_(nullptr), count_(0), op_kernel_(op_kernel) {}
-
-    RocmAsyncBuffer(const RocmKernel* op_kernel, size_t count) : RocmAsyncBuffer(op_kernel) {
-      AllocCpuPtr(count);
-    }
-
-    RocmAsyncBuffer(const RocmKernel* op_kernel, const T& value, size_t count)
-        : RocmAsyncBuffer(op_kernel, count) {
-      T* p = CpuPtr();
-      for (size_t i = 0; i != count; ++i) {
-        *p++ = value;
-      }
-    }
-
-    RocmAsyncBuffer(const RocmKernel* op_kernel, const std::vector<T>& vec) : RocmAsyncBuffer(op_kernel, vec.size()) {
-      memcpy(CpuPtr(), vec.data(), vec.size() * sizeof(T));
-    }
-
-    void AllocCpuPtr(size_t count) {
-      cpu_pinned_copy_ = op_kernel_->AllocateBufferOnCPUPinned<T>(count);
-      if (cpu_pinned_copy_ == nullptr)
-        throw std::runtime_error("alloc failed");
-      count_ = count;
-    }
-
-    Status CopyToGpu() {
-      if (cpu_pinned_copy_) {
-        gpu_copy_ = op_kernel_->GetScratchBuffer<T>(count_);
-        HIP_RETURN_IF_ERROR(hipMemcpyAsync(gpu_copy_.get(), cpu_pinned_copy_.get(), count_ * sizeof(T), hipMemcpyHostToDevice));
-        op_kernel_->AddDeferredReleaseCPUPtr(cpu_pinned_copy_.release());
-      }
-      return Status::OK();
-    }
-
-    T* CpuPtr() const {
-      return cpu_pinned_copy_.get();
-    }
-
-    gsl::span<T> CpuSpan() const {
-      return gsl::span<T>(CpuPtr(), count_);
-    }
-
-    T* GpuPtr() const {
-      return gpu_copy_.get();
-    }
-
-    size_t count() const {
-      return count_;
-    }
-
-   protected:
-    IAllocatorUniquePtr<T> gpu_copy_;
-    IAllocatorUniquePtr<T> cpu_pinned_copy_;
-    size_t count_;
-    const RocmKernel* op_kernel_;
-  };
-
-  inline rocblas_handle RocblasHandle() const {
-    return provider_->PerThreadRocblasHandle();
-  }
-
-  inline miopenHandle_t MiopenHandle() const {
-    return provider_->PerThreadMiopenHandle();
-  }
-
- protected:
-
-  template <typename T>
-  inline const T* GetConstOnes(size_t count) const {
-    return provider_->template GetConstOnes<T>(count);
-  }
-
-  inline Status CopyTensor(const Tensor& src, Tensor& dst) const {
-    return Info().GetDataTransferManager().CopyTensor(src, dst);
-  }
-
-  inline int GetDeviceId() const { return provider_->GetDeviceId(); }
-
- private:
-  ROCMExecutionProvider* provider_;
-};
 
 // Type mapping for MLFloat16 to half
 template <typename T>

--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
@@ -1786,7 +1786,7 @@ std::vector<NodeIndex> candidates;
   // For ROCM EP, exclude the subgraph that is preferred to be placed in CPU
   // These are usually shape related computation subgraphs
   // Following logic can be extended for other EPs
-  std::unordered_set<NodeIndex> cpu_nodes = GetCpuPreferedNodes(graph, Type(), kernel_registries, candidates);
+  std::unordered_set<NodeIndex> cpu_nodes = GetCpuPreferredNodes(graph, Type(), kernel_registries, candidates);
 
   std::vector<std::unique_ptr<ComputeCapability>> result;
   for (auto& node_index : candidates) {

--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
@@ -1,16 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "rocm_common.h"
-#include "rocm_execution_provider.h"
-#include "rocm_fence.h"
-#include "rocm_allocator.h"
-#include "core/framework/kernel_registry.h"
+#include "core/providers/rocm/rocm_execution_provider.h"
+
 #include "core/framework/compute_capability.h"
 #include "core/framework/fallback_cpu_capability.h"
+#include "core/framework/kernel_registry.h"
 #include "core/framework/memcpy.h"
 #include "core/graph/graph_utils.h"
 #include "core/providers/rocm/gpu_data_transfer.h"
+#include "core/providers/rocm/rocm_fence.h"
+#include "core/providers/rocm/rocm_fwd.h"
+#include "core/providers/rocm/rocm_allocator.h"
 
 #ifndef DISABLE_CONTRIB_OPS
 #include "contrib_ops/rocm/rocm_contrib_kernels.h"

--- a/onnxruntime/core/providers/rocm/rocm_fence.cc
+++ b/onnxruntime/core/providers/rocm/rocm_fence.cc
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "rocm_common.h"
-#include "rocm_fence.h"
-#include "gpu_data_transfer.h"
+#include "core/providers/rocm/rocm_fence.h"
+
+#include "core/graph/constants.h"
+#include "core/providers/rocm/gpu_data_transfer.h"
+#include "core/providers/rocm/rocm_common.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/providers/rocm/rocm_fence.h
+++ b/onnxruntime/core/providers/rocm/rocm_fence.h
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 #pragma once
+
 #include "core/framework/tensor.h"
 #include "core/graph/basic_types.h"
+#include "core/providers/rocm/rocm_common.h"
 
 namespace onnxruntime {
 class GPUDataTransfer;

--- a/onnxruntime/core/providers/rocm/rocm_fwd.h
+++ b/onnxruntime/core/providers/rocm/rocm_fwd.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "core/framework/op_kernel.h"
+
 namespace onnxruntime {
 namespace rocm {
 template <typename T>

--- a/onnxruntime/core/providers/rocm/rocm_kernel.h
+++ b/onnxruntime/core/providers/rocm/rocm_kernel.h
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/status.h"
+#include "core/framework/data_transfer_manager.h"
+#include "core/framework/op_kernel.h"
+#include "core/providers/rocm/rocm_common.h"
+#include "core/providers/rocm/rocm_execution_provider.h"
+#include "core/providers/rocm/rocm_fwd.h"
+
+namespace onnxruntime {
+namespace rocm {
+
+// -----------------------------------------------------------------------
+// Base class for HIP kernels
+// -----------------------------------------------------------------------
+class RocmKernel : public OpKernel {
+ public:
+  explicit RocmKernel(const OpKernelInfo& info)
+      : OpKernel(info),
+        // Is this OK to have a non-const execution provider?
+        provider_(const_cast<ROCMExecutionProvider*>(static_cast<const ROCMExecutionProvider*>(info.GetExecutionProvider()))) {
+  }
+
+  Status Compute(OpKernelContext* p_op_kernel_context) const override {
+    auto s = ComputeInternal(p_op_kernel_context);
+
+    if (s.IsOK()) {
+      auto err = hipGetLastError();
+      if (err != hipSuccess) {
+        s = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "HIP error ", hipGetErrorName(err), ":", hipGetErrorString(err));
+      }
+    }
+
+    return s;
+  }
+
+  virtual Status ComputeInternal(OpKernelContext* p_op_kernel_context) const = 0;
+
+  template <typename T>
+  inline IAllocatorUniquePtr<T> AllocateBufferOnCPUPinned(size_t count_or_bytes) const {
+    AllocatorPtr allocator = provider_->GetAllocator(CPU_ALLOCATOR_DEVICE_ID, OrtMemTypeCPU);
+    if (!allocator)
+      return nullptr;
+    return IAllocator::MakeUniquePtr<T>(allocator, count_or_bytes);
+  }
+
+  template <typename T>
+  inline IAllocatorUniquePtr<T> GetScratchBuffer(size_t count_or_bytes) const {
+    return provider_->GetScratchBuffer<T>(count_or_bytes);
+  }
+
+  inline void AddDeferredReleaseCPUPtr(void* p) const {
+    provider_->AddDeferredReleaseCPUPtr(p);
+  }
+
+  const hipDeviceProp_t& GetDeviceProp() const { return provider_->GetDeviceProp(); };
+
+  // To support hipMemcpyAsync, the cpu memory should be allocated in pinned memory
+  // and it can only be released after the copy has finished
+  template <typename T>
+  class RocmAsyncBuffer {
+   public:
+    RocmAsyncBuffer(const RocmKernel* op_kernel) : gpu_copy_(nullptr), count_(0), op_kernel_(op_kernel) {}
+
+    RocmAsyncBuffer(const RocmKernel* op_kernel, size_t count) : RocmAsyncBuffer(op_kernel) {
+      AllocCpuPtr(count);
+    }
+
+    RocmAsyncBuffer(const RocmKernel* op_kernel, const T& value, size_t count)
+        : RocmAsyncBuffer(op_kernel, count) {
+      T* p = CpuPtr();
+      for (size_t i = 0; i != count; ++i) {
+        *p++ = value;
+      }
+    }
+
+    RocmAsyncBuffer(const RocmKernel* op_kernel, const std::vector<T>& vec) : RocmAsyncBuffer(op_kernel, vec.size()) {
+      memcpy(CpuPtr(), vec.data(), vec.size() * sizeof(T));
+    }
+
+    void AllocCpuPtr(size_t count) {
+      cpu_pinned_copy_ = op_kernel_->AllocateBufferOnCPUPinned<T>(count);
+      if (cpu_pinned_copy_ == nullptr)
+        throw std::runtime_error("alloc failed");
+      count_ = count;
+    }
+
+    Status CopyToGpu() {
+      if (cpu_pinned_copy_) {
+        gpu_copy_ = op_kernel_->GetScratchBuffer<T>(count_);
+        HIP_RETURN_IF_ERROR(hipMemcpyAsync(gpu_copy_.get(), cpu_pinned_copy_.get(), count_ * sizeof(T), hipMemcpyHostToDevice));
+        op_kernel_->AddDeferredReleaseCPUPtr(cpu_pinned_copy_.release());
+      }
+      return Status::OK();
+    }
+
+    T* CpuPtr() const {
+      return cpu_pinned_copy_.get();
+    }
+
+    gsl::span<T> CpuSpan() const {
+      return gsl::span<T>(CpuPtr(), count_);
+    }
+
+    T* GpuPtr() const {
+      return gpu_copy_.get();
+    }
+
+    size_t count() const {
+      return count_;
+    }
+
+   protected:
+    IAllocatorUniquePtr<T> gpu_copy_;
+    IAllocatorUniquePtr<T> cpu_pinned_copy_;
+    size_t count_;
+    const RocmKernel* op_kernel_;
+  };
+
+  inline rocblas_handle RocblasHandle() const {
+    return provider_->PerThreadRocblasHandle();
+  }
+
+  inline miopenHandle_t MiopenHandle() const {
+    return provider_->PerThreadMiopenHandle();
+  }
+
+ protected:
+  template <typename T>
+  inline const T* GetConstOnes(size_t count) const {
+    return provider_->template GetConstOnes<T>(count);
+  }
+
+  inline Status CopyTensor(const Tensor& src, Tensor& dst) const {
+    return Info().GetDataTransferManager().CopyTensor(src, dst);
+  }
+
+  inline int GetDeviceId() const { return provider_->GetDeviceId(); }
+
+ private:
+  ROCMExecutionProvider* provider_;
+};
+
+}  // namespace rocm
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/rocm/tensor/transpose.h
+++ b/onnxruntime/core/providers/rocm/tensor/transpose.h
@@ -5,8 +5,7 @@
 
 #include "gsl/gsl"
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
-#include "core/providers/rocm/rocm_common.h"
+#include "core/providers/rocm/rocm_kernel.h"
 #include "core/providers/cpu/tensor/transpose.h"
 
 namespace onnxruntime {

--- a/onnxruntime/test/providers/cuda/reduction_functions_test.cc
+++ b/onnxruntime/test/providers/cuda/reduction_functions_test.cc
@@ -9,6 +9,7 @@
 
 #include "core/common/optional.h"
 #include "core/providers/cuda/reduction/reduction_functions.h"
+#include "core/providers/cuda/shared_inc/cuda_utils.h"
 #include "test/common/tensor_op_test_utils.h"
 #include "test/util/include/asserts.h"
 

--- a/orttraining/orttraining/training_ops/cuda/activation/bias_gelu_grad.h
+++ b/orttraining/orttraining/training_ops/cuda/activation/bias_gelu_grad.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/collective/horovod_kernels.h
+++ b/orttraining/orttraining/training_ops/cuda/collective/horovod_kernels.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "orttraining/core/graph/horovod_adapters.h"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/cuda/collective/nccl_common.h
+++ b/orttraining/orttraining/training_ops/cuda/collective/nccl_common.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "orttraining/core/framework/distributed_run_context.h"
 #include <nccl.h>
 

--- a/orttraining/orttraining/training_ops/cuda/communication/recv.h
+++ b/orttraining/orttraining/training_ops/cuda/communication/recv.h
@@ -5,7 +5,7 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/communication/send.h
+++ b/orttraining/orttraining/training_ops/cuda/communication/send.h
@@ -5,8 +5,7 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
-
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/controlflow/record.h
+++ b/orttraining/orttraining/training_ops/cuda/controlflow/record.h
@@ -3,7 +3,7 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/cudnn_common.h"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/cuda/controlflow/wait.h
+++ b/orttraining/orttraining/training_ops/cuda/controlflow/wait.h
@@ -3,7 +3,7 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/cudnn_common.h"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
+++ b/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_fwd.h"
 #include "core/framework/kernel_registry.h"
 
 using namespace onnxruntime::common;

--- a/orttraining/orttraining/training_ops/cuda/math/isfinite.h
+++ b/orttraining/orttraining/training_ops/cuda/math/isfinite.h
@@ -4,7 +4,7 @@
 #pragma once
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/multi_tensor/common.cuh"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/cuda/math/isfinite.h
+++ b/orttraining/orttraining/training_ops/cuda/math/isfinite.h
@@ -3,7 +3,6 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/multi_tensor/common.cuh"
 

--- a/orttraining/orttraining/training_ops/cuda/math/mixed_precision_scale.h
+++ b/orttraining/orttraining/training_ops/cuda/math/mixed_precision_scale.h
@@ -4,7 +4,7 @@
 #pragma once
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/math/mixed_precision_scale.h
+++ b/orttraining/orttraining/training_ops/cuda/math/mixed_precision_scale.h
@@ -3,7 +3,6 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/cuda/math/scale.h
+++ b/orttraining/orttraining/training_ops/cuda/math/scale.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/math/softmax_grad.h
+++ b/orttraining/orttraining/training_ops/cuda/math/softmax_grad.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/nn/batch_norm_grad.h
+++ b/orttraining/orttraining/training_ops/cuda/nn/batch_norm_grad.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "gsl/gsl"
+
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/cudnn_common.h"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/cuda/nn/dropout.h
+++ b/orttraining/orttraining/training_ops/cuda/nn/dropout.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "orttraining/training_ops/cuda/nn/dropout_impl.h"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/cuda/nn/layer_norm.h
+++ b/orttraining/orttraining/training_ops/cuda/nn/layer_norm.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/optimizer/adam.h
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/adam.h
@@ -3,7 +3,7 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/optimizer/gradient_control.h
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/gradient_control.h
@@ -3,7 +3,7 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/optimizer/lamb.h
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/lamb.h
@@ -3,7 +3,7 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/multi_tensor/common.cuh"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/cuda/optimizer/sg.h
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/sg.h
@@ -3,7 +3,7 @@
 
 #pragma once
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/reduction/all.h
+++ b/orttraining/orttraining/training_ops/cuda/reduction/all.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/reduction/reduction_all.h
+++ b/orttraining/orttraining/training_ops/cuda/reduction/reduction_all.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/multi_tensor/common.cuh"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/cuda/tensor/concat.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/concat.h
@@ -3,7 +3,7 @@
 #pragma once
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/concat.h"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/cuda/tensor/concat.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/concat.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 #pragma once
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/concat.h"
 

--- a/orttraining/orttraining/training_ops/cuda/tensor/gather_elements_grad.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/gather_elements_grad.h
@@ -4,7 +4,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/tensor/gather_elements_grad.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/gather_elements_grad.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/cuda/tensor/gather_grad.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/gather_grad.h
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/tensor/gather_grad_impl.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/gather_grad_impl.h
@@ -3,7 +3,7 @@
 
 #pragma once
 #include <stdint.h>
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/shared_inc/cuda_utils.h"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/cuda/tensor/gather_nd_grad.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/gather_nd_grad.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
 #include "core/providers/cuda/tensor/gather_nd.h"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/cuda/tensor/gather_nd_grad.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/gather_nd_grad.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_common.h"
 #include "core/providers/cuda/tensor/gather_nd.h"
 

--- a/orttraining/orttraining/training_ops/cuda/tensor/split.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/split.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/common/common.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/tensor/split.h"
 #include "orttraining/training_ops/cpu/tensor/split.h"
 

--- a/orttraining/orttraining/training_ops/cuda/tensor/view.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/view.h
@@ -5,7 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/tensor/view.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/view.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/common/common.h"
-#include "core/framework/op_kernel.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/rocm/rocm_training_kernels.cc
+++ b/orttraining/orttraining/training_ops/rocm/rocm_training_kernels.cc
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/providers/rocm/rocm_common.h"
+#include "core/providers/rocm/rocm_fwd.h"
 #include "core/framework/kernel_registry.h"
 
 using namespace onnxruntime::common;

--- a/orttraining/orttraining/training_ops/rocm/tensor/gather_grad_impl.h
+++ b/orttraining/orttraining/training_ops/rocm/tensor/gather_grad_impl.h
@@ -3,7 +3,7 @@
 
 #pragma once
 #include <stdint.h>
-#include "core/providers/rocm/rocm_common.h"
+#include "core/providers/rocm/rocm_kernel.h"
 #include "core/providers/rocm/shared_inc/rocm_utils.h"
 
 namespace onnxruntime {

--- a/tools/ci_build/amd_hipify.py
+++ b/tools/ci_build/amd_hipify.py
@@ -214,6 +214,7 @@ core_ops_files = [
                 'cuda_fence.cc',
                 'cuda_fence.h',
                 'cuda_fwd.h',
+                'cuda_kernel.h',
                 'cuda_pch.cc',
                 'cuda_pch.h',
                 'cuda_provider_factory.cc',


### PR DESCRIPTION
**Description**
Move CudaKernel from cuda_common.h to a new separate header, cuda_kernel.h. Update include sites to use cuda_kernel.h instead if they need CudaKernel. Inclusions of cuda_common.h are now more lightweight.

Make corresponding changes for ROCM execution provider code.

Other minor cleanup.

**Motivation and Context**
We observe intermittent build failures (not infrequent, in some cases) from nvcc when compiling device code. For example:
```
2020-12-10T02:34:26.8526890Z ##[error]cmake\external\protobuf\src\google\protobuf\repeated_field.h(407,0): Error C2993: 'T': is not a valid type for non-type template parameter '__formal'
2020-12-10T02:34:26.8528524Z     79>D:\4\s\cmake\external\protobuf\src\google/protobuf/repeated_field.h(407): error C2993: 'T': is not a valid type for non-type template parameter '__formal' [D:\4\b\RelWithDebInfo\onnxruntime_providers_cuda.vcxproj]
2020-12-10T02:34:26.8532945Z          D:\4\s\cmake\external\protobuf\src\google/protobuf/repeated_field.h(416): note: see reference to class template instantiation 'google::protobuf::internal::TypeImplementsMergeBehaviorProbeForMergeFrom<T>' being compiled
2020-12-10T02:34:26.8539484Z ##[error]cmake\external\protobuf\src\google\protobuf\repeated_field.h(407,0): Error C2065: 'RetType': undeclared identifier
2020-12-10T02:34:26.8544905Z     79>D:\4\s\cmake\external\protobuf\src\google/protobuf/repeated_field.h(407): error C2065: 'RetType': undeclared identifier [D:\4\b\RelWithDebInfo\onnxruntime_providers_cuda.vcxproj]
2020-12-10T02:34:26.8551719Z ##[error]cmake\external\protobuf\src\google\protobuf\repeated_field.h(407,0): Error C2923: 'std::_Select<__formal>::_Apply': 'RetType' is not a valid template type argument for parameter '<unnamed-symbol>'
2020-12-10T02:34:26.8554775Z     79>D:\4\s\cmake\external\protobuf\src\google/protobuf/repeated_field.h(407): error C2923: 'std::_Select<__formal>::_Apply': 'RetType' is not a valid template type argument for parameter '<unnamed-symbol>' [D:\4\b\RelWithDebInfo\onnxruntime_providers_cuda.vcxproj]
2020-12-10T02:34:26.8562526Z ##[error]cmake\external\protobuf\src\google\protobuf\repeated_field.h(407,0): Error C2062: type 'unknown-type' unexpected
2020-12-10T02:34:26.8564451Z     79>D:\4\s\cmake\external\protobuf\src\google/protobuf/repeated_field.h(407): error C2062: type 'unknown-type' unexpected [D:\4\b\RelWithDebInfo\onnxruntime_providers_cuda.vcxproj]
2020-12-10T02:34:26.9465563Z ##[error]C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\BuildCustomizations\CUDA 10.2.targets(764,9): Error MSB3721: The command ""C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\bin\nvcc.exe" -gencode=arch=compute_30,code=\"sm_30,compute_30\" -gencode=arch=compute_37,code=\"sm_37,compute_37\" -gencode=arch=compute_50,code=\"sm_50,compute_50\" -gencode=arch=compute_52,code=\"sm_52,compute_52\" -gencode=arch=compute_60,code=\"sm_60,compute_60\" -gencode=arch=compute_70,code=\"sm_70,compute_70\" --use-local-env -ccbin "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.28.29333\bin\HostX64\x64" -x cu  -ID:\4\b\packages\Microsoft.AI.DirectML.1.4.0\include -ID:\4\s\include\onnxruntime -ID:\4\s\include\onnxruntime\core\session -ID:\4\s\cmake\external\SafeInt -I"D:\4\s\cmake\external\optional-lite\include" -ID:\4\b\RelWithDebInfo -ID:\4\s\cmake\external\onnx -ID:\4\b\RelWithDebInfo\external\onnx -ID:\4\s\cmake\external\protobuf\src -ID:\4\s\cmake\external\flatbuffers\include -ID:\4\s\onnxruntime -I"C:\local\cudnn-10.2-windows10-x64-v8.0.3.33\cuda\include" -ID:\4\s\cmake\external\eigen -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\include" -ID:\4\s\cmake\external\cub -I"C:\Program Files\Java\jdk8u275-b01\include" -I"C:\Program Files\Java\jdk8u275-b01\include\win32" -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\include"     --keep-dir x64\RelWithDebInfo -maxrregcount=0  --machine 64 --compile -cudart shared --expt-relaxed-constexpr --default-stream legacy -Xcudafe --diag_suppress=bad_friend_decl -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=expr_has_no_effect -Xcompiler="-Zi -Ob1 /wd4127 /utf-8 /sdl"    -DNDEBUG -DEIGEN_USE_THREADS -DONNX_NAMESPACE=onnx -DONNX_ML=1 -DONNX_USE_LITE_PROTO=1 -D__ONNX_NO_DOC_STRINGS -DENABLE_ORT_FORMAT_LOAD -DORT_NO_RTTI -DGOOGLE_PROTOBUF_NO_RTTI -DEIGEN_MPL2_ONLY -DEIGEN_HAS_CONSTEXPR -DEIGEN_HAS_VARIADIC_TEMPLATES -DEIGEN_HAS_CXX11_MATH -DEIGEN_HAS_CXX11_ATOMIC -DEIGEN_STRONG_INLINE=inline -DUSE_EIGEN_FOR_BLAS -DORT_RUN_EXTERNAL_ONNX_TESTS -DPLATFORM_WINDOWS -DNOGDI -DNOMINMAX -D_USE_MATH_DEFINES -DUSE_CUDA=1 -DUSE_DML=1 -DDML_TARGET_VERSION_USE_LATEST=1 -DWINVER=0x0601 -D"CMAKE_INTDIR=\"RelWithDebInfo\"" -DWIN32 -D_WINDOWS -DEIGEN_HAS_C99_MATH -DNDEBUG -DGSL_UNENFORCED_ON_CONTRACT_VIOLATION -DEIGEN_USE_THREADS -DONNX_NAMESPACE=onnx -DONNX_ML=1 -DONNX_USE_LITE_PROTO=1 -D__ONNX_NO_DOC_STRINGS -DENABLE_ORT_FORMAT_LOAD -DORT_NO_RTTI -DGOOGLE_PROTOBUF_NO_RTTI -DEIGEN_MPL2_ONLY -DEIGEN_HAS_CONSTEXPR -DEIGEN_HAS_VARIADIC_TEMPLATES -DEIGEN_HAS_CXX11_MATH -DEIGEN_HAS_CXX11_ATOMIC -DEIGEN_STRONG_INLINE=inline -DUSE_EIGEN_FOR_BLAS -DORT_RUN_EXTERNAL_ONNX_TESTS -DPLATFORM_WINDOWS -DNOGDI -DNOMINMAX -D_USE_MATH_DEFINES -DUSE_CUDA=1 -DUSE_DML=1 -DDML_TARGET_VERSION_USE_LATEST=1 -DWINVER=0x0601 -D"CMAKE_INTDIR=\"RelWithDebInfo\"" -D_MBCS -Xcompiler "/EHsc /W4 /nologo /O2 /Fdonnxruntime_providers_cuda.dir\RelWithDebInfo\onnxruntime_providers_cuda.pdb /FS /Zi  /MD /GR-" -o onnxruntime_providers_cuda.dir\RelWithDebInfo\longformer_attention_impl.obj "D:\4\s\onnxruntime\contrib_ops\cuda\bert\longformer_attention_impl.cu"" exited with code 2.
```

These errors point to code that seems unrelated to the actual CUDA kernel code. The hope is that by reducing the amount of device code that is compiled, we reduce the chance of these intermittent compilation failures.

It also seems reasonable to put the CudaKernel class in its own file.