### PR TITLE
Support larger hidden size in Attention Cuda kernel

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/attention.cc
@@ -154,6 +154,19 @@ Status AttentionBase::CheckInputs(const TensorShape& input_shape,
   return Status::OK();
 }
 
+Status AttentionBase::CheckInputs(const TensorShape& input_shape,
+                                  const TensorShape& weights_shape,
+                                  const TensorShape& bias_shape,
+                                  const Tensor*& mask_index,
+                                  const Tensor* past,
+                                  const int max_threads_per_block) const {
+  if (num_heads_ > max_threads_per_block) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "num_heads should be no large than ", max_threads_per_block);
+  }
+
+  return CheckInputs(input_shape, weights_shape, bias_shape, mask_index, past);
+}
+
 Tensor* AttentionBase::GetPresent(OpKernelContext* context,
                                   const Tensor* past,
                                   int batch_size,

--- a/onnxruntime/contrib_ops/cpu/bert/attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/attention.cc
@@ -161,7 +161,7 @@ Status AttentionBase::CheckInputs(const TensorShape& input_shape,
                                   const Tensor* past,
                                   const int max_threads_per_block) const {
   if (num_heads_ > max_threads_per_block) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "num_heads should be no large than ", max_threads_per_block);
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "num_heads should be no larger than ", max_threads_per_block);
   }
 
   return CheckInputs(input_shape, weights_shape, bias_shape, mask_index, past);

--- a/onnxruntime/contrib_ops/cpu/bert/attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_base.h
@@ -19,6 +19,14 @@ class AttentionBase {
                      const Tensor*& mask_index,  // For dummy mask with shape (1, 1) or (batch_size, 1), it will be updated to nullptr.
                      const Tensor* past) const;
 
