### PR TITLE
Remove python 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ For production scenarios, it's strongly recommended to build only from an [offic
 
 |API|Supported Versions|Samples|
 |---|---|---|
-[Python](https://aka.ms/onnxruntime-python)| 3.5, 3.6, 3.7, 3.8 (3.8 excludes Win GPU and Linux ARM)<br>[Python Dev Notes](./docs/Python_Dev_Notes.md)| [Samples](./samples#python)|
+[Python](https://aka.ms/onnxruntime-python)| 3.6, 3.7, 3.8, 3.9 (3.8/3.9 excludes Win GPU and Linux ARM)<br>[Python Dev Notes](./docs/Python_Dev_Notes.md)| [Samples](./samples#python)|
 |[C#](docs/CSharp_API.md)| | [Samples](./samples#C)|
 |[C++](./include/onnxruntime/core/session/onnxruntime_cxx_api.h)| |[Samples](./samples#CC)|
 |[C](docs/C_API.md)| | [Samples](./samples#CC)|

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -52,8 +52,6 @@ stages:
       pool: Linux-CPU
       strategy:
         matrix:
-          Python35:
-            PythonVersion: '3.5'
           Python36:
             PythonVersion: '3.6'
           Python37:
@@ -127,8 +125,6 @@ stages:
       pool: Linux-CPU
       strategy:
         matrix:
-          Python35:
-            PythonVersion: '3.5'
           Python36:
             PythonVersion: '3.6'
           Python37:
@@ -203,8 +199,6 @@ stages:
       pool: Linux-GPU-CUDA10
       strategy:
         matrix:
-          Python35:
-            PythonVersion: '3.5'
           Python36:
             PythonVersion: '3.6'
           Python37:
@@ -352,8 +346,6 @@ stages:
       pool: 'Win-CPU-2019'
       strategy:
         matrix:
-          Python35:
-            PythonVersion: '3.5'
           Python36:
             PythonVersion: '3.6'
           Python37:
@@ -482,8 +474,6 @@ stages:
       pool: 'Win-CPU-2019'
       strategy:
         matrix:
-          Python35:
-            PythonVersion: '3.5'
           Python36:
             PythonVersion: '3.6'
           Python37:
@@ -619,8 +609,6 @@ stages:
         GDN_CODESIGN_TARGETDIRECTORY: '$(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\dist'
       strategy:
         matrix:
-          Python35:
-            PythonVersion: '3.5'
           Python36:
             PythonVersion: '3.6'
           Python37:
@@ -736,8 +724,6 @@ stages:
         vmImage: 'macOS-10.14'
       strategy:
         matrix:
-          Python35:
-            PythonVersion: '3.5'
           Python36:
             PythonVersion: '3.6'
           Python37:
@@ -803,8 +789,6 @@ stages:
             PythonVersion: '3.7'
           Py36:
             PythonVersion: '3.6'
-          Py35:
-            PythonVersion: '3.5'
       steps:
       - checkout: self
         clean: true


### PR DESCRIPTION
**Description**: 

Remove python 3.5 from our python packaging pipeline.

**Motivation and Context**
- Why is this change required? What problem does it solve?

Please see the comments in #5981

- If it fixes an open issue, please link to the issue here.
