### PR TITLE
Fix loss scaling when running ORTTrainer with BERT under mixed-precision mode

### DIFF
--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -44,6 +44,8 @@
 #include "core/profile/context.h"
 #endif
 
+#include <cstdlib>
+
 namespace onnxruntime {
 namespace training {
 
@@ -585,6 +587,9 @@ Status TrainingSession::ConfigureForTraining(
 
   config_result_out = std::move(config_result);
   is_configured_ = true;
+
+  const char* dump_model_path = std::getenv("DUMP_MODEL_PATH");
+  ORT_IGNORE_RETURN_VALUE(Save(dump_model_path, SaveOption::NO_RELOAD));
 
   return Status::OK();
 }
@@ -1679,7 +1684,7 @@ Status PipelineTrainingSession::BuildLossAndLossScaling(
     std::string& loss_name,
     optional<std::string>& loss_scale_input_name,
     optional<TrainingConfigurationResult::MixedPrecisionConfigurationResult>& mixed_precision_config_result) {
-  const bool last_pipeline_stage = pipeline_stage_id + 1 == distributed_config.value().pipeline_parallel_size;
+  const bool last_pipeline_stage = pipeline_stage_id == -1 || (pipeline_stage_id + 1 == distributed_config.value().pipeline_parallel_size);
   const bool enable_loss_scale = is_mixed_precision_enabled_ &&
                                  mixed_precision_config.value().mixed_precision_type == MixedPrecisionDataType::FP16;
   // Enable loss scale if mixed precision is enabled AND at pipeline's last stage if pipeline is used.

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -44,8 +44,6 @@
 #include "core/profile/context.h"
 #endif
 
-#include <cstdlib>
-
 namespace onnxruntime {
 namespace training {
 
@@ -587,9 +585,6 @@ Status TrainingSession::ConfigureForTraining(
 
   config_result_out = std::move(config_result);
   is_configured_ = true;
-
-  const char* dump_model_path = std::getenv("DUMP_MODEL_PATH");
-  ORT_IGNORE_RETURN_VALUE(Save(dump_model_path, SaveOption::NO_RELOAD));
 
   return Status::OK();
 }


### PR DESCRIPTION
Recent experiments reveal a divergence problem introduced by pipeline parallel PR. As shown in the following figure, the green line (with PP) differs from gray (without PP) and orange (with fix in this PR) lines.
![image](https://user-images.githubusercontent.com/3524474/110293692-d9bd2c00-8029-11eb-8f80-a6cec33a12c8.png)
The used script is from ORT's BERT example (based on NV-bert). To speed up the experiment, we use very small model but that model is enough for detecting mixed-precision problem within 1 min. Here is the configuration we use
```
#bert_config.json

{
  "attention_probs_dropout_prob": 0.1,
  "hidden_act": "gelu",
  "hidden_dropout_prob": 0.1,
  "hidden_size": 32,
  "initializer_range": 0.02,
  "intermediate_size": 32,
  "max_position_embeddings": 512,
  "num_attention_heads": 2,
  "num_hidden_layers": 2,
  "type_vocab_size": 2,
  "vocab_size": 30522
}
```
and
```
# part of run_pretraining_ort.sh
...

precision=${3:-"fp16"}
num_gpus=${4:-8}
gpu_memory_limit_gb=${26:-"32"}

seed=${12:-42}
job_name=${13:-"bert_lamb_pretraining"}
allreduce_post_accumulation=${14:-"true"}
allreduce_post_accumulation_fp16=${15:-"true"}

resume_training=${8:-"false"}
create_logfile=${9:-"true"}
accumulate_gradients=${10:-"true"}
deepspeed_zero_stage=${27:-"false"}

train_batch_size=${1:-128}
learning_rate=${2:-"6e-3"}
warmup_proportion=${5:-"0.2843"}
train_steps=${6:-1000}
save_checkpoint_steps=${7:-200}
gradient_accumulation_steps=${11:-4}

train_batch_size_phase2=${17:-128}
learning_rate_phase2=${18:-"4e-3"}
warmup_proportion_phase2=${19:-"0.128"}
train_steps_phase2=${20:-1}
gradient_accumulation_steps_phase2=${11:-2}

...
```