### PR TITLE
Fix AMD CI pipeline by removing longformer_global_impl.cu from HIPify

### DIFF
--- a/tools/ci_build/amd_hipify.py
+++ b/tools/ci_build/amd_hipify.py
@@ -28,6 +28,8 @@ contrib_ops_excluded_files = [
                     'bert/longformer_attention.h',
                     'bert/longformer_attention_impl.cu',
                     'bert/longformer_attention_impl.h',
+                    'bert/longformer_global_impl.cu',
+                    'bert/longformer_global_impl.h',
                     'bert/skip_layer_norm.cc',
                     'bert/skip_layer_norm.h',
                     'bert/skip_layer_norm_impl.cu',


### PR DESCRIPTION
Fix AMD CI pipeline by removing longformer_global_impl.cu from HIPify.