### PR TITLE
Handle models without parameters on ORTModule API

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -728,18 +728,20 @@ class Graph {
 
   /** Gets the mutable NodeArg with the provided name.
   @returns Pointer to NodeArg if found, nullptr if not. */
-  NodeArg* GetNodeArg(const std::string& name) {
+  NodeArg* GetNodeArg(const std::string& name, bool must_exist = false) {
     auto iter = node_args_.find(name);
     if (iter != node_args_.end()) {
       return iter->second.get();
+    } else if (must_exist) {
+      ORT_THROW("Invalid input node ", name, ".");
     }
     return nullptr;
   }
 
   /** Gets the const NodeArg with the provided name.
   @returns Pointer to const NodeArg if found, nullptr if not. */
-  const NodeArg* GetNodeArg(const std::string& name) const {
-    return const_cast<Graph*>(this)->GetNodeArg(name);
+  const NodeArg* GetNodeArg(const std::string& name, bool must_exist = false) const {
+    return const_cast<Graph*>(this)->GetNodeArg(name, must_exist);
   }
 
   // search this and up through any parent_graph_ instance for a NodeArg

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -98,7 +98,8 @@ common::Status SaveInitializedTensors(
     const ExecutionPlanBase& exec_plan,
     const SessionOptions& session_options) {
   LOGS(logger, INFO) << "Saving initialized tensors.";
-  ORT_ENFORCE(ort_value_name_idx_map.MaxIdx() > -1, "OrtValue indexes should have been populated.");
+  const onnxruntime::InitializedTensorSet& initialized_tensor_set = graph.GetAllInitializedTensors();
+  ORT_ENFORCE(initialized_tensor_set.empty() || ort_value_name_idx_map.MaxIdx() > -1, "OrtValue indexes should have been populated.");
 
   // Determine if an intializer was supplied by the user for the purpose of sharing and if it requires a cross-device
   // copy. In case a cross-device copy is required, sharing cannot be accomplished since we allocate our own buffer
@@ -130,7 +131,6 @@ common::Status SaveInitializedTensors(
   };
 
   //1. first plan the memory
-  const onnxruntime::InitializedTensorSet& initialized_tensor_set = graph.GetAllInitializedTensors();
   std::unordered_map<int, const ONNX_NAMESPACE::TensorProto*> id_to_initialized_tensor;
   std::set<int> user_supplied_initializer_ids;  // set containing the ort value ids of all user supplied initializers
   for (const auto& entry : initialized_tensor_set) {

--- a/orttraining/orttraining/core/framework/gradient_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.cc
@@ -55,9 +55,10 @@ GradientGraphBuilder::GradientGraphBuilder(Graph* graph,
 
     const Node* node = graph_->GetProducerNode(name);
     if (!node) {
-      ORT_THROW(name, " couldn't find the producer node.");
+      LOGS(logger_, WARNING) << name << " couldn't find the producer node." << std::endl;
+    } else {
+      y_nodes_.insert(node);
     }
-    y_nodes_.insert(node);
   }
 
   reachable_nodes_ = ReverseBFS(y_nodes_);

--- a/orttraining/orttraining/core/framework/gradient_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.cc
@@ -37,7 +37,7 @@ GradientGraphBuilder::GradientGraphBuilder(Graph* graph,
                                      TransformerLevel::Level2);
 
   for (const auto& name : y_node_arg_names) {
-    const NodeArg* node_arg = graph->GetNodeArg(name);
+    const NodeArg* node_arg = graph->GetNodeArg(name, true);
     if (!node_arg) {
       std::stringstream ss;
       bool first = true;
@@ -66,7 +66,7 @@ GradientGraphBuilder::GradientGraphBuilder(Graph* graph,
 
   // building x_nodes_
   for (const auto& name : x_node_arg_names) {
-    const NodeArg* node_arg = graph->GetNodeArg(name);
+    const NodeArg* node_arg = graph->GetNodeArg(name, true);
     if (!node_arg) {
       ORT_THROW("Node arg ", name, " is not found in the graph.");
     }

--- a/orttraining/orttraining/core/framework/gradient_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.cc
@@ -37,7 +37,7 @@ GradientGraphBuilder::GradientGraphBuilder(Graph* graph,
                                      TransformerLevel::Level2);
 
   for (const auto& name : y_node_arg_names) {
-    const NodeArg* node_arg = graph->GetNodeArg(name, true);
+    const NodeArg* node_arg = graph->GetNodeArg(name);
     if (!node_arg) {
       std::stringstream ss;
       bool first = true;
@@ -66,7 +66,7 @@ GradientGraphBuilder::GradientGraphBuilder(Graph* graph,
 
   // building x_nodes_
   for (const auto& name : x_node_arg_names) {
-    const NodeArg* node_arg = graph->GetNodeArg(name, true);
+    const NodeArg* node_arg = graph->GetNodeArg(name);
     if (!node_arg) {
       ORT_THROW("Node arg ", name, " is not found in the graph.");
     }

--- a/orttraining/orttraining/core/framework/module_gradient_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/module_gradient_graph_builder.cc
@@ -72,11 +72,11 @@ Status ModuleGradientGraphBuilder::Initialize(std::istream& model_istream,
   // Remove the training initializers from the graph and move them to input to save memory.
   std::vector<const NodeArg*> input_args;
   for (const auto& input_name : split_graphs_info_.user_input_names) {
-    input_args.emplace_back(graph.GetNodeArg(input_name));
+    input_args.emplace_back(graph.GetNodeArg(input_name, true));
   }
 
   for (const auto& initializer_name : split_graphs_info_.initializer_names_to_train) {
-    input_args.emplace_back(graph.GetNodeArg(initializer_name));
+    input_args.emplace_back(graph.GetNodeArg(initializer_name, true));
     graph.RemoveInitializedTensor(initializer_name);
   }
 

--- a/orttraining/orttraining/python/training/_utils.py
+++ b/orttraining/orttraining/python/training/_utils.py
@@ -43,16 +43,13 @@ def get_device_index_from_input(input):
     return device_index
 
 def get_device(module):
-    '''Returns the first device found in the `module`'s parameters
-
-    TODO: This approach assumes a single device per model
-    '''
+    '''Returns the first device found in the `module`'s parameters'''
     device = torch.device('cpu')
     try:
         device = next(module.parameters()).device
         for param in module.parameters():
             if param.device != device:
-                raise('ORTModule supports a single device per model for now')
+                raise RuntimeError('ORTModule supports a single device per model for now')
     except StopIteration:
         # Model doesn't have a device set to any of the model parameters
         pass
@@ -71,7 +68,7 @@ def get_device_str(device):
         else:
             device = device.type + ':' + str(device.index)
     else:
-        raise ('Unsupported device type')
+        raise RuntimeError('Unsupported device type')
     return device
 
 def get_default_device_str(type):

--- a/orttraining/orttraining/python/training/_utils.py
+++ b/orttraining/orttraining/python/training/_utils.py
@@ -42,9 +42,19 @@ def get_device_index_from_input(input):
         device_index = get_device_index(input.device)
     return device_index
 
-def get_device(module):
-    '''Returns the first device found in the `module`'s parameters'''
-    device = torch.device('cpu')
+def get_device_index_from_input_args_kwargs(*args, **kwargs):
+    '''Returns device index from first PyTorch Tensor within *args or **kwargs'''
+
+    device = None
+    if args:
+        device = torch.device(args[0].device)
+    elif not device and kwargs:
+        device = torch.device(next(iter(kwargs.values())).device)
+    return device
+
+def get_device_from_module(module):
+    '''Returns the first device found in the `module`'s parameters or None'''
+    device = None
     try:
         device = next(module.parameters()).device
         for param in module.parameters():
@@ -72,10 +82,13 @@ def get_device_str(device):
     return device
 
 def get_default_device_str(type):
-    if type == 'cuda':
-        return 'cuda:' + str(torch.cuda.current_device())
+    if isinstance(type, str):
+        if type == 'cuda':
+            return 'cuda:' + str(torch.cuda.current_device())
+        else:
+            return 'cpu'
     else:
-        return 'cpu'
+        raise RuntimeError('Unsupported device type')
 
 def get_all_gradients_finite_name_from_session(session):
     '''Find all_gradients_finite node on Session graph and return its name'''

--- a/orttraining/orttraining/python/training/_utils.py
+++ b/orttraining/orttraining/python/training/_utils.py
@@ -26,13 +26,12 @@ def timeit(enabled=True):
     return inner if enabled else noop_inner
 
 def get_device_index(device):
-    '''Returns device index from a device'''
-
-    if type(device) == str:
-        # Could be 'cuda:0', 'cuda:1', or 'cpu'. with cpu, set index=0
+    if isinstance(device, str):
+        # could be 'cuda:0', 'cuda:1', or 'cpu'. with cpu, set index=0
         device = torch.device(device)
+    elif isinstance(device, int):
+        return device
     return 0 if device.index is None else device.index
-
 
 def get_device_index_from_input(input):
     '''Returns device index from a input PyTorch Tensor'''
@@ -43,6 +42,43 @@ def get_device_index_from_input(input):
         device_index = get_device_index(input.device)
     return device_index
 
+def get_device(module):
+    '''Returns the first device found in the `module`'s parameters
+
+    TODO: This approach assumes a single device per model
+    '''
+    device = torch.device('cpu')
+    try:
+        device = next(module.parameters()).device
+        for param in module.parameters():
+            if param.device != device:
+                raise('ORTModule supports a single device per model for now')
+    except StopIteration:
+        # Model doesn't have a device set to any of the model parameters
+        pass
+    return device
+
+def get_device_str(device):
+    if isinstance(device, str):
+        # could be 'cuda:0', 'cuda:1', or 'cpu'. with cpu, set index=0
+        if device.find(':') == -1:
+            device += ':' + str(torch.cuda.current_device())
+    elif isinstance(device, int):
+        device = 'cuda:' + str(device)
+    elif isinstance(device, torch.device):
+        if device.index is None:
+            device = device.type + ':' + str(torch.cuda.current_device())
+        else:
+            device = device.type + ':' + str(device.index)
+    else:
+        raise ('Unsupported device type')
+    return device
+
+def get_default_device_str(type):
+    if type == 'cuda':
+        return 'cuda:' + str(torch.cuda.current_device())
+    else:
+        return 'cpu'
 
 def get_all_gradients_finite_name_from_session(session):
     '''Find all_gradients_finite node on Session graph and return its name'''

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -394,6 +394,6 @@ class ORTModule(torch.nn.Module):
         pt_count_params = sum([1 for param in module.parameters()])
         onnx_count_params = sum([1 for param in model.graph.initializer])
         if pt_count_params < 1 or onnx_count_params < 1:
-            raise('ORTModule only supports model with at least one trainable parameter')
+            raise RuntimeError('ORTModule only supports model with at least one trainable parameter')
 
         return model

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -388,4 +388,12 @@ class ORTModule(torch.nn.Module):
                           training=torch.onnx.TrainingMode.TRAINING,
                           dynamic_axes=dynamic_axes)
 
-        return onnx.load_model_from_string(f.getvalue())
+        model = onnx.load_model_from_string(f.getvalue())
+
+        # Models without parameters are not allowed
+        pt_count_params = sum([1 for param in module.parameters()])
+        onnx_count_params = sum([1 for param in model.graph.initializer])
+        if pt_count_params < 1 or onnx_count_params < 1:
+            raise('ORTModule only supports model with at least one trainable parameter')
+
+        return model

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -250,7 +250,6 @@ def test_model_without_parameters(device):
     model = Net().to(device)
     model = ORTModule(model).to(device)
     _ = model(torch.tensor(1.))
-    assert model._use_pytorch_forward == True
 
 @pytest.mark.parametrize("device", ['cuda', 'cpu'])
 def test_model_without_trainable_parameters(device):
@@ -264,8 +263,6 @@ def test_model_without_trainable_parameters(device):
     input = torch.randn(batch_size, in_features, device=device)
     target = torch.empty(batch_size, dtype=torch.long, device=device).random_(nb_classes)
     _ = model(input)
-    assert model._use_pytorch_forward == True
-
 
 @pytest.mark.parametrize("device", ['cuda', 'cpu'])
 def test_custom_model_without_trainable_parameters(device):
@@ -276,8 +273,9 @@ def test_custom_model_without_trainable_parameters(device):
     model = Net()
     model = ORTModule(model).to(device)
     model.to(device)
-    _ = model(torch.tensor(1.).to(device))
-    assert model._use_pytorch_forward == True
+    with pytest.raises(RuntimeError) as e:
+        _ = model(torch.tensor(1.).to(device))
+    assert 'There was an error while exporting the PyTorch model to ONNX' in str(e.value)
 
 @pytest.mark.parametrize("device", ['cuda', 'cpu'])
 def test_model_with_unused_trainable_parameters(device):
@@ -294,7 +292,6 @@ def test_model_with_unused_trainable_parameters(device):
     model = Net(784, 500, 10)
     model = ORTModule(model).to(device)
     model(torch.tensor(1.).to(device))
-    assert model._use_pytorch_forward == True
 
 def test_model_with_multiple_devices_cpu_cuda():
     class MultipleDeviceModel(torch.nn.Module):
@@ -311,7 +308,7 @@ def test_model_with_multiple_devices_cpu_cuda():
     model = MultipleDeviceModel()
     with pytest.raises(RuntimeError) as e:
         model = ORTModule(model)
-        assert e.value == 'ORTModule supports a single device per model for now'
+    assert str(e.value) == 'ORTModule supports a single device per model for now'
 
 def test_model_with_multiple_devices_to_to():
     class MultipleDeviceModel(torch.nn.Module):
@@ -328,7 +325,7 @@ def test_model_with_multiple_devices_to_to():
     model = MultipleDeviceModel()
     with pytest.raises(RuntimeError) as e:
         model = ORTModule(model)
-        assert e.value == 'ORTModule supports a single device per model for now'
+    assert str(e.value) == 'ORTModule supports a single device per model for now'
 
 def test_model_with_multiple_devices_to_cpu():
     class MultipleDeviceModel(torch.nn.Module):
@@ -345,7 +342,7 @@ def test_model_with_multiple_devices_to_cpu():
     model = MultipleDeviceModel()
     with pytest.raises(RuntimeError) as e:
         model = ORTModule(model)
-        assert e.value == 'ORTModule supports a single device per model for now'
+    assert str(e.value) == 'ORTModule supports a single device per model for now'
 
 def test_model_with_multiple_devices_to_cuda():
     class MultipleDeviceModel(torch.nn.Module):
@@ -362,7 +359,7 @@ def test_model_with_multiple_devices_to_cuda():
     model = MultipleDeviceModel()
     with pytest.raises(RuntimeError) as e:
         model = ORTModule(model)
-        assert e.value == 'ORTModule supports a single device per model for now'
+    assert str(e.value) == 'ORTModule supports a single device per model for now'
 
 @pytest.mark.parametrize("device", ['cuda', 'cuda:0', 'cuda:1', 'cuda:2'])
 def test_model_with_different_cuda_devices(device):

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -281,3 +281,71 @@ def test_model_with_unused_trainable_parameters(device):
     with pytest.raises(RuntimeError) as e:
         model(torch.tensor(1.).to(device))
         assert e.value == 'ORTModule only supports model with at least one trainable parameter'
+
+def test_model_with_multiple_devices_cpu_cuda():
+    class MultipleDeviceModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc1 = torch.nn.Linear(10, 10).cpu()
+            self.fc2 = torch.nn.Linear(10, 10).cuda()
+
+        def forward(self, x):
+            x = self.fc1(x)
+            x = self.fc2(x)
+            return x
+
+    model = MultipleDeviceModel()
+    with pytest.raises(RuntimeError) as e:
+        model = ORTModule(model)
+        assert e.value == 'ORTModule supports a single device per model for now'
+
+def test_model_with_multiple_devices_to_to():
+    class MultipleDeviceModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc1 = torch.nn.Linear(10, 10).to('cpu')
+            self.fc2 = torch.nn.Linear(10, 10).to('cuda')
+
+        def forward(self, x):
+            x = self.fc1(x)
+            x = self.fc2(x)
+            return x
+
+    model = MultipleDeviceModel()
+    with pytest.raises(RuntimeError) as e:
+        model = ORTModule(model)
+        assert e.value == 'ORTModule supports a single device per model for now'
+
+def test_model_with_multiple_devices_to_cpu():
+    class MultipleDeviceModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc1 = torch.nn.Linear(10, 10).to('cuda')
+            self.fc2 = torch.nn.Linear(10, 10).cpu()
+
+        def forward(self, x):
+            x = self.fc1(x)
+            x = self.fc2(x)
+            return x
+
+    model = MultipleDeviceModel()
+    with pytest.raises(RuntimeError) as e:
+        model = ORTModule(model)
+        assert e.value == 'ORTModule supports a single device per model for now'
+
+def test_model_with_multiple_devices_to_cuda():
+    class MultipleDeviceModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc1 = torch.nn.Linear(10, 10).to('cpu')
+            self.fc2 = torch.nn.Linear(10, 10).cuda()
+
+        def forward(self, x):
+            x = self.fc1(x)
+            x = self.fc2(x)
+            return x
+
+    model = MultipleDeviceModel()
+    with pytest.raises(RuntimeError) as e:
+        model = ORTModule(model)
+        assert e.value == 'ORTModule supports a single device per model for now'

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -356,7 +356,6 @@ def test_model_with_different_cuda_devices(device):
 
     # Trick to run this test in single GPU machines
     device_id = _utils.get_device_index(device)
-    print(torch.cuda.device_count())
     if device_id >= torch.cuda.device_count():
         warnings.warn('Skipping test_model_with_different_cuda_devices(cuda:{})'.format(device_id))
         return

--- a/run_ortmodule_mvp_mnist.sh
+++ b/run_ortmodule_mvp_mnist.sh
@@ -15,5 +15,5 @@ echo "Copying PyTorch frontend source-code to build folder"
 cp -Rf ../../../orttraining/orttraining/python/training/* ../../../build/Linux/RelWithDebInfo/onnxruntime/training/
 
 echo "Running Flexible API (ORTModule)"
-python ../../../orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist.py --help
-python ../../../orttraining/orttraining/test/python/orttraining_test_ortmodule_mnist.py $@
+python ../../../orttraining/orttraining/test/python/orttraining_test_ortmodule_poc.py --help
+python ../../../orttraining/orttraining/test/python/orttraining_test_ortmodule_poc.py $@


### PR DESCRIPTION
Raise exception when models such 

```
class Net(torch.nn.Module):
    def forward(self, x):
        return x
```

and

```
class Net(torch.nn.Module):
    def __init__(self, input_size, hidden_size, num_classes):
        super(Net, self).__init__()

        self.fc1 = torch.nn.Linear(input_size, hidden_size)
        self.relu = torch.nn.ReLU()
        self.fc2 = torch.nn.Linear(hidden_size, num_classes)

    def forward(self, input1):
        return input1
```
are detected