### PR TITLE
Implement comparing outputs that are sequence of maps of strings to floats

### DIFF
--- a/winml/test/model/compare_feature_value.cpp
+++ b/winml/test/model/compare_feature_value.cpp
@@ -5,7 +5,7 @@
 #include "ort_value_helper.h"
 
 using namespace winrt::Windows::Foundation::Collections;
-using namespace winrt::Windows::AI::MachineLearning;
+using namespace winml;
 
 namespace CompareFeatureValuesHelper{
 
@@ -63,7 +63,7 @@ bool CompareSequenceOfMapsStringToFloat(
     }
     expectedValSequenceIndex++;
   }
-  // If errors or discrepancies found, then return true
+  // If errors or discrepancies are not found, then return true
   return true;
 }
 

--- a/winml/test/model/compare_feature_value.cpp
+++ b/winml/test/model/compare_feature_value.cpp
@@ -1,0 +1,70 @@
+#include "testPch.h"
+#include "compare_feature_value.h"
+#include "StringHelpers.h"
+#include <core/framework/ml_value.h>
+#include "ort_value_helper.h"
+
+using namespace winrt::Windows::Foundation::Collections;
+using namespace winrt::Windows::AI::MachineLearning;
+
+namespace CompareFeatureValuesHelper{
+
+template <typename T>
+bool IsResultCloselyMatch(const T& outvalue, const T& expected_value, const double diff, const double tol) {
+  if (diff > tol) return false;
+  if (std::isnan(diff) && !(std::isnan(outvalue) && std::isnan(expected_value)) &&
+      !(std::isinf(outvalue) && std::isinf(expected_value)))
+    return false;
+  return true;
+}
+
+bool CompareSequenceOfMapsStringToFloat(
+    IVectorView<IMap<winrt::hstring, float>> featureValue,
+    const Ort::Value& val,
+    double perSampleTolerance,
+    double relativePerSampleTolerance) {
+  if (val.GetCount() != featureValue.Size()) {
+    printf("Map lengths are not the same! Got %d, expected %d\n", static_cast<int>(featureValue.Size()), static_cast<int>(val.GetCount()));
+  }
+
+  int expectedValSequenceIndex = 0;
+  Ort::AllocatorWithDefaultOptions allocator;
+  for (IMap<winrt::hstring, float> mapVal : featureValue) {
+    std::map<winrt::hstring, float> expectedKvp;
+    std::vector<std::pair<winrt::hstring, float>> actualKvp;
+
+    Ort::Value mapExpectedOutput(nullptr);
+    Ort::Value mapExpectedOutputKeys(nullptr);
+    Ort::Value mapExpectedOutputValues(nullptr);
+    WINML_EXPECT_NO_THROW(mapExpectedOutput = val.GetValue(expectedValSequenceIndex, allocator));
+    WINML_EXPECT_NO_THROW(mapExpectedOutputKeys = mapExpectedOutput.GetValue(0, allocator));
+    WINML_EXPECT_NO_THROW(mapExpectedOutputValues = mapExpectedOutput.GetValue(1, allocator));
+
+    auto expectedOutputKeys = OrtValueHelpers::LoadTensorFromOrtValue(mapExpectedOutputKeys).as<TensorString>().GetAsVectorView();
+    auto expectedOutputValues = OrtValueHelpers::LoadTensorFromOrtValue(mapExpectedOutputValues).as<TensorFloat>().GetAsVectorView();
+    for (uint32_t i = 0; i < expectedOutputKeys.Size(); i++) {
+      expectedKvp[expectedOutputKeys.GetAt(i)] = expectedOutputValues.GetAt(i);
+    }
+    for (auto kvp : mapVal) {
+      winrt::hstring actualKey = kvp.Key();
+      float actualValue = kvp.Value();
+      if (expectedKvp.find(actualKey) == expectedKvp.end()) {
+        printf("Unexpected key in actual output: %ws", actualKey.c_str());
+        return false;
+      } else {
+        // verify that the value is within tolerable ranges
+        const double diff = std::fabs(expectedKvp[actualKey] - actualValue);
+        const double tol = perSampleTolerance + relativePerSampleTolerance * std::fabs(expectedKvp[actualKey]);
+        if (!IsResultCloselyMatch<double>(actualValue, expectedKvp[actualKey], diff, tol)) {
+          printf("expected (%f), actual (%f), diff: %f, tol= %f .\n", expectedKvp[actualKey], actualValue, diff, tol);
+          return false;
+        }
+      }
+    }
+    expectedValSequenceIndex++;
+  }
+  // If errors or discrepancies found, then return true
+  return true;
+}
+
+}

