### PR TITLE
MLAS: add uint8_t NHWC max pooling

### DIFF
--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -64,6 +64,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, MatMulIntegerToFloat);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, DynamicQuantizeLSTM);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, QLinearConv);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, NhwcMaxPool);
 // ******** End: Quantization ******************* //
 
 // This section includes all op kernel declarations for former experimental ops which have now been removed from onnx.
@@ -147,6 +148,7 @@ Status RegisterQuantizationKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, MatMulIntegerToFloat)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, DynamicQuantizeLSTM)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, QLinearConv)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, NhwcMaxPool)>,
   };
 
   for (auto& function_table_entry : function_table) {

--- a/onnxruntime/contrib_ops/cpu/quantization/nhwc_max_pool.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/nhwc_max_pool.cc
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/common/common.h"
+#include "core/framework/op_kernel.h"
+#include "core/providers/cpu/nn/pool_attributes.h"
+#include "core/common/safeint.h"
+#include "core/util/math.h"
+#include "core/mlas/inc/mlas.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+class NhwcMaxPool : public OpKernel {
+ public:
+  explicit NhwcMaxPool(const OpKernelInfo& info) : OpKernel(info),
+                                                   pool_attrs_(info, "MaxPool", info.node().SinceVersion()) {
+  }
+
+  Status Compute(OpKernelContext* context) const override;
+
+ private:
+   PoolAttributes pool_attrs_;
+};
+
+Status NhwcMaxPool::Compute(OpKernelContext* context) const {
+  const auto* X = context->Input<Tensor>(0);
+  const TensorShape& input_shape = X->Shape();
+
+  const size_t input_rank = input_shape.NumDimensions();
+  ORT_RETURN_IF_NOT(input_rank >= 3, "Input dimension cannot be less than 3.");
+
+  const int64_t N = input_shape[0];
+  const int64_t C = input_shape[input_rank - 1];
+
+  ORT_ENFORCE(input_shape.Size() > 0 || N == 0, "Invalid input shape. Only N can be zero. Got:", input_shape);
+
+  const size_t spatial_dims = input_rank - 2;
+
+  // Compute the output size and effective padding for this pooling operation.
+  std::vector<int64_t> output_dims({N});
+  std::vector<int64_t> pads = pool_attrs_.pads;
+  int64_t kernel_size = 1;
+  int64_t input_image_size = 1;
+  int64_t output_image_size = 1;
+  for (size_t dim = 0; dim < spatial_dims; ++dim) {
+    int64_t kernel = pool_attrs_.kernel_shape[dim];
+    int64_t input_dim = input_shape[dim + 1];
+
+    kernel_size *= kernel;
+    input_image_size *= input_dim;
+
+    int64_t output_dim = 0;
+    pool_attrs_.ComputeSizePadDilations(input_dim,
+                                        pool_attrs_.strides[dim],
+                                        kernel,
+                                        &pads.at(dim),
+                                        &pads.at(spatial_dims + dim),
+                                        pool_attrs_.dilations[dim],
+                                        &output_dim);
+    output_dims.push_back(output_dim);
+
+    output_image_size *= output_dim;
+  }
+  output_dims.push_back(C);
+
+  Tensor* Y = context->Output(0, output_dims);
+
+  constexpr int64_t output_batch_count = 512;
+
+  // Allocate indirection buffer pointers and prepare a padding vector for the
+  // im2col transform.
+  AllocatorPtr alloc;
+  ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&alloc));
+  int64_t col_buffer_batch_count = std::min(output_image_size, output_batch_count);
+  auto* col_data = alloc->Alloc(SafeInt<size_t>(sizeof(const uint8_t*)) * kernel_size * col_buffer_batch_count);
+  BufferUniquePtr col_buffer(col_data, BufferDeleter(alloc));
+  std::vector<uint8_t> padding_data(static_cast<size_t>(C), 0);
+
+  const auto* Xdata = X->template Data<uint8_t>();
+  auto* Ydata = Y->template MutableData<uint8_t>();
+
+  for (int64_t image_id = 0; image_id < N; ++image_id) {
+    for (int64_t output_start = 0; output_start < output_image_size;) {
+      int64_t output_count = std::min(output_image_size - output_start, output_batch_count);
+      math::Im2col<uint8_t, StorageOrder::NHWC>()(
+          Xdata,
+          C,
+          input_shape.GetDims().data() + 1,
+          output_dims.data() + 1,
+          pool_attrs_.kernel_shape.data(),
+          pool_attrs_.strides.data(),
+          pool_attrs_.dilations.data(),
+          pads.data(),
+          static_cast<ptrdiff_t>(spatial_dims),
+          output_start,
+          output_count,
+          static_cast<uint8_t const**>(col_buffer.get()),
+          padding_data.data());
+      MlasMaximumPool(
+          static_cast<uint8_t const**>(col_buffer.get()),
+          Ydata,
+          static_cast<size_t>(C),
+          static_cast<size_t>(output_count),
+          static_cast<size_t>(kernel_size));
+
+      Ydata += output_count * C;
+      output_start += output_count;
+    }
+
+    Xdata += input_image_size * C;
+  }
+
+  return Status::OK();
+}
+
+ONNX_OPERATOR_KERNEL_EX(
+    NhwcMaxPool,
+    kMSDomain,
+    1,
+    kCpuExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<uint8_t>()),
+    NhwcMaxPool);
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/core/graph/contrib_ops/nhwc_schema_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/nhwc_schema_defs.cc
@@ -169,6 +169,23 @@ void RegisterNhwcSchemas() {
         }
       });
 
