### PR TITLE
Fix Linux/Mac error message on input type mismatch

### DIFF
--- a/onnxruntime/core/framework/data_types.cc
+++ b/onnxruntime/core/framework/data_types.cc
@@ -723,6 +723,8 @@ const char* DataTypeImpl::ToString(MLDataType type) {
 #ifdef ORT_NO_RTTI
   return "(unknown type)";
 #else
+  // TODO: name() method of `type_info` class is implementation dependent
+  // and may return a mangled non-human readable string which may have to be unmangled
   return typeid(*type).name();
 #endif
 }

--- a/onnxruntime/core/framework/data_types.cc
+++ b/onnxruntime/core/framework/data_types.cc
@@ -685,33 +685,33 @@ const char* DataTypeImpl::ToString(MLDataType type) {
   if (prim_type != nullptr) {
     switch (prim_type->GetDataType()) {
       case TensorProto_DataType_FLOAT:
-        return "tensor(float)";
+        return "float";
       case TensorProto_DataType_BOOL:
-        return "tensor(bool)";
+        return "bool";
       case TensorProto_DataType_DOUBLE:
-        return "tensor(double)";
+        return "double";
       case TensorProto_DataType_STRING:
-        return "tensor(string)";
+        return "string";
       case TensorProto_DataType_INT8:
-        return "tensor(int8)";
+        return "int8";
       case TensorProto_DataType_UINT8:
-        return "tensor(uint8)";
+        return "uint8";
       case TensorProto_DataType_INT16:
-        return "tensor(int16)";
+        return "int16";
       case TensorProto_DataType_UINT16:
-        return "tensor(uint16)";
+        return "uint16";
       case TensorProto_DataType_INT32:
-        return "tensor(int32)";
+        return "int32";
       case TensorProto_DataType_UINT32:
-        return "tensor(uint32)";
+        return "uint32";
       case TensorProto_DataType_INT64:
-        return "tensor(int64)";
+        return "int64";
       case TensorProto_DataType_UINT64:
-        return "tensor(uint64)";
+        return "uint64";
       case TensorProto_DataType_FLOAT16:
-        return "tensor(float16)";
+        return "float16";
       case TensorProto_DataType_BFLOAT16:
-        return "tensor(bfloat16)";
+        return "bfloat16";
       default:
         break;
     }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1359,14 +1359,13 @@ static common::Status CheckTypes(MLDataType actual, MLDataType expected) {
   if (actual == expected) {
     return Status::OK();
   }
-#ifdef ORT_NO_RTTI
-  return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, "Unexpected input data type");
-#else
+
+  //auto actual_name = std::string(DataTypeImpl::ToString(actual));
+  //auto expected_name = std::string(DataTypeImpl::ToString(expected));
   auto actual_name = std::string(typeid(*actual).name());
   auto expected_name = std::string(typeid(*expected).name());
   return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
                 "Unexpected input data type. Actual: (" + actual_name + ") , expected: (" + expected_name + ")");
-#endif
 }
 
 common::Status InferenceSession::ValidateInputs(const std::vector<std::string>& feed_names,

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1355,16 +1355,20 @@ common::Status InferenceSession::CheckShapes(const std::string& input_name, cons
   return Status::OK();
 }
 
-static common::Status CheckTypes(MLDataType actual, MLDataType expected) {
+static common::Status CheckTypes(MLDataType actual, MLDataType expected, const std::string& base_type) {
   if (actual == expected) {
     return Status::OK();
   }
   std::ostringstream ostr;
   ostr << "Unexpected input data type. Actual: (";
+  ostr << base_type;
+  ostr << "(";
   ostr << DataTypeImpl::ToString(actual);
-  ostr << ") , expected: (";
+  ostr << ")) , expected: (";
+  ostr << base_type;
+  ostr << "(";
   ostr << DataTypeImpl::ToString(expected);
-  ostr << ")";
+  ostr << "))";
 
   return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, ostr.str());
 }
@@ -1394,7 +1398,7 @@ common::Status InferenceSession::ValidateInputs(const std::vector<std::string>& 
       }
       auto expected_element_type = expected_type->AsTensorType()->GetElementType();
       auto input_element_type = input_ml_value.Get<Tensor>().DataType();
-      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_element_type, expected_element_type));
+      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_element_type, expected_element_type, "Tensor"));
 
       // check for shape
       const auto& expected_shape = iter->second.tensor_shape;
