### PR TITLE
Revert "Remove abs in LpPool (#6303)"

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/pool_base.h
+++ b/onnxruntime/core/providers/cpu/nn/pool_base.h
@@ -88,7 +88,7 @@ class LpPool {
 
   template <typename T>
   static void Process(const T& x_data, T& y_data, const PoolProcessContext& cxt) {
-    y_data += static_cast<T>(std::pow(x_data, cxt.p_));
+    y_data += static_cast<T>(std::pow(std::abs(x_data), cxt.p_));
   }
 
   template <typename T>

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -1264,25 +1264,6 @@ TEST(PoolTest, LpPool) {
   test.Run();
 }
 
-TEST(PoolTest, LpPoolWithNegativeNumbers) {
-  OpTester test("LpPool");
-
-  test.AddAttribute("p", static_cast<int64_t>(1));
-  test.AddAttribute("auto_pad", "");
-  test.AddAttribute("strides", std::vector<int64_t>{2});
-  test.AddAttribute("pads", vector<int64_t>{0, 0});
-  test.AddAttribute("kernel_shape", vector<int64_t>{2});
-
-  std::vector<float> x_vals = {0.2f, -0.6f};
-  std::vector<int64_t> x_dims = {1, 1, 2};
-  std::vector<int64_t> expected_dims = {1, 1, 1};
-  std::vector<float> expected_vals = {-0.4f};
-
-  test.AddInput<float>("X", x_dims, x_vals);
-  test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run();
-}
-
 TEST(PoolTest, GlobalLpPool) {
   OpTester test("GlobalLpPool");
   test.AddAttribute("p", static_cast<int64_t>(3));


### PR DESCRIPTION
This reverts commit 3b3e698674dca2014b91fb617e2c4f22ffd0c5c9.

The reason for this revert is as follows:
Even though the logic introduced ***may be*** the right logic for LpPool (as pointed out in #6302), the ONNX spec is very ambiguous about this. It states that "Lp pooling consisting of computing the ***Lp norm*** on all values of a subset of the input....",. Lp norm itself requires using an `abs()` as it is the equivalent of - https://numpy.org/doc/stable/reference/generated/numpy.linalg.norm.html, https://www.tensorflow.org/api_docs/python/tf/norm, and https://pytorch.org/docs/stable/generated/torch.norm.html. 

Given the ambiguity and given that this change breaks tests in DML, it makes sense to keep the logic as it was in the previous releases, clarify the spec in ONNX (with tests), and then change the logic here. 

