### PR TITLE
Rename MakeString and ParseString functions.

### DIFF
--- a/include/onnxruntime/core/common/common.h
+++ b/include/onnxruntime/core/common/common.h
@@ -118,42 +118,42 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 // Throw an exception with optional message.
 // NOTE: The arguments get streamed into a string via ostringstream::operator<<
 // DO NOT use a printf format string, as that will not work as you expect.
-#define ORT_THROW(...)                                                                           \
-  do {                                                                                           \
-    std::cerr << ::onnxruntime::OnnxRuntimeException(ORT_WHERE_WITH_STACK,                       \
-                                                     ::onnxruntime::MakeStringLite(__VA_ARGS__)) \
-                     .what()                                                                     \
-              << std::endl;                                                                      \
-    abort();                                                                                     \
+#define ORT_THROW(...)                                                                       \
+  do {                                                                                       \
+    std::cerr << ::onnxruntime::OnnxRuntimeException(ORT_WHERE_WITH_STACK,                   \
+                                                     ::onnxruntime::MakeString(__VA_ARGS__)) \
+                     .what()                                                                 \
+              << std::endl;                                                                  \
+    abort();                                                                                 \
   } while (false)
 
 // Just in order to mark things as not implemented. Do not use in final code.
-#define ORT_NOT_IMPLEMENTED(...)                                                                    \
-  do {                                                                                              \
-    std::cerr << ::onnxruntime::NotImplementedException(::onnxruntime::MakeStringLite(__VA_ARGS__)) \
-                     .what()                                                                        \
-              << std::endl;                                                                         \
-    abort();                                                                                        \
+#define ORT_NOT_IMPLEMENTED(...)                                                                \
+  do {                                                                                          \
+    std::cerr << ::onnxruntime::NotImplementedException(::onnxruntime::MakeString(__VA_ARGS__)) \
+                     .what()                                                                    \
+              << std::endl;                                                                     \
+    abort();                                                                                    \
   } while (false)
 
 // Check condition.
 // NOTE: The arguments get streamed into a string via ostringstream::operator<<
 // DO NOT use a printf format string, as that will not work as you expect.
-#define ORT_ENFORCE(condition, ...)                                                                \
-  do {                                                                                             \
-    if (!(condition)) {                                                                            \
-      std::cerr << ::onnxruntime::OnnxRuntimeException(ORT_WHERE_WITH_STACK, #condition,           \
-                                                       ::onnxruntime::MakeStringLite(__VA_ARGS__)) \
-                       .what()                                                                     \
-                << std::endl;                                                                      \
-      abort();                                                                                     \
-    }                                                                                              \
+#define ORT_ENFORCE(condition, ...)                                                            \
+  do {                                                                                         \
+    if (!(condition)) {                                                                        \
+      std::cerr << ::onnxruntime::OnnxRuntimeException(ORT_WHERE_WITH_STACK, #condition,       \
+                                                       ::onnxruntime::MakeString(__VA_ARGS__)) \
+                       .what()                                                                 \
+                << std::endl;                                                                  \
+      abort();                                                                                 \
+    }                                                                                          \
   } while (false)
 
-#define ORT_THROW_EX(ex, ...)                                                                  \
-  do {                                                                                         \
-    std::cerr << #ex << "(" << ::onnxruntime::MakeStringLite(__VA_ARGS__) << ")" << std::endl; \
-    abort();                                                                                   \
+#define ORT_THROW_EX(ex, ...)                                                              \
+  do {                                                                                     \
+    std::cerr << #ex << "(" << ::onnxruntime::MakeString(__VA_ARGS__) << ")" << std::endl; \
+    abort();                                                                               \
   } while (false)
 
 #else
@@ -168,11 +168,11 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 // NOTE: The arguments get streamed into a string via ostringstream::operator<<
 // DO NOT use a printf format string, as that will not work as you expect.
 #define ORT_THROW(...) \
-  throw ::onnxruntime::OnnxRuntimeException(ORT_WHERE_WITH_STACK, ::onnxruntime::MakeStringLite(__VA_ARGS__))
+  throw ::onnxruntime::OnnxRuntimeException(ORT_WHERE_WITH_STACK, ::onnxruntime::MakeString(__VA_ARGS__))
 
 // Just in order to mark things as not implemented. Do not use in final code.
 #define ORT_NOT_IMPLEMENTED(...) \
-  throw ::onnxruntime::NotImplementedException(::onnxruntime::MakeStringLite(__VA_ARGS__))
+  throw ::onnxruntime::NotImplementedException(::onnxruntime::MakeString(__VA_ARGS__))
 
 // Check condition.
 // NOTE: The arguments get streamed into a string via ostringstream::operator<<
@@ -180,7 +180,7 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 #define ORT_ENFORCE(condition, ...)                                           \
   if (!(condition))                                                           \
   throw ::onnxruntime::OnnxRuntimeException(ORT_WHERE_WITH_STACK, #condition, \
-                                            ::onnxruntime::MakeStringLite(__VA_ARGS__))
+                                            ::onnxruntime::MakeString(__VA_ARGS__))
 
 #define ORT_THROW_EX(ex, ...) \
   throw ex(__VA_ARGS__)
@@ -190,21 +190,21 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 #define ORT_MAKE_STATUS(category, code, ...)                     \
   ::onnxruntime::common::Status(::onnxruntime::common::category, \
                                 ::onnxruntime::common::code,     \
-                                ::onnxruntime::MakeStringLite(__VA_ARGS__))
+                                ::onnxruntime::MakeString(__VA_ARGS__))
 
 // Check condition. if met, return status.
-#define ORT_RETURN_IF(condition, ...)                                                         \
-  if (condition) {                                                                            \
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,                                                 \
-                           "Satisfied, but should not be: " #condition "\n",                  \
-                           ORT_WHERE.ToString(), ::onnxruntime::MakeStringLite(__VA_ARGS__)); \
+#define ORT_RETURN_IF(condition, ...)                                                     \
+  if (condition) {                                                                        \
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,                                             \
+                           "Satisfied, but should not be: " #condition "\n",              \
+                           ORT_WHERE.ToString(), ::onnxruntime::MakeString(__VA_ARGS__)); \
   }
 
 // Check condition. if not met, return status.
 #define ORT_RETURN_IF_NOT(condition, ...)                                                     \
   if (!(condition)) {                                                                         \
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Not satisfied: " #condition "\n",              \
-                           ORT_WHERE.ToString(), ::onnxruntime::MakeStringLite(__VA_ARGS__)); \
+                           ORT_WHERE.ToString(), ::onnxruntime::MakeString(__VA_ARGS__)); \
   }
 
 // Macros to disable the copy and/or move ctor and assignment methods

--- a/include/onnxruntime/core/common/make_string.h
+++ b/include/onnxruntime/core/common/make_string.h
@@ -40,25 +40,23 @@ inline void MakeStringImpl(std::ostringstream& ss, const T& t, const Args&... ar
 
 /**
  * Makes a string by concatenating string representations of the arguments.
+ * This version uses the current locale.
  */
 template <typename... Args>
 std::string MakeString(const Args&... args) {
   std::ostringstream ss;
-  ss.imbue(std::locale::classic());
   detail::MakeStringImpl(ss, args...);
   return ss.str();
 }
 
 /**
  * Makes a string by concatenating string representations of the arguments.
- * This version uses the current locale.
+ * This version uses std::locale::classic().
  */
 template <typename... Args>
-std::string MakeStringLite(const Args&... args) {
+std::string MakeStringWithClassicLocale(const Args&... args) {
   std::ostringstream ss;
-  // the following line causes a binary size increase
-  //ss.imbue(std::locale::classic());
-  // just use the current locale for this lite version
+  ss.imbue(std::locale::classic());
   detail::MakeStringImpl(ss, args...);
   return ss.str();
 }
@@ -70,6 +68,14 @@ inline std::string MakeString(const std::string& str) {
 }
 
 inline std::string MakeString(const char* cstr) {
+  return cstr;
+}
+
+inline std::string MakeStringWithClassicLocale(const std::string& str) {
+  return str;
+}
+
+inline std::string MakeStringWithClassicLocale(const char* cstr) {
   return cstr;
 }
 

--- a/include/onnxruntime/core/common/parse_string.h
+++ b/include/onnxruntime/core/common/parse_string.h
@@ -15,7 +15,7 @@ namespace onnxruntime {
  * Tries to parse a value from an entire string.
  */
 template <typename T>
-bool TryParseString(const std::string& str, T& value) {
+bool TryParseStringWithClassicLocale(const std::string& str, T& value) {
   if (std::is_integral<T>::value && std::is_unsigned<T>::value) {
     // if T is unsigned integral type, reject negative values which will wrap
     if (!str.empty() && str[0] == '-') {
@@ -43,12 +43,12 @@ bool TryParseString(const std::string& str, T& value) {
   return true;
 }
 
-inline bool TryParseString(const std::string& str, std::string& value) {
+inline bool TryParseStringWithClassicLocale(const std::string& str, std::string& value) {
   value = str;
   return true;
 }
 
-inline bool TryParseString(const std::string& str, bool& value) {
+inline bool TryParseStringWithClassicLocale(const std::string& str, bool& value) {
   if (str == "0" || str == "False" || str == "false") {
     value = false;
     return true;
@@ -66,8 +66,8 @@ inline bool TryParseString(const std::string& str, bool& value) {
  * Parses a value from an entire string.
  */
 template <typename T>
-Status ParseString(const std::string& s, T& value) {
-  ORT_RETURN_IF_NOT(TryParseString(s, value), "Failed to parse value: \"", value, "\"");
+Status ParseStringWithClassicLocale(const std::string& s, T& value) {
+  ORT_RETURN_IF_NOT(TryParseStringWithClassicLocale(s, value), "Failed to parse value: \"", value, "\"");
   return Status::OK();
 }
 
@@ -75,9 +75,9 @@ Status ParseString(const std::string& s, T& value) {
  * Parses a value from an entire string.
  */
 template <typename T>
-T ParseString(const std::string& s) {
+T ParseStringWithClassicLocale(const std::string& s) {
   T value{};
-  ORT_THROW_IF_ERROR(ParseString(s, value));
+  ORT_THROW_IF_ERROR(ParseStringWithClassicLocale(s, value));
   return value;
 }
 

--- a/include/onnxruntime/core/framework/provider_options_utils.h
+++ b/include/onnxruntime/core/framework/provider_options_utils.h
@@ -107,7 +107,7 @@ class ProviderOptionsParser {
     return AddValueParser(
         name,
         [&dest](const std::string& value_str) -> Status {
-          return ParseString(value_str, dest);
+          return ParseStringWithClassicLocale(value_str, dest);
         });
   }
 

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -421,7 +421,7 @@ Status ExecutionFrame::AllocateMLValueTensorPreAllocateBuffer(OrtValue& ort_valu
   if (buffer_num_elements != required_num_elements) {
     // could be an allocation planner bug (less likely) or the model incorrectly uses something like 'None'
     // as a dim_param, or -1 in dim_value in multiple places making the planner think those shapes are equal.
-    auto message = onnxruntime::MakeStringLite(
+    auto message = onnxruntime::MakeString(
         "Shape mismatch attempting to re-use buffer. ",
         reuse_tensor->Shape(), " != ", shape,
         ". Validate usage of dim_value (values should be > 0) and "

--- a/onnxruntime/core/framework/memcpy.cc
+++ b/onnxruntime/core/framework/memcpy.cc
@@ -16,11 +16,11 @@ Status Memcpy::Compute(OpKernelContext* ctx) const {
   Status retval = Info().GetDataTransferManager().CopyTensor(*X, *Y, Info().GetKernelDef().ExecQueueId());
 
   if (!retval.IsOK()) {
-    LOGS(ctx->Logger(), ERROR) << MakeStringLite(retval.ErrorMessage(),
-                                                 " Copying ", Node().InputDefs()[0]->Name(),
-                                                 " to ", Node().OutputDefs()[0]->Name(),
-                                                 " Input shape:", X->Shape(), " Output shape:", Y->Shape(),
-                                                 " X data:", X->DataRaw(), " Y data:", Y->DataRaw());
+    LOGS(ctx->Logger(), ERROR) << MakeString(retval.ErrorMessage(),
+                                             " Copying ", Node().InputDefs()[0]->Name(),
+                                             " to ", Node().OutputDefs()[0]->Name(),
+                                             " Input shape:", X->Shape(), " Output shape:", Y->Shape(),
+                                             " X data:", X->DataRaw(), " Y data:", Y->DataRaw());
   }
 
   return retval;

--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -277,7 +277,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
     const std::string node_name_for_profiling = [&]() -> std::string {
       if (!is_profiler_enabled) return {};
       // Derive something meaningful for profile traces and logs if node name field is blank in execution graph
-      return node.Name().empty() ? MakeStringLite(node.OpType(), "_", node_index) : node.Name();
+      return node.Name().empty() ? MakeString(node.OpType(), "_", node_index) : node.Name();
     }();
 
     if (is_profiler_enabled) {
@@ -303,7 +303,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
 #endif
 #ifdef ENABLE_NVTX_PROFILE
       profile::NvtxRangeCreator node_compute_range(
-          MakeStringLite(node.OpType(), ".", node.Index(), "(", node.Name(), ")"), profile::Color::Blue);
+          MakeString(node.OpType(), ".", node.Index(), "(", node.Name(), ")"), profile::Color::Blue);
       node_compute_range.Begin();
 #endif
       ORT_TRY {

--- a/onnxruntime/core/platform/env_var_utils.h
+++ b/onnxruntime/core/platform/env_var_utils.h
@@ -21,7 +21,7 @@ optional<T> ParseEnvironmentVariable(const std::string& name) {
 
   T parsed_value;
   ORT_ENFORCE(
-      TryParseString(value_str, parsed_value),
+      TryParseStringWithClassicLocale(value_str, parsed_value),
       "Failed to parse environment variable - name: \"", name, "\", value: \"", value_str, "\"");
 
   return parsed_value;

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider_info.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider_info.cc
@@ -40,7 +40,7 @@ CUDAExecutionProviderInfo CUDAExecutionProviderInfo::FromProviderOptions(const P
           .AddValueParser(
               cuda::provider_option_names::kDeviceId,
               [&info](const std::string& value_str) -> Status {
-                ORT_RETURN_IF_ERROR(ParseString(value_str, info.device_id));
+                ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, info.device_id));
                 int num_devices{};
                 ORT_RETURN_IF_NOT(
                     CUDA_CALL(cudaGetDeviceCount(&num_devices)),
@@ -66,13 +66,13 @@ CUDAExecutionProviderInfo CUDAExecutionProviderInfo::FromProviderOptions(const P
 
 ProviderOptions CUDAExecutionProviderInfo::ToProviderOptions(const CUDAExecutionProviderInfo& info) {
   const ProviderOptions options{
-      {cuda::provider_option_names::kDeviceId, MakeString(info.device_id)},
-      {cuda::provider_option_names::kMemLimit, MakeString(info.cuda_mem_limit)},
+      {cuda::provider_option_names::kDeviceId, MakeStringWithClassicLocale(info.device_id)},
+      {cuda::provider_option_names::kMemLimit, MakeStringWithClassicLocale(info.cuda_mem_limit)},
       {cuda::provider_option_names::kArenaExtendStrategy,
        EnumToName(arena_extend_strategy_mapping, info.arena_extend_strategy)},
       {cuda::provider_option_names::kCudnnConvAlgoSearch,
        EnumToName(ort_cudnn_conv_algo_search_mapping, info.cudnn_conv_algo_search)},
-      {cuda::provider_option_names::kDoCopyInDefaultStream, MakeString(info.do_copy_in_default_stream)},
+      {cuda::provider_option_names::kDoCopyInDefaultStream, MakeStringWithClassicLocale(info.do_copy_in_default_stream)},
   };
 
   return options;

--- a/onnxruntime/core/providers/rocm/rocm_execution_provider_info.cc
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider_info.cc
@@ -40,8 +40,8 @@ ROCMExecutionProviderInfo ROCMExecutionProviderInfo::FromProviderOptions(const P
 
 ProviderOptions ROCMExecutionProviderInfo::ToProviderOptions(const ROCMExecutionProviderInfo& info) {
   const ProviderOptions options{
-      {rocm::provider_option_names::kDeviceId, MakeString(info.device_id)},
-      {rocm::provider_option_names::kMemLimit, MakeString(info.hip_mem_limit)},
+      {rocm::provider_option_names::kDeviceId, MakeStringWithClassicLocale(info.device_id)},
+      {rocm::provider_option_names::kMemLimit, MakeStringWithClassicLocale(info.hip_mem_limit)},
       {rocm::provider_option_names::kArenaExtendStrategy,
        EnumToName(arena_extend_strategy_mapping, info.arena_extend_strategy)},
   };

--- a/onnxruntime/test/common/string_utils_test.cc
+++ b/onnxruntime/test/common/string_utils_test.cc
@@ -13,18 +13,18 @@ namespace {
 template <typename T>
 void TestSuccessfulParse(const std::string& input, const T& expected_value) {
   T value;
-  ASSERT_TRUE(TryParseString(input, value));
+  ASSERT_TRUE(TryParseStringWithClassicLocale(input, value));
   EXPECT_EQ(value, expected_value);
 }
 
 template <typename T>
 void TestFailedParse(const std::string& input) {
   T value;
-  EXPECT_FALSE(TryParseString(input, value));
+  EXPECT_FALSE(TryParseStringWithClassicLocale(input, value));
 }
 }  // namespace
 
-TEST(StringUtilsTest, TryParseString) {
+TEST(StringUtilsTest, TryParseStringWithClassicLocale) {
   TestSuccessfulParse("-1", -1);
   TestSuccessfulParse("42", 42u);
   TestSuccessfulParse("2.5", 2.5f);
@@ -83,9 +83,9 @@ std::istream& operator>>(std::istream& is, S& s) {
 TEST(StringUtilsTest, MakeStringAndTryParseStringWithCustomType) {
   S s;
   s.i = 42;
-  const auto str = MakeString(s);
+  const auto str = MakeStringWithClassicLocale(s);
   S parsed_s;
-  ASSERT_TRUE(TryParseString(str, parsed_s));
+  ASSERT_TRUE(TryParseStringWithClassicLocale(str, parsed_s));
   ASSERT_EQ(parsed_s, s);
 }
 


### PR DESCRIPTION
**Description**
Rename MakeString to MakeStringWithClassicLocale, MakeStringLite to MakeString, *ParseString to *ParseStringWithClassicLocale.
Add missing pass-through versions of MakeStringWithClassicLocale for string types.

**Motivation and Context**
MakeString is the version one usually wants so it should have the simplest name.