### PR TITLE
[OpenVINO-EP] Fixes OpenVINO-EP build on windows

### DIFF
--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -12,18 +12,6 @@
 namespace onnxruntime {
 namespace perftest {
 
-#ifdef _MSC_VER
-// Convert a wide Unicode string to an UTF8 string
-std::string utf8_encode(const std::wstring &wstr)
-{
-    if(wstr.empty()) return std::string();
-    int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
-    std::string strTo(size_needed, 0);
-    WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
-    return strTo;
-}
-#endif
-
 std::chrono::duration<double> OnnxRuntimeTestSession::Run() {
   //Randomly pick one OrtValueArray from test_inputs_. (NOT ThreadSafe)
   const std::uniform_int_distribution<int>::param_type p(0, static_cast<int>(test_inputs_.size() - 1));
@@ -86,7 +74,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
     size_t num_of_threads = 8; // [num_of_threads]: Overrides the accelerator default value of number of threads with this value at runtime.
 
     #ifdef _MSC_VER
-    std::string ov_string = utf8_encode(performance_test_config.run_config.ep_runtime_config_string);
+    std::string ov_string = ToMBString(performance_test_config.run_config.ep_runtime_config_string);
     #else
     std::string ov_string = performance_test_config.run_config.ep_runtime_config_string;
     #endif


### PR DESCRIPTION
**Description:**
[FIX] Openvino EP build on windows.

**Motivation and Context:**
The issue is wchar_t is UTF-16 on windows while on other platforms
such as Linux and MacOS, wchar_t is UTF-32.

so wide Unicode string has to be converted to an UTF8 string
for sure on windows else the compiler will throw an error.

This commit fixes this issue.