### PR TITLE
Add gradient registration and tests for Min/Max

### DIFF
--- a/orttraining/orttraining/core/graph/gradient_builder.cc
+++ b/orttraining/orttraining/core/graph/gradient_builder.cc
@@ -1564,10 +1564,10 @@ IMPLEMENT_GRADIENT_BUILDER(GetMinMaxGradient) {
         result.push_back(NodeDef("Cast", {IA(cmp_i)}, {IA(cmp_cast_i)}, {MakeAttribute("to", int64_t(IElemType(0)))}));
         result.push_back(NodeDef("Mul", {IA(cmp_cast_i), GO(0)}, {IA(pre_reduce_grad_i)}));
         ArgDef x_axes = IA("ReduceAxes_" + x.name);
-        ArgDef x_shape = IA("Shape_" + x.name);
-        ArgDef y_shape = IA("Shape_" + y.name + std::to_string(i));
-        ComputeBroadcastBackwardAxesDynamic(x, y, x_shape, y_shape, &x_axes, nullptr, result);
-        HandleBroadcastingDynamic(IA(pre_reduce_grad_i), x, x_shape, GI(i), x_axes, result);
+        ArgDef X_shape = IA("Shape_" + x.name);
+        ArgDef Y_shape = IA("Shape_" + y.name + std::to_string(i));
+        ComputeBroadcastBackwardAxesDynamic(x, y, X_shape, Y_shape, &x_axes, nullptr, result);
+        HandleBroadcastingDynamic(IA(pre_reduce_grad_i), x, X_shape, GI(i), x_axes, result);
       }
     }
   }

--- a/orttraining/orttraining/core/graph/gradient_builder.h
+++ b/orttraining/orttraining/core/graph/gradient_builder.h
@@ -71,6 +71,7 @@ DECLARE_GRADIENT_BUILDER(GetFlattenGradient)
 DECLARE_GRADIENT_BUILDER(GetTopKGradient)
 DECLARE_GRADIENT_BUILDER(GetClipGradient)
 DECLARE_GRADIENT_BUILDER(GetAbsGradient)
+DECLARE_GRADIENT_BUILDER(GetMinMaxGradient)
 
 }  // namespace training
 }  // namespace onnxruntime

--- a/orttraining/orttraining/core/graph/gradient_builder_registry.cc
+++ b/orttraining/orttraining/core/graph/gradient_builder_registry.cc
@@ -102,6 +102,8 @@ void GradientBuilderRegistry::RegisterGradientBuilders() {
   REGISTER_GRADIENT_BUILDER("TopK", GetTopKGradient);
   REGISTER_GRADIENT_BUILDER("Clip", GetClipGradient);
   REGISTER_GRADIENT_BUILDER("Abs", GetAbsGradient);
+  REGISTER_GRADIENT_BUILDER("Min", GetMinMaxGradient);
+  REGISTER_GRADIENT_BUILDER("Max", GetMinMaxGradient);
 };
 
 }  // namespace training

--- a/orttraining/orttraining/test/gradient/gradient_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/gradient_ops_test.cc
@@ -2132,7 +2132,7 @@ TEST(GradientCheckerTest, GatherElementsGrad) {
                                           {MakeAttribute("axis", axis)});
     EXPECT_IS_TINY(max_error);
   }
