### PR TITLE
Enable CI to cover globally allowed types

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -127,6 +127,8 @@ jobs:
     displayName: Build minimal onnxruntime [exceptions ENABLED, type reduction ENABLED (globally allowed types)] and run tests
     inputs:
       script: |
+        echo "!globally_allowed_types;bool,float,int8_t,uint8_t" \
+          > $(test_data_directory)/globally_allowed_types.config && \
         docker run --rm \
           --volume $(Build.SourcesDirectory):/onnxruntime_src \
           --volume $(Build.BinariesDirectory):/build \
@@ -138,7 +140,8 @@ jobs:
             /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_and_run_tests.sh \
               --build-directory /build/with_type_reduction_globally_allowed_types \
               --reduced-ops-config /home/onnxruntimedev/.test_data/globally_allowed_types.config \
-              --enable-type-reduction
+              --enable-type-reduction \
+              --skip-model-tests
       workingDirectory: $(Build.SourcesDirectory)
 
   - script: git checkout -- .

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -8,6 +8,9 @@
 #    test the ort format models generated in step 1.
 #    Exceptions are enabled in this step to help debugging in case of CI failure.
 #    This step builds and tests ORT with and without type reduction enabled.
+# 3.1. Build minimal ORT with type reduction from a globally allowed types list.
+#    This step uses a hard-coded list of types which may not include the types needed by the models
+#    in <repo root>/onnxruntime/test/testdata/, so the tests for those models are skipped.
 # 4. Build baseline minimal ORT for Android arm64-v8a including no kernels and disable exceptions
 #    This step is to report the baseline binary size for Android
 jobs:
@@ -55,73 +58,73 @@ jobs:
             /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_full_ort_and_create_ort_files.sh
       workingDirectory: $(Build.SourcesDirectory)
 
-  # - task: CmdLine@2
-  #   displayName: Build minimal onnxruntime [exceptions DISABLED, type reduction DISABLED]
-  #   inputs:
-  #     script: |
-  #       # We will try to build minimal ORT with exceptions disabled
-  #       # Only the building process is verified here, no test will be performed
-  #       docker run --rm \
-  #         --volume $(Build.SourcesDirectory):/onnxruntime_src \
-  #         --volume $(Build.BinariesDirectory):/build \
-  #         -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
-  #         -e NIGHTLY_BUILD \
-  #         -e BUILD_BUILDNUMBER \
-  #         onnxruntimecentoscpubuild \
-  #           python3 /onnxruntime_src/tools/ci_build/build.py \
-  #             --build_dir /build --cmake_generator Ninja \
-  #             --config Debug\
-  #             --skip_submodule_sync \
-  #             --build_shared_lib \
-  #             --parallel \
-  #             --skip_tests \
-  #             --minimal_build \
-  #             --disable_exceptions
-  #     workingDirectory: $(Build.SourcesDirectory)
+  - task: CmdLine@2
+    displayName: Build minimal onnxruntime [exceptions DISABLED, type reduction DISABLED]
+    inputs:
+      script: |
+        # We will try to build minimal ORT with exceptions disabled
+        # Only the building process is verified here, no test will be performed
+        docker run --rm \
+          --volume $(Build.SourcesDirectory):/onnxruntime_src \
+          --volume $(Build.BinariesDirectory):/build \
+          -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
+          -e NIGHTLY_BUILD \
+          -e BUILD_BUILDNUMBER \
+          onnxruntimecentoscpubuild \
+            python3 /onnxruntime_src/tools/ci_build/build.py \
+              --build_dir /build --cmake_generator Ninja \
+              --config Debug\
+              --skip_submodule_sync \
+              --build_shared_lib \
+              --parallel \
+              --skip_tests \
+              --minimal_build \
+              --disable_exceptions
+      workingDirectory: $(Build.SourcesDirectory)
 
-  # - task: CmdLine@2
-  #   displayName: Build minimal onnxruntime [exceptions ENABLED, type reduction DISABLED, custom ops ENABLED] and run tests
-  #   inputs:
-  #     script: |
-  #       docker run --rm \
-  #         --volume $(Build.SourcesDirectory):/onnxruntime_src \
-  #         --volume $(Build.BinariesDirectory):/build \
-  #         --volume $(test_data_directory):/home/onnxruntimedev/.test_data \
-  #         -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
-  #         -e NIGHTLY_BUILD \
-  #         -e BUILD_BUILDNUMBER \
-  #         onnxruntimecentoscpubuild \
-  #           /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_and_run_tests.sh \
-  #             --build-directory /build/without_type_reduction \
-  #             --reduced-ops-config /home/onnxruntimedev/.test_data/required_ops.ort_models.config \
-  #             --enable-custom-ops
-  #     workingDirectory: $(Build.SourcesDirectory)
+  - task: CmdLine@2
+    displayName: Build minimal onnxruntime [exceptions ENABLED, type reduction DISABLED, custom ops ENABLED] and run tests
+    inputs:
+      script: |
+        docker run --rm \
+          --volume $(Build.SourcesDirectory):/onnxruntime_src \
+          --volume $(Build.BinariesDirectory):/build \
+          --volume $(test_data_directory):/home/onnxruntimedev/.test_data \
+          -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
+          -e NIGHTLY_BUILD \
+          -e BUILD_BUILDNUMBER \
+          onnxruntimecentoscpubuild \
+            /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_and_run_tests.sh \
+              --build-directory /build/without_type_reduction \
+              --reduced-ops-config /home/onnxruntimedev/.test_data/required_ops.ort_models.config \
+              --enable-custom-ops
+      workingDirectory: $(Build.SourcesDirectory)
 
