### PR TITLE
Add support for op kernel type control required types, require int64 for some ops

### DIFF
--- a/onnxruntime/core/common/type_set_utils.h
+++ b/onnxruntime/core/common/type_set_utils.h
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "boost/mp11.hpp"
+
+namespace onnxruntime {
+namespace utils {
+namespace type_set {
+
+// Given type sets A and B, IsSubset<A, B>::value is true when each element in A is also in B.
+template <typename A, typename B>
+struct IsSubset {
+  static_assert(boost::mp11::mp_is_set<A>::value && boost::mp11::mp_is_set<B>::value,
+                "A and B must be type sets.");
+
+  static constexpr bool value =
+      // each element of A is contained in B
+      boost::mp11::mp_all_of_q<
+          A,
+          boost::mp11::mp_bind_front<boost::mp11::mp_set_contains, B>>::value;
+};
+
+// Given type sets A and B, IsEqual<A, B>::value is true when A contains the same elements as B.
+template <typename A, typename B>
+struct IsEqual {
+  static_assert(boost::mp11::mp_is_set<A>::value && boost::mp11::mp_is_set<B>::value,
+                "A and B must be type sets.");
+
+  static constexpr bool value =
+      boost::mp11::mp_size<A>::value == boost::mp11::mp_size<B>::value &&
+      IsSubset<A, B>::value;
+};
+
+}  // namespace type_set
+}  // namespace utils
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
@@ -19,11 +19,15 @@ ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(kCpuExecutionProvider, kOnnxDomain, Ma
 
 ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(kCpuExecutionProvider, kOnnxDomain, Max, 12, Input, 0,
                                           float, double, MLFloat16, int32_t, uint32_t, int64_t, uint64_t);
+ORT_SPECIFY_OP_KERNEL_ARG_REQUIRED_TYPES(kCpuExecutionProvider, kOnnxDomain, Max, 12, Input, 0,
+                                         int64_t);
 
 // Min
 ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(kCpuExecutionProvider, kOnnxDomain, Min, 8, Input, 0, float, double);
-ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(kCpuExecutionProvider, kOnnxDomain, Min, 12,
-                                          Input, 0, float, double, MLFloat16, int32_t, uint32_t, int64_t, uint64_t);
+ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(kCpuExecutionProvider, kOnnxDomain, Min, 12, Input, 0,
+                                          float, double, MLFloat16, int32_t, uint32_t, int64_t, uint64_t);
+ORT_SPECIFY_OP_KERNEL_ARG_REQUIRED_TYPES(kCpuExecutionProvider, kOnnxDomain, Min, 12, Input, 0,
+                                         int64_t);
 
 // Pow
 ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES(kCpuExecutionProvider, kOnnxDomain, Pow, 7, Input, 0, float, double);

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -33,6 +33,9 @@ namespace op_kernel_type_control {
 ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES_ALL_OPSETS(
     kCpuExecutionProvider, kOnnxDomain, Cast, Input, 0,
     ORT_OP_KERNEL_TYPE_CTRL_ALL_TENSOR_DATA_TYPES);
+ORT_SPECIFY_OP_KERNEL_ARG_REQUIRED_TYPES_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, Cast, Input, 0,
+    int64_t);
 
 ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES_ALL_OPSETS(
     kCpuExecutionProvider, kOnnxDomain, Cast, Output, 0,

--- a/onnxruntime/core/providers/cpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/cpu/tensor/gather.cc
@@ -13,6 +13,8 @@ namespace onnxruntime {
 namespace op_kernel_type_control {
 ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES_ALL_OPSETS(
     kCpuExecutionProvider, kOnnxDomain, Gather, Input, 1, int32_t, int64_t);
+ORT_SPECIFY_OP_KERNEL_ARG_REQUIRED_TYPES_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, Gather, Input, 1, int64_t);
 }
 
 namespace {

--- a/onnxruntime/core/providers/cpu/tensor/slice.cc
+++ b/onnxruntime/core/providers/cpu/tensor/slice.cc
@@ -18,9 +18,13 @@ namespace op_kernel_type_control {
 ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES_ALL_OPSETS(
     kCpuExecutionProvider, kOnnxDomain, Slice, Input, 0,
     ORT_OP_KERNEL_TYPE_CTRL_ALL_TENSOR_DATA_TYPES);
+ORT_SPECIFY_OP_KERNEL_ARG_REQUIRED_TYPES_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, Slice, Input, 0, int64_t);
 
 ORT_SPECIFY_OP_KERNEL_ARG_SUPPORTED_TYPES_ALL_OPSETS(
     kCpuExecutionProvider, kOnnxDomain, Slice, Input, 1, int32_t, int64_t);
+ORT_SPECIFY_OP_KERNEL_ARG_REQUIRED_TYPES_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, Slice, Input, 1, int64_t);
 }  // namespace op_kernel_type_control
 
 namespace {

--- a/onnxruntime/core/providers/op_kernel_type_control.h
+++ b/onnxruntime/core/providers/op_kernel_type_control.h
@@ -28,15 +28,16 @@
  *    Zero or more allowed type sets may be given.
  *    The supported type set (1) will be limited by set intersection with all allowed type sets.
  *
- * 4. Enabled types are the types that are actually supported in the build.
+ * 4. Enabled types are the types that are actually supported.
  *    These are the required types and the supported, allowed types.
  *    Defined with set operations:
  *      enabled (4) = union( required (2),
- *                           intersection( supported (1) [, allowed_0 (3), allowed_1, ...] ) )
+ *                           intersection( supported (1)
+ *                                         [, allowed_0 (3), allowed_1, ...] ) )
  *
  * These types are usually associated with an Op argument. It is also possible to specify globally allowed types.
  *
- * Use of these utilities is optional. they are useful for cases where one registered Op kernel handles multiple types.
+ * Use of these utilities is optional. They are useful for cases where one registered Op kernel handles multiple types.
  *
  * See the macros below for usage details. Although this description deals with type sets, lists may be provided which
  * will get converted to sets.

--- a/onnxruntime/core/providers/op_kernel_type_control.h
+++ b/onnxruntime/core/providers/op_kernel_type_control.h
@@ -28,7 +28,7 @@
  *    Zero or more allowed type sets may be given.
  *    The supported type set (1) will be limited by set intersection with all allowed type sets.
  *
- * 4. Enabled types are the types that are actually supported.
+ * 4. Enabled types are the types that are actually supported in this build.
  *    These are the required types and the supported, allowed types.
  *    Defined with set operations:
  *      enabled (4) = union( required (2),
@@ -121,7 +121,8 @@ struct EnabledTypes {
   template <typename T>
   using GetTypesMemberAsSetOrEmpty =
       // !HasTypesMember<T>::value ? TypeList<> : GetTypesMemberAsSet<T>
-      // doesn't evaluate the else branch if the condition is true
+      // if !HasTypesMember<T>::value, GetTypesMemberAsSet<T> is not valid
+      // mp_eval_if_not does not evaluate it in that case
       boost::mp11::mp_eval_if_not<
           HasTypesMember<T>,
           TypeList<>,

--- a/onnxruntime/test/providers/op_kernel_type_control_test.cc
+++ b/onnxruntime/test/providers/op_kernel_type_control_test.cc
@@ -8,23 +8,12 @@
 #include "boost/mp11.hpp"
 
 #include "core/common/type_list.h"
+#include "core/common/type_set_utils.h"
 
 namespace onnxruntime {
 namespace test {
 
-template <typename A, typename B>
-struct TypeSetsEqual {
- private:
-  static_assert(boost::mp11::mp_is_set<A>::value && boost::mp11::mp_is_set<B>::value,
-                "A and B must both be sets.");
-  using ABIntersection = boost::mp11::mp_set_intersection<A, B>;
-
- public:
-  static constexpr bool value =
-      (boost::mp11::mp_size<A>::value == boost::mp11::mp_size<B>::value) &&
-      (boost::mp11::mp_size<ABIntersection>::value == boost::mp11::mp_size<A>::value);
-};
-
+namespace {
 // test types to match op_kernel_type_control::TypesHolder
 template <typename... T>
 struct TestTypesHolder {
@@ -33,39 +22,115 @@ struct TestTypesHolder {
 
 struct TestTypesHolderUnspecified {
 };
-
-// supported + allowed for Op
-static_assert(
-    TypeSetsEqual<
-        op_kernel_type_control::EnabledTypes<
-            TestTypesHolder<int32_t, int64_t, float, double>,
-            TypeList<
-                TestTypesHolder<float, int64_t, char>,
-                TestTypesHolderUnspecified>>::types,
-        TypeList<int64_t, float>>::value,
-    "unexpected enabled types: supported + allowed + unspecified allowed");
-
-// supported + allowed for Op + allowed globally
-static_assert(
-    TypeSetsEqual<
-        op_kernel_type_control::EnabledTypes<
-            TestTypesHolder<int32_t, int64_t, float, double>,
-            TypeList<
-                TestTypesHolder<float, int64_t, char>,
-                TestTypesHolder<int64_t>>>::types,
-        TypeList<int64_t>>::value,
-    "unexpected enabled types: supported + allowed + allowed");
+}  // namespace
 
 // supported
 static_assert(
-    TypeSetsEqual<
+    utils::type_set::IsEqual<
         op_kernel_type_control::EnabledTypes<
             TestTypesHolder<int32_t, int64_t, float, double>,
+            TestTypesHolderUnspecified,
             TypeList<
                 TestTypesHolderUnspecified,
                 TestTypesHolderUnspecified>>::types,
         TypeList<int32_t, int64_t, float, double>>::value,
-    "unexpected enabled types: supported + unspecified allowed + unspecified allowed");
+    "unexpected enabled types");
+
+// supported + allowed for Op
+static_assert(
+    utils::type_set::IsEqual<
+        op_kernel_type_control::EnabledTypes<
+            TestTypesHolder<int32_t, int64_t, float, double>,
+            TestTypesHolderUnspecified,
+            TypeList<
+                TestTypesHolder<float, int64_t>,
+                TestTypesHolderUnspecified>>::types,
+        TypeList<int64_t, float>>::value,
+    "unexpected enabled types");
+
+// supported + allowed for Op, all enabled
+static_assert(
+    utils::type_set::IsEqual<
+        op_kernel_type_control::EnabledTypes<
+            TestTypesHolder<int32_t, int64_t, float, double>,
+            TestTypesHolderUnspecified,
+            TypeList<
+                TestTypesHolder<float, double, int32_t, int64_t>,
+                TestTypesHolderUnspecified>>::types,
+        TypeList<int32_t, int64_t, float, double>>::value,
+    "unexpected enabled types");
+
+// supported + allowed for Op, allowed not subset of supported
+static_assert(
+    utils::type_set::IsEqual<
+        op_kernel_type_control::EnabledTypes<
+            TestTypesHolder<int32_t, int64_t, float, double>,
+            TestTypesHolderUnspecified,
+            TypeList<
+                TestTypesHolder<double, int64_t, char>,
+                TestTypesHolderUnspecified>>::types,
+        TypeList<int64_t, double>>::value,
+    "unexpected enabled types");
+
+// supported + allowed for Op, all disabled
+static_assert(
+    utils::type_set::IsEqual<
+        op_kernel_type_control::EnabledTypes<
+            TestTypesHolder<int32_t, int64_t, float, double>,
+            TestTypesHolderUnspecified,
+            TypeList<
+                TestTypesHolder<>,
+                TestTypesHolderUnspecified>>::types,
+        TypeList<>>::value,
+    "unexpected enabled types");
+
+// supported + allowed for Op + allowed globally
+static_assert(
+    utils::type_set::IsEqual<
+        op_kernel_type_control::EnabledTypes<
+            TestTypesHolder<int32_t, int64_t, float, double>,
+            TestTypesHolderUnspecified,
+            TypeList<
+                TestTypesHolder<float, int64_t>,
+                TestTypesHolder<int64_t>>>::types,
+        TypeList<int64_t>>::value,
+    "unexpected enabled types");
+
+// supported + required + allowed for Op
+static_assert(
+    utils::type_set::IsEqual<
+        op_kernel_type_control::EnabledTypes<
+            TestTypesHolder<int32_t, int64_t, float, double>,
+            TestTypesHolder<int64_t>,
+            TypeList<
+                TestTypesHolder<int32_t, double>,
+                TestTypesHolderUnspecified>>::types,
+        TypeList<int32_t, int64_t, double>>::value,
+    "unexpected enabled types");
+
+// supported + required + allowed for Op, only required enabled
+static_assert(
+    utils::type_set::IsEqual<
+        op_kernel_type_control::EnabledTypes<
+            TestTypesHolder<int32_t, int64_t, float, double>,
+            TestTypesHolder<int64_t>,
+            TypeList<
+                TestTypesHolder<>,
+                TestTypesHolderUnspecified>>::types,
+        TypeList<int64_t>>::value,
+    "unexpected enabled types");
+
+// supported + required + allowed for Op + allowed globally
+static_assert(
+    utils::type_set::IsEqual<
+        op_kernel_type_control::EnabledTypes<
+            TestTypesHolder<int32_t, int64_t, float, double>,
+            TestTypesHolder<int64_t>,
+            TypeList<
+                TestTypesHolder<int32_t, double>,
+                TestTypesHolder<double>>>::types,
+        TypeList<int64_t, double>>::value,
+    "unexpected enabled types");
 
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**
Adds support for required types to the op kernel type control infrastructure. Required types are always enabled.
Added int64 as a required type for certain ops.

**Motivation and Context**
In certain cases, we would like to always enable the op kernel implementation for a certain type.
For example, ops that might reasonably be used in shape-related computations, i.e., those that follow a Shape op which has int64 output, should always have their int64 implementation enabled.