### PR TITLE
save_checkpoint, load_checkpoint and aggregate_checkpoints

### DIFF
--- a/orttraining/orttraining/python/training/_checkpoint_storage.py
+++ b/orttraining/orttraining/python/training/_checkpoint_storage.py
@@ -89,6 +89,9 @@ def to_serialized_hex(user_dict):
 def from_serialized_hex(serialized_hex):
     """Convert serialized_hex to bytes and deserialize it and return"""
 
+    # serialized_hex can be either a regular string or a byte string.
+    # if it is a byte string, convert to regular string using decode()
+    # if it is a regular string, do nothing to it
     try:
         serialized_hex = serialized_hex.decode()
     except AttributeError:

--- a/orttraining/orttraining/python/training/_checkpoint_storage.py
+++ b/orttraining/orttraining/python/training/_checkpoint_storage.py
@@ -82,9 +82,13 @@ def load(path, key=None):
     return load_obj
 
 def to_serialized_hex(user_dict):
+    """Serialize the user_dict and convert the serialized bytes to a hex string and return"""
+
     return pickle.dumps(user_dict).hex()
 
 def from_serialized_hex(serialized_hex):
+    """Convert serialized_hex to bytes and deserialize it and return"""
+
     try:
         serialized_hex = serialized_hex.decode()
     except AttributeError:

--- a/orttraining/orttraining/python/training/_checkpoint_storage.py
+++ b/orttraining/orttraining/python/training/_checkpoint_storage.py
@@ -4,6 +4,7 @@
 
 import h5py
 from collections.abc import Mapping
+import pickle
 
 def _dfs_save(group, save_obj):
     """Recursively go over each level in the save_obj dictionary and save values to a hdf5 group"""
@@ -79,3 +80,13 @@ def load(path, key=None):
         _dfs_load(f, load_obj)
 
     return load_obj
+
+def to_serialized_hex(user_dict):
+    return pickle.dumps(user_dict).hex()
+
+def from_serialized_hex(serialized_hex):
+    try:
+        serialized_hex = serialized_hex.decode()
+    except AttributeError:
+        pass
+    return pickle.loads(bytes.fromhex(serialized_hex))

--- a/orttraining/orttraining/python/training/_utils.py
+++ b/orttraining/orttraining/python/training/_utils.py
@@ -221,3 +221,28 @@ def state_dict_user_dict_key():
     """Returns the user dict key name in the state dictionary"""
 
     return 'user_dict'
+
+def state_dict_trainer_options_mixed_precision_key():
+    """Returns the trainer options mixed precision key name in the state dictionary"""
+
+    return 'mixed_precision'
+
+def state_dict_trainer_options_zero_stage_key():
+    """Returns the trainer options zero_stage key name in the state dictionary"""
+
+    return 'zero_stage'
+
+def state_dict_trainer_options_world_rank_key():
+    """Returns the trainer options world_rank key name in the state dictionary"""
+
+    return 'world_rank'
+
+def state_dict_trainer_options_world_size_key():
+    """Returns the trainer options world_size key name in the state dictionary"""
+
+    return 'world_size'
+
+def state_dict_trainer_options_optimizer_name_key():
+    """Returns the trainer options optimizer_name key name in the state dictionary"""
+
+    return 'optimizer_name'

--- a/orttraining/orttraining/python/training/_utils.py
+++ b/orttraining/orttraining/python/training/_utils.py
@@ -203,3 +203,21 @@ def state_dict_full_precision_key():
     """Returns the full precision key name in the state dictionary"""
 
     return 'fp32'
+
+def state_dict_original_dimension_key():
+    """Returns the original dimension key name in the state dictionary"""
+
+    return 'original_dim'
+
+def state_dict_sharded_optimizer_keys():
+    """Returns the optimizer key names that can be sharded in the state dictionary"""
+
+    return {
+        'Moment_1',
+        'Moment_2'
+    }
+
+def state_dict_user_dict_key():
+    """Returns the user dict key name in the state dictionary"""
+
+    return 'user_dict'

--- a/orttraining/orttraining/python/training/_utils.py
+++ b/orttraining/orttraining/python/training/_utils.py
@@ -202,7 +202,7 @@ def state_dict_trainer_options_key():
 def state_dict_full_precision_key():
     """Returns the full precision key name in the state dictionary"""
 
-    return 'fp32'
+    return 'full_precision'
 
 def state_dict_original_dimension_key():
     """Returns the original dimension key name in the state dictionary"""

