### PR TITLE
Move Linux minimal build CI pipeline to the new Linux machine pool

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -18,7 +18,7 @@ jobs:
   timeoutInMinutes: 120
   workspace:
     clean: all
-  pool: Linux-CPU
+  pool: Linux-CPU-2019
 
   variables:
     test_data_directory: $(Build.SourcesDirectory)/.test_data

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -157,10 +157,12 @@ jobs:
     displayName: Build onnxruntime minimal baseline for Android arm64-v8a and report binary size
     inputs:
       script: |
+        NDK_HOME=$(realpath $ANDROID_NDK_HOME)
         docker run --rm \
           --volume $(Build.SourcesDirectory):/onnxruntime_src \
           --volume $(Build.BinariesDirectory):/build \
           --volume $ANDROID_HOME:/android_home \
+          --volume $NDK_HOME:/ndk_home \
           --volume $(test_data_directory):/home/onnxruntimedev/.test_data \
           -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
           -e NIGHTLY_BUILD \

--- a/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
@@ -18,7 +18,7 @@ python3 /onnxruntime_src/tools/ci_build/build.py \
     --parallel \
     --android \
     --android_sdk_path /android_home \
-    --android_ndk_path /android_home/ndk-bundle \
+    --android_ndk_path /ndk_home \
     --android_abi=arm64-v8a \
     --android_api=29 \
     --minimal_build \


### PR DESCRIPTION
**Description**: 

Move the Linux minimal build to the new Linux machine pool

However, in this new image,  ndk-bundle is a symbolic link.

```
# ls -l /usr/local/lib/android/sdk/
total 40
drwxrwxrwx 18 root root 4096 Mar 17 20:20 build-tools
drwxrwxrwx  3 root root 4096 Mar 17 20:19 cmake
drwxrwxrwx  3 root root 4096 Mar 17 20:16 cmdline-tools
drwxrwxrwx  4 root root 4096 Mar 17 20:19 extras
drwxrwxrwx  2 root root 4096 Mar 17 20:15 licenses
drwxrwxrwx  4 root root 4096 Mar 17 20:20 ndk
lrwxrwxrwx  1 root root   43 Mar 17 20:15 ndk-bundle -> /usr/local/lib/android/sdk/ndk/21.4.7075529
drwxrwxrwx  3 root root 4096 Mar 17 20:16 patcher
drwxrwxrwx  5 root root 4096 Mar 17 20:16 platform-tools
drwxrwxrwx  7 root root 4096 Mar 17 20:18 platforms
drwxrwxrwx  6 root root 4096 Mar 17 20:15 tools
```
So if we directly mount the its parent folder, it doesn't work, the link is broken. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
