### PR TITLE
Fix ImportError in build.py

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -18,7 +18,7 @@ from distutils.version import LooseVersion
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 REPO_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", ".."))
 
-sys.path.append(os.path.join(REPO_DIR, "tools", "python"))
+sys.path.insert(0, os.path.join(REPO_DIR, "tools", "python"))
 
 
 from util import run  # noqa: E402


### PR DESCRIPTION
There is a possible ImportError where build.py can import the wrong 'util' package if there are others present in `sys.path` already

**Description**: 
You can get past this issue by replacing
`sys.path.append(os.path.join(REPO_DIR, "tools", "python"))`
with
`sys.path.insert(0, os.path.join(REPO_DIR, "tools", "python"))`

This ensures that onnxruntime's util library will always be first in sys.path

**Motivation and Context**
Fix to issue here: #6230 

The `tools/ci_build/build.py` script can import the wrong `util` library because `sys.path.**append**` can put the `util` library path after python site-packages path.

On my system, I already have python's site-packages on my path, so after
`sys.path.append(os.path.join(REPO_DIR, "tools", "python"))`
my `sys.path` is
`['/usr/local/lib/python3.7/site-packages', '/home/mgoin/code/onnx-runtime/tools/python']`
