### PR TITLE
[Work in Progress] Option to enable partition of graph after AD

### DIFF
--- a/orttraining/orttraining/core/graph/pipeline_transformer.cc
+++ b/orttraining/orttraining/core/graph/pipeline_transformer.cc
@@ -1592,7 +1592,8 @@ Status ApplyPipelinePartitionToMainGraph(Graph& graph,
   // always tensors being copied from stage s to s+1 (for forward computation)
   // and from s+1 to s (for backward computation).
   std::vector<int> stage_to_rank(num_stages);
-  ORT_ENFORCE(static_cast<int>(rank_ids.size()) == num_stages);
+  ORT_ENFORCE(static_cast<int>(rank_ids.size()) == num_stages,
+              "Expected ", num_stages, " but instead got ", rank_ids.size());
   std::vector<std::pair<int, int>> messages;
   for (int s = 0; s < num_stages - 1; ++s) {
     messages.emplace_back(s, s + 1);

--- a/orttraining/orttraining/core/graph/pipeline_transformer.h
+++ b/orttraining/orttraining/core/graph/pipeline_transformer.h
@@ -23,19 +23,19 @@ Status TransformGraphForPipeline(
 // Partitions the graph into num_stages subgraphs, as defined in op_to_stage map,
 // which maps operators to stage ids. After the graph is partitioned, it drops
 // all the tensors and operators that do not belong to the subgraph pipeline_stage_id.
-// TODO(jufranc): when adapting this code to partition training graphs, add
-// a boolean is_training as parameter.
 Status ApplyPipelinePartitionToMainGraph(Graph& graph,
                                          const std::map<const Node*, int>& op_to_stage,
                                          const int pipeline_stage_id,
                                          const int num_stages,
-                                         const std::vector<int32_t>& rank_ids);
+                                         const std::vector<int32_t>& rank_ids,
+                                         const bool is_training_graph);
 
 // First of two functions to obtain a mapping between operators and stage ids.
 // Input:
 //   - graph is the graph being partitioned into multiple pipeline stages.
 //   - id_to_stage maps string identifiers of operators and stage ids. Each
-// operator is identified with the name of any of its outputs.
+// operator is identified with its name, or when that's not defined, with the
+// name of any of its outputs.
 //   - op_to_stage keeps the output of this function, where op_to_stage[node_ptr]
 // is the pipeline stage ID of the pointed node.
 //   - num_stages is the total number of stages.

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -480,9 +480,6 @@ Status TrainingSession::ConfigureForTraining(
         config.model_with_gradient_graph_path.value(), SaveOption::NO_RELOAD));
   }
 
