### PR TITLE
[ArmNN][Doc]Use meaningful variable name

### DIFF
--- a/docs/execution_providers/ArmNN-ExecutionProvider.md
+++ b/docs/execution_providers/ArmNN-ExecutionProvider.md
@@ -10,9 +10,9 @@ For build instructions, please see the [BUILD page](../../BUILD.md#ArmNN).
 To use ArmNN as execution provider for inferencing, please register it as below.
 ```
 Ort::Env env = Ort::Env{ORT_LOGGING_LEVEL_ERROR, "Default"};
-Ort::SessionOptions sf;
+Ort::SessionOptions so;
 bool enable_cpu_mem_arena = true;
-Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_ArmNN(sf, enable_cpu_mem_arena));
+Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_ArmNN(so, enable_cpu_mem_arena));
 ```
 The C API details are [here](../C_API.md#c-api).
 


### PR DESCRIPTION
- Its more logical to name the `SessionOptions` object as `so` and not as `sf` (can't find what is the meaning for `f`)