### PR TITLE
Workaround for HTTP Error 403: Forbidden for MNIST dataset

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
+++ b/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
@@ -249,6 +249,14 @@ class MNISTWrapper():
         return ModelDescription([input_desc, label_desc], [loss_desc, probability_desc])
 
     def get_loaders(self):
+        # TODO: Remove this temporary fix for urllib.error.HTTPError: HTTP Error 403: Forbidden
+        # once a more permanent solution can be found.
+        # Fix as per https://github.com/pytorch/vision/issues/1938#issuecomment-789986996
+        from six.moves import urllib
+        opener = urllib.request.build_opener()
+        opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+        urllib.request.install_opener(opener)
+
         args_batch_size = 64
         args_test_batch_size = 1000
 


### PR DESCRIPTION
CI started failing with error ```HTTP Error 403: Forbidden``` when trying to download MNIST dataset. Using workaround for downloading MNIST dataset so that CI no longer fails