### PR TITLE
Fix the optional-lite for c++17 and several training related fix

### DIFF
--- a/include/onnxruntime/core/common/optional.h
+++ b/include/onnxruntime/core/common/optional.h
@@ -3,7 +3,10 @@
 
 #pragma once
 
+#define optional_CONFIG_SELECT_OPTIONAL optional_OPTIONAL_NONSTD
+
 #include <nonstd/optional.hpp>
+
 
 namespace onnxruntime {
 

--- a/orttraining/orttraining/core/graph/loss_func/softmax_cross_entropy.cc
+++ b/orttraining/orttraining/core/graph/loss_func/softmax_cross_entropy.cc
@@ -30,7 +30,7 @@ GraphAugmenter::GraphDefs SoftmaxCrossEntropy::operator()(
     new_nodes.emplace_back(NodeDef(OpDef("SoftmaxCrossEntropy", kMSDomain, 1),  // Op
                                    {ArgDef(prediction_name),
                                     ArgDef(label_name, label_type_proto)},  // Inputs
-                                   {ArgDef(loss_name, graph_defs.CreateTypeProto({1,}, ONNX_NAMESPACE::TensorProto_DataType_FLOAT)),
+                                   {ArgDef(loss_name, graph_defs.CreateTypeProto({}, ONNX_NAMESPACE::TensorProto_DataType_FLOAT)),
                                     ArgDef(prob_name)},  // Outputs
                                    NodeAttributes(),
                                    "SoftmaxCrossEntropy"  // name

--- a/orttraining/orttraining/core/graph/training_op_defs.cc
+++ b/orttraining/orttraining/core/graph/training_op_defs.cc
@@ -1978,11 +1978,11 @@ Return true if all elements are true and false otherwise.
       .Output(0, "Y", "output", "TOut")
       .TypeConstraint(
           "TIn",
-          {"tensor(float16)", "tensor(float)", "tensor(double)"},
+          {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
           "Constrain input types to float tensors.")
       .TypeConstraint(
           "TOut",
-          {"tensor(float16)", "tensor(float)", "tensor(double)"},
+          {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
           "Constrain scale types to float tensors.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         updateOutputShape(ctx, 0, {});


### PR DESCRIPTION
**Description**: The optional-lite lib caused some issue for internal repo when using c++17, fixed it by force it to use non std optional at this moment. 
Also add bfloat16 to several training ops.
