### PR TITLE
Disable memory-time sharing amongst tensors that need to be allocated contiguously in memory.

### DIFF
--- a/onnxruntime/core/framework/ort_value_pattern_planner.cc
+++ b/onnxruntime/core/framework/ort_value_pattern_planner.cc
@@ -16,7 +16,8 @@ OrtValuePatternPlanner::OrtValuePatternPlanner(const ExecutionPlanBase& executio
 #ifdef ENABLE_TRAINING
 common::Status OrtValuePatternPlanner::TraceAllocation(int ort_value_idx,
                                                        const AllocPlanPerValue::ProgramCounter& counter,
-                                                       size_t size) {
+                                                       size_t size,
+                                                       bool insert_end) {
   // TODO(codemzs): refactor code.
   const auto& location = execution_planner_.GetLocation(ort_value_idx);
   auto it = planner_map_.find(location);
@@ -24,7 +25,7 @@ common::Status OrtValuePatternPlanner::TraceAllocation(int ort_value_idx,
     return common::Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT);
   }
 
-  it->second->TraceAllocation(ort_value_idx, counter, size);
+  it->second->TraceAllocation(ort_value_idx, counter, size, insert_end);
   return common::Status::OK();
 }
 #endif

--- a/onnxruntime/core/framework/ort_value_pattern_planner.h
+++ b/onnxruntime/core/framework/ort_value_pattern_planner.h
@@ -22,7 +22,7 @@ class OrtValuePatternPlanner {
   // variant of the TraceAllocation calls may be used.
   explicit OrtValuePatternPlanner(const ExecutionPlanBase& execution_plan, bool trace_using_counters = false);
 #ifdef ENABLE_TRAINING
-  common::Status TraceAllocation(int ort_value_idx, const AllocPlanPerValue::ProgramCounter& counter, size_t size);
+  common::Status TraceAllocation(int ort_value_idx, const AllocPlanPerValue::ProgramCounter& counter, size_t size, bool insert_end = false);
 #endif
   common::Status TraceAllocation(int ort_value_idx, size_t size);
   common::Status TraceFree(int ort_value_index);

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -233,14 +233,14 @@ Status SessionState::GetInitializedTensors(
           "Failed to get OrtValue index from name: ", status.ErrorMessage());
       continue;
     }
-    if (initialized_tensors_.find(idx) != initialized_tensors_.end()){
+    if (initialized_tensors_.find(idx) != initialized_tensors_.end()) {
       result.emplace(weight_name, initialized_tensors_.at(idx));
     } else {
       ORT_RETURN_IF_NOT(
           allow_missing_weights,
           "Failed to get initializer with name: ", weight_name, " and index:", idx);
       continue;
-    }    
+    }
   }
   retrieved_weights = std::move(result);
   return Status::OK();
@@ -393,6 +393,12 @@ Status SessionState::GeneratePatternGroupCache(const std::vector<std::reference_
                                                const std::vector<int>& feed_mlvalue_idxs,
                                                MemoryPatternGroup* output,
                                                std::unordered_map<int, TensorShape>& resolved_shapes) const {
+  /*if ((getpid() % 4 == 0)) {
+    bool c = true;
+    while (c) {
+    }
+  }*/
+
   std::map<std::string, TensorShape> feeds;
   for (size_t i = 0, end = feed_mlvalue_idxs.size(); i < end; ++i) {
     std::string name;
@@ -460,7 +466,7 @@ Status SessionState::GeneratePatternGroupCache(const std::vector<std::reference_
       ORT_ENFORCE(exe_plan->allocation_plan[ml_value_idx].alloc_kind == AllocKind::kAllocate);
 
       const auto& counter = exe_plan->allocation_plan[ml_value_idx].program_counter;
-      mem_planner.TraceAllocation(ml_value_idx, counter, size);
+      mem_planner.TraceAllocation(ml_value_idx, counter, size, true);
     }
   }
 

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -393,12 +393,6 @@ Status SessionState::GeneratePatternGroupCache(const std::vector<std::reference_
                                                const std::vector<int>& feed_mlvalue_idxs,
                                                MemoryPatternGroup* output,
                                                std::unordered_map<int, TensorShape>& resolved_shapes) const {
-  /*if ((getpid() % 4 == 0)) {
-    bool c = true;
-    while (c) {
-    }
-  }*/
-
   std::map<std::string, TensorShape> feeds;
   for (size_t i = 0, end = feed_mlvalue_idxs.size(); i < end; ++i) {
     std::string name;


### PR DESCRIPTION
The rationale being if we did memory-time sharing then there is no guarantee we can lay them out contiguously in the scenario when there are two or more nodes that want their input tensors to be laid out contiguously in memory. **Please note we ONLY disable memory-time sharing _amongst_ tensors that need to be laid out contiguously but other activations may share their memory if their time ranges do not overlap.**