### PR TITLE
Remove dead code with invalid import

### DIFF
--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -287,7 +287,6 @@ class ORTTrainer(object):
         from onnx import helper, TensorProto, numpy_helper
         import numpy as np
         from numpy.testing import assert_allclose
-        import _test_helpers
         onnx_model_copy = copy.deepcopy(self._onnx_model)
 
         # Mute the dropout nodes

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1300,6 +1300,7 @@ def run_training_python_frontend_tests(cwd):
     run_subprocess([
         sys.executable, 'orttraining_test_transformers.py',
         'BertModelTest.test_for_pretraining_full_precision_list_and_dict_input'], cwd=cwd)
+    run_subprocess([sys.executable, 'orttraining_test_debuggability.py'], cwd=cwd)
 
     # TODO: use run_orttraining_test_orttrainer_frontend_separately to work around a sporadic segfault.
     # shall revert to run_subprocess call once the segfault issue is resolved.


### PR DESCRIPTION
ORTTrainer was using an invalid import when the debug flag was set
Unit test for debuggability was disabled for some reason. Re0enabling it