+  ONNX_CONTRIB_OPERATOR_SCHEMA(NhwcMaxPool)
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .Input(0, "x", "", "T")
+      .Output(0, "y", "", "T")
+      .TypeConstraint("T", {"tensor(int8)", "tensor(uint8)"}, "")
+      .Attr("auto_pad", "", AttributeProto::STRING, std::string("NOTSET"))
+      .Attr("kernel_shape", "", AttributeProto::INTS)
+      .Attr("dilations", "", AttributeProto::INTS, OPTIONAL_VALUE)
+      .Attr("strides", "", AttributeProto::INTS, OPTIONAL_VALUE)
+      .Attr("pads", "", AttributeProto::INTS, OPTIONAL_VALUE)
+      .Attr("ceil_mode", "", AttributeProto::INT, static_cast<int64_t>(0))
+      .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+        propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        convPoolShapeInferenceNhwc(ctx, true, true, 0, 1);
+      });
+
   ONNX_CONTRIB_OPERATOR_SCHEMA(QLinearGlobalAveragePool)
       .SetDomain(kMSDomain)
       .SinceVersion(1)

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -462,6 +462,16 @@ MlasPool(
     MLAS_THREADPOOL* ThreadPool
     );
 
+void
+MLASCALL
+MlasMaximumPool(
+    const uint8_t* const* Input,
+    uint8_t* Output,
+    size_t Channels,
+    size_t OutputCount,
+    size_t KernelSize
+    );
+
 //
 // Miscellaneous compute routines.
 //

--- a/onnxruntime/core/mlas/lib/pooling.cpp
+++ b/onnxruntime/core/mlas/lib/pooling.cpp
@@ -1304,3 +1304,191 @@ Return Value:
     return;
 #endif
 }
