### PR TITLE
HIP_CLANG_FLAGS replaces HIP_HCC_FLAGS for ROCm later than 4.0

### DIFF
--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -1006,12 +1006,15 @@ if (onnxruntime_USE_ROCM)
   endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
   list(APPEND HIP_HCC_FLAGS ${HIP_CXX_FLAGS})
+  list(APPEND HIP_CLANG_FLAGS ${HIP_CXX_FLAGS})  
 
   # Let hcc to generate GPU code during compilation
   list(APPEND HIP_HCC_FLAGS -fno-gpu-rdc)
+  list(APPEND HIP_CLANG_FLAGS -fno-gpu-rdc)  
 
   # Generate GPU code for GFX9 Generation
   list(APPEND HIP_HCC_FLAGS --amdgpu-target=gfx906 --amdgpu-target=gfx908)
+  list(APPEND HIP_CLANG_FLAGS --amdgpu-target=gfx906 --amdgpu-target=gfx908)
 
   hip_add_library(onnxruntime_providers_rocm ${onnxruntime_providers_rocm_src})
 

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -1005,15 +1005,12 @@ if (onnxruntime_USE_ROCM)
       #list(APPEND HIP_CXX_FLAGS -O0)
   endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
-  list(APPEND HIP_HCC_FLAGS ${HIP_CXX_FLAGS})
   list(APPEND HIP_CLANG_FLAGS ${HIP_CXX_FLAGS})  
 
-  # Let hcc to generate GPU code during compilation
-  list(APPEND HIP_HCC_FLAGS -fno-gpu-rdc)
+  # Generate GPU code during compilation
   list(APPEND HIP_CLANG_FLAGS -fno-gpu-rdc)  
 
   # Generate GPU code for GFX9 Generation
-  list(APPEND HIP_HCC_FLAGS --amdgpu-target=gfx906 --amdgpu-target=gfx908)
   list(APPEND HIP_CLANG_FLAGS --amdgpu-target=gfx906 --amdgpu-target=gfx908)
 
   hip_add_library(onnxruntime_providers_rocm ${onnxruntime_providers_rocm_src})


### PR DESCRIPTION
keep HIP_HCC_FLAGS for old ROCm versions

**Description**: Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
