### PR TITLE
fixed type to experimental session constructor

### DIFF
--- a/samples/c_cxx/model-explorer/batch-model-explorer.cpp
+++ b/samples/c_cxx/model-explorer/batch-model-explorer.cpp
@@ -60,7 +60,9 @@ int main(int argc, char** argv) {
     cout << "Usage: ./onnx-api-example <onnx_model.onnx>" << endl;
     return -1;
   }
-  std::string model_file = argv[1];
+  std::string str = argv[1];
+  std::wstring wide_string = std::wstring(str.begin(), str.end());
+  std::basic_string<ORTCHAR_T> model_file = std::basic_string<ORTCHAR_T>(wide_string);
 
   // onnxruntime setup
   Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "batch-model-explorer");

--- a/samples/c_cxx/model-explorer/batch-model-explorer.cpp
+++ b/samples/c_cxx/model-explorer/batch-model-explorer.cpp
@@ -61,8 +61,13 @@ int main(int argc, char** argv) {
     return -1;
   }
   std::string str = argv[1];
+  std::basic_string<ORTCHAR_T> model_file;
+#ifdef _WIN32
   std::wstring wide_string = std::wstring(str.begin(), str.end());
-  std::basic_string<ORTCHAR_T> model_file = std::basic_string<ORTCHAR_T>(wide_string);
+  model_file = std::basic_string<ORTCHAR_T>(wide_string);
+#else
+  model_file = std::basic_string<ORTCHAR_T>(str.c_str());
+#endif
 
   // onnxruntime setup
   Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "batch-model-explorer");

--- a/samples/c_cxx/model-explorer/batch-model-explorer.cpp
+++ b/samples/c_cxx/model-explorer/batch-model-explorer.cpp
@@ -60,13 +60,13 @@ int main(int argc, char** argv) {
     cout << "Usage: ./onnx-api-example <onnx_model.onnx>" << endl;
     return -1;
   }
-  std::string str = argv[1];
-  std::basic_string<ORTCHAR_T> model_file;
+
 #ifdef _WIN32
+  std::string str = argv[1];
   std::wstring wide_string = std::wstring(str.begin(), str.end());
-  model_file = std::basic_string<ORTCHAR_T>(wide_string);
+  std::basic_string<ORTCHAR_T> model_file = std::basic_string<ORTCHAR_T>(wide_string);
 #else
-  model_file = std::basic_string<ORTCHAR_T>(str.c_str());
+  std::string model_file = argv[1];
 #endif
 
   // onnxruntime setup

--- a/samples/c_cxx/model-explorer/model-explorer.cpp
+++ b/samples/c_cxx/model-explorer/model-explorer.cpp
@@ -49,13 +49,13 @@ int main(int argc, char** argv) {
     cout << "Usage: ./onnx-api-example <onnx_model.onnx>" << endl;
     return -1;
   }
-  std::string str = argv[1];
-  std::basic_string<ORTCHAR_T> model_file;
+
 #ifdef _WIN32
+  std::string str = argv[1];
   std::wstring wide_string = std::wstring(str.begin(), str.end());
-  model_file = std::basic_string<ORTCHAR_T>(wide_string);
+  std::basic_string<ORTCHAR_T> model_file = std::basic_string<ORTCHAR_T>(wide_string);
 #else
-  model_file = std::basic_string<ORTCHAR_T>(str.c_str());
+  std::string model_file = argv[1];
 #endif
 
   // onnxruntime setup

--- a/samples/c_cxx/model-explorer/model-explorer.cpp
+++ b/samples/c_cxx/model-explorer/model-explorer.cpp
@@ -49,7 +49,9 @@ int main(int argc, char** argv) {
     cout << "Usage: ./onnx-api-example <onnx_model.onnx>" << endl;
     return -1;
   }
-  std::string model_file = argv[1];
+  std::string str = argv[1];
+  std::wstring wide_string = std::wstring(str.begin(), str.end());
+  std::basic_string<ORTCHAR_T> model_file = std::basic_string<ORTCHAR_T>(wide_string);
 
   // onnxruntime setup
   Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "example-model-explorer");

--- a/samples/c_cxx/model-explorer/model-explorer.cpp
+++ b/samples/c_cxx/model-explorer/model-explorer.cpp
@@ -50,8 +50,13 @@ int main(int argc, char** argv) {
     return -1;
   }
   std::string str = argv[1];
+  std::basic_string<ORTCHAR_T> model_file;
+#ifdef _WIN32
   std::wstring wide_string = std::wstring(str.begin(), str.end());
-  std::basic_string<ORTCHAR_T> model_file = std::basic_string<ORTCHAR_T>(wide_string);
+  model_file = std::basic_string<ORTCHAR_T>(wide_string);
+#else
+  model_file = std::basic_string<ORTCHAR_T>(str.c_str());
+#endif
 
   // onnxruntime setup
   Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "example-model-explorer");


### PR DESCRIPTION
**Description**: 
Very small change to model-explorer.cpp. It seems the signature of the Ort::Experimental::Session constructor was changed but the sample code wasn't updated to reflect the change. I explain this in an issue: https://github.com/microsoft/onnxruntime/issues/6949

**Motivation and Context**
- Why is this change required? What problem does it solve?
Eliminate compile time error for the model-explorer sample.

- If it fixes an open issue, please link to the issue here.
https://github.com/microsoft/onnxruntime/issues/6949