-  ORT_IGNORE_RETURN_VALUE(
-    Save("with_gradients.onnx", SaveOption::NO_RELOAD));
-
   if (partition_after_ad) {
     ORT_RETURN_IF_ERROR(PartitionGraphForPipeline(
       pipeline_stage_id,

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -480,6 +480,9 @@ Status TrainingSession::ConfigureForTraining(
         config.model_with_gradient_graph_path.value(), SaveOption::NO_RELOAD));
   }
 
+  ORT_IGNORE_RETURN_VALUE(
+    Save("with_gradients.onnx", SaveOption::NO_RELOAD));
+
   if (partition_after_ad) {
     ORT_RETURN_IF_ERROR(PartitionGraphForPipeline(
       pipeline_stage_id,
@@ -496,7 +499,7 @@ Status TrainingSession::ConfigureForTraining(
       auto nodes = model_->MainGraph().GetConsumerNodes(name);
       if (!nodes.empty()) {
         weights_to_keep.insert(name);
-      } 
+      }
     }
     weight_names_to_train = weights_to_keep;
     weights_to_train_ = weights_to_keep;

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -492,8 +492,6 @@ Status TrainingSession::ConfigureForTraining(
       config.weight_names_to_train, 
       filtered_config_weight_names_to_train));
 
-    // TODO(jufranc): why can't I use FilterUnusedWeights? There seems to be
-    // too many versions of `weights to train`. Can we improve this?
     std::unordered_set<std::string> weights_to_keep;
     for (auto& name : weight_names_to_train) {
       auto nodes = model_->MainGraph().GetConsumerNodes(name);

--- a/orttraining/orttraining/core/session/training_session.h
+++ b/orttraining/orttraining/core/session/training_session.h
@@ -228,10 +228,12 @@ class TrainingSession : public InferenceSession {
       // cut_list[i] contains the CutInfo to make the partition between stage i and stage i+1
       std::vector<CutInfo> cut_list;
       // Alternative for partition. We map each operator's string identifier to
-      // a stage identifier. We identify operators using the name of any of
-      // their outputs. All operators in the graph must be in the domain of this
-      // map.
+      // a stage identifier. We identify an operator using its name, or when the
+      // name is not defined, we use the name of any of their outputs.
+      // All operators in the graph must be in the domain of this map.
       std::map<std::string, int> op_id_to_stage;
+      // Flag to describe whether pipeline partition will run after AD.
+      bool partition_after_ad = false;
 
       // The base path at which to save the intermediate partitioned input model (forward pass only).
       optional<PathString> partitioned_model_path{};

--- a/orttraining/orttraining/models/mnist/main.cc
+++ b/orttraining/orttraining/models/mnist/main.cc
@@ -36,7 +36,6 @@ using namespace onnxruntime::training;
 using namespace onnxruntime::training::tensorboard;
 using namespace std;
 
-
 const static int NUM_CLASS = 10;
 const static vector<int64_t> IMAGE_DIMS_GEMM = {784};        // for mnist_gemm models
 const static vector<int64_t> IMAGE_DIMS_CONV = {1, 28, 28};  // for mnist_conv models
@@ -112,7 +111,6 @@ Status ParseArguments(int argc, char* argv[], MnistParameters& params) {
     ORT_RETURN_IF_NOT(params.data_parallel_size > 0, "data_parallel_size must > 0");
     ORT_RETURN_IF_NOT(params.horizontal_parallel_size > 0, "horizontal_parallel_size must > 0");
     ORT_RETURN_IF_NOT(params.pipeline_parallel_size > 0, "pipeline_parallel_size must > 0");
-
 
     // If user doesn't provide partitioned model files, a cut list should be provided for ORT to do partition
     // online. If the pipeline contains n stages, the cut list should be of length (n-1), in order to cut the
@@ -310,5 +308,5 @@ int main(int argc, char* args[]) {
   auto runner = onnxruntime::make_unique<TrainingRunner>(params, *env);
   RETURN_IF_FAIL(runner->Initialize());
   RETURN_IF_FAIL(runner->Run(training_data_loader.get(), test_data_loader.get()));
-  // RETURN_IF_FAIL(runner->EndTraining(test_data_loader.get()));
+  RETURN_IF_FAIL(runner->EndTraining(test_data_loader.get()));
 }

--- a/orttraining/orttraining/models/mnist/main.cc
+++ b/orttraining/orttraining/models/mnist/main.cc
@@ -36,6 +36,7 @@ using namespace onnxruntime::training;
 using namespace onnxruntime::training::tensorboard;
 using namespace std;
 
+
 const static int NUM_CLASS = 10;
 const static vector<int64_t> IMAGE_DIMS_GEMM = {784};        // for mnist_gemm models
 const static vector<int64_t> IMAGE_DIMS_CONV = {1, 28, 28};  // for mnist_conv models
@@ -111,6 +112,7 @@ Status ParseArguments(int argc, char* argv[], MnistParameters& params) {
     ORT_RETURN_IF_NOT(params.data_parallel_size > 0, "data_parallel_size must > 0");
     ORT_RETURN_IF_NOT(params.horizontal_parallel_size > 0, "horizontal_parallel_size must > 0");
     ORT_RETURN_IF_NOT(params.pipeline_parallel_size > 0, "pipeline_parallel_size must > 0");
+
 
     // If user doesn't provide partitioned model files, a cut list should be provided for ORT to do partition
     // online. If the pipeline contains n stages, the cut list should be of length (n-1), in order to cut the
@@ -308,5 +310,5 @@ int main(int argc, char* args[]) {
   auto runner = onnxruntime::make_unique<TrainingRunner>(params, *env);
   RETURN_IF_FAIL(runner->Initialize());
   RETURN_IF_FAIL(runner->Run(training_data_loader.get(), test_data_loader.get()));
-  RETURN_IF_FAIL(runner->EndTraining(test_data_loader.get()));
+  // RETURN_IF_FAIL(runner->EndTraining(test_data_loader.get()));
 }

--- a/orttraining/orttraining/models/runner/training_runner.h
+++ b/orttraining/orttraining/models/runner/training_runner.h
@@ -167,13 +167,15 @@ class TrainingRunner {
     // pre-partitioned, no need to fill this value.
     std::vector<TrainingSession::TrainingConfiguration::CutInfo> pipeline_partition_cut_list;
     // Alternative for partition. We map each operator's string identifier to
-    // a stage identifier. We identify operators using the name of any of
-    // their outputs. All operators in the graph must be in the domain of this
-    // map.
+    // a stage identifier. We identify an operator using its name, or when the
+    // name is not defined, we use the name of any of their outputs.
+    // All operators in the graph must be in the domain of this map.
     // For example, op_id_to_stage["MatMul0"] being 5 means the operator node
     // called "MatMul0" locates on the 6th stage. Note that stage ID is 0-based
     // index.
     std::map<std::string, int> op_id_to_stage;
+    // Flag to describe whether pipeline partition will run after AD.
+    bool partition_after_ad = false;
 
     // model_paths[i] is the name of the pipeline stage for i-th process.
     // The i-th file is run by the i-th MPI rank.

--- a/orttraining/orttraining/test/distributed/pipeline_partition_test.cc
+++ b/orttraining/orttraining/test/distributed/pipeline_partition_test.cc
@@ -51,7 +51,7 @@ TEST(PipelinePartition, DropoutGraph2stages) {
   }
   status = ApplyPipelinePartitionToMainGraph(graph, op_to_stage,
                                              pipeline_stage_id, num_stages,
-                                             rank_ids);
+                                             rank_ids, false);
   EXPECT_TRUE(status.IsOK()) << "Failed to apply partition. Error: "
                              << status.ErrorMessage();
 
@@ -86,12 +86,13 @@ void LoadAndPartitionWithCuts(const PathString& model_path,
                                << status.ErrorMessage();
     status = ApplyPipelinePartitionToMainGraph(graph, op_to_stage,
                                                pipeline_stage_id, num_stages,
-                                               rank_ids);
+                                               rank_ids, false);
     EXPECT_TRUE(status.IsOK()) << "Failed to apply partition. Error: "
                                << status.ErrorMessage();
   } else {
     status = CutBasedApplyPipelinePartitionToMainGraph(graph, cuts,
-                                                       pipeline_stage_id, num_stages);
+                                                       pipeline_stage_id, 
+                                                       num_stages);
     EXPECT_TRUE(status.IsOK()) << "Failed to apply partition. Error: "
                                << status.ErrorMessage();
   }

--- a/orttraining/orttraining/test/distributed/pipeline_partition_test.cc
+++ b/orttraining/orttraining/test/distributed/pipeline_partition_test.cc
@@ -281,7 +281,7 @@ void partitionBackwardGraph(const std::map<std::string, int>& op_id_to_stage,
   }
 }
 
-
+// *Warning*: 
 TEST(PipelinePartitionAfterAD, TwoStages) {
   const std::map<std::string, int> op_id_to_stage = {
     {"T2", 1}, {"T1", 0}, {"T3", 1}, {"T4", 1}, {"T5", 1}, {"T6", 1}, {"T7", 1},

--- a/orttraining/orttraining/test/graph/gradient_graph_builder_test.cc
+++ b/orttraining/orttraining/test/graph/gradient_graph_builder_test.cc
@@ -1161,36 +1161,6 @@ PathString GenerateFileNameWithIndex(const std::string& base_str, int index, con
   return path_utils::MakePathString(base_str, index, file_suffix);
 }
 
-// DistributedRunTestContext provides a method to override existing DistributedRunTestContext instance.
-// This is for test purpose only. Please don't use it for other scenarios.
-class DistributedRunTestContext : public DistributedRunContext
-{
-public:
-    DistributedRunTestContext(const TrainingSession::TrainingConfiguration &config)
-        : DistributedRunContext(config.distributed_config.world_rank,
-                                config.distributed_config.world_size,
-                                config.distributed_config.local_rank,
-                                config.distributed_config.local_size,
-                                config.distributed_config.data_parallel_size,
-                                config.distributed_config.horizontal_parallel_size,
-                                config.distributed_config.pipeline_parallel_size)
-    {
-    }
-
-    // Reset the static DistributedRunContext object with new value.
-    void ResetDistributedRunContext(){
-      DistributedRunContext::GetRunConfig() = params_;
-      auto& dp_group = DistributedRunContext::GetWorkerGroup(WorkerGroupType::DataParallel);
-      dp_group = groups_[WorkerGroupType::DataParallel];
-
-      auto& hp_group = DistributedRunContext::GetWorkerGroup(WorkerGroupType::HorizontalParallel);
-      hp_group = groups_[WorkerGroupType::HorizontalParallel];
-
-      auto& mp_group = DistributedRunContext::GetInstance().GetWorkerGroup(WorkerGroupType::PipelineParallel);
-      mp_group = groups_[WorkerGroupType::PipelineParallel];
-    }
-};
-
 void OverwritePipelineRank(const TrainingSession::TrainingConfiguration& config, const int pipeline_rank) {
   // DistributedRunContext is a static global. Create one if it hasn't been created yet.
   DistributedRunContext::CreateInstance({config.distributed_config.world_rank,


### PR DESCRIPTION
This PR adds an option to partition the graph after AD, but before adding the optimizer nodes. Its motivation is to allow for better automatic partitions.
The partition algorithm is very similar to the one introduced in PR https://github.com/microsoft/onnxruntime/pull/5940.

Code to make this available to the ORTTrainer python API will come in a different PR.

## Assignment constraints
We cannot assign any node to any pipeline stage. There are few constraints that make an assignment valid. We describe them here and implement them in `VerifyAssignment`:

1. Every (pipeline) stage s is assigned at least one operator. 
2. Each operator is assigned to one and only one stage and all operators are assigned to a stage s (the stage id must be within the limits).
3. Given two operators `o1` and `o2`, such that `o1` produces tensor `t`, which is consumed by `o2`. 
     a. If both `o1` and `o2` are forward operators, then we require `stage_of(o1) <= stage_of(o2)`.
     b. If both `o1` and `o2` are backward operators, then we require `stage_of(o1) >= stage_of(o2)`.
     c. If `o1` is a forward operator and `o2` is a backward one, then we require `stage_of(o1) == stage_of(o2)`. This includes two cases: When `t` is the result of some activation function to be used by a backward operator, then we want both operators in the same device, or otherwise we would need extra work for copying `t` to the device of the consumer; and when `t` is an output of the forward computation to be used by the loss function (all these ops should live in the last device). 
4. Let `w` be the name of a parameter/weights tensor which is used by a single layer, and `sw` be the name of a weights tensor shared by multiple layers (e.g., the embedding tensor which are used by the embedding layer and the output classification layer of bert MLM), then we have:
    a. All the consumers of `w` must be assigned to the same stage.
    b. All the backward consumers of `sw` must be in the same stage of the first forward consumer of `sw` (i.e., the embedding layer in our example). 
5. Because we run partition after AD and before adding the optimizer nodes, we need to be careful with the placement of operators that produce tensors used by the optimizer. In particular, we require that for any parameter tensor named `w`, if AD creates an op `o` that generates `w_grad`, then we require `o` and the consumer of `w` to be assigned to the same stage.


## Testing
  * Added a few `PipelinePartitionAfterAD` unit tests with manual partition of small graphs, just to make sure that the partition code runs without problems. Needed to move `DistributedRunTestContext` from GradientGraphBuilderTest to training_session_test_utils.
  * Ideally, we would compare the result of a computation with and without partition. However, I have not found tests for that in ORT, yet. 
  *  I generated many assignment files for bert-tiny to be passed to the `--mapping_file` flag, and for each file, ran: 
```
mpirun -n $N $BUILD_DIR/onnxruntime_training_bert \
  --model_name $BERT_DATA_DIR/bert_models/nv/bert-tiny/bert-tiny-uncased_L_3_H_128_A_2_V_30528_S_512_Dp_0.1_optimized_layer_norm_opset12 \
  --train_data_dir $BERT_DATA_DIR/bert_data/512/books_wiki_en_corpus/train \
  --test_data_dir $BERT_DATA_DIR/bert_data/512/books_wiki_en_corpus/test \
  --train_batch_size 1 --mode train --display_loss_steps 1 --optimizer adam \
  --learning_rate 0.006 --gradient_accumulation_steps 1 --num_train_steps 3 \
  --warmup_ratio 0 --warmup_mode Linear \
  --pipeline_parallel_size $N --mapping_file $assignmentfile --partition_after_ad
```
We used N=[2,3,4]. 
  * Partitioning of forward graphs (as below) should still work.
```
mpirun -n 2 $BUILD_DIR/onnxruntime_training_bert \
  --model_name $BERT_DATA_DIR/bert_models/nv/bert-tiny/bert-tiny-uncased_L_3_H_128_A_2_V_30528_S_512_Dp_0.1_optimized_layer_norm_opset12 \
  --train_data_dir $BERT_DATA_DIR/bert_data/512/books_wiki_en_corpus/train \
  --test_data_dir $BERT_DATA_DIR/bert_data/512/books_wiki_en_corpus/test \
  --train_batch_size 1 --mode train --display_loss_steps 1 --optimizer adam \
  --learning_rate 0.006 --gradient_accumulation_steps 1 --num_train_steps 3 \
  --warmup_ratio 0 --warmup_mode Linear --pipeline_parallel_size 2 --cut_group_info 418
```
  * In order to test PP+DP and PP+HP, we ran the following commands. PP+DP+HP was not tested yet.  
```
mpirun -n 4 $BUILD_DIR/onnxruntime_training_bert \
  --model_name $BERT_DATA_DIR/bert_models/nv/bert-tiny/bert-tiny-uncased_L_3_H_128_A_2_V_30528_S_512_Dp_0.1_optimized_layer_norm_opset12 \
  --train_data_dir $BERT_DATA_DIR/bert_data/512/books_wiki_en_corpus/train \
  --test_data_dir $BERT_DATA_DIR/bert_data/512/books_wiki_en_corpus/test \
  --train_batch_size 1 --mode train --display_loss_steps 1 --optimizer adam \
  --learning_rate 0.006 --gradient_accumulation_steps 1 --num_train_steps 3 \
  --warmup_ratio 0 --warmup_mode Linear \
  --pipeline_parallel_size 2 --mapping_file <assignment file for pp=2> --partition_after_ad \
  --data_parallel_size 2 --use_nccl
```
and

```
mpirun -n 4 $BUILD_DIR/onnxruntime_training_bert \
  --model_name $BERT_DATA_DIR/bert_models/nv/bert-tiny/bert-tiny-uncased_L_3_H_128_A_2_V_30528_S_512_Dp_0.1_optimized_layer_norm_opset12 \
  --train_data_dir $BERT_DATA_DIR/bert_data/512/books_wiki_en_corpus/train \
  --test_data_dir $BERT_DATA_DIR/bert_data/512/books_wiki_en_corpus/test \
  --train_batch_size 1 --mode train --display_loss_steps 1 --optimizer adam \
  --learning_rate 0.006 --gradient_accumulation_steps 1 --num_train_steps 3 \
  --warmup_ratio 0 --warmup_mode Linear \
  --pipeline_parallel_size 2 --mapping_file <assignment file for pp=2> --partition_after_ad \
  --horizontal_parallel_size 2
```

  * I also did some testing with a different optimizer (`[adam|lamb]`) and with gradient accumulation (`--gradient_accumulation_steps 48 --num_train_steps 96`).
```
mpirun -n 4 $BUILD_DIR/onnxruntime_training_bert \
  --model_name $BERT_DATA_DIR/bert_models/bert-tiny/bert-tiny-uncased_L_3_H_128_A_2_V_30528_S_512_Dp_0.1_optimized_layer_norm_opset12 \
  --train_data_dir $BERT_DATA_DIR/bert_data/512/books_wiki_en_corpus/train  \
  --test_data_dir $BERT_DATA_DIR/bert_data/512/books_wiki_en_corpus/test \
  --train_batch_size 1 --mode train --display_loss_steps 1 --optimizer [adam|] \
  --learning_rate 0.006 --gradient_accumulation_steps 48 --num_train_steps 96 \
  --warmup_ratio 0 --warmup_mode Linear --pipeline_parallel_size 4 \
  --mapping_file <assignment file for pp=4> --partition_after_ad
```

All the tests above ran to completion. 

Note: `$BUILD_DIR` above refers to a Release build.

## Current Limitations

* While partitioning bert-large with these changes, we observed that a process was stuck on waiting for another one that went OOM. I'll give a repro instructions for this separately.
* Partition doesn't seem to work when using mixed precision. Currently, we pass as an input to ORT, a mapping between node names (or the names of their produced tensors) and pipeline stage ids. However, when mix precision is enabled, the same node will have different names in different mpi ranks. I believe there is some source of non-determinism in mixed precision code. I'll also provide repro instructions for this separately.

## Performance
We are currently working on performance measurements. **Results will appear here.**
