### PR TITLE
Only set _native folder for Microsoft.AI.MachineLearning package

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -216,9 +216,14 @@ def generate_files(list, args):
         copy_command = "cp"
         runtimes_target = '" target="runtimes\\linux-'
 
+    if is_windowsai_package:
+        runtimes_native_folder = '_native'
+    else:
+        runtimes_native_folder = 'native'
+
     runtimes = '{}{}\\{}"'.format(runtimes_target,
                                   args.target_architecture,
-                                  'lib\\uap10.0' if args.is_store_build else '_native')
+                                  'lib\\uap10.0' if args.is_store_build else runtimes_native_folder)
 
     # Process headers
     files_list.append('<file src=' + '"' + os.path.join(args.sources_path,

--- a/tools/nuget/validate_nuget.py
+++ b/tools/nuget/validate_nuget.py
@@ -119,7 +119,7 @@ def main():
 
         # Check if the relevant dlls are present in the Nuget/Zip
         print('Checking if the Nuget contains relevant dlls')
-        is_windows_ai_package = os.path.basename(full_nuget_path).startswith('Microsoft')
+        is_windows_ai_package = os.path.basename(full_nuget_path).startswith('Microsoft.AI.MachineLearning')
         check_if_dlls_are_present(is_windows_ai_package, args.platforms_supported, zip_file)
 
         # Check if the Nuget has been signed


### PR DESCRIPTION
Issue: For Microsoft.AI.MachineLearning package, the _native folder should be used in nuget pacakge runtimes directory rather than "native." However, it is being used on other pacakges as well.

Fix: Only use _native folder for Microsoft.AI.MachineLearning nuget package.