### PR TITLE
Refine force CPU fallback logic in the CUDA EP 

### DIFF
--- a/onnxruntime/core/framework/fallback_cpu_capability.cc
+++ b/onnxruntime/core/framework/fallback_cpu_capability.cc
@@ -24,8 +24,8 @@ bool IsSmallInitializerWithSingleConsumer(const onnxruntime::GraphViewer& graph,
   for (auto& dim : initializer_tensor->dims()) {
     size *= dim;
   }
-  return size <= Small_Initializer_Threshold &&
-         graph.GetConsumerNodes(arg->Name()).size() == 1;
+
+  return size <= Small_Initializer_Threshold;
 }
 }  // namespace
 
@@ -100,6 +100,11 @@ std::unordered_set<NodeIndex> GetCpuPreferredNodes(const onnxruntime::GraphViewe
       continue;
 
     auto* node = graph.GetNode(cur);
+    if (node->Name() == "na_speech_model/parallel_0_3/na_speech_model/na_speech_model/body/s_decoder/layer_5/ffn/conv_relu_conv/conv1_7/Tensordot/GatherV2") {
+      float f = 1.f / 2;
+      ORT_IGNORE_RETURN_VALUE(f);
+    }
+
     bool place_in_cpu = true;
     for (size_t i = 0; i < node->InputDefs().size(); ++i) {
       auto* input = node->InputDefs()[i];

--- a/onnxruntime/core/framework/fallback_cpu_capability.cc
+++ b/onnxruntime/core/framework/fallback_cpu_capability.cc
@@ -100,11 +100,6 @@ std::unordered_set<NodeIndex> GetCpuPreferredNodes(const onnxruntime::GraphViewe
       continue;
 
     auto* node = graph.GetNode(cur);
-    if (node->Name() == "na_speech_model/parallel_0_3/na_speech_model/na_speech_model/body/s_decoder/layer_5/ffn/conv_relu_conv/conv1_7/Tensordot/GatherV2") {
-      float f = 1.f / 2;
-      ORT_IGNORE_RETURN_VALUE(f);
-    }
-
     bool place_in_cpu = true;
     for (size_t i = 0; i < node->InputDefs().size(); ++i) {
       auto* input = node->InputDefs()[i];

--- a/onnxruntime/core/framework/fallback_cpu_capability.cc
+++ b/onnxruntime/core/framework/fallback_cpu_capability.cc
@@ -14,9 +14,9 @@ using namespace ONNX_NAMESPACE::Utils;
 namespace onnxruntime {
 
 namespace {
-const int64_t Small_Initializer_Threshold = 100;
+const int64_t kSmallInitializerThreshold = 100;
 
-bool IsSmallInitializerWithSingleConsumer(const onnxruntime::GraphViewer& graph, const NodeArg* arg) {
+bool IsSmallInitializer(const onnxruntime::GraphViewer& graph, const NodeArg* arg) {
   const ONNX_NAMESPACE::TensorProto* initializer_tensor;
   if (!graph.GetInitializedTensor(arg->Name(), initializer_tensor))
     return false;
@@ -25,7 +25,7 @@ bool IsSmallInitializerWithSingleConsumer(const onnxruntime::GraphViewer& graph,
     size *= dim;
   }
 
-  return size <= Small_Initializer_Threshold;
+  return size <= kSmallInitializerThreshold;
 }
 }  // namespace
 
@@ -117,7 +117,7 @@ std::unordered_set<NodeIndex> GetCpuPreferredNodes(const onnxruntime::GraphViewe
       }
 
       // allow placing on CPU if it's a small initializer or graph input
-      if (IsSmallInitializerWithSingleConsumer(graph, input) ||
+      if (IsSmallInitializer(graph, input) ||
           std::find(graph_inputs.begin(), graph_inputs.end(), input) != graph_inputs.end()) {
         continue;
       }


### PR DESCRIPTION
**Description**: https://github.com/microsoft/onnxruntime/pull/4940 refined the force fallback to CPU logic for Shape based subgraphs from its initial version. A crude overview of the previous logic to determine if a node needs to be forced to run on CPU was if all its inputs were either on CPU (unless the corresponding CUDA kernel for the op explicitly required the inputs on CPU) or were initializers. The refinement added was to check if the initializers were "small" ( < 100 elements) and if there was only one consumer of this initializer (which is the current node itself). The single consumer logic is overly strict and will cause very poor perf in "repeated shape subgraph pattern" scenarios. 

Example:

Consider many such repeating subgraphs (common in sequence based models)
                                                                                       
-> Shape -> Gather (2 indices) -> Concat (1 element) -> Reshape  <- (data to be reshaped)

With the new logic this becomes

-> Shape -> MemCpyFromHost -> Gather -> Concat -> MemCpyToHost -> Reshape  <- (data to be reshaped)

It places the `Gather` and `Concat` nodes on CUDA because they use initializers shared between all Gathers and Concats in subgraphs processing each sequence index. Since Shape's output is on CPU and finally Reshape's shape info is required on CPU, this tiny subgraph now needs 2 device-host copies + 2 CUDA kernel launches (overkill for gathering 2 shape indices and concating one element to its result) and what is worse is that this is repeated multiple times.

This change relaxes the constraint that the initializer for a candidate node needs to have only one consumer (there is no real case for having this strict check AFAIK).

This may improve perf of sequence models with a lot of shape processing subgraphs.

**Motivation and Context**
Significantly improves the perf of a 1PP model. Saves hundreds of memcpys and overheads of unnecessary CUDA kernel launches and improves perf by >30%