### PR TITLE
Switch Android CI java build to JDK 11 

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -12,12 +12,6 @@ jobs:
     inputs:
       versionSpec: $(pythonVersion)
 
-  - task: JavaToolInstaller@0
-    inputs:
-      versionSpec: '11'
-      jdkArchitectureOption: 'x64'
-      jdkSourceOption: 'PreInstalled'
-
   - script: brew install coreutils ninja
     displayName: Install coreutils and ninja
 
@@ -28,6 +22,12 @@ jobs:
         --start --emulator-extra-args="-partition-size 4096" \
         --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
     displayName: Start Android emulator
+
+  - task: JavaToolInstaller@0
+    inputs:
+      versionSpec: '11'
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'
 
   - script: python3 tools/ci_build/build.py --android --build_dir build --android_sdk_path $ANDROID_HOME --android_ndk_path $ANDROID_HOME/ndk-bundle --android_abi=x86_64 --android_api=29 --skip_submodule_sync --parallel --cmake_generator=Ninja --build_java
     displayName: CPU EP, Build and Test on Android Emulator

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -12,6 +12,12 @@ jobs:
     inputs:
       versionSpec: $(pythonVersion)
 
+  - task: JavaToolInstaller@0
+    inputs:
+      versionSpec: '11'
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'
+
   - script: brew install coreutils ninja
     displayName: Install coreutils and ninja
 

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -23,13 +23,26 @@ jobs:
         --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
     displayName: Start Android emulator
 
+  # Start switching to jdk 11 after the Android Emulator is started since Android SDK manager requires java 8
   - task: JavaToolInstaller@0
+    displayName: Use jdk 11
     inputs:
       versionSpec: '11'
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
 
-  - script: python3 tools/ci_build/build.py --android --build_dir build --android_sdk_path $ANDROID_HOME --android_ndk_path $ANDROID_HOME/ndk-bundle --android_abi=x86_64 --android_api=29 --skip_submodule_sync --parallel --cmake_generator=Ninja --build_java
+  - script: |
+      python3 tools/ci_build/build.py \
+        --android \
+        --build_dir build \
+        --android_sdk_path $ANDROID_HOME \
+        --android_ndk_path $ANDROID_HOME/ndk-bundle \
+        --android_abi=x86_64 \
+        --android_api=29 \
+        --skip_submodule_sync \
+        --parallel \
+        --cmake_generator=Ninja \
+        --build_java
     displayName: CPU EP, Build and Test on Android Emulator
 
   - script: /bin/bash tools/ci_build/github/android/run_nnapi_code_coverage.sh $(pwd)


### PR DESCRIPTION
**Description**: Switch Android CI java build to JDK 11 

**Motivation and Context**
- This is a 1CS security requirement, "For managed code (Java), all code must be compiled with JDK11 and Android SDK platform tools revision 25.04 or later."
- We are still targeting java 8 for compatibility, the change is only the compiler
- This will be required for planned Android packaging work
