### PR TITLE
Fix Windows CI builds by updating test scripts to work with numpy 1.20.

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -332,7 +332,7 @@ class TestInferenceSession(unittest.TestCase):
 
     def testStringListAsInput(self):
         sess = onnxrt.InferenceSession(get_name("identity_string.onnx"))
-        x = np.array(['this', 'is', 'identity', 'test'], dtype=np.str).reshape((2, 2))
+        x = np.array(['this', 'is', 'identity', 'test'], dtype=str).reshape((2, 2))
         x_name = sess.get_inputs()[0].name
         res = sess.run([], {x_name: x.tolist()})
         np.testing.assert_equal(x, res[0])
@@ -360,8 +360,8 @@ class TestInferenceSession(unittest.TestCase):
 
     def testBooleanInputs(self):
         sess = onnxrt.InferenceSession(get_name("logicaland.onnx"))
-        a = np.array([[True, True], [False, False]], dtype=np.bool)
-        b = np.array([[True, False], [True, False]], dtype=np.bool)
+        a = np.array([[True, True], [False, False]], dtype=bool)
+        b = np.array([[True, False], [True, False]], dtype=bool)
 
         # input1:0 is first in the protobuf, and input:0 is second
         # and we maintain the original order.
@@ -386,13 +386,13 @@ class TestInferenceSession(unittest.TestCase):
         output_type = sess.get_outputs()[0].type
         self.assertEqual(output_type, 'tensor(bool)')
 
-        output_expected = np.array([[True, False], [False, False]], dtype=np.bool)
+        output_expected = np.array([[True, False], [False, False]], dtype=bool)
         res = sess.run([output_name], {a_name: a, b_name: b})
         np.testing.assert_equal(output_expected, res[0])
 
     def testStringInput1(self):
         sess = onnxrt.InferenceSession(get_name("identity_string.onnx"))
-        x = np.array(['this', 'is', 'identity', 'test'], dtype=np.str).reshape((2, 2))
+        x = np.array(['this', 'is', 'identity', 'test'], dtype=str).reshape((2, 2))
 
         x_name = sess.get_inputs()[0].name
         self.assertEqual(x_name, "input:0")
@@ -413,7 +413,7 @@ class TestInferenceSession(unittest.TestCase):
 
     def testStringInput2(self):
         sess = onnxrt.InferenceSession(get_name("identity_string.onnx"))
-        x = np.array(['Olá', '你好', '여보세요', 'hello'], dtype=np.unicode).reshape((2, 2))
+        x = np.array(['Olá', '你好', '여보세요', 'hello'], dtype=str).reshape((2, 2))
 
         x_name = sess.get_inputs()[0].name
         self.assertEqual(x_name, "input:0")
@@ -476,7 +476,9 @@ class TestInferenceSession(unittest.TestCase):
 
     def testInputVoid(self):
         sess = onnxrt.InferenceSession(get_name("identity_string.onnx"))
-        x = np.array([b'this', b'is', b'identity', b'test'], np.void).reshape((2, 2))
+        # numpy 1.20+ doesn't automatically pad the bytes based entries in the array when dtype is np.void,
+        # so we use inputs where that is the case
+        x = np.array([b'must', b'have', b'same', b'size'], dtype=np.void).reshape((2, 2))
 
         x_name = sess.get_inputs()[0].name
         self.assertEqual(x_name, "input:0")
@@ -494,14 +496,13 @@ class TestInferenceSession(unittest.TestCase):
 
         res = sess.run([output_name], {x_name: x})
 
-        expr = np.array([['this\x00\x00\x00\x00', 'is\x00\x00\x00\x00\x00\x00'], ['identity', 'test\x00\x00\x00\x00']],
-                        dtype=object)
+        expr = np.array([['must', 'have'], ['same', 'size']], dtype=object)
         np.testing.assert_equal(expr, res[0])
 
     def testRaiseWrongNumInputs(self):
         with self.assertRaises(ValueError) as context:
             sess = onnxrt.InferenceSession(get_name("logicaland.onnx"))
