### PR TITLE
Fix missing libonnxruntime.so.1.2.0

### DIFF
--- a/dockerfiles/Dockerfile.server
+++ b/dockerfiles/Dockerfile.server
@@ -26,8 +26,8 @@ RUN /onnxruntime/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh -p
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 WORKDIR /
-RUN mkdir -p /onnxruntime/build && cd /onnxruntime/build && cmake -DCMAKE_BUILD_TYPE=Release /onnxruntime/server \
-    && make -j$(getconf _NPROCESSORS_ONLN)
+RUN cd /onnxruntime && ./build.sh --config RelWithDebInfo --build_shared_lib --parallel
+
 
 FROM minimal AS final
 COPY --from=build /onnxruntime/build/onnxruntime_server /onnxruntime/server/


### PR DESCRIPTION
Using build.sh for triggering the build as mentioned in the documentation (replaces cmake call and fixes issue that shared library was not built).

Docker (Server/Ubuntu) build fails with missing libonnxruntime.so.1.2.0.

**Motivation and Context**
- fixes issue #6185 
