### PR TITLE
Introduce the option to pass external CUDA allocator.

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_allocator.cc
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.cc
@@ -51,6 +51,23 @@ FencePtr CUDAAllocator::CreateFence(const SessionState* session_state) {
   return std::make_shared<CUDAFence>(GetGPUDataTransfer(session_state));
 }
 
+void* CUDAExternalAllocator::Alloc(size_t size) {
+  void* p = nullptr;
+  if (size > 0) {
+    p = alloc_(size);
+
+    // review(codemzs): ORT_ENFORCE does not seem appropiate.
+    ORT_ENFORCE(p != nullptr);
+
+  }
+
+  return p;
+}
+
+void CUDAExternalAllocator::Free(void* p) {
+  free_(p);
+}
+
 void* CUDAPinnedAllocator::Alloc(size_t size) {
   void* p = nullptr;
   if (size > 0) {

--- a/onnxruntime/core/providers/cuda/cuda_allocator.h
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.h
@@ -22,6 +22,25 @@ class CUDAAllocator : public IAllocator {
   void CheckDevice(bool throw_when_fail) const;
 };
 
+class CUDAExternalAllocator : public CUDAAllocator {
+  typedef void* (*ExternalAlloc)(size_t size);
+  typedef void (*ExternalFree)(void* p);
+
+ public:
+  CUDAExternalAllocator(OrtDevice::DeviceId device_id, const char* name, void* alloc, void* free)
+      : CUDAAllocator(device_id, name) {
+    alloc_ = reinterpret_cast<ExternalAlloc>(alloc);
+    free_ = reinterpret_cast<ExternalFree>(free);
+  }
+
+  void* Alloc(size_t size) override;
+  void Free(void* p) override;
+
+ private:
+  ExternalAlloc alloc_;
+  ExternalFree free_;
+};
+
 //TODO: add a default constructor
 class CUDAPinnedAllocator : public IAllocator {
  public:

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -146,10 +146,6 @@ CUDAExecutionProvider::CUDAExecutionProvider(const CUDAExecutionProviderInfo& in
   CUDA_CALL_THROW(cudaDeviceSynchronize());
   CUDA_CALL_THROW(cudaGetDeviceProperties(&device_prop_, device_id_));
 
-  size_t free = 0;
-  size_t total = 0;
-  CUDA_CALL_THROW(cudaMemGetInfo(&free, &total));
-
   if (external_alloc_ != nullptr && external_free_ != nullptr) {
     void* alloc = external_alloc_;
     void* free = external_free_;

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.h
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.h
@@ -26,8 +26,8 @@ struct CUDAExecutionProviderInfo {
   ArenaExtendStrategy arena_extend_strategy{ArenaExtendStrategy::kNextPowerOfTwo};
   OrtCudnnConvAlgoSearch cudnn_conv_algo{OrtCudnnConvAlgoSearch::EXHAUSTIVE};
   bool do_copy_in_default_stream{true};
-  void* external_alloc;
-  void* external_free;
+  void* external_alloc{nullptr};
+  void* external_free{nullptr};
 };
 
 // Logical device representation.

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.h
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.h
@@ -26,6 +26,8 @@ struct CUDAExecutionProviderInfo {
   ArenaExtendStrategy arena_extend_strategy{ArenaExtendStrategy::kNextPowerOfTwo};
   OrtCudnnConvAlgoSearch cudnn_conv_algo{OrtCudnnConvAlgoSearch::EXHAUSTIVE};
   bool do_copy_in_default_stream{true};
+  void* external_alloc;
+  void* external_free;
 };
 
 // Logical device representation.
@@ -89,6 +91,8 @@ private:
   ArenaExtendStrategy arena_extend_strategy_;
   int cudnn_conv_algo_;
   bool do_copy_in_default_stream_;
+  void* external_alloc_;
+  void* external_free_;
 
   struct DeferredReleaseCPUPtrs {
     bool recorded = false;
@@ -100,7 +104,7 @@ private:
 
   class PerThreadContext final {
    public:
-    PerThreadContext(OrtDevice::DeviceId device_id, size_t cuda_mem_limit, ArenaExtendStrategy arena_extend_strategy);
+    PerThreadContext(OrtDevice::DeviceId device_id, size_t cuda_mem_limit, ArenaExtendStrategy arena_extend_strategy, void* external_alloc, void* external_free);
     ~PerThreadContext();
 
     cublasHandle_t CublasHandle() const {

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -145,6 +145,8 @@ bool do_copy_in_default_stream = true;
 OrtDevice::DeviceId cuda_device_id = 0;
 size_t cuda_mem_limit = std::numeric_limits<size_t>::max();
 onnxruntime::ArenaExtendStrategy arena_extend_strategy = onnxruntime::ArenaExtendStrategy::kNextPowerOfTwo;
+void* cuda_external_alloc;
+void* cuda_external_free;
 #endif
 
 #ifdef USE_TENSORRT
@@ -494,6 +496,21 @@ static bool IsCudaDeviceIdValid(const onnxruntime::logging::Logger& logger, int 
   return true;
 }
 
+static size_t ConvertStringToSizeT(const std::string& str, const std::string& error_message) {
+  size_t size;
+  try {
+#if (defined(__amd64__) || defined(_M_AMD64) || defined(__aarch64__))
+    size = std::stoull(str, nullptr, 0);
+#else
+    size = std::stoul(str, nullptr, 0);
+#endif
+  } catch (...) {
+    throw std::runtime_error(error_message);
+  }
+
+  return size;
+}
+
 static void UpdateCudaProviderOptions(InferenceSession* sess, onnxruntime::CUDAExecutionProviderInfo& options,
                                       std::unordered_map<std::string, std::string> options_map) {
   std::unordered_map<std::string, std::string>::iterator it;
@@ -526,17 +543,7 @@ static void UpdateCudaProviderOptions(InferenceSession* sess, onnxruntime::CUDAE
       throw std::runtime_error("Please provide cuda memory limitation size with positive integer.");
     }
 
-    size_t size;
-    try {
-#if (defined(__amd64__) || defined(_M_AMD64) || defined(__aarch64__))
-      size = std::stoull(it->second, nullptr, 0);
-#else
-      size = std::stoul(it->second, nullptr, 0);
-#endif
-    } catch (...) {
-      throw std::runtime_error("Please provide cuda memory limitation size with positive integer and within range.");
-    }
-
+    size_t size = ConvertStringToSizeT(it->second, "Please provide cuda memory limitation size with positive integer and within range.");
     options.cuda_mem_limit = size;
     LOGS(*(sess->GetLogger()), INFO) << "cuda memory limitation is set to " << size;
   }
@@ -556,6 +563,29 @@ static void UpdateCudaProviderOptions(InferenceSession* sess, onnxruntime::CUDAE
     options.arena_extend_strategy = strategy;
     LOGS(*(sess->GetLogger()), INFO) << "cuda arean extend strategy is set to " << it->second;
   }
+
+  options.external_alloc = nullptr;
+  options.external_free = nullptr;
+  cuda_external_alloc = nullptr;
+  cuda_external_free = nullptr;
+  it = options_map.find("cuda_external_alloc");
+  if (it != options_map.end()) {
+    size_t address = ConvertStringToSizeT(it->second, "Please provide valid cuda device allocator alloc address.");
+    options.external_alloc = reinterpret_cast<void*>(address);
+    LOGS(*(sess->GetLogger()), INFO) << "cuda external allocator alloc set to " << options.external_alloc;
+  }
+
+  it = options_map.find("cuda_external_free");
+  if (it != options_map.end()) {
+    size_t address = ConvertStringToSizeT(it->second, "Please provide valid cuda device allocator free address.");
+    options.external_free = reinterpret_cast<void*>(address);
+    LOGS(*(sess->GetLogger()), INFO) << "cuda external allocator free set to " << options.external_free;
+  }
+
+  ORT_ENFORCE((options.external_alloc == nullptr && options.external_free == nullptr) || (options.external_alloc != nullptr && options.external_free != nullptr));
+
+  cuda_external_alloc = options.external_alloc;
+  cuda_external_free = options.external_free;
 }
 
 static AllocatorPtr GetCudaAllocator(OrtDevice::DeviceId id) {
@@ -565,19 +595,33 @@ static AllocatorPtr GetCudaAllocator(OrtDevice::DeviceId id) {
 
   if (id_to_allocator_map.find(id) == id_to_allocator_map.end()) {
     // Use arena-based allocator
-    AllocatorCreationInfo default_memory_info(
-        [](OrtDevice::DeviceId id) {
-          return onnxruntime::make_unique<CUDAAllocator>(id, CUDA);
-        },
-        id,
-        true,
-        {cuda_mem_limit,
-         static_cast<int>(arena_extend_strategy),
-         -1, -1});
+    if (cuda_external_alloc != nullptr && cuda_external_free != nullptr) {
+      AllocatorCreationInfo default_memory_info(
+          [](OrtDevice::DeviceId id) {
+            return onnxruntime::make_unique<CUDAExternalAllocator>(id, CUDA, cuda_external_alloc, cuda_external_free);
+          },
+          id,
+          false  //Review(codemzs): We should be using the option passed by the user.
+      );
 
-    auto allocator = CreateAllocator(default_memory_info);
+      auto allocator = CreateAllocator(default_memory_info);
 
-    id_to_allocator_map.insert({id, allocator});
+      id_to_allocator_map.insert({id, allocator});
+    } else {
+      AllocatorCreationInfo default_memory_info(
+          [](OrtDevice::DeviceId id) {
+            return onnxruntime::make_unique<CUDAAllocator>(id, CUDA);
+          },
+          id,
+          true, //Review(codemzs): We should be using the option passed by the user.
+          {cuda_mem_limit,
+           static_cast<int>(arena_extend_strategy),
+           -1, -1});
+
+      auto allocator = CreateAllocator(default_memory_info);
+
+      id_to_allocator_map.insert({id, allocator});
+    }
   }
 
   return id_to_allocator_map[id];
@@ -667,8 +711,7 @@ static void RegisterExecutionProviders(InferenceSession* sess, const std::vector
           if (option.first == "device_type") {
             openvino_device_type = option.second;
             params.device_type = openvino_device_type.c_str();
-          }  
-          else if (option.first == "enable_vpu_fast_compile") {
+          } else if (option.first == "enable_vpu_fast_compile") {
             if (option.second == "True") {
               params.enable_vpu_fast_compile = true;
             } else if (option.second == "False") {

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -25,27 +25,18 @@ __TEMP_ENABLE_METHOD_TIMING__ = False
 # Needed to re-implement PyTorch's cpu,cuda,to methods
 T = TypeVar('T', bound='Module')
 
-torch_cuda_allocator_addresses_cpp_source = \'\'\'
+torch_cuda_allocator_addresses_cpp_source = """
 #include <torch/extension.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 
-#include <iostream>
-
 size_t cuda_caching_allocator_raw_alloc_address() {
-    std::cout<<"\nc10::cuda::CUDACachingAllocator::raw_alloc address: " << reinterpret_cast<void*>(&c10::cuda::CUDACachingAllocator::raw_alloc) << "\n";
     return reinterpret_cast<size_t>(&c10::cuda::CUDACachingAllocator::raw_alloc);
 }
 
 size_t cuda_caching_allocator_raw_delete_address() {
-    std::cout<<"\nc10::cuda::CUDACachingAllocator::raw_delete address: " << reinterpret_cast<void*>(&c10::cuda::CUDACachingAllocator::raw_delete) << "\n";
     return reinterpret_cast<size_t>(&c10::cuda::CUDACachingAllocator::raw_delete);
 }
-
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def("raw_alloc", &cuda_caching_allocator_raw_alloc_address, "cuda_caching_allocator_raw_alloc_address");
-  m.def("raw_delete", &cuda_caching_allocator_raw_delete_address, "cuda_caching_allocator_raw_delete_address");
-}
-\'\'\'
+"""
 
 def _get_device_index(device):
     if isinstance(device, str):
@@ -170,7 +161,7 @@ class ORTModule(torch.nn.Module):
         self._save_onnx_prefix = ''
 
         # CPP extension to get torch CUDA allocator's alloc and free function addresses
-        self._torch_cuda_allocator = load_inline(name='inline_extension', cpp_sources=[torch_cuda_allocator_addresses_cpp_source], functions=['raw_alloc', 'raw_delete'], verbose=True, with_cuda=True)
+        self._torch_cuda_allocator = load_inline(name='inline_extension', cpp_sources=[torch_cuda_allocator_addresses_cpp_source], functions=['cuda_caching_allocator_raw_alloc_address', 'cuda_caching_allocator_raw_delete_address'], verbose=True, with_cuda=True)
 
     def _initialize_module_gradient_graph_builder(self):
 
@@ -200,9 +191,8 @@ class ORTModule(torch.nn.Module):
             # Configure the InferenceSessions to use the specific GPU on which the model is placed.
             providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
             provider_options = [{"device_id": str(self._device.index)},
-                                {"cuda_external_alloc": str(self._torch_cuda_allocator.raw_alloc())},
-                                {"cuda_external_free": str(self._torch_cuda_allocator.raw_delete())}]
-
+                                {"cuda_external_alloc": str(self._torch_cuda_allocator.cuda_caching_allocator_raw_alloc_address())},
+                                {"cuda_external_free": str(self._torch_cuda_allocator.cuda_caching_allocator_raw_delete_address())}]
         elif self._device.type == 'cpu':
             providers = ["CPUExecutionProvider"]
             provider_options = [{}]


### PR DESCRIPTION
The motivation for this change is to share allocator with PyTorch to prevent having multiple allocators hiding free spaces from one another