### PR TITLE
Add equalization algorithm and example usage

### DIFF
--- a/onnxruntime/python/tools/quantization/equalization_example/equalization.py
+++ b/onnxruntime/python/tools/quantization/equalization_example/equalization.py
@@ -1,0 +1,589 @@
+import onnx
+import onnx.numpy_helper
+import onnxruntime
+import numpy as np
+import collections
+
+def update_parameter_names(model, first_input_name, final_output_name):
+    """
+        By default, the given model may not have a consistent parameter naming convention.
+        To resolve this, we rename each node to be a conjunction of its op type and index.
+        Then, each parameter of the node is given a name as an extension of the node name.
+        The final model is identical topologically, with updated parameter names.
+    
+        Parameters:
+            model (onnx.onnx_ml_pb2.ModelProto): model with parameter names to be updated.
+            first_input_name (str): name of the first input to the model.
+            final_output_name (str): name of the final output from the model.
+        
+        Returns:
+            model (onnx.onnx_ml_pb2.ModelProto): model with updated parameter names.
+    """
+    
+    name_dict = {first_input_name:first_input_name}
+
+    for i, node in enumerate(model.graph.node):
+        node_type = node.op_type
+
+        if node_type == 'Conv':
+            old_name_1 = model.graph.node[i].input[1]
+            new_name_1 = model.graph.node[i].name + "." + "W"
+            name_dict[old_name_1] = new_name_1
+
+            if len(model.graph.node[i].input) == 3:
+                old_name_2 = model.graph.node[i].input[2]
+                new_name_2 = model.graph.node[i].name + "." + "B"
+                name_dict[old_name_2] = new_name_2
+
+            old_out_name = model.graph.node[i].output[0]
+            new_out_name = model.graph.node[i].name + "." + "Y"
+            name_dict[old_out_name] = new_out_name
+
+        elif node_type == 'BatchNormalization':
+            old_name_1 = model.graph.node[i].input[1]
+            new_name_1 = model.graph.node[i].name + "." + "scale"
+            name_dict[old_name_1] = new_name_1
+
+            old_name_2 = model.graph.node[i].input[2]
+            new_name_2 = model.graph.node[i].name + "." + "B"
+            name_dict[old_name_2] = new_name_2
+
+            old_name_3 = model.graph.node[i].input[3]
+            new_name_3 = model.graph.node[i].name + "." + "mean"
+            name_dict[old_name_3] = new_name_3
+
+            old_name_4 = model.graph.node[i].input[4]
+            new_name_4 = model.graph.node[i].name + "." + "var"
+            name_dict[old_name_4] = new_name_4
+
+            old_out_name = model.graph.node[i].output[0]
+            new_out_name = model.graph.node[i].name + "." + "Y"
+            name_dict[old_out_name] = new_out_name
+
+        elif node_type =='Relu':
+
+            old_out_name = model.graph.node[i].output[0]
+            new_out_name = model.graph.node[i].name + "." + "Y"
+            name_dict[old_out_name] = new_out_name
+
+        elif node_type == 'Add':
+
+            old_out_name = model.graph.node[i].output[0]
+            new_out_name = model.graph.node[i].name + "." + "Y"
+            name_dict[old_out_name] = new_out_name
+
+        elif node_type == 'ReduceMean':
+
+            old_out_name = model.graph.node[i].output[0]
+            new_out_name = model.graph.node[i].name + "." + "Y"
+            name_dict[old_out_name] = new_out_name
+
+        elif node_type == 'Gemm':
+            old_name_1 = model.graph.node[i].input[1]
+            new_name_1 = model.graph.node[i].name + "." + "B"
+            name_dict[old_name_1] = new_name_1
+
+            old_name_2 = model.graph.node[i].input[2]
+            new_name_2 = model.graph.node[i].name + "." + "C"
+            name_dict[old_name_2] = new_name_2
+
+            old_out_name = model.graph.node[i].output[0]
+            new_out_name = model.graph.node[i].name + "." + "Y"
+            name_dict[old_out_name] = new_out_name
+
+        else:
+            print("Unmapped node:", node_type)
+            raise NotImplementedError
+
+    name_dict[final_output_name] = final_output_name
+    
+    for i, node in enumerate(model.graph.node):
+    
+        new_inputs = []
+
+        for j, param in reversed(list(enumerate(node.input))):
+
+            old_name = model.graph.node[i].input[j]
+            new_name = name_dict[old_name]
+            new_inputs.append(new_name)
+            model.graph.node[i].input.pop()
+
+        for j, param in reversed(list(enumerate(new_inputs))):
+
+            model.graph.node[i].input.append(param)
+
+        old_output = model.graph.node[i].output[0]
+        new_output = name_dict[old_output]
+        model.graph.node[i].output.pop()
+        model.graph.node[i].output.append(new_output)
+        
+    for i, init in enumerate(model.graph.initializer):
+        old_init_name = model.graph.initializer[i].name
+        new_init_name = name_dict[old_init_name]
+
+        model.graph.initializer[i].name = new_init_name
+        
+    return model
+
+def get_init_lookup(model):
+    """
+    Create lookup table with each node index and corresponding node name.
+    
+        Parameters:
+            model (onnx.onnx_ml_pb2.ModelProto): model with initializer.
+        
+        Output:
+            init_lookup (dict): mapping from initializer names to respective indecies.
+    """
+        
+    init_lookup = {}
+    
+    for init_index, init in enumerate(model.graph.initializer):
+        
+        init_lookup[init.name] = init_index
+        
+    return init_lookup
+
+def add_zeroed_bias(model, init_lookup):
+    """
+    By default, some models do not have a bias attribute in their convolution op. When
+    merging batchnorm, a bias parameter in the conv layer is necessary as a destination
+    for the reassignment of batchnorm parameters. self.model is modified in-place.
+    
+        Parameters:
+            model (onnx.onnx_ml_pb2.ModelProto): model with some conv layers without bias.
+            init_lookup (dict): mapping of model initializer names to indecies.
+            
+        Outputs:
+            model (onnx.onnx_ml_pb2.ModelProto): model with all conv layers with bias.
+            init_lookup (dict): updated mapping of model initializer names to indecies.
+    """
+
+    for i, node in enumerate(model.graph.node):
+        
+        node_op_type = model.graph.node[i].op_type
+        node_input_len = len(model.graph.node[i].input)
+
+        if node_op_type == "Conv" and node_input_len == 2:
+            node_weight_name = model.graph.node[i].name + "." + "W"
+            node_bias_name = model.graph.node[i].name + "." + "B"
+            
+            init_weight_index = init_lookup[node_weight_name]
+            node_weight_shape = onnx.numpy_helper.to_array(
+                model.graph.initializer[init_weight_index]
+            ).shape
+
+            node_bias_shape = node_weight_shape[0]
+            node_bias_np = np.zeros(node_bias_shape, dtype=np.float32)
+            node_bias_pb = onnx.numpy_helper.from_array(
+                node_bias_np, name=node_bias_name
+            )
+
+            model.graph.node[i].input.append(node_bias_name)
+            model.graph.initializer.append(node_bias_pb)
+            
+    init_lookup = get_init_lookup(model)
+
+    return model, init_lookup
+
+def merge_batchnorm(model, init_lookup):
+    """
+    Integrate batchnorm gamma, beta, running mean, and running var into the parametric
+    values of the preceeding convolutional layer. Also known as merge batchnorm, this
+    operation improves accuracy calculation and reduced latency (if batchnorm is later
+    removed). Results in self.model conv layers changed in-place and batchnorm distribution
+    being 0 centered with 1 variance.
+    
+        Parameters:
+            model (onnx.onnx_ml_pb2.ModelProto): model with batch norm layers.
+            init_lookup (dict): mapping of model initializer names to indecies.
+            
+        Outputs:
+            model (onnx.onnx_ml_pb2.ModelProto): model with batch norm integrated into conv parameters.
+            init_lookup (dict): updated mapping of model initializer names to indecies.
+    """
+    
+    for i in range(len(model.graph.node) - 1):
+        
+        node_1_type = model.graph.node[i].op_type
+        node_2_type = model.graph.node[i+1].op_type
+        
+        node_1_conv_flag = node_1_type == "Conv"
+        node_2_bn_flag   = node_2_type == "BatchNormalization"
+        
+        if node_1_conv_flag and node_2_bn_flag:
+            eps = model.graph.node[i+1].attribute[0].f
+            
+            c_w_name = model.graph.node[i].name + "." + "W"
+            c_b_name = model.graph.node[i].name + "." + "B"
+            b_w_name = model.graph.node[i+1].name + "." + "scale"
+            b_b_name = model.graph.node[i+1].name + "." + "B"
+            b_m_name = model.graph.node[i+1].name + "." + "mean"
+            b_v_name = model.graph.node[i+1].name + "." + "var"
+            
+            c_w_index = init_lookup[c_w_name]
+            c_b_index = init_lookup[c_b_name]
+            b_w_index = init_lookup[b_w_name]
+            b_b_index = init_lookup[b_b_name]
+            b_m_index = init_lookup[b_m_name]
+            b_v_index = init_lookup[b_v_name]
+            
+            c_w = model.graph.initializer[c_w_index]
+            c_b = model.graph.initializer[c_b_index]
+            b_w = model.graph.initializer[b_w_index]
+            b_b = model.graph.initializer[b_b_index]
+            b_m = model.graph.initializer[b_m_index]
+            b_v = model.graph.initializer[b_v_index]
+    
+            c_w = onnx.numpy_helper.to_array(c_w)
+            c_b = onnx.numpy_helper.to_array(c_b)
+            b_w = onnx.numpy_helper.to_array(b_w)
+            b_b = onnx.numpy_helper.to_array(b_b)
+            b_m = onnx.numpy_helper.to_array(b_m)
+            b_v = onnx.numpy_helper.to_array(b_v)
+            
+            adj_c_b = c_b * (b_w / np.sqrt(b_v + eps))
+            adj_b_b = (b_b - (b_w * b_m) / np.sqrt(b_v + eps))
+            new_c_b = adj_c_b + adj_b_b
+
+            new_c_w = (c_w.T * (b_w / np.sqrt(b_v + eps))).T
+
+            new_b_w = np.ones(b_w.shape, dtype=np.float32)
+            new_b_b = np.zeros(b_b.shape, dtype=np.float32)
+            new_b_m = np.zeros(b_m.shape, dtype=np.float32)
+            new_b_v = np.ones(b_v.shape, dtype=np.float32)
+
+            model.graph.initializer[c_w_index].raw_data = onnx.numpy_helper.from_array(new_c_w).raw_data
+            model.graph.initializer[c_b_index].raw_data = onnx.numpy_helper.from_array(new_c_b).raw_data
+            model.graph.initializer[b_w_index].raw_data = onnx.numpy_helper.from_array(new_b_w).raw_data
+            model.graph.initializer[b_b_index].raw_data = onnx.numpy_helper.from_array(new_b_b).raw_data
+            model.graph.initializer[b_m_index].raw_data = onnx.numpy_helper.from_array(new_b_m).raw_data
+            model.graph.initializer[b_v_index].raw_data = onnx.numpy_helper.from_array(new_b_v).raw_data
+
+            model.graph.node[i+1].attribute[0].f = 0
+
+            i = i + 1
+            
+    init_lookup = get_init_lookup(model)
+    
+    return model, init_lookup
+
+def scale(a, s, axis):
+    """
+    Scale array a by scaling factor s. s is applied to each
+    sub-array along specified axis.
+    # https://stackoverflow.com/a/30032182/5196692
+    
+        Parameters:
+            a (numpy.ndarray): numpy array of model weights.
+            s (numpy.ndarray): numpy array of scalings to be applied.
+            axis (int): axis to apply scalings.
+            
+        Outputs:
+            mult_out (numpy.ndarray): numpy array with scalings applied.
+    """
+    
+    if len(a.shape) == 1:
+        axis = 0
+    elif a.shape[1] == 1:
+        axis = 0
+
+    given_axis = axis
+
+    dim_array = np.ones((1,a.ndim),int).ravel()
+    dim_array[given_axis] = -1
+
+    s_reshaped = s.reshape(dim_array)
+
+    mult_out = a*s_reshaped
+
+    assert(a.shape == mult_out.shape)
+
+    return mult_out
+
+def layer_equalization(W1, W2, b1, bn_W1=None, bn_b1=None, eps=0):
+    """
+    Calculates the layer equalized scaling parameters of two convolutional layers
+    and returns the scaled weights accross their appropriate axis. If signed,
+    the full range is used, else the range w.r.t. zero is used.
+    
+        Parameters:
+            W1 (numpy.ndarray): weights of the first conv layer.
+            W2 (numpy.ndarray): weights of the second conv layer.
+            b1 (numpy.ndarray): bias of the first conv layer.
+            bn_W1 (numpy.ndarray): batch norm weights of the first conv layer.
+            bn_b1 (numpy.ndarray): batch norm bias of the first conv layer.
+            eps (float): batch norm epsilon.
+            
+        Outputs:
+            new_W1 (numpy.ndarray): equalized weights of the first conv layer.
+            new_W2 (numpy.ndarray): equalized weights of the second conv layer.
+            new_b1 (numpy.ndarray): equalized bias of the first conv layer.
+            new_bn_W1 (numpy.ndarray): equalized batch norm weights of the first conv layer.
+            new_bn_b1 (numpy.ndarray): equalized batch norm bias of the first conv layer.
+            S (numpy.ndarray): scalings used for equalization.
+    """
+    
+    W1_depthwise_flag = True if W1.shape[1] == 1 else False
+    W2_depthwise_flag = True if W2.shape[1] == 1 else False
+
+    if W1_depthwise_flag == False and W2_depthwise_flag == False:
+        max_1 = np.max(W1, axis=(1, 2, 3)).squeeze()
+        min_1 = np.min(W1, axis=(1, 2, 3)).squeeze()
+
+        max_2 = np.max(W2, axis=(0, 2, 3)).squeeze()
+        min_2 = np.min(W2, axis=(0, 2, 3)).squeeze()
+
+    elif W1_depthwise_flag == True:
+        max_1 = np.max(W1, axis=(1, 2, 3)).squeeze()
+        min_1 = np.min(W1, axis=(1, 2, 3)).squeeze()
+
+        max_2 = np.max(W2, axis=(0, 2, 3)).squeeze()
+        min_2 = np.min(W2, axis=(0, 2, 3)).squeeze()
+
+    elif W2_depthwise_flag == True:
+        max_1 = np.max(W1, axis=(1, 2, 3)).squeeze()
+        min_1 = np.min(W1, axis=(1, 2, 3)).squeeze()
+
+        max_2 = np.max(W2, axis=(1, 2, 3)).squeeze()
+        min_2 = np.min(W2, axis=(1, 2, 3)).squeeze()
+
+    else:
+        raise ValueError
+
+    range_1 = max_1 - min_1
+    range_2 = max_2 - min_2
+
+    S = range_1**-1 * np.sqrt(range_1 * range_2 + eps)
+
+    new_W2 = scale(W2, S**-1, axis=1) if W2_depthwise_flag == False else scale(W2, S**-1, axis=0)
+    new_W1 = scale(W1, S, axis=0)
+    new_b1 = scale(b1, S, axis=0) if b1 is not None else None
+
+    new_bn_W1 = bn_W1
+    new_bn_b1 = bn_b1
+
+    return new_W1, new_W2, new_b1, new_bn_W1, new_bn_b1, S
+
+def get_residual_node_list(model):
+    """
+    Set node identifiers where residual connections occur. Identification is necessary since
+    you can equalize to these node but not from these nodes. In other words, equalizing from 
+    residual nodes would be a mistake because equalization is for one connecting pair but 
+    there are two connecting pairs.
+    
+        Parameters:
+            model (onnx.onnx_ml_pb2.ModelProto): model with residual connections.
+            
+        Outputs:
+            pre_residual_node_names (list): list of node names in model with residual connections.
+    """
+        
+    input_node_names = []
+    
+    for node in model.graph.node:
+        
+        input_node_names.append(node.input)
+
+    input_node_names = [item for sublist in input_node_names for item in sublist]
+    
+    residual_node_names = [x for x, y in collections.Counter(input_node_names).items() if y > 1]
+    
+    pre_residual_node_names = [node.input[0] for node in model.graph.node if node.output[0] in residual_node_names]
+    
+    return pre_residual_node_names
+
+def cross_layer_equalization(model, init_lookup, pre_residual_node_names):
+    """
+    Cross layer equalization is layer equalization applied iteratively
+    over conv layer pairs (groups of ops) in the network. There are
+    three condition accounted for so far in this implementation:
+    1. If the layer pair contains only conv nodes
+    2. If the layer pair contains conv nodes and relu activations,
+    3. If the first of two conv nodes is followed by batchnorm and both
+       have activations.
+    Because of the interdependence of the equalization algorithm, the
+    conditions relevant to the model must be defined and it cannot simply
+    be done in place (as is the case with default quantization). 
+    self.model optimizations are applied in-place. 
+    
+    Parameters:
+        model (onnx.onnx_ml_pb2.ModelProto): model to be equalized.
+        init_lookup (dict): mapping of model initializer names to indecies.
+        pre_residual_node_names (list): list of node names in model with residual connections.
+            
+        Outputs:
+            model (onnx.onnx_ml_pb2.ModelProto): equalized model.
+    """
+
+    for i in range(len(model.graph.node)-3):
+
+        node_1_type = model.graph.node[i].op_type
+        node_2_type = model.graph.node[i+1].op_type
+        node_3_type = model.graph.node[i+2].op_type
+        node_4_type = model.graph.node[i+3].op_type
+
+        node_1_conv_flag = node_1_type == "Conv"
+        node_2_conv_flag = node_2_type == "Conv"
+        node_2_bn_flag   = node_2_type == "BatchNormalization"
+        node_3_conv_flag = node_3_type == "Conv"
+        node_3_relu_flag = node_3_type == "Relu"
+        node_4_conv_flag = node_4_type == "Conv"
+
+        if model.graph.node[i].output[0] in pre_residual_node_names:
+            
+            continue
+
+        if node_1_conv_flag and node_2_conv_flag:
+
+            c1_w_name = model.graph.node[i] + "." + "W"
+            c1_b_name = model.graph.node[i] + "." + "B"
+            c2_w_name = model.graph.node[i+1] + "." + "W"
+            
+            c1_w_index = init_lookup[c1_w_name]
+            c1_b_index = init_lookup[c1_b_name]
+            c2_w_index = init_lookup[c2_w_name]
+
+            c1_w = model.graph.initializer[c1_w_index]
+            c1_b = model.graph.initializer[c1_b_index]
+            c2_w = model.graph.initializer[c2_w_index]
+
+            c1_w = onnx.numpy_helper.to_array(c1_w)
+            c1_b = onnx.numpy_helper.to_array(c1_b)
+            c2_w = onnx.numpy_helper.to_array(c2_w)
+
+            new_c1_w, new_c2_w, new_c1_b, _, _, S = layer_equalization(c1_w, c2_w, c1_b)
+
+            new_c1_w = onnx.numpy_helper.from_array(new_c1_w).raw_data
+            new_c1_b = onnx.numpy_helper.from_array(new_c1_b).raw_data
+            new_c2_w = onnx.numpy_helper.from_array(new_c2_w).raw_data
+
+            model.graph.initializer[c1_w_index].raw_data = new_c1_w
+            model.graph.initializer[c1_b_index].raw_data = new_c1_b
+            model.graph.initializer[c2_w_index].raw_data = new_c2_w
+
+        elif node_1_conv_flag and node_2_bn_flag and node_3_conv_flag: 
+
+            c1_w_name = model.graph.node[i].name + "." + "W"
+            c1_b_name = model.graph.node[i].name + "." + "B"
+            b1_w_name = model.graph.node[i+1].name + "." + "scale"
+            b1_b_name = model.graph.node[i+1].name + "." + "B"
+            c2_w_name = model.graph.node[i+2].name + "." + "W"
+            
+            c1_w_index = init_lookup[c1_w_name]
+            c1_b_index = init_lookup[c1_b_name]
+            b1_w_index = init_lookup[b1_w_name]
+            b1_b_index = init_lookup[b1_b_name]
+            c2_w_index = init_lookup[c2_w_name]
+
+            c1_w = model.graph.initializer[c1_w_index]
+            c1_b = model.graph.initializer[c1_b_index]
+            b1_w = model.graph.initializer[b1_w_index]
+            b1_b = model.graph.initializer[b1_b_index]
+            c2_w = model.graph.initializer[c2_w_index]
+
+            c1_w = onnx.numpy_helper.to_array(c1_w)
+            c1_b = onnx.numpy_helper.to_array(c1_b)
+            b1_w = onnx.numpy_helper.to_array(b1_w)
+            b1_b = onnx.numpy_helper.to_array(b1_b)
+            c2_w = onnx.numpy_helper.to_array(c2_w)
+
+            new_c1_w, new_c2_w, new_c1_b, new_b1_w, new_b1_b, S = layer_equalization(c1_w, c2_w, c1_b, bn_W1=b1_w, bn_b1=b1_b)
+
+            new_c1_w = onnx.numpy_helper.from_array(new_c1_w).raw_data
+            new_c1_b = onnx.numpy_helper.from_array(new_c1_b).raw_data
+            new_b1_w = onnx.numpy_helper.from_array(new_b1_w).raw_data
+            new_b1_b = onnx.numpy_helper.from_array(new_b1_b).raw_data
+            new_c2_w = onnx.numpy_helper.from_array(new_c2_w).raw_data
+
+            model.graph.initializer[c1_w_index].raw_data = new_c1_w
+            model.graph.initializer[c1_b_index].raw_data = new_c1_b
+            model.graph.initializer[b1_w_index].raw_data = new_b1_w
+            model.graph.initializer[b1_b_index].raw_data = new_b1_b
+            model.graph.initializer[c2_w_index].raw_data = new_c2_w
+
+        elif node_1_conv_flag and node_2_bn_flag and node_3_relu_flag and node_4_conv_flag: 
+
+            c1_w_name = model.graph.node[i].name + "." + "W"
+            c1_b_name = model.graph.node[i].name + "." + "B"
+            b1_w_name = model.graph.node[i+1].name + "." + "scale"
+            b1_b_name = model.graph.node[i+1].name + "." + "B"
+            c2_w_name = model.graph.node[i+3].name + "." + "W"
+            
+            c1_w_index = init_lookup[c1_w_name]
+            c1_b_index = init_lookup[c1_b_name]
+            b1_w_index = init_lookup[b1_w_name]
+            b1_b_index = init_lookup[b1_b_name]
+            c2_w_index = init_lookup[c2_w_name]
+
+            c1_w = model.graph.initializer[c1_w_index]
+            c1_b = model.graph.initializer[c1_b_index]
+            b1_w = model.graph.initializer[b1_w_index]
+            b1_b = model.graph.initializer[b1_b_index]
+            c2_w = model.graph.initializer[c2_w_index]
+
+            c1_w = onnx.numpy_helper.to_array(c1_w)
+            c1_b = onnx.numpy_helper.to_array(c1_b)
+            b1_w = onnx.numpy_helper.to_array(b1_w)
+            b1_b = onnx.numpy_helper.to_array(b1_b)
+            c2_w = onnx.numpy_helper.to_array(c2_w)
+
+            new_c1_w, new_c2_w, new_c1_b, new_b1_w, new_b1_b, S = layer_equalization(c1_w, c2_w, c1_b, bn_W1=b1_w, bn_b1=b1_b)
+
+            new_c1_w = onnx.numpy_helper.from_array(new_c1_w).raw_data
+            new_c1_b = onnx.numpy_helper.from_array(new_c1_b).raw_data
+            new_b1_w = onnx.numpy_helper.from_array(new_b1_w).raw_data
+            new_b1_b = onnx.numpy_helper.from_array(new_b1_b).raw_data
+            new_c2_w = onnx.numpy_helper.from_array(new_c2_w).raw_data
+
+            model.graph.initializer[c1_w_index].raw_data = new_c1_w
+            model.graph.initializer[c1_b_index].raw_data = new_c1_b
+            model.graph.initializer[b1_w_index].raw_data = new_b1_w
+            model.graph.initializer[b1_b_index].raw_data = new_b1_b
+            model.graph.initializer[c2_w_index].raw_data = new_c2_w
+
+        else:
+            continue
+          
+    return model
+
+
+def equalize(model_path, save=False, save_path="equalized_model.onnx",
+             first_input_name = "input", final_output_name = "output"):
+    """
+    Execute cross layer equalization after adding bias attribute to conv,
+    replacing relu6 (clip) with relu, and applying merge batchnorm. Model
+    is modified in-place with optimizations to improve quantization.
+        
+        Parameters:
+            model_path (str): path to onnx model.
+            save (bool): flag identifying if model should be saved.
+            save_path (str): path to equalized onnx model.
+            first_input_name (str): name of the first input to the model.
+            final_output_name (str): name of the final output from the model.
+            
+        Outputs:
+            model (onnx.onnx_ml_pb2.ModelProto): equalized onnx model.
+    """
+    
+    model = onnx.load(model_path)
+    onnx.checker.check_model(model)
+    
+    model = update_parameter_names(model, first_input_name, final_output_name)
+    onnx.checker.check_model(model)
+
+    init_lookup = get_init_lookup(model)
+    model, init_lookup = add_zeroed_bias(model, init_lookup)
+    onnx.checker.check_model(model)
+
+    model, init_lookup = merge_batchnorm(model, init_lookup)
+    onnx.checker.check_model(model)
+
+    pre_residual_node_names = get_residual_node_list(model)
+    model = cross_layer_equalization(model, init_lookup, pre_residual_node_names)
+    onnx.checker.check_model(model)
+
+    if save==True:
+        onnx.save(model, save_path)
+        
+    return model

