### PR TITLE
Only report Android Baseline binary size for master branch

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -166,6 +166,7 @@ jobs:
           -e BUILD_SOURCEVERSION=$(Build.SourceVersion) \
           -e BUILD_ID=$(Build.BuildId) \
           -e BUILD_REASON=$(Build.Reason) \
+          -e BUILD_BRANCH=$(Build.SourceBranch) \
           -e DASHBOARD_MYSQL_ORT_PASSWORD=$(dashboard-mysql-ort-password) \
           onnxruntimecentoscpubuild \
             /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh

--- a/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
@@ -47,7 +47,7 @@ if [[ $BUILD_REASON == "IndividualCI" || $BUILD_REASON == "BatchedCI" ]] && [[ $
         --build_project=onnxruntime \
         --build_id=$BUILD_ID
 else
-    echo "No binary size report for build reason: [$BUILD_REASON] and build branch: [$BUILD_SOURCEVERSION]"
+    echo "No binary size report for build reason: [$BUILD_REASON] and build branch: [$BUILD_BRANCH]"
     echo "The content of binary_size_data.txt"
     cat /build/MinSizeRel/binary_size_data.txt
 fi

--- a/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
@@ -28,15 +28,18 @@ python3 /onnxruntime_src/tools/ci_build/build.py \
     --disable_exceptions \
     --include_ops_by_config /home/onnxruntimedev/.test_data/include_no_operators.config
 
-# set current size limit to 1165KB. 
+# set current size limit to 1165KB.
 python3 /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/check_build_binary_size.py \
     --threshold=1165000 \
     /build/MinSizeRel/libonnxruntime.so
 
 # Post the binary size info to ort mysql DB
 # The report script's DB connection failure will not fail the pipeline
-# To reduce noise, we only report binary size for Continuous integration (a merge to master or rel-*)
-if [[ $BUILD_REASON == "IndividualCI" || $BUILD_REASON == "BatchedCI" ]]; then
+# To reduce noise, we only report binary size for Continuous integration (a merge to master)
+echo "BUILD_REASON is $BUILD_REASON"
+echo "BUILD_BRANCH is $BUILD_BRANCH"
+
+if [[ $BUILD_REASON == "IndividualCI" || $BUILD_REASON == "BatchedCI" ]] && [[ $BUILD_BRANCH == "refs/heads/master" ]]; then
     # Install the mysql connector
     python3 -m pip install --user mysql-connector-python
 

--- a/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
@@ -36,9 +36,6 @@ python3 /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/check_build_bin
 # Post the binary size info to ort mysql DB
 # The report script's DB connection failure will not fail the pipeline
 # To reduce noise, we only report binary size for Continuous integration (a merge to master)
-echo "BUILD_REASON is $BUILD_REASON"
-echo "BUILD_BRANCH is $BUILD_BRANCH"
-
 if [[ $BUILD_REASON == "IndividualCI" || $BUILD_REASON == "BatchedCI" ]] && [[ $BUILD_BRANCH == "refs/heads/master" ]]; then
     # Install the mysql connector
     python3 -m pip install --user mysql-connector-python
@@ -50,7 +47,7 @@ if [[ $BUILD_REASON == "IndividualCI" || $BUILD_REASON == "BatchedCI" ]] && [[ $
         --build_project=onnxruntime \
         --build_id=$BUILD_ID
 else
-    echo "No binary size report for build reason: $BUILD_REASON"
+    echo "No binary size report for build reason: [$BUILD_REASON] and build branch: [$BUILD_SOURCEVERSION]"
     echo "The content of binary_size_data.txt"
     cat /build/MinSizeRel/binary_size_data.txt
 fi


### PR DESCRIPTION
**Description**: Only report Android Baseline binary size for master branch

**Motivation and Context**
- For now we report binary size for both master and rel-* branch, and we have size alert setup to warn about binary size increase in our [dashboard ](https://msit.powerbi.com/groups/d1ae6355-afd0-4c40-b78e-676a86cab1e2/dashboards/c9501966-5a90-48a3-8989-d0b0356dd24b), it is better to report the binary size for master only.
- Ideally we may want to update the binary size database schema to include branch also, but the database is also used by other platforms, will keep it this way for now
