### PR TITLE
WIP: Proposal to amend/extend Tensor class to be able to hold   Sparse matrix data.

### DIFF
--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -56,7 +56,7 @@ using BufferNakedPtr = void*;
 // when Tensor instance holds data in its sparse format.
 /// When Tensor holds sparse data then:
 /// - it holds only non-zero values in its buffer
-/// - its shape is a shape of the original dense matrix
+/// - its shape is the shape or rather size of the data in the buffer.
 /// - SparseMetadata must return a non nullptr const pointer to an instance of SparseMetadata
 ///
 /// and SparseMetadata contains the enumeration member that indicates its format.


### PR DESCRIPTION
**Description**: Describe your changes.
We would like to use Prepack mechanism to handle Constant Initializers including Sparse Constant Initializers.
This PR extends Tensor class so it can optionally hold SparseMetadata. The user would be able to know
that the data inside the Tensor is Sparse and how to properly access it.
This way a kernel can ingest the data and apply any conversions to Dense if necessary.
