### PR TITLE
Support none types in forward output

### DIFF
--- a/orttraining/orttraining/python/training/_ortmodule_output_transformation.py
+++ b/orttraining/orttraining/python/training/_ortmodule_output_transformation.py
@@ -29,7 +29,9 @@ def populate_user_output_from_schema_and_outputs(output_schema, output_names, ou
         # Recursively traverse across user_output and replace all _TensorStub
         # with torch.Tensor values from outputs following output_idx
 
-        if isinstance(user_output, _TensorStub):
+        if user_output is None:
+            return None
+        elif isinstance(user_output, _TensorStub):
             output_idx[0] += 1
             return outputs[output_idx[0]-1]
 
@@ -65,8 +67,10 @@ def populate_user_output_from_schema_and_outputs(output_schema, output_names, ou
 def _extract_output_schema(output):
     """Extract the output schema by replacing every torch.Tensor value with _TensorStub"""
 
+    if output is None:
+        return None
     # Depth first traversal to iterate over the output to replace every tensor with a stub
-    if isinstance(output, torch.Tensor):
+    elif isinstance(output, torch.Tensor):
         return _TensorStub()
 
     if isinstance(output, abc.Sequence):
@@ -94,7 +98,9 @@ def _parse_outputs_and_extract_names_and_dynamic_axes(module_output):
     def _populate_output_names_and_dynamic_axes(output, output_names, output_dynamic_axes, output_idx):
         # Depth first traversal to traverse through the entire output collecting output names and dynamic axes
 
-        if isinstance(output, torch.Tensor):
+        if output is None:
+            return
+        elif isinstance(output, torch.Tensor):
             output_name = f'output{output_idx[0]}'
             output_idx[0] += 1
             output_names.append(output_name)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -1286,3 +1286,25 @@ def test_forward_data_and_model_on_different_devices(data_device, model_device):
     with pytest.raises(RuntimeError) as runtime_error:
         ort_model(x)
     assert f"Input argument to forward found on device {torch.device(x.device)}, but expected it to be on module device {ort_model._device}." in str(runtime_error.value)
+
+def test_forward_returns_none_type_as_output():
+    class NeuralNetNoneTypeOutput(torch.nn.Module):
+        def __init__(self, input_size, num_classes):
+            super(NeuralNetNoneTypeOutput, self).__init__()
+
+            self.fc1 = torch.nn.Linear(input_size, num_classes)
+            self.relu1 = torch.nn.ReLU()
+
+        def forward(self, input1):
+            out1 = self.fc1(input1)
+            out1 = self.relu1(out1)
+            return {'out': out1, 'none_output': None}
+
+    device = 'cuda'
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = NeuralNetNoneTypeOutput(D_in, D_out).to(device)
+    x = torch.randn(N, D_in, device=device)
+    output = model(x)
+
+    assert output['out'] is not None
+    assert output['none_output'] is None


### PR DESCRIPTION
**Description**:
```ORTModule``` currently checks for any output type that is not a nested mapping, nested sequence or a ```torch.Tensor```. Because of this, if a pytorch model outputs a ```None``` type, ```ORTModule``` raises an exception although exporting such a model should not lead to any errors (the onnx graph output will not contain any of those ```None``` type arguments after export).

This pull request addresses this by handling ```None``` types while parsing through the pytorch output, building the ouput schema and populating the user outputs.