### PR TITLE
Disable batch size test for AMD CI pipeline after agent upgrade to Rocm 4.1

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-amd-e2e-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-amd-e2e-test-ci-pipeline.yml
@@ -50,13 +50,13 @@ jobs:
       ../../tools/ci_build/github/pai/pai_test_launcher.sh
     displayName: 'Run unit tests'
 
-  - script: |-
-     python orttraining/tools/ci_test/run_batch_size_test.py \
-       --binary_dir build/RelWithDebInfo \
-       --model_root training_e2e_test_data/models \
-       --gpu_sku MI100_32G
-    displayName: 'Run batch size test'
-    condition: succeededOrFailed() # ensure all tests are run
+#  - script: |-
+#     python orttraining/tools/ci_test/run_batch_size_test.py \
+#       --binary_dir build/RelWithDebInfo \
+#       --model_root training_e2e_test_data/models \
+#       --gpu_sku MI100_32G
+#    displayName: 'Run batch size test'
+#    condition: succeededOrFailed() # ensure all tests are run
 
   - script: |-
      python orttraining/tools/ci_test/run_convergence_test.py \

--- a/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
@@ -44,13 +44,13 @@ steps:
     ../../tools/ci_build/github/pai/pai_test_launcher.sh
   displayName: 'Run unit tests'
 
-- script: |-
-    python orttraining/tools/ci_test/run_batch_size_test.py \
-      --binary_dir build/RelWithDebInfo \
-      --model_root training_e2e_test_data/models \
-      --gpu_sku MI100_32G
-  displayName: 'Run batch size test'
-  condition: succeededOrFailed() # ensure all tests are run
+#- script: |-
+#   python orttraining/tools/ci_test/run_batch_size_test.py \
+#      --binary_dir build/RelWithDebInfo \
+#      --model_root training_e2e_test_data/models \
+#     --gpu_sku MI100_32G
+#  displayName: 'Run batch size test'
+#  condition: succeededOrFailed() # ensure all tests are run
 
 - script: |-
     python orttraining/tools/ci_test/run_convergence_test.py \


### PR DESCRIPTION
Disable batch size test for AMD CI pipeline after agent upgrade to Rocm 4.1 until resolved.