### PR TITLE
add explicit barriers for buffer overread and overrwrite

### DIFF
--- a/winml/test/image/imageTestHelper.cpp
+++ b/winml/test/image/imageTestHelper.cpp
@@ -52,6 +52,7 @@ namespace ImageTestHelper {
         com_ptr<ITensorNative> itn = tf.as<ITensorNative>();
         itn->GetBuffer(reinterpret_cast<BYTE**>(&pCPUTensor), &uCapacity);
         if (BitmapPixelFormat::Bgra8 == GetPixelFormat(modelPixelFormat)) {
+            // loop condition is i < size - 2 to avoid potential for extending past the memory buffer
             for (UINT32 i = 0; i < size - 2; i += 4) {
                 UINT32 pixelInd = i / 4;
                 pCPUTensor[pixelInd] = (float)pData[i];
@@ -98,6 +99,7 @@ namespace ImageTestHelper {
         uint32_t height = softwareBitmap.PixelHeight();
         uint32_t width = softwareBitmap.PixelWidth();
         if (BitmapPixelFormat::Bgra8 == GetPixelFormat(modelPixelFormat)) {
+            // loop condition is i < size - 2 to avoid potential for extending past the memory buffer
             for (UINT32 i = 0; i < size - 2; i += 4) {
                 UINT32 pixelInd = i / 4;
                 pCPUTensor[pixelInd] = (float)pData[i];

--- a/winml/test/image/imageTestHelper.cpp
+++ b/winml/test/image/imageTestHelper.cpp
@@ -41,7 +41,6 @@ namespace ImageTestHelper {
         wf::IMemoryBufferReference reference = spBitmapBuffer.CreateReference();
         auto spByteAccess = reference.as<::Windows::Foundation::IMemoryBufferByteAccess>();
         spByteAccess->GetBuffer(&pData, &size);
-
         uint32_t height = softwareBitmap.PixelHeight();
         uint32_t width = softwareBitmap.PixelWidth();
 
@@ -53,14 +52,14 @@ namespace ImageTestHelper {
         com_ptr<ITensorNative> itn = tf.as<ITensorNative>();
         itn->GetBuffer(reinterpret_cast<BYTE**>(&pCPUTensor), &uCapacity);
         if (BitmapPixelFormat::Bgra8 == GetPixelFormat(modelPixelFormat)) {
-            for (UINT32 i = 0; i < size; i += 4) {
+            for (UINT32 i = 0; i < size - 2; i += 4) {
                 UINT32 pixelInd = i / 4;
                 pCPUTensor[pixelInd] = (float)pData[i];
                 pCPUTensor[(height * width) + pixelInd] = (float)pData[i + 1];
                 pCPUTensor[(height * width * 2) + pixelInd] = (float)pData[i + 2];
             }
         } else if (BitmapPixelFormat::Rgba8 == GetPixelFormat(modelPixelFormat)) {
-            for (UINT32 i = 0; i < size; i += 4) {
+            for (UINT32 i = 0; i < size - 2; i += 4) {
                 UINT32 pixelInd = i / 4;
                 pCPUTensor[pixelInd] = (float)pData[i + 2];
                 pCPUTensor[(height * width) + pixelInd] = (float)pData[i + 1];
@@ -99,14 +98,14 @@ namespace ImageTestHelper {
         uint32_t height = softwareBitmap.PixelHeight();
         uint32_t width = softwareBitmap.PixelWidth();
         if (BitmapPixelFormat::Bgra8 == GetPixelFormat(modelPixelFormat)) {
-            for (UINT32 i = 0; i < size; i += 4) {
+            for (UINT32 i = 0; i < size - 2; i += 4) {
                 UINT32 pixelInd = i / 4;
                 pCPUTensor[pixelInd] = (float)pData[i];
                 pCPUTensor[(height * width) + pixelInd] = (float)pData[i + 1];
                 pCPUTensor[(height * width * 2) + pixelInd] = (float)pData[i + 2];
             }
         } else if (BitmapPixelFormat::Rgba8 == GetPixelFormat(modelPixelFormat)) {
-            for (UINT32 i = 0; i < size; i += 4) {
+            for (UINT32 i = 0; i < size - 2; i += 4) {
                 UINT32 pixelInd = i / 4;
                 pCPUTensor[pixelInd] = (float)pData[i + 2];
                 pCPUTensor[(height * width) + pixelInd] = (float)pData[i + 1];

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -817,6 +817,7 @@ static void Scenario22ImageBindingAsCPUTensor() {
   uint32_t height = softwareBitmap.PixelHeight();
   uint32_t width = softwareBitmap.PixelWidth();
   for (UINT32 i = 0; i < size - 2; i += 4) {
+    // loop condition is i < size - 2 to avoid potential for extending past the memory buffer
     UINT32 pixelInd = i / 4;
     pCPUTensor[pixelInd] = (float)pData[i];
     pCPUTensor[(height * width) + pixelInd] = (float)pData[i + 1];
@@ -888,6 +889,7 @@ static void Scenario22ImageBindingAsGPUTensor() {
   uint32_t height = softwareBitmap.PixelHeight();
   uint32_t width = softwareBitmap.PixelWidth();
   for (UINT32 i = 0; i < size - 2; i += 4) {
+    // loop condition is i < size - 2 to avoid potential for extending past the memory buffer
     UINT32 pixelInd = i / 4;
     pCPUTensor[pixelInd] = (FLOAT)pData[i];
     pCPUTensor[(height * width) + pixelInd] = (FLOAT)pData[i + 1];
@@ -1495,6 +1497,7 @@ static void BindMultipleCPUBuffersAsInputs(LearningModelDeviceKind kind) {
   blue_byteaccess->GetBuffer(reinterpret_cast<BYTE**>(&blue_data), &frame_size);
 
   for (UINT32 i = 0; i < size - 2 && i / 4 < frame_size; i += 4) {
+    // loop condition is i < size - 2 to avoid potential for extending past the memory buffer
     UINT32 pixelInd = i / 4;
     red_data[pixelInd] = (float)data[i];
     green_data[pixelInd] = (float)data[i + 1];

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -816,7 +816,7 @@ static void Scenario22ImageBindingAsCPUTensor() {
 
   uint32_t height = softwareBitmap.PixelHeight();
   uint32_t width = softwareBitmap.PixelWidth();
-  for (UINT32 i = 0; i < size; i += 4) {
+  for (UINT32 i = 0; i < size - 2; i += 4) {
     UINT32 pixelInd = i / 4;
     pCPUTensor[pixelInd] = (float)pData[i];
     pCPUTensor[(height * width) + pixelInd] = (float)pData[i + 1];
@@ -887,7 +887,7 @@ static void Scenario22ImageBindingAsGPUTensor() {
 
   uint32_t height = softwareBitmap.PixelHeight();
   uint32_t width = softwareBitmap.PixelWidth();
-  for (UINT32 i = 0; i < size; i += 4) {
+  for (UINT32 i = 0; i < size - 2; i += 4) {
     UINT32 pixelInd = i / 4;
     pCPUTensor[pixelInd] = (FLOAT)pData[i];
     pCPUTensor[(height * width) + pixelInd] = (FLOAT)pData[i + 1];
@@ -1494,7 +1494,7 @@ static void BindMultipleCPUBuffersAsInputs(LearningModelDeviceKind kind) {
   green_byteaccess->GetBuffer(reinterpret_cast<BYTE**>(&green_data), &frame_size);
   blue_byteaccess->GetBuffer(reinterpret_cast<BYTE**>(&blue_data), &frame_size);
 
-  for (UINT32 i = 0; i < size; i += 4) {
+  for (UINT32 i = 0; i < size - 2 && i / 4 < frame_size; i += 4) {
     UINT32 pixelInd = i / 4;
     red_data[pixelInd] = (float)data[i];
     green_data[pixelInd] = (float)data[i + 1];


### PR DESCRIPTION
**Description**: SDL fixes for warnings C6385 and C6386

**Motivation and Context**
in some of the for loops in our test code, rather than explicitly putting conditions to avoid buffer overreading and overrwriting, we make assumptions about buffer size vars.
