### PR TITLE
Avoid false sharing on thread pool data structures

### DIFF
--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -152,11 +152,7 @@ class ThreadPoolLoop;
 #define ORT_FALSE_SHARING_BYTES 64
 #endif
 
-#ifdef _MSC_VER
-#define ORT_ALIGN_TO_AVOID_FALSE_SHARING DECLSPEC_ALIGN(ORT_FALSE_SHARING_BYTES)
-#else
-#define ORT_ALIGN_TO_AVOID_FALSE_SHARING __attribute__ ((aligned(ORT_FALSE_SHARING_BYTES)))
-#endif
+#define ORT_ALIGN_TO_AVOID_FALSE_SHARING alignas(ORT_FALSE_SHARING_BYTES)
 
 struct PaddingToAvoidFalseSharing {
   char padding[ORT_FALSE_SHARING_BYTES];

--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -133,10 +133,16 @@ namespace concurrency {
 // Align to avoid false sharing with prior fields.  TheIf required,
 // padding must be added subsequently to avoid false sharing with
 // later fields.
-#define ORT_ALIGN_TO_AVOID_FALSE_SHARING __attribute__((__aligned__(128)))
+#define ORT_FALSE_SHARING_BYTES 128
+
+#ifdef _MSC_VER
+#define ORT_ALIGN_TO_AVOID_FALSE_SHARING DECLSPEC_ALIGN(ORT_FALSE_SHARING_BYTES)
+#else
+#define ORT_ALIGN_TO_AVOID_FALSE_SHARING __attribute__ ((aligned(ORT_FALSE_SHARING_BYTES)))
+#endif
 
 struct PaddingToAvoidFalseSharing {
-  char padding[128];
+  char padding[ORT_FALSE_SHARING_BYTES];
 };
 
 class ThreadPoolParallelSection;

--- a/onnxruntime/test/onnx/microbenchmark/tptest.cc
+++ b/onnxruntime/test/onnx/microbenchmark/tptest.cc
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <benchmark/benchmark.h>
 #include <core/platform/threadpool.h>
 #include <core/util/thread_utils.h>

--- a/onnxruntime/test/onnx/microbenchmark/tptest.cc
+++ b/onnxruntime/test/onnx/microbenchmark/tptest.cc
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <benchmark/benchmark.h>
 #include <core/platform/threadpool.h>
 #include <core/util/thread_utils.h>
@@ -89,6 +90,52 @@ BENCHMARK(BM_ThreadPoolParallelFor)
     ->Args({40000, 200})
     ->Args({80000, 200})
     ->Args({160000, 200});
+
+static void BM_ThreadPoolSimpleParallelFor(benchmark::State& state) {
+  const int num_threads = static_cast<int>(state.range(0));
+  const size_t len = state.range(1);
+  const size_t body = state.range(2);
+  OrtThreadPoolParams tpo;
+  auto tp = onnxruntime::make_unique<ThreadPool>(&onnxruntime::Env::Default(),
+                                                 onnxruntime::ThreadOptions(),
+                                                 nullptr,
+                                                 num_threads, ALLOW_SPINNING);
+  for (auto _ : state) {
+    for (int j = 0; j < 100; j++) {
+      ThreadPool::TrySimpleParallelFor(tp.get(), len, [&](size_t) {
+	  for (volatile size_t x = 0; x < body; x++) {
+	  }
+	});
+    }
+  }
+}
+
+BENCHMARK(BM_ThreadPoolSimpleParallelFor)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kMicrosecond)
+    ->Args({1, 1, 100000})
+    ->Args({2, 2, 100000})
+    ->Args({4, 4, 100000})
+    ->Args({8, 8, 100000})
+    ->Args({12, 12, 100000})
+    ->Args({13, 13, 100000})
+    ->Args({14, 14, 100000})
+    ->Args({15, 15, 100000})
+    ->Args({16, 16, 100000})
+    ->Args({17, 17, 100000})
+    ->Args({20, 20, 100000})
+    ->Args({24, 24, 100000})
+    ->Args({28, 28, 100000})
+    ->Args({1, 1, 10000})
+    ->Args({2, 2, 10000})
+    ->Args({4, 4, 10000})
+    ->Args({8, 8, 10000})
+    ->Args({14, 14, 10000})
+    ->Args({15, 15, 10000})
+    ->Args({17, 17, 10000})
+    ->Args({20, 20, 10000})
+    ->Args({24, 24, 10000})
+    ->Args({28, 28, 10000});
 
 static void BM_SimpleForLoop(benchmark::State& state) {
   const size_t len = state.range(0);

--- a/onnxruntime/test/onnx/microbenchmark/tptest.cc
+++ b/onnxruntime/test/onnx/microbenchmark/tptest.cc
@@ -110,32 +110,28 @@ static void BM_ThreadPoolSimpleParallelFor(benchmark::State& state) {
   }
 }
 
+// Select number of threads to use for simple loop microbenchmark.  We
+// always cover 1 thread and NUM_THREADS.  In addition, anticipating
+// NUMA effects on 2-socket machines, we look just below and just
+// above the point where the second socket must be used.
+static constexpr int HALF_THREADS = NUM_THREADS>=2 ? ((NUM_THREADS/2)) : 1;
+static constexpr int HALF_THREADS_PLUS_1 = NUM_THREADS>=2 ? ((NUM_THREADS/2)+1) : 1;
+
 BENCHMARK(BM_ThreadPoolSimpleParallelFor)
     ->UseRealTime()
     ->Unit(benchmark::TimeUnit::kMicrosecond)
     ->Args({1, 1, 100000})
-    ->Args({2, 2, 100000})
-    ->Args({4, 4, 100000})
-    ->Args({8, 8, 100000})
-    ->Args({12, 12, 100000})
-    ->Args({13, 13, 100000})
-    ->Args({14, 14, 100000})
-    ->Args({15, 15, 100000})
-    ->Args({16, 16, 100000})
-    ->Args({17, 17, 100000})
-    ->Args({20, 20, 100000})
-    ->Args({24, 24, 100000})
-    ->Args({28, 28, 100000})
+    ->Args({HALF_THREADS, HALF_THREADS, 100000})
+    ->Args({HALF_THREADS_PLUS_1, HALF_THREADS_PLUS_1, 100000})
+    ->Args({NUM_THREADS, NUM_THREADS, 100000})
     ->Args({1, 1, 10000})
-    ->Args({2, 2, 10000})
-    ->Args({4, 4, 10000})
-    ->Args({8, 8, 10000})
-    ->Args({14, 14, 10000})
-    ->Args({15, 15, 10000})
-    ->Args({17, 17, 10000})
-    ->Args({20, 20, 10000})
-    ->Args({24, 24, 10000})
-    ->Args({28, 28, 10000});
+    ->Args({HALF_THREADS, HALF_THREADS, 10000})
+    ->Args({HALF_THREADS_PLUS_1, HALF_THREADS_PLUS_1, 10000})
+    ->Args({NUM_THREADS, NUM_THREADS, 10000})
+    ->Args({1, 1, 1000})
+    ->Args({HALF_THREADS, HALF_THREADS, 1000})
+    ->Args({HALF_THREADS_PLUS_1, HALF_THREADS_PLUS_1, 1000})
+    ->Args({NUM_THREADS, NUM_THREADS, 1000});
 
 static void BM_SimpleForLoop(benchmark::State& state) {
   const size_t len = state.range(0);


### PR DESCRIPTION
**Description**: This change adds alignment and padding to avoid false sharing on fields in the thread pool.  It also adds a new microbenchmark to profile thread-pool performance over short loops.

**Motivation and Context**
MobileNet on a 2*12-core system showed a performance gap between the ORT thread pool and OpenMP.  One cause appeared to be false sharing on fields in the thread pool: ThreadPoolParallelSection::tasks_finished (which the main thread spins on waiting for workers to complete a loop), and the RunQueue::front_ and back_ fields (used respectively by the worker thread and the main thread).

The additional micro-benchmark BM_ThreadPoolSimpleParallelFor tests performance of loops of different sizes at different thread counts.  The results below are on a machine with 2*14-core processors (E5-2690 v4) running with 1, 14, 15, and 28 threads.  For each test, the microbenchmark has N threads run a loop with N iterations; hence a perfect result is for the time taken to be constant as additional threads are added (although we will also see power management effects helping at very low thread counts).  The loop durations (100000, 10000, 1000) correspond roughly to 200us, 20us, and 2us on this machine.  

Before change:
 BM_ThreadPoolSimpleParallelFor/1/1/100000/real_time        17153 us      17154 us         32                                                                                        
 BM_ThreadPoolSimpleParallelFor/14/14/100000/real_time      22553 us      22553 us         30                                                                                        
 BM_ThreadPoolSimpleParallelFor/15/15/100000/real_time      21521 us      21521 us         29                                                                                        
 BM_ThreadPoolSimpleParallelFor/28/28/100000/real_time      24111 us      24111 us         24                                                                                        
 BM_ThreadPoolSimpleParallelFor/1/1/10000/real_time          1719 us       1719 us        407                                                                                        
 BM_ThreadPoolSimpleParallelFor/14/14/10000/real_time        3409 us       3409 us        200                                                                                        
 BM_ThreadPoolSimpleParallelFor/15/15/10000/real_time        3541 us       3541 us        201                                                                                        
 BM_ThreadPoolSimpleParallelFor/28/28/10000/real_time        4576 us       4576 us        151                                                                                        
 BM_ThreadPoolSimpleParallelFor/1/1/1000/real_time            174 us        174 us       4017                                                                                        
 BM_ThreadPoolSimpleParallelFor/14/14/1000/real_time         1586 us       1586 us        402                                                                                        
 BM_ThreadPoolSimpleParallelFor/15/15/1000/real_time         1586 us       1586 us        397                                                                                        
 BM_ThreadPoolSimpleParallelFor/28/28/1000/real_time         2864 us       2864 us        232             

After change:
 BM_ThreadPoolSimpleParallelFor/1/1/100000/real_time        17160 us      17160 us         33                                                                                        
 BM_ThreadPoolSimpleParallelFor/14/14/100000/real_time      20989 us      20989 us         31                                                                                        
 BM_ThreadPoolSimpleParallelFor/15/15/100000/real_time      22286 us      22286 us         31                                                                                        
 BM_ThreadPoolSimpleParallelFor/28/28/100000/real_time      24631 us      24631 us         25                                                                                        
 BM_ThreadPoolSimpleParallelFor/1/1/10000/real_time          1718 us       1718 us        407                                                                                        
 BM_ThreadPoolSimpleParallelFor/14/14/10000/real_time        2868 us       2868 us        242                                                                                        
 BM_ThreadPoolSimpleParallelFor/15/15/10000/real_time        2907 us       2907 us        240                                                                                        
 BM_ThreadPoolSimpleParallelFor/28/28/10000/real_time        3872 us       3872 us        186                                                                                        
 BM_ThreadPoolSimpleParallelFor/1/1/1000/real_time            175 us        175 us       3938                                                                                        
 BM_ThreadPoolSimpleParallelFor/14/14/1000/real_time          933 us        933 us        659                                                                                        
 BM_ThreadPoolSimpleParallelFor/15/15/1000/real_time          912 us        912 us        591                                                                                        
 BM_ThreadPoolSimpleParallelFor/28/28/1000/real_time         1976 us       1976 us        317                                                                                        
