### PR TITLE
EP documentation updates

### DIFF
--- a/docs/reference/execution-providers/ACL-ExecutionProvider.md
+++ b/docs/reference/execution-providers/ACL-ExecutionProvider.md
@@ -2,7 +2,7 @@
 title: ARM Compute Library (ACL)
 parent: Execution Providers
 grand_parent: Reference
-nav_order: 7
+nav_order: 8
 ---
 
 # ACL Execution Provider

--- a/docs/reference/execution-providers/ArmNN-ExecutionProvider.md
+++ b/docs/reference/execution-providers/ArmNN-ExecutionProvider.md
@@ -2,7 +2,7 @@
 title: ARM NN
 parent: Execution Providers
 grand_parent: Reference
-nav_order: 8
+nav_order: 9
 ---
 
 ## ArmNN Execution Provider

--- a/docs/reference/execution-providers/CUDA-ExecutionProvider.md
+++ b/docs/reference/execution-providers/CUDA-ExecutionProvider.md
@@ -7,32 +7,74 @@ nav_order: 1
 
 # CUDA Execution Provider
 
-The CUDA Execution Provider enables hardware accelerated computation on CUDA-enabled GPUs.
+The CUDA Execution Provider enables hardware accelerated computation on Nvidia CUDA-enabled GPUs.
 
 ## Build
 For build instructions, please see the [BUILD page](../../how-to/build.md#CUDA).
 
 ## Configuration Options
-The CUDA EP supports the following configuration options:
+The CUDA Execution Provider supports the following configuration options.
 
 ### device_id
 The device ID.
 
 ### cuda_mem_limit
-The memory limit of the device memory arena in bytes.
+The size limit of the device memory arena in bytes. This size limit is only for the execution provider's arena. The total device memory usage may be higher.
 
 ### arena_extend_strategy
 The strategy for extending the device memory arena.
-Valid values:
-- kNextPowerOfTwo (0)
-- kSameAsRequested (1)
+
+Value                   | Description
+-|-
+kNextPowerOfTwo (0)     | subsequent extensions extend by larger amounts (multiplied by powers of two)
+kSameAsRequested (1)    | extend by the requested amount
 
 ### cudnn_conv_algo_search
 The type of search done for cuDNN convolution algorithms.
-Valid values:
-- EXHAUSTIVE (0)
-- HEURISTIC (1)
-- DEFAULT (2)
+
+Value           | Description
+-|-
+EXHAUSTIVE (0)  | expensive exhaustive benchmarking using cudnnFindConvolutionForwardAlgorithmEx
+HEURISTIC (1)   | lightweight heuristic based search using cudnnGetConvolutionForwardAlgorithm_v7
+DEFAULT (2)     | default algorithm using CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM
 
 ### do_copy_in_default_stream
-Whether to do copies in the default stream or use separate streams.
+Whether to do copies in the default stream or use separate streams. The recommended setting is true. If false, there are race conditions and possibly better performance.
+
+## Example Usage
+
+### Python
+
+```python
+import onnxruntime as ort
+
+model_path = 'model.onnx'
+
+providers = [
+    ('CUDAExecutionProvider', {
+        'device_id': 0,
+        'arena_extend_strategy': 'kNextPowerOfTwo',
+        'cuda_mem_limit': 2 * 1024 * 1024 * 1024,
+        'cudnn_conv_algo_search': 'EXHAUSTIVE',
+        'do_copy_in_default_stream': True,
+    }),
+    'CPUExecutionProvider',
+]
+
+session = ort.InferenceSession(model_path, providers=providers)
+```
+
+### C/C++
+
+```c++
+OrtSessionOptions* session_options = /* ... */;
+
+OrtCUDAProviderOptions options;
+options.device_id = 0;
+options.arena_extend_strategy = 0;
+options.cuda_mem_limit = 2 * 1024 * 1024 * 1024;
+options.cudnn_conv_algo_search = OrtCudnnConvAlgoSearch::EXHAUSTIVE;
+options.do_copy_in_default_stream = 1;
+
+SessionOptionsAppendExecutionProvider_CUDA(session_options, &options);
+```

--- a/docs/reference/execution-providers/CUDA-ExecutionProvider.md
+++ b/docs/reference/execution-providers/CUDA-ExecutionProvider.md
@@ -48,7 +48,7 @@ Whether to do copies in the default stream or use separate streams. The recommen
 ```python
 import onnxruntime as ort
 
-model_path = 'model.onnx'
+model_path = '<path to model>'
 
 providers = [
     ('CUDAExecutionProvider', {

--- a/docs/reference/execution-providers/CUDA-ExecutionProvider.md
+++ b/docs/reference/execution-providers/CUDA-ExecutionProvider.md
@@ -1,0 +1,38 @@
+---
+title: CUDA
+parent: Execution Providers
+grand_parent: Reference
+nav_order: 1
+---
+
+# CUDA Execution Provider
+
+The CUDA Execution Provider enables hardware accelerated computation on CUDA-enabled GPUs.
+
+## Build
+For build instructions, please see the [BUILD page](../../how-to/build.md#CUDA).
+
+## Configuration Options
+The CUDA EP supports the following configuration options:
+
+### device_id
+The device ID.
+
+### cuda_mem_limit
+The memory limit of the device memory arena in bytes.
+
+### arena_extend_strategy
+The strategy for extending the device memory arena.
+Valid values:
+- kNextPowerOfTwo (0)
+- kSameAsRequested (1)
+
+### cudnn_conv_algo_search
+The type of search done for cuDNN convolution algorithms.
+Valid values:
+- EXHAUSTIVE (0)
+- HEURISTIC (1)
+- DEFAULT (2)
+
+### do_copy_in_default_stream
+Whether to do copies in the default stream or use separate streams.

--- a/docs/reference/execution-providers/CUDA-ExecutionProvider.md
+++ b/docs/reference/execution-providers/CUDA-ExecutionProvider.md
@@ -18,8 +18,12 @@ The CUDA Execution Provider supports the following configuration options.
 ### device_id
 The device ID.
 
+Default value: 0
+
 ### cuda_mem_limit
 The size limit of the device memory arena in bytes. This size limit is only for the execution provider's arena. The total device memory usage may be higher.
+
+Default value: max value of C++ size_t type (effectively unlimited)
 
 ### arena_extend_strategy
 The strategy for extending the device memory arena.
@@ -28,6 +32,8 @@ Value                   | Description
 -|-
 kNextPowerOfTwo (0)     | subsequent extensions extend by larger amounts (multiplied by powers of two)
 kSameAsRequested (1)    | extend by the requested amount
+
+Default value: kNextPowerOfTwo
 
 ### cudnn_conv_algo_search
 The type of search done for cuDNN convolution algorithms.
@@ -38,8 +44,12 @@ EXHAUSTIVE (0)  | expensive exhaustive benchmarking using cudnnFindConvolutionFo
 HEURISTIC (1)   | lightweight heuristic based search using cudnnGetConvolutionForwardAlgorithm_v7
 DEFAULT (2)     | default algorithm using CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM
 
+Default value: EXHAUSTIVE
+
 ### do_copy_in_default_stream
 Whether to do copies in the default stream or use separate streams. The recommended setting is true. If false, there are race conditions and possibly better performance.
+
+Default value: true
 
 ## Example Usage
 

--- a/docs/reference/execution-providers/DNNL-ExecutionProvider.md
+++ b/docs/reference/execution-providers/DNNL-ExecutionProvider.md
@@ -2,7 +2,7 @@
 title: Intel DNNL
 parent: Execution Providers
 grand_parent: Reference
-nav_order: 4
+nav_order: 5
 ---
 
 # DNNL Execution Provider

--- a/docs/reference/execution-providers/DirectML-ExecutionProvider.md
+++ b/docs/reference/execution-providers/DirectML-ExecutionProvider.md
@@ -2,7 +2,7 @@
 title: Direct ML
 parent: Execution Providers
 grand_parent: Reference
-nav_order: 3
+nav_order: 4
 ---
 
 # DirectML Execution Provider

--- a/docs/reference/execution-providers/MIGraphX-ExecutionProvider.md
+++ b/docs/reference/execution-providers/MIGraphX-ExecutionProvider.md
@@ -2,7 +2,7 @@
 title: AMD MI GraphX
 parent: Execution Providers
 grand_parent: Reference
-nav_order: 6
+nav_order: 7
 ---
 
 # MIGraphX Execution Provider

--- a/docs/reference/execution-providers/NNAPI-ExecutionProvider.md
+++ b/docs/reference/execution-providers/NNAPI-ExecutionProvider.md
@@ -2,7 +2,7 @@
 title: NNAPI
 parent: Execution Providers
 grand_parent: Reference
-nav_order: 5
+nav_order: 6
 ---
 
 

--- a/docs/reference/execution-providers/Nuphar-ExecutionProvider.md
+++ b/docs/reference/execution-providers/Nuphar-ExecutionProvider.md
@@ -33,7 +33,13 @@ Ort::Session session(env, model_path, sf);
 
 ### Python
 
-You can use the Nuphar execution provider via the python wheel from the ONNX Runtime build. The Nuphar execution provider will be automatically prioritized over the default CPU execution providers, thus no need to separately register the execution provider. Python APIs details are [here](/python/api_summary).
+```python
+import onnxruntime as ort
+
+model_path = '<path to model>'
+providers = ['NupharExecutionProvider', 'CPUExecutionProvider']
+session = ort.InferenceSession(model_path, providers=providers)
+```
 
 ## Performance and Accuracy Testing
 
@@ -161,12 +167,12 @@ SessionOptions.MakeSessionOptionWithNupharProvider("nuphar_cache_path:/path/to/c
 
 * Using in Python
 
-Settings string should be passed in before InferenceSession is created, as providers are not currently exposed yet. Here's an example in Python to set cache path and model checksum:
+Settings string can be set as an execution provider-specific option. Here's an example in Python to set cache path and model checksum:
 
 ```python
 nuphar_settings = 'nuphar_cache_path:{}, nuphar_cache_model_checksum:{}'.format(cache_dir, model_checksum)
-onnxruntime.capi._pybind_state.set_nuphar_settings(nuphar_settings)
-sess = onnxruntime.InferenceSession(model_path)
+providers = [('NupharExecutionProvider', {'nuphar_settings': nuphar_settings}), 'CPUExecutionProvider']
+sess = onnxruntime.InferenceSession(model_path, providers=providers)
 ```
 
 ## Known issues

--- a/docs/reference/execution-providers/Nuphar-ExecutionProvider.md
+++ b/docs/reference/execution-providers/Nuphar-ExecutionProvider.md
@@ -2,7 +2,7 @@
 title: Nuphar
 parent: Execution Providers
 grand_parent: Reference
-nav_order: 9
+nav_order: 10
 ---
 
 # Nuphar Execution Provider (preview)

--- a/docs/reference/execution-providers/OpenVINO-ExecutionProvider.md
+++ b/docs/reference/execution-providers/OpenVINO-ExecutionProvider.md
@@ -2,7 +2,7 @@
 title: OpenVINO
 parent: Execution Providers
 grand_parent: Reference
-nav_order: 2
+nav_order: 3
 ---
 
 # OpenVINO Execution Provider

--- a/docs/reference/execution-providers/RKNPU-ExecutionProvider.md
+++ b/docs/reference/execution-providers/RKNPU-ExecutionProvider.md
@@ -2,7 +2,7 @@
 title: RKNPU
 parent: Execution Providers
 grand_parent: Reference
-nav_order: 10
+nav_order: 11
 ---
 
 # RKNPU Execution Provider (preview)

--- a/docs/reference/execution-providers/TensorRT-ExecutionProvider.md
+++ b/docs/reference/execution-providers/TensorRT-ExecutionProvider.md
@@ -2,7 +2,7 @@
 title: TensorRT
 parent: Execution Providers
 grand_parent: Reference
-nav_order: 1
+nav_order: 2
 ---
 
 # TensorRT Execution Provider

--- a/docs/reference/execution-providers/Vitis-AI-ExecutionProvider.md
+++ b/docs/reference/execution-providers/Vitis-AI-ExecutionProvider.md
@@ -2,7 +2,7 @@
 title: Vitis AI
 parent: Execution Providers
 grand_parent: Reference
-nav_order: 11
+nav_order: 12
 ---
 
 # Vitis-AI Execution Provider


### PR DESCRIPTION
**Description**
Add some initial documentation for the CUDA EP with some details about configuration options.
Update Nuphar EP documentation usage of deprecated set_nuphar_settings() function.

**Motivation and Context**
Needed somewhere to document CUDA EP provider-specific options.
Deprecation of Python global configuration functions.
