### PR TITLE
[WIP] Add Trilu op in ONNX domain from contri_ops 

### DIFF
--- a/cgmanifests/submodules/cgmanifest.json
+++ b/cgmanifests/submodules/cgmanifest.json
@@ -242,7 +242,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "237926eab41de21fb9addc4b03b751fd6a3343ec",
+          "commitHash": "859ca2d9840e23fcdac91df2469d0ac37c0a4187",
           "repositoryUrl": "https://github.com/onnx/onnx"
         },
         "comments": "git submodule at cmake/external/onnx"

--- a/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
+++ b/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
@@ -648,6 +648,9 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, float, Softmax);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, double, Softmax);
 
+// opset 14
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 14, Trilu);
+
 // !!PLEASE READ BELOW!! Following that, add new entries above this comment
 
 /*  *** IMPORTANT! ***
@@ -1693,6 +1696,9 @@ Status RegisterOnnxOperatorKernels(KernelRegistry& kernel_registry) {
                                                                   Softmax)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, float,
                                                                   Softmax)>,
+
+      // opset 14
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 14, Trilu)>,
   };
 
   for (auto& function_table_entry : function_table) {

--- a/onnxruntime/core/providers/cpu/tensor/trilu.cc
+++ b/onnxruntime/core/providers/cpu/tensor/trilu.cc
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/common.h"
+#include "core/framework/op_kernel.h"
+#include "core/util/math_cpuonly.h"
+#include "Eigen/src/Core/Map.h"
+#include "trilu.h"
+#include <functional>
+
+using namespace onnxruntime::common;
+
+namespace onnxruntime {
+
+ONNX_OPERATOR_KERNEL_EX(
+    Trilu,
+    kOnnxDomain,
+    14,
+    kCpuExecutionProvider,
+    KernelDefBuilder().MayInplace(0, 0).TypeConstraint("T", BuildKernelDefConstraints<float, double, int64_t>()),
+    Trilu);
+
+template <typename T>
+static Status TriluImpl(const Tensor* X, Tensor* Y, int64_t k_val, bool up) {
+  const auto& X_shape = X->Shape();
+  int64_t X_num_dims = static_cast<int64_t>(X_shape.NumDimensions());
+
+  const auto* X_data = reinterpret_cast<const T*>(X->DataRaw());
+  int64_t matrix_h = static_cast<int64_t>(X_shape[X_num_dims - 2]);
+  int64_t matrix_w = static_cast<int64_t>(X_shape[X_num_dims - 1]);
+
+  int64_t batch_size = 1;
+  for (int64_t i = 0; i < X_num_dims - 2; ++i) {
+    batch_size *= X_shape[i];
+  }
+
+  int64_t num_matrix_elems = matrix_h * matrix_w;
+  auto* Y_data = reinterpret_cast<T*>(Y->MutableDataRaw());
+  for (int64_t b = 0; b < batch_size; b++) {  // can be parallelized if need to
+    auto X_batch_data = X_data + (b * num_matrix_elems);
+    auto Y_batch_data = Y_data + (b * num_matrix_elems);
+
+    auto input_mat = ConstEigenMatrixMapRowMajor<T>(X_batch_data, matrix_h, matrix_w);
+    auto output_mat = EigenMatrixMapRowMajor<T>(Y_batch_data, matrix_h, matrix_w);
+
+    if (X_batch_data != Y_batch_data) {
+      output_mat = input_mat;
+    }
+
+    if (up) {
+      int64_t start_i = k_val > 0 ? 0 : 1 - k_val;
+      for (int64_t i = start_i; i < matrix_h; i++) {
+        for (int64_t j = 0; j < i + k_val && j < matrix_w; j++) {
+          output_mat(i, j) = 0;
+        }
+      }
+    } else {
+      int64_t end_i = std::min(matrix_h, matrix_w - k_val);
+      for (int64_t i = 0; i < end_i; i++) {
+        for (int64_t j = std::max(static_cast<int64_t>(0), i + k_val + 1); j < matrix_w; j++) {
+          output_mat(i, j) = 0;
+        }
+      }
+    }
+  }
+  return Status::OK();
+}
+
+Status Trilu::Compute(OpKernelContext* ctx) const {
+  Status status;
+  const auto* X = ctx->Input<Tensor>(0);
+  const auto* k = ctx->Input<Tensor>(1);
+
+  bool up = upper_;
+  int64_t k_val = 0;
+  if (k) {
+    ORT_ENFORCE(IsScalarOr1ElementVector(k), "k should be a 1-D or 0-D tensor.");
+    k_val = *(k->template Data<int64_t>());
+  }
+
+  const auto& X_shape = X->Shape();
+  auto* Y = ctx->Output(0, X_shape);
+
+  int64_t X_num_dims = static_cast<int64_t>(X_shape.NumDimensions());
+  // input validation
+  if (X_num_dims < 2) {  // this is getting capture by shape inference code as well
+    return Status(ONNXRUNTIME, INVALID_ARGUMENT, "Input tensor should have a rank of at least 2");
+  }
+
+  MLDataType data_type = X->DataType();
+  const auto element_size = data_type->Size();
+  switch (element_size) {
+    case sizeof(float):
+      status = TriluImpl<float>(X, Y, k_val, up);
+      break;
+    case sizeof(double):
+      status = TriluImpl<double>(X, Y, k_val, up);
+      break;
+    default:
+      ORT_THROW("Unsupported input data type of ", data_type);
+  }
+  return status;
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/tensor/trilu.h
+++ b/onnxruntime/core/providers/cpu/tensor/trilu.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace onnxruntime {
+
+class Trilu final : public OpKernel {
+ public:
+  explicit Trilu(const OpKernelInfo& info) : OpKernel(info) {
+    int64_t temp;
+    ORT_ENFORCE(info.GetAttr<int64_t>("upper", &temp).IsOK());
+    upper_ = temp != 0;
+  }
+  Status Compute(OpKernelContext* ctx) const override;
+
+ private:
+   bool upper_;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/trilu_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/trilu_test.cc
@@ -1,0 +1,242 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+#include "core/util/math.h"
+
+namespace onnxruntime {
+namespace test {
+
+TEST(TriluContribOpTest, two_by_two_float_upper) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  int64_t up = 1;
+  test.AddAttribute("upper", up);
+  test.AddInput<float>("X", {2, 2}, {4.f, 7.f, 2.f, 6.f});
+  test.AddOutput<float>("Y", {2, 2}, {4.f, 7.f, 0.f, 6.f});
+  test.Run();
+}
+
+TEST(TriluContribOpTest, two_by_two_float_lower) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  int64_t up = 0;
+  test.AddAttribute("upper", up);
+  test.AddInput<float>("X", {2, 2}, {4.f, 7.f, 2.f, 6.f});
+  test.AddOutput<float>("Y", {2, 2}, {4.f, 0.f, 2.f, 6.f});
+  test.Run();
+}
+
+TEST(TriluContribOpTest, two_by_two_double_upper) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  test.AddInput<double>("X", {2, 2}, {4, 7, 2, 6});
+  test.AddInput<int64_t>("k", {1}, {1});
+  test.AddOutput<double>("Y", {2, 2}, {0, 7, 0, 0});
+  test.Run();
+}
+
+TEST(TriluContribOpTest, two_by_two_double_lower) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  int64_t up = 0;
+  test.AddAttribute("upper", up);
+  test.AddInput<double>("X", {2, 2}, {4, 7, 2, 6});
+  test.AddInput<int64_t>("k", {1}, {1});
+  test.AddOutput<double>("Y", {2, 2}, {4, 7, 2, 6});
+  test.Run();
+}
+
+TEST(TriluContribOpTest, two_by_two_long_upper) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  int64_t up = 1;
+  test.AddAttribute("upper", up);
+  test.AddInput<int64_t>("X", {2, 2}, {4, 7, 2, 6});
+  test.AddOutput<int64_t>("Y", {2, 2}, {4, 7, 0, 6});
+  test.Run();
+}
+
+TEST(TriluContribOpTest, two_by_two_long_lower) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  int64_t up = 0;
+  test.AddAttribute("upper", up);
+  test.AddInput<int64_t>("X", {2, 2}, {4, 7, 2, 6});
+  test.AddOutput<int64_t>("Y", {2, 2}, {4, 0, 2, 6});
+  test.Run();
+}
+
+TEST(TriluContribOpTest, three_dim_float_upper) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  test.AddInput<float>("X", {2, 3, 4},
+    {4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+     6.f, 1.f, 2.f, 3.f,
+     1.f, 6.f, 2.f, 1.f,
+     4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+    });
+  test.AddInput<int64_t>("k", {1}, {1});
+  test.AddOutput<float>("Y", {2, 3, 4},
+    {0.f, 1.f, 5.f, 8.f,
+     0.f, 0.f, 2.f, 4.f,
+     0.f, 0.f, 0.f, 3.f,
+     0.f, 6.f, 2.f, 1.f,
+     0.f, 0.f, 5.f, 8.f,
+     0.f, 0.f, 0.f, 4.f,
+    });
+  test.Run();
+}
+
+TEST(TriluContribOpTest, three_dim_float_lower) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  int64_t up = 0;
+  test.AddAttribute("upper", up);
+  test.AddInput<float>("X", {2, 3, 4},
+    {4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+     6.f, 1.f, 2.f, 3.f,
+     1.f, 6.f, 2.f, 1.f,
+     4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+    });
+  test.AddInput<int64_t>("k", {1}, {1});
+  test.AddOutput<float>("Y", {2, 3, 4},
+    {4.f, 1.f, 0.f, 0.f,
+     4.f, 3.f, 2.f, 0.f,
+     6.f, 1.f, 2.f, 3.f,
+     1.f, 6.f, 0.f, 0.f,
+     4.f, 1.f, 5.f, 0.f,
+     4.f, 3.f, 2.f, 4.f,
+    });
+  test.Run();
+}
+
+TEST(TriluContribOpTest, neg_k_float_upper) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  int64_t up = 1;
+  test.AddAttribute("upper", up);
+  test.AddInput<float>("X", {2, 3, 4},
+    {4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+     6.f, 1.f, 2.f, 3.f,
+     1.f, 6.f, 2.f, 1.f,
+     4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+    });
+  test.AddInput<int64_t>("k", {1}, {-1});
+  test.AddOutput<float>("Y", {2, 3, 4},
+    {4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+     0.f, 1.f, 2.f, 3.f,
+     1.f, 6.f, 2.f, 1.f,
+     4.f, 1.f, 5.f, 8.f,
+     0.f, 3.f, 2.f, 4.f,
+    });
+  test.Run();
+}
+
+TEST(TriluContribOpTest, neg_k_float_lower) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  int64_t up = 0;
+  test.AddAttribute("upper", up);
+  test.AddInput<float>("X", {2, 3, 4},
+    {4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+     6.f, 1.f, 2.f, 3.f,
+     1.f, 6.f, 2.f, 1.f,
+     4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+    });
+  test.AddInput<int64_t>("k", {1}, {-1});
+  test.AddOutput<float>("Y", {2, 3, 4},
+    {0.f, 0.f, 0.f, 0.f,
+     4.f, 0.f, 0.f, 0.f,
+     6.f, 1.f, 0.f, 0.f,
+     0.f, 0.f, 0.f, 0.f,
+     4.f, 0.f, 0.f, 0.f,
+     4.f, 3.f, 0.f, 0.f,
+    });
+  test.Run();
+}
+
+TEST(TriluContribOpTest, small_k_float_upper) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  test.AddInput<float>("X", {2, 3, 4},
+    {4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+     6.f, 1.f, 2.f, 3.f,
+     1.f, 6.f, 2.f, 1.f,
+     4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+    });
+  test.AddInput<int64_t>("k", {1}, {-5});
+  test.AddOutput<float>("Y", {2, 3, 4},
+    {4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+     6.f, 1.f, 2.f, 3.f,
+     1.f, 6.f, 2.f, 1.f,
+     4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+    });
+  test.Run();
+}
+
+TEST(TriluContribOpTest, small_k_float_lower) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  int64_t up = 0;
+  test.AddAttribute("upper", up);
+  test.AddInput<float>("X", {2, 3, 4},
+    {4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+     6.f, 1.f, 2.f, 3.f,
+     1.f, 6.f, 2.f, 1.f,
+     4.f, 1.f, 5.f, 8.f,
+     4.f, 3.f, 2.f, 4.f,
+    });
+  test.AddInput<int64_t>("k", {1}, {-5});
+  test.AddOutput<float>("Y", {2, 3, 4},
+    {0.f, 0.f, 0.f, 0.f,
+     0.f, 0.f, 0.f, 0.f,
+     0.f, 0.f, 0.f, 0.f,
+     0.f, 0.f, 0.f, 0.f,
+     0.f, 0.f, 0.f, 0.f,
+     0.f, 0.f, 0.f, 0.f,
+    });
+  test.Run();  
+}
+
+TEST(TriluContribOpTest, zero_dim_upper) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  test.AddInput<float>("X", {2, 3, 0}, {});
+  test.AddInput<int64_t>("k", {1}, {0});
+  test.AddOutput<float>("Y", {2, 3, 0}, {});
+  test.Run();
+}
+
+TEST(TriluContribOpTest, zero_dim_lower) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  int64_t up = 0;
+  test.AddAttribute("upper", up);
+  test.AddInput<float>("X", {2, 3, 0}, {});
+  test.AddInput<int64_t>("k", {1}, {0});
+  test.AddOutput<float>("Y", {2, 3, 0}, {});
+  test.Run();
+}
+
+TEST(TriluContribOpTest, zero_dim_2_upper) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  test.AddInput<float>("X", {2, 0, 0}, {});
+  test.AddInput<int64_t>("k", {1}, {-5});
+  test.AddOutput<float>("Y", {2, 0, 0}, {});
+  test.Run();
+}
+
+TEST(TriluContribOpTest, zero_dim_2_lower) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  int64_t up = 0;
+  test.AddAttribute("upper", up);
+  test.AddInput<float>("X", {2, 0, 0}, {});
+  test.AddInput<int64_t>("k", {1}, {-5});
+  test.AddOutput<float>("Y", {2, 0, 0}, {});
+  test.Run();
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/testdata/required_ops.config
+++ b/onnxruntime/test/testdata/required_ops.config
@@ -8,4 +8,4 @@ ai.onnx;12;Add,And,Cast,Concat,Constant,ConstantOfShape,Conv,CumSum,Div,Dropout,
 ai.onnx;14;Trilu
 ai.onnx;314159;Add
 ai.onnx.ml;1;ArrayFeatureExtractor,DictVectorizer,LabelEncoder,LinearClassifier,Normalizer,OneHotEncoder,TreeEnsembleRegressor,ZipMap
-com.microsoft;1;BiasGelu,Fake_FunctionOp,FastGelu,FusedGemm,FusedMatMul,Gelu
+com.microsoft;1;BiasGelu,Fake_FunctionOp,FastGelu,FusedGemm,FusedMatMul,Gelu,Trilu

--- a/onnxruntime/test/testdata/required_ops.config
+++ b/onnxruntime/test/testdata/required_ops.config
@@ -5,6 +5,7 @@ ai.onnx;9;Abs,Add,BatchNormalization,Cast,Clip,Concat,Constant,ConstantOfShape,C
 ai.onnx;10;Add,Cast,Concat,ConstantOfShape,Div,Dropout,Erf,Expand,Gather,Greater,Identity,If,LayerNormalization,Loop,MatMul,Mul,Neg,NonZero,Pow,ReduceMean,ReduceSum,Shape,Sqrt,Squeeze,Sub,Tanh,Transpose,Unsqueeze
 ai.onnx;11;Abs,Add,ArgMax,BatchNormalization,Cast,Clip,Concat,Constant,ConstantOfShape,Conv,Div,Exp,Expand,Flatten,Gather,Gemm,Identity,If,LayerNormalization,Log,Loop,MatMul,MatMulInteger,Max,Min,Mul,Neg,Pow,RandomUniform,Range,ReduceMean,ReduceSum,ReduceSumSquare,Relu,Reshape,Scan,SequenceConstruct,SequenceInsert,SequenceLength,Shape,Sigmoid,Slice,Softmax,Split,Sqrt,Squeeze,Sub,Sum,Tanh,Transpose,Unsqueeze,Where
 ai.onnx;12;Add,And,Cast,Concat,Constant,ConstantOfShape,Conv,CumSum,Div,Dropout,DynamicQuantizeLinear,Equal,Erf,Expand,Flatten,Gather,GatherND,Gemm,GlobalAveragePool,Identity,If,LayerNormalization,Less,Loop,MatMul,MatMulInteger,Min,Mul,NonZero,Not,Pad,Pow,RandomNormalLike,Range,ReduceMean,ReduceSum,Relu,Reshape,Shape,Slice,Softmax,SoftmaxCrossEntropyLoss,SparseSoftmaxCrossEntropy,Split,Sqrt,Squeeze,Sub,Tanh,Transpose,Unsqueeze,Where
+ai.onnx;14;Trilu
 ai.onnx;314159;Add
 ai.onnx.ml;1;ArrayFeatureExtractor,DictVectorizer,LabelEncoder,LinearClassifier,Normalizer,OneHotEncoder,TreeEnsembleRegressor,ZipMap
-com.microsoft;1;BiasGelu,Fake_FunctionOp,FastGelu,FusedGemm,FusedMatMul,Gelu,Trilu
+com.microsoft;1;BiasGelu,Fake_FunctionOp,FastGelu,FusedGemm,FusedMatMul,Gelu

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -3,7 +3,7 @@ mypy
 pytest
 setuptools>=41.4.0
 wheel
-git+http://github.com/onnx/onnx.git@237926eab41de21fb9addc4b03b751fd6a3343ec#egg=onnx
+git+http://github.com/onnx/onnx.git@859ca2d9840e23fcdac91df2469d0ac37c0a4187#egg=onnx
 protobuf
 sympy==1.1.1
 flake8

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -4,7 +4,7 @@ mypy
 pytest
 setuptools>=41.4.0
 wheel
-git+http://github.com/onnx/onnx.git@237926eab41de21fb9addc4b03b751fd6a3343ec#egg=onnx
+git+http://github.com/onnx/onnx.git@859ca2d9840e23fcdac91df2469d0ac37c0a4187#egg=onnx
 argparse
 sympy==1.1.1
 flake8


### PR DESCRIPTION
**Description**:
(Updated)
- ~Move Trilu from contri_ops to~ Add Trilu in ONNX domain; Keep original contri_ops to support backward compatibility
- Bump ONNX commit to consume Trilu support


**Motivation and Context**
https://github.com/onnx/onnx/pull/3291 ONNX has officially supported Trilu since opset_version=14