### PR TITLE
update benchmark_longformer with default test suite

### DIFF
--- a/onnxruntime/python/tools/transformers/longformer/convert_longformer_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/longformer/convert_longformer_to_onnx.py
@@ -22,7 +22,7 @@ import transformers
 from torch.onnx import register_custom_op_symbolic
 from torch.onnx.symbolic_helper import parse_args
 from packaging import version
-
+from pathlib import Path
 from longformer_helper import LongformerHelper, PRETRAINED_LONGFORMER_MODELS
 
 


### PR DESCRIPTION
**Description**: 
Update benchmark_longformer tool to reduce manual work:
(1) Add a default test suites: memory, latency and parity tests on longformer-base-4096. It will trigger when user does not input any parameter.
(2) Replace --models by --model: only test one model in a run.
(3) Memory test returns the delta of memory (memory_in_test - memory_before_test).

Example outputs in T4 GPU:
```
$ python benchmark_longformer.py
b=1, s=512, g=8, latency=69.77ms, memory=?MB longformer-base-4096[torch]
b=1, s=512, g=8, latency=36.46ms, memory=1006.0MB longformer-base-4096_fp32.onnx(max_diff=1.7642974853515625e-05)
b=1, s=512, g=8, latency=37.07ms, memory=728.0MB longformer-base-4096_fp32.onnx[compact_memory](max_diff=6.341934204101562e-05)
b=1, s=512, g=8, latency=10.50ms, memory=364.0MB longformer-base-4096_fp16.onnx(max_diff=0.3200960159301758)
b=1, s=512, g=8, latency=10.45ms, memory=364.0MB longformer-base-4096_fp16.onnx[compact_memory](max_diff=0.2717781066894531)
b=1, s=1024, g=8, latency=122.24ms, memory=?MB longformer-base-4096[torch]
b=1, s=1024, g=8, latency=86.84ms, memory=1114.0MB longformer-base-4096_fp32.onnx(max_diff=0.0001750662922859192)
b=1, s=1024, g=8, latency=85.90ms, memory=858.0MB longformer-base-4096_fp32.onnx[compact_memory](max_diff=4.1484832763671875e-05)
b=1, s=1024, g=8, latency=25.33ms, memory=556.0MB longformer-base-4096_fp16.onnx(max_diff=0.28536319732666016)
b=1, s=1024, g=8, latency=25.13ms, memory=428.0MB longformer-base-4096_fp16.onnx[compact_memory](max_diff=0.2417621612548828)
b=1, s=2048, g=8, latency=225.98ms, memory=?MB longformer-base-4096[torch]
b=1, s=2048, g=8, latency=172.28ms, memory=1386.0MB longformer-base-4096_fp32.onnx(max_diff=0.0014109611511230469)
b=1, s=2048, g=8, latency=165.52ms, memory=1130.0MB longformer-base-4096_fp32.onnx[compact_memory](max_diff=1.9073486328125e-05)
b=1, s=2048, g=8, latency=50.24ms, memory=638.0MB longformer-base-4096_fp16.onnx(max_diff=3.1071019172668457)
b=1, s=2048, g=8, latency=48.68ms, memory=510.0MB longformer-base-4096_fp16.onnx[compact_memory](max_diff=0.1337137222290039)
b=1, s=4096, g=8, latency=432.25ms, memory=?MB longformer-base-4096[torch]
b=1, s=4096, g=8, latency=351.12ms, memory=3210.0MB longformer-base-4096_fp32.onnx(max_diff=8.726119995117188e-05)
b=1, s=4096, g=8, latency=336.64ms, memory=1674.0MB longformer-base-4096_fp32.onnx[compact_memory](max_diff=2.3365020751953125e-05)
b=1, s=4096, g=8, latency=101.20ms, memory=1486.0MB longformer-base-4096_fp16.onnx(max_diff=0.5714325904846191)
b=1, s=4096, g=8, latency=97.42ms, memory=718.0MB longformer-base-4096_fp16.onnx[compact_memory](max_diff=0.48769330978393555)
```
**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

When user need to run memory, latency and parity tests, it is needed to run multiple command lines to run them separately. For memory result, user might need calculate manually to get the delta. 

After this change, user could get all results for longformer-base-4096 in one command line. That saves a lot of time.