### PR TITLE
Fix iOS/macOS build warning for inconsistent symbol visibility settings

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -372,7 +372,7 @@ if(onnxruntime_CROSS_COMPILING)
 endif()
 
 # Mark symbols to be invisible, for macOS/iOS target only
-# Due to many dependencies have different symbol visibility settings, set global complie flags here.
+# Due to many dependencies have different symbol visibility settings, set global compile flags here.
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin|iOS")
   string(APPEND CMAKE_CXX_FLAGS " -fvisibility=hidden -fvisibility-inlines-hidden")
 endif()

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -240,7 +240,7 @@ if (onnxruntime_MINIMAL_BUILD)
   if (onnxruntime_MINIMAL_BUILD_CUSTOM_OPS)
     add_compile_definitions(ORT_MINIMAL_BUILD_CUSTOM_OPS)
   endif()
-  
+
   set(onnxruntime_REDUCED_OPS_BUILD ON)
 
   if (NOT onnxruntime_ENABLE_PYTHON)
@@ -369,6 +369,12 @@ if(onnxruntime_CROSS_COMPILING)
     string(APPEND CMAKE_CXX_FLAGS " -Wno-error=attributes")
     string(APPEND CMAKE_C_FLAGS " -Wno-error=attributes")
   endif()
+endif()
+
+# Mark symbols to be invisible, for macOS/iOS target only
+# Due to many dependencies have different symbol visibility settings, set global complie flags here.
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin|iOS")
+  string(APPEND CMAKE_CXX_FLAGS " -fvisibility=hidden -fvisibility-inlines-hidden")
 endif()
 
 #must after OpenMP settings
@@ -715,7 +721,7 @@ endif()
 
 function(onnxruntime_add_shared_library target_name)
   add_library(${target_name} SHARED ${ARGN})
