### PR TITLE
remove dnnl_dll_path from tensorrt ep python post build copy

### DIFF
--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -339,7 +339,7 @@ if (onnxruntime_USE_TENSORRT)
   add_custom_command(
     TARGET onnxruntime_pybind11_state POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
-        ${DNNL_DLL_PATH} $<TARGET_FILE:onnxruntime_providers_tensorrt>
+        $<TARGET_FILE:onnxruntime_providers_tensorrt>
         $<TARGET_FILE:onnxruntime_providers_shared>
         $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/capi/
   )


### PR DESCRIPTION
tensorrt ep python post build command shouldn't reference dnnl_dll_path , which was a copy/paste mistake.