### PR TITLE
Change BuildKernelDefConstraintsFunctorFromTypeList struct to BuildKernelDefConstraintsFromTypeList function.

### DIFF
--- a/onnxruntime/core/providers/cpu/generator/constant_of_shape.cc
+++ b/onnxruntime/core/providers/cpu/generator/constant_of_shape.cc
@@ -70,8 +70,8 @@ ONNX_CPU_OPERATOR_KERNEL(
     KernelDefBuilder()
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>())
         .TypeConstraint("T2",
-                        BuildKernelDefConstraintsFunctorFromTypeList<SupportedOutputTypes>{}(),
-                        BuildKernelDefConstraintsFunctorFromTypeList<EnabledOutputTypes>{}()),
+                        BuildKernelDefConstraintsFromTypeList<SupportedOutputTypes>(),
+                        BuildKernelDefConstraintsFromTypeList<EnabledOutputTypes>()),
     ConstantOfShape);
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
@@ -230,12 +230,12 @@ REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(Sqrt, 6, 12, double, Sqrt);
 REG_ELEMENTWISE_TYPED_KERNEL(Sqrt, 13, float, Sqrt);
 REG_ELEMENTWISE_TYPED_KERNEL(Sqrt, 13, double, Sqrt);
 
-const auto supported_pow7_types = BuildKernelDefConstraintsFunctorFromTypeList<Pow7Types>{}();
-const auto enabled_pow7_types = BuildKernelDefConstraintsFunctorFromTypeList<EnabledPow7Types>{}();
-const auto supported_pow12_base_types = BuildKernelDefConstraintsFunctorFromTypeList<Pow12BaseTypes>{}();
-const auto supported_pow12_exp_types = BuildKernelDefConstraintsFunctorFromTypeList<Pow12ExpTypes>{}();
-const auto enabled_pow12_base_types = BuildKernelDefConstraintsFunctorFromTypeList<EnabledPow12BaseTypes>{}();
-const auto enabled_pow12_exp_types = BuildKernelDefConstraintsFunctorFromTypeList<EnabledPow12ExpTypes>{}();
+const auto supported_pow7_types = BuildKernelDefConstraintsFromTypeList<Pow7Types>();
+const auto enabled_pow7_types = BuildKernelDefConstraintsFromTypeList<EnabledPow7Types>();
+const auto supported_pow12_base_types = BuildKernelDefConstraintsFromTypeList<Pow12BaseTypes>();
+const auto supported_pow12_exp_types = BuildKernelDefConstraintsFromTypeList<Pow12ExpTypes>();
+const auto enabled_pow12_base_types = BuildKernelDefConstraintsFromTypeList<EnabledPow12BaseTypes>();
+const auto enabled_pow12_exp_types = BuildKernelDefConstraintsFromTypeList<EnabledPow12ExpTypes>();
 REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Pow, 7, 11, Pow, supported_pow7_types, enabled_pow7_types);
 REG_ELEMENTWISE_VERSIONED_KERNEL_NONT_2(Pow, 12, 12, Pow,
                                         supported_pow12_base_types, enabled_pow12_base_types,
@@ -264,19 +264,19 @@ REG_ELEMENTWISE_TYPED_KERNEL(Sum, 13, double, Sum_8);
 
 REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(Max, 6, 7, float, Max_6);
 
-const auto supported_max8_types = BuildKernelDefConstraintsFunctorFromTypeList<Max8Types>{}();
-const auto supported_max12_types = BuildKernelDefConstraintsFunctorFromTypeList<Max12Types>{}();
-const auto enabled_max8_types = BuildKernelDefConstraintsFunctorFromTypeList<EnabledMax8Types>{}();
-const auto enabled_max12_types = BuildKernelDefConstraintsFunctorFromTypeList<EnabledMax12Types>{}();
+const auto supported_max8_types = BuildKernelDefConstraintsFromTypeList<Max8Types>();
+const auto supported_max12_types = BuildKernelDefConstraintsFromTypeList<Max12Types>();
+const auto enabled_max8_types = BuildKernelDefConstraintsFromTypeList<EnabledMax8Types>();
+const auto enabled_max12_types = BuildKernelDefConstraintsFromTypeList<EnabledMax12Types>();
 REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Max, 8, 11, Max_8, supported_max8_types, enabled_max8_types);
 REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Max, 12, 12, Max_8, supported_max12_types, enabled_max12_types);
 // Supposed to add BFloat16 but we are not supporting now, however, separate registration
 REG_ELEMENTWISE_KERNEL_NONT(Max, 13, Max_8, supported_max12_types, enabled_max12_types);
 