-  target_link_directories(${target_name} PRIVATE ${onnxruntime_LINK_DIRS}) 
+  target_link_directories(${target_name} PRIVATE ${onnxruntime_LINK_DIRS})
   if (MSVC)
     target_compile_options(${target_name} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--compiler-options /utf-8>" "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/utf-8>")
     target_compile_options(${target_name} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--compiler-options /sdl>" "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/sdl>")
@@ -753,9 +759,9 @@ function(onnxruntime_add_shared_library_module target_name)
 endfunction()
 
 #almost the same as the above function, except the first line of the body
-function(onnxruntime_add_executable target_name)  
+function(onnxruntime_add_executable target_name)
   add_executable(${target_name} ${ARGN})
-  target_link_directories(${target_name} PRIVATE ${onnxruntime_LINK_DIRS}) 
+  target_link_directories(${target_name} PRIVATE ${onnxruntime_LINK_DIRS})
   if (MSVC)
     target_compile_options(${target_name} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--compiler-options /utf-8>" "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/utf-8>")
     target_compile_options(${target_name} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--compiler-options /sdl>" "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/sdl>")
@@ -979,7 +985,7 @@ if (WIN32)
     list(APPEND ORT_WARNING_FLAGS "/wd4201")
     if (onnxruntime_ENABLE_STATIC_ANALYSIS)
         list(APPEND ORT_WARNING_FLAGS "/analyze:stacksize 131072")
-        list(APPEND ORT_WARNING_FLAGS "/wd6326") # potential comparison of a constant with another constant        
+        list(APPEND ORT_WARNING_FLAGS "/wd6326") # potential comparison of a constant with another constant
         if(onnxruntime_USE_OPENMP)
           list(APPEND ORT_WARNING_FLAGS "/wd6993") # Code analysis ignores OpenMP constructs
         endif()

--- a/include/onnxruntime/core/providers/coreml/coreml_provider_factory.h
+++ b/include/onnxruntime/core/providers/coreml/coreml_provider_factory.h
@@ -28,8 +28,8 @@ enum COREMLFlags {
 extern "C" {
 #endif
 
-ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_CoreML,
-               _In_ OrtSessionOptions* options, uint32_t coreml_flags);
+ORT_EXPORT ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_CoreML,
+                          _In_ OrtSessionOptions* options, uint32_t coreml_flags);
 
 #ifdef __cplusplus
 }

--- a/include/onnxruntime/core/providers/cpu/cpu_provider_factory.h
+++ b/include/onnxruntime/core/providers/cpu/cpu_provider_factory.h
@@ -10,6 +10,7 @@ extern "C" {
 /**
  * \param use_arena zero: false. non-zero: true.
  */
+ORT_EXPORT
 ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_CPU, _In_ OrtSessionOptions* options, int use_arena)
 ORT_ALL_ARGS_NONNULL;
 

--- a/include/onnxruntime/core/providers/nnapi/nnapi_provider_factory.h
+++ b/include/onnxruntime/core/providers/nnapi/nnapi_provider_factory.h
@@ -44,7 +44,8 @@ enum NNAPIFlags {
 extern "C" {
 #endif
 
-ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_Nnapi, _In_ OrtSessionOptions* options, uint32_t nnapi_flags);
+ORT_EXPORT ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_Nnapi,
+                          _In_ OrtSessionOptions* options, uint32_t nnapi_flags);
 
 #ifdef __cplusplus
 }

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -437,8 +437,8 @@ struct OrtApi {
      * The handle to the loaded library is returned in library_handle. It can be freed by the caller after all sessions using the passed in
      * session options are destroyed, or if an error occurs and it is non null.
   */
-  ORT_API2_STATUS(RegisterCustomOpsLibrary, _Inout_ OrtSessionOptions* options, _In_ const char* library_path,
-                  void** library_handle);
+  ORT_EXPORT ORT_API2_STATUS(RegisterCustomOpsLibrary, _Inout_ OrtSessionOptions* options, _In_ const char* library_path,
+                             void** library_handle);
 
   /**
     * To use additional providers, you must build ORT with the extra providers enabled. Then call one of these

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -437,8 +437,8 @@ struct OrtApi {
      * The handle to the loaded library is returned in library_handle. It can be freed by the caller after all sessions using the passed in
      * session options are destroyed, or if an error occurs and it is non null.
   */
-  ORT_EXPORT ORT_API2_STATUS(RegisterCustomOpsLibrary, _Inout_ OrtSessionOptions* options, _In_ const char* library_path,
-                             void** library_handle);
+  ORT_API2_STATUS(RegisterCustomOpsLibrary, _Inout_ OrtSessionOptions* options, _In_ const char* library_path,
+                  void** library_handle);
 
   /**
     * To use additional providers, you must build ORT with the extra providers enabled. Then call one of these

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -53,7 +53,12 @@ extern "C" {
 #define ORT_MUST_USE_RESULT
 #define ORTCHAR_T wchar_t
 #else
+// To make symbols visible on macOS/iOS
+#ifdef __APPLE__
+#define ORT_EXPORT __attribute__((visibility("default")))
+#else
 #define ORT_EXPORT
+#endif
 #define ORT_API_CALL
 #define ORT_MUST_USE_RESULT __attribute__((warn_unused_result))
 #define ORTCHAR_T char
@@ -1131,7 +1136,7 @@ struct OrtApi {
   ORT_API2_STATUS(SetGlobalDenormalAsZero, _Inout_ OrtThreadingOptions* tp_options);
 
   /**
-  * Use this API to create the configuration of an arena that can eventually be used to define 
+  * Use this API to create the configuration of an arena that can eventually be used to define
   * an arena based allocator's behavior
   * \param max_mem - use 0 to allow ORT to choose the default
   * \param arena_extend_strategy -  use -1 to allow ORT to choose the default, 0 = kNextPowerOfTwo, 1 = kSameAsRequested
@@ -1151,8 +1156,8 @@ struct OrtApi {
   * (doc_string field of the GraphProto message within the ModelProto message).
   * If it doesn't exist, an empty string will be returned.
   * \param model_metadata - an instance of OrtModelMetadata
-  * \param allocator - allocator used to allocate the string that will be returned back 
-  * \param value - is set to a null terminated string allocated using 'allocator'. 
+  * \param allocator - allocator used to allocate the string that will be returned back
+  * \param value - is set to a null terminated string allocated using 'allocator'.
     The caller is responsible for freeing it.
   */
   ORT_API2_STATUS(ModelMetadataGetGraphDescription, _In_ const OrtModelMetadata* model_metadata,

--- a/onnxruntime/test/testdata/custom_op_library/custom_op_library.h
+++ b/onnxruntime/test/testdata/custom_op_library/custom_op_library.h
@@ -5,8 +5,7 @@
 extern "C" {
 #endif
 
-OrtStatus* ORT_API_CALL RegisterCustomOps(OrtSessionOptions* options, const OrtApiBase* api);
-
+ORT_EXPORT OrtStatus* ORT_API_CALL RegisterCustomOps(OrtSessionOptions* options, const OrtApiBase* api);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
**Description**: Fix iOS/macOS build warning for inconsistent symbol visibility settings

**Motivation and Context**
- One of ORT iOS user reported this, and we can see this kind of warning in our macOS CI pipeline, this change will fix it
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=316895&view=logs&j=7636b40b-abcf-5c6b-cc48-bcd7d4ae0854&t=4f922874-195a-5571-f5f1-e2f658fa1687&l=1430

- Due to some of dependencies has inconsistent symbol visibility settings, (such as libonnx and libonnx_proto have different settings), set a global compile flags to fix this issue. Also the settings are inconsistent within ORT project.

- Potentially, setting symbols to be invisible can reduce binary size, see https://gcc.gnu.org/wiki/Visibility



