### PR TITLE
Disallow contiguous allocation in scenarios with contradicting tensor placement in memory.

### DIFF
--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -834,11 +834,15 @@ class PlannerImpl {
           return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "AllocateInputsContiguously() requires all inputs to be initializers, or all inputs to be non-initializers.");
 
         if (actual_plan.alloc_kind == AllocKind::kAllocateStatically) {
-          if (std::find(initializer_allocation_order.begin(), initializer_allocation_order.end(), actual_idx) == initializer_allocation_order.end())
-            initializer_allocation_order.push_back(actual_idx);
+          
+          ORT_ENFORCE(std::find(initializer_allocation_order.begin(), initializer_allocation_order.end(), actual_idx) == initializer_allocation_order.end());
+
+          initializer_allocation_order.push_back(actual_idx);
         } else {
-          if (std::find(activation_allocation_order.begin(), activation_allocation_order.end(), actual_idx) == activation_allocation_order.end())
-            activation_allocation_order.push_back(actual_idx);
+
+          ORT_ENFORCE(std::find(activation_allocation_order.begin(), activation_allocation_order.end(), actual_idx) == activation_allocation_order.end());
+          
+          activation_allocation_order.push_back(actual_idx);
         }
       }
     }

--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -834,14 +834,14 @@ class PlannerImpl {
           return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "AllocateInputsContiguously() requires all inputs to be initializers, or all inputs to be non-initializers.");
 
         if (actual_plan.alloc_kind == AllocKind::kAllocateStatically) {
-          
+
           ORT_ENFORCE(std::find(initializer_allocation_order.begin(), initializer_allocation_order.end(), actual_idx) == initializer_allocation_order.end());
 
           initializer_allocation_order.push_back(actual_idx);
-        } else {
+          } else {
 
           ORT_ENFORCE(std::find(activation_allocation_order.begin(), activation_allocation_order.end(), actual_idx) == activation_allocation_order.end());
-          
+
           activation_allocation_order.push_back(actual_idx);
         }
       }


### PR DESCRIPTION
The below scenario should not be allowed:

Assuming both Node 1 and Node 2 take tensor A and B as inputs.

Node 1 wants its input tensors in order A, B.
Node 2 wants its input tensors in order B, A.

This is simply not possible and will require a workaround to copy tensor in an intermediate tensor. 
