### PR TITLE
Tune fast Gelu to use exp(x) instead of tanh(x) on Rocm platform

### DIFF
--- a/onnxruntime/contrib_ops/rocm/bert/fast_gelu_impl.cu
+++ b/onnxruntime/contrib_ops/rocm/bert/fast_gelu_impl.cu
@@ -39,6 +39,9 @@ constexpr float B = 0.7978845608028654;  // sqrt(2.0/M_PI)
 
 constexpr float C = 0.035677408136300125;  // 0.044715 * sqrt(2.0/M_PI)
 
+constexpr float one = 1.0;
+constexpr float two = 2.0;
+
 template <typename T, unsigned TPB>
 __global__ void FastGeluKernel(const T a, const T b, const T c, int input_length, int bias_length, const T* input, const T* bias, T* output) {
   const int idx = blockIdx.x * TPB + threadIdx.x;
@@ -55,10 +58,17 @@ template <unsigned TPB>
 __global__ void FastGeluKernel2(const half2 a, const half2 b, const half2 c, int input_length, int bias_length, const half2* input, const half2* bias, half2* output) {
   const int idx = blockIdx.x * TPB + threadIdx.x;
 
+  const half2 two2 = __floats2half2_rn(two, two);
+  const half2 one2 = __floats2half2_rn(one, one);
+
   if (idx < input_length) {
     const half2 x = input[idx];
     const half2 in = (bias == nullptr) ? x : (x + bias[idx % bias_length]);
-    const half2 cdf = a + a * _Tanh(in * (c * in * in + b));
+
+    //  const half2 cdf = a + a * _Tanh(in * (c * in * in + b));
+    const half2 u = two2 * in * (c * in * in + b);
+    const half2 eu = h2exp(u);
+    const half2 cdf = a + a * (eu - one2)/(eu + one2);
     output[idx] = in * cdf;
   }
 }


### PR DESCRIPTION
For now tanh(...) fn is slow on Rocm platform. Use exp(...) fn instead.

![image](https://user-images.githubusercontent.com/4366369/102799976-13a25e80-4368-11eb-922d-e94ae8c5880a.png)

