### PR TITLE
Enable type reduction for Range, ReverseSequence, ScatterND, Split, and Unique CPU kernels.

### DIFF
--- a/onnxruntime/core/providers/cpu/generator/range.cc
+++ b/onnxruntime/core/providers/cpu/generator/range.cc
@@ -1,11 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "range.h"
+#include "core/providers/cpu/generator/range.h"
 
 #include <cmath>
 
+#include "core/providers/op_kernel_type_control.h"
+
 namespace onnxruntime {
+
+namespace op_kernel_type_control {
+ORT_SPECIFY_OP_KERNEL_ARG_DEFAULT_TYPES_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, Range, Input, 0,
+    float, double, int16_t, int32_t, int64_t);
+}
+
+using RangeDataTypes = ORT_OP_KERNEL_ARG_DEFAULT_TYPE_LIST_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, Range, Input, 0);
+using EnabledRangeDataTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, Range, Input, 0);
 
 // Register a kernel for kMsDomain (contrib op) Range
 #ifndef DISABLE_CONTRIB_OPS
@@ -20,11 +33,10 @@ ONNX_OPERATOR_KERNEL_EX(
     kMSDomain,
     1,
     kCpuExecutionProvider,
-    KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
-                                            DataTypeImpl::GetTensorType<double>(),
-                                            DataTypeImpl::GetTensorType<int16_t>(),
-                                            DataTypeImpl::GetTensorType<int32_t>(),
-                                            DataTypeImpl::GetTensorType<int64_t>()}),
+    KernelDefBuilder()
+        .TypeConstraint("T",
+                        BuildKernelDefConstraintsFromTypeList<RangeDataTypes>(),
+                        BuildKernelDefConstraintsFromTypeList<EnabledRangeDataTypes>()),
     Range);
 
 }  // namespace contrib
@@ -34,11 +46,10 @@ ONNX_OPERATOR_KERNEL_EX(
 ONNX_CPU_OPERATOR_KERNEL(
     Range,
     11,
-    KernelDefBuilder().TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
-                                            DataTypeImpl::GetTensorType<double>(),
-                                            DataTypeImpl::GetTensorType<int16_t>(),
-                                            DataTypeImpl::GetTensorType<int32_t>(),
-                                            DataTypeImpl::GetTensorType<int64_t>()}),
+    KernelDefBuilder()
+        .TypeConstraint("T",
+                        BuildKernelDefConstraintsFromTypeList<RangeDataTypes>(),
+                        BuildKernelDefConstraintsFromTypeList<EnabledRangeDataTypes>()),
     Range);
 
 template <typename T>
@@ -95,8 +106,7 @@ struct CallRangeImpl {
 Status Range::Compute(OpKernelContext* ctx) const {
   const auto* input_tensor = ctx->Input<Tensor>(0);
   if (input_tensor == nullptr) return Status(common::ONNXRUNTIME, common::FAIL, "input count mismatch");
-  utils::MLTypeCallDispatcher<int32_t, float, int64_t, double, int16_t>
-      t_disp(input_tensor->GetElementType());
+  utils::MLTypeCallDispatcherFromTypeList<EnabledRangeDataTypes> t_disp(input_tensor->GetElementType());
   return t_disp.InvokeRet<Status, range_internal::CallRangeImpl>(ctx);
 }
 

--- a/onnxruntime/core/providers/cpu/tensor/reverse_sequence.cc
+++ b/onnxruntime/core/providers/cpu/tensor/reverse_sequence.cc
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "reverse_sequence.h"
+#include "core/providers/cpu/tensor/reverse_sequence.h"
 
 // there's no way to use a raw pointer as the copy destination with std::copy_n
 // (which gsl::copy uses with span::data() which returns a raw pointer) with the 14.11 toolset
@@ -17,28 +17,46 @@
 #pragma warning(pop)
 #endif
 
+#include "core/framework/data_types_internal.h"
 #include "core/framework/utils.h"
 #include "core/framework/tensor.h"
 #include "core/framework/tensor_shape.h"
+#include "core/providers/op_kernel_type_control.h"
+#include "core/providers/op_kernel_type_control_utils.h"
 
 namespace onnxruntime {
+
+namespace op_kernel_type_control {
+ORT_SPECIFY_OP_KERNEL_ARG_DEFAULT_TYPES_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, ReverseSequence, Input, 0,
+    ORT_OP_KERNEL_TYPE_CTRL_ALL_TENSOR_DATA_TYPES);
+}
+
+using ReverseSequenceDataTypes = ORT_OP_KERNEL_ARG_DEFAULT_TYPE_LIST_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, ReverseSequence, Input, 0);
+using EnabledReverseSequenceDataTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, ReverseSequence, Input, 0);
 
 ONNX_OPERATOR_KERNEL_EX(ReverseSequence,
                         kOnnxDomain,
                         10,
                         kCpuExecutionProvider,
-                        KernelDefBuilder().TypeConstraint("T", DataTypeImpl::AllTensorTypes()),
+                        KernelDefBuilder()
+                            .TypeConstraint("T",
+                                            BuildKernelDefConstraintsFromTypeList<ReverseSequenceDataTypes>(),
+                                            BuildKernelDefConstraintsFromTypeList<EnabledReverseSequenceDataTypes>()),
                         ReverseSequenceOp);
 
