### PR TITLE
Support non tuple return values from torch.nn.module

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -104,6 +104,15 @@ def _parse_inputs_for_onnx_export(module, *inputs, **kwargs):
 
 def _parse_outputs_for_onnx_export(module, inputs):
 
+    def _create_output_dim_names_from_mapping(output):
+        output_names, dynamic_axes = [], {}
+        for name, value in output.items():
+            output_names.append(name)
+            dynamic_axes[name] = {}
+            for dim_idx in range(len(value.shape)):
+                dynamic_axes[name].update({dim_idx: '{}_dim{}'.format(name, dim_idx)})
+        return output_names, dynamic_axes
+
     def _create_output_dim_names(output, output_idx, from_sequence):
         if from_sequence and not isinstance(output, torch.Tensor):
             raise TypeError('ORTModule does not support the following model output type {} within a Sequence'.format(type(sample_outputs)))
@@ -118,6 +127,9 @@ def _parse_outputs_for_onnx_export(module, inputs):
     #   Do an inference to grab outputs
     is_train_mode = module.training
     module.eval()
+    output_names = []
+    output_dynamic_axes = {}
+    sample_outputs = None
     with torch.no_grad():
         # Deepcopy inputs, since input values may change after model run.
         sample_inputs_copy = _deepcopy_model_input(*inputs)
@@ -130,12 +142,10 @@ def _parse_outputs_for_onnx_export(module, inputs):
                             " Compute will continue, but unexpected results may occur!")
 
         sample_outputs = model_copy(*sample_inputs_copy)
-        output_names = []
-        output_dynamic_axes = {}
         if isinstance(sample_outputs, torch.Tensor):
             output_names, output_dynamic_axes = _create_output_dim_names(sample_outputs, 0, False)
         elif isinstance(sample_outputs, abc.Mapping):
-            raise NotImplementedError('Dictionaries are not supported as output yet')
+            output_names, output_dynamic_axes = _create_output_dim_names_from_mapping(sample_outputs)
         elif isinstance(sample_outputs, abc.Sequence):
             for idx, out in enumerate(sample_outputs):
                 tmp_output_names, tmp_output_dynamic_axes = _create_output_dim_names(out, idx, True)
@@ -145,7 +155,21 @@ def _parse_outputs_for_onnx_export(module, inputs):
             raise TypeError('ORTModule does not support the following model output type {}'.format(type(sample_outputs)))
     if is_train_mode:
         module.train()
-    return output_names, output_dynamic_axes
+    return output_names, output_dynamic_axes, sample_outputs
+
+def _populate_user_output(sample_user_output, user_output_names, user_outputs):
+    if isinstance(sample_user_output, Mapping):
+        key_value_pairs = [(user_output_names[i], user_outputs[i]) for i in range(len(user_output_names))]
+        return type(sample_user_output)(key_value_pairs)
+    elif isinstance(sample_user_output, tuple):
+        try:
+            # Try constructing the user named tuple from the output tuple
+            return type(sample_user_output)(*user_outputs)
+        except TypeError:
+            # The expected output type is not a namedtuple, but is a regular tuple type
+            pass
+
+    return user_outputs
 
 # TODO: PyTorch's to_dlpack() uses same config for both torch.bool and torch.uint8,
 # and convert the config to torch.uint8 tensor duing from_dlpack(). So a boolean tensor
@@ -178,6 +202,7 @@ class ORTModule(torch.nn.Module):
         self._current_input_shape = None
         self._module_gradient_graph_builder = None
         self._input_names_require_grad = None
+        self._sample_user_output = None
 
         # Training model
         self._onnx_training = None
@@ -392,7 +417,8 @@ class ORTModule(torch.nn.Module):
 
         proc_inputs = [data for data in inputs if data is not None]
 
-        return _ORTModuleFunction.apply(*self._convert_training_graph_input_to_list(*proc_inputs, **kwargs))
+        return _populate_user_output(self._sample_user_output, self._onnx_graphs_info.user_output_names,
+            _ORTModuleFunction.apply(*self._convert_training_graph_input_to_list(*proc_inputs, **kwargs)))
 
     @_utils.timeit(enabled=__TEMP_ENABLE_METHOD_TIMING__)
     def _convert_training_graph_input_to_list(self, *inputs, **kwargs):
