### PR TITLE
[java] Fixing a memory leak in OnnxSequences with String keys or values.

### DIFF
--- a/java/src/main/native/ai_onnxruntime_OnnxSequence.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxSequence.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 #include <jni.h>
@@ -28,6 +28,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxSequence_getStringKeys
     jobjectArray output = createStringArrayFromTensor(jniEnv, api, allocator, keys);
 
     api->ReleaseValue(keys);
+    api->ReleaseValue(element);
 
     return output;
 }
@@ -80,6 +81,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxSequence_getStringValues
     jobjectArray output = createStringArrayFromTensor(jniEnv, api, allocator, values);
 
     api->ReleaseValue(values);
+    api->ReleaseValue(element);
 
     return output;
 }


### PR DESCRIPTION
**Description**:

I'd forgot to free the sequence when extracting String keys and values from a map contained in the sequence.

**Motivation and Context**
- Why is this change required? What problem does it solve? Fixes a small memory leak.
- If it fixes an open issue, please link to the issue here. Fixes #6471.
