### PR TITLE
Add type reduction support to Min, Max and Pow

### DIFF
--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
@@ -4,6 +4,7 @@
 #include "core/framework/data_types_internal.h"
 #include "core/providers/cpu/math/element_wise_ops.h"
 #include "core/providers/cpu/tensor/utils.h"
+#include "core/providers/op_kernel_type_control.h"
 #include <unsupported/Eigen/SpecialFunctions>
 #include "core/util/math.h"
 #include "core/mlas/inc/mlas.h"
@@ -11,6 +12,50 @@
 #include <cmath>
 
 namespace onnxruntime {
+// Supported types for operators that have type reduction enabled
+namespace op_kernel_type_control {
+// Max
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
+    kCpuExecutionProvider, kOnnxDomain, Max, 8, Input, 0, float, double);
+
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
+    kCpuExecutionProvider, kOnnxDomain, Max, 12, Input, 0,
+    float, double, MLFloat16, int32_t, uint32_t, int64_t, uint64_t);
+
+// Min
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
+    kCpuExecutionProvider, kOnnxDomain, Min, 8, Input, 0, float, double);
+
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
+    kCpuExecutionProvider, kOnnxDomain, Min, 12, Input, 0,
+    float, double, MLFloat16, int32_t, uint32_t, int64_t, uint64_t);
+
+// Pow
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
+    kCpuExecutionProvider, kOnnxDomain, Pow, 7, Input, 0, float, double);
+
+// Pow 12 and later has separate Base and Exponent types
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
+    kCpuExecutionProvider, kOnnxDomain, Pow, 12, Input, 0, int32_t, int64_t, float, double);
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
+    kCpuExecutionProvider, kOnnxDomain, Pow, 12, Input, 1, int32_t, int64_t, float, double);
+}  // namespace op_kernel_type_control
+
+//
+// reduce the supported type lists to what's allowed in this build
+//
+using EnabledMin8Types = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Min, 8, Input, 0);
+using EnabledMax8Types = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Max, 8, Input, 0);
+
+using EnabledMin12Types = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Min, 12, Input, 0);
+using EnabledMax12Types = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Max, 12, Input, 0);
+
+using EnabledPow7Types = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Pow, 7, Input, 0);
+using EnabledPow12BaseTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain,
+                                                                  Pow, 12, Input, 0);
+using EnabledPow12ExpTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain,
+                                                                 Pow, 12, Input, 1);
+
 namespace functors {
 template <>
 void Exp<float>::operator()(std::ptrdiff_t first, std::ptrdiff_t last) const {
@@ -56,25 +101,41 @@ void Exp<float>::operator()(std::ptrdiff_t first, std::ptrdiff_t last) const {
           .TypeConstraint("T1", DataTypeImpl::GetTensorType<bool>()),                                           \
       KERNEL_CLASS<TYPE>);
 
-// var args are type constraints for T and T1
-#define REG_ELEMENTWISE_KERNEL_NONT(OP_TYPE, VERSION, KERNEL_CLASS, ...)   \
-  ONNX_CPU_OPERATOR_KERNEL(                                                \
-      OP_TYPE,                                                             \
-      VERSION,                                                             \
-      KernelDefBuilder()                                                   \
-          .TypeConstraint("T", BuildKernelDefConstraints<__VA_ARGS__>())   \
-          .TypeConstraint("T1", BuildKernelDefConstraints<__VA_ARGS__>()), \
+#define REG_ELEMENTWISE_KERNEL_NONT(OP_TYPE, VERSION, KERNEL_CLASS, CONSTRAINTS) \
+  ONNX_CPU_OPERATOR_KERNEL(                                                      \
+      OP_TYPE,                                                                   \
+      VERSION,                                                                   \
+      KernelDefBuilder()                                                         \
+          .TypeConstraint("T", CONSTRAINTS),                                     \
       KERNEL_CLASS);
 
 // var args are type constraints for T and T1
-#define REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(OP_TYPE, VERSION_FROM, VERSION_TO, KERNEL_CLASS, ...) \
-  ONNX_CPU_OPERATOR_VERSIONED_KERNEL(                                                               \
-      OP_TYPE,                                                                                      \
-      VERSION_FROM,                                                                                 \
-      VERSION_TO,                                                                                   \
-      KernelDefBuilder()                                                                            \
-          .TypeConstraint("T", BuildKernelDefConstraints<__VA_ARGS__>())                            \
-          .TypeConstraint("T1", BuildKernelDefConstraints<__VA_ARGS__>()),                          \
+#define REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(OP_TYPE, VERSION_FROM, VERSION_TO, KERNEL_CLASS, CONSTRAINTS) \
+  ONNX_CPU_OPERATOR_VERSIONED_KERNEL(                                                                       \
+      OP_TYPE,                                                                                              \
+      VERSION_FROM,                                                                                         \
+      VERSION_TO,                                                                                           \
+      KernelDefBuilder()                                                                                    \
+          .TypeConstraint("T", CONSTRAINTS),                                                                \
+      KERNEL_CLASS);
+
+#define REG_ELEMENTWISE_KERNEL_NONT_2(OP_TYPE, VERSION, KERNEL_CLASS, T1_CONSTRAINTS, T2_CONSTRAINTS) \
+  ONNX_CPU_OPERATOR_KERNEL(                                                                           \
+      OP_TYPE,                                                                                        \
+      VERSION,                                                                                        \
+      KernelDefBuilder()                                                                              \
+          .TypeConstraint("T", T1_CONSTRAINTS)                                                        \
+          .TypeConstraint("T1", T2_CONSTRAINTS),                                                      \
+      KERNEL_CLASS);
+
+#define REG_ELEMENTWISE_VERSIONED_KERNEL_NONT_2(OP_TYPE, VERSION_FROM, VERSION_TO, KERNEL_CLASS, T1_CONSTRAINTS, T2_CONSTRAINTS) \
+  ONNX_CPU_OPERATOR_VERSIONED_KERNEL(                                                                                            \
+      OP_TYPE,                                                                                                                   \
+      VERSION_FROM,                                                                                                              \
+      VERSION_TO,                                                                                                                \
+      KernelDefBuilder()                                                                                                         \
+          .TypeConstraint("T", T1_CONSTRAINTS)                                                                                   \
+          .TypeConstraint("T1", T2_CONSTRAINTS),                                                                                 \
       KERNEL_CLASS);
 
 REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(Add, 7, 12, float, Add);
@@ -162,11 +223,14 @@ REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(Sqrt, 6, 12, double, Sqrt);
 REG_ELEMENTWISE_TYPED_KERNEL(Sqrt, 13, float, Sqrt);
 REG_ELEMENTWISE_TYPED_KERNEL(Sqrt, 13, double, Sqrt);
 
-REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Pow, 7, 11, Pow, float, double);
-// To reduce templetization we choose to support the below types for both
-// base and the exponent. This gives us 16 permutations
-REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Pow, 12, 12, Pow, int32_t, int64_t, float, double);
-REG_ELEMENTWISE_KERNEL_NONT(Pow, 13, Pow, int32_t, int64_t, float, double);
+const auto pow7_types = BuildKernelDefConstraintsFunctorFromTypeList<EnabledPow7Types>{}();
+// To reduce templatization we choose to support the below types for both
+// base and the exponent. This gives us 16 permutations.
+const auto pow12_base_types = BuildKernelDefConstraintsFunctorFromTypeList<EnabledPow12BaseTypes>{}();
+const auto pow12_exp_types = BuildKernelDefConstraintsFunctorFromTypeList<EnabledPow12ExpTypes>{}();
+REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Pow, 7, 11, Pow, pow7_types);
+REG_ELEMENTWISE_VERSIONED_KERNEL_NONT_2(Pow, 12, 12, Pow, pow12_base_types, pow12_exp_types);
+REG_ELEMENTWISE_KERNEL_NONT_2(Pow, 13, Pow, pow12_base_types, pow12_exp_types);
 
 REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(Exp, 6, 12, float, Exp);
 REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(Exp, 6, 12, double, Exp);
@@ -187,16 +251,21 @@ REG_ELEMENTWISE_TYPED_KERNEL(Sum, 13, float, Sum_8);
 REG_ELEMENTWISE_TYPED_KERNEL(Sum, 13, double, Sum_8);
 
 REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(Max, 6, 7, float, Max_6);
-REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Max, 8, 11, Max_8, float, double);
-REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Max, 12, 12, Max_8, float, double, MLFloat16, int32_t, uint32_t, int64_t, uint64_t);
-// Supposed to add BFloat16 but we are not supporting now, however, separate registration
-REG_ELEMENTWISE_KERNEL_NONT(Max, 13, Max_8, float, double, MLFloat16, int32_t, uint32_t, int64_t, uint64_t);
 
-REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(Min, 6, 7, float, Min_6);
-REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Min, 8, 11, Min_8, float);
-REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Min, 12, 12, Min_8, float, double, MLFloat16, int32_t, uint32_t, int64_t, uint64_t);
+const std::vector<MLDataType> max8_types = BuildKernelDefConstraintsFunctorFromTypeList<EnabledMax8Types>{}();
+const std::vector<MLDataType> max12_types = BuildKernelDefConstraintsFunctorFromTypeList<EnabledMax12Types>{}();
+REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Max, 8, 11, Max_8, max8_types);
+REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Max, 12, 12, Max_8, max12_types);
 // Supposed to add BFloat16 but we are not supporting now, however, separate registration
-REG_ELEMENTWISE_KERNEL_NONT(Min, 13, Min_8, float, double, MLFloat16, int32_t, uint32_t, int64_t, uint64_t);
+REG_ELEMENTWISE_KERNEL_NONT(Max, 13, Max_8, max12_types);
+
+const std::vector<MLDataType> min8_types = BuildKernelDefConstraintsFunctorFromTypeList<EnabledMin8Types>{}();
+const std::vector<MLDataType> min12_types = BuildKernelDefConstraintsFunctorFromTypeList<EnabledMin12Types>{}();
+REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(Min, 6, 7, float, Min_6);
+REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Min, 8, 11, Min_8, min8_types);
+REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Min, 12, 12, Min_8, min12_types);
+// Supposed to add BFloat16 but we are not supporting now, however, separate registration
+REG_ELEMENTWISE_KERNEL_NONT(Min, 13, Min_8, min12_types);
 
 REG_ELEMENTWISE_LOGICALOP_VERSIONED_TYPED_KERNEL(Less, 7, 8, float, Less);
 REG_ELEMENTWISE_LOGICALOP_VERSIONED_TYPED_KERNEL(Less, 7, 8, double, Less);