@@ -1410,7 +1414,7 @@ common::Status InferenceSession::ValidateInputs(const std::vector<std::string>& 
       auto expected_element_type = expected_type->AsSparseTensorType()->GetElementType();
       const SparseTensor& sparse_tensor = input_ml_value.Get<SparseTensor>();
       auto input_element_type = sparse_tensor.Values().DataType();
-      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_element_type, expected_element_type));
+      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_element_type, expected_element_type, "SparseTensor"));
       // Check shape
       const auto& expected_shape = iter->second.tensor_shape;
       if (expected_shape.NumDimensions() > 0) {
@@ -1424,10 +1428,10 @@ common::Status InferenceSession::ValidateInputs(const std::vector<std::string>& 
       }
       auto expected_element_type = expected_type->AsSequenceTensorBase()->GetElementType();
       auto input_element_type = input_ml_value.Get<TensorSeq>().DataType();
-      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_element_type, expected_element_type));
+      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_element_type, expected_element_type, "TensorSequence"));
     } else {
       auto input_type = input_ml_value.Type();
-      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_type, expected_type));
+      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_type, expected_type, ""));
     }
   }
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1359,16 +1359,14 @@ static common::Status CheckTypes(MLDataType actual, MLDataType expected) {
   if (actual == expected) {
     return Status::OK();
   }
-#ifdef ORT_NO_RTTI
-  return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, "Unexpected input data type");
-#else
-  //auto actual_name = std::string(DataTypeImpl::ToString(actual));
-  //auto expected_name = std::string(DataTypeImpl::ToString(expected));
-  auto actual_name = std::string(typeid(*actual).name());
-  auto expected_name = std::string(typeid(*expected).name());
-  return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
-                "Unexpected input data type. Actual: (" + actual_name + ") , expected: (" + expected_name + ")");
-#endif
+  std::ostringstream ostr;
+  ostr << "Unexpected input data type. Actual: (";
+  ostr << DataTypeImpl::ToString(actual);
+  ostr << ") , expected: (";
+  ostr << DataTypeImpl::ToString(expected);
+  ostr << ")";
+
+  return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, ostr.str());
 }
 
 common::Status InferenceSession::ValidateInputs(const std::vector<std::string>& feed_names,

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1398,7 +1398,7 @@ common::Status InferenceSession::ValidateInputs(const std::vector<std::string>& 
       }
       auto expected_element_type = expected_type->AsTensorType()->GetElementType();
       auto input_element_type = input_ml_value.Get<Tensor>().DataType();
-      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_element_type, expected_element_type, "Tensor"));
+      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_element_type, expected_element_type, "tensor"));
 
       // check for shape
       const auto& expected_shape = iter->second.tensor_shape;
@@ -1414,7 +1414,7 @@ common::Status InferenceSession::ValidateInputs(const std::vector<std::string>& 
       auto expected_element_type = expected_type->AsSparseTensorType()->GetElementType();
       const SparseTensor& sparse_tensor = input_ml_value.Get<SparseTensor>();
       auto input_element_type = sparse_tensor.Values().DataType();
-      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_element_type, expected_element_type, "SparseTensor"));
+      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_element_type, expected_element_type, "sparse_tensor"));
       // Check shape
       const auto& expected_shape = iter->second.tensor_shape;
       if (expected_shape.NumDimensions() > 0) {
@@ -1428,7 +1428,7 @@ common::Status InferenceSession::ValidateInputs(const std::vector<std::string>& 
       }
       auto expected_element_type = expected_type->AsSequenceTensorBase()->GetElementType();
       auto input_element_type = input_ml_value.Get<TensorSeq>().DataType();
-      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_element_type, expected_element_type, "TensorSequence"));
+      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_element_type, expected_element_type, "seq"));
     } else {
       auto input_type = input_ml_value.Type();
       ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_type, expected_type, ""));

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1359,13 +1359,16 @@ static common::Status CheckTypes(MLDataType actual, MLDataType expected) {
   if (actual == expected) {
     return Status::OK();
   }
-
+#ifdef ORT_NO_RTTI
+  return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, "Unexpected input data type");
+#else
   //auto actual_name = std::string(DataTypeImpl::ToString(actual));
   //auto expected_name = std::string(DataTypeImpl::ToString(expected));
   auto actual_name = std::string(typeid(*actual).name());
   auto expected_name = std::string(typeid(*expected).name());
   return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
                 "Unexpected input data type. Actual: (" + actual_name + ") , expected: (" + expected_name + ")");
