### PR TITLE
[java] Fix build.gradle so it always targets Java 8 class files.

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -78,6 +78,23 @@ spotless {
 compileJava {
 	dependsOn spotlessJava
 	options.compilerArgs += ["-h", "${project.buildDir}/headers/"]
+	if (!JavaVersion.current().isJava8()) {
+		// Ensures only methods present in Java 8 are used
+		options.compilerArgs.addAll(['--release', '8'])
+		// Gradle versions before 6.6 require that these flags are unset when using "-release"
+		java.sourceCompatibility = null
+		java.targetCompatibility = null
+	}
+}
+
+compileTestJava {
+	if (!JavaVersion.current().isJava8()) {
+		// Ensures only methods present in Java 8 are used
+		options.compilerArgs.addAll(['--release', '8'])
+		// Gradle versions before 6.6 require that these flags are unset when using "-release"
+		java.sourceCompatibility = null
+		java.targetCompatibility = null
+	}
 }
 
 sourceSets.test {


### PR DESCRIPTION
**Description**: 

This adds the `--release 8` flag to all javac commands when running on JDK 9 or newer. That flag ensures that only Java 8 methods are used as well as emitting class files which are Java 8 compatible, instead of using the old `--source 1.8 --target 1.8` mechanism which only ensures the latter.

If we bump the version of Gradle to 6.6 or later then there is a simpler way of doing this - https://docs.gradle.org/6.6/userguide/building_java_projects.html#sec:java_cross_compilation, but I don't know what version of gradle the android build depends on.

Fixes #6584.

