### PR TITLE
Release buffers for prepacked tensors

### DIFF
--- a/onnxruntime/core/framework/execution_providers.h
+++ b/onnxruntime/core/framework/execution_providers.h
@@ -73,8 +73,12 @@ class ExecutionProviders {
   const_iterator begin() const noexcept { return exec_providers_.cbegin(); }
   const_iterator end() const noexcept { return exec_providers_.cend(); }
 
+  const AllocatorPtr GetDefaultCpuAllocator() const {
+    return Get(onnxruntime::kCpuExecutionProvider)->GetAllocator(0, OrtMemTypeDefault);
+  }
+
   OrtMemoryInfo GetDefaultCpuMemoryInfo() const {
-    return Get(onnxruntime::kCpuExecutionProvider)->GetAllocator(0, OrtMemTypeDefault)->Info();
+    return GetDefaultCpuAllocator()->Info();
   }
 
   const std::vector<std::string>& GetIds() const { return exec_provider_ids_; }

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -1004,10 +1004,29 @@ Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_
   MemoryInfo::GenerateTensorMap(GetExecutionPlan(), GetOrtValueNameIdxMap());
 #endif
 
-  const auto& initializer_allocation_order = p_seq_exec_plan_->initializer_allocation_order;
+  // NCCL kernels require initializers to be allocated continously. mem pattern
+  // planner is used to utilize this, where it allocates one single buffer for
+  // all initializers.
+  //
+  // In inferencing scenarios, however, we often want to pre-process and then
+  // release some initializers. See OpKernel::PrePack(). Letting all initializers
+  // sharing a single buffer makes it hard to release individual ones, leading
+  // to memory waste.
+  //
+  // TODO!! remove the #if #else #endif and combine the two branches!
+  // We should only trace tensors that are in initializer_allocation_order.
+  // Unfortunately, allocating some tensors individually leads to out of memory
+  // error in test case:
+  // 'build/RelWithDebInfo/onnxruntime_training_bert', '--model_name', 'training_e2e_test_data/models/nv/bert-large/bert-large-uncased_L_24_H_1024_A_16_V_30528_S_512_Dp_0.1_optimized_layer_norm_opset12', '--train_batch_size', '201', '--mode', 'perf', '--max_seq_length', '128', '--num_train_steps', '10', '--display_loss_steps', '5', '--optimizer', 'adam', '--learning_rate', '5e-4', '--warmup_ratio', '0.1', '--warmup_mode', 'Linear', '--gradient_accumulation_steps', '1', '--max_predictions_per_seq=20', '--allreduce_in_fp16', '--lambda', '0', '--use_nccl', '--seed', '42', '--enable_grad_norm_clip=false', '', '--use_mixed_precision']'
+#if defined(ENABLE_TRAINING) && defined(ORT_USE_NCCL)
   std::unique_ptr<ITensorAllocator> tensor_allocator(
-      ITensorAllocator::Create(enable_mem_pattern_ && !initializer_allocation_order.empty(), *p_seq_exec_plan_, *this, weights_buffers_));
+      ITensorAllocator::Create(enable_mem_pattern_, *p_seq_exec_plan_, *this, weights_buffers_));
+#else
+  std::unique_ptr<ITensorAllocator> tensor_allocator(
+      ITensorAllocator::Create(false, *p_seq_exec_plan_, *this, weights_buffers_));
+#endif
 
