### PR TITLE
Skip running gpt2 model in C# x86

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -822,6 +822,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 skipModels["test_vgg19"] = "Get preallocated buffer for initializer conv4_4_b_0 failed";
                 skipModels["GPT2_LM_HEAD"] = "System out of memory";
                 skipModels["GPT2"] = "System out of memory";
+                skipModels["test_GPT2"] = "System out of memory";
                 skipModels["tf_pnasnet_large"] = "Get preallocated buffer for initializer ConvBnFusion_BN_B_cell_5/comb_iter_1/left/bn_sep_7x7_1/beta:0_203 failed";
                 skipModels["tf_nasnet_large"] = "Get preallocated buffer for initializer ConvBnFusion_BN_B_cell_11/beginning_bn/beta:0_331 failed";
                 skipModels["test_zfnet512"] = "System out of memory";


### PR DESCRIPTION
**Description**: 

Skip running gpt2 model in C# x86

**Motivation and Context**
- Why is this change required? What problem does it solve?
Avoid build failures likes https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=315927&view=results


- If it fixes an open issue, please link to the issue here.
