### PR TITLE
resize_impl.cu: Change _Round to roundf

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -20,11 +20,11 @@ __device__ int NearestPixel_ROUND_PREFER_FLOOR(float x_original, bool) {
   if (x_original == static_cast<int>(x_original) + 0.5f) {
     return static_cast<int>(_Floor(x_original));
   }
-  return static_cast<int>(_Round(x_original));
+  return static_cast<int>(roundf(x_original));
 }
 
 __device__ int NearestPixel_ROUND_PREFER_CEIL(float x_original, bool) {
-  return static_cast<int>(_Round(x_original));
+  return static_cast<int>(roundf(x_original));
 }
 
 __device__ int NearestPixel_FLOOR(float x_original, bool) {


### PR DESCRIPTION
**Description**: 

Initially, it was "round". But it stopped working after the VS 16.9 update. So I changed it to _Round. However, the _Round function was implemented in a strange way and it added unnecessary complexity. So I will revert it back to roundf. 

I believe the code can be improved further. But I'm not quite familiar with CUDA code so I would like to leave it to Edward/Du or someone else. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