@@ -426,7 +452,7 @@ class ORTModule(torch.nn.Module):
 
         # Setup dynamic axes for onnx model
         input_names, dynamic_axes, self._input_names_require_grad = _parse_inputs_for_onnx_export(self._original_module, *inputs, **kwargs)
-        output_names, output_dynamic_axes = _parse_outputs_for_onnx_export(self._original_module, inputs)
+        output_names, output_dynamic_axes, self._sample_user_output = _parse_outputs_for_onnx_export(self._original_module, inputs)
         dynamic_axes.update(output_dynamic_axes)
 
         # TODO: Support contrib OPs support? user model has no hint

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -107,6 +107,8 @@ def _parse_outputs_for_onnx_export(module, inputs):
     def _create_output_dim_names_from_mapping(output):
         output_names, dynamic_axes = [], {}
         for name, value in output.items():
+            if not isinstance(value, torch.Tensor):
+                raise TypeError('ORTModule does not support the following model output type {} within a Mapping'.format(type(output)))
             output_names.append(name)
             dynamic_axes[name] = {}
             for dim_idx in range(len(value.shape)):
@@ -115,7 +117,7 @@ def _parse_outputs_for_onnx_export(module, inputs):
 
     def _create_output_dim_names(output, output_idx, from_sequence):
         if from_sequence and not isinstance(output, torch.Tensor):
-            raise TypeError('ORTModule does not support the following model output type {} within a Sequence'.format(type(sample_outputs)))
+            raise TypeError('ORTModule does not support the following model output type {} within a Sequence'.format(type(output)))
         output_names, dynamic_axes = [], {}
         name = 'output{}'.format(output_idx)
         output_names.append(name)

--- a/orttraining/orttraining/test/python/how_to_install_training_test_dependencies.md
+++ b/orttraining/orttraining/test/python/how_to_install_training_test_dependencies.md
@@ -9,3 +9,7 @@ Due to a [bug on DeepSpeed](https://github.com/microsoft/DeepSpeed/issues/663), 
 
    ```sh
    pip install -r tools/ci_build/github/linux/docker/scripts/training/requirements.txt
+
+2. Install second set of dependencies for ortmodule:
+   ```sh
+   pip install -r tools/ci_build/github/linux/docker/scripts/training/ortmodule/requirements.txt

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-distributed-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-distributed-test-ci-pipeline.yml
@@ -22,7 +22,8 @@ jobs:
           --update --build \
           --build_wheel \
           " \
-          -m
+        -m \
+        -u
       DisplayName: 'Build'
 
   - bash: tools/ci_build/github/linux/docker/scripts/training/azure_scale_set_vm_mount_test_data.sh -p $(orttrainingtestdata-storage-key) -s "//orttrainingtestdata.file.core.windows.net/mnist" -d "/mnist"

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
@@ -22,6 +22,7 @@ jobs:
           --update --build \
           --build_wheel \
           " \
+        -u
       DisplayName: 'Build'
 
   - bash: tools/ci_build/github/linux/docker/scripts/training/azure_scale_set_vm_mount_test_data.sh -p $(orttrainingtestdata-storage-key) -s "//orttrainingtestdata.file.core.windows.net/mnist" -d "/mnist"

--- a/tools/ci_build/github/linux/docker/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_deps.sh
@@ -4,14 +4,16 @@ set -e -x
 SCRIPT_DIR="$( dirname "${BASH_SOURCE[0]}" )"
 INSTALL_DEPS_TRAINING=false
 INSTALL_DEPS_DISTRIBUTED_SETUP=false
+ORTMODULE_BUILD=false
 
-while getopts p:d:tm parameter_Option
+while getopts p:d:tmu parameter_Option
 do case "${parameter_Option}"
 in
 p) PYTHON_VER=${OPTARG};;
 d) DEVICE_TYPE=${OPTARG};;
 t) INSTALL_DEPS_TRAINING=true;;
 m) INSTALL_DEPS_DISTRIBUTED_SETUP=true;;
+u) ORTMODULE_BUILD=true;;
 esac
 done
 
