### PR TITLE
ort_test_utils: skip creating input if it is an initializer

### DIFF
--- a/tools/python/ort_test_dir_utils.py
+++ b/tools/python/ort_test_dir_utils.py
@@ -21,7 +21,7 @@ def _get_numpy_type(model_info, name):
     raise ValueError("{} was not found in the model info.".format(name))
 
 
-def _create_missing_input_data(model_inputs, name_input_map, symbolic_dim_values_map):
+def _create_missing_input_data(model_inputs, name_input_map, symbolic_dim_values_map, initializer_set):
     """
     Update name_input_map with random input for any missing values in the model inputs.
 
@@ -32,7 +32,10 @@ def _create_missing_input_data(model_inputs, name_input_map, symbolic_dim_values
     for input in model_inputs:
         if input.name in name_input_map and name_input_map[input.name] is not None:
             continue
-
+        # skip if the input has already exists in initializer
+        # models whose ir_version < 4 can have input same as initializer; no need to create input data
+        if input.name in initializer_set:
+            continue
         input_type = input.type.WhichOneof('value')
         if input_type != 'tensor_type':
             raise ValueError('Unsupported model. Need to handle input type of {}'.format(input_type))
@@ -127,8 +130,9 @@ def create_test_dir(model_path, root_path, test_name,
     if not symbolic_dim_values_map:
         symbolic_dim_values_map = {}
 
-    _create_missing_input_data(model_inputs, name_input_map, symbolic_dim_values_map)
-
+    for initializer in onnx.load(model_path).graph.initializer:
+        initializer_set.add(initializer.name)
+    _create_missing_input_data(model_inputs, name_input_map, symbolic_dim_values_map, initializer_set)
     save_data("input", name_input_map, model_inputs)
 
     # save expected output data if provided. run model to create if not.

--- a/tools/python/ort_test_dir_utils.py
+++ b/tools/python/ort_test_dir_utils.py
@@ -129,7 +129,7 @@ def create_test_dir(model_path, root_path, test_name,
 
     if not symbolic_dim_values_map:
         symbolic_dim_values_map = {}
-
+    initializer_set = set()
     for initializer in onnx.load(model_path).graph.initializer:
         initializer_set.add(initializer.name)
     _create_missing_input_data(model_inputs, name_input_map, symbolic_dim_values_map, initializer_set)


### PR DESCRIPTION
**Description**:
To support models whose IR_VERSION < 4, skip creating missing input if it is an initializer.

**Motivation and Context**
https://github.com/onnx/models/pull/384
While using ort_test_dir_utils to test onnx/models, there are some models whose IR_VERSION < 4 fail (`[ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Invalid Feed Input Name: XXX`). The reason is those models can have their initializer in the input as well. Actually ort_test_dir_utils doesn't need to create an input for them if they are initializer.