### PR TITLE
Improve work distribution for Expand operator, and sharded LoopCounter configuration

### DIFF
--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -51,7 +51,7 @@ static_assert(sizeof(LoopCounterShard) == CACHE_LINE_BYTES, "Expected loop count
 class alignas(CACHE_LINE_BYTES) LoopCounter {
 public:
  LoopCounter(uint64_t num_iterations,
-	     uint64_t d_of_p,
+             uint64_t d_of_p,
              uint64_t block_size = 1) : _block_size(block_size),
                                         _num_shards(GetNumShards(num_iterations,
                                                                  d_of_p,

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -137,7 +137,7 @@ private:
       num_shards = MAX_SHARDS;
     }
     if (num_shards > d_of_p) {
-      num_shards = d_of_p;
+      num_shards = static_cast<unsigned>(d_of_p);
     }
     return num_shards;
   }

--- a/onnxruntime/core/providers/cpu/tensor/expand.cc
+++ b/onnxruntime/core/providers/cpu/tensor/expand.cc
@@ -115,68 +115,70 @@ Status Expand<T>::Compute(OpKernelContext* context) const {
   auto copy_byte = copy_len * sizeof(T);
 
   auto distribute_fn =
-    [&](ptrdiff_t i) {
+    [&](ptrdiff_t i_start, ptrdiff_t i_end) {
+    for (auto i = i_start; i < i_end; i++) {
       auto input_offset = i * copy_len;
       int64_t output_offset = 0;
       for (auto j = dim_group_start + 1, remains = input_offset; j < max_dims_size; ++j) {
         auto current_count = remains / input_dim_group[j];
         output_offset += current_count * output_dim_group[j];
         remains = remains % input_dim_group[j];
-      }  //for
+      }  //for j
       memcpy(output_data + output_offset, input_data + input_offset, copy_byte);
       output_offsets[i] = output_offset;
-    };  //distribute_fn
+    } //for i
+  };  //distribute_fn
 
   auto per_thread_tasks =
     distribute_count / concurrency::ThreadPool::DegreeOfParallelism(context->GetOperatorThreadPool());
 
   if (per_thread_tasks > 4) {
-    concurrency::ThreadPool::TrySimpleParallelFor(
+    concurrency::ThreadPool::TryParallelFor(
       context->GetOperatorThreadPool(),
       distribute_count,
+      static_cast<double>(copy_byte),
       std::move(distribute_fn));
   } else {
-    for (int64_t i = 0; i < distribute_count; ++i) {
-      distribute_fn(i);
-    }
+    distribute_fn(0, distribute_count);
   }  //else
 
   for (auto i = max_dims_size - 1; i >= dim_group_start; --i) {
     auto copy_fn =
-    [&](ptrdiff_t j) {
-      auto output_offset = output_offsets[j];
-      if (output_offset % output_dim_group[i] == 0) {
-        auto copy_len = output_dim_group[i] / expand_dim_size[i];
-        auto copy_byte = copy_len * sizeof(T);
-        auto output_from = output_data + output_offset;
-        auto output_at = output_from + copy_len;
-        auto output_end = output_from + output_dim_group[i];
-        while (output_at + copy_len <= output_end) {
-          memcpy(output_at, output_from, copy_byte);
-          output_at += copy_len;
-          copy_len <<= 1;
-          copy_byte <<= 1;
-        }  //while
-        while (output_at < output_end) {
-          if (output_at + copy_len <= output_end) {
-            memcpy(output_at, output_from, copy_byte);
-            output_at += copy_len;
-          } else {
-            copy_len >>= 1;
-            copy_byte >>= 1;
-          }
-        }  //while
-      }  //if
+      [&](ptrdiff_t j_start, ptrdiff_t j_end) {
+      for (auto j = j_start; j < j_end; j++) {
+	auto output_offset = output_offsets[j];
+	if (output_offset % output_dim_group[i] == 0) {
+	  auto copy_len = output_dim_group[i] / expand_dim_size[i];
+	  auto copy_byte = copy_len * sizeof(T);
+	  auto output_from = output_data + output_offset;
+	  auto output_at = output_from + copy_len;
+	  auto output_end = output_from + output_dim_group[i];
+	  while (output_at + copy_len <= output_end) {
+	    memcpy(output_at, output_from, copy_byte);
+	    output_at += copy_len;
+	    copy_len <<= 1;
+	    copy_byte <<= 1;
+	  }  //while
+	  while (output_at < output_end) {
+	    if (output_at + copy_len <= output_end) {
+	      memcpy(output_at, output_from, copy_byte);
+	      output_at += copy_len;
+	    } else {
+	      copy_len >>= 1;
+	      copy_byte >>= 1;
+	    }
+	  }  //while
+	}  //if
+      } // for
     };  //copy_fn
     if (per_thread_tasks > 20) {
-      concurrency::ThreadPool::TrySimpleParallelFor(
+      concurrency::ThreadPool::TryParallelFor(
         context->GetOperatorThreadPool(),
         distribute_count,
-        copy_fn);
+        static_cast<double>(copy_byte),
+        std::move(copy_fn));
     } else {
-      for (int64_t j = 0; j < distribute_count; ++j) {
-        copy_fn(j);
-      }
+      copy_fn(0, distribute_count);
     }  //else
   }  //for
   return Status::OK();


### PR DESCRIPTION
**Description**: This PR makes two changes identified while looking at a PGAN model.  

First, it uses ThreadPool::TryParallelFor for the main parallel loops in the Expand operator.  This lets the thread pool decide on the granularity at which to distribute work (unlike TrySimpleParallelFor).  Profiling showed high costs when running "simple" loops with 4M iterations each of which copied only 4 bytes.

Second, it updates the sharded loop counter in the thread pool so that the number of shards is capped by the number of threads.  This helps make the performance of any other high-contention "simple" loops more robust at low thread counts by letting each thread work on its own "home" shard for longer.

**Motivation and Context**

Profiling showed a PGAN model taking 2x+ longer with the non-OpenMP build.  The root cause was that the OpenMP build uses simple static scheduling of loop iterations, while the non-OpenMP build uses dynamic scheduling.  The combination of large numbers of tiny iterations is less significant with static scheduling --- although still desirable to avoid, given that each iteration incurs a std::function invocation.

