### PR TITLE
Deprecate OMP from nuget pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-packaging-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
     DoEsrp: ${{ parameters.DoEsrp }}
     IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
     OrtNugetPackageId: 'Microsoft.ML.OnnxRuntime'
-    AdditionalBuildFlags: '--use_openmp'
+    AdditionalBuildFlags: ''
     AdditionalWinBuildFlags: '--enable_onnx_tests --enable_wcos'
 
 - job: Linux_C_API_Packaging_GPU_x64

--- a/tools/ci_build/github/azure-pipelines/nuget/cpu-esrp-openmp-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/cpu-esrp-openmp-pipeline.yml
@@ -30,6 +30,6 @@ jobs:
     DoEsrp: ${{ parameters.DoEsrp }}
     IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
     OrtNugetPackageId: 'Microsoft.ML.OnnxRuntime'
-    AdditionalBuildFlags: ''
+    AdditionalBuildFlags: '--use_openmp'
     AdditionalWinBuildFlags: '--use_openmp --enable_onnx_tests --enable_wcos'
     BuildVariant: 'default'

--- a/tools/ci_build/github/azure-pipelines/nuget/cpu-esrp-openmp-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/cpu-esrp-openmp-pipeline.yml
@@ -1,0 +1,35 @@
+parameters:
+- name: RunOnnxRuntimeTests
+  displayName: Run Tests?
+  type: boolean
+  default: true
+
+- name: DoCompliance
+  displayName: Run Compliance Tasks?
+  type: boolean
+  default: true
+
+- name: DoEsrp
+  displayName: Run code sign tasks? Must be true if you are doing an Onnx Runtime release.
+  type: boolean
+  default: false
+
+- name: IsReleaseBuild
+  displayName: Is a release build? Set it to true if you are doing an Onnx Runtime release.
+  type: boolean
+  default: false
+
+variables:
+  PackageName: 'Microsoft.ML.OnnxRuntime'
+
+jobs:
+- template: ../templates/c-api-cpu.yml
+  parameters:
+    RunOnnxRuntimeTests: ${{ parameters.RunOnnxRuntimeTests }}
+    DoCompliance: ${{ parameters.DoCompliance }}
+    DoEsrp: ${{ parameters.DoEsrp }}
+    IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
+    OrtNugetPackageId: 'Microsoft.ML.OnnxRuntime'
+    AdditionalBuildFlags: ''
+    AdditionalWinBuildFlags: '--use_openmp --enable_onnx_tests --enable_wcos'
+    BuildVariant: 'default'

--- a/tools/ci_build/github/azure-pipelines/nuget/cpu-esrp-openmp-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/cpu-esrp-openmp-pipeline.yml
@@ -20,7 +20,7 @@ parameters:
   default: false
 
 variables:
-  PackageName: 'Microsoft.ML.OnnxRuntime'
+  PackageName: 'Microsoft.ML.OnnxRuntime.OpenMP'
 
 jobs:
 - template: ../templates/c-api-cpu.yml
@@ -29,7 +29,7 @@ jobs:
     DoCompliance: ${{ parameters.DoCompliance }}
     DoEsrp: ${{ parameters.DoEsrp }}
     IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
-    OrtNugetPackageId: 'Microsoft.ML.OnnxRuntime'
+    OrtNugetPackageId: 'Microsoft.ML.OnnxRuntime.OpenMP'
     AdditionalBuildFlags: '--use_openmp'
-    AdditionalWinBuildFlags: '--use_openmp --enable_onnx_tests --enable_wcos'
+    AdditionalWinBuildFlags: '--enable_onnx_tests --enable_wcos'
     BuildVariant: 'default'


### PR DESCRIPTION
Per team's decision, deprecate OMP from nuget and add a separate pipeline with OMP enabled.
