### PR TITLE
Support for models having partially non trainable parameters

### DIFF
--- a/orttraining/orttraining/core/framework/module_gradient_graph_builder.h
+++ b/orttraining/orttraining/core/framework/module_gradient_graph_builder.h
@@ -64,9 +64,9 @@ class ModuleGradientGraphBuilder {
   Status Initialize(std::istream& model_istream, const ModuleGradientGraphBuilderConfiguration& config);
 
   /**
-   * Build the gradient graph and split it to forward and backward graphs.
+   * Build the gradient graph.
    * @param input_shapes_ptr The pointer to vector of concrete shapes of the user inputs.
-   * @return The status of the gradient graph building and forward/backward graphs splitting.
+   * @return The status of the gradient graph building.
    */
   Status Build(const std::vector<std::vector<int64_t>>* input_shapes_ptr = nullptr);
 
@@ -77,8 +77,8 @@ class ModuleGradientGraphBuilder {
   std::string GetGradientModel() const;
 
   /**
-   * Get the split graphs information.
-   * @return The split graphs information.
+   * Get the training graphs information.
+   * @return The training graphs information.
    */
   TrainingGraphInfo GetTrainingGraphInfo() const { return training_graph_info_; }
 

--- a/orttraining/orttraining/core/framework/module_gradient_graph_builder.h
+++ b/orttraining/orttraining/core/framework/module_gradient_graph_builder.h
@@ -16,6 +16,8 @@ namespace training {
  * The training configuration options.
  */
 struct ModuleGradientGraphBuilderConfiguration {
+  // The names of the weights.
+  std::vector<std::string> initializer_names{};
   // The names of the weights to train.
   std::vector<std::string> initializer_names_to_train{};
   // The names of inputs that require gradient.
@@ -35,6 +37,8 @@ struct TrainingGraphInfo {
   std::vector<std::string> user_input_names{};
   // Map from user input names to corresponding user input grad names for those user inputs that require grad.
   std::unordered_map<std::string, std::string> user_input_grad_names{};
+  // All initializers (trainable as well as non trainable).
+  std::vector<std::string> initializer_names{};
   // Trainable initializers.
   std::vector<std::string> initializer_names_to_train{};
   // Trainable initializer grad names, ordered according to initializer_names_to_train.

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -501,6 +501,7 @@ py::class_<TrainingAgent>(m, "TrainingAgent", R"pbdoc(This is the main class use
       m, "ModuleGradientGraphBuilderConfiguration",
       R"pbdoc(Configuration information for module gradient graph builder.)pbdoc");
   module_gradient_graph_builder_config.def(py::init())
+      .def_readwrite("initializer_names", &ModuleGradientGraphBuilderConfiguration::initializer_names)
       .def_readwrite("initializer_names_to_train", &ModuleGradientGraphBuilderConfiguration::initializer_names_to_train)
       .def_readwrite("input_names_require_grad", &ModuleGradientGraphBuilderConfiguration::input_names_require_grad)
       .def_readwrite("use_invertible_layernorm_grad",
@@ -511,6 +512,7 @@ py::class_<TrainingAgent>(m, "TrainingAgent", R"pbdoc(This is the main class use
   training_graph_info.def(py::init())
       .def_readwrite("user_input_names", &TrainingGraphInfo::user_input_names)
       .def_readwrite("user_input_grad_names", &TrainingGraphInfo::user_input_grad_names)
+      .def_readwrite("initializer_names", &TrainingGraphInfo::initializer_names)
       .def_readwrite("initializer_names_to_train", &TrainingGraphInfo::initializer_names_to_train)
       .def_readwrite("initializer_grad_names_to_train", &TrainingGraphInfo::initializer_grad_names_to_train)
       .def_readwrite("user_output_names", &TrainingGraphInfo::user_output_names)

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -129,8 +129,8 @@ class ORTModule(torch.nn.Module):
             _, _, input_names_require_grad, new_input_shape = \
                 _ortmodule_io.parse_inputs_for_onnx_export(
                     self._original_module_parameters, self._onnx_inference, *inputs, **kwargs)
-            initializer_names_to_train_set = {initializer[0] for initializer in
-                self._flattened_output_module.named_parameters() if initializer[1].requires_grad}
+            initializer_names_to_train_set = {name for name, param in
+                self._flattened_output_module.named_parameters() if param.requires_grad}
             initializer_names_to_train_set_prev = set(self._onnx_graphs_info.initializer_names_to_train) \
                 if self._onnx_graphs_info else None
             # If inputs requiring gradient change from forward to the next, the module_gradient_graph_builder
@@ -357,12 +357,12 @@ class ORTModule(torch.nn.Module):
 
     def _initialize_module_gradient_graph_builder(self):
         # TODO: PyTorch exporter bug: changes the initializer order in ONNX model
-        initializer_names = [p[0]
-                             for p in self._flattened_output_module.named_parameters()]
+        initializer_names = [name
+                             for name, _ in self._flattened_output_module.named_parameters()]
         initializer_names_to_train = []
         if torch.is_grad_enabled():
-            initializer_names_to_train = [p[0]
-                for p in self._flattened_output_module.named_parameters() if p[1].requires_grad]
+            initializer_names_to_train = [name
+                for name, param in self._flattened_output_module.named_parameters() if param.requires_grad]
         onnx_initializer_names = {
             p.name for p in self._onnx_inference.graph.initializer}
         initializer_names_to_train = [

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -129,14 +129,14 @@ class ORTModule(torch.nn.Module):
             _, _, input_names_require_grad, new_input_shape = \
                 _ortmodule_io.parse_inputs_for_onnx_export(
                     self._original_module_parameters, self._onnx_inference, *inputs, **kwargs)
-            initializer_names_to_train_set = {name for name, param in
+            initializer_names_to_train_set_user_model = {name for name, param in
                 self._flattened_output_module.named_parameters() if param.requires_grad}
-            initializer_names_to_train_set_prev = set(self._onnx_graphs_info.initializer_names_to_train) \
+            initializer_names_to_train_set_onnx_graph = set(self._onnx_graphs_info.initializer_names_to_train) \
                 if self._onnx_graphs_info else None
             # If inputs requiring gradient change from forward to the next, the module_gradient_graph_builder
             # needs to be reinitialized so it can compute the backward output for the new inputs that require_grad
             if input_names_require_grad != self._input_names_require_grad or \
-                initializer_names_to_train_set != initializer_names_to_train_set_prev:
+                initializer_names_to_train_set_user_model != initializer_names_to_train_set_onnx_graph:
                 self._input_names_require_grad = input_names_require_grad
                 self._initialize_module_gradient_graph_builder()
                 # Trigger the rebuilding of the gradient graph

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -360,7 +360,7 @@ class ORTModule(torch.nn.Module):
         initializer_names = [name
                              for name, _ in self._flattened_output_module.named_parameters()]
         initializer_names_to_train = []
-        if torch.is_grad_enabled():
+        if self.is_training:
             initializer_names_to_train = [name
                 for name, param in self._flattened_output_module.named_parameters() if param.requires_grad]
         onnx_initializer_names = {

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -1459,6 +1459,8 @@ def test_model_initializer_requires_grad_changes_from_one_forward_to_next():
     training_session1 = model._training_session
     weight_grad_2 = model._original_module.fc1.weight.grad
     bias_grad_2 = model._original_module.fc1.bias.grad
+    assert weight_grad_2 is not None
+    assert bias_grad_2 is not None
 
     model._original_module.fc1.requires_grad_(False)
     output = model(x)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -174,6 +174,19 @@ class NeuralNetNonDifferentiableOutput(torch.nn.Module):
         
         return out1, mask1, out2, mask2     # intentionally place the non-differentiable output in the middle
 
+class NeuralNetPartialNoGradModel(torch.nn.Module):
+    def __init__(self, input_size, hidden_size, num_classes):
+        super(NeuralNetPartialNoGradModel, self).__init__()
+
+        self.fc1 = torch.nn.Linear(input_size, hidden_size).requires_grad_(False)
+        self.relu = torch.nn.ReLU()
+        self.fc2 = torch.nn.Linear(hidden_size, num_classes)
+
+    def forward(self, model_input):
+        out = self.relu(self.fc1(model_input))
+        out = self.fc2(out)
+        return out
+
 # TODO: This is a workaround for the problem that pytest is still cleaning up the previous test
 # while the next task already start. 
 @pytest.fixture(autouse=True)
@@ -1406,20 +1419,6 @@ def test_uint8_input_and_output():
     assert y2 is not None and y2.dtype == torch.uint8
 
 def test_model_partially_requires_grad():
-    class NeuralNetPartialNoGradModel(torch.nn.Module):
-        def __init__(self, input_size, hidden_size, num_classes):
-            super(NeuralNetPartialNoGradModel, self).__init__()
-
-            self.fc1 = torch.nn.Linear(input_size, hidden_size).requires_grad_(False)
-            self.relu = torch.nn.ReLU()
-            self.fc2 = torch.nn.Linear(hidden_size, num_classes)
-
-        def forward(self, model_input):
-            out = None
-            out = self.relu(self.fc1(model_input))
-            out = self.fc2(out)
-            return out
-
     device = 'cuda'
     N, D_in, H, D_out = 64, 784, 500, 10
     model = NeuralNetPartialNoGradModel(D_in, H, D_out).to(device)
@@ -1442,3 +1441,25 @@ def test_model_wrapped_inside_torch_no_grad():
     # Make sure no exception is raised
     with torch.no_grad():
         output = model(x)
+
+def test_model_initializer_requires_grad_changes_from_one_forward_to_next():
+    device = 'cuda'
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = NeuralNetPartialNoGradModel(D_in, H, D_out).to(device)
+    model.fc1.requires_grad_(True)
+    model = ORTModule(model)
+    x = torch.randn(N, D_in, device=device)
+
+    # Make sure no exception is raised
+    output = model(x)
+    loss = torch.sum(output)
+    loss.backward()
+    training_session1 = model._training_session
+
+    model._original_module.fc1.requires_grad_(False)
+    output = model(x)
+    loss = torch.sum(output)
+    loss.backward()
+    training_session2 = model._training_session
+
+    assert training_session1 != training_session2

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -1449,17 +1449,25 @@ def test_model_initializer_requires_grad_changes_from_one_forward_to_next():
     model.fc1.requires_grad_(True)
     model = ORTModule(model)
     x = torch.randn(N, D_in, device=device)
+    assert model._original_module.fc1.weight.grad is None
+    assert model._original_module.fc1.bias.grad is None
 
     # Make sure no exception is raised
     output = model(x)
     loss = torch.sum(output)
     loss.backward()
     training_session1 = model._training_session
+    weight_grad_2 = model._original_module.fc1.weight.grad
+    bias_grad_2 = model._original_module.fc1.bias.grad
 
     model._original_module.fc1.requires_grad_(False)
     output = model(x)
     loss = torch.sum(output)
     loss.backward()
     training_session2 = model._training_session
+    weight_grad_3 = model._original_module.fc1.weight.grad
+    bias_grad_3 = model._original_module.fc1.bias.grad
 
     assert training_session1 != training_session2
+    assert torch.equal(weight_grad_2, weight_grad_3)
+    assert torch.equal(bias_grad_2, bias_grad_3)


### PR DESCRIPTION
**Description**:
This pull request brings support for models where only a part of the parameters are trainable. A simple example of such a model is:

```py
class NeuralNetNoGradModel(torch.nn.Module):
    def __init__(self, input_size, hidden_size, num_classes):
        super(NeuralNetNoGradModel, self).__init__()

        self.fc1 = torch.nn.Linear(input_size, hidden_size).requires_grad_(False)
        self.relu = torch.nn.ReLU()
        self.fc2 = torch.nn.Linear(hidden_size, num_classes)

    def forward(self, model_input):
        out = self.relu(self.fc1(model_input))
        out = self.fc2(out)
        return out
```

In the example above, the ```fc1``` parameter will not be trained.

One of the known limitation of ```ORTModule``` is that there is currently no support for models where a part of the model is executed under the ```torch.no_grad()``` context. For example, the below model does not have support:

```py
class NeuralNetNoGradModel(torch.nn.Module):
    def __init__(self, input_size, hidden_size, num_classes):
        super(NeuralNetNoGradModel, self).__init__()

        self.fc1 = torch.nn.Linear(input_size, hidden_size).requires_grad_(False)
        self.relu = torch.nn.ReLU()
        self.fc2 = torch.nn.Linear(hidden_size, num_classes)

    def forward(self, model_input):
        out = None
        with torch.no_grad():
            out = self.relu(self.fc1(model_input))
        out = self.fc2(out)
        return out
```

With this example, ```ORTModule``` is not able to determine which parameters are trainable and which are not. As a work around, users would need to define the model as shown in the very first example (by setting the ```requires_grad``` attribute of parameters.