### PR TITLE
Reduce logging for ORTModule for the end user

### DIFF
--- a/onnxruntime/core/framework/fallback_cpu_capability.cc
+++ b/onnxruntime/core/framework/fallback_cpu_capability.cc
@@ -132,7 +132,7 @@ std::unordered_set<NodeIndex> GetCpuPreferredNodes(const onnxruntime::GraphViewe
 
     if (place_in_cpu) {
       cpu_nodes.insert(cur);
-      LOGS_DEFAULT(WARNING) << "Force fallback to CPU execution for node: " << node->Name();
+      LOGS_DEFAULT(INFO) << "Force fallback to CPU execution for node: " << node->Name();
       for (auto* output : node->OutputDefs()) {
         cpu_output_args.insert(output);
       }

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -1988,7 +1988,7 @@ CUDAExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
 
     // none of the provided registries has a CUDA kernel for this node
     if (cuda_kernel_def == nullptr) {
-      LOGS_DEFAULT(WARNING) << "CUDA kernel not found in registries for Op type: " << node.OpType() << " node name: " << node.Name();
+      LOGS_DEFAULT(INFO) << "CUDA kernel not found in registries for Op type: " << node.OpType() << " node name: " << node.Name();
       continue;
     }
 

--- a/orttraining/orttraining/core/agent/training_agent.cc
+++ b/orttraining/orttraining/core/agent/training_agent.cc
@@ -115,7 +115,7 @@ common::Status TrainingAgent::RunBackward(int64_t run_id, const std::vector<OrtV
 }
 
 void TrainingAgent::CancelPendingBackwardRun(int64_t run_id) {
-  LOGS(*inference_session_->GetLogger(), WARNING) << "Canceling background task with run_id " << run_id;
+  LOGS(*inference_session_->GetLogger(), INFO) << "Canceling background task with run_id " << run_id;
 
   // resume background thread with terminate = true
   onnxruntime::contrib::OrtTasks::GetInstance().SetBackwardInputs(run_id, {}, true);

--- a/orttraining/orttraining/core/framework/gradient_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.cc
@@ -105,8 +105,8 @@ NodeSet GradientGraphBuilder::ReverseBFS(const NodeSet& nodes) const {
     for (auto edge_it = n->InputEdgesBegin(); edge_it != n->InputEdgesEnd(); ++edge_it) {
       auto it = STOP_GRADIENT_EDGES.find(n->OpType());
       if (it != STOP_GRADIENT_EDGES.end() && it->second.count(edge_it->GetDstArgIndex())) {
-        LOGS(logger_, WARNING) << "Skip building gradient for input_" << edge_it->GetDstArgIndex()
-                               << " of node: " << n->Name();
+        LOGS(logger_, INFO) << "Skip building gradient for input_" << edge_it->GetDstArgIndex()
+                            << " of node: " << n->Name();
         continue;
       }
 

--- a/orttraining/orttraining/core/graph/gradient_builder_base.cc
+++ b/orttraining/orttraining/core/graph/gradient_builder_base.cc
@@ -59,7 +59,7 @@ void ComputeBroadcastBackwardAxes(
       auto A_dim = A_dims[i].dim_param(),
            B_dim = B_dims[j].dim_param();
       if (A_dim != B_dim) {
-        LOGS_DEFAULT(WARNING) << "Gradient building for node " << node_name << ": symbolic dimension expects to match. " <<
+        LOGS_DEFAULT(INFO) << "Gradient building for node " << node_name << ": symbolic dimension expects to match. " <<
                   "A_dims:" << ToString(A_dims) << ", B_dims:" << ToString(B_dims) <<   
                   " This is a relaxing case, and the kernel might run into problem later if A_dims and B_dims turns out not broadcastable.";
       }
@@ -68,7 +68,7 @@ void ComputeBroadcastBackwardAxes(
       auto B_dim = B_dims[j].dim_value();
 
       if (B_dim != 1) {
-        LOGS_DEFAULT(WARNING) << "Gradient building for node " << node_name << ": symbolic broadcasting expects the B_dimension to be 1. " <<
+        LOGS_DEFAULT(INFO) << "Gradient building for node " << node_name << ": symbolic broadcasting expects the B_dimension to be 1. " <<
                   "A_dims:" << ToString(A_dims) << ", B_dims:" << ToString(B_dims) <<   
                   " This is a relaxing case, and the kernel might run into problem later if A_dims and B_dims turns out not broadcastable.";   
       } else {
@@ -81,7 +81,7 @@ void ComputeBroadcastBackwardAxes(
       auto B_dim = B_dims[j].dim_param();
 
       if (A_dim != 1) {
-        LOGS_DEFAULT(WARNING) << "Gradient building for node " << node_name << ": symbolic broadcasting expects the A_dimension to be 1. " <<
+        LOGS_DEFAULT(INFO) << "Gradient building for node " << node_name << ": symbolic broadcasting expects the A_dimension to be 1. " <<
                   "A_dims:" << ToString(A_dims) << ", B_dims:" << ToString(B_dims) <<   
                   " This is a relaxing case, and the kernel might run into problem later if A_dims and B_dims turns out not broadcastable.";
       } else {

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -506,9 +506,9 @@ py::class_<TrainingAgent>(m, "TrainingAgent", R"pbdoc(This is the main class use
       .def_readwrite("use_invertible_layernorm_grad",
                      &ModuleGradientGraphBuilderConfiguration::use_invertible_layernorm_grad);
 
-  py::class_<TrainingGraphInfo> split_graphs_info(m, "TrainingGraphInfo",
+  py::class_<TrainingGraphInfo> training_graph_info(m, "TrainingGraphInfo",
                                                 R"pbdoc(The information of split graphs for frontend.)pbdoc");
-  split_graphs_info.def(py::init())
+  training_graph_info.def(py::init())
       .def_readwrite("user_input_names", &TrainingGraphInfo::user_input_names)
       .def_readwrite("user_input_grad_names", &TrainingGraphInfo::user_input_grad_names)
       .def_readwrite("initializer_names_to_train", &TrainingGraphInfo::initializer_names_to_train)

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -6,6 +6,7 @@ import onnxruntime
 import torch
 import inspect
 from inspect import signature
+from enum import IntEnum
 
 from torch.utils.dlpack import from_dlpack, to_dlpack
 from torch.utils.cpp_extension import load_inline
@@ -20,6 +21,13 @@ from . import _utils, _ortmodule_output_transformation
 
 
 ONNX_OPSET_VERSION = 12
+
+class Verbosity(IntEnum):
+    VERBOSE = 0
+    INFO = 1
+    WARNING = 2
+    ERROR = 3
+    FATAL = 4
 
 def _create_iobinding(io_binding, inputs, model, device):
     '''Creates IO binding for a `model` inputs and output'''
@@ -58,7 +66,7 @@ def _ort_output_to_torch_tensor(ort_output):
     tensor = from_dlpack(ort_output.to_dlpack())
     return tensor.to(torch.bool) if tensor.dtype == torch.uint8 else tensor
 
-def _load_torch_allocator_cpp_extension():
+def _load_torch_allocator_cpp_extension(verbosity):
     torch_cuda_allocator_addresses_cpp_source = """
     #include <torch/extension.h>
     #include <c10/cuda/CUDACachingAllocator.h>
@@ -72,11 +80,11 @@ def _load_torch_allocator_cpp_extension():
 
     return load_inline(name='inline_extension', cpp_sources=[torch_cuda_allocator_addresses_cpp_source],
                         functions=['cuda_caching_allocator_raw_alloc_address', 'cuda_caching_allocator_raw_delete_address'],
-                        verbose=True, with_cuda=True)
+                        verbose=verbosity < Verbosity.WARNING, with_cuda=True)
 
 class ORTModule(torch.nn.Module):
 
-    def __init__(self, module):
+    def __init__(self, module, verbosity = Verbosity.WARNING):
         assert isinstance(module, torch.nn.Module), "'module' must be a torch.nn.Module"
 
         # Create forward dynamically, so each ORTModule instance will have its own copy.
@@ -219,6 +227,9 @@ class ORTModule(torch.nn.Module):
 
         super(ORTModule, self).__init__()
 
+        # Verbosity for logging
+        self._verbosity = verbosity
+
         # Support contrib OPs
         register_custom_ops_pytorch_exporter.register_custom_op()
 
@@ -269,14 +280,14 @@ class ORTModule(torch.nn.Module):
         # Disable external allocator for ROCM EP since external allocator is not supported yet.
         self._use_external_cuda_allocator = (False if self.is_rocm_pytorch else True)
         if self._use_external_cuda_allocator:
-            self._torch_cuda_allocator = _load_torch_allocator_cpp_extension()
+            self._torch_cuda_allocator = _load_torch_allocator_cpp_extension(self._verbosity)
             self._torch_alloc = self._torch_cuda_allocator.cuda_caching_allocator_raw_alloc_address()
             self._torch_free = self._torch_cuda_allocator.cuda_caching_allocator_raw_delete_address()
 
     def _initialize_module_gradient_graph_builder(self):
         # TODO: PyTorch exporter bug: changes the initializer order in ONNX model
         initializer_names = [p[0] for p in self._flattened_output_module.named_parameters()]
-        onnx_initializer_names = [p.name for p in self._onnx_inference.graph.initializer]
+        onnx_initializer_names = {p.name for p in self._onnx_inference.graph.initializer}
         initializer_names = [p for p in initializer_names if p in onnx_initializer_names]
 
         # Build full training graph
@@ -315,7 +326,7 @@ class ORTModule(torch.nn.Module):
         # default to PRIORITY_BASED execution order
         session_options.execution_order = onnxruntime.ExecutionOrder.PRIORITY_BASED
         # 0:Verbose, 1:Info, 2:Warning. 3:Error, 4:Fatal. Default is 2.
-        session_options.log_severity_level = 2
+        session_options.log_severity_level = int(self._verbosity)
 
         self._training_session = onnxruntime.training.TrainingAgent(self._onnx_training.SerializeToString(),
                                                                     session_options, providers, provider_options)

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -84,7 +84,7 @@ def _load_torch_allocator_cpp_extension(verbosity):
 
 class ORTModule(torch.nn.Module):
 
-    def __init__(self, module, verbosity = Verbosity.WARNING):
+    def __init__(self, module):
         assert isinstance(module, torch.nn.Module), "'module' must be a torch.nn.Module"
 
         # Create forward dynamically, so each ORTModule instance will have its own copy.
@@ -228,7 +228,7 @@ class ORTModule(torch.nn.Module):
         super(ORTModule, self).__init__()
 
         # Verbosity for logging
-        self._verbosity = verbosity
+        self._verbosity = Verbosity.WARNING
 
         # Support contrib OPs
         register_custom_ops_pytorch_exporter.register_custom_op()
@@ -421,7 +421,8 @@ class ORTModule(torch.nn.Module):
                                 opset_version=ONNX_OPSET_VERSION,
                                 do_constant_folding=False,
                                 training=torch.onnx.TrainingMode.TRAINING,
-                                dynamic_axes=dynamic_axes)
+                                dynamic_axes=dynamic_axes,
+                                verbose=self._verbosity < Verbosity.WARNING)
         except RuntimeError as e:
             raise RuntimeError('There was an error while exporting the PyTorch model to ONNX: {}'.format(e))
 


### PR DESCRIPTION
**Description**: ORTModule prints many log lines to std out which are not relevant to the end user. Included a verbosity enum in ORTModule that can increase/decrease the log level.
In addition, lowered some log lines from WARNING to INFO.