-  # - script: git checkout -- .
-  #   displayName: Discard local changes to Git repository files
-  #   workingDirectory: $(Build.SourcesDirectory)
+  - script: git checkout -- .
+    displayName: Discard local changes to Git repository files
+    workingDirectory: $(Build.SourcesDirectory)
 
-  # - task: CmdLine@2
-  #   displayName: Build minimal onnxruntime [exceptions ENABLED, type reduction ENABLED] and run tests
-  #   inputs:
-  #     script: |
-  #       docker run --rm \
-  #         --volume $(Build.SourcesDirectory):/onnxruntime_src \
-  #         --volume $(Build.BinariesDirectory):/build \
-  #         --volume $(test_data_directory):/home/onnxruntimedev/.test_data \
-  #         -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
-  #         -e NIGHTLY_BUILD \
-  #         -e BUILD_BUILDNUMBER \
-  #         onnxruntimecentoscpubuild \
-  #           /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_and_run_tests.sh \
-  #             --build-directory /build/with_type_reduction \
-  #             --reduced-ops-config /home/onnxruntimedev/.test_data/required_ops_and_types.ort_models.config \
-  #             --enable-type-reduction
-  #     workingDirectory: $(Build.SourcesDirectory)
+  - task: CmdLine@2
+    displayName: Build minimal onnxruntime [exceptions ENABLED, type reduction ENABLED] and run tests
+    inputs:
+      script: |
+        docker run --rm \
+          --volume $(Build.SourcesDirectory):/onnxruntime_src \
+          --volume $(Build.BinariesDirectory):/build \
+          --volume $(test_data_directory):/home/onnxruntimedev/.test_data \
+          -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
+          -e NIGHTLY_BUILD \
+          -e BUILD_BUILDNUMBER \
+          onnxruntimecentoscpubuild \
+            /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_and_run_tests.sh \
+              --build-directory /build/with_type_reduction \
+              --reduced-ops-config /home/onnxruntimedev/.test_data/required_ops_and_types.ort_models.config \
+              --enable-type-reduction
+      workingDirectory: $(Build.SourcesDirectory)
 
-  # - script: git checkout -- .
-  #   displayName: Discard local changes to Git repository files
-  #   workingDirectory: $(Build.SourcesDirectory)
+  - script: git checkout -- .
+    displayName: Discard local changes to Git repository files
+    workingDirectory: $(Build.SourcesDirectory)
 
   - task: CmdLine@2
     displayName: Build minimal onnxruntime [exceptions ENABLED, type reduction ENABLED (globally allowed types)] and run tests

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -55,32 +55,76 @@ jobs:
             /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_full_ort_and_create_ort_files.sh
       workingDirectory: $(Build.SourcesDirectory)
 
