### PR TITLE
Remove ignored build warnings for pybind on Mac

### DIFF
--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -74,15 +74,6 @@ if (onnxruntime_ENABLE_TRAINING)
   target_include_directories(onnxruntime_pybind11_state PRIVATE ${ORTTRAINING_ROOT})
 endif()
 
-# Disable certain pybind11 warnings while building using AppleClang 12 on macOS
-# TODO, remove this after switch to pybind11 2.6.0+
-if(APPLE AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.0)
-  # https://github.com/pybind/pybind11/pull/2522
-  target_compile_options(onnxruntime_pybind11_state PRIVATE "-Wno-range-loop-analysis")
-  # https://github.com/pybind/pybind11/pull/2294
-  target_compile_options(onnxruntime_pybind11_state PRIVATE "-Wno-unused-value")
-endif()
-
 if(APPLE)
   set(ONNXRUNTIME_SO_LINK_FLAG "-Xlinker -exported_symbols_list ${ONNXRUNTIME_ROOT}/python/exported_symbols.lst")
 elseif(UNIX)


### PR DESCRIPTION
**Description**: Remove ignored build warnings for pybind on Mac

**Motivation and Context**
- #5874 updated the pybind to 2.6.1, so we don't need to ignore build warnings added by #5381, and close this PBI https://msdata.visualstudio.com/Vienna/_workitems/edit/920214
