### PR TITLE
[NNAPI EP] Add per-tensor u8s8 support for Qlinear[Conv/MatMul]

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
@@ -215,7 +215,7 @@ bool HasValidQuantizationZeroPoints(const InitializedTensorSet& initializers, co
 
     const auto zero_point_name = input_defs[idx]->Name();
     if (!Contains(initializers, zero_point_name)) {
-      LOGS_DEFAULT(VERBOSE) << "The zero point of " << op_type << " must be known";
+      LOGS_DEFAULT(VERBOSE) << "The zero point of " << op_type << " must be an initializer tensor";
       return false;
     }
 
@@ -240,7 +240,7 @@ bool HasValidQuantizationZeroPoints(const InitializedTensorSet& initializers, co
       // 1. Per-tensor, the weight will be transformed to uint8 later
       // 2. Per-channel, only from Android API level 29
       if (zero_tensor.data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT8) {
-        LOGS_DEFAULT(VERBOSE) << "u8s8 QlinearConv only supports int8 zero point for weight, "
+        LOGS_DEFAULT(VERBOSE) << "u8s8 Qlinear[Conv/MatMul] only supports int8 zero point for weight, "
                               << "actual zero point type: [" << zero_tensor.data_type() << "]";
         return false;
       }
@@ -271,7 +271,7 @@ bool HasValidQuantizationZeroPoints(const InitializedTensorSet& initializers, co
           node.ModelPath(),
           unpacked_tensor, tensor_byte_size);
       if (!status.IsOK()) {
-        LOGS_DEFAULT(ERROR) << "QLinearConv erro when unpack zero tensor:" << status.ErrorMessage();
+        LOGS_DEFAULT(ERROR) << "Qlinear[Conv/MatMul] error when unpack zero tensor:" << status.ErrorMessage();
         return false;
       }
 
@@ -279,7 +279,7 @@ bool HasValidQuantizationZeroPoints(const InitializedTensorSet& initializers, co
       const int8_t* zero_points = reinterpret_cast<const int8_t*>(unpacked_tensor.get());
       for (size_t i = 0; i < tensor_byte_size; i++) {
         if (zero_points[i] != 0) {
-          LOGS_DEFAULT(VERBOSE) << "QLinearConv only support 0 as zero point, "
+          LOGS_DEFAULT(VERBOSE) << "u8s8 Qlinear[Conv/MatMul]  only support 0 as zero point, "
                                 << "zero_points[" << i << "] has value: " << zero_points[i];
           return false;
         }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
@@ -137,7 +137,9 @@ bool HasValidBinaryOpQuantizedInputs(const Node& node) {
 bool HasValidQuantizationScales(const InitializedTensorSet& initializers, const Node& node,
                                 const std::vector<size_t>& indices, const OpSupportCheckParams& params) {
   const auto& op_type = node.OpType();
-  bool is_qlinear_conv = (op_type == "QLinearConv");
+  auto qlinear_op_type = GetQLinearOpType(node);
+  bool is_qlinear_conv = (qlinear_op_type == QLinearOpType::QLinearConv);
+  bool is_qlinear_matmul = (qlinear_op_type == QLinearOpType::QLinearMatMul);
   const auto input_defs(node.InputDefs());
   for (const auto idx : indices) {
     if (idx >= input_defs.size()) {
@@ -145,45 +147,52 @@ bool HasValidQuantizationScales(const InitializedTensorSet& initializers, const 
                             << " >= input number, " << input_defs.size();
       return false;
     }
+
     const auto scale_name = input_defs[idx]->Name();
-    if (Contains(initializers, scale_name)) {
-      const auto& scale_tensor = *initializers.at(scale_name);
-      int64_t scales_dim = scale_tensor.dims().empty() ? 1 : scale_tensor.dims()[0];
-      bool is_conv_weight = is_qlinear_conv && idx == 4;
-      bool is_conv_u8s8_weight = false;
-
-      if (is_conv_weight) {
-        const auto& weight_tensor = *initializers.at(node.InputDefs()[3]->Name());
-        is_conv_u8s8_weight = weight_tensor.data_type() == ONNX_NAMESPACE::TensorProto_DataType_INT8;
-      }
-
-      // We need to check the per-channel quantization scales dimensions for u8s8 QlinearConv
-      // We only support per-channel quantization for u8s8
-      // For all other cases, the scales should be a scalar
-      if (is_conv_u8s8_weight) {
-        if (params.android_sdk_ver < 29) {
-          LOGS_DEFAULT(VERBOSE) << op_type << " only supports per-channel quantization on Android API 29+, "
-                                << "system API level: " << params.android_sdk_ver;
-          return false;
-        }
-
-        const auto& weight_tensor = *initializers.at(node.InputDefs()[3]->Name());
-        if (weight_tensor.dims()[0] != scales_dim) {
-          LOGS_DEFAULT(VERBOSE) << op_type << " mismatch int8 per-channel quantization weight,"
-                                << " weight dimension[0] " << weight_tensor.dims()[0]
-                                << " scale dimension " << scales_dim;
-          return false;
-        }
-      } else {
-        if (scales_dim != 1) {
-          LOGS_DEFAULT(VERBOSE) << op_type << " does not support per-channel quantization, "
-                                << " for now, only u8s8 QlinearConv supports per-channel quantization on API 29+";
-          return false;
-        }
-      }
-    } else {
-      LOGS_DEFAULT(VERBOSE) << "The scale of " << op_type << " must be known";
+    if (!Contains(initializers, scale_name)) {
+      LOGS_DEFAULT(VERBOSE) << "The scale of " << op_type << " must be an initializer tensor";
       return false;
+    }
+
+    // If this op is Qlinear[Conv/MatMul], we want to check u8s8 support for weight tensor (or B tensor for QlinearMatMul)
+    bool is_conv_matmul_weight = (is_qlinear_conv || is_qlinear_matmul) && idx == 4;
+    bool is_conv_matmul_u8s8_weight = false;
+
+    if (is_conv_matmul_weight) {
+      const auto& weight_tensor = *initializers.at(node.InputDefs()[3]->Name());
+      is_conv_matmul_u8s8_weight = weight_tensor.data_type() == ONNX_NAMESPACE::TensorProto_DataType_INT8;
+    }
+
+    const auto& scale_tensor = *initializers.at(scale_name);
+    int64_t scales_dim = scale_tensor.dims().empty() ? 1 : scale_tensor.dims()[0];
+    if (!is_conv_matmul_u8s8_weight) {
+      if (scales_dim != 1) {
+        LOGS_DEFAULT(VERBOSE) << op_type << " does not support per-channel quantization, "
+                              << " for now, only u8s8 QlinearConv supports per-channel quantization on API 29+";
+        return false;
+      }
+    } else if (scales_dim != 1) {
+      // For u8s8 Qlinear[Conv/MatMul], we support
+      // 1. Per-tensor, the weight will be transformed to uint8 later
+      // 2. Per-channel, only from Android API level 29
+      if (is_qlinear_matmul) {
+        LOGS_DEFAULT(VERBOSE) << "QLinearMatMul does not support per-channel quantization";
+        return false;
+      }
+
+      if (params.android_sdk_ver < 29) {
+        LOGS_DEFAULT(VERBOSE) << op_type << " only supports per-channel quantization on Android API 29+, "
+                              << "system API level: " << params.android_sdk_ver;
+        return false;
+      }
+
+      const auto& weight_tensor = *initializers.at(node.InputDefs()[3]->Name());
+      if (weight_tensor.dims()[0] != scales_dim) {
+        LOGS_DEFAULT(VERBOSE) << op_type << " mismatch int8 per-channel quantization weight,"
+                              << " weight dimension[0] " << weight_tensor.dims()[0]
+                              << " scale dimension " << scales_dim;
+        return false;
+      }
     }
   }
 
@@ -193,7 +202,9 @@ bool HasValidQuantizationScales(const InitializedTensorSet& initializers, const 
 bool HasValidQuantizationZeroPoints(const InitializedTensorSet& initializers, const Node& node,
                                     const std::vector<size_t>& indices) {
   const auto& op_type = node.OpType();
-  bool is_qlinear_conv = (op_type == "QLinearConv");
+  auto qlinear_op_type = GetQLinearOpType(node);
+  bool is_qlinear_conv = (qlinear_op_type == QLinearOpType::QLinearConv);
+  bool is_qlinear_matmul = (qlinear_op_type == QLinearOpType::QLinearMatMul);
   const auto input_defs(node.InputDefs());
   for (const auto idx : indices) {
     if (idx >= input_defs.size()) {
@@ -203,65 +214,76 @@ bool HasValidQuantizationZeroPoints(const InitializedTensorSet& initializers, co
     }
 
     const auto zero_point_name = input_defs[idx]->Name();
-    if (Contains(initializers, zero_point_name)) {
-      bool is_conv_weight = is_qlinear_conv && idx == 5;
-      bool is_conv_u8s8_weight = false;
-      if (is_conv_weight) {
-        const auto& weight_tensor = *initializers.at(node.InputDefs()[3]->Name());
-        is_conv_u8s8_weight = weight_tensor.data_type() == ONNX_NAMESPACE::TensorProto_DataType_INT8;
-      }
-
-      const auto& zero_tensor = *initializers.at(zero_point_name);
-      int64_t zero_dim = zero_tensor.dims().empty() ? 1 : zero_tensor.dims()[0];
-      if (is_conv_u8s8_weight) {
-        if (zero_tensor.data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT8) {
-          LOGS_DEFAULT(VERBOSE) << "u8s8 QlinearConv only supports int8 zero point for weight, "
-                                << "actual zero point type: [" << zero_tensor.data_type() << "]";
-          return false;
-        }
-
-        // For onnx, u8s8 QlinearConv, the weight zero point can be a scalar,
-        // or a tensor with same channel as weight, for NNAPI we only support it be
-        // 0 (scalar) or all 0 (tensor), NNAPI will assume the zero point for per-channel
-        // quantization is 0 there is no input for it
-        const auto& weight_tensor = *initializers.at(node.InputDefs()[3]->Name());
-        if (weight_tensor.dims()[0] != zero_dim && zero_dim != 1) {
-          LOGS_DEFAULT(VERBOSE) << op_type << " mismatch int8 per-channel quantization weight,"
-                                << " weight dimension[0] " << weight_tensor.dims()[0]
-                                << " zero point dimension " << zero_dim;
-          return false;
-        }
-
-        std::unique_ptr<uint8_t[]> unpacked_tensor;
-        size_t tensor_byte_size;
-        auto status = onnxruntime::utils::UnpackInitializerData(
-            zero_tensor,
-            node.ModelPath(),
-            unpacked_tensor, tensor_byte_size);
-        if (!status.IsOK()) {
-          LOGS_DEFAULT(ERROR) << "QLinearConv erro when unpack zero tensor:" << status.ErrorMessage();
-          return false;
-        }
-
-        // Verify all onnx weight zero point(s) are 0(s)
-        const int8_t* zero_points = reinterpret_cast<const int8_t*>(unpacked_tensor.get());
-        for (size_t i = 0; i < tensor_byte_size; i++) {
-          if (zero_points[i] != 0) {
-            LOGS_DEFAULT(VERBOSE) << "QLinearConv only support 0 as zero point, "
-                                  << "zero_points[" << i << "] has value: " << zero_points[i];
-            return false;
-          }
-        }
-      } else {
-        if (zero_dim != 1) {
-          LOGS_DEFAULT(VERBOSE) << op_type << " does not support per-channel quantization, "
-                                << " for now, only u8s8 QlinearConv supports per-channel quantization on API 29+";
-          return false;
-        }
-      }
-    } else {
+    if (!Contains(initializers, zero_point_name)) {
       LOGS_DEFAULT(VERBOSE) << "The zero point of " << op_type << " must be known";
       return false;
+    }
+
+    bool is_conv_matmul_weight = is_qlinear_conv && idx == 5;
+    bool is_conv_matmul_u8s8_weight = false;
+    if (is_conv_matmul_weight) {
+      const auto& weight_tensor = *initializers.at(node.InputDefs()[3]->Name());
+      is_conv_matmul_u8s8_weight = weight_tensor.data_type() == ONNX_NAMESPACE::TensorProto_DataType_INT8;
+    }
+
+    const auto& zero_tensor = *initializers.at(zero_point_name);
+    int64_t zero_dim = zero_tensor.dims().empty() ? 1 : zero_tensor.dims()[0];
+
+    if (!is_conv_matmul_u8s8_weight) {
+      if (zero_dim != 1) {
+        LOGS_DEFAULT(VERBOSE) << op_type << " does not support per-channel quantization, "
+                              << " for now, only u8s8 QlinearConv supports per-channel quantization on API 29+";
+        return false;
+      }
+    } else {
+      // For u8s8 Qlinear[Conv/MatMul], we support
+      // 1. Per-tensor, the weight will be transformed to uint8 later
+      // 2. Per-channel, only from Android API level 29
+      if (zero_tensor.data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT8) {
+        LOGS_DEFAULT(VERBOSE) << "u8s8 QlinearConv only supports int8 zero point for weight, "
+                              << "actual zero point type: [" << zero_tensor.data_type() << "]";
+        return false;
+      }
+
+      if (zero_dim != 1) {
+        if (is_qlinear_matmul) {
+          LOGS_DEFAULT(VERBOSE) << "QLinearMatMul does not support per-channel quantization";
+          return false;
+        }
+      }
+
+      // For onnx, u8s8 QlinearConv, the weight zero point can be a scalar,
+      // or a tensor with same channel as weight, for NNAPI we only support it be
+      // 0 (scalar) or all 0 (tensor), NNAPI will assume the zero point for per-channel
+      // quantization is 0 there is no input for it
+      const auto& weight_tensor = *initializers.at(node.InputDefs()[3]->Name());
+      if (weight_tensor.dims()[0] != zero_dim && zero_dim != 1) {
+        LOGS_DEFAULT(VERBOSE) << op_type << " mismatch int8 per-channel quantization weight,"
+                              << " weight dimension[0] " << weight_tensor.dims()[0]
+                              << " zero point dimension " << zero_dim;
+        return false;
+      }
+
+      std::unique_ptr<uint8_t[]> unpacked_tensor;
+      size_t tensor_byte_size;
+      auto status = onnxruntime::utils::UnpackInitializerData(
+          zero_tensor,
+          node.ModelPath(),
+          unpacked_tensor, tensor_byte_size);
+      if (!status.IsOK()) {
+        LOGS_DEFAULT(ERROR) << "QLinearConv erro when unpack zero tensor:" << status.ErrorMessage();
+        return false;
+      }
+
+      // Verify all onnx weight zero point(s) are 0(s)
+      const int8_t* zero_points = reinterpret_cast<const int8_t*>(unpacked_tensor.get());
+      for (size_t i = 0; i < tensor_byte_size; i++) {
+        if (zero_points[i] != 0) {
+          LOGS_DEFAULT(VERBOSE) << "QLinearConv only support 0 as zero point, "
+                                << "zero_points[" << i << "] has value: " << zero_points[i];
+          return false;
+        }
+      }
     }
   }
 

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
@@ -271,7 +271,8 @@ bool HasValidQuantizationZeroPoints(const InitializedTensorSet& initializers, co
           node.ModelPath(),
           unpacked_tensor, tensor_byte_size);
       if (!status.IsOK()) {
-        LOGS_DEFAULT(ERROR) << "Qlinear[Conv/MatMul] error when unpack zero tensor:" << status.ErrorMessage();
+        LOGS_DEFAULT(ERROR) << "Qlinear[Conv/MatMul] error when unpack zero tensor: " << zero_point_name
+                            << ", error msg: " << status.ErrorMessage();
         return false;
       }
 

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
@@ -272,6 +272,9 @@ enum DataLayout {
   L_1230 = 1,
 };
 
+// This is primarily used for adding the weight (an initializer) of Conv
+// And perform layout change from ONNX -> NNAPI
+// If the QlinearConv is per-tensor u8s8, B will be converted from int8 to uint8
 // TODO, replace this with more efficient code in optimizers
 static Status AddInitializerInNewLayout(ModelBuilder& model_builder,
                                         const std::string& name,
@@ -363,6 +366,9 @@ static Status AddInitializerInNewLayout(ModelBuilder& model_builder,
   return model_builder.AddOperandFromPersistMemoryBuffer(name, &buffer[0], operand_type);
 }
 
+// This is primarily used for adding the input B (an initializer) of MatMul/Gemm (not transposed)
+// and transpose it, since for NNAPI only supports A*B'
+// If the QlinearMatMul is per-tensor u8s8, B will be converted from int8 to uint8
 // TODO, replace this with more efficient code in optimizers
 static Status AddInitializerTransposed(ModelBuilder& model_builder,
                                        const OperandType& source_operand_type,

--- a/onnxruntime/test/providers/cpu/math/quantize_linear_matmul_test.cc
+++ b/onnxruntime/test/providers/cpu/math/quantize_linear_matmul_test.cc
@@ -58,15 +58,15 @@ TEST(QuantizeLinearMatmulOpTest, QLinearMatMul3D_U8S8) {
   test.AddInput<uint8_t>("a_zero_point", {}, {113});
 
   test.AddInput<int8_t>("T2", {2, 4, 3},
-                         {-43, 51, -34,
-                          60, 26, -17,
-                          0, 63, -55,
-                          47, -29, -31,
+                        {-43, 51, -34,
+                         60, 26, -17,
+                         0, 63, -55,
+                         47, -29, -31,
 
-                          -62, 51, -42,
-                          60, 26, -22,
-                          0, -8, -19,
-                          37, -2, -47});
+                         -62, 51, -42,
+                         60, 26, -22,
+                         0, -8, -19,
+                         37, -2, -47});
 
   test.AddInput<float>("b_scale", {}, {0.00802f});
   test.AddInput<int8_t>("b_zero_point", {}, {-2});
@@ -81,6 +81,76 @@ TEST(QuantizeLinearMatmulOpTest, QLinearMatMul3D_U8S8) {
                            160, 101, 134});
 
   test.Run();
+}
+
+TEST(QuantizeLinearMatmulOpTest, QLinearMatMul2D_U8U8) {
+  auto run_test = [](bool only_t1_not_initializer) {
+    OpTester test("QLinearMatMul", 10);
+    test.AddInput<uint8_t>("T1", {2, 4},
+                           {208, 236, 0, 238,
+                            3, 214, 255, 29});
+
+    test.AddInput<float>("a_scale", {}, {0.0066f}, only_t1_not_initializer);
+    test.AddInput<uint8_t>("a_zero_point", {}, {113}, only_t1_not_initializer);
+
+    test.AddInput<uint8_t>("T2", {4, 3},
+                           {152, 51, 244,
+                            60, 26, 255,
+                            0, 127, 246,
+                            127, 254, 247},
+                           only_t1_not_initializer);
+
+    test.AddInput<float>("b_scale", {}, {0.00705f}, only_t1_not_initializer);
+    test.AddInput<uint8_t>("b_zero_point", {}, {114}, only_t1_not_initializer);
+
+    test.AddInput<float>("y_scale", {}, {0.0107f}, only_t1_not_initializer);
+    test.AddInput<uint8_t>("y_zero_point", {}, {118}, only_t1_not_initializer);
+    test.AddOutput<uint8_t>("T3", {2, 3},
+                            {168, 115, 255,
+                             1, 66, 151});
+
+    test.Run();
+  };
+
+  run_test(false);
+
+  // NNAPI will require all inputs except T1 to be initializers
+  run_test(true);
+}
+
+TEST(QuantizeLinearMatmulOpTest, QLinearMatMul2D_U8S8) {
+  auto run_test = [](bool only_t1_not_initializer) {
+    OpTester test("QLinearMatMul", 10);
+    test.AddInput<uint8_t>("T1", {2, 4},
+                           {208, 126, 0, 238,
+                            3, 214, 255, 29});
+
+    test.AddInput<float>("a_scale", {}, {0.0066f}, only_t1_not_initializer);
+    test.AddInput<uint8_t>("a_zero_point", {}, {113}, only_t1_not_initializer);
+
+    test.AddInput<int8_t>("T2", {4, 3},
+                          {-43, 51, -34,
+                           60, 26, -17,
+                           0, 63, -55,
+                           47, -29, -31},
+                          only_t1_not_initializer);
+
+    test.AddInput<float>("b_scale", {}, {0.00802f}, only_t1_not_initializer);
+    test.AddInput<int8_t>("b_zero_point", {}, {0}, only_t1_not_initializer);
+
+    test.AddInput<float>("y_scale", {}, {0.0123f}, only_t1_not_initializer);
+    test.AddInput<uint8_t>("y_zero_point", {}, {118}, only_t1_not_initializer);
+    test.AddOutput<uint8_t>("T3", {2, 3},
+                            {129, 94, 113,
+                             147, 154, 104});
+
+    test.Run();
+  };
+
+  run_test(false);
+
+  // NNAPI will require all inputs except T1 to be initializers
+  run_test(true);
 }
 
 static void QLinearMatMul2DTest(bool only_t1_not_initializer) {


### PR DESCRIPTION
**Description**: [NNAPI EP] Add per-tensor u8s8 support for Qlinear[Conv/MatMul]

**Motivation and Context**
- Per tensor u8s8 will have better perf for some arm devices, NNAPI does not support per-tensor u8s8 (only per-channel u8s8)
- Add a conversion from int8 to uint8 for int8 weights when we load the model into NNAPI
- Add UT for Conv2D_u8s8/u8u8

