### PR TITLE
Collective ops orders - For Feedbacks

### DIFF
--- a/onnxruntime/core/framework/utils.h
+++ b/onnxruntime/core/framework/utils.h
@@ -158,6 +158,11 @@ int32_t ONNXTensorElementDataTypeToProtoTensorType(ONNXTensorElementDataType);
 
 #ifdef ENABLE_TRAINING
 common::Status VerifyInputTensorsAllocatedContiguously(OpKernelContext* context);
+
+int64_t GenerateCollectiveIndex();
+
+common::Status BuildCollectiveOperationDependency(const GraphNodes& nodes_in_original_order,
+                                                  std::unordered_map<NodeIndex, NodeIndex>& collective_op_dependency_relation);
 #endif
 
 }  // namespace utils

--- a/orttraining/orttraining/core/graph/training_op_defs.cc
+++ b/orttraining/orttraining/core/graph/training_op_defs.cc
@@ -942,6 +942,12 @@ Example 4:
             "4 - horozontal parallel, 5 - model parallel.",
             AttributeProto::INT,
             static_cast<int64_t>(0))
+      .Attr("index",
+            "The global unique index of collective operations in the whole graph. "
+            "It is assumed all ranks should contains exactly same collective operations "
+            "and the orders we build the ops are strictly recorded to do a match between ranks.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
       .Input(0, "input", "tensors to be reduced", "T", OpSchema::Variadic)
       .Output(0, "output", "reduced tensors", "T", OpSchema::Variadic)
       .TypeConstraint(
@@ -962,6 +968,12 @@ Example 4:
             "4 - horozontal parallel, 5 - model parallel.",
             AttributeProto::INT,
             static_cast<int64_t>(0))
+      .Attr("index",
+            "The global unique index of collective operations in the whole graph. "
+            "It is assumed all ranks should contains exactly same collective operations "
+            "and the orders we build the ops are strictly recorded to do a match between ranks.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
       .Input(0, "input", "tensors to be sent", "T", OpSchema::Variadic)
       .Output(0, "output", "gathered tensors", "T", OpSchema::Variadic)
       .TypeConstraint(
@@ -980,6 +992,12 @@ Example 4:
             "0 - global parallel group, 1 - data parallel group, "
             "2 - node local data parallel group, 3 - cross node data parallel group, "
             "4 - horozontal parallel, 5 - model parallel.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+      .Attr("index",
+            "The global unique index of collective operations in the whole graph. "
+            "It is assumed all ranks should contains exactly same collective operations "
+            "and the orders we build the ops are strictly recorded to do a match between ranks.",
             AttributeProto::INT,
             static_cast<int64_t>(0))
       .Input(0, "input", "tensors to be reduced and scattered", "T", OpSchema::Variadic)


### PR DESCRIPTION
**Description**: Describe your changes.

**Motivation and Context**

We will see there are some mismatch in the 68 and 279 attention bp all reduce operations. Be noted: 279 and 68 can be run in parallel (from the view of graph) since they are in different branches, they don’t take dependency on each other. 
 
![image](https://user-images.githubusercontent.com/10530022/109476794-44aeb600-7ab2-11eb-9535-0ce745f0c041.png)

here is a solution: 
A). When we build the forward and backward graph, we give each collective ops a unique and auto incremental id as an attribute. All id is assigned in the same order on all ranks, this is guaranteed so far by our code. 
B). All collective ops having bigger id will take dependency on all smaller ids, when doing topo sort (and execution planning).
In this way, all ranks will share the same global order for collective ops. 

This change is a first step for implementing all those, before going forward, I want to collect some feedbacks, in case of any useless efforts. 

