### PR TITLE
Support a CPU kernel for Celu

### DIFF
--- a/onnxruntime/core/providers/cpu/activation/activations.cc
+++ b/onnxruntime/core/providers/cpu/activation/activations.cc
@@ -56,6 +56,7 @@ REGISTER_UNARY_ELEMENTWISE_KERNEL(Softplus, 1);
 REGISTER_UNARY_ELEMENTWISE_KERNEL(Softsign, 1);
 REGISTER_VERSIONED_UNARY_ELEMENTWISE_TYPED_KERNEL(Tanh, 6, 12, float);
 REGISTER_VERSIONED_UNARY_ELEMENTWISE_TYPED_KERNEL(Tanh, 6, 12, double);
+REGISTER_UNARY_ELEMENTWISE_KERNEL(Celu, 12);
 REGISTER_UNARY_ELEMENTWISE_TYPED_KERNEL(Tanh, 13, float);
 REGISTER_UNARY_ELEMENTWISE_TYPED_KERNEL(Tanh, 13, double);
 REGISTER_UNARY_ELEMENTWISE_KERNEL(ThresholdedRelu, 10);
@@ -64,6 +65,7 @@ namespace functors {
 template <typename T>
 Status ElementWiseRangedTransform<T>::Create(const std::string& type, const NodeAttributes& attributes,
                                              std::unique_ptr<ElementWiseRangedTransform<T>>& out) {
+  CREATE_ELE_KERNEL(Celu);
   CREATE_ELE_KERNEL(Elu);
   CREATE_ELE_KERNEL(HardSigmoid);
   CREATE_ELE_KERNEL(LeakyRelu);

--- a/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
+++ b/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
@@ -465,6 +465,7 @@ class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOn
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 12, 12, float_double, Dropout);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 12, 12, double_float, Dropout);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 12, 12, double_double, Dropout);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 12, Celu);
 
 // opset 13
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, float, Erf);
@@ -1093,7 +1094,7 @@ Status RegisterOnnxOperatorKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 9, 10,
                                                                       Flatten)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 9, 10,
-                                                                      float, Gemm)>,
+                                                                            float, Gemm)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 9, 10,
                                                                             double, Gemm)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 9, 12, float,
@@ -1427,6 +1428,7 @@ Status RegisterOnnxOperatorKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 12, 12, float_double, Dropout)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 12, 12, double_float, Dropout)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 12, 12, double_double, Dropout)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 12, Celu)>,
 
       // opset 13
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, Cast)>,

