### PR TITLE
MLAS: add 32-bit transpose support

### DIFF
--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -539,6 +539,15 @@ MlasTranspose(
     size_t N
     );
 
+void
+MLASCALL
+MlasTranspose(
+    const float* Input,
+    float* Output,
+    size_t M,
+    size_t N
+    );
+
 //
 // Buffer reordering routines.
 //


### PR DESCRIPTION
**Description**: Add the uint32_t variant of MlasTranspose and wire the Transpose kernel to use that for all operations involving 32-bit sized quantities.