### PR TITLE
Disable MatmulTransposeFusion for CPU EP

### DIFF
--- a/orttraining/orttraining/core/optimizer/graph_transformer_utils.cc
+++ b/orttraining/orttraining/core/optimizer/graph_transformer_utils.cc
@@ -171,7 +171,7 @@ std::vector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       //transformers.emplace_back(onnxruntime::make_unique<ConstantFolding>(l1_execution_providers));
       transformers.emplace_back(onnxruntime::make_unique<MatMulAddFusion>(l1_execution_providers));
       transformers.emplace_back(onnxruntime::make_unique<FreeDimensionOverrideTransformer>(free_dimension_overrides));
-      transformers.emplace_back(onnxruntime::make_unique<MatmulTransposeFusion>(l1_execution_providers));
+      transformers.emplace_back(onnxruntime::make_unique<MatmulTransposeFusion>(cuda_rocm_execution_providers));
       transformers.emplace_back(onnxruntime::make_unique<BiasDropoutFusion>(cuda_rocm_execution_providers));
       transformers.emplace_back(onnxruntime::make_unique<BiasSoftmaxFusion>(l1_execution_providers));
       transformers.emplace_back(onnxruntime::make_unique<MatMulScaleFusion>(l1_execution_providers, weights_to_train));


### PR DESCRIPTION
**Description**: Disable MatmulTransposeFusion for CPU EP

**Motivation and Context**
- It causes convergence issue in BERT on CPU
- For repro on CPU, please check this [branch](https://github.com/microsoft/onnxruntime/tree/kedeng/bert_cpu)
