### PR TITLE
Log warning when GetGradientForOp() silently fails.

### DIFF
--- a/orttraining/orttraining/core/framework/gradient_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.cc
@@ -211,7 +211,10 @@ Status GradientGraphBuilder::Build(const std::unordered_set<std::string>* p_init
     }
 
     GradientDef node_defs = GetGradientForOp(gradient_graph_config_, graph_, node, output_args_need_grad, input_args_need_grad, logger_);
-
+    if (node_defs.empty()) {
+      LOG(WARNING) << "GetGradientForOp() did not create any nodes for node " << node->Name() << " of type " << node->OpType() << "."; 
+    }
+    
     // updates arg name if gradient accumulation is needed
     for (auto& op_def : node_defs) {
       for (auto& arg : op_def.output_args) {

--- a/orttraining/orttraining/core/framework/gradient_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.cc
@@ -212,7 +212,8 @@ Status GradientGraphBuilder::Build(const std::unordered_set<std::string>* p_init
 
     GradientDef node_defs = GetGradientForOp(gradient_graph_config_, graph_, node, output_args_need_grad, input_args_need_grad, logger_);
     if (node_defs.empty()) {
-      LOG(WARNING) << "GetGradientForOp() did not create any nodes for node " << node->Name() << " of type " << node->OpType() << "."; 
+      LOGS(logger_, WARNING) << "GetGradientForOp() did not create any nodes for node "
+                             << node->Name() << " of type " << node->OpType() << "."; 
     }
     
     // updates arg name if gradient accumulation is needed


### PR DESCRIPTION
**Description**: Log warning when GetGradientForOp() silently fails.

**Motivation and Context**
- In some cases, `GetGradientForOp()` can return without creating any nodes, which may lead to an invalid graph being created.