--- a/winml/test/model/compare_feature_value.h
+++ b/winml/test/model/compare_feature_value.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "testPch.h"
+#include "onnxruntime_cxx_api.h"
+
+namespace CompareFeatureValuesHelper {
+bool CompareSequenceOfMapsStringToFloat(
+    winrt::Windows::Foundation::Collections::IVectorView<winrt::Windows::Foundation::Collections::IMap<winrt::hstring, float>> featureValue,
+    const Ort::Value& val,
+    double per_sample_tolerance,
+    double relative_per_sample_tolerance);
+}

--- a/winml/test/model/ort_value_helper.cpp
+++ b/winml/test/model/ort_value_helper.cpp
@@ -203,10 +203,11 @@ Ort::Value CreateOrtValueFromITensor(winml::ITensor winmlTensor) {
             shape.size(),
             ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING));
     std::vector<const char*> strData;
+    std::vector<std::string> utf8Strs;
     auto strValues = winmlTensor.as<TensorString>().GetAsVectorView();
     for (winrt::hstring str : strValues) {
-      std::string utf8Str = _winml::Strings::UTF8FromHString(str);
-      strData.push_back(utf8Str.c_str());
+      utf8Strs.push_back(std::move(_winml::Strings::UTF8FromHString(str)));
+      strData.push_back(utf8Strs.back().c_str());
     }
     WINML_EXPECT_NO_THROW(ortValueCreated.FillStringTensor(strData.data(), strData.size()));
   }

--- a/winml/test/model/ort_value_helper.cpp
+++ b/winml/test/model/ort_value_helper.cpp
@@ -2,7 +2,7 @@
 #include "ort_value_helper.h"
 #include "StringHelpers.h"
 using namespace winml;
-
+using namespace winrt::Windows::Foundation::Collections;
 namespace OrtValueHelpers {
 
 template <ONNXTensorElementDataType T>
@@ -135,5 +135,81 @@ winml::ITensor LoadTensorFromOrtValue(Ort::Value& val) {
   WINML_EXPECT_NO_THROW(Ort::GetApi().GetTensorMutableData(val, &ortValueTensorData));
   WINML_EXPECT_NO_THROW(memcpy(actualData, ortValueTensorData, actualSizeInBytes * sizeof(char)));
   return tensor;
+}
+
+static ONNXTensorElementDataType OnnxTensorTypeFromWinMLType(winml::TensorKind tensorKind) {
+    switch (tensorKind) {
+    case (TensorKind::Float):
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+    case (TensorKind::UInt8):
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
+    case (TensorKind::Int8):
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8;
+    case (TensorKind::UInt16):
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16;
+    case (TensorKind::Int16):
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16;
+    case (TensorKind::Int32):
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
+    case (TensorKind::Int64):
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
+    case (TensorKind::Boolean):
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL;
+    case (TensorKind::Float16):
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16;
+    case (TensorKind::Double):
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE;
+    case (TensorKind::UInt32):
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32;
+    case (TensorKind::UInt64):
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64;
+    case (TensorKind::Complex64):
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64;
+    case (TensorKind::Complex128):
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128;
+    default:
+      throw std::invalid_argument("No conversion from WinML Type into Onnx TensorType");
+  }
+}
+
+Ort::Value CreateOrtValueFromITensor(winml::ITensor winmlTensor) {
+  Ort::Value ortValueCreated = Ort::Value{nullptr};
+  auto memoryInfo = Ort::MemoryInfo{nullptr};
+  WINML_EXPECT_NO_THROW(memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault));
+  std::vector<int64_t> shape;
+  auto vectorViewShape = winmlTensor.Shape();
+  for (int64_t dimension : vectorViewShape) {
+    shape.push_back(dimension);
+  }
+  if (winmlTensor.TensorKind() != winml::TensorKind::String) {
+    auto winmlTensorNative = winmlTensor.as<ITensorNative>();
+    BYTE* actualData;
+    uint32_t actualSizeInBytes;
+    WINML_EXPECT_HRESULT_SUCCEEDED(winmlTensorNative->GetBuffer(&actualData, &actualSizeInBytes));
+    WINML_EXPECT_NO_THROW(
+        ortValueCreated = Ort::Value::CreateTensor(
+            memoryInfo,
+            actualData,
+            actualSizeInBytes,
+            shape.data(),
+            shape.size(), 
+            OnnxTensorTypeFromWinMLType(winmlTensor.TensorKind())));
+  } else {
+    Ort::AllocatorWithDefaultOptions allocator;
+    WINML_EXPECT_NO_THROW(
+        ortValueCreated = Ort::Value::CreateTensor(
+            allocator,
+            shape.data(),
+            shape.size(),
+            ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING));
+    std::vector<const char*> strData;
+    auto strValues = winmlTensor.as<TensorString>().GetAsVectorView();
+    for (winrt::hstring str : strValues) {
+      std::string utf8Str = _winml::Strings::UTF8FromHString(str);
+      strData.push_back(utf8Str.c_str());
+    }
+    WINML_EXPECT_NO_THROW(ortValueCreated.FillStringTensor(strData.data(), strData.size()));
+  }
+  return ortValueCreated;
 }
 }  // namespace OrtValueHelpers

