### PR TITLE
cmake: support install target with generated pkg-config file

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -147,6 +147,9 @@ option(onnxruntime_USE_MPI "Build with MPI support" OFF)
 # Enable bitcode for iOS
 option(onnxruntime_ENABLE_BITCODE "Enable bitcode for iOS only" OFF)
 
+# Single output director for all binaries
+set (RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin CACHE PATH "Single output directory for all binaries.")
+
 function(set_msvc_c_cpp_compiler_warning_level warning_level)
   if (NOT "${warning_level}" MATCHES "^[0-4]$")
     message(FATAL_ERROR "Expected warning_level value of 0-4, got '${warning_level}'.")
@@ -1569,3 +1572,15 @@ if (WINDOWS_STORE)
 endif()
 
 include(flake8.cmake)
+
+if(UNIX)
+  option(BUILD_PKGCONFIG_FILES "Build and install pkg-config files" ON)
+else()
+  option(BUILD_PKGCONFIG_FILES "Build and install pkg-config files" OFF)
+endif()
+if(BUILD_PKGCONFIG_FILES)
+   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libonnxruntime.pc.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/libonnxruntime.pc @ONLY)
+  install( FILES  ${CMAKE_CURRENT_BINARY_DIR}/libonnxruntime.pc DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
+endif()

--- a/cmake/libonnxruntime.pc.cmake.in
+++ b/cmake/libonnxruntime.pc.cmake.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+bindir=${prefix}/@CMAKE_INSTALL_BINDIR@
+mandir=${prefix}/@CMAKE_INSTALL_MANDIR@
+docdir=${prefix}/@CMAKE_INSTALL_DOCDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/@CMAKE_PROJECT_NAME@
+
+Name: @CMAKE_PROJECT_NAME@
+Description: ONNX runtime
+URL: https://github.com/microsoft/@CMAKE_PROJECT_NAME@
+Version: @ORT_VERSION@
+Libs: -L${libdir} -l@CMAKE_PROJECT_NAME@
+Cflags: -I${includedir}


### PR DESCRIPTION
**Description**:

To install onnxruntime on LInux as a library, it is very useful to generate a pkg-config .pc file so that other
libraries can link to onnxruntime. This PR generates such a file.


**Motivation and Context**

I am working on another open source C++ project that will link to ONNX runtime libraries. Currently I have to configure
the location of the onnx runtime build artifacts by hand. This change automates this process, making it easier for other libraries
to use onnx runtime.