### PR TITLE
[Node.js binding] update dependency 'marked' 1.* -> 2.0.0

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -41,7 +41,7 @@
         "node-pre-gyp-github": "^1.4.3",
         "onnx-proto": "^4.0.4",
         "tar-stream": "^2.2.0",
-        "typedoc": "^0.20.20",
+        "typedoc": "^0.20.25",
         "typescript": "^4.1.3"
       }
     },
@@ -3165,9 +3165,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
-      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.0.tgz",
+      "integrity": "sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==",
       "dev": true,
       "bin": {
         "marked": "bin/marked"
@@ -4509,49 +4509,13 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.2.7.tgz",
-      "integrity": "sha512-bwVc7cdtYYHEO9O+XJ8aNOskKRfaQd5Y4ovLRfbQkmiLSUaR+bdlssbZUUhbQ0JAFMYcTcJ5tjG5KtnufttDHQ==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.2.tgz",
+      "integrity": "sha512-BjUCxVbxMnvjs8jC4b+BQ808vwjJ9Q8NtLqPwXShZ307HdXiDFYP968ORSVfaTNNSWYDBYdMnVKJ0fYNsoZUBA==",
       "dev": true,
       "dependencies": {
         "onigasm": "^2.2.5",
-        "shiki-languages": "^0.2.7",
-        "shiki-themes": "^0.2.7",
         "vscode-textmate": "^5.2.0"
-      }
-    },
-    "node_modules/shiki-languages": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/shiki-languages/-/shiki-languages-0.2.7.tgz",
-      "integrity": "sha512-REmakh7pn2jCn9GDMRSK36oDgqhh+rSvJPo77sdWTOmk44C5b0XlYPwJZcFOMJWUZJE0c7FCbKclw4FLwUKLRw==",
-      "dev": true,
-      "dependencies": {
-        "vscode-textmate": "^5.2.0"
-      }
-    },
-    "node_modules/shiki-themes": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/shiki-themes/-/shiki-themes-0.2.7.tgz",
-      "integrity": "sha512-ZMmboDYw5+SEpugM8KGUq3tkZ0vXg+k60XX6NngDK7gc1Sv6YLUlanpvG3evm57uKJvfXsky/S5MzSOTtYKLjA==",
-      "dev": true,
-      "dependencies": {
-        "json5": "^2.1.0",
-        "vscode-textmate": "^5.2.0"
-      }
-    },
-    "node_modules/shiki-themes/node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/signal-exit": {
@@ -5052,9 +5016,9 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.20.20",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.20.tgz",
-      "integrity": "sha512-qXB40ttDGaqv6q6UIiAVqOpX/GlXoBur0lB4g9fePoYjfwa6OsPkoYufLtsjEaBB0EokShR2aIoI5GX4RB83cw==",
+      "version": "0.20.25",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.25.tgz",
+      "integrity": "sha512-ZQZnjJPrt0rjp216gp6FQC1QC4ojcoKikhfOJ/51CqaJunVDilRLlIO5tCGWj1tzlYYT9eOGhJv7MF3t7rxSmw==",
       "dev": true,
       "dependencies": {
         "colors": "^1.4.0",
@@ -5062,11 +5026,11 @@
         "handlebars": "^4.7.6",
         "lodash": "^4.17.20",
         "lunr": "^2.3.9",
-        "marked": "^1.2.8",
+        "marked": "^2.0.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.4",
-        "shiki": "^0.2.7",
+        "shiki": "^0.9.2",
         "typedoc-default-themes": "^0.12.7"
       },
       "bin": {
@@ -7952,9 +7916,9 @@
       "dev": true
     },
     "marked": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
-      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.0.tgz",
+      "integrity": "sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==",
       "dev": true
     },
     "memory-stream": {
@@ -9008,45 +8972,13 @@
       }
     },
     "shiki": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.2.7.tgz",
-      "integrity": "sha512-bwVc7cdtYYHEO9O+XJ8aNOskKRfaQd5Y4ovLRfbQkmiLSUaR+bdlssbZUUhbQ0JAFMYcTcJ5tjG5KtnufttDHQ==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.2.tgz",
+      "integrity": "sha512-BjUCxVbxMnvjs8jC4b+BQ808vwjJ9Q8NtLqPwXShZ307HdXiDFYP968ORSVfaTNNSWYDBYdMnVKJ0fYNsoZUBA==",
       "dev": true,
       "requires": {
         "onigasm": "^2.2.5",
-        "shiki-languages": "^0.2.7",
-        "shiki-themes": "^0.2.7",
         "vscode-textmate": "^5.2.0"
-      }
-    },
-    "shiki-languages": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/shiki-languages/-/shiki-languages-0.2.7.tgz",
-      "integrity": "sha512-REmakh7pn2jCn9GDMRSK36oDgqhh+rSvJPo77sdWTOmk44C5b0XlYPwJZcFOMJWUZJE0c7FCbKclw4FLwUKLRw==",
-      "dev": true,
-      "requires": {
-        "vscode-textmate": "^5.2.0"
-      }
-    },
-    "shiki-themes": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/shiki-themes/-/shiki-themes-0.2.7.tgz",
-      "integrity": "sha512-ZMmboDYw5+SEpugM8KGUq3tkZ0vXg+k60XX6NngDK7gc1Sv6YLUlanpvG3evm57uKJvfXsky/S5MzSOTtYKLjA==",
-      "dev": true,
-      "requires": {
-        "json5": "^2.1.0",
-        "vscode-textmate": "^5.2.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
       }
     },
     "signal-exit": {
@@ -9459,9 +9391,9 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.20.20",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.20.tgz",
-      "integrity": "sha512-qXB40ttDGaqv6q6UIiAVqOpX/GlXoBur0lB4g9fePoYjfwa6OsPkoYufLtsjEaBB0EokShR2aIoI5GX4RB83cw==",
+      "version": "0.20.25",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.25.tgz",
+      "integrity": "sha512-ZQZnjJPrt0rjp216gp6FQC1QC4ojcoKikhfOJ/51CqaJunVDilRLlIO5tCGWj1tzlYYT9eOGhJv7MF3t7rxSmw==",
       "dev": true,
       "requires": {
         "colors": "^1.4.0",
@@ -9469,11 +9401,11 @@
         "handlebars": "^4.7.6",
         "lodash": "^4.17.20",
         "lunr": "^2.3.9",
-        "marked": "^1.2.8",
+        "marked": "^2.0.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.4",
-        "shiki": "^0.2.7",
+        "shiki": "^0.9.2",
         "typedoc-default-themes": "^0.12.7"
       }
     },

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -63,7 +63,7 @@
     "node-pre-gyp-github": "^1.4.3",
     "onnx-proto": "^4.0.4",
     "tar-stream": "^2.2.0",
-    "typedoc": "^0.20.20",
+    "typedoc": "^0.20.25",
     "typescript": "^4.1.3"
   },
   "dependencies": {


### PR DESCRIPTION
**Description**: Update dev dependency `typedoc@0.20.25`

This change removes indirect dependency for `marked@1.*` (vulnerable version)