### PR TITLE
WinML telemetry sent for Session creation isn't needed

### DIFF
--- a/winml/lib/Api/LearningModelSession.cpp
+++ b/winml/lib/Api/LearningModelSession.cpp
@@ -155,9 +155,6 @@ void LearningModelSession::Initialize() {
 
   // Cache the constructed session
   engine_ = engine;
-
-  // Log to telemetry that WinML LearningModelSession was successful
-  telemetry_helper.LogWinMLSessionCreated();
 }
 
 wfc::IPropertySet

--- a/winml/lib/Common/inc/WinMLTelemetryHelper.h
+++ b/winml/lib/Common/inc/WinMLTelemetryHelper.h
@@ -83,7 +83,6 @@ class WinMLTelemetryHelper {
   }
 
   void LogWinMLShutDown();
-  void LogWinMLSessionCreated();
   void LogWinMLSuspended();
   void LogRuntimeError(HRESULT hr, std::string message, PCSTR file, PCSTR function, int line);
   void LogRuntimeError(HRESULT hr, PCSTR message, PCSTR file, PCSTR function, int line);

--- a/winml/lib/Telemetry/WinMLTelemetryHelper.cpp
+++ b/winml/lib/Telemetry/WinMLTelemetryHelper.cpp
@@ -34,16 +34,6 @@ void WinMLTelemetryHelper::LogWinMLSuspended() {
       TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"));
 }
 
-void WinMLTelemetryHelper::LogWinMLSessionCreated() {
-  WinMLTraceLoggingWrite(
-      provider_,
-      "WinMLSessionCreated",
-      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-      TraceLoggingString("LearningModelSession successfully created.", "message"),
-      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
-}
-
 void WinMLTelemetryHelper::LogRuntimeError(HRESULT hr, PCSTR message, PCSTR file, PCSTR function, int line) {
   if (!telemetry_enabled_)
     return;


### PR DESCRIPTION
There is already a language projection field being sent up in Onnxruntime Session Creation that shows that WinML is used.

	
Here is the enum https://github.com/microsoft/onnxruntime/blob/eab164e1a5cd7760ee653ffe455e7a10cded7cb2/include/onnxruntime/core/session/onnxruntime_c_api.h#L226
	Here it is being set: https://github.com/microsoft/onnxruntime/blob/eab164e1a5cd7760ee653ffe455e7a10cded7cb2/winml/lib/Api.Ort/OnnxruntimeEnvironment.cpp#L210
	Sent here https://github.com/microsoft/onnxruntime/blob/eab164e1a5cd7760ee653ffe455e7a10cded7cb2/onnxruntime/core/platform/windows/telemetry.cc#L207