### PR TITLE
Fix build failure when building with --build_wheel on Windows

### DIFF
--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -228,13 +228,13 @@ TrainingConfigurationResult ConfigureSessionForTraining(
   config.graph_transformer_config.number_recompute_layers = parameters.number_recompute_layers;
 
   if (!parameters.model_after_graph_transforms_path.empty()) {
-    config.model_after_graph_transforms_path = parameters.model_after_graph_transforms_path;
+    config.model_after_graph_transforms_path = ToPathString(parameters.model_after_graph_transforms_path);
   }
   if (!parameters.model_with_gradient_graph_path.empty()) {
-    config.model_with_gradient_graph_path = parameters.model_with_gradient_graph_path;
+    config.model_with_gradient_graph_path = ToPathString(parameters.model_with_gradient_graph_path);
   }
   if (!parameters.model_with_training_graph_path.empty()) {
-    config.model_with_training_graph_path = parameters.model_with_training_graph_path;
+    config.model_with_training_graph_path = ToPathString(parameters.model_with_training_graph_path);
   }
 
   training::PipelineTrainingSession::TrainingConfigurationResult config_result{};


### PR DESCRIPTION
This resolves issue #6536

Signed-off-by: George Nash <george.nash@intel.com>

**Description**: 
Add ToPathString() function to convert the std::string parameter to the PathString type which could be char or wchar_t depending on the OS.

**Motivation and Context**
- Why is this change required? What problem does it solve?
Fix build failure discovered when building on Windows.

- If it fixes an open issue, please link to the issue here.
#6536 