### PR TITLE
Fix RuntimeError of loading model with external tensor

### DIFF
--- a/cgmanifests/submodules/cgmanifest.json
+++ b/cgmanifests/submodules/cgmanifest.json
@@ -242,7 +242,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "174de7d086a768cba29374a56a7461eff87cfdb3",
+          "commitHash": "237926eab41de21fb9addc4b03b751fd6a3343ec",
           "repositoryUrl": "https://github.com/onnx/onnx"
         },
         "comments": "git submodule at cmake/external/onnx"

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2265,6 +2265,9 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
   ctx.set_ir_version(gsl::narrow_cast<int>(IrVersion()));
   ctx.set_opset_imports(DomainToVersionMap());
   ctx.set_schema_registry(schema_registry_.get());
+  // Set the parent directory of model path to load external tensors if exist
+  ctx.set_model_dir(ToMBString(ModelPath().ParentPath().ToPathString()));
+
 
   LexicalScopeContext lsc;
   lsc.output_names.insert(resolve_context_.inputs_and_initializers.cbegin(),

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -3,7 +3,7 @@ mypy
 pytest
 setuptools>=41.4.0
 wheel
-git+http://github.com/onnx/onnx.git@174de7d086a768cba29374a56a7461eff87cfdb3#egg=onnx
+git+http://github.com/onnx/onnx.git@237926eab41de21fb9addc4b03b751fd6a3343ec#egg=onnx
 protobuf
 sympy==1.1.1
 flake8

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -4,7 +4,7 @@ mypy
 pytest
 setuptools>=41.4.0
 wheel
-git+http://github.com/onnx/onnx.git@174de7d086a768cba29374a56a7461eff87cfdb3#egg=onnx
+git+http://github.com/onnx/onnx.git@237926eab41de21fb9addc4b03b751fd6a3343ec#egg=onnx
 argparse
 sympy==1.1.1
 flake8


### PR DESCRIPTION
**Description**:
- Set the parent directory of model path to load external tensors
- (TODO) Resolve new error after fixing the previous one:  (It will be done in another PR)
```
[ONNXRuntimeError] : 2 : INVALID_ARGUMENT : corrupted protobuf data: tensor shape size(1) does not match the data size(0) in prototensor shape size(1) does not match the data size(0) in proto
```

**Motivation and Context**
https://github.com/onnx/onnx/issues/3157
Reload and save the onnx model with external data format will cause runtime error:
```
onnxruntime.capi.onnxruntime_pybind11_state.InvalidGraph: [ONNXRuntimeError] : 10 : INVALID_GRAPH : Load model from chitchatexporttest/median_sampled_qgen_48_past_fp32/median_sampled_qgen_48_past_fp32.onnx failed:This is an invalid model. Error in Node:ConstantOfShape_11958 : Data of TensorProto ( tensor name: ConstantOfShape_11958_attr::value) should be stored in median_sampled_qgen_48_past_fp32.onnx.data, but it doesn't exist or is not accessible.
```