### PR TITLE
Update ORT server build pipeline

### DIFF
--- a/server/ci/run.sh
+++ b/server/ci/run.sh
@@ -7,5 +7,4 @@ make -j$(getconf _NPROCESSORS_ONLN)
 cd /onnxruntime_src/test
 /build/onnxruntime_server_tests
 cd /build
-python3 -m pip install grpcio==1.27.2 requests protobuf
 python3 server_test/test_main.py /build/onnxruntime_server /build/models/opset8/test_mnist /onnxruntime_src/test/testdata/server /build /build/server_test

--- a/tools/ci_build/github/azure-pipelines/linux-ort-srv-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ort-srv-ci-pipeline.yml
@@ -13,11 +13,12 @@ jobs:
       continueOnError: true
       condition: always()
 
-    - task: CmdLine@2
-      displayName: 'Build docker image'
-      inputs:
-        script: docker build --pull -t onnxruntime-server-ubuntu18.04 --build-arg BUILD_USER=onnxruntimedev --build-arg BUILD_UID=$(id -u) --build-arg OS_VERSION=18.04 --build-arg PYTHON_VERSION=3.5 -f Dockerfile.ubuntu_server .
-        workingDirectory: $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker
+    - template: templates/get-docker-image-steps.yml
+      parameters:
+        Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.ubuntu_server
+        Context: tools/ci_build/github/linux/docker
+        DockerBuildArgs: "--build-arg BUILD_USER=onnxruntimedev --build-arg BUILD_UID=$(id -u) --build-arg OS_VERSION=18.04 --build-arg PYTHON_VERSION=3.6"
+        Repository: onnxruntime-server-ubuntu18.04
 
     - task: CmdLine@2
       displayName: 'Run docker image'

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_server
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_server
@@ -1,14 +1,13 @@
-ARG OS_VERSION=16.04
+ARG OS_VERSION=18.04
 FROM ubuntu:${OS_VERSION}
 
-ARG PYTHON_VERSION=3.5
+ARG PYTHON_VERSION=3.6
 
 ADD scripts /tmp/scripts
 RUN /tmp/scripts/install_ubuntu.sh -p $PYTHON_VERSION && /tmp/scripts/install_server_deps.sh && rm -rf /tmp/scripts
 
 WORKDIR /root
 
-ENV LD_LIBRARY_PATH /usr/local/openblas/lib:$LD_LIBRARY_PATH
 ENV PATH /usr/local/go/bin:$PATH
 
 ARG BUILD_UID=1000

--- a/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
@@ -18,8 +18,8 @@ if [ $SYS_LONG_BIT = "64" ]; then
   tar -zxf cmake-3.18.1-Linux-x86_64.tar.gz --strip=1 -C /usr
 
   echo "Installing onnxruntime"
-  aria2c https://github.com/microsoft/onnxruntime/releases/download/v1.4.0/onnxruntime-linux-x64-1.4.0.tgz
-  tar -zxf onnxruntime-linux-x64-1.4.0.tgz --strip=1
+  aria2c https://github.com/microsoft/onnxruntime/releases/download/v1.7.0/onnxruntime-linux-x64-1.7.0.tgz
+  tar -zxf onnxruntime-linux-x64-1.7.0.tgz --strip=1
   cp -r include/* /usr/include 
   cp -r lib/* /usr/lib
   ldconfig /usr/lib
@@ -76,3 +76,5 @@ make -j$(getconf _NPROCESSORS_ONLN)
 make install
 cd /tmp
 rm -rf /tmp/grpc
+
+python3 -m pip install grpcio==1.27.2 requests protobuf


### PR DESCRIPTION
**Description**: 

1. Migrated it to Ed's new docker build script
2.  Use python 3.6 instead, because it is the default one in ubuntu 18.04
3.  Move the "pip install" command to the docker image build stage(instead of when running the image)

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