+  const auto& initializer_allocation_order = p_seq_exec_plan_->initializer_allocation_order;
 
   // move initializers from TensorProto instances in Graph to OrtValue instances in SessionState
   ORT_RETURN_IF_ERROR(

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -1004,10 +1004,10 @@ Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_
   MemoryInfo::GenerateTensorMap(GetExecutionPlan(), GetOrtValueNameIdxMap());
 #endif
 
-  std::unique_ptr<ITensorAllocator> tensor_allocator(
-      ITensorAllocator::Create(enable_mem_pattern_, *p_seq_exec_plan_, *this, weights_buffers_));
-
   const auto& initializer_allocation_order = p_seq_exec_plan_->initializer_allocation_order;
+  std::unique_ptr<ITensorAllocator> tensor_allocator(
+      ITensorAllocator::Create(enable_mem_pattern_ && !initializer_allocation_order.empty(), *p_seq_exec_plan_, *this, weights_buffers_));
+
 
   // move initializers from TensorProto instances in Graph to OrtValue instances in SessionState
   ORT_RETURN_IF_ERROR(

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -1013,7 +1013,7 @@ Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_
   ORT_RETURN_IF_ERROR(
       session_state_utils::SaveInitializedTensors(
           Env::Default(), graph_location, *graph_viewer_,
-          execution_providers_.GetDefaultCpuMemoryInfo(),
+          execution_providers_.GetDefaultCpuAllocator(),
           ort_value_name_idx_map_, initializer_allocation_order, *tensor_allocator,
           [this](int idx, const OrtValue& value, const OrtCallback& d, bool constant) -> Status {
             return AddInitializedTensor(idx, value, &d, constant);

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -31,58 +31,59 @@ namespace onnxruntime {
 namespace session_state_utils {
 
 static common::Status DeserializeTensorProto(const Env& env, const std::basic_string<PATH_CHAR_TYPE>& proto_path,
-                                             const ONNX_NAMESPACE::TensorProto& tensor_proto, const MemBuffer& m,
-                                             const OrtMemoryInfo& default_cpu_memory_info, OrtValue& ort_value,
-                                             OrtCallback& deleter,
-                                             const DataTransferManager& data_transfer_mgr) {
-  const OrtMemoryInfo& alloc_info = m.GetAllocInfo();
-  if (strcmp(alloc_info.name, CPU) == 0 || alloc_info.mem_type == OrtMemTypeCPUOutput) {
-    // deserialize directly to CPU tensor
-    return utils::TensorProtoToMLValue(env, proto_path.c_str(), tensor_proto, m, ort_value, deleter);
+                                             const ONNX_NAMESPACE::TensorProto& tensor_proto, const MemBuffer* m,
+                                             const AllocatorPtr& alloc, const AllocatorPtr& default_cpu_alloc,
+                                             OrtValue& ort_value, const DataTransferManager& data_transfer_mgr) {
+  if (bool(alloc) == (m != nullptr)) {
+    return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, 
+        "DeserializeTensorProto() takes either pre-allocated buffer or an allocator!");
   }
 
-  // deserialize and copy. In the copy stage, it won't check if the buffer has enough room.
-  // The result tensor won't need a deleter because:
-  // 1. It mustn't be a string tensor
-  // 2. The memory is not memory-mapped.
-  deleter.f = nullptr;
-  deleter.param = nullptr;
-  if (tensor_proto.data_type() == ONNX_NAMESPACE::TensorProto_DataType_STRING) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "string tensor is not supported for copying between allocators");
+  // Get shape and type of the tensor, and allocate the empty tensor
+  const auto& dims = tensor_proto.dims();
+  std::vector<int64_t> tensor_shape_vec(static_cast<size_t>(dims.size()));
+  for (int i = 0; i < dims.size(); ++i) {
+    tensor_shape_vec[i] = dims[i];
   }
-
-  // deserialize to CPU first for non-CPU allocator, then alloc and copy
-  size_t cpu_tensor_length;
-  ORT_RETURN_IF_ERROR(utils::GetSizeInBytesFromTensorProto<0>(tensor_proto, &cpu_tensor_length));
-  if (m.GetLen() < cpu_tensor_length) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Internal error. The preallocated buffer is too small. Requires ",
-                           cpu_tensor_length, ", Got ", m.GetLen());
-  }
-
-  std::unique_ptr<char[]> data(new char[cpu_tensor_length]);
+  TensorShape tensor_shape{tensor_shape_vec};
+  const DataTypeImpl* const type = DataTypeImpl::TensorTypeFromONNXEnum(tensor_proto.data_type())->GetElementType();
   std::unique_ptr<Tensor> p_tensor;
-  OrtValue tmp_ort_value;
-  OrtCallback d;
-  ORT_RETURN_IF_ERROR(utils::TensorProtoToMLValue(env, proto_path.c_str(), tensor_proto,
-                                                  MemBuffer(data.get(), cpu_tensor_length, default_cpu_memory_info),
-                                                  tmp_ort_value, d));
-
-  const Tensor& p_deserialize_tensor = tmp_ort_value.Get<Tensor>();
-
-  p_tensor = onnxruntime::make_unique<Tensor>(p_deserialize_tensor.DataType(), p_deserialize_tensor.Shape(), m.GetBuffer(),
-                                              m.GetAllocInfo());
-  // TODO: does this function work for string tensor?
-  Status copy_status = data_transfer_mgr.CopyTensor(p_deserialize_tensor, *p_tensor);
-  if (d.f) d.f(d.param);
-
-  if (!copy_status.IsOK()) {
-    if (copy_status.ErrorMessage().empty()) {
-      // The windows execution provider does not return any error message today for CopyTensor since it is
-      // not implemented yet. That's the reason we're adding our own error message so that we can debug better.
-      return Status(copy_status.Category(), copy_status.Code(),
-                    "Failed to copy tensor to " + p_tensor->Location().ToString());
+  if (m != nullptr) {
+    p_tensor = onnxruntime::make_unique<Tensor>(type, tensor_shape, m->GetBuffer(), m->GetAllocInfo());
+    if (m->GetLen() < p_tensor->SizeInBytes()) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Internal error. The preallocated buffer is too small. Requires ",
+                             p_tensor->SizeInBytes(), ", Got ", m->GetLen());
     }
-    return copy_status;
+  } else {
+    // tensor constructor should give us enough buffer size based on type and shape
+    p_tensor = onnxruntime::make_unique<Tensor>(type, tensor_shape, alloc);
+  }
+
+  if (strcmp(p_tensor->Location().name, CPU) == 0 || p_tensor->Location().mem_type == OrtMemTypeCPUOutput) {
+    // deserialize directly to CPU tensor
+    ORT_RETURN_IF_ERROR(utils::TensorProtoToTensor(env, proto_path.c_str(), tensor_proto, *p_tensor));
+  } else {
+    // non-cpu tensor
+    if (tensor_proto.data_type() == ONNX_NAMESPACE::TensorProto_DataType_STRING) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "string tensor is not supported for copying between allocators");
+    }
+
+    // deserialize to CPU first for non-CPU allocator, then copy
+    std::unique_ptr<Tensor> p_deserialize_tensor = onnxruntime::make_unique<Tensor>(type, tensor_shape, default_cpu_alloc);
+    ORT_RETURN_IF_ERROR(utils::TensorProtoToTensor(env, proto_path.c_str(), tensor_proto, *p_deserialize_tensor));
+    // TODO!! Need a temp buffer allocator for non-escape buffers that maybe too big for stack allocation.
+
+    Status copy_status = data_transfer_mgr.CopyTensor(*p_deserialize_tensor, *p_tensor);
+
+    if (!copy_status.IsOK()) {
+      if (copy_status.ErrorMessage().empty()) {
+        // The windows execution provider does not return any error message today for CopyTensor since it is
+        // not implemented yet. That's the reason we're adding our own error message so that we can debug better.
+        return Status(copy_status.Category(), copy_status.Code(),
+                      "Failed to copy tensor to " + p_tensor->Location().ToString());
+      }
+      return copy_status;
+    }
   }
 
   auto ml_tensor = DataTypeImpl::GetType<Tensor>();
@@ -92,7 +93,7 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
 
 common::Status SaveInitializedTensors(
     const Env& env, const std::basic_string<PATH_CHAR_TYPE>& graph_loc,
-    const GraphViewer& graph, const OrtMemoryInfo& default_cpu_memory_info,
+    const GraphViewer& graph, const AllocatorPtr& default_cpu_alloc,
     const OrtValueNameIdxMap& ort_value_name_idx_map,
     const std::vector<OrtValueIndex>& initializer_allocation_order,
     ITensorAllocator& planner,
@@ -149,7 +150,9 @@ common::Status SaveInitializedTensors(
   auto initialized_tensors_to_allocate = id_to_initialized_tensor;
   for (int ort_value_index : initializer_allocation_order) {
     const auto entry = initialized_tensors_to_allocate.find(ort_value_index);
-    ORT_ENFORCE(entry != initialized_tensors_to_allocate.end());
+    // can not trace string tensor
+    ORT_ENFORCE(entry != initialized_tensors_to_allocate.end() 
+        && entry->second->data_type() != ONNX_NAMESPACE::TensorProto_DataType_STRING);
     ORT_RETURN_IF_ERROR(planner.Trace(entry->first, entry->second));
     initialized_tensors_to_allocate.erase(entry);
   }
@@ -157,6 +160,10 @@ common::Status SaveInitializedTensors(
   for (const auto& entry : initialized_tensors_to_allocate) {
     // We don't want to trace shared initializers since their memory is provided by the user
     if (user_supplied_initializer_ids.find(entry.first) != user_supplied_initializer_ids.end()) {
+      continue;
+    }
+    if (entry.second->data_type() == ONNX_NAMESPACE::TensorProto_DataType_STRING) {
+        // do not trace string tensor
       continue;
     }
     ORT_RETURN_IF_ERROR(planner.Trace(entry.first, entry.second));
@@ -193,13 +200,15 @@ common::Status SaveInitializedTensors(
       const ONNX_NAMESPACE::TensorProto& tensor_proto = *(entry.second);
 
       std::unique_ptr<MemBuffer> m;
+      AllocatorPtr alloc;
       // TODO: if the tensor need be copied, does it have enough room?
-      ORT_RETURN_IF_ERROR(planner.GetPreallocatedBuffer(ort_value_index, name, m));
+      ORT_RETURN_IF_ERROR(planner.GetPreallocatedBuffer(ort_value_index, name, m, alloc));
 #ifndef NDEBUG
-      ORT_ENFORCE(m != nullptr);
-      ORT_ENFORCE(m->GetBuffer() != nullptr || m->GetLen() == 0);
+      if (m != nullptr) {
+        ORT_ENFORCE(m->GetBuffer() != nullptr || m->GetLen() == 0);
+      }
 #endif
-      Status st = DeserializeTensorProto(env, graph_loc, tensor_proto, *m, default_cpu_memory_info, ort_value, deleter,
+      Status st = DeserializeTensorProto(env, graph_loc, tensor_proto, m.get(), alloc, default_cpu_alloc, ort_value,
                                          data_transfer_mgr);
       if (!st.IsOK()) {
         std::ostringstream oss;

--- a/onnxruntime/core/framework/session_state_utils.h
+++ b/onnxruntime/core/framework/session_state_utils.h
@@ -32,7 +32,7 @@ class Logger;
 namespace session_state_utils {
 common::Status SaveInitializedTensors(
     const Env& env, const std::basic_string<PATH_CHAR_TYPE>& graph_loc,
-    const GraphViewer& graph, const OrtMemoryInfo& default_cpu_memory_info,
+    const GraphViewer& graph, const AllocatorPtr& default_cpu_memory_info,
     const OrtValueNameIdxMap& ort_value_name_idx_map, const std::vector<OrtValueIndex>& initializer_allocation_order,
     ITensorAllocator& planner,
     const std::function<Status(int idx, const OrtValue& value, const OrtCallback& d, bool constant)>& save_tensor_func,

--- a/onnxruntime/core/framework/simple_tensor_allocator.cc
+++ b/onnxruntime/core/framework/simple_tensor_allocator.cc
@@ -11,15 +11,18 @@ common::Status SimpleTensorAllocator::Trace(int id, const ONNX_NAMESPACE::Tensor
 }
 
 common::Status SimpleTensorAllocator::GetPreallocatedBuffer(int ort_value_index, const char* name,
-                                                            std::unique_ptr<MemBuffer>& out) {
+                                                            std::unique_ptr<MemBuffer>& out,
+                                                            AllocatorPtr& alloc_out) {
+  const struct OrtMemoryInfo& location = seq_plan_.GetLocation(ort_value_index);
   auto iter = values_.find(ort_value_index);
   if (iter == values_.end()) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "invalid ort_value_index:", ort_value_index);
+    // not traced, only return allocator
+    alloc_out = GetAllocator(location);
+    return Status::OK();
   }
 
   size_t len = 0;
   ORT_RETURN_IF_ERROR(utils::GetSizeInBytesFromTensorProto<kAllocAlignment>(*iter->second, &len));
-  const struct OrtMemoryInfo& location = seq_plan_.GetLocation(ort_value_index);
   if (len == 0) {
     out = onnxruntime::make_unique<MemBuffer>(nullptr, 0, location);
     return Status::OK();

--- a/onnxruntime/core/framework/simple_tensor_allocator.cc
+++ b/onnxruntime/core/framework/simple_tensor_allocator.cc
@@ -5,35 +5,16 @@
 #include "tensorprotoutils.h"
 
 namespace onnxruntime {
-common::Status SimpleTensorAllocator::Trace(int id, const ONNX_NAMESPACE::TensorProto* value) {
-  values_[id] = value;
+common::Status SimpleTensorAllocator::Trace(int /*id*/, const ONNX_NAMESPACE::TensorProto* /*value*/) {
   return Status::OK();
 }
 
-common::Status SimpleTensorAllocator::GetPreallocatedBuffer(int ort_value_index, const char* name,
-                                                            std::unique_ptr<MemBuffer>& out,
+common::Status SimpleTensorAllocator::GetPreallocatedBuffer(int ort_value_index, const char* /*name*/,
+                                                            std::unique_ptr<MemBuffer>& /*out*/,
                                                             AllocatorPtr& alloc_out) {
   const struct OrtMemoryInfo& location = seq_plan_.GetLocation(ort_value_index);
-  auto iter = values_.find(ort_value_index);
-  if (iter == values_.end()) {
-    // not traced, only return allocator
+    // just return allocator and let others handle it.
     alloc_out = GetAllocator(location);
     return Status::OK();
-  }
-
-  size_t len = 0;
-  ORT_RETURN_IF_ERROR(utils::GetSizeInBytesFromTensorProto<kAllocAlignment>(*iter->second, &len));
-  if (len == 0) {
-    out = onnxruntime::make_unique<MemBuffer>(nullptr, 0, location);
-    return Status::OK();
-  }
-  auto alloc = GetAllocator(location);
-  if (!alloc)
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to get allocator for initializer '", name,
-                           "', location: ", location.ToString());
-  void* buffer = alloc->Alloc(len);
-  weights_buffers_.push_back(BufferUniquePtr(buffer, alloc));
-  out = onnxruntime::make_unique<MemBuffer>(buffer, len, location);
-  return Status::OK();
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/simple_tensor_allocator.cc
+++ b/onnxruntime/core/framework/simple_tensor_allocator.cc
@@ -10,7 +10,7 @@ common::Status SimpleTensorAllocator::Trace(int /*id*/, const ONNX_NAMESPACE::Te
 }
 
 common::Status SimpleTensorAllocator::GetPreallocatedBuffer(int ort_value_index, const char* /*name*/,
-                                                            std::unique_ptr<MemBuffer>& /*out*/,
+                                                            std::unique_ptr<MemBuffer>& /*buf_out*/,
                                                             AllocatorPtr& alloc_out) {
   const struct OrtMemoryInfo& location = seq_plan_.GetLocation(ort_value_index);
     // just return allocator and let others handle it.

--- a/onnxruntime/core/framework/simple_tensor_allocator.h
+++ b/onnxruntime/core/framework/simple_tensor_allocator.h
@@ -15,17 +15,12 @@ class ExecutionProviders;
 class SimpleTensorAllocator : public ITensorAllocator {
  private:
   MemoryPatternGroup mem_patterns_;
-  std::vector<BufferUniquePtr>& weights_buffers_;
   const ExecutionPlanBase& seq_plan_;
-
- private:
-  std::unordered_map<int, const ONNX_NAMESPACE::TensorProto*> values_;
 
  public:
   SimpleTensorAllocator(const ExecutionPlanBase& execution_plan, const SessionState& session_state,
-                        std::vector<BufferUniquePtr>& weights_buffers)
+                        std::vector<BufferUniquePtr>& /*weights_buffers*/)
       : ITensorAllocator(session_state),
-        weights_buffers_(weights_buffers),
         seq_plan_(execution_plan) {}
 
   common::Status FinalizePlan(std::unordered_map<std::string, size_t>& planned_memory_sizes_in_byte) override {

--- a/onnxruntime/core/framework/simple_tensor_allocator.h
+++ b/onnxruntime/core/framework/simple_tensor_allocator.h
@@ -29,7 +29,7 @@ class SimpleTensorAllocator : public ITensorAllocator {
     planned_memory_sizes_in_byte = std::unordered_map<std::string, size_t>();
     return Status::OK();
   }
-  common::Status GetPreallocatedBuffer(int ort_value_index, const char* name, std::unique_ptr<MemBuffer>& out, AllocatorPtr& alloc_out) override;
+  common::Status GetPreallocatedBuffer(int ort_value_index, const char* name, std::unique_ptr<MemBuffer>& buf_out, AllocatorPtr& alloc_out) override;
   common::Status Trace(int id, const ONNX_NAMESPACE::TensorProto* value) override;
   const MemoryPatternGroup& GetMemPatterns() override {
     return mem_patterns_;

--- a/onnxruntime/core/framework/simple_tensor_allocator.h
+++ b/onnxruntime/core/framework/simple_tensor_allocator.h
@@ -34,7 +34,7 @@ class SimpleTensorAllocator : public ITensorAllocator {
     planned_memory_sizes_in_byte = std::unordered_map<std::string, size_t>();
     return Status::OK();
   }
-  common::Status GetPreallocatedBuffer(int ort_value_index, const char* name, std::unique_ptr<MemBuffer>& out) override;
+  common::Status GetPreallocatedBuffer(int ort_value_index, const char* name, std::unique_ptr<MemBuffer>& out, AllocatorPtr& alloc_out) override;
   common::Status Trace(int id, const ONNX_NAMESPACE::TensorProto* value) override;
   const MemoryPatternGroup& GetMemPatterns() override {
     return mem_patterns_;

--- a/onnxruntime/core/framework/tensor_allocator.h
+++ b/onnxruntime/core/framework/tensor_allocator.h
@@ -35,15 +35,20 @@ class ITensorAllocator {
   virtual common::Status FinalizePlan(std::unordered_map<std::string, size_t>& planned_memory_sizes_in_byte) = 0;
 
   /**
-   *
-   * \param ort_value_index The index in planner
-   * \param name Tensor name. Only for logging purpose
-   * \param out The allocated buffer
-   *
-   * When it succeeded, p could be NULL if the tensor with 'ort_value_index' will not have any element
-   */
+   * Handing out buffers reserved in @see #Trace() via parameter buf_out,
+   * or, in the case of not reserved tensor, returns an allocator so that
+   * the caller can take care of the dynamic buffer allocation.
+   * buf_out and alloc_out, one and only one can be non-null
+   * 
+   * @param ort_value_index [In]   int id of the tensor 
+   * @param name            [In]   name of the tensor
+   * @param buf_out         [Out]  pre reserved buffer, if not null
+   * @param alloc_out       [Out]  allocator based on tensor's location, if not null
+   * @return 
+  */
   virtual common::Status GetPreallocatedBuffer(int ort_value_index, const char* name,
-                                               std::unique_ptr<MemBuffer>& out, AllocatorPtr& alloc_out) = 0;
+                                               std::unique_ptr<MemBuffer>& buf_out,
+                                               AllocatorPtr& alloc_out) = 0;
 
   virtual const MemoryPatternGroup& GetMemPatterns() = 0;
   /**

--- a/onnxruntime/core/framework/tensor_allocator.h
+++ b/onnxruntime/core/framework/tensor_allocator.h
@@ -43,7 +43,7 @@ class ITensorAllocator {
    * When it succeeded, p could be NULL if the tensor with 'ort_value_index' will not have any element
    */
   virtual common::Status GetPreallocatedBuffer(int ort_value_index, const char* name,
-                                               std::unique_ptr<MemBuffer>& out) = 0;
+                                               std::unique_ptr<MemBuffer>& out, AllocatorPtr& alloc_out) = 0;
 
   virtual const MemoryPatternGroup& GetMemPatterns() = 0;
   /**

--- a/onnxruntime/core/framework/tensor_allocator_with_mem_pattern.h
+++ b/onnxruntime/core/framework/tensor_allocator_with_mem_pattern.h
@@ -73,7 +73,7 @@ class TensorAllocatorWithMemPattern : public ITensorAllocator {
   }
 
   common::Status GetPreallocatedBuffer(int ort_value_index, const char* name,
-                                       std::unique_ptr<MemBuffer>& out, AllocatorPtr& alloc_out) override {
+                                       std::unique_ptr<MemBuffer>& buf_out, AllocatorPtr& alloc_out) override {
     if (!is_sealed_) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Internal error.");
     }
@@ -95,7 +95,7 @@ class TensorAllocatorWithMemPattern : public ITensorAllocator {
     if (it == buffers_.end()) {
       if (block != nullptr && block->size_ == 0) {
         // Because the size is 0, this miss find is expected. we won't allocate a buffer with size of zero.
-        out = onnxruntime::make_unique<MemBuffer>(nullptr, 0, location);
+        buf_out = onnxruntime::make_unique<MemBuffer>(nullptr, 0, location);
         return Status::OK();
       }
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Weight buffer for initializer '", name, "' is not found");
@@ -105,7 +105,7 @@ class TensorAllocatorWithMemPattern : public ITensorAllocator {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Get preallocated buffer for initializer '", name, "' failed");
     }
 
-    out = onnxruntime::make_unique<MemBuffer>(reinterpret_cast<char*>(it->second) + block->offset_, block->size_, location);
+    buf_out = onnxruntime::make_unique<MemBuffer>(reinterpret_cast<char*>(it->second) + block->offset_, block->size_, location);
     return Status::OK();
   }
   common::Status Trace(int id, const ONNX_NAMESPACE::TensorProto* value) override {

--- a/onnxruntime/core/framework/tensor_allocator_with_mem_pattern.h
+++ b/onnxruntime/core/framework/tensor_allocator_with_mem_pattern.h
@@ -73,7 +73,7 @@ class TensorAllocatorWithMemPattern : public ITensorAllocator {
   }
 
   common::Status GetPreallocatedBuffer(int ort_value_index, const char* name,
-                                       std::unique_ptr<MemBuffer>& out) override {
+                                       std::unique_ptr<MemBuffer>& out, AllocatorPtr& alloc_out) override {
     if (!is_sealed_) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Internal error.");
     }
@@ -86,6 +86,11 @@ class TensorAllocatorWithMemPattern : public ITensorAllocator {
     // fall back to allocate separate buffer.
     // if it->second.get() is null, then fall back to the block not found case
     auto block = pattern->GetBlock(ort_value_index);
+    if (nullptr == block) {
+      // not traced, only return allocator
+      alloc_out = GetAllocator(location);
+      return Status::OK();
+    }
     auto it = buffers_.find(location);
     if (it == buffers_.end()) {
       if (block != nullptr && block->size_ == 0) {

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -39,8 +39,18 @@ TensorShape GetTensorShapeFromTensorShapeProto(const ONNX_NAMESPACE::TensorShape
  *                        relative path or an absolute path.
  */
 common::Status TensorProtoToMLValue(const Env& env, const ORTCHAR_T* tensor_proto_path,
-                                    const ONNX_NAMESPACE::TensorProto& input, const MemBuffer& m, OrtValue& value,
-                                    OrtCallback& deleter);
+                                    const ONNX_NAMESPACE::TensorProto& input, const MemBuffer& m, OrtValue& value);
+/**
+ * @brief Deserialize a TensorProto into a preallocated empty Tensor
+ * @param env 
+ * @param model_path 
+ * @param tensor_proto  source data
+ * @param tensorp       destination empty tensor
+ * @return 
+*/
+common::Status TensorProtoToTensor(const Env& env, const ORTCHAR_T* model_path,
+                           const ONNX_NAMESPACE::TensorProto& tensor_proto,
+                           Tensor& tensorp);
 
 /** Creates a TensorProto from a Tensor.
     @param[in] tensor the Tensor whose data and shape will be used to create the TensorProto.

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -32,7 +32,9 @@ class Tensor;
 namespace utils {
 TensorShape GetTensorShapeFromTensorShapeProto(const ONNX_NAMESPACE::TensorShapeProto& tensor_shape_proto);
 
-/**
+std::vector<int64_t> GetTensorShapeFromTensorProto(const ONNX_NAMESPACE::TensorProto& tensor_proto);
+
+    /**
  * deserialize a TensorProto into a preallocated memory buffer.
  * \param tensor_proto_path A local file path of where the 'input' was loaded from. Can be NULL if the tensor proto doesn't
  *                        have any external data or it was loaded from current working dir. This path could be either a
@@ -50,7 +52,7 @@ common::Status TensorProtoToMLValue(const Env& env, const ORTCHAR_T* tensor_prot
 */
 common::Status TensorProtoToTensor(const Env& env, const ORTCHAR_T* model_path,
                            const ONNX_NAMESPACE::TensorProto& tensor_proto,
-                           Tensor& tensorp);
+                           Tensor& tensor);
 
 /** Creates a TensorProto from a Tensor.
     @param[in] tensor the Tensor whose data and shape will be used to create the TensorProto.

--- a/onnxruntime/core/optimizer/optimizer_execution_frame.cc
+++ b/onnxruntime/core/optimizer/optimizer_execution_frame.cc
@@ -41,18 +41,14 @@ OptimizerExecutionFrame::Info::Info(const std::vector<const Node*>& nodes,
       OrtValue ort_value;
       std::unique_ptr<char[]> data(new char[cpu_tensor_length]);
       std::unique_ptr<Tensor> p_tensor;
-      OrtCallback d;
       ORT_RETURN_IF_ERROR(utils::TensorProtoToMLValue(Env::Default(),
                                                       model_path.IsEmpty() ? nullptr : model_path.ToPathString().c_str(),
                                                       tensor_proto,
                                                       MemBuffer(data.get(), cpu_tensor_length, allocator_ptr_->Info()),
-                                                      ort_value,
-                                                      d));
+                                                      ort_value));
 
       initializers_[idx] = ort_value;
       buffer_for_initialized_tensors_[idx] = std::move(data);
-      if (d.f != nullptr)
-        deleter_for_initialized_tensors_[idx] = d;
     }
 
     return Status::OK();

--- a/onnxruntime/core/providers/cuda/rnn/cudnn_rnn_base.cc
+++ b/onnxruntime/core/providers/cuda/rnn/cudnn_rnn_base.cc
@@ -96,6 +96,13 @@ Status CudnnRnnBase<T>::ReorganizeWeights(const Tensor* W, const Tensor* R, cons
   // Prepare the weight data
   reorganized_w_data = GetScratchBuffer<void>(w_size * sizeof(T));
 
+  // In many cases, this allocation is bigger than needed, leaving part of
+  // the buffer unintialized. non-zero garbage data leads to wrong result
+  // in call to cudnnRNNForwardInference()
+  // TODO! refine allocation size for each case.
+  cudaMemset(reorganized_w_data.get(), 0, w_size * sizeof(T));
+
+
   const T* W_data = W->template Data<T>();
   const T* R_data = R->template Data<T>();
   const T* B_data = B == nullptr ? nullptr : B->template Data<T>();

--- a/onnxruntime/test/framework/test_tensor_loader.cc
+++ b/onnxruntime/test/framework/test_tensor_loader.cc
@@ -29,15 +29,11 @@ TEST(CApiTensorTest, load_simple_float_tensor_not_enough_space) {
   // deserialize it
   std::vector<float> output(1);
   OrtValue value;
-  auto deleter = onnxruntime::make_unique<onnxruntime::OrtCallback>();
   OrtMemoryInfo cpu_memory_info(onnxruntime::CPU, OrtDeviceAllocator, OrtDevice(), 0, OrtMemTypeDefault);
   auto st = utils::TensorProtoToMLValue(Env::Default(), nullptr, p,
-                                        MemBuffer(output.data(), output.size() * sizeof(float), cpu_memory_info), value, *deleter);
+                                        MemBuffer(output.data(), output.size() * sizeof(float), cpu_memory_info), value);
   // check the result
   ASSERT_FALSE(st.IsOK());
-  if (deleter->f) {
-    OrtRunCallback(deleter.release());
-  }
 }
 
 TEST(CApiTensorTest, load_simple_float_tensor) {
@@ -54,10 +50,9 @@ TEST(CApiTensorTest, load_simple_float_tensor) {
   // deserialize it
   std::vector<float> output(3);
   OrtValue value;
-  auto deleter = onnxruntime::make_unique<onnxruntime::OrtCallback>();
   OrtMemoryInfo cpu_memory_info(onnxruntime::CPU, OrtDeviceAllocator, OrtDevice(), 0, OrtMemTypeDefault);
   auto st = utils::TensorProtoToMLValue(Env::Default(), nullptr, p,
-                                        MemBuffer(output.data(), output.size() * sizeof(float), cpu_memory_info), value, *deleter);
+                                        MemBuffer(output.data(), output.size() * sizeof(float), cpu_memory_info), value);
   ASSERT_TRUE(st.IsOK()) << st.ErrorMessage();
   float* real_output;
   auto ort_st = g_ort->GetTensorMutableData(&value, (void**)&real_output);
@@ -67,9 +62,6 @@ TEST(CApiTensorTest, load_simple_float_tensor) {
   ASSERT_EQ(real_output[1], 2.2f);
   ASSERT_EQ(real_output[2], 3.5f);
   g_ort->ReleaseStatus(ort_st);
-  if (deleter->f) {
-    OrtRunCallback(deleter.release());
-  }
 }
 
 template <bool use_current_dir>
@@ -113,10 +105,9 @@ static void run_external_data_test() {
 #endif
   }
   OrtValue value;
-  auto deleter = onnxruntime::make_unique<onnxruntime::OrtCallback>();
   OrtMemoryInfo cpu_memory_info(onnxruntime::CPU, OrtDeviceAllocator, OrtDevice(), 0, OrtMemTypeDefault);
   auto st = utils::TensorProtoToMLValue(Env::Default(), nullptr, p,
-                                        MemBuffer(output.data(), output.size() * sizeof(float), cpu_memory_info), value, *deleter);
+                                        MemBuffer(output.data(), output.size() * sizeof(float), cpu_memory_info), value);
   ASSERT_TRUE(st.IsOK()) << st.ErrorMessage();
   float* real_output;
   auto ort_st = g_ort->GetTensorMutableData(&value, (void**)&real_output);
@@ -126,9 +117,6 @@ static void run_external_data_test() {
   ASSERT_EQ(real_output[1], 2.2f);
   ASSERT_EQ(real_output[2], 3.5f);
   g_ort->ReleaseStatus(ort_st);
-  if (deleter->f) {
-    OrtRunCallback(deleter.release());
-  }
 }
 
 TEST(CApiTensorTest, load_float_tensor_with_external_data) {
@@ -167,10 +155,9 @@ TEST(CApiTensorTest, load_huge_tensor_with_external_data) {
   // deserialize it
   std::vector<int> output(total_ele_count);
   OrtValue value;
-  auto deleter = onnxruntime::make_unique<onnxruntime::OrtCallback>();
   OrtMemoryInfo cpu_memory_info(onnxruntime::CPU, OrtDeviceAllocator, OrtDevice(), 0, OrtMemTypeDefault);
   auto st = utils::TensorProtoToMLValue(Env::Default(), nullptr, p,
-                                        MemBuffer(output.data(), output.size() * sizeof(int), cpu_memory_info), value, *deleter);
+                                        MemBuffer(output.data(), output.size() * sizeof(int), cpu_memory_info), value);
 
   // check the result
   ASSERT_TRUE(st.IsOK()) << "Error from TensorProtoToMLValue: " << st.ErrorMessage();
@@ -181,9 +168,6 @@ TEST(CApiTensorTest, load_huge_tensor_with_external_data) {
     ASSERT_EQ(1, buffer[i]);
   }
   g_ort->ReleaseStatus(ort_st);
-  if (deleter->f) {
-    OrtRunCallback(deleter.release());
-  }
 }
 #endif
 #endif

--- a/orttraining/orttraining/models/runner/training_runner.cc
+++ b/orttraining/orttraining/models/runner/training_runner.cc
@@ -1225,7 +1225,6 @@ Status WithOrtValuesFromTensorProtos(
 
   NameMLValMap name_to_ort_value{};
   std::vector<std::vector<char>> tensor_buffers{};
-  std::vector<ScopedOrtCallbackInvoker> tensor_deleters{};
 
   for (const auto& tensor_proto : tensor_protos) {
     const auto* tensor_type = DataTypeImpl::TensorTypeFromONNXEnum(tensor_proto.data_type());
@@ -1239,16 +1238,13 @@ Status WithOrtValuesFromTensorProtos(
     const MemBuffer mem_buffer{tensor_buffer.data(), tensor_buffer.size(), cpu_alloc_info};
 
     OrtValue ort_value;
-    OrtCallback callback;
 
     ORT_RETURN_IF_ERROR(utils::TensorProtoToMLValue(
         Env::Default(), model_location.c_str(), tensor_proto, mem_buffer,
-        ort_value, callback));
-    ScopedOrtCallbackInvoker callback_invoker{callback};
+        ort_value));
 
     name_to_ort_value.emplace(tensor_proto.name(), ort_value);
     tensor_buffers.emplace_back(std::move(tensor_buffer));
-    tensor_deleters.emplace_back(std::move(callback_invoker));
   }
 
   ORT_RETURN_IF_ERROR(use_name_to_ort_value_fn(name_to_ort_value));

--- a/orttraining/orttraining/models/runner/training_util.cc
+++ b/orttraining/orttraining/models/runner/training_util.cc
@@ -52,15 +52,11 @@ common::Status DataSet::AddData(const vector<ONNX_NAMESPACE::TensorProto>& featu
     OrtValue ort_value;
     OrtMemoryInfo info("Cpu", OrtDeviceAllocator, OrtDevice{}, 0, OrtMemTypeDefault);
     std::unique_ptr<char[]> buffer(new char[cpu_tensor_length]);
-    OrtCallback deleter;
     ORT_RETURN_IF_ERROR(utils::TensorProtoToMLValue(
-        Env::Default(), nullptr, tensor_proto, MemBuffer(buffer.get(), cpu_tensor_length, info), ort_value, deleter));
+        Env::Default(), nullptr, tensor_proto, MemBuffer(buffer.get(), cpu_tensor_length, info), ort_value));
 
     sample->push_back(ort_value);
     ortvalue_buffers_.emplace_back(std::move(buffer));
-    if (deleter.f != nullptr) {
-      ortvalue_deleters_.emplace_back(deleter);
-    }
   }
 
   data_.emplace_back(move(sample));

--- a/orttraining/orttraining/test/framework/checkpointing_test.cc
+++ b/orttraining/orttraining/test/framework/checkpointing_test.cc
@@ -53,7 +53,6 @@ void CompareOrtValuesToTensorProtoValues(
 
   NameMLValMap name_to_ort_value_from_tensor_proto{};
   std::vector<std::vector<char>> tensor_buffers{};
-  std::vector<ScopedOrtCallbackInvoker> tensor_deleters{};
 
   for (const auto& name_and_tensor_proto : name_to_tensor_proto) {
     const auto& name = name_and_tensor_proto.first;
@@ -63,14 +62,11 @@ void CompareOrtValuesToTensorProtoValues(
     std::vector<char> tensor_buffer(shape.Size() * sizeof(float));
     MemBuffer m(tensor_buffer.data(), tensor_buffer.size(), cpu_alloc_info);
     OrtValue ort_value;
-    OrtCallback callback;
     ASSERT_STATUS_OK(utils::TensorProtoToMLValue(
-        Env::Default(), model_path.c_str(), tensor_proto, m, ort_value, callback));
-    ScopedOrtCallbackInvoker callback_invoker{callback};
+        Env::Default(), model_path.c_str(), tensor_proto, m, ort_value));
 
     name_to_ort_value_from_tensor_proto.emplace(name, ort_value);
     tensor_buffers.emplace_back(std::move(tensor_buffer));
-    tensor_deleters.emplace_back(std::move(callback_invoker));
   }
 
   for (const auto& name_and_ort_value : name_to_ort_value) {


### PR DESCRIPTION
**Description**:

Enable initializer tensor allocator to transfer buffer ownership to Tensors, so that these buffers can be released after these initializers are prepacked. 

**Motivation and Context**

Prepacking is a kind of operation, where some kernels pre-process weight tensors into another form, in order to speed up inferencing. Prepacking often results in a bigger blob. So kernels usually store the prepacking results into other memory buffers. After prepacking, the original tensors should be deleted to save memory.

Currently, even after these weight tensors are deleted, their memory buffers are not released, resulting in memory waste. This change try to release these buffers when it is possible. There are two implementations of tensor allocators: 1) mem pattern planner based allocator tries to allocate all initializers on a single buffer. It's very hard to release individual tensor buffers in this case. 2) simple tensor allocator allocates each tensors individually. However, it does not give ownership of the buffer to the tensor, so we can not release the buffer either.

This change focus on 2) above. In simple tensor allocators, we tries to give up buffer ownership, and transfer it to the tensor.

TODO about mem pattern planner based allocator, do we have to trace all the initializers? Can we only trace those that needs to be allocated continuously (currently only inputs to nccl kernels, it seems), and let the simple tensor allocators handle the rest?

