### PR TITLE
Removed Dead TODO from inference_session.cc

### DIFF
--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1513,8 +1513,6 @@ Status InferenceSession::Run(const RunOptions& run_options,
 
     ++current_num_runs_;
 
-    // TODO should we add this exec to the list of executors? i guess its not needed now?
-
     // scope of owned_run_logger is just the call to Execute.
     // If Execute ever becomes async we need a different approach
     std::unique_ptr<logging::Logger> owned_run_logger;


### PR DESCRIPTION
**Description**: 
I was exploring outstanding TODOs in ORT and found this one. It seems like the code it referenced no longer exists and it was first introduced when the initial bootstrap commit was created back in 2018.