+#endif
 }
 
 common::Status InferenceSession::ValidateInputs(const std::vector<std::string>& feed_names,

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1253,7 +1253,14 @@ void addObjectMethods(py::module& m, Environment& env) {
         // TODO: Assumes that the OrtValue is a Tensor, make this generic to handle non-Tensors
         ORT_ENFORCE(ml_value->IsTensor(), "Only OrtValues that are Tensors are currently supported");
 
-        return DataTypeImpl::ToString(ml_value->Get<Tensor>().DataType());
+        // Currently only "tensor" OrtValues are supported
+        std::ostringstream ostr;
+        ostr << "tensor";
+        ostr << "(";
+        ostr << DataTypeImpl::ToString(ml_value->Get<Tensor>().DataType());
+        ostr << ")";
+
+        return ostr.str();
       })
       .def("is_tensor", [](OrtValue* ml_value) -> bool {
         return ml_value->IsTensor();

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -148,6 +148,7 @@ void TestInference(Ort::Env& env, T model_uri,
 }
 
 static constexpr PATH_TYPE MODEL_URI = TSTR("testdata/mul_1.onnx");
+static constexpr PATH_TYPE SEQUENCE_MODEL_URI = TSTR("testdata/sequence_length.onnx");
 static constexpr PATH_TYPE CUSTOM_OP_MODEL_URI = TSTR("testdata/foo_1.onnx");
 static constexpr PATH_TYPE CUSTOM_OP_LIBRARY_TEST_MODEL_URI = TSTR("testdata/custom_op_library/custom_op_test.onnx");
 static constexpr PATH_TYPE OVERRIDABLE_INITIALIZER_MODEL_URI = TSTR("testdata/overridable_initializer.onnx");
@@ -1298,7 +1299,7 @@ TEST(CApiTest, TestSharingOfInitializer) {
 }
 
 #ifndef ORT_NO_RTTI
-TEST(CApiTest, TestIncorrectInputTypeToModel) {
+TEST(CApiTest, TestIncorrectInputTypeToModel_Tensors) {
   // simple inference test
   // prepare inputs (incorrect type)
   Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
@@ -1316,14 +1317,45 @@ TEST(CApiTest, TestIncorrectInputTypeToModel) {
   bool exception_thrown = false;
   try {
     auto outputs = session.Run(Ort::RunOptions{nullptr}, input_names.data(), &val, 1, output_names, 1);
-  } catch (Ort::Exception ex) {
+  } catch (const Ort::Exception& ex) {
     exception_thrown = true;
     const char* exception_string = ex.what();
     ASSERT_TRUE(strcmp(exception_string,
-                       "Unexpected input data type. Actual: (tensor(double)) , expected: (tensor(float))") == 0);
+                       "Unexpected input data type. Actual: (Tensor(double)) , expected: (Tensor(float))") == 0);
   }
 
   ASSERT_TRUE(exception_thrown);
 }
+TEST(CApiTest, TestIncorrectInputTypeToModel_SequenceTensors) {
+  // simple inference test
+  // prepare inputs (incorrect type)
+  Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
 
+  double data[] = {2., 1., 4., 3., 6., 5.};
+  const int data_len = sizeof(data) / sizeof(data[0]);
+  const int64_t shape[] = {2, 3};
+  const size_t shape_len = sizeof(shape) / sizeof(shape[0]);
+  Ort::Value val = Ort::Value::CreateTensor<double>(mem_info, data, data_len, shape, shape_len);
+
+  std::vector<Ort::Value> seq;
+  seq.push_back(std::move(val));
+
+  Ort::Value seq_value = Ort::Value::CreateSequence(seq);
+
+  std::vector<const char*> input_names{"X"};
+  const char* output_names[] = {"Y"};
+  Ort::SessionOptions session_options;
+  Ort::Session session(*ort_env, SEQUENCE_MODEL_URI, session_options);
+  bool exception_thrown = false;
+  try {
+    auto outputs = session.Run(Ort::RunOptions{nullptr}, input_names.data(), &seq_value, 1, output_names, 1);
+  } catch (const Ort::Exception& ex) {
+    exception_thrown = true;
+    const char* exception_string = ex.what();
+    ASSERT_TRUE(strcmp(exception_string,
+                       "Unexpected input data type. Actual: (TensorSequence(double)) , expected: (TensorSequence(float))") == 0);
+  }
+
+  ASSERT_TRUE(exception_thrown);
+}
 #endif

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -148,7 +148,6 @@ void TestInference(Ort::Env& env, T model_uri,
 }
 
 static constexpr PATH_TYPE MODEL_URI = TSTR("testdata/mul_1.onnx");
-static constexpr PATH_TYPE SEQUENCE_MODEL_URI = TSTR("testdata/sequence_length.onnx");
 static constexpr PATH_TYPE CUSTOM_OP_MODEL_URI = TSTR("testdata/foo_1.onnx");
 static constexpr PATH_TYPE CUSTOM_OP_LIBRARY_TEST_MODEL_URI = TSTR("testdata/custom_op_library/custom_op_test.onnx");
 static constexpr PATH_TYPE OVERRIDABLE_INITIALIZER_MODEL_URI = TSTR("testdata/overridable_initializer.onnx");

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -148,6 +148,7 @@ void TestInference(Ort::Env& env, T model_uri,
 }
 
 static constexpr PATH_TYPE MODEL_URI = TSTR("testdata/mul_1.onnx");
+static constexpr PATH_TYPE SEQUENCE_MODEL_URI = TSTR("testdata/sequence_length.onnx");
 static constexpr PATH_TYPE CUSTOM_OP_MODEL_URI = TSTR("testdata/foo_1.onnx");
 static constexpr PATH_TYPE CUSTOM_OP_LIBRARY_TEST_MODEL_URI = TSTR("testdata/custom_op_library/custom_op_test.onnx");
 static constexpr PATH_TYPE OVERRIDABLE_INITIALIZER_MODEL_URI = TSTR("testdata/overridable_initializer.onnx");
@@ -1320,10 +1321,10 @@ TEST(CApiTest, TestIncorrectInputTypeToModel) {
     exception_thrown = true;
     const char* exception_string = ex.what();
     ASSERT_TRUE(strcmp(exception_string,
-                       "Unexpected input data type. Actual: (class onnxruntime::PrimitiveDataType<double>) , "
-                       "expected: (class onnxruntime::PrimitiveDataType<float>)") == 0);
+                       "Unexpected input data type. Actual: (tensor(double)) , expected: (tensor(float))") == 0);
   }
 
   ASSERT_TRUE(exception_thrown);
 }