+
+void
+MLASCALL
+MlasMaximumPool(
+    const uint8_t* const* Input,
+    uint8_t* Output,
+    size_t Channels,
+    size_t OutputCount,
+    size_t KernelSize
+    )
+/*++
+
+Routine Description:
+
+    This routine implements the maximum pooling operation.
+
+    The input is supplied as an indirection buffer. Every pointer in the
+    indirection buffer points at a Channels length vector (either from the
+    input tensor or a vector of padding values). These are grouped in batches
+    of length KernelSize that are processed by the kernel to produce a single
+    output of length Channels. These batches are then repeated OutputCount
+    times.
+
+Arguments:
+
+    Input - Supplies an indirection buffer to the elements of the input tensor.
+
+    Output - Supplies the output tensor in channels last format.
+
+    Channels - Supplies the number of channels.
+
+    OutputCount - Supplies the number of channel sized output elements to
+        produce.
+
+    KernelSize - Supplies the total number of channel sized kernel elements to
+        consume.
+
+Return Value:
+
+    None.
+
+--*/
+{
+    while (OutputCount > 0) {
+
+        size_t ChannelOffset = 0;
+        size_t c = Channels;
+
+#if defined(MLAS_SSE2_INTRINSICS)
+
+        while (c >= 32) {
+
+            __m128i MaximumVector0 = _mm_setzero_si128();
+            __m128i MaximumVector1 = _mm_setzero_si128();
+
+            for (size_t k = 0; k < KernelSize; k++) {
+
+                __m128i InputVector0 = _mm_loadu_si128((const __m128i*)&Input[k][ChannelOffset]);
+                __m128i InputVector1 = _mm_loadu_si128((const __m128i*)&Input[k][ChannelOffset + 16]);
+
+                MaximumVector0 = _mm_max_epu8(MaximumVector0, InputVector0);
+                MaximumVector1 = _mm_max_epu8(MaximumVector1, InputVector1);
+            }
+
+            _mm_storeu_si128((__m128i*)&Output[0], MaximumVector0);
+            _mm_storeu_si128((__m128i*)&Output[16], MaximumVector1);
+            Output += 32;
+
+            ChannelOffset += 32;
+            c -= 32;
+        }
+
+        while (c >= 16) {
+
+            __m128i MaximumVector0 = _mm_setzero_si128();
+
+            for (size_t k = 0; k < KernelSize; k++) {
+
+                __m128i InputVector0 = _mm_loadu_si128((const __m128i*)&Input[k][ChannelOffset]);
+
+                MaximumVector0 = _mm_max_epu8(MaximumVector0, InputVector0);
+            }
+
+            _mm_storeu_si128((__m128i*)&Output[0], MaximumVector0);
+            Output += 16;
+
+            ChannelOffset += 16;
+            c -= 16;
+        }
+
+        if (c >= 8) {
+
+            __m128i MaximumVector0 = _mm_setzero_si128();
+
+            for (size_t k = 0; k < KernelSize; k++) {
+
+                __m128i InputVector0 = _mm_loadl_epi64((const __m128i*)&Input[k][ChannelOffset]);
+
+                MaximumVector0 = _mm_max_epu8(MaximumVector0, InputVector0);
+            }
+
+            _mm_storel_epi64((__m128i*)&Output[0], MaximumVector0);
+            Output += 8;
+
+            ChannelOffset += 8;
+            c -= 8;
+        }
+
+#elif defined(MLAS_NEON_INTRINSICS)
+
+        while (c >= 32) {
+
+            uint8x16_t MaximumVector0 = vdupq_n_u8(0);
+            uint8x16_t MaximumVector1 = vdupq_n_u8(0);
+
+            for (size_t k = 0; k < KernelSize; k++) {
+
+                uint8x16_t InputVector0 = vld1q_u8(&Input[k][ChannelOffset]);
+                uint8x16_t InputVector1 = vld1q_u8(&Input[k][ChannelOffset + 16]);
+
+                MaximumVector0 = vmaxq_u8(MaximumVector0, InputVector0);
+                MaximumVector1 = vmaxq_u8(MaximumVector1, InputVector1);
+            }
+
+            vst1q_u8(&Output[0], MaximumVector0);
+            vst1q_u8(&Output[16], MaximumVector1);
+            Output += 32;
+
+            ChannelOffset += 32;
+            c -= 32;
+        }
+
+        while (c >= 16) {
+
+            uint8x16_t MaximumVector0 = vdupq_n_u8(0);
+
+            for (size_t k = 0; k < KernelSize; k++) {
+
+                uint8x16_t InputVector0 = vld1q_u8(&Input[k][ChannelOffset]);
+
+                MaximumVector0 = vmaxq_u8(MaximumVector0, InputVector0);
+            }
+
+            vst1q_u8(&Output[0], MaximumVector0);
+            Output += 16;
+
+            ChannelOffset += 16;
+            c -= 16;
+        }
+
+        if (c >= 8) {
+
+            uint8x8_t MaximumVector0 = vdup_n_u8(0);
+
+            for (size_t k = 0; k < KernelSize; k++) {
+
+                uint8x8_t InputVector0 = vld1_u8(&Input[k][ChannelOffset]);
+
+                MaximumVector0 = vmax_u8(MaximumVector0, InputVector0);
+            }
+
+            vst1_u8(&Output[0], MaximumVector0);
+            Output += 8;
+
+            ChannelOffset += 8;
+            c -= 8;
+        }
+
+#endif
+
+        while (c > 0) {
+
+            int32_t MaximumValue = 0;
+
+            for (size_t k = 0; k < KernelSize; k++) {
+                MaximumValue = std::max(MaximumValue, int32_t(Input[k][ChannelOffset]));
+            }
+
+            *Output++ = uint8_t(MaximumValue);
+
+            ChannelOffset += 1;
+            c -= 1;
+        }
+
+        Input += KernelSize;
+        OutputCount -= 1;
+    }
+}

