### PR TITLE
Increase the distributed tests pipeline timeout to 120 minutes

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-distributed-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-distributed-test-ci-pipeline.yml
@@ -40,7 +40,7 @@ jobs:
             --cwd /build/RelWithDebInfo \
     displayName: 'Run orttraining_distributed_tests.py'
     condition: succeededOrFailed()
-    timeoutInMinutes: 60
+    timeoutInMinutes: 120
   
   - template: templates/component-governance-component-detection-steps.yml
     parameters:


### PR DESCRIPTION
**Description**: Pipeline tests seem to be timing out, so increasing the timeout to 120 minutes.