### PR TITLE
Assert that the data is on the same device as ORTModule

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -44,6 +44,12 @@ def _onnx_value_info_to_buffer_tensor(value_info, device):
     dtype = _utils.dtype_onnx_to_torch(value_info.type.tensor_type.elem_type)
     return torch.zeros(shape, device=device, dtype=dtype)
 
+def _check_device(device, argument_str, *args):
+    for arg in args:
+        arg_device = _utils.get_device_from_input_args_kwargs(arg)
+        if arg_device != device:
+            raise RuntimeError(f"{argument_str} found on device {arg_device}, but expected it to be on module device {device}.")
+
 # TODO: PyTorch's to_dlpack() uses same config for both torch.bool and torch.uint8,
 # and convert the config to torch.uint8 tensor duing from_dlpack(). So a boolean tensor
 # from forward graph outputs will be converted to torch.uint8 tensor. When this tensor
@@ -134,6 +140,9 @@ class ORTModule(torch.nn.Module):
                     Module outputs are returned to the user
                     '''
 
+                    # Assert that the input and model device match
+                    _check_device(self._device, "Input argument to forward", *inputs)
+
                     # Use IO binding
                     _create_iobinding(self._training_io_binding, inputs, self._onnx_training, self._device)
 
@@ -147,12 +156,18 @@ class ORTModule(torch.nn.Module):
                     ctx.set_materialize_grads(False)
                     ctx.output_info = [(output.shape, output.device, output.dtype) for output in user_outputs]
 
+                    # Assert that the outputs and model device match
+                    _check_device(self._device, "Output argument from forward", *user_outputs)
+
                     return user_outputs
 
                 @staticmethod
                 def backward(ctx, *grad_outputs):
                     '''Performs backward pass based on grad wrt module output
                     '''
+
+                    # Assert that the grad_outputs and model device match
+                    _check_device(self._device, "Input argument to backward", *grad_outputs)
 
                     # Use IO binding
                     # Push user output grads to ONNX backend.

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -46,9 +46,10 @@ def _onnx_value_info_to_buffer_tensor(value_info, device):
 
 def _check_device(device, argument_str, *args):
     for arg in args:
-        arg_device = _utils.get_device_from_input_args_kwargs(arg)
-        if arg_device != device:
-            raise RuntimeError(f"{argument_str} found on device {arg_device}, but expected it to be on module device {device}.")
+        if arg is not None and isinstance(arg, torch.Tensor):
+            arg_device = torch.device(arg.device)
+            if arg_device != device:
+                raise RuntimeError(f"{argument_str} found on device {arg_device}, but expected it to be on module device {device}.")
 
 # TODO: PyTorch's to_dlpack() uses same config for both torch.bool and torch.uint8,
 # and convert the config to torch.uint8 tensor duing from_dlpack(). So a boolean tensor

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -1236,4 +1236,4 @@ def test_forward_data_and_model_on_different_devices(data_device, model_device):
     x = torch.randn(N, D_in, device=data_device)
     with pytest.raises(RuntimeError) as runtime_error:
         ort_model(x)
-    assert f"Input argument to forward found on device {_utils.get_device_from_input_args_kwargs(x)}, but expected it to be on module device {ort_model._device}." in str(runtime_error.value)
+    assert f"Input argument to forward found on device {torch.device(x.device)}, but expected it to be on module device {ort_model._device}." in str(runtime_error.value)


### PR DESCRIPTION
**Description**: Input to ```forward``` and ```backward``` can be on different devices. This pull request introduces a simple check to ensure that the incoming data resides on the same device as the module.