-const auto supported_min8_types = BuildKernelDefConstraintsFunctorFromTypeList<Min8Types>{}();
-const auto supported_min12_types = BuildKernelDefConstraintsFunctorFromTypeList<Min12Types>{}();
-const auto enabled_min8_types = BuildKernelDefConstraintsFunctorFromTypeList<EnabledMin8Types>{}();
-const auto enabled_min12_types = BuildKernelDefConstraintsFunctorFromTypeList<EnabledMin12Types>{}();
+const auto supported_min8_types = BuildKernelDefConstraintsFromTypeList<Min8Types>();
+const auto supported_min12_types = BuildKernelDefConstraintsFromTypeList<Min12Types>();
+const auto enabled_min8_types = BuildKernelDefConstraintsFromTypeList<EnabledMin8Types>();
+const auto enabled_min12_types = BuildKernelDefConstraintsFromTypeList<EnabledMin12Types>();
 REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(Min, 6, 7, float, Min_6);
 REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Min, 8, 11, Min_8, supported_min8_types, enabled_min8_types);
 REG_ELEMENTWISE_VERSIONED_KERNEL_NONT(Min, 12, 12, Min_8, supported_min12_types, enabled_min12_types);

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -308,10 +308,10 @@ Status Cast::Compute(OpKernelContext* context) const {
   return Status::OK();
 }
 
-const auto supported_src_type_constraints = BuildKernelDefConstraintsFunctorFromTypeList<SupportedSrcTypes>{}();
-const auto supported_dst_type_constraints = BuildKernelDefConstraintsFunctorFromTypeList<SupportedDstTypes>{}();
-const auto enabled_src_type_constraints = BuildKernelDefConstraintsFunctorFromTypeList<EnabledSrcTypes>{}();
-const auto enabled_dst_type_constraints = BuildKernelDefConstraintsFunctorFromTypeList<EnabledDstTypes>{}();
+const auto supported_src_type_constraints = BuildKernelDefConstraintsFromTypeList<SupportedSrcTypes>();
+const auto supported_dst_type_constraints = BuildKernelDefConstraintsFromTypeList<SupportedDstTypes>();
+const auto enabled_src_type_constraints = BuildKernelDefConstraintsFromTypeList<EnabledSrcTypes>();
+const auto enabled_dst_type_constraints = BuildKernelDefConstraintsFromTypeList<EnabledDstTypes>();
 
 }  // namespace
 

