### PR TITLE
Add check that Loop subgraph iter_num and cond inputs have a shape

### DIFF
--- a/onnxruntime/core/providers/cpu/controlflow/loop.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/loop.cc
@@ -399,6 +399,12 @@ Status LoopImpl::Initialize() {
 
   auto& subgraph_inputs = info_.subgraph.GetInputs();
 
+  // we need to know if the subgraph expects a rank 0 or rank 1 value for these, so a shape is required.
+  ORT_RETURN_IF(subgraph_inputs[0]->Shape() == nullptr, "Loop subgraph input 0 has unknown shape: ",
+                subgraph_inputs[0]->Name());
+  ORT_RETURN_IF(subgraph_inputs[1]->Shape() == nullptr, "Loop subgraph input 1 has unknown shape: ",
+                subgraph_inputs[1]->Name());
+
   auto iter_num_rank = subgraph_inputs[0]->Shape()->dim_size();
   auto condition_rank = subgraph_inputs[1]->Shape()->dim_size();
 


### PR DESCRIPTION
**Description**: 
Add check that the first 2 Loop subgraph inputs have an shape (could be explicit or inferred) as we need to know the rank the subgraph expects. Other inputs to the subgraph are more opaque so we can just pass them through.

We can't do the check earlier as the Loop inferencing doesn't see the subgraph, so can't check if the subgraph has an explicit shape. We can't add a check in the generic Graph::InferAndVerifySubgraphTypes as there are other scenarios where it's fine for there to be no shape (e.g. outer scope variable being used in a subgraph two levels down), and we don't want to be adding operator specific logic at that level.

Manually tested with model from #6874. 

**Motivation and Context**
Provides error message for #6874