--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
@@ -15,40 +15,34 @@ namespace onnxruntime {
 // Supported types for operators that have type reduction enabled
 namespace op_kernel_type_control {
 // Max
-ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
-    kCpuExecutionProvider, kOnnxDomain, Max, 8, Input, 0, float, double);
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(kCpuExecutionProvider, kOnnxDomain, Max, 8, Input, 0, float, double);
 
-ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
-    kCpuExecutionProvider, kOnnxDomain, Max, 12, Input, 0,
-    float, double, MLFloat16, int32_t, uint32_t, int64_t, uint64_t);
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(kCpuExecutionProvider, kOnnxDomain, Max, 12, Input, 0,
+                                          float, double, MLFloat16, int32_t, uint32_t, int64_t, uint64_t);
 
 // Min
-ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
-    kCpuExecutionProvider, kOnnxDomain, Min, 8, Input, 0, float, double);
-
-ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
-    kCpuExecutionProvider, kOnnxDomain, Min, 12, Input, 0,
-    float, double, MLFloat16, int32_t, uint32_t, int64_t, uint64_t);
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(kCpuExecutionProvider, kOnnxDomain, Min, 8, Input, 0, float, double);
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(kCpuExecutionProvider, kOnnxDomain, Min, 12,
+                                          Input, 0, float, double, MLFloat16, int32_t, uint32_t, int64_t, uint64_t);
 
 // Pow
-ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
-    kCpuExecutionProvider, kOnnxDomain, Pow, 7, Input, 0, float, double);
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(kCpuExecutionProvider, kOnnxDomain, Pow, 7, Input, 0, float, double);
 
 // Pow 12 and later has separate Base and Exponent types
-ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
-    kCpuExecutionProvider, kOnnxDomain, Pow, 12, Input, 0, int32_t, int64_t, float, double);
-ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
-    kCpuExecutionProvider, kOnnxDomain, Pow, 12, Input, 1, int32_t, int64_t, float, double);
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(kCpuExecutionProvider, kOnnxDomain, Pow, 12,
+                                          Input, 0, int32_t, int64_t, float, double);
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(kCpuExecutionProvider, kOnnxDomain, Pow, 12,
+                                          Input, 1, int32_t, int64_t, float, double);
 }  // namespace op_kernel_type_control
 
 //
 // reduce the supported type lists to what's allowed in this build
 //
-using EnabledMin8Types = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Min, 8, Input, 0);
 using EnabledMax8Types = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Max, 8, Input, 0);
-
-using EnabledMin12Types = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Min, 12, Input, 0);
 using EnabledMax12Types = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Max, 12, Input, 0);
+
+using EnabledMin8Types = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Min, 8, Input, 0);
+using EnabledMin12Types = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Min, 12, Input, 0);
 
 using EnabledPow7Types = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Pow, 7, Input, 0);
 using EnabledPow12BaseTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain,

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -30,9 +30,9 @@ using namespace boost::mp11;
 namespace onnxruntime {
 
 namespace op_kernel_type_control {
-// we're using one set of types for all opsets of Cast, so use -1 as a generic opset value
-ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
-    kCpuExecutionProvider, kOnnxDomain, Cast, -1, Input, 0,
+// we're using one set of types for all opsets of Cast
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, Cast, Input, 0,
     bool,
     float, double,
     uint8_t, uint16_t, uint32_t, uint64_t,
@@ -40,8 +40,8 @@ ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
     MLFloat16, BFloat16,
     std::string);
 
-ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
-    kCpuExecutionProvider, kOnnxDomain, Cast, -1, Output, 0,
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, Cast, Output, 0,
     bool,
     float, double,
     uint8_t, uint16_t, uint32_t, uint64_t,
@@ -51,9 +51,10 @@ ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
 }  // namespace op_kernel_type_control
 
 namespace {
-
-using EnabledSrcTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Cast, -1, Input, 0);
-using EnabledDstTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Cast, -1, Output, 0);
+using EnabledSrcTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST_ALL_OPSETS(kCpuExecutionProvider, kOnnxDomain,
+                                                                       Cast, Input, 0);
+using EnabledDstTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST_ALL_OPSETS(kCpuExecutionProvider, kOnnxDomain,
+                                                                       Cast, Output, 0);
 
 using IndirectCastTypes = TypeList<MLFloat16, BFloat16>;
 

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -30,8 +30,9 @@ using namespace boost::mp11;
 namespace onnxruntime {
 
 namespace op_kernel_type_control {
+// we're using one set of types for all opsets of Cast, so use -1 as a generic opset value
 ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
-    kCpuExecutionProvider, kOnnxDomain, Cast, Input, 0,
+    kCpuExecutionProvider, kOnnxDomain, Cast, -1, Input, 0,
     bool,
     float, double,
     uint8_t, uint16_t, uint32_t, uint64_t,
@@ -40,7 +41,7 @@ ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
     std::string);
 
 ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
-    kCpuExecutionProvider, kOnnxDomain, Cast, Output, 0,
+    kCpuExecutionProvider, kOnnxDomain, Cast, -1, Output, 0,
     bool,
     float, double,
     uint8_t, uint16_t, uint32_t, uint64_t,
@@ -51,8 +52,8 @@ ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
 
 namespace {
 
-using EnabledSrcTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Cast, Input, 0);
-using EnabledDstTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Cast, Output, 0);
+using EnabledSrcTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Cast, -1, Input, 0);
+using EnabledDstTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, Cast, -1, Output, 0);
 
 using IndirectCastTypes = TypeList<MLFloat16, BFloat16>;
 

