### PR TITLE
Add option to pre-allreduce-scale gradients with sample count 

### DIFF
--- a/orttraining/orttraining/core/graph/adasum_optimizer_graph_builder.cc
+++ b/orttraining/orttraining/core/graph/adasum_optimizer_graph_builder.cc
@@ -129,10 +129,10 @@ static Status AddNcclAllReduceForGradientsWithGroups(
     allreduce_outputs[i] = ArgDef(gradient_argdefs[i].name + "_AllReduce_Out", allreduced_gradient_type_proto);
   }
   graph_defs.AddNodeDefs({NodeDef(OpDef{"View", kMSDomain, 1},
-                                    view_inputs,
-                                    allreduce_outputs,
-                                    NodeAttributes(),
-                                    "AllReduceOutputView")});
+                                  view_inputs,
+                                  allreduce_outputs,
+                                  NodeAttributes(),
+                                  "AllReduceOutputView")});
 
   gradient_argdefs = allreduce_outputs;
   return Status::OK();
@@ -153,7 +153,7 @@ static Status AddAdasumAllReduceForGradients(
                                   gradient_argdefs,
                                   adasum_output_argdefs,
                                   {ONNX_NAMESPACE::MakeAttribute("reduce_algo",
-                                    static_cast<int64_t>(adasum_reduction_type))},
+                                                                 static_cast<int64_t>(adasum_reduction_type))},
                                   "AdasumAllReduce")});
   gradient_argdefs = std::move(adasum_output_argdefs);
   return Status::OK();
