### PR TITLE
Add support for large models

### DIFF
--- a/orttraining/orttraining/core/framework/gradient_graph_builder.h
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.h
@@ -134,7 +134,7 @@ class GradientGraphBuilder {
   NodeSet BFSWithStopGradient(const std::unordered_set<std::string>& x_node_arg_names) const;
 
   /**
-  Perferms a ReverseBFS on the graph with STOP_GRADIENT_EDGES constrain
+  Performs a ReverseBFS on the graph with STOP_GRADIENT_EDGES constrain
   It will skip traversing over the edges defined in STOP_GRADIENT_EDGES map.
   The resulting node set contains all the nodes that are differentiable wrt the input nodes
   @param Starting nodes for ReverseBFS

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -432,7 +432,7 @@ class ORTModule(torch.nn.Module):
         '''
         # User inputs
         non_none_inputs = [inp for inp in inputs if inp is not None]
-        named_buffers_iter = iter(self._original_module.named_buffers())
+        named_buffers_iter = iter(self._flattened_output_module.named_buffers())
         result = []
         for input_idx, name in enumerate(self._onnx_graphs_info.user_input_names):
             inp = None
@@ -442,9 +442,9 @@ class ORTModule(torch.nn.Module):
                 inp = kwargs[name]
             elif input_idx >= len(non_none_inputs):
                 # Registered buffers are translated to user_input+initializer in ONNX
+                # TODO: Check what happens when the number of inputs change form one call to the next
                 buffer_name, inp = next(named_buffers_iter)
-                # `name` contains a `_base_module` prefix from `FlattenedOutputModule`
-                assert buffer_name in name, f'Input name {name} expected, but {buffer_name} found!'
+                assert buffer_name == name, f'Input name {name} expected, but {buffer_name} found!'
 
             if inp is not None:
                 result.append(inp)

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -354,10 +354,6 @@ class ORTModule(torch.nn.Module):
         if self._is_training():
             initializer_names_to_train = [name
                 for name, param in self._flattened_output_module.named_parameters() if param.requires_grad]
-        onnx_initializer_names = {
-            p.name for p in self._onnx_inference.graph.initializer}
-        initializer_names_to_train = [
-            p for p in initializer_names_to_train if p in onnx_initializer_names]
 
         # Build full training graph
         grad_builder_config = C.ModuleGradientGraphBuilderConfiguration()
@@ -492,7 +488,9 @@ class ORTModule(torch.nn.Module):
                                   do_constant_folding=False,
                                   training=torch.onnx.TrainingMode.TRAINING,
                                   dynamic_axes=dynamic_axes,
-                                  verbose=self._verbosity < Verbosity.WARNING)
+                                  verbose=self._verbosity < Verbosity.WARNING,
+                                  export_params=False,
+                                  keep_initializers_as_inputs=True)
         except RuntimeError as e:
             raise RuntimeError(
                 'There was an error while exporting the PyTorch model to ONNX: {}'.format(e))

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_poc.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_poc.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import os
 import torch
 import time
 from torchvision import datasets, transforms


### PR DESCRIPTION
Current implementation exports pytorch models to onnx including initializers, which are moved to input nodes and deleted from initializer list. Because initializers are included, 2GB size limit is easily reached by big models.

This PR exports the model without initializers, allowing large models to be exported and trained