### PR TITLE
Fix Python Packaging Pipeline (training) failure

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
@@ -2,6 +2,7 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 # transformers requires sklearn
 sklearn
+numpy==1.16.6
 transformers==v2.10.0
 torch==1.6.0+cu101
 torchvision==0.7.0+cu101


### PR DESCRIPTION
**Description**: Fix Python Packaging Pipeline (training) failure

**Motivation and Context**
- For some reason, the numpy used by "Linux_py_GPU_Wheels Python38" in Python Packaging Pipeline (training) changed from 1.16.6 to 1.20.0rc2, which caused the faiure.
- Update the tools/ci_build/github/linux/docker/scripts/training/requirements.txt to force using numpy==1.16.6
- Passed pipeline run here, https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=141303&view=logs&j=53da5cdd-6498-551f-0482-c53cbbb1d34c
