### PR TITLE
Improvements to quantizer: Removed unused qType field, add reshape op

### DIFF
--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -531,6 +531,10 @@ class ONNXQuantizer:
         Quantized the bias. Zero Point == 0 and Scale == Input_Scale * Weight_Scale
         '''
 
+        # Handle case where bias already in quantizatio map
+        if bias_name in self.quantized_value_map:
+            return self.quantized_value_map[bias_name].q_name
+
         # get scale for weight
         weight_scale_name = self.quantized_value_map[weight_name].scale_name
         weight_initializer = find_by_name(weight_scale_name, self.model.initializer())

--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -575,8 +575,7 @@ class ONNXQuantizer:
 
         assert (bias_name not in self.quantized_value_map)
         quantized_value = QuantizedValue(bias_name, quantized_bias_name, quantized_bias_scale_name, "",
-                                         QuantizedValueType.Initializer, 0 if bias_scale_data.size > 1 else None,
-                                         onnx_proto.TensorProto.INT32)
+                                         QuantizedValueType.Initializer, 0 if bias_scale_data.size > 1 else None)
         self.quantized_value_map[bias_name] = quantized_value
 
         return quantized_bias_name
@@ -668,7 +667,7 @@ class ONNXQuantizer:
 
         # Log entry for this quantized weight
         quantized_value = QuantizedValue(weight.name, q_weight_name, scale_name, zp_name,
-                                         QuantizedValueType.Initializer, None, qType)
+                                         QuantizedValueType.Initializer, None)
         self.quantized_value_map[weight.name] = quantized_value
 
         return q_weight_name, zp_name, scale_name
@@ -714,7 +713,7 @@ class ONNXQuantizer:
         scale_name = weight_name + "_scale"
 
         quantized_value = QuantizedValue(weight_name, q_weight_name, scale_name, zp_name,
-                                         QuantizedValueType.Initializer, None, weight_qType)
+                                         QuantizedValueType.Initializer, None)
         self.quantized_value_map[weight_name] = quantized_value
 
         # Update packed weight, zero point, and scale initializers

--- a/onnxruntime/python/tools/quantization/operators/gavgpool.py
+++ b/onnxruntime/python/tools/quantization/operators/gavgpool.py
@@ -24,7 +24,7 @@ class QGlobalAveragePool(QuantOperatorBase):
         output_scale_name = output_scale_name_from_parameter if data_found else quantized_input_value.scale_name
         output_zp_name = output_zp_name_from_parameter if data_found else quantized_input_value.zp_name
         quantized_output_value = QuantizedValue(node.output[0], node.output[0] + "_quantized", output_scale_name,
-                                                output_zp_name, quantized_input_value.qType)
+                                                output_zp_name)
         self.quantizer.quantized_value_map[node.output[0]] = quantized_output_value
 
         kwargs = {}

--- a/onnxruntime/python/tools/quantization/operators/pad.py
+++ b/onnxruntime/python/tools/quantization/operators/pad.py
@@ -39,7 +39,7 @@ class QPad(QuantOperatorBase):
                     scale_array = onnx.numpy_helper.to_array(scale_tensor)
                     scale_value = scale_array.item() if scale_array.ndim == 0 else scale_array[0]
                     padding_constant_array = onnx.numpy_helper.to_array(padding_constant_initializer)
-                    quantized_padding_constant_array = quantize_nparray(quantized_input_value.qType,
+                    quantized_padding_constant_array = quantize_nparray(self.quantizer.input_qType,
                                                                         padding_constant_array, scale_value, zp_value)
                     quantized_padding_constant_name = node.input[2] + "_quantized"
                     quantized_padding_constant_initializer = onnx.numpy_helper.from_array(
@@ -49,7 +49,7 @@ class QPad(QuantOperatorBase):
                     self.quantizer.model.add_initializer(quantized_padding_constant_initializer)
                     node.input[2] = quantized_padding_constant_name
                 else:
-                    pad_value_qnodes = self.quantizer._get_quantize_input_nodes(node, 2, quantized_input_value.qType,
+                    pad_value_qnodes = self.quantizer._get_quantize_input_nodes(node, 2, self.quantizer.input_qType,
                                                                                 quantized_input_value.scale_name,
                                                                                 quantized_input_value.zp_name)
                     self.quantizer.new_nodes += [pad_value_qnodes]

--- a/onnxruntime/python/tools/quantization/operators/reshape.py
+++ b/onnxruntime/python/tools/quantization/operators/reshape.py
@@ -1,0 +1,31 @@
+import onnx
+from .base_operator import QuantOperatorBase
+from ..quant_utils import QuantizedValue, QuantizedValueType
+from onnx import onnx_pb as onnx_proto
+
+
+class ReshapeQuant(QuantOperatorBase):
+    def __init__(self, onnx_quantizer, onnx_node):
+        super().__init__(onnx_quantizer, onnx_node)
+
+    def quantize(self):
+        node = self.node
+        assert (node.op_type == "Reshape")
+
+        # If input to this node is not quantized then keep this node
+        if node.input[0] not in self.quantizer.quantized_value_map:
+            self.quantizer.new_nodes += [node]
+            return
+
+        # Reshape is a no-op in terms of quantization
+        quantized_input_value = self.quantizer.quantized_value_map[node.input[0]]
+        quantized_output_value = QuantizedValue(node.output[0], node.output[0] + "_quantized",
+                                                quantized_input_value.scale_name, quantized_input_value.zp_name,
+                                                QuantizedValueType.Input)
+        # Create an entry for output quantized value
+        self.quantizer.quantized_value_map[node.output[0]] = quantized_output_value
+
+        node.input[0] = quantized_input_value.q_name
+        node.output[0] = quantized_output_value.q_name
+        self.quantizer.new_nodes += [node]
+

--- a/onnxruntime/python/tools/quantization/qdq_quantizer.py
+++ b/onnxruntime/python/tools/quantization/qdq_quantizer.py
@@ -134,7 +134,7 @@ class QDQQuantizer(ONNXQuantizer):
                 self.model.add_nodes([qlinear_node, dequant_node])
 
                 quantized_value = QuantizedValue(tensor_name, tensor_name + "_QuantizeLinear", scale_name, zp_name,
-                                                 QuantizedValueType.Input, None, self.input_qType)
+                                                 QuantizedValueType.Input)
                 self.quantized_value_map[tensor_name] = quantized_value
 
     def quantize_bias_tensors(self):

--- a/onnxruntime/python/tools/quantization/registry.py
+++ b/onnxruntime/python/tools/quantization/registry.py
@@ -13,8 +13,11 @@ from .operators.gavgpool import QGlobalAveragePool
 from .operators.lstm import LSTMQuant
 from .operators.split import QSplit
 from .operators.pad import QPad
+from .operators.reshape import ReshapeQuant
 
-CommonOpsRegistry = {"Gather": GatherQuant, "EmbedLayerNormalization": EmbedLayerNormalizationQuant}
+CommonOpsRegistry = {"Gather": GatherQuant,
+                     "EmbedLayerNormalization": EmbedLayerNormalizationQuant,
+                     "Reshape": ReshapeQuant}
 
 IntegerOpsRegistry = {
     "Conv": ConvInteger,

--- a/onnxruntime/test/python/quantization/test_op_reshape.py
+++ b/onnxruntime/test/python/quantization/test_op_reshape.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+# coding: utf-8
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import unittest
+import onnx
+import numpy as np
+from onnx import helper, TensorProto
+from onnxruntime.quantization import quantize_static
+from op_test_utils import TestDataFeeds, check_model_correctness, check_op_type_count
+
+class TestOpReshape(unittest.TestCase):
+    def input_feeds(self, n, name2shape):
+        input_data_list = []
+        for i in range(n):
+            inputs = {}
+            for name, shape in name2shape.items():
+                inputs.update({name: np.random.randint(-1, 2, shape).astype(np.float32)})
+            input_data_list.extend([inputs])
+        dr = TestDataFeeds(input_data_list)
+        return dr
+
+    def construct_model_matmul_reshape(self, output_model_path, input_shape, weight_shape, output_shape):
+        #    (input)
+        #      |
+        #     MatMul
+        #      |
+        #    Reshape
+        #      |
+        #    (output)
+        input_name = 'input'
+        output_name = 'output'
+        initializers = []
+
+        # make MatMul node
+        weight_name = 'matmul_weight'
+        matmul_output_name = 'matmul_output'
+        matmul_inputs = [input_name, weight_name]
+        matmul_outputs = [matmul_output_name]
+        matmul_name = 'matmul_node'
+        matmul_weight_data = np.random.normal(0, 0.1, weight_shape).astype(np.float32)
+        initializers.append(onnx.numpy_helper.from_array(matmul_weight_data, name=weight_name))
+
+        matmul_node = onnx.helper.make_node('MatMul', matmul_inputs, matmul_outputs, name=matmul_name)
+
+        # make Reshape node
+        reshape_shape = 'reshape_shape'
+        reshape_inputs = [matmul_output_name, reshape_shape]
+        reshape_output = [output_name]
+        reshape_name = 'reshape_node'
+        initializers.append(onnx.numpy_helper.from_array(np.array(output_shape, dtype=np.int64), name=reshape_shape))
+        reshape_node = onnx.helper.make_node('Reshape', reshape_inputs, reshape_output, name=reshape_name)
+
+
+        # make graph
+        input_tensor = helper.make_tensor_value_info(input_name, TensorProto.FLOAT, input_shape)
+        output_tensor = helper.make_tensor_value_info(output_name, TensorProto.FLOAT, output_shape)
+        graph_name = 'Reshape_Quant_Test'
+        graph = helper.make_graph([matmul_node, reshape_node], graph_name,
+                                  [input_tensor], [output_tensor], initializer=initializers)
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 11)])
+        model.ir_version = onnx.IR_VERSION
+
+        onnx.save(model, output_model_path)
+
+    def test_quantize_reshape(self):
+        np.random.seed(1)
+        model_fp32_path = 'reshape_fp32.onnx'
+        model_uint8_path = 'reshape_uint8.onnx'
+        data_reader = self.input_feeds(1, {'input': [3, 7]})
+        self.construct_model_matmul_reshape(model_fp32_path,
+                                  [3, 7],
+                                  [7, 3],
+                                  [1, 9])
+        quantize_static(model_fp32_path,
+                        model_uint8_path,
+                        data_reader
+                        )
+        data_reader.rewind()
+        qdq_nodes = {'QLinearMatMul': 1, 'QuantizeLinear': 1, 'DequantizeLinear': 1, 'Reshape': 1}
+        check_op_type_count(self, model_uint8_path, **qdq_nodes)
+        check_model_correctness(self, model_fp32_path, model_uint8_path, data_reader.get_next())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* Remove the unused `qType` field. This was always set to `uint8` anyway, which was incorrect for `int8` quantization.
* Fix case when quantized bias already present in quantizer map
* Support for Reshape op added, which is a passthrough (no-op in terms of quantization).