+  // This check function is specifically used in cuda
+  Status CheckInputs(const TensorShape& input_shape,
+                     const TensorShape& weights_shape,
+                     const TensorShape& bias_shape,
+                     const Tensor*& mask_index,  // For dummy mask with shape (1, 1) or (batch_size, 1), it will be updated to nullptr.
+                     const Tensor* past,
+                     const int max_threads_per_block) const;
+
   Tensor* GetPresent(OpKernelContext* context,
                      const Tensor* past,
                      int batch_size,

--- a/onnxruntime/contrib_ops/cuda/bert/attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/attention.cc
@@ -39,7 +39,9 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
   const Tensor* bias = context->Input<Tensor>(2);
   const Tensor* mask_index = context->Input<Tensor>(3);
   const Tensor* past = context->Input<Tensor>(4);
-  ORT_RETURN_IF_ERROR(CheckInputs(input->Shape(), weights->Shape(), bias->Shape(), mask_index, past));
+
+  auto& device_prop = GetDeviceProp();
+  ORT_RETURN_IF_ERROR(CheckInputs(input->Shape(), weights->Shape(), bias->Shape(), mask_index, past, device_prop.maxThreadsPerBlock));
 
   // input shape (batch_size, sequence_length, input_hidden_size)
   const auto& shape = input->Shape();
@@ -52,7 +54,7 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
   int hidden_size = static_cast<int>(bias_shape[0]) / 3;
 
   int head_size = hidden_size / num_heads_;
- 
+
   std::vector<int64_t> output_shape(3);
   output_shape[0] = shape[0];
   output_shape[1] = shape[1];
@@ -77,7 +79,6 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
 
   // Bias shape is (N), broadcast using B(N, M) = 1 * bias(N, 1) x ones(1, M) + 0 * B.
   // TODO: use custom kernel of expand to improve the performance.
-  auto& device_prop = GetDeviceProp();
   CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(
       cublas, CUBLAS_OP_N, CUBLAS_OP_N, n, m, 1, &one,
       reinterpret_cast<const CudaT*>(bias->template Data<T>()), n,

--- a/onnxruntime/contrib_ops/cuda/bert/attention_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_impl.h
@@ -58,19 +58,19 @@ cublasStatus_t inline CublasGemmStridedBatched(
 
 bool LaunchTransCtx(cudaStream_t stream,
                     const int sequence_length, const int batch_size, const int head_size, const int num_heads,
-                    const float* input, float* output);
+                    const int max_threads_per_block, const float* input, float* output);
 
 bool LaunchTransCtx(cudaStream_t stream,
                     const int sequence_length, const int batch_size, const int head_size, const int num_heads,
-                    const half* input, half* output);
+                    const int max_threads_per_block, const half* input, half* output);
 
 bool LaunchTransQkv(cudaStream_t stream,
                     const int sequence_length, const int batch_size, const int head_size, const int num_heads,
-                    const float* input, float* output);
+                    const int max_threads_per_block, const float* input, float* output);
 
 bool LaunchTransQkv(cudaStream_t stream,
                     const int sequence_length, const int batch_size, const int head_size, const int num_heads,
-                    const half* input, half* output);
+                    const int max_threads_per_block, const half* input, half* output);
 
 bool LaunchConcatPastToPresent(cudaStream_t stream,
                                const int all_sequence_length,
@@ -78,6 +78,7 @@ bool LaunchConcatPastToPresent(cudaStream_t stream,
                                const int batch_size,
                                const int head_size,
                                const int num_heads,
+                               const int max_threads_per_block,
                                const float* past,
                                const float* k_v,
                                float* present);
@@ -88,6 +89,7 @@ bool LaunchConcatPastToPresent(cudaStream_t stream,
                                const int batch_size,
                                const int head_size,
                                const int num_heads,
+                               const int max_threads_per_block,
                                const half* past,
                                const half* k_v,
                                half* present);

--- a/onnxruntime/contrib_ops/cuda/bert/attention_past.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_past.cu
@@ -96,25 +96,26 @@ bool LaunchConcatPastToPresent(cudaStream_t stream,
                                const int batch_size,
                                const int head_size,
                                const int num_heads,
+                               const int max_threads_per_block,
                                const float* past,
                                const float* k_v,
                                float* present) {
   const dim3 grid(all_sequence_length, batch_size, 2);
   if (0 == (head_size & 1)) {
     const int H = head_size / 2;
-    if (H * num_heads <= 1024) {
+    if (H * num_heads <= max_threads_per_block) {
       const dim3 block(H, num_heads, 1);
       ConcatPastToPresent<float2><<<grid, block, 0, stream>>>(sequence_length, reinterpret_cast<const float2*>(past), reinterpret_cast<const float2*>(k_v), reinterpret_cast<float2*>(present));
     } else {
-      const dim3 block(1024 / num_heads, num_heads, 1);
+      const dim3 block(max_threads_per_block / num_heads, num_heads, 1);
       ConcatPastToPresentLarge<float2><<<grid, block, 0, stream>>>(sequence_length, H, reinterpret_cast<const float2*>(past), reinterpret_cast<const float2*>(k_v), reinterpret_cast<float2*>(present));
     }
   } else {
-    if (head_size * num_heads <= 1024) {
+    if (head_size * num_heads <= max_threads_per_block) {
       const dim3 block(head_size, num_heads, 1);
       ConcatPastToPresent<float><<<grid, block, 0, stream>>>(sequence_length, past, k_v, present);
     } else {
-      const dim3 block(1024 / num_heads, num_heads, 1);
+      const dim3 block(max_threads_per_block / num_heads, num_heads, 1);
       ConcatPastToPresentLarge<float><<<grid, block, 0, stream>>>(sequence_length, head_size, past, k_v, present);
     }
 
@@ -128,34 +129,35 @@ bool LaunchConcatPastToPresent(cudaStream_t stream,
                                const int batch_size,
                                const int head_size,
                                const int num_heads,
+                               const int max_threads_per_block,
                                const half* past,
                                const half* k_v,
                                half* present) {
   const dim3 grid(all_sequence_length, batch_size, 2);
   if (0 == (head_size % 4)) {
     const int H = head_size / 4;
-    if (H * num_heads <= 1024) {
+    if (H * num_heads <= max_threads_per_block) {
       const dim3 block(H, num_heads, 1);
       ConcatPastToPresent<float2><<<grid, block, 0, stream>>>(sequence_length, reinterpret_cast<const float2*>(past), reinterpret_cast<const float2*>(k_v), reinterpret_cast<float2*>(present));
     } else {
-      const dim3 block(1024 / num_heads, num_heads, 1);
+      const dim3 block(max_threads_per_block / num_heads, num_heads, 1);
       ConcatPastToPresentLarge<float2><<<grid, block, 0, stream>>>(sequence_length, H, reinterpret_cast<const float2*>(past), reinterpret_cast<const float2*>(k_v), reinterpret_cast<float2*>(present));
     }
   } else if (0 == (head_size & 1)) {
     const int H = head_size / 2;
-    if (H * num_heads <= 1024) {
+    if (H * num_heads <= max_threads_per_block) {
       const dim3 block(H, num_heads, 1);
       ConcatPastToPresent<half2><<<grid, block, 0, stream>>>(sequence_length, reinterpret_cast<const half2*>(past), reinterpret_cast<const half2*>(k_v), reinterpret_cast<half2*>(present));
     } else {
-      const dim3 block(1024 / num_heads, num_heads, 1);
+      const dim3 block(max_threads_per_block / num_heads, num_heads, 1);
       ConcatPastToPresentLarge<half2><<<grid, block, 0, stream>>>(sequence_length, H, reinterpret_cast<const half2*>(past), reinterpret_cast<const half2*>(k_v), reinterpret_cast<half2*>(present));
     }
   } else {  // this should be an "odd" case. probably not worth catching it in the half2 kernel.
-    if (head_size * num_heads <= 1024) {
+    if (head_size * num_heads <= max_threads_per_block) {
       const dim3 block(head_size, num_heads, 1);
       ConcatPastToPresent<half><<<grid, block, 0, stream>>>(sequence_length, past, k_v, present);
     } else {
-      const dim3 block(1024 / num_heads, num_heads, 1);
+      const dim3 block(max_threads_per_block / num_heads, num_heads, 1);
       ConcatPastToPresentLarge<half><<<grid, block, 0, stream>>>(sequence_length, head_size, past, k_v, present);
     }
   }

--- a/onnxruntime/contrib_ops/cuda/bert/attention_past.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_past.cu
@@ -47,6 +47,49 @@ __global__ void ConcatPastToPresent(const int sequence_length,
   }
 }
 
+template <typename T>
+__global__ void ConcatPastToPresentLarge(const int sequence_length,
+                                         const int H,
+                                         const T* past,
+                                         const T* k_v,
+                                         T* present) {
+  // Use when (H*)*num_heads > 1024
+  int h = threadIdx.x;
+  const int n = threadIdx.y;
+  const int s = blockIdx.x;
+  const int b = blockIdx.y;
+  const int is_v = blockIdx.z;  // 0 for k, 1 for v
+
+  const int all_sequence_length = gridDim.x;
+  const int batch_size = gridDim.y;
+  const int num_heads = blockDim.y;
+  const int stride = blockDim.x;
+
+  // past:    2 x BxNxS'xH   (past_k and past_v)
+  // k_v:     2 x BxNxSxH    (k and v)
+  // present: 2 x BxNxS*xH   (present_k and present_v)
+  const int past_sequence_length = all_sequence_length - sequence_length;
+
+  const int present_SH = all_sequence_length * H;
+  const int present_NSH = num_heads * present_SH;
+  while (h < H) {
+    int out_offset = b * present_NSH + n * present_SH + s * H + h + is_v * (present_NSH * batch_size);
+    if (s < past_sequence_length) {
+      const int past_SH = past_sequence_length * H;
+      const int past_NSH = num_heads * past_SH;
+      const int in_offset = b * past_NSH + n * past_SH + s * H + h + is_v * (past_NSH * batch_size);
+      present[out_offset] = past[in_offset];
+    } else if (s < all_sequence_length) {
+      const int SH = sequence_length * H;
+      const int NSH = num_heads * SH;
+      const int in_offset = b * NSH + n * SH + (s - past_sequence_length) * H + h + is_v * (NSH * batch_size);
+      present[out_offset] = k_v[in_offset];
+    }
+
+    h += stride;
+  }
+}
+
 bool LaunchConcatPastToPresent(cudaStream_t stream,
                                const int all_sequence_length,
                                const int sequence_length,
@@ -58,11 +101,23 @@ bool LaunchConcatPastToPresent(cudaStream_t stream,
                                float* present) {
   const dim3 grid(all_sequence_length, batch_size, 2);
   if (0 == (head_size & 1)) {
-    const dim3 block(head_size / 2, num_heads, 1);
-    ConcatPastToPresent<float2><<<grid, block, 0, stream>>>(sequence_length, reinterpret_cast<const float2*>(past), reinterpret_cast<const float2*>(k_v), reinterpret_cast<float2*>(present));
+    const int H = head_size / 2;
+    if (H * num_heads <= 1024) {
+      const dim3 block(H, num_heads, 1);
+      ConcatPastToPresent<float2><<<grid, block, 0, stream>>>(sequence_length, reinterpret_cast<const float2*>(past), reinterpret_cast<const float2*>(k_v), reinterpret_cast<float2*>(present));
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      ConcatPastToPresentLarge<float2><<<grid, block, 0, stream>>>(sequence_length, H, reinterpret_cast<const float2*>(past), reinterpret_cast<const float2*>(k_v), reinterpret_cast<float2*>(present));
+    }
   } else {
-    const dim3 block(head_size, num_heads, 1);
-    ConcatPastToPresent<float><<<grid, block, 0, stream>>>(sequence_length, past, k_v, present);
+    if (head_size * num_heads <= 1024) {
+      const dim3 block(head_size, num_heads, 1);
+      ConcatPastToPresent<float><<<grid, block, 0, stream>>>(sequence_length, past, k_v, present);
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      ConcatPastToPresentLarge<float><<<grid, block, 0, stream>>>(sequence_length, head_size, past, k_v, present);
+    }
+
   }
   return CUDA_CALL(cudaPeekAtLastError());
 }
@@ -78,14 +133,31 @@ bool LaunchConcatPastToPresent(cudaStream_t stream,
                                half* present) {
   const dim3 grid(all_sequence_length, batch_size, 2);
   if (0 == (head_size % 4)) {
-    const dim3 block(head_size / 4, num_heads, 1);
-    ConcatPastToPresent<float2><<<grid, block, 0, stream>>>(sequence_length, reinterpret_cast<const float2*>(past), reinterpret_cast<const float2*>(k_v), reinterpret_cast<float2*>(present));
+    const int H = head_size / 4;
+    if (H * num_heads <= 1024) {
+      const dim3 block(H, num_heads, 1);
+      ConcatPastToPresent<float2><<<grid, block, 0, stream>>>(sequence_length, reinterpret_cast<const float2*>(past), reinterpret_cast<const float2*>(k_v), reinterpret_cast<float2*>(present));
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      ConcatPastToPresentLarge<float2><<<grid, block, 0, stream>>>(sequence_length, H, reinterpret_cast<const float2*>(past), reinterpret_cast<const float2*>(k_v), reinterpret_cast<float2*>(present));
+    }
   } else if (0 == (head_size & 1)) {
-    const dim3 block(head_size / 2, num_heads, 1);
-    ConcatPastToPresent<half2><<<grid, block, 0, stream>>>(sequence_length, reinterpret_cast<const half2*>(past), reinterpret_cast<const half2*>(k_v), reinterpret_cast<half2*>(present));
+    const int H = head_size / 2;
+    if (H * num_heads <= 1024) {
+      const dim3 block(H, num_heads, 1);
+      ConcatPastToPresent<half2><<<grid, block, 0, stream>>>(sequence_length, reinterpret_cast<const half2*>(past), reinterpret_cast<const half2*>(k_v), reinterpret_cast<half2*>(present));
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      ConcatPastToPresentLarge<half2><<<grid, block, 0, stream>>>(sequence_length, H, reinterpret_cast<const half2*>(past), reinterpret_cast<const half2*>(k_v), reinterpret_cast<half2*>(present));
+    }
   } else {  // this should be an "odd" case. probably not worth catching it in the half2 kernel.
-    const dim3 block(head_size, num_heads, 1);
-    ConcatPastToPresent<half><<<grid, block, 0, stream>>>(sequence_length, past, k_v, present);
+    if (head_size * num_heads <= 1024) {
+      const dim3 block(head_size, num_heads, 1);
+      ConcatPastToPresent<half><<<grid, block, 0, stream>>>(sequence_length, past, k_v, present);
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      ConcatPastToPresentLarge<half><<<grid, block, 0, stream>>>(sequence_length, head_size, past, k_v, present);
+    }
   }
   return CUDA_CALL(cudaPeekAtLastError());
 }

--- a/onnxruntime/contrib_ops/cuda/bert/attention_transpose.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_transpose.cu
@@ -49,6 +49,33 @@ __global__ void TransposeCtx(const int H, const T* input, T* output) {
   }
 }
 
+template <typename T>
+__global__ void TransposeCtxLarge(const int H, const T* input, T* output) {
+  // Use when (H*)*num_heads > 1024
+
+  // Input:  BxNxSxH
+  // Output: BxSxNxH
+
+  int n = threadIdx.y;
+  int s = blockIdx.x;
+  int b = blockIdx.y;
+
+  int stride = blockDim.x;
+  int num_heads = blockDim.y;
+  int sequence_length = gridDim.x;
+
+  const int NH = num_heads * H;
+  const int NHS = NH * sequence_length;
+  const int in_offset = s * H + n * sequence_length * H + b * NHS;
+  const int out_offset = n * H + s * NH + b * NHS;
+
+  int i = threadIdx.x;
+  while (i < H) {
+    output[out_offset + i] = input[in_offset + i];
+    i += stride;
+  }
+}
+
 bool LaunchTransCtx(cudaStream_t stream,
                     const int sequence_length, const int batch_size, const int head_size, const int num_heads,
                     const float* input, float* output) {
@@ -57,11 +84,21 @@ bool LaunchTransCtx(cudaStream_t stream,
     const int H = head_size / 2;
     const float2* input2 = reinterpret_cast<const float2*>(input);
     float2* output2 = reinterpret_cast<float2*>(output);
-    const dim3 block(H, num_heads, 1);
-    TransposeCtx<float2><<<grid, block, 0, stream>>>(H, input2, output2);
+    if (H * num_heads <= 1) {
+      const dim3 block(H, num_heads, 1);
+      TransposeCtx<float2><<<grid, block, 0, stream>>>(H, input2, output2);
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      TransposeCtxLarge<float2><<<grid, block, 0, stream>>>(H, input2, output2);
+    }
   } else {
-    const dim3 block(head_size, num_heads, 1);
-    TransposeCtx<float><<<grid, block, 0, stream>>>(head_size, input, output);
+    if (head_size * num_heads <= 1) {
+      const dim3 block(head_size, num_heads, 1);
+      TransposeCtx<float><<<grid, block, 0, stream>>>(head_size, input, output);
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      TransposeCtxLarge<float><<<grid, block, 0, stream>>>(head_size, input, output);
+    }
   }
   return CUDA_CALL(cudaPeekAtLastError());
 }
@@ -72,19 +109,34 @@ bool LaunchTransCtx(cudaStream_t stream,
   const dim3 grid(sequence_length, batch_size, 1);
   if (0 == (head_size % 4)) {
     const int H = head_size / 4;
-    const dim3 block(H, num_heads, 1);
     const float2* input2 = reinterpret_cast<const float2*>(input);
     float2* output2 = reinterpret_cast<float2*>(output);
-    TransposeCtx<float2><<<grid, block, 0, stream>>>(H, input2, output2);
+    if (H * num_heads <= 1024) {
+      const dim3 block(H, num_heads, 1);
+      TransposeCtx<float2><<<grid, block, 0, stream>>>(H, input2, output2);
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      TransposeCtxLarge<float2><<<grid, block, 0, stream>>>(H, input2, output2);
+    }
   } else if (0 == (head_size & 1)) {
     const int H = head_size / 2;
-    const dim3 block(H, num_heads, 1);
     const half2* input2 = reinterpret_cast<const half2*>(input);
     half2* output2 = reinterpret_cast<half2*>(output);
-    TransposeCtx<half2><<<grid, block, 0, stream>>>(H, input2, output2);
+    if (H * num_heads <= 1024) {
+      const dim3 block(H, num_heads, 1);
+      TransposeCtx<half2><<<grid, block, 0, stream>>>(H, input2, output2);
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      TransposeCtxLarge<half2><<<grid, block, 0, stream>>>(H, input2, output2);
+    }
   } else {  // this should be an "odd" case. probably not worth catching it in the half2 kernel.
-    const dim3 block(head_size, num_heads, 1);
-    TransposeCtx<half><<<grid, block, 0, stream>>>(head_size, input, output);
+    if (head_size * num_heads <= 1024) {
+      const dim3 block(head_size, num_heads, 1);
+      TransposeCtx<half><<<grid, block, 0, stream>>>(head_size, input, output);
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      TransposeCtxLarge<half><<<grid, block, 0, stream>>>(head_size, input, output);
+    }
   }
 
   return CUDA_CALL(cudaPeekAtLastError());
@@ -115,6 +167,35 @@ __global__ void TransposeQKV(const int H, const T* input, T* output) {
   }
 }
 
+template <typename T>
+__global__ void TransposeQKVLarge(const int H, const T* input, T* output) {
+  // // Use when (H*)*num_heads > 1024
+
+  // Input:  BxSx3xNxH
+  // Output: 3xBxNxSxH
+
+  int n = threadIdx.y;
+  int s = blockIdx.x;
+  int b = blockIdx.y;
+  int m = blockIdx.z;  // matrix id
+
+  const int stride = blockDim.x;
+  const int num_heads = blockDim.y;
+
+  const int sequence_length = gridDim.x;
+  const int batch_size = gridDim.y;
+  const int NH = num_heads * H;
+  const int NHS = NH * sequence_length;
+  const int in_offset = n * H + m * NH + s * 3 * NH + b * NHS * 3;
+  const int out_offset = s * H + n * sequence_length * H + b * NHS + m * NHS * batch_size;
+
+  int i = threadIdx.x;
+  while (i < H) {
+    output[out_offset + i] = input[in_offset + i];
+    i += stride;
+  }
+}
+
 bool LaunchTransQkv(cudaStream_t stream,
                     const int sequence_length, const int batch_size, const int head_size, const int num_heads,
                     const float* input, float* output) {
@@ -123,11 +204,22 @@ bool LaunchTransQkv(cudaStream_t stream,
     const int H = head_size / 2;
     const float2* input2 = reinterpret_cast<const float2*>(input);
     float2* output2 = reinterpret_cast<float2*>(output);
-    const dim3 block(H, num_heads, 1);
-    TransposeQKV<float2><<<grid, block, 0, stream>>>(H, input2, output2);
+    if (H * num_heads <= 1024) {
+      const dim3 block(H, num_heads, 1);
+      TransposeQKV<float2><<<grid, block, 0, stream>>>(H, input2, output2);
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      TransposeQKVLarge<float2><<<grid, block, 0, stream>>>(H, input2, output2);
+    }
   } else {
-    const dim3 block(head_size, num_heads, 1);
-    TransposeQKV<float><<<grid, block, 0, stream>>>(head_size, input, output);
+    if (head_size * num_heads <= 1024) {
+      const dim3 block(head_size, num_heads, 1);
+      TransposeQKV<float><<<grid, block, 0, stream>>>(head_size, input, output);
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      TransposeQKVLarge<float><<<grid, block, 0, stream>>>(head_size, input, output);
+    }
+
   }
   return CUDA_CALL(cudaPeekAtLastError());
 }
@@ -138,19 +230,34 @@ bool LaunchTransQkv(cudaStream_t stream,
   const dim3 grid(sequence_length, batch_size, 3);
   if (0 == (head_size % 4)) {
     const int H = head_size / 4;
-    const dim3 block(H, num_heads, 1);
     const float2* input2 = reinterpret_cast<const float2*>(input);
     float2* output2 = reinterpret_cast<float2*>(output);
-    TransposeQKV<float2><<<grid, block, 0, stream>>>(H, input2, output2);
+    if (H * num_heads <= 1024) {
+      const dim3 block(H, num_heads, 1);
+      TransposeQKV<float2><<<grid, block, 0, stream>>>(H, input2, output2);
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      TransposeQKVLarge<float2><<<grid, block, 0, stream>>>(H, input2, output2);
+    }
   } else if (0 == (head_size & 1)) {
     const int H = head_size / 2;
-    const dim3 block(H, num_heads, 1);
     const half2* input2 = reinterpret_cast<const half2*>(input);
     half2* output2 = reinterpret_cast<half2*>(output);
-    TransposeQKV<half2><<<grid, block, 0, stream>>>(H, input2, output2);
+    if (H * num_heads <= 1024) {
+      const dim3 block(H, num_heads, 1);
+      TransposeQKV<half2><<<grid, block, 0, stream>>>(H, input2, output2);
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      TransposeQKVLarge<half2><<<grid, block, 0, stream>>>(H, input2, output2);
+    }
   } else {  // this should be an "odd" case. probably not worth catching it in the half2 kernel..
-    const dim3 block(head_size, num_heads, 1);
-    TransposeQKV<half><<<grid, block, 0, stream>>>(head_size, input, output);
+    if (head_size * num_heads <= 1024) {
+      const dim3 block(head_size, num_heads, 1);
+      TransposeQKV<half><<<grid, block, 0, stream>>>(head_size, input, output);
+    } else {
+      const dim3 block(1024 / num_heads, num_heads, 1);
+      TransposeQKVLarge<half><<<grid, block, 0, stream>>>(head_size, input, output);
+    }
   }
   return CUDA_CALL(cudaPeekAtLastError());
 }

--- a/onnxruntime/contrib_ops/cuda/bert/attention_transpose.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_transpose.cu
@@ -84,7 +84,7 @@ bool LaunchTransCtx(cudaStream_t stream,
     const int H = head_size / 2;
     const float2* input2 = reinterpret_cast<const float2*>(input);
     float2* output2 = reinterpret_cast<float2*>(output);
-    if (H * num_heads <= 1) {
+    if (H * num_heads <= 1024) {
       const dim3 block(H, num_heads, 1);
       TransposeCtx<float2><<<grid, block, 0, stream>>>(H, input2, output2);
     } else {
@@ -92,7 +92,7 @@ bool LaunchTransCtx(cudaStream_t stream,
       TransposeCtxLarge<float2><<<grid, block, 0, stream>>>(H, input2, output2);
     }
   } else {
-    if (head_size * num_heads <= 1) {
+    if (head_size * num_heads <= 1024) {
       const dim3 block(head_size, num_heads, 1);
       TransposeCtx<float><<<grid, block, 0, stream>>>(head_size, input, output);
     } else {

--- a/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.cc
@@ -49,7 +49,8 @@ Status QAttention<T, int8_t>::CheckInputs(const Tensor* input,
                                           const Tensor* i_zp_tensor,
                                           const Tensor* w_zp_tensor,
                                           const Tensor* past_tensor) const {
-  ORT_RETURN_IF_ERROR(AttentionBase::CheckInputs(input->Shape(), weights->Shape(), bias->Shape(), mask_index, past_tensor));
+  auto& device_prop = GetDeviceProp();
+  ORT_RETURN_IF_ERROR(AttentionBase::CheckInputs(input->Shape(), weights->Shape(), bias->Shape(), mask_index, past_tensor, device_prop.maxThreadsPerBlock));
 
   ORT_RETURN_IF_NOT(IsScalarOr1ElementVector(input_scale_tensor),
                     "input scale must be a scalar or 1D tensor of size 1");

--- a/onnxruntime/python/tools/transformers/README.md
+++ b/onnxruntime/python/tools/transformers/README.md
@@ -14,12 +14,12 @@ First you need install onnxruntime or onnxruntime-gpu package for CPU or GPU inf
 
 ## Limitations
 
-Due to CUDA implementation of Attention kernel, maximum hidden dimension is 4096 for float16 model and 2048 for float32 model in GPU. Normally, maximum supported sequence length is 4096 for Longformer and 1024 for other types of models.
+Due to CUDA implementation of Attention kernel, maximum number of attention heads is 1024. Normally, maximum supported sequence length is 4096 for Longformer and 1024 for other types of models.
 
 ## Export a transformer model to ONNX
 
 PyTorch could export model to ONNX. The tf2onnx and keras2onnx tools can be used to convert model that trained by Tensorflow.
-Huggingface transformers has a [notebook](https://github.com/huggingface/transformers/blob/master/notebooks/04-onnx-export.ipynb) shows an example of exporting a pretrained model to ONNX. 
+Huggingface transformers has a [notebook](https://github.com/huggingface/transformers/blob/master/notebooks/04-onnx-export.ipynb) shows an example of exporting a pretrained model to ONNX.
 For Keras2onnx, please refer to its [example script](https://github.com/onnx/keras-onnx/blob/master/applications/nightly_build/test_transformers.py).
 For tf2onnx, please refer to its [BERT tutorial](https://github.com/onnx/tensorflow-onnx/blob/master/tutorials/BertTutorial.ipynb).
 
@@ -134,13 +134,13 @@ We tested on Tesla V100-PCIE-16GB GPU (CPU is Intel Xeon(R) E5-2690 v4) for diff
 
 The model has 12 layers and 768 hidden, with input_ids as input.
 
-| engine      | version | precision | b | s=8  | s=16 | s=32 | s=64 | s=128 | s=256 | s=512 | 
-|-------------|---------|-----------|---|------|------|------|------|-------|-------|-------| 
-| torchscript | 1.5.1   | fp32      | 1 | 7.92 | 8.78 | 8.91 | 9.18 | 9.56  | 9.39  | 12.83 | 
-| onnxruntime | 1.4.0   | fp32      | 1 | 1.38 | 1.42 | 1.67 | 2.15 | 3.11  | 5.37  | 10.74 | 
-| onnxruntime | 1.4.0   | fp16      | 1 | 1.30 | 1.29 | 1.31 | 1.33 | 1.45  | 1.95  | 3.36  | 
-| onnxruntime | 1.4.0   | fp32      | 4 | 1.51 | 1.93 | 2.98 | 5.01 | 9.13  | 17.95 | 38.15 | 
-| onnxruntime | 1.4.0   | fp16      | 4 | 1.27 | 1.35 | 1.43 | 1.83 | 2.66  | 4.40  | 9.76  | 
+| engine      | version | precision | b | s=8  | s=16 | s=32 | s=64 | s=128 | s=256 | s=512 |
+|-------------|---------|-----------|---|------|------|------|------|-------|-------|-------|
+| torchscript | 1.5.1   | fp32      | 1 | 7.92 | 8.78 | 8.91 | 9.18 | 9.56  | 9.39  | 12.83 |
+| onnxruntime | 1.4.0   | fp32      | 1 | 1.38 | 1.42 | 1.67 | 2.15 | 3.11  | 5.37  | 10.74 |
+| onnxruntime | 1.4.0   | fp16      | 1 | 1.30 | 1.29 | 1.31 | 1.33 | 1.45  | 1.95  | 3.36  |
+| onnxruntime | 1.4.0   | fp32      | 4 | 1.51 | 1.93 | 2.98 | 5.01 | 9.13  | 17.95 | 38.15 |
+| onnxruntime | 1.4.0   | fp16      | 4 | 1.27 | 1.35 | 1.43 | 1.83 | 2.66  | 4.40  | 9.76  |
 
 [run_benchmark.sh](https://github.com/microsoft/onnxruntime/blob/master/onnxruntime/python/tools/transformers/run_benchmark.sh) is used to get the results.
 
@@ -171,7 +171,7 @@ python -m onnxruntime.transformers.benchmark_gpt2 --use_gpu -m gpt2 -o -v -b 1 8
 
 ### Benchmark.py
 
-If you use run_benchmark.sh, you need not use benchmark.py directly. You can skip this section if you do not want to know the details. 
+If you use run_benchmark.sh, you need not use benchmark.py directly. You can skip this section if you do not want to know the details.
 
 Below is example to runing benchmark.py on pretrained model bert-base-cased on GPU.
 


### PR DESCRIPTION
-Parity confirmed by comparing with CPU

-Perf test:
number of heads = 32
seq_len = 128
head_size    |     hidden_size    |    latency(ms)
32               |     1024               |     0.582
48               |     1536               |     0.802
64               |     2048               |     1.110
--------------------------------------(apply new kernels below)
65               |     2080               |     1.142
80               |     2560               |     1.332
96               |     3072               |     1.669
108             |     3456               |     1.930
128             |     4096               |     2.314
144             |     4608               |     2.697
160             |     5120               |     2.956
