### PR TITLE
Configure session thread pool spinning preference

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -48,6 +48,6 @@ static const char* const kOrtSessionOptionsConfigSetDenormalAsZero = "session.se
 static const char* const kOrtSessionOptionsEnableQuantQDQ = "session.enable_quant_qdq";
 
 // It controls whether allow the thread to spin a few times before blocking
-// "0": default value, thread will block if no job to run
-// "1": thread will spin a number of times before blocking
+// "0": thread will block if found no job to run
+// "1": default, thread will spin a number of times before blocking
 static const char* const kOrtSessionOptionsConfigAllowSpinning = "session.allow_spinning";

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -46,3 +46,8 @@ static const char* const kOrtSessionOptionsConfigSetDenormalAsZero = "session.se
 // "1": enable. ORT does fusion logic for QDQ format.
 // Its default value is "1"
 static const char* const kOrtSessionOptionsEnableQuantQDQ = "session.enable_quant_qdq";
+
+// It controls whether allow the thread to spin a few times before blocking
+// "0": default value, thread will block if no job to run
+// "1": thread will spin a number of times before blocking
+static const char* const kOrtSessionOptionsConfigAllowSpinning = "session.allow_spinning";

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -47,7 +47,8 @@ static const char* const kOrtSessionOptionsConfigSetDenormalAsZero = "session.se
 // Its default value is "1"
 static const char* const kOrtSessionOptionsEnableQuantQDQ = "session.enable_quant_qdq";
 
-// It controls whether allow the thread to spin a few times before blocking
+// Configure whether to allow the inter_op/intra_op threads spinning a number of times before blocking
 // "0": thread will block if found no job to run
 // "1": default, thread will spin a number of times before blocking
-static const char* const kOrtSessionOptionsConfigAllowSpinning = "session.allow_spinning";
+static const char* const kOrtSessionOptionsConfigAllowInterOpSpinning = "session.inter_op.allow_spinning";
+static const char* const kOrtSessionOptionsConfigAllowIntraOpSpinning = "session.intra_op.allow_spinning";

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -228,7 +228,7 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
   }
 
   use_per_session_threads_ = session_options.use_per_session_threads;
-  bool allow_spinning = session_options_.GetConfigOrDefault(kOrtSessionOptionsConfigAllowSpinning, "0") == "1";
+  bool allow_spinning = session_options_.GetConfigOrDefault(kOrtSessionOptionsConfigAllowSpinning, "1") == "1";
 
   if (use_per_session_threads_) {
     LOGS(*session_logger_, INFO) << "Creating and using per session threadpools since use_per_session_threads_ is true";

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -228,11 +228,12 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
   }
 
   use_per_session_threads_ = session_options.use_per_session_threads;
-  bool allow_spinning = session_options_.GetConfigOrDefault(kOrtSessionOptionsConfigAllowSpinning, "1") == "1";
 
   if (use_per_session_threads_) {
     LOGS(*session_logger_, INFO) << "Creating and using per session threadpools since use_per_session_threads_ is true";
     {
+      bool allow_intra_op_spinning =
+          session_options_.GetConfigOrDefault(kOrtSessionOptionsConfigAllowIntraOpSpinning, "1") == "1";
       OrtThreadPoolParams to = session_options_.intra_op_param;
       if (to.name == nullptr) {
         to.name = ORT_TSTR("intra-op");
@@ -243,11 +244,13 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
       to.auto_set_affinity = to.thread_pool_size == 0 &&
                              session_options_.execution_mode == ExecutionMode::ORT_SEQUENTIAL &&
                              to.affinity_vec_len == 0;
-      to.allow_spinning = allow_spinning;
+      to.allow_spinning = allow_intra_op_spinning;
       thread_pool_ =
           concurrency::CreateThreadPool(&Env::Default(), to, concurrency::ThreadPoolType::INTRA_OP);
     }
     if (session_options_.execution_mode == ExecutionMode::ORT_PARALLEL) {
+      bool allow_inter_op_spinning = 
+          session_options_.GetConfigOrDefault(kOrtSessionOptionsConfigAllowInterOpSpinning, "1") == "1";
       OrtThreadPoolParams to = session_options_.inter_op_param;
       // If the thread pool can use all the processors, then
       // we set thread affinity.
@@ -256,7 +259,7 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
       if (to.name == nullptr)
         to.name = ORT_TSTR("intra-op");
       to.set_denormal_as_zero = set_denormal_as_zero;
-      to.allow_spinning = allow_spinning;
+      to.allow_spinning = allow_inter_op_spinning;
       inter_op_thread_pool_ =
           concurrency::CreateThreadPool(&Env::Default(), to, concurrency::ThreadPoolType::INTER_OP);
       if (inter_op_thread_pool_ == nullptr) {


### PR DESCRIPTION
Add session configuration entry to allow for setting spinning preference of session-level thread pool.
Usage example in python:

sess_opt.add_session_config_entry('session.allow_spinning', '0') // disable thread spinning
or: 
sess_opt.add_session_config_entry('session.allow_spinning', '1') // enable thread spinning, default


