### PR TITLE
Refine transformers profiler output

### DIFF
--- a/onnxruntime/python/tools/transformers/README.md
+++ b/onnxruntime/python/tools/transformers/README.md
@@ -224,9 +224,9 @@ profiler.py can be used to run profiling on a transformer model. It can help fig
 Examples commands:
 
 ```console
-python -m onnxruntime.transformers.profiler --model bert.onnx --batch_size 1 --sequence_length 128 --samples 1000 --dummy_inputs bert --thread_num 8 --kernel_time_only
-python -m onnxruntime.transformers.profiler --model bert.onnx --batch_size 1 --sequence_length 128 --samples 1000 --dummy_inputs gpt2 --use_gpu
-python -m onnxruntime.transformers.profiler --model longformer.onnx --batch_size 1 --sequence_length 4096 --global_length 8 --samples 1000 --thread_num 8 --dummy_inputs longformer --use_gpu
+python -m onnxruntime.transformers.profiler --model bert.onnx --batch_size 8 --sequence_length 128 --samples 1000 --dummy_inputs bert --thread_num 8 --kernel_time_only
+python -m onnxruntime.transformers.profiler --model gpt2.onnx --batch_size 1 --sequence_length 1 --past_sequence_length 128 --samples 1000 --dummy_inputs gpt2 --use_gpu
+python -m onnxruntime.transformers.profiler --model longformer.onnx --batch_size 1 --sequence_length 4096 --global_length 8 --samples 1000 --dummy_inputs longformer --use_gpu
 ```
 
 Result file like onnxruntime_profile__<date_time>.json will be output to current directory. Summary of nodes, top expensive nodes and results grouped by operator type will be printed to console.

--- a/onnxruntime/python/tools/transformers/README.md
+++ b/onnxruntime/python/tools/transformers/README.md
@@ -217,3 +217,16 @@ For GPU, please append --use_gpu to the command.
 
 After test is finished, a file like perf_results_CPU_B1_S128_<date_time>.txt or perf_results_GPU_B1_S128_<date_time>.txt will be output to the model directory.
 
+## Profiling
+
+profiler.py can be used to run profiling on a transformer model. It can help figure out the bottleneck of a model, and time spent on a node or subgraph.
+
+Examples commands:
+
+```console
+python -m onnxruntime.transformers.profiler --model bert.onnx --batch_size 1 --sequence_length 128 --samples 1000 --dummy_inputs bert --thread_num 8 --kernel_time_only
+python -m onnxruntime.transformers.profiler --model bert.onnx --batch_size 1 --sequence_length 128 --samples 1000 --dummy_inputs gpt2 --use_gpu
+python -m onnxruntime.transformers.profiler --model longformer.onnx --batch_size 1 --sequence_length 4096 --global_length 8 --samples 1000 --thread_num 8 --dummy_inputs longformer --use_gpu
+```
+
+Result file like onnxruntime_profile__<date_time>.json will be output to current directory. Summary of nodes, top expensive nodes and results grouped by operator type will be printed to console.

--- a/onnxruntime/python/tools/transformers/bert_test_data.py
+++ b/onnxruntime/python/tools/transformers/bert_test_data.py
@@ -151,16 +151,16 @@ def get_graph_input_from_embed_node(onnx_model, embed_node, input_index):
     return graph_input
 
 
-def get_bert_inputs(onnx_file, input_ids_name=None, segment_ids_name=None, input_mask_name=None):
-    """
-    Get graph inputs for bert model.
+def find_bert_inputs(onnx_model, input_ids_name=None, segment_ids_name=None, input_mask_name=None):
+    """Find graph inputs for BERT model.
     First, we will deduce from EmbedLayerNormalization node. If not found, we will guess based on naming.
-    """
-    model = ModelProto()
-    with open(onnx_file, "rb") as f:
-        model.ParseFromString(f.read())
 
-    onnx_model = OnnxModel(model)
+    Args:
+        onnx_model (OnnxModel): onnx model object
+        input_ids_name (str, optional): Name of graph input for input IDs. Defaults to None.
+        segment_ids_name (str, optional): Name of graph input for segment IDs. Defaults to None.
+        input_mask_name (str, optional): Name of graph input for attention mask. Defaults to None.
+    """
     graph_inputs = onnx_model.get_graph_inputs_excluding_initializers()
 
     if input_ids_name is not None:
@@ -214,6 +214,24 @@ def get_bert_inputs(onnx_file, input_ids_name=None, segment_ids_name=None, input
         return input_ids, segment_ids, input_mask
 
     raise ValueError("Fail to assign 3 inputs. You might try rename the graph inputs.")
+
+
+def get_bert_inputs(onnx_file, input_ids_name=None, segment_ids_name=None, input_mask_name=None):
+    """Find graph inputs for BERT model.
+    First, we will deduce from EmbedLayerNormalization node. If not found, we will guess based on naming.
+
+    Args:
+        onnx_file (str): onnx model path
+        input_ids_name (str, optional): Name of graph input for input IDs. Defaults to None.
+        segment_ids_name (str, optional): Name of graph input for segment IDs. Defaults to None.
+        input_mask_name (str, optional): Name of graph input for attention mask. Defaults to None.
+    """
+    model = ModelProto()
+    with open(onnx_file, "rb") as f:
+        model.ParseFromString(f.read())
+
+    onnx_model = OnnxModel(model)
+    find_bert_inputs(onnx_model, input_ids_name, segment_ids_name, input_mask_name)
 
 
 def parse_arguments():


### PR DESCRIPTION
**Description**: 
Improve profiler outputs:
(1) Group results by nodes name in the original order, so that we can have duration before/after each node to help estimate subgraph latency.
(2) Add document for some functions
(3) Add document for profiling in readme
(4) Change default threshold to 0.01, so that top expensive nodes have a short list by default.
(5) Do not output CPU duration in CPU only mode since duration is always same as CPU duration.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

Refine output to help estimate subgraph latency.