+namespace {
 template <typename T>
-static void ReverseSequenceImpl(const Tensor& X, Tensor& Y, gsl::span<const int64_t> sequence_lengths,
-                                int64_t max_seq_len, int64_t batch_size, int64_t input_size, bool time_major);
+struct ReverseSequenceImplDispatchTarget {
+  void operator()(const Tensor& X, Tensor& Y, gsl::span<const int64_t> sequence_lengths,
+                  int64_t max_seq_len, int64_t batch_size, int64_t input_size, bool time_major) const;
+};
+}  // namespace
 
 Status ReverseSequenceOp::Compute(OpKernelContext* context) const {
-  Status status = Status::OK();
-
   const auto& X = *context->Input<Tensor>(0);
-  const auto data_type = X.DataType();
   const auto& dims = X.Shape();
 
   const auto batch_size = time_major_ ? dims[1] : dims[0];
@@ -55,58 +73,61 @@ Status ReverseSequenceOp::Compute(OpKernelContext* context) const {
 
   auto& Y = *context->Output(0, dims);
 
-  DispatchOnTensorType(data_type, ReverseSequenceImpl, X, Y, seq_lengths.DataAsSpan<int64_t>(),
-                       max_seq_len, batch_size, input_size, time_major_);
+  utils::MLTypeCallDispatcherFromTypeList<EnabledReverseSequenceDataTypes> dispatcher{X.GetElementType()};
+  dispatcher.Invoke<ReverseSequenceImplDispatchTarget>(
+      X, Y, seq_lengths.DataAsSpan<int64_t>(), max_seq_len, batch_size, input_size, time_major_);
 
-  return status;
+  return Status::OK();
 }
 
-static int64_t TimeMajorInputOffset(const int64_t max_seq_len,
-                                    const int64_t batch_size,
-                                    const int64_t input_size,
-                                    const int64_t batch_num,
-                                    const int64_t seq_num) {
+namespace {
+int64_t TimeMajorInputOffset(const int64_t max_seq_len,
+                             const int64_t batch_size,
+                             const int64_t input_size,
+                             const int64_t batch_num,
+                             const int64_t seq_num) {
   ORT_UNUSED_PARAMETER(max_seq_len);
   return seq_num * batch_size * input_size + batch_num * input_size;
 }
 
-static int64_t BatchMajorInputOffset(const int64_t max_seq_len,
-                                     const int64_t batch_size,
-                                     const int64_t input_size,
-                                     const int64_t batch_num,
-                                     const int64_t seq_num) {
+int64_t BatchMajorInputOffset(const int64_t max_seq_len,
+                              const int64_t batch_size,
+                              const int64_t input_size,
+                              const int64_t batch_num,
+                              const int64_t seq_num) {
   ORT_UNUSED_PARAMETER(batch_size);
   return batch_num * max_seq_len * input_size + seq_num * input_size;
 }
 
-static int64_t TimeMajorOutputOffset(const int64_t max_seq_len,
-                                     const int64_t batch_size,
-                                     const int64_t input_size,
-                                     const int64_t batch_num,
-                                     const int64_t seq_num,
-                                     const int64_t seq_len) {
+int64_t TimeMajorOutputOffset(const int64_t max_seq_len,
+                              const int64_t batch_size,
+                              const int64_t input_size,
+                              const int64_t batch_num,
+                              const int64_t seq_num,
+                              const int64_t seq_len) {
   ORT_UNUSED_PARAMETER(max_seq_len);
   return (seq_len - seq_num - 1) * batch_size * input_size + batch_num * input_size;
 }
 
-static int64_t BatchMajorOutputOffset(const int64_t max_seq_len,
-                                      const int64_t batch_size,
-                                      const int64_t input_size,
-                                      const int64_t batch_num,
-                                      const int64_t seq_num,
-                                      const int64_t seq_len) {
+int64_t BatchMajorOutputOffset(const int64_t max_seq_len,
+                               const int64_t batch_size,
+                               const int64_t input_size,
+                               const int64_t batch_num,
+                               const int64_t seq_num,
+                               const int64_t seq_len) {
   ORT_UNUSED_PARAMETER(batch_size);
   return batch_num * max_seq_len * input_size + (seq_len - seq_num - 1) * input_size;
 }
 
 template <typename T>
-static void ReverseSequenceImpl(const Tensor& X,
-                                Tensor& Y,
-                                gsl::span<const int64_t> sequence_lengths,
-                                const int64_t max_seq_len,
-                                const int64_t batch_size,
-                                const int64_t input_size,
-                                bool time_major) {
+void ReverseSequenceImplDispatchTarget<T>::operator()(
+    const Tensor& X,
+    Tensor& Y,
+    gsl::span<const int64_t> sequence_lengths,
+    const int64_t max_seq_len,
+    const int64_t batch_size,
+    const int64_t input_size,
+    bool time_major) const {
   gsl::span<const T> inputs = X.DataAsSpan<T>();
   gsl::span<T> inputs_reverse = Y.MutableDataAsSpan<T>();
 
@@ -139,5 +160,6 @@ static void ReverseSequenceImpl(const Tensor& X,
     }
   }
 }
+}  // namespace
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/tensor/scatter_nd.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter_nd.cc
@@ -1,25 +1,43 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "scatter_nd.h"
+#include "core/providers/cpu/tensor/scatter_nd.h"
+
 #include "core/platform/threadpool.h"
+#include "core/providers/op_kernel_type_control.h"
+#include "core/providers/op_kernel_type_control_utils.h"
 #include "core/providers/cpu/tensor/utils.h"
 
 namespace onnxruntime {
+
+namespace op_kernel_type_control {
+ORT_SPECIFY_OP_KERNEL_ARG_DEFAULT_TYPES_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, ScatterND, Input, 0,
+    ORT_OP_KERNEL_TYPE_CTRL_ALL_TENSOR_DATA_TYPES);
+}
+
+using ScatterNDDataTypes = ORT_OP_KERNEL_ARG_DEFAULT_TYPE_LIST_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, ScatterND, Input, 0);
+using EnabledScatterNDDataTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, ScatterND, Input, 0);
 
 ONNX_CPU_OPERATOR_VERSIONED_KERNEL(
     ScatterND,
     11,
     12,
     KernelDefBuilder()
-        .TypeConstraint("T", DataTypeImpl::AllTensorTypes()),
+        .TypeConstraint("T",
+                        BuildKernelDefConstraintsFromTypeList<ScatterNDDataTypes>(),
+                        BuildKernelDefConstraintsFromTypeList<EnabledScatterNDDataTypes>()),
     ScatterND);
 
 ONNX_CPU_OPERATOR_KERNEL(
     ScatterND,
     13,
     KernelDefBuilder()
-        .TypeConstraint("T", DataTypeImpl::AllTensorTypes()),
+        .TypeConstraint("T",
+                        BuildKernelDefConstraintsFromTypeList<ScatterNDDataTypes>(),
+                        BuildKernelDefConstraintsFromTypeList<EnabledScatterNDDataTypes>()),
     ScatterND);
 
 Status ScatterNDBase::ValidateShapes(const TensorShape& input_shape,
@@ -148,6 +166,15 @@ Status ScatterND::Compute(OpKernelContext* context) const {
 }
 
 Status ScatterND::ScatterNumber(const Prepare& p, concurrency::ThreadPool* tp) const {
+  constexpr bool has_non_string_enabled_type =
+      !boost::mp11::mp_empty<
+          boost::mp11::mp_remove<
+              EnabledScatterNDDataTypes,
+              std::string>>::value;
+  if (!has_non_string_enabled_type) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Non-string data types are not supported in this build.");
+  }
+
   auto lambda = [&](int64_t i) {
     memcpy(p.output_base + p.element_offsets[i] * p.element_bytes,
            p.input_base + i * p.bytes_to_copy,
@@ -163,6 +190,10 @@ Status ScatterND::ScatterNumber(const Prepare& p, concurrency::ThreadPool* tp) c
 }
 
 Status ScatterND::ScatterString(const Prepare& p, concurrency::ThreadPool* tp) const {
+  if (!utils::HasType<EnabledScatterNDDataTypes, std::string>()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "String data type is not supported in this build.");
+  }
+
   auto lambda = [&](int64_t i) {
     for (int64_t j = 0; j < static_cast<int64_t>(p.element_to_copy); ++j) {
       p.output_str_base[p.element_offsets[i] + j] = p.input_str_base[i * p.element_to_copy + j];

--- a/onnxruntime/core/providers/cpu/tensor/split.cc
+++ b/onnxruntime/core/providers/cpu/tensor/split.cc
@@ -96,6 +96,7 @@ Status Split::Compute(OpKernelContext* context) const {
 
   Status status;
 
+  // Note: The non-string implementations can probably be based on data type size.
   if (input.IsDataType<float>())
     status = ComputeImpl<float>(*context, input);
   else if (input.IsDataType<int32_t>())

--- a/onnxruntime/core/providers/cpu/tensor/split.cc
+++ b/onnxruntime/core/providers/cpu/tensor/split.cc
@@ -2,25 +2,35 @@
 // Licensed under the MIT License.
 
 #include "core/providers/cpu/tensor/split.h"
-#include "core/providers/common.h"
-#include "core/util/math.h"
-#include "core/util/math_cpuonly.h"
 
 #include "gsl/gsl"
 
+#include "core/providers/common.h"
+#include "core/providers/op_kernel_type_control.h"
+#include "core/providers/op_kernel_type_control_utils.h"
+#include "core/util/math.h"
+#include "core/util/math_cpuonly.h"
+
 namespace onnxruntime {
+
+namespace op_kernel_type_control {
+ORT_SPECIFY_OP_KERNEL_ARG_DEFAULT_TYPES_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, Split, Input, 0,
+    float, int32_t, int64_t, uint8_t, std::string);
+}
+
+using SplitDataTypes = ORT_OP_KERNEL_ARG_DEFAULT_TYPE_LIST_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, Split, Input, 0);
+using EnabledSplitDataTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, Split, Input, 0);
 
 ONNX_CPU_OPERATOR_VERSIONED_KERNEL(
     Split,
     2,
     10,
     KernelDefBuilder().TypeConstraint("T",
-                                      std::vector<MLDataType>{
-                                          DataTypeImpl::GetTensorType<float>(),
-                                          DataTypeImpl::GetTensorType<int32_t>(),
-                                          DataTypeImpl::GetTensorType<int64_t>(),
-                                          DataTypeImpl::GetTensorType<uint8_t>(),
-                                          DataTypeImpl::GetTensorType<std::string>()}),
+                                      BuildKernelDefConstraintsFromTypeList<SplitDataTypes>(),
+                                      BuildKernelDefConstraintsFromTypeList<EnabledSplitDataTypes>()),
     Split);
 
 // Opset 11 starts to support Neg Axis.
@@ -29,12 +39,8 @@ ONNX_CPU_OPERATOR_VERSIONED_KERNEL(
     11,
     12,
     KernelDefBuilder().TypeConstraint("T",
-                                      std::vector<MLDataType>{
-                                          DataTypeImpl::GetTensorType<float>(),
-                                          DataTypeImpl::GetTensorType<int32_t>(),
-                                          DataTypeImpl::GetTensorType<int64_t>(),
-                                          DataTypeImpl::GetTensorType<uint8_t>(),
-                                          DataTypeImpl::GetTensorType<std::string>()}),
+                                      BuildKernelDefConstraintsFromTypeList<SplitDataTypes>(),
+                                      BuildKernelDefConstraintsFromTypeList<EnabledSplitDataTypes>()),
     Split);
 
 // Opset 13 starts to supports 'split' as optional input.
@@ -42,12 +48,8 @@ ONNX_CPU_OPERATOR_KERNEL(
     Split,
     13,
     KernelDefBuilder().TypeConstraint("T",
-                                      std::vector<MLDataType>{
-                                          DataTypeImpl::GetTensorType<float>(),
-                                          DataTypeImpl::GetTensorType<int32_t>(),
-                                          DataTypeImpl::GetTensorType<int64_t>(),
-                                          DataTypeImpl::GetTensorType<uint8_t>(),
-                                          DataTypeImpl::GetTensorType<std::string>()}),
+                                      BuildKernelDefConstraintsFromTypeList<SplitDataTypes>(),
+                                      BuildKernelDefConstraintsFromTypeList<EnabledSplitDataTypes>()),
     Split);
 
 Status SplitBase::PrepareForCompute(const TensorShape& input_shape, int num_outputs, int64_t& axis, int& before_dims,
@@ -123,6 +125,10 @@ inline void copy_data<std::string>(const std::string* src, std::string* dst, siz
 
 template <typename T>
 Status Split::ComputeImpl(OpKernelContext& context, const Tensor& input) const {
+  if (!utils::HasType<EnabledSplitDataTypes, T>()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Data type is not supported in this build.");
+  }
+
   auto& input_shape = input.Shape();
   auto num_outputs = context.OutputCount();
   int64_t axis = axis_;

--- a/onnxruntime/core/providers/cpu/tensor/unique.cc
+++ b/onnxruntime/core/providers/cpu/tensor/unique.cc
@@ -93,6 +93,7 @@ Status Unique::Compute(OpKernelContext* context) const {
 
   Status status;
   // arbitrary set of types to support initially
+  // Note: The non-string implementations can probably be based on data type size.
   if (input.IsDataType<float>())
     status = ComputeImpl<float>(*context);
   else if (input.IsDataType<int64_t>())


### PR DESCRIPTION
**Description**
Enable type reduction for Range, ReverseSequence, ScatterND, Split, and Unique CPU kernels.

**Motivation and Context**
Enable binary size reduction by excluding implementations for specific types.