--- a/onnxruntime/core/providers/cpu/tensor/isinf.cc
+++ b/onnxruntime/core/providers/cpu/tensor/isinf.cc
@@ -14,14 +14,15 @@ namespace onnxruntime {
 // https://github.com/onnx/onnx/blob/master/docs/Operators.md#IsInf
 
 namespace op_kernel_type_control {
-ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
-    kCpuExecutionProvider, kOnnxDomain, IsInf, -1, Input, 0,
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, IsInf, Input, 0,
     float, double);
 }  // namespace op_kernel_type_control
 
 class IsInf final : public OpKernel {
  public:
-  using EnabledTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, IsInf, -1, Input, 0);
+  using EnabledTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST_ALL_OPSETS(kCpuExecutionProvider, kOnnxDomain,
+                                                                      IsInf, Input, 0);
 
   explicit IsInf(const OpKernelInfo& info);
   Status Compute(OpKernelContext* context) const override;

--- a/onnxruntime/core/providers/cpu/tensor/isinf.cc
+++ b/onnxruntime/core/providers/cpu/tensor/isinf.cc
@@ -15,13 +15,13 @@ namespace onnxruntime {
 
 namespace op_kernel_type_control {
 ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(
-    kCpuExecutionProvider, kOnnxDomain, IsInf, Input, 0,
+    kCpuExecutionProvider, kOnnxDomain, IsInf, -1, Input, 0,
     float, double);
 }  // namespace op_kernel_type_control
 
 class IsInf final : public OpKernel {
  public:
-  using EnabledTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, IsInf, Input, 0);
+  using EnabledTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(kCpuExecutionProvider, kOnnxDomain, IsInf, -1, Input, 0);
 
   explicit IsInf(const OpKernelInfo& info);
   Status Compute(OpKernelContext* context) const override;

--- a/onnxruntime/core/providers/op_kernel_type_control.h
+++ b/onnxruntime/core/providers/op_kernel_type_control.h
@@ -248,7 +248,7 @@ struct EnabledTypes {
  * @param ArgIndex Index of the given Op kernel argument.
  */
 #define ORT_OP_KERNEL_ARG_ENABLED_TYPE_TUPLE(                                              \
-    OpProvider, OpDomain, OpName, Opset, ArgDirection, ArgIndex)                           \
+    OpProvider, OpDomain, OpName, OpSet, ArgDirection, ArgIndex)                           \
   ::boost::mp11::mp_rename<                                                                \
       ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(                                                 \
           OpProvider, OpDomain, OpName, OpSet, ArgDirection, ArgIndex, SupportedTypeList), \
@@ -264,7 +264,7 @@ struct EnabledTypes {
  * @param ArgIndex Index of the given Op kernel argument.
  */
 #define ORT_OP_KERNEL_ARG_ENABLED_TYPE_TUPLE_ALL_OPSETS(                                  \
-    OpProvider, OpDomain, OpName, Opset, ArgDirection, ArgIndex)                          \
+    OpProvider, OpDomain, OpName, ArgDirection, ArgIndex)                                 \
   ORT_OP_KERNEL_ARG_ENABLED_TYPE_TUPLE(OpProvider, OpDomain, OpName,                      \
                                        ::onnxruntime::op_kernel_type_control::kAllOpSets, \
                                        ArgDirection, ArgIndex)


### PR DESCRIPTION
**Description**: 
Add type reduction support to Min, Max and Pow
Update the C++ type reduction infrastructure to allow specifying an opset for the supported types list, as those can change across opset versions.
Minor updates to the type usage tracking script

**Motivation and Context**
Reduce build size for 1P models