### PR TITLE
Remove OpSchema dummy definition in minimal build

### DIFF
--- a/include/onnxruntime/core/graph/function.h
+++ b/include/onnxruntime/core/graph/function.h
@@ -21,8 +21,10 @@ class Function {
  public:
   virtual ~Function() = default;
 
+#if !defined(ORT_MINIMAL_BUILD)
   /** Gets the OpSchema for the Function. */
   virtual const ONNX_NAMESPACE::OpSchema& OpSchema() const = 0;
+#endif
 
   /** Gets the Graph instance for the Function body subgraph. */
   virtual const onnxruntime::Graph& Body() const = 0;

--- a/include/onnxruntime/core/graph/onnx_protobuf.h
+++ b/include/onnxruntime/core/graph/onnx_protobuf.h
@@ -38,11 +38,6 @@
 #include "onnx/defs/schema.h"
 #else
 #include "onnx/defs/data_type_utils.h"
-
-// stub definition of OpSchema to minimize other code changes
-namespace ONNX_NAMESPACE {
-class OpSchema {};
-}  // namespace ONNX_NAMESPACE
 #endif
 
 #include "onnx/onnx_pb.h"


### PR DESCRIPTION
**Description**: 
Remove OpSchema dummy definition. Only needed for Function now, and we can just exclude the method in Function

**Motivation and Context**
Cleaner/more specific to exclude in Function as a general purpose definition of OpSchema is longer needed in minimal build.