### PR TITLE
Fix Experimental API build breaks in Inbox Build

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -85,6 +85,7 @@ get_filename_component(winrt_idl "${winml_api_root}/Windows.AI.MachineLearning.i
 get_filename_component(winrt_experimental_idl "${winml_api_root}/Microsoft.AI.MachineLearning.Experimental.idl" ABSOLUTE)
 get_filename_component(idl_native "${winml_api_root}/windows.ai.machineLearning.native.idl" ABSOLUTE)
 get_filename_component(idl_native_internal "${winml_api_root}/windows.ai.machineLearning.native.internal.idl" ABSOLUTE)
+get_filename_component(winrt_winmd "${CMAKE_CURRENT_BINARY_DIR}/${winml_root_ns}.AI.MachineLearning.winmd" ABSOLUTE)
 
 # generate cppwinrt sdk
 add_generate_cppwinrt_sdk_headers_target(
@@ -112,15 +113,15 @@ add_dependencies(winml_api RESTORE_NUGET_PACKAGES)
 
 # generate winml.experimental headers from idl
 target_cppwinrt(winml_api_experimental
-  ${winrt_experimental_idl}                                        # winml winrt idl to compile
-  ${experimental_output_name}                                      # outputs name
-  ${winml_lib_api_dir}                                             # location for cppwinrt generated component sources
-  ${sdk_folder}                                                    # location of sdk folder
-  ${sdk_version}                                                   # sdk version
-  ${target_folder}                                                 # the folder this target will be placed under
-  ${winml_midl_defines}                                            # the midl compiler defines
-  ${winml_api_use_ns_prefix}                                       # set ns_prefix
-  "${CMAKE_CURRENT_BINARY_DIR}/Microsoft.AI.MachineLearning.winmd" # set additional cppwinrt ref path
+  ${winrt_experimental_idl}   # winml winrt idl to compile
+  ${experimental_output_name} # outputs name
+  ${winml_lib_api_dir}        # location for cppwinrt generated component sources
+  ${sdk_folder}               # location of sdk folder
+  ${sdk_version}              # sdk version
+  ${target_folder}            # the folder this target will be placed under
+  ${winml_midl_defines}       # the midl compiler defines
+  ${winml_api_use_ns_prefix}  # set ns_prefix
+  ${winrt_winmd}              # set additional cppwinrt ref path
 )
 add_dependencies(winml_api_experimental RESTORE_NUGET_PACKAGES)
 add_dependencies(winml_api_experimental winml_api)
@@ -485,7 +486,6 @@ target_precompiled_header(winml_lib_api pch.h)
 # Includes
 target_include_directories(winml_lib_api PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api)                   # windows machine learning generated component headers
 target_include_directories(winml_lib_api PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api/comp_generated)    # windows machine learning generated component headers
-target_include_directories(winml_lib_api PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api_experimental/comp_generated) # windows machine learning generated component headers
 target_include_directories(winml_lib_api PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml/sdk/cppwinrt/include)  # sdk cppwinrt headers
 
 target_include_directories(winml_lib_api PRIVATE ${winml_lib_api_dir})
@@ -707,6 +707,10 @@ target_compile_definitions(winml_dll PRIVATE VER_PRIVATE=${VERSION_PRIVATE_PART}
 target_compile_definitions(winml_dll PRIVATE VER_STRING=\"${VERSION_STRING}\")
 target_compile_definitions(winml_dll PRIVATE BINARY_NAME=\"${BINARY_NAME}\")
 
+if (onnxruntime_WINML_NAMESPACE_OVERRIDE STREQUAL "Windows")
+  target_compile_definitions(winml_dll PRIVATE "BUILD_INBOX=1")
+endif()
+
 # Specify the usage of a precompiled header
 target_precompiled_header(winml_dll pch.h)
 
@@ -719,7 +723,9 @@ target_include_directories(winml_dll PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml/s
 target_include_directories(winml_dll PRIVATE ${winml_dll_dir})
 target_include_directories(winml_dll PRIVATE ${winml_lib_api_dir})
 target_include_directories(winml_dll PRIVATE ${winml_lib_api_dir}/impl)
-target_include_directories(winml_dll PRIVATE ${winml_lib_api_experimental_dir})
+if (NOT winml_is_inbox)
+  target_include_directories(winml_dll PRIVATE ${winml_lib_api_experimental_dir})
+endif()
 target_include_directories(winml_dll PRIVATE ${winml_lib_api_ort_dir}/inc)
 target_include_directories(winml_dll PRIVATE ${winml_adapter_dir})
 target_include_directories(winml_dll PRIVATE ${winml_lib_api_image_dir}/inc)

--- a/winml/dll/module.cpp
+++ b/winml/dll/module.cpp
@@ -6,12 +6,17 @@
 #include <Hstring.h>
 #include "LearningModelDevice.h"
 #include "OnnxruntimeProvider.h"
+
+#ifndef BUILD_INBOX
+
 #include "Dummy.h"
 #include "LearningModelSessionOptionsExperimental.h"
 #include "LearningModelSessionExperimental.h"
 
 #define STRINGIFY(x) #x
 #define XSTRINGIFY(x) STRINGIFY(x)
+
+#endif
 
 using namespace winmlp;
 
@@ -90,6 +95,7 @@ STDAPI DllCanUnloadNow() {
   return S_FALSE;
 }
 
+#ifndef BUILD_INBOX
 STDAPI DllGetExperimentalActivationFactory(void* classId, void** factory) noexcept {
   try {
     *factory = nullptr;
@@ -116,11 +122,16 @@ STDAPI DllGetExperimentalActivationFactory(void* classId, void** factory) noexce
     return winrt::to_hresult();
   }
 }
+#endif
 
 STDAPI DllGetActivationFactory(HSTRING classId, void** factory) {
   auto ret = WINRT_GetActivationFactory(classId, factory);
-  if (ret != 0)
-    return DllGetExperimentalActivationFactory(classId, factory);
 
-  return 0;
+#ifndef BUILD_INBOX
+  if (ret != 0) {
+    return DllGetExperimentalActivationFactory(classId, factory);
+  }
+#endif
+
+  return ret;
 }

--- a/winml/test/common/winrt_headers.h
+++ b/winml/test/common/winrt_headers.h
@@ -35,9 +35,13 @@
 #include CREATE_CPPWINRT_COMPONENT_HEADER()
 #include CREATE_CPPWINRT_EXPERIMENTAL_COMPONENT_HEADER()
 
+#ifndef BUILD_INBOX
+
 // WinML Native Headers
 #include CREATE_NATIVE_HEADER()
 #include CREATE_NATIVE_INTERNAL_HEADER()
+
+#endif
 
 namespace winml = winrt::WINML_ROOT_NS::AI::MachineLearning;
 namespace wf = winrt::Windows::Foundation;


### PR DESCRIPTION
Fix Experimental API build breaks in Inbox Build

Issue: The Experimental API refers to the Microsoft namespace directly. This should be conditional on whether inbox or redist is being built. Additionally, the experimental api should be ifdefed out completely from the inbox binary.