### PR TITLE
Clean up checkpoint tests to use the new checkpoint functions

### DIFF
--- a/orttraining/orttraining/python/training/checkpoint.py
+++ b/orttraining/orttraining/python/training/checkpoint.py
@@ -12,6 +12,9 @@ from . import _checkpoint_storage, _utils
 
 
 def experimental_state_dict(ort_trainer, include_optimizer_state=True):
+    warnings.warn("experimental_state_dict() will be deprecated soon. "
+                "Please use ORTTrainer.state_dict() instead.", DeprecationWarning)
+
     if not ort_trainer._training_session:
         warnings.warn("ONNX Runtime training session is not initialized yet. "
                         "Please run train_step or eval_step at least once before calling state_dict().")
@@ -35,6 +38,9 @@ def experimental_state_dict(ort_trainer, include_optimizer_state=True):
 
 
 def experimental_load_state_dict(ort_trainer, state_dict, strict=False):
+    warnings.warn("experimental_load_state_dict() will be deprecated soon. "
+                "Please use ORTTrainer.load_state_dict() instead.", DeprecationWarning)
+
     # Note: It may happen ONNX model has not yet been initialized
     # In this case we cache a reference to desired state and delay the restore until after initialization
     # Unexpected behavior will result if the user changes the reference before initialization
@@ -65,6 +71,9 @@ def experimental_load_state_dict(ort_trainer, state_dict, strict=False):
 
 
 def experimental_save_checkpoint(ort_trainer, checkpoint_dir, checkpoint_prefix="ORT_checkpoint", checkpoint_state_dict=None, include_optimizer_state=True):
+    warnings.warn("experimental_save_checkpoint() will be deprecated soon. "
+                "Please use ORTTrainer.save_checkpoint() instead.", DeprecationWarning)
+
     if checkpoint_state_dict is None:
         checkpoint_state_dict = {'model': experimental_state_dict(ort_trainer, include_optimizer_state)}
     else:
