### PR TITLE
fix -Wdangling-gsl

### DIFF
--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -261,8 +261,11 @@ template <typename T>
 Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const Path& model_path, /*out*/ T* p_data, size_t expected_size) {
 #if !defined(ORT_MINIMAL_BUILD)
   if (HasExternalData(tensor)) {
-    auto tensor_proto_path = model_path.IsEmpty() ? nullptr : model_path.ParentPath().ToPathString().c_str();
-    return UnpackTensorWithExternalData(tensor, tensor_proto_path, expected_size, p_data);
+    return UnpackTensorWithExternalData(
+        tensor,
+        model_path.IsEmpty() ? nullptr : model_path.ParentPath().ToPathString().c_str(),
+        expected_size,
+        p_data);
   }
 #else
   ORT_UNUSED_PARAMETER(model_path);


### PR DESCRIPTION
**Description**: 
fixing  -Wdangling-gsl
ToPathString() returns a std::string. Chaining the call to c_str() is not safe as it will result in a dangling pointer as this temp obj will be destroyed at the end of the full-expression

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
