### PR TITLE
Don't send out Runtime error telemetry when can't create LearningModelDevice on machine without hardware adapters

### DIFF
--- a/winml/dll/module.cpp
+++ b/winml/dll/module.cpp
@@ -20,18 +20,6 @@
 
 using namespace winmlp;
 
-void __stdcall OnErrorReported(bool alreadyReported, wil::FailureInfo const& failure) WI_NOEXCEPT {
-  if (!alreadyReported) {
-    winrt::hstring message(failure.pszMessage ? failure.pszMessage : L"");
-    telemetry_helper.LogRuntimeError(
-        failure.hr,
-        winrt::to_string(message),
-        failure.pszFile,
-        failure.pszFunction,
-        failure.uLineNumber);
-  }
-}
-
 extern "C" BOOL WINAPI DllMain(_In_ HINSTANCE hInstance, DWORD dwReason, _In_ void* lpvReserved) {
   switch (dwReason) {
     case DLL_PROCESS_ATTACH:
@@ -40,7 +28,6 @@ extern "C" BOOL WINAPI DllMain(_In_ HINSTANCE hInstance, DWORD dwReason, _In_ vo
       // Register the TraceLogging provider feeding telemetry.  It's OK if this fails;
       // trace logging calls just become no-ops.
       telemetry_helper.Register();
-      wil::SetResultTelemetryFallback(&OnErrorReported);
       break;
     case DLL_PROCESS_DETACH:
       telemetry_helper.LogWinMLShutDown();

--- a/winml/lib/Api.Image/D3DDeviceCache.cpp
+++ b/winml/lib/Api.Image/D3DDeviceCache.cpp
@@ -62,7 +62,7 @@ D3DDeviceCache::D3DDeviceCache(winml::LearningModelDeviceKind const& deviceKind)
     winrt::com_ptr<IDXGIAdapter1> spAdapter;
     hardwareAdapterSuccessfullyObtained = GetDXGIHardwareAdapterWithPreference(preference, spAdapter.put());
     if (hardwareAdapterSuccessfullyObtained == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
-      WINML_THROW_HR_IF_TRUE_MSG_NO_TELEMETRY_SENT(hardwareAdapterSuccessfullyObtained, true, noHardwareAdaptersAvailableErrStr);
+      WINML_THROW_HR_MSG_NO_TELEMETRY_SENT(hardwareAdapterSuccessfullyObtained, noHardwareAdaptersAvailableErrStr);
     } else {
       WINML_THROW_IF_FAILED_MSG(hardwareAdapterSuccessfullyObtained, failedToObtainHardwareAdaptersErrStr);
     }
@@ -73,7 +73,7 @@ D3DDeviceCache::D3DDeviceCache(winml::LearningModelDeviceKind const& deviceKind)
     winrt::com_ptr<IDXCoreAdapter> spAdapter;
     hardwareAdapterSuccessfullyObtained = GetDXCoreHardwareAdapterWithPreference(preference, spAdapter.put());
     if (hardwareAdapterSuccessfullyObtained == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
-      WINML_THROW_HR_IF_TRUE_MSG_NO_TELEMETRY_SENT(hardwareAdapterSuccessfullyObtained, true, noHardwareAdaptersAvailableErrStr);
+      WINML_THROW_HR_MSG_NO_TELEMETRY_SENT(hardwareAdapterSuccessfullyObtained, noHardwareAdaptersAvailableErrStr);
     } else {
       WINML_THROW_IF_FAILED_MSG(hardwareAdapterSuccessfullyObtained, failedToObtainHardwareAdaptersErrStr);
     }

--- a/winml/lib/Api.Image/D3DDeviceCache.cpp
+++ b/winml/lib/Api.Image/D3DDeviceCache.cpp
@@ -55,15 +55,16 @@ D3DDeviceCache::D3DDeviceCache(winml::LearningModelDeviceKind const& deviceKind)
   CommonDeviceHelpers::AdapterEnumerationSupport support;
   WINML_THROW_IF_FAILED(CommonDeviceHelpers::GetAdapterEnumerationSupport(&support));
 
-  const char errStr[] = "No hardware adapters available";
+  const char noHardwareAdaptersAvailableErrStr[] = "No hardware adapters available";
+  const char failedToObtainHardwareAdaptersErrStr[] = "Failed to obtain hardware adapters.";
   HRESULT hardwareAdapterSuccessfullyObtained = S_OK;
   if (support.has_dxgi) {
     winrt::com_ptr<IDXGIAdapter1> spAdapter;
     hardwareAdapterSuccessfullyObtained = GetDXGIHardwareAdapterWithPreference(preference, spAdapter.put());
     if (hardwareAdapterSuccessfullyObtained == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
-      WINML_THROW_HR_IF_TRUE_MSG_NO_TELEMETRY_SENT(hardwareAdapterSuccessfullyObtained, true, errStr);
+      WINML_THROW_HR_IF_TRUE_MSG_NO_TELEMETRY_SENT(hardwareAdapterSuccessfullyObtained, true, noHardwareAdaptersAvailableErrStr);
     } else {
-      WINML_THROW_IF_FAILED_MSG(hardwareAdapterSuccessfullyObtained, "Failed to obtain hardware adapters.");
+      WINML_THROW_IF_FAILED_MSG(hardwareAdapterSuccessfullyObtained, failedToObtainHardwareAdaptersErrStr);
     }
     WINML_THROW_IF_FAILED(D3D12CreateDevice(spAdapter.get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(device_.put())));
   }
@@ -72,9 +73,9 @@ D3DDeviceCache::D3DDeviceCache(winml::LearningModelDeviceKind const& deviceKind)
     winrt::com_ptr<IDXCoreAdapter> spAdapter;
     hardwareAdapterSuccessfullyObtained = GetDXCoreHardwareAdapterWithPreference(preference, spAdapter.put());
     if (hardwareAdapterSuccessfullyObtained == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
-      WINML_THROW_HR_IF_TRUE_MSG_NO_TELEMETRY_SENT(hardwareAdapterSuccessfullyObtained, true, errStr);
+      WINML_THROW_HR_IF_TRUE_MSG_NO_TELEMETRY_SENT(hardwareAdapterSuccessfullyObtained, true, noHardwareAdaptersAvailableErrStr);
     } else {
-      WINML_THROW_IF_FAILED_MSG(hardwareAdapterSuccessfullyObtained, "Failed to obtain hardware adapters.");
+      WINML_THROW_IF_FAILED_MSG(hardwareAdapterSuccessfullyObtained, failedToObtainHardwareAdaptersErrStr);
     }
     WINML_THROW_IF_FAILED(D3D12CreateDevice(spAdapter.get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(device_.put())));
   }

--- a/winml/lib/Api.Image/D3DDeviceCache.cpp
+++ b/winml/lib/Api.Image/D3DDeviceCache.cpp
@@ -56,15 +56,26 @@ D3DDeviceCache::D3DDeviceCache(winml::LearningModelDeviceKind const& deviceKind)
   WINML_THROW_IF_FAILED(CommonDeviceHelpers::GetAdapterEnumerationSupport(&support));
 
   const char errStr[] = "No hardware adapters available";
+  HRESULT hardwareAdapterSuccessfullyObtained = S_OK;
   if (support.has_dxgi) {
     winrt::com_ptr<IDXGIAdapter1> spAdapter;
-    WINML_THROW_IF_FAILED_MSG(GetDXGIHardwareAdapterWithPreference(preference, spAdapter.put()), errStr);
+    hardwareAdapterSuccessfullyObtained = GetDXGIHardwareAdapterWithPreference(preference, spAdapter.put());
+    if (hardwareAdapterSuccessfullyObtained == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+      WINML_THROW_HR_IF_TRUE_MSG_NO_TELEMETRY_SENT(hardwareAdapterSuccessfullyObtained, true, errStr);
+    } else {
+      WINML_THROW_IF_FAILED_MSG(hardwareAdapterSuccessfullyObtained, "Failed to obtain hardware adapters.");
+    }
     WINML_THROW_IF_FAILED(D3D12CreateDevice(spAdapter.get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(device_.put())));
   }
 #ifdef ENABLE_DXCORE
   if (support.has_dxgi == false) {
     winrt::com_ptr<IDXCoreAdapter> spAdapter;
-    WINML_THROW_IF_FAILED_MSG(GetDXCoreHardwareAdapterWithPreference(preference, spAdapter.put()), errStr);
+    hardwareAdapterSuccessfullyObtained = GetDXCoreHardwareAdapterWithPreference(preference, spAdapter.put());
+    if (hardwareAdapterSuccessfullyObtained == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+      WINML_THROW_HR_IF_TRUE_MSG_NO_TELEMETRY_SENT(hardwareAdapterSuccessfullyObtained, true, errStr);
+    } else {
+      WINML_THROW_IF_FAILED_MSG(hardwareAdapterSuccessfullyObtained, "Failed to obtain hardware adapters.");
+    }
     WINML_THROW_IF_FAILED(D3D12CreateDevice(spAdapter.get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(device_.put())));
   }
 #endif

--- a/winml/lib/Common/inc/errors.h
+++ b/winml/lib/Common/inc/errors.h
@@ -36,6 +36,21 @@
 #define WINML_THROW_HR_IF_TRUE_MSG(hr, value, message, ...) WINML_THROW_HR_IF_FALSE_MSG(hr, !(value), message, __VA_ARGS__)
 #define WINML_THROW_HR_IF_NULL_MSG(hr, value, message, ...) WINML_THROW_HR_IF_TRUE_MSG(hr, ((value) == nullptr), message, __VA_ARGS__)
 
+#define WINML_THROW_HR_IF_FALSE_MSG_NO_TELEMETRY_SENT(hr, value, message, ...)                        \
+  do {                                                                              \
+    auto _value = value;                                                            \
+    if (_value == false) {                                                          \
+      auto _hr = hr;                                                                \
+      char msg[1024];                                                               \
+      sprintf_s(msg, message, __VA_ARGS__);                                         \
+      winrt::hstring errorMessage(_winml::Strings::HStringFromUTF8(msg));           \
+      throw winrt::hresult_error(_hr, errorMessage);                                \
+    }                                                                               \
+  } while (0)
+
+#define WINML_THROW_HR_IF_TRUE_MSG_NO_TELEMETRY_SENT(hr, value, message, ...) WINML_THROW_HR_IF_FALSE_MSG_NO_TELEMETRY_SENT(hr, !(value), message, __VA_ARGS__)
+#define WINML_THROW_HR_IF_NULL_MSG_NO_TELEMETRY_SENT(hr, value, message, ...) WINML_THROW_HR_IF_TRUE_MSG_NO_TELEMETRY_SENT(hr, ((value) == nullptr), message, __VA_ARGS__)
+
 //
 // WINML_THROW_IF_FAILED* Variants
 //

--- a/winml/lib/Common/inc/errors.h
+++ b/winml/lib/Common/inc/errors.h
@@ -36,21 +36,6 @@
 #define WINML_THROW_HR_IF_TRUE_MSG(hr, value, message, ...) WINML_THROW_HR_IF_FALSE_MSG(hr, !(value), message, __VA_ARGS__)
 #define WINML_THROW_HR_IF_NULL_MSG(hr, value, message, ...) WINML_THROW_HR_IF_TRUE_MSG(hr, ((value) == nullptr), message, __VA_ARGS__)
 
-#define WINML_THROW_HR_IF_FALSE_MSG_NO_TELEMETRY_SENT(hr, value, message, ...)                        \
-  do {                                                                              \
-    auto _value = value;                                                            \
-    if (_value == false) {                                                          \
-      auto _hr = hr;                                                                \
-      char msg[1024];                                                               \
-      sprintf_s(msg, message, __VA_ARGS__);                                         \
-      winrt::hstring errorMessage(_winml::Strings::HStringFromUTF8(msg));           \
-      throw winrt::hresult_error(_hr, errorMessage);                                \
-    }                                                                               \
-  } while (0)
-
-#define WINML_THROW_HR_IF_TRUE_MSG_NO_TELEMETRY_SENT(hr, value, message, ...) WINML_THROW_HR_IF_FALSE_MSG_NO_TELEMETRY_SENT(hr, !(value), message, __VA_ARGS__)
-#define WINML_THROW_HR_IF_NULL_MSG_NO_TELEMETRY_SENT(hr, value, message, ...) WINML_THROW_HR_IF_TRUE_MSG_NO_TELEMETRY_SENT(hr, ((value) == nullptr), message, __VA_ARGS__)
-
 //
 // WINML_THROW_IF_FAILED* Variants
 //
@@ -61,6 +46,15 @@
     telemetry_helper.LogRuntimeError(_result, "", __FILE__, __FUNCTION__, __LINE__); \
     throw winrt::hresult_error(_result, winrt::hresult_error::from_abi);             \
   }
+
+#define WINML_THROW_HR_MSG_NO_TELEMETRY_SENT(hr, message, ...)               \
+  do {                                                                       \
+    auto _hr = hr;                                                           \
+    char msg[1024];                                                          \
+    sprintf_s(msg, message, __VA_ARGS__);                                    \
+    winrt::hstring errorMessage(_winml::Strings::HStringFromUTF8(msg));      \
+    throw winrt::hresult_error(_hr, errorMessage);                           \
+  } while (0)
 
 #define WINML_THROW_IF_FAILED(hr)                                                  \
   do {                                                                             \


### PR DESCRIPTION
Runtime error telemetry should only be sent out for scenarios where WinML behaved in an unexpected incorrect way.

In the scenario, that there are no hardware adapters available and a LearningModelDevice targetting GPU can't be created, Runtime error telemetry shouldn't be sent but hresult error should still be returned to the client app.

TelemetryFallback callback function that calls LogRuntimeError for any failure can be removed for these reasons:
- WinML "THROW_IF_FAILED" macros already call LogRuntimeError, no need to send error telemetry twice.
- The telemetry data sent by this callback function doesn't contain line and file information.
- Having this prevents WinML from throwing error without sending telemetry.