### PR TITLE
Fix CUDA test hang

### DIFF
--- a/onnxruntime/test/framework/cuda/allocator_cuda_test.cc
+++ b/onnxruntime/test/framework/cuda/allocator_cuda_test.cc
@@ -12,6 +12,10 @@ namespace onnxruntime {
 namespace test {
 TEST(AllocatorTest, CUDAAllocatorTest) {
   OrtDevice::DeviceId cuda_device_id = 0;
+
+  // ensure CUDA device is avaliable.
+  CUDA_CALL_THROW(cudaSetDevice(cuda_device_id));
+
   AllocatorCreationInfo default_memory_info(
       {[](OrtDevice::DeviceId id) { return onnxruntime::make_unique<CUDAAllocator>(id, CUDA); }, cuda_device_id});
 


### PR DESCRIPTION
**Description**: Describe your changes.

Fix bug: CUDA test hang without GPU as described in #4656 

**Motivation and Context**
- Why is this change required? What problem does it solve?
  Test case `AllocatorTest.CUDAAllocatorTest` falls in infinite loop if build machine has no GPU in Release build.

  To solve this issue, a `cudaSetDevice` call is added to ensure the cuda device is available.

- If it fixes an open issue, please link to the issue here.

  #4656 