### PR TITLE
Docs changes since 11/30/2020

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ plugins:
   - jekyll-toc
 kramdown:
   parse_block_html: true
+  toc_levels: "1,2,3"
 logo: "/images/ONNX-Runtime-logo.svg"
 aux_links:
   "Get started":

--- a/docs/how-to/add-custom-op.md
+++ b/docs/how-to/add-custom-op.md
@@ -23,7 +23,7 @@ Use the custom operator C/C++ API (onnxruntime_c_api.h)
 * Create an OrtCustomOp structure for each op and add them to the OrtCustomOpDomain with OrtCustomOpDomain_Add
 * Call OrtAddCustomOpDomain to add the custom domain of ops to the session options
   
-See [this](https://github.com/microsoft/onnxruntime/blob/master/onnxruntime/test/shared_lib/test_inference.cc) for an example called MyCustomOp that uses the C++ helper API (onnxruntime_cxx_api.h).
+See [this](https://github.com/microsoft/onnxruntime/blob/master/onnxruntime/test/shared_lib/test_inference.cc) for examples called MyCustomOp and SliceCustomOp that use the C++ helper API (onnxruntime_cxx_api.h).
 
 You can also compile the custom ops into a shared library and use that to run a model via the C++ API. The same test file contains an example.
 

--- a/docs/how-to/build.md
+++ b/docs/how-to/build.md
@@ -15,9 +15,9 @@ nav_order: 5
 
 ## Inference
 
-## Start: Baseline CPU
+### CPU
 
-### Prerequisites
+#### Prerequisites
 * Checkout the source tree:
    ```
    git clone --recursive https://github.com/Microsoft/onnxruntime
@@ -26,35 +26,33 @@ nav_order: 5
 * Install cmake-3.13 or higher from https://cmake.org/download/.
 
 
-### Build Instructions
-#### Windows
+#### Build Instructions
+
+##### Windows
+
 Open Developer Command Prompt for Visual Studio version you are going to use. This will properly setup the environment including paths to your compiler, linker, utilities and header files.
 ```
 .\build.bat --config RelWithDebInfo --build_shared_lib --parallel
 ```
 The default Windows CMake Generator is Visual Studio 2017, but you can also use the newer Visual Studio 2019 by passing `--cmake_generator "Visual Studio 16 2019"` to `.\build.bat`
 
+##### Linux
 
-#### Linux/macOS
 ```
 ./build.sh --config RelWithDebInfo --build_shared_lib --parallel
 ```
+
 ##### macOS
+
 By default, ORT is configured to be built for a minimum target macOS version of 10.12.
 The shared library in the release Nuget(s) and the Python wheel may be installed on macOS versions of 10.12+.
 
-If you would like to use [Xcode](https://developer.apple.com/xcode/) to build the onnxruntime for x86_64 macOS, use
-* With Xcode 11
-   ```
-   ./build.sh --config RelWithDebInfo --build_shared_lib --parallel --use_xcode
-   ```
-* With Xcode 12
-   ```
-   ./build.sh --config RelWithDebInfo --build_shared_lib --parallel --use_xcode \
-              --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=x86_64
-   ```
+If you would like to use [Xcode](https://developer.apple.com/xcode/) to build the onnxruntime for x86_64 macOS, please add the --user_xcode argument in the command line.
 
-#### Notes
+Without this flag, the cmake build generator will be Unix makefile by default.
+Also, if you want to cross-compile for Apple Silicon in an Intel-based MacOS machine, please add the argument --osx_arch arm64 with cmake > 3.19. Note: unit tests will be skipped due to the incompatible CPU instruction set.
+
+##### Notes
 
 * Please note that these instructions build the debug build, which may have performance tradeoffs
 * To build the version from each release (which include Windows, Linux, and Mac variants), see these .yml files for reference: [CPU](https://github.com/microsoft/onnxruntime/blob/master/tools/ci_build/github/azure-pipelines/nuget/cpu-esrp-pipeline.yml), [GPU](https://github.com/microsoft/onnxruntime/blob/master/tools/ci_build/github/azure-pipelines/nuget/gpu-esrp-pipeline.yml)
@@ -70,9 +68,9 @@ If you would like to use [Xcode](https://developer.apple.com/xcode/) to build th
     ```
 ---
 
-## Supported architectures and build environments
+### Supported architectures and build environments
 
-### Architectures
+#### Architectures
 
 |           | x86_32       | x86_64       | ARM32v7      | ARM64        |
 |-----------|:------------:|:------------:|:------------:|:------------:|
@@ -80,7 +78,7 @@ If you would like to use [Xcode](https://developer.apple.com/xcode/) to build th
 |Linux      | YES          | YES          |  YES         | YES          |
 |macOS      | NO           | YES          |  NO          | NO           |
 
-### Environments
+#### Environments
 
 | OS          | Supports CPU | Supports GPU| Notes                              |
 |-------------|:------------:|:------------:|------------------------------------|
@@ -91,7 +89,7 @@ If you would like to use [Xcode](https://developer.apple.com/xcode/) to build th
 
 GCC 4.x and below are not supported.
 
-### OS/Compiler Matrix:
+#### OS/Compiler Matrix
 
 | OS/Compiler | Supports VC  | Supports GCC     |  Supports Clang  |
 |-------------|:------------:|:----------------:|:----------------:|
@@ -99,9 +97,10 @@ GCC 4.x and below are not supported.
 |Linux        | NO           | YES(gcc>=4.8)    | Not tested       |
 |macOS        | NO           | Not tested       | YES (Minimum version required not ascertained)|
 
-
 ---
-## Common Build Instructions
+
+#### Common Build Instructions
+
 |Description|Command|Additional details|
 |-----------|-----------|-----------|
 |**Basic build**|build.bat (Windows)<br>./build.sh (Linux)||
@@ -110,7 +109,8 @@ GCC 4.x and below are not supported.
 |**Build using parallel processing**|--parallel|This is strongly recommended to speed up the build.|
 |**Build Shared Library**|--build_shared_lib||
 
-### APIs and Language Bindings
+#### APIs and Language Bindings
+
 |API|Command|Additional details|
 |-----------|-----------|-----------|
 |**Python**|--build_wheel||
@@ -120,32 +120,35 @@ GCC 4.x and below are not supported.
 |**Node.js**|--build_nodejs|Build Node.js binding. Implies `--build_shared_lib`|
 
 ---
-## Reduced Operator Kernel Build
+### Reduced Operator Kernel Build
 Reduced Operator Kernel builds allow you to customize the kernels in the build to provide smaller binary sizes - [see instructions](https://github.com/microsoft/onnxruntime/blob/master/docs/Reduced_Operator_Kernel_build.md).
 
-## ONNX Runtime for Mobile Platforms
+### ONNX Runtime for Mobile Platforms
 For builds compatible with mobile platforms, see more details in [ONNX_Runtime_for_Mobile_Platforms.md](https://github.com/microsoft/onnxruntime/blob/master/docs/ONNX_Runtime_for_Mobile_Platforms.md). Android and iOS build instructions can be found below on this page - [Android](#Android), [iOS](#iOS)
 
-## Build ONNX Runtime Server on Linux
+### Build ONNX Runtime Server on Linux
 Read more about ONNX Runtime Server [here](https://github.com/microsoft/onnxruntime/blob/master/docs/ONNX_Runtime_Server_Usage.md).
 
 Build instructions are [here](https://github.com/microsoft/onnxruntime/blob/master/docs/Server.md)
 
-## Build Nuget packages
+### Build Nuget packages
+
 Currently only supported on Windows and Linux.
-### Prerequisites
+
+#### Prerequisites
+
 * dotnet is required for building csharp bindings and creating managed nuget package. Follow the instructions [here](https://dotnet.microsoft.com/download) to download dotnet. Tested with versions 2.1 and 3.1.
 * nuget.exe. Follow the instructions [here](https://docs.microsoft.com/en-us/nuget/install-nuget-client-tools#nugetexe-cli) to download nuget
   * On Windows, downloading nuget is straightforward and simply following the instructions above should work.
   * On Linux, nuget relies on Mono runtime and therefore this needs to be setup too. Above link has all the information to setup Mono and nuget. The instructions can directly be found [here](https://www.mono-project.com/docs/getting-started/install/). In some cases it is required to run `sudo apt-get install mono-complete` after installing mono.
 
-### Build Instructions
-#### Windows
+#### Build Instructions
+##### Windows
 ```
 .\build.bat --build_nuget
 ```
 
-#### Linux
+##### Linux
 ```
 ./build.sh --build_nuget
 ```
@@ -153,10 +156,12 @@ Nuget packages are created under <native_build_dir>\nuget-artifacts
 
 ---
 
-## Execution Provider Shared Libraries
+### Execution Provider Shared Libraries
+
 The DNNL, TensorRT, and OpenVINO providers are built as shared libraries vs being statically linked into the main onnxruntime. This enables them to be loaded only when needed, and if the dependent libraries of the provider are not installed onnxruntime will still run fine, it just will not be able to use that provider. For non shared library providers, all dependencies of the provider must exist to load onnxruntime.
 
-### Built files
+#### Built files
+
 On Windows, shared provider libraries will be named 'onnxruntime_providers_\*.dll' (for example onnxruntime_providers_openvino.dll).
 On Unix, they will be named 'libonnxruntime_providers_\*.so'
 On Mac, they will be named 'libonnxruntime_providers_\*.dylib'.
@@ -165,7 +170,8 @@ There is also a shared library that shared providers depend on called onnxruntim
 
 Note: It is not recommended to put these libraries in a system location or added to a library search path (like LD_LIBRARY_PATH on Unix). If multiple versions of onnxruntime are installed on the system this can make them find the wrong libraries and lead to undefined behavior.
 
-### Loading the shared providers
+#### Loading the shared providers
+
 Shared provider libraries are loaded by the onnxruntime code (do not load or depend on them in your client code). The API for registering shared or non shared providers is identical, the difference is that shared ones will be loaded at runtime when the provider is added to the session options (through a call like OrtSessionOptionsAppendExecutionProvider_OpenVINO or SessionOptionsAppendExecutionProvider_OpenVINO in the C API).
 If a shared provider library cannot be loaded (if the file doesn't exist, or its dependencies don't exist or not in the path) then an error will be returned.
 
@@ -173,10 +179,12 @@ The onnxruntime code will look for the provider shared libraries in the same loc
 
 ---
 
-## Execution Providers
+### Execution Providers
 
-### CUDA
-#### Prerequisites
+#### CUDA
+
+##### Prerequisites
+
 * Install [CUDA](https://developer.nvidia.com/cuda-toolkit) and [cuDNN](https://developer.nvidia.com/cudnn)
   * ONNX Runtime is built and tested with CUDA 10.2 and cuDNN 8.0.3 using Visual Studio 2019 version 16.7.
     ONNX Runtime can also be built with CUDA versions from 10.1 up to 11.0, and cuDNN versions from 7.6 up to 8.0.
@@ -184,22 +192,24 @@ The onnxruntime code will look for the provider shared libraries in the same loc
   * The path to the cuDNN installation (include the `cuda` folder in the path) must be provided via the cuDNN_PATH environment variable, or `--cudnn_home` parameter. The cuDNN path should contain `bin`, `include` and `lib` directories.
   * The path to the cuDNN bin directory must be added to the PATH environment variable so that cudnn64_8.dll is found.
 
-#### Build Instructions
-##### Windows
+
+##### Build Instructions
+
+###### Windows
 
 ```
 .\build.bat --use_cuda --cudnn_home <cudnn home path> --cuda_home <cuda home path>
 ```
 
-##### Linux
+###### Linux
+
 ```
 ./build.sh --use_cuda --cudnn_home <cudnn home path> --cuda_home <cuda home path>
 ```
 
 A Dockerfile is available [here](https://github.com/microsoft/onnxruntime/blob/master/dockerfiles#cuda).
 
-
-#### Notes
+##### Notes
 * Depending on compatibility between the CUDA, cuDNN, and Visual Studio 2017 versions you are using, you may need to explicitly install an earlier version of the MSVC toolset.
  * CUDA 10.0 is [known to work](https://devblogs.microsoft.com/cppblog/cuda-10-is-now-available-with-support-for-the-latest-visual-studio-2017-versions/) with toolsets from 14.11 up to 14.16 (Visual Studio 2017 15.9), and should continue to work with future Visual Studio versions
  * CUDA 9.2 is known to work with the 14.11 MSVC toolset (Visual Studio 15.3 and 15.4)
@@ -213,14 +223,14 @@ A Dockerfile is available [here](https://github.com/microsoft/onnxruntime/blob/m
 e.g. C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\VC\VCTargets\BuildCustomizations\.
 If you want to build with an earlier version, you must temporarily remove the 'CUDA x.y.*' files for later versions from this directory.
 
-
 ---
 
-### TensorRT
+#### TensorRT
 
 See more information on the TensorRT Execution Provider [here](../reference/execution-providers/TensorRT-ExecutionProvider.md).
 
-#### Prerequisites
+##### Prerequisites
+
 * Install [CUDA](https://developer.nvidia.com/cuda-toolkit) and [cuDNN](https://developer.nvidia.com/cudnn)
    * The TensorRT execution provider for ONNX Runtime is built and tested with CUDA 11.0 and cuDNN 8.0.
    * The path to the CUDA installation must be provided via the CUDA_PATH environment variable, or the `--cuda_home` parameter. The CUDA path should contain `bin`, `include` and `lib` directories.
@@ -230,13 +240,13 @@ See more information on the TensorRT Execution Provider [here](../reference/exec
    * The TensorRT execution provider for ONNX Runtime is built on TensorRT 7.1 and is tested with TensorRT 7.1.3.4.
    * The path to TensorRT installation must be provided via the `--tensorrt_home` parameter.
 
-#### Build Instructions
-##### Windows
+##### Build Instructions
+###### Windows
 ```
 .\build.bat --cudnn_home <path to cuDNN home> --cuda_home <path to CUDA home> --use_tensorrt --tensorrt_home <path to TensorRT home>
 ```
 
-##### Linux
+###### Linux
 
 ```
 ./build.sh --cudnn_home <path to cuDNN e.g. /usr/lib/x86_64-linux-gnu/> --cuda_home <path to folder for CUDA e.g. /usr/local/cuda> --use_tensorrt --tensorrt_home <path to TensorRT home>
@@ -246,7 +256,7 @@ Dockerfile instructions are available [here](https://github.com/microsoft/onnxru
 
 ---
 
-#### NVIDIA Jetson TX1/TX2/Nano/Xavier
+##### NVIDIA Jetson TX1/TX2/Nano/Xavier
 
 These instructions are for JetPack SDK 4.4.
 
@@ -291,6 +301,7 @@ These instructions are for JetPack SDK 4.4.
     ```
 
     Note: You may optionally build with experimental TensorRT support.
+
     ```bash
     ./build.sh --config Release --update --build --parallel --build_wheel \
     --use_tensorrt --cuda_home /usr/local/cuda --cudnn_home /usr/lib/aarch64-linux-gnu \
@@ -299,34 +310,37 @@ These instructions are for JetPack SDK 4.4.
 
 ---
 
-### DNNL and MKLML
+#### DNNL and MKLML
+
 See more information on DNNL and MKL-ML [here](../reference/execution-providers/DNNL-ExecutionProvider.md).
 
-#### Build Instructions
+##### Build Instructions
 
 The DNNL execution provider can be built for Intel CPU or GPU. To build for Intel GPU, install [Intel SDK for OpenCL Applications](https://software.intel.com/content/www/us/en/develop/tools/opencl-sdk.html). Install the latest GPU driver - [Windows graphics driver](https://downloadcenter.intel.com/product/80939/Graphics), [Linux graphics compute runtime and OpenCL driver](https://github.com/intel/compute-runtime/releases).
 
-##### Windows
+###### Windows
 `.\build.bat --use_dnnl`
 
-##### Linux
+###### Linux
 `./build.sh --use_dnnl`
 
 To build for Intel GPU, replace dnnl_opencl_root with the path of the Intel SDK for OpenCL Applications.
 
-##### Windows 
+###### Windows 
 
 `.\build.bat --use_dnnl --dnnl_gpu_runtime ocl --dnnl_opencl_root "c:\program files (x86)\intelswtools\sw_dev_tools\opencl\sdk"`
-##### Linux
+###### Linux
 
 `./build.sh --use_dnnl --dnnl_gpu_runtime ocl --dnnl_opencl_root "/opt/intel/sw_dev_tools/opencl-sdk"`s
 
 ---
 
-### OpenVINO
+#### OpenVINO
+
 See more information on the OpenVINO Execution Provider [here](../reference/execution-providers/OpenVINO-ExecutionProvider.md).
 
-#### Prerequisites
+##### Prerequisites
+
 1. Install the Intel<sup>®</sup> Distribution of OpenVINO<sup>TM</sup> Toolkit **Release 2021.1** for the appropriate OS and target hardware :
    * [Linux - CPU, GPU, VPU, VAD-M](https://software.intel.com/en-us/openvino-toolkit/choose-download/free-download-linux)
    * [Linux - FPGA](https://software.intel.com/en-us/openvino-toolkit/choose-download/free-download-linux-fpga)
@@ -360,14 +374,14 @@ See more information on the OpenVINO Execution Provider [here](../reference/exec
       * Note that if OpenVINO was installed with root permissions, this file has to be changed with the same permissions.
 
 
-#### Build Instructions
-##### Windows
+##### Build Instructions
+###### Windows
 ```
 .\build.bat --config RelWithDebInfo --use_openvino <hardware_option>
 ```
 *Note: The default Windows CMake Generator is Visual Studio 2017, but you can also use the newer Visual Studio 2019 by passing `--cmake_generator "Visual Studio 16 2019"` to `.\build.bat`*
 
-##### Linux
+###### Linux
 ```
 ./build.sh --config RelWithDebInfo --use_openvino <hardware_option>
 ```
@@ -401,10 +415,10 @@ For more information on OpenVINO Execution Provider&#39;s ONNX Layer support, To
 
 ---
 
-### NUPHAR
+#### NUPHAR
 See more information on the Nuphar Execution Provider [here](../reference/execution-providers/Nuphar-ExecutionProvider.md).
 
-#### Prerequisites
+##### Prerequisites
 * The Nuphar execution provider for ONNX Runtime is built and tested with LLVM 9.0.0. Because of TVM's requirement when building with LLVM, you need to build LLVM from source. To build the debug flavor of ONNX Runtime, you need the debug build of LLVM.
    * Windows (Visual Studio 2017):
    ```
@@ -459,15 +473,15 @@ index 7dfa97c..6d99e71 100644
    cmake -DCMAKE_INSTALL_PREFIX=/llvm/install/path -DBUILD_TYPE=Release -P cmake_install.cmake
    ```
 
-#### Build Instructions
-##### Windows
+##### Build Instructions
+###### Windows
 ```
 .\build.bat --llvm_path=\llvm\install\path\lib\cmake\llvm --use_mklml --use_nuphar --build_shared_lib --build_csharp --enable_pybind --config=Release
 ```
 
 * These instructions build the release flavor. The Debug build of LLVM would be needed to build with the Debug flavor of ONNX Runtime.
 
-##### Linux:
+###### Linux:
 ```
 ./build.sh --llvm_path=/llvm/install/path/lib/cmake/llvm --use_mklml --use_nuphar --build_shared_lib --build_csharp --enable_pybind --config=Release
 ```
@@ -477,21 +491,21 @@ Dockerfile instructions are available [here](https://github.com/microsoft/onnxru
 
 ---
 
-### DirectML
+#### DirectML
 See more information on the DirectML execution provider [here](../reference/execution-providers/DirectML-ExecutionProvider.md).
-#### Windows
+##### Windows
 ```
 .\build.bat --use_dml
 ```
-#### Notes
+##### Notes
 The DirectML execution provider supports building for both x64 and x86 architectures. DirectML is only supported on Windows.
 
 ---
 
-### ARM Compute Library
+#### ARM Compute Library
 See more information on the ACL Execution Provider [here](../reference/execution-providers/ACL-ExecutionProvider.md).
 
-#### Prerequisites
+##### Prerequisites
 * Supported backend: i.MX8QM Armv8 CPUs
 * Supported BSP: i.MX8QM BSP
   * Install i.MX8QM BSP: `source fsl-imx-xwayland-glibc-x86_64-fsl-image-qt5-aarch64-toolchain-4*.sh`
@@ -502,7 +516,7 @@ alias cmake="/usr/bin/cmake -DCMAKE_TOOLCHAIN_FILE=$OECORE_NATIVE_SYSROOT/usr/sh
 ```
 * See [Build ARM](#ARM) below for information on building for ARM devices
 
-#### Build Instructions
+##### Build Instructions
 
 1. Configure ONNX Runtime with ACL support:
 ```
@@ -528,81 +542,98 @@ onnxruntime_perf_test
 onnxruntime_test_all
 ```
 
-#### Native Build Instructions (validated on Jetson Nano and Jetson Xavier)
+##### Native Build Instructions (validated on Jetson Nano and Jetson Xavier)
 
 1. Build ACL Library (skip if already built)
-```
-cd ~
-git clone -b v20.02 https://github.com/Arm-software/ComputeLibrary.git
-cd ComputeLibrary
-sudo apt-get install -y scons g++-arm-linux-gnueabihf
-scons -j8 arch=arm64-v8a  Werror=1 debug=0 asserts=0 neon=1 opencl=1 examples=1 build=native
-```
-2. Cmake is needed to build ONNX Runtime. Because the minimum required version is 3.13,
+
+    ```bash
+    cd ~
+    git clone -b v20.02 https://github.com/Arm-software/ComputeLibrary.git
+    cd ComputeLibrary
+    sudo apt-get install -y scons g++-arm-linux-gnueabihf
+    scons -j8 arch=arm64-v8a  Werror=1 debug=0 asserts=0 neon=1 opencl=1 examples=1 build=native
+    ```
+
+1. Cmake is needed to build ONNX Runtime. Because the minimum required version is 3.13,
    it is necessary to build CMake from source. Download Unix/Linux sources from https://cmake.org/download/
    and follow https://cmake.org/install/ to build from source. Version 3.17.5 and 3.18.4 have been tested on Jetson.
-3. Build onnxruntime with --use_acl flag with one of the supported ACL version flags. (ACL_1902 | ACL_1905 | ACL_1908 | ACL_2002)
-```
+
+1. Build onnxruntime with --use_acl flag with one of the supported ACL version flags. (ACL_1902 | ACL_1905 | ACL_1908 | ACL_2002)
 
 ---
 
-### ArmNN
+#### ArmNN
+
 See more information on the ArmNN Execution Provider [here](../reference/execution-providers/ArmNN-ExecutionProvider.md).
 
-#### Prerequisites
+##### Prerequisites
+
 * Supported backend: i.MX8QM Armv8 CPUs
 * Supported BSP: i.MX8QM BSP
   * Install i.MX8QM BSP: `source fsl-imx-xwayland-glibc-x86_64-fsl-image-qt5-aarch64-toolchain-4*.sh`
 * Set up the build environment
-```
+
+```bash
 source /opt/fsl-imx-xwayland/4.*/environment-setup-aarch64-poky-linux
 alias cmake="/usr/bin/cmake -DCMAKE_TOOLCHAIN_FILE=$OECORE_NATIVE_SYSROOT/usr/share/cmake/OEToolchainConfig.cmake"
 ```
+
 * See [Build ARM](#ARM) below for information on building for ARM devices
 
-#### Build Instructions
-```
+##### Build Instructions
+
+```bash
 ./build.sh --use_armnn
 ```
+
 The Relu operator is set by default to use the CPU execution provider for better performance. To use the ArmNN implementation build with --armnn_relu flag
-```
+
+```bash
 ./build.sh --use_armnn --armnn_relu
 ```
+
 The Batch Normalization operator is set by default to use the CPU execution provider. To use the ArmNN implementation build with --armnn_bn flag
-```
+
+```bash
 ./build.sh --use_armnn --armnn_bn
 ```
 
 To use a library outside the normal environment you can set a custom path by using --armnn_home and --armnn_libs tags that defines the path to the ArmNN home directory and the build directory respectively.
-```
+
+```bash
 ./build.sh --use_armnn --armnn_home /path/to/ComputeLibrary --armnn_libs /path/to/build
 ```
 
 ---
 
-### RKNPU
+#### RKNPU
 See more information on the RKNPU Execution Provider [here](../reference/execution-providers/RKNPU-ExecutionProvider.md).
 
-#### Prerequisites
+##### Prerequisites
 
 * Supported platform: RK1808 Linux
 * See [Build ARM](#ARM) below for information on building for ARM devices
 * Use gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu instead of gcc-linaro-6.3.1-2017.05-x86_64_arm-linux-gnueabihf, and modify CMAKE_CXX_COMPILER & CMAKE_C_COMPILER in tool.cmake:
-  ```
-  set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
-  set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
-  ```
+  
+```
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+```
 
-#### Build Instructions
-##### Linux
+##### Build Instructions
+###### Linux
+
 1. Download [rknpu_ddk](#https://github.com/airockchip/rknpu_ddk.git) to any directory.
 
-2. Build ONNX Runtime library and test:
-    ```
+1. Build ONNX Runtime library and test:
+
+    ```bash
     ./build.sh --arm --use_rknpu --parallel --build_shared_lib --build_dir build_arm --config MinSizeRel --cmake_extra_defines RKNPU_DDK_PATH=<Path To rknpu_ddk> CMAKE_TOOLCHAIN_FILE=<Path To tool.cmake> ONNX_CUSTOM_PROTOC_EXECUTABLE=<Path To protoc>
     ```
-3. Deploy ONNX runtime and librknpu_ddk.so on the RK1808 board:
-    ```
+
+1. Deploy ONNX runtime and librknpu_ddk.so on the RK1808 board:
+
+    ```bash
     libonnxruntime.so.1.2.0
     onnxruntime_test_all
     rknpu_ddk/lib64/librknpu_ddk.so
@@ -610,82 +641,92 @@ See more information on the RKNPU Execution Provider [here](../reference/executi
 
 ---
 
-### Vitis-AI
+#### Vitis-AI
 See more information on the Xilinx Vitis-AI execution provider [here](../reference/execution-providers/Vitis-AI-ExecutionProvider.md).
 
 For instructions to setup the hardware environment: [Hardware setup](../reference/execution-providers/Vitis-AI-ExecutionProvider.md#Hardware-setup)
 
-#### Linux
+##### Linux
 
-```
+```bash
 ./build.sh --use_vitisai
 ```
-#### Notes
+
+##### Notes
 The Vitis-AI execution provider is only supported on Linux.
 
-## Options
-### OpenMP
-#### Build Instructions
-##### Windows
-```
+### Options
+#### OpenMP
+##### Build Instructions
+###### Windows
+
+```powershell
 .\build.bat --use_openmp
 ```
 
-##### Linux/macOS
-```
-./build.sh --use_openmp
+###### Linux/macOS
 
+```bash
+./build.sh --use_openmp
 ```
 
 ---
 
-### OpenBLAS
-#### Prerequisites
+#### OpenBLAS
+##### Prerequisites
+
 * OpenBLAS
    * Windows: See build instructions [here](https://github.com/xianyi/OpenBLAS/wiki/How-to-use-OpenBLAS-in-Microsoft-Visual-Studio#build-openblas-for-universal-windows-platform)
    * Linux: Install the libopenblas-dev package `sudo apt-get install libopenblas-dev`
 
-#### Build Instructions
-##### Windows
+##### Build Instructions
+###### Windows
+
 ```
 .\build.bat --use_openblas
 ```
 
-##### Linux
-```
+###### Linux
+
+```bash
 ./build.sh --use_openblas
 ```
 
 ---
 
-### DebugNodeInputsOutputs
+#### DebugNodeInputsOutputs
 OnnxRuntime supports build options for enabling debugging of intermediate tensor shapes and data.
 
-#### Build Instructions
+##### Build Instructions
 Set onnxruntime_DEBUG_NODE_INPUTS_OUTPUT to build with this enabled.
 
-**Linux**
-```
+###### Linux
+
+```bash
 ./build.sh --cmake_extra_defines onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS=1
 ```
 
-**Windows**
+###### Windows
+
 ```
 .\build.bat --cmake_extra_defines onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS=1
 ```
 
-#### Configuration
+##### Configuration
+
 The debug dump behavior can be controlled with several environment variables.
 See [onnxruntime/core/framework/debug_node_inputs_outputs_utils.h](https://github.com/microsoft/onnxruntime/blob/master/onnxruntime/core/framework/debug_node_inputs_outputs_utils.h) for details.
 
-##### Examples
+###### Examples
 
 To specify that node output data should be dumped (to stdout by default), set this environment variable:
+
 ```
 ORT_DEBUG_NODE_IO_DUMP_OUTPUT_DATA=1
 ```
 
 To specify that node output data should be dumped to files for nodes with name "Foo" or "Bar", set these environment variables:
+
 ```
 ORT_DEBUG_NODE_IO_DUMP_OUTPUT_DATA=1
 ORT_DEBUG_NODE_IO_NAME_FILTER="Foo;Bar"
@@ -694,19 +735,20 @@ ORT_DEBUG_NODE_IO_DUMP_DATA_TO_FILES=1
 
 ---
 
-## Architectures
-### x86
-#### Build Instructions
-##### Windows
+### Architectures
+#### x86
+##### Build Instructions
+###### Windows
 * add `--x86` argument when launching `.\build.bat`
 
-##### Linux
+###### Linux
 * Must be built on a x86 OS
 * add --x86 argument to build.sh
 
 ---
 
-### ARM
+#### ARM
+
 There are a few options for building for ARM.
 
 * [Cross compiling for ARM with simulation (Linux/Windows)](#Cross-compiling-for-ARM-with-simulation-LinuxWindows) - **Recommended**;  Easy, slow
@@ -714,8 +756,8 @@ There are a few options for building for ARM.
 * [Native compiling on Linux ARM device](#Native-compiling-on-Linux-ARM-device) - Easy, slower
 * [Cross compiling on Windows](#Cross-compiling-on-Windows)
 
+##### Cross compiling for ARM with simulation (Linux/Windows)
 
-#### Cross compiling for ARM with simulation (Linux/Windows)
 *EASY, SLOW, RECOMMENDED*
 
 This method rely on qemu user mode emulation. It allows you to compile using a desktop or cloud VM through instruction level simulation. You'll run the build on x86 CPU and translate every ARM instruction to x86. This is much faster than compiling natively on a low-end ARM device and avoids out-of-memory issues that may be encountered. The resulting ONNX Runtime Python wheel (.whl) file is then deployed to an ARM device where it can be invoked in Python 3 scripts.
@@ -724,140 +766,162 @@ Here is [an example for Raspberrypi3 and Raspbian](https://github.com/microsoft/
 
 The build process can take hours.
 
-#### Cross compiling on Linux
+##### Cross compiling on Linux
+
 *Difficult, fast*
 
 This option is very fast and allows the package to be built in minutes, but is challenging to setup. If you have a large code base (e.g. you are adding a new execution provider to onnxruntime), this may be the only feasible method.
 
-##### 1. Get the corresponding toolchain.
-TLDR; Go to https://www.linaro.org/downloads/, get "64-bit Armv8 Cortex-A, little-endian" and "Linux Targeted", not "Bare-Metal Targeted". Extract it to your build machine and add the bin folder to your $PATH env. Then skip this part.
+1. Get the corresponding toolchain.
 
-You can use [GCC](https://gcc.gnu.org/) or [Clang](http://clang.llvm.org/). Both work, but instructions here are based on GCC.
+    TLDR; Go to https://www.linaro.org/downloads/, get "64-bit Armv8 Cortex-A, little-endian" and "Linux Targeted", not "Bare-Metal Targeted". Extract it to your build machine and add the bin folder to your $PATH env. Then skip this part.
 
-In GCC terms:
-* "build" describes the type of system on which GCC is being configured and compiled
-* "host" describes the type of system on which GCC runs.
-"target" to describe the type of system for which GCC produce code
-When not cross compiling, usually "build" = "host" = "target". When you do cross compile, usually "build" = "host" != "target". For example, you may build GCC on x86_64, then run GCC on x86_64, then generate binaries that target aarch64. In this case,"build" = "host" = x86_64 Linux, target is aarch64 Linux.
+    You can use [GCC](https://gcc.gnu.org/) or [Clang](http://clang.llvm.org/). Both work, but instructions here are based on GCC.
 
-You can either build GCC from source code by yourself, or get a prebuilt one from a vendor like Ubuntu, linaro. Choosing the same compiler version as your target operating system is best. If ths is not possible, choose the latest stable one and statically link to the GCC libs.
+    In GCC terms:
+    * "build" describes the type of system on which GCC is being configured and compiled
+    * "host" describes the type of system on which GCC runs.
+    * "target" to describe the type of system for which GCC produce code
 
-When you get the compiler, run `aarch64-linux-gnu-gcc -v` This should produce an output like below:
+    When not cross compiling, usually "build" = "host" = "target". When you do cross compile, usually "build" = "host" != "target". For example, you may build GCC on x86_64, then run GCC on x86_64, then generate binaries that target aarch64. In this case,"build" = "host" = x86_64 Linux, target is aarch64 Linux.
 
-```
-Using built-in specs.
-COLLECT_GCC=/usr/bin/aarch64-linux-gnu-gcc
-COLLECT_LTO_WRAPPER=/usr/libexec/gcc/aarch64-linux-gnu/9/lto-wrapper
-Target: aarch64-linux-gnu
-Configured with: ../gcc-9.2.1-20190827/configure --bindir=/usr/bin --build=x86_64-redhat-linux-gnu --datadir=/usr/share --disable-decimal-float --disable-dependency-tracking --disable-gold --disable-libgcj --disable-libgomp --disable-libmpx --disable-libquadmath --disable-libssp --disable-libunwind-exceptions --disable-shared --disable-silent-rules --disable-sjlj-exceptions --disable-threads --with-ld=/usr/bin/aarch64-linux-gnu-ld --enable-__cxa_atexit --enable-checking=release --enable-gnu-unique-object --enable-initfini-array --enable-languages=c,c++ --enable-linker-build-id --enable-lto --enable-nls --enable-obsolete --enable-plugin --enable-targets=all --exec-prefix=/usr --host=x86_64-redhat-linux-gnu --includedir=/usr/include --infodir=/usr/share/info --libexecdir=/usr/libexec --localstatedir=/var --mandir=/usr/share/man --prefix=/usr --program-prefix=aarch64-linux-gnu- --sbindir=/usr/sbin --sharedstatedir=/var/lib --sysconfdir=/etc --target=aarch64-linux-gnu --with-bugurl=http://bugzilla.redhat.com/bugzilla/ --with-gcc-major-version-only --with-isl --with-newlib --with-plugin-ld=/usr/bin/aarch64-linux-gnu-ld --with-sysroot=/usr/aarch64-linux-gnu/sys-root --with-system-libunwind --with-system-zlib --without-headers --enable-gnu-indirect-function --with-linker-hash-style=gnu
-Thread model: single
-gcc version 9.2.1 20190827 (Red Hat Cross 9.2.1-3) (GCC)
-```
+    You can either build GCC from source code by yourself, or get a prebuilt one from a vendor like Ubuntu, linaro. Choosing the same compiler version as your target operating system is best. If ths is not possible, choose the latest stable one and statically link to the GCC libs.
 
-Check the value of `--build`, `--host`, `--target`, and if it has special args like `--with-arch=armv8-a`, `--with-arch=armv6`, `--with-tune=arm1176jz-s`, `--with-fpu=vfp`, `--with-float=hard`.
+    When you get the compiler, run `aarch64-linux-gnu-gcc -v` This should produce an output like below:
 
-You must also know what kind of flags your target hardware need, which can differ greatly. For example, if you just get the normal ARMv7 compiler and use it for Raspberry Pi V1 directly, it won't work because Raspberry Pi only has ARMv6. Generally every hardware vendor will provide a toolchain; check how that one was built.
+    ```bash
+    Using built-in specs.
+    COLLECT_GCC=/usr/bin/aarch64-linux-gnu-gcc
+    COLLECT_LTO_WRAPPER=/usr/libexec/gcc/aarch64-linux-gnu/9/lto-wrapper
+    Target: aarch64-linux-gnu
+    Configured with: ../gcc-9.2.1-20190827/configure --bindir=/usr/bin --build=x86_64-redhat-linux-gnu --datadir=/usr/share --disable-decimal-float --disable-dependency-tracking --disable-gold --disable-libgcj --disable-libgomp --disable-libmpx --disable-libquadmath --disable-libssp --disable-libunwind-exceptions --disable-shared --disable-silent-rules --disable-sjlj-exceptions --disable-threads --with-ld=/usr/bin/aarch64-linux-gnu-ld --enable-__cxa_atexit --enable-checking=release --enable-gnu-unique-object --enable-initfini-array --enable-languages=c,c++ --enable-linker-build-id --enable-lto --enable-nls --enable-obsolete --enable-plugin --enable-targets=all --exec-prefix=/usr --host=x86_64-redhat-linux-gnu --includedir=/usr/include --infodir=/usr/share/info --libexecdir=/usr/libexec --localstatedir=/var --mandir=/usr/share/man --prefix=/usr --program-prefix=aarch64-linux-gnu- --sbindir=/usr/sbin --sharedstatedir=/var/lib --sysconfdir=/etc --target=aarch64-linux-gnu --with-bugurl=http://bugzilla.redhat.com/bugzilla/ --with-gcc-major-version-only --with-isl --with-newlib --with-plugin-ld=/usr/bin/aarch64-linux-gnu-ld --with-sysroot=/usr/aarch64-linux-gnu/sys-root --with-system-libunwind --with-system-zlib --without-headers --enable-gnu-indirect-function --with-linker-hash-style=gnu
+    Thread model: single
+    gcc version 9.2.1 20190827 (Red Hat Cross 9.2.1-3) (GCC)
+    ```
 
-A target env is identifed by:
+    Check the value of `--build`, `--host`, `--target`, and if it has special args like `--with-arch=armv8-a`, `--with-arch=armv6`, `--with-tune=arm1176jz-s`, `--with-fpu=vfp`, `--with-float=hard`.
 
-* Arch: x86_32, x86_64, armv6,armv7,arvm7l,aarch64,...
-* OS: bare-metal or linux.
-* Libc: gnu libc/ulibc/musl/...
-* ABI: ARM has mutilple ABIs like eabi, eabihf...
+    You must also know what kind of flags your target hardware need, which can differ greatly. For example, if you just get the normal ARMv7 compiler and use it for Raspberry Pi V1 directly, it won't work because Raspberry Pi only has ARMv6. Generally every hardware vendor will provide a toolchain; check how that one was built.
 
-You can get all these information from the previous output, please be sure they are all correct.
+    A target env is identifed by:
 
-##### 2. Get a pre-compiled protoc:
+    * Arch: x86_32, x86_64, armv6,armv7,arvm7l,aarch64,...
+    * OS: bare-metal or linux.
+    * Libc: gnu libc/ulibc/musl/...
+    * ABI: ARM has mutilple ABIs like eabi, eabihf...
+
+    You can get all these information from the previous output, please be sure they are all correct.
+
+2. Get a pre-compiled protoc:
+
    Get this from https://github.com/protocolbuffers/protobuf/releases/download/v3.11.2/protoc-3.11.2-linux-x86_64.zip and unzip after downloading.
    The version must match the one onnxruntime is using. Currently we are using 3.11.2.
 
-##### 3. (Optional) Setup sysroot to enable python extension. *Skip if not using Python.*
+3. (Optional) Setup sysroot to enable python extension. *Skip if not using Python.*
 
-   Dump the root file system of the target operating system to your build machine. We'll call that folder "sysroot" and use it for build onnxruntime python extension. Before doing that, you should install python3 dev package(which contains the C header files) and numpy python package on the target machine first.
+    Dump the root file system of the target operating system to your build machine. We'll call that folder "sysroot" and use it for build onnxruntime python extension. Before doing that, you should install python3 dev package(which contains the C header files) and numpy python package on the target machine first.
 
-   Below are some examples.
+    Below are some examples.
 
-   If the target OS is raspbian-buster, please download the RAW image from [their website](https://www.raspberrypi.org/downloads/raspbian/) then run:
-```bash
-$ fdisk -l 2020-02-13-raspbian-buster.img
-```
-Disk 2020-02-13-raspbian-buster.img: 3.54 GiB, 3787456512 bytes, 7397376 sectors
-Units: sectors of 1 * 512 = 512 bytes
-Sector size (logical/physical): 512 bytes / 512 bytes
-I/O size (minimum/optimal): 512 bytes / 512 bytes
-Disklabel type: dos
-Disk identifier: 0xea7d04d6
+    If the target OS is raspbian-buster, please download the RAW image from [their website](https://www.raspberrypi.org/downloads/raspbian/) then run:
 
-| Device                          | Boot | Start  | End     | Sectors | Size | Id | Type            |
-|---------------------------------|------|--------|---------|---------|------|----|-----------------|
-| 2020-02-13-raspbian-buster.img1 |      | 8192   | 532479  | 524288  | 256M | c  | W95 FAT32 (LBA) |
-| 2020-02-13-raspbian-buster.img2 |      | 532480 | 7397375 | 6864896 | 3.3G | 83 | Linux           |
+    ```bash
+    $ fdisk -l 2020-02-13-raspbian-buster.img
+    ```
 
-You'll find the the root partition starts at the 532480 sector, which is 532480 \* 512=272629760 bytes from the beginning.
+    Disk 2020-02-13-raspbian-buster.img: 3.54 GiB, 3787456512 bytes, 7397376 sectors
+    Units: sectors of 1 * 512 = 512 bytes
+    Sector size (logical/physical): 512 bytes / 512 bytes
+    I/O size (minimum/optimal): 512 bytes / 512 bytes
+    Disklabel type: dos
+    Disk identifier: 0xea7d04d6
 
-Then run:
-```bash
-$ mkdir /mnt/pi
-$ mount -r -o loop,offset=272629760 2020-02-13-raspbian-buster.img /mnt/pi
-```
+    | Device                          | Boot | Start  | End     | Sectors | Size | Id | Type            |
+    |---------------------------------|------|--------|---------|---------|------|----|-----------------|
+    | 2020-02-13-raspbian-buster.img1 |      | 8192   | 532479  | 524288  | 256M | c  | W95 FAT32 (LBA) |
+    | 2020-02-13-raspbian-buster.img2 |      | 532480 | 7397375 | 6864896 | 3.3G | 83 | Linux           |
 
-You'll see all raspbian files at /mnt/pi. However you can't use it yet. Because some of the symlinks are broken, you must fix them first.
-In /mnt/pi, run
-```
-$ find . -type l -exec realpath  {} \; |grep 'No such file'
-```
-It will show which are broken.
-Then you can fix them by running:
-```bash
-$ mkdir /mnt/pi2
-$ cd /mnt/pi2
-$ sudo tar -C /mnt/pi -cf - . | sudo tar --transform 'flags=s;s,^/,/mnt/pi2/,' -xf -
-```
-Then /mnt/pi2 is the sysroot folder you'll use in the next step.
+    You'll find the the root partition starts at the 532480 sector, which is 532480 \* 512=272629760 bytes from the beginning.
 
-If the target OS is Ubuntu, you can get an image from [https://cloud-images.ubuntu.com/](https://cloud-images.ubuntu.com/). But that image is in qcow2 format. Please convert it before run fdisk and mount.
-```bash
-qemu-img convert -p -O raw ubuntu-18.04-server-cloudimg-arm64.img ubuntu.raw
-```
-The remaining part is similar to raspbian.
+    Then run:
 
-If the target OS is manylinux2014, you can get it by:
-Install qemu-user-static from apt or dnf.
-Then run the docker
-Ubuntu:
-```bash
-docker run -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static -it --rm quay.io/pypa/manylinux2014_aarch64 /bin/bash
-```
-The "-v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static" arg is not needed on Fedora.
+    ```bash
+    $ mkdir /mnt/pi
+    $ mount -r -o loop,offset=272629760 2020-02-13-raspbian-buster.img /mnt/pi
+    ```
 
-Then, inside the docker, run
-```bash
-cd /opt/python
-./cp35-cp35m/bin/python -m pip install numpy==1.16.6
-./cp36-cp36m/bin/python -m pip install numpy==1.16.6
-./cp37-cp37m/bin/python -m pip install numpy==1.16.6
-./cp38-cp38/bin/python -m pip install numpy==1.16.6
-```
+    You'll see all raspbian files at /mnt/pi. However you can't use it yet. Because some of the symlinks are broken, you must fix them first.
 
-These commands will take a few hours because numpy doesn't have a prebuilt package yet. When completed, open a second window and run
-```bash
-docker ps
-```
-From the output:
-```
-CONTAINER ID        IMAGE                                COMMAND             CREATED             STATUS              PORTS               NAMES
-5a796e98db05        quay.io/pypa/manylinux2014_aarch64   "/bin/bash"         3 minutes ago       Up 3 minutes                            affectionate_cannon
-```
-You'll see the docker instance id is: 5a796e98db05. Use the following command to export the root filesystem as the sysroot for future use.
+    In /mnt/pi, run
 
-```bash
-docker export 5a796e98db05 -o manylinux2014_aarch64.tar
-```
+    ```bash
+    $ find . -type l -exec realpath  {} \; |grep 'No such file'
+    ```
 
-##### 4. Generate CMake toolchain file
-   Save the following content as tool.cmake
+    It will show which are broken.
+    Then you can fix them by running:
 
-```cmake
+    ```bash
+    $ mkdir /mnt/pi2
+    $ cd /mnt/pi2
+    $ sudo tar -C /mnt/pi -cf - . | sudo tar --transform 'flags=s;s,^/,/mnt/pi2/,' -xf -
+    ```
+
+    Then /mnt/pi2 is the sysroot folder you'll use in the next step.
+
+    If the target OS is Ubuntu, you can get an image from [https://cloud-images.ubuntu.com/](https://cloud-images.ubuntu.com/). But that image is in qcow2 format. Please convert it before run fdisk and mount.
+
+    ```bash
+    qemu-img convert -p -O raw ubuntu-18.04-server-cloudimg-arm64.img ubuntu.raw
+    ```
+
+    The remaining part is similar to raspbian.
+
+    If the target OS is manylinux2014, you can get it by:
+    Install qemu-user-static from apt or dnf.
+    Then run the docker
+
+    Ubuntu:
+    
+    ```bash
+    docker run -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static -it --rm quay.io/pypa/manylinux2014_aarch64 /bin/bash
+    ```
+
+    The "-v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static" arg is not needed on Fedora.
+
+    Then, inside the docker, run
+
+    ```bash
+    cd /opt/python
+    ./cp35-cp35m/bin/python -m pip install numpy==1.16.6
+    ./cp36-cp36m/bin/python -m pip install numpy==1.16.6
+    ./cp37-cp37m/bin/python -m pip install numpy==1.16.6
+    ./cp38-cp38/bin/python -m pip install numpy==1.16.6
+    ```
+
+    These commands will take a few hours because numpy doesn't have a prebuilt package yet. When completed, open a second window and run
+
+    ```bash
+    docker ps
+    ```
+
+    From the output:
+    
+    ```
+    CONTAINER ID        IMAGE                                COMMAND             CREATED             STATUS              PORTS               NAMES
+    5a796e98db05        quay.io/pypa/manylinux2014_aarch64   "/bin/bash"         3 minutes ago       Up 3 minutes                            affectionate_cannon
+    ```
+    
+    You'll see the docker instance id is: 5a796e98db05. Use the following command to export the root filesystem as the sysroot for future use.
+
+    ```bash
+    docker export 5a796e98db05 -o manylinux2014_aarch64.tar
+    ```
+
+4. Generate CMake toolchain file
+    Save the following content as tool.cmake
+
+    ```cmake
     SET(CMAKE_SYSTEM_NAME Linux)
     SET(CMAKE_SYSTEM_VERSION 1)
     SET(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
@@ -867,38 +931,46 @@ docker export 5a796e98db05 -o manylinux2014_aarch64.tar
     SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
     SET(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
     SET(CMAKE_FIND_ROOT_PATH /mnt/pi)
-```
-If you don't have a sysroot, you can delete the last line.
+    ```
 
-##### 5.  Run CMake and make
- Append `-DONNX_CUSTOM_PROTOC_EXECUTABLE=/path/to/protoc -DCMAKE_TOOLCHAIN_FILE=path/to/tool.cmake` to your cmake args, run cmake and make to build it. If you want to build Python package as well, you can use cmake args like:
-```
--Donnxruntime_GCC_STATIC_CPP_RUNTIME=ON -DCMAKE_BUILD_TYPE=Release -Dprotobuf_WITH_ZLIB=OFF -DCMAKE_TOOLCHAIN_FILE=path/to/tool.cmake -Donnxruntime_ENABLE_PYTHON=ON -DPYTHON_EXECUTABLE=/mnt/pi/usr/bin/python3 -Donnxruntime_BUILD_SHARED_LIB=OFF -Donnxruntime_DEV_MODE=OFF -DONNX_CUSTOM_PROTOC_EXECUTABLE=/path/to/protoc "-DPYTHON_INCLUDE_DIR=/mnt/pi/usr/include;/mnt/pi/usr/include/python3.7m" -DNUMPY_INCLUDE_DIR=/mnt/pi/folder/to/numpy/headers
-```
+    If you don't have a sysroot, you can delete the last line.
 
-After running cmake, run
-```
-$ make
-```
+5.  Run CMake and make
 
-##### 6.  (Optional) Build Python package
-Copy the setup.py file from the source folder to the build folder and run
-```bash
-python3 setup.py bdist_wheel -p linux_aarch64
-```
+    Append `-DONNX_CUSTOM_PROTOC_EXECUTABLE=/path/to/protoc -DCMAKE_TOOLCHAIN_FILE=path/to/tool.cmake` to your cmake args, run cmake and make to build it. If you want to build Python package as well, you can use cmake args like:
 
-If targeting manylinux, unfortunately their tools do not work in the cross-compiling scenario. Run it in a docker like:
+    ```bash
+    -Donnxruntime_GCC_STATIC_CPP_RUNTIME=ON -DCMAKE_BUILD_TYPE=Release -Dprotobuf_WITH_ZLIB=OFF -DCMAKE_TOOLCHAIN_FILE=path/to/tool.cmake -Donnxruntime_ENABLE_PYTHON=ON -DPYTHON_EXECUTABLE=/mnt/pi/usr/bin/python3 -Donnxruntime_BUILD_SHARED_LIB=OFF -Donnxruntime_DEV_MODE=OFF -DONNX_CUSTOM_PROTOC_EXECUTABLE=/path/to/protoc "-DPYTHON_INCLUDE_DIR=/mnt/pi/usr/include;/mnt/pi/usr/include/python3.7m" -DNUMPY_INCLUDE_DIR=/mnt/pi/folder/to/numpy/headers
+    ```
 
-```bash
-docker run  -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static -v `pwd`:/tmp/a -w /tmp/a --rm quay.io/pypa/manylinux2014_aarch64 /opt/python/cp37-cp37m/bin/python3 setup.py bdist_wheel
-```
-This is not needed if you only want to target a specfic Linux distribution (i.e. Ubuntu).
+    After running cmake, run
 
+    ```bash
+    $ make
+    ```
 
-#### Native compiling on Linux ARM device
+6.  (Optional) Build Python package
+
+    Copy the setup.py file from the source folder to the build folder and run
+
+    ```bash
+    python3 setup.py bdist_wheel -p linux_aarch64
+    ```
+
+    If targeting manylinux, unfortunately their tools do not work in the cross-compiling scenario. Run it in a docker like:
+
+    ```bash
+    docker run  -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static -v `pwd`:/tmp/a -w /tmp/a --rm quay.io/pypa/manylinux2014_aarch64 /opt/python/cp37-cp37m/bin/python3 setup.py bdist_wheel
+    ```
+
+    This is not needed if you only want to target a specfic Linux distribution (i.e. Ubuntu).
+
+##### Native compiling on Linux ARM device
+
 *Easy, slower*
 
 Docker build runs on a Raspberry Pi 3B with Raspbian Stretch Lite OS (Desktop version will run out memory when linking the .so file) will take 8-9 hours in total.
+
 ```bash
 sudo apt-get update
 sudo apt-get install -y \
@@ -949,8 +1021,10 @@ ls -l /code/onnxruntime/build/Linux/MinSizeRel/*.so
 ls -l /code/onnxruntime/build/Linux/MinSizeRel/dist/*.whl
 ```
 
-#### Cross compiling on Windows
+##### Cross compiling on Windows
+
 **Using Visual C++ compilers**
+
 1. Download and install Visual C++ compilers and libraries for ARM(64).
    If you have Visual Studio installed, please use the Visual Studio Installer (look under the section `Individual components` after choosing to `modify` Visual Studio) to download and install the corresponding ARM(64) compilers and libraries.
 
@@ -958,191 +1032,208 @@ ls -l /code/onnxruntime/build/Linux/MinSizeRel/dist/*.whl
 
 ---
 
-### Android
+#### Android
 
-#### Prerequisites
+##### Prerequisites
 
 The SDK and NDK packages can be installed via Android Studio or the sdkmanager command line tool.
 Android Studio is more convenient but a larger installation.
 The command line tools are smaller and usage can be scripted, but are  a little more complicated to setup. They also require a Java runtime environment to be available.
 
-General Info:
-  - API levels: https://developer.android.com/guide/topics/manifest/uses-sdk-element.html
-  - Android ABIs: https://developer.android.com/ndk/guides/abis
-  - System Images: https://developer.android.com/topic/generic-system-image
+Resources:
+- API levels: https://developer.android.com/guide/topics/manifest/uses-sdk-element.html
+- Android ABIs: https://developer.android.com/ndk/guides/abis
+- System Images: https://developer.android.com/topic/generic-system-image
 
-##### Android Studio
+###### Android Studio
 
-Install Android Studio from https://developer.android.com/studio
+1. Install Android Studio from https://developer.android.com/studio
 
-Install any additional SDK Platforms if necessary
-  - File->Settings->Appearance & Behavior->System Settings->Android SDK to see what is currently installed
-    - Note that the SDK path you need to use as --android_sdk_path when building ORT is also on this configuration page
-    - Most likely you don't require additional SDK Platform packages as the latest platform can target earlier API levels.
+1. Install any additional SDK Platforms if necessary
 
-Install an NDK version
-  - File->Settings->Appearance & Behavior->System Settings->Android SDK
-    - 'SDK Tools' tab
-      - Select 'Show package details' checkbox at the bottom to see specific versions.
-        By default the latest will be installed which should be fine.
-  - The NDK path will be the 'ndk/{version}' subdirectory of the SDK path shown
-    - e.g. if 21.1.6352462 is installed it will be {SDK path}/ndk/21.1.6352462
+* File->Settings->Appearance & Behavior->System Settings->Android SDK to see what is currently installed
+* Note that the SDK path you need to use as --android_sdk_path when building ORT is also on this configuration page
+* Most likely you don't require additional SDK Platform packages as the latest platform can target earlier API levels.
 
-##### sdkmanager from command line tools
-  - If necessary install the Java Runtime Environment and set the JAVA_HOME environment variable to point to it
-    - https://www.java.com/en/download/
-    - Windows note: You MUST install the 64-bit version (https://www.java.com/en/download/manual.jsp) otherwise sdkmanager will only list x86 packages
+1. Install an NDK version
+
+* File->Settings->Appearance & Behavior->System Settings->Android SDK
+* 'SDK Tools' tab
+  * Select 'Show package details' checkbox at the bottom to see specific versions. By default the latest will be installed which should be fine.
+* The NDK path will be the 'ndk/{version}' subdirectory of the SDK path shown
+  * e.g. if 21.1.6352462 is installed it will be {SDK path}/ndk/21.1.6352462
+
+###### sdkmanager from command line tools
+
+* If necessary install the Java Runtime Environment and set the JAVA_HOME environment variable to point to it
+  * https://www.java.com/en/download/
+  * Windows note: You MUST install the 64-bit version (https://www.java.com/en/download/manual.jsp) otherwise sdkmanager will only list x86 packages
       and the latest NDK is x64 only.
-  - For sdkmanager to work it needs a certain directory structure.
-    First create the top level directory for the Android infrastructure.
-    - in our example we'll call that `.../Android/`
-  - Download the command line tools from the 'Command line tools only' section towards the bottom
-    of https://developer.android.com/studio
-  - Create a directory called 'cmdline-tools' under your top level directory
-    - giving `.../Android/cmdline-tools`
-  - extract the 'tools' directory from the command line tools zip file into this directory
-    - giving `.../Android/cmdline-tools/tools`
-    - Windows note: preferably extract using 7-zip.
-      If using the built in Windows zip extract tool you will need to fix the directory structure
-      by moving the jar files from `tools\lib\_` up to `tools\lib`
-      - See https://stackoverflow.com/questions/27364963/could-not-find-or-load-main-class-com-android-sdkmanager-main
-  - you should now be able to run Android/cmdline-tools/bin/sdkmanager[.bat] successfully
-    - if you see an error about it being unable to save settings and the sdkmanager help text,
+* For sdkmanager to work it needs a certain directory structure. First create the top level directory for the Android infrastructure.
+  * in our example we'll call that `.../Android/`
+* Download the command line tools from the 'Command line tools only' section towards the bottom of https://developer.android.com/studio
+* Create a directory called 'cmdline-tools' under your top level directory
+  * giving `.../Android/cmdline-tools`
+* Extract the 'tools' directory from the command line tools zip file into this directory
+  * giving `.../Android/cmdline-tools/tools`
+  * Windows note: preferably extract using 7-zip. If using the built in Windows zip extract tool you will need to fix the directory structure by moving the jar files from `tools\lib\_` up to `tools\lib`
+    * See https://stackoverflow.com/questions/27364963/could-not-find-or-load-main-class-com-android-sdkmanager-main
+* You should now be able to run Android/cmdline-tools/bin/sdkmanager[.bat] successfully
+  * if you see an error about it being unable to save settings and the sdkmanager help text,
       your directory structure is incorrect.
-      - see the final steps in this answer to double check: https://stackoverflow.com/a/61176718
+  * see the final steps in this answer to double check: https://stackoverflow.com/a/61176718
 
-  - Run `.../Android/cmdline-tools/bin/sdkmanager --list` to see the packages available
+* Run `.../Android/cmdline-tools/bin/sdkmanager --list` to see the packages available
 
-  - Install the SDK Platform
-    - Generally installing the latest is fine. You pick an API level when compiling the code and the latest platform will support many recent API levels
-      - e.g. `sdkmanager --install "platforms;android-29"`
-    - This will install into the 'platforms' directory of our top level directory
-      - so the 'Android' directory in our example
-    - The SDK path to use as --android_sdk_path when building is this top level directory
+* Install the SDK Platform
+  * Generally installing the latest is fine. You pick an API level when compiling the code and the latest platform will support many recent API levels e.g.
 
-  - Install the NDK
-    - Find the available NDK versions by running `sdkmanager --list`
-    - Install
-      - you can install a specific version or the latest (called 'ndk-bundle')
-      - e.g. `sdkmanager --install "ndk;21.1.6352462"`
-        - NDK path in our example with this install would be `.../Android/ndk/21.1.6352462`
-      - NOTE: If you install the ndk-bundle package the path will be `.../Android/ndk-bundle` as there's no version number
+    ```
+    sdkmanager --install "platforms;android-29"
+    ```
 
-#### Android Build Instructions
+  * This will install into the 'platforms' directory of our top level directory, the `Android` directory in our example
+  * The SDK path to use as `--android_sdk_path` when building is this top level directory
 
-##### Cross compiling on Windows
+* Install the NDK
+  * Find the available NDK versions by running `sdkmanager --list`
+  * Install
+    * you can install a specific version or the latest (called 'ndk-bundle') e.g. `sdkmanager --install "ndk;21.1.6352462"`
+    * NDK path in our example with this install would be `.../Android/ndk/21.1.6352462`
+    * NOTE: If you install the ndk-bundle package the path will be `.../Android/ndk-bundle` as there's no version number
+
+##### Android Build Instructions
+
+###### Cross compiling on Windows
 
 The [Ninja](https://ninja-build.org/) generator needs to be used to build on Windows as the Visual Studio generator doesn't support Android.
 
-```
+```powershell
 ./build.bat --android --android_sdk_path <android sdk path> --android_ndk_path <android ndk path> --android_abi <android abi, e.g., arm64-v8a (default) or armeabi-v7a> --android_api <android api level, e.g., 27 (default)> --cmake_generator Ninja
 ```
 
 e.g. using the paths from our example
+
 ```
 ./build.bat --android --android_sdk_path .../Android --android_ndk_path .../Android/ndk/21.1.6352462 --android_abi arm64-v8a --android_api 27 --cmake_generator Ninja
 ```
 
-##### Cross compiling on Linux and macOS
+###### Cross compiling on Linux and macOS
 
-```
+```bash
 ./build.sh --android --android_sdk_path <android sdk path> --android_ndk_path <android ndk path> --android_abi <android abi, e.g., arm64-v8a (default) or armeabi-v7a> --android_api <android api level, e.g., 27 (default)>
 ```
 
-##### Build Android Archive (AAR)
+###### Build Android Archive (AAR)
 
 Android Archive (AAR) files, which can be imported directly in Android Studio, will be generated in your_build_dir/java/build/outputs/aar, by using the above building commands with `--build_java`
 
 To build on Windows with `--build_java` enabled you must also:
-  - set JAVA_HOME to the path to your JDK install
-    - this could be the JDK from Android Studio, or a [standalone JDK install](https://www.oracle.com/java/technologies/javase-downloads.html)
-    - e.g. Powershell: `$env:JAVA_HOME="C:\Program Files\Java\jdk-15"`
-           CMD: `set JAVA_HOME=C:\Program Files\Java\jdk-15`
-  - install [Gradle](https://gradle.org/install/) and add the directory to the PATH
-    - e.g. Powershell: `$env:PATH="$env:PATH;C:\Gradle\gradle-6.6.1\bin"`
-           CMD: `set PATH=%PATH%;C:\Gradle\gradle-6.6.1\bin`
-  - run the build from an admin window
-    - the Java build needs permissions to create a symlink, which requires an admin window
 
-#### Android NNAPI Execution Provider
+* set JAVA_HOME to the path to your JDK install
+  * this could be the JDK from Android Studio, or a [standalone JDK install](https://www.oracle.com/java/technologies/javase-downloads.html)
+  * e.g. Powershell: `$env:JAVA_HOME="C:\Program Files\Java\jdk-15"` CMD: `set JAVA_HOME=C:\Program Files\Java\jdk-15`
+* install [Gradle](https://gradle.org/install/) and add the directory to the PATH
+  * e.g. Powershell: `$env:PATH="$env:PATH;C:\Gradle\gradle-6.6.1\bin"` CMD: `set PATH=%PATH%;C:\Gradle\gradle-6.6.1\bin`
+* run the build from an admin window
+  * the Java build needs permissions to create a symlink, which requires an admin window
+
+##### Android NNAPI Execution Provider
 
 If you want to use NNAPI Execution Provider on Android, see [NNAPI Execution Provider](../reference/execution-providers/NNAPI-ExecutionProvider.md).
 
-##### Build Instructions
+###### Build Instructions
 
 Android NNAPI Execution Provider can be built using building commands in [Android Build instructions](#android-build-instructions) with `--use_nnapi`
 
 ---
 
-### iOS
+#### iOS
 
-#### Prerequisites
+##### Prerequisites
+
 * A Mac computer with latest macOS
 * Xcode, https://developer.apple.com/xcode/
 * CMake, https://cmake.org/download/
 * Python 3, https://www.python.org/downloads/mac-osx/
 
-#### General Info:
+##### General Info
+
 * iOS Platforms
 
-   The following two platforms are supported
-   * iOS device (iPhone, iPad) with arm64 architecture
-   * iOS simulator with x86_64 architecture
+  The following two platforms are supported
+  * iOS device (iPhone, iPad) with arm64 architecture
+  * iOS simulator with x86_64 architecture
 
-   armv7, armv7s and i386 architectures are not currently supported.
+  The following platforms are *not* supported
+  * armv7
+  * armv7s
+  * i386 architectures
+  * tvOS
+  * watchOS platforms are not currently supported.
 
-   tvOS and watchOS platforms are not currently supported.
 * apple_deploy_target
 
-   Specify the minimum version of the target platform (iOS) on which the target binaries are to be deployed.
+  Specify the minimum version of the target platform (iOS) on which the target binaries are to be deployed.
+
 * Code Signing
 
-   If the development team ID which has a valid code signing certificate is specified, Xcode will code sign the onnxruntime library in the building process, otherwise, the onnxruntime will be built without code signing. It may be required or desired to code sign the library for iOS devices. For more information, see [Code Signing](https://developer.apple.com/support/code-signing/).
+  If the development team ID which has a valid code signing certificate is specified, Xcode will code sign the onnxruntime library in the building process, otherwise, the onnxruntime will be built without code signing. It may be required or desired to code sign the library for iOS devices. For more information, see [Code Signing](https://developer.apple.com/support/code-signing/).
 
-#### Build Instructions
+##### Build Instructions
+
 Run one of the following build scripts from the ONNX Runtime repository root,
-##### Cross build for iOS simulator
-```
+###### Cross build for iOS simulator
+
+```bash
 ./build.sh --config <Release|Debug|RelWithDebInfo|MinSizeRel> --use_xcode \
            --ios --ios_sysroot iphonesimulator --osx_arch x86_64 --apple_deploy_target <minimal iOS version>
 ```
-##### Cross build for iOS device
-```
+
+###### Cross build for iOS device
+
+```bash
 ./build.sh --config <Release|Debug|RelWithDebInfo|MinSizeRel> --use_xcode \
            --ios --ios_sysroot iphoneos --osx_arch arm64 --apple_deploy_target <minimal iOS version>
 ```
-##### Cross build for iOS device and code sign the library
-```
+
+###### Cross build for iOS device and code sign the library
+
+```bash
 ./build.sh --config <Release|Debug|RelWithDebInfo|MinSizeRel> --use_xcode \
            --ios --ios_sysroot iphoneos --osx_arch arm64 --apple_deploy_target <minimal iOS version> \
            --xcode_code_signing_team_id <Your Apple developmemt team ID>
 ```
+
 ---
 
-### AMD MIGraphX
+#### AMD MIGraphX
 
 See more information on the MIGraphX Execution Provider [here](../reference/execution-providers/MIGraphX-ExecutionProvider.md).
 
-#### Prerequisites
+##### Prerequisites
+
 * Install [ROCM](https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html)
-   * The MIGraphX execution provider for ONNX Runtime is built and tested with ROCM3.3
+  * The MIGraphX execution provider for ONNX Runtime is built and tested with ROCM3.3
 * Install [MIGraphX](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX)
-   * The path to MIGraphX installation must be provided via the `--migraphx_home parameter`.
+  * The path to MIGraphX installation must be provided via the `--migraphx_home parameter`.
 
-#### Build Instructions
+##### Build Instructions
 
-##### Linux
+###### Linux
 
-```
+```bash
 ./build.sh --config <Release|Debug|RelWithDebInfo> --use_migraphx --migraphx_home <path to MIGraphX home>
 ```
 
 Dockerfile instructions are available [here](https://github.com/microsoft/onnxruntime/blob/master/dockerfiles#migraphx)
 
-***
+---
 
-# Training
-## Prerequisites
+## Training
+
+### CUDA
+#### Prerequisites
 
 The default NVIDIA GPU build requires CUDA runtime libraries installed on the system:
 
@@ -1154,7 +1245,7 @@ The default NVIDIA GPU build requires CUDA runtime libraries installed on the sy
 
 These dependency versions should reflect what is in [Dockerfile.training](https://github.com/microsoft/onnxruntime/blob/master/dockerfiles/Dockerfile.training).
 
-## Build instructions
+#### Build instructions
 
 1. Checkout this code repo with `git clone https://github.com/microsoft/onnxruntime`
 
@@ -1173,5 +1264,27 @@ These dependency versions should reflect what is in [Dockerfile.training](https:
 
    * Change to the ONNX Runtime repo base folder: `cd onnxruntime`
    * Run `./build.sh --enable_training --use_cuda --config=RelWithDebInfo --build_wheel`
+
+    This produces the .whl file in `./build/Linux/RelWithDebInfo/dist` for ONNX Runtime Training.
+
+### ROCM
+#### Prerequisites
+
+The default AMD GPU build requires ROCM software toolkit installed on the system:
+
+* [ROCM](https://rocmdocs.amd.com/en/latest/)
+* [OpenMPI](https://www.open-mpi.org/) 4.0.4
+  * See [install_openmpi.sh](./tools/ci_build/github/linux/docker/scripts/install_openmpi.sh)
+
+These dependency versions should reflect what is in [Dockerfile.training](./dockerfiles/Dockerfile.training).
+
+#### Build instructions
+
+1. Checkout this code repo with `git clone https://github.com/microsoft/onnxruntime`
+
+2. Create the ONNX Runtime wheel
+
+   * Change to the ONNX Runtime repo base folder: `cd onnxruntime`
+   * Run `./build.sh --config RelWithDebInfo --enable_training --build_wheel --use_rocm --rocm_home /opt/rocm --nccl_home /opt/rocm --mpi_home <location for openmpi>`
 
     This produces the .whl file in `./build/Linux/RelWithDebInfo/dist` for ONNX Runtime Training.

--- a/docs/how-to/custom-python-operator.md
+++ b/docs/how-to/custom-python-operator.md
@@ -1,11 +1,13 @@
 ---
 title: Use the PyOp operator
 parent: How to
-nav_order: 4
+nav_order: 6
 ---
 
 # How to use the Python Operator (PyOp)
 {: .no_toc }
+
+**Deprecation Note: This feature is deprecated and no longer supported**
 
 The Python Operator provides the capability to easily invoke any custom Python code within a single node of an ONNX graph using ONNX Runtime. This can be useful for quicker experimentation when a model requires operators that are not officially supported in ONNX and ONNX Runtime, particularly if there is already a Python implementation for the required functionality. This should be used with discretion in production scenarios, and all security or other risks should be considered beforehand.
 

--- a/docs/reference/execution-providers/TensorRT-ExecutionProvider.md
+++ b/docs/reference/execution-providers/TensorRT-ExecutionProvider.md
@@ -5,10 +5,10 @@ grand_parent: Reference
 nav_order: 1
 ---
 
-# TensortRT Execution Provider
+# TensorRT Execution Provider
 {: .no_toc }
 
-The TensorRT execution provider in the ONNX Runtime makes use of NVIDIA's [TensortRT](https://developer.nvidia.com/tensorrt) Deep Learning inferencing engine to accelerate ONNX model in their family of GPUs. Microsoft and NVIDIA worked closely to integrate the TensorRT execution provider with ONNX Runtime.
+The TensorRT execution provider in the ONNX Runtime makes use of NVIDIA's [TensorRT](https://developer.nvidia.com/tensorrt) Deep Learning inferencing engine to accelerate ONNX model in their family of GPUs. Microsoft and NVIDIA worked closely to integrate the TensorRT execution provider with ONNX Runtime.
 
 With the TensorRT execution provider, the ONNX Runtime delivers better inferencing performance on the same hardware compared to generic GPU acceleration. 
 


### PR DESCRIPTION
Third (and final, hopefully) sweep of the markdown files in master into the website.

In addition:
- Correct heading levels in build.md
- Re-order how-to docs slightly
- Only render heading levels 1-3 in article TOCs.
