### PR TITLE
Exclude profiler from minimal build

### DIFF
--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -171,7 +171,33 @@ struct PaddingToAvoidFalseSharing {
 4. Note LogStart must pair with either LogEnd or LogEndAndStart, otherwise ORT_ENFORCE will fail;
 5. ThreadPoolProfiler is thread-safe.
 */
-
+#ifdef ORT_MINIMAL_BUILD
+class ThreadPoolProfiler {
+ public:
+  enum ThreadPoolEvent {
+    DISTRIBUTION = 0,
+    DISTRIBUTION_ENQUEUE,
+    RUN,
+    WAIT,
+    WAIT_REVOKE,
+    MAX_EVENT
+  };
+  ThreadPoolProfiler(int, const CHAR_TYPE*){};
+  ~ThreadPoolProfiler() = default;
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(ThreadPoolProfiler);
+  using Clock = std::chrono::high_resolution_clock;
+  void Start(){};
+  std::string Stop() { return "not available for mininum build"; }
+  void LogStart(){};
+  void LogEnd(ThreadPoolEvent){};
+  void LogEndAndStart(ThreadPoolEvent){};
+  void LogStartAndCoreAndBlock(std::ptrdiff_t){};
+  void LogCoreAndBlock(std::ptrdiff_t){};
+  void LogThreadId(int){};
+  void LogRun(int){};
+  std::string DumpChildThreadStat() { return {}; }
+};
+#else
 class ThreadPoolProfiler {
  public:
   enum ThreadPoolEvent {
@@ -224,6 +250,7 @@ class ThreadPoolProfiler {
   std::vector<ChildThreadStat> child_thread_stats_;
   std::string threal_pool_name_;
 };
+#endif
 
 // Extended Eigen thread pool interface, avoiding the need to modify
 // the ThreadPoolInterface.h header from the external Eigen

--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -187,7 +187,7 @@ class ThreadPoolProfiler {
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(ThreadPoolProfiler);
   using Clock = std::chrono::high_resolution_clock;
   void Start(){};
-  std::string Stop() { return "not available for mininum build"; }
+  std::string Stop() { return "not available for minimum build"; }
   void LogStart(){};
   void LogEnd(ThreadPoolEvent){};
   void LogEndAndStart(ThreadPoolEvent){};

--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -247,7 +247,7 @@ class ThreadPoolProfiler {
     PaddingToAvoidFalseSharing padding_; //to prevent false sharing
   };
   std::vector<ChildThreadStat> child_thread_stats_;
-  std::string threal_pool_name_;
+  std::string thread_pool_name_;
 };
 #endif
 

--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -185,9 +185,8 @@ class ThreadPoolProfiler {
   ThreadPoolProfiler(int, const CHAR_TYPE*){};
   ~ThreadPoolProfiler() = default;
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(ThreadPoolProfiler);
-  using Clock = std::chrono::high_resolution_clock;
   void Start(){};
-  std::string Stop() { return "not available for minimum build"; }
+  std::string Stop() { return "not available for minimal build"; }
   void LogStart(){};
   void LogEnd(ThreadPoolEvent){};
   void LogEndAndStart(ThreadPoolEvent){};

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -38,19 +38,19 @@ namespace onnxruntime {
 namespace concurrency {
 
 #if !defined(ORT_MINIMAL_BUILD)
-ThreadPoolProfiler::ThreadPoolProfiler(int num_threads, const CHAR_TYPE* threal_pool_name) : 
+ThreadPoolProfiler::ThreadPoolProfiler(int num_threads, const CHAR_TYPE* thread_pool_name) : 
     num_threads_(num_threads) {
   child_thread_stats_.assign(num_threads, {});
-  if (threal_pool_name) {
+  if (thread_pool_name) {
 #ifdef _WIN32
     using convert_type = std::codecvt_utf8<wchar_t>;
     std::wstring_convert<convert_type, wchar_t> converter;
-    threal_pool_name_ = converter.to_bytes(threal_pool_name);
+    thread_pool_name_ = converter.to_bytes(thread_pool_name);
 #else
-    threal_pool_name_ = threal_pool_name;
+    thread_pool_name_ = thread_pool_name;
 #endif
   } else {
-    threal_pool_name_ = "unnamed_thread_pool";
+    thread_pool_name_ = "unnamed_thread_pool";
   }
 }
 
@@ -75,7 +75,7 @@ std::string ThreadPoolProfiler::Stop() {
   std::stringstream ss;
   ss << "{\"main_thread\": {"
      << "\"thread_pool_name\": \""
-     << threal_pool_name_ << "\", "
+     << thread_pool_name_ << "\", "
      << GetMainThreadStat().Reset()
      << "}, \"sub_threads\": {"
      << DumpChildThreadStat()

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "core/common/eigen_common_wrapper.h"
 #include "core/platform/EigenNonBlockingThreadPool.h"
 #include "core/platform/ort_mutex.h"
+#if !defined(ORT_MINIMAL_BUILD)
 #ifdef _WIN32
 #include "processthreadsapi.h"
 #include <codecvt>
@@ -30,11 +31,13 @@ limitations under the License.
 #else
 #include <sched.h>
 #endif
+#endif
 
 namespace onnxruntime {
 
 namespace concurrency {
 
+#if !defined(ORT_MINIMAL_BUILD)
 ThreadPoolProfiler::ThreadPoolProfiler(int num_threads, const CHAR_TYPE* threal_pool_name) : 
     num_threads_(num_threads) {
   child_thread_stats_.assign(num_threads, {});
@@ -220,6 +223,7 @@ std::string ThreadPoolProfiler::DumpChildThreadStat() {
   }
   return ss.str();
 }
+#endif
 
   // A sharded loop counter distributes loop iterations between a set of worker threads.  The iteration space of
 // the loop is divided (perhaps unevenly) between the shards.  Each thread has a home shard (perhaps not uniquely


### PR DESCRIPTION
Exclude thread pool profiler from minimal build to avoid unnecessary binary size increase.