### PR TITLE
[Test Only] Support ConvTranspose-14

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
@@ -212,7 +212,7 @@ struct ConvTransposeAttributes : public ConvAttributes {
     if (pad_type == AutoPadType::SAME_UPPER || pad_type == AutoPadType::SAME_LOWER) {
       // total pad
       auto total_pad = ComputeTotalPad(in_size, stride, adj,
-                                       kernel, dilation, in_size);
+                                       kernel, dilation, in_size * stride);
       DistributePadding(pad_type, total_pad, *pad_head, *pad_tail);
     }
 


### PR DESCRIPTION
**Description**: Support ConvTranspose-14.

**Motivation and Context**
This change aligns the keras/tensorflow ConvTranspose padding=same case for dynamic input shape. It handles stride>1 in particular. Validated two models locally (unetplusplus and unet) and it works correctly.