### PR TITLE
Add missing transforms, clear iobinding

### DIFF
--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -37,6 +37,8 @@
 #include "core/optimizer/skip_layer_norm_fusion.h"
 #include "core/optimizer/slice_elimination.h"
 #include "core/optimizer/unsqueeze_elimination.h"
+#include "core/optimizer/matmul_transpose_fusion.h"
+#include "orttraining/core/optimizer/bias_dropout_fusion.h"
 
 namespace onnxruntime {
 class IExecutionProvider;
@@ -151,6 +153,8 @@ std::vector<std::unique_ptr<GraphTransformer>> GenerateTransformers(TransformerL
       transformers.emplace_back(onnxruntime::make_unique<AttentionFusion>(cpu_cuda_execution_providers));
       transformers.emplace_back(onnxruntime::make_unique<EmbedLayerNormFusion>(cpu_cuda_execution_providers));
 
+      transformers.emplace_back(onnxruntime::make_unique<BiasDropoutFusion>(cpu_cuda_execution_providers));
+      transformers.emplace_back(onnxruntime::make_unique<MatmulTransposeFusion>(cpu_cuda_execution_providers));
       transformers.emplace_back(onnxruntime::make_unique<BiasGeluFusion>(cpu_cuda_execution_providers));
       transformers.emplace_back(onnxruntime::make_unique<BiasSoftmaxFusion>(cpu_cuda_execution_providers));
       transformers.emplace_back(onnxruntime::make_unique<SkipLayerNormFusion>(cpu_cuda_execution_providers));

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -154,6 +154,7 @@ std::vector<std::unique_ptr<GraphTransformer>> GenerateTransformers(TransformerL
       transformers.emplace_back(onnxruntime::make_unique<EmbedLayerNormFusion>(cpu_cuda_execution_providers));
 
       transformers.emplace_back(onnxruntime::make_unique<BiasDropoutFusion>(cpu_cuda_execution_providers));
+      // TODO: This should be combined with MatMulScaleFusion and deprecate MatmulTransposeFusion
       transformers.emplace_back(onnxruntime::make_unique<MatmulTransposeFusion>(cpu_cuda_execution_providers));
       transformers.emplace_back(onnxruntime::make_unique<BiasGeluFusion>(cpu_cuda_execution_providers));
       transformers.emplace_back(onnxruntime::make_unique<BiasSoftmaxFusion>(cpu_cuda_execution_providers));

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -376,6 +376,11 @@ class ORTModule(torch.nn.Module):
                 # Append backward ouput for all trained initializers
                 results += [_ort_output_to_torch_tensor(backward_output)
                             for backward_output in backward_outputs[:num_initializers]]
+
+                # The OrtValue has a shared_ptr to the data. At this point there are two shared_ptrs to the data, one throught the 
+                # OrtValue in the output iobinding, and the other through the copy in OrtDLManagedTensor.
+                # The following call clears the iobinding output, reducing the use_count to 1, so that once torch finishes computation
+                # on the DLpack tensors, the memory can be freed.
                 self._gradient_io_binding.clear_binding_outputs()
                 return tuple(results)
 

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -376,6 +376,7 @@ class ORTModule(torch.nn.Module):
                 # Append backward ouput for all trained initializers
                 results += [_ort_output_to_torch_tensor(backward_output)
                             for backward_output in backward_outputs[:num_initializers]]
+                self._gradient_io_binding.clear_binding_outputs()
                 return tuple(results)
 
         return _ORTModuleFunction.apply(*self._convert_gradient_graph_input_to_list(self._original_module, *inputs, **kwargs))


### PR DESCRIPTION
This PR enables some missing graph fusion transforms, which helps reduce peak activation memory size, and also clears output iobinding to remove ORT's ref to the gradient buffer.