### PR TITLE
Use onnxruntime_USE_FULL_PROTOBUF=OFF for the cuda execution provider

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -826,11 +826,6 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
                            "ON" if args.use_openvino.startswith("MULTI") else "OFF"),
                        "-Donnxruntime_USE_OPENVINO_BINARY=" + (
                            "ON" if args.use_openvino else "OFF")]
-    # temp turn on only for linux gpu build
-    if not is_windows():
-        if args.use_cuda:
-            cmake_args += [
-                "-Donnxruntime_USE_FULL_PROTOBUF=ON"]
 
     # TensorRT and OpenVINO providers currently only supports
     # full_protobuf option.


### PR DESCRIPTION
This removes a special case of the cuda EP.
