### PR TITLE
Device handling fixes in ORTModule

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -206,9 +206,9 @@ class InferenceSession(Session):
             self._create_inference_session(providers, provider_options)
         except RuntimeError:
             if self._enable_fallback:
-                print("EP Error using {}".format(self._providers))
+                print("EP Error using {}".format(providers))
                 print("Falling back to {} and retrying.".format(self._fallback_providers))
-                self._create_inference_session(self._fallback_providers)
+                self._create_inference_session(self._fallback_providers, provider_options)
                 # Fallback only once.
                 self.disable_fallback()
             else:

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -151,7 +151,7 @@ class ORTModule(torch.nn.Module):
         '''Thin layer to capture device for ORTModule IO bindings'''
         # TODO: Should we do anything?
         self._require_export = False
-        return super(ORTModule, self).to(args, kwargs)
+        return super(ORTModule, self).to(*args, **kwargs)
 
     def forward(self, *inputs, **kwargs):
         '''Forward pass starts here and continues at `_ORTModuleFunction.forward`

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -190,11 +190,12 @@ class ORTModule(torch.nn.Module):
             self._onnx_backward = onnx.load_model_from_string(self._module_gradient_graph_builder.get_backward_model())
             self._onnx_graphs_info = self._module_gradient_graph_builder.get_split_graphs_info()
 
-            if self._device.type == 'cuda':
+            model_device = torch.device(self._device)
+            if model_device.type == 'cuda':
                 # Configure the InferenceSessions to use the specific GPU on which the model is placed.
                 providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-                provider_options = [{"device_id": str(self._device.index)}, {}]
-            elif self._device.type == 'cpu':
+                provider_options = [{"device_id": str(model_device)}, {}]
+            elif model_device.type == 'cpu':
                 providers = ["CPUExecutionProvider"]
                 provider_options = [{}]
 

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -9,9 +9,9 @@ import warnings
 import numpy as np
 from inspect import signature
 
-# Needed to re-implement PyTorch's cpu,cuda,to methods
-from torch import Tensor, device, dtype
 from torch.utils.dlpack import from_dlpack
+
+# Needed to re-implement PyTorch's cpu,cuda,to methods
 from typing import Union, Tuple, Any, Callable, Iterator, Set, Optional, overload, TypeVar, Mapping, Dict
 
 from onnxruntime.capi import _pybind_state as C
@@ -26,11 +26,34 @@ T = TypeVar('T', bound='Module')
 
 
 def _get_device_index(device):
-    if type(device) == str:
+    if isinstance(device, str):
         # could be 'cuda:0', 'cuda:1', or 'cpu'. with cpu, set index=0
         device = torch.device(device)
+    elif isinstance(device, int):
+        return device
     return 0 if device.index is None else device.index
 
+def _get_device_str(device):
+    if isinstance(device, str):
+        # could be 'cuda:0', 'cuda:1', or 'cpu'. with cpu, set index=0
+        if device.find(':') == -1:
+            device += ':' + str(torch.cuda.current_device())
+    elif isinstance(device, int):
+        device = 'cuda:' + str(device)
+    elif isinstance(device, torch.device):
+        if device.index is None:
+            device = device.type + ':' + str(torch.cuda.current_device())
+        else:
+            device = device.type + ':' + str(device.index)
+    else:
+        raise ('Unsupported device type')
+    return device
+
+def _get_default_device_str(type):
+    if type == 'cuda':
+        return 'cuda:' + str(torch.cuda.current_device())
+    else:
+        return 'cpu'
 
 def _create_iobinding(io_binding, inputs, model, device):
     '''Creates IO binding for a `model` inputs and output'''
@@ -42,7 +65,7 @@ def _create_iobinding(io_binding, inputs, model, device):
                               inputs[idx].data_ptr())
 
     for value_info in model.graph.output:
-        io_binding.bind_output(value_info.name, device if device.find(':') == -1 else device[:device.find(':')],
+        io_binding.bind_output(value_info.name, device.type,
                                device_id=_get_device_index(device))
 
 
@@ -102,59 +125,49 @@ class ORTModule(torch.nn.Module):
 
     def cpu(self: T) -> T:
         '''Thin layer to capture device for ORTModule IO bindings'''
-        if self._device != 'cpu':
+
+        if self._device.type != 'cpu':
             self._require_export = True
-            self._device = 'cpu'
+            self._device = torch.device('cpu')
+
         return super(ORTModule, self).cpu()
 
-    def cuda(self: T, device: Optional[Union[int, device]] = None) -> T:
+    def cuda(self: T, device: Optional[Union[int, torch.device]] = None) -> T:
         '''Thin layer to capture device for ORTModule IO bindings'''
-        if device:
-            device = str(device)
-        else:
-            device = 'cuda'
-        if self._device != str(device):
+
+        if device is None:
+            if _get_device_str(self._device) != _get_default_device_str('cuda'):
+                self._require_export = True
+                self._device = torch.device(_get_default_device_str('cuda'))
+        elif _get_device_str(self._device) != _get_device_str(device):
             self._require_export = True
-            self._device = device
+            self._device = torch.device(_get_device_str(device))
+
         return super(ORTModule, self).cuda(device)
 
     @overload
-    def to(self: T, device: Optional[Union[int, device]] = ...,
-           dtype: Optional[Union[dtype, str]] = ...,
+    def to(self: T, device: Optional[Union[int, torch.device]] = ...,
+           dtype: Optional[Union[torch.dtype, str]] = ...,
            non_blocking: bool = ...) -> T:
-        '''Thin layer to capture device for ORTModule IO bindings'''
-        if device:
-            device = str(device)
-        else:
-            device = None
-        if self._device != str(device) and device is not None:
-            self._require_export = True
-            self._device = device
-        return super(ORTModule, self).to(device, dtype, non_blocking)
+        ...
 
     @overload
-    def to(self: T, dtype: Union[dtype, str], non_blocking: bool = ...) -> T:
-        '''Thin layer to capture device for ORTModule IO bindings'''
-        # TODO: Should we do anything?
-        self._require_export = False
-        return super(ORTModule, self).to(dtype, non_blocking)
+    def to(self: T, dtype: Union[torch.dtype, str], non_blocking: bool = ...) -> T:
+        ...
 
     @overload
-    def to(self: T, tensor: Tensor, non_blocking: bool = ...) -> T:
-        '''Thin layer to capture device for ORTModule IO bindings'''
-        # TODO: Long shot by sending model to tensor's device
-        device = None
-        if tensor:
-            device = str(tensor.device)
-        if self._device != str(device) and device is not None:
-            self._require_export = True
-            self._device = device
-        return super(ORTModule, self).to(tensor, non_blocking)
+    def to(self: T, tensor: torch.Tensor, non_blocking: bool = ...) -> T:
+        ...
 
     def to(self, *args, **kwargs):
         '''Thin layer to capture device for ORTModule IO bindings'''
-        # TODO: Should we do anything?
-        self._require_export = False
+
+        device, _, _, _ = torch._C._nn._parse_to(*args, **kwargs)
+        if device:
+            device_str = _get_device_str(device)
+            if _get_device_str(self._device) != device_str:
+                self._require_export = True
+                self._device = torch.device(device_str)
         return super(ORTModule, self).to(*args, **kwargs)
 
     def forward(self, *inputs, **kwargs):
@@ -190,12 +203,13 @@ class ORTModule(torch.nn.Module):
             self._onnx_backward = onnx.load_model_from_string(self._module_gradient_graph_builder.get_backward_model())
             self._onnx_graphs_info = self._module_gradient_graph_builder.get_split_graphs_info()
 
-            model_device = torch.device(self._device)
-            if model_device.type == 'cuda':
+            providers = None
+            provider_options = None
+            if self._device.type == 'cuda':
                 # Configure the InferenceSessions to use the specific GPU on which the model is placed.
                 providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-                provider_options = [{"device_id": str(model_device)}, {}]
-            elif model_device.type == 'cpu':
+                provider_options = [{"device_id": str(self._device.index)}]
+            elif self._device.type == 'cpu':
                 providers = ["CPUExecutionProvider"]
                 provider_options = [{}]
 
@@ -232,7 +246,7 @@ class ORTModule(torch.nn.Module):
                 # Use IO binding
                 _create_iobinding(self._forward_io_binding, inputs,
                                   self._onnx_forward,
-                                  str(self._device))
+                                  self._device)
 
                 # Run
                 self._forward_session.run_with_iobinding(self._forward_io_binding)
@@ -269,7 +283,7 @@ class ORTModule(torch.nn.Module):
                 backward_grad_output = tuple(grad_output_dict[name] for name in self._onnx_graphs_info.backward_output_grad_names)
                 _create_iobinding(self._backward_io_binding, [*ctx.saved_tensors, *backward_grad_output],
                                    self._onnx_backward,
-                                   str(self._device))
+                                   self._device)
 
                 # Run
                 self._backward_session.run_with_iobinding(self._backward_io_binding)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist.py
@@ -40,10 +40,7 @@ def train(args, model, device, optimizer, loss_fn, train_loader, epoch):
         data = data.reshape(data.shape[0], -1)
 
         optimizer.zero_grad()
-        if args.pytorch_only:
-            probability = model(data)
-        else:
-            probability = model(data)
+        probability = model(data)
 
         if args.view_graphs:
             import torchviz

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed.py
@@ -50,10 +50,7 @@ def train(args, model, device, optimizer, loss_fn, train_loader, epoch):
         data = data.reshape(data.shape[0], -1).half()
 
         optimizer.zero_grad()
-        if args.pytorch_only:
-            probability = model(data)
-        else:
-            probability = model(data)
+        probability = model(data)
 
         if args.view_graphs:
             import torchviz

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed.py
@@ -1,3 +1,13 @@
+"""Test for a simple ORTModule using the high-level DeepSpeed API.
+
+To run on the local GPU(s):
+
+```
+$ pip install deepspeed
+$ deepspeed orttraining_test_ortmodule_mnist_deepspeed.py \
+    --deepspeed_config=orttraining_test_ortmodule_mnist_deepspeed_config.json
+```
+"""
 import argparse
 import logging
 import torch
@@ -25,7 +35,8 @@ class NeuralNet(torch.nn.Module):
 
 
 def train(args, model, device, optimizer, loss_fn, train_loader, epoch):
-    print('\n======== Epoch {:} / {:} with batch size {:} ========'.format(epoch+1, args.epochs, model.train_batch_size()))
+    print('\n======== Epoch {:} / {:} with batch size {:} ========'.format(
+        epoch+1, args.epochs, model.train_batch_size()))
     model.train()
     # Measure how long the training epoch takes.
     t0 = time.time()
@@ -36,7 +47,7 @@ def train(args, model, device, optimizer, loss_fn, train_loader, epoch):
 
     for iteration, (data, target) in enumerate(train_loader):
         data, target = data.to(device), target.to(device)
-        data = data.reshape(data.shape[0], -1)
+        data = data.reshape(data.shape[0], -1).half()
 
         optimizer.zero_grad()
         if args.pytorch_only:
@@ -87,7 +98,7 @@ def test(args, model, device, loss_fn, test_loader):
     with torch.no_grad():
         for data, target in test_loader:
             data, target = data.to(device), target.to(device)
-            data = data.reshape(data.shape[0], -1)
+            data = data.reshape(data.shape[0], -1).half()
             output = model(data)
 
             # Stats

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed.py
@@ -150,9 +150,9 @@ def main():
 
     # DeepSpeed-related settings
     parser.add_argument('--local_rank',
-                                                type=int,
-                                                default=-1,
-                                                help='local rank passed from distributed launcher')
+                        type=int,
+                        required=True,
+                        help='local rank passed from distributed launcher')
     parser = deepspeed.add_config_arguments(parser)
     
     args = parser.parse_args()

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed.py
@@ -1,0 +1,217 @@
+import argparse
+import logging
+import torch
+import time
+from torchvision import datasets, transforms
+
+import onnxruntime
+from onnxruntime.training import ORTModule
+
+import deepspeed
+
+class NeuralNet(torch.nn.Module):
+    def __init__(self, input_size, hidden_size, num_classes):
+        super(NeuralNet, self).__init__()
+
+        self.fc1 = torch.nn.Linear(input_size, hidden_size)
+        self.relu = torch.nn.ReLU()
+        self.fc2 = torch.nn.Linear(hidden_size, num_classes)
+
+    def forward(self, input1):
+        out = self.fc1(input1)
+        out = self.relu(out)
+        out = self.fc2(out)
+        return out
+
+
+def train(args, model, device, optimizer, loss_fn, train_loader, epoch):
+    print('\n======== Epoch {:} / {:} with batch size {:} ========'.format(epoch+1, args.epochs, model.train_batch_size()))
+    model.train()
+    # Measure how long the training epoch takes.
+    t0 = time.time()
+    start_time = t0
+
+    # Reset the total loss for this epoch.
+    total_loss = 0
+
+    for iteration, (data, target) in enumerate(train_loader):
+        data, target = data.to(device), target.to(device)
+        data = data.reshape(data.shape[0], -1)
+
+        optimizer.zero_grad()
+        if args.pytorch_only:
+            probability = model(data)
+        else:
+            probability = model(data)
+
+        if args.view_graphs:
+            import torchviz
+            pytorch_backward_graph = torchviz.make_dot(probability, params=dict(list(model.named_parameters())))
+            pytorch_backward_graph.view()
+
+        loss = loss_fn(probability, target)
+        # Accumulate the training loss over all of the batches so that we can
+        # calculate the average loss at the end. `loss` is a Tensor containing a
+        # single value; the `.item()` function just returns the Python value
+        # from the tensor.
+        total_loss += loss.item()
+
+        model.backward(loss)
+        model.step()
+
+        # Stats
+        if iteration % args.log_interval == 0:
+            curr_time = time.time()
+            elapsed_time = curr_time - start_time
+            print('[{:5}/{:5} ({:2.0f}%)]\tLoss: {:.6f}\tExecution time: {:.4f}'.format(
+                iteration * len(data), len(train_loader.dataset),
+                100. * iteration / len(train_loader), loss, elapsed_time))
+            start_time = curr_time
+
+    # Calculate the average loss over the training data.
+    avg_train_loss = total_loss / len(train_loader)
+
+    epoch_time = time.time() - t0
+    print("\n  Average training loss: {0:.2f}".format(avg_train_loss))
+    print("  Training epoch took: {:.4f}s".format(epoch_time))
+    return epoch_time
+
+
+def test(args, model, device, loss_fn, test_loader):
+    model.eval()
+
+    t0 = time.time()
+
+    test_loss = 0
+    correct = 0
+    with torch.no_grad():
+        for data, target in test_loader:
+            data, target = data.to(device), target.to(device)
+            data = data.reshape(data.shape[0], -1)
+            output = model(data)
+
+            # Stats
+            test_loss += loss_fn(output, target, False).item()
+            pred = output.argmax(dim=1, keepdim=True)
+            correct += pred.eq(target.view_as(pred)).sum().item()
+    test_loss /= len(test_loader.dataset)
+    print('\nTest set: Batch size: {:}, Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(
+        args.test_batch_size, test_loss, correct, len(test_loader.dataset),
+        100. * correct / len(test_loader.dataset)))
+
+    # Report the final accuracy for this validation run.
+    epoch_time = time.time() - t0
+    print("  Accuracy: {0:.2f}".format(float(correct)/len(test_loader.dataset)))
+    print("  Validation took: {:.4f}s".format(epoch_time))
+    return epoch_time
+
+def my_loss(x, target, is_train=True):
+    if is_train:
+        return torch.nn.CrossEntropyLoss()(x, target)
+    else:
+        return torch.nn.CrossEntropyLoss(reduction='sum')(x, target)
+
+def main():
+    # Training settings
+    parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
+    parser.add_argument('--train-steps', type=int, default=-1, metavar='N',
+                        help='number of steps to train. Set -1 to run through whole dataset (default: -1)')
+    parser.add_argument('--lr', type=float, default=0.01, metavar='LR',
+                        help='learning rate (default: 0.01)')
+    parser.add_argument('--batch-size', type=int, default=32, metavar='N',
+                        help='input batch size for training (default: 32)')
+    parser.add_argument('--test-batch-size', type=int, default=64, metavar='N',
+                        help='input batch size for testing (default: 64)')
+    parser.add_argument('--no-cuda', action='store_true', default=False,
+                        help='disables CUDA training')
+    parser.add_argument('--seed', type=int, default=42, metavar='S',
+                        help='random seed (default: 42)')
+    parser.add_argument('--pytorch-only', action='store_true', default=False,
+                        help='disables ONNX Runtime training')
+    parser.add_argument('--log-interval', type=int, default=300, metavar='N',
+                        help='how many batches to wait before logging training status (default: 300)')
+    parser.add_argument('--view-graphs', action='store_true', default=False,
+                        help='views forward and backward graphs')
+    parser.add_argument('--epochs', type=int, default=10, metavar='N',
+                        help='number of epochs to train (default: 10)')
+    parser.add_argument('--log-level', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], default='WARNING',
+                        help='Log level (default: WARNING)')
+
+    # DeepSpeed-related settings
+    parser.add_argument('--local_rank',
+                                                type=int,
+                                                default=-1,
+                                                help='local rank passed from distributed launcher')
+    parser = deepspeed.add_config_arguments(parser)
+    
+    args = parser.parse_args()
+
+
+    # Common setup
+    torch.manual_seed(args.seed)
+    onnxruntime.set_seed(args.seed)
+
+    # TODO: CUDA support is broken due to copying from PyTorch into ORT
+    if not args.no_cuda and torch.cuda.is_available():
+        device = "cuda:" + str(args.local_rank)
+    else:
+        device = "cpu"
+
+    ## Data loader
+    train_set = datasets.MNIST('./data', train=True, download=True,
+                               transform=transforms.Compose([transforms.ToTensor(),
+                                                             transforms.Normalize((0.1307,), (0.3081,))]))
+    test_loader = None
+    if args.test_batch_size > 0:
+        test_loader = torch.utils.data.DataLoader(
+            datasets.MNIST('./data', train=False, transform=transforms.Compose([
+                transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])),
+            batch_size=args.test_batch_size, shuffle=True)
+
+    # Model architecture
+    model = NeuralNet(input_size=784, hidden_size=500, num_classes=10).to(device)
+    if not args.pytorch_only:
+        print('Training MNIST on ORTModule....')
+        model = ORTModule(model)
+
+        # TODO: change it to False to stop saving ONNX models
+        model._save_onnx = True
+        model._save_onnx_prefix = 'MNIST'
+
+        # Set log level
+        numeric_level = getattr(logging, args.log_level.upper(), None)
+        if not isinstance(numeric_level, int):
+            raise ValueError('Invalid log level: %s' % args.log_level)
+        logging.basicConfig(level=numeric_level)
+    else:
+        print('Training MNIST on vanilla PyTorch....')
+
+    model, optimizer, train_loader, _ = deepspeed.initialize(
+        args=args,model=model,
+        model_parameters=[p for p in model.parameters() if p.requires_grad],
+        training_data=train_set)
+    
+    # Train loop
+    total_training_time, total_test_time, epoch_0_training = 0, 0, 0
+    for epoch in range(0, args.epochs):
+        total_training_time += train(args, model, device, optimizer, my_loss, train_loader, epoch)
+        if not args.pytorch_only and epoch == 0:
+            epoch_0_training = total_training_time
+        if args.test_batch_size > 0:
+            total_test_time += test(args, model, device, my_loss, test_loader)
+
+    print('\n======== Global stats ========')
+    if not args.pytorch_only:
+        estimated_export = 0
+        if args.epochs > 1:
+            estimated_export = epoch_0_training - (total_training_time - epoch_0_training)/(args.epochs-1)
+            print("  Estimated ONNX export took:               {:.4f}s".format(estimated_export))
+        else:
+            print("  Estimated ONNX export took:               Estimate available when epochs > 1 only")
+        print("  Accumulated training without export took: {:.4f}s".format(total_training_time - estimated_export))
+    print("  Accumulated training took:                {:.4f}s".format(total_training_time))
+    print("  Accumulated validation took:              {:.4f}s".format(total_test_time))
+
+
+if __name__ == '__main__':
+    main()

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed_config.json
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed_config.json
@@ -30,3 +30,4 @@
     },
     "zero_allow_untested_optimizer": true
   }
+  

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed_config.json
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed_config.json
@@ -1,0 +1,27 @@
+{
+    "train_batch_size": 32,
+    "steps_per_print": 2000,
+    "optimizer": {
+      "type": "SGD",
+      "params": {
+        "lr": 0.001
+      }
+    },
+    "scheduler": {
+      "type": "WarmupLR",
+      "params": {
+        "warmup_min_lr": 0,
+        "warmup_max_lr": 0.001,
+        "warmup_num_steps": 1000
+      }
+    },
+    "wall_clock_breakdown": true,
+    "fp16": {
+      "enabled": false
+    }
+    "zero_optimization": {
+        "stage":1,
+        "reduce_bucket_size": 500000000
+    },
+    "zero_allow_untested_optimizer": true
+  }

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed_config.json
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed_config.json
@@ -29,5 +29,4 @@
         "reduce_bucket_size": 500000000
     },
     "zero_allow_untested_optimizer": true
-  }
-  
+}

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed_config.json
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed_config.json
@@ -17,8 +17,13 @@
     },
     "wall_clock_breakdown": true,
     "fp16": {
-      "enabled": false
-    }
+        "enabled": true,
+        "loss_scale": 0,
+        "initial_scale_power": 32,
+        "loss_scale_window": 1000,
+        "hysteresis": 2,
+        "min_loss_scale": 1
+    },
     "zero_optimization": {
         "stage":1,
         "reduce_bucket_size": 500000000

--- a/run_ortmodule_mvp_mnist_deepspeed.sh
+++ b/run_ortmodule_mvp_mnist_deepspeed.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+cur_dir=$(basename `pwd`)
+
+if [[ ${cur_dir} != "RelWithDebInfo" ]]
+then
+    echo "Going to build folder (aka build/Linux/RelWithDebInfo)"
+    cd build/Linux/RelWithDebInfo
+fi
+
+echo "Exporting PYTHONPATH to use build dir as onnxruntime package"
+export PYTHONPATH=$(pwd)
+
+echo "Copying PyTorch frontend source-code to build folder"
+cp -Rf ../../../orttraining/orttraining/python/training/* ../../../build/Linux/RelWithDebInfo/onnxruntime/training/
+
+echo "Running Flexible API (ORTModule)"
+python ../../../orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed.py --help
+deepspeed ../../../orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed.py --deepspeed_config ../../../orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist_deepspeed_config.json $@


### PR DESCRIPTION
**Description**: Multiple fixes to device handling logic in `ORTModule`.
* The `args` and `kwargs` should be expanded in the call to `super(...).to()`.
* When using multiple devices, the `device_id` should be set on the output `IOBinding`.
* When using multiple devices, the `device_id` should be set on the `CUDAExecutionProvider` in each `InferenceSession`.

**Motivation and Context**
- This fixes an observed `TypeError` where a `tuple, dict` are the observed argument types in the superclass method. Thanks to @harshithapv for uncovering the bug!
- It enables distributed data parallel training on a single multi-GPU machine.
