### PR TITLE
Optimize CPU ConvGrad kernel for pointwise convolutions

### DIFF
--- a/orttraining/orttraining/test/gradient/gradient_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/gradient_ops_test.cc
@@ -803,15 +803,15 @@ void ConvGradientCheckerTest(std::vector<std::unique_ptr<IExecutionProvider>>* e
   OpDef op_def{"Conv"};
   float error_tolerance = 1e-1f;
 
-  //conv dead simple
+  // 1D convolution
   {
-    TensorShape x_shape({1, 1, 1, 1});
-    TensorShape w_shape({1, 1, 1, 1});
+    TensorShape x_shape({2, 1, 5});
+    TensorShape w_shape({1, 1, 3});
     TensorShape b_shape({1});
-    TensorShape y_shape({1, 1, 1, 1});
+    TensorShape y_shape({2, 1, 5});
     gradient_checker.ComputeGradientError(op_def, {x_shape, w_shape, b_shape}, {y_shape}, &max_error,
-                                          {MakeAttribute("kernel_shape", std::vector<int64_t>{1, 1}),
-                                           MakeAttribute("pads", std::vector<int64_t>{0, 0, 0, 0})},
+                                          {MakeAttribute("kernel_shape", std::vector<int64_t>{3}),
+                                           MakeAttribute("pads", std::vector<int64_t>{1, 1})},
                                           // TODO: ConvGrad does not handle the case where W does not have gradient.
                                           // Check for not has_gradient need to be disabled to pass this test.
                                           false,
@@ -820,7 +820,59 @@ void ConvGradientCheckerTest(std::vector<std::unique_ptr<IExecutionProvider>>* e
     EXPECT_IS_TINIER_THAN(max_error, error_tolerance);
   }
 
-  //conv simple
+  // 1D strided convolution
+  {
+    TensorShape x_shape({2, 1, 7});
+    TensorShape w_shape({1, 1, 3});
+    TensorShape b_shape({1});
+    TensorShape y_shape({2, 1, 4});
+    gradient_checker.ComputeGradientError(op_def, {x_shape, w_shape, b_shape}, {y_shape}, &max_error,
+                                          {MakeAttribute("kernel_shape", std::vector<int64_t>{3}),
+                                           MakeAttribute("pads", std::vector<int64_t>{1, 1}),
+                                           MakeAttribute("strides", std::vector<int64_t>{2})},
+                                          // TODO: ConvGrad does not handle the case where W does not have gradient.
+                                          // Check for not has_gradient need to be disabled to pass this test.
+                                          false,
+                                          false,
+                                          execution_providers);
+    EXPECT_IS_TINIER_THAN(max_error, error_tolerance);
+  }
+
+  // 1D pointwise convolution (with padding)
+  {
+    TensorShape x_shape({2, 1, 5});
+    TensorShape w_shape({1, 1, 1});
+    TensorShape b_shape({1});
+    TensorShape y_shape({2, 1, 7});
+    gradient_checker.ComputeGradientError(op_def, {x_shape, w_shape, b_shape}, {y_shape}, &max_error,
+                                          {MakeAttribute("kernel_shape", std::vector<int64_t>{1}),
+                                           MakeAttribute("pads", std::vector<int64_t>{1, 1})},
+                                          // TODO: ConvGrad does not handle the case where W does not have gradient.
+                                          // Check for not has_gradient need to be disabled to pass this test.
+                                          false,
+                                          false,
+                                          execution_providers);
+    EXPECT_IS_TINIER_THAN(max_error, error_tolerance);
+  }
+
+  // 1D pointwise convolution (no padding)
+  {
+    TensorShape x_shape({2, 1, 5});
+    TensorShape w_shape({1, 1, 1});
+    TensorShape b_shape({1});
+    TensorShape y_shape({2, 1, 5});
+    gradient_checker.ComputeGradientError(op_def, {x_shape, w_shape, b_shape}, {y_shape}, &max_error,
+                                          {MakeAttribute("kernel_shape", std::vector<int64_t>{1}),
+                                           MakeAttribute("pads", std::vector<int64_t>{0, 0})},
+                                          // TODO: ConvGrad does not handle the case where W does not have gradient.
+                                          // Check for not has_gradient need to be disabled to pass this test.
+                                          false,
+                                          false,
+                                          execution_providers);
+    EXPECT_IS_TINIER_THAN(max_error, error_tolerance);
+  }
+
+  // 2D convolution
   {
     TensorShape x_shape({1, 1, 3, 3});
     TensorShape w_shape({1, 1, 3, 3});
@@ -837,7 +889,7 @@ void ConvGradientCheckerTest(std::vector<std::unique_ptr<IExecutionProvider>>* e
     EXPECT_IS_TINIER_THAN(max_error, error_tolerance);
   }
 
-  //conv
+  // 2D convolution
   {
     TensorShape x_shape({2, 1, 5, 5});
     TensorShape w_shape({1, 1, 3, 3});
@@ -854,7 +906,41 @@ void ConvGradientCheckerTest(std::vector<std::unique_ptr<IExecutionProvider>>* e
     EXPECT_IS_TINIER_THAN(max_error, error_tolerance);
   }
 
-  //conv_with_strides
+  // 2D pointwise convolution (with padding)
+  {
+    TensorShape x_shape({1, 1, 1, 1});
+    TensorShape w_shape({1, 1, 1, 1});
+    TensorShape b_shape({1});
+    TensorShape y_shape({1, 1, 3, 3});
+    gradient_checker.ComputeGradientError(op_def, {x_shape, w_shape, b_shape}, {y_shape}, &max_error,
+                                          {MakeAttribute("kernel_shape", std::vector<int64_t>{1, 1}),
+                                           MakeAttribute("pads", std::vector<int64_t>{1, 1, 1, 1})},
+                                          // TODO: ConvGrad does not handle the case where W does not have gradient.
+                                          // Check for not has_gradient need to be disabled to pass this test.
+                                          false,
+                                          false,
+                                          execution_providers);
+    EXPECT_IS_TINIER_THAN(max_error, error_tolerance);
+  }
+
+  // 2D pointwise convolution (no padding)
+  {
+    TensorShape x_shape({1, 1, 1, 1});
+    TensorShape w_shape({1, 1, 1, 1});
+    TensorShape b_shape({1});
+    TensorShape y_shape({1, 1, 1, 1});
+    gradient_checker.ComputeGradientError(op_def, {x_shape, w_shape, b_shape}, {y_shape}, &max_error,
+                                          {MakeAttribute("kernel_shape", std::vector<int64_t>{1, 1}),
+                                           MakeAttribute("pads", std::vector<int64_t>{0, 0, 0, 0})},
+                                          // TODO: ConvGrad does not handle the case where W does not have gradient.
+                                          // Check for not has_gradient need to be disabled to pass this test.
+                                          false,
+                                          false,
+                                          execution_providers);
+    EXPECT_IS_TINIER_THAN(max_error, error_tolerance);
+  }
+
+  // 2D strided convolution
   {
     TensorShape x_shape({2, 1, 7, 5});
     TensorShape w_shape({1, 1, 3, 3});
@@ -872,7 +958,7 @@ void ConvGradientCheckerTest(std::vector<std::unique_ptr<IExecutionProvider>>* e
     EXPECT_IS_TINIER_THAN(max_error, error_tolerance);
   }
 
-  //conv_with_dilation
+  // 2D dilated convolution (no padding)
   {
     TensorShape x_shape({2, 1, 5, 5});
     TensorShape w_shape({1, 1, 3, 3});
@@ -890,7 +976,7 @@ void ConvGradientCheckerTest(std::vector<std::unique_ptr<IExecutionProvider>>* e
     EXPECT_IS_TINIER_THAN(max_error, error_tolerance);
   }
 
-  //conv_with_dilation
+  // 2D dilated convolution (with padding)
   {
     TensorShape x_shape({2, 1, 7, 5});
     TensorShape w_shape({1, 1, 3, 3});
@@ -908,7 +994,7 @@ void ConvGradientCheckerTest(std::vector<std::unique_ptr<IExecutionProvider>>* e
     EXPECT_IS_TINIER_THAN(max_error, error_tolerance);
   }
 
-  //conv3d
+  // 3D convolution
   {
     TensorShape x_shape({2, 1, 5, 5, 5});
     TensorShape w_shape({1, 1, 3, 3, 3});
@@ -925,7 +1011,7 @@ void ConvGradientCheckerTest(std::vector<std::unique_ptr<IExecutionProvider>>* e
     EXPECT_IS_TINIER_THAN(max_error, error_tolerance);
   }
 
-  //conv3d_with_strides
+  // 3D strided convolution
   {
     TensorShape x_shape({2, 1, 7, 5, 5});
     TensorShape w_shape({1, 1, 3, 3, 3});

--- a/orttraining/orttraining/training_ops/cpu/nn/conv_grad.cc
+++ b/orttraining/orttraining/training_ops/cpu/nn/conv_grad.cc
@@ -40,19 +40,19 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
   // Copied from conv_impl.h, maybe refactor
   std::vector<int64_t> kernel_shape;
   ORT_RETURN_IF_ERROR(conv_attrs_.ComputeKernelShape(W->Shape(), kernel_shape));
+  size_t kernel_rank = kernel_shape.size();
 
-  bool Is2DKernel = kernel_shape.size() == 2;
   std::vector<int64_t> pads(conv_attrs_.pads);
   if (pads.empty()) {
-    pads.resize(kernel_shape.size() * 2, 0);
+    pads.resize(kernel_rank * 2, 0);
   }
   std::vector<int64_t> dilations(conv_attrs_.dilations);
   if (dilations.empty()) {
-    dilations.resize(kernel_shape.size(), 1);
+    dilations.resize(kernel_rank, 1);
   }
   std::vector<int64_t> strides(conv_attrs_.strides);
   if (strides.empty()) {
-    strides.resize(kernel_shape.size(), 1);
+    strides.resize(kernel_rank, 1);
   }
 
   Tensor* dW = context->Output(1, W->Shape());
@@ -85,7 +85,7 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
 
   BufferUniquePtr bias_multiplier(alloc->Alloc(sizeof(T) * output_image_size), BufferDeleter(alloc));
   T* bias_multiplier_data = nullptr;
-  Tensor* dB = context->Output(2, TensorShape({M}));
+  Tensor* dB = context->Output(2, {M});
   T* dBdata = nullptr;
   if (dB) {
     dBdata = dB->template MutableData<T>();
@@ -98,37 +98,58 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
                               &CPUMathUtil::Instance());
   }
 
+  bool skip_im2col = (kernel_size == 1) && conv_attrs_.HasStridesOneAndNoPadding();
+
   for (int image_id = 0; image_id < N; ++image_id) {
     for (int group_id = 0; group_id < conv_attrs_.group; ++group_id) {
-      if (Is2DKernel) {
-        math::Im2col<T, StorageOrder::NCHW>()(
-            Xdata + group_id * X_offset,
-            C / conv_attrs_.group,
-            input_shape[0],
-            input_shape[1],
-            kernel_shape[0],
-            kernel_shape[1],
-            dilations[0],
-            dilations[1],
-            pads[0],
-            pads[1],
-            pads[2],
-            pads[3],
-            strides[0],
-            strides[1],
-            col_buffer_data);
-      } else {
-        math::Im2col<T, StorageOrder::NCHW>()(
-            Xdata + group_id * X_offset,
-            input_shape.GetDims().data(),
-            output_shape.GetDims().data(),
-            kernel_dim,
-            kernel_shape.data(),
-            strides.data(),
-            dilations.data(),
-            pads.data(),
-            static_cast<int>(kernel_shape.size()),
-            col_buffer_data);
+      if (!skip_im2col) {
+        if (kernel_rank == 1) {
+          math::Im2col<T, StorageOrder::NCHW>()(
+              Xdata + group_id * X_offset,
+              C / conv_attrs_.group,
+              1,
+              input_shape[0],
+              1,
+              kernel_shape[0],
+              1,
+              dilations[0],
+              0,
+              pads[0],
+              0,
+              pads[1],
+              1,
+              strides[0],
+              col_buffer_data);
+        } else if (kernel_rank == 2) {
+          math::Im2col<T, StorageOrder::NCHW>()(
+              Xdata + group_id * X_offset,
+              C / conv_attrs_.group,
+              input_shape[0],
+              input_shape[1],
+              kernel_shape[0],
+              kernel_shape[1],
+              dilations[0],
+              dilations[1],
+              pads[0],
+              pads[1],
+              pads[2],
+              pads[3],
+              strides[0],
+              strides[1],
+              col_buffer_data);
+        } else {
+          math::Im2col<T, StorageOrder::NCHW>()(
+              Xdata + group_id * X_offset,
+              input_shape.GetDims().data(),
+              output_shape.GetDims().data(),
+              kernel_dim,
+              kernel_shape.data(),
+              strides.data(),
+              dilations.data(),
+              pads.data(),
+              static_cast<int>(kernel_shape.size()),
+              col_buffer_data);
+        }
       }
       // Gradient with respect to W, filter.
       math::Gemm<T>(
@@ -139,7 +160,7 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
           output_image_size,
           1,
           dYdata + group_id * Y_offset,
-          col_buffer_data,
+          skip_im2col ? Xdata + group_id * X_offset : col_buffer_data,
           1,
           dWdata + group_id * W_offset,
           tp);
@@ -181,7 +202,7 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
             col_buffer_data,
             tp);
 
-        if (Is2DKernel) {
+        if (kernel_rank == 2) {
           math::Col2im<T, CPUMathUtil, StorageOrder::NCHW>(
               col_buffer_data,
               C / conv_attrs_.group,


### PR DESCRIPTION
**Description**: Optimize the CPU ConvGrad kernel for pointwise convolutions.

All credit for the optimizations goes to @tracysh.

**Motivation and Context**
- Speeds up CPU training for a model that uses 1-D pointwise convolutions by avoiding unnecessary `col2im()` transformation.
