### PR TITLE
Move create kernels earlier during session init

### DIFF
--- a/include/onnxruntime/core/framework/op_kernel.h
+++ b/include/onnxruntime/core/framework/op_kernel.h
@@ -45,6 +45,23 @@ class OpKernel {
     return op_kernel_info_.GetKernelDef();
   }
 
+  /**
+   * @brief   A secondary initializer.
+   *
+   * Similar to the constructor, this function is called only once for each kernel,
+   * during the session creation stage.
+   *
+   * We want to create the coresponding kernel object as soon as a node's operator
+   * is loaded, so that the session creator can leverage the kernel's functionality
+   * in initial graph processing. At the same time, some kernels may have part of
+   * init logic depend on other part of the graph. These kernels can override this
+   * function, which will be invoked near the end of the session creation, after
+   * all graph data are loaded.
+   */
+  virtual Status SecondaryInit() {
+    return Status::OK();
+  }
+
   virtual Status Compute(_Inout_ OpKernelContext* context) const ORT_MUST_USE_RESULT = 0;
 
   virtual Status ComputeAsync(_Inout_ OpKernelContext*, DoneCallback) const ORT_MUST_USE_RESULT {

--- a/onnxruntime/contrib_ops/cpu/qlinear_lookup_table.h
+++ b/onnxruntime/contrib_ops/cpu/qlinear_lookup_table.h
@@ -16,7 +16,6 @@ typedef std::function<void(const float* input, float* output, size_t length)> Lo
 // function that transform single value
 typedef std::function<float(float)> LookupTableScalarTransformer;
 
-
 template <typename T>
 class QLinearLookupBase : public OpKernel {
  public:
@@ -24,7 +23,7 @@ class QLinearLookupBase : public OpKernel {
       : OpKernel(info), fixed_lookup_table_() {
   }
 
-//  protected:
+  //  protected:
   template <typename Transformer>
   Status ComputeBase(OpKernelContext* context, Transformer fn) const;
 
@@ -42,6 +41,8 @@ class QLinearLeakyRelu final : public QLinearLookupBase<T> {
  public:
   QLinearLeakyRelu(const OpKernelInfo& info);
 
+  Status SecondaryInit() override;
+
   Status Compute(OpKernelContext* context) const override;
 
  private:
@@ -52,6 +53,8 @@ template <typename T>
 class QLinearSigmoid final : public QLinearLookupBase<T> {
  public:
   QLinearSigmoid(const OpKernelInfo& info);
+
+  Status SecondaryInit() override;
 
   Status Compute(OpKernelContext* context) const override;
 };

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -305,6 +305,12 @@ class SessionState {
   // create kernels using info in kernel_create_info_map_
   Status CreateKernels(const KernelRegistryManager& custom_registry_manager);
 
+  /**
+  Call SecondaryInit() of each kernel. We want to call CreateKernels as early as
+  possible, and call secondary init as late as possible.
+  */
+  Status SecondaryKernelInit();
+
   // remove TensorProto versions of initializers from Graph instance
   // (replaced byOrtValue instances in initialized_tensors_)
   void CleanInitializedTensorsFromGraph();


### PR DESCRIPTION
This change split the kernel initialization logic into two part, the constructor and a virtual function SecondaryInit(). The goal here is to move the create kernel phase earlier, at least before const tensor de-serialization, and for some kernel init logic that depend on weight tensor values, those are moved to SecondaryInit()

**Motivation and Context**
*Problem*:

Some kernels prepack some const input tensors (weights) into another buffer, maintained internally in the kernel. After prepacking, the const tensor should be deleted, with its memory buffer reclaimed. 

Unfortunately, this leads to large amount of wasted memory in most cases, as these buffers are allocated either on memory pattern, or on memory arena, which makes deallocation impossible.

*Solution*:

We need to make the memory pattern planner aware of the prepacking, so that it won't trace const tensors that are going to be prepacked and deleted. Unfortunately this can not be done in a jiffy, as only the kernel object would know whether a weight tensor should be prepacked or not. But the memory pattern planner is run before the kernel objects are created.

So this change is the first step of implementing the solution: we move the kernel creation earlier, before memory pattern planner  runs. In the future we will have other changes for rest of the work.