### PR TITLE
Don't resolve symlink in resolve_executable_path().

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -481,7 +481,7 @@ def resolve_executable_path(command_or_path):
     if executable_path is None:
         raise BuildError("Failed to resolve executable path for "
                          "'{}'.".format(command_or_path))
-    return os.path.realpath(executable_path)
+    return os.path.abspath(executable_path)
 
 
 def get_linux_distro():


### PR DESCRIPTION
**Description**
With Snap-installed CMake, we get a symlink like this:
/snap/bin/cmake -> /usr/bin/snap

However, calling /snap/bin/cmake is not the same as calling /usr/bin/snap.

This change avoids resolving symlinks when getting the absolute path to cmake.

**Motivation and Context**
Addressing https://github.com/microsoft/onnxruntime/issues/6533.