-  
+
   {
     // GatherElementsGradWithAxisInMiddle
     TensorInfo data_info({2, 2, 2}, true);
@@ -2215,6 +2215,86 @@ TEST(GradientCheckerTest, ClipGrad) {
     std::vector<std::vector<float>> x_datas = {{1, 2, 3, 4, 5, 6, 7, 8}};
     TensorInfo y_info({2, 2, 2}, true);
     gradient_checker.ComputeGradientError(op_def, {x_info}, {y_info}, &max_error, x_datas);
+    EXPECT_IS_TINY(max_error);
+  }
+}
+
+TEST(GradientCheckerTest, MinGrad) {
+  float max_error;
+  GradientChecker<float, float, float> gradient_checker;
+  OpDef op_def{"Min", kOnnxDomain, 11};
+
+  {
+    TensorInfo x_info({2, 3, 4}, true);
+    TensorInfo y_info({2, 3, 4}, true);
+    gradient_checker.ComputeGradientError(op_def, {x_info}, {y_info}, &max_error);
+    EXPECT_IS_TINY(max_error);
+  }
+
+  {
+    TensorInfo x1_info({2, 3, 4}, true);
+    TensorInfo x2_info({2, 3, 4}, true);
+    TensorInfo x3_info({2, 3, 4}, true);
+    TensorInfo y_info({2, 3, 4}, true);
+    gradient_checker.ComputeGradientError(op_def, {x1_info, x2_info, x3_info}, {y_info}, &max_error);
+    EXPECT_IS_TINY(max_error);
+  }
+
+  {
+    TensorInfo x1_info({2, 2}, true);
+    TensorInfo x2_info({2, 2}, true);
+    TensorInfo y_info({2, 2}, true);
+    std::vector<std::vector<float>> x_datas = {{1, 2, 3, 4}, {1, 1, 4, 4}};
+    gradient_checker.ComputeGradientError(op_def, {x1_info, x2_info}, {y_info}, &max_error);
+    EXPECT_IS_TINY(max_error);
+  }
+
+  {
+    TensorInfo x1_info({2, 3, 4}, true);
+    TensorInfo x2_info({3, 4}, true);
+    TensorInfo x3_info({4}, true);
+    TensorInfo y_info({2, 3, 4}, true);
+    gradient_checker.ComputeGradientError(op_def, {x1_info, x2_info, x3_info}, {y_info}, &max_error);
+    EXPECT_IS_TINY(max_error);
+  }
+}
+
+TEST(GradientCheckerTest, MaxGrad) {
+  float max_error;
+  GradientChecker<float, float, float> gradient_checker;
+  OpDef op_def{"Max", kOnnxDomain, 11};
+
+  {
+    TensorInfo x_info({2, 3, 4}, true);
+    TensorInfo y_info({2, 3, 4}, true);
+    gradient_checker.ComputeGradientError(op_def, {x_info}, {y_info}, &max_error);
+    EXPECT_IS_TINY(max_error);
+  }
+
+  {
+    TensorInfo x1_info({2, 3, 4}, true);
+    TensorInfo x2_info({2, 3, 4}, true);
+    TensorInfo x3_info({2, 3, 4}, true);
+    TensorInfo y_info({2, 3, 4}, true);
+    gradient_checker.ComputeGradientError(op_def, {x1_info, x2_info, x3_info}, {y_info}, &max_error);
+    EXPECT_IS_TINY(max_error);
+  }
+
+  {
+    TensorInfo x1_info({2, 2}, true);
+    TensorInfo x2_info({2, 2}, true);
+    TensorInfo y_info({2, 2}, true);
+    std::vector<std::vector<float>> x_datas = {{1, 2, 3, 4}, {1, 1, 4, 4}};
+    gradient_checker.ComputeGradientError(op_def, {x1_info, x2_info}, {y_info}, &max_error);
+    EXPECT_IS_TINY(max_error);
+  }
+
+  {
+    TensorInfo x1_info({2, 3, 4}, true);
+    TensorInfo x2_info({3, 4}, true);
+    TensorInfo x3_info({4}, true);
+    TensorInfo y_info({2, 3, 4}, true);
+    gradient_checker.ComputeGradientError(op_def, {x1_info, x2_info, x3_info}, {y_info}, &max_error);
     EXPECT_IS_TINY(max_error);
   }
 }


### PR DESCRIPTION
**Description**: Add gradient registration and corresponding tests for ops `Min` and `Max`

**Motivation and Context**
- Support training of a model that uses `Max`
- `Min` shares the same logic as `Max`