### PR TITLE
Let execution fall back to CPU EP if Compile of a partition on current EP fails

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -921,10 +921,17 @@ class Graph {
   @returns Node with fused subgraph.
   @remarks As a new Graph instance for the fused nodes is not created, a GraphViewer can be constructed with the
            IndexedSubGraph information to provide a view of the subgraph. The original nodes are left in place
-           while this is in use. 
+           while this is in use.
 		   Call FinalizeFuseSubGraph to remove them once the fused replacement node is fully created.
   */
   Node& BeginFuseSubGraph(const IndexedSubGraph& sub_graph, const std::string& fused_node_name);
+
+  /**
+  If we have BeginFuseSubGraph, but somehow hit errors, such as Compile of an EP failed on thesub_graph.
+  We can call CancelFuseSubGraph to undo the changes of BeginFuseSubGraph
+  @param fused_node The fused node and it's function body to be removed from the graph
+  */
+  void CancelFuseSubGraph(const Node& fused_node);
 
   void FinalizeFuseSubGraph(const IndexedSubGraph& sub_graph, Node& fused_node);
 #endif

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -3406,7 +3406,6 @@ void Graph::CancelFuseSubGraph(const Node& fused_node) {
         return func.get() == fused_node_func;
       });
   if (it != function_container_.end()) {
-    LOGS(logger_, VERBOSE) << "Oh, we found it, this!!!!!";
     function_container_.erase(it);
   }
 #endif

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -3389,6 +3389,32 @@ Node& Graph::BeginFuseSubGraph(const IndexedSubGraph& sub_graph, const std::stri
   return node;
 }
 
