### PR TITLE
Add *args support.

### DIFF
--- a/orttraining/orttraining/python/training/_ortmodule_output_transformation.py
+++ b/orttraining/orttraining/python/training/_ortmodule_output_transformation.py
@@ -161,11 +161,6 @@ def get_flattened_output_module(original_module):
     return FlattenedOutputModule(original_module)
 
 def parse_inputs_for_onnx_export(all_input_parameters, onnx_graph, *inputs, **kwargs):
-    # TODO: remove after PyTorch ONNX exporter supports VAR_KEYWORD parameters.
-    for input_parameter in all_input_parameters:
-        if input_parameter.kind == inspect.Parameter.VAR_KEYWORD:
-            raise NotImplementedError("The model's forward method has **kwargs parameter which is currently not supported.")
-
     # Ignore optional inputs explicitly specified as None
     # ONNX exporter may remove unused inputs
     onnx_graph_input_names = []

--- a/orttraining/orttraining/python/training/_ortmodule_output_transformation.py
+++ b/orttraining/orttraining/python/training/_ortmodule_output_transformation.py
@@ -164,7 +164,7 @@ def parse_inputs_for_onnx_export(all_input_parameters, onnx_graph, *inputs, **kw
     # TODO: remove after PyTorch ONNX exporter supports VAR_KEYWORD parameters.
     for input_parameter in all_input_parameters:
         if input_parameter.kind == inspect.Parameter.VAR_KEYWORD:
-            warnings.warn("The model's forward method has **kwargs parameter which is not supported.")
+            raise NotImplementedError("The model's forward method has **kwargs parameter which is currently not supported.")
 
     # Ignore optional inputs explicitly specified as None
     # ONNX exporter may remove unused inputs

--- a/orttraining/orttraining/python/training/_ortmodule_output_transformation.py
+++ b/orttraining/orttraining/python/training/_ortmodule_output_transformation.py
@@ -186,7 +186,7 @@ def parse_inputs_for_onnx_export(all_input_parameters, onnx_graph, *inputs, **kw
                 name = f'var_positional_{input_parameter.name}{var_positional_idx}'
                 var_positional_idx += 1
                 inp = inputs[i]
-                if inp is not None and name in onnx_graph_input_names:
+                if inp is not None and (onnx_graph is None or name in onnx_graph_input_names):
                     if inp.requires_grad:
                         # input_names_require_grad holds all input tensors that have requires_grad
                         input_names_require_grad.append(name)
@@ -204,7 +204,7 @@ def parse_inputs_for_onnx_export(all_input_parameters, onnx_graph, *inputs, **kw
                 inp = inputs[input_idx]
             elif name in kwargs and kwargs[name] is not None:
                 inp = kwargs[name]
-            if inp is not None and name in onnx_graph_input_names:
+            if inp is not None and (onnx_graph is None or name in onnx_graph_input_names):
                 if inp.requires_grad:
                     # input_names_require_grad holds all input tensors that have requires_grad
                     input_names_require_grad.append(name)

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -239,6 +239,7 @@ class ORTModule(torch.nn.Module):
         self._flattened_output_module = \
             _ortmodule_output_transformation.get_flattened_output_module(self._original_module)
         self._original_module_parameters = signature(self._original_module.forward).parameters.values()
+        # TODO: remove after PyTorch ONNX exporter supports VAR_KEYWORD parameters.
         for input_parameter in self._original_module_parameters:
             if input_parameter.kind == inspect.Parameter.VAR_KEYWORD:
                 warnings.warn("The model's forward method has **kwargs parameter which is not supported.")

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -4,7 +4,6 @@ import logging
 import onnx
 import onnxruntime
 import torch
-import warnings
 import inspect
 from inspect import signature
 
@@ -239,10 +238,6 @@ class ORTModule(torch.nn.Module):
         self._flattened_output_module = \
             _ortmodule_output_transformation.get_flattened_output_module(self._original_module)
         self._original_module_parameters = signature(self._original_module.forward).parameters.values()
-        # TODO: remove after PyTorch ONNX exporter supports VAR_KEYWORD parameters.
-        for input_parameter in self._original_module_parameters:
-            if input_parameter.kind == inspect.Parameter.VAR_KEYWORD:
-                warnings.warn("The model's forward method has **kwargs parameter which is not supported.")
 
         self._onnx_inference = None
         self._is_training = True
@@ -382,7 +377,6 @@ class ORTModule(torch.nn.Module):
         '''Exports PyTorch `module` to ONNX with training flag, using `*inputs` as input
 
         TODO: How to support dynamic axes? Dimensions are determined by samples
-        TODO: How to ingest **kwargs in proper order during export?
         '''
 
         # Setup dynamic axes for onnx model

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -239,6 +239,11 @@ class ORTModule(torch.nn.Module):
             _ortmodule_output_transformation.get_flattened_output_module(self._original_module)
         self._original_module_parameters = signature(self._original_module.forward).parameters.values()
 
+        # TODO: remove after PyTorch ONNX exporter supports VAR_KEYWORD parameters.
+        for input_parameter in self._original_module_parameters:
+            if input_parameter.kind == inspect.Parameter.VAR_KEYWORD:
+                raise NotImplementedError("The model's forward method has **kwargs parameter which is currently not supported.")
+
         self._onnx_inference = None
         self._is_training = True
 

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -238,19 +238,21 @@ def test_forward_call_multiple_positional_arguments_var_keyword():
 
     N, D_in, H, D_out = 64, 784, 500, 10
     model = NeuralNetMultiplePositionalArgumentsVarKeyword(input_size=D_in, hidden_size=H, num_classes=D_out).to(device)
-    with pytest.warns(UserWarning) as warning_context_manager:
+
+    # TODO: remove exception check and uncomment the rest of the test when
+    # PyTorch ONNX exporter supports **kwargs.
+    with pytest.raises(NotImplementedError) as runtime_error:
         ort_model = ORTModule(model)
-    assert len(warning_context_manager) == 1
-    assert "**kwargs" in str(warning_context_manager[0].message)
+    assert 'ORTModule does not support the following model output type' in str(runtime_error.value)
 
-    # Check that the original forward signature is preserved.
-    assert signature(model.forward) == signature(ort_model.forward)
-    x = torch.randn(N, D_in, device=device)
-    y = torch.randn(N, D_in, device=device)
+    # # Check that the original forward signature is preserved.
+    # assert signature(model.forward) == signature(ort_model.forward)
+    # x = torch.randn(N, D_in, device=device)
+    # y = torch.randn(N, D_in, device=device)
 
-    # Make sure model runs without any exception
-    output = ort_model(x, y)
-    assert output is not None
+    # # Make sure model runs without any exception
+    # output = ort_model(x, y)
+    # assert output is not None
 
 def test_forward_call_positional_arguments():
     device = 'cuda'

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -243,7 +243,7 @@ def test_forward_call_multiple_positional_arguments_var_keyword():
     # PyTorch ONNX exporter supports **kwargs.
     with pytest.raises(NotImplementedError) as runtime_error:
         ort_model = ORTModule(model)
-    assert 'ORTModule does not support the following model output type' in str(runtime_error.value)
+    assert '**kwargs' in str(runtime_error.value)
 
     # # Check that the original forward signature is preserved.
     # assert signature(model.forward) == signature(ort_model.forward)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -218,18 +218,17 @@ def test_forward_call_multiple_positional_arguments():
     output = ort_model(x, y)
     assert output is not None
 
-# TODO: Re-enable after "Support models with dynamically defined inputs" done.
-# def test_forward_call_positional_arguments():
-#     device = 'cuda'
+def test_forward_call_positional_arguments():
+    device = 'cuda'
 
-#     N, D_in, H, D_out = 64, 784, 500, 10
-#     model = NeuralNetPositionalArguments(input_size=D_in, hidden_size=H, num_classes=D_out).to(device)
-#     model = ORTModule(model)
-#     args = [torch.randn(N, D_in, device=device), torch.randn(N, D_in, device=device), torch.randn(N, D_in, device=device)]
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = NeuralNetPositionalArguments(input_size=D_in, hidden_size=H, num_classes=D_out).to(device)
+    model = ORTModule(model)
+    args = [torch.randn(N, D_in, device=device), torch.randn(N, D_in, device=device), torch.randn(N, D_in, device=device)]
 
-#     # Make sure model runs without any exception
-#     output = model(*args)
-#     assert output is not None
+    # Make sure model runs without any exception
+    output = model(*args)
+    assert output is not None
 
 def test_forward_call_keyword_arguments():
     device = 'cuda'


### PR DESCRIPTION
Re-enable test_forward_call_positional_arguments test.

The test was disabled by https://github.com/microsoft/onnxruntime/pull/6539 after adding support for removed unused inputs by ONNX converter. This PR adds proper support for *args (including dynamic axes and unused inputs) and re-enables the test.