@@ -117,8 +119,10 @@ ${PYTHON_EXE} -m pip install -r ${0/%install_deps\.sh/requirements\.txt}
 if [ $DEVICE_TYPE = "gpu" ]; then
   if [[ $INSTALL_DEPS_TRAINING = true ]]; then
     ${PYTHON_EXE} -m pip install -r ${0/%install_deps.sh/training\/requirements.txt}
-    # Due to a [bug on DeepSpeed](https://github.com/microsoft/DeepSpeed/issues/663), we install it separately through secondary/requirements.txt
-    ${PYTHON_EXE} -m pip install -r ${0/%install_deps.sh/training\/secondary\/requirements.txt}
+    if [[ $ORTMODULE_BUILD = true ]]; then
+      # Due to a [bug on DeepSpeed](https://github.com/microsoft/DeepSpeed/issues/663), we install it separately through ortmodule/requirements.txt
+      ${PYTHON_EXE} -m pip install -r ${0/%install_deps.sh/training\/ortmodule\/requirements.txt}
+    fi
   fi
   if [[ $INSTALL_DEPS_DISTRIBUTED_SETUP = true ]]; then
     source ${0/%install_deps.sh/install_openmpi.sh}

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/requirements.txt
@@ -1,0 +1,3 @@
+deepspeed
+numpy==1.19.5
+transformers==v4.3.2

--- a/tools/ci_build/github/linux/docker/scripts/training/secondary/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/secondary/requirements.txt
@@ -1,1 +1,0 @@
-deepspeed

--- a/tools/ci_build/github/linux/run_dockerbuild.sh
+++ b/tools/ci_build/github/linux/run_dockerbuild.sh
@@ -6,10 +6,11 @@ SOURCE_ROOT=$(realpath $SCRIPT_DIR/../../../../)
 CUDA_VER=cuda10.1-cudnn7.6
 YOCTO_VERSION="4.19"
 INSTALL_DEPS_DISTRIBUTED_SETUP=false
+ORTMODULE_BUILD=false
 ALLOW_RELEASED_ONNX_OPSET_ONLY_ENV="ALLOW_RELEASED_ONNX_OPSET_ONLY="$ALLOW_RELEASED_ONNX_OPSET_ONLY
 echo "ALLOW_RELEASED_ONNX_OPSET_ONLY environment variable is set as "$ALLOW_RELEASED_ONNX_OPSET_ONLY_ENV
 
-while getopts c:o:d:r:p:x:a:v:y:t:i:m parameter_Option
+while getopts c:o:d:r:p:x:a:v:y:t:i:mu parameter_Option
 do case "${parameter_Option}"
 in
 #android, ubuntu16.04, ubuntu18.04, CentOS7
@@ -36,6 +37,8 @@ t) EXTRA_IMAGE_TAG=${OPTARG};;
 i) IMAGE_CACHE_CONTAINER_REGISTRY_NAME=${OPTARG};;
 # install distributed setup dependencies
 m) INSTALL_DEPS_DISTRIBUTED_SETUP=true;;
+# install ortmodule specific dependencies
+u) ORTMODULE_BUILD=true;;
 esac
 done
 
@@ -85,6 +88,9 @@ else
         fi
         if [[ $INSTALL_DEPS_DISTRIBUTED_SETUP = true ]]; then
             INSTALL_DEPS_EXTRA_ARGS="${INSTALL_DEPS_EXTRA_ARGS} -m"
+        fi
+        if [[ $ORTMODULE_BUILD = true ]]; then
+            INSTALL_DEPS_EXTRA_ARGS="${INSTALL_DEPS_EXTRA_ARGS} -u"
         fi
         $GET_DOCKER_IMAGE_CMD --repository "onnxruntime-$IMAGE" \
             --docker-build-args="--build-arg BUILD_USER=onnxruntimedev --build-arg BUILD_UID=$(id -u) --build-arg PYTHON_VERSION=${PYTHON_VER} --build-arg INSTALL_DEPS_EXTRA_ARGS=\"${INSTALL_DEPS_EXTRA_ARGS}\"" \


### PR DESCRIPTION
Support for following types is added:
- Any dictionary type (where values are ```torch.Tensor``` type)
- Named tuples
- HuggingFace ModelOutput types (where values are only ```torch.Tensor``` type. Some of the outputs contain tuples of tensors which are not yet supported.)