--- a/winml/test/model/ort_value_helper.h
+++ b/winml/test/model/ort_value_helper.h
@@ -3,6 +3,8 @@
 
 namespace OrtValueHelpers {
 winml::ITensor LoadTensorFromOrtValue(Ort::Value& val);
+
+Ort::Value CreateOrtValueFromITensor(winml::ITensor winmlTensor);
 }
 
 template <ONNXTensorElementDataType T>

--- a/winml/test/model/skip_model_tests.h
+++ b/winml/test/model/skip_model_tests.h
@@ -8,15 +8,6 @@ static const std::string disabledGpuTestDefaultReason = "Model not working on GP
 // {"model test name", "reason for why it is happening and bug filed for it."}
 std::unordered_map<std::string, std::string> disabledTests(
     {
-     // Tier 2 models
-     {"coreml_VGG16_ImageNet_opset8", "Bug 31011100: Processing string tensors need to be implemented in WinML model tests https://microsoft.visualstudio.com/OS/_workitems/edit/31011100"},
-     {"coreml_VGG16_ImageNet_opset9", "Bug 31011100: Processing string tensors need to be implemented in WinML model tests https://microsoft.visualstudio.com/OS/_workitems/edit/31011100"},
-     {"coreml_Resnet50_opset9", "Bug 31011100: Processing string tensors need to be implemented in WinML model tests https://microsoft.visualstudio.com/OS/_workitems/edit/31011100"},
-     {"coreml_inceptionv3_opset9", "Bug 31011100: Processing string tensors need to be implemented in WinML model tests https://microsoft.visualstudio.com/OS/_workitems/edit/31011100"},
-     {"coreml_VGG16_ImageNet_opset10", "Bug 31011100: Processing string tensors need to be implemented in WinML model tests https://microsoft.visualstudio.com/OS/_workitems/edit/31011100"},
-     {"coreml_Resnet50_opset10", "Bug 31011100: Processing string tensors need to be implemented in WinML model tests https://microsoft.visualstudio.com/OS/_workitems/edit/31011100"},
-     {"coreml_inceptionv3_opset10", "Bug 31011100: Processing string tensors need to be implemented in WinML model tests https://microsoft.visualstudio.com/OS/_workitems/edit/31011100"},
-
      // Tier 3 models
      {"mxnet_arcface_opset8", disabledTestDefaultReason},
      {"XGBoost_XGClassifier_sklearn_load_wine_opset7", disabledTestDefaultReason},


### PR DESCRIPTION
This change implements 2 things for winml model tests:

- Moves the creation of Ort::Value from ITensor into ort_value_helpers.cpp
- Implement the comparing of outputs that are of type sequence of maps of strings to floats
