### PR TITLE
Update baseline due to loss scale fix

### DIFF
--- a/orttraining/orttraining/test/python/orttraining_run_glue.py
+++ b/orttraining/orttraining/test/python/orttraining_run_glue.py
@@ -124,7 +124,7 @@ class ORTGlueTest(unittest.TestCase):
     def test_bert_fp16_with_mrpc(self):
         expected_acc = 0.84
         expected_f1 = 0.88
-        expected_loss = 0.44
+        expected_loss = 0.46
 
         results = self.run_glue(model_name="bert-base-cased", task_name="MRPC", fp16=True)
 


### PR DESCRIPTION
A baseline is changed after #6929. Before that commit, the metrics are
```
2021-03-06T01:51:48.3852208Z 03/06/2021 01:51:48 - INFO - __main__ -   ***** Eval results mrpc *****
2021-03-06T01:51:48.3853098Z 03/06/2021 01:51:48 - INFO - __main__ -     acc = 0.8431372549019608
2021-03-06T01:51:48.3853918Z 03/06/2021 01:51:48 - INFO - __main__ -     f1 = 0.889655172413793
2021-03-06T01:51:48.3854776Z 03/06/2021 01:51:48 - INFO - __main__ -     acc_and_f1 = 0.8663962136578769
2021-03-06T01:51:48.3855624Z 03/06/2021 01:51:48 - INFO - __main__ -     loss = 0.42792631817214627
```
After that commit, they become
```
2021-03-08T14:35:39.7116375Z 03/08/2021 14:35:39 - INFO - __main__ -   ***** Eval results mrpc *****
2021-03-08T14:35:39.7117294Z 03/08/2021 14:35:39 - INFO - __main__ -     acc = 0.8455882352941176
2021-03-08T14:35:39.7118147Z 03/08/2021 14:35:39 - INFO - __main__ -     f1 = 0.8923076923076922
2021-03-08T14:35:39.7118996Z 03/08/2021 14:35:39 - INFO - __main__ -     acc_and_f1 = 0.868947963800905
2021-03-08T14:35:39.7119853Z 03/08/2021 14:35:39 - INFO - __main__ -     loss = 0.4538641466813929
```
Based on the following reasons, we think this is a numerical instability so this PR is created to update the metric.
1. With #6929, only `loss` is worse and the other metrics are better.
2. The `loss` for RoBerta under fp32 and fp16 are 0.35 and 0.33, respectively. For BERT (this PR's case), the corresponding values were 0.44 and 0.44. This PR changes fp16's `loss` to 0.46. Still, the gap between BERT's two scores is similar to RoBerta's.