### PR TITLE
[OpenVINO-EP] Add usage details of unified MCR container image

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -86,6 +86,12 @@ Use `docker pull` with any of the images and tags below to pull an image and try
 
 **Ubuntu 18.04, Python & C# Bindings**
 
+### **1. Using MCR container images**
+
+The unified MCR container image can be used to run an application on any of the target accelerators. In order to select the target accelerator, the application should explicitly specifiy the choice using the *device_type*  configuration option for OpenVINO Execution provider. Refer to [OpenVINO EP runtime configuration documentation](https://github.com/microsoft/onnxruntime/blob/master/docs/execution_providers/OpenVINO-ExecutionProvider.md#runtime-configuration-options) for details on specifying this option in the application code. 
+If the *device_type* runtime config option is not explicitly specified, CPU will be chosen as the hardware target execution.
+### **2. Building from Dockerfile**
+
 1. Build the onnxruntime image for one of the accelerators supported below.
 
    Retrieve your docker image in one of the following ways.


### PR DESCRIPTION
**Description**: Add documentation on using pre-built container image published in Microsoft Container Registry.

**Motivation and Context**
- Going forward, a single unifed docker image will be published in
MCR. The hardware accelerator target choice will have to be made
in the application using OpenVINO EP's runtime config options.
