### PR TITLE
Missed ORTModule conversion in test case for none type output

### DIFF
--- a/orttraining/orttraining/python/training/_ortmodule_output_transformation.py
+++ b/orttraining/orttraining/python/training/_ortmodule_output_transformation.py
@@ -134,7 +134,9 @@ def get_flattened_output_module(original_module):
         def _flatten_output(output, flat_output):
             # Recursively traverse over the output and populate the flat_output with torch.Tensors
 
-            if isinstance(output, torch.Tensor):
+            if output is None:
+                return
+            elif isinstance(output, torch.Tensor):
                 flat_output.append(output)
             elif isinstance(output, abc.Sequence):
                 for value in output:

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -1303,6 +1303,7 @@ def test_forward_returns_none_type_as_output():
     device = 'cuda'
     N, D_in, H, D_out = 64, 784, 500, 10
     model = NeuralNetNoneTypeOutput(D_in, D_out).to(device)
+    model = ORTModule(model)
     x = torch.randn(N, D_in, device=device)
     output = model(x)
 


### PR DESCRIPTION
The unit test added earlier for none type output did not convert the pytorch model to ORTModule. Addressing that in this PR.