### PR TITLE
Make it easier to fold MakeString usages to reduce binary size.

### DIFF
--- a/include/onnxruntime/core/common/make_string.h
+++ b/include/onnxruntime/core/common/make_string.h
@@ -57,15 +57,15 @@ struct if_char_array_make_ptr {
   using type = T;
 };
 
-// specialization that matches an array reference, which is what the char array from a string literal 
+// specialization that matches an array reference, which is what the char array from a string literal
 // used in a call to MakeString will be.
 // if the type is a char[n] array we 'decay' it to a char* so that the usages can be folded.
 template <class T, size_t N>
 struct if_char_array_make_ptr<T (&)[N]> {
   // remove a single extent (T[x] -> T, but T[x][y] -> T[y]) so we only match char[x],
-  // and get the type name without the 'const' so both 'const char (&)[n]' and 'char (&)[n]' are matched. 
-  using element_type = std::remove_const<std::remove_extent<T>::type>::type;
-  using type = std::conditional<std::is_same<char, element_type>::value, const T*, T (&)[N]>::type;
+  // and get the type name without the 'const' so both 'const char (&)[n]' and 'char (&)[n]' are matched.
+  using element_type = typename std::remove_const<typename std::remove_extent<T>::type>::type;
+  using type = typename std::conditional<std::is_same<char, element_type>::value, T*, T (&)[N]>::type;
 };
 
 // helper to make usage simpler in MakeString

--- a/include/onnxruntime/core/common/make_string.h
+++ b/include/onnxruntime/core/common/make_string.h
@@ -19,10 +19,12 @@
 
 #include <locale>
 #include <sstream>
+#include <type_traits>
 
 namespace onnxruntime {
 
 namespace detail {
+
 inline void MakeStringImpl(std::ostringstream& /*ss*/) noexcept {
 }
 
@@ -36,6 +38,38 @@ inline void MakeStringImpl(std::ostringstream& ss, const T& t, const Args&... ar
   MakeStringImpl(ss, t);
   MakeStringImpl(ss, args...);
 }
+
+// see MakeString comments for explanation of why this is necessary
+template <typename... Args>
+inline std::string MakeStringImpl(const Args&... args) noexcept {
+  std::ostringstream ss;
+  MakeStringImpl(ss, args...);
+  return ss.str();
+}
+
+//
+// Infrastructure to convert char[x] to char* to reduce binary size
+//
+
+// default is to leave the type as is
+template <class T>
+struct if_char_array_make_ptr {
+  using type = T;
+};
+
+// specialization that matches an array reference (which is what an array being passed to MakeString will be).
+// if the type is a char[x] array we 'decay' it to a char* so that the usages can be folded.
+template <class T, size_t N>
+struct if_char_array_make_ptr<T (&)[N]> {
+  // remove a single extent (so T[x] -> T, but T[x][y] -> T[y]) so we only match char[x],
+  // and get the type name with no 'const' in it
+  using element_type = std::remove_const_t<std::remove_extent_t<T>>;
+  using type = std::conditional_t<std::is_same<char, element_type>::value, const T*, T (&)[N]>;
+};
+
+// helper to make usage simpler in MakeString
+template <class T>
+using if_char_array_make_ptr_t = typename if_char_array_make_ptr<T>::type;
 }  // namespace detail
 
 /**
@@ -44,9 +78,18 @@ inline void MakeStringImpl(std::ostringstream& ss, const T& t, const Args&... ar
  */
 template <typename... Args>
 std::string MakeString(const Args&... args) {
-  std::ostringstream ss;
-  detail::MakeStringImpl(ss, args...);
-  return ss.str();
+  // we need to update the types from the MakeString template instantiation to decay any char[n] to char*.
+  //   e.g. MakeString("in", "out") goes from MakeString<char[2], char[3]> to MakeStringImpl<char*, char*>
+  //        so that MakeString("out", "in") will also match MakeStringImpl<char*, char*> instead of requiring
+  //        MakeStringImpl<char[3], char[2]>.
+  //
+  // We have to do the type processing before any actual work, so this function purely implements the type processing.
+  // if we do not do it this way we do not get the full binary size reduction.
+  //
+  // See https://stackoverflow.com/a/29418212/684911 for overall details of the approach, but note it does not cover
+  // the need to do the type processing as a separate step.
+
+  return detail::MakeStringImpl(detail::if_char_array_make_ptr_t<Args const&>(args)...);
 }
 
 /**
@@ -57,7 +100,7 @@ template <typename... Args>
 std::string MakeStringWithClassicLocale(const Args&... args) {
   std::ostringstream ss;
   ss.imbue(std::locale::classic());
-  detail::MakeStringImpl(ss, args...);
+  return detail::MakeStringImpl(ss, args...);
   return ss.str();
 }
 


### PR DESCRIPTION
**Description**: 
MakeString is often used with string literals, which have a type of char[n]. As the 'n' differs based on the length of the string literal it makes it harder to re-use the combinations of types in the MakeString template instantiation.

Add a layer to decay a char[n] argument to char* so that we can re-use the MakeString implementation for a combination of types more effectively.

Tested with various platforms and build types to validate. All tests showed a reduction in size. Example reductions for two main build types:

Android MinSizeRel minimal build, static libc++, no ops, no exceptions (i.e. ORT mobile base build)
 - Before: 1,129,344
 - After: 1,096,576
 - Saving: 32KB

Windows Release build with all ops
  - Before: 7,244,800
  - After: 7,193,088
 - Saving: 50KB


**Motivation and Context**
Reduce binary size from MakeString