### PR TITLE
Move TensorRT  Windows CI build to the machine pool

### DIFF
--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: 'build'
-  pool: 'Win-TRT'
+  pool: 'onnxruntime-tensorrt-winbuild'
   variables:
     OrtPackageId: 'Microsoft.ML.OnnxRuntime'
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'


### PR DESCRIPTION
**Description**: 

Move TensorRT  Windows CI build to the machine pool.

This PR is similar to #7050.

**Motivation and Context**
- Why is this change required? What problem does it solve?

To reduce our maintenance cost. 

- If it fixes an open issue, please link to the issue here.
