### PR TITLE
Loading Tensors from Disjoint buffers WinML breaks

### DIFF
--- a/winml/lib/Api/impl/TensorBase.h
+++ b/winml/lib/Api/impl/TensorBase.h
@@ -519,7 +519,7 @@ struct TensorBase : TBase {
       // efficiently query the size of the data.
       auto size_in_bytes = 0;
       for (auto buffer : buffers) {
-        size_in_bytes += buffer.Capacity();
+        size_in_bytes += buffer.Length();
       }
 
       auto num_elements = size_in_bytes / sizeof(T);

--- a/winml/test/api/raw/weak_buffer.h
+++ b/winml/test/api/raw/weak_buffer.h
@@ -42,9 +42,14 @@ public:
     }
 
     virtual HRESULT STDMETHODCALLTYPE get_Length(
-        UINT32 * /*value*/)
+        UINT32 * value)
     {
-        return E_NOTIMPL;
+        if (value == nullptr) {
+            return E_POINTER;
+        }
+
+        *value = static_cast<uint32_t>(m_p_end - m_p_begin) * sizeof(T);
+        return S_OK;
     }
 
     virtual HRESULT STDMETHODCALLTYPE put_Length(

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -1667,11 +1667,8 @@ static void BindMultipleCPUBuffersOutputsOnGpu() {
 }
 
 static void TestBatchBuffers() {
-  std::wstring filePath = FileHelpers::GetModulePath() + L"testdata\\transform\\fusion\\attention_symbolic_batch.onnx";
-
-  LearningModel model = nullptr;
-  APITest::LoadModel(filePath, model);
-
+  std::wstring modelPath = FileHelpers::GetModulePath() + L"testdata\\transform\\fusion\\attention_symbolic_batch.onnx";
+  auto model = LearningModel::LoadFromFilePath(modelPath);
   LearningModelSession session(model);
   LearningModelBinding binding(session);
 

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -1667,8 +1667,10 @@ static void BindMultipleCPUBuffersOutputsOnGpu() {
 }
 
 static void TestBatchBuffers() {
+  std::wstring filePath = FileHelpers::GetModulePath() + L"testdata\\transform\\fusion\\attention_symbolic_batch.onnx";
+
   LearningModel model = nullptr;
-  APITest::LoadModel(L"testdata\\transform\\fusion\\attention_symbolic_batch.onnx", model);
+  APITest::LoadModel(filePath, model);
 
   LearningModelSession session(model);
   LearningModelBinding binding(session);

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.h
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.h
@@ -44,6 +44,7 @@ struct ScenarioTestsApi
     VoidTest BindMultipleCPUBuffersInputsOnGpu;
     VoidTest BindMultipleCPUBuffersOutputsOnCpu;
     VoidTest BindMultipleCPUBuffersOutputsOnGpu;
+    VoidTest TestBatchBuffers;
 };
 const ScenarioTestsApi& getapi();
 
@@ -89,4 +90,5 @@ WINML_TEST(ScenarioCppWinrtTests, BindMultipleCPUBuffersInputsOnCpu)
 WINML_TEST(ScenarioCppWinrtTests, BindMultipleCPUBuffersInputsOnGpu)
 WINML_TEST(ScenarioCppWinrtTests, BindMultipleCPUBuffersOutputsOnCpu)
 WINML_TEST(ScenarioCppWinrtTests, BindMultipleCPUBuffersOutputsOnGpu)
+WINML_TEST(ScenarioCppWinrtTests, TestBatchBuffers)
 WINML_TEST_CLASS_END()


### PR DESCRIPTION
Loading Tensors from Disjoint buffers WinML breaks

Issue: the length of the tensor is computed using the tensor capacity and not length. Use Length and not Capacity.