### PR TITLE
Resolve HTTP Error 503: Service Unavailable for MNIST dataset

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
+++ b/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
@@ -257,6 +257,15 @@ class MNISTWrapper():
         opener.addheaders = [('User-agent', 'Mozilla/5.0')]
         urllib.request.install_opener(opener)
 
+        # TODO: Remove this temporary fix when the issue https://github.com/pytorch/vision/issues/3549 is resolved
+        # Resource http://yann.lecun.com/exdb/mnist/ is not available
+        datasets.MNIST.resources = [
+            ('https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz', 'f68b3c2dcbeaaa9fbdd348bbdeb94873'),
+            ('https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz', 'd53e105ee54ea40749a09fcbcd1e9432'),
+            ('https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz', '9fb629c4189551a2d022fa330f9573f3'),
+            ('https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz', 'ec29112dd5afa0611ce80d1b7f02629c')
+        ]
+
         args_batch_size = 64
         args_test_batch_size = 1000
 


### PR DESCRIPTION
The url http://yann.lecun.com/exdb/mnist/ is not available at this time. Temporary solution to retrieve the MNIST dataset from the other mirror in ```torchvision```: https://github.com/pytorch/vision/blob/master/torchvision/datasets/mnist.py#L37: 'https://ossci-datasets.s3.amazonaws.com/mnist/' for the time being.