### PR TITLE
[OpenVINO EP] Update docs MCR image publishing policy change

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -88,6 +88,8 @@ Use `docker pull` with any of the images and tags below to pull an image and try
 
 ### **1. Using MCR container images**
 
+*Note: ONNX Runtime 1.7 will be the last release that will publish MCR container images. Please switch to using PyPi packages or bulding from Dockefile section below from ONNX Runtime 1.8 onwards.*
+
 The unified MCR container image can be used to run an application on any of the target accelerators. In order to select the target accelerator, the application should explicitly specifiy the choice using the *device_type*  configuration option for OpenVINO Execution provider. Refer to [OpenVINO EP runtime configuration documentation](https://github.com/microsoft/onnxruntime/blob/master/docs/execution_providers/OpenVINO-ExecutionProvider.md#runtime-configuration-options) for details on specifying this option in the application code. 
 If the *device_type* runtime config option is not explicitly specified, CPU will be chosen as the hardware target execution.
 ### **2. Building from Dockerfile**


### PR DESCRIPTION
**Description**: ONNX Runtime 1.7 will the last release that will publish MCR
container images for ONNX Runtime with OpenVINO EP. From ONNX
Runtime 1.8 onwards, this will be discontinued. Users are advised
to switch to using PyPi packages or build their own containers
using dockerfiles..