--- a/orttraining/orttraining/python/training/checkpoint.py
+++ b/orttraining/orttraining/python/training/checkpoint.py
@@ -3,6 +3,7 @@ import onnx
 import os
 import torch
 import warnings
+from . import _checkpoint_storage, _utils
 
 
 ################################################################################
@@ -108,6 +109,197 @@ def experimental_load_checkpoint(ort_trainer, checkpoint_dir, checkpoint_prefix=
     else:
         return _load_single_checkpoint(ort_trainer, checkpoint_dir, checkpoint_prefix, is_partitioned, strict)
 
+def _order_paths(paths):
+    """Reorders the given paths in ascending order of rank and return the ordered list"""
+
+    trainer_options_path_tuples = []
+
+    for path in paths:
+        trainer_options_path_tuples.append((_checkpoint_storage.load(path,
+            key=_utils.state_dict_trainer_options_key()), path))
+
+    ordered_paths = [path for _, path in sorted(trainer_options_path_tuples,
+        key=lambda trainer_options_path_pair: trainer_options_path_pair[0]['world_rank'])]
+
+    return ordered_paths
+
+def _aggregate_model_states(rank_state_dict, sharded_states_original_dims, state_dict):
+    """Aggregates all model states from the rank_state_dict into state_dict"""
+
+    model = _utils.state_dict_model_key()
+    full_precision = _utils.state_dict_full_precision_key()
+    partition_info = _utils.state_dict_partition_info_key()
+    original_dim = _utils.state_dict_original_dimension_key()
+
+    # if there are no model states in the rank_state_dict, no model aggregation is needed
+    if model not in rank_state_dict:
+        return
+
+    if model not in state_dict:
+        state_dict[model] = {}
+
+    if full_precision not in state_dict[model]:
+        state_dict[model][full_precision] = {}
+
+    # iterate over all model state keys
+    for model_state_key, model_state_value in rank_state_dict[model][full_precision].items():
+        if model_state_key in rank_state_dict[partition_info]:
+            # this model state is sharded since a record exists in the partition_info subdict
+            # record the original dimension for this model state
+            sharded_states_original_dims[model_state_key] = \
+                rank_state_dict[partition_info][model_state_key][original_dim]
+
+            if model_state_key in state_dict[model][full_precision]:
+                # state_dict already contains a record for this model state
+                # since this model state is sharded, concatenate the model state value to
+                # the record in the state_dict
+                state_dict[model][full_precision][model_state_key] = \
+                    np.concatenate((state_dict[model][full_precision][model_state_key], model_state_value))
+            else:
+                # create a new entry for this model state in the state_dict
+                state_dict[model][full_precision][model_state_key] = model_state_value
+        else:
+            # this model state is not sharded since a record for it does not exist in the partition_info subdict
+            if model_state_key in state_dict[model][full_precision]:
+                # state_dict already contains a record for this unsharded state.
+                # assert that all values are the same for this previously loaded model state
+                assert (state_dict[model][full_precision][model_state_key] == model_state_value).all(), \
+                    "Value mismatch for model state {}".format(model_state_key)
+            else:
+                # create a new entry for this model state in the state_dict
+                state_dict[model][full_precision][model_state_key] = model_state_value
+
+def _aggregate_optimizer_states(rank_state_dict, sharded_states_original_dims, state_dict):
+    """Aggregates all optimizer states from the rank_state_dict into state_dict"""
+
+    optimizer = _utils.state_dict_optimizer_key()
+    partition_info = _utils.state_dict_partition_info_key()
+    original_dim = _utils.state_dict_original_dimension_key()
+    sharded_optimizer_keys = _utils.state_dict_sharded_optimizer_keys()
+
+    # if there are no optimizer states in the rank_state_dict, no optimizer aggregation is needed
+    if optimizer not in rank_state_dict:
+        return
+
+    if optimizer not in state_dict:
+        state_dict[optimizer] = {}
+
+    # iterate over all optimizer state keys
+    for model_state_key, optimizer_dict in rank_state_dict[optimizer].items():
+        for optimizer_key, optimizer_value in optimizer_dict.items():
+            if model_state_key not in state_dict[optimizer]:
+                state_dict[optimizer][model_state_key] = {}
+
+            if optimizer_key in sharded_optimizer_keys and model_state_key in rank_state_dict[partition_info]:
+                # this optimizer state is sharded since a record exists in the partition_info subdict
+                # record the original dimension for this optimizer state
+                sharded_states_original_dims[model_state_key] = \
+                    rank_state_dict[partition_info][model_state_key][original_dim]
+
+                if optimizer_key in state_dict[optimizer][model_state_key]:
+                    # state_dict already contains a record for this optimizer state
+                    # since this optimizer state is sharded, concatenate the optimizer state value
+                    # to the record in the state_dict
+                    state_dict[optimizer][model_state_key][optimizer_key] = \
+                        np.concatenate((state_dict[optimizer][model_state_key][optimizer_key], optimizer_value))
+                else:
+                    # create a new entry for this optimizer state in the state_dict
+                    state_dict[optimizer][model_state_key][optimizer_key] = optimizer_value
+            else:
+                # this optimizer state is not sharded since a record for it does not exist in the partition_info subdict
+                # or this optimizer key is not one of the sharded optimizer keys
+                if optimizer_key in state_dict[optimizer][model_state_key]:
+                    # state_dict already contains a record for this unsharded state.
+                    # assert that all values are the same for this previously loaded optimizr state
+                    assert (state_dict[optimizer][model_state_key][optimizer_key] == optimizer_value).all(), \
+                        "Value mismatch for model state {} and optimizer state {}".format(model_state_key, optimizer_key)
+                else:
+                    # create a new entry for this optimizer state in the state_dict
+                    state_dict[optimizer][model_state_key][optimizer_key] =  optimizer_value
+
+def _reshape_states(sharded_states_original_dims, state_dict):
+    """Reshape model and optimizer states in the state_dict according to dimensions in sharded_states_original_dims"""
+
+    model = _utils.state_dict_model_key()
+    full_precision = _utils.state_dict_full_precision_key()
+    optimizer = _utils.state_dict_optimizer_key()
+    sharded_optimizer_keys = _utils.state_dict_sharded_optimizer_keys()
+
+    for sharded_state_key, original_dim in sharded_states_original_dims.items():
+        # reshape model states to original_dim
+        if model in state_dict:
+            state_dict[model][full_precision][sharded_state_key] = \
+                state_dict[model][full_precision][sharded_state_key].reshape(original_dim)
+
+        # reshape optimizer states to original_dim
+        if optimizer in state_dict:
+            for optimizer_key, optimizer_value in state_dict[optimizer][sharded_state_key].items():
+                if optimizer_key in sharded_optimizer_keys:
+                    state_dict[optimizer][sharded_state_key][optimizer_key] = optimizer_value.reshape(original_dim)
+
+def _aggregate_trainer_options(rank_state_dict, state_dict):
+    """Extracts trainer options from rank_state_dict and loads them accordingly on state_dict"""
+
+    state_dict[_utils.state_dict_trainer_options_key()] = {}
+
+    state_dict[_utils.state_dict_trainer_options_key()]['mixed_precision'] = \
+        rank_state_dict[_utils.state_dict_trainer_options_key()]['mixed_precision']
+    state_dict[_utils.state_dict_trainer_options_key()]['zero_stage'] = 0
+    state_dict[_utils.state_dict_trainer_options_key()]['world_rank'] = 0
+    state_dict[_utils.state_dict_trainer_options_key()]['world_size'] = 1
+    state_dict[_utils.state_dict_trainer_options_key()]['optimizer_name'] = \
+        rank_state_dict[_utils.state_dict_trainer_options_key()]['optimizer_name']
+
+def aggregate_checkpoints(paths, pytorch_format=True):
+    """Aggregate checkpoint files and return a single state dictionary
+
+    Aggregates checkpoint files specified by paths and laods the checkpoint file one at a time merging
+    them into a single state dictionary
+
+    Args:
+        paths: list of more than one file represented as strings where the checkpoint is saved
+        pytorch_format: boolean flag to select either ONNX Runtime or PyTorch state schema
+    Returns:
+        state_dict that can be loaded into an ORTTrainer or into a PyTorch model
+    """
+
+    # order the paths in ascending order of ranks
+    ordered_paths = _order_paths(paths)
+
+    state_dict = {}
+    sharded_states_original_dims = {}
+
+    for rank, path in enumerate(ordered_paths):
+        rank_state_dict = _checkpoint_storage.load(path)
+
+        assert _utils.state_dict_partition_info_key() in rank_state_dict, "Missing information: partition_info"
+        assert _utils.state_dict_trainer_options_key() in rank_state_dict, "Missing information: trainer_options"
+        assert rank == rank_state_dict[_utils.state_dict_trainer_options_key()]['world_rank'], \
+            "Unexpected rank in file at path {}. Expected {}, got {}".\
+                format(path, rank, rank_state_dict[_utils.state_dict_trainer_options_key()]['world_rank'])
+
+        # aggregate all model states
+        _aggregate_model_states(rank_state_dict, sharded_states_original_dims, state_dict)
+
+        # aggregate all optimizer states if pytorch_format is False
+        if not pytorch_format:
+            _aggregate_optimizer_states(rank_state_dict, sharded_states_original_dims, state_dict)
+
+        # entry for trainer_options in the state_dict to perform other sanity checks
+        if _utils.state_dict_trainer_options_key() not in state_dict:
+            _aggregate_trainer_options(rank_state_dict, state_dict)
+
+        # entry for user_dict in the state_dict if not already present
+        if _utils.state_dict_user_dict_key() not in state_dict and \
+            _utils.state_dict_user_dict_key() in rank_state_dict:
+            state_dict[_utils.state_dict_user_dict_key()] = rank_state_dict[_utils.state_dict_user_dict_key()]
+
+    # reshape all the sharded tensors based on the original dimensions stored in sharded_states_original_dims
+    _reshape_states(sharded_states_original_dims, state_dict)
+
+    # return a flat structure for PyTorch model in case pytorch_format is True
+    # else return the hierarchical structure for ORTTrainer
+    return state_dict[_utils.state_dict_model_key()][_utils.state_dict_full_precision_key()] if pytorch_format else state_dict
 
 ################################################################################
 # Helper functions
@@ -201,7 +393,7 @@ class _CombineZeroCheckpoint(object):
         name_split = name.split('_view_')
         view_num = None
         if(len(name_split) > 1):
-            view_num = int(name_split[1])           
+            view_num = int(name_split[1])
         optimizer_key = ''
         mp_suffix = ''
         if name_split[0].startswith('Moment_1'):

--- a/orttraining/orttraining/python/training/checkpoint.py
+++ b/orttraining/orttraining/python/training/checkpoint.py
@@ -123,9 +123,9 @@ def _order_paths(paths):
 
     return ordered_paths
 
-def _add_or_update_sharded_key(state_key, state_value, state_sub_dict,
+def _add_or_update_sharded_key_for_zero(state_key, state_value, state_sub_dict,
                                model_state_key, original_dim, sharded_states_original_dims):
-    """Add or update the record for the sharded_key state_key in the state_sub_dict"""
+    """Add or update the record for the sharded state_key in the state_sub_dict"""
 
     # record the original dimension for this state
     sharded_states_original_dims[model_state_key] = original_dim
@@ -140,8 +140,8 @@ def _add_or_update_sharded_key(state_key, state_value, state_sub_dict,
         # create a new entry for this state in the state_dict
         state_sub_dict[state_key] = state_value
 
-def _add_or_validate_unsharded_key(state_key, state_value, state_sub_dict, mismatch_error_string):
-    """Add or validate the record for the unsharded_key state_key in the state_sub_dict"""
+def _add_or_validate_unsharded_key_for_zero(state_key, state_value, state_sub_dict, mismatch_error_string):
+    """Add or validate the record for the unsharded state_key in the state_sub_dict"""
 
     if state_key in state_sub_dict:
         # state_dict already contains a record for this unsharded state.
@@ -173,12 +173,12 @@ def _aggregate_model_states(rank_state_dict, sharded_states_original_dims, state
     for model_state_key, model_state_value in rank_state_dict[model][full_precision].items():
         if model_state_key in rank_state_dict[partition_info]:
             # this model state is sharded since a record exists in the partition_info subdict
-            _add_or_update_sharded_key(model_state_key, model_state_value,
+            _add_or_update_sharded_key_for_zero(model_state_key, model_state_value,
                 state_dict[model][full_precision], model_state_key,
                 rank_state_dict[partition_info][model_state_key][original_dim], sharded_states_original_dims)
         else:
             # this model state is not sharded since a record for it does not exist in the partition_info subdict
-            _add_or_validate_unsharded_key(model_state_key, model_state_value,
+            _add_or_validate_unsharded_key_for_zero(model_state_key, model_state_value,
                 state_dict[model][full_precision], "Value mismatch for model state {}".format(model_state_key))
 
 def _aggregate_optimizer_states(rank_state_dict, sharded_states_original_dims, state_dict):
@@ -204,13 +204,13 @@ def _aggregate_optimizer_states(rank_state_dict, sharded_states_original_dims, s
 
             if optimizer_key in sharded_optimizer_keys and model_state_key in rank_state_dict[partition_info]:
                 # this optimizer state is sharded since a record exists in the partition_info subdict
-                _add_or_update_sharded_key(optimizer_key, optimizer_value,
+                _add_or_update_sharded_key_for_zero(optimizer_key, optimizer_value,
                     state_dict[optimizer][model_state_key], model_state_key,
                     rank_state_dict[partition_info][model_state_key][original_dim], sharded_states_original_dims)
             else:
                 # this optimizer state is not sharded since a record for it does not exist in the partition_info subdict
                 # or this optimizer key is not one of the sharded optimizer keys
-                _add_or_validate_unsharded_key(optimizer_key, optimizer_value,
+                _add_or_validate_unsharded_key_for_zero(optimizer_key, optimizer_value,
                     state_dict[optimizer][model_state_key],
                     "Value mismatch for model state {} and optimizer state {}".format(model_state_key, optimizer_key))
 

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -1290,10 +1290,9 @@ class ORTTrainer(object):
             # if aggregation is required, aggregation logic must be run on the saved checkpoints
             state_dict = checkpoint.aggregate_checkpoints(paths, pytorch_format=False)
         else:
-            # if aggregation is not required, reorder the checkpoints in order of ascending rank,
-            # and load the checkpoint for the current ORTTrainer rank.
-            ordered_paths = checkpoint._order_paths(paths)
-            state_dict = _checkpoint_storage.load(ordered_paths[0])
+            # if aggregation is not required, there must only be a single file that needs to be loaded
+            assert len(paths) == 1, "Expected number of files to load: 1, got {}".format(len(paths))
+            state_dict = _checkpoint_storage.load(paths[0])
 
         # extract user dict from the saved checkpoint
         user_dict = {}

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -910,7 +910,7 @@ class ORTTrainer(object):
                 type: dict,
                 schema:
                 {
-                    "fp32":
+                    "full_precision":
                     {
                         type: dict,
                         schema:

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -1178,7 +1178,8 @@ class ORTTrainer(object):
         # dictionary
         self._load_optimizer_states(current_state_dict, state_dict)
 
-        return current_state_dict[_utils.state_dict_optimizer_key()]
+        return current_state_dict[_utils.state_dict_optimizer_key()] if \
+            _utils.state_dict_optimizer_key() in current_state_dict else {}
 
     def load_state_dict(self, state_dict, strict=True):
         """Loads state_dict containing model/optimizer states into ORTTrainer
@@ -1202,8 +1203,9 @@ class ORTTrainer(object):
             return
 
         # load states onto the frontend onnx graph
-        state_dict = self._load_state_dict_impl(state_dict, strict=strict)
+        optimizer_state_dict = self._load_state_dict_impl(state_dict, strict=strict)
 
         # create a new training session after loading initializer states onto the onnx graph
         # pass the populated states to the training session to populate the backend graph
-        self._init_session(state_dict)
+        self._init_session(optimizer_state_dict)
+

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -1094,6 +1094,10 @@ class ORTTrainer(object):
             # or can be a regular string (coming from user)
             optimizer_name = \
                 state_dict[_utils.state_dict_trainer_options_key()][_utils.state_dict_trainer_options_optimizer_name_key()]
+
+            # optimizer_name can be either a regular string or a byte string.
+            # if it is a byte string, convert to regular string using decode()
+            # if it is a regular string, do nothing to it
             try:
                 optimizer_name = optimizer_name.decode()
             except AttributeError:

--- a/orttraining/orttraining/test/python/orttraining_test_checkpoint_storage.py
+++ b/orttraining/orttraining/test/python/orttraining_test_checkpoint_storage.py
@@ -8,7 +8,6 @@ import numpy as np
 import os
 import shutil
 import pickle
-import binascii
 
 from onnxruntime.training import _checkpoint_storage
 
@@ -215,7 +214,7 @@ def test_checkpoint_storage_for_custom_user_dict_succeeds(checkpoint_storage_tes
         'custom_class': custom_class
     }
 
-    pickled_bytes = binascii.b2a_hex(pickle.dumps(user_dict))
+    pickled_bytes = pickle.dumps(user_dict).hex()
     to_save = {
         'a': torch.tensor(np.array([1.0, 2.0]), dtype=torch.float32),
         'user_dict': pickled_bytes
@@ -224,7 +223,11 @@ def test_checkpoint_storage_for_custom_user_dict_succeeds(checkpoint_storage_tes
 
     loaded_dict = _checkpoint_storage.load(pytest.checkpoint_path)
     assert (loaded_dict['a'] == to_save['a'].numpy()).all()
-    loaded_obj = pickle.loads(binascii.a2b_hex(loaded_dict['user_dict']))
+    try:
+        loaded_dict['user_dict'] = loaded_dict['user_dict'].decode()
+    except AttributeError:
+        pass
+    loaded_obj = pickle.loads(bytes.fromhex(loaded_dict['user_dict']))
 
     assert torch.all(loaded_obj['tensor1'].eq(user_dict['tensor1']))
     assert loaded_obj['custom_class'] == custom_class

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_checkpoint_functions.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_checkpoint_functions.py
@@ -503,7 +503,7 @@ def test_load_checkpoint(aggregate_checkpoints_mock, load_mock):
     }
     trainer.load_state_dict = Mock()
 
-    load_mock.side_effect = [trainer_options, trainer_options, state_dict]
+    load_mock.side_effect = [trainer_options, state_dict]
     trainer.load_checkpoint('abc')
 
     args_list = load_mock.call_args_list
@@ -511,9 +511,6 @@ def test_load_checkpoint(aggregate_checkpoints_mock, load_mock):
     assert load_args[0] == 'abc'
     assert load_kwargs['key'] == 'trainer_options'
     load_args, load_kwargs = args_list[1]
-    assert load_args[0] == 'abc'
-    assert load_kwargs['key'] == 'trainer_options'
-    load_args, load_kwargs = args_list[2]
     assert load_args[0] == 'abc'
     assert 'key' not in load_kwargs
     assert not aggregate_checkpoints_mock.called
@@ -578,7 +575,7 @@ def test_load_checkpoint_user_dict(aggregate_checkpoints_mock, load_mock):
     }
     trainer.load_state_dict = Mock()
 
-    load_mock.side_effect = [trainer_options, trainer_options, state_dict]
+    load_mock.side_effect = [trainer_options, state_dict]
     user_dict = trainer.load_checkpoint('abc')
 
     assert torch.all(torch.eq(user_dict['array'], torch.tensor(np.arange(5))))

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_checkpoint_functions.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_checkpoint_functions.py
@@ -59,7 +59,7 @@ def _get_load_state_dict_strict_error_arguments():
 
     training_session_state_dict = {
         'model': {
-            'fp32': {
+            'full_precision': {
                 'a': np.arange(5),
                 'b': np.arange(7)
             }
@@ -77,20 +77,20 @@ def _get_load_state_dict_strict_error_arguments():
 
     # input state dictionaries
     precision_key_missing = {'model': {}, 'optimizer': {}}
-    precision_key_unexpected = {'model': {'fp32': {}, 'fp16': {}}, 'optimizer': {}}
-    model_state_key_missing = {'model': {'fp32': {}}, 'optimizer': {}}
-    model_state_key_unexpected = {'model': {'fp32': {'a': 2, 'b': 3, 'c': 4}}, 'optimizer': {}}
-    optimizer_model_state_key_missing = {'model': {'fp32': {'a': 2, 'b': 3}}, 'optimizer': {}}
-    optimizer_model_state_key_unexpected = {'model': {'fp32': {'a': 2, 'b': 3}}, 'optimizer': \
+    precision_key_unexpected = {'model': {'full_precision': {}, 'mixed_precision': {}}, 'optimizer': {}}
+    model_state_key_missing = {'model': {'full_precision': {}}, 'optimizer': {}}
+    model_state_key_unexpected = {'model': {'full_precision': {'a': 2, 'b': 3, 'c': 4}}, 'optimizer': {}}
+    optimizer_model_state_key_missing = {'model': {'full_precision': {'a': 2, 'b': 3}}, 'optimizer': {}}
+    optimizer_model_state_key_unexpected = {'model': {'full_precision': {'a': 2, 'b': 3}}, 'optimizer': \
         {'a': {}, 'shared_optimizer_state': {}, 'b': {}}}
-    optimizer_state_key_missing = {'model': {'fp32': {'a': 2, 'b': 3}}, 'optimizer': \
+    optimizer_state_key_missing = {'model': {'full_precision': {'a': 2, 'b': 3}}, 'optimizer': \
         {'a': {}, 'shared_optimizer_state': {'step': np.arange(5)}}}
-    optimizer_state_key_unexpected = {'model': {'fp32': {'a': 2, 'b': 3}}, 'optimizer': \
+    optimizer_state_key_unexpected = {'model': {'full_precision': {'a': 2, 'b': 3}}, 'optimizer': \
         {'a': {'Moment_1': np.arange(5), 'Moment_2': np.arange(7)}, 'shared_optimizer_state': {'step': np.arange(5), 'another_step': np.arange(1)}}}
 
     input_arguments = [
-        (training_session_state_dict, precision_key_missing, ['fp32']),
-        (training_session_state_dict, precision_key_unexpected, ['fp16']),
+        (training_session_state_dict, precision_key_missing, ['full_precision']),
+        (training_session_state_dict, precision_key_unexpected, ['mixed_precision']),
         (training_session_state_dict, model_state_key_missing, ['a', 'b']),
         (training_session_state_dict, model_state_key_unexpected, ['c']),
         (training_session_state_dict, optimizer_model_state_key_missing, ['a', 'shared_optimizer_state']),
@@ -126,7 +126,7 @@ def test_training_session_provides_empty_model_states(onnx_model_mock):
 def test_training_session_provides_model_states(onnx_model_mock):
     trainer = _create_trainer()
     model_states = {
-        'fp32': {
+        'full_precision': {
             'a': np.arange(5),
             'b': np.arange(7)
         }
@@ -136,14 +136,14 @@ def test_training_session_provides_model_states(onnx_model_mock):
     trainer._onnx_model = onnx_model_mock()
 
     state_dict = trainer.state_dict()
-    assert (state_dict['model']['fp32']['a'] == np.arange(5)).all()
-    assert (state_dict['model']['fp32']['b'] == np.arange(7)).all()
+    assert (state_dict['model']['full_precision']['a'] == np.arange(5)).all()
+    assert (state_dict['model']['full_precision']['b'] == np.arange(7)).all()
 
 @patch('onnx.ModelProto')
 def test_training_session_provides_model_states_pytorch_format(onnx_model_mock):
     trainer = _create_trainer()
     model_states = {
-        'fp32': {
+        'full_precision': {
             'a': np.arange(5),
             'b': np.arange(7)
         }
@@ -160,7 +160,7 @@ def test_training_session_provides_model_states_pytorch_format(onnx_model_mock):
 def test_onnx_graph_provides_frozen_model_states(onnx_model_mock):
     trainer = _create_trainer()
     model_states = {
-        'fp32': {
+        'full_precision': {
             'a': np.arange(5),
             'b': np.arange(7)
         }
@@ -176,11 +176,11 @@ def test_onnx_graph_provides_frozen_model_states(onnx_model_mock):
     ]
 
     state_dict = trainer.state_dict()
-    assert (state_dict['model']['fp32']['a'] == np.arange(5)).all()
-    assert (state_dict['model']['fp32']['b'] == np.arange(7)).all()
-    assert (state_dict['model']['fp32']['a_frozen_weight'] == np.array([1, 2, 3], dtype=np.float32)).all()
-    assert 'a_non_fronzen_weight' not in state_dict['model']['fp32']
-    assert (state_dict['model']['fp32']['a_float16_weight'] == np.array([7, 8, 9], dtype=np.float32)).all()
+    assert (state_dict['model']['full_precision']['a'] == np.arange(5)).all()
+    assert (state_dict['model']['full_precision']['b'] == np.arange(7)).all()
+    assert (state_dict['model']['full_precision']['a_frozen_weight'] == np.array([1, 2, 3], dtype=np.float32)).all()
+    assert 'a_non_fronzen_weight' not in state_dict['model']['full_precision']
+    assert (state_dict['model']['full_precision']['a_float16_weight'] == np.array([7, 8, 9], dtype=np.float32)).all()
 
 @patch('onnx.ModelProto')
 def test_training_session_provides_empty_optimizer_states(onnx_model_mock):
@@ -217,7 +217,7 @@ def test_training_session_provides_optimizer_states(onnx_model_mock):
 def test_training_session_provides_optimizer_states_pytorch_format(onnx_model_mock):
     trainer = _create_trainer()
     model_states = {
-        'fp32': {
+        'full_precision': {
             'a': np.arange(5),
             'b': np.arange(7)
         }
@@ -267,7 +267,7 @@ def test_training_session_provides_partition_info_map(onnx_model_mock):
 def test_training_session_provides_all_states(onnx_model_mock):
     trainer = _create_trainer(zero_enabled=True)
     model_states = {
-        'fp32': {
+        'full_precision': {
             'a': np.arange(5),
             'b': np.arange(7)
         }
@@ -291,8 +291,8 @@ def test_training_session_provides_all_states(onnx_model_mock):
     trainer._onnx_model = onnx_model_mock()
 
     state_dict = trainer.state_dict()
-    assert (state_dict['model']['fp32']['a'] == np.arange(5)).all()
-    assert (state_dict['model']['fp32']['b'] == np.arange(7)).all()
+    assert (state_dict['model']['full_precision']['a'] == np.arange(5)).all()
+    assert (state_dict['model']['full_precision']['b'] == np.arange(7)).all()
     assert (state_dict['optimizer']['model_weight']['Moment_1'] == np.arange(5)).all()
     assert (state_dict['optimizer']['model_weight']['Moment_2'] == np.arange(7)).all()
     assert (state_dict['optimizer']['shared_optimizer_state']['step'] == np.arange(1)).all()
@@ -302,7 +302,7 @@ def test_load_state_dict_holds_when_training_session_not_initialized():
     trainer = _create_trainer()
     state_dict = {
         'model': {
-            'fp32': {
+            'full_precision': {
                 'a': np.arange(5),
                 'b': np.arange(7)
             }
@@ -371,7 +371,7 @@ def test_load_state_dict_loads_the_states_and_inits_training_session(onnx_model_
     trainer = _create_trainer()
     training_session_state_dict = {
         'model': {
-            'fp32': {
+            'full_precision': {
                 'a': np.arange(5),
                 'b': np.arange(7)
             }
@@ -389,7 +389,7 @@ def test_load_state_dict_loads_the_states_and_inits_training_session(onnx_model_
 
     input_state_dict = {
         'model': {
-            'fp32': {
+            'full_precision': {
                 'a': np.array([1, 2]),
                 'b': np.array([3, 4])
             }
@@ -602,7 +602,7 @@ def test_checkpoint_aggregation(load_mock):
 
     state_dict1 = {
         'model': {
-            'fp32': {
+            'full_precision': {
                 'sharded': np.array([1, 2, 3]),
                 'non_sharded': np.array([11, 22, 33])
             }
@@ -633,7 +633,7 @@ def test_checkpoint_aggregation(load_mock):
 
     state_dict2 = {
         'model': {
-            'fp32': {
+            'full_precision': {
                 'sharded': np.array([4, 5, 6]),
                 'non_sharded': np.array([11, 22, 33])
             }
@@ -665,8 +665,8 @@ def test_checkpoint_aggregation(load_mock):
     load_mock.side_effect = [trainer_options1, trainer_options2, state_dict1, state_dict2]
     state_dict = checkpoint.aggregate_checkpoints(['abc', 'def'], pytorch_format=False)
 
-    assert (state_dict['model']['fp32']['sharded'] == np.array([[1, 2, 3], [4, 5, 6]])).all()
-    assert (state_dict['model']['fp32']['non_sharded'] == np.array([11, 22, 33])).all()
+    assert (state_dict['model']['full_precision']['sharded'] == np.array([[1, 2, 3], [4, 5, 6]])).all()
+    assert (state_dict['model']['full_precision']['non_sharded'] == np.array([11, 22, 33])).all()
     assert (state_dict['optimizer']['sharded']['Moment_1'] == np.array([[9, 8, 7], [6, 5, 4]])).all()
     assert (state_dict['optimizer']['sharded']['Moment_2'] == np.array([[99, 88, 77], [66, 55, 44]])).all()
     assert (state_dict['optimizer']['sharded']['Step'] == np.array([5])).all()


### PR DESCRIPTION
**Description**:
Implementation of three functions is added in this pull request:
- ```save_checkpoint``` to save the ```state_dict``` to disk.
- ```load_checkpoint``` to load ```state_dict``` from disk.
- ```aggregate_checkpoints``` to aggregate multiple checkpoints into a single ```state_dict```.

**Motivation and Context**
- Why is this change required? What problem does it solve?
This work is a part of the checkpoint redesign.