+
 #endif

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1321,7 +1321,7 @@ TEST(CApiTest, TestIncorrectInputTypeToModel_Tensors) {
     exception_thrown = true;
     const char* exception_string = ex.what();
     ASSERT_TRUE(strcmp(exception_string,
-                       "Unexpected input data type. Actual: (Tensor(double)) , expected: (Tensor(float))") == 0);
+                       "Unexpected input data type. Actual: (tensor(double)) , expected: (tensor(float))") == 0);
   }
 
   ASSERT_TRUE(exception_thrown);
@@ -1353,7 +1353,7 @@ TEST(CApiTest, TestIncorrectInputTypeToModel_SequenceTensors) {
     exception_thrown = true;
     const char* exception_string = ex.what();
     ASSERT_TRUE(strcmp(exception_string,
-                       "Unexpected input data type. Actual: (TensorSequence(double)) , expected: (TensorSequence(float))") == 0);
+                       "Unexpected input data type. Actual: (seq(double)) , expected: (seq(float))") == 0);
   }
 
   ASSERT_TRUE(exception_thrown);


### PR DESCRIPTION
**Description**: The name() method of `type_info` class is implementation dependent and may return a mangled non-human readable string which may have to be unmangled (see https://github.com/microsoft/onnxruntime/issues/4787 to see how gcc's stdlib implementation returns name of type_info). Currently this mangled string bubbles all the way up to the users on type mis-match. AFAIK - only MSVC's implementation seems human readable. This change tries to remedy this unfriendly error message on some platforms.

**Motivation and Context**
Takeaway from https://github.com/microsoft/onnxruntime/issues/4787
https://github.com/microsoft/onnxruntime/issues/3890
https://stackoverflow.com/questions/62720299/error-while-inferencing-a-lstm-model-with-the-help-of-onnx-runtime-invalid-arg
