### PR TITLE
Add direct link to build instructions on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Common use cases for ONNX Runtime:
 * [Training](https://www.onnxruntime.ai/docs/get-started/training.html)
 * [Documentation](https://www.onnxruntime.ai/docs/)
 * [Samples and Tutorials](https://www.onnxruntime.ai/docs/tutorials/)
+* [Build Instructions](https://www.onnxruntime.ai/docs/how-to/build.html)
 * [Frequently Asked Questions](./docs/FAQ.md)
 
 ## Build Pipeline Status


### PR DESCRIPTION
**Description**: Since BUILD.md page will be moved out of the master branch and into gh-pages, adding a direct link on main readme for easier discovery.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
