### PR TITLE
Tile perf enhancements - continued

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/tile.cc
+++ b/onnxruntime/core/providers/cpu/tensor/tile.cc
@@ -106,14 +106,25 @@ namespace TileOp {
 bool IsTileMemcpy(const TensorShape& input_shape,
                   const int64_t* repeats,
                   size_t rank,
-                  /*out*/ size_t& num_of_copies) {
+                  /*out*/ bool& is_batched_memcpy,
+                  /*out*/ size_t& num_of_elements_per_batch,
+                  /*out*/ size_t& num_of_copies_per_batch,
+                  /*out*/ size_t& num_of_batch_copies) {
   for (int64_t i = static_cast<int64_t>(rank) - 1; i >= 0; --i) {
     if (repeats[i] != 1) {
       if (input_shape.SizeToDimension(i) == 1) {
-        num_of_copies = 1;
+        num_of_copies_per_batch = 1;
         for (int64_t j = 0; j <= i; ++j) {
-          num_of_copies *= repeats[j];
+          num_of_copies_per_batch *= repeats[j];
         }
+
+        is_batched_memcpy = false;
+        return true;
+      } else if (i == 1) {
+        num_of_elements_per_batch = static_cast<size_t>(input_shape.SizeFromDimension(1));
+        num_of_copies_per_batch = repeats[i];
+        num_of_batch_copies = repeats[0];
+        is_batched_memcpy = true;
         return true;
       } else {
         break;
@@ -166,20 +177,55 @@ Status Tile::Compute(OpKernelContext* ctx) const {
     return Status::OK();
   }
 
-  size_t num_of_copies = 1;
-  if (TileOp::IsTileMemcpy(input_shape, repeats, input_rank, num_of_copies)) {
+  bool is_batched_memcpy = false;
+  size_t num_of_elements_per_batch = 1;
+  size_t num_of_copies_per_batch = 1;
+  size_t num_of_batch_copies = 1;
+  if (TileOp::IsTileMemcpy(input_shape,
+                           repeats,
+                           input_rank,
+                           is_batched_memcpy,
+                           num_of_elements_per_batch,
+                           num_of_copies_per_batch,
+                           num_of_batch_copies)) {
     // TODO: Handle string copies when the kernel eventually supports string type.
     // For now, it shouldn't throw in the enforce as the kernel doesn't claim string support
     ORT_ENFORCE(!input_tensor.IsDataType<std::string>(), "Tile doesn't support string type yet");
 
     int8_t* output_data_casted = reinterpret_cast<int8_t*>(output_tensor.MutableDataRaw());
+    const int8_t* input_data_casted = reinterpret_cast<const int8_t*>(input_tensor.DataRaw());
     const void* input_data_raw = input_tensor.DataRaw();
-    size_t tensor_size_in_bytes = input_tensor.SizeInBytes();
 
-    // TODO: Add multi-threading logic if num_of_copies is large enough
-    for (size_t i = 0; i < num_of_copies; ++i) {
-      memcpy(static_cast<void*>(output_data_casted), input_data_raw, tensor_size_in_bytes);
-      output_data_casted += tensor_size_in_bytes;
+    if (!is_batched_memcpy) {
+      size_t copy_bytes = input_tensor.SizeInBytes();
+      // TODO: Add multi-threading logic if num_of_copies_per_batch is large enough
+      for (size_t i = 0; i < num_of_copies_per_batch; ++i) {
+        memcpy(static_cast<void*>(output_data_casted), input_data_raw, copy_bytes);
+        output_data_casted += copy_bytes;
+      }
+    } else {
+      size_t copy_bytes = num_of_elements_per_batch * input_tensor.DataType()->Size();
+      size_t batch_count = static_cast<size_t>(input_tensor.Shape()[0]);  // The tensor is atleast 1-D- this is safe
+
+      // TODO: Multi-thread if needed
+      for (size_t batch = 0; batch < batch_count; ++batch) {
+        for (size_t i = 0; i < num_of_copies_per_batch; ++i) {
+          memcpy(static_cast<void*>(output_data_casted), static_cast<const void*>(input_data_casted), copy_bytes);
+          output_data_casted += copy_bytes;
+        }
+        input_data_casted += copy_bytes;
+      }
+
+      // Now account for batch dim repeat
+      // reset some values
+      output_data_casted = reinterpret_cast<int8_t*>(output_tensor.MutableDataRaw());
+      copy_bytes *= num_of_copies_per_batch * batch_count;
+      int8_t* copy_ptr = output_data_casted + copy_bytes;
+
+      for (size_t i = 1; i < num_of_batch_copies; ++i) {
+        memcpy(static_cast<void*>(copy_ptr), static_cast<const void*>(output_data_casted), copy_bytes);
+        copy_ptr += copy_bytes;
+      }
     }
 
     return Status::OK();

--- a/onnxruntime/core/providers/cpu/tensor/tile.h
+++ b/onnxruntime/core/providers/cpu/tensor/tile.h
@@ -14,7 +14,7 @@ namespace TileOp {
 // repeats: [1, 200, 1]
 // output shape: [1, 200, 256 * 50]
 
-// As a slight generalized extension, it also supports "batched" multiple copies of the input data buffer
+// As a slight extension, it also supports "batched" multiple copies of the input data buffer
 // (`is_batched_memcpy` will be set to true)
 // E.g.: input_shape: [5, 1, 256 * 50]
 // repeats: [1, 200, 1]

--- a/onnxruntime/core/providers/cpu/tensor/tile.h
+++ b/onnxruntime/core/providers/cpu/tensor/tile.h
@@ -14,10 +14,24 @@ namespace TileOp {
 // repeats: [1, 200, 1]
 // output shape: [1, 200, 256 * 50]
 
+// As a slight generalized extension, it also supports "batched" multiple copies of the input data buffer
+// (`is_batched_memcpy` will be set to true)
+// E.g.: input_shape: [5, 1, 256 * 50]
+// repeats: [1, 200, 1]
+// output shape: [5, 200, 256 * 50]
+
+// Repeating the batch is also supported
+// E.g.: input_shape: [5, 1, 256 * 50]
+// repeats: [2, 200, 1]
+// output shape: [10, 200, 256 * 50]
+
 bool IsTileMemcpy(const TensorShape& input_shape,
                   const int64_t* repeats,
                   size_t rank,
-                  /*out*/ size_t& num_of_copies);
+                  /*out*/ bool& is_batched_memcpy,
+                  /*out*/ size_t& num_of_elements_per_batch,
+                  /*out*/ size_t& num_of_copies_per_batch,
+                  /*out*/ size_t& num_of_batch_copies);
 }  // namespace TileOp
 
 struct Tile : OpKernel {

--- a/onnxruntime/core/providers/cuda/tensor/tile.cc
+++ b/onnxruntime/core/providers/cuda/tensor/tile.cc
@@ -76,31 +76,73 @@ Status Tile::ComputeInternal(OpKernelContext* ctx) const {
     return Status::OK();
   }
 
-  size_t num_of_copies = 1;
-  if (TileOp::IsTileMemcpy(input_shape, repeats, rank, num_of_copies)) {
-    if (input_tensor.IsDataType<float>() ||
-        input_tensor.IsDataType<int32_t>()) {
-      TileMemcpyImpl(
-          reinterpret_cast<const typename ToCudaType<float>::MappedType*>(input_data),
-          input_shape.Size(),
-          reinterpret_cast<typename ToCudaType<float>::MappedType*>(output_data),
-          output_shape.Size());
-    } else if (input_tensor.IsDataType<double>() ||
-               input_tensor.IsDataType<int64_t>()) {
-      TileMemcpyImpl(
-          reinterpret_cast<const typename ToCudaType<double>::MappedType*>(input_data),
-          input_shape.Size(),
-          reinterpret_cast<typename ToCudaType<double>::MappedType*>(output_data),
-          output_shape.Size());
-    } else if (input_tensor.IsDataType<MLFloat16>()) {
-      TileMemcpyImpl(
-          reinterpret_cast<const typename ToCudaType<MLFloat16>::MappedType*>(input_data),
-          input_shape.Size(),
-          reinterpret_cast<typename ToCudaType<MLFloat16>::MappedType*>(output_data),
-          output_shape.Size());
+  bool is_batched_memcpy = false;
+  size_t num_of_elements_per_batch = 1;
+  size_t num_of_copies_per_batch = 1;
+  size_t num_of_batch_copies = 1;
+  if (TileOp::IsTileMemcpy(input_shape,
+                           repeats,
+                           rank,
+                           is_batched_memcpy,
+                           num_of_elements_per_batch,
+                           num_of_copies_per_batch,
+                           num_of_batch_copies)) {
+    if (!is_batched_memcpy) {
+      if (input_tensor.IsDataType<float>() ||
+          input_tensor.IsDataType<int32_t>()) {
+        TileMemcpyImpl(
+            reinterpret_cast<const typename ToCudaType<float>::MappedType*>(input_data),
+            input_shape.Size(),
+            reinterpret_cast<typename ToCudaType<float>::MappedType*>(output_data),
+            output_shape.Size());
+      } else if (input_tensor.IsDataType<double>() ||
+                 input_tensor.IsDataType<int64_t>()) {
+        TileMemcpyImpl(
+            reinterpret_cast<const typename ToCudaType<double>::MappedType*>(input_data),
+            input_shape.Size(),
+            reinterpret_cast<typename ToCudaType<double>::MappedType*>(output_data),
+            output_shape.Size());
+      } else if (input_tensor.IsDataType<MLFloat16>()) {
+        TileMemcpyImpl(
+            reinterpret_cast<const typename ToCudaType<MLFloat16>::MappedType*>(input_data),
+            input_shape.Size(),
+            reinterpret_cast<typename ToCudaType<MLFloat16>::MappedType*>(output_data),
+            output_shape.Size());
+      } else {
+        // Won't hit this as the kernel doesn't claim support for any type that will trigger this
+        ORT_THROW("Tile doesn't have an implementation yet for the type: ", input_tensor.DataType());
+      }
     } else {
-      // Won't hit this as the kernel doesn't claim support for any type that will trigger this
-      ORT_THROW("Tile doesn't have an implementation yet for the type: ", input_tensor.DataType());
+      if (input_tensor.IsDataType<float>() ||
+          input_tensor.IsDataType<int32_t>()) {
+        TileBatchedMemcpyImpl(
+            reinterpret_cast<const typename ToCudaType<float>::MappedType*>(input_data),
+            num_of_elements_per_batch,
+            input_shape[0],
+            fast_divmod(static_cast<int>(num_of_elements_per_batch * num_of_copies_per_batch)),
+            reinterpret_cast<typename ToCudaType<float>::MappedType*>(output_data),
+            output_shape.Size());
+      } else if (input_tensor.IsDataType<double>() ||
+                 input_tensor.IsDataType<int64_t>()) {
+        TileBatchedMemcpyImpl(
+            reinterpret_cast<const typename ToCudaType<double>::MappedType*>(input_data),
+            num_of_elements_per_batch,
+            input_shape[0],
+            fast_divmod(static_cast<int>(num_of_elements_per_batch * num_of_copies_per_batch)),
+            reinterpret_cast<typename ToCudaType<double>::MappedType*>(output_data),
+            output_shape.Size());
+      } else if (input_tensor.IsDataType<MLFloat16>()) {
+        TileBatchedMemcpyImpl(
+            reinterpret_cast<const typename ToCudaType<MLFloat16>::MappedType*>(input_data),
+            num_of_elements_per_batch,
+            input_shape[0],
+            fast_divmod(static_cast<int>(num_of_elements_per_batch * num_of_copies_per_batch)),
+            reinterpret_cast<typename ToCudaType<MLFloat16>::MappedType*>(output_data),
+            output_shape.Size());
+      } else {
+        // Won't hit this as the kernel doesn't claim support for any type that will trigger this
+        ORT_THROW("Tile doesn't have an implementation yet for the type: ", input_tensor.DataType());
+      }
     }
 
     return Status::OK();

--- a/onnxruntime/core/providers/cuda/tensor/tile.cc
+++ b/onnxruntime/core/providers/cuda/tensor/tile.cc
@@ -118,7 +118,7 @@ Status Tile::ComputeInternal(OpKernelContext* ctx) const {
         TileBatchedMemcpyImpl(
             reinterpret_cast<const typename ToCudaType<float>::MappedType*>(input_data),
             num_of_elements_per_batch,
-            input_shape[0],
+            input_shape[0],  // The tensor is atleast 1-D- this is safe
             fast_divmod(static_cast<int>(num_of_elements_per_batch * num_of_copies_per_batch)),
             reinterpret_cast<typename ToCudaType<float>::MappedType*>(output_data),
             output_shape.Size());
@@ -127,7 +127,7 @@ Status Tile::ComputeInternal(OpKernelContext* ctx) const {
         TileBatchedMemcpyImpl(
             reinterpret_cast<const typename ToCudaType<double>::MappedType*>(input_data),
             num_of_elements_per_batch,
-            input_shape[0],
+            input_shape[0],  // The tensor is atleast 1-D- this is safe
             fast_divmod(static_cast<int>(num_of_elements_per_batch * num_of_copies_per_batch)),
             reinterpret_cast<typename ToCudaType<double>::MappedType*>(output_data),
             output_shape.Size());
@@ -135,7 +135,7 @@ Status Tile::ComputeInternal(OpKernelContext* ctx) const {
         TileBatchedMemcpyImpl(
             reinterpret_cast<const typename ToCudaType<MLFloat16>::MappedType*>(input_data),
             num_of_elements_per_batch,
-            input_shape[0],
+            input_shape[0],  // The tensor is atleast 1-D- this is safe
             fast_divmod(static_cast<int>(num_of_elements_per_batch * num_of_copies_per_batch)),
             reinterpret_cast<typename ToCudaType<MLFloat16>::MappedType*>(output_data),
             output_shape.Size());

--- a/onnxruntime/core/providers/cuda/tensor/tile_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/tile_impl.h
@@ -25,5 +25,14 @@ void TileMemcpyImpl(
     T* output_data,
     const size_t num_output_elements);
 
+template <typename T>
+void TileBatchedMemcpyImpl(
+    const T* input_data,
+    const size_t num_of_elements_per_input_batch,
+    const size_t num_input_batch_count,
+    const fast_divmod& num_of_elements_per_output_batch,
+    T* output_data,
+    const size_t num_output_elements);
+
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
@@ -48,10 +48,21 @@ void RunTestWrapper() {
   RunTest<T>({111, 112, 113, 122, 123, 124}, {2, 1, 3}, {1, 1, 1}, {3}, {111, 112, 113, 122, 123, 124}, {2, 1, 3});
 
   // TileWhichIsBasicallyCopiesOfInputBuffer - 1
+  // This will trigger the MemCpy optimization path
   RunTest<T>({111, 112, 113}, {1, 1, 3}, {2, 2, 1}, {3}, {111, 112, 113, 111, 112, 113, 111, 112, 113, 111, 112, 113}, {2, 2, 3});
 
   // TileWhichIsBasicallyCopiesOfInputBuffer - 2
+  // This will trigger the MemCpy optimization path
   RunTest<T>({111, 112, 113}, {1, 1, 3}, {3, 1, 1}, {3}, {111, 112, 113, 111, 112, 113, 111, 112, 113}, {3, 1, 3});
+
+  // TileWhichIsBasicallyCopiesOfInputBuffer - 3 (batch > 1 and batch_repeat == 1)
+  // This will trigger the MemCpy optimization path
+  RunTest<T>({111, 112, 113, 11, 12, 13}, {2, 1, 3}, {1, 2, 1}, {3}, {111, 112, 113, 111, 112, 113, 11, 12, 13, 11, 12, 13}, {2, 2, 3});
+
+  // TileWhichIsBasicallyCopiesOfInputBuffer - 3 (batch > 1 and batch_repeat > 1)
+  // This will trigger the MemCpy optimization path
+  RunTest<T>({111, 112, 113, 11, 12, 13}, {2, 1, 3}, {2, 2, 1}, {3},
+             {111, 112, 113, 111, 112, 113, 11, 12, 13, 11, 12, 13, 111, 112, 113, 111, 112, 113, 11, 12, 13, 11, 12, 13}, {4, 2, 3});
 }
 
 template <>
@@ -78,10 +89,23 @@ void RunTestWrapper<bool>() {
   RunTest<bool>({true, false, true, false, true, true}, {2, 1, 3}, {1, 1, 1}, {3}, {true, false, true, false, true, true}, {2, 1, 3});
 
   // TileWhichIsBasicallyCopiesOfInputBuffer - 1
+  // This will trigger the MemCpy optimization path
   RunTest<bool>({true, false, true}, {1, 1, 3}, {2, 2, 1}, {3}, {true, false, true, true, false, true, true, false, true, true, false, true}, {2, 2, 3});
 
   // TileWhichIsBasicallyCopiesOfInputBuffer - 2
+  // This will trigger the MemCpy optimization path
   RunTest<bool>({true, false, true}, {1, 1, 3}, {3, 1, 1}, {3}, {true, false, true, true, false, true, true, false, true}, {3, 1, 3});
+
+  // TileWhichIsBasicallyCopiesOfInputBuffer - 3 (batch > 1 and batch_repeat == 1)
+  // This will trigger the MemCpy optimization path
+  RunTest<bool>({true, false, true, true, false, true}, {2, 1, 3}, {1, 2, 1}, {3},
+                {true, false, true, true, false, true, true, false, true, true, false, true}, {2, 2, 3});
+
+  // TileWhichIsBasicallyCopiesOfInputBuffer - 3 (batch > 1 and batch_repeat > 1)
+  // This will trigger the MemCpy optimization path
+  RunTest<bool>({true, false, true, true, false, true}, {2, 1, 3}, {2, 2, 1}, {3},
+                {true, false, true, true, false, true, true, false, true, true, false, true, true, false, true, true, false, true, true, false, true, true, false, true},
+                {4, 2, 3});
 }
 
 TEST(TensorOpTest, TileFloatType) {

--- a/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tile_op_test.cc
@@ -56,11 +56,11 @@ void RunTestWrapper() {
   RunTest<T>({111, 112, 113}, {1, 1, 3}, {3, 1, 1}, {3}, {111, 112, 113, 111, 112, 113, 111, 112, 113}, {3, 1, 3});
 
   // TileWhichIsBasicallyCopiesOfInputBuffer - 3 (batch > 1 and batch_repeat == 1)
-  // This will trigger the MemCpy optimization path
+  // This will trigger the (Batched) MemCpy optimization path
   RunTest<T>({111, 112, 113, 11, 12, 13}, {2, 1, 3}, {1, 2, 1}, {3}, {111, 112, 113, 111, 112, 113, 11, 12, 13, 11, 12, 13}, {2, 2, 3});
 
   // TileWhichIsBasicallyCopiesOfInputBuffer - 3 (batch > 1 and batch_repeat > 1)
-  // This will trigger the MemCpy optimization path
+  // This will trigger the (Batched) MemCpy optimization path
   RunTest<T>({111, 112, 113, 11, 12, 13}, {2, 1, 3}, {2, 2, 1}, {3},
              {111, 112, 113, 111, 112, 113, 11, 12, 13, 11, 12, 13, 111, 112, 113, 111, 112, 113, 11, 12, 13, 11, 12, 13}, {4, 2, 3});
 }
@@ -97,12 +97,12 @@ void RunTestWrapper<bool>() {
   RunTest<bool>({true, false, true}, {1, 1, 3}, {3, 1, 1}, {3}, {true, false, true, true, false, true, true, false, true}, {3, 1, 3});
 
   // TileWhichIsBasicallyCopiesOfInputBuffer - 3 (batch > 1 and batch_repeat == 1)
-  // This will trigger the MemCpy optimization path
+  // This will trigger the (Batched) MemCpy optimization path
   RunTest<bool>({true, false, true, true, false, true}, {2, 1, 3}, {1, 2, 1}, {3},
                 {true, false, true, true, false, true, true, false, true, true, false, true}, {2, 2, 3});
 
   // TileWhichIsBasicallyCopiesOfInputBuffer - 3 (batch > 1 and batch_repeat > 1)
-  // This will trigger the MemCpy optimization path
+  // This will trigger the (Batched) MemCpy optimization path
   RunTest<bool>({true, false, true, true, false, true}, {2, 1, 3}, {2, 2, 1}, {3},
                 {true, false, true, true, false, true, true, false, true, true, false, true, true, false, true, true, false, true, true, false, true, true, false, true},
                 {4, 2, 3});


### PR DESCRIPTION
**Description**: 

https://github.com/microsoft/onnxruntime/pull/6376 introduced an optimization to the Tile kernels to process inputs where the net tiling effect is just multiple copies of the input buffer.

For example:
input shape = [1, 1, 256 * 50]
repeats = [1, 200, 1]
output shape = [1, 200, 256 * 50]

This worked well when there was no batching involved and the optimization didn't kick-in when batching was introduced.
As a slight extension, handle batching in this optimization.

For example:
input shape = [***5***, 1, 256 * 50]
repeats = [1, 200, 1]
output shape = [***5***, 200, 256 * 50]

In this case, we would copy each of the 5 sub-tensors in the batch 200 times.

Improves the perf of a 1PP model by ~30% (95 percentile) when batch size is 5.

**Motivation and Context**
Performance