--- a/onnxruntime/core/mlas/lib/qdwconv.cpp
+++ b/onnxruntime/core/mlas/lib/qdwconv.cpp
@@ -202,10 +202,12 @@ Routine Description:
 
     This routine implements the depthwise convolution operation.
 
-    The input tensor is organized in channels last format (NHWC) after applying
-    the Im2col transform, so the length of each row of the input tensor is
-    Channels times KernelSize. The number of columns of the input tensor is
-    OutputCount.
+    The input is supplied as an indirection buffer. Every pointer in the
+    indirection buffer points at a Channels length vector (either from the
+    input tensor or a vector of padding values). These are grouped in batches
+    of length KernelSize that are processed by the kernel to produce a single
+    output of length Channels. These batches are then repeated OutputCount
+    times.
 
     The filter tensor is organized in HW1O format, so the length of each row of
     the filter tensor is Channels. The number of columns of the filter tensor
@@ -254,8 +256,7 @@ Return Value:
             Output,
             Channels,
             OutputCount,
-            KernelSize
-            );
+            KernelSize);
 
     } else {
 
@@ -271,7 +272,6 @@ Return Value:
             Output,
             Channels,
             OutputCount,
-            KernelSize
-            );
+            KernelSize);
     }
 }

--- a/onnxruntime/core/providers/cpu/nn/pool_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/pool_attributes.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cmath>
 #include "core/common/common.h"
 #include "core/framework/op_node_proto_helper.h"
 #include "core/framework/tensor_shape.h"