--- a/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
+++ b/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
@@ -66,7 +66,7 @@ TEST_F(ActivationOpTest, Celu) {
   TestActivationOp<float>(
       "Celu",
       input_values,
-      [alpha](float x) { return std::max(0.0f, x) + std::min(0.0f, alpha * (exp(x) - 1)); },
+      [alpha](float x) { return std::max(0.0f, x) + std::min(0.0f, alpha * (static_cast<float>(exp(x)) - 1)); },
       {{"alpha", alpha}}, true, 12);
 }
 TEST_F(ActivationOpTest, LeakyRelu) {

--- a/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
+++ b/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
@@ -66,7 +66,7 @@ TEST_F(ActivationOpTest, Celu) {
   TestActivationOp<float>(
       "Celu",
       input_values,
-      [alpha](float x) { return std::max(0.0f, x) + std::min(0.0f, alpha * (static_cast<float>(exp(x)) - 1)); },
+      [alpha](float x) { return std::max(0.0f, x) + std::min(0.0f, alpha * (static_cast<float>(exp(x / alpha)) - 1)); },
       {{"alpha", alpha}}, true, 12);
 }
 TEST_F(ActivationOpTest, LeakyRelu) {

--- a/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
+++ b/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
@@ -66,7 +66,7 @@ TEST_F(ActivationOpTest, Celu) {
   TestActivationOp<float>(
       "Celu",
       input_values,
-      [alpha](float x) { return std::max(0.f, x) + std::min(0.f, alpha * (exp(x / alpha) - 1)); },
+      [alpha](float x) { return std::max(0.0f, x) + std::min(0.0f, alpha * (exp(x / alpha) - 1)); },
       {{"alpha", alpha}}, true, 12);
 }
 TEST_F(ActivationOpTest, LeakyRelu) {

--- a/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
+++ b/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
@@ -66,7 +66,7 @@ TEST_F(ActivationOpTest, Celu) {
   TestActivationOp<float>(
       "Celu",
       input_values,
-      [alpha](float x) { return std::max(0.0f, x) + std::min(0.0f, alpha * (exp(static_cast<float>(x / alpha)) - 1)); },
+      [alpha](float x) { return std::max(0.0f, x) + std::min(0.0f, alpha); },
       {{"alpha", alpha}}, true, 12);
 }
 TEST_F(ActivationOpTest, LeakyRelu) {

--- a/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
+++ b/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
@@ -66,7 +66,7 @@ TEST_F(ActivationOpTest, Celu) {
   TestActivationOp<float>(
       "Celu",
       input_values,
-      [alpha](float x) { return std::max(0.0f, x) + std::min(0.0f, alpha); },
+      [alpha](float x) { return std::max(0.0f, x) + std::min(0.0f, alpha * (exp(x) - 1)); },
       {{"alpha", alpha}}, true, 12);
 }
 TEST_F(ActivationOpTest, LeakyRelu) {

--- a/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
+++ b/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
@@ -61,6 +61,14 @@ TEST_F(ActivationOpTest, Elu) {
                           {{"alpha", alpha}});
 }
 
+TEST_F(ActivationOpTest, Celu) {
+  float alpha = -0.5f;
+  TestActivationOp<float>(
+      "Celu",
+      input_values,
+      [alpha](float x) { return std::max(0.f, x) + std::min(0.f, alpha * (exp(x / alpha) - 1)); },
+      {{"alpha", alpha}}, true, 12);
+}
 TEST_F(ActivationOpTest, LeakyRelu) {
   float alpha = 0.1f;
   TestActivationOp<float>("LeakyRelu",

--- a/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
+++ b/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
@@ -66,7 +66,7 @@ TEST_F(ActivationOpTest, Celu) {
   TestActivationOp<float>(
       "Celu",
       input_values,
-      [alpha](float x) { return std::max(0.0f, x) + std::min(0.0f, alpha * (exp(x / alpha) - 1)); },
+      [alpha](float x) { return std::max(0.0f, x) + std::min(0.0f, alpha * (exp(static_cast<float>(x / alpha)) - 1)); },
       {{"alpha", alpha}}, true, 12);
 }
 TEST_F(ActivationOpTest, LeakyRelu) {

--- a/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
+++ b/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
@@ -66,8 +66,10 @@ TEST_F(ActivationOpTest, Celu) {
   TestActivationOp<float>(
       "Celu",
       input_values,
+      // TODO: Investigate why gcc 4 fails to compile without the explicit cast
       [alpha](float x) { return std::max(0.0f, x) + std::min(0.0f, alpha * (static_cast<float>(exp(x / alpha)) - 1)); },
-      {{"alpha", alpha}}, true, 12);
+      // Disable on TensorRT as it seems like it doesn't yet support Celu
+      {{"alpha", alpha}}, false, 12);
 }
 TEST_F(ActivationOpTest, LeakyRelu) {
   float alpha = 0.1f;


### PR DESCRIPTION
**Description**: Celu in ONNX is a function based op and it seems like it is incorrectly composed and given that ORT doesn't have a kernel for Celu, users get incorrect results from models that contain them because it has to use the incoorectly composed subgraph for Celu. This change adds a CPU kernel given that that is the only way users can now get right results and in any case, it is better to have a kernel (atleast for the default provider) for function based ONNX ops  for perf reasons.  In future, we may support other EPs on a need-basis.


**Motivation and Context**
Resolve https://github.com/microsoft/onnxruntime/issues/6906

Bug report in ONNX: https://github.com/onnx/onnx/issues/3323
