### PR TITLE
Fix layer_norm.cc on x86

### DIFF
--- a/orttraining/orttraining/training_ops/cpu/nn/layer_norm.cc
+++ b/orttraining/orttraining/training_ops/cpu/nn/layer_norm.cc
@@ -58,10 +58,10 @@ Status LayerNormGrad<T, simplified>::Compute(OpKernelContext* op_kernel_context)
   const Tensor* X = op_kernel_context->Input<Tensor>(input_index++);
   const auto& X_shape = X->Shape();
   const auto axis = HandleNegativeAxis(axis_, X_shape.NumDimensions());
-  ORT_ENFORCE(X_shape.SizeToDimension(axis) <= std::numeric_limits<int>::max());
-  ORT_ENFORCE(X_shape.SizeFromDimension(axis) <= std::numeric_limits<int>::max());
-  const auto N = (int) X_shape.SizeToDimension(axis);
-  const auto M = (int) X_shape.SizeFromDimension(axis);
+  ORT_ENFORCE(X_shape.SizeToDimension(axis) <= std::numeric_limits<Eigen::Index>::max());
+  ORT_ENFORCE(X_shape.SizeFromDimension(axis) <= std::numeric_limits<Eigen::Index>::max());
+  const auto N = static_cast<Eigen::Index>(X_shape.SizeToDimension(axis));
+  const auto M = static_cast<Eigen::Index>(X_shape.SizeFromDimension(axis));
   ORT_ENFORCE(M != 1);
   
   const Tensor* scale = op_kernel_context->Input<Tensor>(input_index++);
@@ -148,10 +148,10 @@ Status InvertibleLayerNormGrad<T>::Compute(OpKernelContext* op_kernel_context) c
   const auto& Y_shape = Y_grad->Shape();
   const auto& X_shape = Y_shape;
   const auto axis = HandleNegativeAxis(axis_, X_shape.NumDimensions());
-  ORT_ENFORCE(X_shape.SizeToDimension(axis) <= std::numeric_limits<int>::max());
-  ORT_ENFORCE(X_shape.SizeFromDimension(axis) <= std::numeric_limits<int>::max());
-  const auto N = (int) X_shape.SizeToDimension(axis);
-  const auto M = (int) X_shape.SizeFromDimension(axis);
+  ORT_ENFORCE(X_shape.SizeToDimension(axis) <= std::numeric_limits<Eigen::Index>::max());
+  ORT_ENFORCE(X_shape.SizeFromDimension(axis) <= std::numeric_limits<Eigen::Index>::max());
+  const auto N = static_cast<Eigen::Index>(X_shape.SizeToDimension(axis));
+  const auto M = static_cast<Eigen::Index>(X_shape.SizeFromDimension(axis));
   ORT_ENFORCE(M != 1);
   const auto& scale_shape = scale->Shape();
 

--- a/orttraining/orttraining/training_ops/cpu/nn/layer_norm.cc
+++ b/orttraining/orttraining/training_ops/cpu/nn/layer_norm.cc
@@ -58,8 +58,10 @@ Status LayerNormGrad<T, simplified>::Compute(OpKernelContext* op_kernel_context)
   const Tensor* X = op_kernel_context->Input<Tensor>(input_index++);
   const auto& X_shape = X->Shape();
   const auto axis = HandleNegativeAxis(axis_, X_shape.NumDimensions());
-  const auto N = X_shape.SizeToDimension(axis);
-  const auto M = X_shape.SizeFromDimension(axis);
+  ORT_ENFORCE(X_shape.SizeToDimension(axis) <= std::numeric_limits<int>::max());
+  ORT_ENFORCE(X_shape.SizeFromDimension(axis) <= std::numeric_limits<int>::max());
+  const auto N = (int) X_shape.SizeToDimension(axis);
+  const auto M = (int) X_shape.SizeFromDimension(axis);
   ORT_ENFORCE(M != 1);
   
   const Tensor* scale = op_kernel_context->Input<Tensor>(input_index++);
@@ -146,8 +148,10 @@ Status InvertibleLayerNormGrad<T>::Compute(OpKernelContext* op_kernel_context) c
   const auto& Y_shape = Y_grad->Shape();
   const auto& X_shape = Y_shape;
   const auto axis = HandleNegativeAxis(axis_, X_shape.NumDimensions());
-  const auto N = X_shape.SizeToDimension(axis);
-  const auto M = X_shape.SizeFromDimension(axis);
+  ORT_ENFORCE(X_shape.SizeToDimension(axis) <= std::numeric_limits<int>::max());
+  ORT_ENFORCE(X_shape.SizeFromDimension(axis) <= std::numeric_limits<int>::max());
+  const auto N = (int) X_shape.SizeToDimension(axis);
+  const auto M = (int) X_shape.SizeFromDimension(axis);
   ORT_ENFORCE(M != 1);
   const auto& scale_shape = scale->Shape();
 


### PR DESCRIPTION
**Description**: Explicitly cast size parameters to int

**Motivation and Context**
Building with --enable_training or --enable_training_ops on x86 encounters build errors in layer_norm.cc because SizeToDimension and SizeFromDimension return int64_t, whereas the Eigen constructors and templates take int. This compiles fine in x64 builds, but in x86 builds all the uses of M or N produce an error like:
> error C2398: Element '2': conversion from 'const int64_t' to 'Eigen::EigenBase<Derived>::Index' requires a narrowing conversion