@@ -168,7 +168,6 @@ Status AdasumOptimizerGraphBuilder::BuildInternal(
     std::vector<ArgDef>& gradient_argdefs,
     std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& weight_to_opt_mapping,
     OptimizerOutputKeyMap<std::string>& optimizer_graph_outputs) {
-  
   // Set weight update to false for optimizer
   for (auto& opt_config : opt_configs_) {
     opt_config.update_weight = false;
@@ -189,9 +188,12 @@ Status AdasumOptimizerGraphBuilder::BuildInternal(
     scale_divisor *= opt_graph_config_.local_size;
   }
 
-  const float scale = 1.0f / scale_divisor;
+  const float scale_value = 1.0f / scale_divisor;
+  ArgDef scale = ArgDef(nodearg_name_generator("grad_pre_scaler"), graph_defs.CreateTypeProto({}, ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
+  graph_defs.AddInitializers({CreateTensorProto<float>(scale.name, scale_value, {})});
+
   // Only fuse if using hierarchical reduce.
-  const bool fuse_scaling_outputs = opt_graph_config_.adasum_reduction_type == AdasumReductionType::GpuHierarchicalReduction ? true: false;
+  const bool fuse_scaling_outputs = opt_graph_config_.adasum_reduction_type == AdasumReductionType::GpuHierarchicalReduction ? true : false;
   ORT_RETURN_IF_ERROR(AddGradientScalingNodes(nodearg_name_generator, scale, gradient_argdefs, fused_gradient_argdef, graph_defs,
                                               opt_graph_config_.AllReduceDataType(), fuse_scaling_outputs));
 
@@ -200,7 +202,7 @@ Status AdasumOptimizerGraphBuilder::BuildInternal(
   if (opt_graph_config_.adasum_reduction_type == AdasumReductionType::GpuHierarchicalReduction) {
 #ifdef ORT_USE_NCCL
     ORT_RETURN_IF_ERROR(AddNcclAllReduceForGradientsWithGroups(gradient_argdefs, fused_gradient_argdef, graph_defs,
-                                                              reduced_fused_gradient_argdef, WorkerGroupType::NodeLocalDataParallel));
+                                                               reduced_fused_gradient_argdef, WorkerGroupType::NodeLocalDataParallel));
 #else
     ORT_THROW("ORT is not built with NCCL.");
 #endif

--- a/orttraining/orttraining/core/graph/optimizer_config.h
+++ b/orttraining/orttraining/core/graph/optimizer_config.h
@@ -50,7 +50,7 @@ struct OptimizerNodeConfig {
   std::unordered_map<std::string, float> attributes{};
   std::unordered_map<std::string, int64_t> int_attributes{};
   std::string loss_scale_input_name{};
-  NameMLValMap initial_states{}; // initial states for optimizer initializers
+  NameMLValMap initial_states{};  // initial states for optimizer initializers
   bool use_mixed_precision_moments{false};
   bool update_weight{true};  // indicates whether Optimizer should do weight update, or output new gradient
   bool enabled{true};        // indicates whether this weight is included in the Optimizer
@@ -66,12 +66,18 @@ struct OptimizerGraphConfig {
   MixedPrecisionDataType mixed_precision_type{MixedPrecisionDataType::FP16};
   bool allreduce_in_mixed_precision_type{false};
   bool use_nccl{false};
+  bool enable_grad_norm_clip{true};
+
+  // whether prescale gradient with total sample count.
+  // by default false, then we prescale gradient with gradient_accumulation_step * data_parallel_size
+  bool prescale_grads_with_sample_count{false};
+  std::string sample_count_input_name{};
+
   ZeROConfig deepspeed_zero{0};
   int gradient_accumulation_steps{1};
   std::string loss_scale_input_name{};  // empty string means no loss scaling factor is applied
   AdasumReductionType adasum_reduction_type{AdasumReductionType::None};
-  bool enable_grad_norm_clip{true};
-  NameMLValMap shared_optimizer_states{}; // initial states for shared params, eg. 'Step' for lamb
+  NameMLValMap shared_optimizer_states{};  // initial states for shared params, eg. 'Step' for lamb
 
   ONNX_NAMESPACE::TensorProto_DataType AllReduceDataType() const {
     if (!allreduce_in_mixed_precision_type) {
@@ -79,10 +85,13 @@ struct OptimizerGraphConfig {
     }
 
     switch (mixed_precision_type) {
-      case MixedPrecisionDataType::FP16: return ONNX_NAMESPACE::TensorProto_DataType_FLOAT16;
-      case MixedPrecisionDataType::BF16: return ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16;
-      default: return ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED;
-    }  
+      case MixedPrecisionDataType::FP16:
+        return ONNX_NAMESPACE::TensorProto_DataType_FLOAT16;
+      case MixedPrecisionDataType::BF16:
+        return ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16;
+      default:
+        return ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED;
+    }
   }
 };
 

--- a/orttraining/orttraining/core/graph/optimizer_graph_builder.cc
+++ b/orttraining/orttraining/core/graph/optimizer_graph_builder.cc
@@ -155,8 +155,7 @@ Status OptimizerGraphBuilder::AddGradientScalingNodes(
 Status OptimizerGraphBuilder::AddGradientScalingNodes(
     const NodeArgNameGeneratorFn& nodearg_name_generator,
     const float scale,
-    std::vector<ArgDef>& input_gradient_argdefs,  // update argdefs in place
-    std::vector<ArgDef>& output_gradient_argdef,  // update argdef in place
+    std::vector<ArgDef>& gradient_argdefs,  // update argdefs in place
     GraphAugmenter::GraphDefs& graph_defs,
     ONNX_NAMESPACE::TensorProto_DataType target_type) {
   ArgDef pre_allreduce_scale(nodearg_name_generator("pre_allreduce_scale"),
@@ -169,12 +168,13 @@ Status OptimizerGraphBuilder::AddGradientScalingNodes(
 
   std::vector<ArgDef> inputs;
   inputs.emplace_back(pre_allreduce_scale);
-  for (size_t i = 0; i < input_gradient_argdefs.size(); ++i) {
-    inputs.emplace_back(input_gradient_argdefs[i]);
+  for (size_t i = 0; i < gradient_argdefs.size(); ++i) {
+    inputs.emplace_back(gradient_argdefs[i]);
   }
 
-  for (size_t i = 0; i < input_gradient_argdefs.size(); ++i) {
-    ArgDef& gradient_argdef = input_gradient_argdefs[i];
+  std::vector<ArgDef> output_gradient_argdef;
+  for (size_t i = 0; i < gradient_argdefs.size(); ++i) {
+    ArgDef& gradient_argdef = gradient_argdefs[i];
 
     TypeProto* scaled_gradient_type_proto = graph_defs.CopyTypeProto(gradient_argdef);
     scaled_gradient_type_proto->mutable_tensor_type()->set_elem_type(target_type);
@@ -188,6 +188,7 @@ Status OptimizerGraphBuilder::AddGradientScalingNodes(
                                   std::vector<AttributeProto>({ONNX_NAMESPACE::MakeAttribute("to", static_cast<int64_t>(target_type))}),
                                   pre_allreduce_scale.name)});
 
+  gradient_argdefs = std::move(output_gradient_argdef);
   return Status::OK();
 }
 

--- a/orttraining/orttraining/core/graph/optimizer_graph_builder.h
+++ b/orttraining/orttraining/core/graph/optimizer_graph_builder.h
@@ -87,7 +87,7 @@ class OptimizerGraphBuilder {
 
   Status AddGradientScalingNodes(
       const NodeArgNameGeneratorFn& nodearg_name_generator,
-      const float scale,
+      const ArgDef& pre_allreduce_scale,
       std::vector<ArgDef>& gradient_argdefs,
       ArgDef& fused_gradient_argdef,
       GraphAugmenter::GraphDefs& graph_defs,
@@ -96,10 +96,14 @@ class OptimizerGraphBuilder {
 
   Status AddGradientScalingNodes(
       const NodeArgNameGeneratorFn& nodearg_name_generator,
-      const float scale,
+      const ArgDef& pre_allreduce_scale,
       std::vector<ArgDef>& gradient_argdefs,  // update argdefs in place
       GraphAugmenter::GraphDefs& graph_defs,
       ONNX_NAMESPACE::TensorProto_DataType allreduce_element_type);
+
+  ArgDef GetGradientPreAllReduceScaler(
+      const NodeArgNameGeneratorFn& nodearg_name_generator,
+      GraphAugmenter::GraphDefs& graph_defs);
 
   Status AddGradientNorm(
       const NodeArgNameGeneratorFn& nodearg_name_generator,

--- a/orttraining/orttraining/core/graph/optimizer_graph_builder.h
+++ b/orttraining/orttraining/core/graph/optimizer_graph_builder.h
@@ -97,10 +97,9 @@ class OptimizerGraphBuilder {
   Status AddGradientScalingNodes(
       const NodeArgNameGeneratorFn& nodearg_name_generator,
       const float scale,
-      std::vector<ArgDef>& gradient_argdefs,        // update argdefs in place
-      std::vector<ArgDef>& output_gradient_argdef,  // update argdef in place
+      std::vector<ArgDef>& gradient_argdefs,  // update argdefs in place
       GraphAugmenter::GraphDefs& graph_defs,
-      ONNX_NAMESPACE::TensorProto_DataType target_type);
+      ONNX_NAMESPACE::TensorProto_DataType allreduce_element_type);
 
   Status AddGradientNorm(
       const NodeArgNameGeneratorFn& nodearg_name_generator,

--- a/orttraining/orttraining/core/graph/zero_optimizer_graph_builder.cc
+++ b/orttraining/orttraining/core/graph/zero_optimizer_graph_builder.cc
@@ -83,7 +83,7 @@ static Status AddL2NormNcclAllReduce(
                                   {norm_squared},
                                   {allreduce_output},
                                   {ONNX_NAMESPACE::MakeAttribute("group_type",
-                                                                static_cast<int64_t>(WorkerGroupType::DataParallel))},
+                                                                 static_cast<int64_t>(WorkerGroupType::DataParallel))},
                                   allreduce_output.name)});
 
   // Sqrt the reduced L2 norm.
@@ -452,9 +452,16 @@ Status ZeROOptimizerGraphBuilder::BuildInternal(
 
   // add gradient scaling
   ArgDef fused_gradient_argdef;
-  const auto total_num_accumulations = opt_graph_config_.gradient_accumulation_steps * opt_graph_config_.data_parallel_group_size;
-  ORT_RETURN_IF_NOT(total_num_accumulations > 0);
-  const float scale = 1.0f / total_num_accumulations;
+  ArgDef scale;
+  if (opt_graph_config_.prescale_grads_with_sample_count) {
+    scale = GetGradientPreAllReduceScaler(nodearg_name_generator, graph_defs);
+  } else {
+    const auto total_num_accumulations = opt_graph_config_.gradient_accumulation_steps * opt_graph_config_.data_parallel_group_size;
+    ORT_RETURN_IF_NOT(total_num_accumulations > 0);
+    const float scale_value = 1.0f / total_num_accumulations;
+    scale = ArgDef(nodearg_name_generator("grad_pre_scaler"), graph_defs.CreateTypeProto({}, ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
+    graph_defs.AddInitializers({CreateTensorProto<float>(scale.name, scale_value, {})});
+  }
   ORT_RETURN_IF_ERROR(AddGradientScalingNodes(nodearg_name_generator, scale, gradient_argdefs, fused_gradient_argdef, graph_defs,
                                               opt_graph_config_.AllReduceDataType(), false));
 

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -128,6 +128,8 @@ Status SetupOptimizerParams(
   opt_graph_config.adasum_reduction_type = optimizer_config.adasum_reduction_type;
   opt_graph_config.enable_grad_norm_clip = optimizer_config.enable_grad_norm_clip;
   opt_graph_config.deepspeed_zero = optimizer_config.deepspeed_zero;
+  opt_graph_config.prescale_grads_with_sample_count = optimizer_config.prescale_grads_with_sample_count;
+  opt_graph_config.sample_count_input_name = optimizer_config.sample_count_input_name;
 
   // check if shared initial optimizer states have been provided
   if (config.init_optimizer_states) {
@@ -422,7 +424,7 @@ Status TrainingSession::ConfigureForTraining(
   ORT_RETURN_IF_ERROR(ApplyModelParallelTransformationsToMainGraph(trainable_initializers, config_result));
 
   weight_partition_info_ = config_result.weight_partition_info;
-  
+
   // Save the model after graph transformations
   if (IsRootNode(config) && config.model_after_graph_transforms_path.has_value()) {
     ORT_IGNORE_RETURN_VALUE(Save(
@@ -464,7 +466,7 @@ Status TrainingSession::ConfigureForTraining(
 
   ORT_RETURN_IF_ERROR(BuildGradientGraph(
       weight_names_to_train, loss_name, config.gradient_graph_config, *session_logger_));
-    
+
   if (IsRootNode(config) && config.model_with_gradient_graph_path.has_value()) {
     ORT_IGNORE_RETURN_VALUE(Save(
         config.model_with_gradient_graph_path.value(), SaveOption::NO_RELOAD));
@@ -1685,10 +1687,10 @@ Status PipelineTrainingSession::BuildLossAndLossScaling(
   loss_scale_input_name = enable_true_loss_scale ? optional<std::string>{""} : optional<std::string>{};
 
   ORT_RETURN_IF_ERROR(BuildLoss(
-    external_loss_name,
-    loss_name,
-    loss_function_config,
-    loss_scale_input_name));
+      external_loss_name,
+      loss_name,
+      loss_function_config,
+      loss_scale_input_name));
 
   if (enable_true_loss_scale) {
     TrainingConfigurationResult::MixedPrecisionConfigurationResult mp_result{};

--- a/orttraining/orttraining/core/session/training_session.h
+++ b/orttraining/orttraining/core/session/training_session.h
@@ -39,7 +39,7 @@ class TrainingSession : public InferenceSession {
 
   TrainingSession(const SessionOptions& session_options, const Environment& env)
       : InferenceSession(session_options, env) {}
-  virtual ~TrainingSession() {};
+  virtual ~TrainingSession(){};
 
   /**
    * The training configuration options.
@@ -179,6 +179,10 @@ class TrainingSession : public InferenceSession {
       AdasumReductionType adasum_reduction_type{AdasumReductionType::None};
       // Whether to enable gradient clipping.
       bool enable_grad_norm_clip{true};
+      // Whether to prescale gradient with accumulated sample count instead of accumulation_step * data_parallel_size.
+      bool prescale_grads_with_sample_count{false};
+      // The sample count input name.
+      std::string sample_count_input_name{};
     };
     // The optimizer configuration.
     // If not provided, no optimizer is added.
@@ -503,16 +507,16 @@ class TrainingSession : public InferenceSession {
       std::string& loss_name,
       const optional<TrainingConfiguration::LossFunctionConfiguration>& loss_function_config,
       optional<std::string>& loss_scale_input_name);
-  
+
   virtual common::Status BuildLossAndLossScaling(
-    const int32_t pipeline_stage_id,
-    const optional<std::string>& external_loss_name,
-    const optional<TrainingConfiguration::MixedPrecisionConfiguration>& mixed_precision_config,
-    const optional<TrainingConfiguration::DistributedConfiguration>& distributed_config,
-    const optional<TrainingConfiguration::LossFunctionConfiguration>& loss_function_config,
-    std::string& loss_name,
-    optional<std::string>& loss_scale_input_name,
-    optional<TrainingConfigurationResult::MixedPrecisionConfigurationResult>& mixed_precision_config_result);
+      const int32_t pipeline_stage_id,
+      const optional<std::string>& external_loss_name,
+      const optional<TrainingConfiguration::MixedPrecisionConfiguration>& mixed_precision_config,
+      const optional<TrainingConfiguration::DistributedConfiguration>& distributed_config,
+      const optional<TrainingConfiguration::LossFunctionConfiguration>& loss_function_config,
+      std::string& loss_name,
+      optional<std::string>& loss_scale_input_name,
+      optional<TrainingConfigurationResult::MixedPrecisionConfigurationResult>& mixed_precision_config_result);
 
   /** Enable mixed precision training
   @param weights_to_train a set of weights to be training.
@@ -595,14 +599,14 @@ class PipelineTrainingSession final : public TrainingSession {
       optional<TrainingConfigurationResult::PipelineConfigurationResult>& pipeline_config_result) override;
 
   common::Status BuildLossAndLossScaling(
-    const int32_t pipeline_stage_id,
-    const optional<std::string>& external_loss_name,
-    const optional<TrainingConfiguration::MixedPrecisionConfiguration>& mixed_precision_config,
-    const optional<TrainingConfiguration::DistributedConfiguration>& distributed_config,
-    const optional<TrainingConfiguration::LossFunctionConfiguration>& loss_function_config,
-    std::string& loss_name,
-    optional<std::string>& loss_scale_input_name,
-    optional<TrainingConfigurationResult::MixedPrecisionConfigurationResult>& mixed_precision_config_result) override;
+      const int32_t pipeline_stage_id,
+      const optional<std::string>& external_loss_name,
+      const optional<TrainingConfiguration::MixedPrecisionConfiguration>& mixed_precision_config,
+      const optional<TrainingConfiguration::DistributedConfiguration>& distributed_config,
+      const optional<TrainingConfiguration::LossFunctionConfiguration>& loss_function_config,
+      std::string& loss_name,
+      optional<std::string>& loss_scale_input_name,
+      optional<TrainingConfigurationResult::MixedPrecisionConfigurationResult>& mixed_precision_config_result) override;
 
   // Set some PipelineContext fields based on configuration result
   // returned by TrainingSession::ConfigureForTraining.

--- a/orttraining/orttraining/models/bert/main.cc
+++ b/orttraining/orttraining/models/bert/main.cc
@@ -169,6 +169,8 @@ Status ParseArguments(int argc, char* argv[], BertParameters& params, OrtParamet
       "separate each consumer node with a '/'. ", cxxopts::value<std::vector<std::string>>()->default_value(""))
       ("enable_grad_norm_clip", "Specify whether to enable gradient clipping for optimizers.",
         cxxopts::value<bool>()->default_value("true"))
+      ("prescale_grads_with_sample_count", "Specify whether to prescale gradients with accumulated sample count.",
+        cxxopts::value<bool>()->default_value("false"))
       ("enable_gelu_approximation", "Specify whether to enable GELU approximation.",
         cxxopts::value<bool>()->default_value("true"))
       ("attn_dropout_recompute", "Enable checkpointing of attention dropout to save memory.",
@@ -348,6 +350,7 @@ Status ParseArguments(int argc, char* argv[], BertParameters& params, OrtParamet
 
     params.deepspeed_zero = ZeROConfig(flags["deepspeed_zero_stage"].as<int>());
     params.enable_grad_norm_clip = flags["enable_grad_norm_clip"].as<bool>();
+    params.prescale_grads_with_sample_count = flags["prescale_grads_with_sample_count"].as<bool>();
 
     float alpha = flags["alpha"].as<float>();
     float beta = flags["beta"].as<float>();
@@ -802,7 +805,8 @@ int main(int argc, char* argv[]) {
   OrtParameters ort_params{};
   RETURN_IF_FAIL(ParseArguments(argc, argv, params, ort_params));
   bool keep_looping = params.debug_break;
-  while(keep_looping);
+  while (keep_looping)
+    ;
 
   // setup logger, be noted: LOGS_DEFAULT must be after logging manager initialization.
   string default_logger_id{"Default"};

--- a/orttraining/orttraining/models/runner/training_runner.cc
+++ b/orttraining/orttraining/models/runner/training_runner.cc
@@ -146,6 +146,7 @@ Status TrainingRunner::Initialize() {
     opt.deepspeed_zero = params_.deepspeed_zero;
     opt.adasum_reduction_type = params_.GetAdasumReductionType();
     opt.enable_grad_norm_clip = params_.enable_grad_norm_clip;
+    opt.prescale_grads_with_sample_count = params_.prescale_grads_with_sample_count;
     config.optimizer_config = opt;
   }
 

--- a/orttraining/orttraining/models/runner/training_runner.h
+++ b/orttraining/orttraining/models/runner/training_runner.h
@@ -181,6 +181,8 @@ class TrainingRunner {
     VectorString pipeline_stage_paths;
     // Enable gradient clipping.
     bool enable_grad_norm_clip = true;
+    // Enable gradient prescaling with sample count
+    bool prescale_grads_with_sample_count = false;
 
     // Enable GELU approximation
     bool enable_gelu_approximation = false;
@@ -237,7 +239,7 @@ class TrainingRunner {
                         size_t& gradient_accumulation_step_count);
   void CheckWorkerException(const std::exception_ptr& p);
   Status TrainingLoop(IDataLoader& training_data_loader, IDataLoader* test_data_loader,
-    const MapStringToString& mapped_dimensions);
+                      const MapStringToString& mapped_dimensions);
   Status Evaluate(TrainingSession& session, IDataLoader& data_loader);
 
   Status SaveCheckpoint(const PathString& checkpoint_path);

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -393,7 +393,9 @@ def create_ort_training_session_with_optimizer(model, device, training_optimizer
                                                frozen_weights=[], opset_version=DEFAULT_OPSET_VERSION,
                                                use_deterministic_compute=False,
                                                use_invertible_layernorm_grad=False,
-                                               enable_adasum=False):
+                                               enable_adasum=False,
+                                               prescale_grads_with_sample_count=False,
+                                               sample_count_feed_name=None):
     output_name = model.graph.output[0].name
     ort_parameters = ort.TrainingParameters()
     ort_parameters.loss_output_name = output_name
@@ -407,6 +409,8 @@ def create_ort_training_session_with_optimizer(model, device, training_optimizer
     ort_parameters.set_gradients_as_graph_outputs = False
     ort_parameters.use_invertible_layernorm_grad = use_invertible_layernorm_grad
     ort_parameters.enable_adasum = enable_adasum
+    ort_parameters.prescale_grads_with_sample_count = prescale_grads_with_sample_count
+    ort_parameters.sample_count_feed_name = sample_count_feed_name
     output_types = {}
     for output in model.graph.output:
         output_types[output.name] = output.type.tensor_type
@@ -548,7 +552,8 @@ class ORTTrainer():
                  global_step=0, get_lr_this_step=None, loss_scaler=None, deepspeed_zero_stage=0,
                  enable_grad_norm_clip=True, frozen_weights=[], _opset_version=DEFAULT_OPSET_VERSION,
                  _enable_internal_postprocess=True, _extra_postprocess=None, _use_deterministic_compute=False,
-                 use_invertible_layernorm_grad=False, run_symbolic_shape_infer=False, enable_adasum=False):
+                 use_invertible_layernorm_grad=False, run_symbolic_shape_infer=False, enable_adasum=False,
+                 prescale_grads_with_sample_count=False, sample_count_description=None):
         super(ORTTrainer, self).__init__()
         """
         Initialize ORTTrainer.
@@ -618,6 +623,13 @@ class ORTTrainer():
                Defaults to False
             run_symbolic_shape_infer: run symbolic shape inference
                Defaults to False
+            prescale_grads_with_sample_count: prescale gradient with accumulated sample count.
+                Defaults to False
+            sample_count_description: the name, shape and type of the accumulated single rank 
+               sample count in form of IODescription(Sample_Count_Name, [1,], torch.float32).
+               Because sample_count is an input to the training model,
+               Sample_Count_Name must be specified so that there is no name conflict
+               within the model. Only applicable when prescale_grads_with_sample_count is True.
         """
         warnings.warn('DISCLAIMER: This is an early version of an experimental training API and it is subject to change. DO NOT create production applications with it')
         self.is_train = True
@@ -646,7 +658,7 @@ class ORTTrainer():
                 self._extra_postprocess(self.onnx_model_)
 
         self.model_desc_ = model_desc
-        self.input_desc_with_lr = [*self.model_desc_.inputs_, learning_rate_description]
+        self.input_desc_with_lr = [*self.model_desc_.inputs_, learning_rate_description, sample_count_description]
 
         self.world_rank = world_rank
         self.world_size = world_size
@@ -681,6 +693,8 @@ class ORTTrainer():
         self.use_invertible_layernorm_grad = use_invertible_layernorm_grad
         self.run_symbolic_shape_infer = run_symbolic_shape_infer
         self.enable_adasum = enable_adasum
+        self.prescale_grads_with_sample_count_ = prescale_grads_with_sample_count
+        self.sample_count_description_ = sample_count_description
 
         # use this special string to workaround a corner case that external loss_scale is passed into train_step as kwargs.
         # see prepare_input_and_fetches for more details.
@@ -711,7 +725,9 @@ class ORTTrainer():
                 enable_grad_norm_clip=self.enable_grad_norm_clip_,
                 frozen_weights=self.frozen_weights_, opset_version=self.opset_version_,
                 use_deterministic_compute=self._use_deterministic_compute,
-                use_invertible_layernorm_grad=self.use_invertible_layernorm_grad, enable_adasum=self.enable_adasum)
+                use_invertible_layernorm_grad=self.use_invertible_layernorm_grad, enable_adasum=self.enable_adasum,
+                prescale_grads_with_sample_count=self.prescale_grads_with_sample_count_,
+                sample_count_feed_name=self.sample_count_description_.name_)
 
         self.loss_scale_input_name = self.session.loss_scale_input_name
 

--- a/orttraining/orttraining/python/training/model_desc_validation.py
+++ b/orttraining/orttraining/python/training/model_desc_validation.py
@@ -5,6 +5,7 @@ from ._utils import static_vars
 
 
 LEARNING_RATE_IO_DESCRIPTION_NAME = "__learning_rate"
+SAMPLE_COUNT_IO_DESCRIPTION_NAME = "__accumulated_sample_count_per_rank"
 ALL_FINITE_IO_DESCRIPTION_NAME = "__all_finite"
 LOSS_SCALE_INPUT_IO_DESCRIPTION_NAME = "__loss_scale_input_name"
 GRADIENT_ACCUMULATION_IO_DESCRIPTION_NAME = "__gradient_accumulation_name"
@@ -50,6 +51,7 @@ class _ORTTrainerModelDesc(object):
 
         # Hard-code learning rate, all_finite descriptors
         self.learning_rate = self._InputDescriptionTyped(LEARNING_RATE_IO_DESCRIPTION_NAME, [1], torch.float32)
+        self.sample_count = self._InputDescriptionTyped(SAMPLE_COUNT_IO_DESCRIPTION_NAME, [1], torch.float32)
 
         # Convert dict in object
         for k, v in self._validated.items():
@@ -91,6 +93,11 @@ class _ORTTrainerModelDesc(object):
         if self.learning_rate:
             pretty_msg += '\nLearning rate: '
             pretty_msg += f'(name={self.learning_rate.name}, shape={self.learning_rate.shape}, dtype={self.learning_rate.dtype})'
+
+        # Sample count per rank
+        if self.sample_count:
+            pretty_msg += '\nSample count per rank: '
+            pretty_msg += f'(name={self.sample_count.name}, shape={self.sample_count.shape}, dtype={self.sample_count.dtype})'
 
         # Mixed precision
         if getattr(self, ALL_FINITE_IO_DESCRIPTION_NAME, None) or getattr(self, LOSS_SCALE_INPUT_IO_DESCRIPTION_NAME, None):

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -211,7 +211,11 @@ class ORTTrainerOptions(object):
                         'run_symbolic_shape_infer' : {
                             'type' : 'boolean',
                             'default' : False
-                        }
+                        },
+                        'prescale_grads_with_sample_count' : {
+                            'type' : 'boolean',
+                            'default' : False
+                        },
                     }
                 },
                 'debug' : {
@@ -348,6 +352,8 @@ class ORTTrainerOptions(object):
             enables use of invertible layer norm gradients
         utils.run_symbolic_shape_infer (bool, default is False):
             runs symbolic shape inference on the model
+        utils.prescale_grads_with_sample_count  (bool, default is False):
+            prescales gradients with accumulated sample count.
         debug (dict):
             debug options
         debug.deterministic_compute (bool, default is False)
@@ -657,6 +663,10 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
                 'default': False
             },
             'run_symbolic_shape_infer': {
+                'type': 'boolean',
+                'default': False
+            },
+            'prescale_grads_with_sample_count': {
                 'type': 'boolean',
                 'default': False
             }

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -80,7 +80,8 @@ def testORTTrainerOptionsDefaultValues(test_input):
             'frozen_weights': [],
             'grad_norm_clip': True,
             'invertible_layer_norm_gradient': False,
-            'run_symbolic_shape_infer': False
+            'run_symbolic_shape_infer': False,
+            'prescale_grads_with_sample_count': False
         },
         'debug': {
             'deterministic_compute': False,


### PR DESCRIPTION
**Description**: To fill the gap for FairSeq models.

In FairSeq trainer, they calculate the gradients first, once a global step is done, divide the gradient with total sample count of the global step. 

To support FairSeq models in ORT, we need align with this.  

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
