### PR TITLE
Continue memory planning when unknown shape tensor is encountered.

### DIFF
--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -434,6 +434,9 @@ Status SessionState::GeneratePatternGroupCache(const std::vector<std::reference_
         if (is_resolved != 0) {
           resolved_shapes[ml_value_idx] = resolved_shape;
         }
+      } else {
+        LOGS(logger_, INFO) << "[Static memory planning] Could not resolve shape for tensor with ML index "
+                            << ml_value_idx << ", will allocate dynamically.";
       }
     }
   }

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -389,7 +389,7 @@ void TryCalculateSizeFromResolvedShape(int ml_value_idx, std::unordered_map<int,
 
 }  // namespace
 
-// If this function fails NO TRAINING will take place, hence lets ONLY FAIL and stop training where warranted, example SIZE overflow.
+// If this function fails NO memory planning will take place, hence lets ONLY FAIL and stop training where warranted, example SIZE overflow.
 Status SessionState::GeneratePatternGroupCache(const std::vector<std::reference_wrapper<const TensorShape>>& input_shape,
                                                const std::vector<int>& feed_mlvalue_idxs,
                                                MemoryPatternGroup* output,


### PR DESCRIPTION
Currently we disallow any memory planning to happen when a tensor whose shape cannot be resolved ahead of graph execution for example in graphs that have NonZero op. This results in no memory planning taking places which can affect the total memory footprint at training and/or throughput. It also disables features like contiguous memory allocation that need memory planning. Instead of disabling memory planning altogether we can take a hybrid approach to memory plan as much as possible and dynamically allocate the rest.