### PR TITLE
Support building python bindings when building unit tests is manually disabled.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1503,12 +1503,11 @@ if (onnxruntime_BUILD_NODEJS)
   include(onnxruntime_nodejs.cmake)
 endif()
 
-# some of the tests rely on the shared libs to be
-# built; hence the ordering
+if (onnxruntime_ENABLE_PYTHON)
+  include(onnxruntime_python.cmake)
+endif()
+
 if (onnxruntime_BUILD_UNIT_TESTS)
-  if (onnxruntime_ENABLE_PYTHON)
-    include(onnxruntime_python.cmake)
-  endif()
   include(onnxruntime_unittests.cmake)
 endif()
 

--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -262,7 +262,7 @@ file(GLOB onnxruntime_python_datasets_data CONFIGURE_DEPENDS
     "${ONNXRUNTIME_ROOT}/python/datasets/*.onnx"
 )
 
-set(build_output_target onnxruntime)
+set(build_output_target onnxruntime_common)
 
 add_custom_command(
   TARGET onnxruntime_pybind11_state POST_BUILD

--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -220,19 +220,22 @@ else()
   )
 endif()
 
-file(GLOB onnxruntime_python_test_srcs CONFIGURE_DEPENDS
-    "${ONNXRUNTIME_ROOT}/test/python/*.py"
-    "${ORTTRAINING_SOURCE_DIR}/test/python/*.py"
-)
-file(GLOB onnxruntime_python_quantization_test_srcs CONFIGURE_DEPENDS
-    "${ONNXRUNTIME_ROOT}/test/python/quantization/*.py"
-)
-file(GLOB onnxruntime_python_checkpoint_test_srcs CONFIGURE_DEPENDS
-    "${ORTTRAINING_SOURCE_DIR}/test/python/checkpoint/*.py"
-)
-file(GLOB onnxruntime_python_dhp_parallel_test_srcs CONFIGURE_DEPENDS
-    "${ORTTRAINING_SOURCE_DIR}/test/python/dhp_parallel/*.py"
-)
+if (onnxruntime_BUILD_UNIT_TESTS)
+  file(GLOB onnxruntime_python_test_srcs CONFIGURE_DEPENDS
+      "${ONNXRUNTIME_ROOT}/test/python/*.py"
+      "${ORTTRAINING_SOURCE_DIR}/test/python/*.py"
+  )
+  file(GLOB onnxruntime_python_quantization_test_srcs CONFIGURE_DEPENDS
+      "${ONNXRUNTIME_ROOT}/test/python/quantization/*.py"
+  )
+  file(GLOB onnxruntime_python_checkpoint_test_srcs CONFIGURE_DEPENDS
+      "${ORTTRAINING_SOURCE_DIR}/test/python/checkpoint/*.py"
+  )
+  file(GLOB onnxruntime_python_dhp_parallel_test_srcs CONFIGURE_DEPENDS
+      "${ORTTRAINING_SOURCE_DIR}/test/python/dhp_parallel/*.py"
+  )
+endif()
+
 file(GLOB onnxruntime_python_tools_srcs CONFIGURE_DEPENDS
     "${ONNXRUNTIME_ROOT}/python/tools/*.py"
 )
@@ -259,109 +262,115 @@ file(GLOB onnxruntime_python_datasets_data CONFIGURE_DEPENDS
     "${ONNXRUNTIME_ROOT}/python/datasets/*.onnx"
 )
 
-set(test_data_target onnxruntime_test_all)
+set(build_output_target onnxruntime)
 
 add_custom_command(
   TARGET onnxruntime_pybind11_state POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/backend
-  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/capi
-  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/capi/training
-  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/datasets
-  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/tools
-  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/tools/featurizer_ops
-  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/transformers
-  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/transformers/longformer
-  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/quantization
-  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/quantization/operators
-  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/checkpoint
-  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/dhp_parallel
-  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/quantization
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/backend
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/training
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/datasets
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/tools
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/tools/featurizer_ops
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/transformers
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/transformers/longformer
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/quantization
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/quantization/operators
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/checkpoint
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/dhp_parallel
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/quantization
   COMMAND ${CMAKE_COMMAND} -E copy
       ${ONNXRUNTIME_ROOT}/__init__.py
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${REPO_ROOT}/ThirdPartyNotices.txt
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${REPO_ROOT}/docs/Privacy.md
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${REPO_ROOT}/LICENSE
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/
-  COMMAND ${CMAKE_COMMAND} -E copy
-      ${onnxruntime_python_test_srcs}
-      $<TARGET_FILE_DIR:${test_data_target}>
-  COMMAND ${CMAKE_COMMAND} -E copy
-      ${onnxruntime_python_quantization_test_srcs}
-      $<TARGET_FILE_DIR:${test_data_target}>/quantization/
-  COMMAND ${CMAKE_COMMAND} -E copy
-      ${onnxruntime_python_checkpoint_test_srcs}
-      $<TARGET_FILE_DIR:${test_data_target}>/checkpoint/
-  COMMAND ${CMAKE_COMMAND} -E copy
-      ${onnxruntime_python_dhp_parallel_test_srcs}
-      $<TARGET_FILE_DIR:${test_data_target}>/dhp_parallel/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${onnxruntime_backend_srcs}
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/backend/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/backend/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${onnxruntime_python_srcs}
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/capi/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${onnxruntime_python_capi_training_srcs}
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/capi/training/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/training/
   COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_FILE:onnxruntime_pybind11_state>
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/capi/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${onnxruntime_python_datasets_srcs}
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/datasets/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/datasets/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${onnxruntime_python_datasets_data}
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/datasets/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/datasets/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${onnxruntime_python_tools_srcs}
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/tools/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/tools/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${onnxruntime_python_tools_featurizers_src}
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/tools/featurizer_ops/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/tools/featurizer_ops/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${onnxruntime_python_quantization_src}
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/quantization/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/quantization/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${onnxruntime_python_quantization_operators_src}
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/quantization/operators/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/quantization/operators/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${onnxruntime_python_transformers_src}
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/transformers/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/transformers/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${onnxruntime_python_transformers_longformer_src}
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/transformers/longformer/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/transformers/longformer/
   COMMAND ${CMAKE_COMMAND} -E copy
       ${REPO_ROOT}/VERSION_NUMBER
-      $<TARGET_FILE_DIR:${test_data_target}>
+      $<TARGET_FILE_DIR:${build_output_target}>
 )
