### PR TITLE
[NNAPI EP] Possible fd leak in NNAPI NNMemory

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/model.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/model.cc
@@ -130,7 +130,7 @@ Model::NNMemory::~NNMemory() {
     munmap(data_ptr_, byte_size_);
   }
 
-  if (fd_ > 0) close(fd_);
+  if (fd_ >= 0) close(fd_);
 }
 #else
 Model::NNMemory::NNMemory(const NnApi* /*nnapi*/, const char* name, size_t size) {

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/model.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/model.h
@@ -36,7 +36,7 @@ class Model {
    private:
     // NnApi instance to use. Not owned by this object.
     const NnApi* nnapi_{nullptr};
-    int fd_{0};
+    int fd_{-1};
     size_t byte_size_{0};
     uint8_t* data_ptr_{nullptr};
     ANeuralNetworksMemory* nn_memory_handle_{nullptr};


### PR DESCRIPTION
**Description**: Possible fd leak in NNAPI NNMemory

**Motivation and Context**
- In theory, valid fd values are non-negative, including zero.
- See this change in TFlite's NNAPI delegate, https://github.com/tensorflow/tensorflow/commit/46ff46bd09ac3be89d093b176399076b4142c8d8
