### PR TITLE
Unblock Android CI code coverage failure

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: Android_CI
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-10.14'
   timeoutInMinutes: 120
   steps:
   # Onnx has no 3.9 python package available yet, need to use python 3.8 to avoid build onnx package


### PR DESCRIPTION
**Description**: Unblock Android CI code coverage failure

**Motivation and Context**
- The Android CI fails to generate code coverage data from 1/19. From the failed run, seems the compiler setting are changed in the pipeline.
- The exact reason of the failure is unknown. But use MacOS 10.14 can temporarily mitigate this problem.
