### PR TITLE
Increase timeout for Linux GPU CUDA11 build.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-gpu-cuda-11-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-cuda-11-pipeline.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: Linux_Build
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   workspace:
     clean: all
   pool: Linux-GPU-CUDA10


### PR DESCRIPTION
**Description**
Increase timeout for Linux GPU CUDA11 build.

**Motivation and Context**
Sometimes the build needs to build a new docker image. This takes more time and should not cause a build failure.
