### PR TITLE
Add fp16 support for BatchNormalization ForwardTraining/Backward

### DIFF
--- a/onnxruntime/core/providers/cuda/nn/batch_norm.cc
+++ b/onnxruntime/core/providers/cuda/nn/batch_norm.cc
@@ -19,6 +19,8 @@ namespace cuda {
       T,                                                             \
       kCudaExecutionProvider,                                        \
       KernelDefBuilder()                                             \
+          .Alias(3, 1)                                               \
+          .Alias(4, 2)                                               \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()),    \
       BatchNorm<T>);                                                 \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                     \
@@ -28,6 +30,8 @@ namespace cuda {
       T,                                                             \
       kCudaExecutionProvider,                                        \
       KernelDefBuilder()                                             \
+          .Alias(3, 1)                                               \
+          .Alias(4, 2)                                               \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()),    \
       BatchNorm<T>);
 
@@ -86,22 +90,56 @@ Status BatchNorm<T>::ComputeInternal(OpKernelContext* p_op_kernel_context) const
     Impl_Cast<CudaT, float>(mean_data, f_mean.get(), C);
     Impl_Cast<CudaT, float>(var_data, f_var.get(), C);
 
-    CUDNN_RETURN_IF_ERROR(cudnnBatchNormalizationForwardInference(
-        CudnnHandle(),
-        cudnn_batch_norm_mode_,
-        &alpha,
-        &beta,
-        data_desc,
-        x_data,
-        data_desc,
-        y_data,
-        bn_tensor_desc,
-        f_scale.get(),
-        f_B.get(),
-        f_mean.get(),
-        f_var.get(),
-        epsilon_));
+    // in BatchNorm Forward Training mode if all 5 outputs present
+    if (running_mean && running_var && saved_mean && saved_var) {
+      auto f_saved_mean = GetScratchBuffer<float>(C);
+      auto f_saved_inv_var = GetScratchBuffer<float>(C);
 
+      auto running_mean_data = reinterpret_cast<CudaT*>(running_mean->template MutableData<T>());
+      auto running_var_data = reinterpret_cast<CudaT*>(running_var->template MutableData<T>());
+      auto saved_mean_data = reinterpret_cast<CudaT*>(saved_mean->template MutableData<T>());
+      auto saved_inv_var_data = reinterpret_cast<CudaT*>(saved_var->template MutableData<T>());
+
+      CUDNN_RETURN_IF_ERROR(cudnnBatchNormalizationForwardTraining(
+          CudnnHandle(),
+          cudnn_batch_norm_mode_,
+          &alpha,
+          &beta,
+          data_desc,
+          x_data,
+          data_desc,
+          y_data,
+          bn_tensor_desc,
+          f_scale.get(),
+          f_B.get(),
+          momentum_,
+          f_mean.get(),
+          f_var.get(),
+          epsilon_,
+          f_saved_mean.get(),
+          f_saved_inv_var.get()));
+
+      Impl_Cast<float, CudaT>(f_mean.get(), running_mean_data, C);
+      Impl_Cast<float, CudaT>(f_var.get(), running_var_data, C);
+      Impl_Cast<float, CudaT>(f_saved_mean.get(), saved_mean_data, C);
+      Impl_Cast<float, CudaT>(f_saved_inv_var.get(), saved_inv_var_data, C);
+    } else {
+      CUDNN_RETURN_IF_ERROR(cudnnBatchNormalizationForwardInference(
+          CudnnHandle(),
+          cudnn_batch_norm_mode_,
+          &alpha,
+          &beta,
+          data_desc,
+          x_data,
+          data_desc,
+          y_data,
+          bn_tensor_desc,
+          f_scale.get(),
+          f_B.get(),
+          f_mean.get(),
+          f_var.get(),
+          epsilon_));
+    }
     return Status::OK();
   }
 

--- a/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
+++ b/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
@@ -63,6 +63,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, LogSoftmaxGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, BatchNormalizationGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, BatchNormalizationGrad);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, BatchNormalizationGrad);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, GatherGrad);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, BiasDropout);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 9, TrainableDropout);
@@ -206,6 +207,7 @@ Status RegisterCudaTrainingKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, int64_t, SoftmaxCrossEntropyLossGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, BatchNormalizationGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, BatchNormalizationGrad)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, BatchNormalizationGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, GatherGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, DivGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, DivGrad)>,

