### PR TITLE
Fix fallback providers for InferenceSession

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -278,7 +278,7 @@ class InferenceSession(Session):
 
         try:
             self._create_inference_session(providers, provider_options)
-        except RuntimeError:
+        except ValueError:
             if self._enable_fallback:
                 print("EP Error using {}".format(providers))
                 print("Falling back to {} and retrying.".format(self._fallback_providers))
@@ -291,16 +291,16 @@ class InferenceSession(Session):
     def _create_inference_session(self, providers, provider_options):
         available_providers = C.get_available_providers()
 
-        # validate providers and provider_options before other initialization
-        providers, provider_options = check_and_normalize_provider_args(providers,
-                                                                        provider_options,
-                                                                        available_providers)
-
         # Tensorrt can fall back to CUDA. All others fall back to CPU.
         if 'TensorrtExecutionProvider' in available_providers:
             self._fallback_providers = ['CUDAExecutionProvider', 'CPUExecutionProvider']
         else:
             self._fallback_providers = ['CPUExecutionProvider']
+
+        # validate providers and provider_options before other initialization
+        providers, provider_options = check_and_normalize_provider_args(providers,
+                                                                        provider_options,
+                                                                        available_providers)
 
         session_options = self._sess_options if self._sess_options else C.get_default_session_options()
         if self._model_path:


### PR DESCRIPTION
Currently a `ValueError` is raised when a provider can't be set to `InferenceSession`, but the exception handling code expects a `RuntimeError` exception to fallback to a default provider

This PR fixes the code to expect a `ValueError` instead