--- a/onnxruntime/test/contrib_ops/nhwc_maxpool_op_test.cc
+++ b/onnxruntime/test/contrib_ops/nhwc_maxpool_op_test.cc
@@ -79,8 +79,6 @@ class NhwcMaxPoolOpTester {
 
     const int64_t input_image_size = std::accumulate(
         input_shape, input_shape + kernel_rank, 1LL, std::multiplies<int64_t>());
-    const int64_t kernel_size = std::accumulate(
-        kernel_shape_.data(), kernel_shape_.data() + kernel_rank, 1LL, std::multiplies<int64_t>());
 
     const T* Xdata = X_data_.data();
     T* Ydata = Y_data.data();

--- a/onnxruntime/test/contrib_ops/nhwc_maxpool_op_test.cc
+++ b/onnxruntime/test/contrib_ops/nhwc_maxpool_op_test.cc
@@ -1,0 +1,211 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <algorithm>
+#include "core/util/math.h"
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+#include <random>
+
+namespace onnxruntime {
+namespace test {
+
+template <typename T>
+class NhwcMaxPoolOpTester {
+ private:
+  std::default_random_engine generator_{1234};
+  std::vector<T> X_data_;
+  std::vector<int64_t> X_shape_;
+  std::vector<int64_t> kernel_shape_;
+  std::vector<int64_t> pads_;
+  std::vector<int64_t> strides_;
+  std::vector<int64_t> dilations_;
+
+  static size_t ShapeSize(const std::vector<int64_t>& shape) {
+    return static_cast<size_t>(std::accumulate(shape.cbegin(), shape.cend(), 1LL, std::multiplies<int64_t>()));
+  }
+
+  static bool NextPosition(int64_t N, const int64_t* shape, int64_t* dims) {
+    // Loop over spatial axes in reverse order to choose an index, like counting.
+    bool incremented = false;
+    for (int64_t d_i = N - 1; d_i >= 0; --d_i) {
+      int64_t d_max = shape[d_i];
+      ORT_ENFORCE(dims[d_i] < d_max);
+      if (dims[d_i] == d_max - 1) {
+        dims[d_i] = 0;
+      } else {  // dims[d_i] < d_max - 1
+        ++dims[d_i];
+        incremented = true;
+        break;
+      }
+    }
+    return incremented;
+  }
+
+  void ComputeExpectedOutput(std::vector<T>& Y_data, std::vector<int64_t>& Y_shape) {
+    ORT_ENFORCE(X_shape_.size() >= 2 && X_shape_.size() == kernel_shape_.size() + 2);
+
+    const size_t kernel_rank = kernel_shape_.size();
+
+    const int64_t batch_count = X_shape_[0];
+    const int64_t channels = X_shape_[X_shape_.size() - 1];
+
+    std::vector<int64_t> pads(pads_);
+    if (pads.empty()) {
+      pads.resize(kernel_rank * 2, 0);
+    }
+    std::vector<int64_t> dilations(dilations_);
+    if (dilations.empty()) {
+      dilations.resize(kernel_rank, 1);
+    }
+    std::vector<int64_t> strides(strides_);
+    if (strides.empty()) {
+      strides.resize(kernel_rank, 1);
+    }
+
+    const int64_t* input_shape = X_shape_.data() + 1;
+
+    // Compute the expected shape of the output.
+    Y_shape.reserve(kernel_rank + 2);
+    Y_shape.push_back(batch_count);
+    for (size_t n = 0; n < kernel_rank; n++) {
+      Y_shape.push_back(((input_shape[n] + pads[n] + pads[kernel_rank + n]) -
+                         (dilations[n] * (kernel_shape_[n] - 1) + 1)) / strides[n] + 1);
+    }
+    Y_shape.push_back(channels);
+    Y_data.resize(ShapeSize(Y_shape));
+
+    const int64_t* output_shape = Y_shape.data() + 1;
+
+    const int64_t input_image_size = std::accumulate(
+        input_shape, input_shape + kernel_rank, 1LL, std::multiplies<int64_t>());
+    const int64_t kernel_size = std::accumulate(
+        kernel_shape_.data(), kernel_shape_.data() + kernel_rank, 1LL, std::multiplies<int64_t>());
+
+    const T* Xdata = X_data_.data();
+    T* Ydata = Y_data.data();
+
+    for (int64_t batch = 0; batch < batch_count; batch++) {
+      std::vector<int64_t> d_output(kernel_rank, 0);
+      std::vector<int64_t> d_kernel(kernel_rank, 0);
+      do {
+        std::fill_n(Ydata, channels, static_cast<T>(0));
+        do {
+          int64_t input_offset = 0;
+          bool is_padding = false;
+          for (size_t axis = 0; axis < kernel_rank; ++axis) {
+            int64_t input_dim = d_kernel[axis] * dilations[axis] + d_output[axis] * strides[axis] - pads[axis];
+            is_padding |= !math::is_a_ge_zero_and_a_lt_b(input_dim, input_shape[axis]);
+            input_offset *= input_shape[axis];
+            input_offset += input_dim;
+          }
+          if (!is_padding) {
+            const T* data_ptr = Xdata + input_offset * channels;
+            for (int64_t c = 0; c < channels; c++) {
+              Ydata[c] = std::max(Ydata[c], data_ptr[c]);
+            }
+          }
+        } while (NextPosition(kernel_rank, kernel_shape_.data(), d_kernel.data()));
+        Ydata += channels;
+      } while (NextPosition(kernel_rank, output_shape, d_output.data()));
+      Xdata += channels * input_image_size;
+    }
+  }
+
+ public:
+  void GenerateRandomInput(const std::vector<int64_t>& shape) {
+    std::uniform_int_distribution<int32_t> distribution(0, 255);
+    size_t shape_size = ShapeSize(shape);
+    X_data_.resize(shape_size);
+    for (size_t n = 0; n < shape_size; n++) {
+      X_data_[n] = static_cast<T>(distribution(generator_));
+    }
+    X_shape_ = shape;
+  }
+
+  void SetKernelShape(const std::vector<int64_t>& kernel_shape) {
+    kernel_shape_ = kernel_shape;
+  }
+
+  void SetPads(const std::vector<int64_t>& pads) {
+    pads_ = pads;
+  }
+
+  void SetStrides(const std::vector<int64_t>& strides) {
+    strides_ = strides;
+  }
+
+  void SetDilations(const std::vector<int64_t>& dilations) {
+    dilations_ = dilations;
+  }
+
+  void Run() {
+    std::vector<T> Y_data;
+    std::vector<int64_t> Y_shape;
+    ComputeExpectedOutput(Y_data, Y_shape);
+
+    OpTester test("NhwcMaxPool", 1, onnxruntime::kMSDomain);
+    test.AddInput<T>("x", X_shape_, X_data_);
+    test.AddOutput<T>("y", Y_shape, Y_data);
+    test.AddAttribute("kernel_shape", kernel_shape_);
+    if (!pads_.empty()) {
+      test.AddAttribute("pads", pads_);
+    }
+    if (!strides_.empty()) {
+      test.AddAttribute("strides", strides_);
+    }
+    if (!dilations_.empty()) {
+      test.AddAttribute("dilations", dilations_);
+    }
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "");
+  }
+};
+
+TEST(NhwcMaxPoolContribOpTest, MaxPool1D) {
+  for (int64_t channels = 1; channels < 64; channels++) {
+    NhwcMaxPoolOpTester<uint8_t> test;
+    test.GenerateRandomInput({1, 23, channels});
+    test.SetKernelShape({5});
+    test.SetPads({2, 2});
+    test.Run();
+  }
+}
+
+TEST(NhwcMaxPoolContribOpTest, MaxPool2D) {
+  for (int64_t channels = 1; channels < 64; channels++) {
+    NhwcMaxPoolOpTester<uint8_t> test;
+    test.GenerateRandomInput({1, 15, 19, channels});
+    test.SetKernelShape({3, 5});
+    test.SetPads({1, 1, 1, 1});
+    test.Run();
+  }
+}
+
+TEST(NhwcMaxPoolContribOpTest, MaxPool3D) {
+  for (int64_t channels = 1; channels < 64; channels++) {
+    NhwcMaxPoolOpTester<uint8_t> test;
+    test.GenerateRandomInput({1, 9, 13, 15, channels});
+    test.SetKernelShape({2, 4, 6});
+    test.SetPads({0, 0, 0, 1, 1, 1});
+    test.Run();
+  }
+}
+
+TEST(NhwcMaxPoolContribOpTest, MaxPoolStrides) {
+  NhwcMaxPoolOpTester<uint8_t> test;
+  test.GenerateRandomInput({4, 23, 19, 32});
+  test.SetKernelShape({3, 3});
+  test.SetStrides({2, 2});
+  test.Run();
+}
+
+TEST(NhwcMaxPoolContribOpTest, MaxPoolDilations) {
+  NhwcMaxPoolOpTester<uint8_t> test;
+  test.GenerateRandomInput({4, 23, 19, 32});
+  test.SetKernelShape({3, 3});
+  test.SetDilations({2, 2});
+  test.Run();
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/nhwc_maxpool_op_test.cc
+++ b/onnxruntime/test/contrib_ops/nhwc_maxpool_op_test.cc
@@ -111,6 +111,9 @@ class NhwcMaxPoolOpTester {
   }
 
  public:
+  NhwcMaxPoolOpTester() {
+  }
+
   void GenerateRandomInput(const std::vector<int64_t>& shape) {
     std::uniform_int_distribution<int32_t> distribution(0, 255);
     size_t shape_size = ShapeSize(shape);

--- a/onnxruntime/test/providers/cpu/nn/qlinearconv_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/qlinearconv_op_test.cc
@@ -5,7 +5,6 @@
 #include "core/util/math.h"
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
-#include "core/mlas/inc/mlas.h"
 #include <random>
 
 namespace onnxruntime {
@@ -387,9 +386,7 @@ class QLinearConvOpTester {
     Y_shape.push_back(output_channels);
     for (size_t n = 0; n < kernel_rank; n++) {
       Y_shape.push_back(((input_shape[n] + pads[n] + pads[kernel_rank + n]) -
-                         (dilations[n] * (kernel_shape[n] - 1) + 1)) /
-                            strides[n] +
-                        1);
+                         (dilations[n] * (kernel_shape[n] - 1) + 1)) / strides[n] + 1);
     }
     const int64_t* output_shape = Y_shape.data() + 2;
     Y_data.resize(ShapeSize(Y_shape));


### PR DESCRIPTION
**Description**: Add support to transform graphs containing uint8 MaxPool to a custom operator that supports NHWC format that can be more easily vectorized.

**Motivation and Context**
Add support to:
1. Extend the NCHW->NHWC graph transformer to recognized MaxPool(uint8) and replace this with com.ms.NhwcMaxPool(uint8).
2. Implement the com.ms.NhwcMaxPool operator.
3. Implement a MLAS routine to do a vectorized MaxPool using an indirection buffer.

Although the current implementation of NhwcMaxPool is single threaded, this easily beats the old code path of transposing back to NCHW, running a scalar MaxPool, then typically transposing back to NHWC for additional convolutions.
