### PR TITLE
Enable priority-based execution order as default to support inputs with symbolic/dynamic shape

### DIFF
--- a/orttraining/orttraining/core/graph/gradient_builder_base.cc
+++ b/orttraining/orttraining/core/graph/gradient_builder_base.cc
@@ -59,8 +59,8 @@ void ComputeBroadcastBackwardAxes(
       auto A_dim = A_dims[i].dim_param(),
            B_dim = B_dims[j].dim_param();
       if (A_dim != B_dim) {
-        ORT_THROW("Gradient building error for node ", node_name, ": symbolic dimension doesn't match. ",
-                  "A_dims:", ToString(A_dims), ", B_dims:", ToString(B_dims));
+        LOGS_DEFAULT(WARNING) << "Gradient building error for node " << node_name << ": symbolic dimension doesn't match. " <<
+                  "A_dims:" << ToString(A_dims) << ", B_dims:" << ToString(B_dims); 
       }
     } else if (A_dims[i].has_dim_param() && B_dims[j].has_dim_value()) {
       auto A_dim = A_dims[i].dim_param();

--- a/orttraining/orttraining/core/graph/gradient_builder_base.cc
+++ b/orttraining/orttraining/core/graph/gradient_builder_base.cc
@@ -67,19 +67,25 @@ void ComputeBroadcastBackwardAxes(
       auto B_dim = B_dims[j].dim_value();
 
       if (B_dim != 1) {
-        ORT_THROW("Gradient building error for node ", node_name, ": symbolic broadcasting requires the B_dimension to be 1. ",
-                  "A_dims:", ToString(A_dims), ", B_dims:", ToString(B_dims));
+        LOGS_DEFAULT(WARNING) << "Gradient building error for node " << node_name << ": symbolic broadcasting requires the B_dimension to be 1. " <<
+                  "A_dims:" << ToString(A_dims) << ", B_dims:" << ToString(B_dims);  
+        --i;
+        --j;            
+        continue;
       }
       if (B_axes) {
         B_axes->push_back(gsl::narrow_cast<int64_t>(k));
       }
     } else if (A_dims[i].has_dim_value() && B_dims[j].has_dim_param()) {
-      auto A_dim = A_dims[j].dim_value();
-      auto B_dim = B_dims[i].dim_param();
+      auto A_dim = A_dims[i].dim_value();
+      auto B_dim = B_dims[j].dim_param();
 
       if (A_dim != 1) {
-        ORT_THROW("Gradient building error for node ", node_name, ": symbolic broadcasting requires the A_dimension to be 1. ",
-                  "A_dims:", ToString(A_dims), ", B_dims:", ToString(B_dims));
+        LOGS_DEFAULT(WARNING) << "Gradient building error for node " << node_name << ": symbolic broadcasting requires the A_dimension to be 1. " <<
+                  "A_dims:" << ToString(A_dims) << ", B_dims:" << ToString(B_dims); 
+        --i;
+        --j;            
+        continue;
       }
       if (A_axes) {
         A_axes->push_back(gsl::narrow_cast<int64_t>(k));

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -220,6 +220,9 @@ class ORTModule(torch.nn.Module):
 
         # Related to training graph shape inference
         self._current_input_shape = None
+        # default execution order is priority-based for both dynamic/static shape input for now
+        # if we observe benefit of static shape, we can expose this flag to user       
+        self._use_static_shape = False 
         self._module_gradient_graph_builder = None
         self._input_names_require_grad = None
         self._original_module_output_schema = None
@@ -282,6 +285,8 @@ class ORTModule(torch.nn.Module):
         session_options = onnxruntime.SessionOptions()
         session_options.enable_mem_pattern = False
         session_options.use_deterministic_compute = False
+        # default to PRIORITY_BASED execution order
+        session_options.execution_order = onnxruntime.ExecutionOrder.PRIORITY_BASED
         # 0:Verbose, 1:Info, 2:Warning. 3:Error, 4:Fatal. Default is 2.
         session_options.log_severity_level = 2
 
@@ -296,7 +301,10 @@ class ORTModule(torch.nn.Module):
         self._training_io_binding = self._training_session.io_binding()
 
     def _build_training_graph(self, *inputs, **kwargs):
-        self._module_gradient_graph_builder.build(self._current_input_shape)
+        if self._use_static_shape:
+            self._module_gradient_graph_builder.build(self._current_input_shape)
+        else:
+            self._module_gradient_graph_builder.build()
         self._onnx_training = onnx.load_model_from_string(self._module_gradient_graph_builder.get_training_model())
         self._onnx_graphs_info = self._module_gradient_graph_builder.get_training_graph_info()
 

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -3,6 +3,7 @@
 # orttraining_test_ortmodule_api.py
 
 import math
+import random
 import copy
 import torch
 from transformers import AutoConfig, BertForSequenceClassification
@@ -171,6 +172,17 @@ def _get_bert_for_sequence_classification_sample_data(device):
     input_ids = torch.randint(0, 100, (32, 64), dtype=torch.long, device=device)
     input_mask = torch.randint(0, 100, (32, 64), dtype=torch.long, device=device)
     labels = torch.randint(0, 1, (32,), dtype=torch.long, device=device)
+
+    return input_ids, input_mask, labels
+
+def _get_bert_for_sequence_classification_sample_data_with_random_shapes(device):
+    """Returns sample data with random shape to be used with BertForSequenceClassification model"""
+
+    x = random.randint(1,100)
+    y = random.randint(1,100)
+    input_ids = torch.randint(0, 100, (x, y), dtype=torch.long, device=device)
+    input_mask = torch.randint(0, 100, (x, y), dtype=torch.long, device=device)
+    labels = torch.randint(0, 1, (x,), dtype=torch.long, device=device)
 
     return input_ids, input_mask, labels
 
@@ -575,6 +587,43 @@ def test_mixed_nnmodule_ortmodules_training():
         _test_helpers.assert_gradients_match_and_reset_gradient(ort_model1, pt_model1)
         _test_helpers.assert_gradients_match_and_reset_gradient(ort_model2, pt_model2)
         _test_helpers.assert_gradients_match_and_reset_gradient(ort_model3, pt_model3)
+
+def test_ortmodule_inputs_with_dynamic_shape():
+    D_in, H, D_out = 784, 500, 10
+
+    model = NeuralNetSinglePositionalArgument(D_in, H, D_out).to('cuda')
+    model = ORTModule(model)
+
+    for step in range(10):
+        N = random.randint(1,100)
+        x = torch.randn(N, D_in, device='cuda', requires_grad=True)
+        assert x.grad is None
+
+        prediction = model(x)
+        s = prediction.sum()
+        s.backward()
+
+        assert x.grad is not None 
+        for param in model.parameters():
+            assert param.grad is not None
+            param.grad = None
+
+
+def test_bert_inputs_with_dynamic_shape():
+    model = _get_bert_for_sequence_classification_model('cuda')
+    model = ORTModule(model)
+
+    for step in range(10):
+        x, y, z = _get_bert_for_sequence_classification_sample_data_with_random_shapes('cuda')
+
+        outputs = model(x, y, None, None, None, None, z)
+        s = outputs[0]
+        s.backward()
+
+        for param in model.parameters():
+            assert param.grad is not None
+            param.grad = None
+
 
 @pytest.mark.parametrize("device", ['cuda', 'cpu'])
 def test_changes_input_requires_grad_reinitializes_module_gradient_graph_builder(device):


### PR DESCRIPTION
**Description**: When building training graph without concrete shape, e.g. bert, the max bs would be 20, far less than 35 when providing concrete shape. The reason is because memory allocation planner can't efficiently assign reusable buffers due to symbolic shapes happening in later stage of execution order.
The solution is to enable priority-based execution order (for Shape op), thus memory allocation can be better planned. During the experiment, the max bs can now be 36.  

In this PR:
- introduce new flag - "_use_static_shape" in case we want to expose it to user
- fixed gradient builder issues when testing gpt-2 and bert related UTs
- encounter CUDA error with gpt-2 (regression by merging code from master) - thus has dependency on https://github.com/microsoft/onnxruntime/pull/6833 and https://github.com/microsoft/onnxruntime/pull/6838 - both are merged