### PR TITLE
[Test] Revert "Enable ONNX backend test of SequenceProto input/output "

### DIFF
--- a/cgmanifests/submodules/cgmanifest.json
+++ b/cgmanifests/submodules/cgmanifest.json
@@ -232,7 +232,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "6c3d8509ee005de938ad596dcd922ff8b6a2f523",
+          "commitHash": "994c6181247d7b419b28889fc57d5817e2089419",
           "repositoryUrl": "https://github.com/onnx/onnx"
         },
         "comments": "git submodule at cmake/external/onnx"

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -22,19 +22,13 @@ class OrtBackendTest(onnx.backend.test.BackendTest):
 
     @classmethod
     def assert_similar_outputs(cls, ref_outputs, outputs, rtol, atol):
-        def assert_similar_array(ref_output, output):
-            np.testing.assert_equal(ref_output.dtype, output.dtype)
-            if ref_output.dtype == np.object:
-                np.testing.assert_array_equal(ref_output, output)
-            else:
-                np.testing.assert_allclose(ref_output, output, rtol=1e-3, atol=1e-5)            
         np.testing.assert_equal(len(ref_outputs), len(outputs))
         for i in range(len(outputs)):
-            if isinstance(outputs[i], list):
-                for j in range(len(outputs[i])):
-                    assert_similar_array(ref_outputs[i][j], outputs[i][j])
+            np.testing.assert_equal(ref_outputs[i].dtype, outputs[i].dtype)
+            if ref_outputs[i].dtype == np.object:
+                np.testing.assert_array_equal(ref_outputs[i], outputs[i])
             else:
-                assert_similar_array(ref_outputs[i], outputs[i])
+                np.testing.assert_allclose(ref_outputs[i], outputs[i], rtol=1e-3, atol=1e-5)
 
 
 def create_backend_test(testname=None):

--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -21,17 +21,20 @@
         "^test_nesterov_momentum",
         "^test_pow_types_float32_uint32",
         "^test_pow_types_float32_uint64",
+        "^test_sequence_insert_at_back_cpu", // numpy_helper currently not supporting loading segments.
+        "^test_sequence_insert_at_front_cpu", // numpy_helper currently not supporting loading segments.
         "^test_gradient_of_add_and_mul",
         "^test_gradient_of_add",
         "^test_batchnorm_example_training_mode",
         "^test_batchnorm_epsilon_training_mode",
-        "^test_MaxPool2d_stride_padding_dilation_cpu", // result approximation error; need to be updated in ONNX
         "^test_maxunpool_export_with_output_shape", // result mismatch
         "^test_resize_downsample_scales_cubic_align_corners", // results mismatch with onnx tests
         "^test_resize_downsample_scales_linear_align_corners", // results mismatch with onnx tests
         "^test_adam", // NOT_IMPLEMENTED : Could not find an implementation for the node Adam(1)
         "^test_adam_multiple", // NOT_IMPLEMENTED : Could not find an implementation for the node Adam(1)
         "^test_training_dropout.*", // NOT_IMPLEMENTED : Could not find an implementation for the node Dropout(12) (Temporary, subsequent PR will add this -- we need training_mode change in the kernel)
+        "^test_if_seq_cpu", // ONNX backend test runner doesn't handle sequences: https://github.com/onnx/onnx/issues/3086
+        "^test_loop13_seq_cpu", // ONNX backend test runner doesn't handle sequences: https://github.com/onnx/onnx/issues/3086
         "^test_resize_downsample_scales_cubic_A_n0p5_exclude_outside_cpu", // NOT_IMPLEMENTED : Could not find an implementation for the node Resize(13)
         "^test_resize_downsample_scales_cubic_cpu",
         "^test_resize_downsample_scales_linear_cpu",

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -3,7 +3,7 @@ mypy
 pytest
 setuptools>=41.4.0
 wheel
-git+http://github.com/onnx/onnx.git@6c3d8509ee005de938ad596dcd922ff8b6a2f523#egg=onnx
+git+http://github.com/onnx/onnx.git@994c6181247d7b419b28889fc57d5817e2089419#egg=onnx
 protobuf
 sympy==1.1.1
 flake8

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -4,7 +4,7 @@ mypy
 pytest
 setuptools>=41.4.0
 wheel
-git+http://github.com/onnx/onnx.git@6c3d8509ee005de938ad596dcd922ff8b6a2f523#egg=onnx
+git+http://github.com/onnx/onnx.git@994c6181247d7b419b28889fc57d5817e2089419#egg=onnx
 argparse
 sympy==1.1.1
 flake8


### PR DESCRIPTION
Reverts microsoft/onnxruntime#6043; Currently this merged PR seems using the wrong commit to build ONNX. Try to revert it and see whether the CIs are using the given commit to build ONNX.