### PR TITLE
[NNAPI EP] Fix of support API version bug for [de]quantize

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -1029,7 +1029,7 @@ class QuantizeLinearOpSupportChecker : public BaseOpSupportChecker {
                          const OpSupportCheckParams& params) const override;
 
   int32_t GetMinSupportedSdkVer(const Node& /* node */, const OpSupportCheckParams& /* params */) const override {
-    return 27;
+    return 29;
   }
 };
 
@@ -1070,7 +1070,7 @@ class DequantizeLinearOpSupportChecker : public BaseOpSupportChecker {
                          const OpSupportCheckParams& params) const override;
 
   int32_t GetMinSupportedSdkVer(const Node& /* node */, const OpSupportCheckParams& /* params */) const override {
-    return 29;
+    return 27;
   }
   bool HasSupportedInputsImpl(const Node& node) const override;
 };


### PR DESCRIPTION
**Description**: [NNAPI EP] Fix of support api version bug for [de]quantize

**Motivation and Context**
- The GetMinSupportedSdkVer() of QuantizeLinear and DequantizeLinear operations return wrong Android API versions. This will cause error if ORT running models contains QuantizeLinear on Android API 28-


