### PR TITLE
[OpenVINO-EP] Using Core::ReadNetwork() method for creating a CNNNetwork

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_utils.cc
+++ b/onnxruntime/core/providers/openvino/backend_utils.cc
@@ -73,8 +73,8 @@ CreateCNNNetwork(const Provider_ModelProto& model_proto, const GlobalContext& gl
   try {
     cnn_network = global_context.ie_core.ReadNetwork(model, blob);
     LOGS_DEFAULT(INFO) << "Read network Done";
-  } catch (const std::exception& exp) {
-    ORT_THROW(log_tag + "[OpenVINO-EP] Exception while Reading network: " + std::string(exp.what()));
+  } catch (const InferenceEngine::details::InferenceEngineException& e) {
+    ORT_THROW(log_tag + "[OpenVINO-EP] Exception while Reading network: " + std::string(e.what()));
   } catch (...) {
     ORT_THROW(log_tag + "[OpenVINO-EP] Unknown exception while Reading network");
   }

--- a/onnxruntime/core/providers/openvino/ov_versions/capability_2021_1.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/capability_2021_1.cc
@@ -272,16 +272,17 @@ static bool IsUnsupportedOpMode(const Node* node, const GraphViewer& graph_viewe
         return true;
     }
   } else if (optype == "Max" || optype == "Min" || optype == "Mean" || optype == "Sum") {
-    if (GetInputCount(node, initializers) == 1)
+    if (GetInputCount(node, initializers) == 1) {
       return true;
-      if (optype == "Max" || optype == "Min") {
-        for (size_t i = 0; i < node->InputDefs().size(); i++) {
-          auto dtype = node->InputDefs()[i]->TypeAsProto()->tensor_type().elem_type();
-          if (dtype == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT8 ||
-              dtype == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT16)
-            return true;
-       }
+    }
+    if (optype == "Max" || optype == "Min") {
+      for (size_t i = 0; i < node->InputDefs().size(); i++) {
+        auto dtype = node->InputDefs()[i]->TypeAsProto()->tensor_type().elem_type();
+        if (dtype == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT8 ||
+            dtype == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT16)
+          return true;
       }
+    }
   } else if (optype == "Clip") {
     //Only float 16, float and double data types are supported
     const bool data_is_float = node->InputDefs()[0]->Type()->find("float") != std::string::npos;


### PR DESCRIPTION
**Description**: 
Using Core::ReadNetwork() method for reading and creating a CNNNetwork for OpenVINO versions >=2020.4

**Motivation and Context**
Since OpenVINO™ 2020.4 version, Inference Engine enables reading ONNX models via the Inference Engine Core API and there is no need to use directly the low-level ONNX* Importer API anymore. To read ONNX* models, it's recommended to use the Core::ReadNetwork() method that provide a uniform way to read models from ONNX format.

**More Info here:**
ONNX* Importer API is deprecated.
https://docs.openvinotoolkit.org/latest/openvino_docs_IE_DG_OnnxImporterTutorial.html

**Info on ReadNetwork() method from InferenceEngine::Core Class:**
https://docs.openvinotoolkit.org/latest/classInferenceEngine_1_1Core.html#a251861e52a979d6e61848babae3673ef