--- a/orttraining/orttraining/training_ops/cuda/nn/batch_norm_grad.cc
+++ b/orttraining/orttraining/training_ops/cuda/nn/batch_norm_grad.cc
@@ -5,6 +5,7 @@
 #include "core/providers/common.h"
 #include "core/providers/cuda/cudnn_common.h"
 #include "core/providers/cpu/nn/batch_norm_helper.h"
+#include "core/providers/cuda/math/unary_elementwise_ops_impl.h"
 
 using namespace std;
 namespace onnxruntime {
@@ -54,28 +55,68 @@ Status BatchNormalizationGrad<T>::ComputeInternal(OpKernelContext* ctx) const {
   ORT_RETURN_IF_ERROR(input_tensor.Set(new_dims, CudnnTensor::GetDataType<CudaT>()));
   ORT_RETURN_IF_ERROR(scale_bias_tensor.Set(input_tensor, cudnn_batch_norm_mode_));
 
-  // note this is only valid for cudnnBatchNormalizationForwardTraining, not ForwardInference
-  CUDNN_RETURN_IF_ERROR(
-      cudnnBatchNormalizationBackward(
-          CudnnHandle(),
-          cudnn_batch_norm_mode_,
-          &alpha,
-          &beta,
-          &alpha,
-          &beta,
-          input_tensor,
-          X_data,
-          input_tensor,
-          dY_data,
-          input_tensor,
-          dX_data,
-          scale_bias_tensor,
-          Scale_data,
-          dScale_data,
-          dBias_data,
-          epsilon_,
-          saved_mean_data,
-          saved_variance_data));
+  if (X->IsDataType<MLFloat16>()) {
+    const int C = input_shape.GetDims()[1];
+    auto f_scale = GetScratchBuffer<float>(C);
+    auto f_dScale = GetScratchBuffer<float>(C);
+    auto f_dBias = GetScratchBuffer<float>(C);
+    auto f_saved_mean = GetScratchBuffer<float>(C);
+    auto f_saved_var = GetScratchBuffer<float>(C);
+
+    Impl_Cast<CudaT, float>(Scale_data, f_scale.get(), C);
+    Impl_Cast<CudaT, float>(saved_mean_data, f_saved_mean.get(), C);
+    Impl_Cast<CudaT, float>(saved_variance_data, f_saved_var.get(), C);
+
+    // note this is only valid for cudnnBatchNormalizationForwardTraining, not ForwardInference
+    CUDNN_RETURN_IF_ERROR(
+        cudnnBatchNormalizationBackward(
+            CudnnHandle(),
+            cudnn_batch_norm_mode_,
+            &alpha,
+            &beta,
+            &alpha,
+            &beta,
+            input_tensor,
+            X_data,
+            input_tensor,
+            dY_data,
+            input_tensor,
+            dX_data,
+            scale_bias_tensor,
+            f_scale.get(),
+            f_dScale.get(),
+            f_dBias.get(),
+            epsilon_,
+            f_saved_mean.get(),
+            f_saved_var.get()));
+
+    Impl_Cast<float, CudaT>(f_dScale.get(), dScale_data, C);
+    Impl_Cast<float, CudaT>(f_dBias.get(), dBias_data, C);
+  } else {
+    // note this is only valid for cudnnBatchNormalizationForwardTraining, not ForwardInference
+    CUDNN_RETURN_IF_ERROR(
+        cudnnBatchNormalizationBackward(
+            CudnnHandle(),
+            cudnn_batch_norm_mode_,
+            &alpha,
+            &beta,
+            &alpha,
+            &beta,
+            input_tensor,
+            X_data,
+            input_tensor,
+            dY_data,
+            input_tensor,
+            dX_data,
+            scale_bias_tensor,
+            Scale_data,
+            dScale_data,
+            dBias_data,
+            epsilon_,
+            saved_mean_data,
+            saved_variance_data));
+  }
+
   return Status::OK();
 }
 
@@ -85,6 +126,7 @@ Status BatchNormalizationGrad<T>::ComputeInternal(OpKernelContext* ctx) const {
 
 SPECIALIZED_GRADIENT(float)
 SPECIALIZED_GRADIENT(double)
+SPECIALIZED_GRADIENT(MLFloat16)
 
 }  // namespace cuda
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**
- Add fp16 support for BatchNormalization ForwardTraining/Backward
- Bind inputs `mean` and `var` with outputs `mean` and `var`, respectively

**Motivation and Context**
- Currently BatchNormalization does not support fp16 and should be kept in fp32 when training
- Fix the problem that `running_mean` and `running_var` do not change in training mode