### PR TITLE
Update links to gh-pages for ORT minimal documents

### DIFF
--- a/docs/ONNX_Runtime_Mobile_NNAPI_perf_considerations.md
+++ b/docs/ONNX_Runtime_Mobile_NNAPI_perf_considerations.md
@@ -72,7 +72,7 @@ For our MNIST model that would mean that after the _basic_ optimizations are app
 
 To create an NNAPI-aware ORT format model please follow these steps.
 
-1. Create a 'full' build of ONNX Runtime with the NNAPI EP by [building ONNX Runtime from source](https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#start-baseline-cpu).
+1. Create a 'full' build of ONNX Runtime with the NNAPI EP by [building ONNX Runtime from source](https://www.onnxruntime.ai/docs/how-to/build.html#cpu).
 
     This build can be done on any platform, as the NNAPI EP can be used to create the ORT format model without the Android NNAPI library as there is no model execution in this process. When building add `--use_nnapi --build_shared_lib --build_wheel` to the build flags if any of those are missing.
 

--- a/docs/ONNX_Runtime_Mobile_NNAPI_perf_considerations.md
+++ b/docs/ONNX_Runtime_Mobile_NNAPI_perf_considerations.md
@@ -1,13 +1,13 @@
 # ONNX Runtime Mobile: Performance Considerations When Using NNAPI
 
-ONNX Runtime Mobile with the NNAPI Execution Provider (EP) can be used to execute ORT format models on Android platforms using NNAPI. This document explains the details of how different optimizations affect performance, and provides some suggestions for performance testing with ORT format models. 
+ONNX Runtime Mobile with the NNAPI Execution Provider (EP) can be used to execute ORT format models on Android platforms using NNAPI. This document explains the details of how different optimizations affect performance, and provides some suggestions for performance testing with ORT format models.
 
 Please review the introductory details for [using NNAPI with ONNX Runtime Mobile](ONNX_Runtime_for_Mobile_Platforms.md#Using-NNAPI-with-ONNX-Runtime-Mobile) first.
 
 
 ## 1. ONNX Model Optimization Example
 
-ONNX Runtime applies optimizations to the ONNX model to improve inferencing performance. These optimizations occur prior to exporting an ORT format model. See the [graph optimization](ONNX_Runtime_Graph_Optimizations.md) documentation for further details of the available optimizations.
+ONNX Runtime applies optimizations to the ONNX model to improve inferencing performance. These optimizations occur prior to exporting an ORT format model. See the [graph optimization](https://www.onnxruntime.ai/docs/resources/graph-optimizations.html) documentation for further details of the available optimizations.
 
 It is important to understand how the different optimization levels affect the nodes in the model, as this will determine how much of the model can be executed using NNAPI.
 
@@ -27,7 +27,7 @@ _Layout_ optimizations are hardware specific, and should not be used when creati
 
 Below is an example of the changes that occur in _basic_ and _extended_ optimizations when applied to the MNIST model with only the CPU EP enabled. The optimization level is specified when creating the ORT format model using `convert_onnx_models_to_ort.py`.
 
-  - At the _basic_ level we combine the Conv and Add nodes (the addition is done via the 'B' input to Conv), we combine the MatMul and Add into a single Gemm node (the addition is done via the 'C' input to Gemm), and constant fold to remove one of the Reshape nodes. 
+  - At the _basic_ level we combine the Conv and Add nodes (the addition is done via the 'B' input to Conv), we combine the MatMul and Add into a single Gemm node (the addition is done via the 'C' input to Gemm), and constant fold to remove one of the Reshape nodes.
     - `python <ORT repository root>/tools/python/convert_onnx_models_to_ort.py --optimization_level basic /dir_with_mnist_onnx_model`
   - At the _extended_ level we additionally fuse the Conv and Relu nodes using the internal ONNX Runtime FusedConv operator.
     - `python <ORT repository root>/tools/python/convert_onnx_models_to_ort.py --optimization_level extended /dir_with_mnist_onnx_model`
@@ -56,11 +56,11 @@ The best optimization settings will differ by model. Some models may perform bet
 
 It is suggested to run performance tests:
   - with NNAPI enabled and an ORT format model created with _basic_ level optimization
-  - with NNAPI disabled and an ORT format model created with _extended_ level optimization 
+  - with NNAPI disabled and an ORT format model created with _extended_ level optimization
 
 For most scenarios it is expected that one of these two approaches will yield the best performance.
 
-If using an ORT format model with _basic_ level optimizations and NNAPI yields equivalent or better performance, it _may_ be possible to further improve performance by creating an NNAPI-aware ORT format model. The difference with this model is that the _extended_ optimizations are applied to nodes that can not be executed using NNAPI. Whether any nodes fall into this category is model dependent. 
+If using an ORT format model with _basic_ level optimizations and NNAPI yields equivalent or better performance, it _may_ be possible to further improve performance by creating an NNAPI-aware ORT format model. The difference with this model is that the _extended_ optimizations are applied to nodes that can not be executed using NNAPI. Whether any nodes fall into this category is model dependent.
 
 ## 3. Creating an NNAPI-aware ORT format model
 
@@ -72,7 +72,7 @@ For our MNIST model that would mean that after the _basic_ optimizations are app
 
 To create an NNAPI-aware ORT format model please follow these steps.
 
-1. Create a 'full' build of ONNX Runtime with the NNAPI EP by [building ONNX Runtime from source](https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#start-baseline-cpu). 
+1. Create a 'full' build of ONNX Runtime with the NNAPI EP by [building ONNX Runtime from source](https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#start-baseline-cpu).
 
     This build can be done on any platform, as the NNAPI EP can be used to create the ORT format model without the Android NNAPI library as there is no model execution in this process. When building add `--use_nnapi --build_shared_lib --build_wheel` to the build flags if any of those are missing.
 
@@ -91,10 +91,10 @@ To create an NNAPI-aware ORT format model please follow these steps.
 
 2. Install the python wheel from the build output directory.
 
-    - Windows : This is located in `build/Windows/<config>/<config>/dist/<package name>.whl`. 
-    
+    - Windows : This is located in `build/Windows/<config>/<config>/dist/<package name>.whl`.
+
     - Linux : This is located in `build/Linux/<config>/dist/<package name>.whl`.
-    
+
         The package name will differ based on your platform, python version, and build parameters. `<config>` is the value from the `--config` parameter from the build command.
         ```
             pip install -U build\Windows\RelWithDebIfo\RelWithDebIfo\dist\onnxruntime_noopenmp-1.5.2-cp37-cp37m-win_amd64.whl

--- a/docs/ONNX_Runtime_for_Mobile_Platforms.md
+++ b/docs/ONNX_Runtime_for_Mobile_Platforms.md
@@ -11,7 +11,7 @@ The minimal build can be used with any ORT format model, provided that the kerne
 
 ## Steps to create model and minimal build
 
-You will need a script from the the ONNX Runtime repository, and to also perform a custom build, so you will need to clone the repository locally. See [here](https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#prerequisites) for initial steps.
+You will need a script from the the ONNX Runtime repository, and to also perform a custom build, so you will need to clone the repository locally. See [here](https://www.onnxruntime.ai/docs/how-to/build.html#prerequisites) for initial steps.
 
 The directory the ONNX Runtime repository was cloned into is referred to as `<ONNX Runtime repository root>` in this documentation.
 
@@ -40,7 +40,7 @@ Running `'python <ORT repository root>/tools/python/convert_onnx_models_to_ort.p
 
 You will need to build ONNX Runtime from source to reduce the included operator kernels and other aspects of the binary.
 
-See [here](https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#start-baseline-cpu) for the general ONNX Runtime build instructions.
+See [here](https://www.onnxruntime.ai/docs/how-to/build.html#cpu) for the general ONNX Runtime build instructions.
 
 
 #### Binary size reduction options:
@@ -137,7 +137,7 @@ To limit the optimization level when creating the ORT format models using `tools
 
 For NNAPI to be used on Android with ONNX Runtime Mobile, the NNAPI Execution Provider must be included in the minimal build.
 
-First, read the general instructions for [creating an Android build with NNAPI included](https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#Android-NNAPI-Execution-Provider). These provide details on setting up the components required to create an Android build of ONNX Runtime, such as the Android NDK.
+First, read the general instructions for [creating an Android build with NNAPI included](https://www.onnxruntime.ai/docs/how-to/build.html#android-nnapi-execution-provider). These provide details on setting up the components required to create an Android build of ONNX Runtime, such as the Android NDK.
 
 Once you have all the necessary components setup, follow the instructions to [create the minimal build](#2-Create-the-minimal-build), with the following changes:
   - Replace `--minimal_build` with `--minimal_build extended` to enable support for execution providers that dynamically create kernels at runtime, which is needed by the NNAPI Execution Provider.

--- a/docs/ONNX_Runtime_for_Mobile_Platforms.md
+++ b/docs/ONNX_Runtime_for_Mobile_Platforms.md
@@ -25,7 +25,7 @@ This will require the standard ONNX Runtime python package to be installed.
     - `pip install onnxruntime`
     - ensure that any existing ONNX Runtime python package was uninstalled first, or use `-U` with the above command to upgrade an existing package
   - Copy all the ONNX models you wish to convert and use with the minimal build into a directory
-  - Convert the ONNX models to ORT format 
+  - Convert the ONNX models to ORT format
     - `python <ONNX Runtime repository root>/tools/python/convert_onnx_models_to_ort.py <path to directory containing one or more .onnx models>`
       - For each ONNX model an ORT format model will be created with '.ort' as the file extension.
       - A `required_operators.config` configuration file will also be created.
@@ -38,7 +38,7 @@ Running `'python <ORT repository root>/tools/python/convert_onnx_models_to_ort.p
 
 ### 2. Create the minimal build
 
-You will need to build ONNX Runtime from source to reduce the included operator kernels and other aspects of the binary. 
+You will need to build ONNX Runtime from source to reduce the included operator kernels and other aspects of the binary.
 
 See [here](https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#start-baseline-cpu) for the general ONNX Runtime build instructions.
 
@@ -52,27 +52,27 @@ The follow options can be used to reduce the build size. Enable all options that
       - NOTE: This step will edit some of the ONNX Runtime source files to exclude unused kernels. If you wish to go back to creating a full build, or wish to change the operator kernels included, you should run `git reset --hard` or `git checkout HEAD -- ./onnxruntime/core/providers` to undo these changes.
 
   - Enable minimal build (`--minimal_build`)
-    - A minimal build will ONLY support loading and executing ORT format models. 
-    - RTTI is disabled by default in this build, unless the Python bindings (`--build_wheel`) are enabled. 
-    - If you wish to enable execution providers that compile kernels such as NNAPI specify `--minimal_build extended`. 
+    - A minimal build will ONLY support loading and executing ORT format models.
+    - RTTI is disabled by default in this build, unless the Python bindings (`--build_wheel`) are enabled.
+    - If you wish to enable execution providers that compile kernels such as NNAPI specify `--minimal_build extended`.
       - See [here](#Using-NNAPI-with-ONNX-Runtime-Mobile) for more information about using NNAPI with ONNX Runtime Mobile on Android platforms
 
   - Disable exceptions (`--disable_exceptions`)
     - Disables support for exceptions in the build.
-      - Any locations that would have thrown an exception will instead log the error message and call abort(). 
+      - Any locations that would have thrown an exception will instead log the error message and call abort().
       - Requires `--minimal_build`.
       - NOTE: This is not a valid option if you need the Python bindings (`--build_wheel`) as the Python Wheel requires exceptions to be enabled.
-    - Exceptions are only used in ONNX Runtime for exceptional things. If you have validated the input to be used, and validated that the model can be loaded, it is unlikely that ORT would throw an exception unless there's a system level issue (e.g. out of memory). 
+    - Exceptions are only used in ONNX Runtime for exceptional things. If you have validated the input to be used, and validated that the model can be loaded, it is unlikely that ORT would throw an exception unless there's a system level issue (e.g. out of memory).
 
   - ML op support (`--disable_ml_ops`)
-    - Whilst the operator kernel reduction script will disable all unused ML operator kernels, additional savings can be achieved by removing support for ML specific types. If you know that your model has no ML ops, or no ML ops that use the Map type, this flag can be provided. 
+    - Whilst the operator kernel reduction script will disable all unused ML operator kernels, additional savings can be achieved by removing support for ML specific types. If you know that your model has no ML ops, or no ML ops that use the Map type, this flag can be provided.
     - See the specs for the [ONNX ML Operators](https://github.com/onnx/onnx/blob/master/docs/Operators-ml.md) if unsure.
 
   - Use shared libc++ on Android (`--android_cpp_shared`)
     - Building using the shared libc++ library instead of the default static libc++ library will result in a smaller libonnxruntime.so library.
     - See [Android NDK documentation](https://developer.android.com/ndk/guides/cpp-support) for more information.
 
-#### Build Configuration 
+#### Build Configuration
 
 The `MinSizeRel` configuration will produce the smallest binary size.
 The `Release` configuration could also be used if you wish to prioritize performance over binary size.
@@ -89,7 +89,7 @@ The `Release` configuration could also be used if you wish to prioritize perform
 
 ##### Building ONNX Runtime Python Wheel as part of Minimal build
 
-Remove `--disable_exceptions` (Python requires exceptions to be enabled) and add `--build_wheel` to build a Python Wheel with the ONNX Runtime bindings. 
+Remove `--disable_exceptions` (Python requires exceptions to be enabled) and add `--build_wheel` to build a Python Wheel with the ONNX Runtime bindings.
 A .whl file will be produced in the build output directory under the `<config>/dist` folder.
 
   - The Python Wheel for a Windows MinSizeRel build using build.bat would be in `<ONNX Runtime repository root>\build\Windows\MinSizeRel\MinSizeRel\dist\`
@@ -124,11 +124,11 @@ session = onnxruntime.InferenceSession(<path to model>, so)
 
 Using the NNAPI Execution Provider on Android platforms is now supported by ONNX Runtime Mobile. A minimal build targeting Android with NNAPI support must be created. An ORT format model that only uses ONNX operators is also recommended as a starting point.
 
-For a more in-depth analysis of the performance considerations when using NNAPI with an ORT format model please see [ONNX Runtime Mobile: Performance Considerations When Using NNAPI](ONNX_Runtime_Mobile_NNAPI_perf_considerations.md). 
+For a more in-depth analysis of the performance considerations when using NNAPI with an ORT format model please see [ONNX Runtime Mobile: Performance Considerations When Using NNAPI](ONNX_Runtime_Mobile_NNAPI_perf_considerations.md).
 
 ### Limit ORT format model to ONNX operators
 
-The NNAPI Execution Provider is only able to execute ONNX operators using NNAPI. When creating the ORT format model it is recommended to limit the optimization level to 'basic' so that custom internal ONNX Runtime operators are not added by the 'extended' optimizations. This will ensure that the maximum number of nodes can be executed using NNAPI. See the [graph optimization](ONNX_Runtime_Graph_Optimizations.md) documentation for details on the optimization levels.
+The NNAPI Execution Provider is only able to execute ONNX operators using NNAPI. When creating the ORT format model it is recommended to limit the optimization level to 'basic' so that custom internal ONNX Runtime operators are not added by the 'extended' optimizations. This will ensure that the maximum number of nodes can be executed using NNAPI. See the [graph optimization](https://www.onnxruntime.ai/docs/resources/graph-optimizations.html) documentation for details on the optimization levels.
 
 To limit the optimization level when creating the ORT format models using `tools\python\convert_onnx_models_to_ort.py` as per the above [instructions](#1-Create-ORT-format-model-and-configuration-file-with-required-operators), add `--optimization_level basic` to the arguments.
   - e.g. `python <ORT repository root>/tools/python/convert_onnx_models_to_ort.py --optimization_level basic /models`
@@ -142,9 +142,9 @@ First, read the general instructions for [creating an Android build with NNAPI i
 Once you have all the necessary components setup, follow the instructions to [create the minimal build](#2-Create-the-minimal-build), with the following changes:
   - Replace `--minimal_build` with `--minimal_build extended` to enable support for execution providers that dynamically create kernels at runtime, which is needed by the NNAPI Execution Provider.
   - Add `--use_nnapi` to include the NNAPI Execution Provider in the build
-  - Windows example:  
+  - Windows example:
     `<ONNX Runtime repository root>.\build.bat --config RelWithDebInfo --android --android_sdk_path D:\Android --android_ndk_path D:\Android\ndk\21.1.6352462\ --android_abi arm64-v8a --android_api 29 --cmake_generator Ninja --minimal_build extended --use_nnapi --disable_ml_ops --disable_exceptions --build_shared_lib --skip_tests --include_ops_by_config <config file produced by step 1>`
-  - Linux example:  
+  - Linux example:
     `<ONNX Runtime repository root>./build.sh --config RelWithDebInfo --android --android_sdk_path /Android --android_ndk_path /Android/ndk/21.1.6352462/ --android_abi arm64-v8a --android_api 29 --minimal_build extended --use_nnapi --disable_ml_ops --disable_exceptions --build_shared_lib --skip_tests --include_ops_by_config <config file produced by step 1>`
 
 ## Limitations
@@ -154,7 +154,7 @@ A minimal build has the following limitations currently:
     - Model must be converted to ORT format
   - No support for runtime optimizations
     - Optimizations should be performed prior to conversion to ORT format
-  - Execution providers that statically register kernels (e.g. ONNX Runtime CPU Execution Provider) are supported by default 
+  - Execution providers that statically register kernels (e.g. ONNX Runtime CPU Execution Provider) are supported by default
   - Limited support for runtime partitioning (assigning nodes in a model to specific execution providers)
     - Execution providers that statically register kernels and will be used at runtime MUST be enabled when creating the ORT format model
     - Execution providers that compile nodes are optionally supported, and nodes they create will be correctly partitioned at runtime


### PR DESCRIPTION
**Description**: Update links to gh-pages for ORT minimal documents

Update the broken links to the [graph optimization], update the link to build.md to https://www.onnxruntime.ai/docs/how-to/build.html