--- a/onnxruntime/python/tools/quantization/equalization_example/mobilenetv2_quantization.ipynb
+++ b/onnxruntime/python/tools/quantization/equalization_example/mobilenetv2_quantization.ipynb
@@ -1,0 +1,1932 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Python version\n",
+      "3.8.6 | packaged by conda-forge | (default, Oct  7 2020, 18:22:52) [MSC v.1916 64 bit (AMD64)]\n",
+      "Version info.\n",
+      "sys.version_info(major=3, minor=8, micro=6, releaselevel='final', serial=0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "print(\"Python version\")\n",
+    "print (sys.version)\n",
+    "print(\"Version info.\")\n",
+    "print (sys.version_info)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "Quantization has been shown to give 2-4x reduction in model size and as much as have an increase in model throughput. However, quantization also has been linked to significant degradation of model accuracy. By using model equalization, engineers are able to amiliorate the concerns of quantized model accuracy degradation at no expense to the optimizations of model size and throughput.\n",
+    "\n",
+    "This tutorial shows how to preserve model accuracy through cross layer equalization, as well as how to perform either data-free model quantization or calibrated model quantization. This quantization functionality has recently been enabled in ONNX Runtime, allowing for significant performance gains on processors with AVX-512 VNNI instructions or similar quantization optimized hardware.\n",
+    "\n",
+    "The process of quantization has a few steps, which includes: \n",
+    "\n",
+    "0. Import Modules, \n",
+    "1. Define Data Loader, \n",
+    "2. Export Model to ONNX, \n",
+    "3. Equalize Model, \n",
+    "4. Quantize Model, \n",
+    "5. Validation Inference, and \n",
+    "6. Final Results. \n",
+    "\n",
+    "We will be converting a model from, and do data loading with, PyTorch. These steps can also be done from any other ONNX supported framework."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0. Import Modules\n",
+    "\n",
+    "This tutorial involves a few libraries. There uses are as follows:\n",
+    "- onnx and onnxruntime are used for model loading and inference. \n",
+    "- torch and torchvision are used for data loading (with multi-process image preprocessing)\n",
+    "- numpy is used to store model results\n",
+    "- sklearn.metrics enables calculations such as accuracy, precision, recall, F1 score, etc.\n",
+    "- matplotlib is used to create the bar plots displaying the resulting metrics\n",
+    "\n",
+    "Note the version of onnx and onnxruntime used to make this notebook possible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "onnx 1.8.0\n",
+      "onnxruntime 1.5.2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Model and Inference\n",
+    "import onnx\n",
+    "import onnx.numpy_helper\n",
+    "import onnxruntime\n",
+    "import onnxruntime.quantization\n",
+    "\n",
+    "# Data Loader\n",
+    "import torch\n",
+    "import torchvision\n",
+    "\n",
+    "# Evaluation\n",
+    "import numpy as np\n",
+    "import sklearn.metrics\n",
+    "\n",
+    "# Visualization\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "plt.style.use('ggplot')\n",
+    "\n",
+    "# Other Utilities\n",
+    "import os\n",
+    "import pandas as pd\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "\n",
+    "print(\"onnx\", onnx.__version__)\n",
+    "print(\"onnxruntime\", onnxruntime.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will also use the model referenced in the original paper on [Data-Free Quantization Through Weight Equalization and Bias Correction](https://arxiv.org/abs/1906.04721). The MobileNetV2 model is authored by Ji Lin, [whose repository is linked here](https://github.com/tonylins/pytorch-mobilenet-v2)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not os.path.exists(\"pytorch_mobilenet_v2\"):\n",
+    "    import git\n",
+    "    git_path = \"https://github.com/tonylins/pytorch-mobilenet-v2.git\"\n",
+    "    git.Git().clone(git_path)\n",
+    "    \n",
+    "    os.rename(\"pytorch-mobilenet-v2\", \"pytorch_mobilenet_v2\")\n",
+    "\n",
+    "import pytorch_mobilenet_v2.MobileNetV2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Define Data Loader\n",
+    "\n",
+    "The data source used for this tutorial is ImageNet, which is described by image-net.org as:\n",
+    "\n",
+    "> ImageNet is an image database organized according to the WordNet hierarchy (currently only the nouns), in which each node of the hierarchy is depicted by hundreds and thousands of images.\n",
+    "\n",
+    "The original source is larger than necessary for pedagogy, so we will use a sample of 1,000 training and 1,000 validation images (one image for each class). The data used is provided by PyTorch and is linked here.\n",
+    "\n",
+    "> https://s3.amazonaws.com/pytorch-tutorial-assets/imagenet_1k.zip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TRAIN_DATA_PATH = '/Users/jkonan/OneDrive - Intel Corporation/Data/imagenet_1k/train'\n",
+    "TEST_DATA_PATH = '/Users/jkonan/OneDrive - Intel Corporation/Data/imagenet_1k/val'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For pre-processing, the dataset class and dataloader class are both provided by Ji Lin. There are four pre-processing steps for validation:\n",
+    "\n",
+    "1. Resizing the image to have width 256 and height 256,\n",
+    "2. Cropping the center of the image to have 224 width and 224 height,\n",
+    "3. Converting the image to a pytorch tensor (required for dataloading),\n",
+    "4. Normalizing the image using the mean and standard of all imagenet training.\n",
+    "\n",
+    "The final input size to the model is (batch_size, number of channels, height, width) = (1, 3, 224, 224)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Details of the training dataset and data loader are below.\n",
+      "\n",
+      "Num Observations: 1000\n",
+      "Num Batches:\t  1000\n",
+      "Batch Shape:\t  [1, 3, 224, 224]\n",
+      "Num Classes:\t  1000\n",
+      "\n",
+      "\n",
+      "Details of the validation dataset and data loader are below.\n",
+      "\n",
+      "Num Observations: 1000\n",
+      "Num Batches:\t  1000\n",
+      "Batch Shape:\t  [1, 3, 224, 224]\n",
+      "Num Classes:\t  1000\n"
+     ]
+    }
+   ],
+   "source": [
+    "batch_size, in_channels, input_size = 1, 3, 224\n",
+    "n_worker = 8\n",
+    "\n",
+    "imagenet_transforms = torchvision.transforms.Compose([\n",
+    "    torchvision.transforms.Resize(int(input_size/0.875)),\n",
+    "    torchvision.transforms.CenterCrop(input_size),\n",
+    "    torchvision.transforms.ToTensor(),\n",
+    "    torchvision.transforms.Normalize(mean=[0.485, 0.456, 0.406],\n",
+    "                                     std =[0.229, 0.224, 0.225])\n",
+    "])\n",
+    "\n",
+    "train_dataset = torchvision.datasets.ImageFolder(\n",
+    "    TRAIN_DATA_PATH, \n",
+    "    imagenet_transforms\n",
+    ")\n",
+    "\n",
+    "train_loader = torch.utils.data.DataLoader(\n",
+    "    dataset=train_dataset,\n",
+    "    batch_size=batch_size, \n",
+    "    num_workers=n_worker\n",
+    ")\n",
+    "\n",
+    "val_dataset = torchvision.datasets.ImageFolder(\n",
+    "    TEST_DATA_PATH, \n",
+    "    imagenet_transforms\n",
+    ")\n",
+    "\n",
+    "val_loader = torch.utils.data.DataLoader(\n",
+    "    dataset=val_dataset,\n",
+    "    batch_size=batch_size, \n",
+    "    num_workers=n_worker\n",
+    ")\n",
+    "\n",
+    "example_train_input = next(iter(train_loader))[0]\n",
+    "example_val_input = next(iter(val_loader))[0]\n",
+    "\n",
+    "print(\"Details of the training dataset and data loader are below.\\n\")\n",
+    "print(\"Num Observations: {}\\nNum Batches:\\t  {}\\nBatch Shape:\\t  {}\\nNum Classes:\\t  {}\".\\\n",
+    "      format(len(train_dataset), len(train_loader), list(example_train_input.shape), len(train_dataset.classes)))\n",
+    "\n",
+    "print(\"\\n\\nDetails of the validation dataset and data loader are below.\\n\")\n",
+    "print(\"Num Observations: {}\\nNum Batches:\\t  {}\\nBatch Shape:\\t  {}\\nNum Classes:\\t  {}\".\\\n",
+    "      format(len(val_dataset), len(val_loader), list(example_val_input.shape), len(val_dataset.classes)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For QLinearOps, we will need a custom data reader class with a `get_next` attribute function. This is a modification to the PyTorch dataloader, which returns batches as a tuple of tensors versus the data reader returning batches as a dictionary with clearly labeled input name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class data_reader:\n",
+    "    def __init__(self, loader, input_name=\"input\"):\n",
+    "        self.reader = iter([{input_name:data[0].numpy()} for data in loader])\n",
+    "    \n",
+    "    def get_next(self):\n",
+    "        return next(self.reader, None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Export Model to ONNX"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are six model versions of interest, each specified by a path. This includes...\n",
+    "\n",
+    "- `ONNX_MODEL_PATH`, the original baseline float32 model;\n",
+    "- `QI_ONNX_MODEL_PATH`, the dynamic quantized QIntegerOps uint8 baseline model;\n",
+    "- `QL_ONNX_MODEL_PATH`, the static quantized QLinearOps uint baseline model;\n",
+    "- `E_ONNX_MODEL_PATH`, the float32 equalized model;\n",
+    "- `QI_E_ONNX_MODEL_PATH`, the dynamic quantized QIntegerOps uint8 baseline model;\n",
+    "- `QL_E_ONNX_MODEL_PATH`, the static quantized QLinearOps uint baseline model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Equalized\tIntegerOps\tLinearOps\tPath\n",
+      "    False\t     False\t    False\tmodels/mobilenet_v2.onnx\n",
+      "    False\t      True\t    False\tmodels/QI-mobilenet_v2.onnx\n",
+      "    False\t     False\t     True\tmodels/QL-mobilenet_v2.onnx\n",
+      "     True\t     False\t    False\tmodels/E-mobilenet_v2.onnx\n",
+      "     True\t      True\t    False\tmodels/QI-E-mobilenet_v2.onnx\n",
+      "     True\t     False\t     True\tmodels/QL-E-mobilenet_v2.onnx\n"
+     ]
+    }
+   ],
+   "source": [
+    "MODEL_PATH = \"models\"\n",
+    "MODEL_NAME = \"mobilenet_v2\"\n",
+    "\n",
+    "ONNX_MODEL_PATH = MODEL_PATH + \"/\" + MODEL_NAME + \".onnx\"\n",
+    "QI_ONNX_MODEL_PATH = MODEL_PATH + \"/\" + \"QI-\" + MODEL_NAME + \".onnx\"\n",
+    "QL_ONNX_MODEL_PATH = MODEL_PATH + \"/\" + \"QL-\" + MODEL_NAME + \".onnx\"\n",
+    "\n",
+    "E_ONNX_MODEL_PATH = MODEL_PATH + \"/\" + \"E-\" + MODEL_NAME + \".onnx\"\n",
+    "QI_E_ONNX_MODEL_PATH = MODEL_PATH + \"/\" + \"QI-E-\" + MODEL_NAME + \".onnx\"\n",
+    "QL_E_ONNX_MODEL_PATH = MODEL_PATH + \"/\" + \"QL-E-\" + MODEL_NAME + \".onnx\"\n",
+    "\n",
+    "if not os.path.exists(MODEL_PATH):\n",
+    "    os.makedirs(MODEL_PATH)\n",
+    "    \n",
+    "print(\"Equalized\\tIntegerOps\\tLinearOps\\tPath\")\n",
+    "print(\"    False\\t     False\\t    False\\t\", ONNX_MODEL_PATH, sep=\"\")\n",
+    "print(\"    False\\t      True\\t    False\\t\", QI_ONNX_MODEL_PATH, sep=\"\")\n",
+    "print(\"    False\\t     False\\t     True\\t\", QL_ONNX_MODEL_PATH, sep=\"\")\n",
+    "print(\"     True\\t     False\\t    False\\t\", E_ONNX_MODEL_PATH, sep=\"\")\n",
+    "print(\"     True\\t      True\\t    False\\t\", QI_E_ONNX_MODEL_PATH, sep=\"\")\n",
+    "print(\"     True\\t     False\\t     True\\t\", QL_E_ONNX_MODEL_PATH, sep=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Converting ReLU6 to ReLU\n",
+    "\n",
+    "ReLU6 is not currently supported for onnxruntime quantization, so we convert ReLU6 to ReLU. This change in topology has been shown to have low affect on accuracy. Augmenting the model is also possible after the model is in onnx but requires custom scripts.\n",
+    "\n",
+    "It is also worth noting the exported model opset, which is opset 12. The most recent opset is opset 12, and it is above the minimum supported opset version 11 that is required for quantization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_relu6_to_relu(model):\n",
+    "    for child_name, child in model.named_children():\n",
+    "        if isinstance(child, torch.nn.ReLU6):\n",
+    "            setattr(model, child_name, torch.nn.ReLU(inplace=True))\n",
+    "        else:\n",
+    "            convert_relu6_to_relu(child)\n",
+    "\n",
+    "mobilenet_v2 = pytorch_mobilenet_v2.MobileNetV2.mobilenet_v2()\n",
+    "convert_relu6_to_relu(mobilenet_v2)\n",
+    "dummy_input = torch.ones(example_val_input.shape)\n",
+    "\n",
+    "torch.onnx.export(mobilenet_v2,\n",
+    "                  dummy_input,\n",
+    "                  ONNX_MODEL_PATH,\n",
+    "                  input_names = ['input'],\n",
+    "                  output_names = ['output'],\n",
+    "                  opset_version=12)\n",
+    "\n",
+    "onnx_model = onnx.load(ONNX_MODEL_PATH)\n",
+    "onnx.checker.check_model(onnx_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Equalize Model "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Cross layer equalization is applied using the equalize function we developed for onnx. The paper motivating this code is titled [Data-Free Quantization Through Weight Equalization and Bias Correction](https://arxiv.org/pdf/1906.04721.pdf). Internally, the equalization algorithm performs a few steps, which include:\n",
+    "1. Model Augmentation - Converting ReLU6 to ReLU, merging batch normalization, and removing unused nodes.\n",
+    "2. Defining Iterable Set - Chosing which pairs of nodes to equalize between (in order).\n",
+    "3. Executing Iterations - Applying layer equalization to each pair of the iterable set and updating both weights and biases.\n",
+    "\n",
+    "Because network topologies vary based on their origin, it is recommended that users of this function use onnx opset 12. Further, modifications may be necessary for either converting to ReLU, merge batch normalization, or any other augmentation necessary to simplify the model into only conv, batchnorm, and add ops.\n",
+    "\n",
+    "These three steps and their doc strings can be found in equalization.py."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import equalization\n",
+    "\n",
+    "equalized_onnx_model = equalization.equalize(ONNX_MODEL_PATH)\n",
+    "\n",
+    "onnx.save(equalized_onnx_model,\n",
+    "          E_ONNX_MODEL_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Quantize Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Quantization is done in ONNX Runtime using its [onnx quantization tool](https://github.com/microsoft/onnxruntime/tree/master/onnxruntime/python/tools/quantization). The doc strings of the arguments needed for quantization are worth quoting here at length. Verbatim, quantization requires the following:\n",
+    "- param `model_input`: file path of model to quantize\n",
+    "- param `model_output`: file path of quantized model\n",
+    "- param `calibration_data_reader`: a calibration data reader. It enumerates calibration data and generates inputs for the original model.\n",
+    "- param `op_types_to_quantize`: specify the types of operators to quantize, like ['Conv'] to quantize Conv only. It quantizes all supported operators by default.\n",
+    "- param `op_types`: operators to quantize\n",
+    "- param `per_channel`: quantize weights per channel\n",
+    "- param `reduce_range`: quantize weights with 7-bits. It may improve the accuracy for some models running on non-VNNI machine, especially for per-channel mode\n",
+    "- param `activation_type`: quantization data type of activation\n",
+    "- param `weight_type`: quantization data type of weight\n",
+    "- param `nodes_to_quantize`: List of nodes names to quantize. When this list is not None only the nodes in this list are quantized. example:\n",
+    "        ```\n",
+    "        [\n",
+    "            'Conv__224',\n",
+    "            'Conv__252'\n",
+    "        ]\n",
+    "        ```\n",
+    "-  param `nodes_to_exclude`: List of nodes names to exclude. The nodes in this list will be excluded from quantization\n",
+    "        when it is not None.\n",
+    "-  parma `use_external_data_format`: option used for large size (>2GB) model. Set to False by default. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4a. Quantize Model (IntegerOps)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Models quantized using IntegerOps have their quantization parameters calculated dynamically and result in an int8 onnx model. Models derived under dynamic regimes do not need any additional data to compute. For this reason, these models are considered \"data-free\" quantized models. \n",
+    "\n",
+    "The relevant code for quantizing the baseline model using IntegerOps is as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kwargs = {\"op_types_to_quantize\":     [],\n",
+    "          \"per_channel\":              False,\n",
+    "          \"reduce_range\":             False,\n",
+    "          \"activation_type\":          onnxruntime.quantization.QuantType.QUInt8,\n",
+    "          \"weight_type\":              onnxruntime.quantization.QuantType.QUInt8,\n",
+    "          \"nodes_to_quantize\":        [],\n",
+    "          \"nodes_to_exclude\":         [],\n",
+    "          \"use_external_data_format\": False}\n",
+    "\n",
+    "onnxruntime.quantization.quantize_dynamic(ONNX_MODEL_PATH, \n",
+    "                                          QI_ONNX_MODEL_PATH, \n",
+    "                                          **kwargs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### IntegerOps Model Size Reduction\n",
+    "\n",
+    "We see that the baseline quantized using IntegerOps results in an approximate 50% reduction in model size. This is to be expected, and similar model sizes will be observed in subsequent experiments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "ONNX model size (MB):     14.19\n",
+      "\n",
+      "QI-ONNX model size (MB):  7.65\n"
+     ]
+    }
+   ],
+   "source": [
+    "onnx_size_mb   = os.path.getsize(ONNX_MODEL_PATH)/1e6\n",
+    "qi_onnx_size_mb = os.path.getsize(QI_ONNX_MODEL_PATH)/1e6\n",
+    "\n",
+    "print(\"\\nONNX model size (MB):     {:.2f}\".format(onnx_size_mb))\n",
+    "print(\"\\nQI-ONNX model size (MB):  {:.2f}\".format(qi_onnx_size_mb))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4b. Equalized and Quantized Model (IntegerOps)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Models first equalized follow the same quantize procedure as non-equalized models. In the case of IntegerOps, we take an equalized model then dynamically quantize it to create an int8 model. This procedure is still \"data-free\" because neither equalization nor dynamic quantization requires additional data.\n",
+    "\n",
+    "The relevant code for quantizing the equalized model using IntegerOps is as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kwargs = {\"op_types_to_quantize\":     [],\n",
+    "          \"per_channel\":              False,\n",
+    "          \"reduce_range\":             False,\n",
+    "          \"activation_type\":          onnxruntime.quantization.QuantType.QUInt8,\n",
+    "          \"weight_type\":              onnxruntime.quantization.QuantType.QUInt8,\n",
+    "          \"nodes_to_quantize\":        [],\n",
+    "          \"nodes_to_exclude\":         [],\n",
+    "          \"use_external_data_format\": False}\n",
+    "\n",
+    "onnxruntime.quantization.quantize_dynamic(E_ONNX_MODEL_PATH, \n",
+    "                                          QI_E_ONNX_MODEL_PATH, \n",
+    "                                          **kwargs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "E-ONNX model size (MB):     14.19\n",
+      "\n",
+      "QI-E-ONNX model size (MB):  7.75\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_onnx_size_mb   = os.path.getsize(E_ONNX_MODEL_PATH)/1e6\n",
+    "qi_e_onnx_size_mb = os.path.getsize(QI_E_ONNX_MODEL_PATH)/1e6\n",
+    "\n",
+    "print(\"\\nE-ONNX model size (MB):     {:.2f}\".format(onnx_size_mb))\n",
+    "print(\"\\nQI-E-ONNX model size (MB):  {:.2f}\".format(qi_e_onnx_size_mb))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4c. Quantize Model (QLinearOps)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Models quantized using QLinearOps have their quantization parameters calibrated for static use and result in an int8 onnx model. Models derived under static regimes require additional data to compute. QLinearOps is preferred for decreased model latency if the time and data for calibration is available.\n",
+    "\n",
+    "The relevant code for quantizing the baseline model using QLinearOps is as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Calibrated,quantized parameters calculated and returned.\n"
+     ]
+    }
+   ],
+   "source": [
+    "train_data_reader = data_reader(train_loader)\n",
+    "\n",
+    "kwargs = {\"op_types_to_quantize\":     [],\n",
+    "          \"per_channel\":              False,\n",
+    "          \"reduce_range\":             False,\n",
+    "          \"activation_type\":          onnxruntime.quantization.QuantType.QUInt8,\n",
+    "          \"weight_type\":              onnxruntime.quantization.QuantType.QUInt8,\n",
+    "          \"nodes_to_quantize\":        [],\n",
+    "          \"nodes_to_exclude\":         [],\n",
+    "          \"use_external_data_format\": False}\n",
+    "\n",
+    "onnxruntime.quantization.quantize_static(ONNX_MODEL_PATH, \n",
+    "                                         QL_ONNX_MODEL_PATH, \n",
+    "                                         train_data_reader,\n",
+    "                                         **kwargs)\n",
+    "\n",
+    "if os.path.exists(\"./augmented_model.onnx\"):\n",
+    "    os.remove(\"./augmented_model.onnx\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### QLinearOps Model Size Reduction\n",
+    "\n",
+    "As expected, we see that the baseline quantized using QLinearOps results in an approximate 50% reduction in model size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "ONNX model size (MB):     14.19\n",
+      "\n",
+      "QL-ONNX model size (MB):  7.65\n"
+     ]
+    }
+   ],
+   "source": [
+    "onnx_size_mb   = os.path.getsize(ONNX_MODEL_PATH)/1e6\n",
+    "ql_onnx_size_mb = os.path.getsize(QL_ONNX_MODEL_PATH)/1e6\n",
+    "\n",
+    "print(\"\\nONNX model size (MB):     {:.2f}\".format(onnx_size_mb))\n",
+    "print(\"\\nQL-ONNX model size (MB):  {:.2f}\".format(ql_onnx_size_mb))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4d. Equalized and Quantized Model (QLinearOps)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similarly, models equalized then quantized using QLinearOps follow the same procedure as non-equalized models. Though equalization is \"data-free\", when used in conjunction with QLinearOps the procedure is no longer \"data-free.\" If you are considering QLinearOps, equalization is recommended because the affected model will likely see less of an accuracy drop.\n",
+    "\n",
+    "The relevant code for quantizing the equalized model using QLinearOps is as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Calibrated,quantized parameters calculated and returned.\n"
+     ]
+    }
+   ],
+   "source": [
+    "train_data_reader = data_reader(train_loader)\n",
+    "\n",
+    "kwargs = {\"op_types_to_quantize\":     [],\n",
+    "          \"per_channel\":              False,\n",
+    "          \"reduce_range\":             False,\n",
+    "          \"activation_type\":          onnxruntime.quantization.QuantType.QUInt8,\n",
+    "          \"weight_type\":              onnxruntime.quantization.QuantType.QUInt8,\n",
+    "          \"nodes_to_quantize\":        [],\n",
+    "          \"nodes_to_exclude\":         [],\n",
+    "          \"use_external_data_format\": False}\n",
+    "\n",
+    "onnxruntime.quantization.quantize_static(E_ONNX_MODEL_PATH, \n",
+    "                                         QL_E_ONNX_MODEL_PATH, \n",
+    "                                         train_data_reader,\n",
+    "                                         **kwargs)\n",
+    "\n",
+    "if os.path.exists(\"./augmented_model.onnx\"):\n",
+    "    os.remove(\"./augmented_model.onnx\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### QLinearOps Model Size Reduction\n",
+    "\n",
+    "As expected, we see that the baseline quantized using QLinearOps results in an approximate 50% reduction in model size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "E-ONNX model size (MB):     14.26\n",
+      "\n",
+      "QI-E-ONNX model size (MB):  7.72\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_onnx_size_mb   = os.path.getsize(E_ONNX_MODEL_PATH)/1e6\n",
+    "ql_e_onnx_size_mb = os.path.getsize(QL_E_ONNX_MODEL_PATH)/1e6\n",
+    "\n",
+    "print(\"\\nE-ONNX model size (MB):     {:.2f}\".format(e_onnx_size_mb))\n",
+    "print(\"\\nQI-E-ONNX model size (MB):  {:.2f}\".format(ql_e_onnx_size_mb))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Validation Inference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For inference, we define a few helper functions. They include methods for setting up an ONNX Runtime inference session, calculating loss, calculating latency, and reporting results. Validation performs inference on the validation set, and, at the end of the loop, its predictions are used for metric calculation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class init_inference:\n",
+    "    def __init__(self, session):\n",
+    "        self.session = session\n",
+    "        \n",
+    "    def __call__(self, image):\n",
+    "        input_data = image.numpy()\n",
+    "        input_name  = self.session.get_inputs()[0].name\n",
+    "    \n",
+    "        return self.session.run(None, {input_name: input_data})\n",
+    "\n",
+    "def Xent(logits, labels):\n",
+    "    logits = torch.tensor(logits[0])\n",
+    "    loss_fn = torch.nn.CrossEntropyLoss()\n",
+    "    \n",
+    "    return float(loss_fn(logits, labels))\n",
+    "\n",
+    "def mean_latency_fn(tqdm_dataloader):\n",
+    "    start = tqdm_dataloader.start_t\n",
+    "    stop = tqdm_dataloader.last_print_t\n",
+    "    n = tqdm_dataloader.n\n",
+    "    \n",
+    "    mean_latency = (stop - start)/n\n",
+    "    \n",
+    "    return mean_latency\n",
+    "\n",
+    "def simple_table(data_multilist, x_label_list, y_label_list):\n",
+    "    for i in range(len(y_label_list)+1):\n",
+    "        if i == 0:\n",
+    "            row = [\"\\t\"]\n",
+    "            row.extend(x_label_list)\n",
+    "            string = \"\\t\".join(row)\n",
+    "        else:\n",
+    "            row = [y_label_list[i-1]]\n",
+    "            \n",
+    "            row.extend([format(x, \".6f\") for x in data_multilist[i-1]])\n",
+    "            string = \"\\t\".join(row)\n",
+    "            \n",
+    "        print(string)\n",
+    "        \n",
+    "    return None\n",
+    "\n",
+    "def plot_statistic(x, y, title, x_label, y_label):\n",
+    "\n",
+    "    label_pos = [i for i, _ in enumerate(x)]\n",
+    "\n",
+    "    plt.figure(figsize=(12, 6))\n",
+    "    plt.bar(label_pos, x, color='black', width=0.8)\n",
+    "    plt.xlabel(x_label)\n",
+    "    plt.ylabel(y_label)\n",
+    "    plt.title(title)\n",
+    "    plt.xticks(label_pos, y)\n",
+    "    \n",
+    "    plt.show()\n",
+    "    \n",
+    "    return None\n",
+    "\n",
+    "def validate(dataloader, session):\n",
+    "    tqdm_dataloader = tqdm(dataloader)\n",
+    "    inference = init_inference(session)\n",
+    "    loss_labels, pred_labels, true_labels = [], [], []\n",
+    "\n",
+    "    for idx, (images, target) in enumerate(tqdm_dataloader):\n",
+    "        \n",
+    "        logits = inference(images)\n",
+    "        labels = np.argmax(logits[0][0])\n",
+    "        loss   = Xent(logits, target)\n",
+    "\n",
+    "        pred_labels.append(labels)\n",
+    "        true_labels.append(int(target))\n",
+    "        loss_labels.append(loss + 1e-6)\n",
+    "        \n",
+    "    mean_latency = mean_latency_fn(tqdm_dataloader)\n",
+    "\n",
+    "    return loss_labels, pred_labels, true_labels, mean_latency"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5a. Validate Baseline Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1000/1000 [00:40<00:00, 24.62it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "ort_session = onnxruntime.InferenceSession(ONNX_MODEL_PATH)\n",
+    "\n",
+    "loss_labels, pred_labels, true_labels, mean_latency =\\\n",
+    "    validate(val_loader, ort_session)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5b. Validate Equalized Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1000/1000 [00:39<00:00, 25.34it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_ort_session = onnxruntime.InferenceSession(E_ONNX_MODEL_PATH)\n",
+    "\n",
+    "e_loss_labels, e_pred_labels, e_true_labels, e_mean_latency =\\\n",
+    "    validate(val_loader, e_ort_session)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5c. Validate Baseline IntegerOps Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1000/1000 [02:10<00:00,  7.63it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "qi_ort_session = onnxruntime.InferenceSession(QI_ONNX_MODEL_PATH)\n",
+    "\n",
+    "qi_loss_labels, qi_pred_labels, qi_true_labels, qi_mean_latency =\\\n",
+    "    validate(val_loader, qi_ort_session)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5d. Validate Equalized IntegerOps Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1000/1000 [02:17<00:00,  7.28it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "qi_e_ort_session = onnxruntime.InferenceSession(QI_E_ONNX_MODEL_PATH)\n",
+    "\n",
+    "qi_e_loss_labels, qi_e_pred_labels, qi_e_true_labels, qi_e_mean_latency =\\\n",
+    "    validate(val_loader, qi_e_ort_session)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5e. Validate Baseline QLinearOps Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1000/1000 [02:03<00:00,  8.07it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "ql_ort_session = onnxruntime.InferenceSession(QL_ONNX_MODEL_PATH)\n",
+    "\n",
+    "ql_loss_labels, ql_pred_labels, ql_true_labels, ql_mean_latency =\\\n",
+    "    validate(val_loader, ql_ort_session)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5f. Validate Equalized QLinearOps Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1000/1000 [02:04<00:00,  8.04it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "ql_e_ort_session = onnxruntime.InferenceSession(QL_E_ONNX_MODEL_PATH)\n",
+    "\n",
+    "ql_e_loss_labels, ql_e_pred_labels, ql_e_true_labels, ql_e_mean_latency =\\\n",
+    "    validate(val_loader, ql_e_ort_session)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Final Results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The final results include four metrics: latency, loss, accuracy, and model size. \n",
+    "- **Latency** gives us an idea of how long on average it takes to do inference on an image. \n",
+    "- **Loss** tells us precicely how much our model's predicted logits differ from the expected class. \n",
+    "- **Accuracy** tells us how often the most likely predicted class is consistent with the expected class. \n",
+    "- **Model size** gives us an idea of the memory bandwidth required to perform inference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6a. Model Inference Latency"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Though quantization has theoretical performance improvements, we see that some systems (such as the one this experiment is ran on) cannot always benifit from these gains. In particular, AVX-512 VNNI instructions enable lower latencies, which this system cannot benifit from. However, it is still worth noting how QLinearOps is relatively faster to IntegerOps, though quantization is not recommended on a system such as this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# print('Validation latency results are below.\\n')\n",
+    "\n",
+    "# simple_table(\n",
+    "#     data_multilist = [[mean_latency,      e_mean_latency   ],\n",
+    "#                       [qi_mean_latency,   qi_e_mean_latency],\n",
+    "#                       [ql_e_mean_latency, ql_e_mean_latency]], \n",
+    "#     x_label_list = [\"Baseline\", \"Equalized\"], \n",
+    "#     y_label_list = [\"float32 \", \"IntegerOps\", \"QLinearOps\"]\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# x = [mean_latency, e_mean_latency, qi_mean_latency, qi_e_mean_latency, ql_mean_latency, ql_e_mean_latency]\n",
+    "# y = ['Baseline-fp32', 'Equalized-fp32', 'Baseline-IOps', 'Equalized-IOps', 'Baseline-LOps', 'Equalized-LOps']\n",
+    "# title = \"MobileNetV2 Latency Results\"\n",
+    "# x_label = \"Model Type\"\n",
+    "# y_label = \"Mean Latency (sec)\"\n",
+    "\n",
+    "# plot_statistic(x, y, title, x_label, y_label)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6b. Model Inference Cross Entropy Loss"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below, it is apparent that quantized models adversely affect logit calculation and result in a higher loss. Though QLinearOps is faster than Integer Ops (as seen above), this higher speed is accompanied with less precise logits. Engineers are encouraged to weigh the tradeoffs between these two models, and to also consider the later reported accuracy results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation loss results are below.\n",
+      "\n",
+      "\t\tBaseline\tEqualized\n",
+      "float32 \t1.112608\t1.112607\n",
+      "IntegerOps\t2.430798\t1.886650\n",
+      "QLinearOps\t3.679957\t2.367664\n"
+     ]
+    }
+   ],
+   "source": [
+    "mean_loss      = np.mean(loss_labels)\n",
+    "e_mean_loss    = np.mean(e_loss_labels)\n",
+    "qi_mean_loss   = np.mean(qi_loss_labels)\n",
+    "qi_e_mean_loss = np.mean(qi_e_loss_labels)\n",
+    "ql_mean_loss   = np.mean(ql_loss_labels)\n",
+    "ql_e_mean_loss = np.mean(ql_e_loss_labels)\n",
+    "\n",
+    "print('Validation loss results are below.\\n')\n",
+    "\n",
+    "simple_table(\n",
+    "    data_multilist = [[mean_loss,    e_mean_loss   ],\n",
+    "                      [qi_mean_loss, qi_e_mean_loss],\n",
+    "                      [ql_mean_loss, ql_e_mean_loss]],\n",
+    "    x_label_list = [\"Baseline\", \"Equalized\"],\n",
+    "    y_label_list = [\"float32 \", \"IntegerOps\", \"QLinearOps\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtMAAAGHCAYAAAByA95NAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAABEH0lEQVR4nO3deXhU5f3//9dkQhLClpAQMAEKhCAgZYmRrRK2iFSgVaEsfkQRKbuIC4K2JfBRaNi0IlhUAqi0fsQNlaJiUBYNFDAJOwIFZE1jFgwQQpjM+f3Bl/kxJoTxkJmcwPNxXVxX5px7znnPueeQV+655xybYRiGAAAAAPxifhVdAAAAAFBZEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDeCGNWzYMCUkJJTZZtq0aWratKnr8bJly+Tv7+/t0lCJrFu3TjabTcePH6/oUgBYEGEagCUMGzZMNptN/fv3L7Fu5cqVstlsXgm5Tz/9tDZv3nxd21i2bJlsNptuv/12OZ1Ot3XdunXTiBEjftH2mjZtqmnTprkep6eny2azafXq1aW2nzdvnqpVq6affvpJGzduVP/+/VW/fn1VrVpVMTExmjZtmi5cuFDmPn/+R0VFuxxgL/8LDQ1V586dr3oMfOmbb76RzWbTkSNHKroUABZAmAZgGQ0bNtSnn36q//73v27LX3/9df3qV7/yyj6rV6+u8PDw696OzWbT7t279dZbb5VDVe7atWunO+64Q2+88Uap6xcvXqxBgwapVq1a+vbbbxUdHa1//vOf2rNnj5KSkrRw4UJNnDix3OvyhbS0NJ06dUqpqalq166d7r33Xu3evbuiywIAF8I0AMuIiYlRx44dtWzZMteyo0eP6ssvv9QjjzxSov3q1at1++23KzAwUBERERo7dqzOnTtXot2LL76oqKgoBQcHq3///srOznat82RE9rvvvlOvXr1UvXp11alTR/fff79++OEHtzZ+fn6aOHGi/vSnP5Vaw5VeeeUVNW/eXEFBQYqJidGMGTPkcDgkXRrJ/s9//qPp06e7RmWPHDmiUaNGadWqVcrMzHTb1saNG7Vv3z6NHDlSkjRlyhTNnj1b8fHxaty4sfr3768pU6ZoxYoVZdZ0LadOndLgwYMVEhKiqlWrqlu3btq2bZtr/cWLF/Xkk0+qfv36CgwM1C233KLBgwe71u/evVt33323QkJCVK1aNbVo0UJvv/32Nfdbp04d1atXTy1atFBSUpIuXryor776yrX+7Nmzevzxx139265dO3344Ydu25g5c6aaNGmiwMBA1alTR3fffbfOnz8vqfT+L2vk+ciRI+rSpYskqXHjxrLZbOrWrdt1vUYAlRthGoCljBw5UosXL5ZhGJIujbr27NmzxMj0jh079Lvf/U7x8fHKyMjQm2++qVWrVmn06NFu7bZs2aJ169bp888/1+rVq7Vjxw4NHz7c43r27Nmjrl27qlOnTtq2bZu++uor2e123XXXXSosLHRr+9xzz8nhcGj27NlX3d60adM0d+5c/fWvf9XevXv18ssv67XXXtP06dMlSR9++KEaNWqkp556SqdOndKpU6fUoEEDDR48WMHBwVq6dKnb9t544w39+te/VseOHa+6z59++um6Rt8Nw9C9996rffv2adWqVdqyZYvq1q2ru+66y/WHySuvvKIVK1Zo+fLlOnDggD755BO3moYMGaKwsDClpqZq586devHFFxUaGupxDUVFRXrttdckSQEBAa66+vXrp+3bt+vdd9/Vrl27NGbMGA0ePFhr166VdOl4JiUl6eWXX9aBAwf05Zdf6re//a3pY9GgQQN9/PHHki69t06dOuUK79f7GgFUUgYAWMDDDz9s9OzZ0zh//rxRu3Zt46uvvjIcDocRFRVlfPDBB8bSpUsNu93uav/ggw8ad9xxh9s2Vq5cadhsNuPIkSOubVarVs04ffq0q80XX3xhSDL2799vGIZhJCYmGtHR0a71P9/Pww8/bAwaNMhtP4WFhUbVqlWNjz76qMRzFi1aZAQHBxvHjh0zDMMwunbtajz66KOGYRjGuXPnjKpVqxqfffaZ2/befPNNo1atWq7H0dHRRmJiYoljNGbMGKNJkyaG0+k0DMMw8vLyjKpVqxqvvPLKVY6qYezZs8eoUaNGmW1KOw5XSklJMSQZu3fvdjsG9erVM6ZPn24YhmFMmDDB6N69u6u2n6tZs6axdOnSMmu40tdff21IMoKDg41q1aoZNpvNkGQ0bdrUyMvLc7UJDAx061/DMIxHHnnE+P3vf28YhmG8+OKLRkxMjFFUVOTx6964caMhyTh8+LBbLZf79Ofrzb5GADcGRqYBWEpQUJCGDh2qN954Q//617/kcDjUr1+/Eu12796t+Ph4t2Vdu3aVYRjas2ePa1nLli1Vq1Yt1+Pf/OY3kqS9e/d6VM/WrVv10UcfqXr16q5/YWFhKiws1IEDB0q0HzFihJo0aaLnnnuu1JrPnz+v/v37u21v1KhR+umnn/Tjjz+WWcuoUaN06NAh1zSH5cuXS5IefPDBUtsfOHBAvXr10uDBgzV+/HiPXm9pdu/erbCwMLVs2dK1LDAwUB06dHDNX37kkUe0c+dONW3aVKNHj9YHH3ygoqIiV/unn35aI0aMULdu3TRt2jSlpaV5tO8vvvhC6enp+uijjxQdHa1ly5YpJCRE0qW+KSoqUlRUlNvxvDw6LkkDBw7UxYsX9atf/UrDhg3T22+/rTNnzpg+FmUx+xoBVG6EaQCWM2rUKH344YeaPXu2HnnkEVWpUqXUdjab7RctN8PpdGro0KHKyMhw+7d///5Sr9Jht9s1b948LV++3G1O8eVtSdJ7773ntq2dO3fqwIEDql27dpm1tGnTRh06dNDrr78u6dIUj4EDB7rC5ZV27dql+Ph49enTxzU94nqUdkwNw3Atb9u2rQ4fPqy5c+cqICBAjz/+uNq2bav8/HxJ0l/+8hft379fAwcO1K5du9SxY0f9+c9/vuZ+GzVqpJiYGP3+97/XggULdN9997mmljidTtWqVatE3+zZs0efffaZJCkqKkr79u3TkiVLFBERoeeff1633nqrjh07JunSXHfj/00puuzixYumjpHZ1wigciNMA7CcFi1a6I477lBqaupVLyt32223af369W7L1q9fL5vN5jaCunfvXlegk6TU1FTXPjwRFxenHTt2KDo6Wk2bNnX7d7X5sL169VLv3r315JNPlqg5KChIhw4dKrGtpk2bym63S7o0J7i4uLjUbY8aNUorV67UqlWrtGPHDtcXD6+0detWde3aVQMHDtTf//736/7j4rbbblN2drbbiP+FCxe0ZcsW3Xbbba5l1atX13333af58+dr27Zt2rt3r1sfNWnSRGPHjtX777+v//3f/9Xf//73X1RH79691bRpU9f88ri4OJ0+fVqFhYUljmXDhg1dzwsMDFTv3r01e/Zs7dy5UwUFBVq5cqUkKSIiQllZWW7H+1ojypfnbJfWR9f7GgFUPtyZAIAlffHFFyosLLzqaO2kSZMUGxurJ598UiNHjtSRI0f02GOP6X/+53/cgpTNZtNDDz2kF154Qbm5uRo3bpz69OmjmJgYj+p47rnn1L59ez344IN6/PHHVadOHR05ckQrV67U448/riZNmpT6vHnz5ql169aqUqWK62oR1atX13PPPeeaAnLXXXfJ4XBo586dSk9P16xZsyRdukrEt99+q6NHjyo4OFi1a9eWn9+lsY9BgwbpiSee0EMPPaTbbrtNnTt3dtvvhg0b1LdvXw0YMEDPPvus22UG69WrV+ZrLSoqUkZGhtsyPz8/9ejRQ+3bt9cDDzyghQsXqlatWnr++edVWFioMWPGSJLmzJmjyMhItW3bVsHBwXrnnXdkt9vVrFkznT17VpMnT1b//v3VuHFjnT59Wp9//rnbHz2emjRpkgYPHqwnn3xSPXr0UEJCgu6//37NmjVLbdq0UV5enlJTUxUUFKQ//vGPSk5OltPpVPv27RUSEqK1a9fqzJkzrn13795dBQUF+stf/qJHH31UaWlpWrhwYZk1/OpXv5Kfn59Wr16tQYMGKTAwUHa7vdxeI4BKpoLnbAOAYRj//xcQr+bnXww0DMP417/+ZcTGxhoBAQFGeHi4MXr0aOPs2bMltjlnzhyjXr16RlBQkHHvvfcaWVlZrjbX+gKiYRjGjh07jN/97ndGSEiIERQUZERHRxt//OMfjZycnKs+xzAMY9y4cYYk1xcQL1u8eLHRpk0bIzAw0AgJCTHat29vvPrqq671W7duNWJjY42goKBSv+g2fvx4Q5Lx8ssvl9jnww8/bEgq9V9ZEhMTS31OYGCgYRiGcfLkSWPQoEFGrVq1jKCgICM+Pt7YunWr6/mLFi0yYmNjjRo1ahjVqlUz4uLijJUrVxqGYRjnz583hgwZYjRq1MgIDAw06tSpYwwcONA4evToVev5+Zf+LisuLjaaNWtmPPjgg4ZhGEZBQYExefJko1GjRkaVKlWMunXrGnfffbexdu1awzAM44MPPjA6depkhISEGFWrVjVuu+02Y/HixW7bTE5ONho3bmwEBQUZvXv3Nt55550yv4BoGIYxa9YsIzIy0vDz8zO6du1q6jUCuDHYDONnk8UAAAAAeIQ50wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATKr0N205efJkRZdgaeHh4a5b78Ka6CPro4+sjf6xPvrI+uija4uMjCx1OSPTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACY5F/RBQAAAHOioqIquoQbyokTJyq6BFRCjEwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASf6+2ElRUZESExPlcDhUXFysjh07auDAgW5tdu/erdmzZysiIkKS1KFDBw0YMMAX5QEAAACm+CRMV6lSRYmJiQoKCpLD4dDUqVPVtm1bNWvWzK1dixYtNGXKFF+UBAAAAFw3n0zzsNlsCgoKkiQVFxeruLhYNpvNF7sGAAAAvMZmGIbhix05nU5NnjxZmZmZuvvuu/Xggw+6rd+9e7fmzZunsLAwhYaGaujQoWrQoEGJ7aSkpCglJUWSlJSUpKKiIl+UX2n5+/vL4XBUdBkoA31kffSRtd3M/RMYGFjRJdxQLly4UNElVJib+TzyVEBAQKnLfRamLzt37pzmzp2rRx55RA0bNnQtLygokJ+fn4KCgpSWlqZly5Zp/vz519zeyZMnvVlupRceHq7s7OyKLgNloI+sjz6ytpu5f6Kioiq6hBvKiRMnKrqECnMzn0eeioyMLHW5z6/mUa1aNbVs2VIZGRluy4ODg11TQWJjY1VcXKz8/HxflwcAAAB4zCdhOj8/X+fOnZN06coeO3fuLPHX9OnTp3V5kPzgwYNyOp2qUaOGL8oDAAAATPHJ1Tzy8vK0cOFCOZ1OGYahTp066fbbb9eaNWskSb169dLmzZu1Zs0a2e12BQQEaOLEiXxJEQAAAJbm8znT5Y0502VjDpT10UfWRx9Z283cP8yZLl/Mmb45zyNPWWbONAAAAHCjIEwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATPL3xU6KioqUmJgoh8Oh4uJidezYUQMHDnRrYxiGli5dqvT0dAUGBmrs2LFq0qSJL8oDAAAATPFJmK5SpYoSExMVFBQkh8OhqVOnqm3btmrWrJmrTXp6ujIzMzV//nwdOHBAixcv1syZM31RHgAAAGCKT6Z52Gw2BQUFSZKKi4tVXFwsm83m1mbbtm2Kj4+XzWZTs2bNdO7cOeXl5fmiPAAAAMAUn4xMS5LT6dTkyZOVmZmpu+++WzExMW7rc3NzFR4e7nocFham3NxchYaG+qpEAAAA4BfxWZj28/PTnDlzdO7cOc2dO1dHjx5Vw4YNXesNwyjxnJ+PXktSSkqKUlJSJElJSUluARwl+fv7c4wsjj6yPvrI2ugflJeb+X3EeWSez8L0ZdWqVVPLli2VkZHhFqbDwsKUnZ3tepyTk1PqqHRCQoISEhJcj698DkoKDw/nGFkcfWR99JG10T8oLzfz+4jz6NoiIyNLXe6TOdP5+fk6d+6cpEtX9ti5c6eioqLc2sTFxWnDhg0yDEP79+9XcHAwUzwAAABgaT4Zmc7Ly9PChQvldDplGIY6deqk22+/XWvWrJEk9erVS+3atVNaWpomTJiggIAAjR071helAQAAAKbZjNImK1ciJ0+erOgSLI2PbayPPrI++sjabub++fmnvLg+J06cqOgSKszNfB55qkKneQAAAAA3IsI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmOTvSaNvvvlGjRo1Uv369XXy5Em99tpr8vPz04gRIxQVFeXtGgEAAABL8mhk+t1331X16tUlSW+99Zaio6PVokULLV682KvFAQAAAFbmUZjOz89XSEiIioqK9P3332vIkCEaMGCAjhw54uXyAAAAAOvyaJpHzZo1lZmZqaNHjyo6OlpVqlTRhQsXvF0bAAAAYGkehen+/ftr8uTJ8vPz0xNPPCFJ2rlzp371q195tTgAAADAyjwK0926dVOnTp0kSYGBgZKkmJgYTZw40WuFAQAAAFbn8ZxpwzAUGBgop9Opr7/+WhkZGapZs6a36wMAAAAsy6MwnZSUpFOnTkmS3nnnHX366adatWqV3nrrLa8WBwAAAFiZR2H61KlTatSokSRp48aNeu6555SYmKjU1FRv1gYAAABYmkdzpv38/ORwOHTq1CkFBwcrPDxcTqdThYWF3q4PAAAAsCyPwnTbtm310ksv6cyZM+rcubMk6fjx46pdu7ZXiwMAAACszKMwPXr0aK1fv152u13x8fGSpDNnzugPf/iDV4sDAAAArMyjMF2lShUlJCTI6XTqp59+Uq1atXTbbbd5uzYAAADA0jwK0wUFBVqyZIlSU1NVXFwsu92uzp07a/jw4QoODvZ2jQAAAIAleXQ1j6VLl6qwsFBz587V8uXLNXfuXBUVFWnJkiXerg8AAACwLI/CdEZGhh577DFFRkaqSpUqioyM1NixY7V9+3Zv1wcAAABYlkdhOiAgQPn5+W7L8vPz5e/v0SwRAAAA4IbkURru0aOHXnjhBfXp00d16tTRjz/+qH/961/q2bOnt+sDAAAALMujMH3//fcrNDRU3377rXJzc1W7dm39/ve/V48ePbxdHwAAAGBZHoVpm82mHj16uIXn4uJiLViwQOPHj/dacQAAAICVeTRnujROp1MbN24sz1oAAACASsUn3yDMzs7WwoULdfr0adlsNiUkJOiee+5xa7N7927Nnj1bERERkqQOHTpowIABvigPAAAAMMUnYdput2vo0KFq0qSJzp8/rylTpqh169aqX7++W7sWLVpoypQpvigJAAAAuG5lhumvvvrqquuKi4s93kloaKhCQ0MlSVWrVlVUVJRyc3NLhGkAAACgMikzTF9rTnTLli1/8Q6zsrJ0+PBhNW3atMS6/fv3a9KkSQoNDdXQoUPVoEGDX7x9AAAAwFdshmEYvtpZYWGhEhMTdf/996tDhw5u6woKCuTn56egoCClpaVp2bJlmj9/foltpKSkKCUlRZKUlJSkoqIin9ReWfn7+8vhcFR0GSgDfWR99JG13cz9ExgYWNEl3FAuXLhQ0SVUmJv5PPJUQEBAqct9FqYdDodmzZqlNm3aqG/fvtdsP27cOP31r39VzZo1y2x38uTJ8irxhhQeHq7s7OyKLgNloI+sjz6ytpu5f6Kioiq6hBvKiRMnKrqECnMzn0eeioyMLHW56Uvj/RKGYWjRokWKioq6apA+ffq0Luf6gwcPyul0qkaNGr4oDwAAADDFJ1fz+P7777VhwwY1bNhQkyZNkiQNGTLE9RdQr169tHnzZq1Zs0Z2u10BAQGaOHGibDabL8oDAAAATPFJmG7evLlWrFhRZpvevXurd+/evigHAAAAKBceTfOYO3eutmzZwsR0AAAA4AoejUzfeuut+uCDD7Ro0SJ16tRJ8fHxuvXWW71dG4AbHF+eKl8385enAKCieBSm+/Xrp379+unYsWPauHGjXn75ZdntdnXt2lV33nmn6tWr5+06AQAAAMv5RXOmGzRooAceeEDt2rXTkiVL9N577+nTTz9V06ZNNXToUDVq1MhLZQIAAADW43GYPnnypDZs2KBvv/1W/v7+6tKliyZPnqyaNWtqzZo1mjNnjhYuXOjNWgEAAABL8ShMT5kyRT/++KM6deqkCRMmKCYmxm1937599dlnn3mlQAAAAMCqPArT9957r+Li4uTvf/XmjEoDAAC444vW5cuKX7T2KEx37NhR586d06ZNm5SXl6fQ0FC1a9dO1atX93Z9AAAAgGV5FKZ37dqluXPnKjIyUuHh4crJyVFycrKeeuop/frXv/Z2jQAAAIAleRSmk5OTNXLkSHXu3Nm1bNOmTUpOTtbf/vY3b9UGAAAAWJpHd0DMy8tTx44d3Za1b99ep0+f9kZNAAAAQKXgUZiOj4/X559/7rZszZo1io+P90pRAAAAQGXg0TSPw4cP68svv9Qnn3yi2rVrKzc3Vz/99JNiYmKUmJjoajd9+nSvFQoAAABYjUdhumfPnurZs6e3awEAAAAqFY/CdLdu3bxcBgAAAFD5eHw78a+//lobNmxQbm6uateurfj4eHXv3t2btQEAAACW5lGY/vDDD7V+/Xr169dP4eHhys7O1ieffKK8vDzdf//93q4RAAAAsCSPwvTatWs1bdo01alTx7WsTZs2SkxMJEwDAADgpuXRpfEuXLigmjVrui2rUaOGioqKvFIUAAAAUBl4FKbbtm2r+fPn6+TJkyoqKtKJEye0YMECtWnTxtv1AQAAAJbl0TSP4cOHa8mSJZo0aZIcDof8/f3VqVMnPfLII96uDwAAALCsa4Zpp9OpTz/9VCNHjtTYsWN15swZ1ahRQ35+Hg1qAwAAADesayZiPz8/ffHFF/L395efn59q1apFkAYAAADk4Zzprl276ssvv/R2LQAAAECl4tGc6YMHD+rzzz/XJ598orCwMNlsNte66dOne604AAAAwMo8CtM9e/ZUz549vV0LAAAAUKl4FKajoqIUExNTYvnBgwfLvSAAAACgsvBozvQLL7xQ6vIZM2aUazEAAABAZVLmyLTT6ZQkGYbh+nfZf//7X9ntdu9WBwAAAFhYmWF6yJAhrp8HDx7sts7Pz0/33Xefd6oCAAAAKoEyw/SCBQtkGIamTZvmdtUOm82mmjVrKiAgwOsFAgAAAFZVZpiuU6eOJOnVV1/1STEAAABAZeLR1TzOnj2rTz75RD/88IMKCwvd1nGdaQAAANysPArTL7/8shwOhzp16sTUDgAAAOD/8ShM79+/X4sXL1aVKlVM7SQ7O1sLFy7U6dOnZbPZlJCQoHvuucetjWEYWrp0qdLT0xUYGKixY8eqSZMmpvYHAAAA+IJHYbphw4bKyclRvXr1TO3Ebrdr6NChatKkic6fP68pU6aodevWql+/vqtNenq6MjMzNX/+fB04cECLFy/WzJkzTe0PAAAA8AWPwnSrVq00c+ZMdevWTSEhIW7revTocc3nh4aGKjQ0VJJUtWpVRUVFKTc31y1Mb9u2TfHx8bLZbGrWrJnOnTunvLw81/MAAAAAq/EoTO/bt09hYWHauXNniXWehOkrZWVl6fDhw2ratKnb8tzcXIWHh7seh4WFKTc3t0SYTklJUUpKiiQpKSnJ7Tkoyd/fn2NkcfQRysvN+j7iHEJ54X1kfVbsI4/CdGJiYrnsrLCwUPPmzdOwYcMUHBzstu7KuyteZrPZSixLSEhQQkKC63F2dna51HajCg8P5xhZHH2E8nKzvo84h1BeeB9ZX0X2UWRkZKnL/cp60oEDB9weFxUVuT3esmWLxwU4HA7NmzdPXbp0UYcOHUqsDwsLcztAOTk5TPEAAACApZUZpl944QW3x6NGjXJ7vHDhQo92YhiGFi1apKioKPXt27fUNnFxcdqwYYMMw9D+/fsVHBxMmAYAAICllTnNo7SpF79k/WXff/+9NmzYoIYNG2rSpEmSpCFDhrhGonv16qV27dopLS1NEyZMUEBAgMaOHevRtgEAAICKUmaYLm3O8i9Zf1nz5s21YsWKa25rxIgRHm0PAAAAsIIyp3kAAAAAuLoyR6YLCws1ZswY1+OCggK3xxcuXPBeZQAAAIDFlRmmy+uSeAAAAMCNqMww3bJlS1/VAQAAAFQ6Ht20BQBw84mKiqroEm4oJ06cqOgSAHgBX0AEAAAATCJMAwAAACaZCtNFRUVyOBzlXQsAAABQqXgUpt966y0dPHhQkpSWlqZHHnlEw4YN07Zt27xaHAAAAGBlHoXpb775Rg0aNJAkvf/++3rsscf0zDPP6J133vFqcQAAAICVeXQ1jwsXLigwMFBnzpzRf//7X3Xs2FGSlJ2d7dXiAAAAACvzKExHRkZq48aNyszMVOvWrSVJ+fn5CggI8GpxAAAAgJV5NM3j0Ucf1RdffKHdu3dr0KBBkqTt27e7gjUAAABwM/JoZLpp06Z64YUX3JZ16dJFXbp08UpRAAAAQGXgUZjetWuXIiIiFBERoby8PP3jH/+Qn5+fHnjgAYWEhHi5RAAAAMCaPJrmkZycLD+/S03feustFRcXy2az6bXXXvNqcQAAAICVeTQynZubq/DwcBUXF2v79u169dVX5e/vr1GjRnm7PgAAAMCyPArTVatW1enTp3Xs2DHVr19fQUFBcjgc3AURAAAANzWPwnTv3r317LPPyuFwaNiwYZKkffv2KSoqypu1AQAAAJbmUZi+99571b59e/n5+alevXqSpNq1a2v06NFeLQ4AAACwMo/CtCTVrVtX33//vQ4ePKjatWvr1ltvld1u92ZtAAAAgKV5FKZPnDihWbNmqaioSGFhYcrJyVGVKlU0efJk1a9f39s1AgAAAJbkUZhevHixEhIS1K9fP9lsNknSJ598ouTkZCUmJnq1QAAAAMCqPLrO9JEjR9S3b19XkJakPn366MiRI96qCwAAALA8j8J07dq1tWfPHrdle/fuVWhoqFeKAgAAACoDj6Z5DBkyRLNmzdLtt9+u8PBwZWdnKy0tTY899pi36wMAAAAsy6MwHRsbq9mzZys1NVV5eXlq0KCBBg4cqMjISG/XBwAAAFjWNcO00+nU0KFDtWzZMvXv398XNQEAAACVwjXnTPv5+SkyMlJnzpzxRT0AAABApeHRNI8777xTs2bN0m9/+1uFhYW5XdWjVatWXisOAAAAsDKPwvSaNWskSe+9957bcpvNpgULFpR/VQAAAEAl4FGYXrhwobfrAAAAACqdMudMnz17VhkZGaWuy8jI0NmzZ71REwAAAFAplDky/cEHH6hGjRpq27ZtiXWHDx/Wjh079NBDD11zJ6+++qrS0tJUq1YtzZs3r8T63bt3a/bs2YqIiJAkdejQQQMGDPDwJQAAAAAVo8yR6bS0NCUkJJS6LiEhQdu2bfNoJ926ddNzzz1XZpsWLVpozpw5mjNnDkEaAAAAlUKZYfr06dOqWbNmqeuqV6+un376yaOdtGzZUtWrV//l1QEAAAAWVuY0j2rVqunkyZOl3unw1KlTCg4OLrdC9u/fr0mTJik0NFRDhw5VgwYNSm2XkpKilJQUSVJSUpLCw8PLrYYbkb+/P8fI4ugjlBfeR9ZG/1gffWR9VuyjMsN0+/bttXTpUk2aNEkBAQGu5UVFRXrzzTfVsWPHcimicePGevXVVxUUFKS0tDTNmTNH8+fPL7VtQkKC29ST7OzscqnhRhUeHs4xsjj6COWF95G10T/WRx9ZX0X2UWmDy9I1wvSgQYP0v//7vxo/frzatm2rkJAQnT59Wtu3b1dYWJgGDhxYLsVdOcIdGxur5ORk5efnX3WKCQAAAGAFZYbpqlWr6vnnn9f69eu1c+dOHTp0SNWrV9egQYMUHx8vf3+PLlN9TadPn1atWrVks9l08OBBOZ1O1ahRo1y2DQAAAHjLNdOwv7+/evbsqZ49e5reyd/+9jft2bNHZ86c0ejRozVw4EA5HA5JUq9evbR582atWbNGdrtdAQEBmjhxotstywEAAAArKp+h5WuYOHFimet79+6t3r17+6IUAAAAoNyUeWk8AAAAAFdHmAYAAABMIkwDAAAAJnk0Z/rs2bP65JNP9MMPP6iwsNBt3fTp071SGAAAAGB1HoXpl19+WQ6HQ506dXK7eQsAAABwM/MoTO/fv1+LFy9WlSpVvF0PAAAAUGl4NGe6YcOGysnJ8XYtAAAAQKXi0ch0q1atNHPmTHXr1k0hISFu63r06OGNugAAAADL8yhM79u3T2FhYdq5c2eJdYRpAAAA3Kw8CtOJiYnergMAAACodH7x7cQNw5BhGK7Hfn5cqhoAAAA3J4/CdG5urpKTk7V3716dO3fObd27777rlcIAAAAAq/NoWPn111+Xv7+/pk6dqqCgIM2aNUtxcXH64x//6O36AAAAAMvyKEzv379fY8aMUaNGjWSz2dSoUSONGTNGq1at8nZ9AAAAgGV5FKb9/Pxkt9slSdWqVVN+fr4CAwOVm5vr1eIAAAAAK/NoznTTpk2Vnp6u9u3bq02bNnrppZcUEBCg6Ohob9cHAAAAWJZHYfqxxx5zXcFj2LBh+vTTT3X+/Hn16dPHq8UBAAAAVuZRmK5WrZrr54CAAPXv399rBQEAAACVhUdh+uLFi3r//ff17bff6syZM3rzzTe1fft2nTp1Sr179/Z2jQAAAIAlefQFxDfffFPHjh3ThAkTZLPZJEkNGjTQmjVrvFocAAAAYGUejUxv2bJF8+fPV1BQkCtM165dm6t5AAAA4Kbm0ci0v7+/nE6n27L8/HzVqFHDK0UBAAAAlYFHYbpjx45asGCBsrKyJEl5eXlKTk5W586dvVocAAAAYGUehekHHnhAEREReuqpp1RQUKAJEyYoNDRUf/jDH7xdHwAAAGBZHs2Z9vf317BhwzRs2DDX9I7Lc6cBAACAm1WZYTo7O7vU5Tk5Oa6fw8PDy7ciAAAAoJIoM0yPGzfumht49913y60YAAAAoDIpM0w3bNhQFy9eVNeuXdWlSxfVrl3bV3VZXlRUVEWXcEM5ceJEuW+TPipf3ugjAAAquzLD9Jw5c3T06FGtX79eU6dOVVRUlOLj49WhQwcFBAT4qkYAAADAkq55NY+GDRtq6NChWrBggfr06aPvvvtOI0eO1KFDh3xRHwAAAGBZHl0aT5IyMzO1Z88eHThwQI0bN1b16tW9WRcAAABgeWVO8zh79qy++eYbrV+/XoWFherSpYumT5/OFTwAAAAAXSNMjxo1ShEREerSpYuaNWsm6dIIdWZmpqtNq1atvFshAAAAYFFlhumQkBAVFRVp7dq1Wrt2bYn1NptNCxYsuOZOXn31VaWlpalWrVqaN29eifWGYWjp0qVKT09XYGCgxo4dqyZNmvyClwEAAAD4XplheuHCheWyk27duql3795X3V56eroyMzM1f/58HThwQIsXL9bMmTPLZd8AAACAt3j8BcTr0bJlyzK/sLht2zbFx8fLZrOpWbNmOnfunPLy8nxRGgAAAGBamSPTvpKbm+v2pcawsDDl5uYqNDS0RNuUlBSlpKRIkpKSkvgy5A2CfrQ++sj66CNro3+sjz6yPiv2kSXCtGEYJZbZbLZS2yYkJCghIcH1ODs722t1wXfoR+ujj6yPPrI2+sf66CPrq8g+ioyMLHW5T6Z5XEtYWJjbwcnJySl1VBoAAACwEkuE6bi4OG3YsEGGYWj//v0KDg4mTAMAAMDyfDLN429/+5v27NmjM2fOaPTo0Ro4cKAcDockqVevXmrXrp3S0tI0YcIEBQQEaOzYsb4oCwAAALguPgnTEydOLHO9zWbTiBEjfFEKAAAAUG4sMc0DAAAAqIwI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACT/H21o4yMDC1dulROp1M9e/bUvffe67Z+9+7dmj17tiIiIiRJHTp00IABA3xVHgAAAPCL+SRMO51OJScn689//rPCwsL07LPPKi4uTvXr13dr16JFC02ZMsUXJQEAAADXzSfTPA4ePKh69eqpbt268vf3V+fOnbV161Zf7BoAAADwGp+E6dzcXIWFhbkeh4WFKTc3t0S7/fv3a9KkSZo5c6aOHTvmi9IAAAAA03wyzcMwjBLLbDab2+PGjRvr1VdfVVBQkNLS0jRnzhzNnz+/xPNSUlKUkpIiSUpKSlJ4eLh3ioZP0Y/WRx9ZH31kbfSP9dFH1mfFPvJJmA4LC1NOTo7rcU5OjkJDQ93aBAcHu36OjY1VcnKy8vPzVbNmTbd2CQkJSkhIcD3Ozs72UtXwJfrR+ugj66OPrI3+sT76yPoqso8iIyNLXe6TaR7R0dE6deqUsrKy5HA4lJqaqri4OLc2p0+fdo1gHzx4UE6nUzVq1PBFeQAAAIApPhmZttvtGj58uGbMmCGn06nu3burQYMGWrNmjSSpV69e2rx5s9asWSO73a6AgABNnDixxFQQAAAAwEp8dp3p2NhYxcbGui3r1auX6+fevXurd+/evioHAAAAuG7cAREAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMMnfVzvKyMjQ0qVL5XQ61bNnT917771u6w3D0NKlS5Wenq7AwECNHTtWTZo08VV5AAAAwC/mk5Fpp9Op5ORkPffcc3rppZf07bff6vjx425t0tPTlZmZqfnz52vkyJFavHixL0oDAAAATPNJmD548KDq1aununXryt/fX507d9bWrVvd2mzbtk3x8fGy2Wxq1qyZzp07p7y8PF+UBwAAAJjikzCdm5ursLAw1+OwsDDl5uaWaBMeHl5mGwAAAMBKfDJn2jCMEstsNtsvbiNJKSkpSklJkSQlJSUpMjKynKr8ZUqrF9ZCH1kffWRt9I/10UfWRx/d+HwyMh0WFqacnBzX45ycHIWGhpZok52dXWYbSUpISFBSUpKSkpK8V/ANZMqUKRVdAq6BPrI++sja6B/ro4+sjz4yzydhOjo6WqdOnVJWVpYcDodSU1MVFxfn1iYuLk4bNmyQYRjav3+/goODSw3TAAAAgFX4ZJqH3W7X8OHDNWPGDDmdTnXv3l0NGjTQmjVrJEm9evVSu3btlJaWpgkTJiggIEBjx471RWkAAACAaT67znRsbKxiY2PdlvXq1cv1s81m04gRI3xVzk0jISGhokvANdBH1kcfWRv9Y330kfXRR+bZDGbGAwAAAKZwO3EAAADAJJ9N87jZDBo0SA0bNpQk+fn5afjw4br11lvLbfsLFy7U7bffro4dO2rRokXq27ev6tevf93b3bt3r9544w3Z7XbNmDFDAQEBpbabMWOGTp8+reLiYjVv3lwjRoyQn5+fVq1apbVr18put6tmzZoaM2aM6tSpc911lZcr+0WSfvOb35S4tf31GjdunP7617+qZs2a+vOf/6wXXnjhura3bt06/ec//9Gjjz5aYt2mTZu0YsUKhYSEKDExsdTnFxUVKTExUQ6HQ8XFxerYsaMGDhwoSXr77bf13Xffyd/fX3Xr1tXYsWNVrVq166q3PFXW82jatGkaOnSooqOjVVBQoCVLluj777+XJN16660aPny4goODr3s/FeVGO4+u3FdOTo6Sk5N1/PhxGYah2NhYDR06VP7+lfPX5Y1wDl1mGIY+/PBDrV+/XjabTbVr19bw4cPVoEGD696fr93I59BlDodDy5cv13fffSebzab69evr0UcfdbvvyI2icv7vUAkEBARozpw5kqSMjAz985//1PTp072yr9GjR5fbtjZu3Kh+/fqpe/fuZbZ74oknFBwcLMMwNG/ePG3atEm/+c1v1KhRIyUlJSkwMFBr1qzR8uXL9cQTT5Rbfdfryn7xhev9z+tavvrqKz366KNq1arVVdtUqVJFiYmJCgoKksPh0NSpU9W2bVs1a9ZMrVu31gMPPCC73a7ly5fro48+0oMPPujVmn+JynoeXenvf/+7GjRooPHjx0uSVqxYoUWLFunJJ5/0yv584UY7jy4zDENz585Vr1699Mwzz8jpdOq1117TO++8o6FDh/qkhvJ2I5xDl33xxRfav3+/5syZo8DAQG3fvl2zZ8/WvHnzrjrwY1U36jl0pX/+8586f/68Xn75Zfn5+enrr7/W3LlzNXPmzFLvI1KZEaZ94Pz5867RvsLCQs2ePVvnzp2Tw+HQ4MGDdccdd6iwsFAvvfSScnNz5XQ61b9/f3Xu3FmHDh3Sm2++qcLCQtWsWVNjx44tccnAK/+CHzp0qO655x6lpaUpICBAkyZNUkhIiPLz8/X666+7rvf98MMPq3nz5m7bWbt2rTZt2qTt27dr586d6tmzp1asWKHq1avr5MmTatGihWsE+vKoWnFxsRwOh+vEuDLUxcTEaOPGjV47ruUpIyNDy5YtU40aNdS4cWNlZWVpypQpWrFihYKCgvS73/1OkvTUU09p8uTJioiI0OzZs5WTk6OLFy/qnnvuKfXLG0OHDtXbb7+td999V9u2bZMk5efnq02bNho7dqw2bNigzz77TA6HQzExMa7j+/XXX2vlypUKCQnRLbfcoipVqpTY9vvvv699+/YpKytLcXFxatCggbZs2aKLFy8qKytLd955p/7whz/IZrMpKChI0qX+Ki4udvVXmzZtXNtr1qyZNm/eXO7HtrxUlvPoSpmZmTp06JDbH5QDBgzQY489pszMTOXk5JR6jkmXQvihQ4ckSd27d1ffvn3L9Xh6Q2U8j660a9cuBQQEuAYT/Pz89PDDD2v8+PEaOHCgNm3aVOo5drX3ndVUxnPoSh9//LESExMVGBgo6dL/X82aNdM333yjHj16aOjQobrrrru0e/duVatWTRMnTlTNmjW1evVqffnll7Lb7apfv74mTpxYfge1nFX2c+iyCxcuaN26dVqwYIH8/C7NKO7evbu+/vpr7dq1S3Xr1tXMmTPVtGlTHTlyRLfccovGjx+vwMBA/eMf/9C2bdtkt9vVunVrPfTQQ+V0dL2HMO0lRUVFmjRpki5evKi8vDzXR/BVqlTR008/reDgYOXn5+tPf/qT4uLilJGRodDQUD377LOSpIKCAjkcDi1ZskTPPPOMatasqdTUVL3zzjtlXjbwwoULiomJ0ZAhQ7R8+XKtXbtW/fv319KlS9W3b181b95c2dnZmjFjhl566SW35/bs2VP79u1zfWS3e/duHTx4UC+++KLq1KmjGTNmaMuWLerYsaOkS1M9Dh48qLZt27qWXemrr75S27Zty+mIlo/L/XLZfffdp7i4OL322muaOnWq6tWrV+K4XM3YsWNVvXp1FRUV6dlnn1WHDh1Uo0aNUtsOGjRIgwYNUkFBgaZOnarevXvr+PHjSk1N1fPPPy9/f38tXrxYGzduVOvWrbVixQrNmjVLwcHBmj59uho1alRimwMGDNCuXbtcv7zWrVungwcPat68eQoMDNSzzz6r2NhYRUdHy+l0avLkycrMzNTdd9+tmJiYEtv76quvLBcAKuN5dKXjx4+rUaNGrl8m0qWA1qhRIx0/flxVq1Yt9RyLiIhQbm6u5s2bJ0k6d+5ceRzOcnMjnUdXOnbsmBo3buy2LDg4WOHh4crMzJSkUs+xH3/8scT7zioq+zl0WUFBgQoLC1WvXj235dHR0Tp27Jhrn40bN9ZDDz2k999/X++9954effRRffzxx1qwYIGqVKlimXPpRj2HLsvMzFR4eHiJ6WxNmjTRsWPHVLduXZ08eVKjR49W8+bN9eqrr+qLL75Qjx49tGXLFv3tb3+TzWazTH9dC2HaS678CGf//v1asGCB5s2bJ8Mw9M4772jv3r2y2WzKzc3VTz/9pIYNG+rtt9/W8uXLdfvtt6tFixY6evSojh07pueff16S5HQ6r3kjG39/f91+++2SLr1pd+zYIUnauXOnjh8/7mpXUFCg8+fPq2rVqmVur2nTpqpbt66kS3O69u3b5wrOf/rTn1RUVKT58+dr165dat26tet5GzZs0KFDhzRt2rRfcNS8r7SP1o4cOaKIiAjdcsstkqT4+HjXLevLsnr1am3dulWSlJ2drVOnTl31PzDp0kfI8+fPV58+fdSkSRN9/vnnOnz4sOuXVlFRkWrWrKkDBw7otttuc80969Spk06dOuXR62vdurWrhvbt22vfvn2Kjo6Wn5+f5syZo3Pnzmnu3Lk6evSo23y9Dz/8UHa7XV26dPFoP75S2c8jwzBK/TjzyosolXaOtWrVSllZWVqyZIliY2Pdzi0ruJHPo6v11+XlpZ1j7dq1K/G+s4rKfg5dy5V9Y7PZXAMCXbp00dy5cyVJDRs21Pz583XHHXeoffv2pvZT3m7kc+jyPq42lePy8rCwMNenEvHx8Vq9erX69OmjgIAALVq0SLGxsa73kNURpn2gWbNmOnPmjPLz85Wenq78/HwlJSXJ399f48aNU1FRkSIjIzVr1iylpaXpn//8p9q0aaP27durfv36mjFjhsf7stvtrjeqn5+fiouLJV16Y5f2hcLLXySMjo42Nd8tICBAcXFx2rp1q+sX/o4dO/TRRx9p2rRpHn8kZFV2u90t+BQVFUmSdu/erZ07d+qFF15QYGCgpk2bposXL5a5rffee0+1a9d2fYRsGIa6du2qBx54wK3dli1bSn3+5dFl6dIdQwcNGnTN+n/+n1m1atXUsmVLZWRkuML0unXr9N1332nq1KmWnsdWGc+jBg0a6PDhw3I6na7RaafTqR9++EH169d3fdT9c9WrV9ecOXOUkZGhzz//XKmpqZX6RlaV5TyqX7++/v3vf7u1LygoUE5OjurWreuadnMlm81W6vtuwIABZb6OilAZz6HLgoODFRQUpP/+97+uPz4l6fDhw2rZsmWpNVze/7PPPqs9e/Zo27Zt+uCDD/Tiiy/Kbrd7/FqsoLKcQ5fVq1dPP/74Y4k/lA4fPuwKyD//fWOz2WS32zVz5kzt3LlTqamp+vzzz6/65Xor4dJ4PnDixAk5nU7VqFFDBQUFqlWrlvz9/bVr1y79+OOPkqTc3FwFBAQoPj5e/fr106FDhxQZGan8/Hzt379f0qVvxl7+OOuXat26tT7//HPX4yNHjki6NLo8Z86cqwbpgwcPKisrS06nU5s2bVLz5s1VWFiovLw8SZfm4KanpysqKkrSpRPljTfe0DPPPKNatWqZqtXXIiMjlZWV5foY95tvvnGtq1Onjg4fPixJOnTokLKysiRd+gVbrVo1BQYG6sSJEzpw4ECZ+/juu++0Y8cODR8+3LXs17/+tTZv3qyffvpJknT27Fn9+OOPiomJ0Z49e3TmzBk5HA7XPObLo8tz5sy5apDeuXOnzp49q6KiIm3dulW33nqr8vPzXR+VFRUVaefOna7+ysjI0Mcff6zJkye75iFaVWU8j+rVq6fGjRvrww8/dC378MMP1bhxY9fH1aWdY/n5+XI6nerYsaMGDx7seg9a2Y1wHv3617/WhQsXtH79ekmXQsNbb72lbt26uc6P0s6x0t53VlQZz6Er9evXT0uXLnUFyR07dmjfvn268847JV0KhZf7+ZtvvlHz5s3ldDqVnZ2tVq1a6cEHH3RNF7GiG+EcuiwoKEhdu3bVm2++KafTKUlav369Lly44PpuVXZ2tus9dbm/CgsLVVBQoNjYWA0bNsz1/rA6Rqa95OfzocaNGyc/Pz/deeedmjVrlqZMmaJGjRq5Qs3Ro0e1fPly2Ww2+fv7a8SIEfL399dTTz2lpUuXqqCgQMXFxbrnnntMXQbokUceUXJysp5++mkVFxerRYsWGjly5DWf16xZM/3jH//Q0aNH1aJFC7Vv3175+fmaPXu2Ll68KKfTqVatWumuu+6SJC1fvlyFhYV68cUXJUnh4eGuv2Ct4Of90rZtW/3P//yPRo0apaSkJNWoUUPNmzd3/aLo2LGjNmzYoEmTJik6OlqRkZGu53355Zd6+umnFRkZWeoc5CutWrVKeXl5ro/RLv81P3jwYL3wwgsyDEN2u12PPvqomjVrpj/84Q/685//rJCQEDVu3Nj1n9G13HrrrXrllVeUmZmpO++8U9HR0frhhx+0cOFCOZ1OGYahTp06uUYGkpOT5XA4XB/fxsTEePS+8JUb4TwaPXq0lixZoscee0zSpWM8ZswY1/rSzrGjR4/q73//u6vffz5iVNFu1PPIZrPp6aef1uLFi/XBBx/IMAy1a9dOQ4YMcbUp7RzLyMgo8b6zisp8DiUlJblGkJs1a6YnnnhC586d01NPPSU/Pz+FhITomWeecY1yBwYG6tixY5o8ebKCg4P1xBNPyOl06pVXXnHNY+/Tp48lLv95I55DkyZNco02d+rUSQ888IDefvttPf74465PcJ5++mlXm6ioKK1bt06vv/666tWrp169eqmgoMCVLwzD0MMPP2z+IPsQd0DEVe3evVuffvqppkyZUtGl+FRlfd1lXQMU1lRZ32ueuBFfG+eYtV2+YsWN4kY8hy7LysrSrFmzXF+yruyY5gEAAACYxMg0AAAAYBIj0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAquaysLA0cONB1Y4yyrFu3Tn/5y198UBUA3By4zjQA+NC4ceOUm5ur1157zXWbXunSNVp/+OEHLViwQBERET6va+/evZo5c6br8YULF9xu5PPSSy8pPDzc53UBgNURpgHAxyIiIvTtt9/qt7/9raRLN8q4fFe3itKiRQvXNXqzsrI0fvx4LVu2rNLddhkAfI0wDQA+Fh8frw0bNrjC9Lp169S1a1f93//9n6tNQUGBlixZovT0dAUGBqpnz56677775OfnJ6fTqeXLl2v9+vWqWrWq+vbt67b9goICvfnmm0pPT5fNZlP37t01cOBA+fn98pl9Bw8e1KxZs7Ro0SJXsN68ebM++OADzZkzRytWrNCxY8fk5+en9PR03XLLLRozZowaNWok6dLtqZcsWaK9e/cqKChIffr00T333GPyyAGA9TBnGgB8LCYmRgUFBTp+/LicTqc2bdqkLl26uLVZsmSJCgoKtGDBAk2bNk0bNmzQunXrJEkpKSlKS0vTrFmzlJSUpH//+99uz12wYIHsdrvmz5+v2bNna/v27Vq7dq2pWps2barq1atrx44drmUbN25UfHy86/G2bdvUqVMnLVmyRL/5zW80Z84cORwOOZ1OzZo1S40aNdJrr72mqVOnavXq1crIyDBVCwBYEWEaACrA5dHpHTt2KDIyUrVr13atczqdSk1N1QMPPKCqVasqIiJCffv21YYNGyRJmzZt0j333KPw8HBVr15d9957r+u5p0+fVkZGhoYNG6agoCDVqlVLffr0UWpqqulau3btqo0bN0qSzp49q+3bt+vOO+90rW/SpIk6duwof39/9e3bVxcvXtSBAwf0n//8R/n5+RowYID8/f1Vt25d9ezZ87pqAQCrYZoHAFSA+Ph4JSYmKisrS127dnVbl5+fL4fD4faFvzp16ig3N1eSlJeXV2LdZdnZ2SouLtbIkSNdywzDUFhY2HXV+sQTT6iwsFCpqalq0aKFQkNDXeuv3Lafn5/CwsKUl5fnqnXYsGGu9U6nUy1atDBdCwBYDWEaACpAnTp1FBERofT0dI0ePdptXc2aNWW325Wdna369etLuhSSL49eh4aGKjs729X+yp/DwsLk7++v5OTkcvvyYO3atdWsWTNt2bJFGzdu1F133eW2Picnx/Wz0+lUTk6OQkNDZbfbFRERofnz55dLHQBgRUzzAIAKMnr0aE2dOlVBQUFuy/38/NSpUye98847On/+vH788UetWrXKNa+6U6dO+uyzz5STk6OzZ89q5cqVrueGhoaqTZs2euutt1RQUCCn06nMzEzt2bPnumqNj4/Xxx9/rKNHj6p9+/Zu6w4dOqR///vfKi4u1urVq1WlShXFxMSoadOmqlq1qlauXKmioiI5nU4dPXpUBw8evK5aAMBKGJkGgApSr169q64bPny4lixZovHjxysgIEA9e/ZU9+7dJUk9e/bUyZMnNWnSJFWtWlX9+vXTrl27XM8dP368/vGPf+jJJ5/U+fPnVbduXf3+97+/rlrbt2+vxYsX64477igR/uPi4pSamqqFCxeqXr16euqpp+Tvf+nXy+TJk/XWW29p3LhxcjgcioyM1KBBg66rFgCwEpthGEZFFwEAsL7HHntMf/zjH9W6dWvXshUrVigzM1MTJkyowMoAoOIwzQMAcE2bN2+WJLVq1aqCKwEAa2GaBwCgTNOmTdPx48c1fvx4Uzd+AYAbGdM8AAAAAJMYYgAAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYNL/Bw+4CtGPG6dYAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 864x432 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "x = [mean_loss, e_mean_loss, qi_mean_loss, qi_e_mean_loss, ql_mean_loss, ql_e_mean_loss]\n",
+    "y = ['Baseline-fp32', 'Equalized-fp32', 'Baseline-IOps', 'Equalized-IOps', 'Baseline-LOps', 'Equalized-LOps']\n",
+    "title = \"MobileNetV2 Loss Results\"\n",
+    "x_label = \"Model Type\"\n",
+    "y_label = \"Mean Cross Entropy Loss\"\n",
+    "    \n",
+    "plot_statistic(x, y, title, x_label, y_label)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6c. Model Inference Accuracy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below, we see that, without equalization, IntegerOps takes a significant model hit of over 20% and QLinearOps takes an even greater hit of over 40%. Equalization ameliorates the accuracy degradation caused by quantization, with IntegerOps and QLinearOps seeing less than 5% and 10% accuracy drop, respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation accuracy results are below.\n",
+      "\n",
+      "\t\tBaseline\tEqualized\n",
+      "float32 \t0.726000\t0.726000\n",
+      "IntegerOps\t0.480000\t0.578000\n",
+      "QLinearOps\t0.303000\t0.498000\n"
+     ]
+    }
+   ],
+   "source": [
+    "accuracy_score      = sklearn.metrics.accuracy_score(true_labels, pred_labels)\n",
+    "e_accuracy_score    = sklearn.metrics.accuracy_score(e_true_labels, e_pred_labels)\n",
+    "qi_accuracy_score   = sklearn.metrics.accuracy_score(qi_true_labels, qi_pred_labels)\n",
+    "qi_e_accuracy_score = sklearn.metrics.accuracy_score(qi_e_true_labels, qi_e_pred_labels)\n",
+    "ql_accuracy_score   = sklearn.metrics.accuracy_score(ql_true_labels, ql_pred_labels)\n",
+    "ql_e_accuracy_score = sklearn.metrics.accuracy_score(ql_e_true_labels, ql_e_pred_labels)\n",
+    "\n",
+    "print('Validation accuracy results are below.\\n')\n",
+    "\n",
+    "simple_table(\n",
+    "    data_multilist = [[accuracy_score,    e_accuracy_score   ] ,\n",
+    "                      [qi_accuracy_score, qi_e_accuracy_score] ,\n",
+    "                      [ql_accuracy_score, ql_e_accuracy_score]],\n",
+    "    x_label_list = [\"Baseline\", \"Equalized\"],\n",
+    "    y_label_list = [\"float32 \", \"IntegerOps\", \"QLinearOps\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtMAAAGHCAYAAAByA95NAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAABGkklEQVR4nO3de1wUdf///+eyCKig4iIQaqkIHvJSQzybhqBXl5bZpZ+0Ls1DlqamnTQtM+vKwlOW2lUesbK6squyk5WReUQTD3g2RTxkagiopIgKO78//LFfN1DXEdZFH/fbzduNmXnPzGv3vSNPZt8zYzEMwxAAAACAq+Z1vQsAAAAASivCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBeKS+ffsqLi7usm3GjRun2rVrO6bnz58vb2/vki4NuGp8NoEbF2EawDXr27evLBaLunXrVmjZokWLZLFYSiRIPPvss1q7du01bWP+/PmyWCxq0qSJ7Ha707K77rpLAwYMuKrt1a5dW+PGjXNMb9q0SRaLRYsXLy6y/ZQpU1S+fHmdPHlSK1euVLdu3VStWjWVLVtWERERGjdunM6ePevSvs+ePaugoCCVLVtWGRkZV1X3jaigbwv+ValSRR06dLjmz0xxWLBggSwWy/UuA0AxIEwDKBa33nqrvv76a/3xxx9O82fNmqXbbrutRPbp7++voKCga96OxWLR9u3b9f777xdDVc7uuOMONW3aVLNnzy5y+Zw5c9SjRw9VrFhRq1evVnh4uD766CPt2LFD8fHxevvtt/Xkk0+6tK/PPvtMt912m2JiYjR//vziexHX4Ny5c9d1/1arVUeOHNGRI0f0008/qVKlSvrHP/6h9PT061oXgBsHYRpAsYiIiFCLFi2cQtzBgwf1448/ql+/foXaL168WE2aNJGvr6+Cg4M1ePBgnT59ulC7N954Q1WrVlW5cuXUrVs3pzOufx3mUZQNGzaoY8eO8vf3V5UqVfTPf/5TBw4ccGrj5eWlJ598Ui+88EKRNVxs+vTpqlu3rvz8/BQREaHx48crLy9P0oUz2Xv37tXLL7/sOBu6f/9+DRw4UN98842OHj3qtK2VK1dq165deuyxxyRJo0aN0sSJE9W2bVvVrFlT3bp106hRo7Rw4cLL1lRg5syZ6tu3r/r27VtkeD916pSefPJJVa9eXb6+vqpRo4Zee+01x/L09HT169dPISEh8vPzU506dTRv3jxJ0rJly2SxWHTo0CGnbXp7ezv6fP/+/bJYLPrwww/VqVMnlS9fXs8//7wMw9Cjjz6q8PBwlS1bVrVq1dLzzz9f6Ix7YmKi7rzzTpUrV04VK1ZUu3bttHfvXv3888+yWq367bffnNq/9957CggI0J9//nnZ9yU0NFShoaFq2LChxo4dqxMnTuiXX35xLP/jjz/Ut29fValSRQEBAWrdurVWrFjhWH7+/Hk9/fTTqlatmnx9fXXLLbeoZ8+ejuVFDUm63JnnZcuWqXfv3pLk+Jz07dtXkrRq1Sq1bt1aAQEBCggIUKNGjfTDDz9c9vUBuL4I0wCKzWOPPaY5c+bIMAxJF866xsbGFjozvWXLFnXp0kVt27ZVSkqK3nvvPX3zzTcaNGiQU7t169Zp2bJl+v7777V48WJt2bJF/fv3d7meHTt2qF27dmrZsqXWr1+vpUuXymq1qkOHDsrNzXVq+/zzzysvL08TJ0685PbGjRunyZMn6/XXX9fOnTv11ltvaebMmXr55ZclSZ9//rlq1KihZ555xnE2tHr16urZs6fKlSunhIQEp+3Nnj1bf/vb39SiRYtL7vPkyZMunX3ftWuX1q5dqwcffFD33Xefjh07pmXLljmWG4ahe+65R1999ZWmT5+unTt36v3331eVKlUkSWfOnFG7du20efNmffjhh9qxY4emT5+ucuXKXXHff/Xcc8/poYce0tatWzVkyBAZhqGQkBB99NFH2rlzp958800lJCQ4BfnExET9/e9/V5MmTbRmzRr98ssvevjhh3X+/HnFxMQoIiLCEewLzJkzRz179lRAQIBLdZ0+fdqxDR8fH8frjomJ0Z9//qnvvvtOmzZtUqdOndShQwft3LlT0oU/oBYuXKgFCxZoz549+uqrry7bZ1fSqlUrzZgxQ5Icn5O33npL+fn56tKli5o3b66NGzdq48aNGjdunKk+AOBGBgBcoz59+hixsbHGmTNnjMqVKxtLly418vLyjKpVqxqfffaZkZCQYFitVkf7Xr16GU2bNnXaxqJFiwyLxWLs37/fsc3y5csbJ06ccLT54YcfDEnG7t27DcMwjJdeeskIDw93LP/rfvr06WP06NHDaT+5ublG2bJljS+++KLQOu+++65Rrlw547fffjMMwzDatWtnPPLII4ZhGMbp06eNsmXLGt99953T9t577z2jYsWKjunw8HDjpZdeKvQePf7440atWrUMu91uGIZhHD9+3Chbtqwxffr0S7yrhrFjxw4jICDgsm0KPPnkk0bXrl2d9vfggw86phMTEw1JRnJycpHrz5kzx/D19XW89r/6+eefDUmFllutViMhIcEwDMPYt2+fIcl45ZVXrljvG2+8YdSuXdsx3aZNG6Nz586XbD9lyhTj1ltvNfLz8w3DMIxdu3YZkox169Zdcp2EhARDklG+fHmjfPnyhiRDktG8eXPj/PnzjjZVq1Z1TBeIiYkxhg8fbhiGYQwbNsyIiYlx9N1fFXz+L/bBBx8YF/+K/etn86/LDcMwsrKyDEnGzz//fMnXBMDzcGYaQLHx8/NT7969NXv2bH377bfKy8vTvffeW6jd9u3b1bZtW6d57dq1k2EY2rFjh2Ne/fr1VbFiRcd069atJclxxvBKkpOT9cUXX8jf39/xz2azKTc3V3v27CnUfsCAAY4hCEXVfObMGXXr1s1pewMHDtTJkyd17Nixy9YycOBApaWlaenSpZIuDAOQpF69ehXZfs+ePerYsaN69uypoUOHXnbbubm5ev/999WnTx/HvL59++rzzz9XZmampAvDXQIDAxUdHV3kNjZs2KD69eurWrVql92XK5o1a1Zo3uzZs9W8eXOFhITI399fo0ePdhpuUzAc51L69u2r9PR0x5CH2bNnq1GjRmratOlla7FarUpJSdGGDRv0wQcfqGbNmnr//fcdF8QmJyfr6NGjqlSpklO/rly50vEZ6devn7Zu3aratWtr0KBB+uyzz0pkLHhgYKAGDBigv//97/rHP/6h+Ph4/frrr8W+HwDFi/v0AChWAwcO1B133KGDBw+qX79+KlOmTJHtLjWetDjvcGC329W7d2+NGjWq0DKbzVZontVq1ZQpU3T33Xdr2LBhhbYlSZ9++qkiIyMLrVu5cuXL1tKoUSM1b95cs2bNUmxsrGbPnq0HHnhAlSpVKtR227Zt6tChg+677z698847l92uJP3vf/9TVlaWunfv7jQ/Pz9f7733np5++mlJV35vL7fcy+vCuRfj/x/CU7D9v94BRZLKly/vNP3pp59qyJAhio+PV7t27VShQgV9+umneuGFF1zef+XKldW9e3fNnj1bcXFxev/9953umnI5BePq69Spo1OnTum+++5TSkqKfH19ZbfbVa9ePX3xxReF1isYXtG4cWPt27dPP/74o37++WcNHz5cL774otauXasKFSrIy8vL6X2RLoyzNmP27NkaPny4lixZoh9//FEvvviiZsyYoYEDB5raHoCSx5lpAMWqXr16atq0qZKSki55W7nbb79dy5cvd5q3fPlyWSwW1a9f3zFv586dys7OdkwnJSU59uGK6OhobdmyReHh4apdu7bTv8DAwCLX6dixo+6++25HAL24Zj8/P6WlpRXaVu3atWW1WiVdGIubn59f5LYHDhyoRYsW6ZtvvtGWLVscFx5eLDk5We3atdMDDzygd955x6U/LgouPExJSXH6N3LkSMeFiE2aNFFWVpbWr19f5DaaNGmi7du3F7rAsEBwcLAk6fDhw455KSkphUJkUVasWKE77rhDTz/9tJo0aaKIiAjt37+/0P6vdKHdwIED9fXXX+vdd9/V6dOn9a9//euK+/6rAQMGKCcnxzFmOTo6WmlpaapQoUKhPg0LC3Os5+/vr/vvv1/Tpk3T+vXrtXPnTsdnODg42Ol9kaSNGzdeto6CMdtFfVYaNGigp59+Wt99950eeeQRzZo166pfJwA3ur6jTADcCP46ZvT06dNGZmamY/qv40U3b95sWK1W46mnnjJ27txpfPfdd0b16tWNXr16OW0zICDAuO+++4ytW7cay5cvNyIiIpzG1V5pzPSOHTsMf39/46GHHjJ++eUXIy0tzVi6dKkxbNgwY+/evUWuU7Cet7e3UbZsWceYacMwjFdeecUxhnnXrl3Gtm3bjI8//tgYOXKko02nTp2MmJgY48CBA8axY8ccY3wL3peKFSsagYGBxu23317ofVy+fLkREBBg9OvXzzhy5IjTv0vZvn27IclYsWJFoWV79+41JBnLly837Ha7ceeddxq1atUyFi1aZKSlpRmrVq0yZs+e7agtMjLSuOOOO4wff/zRSEtLMxITE43//ve/hmEYxvnz543bbrvNuPvuu42dO3caK1euNO68807DYrEUGjO9cuVKpzqmT59ulC1b1li0aJGRmppqvPnmm4bNZnMaM/zDDz8YXl5exvDhw43Nmzcbu3btMhISEoxdu3Y5bev22283fHx8jL59+17yPSlQVN8axoXx2jabzTh58qRx5swZ4/bbbzeio6ONH374wdi3b5+xdu1a47XXXnOMq584caKxYMECY9u2bUZaWpoxfvx4w2q1Omr78ccfDUnG9OnTjdTUVGPWrFlGcHDwZcdMr1u3zpBkfP7550Z6errx559/Gnv27DFGjhxprFy50ti/f7+RlJRk1K9f3+m4AOB5CNMArllRF2BdrKhQ8+233xpRUVGGj4+PERQUZAwaNMg4depUoW1OmjTJCA0NNfz8/IyuXbsa6enpjjZXCtOGYRhbtmwxunTpYlSqVMnw8/MzwsPDjUcffdQR9i8VuIYMGWJIcgrThnHhQr1GjRoZvr6+RqVKlYxmzZoZ//nPfxzLk5OTjaioKMPPz8+QZOzbt89p/aFDhxqSjLfeeqvQPvv06eO4SO6v/y5l2LBhRlhY2CUvjouOjjb+9a9/GYZhGNnZ2cbQoUON0NBQo0yZMkaNGjWM119/3dH2yJEjRu/evQ2bzWb4+voaderUcQRlwzCMtWvXOl5bw4YNjRUrVhR5AeJfw/S5c+eMxx57zAgMDDQCAgKMBx980Jg+fXqh1/X9998bLVq0MPz8/IwKFSoYd911l+OPngJvvvmmIclISkq65HtS4FJ9++effxqBgYHGmDFjDMMwjIyMDGPQoEFGWFiYUaZMGSMsLMzo2rWrsXHjRsMwLlyYGhUVZQQEBBjly5c3oqOjjUWLFjlt89VXXzXCwsKM8uXLGz179jRmzJhx2TBtGIYxfPhwIzg42LBYLEafPn2Mw4cPG/fff79RtWpVw8fHx7jllluMAQMGOF2EC8DzWAzDhe/oAADwACNHjtR3332nrVu3Xu9SAEASFyACAEqBkydPauvWrZo9e7amTp16vcsBAAfOTAMAPN5dd92lX375RT169NC8efMcdxcBgOuNMA0AAACYxJ/2AAAAgEmEaQAAAMAkwjQAAABgUqm/m8dfnzoFZ0FBQcrIyLjeZeAy6CPPRx95NvrH89FHno8+urKLn4p6Mc5MAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgkvf1LqC0qlq16vUu4Yby+++/F/s26aPiVRJ9BABAaceZaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJPcdp/plJQUJSQkyG63KzY2Vl27dnVa/tVXX2nlypWSJLvdrkOHDmnu3Lny9/d3V4kAAADAVXFLmLbb7Zo7d67GjBkjm82m0aNHKzo6WtWqVXO06dKli7p06SJJWr9+vb799luCNAAAADyaW4Z5pKamKjQ0VCEhIfL29larVq2UnJx8yfarV69W69at3VEaAAAAYJpbzkxnZWXJZrM5pm02m/bs2VNk27NnzyolJUWPPPJIkcsTExOVmJgoSYqPj1dQUFDxFwy3ox89383cR97e3jf16/d09I/no488H31knlvCtGEYheZZLJYi227YsEF16tS55BCPuLg4xcXFOaYzMjKKp0hcV/Sj57uZ+ygoKOimfv2ejv7xfPSR56OPriwsLKzI+W4Z5mGz2ZSZmemYzszMVGBgYJFtV69erTZt2rijLAAAAOCauCVMh4eH68iRI0pPT1deXp6SkpIUHR1dqF1OTo527NhR5DIAAADA07hlmIfValX//v01fvx42e12xcTEqHr16lqyZIkkqWPHjpKkdevWqVGjRvLz83NHWQAAAMA1cdt9pqOiohQVFeU0ryBEF7jrrrt01113uaskAAAA4JrwBEQAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGCSt7t2lJKSooSEBNntdsXGxqpr166F2mzfvl3z589Xfn6+AgIC9PLLL7urPAAAAOCquSVM2+12zZ07V2PGjJHNZtPo0aMVHR2tatWqOdqcPn1ac+bM0QsvvKCgoCCdPHnSHaUBAAAAprllmEdqaqpCQ0MVEhIib29vtWrVSsnJyU5tVq1apebNmysoKEiSVLFiRXeUBgAAAJjmljPTWVlZstlsjmmbzaY9e/Y4tTly5Ijy8vI0btw4nTlzRp06dVK7du0KbSsxMVGJiYmSpPj4eEf4RulGP3q+m7mPvL29b+rX7+noH89HH3k++sg8t4RpwzAKzbNYLE7T+fn52rdvn1588UWdO3dOY8aMUUREhMLCwpzaxcXFKS4uzjGdkZFRMkXDrehHz3cz91FQUNBN/fo9Hf3j+egjz0cfXdlfM2kBt4Rpm82mzMxMx3RmZqYCAwMLtQkICJCfn5/8/PxUr149HThw4JKFAwAAANebW8ZMh4eH68iRI0pPT1deXp6SkpIUHR3t1CY6Olq7du1Sfn6+zp49q9TUVFWtWtUd5QEAAACmuOXMtNVqVf/+/TV+/HjZ7XbFxMSoevXqWrJkiSSpY8eOqlatmho3bqxnn31WXl5eat++vW699VZ3lAcAAACYYjGKGtBcihw+fPi67Jez5sXr999/L/Zt0kfFqyT6qLRgLKFno388H33k+eijK7vU0GOegAgAAACYRJgGAAAATCJMAwAAACa55QJEAEDpw3UHxetmvu4AuJFxZhoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACZ5u9IoIyNDBw4c0OnTp1W+fHnddtttCgoKKunaAAAAAI92yTCdl5enxMRE/fjjj0pPT1doaKj8/PyUm5uro0ePKjg4WB06dFBcXJy8vV3K5AAAAMAN5ZIpeMSIEWrQoIEee+wxRUREyMvr/40IsdvtSk1N1cqVKzVy5Ei98cYbbikWAAAA8CSXDNPjxo1TxYoVi1zm5eWlyMhIRUZGKjs7u8SKAwAAADzZJS9AvFSQ/qsKFSoUWzEAAABAaeLSYOdTp07pq6++0oEDB5Sbm+u07OWXXy6RwgAAAABP51KYfuutt5SXl6eWLVvKx8enpGsCAAAASgWXwvTu3bs1Z84clSlTpqTrAQAAAEoNlx7acuuttyozM7OkawEAAABKFZfOTDdo0ECvvfaa7rrrLlWqVMlpWfv27V3aUUpKihISEmS32xUbG6uuXbs6Ld++fbsmTpyo4OBgSVLz5s3VvXt3l7YNAAAAXA8uheldu3bJZrNp69athZa5Eqbtdrvmzp2rMWPGyGazafTo0YqOjla1atWc2tWrV0+jRo1ysXQAAADg+nIpTL/00kvXtJPU1FSFhoYqJCREktSqVSslJycXCtMAAABAaeLyc8BPnTqlDRs2KCsrS5UrV1aTJk3k7+/v0rpZWVmy2WyOaZvNpj179hRqt3v3bo0YMUKBgYHq3bu3qlev7mp5AAAAgNu5fDeP119/XVWrVlVQUJA2btyo+fPna/To0YqMjLzi+oZhFJpnsVicpmvWrKn//Oc/8vPz08aNGzVp0iRNmzat0HqJiYlKTEyUJMXHxysoKMiVlwAPRz96vpu5j7y9vW/q14/icTN/hjiGPB99ZJ5LYXr+/PkaMGCAWrdu7ZiXlJSkhIQEvf7661dc32azOd0NJDMzU4GBgU5typUr5/g5KipKc+fOVXZ2dqEnLMbFxSkuLs4xnZGR4cpLgIejHz3fzdxHQUFBN/XrR/G4mT9DN/MxVLVq1etdwg3l999/v277DgsLK3K+S7fGO3LkiFq2bOk0r0WLFjp69KhLOw8PD9eRI0eUnp6uvLw8JSUlKTo62qnNiRMnHGewU1NTZbfbFRAQ4NL2AQAAgOvBpTPToaGhSkpKUps2bRzz1qxZ47ig8EqsVqv69++v8ePHy263KyYmRtWrV9eSJUskSR07dtTatWu1ZMkSWa1W+fj46Mknnyw0FAQAAADwJBajqAHNf/Hrr78qPj5eYWFhCgoK0rFjx3TkyBGNGjVKderUcUedl3T48OHrsl++tileJfG1DX1UvK7nV2vX2836FTXHUPHiGLr5jiGJ46i4eeIwD5fOTNepU0fTp0/Xxo0bdfz4cTVp0kRRUVEu380DAAAAuBG5fGs8f39/tW3btiRrAQAAAEqVS4bp8ePH64UXXpAkjR079pLjl19++eWSqQwAAADwcJcM0+3atXP87MojwwHgajGWsHjdzGNyAeB6uWSYvvjOHVWrVlVEREShNqmpqSVTFQAAAFAKuHSf6VdffbXI+ePHjy/WYgAAAIDS5LIXINrtdkkXHgde8K/AH3/8IavVWrLVAQAAAB7ssmH6wQcfdPzcs2dPp2VeXl66//77S6YqAAAAoBS4bJieMWOGDMPQuHHjnO7aYbFYVKFCBfn4+JR4gQAAAICnumyYrlKliux2u4KDg1WpUiWVKVPGXXUBAAAAHu+KFyB6eXkpPT1dLjx1HAAAALipuHQ3j+7du2v27Nk6duyY7Ha70z8AAADgZuXS48RnzpwpSVqxYkWhZZ988knxVgQAAACUEi6F6RkzZpR0HQAAAECp41KYrlKliqQL950+efKkKlasKC8vl0aIAAAAADcsl8J0Tk6O5s2bp9WrV8tut8tqtapVq1bq37+/ypUrV9I1AgAAAB7JpdPLCQkJys3N1ZQpU7RgwQJNnjxZ586d07x580q6PgAAAMBjuRSmU1JS9MQTTygsLExlypRRWFiYBg8erM2bN5d0fQAAAIDHcilM+/j4KDs722ledna2vL1dGiUCAAAA3JBcSsPt27fXq6++qs6dO6tKlSo6duyYvv32W8XFxZV0fQAAAIDHcilM//Of/1RgYKBWr16trKwsVa5cWffdd59iYmJKuj4AAADAY7kUpi0Wi9q3b6/27duXdD0AAABAqeHyoOelS5dq9erVOn78uAIDA9W6dWvFxMTIYrGUZH0AAACAx3IpTC9YsEDJycnq3LmzgoKClJGRoa+//lqHDx9Wr169SrpGAAAAwCO5FKaXLVumCRMmyGazOeZFRUXpueeeI0wDAADgpuXSrfHKli2rsmXLFprH0w8BAABwM3PpzHSnTp00efJkde3aVZUrV1ZmZqa++uorde7cWX/88YejXUhISIkVCgAAAHgal8L0/PnzJUnbt293mr9t2zYlJCQ4pj/55JPiqwwAAADwcC6FaUIyAAAAUNhVPQ88IyPD8dCWoKCgkqoJAAAAKBVcCtPHjx/Xm2++qd27dysgIEB//vmnIiMjNXz4cFWuXLmkawQAAAA8kkt385g9e7Zuu+02JSQkaNasWUpISFCNGjU0e/bskq4PAAAA8Fguhelff/1VDz/8sPz8/CRJfn5+6tWrl3bv3l2ixQEAAACezKUwXb58eR06dMhp3uHDh7nPNAAAAG5qLo2Z7tKli/7973+rffv2qlKlio4dO6Zly5apR48eLu8oJSVFCQkJstvtio2NVdeuXYtsl5qaqhdeeEFPPfWUWrRo4fL2AQAAAHdzKUzHxcUpNDRUq1at0sGDBxUYGKjhw4erQYMGLu3Ebrdr7ty5GjNmjGw2m0aPHq3o6GhVq1atULsPP/xQjRs3vuoXAgAAALjbFcO03W7X8OHD9cYbb7gcnv8qNTVVoaGhjicktmrVSsnJyYXC9HfffafmzZtr7969pvYDAAAAuNMVx0x7eXnJy8tL58+fN72TrKws2Ww2x7TNZlNWVlahNuvWrVPHjh1N7wcAAABwJ5eGeXTq1ElTp07V/fffr8qVK8tisTiWFZxtvhzDMArNu3gb0oVHlv/rX/+Sl9fl831iYqISExMlSfHx8Tw85gZBP3o++sjz0Uee7WbuH29v75v69aP4eOLnyKUwPW/ePEnSli1bCi1z5VHjNptNmZmZjunMzEwFBgY6tdm7d6/eeustSVJ2drY2bdokLy8vNWvWzKldXFyc4uLiHNMZGRmuvAR4OPrR89FHno8+8mw3c/8EBQXd1K8fxed6fo7CwsKKnO9SmHYlMF9OeHi4jhw5ovT0dFWuXFlJSUkaNmyYU5u3337b6ecmTZoUCtIAAACAJ3EpTBfIyspSVlaWKleufFWPEbdarerfv7/Gjx8vu92umJgYVa9eXUuWLJEkxkkDAACgVHIpTGdkZGjatGnavXu3/P39derUKUVERGjYsGGqUqWKSzuKiopSVFSU07xLheghQ4a4tE0AAADgenLpCYhvv/22atWqpfnz52vOnDmaP3++wsPDnYZmAAAAADcbl8J0WlqaevXqJT8/P0mSn5+fevXqpbS0tBItDgAAAPBkLoXpiIgIpaamOs3bu3evIiMjS6QoAAAAoDRwacx0SEiIXn/9dUVFRTluc7dp0ya1adPG6U4fPXr0KLFCAQAAAE/jUpg+f/68mjdvLunCPaDLlCmjZs2a6dy5c073jwYAAABuJi6F6cGDB5d0HQAAAECpc8kx0ydPnnRpAydOnCiuWgAAAIBS5ZJnpl9++WXVr19fbdu2Ve3ateXl9f9yt91uV2pqqlasWKGdO3dqypQpbikWAAAA8CSXDNMTJ05UYmKiZs6cqfT0dAUHB6ts2bI6c+aM0tPTFRoaqg4dOqhv375uLBcAAADwHJcM097e3rr77rt19913KyMjQwcPHlROTo7Kly+v22677aoeJw4AAADciFy6ADEoKEhBQUElXQsAAABQqrj00BYAAAAAhRGmAQAAAJMI0wAAAIBJLoXpAwcOlHQdAAAAQKnj0gWIr7zyiipXrqw777xTd955pwIDA0u6LgAAAMDjuRSmZ82apY0bN2rlypX69NNPVadOHbVt21bNmzeXr69vSdcIAAAAeCSXwrTValXTpk3VtGlT5eTkaM2aNfrqq680Z84cNWvWTHFxcapbt25J1woAAAB4lKu6ADE3N1fr1q1TUlKSMjMz1apVK4WGhmr69OmaM2dOSdUIAAAAeCSXzkxv3LhRK1as0KZNm1S3bl21b99ezz33nHx8fCRJd999tx5//HENGDCgRIsFAAAAPIlLYfrDDz9Uu3bt1KdPnyIvPvT391ffvn2LuzYAAADAo7kUpqdMmXLFNrGxsddcDAAAAFCauDRmevLkydq5c6fTvJ07d7oUsgEAAIAblUtheseOHapTp47TvMjISG3fvr1EigIAAABKA5fCdJkyZZSbm+s0Lzc3V1artUSKAgAAAEoDl8J0o0aNNGvWLOXk5EiScnJyNHfuXDVu3LgkawMAAAA8mksXID788MOaPn26+vfvL39/f506dUqNGzfWE088UdL1AQAAAB7LpTDt7++v0aNH6/jx48rMzFRQUJAqVapUwqUBAAAAns2lMF0gMDBQlSpVkmEYstvtkiQvr6t6iCIAAABww3ApTGdlZWnu3LnauXOnTp8+7bTsk08+KZHCAAAAAE/n0mnlWbNmydvbW2PHjpWfn58mTJig6OhoPfrooyVdHwAAAOCxXArTu3fv1uOPP64aNWrIYrGoRo0aevzxx/XNN9+UdH0AAACAx3IpTHt5eTnuKV2+fHllZ2fL19dXWVlZJVocAAAA4MlcGjNdu3Ztbdq0Sc2aNVOjRo00depU+fj4KDw8vKTrAwAAADyWS2H6iSeekGEYkqS+ffvq66+/1pkzZ9S5c2eXd5SSkqKEhATZ7XbFxsaqa9euTsuTk5P1ySefyGKxyGq1qm/fvqpbt67rrwQAAABwsyuGabvdroSEBA0cOFCS5OPjo27dul3VTux2u+bOnasxY8bIZrNp9OjRio6OVrVq1Rxt/va3vyk6OloWi0UHDhzQ1KlT9eabb17dqwEAAADc6Iph2svLS1u2bJHFYjG9k9TUVIWGhiokJESS1KpVKyUnJzuFaT8/P8fPZ8+evab9AQBwM6hater1LuGG8vvvv1/vElAKuTTMo3Pnzlq4cKEeeOABeXtf1XNeJF24T7XNZnNM22w27dmzp1C7devW6aOPPtLJkyc1evToIreVmJioxMRESVJ8fLyCgoKuuh54HvrR89FHno8+8mz0j+ejjzyfJ/aRS8n4+++/14kTJ/Ttt9+qQoUKTsveeeedK65fMN76YkWdeW7WrJmaNWumHTt26JNPPtGLL75YqE1cXJzi4uIc0xkZGa68BHg4+tHz0Ueejz7ybPSP56OPPN/17KOwsLAi57t8AeK1sNlsyszMdExnZmYqMDDwku3r16+vt99+W9nZ2YXCOwAAAOApXArT9evXv6adhIeH68iRI0pPT1flypWVlJSkYcOGObU5evSoQkJCZLFYlJaWpry8PAUEBFzTfgEAAICS5FKY/uSTTy65rEePHldc32q1qn///ho/frzsdrtiYmJUvXp1LVmyRJLUsWNHrV27VitWrJDVapWPj4+eeuopLkIEAACAR3MpTF88REOSTpw4oR07dqhZs2Yu7ygqKkpRUVFO8zp27Oj4uWvXroXuPQ0AAAB4MpfC9ODBgwvNS0lJ0apVq4q9IAAAAKC08DK7YsOGDZWcnFyctQAAAACliktnpv/44w+n6bNnz2rVqlUeea8/AAAAwF1cCtN/vfOGj4+PatasqSFDhpRIUQAAAEBpcM138wAAAABuVi6Nmd6/f3+hJ85kZGRo//79JVETAAAAUCq4FKanT5+u/Px8p3l5eXmaMWNGiRQFAAAAlAYuhemMjAyFhIQ4zQsNDdWxY8dKpCgAAACgNHApTFeuXFlpaWlO89LS0hQYGFgiRQEAAAClgUsXIHbu3FmTJk1Sly5dFBISoj/++ENff/21/vnPf5Z0fQAAAIDHcilMx8XFqXz58lq6dKkyMzNls9n08MMPq0WLFiVdHwAAAOCxXArTktSyZUu1bNmyJGsBAAAAShWXxkzPmzdPv/76q9O8X3/9VfPnzy+JmgAAAIBSwaUwvXr1aoWHhzvNq1WrllatWlUiRQEAAAClgUth2mKxyG63O82z2+0yDKNEigIAAABKA5fCdN26dfXf//7XEajtdrs+/fRT1a1bt0SLAwAAADyZSxcg9uvXT/Hx8Ro4cKCCgoKUkZGhwMBAjRw5sqTrAwAAADyWS2HaZrNpwoQJSk1Nddwar3bt2iVdGwAAAODRXBrmIUleXl6KjIxUy5Yt5efnpw8//FCPP/54SdYGAAAAeDSX7zOdnZ2tVatWafny5dq/f7/q1q2rvn37lmBpAAAAgGe7bJjOy8vT+vXrtWzZMm3evFmhoaFq3bq1jh07pqeffloVK1Z0V50AAACAx7lsmH700Ufl5eWldu3a6YEHHlCtWrUkSUuWLHFLcQAAAIAnu+yY6dtuu02nT59Wamqq9u7dq1OnTrmrLgAAAMDjXfbM9Lhx43Ts2DEtX75cX3/9tRISEtSwYUOdPXtW+fn57qoRAAAA8EhXvACxSpUq6t69u7p3765du3Zp+fLlslgsGjFihGJiYtSrVy931AkAAAB4HJfv5iFdeBJi3bp11a9fP61bt04rVqwoqboAAAAAj3dVYbqAj4+P2rRpozZt2hR3PQAAAECp4fJDWwAAAAA4I0wDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADDJ1H2mzUhJSVFCQoLsdrtiY2PVtWtXp+UrV67Ul19+KUny8/PTgAEDVKNGDXeVBwAAAFw1t5yZttvtmjt3rp5//nlNnTpVq1ev1qFDh5zaBAcHa9y4cZo8ebK6deumWbNmuaM0AAAAwDS3hOnU1FSFhoYqJCRE3t7eatWqlZKTk53a1KlTR/7+/pKkiIgIZWZmuqM0AAAAwDS3DPPIysqSzWZzTNtsNu3Zs+eS7ZcuXao77rijyGWJiYlKTEyUJMXHxysoKKh4i8V1QT96PvrI89FHno3+8Xz0kefzxD5yS5g2DKPQPIvFUmTbbdu26eeff9Yrr7xS5PK4uDjFxcU5pjMyMoqnSFxX9KPno488H33k2egfz0cfeb7r2UdhYWFFznfLMA+bzeY0bCMzM1OBgYGF2h04cEAzZ87UiBEjFBAQ4I7SAAAAANPcEqbDw8N15MgRpaenKy8vT0lJSYqOjnZqk5GRocmTJ2vo0KGXTP4AAACAJ3HLMA+r1ar+/ftr/PjxstvtiomJUfXq1bVkyRJJUseOHfW///1Pp06d0pw5cxzrxMfHu6M8AAAAwBSLUdSA5lLk8OHD12W/VatWvS77vVH9/vvvxb5N+qh40Ueer7j7iP4pXhxDno8+8nwl0Ueuuq5jpgEAAIAbEWEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADDJ2107SklJUUJCgux2u2JjY9W1a1en5b///rv+85//aN++ferZs6e6dOnirtIAAAAAU9wSpu12u+bOnasxY8bIZrNp9OjRio6OVrVq1Rxt/P391a9fPyUnJ7ujJAAAAOCauWWYR2pqqkJDQxUSEiJvb2+1atWqUGiuWLGiateuLavV6o6SAAAAgGvmljPTWVlZstlsjmmbzaY9e/aY2lZiYqISExMlSfHx8QoKCiqWGnF90Y+ejz7yfPSRZ6N/PB995Pk8sY/cEqYNwyg0z2KxmNpWXFyc4uLiHNMZGRmm64LnoB89H33k+egjz0b/eD76yPNdzz4KCwsrcr5bhnnYbDZlZmY6pjMzMxUYGOiOXQMAAAAlxi1hOjw8XEeOHFF6erry8vKUlJSk6Ohod+waAAAAKDFuGeZhtVrVv39/jR8/Xna7XTExMapevbqWLFkiSerYsaNOnDihUaNG6cyZM7JYLFq8eLHeeOMNlStXzh0lAgAAAFfNbfeZjoqKUlRUlNO8jh07On6uVKmS3n33XXeVAwAAAFwznoAIAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJjk7a4dpaSkKCEhQXa7XbGxseratavTcsMwlJCQoE2bNsnX11eDBw9WrVq13FUeAAAAcNXccmbabrdr7ty5ev755zV16lStXr1ahw4dcmqzadMmHT16VNOmTdNjjz2mOXPmuKM0AAAAwDS3hOnU1FSFhoYqJCRE3t7eatWqlZKTk53arF+/Xm3btpXFYlFkZKROnz6t48ePu6M8AAAAwBS3hOmsrCzZbDbHtM1mU1ZWVqE2QUFBl20DAAAAeBK3jJk2DKPQPIvFctVtJCkxMVGJiYmSpPj4eIWFhRVTlVenqHrhWegjz0cfeTb6x/PRR56PPrrxueXMtM1mU2ZmpmM6MzNTgYGBhdpkZGRcto0kxcXFKT4+XvHx8SVX8A1k1KhR17sEXAF95PnoI89G/3g++sjz0UfmuSVMh4eH68iRI0pPT1deXp6SkpIUHR3t1CY6OlorVqyQYRjavXu3ypUrV2SYBgAAADyFW4Z5WK1W9e/fX+PHj5fdbldMTIyqV6+uJUuWSJI6duyoO+64Qxs3btSwYcPk4+OjwYMHu6M0AAAAwDS33Wc6KipKUVFRTvM6duzo+NlisWjAgAHuKuemERcXd71LwBXQR56PPvJs9I/no488H31knsVgZDwAAABgCo8TBwAAAExy2zCPm02PHj106623SpK8vLzUv39/1alTp9i2//bbb6tJkyZq0aKF3n33Xd1zzz2qVq3aNW93586dmj17tqxWq8aPHy8fH58i240fP14nTpxQfn6+6tatqwEDBsjLy0vffPONfvrpJ1mtVlWoUEGPP/64qlSpcs11FZeL+0WSWrduXejR9tdqyJAhev3111WhQgWNGTNGr7766jVtb9myZdq7d68eeeSRQsvWrFmjhQsXqlKlSnrppZeKXP/cuXN66aWXlJeXp/z8fLVo0UIPPPCAJOmDDz7Qhg0b5O3trZCQEA0ePFjly5e/pnqLU2k9jsaNG6fevXsrPDxcOTk5mjdvnn799VdJUp06ddS/f3+VK1fumvdzvdxox9HF+8rMzNTcuXN16NAhGYahqKgo9e7dW97epfPX5Y1wDBUwDEOff/65li9fLovFosqVK6t///6qXr36Ne/P3W7kY6hAXl6eFixYoA0bNshisahatWp65JFHnJ47cqMonf87lAI+Pj6aNGmSJCklJUUfffSRXn755RLZ16BBg4ptWytXrtS9996rmJiYy7Z76qmnVK5cORmGoSlTpmjNmjVq3bq1atSoofj4ePn6+mrJkiVasGCBnnrqqWKr71pd3C/ucK3/eV3J0qVL9cgjj6hBgwaXbFOmTBm99NJL8vPzU15ensaOHavGjRsrMjJSDRs21EMPPSSr1aoFCxboiy++UK9evUq05qtRWo+ji73zzjuqXr26hg4dKklauHCh3n33XT399NMlsj93uNGOowKGYWjy5Mnq2LGjRo4cKbvdrpkzZ+rjjz9W79693VJDcbsRjqECP/zwg3bv3q1JkybJ19dXmzdv1sSJEzVlypRLnvjxVDfqMXSxjz76SGfOnNFbb70lLy8v/fzzz5o8ebJee+21Ip8jUpoRpt3gzJkzjrN9ubm5mjhxok6fPq28vDz17NlTTZs2VW5urqZOnaqsrCzZ7XZ169ZNrVq1Ulpamt577z3l5uaqQoUKGjx4cKFbBl78F3zv3r3VqVMnbdy4UT4+PhoxYoQqVaqk7OxszZo1y3G/7z59+qhu3bpO2/npp5+0Zs0abd68WVu3blVsbKwWLlwof39/HT58WPXq1XOcgS44q5afn6+8vDzHgXFxqIuIiNDKlStL7H0tTikpKZo/f74CAgJUs2ZNpaena9SoUVq4cKH8/PzUpUsXSdIzzzyj5557TsHBwZo4caIyMzN1/vx5derUqciLN3r37q0PPvhAn3zyidavXy9Jys7OVqNGjTR48GCtWLFC3333nfLy8hQREeF4f3/++WctWrRIlSpV0i233KIyZcoU2vb//vc/7dq1S+np6YqOjlb16tW1bt06nT9/Xunp6WrTpo3+7//+TxaLRX5+fpIu9Fd+fr6jvxo1auTYXmRkpNauXVvs721xKS3H0cWOHj2qtLQ0pz8ou3fvrieeeEJHjx5VZmZmkceYdCGEp6WlSZJiYmJ0zz33FOv7WRJK43F0sW3btsnHx8dxMsHLy0t9+vTR0KFD9cADD2jNmjVFHmOX+tx5mtJ4DF3syy+/1EsvvSRfX19JF/7/ioyM1KpVq9S+fXv17t1bHTp00Pbt21W+fHk9+eSTqlChghYvXqwff/xRVqtV1apV05NPPll8b2oxK+3HUIGzZ89q2bJlmjFjhry8LowojomJ0c8//6xt27YpJCREr732mmrXrq39+/frlltu0dChQ+Xr66sPP/xQ69evl9VqVcOGDfXwww8X07tbcgjTJeTcuXMaMWKEzp8/r+PHjzu+gi9TpoyeffZZlStXTtnZ2XrhhRcUHR2tlJQUBQYGavTo0ZKknJwc5eXlad68eRo5cqQqVKigpKQkffzxx5e9beDZs2cVERGhBx98UAsWLNBPP/2kbt26KSEhQffcc4/q1q2rjIwMjR8/XlOnTnVaNzY2Vrt27XJ8Zbd9+3alpqbqjTfeUJUqVTR+/HitW7dOLVq0kHRhqEdqaqoaN27smHexpUuXqnHjxsX0jhaPgn4pcP/99ys6OlozZ87U2LFjFRoaWuh9uZTBgwfL399f586d0+jRo9W8eXMFBAQU2bZHjx7q0aOHcnJyNHbsWN199906dOiQkpKS9O9//1ve3t6aM2eOVq5cqYYNG2rhwoWaMGGCypUrp5dfflk1atQotM3u3btr27Ztjl9ey5YtU2pqqqZMmSJfX1+NHj1aUVFRCg8Pl91u13PPPaejR4/q73//uyIiIgptb+nSpR4XAErjcXSxQ4cOqUaNGo5fJtKFgFajRg0dOnRIZcuWLfIYCw4OVlZWlqZMmSJJOn36dHG8ncXmRjqOLvbbb7+pZs2aTvPKlSunoKAgHT16VJKKPMaOHTtW6HPnKUr7MVQgJydHubm5Cg0NdZofHh6u3377zbHPmjVr6uGHH9b//vc/ffrpp3rkkUf05ZdfasaMGSpTpozHHEs36jFU4OjRowoKCio0nK1WrVr67bffFBISosOHD2vQoEGqW7eu/vOf/+iHH35Q+/bttW7dOr355puyWCwe019XQpguIRd/hbN7927NmDFDU6ZMkWEY+vjjj7Vz505ZLBZlZWXp5MmTuvXWW/XBBx9owYIFatKkierVq6eDBw/qt99+07///W9Jkt1uv+KDbLy9vdWkSRNJFz60W7ZskSRt3bpVhw4dcrTLycnRmTNnVLZs2ctur3bt2goJCZF0YUzXrl27HMH5hRde0Llz5zRt2jRt27ZNDRs2dKy3YsUKpaWlady4cVfxrpW8or5a279/v4KDg3XLLbdIktq2bet4ZP3lLF68WMnJyZKkjIwMHTly5JL/gUkXvkKeNm2aOnfurFq1aun777/Xvn37HL+0zp07pwoVKmjPnj26/fbbHWPPWrZsqSNHjrj0+ho2bOiooVmzZtq1a5fCw8Pl5eWlSZMm6fTp05o8ebIOHjzoNF7v888/l9Vq1Z133unSftyltB9HhmEU+XXmxTdRKuoYa9CggdLT0zVv3jxFRUU5HVue4EY+ji7VXwXzizrG7rjjjkKfO09R2o+hK7m4bywWi+OEwJ133qnJkydLkm699VZNmzZNTZs2VbNmzUztp7jdyMdQwT4uNZSjYL7NZnN8K9G2bVstXrxYnTt3lo+Pj959911FRUU5PkOejjDtBpGRkfrzzz+VnZ2tTZs2KTs7W/Hx8fL29taQIUN07tw5hYWFacKECdq4caM++ugjNWrUSM2aNVO1atU0fvx4l/dltVodH1QvLy/l5+dLuvDBLuqCwoILCcPDw02Nd/Px8VF0dLSSk5Mdv/C3bNmiL774QuPGjXP5KyFPZbVanYLPuXPnJEnbt2/X1q1b9eqrr8rX11fjxo3T+fPnL7utTz/9VJUrV3Z8hWwYhtq1a6eHHnrIqd26deuKXL/g7LJ04YmhPXr0uGL9f/3PrHz58qpfv75SUlIcYXrZsmXasGGDxo4d69Hj2ErjcVS9enXt27dPdrvdcXbabrfrwIEDqlatmuOr7r/y9/fXpEmTlJKSou+//15JSUml+kFWpeU4qlatmn755Ren9jk5OcrMzFRISIhj2M3FLBZLkZ+77t27X/Z1XA+l8RgqUK5cOfn5+emPP/5w/PEpSfv27VP9+vWLrKFg/6NHj9aOHTu0fv16ffbZZ3rjjTdktVpdfi2eoLQcQwVCQ0N17NixQn8o7du3zxGQ//r7xmKxyGq16rXXXtPWrVuVlJSk77///pIX13sSbo3nBr///rvsdrsCAgKUk5OjihUrytvbW9u2bdOxY8ckSVlZWfLx8VHbtm117733Ki0tTWFhYcrOztbu3bslXbgytuDrrKvVsGFDff/9947p/fv3S7pwdnnSpEmXDNKpqalKT0+X3W7XmjVrVLduXeXm5ur48eOSLozB3bRpk6pWrSrpwoEye/ZsjRw5UhUrVjRVq7uFhYUpPT3d8TXuqlWrHMuqVKmiffv2SZLS0tKUnp4u6cIv2PLly8vX11e///679uzZc9l9bNiwQVu2bFH//v0d8/72t79p7dq1OnnypCTp1KlTOnbsmCIiIrRjxw79+eefysvLc4xjLji7PGnSpEsG6a1bt+rUqVM6d+6ckpOTVadOHWVnZzu+Kjt37py2bt3q6K+UlBR9+eWXeu655xzjED1VaTyOQkNDVbNmTX3++eeOeZ9//rlq1qzp+Lq6qGMsOztbdrtdLVq0UM+ePR2fQU92IxxHf/vb33T27FktX75c0oXQ8P777+uuu+5yHB9FHWNFfe48UWk8hi527733KiEhwREkt2zZol27dqlNmzaSLoTCgn5etWqV6tatK7vdroyMDDVo0EC9evVyDBfxRDfCMVTAz89P7dq103vvvSe73S5JWr58uc6ePeu4tiojI8PxmSror9zcXOXk5CgqKkp9+/Z1fD48HWemS8hfx0MNGTJEXl5eatOmjSZMmKBRo0apRo0ajlBz8OBBLViwQBaLRd7e3howYIC8vb31zDPPKCEhQTk5OcrPz1enTp1M3QaoX79+mjt3rp599lnl5+erXr16euyxx664XmRkpD788EMdPHhQ9erVU7NmzZSdna2JEyfq/PnzstvtatCggTp06CBJWrBggXJzc/XGG29IkoKCghx/wXqCv/ZL48aN9a9//UsDBw5UfHy8AgICVLduXccvihYtWmjFihUaMWKEwsPDFRYW5ljvxx9/1LPPPquwsLAixyBf7JtvvtHx48cdX6MV/DXfs2dPvfrqqzIMQ1arVY888ogiIyP1f//3fxozZowqVaqkmjVrOv4zupI6depo+vTpOnr0qNq0aaPw8HAdOHBAb7/9tux2uwzDUMuWLR1nBubOnau8vDzH17cREREufS7c5UY4jgYNGqR58+bpiSeekHThPX788ccdy4s6xg4ePKh33nnH0e9/PWN0vd2ox5HFYtGzzz6rOXPm6LPPPpNhGLrjjjv04IMPOtoUdYylpKQU+tx5itJ8DMXHxzvOIEdGRuqpp57S6dOn9cwzz8jLy0uVKlXSyJEjHWe5fX199dtvv+m5555TuXLl9NRTT8lut2v69OmOceydO3f2iNt/3ojH0IgRIxxnm1u2bKmHHnpIH3zwgYYPH+74BufZZ591tKlataqWLVumWbNmKTQ0VB07dlROTo4jXxiGoT59+ph/k92IJyDikrZv366vv/5ao0aNut6luFVpfd2XuwcoPFNp/ay54kZ8bRxjnq3gjhU3ihvxGCqQnp6uCRMmOC6yLu0Y5gEAAACYxJlpAAAAwCTOTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAo5dLT0/XAAw84HoxxOcuWLdOLL77ohqoA4ObAfaYBwI2GDBmirKwszZw50/GYXunCPVoPHDigGTNmKDg42O117dy5U6+99ppj+uzZs04P8pk6daqCgoLcXhcAeDrCNAC4WXBwsFavXq1//OMfki48KKPgqW7XS7169Rz36E1PT9fQoUM1f/78UvfYZQBwN8I0ALhZ27ZttWLFCkeYXrZsmdq1a6f//ve/jjY5OTmaN2+eNm3aJF9fX8XGxur++++Xl5eX7Ha7FixYoOXLl6ts2bK65557nLafk5Oj9957T5s2bZLFYlFMTIweeOABeXld/ci+1NRUTZgwQe+++64jWK9du1afffaZJk2apIULF+q3336Tl5eXNm3apFtuuUWPP/64atSoIenC46nnzZunnTt3ys/PT507d1anTp1MvnMA4HkYMw0AbhYREaGcnBwdOnRIdrtda9as0Z133unUZt68ecrJydGMGTM0btw4rVixQsuWLZMkJSYmauPGjZowYYLi4+P1yy+/OK07Y8YMWa1WTZs2TRMnTtTmzZv1008/maq1du3a8vf315YtWxzzVq5cqbZt2zqm169fr5YtW2revHlq3bq1Jk2apLy8PNntdk2YMEE1atTQzJkzNXbsWC1evFgpKSmmagEAT0SYBoDroODs9JYtWxQWFqbKlSs7ltntdiUlJemhhx5S2bJlFRwcrHvuuUcrVqyQJK1Zs0adOnVSUFCQ/P391bVrV8e6J06cUEpKivr27Ss/Pz9VrFhRnTt3VlJSkula27Vrp5UrV0qSTp06pc2bN6tNmzaO5bVq1VKLFi3k7e2te+65R+fPn9eePXu0d+9eZWdnq3v37vL29lZISIhiY2OvqRYA8DQM8wCA66Bt27Z66aWXlJ6ernbt2jkty87OVl5entMFf1WqVFFWVpYk6fjx44WWFcjIyFB+fr4ee+wxxzzDMGSz2a6p1qeeekq5ublKSkpSvXr1FBgY6Fh+8ba9vLxks9l0/PhxR619+/Z1LLfb7apXr57pWgDA0xCmAeA6qFKlioKDg7Vp0yYNGjTIaVmFChVktVqVkZGhatWqSboQkgvOXgcGBiojI8PR/uKfbTabvL29NXfu3GK7eLBy5cqKjIzUunXrtHLlSnXo0MFpeWZmpuNnu92uzMxMBQYGymq1Kjg4WNOmTSuWOgDAEzHMAwCuk0GDBmns2LHy8/Nzmu/l5aWWLVvq448/1pkzZ3Ts2DF98803jnHVLVu21HfffafMzEydOnVKixYtcqwbGBioRo0a6f3331dOTo7sdruOHj2qHTt2XFOtbdu21ZdffqmDBw+qWbNmTsvS0tL0yy+/KD8/X4sXL1aZMmUUERGh2rVrq2zZslq0aJHOnTsnu92ugwcPKjU19ZpqAQBPwplpALhOQkNDL7msf//+mjdvnoYOHSofHx/FxsYqJiZGkhQbG6vDhw9rxIgRKlu2rO69915t27bNse7QoUP14Ycf6umnn9aZM2cUEhKi++6775pqbdasmebMmaOmTZsWCv/R0dFKSkrS22+/rdDQUD3zzDPy9r7w6+W5557T+++/ryFDhigvL09hYWHq0aPHNdUCAJ7EYhiGcb2LAAB4vieeeEKPPvqoGjZs6Ji3cOFCHT16VMOGDbuOlQHA9cMwDwDAFa1du1aS1KBBg+tcCQB4FoZ5AAAua9y4cTp06JCGDh1q6sEvAHAjY5gHAAAAYBKnGAAAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmPT/AVPN8jF6rN44AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 864x432 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "x = [accuracy_score, e_accuracy_score, qi_accuracy_score, qi_e_accuracy_score, ql_accuracy_score, ql_e_accuracy_score]\n",
+    "y = ['Baseline-fp32', 'Equalized-fp32', 'Baseline-IOps', 'Equalized-IOps', 'Baseline-LOps', 'Equalized-LOps']\n",
+    "title = \"MobileNetV2 Accuracy Results\"\n",
+    "x_label = \"Model Type\"\n",
+    "y_label = \"Accuracy (proportion)\"\n",
+    "    \n",
+    "plot_statistic(x, y, title, x_label, y_label)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6d. Model Inference F1 Score\n",
+    "\n",
+    "For comparison, results of the F1 score are included. The behavior is similar to what was observed in the accuracy calculation. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation accuracy results are below.\n",
+      "\n",
+      "\t\tBaseline\tEqualized\n",
+      "float32 \t0.668333\t0.668333\n",
+      "IntegerOps\t0.410075\t0.507652\n",
+      "QLinearOps\t0.253002\t0.433317\n"
+     ]
+    }
+   ],
+   "source": [
+    "f1_score      = sklearn.metrics.f1_score(true_labels, pred_labels, average=\"weighted\")\n",
+    "e_f1_score    = sklearn.metrics.f1_score(e_true_labels, e_pred_labels, average=\"weighted\")\n",
+    "qi_f1_score   = sklearn.metrics.f1_score(qi_true_labels, qi_pred_labels, average=\"weighted\")\n",
+    "qi_e_f1_score = sklearn.metrics.f1_score(qi_e_true_labels, qi_e_pred_labels, average=\"weighted\")\n",
+    "ql_f1_score   = sklearn.metrics.f1_score(ql_true_labels, ql_pred_labels, average=\"weighted\")\n",
+    "ql_e_f1_score = sklearn.metrics.f1_score(ql_e_true_labels, ql_e_pred_labels, average=\"weighted\")\n",
+    "\n",
+    "print('Validation accuracy results are below.\\n')\n",
+    "\n",
+    "simple_table(\n",
+    "    data_multilist = [[f1_score,    e_f1_score   ] ,\n",
+    "                      [qi_f1_score, qi_e_f1_score] ,\n",
+    "                      [ql_f1_score, ql_e_f1_score]],\n",
+    "    x_label_list = [\"Baseline\", \"Equalized\"],\n",
+    "    y_label_list = [\"float32 \", \"IntegerOps\", \"QLinearOps\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtMAAAGHCAYAAAByA95NAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAA+GUlEQVR4nO3de1wU9f7H8feyKyCCiouCCKaipmZqSKbW0TgQx6w8duykJzUVLa9pWuYlr6covHUxK8t72c1OZf06ZkreRZNS8tZF8n6LAIujqAg7vz98sA83EGmEZdHX8/Hw8WBmvjPz2f3OyJvZ785YDMMwBAAAAOBP8yrvAgAAAICKijANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAeq2/fvoqNjS22zZQpU9SwYUPn9OLFi2Wz2cq6NKBE6tWrp2effba8ywBQhgjTAEpF3759ZbFY1K1bt0LLli9fLovFUiYh98knn9TWrVuvahuLFy+WxWJR69at5XA4XJbdeeedGjBgwJ/aXsOGDTVlyhTn9I4dO2SxWLRixYoi28+aNUtVqlTR77//ro0bN6pbt24KCwtT5cqV1ahRI02ZMkXnz58vdp9TpkyRxWIp9C8xMVGSdOLECfXs2VM33XSTbDbbFf9IKXD27FlNnDhRjRo1UuXKlWW323Xrrbdq9uzZJXszykG9evWcr9/X11cNGzbUhAkTlJubW96lFTo2AFR8XL4BUGrq1q2r//u//9Mvv/yi4OBg5/w333xTN9xwg44ePVrq+/T395e/v/9Vb8disWjPnj1666231Ldv36sv7BK33HKLbr31Vs2bN0+dO3cutHz+/Pnq3r27qlWrps2bNysiIkIjRoxQeHi4tm/frkGDBumXX37R66+/Xux+6tWrpy1btrjMCwgIkCSdP39eNWrU0KhRo/Thhx8qLy+vRLUPHjxYa9eu1csvv6yWLVsqOztbO3bs0OHDh0v46s3Jzc2Vt7e36fXHjBmjxx9/XLm5ufr666/Vv39/ORwOPffcc6VYJQBwZRpAKWrUqJHatm2rxYsXO+cdPnxYq1evVr9+/Qq1X7FihVq3bi0fHx/VqlVLQ4YM0ZkzZwq1e+GFF1SnTh35+fmpW7duysjIcC774zCPonz77beKi4uTv7+/atasqX/84x86dOiQSxsvLy89/vjjevrpp4us4VKvvPKKmjRpIl9fXzVq1EgJCQnOcHrnnXfq559/1tSpU51XRw8ePKiBAwfq888/18mTJ122tXHjRv3www969NFHJUljx47V9OnT1aFDB9WvX1/dunXT2LFjtWzZsmJrkiSr1aqQkBCXf1WqVJF0MWi/8sor6t+/v0JCQq64rQLLly/X6NGj1bVrV9WvX18tW7ZU3759NWnSJJd2H3zwgVq3bi1fX1/Z7XbdfffdOnXqlCTpwoULGjt2rOrUqSNvb281a9ZM7777rsv6FotFs2fP1kMPPaRq1aqpZ8+ekqTVq1fr9ttvV+XKlVWnTh3169dPmZmZV6zb399fISEhqlu3rv75z3/qrrvu0pdffunS5v3331erVq3k6+urevXqadSoUS59v2nTJt1+++0KCAhQQECAWrZs6dzGwYMHZbFYtGnTJpdtFnfl+XLHxoULFzRq1CiFhYXJx8dHtWvXVo8ePa74GgF4BsI0gFL16KOPav78+TIMQ9LFq64xMTG64YYbXNrt3LlTXbp0UYcOHZSamqolS5bo888/16BBg1zabdu2TevWrdPKlSu1YsUK7dy5U/Hx8SWuZ+/everYsaPatWunb775RmvWrJHVatVdd92lc+fOubQdP3688vLyNH369Mtub8qUKZo5c6aef/55ff/993r55Zf1xhtvaOrUqZKkjz/+WPXq1dMTTzyhEydO6MSJEwoPD1ePHj3k5+enRYsWuWxv3rx5uvnmm9W2bdvL7vP3339XUFBQiV9zaapdu7ZWrlyprKysy7ZZtGiRevXqpa5du2r79u1au3atOnXqpPz8fEkX39d58+bppZde0u7du9WrVy/16tVLX331lct2pk6dqnbt2mn79u1KSEjQmjVr9Pe//109evTQzp07tXz5ch08eFD333+/8/gqiR07dmjTpk0uV7oXL16swYMH64knntDevXv11ltvKSkpyXn85efnq0uXLrrtttu0fft2bd++XVOmTJGfn9+feftcXO7YeOWVV7Rs2TItXbpU+/bt02effVbs8QDAwxgAUAr69OljxMTEGGfPnjVq1KhhrFmzxsjLyzPq1KljfPTRR8aiRYsMq9XqbN+rVy/j1ltvddnG8uXLDYvFYhw8eNC5zSpVqhi//fabs82XX35pSDJ++uknwzAMY/LkyUZERIRz+R/306dPH6N79+4u+zl37pxRuXJl45NPPim0zty5cw0/Pz/jyJEjhmEYRseOHY3+/fsbhmEYZ86cMSpXrmx88cUXLttbsmSJUa1aNed0RESEMXny5ELv0eDBg40GDRoYDofDMAzDOHXqlFG5cmXjlVdeucy7ahh79+41AgICim1T8D5YLBajSpUqLv/OnTtXqG1BX5XEpk2bjLp16xpeXl7GzTffbDzyyCPG8uXLna/BMAwjPDzcGDp0aJHrnzlzxvD29jZeffVVl/ldu3Y1oqOjndOSjPj4eJc2HTt2NMaMGeMy79ChQ4YkY8eOHZet+YYbbjC8vb2NKlWqGN7e3oYkw2q1Ovu7oM3rr7/ust769esNSUZWVpaRlZVlSDLWrl1b5D4OHDhgSDI2btzoMv+PfX/DDTcYzzzzzGWXG4ZhDB8+3IiOjnZ5TwFUHFyZBlCqfH191bt3b82bN0///e9/lZeXp/vuu69Quz179qhDhw4u8zp27CjDMLR3717nvGbNmqlatWrO6dtvv12S9P3335eonpSUFH3yySfOsdX+/v6y2+06d+6c9u3bV6j9gAED1KBBA40fP77Ims+ePatu3bq5bG/gwIH6/fff9euvvxZby8CBA7V//36tWbNGkrR06VJJUq9evYpsv2/fPsXFxalHjx4aNmzYFV9reHi4UlNTXf5dzbhj6eL7/fPPP2vjxo3q06ePfvnlF3Xr1k1dunSRYRhKT0/XkSNHFBcXV+T6aWlpys3NLbKv9+zZ4zKvTZs2LtMpKSl66aWXXN7rZs2aSVKRfXepoUOHKjU1VZs2bVKXLl00bNgwde3aVZL066+/6tChQxo1apTLtu+++25nzYGBgRowYID+9re/6e6771ZiYqJ+/PHHEr9vf0a/fv20a9cuNWzYUIMGDdJHH33kEV+WBFAyfAERQKkbOHCgbrnlFh0+fFj9+vVTpUqVimxnsVj+1HwzHA6HevfurbFjxxZaZrfbC82zWq2aNWuWOnXqpOHDhxfaliR9+OGHaty4caF1a9SoUWwtLVu21G233aY333xTMTExmjdvnh588EFVr169UNvdu3frrrvu0t///vcrfvGwQKVKla44ftwMm82m9u3bq3379nriiSe0dOlS9e7dWxs2bFDTpk0lXbnP/rjcMIxC8wrGdxdwOBwaM2aMevfuXWh7Vxr3XaNGDed7sWzZMt14442KjIzUww8/7OzHl19+WdHR0YXWDQsLk3RxCM6IESO0atUqrV69WhMnTtScOXM0cOBAeXl5OV/HpS5cuFBsXUVp1aqVDhw4oNWrV2vt2rUaMWKEJk6cqK1bt6pq1ap/ensA3IswDaDUNW3aVLfeeqs2b96sJUuWFNnmpptu0vr1613mrV+/XhaLxXn1Ubp4BTo7O9sZKpKTk537KImoqCjt3LlTERERJQ7pcXFx6tSpk0aNGuUMTQU1+/r6av/+/UXelaOAt7e3c7zwHw0cOFCDBg3S559/rp07dxYZlFNSUtSpUyf16tVLL730Uqn+cVEaCt779PR0dezYUWFhYfryyy+L/ASiYcOG8vHx0fr163XTTTc552/YsMFluihRUVHas2fPVf+B4OPjo/Hjx+upp55St27dFBwcrPDwcP3444965JFHil23efPmat68uUaNGqVBgwbpzTff1MCBA1WzZk1J0vHjx51t09PTdezYsWK3d7ljw9/fX/fff7/uv/9+jR8/XrVr19b69euLfE8BeBbCNIAy8eWXX+rcuXOXvVo7evRoRUZGatSoUXr00Ud18OBBPfbYY+rZs6fq1q3rbGexWPTwww/r2WefVVZWloYOHap77rlHjRo1KlEd48ePV5s2bdSrVy+NGDFCNWvW1MGDB7V8+XKNGDFCDRo0KHK9WbNmqUWLFi5Xe/39/TV+/HjnEJC77rpLeXl52rVrl3bs2KFp06ZJkurXr6/Nmzfr8OHD8vPzU40aNZyhvHv37ho5cqQefvhh3XTTTWrfvr3Lfjds2KB7771XDzzwgMaNG6dffvnFuezP3IWjKKmpqZKkrKwsnT592jndqlWry67TsWNH/etf/1JUVJRq1qyptLQ0jR8/XtWrV3de1Z08ebIGDx6s4OBgPfDAA3I4HFq7dq169OihoKAgDR8+XBMnTlTNmjXVqlUrffjhh/r000+1evXqYuv997//rbi4OI0cOVJ9+vRRQECA9u3bpw8//FBz5sxR5cqVS/zaH374YU2aNEkvvfSSnn76aSUkJKh///6qXr26unbtqkqVKun777/XF198oTfeeENpaWmaN2+e7rvvPoWHh+v48ePauHGjIiMjJUmVK1fW7bffrunTp6tJkybKy8vT008/LR8fn2LrKOrYmDVrlkJDQ9WqVSv5+fnpvffek9VqLfLTDwAeqHyHbAO4VlzpS21//GKgYRjGf//7XyMyMtLw9vY2goKCjEGDBhmnT58utM0ZM2YYISEhhq+vr9G1a1cjPT3d2eZKX0A0DMPYuXOn0aVLF6N69eqGr6+vERERYTzyyCNGZmbmZdcxDMMYOnSoIcn5BcQC8+fPN1q2bGn4+PgY1atXN9q0aWO89tprzuUpKSlGZGSk4evra0gyDhw44LL+sGHDDEnGyy+/XGifffr0MSQV+a84f3wfimJmu88//7xxxx13GDVr1jR8fHyM8PBwo2fPnsaePXtc2i1dutRo0aKF4e3tbdSoUcPo3LmzcerUKcMwDCM3N9cYM2aMERoaalSqVMlo2rSp8c477xSq7e233y60/w0bNhgxMTGGv7+/4efnZzRp0sQYMWKEceHChcvW/Mcv/RV49tlnjWrVqjn7/ZNPPjHatm1rVK5c2QgICDBatmxpTJ061TAMwzh+/Lhx//33G3Xq1DG8vb2N2rVrGwMGDHD5MuyPP/5odOjQwfDz8zMaNmxofPTRR1f8AmJRx8bcuXONyMhIIyAgwKhSpYoRFRVlLF++/LKvD4BnsRjGn7i/EAAAAAAn7uYBAAAAmESYBgAAAExy2xcQU1NTtWjRIjkcDsXExDjv91ngs88+08aNGyVdvB3S0aNHtWDBAvn7+7urRAAAAOBPcUuYdjgcWrBggSZMmCC73a5x48YpKirKeS9PSerSpYu6dOkiSfrmm2/03//+lyANAAAAj+aWYR5paWkKCQlRcHCw8+b/KSkpl22/efNm51POAAAAAE/lljCdlZXl8qQxu92urKysItueP39eqampatu2bZHLk5KSNHbs2CKfZgYAAAC4k1uGeRR1973LPdHr22+/1Y033njZIR6xsbGKjY11Tl/69CkUFhQUpIyMjPIuA8WgjzwffeTZ6B/PRx95PvroykJDQ4uc75Yr03a7XZmZmc7pzMxMBQYGFtl28+bNuuOOO9xRFgAAAHBV3BKmIyIidOLECaWnpysvL0/JycmKiooq1C4nJ0d79+4tchkAAADgadwyzMNqtSo+Pl4JCQlyOByKjo5WeHi4Vq1aJUmKi4uTJG3btk0tW7aUr6+vO8oCAAAArkqFf5w4Y6aLxxgoz0cfeT76yLPRP56PPvJ89NGVleuYaQAAAOBaRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmOSWx4lfi+rUqVPeJVxTjh07VurbpI9KV1n0EQAAFR1XpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCSbu3aUmpqqRYsWyeFwKCYmRl27di3UZs+ePVq8eLHy8/MVEBCgqVOnuqs8AAAA4E9zS5h2OBxasGCBJkyYILvdrnHjxikqKkphYWHONmfOnNH8+fP19NNPKygoSL///rs7SgMAAABMc8swj7S0NIWEhCg4OFg2m03t27dXSkqKS5tNmzbptttuU1BQkCSpWrVq7igNAAAAMM0tV6azsrJkt9ud03a7Xfv27XNpc+LECeXl5WnKlCk6e/asOnfurI4dO7qjPAAAAMAUt4RpwzAKzbNYLC7T+fn5OnDggCZOnKjc3FxNmDBBjRo1UmhoqEu7pKQkJSUlSZISExOdV7JRsdGPnu967iObzXZdv35PR/94PvrI89FH5rklTNvtdmVmZjqnMzMzFRgYWKhNQECAfH195evrq6ZNm+rQoUOFwnRsbKxiY2Od0xkZGWVbPNyCfvR813MfBQUFXdev39PRP56PPvJ89NGV/TGTFnDLmOmIiAidOHFC6enpysvLU3JysqKiolzaREVF6YcfflB+fr7Onz+vtLQ01alTxx3lAQAAAKa45cq01WpVfHy8EhIS5HA4FB0drfDwcK1atUqSFBcXp7CwMLVq1UpPPvmkvLy89Ne//lV169Z1R3kAAACAKRajqAHNFcjx48fLZb9cNS9dx44dK/Vt0kelqyz6qKLg40/PRv94PvrI89FHV1auwzwAAACAaxFhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAk2zu2lFqaqoWLVokh8OhmJgYde3a1WX5nj17NH36dNWqVUuSdNttt+mBBx5wV3kAgD+oU6dOeZdwTTl27Fh5lwCgDLglTDscDi1YsEATJkyQ3W7XuHHjFBUVpbCwMJd2TZs21dixY91REgAAAHDV3DLMIy0tTSEhIQoODpbNZlP79u2VkpLijl0DAAAAZcYtV6azsrJkt9ud03a7Xfv27SvU7qefftLo0aMVGBio3r17Kzw8vFCbpKQkJSUlSZISExMVFBRUdoXDbehHz3c995HNZruuXz9Kx/V8DHEOeT76yDy3hGnDMArNs1gsLtP169fXa6+9Jl9fX23fvl0zZszQ7NmzC60XGxur2NhY53RGRkbpFwy3ox893/XcR0FBQdf160fpuJ6PIc4hz0cfXVloaGiR890yzMNutyszM9M5nZmZqcDAQJc2fn5+8vX1lSRFRkYqPz9f2dnZ7igPAAAAMMUtYToiIkInTpxQenq68vLylJycrKioKJc2v/32m/MKdlpamhwOhwICAtxRHgAAAGCKW4Z5WK1WxcfHKyEhQQ6HQ9HR0QoPD9eqVaskSXFxcdq6datWrVolq9Uqb29vPf7444WGggAAAACexG33mY6MjFRkZKTLvLi4OOfPnTp1UqdOndxVDgAAAHDVeAIiAAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYJKtvAsAAAC4VtWpU6e8S7imHDt2rLxLKIQr0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCQeJw6g3PCY3dLliY/ZBYBrnduuTKempmrEiBF67LHHtHz58su2S0tLU/fu3bV161Z3lQYAAACY4pYw7XA4tGDBAo0fP14vvviiNm/erKNHjxbZ7p133lGrVq3cURYAAABwVdwSptPS0hQSEqLg4GDZbDa1b99eKSkphdp98cUXuu2221S1alV3lAUAAABclRKF6QsXLui9997TsGHD1KdPH0nSd999p5UrV5ZoJ1lZWbLb7c5pu92urKysQm22bdumuLi4ktYOAAAAlKsSfQFxyZIlysrK0vDhw/Xcc89JksLDw7VkyRJ16tTpiusbhlFonsVicZlevHixevbsKS+v4vN9UlKSkpKSJEmJiYkKCgoqyUuAh6MfPR995PnoI892PfePzWa7rl8/So8nHkclCtPbtm3T7Nmz5evr6wzBNWrUKHR1+XLsdrsyMzOd05mZmQoMDHRp8/PPP+vll1+WJGVnZ2vHjh3y8vJSmzZtXNrFxsYqNjbWOZ2RkVGiGuDZ6EfPRx95PvrIs13P/RMUFHRdv36UnvI8jkJDQ4ucX6IwbbPZ5HA4XOZlZ2crICCgRDuPiIjQiRMnlJ6erho1aig5OVnDhw93afPqq6+6/Ny6detCQRoAAADwJCUK023bttWcOXPUt29fSdKpU6e0ePFitW/fvkQ7sVqtio+PV0JCghwOh6KjoxUeHq5Vq1ZJEuOkAQAAUCFZjKIGNP9BXl6eli5dqq+++kq5ubny9vZWTEyMevXqJZutfJ/7cvz48XLZLw+bKF1l8bAJ+qh00Ueer7T7iP4pXdfzQ3Wu52EenEelqzzPI9PDPBwOhz766CP17NlTffv2dQ7v+OMXCAEAAIDrzRVvjefl5aUvv/xSVqtVklS1alWCNAAAAKAS3me6Y8eOWr16dVnXAgAAAFQoJRrwnJaWppUrV+qzzz6T3W53uTI9derUMisOAAAA8GQlCtMxMTGKiYkp61oAAACACqVEYfrOO+8s4zIAAACAiqfE97Vbu3atNmzYoKysLNWoUUMdOnRQdHR0WdYGAAAAeLQShemPP/5Y69ev13333ee8V+Rnn32mU6dO6R//+EdZ1wgAAAB4pBKF6a+++kpTpkxRzZo1nfNatmypyZMnE6YBAABw3SrRrfHOnz+vqlWruswLCAhQbm5umRQFAAAAVAQlCtOtWrXS7Nmzdfz4ceXm5urYsWOaM2eOWrZsWdb1AQAAAB6rRMM84uPjtXDhQo0ePVp5eXmy2Wxq166d+vXrV9b1AQAAAB6rRGHaz89Pw4YN05AhQ/S///1PAQEB8vIq0UVtAAAA4JpVokS8fv16HTp0SF5eXqpWrZq8vLx08OBBbdiwoazrAwAAADxWicL0Bx98ILvd7jIvKChI77//fpkUBQAAAFQEJQrTZ8+elZ+fn8s8Pz8/nTlzpkyKAgAAACqCEoXpsLAwbd261WXetm3bFBYWViZFAQAAABVBib6A2LNnTz3//PNKTk5WSEiITp48qV27dmncuHFlXR8AAADgsUoUpps0aaJZs2Zp06ZNysjIUMOGDdW3b18FBQWVdX0AAACAxypRmJYufuGwa9eukqTTp0/L39+/rGoCAAAAKoRiw/T69etVrVo1tWrVSpK0f/9+zZgxQ1lZWQoJCdGYMWMUGhrqjjoBAAAAj1PsFxA///xzVa9e3Tk9d+5c3XzzzZo5c6Zuvvlmvf3222VdHwAAAOCxig3TGRkZqlu3rvPnI0eO6OGHH1Z4eLh69uyptLQ0txQJAAAAeKJiw7SXl5fy8vIkST/99JNCQ0OdY6V9fHyUm5tb9hUCAAAAHqrYMN2sWTO9//77OnTokL744gu1bt3auezYsWMuQ0AAAACA602xYbpfv346cOCAJk6cKB8fH+fdPCRpw4YNatmyZVnXBwAAAHisYu/mUaNGDU2ePLnIZT179iyTggAAAICKokSPEwcAAABQGGEaAAAAMIkwDQAAAJhEmAYAAABMMh2mDcPQ3r17S7MWAAAAoEIxHabz8vI0derU0qwFAAAAqFCKvTXe+vXrL7us4MmIAAAAwPWq2DD92muvqUGDBqpUqVKhZYZhlFlRAAAAQEVQbJiuXbu2evbsqebNmxdalpubq969e5dZYQAAAICnK3bMdLNmzXT8+PGiV/TyUrNmzcqkKAAAAKAiKPbK9KOPPnr5FW22yz5qHAAAALgeFBumf/vtN1WvXr1UdpSamqpFixbJ4XAoJiZGXbt2dVmekpKiDz74QBaLRVarVX379lWTJk1KZd8AAABAWSh2mMeIESNcpmfOnGlqJw6HQwsWLND48eP14osvavPmzTp69KhLm5tvvlkzZszQjBkzNHjwYM2dO9fUvgAAAAB3KTZM//GOHXv27DG1k7S0NIWEhCg4OFg2m03t27dXSkqKSxtfX19ZLBZJ0vnz550/AwAAAJ6q2GEepRVos7KyZLfbndN2u1379u0r1G7btm1699139fvvv2vcuHFFbispKUlJSUmSpMTERAUFBZVKjShf9KPno488H33k2a7n/rHZbNf160fp8cTjqNgwnZ+fr927dzunHQ6Hy7SkIm+b90dF3ZO6qKDepk0btWnTRnv37tUHH3ygiRMnFmoTGxur2NhY53RGRsYV9w/PRz96PvrI89FHnu167p+goKDr+vWj9JTncRQaGlrk/GLDdLVq1fT66687p/39/V2mLRaL5syZc8Wd2+12ZWZmOqczMzMVGBh42fbNmjXTq6++quzsbFWtWvWK2wcAAADKQ7Fh+tVXXy2VnUREROjEiRNKT09XjRo1lJycrOHDh7u0OXnypIKDg2WxWLR//37l5eUpICCgVPYPAAAAlIViw3RpsVqtio+PV0JCghwOh6KjoxUeHq5Vq1ZJkuLi4rR161Zt2LBBVqtV3t7eGjlyJF9CBAAAgEdzS5iWpMjISEVGRrrMi4uLc/7ctWvXQveeBgAAADxZsbfGAwAAAHB5hGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAk2zlXQAAADCnTp065V3CNeXYsWPlXQIqIK5MAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJJu7dpSamqpFixbJ4XAoJiZGXbt2dVm+ceNGffrpp5IkX19fDRgwQPXq1XNXeQAAAMCf5pYr0w6HQwsWLND48eP14osvavPmzTp69KhLm1q1amnKlCmaOXOmunXrpjfffNMdpQEAAACmuSVMp6WlKSQkRMHBwbLZbGrfvr1SUlJc2tx4443y9/eXJDVq1EiZmZnuKA0AAAAwzS1hOisrS3a73Tltt9uVlZV12fZr1qzRLbfc4o7SAAAAANPcMmbaMIxC8ywWS5Ftd+/erbVr1+rf//53kcuTkpKUlJQkSUpMTFRQUFDpFYpyQz96PvrI89FHno3+8Xz0kefzxD5yS5i22+0uwzYyMzMVGBhYqN2hQ4f0xhtvaNy4cQoICChyW7GxsYqNjXVOZ2RklH7BcDv60fPRR56PPvJs9I/no488X3n2UWhoaJHz3TLMIyIiQidOnFB6erry8vKUnJysqKgolzYZGRmaOXOmhg0bdtliAQAAAE/ilivTVqtV8fHxSkhIkMPhUHR0tMLDw7Vq1SpJUlxcnP7zn//o9OnTmj9/vnOdxMREd5QHAAAAmGIxihrQXIEcP368XPZbp06dctnvterYsWOlvk36qHTRR56vtPuI/ildnEOejz7yfGXRRyVVrsM8AAAAgGsRYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJNs7tpRamqqFi1aJIfDoZiYGHXt2tVl+bFjx/Taa6/pwIED6tGjh7p06eKu0gAAAABT3BKmHQ6HFixYoAkTJshut2vcuHGKiopSWFiYs42/v7/69eunlJQUd5QEAAAAXDW3DPNIS0tTSEiIgoODZbPZ1L59+0KhuVq1amrYsKGsVqs7SgIAAACumluuTGdlZclutzun7Xa79u3bZ2pbSUlJSkpKkiQlJiYqKCioVGpE+aIfPR995PnoI89G/3g++sjzeWIfuSVMG4ZRaJ7FYjG1rdjYWMXGxjqnMzIyTNcFz0E/ej76yPPRR56N/vF89JHnK88+Cg0NLXK+W4Z52O12ZWZmOqczMzMVGBjojl0DAAAAZcYtYToiIkInTpxQenq68vLylJycrKioKHfsGgAAACgzbhnmYbVaFR8fr4SEBDkcDkVHRys8PFyrVq2SJMXFxem3337T2LFjdfbsWVksFq1YsUIvvPCC/Pz83FEiAAAA8Ke57T7TkZGRioyMdJkXFxfn/Ll69eqaO3euu8oBAAAArhpPQAQAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCTCNAAAAGASYRoAAAAwiTANAAAAmESYBgAAAEwiTAMAAAAmEaYBAAAAkwjTAAAAgEmEaQAAAMAkwjQAAABgEmEaAAAAMIkwDQAAAJhEmAYAAABMIkwDAAAAJhGmAQAAAJMI0wAAAIBJhGkAAADAJMI0AAAAYBJhGgAAADCJMA0AAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwCSbu3aUmpqqRYsWyeFwKCYmRl27dnVZbhiGFi1apB07dsjHx0dDhgxRgwYN3FUeAAAA8Ke55cq0w+HQggULNH78eL344ovavHmzjh496tJmx44dOnnypGbPnq1HH31U8+fPd0dpAAAAgGluCdNpaWkKCQlRcHCwbDab2rdvr5SUFJc233zzjTp06CCLxaLGjRvrzJkzOnXqlDvKAwAAAExxS5jOysqS3W53TtvtdmVlZRVqExQUVGwbAAAAwJO4Zcy0YRiF5lkslj/dRpKSkpKUlJQkSUpMTFRoaGgpVfnnFFUvPAt95PnoI89G/3g++sjz0UfXPrdcmbbb7crMzHROZ2ZmKjAwsFCbjIyMYttIUmxsrBITE5WYmFh2BV9Dxo4dW94l4AroI89HH3k2+sfz0Ueejz4yzy1hOiIiQidOnFB6erry8vKUnJysqKgolzZRUVHasGGDDMPQTz/9JD8/vyLDNAAAAOAp3DLMw2q1Kj4+XgkJCXI4HIqOjlZ4eLhWrVolSYqLi9Mtt9yi7du3a/jw4fL29taQIUPcURoAAABgmtvuMx0ZGanIyEiXeXFxcc6fLRaLBgwY4K5yrhuxsbHlXQKugD7yfPSRZ6N/PB995PnoI/MsBiPjAQAAAFN4nDgAAABgktuGeVxvunfvrrp160qSvLy8FB8frxtvvLHUtv/qq6+qdevWatu2rebOnat7771XYWFhV73d77//XvPmzZPValVCQoK8vb2LbJeQkKDffvtN+fn5atKkiQYMGCAvLy99/vnn+uqrr2S1WlW1alUNHjxYNWvWvOq6Ssul/SJJt99+e6FH21+toUOH6vnnn1fVqlU1YcIEPfvss1e1vXXr1unnn39W//79Cy3bsmWLli1bpurVq2vy5MlFrp+bm6vJkycrLy9P+fn5atu2rR588EFJ0ttvv61vv/1WNptNwcHBGjJkiKpUqXJV9ZaminoeTZkyRb1791ZERIRycnK0cOFC/fjjj5KkG2+8UfHx8fLz87vq/ZSXa+08unRfmZmZWrBggY4ePSrDMBQZGanevXvLZquYvy6vhXOogGEY+vjjj7V+/XpZLBbVqFFD8fHxCg8Pv+r9udu1fA4VyMvL09KlS/Xtt9/KYrEoLCxM/fv3d3nuyLWiYv7vUAF4e3trxowZkqTU1FS9++67mjp1apnsa9CgQaW2rY0bN+q+++5TdHR0se1GjhwpPz8/GYahWbNmacuWLbr99ttVr149JSYmysfHR6tWrdLSpUs1cuTIUqvval3aL+5wtf95XcmaNWvUv39/NW/e/LJtKlWqpMmTJ8vX11d5eXmaNGmSWrVqpcaNG6tFixZ66KGHZLVatXTpUn3yySfq1atXmdb8Z1TU8+hSr7/+usLDwzVs2DBJ0rJlyzR37lyNGjWqTPbnDtfaeVTAMAzNnDlTcXFxeuqpp+RwOPTGG2/ovffeU+/evd1SQ2m7Fs6hAl9++aV++uknzZgxQz4+Pvruu+80ffp0zZo167IXfjzVtXoOXerdd9/V2bNn9fLLL8vLy0tr167VzJkz9dxzzxX5HJGKjDDtBmfPnnVe7Tt37pymT5+uM2fOKC8vTz169NCtt96qc+fO6cUXX1RWVpYcDoe6deum9u3ba//+/VqyZInOnTunqlWrasiQIYVuGXjpX/C9e/dW586dtX37dnl7e2v06NGqXr26srOz9eabbzrv992nTx81adLEZTtfffWVtmzZou+++067du1STEyMli1bJn9/fx0/flxNmzZ1XoEuuKqWn5+vvLw854lxaahr1KiRNm7cWGbva2lKTU3V4sWLFRAQoPr16ys9PV1jx47VsmXL5Ovrqy5dukiSnnjiCY0ZM0a1atXS9OnTlZmZqQsXLqhz585Ffnmjd+/eevvtt/XBBx/om2++kSRlZ2erZcuWGjJkiDZs2KAvvvhCeXl5atSokfP9Xbt2rZYvX67q1aurdu3aqlSpUqFt/+c//9EPP/yg9PR0RUVFKTw8XNu2bdOFCxeUnp6uO+64Q//85z9lsVjk6+sr6WJ/5efnO/urZcuWzu01btxYW7duLfX3trRUlPPoUidPntT+/ftd/qB84IEH9Nhjj+nkyZPKzMws8hyTLobw/fv3S5Kio6N17733lur7WRYq4nl0qd27d8vb29t5McHLy0t9+vTRsGHD9OCDD2rLli1FnmOXO+48TUU8hy716aefavLkyfLx8ZF08f+vxo0ba9OmTfrrX/+q3r1766677tKePXtUpUoVPf7446patapWrFih1atXy2q1KiwsTI8//njpvamlrKKfQwXOnz+vdevWac6cOfLyujiiODo6WmvXrtXu3bsVHBys5557Tg0bNtTBgwdVu3ZtDRs2TD4+PnrnnXf0zTffyGq1qkWLFnr44YdL6d0tO4TpMpKbm6vRo0frwoULOnXqlPMj+EqVKunJJ5+Un5+fsrOz9fTTTysqKkqpqakKDAzUuHHjJEk5OTnKy8vTwoUL9dRTT6lq1apKTk7We++9V+xtA8+fP69GjRrpX//6l5YuXaqvvvpK3bp106JFi3TvvfeqSZMmysjIUEJCgl588UWXdWNiYvTDDz84P7Lbs2eP0tLS9MILL6hmzZpKSEjQtm3b1LZtW0kXh3qkpaWpVatWznmXWrNmjVq1alVK72jpKOiXAvfff7+ioqL0xhtvaNKkSQoJCSn0vlzOkCFD5O/vr9zcXI0bN0633XabAgICimzbvXt3de/eXTk5OZo0aZI6deqko0ePKjk5Wc8884xsNpvmz5+vjRs3qkWLFlq2bJmmTZsmPz8/TZ06VfXq1Su0zQceeEC7d+92/vJat26d0tLSNGvWLPn4+GjcuHGKjIxURESEHA6HxowZo5MnT+pvf/ubGjVqVGh7a9as8bgAUBHPo0sdPXpU9erVc/4ykS4GtHr16uno0aOqXLlykedYrVq1lJWVpVmzZkmSzpw5UxpvZ6m5ls6jSx05ckT169d3mefn56egoCCdPHlSkoo8x3799ddCx52nqOjnUIGcnBydO3dOISEhLvMjIiJ05MgR5z7r16+vhx9+WP/5z3/04Ycfqn///vr00081Z84cVapUyWPOpWv1HCpw8uRJBQUFFRrO1qBBAx05ckTBwcE6fvy4Bg0apCZNmui1117Tl19+qb/+9a/atm2bXnrpJVksFo/pryshTJeRSz/C+emnnzRnzhzNmjVLhmHovffe0/fffy+LxaKsrCz9/vvvqlu3rt5++20tXbpUrVu3VtOmTXX48GEdOXJEzzzzjCTJ4XBc8UE2NptNrVu3lnTxoN25c6ckadeuXTp69KizXU5Ojs6ePavKlSsXu72GDRsqODhY0sUxXT/88IMzOD/99NPKzc3V7NmztXv3brVo0cK53oYNG7R//35NmTLlT7xrZa+oj9YOHjyoWrVqqXbt2pKkDh06OB9ZX5wVK1YoJSVFkpSRkaETJ05c9j8w6eJHyLNnz9Y999yjBg0aaOXKlTpw4IDzl1Zubq6qVq2qffv26aabbnKOPWvXrp1OnDhRotfXokULZw1t2rTRDz/8oIiICHl5eWnGjBk6c+aMZs6cqcOHD7uM1/v4449ltVr1l7/8pUT7cZeKfh4ZhlHkx5mX3kSpqHOsefPmSk9P18KFCxUZGelybnmCa/k8ulx/Fcwv6hy75ZZbCh13nqKin0NXcmnfWCwW5wWBv/zlL5o5c6YkqW7dupo9e7ZuvfVWtWnTxtR+Stu1fA4V7ONyQzkK5tvtduenEh06dNCKFSt0zz33yNvbW3PnzlVkZKTzGPJ0hGk3aNy4sf73v/8pOztbO3bsUHZ2thITE2Wz2TR06FDl5uYqNDRU06ZN0/bt2/Xuu++qZcuWatOmjcLCwpSQkFDifVmtVueB6uXlpfz8fEkXD+yivlBY8EXCiIgIU+PdvL29FRUVpZSUFOcv/J07d+qTTz7RlClTSvyRkKeyWq0uwSc3N1eStGfPHu3atUvPPvusfHx8NGXKFF24cKHYbX344YeqUaOG8yNkwzDUsWNHPfTQQy7ttm3bVuT6BVeXpYtPDO3evfsV6//jf2ZVqlRRs2bNlJqa6gzT69at07fffqtJkyZ59Di2ingehYeH68CBA3I4HM6r0w6HQ4cOHVJYWJjzo+4/8vf314wZM5SamqqVK1cqOTm5Qj/IqqKcR2FhYfr6669d2ufk5CgzM1PBwcHOYTeXslgsRR53DzzwQLGvozxUxHOogJ+fn3x9ffXLL784//iUpAMHDqhZs2ZF1lCw/3Hjxmnv3r365ptv9NFHH+mFF16Q1Wot8WvxBBXlHCoQEhKiX3/9tdAfSgcOHHAG5D/+vrFYLLJarXruuee0a9cuJScna+XKlZf9cr0n4dZ4bnDs2DE5HA4FBAQoJydH1apVk81m0+7du/Xrr79KkrKysuTt7a0OHTrovvvu0/79+xUaGqrs7Gz99NNPki5+M7bg46w/q0WLFlq5cqVz+uDBg5IuXl2eMWPGZYN0Wlqa0tPT5XA4tGXLFjVp0kTnzp3TqVOnJF0cg7tjxw7VqVNH0sUTZd68eXrqqadUrVo1U7W6W2hoqNLT050f427atMm5rGbNmjpw4IAkaf/+/UpPT5d08RdslSpV5OPjo2PHjmnfvn3F7uPbb7/Vzp07FR8f75x38803a+vWrfr9998lSadPn9avv/6qRo0aae/evfrf//6nvLw85zjmgqvLM2bMuGyQ3rVrl06fPq3c3FylpKToxhtvVHZ2tvOjstzcXO3atcvZX6mpqfr00081ZswY5zhET1URz6OQkBDVr19fH3/8sXPexx9/rPr16zs/ri7qHMvOzpbD4VDbtm3Vo0cP5zHoya6F8+jmm2/W+fPntX79ekkXQ8Nbb72lO++803l+FHWOFXXceaKKeA5d6r777tOiRYucQXLnzp364YcfdMcdd0i6GAoL+nnTpk1q0qSJHA6HMjIy1Lx5c/Xq1cs5XMQTXQvnUAFfX1917NhRS5YskcPhkCStX79e58+fd363KiMjw3lMFfTXuXPnlJOTo8jISPXt29d5fHg6rkyXkT+Ohxo6dKi8vLx0xx13aNq0aRo7dqzq1avnDDWHDx/W0qVLZbFYZLPZNGDAANlsNj3xxBNatGiRcnJylJ+fr86dO5u6DVC/fv20YMECPfnkk8rPz1fTpk316KOPXnG9xo0b65133tHhw4fVtGlTtWnTRtnZ2Zo+fbouXLggh8Oh5s2b66677pIkLV26VOfOndMLL7wgSQoKCnL+BesJ/tgvrVq1Us+ePTVw4EAlJiYqICBATZo0cf6iaNu2rTZs2KDRo0crIiJCoaGhzvVWr16tJ598UqGhoUWOQb7U559/rlOnTjk/Riv4a75Hjx569tlnZRiGrFar+vfvr8aNG+uf//ynJkyYoOrVq6t+/frO/4yu5MYbb9Qrr7yikydP6o477lBERIQOHTqkV199VQ6HQ4ZhqF27ds4rAwsWLFBeXp7z49tGjRqV6Lhwl2vhPBo0aJAWLlyoxx57TNLF93jw4MHO5UWdY4cPH9brr7/u7Pc/XjEqb9fqeWSxWPTkk09q/vz5+uijj2QYhm655Rb961//crYp6hxLTU0tdNx5iop8DiUmJjqvIDdu3FgjR47UmTNn9MQTT8jLy0vVq1fXU0895bzK7ePjoyNHjmjMmDHy8/PTyJEj5XA49MorrzjHsd9zzz0ecfvPa/EcGj16tPNqc7t27fTQQw/p7bff1ogRI5yf4Dz55JPONnXq1NG6dev05ptvKiQkRHFxccrJyXHmC8Mw1KdPH/NvshvxBERc1p49e/R///d/Gjt2bHmX4lYV9XUXdw9QeKaKeqyVxLX42jjHPFvBHSuuFdfiOVQgPT1d06ZNc37JuqJjmAcAAABgElemAQAAAJO4Mg0AAACYRJgGAAAATCJMAwAAACYRpgGggktPT9eDDz7ofDBGcdatW6eJEye6oSoAuD5wn2kAcKOhQ4cqKytLb7zxhvMxvdLFe7QeOnRIc+bMUa1atdxe1/fff6/nnnvOOX3+/HmXB/m8+OKLCgoKcntdAODpCNMA4Ga1atXS5s2bdffdd0u6+KCMgqe6lZemTZs679Gbnp6uYcOGafHixRXuscsA4G6EaQBwsw4dOmjDhg3OML1u3Tp17NhR77//vrNNTk6OFi5cqB07dsjHx0cxMTG6//775eXlJYfDoaVLl2r9+vWqXLmy7r33Xpft5+TkaMmSJdqxY4csFouio6P14IMPysvrz4/sS0tL07Rp0zR37lxnsN66das++ugjzZgxQ8uWLdORI0fk5eWlHTt2qHbt2ho8eLDq1asn6eLjqRcuXKjvv/9evr6+uueee9S5c2eT7xwAeB7GTAOAmzVq1Eg5OTk6evSoHA6HtmzZor/85S8ubRYuXKicnBzNmTNHU6ZM0YYNG7Ru3TpJUlJSkrZv365p06YpMTFRX3/9tcu6c+bMkdVq1ezZszV9+nR99913+uqrr0zV2rBhQ/n7+2vnzp3OeRs3blSHDh2c0998843atWunhQsX6vbbb9eMGTOUl5cnh8OhadOmqV69enrjjTc0adIkrVixQqmpqaZqAQBPRJgGgHJQcHV6586dCg0NVY0aNZzLHA6HkpOT9dBDD6ly5cqqVauW7r33Xm3YsEGStGXLFnXu3FlBQUHy9/dX165dnev+9ttvSk1NVd++feXr66tq1arpnnvuUXJysulaO3bsqI0bN0qSTp8+re+++0533HGHc3mDBg3Utm1b2Ww23Xvvvbpw4YL27dunn3/+WdnZ2XrggQdks9kUHBysmJiYq6oFADwNwzwAoBx06NBBkydPVnp6ujp27OiyLDs7W3l5eS5f+KtZs6aysrIkSadOnSq0rEBGRoby8/P16KOPOucZhiG73X5VtY4cOVLnzp1TcnKymjZtqsDAQOfyS7ft5eUlu92uU6dOOWvt27evc7nD4VDTpk1N1wIAnoYwDQDloGbNmqpVq5Z27NihQYMGuSyrWrWqrFarMjIyFBYWJuliSC64eh0YGKiMjAxn+0t/ttvtstlsWrBgQal9ebBGjRpq3Lixtm3bpo0bN+quu+5yWZ6Zmen82eFwKDMzU4GBgbJarapVq5Zmz55dKnUAgCdimAcAlJNBgwZp0qRJ8vX1dZnv5eWldu3a6b333tPZs2f166+/6vPPP3eOq27Xrp2++OILZWZm6vTp01q+fLlz3cDAQLVs2VJvvfWWcnJy5HA4dPLkSe3du/eqau3QoYM+/fRTHT58WG3atHFZtn//fn399dfKz8/XihUrVKlSJTVq1EgNGzZU5cqVtXz5cuXm5srhcOjw4cNKS0u7qloAwJNwZRoAyklISMhll8XHx2vhwoUaNmyYvL29FRMTo+joaElSTEyMjh8/rtGjR6ty5cq67777tHv3bue6w4YN0zvvvKNRo0bp7NmzCg4O1t///verqrVNmzaaP3++br311kLhPyoqSsnJyXr11VcVEhKiJ554QjbbxV8vY8aM0VtvvaWhQ4cqLy9PoaGh6t69+1XVAgCexGIYhlHeRQAAPN9jjz2mRx55RC1atHDOW7ZsmU6ePKnhw4eXY2UAUH4Y5gEAuKKtW7dKkpo3b17OlQCAZ2GYBwCgWFOmTNHRo0c1bNgwUw9+AYBrGcM8AAAAAJO4xAAAAACYRJgGAAAATCJMAwAAACYRpgEAAACTCNMAAACASYRpAAAAwKT/B1lNXwzHyOCdAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 864x432 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "x = [f1_score, e_f1_score, qi_f1_score, qi_e_f1_score, ql_f1_score, ql_e_f1_score]\n",
+    "y = ['Baseline-fp32', 'Equalized-fp32', 'Baseline-IOps', 'Equalized-IOps', 'Baseline-LOps', 'Equalized-LOps']\n",
+    "title = \"MobileNetV2 F1 Score Results\"\n",
+    "x_label = \"Model Type\"\n",
+    "y_label = \"F1 Score\"\n",
+    "    \n",
+    "plot_statistic(x, y, title, x_label, y_label)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6e. Model Size"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below, with and without equalization, we see that model sizes are reduced by quantization. The size reduction is similar between IntegerOps and QLinearOps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model sizes are below.\n",
+      "\n",
+      "\t\tBaseline\tEqualized\n",
+      "float32 \t14.186708\t14.258113\n",
+      "IntegerOps\t7.648918\t7.751473\n",
+      "QLinearOps\t7.646638\t7.724481\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Model sizes are below.\\n')\n",
+    "\n",
+    "simple_table(\n",
+    "    data_multilist = [[onnx_size_mb,    e_onnx_size_mb   ] ,\n",
+    "                      [qi_onnx_size_mb, qi_e_onnx_size_mb] ,\n",
+    "                      [ql_onnx_size_mb, ql_e_onnx_size_mb]],\n",
+    "    x_label_list = [\"Baseline\", \"Equalized\"],\n",
+    "    y_label_list = [\"float32 \", \"IntegerOps\", \"QLinearOps\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtAAAAGHCAYAAACZNGVOAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAA7eElEQVR4nO3dd3QU9f7/8dcmMY0SQkKAJCItoQpSpSYCAZVyLXgBkSYoXa+ASLleylE0lIgiKArS1Qv3SlEu6tdQEqrU0FUwtAgYQughhGT39weH/RFTyJBkdwLPxzmck5357Mx757NDXvnsZ2csNpvNJgAAAAB54uLsAgAAAICihAANAAAAGECABgAAAAwgQAMAAAAGEKABAAAAAwjQAAAAgAEEaAD3vT59+igiIiLXNhMmTFDVqlXtjxcsWCA3N7fCLu2BtWHDBlksFiUkJOT5OQXVJ3/tawAwigANwFT69Okji8Wizp07Z1m3cuVKWSyWQgm2b775prZt25avbSxYsEAWi0UNGjSQ1WrNtO6JJ57QK6+8Ymh7VatW1YQJE+yP9+zZI4vFojVr1mTbPioqSsWKFdOlS5e0ceNGde7cWcHBwfLy8lJISIgmTJigGzdu5LrPCRMm2F/DX+3du1cWi8Vw8HWk69ev61//+pdCQkLk5eUlPz8/NWrUSDNmzLC3KYi+BvBgI0ADMJ0KFSrou+++059//plp+eeff65HHnmkUPZZvHhx+fv753s7FotFBw8e1KJFiwqgqszq1aunRo0aac6cOdmunzt3rrp27SofHx9t3rxZVapU0VdffaVDhw4pMjJSs2bN0htvvHHX/ZQpU0aHDx/W7t27My3/7LPPCu34F5RBgwZp0aJFmjp1qg4dOqR169ZpyJAhunjxor1NQfU1gAcXARqA6YSEhKhJkyZasGCBfdnJkyf1008/6eWXX87Sfs2aNWrQoIE8PDwUEBCgwYMH69q1a1naffDBBwoKCpK3t7c6d+6spKQk+7q8fKy/a9cutWvXTsWLF1eZMmX0/PPP68SJE5nauLi46I033tA///nPbGu408cff6zq1avL09NTISEhmjRpktLT0yXdGrH+/fffNXHiRPuo7/HjxzVgwACtXr1aZ8+ezbStjRs36pdfflH//v0lSaNHj9aUKVMUFhamSpUqqXPnzho9erSWLVuWa02SVLJkSb3wwguZgnpKSoq++uor9evXL0v7bdu2KSwsTF5eXvL19VX37t2VmJiY5bUGBwfL29tbTz75pE6ePJllO3k5vnezcuVKjRw5Us8++6wqVaqkunXrqk+fPho3bpy9zV/7+vbx/eu/48ePS5KuXr2qf/zjH/b3Tr169bR8+XJDdQG4vxCgAZhS//79NXfuXNlsNkm3RlfbtGmTZQR03759+tvf/qawsDDFxcVp4cKFWr16tQYOHJip3fbt27Vhwwb98MMPWrNmjfbt26e+ffvmuZ5Dhw4pPDxcTZs21c6dO7Vu3Tq5urqqbdu2Sk1NzdR27NixSk9P15QpU3Lc3oQJEzRt2jS9//77Onz4sD766CN99tlnmjhxoiRp+fLlqlixokaMGKEzZ87ozJkzevjhh9WtWzd5e3tr/vz5mbY3Z84cPfroo2rSpEmO+7x06VKeR1779++vr776yv5HwL///W+VL19eLVu2zNTu7NmzateunYKDg7V9+3Z99913OnDgQKYpOKtWrdKwYcM0fPhwxcXFqUuXLho5cmSm7Rg5vrkpX768fvjhByUnJ+f5ObeP75kzZ3T69GlFRESoRo0aKlu2rGw2mzp16qS9e/dq6dKlOnDggAYNGqRu3bpp7dq1ed4HgPuMDQBMpHfv3rY2bdrYrl+/bitdurRt3bp1tvT0dFtQUJDtm2++sc2fP9/m6upqb9+jRw9bo0aNMm1j5cqVNovFYjt+/Lh9m8WKFbNdvHjR3ubHH3+0SbL99ttvNpvNZhs/frytSpUq9vV/3U/v3r1tXbt2zbSf1NRUm5eXl23FihVZnjN79mybt7e37dSpUzabzWYLDw+39evXz2az2WzXrl2zeXl52b7//vtM21u4cKHNx8fH/rhKlSq28ePHZzlGgwYNslWuXNlmtVptNpvNduHCBZuXl5ft448/zuGo2myHDh2ylShRItc2fz0ONWvWtM2bN89ms9lsjz/+uC0qKsq2fv16myT763r77bdtQUFBths3bti3ERcXZ5Nki4mJsdlsNlvz5s1t3bt3z7SfESNGZNqO0eObk02bNtkqVKhgc3FxsT366KO2V1991bZy5Ur7sfrra/yrsWPH2gICAmzx8fE2m81mW79+vc3DwyPTe8dms9lefvll2zPPPJNrLQDuX4xAAzAlT09P9ezZU3PmzNH//vc/paenq1OnTlnaHTx4UGFhYZmWhYeHy2az6dChQ/ZlNWvWlI+Pj/1x8+bNJUmHDx/OUz07duzQihUrVLx4cfs/Pz8/paam6siRI1nav/LKK6pcubLGjh2bbc3Xr19X586dM21vwIABunTpks6dO5drLQMGDFB8fLzWrVsnSVqyZIkkqUePHtm2P3LkiNq1a6du3bpp6NCheXq9kvTqq69qzpw52rdvn+Li4tSrV69sX0uTJk3k7u5uX1a3bl35+Pjo4MGDkm6NLjdr1izT81q0aJHpsdHjm5PmzZvr999/18aNG9W7d2/9+eef6ty5s/72t7/ZP83IyeLFi/XBBx9o5cqVqlSpkr2utLQ0BQUFZaptyZIlhuoCcH/hGk0ATGvAgAGqV6+eTp48qZdfflkPPfRQtu0sFouh5ffCarWqZ8+eGj16dJZ1fn5+WZa5uroqKipKTz31lF5//fUs25Kk//znPwoNDc3y3NKlS+daS926dfX444/r888/V5s2bTRnzhx16dJFpUqVytL2wIEDatu2rZ555hl9+umnuW73r3r37q0xY8Zo2LBheu6553Kc/pGX43+3vjB6fHPj5uamZs2aqVmzZhoxYoSWLFminj17KjY2VuHh4dk+Z9OmTerfv78WLFigpk2bZqrLx8dHO3bsyPKcO/9oAPBgIUADMK0aNWqoUaNG2rx5sxYuXJhtm1q1aikmJibTspiYGFksFtWsWdO+7PDhw7p8+bJKliwpSdqyZYt9H3nRsGFD7du3T1WqVMlzMG/Xrp2eeuopDR8+XC4u//8Dv1q1asnT01Px8fFq3759js93d3dXRkZGtusGDBiggQMHavXq1dq3b1+24XjHjh166qmn1KNHD3344YeG/6Dw9fXVCy+8oCVLluQ437dWrVqaP3++0tLS7IFy7969unTpkmrVqiXp1uj/5s2bNXjwYPvzNm/enGk793J88+p2H//1i423xcfH67nnntPbb7+trl27Zqnr4sWLSk1NVe3atQu0LgBFF1M4AJjajz/+qKSkJFWpUiXb9SNHjtTu3bs1fPhw/fLLL/rhhx/02muv6aWXXlKFChXs7SwWi3r16qUDBw4oNjZWQ4YMUYcOHRQSEpKnOsaOHavDhw+rR48e2r59u44dO6b169frH//4h+Lj43N8XlRUlLZu3art27fblxUvXlxjx47V2LFjNXPmTP366686ePCg/v3vf2vUqFH2dpUqVdLmzZt18uRJJSUlZbq2dNeuXeXl5aVevXqpVq1aWaZIxMbGqk2bNnrmmWc0ZswY/fnnnzp79myWq3fczZw5c3Tu3Dm1bt062/VDhw7V5cuX1adPHx04cECbNm1Sz5491aJFC/sXDkeMGKGlS5fqo48+0pEjRzR//nwtXrw403bu9fj+VXh4uGbPnq2dO3fqxIkTWrt2rQYPHqxSpUqpVatWWdpfv35dHTt2VNOmTdWvXz/7MTp79qwyMjLUunVrRURE6Pnnn9eKFSsUHx+vXbt26eOPP87xcoIA7n8EaACm5u3tneuUhjp16ujbb79VTEyM6tatq549e6pDhw6aPXt2pnaNGzdWixYt1LZtWz355JP2kdO8qlGjhrZs2aKrV6/qySefVM2aNfXqq6/q+vXr2U6duPN5AwYM0PXr1zMt/9e//qXp06dr7ty5qlu3rlq0aKHp06erYsWK9jYTJ07UpUuXVK1aNZUpUybTpd+8vb3Vs2dPXbhwwX7pujvNmzdPV65c0fz581W+fPlM/4zw9PTM9codZcuW1f/93/8pISFBjRo1UseOHVW7dm1988039jbPPfecoqKiNGXKFNWpU0dffvmlJk+enOU43cvx/aunn35aX375pdq3b69q1arp5ZdfVkhIiDZv3pzt6/jzzz91+PBhfffdd1mO06lTp2SxWPTtt9/q+eef1/Dhw1W9enV16NBB//vf/3L8ow7A/c9iu9u3KgAAAADYMQINAAAAGECABgAAAAwgQAMAAAAGEKABAAAAAwjQAAAAgAEEaAAAAMCAInknwtOnTzu7BNPy9/dXUlKSs8tALugj86OPzI8+Mj/6yPzoo7sLDAzMdjkj0AAAAIABBGgAAADAAAI0AAAAYAABGgAAADCAAA0AAAAYQIAGAAAADCBAAwAAAAYQoAEAAAADCNAAAACAAQRoAAAAwAACNAAAAGAAARoAAAAwgAANAAAAGODm7AKAghIUFOTsEu4rf/zxh7NLAADAlBiBBgAAAAxwyAj0J598ot27d8vHx0dRUVGZ1n377bdasmSJ5s6dq5IlSzqinHvC6GbBYnQTAAAUVQ4ZgX7iiSc0duzYLMuTkpK0f/9++fv7O6IMAAAAIN8cEqBr1qyp4sWLZ1m+cOFCvfTSS7JYLI4oAwAAAMg3p82B3rlzp0qXLq2KFSs6qwQAAADAMKdchePGjRtavny53n777Ty1j46OVnR0tCQpMjKSKR/3AfrQ/B7kPnJzc3ugX39RQB+ZH31kfvTRvXNKgP7zzz+VmJiokSNHSpLOnz+vUaNG6f3331epUqWytI+IiFBERIT9cVJSkqNKRSGhD83vQe4jf3//B/r1FwX0kfnRR+ZHH91dYGBgtsudEqArVKiguXPn2h8PGTJE77//vqmvwgEAAABIDgrQH374oQ4dOqQrV65o4MCB6tKli1q3bu2IXQMAAAAFyiEB+o033sh1/axZsxxRBgAAAJBv3IkQAAAAMIAADQAAABhAgAYAAAAMIEADAAAABhCgAQAAAAMI0AAAAIABBGgAAADAAAI0AAAAYAABGgAAADCAAA0AAAAYQIAGAAAADCBAAwAAAAYQoAEAAAADCNAAAACAAQRoAAAAwAACNAAAAGAAARoAAAAwgAANAAAAGECABgAAAAwgQAMAAAAGEKABAAAAAwjQAAAAgAEEaAAAAMAAAjQAAABgAAEaAAAAMIAADQAAABhAgAYAAAAMIEADAAAABhCgAQAAAAMI0AAAAIABBGgAAADAAAI0AAAAYAABGgAAADCAAA0AAAAYQIAGAAAADHBzxE4++eQT7d69Wz4+PoqKipIkLV68WLt27ZKbm5vKli2rwYMHq1ixYo4oBwAAALhnDhmBfuKJJzR27NhMy+rUqaOoqChNmzZN5cuX14oVKxxRCgAAAJAvDgnQNWvWVPHixTMtq1u3rlxdXSVJoaGhSk5OdkQpAAAAQL44ZArH3axbt07NmjXLcX10dLSio6MlSZGRkfL393dUaSgk9KH5Pch95Obm9kC//qKAPjI/+sj86KN75/QAvXz5crm6uqply5Y5tomIiFBERIT9cVJSkiNKQyGiD83vQe4jf3//B/r1FwX0kfnRR+ZHH91dYGBgtsudehWODRs2aNeuXXr99ddlsVicWQoAAACQJ04L0HFxcVq1apVGjRolDw8PZ5UBAAAAGOKQKRwffvihDh06pCtXrmjgwIHq0qWLVqxYofT0dL3zzjuSpJCQEPXv398R5QAAAAD3zCEB+o033siyrHXr1o7YNQAAAFCguBMhAAAAYAABGgAAADCAAA0AAAAYQIAGAAAADCBAAwAAAAYQoAEAAAADCNAAAACAAQRoAAAAwAACNAAAAGAAARoAAAAwgAANAAAAGECABgAAAAwgQAMAAAAGEKABAAAAAwjQAAAAgAEEaAAAAMAAAjQAAABgAAEaAAAAMIAADQAAABhAgAYAAAAMIEADAAAABhCgAQAAAAMI0AAAAIABBGgAAADAAAI0AAAAYAABGgAAADCAAA0AAAAYQIAGAAAADCBAAwAAAAYQoAEAAAADCNAAAACAAQRoAAAAwAACNAAAAGAAARoAAAAwwM0RO/nkk0+0e/du+fj4KCoqSpJ09epVTZ8+XefOnVOZMmU0bNgwFS9e3BHlAAAAAPfMISPQTzzxhMaOHZtp2cqVK/Xoo49qxowZevTRR7Vy5UpHlAIAAADki0MCdM2aNbOMLu/YsUPh4eGSpPDwcO3YscMRpQAAAAD54rQ50JcuXZKvr68kydfXV5cvX3ZWKQAAAECeOWQOdH5FR0crOjpakhQZGSl/f38nV4T8og/N70HuIzc3twf69RcF9JH50UfmRx/dO6cFaB8fH124cEG+vr66cOGCSpYsmWPbiIgIRURE2B8nJSU5okQUIvrQ/B7kPvL393+gX39RQB+ZH31kfvTR3QUGBma73GlTOBo2bKiYmBhJUkxMjBo1auSsUgAAAIA8c8gI9IcffqhDhw7pypUrGjhwoLp06aJnn31W06dP17p16+Tv76/hw4c7ohQAAAAgXxwSoN94441sl48bN84RuwcAAAAKDHciBAAAAAwgQAMAAAAGEKABAAAAAwjQAAAAgAG5fokwIyNDO3fu1O7du3XixAldu3ZNxYoV0yOPPKJ69eqpUaNGcnV1dVStAAAAgNPlGKB/+uknLV++XMHBwapRo4YaNGggT09PpaamKiEhQWvXrtXChQv13HPPqV27do6sGQAAAHCaHAP0mTNn9P7776tUqVJZ1jVu3FiSdOHCBX333XeFVhwAAABgNjkG6F69et31yb6+vnlqBwAAANwvDH+J8NKlS/r555+VkJBQGPUAAAAAppbrlwiTk5M1b948JSQkKDQ0VJ06ddL48ePl4uKia9euaejQoWrevLmjagUAAACcLtcR6M8//1zFihVT7969ZbPZNGnSJA0cOFBz587V8OHDtWLFCkfVCQAAAJhCrgH6t99+06uvvqp69erplVde0aVLl9SoUSNJUqNGjXTu3DmHFAkAAACYRa4BOiMjQ25ut2Z5eHh4yNPTUxaLxSGFAQAAAGZ01xupHDhwwP7YarVmeQwAAAA8SHIN0D4+Pvr000/tj4sXL57pccmSJQuvMgAAAMCEcg3Qs2bNclQdAAAAQJFg+DrQAAAAwIMs1xHooUOH3nUDM2fOLLBiAAAAALPLNUCfP39e5cqVU1hYmKpWreqomgAAAADTyjVAf/7559q0aZNiY2MVGxursLAwtWzZUv7+/o6qDwAAADCVXAN0iRIl9PTTT+vpp59WQkKCYmNjNX78eJUrV04DBgxQQECAo+oEAAAATCHPXyIMCgpSrVq1FBoaqqNHj+rq1auFWRcAAABgSrmOQEtSQkKCNmzYoM2bNysoKEhhYWEaOHCgPDw8HFEfAAAAYCq5BujRo0frxo0batmypd555x2VLl3avu72XQhdXLgSHgAAAB4cuQboY8eOSZKWLl2qpUuXZtsmp+UAAADA/SjXAM01ngEAAIDMcg3QZcqUcVQdAAAAQJGQ4wTmhQsX6uLFi7k++eLFi1q4cGFB1wQAAACYVo4j0IGBgRozZoyCg4NVo0YNBQYGysvLS9evX9eZM2d06NAhnT59Ws8//7wj6wUAAACcKscA3bZtW7Vq1Uo7d+7Unj17tGPHDqWkpKhYsWKqUKGC2rZtqwYNGsjV1dWR9QIAAABOlescaDc3NzVp0kRNmjRxVD0AAACAqXERZwAAAMAAAjQAAABgAAEaAAAAMIAADQAAABiQ65cI75SQkKBt27bp4sWLeuWVV/THH38oPT1djzzySL4KWL16tdatWyeLxaKHH35YgwcPlru7e762CQAAABSWPI1Ab926VRMmTFBycrI2btwoSUpNTdWiRYvytfPk5GR9//33ioyMVFRUlKxWq7Zs2ZKvbQIAAACFKU8j0MuWLdPbb7+tihUrauvWrZKkRx55RMePH893AVarVWlpaXJ1dVVaWpp8fX3zvU0AAACgsOQpQF+6dCnLVA2LxSKLxZKvnZcuXVqdOnXSoEGD5O7urrp166pu3br52iYAAABQmPIUoCtXrqzY2FiFh4fbl23evFlVq1bN186vXr2qHTt2aNasWfL29tYHH3yg2NhYhYWFZWoXHR2t6OhoSVJkZKT8/f3ztV84H31ofg9yH7m5uT3Qr78ooI/Mjz4yP/ro3llsNpvtbo3++OMPvfvuuwoICNCRI0dUq1YtnT59Wm+//bbKly9/zzvfunWr4uLiNGjQIElSTEyMjhw5oldeeSXX550+ffqe93mvgoKCHL7P+9kff/xR4NukjwpWYfRRUeHv76+kpCRnl4Fc0EfmRx+ZH310d4GBgdkuz9MIdFBQkD788EPt2rVLDRo0kJ+fnxo0aCBPT898FeXv768jR47oxo0bcnd31/79+1WlSpV8bRMAAAAoTHkK0DExMXr00UfVrFmzTMs3bdqkFi1a3PPOQ0JC1KRJE40aNUqurq6qWLGiIiIi7nl7AAAAQGHLU4D+5JNP5Ovrq2HDhqlatWr25XPmzMlXgJakLl26qEuXLvnaBgAAAOAoeQrQHh4eGjhwoKZNm6Zu3bqpTZs2kqQ8TJ8GABQhfJegYD3I3yUA7md5CtAWi0WPPfaYJk6cqKlTp+rEiRPq06dPvi9jBwAAcL/hD9GCZcY/RPMUoG+PNAcGBmrSpEmaMWOG3nnnHWVkZBRqcQDuL/xSKVhm/KWCwsd5VLA4j3Av8nQr71q1atl/9vb21qhRoxQSEiIfH59CKwwAAAAwozyNQI8aNSrTY4vFou7du6t79+6FUhQAAABgVjkG6OXLl+v555+XJC1dujTHDXTt2rXgqwIAAABMKscAff78+Wx/BgAAAB5kOQboV1991f7z4MGDHVIMAAAAYHa5zoFOTU2VJPstu202m9auXatTp04pNDRUzZs3L/wKAQAAABPJ9SocH374obZv325/vHjxYn311Ve6cOGC5s+fr++++67QCwQAAADMJNcAHR8frwYNGkiS0tPTtXbtWg0fPlzDhw/X6NGjtXbtWocUCQAAAJhFrgH6xo0bKlasmCTp999/l4uLi2rXri1Jqlq1qi5cuFD4FQIAAAAmkmuALl26tE6cOCFJ2rt3r2rUqGFfd+3aNT300EOFWx0AAABgMrl+ibBTp0569913Va1aNe3du1cjRoywr9u7d68eeeSRQi8QAAAAMJNcA3Tr1q1Vrlw5/f777+rYsaOqV69uX+fu7q4XXnih0AsEAAAAzOSut/KuWbOmatasmWV5w4YNC6UgAAAAwMxynQMNAAAAIDMCNAAAAGAAARoAAAAwgAANAAAAGJDjlwjHjRsni8Vy1w1MnDixQAsCAAAAzCzHAN26dWtH1gEAAAAUCTkG6CeeeMKBZQAAAABFw12vAy1JNptNa9eu1ebNm3XlyhVNmzZNhw4d0sWLF9WsWbPCrhEAAAAwjTx9iXDp0qVav369IiIilJSUJEny8/PTqlWrCrU4AAAAwGzyFKBjYmI0atQoNW/e3P7FwoCAACUmJhZqcQAAAIDZ5ClAW61WeXp6ZlqWmpqaZRkAAABwv8tTgK5Xr54WLVqkmzdvSro1J3rp0qVq0KBBoRYHAAAAmE2eAnSvXr2UnJysPn36KCUlRb169dK5c+f00ksvFXZ9AAAAgKnk6Soc3t7eeuutt3Tx4kUlJSXJ399fpUqVKuTSAAAAAPPJMUBbrdYsy0qWLKmSJUtmWu/iwt3AAQAA8ODIMUC/+OKLedrA0qVLC6wYAAAAwOxyDNAzZ860/7x7925t27ZNzz33nPz9/ZWUlKRVq1bp8ccfd0iRAAAAgFnkGKDLlClj/3n16tWKjIxUsWLFJEmBgYGqXLmyxowZo3bt2hV+lQAAAIBJ5GkCc0pKim7cuJFpWVpamlJSUgqlKAAAAMCs8nQVjvDwcL3zzjvq0KGD/Pz8dP78eX3//fcKDw/PdwHXrl3T7NmzderUKVksFg0aNEihoaH53i4AAABQGPIUoHv06KFy5cppy5YtunDhgkqVKqUnn3xSERER+S5g/vz5euyxxzRixAilp6dnGekGAAAAzCRPAdrFxUXt2rUr8PnOKSkpOnz4sIYMGXKrGDc3ubnlqSQAAADAKSw2m82Wl4br169XbGyskpOTVbp0aYWFhalVq1b52vnx48f12WefKTg4WCdOnFDlypXVp08feXp6ZmoXHR2t6OhoSVJkZKTS0tLytd974eHh4fB93s8K45MG+qhg0UfmRx+ZH31kfvSR+TlzdoK7u3u2y/M03Lt8+XLFxMSoU6dO9svYffvtt7pw4YKef/75ey4qIyNDx44dU9++fRUSEqL58+dr5cqV6tatW6Z2ERERmaaLJCUl3fM+YQ70ofnRR+ZHH5kffWR+9JH5ObOPAgMDs12epwC9du1aTZgwIdOl7erWravx48fnK0D7+fnJz89PISEhkqQmTZpo5cqV97w9AAAAoLDl6TJ2N27csN/C+7YSJUrkeypFqVKl5Ofnp9OnT0uS9u/fr+Dg4HxtEwAAAChMeRqBfuyxxzRjxgy99NJL8vf317lz5/T111+rbt26+S6gb9++mjFjhtLT0xUQEKDBgwfne5sAAABAYclTgO7bt6/mzZunkSNHKj09XW5ubmratKlefvnlfBdQsWJFRUZG5ns7AAAAgCPkKUB7e3tr6NChGjx4sK5cuaISJUrIxSVPsz8AAACA+0quATqnbz0mJyfbf/b39y/YigAAAAATyzVA377BSW6WLl1aYMUAAAAAZpdrgK5QoYJu3ryp8PBwtWzZUqVLl3ZUXQAAAIAp5Rqgp06dqpMnTyomJkbjxo1TUFCQwsLC9Pjjj+d4ZxYAAADgfnbXbwJWqFBBPXv21MyZM9WhQwft2rVL/fv3V3x8vCPqAwAAAEwlz5fSOHv2rA4dOqQjR46oUqVKKl68eGHWBQAAAJhSrlM4rl69qk2bNikmJkapqalq2bKlJk6cyJU3AAAA8MDKNUAPGDBAAQEBatmypUJDQyXdGok+e/asvU3t2rULt0IAAADARHIN0KVKlVJaWprWrl2rtWvXZllvsVg0c+bMQisOAAAAMJtcA/SsWbMcVQcAAABQJHA/bgAAAMAAAjQAAABgAAEaAAAAMIAADQAAABhAgAYAAAAMIEADAAAABhCgAQAAAAMI0AAAAIABBGgAAADAAAI0AAAAYAABGgAAADCAAA0AAAAYQIAGAAAADCBAAwAAAAYQoAEAAAADCNAAAACAAQRoAAAAwAACNAAAAGAAARoAAAAwgAANAAAAGECABgAAAAwgQAMAAAAGEKABAAAAA0wRoK1Wq9566y1FRkY6uxQAAAAgV6YI0GvWrFFQUJCzywAAAADuyukB+vz589q9e7fatGnj7FIAAACAu3J6gF6wYIF69Oghi8Xi7FIAAACAu3Jz5s537dolHx8fVa5cWQcPHsyxXXR0tKKjoyVJkZGR8vf3d1SJKCT0ofnRR+ZHH5kffWR+9JH5mbGPnBqgf/31V+3cuVN79uxRWlqarl+/rhkzZuj111/P1C4iIkIRERH2x0lJSY4uFQWMPjQ/+sj86CPzo4/Mjz4yP2f2UWBgYLbLnRqgu3fvru7du0uSDh48qO+++y5LeAYAAADMxOlzoAEAAICixKkj0HeqVauWatWq5ewyAAAAgFwxAg0AAAAYQIAGAAAADCBAAwAAAAYQoAEAAAADCNAAAACAAQRoAAAAwAACNAAAAGAAARoAAAAwgAANAAAAGECABgAAAAwgQAMAAAAGEKABAAAAAwjQAAAAgAEEaAAAAMAAAjQAAABgAAEaAAAAMIAADQAAABhAgAYAAAAMIEADAAAABhCgAQAAAAMI0AAAAIABBGgAAADAAAI0AAAAYAABGgAAADCAAA0AAAAYQIAGAAAADCBAAwAAAAYQoAEAAAADCNAAAACAAQRoAAAAwAACNAAAAGAAARoAAAAwgAANAAAAGECABgAAAAwgQAMAAAAGuDlz50lJSZo1a5YuXrwoi8WiiIgItW/f3pklAQAAALlyaoB2dXVVz549VblyZV2/fl2jR49WnTp1FBwc7MyyAAAAgBw5dQqHr6+vKleuLEny8vJSUFCQkpOTnVkSAAAAkCunjkDfKTExUceOHVPVqlWzrIuOjlZ0dLQkKTIyUv7+/o4uDwWMPjQ/+sj86CPzo4/Mjz4yPzP2kSkCdGpqqqKiotSnTx95e3tnWR8REaGIiAj746SkJEeWh0JAH5offWR+9JH50UfmRx+ZnzP7KDAwMNvlTr8KR3p6uqKiotSyZUs9/vjjzi4HAAAAyJVTA7TNZtPs2bMVFBSkjh07OrMUAAAAIE+cOoXj119/VWxsrCpUqKCRI0dKkl588UXVr1/fmWUBAAAAOXJqgK5evbqWLVvmzBIAAAAAQ5w+BxoAAAAoSgjQAAAAgAEEaAAAAMAAAjQAAABgAAEaAAAAMIAADQAAABhAgAYAAAAMIEADAAAABhCgAQAAAAMI0AAAAIABBGgAAADAAAI0AAAAYAABGgAAADCAAA0AAAAYQIAGAAAADCBAAwAAAAYQoAEAAAADCNAAAACAAQRoAAAAwAACNAAAAGAAARoAAAAwgAANAAAAGECABgAAAAwgQAMAAAAGEKABAAAAAwjQAAAAgAEEaAAAAMAAAjQAAABgAAEaAAAAMIAADQAAABhAgAYAAAAMIEADAAAABhCgAQAAAAMI0AAAAIABbs4uIC4uTvPnz5fValWbNm307LPPOrskAAAAIEdOHYG2Wq364osvNHbsWE2fPl2bN29WQkKCM0sCAAAAcuXUAH306FGVK1dOZcuWlZubm5o1a6YdO3Y4syQAAAAgV04N0MnJyfLz87M/9vPzU3JyshMrAgAAAHLn1DnQNpstyzKLxZJlWXR0tKKjoyVJkZGRCgwMLPTa/iq7WmEu9JH50UfmRx+ZH31kfvTR/c+pI9B+fn46f/68/fH58+fl6+ubpV1ERIQiIyMVGRnpyPKKpNGjRzu7BNwFfWR+9JH50UfmRx+ZH31075waoKtUqaIzZ84oMTFR6enp2rJlixo2bOjMkgAAAIBcOXUKh6urq/r27atJkybJarWqVatWevjhh51ZEgAAAJArp18Hun79+qpfv76zy7hvREREOLsE3AV9ZH70kfnRR+ZHH5kffXTvLDZmugMAAAB5xq28AQAAAAOcPoXjftK1a1dVqFBBkuTi4qK+ffuqWrVqBbb9WbNmqUGDBmrSpIlmz56tjh07Kjg4ON/bPXz4sObMmSNXV1dNmjRJ7u7u2babNGmSLl68qIyMDFWvXl2vvPKKXFxctHr1aq1du1aurq4qWbKkBg0apDJlyuS7roJyZ79IUvPmzQv8lvFDhgzR+++/r5IlS+rtt9/Wu+++m6/tbdiwQb///rv69euXZd3WrVu1bNkylSpVSuPHj8/2+WlpaRo/frzS09OVkZGhJk2aqEuXLpKkxYsXa9euXXJzc1PZsmU1ePBgFStWLF/1FqSieh5NmDBBPXv2VJUqVZSSkqJ58+bp119/lSRVq1ZNffv2lbe3d7734yz323l0577Onz+vL774QgkJCbLZbKpfv7569uwpN7ei+SvyfjiHbrPZbFq+fLliYmJksVhUunRp9e3bt0h+X+p+PoduS09P15IlS7Rr1y5ZLBYFBwerX79+me75cb8omv87mJS7u7umTp0qSYqLi9NXX32liRMnFsq+Bg4cWGDb2rhxozp16qRWrVrl2m7YsGHy9vaWzWZTVFSUtm7dqubNm6tixYqKjIyUh4eH/u///k9LlizRsGHDCqy+/LqzXxwhv/9h3c26devUr18/1a5dO8c2Dz30kMaPHy9PT0+lp6dr3LhxeuyxxxQaGqo6deqoe/fucnV11ZIlS7RixQr16NGjUGs2oqieR3f69NNP9fDDD2vo0KGSpGXLlmn27NkaPnx4oezPEe638+g2m82madOmqV27dnrrrbdktVr12Wef6euvv1bPnj0dUkNBux/Oodt+/PFH/fbbb5o6dao8PDy0d+9eTZkyRVFRUTkO9pjV/XoO3emrr77S9evX9dFHH8nFxUXr16/XtGnT9N5772V7n4+ijABdSK5fv24f1UtNTdWUKVN07do1paenq1u3bmrUqJFSU1M1ffp0JScny2q1qnPnzmrWrJni4+O1cOFCpaamqmTJkho8eHCW62Pf+Zd6z5491b59e+3evVvu7u4aOXKkSpUqpcuXL+vzzz+3X2u7d+/eql69eqbtrF27Vlu3btXevXu1f/9+tWnTRsuWLVPx4sV1+vRp1ahRwz7SfHv0LCMjQ+np6faT4c4gFxISoo0bNxbacS1IcXFxWrBggUqUKKFKlSopMTFRo0eP1rJly+Tp6am//e1vkqQRI0Zo1KhRCggI0JQpU3T+/HndvHlT7du3z/YLGD179tTixYu1dOlS7dy5U5J0+fJl1a1bV4MHD1ZsbKy+//57paenKyQkxH58169fr5UrV6pUqVIqX768HnrooSzb/u9//6tffvlFiYmJatiwoR5++GFt375dN2/eVGJiolq0aKG///3vslgs8vT0lHSrvzIyMuz9VbduXfv2QkNDtW3btgI/tgWlqJxHdzp79qzi4+Mz/RH5wgsv6LXXXtPZs2d1/vz5bM8x6Vbwjo+PlyS1atVKHTt2LNDjWRiK4nl0pwMHDsjd3d0+gODi4qLevXtr6NCh6tKli7Zu3ZrtOZbT+85siuI5dKdVq1Zp/Pjx8vDwkHTr/6/Q0FBt2rRJrVu3Vs+ePdW2bVsdPHhQxYoV0xtvvKGSJUtqzZo1+umnn+Tq6qrg4GC98cYbBXdQC1hRP4duu3HjhjZs2KCZM2fKxeXWDOFWrVpp/fr1OnDggMqWLav33ntPVatW1fHjx1W+fHkNHTpUHh4e+vLLL7Vz5065urqqTp066tWrVwEd3cJDgC5AaWlpGjlypG7evKkLFy7YP15/6KGH9Oabb8rb21uXL1/WP//5TzVs2FBxcXHy9fXVmDFjJEkpKSlKT0/XvHnz9NZbb6lkyZLasmWLvv76aw0ePDjH/d64cUMhISF68cUXtWTJEq1du1adO3fW/Pnz1bFjR1WvXl1JSUmaNGmSpk+fnum5bdq00S+//GL/OO7gwYM6evSoPvjgA5UpU0aTJk3S9u3b1aRJE0m3pnEcPXpUjz32mH3ZndatW6fHHnusgI5owbjdL7c999xzatiwoT777DONGzdO5cqVy3JccjJ48GAVL15caWlpGjNmjB5//HGVKFEi27Zdu3ZV165dlZKSonHjxumpp55SQkKCtmzZonfeeUdubm6aO3euNm7cqDp16mjZsmWaPHmyvL29NXHiRFWsWDHLNl944QUdOHDA/gtrw4YNOnr0qKKiouTh4aExY8aofv36qlKliqxWq0aNGqWzZ8/qySefVEhISJbtrVu3znS/9IvieXSnhIQEVaxY0f4LRLoVyipWrKiEhAR5eXlle44FBAQoOTlZUVFRkqRr164VxOEsMPfTeXSnU6dOqVKlSpmWeXt7y9/fX2fPnpWkbM+xc+fOZXnfmUVRP4duS0lJUWpqqsqVK5dpeZUqVXTq1Cn7PitVqqRevXrpv//9r/7zn/+oX79+WrVqlWbOnKmHHnrINOfS/XoO3Xb27Fn5+/tnmapWuXJlnTp1SmXLltXp06c1cOBAVa9eXZ988ol+/PFHtW7dWtu3b9eHH34oi8Vimv66GwJ0Abrz45nffvtNM2fOVFRUlGw2m77++msdPnxYFotFycnJunTpkipUqKDFixdryZIlatCggWrUqKGTJ0/q1KlTeueddyRJVqs127sz3snNzU0NGjSQdOuNum/fPknS/v37lZCQYG+XkpKi69evy8vLK9ftVa1aVWXLlpV0a47WL7/8Yg/L//znP5WWlqYZM2bowIEDqlOnjv15sbGxio+P14QJEwwctcKX3cdmx48fV0BAgMqXLy9JCgsLs98uPjdr1qzRjh07JElJSUk6c+ZMjv9pSbc+Hp4xY4Y6dOigypUr64cfftCxY8fsv6jS0tJUsmRJHTlyRLVq1bLPJWvatKnOnDmTp9dXp04dew2NGzfWL7/8oipVqsjFxUVTp07VtWvXNG3aNJ08eTLT/Lvly5fL1dVVLVu2zNN+HKWon0c2my3bjyrvvOBRdudY7dq1lZiYqHnz5ql+/fqZzi0zuJ/Po5z66/by7M6xevXqZXnfmUVRP4fu5s6+sVgs9kGAli1batq0aZKkChUqaMaMGWrUqJEaN258T/spaPfzOXR7HzlN07i93M/Pz/7pQ1hYmNasWaMOHTrI3d1ds2fPVv369e3vIbMjQBeS0NBQXblyRZcvX9aePXt0+fJlRUZGys3NTUOGDFFaWpoCAwM1efJk7d69W1999ZXq1q2rxo0bKzg4WJMmTcrzvlxdXe1vThcXF2VkZEi69WbO7kuBt78MWKVKlXuav+bu7q6GDRtqx44d9l/y+/bt04oVKzRhwoQ8f9xjVq6urpnCTlpamiTp4MGD2r9/v9599115eHhowoQJunnzZq7b+s9//qPSpUvbPx622WwKDw9X9+7dM7Xbvn17ts+/PYosSQ0bNlTXrl3vWv9f/wMrVqyYatasqbi4OHuA3rBhg3bt2qVx48aZel5aUTyPHn74YR07dkxWq9U+Cm21WnXixAkFBwfbP8b+q+LFi2vq1KmKi4vTDz/8oC1btuQ62md2ReU8Cg4O1s8//5ypfUpKis6fP6+yZcvap9TcyWKxZPu+e+GFF3J9Hc5QFM+h27y9veXp6ak///zT/genJB07dkw1a9bMtobb+x8zZowOHTqknTt36ptvvtEHH3wgV1fXPL8WMygq59Bt5cqV07lz57L8cXTs2DF7KP7r7xuLxSJXV1e999572r9/v7Zs2aIffvghxy/ImwmXsSskf/zxh6xWq0qUKKGUlBT5+PjIzc1NBw4c0Llz5yRJycnJcnd3V1hYmDp16qT4+HgFBgbq8uXL+u233yTd+kbr7Y+qjKpTp45++OEH++Pjx49LujWKPHXq1BzD89GjR5WYmCir1aqtW7eqevXqSk1N1YULFyTdmlO7Z88eBQUFSbp1csyZM0dvvfWWfHx87qlWRwsMDFRiYqL9I9pNmzbZ15UpU0bHjh2TJMXHxysxMVHSrV+qxYoVk4eHh/744w8dOXIk133s2rVL+/btU9++fe3LHn30UW3btk2XLl2SJF29elXnzp1TSEiIDh06pCtXrig9Pd0+L/n2KPLUqVNzDM/79+/X1atXlZaWph07dqhatWq6fPmy/WOwtLQ07d+/395fcXFxWrVqlUaNGmWfV2hWRfE8KleunCpVqqTly5fbly1fvlyVKlWyfxSd3Tl2+fJlWa1WNWnSRN26dbO/B83sfjiPHn30Ud24cUMxMTGSbgWFRYsW6YknnrCfH9mdY9m978yoKJ5Dd+rUqZPmz59vD4/79u3TL7/8ohYtWki6FQRv9/OmTZtUvXp1Wa1WJSUlqXbt2urRo4d9KogZ3Q/n0G2enp4KDw/XwoULZbVaJUkxMTG6ceOG/btSSUlJ9vfU7f5KTU1VSkqK6tevrz59+tjfH2bHCHQB+uv8piFDhsjFxUUtWrTQ5MmTNXr0aFWsWNEeZE6ePKklS5bIYrHIzc1Nr7zyitzc3DRixAjNnz9fKSkpysjIUPv27e/pkj0vv/yyvvjiC7355pvKyMhQjRo11L9//7s+LzQ0VF9++aVOnjypGjVqqHHjxrp8+bKmTJmimzdvymq1qnbt2mrbtq0kacmSJUpNTdUHH3wgSfL397f/pWoGf+2Xxx57TC+99JIGDBigyMhIlShRQtWrV7f/cmjSpIliY2M1cuRIValSRYGBgfbn/fTTT3rzzTcVGBiY7ZziO61evVoXLlywf0R2+6/2bt266d1335XNZpOrq6v69eun0NBQ/f3vf9fbb7+tUqVKqVKlSvb/gO6mWrVq+vjjj3X27Fm1aNFCVapU0YkTJzRr1ixZrVbZbDY1bdrUPgLwxRdfKD093f7RbEhISJ7eF45yP5xHAwcO1Lx58/Taa69JunWMBw0aZF+f3Tl28uRJffrpp/Z+/+vIkLPdr+eRxWLRm2++qblz5+qbb76RzWZTvXr19OKLL9rbZHeOxcXFZXnfmUVRPociIyPtI8WhoaEaNmyYrl27phEjRsjFxUWlSpXSW2+9ZR/N9vDw0KlTpzRq1Ch5e3tr2LBhslqt+vjjj+3z0jt06GCKS3Xej+fQyJEj7aPKTZs2Vffu3bV48WL94x//sH9S8+abb9rbBAUFacOGDfr8889Vrlw5tWvXTikpKfZ8YbPZ1Lt373s/yA7EnQiRycGDB/Xdd99p9OjRzi7FoYrq687tGp0wp6L6XsuL+/G1cY6Z2+0rTdwv7sdz6LbExERNnjzZ/kXpoo4pHAAAAIABjEADAAAABjACDQAAABhAgAYAAAAMIEADAAAABhCgAaAISkxMVJcuXew3q8jNhg0b9K9//csBVQHAg4HrQANAIRsyZIiSk5P12Wef2W+RK926huqJEyc0c+ZMBQQEOLyuw4cP67333rM/vnHjRqab60yfPl3+/v4OrwsAzI4ADQAOEBAQoM2bN+vpp5+WdOvmFbfvruYsNWrUsF9DNzExUUOHDtWCBQuK3C2PAcDRCNAA4ABhYWGKjY21B+gNGzYoPDxc//73v+1tUlJSNG/ePO3Zs0ceHh5q06aNnnvuObm4uMhqtWrJkiWKiYmRl5eXOnbsmGn7KSkpWrhwofbs2SOLxaJWrVqpS5cucnExPlPv6NGjmjx5smbPnm0P09u2bdM333yjqVOnatmyZTp16pRcXFy0Z88elS9fXoMGDVLFihUl3bo19Lx583T48GF5enqqQ4cOat++/T0eOQAwH+ZAA4ADhISEKCUlRQkJCbJardq6datatmyZqc28efOUkpKimTNnasKECYqNjdWGDRskSdHR0dq9e7cmT56syMhI/fzzz5meO3PmTLm6umrGjBmaMmWK9u7dq7Vr195TrVWrVlXx4sW1b98++7KNGzcqLCzM/njnzp1q2rSp5s2bp+bNm2vq1KlKT0+X1WrV5MmTVbFiRX322WcaN26c1qxZo7i4uHuqBQDMiAANAA5yexR63759CgwMVOnSpe3rrFartmzZou7du8vLy0sBAQHq2LGjYmNjJUlbt25V+/bt5e/vr+LFi+vZZ5+1P/fixYuKi4tTnz595OnpKR8fH3Xo0EFbtmy551rDw8O1ceNGSdLVq1e1d+9etWjRwr6+cuXKatKkidzc3NSxY0fdvHlTR44c0e+//67Lly/rhRdekJubm8qWLas2bdrkqxYAMBumcACAg4SFhWn8+PFKTExUeHh4pnWXL19Wenp6pi/tlSlTRsnJyZKkCxcuZFl3W1JSkjIyMtS/f3/7MpvNJj8/v3zVOmzYMKWmpmrLli2qUaOGfH197evv3LaLi4v8/Px04cIFe619+vSxr7darapRo8Y91wIAZkOABgAHKVOmjAICArRnzx4NHDgw07qSJUvK1dVVSUlJCg4OlnQrGN8epfb19VVSUpK9/Z0/+/n5yc3NTV988UWBfQGwdOnSCg0N1fbt27Vx40a1bds20/rz58/bf7ZarTp//rx8fX3l6uqqgIAAzZgxo0DqAAAzYgoHADjQwIEDNW7cOHl6emZa7uLioqZNm+rrr7/W9evXde7cOa1evdo+T7pp06b6/vvvdf78eV29elUrV660P9fX11d169bVokWLlJKSIqvVqrNnz+rQoUP5qjUsLEyrVq3SyZMn1bhx40zr4uPj9fPPPysjI0Nr1qzRQw89pJCQEFWtWlVeXl5auXKl0tLSZLVadfLkSR09ejRftQCAmTACDQAOVK5cuRzX9e3bV/PmzdPQoUPl7u6uNm3aqFWrVpKkNm3a6PTp0xo5cqS8vLzUqVMnHThwwP7coUOH6ssvv9Tw4cN1/fp1lS1bVs8880y+am3cuLHmzp2rRo0aZQn8DRs21JYtWzRr1iyVK1dOI0aMkJvbrV8po0aN0qJFizRkyBClp6crMDBQXbt2zVctAGAmFpvNZnN2EQAAc3rttdf06quvqk6dOvZly5Yt09mzZ/X66687sTIAcB6mcAAAsrVt2zZJUu3atZ1cCQCYC1M4AABZTJgwQQkJCRo6dOg93YwFAO5nTOEAAAAADGBYAQAAADCAAA0AAAAYQIAGAAAADCBAAwAAAAYQoAEAAAADCNAAAACAAf8PHgLs/MQY5+0AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 864x432 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "x = [onnx_size_mb, e_onnx_size_mb, qi_onnx_size_mb, qi_e_onnx_size_mb, ql_onnx_size_mb, ql_e_onnx_size_mb]\n",
+    "y = ['Baseline-fp32', 'Equalized-fp32', 'Baseline-IOps', 'Equalized-IOps', 'Baseline-LOps', 'Equalized-LOps']\n",
+    "title = \"MobileNetV2 Model Size\"\n",
+    "x_label = \"Model Type\"\n",
+    "y_label = \"Model Size (MB)\"\n",
+    "    \n",
+    "plot_statistic(x, y, title, x_label, y_label)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Summary\n",
+    "\n",
+    "#### Advantages of Equalization\n",
+    "- Large gains in accuracy in models with depthwise convolutions\n",
+    "- Future proof, theoretically shows gains in int6 (though not as large)\n",
+    "- It produces an optimized network, so you can stack other techniques\n",
+    "- Data-free quantization technique, which only needs the network to function\n",
+    "\n",
+    "#### Challenges and Limitations\n",
+    "- The algorithm is designed for simplified topologies (Conv, BN, ReLU)\n",
+    "- Some models already seeing high accuracy see only marginal benifit (e.g. ResNet)\n",
+    "\n",
+    "#### Future Work and Improvements\n",
+    "- Testing equalization in an environment with int4 capabilities\n",
+    "- Needs to be tested on additional models to become more robust to errors\n",
+    "- Bias Correction is also suggested in the original paper, with 1-3% gains"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Appendix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below are details of the system information and packages used to generate the results in this notebook. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'python_version': '3.8.6.final.0 (64 bit)',\n",
+       " 'cpuinfo_version': [7, 0, 0],\n",
+       " 'cpuinfo_version_string': '7.0.0',\n",
+       " 'arch': 'X86_64',\n",
+       " 'bits': 64,\n",
+       " 'count': 8,\n",
+       " 'arch_string_raw': 'AMD64',\n",
+       " 'vendor_id_raw': 'GenuineIntel',\n",
+       " 'brand_raw': 'Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz',\n",
+       " 'hz_advertised_friendly': '1.9000 GHz',\n",
+       " 'hz_actual_friendly': '1.4080 GHz',\n",
+       " 'hz_advertised': [1900000000, 0],\n",
+       " 'hz_actual': [1408000000, 0],\n",
+       " 'l2_cache_size': 1048576,\n",
+       " 'stepping': 12,\n",
+       " 'model': 142,\n",
+       " 'family': 6,\n",
+       " 'l3_cache_size': 8388608,\n",
+       " 'flags': ['3dnow',\n",
+       "  '3dnowprefetch',\n",
+       "  'abm',\n",
+       "  'acpi',\n",
+       "  'adx',\n",
+       "  'aes',\n",
+       "  'apic',\n",
+       "  'avx',\n",
+       "  'avx2',\n",
+       "  'bmi1',\n",
+       "  'bmi2',\n",
+       "  'clflush',\n",
+       "  'clflushopt',\n",
+       "  'cmov',\n",
+       "  'cx16',\n",
+       "  'cx8',\n",
+       "  'de',\n",
+       "  'dtes64',\n",
+       "  'dts',\n",
+       "  'erms',\n",
+       "  'est',\n",
+       "  'f16c',\n",
+       "  'fma',\n",
+       "  'fpu',\n",
+       "  'fxsr',\n",
+       "  'ht',\n",
+       "  'hypervisor',\n",
+       "  'ia64',\n",
+       "  'invpcid',\n",
+       "  'lahf_lm',\n",
+       "  'mca',\n",
+       "  'mce',\n",
+       "  'mmx',\n",
+       "  'movbe',\n",
+       "  'mpx',\n",
+       "  'msr',\n",
+       "  'mtrr',\n",
+       "  'osxsave',\n",
+       "  'pae',\n",
+       "  'pat',\n",
+       "  'pbe',\n",
+       "  'pcid',\n",
+       "  'pclmulqdq',\n",
+       "  'pdcm',\n",
+       "  'pge',\n",
+       "  'pni',\n",
+       "  'popcnt',\n",
+       "  'pse',\n",
+       "  'pse36',\n",
+       "  'rdrnd',\n",
+       "  'rdseed',\n",
+       "  'sep',\n",
+       "  'serial',\n",
+       "  'smap',\n",
+       "  'smep',\n",
+       "  'ss',\n",
+       "  'sse',\n",
+       "  'sse2',\n",
+       "  'sse4_1',\n",
+       "  'sse4_2',\n",
+       "  'ssse3',\n",
+       "  'tm',\n",
+       "  'tm2',\n",
+       "  'tsc',\n",
+       "  'vme',\n",
+       "  'xsave',\n",
+       "  'xtpr'],\n",
+       " 'l2_cache_line_size': 256,\n",
+       " 'l2_cache_associativity': 6}"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import cpuinfo # !conda install -c conda-forge py-cpuinfo\n",
+    "cpuinfo.get_cpu_info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# packages in environment at C:\\Users\\jkonan\\Anaconda3:\n",
+      "#\n",
+      "Note: you may need to restart the kernel to use updated packages.\n",
+      "\n",
+      "# Name                    Version                   Build  Channel\n",
+      "_ipyw_jlab_nb_ext_conf    0.1.0                    py38_0  \n",
+      "anaconda-client           1.7.2                      py_0    conda-forge\n",
+      "anaconda-navigator        1.10.0                   py38_0  \n",
+      "argon2-cffi               20.1.0           py38h294d835_2    conda-forge\n",
+      "async_generator           1.10                       py_0    conda-forge\n",
+      "attrs                     20.3.0             pyhd3deb0d_0    conda-forge\n",
+      "backcall                  0.2.0              pyh9f0ad1d_0    conda-forge\n",
+      "backports                 1.0                        py_2    conda-forge\n",
+      "backports.functools_lru_cache 1.6.1                      py_0    conda-forge\n",
+      "beautifulsoup4            4.9.3              pyhb0f4dca_0    conda-forge\n",
+      "blas                      2.21                        mkl    conda-forge\n",
+      "bleach                    3.2.1              pyh9f0ad1d_0    conda-forge\n",
+      "brotlipy                  0.7.0           py38hab1e662_1001    conda-forge\n",
+      "bzip2                     1.0.8                he774522_3    conda-forge\n",
+      "ca-certificates           2020.11.8            h5b45459_0    conda-forge\n",
+      "cerberus                  1.3.2                    pypi_0    pypi\n",
+      "certifi                   2020.11.8        py38haa244fe_0    conda-forge\n",
+      "cffi                      1.14.3           py38h0e640b1_1    conda-forge\n",
+      "chardet                   3.0.4           py38h9bdc248_1008    conda-forge\n",
+      "click                     7.1.2              pyh9f0ad1d_0    conda-forge\n",
+      "clyent                    1.2.2                      py_1    conda-forge\n",
+      "cmake                     3.18.2.post1             pypi_0    pypi\n",
+      "colorama                  0.4.4              pyh9f0ad1d_0    conda-forge\n",
+      "conda                     4.9.2            py38haa244fe_0    conda-forge\n",
+      "conda-build               3.20.5           py38h9bdc248_0    conda-forge\n",
+      "conda-env                 2.6.0                         1    conda-forge\n",
+      "conda-package-handling    1.7.2            py38h8934438_0    conda-forge\n",
+      "conda-verify              3.1.1           py38h32f6830_1002    conda-forge\n",
+      "console_shortcut          0.1.1                         4  \n",
+      "cryptography              3.2.1            py38hd8c33c5_0    conda-forge\n",
+      "cudatoolkit               10.2.89              h74a9793_1  \n",
+      "cycler                    0.10.0                     py_2    conda-forge\n",
+      "decorator                 4.4.2                      py_0    conda-forge\n",
+      "defusedxml                0.6.0                      py_0    conda-forge\n",
+      "efficientnet-pytorch      0.7.0                    pypi_0    pypi\n",
+      "entrypoints               0.3             pyhd8ed1ab_1003    conda-forge\n",
+      "filelock                  3.0.12             pyh9f0ad1d_0    conda-forge\n",
+      "freeglut                  3.0.0             h6538335_1005    conda-forge\n",
+      "freetype                  2.10.4               h546665d_0    conda-forge\n",
+      "future                    0.18.2           py38haa244fe_2    conda-forge\n",
+      "git                       2.29.2               h57928b3_1    conda-forge\n",
+      "gitdb                     4.0.5                      py_0    conda-forge\n",
+      "gitpython                 3.1.11                     py_0    conda-forge\n",
+      "glob2                     0.7                        py_0    conda-forge\n",
+      "graphviz                  2.38.0            h6538335_1011    conda-forge\n",
+      "icu                       67.1                 h33f27b4_0    conda-forge\n",
+      "idna                      2.10               pyh9f0ad1d_0    conda-forge\n",
+      "importlib-metadata        2.0.0                      py_1    conda-forge\n",
+      "importlib_metadata        2.0.0                         1    conda-forge\n",
+      "intel-openmp              2020.3             h57928b3_311    conda-forge\n",
+      "ipdb                      0.13.3             pyh9f0ad1d_0    conda-forge\n",
+      "ipykernel                 5.3.4            py38h7b7c402_1    conda-forge\n",
+      "ipython                   7.19.0           py38hc5df569_0    conda-forge\n",
+      "ipython_genutils          0.2.0                      py_1    conda-forge\n",
+      "ipywidgets                7.5.1              pyh9f0ad1d_1    conda-forge\n",
+      "jasper                    2.0.14               hdc05fd1_1    conda-forge\n"
+     ]
+    }
+   ],
+   "source": [
+    "conda list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "jedi                      0.17.2           py38haa244fe_1    conda-forge\n",
+      "jinja2                    2.11.2             pyh9f0ad1d_0    conda-forge\n",
+      "joblib                    0.17.0                   pypi_0    pypi\n",
+      "jpeg                      9d                   h8ffe710_0    conda-forge\n",
+      "json5                     0.9.5              pyh9f0ad1d_0    conda-forge\n",
+      "jsonschema                3.2.0                      py_2    conda-forge\n",
+      "jupyter_client            6.1.7                      py_0    conda-forge\n",
+      "jupyter_contrib_core      0.3.3                      py_2    conda-forge\n",
+      "jupyter_contrib_nbextensions 0.5.1            py38h32f6830_1    conda-forge\n",
+      "jupyter_core              4.7.0            py38haa244fe_0    conda-forge\n",
+      "jupyter_highlight_selected_word 0.2.0           py38h32f6830_1002    conda-forge\n",
+      "jupyter_latex_envs        1.4.6           py38h32f6830_1001    conda-forge\n",
+      "jupyter_nbextensions_configurator 0.4.1            py38h32f6830_2    conda-forge\n",
+      "jupyterlab                2.2.9                      py_0    conda-forge\n",
+      "jupyterlab_pygments       0.1.2              pyh9f0ad1d_0    conda-forge\n",
+      "jupyterlab_server         1.2.0                      py_0    conda-forge\n",
+      "kiwisolver                1.3.1            py38hbd9d945_0    conda-forge\n",
+      "libarchive                3.4.3                h793d221_0    conda-forge\n",
+      "libblas                   3.8.0                    21_mkl    conda-forge\n",
+      "libcblas                  3.8.0                    21_mkl    conda-forge\n",
+      "libclang                  10.0.1          default_hf44288c_1    conda-forge\n",
+      "libiconv                  1.16                 he774522_0    conda-forge\n",
+      "liblapack                 3.8.0                    21_mkl    conda-forge\n",
+      "liblapacke                3.8.0                    21_mkl    conda-forge\n",
+      "liblief                   0.10.1               ha925a31_2    conda-forge\n",
+      "libopencv                 4.5.0                    py38_3    conda-forge\n",
+      "libpng                    1.6.37               h1d00b33_2    conda-forge\n",
+      "libprotobuf               3.13.0.1             h200bbdf_0    conda-forge\n",
+      "libsodium                 1.0.18               h8d14728_1    conda-forge\n",
+      "libtiff                   4.1.0                hc10be44_6    conda-forge\n",
+      "libwebp-base              1.1.0                h8ffe710_3    conda-forge\n",
+      "libxml2                   2.9.10               h1006b36_2    conda-forge\n",
+      "libxslt                   1.1.33               h579f668_1    conda-forge\n",
+      "lxml                      4.6.1            py38he3d0fc9_0    conda-forge\n",
+      "lz4-c                     1.9.2                h62dcd97_2    conda-forge\n",
+      "lzo                       2.10              he774522_1000    conda-forge\n",
+      "m2-msys2-runtime          2.5.0.17080.65c939c               3  \n",
+      "m2-patch                  2.7.5                         2  \n",
+      "m2w64-gcc-libgfortran     5.3.0                         6  \n",
+      "m2w64-gcc-libs            5.3.0                         7  \n",
+      "m2w64-gcc-libs-core       5.3.0                         7  \n",
+      "m2w64-gmp                 6.1.0                         2  \n",
+      "m2w64-libwinpthread-git   5.0.0.4634.697f757               2  \n",
+      "markupsafe                1.1.1            py38hab1e662_2    conda-forge\n",
+      "matplotlib                3.3.3            py38haa244fe_0    conda-forge\n",
+      "matplotlib-base           3.3.3            py38h34ddff4_0    conda-forge\n",
+      "memory_profiler           0.58.0                     py_0    conda-forge\n",
+      "menuinst                  1.4.16           py38h32f6830_1    conda-forge\n",
+      "mistune                   0.8.4           py38h294d835_1002    conda-forge\n",
+      "mkl                       2020.4             hb70f87d_311    conda-forge\n",
+      "msys2-conda-epoch         20160418                      1  \n",
+      "navigator-updater         0.2.1                    py38_0  \n",
+      "nbclient                  0.5.1                      py_0    conda-forge\n",
+      "nbconvert                 6.0.7            py38haa244fe_3    conda-forge\n",
+      "nbformat                  5.0.8                      py_0    conda-forge\n",
+      "nest-asyncio              1.4.3              pyhd8ed1ab_0    conda-forge\n",
+      "netron                    4.4.8                    pypi_0    pypi\n",
+      "ninja                     1.10.1               h587dcfd_2    conda-forge\n",
+      "notebook                  6.1.5            py38haa244fe_0    conda-forge\n",
+      "numpy                     1.19.4           py38h0cc643e_1    conda-forge\n",
+      "olefile                   0.46               pyh9f0ad1d_1    conda-forge\n",
+      "onnx                      1.7.0                    pypi_0    pypi\n",
+      "onnxruntime               1.5.2                    pypi_0    pypi\n",
+      "opencv                    4.5.0                    py38_3    conda-forge\n",
+      "openssl                   1.1.1h               he774522_0    conda-forge\n",
+      "packaging                 20.4               pyh9f0ad1d_0    conda-forge\n",
+      "pandas                    1.1.4            py38h4c96930_0    conda-forge\n",
+      "pandoc                    2.11.2               h8ffe710_0    conda-forge\n",
+      "pandocfilters             1.4.2                      py_1    conda-forge\n",
+      "parso                     0.7.1              pyh9f0ad1d_0    conda-forge\n",
+      "pickleshare               0.7.5                   py_1003    conda-forge\n",
+      "pillow                    8.0.1            py38hd8d9125_0    conda-forge\n",
+      "pip                       20.2.4                     py_0    conda-forge\n",
+      "pkginfo                   1.6.1              pyh9f0ad1d_0    conda-forge\n",
+      "powershell_shortcut       0.0.1                         3  \n",
+      "prometheus_client         0.9.0              pyhd3deb0d_0    conda-forge\n",
+      "prompt-toolkit            3.0.8              pyha770c72_0    conda-forge\n",
+      "protobuf                  3.9.2                    pypi_0    pypi\n",
+      "psutil                    5.7.3            py38hab1e662_0    conda-forge\n",
+      "py-cpuinfo                7.0.0                    pypi_0    pypi\n",
+      "py-lief                   0.10.1           py38h4b9bc1a_2    conda-forge\n",
+      "py-opencv                 4.5.0            py38hc5df569_3    conda-forge\n",
+      "pycosat                   0.6.3           py38hab1e662_1005    conda-forge\n",
+      "pycparser                 2.20               pyh9f0ad1d_2    conda-forge\n",
+      "pydot                     1.4.1           py38h32f6830_1003    conda-forge\n",
+      "pygments                  2.7.2                      py_0    conda-forge\n",
+      "pyopenssl                 19.1.0                     py_1    conda-forge\n",
+      "pyparsing                 2.4.7              pyh9f0ad1d_0    conda-forge\n",
+      "pyqt                      5.12.3           py38h7ae7562_4    conda-forge\n",
+      "pyqt5-sip                 4.19.18                  pypi_0    pypi\n",
+      "pyqtchart                 5.12                     pypi_0    pypi\n",
+      "pyqtwebengine             5.12.1                   pypi_0    pypi\n",
+      "pyrsistent                0.17.3           py38h294d835_1    conda-forge\n",
+      "pysocks                   1.7.1            py38h9bdc248_2    conda-forge\n",
+      "python                    3.8.6           h60c2a47_0_cpython    conda-forge\n",
+      "python-dateutil           2.8.1                      py_0    conda-forge\n",
+      "python-graphviz           0.15               pyhd3deb0d_0    conda-forge\n",
+      "python-libarchive-c       2.9              py38h9bdc248_2    conda-forge\n",
+      "python_abi                3.8                      1_cp38    conda-forge\n",
+      "pytorch                   1.6.0           py3.8_cuda102_cudnn7_0    pytorch\n",
+      "pytorchcv                 0.0.58                   pypi_0    pypi\n",
+      "pytz                      2020.4             pyhd8ed1ab_0    conda-forge\n",
+      "pywin32                   228              py38h1e8a9f7_0    conda-forge\n",
+      "pywinpty                  0.5.7            py38h32f6830_1    conda-forge\n",
+      "pyyaml                    5.3.1            py38hab1e662_1    conda-forge\n",
+      "pyzmq                     20.0.0           py38h7a0e47e_1    conda-forge\n",
+      "qt                        5.12.9               hb2cf2c5_0    conda-forge\n",
+      "qtpy                      1.9.0                      py_0    conda-forge\n",
+      "requests                  2.25.0             pyhd3deb0d_0    conda-forge\n",
+      "ripgrep                   12.1.1               h301d43c_1    conda-forge\n",
+      "ruamel_yaml               0.15.80         py38hab1e662_1003    conda-forge\n",
+      "scikit-learn              0.23.2                   pypi_0    pypi\n",
+      "scipy                     1.5.4                    pypi_0    pypi\n",
+      "send2trash                1.5.0                      py_0    conda-forge\n",
+      "setuptools                50.3.2                   pypi_0    pypi\n",
+      "six                       1.15.0             pyh9f0ad1d_0    conda-forge\n",
+      "sklearn                   0.0                      pypi_0    pypi\n",
+      "smmap                     3.0.4              pyh9f0ad1d_0    conda-forge\n",
+      "soupsieve                 2.0.1                      py_1    conda-forge\n",
+      "sqlite                    3.33.0               he774522_1    conda-forge\n",
+      "style                     1.1.0                    pypi_0    pypi\n",
+      "tensorboardx              2.1                        py_0    conda-forge\n",
+      "terminado                 0.9.1            py38haa244fe_1    conda-forge\n",
+      "testpath                  0.4.4                      py_0    conda-forge\n",
+      "threadpoolctl             2.1.0                    pypi_0    pypi\n",
+      "timm                      0.3.1                    pypi_0    pypi\n",
+      "tk                        8.6.10               he774522_1    conda-forge\n",
+      "torchvision               0.7.0                py38_cu102    pytorch\n",
+      "tornado                   6.1              py38h294d835_0    conda-forge\n",
+      "tqdm                      4.52.0             pyhd3deb0d_0    conda-forge\n",
+      "traitlets                 5.0.5                      py_0    conda-forge\n",
+      "typing-extensions         3.7.4.3                       0    conda-forge\n",
+      "typing_extensions         3.7.4.3                    py_0    conda-forge\n",
+      "update                    0.0.1                    pypi_0    pypi\n",
+      "urllib3                   1.25.11                    py_0    conda-forge\n",
+      "vc                        14.1                 h869be7e_1    conda-forge\n",
+      "vs2015_runtime            14.16.27012          h30e32a0_2    conda-forge\n",
+      "wcwidth                   0.2.5              pyh9f0ad1d_2    conda-forge\n",
+      "webencodings              0.5.1                      py_1    conda-forge\n",
+      "wheel                     0.35.1             pyh9f0ad1d_0    conda-forge\n",
+      "widgetsnbextension        3.5.1            py38haa244fe_4    conda-forge\n",
+      "win_inet_pton             1.1.0            py38h32f6830_1    conda-forge\n",
+      "wincertstore              0.2             py38h32f6830_1005    conda-forge\n",
+      "winpty                    0.4.3                         4    conda-forge\n",
+      "xmltodict                 0.12.0                     py_0    conda-forge\n",
+      "xz                        5.2.5                h62dcd97_1    conda-forge\n",
+      "yaml                      0.2.5                he774522_0    conda-forge\n",
+      "zeromq                    4.3.3                h0e60522_2    conda-forge\n",
+      "zipp                      3.4.0                      py_0    conda-forge\n",
+      "zlib                      1.2.11            h62dcd97_1010    conda-forge\n",
+      "zstd                      1.4.5                h1f3a1b7_2    conda-forge\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "anaconda-client==1.7.2\n",
+      "anaconda-navigator==1.10.0\n",
+      "argon2-cffi @ file:///D:/bld/argon2-cffi_1605217273648/work\n",
+      "async-generator==1.10\n",
+      "attrs @ file:///home/conda/feedstock_root/build_artifacts/attrs_1605083924122/work\n",
+      "backcall @ file:///home/conda/feedstock_root/build_artifacts/backcall_1592338393461/work\n",
+      "backports.functools-lru-cache==1.6.1\n",
+      "beautifulsoup4 @ file:///home/conda/feedstock_root/build_artifacts/beautifulsoup4_1601745390275/work\n",
+      "bleach @ file:///home/conda/feedstock_root/build_artifacts/bleach_1600454382015/work\n",
+      "brotlipy==0.7.0\n",
+      "Cerberus==1.3.2\n",
+      "certifi==2020.11.8\n",
+      "cffi @ file:///D:/bld/cffi_1602537433319/work\n",
+      "chardet @ file:///D:/bld/chardet_1602255508636/work\n",
+      "click==7.1.2\n",
+      "clyent==1.2.2\n",
+      "cmake==3.18.2.post1\n",
+      "colorama @ file:///home/conda/feedstock_root/build_artifacts/colorama_1602866480661/work\n",
+      "conda==4.9.2\n",
+      "conda-build==3.20.5\n",
+      "conda-package-handling @ file:///D:/bld/conda-package-handling_1602877082869/work\n",
+      "conda-verify @ file:///D:/bld/conda-verify_1603158504992/work\n",
+      "cryptography @ file:///D:/bld/cryptography_1604179264939/work\n",
+      "cycler==0.10.0\n",
+      "decorator==4.4.2\n",
+      "defusedxml==0.6.0\n",
+      "efficientnet-pytorch==0.7.0\n",
+      "entrypoints @ file:///home/conda/feedstock_root/build_artifacts/entrypoints_1605121927639/work/dist/entrypoints-0.3-py2.py3-none-any.whl\n",
+      "filelock @ file:///home/conda/feedstock_root/build_artifacts/filelock_1589994591731/work\n",
+      "future @ file:///D:/bld/future_1605203720223/work\n",
+      "gitdb @ file:///home/conda/feedstock_root/build_artifacts/gitdb_1588651542737/work\n",
+      "GitPython @ file:///home/conda/feedstock_root/build_artifacts/gitpython_1603460643560/work\n",
+      "glob2==0.7\n",
+      "graphviz @ file:///home/conda/feedstock_root/build_artifacts/python-graphviz_1605462368198/work\n",
+      "idna @ file:///home/conda/feedstock_root/build_artifacts/idna_1593328102638/work\n",
+      "importlib-metadata @ file:///home/conda/feedstock_root/build_artifacts/importlib-metadata_1602263269022/work\n",
+      "ipdb @ file:///home/conda/feedstock_root/build_artifacts/ipdb_1595950402795/work\n",
+      "ipykernel @ file:///D:/bld/ipykernel_1602683005810/work/dist/ipykernel-5.3.4-py3-none-any.whl\n",
+      "ipython @ file:///D:/bld/ipython_1604159844946/work\n",
+      "ipython-genutils==0.2.0\n",
+      "ipywidgets @ file:///home/conda/feedstock_root/build_artifacts/ipywidgets_1599554010055/work\n",
+      "jedi @ file:///D:/bld/jedi_1605054817163/work\n",
+      "Jinja2==2.11.2\n",
+      "joblib==0.17.0\n",
+      "json5 @ file:///home/conda/feedstock_root/build_artifacts/json5_1600692310011/work\n",
+      "jsonschema @ file:///home/conda/feedstock_root/build_artifacts/jsonschema_1602551949684/work\n",
+      "jupyter-client @ file:///home/conda/feedstock_root/build_artifacts/jupyter_client_1598486169312/work\n",
+      "jupyter-contrib-core==0.3.3\n",
+      "jupyter-contrib-nbextensions @ file:///D:/bld/jupyter_contrib_nbextensions_1602805696229/work\n",
+      "jupyter-core @ file:///D:/bld/jupyter_core_1605735280365/work\n",
+      "jupyter-highlight-selected-word @ file:///D:/bld/jupyter_highlight_selected_word_1603234417974/work\n",
+      "jupyter-latex-envs @ file:///D:/bld/jupyter_latex_envs_1602789059680/work\n",
+      "jupyter-nbextensions-configurator @ file:///D:/bld/jupyter_nbextensions_configurator_1602769732224/work\n",
+      "jupyterlab==2.2.9\n",
+      "jupyterlab-pygments @ file:///home/conda/feedstock_root/build_artifacts/jupyterlab_pygments_1601375948261/work\n",
+      "jupyterlab-server @ file:///home/conda/feedstock_root/build_artifacts/jupyterlab_server_1593951277307/work\n",
+      "kiwisolver @ file:///D:/bld/kiwisolver_1604322452227/work\n",
+      "libarchive-c @ file:///D:/bld/python-libarchive-c_1602422843138/work\n",
+      "lxml @ file:///D:/bld/lxml_1603105115271/work\n",
+      "MarkupSafe @ file:///D:/bld/markupsafe_1602267501600/work\n",
+      "matplotlib @ file:///D:/bld/matplotlib-suite_1605180506412/work\n",
+      "memory-profiler @ file:///home/conda/feedstock_root/build_artifacts/memory_profiler_1603216722181/work\n",
+      "menuinst @ file:///D:/bld/menuinst_1602541318140/work\n",
+      "mistune @ file:///D:/bld/mistune_1605115857778/work\n",
+      "navigator-updater==0.2.1\n",
+      "nbclient @ file:///home/conda/feedstock_root/build_artifacts/nbclient_1602859080374/work\n",
+      "nbconvert @ file:///D:/bld/nbconvert_1605402041690/work\n",
+      "nbformat @ file:///home/conda/feedstock_root/build_artifacts/nbformat_1602732862338/work\n",
+      "nest-asyncio @ file:///home/conda/feedstock_root/build_artifacts/nest-asyncio_1605195931949/work\n",
+      "netron==4.4.8\n",
+      "notebook @ file:///D:/bld/notebook_1605103957289/work\n",
+      "numpy @ file:///D:/bld/numpy_1604946157939/work\n",
+      "olefile @ file:///home/conda/feedstock_root/build_artifacts/olefile_1602866521163/work\n",
+      "onnx==1.8.0\n",
+      "onnxruntime @ file:///C:/Users/jkonan/onnxruntime-1.5.2-cp38-cp38-win_amd64.whl\n",
+      "packaging @ file:///home/conda/feedstock_root/build_artifacts/packaging_1589925210001/work\n",
+      "pandas @ file:///D:/bld/pandas_1604166777043/work\n",
+      "pandocfilters==1.4.2\n",
+      "parso @ file:///home/conda/feedstock_root/build_artifacts/parso_1595548966091/work\n",
+      "pickleshare @ file:///home/conda/feedstock_root/build_artifacts/pickleshare_1602536217715/work\n",
+      "Pillow @ file:///D:/bld/pillow_1604748918199/work\n",
+      "pkginfo @ file:///home/conda/feedstock_root/build_artifacts/pkginfo_1603792998002/work\n",
+      "prometheus-client @ file:///home/conda/feedstock_root/build_artifacts/prometheus_client_1605543085815/work\n",
+      "prompt-toolkit @ file:///home/conda/feedstock_root/build_artifacts/prompt-toolkit_1605053337398/work\n",
+      "protobuf==3.13.0\n",
+      "Note: you may need to restart the kernel to use updated packages.\n",
+      "psutil @ file:///D:/bld/psutil_1603571190351/work\n",
+      "py-cpuinfo==7.0.0\n",
+      "pycosat @ file:///D:/bld/pycosat_1602278156974/work\n",
+      "pycparser @ file:///home/conda/feedstock_root/build_artifacts/pycparser_1593275161868/work\n",
+      "pydot @ file:///D:/bld/pydot_1602650922173/work\n",
+      "Pygments @ file:///home/conda/feedstock_root/build_artifacts/pygments_1603558917696/work\n",
+      "pyOpenSSL==19.1.0\n",
+      "pyparsing==2.4.7\n",
+      "PyQt5==5.12.3\n",
+      "PyQt5-sip==4.19.18\n",
+      "PyQtChart==5.12\n",
+      "PyQtWebEngine==5.12.1\n",
+      "pyrsistent @ file:///D:/bld/pyrsistent_1605115827510/work\n",
+      "PySocks @ file:///D:/bld/pysocks_1602327034683/work\n",
+      "python-dateutil==2.8.1\n",
+      "pytorchcv==0.0.58\n",
+      "pytz @ file:///home/conda/feedstock_root/build_artifacts/pytz_1604321279890/work\n",
+      "pywin32==228\n",
+      "pywinpty @ file:///D:/bld/pywinpty_1602377663724/work\n",
+      "PyYAML==5.3.1\n",
+      "pyzmq==20.0.0\n",
+      "QtPy==1.9.0\n",
+      "requests @ file:///home/conda/feedstock_root/build_artifacts/requests_1605186911681/work\n",
+      "ruamel-yaml-conda @ file:///D:/bld/ruamel_yaml_1602430512995/work\n",
+      "scikit-learn==0.23.2\n",
+      "scipy==1.5.4\n",
+      "Send2Trash==1.5.0\n",
+      "six @ file:///home/conda/feedstock_root/build_artifacts/six_1590081179328/work\n",
+      "sklearn==0.0\n",
+      "smmap @ file:///home/conda/feedstock_root/build_artifacts/smmap_1588651577140/work\n",
+      "soupsieve @ file:///home/conda/feedstock_root/build_artifacts/soupsieve_1597680516047/work\n",
+      "style==1.1.0\n",
+      "tensorboardX @ file:///home/conda/feedstock_root/build_artifacts/tensorboardx_1594067496847/work\n",
+      "terminado @ file:///D:/bld/terminado_1605117138129/work\n",
+      "testpath==0.4.4\n",
+      "threadpoolctl==2.1.0\n",
+      "timm==0.3.1\n",
+      "torch==1.6.0\n",
+      "torchvision==0.7.0\n",
+      "tornado @ file:///D:/bld/tornado_1604105353952/work\n",
+      "tqdm @ file:///home/conda/feedstock_root/build_artifacts/tqdm_1605543106900/work\n",
+      "traitlets @ file:///home/conda/feedstock_root/build_artifacts/traitlets_1602771532708/work\n",
+      "typing-extensions @ file:///home/conda/feedstock_root/build_artifacts/typing_extensions_1602702424206/work\n",
+      "update==0.0.1\n",
+      "urllib3 @ file:///home/conda/feedstock_root/build_artifacts/urllib3_1603125704209/work\n",
+      "wcwidth @ file:///home/conda/feedstock_root/build_artifacts/wcwidth_1600965781394/work\n",
+      "webencodings==0.5.1\n",
+      "widgetsnbextension @ file:///D:/bld/widgetsnbextension_1605475695976/work\n",
+      "win-inet-pton @ file:///D:/bld/win_inet_pton_1602260115377/work\n",
+      "wincertstore==0.2\n",
+      "xmltodict==0.12.0\n",
+      "zipp @ file:///home/conda/feedstock_root/build_artifacts/zipp_1603668650351/work\n"
+     ]
+    }
+   ],
+   "source": [
+    "pip freeze"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
**Description**
This pull request implements part of the paper on [Data-Free Quantization Through Weight Equalization and Bias Correction](https://arxiv.org/pdf/1906.04721.pdf) by Nagel et al. 2019, specifically the equalization algorithm.

**Motivation and Context**
Equalization shows improved performance in data-free quantization in models that see performance loss in depth-wise convolutions. The reference example is MobileNetV2, which observes an accuracy drop when converting from float32 to int8 using quantization. In the reference model, equalization improves IntegerOps accuracy by roughly 10% and improves QLinearOps accuracy by roughly 20%. Both the algorithm and this example result are included.

I presented this work to Microsoft as an intern with Intel Corporation at the Microsoft Technology Center in Folsom, CA. Thank you @yufenglee for considering this request.