### PR TITLE
Fix range loop error while building.

### DIFF
--- a/orttraining/orttraining/test/graph/optimizer_graph_builder_test.cc
+++ b/orttraining/orttraining/test/graph/optimizer_graph_builder_test.cc
@@ -172,7 +172,7 @@ static void TestOptimizerGraphBuilderWithInitialStates(OptimizerGraphConfig conf
     NameMLValMap per_weight_states;
     OrtValue ml_value;
 
-    for (const auto key : MOMENTS_PREFIXES) {
+    for (const auto& key : MOMENTS_PREFIXES) {
       CreateMLValue<float>(TestCPUExecutionProvider()->GetAllocator(0, OrtMemTypeDefault), dims, values, &ml_value);
       per_weight_states.insert(std::make_pair(key, std::move(ml_value)));
     }


### PR DESCRIPTION
I am getting a range-loop-construct warning (which converts to an error) when building using clang-10. This is the error message.

error: loop variable 'key' of type 'const std::__cxx11::basic_string<char>' creates a copy from type 'const std::__cxx11::basic_string<char>' [-Werror,-Wrange-loop-construct]