+void Graph::CancelFuseSubGraph(const Node& fused_node) {
+  auto node_idx = fused_node.Index();
+  if (!GetNode(node_idx))
+    return;
+
+  if (fused_node.NodeType() != Node::Type::Fused)
+    return;
+
+#if !defined(ORT_MINIMAL_BUILD)
+  // Remove the FuntionBody from function_container_
+  const auto* fused_node_func = fused_node.GetFunctionBody();
+  auto it = std::find_if(
+      function_container_.begin(), function_container_.end(),
+      [fused_node_func](const std::unique_ptr<onnxruntime::Function>& func) {
+        return func.get() == fused_node_func;
+      });
+  if (it != function_container_.end()) {
+    LOGS(logger_, VERBOSE) << "Oh, we found it, this!!!!!";
+    function_container_.erase(it);
+  }
+#endif
+
+  // Remove the fused_node
+  RemoveNode(node_idx);
+}
+
 void Graph::FinalizeFuseSubGraph(const IndexedSubGraph& sub_graph, Node& fused_node) {
   const auto* func_meta_def = sub_graph.GetMetaDef();
   ORT_ENFORCE(nullptr != func_meta_def);
@@ -3429,9 +3455,7 @@ void Graph::FinalizeFuseSubGraph(const IndexedSubGraph& sub_graph, Node& fused_n
         if (it != input_indexes.cend()) {
           AddEdge(producer_idx, new_node_idx, src_idx, it->second);
         }
-      } 
-      else
-      {
+      } else {
         int dst_implicit_input_idx = dst_idx - (int)node->InputDefs().size();
         ORT_ENFORCE(dst_implicit_input_idx < (int)node->ImplicitInputDefs().size());
         auto it = input_indexes.find(node->ImplicitInputDefs()[dst_implicit_input_idx]->Name());

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -3398,7 +3398,7 @@ void Graph::CancelFuseSubGraph(const Node& fused_node) {
     return;
 
 #if !defined(ORT_MINIMAL_BUILD)
-  // Remove the FuntionBody from function_container_
+  // Remove the function body from function container
   const auto* fused_node_func = fused_node.GetFunctionBody();
   auto it = std::find_if(
       function_container_.begin(), function_container_.end(),

--- a/onnxruntime/test/providers/internal_testing/internal_testing_execution_provider.h
+++ b/onnxruntime/test/providers/internal_testing/internal_testing_execution_provider.h
@@ -15,8 +15,8 @@ class InternalTestingExecutionProvider : public IExecutionProvider {
   GetCapability(const onnxruntime::GraphViewer& graph_view,
                 const std::vector<const KernelRegistry*>& /*kernel_registries*/) const override;
 
-  virtual common::Status Compile(const std::vector<FusedNodeAndGraph>& fused_nodes,
-                                 std::vector<NodeComputeInfo>& node_compute_funcs) override;
+  common::Status Compile(const std::vector<FusedNodeAndGraph>& fused_nodes,
+                         std::vector<NodeComputeInfo>& node_compute_funcs) override;
 
   FusionStyle GetFusionStyle() const override {
     return FusionStyle::FilteredGraphViewer;

--- a/onnxruntime/test/providers/internal_testing/internal_testing_execution_provider.h
+++ b/onnxruntime/test/providers/internal_testing/internal_testing_execution_provider.h
@@ -15,8 +15,8 @@ class InternalTestingExecutionProvider : public IExecutionProvider {
   GetCapability(const onnxruntime::GraphViewer& graph_view,
                 const std::vector<const KernelRegistry*>& /*kernel_registries*/) const override;
 
-  common::Status Compile(const std::vector<FusedNodeAndGraph>& fused_nodes,
-                         std::vector<NodeComputeInfo>& node_compute_funcs) override;
+  virtual common::Status Compile(const std::vector<FusedNodeAndGraph>& fused_nodes,
+                                 std::vector<NodeComputeInfo>& node_compute_funcs) override;
 
   FusionStyle GetFusionStyle() const override {
     return FusionStyle::FilteredGraphViewer;

--- a/onnxruntime/test/providers/internal_testing/internal_testing_tests.cc
+++ b/onnxruntime/test/providers/internal_testing/internal_testing_tests.cc
@@ -254,5 +254,97 @@ TEST(InternalTestingEP, TestModelWithSubgraph) {
                             feeds);
 }
 
+// A custom InternalTestingEP extension
+// This is to testing execution fall back to CPU EP if Compile fails, for ORT format
+// This EP will take an additional compile_failure_ops
+// If in Compile() any nodes in the partition is also in compile_failure_ops
+// The Compile will fail
+class CompileFailureTestExecutionProvider : public InternalTestingExecutionProvider {
+ public:
+  CompileFailureTestExecutionProvider(const std::unordered_set<std::string>& supported_ops,
+                                      const std::unordered_set<std::string>& compile_failure_ops);
+  virtual ~CompileFailureTestExecutionProvider() = default;
+
+  Status Compile(const std::vector<FusedNodeAndGraph>& fused_nodes,
+                 std::vector<NodeComputeInfo>& node_compute_funcs) override;
+
+ private:
+  std::unordered_set<std::string> compile_failure_ops_;
+};
+
+CompileFailureTestExecutionProvider::CompileFailureTestExecutionProvider(
+    const std::unordered_set<std::string>& supported_ops,
+    const std::unordered_set<std::string>& compile_failure_ops)
+    : InternalTestingExecutionProvider(supported_ops),
+      compile_failure_ops_(compile_failure_ops) {}
+
+Status CompileFailureTestExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused_nodes,
+                                                    std::vector<NodeComputeInfo>& node_compute_funcs) {
+  for (const auto& fused_node_and_graph : fused_nodes) {
+    // If any nodes in this partition is also in compile_failure_ops_, the Compile will fail
+    const onnxruntime::GraphViewer& graph_viewer(fused_node_and_graph.filtered_graph);
+    for (const auto& node : graph_viewer.Nodes()) {
+      if (compile_failure_ops_.find(node.OpType()) != compile_failure_ops_.end()) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "CompileFailureTestExecutionProvider::Compile failed for node: ", node.Name());
+      }
+    }
+  }
+
+  return InternalTestingExecutionProvider::Compile(fused_nodes, node_compute_funcs);
+}
+
+TEST(InternalTestingEP, TestOrtModelWithCompileFailure) {
+  // In the test file, there are 2 Conv and 1 Gemm nodes, all disconnected
+  // So we should have 3 partitions be taken by InternalTestingExecutionProvider/CompileFailureTestExecutionProvider
+  // But CompileFailureTestExecutionProvider will fail the Compile for partition contains "Gemm" node
+  // This is to test the model initialization won't fail and Gemm node will not be replaced by the fused_node
+  const ORTCHAR_T* ort_model_path = ORT_TSTR("testdata/mnist.ort");
+
+  const std::unordered_set<std::string>& supported_ops{"Conv", "Gemm"};
+  const std::unordered_set<std::string>& compile_failure_ops{"Gemm"};
+
+  // Use InternalTestingExecutionProvider
+  // We should have 3 partitions taken by the EP
+  // 2 Conv and 1 Gemm
+  {
+    InferenceSessionWrapper session(SessionOptions(), GetEnvironment());
+    ASSERT_STATUS_OK(session.RegisterExecutionProvider(
+        onnxruntime::make_unique<InternalTestingExecutionProvider>(supported_ops)));
+    ASSERT_STATUS_OK(session.Load(ort_model_path));
+    ASSERT_STATUS_OK(session.Initialize());
+
+    int num_replaced_nodes = CountAndValidateAssignedNodes(
+        session.GetGraph(), supported_ops, session.GetSessionState().GetFuncMgr());
+
+    ASSERT_EQ(num_replaced_nodes, 3);
+  }
+
+  // Use CompileFailureTestExecutionProvider which will fail Compile on "Gemm"
+  // We should have 2 partitions taken by the EP
+  // 2 Conv
+  {
+    InferenceSessionWrapper session(SessionOptions(), GetEnvironment());
+    ASSERT_STATUS_OK(session.RegisterExecutionProvider(
+        onnxruntime::make_unique<CompileFailureTestExecutionProvider>(supported_ops, compile_failure_ops)));
+    ASSERT_STATUS_OK(session.Load(ort_model_path));
+    ASSERT_STATUS_OK(session.Initialize());
+
+    const auto& graph = session.GetGraph();
+    int num_replaced_nodes = CountAndValidateAssignedNodes(
+        session.GetGraph(), {"Conv"}, session.GetSessionState().GetFuncMgr());
+
+    ASSERT_EQ(num_replaced_nodes, 2);
+
+    int count_compile_failure_nodes = 0;
+    for (const auto& node : graph.Nodes()) {
+      if (compile_failure_ops.find(node.OpType()) != compile_failure_ops.end())
+        count_compile_failure_nodes++;
+    }
+
+    ASSERT_EQ(count_compile_failure_nodes, 1);
+  }
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**: Let execution fall back to CPU EP if Compile of a partition on current EP fails

**Motivation and Context**
- This is a feature request from 1p customer
- When EP::Compile fails, currently we will fail the entire execution, add a way to let the particular partition which fails the EP::Compile fall back to next EP
- This is only valid for EP using FilteredGraphViewer for now, to be specific, NNAPI and CoreML EP, all other EP will not be affected by this change
- This logic only works for using ORT format for mobile scenario, onnx model will not be affected by this change
- The user scenario is, NNAPI EP gives correct Capabilities for all the devices, if user want to restrict use certain devices (such as GPU), you can only get the error when you compile the NNAPI model if this is not possible
