### PR TITLE
Add pipeline to clear the cache for huggingface transormers models

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-clear-cache-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-clear-cache-pipeline.yml
@@ -1,0 +1,25 @@
+trigger: none
+
+jobs:
+- job: Onnxruntime_Linux_GPU_ORTModule_Clear_Cache
+
+  timeoutInMinutes: 120
+  pool: 'Linux-Single-GPU-V100'
+
+  steps:
+  - checkout: self
+    clean: true
+    submodules: recursive
+
+  - bash: tools/ci_build/github/linux/docker/scripts/training/azure_scale_set_vm_mount_test_data.sh -p $(orttrainingtestdata-storage-key) -s "//orttrainingtestdata.file.core.windows.net/hf-models-cache" -d "/hf_models_cache"
+    displayName: 'Mount hf-models-cache'
+    condition: succeededOrFailed()
+
+  - bash: rm /hf_models_cache/huggingface/transformers/*
+    displayName: 'Clear huggingface transformers cache'
+
+  - template: templates/component-governance-component-detection-steps.yml
+    parameters:
+      condition: 'succeeded'
+
+  - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-clear-cache-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-clear-cache-pipeline.yml
@@ -1,10 +1,10 @@
 trigger: none
 
 jobs:
-- job: Onnxruntime_Linux_GPU_ORTModule_Clear_Cache
+- job: Onnxruntime_Linux_GPU_ORTTraining_Clear_Cache
 
-  timeoutInMinutes: 120
-  pool: 'Linux-Single-GPU-V100'
+  timeoutInMinutes: 15
+  pool: 'Linux-CPU-2019'
 
   steps:
   - checkout: self


### PR DESCRIPTION
**Description**:
Add a new pipeline that mounts the huggingface models cache from the storage account and then deletes all the pre-downloaded models from the mounted volume.
On the next run of the CI pipeline ```orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml```, the models will be re-downloaded and saved in the storage account.
This pipeline will be set up to run once a week.