### PR TITLE
Fix some compile warnings

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -173,10 +173,10 @@ typedef OrtStatus* OrtStatusPtr;
 #endif
 
 // __VA_ARGS__ on Windows and Linux are different
-#define ORT_API(RETURN_TYPE, NAME, ...) ORT_EXPORT RETURN_TYPE ORT_API_CALL NAME(__VA_ARGS__) NO_EXCEPTION
+#define ORT_API(RETURN_TYPE, NAME, ...) RETURN_TYPE ORT_API_CALL NAME(__VA_ARGS__) NO_EXCEPTION
 
 #define ORT_API_STATUS(NAME, ...) \
-  ORT_EXPORT _Check_return_ _Ret_maybenull_ OrtStatusPtr ORT_API_CALL NAME(__VA_ARGS__) NO_EXCEPTION ORT_MUST_USE_RESULT
+  _Success_(return == 0) _Check_return_ _Ret_maybenull_ OrtStatusPtr ORT_API_CALL NAME(__VA_ARGS__) NO_EXCEPTION ORT_MUST_USE_RESULT
 
 // XXX: Unfortunately, SAL annotations are known to not work with function pointers
 #define ORT_API2_STATUS(NAME, ...) \
@@ -184,7 +184,7 @@ typedef OrtStatus* OrtStatusPtr;
 
 // Used in *.cc files. Almost as same as ORT_API_STATUS, except without ORT_MUST_USE_RESULT and ORT_EXPORT
 #define ORT_API_STATUS_IMPL(NAME, ...) \
-  _Check_return_ _Ret_maybenull_ OrtStatusPtr ORT_API_CALL NAME(__VA_ARGS__) NO_EXCEPTION
+  _Success_(return == 0) _Check_return_ _Ret_maybenull_ OrtStatusPtr ORT_API_CALL NAME(__VA_ARGS__) NO_EXCEPTION
 
 #define ORT_CLASS_RELEASE(X) void(ORT_API_CALL * Release##X)(_Frees_ptr_opt_ Ort##X * input)
 
