### PR TITLE
[WIP] Remove spotless

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -63,17 +63,6 @@ wrapper {
 	gradleVersion = '6.1.1'
 }
 
-spotless {
-	java {
-		removeUnusedImports()
-		googleJavaFormat()
-	}
-	format 'gradle', {
-		target '**/*.gradle'
-		trimTrailingWhitespace()
-		indentWithTabs()
-	}
-}
 
 compileJava {
 	dependsOn spotlessJava


### PR DESCRIPTION
**Description**: 

Our CI builds are failing because they can't download the spotless library from gradle server. I don't know what's going on, let's temporarily disable it first.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
