### PR TITLE
Don't try to bind unused inputs in the Training frontend

### DIFF
--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -804,7 +804,7 @@ class ORTTrainer(object):
         else:
             iobinding = self._eval_io_binding
 
-        # Get the list of rhe actual session inputs because unused inputs can be removed.
+        # Get the list of the actual session inputs because unused inputs can be removed.
         input_nodes = self._training_session.get_inputs()
         input_node_names = [input_node.name for input_node in input_nodes]
 

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -805,7 +805,7 @@ class ORTTrainer(object):
             iobinding = self._eval_io_binding
 
         # Get the list of session input because unused inputs can be removed.
-        input_nodes = self._training_session.get_inputs())
+        input_nodes = self._training_session.get_inputs()
         print("*"*10)
         for input_node in input_nodes:
             print(node.name)

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -808,7 +808,7 @@ class ORTTrainer(object):
         input_nodes = self._training_session.get_inputs()
         print("*"*10)
         for input_node in input_nodes:
-            print(node.name)
+            print(input_node.name)
 
         # Bind input tensors
         for input, input_desc in zip(inputs, inputs_desc):

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -804,7 +804,12 @@ class ORTTrainer(object):
         else:
             iobinding = self._eval_io_binding
 
-        print("x"*10, ": ", self._training_session.get_inputs())
+        # Get the list of session input because unused inputs can be removed.
+        input_nodes = self._training_session.get_inputs())
+        print("*"*10)
+        for input_node in input_nodes:
+            print(node.name)
+
         # Bind input tensors
         for input, input_desc in zip(inputs, inputs_desc):
             device_index = _utils.get_device_index_from_input(input)

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -804,7 +804,7 @@ class ORTTrainer(object):
         else:
             iobinding = self._eval_io_binding
 
-        print(self._training_session.get_inputs(self))
+        print("x"*10, ": ", self._training_session.get_inputs())
         # Bind input tensors
         for input, input_desc in zip(inputs, inputs_desc):
             device_index = _utils.get_device_index_from_input(input)

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -804,21 +804,20 @@ class ORTTrainer(object):
         else:
             iobinding = self._eval_io_binding
 
-        # Get the list of session input because unused inputs can be removed.
+        # Get the list of rhe actual session inputs because unused inputs can be removed.
         input_nodes = self._training_session.get_inputs()
-        print("*"*10)
-        for input_node in input_nodes:
-            print(input_node.name)
+        input_node_names = [input_node.name for input_node in input_nodes]
 
         # Bind input tensors
         for input, input_desc in zip(inputs, inputs_desc):
-            device_index = _utils.get_device_index_from_input(input)
-            iobinding.bind_input(input_desc.name,
-                                 input.device.type,
-                                 device_index,
-                                 _utils.dtype_torch_to_numpy(input.dtype),
-                                 list(input.size()),
-                                 input.data_ptr())
+            if input_desc.name in input_node_names:
+                device_index = _utils.get_device_index_from_input(input)
+                iobinding.bind_input(input_desc.name,
+                                    input.device.type,
+                                    device_index,
+                                    _utils.dtype_torch_to_numpy(input.dtype),
+                                    list(input.size()),
+                                    input.data_ptr())
 
         # Bind output tensors
         outputs_desc_resolved = self._resolve_symbolic_dimensions(inputs, inputs_desc, outputs_desc)

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -804,6 +804,7 @@ class ORTTrainer(object):
         else:
             iobinding = self._eval_io_binding
 
+        print(self._training_session.get_inputs(self))
         # Bind input tensors
         for input, input_desc in zip(inputs, inputs_desc):
             device_index = _utils.get_device_index_from_input(input)

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -1432,7 +1432,7 @@ def testORTTrainerOptionsDisabledAdasumFlag(test_input):
 def testORTTrainerUnusedInput():
     class UnusedInputModel(torch.nn.Module):
         def __init__(self):
-            super(Net, self).__init__()
+            super(UnusedInputModel, self).__init__()
         def forward(self, x, y):
             return torch.mean(x)
 

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -1445,4 +1445,4 @@ def testORTTrainerUnusedInput():
     try:
         trainer.train_step(torch.FloatTensor([1.0]), torch.FloatTensor([1.0]))
     except RuntimeError:
-        self.fail("RuntimeError doing train_step with unused input.")
+        pytest.fail("RuntimeError doing train_step with unused input.")

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -1445,4 +1445,4 @@ def testORTTrainerUnusedInput():
     try:
         trainer.train_step(torch.FloatTensor([1.0]), torch.FloatTensor([1.0]))
     except RuntimeError:
-        pytest.fail("RuntimeError doing train_step with unused input.")
+        pytest.fail("RuntimeError doing train_step with an unused input.")

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -1428,3 +1428,17 @@ def testORTTrainerOptionsDisabledAdasumFlag(test_input):
 
     actual_values = orttrainer_options.ORTTrainerOptions(test_input)
     assert actual_values.distributed.enable_adasum == False
+
+def testORTTrainerUnusedInput():
+    class UnusedInputModel(torch.nn.Module):
+        def __init__(self):
+            super(Net, self).__init__()
+        def forward(self, x, y):
+            return torch.mean(x)
+
+    model = UnusedInputModel()
+    model_desc = {'inputs': [('x', [1]), ('y', [1])], 'outputs': [('loss', [], True)]}
+    optim_config = optim.LambConfig(lr=0.001)
+    trainer = orttrainer.ORTTrainer(model, model_desc, optim_config)
+    # Run just one step to make sure there are no iobinding errors for the unused input.
+    trainer.train_step(torch.FloatTensor([1.0]), torch.FloatTensor([1.0]))

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -1440,5 +1440,9 @@ def testORTTrainerUnusedInput():
     model_desc = {'inputs': [('x', [1]), ('y', [1])], 'outputs': [('loss', [], True)]}
     optim_config = optim.LambConfig(lr=0.001)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config)
+
     # Run just one step to make sure there are no iobinding errors for the unused input.
-    trainer.train_step(torch.FloatTensor([1.0]), torch.FloatTensor([1.0]))
+    try:
+        trainer.train_step(torch.FloatTensor([1.0]), torch.FloatTensor([1.0]))
+    except RuntimeError:
+        self.fail("RuntimeError doing train_step with unused input.")


### PR DESCRIPTION
A PyTorch model can have inputs that don't affect the output.
Such inputs are removed from the ORT graph as an optimization.
Now, the training frontend still tries to bind such inputs, which leads to errors.
This PR make the frontend bind only actual graph inputs.