-            a = np.array([[True, True], [False, False]], dtype=np.bool)
+            a = np.array([[True, True], [False, False]], dtype=bool)
             res = sess.run([], {'input:0': a})
 
         self.assertTrue('Model requires 2 inputs' in str(context.exception))
@@ -559,8 +560,8 @@ class TestInferenceSession(unittest.TestCase):
         opt.graph_optimization_level = onnxrt.GraphOptimizationLevel.ORT_ENABLE_EXTENDED
         self.assertEqual(opt.graph_optimization_level, onnxrt.GraphOptimizationLevel.ORT_ENABLE_EXTENDED)
         sess = onnxrt.InferenceSession(get_name("logicaland.onnx"), sess_options=opt)
-        a = np.array([[True, True], [False, False]], dtype=np.bool)
-        b = np.array([[True, False], [True, False]], dtype=np.bool)
+        a = np.array([[True, True], [False, False]], dtype=bool)
+        b = np.array([[True, False], [True, False]], dtype=bool)
 
         res = sess.run([], {'input1:0': a, 'input:0': b})
 

--- a/onnxruntime/test/python/onnxruntime_test_python_mlops.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_mlops.py
@@ -125,7 +125,7 @@ class TestInferenceSession(unittest.TestCase):
         output_expected = np.array([3], ndmin=2, dtype=np.int64)
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
-        x = np.array(['4'], ndmin=2, dtype=np.object)
+        x = np.array(['4'], ndmin=2, dtype=object)
         res = sess.run([output_name], {input_name: x})
         output_expected = np.array([3], ndmin=2, dtype=np.int64)
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
@@ -134,11 +134,12 @@ class TestInferenceSession(unittest.TestCase):
         available_providers = onnxrt.get_available_providers()
 
         # The Windows GPU CI pipeline builds the wheel with both CUDA and DML enabled and ORT does not support cases
-        # where one node is asigned to CUDA and one node to DML as it doesn't have the data transfer capabilities to deal with
-        # potentially different device memory. Hence, use a session with only DML and CPU (excluding CUDA) for this test as it breaks
-        # with both CUDA and DML registered.
+        # where one node is assigned to CUDA and one node to DML, as it doesn't have the data transfer capabilities to
+        # deal with potentially different device memory. Hence, use a session with only DML and CPU (excluding CUDA)
+        # for this test as it breaks with both CUDA and DML registered.
         if ('CUDAExecutionProvider' in available_providers and 'DmlExecutionProvider' in available_providers):
-            sess = onnxrt.InferenceSession(get_name("mlnet_encoder.onnx"), None, ['DmlExecutionProvider', 'CPUExecutionProvider'])
+            sess = onnxrt.InferenceSession(get_name("mlnet_encoder.onnx"), None,
+                                           ['DmlExecutionProvider', 'CPUExecutionProvider'])
         else:
             sess = onnxrt.InferenceSession(get_name("mlnet_encoder.onnx"))
 
@@ -160,11 +161,12 @@ class TestInferenceSession(unittest.TestCase):
         # (to save space). It does not have this behaviour for void
         # but as a result, numpy does not know anymore the size
         # of each element, they all have the same size.
-        c1 = np.array([b'A\0A\0\0', b"B\0B\0", b"C\0C\0"], np.void).reshape(1, 3)
+        c1 = np.array([b'A\0A\0\0', b"B\0B\0\0", b"C\0C\0\0"], np.void).reshape(1, 3)
         res = sess.run(None, {'C0': c0, 'C1': c1})
         mat = res[1]
         total = mat.sum()
         self.assertEqual(total, 0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description**: 
pip install of numpy is bringing in a newer version which has some new deprecations and changed behavior.

- Some aliases are deprecated in favor of the built-in python types. 
  - See https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
- np.array with bytes for entries and dtype of np.void no longer automatically pads. Change a test to adjust for that.


**Motivation and Context**
Fix broken CI builds