### PR TITLE
Add README for docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 
 We're always looking for your help to improve the product (bug fixes, new features, documentation, etc).
 
-## Contributing a code change
+## Contribute a code change
 * Start by reading the [Engineering Design](./docs/InferenceHighLevelDesign.md). More documentation can be found in the [docs folder](./docs/) and [here](https://microsoft.github.io/onnxruntime/).
 * If your change is non-trivial or introduces new public facing APIs (discussed in more detail below) please use the [feature request issue template](https://github.com/microsoft/onnxruntime/issues/new?template=feature_request.md) to discuss it with the team and get consensus on the basic design and direction first. For all other changes, you can directly create a pull request (PR) and we'll be happy to take a look.
 * Make sure your PR adheres to the [PR Guidelines](./docs/PR_Guidelines.md) and [Coding Conventions and Standards](./docs/Coding_Conventions_and_Standards.md) established by the team.
 * If you're unsure about any of the above and want to contribute, you're welcome to [start a discussion](https://github.com/microsoft/onnxruntime/discussions) with the team.
 
-## Proposing new public APIs
+## Propose a new public API
 
  ONNX Runtime has a collection of [public APIs](./README.md#api-documentation).  Some of these APIs make their way back into the Windows OS.  We make compatibility commitments for these APIs and follow a structured process when adding to them.  Please use the [Feature Request issue template](https://github.com/microsoft/onnxruntime/issues/new?template=feature_request.md) before starting any PRs that affect any of the public APIs.
  
@@ -52,6 +52,18 @@ For making changes to the Windows Machine Learning WinRT API, please label your 
 * Note: After creating a pull request, you might not see a build getting triggered right away. One of the
 onnxruntime team members will trigger the build for you.
 
+## Contribute to ONNX Runtime docs
+
+Tutorials, how-to guides and API reference docs for ONNX Runtime are published at https://onnxruntime.ai/docs.
+
+The html docs are generated from markdown using Jekyll and published using GitHub Pages.
+
+To update the docs, create a Pull Request against the [gh-pages](https://github.com/microsoft/onnxruntime/tree/gh-pages) branch of the [ONNX Runtime repo](https://github.com/microsoft/onnxruntime).
+
+Once your PR is approved and merged, your changes will be automatically published to https://onnxruntime.ai/docs.
+
+Note: technical reference docs for developers of ONNX Runtime source code can be found [here](https://github.com/microsoft/onnxruntime/docs)
+
 ## Licensing guidelines
 
 This project welcomes contributions and suggestions. Most contributions require you to
@@ -69,7 +81,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
 or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-## Reporting Security Issues
+## Report a security issue
 
 Security issues and bugs should be reported privately, via email, to the Microsoft Security
 Response Center (MSRC) at [secure@microsoft.com](mailto:secure@microsoft.com). You should

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# How to update ONNX Runtime docs
+
+The docs for ONNX Runtime are published at https://onnxruntime.ai/docs.
+
+The docs are generated from markdown using Jekyll and published using GitHub Pages.
+
+To update the docs, create a Pull Request against the [gh-pages](https://github.com/microsoft/onnxruntime/tree/gh-pages) branch of the [ONNX Runtime repo](https://github.com/microsoft/onnxruntime).
+
+Once your PR is approved and merged, your changes will be automatically published to https://onnxruntime.ai/docs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,0 @@
-# How to update ONNX Runtime docs
-
-The docs for ONNX Runtime are published at https://onnxruntime.ai/docs.
-
-The docs are generated from markdown using Jekyll and published using GitHub Pages.
-
-To update the docs, create a Pull Request against the [gh-pages](https://github.com/microsoft/onnxruntime/tree/gh-pages) branch of the [ONNX Runtime repo](https://github.com/microsoft/onnxruntime).
-
-Once your PR is approved and merged, your changes will be automatically published to https://onnxruntime.ai/docs.


### PR DESCRIPTION
**Description**: Add instructions for updating docs website.

Initial version. We can update with instructions for building locally and staging, as necessary.

