### PR TITLE
Update DirectML 1.4.1 to 1.4.2 for ORT 1.7

### DIFF
--- a/cmake/external/dml.cmake
+++ b/cmake/external/dml.cmake
@@ -20,7 +20,7 @@ if (NOT onnxruntime_USE_CUSTOM_DIRECTML)
   set(NUGET_CONFIG ${PROJECT_SOURCE_DIR}/../NuGet.config)
   set(PACKAGES_CONFIG ${PROJECT_SOURCE_DIR}/../packages.config)
   get_filename_component(PACKAGES_DIR ${CMAKE_CURRENT_BINARY_DIR}/../packages ABSOLUTE)
-  set(DML_PACKAGE_DIR ${PACKAGES_DIR}/Microsoft.AI.DirectML.1.4.1)
+  set(DML_PACKAGE_DIR ${PACKAGES_DIR}/Microsoft.AI.DirectML.1.4.2)
   set(DML_SHARED_LIB DirectML.dll)
 
   # Restore nuget packages, which will pull down the DirectML redist package

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GoogleTestAdapter" version="0.17.1" targetFramework="net46" />
-  <package id="Microsoft.AI.DirectML" version="1.4.1" targetFramework="native" />
+  <package id="Microsoft.AI.DirectML" version="1.4.2" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.201113.7" targetFramework="native" />
 </packages>

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -76,7 +76,7 @@ def generate_repo_url(list, repo_url, commit_id):
 
 
 def generate_dependencies(list, package_name, version):
-    dml_dependency = '<dependency id="Microsoft.AI.DirectML" version="1.4.1"/>'
+    dml_dependency = '<dependency id="Microsoft.AI.DirectML" version="1.4.2"/>'
 
     if (package_name == 'Microsoft.AI.MachineLearning'):
         list.append('<dependencies>')


### PR DESCRIPTION
**Description**: Update ORT to latest DirectML with bug fixes.

**Motivation and Context**
Extends support of PIX markers to DirectML Redist package (previously only supported on Inbox).
