### PR TITLE
Add an option to save the training graph after optimization

### DIFF
--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -660,8 +660,8 @@ class ORTTrainer(object):
             self.options.graph_transformer.gelu_recompute or
             self.options.graph_transformer.transformer_layer_recompute):
             session_options.execution_order = ort.ExecutionOrder.PRIORITY_BASED
-        if len(self.options.debug.optimized_model_filepath) > 0:
-            session_options.optimized_model_filepath = self.options.debug.optimized_model_filepath
+        if len(self.options.debug.graph_save_paths.model_with_training_graph_after_optimization_path) > 0:
+            session_options.optimized_model_filepath = self.options.debug.graph_save_paths.model_with_training_graph_after_optimization_path
 
         # old ort session may already exists and occupies GPU memory when creating new session, this may cause OOM error.
         # for example, load_state_dict will be called before returing the function, and it calls _init_session again

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -660,6 +660,8 @@ class ORTTrainer(object):
             self.options.graph_transformer.gelu_recompute or
             self.options.graph_transformer.transformer_layer_recompute):
             session_options.execution_order = ort.ExecutionOrder.PRIORITY_BASED
+        if len(self.options.debug.optimized_model_filepath) > 0:
+            session_options.optimized_model_filepath = self.options.debug.optimized_model_filepath
 
         # old ort session may already exists and occupies GPU memory when creating new session, this may cause OOM error.
         # for example, load_state_dict will be called before returing the function, and it calls _init_session again

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -245,7 +245,11 @@ class ORTTrainerOptions(object):
                                     'default': ''
                                 }
                             }
-                        }                        
+                        },
+                        'optimized_model_filepath' : {
+                            'type' : 'str',
+                            'default' : ''
+                        },
                     }
                 },
                 '_internal_use' : {
@@ -365,6 +369,8 @@ class ORTTrainerOptions(object):
         debug.graph_save_paths.model_with_training_graph_path (str, default is "")
             path to export the training ONNX graph with forward, gradient and optimizer nodes.
             No output when it is empty.
+        debug.optimized_model_filepath (str, default is empty)
+            outputs the optimized training graph to the path if nonempty.
         _internal_use (dict):
             internal options, possibly undocumented, that might be removed without notice
         _internal_use.enable_internal_postprocess (bool, default is True):
@@ -693,6 +699,10 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
                         'default': ''
                     }
                 }
+            },
+            'optimized_model_filepath' : {
+                'type' : 'str',
+                'default' : ''
             },
         }
     },

--- a/orttraining/orttraining/python/training/orttrainer_options.py
+++ b/orttraining/orttraining/python/training/orttrainer_options.py
@@ -243,12 +243,12 @@ class ORTTrainerOptions(object):
                                 'model_with_training_graph_path': {
                                     'type': 'string',
                                     'default': ''
-                                }
+                                },
+                                'model_with_training_graph_after_optimization_path': {
+                                    'type': 'string',
+                                    'default': ''
+                                },
                             }
-                        },
-                        'optimized_model_filepath' : {
-                            'type' : 'str',
-                            'default' : ''
                         },
                     }
                 },
@@ -369,7 +369,7 @@ class ORTTrainerOptions(object):
         debug.graph_save_paths.model_with_training_graph_path (str, default is "")
             path to export the training ONNX graph with forward, gradient and optimizer nodes.
             No output when it is empty.
-        debug.optimized_model_filepath (str, default is empty)
+        debug.graph_save_paths.model_with_training_graph_after_optimization_path (str, default is "")
             outputs the optimized training graph to the path if nonempty.
         _internal_use (dict):
             internal options, possibly undocumented, that might be removed without notice
@@ -683,7 +683,7 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
             },
             'graph_save_paths' : {
                 'type' : 'dict',
-               'default_setter': lambda _: {},
+                'default_setter': lambda _: {},
                 'required': False,
                 'schema': {
                     'model_after_graph_transforms_path': {
@@ -697,12 +697,12 @@ _ORTTRAINER_OPTIONS_SCHEMA = {
                     'model_with_training_graph_path': {
                         'type': 'string',
                         'default': ''
-                    }
+                    },
+                    'model_with_training_graph_after_optimization_path': {
+                        'type': 'string',
+                        'default': ''
+                    },
                 }
-            },
-            'optimized_model_filepath' : {
-                'type' : 'str',
-                'default' : ''
             },
         }
     },

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -1429,13 +1429,14 @@ def testORTTrainerUnusedInput():
         pytest.fail("RuntimeError doing train_step with an unused input.")
 
 @pytest.mark.parametrize("debug_files", [
-    ({'model_after_graph_transforms_path': 'transformed.onnx',
+    {'model_after_graph_transforms_path': 'transformed.onnx',
       'model_with_gradient_graph_path': 'transformed_grad.onnx',
-      'model_with_training_graph_path': 'training.onnx'
-    }),
-    ({'model_after_graph_transforms_path': 'transformed.onnx',
+      'model_with_training_graph_path': 'training.onnx',
+      'model_with_training_graph_after_optimization_path': 'training_optimized.onnx'
+    },
+    {'model_after_graph_transforms_path': 'transformed.onnx',
       'model_with_training_graph_path': ''
-    }),
+    },
     ])
 def testTrainingGraphExport(debug_files):
     device = 'cuda'
@@ -1466,6 +1467,8 @@ def testTrainingGraphExport(debug_files):
                     assert any("Grad" in n.name for n in saved_graph.node)
                 elif k == 'model_after_graph_transforms_path':
                     assert any("LayerNormalization" in n.op_type for n in saved_graph.node)
+                elif k == 'model_with_training_graph_after_optimization_path':
+                    assert any("FusedMatMul" in n.op_type for n in saved_graph.node)
                 # remove saved file
                 os.remove(path)
             else:

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -88,7 +88,8 @@ def testORTTrainerOptionsDefaultValues(test_input):
             'graph_save_paths' : {
                 'model_after_graph_transforms_path': '',
                 'model_with_gradient_graph_path': '',
-                'model_with_training_graph_path': ''                            
+                'model_with_training_graph_path': '',
+                'model_with_training_graph_after_optimization_path': ''
             }
         },
         '_internal_use': {


### PR DESCRIPTION
**Description**: Add an option in `ORTTrainerOptions` to save the training graph after optimization.

**Motivation and Context**
- PR #6333 added options to dump graphs at various stages in ORTTrainer. However, the graph goes through additional optimization in `InferenceSession::Initialize()` creating discrepancy between the training graph and the actual graph that is executed.
- This PR adds an option to save the graph after optimization from ORTTrainer. The option was already available in `SessionOptions` (as opposed to `TrainingParameters`) so the change is small.
