### PR TITLE
[CoreML EP] Add options to enable CoreML EP only on hardware with Apple Neural Engine

### DIFF
--- a/include/onnxruntime/core/providers/coreml/coreml_provider_factory.h
+++ b/include/onnxruntime/core/providers/coreml/coreml_provider_factory.h
@@ -19,9 +19,14 @@ enum COREMLFlags {
   // Enable CoreML EP on subgraph
   COREML_FLAG_ENABLE_ON_SUBGRAPH = 0x002,
 
+  // By default CoreML Execution provider will be enabled for all compatible Apple devices
+  // Enable this option will only enable CoreML EP for Apple devices with ANE (Apple Neural Engine)
+  // Please note, enable this option does not guarantee the entire model to be executed using ANE only
+  COREML_FLAG_ONLY_ENABLE_DEVICE_WITH_ANE = 0x004,
+
   // Keep COREML_FLAG_MAX at the end of the enum definition
   // And assign the last COREMLFlag to it
-  COREML_FLAG_LAST = COREML_FLAG_ENABLE_ON_SUBGRAPH,
+  COREML_FLAG_LAST = COREML_FLAG_ONLY_ENABLE_DEVICE_WITH_ANE,
 };
 
 #ifdef __cplusplus

--- a/onnxruntime/core/providers/coreml/builders/helper.cc
+++ b/onnxruntime/core/providers/coreml/builders/helper.cc
@@ -142,10 +142,11 @@ bool HasNeuralEngine(const logging::Logger& logger) {
   // A12: iPhone XS (11,2), iPad Mini - 5th Gen (11,1)
   // A12X: iPad Pro - 3rd Gen (8,1)
   // For more information, see https://www.theiphonewiki.com/wiki/Models
-  if (strncmp("iPad", system_info.machine, 4) == 0) {
+  size_t str_len = strlen(system_info.machine);
+  if (str_len > 4 && strncmp("iPad", system_info.machine, 4) == 0) {
     const int major_version = atoi(system_info.machine + 4);
     has_neural_engine = major_version >= 8;  // There are no device between iPad 8 and 11.
-  } else if (strncmp("iPhone", system_info.machine, 6) == 0) {
+  } else if (str_len > 6 && strncmp("iPhone", system_info.machine, 6) == 0) {
     const int major_version = atoi(system_info.machine + 6);
     has_neural_engine = major_version >= 11;
   }

--- a/onnxruntime/core/providers/coreml/builders/helper.cc
+++ b/onnxruntime/core/providers/coreml/builders/helper.cc
@@ -3,6 +3,11 @@
 
 #include <vector>
 
+#ifdef __APPLE__
+#include <sys/utsname.h>
+#include <TargetConditionals.h>
+#endif
+
 #include "helper.h"
 #include <core/graph/graph_viewer.h>
 
@@ -120,6 +125,42 @@ std::vector<std::vector<NodeIndex>> GetSupportedNodes(const GraphViewer& graph_v
   }
 
   return supported_node_vecs;
+}
+
+bool HasNeuralEngine(const logging::Logger& logger) {
+  bool has_neural_engine = false;
+
+#ifdef __APPLE__
+  struct utsname system_info;
+  uname(&system_info);
+  LOGS(logger, VERBOSE) << "Current Apple hardware info: " << system_info.machine;
+
+#if TARGET_OS_IPHONE
+  // utsname.machine has device identifier. For example, identifier for iPhone Xs is "iPhone11,2".
+  // Since Neural Engine is only available for use on A12 and later, major device version in the
+  // identifier is checked for these models:
+  // A12: iPhone XS (11,2), iPad Mini - 5th Gen (11,1)
+  // A12X: iPad Pro - 3rd Gen (8,1)
+  // For more information, see https://www.theiphonewiki.com/wiki/Models
+  if (strncmp("iPad", system_info.machine, 4) == 0) {
+    const int major_version = atoi(system_info.machine + 4);
+    has_neural_engine = major_version >= 8;  // There are no device between iPad 8 and 11.
+  } else if (strncmp("iPhone", system_info.machine, 6) == 0) {
+    const int major_version = atoi(system_info.machine + 6);
+    has_neural_engine = major_version >= 11;
+  }
+#elif TARGET_OS_OSX && TARGET_CPU_ARM64
+  // Only Mac with arm64 CPU (Apple Silicon) has ANE.
+  has_neural_engine = true;
+#endif  // #if TARGET_OS_IPHONE
+#else
+  // In this case, we are running the EP on non-apple platform, which means we are running the model
+  // conversion with CoreML EP enabled, for this we always assume the target system has Neural Engine
+  LOGS(logger, VERBOSE) << "HasNeuralEngine running on non-Apple hardware for model conversion only";
+  has_neural_engine = true;
+#endif  // #ifdef __APPLE__
+
+  return has_neural_engine;
 }
 
 }  // namespace coreml

--- a/onnxruntime/core/providers/coreml/builders/helper.h
+++ b/onnxruntime/core/providers/coreml/builders/helper.h
@@ -28,5 +28,9 @@ bool IsInputSupported(const NodeArg& node_arg, const std::string& parent_name, c
 std::vector<std::vector<NodeIndex>> GetSupportedNodes(const GraphViewer& graph_viewer,
                                                       const logging::Logger& logger);
 
+// CoreML is more efficient running using Apple Neural Engine
+// This is to detect if the current system has Apple Neural Engine
+bool HasNeuralEngine(const logging::Logger& logger);
+
 }  // namespace coreml
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/coreml/coreml_execution_provider.cc
+++ b/onnxruntime/core/providers/coreml/coreml_execution_provider.cc
@@ -67,6 +67,13 @@ CoreMLExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_vie
   */
 
   const auto& logger = *GetLogger();
+
+  bool has_neural_engine = coreml::HasNeuralEngine(logger);
+  if ((coreml_flags_ & COREML_FLAG_ONLY_ENABLE_DEVICE_WITH_ANE) && !has_neural_engine) {
+    LOGS(logger, VERBOSE) << "The current system does not have Apple Neural Engine";
+    return result;
+  }
+
   const auto node_groups = coreml::GetSupportedNodes(graph_viewer, logger);
 
   if (node_groups.empty()) {


### PR DESCRIPTION
**Description**: [CoreML EP] Add options to enable CoreML EP only on hardware with Apple Neural Engine

**Motivation and Context**
- CoreML is more efficient using ANE (Apple Neural Engine), add an option to run it using ANE only, by default CoreML EP will still run on all compatible devices.

