### PR TITLE
OpenVino add build_shared_lib flag in the build command

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -391,13 +391,13 @@ Note that OpenVINO is built as a [shared provider library](#Execution-Provider-S
 
 ##### Windows
 ```
-.\build.bat --config RelWithDebInfo --use_openvino <hardware_option>
+.\build.bat --config RelWithDebInfo --use_openvino <hardware_option> --build_shared_lib
 ```
 *Note: The default Windows CMake Generator is Visual Studio 2017, but you can also use the newer Visual Studio 2019 by passing `--cmake_generator "Visual Studio 16 2019"` to `.\build.bat`*
 
 ##### Linux
 ```
-./build.sh --config RelWithDebInfo --use_openvino <hardware_option>
+./build.sh --config RelWithDebInfo --use_openvino <hardware_option> --build_shared_lib
 ```
 
    <code>--use_openvino</code>: Builds the OpenVINO Execution Provider in ONNX Runtime.

--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -84,7 +84,7 @@ RUN apt update && apt -y install --no-install-recommends apt-transport-https ca-
     git clone --recursive -b ${ONNXRUNTIME_BRANCH} ${ONNXRUNTIME_REPO} && \
     /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh && \
     cd onnxruntime/cmake/external/onnx && python3 setup.py install && \
-    cd ${MY_ROOT}/onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino ${DEVICE} --build_wheel && \
+    cd ${MY_ROOT}/onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino ${DEVICE} --build_shared_lib --build_wheel && \
     pip install build/Linux/Release/dist/*-linux_x86_64.whl && \
     cd ${MY_ROOT}/ && rm -rf onnxruntime && cd /opt && rm -rf v1.0.22.zip && cd ${MY_ROOT} &&\
     apt remove -y cmake && cd /usr/share/python-wheels/ && rm -rf *.whl &&\

--- a/dockerfiles/Dockerfile.openvino-csharp
+++ b/dockerfiles/Dockerfile.openvino-csharp
@@ -102,7 +102,7 @@ RUN apt update && \
     git clone --recursive -b ${ONNXRUNTIME_BRANCH} ${ONNXRUNTIME_REPO} && \
     /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh && \
     cd onnxruntime/cmake/external/onnx && python3 setup.py install && \
-    cd ${MY_ROOT}/onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino ${DEVICE} --build_nuget && \
+    cd ${MY_ROOT}/onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino ${DEVICE} --build_nuget --build_shared_lib && \
     mv ${MY_ROOT}/onnxruntime/build/Linux/Release/nuget-artifacts ${MY_ROOT} && \
 # Clean-up unnecessary files
     rm -rf ${MY_ROOT}/cmake* /opt/cmake ${MY_ROOT}/onnxruntime && \

--- a/onnxruntime/core/providers/openvino/ov_versions/capability_2021_1.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/capability_2021_1.cc
@@ -272,8 +272,8 @@ static bool IsUnsupportedOpMode(const Node* node, const GraphViewer& graph_viewe
         return true;
     }
   } else if (optype == "Max" || optype == "Min" || optype == "Mean" || optype == "Sum") {
-    if (GetInputCount(node, initializers) == 1)
-      return true;
+      if (GetInputCount(node, initializers) == 1)
+        return true;
       if (optype == "Max" || optype == "Min") {
         for (size_t i = 0; i < node->InputDefs().size(); i++) {
           auto dtype = node->InputDefs()[i]->TypeAsProto()->tensor_type().elem_type();


### PR DESCRIPTION
We were not able to build C++ samples without build_shared_lib flag in the build command. 

**Motivation and Context**
- This changes was required in dockerfiles to enable c++ sample build 
- If it fixes an open issue, please link to the issue here.
