### PR TITLE
Revert Gather Grad optimization in PR 6381 targeted for Rocm

### DIFF
--- a/orttraining/orttraining/training_ops/rocm/tensor/gather_grad_impl.cu
+++ b/orttraining/orttraining/training_ops/rocm/tensor/gather_grad_impl.cu
@@ -20,7 +20,7 @@ __global__ void _Iota(
   output[idx] = input[idx];
 }
 
-template <typename T, typename Tin>
+template <typename T, typename Tin, int NumElementsPerThread>
 __global__ void _GatherGradImpl(
     const Tin* input,
     const Tin* indices,
@@ -32,19 +32,18 @@ __global__ void _GatherGradImpl(
     int64_t stride) {
   int idx = blockIdx.x * 4 + threadIdx.y;
 
-  const int SZ = 4;
   if (idx < numel && (idx == 0 || input[idx] != input[idx - 1])) {
     do {
       for (int itr = 0; itr < param_itrs; ++itr) {
-        const int start_feature = threadIdx.x + blockIdx.y * blockDim.x * SZ;
+        const int start_feature = threadIdx.x + blockIdx.y * blockDim.x * NumElementsPerThread;
         const int weight_row = itr * input_numel + ((int)input[idx]) * stride;  //the offset of the input
         const int grad_row = (itr * numel + ((int)indices[idx])) * stride;      //the offset of the gradient
 
-        float gradient[SZ];
-        float weight[SZ];
+        float gradient[NumElementsPerThread];
+        float weight[NumElementsPerThread];
 
 #pragma unroll
-        for (int ii = 0; ii < SZ; ii++) {
+        for (int ii = 0; ii < NumElementsPerThread; ii++) {
           int feature_dim = start_feature + ii * GPU_WARP_SIZE;
           if (feature_dim < stride) {
             gradient[ii] = static_cast<float>(grad_output[grad_row + feature_dim]);
@@ -53,12 +52,12 @@ __global__ void _GatherGradImpl(
         }
 
 #pragma unroll
-        for (int ii = 0; ii < SZ; ii++) {
+        for (int ii = 0; ii < NumElementsPerThread; ii++) {
           weight[ii] += gradient[ii];
         }
 
 #pragma unroll
-        for (int ii = 0; ii < SZ; ii++) {
+        for (int ii = 0; ii < NumElementsPerThread; ii++) {
           int feature_dim = start_feature + ii * GPU_WARP_SIZE;
           if (feature_dim < stride) {
             grad_weight[weight_row + feature_dim] = static_cast<T>(weight[ii]);
@@ -67,6 +66,54 @@ __global__ void _GatherGradImpl(
       }
       idx++;
     } while (idx < numel && input[idx] == input[idx - 1]);
+  }
+}
+
+// Special optimization for the case which the gather is on axis=0
+template <typename T, typename Tin, int NumElementsPerThread>
+__global__ void _GatherAxis0GradImpl(
+    const Tin* input,
+    const Tin* indices,
+    const T* grad_output,
+    T* grad_weight,
+    int64_t numel,
+    int64_t input_numel,
+    int64_t stride)
+{
+  int idx = blockIdx.x * 4 + threadIdx.y;
+
+  if (idx < numel && (idx == 0 || input[idx] != input[idx - 1])) {
+    const int start_feature = threadIdx.x + blockIdx.y * blockDim.x * NumElementsPerThread;
+    const int weight_row = ((int)input[idx]) * stride;  //the offset of the input
+
+    float weight[NumElementsPerThread];
+    for (int ii = 0; ii < NumElementsPerThread; ii++) {
+      int feature_dim = start_feature + ii * GPU_WARP_SIZE/4;
+      if (feature_dim < stride)
+        weight[ii] = static_cast<float>(grad_weight[weight_row + feature_dim]);
+    }
+
+    do {
+        const int grad_row = ((int)indices[idx]) * stride;      //the offset of the gradient
+        float gradient[NumElementsPerThread];
+
+#pragma unroll
+        for (int ii = 0; ii < NumElementsPerThread; ii++) {
+          int feature_dim = start_feature + ii * GPU_WARP_SIZE/4;
+          if (feature_dim < stride) {
+            gradient[ii] = static_cast<float>(grad_output[grad_row + feature_dim]);
+            weight[ii] += gradient[ii];
+          }
+        }
+        idx++;
+    } while (idx < numel && input[idx] == input[idx - 1]);
+    
+#pragma unroll
+    for (int ii = 0; ii < NumElementsPerThread; ii++) {
+      int feature_dim = start_feature + ii * GPU_WARP_SIZE/4;
+      if (feature_dim < stride)
+        grad_weight[weight_row + feature_dim] = static_cast<T>(weight[ii]);
+    }
   }
 }
 
@@ -90,7 +137,7 @@ void GatherGradImpl(
   {
     const auto blocks_per_grid = CeilDiv(num_indices, GridDim::maxThreadsPerBlock);
     hipcub::CountingInputIterator<Tin> counting_input(Tin{});
-    hipLaunchKernelGGL(_Iota, dim3(blocks_per_grid), dim3(GridDim::maxThreadsPerBlock), 0, stream, 
+    hipLaunchKernelGGL(_Iota, dim3(blocks_per_grid), dim3(GridDim::maxThreadsPerBlock), 0, stream,
         counting_input, num_indices, original_indices.get());
   }
 
@@ -114,17 +161,30 @@ void GatherGradImpl(
       num_indices, 0, sizeof(Tin)*8, stream));
 
   dim3 block(GPU_WARP_SIZE, 4);
-  dim3 grid(CeilDiv(num_indices, 4), CeilDiv(stride, 128));
+  dim3 grid(CeilDiv(num_indices, 4), CeilDiv(stride, GridDim::maxElementsPerThread * GPU_WARP_SIZE));
 
-  hipLaunchKernelGGL(_GatherGradImpl, dim3(grid), dim3(block), 0, stream, 
-      indices_data_sorted.get(),
-      original_indices_sorted.get(),
-      grad_data,
-      output_data,
-      num_indices,
-      num_inputs,
-      param_itrs,
-      stride);
+// commented optimization resulted in increase variance of loss for BERT across multiple reasons
+//if (param_itrs == 1)
+//{
+//  hipLaunchKernelGGL(HIP_KERNEL_NAME(_GatherAxis0GradImpl<T, Tin, GridDim::maxElementsPerThread>), dim3(grid), dim3(block), 0, stream,
+//    indices_data_sorted.get(),
+//    original_indices_sorted.get(),
+//    grad_data,
+//    output_data,
+//    num_indices,
+//    num_inputs,
+//    stride); 
+//} else {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(_GatherGradImpl<T, Tin, GridDim::maxElementsPerThread>), dim3(grid), dim3(block), 0, stream,
+        indices_data_sorted.get(),
+        original_indices_sorted.get(),
+        grad_data,
+        output_data,
+        num_indices,
+        num_inputs,
+        param_itrs,
+        stride);
+//}
 }
 
 #define SPECIALIZED_GRAD_IMPL2(T)           \

--- a/orttraining/orttraining/training_ops/rocm/tensor/gather_grad_impl.cu
+++ b/orttraining/orttraining/training_ops/rocm/tensor/gather_grad_impl.cu
@@ -84,12 +84,13 @@ void GatherGradImpl(
     ) {
   // allocate intermediate buffers
   auto original_indices = rocm_kernel.template GetScratchBuffer<Tin>(num_indices);
+  hipStream_t stream = rocm_kernel.Stream();
 
   // initialize original_indices with [0, num_indices)
   {
     const auto blocks_per_grid = CeilDiv(num_indices, GridDim::maxThreadsPerBlock);
     hipcub::CountingInputIterator<Tin> counting_input(Tin{});
-    hipLaunchKernelGGL(_Iota, dim3(blocks_per_grid), dim3(GridDim::maxThreadsPerBlock), 0, 0, 
+    hipLaunchKernelGGL(_Iota, dim3(blocks_per_grid), dim3(GridDim::maxThreadsPerBlock), 0, stream, 
         counting_input, num_indices, original_indices.get());
   }
 
@@ -102,7 +103,7 @@ void GatherGradImpl(
       nullptr, sort_temp_storage_size_bytes,
       indices_data, indices_data_sorted.get(),
       original_indices.get(), original_indices_sorted.get(),
-      num_indices));
+      num_indices, 0, sizeof(Tin)*8, stream));
 
   auto sort_temp_storage = rocm_kernel.GetScratchBuffer<void>(sort_temp_storage_size_bytes);
 
@@ -110,12 +111,12 @@ void GatherGradImpl(
       sort_temp_storage.get(), sort_temp_storage_size_bytes,
       indices_data, indices_data_sorted.get(),
       original_indices.get(), original_indices_sorted.get(),
-      num_indices));
+      num_indices, 0, sizeof(Tin)*8, stream));
 
   dim3 block(GPU_WARP_SIZE, 4);
   dim3 grid(CeilDiv(num_indices, 4), CeilDiv(stride, 128));
 
-  hipLaunchKernelGGL(_GatherGradImpl, dim3(grid), dim3(block), 0, 0, 
+  hipLaunchKernelGGL(_GatherGradImpl, dim3(grid), dim3(block), 0, stream, 
       indices_data_sorted.get(),
       original_indices_sorted.get(),
       grad_data,


### PR DESCRIPTION
For reasons not fully understood, PR 6381 has increased the variance of the observed loss on our BERT convergence test. As it is only an optimization, we will revert for now and revisit the situation in the future.

Commit | Note | Final Loss | Sigma | Max-diff | % noise
-- | -- | -- | -- | -- | --
7f57317 | PR   6381 | 0.674179 | 0.0136674 | 0.02963 | 2.03%
9a9e741 | comment optimization | 0.670375 | 0.00052346 | 0.001588 | 0.08%




Final loss is calculated across 10 runs of run_convergence_test.py.