### PR TITLE
Support required types when excluding typed registrations

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -130,7 +130,9 @@ jobs:
     displayName: Build minimal onnxruntime [exceptions ENABLED, type reduction ENABLED (globally allowed types)] and run tests
     inputs:
       script: |
-        echo "!globally_allowed_types;bool,float,int8_t,uint8_t" \
+        printf "%s\n%s\n" \
+          "!globally_allowed_types;bool,float,int8_t,uint8_t" \
+          "!no_ops_specified_means_all_ops_are_required" \
           > $(test_data_directory)/globally_allowed_types.config && \
         docker run --rm \
           --volume $(Build.SourcesDirectory):/onnxruntime_src \

--- a/tools/ci_build/op_registration_utils.py
+++ b/tools/ci_build/op_registration_utils.py
@@ -184,6 +184,11 @@ def _process_lines(lines: typing.List[str], offset: int, registration_processor:
         registration_processor.process_registration(lines_to_process, domain, op_type,
                                                     int(start_version), int(end_version), type)
 
+    else:
+        log.warning("Ignoring unhandled kernel registration variant: {}".format(code_line))
+        for line in lines_to_process:
+            registration_processor.process_other_line(line)
+
     return offset + 1
 
 

--- a/tools/python/util/ort_format_model/__init__.py
+++ b/tools/python/util/ort_format_model/__init__.py
@@ -12,4 +12,7 @@ sys.path.append(ort_fbs_py_path)
 
 from .utils import create_config_from_models  # noqa
 from .ort_model_processor import OrtFormatModelProcessor  # noqa
-from .operator_type_usage_processors import OperatorTypeUsageManager  # noqa
+from .operator_type_usage_processors import (  # noqa
+    GloballyAllowedTypesOpTypeImplFilter,
+    OpTypeImplFilterInterface,
+    OperatorTypeUsageManager)

--- a/tools/python/util/ort_format_model/operator_type_usage_processors.py
+++ b/tools/python/util/ort_format_model/operator_type_usage_processors.py
@@ -266,13 +266,13 @@ class OneHotProcessor(TypeUsageProcessor):
         type0 = value_name_to_typestr(node.Inputs(0), value_name_to_typeinfo)
         type1 = value_name_to_typestr(node.Inputs(1), value_name_to_typeinfo)
         type2 = value_name_to_typestr(node.Inputs(2), value_name_to_typeinfo)
-        key = tuple(type0, type1, type2)
+        key = (type0, type1, type2)
         self._triples.add(key)
 
     def is_typed_registration_needed(self, type_in_registration: str,
                                      globally_allowed_types: typing.Optional[typing.Set[str]]):
         # the OneHot registration involves a concatenation of the 3 types involved
-        reg_types = tuple(_reg_type_to_cpp_type(reg_type) for reg_type in _split_reg_types(type_in_registration))
+        reg_types = tuple([_reg_type_to_cpp_type(reg_type) for reg_type in _split_reg_types(type_in_registration)])
         if globally_allowed_types is not None:
             return all(reg_type in globally_allowed_types for reg_type in reg_types)
         else:

--- a/tools/python/util/ort_format_model/operator_type_usage_processors.py
+++ b/tools/python/util/ort_format_model/operator_type_usage_processors.py
@@ -366,7 +366,7 @@ def _create_operator_type_usage_processors():
     default_processor_onnxml_ops = []
 
     [add(DefaultTypeUsageProcessor('ai.onnx', op)) for op in default_processor_onnx_ops]
-    [add(DefaultTypeUsageProcessor('ai.onnx', op, required_input_types={0: {"int64_t"}})) \
+    [add(DefaultTypeUsageProcessor('ai.onnx', op, required_input_types={0: {"int64_t"}}))
         for op in default_processor_onnx_ops_requiring_int64_for_input_0]
     [add(DefaultTypeUsageProcessor('ai.onnx.ml', op)) for op in default_processor_onnxml_ops]
     [add(DefaultTypeUsageProcessor('com.microsoft', op)) for op in internal_ops]

--- a/tools/python/util/ort_format_model/types.py
+++ b/tools/python/util/ort_format_model/types.py
@@ -20,8 +20,8 @@ class FbsTypeInfo:
         fbs.TensorDataType.TensorDataType.DOUBLE: 'double',
         fbs.TensorDataType.TensorDataType.UINT32: 'uint32_t',
         fbs.TensorDataType.TensorDataType.UINT64: 'uint64_t',
-        fbs.TensorDataType.TensorDataType.COMPLEX64: 'complex64 is not supported',
-        fbs.TensorDataType.TensorDataType.COMPLEX128: 'complex128 is not supported',
+        # fbs.TensorDataType.TensorDataType.COMPLEX64: 'complex64 is not supported',
+        # fbs.TensorDataType.TensorDataType.COMPLEX128: 'complex128 is not supported',
         fbs.TensorDataType.TensorDataType.BFLOAT16: 'BFloat16'
     }
 

--- a/tools/python/util/reduced_build_config_parser.py
+++ b/tools/python/util/reduced_build_config_parser.py
@@ -7,21 +7,24 @@ import os
 try:
     import flatbuffers  # noqa
     have_flatbuffers = True
-    from .ort_format_model import OperatorTypeUsageManager  # noqa
+    from .ort_format_model import GloballyAllowedTypesOpTypeImplFilter, OperatorTypeUsageManager  # noqa
 except ImportError:
     have_flatbuffers = False
 
 
 def parse_config(config_file: str, enable_type_reduction: bool = False):
     '''
-    Parse the configuration file and return the required operators dictionary, and possibly either an
-    OperatorTypeUsageManager or a globally allowed types list.
+    Parse the configuration file and return the required operators dictionary and an
+    OpTypeImplFilterInterface instance.
 
     Configuration file lines can do the following:
     1. specify required operators
     2. specify globally allowed types for all operators
+    3. specify what it means for no required operators to be specified
 
-    The basic format for specifying required operators (1) is `domain;opset;op1,op2...`
+    1. Specifying required operators
+
+    The basic format for specifying required operators is `domain;opset;op1,op2...`
     e.g. `ai.onnx;11;Add,Cast,Clip,...
 
     If the configuration file is generated from ORT format models it may optionally contain JSON for per-operator
@@ -44,47 +47,69 @@ def parse_config(config_file: str, enable_type_reduction: bool = False):
     ai.onnx.OneHot is an example of this, where 3 type names from the inputs are combined into a string.
         `{"custom": ["float_int64_t_int64_t", "int64_t_string_int64_t"]}`
 
-    The format for specifying globally allowed types for all operators (2) is `!globally_allowed_types;T0,T1,...`
+    2. Specifying globally allowed types for all operators
+
+    The format for specifying globally allowed types for all operators is:
+        `!globally_allowed_types;T0,T1,...`
+
     Ti should be a C++ scalar type supported by ONNX and ORT.
     At most one globally allowed types specification is allowed.
 
     Specifying per-operator type information and specifying globally allowed types are mutually exclusive - it is an
     error to specify both.
 
+    3. Specify what it means for no required operators to be specified
+
+    By default, if no required operators are specified, NO operators are required.
+
+    With the following line, if no required operators are specified, ALL operators are required:
+        `!no_ops_specified_means_all_ops_are_required`
+
     :param config_file: Configuration file to parse
     :param enable_type_reduction: Set to True to use the type information in the config.
                                   If False the type information will be ignored.
-                                  If the flatbuffers module is unavailable op-specific type information will be ignored
-                                  as the per-op usage of the type information is via OperatorTypeUsageManager which has
-                                  a dependency on the ORT flatbuffers python schema.
-    :return: required_ops, op_type_usage_manager, globally_allowed_types:
-             Dictionary of domain:opset:[ops] for required operators
-             OperatorTypeUsageManager manager with operator specific type usage information if available. None if
-             type reduction was disabled, per-op type reduction was not specified, or the flatbuffers module is not
-             available.
-             List of globally allowed types. None if type reduction was disabled, or globally allowed types were not
-             specified.
-             At most one of the op_type_usage_manager and globally_allowed_types tuple elements will not be None.
+                                  If the flatbuffers module is unavailable type information will be ignored as the
+                                  type-based filtering has a dependency on the ORT flatbuffers schema.
+    :return: required_ops: Dictionary of domain:opset:[ops] for required operators. If None, all operators are
+                           required.
+             op_type_impl_filter: OpTypeImplFilterInterface instance if type reduction is enabled, the flatbuffers
+                                  module is available, and type reduction information is present. None otherwise.
     '''
 
     if not os.path.isfile(config_file):
         raise ValueError('Configuration file {} does not exist'.format(config_file))
 
+    # only enable type reduction when flatbuffers is available
+    enable_type_reduction = enable_type_reduction and have_flatbuffers
+
     required_ops = {}
-    op_type_usage_manager = OperatorTypeUsageManager() if enable_type_reduction and have_flatbuffers else None
+    no_ops_specified_means_all_ops_are_required = False
+    op_type_usage_manager = OperatorTypeUsageManager() if enable_type_reduction else None
     has_op_type_reduction_info = False
     globally_allowed_types = None
 
+    def process_non_op_line(line):
+        if not line or line.startswith("#"):  # skip empty lines and comments
+            return True
+
+        if line.startswith("!globally_allowed_types;"):  # handle globally allowed types
+            if enable_type_reduction:
+                nonlocal globally_allowed_types
+                if globally_allowed_types is not None:
+                    raise RuntimeError("Globally allowed types were already specified.")
+                globally_allowed_types = set(segment.strip() for segment in line.split(';')[1].split(','))
+            return True
+
+        if line == "!no_ops_specified_means_all_ops_are_required":  # handle all ops required line
+            nonlocal no_ops_specified_means_all_ops_are_required
+            no_ops_specified_means_all_ops_are_required = True
+            return True
+
+        return False
+
     with open(config_file, 'r') as config:
         for line in [orig_line.strip() for orig_line in config.readlines()]:
-            if not line or line.startswith("#"):  # skip empty lines and comments
-                continue
-
-            if line.startswith("!globally_allowed_types;"):  # handle globally allowed types
-                if enable_type_reduction:
-                    if globally_allowed_types is not None:
-                        raise RuntimeError("Globally allowed types were already specified.")
-                    globally_allowed_types = [segment.strip() for segment in line.split(';')[1].split(',')]
+            if process_non_op_line(line):
                 continue
 
             domain, opset_str, operators_str = [segment.strip() for segment in line.split(';')]
@@ -151,6 +176,10 @@ def parse_config(config_file: str, enable_type_reduction: bool = False):
             else:
                 required_ops[domain][opset].update(operators)
 
+    if len(required_ops) == 0 and no_ops_specified_means_all_ops_are_required:
+        required_ops = None
+
+    op_type_impl_filter = None
     if enable_type_reduction:
         if not has_op_type_reduction_info:
             op_type_usage_manager = None
@@ -158,4 +187,9 @@ def parse_config(config_file: str, enable_type_reduction: bool = False):
             raise RuntimeError(
                 "Specifying globally allowed types and per-op type reduction info together is unsupported.")
 
-    return required_ops, op_type_usage_manager, globally_allowed_types
+        if globally_allowed_types is not None:
+            op_type_impl_filter = GloballyAllowedTypesOpTypeImplFilter(globally_allowed_types)
+        elif op_type_usage_manager is not None:
+            op_type_impl_filter = op_type_usage_manager.make_op_type_impl_filter()
+
+    return required_ops, op_type_impl_filter


### PR DESCRIPTION
**Description**
Support required types when excluding typed kernel registrations.
Analogous to #6832 for typed registrations.

**Motivation and Context**
In certain cases, we would like to always enable the op kernel implementation for a certain type.
For example, ops that might reasonably be used in shape-related computations, i.e., those that follow a Shape op which has int64 output, should always have their int64 implementation enabled.