-  - task: CmdLine@2
-    displayName: Build minimal onnxruntime [exceptions DISABLED, type reduction DISABLED]
-    inputs:
-      script: |
-        # We will try to build minimal ORT with exceptions disabled
-        # Only the building process is verified here, no test will be performed
-        docker run --rm \
-          --volume $(Build.SourcesDirectory):/onnxruntime_src \
-          --volume $(Build.BinariesDirectory):/build \
-          -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
-          -e NIGHTLY_BUILD \
-          -e BUILD_BUILDNUMBER \
-          onnxruntimecentoscpubuild \
-            python3 /onnxruntime_src/tools/ci_build/build.py \
-              --build_dir /build --cmake_generator Ninja \
-              --config Debug\
-              --skip_submodule_sync \
-              --build_shared_lib \
-              --parallel \
-              --skip_tests \
-              --minimal_build \
-              --disable_exceptions
-      workingDirectory: $(Build.SourcesDirectory)
+  # - task: CmdLine@2
+  #   displayName: Build minimal onnxruntime [exceptions DISABLED, type reduction DISABLED]
+  #   inputs:
+  #     script: |
+  #       # We will try to build minimal ORT with exceptions disabled
+  #       # Only the building process is verified here, no test will be performed
+  #       docker run --rm \
+  #         --volume $(Build.SourcesDirectory):/onnxruntime_src \
+  #         --volume $(Build.BinariesDirectory):/build \
+  #         -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
+  #         -e NIGHTLY_BUILD \
+  #         -e BUILD_BUILDNUMBER \
+  #         onnxruntimecentoscpubuild \
+  #           python3 /onnxruntime_src/tools/ci_build/build.py \
+  #             --build_dir /build --cmake_generator Ninja \
+  #             --config Debug\
+  #             --skip_submodule_sync \
+  #             --build_shared_lib \
+  #             --parallel \
+  #             --skip_tests \
+  #             --minimal_build \
+  #             --disable_exceptions
+  #     workingDirectory: $(Build.SourcesDirectory)
+
+  # - task: CmdLine@2
+  #   displayName: Build minimal onnxruntime [exceptions ENABLED, type reduction DISABLED, custom ops ENABLED] and run tests
+  #   inputs:
+  #     script: |
+  #       docker run --rm \
+  #         --volume $(Build.SourcesDirectory):/onnxruntime_src \
+  #         --volume $(Build.BinariesDirectory):/build \
+  #         --volume $(test_data_directory):/home/onnxruntimedev/.test_data \
+  #         -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
+  #         -e NIGHTLY_BUILD \
+  #         -e BUILD_BUILDNUMBER \
+  #         onnxruntimecentoscpubuild \
+  #           /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_and_run_tests.sh \
+  #             --build-directory /build/without_type_reduction \
+  #             --reduced-ops-config /home/onnxruntimedev/.test_data/required_ops.ort_models.config \
+  #             --enable-custom-ops
+  #     workingDirectory: $(Build.SourcesDirectory)
+
+  # - script: git checkout -- .
+  #   displayName: Discard local changes to Git repository files
+  #   workingDirectory: $(Build.SourcesDirectory)
+
+  # - task: CmdLine@2
+  #   displayName: Build minimal onnxruntime [exceptions ENABLED, type reduction ENABLED] and run tests
+  #   inputs:
+  #     script: |
+  #       docker run --rm \
+  #         --volume $(Build.SourcesDirectory):/onnxruntime_src \
+  #         --volume $(Build.BinariesDirectory):/build \
+  #         --volume $(test_data_directory):/home/onnxruntimedev/.test_data \
+  #         -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
+  #         -e NIGHTLY_BUILD \
+  #         -e BUILD_BUILDNUMBER \
+  #         onnxruntimecentoscpubuild \
+  #           /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_and_run_tests.sh \
+  #             --build-directory /build/with_type_reduction \
+  #             --reduced-ops-config /home/onnxruntimedev/.test_data/required_ops_and_types.ort_models.config \
+  #             --enable-type-reduction
+  #     workingDirectory: $(Build.SourcesDirectory)
+
+  # - script: git checkout -- .
+  #   displayName: Discard local changes to Git repository files
+  #   workingDirectory: $(Build.SourcesDirectory)
 
   - task: CmdLine@2
-    displayName: Build minimal onnxruntime [exceptions ENABLED, type reduction DISABLED, custom ops ENABLED] and run tests
+    displayName: Build minimal onnxruntime [exceptions ENABLED, type reduction ENABLED (globally allowed types)] and run tests
     inputs:
       script: |
         docker run --rm \
@@ -92,30 +136,8 @@ jobs:
           -e BUILD_BUILDNUMBER \
           onnxruntimecentoscpubuild \
             /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_and_run_tests.sh \
-              --build-directory /build/without_type_reduction \
-              --reduced-ops-config /home/onnxruntimedev/.test_data/required_ops.ort_models.config \
-              --enable-custom-ops
-      workingDirectory: $(Build.SourcesDirectory)
-
-  - script: git checkout -- .
-    displayName: Discard local changes to Git repository files
-    workingDirectory: $(Build.SourcesDirectory)
-
-  - task: CmdLine@2
-    displayName: Build minimal onnxruntime [exceptions ENABLED, type reduction ENABLED] and run tests
-    inputs:
-      script: |
-        docker run --rm \
-          --volume $(Build.SourcesDirectory):/onnxruntime_src \
-          --volume $(Build.BinariesDirectory):/build \
-          --volume $(test_data_directory):/home/onnxruntimedev/.test_data \
-          -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
-          -e NIGHTLY_BUILD \
-          -e BUILD_BUILDNUMBER \
-          onnxruntimecentoscpubuild \
-            /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_and_run_tests.sh \
-              --build-directory /build/with_type_reduction \
-              --reduced-ops-config /home/onnxruntimedev/.test_data/required_ops_and_types.ort_models.config \
+              --build-directory /build/with_type_reduction_globally_allowed_types \
+              --reduced-ops-config /home/onnxruntimedev/.test_data/globally_allowed_types.config \
               --enable-type-reduction
       workingDirectory: $(Build.SourcesDirectory)
 

