### PR TITLE
Fix longformer parity and perf regression

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/longformer_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/longformer_attention_base.h
@@ -25,5 +25,10 @@ class LongformerAttentionBase {
   int window_;     // Attention windows length (W). It is half (one-sided) of total window size.
 };
 
+namespace longformer {
+// Environment variable to give a hint about choosing kernels for less memory or latency.
+constexpr const char* kUseCompactMemory = "ORT_LONGFORMER_COMPACT_MEMORY";
+}  // namespace longformer
+
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention.h
@@ -18,6 +18,9 @@ class LongformerAttention final : public CudaKernel, public LongformerAttentionB
  public:
   LongformerAttention(const OpKernelInfo& info);
   Status ComputeInternal(OpKernelContext* context) const override;
+
+ private:
+  bool use_compact_memory_;
 };
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention_impl.h
@@ -18,9 +18,10 @@ size_t GetLongformerAttentionWorkspaceSize(
     int head_size,
     int sequence_length,
     int max_num_global,
-    int window);
+    int window,
+    bool use_fast_kernel);
 
-  bool LaunchLongformerAttentionKernel(
+bool LaunchLongformerAttentionKernel(
     const cudaDeviceProp& device_prop,  // Device Properties
     cublasHandle_t& cublas,             // Cublas handle
     cudaStream_t stream,                // CUDA stream
@@ -39,7 +40,8 @@ size_t GetLongformerAttentionWorkspaceSize(
     int head_size,                      // Hidden layer size per head (H)
     int window,                         // One sided attention window (W)
     int max_num_global,                 // Maximum number of global tokens (G)
-    const size_t element_size           // Element size of input tensor
+    const size_t element_size,          // Element size of input tensor,
+    bool use_fast_kernel                // Use compact memory
 );
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention_softmax.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention_softmax.cu
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This is cuda kernels for longformer attention. It stores two matrix of
-// It uses more memory but it is faster.
+// This is fast cuda kernels for longformer attention softmax.
+// It uses two temporary matrix of BxNxSxS, and consumes more memory when sequence length is large.
+
 #include <cub/cub.cuh>
 #include <cublas_v2.h>
 #include <cuda_fp16.h>

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention_softmax.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention_softmax.cu
@@ -1,0 +1,656 @@
+/*
+Copyright (c) NVIDIA Corporation and Microsoft Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is cuda kernels for longformer attention. It stores two matrix of
+// It uses more memory but it is faster.
+#include <cub/cub.cuh>
+#include <cublas_v2.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <math_constants.h>
+#include "core/providers/cuda/cu_inc/common.cuh"
+#include "core/providers/cuda/cuda_common.h"
+#include "longformer_attention_softmax.h"
+#include "attention_impl.h"
+
+using namespace onnxruntime::cuda;
+using namespace cub;
+
+#define CHECK(expr)         \
+  if (!CUBLAS_CALL(expr)) { \
+    return false;           \
+  }
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+template <typename T, int blockSize>
+__launch_bounds__(blockSize)
+    __global__ void LongformerSoftmaxFastKernel(const int* global_attention,
+                                                const int* global_index,
+                                                const int* batch_global_num,
+                                                const T* input,
+                                                const T* attention_mask,
+                                                T* output,
+                                                float scaler,
+                                                int dim0,
+                                                int sequence_length,
+                                                int attention_window) {
+  typedef cub::BlockReduce<float, blockSize> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage block_reduce_temp;
+  __shared__ float max_shared;
+  __shared__ float sum_shared;
+
+  const T* input_block = input + sequence_length * blockIdx.x;
+  T* output_block = output + sequence_length * blockIdx.x;
+  const int batch_index = blockIdx.x / dim0;
+  const int row_index = blockIdx.x % sequence_length;
+  const int global_num = batch_global_num[batch_index];
+
+  // To be consistent with Huggingface Longformer, the row of maksed word are set as zero.
+  if ((float)attention_mask[batch_index * sequence_length + row_index] < 0.0f) {
+    for (int i = threadIdx.x; i < sequence_length; i += blockSize) {
+      output_block[i] = (T)(0);
+    }
+    return;
+  }
+
+  // local attention token
+  int col_start = 0;
+  int col_end = sequence_length;
+  bool is_local_row = (global_attention[batch_index * sequence_length + row_index] == (int)0);
+  if (is_local_row) {
+    col_start = row_index - attention_window;
+    if (col_start < 0) {
+      col_start = 0;
+    }
+
+    col_end = row_index + attention_window + 1;
+    if (col_end > sequence_length) {
+      col_end = sequence_length;
+    }
+  }
+
+  const T* mask_block = attention_mask + sequence_length * batch_index;
+  int tid = threadIdx.x;
+
+  // calculate max input
+  float max_input = -CUDART_INF_F;
+  // #pragma unroll 16
+  for (int i = tid + col_start; i < col_end; i += blockSize) {
+    float x = input_block[i];
+    x = x * scaler + (float)mask_block[i];
+    if (max_input < x) {
+      max_input = x;
+    }
+  }
+
+  if (is_local_row) {
+    for (int g = tid; g < global_num; g += blockSize) {
+      int i = global_index[g];
+      if (i < col_start || i > col_end) {
+        float x = input_block[i];
+        x = x * scaler + (float)mask_block[i];
+        if (max_input < x) {
+          max_input = x;
+        }
+      }
+    }
+  }
+
+  float max_block = BlockReduce(block_reduce_temp).Reduce(max_input, cub::Max());
+  if (tid == 0) {
+    max_shared = max_block;
+  }
+  __syncthreads();
+
+  float sum_input = 0.f;
+  // #pragma unroll 16
+  for (int i = tid + col_start; i < col_end; i += blockSize) {
+    float x = input_block[i];
+    x = expf((x)*scaler + (float)mask_block[i] - max_shared);
+    sum_input += x;
+  }
+
+  if (is_local_row) {
+    for (int g = tid; g < global_num; g += blockSize) {
+      int i = global_index[g];
+      if (i < col_start || i > col_end) {
+        float x = input_block[i];
+        x = expf((x)*scaler + (float)mask_block[i] - max_shared);
+        sum_input += x;
+      }
+    }
+  }
+
+  float sum_block = BlockReduce(block_reduce_temp).Reduce(sum_input, cub::Sum());
+  if (tid == 0) {
+    sum_shared = sum_block;
+  }
+  __syncthreads();
+  float recip_sum = 1.f / sum_shared;
+
+  if (is_local_row) {
+    // We only need to fill in zeros for blocks that will be used in the matrix multiplication
+    // following the Softmax.
+    //
+    // For now zero-out only [row_index - 2*attention_window, row_index + 2*attention_window],
+    // we can even be more agressive and reduce the zeroing out window size since
+    // each row has entries in 3 blocks (3*attention_window size instead of 4*attention_window)
+    int zero_start = row_index - 2 * attention_window;
+    if (zero_start < 0) {
+      zero_start = 0;
+    }
+
+    int zero_end = row_index + 2 * attention_window;
+    if (zero_end > sequence_length) {
+      zero_end = sequence_length;
+    }
+
+    for (int i = tid + zero_start; i < zero_end; i += blockSize) {
+      output_block[i] = (T)(0.);
+    }
+
+    for (int g = tid; g < global_num; g += blockSize) {
+      int i = global_index[g];
+      float x = input_block[i];
+      x = expf((x)*scaler + (float)mask_block[i] - max_shared);
+      output_block[i] = (T)(recip_sum * x);
+    }
+  }
+
+  // #pragma unroll 16
+  for (int i = tid + col_start; i < col_end; i += blockSize) {
+    float x = input_block[i];
+    x = expf((x)*scaler + (float)mask_block[i] - max_shared);
+    output_block[i] = (T)(recip_sum * x);
+  }
+}
+
+// Launch the softmax kernel for non compact memory.
+bool launchSoftmaxFastKernel(
+    cudaStream_t stream,
+    cublasHandle_t cublas,
+    void* workspace,              // softmax space
+    const void* q,                // transposed Q with shape (B, N, S, H)
+    const void* k,                // transposed K with shape (B, N, S, H)
+    const void* v,                // transposed V with shape (B, N, S, H)
+    const void* attention_mask,   // attention mask with shape (B, S), with value 0.0 not masked, and -10000.0 masked.
+    const void* global_q,         // Q for global tokens with shape (B, N, S, H)
+    const void* global_k,         // K for global tokens with shape (B, N, S, H)
+    const void* global_v,         // V for global tokens with shape (B, N, S, H)
+    const int* global_attention,  // global attention with shape (B, S), with value 0 for local attention and 1 for global attention.
+    const int* global_index,      // Global index with shape (B, S)
+    const int* batch_global_num,  // Number of global tokens per batch with shape (B, 1)
+    void* pinned_buffer,          // Pinned memory in CPU. Number of global tokens per batch with shape (B, 1)
+    void* output,                 // output with shape (B, N, S, H)
+    float scaler,                 // scalar
+    int batch_size,               // batch size
+    int sequence_length,          // sequence length
+    int num_heads,                // number of heads
+    int head_size,                // hidden size per head
+    int attention_window,         // one sided windows size
+    size_t element_size) {        // size of element: 2 for half, and 4 for float
+
+  bool is_fp16 = (element_size == 2);
+  void* scratch1 = reinterpret_cast<char*>(workspace);
+  void* scratch2 = reinterpret_cast<char*>(scratch1) + GetAttentionScratchSize(element_size, batch_size, num_heads, sequence_length, sequence_length);
+
+  // setup shared parameters for two strided batched matrix multiplies
+  cudaDataType_t Atype;
+  cudaDataType_t Btype;
+  cudaDataType_t Ctype;
+  cudaDataType_t resultType;
+  cublasGemmAlgo_t algo = CUBLAS_GEMM_DEFAULT;
+
+  __half one_fp16, zero_fp16;
+  float one_fp32, zero_fp32;
+  void *alpha, *beta_0, *beta_1;
+
+  if (is_fp16) {
+    one_fp16 = __float2half(1.f);
+    zero_fp16 = __float2half(0.f);
+    alpha = static_cast<void*>(&one_fp16);
+    beta_0 = static_cast<void*>(&zero_fp16);
+    beta_1 = static_cast<void*>(&one_fp16);
+    Atype = CUDA_R_16F;
+    Btype = CUDA_R_16F;
+    Ctype = CUDA_R_16F;
+    resultType = CUDA_R_16F;
+    algo = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
+  } else {
+    one_fp32 = 1.f;
+    zero_fp32 = 0.f;
+    alpha = static_cast<void*>(&one_fp32);
+    beta_0 = static_cast<void*>(&zero_fp32);
+    beta_1 = static_cast<void*>(&one_fp32);
+    Atype = CUDA_R_32F;
+    Btype = CUDA_R_32F;
+    Ctype = CUDA_R_32F;
+    resultType = CUDA_R_32F;
+  }
+
+  // Strided batch matrix multiply
+  //    qk = q * k^T
+  // Shapes: q and k = B x N x S x H, qk = B x N x S x S
+  // Convert col-major to row-major by swapping q and k in Gemm
+
+  // Local attention part
+  // S x S is calculated using sliding block WxW (W is one sided window size) like the following:
+  //   [W][W]
+  //   [W][W][W]
+  //      [W][W][W]
+  //         [W][W]
+  // The first and last rows have 2 blocks, and the remaining has 3 blocks per row.
+  // The calculation are splited into 3 parts. Firstly, fill the middle rows,  then the first row and finally the last row.
+  // The results are stored in scratch1.
+
+  int w = attention_window;
+  int x_offset = num_heads * sequence_length * head_size;
+  int y_offset = num_heads * sequence_length * sequence_length;
+  int last_block = (sequence_length / w) - 1;
+  int strideA = sequence_length * head_size;
+  int strideB = sequence_length * head_size;
+  int strideC = sequence_length * sequence_length;
+
+  // When S == 2W, there is no middle rows of blocks:
+  //   [W][W]
+  //   [W][W]
+  // We can use normal matrix multiplication in this case.
+  if (sequence_length == 2 * w) {
+    CHECK(cublasGemmStridedBatchedEx(cublas,
+                                     CUBLAS_OP_T,
+                                     CUBLAS_OP_N,
+                                     sequence_length,
+                                     sequence_length,
+                                     head_size,
+                                     alpha,
+                                     k,
+                                     Atype,
+                                     head_size,
+                                     sequence_length * head_size,
+                                     q,
+                                     Btype,
+                                     head_size,
+                                     sequence_length * head_size,
+                                     beta_0,
+                                     scratch1,
+                                     Ctype,
+                                     sequence_length,
+                                     sequence_length * sequence_length,
+                                     batch_size * num_heads,
+                                     resultType,
+                                     algo));
+  } else {  // sequence_length > 2 * w
+    for (int i = 0; i < batch_size; ++i) {
+      for (int j = 0; j < num_heads; ++j) {
+        void* q_head = (char*)q + (i * x_offset + j * sequence_length * head_size + w * head_size) * element_size;
+        void* k_head = (char*)k + (i * x_offset + j * sequence_length * head_size) * element_size;
+        void* qk_head = (char*)scratch1 + (i * y_offset + j * sequence_length * sequence_length + w * sequence_length) * element_size;
+        int count = (sequence_length - 2 * w) / w;
+        CHECK(cublasGemmStridedBatchedEx(cublas,
+                                         CUBLAS_OP_T,
+                                         CUBLAS_OP_N,
+                                         3 * w,                    // m
+                                         w,                        // n
+                                         head_size,                // k
+                                         alpha,                    // alpha
+                                         k_head,                   // A
+                                         Atype,                    // A type
+                                         head_size,                // lda
+                                         w * head_size,            // strideA
+                                         q_head,                   // B
+                                         Btype,                    // B type
+                                         head_size,                // ldb
+                                         w * head_size,            // strideB
+                                         beta_0,                   // beta
+                                         qk_head,                  // C
+                                         Ctype,                    // C type
+                                         sequence_length,          // ldc
+                                         sequence_length * w + w,  // strideC
+                                         count,                    // batch count
+                                         resultType,
+                                         algo));
+      }
+    }
+
+    CHECK(cublasGemmStridedBatchedEx(cublas,
+                                     CUBLAS_OP_T,
+                                     CUBLAS_OP_N,
+                                     2 * w,                   // m
+                                     w,                       // n
+                                     head_size,               // k
+                                     alpha,                   // alpha
+                                     k,                       // A
+                                     Atype,                   // A type
+                                     head_size,               // lda
+                                     strideA,                 // strideA
+                                     q,                       // B
+                                     Btype,                   // B type
+                                     head_size,               // ldb
+                                     strideB,                 // strideB
+                                     beta_0,                  // beta
+                                     scratch1,                // C
+                                     Ctype,                   // C type
+                                     sequence_length,         // ldc
+                                     strideC,                 // strideC
+                                     batch_size * num_heads,  // batch count
+                                     resultType,
+                                     algo));
+
+    void* q_head = (char*)q + (last_block * w * head_size) * element_size;
+    void* k_head = (char*)k + ((last_block - 1) * w * head_size) * element_size;
+    void* qk_head = (char*)scratch1 + (last_block * w * sequence_length + (last_block - 1) * w) * element_size;
+    CHECK(cublasGemmStridedBatchedEx(cublas,
+                                     CUBLAS_OP_T,
+                                     CUBLAS_OP_N,
+                                     2 * w,
+                                     w,
+                                     head_size,
+                                     alpha,
+                                     k_head,
+                                     Atype,
+                                     head_size,
+                                     strideA,
+                                     q_head,
+                                     Btype,
+                                     head_size,
+                                     strideB,
+                                     beta_0,
+                                     qk_head,
+                                     Ctype,
+                                     sequence_length,
+                                     strideC,
+                                     batch_size * num_heads,
+                                     resultType,
+                                     algo));
+  }
+
+  const int* batch_global_count = reinterpret_cast<const int*>(pinned_buffer);
+  // Global attention part
+  for (int i = 0; i < batch_size; ++i) {
+    if (batch_global_count[i] > 0) {
+      void* q_batch = (char*)q + (i * x_offset) * element_size;
+      void* k_batch = (char*)k + (i * x_offset) * element_size;
+      void* qk_batch = (char*)scratch1 + (i * y_offset) * element_size;
+      // Local tokens attending global tokens
+      CHECK(cublasGemmStridedBatchedEx(cublas,
+                                       CUBLAS_OP_T,
+                                       CUBLAS_OP_N,
+                                       batch_global_count[i],
+                                       sequence_length,
+                                       head_size,
+                                       alpha,
+                                       k_batch,
+                                       Atype,
+                                       head_size,
+                                       strideA,
+                                       q_batch,
+                                       Btype,
+                                       head_size,
+                                       strideB,
+                                       beta_0,
+                                       qk_batch,
+                                       Ctype,
+                                       sequence_length,
+                                       strideC,
+                                       num_heads,
+                                       resultType,
+                                       algo));
+
+      void* global_q_batch = (char*)global_q + (i * num_heads * sequence_length * head_size) * element_size;
+      void* global_k_batch = (char*)global_k + (i * x_offset) * element_size;
+      int strideB_global = sequence_length * head_size;
+
+      // Global tokens attending everything
+      // This GEMMs need to be last to make sure all global token entries are re-written.
+      CHECK(cublasGemmStridedBatchedEx(cublas,
+                                       CUBLAS_OP_T,
+                                       CUBLAS_OP_N,
+                                       sequence_length,
+                                       batch_global_count[i],
+                                       head_size,
+                                       alpha,
+                                       global_k_batch,
+                                       Atype,
+                                       head_size,
+                                       strideA,
+                                       global_q_batch,
+                                       Btype,
+                                       head_size,
+                                       strideB_global,
+                                       beta_0,
+                                       qk_batch,
+                                       Ctype,
+                                       sequence_length,
+                                       strideC,
+                                       num_heads,
+                                       resultType,
+                                       algo));
+    }
+  }
+
+  int dim0 = sequence_length * num_heads;
+  int dim1 = sequence_length;
+  void* softmax_out = scratch2;
+
+  const int blockSize = 64;
+  const int gridSize = batch_size * num_heads * sequence_length;
+  if (is_fp16) {
+    LongformerSoftmaxFastKernel<__half, blockSize><<<gridSize, blockSize, 0, stream>>>(
+        global_attention,
+        global_index,
+        batch_global_num,
+        static_cast<const __half*>(scratch1),
+        static_cast<const __half*>(attention_mask),
+        static_cast<__half*>(softmax_out), scaler, dim0, dim1, attention_window);
+  } else {
+    LongformerSoftmaxFastKernel<float, blockSize><<<gridSize, blockSize, 0, stream>>>(
+        global_attention,
+        global_index,
+        batch_global_num,
+        static_cast<const float*>(scratch1),
+        static_cast<const float*>(attention_mask),
+        static_cast<float*>(softmax_out), scaler, dim0, dim1, attention_window);
+  }
+
+  // Run the matrix multiply: output = softmax_out * v
+  //   softmax_out: B x N x S x S
+  //             v: B x N x S x H
+  //      attn_out: B x N x S x H
+  // Calculation uses full Gemm (S == 2W) or sliding blocks (S > 2W) in a way similar to local attention part.
+
+  if (sequence_length == 2 * w) {
+    // convert col-major to row-major by swapping softmax_out and v
+    CHECK(cublasGemmStridedBatchedEx(cublas,
+                                     CUBLAS_OP_N,
+                                     CUBLAS_OP_N,
+                                     head_size,
+                                     sequence_length,
+                                     sequence_length,
+                                     alpha,
+                                     v,
+                                     Atype,
+                                     head_size,
+                                     sequence_length * head_size,
+                                     softmax_out,
+                                     Btype,
+                                     sequence_length,
+                                     sequence_length * sequence_length,
+                                     beta_0,
+                                     output,
+                                     Ctype,
+                                     head_size,
+                                     sequence_length * head_size,
+                                     batch_size * num_heads,
+                                     resultType,
+                                     algo));
+  } else {  // sequence_length > 2 * w
+    for (int i = 0; i < batch_size; ++i) {
+      for (int j = 0; j < num_heads; ++j) {
+        void* v_head = (char*)v + (i * x_offset + j * head_size * sequence_length) * element_size;
+        void* prob_head = (char*)softmax_out + (i * y_offset + j * sequence_length * sequence_length + w * sequence_length) * element_size;
+        void* out_head = (char*)output + (i * x_offset + j * head_size * sequence_length + w * head_size) * element_size;
+        int count = (sequence_length - 2 * w) / w;
+        CHECK(cublasGemmStridedBatchedEx(cublas,
+                                         CUBLAS_OP_N,
+                                         CUBLAS_OP_N,
+                                         head_size,
+                                         w,
+                                         3 * w,
+                                         alpha,
+                                         v_head,
+                                         Atype,
+                                         head_size,
+                                         w * head_size,
+                                         prob_head,
+                                         Btype,
+                                         sequence_length,
+                                         sequence_length * w + w,
+                                         beta_0,
+                                         out_head,
+                                         Ctype,
+                                         head_size,
+                                         w * head_size,
+                                         count,
+                                         resultType,
+                                         algo));
+      }
+    }
+
+    CHECK(cublasGemmStridedBatchedEx(cublas,
+                                     CUBLAS_OP_N,
+                                     CUBLAS_OP_N,
+                                     head_size,
+                                     w,
+                                     2 * w,
+                                     alpha,
+                                     v,
+                                     Atype,
+                                     head_size,
+                                     sequence_length * head_size,
+                                     softmax_out,
+                                     Btype,
+                                     sequence_length,
+                                     sequence_length * sequence_length,
+                                     beta_0,
+                                     output,
+                                     Ctype,
+                                     head_size,
+                                     sequence_length * head_size,
+                                     batch_size * num_heads,
+                                     resultType,
+                                     algo));
+
+    void* v_head = (char*)v + (last_block - 1) * w * head_size * element_size;
+    void* prob_head = (char*)softmax_out + (sequence_length * last_block * w + (last_block - 1) * w) * element_size;
+    void* out_head = (char*)output + last_block * w * head_size * element_size;
+
+    CHECK(cublasGemmStridedBatchedEx(cublas,
+                                     CUBLAS_OP_N,
+                                     CUBLAS_OP_N,
+                                     head_size,
+                                     w,
+                                     2 * w,
+                                     alpha,
+                                     v_head,
+                                     Atype,
+                                     head_size,
+                                     sequence_length * head_size,
+                                     prob_head,
+                                     Btype,
+                                     sequence_length,
+                                     sequence_length * sequence_length,
+                                     beta_0,
+                                     out_head,
+                                     Ctype,
+                                     head_size,
+                                     sequence_length * head_size,
+                                     batch_size * num_heads,
+                                     resultType,
+                                     algo));
+  }
+
+  for (int i = 0; i < batch_size; ++i) {
+    if (batch_global_count[i] > 0) {
+      int glob_longdim_mm = (last_block - 1) * w;
+
+      void* v_head = (char*)v + (i * x_offset) * element_size;
+      void* prob_head = (char*)softmax_out + (i * y_offset + 2 * w * sequence_length) * element_size;
+      void* out_head = (char*)output + (i * x_offset + 2 * w * head_size) * element_size;
+
+      CHECK(cublasGemmStridedBatchedEx(cublas,
+                                       CUBLAS_OP_N,
+                                       CUBLAS_OP_N,
+                                       head_size,
+                                       glob_longdim_mm,
+                                       batch_global_count[i],
+                                       alpha,
+                                       v_head,
+                                       Atype,
+                                       head_size,
+                                       sequence_length * head_size,
+                                       prob_head,
+                                       Btype,
+                                       sequence_length,
+                                       sequence_length * sequence_length,
+                                       beta_1,
+                                       out_head,
+                                       Ctype,
+                                       head_size,
+                                       sequence_length * head_size,
+                                       num_heads,
+                                       resultType,
+                                       algo));
+
+      // Global tokens
+      v_head = (char*)global_v + (i * x_offset) * element_size;
+      prob_head = (char*)softmax_out + (i * y_offset) * element_size;
+      out_head = (char*)output + (i * x_offset) * element_size;
+
+      CHECK(cublasGemmStridedBatchedEx(cublas,
+                                       CUBLAS_OP_N,
+                                       CUBLAS_OP_N,
+                                       head_size,
+                                       batch_global_count[i],
+                                       sequence_length,  // Re-write entries completely
+                                       alpha,
+                                       v_head,
+                                       Atype,
+                                       head_size,
+                                       sequence_length * head_size,
+                                       prob_head,
+                                       Btype,
+                                       sequence_length,
+                                       sequence_length * sequence_length,
+                                       beta_0,    // Use beta=0 to overwrite
+                                       out_head,  // Here assumes global tokens are at the beginning of sequence.
+                                       Ctype,
+                                       head_size,
+                                       sequence_length * head_size,
+                                       num_heads,
+                                       resultType,
+                                       algo));
+    }
+  }
+
+  return true;
+}
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention_softmax.h
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention_softmax.h
@@ -1,0 +1,51 @@
+/*
+Copyright (c) NVIDIA Corporation and Microsoft Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is cuda kernels for longformer attention. It stores two matrix of
+// It uses more memory but it is faster.
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+// Launch the softmax kernel for non compact memory.
+bool launchSoftmaxFastKernel(
+    cudaStream_t stream,
+    cublasHandle_t cublas,
+    void* workspace,              // softmax space
+    const void* q,                // transposed Q with shape (B, N, S, H)
+    const void* k,                // transposed K with shape (B, N, S, H)
+    const void* v,                // transposed V with shape (B, N, S, H)
+    const void* attention_mask,   // attention mask with shape (B, S), with value 0.0 not masked, and -10000.0 masked.
+    const void* global_q,         // Q for global tokens with shape (B, N, S, H)
+    const void* global_k,         // K for global tokens with shape (B, N, S, H)
+    const void* global_v,         // V for global tokens with shape (B, N, S, H)
+    const int* global_attention,  // global attention with shape (B, S), with value 0 for local attention and 1 for global attention.
+    const int* global_index,      // Global index with shape (B, S)
+    const int* batch_global_num,  // Number of global tokens per batch with shape (B, 1)
+    void* pinned_buffer,          // Pinned memory in CPU. Number of global tokens per batch with shape (B, 1)
+    void* output,                 // output with shape (B, N, S, H)
+    float scaler,                 // scalar
+    int batch_size,               // batch size
+    int sequence_length,          // sequence length
+    int num_heads,                // number of heads
+    int head_size,                // hidden size per head
+    int attention_window,         // one sided windows size
+    size_t element_size);
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention_softmax.h
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention_softmax.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This is cuda kernels for longformer attention. It stores two matrix of
-// It uses more memory but it is faster.
+// This is fast cuda kernels for longformer attention softmax.
+// It uses two temporary matrix of BxNxSxS, and consumes more memory when sequence length is large.
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/python/tools/transformers/benchmark_helper.py
+++ b/onnxruntime/python/tools/transformers/benchmark_helper.py
@@ -235,3 +235,85 @@ def allocateOutputBuffers(output_buffers, output_buffer_max_sizes, device):
 
     for i in output_buffer_max_sizes:
         output_buffers.append(torch.empty(i, dtype=torch.float32, device=device))
+
+
+def set_random_seed(seed=123):
+    """Set random seed manully to get deterministic results"""
+    import random
+    random.seed(seed)
+    numpy.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    #torch.backends.cudnn.enabled = False
+    #torch.backends.cudnn.benchmark = False
+    #torch.backends.cudnn.deterministic = True
+
+
+def measure_memory(is_gpu, func):
+    import os
+    import psutil
+    from time import sleep
+
+    class MemoryMonitor:
+        def __init__(self, keep_measuring=True):
+            self.keep_measuring = keep_measuring
+
+        def measure_cpu_usage(self):
+            max_usage = 0
+            while True:
+                max_usage = max(max_usage, psutil.Process(os.getpid()).memory_info().rss / 1024**2)
+                sleep(0.005)  # 5ms
+                if not self.keep_measuring:
+                    break
+            return max_usage
+
+        def measure_gpu_usage(self):
+            from py3nvml.py3nvml import nvmlInit, nvmlDeviceGetCount, nvmlDeviceGetHandleByIndex, \
+                                 nvmlDeviceGetMemoryInfo, nvmlDeviceGetName, nvmlShutdown, NVMLError
+            max_gpu_usage = []
+            gpu_name = []
+            try:
+                nvmlInit()
+                deviceCount = nvmlDeviceGetCount()
+                max_gpu_usage = [0 for i in range(deviceCount)]
+                gpu_name = [nvmlDeviceGetName(nvmlDeviceGetHandleByIndex(i)) for i in range(deviceCount)]
+                while True:
+                    for i in range(deviceCount):
+                        info = nvmlDeviceGetMemoryInfo(nvmlDeviceGetHandleByIndex(i))
+                        max_gpu_usage[i] = max(max_gpu_usage[i], info.used / 1024**2)
+                    sleep(0.005)  # 5ms
+                    if not self.keep_measuring:
+                        break
+                nvmlShutdown()
+                return [{
+                    "device_id": i,
+                    "name": gpu_name[i],
+                    "max_used_MB": max_gpu_usage[i]
+                } for i in range(deviceCount)]
+            except NVMLError as error:
+                if not self.silent:
+                    self.logger.error("Error fetching GPU information using nvml: %s", error)
+                return None
+
+    monitor = MemoryMonitor(False)
+    if is_gpu:
+        print(f"GPU memory usage before testing: {monitor.measure_gpu_usage()}")
+    else:
+        print(f"Peak CPU memory usage before testing: {monitor.measure_cpu_usage():.2f} MB")
+
+    from concurrent.futures import ThreadPoolExecutor
+    with ThreadPoolExecutor() as executor:
+        monitor = MemoryMonitor()
+        mem_thread = executor.submit(monitor.measure_gpu_usage if is_gpu else monitor.measure_cpu_usage)
+        try:
+            fn_thread = executor.submit(func)
+            result = fn_thread.result()
+        finally:
+            monitor.keep_measuring = False
+            max_usage = mem_thread.result()
+        if is_gpu:
+            print(f"Peak GPU memory usage: {max_usage}")
+        else:
+            print(f"Peak CPU memory usage: {max_usage:.2f} MB")
+        return max_usage

--- a/onnxruntime/python/tools/transformers/longformer/__init__.py
+++ b/onnxruntime/python/tools/transformers/longformer/__init__.py
@@ -1,3 +1,9 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
 import os
 import sys
 

--- a/onnxruntime/python/tools/transformers/longformer/benchmark_longformer.py
+++ b/onnxruntime/python/tools/transformers/longformer/benchmark_longformer.py
@@ -1,4 +1,11 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+#
 # This script run benchmark of latency or peak memory usage of Longformer model inference.
+#
 # Please run convert_longformer_to_onnx.py to get onnx model before running this script.
 # Tested with python 3.6, onnxruntime-gpu 1.7.0, PyTorch 1.7.1, transformers 4.3.2, CUDA 10.2.
 #

--- a/onnxruntime/python/tools/transformers/longformer/convert_longformer_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/longformer/convert_longformer_to_onnx.py
@@ -1,3 +1,12 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+# This script converts Longformer model from huggingface transformers 4.0 or later to ONNX.
+# Unlike normal ONNX model exporting, it will directly translate LongformerSelfAttention to the LongformerAttention operator in ONNX Runtime.
+#
 # Before running this script, please run "python setup.py install" in ../torch_extensions under Linux with PyTorch installed.
 # Then you can update the path of longformer_attention.cpython-*.so and run this script in same environment.
 #

--- a/onnxruntime/python/tools/transformers/longformer/convert_longformer_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/longformer/convert_longformer_to_onnx.py
@@ -1,9 +1,10 @@
-# Before running this script, please run "python setup.py install" in ../torch_extensions to build longformer_attention.cpp
-# under a python environment with PyTorch installed. Then you can update the path of longformer_attention.cpython-*.so
-# and run this script in same environment.
-# Tested in Ubuntu 18.04, python 3.6, PyTorch 1.7.1, transformers 4.3.0.
-# GPU is not needed for this script. You can run it in CPU.
-# For inference of the onnx model, you will need latest onnxruntime-gpu 1.7.0 or above.
+# Before running this script, please run "python setup.py install" in ../torch_extensions under Linux with PyTorch installed.
+# Then you can update the path of longformer_attention.cpython-*.so and run this script in same environment.
+#
+# It is tested in Ubuntu 18.04, python 3.6, PyTorch 1.7.1, transformers 4.3.0 or 4.3.2.
+# GPU is not needed for this script. You can run it in CPU. For --optimize_onnx, you can use either onnxruntime or onnxruntime-gpu package.
+#
+# For inference of the onnx model, you will need onnxruntime-gpu 1.7.0 or above.
 
 import torch
 import numpy as np
@@ -12,6 +13,8 @@ import transformers
 from torch.onnx import register_custom_op_symbolic
 from torch.onnx.symbolic_helper import parse_args
 from packaging import version
+
+from longformer_helper import LongformerHelper, PRETRAINED_LONGFORMER_MODELS
 
 
 @parse_args('v', 'v', 'v', 'v', 'v', 'v', 'v', 'i', 'i')
@@ -31,17 +34,9 @@ def my_longformer_attention(g, input, weight, bias, mask, global_weight, global_
 # namespace is onnxruntime which is registered in longformer_attention.cpp
 register_custom_op_symbolic('onnxruntime::LongformerAttention', my_longformer_attention, 9)
 
-# TODO: update the path according to output of "python setup.py install" when your python version is not 3.6
+# TODO: search the directory to find correct output filename of "python setup.py install" when python version is not 3.6
 torch.ops.load_library(
     r'../torch_extensions/build/lib.linux-x86_64-3.6/longformer_attention.cpython-36m-x86_64-linux-gnu.so')
-
-# mapping from model name to pretrained model name
-MODELS = {
-    "longformer-base-4096": "allenai/longformer-base-4096",
-    "longformer-random-tiny": "patrickvonplaten/longformer-random-tiny"  # A tiny model for debugging
-}
-
-is_debug = False
 
 
 def parse_arguments():
@@ -51,21 +46,24 @@ def parse_arguments():
                         "--model",
                         required=False,
                         type=str,
-                        default="longformer-random-tiny" if is_debug else "longformer-base-4096",
-                        choices=list(MODELS.keys()),
-                        help="Pre-trained models in the list: " + ", ".join(MODELS.keys()))
+                        default="longformer-base-4096",
+                        help="Checkpoint directory or pre-trained model names in the list: " +
+                        ", ".join(PRETRAINED_LONGFORMER_MODELS.keys()))
 
-    # Sequence length shall choose properly.
-    # If multiple of windows size is used, there is no padding in ONNX model so you will need padding by yourself before running onnx model.
-    parser.add_argument("-s", "--sequence_length", type=int, default=4 if is_debug else 512)
-
-    parser.add_argument("-g", "--global_length", type=int, default=1 if is_debug else 8)
+    parser.add_argument(
+        '--export_padding',
+        required=False,
+        action='store_true',
+        help=
+        'Export padding logic to ONNX graph. If not enabled, user need pad input so that sequence length is multiple of window size.'
+    )
+    parser.set_defaults(export_padding=False)
 
     parser.add_argument('-o',
                         '--optimize_onnx',
                         required=False,
                         action='store_true',
-                        help='Use optimizer.py to optimize onnx model')
+                        help='Use optimizer.py to optimize onnx model.')
     parser.set_defaults(optimize_onnx=False)
 
     parser.add_argument("-p",
@@ -80,36 +78,77 @@ def parse_arguments():
     return args
 
 
-def get_dummy_inputs(sequence_length, num_global_tokens, device):
+# Create a dummy input for ONNX export.
+def get_dummy_inputs(config, export_padding, device):
+
+    # When sequence length is multiple of windows size, there is no padding logic in ONNX graph
+    sequence_length = config.attention_window[0] + 1 if export_padding else config.attention_window[0]
+
     # Create dummy inputs
     input_ids = torch.arange(sequence_length).unsqueeze(0).to(device)
-    attention_mask = torch.ones(input_ids.shape, dtype=torch.long,
-                                device=input_ids.device)  # TODO: use random word ID. #TODO: simulate masked word
-    global_attention_mask = torch.zeros(input_ids.shape, dtype=torch.long, device=input_ids.device)
-    if num_global_tokens > 0:
-        global_token_index = list(range(num_global_tokens))
-        global_attention_mask[:, global_token_index] = 1
-    # TODO: support more inputs like token_type_ids, position_ids
+
+    attention_mask = torch.ones(input_ids.shape, dtype=torch.long, device=device)
+    attention_mask[:, sequence_length - 1] = 0  # last token is masked
+
+    global_attention_mask = torch.zeros(input_ids.shape, dtype=torch.long, device=device)
+    global_attention_mask[:, 0] = 1  # first token is global token
+
     return input_ids, attention_mask, global_attention_mask
 
 
-args = parse_arguments()
-
-model_name = args.model
-onnx_model_path = model_name + ".onnx"
-
-from transformers import LongformerModel
-model = LongformerModel.from_pretrained(MODELS[model_name])  # pretrained model name or directory
-
-input_ids, attention_mask, global_attention_mask = get_dummy_inputs(sequence_length=args.sequence_length,
-                                                                    num_global_tokens=args.global_length,
-                                                                    device=torch.device('cpu'))
-
-example_outputs = model(input_ids, attention_mask=attention_mask, global_attention_mask=global_attention_mask)
-
-
 # A new function to replace LongformerSelfAttention.forward
-#For transformer 4.3
+# For transformers 4.0.0
+def my_longformer_self_attention_forward_4(self,
+                                           hidden_states,
+                                           attention_mask=None,
+                                           is_index_masked=None,
+                                           is_index_global_attn=None,
+                                           is_global_attn=None):
+    global_mask = is_index_global_attn.int()
+    # The following check is based on the dummy inputs (only the first token is global).
+    assert len(global_mask.shape) == 2 and global_mask.shape[0] == 1 and global_mask.count_nonzero().item(
+    ) == 1 and global_mask.tolist()[0][0] == 1
+
+    input_mask = is_index_masked.float()
+    input_mask = input_mask.masked_fill(is_index_masked, -10000.0)
+    # Yet another way to generate input_mask = torch.masked_fill(attention_mask, is_index_global_attn, 0.0)
+
+    # TODO: add postprocess of ONNX model to calculate based on graph input: input_mask = (attention_mask - 1) * 10000.0
+    # TODO: add postprocess of ONNX model to use graph input directly: glboal_mask = global_attention_mask
+
+    # The following check is based on the dummy inputs (only the last token is masked).
+    assert len(input_mask.shape) == 2 and input_mask.shape[0] == 1 and input_mask.count_nonzero().item(
+    ) == 1 and input_mask.tolist()[0][-1] == -10000.0
+
+    weight = torch.stack(
+        (self.query.weight.transpose(0, 1), \
+         self.key.weight.transpose(0, 1), \
+         self.value.weight.transpose(0, 1)), dim=1)
+    weight = weight.reshape(self.embed_dim, 3 * self.embed_dim)
+
+    bias = torch.stack((self.query.bias, self.key.bias, self.value.bias), dim=0)
+    bias = bias.reshape(3 * self.embed_dim)
+
+    global_weight = torch.stack((self.query_global.weight.transpose(0, 1), \
+                                 self.key_global.weight.transpose(0, 1), \
+                                 self.value_global.weight.transpose(0, 1)),
+                                dim=1)
+    global_weight = global_weight.reshape(self.embed_dim, 3 * self.embed_dim)
+
+    global_bias = torch.stack((self.query_global.bias, self.key_global.bias, self.value_global.bias), dim=0)
+    global_bias = global_bias.reshape(3 * self.embed_dim)
+
+    attn_output = torch.ops.onnxruntime.LongformerAttention(hidden_states, weight, bias, input_mask, global_weight,
+                                                            global_bias, global_mask, self.num_heads,
+                                                            self.one_sided_attn_window_size)
+
+    assert attn_output.size() == hidden_states.size(), "Unexpected size"
+
+    outputs = (attn_output, )
+    return outputs
+
+
+# For transformers 4.3.0
 def my_longformer_self_attention_forward_4_3(self,
                                              hidden_states,
                                              attention_mask=None,
@@ -117,190 +156,135 @@ def my_longformer_self_attention_forward_4_3(self,
                                              is_index_global_attn=None,
                                              is_global_attn=None,
                                              output_attentions=False):
-    # TODO: move mask calculation to LongFormerModel class to avoid calculating it again and again in each layer.
-    global_mask = is_index_global_attn.int()
-    torch.masked_fill(attention_mask, is_index_global_attn, 0.0)
-
-    weight = torch.stack(
-        (self.query.weight.transpose(0, 1), self.key.weight.transpose(0, 1), self.value.weight.transpose(0, 1)), dim=1)
-    weight = weight.reshape(self.embed_dim, 3 * self.embed_dim)
-
-    bias = torch.stack((self.query.bias, self.key.bias, self.value.bias), dim=0)
-    bias = bias.reshape(3 * self.embed_dim)
-
-    global_weight = torch.stack((self.query_global.weight.transpose(0, 1), self.key_global.weight.transpose(
-        0, 1), self.value_global.weight.transpose(0, 1)),
-                                dim=1)
-    global_weight = global_weight.reshape(self.embed_dim, 3 * self.embed_dim)
-
-    global_bias = torch.stack((self.query_global.bias, self.key_global.bias, self.value_global.bias), dim=0)
-    global_bias = global_bias.reshape(3 * self.embed_dim)
-
-    attn_output = torch.ops.onnxruntime.LongformerAttention(hidden_states, weight, bias, attention_mask, global_weight,
-                                                            global_bias, global_mask, self.num_heads,
-                                                            self.one_sided_attn_window_size)
-
-    assert attn_output.size() == hidden_states.size(), "Unexpected size"
-
-    outputs = (attn_output, )
-    return outputs
+    assert output_attentions == False
+    return my_longformer_self_attention_forward_4(self, hidden_states, attention_mask, is_index_masked,
+                                                  is_index_global_attn, is_global_attn)
 
 
-#For transformers 4.0
-def my_longformer_self_attention_forward_4(self,
-                                           hidden_states,
-                                           attention_mask=None,
-                                           is_index_masked=None,
-                                           is_index_global_attn=None,
-                                           is_global_attn=None):
-    # TODO: move mask calculation to LongFormerModel class to avoid calculating it again and again in each layer.
-    global_mask = is_index_global_attn.int()
-    torch.masked_fill(attention_mask, is_index_global_attn, 0.0)
-
-    weight = torch.stack(
-        (self.query.weight.transpose(0, 1), self.key.weight.transpose(0, 1), self.value.weight.transpose(0, 1)), dim=1)
-    weight = weight.reshape(self.embed_dim, 3 * self.embed_dim)
-
-    bias = torch.stack((self.query.bias, self.key.bias, self.value.bias), dim=0)
-    bias = bias.reshape(3 * self.embed_dim)
-
-    global_weight = torch.stack((self.query_global.weight.transpose(0, 1), self.key_global.weight.transpose(
-        0, 1), self.value_global.weight.transpose(0, 1)),
-                                dim=1)
-    global_weight = global_weight.reshape(self.embed_dim, 3 * self.embed_dim)
-
-    global_bias = torch.stack((self.query_global.bias, self.key_global.bias, self.value_global.bias), dim=0)
-    global_bias = global_bias.reshape(3 * self.embed_dim)
-
-    attn_output = torch.ops.onnxruntime.LongformerAttention(hidden_states, weight, bias, attention_mask, global_weight,
-                                                            global_bias, global_mask, self.num_heads,
-                                                            self.one_sided_attn_window_size)
-
-    assert attn_output.size() == hidden_states.size(), "Unexpected size"
-
-    outputs = (attn_output, )
-    return outputs
+# For transformers 4.3.2
+def my_longformer_self_attention_forward_4_3_2(self,
+                                               hidden_states,
+                                               attention_mask=None,
+                                               layer_head_mask=None,
+                                               is_index_masked=None,
+                                               is_index_global_attn=None,
+                                               is_global_attn=None,
+                                               output_attentions=False):
+    assert output_attentions == False
+    assert layer_head_mask is None
+    return my_longformer_self_attention_forward_4(self, hidden_states, attention_mask, is_index_masked,
+                                                  is_index_global_attn, is_global_attn)
 
 
-# For transformers 3.0
-def my_longformer_attention_forward_3(self, hidden_states, attention_mask, output_attentions=False):
+def export_longformer(model, onnx_model_path, export_padding):
+    input_ids, attention_mask, global_attention_mask = get_dummy_inputs(model.config,
+                                                                        export_padding,
+                                                                        device=torch.device('cpu'))
 
-    assert output_attentions is False
+    example_outputs = model(input_ids, attention_mask=attention_mask, global_attention_mask=global_attention_mask)
 
-    # TODO: attention_mask can directly be passed from inputs of model to avoid these processing.
-    attention_mask = attention_mask.squeeze(dim=2).squeeze(dim=1)
-    global_mask = (attention_mask > 0).int()
-    torch.masked_fill(attention_mask, attention_mask > 0, 0.0)
+    if version.parse(transformers.__version__) < version.parse("4.0.0"):
+        raise RuntimeError("This tool requires transformers 4.0.0 or later.")
 
-    weight = torch.stack(
-        (self.query.weight.transpose(0, 1), self.key.weight.transpose(0, 1), self.value.weight.transpose(0, 1)), dim=1)
-    weight = weight.reshape(self.embed_dim, 3 * self.embed_dim)
+    # Here we replace LongformerSelfAttention.forward using our implmentation for exporting ONNX model
+    from transformers import LongformerSelfAttention
+    import inspect
+    key = ' '.join(inspect.getfullargspec(LongformerSelfAttention.forward).args)
+    args_to_func = {
+        'self hidden_states attention_mask layer_head_mask is_index_masked is_index_global_attn is_global_attn output_attentions':
+        my_longformer_self_attention_forward_4_3_2,
+        'self hidden_states attention_mask is_index_masked is_index_global_attn is_global_attn output_attentions':
+        my_longformer_self_attention_forward_4_3,
+        'self hidden_states attention_mask is_index_masked is_index_global_attn is_global_attn':
+        my_longformer_self_attention_forward_4,
+    }
 
-    bias = torch.stack((self.query.bias, self.key.bias, self.value.bias), dim=0)
-    bias = bias.reshape(3 * self.embed_dim)
+    if key not in args_to_func:
+        print("Current arguments", inspect.getfullargspec(LongformerSelfAttention.forward).args)
+        raise RuntimeError(
+            "LongformerSelfAttention.forward arguments are different. Please install supported version (like transformers 4.3.0)."
+        )
 
-    global_weight = torch.stack((self.query_global.weight.transpose(0, 1), self.key_global.weight.transpose(
-        0, 1), self.value_global.weight.transpose(0, 1)),
-                                dim=1)
-    global_weight = global_weight.reshape(self.embed_dim, 3 * self.embed_dim)
+    # Store for restoring later
+    original_forward = LongformerSelfAttention.forward
 
-    global_bias = torch.stack((self.query_global.bias, self.key_global.bias, self.value_global.bias), dim=0)
-    global_bias = global_bias.reshape(3 * self.embed_dim)
+    LongformerSelfAttention.forward = args_to_func[key]
 
-    attn_output = torch.ops.onnxruntime.LongformerAttention(hidden_states, weight, bias, attention_mask, global_weight,
-                                                            global_bias, global_mask, self.num_heads,
-                                                            self.one_sided_attn_window_size)
+    example_inputs = (input_ids, attention_mask, global_attention_mask)
 
-    assert attn_output.size() == hidden_states.size(), "Unexpected size"
+    Path(onnx_model_path).parent.mkdir(parents=True, exist_ok=True)
 
-    outputs = (attn_output, )
-    return outputs
-
-
-# Here we replace LongformerSelfAttention.forward using our implmentation for exporting ONNX model
-from transformers.modeling_longformer import LongformerSelfAttention
-key = ' '.join(inspect.getfullargspec(LongformerSelfAttention.forward).args)
-args_to_func = {
-    'self hidden_states attention_mask is_index_masked is_index_global_attn is_global_attn output_attentions':
-    my_longformer_self_attention_forward_4_3,
-    'self hidden_states attention_mask is_index_masked is_index_global_attn is_global_attn':
-    my_longformer_self_attention_forward_4,
-    'self hidden_states attention_mask output_attentions': my_longformer_self_attention_forward_3,
-}
-
-if key not in args_to_func:
-    raise RuntimeError(
-        "LongformerSelfAttention.forward arguments are different. Please install supported version (like 4.3.0) of transformers package."
-    )
-
-LongformerSelfAttention.forward = args_to_func[key]
-"""
-if version.parse(transformers.__version__) < version.parse("4.0.0"):
-    from transformers.modeling_longformer import LongformerSelfAttention
-    #original_forward = LongformerSelfAttention.forward
-    LongformerSelfAttention.forward = my_longformer_attention_forward_3
-else:
-    from transformers.models.longformer.modeling_longformer import LongformerSelfAttention
-    #original_forward = LongformerSelfAttention.forward
-    LongformerSelfAttention.forward = my_longformer_self_attention_forward_4
-"""
-
-# TODO: support more inputs like (input_ids, attention_mask, global_attention_mask, token_type_ids, position_ids)
-example_inputs = (input_ids, attention_mask, global_attention_mask)
-
-torch.onnx.export(model,
-                  example_inputs,
-                  onnx_model_path,
-                  opset_version=11,
-                  example_outputs=example_outputs,
-                  input_names=["input_ids", "attention_mask", "global_attention_mask"],
-                  output_names=["last_state", "pooler"],
-                  dynamic_axes={
-                      'input_ids': {
-                          0: 'batch_size',
-                          1: 'sequence_length'
+    torch.onnx.export(model,
+                      example_inputs,
+                      onnx_model_path,
+                      opset_version=11,
+                      example_outputs=example_outputs,
+                      input_names=["input_ids", "attention_mask", "global_attention_mask"],
+                      output_names=["last_state", "pooler"],
+                      dynamic_axes={
+                          'input_ids': {
+                              0: 'batch_size',
+                              1: 'sequence_length'
+                          },
+                          'attention_mask': {
+                              0: 'batch_size',
+                              1: 'sequence_length'
+                          },
+                          'global_attention_mask': {
+                              0: 'batch_size',
+                              1: 'sequence_length'
+                          },
+                          'last_state': {
+                              0: 'batch_size',
+                              1: 'sequence_length'
+                          },
+                          'pooler': {
+                              0: 'batch_size',
+                              1: 'sequence_length'
+                          }
                       },
-                      'attention_mask': {
-                          0: 'batch_size',
-                          1: 'sequence_length'
-                      },
-                      'global_attention_mask': {
-                          0: 'batch_size',
-                          1: 'sequence_length'
-                      },
-                      'last_state': {
-                          0: 'batch_size',
-                          1: 'sequence_length'
-                      },
-                      'pooler': {
-                          0: 'batch_size',
-                          1: 'sequence_length'
-                      }
-                  },
-                  custom_opsets={"com.microsoft": 1})
-print(f"ONNX model exported to {onnx_model_path}")
+                      custom_opsets={"com.microsoft": 1})
+    print(f"ONNX model exported to {onnx_model_path}")
 
-if args.sequence_length % model.config.attention_window[0] == 0:
-    print(
-        f"*Attention*: You need input padding for inference: input sequece length shall be multiple of {model.config.attention_window[0]}. It is because the example input for export ONNX model does not need padding so padding logic is not in onnx model."
-    )
+    # Restore original implementaiton:
+    LongformerSelfAttention.forward = original_forward
 
-# Restore Huggingface implementaiton like the following:
-# LongformerSelfAttention.forward = original_forward
 
-if args.precision != 'fp32' or args.optimize_onnx:
+def optimize_longformer(onnx_model_path, fp32_model_path, fp16_model_path=None):
     from onnx import load_model
     from onnxruntime.transformers.onnx_model_bert import BertOnnxModel, BertOptimizationOptions
     model = load_model(onnx_model_path, format=None, load_external_data=True)
     optimization_options = BertOptimizationOptions('bert')
-    optimizer = BertOnnxModel(model, num_heads=16, hidden_size=768)
+    optimizer = BertOnnxModel(model, num_heads=16,
+                              hidden_size=768)  # paramters does not matter since attention fusion is not needed.
     optimizer.optimize(optimization_options)
-    optimized_model_path = model_name + "_fp32.onnx"
-    optimizer.save_model_to_file(optimized_model_path)
-    print(f"optimized fp32 model saved to {optimized_model_path}")
 
-    if args.precision == 'fp16':
+    use_external_data_format = False
+    if fp32_model_path:
+        optimizer.save_model_to_file(fp32_model_path, use_external_data_format)
+        print(f"optimized fp32 model saved to {fp32_model_path}")
+
+    if fp16_model_path:
         optimizer.convert_model_float32_to_float16(cast_input_output=True)
-        optimized_model_path = model_name + "_fp16.onnx"
-        optimizer.save_model_to_file(optimized_model_path)
-        print(f"optimized fp16 model saved to {optimized_model_path}")
+        optimizer.save_model_to_file(fp16_model_path, use_external_data_format)
+        print(f"optimized fp16 model saved to {fp16_model_path}")
+
+
+def main(args):
+    model_name = args.model
+    onnx_model_path = model_name + ".onnx"
+
+    from transformers import LongformerModel
+    model = LongformerModel.from_pretrained(PRETRAINED_LONGFORMER_MODELS[model_name])
+
+    export_longformer(model, onnx_model_path, args.export_padding)
+
+    if args.optimize_onnx or args.precision != 'fp32':
+        fp32_model_path = model_name + "_fp32.onnx"
+        fp16_model_path = model_name + "_fp16.onnx" if args.precision == 'fp16' else None
+        optimize_longformer(onnx_model_path, fp32_model_path, fp16_model_path)
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    main(args)

--- a/onnxruntime/python/tools/transformers/longformer/longformer_helper.py
+++ b/onnxruntime/python/tools/transformers/longformer/longformer_helper.py
@@ -3,7 +3,8 @@
 # Licensed under the MIT License.  See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-# This script helps onnx conversion and validation for GPT2 model with past state.
+# This script helps creating dummy inputs for Longformer model.
+
 import os
 import logging
 import torch

--- a/onnxruntime/python/tools/transformers/longformer/longformer_helper.py
+++ b/onnxruntime/python/tools/transformers/longformer/longformer_helper.py
@@ -1,0 +1,75 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+# This script helps onnx conversion and validation for GPT2 model with past state.
+import os
+import logging
+import torch
+import onnx
+import random
+import numpy
+import time
+import re
+from pathlib import Path
+from typing import List, Dict, Tuple, Union
+
+logger = logging.getLogger(__name__)
+
+PRETRAINED_LONGFORMER_MODELS = {
+    "longformer-base-4096": "allenai/longformer-base-4096",
+    "longformer-large-4096": "allenai/longformer-large-4096",
+    "longformer-random-tiny": "patrickvonplaten/longformer-random-tiny"  # A tiny model for debugging
+}
+
+
+class LongformerInputs:
+    def __init__(self, input_ids, attention_mask, global_attention_mask):
+        self.input_ids: torch.LongTensor = input_ids
+        self.attention_mask: Union[torch.FloatTensor, torch.HalfTensor] = attention_mask
+        self.global_attention_mask: Union[torch.FloatTensor, torch.HalfTensor] = global_attention_mask
+
+    def to_list(self) -> List:
+        return [v for v in [self.input_ids, self.attention_mask, self.global_attention_mask] if v is not None]
+
+    def to_tuple(self) -> Tuple:
+        return tuple(v for v in self.to_list())
+
+    def get_ort_inputs(self) -> Dict:
+        return {
+            "input_ids": numpy.ascontiguousarray(self.input_ids.cpu().numpy()),
+            "attention_mask": numpy.ascontiguousarray(self.attention_mask.cpu().numpy()),
+            "global_attention_mask": numpy.ascontiguousarray(self.global_attention_mask.cpu().numpy()),
+        }
+
+
+class LongformerHelper:
+    """ A helper class for Longformer model conversion, inference and verification.
+    """
+    @staticmethod
+    def get_dummy_inputs(batch_size: int,
+                         sequence_length: int,
+                         num_global_tokens: int,
+                         device: torch.device,
+                         vocab_size: int = 100) -> LongformerInputs:
+        """ Create random inputs for Longformer model.
+        Returns torch tensors of input_ids, attention_mask and global_attention_mask tensors.
+        """
+
+        input_ids = torch.randint(low=0,
+                                  high=vocab_size - 1,
+                                  size=(batch_size, sequence_length),
+                                  dtype=torch.long,
+                                  device=device)
+        attention_mask = torch.ones(input_ids.shape, dtype=torch.long, device=device)
+        global_attention_mask = torch.zeros(input_ids.shape, dtype=torch.long, device=device)
+        global_token_index = list(range(num_global_tokens))
+        global_attention_mask[:, global_token_index] = 1
+        return LongformerInputs(input_ids, attention_mask, global_attention_mask)
+
+    @staticmethod
+    def get_output_shapes(batch_size: int, sequence_length: int, hidden_size: int) -> Dict[str, List[int]]:
+        """ Returns a dictionary with output name as key, and shape as value.
+        """
+        return {"last_state": [batch_size, sequence_length, hidden_size], "pooler": [batch_size, sequence_length]}

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -410,7 +410,7 @@ class OnnxModel:
         from packaging.version import Version
         import onnxconverter_common as oc
         if Version(oc.__version__) > Version("1.7.0"):
-            self.model = oc.float16.convert_float_to_float16(self.model, keep_io_types=cast_input_output)
+            self.model = oc.float16.convert_float_to_float16(self.model, keep_io_types=not cast_input_output)
             return
 
         graph = self.model.graph

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -405,12 +405,15 @@ class OnnxModel:
         self.model.opset_import[0].version = original_opset_version
 
     def convert_model_float32_to_float16(self, cast_input_output=True):
-        """ Convert a graph to FLOAT16
+        """Convert a graph to FLOAT16. By default, we will keep data types of inputs and outputs.
+           For decoder model with past_key_values, it is recommended to set cast_input_output=False for better performance.
+        Args:
+            cast_input_output (bool, optional): keep data type of inputs and outputs, and add Cast nodes to convert float32 inputs to float16, and float16 to float32 for outputs. Defaults to True.
         """
         from packaging.version import Version
         import onnxconverter_common as oc
         if Version(oc.__version__) > Version("1.7.0"):
-            self.model = oc.float16.convert_float_to_float16(self.model, keep_io_types=not cast_input_output)
+            self.model = oc.float16.convert_float_to_float16(self.model, keep_io_types=cast_input_output)
             return
 
         graph = self.model.graph

--- a/tools/ci_build/amd_hipify.py
+++ b/tools/ci_build/amd_hipify.py
@@ -26,6 +26,8 @@ contrib_ops_excluded_files = [
                     'bert/layer_norm.cuh',
                     'bert/longformer_attention.cc',
                     'bert/longformer_attention.h',
+                    'bert/longformer_attention_softmax.cu',
+                    'bert/longformer_attention_softmax.h',
                     'bert/longformer_attention_impl.cu',
                     'bert/longformer_attention_impl.h',
                     'bert/longformer_global_impl.cu',


### PR DESCRIPTION
**Description**: 

(1) Restore original CUDA kernel as default, and add an environment variable to enable new CUDA kernel when memory is a concern.
(2) Update convert_longformer_to_onnx: support  transformers 4.3.2, where an extra parameter is added to LongformerSelfAttention.forward; add an option --export_padding so that user could choose whether to have padding logic in ONNX model.
(3) Improve benchmark_longformer tool: add memory measurement

To use new kernel, set environment variable ORT_LONGFORMER_COMPACT_MEMORY=1. Note that when sequence_length <= 2 * attention_window or global_tokens > attention_window, we will use fast kernel and ignore the environment variable. This is for experimental purpose, and the environment variable might be removed in the future.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

Walk around a few issues in https://github.com/microsoft/onnxruntime/pull/6646:
(1) The result is different with huggingface transformers when sequence_length == 2 * attention_window.
(2) Kernel using compact memory is slower
(3) There is additional constraint that number of global tokens <= attention_window.