### PR TITLE
[Experimenting]Replace deepthink longformer's subgraph with SequencePooling Op

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/sequence_pooling.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/sequence_pooling.cc
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "sequence_pooling.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+#define REGISTER_KERNEL_TYPED(T)                                  \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
+      SequencePooling,                                            \
+      kMSDomain,                                                  \
+      1,                                                          \
+      T,                                                          \
+      kCpuExecutionProvider,                                      \
+      KernelDefBuilder()                                          \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      SequencePooling<T>);
+
+REGISTER_KERNEL_TYPED(float)
+
+template <typename T>
+SequencePooling<T>::SequencePooling(const OpKernelInfo& op_kernel_info) : OpKernel(op_kernel_info) {
+}
+
+template <typename T>
+Status SequencePooling<T>::Compute(OpKernelContext* context) const {
+  // get inputs tensors and data
+  const Tensor* input_tensor = context->Input<Tensor>(0);
+  const T* input_data = input_tensor->template Data<T>();
+  const Tensor* sentence_lengthes_tensor = context->Input<Tensor>(1);
+  //const int32_t* sentence_lengthes_data = sentence_lengthes_tensor->template Data<int32_t>();
+
+  // shape info
+  const auto& input_shape = input_tensor->Shape().GetDims();
+  const int batch_size = static_cast<int>(input_shape[0]);
+  //const int sequence_length_for_split = static_cast<int>(input_shape[1]);
+  const int hidden_size = static_cast<int>(input_shape[2]);
+
+  const auto& sentence_lengthes_shape = sentence_lengthes_tensor->Shape().GetDims();
+  const int num_sequences = static_cast<int>(sentence_lengthes_shape[1]);
+
+  // initialize outputs
+  TensorShape output_shape({batch_size, num_sequences, hidden_size});
+  Tensor* output_tensor(context->Output(0, output_shape));
+  T* output_data = output_tensor->template MutableData<T>();
+
+  Tensor* masks_tensor(context->Output(1, sentence_lengthes_tensor->Shape()));
+  T* masks_data = masks_tensor->template MutableData<T>();
+
+  // assign values to outputs
+  memcpy(output_data, input_data, batch_size * num_sequences * hidden_size * sizeof(T));
+  for (int i = 0; i < batch_size * num_sequences; i++) {
+    *masks_data++ = 1;
+  }
+
+  return Status::OK();
+}
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/bert/sequence_pooling.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/sequence_pooling.cc
@@ -53,7 +53,7 @@ Status SequencePooling<T>::Compute(OpKernelContext* context) const {
   const Tensor* input_tensor = context->Input<Tensor>(0);
   const T* input_data = input_tensor->template Data<T>();
   const Tensor* sentence_lengthes_tensor = context->Input<Tensor>(1);
-  const int32_t* sentence_lengthes_data = sentence_lengthes_tensor->template Data<int32_t>();
+  const int64_t* sentence_lengthes_data = sentence_lengthes_tensor->template Data<int64_t>();
 
   // shape info
   const auto& input_shape = input_tensor->Shape().GetDims();
@@ -64,9 +64,9 @@ Status SequencePooling<T>::Compute(OpKernelContext* context) const {
   const int num_sequences = static_cast<int>(sentence_lengthes_shape[1]);
 
   // check inputs
-  std::vector<std::vector<int32_t>> sentence_lengthes_prefixsum;
+  std::vector<std::vector<int64_t>> sentence_lengthes_prefixsum;
   for (int batch = 0; batch < batch_size; ++batch) {
-    std::vector<int32_t> sentence_length_prefixsum;
+    std::vector<int64_t> sentence_length_prefixsum;
     sentence_length_prefixsum.reserve(num_sequences);
 
     const std::ptrdiff_t offset(batch * num_sequences);
@@ -91,8 +91,8 @@ Status SequencePooling<T>::Compute(OpKernelContext* context) const {
   for (int batch = 0; batch < batch_size; ++batch) {
     ThreadPool::TryParallelFor(tp, loop_len, cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
       for (std::ptrdiff_t i = begin; i != end; ++i) {
-        const int32_t* sentence_length_data(sentence_lengthes_data + i);
-        const int32_t sentence_length(*sentence_length_data);
+        const int64_t* sentence_length_data(sentence_lengthes_data + i);
+        const int64_t sentence_length(*sentence_length_data);
         if (sentence_length == 0) {
           continue;
         }
@@ -109,7 +109,8 @@ Status SequencePooling<T>::Compute(OpKernelContext* context) const {
   }
 
   // optional 2: column-based, need to transpose first, easy to parallel(even distribution), especially in cuda
-  // todo
+  // todo:
+
   return Status::OK();
 }
 

--- a/onnxruntime/contrib_ops/cpu/bert/sequence_pooling.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/sequence_pooling.cc
@@ -34,12 +34,12 @@ inline static void MaxPoolingByRowImpl(T* start_dst, const T* start_src, const T
 }
 
 template <typename T>
-static void MaxPoolingByRow(T* start_dst, const T* start_src, int32_t sentence_length, int hidden_size) {
+static void MaxPoolingByRow(T* start_dst, const T* start_src, int64_t sentence_length, int hidden_size) {
   ORT_ENFORCE(sentence_length > 0);
   memcpy(start_dst, start_src, hidden_size * sizeof(T));
   for (int offset = 1; offset < sentence_length; ++offset) {
     start_src += hidden_size;
-    MaxPoolingByRowImpl(start_dst, start_src, start_src + hidden_size);
+    MaxPoolingByRowImpl<T>(start_dst, start_src, start_src + hidden_size);
   }
 }
 
@@ -99,7 +99,7 @@ Status SequencePooling<T>::Compute(OpKernelContext* context) const {
         const std::ptrdiff_t past_sentence_length_sum = (i == 0) ? 0 : sentence_lengthes_prefixsum[batch][i - 1];
         const std::ptrdiff_t input_offset(batch * sequence_length_for_split * hidden_size + past_sentence_length_sum * hidden_size);
         const std::ptrdiff_t output_offset(batch * num_sequences * hidden_size + i * hidden_size);
-        MaxPoolingByRow(output_data + output_offset, input_data + input_offset, sentence_length, hidden_size);
+        MaxPoolingByRow<T>(output_data + output_offset, input_data + input_offset, sentence_length, hidden_size);
       }
     });
   }

--- a/onnxruntime/contrib_ops/cpu/bert/sequence_pooling.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/sequence_pooling.cc
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 #include "sequence_pooling.h"
+#include "core/platform/threadpool.h"
+
+using onnxruntime::concurrency::ThreadPool;
 
 namespace onnxruntime {
 namespace contrib {
@@ -20,6 +23,27 @@ namespace contrib {
 REGISTER_KERNEL_TYPED(float)
 
 template <typename T>
+inline static void MaxPoolingByRowImpl(T* start_dst, const T* start_src, const T* end_src) {
+  while (start_src != end_src) {
+    if (*start_src > *start_dst) {
+      *start_dst = *start_src;
+    }
+    ++start_src;
+    ++start_dst;
+  }
+}
+
+template <typename T>
+static void MaxPoolingByRow(T* start_dst, const T* start_src, int32_t sentence_length, int hidden_size) {
+  ORT_ENFORCE(sentence_length > 0);
+  memcpy(start_dst, start_src, hidden_size * sizeof(T));
+  for (int offset = 1; offset < sentence_length; ++offset) {
+    start_src += hidden_size;
+    MaxPoolingByRowImpl(start_dst, start_src, start_src + hidden_size);
+  }
+}
+
+template <typename T>
 SequencePooling<T>::SequencePooling(const OpKernelInfo& op_kernel_info) : OpKernel(op_kernel_info) {
 }
 
@@ -29,16 +53,28 @@ Status SequencePooling<T>::Compute(OpKernelContext* context) const {
   const Tensor* input_tensor = context->Input<Tensor>(0);
   const T* input_data = input_tensor->template Data<T>();
   const Tensor* sentence_lengthes_tensor = context->Input<Tensor>(1);
-  //const int32_t* sentence_lengthes_data = sentence_lengthes_tensor->template Data<int32_t>();
+  const int32_t* sentence_lengthes_data = sentence_lengthes_tensor->template Data<int32_t>();
 
   // shape info
   const auto& input_shape = input_tensor->Shape().GetDims();
   const int batch_size = static_cast<int>(input_shape[0]);
-  //const int sequence_length_for_split = static_cast<int>(input_shape[1]);
+  const int sequence_length_for_split = static_cast<int>(input_shape[1]);
   const int hidden_size = static_cast<int>(input_shape[2]);
-
   const auto& sentence_lengthes_shape = sentence_lengthes_tensor->Shape().GetDims();
   const int num_sequences = static_cast<int>(sentence_lengthes_shape[1]);
+
+  // check inputs
+  std::vector<std::vector<int32_t>> sentence_lengthes_prefixsum;
+  for (int batch = 0; batch < batch_size; ++batch) {
+    std::vector<int32_t> sentence_length_prefixsum;
+    sentence_length_prefixsum.reserve(num_sequences);
+
+    const std::ptrdiff_t offset(batch * num_sequences);
+    std::partial_sum(sentence_lengthes_data + offset, sentence_lengthes_data + offset + num_sequences, sentence_length_prefixsum.begin());
+
+    ORT_ENFORCE(sentence_length_prefixsum[num_sequences - 1] == sequence_length_for_split);
+    sentence_lengthes_prefixsum.push_back(std::move(sentence_length_prefixsum));
+  }
 
   // initialize outputs
   TensorShape output_shape({batch_size, num_sequences, hidden_size});
@@ -48,12 +84,32 @@ Status SequencePooling<T>::Compute(OpKernelContext* context) const {
   Tensor* masks_tensor(context->Output(1, sentence_lengthes_tensor->Shape()));
   T* masks_data = masks_tensor->template MutableData<T>();
 
-  // assign values to outputs
-  memcpy(output_data, input_data, batch_size * num_sequences * hidden_size * sizeof(T));
+  // optional 1: row-based, parallel unfriendly(uneven distribution), but no need to transpose ahead for better locality
+  auto* tp = context->GetOperatorThreadPool();
+  const int loop_len = num_sequences;
+  const double cost = static_cast<double>(sequence_length_for_split) * static_cast<double>(hidden_size) / static_cast<double>(num_sequences);
+  for (int batch = 0; batch < batch_size; ++batch) {
+    ThreadPool::TryParallelFor(tp, loop_len, cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+      for (std::ptrdiff_t i = begin; i != end; ++i) {
+        const int32_t* sentence_length_data(sentence_lengthes_data + i);
+        const int32_t sentence_length(*sentence_length_data);
+        if (sentence_length == 0) {
+          continue;
+        }
+        const std::ptrdiff_t past_sentence_length_sum = (i == 0) ? 0 : sentence_lengthes_prefixsum[batch][i - 1];
+        const std::ptrdiff_t input_offset(batch * sequence_length_for_split * hidden_size + past_sentence_length_sum * hidden_size);
+        const std::ptrdiff_t output_offset(batch * num_sequences * hidden_size + i * hidden_size);
+        MaxPoolingByRow(output_data + output_offset, input_data + input_offset, sentence_length, hidden_size);
+      }
+    });
+  }
+
   for (int i = 0; i < batch_size * num_sequences; i++) {
     *masks_data++ = 1;
   }
 
+  // optional 2: column-based, need to transpose first, easy to parallel(even distribution), especially in cuda
+  // todo
   return Status::OK();
 }
 

--- a/onnxruntime/contrib_ops/cpu/bert/sequence_pooling.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/sequence_pooling.cc
@@ -22,8 +22,9 @@ namespace contrib {
 
 REGISTER_KERNEL_TYPED(float)
 
+namespace {
 template <typename T>
-inline static void MaxPoolingByRowImpl(T* start_dst, const T* start_src, const T* end_src) {
+inline void MaxPoolingByRowImpl(T* start_dst, const T* start_src, const T* end_src) {
   while (start_src != end_src) {
     if (*start_src > *start_dst) {
       *start_dst = *start_src;
@@ -34,7 +35,7 @@ inline static void MaxPoolingByRowImpl(T* start_dst, const T* start_src, const T
 }
 
 template <typename T>
-static void MaxPoolingByRow(T* start_dst, const T* start_src, int64_t sentence_length, int hidden_size) {
+void MaxPoolingByRow(T* start_dst, const T* start_src, int64_t sentence_length, int hidden_size) {
   ORT_ENFORCE(sentence_length > 0);
   memcpy(start_dst, start_src, hidden_size * sizeof(T));
   for (int offset = 1; offset < sentence_length; ++offset) {
@@ -42,6 +43,7 @@ static void MaxPoolingByRow(T* start_dst, const T* start_src, int64_t sentence_l
     MaxPoolingByRowImpl<T>(start_dst, start_src, start_src + hidden_size);
   }
 }
+} //namespace
 
 template <typename T>
 SequencePooling<T>::SequencePooling(const OpKernelInfo& op_kernel_info) : OpKernel(op_kernel_info) {

--- a/onnxruntime/contrib_ops/cpu/bert/sequence_pooling.h
+++ b/onnxruntime/contrib_ops/cpu/bert/sequence_pooling.h
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/framework/op_kernel.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+template <typename T>
+class SequencePooling : public OpKernel {
+ public:
+  explicit SequencePooling(const OpKernelInfo& op_kernel_info);
+  Status Compute(OpKernelContext* context) const override;
+
+};
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -11,6 +11,7 @@ namespace contrib {
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SampleOp);
 
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, Attention);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SequencePooling);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, ExpandDims);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedConv);
@@ -156,6 +157,7 @@ Status RegisterCpuContribKernels(KernelRegistry& kernel_registry) {
 
       // add more kernels here
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, Attention)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SequencePooling)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, ExpandDims)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedConv)>,

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -565,7 +565,7 @@ GELU (Gaussian Error Linear Unit) approximation: Y=0.5*X*(1+tanh(0.797885*X+0.03
       .Input(1, "batch_sentence_lengthes", "2D batch_sentence_lengthes with shape (batch_size, num_sequences)", "M")
       .Output(0, "output", "3D output tensor with shape (batch_size, num_sequences, hidden_size)", "T")
       .Output(1, "masks", "2D masks tensor with shape (batch_size, num_sequences)", "T")
-      .TypeConstraint("M", {"tensor(int32)"}, "Constrain input and output integer tensors types")
+      .TypeConstraint("M", {"tensor(int64)"}, "Constrain input and output integer tensors types")
       .TypeConstraint("T", {"tensor(float)", "tensor(float16)"}, "Constrain input and output float tensors types.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         propagateElemTypeFromInputToOutput(ctx, 0, 0);

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -554,6 +554,49 @@ GELU (Gaussian Error Linear Unit) approximation: Y=0.5*X*(1+tanh(0.797885*X+0.03
       .TypeConstraint("T", {"tensor(float)", "tensor(float16)"}, "Constrain input and output types to float or half tensors.")
       .TypeConstraint("U", {"tensor(float)"}, "Constrain mean and inv_std_var to float tensors.")
       .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput);
+
+  static const char* SequencePooling_ver1_doc = R"DOC(sequence pooling and padding trial)DOC";
+
+  ONNX_CONTRIB_OPERATOR_SCHEMA(SequencePooling)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .SetDoc(SequencePooling_ver1_doc)
+      .Input(0, "batch_input_tensor", "3D batch_input_tensor with shape (batch_size, sequence_length_for_split, hidden_size)", "T")
+      .Input(1, "batch_sentence_lengthes", "2D batch_sentence_lengthes with shape (batch_size, num_sequences)", "M")
+      .Output(0, "output", "3D output tensor with shape (batch_size, num_sequences, hidden_size)", "T")
+      .Output(1, "masks", "2D masks tensor with shape (batch_size, num_sequences)", "T")
+      .TypeConstraint("M", {"tensor(int32)"}, "Constrain input and output integer tensors types")
+      .TypeConstraint("T", {"tensor(float)", "tensor(float16)"}, "Constrain input and output float tensors types.")
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        propagateElemTypeFromInputToOutput(ctx, 0, 1);
+        propagateShapeFromInputToOutput(ctx, 1, 1);
+        if (!hasInputShape(ctx, 0))
+          return;
+
+        auto& batch_input_tensor_shape = getInputShape(ctx, 0);
+        auto& batch_input_tensor_dims = batch_input_tensor_shape.dim();
+
+        if (batch_input_tensor_dims.size() != 3) {
+          fail_shape_inference("batch_input_tensor should have 3 dimensions");
+        }
+
+        if (!hasInputShape(ctx, 1))
+          return;
+
+        auto& batch_sentence_lengthes_shape = getInputShape(ctx, 1);
+        auto& batch_sentence_lengthes_dims = batch_sentence_lengthes_shape.dim();
+
+        if (batch_sentence_lengthes_dims.size() != 2) {
+          fail_shape_inference("batch_sentence_lengthes should have 2 dimensions");
+        }
+
+        ONNX_NAMESPACE::TensorShapeProto shape;
+        *shape.add_dim() = batch_input_tensor_dims[0];
+        *shape.add_dim() = batch_sentence_lengthes_dims[1];
+        *shape.add_dim() = batch_input_tensor_dims[2];
+        ONNX_NAMESPACE::updateOutputShape(ctx, 0, shape);
+      });
 }
 
 void RegisterContribSchemas() {

--- a/onnxruntime/test/contrib_ops/sequence_pooling_test.cc
+++ b/onnxruntime/test/contrib_ops/sequence_pooling_test.cc
@@ -9,15 +9,19 @@ namespace test {
 
 TEST(SequencePoolingTest, DummyTest) {
   OpTester test("SequencePooling", 1, onnxruntime::kMSDomain);
-  std::vector<float> batch_input{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
-  std::vector<int32_t> batch_sequence_lengths{4, 8};
-  std::vector<float> output{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
-  std::vector<float> masks{1.0f, 1.0f};
+  std::vector<float> batch_input{1.0f, 2.0f, 3.0f, 3.0f, 5.0f, 5.0f, 4.0f, 3.0f, 6.0f,
+                                 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
+                                 1.0f, 2.0f, 3.0f, 3.0f, 5.0f, 5.0f, 4.0f, 3.0f, 6.0f,
+                                 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
+  std::vector<int32_t> batch_sequence_lengths{1, 2, 3, 1, 2, 3};
+  std::vector<float> output{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
+                            1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
+  std::vector<float> masks{1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
 
-  test.AddInput<float>("batch_input_tensor", {1, 3, 3}, batch_input);
-  test.AddInput<int32_t>("batch_sentence_lengthes", {1, 2}, batch_sequence_lengths);
-  test.AddOutput<float>("output", {1, 2, 3}, output);
-  test.AddOutput<float>("masks", {1, 2}, masks);
+  test.AddInput<float>("batch_input_tensor", {2, 6, 3}, batch_input);
+  test.AddInput<int32_t>("batch_sentence_lengthes", {2, 3}, batch_sequence_lengths);
+  test.AddOutput<float>("output", {2, 3, 3}, output);
+  test.AddOutput<float>("masks", {2, 3}, masks);
   test.Run();
 }
 

--- a/onnxruntime/test/contrib_ops/sequence_pooling_test.cc
+++ b/onnxruntime/test/contrib_ops/sequence_pooling_test.cc
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+TEST(SequencePoolingTest, DummyTest) {
+  OpTester test("SequencePooling", 1, onnxruntime::kMSDomain);
+  std::vector<float> batch_input{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
+  std::vector<int32_t> batch_sequence_lengths{4, 8};
+  std::vector<float> output{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  std::vector<float> masks{1.0f, 1.0f};
+
+  test.AddInput<float>("batch_input_tensor", {1, 3, 3}, batch_input);
+  test.AddInput<int32_t>("batch_sentence_lengthes", {1, 2}, batch_sequence_lengths);
+  test.AddOutput<float>("output", {1, 2, 3}, output);
+  test.AddOutput<float>("masks", {1, 2}, masks);
+  test.Run();
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/sequence_pooling_test.cc
+++ b/onnxruntime/test/contrib_ops/sequence_pooling_test.cc
@@ -13,13 +13,13 @@ TEST(SequencePoolingTest, DummyTest) {
                                  1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
                                  1.0f, 2.0f, 3.0f, 3.0f, 5.0f, 5.0f, 4.0f, 3.0f, 6.0f,
                                  1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
-  std::vector<int32_t> batch_sequence_lengths{1, 2, 3, 1, 2, 3};
+  std::vector<int64_t> batch_sequence_lengths{1, 2, 3, 1, 2, 3};
   std::vector<float> output{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
                             1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
   std::vector<float> masks{1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
 
   test.AddInput<float>("batch_input_tensor", {2, 6, 3}, batch_input);
-  test.AddInput<int32_t>("batch_sentence_lengthes", {2, 3}, batch_sequence_lengths);
+  test.AddInput<int64_t>("batch_sentence_lengthes", {2, 3}, batch_sequence_lengths);
   test.AddOutput<float>("output", {2, 3, 3}, output);
   test.AddOutput<float>("masks", {2, 3}, masks);
   test.Run();


### PR DESCRIPTION
A longformer fp16 model with 4k input length on V100:
the change brings perf from ~40ms -> 15.72ms(the new op takes ~4.6% of the inference time)

what SequencePooling op does: split a 4k*768 tensor to multiple slice and maxpools each of them.

more experiments ongoing...