--- a/onnxruntime/core/providers/cpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/cpu/tensor/gather.cc
@@ -21,8 +21,8 @@ using SupportedIndexTypes = ORT_OP_KERNEL_ARG_SUPPORTED_TYPE_LIST_ALL_OPSETS(kCp
 using EnabledIndexTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST_ALL_OPSETS(kCpuExecutionProvider, kOnnxDomain,
                                                                          Gather, Input, 1);
 
-const auto supported_index_type_constraints = BuildKernelDefConstraintsFunctorFromTypeList<SupportedIndexTypes>{}();
-const auto enabled_index_type_constraints = BuildKernelDefConstraintsFunctorFromTypeList<EnabledIndexTypes>{}();
+const auto supported_index_type_constraints = BuildKernelDefConstraintsFromTypeList<SupportedIndexTypes>();
+const auto enabled_index_type_constraints = BuildKernelDefConstraintsFromTypeList<EnabledIndexTypes>();
 }  // namespace
 
 ONNX_CPU_OPERATOR_VERSIONED_KERNEL(

--- a/onnxruntime/core/providers/cpu/tensor/isinf.cc
+++ b/onnxruntime/core/providers/cpu/tensor/isinf.cc
@@ -40,8 +40,8 @@ ONNX_CPU_OPERATOR_KERNEL(
     10,
     KernelDefBuilder()
         .TypeConstraint("T1",
-                        BuildKernelDefConstraintsFunctorFromTypeList<IsInf::SupportedTypes>{}(),
-                        BuildKernelDefConstraintsFunctorFromTypeList<IsInf::EnabledTypes>{}())
+                        BuildKernelDefConstraintsFromTypeList<IsInf::SupportedTypes>(),
+                        BuildKernelDefConstraintsFromTypeList<IsInf::EnabledTypes>())
         .TypeConstraint("T2", DataTypeImpl::GetTensorType<bool>()),
     IsInf);
 

--- a/onnxruntime/core/providers/cpu/tensor/slice.cc
+++ b/onnxruntime/core/providers/cpu/tensor/slice.cc
@@ -33,10 +33,10 @@ using EnabledDataTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST_ALL_OPSETS(kCpuExec
 using EnabledIndicesTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST_ALL_OPSETS(kCpuExecutionProvider, kOnnxDomain,
                                                                            Slice, Input, 1);
 
-const auto supported_data_type_constraints = BuildKernelDefConstraintsFunctorFromTypeList<SupportedDataTypes>{}();
-const auto supported_indices_type_constraints = BuildKernelDefConstraintsFunctorFromTypeList<SupportedIndicesTypes>{}();
-const auto enabled_data_type_constraints = BuildKernelDefConstraintsFunctorFromTypeList<EnabledDataTypes>{}();
-const auto enabled_indices_type_constraints = BuildKernelDefConstraintsFunctorFromTypeList<EnabledIndicesTypes>{}();
+const auto supported_data_type_constraints = BuildKernelDefConstraintsFromTypeList<SupportedDataTypes>();
+const auto supported_indices_type_constraints = BuildKernelDefConstraintsFromTypeList<SupportedIndicesTypes>();
+const auto enabled_data_type_constraints = BuildKernelDefConstraintsFromTypeList<EnabledDataTypes>();
+const auto enabled_indices_type_constraints = BuildKernelDefConstraintsFromTypeList<EnabledIndicesTypes>();
 
 // std::clamp doesn't exist until C++17 so create a local version
 template <typename T>

--- a/onnxruntime/core/providers/cpu/tensor/transpose.cc
+++ b/onnxruntime/core/providers/cpu/tensor/transpose.cc
@@ -25,8 +25,8 @@ using SupportedDataTypes = ORT_OP_KERNEL_ARG_SUPPORTED_TYPE_LIST_ALL_OPSETS(kCpu
 using EnabledDataTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST_ALL_OPSETS(kCpuExecutionProvider, kOnnxDomain,
                                                                         Transpose, Input, 0);
 
-const auto supported_type_constraints = BuildKernelDefConstraintsFunctorFromTypeList<SupportedDataTypes>{}();
-const auto enabled_type_constraints = BuildKernelDefConstraintsFunctorFromTypeList<EnabledDataTypes>{}();
+const auto supported_type_constraints = BuildKernelDefConstraintsFromTypeList<SupportedDataTypes>();
+const auto enabled_type_constraints = BuildKernelDefConstraintsFromTypeList<EnabledDataTypes>();
 }  // namespace
 
 /* A permutation [a,b,c,...] indicates that


### PR DESCRIPTION
**Description**
Change BuildKernelDefConstraintsFunctorFromTypeList struct to BuildKernelDefConstraintsFromTypeList function.
The original name is too long.

**Motivation and Context**
Clean up.