@@ -84,6 +93,9 @@ def experimental_save_checkpoint(ort_trainer, checkpoint_dir, checkpoint_prefix=
 
 
 def experimental_load_checkpoint(ort_trainer, checkpoint_dir, checkpoint_prefix="ORT_checkpoint", strict=False):
+    warnings.warn("experimental_load_checkpoint() will be deprecated soon. "
+                "Please use ORTTrainer.load_checkpoint() instead.", DeprecationWarning)
+
     checkpoint_files = _list_checkpoint_files(
         checkpoint_dir, checkpoint_prefix)
     is_partitioned = False
@@ -477,6 +489,9 @@ class _CombineZeroCheckpoint(object):
                 self._update_weight_statistics(weight_name, v)
 
     def aggregate_checkpoints(self):
+        warnings.warn("_CombineZeroCheckpoint.aggregate_checkpoints() will be deprecated soon. "
+                    "Please use aggregate_checkpoints() instead.", DeprecationWarning)
+
         checkpoint_prefix = self.checkpoint_files[0].split('.ZeRO')[0]
         self.aggregate_state_dict = dict()
 

--- a/orttraining/orttraining/python/training/checkpoint.py
+++ b/orttraining/orttraining/python/training/checkpoint.py
@@ -256,6 +256,16 @@ def _aggregate_trainer_options(rank_state_dict, state_dict):
     state_dict[_utils.state_dict_trainer_options_key()][optimizer_name] = \
         rank_state_dict[_utils.state_dict_trainer_options_key()][optimizer_name]
 
+def _to_pytorch_format(state_dict):
+    """Convert ORT state dictionary schema (hierarchical structure) to PyTorch state dictionary schema (flat structure)"""
+
+    pytorch_state_dict = {}
+    for model_state_key, model_state_value in \
+        state_dict[_utils.state_dict_model_key()][_utils.state_dict_full_precision_key()].items():
+        # convert numpy array to a torch tensor
+        pytorch_state_dict[model_state_key] = torch.tensor(model_state_value)
+    return pytorch_state_dict
+
 def aggregate_checkpoints(paths, pytorch_format=True):
     """Aggregate checkpoint files and return a single state dictionary
 
@@ -337,7 +347,7 @@ def aggregate_checkpoints(paths, pytorch_format=True):
 
     # return a flat structure for PyTorch model in case pytorch_format is True
     # else return the hierarchical structure for ORTTrainer
-    return state_dict[_utils.state_dict_model_key()][_utils.state_dict_full_precision_key()] if pytorch_format else state_dict
+    return _to_pytorch_format(state_dict) if pytorch_format else state_dict
 
 ################################################################################
 # Helper functions

--- a/orttraining/orttraining/python/training/checkpoint.py
+++ b/orttraining/orttraining/python/training/checkpoint.py
@@ -63,18 +63,6 @@ def experimental_load_state_dict(ort_trainer, state_dict, strict=False):
     session_state = {name:state_dict[name].numpy() for name in state_dict}
     ort_trainer._training_session.load_state(session_state, strict)
 
-# Temporary function to test optimizer state loading
-def _experimental_load_optimizer_state(ort_trainer, optim_state_dict):
-    ort_trainer._optim_state_dict = optim_state_dict
-
-    # Note: It may happen ONNX model has not yet been initialized
-    # In this case we cache a reference to desired state and delay the restore until after initialization
-    # Unexpected behavior will result if the user changes the reference before initialization    
-    if not ort_trainer._training_session:
-        return
-
-    ort_trainer._init_session()
-
 
 def experimental_save_checkpoint(ort_trainer, checkpoint_dir, checkpoint_prefix="ORT_checkpoint", checkpoint_state_dict=None, include_optimizer_state=True):
     if checkpoint_state_dict is None:

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -148,7 +148,7 @@ class ORTTrainer(object):
                 "'loss_fn' must be either 'None' or 'torch.nn.Module'"
             self._torch_model = model
             self.loss_fn = loss_fn
-            # TODO: Subject to change after checkpoint redesign
+            # TODO: Remove when experimental checkpoint functions are removed.
             self._torch_state_dict_keys = list(model.state_dict().keys())
         elif isinstance(model, onnx.ModelProto):
             assert loss_fn is None, "'loss_fn' must not be specified when 'model' is an ONNX model"
@@ -202,9 +202,8 @@ class ORTTrainer(object):
                 ort.set_cuda_mem_limit(self.options.device.mem_limit)
             ort.set_cuda_device_id(_utils.get_device_index(self.options.device.id))
 
-        # TODO: Subject to change after checkpoint redesign
+        # TODO: Remove when experimental checkpoint functions are removed.
         self._state_dict = {}
-        self._optim_state_dict = {}
 
         self._train_step_info = TrainStepInfo(self.optim_config)
         self._training_session = None
@@ -637,8 +636,6 @@ class ORTTrainer(object):
         ort_parameters.weights_to_train = trainable_params
         ort_parameters.optimizer_attributes_map = optimizer_attributes_map
         ort_parameters.optimizer_int_attributes_map = optimizer_int_attributes_map
-        if bool(self._optim_state_dict):
-            ort_parameters.set_optimizer_initial_state(self._optim_state_dict)
         if bool(optimizer_state_dict):
             ort_parameters.set_optimizer_initial_state(optimizer_state_dict)
 
@@ -738,7 +735,7 @@ class ORTTrainer(object):
             self._model_desc_outputs_with_gradient_accumulation = [
                 *self.model_desc.outputs, self.model_desc.gradient_accumulation]
 
-        # TODO: Subject to change after checkpoint redesign
+        # TODO: Remove when experimental checkpoint functions are removed
         if self._state_dict:
             checkpoint.experimental_load_state_dict(self, self._state_dict, self._load_state_dict_strict)
             self._state_dict_debug = self._state_dict

--- a/orttraining/orttraining/test/python/_test_commons.py
+++ b/orttraining/orttraining/test/python/_test_commons.py
@@ -130,35 +130,9 @@ def generate_dummy_optim_state(model, optimizer):
     if isinstance(optimizer, optim.LambConfig):
         step_val = np.full([1], 5, dtype=np.int64)
         optim_state[shared_state_key] = {step_key: step_val}
-    return optim_state
-
-
-def get_optim_state_from_state_dict(state_dict, optimizer):
-    if not (isinstance(optimizer, optim.AdamConfig) or isinstance(optimizer, optim.LambConfig)):
-        return dict()
-
-    moment_keys = ["Moment_1", "Moment_2"]
-    uc_key = "Update_Count"
-    step_key = "Step"
-    shared_state_key = "shared_optimizer_state"
-
-    optim_state = dict()
-    for param_name, v in state_dict.items():
-        if '_view_' in param_name:
-            param_name = param_name.split('_view_')[0]
-
-        for moment in moment_keys:
-            if param_name.startswith(moment):
-                fp32_name = param_name.split(moment + '_')[-1]
-                if fp32_name not in optim_state:
-                    optim_state[fp32_name] = dict()
-                optim_state[fp32_name].update({moment: v})
-                break
-        if param_name.startswith(uc_key):
-            fp32_name = param_name.split(uc_key + '_')[-1]
-            if fp32_name not in optim_state:
-                optim_state[fp32_name] = dict()
-            optim_state[fp32_name].update({uc_key: v})
-        elif param_name == step_key:
-            optim_state[shared_state_key] = {step_key: v}
-    return optim_state
+    return {
+        'optimizer': optim_state,
+        'trainer_options': {
+            'optimizer_name': optimizer.name
+        }
+    }

--- a/orttraining/orttraining/test/python/_test_commons.py
+++ b/orttraining/orttraining/test/python/_test_commons.py
@@ -4,10 +4,11 @@ import sys
 import subprocess
 import copy
 import numpy as np
+from numpy.testing import assert_allclose
 import torch
 import onnx
 
-from onnxruntime.training import optim
+from onnxruntime.training import optim, _utils
 
 def _single_run(execution_file, scenario, checkopint_dir = None):
     cmd = [sys.executable, execution_file]
@@ -136,3 +137,67 @@ def generate_dummy_optim_state(model, optimizer):
             'optimizer_name': optimizer.name
         }
     }
+
+def _load_pytorch_transformer_model(device, dynamic_axes=False, legacy_api=False):
+    # Loads external Pytorch TransformerModel into utils
+    pytorch_transformer_path = os.path.join('samples', 'python', 'pytorch_transformer')
+    pt_model_path = os.path.join(pytorch_transformer_path, 'pt_model.py')
+    pt_model = _utils.import_module_from_file(pt_model_path)
+    ort_utils_path = os.path.join(pytorch_transformer_path, 'ort_utils.py')
+    ort_utils = _utils.import_module_from_file(ort_utils_path)
+    utils_path = os.path.join(pytorch_transformer_path, 'utils.py')
+    utils = _utils.import_module_from_file(utils_path)
+
+    # Modeling
+    model = pt_model.TransformerModel(28785, 200, 2, 200, 2, 0.2).to(device)
+    my_loss = ort_utils.my_loss
+    if legacy_api:
+        if dynamic_axes:
+            model_desc = ort_utils.legacy_transformer_model_description_dynamic_axes()
+        else:
+            model_desc = ort_utils.legacy_transformer_model_description()
+    else:
+        if dynamic_axes:
+            model_desc = ort_utils.transformer_model_description_dynamic_axes()
+        else:
+            model_desc = ort_utils.transformer_model_description()
+
+
+    # Preparing data
+    train_data, val_data, test_data = utils.prepare_data(device, 20, 20)
+    return model, model_desc, my_loss, utils.get_batch, train_data, val_data, test_data
+
+def assert_all_states_close_ort(state_dict_pre_checkpoint, state_dict_post_checkpoint, reshape_states=False):
+    """Assert that the two ORTTrainer (hierarchical) state dictionaries are very close for all states"""
+
+    assert ('model' in state_dict_pre_checkpoint) == ('model' in state_dict_post_checkpoint)
+    assert ('optimizer' in state_dict_pre_checkpoint) == ('optimizer' in state_dict_post_checkpoint)
+
+    if 'model' in state_dict_pre_checkpoint:
+        for model_state_key in state_dict_pre_checkpoint['model']['full_precision']:
+            if reshape_states:
+                assert_allclose(state_dict_pre_checkpoint['model']['full_precision'][model_state_key],
+                    state_dict_post_checkpoint['model']['full_precision'][model_state_key]\
+                        .reshape(state_dict_pre_checkpoint['model']['full_precision'][model_state_key].shape))
+            else:
+                assert_allclose(state_dict_pre_checkpoint['model']['full_precision'][model_state_key],
+                    state_dict_post_checkpoint['model']['full_precision'][model_state_key])
+
+    if 'optimizer' in state_dict_pre_checkpoint:
+        for model_state_key in state_dict_pre_checkpoint['optimizer']:
+            for optimizer_state_key in state_dict_pre_checkpoint['optimizer'][model_state_key]:
+                if reshape_states:
+                    assert_allclose(state_dict_pre_checkpoint['optimizer'][model_state_key][optimizer_state_key],
+                        state_dict_post_checkpoint['optimizer'][model_state_key][optimizer_state_key]\
+                            .reshape(state_dict_pre_checkpoint['optimizer'][model_state_key][optimizer_state_key].shape))
+                else:
+                    assert_allclose(state_dict_pre_checkpoint['optimizer'][model_state_key][optimizer_state_key],
+                        state_dict_post_checkpoint['optimizer'][model_state_key][optimizer_state_key])
+
+def assert_all_states_close_pytorch(state_dict_pre_checkpoint, pytorch_model):
+    """Assert that the state_dict_pre_checkpoint state dictionary is very close to the one extracted from the pytorch model after loading"""
+
+    pytorch_model.load_state_dict(state_dict_pre_checkpoint)
+    state_dict_pytorch = pytorch_model.state_dict()
+    for key, value in state_dict_pytorch.items():
+        assert_allclose(value, state_dict_pre_checkpoint[key])

--- a/orttraining/orttraining/test/python/checkpoint/_test_helpers.py
+++ b/orttraining/orttraining/test/python/checkpoint/_test_helpers.py
@@ -1,6 +1,7 @@
 import os
 import pickle
 from itertools import islice
+import glob
 
 import torch
 import torch.distributed as dist
@@ -29,14 +30,16 @@ def makedir(checkpoint_dir):
     if not os.path.exists(checkpoint_dir):
         os.makedirs(checkpoint_dir, exist_ok = True)
 
-def _save(trainer, checkpoint_dir, state_dict_key_name):
-    """Saves the ORTTrainer checkpoint and the complete state dictionary to the given checkpoint_dir directory""" 
+def _save(trainer, checkpoint_dir, state_dict_key_name, world_rank=None):
+    """Saves the ORTTrainer checkpoint and the complete state dictionary to the given checkpoint_dir directory"""
 
     # save current model parameters as a checkpoint
     makedir(checkpoint_dir)
-    checkpoint.experimental_save_checkpoint(trainer, checkpoint_dir)
-    state_dict = checkpoint.experimental_state_dict(trainer)
-    pickle.dump({state_dict_key_name : state_dict}, open(os.path.join(checkpoint_dir, state_dict_key_name+'.pkl'), "wb"))
+    checkpoint_file_name = 'checkpoint{}.ortcp'.format('' if world_rank is None else str(world_rank))
+    trainer.save_checkpoint(os.path.join(checkpoint_dir, checkpoint_file_name))
+    state_dict = trainer.state_dict()
+    with open(os.path.join(checkpoint_dir, state_dict_key_name+'.pkl'), "wb") as f:
+        pickle.dump({state_dict_key_name : state_dict}, f)
 
 def _chunkify(sequence, num_chunks):
     """Breaks down a given sequence into num_chunks chunks"""
@@ -94,7 +97,9 @@ def create_orttrainer_and_load_checkpoint(device, trainer_opts, checkpoint_dir, 
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=loss_fn, options=orttrainer.ORTTrainerOptions(trainer_opts))
 
     # load checkpoint into trainer
-    checkpoint.experimental_load_checkpoint(trainer, checkpoint_dir)
+    checkpoint_file_name = 'checkpoint*.ortcp'
+    checkpoint_files = glob.glob(os.path.join(checkpoint_dir, checkpoint_file_name))
+    trainer.load_checkpoint(*checkpoint_files)
 
     # run an eval step to innitialize the graph
     torch.manual_seed(seed)
@@ -102,7 +107,7 @@ def create_orttrainer_and_load_checkpoint(device, trainer_opts, checkpoint_dir, 
     data, targets = batcher_fn(train_data, 0)
     trainer.eval_step(data, targets)
 
-    return checkpoint.experimental_state_dict(trainer), model
+    return trainer.state_dict(), model
 
 def create_initialized_orttrainer(device, trainer_opts, use_lamb=True):
     seed = 1
@@ -219,22 +224,25 @@ def _split_name(name):
     param_name = param_name.split('_fp16')[0]
     return param_name, optimizer_key, view_num, fp16_key
 
-def aggregate_states(aggregated_states, state_dict):
-    """Concatenate existing aggregated state dict values with given state_dict values"""
+def aggregate_states(checkpoint_dir, filename_prefix='state_dict', state_dict_key_name='state_dict'):
+    """Aggregate state dictionaries saved in the checkpoint_dir as pickle files with name filename_prefix_world_rank.pkl"""
 
-    for key, value in state_dict.items():
-        weight_name, optimizer_key, view_num, fp16_key = _split_name(key)
-        if view_num is not None:
-            # parameter is sharded
-            param_name = optimizer_key + weight_name + fp16_key
+    aggregated_states = {}
+    num_states = len(glob.glob1(checkpoint_dir,"{}*".format(filename_prefix)))
+    for rank in range(num_states):
+        rank_state_dict = None
+        with open(os.path.join(checkpoint_dir, '{}_{}.pkl'.format(filename_prefix, rank)), 'rb') as f:
+            rank_state_dict = pickle.load(f)
+        # if state_dict_key_name is None, then the rank_state_dictis the loaded object
+        if state_dict_key_name:
+            # if it has a name, index into the loaded object to extract the rank_state_dict
+            rank_state_dict = rank_state_dict['{}_{}'.format(state_dict_key_name, rank)]
 
-            if param_name in aggregated_states and optimizer_key not in ['Update_Count_']:
-                # found a previous shard of the param, concatenate shards ordered by ranks
-                aggregated_states[param_name] = torch.cat((aggregated_states[param_name], value))
-            else:
-                aggregated_states[param_name] = value
-        else:
-            aggregated_states[key] = value
+        checkpoint._aggregate_model_states(rank_state_dict, {}, aggregated_states, rank_state_dict['trainer_options']['mixed_precision'])
+
+        checkpoint._aggregate_optimizer_states(rank_state_dict, {}, aggregated_states)
+    
+    return aggregated_states
 
 def create_orttrainer_and_save_checkpoint(device, trainer_opts, checkpoint_dir, state_dict_key_name='state_dict', use_lamb=True):
     learning_rate = 0.1
@@ -255,8 +263,10 @@ def create_orttrainer_and_save_checkpoint(device, trainer_opts, checkpoint_dir, 
 
     # save current model parameters as a checkpoint
     if checkpoint_dir:
-        _save(trainer, checkpoint_dir, state_dict_key_name)
-
+        if 'distributed' in trainer_opts and 'deepspeed_zero_optimization' in trainer_opts['distributed']:
+            _save(trainer, checkpoint_dir, state_dict_key_name, world_rank=trainer_opts['distributed']['world_rank'])
+        else:
+            _save(trainer, checkpoint_dir, state_dict_key_name)
 
 def load_model_optim_state_and_eval(device, trainer_opts, use_lamb=True):
     learning_rate = 0.1
@@ -271,10 +281,62 @@ def load_model_optim_state_and_eval(device, trainer_opts, use_lamb=True):
 
     # load dummy state
     dummy_init_state = generate_dummy_optim_state(model, optim_config)
-    checkpoint._experimental_load_optimizer_state(trainer, dummy_init_state)
+    trainer.load_state_dict(dummy_init_state)
 
     # run an eval step to innitialize the graph
     data, targets = batcher_fn(train_data, 0)
     trainer.eval_step(data, targets)
 
-    return dummy_init_state, checkpoint.experimental_state_dict(trainer)
+    optimizer_state_dict = trainer.state_dict()
+    del optimizer_state_dict['model']
+
+    return dummy_init_state, optimizer_state_dict
+
+def assert_all_states_close_ort(state_dict_pre_checkpoint, state_dict_post_checkpoint, reshape_states=False):
+    """Assert that the two ORTTrainer (hierarchical) state dictionaries are very close for all states"""
+
+    assert ('model' in state_dict_pre_checkpoint) == ('model' in state_dict_post_checkpoint)
+    assert ('optimizer' in state_dict_pre_checkpoint) == ('optimizer' in state_dict_post_checkpoint)
+
+    if 'model' in state_dict_pre_checkpoint:
+        for model_state_key in state_dict_pre_checkpoint['model']['full_precision']:
+            if reshape_states:
+                assert_allclose(state_dict_pre_checkpoint['model']['full_precision'][model_state_key],
+                    state_dict_post_checkpoint['model']['full_precision'][model_state_key]\
+                        .reshape(state_dict_pre_checkpoint['model']['full_precision'][model_state_key].shape))
+            else:
+                assert_allclose(state_dict_pre_checkpoint['model']['full_precision'][model_state_key],
+                    state_dict_post_checkpoint['model']['full_precision'][model_state_key])
+    
+    if 'optimizer' in state_dict_pre_checkpoint:
+        for model_state_key in state_dict_pre_checkpoint['optimizer']:
+            for optimizer_state_key in state_dict_pre_checkpoint['optimizer'][model_state_key]:
+                if reshape_states:
+                    assert_allclose(state_dict_pre_checkpoint['optimizer'][model_state_key][optimizer_state_key],
+                        state_dict_post_checkpoint['optimizer'][model_state_key][optimizer_state_key]\
+                            .reshape(state_dict_pre_checkpoint['optimizer'][model_state_key][optimizer_state_key].shape))
+                else:
+                    assert_allclose(state_dict_pre_checkpoint['optimizer'][model_state_key][optimizer_state_key],
+                        state_dict_post_checkpoint['optimizer'][model_state_key][optimizer_state_key])
+
+def assert_all_states_close_pytorch(state_dict_pre_checkpoint, pytorch_model):
+    """Assert that the state_dict_pre_checkpoint state dictionary is very close to the one extracted from the pytorch model after loading"""
+    pytorch_model.load_state_dict(state_dict_pre_checkpoint)
+    state_dict_pytorch = pytorch_model.state_dict()
+    for key, value in state_dict_pytorch.items():
+        assert_allclose(value, state_dict_pre_checkpoint[key])
+
+def assert_all_states_close(checkpoint_dir, state_dict_key_name, state_dict_post_checkpoint, pytorch_model=None):
+    """Extract previously saved state dictionary from pickle file and compare against state_dict_post_checkpoint for all states"""
+
+    state = None
+    with open(os.path.join(checkpoint_dir, '{}.pkl'.format(state_dict_key_name)), 'rb') as f:
+        state = pickle.load(f)
+    state_dict_pre_checkpoint = state[state_dict_key_name]
+
+    # assert that the ort states are close
+    assert_all_states_close_ort(state_dict_pre_checkpoint, state_dict_post_checkpoint)
+
+    # assert that the pytorch model states are close
+    if pytorch_model:
+        assert_all_states_close_pytorch(checkpoint._to_pytorch_format(state_dict_pre_checkpoint), pytorch_model)

--- a/orttraining/orttraining/test/python/checkpoint/orttraining_test_checkpoint_aggregation.py
+++ b/orttraining/orttraining/test/python/checkpoint/orttraining_test_checkpoint_aggregation.py
@@ -21,73 +21,22 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import onnxruntime
 from onnxruntime.training import checkpoint
-from _test_helpers import distributed_setup, create_orttrainer_and_load_checkpoint, split_state_dict, aggregate_states, global_fp16_fp32_atol
+from _test_helpers import distributed_setup, create_orttrainer_and_load_checkpoint, aggregate_states, assert_all_states_close_ort
 
 
 def test_zero_aggregation(checkpoint_dir, loaded_state_dict, is_mixedprecision):
     # get aggregated state dict independently
-    checkpoint_files = checkpoint._list_checkpoint_files(checkpoint_dir, "ORT_checkpoint")
-    agg_checkpoint = checkpoint._CombineZeroCheckpoint(checkpoint_files)
-    aggregate_state_dict = agg_checkpoint.aggregate_checkpoints()
+    aggregate_state_dict_from_checkpoint = \
+        checkpoint.aggregate_checkpoints(glob.glob(os.path.join(checkpoint_dir, "checkpoint*.ortcp")), pytorch_format=False)
 
     # verify loaded state and aggregated states match:
-    assert aggregate_state_dict.keys() == loaded_state_dict.keys()
-    for k, v in loaded_state_dict.items():
-        assert_allclose(v, aggregate_state_dict[k])
+    assert_all_states_close_ort(loaded_state_dict, aggregate_state_dict_from_checkpoint)
 
-    # split state for next few checks
-    loaded_state_dict = split_state_dict(loaded_state_dict)
+    # manually aggregate the states from the previously saved pickle file
+    aggregate_state_dict_from_test = aggregate_states(checkpoint_dir)
 
-    # verify that aggregation is done correctly
-    num_states = len(glob.glob1(checkpoint_dir, "state_dict*"))
-
-    sharded_state_rank_offset = dict()
-    for rank in range(num_states):
-        state = None
-        with open(os.path.join(checkpoint_dir, 'state_dict_'+str(rank)+'.pkl'), 'rb') as f:
-            state = pickle.load(f)
-        rank_state_dict = split_state_dict(state['state_dict_'+str(rank)])
-
-        if is_mixedprecision:
-            for k, v in rank_state_dict['fp16_param'].items():
-                # verify fp16 weights match
-                assert_allclose(v, loaded_state_dict['fp16_param'][k])
-                # verify rank fp16 weights match loaded fp32 correctly
-                fp32_name = k.split('_fp16')[0]
-                assert_allclose(v, loaded_state_dict['fp32_param'][fp32_name], atol=global_fp16_fp32_atol)
-
-        for k, v in rank_state_dict['fp32_param'].items():
-            if k in loaded_state_dict['fp32_param']:
-                assert_allclose(v, loaded_state_dict['fp32_param'][k])
-            else:
-                assert '_view_' in k
-                weight_key = k.split('_view_')[0]
-                rank_offset = 0
-                if weight_key in sharded_state_rank_offset:
-                    rank_offset = sharded_state_rank_offset[weight_key]
-                rank_len = v.numel()
-                loaded_tensor = loaded_state_dict['fp32_param'][weight_key].view(-1)
-                assert rank_offset + rank_len <= loaded_tensor.numel()
-                assert_allclose(v, loaded_tensor[rank_offset: rank_offset + rank_len])
-                # update offset
-                sharded_state_rank_offset[weight_key] = rank_offset + rank_len
-
-        for k, v in rank_state_dict['optimizer'].items():
-            if k in loaded_state_dict['optimizer']:
-                assert_allclose(v, loaded_state_dict['optimizer'][k])
-            else:
-                assert '_view_' in k
-                if k.startswith('Moment_'):  # verify moment tensors
-                    optim_key = k.split('_view_')[0]
-                    rank_offset = 0
-                    if optim_key in sharded_state_rank_offset:
-                        rank_offset = sharded_state_rank_offset[optim_key]
-                    rank_len = v.numel()
-                    loaded_tensor = loaded_state_dict['optimizer'][optim_key].view(-1)
-                    assert rank_offset + rank_len <= loaded_tensor.numel()
-                    assert_allclose(v, loaded_tensor[rank_offset: rank_offset + rank_len])
-
-                    sharded_state_rank_offset[optim_key] = rank_offset + rank_len
+    # compare state dictionaries between the manually aggregated state dictionary with the aggregated state dictionary from the ORTTrainer
+    assert_all_states_close_ort(aggregate_state_dict_from_test, aggregate_state_dict_from_checkpoint, reshape_states=True)
 
 
 def test_aggregation_from_distributed_zero_full_precision_adam(device='cuda', checkpoint_dir='checkpoint_dir/distributed_zero/full_precision/adam/'):

--- a/orttraining/orttraining/test/python/checkpoint/orttraining_test_checkpoint_aggregation.py
+++ b/orttraining/orttraining/test/python/checkpoint/orttraining_test_checkpoint_aggregation.py
@@ -21,7 +21,8 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import onnxruntime
 from onnxruntime.training import checkpoint
-from _test_helpers import distributed_setup, create_orttrainer_and_load_checkpoint, aggregate_states, assert_all_states_close_ort
+from _test_helpers import distributed_setup, create_orttrainer_and_load_checkpoint, aggregate_states
+from _test_commons import assert_all_states_close_ort
 
 
 def test_zero_aggregation(checkpoint_dir, loaded_state_dict, is_mixedprecision):

--- a/orttraining/orttraining/test/python/checkpoint/orttraining_test_load_checkpoint.py
+++ b/orttraining/orttraining/test/python/checkpoint/orttraining_test_load_checkpoint.py
@@ -19,8 +19,8 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import onnxruntime
 from onnxruntime.training import checkpoint
-from _test_helpers import distributed_setup, create_orttrainer_and_load_checkpoint, aggregate_states, assert_all_states_close, assert_all_states_close_ort, assert_all_states_close_pytorch
-
+from _test_helpers import distributed_setup, create_orttrainer_and_load_checkpoint, aggregate_states, assert_all_states_close
+from _test_commons import assert_all_states_close_ort, assert_all_states_close_pytorch
 
 def test_load_from_single_node_full_precision_into_single_node_full_precision(device = 'cuda', checkpoint_dir = 'checkpoint_dir/single_node/full_precision/'):
     opts = {'device' : {'id' : device},

--- a/orttraining/orttraining/test/python/checkpoint/orttraining_test_load_checkpoint.py
+++ b/orttraining/orttraining/test/python/checkpoint/orttraining_test_load_checkpoint.py
@@ -8,8 +8,6 @@
 
 import os
 import pickle
-from numpy.testing import assert_allclose
-import numpy as np
 import argparse
 import glob
 
@@ -21,57 +19,28 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import onnxruntime
 from onnxruntime.training import checkpoint
-from _test_helpers import distributed_setup, create_orttrainer_and_load_checkpoint, split_state_dict, aggregate_states, global_fp16_fp32_atol
+from _test_helpers import distributed_setup, create_orttrainer_and_load_checkpoint, aggregate_states, assert_all_states_close, assert_all_states_close_ort, assert_all_states_close_pytorch
 
 
 def test_load_from_single_node_full_precision_into_single_node_full_precision(device = 'cuda', checkpoint_dir = 'checkpoint_dir/single_node/full_precision/'):
     opts = {'device' : {'id' : device},
             'debug' : {'deterministic_compute': True}}
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_pre_checkpoint.items():
-        assert_allclose(value, state_dict_post_checkpoint[key])
-    
-    # load state into pytorch and compare
-    model.load_state_dict(state_dict_pre_checkpoint, strict=False)
-    state_dict_pytorch = model.state_dict()
-    for key, value in state_dict_pytorch.items():
-        assert_allclose(value, state_dict_pre_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 def test_load_from_single_node_mixed_precision_into_single_node_full_precision(device = 'cuda', checkpoint_dir = 'checkpoint_dir/single_node/mixed_precision/'):
     opts = {'device' : {'id' : device},
             'debug' : {'deterministic_compute': True}}
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_pre_checkpoint.items():
-        if key.endswith('_fp16'):
-            full_precision_key = key[:-5]
-            assert full_precision_key in state_dict_post_checkpoint
-            assert_allclose(value, state_dict_post_checkpoint[full_precision_key], atol=global_fp16_fp32_atol)
-        else:
-            assert_allclose(value, state_dict_post_checkpoint[key])
-    
-    # load state into pytorch and compare
-    model.load_state_dict(state_dict_pre_checkpoint, strict=False)
-    state_dict_pytorch = model.state_dict()
-    for key, value in state_dict_pytorch.items():
-        assert_allclose(value, state_dict_pre_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 def test_load_from_single_node_mixed_precision_into_single_node_mixed_precision(device = 'cuda', checkpoint_dir = 'checkpoint_dir/single_node/mixed_precision/'):
     opts = {
@@ -82,18 +51,12 @@ def test_load_from_single_node_mixed_precision_into_single_node_mixed_precision(
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_pre_checkpoint.items():
-        assert_allclose(value, state_dict_post_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 def test_load_from_single_node_full_precision_into_single_node_mixed_precision(device = 'cuda', checkpoint_dir = 'checkpoint_dir/single_node/full_precision/'):
     opts = {
@@ -104,72 +67,32 @@ def test_load_from_single_node_full_precision_into_single_node_mixed_precision(d
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_post_checkpoint.items():
-        if key.endswith('_fp16'):
-            full_precision_key = key[:-5]
-            assert full_precision_key in state_dict_pre_checkpoint
-            assert_allclose(value, state_dict_pre_checkpoint[full_precision_key], atol=global_fp16_fp32_atol)
-        else:
-            assert_allclose(value, state_dict_pre_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 def test_load_from_data_parallelism_full_precision_into_single_node_full_precision(device = 'cuda', checkpoint_dir = 'checkpoint_dir/data_parallelism/full_precision/'):
     opts = {'device' : {'id' : device},
             'debug' : {'deterministic_compute': True}}
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_pre_checkpoint.items():
-        assert_allclose(value, state_dict_post_checkpoint[key])
-    
-    # load state into pytorch and compare
-    model.load_state_dict(state_dict_pre_checkpoint, strict=False)
-    state_dict_pytorch = model.state_dict()
-    for key, value in state_dict_pytorch.items():
-        assert_allclose(value, state_dict_pre_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 def test_load_from_data_parallelism_mixed_precision_into_single_node_full_precision(device = 'cuda', checkpoint_dir = 'checkpoint_dir/data_parallelism/mixed_precision/'):
     opts = {'device' : {'id' : device},
             'debug' : {'deterministic_compute': True}}
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_pre_checkpoint.items():
-        if key.endswith('_fp16'):
-            full_precision_key = key[:-5]
-            assert full_precision_key in state_dict_post_checkpoint
-            assert_allclose(value, state_dict_post_checkpoint[full_precision_key], atol=global_fp16_fp32_atol)
-        else:
-            assert_allclose(value, state_dict_post_checkpoint[key])
-    
-    # load state into pytorch and compare
-    model.load_state_dict(state_dict_pre_checkpoint, strict=False)
-    state_dict_pytorch = model.state_dict()
-    for key, value in state_dict_pytorch.items():
-        assert_allclose(value, state_dict_pre_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 def test_load_from_data_parallelism_mixed_precision_into_single_node_mixed_precision(device = 'cuda', checkpoint_dir = 'checkpoint_dir/data_parallelism/mixed_precision/'):
     opts = {
@@ -180,18 +103,12 @@ def test_load_from_data_parallelism_mixed_precision_into_single_node_mixed_preci
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_pre_checkpoint.items():
-        assert_allclose(value, state_dict_post_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 def test_load_from_data_parallelism_full_precision_into_single_node_mixed_precision(device = 'cuda', checkpoint_dir = 'checkpoint_dir/data_parallelism/full_precision/'):
     opts = {
@@ -202,97 +119,48 @@ def test_load_from_data_parallelism_full_precision_into_single_node_mixed_precis
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_post_checkpoint.items():
-        if key.endswith('_fp16'):
-            full_precision_key = key[:-5]
-            assert full_precision_key in state_dict_pre_checkpoint
-            assert_allclose(value, state_dict_pre_checkpoint[full_precision_key], atol=global_fp16_fp32_atol)
-        else:
-            assert_allclose(value, state_dict_pre_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 def test_load_from_distributed_zero_full_precision_into_single_node_full_precision(device = 'cuda', checkpoint_dir = 'checkpoint_dir/distributed_zero/full_precision/'):
     opts = {'device' : {'id' : device},
         'debug' : {'deterministic_compute': True}}
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
 
-    num_states = len(glob.glob1(checkpoint_dir,"state_dict*"))
-    optimizer_states = dict()
-    for rank in range(num_states):
-        state = None
-        with open(os.path.join(checkpoint_dir, 'state_dict_'+str(rank)+'.pkl'), 'rb') as f:
-            state = pickle.load(f)
-        state_dict_pre_checkpoint = split_state_dict(state['state_dict_'+str(rank)])
+    # manually aggregate states from the previously saved state dictionary in a pickle file
+    aggregated_state_dict = aggregate_states(checkpoint_dir)
 
-        # compare all states
-        # model states
-        for key, value in state_dict_pre_checkpoint['fp32_param'].items():
-            assert_allclose(value, state_dict_post_checkpoint['fp32_param'][key])
+    # compare the manually aggregated state dictionary with the aggregated state dictionary from the ORTTrainer
+    assert_all_states_close_ort(aggregated_state_dict, state_dict_post_checkpoint, reshape_states=True)
 
-        # collect optimizer states for later comparison since they are sharded
-        aggregate_states(optimizer_states, state_dict_pre_checkpoint['optimizer'])
-
-    # compare optimizer states
-    for key, value in optimizer_states.items():
-        assert_allclose(value.reshape(state_dict_post_checkpoint['optimizer'][key].size()), state_dict_post_checkpoint['optimizer'][key])
-    
-    # load state into pytorch and compare
-    checkpoint_files = checkpoint._list_checkpoint_files(checkpoint_dir, "ORT_checkpoint")
-    agg_checkpoint = checkpoint._CombineZeroCheckpoint(checkpoint_files)
-    agg_state_dict = agg_checkpoint.aggregate_checkpoints()
-    model.load_state_dict(agg_state_dict, strict=False)
-    state_dict_pytorch = model.state_dict()
-    for key, value in state_dict_pytorch.items():
-        assert_allclose(value, agg_state_dict[key])
+    # aggregate checkpoints previously saved and load it into the pytorch model for comparison
+    checkpoint_files = glob.glob(os.path.join(checkpoint_dir, 'checkpoint*.ortcp'))
+    agg_state_dict = checkpoint.aggregate_checkpoints(checkpoint_files, pytorch_format=True)
+    assert_all_states_close_pytorch(agg_state_dict, model)
 
 def test_load_from_distributed_zero_mixed_precision_into_single_node_full_precision(device = 'cuda', checkpoint_dir = 'checkpoint_dir/distributed_zero/mixed_precision/lamb'):
     opts = {'device' : {'id' : device},
         'debug' : {'deterministic_compute': True}}
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
 
-    num_states = len(glob.glob1(checkpoint_dir,"state_dict*"))
-    optimizer_states = dict()
-    for rank in range(num_states):
-        state = None
-        with open(os.path.join(checkpoint_dir, 'state_dict_'+str(rank)+'.pkl'), 'rb') as f:
-            state = pickle.load(f)
-        state_dict_pre_checkpoint = split_state_dict(state['state_dict_'+str(rank)])
+    # manually aggregate states from the previously saved state dictionary in a pickle file
+    aggregated_state_dict = aggregate_states(checkpoint_dir)
 
-        # compare all states
-        # fp16 states are not sharded
-        for key, value in state_dict_pre_checkpoint['fp16_param'].items():
-            assert_allclose(value, state_dict_post_checkpoint['fp32_param'][key[:-5]], atol=global_fp16_fp32_atol)
+    # compare the manually aggregated state dictionary with the aggregated state dictionary from the ORTTrainer
+    assert_all_states_close_ort(aggregated_state_dict, state_dict_post_checkpoint, reshape_states=True)
 
-        # collect optimizer states for later comparison since they are sharded
-        aggregate_states(optimizer_states, state_dict_pre_checkpoint['optimizer'])
-
-    # compare optimizer states
-    for key, value in optimizer_states.items():
-        assert_allclose(value.reshape(state_dict_post_checkpoint['optimizer'][key].size()), state_dict_post_checkpoint['optimizer'][key])
-    
-    # load state into pytorch and compare
-    checkpoint_files = checkpoint._list_checkpoint_files(checkpoint_dir, "ORT_checkpoint")
-    agg_checkpoint = checkpoint._CombineZeroCheckpoint(checkpoint_files)
-    agg_state_dict = agg_checkpoint.aggregate_checkpoints()
-    model.load_state_dict(agg_state_dict, strict=False)
-    state_dict_pytorch = model.state_dict()
-    for key, value in state_dict_pytorch.items():
-        assert_allclose(value, agg_state_dict[key])
+    # aggregate checkpoints previously saved and load it into the pytorch model for comparison
+    checkpoint_files = glob.glob(os.path.join(checkpoint_dir, 'checkpoint*.ortcp'))
+    agg_state_dict = checkpoint.aggregate_checkpoints(checkpoint_files, pytorch_format=True)
+    assert_all_states_close_pytorch(agg_state_dict, model)
 
 def test_load_from_distributed_zero_mixed_precision_into_single_node_mixed_precision(device = 'cuda', checkpoint_dir = 'checkpoint_dir/distributed_zero/mixed_precision/lamb'):
     opts = {
@@ -303,30 +171,20 @@ def test_load_from_distributed_zero_mixed_precision_into_single_node_mixed_preci
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
 
-    num_states = len(glob.glob1(checkpoint_dir,"state_dict*"))
-    optimizer_states = dict()
-    for rank in range(num_states):
-        state = None
-        with open(os.path.join(checkpoint_dir, 'state_dict_'+str(rank)+'.pkl'), 'rb') as f:
-            state = pickle.load(f)
-        state_dict_pre_checkpoint = split_state_dict(state['state_dict_'+str(rank)])
+    # manually aggregate states from the previously saved state dictionary in a pickle file
+    aggregated_state_dict = aggregate_states(checkpoint_dir)
 
-        # compare all states
-        # fp16 states are not sharded
-        for key, value in state_dict_pre_checkpoint['fp16_param'].items():
-            assert_allclose(value, state_dict_post_checkpoint['fp16_param'][key])
+    # compare the manually aggregated state dictionary with the aggregated state dictionary from the ORTTrainer
+    assert_all_states_close_ort(aggregated_state_dict, state_dict_post_checkpoint, reshape_states=True)
 
-        # collect optimizer states for later comparison since they are sharded
-        aggregate_states(optimizer_states, state_dict_pre_checkpoint['optimizer'])
-
-    # compare optimizer states
-    for key, value in optimizer_states.items():
-        assert_allclose(value.reshape(state_dict_post_checkpoint['optimizer'][key].size()), state_dict_post_checkpoint['optimizer'][key])
+    # aggregate checkpoints previously saved and load it into the pytorch model for comparison
+    checkpoint_files = glob.glob(os.path.join(checkpoint_dir, 'checkpoint*.ortcp'))
+    agg_state_dict = checkpoint.aggregate_checkpoints(checkpoint_files, pytorch_format=True)
+    assert_all_states_close_pytorch(agg_state_dict, model)
 
 def test_load_from_distributed_zero_full_precision_into_single_node_mixed_precision(device = 'cuda', checkpoint_dir = 'checkpoint_dir/distributed_zero/full_precision/lamb/'):
     opts = {
@@ -337,30 +195,20 @@ def test_load_from_distributed_zero_full_precision_into_single_node_mixed_precis
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
 
-    num_states = len(glob.glob1(checkpoint_dir,"state_dict*"))
-    optimizer_states = dict()
-    for rank in range(num_states):
-        state = None
-        with open(os.path.join(checkpoint_dir, 'state_dict_'+str(rank)+'.pkl'), 'rb') as f:
-            state = pickle.load(f)
-        state_dict_pre_checkpoint = split_state_dict(state['state_dict_'+str(rank)])
+    # manually aggregate states from the previously saved state dictionary in a pickle file
+    aggregated_state_dict = aggregate_states(checkpoint_dir)
 
-        # compare all states
-        # fp32 states are not sharded
-        for key, value in state_dict_post_checkpoint['fp16_param'].items():
-            assert_allclose(value, state_dict_pre_checkpoint['fp32_param'][key[:-5]], atol=global_fp16_fp32_atol)
+    # compare the manually aggregated state dictionary with the aggregated state dictionary from the ORTTrainer
+    assert_all_states_close_ort(aggregated_state_dict, state_dict_post_checkpoint, reshape_states=True)
 
-        # collect optimizer states for later comparison since they are sharded
-        aggregate_states(optimizer_states, state_dict_pre_checkpoint['optimizer'])
-
-    # compare optimizer states
-    for key, value in optimizer_states.items():
-        assert_allclose(value.reshape(state_dict_post_checkpoint['optimizer'][key].size()), state_dict_post_checkpoint['optimizer'][key])
+    # aggregate checkpoints previously saved and load it into the pytorch model for comparison
+    checkpoint_files = glob.glob(os.path.join(checkpoint_dir, 'checkpoint*.ortcp'))
+    agg_state_dict = checkpoint.aggregate_checkpoints(checkpoint_files, pytorch_format=True)
+    assert_all_states_close_pytorch(agg_state_dict, model)
 
 @distributed_setup
 def test_load_from_single_node_full_precision_into_data_parallelism_full_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/single_node/full_precision/'):
@@ -374,24 +222,12 @@ def test_load_from_single_node_full_precision_into_data_parallelism_full_precisi
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_pre_checkpoint.items():
-        assert_allclose(value, state_dict_post_checkpoint[key])
-    
-    # load state into pytorch and compare
-    model.load_state_dict(state_dict_pre_checkpoint, strict=False)
-    state_dict_pytorch = model.state_dict()
-    for key, value in state_dict_pytorch.items():
-        assert_allclose(value, state_dict_pre_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 @distributed_setup
 def test_load_from_single_node_mixed_precision_into_data_parallelism_full_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/single_node/mixed_precision/'):
@@ -405,29 +241,12 @@ def test_load_from_single_node_mixed_precision_into_data_parallelism_full_precis
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_pre_checkpoint.items():
-        if key.endswith('_fp16'):
-            full_precision_key = key[:-5]
-            assert full_precision_key in state_dict_post_checkpoint
-            assert_allclose(value, state_dict_post_checkpoint[full_precision_key], atol=global_fp16_fp32_atol)
-        else:
-            assert_allclose(value, state_dict_post_checkpoint[key])
-    
-    # load state into pytorch and compare
-    model.load_state_dict(state_dict_pre_checkpoint, strict=False)
-    state_dict_pytorch = model.state_dict()
-    for key, value in state_dict_pytorch.items():
-        assert_allclose(value, state_dict_pre_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 @distributed_setup
 def test_load_from_single_node_mixed_precision_into_data_parallelism_mixed_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/single_node/mixed_precision/'):
@@ -445,18 +264,12 @@ def test_load_from_single_node_mixed_precision_into_data_parallelism_mixed_preci
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_pre_checkpoint.items():
-        assert_allclose(value, state_dict_post_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 @distributed_setup
 def test_load_from_single_node_full_precision_into_data_parallelism_mixed_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/single_node/full_precision/'):
@@ -474,23 +287,12 @@ def test_load_from_single_node_full_precision_into_data_parallelism_mixed_precis
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_post_checkpoint.items():
-        if key.endswith('_fp16'):
-            full_precision_key = key[:-5]
-            assert full_precision_key in state_dict_pre_checkpoint
-            assert_allclose(value, state_dict_pre_checkpoint[full_precision_key], atol=global_fp16_fp32_atol)
-        else:
-            assert_allclose(value, state_dict_pre_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 @distributed_setup
 def test_load_from_data_parallelism_full_precision_into_data_parallelism_full_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/data_parallelism/full_precision/'):
@@ -504,24 +306,12 @@ def test_load_from_data_parallelism_full_precision_into_data_parallelism_full_pr
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_pre_checkpoint.items():
-        assert_allclose(value, state_dict_post_checkpoint[key])
-    
-    # load state into pytorch and compare
-    model.load_state_dict(state_dict_pre_checkpoint, strict=False)
-    state_dict_pytorch = model.state_dict()
-    for key, value in state_dict_pytorch.items():
-        assert_allclose(value, state_dict_pre_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 @distributed_setup
 def test_load_from_data_parallelism_mixed_precision_into_data_parallelism_full_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/data_parallelism/mixed_precision/'):
@@ -535,29 +325,12 @@ def test_load_from_data_parallelism_mixed_precision_into_data_parallelism_full_p
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_pre_checkpoint.items():
-        if key.endswith('_fp16'):
-            full_precision_key = key[:-5]
-            assert full_precision_key in state_dict_post_checkpoint
-            assert_allclose(value, state_dict_post_checkpoint[full_precision_key], atol=global_fp16_fp32_atol)
-        else:
-            assert_allclose(value, state_dict_post_checkpoint[key])
-    
-    # load state into pytorch and compare
-    model.load_state_dict(state_dict_pre_checkpoint, strict=False)
-    state_dict_pytorch = model.state_dict()
-    for key, value in state_dict_pytorch.items():
-        assert_allclose(value, state_dict_pre_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 @distributed_setup
 def test_load_from_data_parallelism_mixed_precision_into_data_parallelism_mixed_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/data_parallelism/mixed_precision/'):
@@ -575,18 +348,12 @@ def test_load_from_data_parallelism_mixed_precision_into_data_parallelism_mixed_
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_pre_checkpoint.items():
-        assert_allclose(value, state_dict_post_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 @distributed_setup
 def test_load_from_data_parallelism_full_precision_into_data_parallelism_mixed_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/data_parallelism/full_precision/'):
@@ -604,23 +371,12 @@ def test_load_from_data_parallelism_full_precision_into_data_parallelism_mixed_p
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = state['state_dict']
-
     # compare all states
-    for key, value in state_dict_post_checkpoint.items():
-        if key.endswith('_fp16'):
-            full_precision_key = key[:-5]
-            assert full_precision_key in state_dict_pre_checkpoint
-            assert_allclose(value, state_dict_pre_checkpoint[full_precision_key], atol=global_fp16_fp32_atol)
-        else:
-            assert_allclose(value, state_dict_pre_checkpoint[key])
+    assert_all_states_close(checkpoint_dir, 'state_dict', state_dict_post_checkpoint, model)
 
 @distributed_setup
 def test_load_from_distributed_zero_full_precision_into_data_parallelism_full_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/distributed_zero/full_precision/lamb/'):
@@ -634,39 +390,20 @@ def test_load_from_distributed_zero_full_precision_into_data_parallelism_full_pr
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
 
-    num_states = len(glob.glob1(checkpoint_dir,"state_dict*"))
-    optimizer_states = dict()
-    for rank in range(num_states):
-        state = None
-        with open(os.path.join(checkpoint_dir, 'state_dict_'+str(rank)+'.pkl'), 'rb') as f:
-            state = pickle.load(f)
-        state_dict_pre_checkpoint = split_state_dict(state['state_dict_'+str(rank)])
+    # manually aggregate states from the previously saved state dictionary in a pickle file
+    aggregated_state_dict = aggregate_states(checkpoint_dir)
 
-        # compare all states
-        # model states
-        for key, value in state_dict_pre_checkpoint['fp32_param'].items():
-            assert_allclose(value, state_dict_post_checkpoint['fp32_param'][key])
+    # compare the manually aggregated state dictionary with the aggregated state dictionary from the ORTTrainer
+    assert_all_states_close_ort(aggregated_state_dict, state_dict_post_checkpoint, reshape_states=True)
 
-        # collect optimizer states for later comparison since they are sharded
-        aggregate_states(optimizer_states, state_dict_pre_checkpoint['optimizer'])
-
-    # compare optimizer states
-    for key, value in optimizer_states.items():
-        assert_allclose(value.reshape(state_dict_post_checkpoint['optimizer'][key].size()), state_dict_post_checkpoint['optimizer'][key])
-    
-    # load state into pytorch and compare
-    checkpoint_files = checkpoint._list_checkpoint_files(checkpoint_dir, "ORT_checkpoint")
-    agg_checkpoint = checkpoint._CombineZeroCheckpoint(checkpoint_files)
-    agg_state_dict = agg_checkpoint.aggregate_checkpoints()
-    model.load_state_dict(agg_state_dict, strict=False)
-    state_dict_pytorch = model.state_dict()
-    for key, value in state_dict_pytorch.items():
-        assert_allclose(value, agg_state_dict[key])
+    # aggregate checkpoints previously saved and load it into the pytorch model for comparison
+    checkpoint_files = glob.glob(os.path.join(checkpoint_dir, 'checkpoint*.ortcp'))
+    agg_state_dict = checkpoint.aggregate_checkpoints(checkpoint_files, pytorch_format=True)
+    assert_all_states_close_pytorch(agg_state_dict, model)
 
 @distributed_setup
 def test_load_from_distributed_zero_mixed_precision_into_data_parallelism_full_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/distributed_zero/mixed_precision/lamb'):
@@ -680,39 +417,20 @@ def test_load_from_distributed_zero_mixed_precision_into_data_parallelism_full_p
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
 
-    num_states = len(glob.glob1(checkpoint_dir,"state_dict*"))
-    optimizer_states = dict()
-    for rank in range(num_states):
-        state = None
-        with open(os.path.join(checkpoint_dir, 'state_dict_'+str(rank)+'.pkl'), 'rb') as f:
-            state = pickle.load(f)
-        state_dict_pre_checkpoint = split_state_dict(state['state_dict_'+str(rank)])
+    # manually aggregate states from the previously saved state dictionary in a pickle file
+    aggregated_state_dict = aggregate_states(checkpoint_dir)
 
-        # compare all states
-        # fp16 states are not sharded
-        for key, value in state_dict_pre_checkpoint['fp16_param'].items():
-            assert_allclose(value, state_dict_post_checkpoint['fp32_param'][key[:-5]], atol=global_fp16_fp32_atol)
+    # compare the manually aggregated state dictionary with the aggregated state dictionary from the ORTTrainer
+    assert_all_states_close_ort(aggregated_state_dict, state_dict_post_checkpoint, reshape_states=True)
 
-        # collect optimizer states for later comparison since they are sharded
-        aggregate_states(optimizer_states, state_dict_pre_checkpoint['optimizer'])
-
-    # compare optimizer states
-    for key, value in optimizer_states.items():
-        assert_allclose(value.reshape(state_dict_post_checkpoint['optimizer'][key].size()), state_dict_post_checkpoint['optimizer'][key])
-    
-    # load state into pytorch and compare
-    checkpoint_files = checkpoint._list_checkpoint_files(checkpoint_dir, "ORT_checkpoint")
-    agg_checkpoint = checkpoint._CombineZeroCheckpoint(checkpoint_files)
-    agg_state_dict = agg_checkpoint.aggregate_checkpoints()
-    model.load_state_dict(agg_state_dict, strict=False)
-    state_dict_pytorch = model.state_dict()
-    for key, value in state_dict_pytorch.items():
-        assert_allclose(value, agg_state_dict[key])
+    # aggregate checkpoints previously saved and load it into the pytorch model for comparison
+    checkpoint_files = glob.glob(os.path.join(checkpoint_dir, 'checkpoint*.ortcp'))
+    agg_state_dict = checkpoint.aggregate_checkpoints(checkpoint_files, pytorch_format=True)
+    assert_all_states_close_pytorch(agg_state_dict, model)
 
 @distributed_setup
 def test_load_from_distributed_zero_mixed_precision_into_data_parallelism_mixed_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/distributed_zero/mixed_precision/lamb'):
@@ -730,30 +448,20 @@ def test_load_from_distributed_zero_mixed_precision_into_data_parallelism_mixed_
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
 
-    num_states = len(glob.glob1(checkpoint_dir,"state_dict*"))
-    optimizer_states = dict()
-    for rank in range(num_states):
-        state = None
-        with open(os.path.join(checkpoint_dir, 'state_dict_'+str(rank)+'.pkl'), 'rb') as f:
-            state = pickle.load(f)
-        state_dict_pre_checkpoint = split_state_dict(state['state_dict_'+str(rank)])
+    # manually aggregate states from the previously saved state dictionary in a pickle file
+    aggregated_state_dict = aggregate_states(checkpoint_dir)
 
-        # compare all states
-        # fp16 states are not sharded
-        for key, value in state_dict_pre_checkpoint['fp16_param'].items():
-            assert_allclose(value, state_dict_post_checkpoint['fp16_param'][key])
+    # compare the manually aggregated state dictionary with the aggregated state dictionary from the ORTTrainer
+    assert_all_states_close_ort(aggregated_state_dict, state_dict_post_checkpoint, reshape_states=True)
 
-        # collect optimizer states for later comparison since they are sharded
-        aggregate_states(optimizer_states, state_dict_pre_checkpoint['optimizer'])
-
-    # compare optimizer states
-    for key, value in optimizer_states.items():
-        assert_allclose(value.reshape(state_dict_post_checkpoint['optimizer'][key].size()), state_dict_post_checkpoint['optimizer'][key])
+    # aggregate checkpoints previously saved and load it into the pytorch model for comparison
+    checkpoint_files = glob.glob(os.path.join(checkpoint_dir, 'checkpoint*.ortcp'))
+    agg_state_dict = checkpoint.aggregate_checkpoints(checkpoint_files, pytorch_format=True)
+    assert_all_states_close_pytorch(agg_state_dict, model)
 
 @distributed_setup
 def test_load_from_distributed_zero_full_precision_into_data_parallelism_mixed_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/distributed_zero/full_precision/lamb/'):
@@ -771,30 +479,20 @@ def test_load_from_distributed_zero_full_precision_into_data_parallelism_mixed_p
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
     state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
 
-    num_states = len(glob.glob1(checkpoint_dir,"state_dict*"))
-    optimizer_states = dict()
-    for rank in range(num_states):
-        state = None
-        with open(os.path.join(checkpoint_dir, 'state_dict_'+str(rank)+'.pkl'), 'rb') as f:
-            state = pickle.load(f)
-        state_dict_pre_checkpoint = split_state_dict(state['state_dict_'+str(rank)])
+    # manually aggregate states from the previously saved state dictionary in a pickle file
+    aggregated_state_dict = aggregate_states(checkpoint_dir)
 
-        # compare all states
-        # fp32 states are not sharded
-        for key, value in state_dict_post_checkpoint['fp16_param'].items():
-            assert_allclose(value, state_dict_pre_checkpoint['fp32_param'][key[:-5]], atol=global_fp16_fp32_atol)
+    # compare the manually aggregated state dictionary with the aggregated state dictionary from the ORTTrainer
+    assert_all_states_close_ort(aggregated_state_dict, state_dict_post_checkpoint, reshape_states=True)
 
-        # collect optimizer states for later comparison since they are sharded
-        aggregate_states(optimizer_states, state_dict_pre_checkpoint['optimizer'])
-
-    # compare optimizer states
-    for key, value in optimizer_states.items():
-        assert_allclose(value.reshape(state_dict_post_checkpoint['optimizer'][key].size()), state_dict_post_checkpoint['optimizer'][key])
+    # aggregate checkpoints previously saved and load it into the pytorch model for comparison
+    checkpoint_files = glob.glob(os.path.join(checkpoint_dir, 'checkpoint*.ortcp'))
+    agg_state_dict = checkpoint.aggregate_checkpoints(checkpoint_files, pytorch_format=True)
+    assert_all_states_close_pytorch(agg_state_dict, model)
 
 @distributed_setup
 def test_load_from_single_node_full_precision_into_distributed_zero_full_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/single_node/full_precision/'):
@@ -812,44 +510,31 @@ def test_load_from_single_node_full_precision_into_distributed_zero_full_precisi
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
-    state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
+    state_dict_post_checkpoint, _ = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
     state = None
     with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
         state = pickle.load(f)
-    state_dict_pre_checkpoint = split_state_dict(state['state_dict'])
+    state_dict_pre_checkpoint = state['state_dict']
 
-    # compare all states
-    # model states
-    for key, value in state_dict_pre_checkpoint['fp32_param'].items():
-        assert_allclose(value, state_dict_post_checkpoint['fp32_param'][key])
+    # To compare state dictioanry from a single node trainer to the state dictioanry from a zero run:
+    # - Save the state dictionaries for each rank for the zero run in a pickle file (distributed_state_world_rank.pkl)
+    # - On rank 0, manually load each state dictionary and aggregate all of them into a single state dictionary.
+    # - Compare the aggregated state dictionary against the state dictionary previously saved from the single node run.
 
-    # round about way of checking optimizer states. Save state dicts into temporary folder, read them and aggregate them.
     with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'), "wb") as f:
         pickle.dump(state_dict_post_checkpoint, f)
     dist.barrier()
 
     if world_rank == 0:
-        num_states = len(glob.glob1(checkpoint_dir,"distributed_state*"))
-        optimizer_states = dict()
-        for rank in range(num_states):
-            rank_state_dict = None
-            with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(rank)+'.pkl'), 'rb') as f:
-                rank_state_dict = pickle.load(f)
+        # manually aggregate states from the previously saved state dictionary in a pickle file
+        aggregated_state_dict = aggregate_states(checkpoint_dir, filename_prefix='distributed_state', state_dict_key_name=None)
 
-            # collect optimizer states for later comparison since they are sharded
-            aggregate_states(optimizer_states, rank_state_dict['optimizer'])
+        # compare the manually aggregated state dictionary with the single node state dictionary that was previously saved in a pickle file
+        assert_all_states_close_ort(aggregated_state_dict, state_dict_pre_checkpoint, reshape_states=True)
 
-        # compare optimizer states
-        """
-        TODO: Uncomment this after Checkpoint redesign. Current implementation does not support it
-        for key, value in optimizer_states.items():
-            assert_allclose(value.reshape(state_dict_pre_checkpoint['optimizer'][key].size()), state_dict_pre_checkpoint['optimizer'][key])
-        """
-    
     dist.barrier()
     os.remove(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'))
 
@@ -869,44 +554,31 @@ def test_load_from_single_node_mixed_precision_into_distributed_zero_full_precis
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
-    state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
+    state_dict_post_checkpoint, _ = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
     state = None
     with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
         state = pickle.load(f)
-    state_dict_pre_checkpoint = split_state_dict(state['state_dict'])
+    state_dict_pre_checkpoint = state['state_dict']
 
-    # compare all states
-    # model states
-    for key, value in state_dict_pre_checkpoint['fp16_param'].items():
-        assert_allclose(value, state_dict_post_checkpoint['fp32_param'][key[:-5]], atol=global_fp16_fp32_atol)
+    # To compare state dictioanry from a single node trainer to the state dictioanry from a zero run:
+    # - Save the state dictionaries for each rank for the zero run in a pickle file (distributed_state_world_rank.pkl)
+    # - On rank 0, manually load each state dictionary and aggregate all of them into a single state dictionary.
+    # - Compare the aggregated state dictionary against the state dictionary previously saved from the single node run.
 
-    # round about way of checking optimizer states. Save state dicts into temporary folder, read them and aggregate them.
     with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'), "wb") as f:
         pickle.dump(state_dict_post_checkpoint, f)
     dist.barrier()
 
     if world_rank == 0:
-        num_states = len(glob.glob1(checkpoint_dir,"distributed_state*"))
-        optimizer_states = dict()
-        for rank in range(num_states):
-            rank_state_dict = None
-            with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(rank)+'.pkl'), 'rb') as f:
-                rank_state_dict = pickle.load(f)
+        # manually aggregate states from the previously saved state dictionary in a pickle file
+        aggregated_state_dict = aggregate_states(checkpoint_dir, filename_prefix='distributed_state', state_dict_key_name=None)
 
-            # collect optimizer states for later comparison since they are sharded
-            aggregate_states(optimizer_states, rank_state_dict['optimizer'])
+        # compare the manually aggregated state dictionary with the single node state dictionary that was previously saved in a pickle file
+        assert_all_states_close_ort(aggregated_state_dict, state_dict_pre_checkpoint, reshape_states=True)
 
-        # compare optimizer states
-        """
-        TODO: Uncomment this after Checkpoint redesign. Current implementation does not support it
-        for key, value in optimizer_states.items():
-            assert_allclose(value.reshape(state_dict_pre_checkpoint['optimizer'][key].size()), state_dict_pre_checkpoint['optimizer'][key])
-        """
-    
     dist.barrier()
     os.remove(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'))
 
@@ -930,44 +602,31 @@ def test_load_from_single_node_mixed_precision_into_distributed_zero_mixed_preci
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
-    state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
+    state_dict_post_checkpoint, _ = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
     state = None
     with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
         state = pickle.load(f)
-    state_dict_pre_checkpoint = split_state_dict(state['state_dict'])
+    state_dict_pre_checkpoint = state['state_dict']
 
-    # compare all states
-    # model states
-    for key, value in state_dict_pre_checkpoint['fp16_param'].items():
-        assert_allclose(value, state_dict_post_checkpoint['fp16_param'][key])
+    # To compare state dictioanry from a single node trainer to the state dictioanry from a zero run:
+    # - Save the state dictionaries for each rank for the zero run in a pickle file (distributed_state_world_rank.pkl)
+    # - On rank 0, manually load each state dictionary and aggregate all of them into a single state dictionary.
+    # - Compare the aggregated state dictionary against the state dictionary previously saved from the single node run.
 
-    # round about way of checking optimizer states. Save state dicts into temporary folder, read them and aggregate them.
     with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'), "wb") as f:
         pickle.dump(state_dict_post_checkpoint, f)
     dist.barrier()
 
     if world_rank == 0:
-        num_states = len(glob.glob1(checkpoint_dir,"distributed_state*"))
-        optimizer_states = dict()
-        for rank in range(num_states):
-            rank_state_dict = None
-            with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(rank)+'.pkl'), 'rb') as f:
-                rank_state_dict = pickle.load(f)
+        # manually aggregate states from the previously saved state dictionary in a pickle file
+        aggregated_state_dict = aggregate_states(checkpoint_dir, filename_prefix='distributed_state', state_dict_key_name=None)
 
-            # collect optimizer states for later comparison since they are sharded
-            aggregate_states(optimizer_states, rank_state_dict['optimizer'])
+        # compare the manually aggregated state dictionary with the single node state dictionary that was previously saved in a pickle file
+        assert_all_states_close_ort(aggregated_state_dict, state_dict_pre_checkpoint, reshape_states=True)
 
-        # compare optimizer states
-        """
-        TODO: Uncomment this after Checkpoint redesign. Current implementation does not support it
-        for key, value in optimizer_states.items():
-            assert_allclose(value.reshape(state_dict_pre_checkpoint['optimizer'][key].size()), state_dict_pre_checkpoint['optimizer'][key])
-        """
-    
     dist.barrier()
     os.remove(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'))
 
@@ -991,44 +650,31 @@ def test_load_from_single_node_full_precision_into_distributed_zero_mixed_precis
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
-    state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
+    state_dict_post_checkpoint, _ = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
     state = None
     with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
         state = pickle.load(f)
-    state_dict_pre_checkpoint = split_state_dict(state['state_dict'])
+    state_dict_pre_checkpoint = state['state_dict']
 
-    # compare all states
-    # model states
-    for key, value in state_dict_post_checkpoint['fp16_param'].items():
-        assert_allclose(value, state_dict_pre_checkpoint['fp32_param'][key[:-5]], atol=global_fp16_fp32_atol)
+    # To compare state dictioanry from a single node trainer to the state dictioanry from a zero run:
+    # - Save the state dictionaries for each rank for the zero run in a pickle file (distributed_state_world_rank.pkl)
+    # - On rank 0, manually load each state dictionary and aggregate all of them into a single state dictionary.
+    # - Compare the aggregated state dictionary against the state dictionary previously saved from the single node run.
 
-    # round about way of checking optimizer states. Save state dicts into temporary folder, read them and aggregate them.
     with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'), "wb") as f:
         pickle.dump(state_dict_post_checkpoint, f)
     dist.barrier()
 
     if world_rank == 0:
-        num_states = len(glob.glob1(checkpoint_dir,"distributed_state*"))
-        optimizer_states = dict()
-        for rank in range(num_states):
-            rank_state_dict = None
-            with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(rank)+'.pkl'), 'rb') as f:
-                rank_state_dict = pickle.load(f)
+        # manually aggregate states from the previously saved state dictionary in a pickle file
+        aggregated_state_dict = aggregate_states(checkpoint_dir, filename_prefix='distributed_state', state_dict_key_name=None)
 
-            # collect optimizer states for later comparison since they are sharded
-            aggregate_states(optimizer_states, rank_state_dict['optimizer'])
+        # compare the manually aggregated state dictionary with the single node state dictionary that was previously saved in a pickle file
+        assert_all_states_close_ort(aggregated_state_dict, state_dict_pre_checkpoint, reshape_states=True)
 
-        # compare optimizer states
-        """
-        TODO: Uncomment this after Checkpoint redesign. Current implementation does not support it
-        for key, value in optimizer_states.items():
-            assert_allclose(value.reshape(state_dict_pre_checkpoint['optimizer'][key].size()), state_dict_pre_checkpoint['optimizer'][key])
-        """
-    
     dist.barrier()
     os.remove(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'))
 
@@ -1048,44 +694,31 @@ def test_load_from_data_parallelism_full_precision_into_distributed_zero_full_pr
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
-    state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
+    state_dict_post_checkpoint, _ = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
     state = None
     with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
         state = pickle.load(f)
-    state_dict_pre_checkpoint = split_state_dict(state['state_dict'])
+    state_dict_pre_checkpoint = state['state_dict']
 
-    # compare all states
-    # model states
-    for key, value in state_dict_pre_checkpoint['fp32_param'].items():
-        assert_allclose(value, state_dict_post_checkpoint['fp32_param'][key])
+    # To compare state dictioanry from a data parallel node trainer to the state dictioanry from a zero run:
+    # - Save the state dictionaries for each rank for the zero run in a pickle file (distributed_state_world_rank.pkl)
+    # - On rank 0, manually load each state dictionary and aggregate all of them into a single state dictionary.
+    # - Compare the aggregated state dictionary against the state dictionary previously saved from the data parallel node run.
 
-    # round about way of checking optimizer states. Save state dicts into temporary folder, read them and aggregate them.
     with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'), "wb") as f:
         pickle.dump(state_dict_post_checkpoint, f)
     dist.barrier()
 
     if world_rank == 0:
-        num_states = len(glob.glob1(checkpoint_dir,"distributed_state*"))
-        optimizer_states = dict()
-        for rank in range(num_states):
-            rank_state_dict = None
-            with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(rank)+'.pkl'), 'rb') as f:
-                rank_state_dict = pickle.load(f)
+        # manually aggregate states from the previously saved state dictionary in a pickle file
+        aggregated_state_dict = aggregate_states(checkpoint_dir, filename_prefix='distributed_state', state_dict_key_name=None)
 
-            # collect optimizer states for later comparison since they are sharded
-            aggregate_states(optimizer_states, rank_state_dict['optimizer'])
+        # compare the manually aggregated state dictionary with the data parallel state dictionary that was previously saved in a pickle file
+        assert_all_states_close_ort(aggregated_state_dict, state_dict_pre_checkpoint, reshape_states=True)
 
-        # compare optimizer states
-        """
-        TODO: Uncomment this after Checkpoint redesign. Current implementation does not support it
-        for key, value in optimizer_states.items():
-            assert_allclose(value.reshape(state_dict_pre_checkpoint['optimizer'][key].size()), state_dict_pre_checkpoint['optimizer'][key])
-        """
-    
     dist.barrier()
     os.remove(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'))
 
@@ -1105,44 +738,31 @@ def test_load_from_data_parallelism_mixed_precision_into_distributed_zero_full_p
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
-    state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
+    state_dict_post_checkpoint, _ = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
     state = None
     with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
         state = pickle.load(f)
-    state_dict_pre_checkpoint = split_state_dict(state['state_dict'])
+    state_dict_pre_checkpoint = state['state_dict']
 
-    # compare all states
-    # model states
-    for key, value in state_dict_pre_checkpoint['fp16_param'].items():
-        assert_allclose(value, state_dict_post_checkpoint['fp32_param'][key[:-5]], atol=global_fp16_fp32_atol)
+    # To compare state dictioanry from a data parallel node trainer to the state dictioanry from a zero run:
+    # - Save the state dictionaries for each rank for the zero run in a pickle file (distributed_state_world_rank.pkl)
+    # - On rank 0, manually load each state dictionary and aggregate all of them into a single state dictionary.
+    # - Compare the aggregated state dictionary against the state dictionary previously saved from the data parallel node run.
 
-    # round about way of checking optimizer states. Save state dicts into temporary folder, read them and aggregate them.
     with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'), "wb") as f:
         pickle.dump(state_dict_post_checkpoint, f)
     dist.barrier()
 
     if world_rank == 0:
-        num_states = len(glob.glob1(checkpoint_dir,"distributed_state*"))
-        optimizer_states = dict()
-        for rank in range(num_states):
-            rank_state_dict = None
-            with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(rank)+'.pkl'), 'rb') as f:
-                rank_state_dict = pickle.load(f)
+        # manually aggregate states from the previously saved state dictionary in a pickle file
+        aggregated_state_dict = aggregate_states(checkpoint_dir, filename_prefix='distributed_state', state_dict_key_name=None)
 
-            # collect optimizer states for later comparison since they are sharded
-            aggregate_states(optimizer_states, rank_state_dict['optimizer'])
+        # compare the manually aggregated state dictionary with the data parallel state dictionary that was previously saved in a pickle file
+        assert_all_states_close_ort(aggregated_state_dict, state_dict_pre_checkpoint, reshape_states=True)
 
-        # compare optimizer states
-        """
-        TODO: Uncomment this after Checkpoint redesign. Current implementation does not support it
-        for key, value in optimizer_states.items():
-            assert_allclose(value.reshape(state_dict_pre_checkpoint['optimizer'][key].size()), state_dict_pre_checkpoint['optimizer'][key])
-        """
-    
     dist.barrier()
     os.remove(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'))
 
@@ -1166,44 +786,31 @@ def test_load_from_data_parallelism_mixed_precision_into_distributed_zero_mixed_
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
-    state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
+    state_dict_post_checkpoint, _ = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
     state = None
     with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
         state = pickle.load(f)
-    state_dict_pre_checkpoint = split_state_dict(state['state_dict'])
+    state_dict_pre_checkpoint = state['state_dict']
 
-    # compare all states
-    # model states
-    for key, value in state_dict_pre_checkpoint['fp16_param'].items():
-        assert_allclose(value, state_dict_post_checkpoint['fp16_param'][key])
+    # To compare state dictioanry from a data parallel node trainer to the state dictioanry from a zero run:
+    # - Save the state dictionaries for each rank for the zero run in a pickle file (distributed_state_world_rank.pkl)
+    # - On rank 0, manually load each state dictionary and aggregate all of them into a single state dictionary.
+    # - Compare the aggregated state dictionary against the state dictionary previously saved from the data parallel node run.
 
-    # round about way of checking optimizer states. Save state dicts into temporary folder, read them and aggregate them.
     with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'), "wb") as f:
         pickle.dump(state_dict_post_checkpoint, f)
     dist.barrier()
 
     if world_rank == 0:
-        num_states = len(glob.glob1(checkpoint_dir,"distributed_state*"))
-        optimizer_states = dict()
-        for rank in range(num_states):
-            rank_state_dict = None
-            with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(rank)+'.pkl'), 'rb') as f:
-                rank_state_dict = pickle.load(f)
+        # manually aggregate states from the previously saved state dictionary in a pickle file
+        aggregated_state_dict = aggregate_states(checkpoint_dir, filename_prefix='distributed_state', state_dict_key_name=None)
 
-            # collect optimizer states for later comparison since they are sharded
-            aggregate_states(optimizer_states, rank_state_dict['optimizer'])
+        # compare the manually aggregated state dictionary with the data parallel state dictionary that was previously saved in a pickle file
+        assert_all_states_close_ort(aggregated_state_dict, state_dict_pre_checkpoint, reshape_states=True)
 
-        # compare optimizer states
-        """
-        TODO: Uncomment this after Checkpoint redesign. Current implementation does not support it
-        for key, value in optimizer_states.items():
-            assert_allclose(value.reshape(state_dict_pre_checkpoint['optimizer'][key].size()), state_dict_pre_checkpoint['optimizer'][key])
-        """
-    
     dist.barrier()
     os.remove(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'))
 
@@ -1227,44 +834,31 @@ def test_load_from_data_parallelism_full_precision_into_distributed_zero_mixed_p
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
-    state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
+    state_dict_post_checkpoint, _ = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
     state = None
     with open(os.path.join(checkpoint_dir, 'state_dict.pkl'), 'rb') as f:
         state = pickle.load(f)
-    state_dict_pre_checkpoint = split_state_dict(state['state_dict'])
+    state_dict_pre_checkpoint = state['state_dict']
 
-    # compare all states
-    # model states
-    for key, value in state_dict_post_checkpoint['fp16_param'].items():
-        assert_allclose(value, state_dict_pre_checkpoint['fp32_param'][key[:-5]], atol=global_fp16_fp32_atol)
+    # To compare state dictioanry from a data parallel node trainer to the state dictioanry from a zero run:
+    # - Save the state dictionaries for each rank for the zero run in a pickle file (distributed_state_world_rank.pkl)
+    # - On rank 0, manually load each state dictionary and aggregate all of them into a single state dictionary.
+    # - Compare the aggregated state dictionary against the state dictionary previously saved from the data parallel node run.
 
-    # round about way of checking optimizer states. Save state dicts into temporary folder, read them and aggregate them.
     with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'), "wb") as f:
         pickle.dump(state_dict_post_checkpoint, f)
     dist.barrier()
 
     if world_rank == 0:
-        num_states = len(glob.glob1(checkpoint_dir,"distributed_state*"))
-        optimizer_states = dict()
-        for rank in range(num_states):
-            rank_state_dict = None
-            with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(rank)+'.pkl'), 'rb') as f:
-                rank_state_dict = pickle.load(f)
+        # manually aggregate states from the previously saved state dictionary in a pickle file
+        aggregated_state_dict = aggregate_states(checkpoint_dir, filename_prefix='distributed_state', state_dict_key_name=None)
 
-            # collect optimizer states for later comparison since they are sharded
-            aggregate_states(optimizer_states, rank_state_dict['optimizer'])
+        # compare the manually aggregated state dictionary with the data parallel state dictionary that was previously saved in a pickle file
+        assert_all_states_close_ort(aggregated_state_dict, state_dict_pre_checkpoint, reshape_states=True)
 
-        # compare optimizer states
-        """
-        TODO: Uncomment this after Checkpoint redesign. Current implementation does not support it
-        for key, value in optimizer_states.items():
-            assert_allclose(value.reshape(state_dict_pre_checkpoint['optimizer'][key].size()), state_dict_pre_checkpoint['optimizer'][key])
-        """
-    
     dist.barrier()
     os.remove(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'))
 
@@ -1284,24 +878,17 @@ def test_load_from_distributed_zero_full_precision_into_distributed_zero_full_pr
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
-    state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
+    state_dict_post_checkpoint, _ = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
     state = None
     with open(os.path.join(checkpoint_dir, 'state_dict_'+str(world_rank)+'.pkl'), 'rb') as f:
         state = pickle.load(f)
-    state_dict_pre_checkpoint = split_state_dict(state['state_dict_'+str(world_rank)])
+    state_dict_pre_checkpoint = state['state_dict_'+str(world_rank)]
 
-    # compare all states
-    # model states
-    for key, value in state_dict_pre_checkpoint['fp32_param'].items():
-        assert_allclose(value, state_dict_post_checkpoint['fp32_param'][key])
-
-    # compare optimizer states
-    for key, value in state_dict_pre_checkpoint['optimizer'].items():
-        assert_allclose(value, state_dict_post_checkpoint['optimizer'][key])
+    # compare all states for each rank independently
+    assert_all_states_close_ort(state_dict_pre_checkpoint, state_dict_post_checkpoint)
 
 @distributed_setup
 def test_load_from_distributed_zero_mixed_precision_into_distributed_zero_full_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/distributed_zero/mixed_precision/lamb'):
@@ -1319,29 +906,37 @@ def test_load_from_distributed_zero_mixed_precision_into_distributed_zero_full_p
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
-    state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
+    state_dict_post_checkpoint, _ = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict_'+str(world_rank)+'.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = split_state_dict(state['state_dict_'+str(world_rank)])
+    # To compare state dictioanry between two distributed zero node trainers (with different mixed precision parameter):
+    # - Save the state dictionaries for each rank for the current zero run in a pickle file (distributed_state_world_rank.pkl)
+    # - On rank 0, manually load each state dictionary (distributed_state_world_rank.pkl) and aggregate all of them into a single state dictionary.
+    # - Aggregate the checkpoint files from the previous zero run checkpoint files into a single state dictionary.
+    # - Compare the aggregated state dictionary from the current run against the aggregated state dictionary from the previous run.
+    # This is needed because the full precision model weights in a mixed precision trainer are sharded but the same weights
+    # are not shareded in a full precision trainer run.
+    # Therefore, the state dictionary model weights are different between a mixed precision trainer run and full precision trainer run.
+    # Which is why the need to compare the aggregated state dictionary (which returns a single state dictionary with all model and optimizer states)
+    # as opposed to comparing the state dictionary for each rank independently.
 
-    # compare all states
-    # model states
-    """
-    TODO: Uncomment this after Checkpoint redesign. Current implementation does not support it
-    fp32 weights pre checkpoint are sharded. But since this is a one to one mapping (from distributed zero to distributed zero albeit
-    mixed to full precision), the fp32 weights are not aggregated before copying into the new trainer
-    for key, value in state_dict_pre_checkpoint['fp16_param'].items():
-        assert_allclose(value, state_dict_post_checkpoint['fp32_param'][key[:-5]], atol=global_fp16_fp32_atol)
-    """
+    with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'), "wb") as f:
+        pickle.dump(state_dict_post_checkpoint, f)
+    dist.barrier()
 
-    # compare optimizer states
-    for key, value in state_dict_pre_checkpoint['optimizer'].items():
-        assert_allclose(value, state_dict_post_checkpoint['optimizer'][key])
+    if world_rank == 0:
+        # manually aggregate the states for the current full precision zero trainer
+        checkpoint_files = glob.glob(os.path.join(checkpoint_dir, 'checkpoint*.ortcp'))
+        aggregated_state_dict1 = checkpoint.aggregate_checkpoints(checkpoint_files, pytorch_format=False)
+        # aggregate checkpoints from the previous mixed precision zero trainer
+        aggregated_state_dict2 = aggregate_states(checkpoint_dir, filename_prefix='distributed_state', state_dict_key_name=None)
+
+        # compare the two state dictionaries
+        assert_all_states_close_ort(aggregated_state_dict2, aggregated_state_dict1, reshape_states=True)
+
+    dist.barrier()
+    os.remove(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'))
 
 @distributed_setup
 def test_load_from_distributed_zero_mixed_precision_into_distributed_zero_mixed_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/distributed_zero/mixed_precision/lamb'):
@@ -1363,24 +958,17 @@ def test_load_from_distributed_zero_mixed_precision_into_distributed_zero_mixed_
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
-    state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
+    state_dict_post_checkpoint, _ = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
     state = None
     with open(os.path.join(checkpoint_dir, 'state_dict_'+str(world_rank)+'.pkl'), 'rb') as f:
         state = pickle.load(f)
-    state_dict_pre_checkpoint = split_state_dict(state['state_dict_'+str(world_rank)])
+    state_dict_pre_checkpoint = state['state_dict_'+str(world_rank)]
 
-    # compare all states
-    # model states
-    for key, value in state_dict_pre_checkpoint['fp16_param'].items():
-        assert_allclose(value, state_dict_post_checkpoint['fp16_param'][key])
-
-    # compare optimizer states
-    for key, value in state_dict_pre_checkpoint['optimizer'].items():
-        assert_allclose(value, state_dict_post_checkpoint['optimizer'][key])
+    # compare all states for each rank independently
+    assert_all_states_close_ort(state_dict_pre_checkpoint, state_dict_post_checkpoint)
 
 @distributed_setup
 def test_load_from_distributed_zero_full_precision_into_distributed_zero_mixed_precision(world_rank, world_size, device, checkpoint_dir = 'checkpoint_dir/distributed_zero/full_precision/lamb/'):
@@ -1402,24 +990,37 @@ def test_load_from_distributed_zero_full_precision_into_distributed_zero_mixed_p
                 },
                 'debug' : {'deterministic_compute': True}
             }
-    
+
     # extract state dictionaries to compare
-    state_dict_post_checkpoint, model = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
-    state_dict_post_checkpoint = split_state_dict(state_dict_post_checkpoint)
+    state_dict_post_checkpoint, _ = create_orttrainer_and_load_checkpoint(device, opts, checkpoint_dir)
 
-    state = None
-    with open(os.path.join(checkpoint_dir, 'state_dict_'+str(world_rank)+'.pkl'), 'rb') as f:
-        state = pickle.load(f)
-    state_dict_pre_checkpoint = split_state_dict(state['state_dict_'+str(world_rank)])
+    # To compare state dictioanry between two distributed zero node trainers (with different mixed precision parameter):
+    # - Save the state dictionaries for each rank for the current zero run in a pickle file (distributed_state_world_rank.pkl)
+    # - On rank 0, manually load each state dictionary (distributed_state_world_rank.pkl) and aggregate all of them into a single state dictionary.
+    # - Aggregate the checkpoint files from the previous zero run checkpoint files into a single state dictionary.
+    # - Compare the aggregated state dictionary from the current run against the aggregated state dictionary from the previous run.
+    # This is needed because the full precision model weights in a mixed precision trainer are sharded but the same weights
+    # are not shareded in a full precision trainer run.
+    # Therefore, the state dictionary model weights are different between a mixed precision trainer run and full precision trainer run.
+    # Which is why the need to compare the aggregated state dictionary (which returns a single state dictionary with all model and optimizer states)
+    # as opposed to comparing the state dictionary for each rank independently.
 
-    # compare all states
-    # model states
-    for key, value in state_dict_post_checkpoint['fp16_param'].items():
-        assert_allclose(value, state_dict_pre_checkpoint['fp32_param'][key[:-5]], atol=global_fp16_fp32_atol)
+    with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'), "wb") as f:
+        pickle.dump(state_dict_post_checkpoint, f)
+    dist.barrier()
 
-    # compare optimizer states
-    for key, value in state_dict_pre_checkpoint['optimizer'].items():
-        assert_allclose(value, state_dict_post_checkpoint['optimizer'][key])
+    if world_rank == 0:
+        # manually aggregate the states for the current full precision zero trainer
+        checkpoint_files = glob.glob(os.path.join(checkpoint_dir, 'checkpoint*.ortcp'))
+        aggregated_state_dict1 = checkpoint.aggregate_checkpoints(checkpoint_files, pytorch_format=False)
+        # aggregate checkpoints from the previous mixed precision zero trainer
+        aggregated_state_dict2 = aggregate_states(checkpoint_dir, filename_prefix='distributed_state', state_dict_key_name=None)
+
+        # compare the two state dictionaries
+        assert_all_states_close_ort(aggregated_state_dict2, aggregated_state_dict1, reshape_states=True)
+
+    dist.barrier()
+    os.remove(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'))
 
 function_map = {
     # all config to single node config

--- a/orttraining/orttraining/test/python/checkpoint/orttraining_test_load_optimizer_state.py
+++ b/orttraining/orttraining/test/python/checkpoint/orttraining_test_load_optimizer_state.py
@@ -20,7 +20,8 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import onnxruntime
 from onnxruntime.training import checkpoint, optim
-from _test_helpers import distributed_setup, load_model_optim_state_and_eval, aggregate_states, assert_all_states_close_ort
+from _test_helpers import distributed_setup, load_model_optim_state_and_eval, aggregate_states
+from _test_commons import assert_all_states_close_ort
 
 def verify_optimizer_state_match(device, opts, checkpoint_dir,  world_rank, use_lamb=False):
     expected_optim_state, trainer_optim_state = load_model_optim_state_and_eval(device, opts, use_lamb)

--- a/orttraining/orttraining/test/python/checkpoint/orttraining_test_load_optimizer_state.py
+++ b/orttraining/orttraining/test/python/checkpoint/orttraining_test_load_optimizer_state.py
@@ -20,37 +20,27 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import onnxruntime
 from onnxruntime.training import checkpoint, optim
-from _test_helpers import distributed_setup, load_model_optim_state_and_eval, split_state_dict, aggregate_states, global_fp16_fp32_atol
-from _test_commons import get_optim_state_from_state_dict
+from _test_helpers import distributed_setup, load_model_optim_state_and_eval, aggregate_states, assert_all_states_close_ort
 
 def verify_optimizer_state_match(device, opts, checkpoint_dir,  world_rank, use_lamb=False):
-    expected_optim_state, trainer_state = load_model_optim_state_and_eval(device, opts, use_lamb)
-    trainer_state = split_state_dict(trainer_state)
-    # round about way of checking optimizer states. Save state dicts into temporary folder, read them and aggregate them.
+    expected_optim_state, trainer_optim_state = load_model_optim_state_and_eval(device, opts, use_lamb)
+
+    # verify optimizer states are matching by:
+    # - Saving the state dictionaries for each rank in the zero run in a pickle file.
+    # - Loading them one by one and aggregating them into a single state dictionary
+    # - Comparing this aggregated state dictionary with the full dummy optimizer dictionary (expected_optim_state)
+    # created by load_model_optim_state_and_eval
+
     with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'), "wb") as f:
-        pickle.dump(trainer_state, f)
+        pickle.dump(trainer_optim_state, f)
     dist.barrier()
 
     if world_rank == 0:
-        num_states = len(glob.glob1(checkpoint_dir, "distributed_state*"))
-        optimizer_states = dict()
-        for rank in range(num_states):
-            rank_state_dict = None
-            with open(os.path.join(checkpoint_dir, 'distributed_state_'+str(rank)+'.pkl'), 'rb') as f:
-                rank_state_dict = pickle.load(f)
+        # aggregate states and compare
+        aggregated_state_dict = aggregate_states(checkpoint_dir, filename_prefix='distributed_state', state_dict_key_name=None)
 
-            # collect optimizer states for later comparison since they are sharded
-            aggregate_states(optimizer_states, rank_state_dict['optimizer'])
-
-        # compare optimizer states
-        optimizer_config = optim.LambConfig() if use_lamb else optim.AdamConfig()
-        actual_optim_state = get_optim_state_from_state_dict(optimizer_states, optimizer_config)
-        assert actual_optim_state.keys() == expected_optim_state.keys()
-        for param_name, a_state in actual_optim_state.items():
-            for k, v in a_state.items():
-                assert_allclose(v.reshape(expected_optim_state[param_name][k].shape),
-                                expected_optim_state[param_name][k], 
-                                err_msg=f"Optimizer state mismatch for param {param_name}, key {k}")
+        # compare all states
+        assert_all_states_close_ort(aggregated_state_dict, expected_optim_state, reshape_states=True)
 
     dist.barrier()
     os.remove(os.path.join(checkpoint_dir, 'distributed_state_'+str(world_rank)+'.pkl'))

--- a/orttraining/orttraining/test/python/orttraining_run_bert_pretrain.py
+++ b/orttraining/orttraining/test/python/orttraining_run_bert_pretrain.py
@@ -15,6 +15,7 @@ import dataclasses
 from dataclasses import dataclass, field
 from typing import Optional, Any, Dict
 import json
+import glob
 
 import unittest
 
@@ -30,7 +31,7 @@ from concurrent.futures import ProcessPoolExecutor
 import onnxruntime as ort
 from onnxruntime.training import amp, optim, orttrainer
 from onnxruntime.training.optim import PolyWarmupLRScheduler, LinearWarmupLRScheduler
-from onnxruntime.training.checkpoint import experimental_save_checkpoint, _list_checkpoint_files, _CombineZeroCheckpoint
+from onnxruntime.training.checkpoint import aggregate_checkpoints
 
 # need to override torch.onnx.symbolic_opset12.nll_loss to handle ignore_index == -100 cases.
 # the fix for ignore_index == -100 cases is already in pytorch master.
@@ -411,7 +412,7 @@ def prepare_model(args, device):
 
     model = BertForPreTraining(config)
     if args.init_state_dict is not None:
-        model.load_state_dict(args.init_state_dict, strict=False)
+        model.load_state_dict(args.init_state_dict)
     model_desc = bert_model_description(config)
 
     lr_scheduler = LinearWarmupLRScheduler(total_steps=int(args.max_steps), warmup=args.warmup_proportion)
@@ -549,7 +550,7 @@ def do_pretrain(args):
 
                     if global_step >= args.max_steps:
                         if args.save_checkpoint:
-                            experimental_save_checkpoint(model, args.output_dir)
+                            model.save_checkpoint(os.path.join(args.output_dir, 'checkpoint-{}.ortcp'.format(args.world_rank)))
                         final_loss = average_loss / (args.log_freq * args.gradient_accumulation_steps)
                         return final_loss
 
@@ -693,11 +694,8 @@ class ORTBertPretrainTest(unittest.TestCase):
 
         # on rank 0, load the trained state
         if args.world_rank == 0:
-            checkpoint_files = _list_checkpoint_files(self.output_dir, "ORT_checkpoint")
-            ckpt_agg = _CombineZeroCheckpoint(checkpoint_files)
-            final_state_dict = ckpt_agg.aggregate_checkpoints()
-
-            args.init_state_dict = final_state_dict
+            checkpoint_files = glob.glob(os.path.join(self.output_dir, 'checkpoint*.ortcp'))
+            args.init_state_dict = aggregate_checkpoints(checkpoint_files, pytorch_format=True)
 
         torch.distributed.barrier()
 

--- a/orttraining/orttraining/test/python/orttraining_test_allreduce_adasum.py
+++ b/orttraining/orttraining/test/python/orttraining_test_allreduce_adasum.py
@@ -9,7 +9,7 @@ import torch
 import argparse
 from onnxruntime.capi._pybind_state import set_cuda_device_id, get_mpi_context_world_rank, get_mpi_context_world_size
 from onnxruntime.training import optim, orttrainer
-from orttraining_test_orttrainer_frontend import _load_pytorch_transformer_model
+from _test_commons import _load_pytorch_transformer_model
 from onnxruntime import set_seed
 
 def _run_adasum_tests(opts):

--- a/orttraining/orttraining/test/python/orttraining_test_checkpoint.py
+++ b/orttraining/orttraining/test/python/orttraining_test_checkpoint.py
@@ -27,23 +27,29 @@ makedir(checkpoint_dir)
 #       orttrainer can be instantiated. Hence the need to run these tests in different processes one at a time.
 # - workflow:
 #     - orttraining_test_checkpoint.py calls orttraining_test_save_checkpoint.py to save following files to disk
-#         - ORTTrainer checkpoint files through the experimental_save_checkpoint method
-#         - ORTTrainer states through pickle after extracting all the states of the ORTTrainer through the experimental_state_dict method
+#         - ORTTrainer checkpoint files through the ORTTrainer.save_checkpoint method
+#         - ORTTrainer states through pickle after extracting all the states of the ORTTrainer through the ORTTrainer.state_dict method
 #         - for each configuration across [onnxruntime orttrainer][full_precision, mixed_precision][single node training, data parallel training, distributed zero training]
 #     - orttraining_test_checkpoint.py calls orttraining_test_load_checkpoint.py to load each checkpoint into each orttrainer configuration
-#         - Saved ORTTrainer checkpoint files are loaded into an ORTTrainer using the experimental_load_checkpoint method for each ORTTrainer configuration.
+#         - Saved ORTTrainer checkpoint files are loaded into an ORTTrainer using the ORTTrainer.load_checkpoint method for each ORTTrainer configuration.
 #         - Saved states are loaded into a python dictionary (called the state dictionary) through pickle
 #         - state dictionary is extracted from the ORTTrainer after it has loaded the checkpoint file and the onnx graph has been initialized (by calling eval_step)
-#           through the experimental_state_dict method.
+#           through the ORTTrainer.state_dict method.
 #         - the loaded state dictionary (through pickle) is compared against the extracted state dictionary for:
-#             - equality (or new equality) of model states
-#             - equality (or new equality) of optimizer states
+#             - equality (or near equality) of model states
+#             - equality (or near equality) of optimizer states
 #         - In some cases the comparison is not directly possible; for example single node trainer to a distributed zero trainer because the extracted state
 #           dictionary is a distributed one and cannot be compared against a single node trainer directly.
 #             - First these states are saved using pickle for each rank to a file on disk
 #             - Wait for all ranks to complete writing the file to disk using barrier()
 #             - Load all states and aggregate them into 1 state dictionary
 #             - Compare this aggregated state dictionary against the original one loaded from disk.
+#         - Similarly, it is not possible to compare mixed precision zero trainer state_dict against full precision zero trainer state_dict because the
+#           full precision states are sharded in the mixed precision trainer run and not shareded in the full precision trainer run. To compare these two state_dicts:
+#             - Both state_dicts (mixed precision and full precision) are saved to file for all ranks.
+#             - Wait for all ranks to complete writing the file to disk using barrier()
+#             - Load all states and aggregate them into 1 state dictionary fpr both the configs.
+#             - Compare this aggregated state dictionaries against one another.
 
 save_checkpoint_file = os.path.join('checkpoint', 'orttraining_test_save_checkpoint.py')
 load_checkpoint_file = os.path.join('checkpoint', 'orttraining_test_load_checkpoint.py')

--- a/orttraining/orttraining/test/python/orttraining_test_debuggability.py
+++ b/orttraining/orttraining/test/python/orttraining_test_debuggability.py
@@ -16,7 +16,7 @@ from onnxruntime.training import _utils, amp, optim, orttrainer, TrainStepInfo,\
                                       model_desc_validation as md_val,\
                                       orttrainer_options as orttrainer_options
 
-from orttraining_test_orttrainer_frontend import _load_pytorch_transformer_model
+from _test_commons import _load_pytorch_transformer_model
 
 import _test_helpers
 

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_bert_toy_onnx.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_bert_toy_onnx.py
@@ -19,6 +19,7 @@ from onnxruntime.training import _utils, amp, checkpoint, optim, orttrainer, Tra
                                       orttrainer_options as orttrainer_options
 
 import _test_commons, _test_helpers
+from checkpoint._test_helpers import assert_all_states_close_ort
 
 ###############################################################################
 # Helper functions ############################################################
@@ -394,20 +395,20 @@ def testToyBertCheckpointBasic():
     model = load_bert_onnx_model()
     model_desc = bert_model_description()
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, options=opts)
-    sd = checkpoint.experimental_state_dict(trainer)
+    sd = trainer.state_dict()
 
     ## All initializers must be present in the state_dict
     ##  when the specified model for ORTTRainer is an ONNX model
     for param in trainer._onnx_model.graph.initializer:
-        assert param.name in sd
+        assert param.name in sd['model']['full_precision']
 
     ## Modify one of the state values and load into ORTTrainer
-    sd['bert.encoder.layer.0.attention.output.LayerNorm.weight'] += 10
-    checkpoint.experimental_load_state_dict(trainer, sd)
+    sd['model']['full_precision']['bert.encoder.layer.0.attention.output.LayerNorm.weight'] += 10
+    trainer.load_state_dict(sd)
 
     ## Save a checkpoint
     ckpt_dir = 'testdata'
-    checkpoint.experimental_save_checkpoint(trainer, ckpt_dir, 'bert_toy_save_test')
+    trainer.save_checkpoint(os.path.join(ckpt_dir, 'bert_toy_save_test.ortcp'))
     del trainer
     del model
 
@@ -415,12 +416,11 @@ def testToyBertCheckpointBasic():
     model2 = load_bert_onnx_model()
     model_desc2 = bert_model_description()
     trainer2 = orttrainer.ORTTrainer(model2, model_desc2, optim_config, options=opts)
-    checkpoint.experimental_load_checkpoint(trainer2, ckpt_dir, 'bert_toy_save_test')
-    loaded_sd = checkpoint.experimental_state_dict(trainer2)
+    trainer2.load_checkpoint(os.path.join(ckpt_dir, 'bert_toy_save_test.ortcp'))
+    loaded_sd = trainer2.state_dict()
 
     # Assert whether original state and the one loaded from checkpoint matches
-    for k,v in loaded_sd.items():
-        assert torch.all(torch.eq(v, sd[k]))
+    assert_all_states_close_ort(sd, loaded_sd)
 
 
 def testToyBertCheckpointFrozenWeights():
@@ -446,21 +446,21 @@ def testToyBertCheckpointFrozenWeights():
     # Evaluate once to get a base loss
     loss = trainer.eval_step(*sample_input)
     # Save checkpoint
-    state_dict = checkpoint.experimental_state_dict(trainer)
+    state_dict = trainer.state_dict()
 
     # Load previous state into another instance of ORTTrainer
     model2 = load_bert_onnx_model()
     model_desc2 = bert_model_description()
     optim_config2 = optim.LambConfig()
     trainer2 = orttrainer.ORTTrainer(model2, model_desc2, optim_config2, options=opts)
-    checkpoint.experimental_load_state_dict(trainer2, state_dict)
+    trainer2.load_state_dict(state_dict)
     # Evaluate once to get a base loss
     ckpt_loss = trainer2.eval_step(*sample_input)
 
     # Must match as both trainers have the same dict state
     assert_allclose(loss.cpu(), ckpt_loss.cpu())
-    loaded_state_dict = checkpoint.experimental_state_dict(trainer2)
-    assert state_dict.keys() == loaded_state_dict.keys()
+    loaded_state_dict = trainer2.state_dict()
+    assert_all_states_close_ort(state_dict, loaded_state_dict)
 
 @pytest.mark.parametrize("optimizer, mixedprecision_enabled", [
     (optim.LambConfig(), False),
@@ -488,10 +488,9 @@ def testToyBertLoadOptimState(optimizer, mixedprecision_enabled):
     model_desc = bert_model_description()
     dummy_init_state = _test_commons.generate_dummy_optim_state(model, optimizer)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, options=opts)
-    checkpoint._experimental_load_optimizer_state(trainer, dummy_init_state)
+    trainer.load_state_dict(dummy_init_state)
     
     # Expected values
-    expected_eval_loss = [10.997552871]
     input_ids = torch.tensor([[26598],[21379],[19922],[ 5219],[ 5644],[20559],[23777],[25672],[22969],[16824],[16822],[635],[27399],[20647],[18519],[15546]], device=device)
     segment_ids = torch.tensor([[0],[1],[0],[1],[0],[0],[1],[0],[0],[1],[1],[0],[0],[1],[1],[1]], device=device)
     input_mask = torch.tensor([[0],[0],[0],[0],[1],[1],[1],[0],[1],[1],[0],[0],[0],[1],[0],[0]], device=device)
@@ -501,9 +500,9 @@ def testToyBertLoadOptimState(optimizer, mixedprecision_enabled):
     # Actual values
     _ = trainer.eval_step(input_ids, segment_ids, input_mask, masked_lm_labels, next_sentence_labels)
     
-    actual_state = checkpoint.experimental_state_dict(trainer)
-    actual_optim_state = _test_commons.get_optim_state_from_state_dict(actual_state, optimizer)
-    _test_helpers.assert_optim_state(dummy_init_state, actual_optim_state)
+    actual_state_dict = trainer.state_dict()
+    del actual_state_dict['model']
+    assert_all_states_close_ort(actual_state_dict, dummy_init_state)
 
 @pytest.mark.parametrize("model_params", [
     (['bert.embeddings.LayerNorm.bias']),

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_bert_toy_onnx.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_bert_toy_onnx.py
@@ -19,7 +19,6 @@ from onnxruntime.training import _utils, amp, checkpoint, optim, orttrainer, Tra
                                       orttrainer_options as orttrainer_options
 
 import _test_commons, _test_helpers
-from checkpoint._test_helpers import assert_all_states_close_ort
 
 ###############################################################################
 # Helper functions ############################################################
@@ -420,7 +419,7 @@ def testToyBertCheckpointBasic():
     loaded_sd = trainer2.state_dict()
 
     # Assert whether original state and the one loaded from checkpoint matches
-    assert_all_states_close_ort(sd, loaded_sd)
+    _test_commons.assert_all_states_close_ort(sd, loaded_sd)
 
 
 def testToyBertCheckpointFrozenWeights():
@@ -460,7 +459,7 @@ def testToyBertCheckpointFrozenWeights():
     # Must match as both trainers have the same dict state
     assert_allclose(loss.cpu(), ckpt_loss.cpu())
     loaded_state_dict = trainer2.state_dict()
-    assert_all_states_close_ort(state_dict, loaded_state_dict)
+    _test_commons.assert_all_states_close_ort(state_dict, loaded_state_dict)
 
 @pytest.mark.parametrize("optimizer, mixedprecision_enabled", [
     (optim.LambConfig(), False),
@@ -502,7 +501,7 @@ def testToyBertLoadOptimState(optimizer, mixedprecision_enabled):
     
     actual_state_dict = trainer.state_dict()
     del actual_state_dict['model']
-    assert_all_states_close_ort(actual_state_dict, dummy_init_state)
+    _test_commons.assert_all_states_close_ort(actual_state_dict, dummy_init_state)
 
 @pytest.mark.parametrize("model_params", [
     (['bert.embeddings.LayerNorm.bias']),

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_checkpoint_functions.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_checkpoint_functions.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch, Mock
-from orttraining_test_orttrainer_frontend import _load_pytorch_transformer_model
+from _test_commons import _load_pytorch_transformer_model
 from onnxruntime.training import amp, checkpoint, optim, orttrainer, _checkpoint_storage
 import numpy as np
 import onnx

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -17,42 +17,6 @@ from onnxruntime.training import _utils, amp, checkpoint, optim, orttrainer, Tra
                                       model_desc_validation as md_val,\
                                       orttrainer_options as orttrainer_options
 import _test_commons,_test_helpers
-from checkpoint._test_helpers import assert_all_states_close_ort
-
-
-###############################################################################
-# Helper functions ############################################################
-###############################################################################
-
-
-def _load_pytorch_transformer_model(device, dynamic_axes=False, legacy_api=False):
-    # Loads external Pytorch TransformerModel into utils
-    pytorch_transformer_path = os.path.join('samples', 'python', 'pytorch_transformer')
-    pt_model_path = os.path.join(pytorch_transformer_path, 'pt_model.py')
-    pt_model = _utils.import_module_from_file(pt_model_path)
-    ort_utils_path = os.path.join(pytorch_transformer_path, 'ort_utils.py')
-    ort_utils = _utils.import_module_from_file(ort_utils_path)
-    utils_path = os.path.join(pytorch_transformer_path, 'utils.py')
-    utils = _utils.import_module_from_file(utils_path)
-
-    # Modeling
-    model = pt_model.TransformerModel(28785, 200, 2, 200, 2, 0.2).to(device)
-    my_loss = ort_utils.my_loss
-    if legacy_api:
-        if dynamic_axes:
-            model_desc = ort_utils.legacy_transformer_model_description_dynamic_axes()
-        else:
-            model_desc = ort_utils.legacy_transformer_model_description()
-    else:
-        if dynamic_axes:
-            model_desc = ort_utils.transformer_model_description_dynamic_axes()
-        else:
-            model_desc = ort_utils.transformer_model_description()
-
-
-    # Preparing data
-    train_data, val_data, test_data = utils.prepare_data(device, 20, 20)
-    return model, model_desc, my_loss, utils.get_batch, train_data, val_data, test_data
 
 
 ###############################################################################
@@ -573,7 +537,7 @@ def testInstantiateORTTrainer(step_fn, lr_scheduler, expected_lr_values, device)
         opts.update({'lr_scheduler' : lr_scheduler(total_steps=total_steps, warmup=0.5)})
     opts = orttrainer.ORTTrainerOptions(opts)
     optim_config = optim.LambConfig(lr=initial_lr)
-    model, model_desc, my_loss, batcher_fn, train_data, val_data, _ = _load_pytorch_transformer_model(device)
+    model, model_desc, my_loss, batcher_fn, train_data, val_data, _ = _test_commons._load_pytorch_transformer_model(device)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=opts)
 
     # Run a train or evaluation step
@@ -669,7 +633,7 @@ def testORTDeterministicCompute(seed, device):
     # Setup for the first ORTTRainer run
     torch.manual_seed(seed)
     set_seed(seed)
-    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _load_pytorch_transformer_model(device)
+    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _test_commons._load_pytorch_transformer_model(device)
     first_trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=opts)
     data, targets = batcher_fn(train_data, 0)
     _ = first_trainer.train_step(data, targets)
@@ -678,7 +642,7 @@ def testORTDeterministicCompute(seed, device):
     # Setup for the second ORTTRainer run
     torch.manual_seed(seed)
     set_seed(seed)
-    model, _, _, _, _, _, _ = _load_pytorch_transformer_model(device)
+    model, _, _, _, _, _, _ = _test_commons._load_pytorch_transformer_model(device)
     second_trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=opts)
     _ = second_trainer.train_step(data, targets)
     assert second_trainer._onnx_model is not None
@@ -707,7 +671,7 @@ def testORTTrainerMixedPrecisionLossScaler(seed, device, expected_loss, fetches)
                                                 'enabled' : True,
                                                 'loss_scaler' : loss_scaler},
                                             'debug' : {'deterministic_compute' : True}})
-    model, model_desc, my_loss, batcher_fn, train_data, val_data, _ = _load_pytorch_transformer_model(device)
+    model, model_desc, my_loss, batcher_fn, train_data, val_data, _ = _test_commons._load_pytorch_transformer_model(device)
     optim_config = optim.LambConfig(lr=0.001)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=options)
 
@@ -773,7 +737,7 @@ def testORTTrainerRecompute(attn_dropout, gelu, transformer_layer, number_layers
                                                 'number_recompute_layers': number_layers
                                             },
                                             'debug' : {'deterministic_compute' : True}})
-    model, model_desc, my_loss, batcher_fn, train_data, val_data, _ = _load_pytorch_transformer_model(device)
+    model, model_desc, my_loss, batcher_fn, train_data, val_data, _ = _test_commons._load_pytorch_transformer_model(device)
     optim_config = optim.LambConfig(lr=0.001)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=options)
 
@@ -809,7 +773,7 @@ def testORTTrainerGradientAccumulation(seed, device, gradient_accumulation_steps
     options = orttrainer.ORTTrainerOptions({'device' : {'id' : device},
                                             'batch' : {'gradient_accumulation_steps' : gradient_accumulation_steps},
                                             'debug' : {'deterministic_compute' : True}})
-    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _load_pytorch_transformer_model(device)
+    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _test_commons._load_pytorch_transformer_model(device)
     optim_config = optim.LambConfig(lr=0.001)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=options)
 
@@ -835,7 +799,7 @@ def testORTTrainerDynamicShape(dynamic_axes):
     # Setup ORTTrainer
     options = orttrainer.ORTTrainerOptions({})
     model, model_desc, my_loss, batcher_fn,\
-        train_data, _, _ = _load_pytorch_transformer_model(device, dynamic_axes=dynamic_axes)
+        train_data, _, _ = _test_commons._load_pytorch_transformer_model(device, dynamic_axes=dynamic_axes)
     optim_config = optim.LambConfig(lr=0.001)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=options)
 
@@ -863,7 +827,7 @@ def testORTTrainerInternalUseContribOps(enable_onnx_contrib_ops):
     # Setup ORTTrainer
     options = orttrainer.ORTTrainerOptions({"_internal_use": {"enable_onnx_contrib_ops": enable_onnx_contrib_ops}})
     model, model_desc, my_loss, batcher_fn,\
-        train_data, _, _ = _load_pytorch_transformer_model(device)
+        train_data, _, _ = _test_commons._load_pytorch_transformer_model(device)
     optim_config = optim.LambConfig(lr=0.001)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=options)
 
@@ -891,7 +855,7 @@ def testORTTrainerFrozenWeights(model_params):
     # Setup ORTTrainer WITHOUT frozen weights
     options = orttrainer.ORTTrainerOptions({})
     model, model_desc, my_loss, batcher_fn,\
-        train_data, _, _ = _load_pytorch_transformer_model(device)
+        train_data, _, _ = _test_commons._load_pytorch_transformer_model(device)
     optim_config = optim.LambConfig(lr=0.001)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=options)
     for i in range(total_steps):
@@ -906,7 +870,7 @@ def testORTTrainerFrozenWeights(model_params):
 
     # Setup ORTTrainer WITH frozen weights
     options = orttrainer.ORTTrainerOptions({'utils' : {'frozen_weights' : model_params}})
-    model, _, _, _, _, _, _ = _load_pytorch_transformer_model(device)
+    model, _, _, _, _, _, _ = _test_commons._load_pytorch_transformer_model(device)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=options)
     for i in range(total_steps):
         data, targets = batcher_fn(train_data, i)
@@ -980,14 +944,14 @@ def testORTTrainerStateDictWrapModelLossFn(loss_scaler, optimizer_config, gradie
     trainer2.load_state_dict(state_dict)
 
     # Verify state was loaded properly
-    assert_all_states_close_ort(state_dict, trainer2._load_state_dict.args[0])
+    _test_commons.assert_all_states_close_ort(state_dict, trainer2._load_state_dict.args[0])
 
     # Perform a second step in both training session 1 and 2 and verify they match
     trainer.train_step(x=data2, label=label2)
     state_dict = trainer.state_dict()
     trainer2.train_step(x=data2, label=label2)
     state_dict2 = trainer2.state_dict()
-    assert_all_states_close_ort(state_dict, state_dict2)
+    _test_commons.assert_all_states_close_ort(state_dict, state_dict2)
 
 
 def testORTTrainerNonPickableModel():
@@ -1056,7 +1020,7 @@ def testORTTrainerLegacyAndExperimentalWeightsCheck(seed, device):
             'deterministic_compute': True
         },
     })
-    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _load_pytorch_transformer_model(device)
+    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _test_commons._load_pytorch_transformer_model(device)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=opts)
     # Training loop
     for i in range(total_steps):
@@ -1066,7 +1030,7 @@ def testORTTrainerLegacyAndExperimentalWeightsCheck(seed, device):
     # Setup for the legacy ORTTrainer run
     torch.manual_seed(seed)
     set_seed(seed)
-    model, (model_desc, lr_desc), _, _, _, _, _ = _load_pytorch_transformer_model(device, legacy_api=True)
+    model, (model_desc, lr_desc), _, _, _, _, _ = _test_commons._load_pytorch_transformer_model(device, legacy_api=True)
     legacy_trainer = Legacy_ORTTrainer(model, my_loss, model_desc, "LambOptimizer", None, lr_desc,
                                        device, _use_deterministic_compute=True)
     # Training loop
@@ -1094,7 +1058,7 @@ def testORTTrainerLegacyAndExperimentalPrecisionLossScaler(seed, device):
                                                 'enabled' : True,
                                                 'loss_scaler' : loss_scaler},
                                             'debug' : {'deterministic_compute' : True,}})
-    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _load_pytorch_transformer_model(device)
+    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _test_commons._load_pytorch_transformer_model(device)
     optim_config = optim.LambConfig(lr=0.001)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=options)
     # Training loop
@@ -1109,7 +1073,7 @@ def testORTTrainerLegacyAndExperimentalPrecisionLossScaler(seed, device):
     # Setup legacy API
     torch.manual_seed(seed)
     set_seed(seed)
-    model, (model_desc, lr_desc), _, _, _, _, _ = _load_pytorch_transformer_model(device, legacy_api=True)
+    model, (model_desc, lr_desc), _, _, _, _, _ = _test_commons._load_pytorch_transformer_model(device, legacy_api=True)
     loss_scaler = Legacy_LossScaler('ort_test_input_loss_scalar', True)
     legacy_trainer = Legacy_ORTTrainer(model, my_loss, model_desc, "LambOptimizer",
                                        None, lr_desc, device=device,
@@ -1147,7 +1111,7 @@ def testORTTrainerLegacyAndExperimentalGradientAccumulation(seed, device, gradie
     options = orttrainer.ORTTrainerOptions({'device' : {'id' : device},
                                             'batch' : {'gradient_accumulation_steps' : gradient_accumulation_steps},
                                             'debug' : {'deterministic_compute' : True}})
-    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _load_pytorch_transformer_model(device)
+    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _test_commons._load_pytorch_transformer_model(device)
     optim_config = optim.LambConfig(lr=0.001)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=options)
     # Training loop
@@ -1160,7 +1124,7 @@ def testORTTrainerLegacyAndExperimentalGradientAccumulation(seed, device, gradie
     # Setup legacy API
     torch.manual_seed(seed)
     set_seed(seed)
-    model, (model_desc, lr_desc), _, _, _, _, _ = _load_pytorch_transformer_model(device, legacy_api=True)
+    model, (model_desc, lr_desc), _, _, _, _, _ = _test_commons._load_pytorch_transformer_model(device, legacy_api=True)
     legacy_trainer = Legacy_ORTTrainer(model, my_loss, model_desc, "LambOptimizer",
                                        None, lr_desc, device=device,
                                        _use_deterministic_compute=True,
@@ -1215,7 +1179,7 @@ def testORTTrainerLegacyAndExperimentalLRScheduler(seed, device, optimizer_confi
     options = orttrainer.ORTTrainerOptions({'device' : {'id' : device},
                                             'debug' : {'deterministic_compute' : True},
                                             'lr_scheduler' : lr_scheduler})
-    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _load_pytorch_transformer_model(device)
+    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _test_commons._load_pytorch_transformer_model(device)
     optim_config = optimizer_config(lr=lr)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=options)
     # Training loop
@@ -1247,7 +1211,7 @@ def testORTTrainerLegacyAndExperimentalLRScheduler(seed, device, optimizer_confi
     else:
         raise RuntimeError("Invalid get_lr_this_step")
 
-    model, (model_desc, lr_desc), _, _, _, _, _ = _load_pytorch_transformer_model(device, legacy_api=True)
+    model, (model_desc, lr_desc), _, _, _, _, _ = _test_commons._load_pytorch_transformer_model(device, legacy_api=True)
     legacy_trainer = Legacy_ORTTrainer(model, my_loss, model_desc, legacy_optimizer_config,
                                        None, lr_desc, device=device,
                                        _use_deterministic_compute=True,
@@ -1363,7 +1327,7 @@ def testORTTrainerRunSymbolicShapeInfer():
     set_seed(seed)
     options = orttrainer.ORTTrainerOptions({'device' : {'id' : device},
                                             'debug' : {'deterministic_compute' : True}})
-    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _load_pytorch_transformer_model(device)
+    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _test_commons._load_pytorch_transformer_model(device)
     optim_config = optim.LambConfig(lr=0.001)
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=options)
     # Training loop
@@ -1376,7 +1340,7 @@ def testORTTrainerRunSymbolicShapeInfer():
     # Setup with symbolic shape inference
     torch.manual_seed(seed)
     set_seed(seed)
-    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _load_pytorch_transformer_model(device)
+    model, model_desc, my_loss, batcher_fn, train_data, _, _ = _test_commons._load_pytorch_transformer_model(device)
     optim_config = optim.LambConfig(lr=0.001)
     options.utils.run_symbolic_shape_infer = True
     trainer = orttrainer.ORTTrainer(model, model_desc, optim_config, loss_fn=my_loss, options=options)
@@ -1390,7 +1354,7 @@ def testORTTrainerRunSymbolicShapeInfer():
     # Setup with symbolic shape inference in legacy API
     torch.manual_seed(seed)
     set_seed(seed)
-    model, (model_desc, lr_desc), _, _, _, _, _ = _load_pytorch_transformer_model(device, legacy_api=True)
+    model, (model_desc, lr_desc), _, _, _, _, _ = _test_commons._load_pytorch_transformer_model(device, legacy_api=True)
     legacy_trainer = Legacy_ORTTrainer(model, my_loss, model_desc, "LambOptimizer",
                                        None, lr_desc, device=device,
                                        run_symbolic_shape_infer=True,


### PR DESCRIPTION
**Description**:
- For ```aggregate_checkpoints``` function, return the state_dict as torch tensors in case ```pytorch_format``` is ```True```
- Add deprecation warning for old checkpoint functions.
- Migrate all the checkpoint related tests to start using the new checkpoint API.
