### PR TITLE
dnnl format tag fix

### DIFF
--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_kernel.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_kernel.cc
@@ -39,7 +39,7 @@ dnnl::memory::format_tag DnnlKernel::GetSourceFormat(int dim_size) {
       break;
     }
     case 3: {
-      source_format = dnnl::memory::format_tag::ntc;
+      source_format = dnnl::memory::format_tag::ncw;
       break;
     }
     case 4: {


### PR DESCRIPTION
**Description**: modify dnnl::memory::format_tag::ntc to dnnl::memory::format_tag::ncw

**Motivation and Context**
- format tag should be dnnl::memory::format_tag::ncw
