### PR TITLE
Fix broken link in ONNX_Runtime_Server_Usage.md

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -342,7 +342,7 @@ Note: When running the container you built in Docker, please either use 'nvidia-
   ```
 3. Send HTTP requests to the container running ONNX Runtime Server
 
-  Send HTTP requests to the docker container through the binding local port. Here is the full [usage document](https://github.com/Microsoft/onnxruntime/blob/master/docs/ONNX_Runtime_Server_Usage.md).
+  Send HTTP requests to the docker container through the binding local port. Here is the full [usage document](../docs/ONNX_Runtime_Server_Usage.md).
   ```
   curl  -X POST -d "@request.json" -H "Content-Type: application/json" http://0.0.0.0:{your_local_port}/v1/models/mymodel/versions/3:predict  
   ```

--- a/docs/ONNX_Runtime_Server_Usage.md
+++ b/docs/ONNX_Runtime_Server_Usage.md
@@ -53,7 +53,7 @@ http://<your_ip_address>:<port>/v1/models/<your-model-name>/versions/<your-versi
 
 ### Request and Response Payload
 
-The request and response need to be a protobuf message. The Protobuf definition can be found [here](../onnxruntime/server/protobuf/predict.proto).
+The request and response need to be a protobuf message. The Protobuf definition can be found [here](../server/protobuf/predict.proto).
 
 A protobuf message could have two formats: binary and JSON. Usually the binary payload has better latency, in the meanwhile the JSON format is easy for human readability. 
 


### PR DESCRIPTION
**Description**: Fixed broken link to protobuf file in server usage markdown. It was leading to a non-existing page before. As well as made a link to the server usage documentation with a relative path, and now it can be shown in forks as well.

**Motivation and Context**
- _Why is this change required? What problem does it solve?_
It saves time for developers looking for a protobuf definition of `PredictRequest` and `PredictResponse`.
