### PR TITLE
[java] Adds support for OrtEnvironment thread pools

### DIFF
--- a/cmake/onnxruntime_java.cmake
+++ b/cmake/onnxruntime_java.cmake
@@ -137,7 +137,7 @@ else()
   # We don't do distribution for Android
   # Set for completeness
   set(JAVA_PLAT "android")
- endif()
+endif()
 
 # Similar to Nuget schema
 set(JAVA_OS_ARCH ${JAVA_PLAT}-${JNI_ARCH})

--- a/java/build-android.gradle
+++ b/java/build-android.gradle
@@ -63,7 +63,7 @@ android {
 }
 
 dependencies {
-	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.1'
-	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.1'
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 	testImplementation 'com.google.protobuf:protobuf-java:3.10.0'
 }

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'maven-publish'
 	id 'signing'
 	id 'jacoco'
-	id 'com.diffplug.gradle.spotless' version '3.26.0'
+	id 'com.diffplug.spotless' version '5.9.0'
 }
 
 allprojects {
@@ -76,6 +76,7 @@ spotless {
 }
 
 compileJava {
+	dependsOn spotlessJava
 	options.compilerArgs += ["-h", "${project.buildDir}/headers/"]
 }
 
@@ -121,6 +122,7 @@ if (cmakeBuildDir != null) {
 		include 'docs/**'
 		into cmakeBuildOutputDir
 	}
+	cmakeBuild.dependsOn test
 	cmakeBuild.dependsOn allJar
 	cmakeBuild.dependsOn sourcesJar
 	cmakeBuild.dependsOn javadocJar
@@ -136,12 +138,19 @@ if (cmakeBuildDir != null) {
 }
 
 dependencies {
-	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.1'
-	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.1'
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 	testImplementation 'com.google.protobuf:protobuf-java:3.10.0'
 }
 
+processTestResources {
+	duplicatesStrategy(DuplicatesStrategy.INCLUDE) // allows duplicates in the test resources
+}
+
 test {
+	java {
+		dependsOn spotlessJava
+	}
 	useJUnitPlatform()
 	if (cmakeBuildDir != null) {
 		workingDir cmakeBuildDir

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -122,7 +122,6 @@ if (cmakeBuildDir != null) {
 		include 'docs/**'
 		into cmakeBuildOutputDir
 	}
-	cmakeBuild.dependsOn test
 	cmakeBuild.dependsOn allJar
 	cmakeBuild.dependsOn sourcesJar
 	cmakeBuild.dependsOn javadocJar
@@ -134,7 +133,6 @@ if (cmakeBuildDir != null) {
 		into cmakeBuildOutputDir
 	}
 	cmakeCheck.dependsOn check
-
 }
 
 dependencies {

--- a/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
@@ -28,6 +28,8 @@ final class OnnxRuntime {
   private static final int ORT_API_VERSION_2 = 2;
   // Post 1.3 builds of the ORT API
   private static final int ORT_API_VERSION_3 = 3;
+  // Post 1.6 builds of the ORT API
+  private static final int ORT_API_VERSION_7 = 7;
 
   /** The short name of the ONNX runtime shared library */
   static final String ONNXRUNTIME_LIBRARY_NAME = "onnxruntime";
@@ -93,7 +95,7 @@ final class OnnxRuntime {
     try {
       load(tempDirectory, ONNXRUNTIME_LIBRARY_NAME);
       load(tempDirectory, ONNXRUNTIME_JNI_LIBRARY_NAME);
-      ortApiHandle = initialiseAPIBase(ORT_API_VERSION_3);
+      ortApiHandle = initialiseAPIBase(ORT_API_VERSION_7);
       providers = initialiseProviders(ortApiHandle);
       loaded = true;
     } finally {

--- a/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
+++ b/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2021 Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -110,6 +110,36 @@ public class OrtEnvironment implements AutoCloseable {
     return INSTANCE;
   }
 
+  /**
+   * Creates an OrtEnvironment using the specified global thread pool options. Note unlike the other
+   * {@code getEnvironment} methods if there already is an existing OrtEnvironment this call throws
+   * {@link IllegalStateException} as we cannot guarantee that the environment has the appropriate
+   * thread pool configuration.
+   *
+   * @param loggingLevel The logging level to use.
+   * @param name The log id.
+   * @param threadOptions The global thread pool options.
+   * @return The OrtEnvironment singleton.
+   */
+  public static synchronized OrtEnvironment getEnvironment(
+      OrtLoggingLevel loggingLevel, String name, ThreadingOptions threadOptions) {
+    if (INSTANCE == null) {
+      try {
+        INSTANCE = new OrtEnvironment(loggingLevel, name);
+        curLogLevel = loggingLevel;
+        curLoggingName = name;
+      } catch (OrtException e) {
+        throw new IllegalStateException("Failed to create OrtEnvironment", e);
+      }
+      refCount.incrementAndGet();
+      return INSTANCE;
+    } else {
+      // As the thread pool state is unknown, and that's probably not what the user wanted.
+      throw new IllegalStateException(
+          "Tried to specify the thread pool when creating an OrtEnvironment, but one already exists.");
+    }
+  }
+
   final long nativeHandle;
 
   final OrtAllocator defaultAllocator;
@@ -134,6 +164,22 @@ public class OrtEnvironment implements AutoCloseable {
    */
   private OrtEnvironment(OrtLoggingLevel loggingLevel, String name) throws OrtException {
     nativeHandle = createHandle(OnnxRuntime.ortApiHandle, loggingLevel.getValue(), name);
+    defaultAllocator = new OrtAllocator(getDefaultAllocator(OnnxRuntime.ortApiHandle), true);
+  }
+
+  /**
+   * Create an OrtEnvironment using the specified name, log level and threading options.
+   *
+   * @param loggingLevel The logging level to use.
+   * @param name The logging id of the environment.
+   * @param threadOptions The global thread pool configuration.
+   * @throws OrtException If the environment couldn't be created.
+   */
+  private OrtEnvironment(OrtLoggingLevel loggingLevel, String name, ThreadingOptions threadOptions)
+      throws OrtException {
+    nativeHandle =
+        createHandle(
+            OnnxRuntime.ortApiHandle, loggingLevel.getValue(), name, threadOptions.nativeHandle);
     defaultAllocator = new OrtAllocator(getDefaultAllocator(OnnxRuntime.ortApiHandle), true);
   }
 
@@ -290,6 +336,19 @@ public class OrtEnvironment implements AutoCloseable {
       throws OrtException;
 
   /**
+   * Creates the native object with a global thread pool.
+   *
+   * @param apiHandle The API pointer.
+   * @param loggingLevel The logging level.
+   * @param name The name of the environment.
+   * @param threadOptionsHandle The threading options handle.
+   * @return The pointer to the native object.
+   * @throws OrtException If the creation failed.
+   */
+  private static native long createHandle(
+      long apiHandle, int loggingLevel, String name, long threadOptionsHandle) throws OrtException;
+
+  /**
    * Gets a reference to the default allocator.
    *
    * @param apiHandle The API handle to use.
@@ -317,4 +376,114 @@ public class OrtEnvironment implements AutoCloseable {
    */
   private static native void setTelemetry(long apiHandle, long nativeHandle, boolean sendTelemetry)
       throws OrtException;
+
+  /**
+   * Controls the global thread pools in the environment. Only used if the session is constructed
+   * using an options with {@link OrtSession.SessionOptions#disablePerSessionThreads} set.
+   */
+  public static final class ThreadingOptions implements AutoCloseable {
+
+    private final long nativeHandle;
+
+    private boolean closed = false;
+
+    /** Create an empty threading options. */
+    public ThreadingOptions() {
+      nativeHandle = createThreadingOptions(OnnxRuntime.ortApiHandle);
+    }
+
+    /** Checks if the ThreadingOptions is closed, if so throws {@link IllegalStateException}. */
+    private void checkClosed() {
+      if (closed) {
+        throw new IllegalStateException("Trying to use a closed ThreadingOptions");
+      }
+    }
+
+    /** Closes the threading options. */
+    @Override
+    public void close() {
+      if (!closed) {
+        closeThreadingOptions(OnnxRuntime.ortApiHandle, nativeHandle);
+        closed = true;
+      } else {
+        throw new IllegalStateException("Trying to close a closed ThreadingOptions.");
+      }
+    }
+
+    /**
+     * Sets the number of threads available for inter-op parallelism (i.e. running multiple ops in
+     * parallel).
+     *
+     * <p>Setting it to 0 will allow ORT to choose the number of threads, setting it to 1 will cause
+     * the main thread to be used (i.e., no thread pools will be used).
+     *
+     * @param numThreads The number of threads.
+     * @throws OrtException If there was an error in native code.
+     */
+    public void setGlobalInterOpNumThreads(int numThreads) throws OrtException {
+      checkClosed();
+      if (numThreads < 0) {
+        throw new IllegalArgumentException("Number of threads must be non-negative.");
+      }
+      setGlobalInterOpNumThreads(OnnxRuntime.ortApiHandle, nativeHandle, numThreads);
+    }
+
+    /**
+     * Sets the number of threads available for intra-op parallelism (i.e. within a single op).
+     *
+     * <p>Setting it to 0 will allow ORT to choose the number of threads, setting it to 1 will cause
+     * the main thread to be used (i.e., no thread pools will be used).
+     *
+     * @param numThreads The number of threads.
+     * @throws OrtException If there was an error in native code.
+     */
+    public void setGlobalIntraOpNumThreads(int numThreads) throws OrtException {
+      checkClosed();
+      if (numThreads < 0) {
+        throw new IllegalArgumentException("Number of threads must be non-negative.");
+      }
+      setGlobalIntraOpNumThreads(OnnxRuntime.ortApiHandle, nativeHandle, numThreads);
+    }
+
+    /**
+     * Allows spinning of thread pools when their queues are empty. This call sets the value for
+     * both inter-op and intra-op thread pools.
+     *
+     * <p>If the CPU usage is very high then do not enable this.
+     *
+     * @param allowSpinning If true allow the thread pools to spin.
+     * @throws OrtException If there was an error in native code.
+     */
+    public void setGlobalSpinControl(boolean allowSpinning) throws OrtException {
+      checkClosed();
+      setGlobalSpinControl(OnnxRuntime.ortApiHandle, nativeHandle, allowSpinning ? 1 : 0);
+    }
+
+    /**
+     * When this is set it causes intra-op and inter-op thread pools to flush denormal values to
+     * zero.
+     *
+     * @throws OrtException If there was an error in native code.
+     */
+    public void setGlobalDenormalAsZero() throws OrtException {
+      checkClosed();
+      setGlobalDenormalAsZero(OnnxRuntime.ortApiHandle, nativeHandle);
+    }
+
+    private static native long createThreadingOptions(long apiHandle);
+
+    private native void setGlobalIntraOpNumThreads(
+        long apiHandle, long nativeHandle, int numThreads) throws OrtException;
+
+    private native void setGlobalInterOpNumThreads(
+        long apiHandle, long nativeHandle, int numThreads) throws OrtException;
+
+    private native void setGlobalSpinControl(long apiHandle, long nativeHandle, int allowSpinning)
+        throws OrtException;
+
+    private native void setGlobalDenormalAsZero(long apiHandle, long nativeHandle)
+        throws OrtException;
+
+    private native void closeThreadingOptions(long apiHandle, long nativeHandle);
+  }
 }

--- a/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
+++ b/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
@@ -125,7 +125,7 @@ public class OrtEnvironment implements AutoCloseable {
       OrtLoggingLevel loggingLevel, String name, ThreadingOptions threadOptions) {
     if (INSTANCE == null) {
       try {
-        INSTANCE = new OrtEnvironment(loggingLevel, name);
+        INSTANCE = new OrtEnvironment(loggingLevel, name, threadOptions);
         curLogLevel = loggingLevel;
         curLoggingName = name;
       } catch (OrtException e) {
@@ -379,7 +379,7 @@ public class OrtEnvironment implements AutoCloseable {
 
   /**
    * Controls the global thread pools in the environment. Only used if the session is constructed
-   * using an options with {@link OrtSession.SessionOptions#disablePerSessionThreads} set.
+   * using an options with {@link OrtSession.SessionOptions#disablePerSessionThreads()} set.
    */
   public static final class ThreadingOptions implements AutoCloseable {
 

--- a/java/src/main/native/ai_onnxruntime_OrtEnvironment.c
+++ b/java/src/main/native/ai_onnxruntime_OrtEnvironment.c
@@ -12,13 +12,35 @@
  * Method:    createHandle
  * Signature: (Ljava/lang/String;)J
  */
-JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtEnvironment_createHandle(JNIEnv * jniEnv, jclass jobj, jlong apiHandle, jint loggingLevel, jstring name) {
+JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtEnvironment_createHandle__JILjava_lang_String_2
+  (JNIEnv * jniEnv, jclass jobj, jlong apiHandle, jint loggingLevel, jstring name) {
     (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtEnv* env;
     jboolean copy;
     const char* cName = (*jniEnv)->GetStringUTFChars(jniEnv, name, &copy);
     checkOrtStatus(jniEnv,api,api->CreateEnv(convertLoggingLevel(loggingLevel), cName, &env));
+    (*jniEnv)->ReleaseStringUTFChars(jniEnv,name,cName);
+    checkOrtStatus(jniEnv, api, api->SetLanguageProjection(env, ORT_PROJECTION_JAVA));
+    return (jlong) env;
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtEnvironment
+ * Method:    createHandle
+ * Signature: (JILjava/lang/String;J)J
+ */
+JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtEnvironment_createHandle__JILjava_lang_String_2J
+  (JNIEnv * jniEnv, jclass jobj, jlong apiHandle, jint loggingLevel, jstring name, jlong threadOptionsHandle) {
+    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    const OrtApi* api = (const OrtApi*) apiHandle;
+    OrtEnv* env;
+    jboolean copy;
+    const char* cName = (*jniEnv)->GetStringUTFChars(jniEnv, name, &copy);
+    checkOrtStatus(jniEnv,api,api->CreateEnvWithGlobalThreadPools(convertLoggingLevel(loggingLevel),
+                                                                  cName,
+                                                                  (OrtThreadingOptions*) threadOptionsHandle,
+                                                                  &env));
     (*jniEnv)->ReleaseStringUTFChars(jniEnv,name,cName);
     checkOrtStatus(jniEnv, api, api->SetLanguageProjection(env, ORT_PROJECTION_JAVA));
     return (jlong) env;

--- a/java/src/main/native/ai_onnxruntime_OrtEnvironment_ThreadingOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtEnvironment_ThreadingOptions.c
@@ -15,7 +15,7 @@
  */
 JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtEnvironment_00024ThreadingOptions_createThreadingOptions
   (JNIEnv * jniEnv, jclass clazz, jlong apiHandle) {
-    (void) jclazz; // Required JNI parameter not needed by functions which don't need to access their host class.
+    (void) clazz; // Required JNI parameter not needed by functions which don't need to access their host class.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtThreadingOptions* opts;
     checkOrtStatus(jniEnv,api,api->CreateThreadingOptions(&opts));

--- a/java/src/main/native/ai_onnxruntime_OrtEnvironment_ThreadingOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtEnvironment_ThreadingOptions.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include <jni.h>
+#include <string.h>
+#include "onnxruntime/core/session/onnxruntime_c_api.h"
+#include "OrtJniUtil.h"
+#include "ai_onnxruntime_OrtEnvironment_ThreadingOptions.h"
+
+/*
+ * Class:     ai_onnxruntime_OrtEnvironment_ThreadingOptions
+ * Method:    createThreadingOptions
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtEnvironment_00024ThreadingOptions_createThreadingOptions
+  (JNIEnv * jniEnv, jclass clazz, jlong apiHandle) {
+    (void) jclazz; // Required JNI parameter not needed by functions which don't need to access their host class.
+    const OrtApi* api = (const OrtApi*) apiHandle;
+    OrtThreadingOptions* opts;
+    checkOrtStatus(jniEnv,api,api->CreateThreadingOptions(&opts));
+    return (jlong) opts;
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtEnvironment_ThreadingOptions
+ * Method:    setGlobalIntraOpNumThreads
+ * Signature: (JJI)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtEnvironment_00024ThreadingOptions_setGlobalIntraOpNumThreads
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint numThreads) {
+    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    const OrtApi* api = (const OrtApi*) apiHandle;
+    checkOrtStatus(jniEnv,api,api->SetGlobalIntraOpNumThreads((OrtThreadingOptions*) handle, numThreads));
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtEnvironment_ThreadingOptions
+ * Method:    setGlobalInterOpNumThreads
+ * Signature: (JJI)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtEnvironment_00024ThreadingOptions_setGlobalInterOpNumThreads
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint numThreads) {
+    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    const OrtApi* api = (const OrtApi*) apiHandle;
+    checkOrtStatus(jniEnv,api,api->SetGlobalInterOpNumThreads((OrtThreadingOptions*) handle, numThreads));
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtEnvironment_ThreadingOptions
+ * Method:    setGlobalSpinControl
+ * Signature: (JJI)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtEnvironment_00024ThreadingOptions_setGlobalSpinControl
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint allowSpinning) {
+    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    const OrtApi* api = (const OrtApi*) apiHandle;
+    checkOrtStatus(jniEnv,api,api->SetGlobalSpinControl((OrtThreadingOptions*) handle, allowSpinning));
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtEnvironment_ThreadingOptions
+ * Method:    setGlobalDenormalAsZero
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtEnvironment_00024ThreadingOptions_setGlobalDenormalAsZero
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle) {
+    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    const OrtApi* api = (const OrtApi*) apiHandle;
+    checkOrtStatus(jniEnv,api,api->SetGlobalDenormalAsZero((OrtThreadingOptions*) handle));
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtEnvironment_ThreadingOptions
+ * Method:    closeThreadingOptions
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtEnvironment_00024ThreadingOptions_closeThreadingOptions
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle) {
+  (void)jniEnv; (void)jobj;  // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  api->ReleaseThreadingOptions((OrtThreadingOptions*)handle);
+}

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -454,6 +454,7 @@ public class InferenceTest {
         OrtEnvironment newEnv =
             OrtEnvironment.getEnvironment(
                 OrtLoggingLevel.ORT_LOGGING_LEVEL_FATAL, "fail", threadOpts);
+        // fail as we can't recreate environments with different threading options
         fail("Should have thrown IllegalStateException");
       } catch (IllegalStateException e) {
         // pass
@@ -686,7 +687,7 @@ public class InferenceTest {
   }
 
   @Test
-  @EnabledIfSystemProperty(named = "USE_CUDA", matches = "*")
+  @EnabledIfSystemProperty(named = "USE_CUDA", matches = "1")
   public void testCUDA() throws OrtException {
     EnumSet<OrtProvider> providers = OrtEnvironment.getAvailableProviders();
     assertTrue(providers.size() > 1);

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /** Tests for the onnx-runtime Java interface. */
 public class InferenceTest {
@@ -394,6 +395,75 @@ public class InferenceTest {
   }
 
   @Test
+  public void environmentThreadPoolTest() throws OrtException {
+    Path squeezeNet = getResourcePath("/squeezenet.onnx");
+    String modelPath = squeezeNet.toString();
+    float[] inputData = loadTensorFromFile(getResourcePath("/bench.in"));
+    float[] expectedOutput = loadTensorFromFile(getResourcePath("/bench.expected_out"));
+    Map<String, OnnxTensor> container = new HashMap<>();
+
+    OrtEnvironment.ThreadingOptions threadOpts = new OrtEnvironment.ThreadingOptions();
+    threadOpts.setGlobalInterOpNumThreads(2);
+    threadOpts.setGlobalIntraOpNumThreads(2);
+    threadOpts.setGlobalDenormalAsZero();
+    threadOpts.setGlobalSpinControl(true);
+    try (OrtEnvironment env =
+            OrtEnvironment.getEnvironment(
+                OrtLoggingLevel.ORT_LOGGING_LEVEL_FATAL, "environmentThreadPoolTest", threadOpts);
+        OrtSession.SessionOptions options = new SessionOptions();
+        OrtSession.SessionOptions disableThreadOptions = new SessionOptions()) {
+      disableThreadOptions.disablePerSessionThreads();
+
+      // Check that the regular session executes
+      try (OrtSession session = env.createSession(modelPath, options)) {
+        NodeInfo inputMeta = session.getInputInfo().values().iterator().next();
+        long[] inputShape = ((TensorInfo) inputMeta.getInfo()).shape;
+        Object tensorData = OrtUtil.reshape(inputData, inputShape);
+        OnnxTensor tensor = OnnxTensor.createTensor(env, tensorData);
+        container.put(inputMeta.getName(), tensor);
+        try (OrtSession.Result result = session.run(container)) {
+          OnnxValue resultTensor = result.get(0);
+          float[] resultArray = TestHelpers.flattenFloat(resultTensor.getValue());
+          assertEquals(expectedOutput.length, resultArray.length);
+          assertArrayEquals(expectedOutput, resultArray, 1e-6f);
+        }
+        container.clear();
+        tensor.close();
+      }
+
+      // Check that the session using the env thread pool executes
+      try (OrtSession session = env.createSession(modelPath, disableThreadOptions)) {
+        NodeInfo inputMeta = session.getInputInfo().values().iterator().next();
+        long[] inputShape = ((TensorInfo) inputMeta.getInfo()).shape;
+        Object tensorData = OrtUtil.reshape(inputData, inputShape);
+        OnnxTensor tensor = OnnxTensor.createTensor(env, tensorData);
+        container.put(inputMeta.getName(), tensor);
+        try (OrtSession.Result result = session.run(container)) {
+          OnnxValue resultTensor = result.get(0);
+          float[] resultArray = TestHelpers.flattenFloat(resultTensor.getValue());
+          assertEquals(expectedOutput.length, resultArray.length);
+          assertArrayEquals(expectedOutput, resultArray, 1e-6f);
+        }
+        container.clear();
+        tensor.close();
+      }
+    }
+
+    try (OrtEnvironment env = OrtEnvironment.getEnvironment("test")) {
+      try {
+        OrtEnvironment newEnv =
+            OrtEnvironment.getEnvironment(
+                OrtLoggingLevel.ORT_LOGGING_LEVEL_FATAL, "fail", threadOpts);
+        fail("Should have thrown IllegalStateException");
+      } catch (IllegalStateException e) {
+        // pass
+      }
+    }
+
+    threadOpts.close();
+  }
+
+  @Test
   public void inferenceTest() throws OrtException {
     canRunInferenceOnAModel(OptLevel.NO_OPT, ExecutionMode.PARALLEL);
     canRunInferenceOnAModel(OptLevel.NO_OPT, ExecutionMode.SEQUENTIAL);
@@ -616,32 +686,31 @@ public class InferenceTest {
   }
 
   @Test
+  @EnabledIfSystemProperty(named = "USE_CUDA", matches = "*")
   public void testCUDA() throws OrtException {
-    if (System.getProperty("USE_CUDA") != null) {
-      EnumSet<OrtProvider> providers = OrtEnvironment.getAvailableProviders();
-      assertTrue(providers.size() > 1);
-      assertTrue(providers.contains(OrtProvider.CPU));
-      assertTrue(providers.contains(OrtProvider.CUDA));
-      SqueezeNetTuple tuple = openSessionSqueezeNet(0);
-      try (OrtEnvironment env = tuple.env;
-          OrtSession session = tuple.session) {
-        float[] inputData = tuple.inputData;
-        float[] expectedOutput = tuple.outputData;
-        NodeInfo inputMeta = session.getInputInfo().values().iterator().next();
-        Map<String, OnnxTensor> container = new HashMap<>();
-        long[] inputShape = ((TensorInfo) inputMeta.getInfo()).shape;
-        Object tensor = OrtUtil.reshape(inputData, inputShape);
-        container.put(inputMeta.getName(), OnnxTensor.createTensor(env, tensor));
-        try (OrtSession.Result result = session.run(container)) {
-          OnnxValue resultTensor = result.get(0);
-          float[] resultArray = TestHelpers.flattenFloat(resultTensor.getValue());
-          assertEquals(expectedOutput.length, resultArray.length);
-          assertArrayEquals(expectedOutput, resultArray, 1e-6f);
-        } catch (OrtException e) {
-          throw new IllegalStateException("Failed to execute a scoring operation", e);
-        }
-        OnnxValue.close(container.values());
+    EnumSet<OrtProvider> providers = OrtEnvironment.getAvailableProviders();
+    assertTrue(providers.size() > 1);
+    assertTrue(providers.contains(OrtProvider.CPU));
+    assertTrue(providers.contains(OrtProvider.CUDA));
+    SqueezeNetTuple tuple = openSessionSqueezeNet(0);
+    try (OrtEnvironment env = tuple.env;
+        OrtSession session = tuple.session) {
+      float[] inputData = tuple.inputData;
+      float[] expectedOutput = tuple.outputData;
+      NodeInfo inputMeta = session.getInputInfo().values().iterator().next();
+      Map<String, OnnxTensor> container = new HashMap<>();
+      long[] inputShape = ((TensorInfo) inputMeta.getInfo()).shape;
+      Object tensor = OrtUtil.reshape(inputData, inputShape);
+      container.put(inputMeta.getName(), OnnxTensor.createTensor(env, tensor));
+      try (OrtSession.Result result = session.run(container)) {
+        OnnxValue resultTensor = result.get(0);
+        float[] resultArray = TestHelpers.flattenFloat(resultTensor.getValue());
+        assertEquals(expectedOutput.length, resultArray.length);
+        assertArrayEquals(expectedOutput, resultArray, 1e-6f);
+      } catch (OrtException e) {
+        throw new IllegalStateException("Failed to execute a scoring operation", e);
       }
+      OnnxValue.close(container.values());
     }
   }
 


### PR DESCRIPTION
**Description**:
Adds support for environment level thread pools to the Java API. It also bumps a few things in the gradle file to make it support newer gradle versions (though it doesn't bump the gradle version itself).

**Motivation and Context**
- Why is this change required? What problem does it solve? Java <-> C API parity.
