### PR TITLE
Update ORT model conversion script to support custom ops

### DIFF
--- a/docs/ONNX_Runtime_for_Mobile_Platforms.md
+++ b/docs/ONNX_Runtime_for_Mobile_Platforms.md
@@ -159,7 +159,6 @@ A minimal build has the following limitations currently:
     - Execution providers that statically register kernels and will be used at runtime MUST be enabled when creating the ORT format model
     - Execution providers that compile nodes are optionally supported, and nodes they create will be correctly partitioned at runtime
       - currently this is limited to the NNAPI Execution Provider
-  - No support for custom operators
 
 We do not currently offer backwards compatibility guarantees for ORT format models, as we will be expanding the capabilities in the short term and may need to update the internal format in an incompatible manner to accommodate these changes. You may need to regenerate the ORT format models to use with a future version of ONNX Runtime. Once the feature set stabilizes we will provide backwards compatibility guarantees.
 

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -223,7 +223,7 @@ using namespace onnxruntime::logging;
 
 static Env& platform_env = Env::Default();
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
 // Custom op section starts
 
 CustomOpLibrary::CustomOpLibrary(const char* library_path, OrtSessionOptions& ort_so) {
@@ -271,7 +271,7 @@ void CustomOpLibrary::UnloadLibrary() {
 }
 
 // Custom op section ends
-#endif  // !defined(ORT_MINIMAL_BUILD)
+#endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
 
 template <typename T>
 static void AddNonTensor(const OrtValue& val, std::vector<py::object>& pyobjs,
@@ -662,7 +662,7 @@ static void GenerateProviderOptionsMap(const std::vector<std::string>& providers
   }
 }
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
 static void RegisterCustomOpDomainsAndLibraries(PyInferenceSession* sess, const PySessionOptions& so) {
   if (!so.custom_op_domains_.empty()) {
     // Register all custom op domains that will be needed for the session
@@ -847,7 +847,7 @@ void addGlobalMethods(py::module& m, Environment& env) {
 #endif
 #ifdef USE_TENSORRT
             onnxruntime::CreateExecutionProviderFactory_Tensorrt(
-              [&]() {
+                [&]() {
                   TensorrtExecutionProviderInfo info{};
                   return info;
                 }()),
@@ -1544,7 +1544,7 @@ Applies to session load, initialization, etc. Default is 0.)pbdoc")
           "register_custom_ops_library",
           [](PySessionOptions* options, const char* library_path)
               -> void {
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
             // We need to pass in an `OrtSessionOptions` instance because the exported method in the shared library expects that
             // Once we have access to the `OrtCustomOpDomains` within the passed in `OrtSessionOptions` instance, we place it
             // into the container we are maintaining for that very purpose and the `ortSessionoptions` instance can go out of scope.
@@ -1686,7 +1686,7 @@ including arg name, arg type (contains both type and shape).)pbdoc")
 #endif
         } else {
           sess = onnxruntime::make_unique<PyInferenceSession>(env, so);
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
           RegisterCustomOpDomainsAndLibraries(sess.get(), so);
 #endif
 

--- a/onnxruntime/python/onnxruntime_pybind_state_common.h
+++ b/onnxruntime/python/onnxruntime_pybind_state_common.h
@@ -11,7 +11,7 @@
 namespace onnxruntime {
 namespace python {
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
 struct CustomOpLibrary {
   CustomOpLibrary(const char* library_path, OrtSessionOptions& ort_so);
 
@@ -29,7 +29,7 @@ struct CustomOpLibrary {
 
 // Thin wrapper over internal C++ SessionOptions to accommodate custom op library management for the Python user
 struct PySessionOptions : public SessionOptions {
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
   // `PySessionOptions` has a vector of shared_ptrs to CustomOpLibrary, because so that it can be re-used for all
   // `PyInferenceSession`s using the same `PySessionOptions` and that each `PyInferenceSession` need not construct
   // duplicate CustomOpLibrary instances.
@@ -58,7 +58,9 @@ struct PyInferenceSession {
       sess_ = onnxruntime::make_unique<InferenceSession>(so, env, buffer);
     }
   }
+#endif
 
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
   void AddCustomOpLibraries(const std::vector<std::shared_ptr<CustomOpLibrary>>& custom_op_libraries) {
     if (!custom_op_libraries.empty()) {
       custom_op_libraries_.reserve(custom_op_libraries.size());
@@ -79,7 +81,7 @@ struct PyInferenceSession {
   }
 
  private:
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
   // Hold CustomOpLibrary resources so as to tie it to the life cycle of the InferenceSession needing it.
   // NOTE: Define this above `sess_` so that this is destructed AFTER the InferenceSession instance -
   // this is so that the custom ops held by the InferenceSession gets destroyed prior to the library getting unloaded

--- a/tools/ci_build/github/linux/ort_minimal/build_full_ort_and_create_ort_files.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_full_ort_and_create_ort_files.sh
@@ -44,5 +44,13 @@ python3 /onnxruntime_src/tools/python/create_reduced_build_config.py --format OR
     /onnxruntime_src/onnxruntime/test/testdata \
     /home/onnxruntimedev/.test_data/required_ops_and_types.ort_models.config
 
+# Test that we can convert an ONNX model with custom ops to ORT format
+mkdir /home/onnxruntimedev/.test_data/custom_ops_model
+cp /onnxruntime_src/onnxruntime/test/testdata/custom_op_library/*.onnx /home/onnxruntimedev/.test_data/custom_ops_model/
+python3 /onnxruntime_src/tools/python/convert_onnx_models_to_ort.py \
+    --custom_op_library /build/Debug/libcustom_op_library.so \
+    /home/onnxruntimedev/.test_data/custom_ops_model
+rm -rf /home/onnxruntimedev/.test_data/custom_ops_model
+
 # Clear the build
 rm -rf /build/Debug

--- a/tools/python/convert_onnx_models_to_ort.py
+++ b/tools/python/convert_onnx_models_to_ort.py
@@ -11,7 +11,7 @@ import re
 import onnxruntime as ort
 
 
-def _create_config_file_from_ort_models(model_path, enable_type_reduction: bool):
+def _create_config_file_from_ort_models(model_path: pathlib.Path, enable_type_reduction: bool):
     filename = 'required_operators_and_types.config' if enable_type_reduction else 'required_operators.config'
     config_file_path = model_path.joinpath(filename)
 
@@ -48,12 +48,12 @@ def _convert(model_path: pathlib.Path, optimization_level: ort.GraphOptimization
     for model in models:
         # ignore any files with an extension of .optimized.onnx which are presumably from previous executions
         # of this script
-        if re.match(r'.*\.optimized\.onnx', model, flags=re.IGNORECASE):
+        if re.match(r'.*\.optimized\.onnx$', model, flags=re.IGNORECASE):
             print('Ignoring ' + model)
             continue
 
         # create .ort file in same dir as original onnx model
-        ort_target_path = re.sub('.onnx$', '.ort', model)
+        ort_target_path = re.sub(r'\.onnx$', '.ort', model)
 
         if create_optimized_onnx_model:
             # Create an ONNX file with the same optimizations that will be used for the ORT format file.

--- a/tools/python/convert_onnx_models_to_ort.py
+++ b/tools/python/convert_onnx_models_to_ort.py
@@ -7,7 +7,6 @@ import glob
 import os
 import pathlib
 import re
-import tempfile
 
 import onnxruntime as ort
 

--- a/tools/python/convert_onnx_models_to_ort.py
+++ b/tools/python/convert_onnx_models_to_ort.py
@@ -5,79 +5,77 @@
 import argparse
 import glob
 import os
+import pathlib
 import re
 import tempfile
 
 import onnxruntime as ort
 
 
-def _create_config_file_from_ort_models(optimized_model_path, enable_type_reduction: bool):
-    config_file_path = os.path.join(optimized_model_path, 'required_operators.config')
+def _create_config_file_from_ort_models(model_path, enable_type_reduction: bool):
+    if model_path.is_file():
+        model_path = model_path.parent
+
+    filename = 'required_operators_and_types.config' if enable_type_reduction else 'required_operators.config'
+    config_file_path = os.path.join(model_path, filename)
     print("Creating configuration file for operators required by ORT format models in {}.".format(config_file_path))
+
     from util.ort_format_model import create_config_from_models
+    create_config_from_models(model_path, config_file_path, enable_type_reduction)
 
-    create_config_from_models(optimized_model_path, config_file_path, enable_type_reduction)
+
+def _create_session_options(optimization_level: ort.GraphOptimizationLevel,
+                            output_model_path: pathlib.Path,
+                            custom_op_library: pathlib.Path):
+    so = ort.SessionOptions()
+    so.optimized_model_filepath = str(output_model_path)
+    so.graph_optimization_level = optimization_level
+
+    if custom_op_library:
+        so.register_custom_ops_library(str(custom_op_library))
+
+    return so
 
 
-def _convert(model_path: str, optimization_level: ort.GraphOptimizationLevel, use_nnapi: bool):
-    models = glob.glob(os.path.join(model_path, '**', '*.onnx'), recursive=True)
+def _convert(model_path: pathlib.Path, optimization_level: ort.GraphOptimizationLevel, use_nnapi: bool,
+             custom_op_library: pathlib.Path, create_optimized_onnx_model: bool):
+    if model_path.is_file():
+        models = [str(model_path)]
+    else:
+        models = glob.glob(os.path.join(model_path, '**', '*.onnx'), recursive=True)
 
     if len(models) == 0:
         raise ValueError("No .onnx files were found in " + model_path)
 
-    # create temp directory to create optimized onnx format models in. currently we need this to create the
-    # config file with required operators. long term we could potentially do this from the ORT format model,
-    # however that requires a lot of infrastructure to be able to parse the flatbuffers schema for those files
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        for model in models:
-            model_filename = os.path.basename(model)
-            # create .optimized.onnx file in temp dir
-            onnx_target_path = os.path.join(tmpdirname, re.sub('.onnx$', '.optimized.onnx', model_filename))
-            # create .ort file in same dir as original onnx model
-            ort_target_path = re.sub('.onnx$', '.ort', model)
+    providers = ['CPUExecutionProvider']
+    if use_nnapi:
+        # providers are priority based, so register NNAPI first
+        providers.insert(0, 'NnapiExecutionProvider')
 
-            so = ort.SessionOptions()
-            so.optimized_model_filepath = onnx_target_path
-            so.graph_optimization_level = optimization_level
+    for model in models:
+        # create .ort file in same dir as original onnx model
+        ort_target_path = re.sub('.onnx$', '.ort', model)
 
-            print("Optimizing ONNX model {}".format(model))
-            # creating the session will result in the optimized model being saved. we use just the CPU EP for this step
-            providers = ['CPUExecutionProvider']
+        if create_optimized_onnx_model:
+            # Create an ONNX file with the same optimizations that will be used for the ORT format file.
+            # This allows the ONNX equivalent of the ORT format model to be easily viewed in Netron.
+            optimized_target_path = re.sub('.onnx$', '.optimized.onnx', model)
+            so = _create_session_options(optimization_level, optimized_target_path, custom_op_library)
+
+            print("Saving optimized ONNX model {}".format(model))
             _ = ort.InferenceSession(model, sess_options=so, providers=providers)
 
-            # special case if we're enabling a compiling EP like NNAPI. we don't currently have a way to read the
-            # required ops from an ORT format model, so we need an ONNX model that is only optimized to 'basic' level
-            # to ensure all the nodes that NNAPI may take still exist. we can merge the required operators from that
-            # with the required operators from an ONNX model optimized to a higher level (if the user requested that).
-            # we must use this model with creating the ORT format model to maximize the nodes that NNAPI can potentially
-            # take, so replace onnx_target_path with the new path.
-            if use_nnapi and \
-                (optimization_level == ort.GraphOptimizationLevel.ORT_ENABLE_EXTENDED or
-                 optimization_level == ort.GraphOptimizationLevel.ORT_ENABLE_ALL):
-                onnx_target_path = os.path.join(tmpdirname, re.sub('.onnx$', '.optimized.basic.onnx', model_filename))
-                so.optimized_model_filepath = onnx_target_path
-                so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_BASIC
-                _ = ort.InferenceSession(model, sess_options=so, providers=providers)
+        # Load ONNX model, optimize, and save to ORT format
+        so = _create_session_options(optimization_level, ort_target_path, custom_op_library)
+        so.add_session_config_entry('session.save_model_format', 'ORT')
 
-            # Second, convert optimized ONNX model to ORT format
-            # we enable the compiling EPs when we generate the ORT format model so that we preserve the nodes it may
-            # take, but allow optimization on any others
-            if use_nnapi:
-                # providers are priority based, so register NNAPI first
-                providers.insert(0, 'NnapiExecutionProvider')
+        print("Converting optimized ONNX model to ORT format model {}".format(ort_target_path))
+        _ = ort.InferenceSession(model, sess_options=so, providers=providers)
 
-            so.optimized_model_filepath = ort_target_path
-            # Use original optimization level so that if NNAPI is enabled we optimize nodes it is not taking
-            so.graph_optimization_level = optimization_level
-            so.add_session_config_entry('session.save_model_format', 'ORT')
-
-            print("Converting optimized ONNX model to ORT format model {}".format(ort_target_path))
-            _ = ort.InferenceSession(onnx_target_path, sess_options=so, providers=providers)
-
-            # orig_size = os.path.getsize(onnx_target_path)
-            # new_size = os.path.getsize(ort_target_path)
-            # print("Serialized {} to {}. Sizes: orig={} new={} diff={} new:old={:.4f}:1.0".format(
-            #     onnx_target_path, ort_target_path, orig_size, new_size, new_size - orig_size, new_size / orig_size))
+        # orig_size = os.path.getsize(onnx_target_path)
+        # new_size = os.path.getsize(ort_target_path)
+        # print("Serialized {} to {}. Sizes: orig={} new={} diff={} new:old={:.4f}:1.0".format(
+        #     onnx_target_path, ort_target_path, orig_size, new_size, new_size - orig_size, new_size / orig_size))
 
 
 def _get_optimization_level(level):
@@ -128,17 +126,33 @@ def parse_args():
                         help='Add operator specific type information to the configuration file to potentially reduce '
                              'the types supported by individual operator implementations.')
 
-    parser.add_argument('model_path', help='Provide path to directory containing ONNX model/s to convert. '
-                                           'Files with .onnx extension will be processed.')
+    parser.add_argument('--custom_op_library', type=pathlib.Path, default=None,
+                        help='Provide path to shared library containing custom operator kernels to register.')
+
+    parser.add_argument('--save_optimized_onnx_model', action='store_true',
+                        help='Save the optimized version of each ONNX model. '
+                             'This will have the same optimizations applied as the ORT format model.')
+
+    parser.add_argument('model_path', type=pathlib.Path,
+                        help='Provide path to ONNX model/s to convert. Can be a specific model or a directory. '
+                             'All files with a .onnx extension, including in subdirectories, will be processed '
+                             'if the path is a directory.')
 
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
+
+    model_path = args.model_path.resolve()
+    custom_op_library = args.custom_op_library.resolve() if args.custom_op_library else None
+
+    if custom_op_library and not custom_op_library.is_file():
+        raise FileNotFoundError("Unable to find custom operator library '{0}'".format(custom_op_library))
+
     optimization_level = _get_optimization_level(args.optimization_level)
-    _convert(args.model_path, optimization_level, args.use_nnapi)
-    _create_config_file_from_ort_models(args.model_path, args.enable_type_reduction)
+    _convert(model_path, optimization_level, args.use_nnapi, custom_op_library, args.save_optimized_onnx_model)
+    _create_config_file_from_ort_models(model_path, args.enable_type_reduction)
 
 
 if __name__ == '__main__':

--- a/tools/python/create_reduced_build_config.py
+++ b/tools/python/create_reduced_build_config.py
@@ -5,6 +5,7 @@
 import argparse
 import os
 import onnx
+import pathlib
 import sys
 
 
@@ -103,19 +104,29 @@ def main():
                            help='Enable tracking of the specific types that individual operators require. '
                                 'Operator implementations MAY support limiting the type support included in the build '
                                 'to these types. Only possible with ORT format models.')
-    argparser.add_argument('model_path_or_dir', type=str,
+    argparser.add_argument('model_path_or_dir', type=pathlib.Path,
                            help='Path to a single model, or a directory that will be recursively searched '
                                 'for models to process.')
 
-    argparser.add_argument('config_path', type=str, help='Path to write configuration file to.')
+    argparser.add_argument('config_path', nargs='?', type=pathlib.Path, default=None,
+                           help='Path to write configuration file to. Default is to write to required_operators.config '
+                                'or required_operators_and_types.config in the same directory as the models.')
 
     args = argparser.parse_args()
-    model_path_or_dir = os.path.abspath(args.model_path_or_dir)
-    config_path = os.path.abspath(args.config_path)
 
     if args.enable_type_reduction and args.format == 'ONNX':
         print('Type reduction requires model format to be ORT.', file=sys.stderr)
         sys.exit(-1)
+
+    model_path_or_dir = args.model_path_or_dir.resolve()
+    if args.config_path:
+        config_path = args.config_path.resolve()
+    else:
+        config_path = model_path_or_dir if model_path_or_dir.is_dir() else model_path_or_dir.parent
+
+    if config_path.is_dir():
+        filename = 'required_operators_and_types.config' if args.enable_type_reduction else 'required_operators.config'
+        config_path = config_path.joinpath(filename)
 
     if args.format == 'ONNX':
         create_config_from_onnx_models(model_path_or_dir, config_path)

--- a/tools/python/util/ort_format_model/utils.py
+++ b/tools/python/util/ort_format_model/utils.py
@@ -49,7 +49,7 @@ def create_config_from_models(model_path_or_dir: str, output_file: str = None, e
         if not filename:
             raise RuntimeError("Invalid output path for configuration: {}".format(output_file))
 
-        if not os.path.exists(directory):
+        if directory and not os.path.exists(directory):
             os.makedirs(directory)
     else:
         dir = model_path_or_dir


### PR DESCRIPTION
**Description**: 
Update ORT format model conversion script to support custom ops.
Simplify conversion now that we can process the ORT format file to determine the required ops.
Enable custom op registration via python in a minimal build with custom ops
Use pathlib in a few places when working with paths.

**Motivation and Context**
Better support for converting a model with custom ops.