### PR TITLE
Delay load dxcore in winml model tests

### DIFF
--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -279,6 +279,9 @@ if(NOT onnxruntime_ENABLE_MEMLEAK_CHECKER)
     SOURCES ${winml_test_model_src}
     LIBS winml_test_common ${winml_test_model_libs}
   )
+  if (EXISTS ${dxcore_header})
+    target_delayload(winml_test_model ext-ms-win-dxcore-l1-*.dll)
+  endif()
   target_precompiled_header(winml_test_model testPch.h)
 endif()
 


### PR DESCRIPTION
This fixes the Windows CI build.