### PR TITLE
Package ARM artifacts

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/windowsai-nuget-build.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windowsai-nuget-build.yml
@@ -151,7 +151,7 @@ steps:
         testRunTitle: 'Unit Test Run'
       condition: succeededOrFailed()
   
-  - ${{ if and(eq(parameters.BuildArch, 'x64'), eq(parameters.BuildForStore, 'false'), eq(parameters.Runtime, 'dynamic')) }}:
+  - ${{ if and(eq(parameters.BuildForStore, 'false'), eq(parameters.Runtime, 'dynamic')) }}:
     - script: |
        xcopy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\winml_test_api.exe $(Build.ArtifactStagingDirectory)\test_artifact\
        copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\winml_test_scenario.exe $(Build.ArtifactStagingDirectory)\test_artifact\


### PR DESCRIPTION
**Description**: We are running tests in ARM machines and plan to leave an ARM64 machine on and regularly running the latest build. This change just adds test artifacts for platforms other than x64.