--- a/tools/ci_build/github/linux/ort_minimal/build_full_ort_and_create_ort_files.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_full_ort_and_create_ort_files.sh
@@ -44,6 +44,10 @@ python3 /onnxruntime_src/tools/python/create_reduced_build_config.py --format OR
     /onnxruntime_src/onnxruntime/test/testdata \
     /home/onnxruntimedev/.test_data/required_ops_and_types.ort_models.config
 
+# Config with type reduction via globally allowed types
+echo "!globally_allowed_types;float,int8_t,uint8_t" \
+    > /home/onnxruntimedev/.test_data/globally_allowed_types.config
+
 # Test that we can convert an ONNX model with custom ops to ORT format
 mkdir /home/onnxruntimedev/.test_data/custom_ops_model
 cp /onnxruntime_src/onnxruntime/test/testdata/custom_op_library/*.onnx /home/onnxruntimedev/.test_data/custom_ops_model/

--- a/tools/ci_build/github/linux/ort_minimal/build_full_ort_and_create_ort_files.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_full_ort_and_create_ort_files.sh
@@ -45,7 +45,7 @@ python3 /onnxruntime_src/tools/python/create_reduced_build_config.py --format OR
     /home/onnxruntimedev/.test_data/required_ops_and_types.ort_models.config
 
 # Config with type reduction via globally allowed types
-echo "!globally_allowed_types;float,int8_t,uint8_t" \
+echo "!globally_allowed_types;bool,float,int8_t,uint8_t" \
     > /home/onnxruntimedev/.test_data/globally_allowed_types.config
 
 # Test that we can convert an ONNX model with custom ops to ORT format

--- a/tools/ci_build/github/linux/ort_minimal/build_full_ort_and_create_ort_files.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_full_ort_and_create_ort_files.sh
@@ -44,10 +44,6 @@ python3 /onnxruntime_src/tools/python/create_reduced_build_config.py --format OR
     /onnxruntime_src/onnxruntime/test/testdata \
     /home/onnxruntimedev/.test_data/required_ops_and_types.ort_models.config
 
-# Config with type reduction via globally allowed types
-echo "!globally_allowed_types;bool,float,int8_t,uint8_t" \
-    > /home/onnxruntimedev/.test_data/globally_allowed_types.config
-
 # Test that we can convert an ONNX model with custom ops to ORT format
 mkdir /home/onnxruntimedev/.test_data/custom_ops_model
 cp /onnxruntime_src/onnxruntime/test/testdata/custom_op_library/*.onnx /home/onnxruntimedev/.test_data/custom_ops_model/

--- a/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_and_run_tests.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_and_run_tests.sh
@@ -14,12 +14,17 @@ USAGE_TEXT="Usage:
   -c|--reduced-ops-config <reduced Ops config file>
     Specifies the reduced Ops configuration file path. Required.
   [--enable-type-reduction]
-    Builds with type reduction enabled."
+    Builds with type reduction enabled.
+  [--enable-custom-ops]
+    Builds with custom op support enabled.
+  [--skip-model-tests]
+    Does not run the E2E model tests."
 
 BUILD_DIR=
 REDUCED_OPS_CONFIG_FILE=
 ENABLE_TYPE_REDUCTION=
 MINIMAL_BUILD_ARGS=
+SKIP_MODEL_TESTS=
 
 while [[ $# -gt 0 ]]
 do
@@ -41,6 +46,10 @@ do
             ;;
         --enable-custom-ops)
             MINIMAL_BUILD_ARGS="custom_ops"
+            shift
+            ;;
+        --skip-model-tests)
+            SKIP_MODEL_TESTS=1
             shift
             ;;
         *)
@@ -69,8 +78,10 @@ python3 /onnxruntime_src/tools/ci_build/build.py \
     --include_ops_by_config ${REDUCED_OPS_CONFIG_FILE} \
     ${ENABLE_TYPE_REDUCTION:+"--enable_reduced_operator_type_support"}
 
-# Run the e2e test cases
-${BUILD_DIR}/Debug/onnx_test_runner /onnxruntime_src/onnxruntime/test/testdata/ort_minimal_e2e_test_data
+if [[ -z "${SKIP_MODEL_TESTS}" ]]; then
+    # Run the e2e model test cases
+    ${BUILD_DIR}/Debug/onnx_test_runner /onnxruntime_src/onnxruntime/test/testdata/ort_minimal_e2e_test_data
+fi
 
 # Print binary size info
 python3 /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/check_build_binary_size.py \


### PR DESCRIPTION
**Description**
Add test to CI build to cover type reduction with globally allowed types.

**Motivation and Context**
Exercise functionality in CI build.