+
+if (onnxruntime_BUILD_UNIT_TESTS)
+  add_custom_command(
+    TARGET onnxruntime_pybind11_state POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${onnxruntime_python_test_srcs}
+        $<TARGET_FILE_DIR:${build_output_target}>
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${onnxruntime_python_quantization_test_srcs}
+        $<TARGET_FILE_DIR:${build_output_target}>/quantization/
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${onnxruntime_python_checkpoint_test_srcs}
+        $<TARGET_FILE_DIR:${build_output_target}>/checkpoint/
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${onnxruntime_python_dhp_parallel_test_srcs}
+        $<TARGET_FILE_DIR:${build_output_target}>/dhp_parallel/
+  )
+endif()
 
 if (onnxruntime_ENABLE_TRAINING)
   add_custom_command(
     TARGET onnxruntime_pybind11_state POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/training
-    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/training/amp
-    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/training/optim
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/amp
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/optim
     COMMAND ${CMAKE_COMMAND} -E copy
         ${onnxruntime_python_capi_training_srcs}
-        $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/capi/training/
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/training/
     COMMAND ${CMAKE_COMMAND} -E copy
         ${onnxruntime_python_root_srcs}
-        $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/training/
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/
     COMMAND ${CMAKE_COMMAND} -E copy
         ${onnxruntime_python_amp_srcs}
-        $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/training/amp/
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/amp/
     COMMAND ${CMAKE_COMMAND} -E copy
         ${onnxruntime_python_optim_srcs}
-        $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/training/optim/
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/optim/
     COMMAND ${CMAKE_COMMAND} -E copy
         ${onnxruntime_python_train_tools_srcs}
-        $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/training/
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/
   )
 endif()
 
@@ -371,7 +380,7 @@ if (onnxruntime_USE_DNNL)
     COMMAND ${CMAKE_COMMAND} -E copy
         ${DNNL_DLL_PATH} $<TARGET_FILE:onnxruntime_providers_dnnl>
         $<TARGET_FILE:onnxruntime_providers_shared>
-        $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/capi/
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/
   )
 endif()
 
@@ -381,7 +390,7 @@ if (onnxruntime_USE_TENSORRT)
     COMMAND ${CMAKE_COMMAND} -E copy
         $<TARGET_FILE:onnxruntime_providers_tensorrt>
         $<TARGET_FILE:onnxruntime_providers_shared>
-        $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/capi/
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/
   )
 endif()
 
@@ -392,7 +401,7 @@ if (onnxruntime_USE_OPENVINO)
       COMMAND ${CMAKE_COMMAND} -E copy
           ${OPENVINO_DLL_PATH} $<TARGET_FILE:onnxruntime_providers_openvino>
           $<TARGET_FILE:onnxruntime_providers_shared>
-          $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/capi/
+          $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/
     )
   endif()
 endif()
@@ -402,7 +411,7 @@ if (onnxruntime_USE_TVM)
     TARGET onnxruntime_pybind11_state POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
         $<TARGET_FILE:tvm> $<TARGET_FILE:nnvm_compiler>
-        $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/capi/
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/
   )
 endif()
 
@@ -412,10 +421,10 @@ if (onnxruntime_USE_NUPHAR)
   )
   add_custom_command(
     TARGET onnxruntime_pybind11_state POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/nuphar
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/nuphar
     COMMAND ${CMAKE_COMMAND} -E copy
       ${onnxruntime_python_nuphar_python_srcs}
-      $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/nuphar/
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/nuphar/
   )
 endif()
 
@@ -424,7 +433,7 @@ if (onnxruntime_USE_DML)
     TARGET onnxruntime_pybind11_state POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
         ${DML_PACKAGE_DIR}/bin/${onnxruntime_target_platform}-win/${DML_SHARED_LIB}
-        $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/capi/
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/
   )
 endif()
 
@@ -433,7 +442,7 @@ if (onnxruntime_USE_NNAPI_BUILTIN)
     TARGET onnxruntime_pybind11_state POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
         $<TARGET_FILE:onnxruntime_providers_nnapi>
-        $<TARGET_FILE_DIR:${test_data_target}>/onnxruntime/capi/
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/
   )
 endif()
 


### PR DESCRIPTION
**Description**: 
If unit tests are manually excluded via `--cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF` (e.g. testing changes to binary size where you want to keep the build time as quick as possible) it should still be possible to create the python bindings.

Update CMakeLists.txt to decouple the inclusion of onnxruntime_python.cmake from unit tests being enabled.

Update onnxruntime_python.cmake so it works when unit tests are disabled. Also skip copying of test py files when unit tests are disabled.

**Motivation and Context**
Keep build time short but still be able to create a python wheel to test changes. 