@@ -934,7 +934,7 @@ struct OrtApi {
   // Release instance of OrtAllocator obtained from CreateAllocator API
   ORT_CLASS_RELEASE(Allocator);
 
-  ORT_API2_STATUS(RunWithBinding, _Inout_ OrtSession* sess, _In_opt_ const OrtRunOptions* run_options, _In_ const OrtIoBinding* binding_ptr);
+  ORT_API2_STATUS(RunWithBinding, _Inout_ OrtSession* sess, _In_ const OrtRunOptions* run_options, _In_ const OrtIoBinding* binding_ptr);
 
   // Creates an IoBinding instance that allows one to bind pre-allocated OrtValues
   // to input names. Thus if you want to use a raw on device buffer as input or output

--- a/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
@@ -98,22 +98,22 @@ class AttentionCPUBase : public AttentionBase {
                              T* present,                                   // present state
                              ThreadPool* tp) const {
     const int all_sequence_length = past_sequence_length + sequence_length;                  // S* = S' + S
-    const size_t past_chunk_length = static_cast<size_t>(past_sequence_length * head_size);  // S' x H
-    const size_t input_chunk_length = static_cast<size_t>(sequence_length * head_size);      // S x H
+    const size_t past_chunk_length = static_cast<size_t>(past_sequence_length) * head_size;  // S' x H
+    const size_t input_chunk_length = static_cast<size_t>(sequence_length) * head_size;      // S x H
     const size_t present_chunk_length = past_chunk_length + input_chunk_length;              // S* x H
 
     {
       if (mask_data != nullptr) {
         PrepareMask(mask_index, mask_index_dims, mask_data, is_unidirectional_, batch_size, sequence_length, past_sequence_length);
       } else {  // no any mask
-        memset(attention_probs, 0, batch_size * num_heads_ * sequence_length * all_sequence_length * sizeof(T));
+        memset(attention_probs, 0, static_cast<size_t>(batch_size) * num_heads_ * sequence_length * all_sequence_length * sizeof(T));
       }
 
       const int loop_len = batch_size * num_heads_;
       const float alpha = 1.0f / sqrt(static_cast<float>(head_size));
 
       // The cost of Gemm
-      const double cost = static_cast<double>(head_size * sequence_length * all_sequence_length);
+      const double cost = static_cast<double>(head_size) * sequence_length * all_sequence_length;
 
       ThreadPool::TryParallelFor(tp, loop_len, cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
         for (std::ptrdiff_t i = begin; i != end; ++i) {

--- a/onnxruntime/contrib_ops/cpu/tokenizer.cc
+++ b/onnxruntime/contrib_ops/cpu/tokenizer.cc
@@ -471,10 +471,10 @@ Status Tokenizer::Compute(OpKernelContext* ctx) const {
   size_t C = 0;
   if (input_dims.size() == 1) {
     N = 1;
-    C = input_dims[0];
+    C = gsl::narrow<size_t>(input_dims[0]);
   } else if (input_dims.size() == 2) {
-    N = input_dims[0];
-    C = input_dims[1];
+    N = gsl::narrow<size_t>(input_dims[0]);
+    C = gsl::narrow<size_t>(input_dims[1]);
   } else {
     return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
                   "Input dimensions are either [C] or [N][C] allowed");

--- a/onnxruntime/contrib_ops/cuda/bert/fast_gelu_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/fast_gelu_impl.cu
@@ -33,11 +33,11 @@ namespace contrib {
 namespace cuda {
 
 // constants for approximating the normal cdf
-constexpr float A = 0.5;
+constexpr float A = 0.5f;
 
-constexpr float B = 0.7978845608028654;  // sqrt(2.0/M_PI)
+constexpr float B = 0.7978845608028654f;  // sqrt(2.0/M_PI)
 
-constexpr float C = 0.035677408136300125;  // 0.044715 * sqrt(2.0/M_PI)
+constexpr float C = 0.035677408136300125f;  // 0.044715 * sqrt(2.0/M_PI)
 
 template <typename T, unsigned TPB>
 __global__ void FastGeluKernel(const T a, const T b, const T c, int input_length, int bias_length, const T* input, const T* bias, T* output) {

--- a/onnxruntime/contrib_ops/cuda/layer_norm.cc
+++ b/onnxruntime/contrib_ops/cuda/layer_norm.cc
@@ -64,8 +64,8 @@ Status LayerNorm<T, U, simplified>::ComputeInternal(OpKernelContext* ctx) const 
   const TensorShape& x_shape = X->Shape();
   const int64_t axis = HandleNegativeAxis(axis_, x_shape.NumDimensions());
 
-  auto n1 = x_shape.SizeToDimension(axis);
-  auto n2 = x_shape.SizeFromDimension(axis);
+  int n1 = gsl::narrow<int>(x_shape.SizeToDimension(axis));
+  int n2 = gsl::narrow<int>(x_shape.SizeFromDimension(axis));
 
   ORT_ENFORCE(n2 != 1, "n2 should not be 1");
 

--- a/onnxruntime/contrib_ops/cuda/layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/layer_norm_impl.cu
@@ -354,17 +354,17 @@ void HostApplyLayerNorm(
     U* mean,
     U* invvar,
     const T* input,
-    int64_t n1,
-    int64_t n2,
+    int n1,
+    int n2,
     double epsilon,
     const T* gamma,
     const T* beta) {
-  const uint64_t maxGridY = prop.maxGridSize[1];
+  const int maxGridY = prop.maxGridSize[1];
   const int warp_size = prop.warpSize;
   ORT_ENFORCE(warp_size == GPU_WARP_SIZE);
 
   const dim3 threads(warp_size, 4, 1);
-  const dim3 blocks(1, std::min((uint64_t)n1, maxGridY), 1);
+  const dim3 blocks(1, std::min<unsigned int>(n1, maxGridY), 1);
   int nshared =
       threads.y > 1 ? threads.y * sizeof(U) + (threads.y / 2) * sizeof(U) : 0;
   cuApplyLayerNorm<T, U, simplified><<<blocks, threads, nshared, 0>>>(
@@ -377,9 +377,9 @@ void HostApplyLayerNorm(
       gamma, beta);
 }
 
-#define LAYERNORM_LINEAR_IMPL(T, U, simplified)                                                                       \
-  template void HostApplyLayerNorm<T, U, simplified>(const cudaDeviceProp& prop, T* output, U* mean, U* invvar, const T* input, int64_t n1, int64_t n2, \
-                                   double epsilon, const T* gamma, const T* beta);
+#define LAYERNORM_LINEAR_IMPL(T, U, simplified)                                                                                                 \
+  template void HostApplyLayerNorm<T, U, simplified>(const cudaDeviceProp& prop, T* output, U* mean, U* invvar, const T* input, int n1, int n2, \
+                                                     double epsilon, const T* gamma, const T* beta);
 
 LAYERNORM_LINEAR_IMPL(float, float, true)
 LAYERNORM_LINEAR_IMPL(half, float, true)

--- a/onnxruntime/contrib_ops/cuda/layer_norm_impl.h
+++ b/onnxruntime/contrib_ops/cuda/layer_norm_impl.h
@@ -36,8 +36,8 @@ void HostApplyLayerNorm(
     U* mean,
     U* invvar,
     const T* input,
-    int64_t n1,
-    int64_t n2,
+    int n1,
+    int n2,
     double epsilon,
     const T* gamma,
     const T* beta);

--- a/onnxruntime/contrib_ops/cuda/math/bias_softmax_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/math/bias_softmax_impl.cu
@@ -249,29 +249,31 @@ void DispatchBiasSoftMaxForwardViaDnnLibraryImpl(
   auto* Y_data = reinterpret_cast<CudaT*>(Y->template MutableData<T>());
 
   // binary elementise kernel requires input pitches
-  TArray<int64_t> lhs_padded_strides(X_shape.NumDimensions());
-  for (int i = -1, lhs_pitch = 1; i >= -(int)X_shape.NumDimensions(); i--) {
+  TArray<int64_t> lhs_padded_strides(static_cast<int>(X_shape.NumDimensions()));
+  int64_t lhs_pitch = 1, rhs_pitch = 1;
+  for (int i = -1; i >= -(int)X_shape.NumDimensions(); i--) {
     size_t positive_i = X_shape.NumDimensions() + i;
-    lhs_padded_strides[positive_i] = lhs_pitch;
+    lhs_padded_strides[static_cast<int>(positive_i)] = lhs_pitch;
     lhs_pitch *= X_shape[positive_i];
   }
 
   // set pitches for bias so it broadcasts along relevant dimensions
-  TArray<int64_t> rhs_padded_strides(X_shape.NumDimensions());
-  for (int i = -1, rhs_pitch = 1; i >= -(int)X_shape.NumDimensions(); i--) {
+  TArray<int64_t> rhs_padded_strides(static_cast<int>(X_shape.NumDimensions()));
+  for (int i = -1; i >= -(int)X_shape.NumDimensions(); i--) {
     size_t positive_ix = X_shape.NumDimensions() + i;
     size_t positive_ib = B_shape.NumDimensions() + i;
     if (broadcast_axis <= positive_ix && positive_ix < softmax_axis) {
-      rhs_padded_strides[positive_ix] = 0;
+      rhs_padded_strides[static_cast<int>(positive_ix)] = 0;
       continue;
     }
-    rhs_padded_strides[positive_ix] = rhs_pitch;
+    rhs_padded_strides[static_cast<int>(positive_ix)] = rhs_pitch;
     rhs_pitch *= B_shape[positive_ib];
   }
 
-  TArray<fast_divmod> fdm_output_strides(X_shape.NumDimensions());
+  TArray<fast_divmod> fdm_output_strides(static_cast<int>(X_shape.NumDimensions()));
+  //TODO: fast_divmod only supports int32
   for (int i = 0; i < fdm_output_strides.Size(); i++)
-    fdm_output_strides[i] = fast_divmod(lhs_padded_strides[i]);
+    fdm_output_strides[i] = fast_divmod(static_cast<int>(lhs_padded_strides[i]));
   fast_divmod fdm_H, fdm_C;
 
   // invoke elementwise add with broadcast kernel

--- a/onnxruntime/contrib_ops/cuda/math/fft_ops_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/math/fft_ops_impl.cu
@@ -30,7 +30,7 @@ template <typename T>
 void PostProcess(const std::vector<int64_t>& signal_dims, int64_t N, T* output_data) {
   int64_t scale = std::accumulate(signal_dims.begin(), signal_dims.end(), 1ll, std::multiplies<int64_t>());
   int blocksPerGrid = (int)(ceil(static_cast<float>(N) / GridDim::maxThreadsPerBlock));
-  _Normalize<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(output_data, N, scale);
+  _Normalize<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(output_data, N, static_cast<int>(scale));
 }
 
 #define SPECIALIZED_IMPL(T) \

--- a/onnxruntime/core/framework/bfc_arena.h
+++ b/onnxruntime/core/framework/bfc_arena.h
@@ -20,14 +20,16 @@ limitations under the License.
 #include <mutex>
 #include <sstream>
 
+#include "onnxruntime_config.h"
+
 #include "core/common/common.h"
 #include "core/common/logging/logging.h"
 #include "core/common/logging/severity.h"
+#include "core/common/safeint.h"
+
 #include "core/platform/ort_mutex.h"
 #include "core/framework/arena.h"
 #include "core/framework/arena_extend_strategy.h"
-#include "core/common/safeint.h"
-#include "onnxruntime_config.h"
 
 #if defined(PLATFORM_WINDOWS)
 #include <intrin.h>

--- a/onnxruntime/core/framework/session_options.cc
+++ b/onnxruntime/core/framework/session_options.cc
@@ -26,7 +26,7 @@ const std::string SessionOptions::GetConfigOrDefault(const std::string& config_k
   return iter == session_configurations.cend() ? default_value : iter->second;
 }
 
-Status SessionOptions::AddConfigEntry(const char* config_key, const char* config_value) noexcept {
+Status SessionOptions::AddConfigEntry(_In_z_ const char* config_key, _In_z_ const char* config_value) noexcept {
   std::string key(config_key);
   if (key.empty() || key.length() > 128)
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Config key is empty or longer than maximum length 128");
@@ -47,7 +47,7 @@ Status SessionOptions::AddConfigEntry(const char* config_key, const char* config
   return Status::OK();
 }
 
-Status SessionOptions::AddInitializer(const char* name, const OrtValue* val) noexcept {
+Status SessionOptions::AddInitializer(_In_z_ const char* name, _In_ const OrtValue* val) noexcept {
   // input validation
   if (name == nullptr) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Received nullptr for name.");

--- a/onnxruntime/core/framework/session_options.h
+++ b/onnxruntime/core/framework/session_options.h
@@ -112,7 +112,7 @@ struct SessionOptions {
   std::unordered_map<std::string, const OrtValue*> initializers_to_share_map;
 
   // See onnxruntime_c_api.h for detailed documentation.
-  Status AddInitializer(const char* name, const OrtValue* val) noexcept;
+  Status AddInitializer(_In_z_ const char* name, _In_ const OrtValue* val) noexcept;
 
   // Check if the given SessionOptions has a config using the given config_key.
   // Returns true if found and copies the value into config_value.

--- a/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
@@ -61,9 +61,9 @@ Info::Info(const Node& node, const GraphViewer& subgraph_in, int num_scan_inputs
 }
 
 void ReadDirections(const OpKernelInfo& info, const std::string& attr_name,
-                    std::vector<int64_t>& directions, int64_t num_entries) {
+                    std::vector<int64_t>& directions, size_t num_entries) {
   if (info.GetAttrs<int64_t>(attr_name, directions).IsOK()) {
-    ORT_ENFORCE(num_entries < 0 || gsl::narrow_cast<int64_t>(directions.size()) == num_entries,
+    ORT_ENFORCE(directions.size() == num_entries,
                 "Number of entries in '", attr_name, "' was ", directions.size(),
                 " but expected ", num_entries);
 

--- a/onnxruntime/core/providers/cpu/controlflow/scan_utils.h
+++ b/onnxruntime/core/providers/cpu/controlflow/scan_utils.h
@@ -184,7 +184,7 @@ class OutputIterator {
 };
 
 void ReadDirections(const OpKernelInfo& info, const std::string& attr_name,
-                    std::vector<int64_t>& directions, int64_t num_entries);
+                    std::vector<int64_t>& directions, size_t num_entries);
 
 Status AllocateOutput(OpKernelContextInternal& context, const GraphViewer& subgraph,
                       int output_index, bool is_loop_state_var, int64_t batch_size, int64_t sequence_len,

--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
@@ -931,9 +931,9 @@ Status BitShift<T>::Compute(OpKernelContext* context) const {
       [](BroadcastHelper& per_iter_bh) {
         bool shift_left = per_iter_bh.GetUserData();
         const T& input0 = per_iter_bh.ScalarInput0<T>();
-        auto input1 = per_iter_bh.EigenInput1<T>();
-        auto output = per_iter_bh.OutputEigen<T>();
-        int64_t i = 0;
+        ConstEigenVectorMap<T> input1 = per_iter_bh.EigenInput1<T>();
+        EigenVectorMap<T> output = per_iter_bh.OutputEigen<T>();
+        ptrdiff_t i = 0;
         if (shift_left) {
           for (const auto& input : input1.array()) {
             output[i++] = input0 << input;
@@ -949,7 +949,7 @@ Status BitShift<T>::Compute(OpKernelContext* context) const {
         auto input0 = per_iter_bh.EigenInput0<T>();
         const T& input1 = per_iter_bh.ScalarInput1<T>();
         auto output = per_iter_bh.OutputEigen<T>();
-        int64_t i = 0;
+        ptrdiff_t i = 0;
         if (shift_left) {
           for (const auto& input : input0.array()) {
             output[i++] = input << input1;
@@ -1173,8 +1173,8 @@ class Asinh final : public OpKernel {
     auto X_data = X.template Data<float>();
     auto Y_data = Y.template MutableData<float>();
 
-    auto in = gsl::make_span(X_data, X.Shape().Size());
-    auto out = gsl::make_span(Y_data, Y.Shape().Size());
+    auto in = gsl::make_span(X_data, gsl::narrow<ptrdiff_t>(X.Shape().Size()));
+    auto out = gsl::make_span(Y_data, gsl::narrow<ptrdiff_t>(Y.Shape().Size()));
 
     for (size_t index = 0; index < in.size(); ++index) {
       out[index] = std::asinh(in[index]);
@@ -1205,8 +1205,8 @@ class Acosh final : public OpKernel {
     auto X_data = X.template Data<float>();
     auto Y_data = Y.template MutableData<float>();
 
-    auto in = gsl::make_span(X_data, X.Shape().Size());
-    auto out = gsl::make_span(Y_data, Y.Shape().Size());
+    auto in = gsl::make_span(X_data, gsl::narrow<ptrdiff_t>(X.Shape().Size()));
+    auto out = gsl::make_span(Y_data, gsl::narrow<ptrdiff_t>(Y.Shape().Size()));
 
     for (size_t index = 0; index < in.size(); ++index) {
       out[index] = std::acosh(in[index]);
@@ -1237,8 +1237,8 @@ class Atanh final : public OpKernel {
     auto X_data = X.template Data<float>();
     auto Y_data = Y.template MutableData<float>();
 
-    auto in = gsl::make_span(X_data, X.Shape().Size());
-    auto out = gsl::make_span(Y_data, Y.Shape().Size());
+    auto in = gsl::make_span(X_data, gsl::narrow<ptrdiff_t>(X.Shape().Size()));
+    auto out = gsl::make_span(Y_data, gsl::narrow<ptrdiff_t>(Y.Shape().Size()));
 
     for (size_t index = 0; index < in.size(); ++index) {
       out[index] = std::atanh(in[index]);
@@ -1623,7 +1623,7 @@ void UntypedBroadcastTwo(OpKernelContext& context, const ProcessBroadcastSpanFun
   Tensor& output_tensor = *context.Output(0, input_broadcaster.GetOutputShape());
 
   size_t span_size = input_broadcaster.GetSpanSize();
-  size_t output_size = output_tensor.Shape().Size();
+  size_t output_size = static_cast<ptrdiff_t>(output_tensor.Shape().Size());
 
   // one or more zero dimensions so nothing more to do
   if (output_size == 0) {

--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.h
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.h
@@ -432,12 +432,12 @@ class Erf final : public OpKernel {
 
 template <typename T>
 auto MakeEigenArrayMap(Tensor& t) -> EigenVectorArrayMap<T> {
-  return EigenVectorArrayMap<T>(t.template MutableData<T>(), t.Shape().Size());
+  return EigenVectorArrayMap<T>(t.template MutableData<T>(), gsl::narrow<ptrdiff_t>(t.Shape().Size()));
 }
 
 template <typename T>
 auto MakeEigenArrayMap(const Tensor& t) -> ConstEigenVectorArrayMap<T> {
-  return ConstEigenVectorArrayMap<T>(t.template Data<T>(), t.Shape().Size());
+  return ConstEigenVectorArrayMap<T>(t.template Data<T>(), gsl::narrow<ptrdiff_t>(t.Shape().Size()));
 }
 
 struct BroadcastIterator {
@@ -470,12 +470,12 @@ struct BroadcastIterator {
     return index;
   }
 
-  void Reserve(int64_t max_dims) {
+  void Reserve(ptrdiff_t max_dims) {
     deltas_.reserve(static_cast<size_t>(max_dims));
     counts_.reserve(static_cast<size_t>(max_dims));
   }
 
-  void Init(int64_t axis, int64_t largest) {
+  void Init(ptrdiff_t axis, ptrdiff_t largest) {
     ORT_ENFORCE(axis == 1 || axis == largest, "Attempting to broadcast an axis by a dimension other than 1. ", axis, " by ", largest);
 
     deltas_.push_back(axis > 1);
@@ -483,7 +483,7 @@ struct BroadcastIterator {
     count_ *= axis;
   }
 
-  void Append(int64_t axis, int64_t largest) {
+  void Append(ptrdiff_t axis, ptrdiff_t largest) {
     ORT_ENFORCE(axis == 1 || axis == largest, "Attempting to broadcast an axis by a dimension other than 1. ", axis, " by ", largest);
 
     // If we're greater than 1, it doesn't matter what the other tensor does
@@ -509,9 +509,9 @@ struct BroadcastIterator {
     counts_.push_back(1);
   }
 
-  std::vector<int64_t> counters_;
+  std::vector<ptrdiff_t> counters_;
   std::vector<ptrdiff_t> deltas_;
-  std::vector<int64_t> counts_;
+  std::vector<ptrdiff_t> counts_;
   ptrdiff_t count_{1};  // Running total count of entries in tensor, used while building up the entries
 
  private:
@@ -540,13 +540,13 @@ struct Broadcaster {
           iterator1_.Init(1, 1);
           iterator2_.Init(1, 1);
         } else {
-          auto axis = *--iter2;
+          ptrdiff_t axis = static_cast<ptrdiff_t>(*--iter2);
           iterator1_.Init(1, axis);
           iterator2_.Init(axis, axis);
           *--output_shape = axis;
         }
       } else {  // Shape2 is a scalar
-        auto axis = *--iter1;
+        ptrdiff_t axis = static_cast<ptrdiff_t>(*--iter1);
         iterator1_.Init(axis, axis);
         iterator2_.Init(1, axis);
         *--output_shape = axis;
@@ -554,12 +554,12 @@ struct Broadcaster {
       index++;  // Manually increment since we processed one axis
     } else {
       for (; index < dimension_count_min; index++) {
-        auto axis1 = *--iter1;
-        auto axis2 = *--iter2;
+        ptrdiff_t axis1 = static_cast<ptrdiff_t>(*--iter1);
+        ptrdiff_t axis2 = static_cast<ptrdiff_t>(*--iter2);
 
-        auto largest = std::max(axis1, axis2);
-        auto smallest = std::min(axis1, axis2);
-        auto dim_to_use = largest;
+        ptrdiff_t largest = std::max<ptrdiff_t>(axis1, axis2);
+        ptrdiff_t smallest = std::min<ptrdiff_t>(axis1, axis2);
+        ptrdiff_t dim_to_use = largest;
 
         if (smallest == 0) {
           ORT_ENFORCE(largest <= 1, "Can broadcast 0 by 0 or 1. ", largest, " is invalid.");
@@ -580,12 +580,12 @@ struct Broadcaster {
     }
 
     for (; index < dimension_count_min; index++) {
-      auto axis1 = *--iter1;
-      auto axis2 = *--iter2;
+      ptrdiff_t axis1 = static_cast<ptrdiff_t>(*--iter1);
+      ptrdiff_t axis2 = static_cast<ptrdiff_t>(*--iter2);
 
-      auto largest = std::max(axis1, axis2);
-      auto smallest = std::min(axis1, axis2);
-      auto dim_to_use = largest;
+      ptrdiff_t largest = std::max(axis1, axis2);
+      ptrdiff_t smallest = std::min(axis1, axis2);
+      ptrdiff_t dim_to_use = largest;
 
       if (smallest == 0) {
         ORT_ENFORCE(largest <= 1, "Can broadcast 0 by 0 or 1. ", largest, " is invalid.");
@@ -604,12 +604,12 @@ struct Broadcaster {
     // If one shape is bigger than another we need to broadcast the smaller onto the bigger from this point on
     for (; index < dimension_count_max; index++) {
       if (dimension_count_max == shape2.size()) {
-        auto axis = *--iter2;
+        ptrdiff_t axis = static_cast<ptrdiff_t>(*--iter2);
         iterator1_.Append(1, axis);
         iterator2_.Append(axis, axis);
         *--output_shape = axis;
       } else {
-        auto axis = *--iter1;
+        ptrdiff_t axis = static_cast<ptrdiff_t>(*--iter1);
         iterator1_.Append(axis, axis);
         iterator2_.Append(1, axis);
         *--output_shape = axis;
@@ -710,11 +710,11 @@ struct InputBroadcaster {
 };
 
 struct OutputBroadcaster {
-  OutputBroadcaster(size_t span_size, Tensor& tensor, int64_t start_offset = 0, int64_t end_offset = 0)
+  OutputBroadcaster(size_t span_size, Tensor& tensor, ptrdiff_t start_offset = 0, ptrdiff_t end_offset = 0)
       : element_size_(tensor.DataType()->Size()),
         span_size_(span_size) {
-    int64_t len = tensor.Shape().Size();
-    int64_t real_end = (end_offset <= 0) ? len : end_offset;
+    ptrdiff_t len = gsl::narrow<ptrdiff_t>(tensor.Shape().Size());
+    ptrdiff_t real_end = (end_offset <= 0) ? len : end_offset;
     if (start_offset != 0 || end_offset != 0) {  // Keep original semantic
       ORT_ENFORCE(start_offset >= 0 && real_end >= 0 && start_offset <= real_end && real_end <= len,
                   "Invalid start/ending offset [", start_offset, ",", real_end, ") for tensor of length:", len);

--- a/onnxruntime/core/providers/cpu/nn/batch_norm.h
+++ b/onnxruntime/core/providers/cpu/nn/batch_norm.h
@@ -24,6 +24,7 @@
 #include "core/framework/tensor.h"
 #include "core/util/math_cpuonly.h"
 #include "core/providers/cpu/nn/batch_norm_helper.h"
+#include <safeint/SafeInt.hpp>
 
 namespace onnxruntime {
 
@@ -60,7 +61,7 @@ class BatchNorm : public OpKernel {
     // calculate sample_size (per individual channel)
     size_t sample_size = 1;
     for (size_t i = 2; i < dims_vec.size(); ++i) {
-      sample_size *= dims_vec[i];
+      sample_size *= gsl::narrow<size_t>(dims_vec[i]);
     }
 
     // calculate sample_size (including all channels)

--- a/onnxruntime/core/providers/cpu/object_detection/non_max_suppression.cc
+++ b/onnxruntime/core/providers/cpu/object_detection/non_max_suppression.cc
@@ -15,7 +15,10 @@ limitations under the License.
 #include "non_max_suppression_helper.h"
 #include <queue>
 #include <utility>
-
+//TODO:fix the warnings
+#ifdef _MSC_VER
+#pragma warning(disable : 4244)
+#endif
 namespace onnxruntime {
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(
@@ -180,7 +183,7 @@ Status NonMaxSuppression::Compute(OpKernelContext* ctx) const {
 
   std::vector<SelectedIndex> selected_indices;
   std::vector<BoxInfo> selected_boxes_inside_class;
-  selected_boxes_inside_class.reserve(std::min(max_output_boxes_per_class, pc.num_boxes_));
+  selected_boxes_inside_class.reserve(std::min<size_t>(static_cast<size_t>(max_output_boxes_per_class), pc.num_boxes_));
 
   for (int64_t batch_index = 0; batch_index < pc.num_batches_; ++batch_index) {
     for (int64_t class_index = 0; class_index < pc.num_classes_; ++class_index) {

--- a/onnxruntime/core/providers/cpu/object_detection/non_max_suppression_helper.h
+++ b/onnxruntime/core/providers/cpu/object_detection/non_max_suppression_helper.h
@@ -30,7 +30,7 @@ struct PrepareContext {
   const float* iou_threshold_ = nullptr;
   int64_t num_batches_ = 0;
   int64_t num_classes_ = 0;
-  int64_t num_boxes_ = 0;
+  int num_boxes_ = 0;
 };
 
 struct SelectedIndex {

--- a/onnxruntime/core/providers/cpu/tensor/pad.cc
+++ b/onnxruntime/core/providers/cpu/tensor/pad.cc
@@ -177,7 +177,7 @@ static void FlattenInnerShape(const std::vector<int64_t>& input_dims, const std:
 
   // Find all inner most dimensions that can be flattened.
   do {
-    inner_size *= input_dims[inner_axis];
+    inner_size *= static_cast<size_t>(input_dims[inner_axis]);
 
     if (inner_axis == 0)
       break;

--- a/onnxruntime/core/providers/cpu/tensor/transpose.cc
+++ b/onnxruntime/core/providers/cpu/tensor/transpose.cc
@@ -235,10 +235,10 @@ static Status DoUntypedTranspose(const std::vector<size_t>& permutations, const 
   for (int64_t i = rank - 1; i >= 0; --i) {
     int64_t input_axis = permutations[i];
     if (is_suffix && (input_axis == i)) {
-      suffix_blocksize *= input_dims[input_axis];
+      suffix_blocksize *= static_cast<size_t>(input_dims[input_axis]);
     } else {
       is_suffix = false;
-      prefix_blocksize *= input_dims[input_axis];
+      prefix_blocksize *= static_cast<size_t>(input_dims[input_axis]);
       ++num_axes_in_prefix;
     }
   }

--- a/onnxruntime/core/providers/cuda/cu_inc/variadic_elementwise_impl.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/variadic_elementwise_impl.cuh
@@ -68,7 +68,7 @@ void VariadicElementWiseNoBroadcastInputBatchImpl(
     T* output) {
   constexpr int32_t elements_per_thread = GridDim::maxElementsPerThread;
   constexpr int32_t threads_per_block = GridDim::maxThreadsPerBlock;
-  const int32_t blocks_per_grid = CeilDiv(N, elements_per_thread * threads_per_block);
+  const int32_t blocks_per_grid = static_cast<int32_t>(CeilDiv(N, elements_per_thread * threads_per_block));
   VariadicElementWiseNoBroadcastInputBatchKernel<T, Func, max_input_batch_size, elements_per_thread>
       <<<blocks_per_grid, threads_per_block>>>(func, N, inputs, output);
 }

--- a/onnxruntime/core/providers/cuda/math/cumsum.cc
+++ b/onnxruntime/core/providers/cuda/math/cumsum.cc
@@ -82,7 +82,6 @@ Status CumSum::ComputeInternal(OpKernelContext* ctx) const {
                fast_divmod_input_stride_along_axis,
                reinterpret_cast<typename ToCudaType<float>::MappedType*>(output.MutableData<float>()),
                output_shape.Size(),
-               input->DataType()->Size(),
                exclusive_,
                reverse_);
   } else if (input->IsDataType<double>()) {
@@ -91,7 +90,6 @@ Status CumSum::ComputeInternal(OpKernelContext* ctx) const {
                fast_divmod_input_stride_along_axis,
                reinterpret_cast<typename ToCudaType<double>::MappedType*>(output.MutableData<double>()),
                output_shape.Size(),
-               input->DataType()->Size(),
                exclusive_,
                reverse_);
   } else if (input->IsDataType<int32_t>()) {
@@ -100,7 +98,6 @@ Status CumSum::ComputeInternal(OpKernelContext* ctx) const {
                fast_divmod_input_stride_along_axis,
                reinterpret_cast<typename ToCudaType<int32_t>::MappedType*>(output.MutableData<int32_t>()),
                output_shape.Size(),
-               input->DataType()->Size(),
                exclusive_,
                reverse_);
   } else if (input->IsDataType<int64_t>()) {
@@ -109,7 +106,6 @@ Status CumSum::ComputeInternal(OpKernelContext* ctx) const {
                fast_divmod_input_stride_along_axis,
                reinterpret_cast<typename ToCudaType<int64_t>::MappedType*>(output.MutableData<int64_t>()),
                output_shape.Size(),
-               input->DataType()->Size(),
                exclusive_,
                reverse_);
   } else if (input->IsDataType<uint32_t>()) {
@@ -118,7 +114,6 @@ Status CumSum::ComputeInternal(OpKernelContext* ctx) const {
                fast_divmod_input_stride_along_axis,
                reinterpret_cast<typename ToCudaType<uint32_t>::MappedType*>(output.MutableData<uint32_t>()),
                output_shape.Size(),
-               input->DataType()->Size(),
                exclusive_,
                reverse_);
   } else if (input->IsDataType<uint64_t>()) {
@@ -127,7 +122,6 @@ Status CumSum::ComputeInternal(OpKernelContext* ctx) const {
                fast_divmod_input_stride_along_axis,
                reinterpret_cast<typename ToCudaType<uint64_t>::MappedType*>(output.MutableData<uint64_t>()),
                output_shape.Size(),
-               input->DataType()->Size(),
                exclusive_,
                reverse_);
   } else if (input->IsDataType<MLFloat16>()) {
@@ -136,7 +130,6 @@ Status CumSum::ComputeInternal(OpKernelContext* ctx) const {
                fast_divmod_input_stride_along_axis,
                reinterpret_cast<typename ToCudaType<MLFloat16>::MappedType*>(output.MutableData<MLFloat16>()),
                output_shape.Size(),
-               input->DataType()->Size(),
                exclusive_,
                reverse_);
   } else {

--- a/onnxruntime/core/providers/cuda/math/cumsum_impl.cu
+++ b/onnxruntime/core/providers/cuda/math/cumsum_impl.cu
@@ -69,16 +69,15 @@ __global__ void _CumSumKernel(
   output_data[indices_index] = sum;
 }
 
-template<typename T>
+template <typename T>
 void CumSumImpl(
     const T* input_data,
     const fast_divmod& input_dim_along_axis,
     const fast_divmod& input_stride_along_axis,
     T* output_data,
-    const int64_t output_size,
-    const size_t element_size,
-    const bool exclusive,
-    const bool reverse) {
+    int64_t output_size,
+    bool exclusive,
+    bool reverse) {
   if (output_size > 0) {
     int blocksPerGrid = static_cast<int>((output_size + GridDim::maxThreadsPerBlock - 1) / GridDim::maxThreadsPerBlock);
 
@@ -97,70 +96,63 @@ template void CumSumImpl<int32_t>(
     const fast_divmod& input_dim_along_axis,
     const fast_divmod& input_stride_along_axis,
     int32_t* output_data,
-    const int64_t output_size,
-    const size_t element_size,
-    const bool exclusive,
-    const bool reverse);
+    int64_t output_size,
+    bool exclusive,
+    bool reverse);
 
 template void CumSumImpl<int64_t>(
     const int64_t* input_data,
     const fast_divmod& input_dim_along_axis,
     const fast_divmod& input_stride_along_axis,
     int64_t* output_data,
-    const int64_t output_size,
-    const size_t element_size,
-    const bool exclusive,
-    const bool reverse);
+    int64_t output_size,
+    bool exclusive,
+    bool reverse);
 
 template void CumSumImpl<uint32_t>(
     const uint32_t* input_data,
     const fast_divmod& input_dim_along_axis,
     const fast_divmod& input_stride_along_axis,
     uint32_t* output_data,
-    const int64_t output_size,
-    const size_t element_size,
-    const bool exclusive,
-    const bool reverse);
+    int64_t output_size,
+    bool exclusive,
+    bool reverse);
 
 template void CumSumImpl<uint64_t>(
     const uint64_t* input_data,
     const fast_divmod& input_dim_along_axis,
     const fast_divmod& input_stride_along_axis,
     uint64_t* output_data,
-    const int64_t output_size,
-    const size_t element_size,
-    const bool exclusive,
-    const bool reverse);
+    int64_t output_size,
+    bool exclusive,
+    bool reverse);
 
 template void CumSumImpl<float>(
     const float* input_data,
     const fast_divmod& input_dim_along_axis,
     const fast_divmod& input_stride_along_axis,
     float* output_data,
-    const int64_t output_size,
-    const size_t element_size,
-    const bool exclusive,
-    const bool reverse);
+    int64_t output_size,
+    bool exclusive,
+    bool reverse);
 
 template void CumSumImpl<double>(
     const double* input_data,
     const fast_divmod& input_dim_along_axis,
     const fast_divmod& input_stride_along_axis,
     double* output_data,
-    const int64_t output_size,
-    const size_t element_size,
-    const bool exclusive,
-    const bool reverse);
+    int64_t output_size,
+    bool exclusive,
+    bool reverse);
 
 template void CumSumImpl<half>(
     const half* input_data,
     const fast_divmod& input_dim_along_axis,
     const fast_divmod& input_stride_along_axis,
     half* output_data,
-    const int64_t output_size,
-    const size_t element_size,
-    const bool exclusive,
-    const bool reverse);
+    int64_t output_size,
+    bool exclusive,
+    bool reverse);
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/cumsum_impl.h
+++ b/onnxruntime/core/providers/cuda/math/cumsum_impl.h
@@ -15,10 +15,9 @@ void CumSumImpl(
     const fast_divmod& input_dim_along_axis,
     const fast_divmod& input_stride_along_axis,
     T* output_data,
-    const int64_t output_size,
-    const size_t element_size,
-    const bool exclusive,
-    const bool reverse);
+    int64_t output_size,
+    bool exclusive,
+    bool reverse);
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/topk_impl.cu
+++ b/onnxruntime/core/providers/cuda/math/topk_impl.cu
@@ -10,7 +10,10 @@
 #include "cub/util_allocator.cuh"
 #include "cub/device/device_radix_sort.cuh"
 #include <limits>
-
+//TODO:fix the warnings
+#ifdef _MSC_VER
+#pragma warning(disable : 4244)
+#endif
 namespace onnxruntime {
 namespace cuda {
 

--- a/onnxruntime/core/providers/cuda/object_detection/non_max_suppression_impl.cu
+++ b/onnxruntime/core/providers/cuda/object_detection/non_max_suppression_impl.cu
@@ -25,7 +25,10 @@ limitations under the License.
 #include <thrust/execution_policy.h>
 
 #include <cub/cub.cuh>
-
+//TODO:fix the warnings
+#ifdef _MSC_VER
+#pragma warning(disable : 4244)
+#endif
 namespace onnxruntime {
 namespace cuda {
 

--- a/onnxruntime/core/providers/cuda/tensor/compress_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/compress_impl.cu
@@ -4,7 +4,10 @@
 #include "core/providers/cuda/cu_inc/common.cuh"
 #include "core/providers/cuda/cuda_common.h"
 #include "compress_impl.h"
-
+//TODO:fix the warnings
+#ifdef _MSC_VER
+#pragma warning(disable : 4244)
+#endif
 #include <thrust/scan.h>
 #include <thrust/execution_policy.h>
 

--- a/onnxruntime/core/providers/cuda/tensor/gather_nd_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/gather_nd_impl.cu
@@ -61,7 +61,7 @@ void ComputeSliceOffsetsImpl(
     const int64_t* const sizes_from_slice_dims_data,  // num_slice_dims elements
     const TIndex* const indices_data,                 // num_slices * num_slice_dims elements
     int64_t* const input_slice_offsets_data) {        // num_slices elements
-  const auto blocks_per_grid = CeilDiv(num_slices, GridDim::maxThreadsPerBlock);
+  const unsigned int blocks_per_grid = static_cast<unsigned int>(CeilDiv(num_slices, GridDim::maxThreadsPerBlock));
   _ComputeSliceOffsetsKernel<<<blocks_per_grid, GridDim::maxThreadsPerBlock>>>(
       batch_dims,
       input_dims,
@@ -81,7 +81,7 @@ void GatherNDImpl(
     void* output_data,
     const size_t slice_size,
     const int64_t* input_slice_offsets_data) {
-  const auto blocks_per_grid = CeilDiv(num_slices * slice_size, GridDim::maxThreadsPerBlock);
+  const unsigned int blocks_per_grid = static_cast<unsigned int>(CeilDiv(num_slices * slice_size, GridDim::maxThreadsPerBlock));
   _GatherNDKernel<T><<<blocks_per_grid, GridDim::maxThreadsPerBlock, 0>>>(
       num_slices, static_cast<const T*>(input_data), static_cast<T*>(output_data), slice_size, input_slice_offsets_data);
 }

--- a/onnxruntime/core/providers/cuda/tensor/nonzero_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/nonzero_impl.cu
@@ -11,8 +11,9 @@ namespace cuda {
 
 static const int NONZERO_THREADS_PER_BLOCK = GridDim::maxThreadsPerBlock;
 
+//TODO:check overflow
 int NonZeroCalcBlockCount(int64_t x_size) {
-  return CeilDiv(x_size, NONZERO_THREADS_PER_BLOCK);
+  return static_cast<int>(CeilDiv(x_size, NONZERO_THREADS_PER_BLOCK));
 }
 
 cudaError_t NonZeroCalcPrefixSumTempStorageBytes(

--- a/onnxruntime/core/providers/cuda/tensor/quantize_linear.cu
+++ b/onnxruntime/core/providers/cuda/tensor/quantize_linear.cu
@@ -54,7 +54,7 @@ Status CudaQuantizeLinear(const InT* input, OutT* output, const InT* scale, cons
       output,
       scale,
       zero_point,
-      num_of_element,
+      static_cast<int>(num_of_element),
       Round<InT>());
   return Status::OK();
 }
@@ -85,7 +85,7 @@ Status CudaDequantizeLinear(const InT* input, OutT* output, const OutT* scale, c
       output,
       scale,
       zero_point,
-      num_of_element);
+      static_cast<int>(num_of_element));
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/cuda/tensor/scatter_elements_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_elements_impl.cu
@@ -137,7 +137,7 @@ static int CompactInputIndicesDims(
       }
     }
   }
-  new_axis = eff_input_dims.size() - new_axis;
+  new_axis = static_cast<int>(eff_input_dims.size()) - new_axis;
   std::reverse(eff_input_dims.begin(), eff_input_dims.end());
   std::reverse(eff_indices_dims.begin(), eff_indices_dims.end());
   return new_axis;
@@ -155,7 +155,7 @@ Status ScatterElementsImpl2D(
     T* output_data,
     const FuncT& func) {
   int blocksPerGrid = gsl::narrow_cast<int>(CeilDiv(indices_size, GridDim::maxThreadsPerBlock));
-  fast_divmod indices_stride_row(indices_dims[1]);
+  fast_divmod indices_stride_row(static_cast<int>(indices_dims[1]));
   if (axis == 0) {
     _ScatterElementsKernel2D<T, Tin, true, FuncT><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0>>>(
         gsl::narrow_cast<int>(input_dims[0]), input_data,

--- a/onnxruntime/core/providers/cuda/tensor/transpose.cc
+++ b/onnxruntime/core/providers/cuda/tensor/transpose.cc
@@ -170,7 +170,7 @@ Status Transpose::DoTranspose(const cudaDeviceProp& prop,
       tmp_output_strides[i] = new_output_strides[new_permutations[i]];
     }
     return Transpose4DImpl(element_size, input_shape, tmp_input_strides, input.DataRaw(),
-                           tmp_output_strides, output.MutableDataRaw(), output.Shape().Size());
+                           tmp_output_strides, output.MutableDataRaw(), gsl::narrow<int>(output.Shape().Size()));
   }
 
   // General cases
@@ -185,7 +185,7 @@ Status Transpose::DoTranspose(const cudaDeviceProp& prop,
   }
 
   auto status = TransposeImpl(element_size, new_rank, input_strides, input.DataRaw(),
-                              output_strides, output.MutableDataRaw(), output.Shape().Size());
+                              output_strides, output.MutableDataRaw(), gsl::narrow<int>(output.Shape().Size()));
 
   return status;
 }

--- a/onnxruntime/core/providers/cuda/tensor/transpose_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/transpose_impl.h
@@ -17,8 +17,8 @@ bool CanDoTranspose4D(const cudaDeviceProp& prop,
                       const std::vector<int64_t>& input_dims,
                       const std::vector<size_t>& permutations);
 Status Transpose4DImpl(size_t element_size, const TArray<int64_t>& input_shape, const TArray<int64_t>& input_strides, const void* input_data,
-                       const TArray<int64_t>& output_strides, void* output_data, int64_t N);
+                       const TArray<int64_t>& output_strides, void* output_data, int N);
 Status TransposeImpl(size_t element_size, int32_t shape_rank, const TArray<int64_t>& input_strides,
-                     const void* input_data, const TArray<fast_divmod>& fdm_output_strides, void* output_data, int64_t N);
+                     const void* input_data, const TArray<fast_divmod>& fdm_output_strides, void* output_data, int N);
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -407,10 +407,10 @@ namespace {
 // provider either model_path, or modal_data + model_data_length.
 static ORT_STATUS_PTR CreateSessionAndLoadModel(_In_ const OrtSessionOptions* options,
                                                 _In_ const OrtEnv* env,
-                                                _In_ const ORTCHAR_T* model_path,
-                                                _In_ const void* model_data,
-                                                _In_ size_t model_data_length,
-                                                _Outptr_ std::unique_ptr<onnxruntime::InferenceSession>& sess) {
+                                                _In_opt_z_ const ORTCHAR_T* model_path,
+                                                _In_opt_ const void* model_data,
+                                                size_t model_data_length,
+                                                std::unique_ptr<onnxruntime::InferenceSession>& sess) {
   // quick check here to decide load path. InferenceSession will provide error message for invalid values.
   // TODO: Could move to a helper
   const Env& os_env = Env::Default();  // OS environment (!= ORT environment)
@@ -605,8 +605,8 @@ struct OrtIoBinding {
   OrtIoBinding& operator=(const OrtIoBinding&) = delete;
 };
 
-ORT_API_STATUS_IMPL(OrtApis::RunWithBinding, _Inout_ OrtSession* sess, _In_opt_ const OrtRunOptions* run_options,
-                    const OrtIoBinding* binding_ptr) {
+ORT_API_STATUS_IMPL(OrtApis::RunWithBinding, _Inout_ OrtSession* sess, _In_ const OrtRunOptions* run_options,
+                    _In_ const OrtIoBinding* binding_ptr) {
   API_IMPL_BEGIN
   auto session = reinterpret_cast<::onnxruntime::InferenceSession*>(sess);
   auto status = session->Run(*run_options, *binding_ptr->binding_);
@@ -665,7 +665,7 @@ ORT_API_STATUS_IMPL(OrtApis::BindOutputToDevice, _Inout_ OrtIoBinding* binding_p
 }
 
 ORT_API_STATUS_IMPL(OrtApis::GetBoundOutputNames, _In_ const OrtIoBinding* binding_ptr, _In_ OrtAllocator* allocator,
-                    _Out_ char** buffer, _Out_writes_all_(count) size_t** lengths, _Out_ size_t* count) {
+                    _Out_ char** buffer, _Outptr_result_maybenull_ size_t** lengths, _Out_ size_t* count) {
   API_IMPL_BEGIN
   const auto& output_names = binding_ptr->binding_->GetOutputNames();
   if (output_names.empty()) {
@@ -712,7 +712,7 @@ ORT_API_STATUS_IMPL(OrtApis::GetBoundOutputNames, _In_ const OrtIoBinding* bindi
 }
 
 ORT_API_STATUS_IMPL(OrtApis::GetBoundOutputValues, _In_ const OrtIoBinding* binding_ptr, _In_ OrtAllocator* allocator,
-                    _Out_writes_all_(output_count) OrtValue*** output, _Out_ size_t* output_count) {
+                    _Outptr_result_maybenull_ OrtValue*** output, _Out_ size_t* output_count) {
   API_IMPL_BEGIN
   const auto& outputs = binding_ptr->binding_->GetOutputs();
   if (outputs.empty()) {
@@ -1713,14 +1713,16 @@ ORT_API_STATUS_IMPL(OrtApis::GetOpaqueValue, _In_ const char* domain_name, _In_ 
 ORT_API_STATUS_IMPL(OrtApis::GetAvailableProviders, _Outptr_ char*** out_ptr,
                     _In_ int* providers_length) {
   API_IMPL_BEGIN
+  //TODO: there is no need to manually malloc/free these memory, it is insecure
+  //and inefficient. Instead, the implementation could scan the array twice,
+  //and use a single string object to hold all the names.
   const size_t MAX_LEN = 30;
   const auto& available_providers = GetAvailableExecutionProviderNames();
   const int available_count = gsl::narrow<int>(available_providers.size());
-  char** const out = (char**)malloc(available_count * sizeof(char*));
+  char** const out = new char*[available_count];
   if (out) {
     for (int i = 0; i < available_count; i++) {
-      out[i] = (char*)malloc((MAX_LEN + 1) * sizeof(char));
-      if (out[i]) {
+      out[i] = new char[MAX_LEN + 1];
 #ifdef _MSC_VER
         strncpy_s(out[i], MAX_LEN, available_providers[i].c_str(), MAX_LEN);
         out[i][MAX_LEN] = '\0';
@@ -1730,7 +1732,6 @@ ORT_API_STATUS_IMPL(OrtApis::GetAvailableProviders, _Outptr_ char*** out_ptr,
         strncpy(out[i], available_providers[i].c_str(), MAX_LEN);
         out[i][MAX_LEN] = '\0';
 #endif
-      }
     }
   }
   *providers_length = available_count;
@@ -1739,16 +1740,15 @@ ORT_API_STATUS_IMPL(OrtApis::GetAvailableProviders, _Outptr_ char*** out_ptr,
   return nullptr;
 }
 
+//TODO: we don't really need the second parameter
 ORT_API_STATUS_IMPL(OrtApis::ReleaseAvailableProviders, _In_ char** ptr,
                     _In_ int providers_length) {
   API_IMPL_BEGIN
   if (ptr) {
     for (int i = 0; i < providers_length; i++) {
-      if (ptr[i]) {
-        free(ptr[i]);
-      }
+      delete[] ptr[i];
     }
-    free(ptr);
+    delete[] ptr;
   }
   API_IMPL_END
   return NULL;
@@ -1807,7 +1807,7 @@ ORT_API_STATUS_IMPL(OrtApis::SetLanguageProjection, _In_ const OrtEnv* ort_env, 
   API_IMPL_END
 }
 
-ORT_API_STATUS_IMPL(OrtApis::SessionGetProfilingStartTimeNs, _In_ const OrtSession* sess, _Outptr_ uint64_t* out) {
+ORT_API_STATUS_IMPL(OrtApis::SessionGetProfilingStartTimeNs, _In_ const OrtSession* sess, _Out_ uint64_t* out) {
   API_IMPL_BEGIN
   const auto* session = reinterpret_cast<const ::onnxruntime::InferenceSession*>(sess);
   auto profiling_start_time = session->GetProfiling().GetStartTimeNs();

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -209,7 +209,7 @@ ORT_API_STATUS_IMPL(CreateAllocator, const OrtSession* sess, const OrtMemoryInfo
                     _Outptr_ OrtAllocator** out);
 ORT_API(void, ReleaseAllocator, _Frees_ptr_opt_ OrtAllocator* allocator);
 
-ORT_API_STATUS_IMPL(RunWithBinding, _Inout_ OrtSession* sess, _In_opt_ const OrtRunOptions* run_options, _In_ const OrtIoBinding* binding_ptr);
+ORT_API_STATUS_IMPL(RunWithBinding, _Inout_ OrtSession* sess, _In_ const OrtRunOptions* run_options, _In_ const OrtIoBinding* binding_ptr);
 
 ORT_API_STATUS_IMPL(CreateIoBinding, _Inout_ OrtSession* sess, _Outptr_ OrtIoBinding** out);
 ORT_API(void, ReleaseIoBinding, _Frees_ptr_opt_ OrtIoBinding* allocator);
@@ -218,9 +218,9 @@ ORT_API_STATUS_IMPL(BindInput, _Inout_ OrtIoBinding* binding_ptr, _In_ const cha
 ORT_API_STATUS_IMPL(BindOutput, _Inout_ OrtIoBinding* binding_ptr, _In_ const char* name, _In_ const OrtValue* val_ptr);
 ORT_API_STATUS_IMPL(BindOutputToDevice, _Inout_ OrtIoBinding* binding_ptr, _In_ const char* name, _In_ const OrtMemoryInfo* val_ptr);
 ORT_API_STATUS_IMPL(GetBoundOutputNames, _In_ const OrtIoBinding* binding_ptr, _In_ OrtAllocator* allocator,
-                    _Out_ char** buffer, _Out_writes_all_(count) size_t** lengths, _Out_ size_t* count);
+                    _Out_ char** buffer, _Outptr_result_maybenull_ size_t** lengths, _Out_ size_t* count);
 ORT_API_STATUS_IMPL(GetBoundOutputValues, _In_ const OrtIoBinding* binding_ptr, _In_ OrtAllocator* allocator,
-                    _Out_writes_all_(output_count) OrtValue*** output, _Out_ size_t* output_count);
+                    _Outptr_result_maybenull_ OrtValue*** output, _Out_ size_t* output_count);
 
 ORT_API(void, ClearBoundInputs, _Inout_ OrtIoBinding* binding_ptr);
 ORT_API(void, ClearBoundOutputs, _Inout_ OrtIoBinding* binding_ptr);
@@ -238,12 +238,12 @@ ORT_API_STATUS_IMPL(TensorAt, _Inout_ OrtValue* value, const int64_t* location_v
 ORT_API_STATUS_IMPL(CreateAndRegisterAllocator, _Inout_ OrtEnv* env, _In_ const OrtMemoryInfo* mem_info, _In_ const OrtArenaCfg* arena_cfg);
 
 ORT_API_STATUS_IMPL(SetLanguageProjection, _In_ const OrtEnv* ort_env, _In_ OrtLanguageProjection projection);
-ORT_API_STATUS_IMPL(SessionGetProfilingStartTimeNs, _In_ const OrtSession* sess, _Outptr_ uint64_t* out);
+ORT_API_STATUS_IMPL(SessionGetProfilingStartTimeNs, _In_ const OrtSession* sess, _Out_ uint64_t* out);
 
 ORT_API_STATUS_IMPL(SetGlobalIntraOpNumThreads, _Inout_ OrtThreadingOptions* tp_options, int intra_op_num_threads);
 ORT_API_STATUS_IMPL(SetGlobalInterOpNumThreads, _Inout_ OrtThreadingOptions* tp_options, int inter_op_num_threads);
 ORT_API_STATUS_IMPL(SetGlobalSpinControl, _Inout_ OrtThreadingOptions* tp_options, int allow_spinning);
-ORT_API_STATUS_IMPL(AddInitializer, _Inout_ OrtSessionOptions* options, _In_ const char* name,
+ORT_API_STATUS_IMPL(AddInitializer, _Inout_ OrtSessionOptions* options, _In_z_ const char* name,
                     _In_ const OrtValue* val);
 
 ORT_API_STATUS_IMPL(SessionOptionsAppendExecutionProvider_CUDA,

--- a/onnxruntime/core/util/math.h
+++ b/onnxruntime/core/util/math.h
@@ -95,9 +95,9 @@ void Scale(int N, const float* alpha, const T* x, T* y, Provider* provider);
 
 template <typename T>
 void MatMul(
-    int M,
-    int N,
-    int K,
+    ptrdiff_t M,
+    ptrdiff_t N,
+    ptrdiff_t K,
     const T* A,
     const T* B,
     T* C, concurrency::ThreadPool* threadpool);
@@ -108,9 +108,9 @@ template <typename T, class Provider>
 void Gemm(
     CBLAS_TRANSPOSE TransA,
     CBLAS_TRANSPOSE TransB,
-    int64_t M,
-    int64_t N,
-    int64_t K,
+    ptrdiff_t M,
+    ptrdiff_t N,
+    ptrdiff_t K,
     T alpha,
     const T* A,
     const T* B,
@@ -124,9 +124,9 @@ template <typename T, class Provider>
 void GemmEx(
     CBLAS_TRANSPOSE TransA,
     CBLAS_TRANSPOSE TransB,
-    int M,
-    int N,
-    int K,
+    ptrdiff_t M,
+    ptrdiff_t N,
+    ptrdiff_t K,
     T alpha,
     const T* A,
     int lda,
@@ -154,7 +154,7 @@ void Gemv(
     Provider* provider);
 
 template <typename T, class Provider>
-void Set(int64_t N, T alpha, T* X, Provider* provider);
+void Set(ptrdiff_t N, T alpha, T* X, Provider* provider);
 
 template <typename T, class Provider>
 void Dot(int N, const T* a, const T* b, T* y, Provider* provider);
@@ -200,7 +200,7 @@ struct Im2col<T, StorageOrder::NCHW> {
       const int64_t* stride,
       const int64_t* dilation,
       const int64_t* pad,
-      int64_t rank,
+      ptrdiff_t rank,
       T* data_col,
       bool accumulate_output = false,
       T padding_value = 0);
@@ -237,7 +237,7 @@ struct Im2col<T, StorageOrder::NHWC> {
       const int64_t* stride,
       const int64_t* dilation,
       const int64_t* pad,
-      int64_t rank,
+      ptrdiff_t rank,
       T* data_col,
       T padding_value = 0);
 };
@@ -253,7 +253,7 @@ void Col2imNd(
     const int64_t* stride,
     const int64_t* dilation,
     const int64_t* pad,
-    int64_t N,
+    ptrdiff_t N,
     T* data_img,
     Provider* provider);
 

--- a/onnxruntime/core/util/math_cpu.cc
+++ b/onnxruntime/core/util/math_cpu.cc
@@ -41,11 +41,11 @@ namespace onnxruntime {
 namespace math {
 
 // MatMul implementation purely based on Eigen.
-#define EIGEN_MATMUL_FUNCTION(T)                                                                \
-  template <>                                                                                   \
-  void MatMul<T>(int M, int N, int K, const T* A, const T* B, T* C, concurrency::ThreadPool*) { \
-    auto C_mat = EigenMatrixMap<T>(C, N, M);                                                    \
-    C_mat.noalias() = ConstEigenMatrixMap<T>(B, N, K) * ConstEigenMatrixMap<T>(A, K, M);        \
+#define EIGEN_MATMUL_FUNCTION(T)                                                                                  \
+  template <>                                                                                                     \
+  void MatMul<T>(ptrdiff_t M, ptrdiff_t N, ptrdiff_t K, const T* A, const T* B, T* C, concurrency::ThreadPool*) { \
+    auto C_mat = EigenMatrixMap<T>(C, N, M);                                                                      \
+    C_mat.noalias() = ConstEigenMatrixMap<T>(B, N, K) * ConstEigenMatrixMap<T>(A, K, M);                          \
   }
 
 EIGEN_MATMUL_FUNCTION(int32_t)
@@ -76,8 +76,8 @@ EIGEN_MATMUL_FUNCTION(uint64_t)
 // (transpose) if the argument TransA or TransB is set to CblasNoTrans or
 // CblasTrans, respectively, for each of A and B.
 template <>
-void Gemm<float, ThreadPool>(const CBLAS_TRANSPOSE TransA, const CBLAS_TRANSPOSE TransB, const int64_t M,
-                             const int64_t N, const int64_t K, float alpha, const float* A, const float* B, float beta,
+void Gemm<float, ThreadPool>(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, ptrdiff_t M,
+                             ptrdiff_t N, ptrdiff_t K, float alpha, const float* A, const float* B, float beta,
                              float* C, ThreadPool* threadpool) {
   int lda = static_cast<int>((TransA == CblasNoTrans) ? K : M);
   int ldb = static_cast<int>((TransB == CblasNoTrans) ? N : K);
@@ -86,8 +86,8 @@ void Gemm<float, ThreadPool>(const CBLAS_TRANSPOSE TransA, const CBLAS_TRANSPOSE
 
 #ifdef MLAS_SUPPORTS_GEMM_DOUBLE
 template <>
-void Gemm<double, ThreadPool>(const CBLAS_TRANSPOSE TransA, const CBLAS_TRANSPOSE TransB, const int64_t M,
-                              const int64_t N, const int64_t K, double alpha, const double* A, const double* B, double beta,
+void Gemm<double, ThreadPool>(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, ptrdiff_t M,
+                              ptrdiff_t N, ptrdiff_t K, double alpha, const double* A, const double* B, double beta,
                               double* C, ThreadPool* threadpool) {
   int lda = static_cast<int>((TransA == CblasNoTrans) ? K : M);
   int ldb = static_cast<int>((TransB == CblasNoTrans) ? N : K);
@@ -95,8 +95,8 @@ void Gemm<double, ThreadPool>(const CBLAS_TRANSPOSE TransA, const CBLAS_TRANSPOS
 }
 #else
 template <>
-void Gemm<double, ThreadPool>(const CBLAS_TRANSPOSE TransA, const CBLAS_TRANSPOSE TransB, const int64_t M,
-                              const int64_t N, const int64_t K, double alpha, const double* A, const double* B, double beta,
+void Gemm<double, ThreadPool>(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, ptrdiff_t M,
+                              ptrdiff_t N, ptrdiff_t K, double alpha, const double* A, const double* B, double beta,
                               double* C, ThreadPool*) {
   auto C_mat = EigenMatrixMap<double>(C, N, M);
   if (beta == 0) {
@@ -140,13 +140,13 @@ void Gemm<double, ThreadPool>(const CBLAS_TRANSPOSE TransA, const CBLAS_TRANSPOS
 #endif
 
 template <>
-void MatMul<float>(int M, int N, int K, const float* A, const float* B, float* C, ThreadPool* threadpool) {
+void MatMul<float>(ptrdiff_t M, ptrdiff_t N, ptrdiff_t K, const float* A, const float* B, float* C, ThreadPool* threadpool) {
   MlasGemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.f, A, K, B, N, 0.f, C, N, threadpool);
 }
 
 #ifdef MLAS_SUPPORTS_GEMM_DOUBLE
 template <>
-void MatMul<double>(int M, int N, int K, const double* A, const double* B, double* C, ThreadPool* threadpool) {
+void MatMul<double>(ptrdiff_t M, ptrdiff_t N, ptrdiff_t K, const double* A, const double* B, double* C, ThreadPool* threadpool) {
   MlasGemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.f, A, K, B, N, 0.f, C, N, threadpool);
 }
 #else
@@ -154,7 +154,7 @@ EIGEN_MATMUL_FUNCTION(double)
 #endif
 
 template <>
-void GemmEx<float, ThreadPool>(const CBLAS_TRANSPOSE TransA, const CBLAS_TRANSPOSE TransB, int M, int N, int K,
+void GemmEx<float, ThreadPool>(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, ptrdiff_t M, ptrdiff_t N, ptrdiff_t K,
                                float alpha, const float* A, int lda, const float* B, int ldb, float beta, float* C,
                                int ldc, ThreadPool* threadpool) {
   MlasGemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc, threadpool);
@@ -256,14 +256,14 @@ SPECIALIZED_ROWWISEMAX(float)
 SPECIALIZED_ROWWISEMAX(double)
 #undef SPECIALIZED_ROWWISEMAX
 
-#define SPECIALIZED_SET(T)                                                       \
-  template <>                                                                    \
-  void Set<T, CPUMathUtil>(const int64_t N, const T alpha, T* Y, CPUMathUtil*) { \
-    if (alpha == (T)0) {                                                         \
-      memset(Y, 0, N * sizeof(T));                                               \
-    } else {                                                                     \
-      EigenVectorMap<T>(Y, N).setConstant(alpha);                                \
-    }                                                                            \
+#define SPECIALIZED_SET(T)                                                         \
+  template <>                                                                      \
+  void Set<T, CPUMathUtil>(const ptrdiff_t N, const T alpha, T* Y, CPUMathUtil*) { \
+    if (alpha == (T)0) {                                                           \
+      memset(Y, 0, N * sizeof(T));                                                 \
+    } else {                                                                       \
+      EigenVectorMap<T>(Y, N).setConstant(alpha);                                  \
+    }                                                                              \
   }
 
 SPECIALIZED_SET(float);
@@ -372,7 +372,7 @@ void Im2col<T, StorageOrder::NCHW>::operator()(
     const int64_t* stride,
     const int64_t* dilation,
     const int64_t* pad,
-    int64_t rank,
+    ptrdiff_t rank,
     T* data_col,
     bool accumulate_output,
     T padding_value) {
@@ -382,7 +382,7 @@ void Im2col<T, StorageOrder::NCHW>::operator()(
   for (int64_t c_col = 0; c_col < channels_col; ++c_col) {
     // Loop over spatial axes in reverse order to compute a per-axis offset.
     int64_t offset = c_col;
-    for (int64_t d_i = rank - 1; d_i >= 0; --d_i) {
+    for (ptrdiff_t d_i = rank - 1; d_i >= 0; --d_i) {
       if (d_i < rank - 1) {
         offset /= kernel_shape[d_i + 1];
       }
@@ -394,7 +394,7 @@ void Im2col<T, StorageOrder::NCHW>::operator()(
       int64_t index_col = c_col;
       int64_t index_im = c_col / kernel_size;
       bool is_padding = false;
-      for (int64_t d_i = 0; d_i < rank; ++d_i) {
+      for (ptrdiff_t d_i = 0; d_i < rank; ++d_i) {
         int64_t d = d_iter[d_i];
         int64_t d_im = d * stride[d_i] - pad[d_i] + d_offset[d_i] * dilation[d_i];
         is_padding |= !is_a_ge_zero_and_a_lt_b(d_im, im_shape[d_i]);
@@ -456,7 +456,7 @@ void Im2col<T, StorageOrder::NHWC>::operator()(
             if (is_a_ge_zero_and_a_lt_b(iw, input_w)) {
               // Increase the copy count size to reduce the number of copy calls.
               int64_t batch_w = std::min(kw, input_w - iw);
-              std::memcpy(data_col, data_im + (ih * input_w + iw) * group_channels, sizeof(T) * batch_w * group_channels);
+              std::memcpy(data_col, data_im + (ih * input_w + iw) * group_channels, gsl::narrow<size_t>(sizeof(T) * batch_w * group_channels));
               data_col += batch_w * group_channels;
               iw += batch_w;
               kw -= batch_w;
@@ -471,7 +471,7 @@ void Im2col<T, StorageOrder::NHWC>::operator()(
             if (is_a_ge_zero_and_a_lt_b(iw, input_w)) {
               // N.B. Using std::memcpy helped here over std::copy_n when doing a
               // transform for an image with a small number of group channels.
-              std::memcpy(data_col, data_im + (ih * input_w + iw) * input_channels, sizeof(T) * group_channels);
+              std::memcpy(data_col, data_im + (ih * input_w + iw) * input_channels, gsl::narrow<size_t>(sizeof(T) * group_channels));
               data_col += group_channels;
             } else {
               data_col = std::fill_n(data_col, group_channels, padding_value);
@@ -502,7 +502,7 @@ void Im2col<T, StorageOrder::NHWC>::operator()(
     const int64_t* stride,
     const int64_t* dilation,
     const int64_t* pad,
-    int64_t rank,
+    ptrdiff_t rank,
     T* data_col,
     T padding_value) {
   // iterate dimensions on output image shape (without Batch and Channel)
@@ -518,7 +518,7 @@ void Im2col<T, StorageOrder::NHWC>::operator()(
       // and the inner col, and whether the index lies in the padding.
       int64_t index_im = 0;
       bool is_padding = false;
-      for (int64_t d_i = 0; d_i < rank; ++d_i) {
+      for (ptrdiff_t d_i = 0; d_i < rank; ++d_i) {
         int64_t d_im = d_output[d_i] * stride[d_i] - pad[d_i] + d_kernel[d_i] * dilation[d_i];
         is_padding |= !is_a_ge_zero_and_a_lt_b(d_im, im_shape[d_i]);
         index_im *= im_shape[d_i];
@@ -549,8 +549,8 @@ void Col2im<float, CPUMathUtil, StorageOrder::NCHW>(const float* data_col, int64
   const int64_t output_w =
       (width + pad_l + pad_r - (dilation_w * (kernel_w - 1) + 1)) / stride_w +
       1;
-
-  Set<float, CPUMathUtil>(height * width * channels, 0, data_im, context);
+  const int64_t hwc = height * width * channels;
+  Set<float, CPUMathUtil>(gsl::narrow<ptrdiff_t>(hwc), 0, data_im, context);
 
   // Fast path for zero padding and no dilation
   // From Torch, modified THNN_(unfolded_acc)
@@ -650,7 +650,8 @@ void Col2im<float, CPUMathUtil, StorageOrder::NHWC>(const float* data_col, int64
   const int64_t dkernel_h = dilation_h * (kernel_h - 1) + 1;
   const int64_t dkernel_w = dilation_w * (kernel_w - 1) + 1;
 
-  Set<float, CPUMathUtil>(height * width * channels, 0, data_im, context);
+  const int64_t hwc = height * width * channels;
+  Set<float, CPUMathUtil>(gsl::narrow<ptrdiff_t>(hwc), 0, data_im, context);
   int64_t height_col = (height + pad_t + pad_b - dkernel_h) / stride_h + 1;
   int64_t width_col = (width + pad_l + pad_r - dkernel_w) / stride_w + 1;
   int64_t h_pad = -pad_t;
@@ -677,9 +678,9 @@ template <>
 void Col2imNd<float, CPUMathUtil, StorageOrder::NCHW>(const float* data_col, const int64_t* img_shape,
                                                       const int64_t* output_shape, int64_t channels_col, int64_t img_size,
                                                       const int64_t* kernel_shape, const int64_t* stride,
-                                                      const int64_t* dilation, const int64_t* pad, int64_t N,
+                                                      const int64_t* dilation, const int64_t* pad, ptrdiff_t N,
                                                       float* data_img, CPUMathUtil* context) {
-  Set<float, CPUMathUtil>(img_size, 0, data_img, context);
+  Set<float, CPUMathUtil>(gsl::narrow<ptrdiff_t>(img_size), 0, data_img, context);
   Im2col<float, StorageOrder::NCHW>()(
       data_col,
       img_shape,

--- a/onnxruntime/core/util/math_cpuonly.h
+++ b/onnxruntime/core/util/math_cpuonly.h
@@ -101,11 +101,11 @@ using ConstEigenMatrixMapRowMajorOuterStride =
 
 template <typename T>
 auto EigenMap(Tensor& t) -> EigenVectorMap<T> {
-  return EigenVectorMap<T>(t.template MutableData<T>(), t.Shape().Size());
+  return EigenVectorMap<T>(t.template MutableData<T>(), gsl::narrow<ptrdiff_t>(t.Shape().Size()));
 }
 template <typename T>
 auto EigenMap(const Tensor& t) -> ConstEigenVectorMap<T> {
-  return ConstEigenVectorMap<T>(t.template Data<T>(), t.Shape().Size());
+  return ConstEigenVectorMap<T>(t.template Data<T>(), gsl::narrow<ptrdiff_t>(t.Shape().Size()));
 }
 
 class CPUMathUtil {

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1518,6 +1518,7 @@ Applies to session load, initialization, etc. Default is 0.)pbdoc")
       .def(
           "add_session_config_entry",
           [](PySessionOptions* options, const char* config_key, const char* config_value) -> void {
+            //config_key and config_value will be copied
             const Status status = options->AddConfigEntry(config_key, config_value);
             if (!status.IsOK())
               throw std::runtime_error(status.ErrorMessage());

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -254,7 +254,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   if (pause) {
     printf("Enter to continue...\n");
     fflush(stdout);
-    getchar();
+    (void)getchar();
   }
 
   {


### PR DESCRIPTION
**Description**: 

Fix some compile warnings

**Motivation and Context**
- Why is this change required? What problem does it solve?

Required by static code analyzer. 

To fix some errors like:

Inconsistent annotation for 'RunWithBinding': `_Param_(3)` has `'SAL_pre SAL_notref SAL_null(__no) SAL_pre SAL_valid SAL_pre SAL_notref SAL_deref SAL_notref SAL_access(0x1)'` on the prior instance. See c:\a\1\s\onnxruntime\core\session\ort_apis.h(212). Note: There are several prototypes for this function. This warning compares the first with instance number 3. 
at C:\a\1\s\onnxruntime\core\session\\onnxruntime_c_api.cc@608,0


- If it fixes an open issue, please link to the issue here.
