### PR TITLE
Support eval mode and torch.no_grad context in ORTModule

### DIFF
--- a/orttraining/orttraining/core/framework/ortmodule_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/ortmodule_graph_builder.cc
@@ -3,7 +3,7 @@
 
 #include "core/graph/graph_utils.h"
 #include "core/providers/cpu/cpu_execution_provider.h"
-#include "orttraining/core/framework/module_gradient_graph_builder.h"
+#include "orttraining/core/framework/ortmodule_graph_builder.h"
 #include "orttraining/core/framework/gradient_graph_builder.h"
 #include "orttraining/core/session/training_session.h"
 #include "orttraining/core/optimizer/graph_transformer_utils.h"
@@ -13,8 +13,8 @@ namespace training {
 
 using namespace onnxruntime::common;
 
-Status ModuleGradientGraphBuilder::Initialize(std::istream& model_istream,
-                                              const ModuleGradientGraphBuilderConfiguration& config) {
+Status OrtModuleGraphBuilder::Initialize(std::istream& model_istream,
+                                         const OrtModuleGraphBuilderConfiguration& config) {
   // Save the model and config.
   ONNX_NAMESPACE::ModelProto model_proto;
   ORT_RETURN_IF_ERROR(Model::Load(model_istream, &model_proto));
@@ -31,27 +31,27 @@ Status ModuleGradientGraphBuilder::Initialize(std::istream& model_istream,
   const std::vector<const NodeArg*>& graph_inputs = graph.GetInputsIncludingInitializers();
   for (auto& node_arg : graph_inputs) {
     if (initializer_names.find(node_arg->Name()) == initializer_names.end()) {
-      training_graph_info_.user_input_names.emplace_back(node_arg->Name());
+      graph_info_.user_input_names.emplace_back(node_arg->Name());
     }
   }
 
   const std::vector<const NodeArg*>& graph_outputs = graph.GetOutputs();
   for (auto& node_arg : graph_outputs) {
-    training_graph_info_.user_output_names.emplace_back(node_arg->Name());
+    graph_info_.user_output_names.emplace_back(node_arg->Name());
   }
 
-  training_graph_info_.initializer_names_to_train.assign(config.initializer_names_to_train.begin(),
+  graph_info_.initializer_names_to_train.assign(config.initializer_names_to_train.begin(),
                                                          config.initializer_names_to_train.end());
-  training_graph_info_.initializer_names.assign(config.initializer_names.begin(),
+  graph_info_.initializer_names.assign(config.initializer_names.begin(),
                                                 config.initializer_names.end());
 
   std::vector<const NodeArg*> input_args;
-  for (const auto& input_name : training_graph_info_.user_input_names) {
+  for (const auto& input_name : graph_info_.user_input_names) {
     input_args.emplace_back(graph.GetNodeArg(input_name));
   }
 
   // Remove all the initializers from the graph and move them to graph inputs.
-  for (const auto& initializer_name : training_graph_info_.initializer_names) {
+  for (const auto& initializer_name : graph_info_.initializer_names) {
     const NodeArg* node_arg = graph.GetNodeArg(initializer_name);
     ORT_ENFORCE(node_arg != nullptr);
     input_args.emplace_back(node_arg);
@@ -62,12 +62,12 @@ Status ModuleGradientGraphBuilder::Initialize(std::istream& model_istream,
   return Status::OK();
 }
 
-// Build the gradient graphs from original graph.
+// Build the inference/gradient graphs from original graph.
 // Since the input shapes may differ, and the graph optimizers (mainly constant folding) may fold this
 // shape info to constants, the optimized graph (before gradient graph building) can not be shared.
 // So each time we need to start from the beginning, i.e., 1) replace input shapes, 2) apply graph optimizers,
 // 3) build gradient graph, and finally 4) adjust the graph inputs and outputs.
-Status ModuleGradientGraphBuilder::Build(const std::vector<std::vector<int64_t>>* input_shapes_ptr) {
+Status OrtModuleGraphBuilder::Build(const std::vector<std::vector<int64_t>>* input_shapes_ptr) {
   // Make a copy of the original model.
   auto model_proto = model_->ToProto();
   ORT_RETURN_IF_ERROR(Model::Load(model_proto, gradient_model_, nullptr, *logger_));
@@ -77,8 +77,16 @@ Status ModuleGradientGraphBuilder::Build(const std::vector<std::vector<int64_t>>
     SetConcreteInputShapes(*input_shapes_ptr);
   }
 
-  // Build the gradient graph.
-  ORT_RETURN_IF_ERROR(BuildGradientGraph());
+  // Optimize the inference graph, and if needed, build the gradient graph.
+  std::unordered_set<std::string> x_node_arg_names;
+  ORT_RETURN_IF_ERROR(OptimizeInferenceGraph(x_node_arg_names));
+  if (!config_.build_gradient_graph) {
+    // This graph will be used only for inferencing, so stop right here.
+    // No need to build a gradient graph.
+    return Status::OK();
+  }
+
+  ORT_RETURN_IF_ERROR(BuildGradientGraph(x_node_arg_names));
 
   // Handle user outputs and output grads.
   HandleOutputsAndGrads();
@@ -89,7 +97,7 @@ Status ModuleGradientGraphBuilder::Build(const std::vector<std::vector<int64_t>>
   return Status::OK();
 }
 
-std::string ModuleGradientGraphBuilder::GetGradientModel() const {
+std::string OrtModuleGraphBuilder::GetModel() const {
   std::string model_str;
   if (!gradient_model_->ToProto().SerializeToString(&model_str)) {
     ORT_THROW("Fail to serialize gradient model to string.");
@@ -97,7 +105,7 @@ std::string ModuleGradientGraphBuilder::GetGradientModel() const {
   return model_str;
 }
 
-std::string ModuleGradientGraphBuilder::GetInferenceOptimizedModel() const {
+std::string OrtModuleGraphBuilder::GetInferenceOptimizedModel() const {
   std::string model_str;
   if (!inference_optimized_model_->ToProto().SerializeToString(&model_str)) {
     ORT_THROW("Fail to serialize inference optimized model to string.");
@@ -105,13 +113,13 @@ std::string ModuleGradientGraphBuilder::GetInferenceOptimizedModel() const {
   return model_str;
 }
 
-void ModuleGradientGraphBuilder::SetConcreteInputShapes(const std::vector<std::vector<int64_t>>& input_shapes) {
-  ORT_ENFORCE(input_shapes.size() == training_graph_info_.user_input_names.size(),
+void OrtModuleGraphBuilder::SetConcreteInputShapes(const std::vector<std::vector<int64_t>>& input_shapes) {
+  ORT_ENFORCE(input_shapes.size() == graph_info_.user_input_names.size(),
               "The size of concrete input shapes and the size of user inputs does not match.");
   Graph& gradient_graph = gradient_model_->MainGraph();
   std::vector<const NodeArg*> input_args;
   size_t input_index = 0;
-  for (const auto& input_name : training_graph_info_.user_input_names) {
+  for (const auto& input_name : graph_info_.user_input_names) {
     NodeArg* input_node_arg = gradient_graph.GetNodeArg(input_name);
     ONNX_NAMESPACE::TensorShapeProto new_shape;
     for (size_t i = 0; i < input_shapes[input_index].size(); i++) {
@@ -132,7 +140,7 @@ void ModuleGradientGraphBuilder::SetConcreteInputShapes(const std::vector<std::v
   gradient_graph.SetInputs(input_args);
 }
 
-Status ModuleGradientGraphBuilder::BuildGradientGraph() {
+Status OrtModuleGraphBuilder::OptimizeInferenceGraph(std::unordered_set<std::string>& x_node_arg_names) {
   // Resolve original graph, register and apply transformers for pre-training.
   Graph& gradient_graph = gradient_model_->MainGraph();
   ORT_RETURN_IF_ERROR(gradient_graph.Resolve());
@@ -142,7 +150,6 @@ Status ModuleGradientGraphBuilder::BuildGradientGraph() {
   std::unique_ptr<CPUExecutionProvider> cpu_execution_provider =
       onnxruntime::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
 
-  std::unordered_set<std::string> x_node_arg_names;
   std::set_union(config_.initializer_names_to_train.begin(), config_.initializer_names_to_train.end(),
                  config_.input_names_require_grad.begin(), config_.input_names_require_grad.end(),
                  std::inserter(x_node_arg_names, x_node_arg_names.begin()));
@@ -169,19 +176,25 @@ Status ModuleGradientGraphBuilder::BuildGradientGraph() {
   // Save a copy of inference optimized model
   ORT_RETURN_IF_ERROR(Model::Load(gradient_model_->ToProto(), inference_optimized_model_, nullptr, *logger_));
 
+  return Status::OK();
+}
+
+Status OrtModuleGraphBuilder::BuildGradientGraph(const std::unordered_set<std::string>& x_node_arg_names) {
+  Graph& gradient_graph = gradient_model_->MainGraph();
+
   // Build gradient graph.
   GradientGraphConfiguration gradient_graph_config{};
   gradient_graph_config.use_invertible_layernorm_grad = config_.use_invertible_layernorm_grad;
   gradient_graph_config.set_gradients_as_graph_outputs = true;
-  std::unordered_set<std::string> y_node_arg_names(training_graph_info_.user_output_names.begin(),
-                                                   training_graph_info_.user_output_names.end());
+  std::unordered_set<std::string> y_node_arg_names(graph_info_.user_output_names.begin(),
+                                                   graph_info_.user_output_names.end());
   GradientGraphBuilder grad_graph_builder(&gradient_graph, y_node_arg_names, x_node_arg_names, "",
                                           gradient_graph_config, *logger_);
 
   const std::unordered_set<std::string>& non_differentiable_output_names = grad_graph_builder.GetNonDifferentiableYNodeArgNames();
-  for (size_t i = 0; i < training_graph_info_.user_output_names.size(); ++i) {
-    if (non_differentiable_output_names.count(training_graph_info_.user_output_names[i]) > 0) {
-      training_graph_info_.output_grad_indices_non_differentiable.emplace_back(i);
+  for (size_t i = 0; i < graph_info_.user_output_names.size(); ++i) {
+    if (non_differentiable_output_names.count(graph_info_.user_output_names[i]) > 0) {
+      graph_info_.output_grad_indices_non_differentiable.emplace_back(i);
     }
   }
 
@@ -189,12 +202,12 @@ Status ModuleGradientGraphBuilder::BuildGradientGraph() {
   return Status::OK();
 }
 
-void ModuleGradientGraphBuilder::HandleOutputsAndGrads() {
+void OrtModuleGraphBuilder::HandleOutputsAndGrads() {
   Graph& gradient_graph = gradient_model_->MainGraph();
   GraphViewer gradient_graph_viewer(gradient_graph);
   const auto& gradient_node_topology_list = gradient_graph_viewer.GetNodesInTopologicalOrder();
   std::unordered_set<std::string> user_output_grad_names_set;
-  for (const auto& name : training_graph_info_.user_output_names) {
+  for (const auto& name : graph_info_.user_output_names) {
     user_output_grad_names_set.insert(GradientBuilderBase::GradientName(name));
   }
 
@@ -226,7 +239,7 @@ void ModuleGradientGraphBuilder::HandleOutputsAndGrads() {
   NodeAttributes attributes{};
 
   // YieldOps non_differentiable_outputs attribute specifies the indices of outputs that are not differentiable
-  const auto& non_differentiable_indices = training_graph_info_.output_grad_indices_non_differentiable;
+  const auto& non_differentiable_indices = graph_info_.output_grad_indices_non_differentiable;
   if (non_differentiable_indices.size() > 0) {
     ONNX_NAMESPACE::AttributeProto non_differentiable_outputs;
     const std::string non_differentiable_outputs_name = "non_differentiable_outputs";
@@ -247,9 +260,9 @@ void ModuleGradientGraphBuilder::HandleOutputsAndGrads() {
 
   std::vector<NodeArg*> yield_input_node_args;
   std::vector<NodeArg*> yield_output_node_args;
-  training_graph_info_.output_grad_indices_require_full_shape.clear();
-  for (size_t i = 0; i < training_graph_info_.user_output_names.size(); i++) {
-    std::string name = training_graph_info_.user_output_names[i];
+  graph_info_.output_grad_indices_require_full_shape.clear();
+  for (size_t i = 0; i < graph_info_.user_output_names.size(); i++) {
+    std::string name = graph_info_.user_output_names[i];
     yield_input_node_args.emplace_back(gradient_graph.GetNodeArg(name));
     std::string grad_name = GradientBuilderBase::GradientName(name);
     if (internal_output_grad_names.find(grad_name) != internal_output_grad_names.end()) {
@@ -258,7 +271,7 @@ void ModuleGradientGraphBuilder::HandleOutputsAndGrads() {
       // If output grad is the direct input of backward graph, we need to materialize it
       // to a all-0 tensor with same shape of output, otherwise, since it will be an input of
       // Add node, it's OK to use scalar-0 tensor to save memory.
-      training_graph_info_.output_grad_indices_require_full_shape.emplace_back(i);
+      graph_info_.output_grad_indices_require_full_shape.emplace_back(i);
       full_shape_outputs.add_ints(static_cast<int64_t>(i));
     }
 
@@ -274,7 +287,7 @@ void ModuleGradientGraphBuilder::HandleOutputsAndGrads() {
                          kMSDomain);
 }
 
-void ModuleGradientGraphBuilder::ReorderOutputs() {
+void OrtModuleGraphBuilder::ReorderOutputs() {
   // Adjust gradient graph outputs by the following order:
   // 1. user input grads if required, with same order of user inputs,
   // 2. trainable initailizer grads, with same order of trainable initializers.
@@ -289,24 +302,24 @@ void ModuleGradientGraphBuilder::ReorderOutputs() {
                                                               config_.input_names_require_grad.end());
 
   std::vector<const NodeArg*> new_output_args;
-  training_graph_info_.user_input_grad_names.clear();
-  for (const auto& input_name : training_graph_info_.user_input_names) {
+  graph_info_.user_input_grad_names.clear();
+  for (const auto& input_name : graph_info_.user_input_names) {
     if (user_input_require_grad_set.find(input_name) != user_input_require_grad_set.end()) {
       std::string input_gradient_name = GradientBuilderBase::GradientName(input_name);
       ORT_ENFORCE(gradient_output_arg_map.find(input_gradient_name) != gradient_output_arg_map.end(),
                   "Required user input grad is not found on gradient graph.");
-      training_graph_info_.user_input_grad_names[input_name] = input_gradient_name;
+      graph_info_.user_input_grad_names[input_name] = input_gradient_name;
       new_output_args.emplace_back(gradient_output_arg_map[input_gradient_name]);
     }
   }
 
   // Add initializer gradients to graph outputs.
-  training_graph_info_.initializer_grad_names_to_train.clear();
-  for (const auto& initializer_name : training_graph_info_.initializer_names_to_train) {
+  graph_info_.initializer_grad_names_to_train.clear();
+  for (const auto& initializer_name : graph_info_.initializer_names_to_train) {
     std::string initializer_gradient_name = GradientBuilderBase::GradientName(initializer_name);
     ORT_ENFORCE(gradient_output_arg_map.find(initializer_gradient_name) != gradient_output_arg_map.end(),
                 "Trainable initializer grad is not found on gradient graph.");
-    training_graph_info_.initializer_grad_names_to_train.emplace_back(initializer_gradient_name);
+    graph_info_.initializer_grad_names_to_train.emplace_back(initializer_gradient_name);
     new_output_args.emplace_back(gradient_output_arg_map[initializer_gradient_name]);
   }
 

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -12,7 +12,7 @@
 #include "orttraining/core/agent/training_agent.h"
 #include "orttraining/core/graph/optimizer_config.h"
 #include "orttraining/core/framework/communication/mpi/mpi_context.h"
-#include "orttraining/core/framework/module_gradient_graph_builder.h"
+#include "orttraining/core/framework/ortmodule_graph_builder.h"
 #include "python/onnxruntime_pybind_mlvalue.h"
 
 namespace onnxruntime {
@@ -497,55 +497,56 @@ py::class_<TrainingAgent>(m, "TrainingAgent", R"pbdoc(This is the main class use
       })
       ;
 
-  py::class_<ModuleGradientGraphBuilderConfiguration> module_gradient_graph_builder_config(
-      m, "ModuleGradientGraphBuilderConfiguration",
-      R"pbdoc(Configuration information for module gradient graph builder.)pbdoc");
-  module_gradient_graph_builder_config.def(py::init())
-      .def_readwrite("initializer_names", &ModuleGradientGraphBuilderConfiguration::initializer_names)
-      .def_readwrite("initializer_names_to_train", &ModuleGradientGraphBuilderConfiguration::initializer_names_to_train)
-      .def_readwrite("input_names_require_grad", &ModuleGradientGraphBuilderConfiguration::input_names_require_grad)
+  py::class_<OrtModuleGraphBuilderConfiguration> module_graph_builder_config(
+      m, "OrtModuleGraphBuilderConfiguration",
+      R"pbdoc(Configuration information for module graph builder.)pbdoc");
+  module_graph_builder_config.def(py::init())
+      .def_readwrite("initializer_names", &OrtModuleGraphBuilderConfiguration::initializer_names)
+      .def_readwrite("initializer_names_to_train", &OrtModuleGraphBuilderConfiguration::initializer_names_to_train)
+      .def_readwrite("input_names_require_grad", &OrtModuleGraphBuilderConfiguration::input_names_require_grad)
       .def_readwrite("use_invertible_layernorm_grad",
-                     &ModuleGradientGraphBuilderConfiguration::use_invertible_layernorm_grad);
+                     &OrtModuleGraphBuilderConfiguration::use_invertible_layernorm_grad)
+      .def_readwrite("build_gradient_graph", &OrtModuleGraphBuilderConfiguration::build_gradient_graph);
 
-  py::class_<TrainingGraphInfo> training_graph_info(m, "TrainingGraphInfo",
-                                                R"pbdoc(The information of split graphs for frontend.)pbdoc");
-  training_graph_info.def(py::init())
-      .def_readwrite("user_input_names", &TrainingGraphInfo::user_input_names)
-      .def_readwrite("user_input_grad_names", &TrainingGraphInfo::user_input_grad_names)
-      .def_readwrite("initializer_names", &TrainingGraphInfo::initializer_names)
-      .def_readwrite("initializer_names_to_train", &TrainingGraphInfo::initializer_names_to_train)
-      .def_readwrite("initializer_grad_names_to_train", &TrainingGraphInfo::initializer_grad_names_to_train)
-      .def_readwrite("user_output_names", &TrainingGraphInfo::user_output_names)
-      .def_readwrite("output_grad_indices_non_differentiable", &TrainingGraphInfo::output_grad_indices_non_differentiable)
-      .def_readwrite("output_grad_indices_require_full_shape", &TrainingGraphInfo::output_grad_indices_require_full_shape);
+  py::class_<GraphInfo> graph_info(m, "GraphInfo",
+                                      R"pbdoc(The information of split graphs for frontend.)pbdoc");
+  graph_info.def(py::init())
+      .def_readwrite("user_input_names", &GraphInfo::user_input_names)
+      .def_readwrite("user_input_grad_names", &GraphInfo::user_input_grad_names)
+      .def_readwrite("initializer_names", &GraphInfo::initializer_names)
+      .def_readwrite("initializer_names_to_train", &GraphInfo::initializer_names_to_train)
+      .def_readwrite("initializer_grad_names_to_train", &GraphInfo::initializer_grad_names_to_train)
+      .def_readwrite("user_output_names", &GraphInfo::user_output_names)
+      .def_readwrite("output_grad_indices_non_differentiable", &GraphInfo::output_grad_indices_non_differentiable)
+      .def_readwrite("output_grad_indices_require_full_shape", &GraphInfo::output_grad_indices_require_full_shape);
 
-  py::class_<ModuleGradientGraphBuilder> module_gradient_graph_builder(m, "ModuleGradientGraphBuilder");
-  module_gradient_graph_builder.def(py::init([]() { return onnxruntime::make_unique<ModuleGradientGraphBuilder>(); }))
+  py::class_<OrtModuleGraphBuilder> ortmodule_graph_builder(m, "OrtModuleGraphBuilder");
+  ortmodule_graph_builder.def(py::init([]() { return onnxruntime::make_unique<OrtModuleGraphBuilder>(); }))
       .def("initialize",
-           [](ModuleGradientGraphBuilder* module_gradient_graph_builder, const py::bytes& serialized_model,
-              const ModuleGradientGraphBuilderConfiguration& config) {
+           [](OrtModuleGraphBuilder* ortmodule_graph_builder, const py::bytes& serialized_model,
+              const OrtModuleGraphBuilderConfiguration& config) {
              std::istringstream buffer(serialized_model);
-             ORT_THROW_IF_ERROR(module_gradient_graph_builder->Initialize(buffer, config));
+             ORT_THROW_IF_ERROR(ortmodule_graph_builder->Initialize(buffer, config));
            })
       .def("build",
-           [](ModuleGradientGraphBuilder* module_gradient_graph_builder) {
-             ORT_THROW_IF_ERROR(module_gradient_graph_builder->Build());
+           [](OrtModuleGraphBuilder* ortmodule_graph_builder) {
+             ORT_THROW_IF_ERROR(ortmodule_graph_builder->Build());
            })
       .def("build",
-           [](ModuleGradientGraphBuilder* module_gradient_graph_builder,
+           [](OrtModuleGraphBuilder* ortmodule_graph_builder,
               const std::vector<std::vector<int64_t>>& input_shapes) {
-             ORT_THROW_IF_ERROR(module_gradient_graph_builder->Build(&input_shapes));
+             ORT_THROW_IF_ERROR(ortmodule_graph_builder->Build(&input_shapes));
            })
-      .def("get_training_model",
-           [](ModuleGradientGraphBuilder* module_gradient_graph_builder) {
-             return py::bytes(module_gradient_graph_builder->GetGradientModel());
+      .def("get_model",
+           [](OrtModuleGraphBuilder* ortmodule_graph_builder) {
+             return py::bytes(ortmodule_graph_builder->GetModel());
            })
       .def("get_inference_optimized_model",
-           [](ModuleGradientGraphBuilder* module_gradient_graph_builder) {
-             return py::bytes(module_gradient_graph_builder->GetInferenceOptimizedModel());
+           [](OrtModuleGraphBuilder* ortmodule_graph_builder) {
+             return py::bytes(ortmodule_graph_builder->GetInferenceOptimizedModel());
            })
-      .def("get_training_graph_info", [](ModuleGradientGraphBuilder* module_gradient_graph_builder) {
-        return module_gradient_graph_builder->GetTrainingGraphInfo();
+      .def("get_graph_info", [](OrtModuleGraphBuilder* ortmodule_graph_builder) {
+        return ortmodule_graph_builder->GetGraphInfo();
       });
 }
 

--- a/orttraining/orttraining/python/training/__init__.py
+++ b/orttraining/orttraining/python/training/__init__.py
@@ -8,6 +8,6 @@ from onnxruntime.capi.training.training_session import TrainingSession
 from .orttrainer_options import ORTTrainerOptions
 from .orttrainer import ORTTrainer, TrainStepInfo
 from . import amp, checkpoint, optim, model_desc_validation
-from .training_agent import TrainingAgent
+from .execution_agent import InferenceAgent, TrainingAgent
 from .ortmodule import ORTModule
 from .runstateinfo import RunStateInfo

--- a/orttraining/orttraining/python/training/_ortmodule_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/_ortmodule_graph_execution_manager.py
@@ -1,0 +1,304 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+from . import _utils, _ortmodule_utils, _ortmodule_output_transformation as _ortmodule_io
+
+from onnxruntime.capi.onnxruntime_inference_collection import OrtValue
+from onnxruntime.capi import _pybind_state as C
+
+from abc import ABC, abstractmethod
+import io
+import inspect
+import onnx
+import onnxruntime
+import torch
+from torch.utils.cpp_extension import ROCM_HOME
+
+ONNX_OPSET_VERSION = 12
+
+def _run_forward(execution_session, onnx_model, device, *inputs, **kwargs):
+    """Runs the forward graph on execution_session with given model inputs and device"""
+
+    # Assert that the input and model device match
+    _ortmodule_utils._check_same_device(
+        device, "Input argument to forward", *inputs)
+
+    # TODO: Try to reuse the output buffers as some of the output tensors are same sizes,
+    #   especially the backward graph outputs.
+    io_binding = execution_session.io_binding()
+    run_options = C.RunOptions()
+
+    # Use IO binding
+    _ortmodule_utils._create_iobinding(io_binding, inputs, onnx_model, device)
+
+    # Run and return module outputs.
+    ort_output = execution_session.run_forward(io_binding, run_options)
+    forward_outputs, run_id = ort_output.ortvalues, ort_output.run_id
+
+    user_outputs = tuple(_ortmodule_utils._ortvalue_to_torch_tensor(
+        forward_output) for forward_output in forward_outputs)
+
+    # Assert that the outputs and model device match
+    _ortmodule_utils._check_same_device(
+        device, "Output argument from forward", *user_outputs)
+
+    output_info = [(output.shape, output.device, output.dtype) for output in user_outputs]
+    run_info = onnxruntime.training.RunStateInfo(run_id, run_options, io_binding, output_info)
+
+    # Return user outputs and forward run information
+    return user_outputs, run_info
+
+class GraphExecutionManager(ABC):
+    def __init__(self, module):
+        """Manages building and execution of onnx graphs
+
+        This class is an abstract class and should not directly be instantiated.
+        Please use one of the concrete implementations of GraphExecutionManager.
+
+        Interacts with OrtModuleGraphBuilder to build and optimize
+        the onnx graph, and ExecutionAgent to run the onnx graph.
+        """
+
+        # Original and flattened (tranformed) output module
+        self._original_module = module._base_module
+        self._flattened_module = module
+
+        # Exported model
+        self._onnx_model = None
+        
+        # Model after inference optimization or gradient building.
+        self._optimized_onnx_model = None
+        self._graph_builder = None
+        self._graph_info = None
+
+        # TrainingAgent or InferenceAgent
+        self._execution_agent = None
+
+        # Debug flags
+        self._save_onnx = False
+        self._save_onnx_prefix = ''
+
+        # Value can be either torch.onnx.TrainingMode.TRAININGor torch.onnx.TrainingMode.EVAL
+        # To be instantiated in the concrete implementation of GraphExecutionManager
+        self._export_mode = None
+
+        # Related to training graph shape inference
+        self._current_input_shape = None
+        # default execution order is priority-based for both dynamic/static shape input for now
+        # if we observe benefit of static shape, we can expose this flag to user
+        self._use_static_shape = False
+        self._input_names_require_grad = None
+        self._module_output_schema = None
+
+        # Verbosity for logging
+        self._verbosity = _ortmodule_utils.Verbosity.WARNING
+
+        # TODO: Single device support for now
+        self._device = _utils.get_device_from_module(module)
+
+        self._module_parameters = inspect.signature(
+            self._original_module.forward).parameters.values()
+
+        # TODO: remove after PyTorch ONNX exporter supports VAR_KEYWORD parameters.
+        for input_parameter in self._module_parameters:
+            if input_parameter.kind == inspect.Parameter.VAR_KEYWORD:
+                raise NotImplementedError(
+                    "The model's forward method has **kwargs parameter which is currently not supported.")
+
+        self.is_rocm_pytorch = (True if (
+            (torch.version.hip is not None) and (ROCM_HOME is not None)) else False)
+
+        self._use_external_gpu_allocator = True
+        if self._use_external_gpu_allocator:
+            # CPP extension to get torch GPU allocator's alloc and free function addresses
+            self._torch_gpu_allocator = _ortmodule_utils._load_torch_gpu_allocator_cpp_extension(self._verbosity,
+                                                                                                 self.is_rocm_pytorch)
+            self._torch_alloc = self._torch_gpu_allocator.gpu_caching_allocator_raw_alloc_address()
+            self._torch_free = self._torch_gpu_allocator.gpu_caching_allocator_raw_delete_address()
+
+    @abstractmethod
+    def forward(self):
+        """Executes the forward method for ORTModule
+
+        This is an abstract method and must be overridden by a concrete implementation.
+        This is the only method that the user should call on a concrete instance of the ExecutionManager
+        All other methods are internal"""
+        pass
+
+    def _build_graph(self):
+        if self._use_static_shape:
+            self._graph_builder.build(
+                self._current_input_shape)
+        else:
+            self._graph_builder.build()
+
+        self._optimized_onnx_model = onnx.load_model_from_string(
+            self._graph_builder.get_model())
+        self._graph_info = \
+            self._graph_builder.get_graph_info()
+
+
+    def _get_session_config(self):
+        """Creates and returns the session configuration to be used for the ExecutionAgent"""
+        providers = None
+        provider_options = None
+        if self._device.type == 'cuda':
+            # Configure the InferenceSessions to use the specific GPU on which the model is placed.
+            providers = (["ROCMExecutionProvider"] if self.is_rocm_pytorch else [
+                         "CUDAExecutionProvider"])
+            providers.append("CPUExecutionProvider")
+            if self._use_external_gpu_allocator:
+                provider_options = [{"device_id": str(self._device.index), "gpu_external_alloc": str(
+                    self._torch_alloc), "gpu_external_free": str(self._torch_free)}, {}]
+            else:
+                provider_options = [{"device_id": str(self._device.index)}, {}]
+        elif self._device.type == 'cpu':
+            providers = ["CPUExecutionProvider"]
+            provider_options = [{}]
+
+        session_options = onnxruntime.SessionOptions()
+        session_options.enable_mem_pattern = False
+        session_options.use_deterministic_compute = False
+        # default to PRIORITY_BASED execution order
+        session_options.execution_order = onnxruntime.ExecutionOrder.PRIORITY_BASED
+        # 0:Verbose, 1:Info, 2:Warning. 3:Error, 4:Fatal. Default is 2.
+        session_options.log_severity_level = int(self._verbosity)
+
+        # enable dumping optimized training graph
+        if self._save_onnx:
+            session_options.optimized_model_filepath = self._save_onnx_prefix + '_training_optimized.onnx'
+
+        return session_options, providers, provider_options
+
+    def _export_model(self, *inputs, **kwargs):
+        # 1. Set the self._device from the user module
+        # 2. Export the user model under self._export_training_flag mode
+        # Return True if the model needed to be exported, False if no export was required.
+        if self._onnx_model:
+            # All required models have already been exported previously
+            return False
+
+        self._set_device_from_module()
+        self._onnx_model = self._get_exported_model(*inputs, **kwargs)
+
+        return True
+
+    def _get_exported_model(self, *inputs, **kwargs):
+        '''Exports PyTorch `self._flattened_module` to ONNX for inferencing or training, using `*inputs` as input
+
+        TODO: How to support dynamic axes? Dimensions are determined by samples
+        '''
+
+        # Setup dynamic axes for onnx model
+        input_names, dynamic_axes, self._input_names_require_grad, _ = \
+            _ortmodule_io.parse_inputs_for_onnx_export(
+                self._module_parameters, None, *inputs, **kwargs)
+        output_names, output_dynamic_axes, self._module_output_schema = \
+            _ortmodule_io.parse_outputs_for_onnx_export_and_extract_output_schema(
+                self._original_module, inputs, kwargs)
+        dynamic_axes.update(output_dynamic_axes)
+
+        # Export torch.nn.Module to ONNX
+        f = io.BytesIO()
+
+        # Deepcopy inputs, since input values may change after model run.
+        # NOTE: Inputs may contain tensors that have attributes preventing their deepcopy (example grad_fn).
+        # Therefore, deepcopy only the data component of the input tensors for export.
+        sample_inputs_copy, sample_kwargs_copy = \
+            _ortmodule_io.deepcopy_model_input(
+                *inputs, **kwargs)
+
+        # Ops behaving differently under train/eval mode need to exported with the
+        # correct training flag to reflect the expected behavior.
+        # For example, the Dropout node in a model is dropped under eval mode.
+        assert self._export_mode is not None, "Please use a concrete instance of ExecutionManager"
+
+        try:
+            with torch.no_grad():
+                torch.onnx.export(self._flattened_module,
+                                  sample_inputs_copy + (sample_kwargs_copy, ),
+                                  f,
+                                  input_names=input_names,
+                                  output_names=output_names,
+                                  opset_version=ONNX_OPSET_VERSION,
+                                  do_constant_folding=False,
+                                  training=self._export_mode,
+                                  dynamic_axes=dynamic_axes,
+                                  verbose=self._verbosity < _ortmodule_utils.Verbosity.WARNING,
+                                  export_params=False,
+                                  keep_initializers_as_inputs=True)
+        except RuntimeError as e:
+            raise RuntimeError(
+                'There was an error while exporting the PyTorch model to ONNX: {}'.format(e))
+
+        return onnx.load_model_from_string(f.getvalue())
+
+    def _set_device_from_module(self):
+        """Get the device from the module and save it to self._device"""
+
+        device_from_module = _utils.get_device_from_module(
+            self._original_module)
+        if not self._device or self._device != device_from_module:
+            self._device = device_from_module
+            if not self._device:
+                raise RuntimeError(
+                    'A device must be specified in the model or data!')
+
+    def _convert_training_graph_input_to_list(self, *inputs, **kwargs):
+        '''Creates forward `*inputs` list from user input and PyTorch initializers
+
+        TODO: How IO binding model inputs and outputs affects initializer copies?
+
+        ONNX Runtime forward requires an ordered list of:
+            * User input: computed from forward InferenceSession
+            * Initializers: computed from original PyTorch model parameters
+        '''
+        # User inputs
+        non_none_inputs = [inp for inp in inputs if inp is not None]
+        named_buffers_iter = iter(self._flattened_module.named_buffers())
+        result = []
+        for input_idx, name in enumerate(self._graph_info.user_input_names):
+            inp = None
+            if input_idx < len(non_none_inputs):
+                inp = non_none_inputs[input_idx]
+            elif name in kwargs and kwargs[name] is not None:
+                inp = kwargs[name]
+            elif input_idx >= len(non_none_inputs):
+                # Registered buffers are translated to user_input+initializer in ONNX
+                # TODO: Check what happens when the number of inputs change form one call to the next
+                buffer_name, inp = next(named_buffers_iter)
+                assert buffer_name == name, f'Input name {name} expected, but {buffer_name} found!'
+
+            if inp is not None:
+                result.append(inp)
+            else:
+                # TODO: Re-export ONNX if any input from onnx_graphs_info.user_input_names is None.
+                raise RuntimeError(
+                    f'Input is present in ONNX graph but not provided: {name}.')
+
+        # Initializers
+        for param in self._flattened_module.named_parameters():
+            result.append(param[1])
+
+        return result
+
+    def _initialize_graph_builder(self, training):
+        """Creates a new OrtModuleGraphBuilder, initializes it and saves it to self._graph_builder"""
+
+        # TODO: PyTorch exporter bug: changes the initializer order in ONNX model
+        initializer_names = [name
+                             for name, _ in self._flattened_module.named_parameters()]
+        initializer_names_to_train = [name
+            for name, param in self._flattened_module.named_parameters() if param.requires_grad]
+
+        # Build and optimize the full graph
+        grad_builder_config = C.OrtModuleGraphBuilderConfiguration()
+        grad_builder_config.initializer_names = initializer_names
+        grad_builder_config.initializer_names_to_train = initializer_names_to_train
+        grad_builder_config.input_names_require_grad = self._input_names_require_grad
+        grad_builder_config.build_gradient_graph = training
+        self._graph_builder = C.OrtModuleGraphBuilder()
+        self._graph_builder.initialize(
+            self._onnx_model.SerializeToString(), grad_builder_config)

--- a/orttraining/orttraining/python/training/_ortmodule_graph_execution_manager_factory.py
+++ b/orttraining/orttraining/python/training/_ortmodule_graph_execution_manager_factory.py
@@ -1,0 +1,18 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+from ._ortmodule_training_manager import TrainingManager
+from ._ortmodule_inference_manager import InferenceManager
+
+class GraphExecutionManagerFactory(object):
+    def __init__(self, module):
+        self._training_manager = TrainingManager(module)
+        self._inference_manager = InferenceManager(module)
+
+    def __call__(self, is_training):
+        if is_training:
+            return self._training_manager
+        else:
+            return self._inference_manager

--- a/orttraining/orttraining/python/training/_ortmodule_inference_manager.py
+++ b/orttraining/orttraining/python/training/_ortmodule_inference_manager.py
@@ -1,0 +1,102 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+from . import _utils, _ortmodule_utils, _ortmodule_output_transformation as _ortmodule_io
+from ._ortmodule_graph_execution_manager import GraphExecutionManager, _run_forward
+
+import onnx
+import onnxruntime
+
+import torch
+
+class InferenceManager(GraphExecutionManager):
+    """Concrete instance of GraphExecutionManager that is able to manage the inference model
+
+    InferenceManager is resposible for building and running the forward graph of the inference model
+    """
+    def __init__(self, model):
+        super().__init__(model)
+
+        self._export_mode = torch.onnx.TrainingMode.EVAL
+
+    def forward(self, *inputs, **kwargs):
+        '''Forward pass of the inference model
+
+        ONNX model is exported the first time this method is executed.
+        Next, we build an optimized inference graph with module_graph_builder.
+        Finally, we instantiate the ONNX Runtime InferenceSession through the InferenceAgent.
+        '''
+
+        # Exporting module to ONNX for the first time
+        # Flag to indicate whether the graph needs to be built
+        # It should be built every time the module graph builder is initialized
+        build_graph = \
+            self._get_exported_model_and_init_graph_builder(
+                *inputs, **kwargs)
+
+        _, _, _, new_input_shape = \
+            _ortmodule_io.parse_inputs_for_onnx_export(
+                self._module_parameters, self._onnx_model, *inputs, **kwargs)
+
+        # Build the inference graph
+        if build_graph:
+            self._current_input_shape = new_input_shape
+            self._build_graph()
+
+        module_device = _utils.get_device_from_module(self._original_module)
+        # The inference session should be created every time
+        # the graph was built or if the device changed between calls to forward
+        create_execution_session = build_graph or self._device != module_device
+        if self._device != module_device:
+            self._device = module_device
+
+        if create_execution_session:
+            # Create execution session creates the inference_session
+            self._create_execution_agent()
+
+        user_outputs, _ = _run_forward(
+            self._execution_agent, self._optimized_onnx_model, self._device,
+            *self._convert_training_graph_input_to_list(*inputs, **kwargs))
+
+        return _ortmodule_io.populate_user_output_from_schema_and_outputs(
+            self._module_output_schema,
+            self._graph_info.user_output_names,
+            user_outputs)
+
+    def _build_graph(self):
+        """Build an optimized inference graph using the module_graph_builder"""
+
+        super()._build_graph()
+
+        if self._save_onnx:
+            onnx.save(self._optimized_onnx_model,
+                      self._save_onnx_prefix + '_inference.onnx')
+
+    def _get_exported_model_and_init_graph_builder(self, *inputs, **kwargs):
+        """Export the pytorch model in inference mode
+
+        Returns True if model was exported and False if it has already been previously exported
+        """
+
+        did_export = self._export_model(*inputs, **kwargs)
+
+        if did_export:
+            # If model was exported, then initialize the graph builder
+            self._initialize_graph_builder(training=False)
+
+            # Save the onnx model if the model was exported
+            if self._save_onnx:
+                onnx.save(self._onnx_model,
+                        self._save_onnx_prefix + '_exported_inference_model.onnx')
+
+        return did_export
+
+    def _create_execution_agent(self):
+        """Creates an InferenceAgent that can run forward graph on an inference model"""
+
+        session_options, providers, provider_options = self._get_session_config()
+        self._execution_agent = onnxruntime.training.InferenceAgent(
+            self._optimized_onnx_model.SerializeToString(),
+            session_options, providers, provider_options)

--- a/orttraining/orttraining/python/training/_ortmodule_training_manager.py
+++ b/orttraining/orttraining/python/training/_ortmodule_training_manager.py
@@ -1,0 +1,226 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+from . import _utils, _ortmodule_utils, _ortmodule_output_transformation as _ortmodule_io
+from ._ortmodule_graph_execution_manager import GraphExecutionManager, _run_forward
+
+import onnx
+import onnxruntime
+
+import torch
+
+class TrainingManager(GraphExecutionManager):
+    """Concrete instance of GraphExecutionManager that is able to manage the training model
+
+    TrainingManager is resposible for building and running the forward and backward graph of the training model
+    """
+    def __init__(self, model):
+        super().__init__(model)
+
+        self._export_mode = torch.onnx.TrainingMode.TRAINING
+
+    def forward(self, *inputs, **kwargs):
+        '''Forward pass starts here and continues at `_ORTModuleFunction.forward`
+
+        ONNX model is exported the first time this method is executed.
+        Next, we build a full training graph with module_graph_builder.
+        Finally, we instantiate the ONNX Runtime InferenceSession.
+        '''
+
+        # Exporting module to ONNX for the first time
+        # Flag to indicate whether the gradient graph needs to be built
+        # It should be built every time the module graph builder is initialized
+        build_gradient_graph = \
+            self._get_exported_model_and_init_graph_builder(
+                *inputs, **kwargs)
+
+        _, _, input_names_require_grad, new_input_shape = \
+            _ortmodule_io.parse_inputs_for_onnx_export(
+                self._module_parameters, self._onnx_model, *inputs, **kwargs)
+        # Reinitialize graph builder if the inputs or initializers requiring gradient have changed.
+        build_gradient_graph = build_gradient_graph or \
+            self._reinitialize_graph_builder(input_names_require_grad)
+
+        # Build the gradient graph
+        if build_gradient_graph:
+            self._current_input_shape = new_input_shape
+            self._build_graph()
+
+        module_device = _utils.get_device_from_module(self._original_module)
+        # The _training_session/_inference_session should be created every time
+        # the graph was built or if the device changed between calls to forward
+        create_execution_session = \
+            build_gradient_graph or self._device != module_device
+        if self._device != module_device:
+            self._device = module_device
+
+        if create_execution_session:
+            # Create execution session creates the training_session
+            self._create_execution_agent()
+
+        class _ORTModuleFunction(torch.autograd.Function):
+            '''Use a custom torch.autograd.Function to associate self.backward_graph as the
+            gradient implementation for self.forward_graph.'''
+
+            @staticmethod
+            def forward(ctx, *inputs, **kwargs):
+                '''Performs forward pass based on user input and PyTorch initializer
+
+                Autograd Function's apply() doesn't support keyword arguments,
+                so `*inputs` has all the arguments - keyword arguments converted
+                to positional by the caller.
+
+                Module outputs are returned to the user
+                '''
+
+                user_outputs, ctx.run_info = _run_forward(self._execution_agent,
+                                                          self._optimized_onnx_model,
+                                                          self._device,
+                                                          *inputs,
+                                                          **kwargs)
+
+                # Disable materializing grads then None object will not be converted to a tensor filled with zeros prior to calling backward.
+                # Also save shape, device and type info to ctx for materializing tensor in backward if output grad is None.
+                ctx.set_materialize_grads(False)
+
+                return user_outputs
+
+            @staticmethod
+            def backward(ctx, *grad_outputs):
+                '''Performs backward pass based on grad wrt module output
+                '''
+                assert ctx.run_info is not None, 'forward() or __call__() methods must be called before backward()'
+
+                # Assert that the grad_outputs and model device match
+                _ortmodule_utils._check_same_device(
+                    self._device, "Input argument to backward", *grad_outputs)
+
+                # Use IO binding
+                # Push user output grads to ONNX backend.
+                contiguous_grad_outputs = []
+                for idx, grad_output in enumerate(grad_outputs):
+                    if idx in self._graph_info.output_grad_indices_non_differentiable:
+                        assert grad_output is None, "ORT found the {}-th module output '{}' is non-differentiable according to the onnx graph. " \
+                                                    "However, the gradient value is still provided by torch's autograd engine." \
+                                                    .format(idx, self._graph_info.user_output_names[idx]) 
+                        continue
+                    
+                    if grad_output is None:
+                        shape, device, dtype = ctx.run_info.output_info[idx]
+                        if idx in self._graph_info.output_grad_indices_require_full_shape:
+                            grad_output = torch.zeros(
+                                shape, device=device, dtype=dtype)
+                        else:
+                            grad_output = torch.tensor(
+                                0., device=device, dtype=dtype)
+                    elif not grad_output.is_contiguous():
+                        grad_output = grad_output.contiguous()
+                    contiguous_grad_outputs.append(grad_output)
+                backward_grad_output_ortvalue = [_ortmodule_utils._ortvalue_from_torch_tensor(
+                    grad_output) for grad_output in contiguous_grad_outputs]
+
+                # Run and get results
+                run_id = ctx.run_info.run_id
+                training_io_binding = ctx.run_info.io_binding
+                self._execution_agent.run_backward(backward_grad_output_ortvalue, run_id)
+                backward_outputs = training_io_binding.get_outputs()
+
+                # Return input and initializer gradients
+                num_user_input_grads = len(self._input_names_require_grad)
+
+                results = []
+                for input_name in self._graph_info.user_input_names:
+                    try:
+                        # Append to the results the backward output for each input that required grad
+                        results.append(_ortmodule_utils._ortvalue_to_torch_tensor(
+                            backward_outputs[self._input_names_require_grad.index(input_name)]))
+                    except ValueError:
+                        # input_name is not found in the self._input_names_require_grad list
+                        # Append None to results for each input that did not require grad
+                        results.append(None)
+
+                # Append gradients of initializer to results
+                # Go over each initializer, check if it required grad and append to results accordingly
+                initializer_names_to_train_set = set(self._graph_info.initializer_names_to_train)
+                initializer_index = num_user_input_grads
+                for initializer_name in self._graph_info.initializer_names:
+                    if initializer_name in initializer_names_to_train_set:
+                        results.append(_ortmodule_utils._ortvalue_to_torch_tensor(backward_outputs[initializer_index]))
+                        initializer_index += 1
+                    else:
+                        results.append(None)
+
+                # The OrtValue has a shared_ptr to the data.
+                # At this point there are two shared_ptrs to the data, one through the
+                # OrtValue in the output iobinding, and the other through the copy in OrtDLManagedTensor.
+                # The following call clears the iobinding output, reducing the use_count to 1, so that once torch finishes computation
+                # on the DLpack tensors, the memory can be freed.
+                training_io_binding.clear_binding_outputs()
+                return tuple(results)
+
+        return _ortmodule_io.populate_user_output_from_schema_and_outputs(
+            self._module_output_schema,
+            self._graph_info.user_output_names,
+            _ORTModuleFunction.apply(*self._convert_training_graph_input_to_list(*inputs, **kwargs)))
+
+    def _build_graph(self):
+        """Build an optimized gradient graph using the module_graph_builder"""
+
+        super()._build_graph()
+
+        if self._save_onnx:
+            onnx.save(self._optimized_onnx_model,
+                      self._save_onnx_prefix + '_training.onnx')
+
+            inference_optimized_model = onnx.load_model_from_string(
+                self._graph_builder.get_inference_optimized_model())
+
+            onnx.save(inference_optimized_model,
+                      self._save_onnx_prefix + '_inference_optimized.onnx')
+
+    def _get_exported_model_and_init_graph_builder(self, *inputs, **kwargs):
+        """Export the pytorch model in training mode
+
+        Returns True if model was exported and False if it has already been previously exported
+        """
+
+        did_export = self._export_model(*inputs, **kwargs)
+
+        if did_export:
+            # If model was exported, then initialize the graph builder
+            self._initialize_graph_builder(training=True)
+
+            # Save the onnx model if the model was exported
+            if self._save_onnx:
+                onnx.save(self._onnx_model,
+                        self._save_onnx_prefix + '_exported_training_model.onnx')
+
+        return did_export
+
+    def _create_execution_agent(self):
+        """Creates a TrainingAgent that can run the forward and backward graph on the training model"""
+
+        session_options, providers, provider_options = self._get_session_config()
+        self._execution_agent = onnxruntime.training.TrainingAgent(self._optimized_onnx_model.SerializeToString(),
+                                                                   session_options, providers, provider_options)
+
+    def _reinitialize_graph_builder(self, input_names_require_grad):
+        """Return true if the module graph builder was reinitialized"""
+
+        initializer_names_to_train_set_user_model = {name for name, param in
+            self._flattened_module.named_parameters() if param.requires_grad}
+        initializer_names_to_train_set_onnx_graph = set(self._graph_info.initializer_names_to_train) \
+            if self._graph_info else None
+
+        # If inputs requiring gradient change from forward to the next, the module_gradient_graph_builder
+        # needs to be reinitialized so it can compute the backward output for the new inputs that require_grad
+        if input_names_require_grad != self._input_names_require_grad or \
+            initializer_names_to_train_set_user_model != initializer_names_to_train_set_onnx_graph:
+            self._input_names_require_grad = input_names_require_grad
+            self._initialize_graph_builder(training=True)
+
+            return True
+
+        return False

--- a/orttraining/orttraining/python/training/_ortmodule_utils.py
+++ b/orttraining/orttraining/python/training/_ortmodule_utils.py
@@ -1,0 +1,72 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+from . import _utils
+
+import onnxruntime
+from onnxruntime.capi.onnxruntime_inference_collection import OrtValue
+from onnxruntime.capi import _pybind_state as C
+
+import torch
+from torch.utils.dlpack import from_dlpack, to_dlpack
+from torch.utils.cpp_extension import load_inline
+
+from enum import IntEnum
+
+class Verbosity(IntEnum):
+    VERBOSE = 0
+    INFO = 1
+    WARNING = 2
+    ERROR = 3
+    FATAL = 4
+
+def _ortvalue_to_torch_tensor(ortvalue):
+    # PyTorch's to_dlpack() uses same config for both torch.bool and torch.uint8,
+    # and convert the config to torch.uint8 tensor duing from_dlpack().
+    # So we need to convert the torch tensor to torch.bool type if OrtValue is bool tensor.
+    torch_tensor = from_dlpack(ortvalue._ortvalue.to_dlpack())
+    return torch_tensor.to(torch.bool) if ortvalue.data_type() == 'tensor(bool)' else torch_tensor
+
+
+def _ortvalue_from_torch_tensor(torch_tensor):
+    return OrtValue(C.OrtValue.from_dlpack(to_dlpack(torch_tensor), torch_tensor.dtype == torch.bool))
+
+def _load_torch_gpu_allocator_cpp_extension(verbosity, is_rocm_pytorch):
+    gpu_identifier = "hip" if is_rocm_pytorch else "cuda"
+    gpu_allocator_header = "HIPCachingAllocator" if is_rocm_pytorch else "CUDACachingAllocator"
+    torch_gpu_allocator_addresses_cpp_source = f"#include <torch/extension.h>\n" \
+    f"#include <c10/{gpu_identifier}/{gpu_allocator_header}.h>\n" \
+    f"size_t gpu_caching_allocator_raw_alloc_address() {{\n" \
+    f"    return reinterpret_cast<size_t>(&c10::{gpu_identifier}::{gpu_allocator_header}::raw_alloc);\n" \
+    f"}}\n" \
+    f"size_t gpu_caching_allocator_raw_delete_address() {{\n" \
+    f"    return reinterpret_cast<size_t>(&c10::{gpu_identifier}::{gpu_allocator_header}::raw_delete);\n" \
+    f"}}\n"
+
+    return load_inline(name='inline_extension', cpp_sources=[torch_gpu_allocator_addresses_cpp_source],
+                       extra_cflags=['-D__HIP_PLATFORM_HCC__=1' if is_rocm_pytorch else ''],
+                       functions=['gpu_caching_allocator_raw_alloc_address',
+                                  'gpu_caching_allocator_raw_delete_address'],
+                       verbose=verbosity < Verbosity.WARNING, with_cuda=True)
+
+def _check_same_device(device, argument_str, *args):
+    '''Check that all tensor arguments in *args reside on the same device as the input device'''
+
+    for arg in args:
+        if arg is not None and isinstance(arg, torch.Tensor):
+            arg_device = torch.device(arg.device)
+            if arg_device != device:
+                raise RuntimeError(
+                    f"{argument_str} found on device {arg_device}, but expected it to be on module device {device}.")
+
+def _create_iobinding(io_binding, inputs, model, device):
+    '''Creates IO binding for a `model` inputs and output'''
+    for idx, value_info in enumerate(model.graph.input):
+        io_binding.bind_ortvalue_input(
+            value_info.name, _ortvalue_from_torch_tensor(inputs[idx]))
+
+    for value_info in model.graph.output:
+        io_binding.bind_output(value_info.name, device.type,
+                               device_id=_utils.get_device_index(device))

--- a/orttraining/orttraining/python/training/execution_agent.py
+++ b/orttraining/orttraining/python/training/execution_agent.py
@@ -9,9 +9,72 @@ from onnxruntime.capi.onnxruntime_inference_collection import IOBinding, OrtValu
 from onnxruntime.capi._pybind_state import TrainingAgent as C_TrainingAgent
 
 
+class ExecutionAgentOutput(object):
+    def __init__(self, ortvalues, run_id=None):
+        self.ortvalues = ortvalues
+        self.run_id = run_id
+
+
+class InferenceAgent(object):
+    """
+    This is the main class used to run an ORTModule model inferencing.
+    """
+
+    def __init__(self, path_or_bytes, session_options=None, providers=None, provider_options=None):
+        """
+        :param path_or_bytes: filename or serialized ONNX or ORT format model in a byte string
+        :param sess_options: session options
+        :param providers: Optional sequence of providers in order of decreasing
+            precedence. Values can either be provider names or tuples of
+            (provider name, options dict). If not provided, then all available
+            providers are used with the default precedence.
+        :param provider_options: Optional sequence of options dicts corresponding
+            to the providers listed in 'providers'.
+
+        The model type will be inferred unless explicitly set in the SessionOptions.
+        To explicitly set:
+          so = onnxruntime.SessionOptions()
+          so.add_session_config_entry('session.load_model_format', 'ONNX') or
+          so.add_session_config_entry('session.load_model_format', 'ORT') or
+
+        A file extension of '.ort' will be inferred as an ORT format model.
+        All other filenames are assumed to be ONNX format models.
+
+        'providers' can contain either names or names and options. When any options
+        are given in 'providers', 'provider_options' should not be used.
+
+        The list of providers is ordered by precedence. For example ['CUDAExecutionProvider', 'CPUExecutionProvider']
+        means execute a node using CUDAExecutionProvider if capable, otherwise execute using CPUExecutionProvider.
+        """
+
+        self._inference_session = None
+
+        self.create_inference_agent(path_or_bytes, session_options, providers, provider_options)
+
+    def create_inference_agent(self, path_or_bytes, session_options, providers, provider_options):
+        self._inference_session = onnxruntime.InferenceSession(path_or_bytes, session_options,
+                                                               providers, provider_options)
+
+    def io_binding(self):
+        """Return an onnxruntime.IOBinding object`."""
+
+        return IOBinding(self._inference_session)
+
+    def run_forward(self, iobinding, run_options):
+        """
+         Compute the forward graph.
+         :param iobinding: the iobinding object that has graph inputs/outputs bind.
+         :param run_options: See :class:`onnxruntime.RunOptions`.
+        """
+
+        self._inference_session.run_with_iobinding(iobinding, run_options)
+        ortvalues = iobinding.get_outputs()
+        return ExecutionAgentOutput(ortvalues)
+
+
 class TrainingAgent(object):
     """
-    This is the main class used to run a ORTModule model.
+    This is the main class used to run an ORTModule model training.
     """
 
     def __init__(self, path_or_bytes, session_options=None, providers=None, provider_options=None):
@@ -46,14 +109,14 @@ class TrainingAgent(object):
 
         self.create_training_agent(path_or_bytes, session_options, providers, provider_options)
 
-
     def create_training_agent(self, path_or_bytes, session_options, providers, provider_options):
         self._inference_session = onnxruntime.InferenceSession(path_or_bytes, session_options,
                                                                providers, provider_options)
         self._training_agent = C_TrainingAgent(self._inference_session._sess)
 
     def io_binding(self):
-        "Return an onnxruntime.IOBinding object`."
+        """Return an onnxruntime.IOBinding object`."""
+
         return IOBinding(self._inference_session)
 
     def run_forward(self, iobinding, run_options):
@@ -62,12 +125,15 @@ class TrainingAgent(object):
          :param iobinding: the iobinding object that has graph inputs/outputs bind.
          :param run_options: See :class:`onnxruntime.RunOptions`.
         """
+
         ortvalues, run_id = self._training_agent.run_forward(iobinding._iobinding, run_options)
-        return [OrtValue(ortvalue) for ortvalue in ortvalues], run_id
+        ortvalues = [OrtValue(ortvalue) for ortvalue in ortvalues]
+        return ExecutionAgentOutput(ortvalues, run_id)
 
     def run_backward(self, backward_output_grads, run_id):
         """
          Resume executing the backward subgraph starting from Yield Op.
          :param backward_output_grads: Output gradients for backward.
         """
+
         self._training_agent.run_backward([ortvalue._ortvalue for ortvalue in backward_output_grads], run_id)

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -3,94 +3,42 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-from . import _utils
 from . import _ortmodule_output_transformation as _ortmodule_io
+from ._ortmodule_graph_execution_manager_factory import GraphExecutionManagerFactory
+
 from onnxruntime.training import register_custom_ops_pytorch_exporter
-from onnxruntime.capi.onnxruntime_inference_collection import OrtValue
-from onnxruntime.capi import _pybind_state as C
 
 import functools
-import io
-import logging
-import onnx
-import onnxruntime
 import torch
-import inspect
-from inspect import signature
-from enum import IntEnum
-from typing import Iterator, Optional, Tuple
-
-from torch.utils.dlpack import from_dlpack, to_dlpack
-from torch.utils.cpp_extension import load_inline
+from typing import Iterator, Optional, Tuple, TypeVar
 
 # Needed to override PyTorch methods
-from typing import TypeVar
 T = TypeVar('T', bound='Module')
 
-
-ONNX_OPSET_VERSION = 12
-
-
-def _ortvalue_to_torch_tensor(ortvalue):
-    # PyTorch's to_dlpack() uses same config for both torch.bool and torch.uint8,
-    # and convert the config to torch.uint8 tensor duing from_dlpack().
-    # So we need to convert the torch tensor to torch.bool type if OrtValue is bool tensor.
-    torch_tensor = from_dlpack(ortvalue._ortvalue.to_dlpack())
-    return torch_tensor.to(torch.bool) if ortvalue.data_type() == 'tensor(bool)' else torch_tensor
-
-
-def _ortvalue_from_torch_tensor(torch_tensor):
-    return OrtValue(C.OrtValue.from_dlpack(to_dlpack(torch_tensor), torch_tensor.dtype == torch.bool))
-
-
-class Verbosity(IntEnum):
-    VERBOSE = 0
-    INFO = 1
-    WARNING = 2
-    ERROR = 3
-    FATAL = 4
-
-def _create_iobinding(io_binding, inputs, model, device):
-    '''Creates IO binding for a `model` inputs and output'''
-    for idx, value_info in enumerate(model.graph.input):
-        io_binding.bind_ortvalue_input(
-            value_info.name, _ortvalue_from_torch_tensor(inputs[idx]))
-
-    for value_info in model.graph.output:
-        io_binding.bind_output(value_info.name, device.type,
-                               device_id=_utils.get_device_index(device))
-
-
-def _check_same_device(device, argument_str, *args):
-    '''Check that all tensor arguments in *args reside on the same device as the input device'''
-
-    for arg in args:
-        if arg is not None and isinstance(arg, torch.Tensor):
-            arg_device = torch.device(arg.device)
-            if arg_device != device:
-                raise RuntimeError(
-                    f"{argument_str} found on device {arg_device}, but expected it to be on module device {device}.")
-
-def _load_torch_gpu_allocator_cpp_extension(verbosity, is_rocm_pytorch):
-    gpu_identifier = "hip" if is_rocm_pytorch else "cuda"
-    gpu_allocator_header = "HIPCachingAllocator" if is_rocm_pytorch else "CUDACachingAllocator"
-    torch_gpu_allocator_addresses_cpp_source = f"#include <torch/extension.h>\n" \
-    f"#include <c10/{gpu_identifier}/{gpu_allocator_header}.h>\n" \
-    f"size_t gpu_caching_allocator_raw_alloc_address() {{\n" \
-    f"    return reinterpret_cast<size_t>(&c10::{gpu_identifier}::{gpu_allocator_header}::raw_alloc);\n" \
-    f"}}\n" \
-    f"size_t gpu_caching_allocator_raw_delete_address() {{\n" \
-    f"    return reinterpret_cast<size_t>(&c10::{gpu_identifier}::{gpu_allocator_header}::raw_delete);\n" \
-    f"}}\n"
-
-    return load_inline(name='inline_extension', cpp_sources=[torch_gpu_allocator_addresses_cpp_source],
-                       extra_cflags=['-D__HIP_PLATFORM_HCC__=1' if is_rocm_pytorch else ''],
-                       functions=['gpu_caching_allocator_raw_alloc_address',
-                                  'gpu_caching_allocator_raw_delete_address'],
-                       verbose=verbosity < Verbosity.WARNING, with_cuda=True)
-
-
 class ORTModule(torch.nn.Module):
+    """Specializes a user torch.nn.Module to leverage ONNX Runtime graph execution.
+
+    ORTModule specializes the user's torch.nn.Module and provides forward, backward
+    implementations be leveraging ONNX Runtime.
+
+    ORTModule interacts with:
+    - GraphExecutionManagerFactory: Which returns a GraphExecutionManager based on
+    whether or not the user's torch module is in training mode or eval mode.
+    - GraphExecutionManager: Responsible for building and executing the forward and backward graphs.
+        - InferenceManager(GraphExecutionManager): Responsible for building, optimizing
+        and executing the inference onnx graph.
+        - TrainingManager(GraphExecutionManager): Responsible for building, optimizing
+        and executing the training onnx graph.
+
+        The GraphExecutionManager first exports the user model into an onnx model.
+        Following that, GraphExecutionManager interacts with OrtModuleGraphBuilder to optimize the onnx graph.
+        Once the onnx graph has been optimized, an ExecutionAgent is instantiated that
+        facilitates in executing the forward and backward subgraphs of the onnx model.
+
+    - _ortmodule_io: Provides utilities to transform the user inputs and outputs of the model.
+        - It facilitates in flattening the output from the user's PyTorch model (since exporting
+        of nested structures is not supported at the moment)
+    """
 
     def __init__(self, module):
         assert isinstance(
@@ -106,174 +54,8 @@ class ORTModule(torch.nn.Module):
             Next, we build a full training graph with module_gradient_graph_builder.
             Finally, we instantiate the ONNX Runtime InferenceSession.
             '''
-            # TODO: using pytorch for evaluation for now. We will use ORT for evaluation later.
-            # TODO: If the model is being executed with the gradient disabled (inside torch.no_grad() context for example),
-            # leverage pytorch model for now.
-            if not self._is_training():
-                return self._original_module(*inputs, **kwargs)
 
-            # Exporting module to ONNX for the first time
-            if not self._onnx_training:
-                device_from_module = _utils.get_device_from_module(
-                    self._original_module)
-                if not self._device or self._device != device_from_module:
-                    self._device = device_from_module
-                    if not self._device:
-                        raise RuntimeError(
-                            'A device must be specified in the model or data!')
-                self._get_inference_graph_and_init_gradient_graph_builder(
-                    *inputs, **kwargs)
-
-            # Flag to indicate whether the gradient_graph needs to be built
-            build_gradient_graph = self._current_input_shape is None
-            _, _, input_names_require_grad, new_input_shape = \
-                _ortmodule_io.parse_inputs_for_onnx_export(
-                    self._original_module_parameters, self._onnx_inference, *inputs, **kwargs)
-            initializer_names_to_train_set_user_model = {name for name, param in
-                self._flattened_output_module.named_parameters() if param.requires_grad}
-            initializer_names_to_train_set_onnx_graph = set(self._onnx_graphs_info.initializer_names_to_train) \
-                if self._onnx_graphs_info else None
-            # If inputs requiring gradient change from forward to the next, the module_gradient_graph_builder
-            # needs to be reinitialized so it can compute the backward output for the new inputs that require_grad
-            if input_names_require_grad != self._input_names_require_grad or \
-                initializer_names_to_train_set_user_model != initializer_names_to_train_set_onnx_graph:
-                self._input_names_require_grad = input_names_require_grad
-                self._initialize_module_gradient_graph_builder()
-                # Trigger the rebuilding of the gradient graph
-                build_gradient_graph = True
-
-            if build_gradient_graph:
-                self._current_input_shape = new_input_shape
-                self._build_training_graph()
-                self._create_training_session()
-
-            module_device = _utils.get_device_from_module(
-                self._original_module)
-            if self._device != module_device:
-                self._device = module_device
-                self._create_training_session()
-
-            class _ORTModuleFunction(torch.autograd.Function):
-                '''Use a custom torch.autograd.Function to associate self.backward_graph as the
-                gradient implementation for self.forward_graph.'''
-
-                @staticmethod
-                def forward(ctx, *inputs, **kwargs):
-                    '''Performs forward pass based on user input and PyTorch initializer
-
-                    Autograd Function's apply() doesn't support keyword arguments,
-                    so `*inputs` has all the arguments - keyword arguments converted
-                    to positional by the caller.
-
-                    Module outputs are returned to the user
-                    '''
-
-                    # Assert that the input and model device match
-                    _check_same_device(
-                        self._device, "Input argument to forward", *inputs)
-
-                    # TODO: Try to reuse the output buffers as some of the output tensors are same sizes,
-                    #   especially the backward graph outputs.
-                    training_io_binding = self._training_session.io_binding()
-                    run_options = C.RunOptions()
-                    
-                    # Use IO binding
-                    _create_iobinding(training_io_binding, inputs, self._onnx_training, self._device)
-
-                    # Run and return module outputs.
-                    forward_outputs, run_id = self._training_session.run_forward(training_io_binding, run_options)
-                    user_outputs = tuple(_ortvalue_to_torch_tensor(
-                        forward_output) for forward_output in forward_outputs)
-                    # Disable materializing grads then None object will not be converted to a tensor filled with zeros prior to calling backward.
-                    # Also save shape, device and type info to ctx for materializing tensor in backward if output grad is None.
-                    ctx.set_materialize_grads(False)
-                    output_info = [(output.shape, output.device, output.dtype) for output in user_outputs]
-                    ctx.run_info = onnxruntime.training.RunStateInfo(run_id, run_options, training_io_binding, output_info)
-
-                    # Assert that the outputs and model device match
-                    _check_same_device(
-                        self._device, "Output argument from forward", *user_outputs)
-
-                    return user_outputs
-
-                @staticmethod
-                def backward(ctx, *grad_outputs):
-                    '''Performs backward pass based on grad wrt module output
-                    '''
-                    assert ctx.run_info is not None, 'forward() or __call__() methods must be called before backward()'
-
-                    # Assert that the grad_outputs and model device match
-                    _check_same_device(
-                        self._device, "Input argument to backward", *grad_outputs)
-
-                    # Use IO binding
-                    # Push user output grads to ONNX backend.
-                    contiguous_grad_outputs = []
-                    for idx, grad_output in enumerate(grad_outputs):
-                        if idx in self._onnx_graphs_info.output_grad_indices_non_differentiable:
-                            assert grad_output is None, "ORT found the {}-th module output '{}' is non-differentiable according to the onnx graph. " \
-                                                        "However, the gradient value is still provided by torch's autograd engine." \
-                                                        .format(idx, self._onnx_graphs_info.user_output_names[idx]) 
-                            continue
-                        
-                        if grad_output is None:
-                            shape, device, dtype = ctx.run_info.output_info[idx]
-                            if idx in self._onnx_graphs_info.output_grad_indices_require_full_shape:
-                                grad_output = torch.zeros(
-                                    shape, device=device, dtype=dtype)
-                            else:
-                                grad_output = torch.tensor(
-                                    0., device=device, dtype=dtype)
-                        elif not grad_output.is_contiguous():
-                            grad_output = grad_output.contiguous()
-                        contiguous_grad_outputs.append(grad_output)
-                    backward_grad_output_ortvalue = [_ortvalue_from_torch_tensor(
-                        grad_output) for grad_output in contiguous_grad_outputs]
-
-                    # Run and get results
-                    run_id = ctx.run_info.run_id
-                    training_io_binding = ctx.run_info.io_binding
-                    self._training_session.run_backward(backward_grad_output_ortvalue, run_id)
-                    backward_outputs = training_io_binding.get_outputs()
-
-                    # Return input and initializer gradients
-                    num_user_input_grads = len(self._input_names_require_grad)
-
-                    results = []
-                    for input_name in self._onnx_graphs_info.user_input_names:
-                        try:
-                            # Append to the results the backward output for each input that required grad
-                            results.append(_ortvalue_to_torch_tensor(
-                                backward_outputs[self._input_names_require_grad.index(input_name)]))
-                        except ValueError:
-                            # input_name is not found in the self._input_names_require_grad list
-                            # Append None to results for each input that did not require grad
-                            results.append(None)
-
-                    # Append gradients of initializer to results
-                    # Go over each initializer, check if it required grad and append to results accordingly
-                    initializer_names_to_train_set = set(self._onnx_graphs_info.initializer_names_to_train) \
-                        if self._onnx_graphs_info else None
-                    initializer_index = num_user_input_grads
-                    for initializer_name in self._onnx_graphs_info.initializer_names:
-                        if initializer_name in initializer_names_to_train_set:
-                            results.append(_ortvalue_to_torch_tensor(backward_outputs[initializer_index]))
-                            initializer_index += 1
-                        else:
-                            results.append(None)
-
-                    # The OrtValue has a shared_ptr to the data.
-                    # At this point there are two shared_ptrs to the data, one through the
-                    # OrtValue in the output iobinding, and the other through the copy in OrtDLManagedTensor.
-                    # The following call clears the iobinding output, reducing the use_count to 1, so that once torch finishes computation
-                    # on the DLpack tensors, the memory can be freed.
-                    training_io_binding.clear_binding_outputs()
-                    return tuple(results)
-
-            return _ortmodule_io.populate_user_output_from_schema_and_outputs(
-                self._original_module_output_schema,
-                self._onnx_graphs_info.user_output_names,
-                _ORTModuleFunction.apply(*self._convert_training_graph_input_to_list(*inputs, **kwargs)))
+            return self._execution_manager(self._is_training()).forward(*inputs, **kwargs)
 
         # Bind the forward method.
         self.forward = _forward.__get__(self)
@@ -283,226 +65,25 @@ class ORTModule(torch.nn.Module):
 
         super(ORTModule, self).__init__()
 
-        # Verbosity for logging
-        self._verbosity = Verbosity.WARNING
-
         # Support contrib OPs
         register_custom_ops_pytorch_exporter.register_custom_op()
-
-        # TODO: Single device support for now
-        self._device = _utils.get_device_from_module(module)
 
         # User module is wrapped to use its initializers and save computed gradients
         self._original_module = module
         # Get the module that flattens the output from the original module into a tuple
         self._flattened_output_module = \
-            _ortmodule_io.get_flattened_output_module(
-                self._original_module)
-        self._original_module_parameters = signature(
-            self._original_module.forward).parameters.values()
+            _ortmodule_io.get_flattened_output_module(self._original_module)
 
-        # TODO: remove after PyTorch ONNX exporter supports VAR_KEYWORD parameters.
-        for input_parameter in self._original_module_parameters:
-            if input_parameter.kind == inspect.Parameter.VAR_KEYWORD:
-                raise NotImplementedError(
-                    "The model's forward method has **kwargs parameter which is currently not supported.")
-
-        self._onnx_inference = None
-
-        # Related to training graph shape inference
-        self._current_input_shape = None
-        # default execution order is priority-based for both dynamic/static shape input for now
-        # if we observe benefit of static shape, we can expose this flag to user
-        self._use_static_shape = False
-        self._module_gradient_graph_builder = None
-        self._input_names_require_grad = None
-        self._original_module_output_schema = None
-        self._onnx_graphs_info = None
-
-        # Training model
-        self._onnx_training = None
-        self._training_session = None
-
-        # Log level
-        self._loglevel = getattr(logging, 'WARNING')
-
-        # Debug flags
-        self._save_onnx = False
-        self._save_onnx_prefix = ''
-
-        from torch.utils.cpp_extension import ROCM_HOME
-        self.is_rocm_pytorch = (True if (
-            (torch.version.hip is not None) and (ROCM_HOME is not None)) else False)
-
-        self._use_external_gpu_allocator = True
-        if self._use_external_gpu_allocator:
-            # CPP extension to get torch GPU allocator's alloc and free function addresses
-            self._torch_gpu_allocator = _load_torch_gpu_allocator_cpp_extension(self._verbosity, self.is_rocm_pytorch)
-            self._torch_alloc = self._torch_gpu_allocator.gpu_caching_allocator_raw_alloc_address()
-            self._torch_free = self._torch_gpu_allocator.gpu_caching_allocator_raw_delete_address()
+        self._execution_manager = GraphExecutionManagerFactory(self._flattened_output_module)
 
     def _is_training(self):
         return self._flattened_output_module.training and torch.is_grad_enabled()
-
-    def _initialize_module_gradient_graph_builder(self):
-        # TODO: PyTorch exporter bug: changes the initializer order in ONNX model
-        initializer_names = [name
-                             for name, _ in self._flattened_output_module.named_parameters()]
-        initializer_names_to_train = []
-        if self._is_training():
-            initializer_names_to_train = [name
-                for name, param in self._flattened_output_module.named_parameters() if param.requires_grad]
-
-        # Build full training graph
-        grad_builder_config = C.ModuleGradientGraphBuilderConfiguration()
-        grad_builder_config.initializer_names = initializer_names
-        grad_builder_config.initializer_names_to_train = initializer_names_to_train
-        grad_builder_config.input_names_require_grad = self._input_names_require_grad
-        self._module_gradient_graph_builder = C.ModuleGradientGraphBuilder()
-        self._module_gradient_graph_builder.initialize(
-            self._onnx_inference.SerializeToString(), grad_builder_config)
-
-    def _get_inference_graph_and_init_gradient_graph_builder(self, *inputs, **kwargs):
-        self._onnx_inference = self._get_inference_graph(*inputs, **kwargs)
-        if self._save_onnx:
-            onnx.save(self._onnx_inference, self._save_onnx_prefix + '_inference.onnx')
-        self._initialize_module_gradient_graph_builder()
-
-    def _create_training_session(self):
-        providers = None
-        provider_options = None
-        if self._device.type == 'cuda':
-            # Configure the InferenceSessions to use the specific GPU on which the model is placed.
-            providers = (["ROCMExecutionProvider"] if self.is_rocm_pytorch else [
-                         "CUDAExecutionProvider"])
-            providers.append("CPUExecutionProvider")
-            if self._use_external_gpu_allocator:
-                provider_options = [{"device_id": str(self._device.index), "gpu_external_alloc": str(
-                    self._torch_alloc), "gpu_external_free": str(self._torch_free)}, {}]
-            else:
-                provider_options = [{"device_id": str(self._device.index)}, {}]
-        elif self._device.type == 'cpu':
-            providers = ["CPUExecutionProvider"]
-            provider_options = [{}]
-
-        session_options = onnxruntime.SessionOptions()
-        session_options.enable_mem_pattern = False
-        session_options.use_deterministic_compute = False
-        # default to PRIORITY_BASED execution order
-        session_options.execution_order = onnxruntime.ExecutionOrder.PRIORITY_BASED
-        # 0:Verbose, 1:Info, 2:Warning. 3:Error, 4:Fatal. Default is 2.
-        session_options.log_severity_level = int(self._verbosity)
-        # enable dumping optimized training graph
-        if self._save_onnx:
-            session_options.optimized_model_filepath = self._save_onnx_prefix + '_training_optimized.onnx'
-
-        self._training_session = onnxruntime.training.TrainingAgent(self._onnx_training.SerializeToString(),
-                                                                    session_options, providers, provider_options)
-
-    def _build_training_graph(self, *inputs, **kwargs):
-        if self._use_static_shape:
-            self._module_gradient_graph_builder.build(
-                self._current_input_shape)
-        else:
-            self._module_gradient_graph_builder.build()
-        self._onnx_training = onnx.load_model_from_string(
-            self._module_gradient_graph_builder.get_training_model())
-        self._onnx_graphs_info = self._module_gradient_graph_builder.get_training_graph_info()
-
-        if self._save_onnx:
-            inference_optimized_model = onnx.load_model_from_string(
-                self._module_gradient_graph_builder.get_inference_optimized_model())
-            onnx.save(inference_optimized_model, self._save_onnx_prefix + '_inference_optimized.onnx')
-            onnx.save(self._onnx_training, self._save_onnx_prefix + '_training.onnx')
 
     def eval(self: T) -> T:
         self._flattened_output_module.eval()
 
     def train(self: T, mode: bool = True) -> T:
         self._flattened_output_module.train(mode)
-
-    def _convert_training_graph_input_to_list(self, *inputs, **kwargs):
-        '''Creates forward `*inputs` list from user input and PyTorch initializers
-
-        TODO: How IO binding model inputs and outputs affects initializer copies?
-
-        ONNX Runtime forward requires an ordered list of:
-            * User input: computed from forward InferenceSession
-            * Initializers: computed from original PyTorch model parameters
-        '''
-        # User inputs
-        non_none_inputs = [inp for inp in inputs if inp is not None]
-        named_buffers_iter = iter(self._flattened_output_module.named_buffers())
-        result = []
-        for input_idx, name in enumerate(self._onnx_graphs_info.user_input_names):
-            inp = None
-            if input_idx < len(non_none_inputs):
-                inp = non_none_inputs[input_idx]
-            elif name in kwargs and kwargs[name] is not None:
-                inp = kwargs[name]
-            elif input_idx >= len(non_none_inputs):
-                # Registered buffers are translated to user_input+initializer in ONNX
-                # TODO: Check what happens when the number of inputs change form one call to the next
-                buffer_name, inp = next(named_buffers_iter)
-                assert buffer_name == name, f'Input name {name} expected, but {buffer_name} found!'
-
-            if inp is not None:
-                result.append(inp)
-            else:
-                # TODO: Re-export ONNX if any input from _onnx_graphs_info.user_input_names is None.
-                raise RuntimeError(
-                    f'Input is present in ONNX graph but not provided: {name}.')
-
-        # Initializers
-        for param in self._flattened_output_module.named_parameters():
-            result.append(param[1])
-
-        return result
-
-    def _get_inference_graph(self, *inputs, **kwargs):
-        '''Exports PyTorch `module` to ONNX with training flag, using `*inputs` as input
-
-        TODO: How to support dynamic axes? Dimensions are determined by samples
-        '''
-
-        # Setup dynamic axes for onnx model
-        input_names, dynamic_axes, self._input_names_require_grad, _ = \
-            _ortmodule_io.parse_inputs_for_onnx_export(
-                self._original_module_parameters, None, *inputs, **kwargs)
-        output_names, output_dynamic_axes, self._original_module_output_schema = \
-            _ortmodule_io.parse_outputs_for_onnx_export_and_extract_output_schema(
-                self._original_module, inputs, kwargs)
-        dynamic_axes.update(output_dynamic_axes)
-
-        # Export torch.nn.Module to ONNX
-        f = io.BytesIO()
-
-        # Deepcopy inputs, since input values may change after model run.
-        # NOTE: Inputs may contain tensors that have attributes preventing their deepcopy (example grad_fn).
-        # Therefore, deepcopy only the data component of the input tensors for export.
-        sample_inputs_copy, sample_kwargs_copy = \
-            _ortmodule_io.deepcopy_model_input(
-                *inputs, **kwargs)
-
-        try:
-            with torch.no_grad():
-                torch.onnx.export(self._flattened_output_module,
-                                  sample_inputs_copy + (sample_kwargs_copy, ),
-                                  f,
-                                  input_names=input_names,
-                                  output_names=output_names,
-                                  opset_version=ONNX_OPSET_VERSION,
-                                  do_constant_folding=False,
-                                  training=torch.onnx.TrainingMode.TRAINING,
-                                  dynamic_axes=dynamic_axes,
-                                  verbose=self._verbosity < Verbosity.WARNING,
-                                  export_params=False,
-                                  keep_initializers_as_inputs=True)
-        except RuntimeError as e:
-            raise RuntimeError(
-                'There was an error while exporting the PyTorch model to ONNX: {}'.format(e))
-
-        return onnx.load_model_from_string(f.getvalue())
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):
         """Override original method to delegate execution to the base module"""

--- a/orttraining/orttraining/test/python/_test_helpers.py
+++ b/orttraining/orttraining/test/python/_test_helpers.py
@@ -116,7 +116,7 @@ def assert_optim_state(expected_state, actual_state, rtol=1e-7, atol=0):
 
 def is_dynamic_axes(model):
     # Check inputs
-    for inp in model._onnx_training.graph.input:
+    for inp in model._execution_manager(model._is_training())._optimized_onnx_model.graph.input:
         shape = inp.type.tensor_type.shape
         if shape:
             for dim in shape.dim:
@@ -124,7 +124,7 @@ def is_dynamic_axes(model):
                     return False
 
     # Check outputs
-    for out in model._onnx_training.graph.output:
+    for out in model._execution_manager(model._is_training())._optimized_onnx_model.graph.output:
         shape = out.type.tensor_type.shape
         if shape:
             for dim in shape.dim:

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -425,7 +425,8 @@ def test_torch_nn_module_to_api(original_device, to_argument):
     model = model.to(to_argument)
     x = x.to(to_argument)
     model(x)
-    assert _utils.get_device_str(model._device) == _utils.get_device_str(torch.device(to_argument))
+    assert _utils.get_device_str(model._execution_manager(model._is_training())._device) == \
+        _utils.get_device_str(torch.device(to_argument))
 
 def test_model_without_device():
     # Model doesn't have device (CPU is assumed)
@@ -475,7 +476,7 @@ def test_input_requires_grad_saved(device):
     model = ORTModule(model)
     x = torch.randn(N, D_in, device=device, requires_grad=True) + 1
     model(x)
-    assert model._input_names_require_grad == ['input1']
+    assert model._execution_manager(model._is_training())._input_names_require_grad == ['input1']
 
 @pytest.mark.parametrize("device", ['cuda', 'cpu'])
 def test_input_requires_grad_backward_creates_input_grad(device):
@@ -826,11 +827,19 @@ def test_changes_input_requires_grad_reinitializes_module_gradient_graph_builder
     N, D_in, H, D_out = 32, 784, 500, 10
     model = NeuralNetSinglePositionalArgument(D_in, H, D_out).to(device)
     model = ORTModule(model)
-    x = torch.randn(N, D_in, device=device, requires_grad=True)
-    model(x.data)
-    module_gradient_graph_builder = model._module_gradient_graph_builder
-    model(x)
-    assert module_gradient_graph_builder != model._module_gradient_graph_builder
+    x = torch.randn(N, D_in, device=device)
+    y = x.clone()
+    y.requires_grad_(True)
+    output_x = torch.sum(model(x))
+    output_x.backward()
+    assert x.grad is None
+    module_gradient_graph_builder_training = \
+        model._execution_manager(model._is_training())._graph_builder
+    output_y = torch.sum(model(y))
+    output_y.backward()
+    assert y.grad is not None
+    assert module_gradient_graph_builder_training != \
+        model._execution_manager(model._is_training())._graph_builder
 
 @pytest.mark.parametrize("device", ['cuda'])
 def test_input_requires_grad_backward_creates_input_grad_as_required0(device):
@@ -1416,7 +1425,7 @@ def test_forward_data_and_model_on_different_devices(data_device, model_device):
     x = torch.randn(N, D_in, device=data_device)
     with pytest.raises(RuntimeError) as runtime_error:
         ort_model(x)
-    assert f"Input argument to forward found on device {torch.device(x.device)}, but expected it to be on module device {ort_model._device}." in str(runtime_error.value)
+    assert f"Input argument to forward found on device {torch.device(x.device)}, but expected it to be on module device {ort_model._execution_manager(ort_model._is_training())._device}." in str(runtime_error.value)
 
 def test_forward_returns_none_type_as_output():
     class NeuralNetNoneTypeOutput(torch.nn.Module):
@@ -1527,7 +1536,7 @@ def test_model_initializer_requires_grad_changes_from_one_forward_to_next():
     output = model(x)
     loss = torch.sum(output)
     loss.backward()
-    training_session1 = model._training_session
+    training_session1 = model._execution_manager(model._is_training())._execution_agent
     weight_grad_2 = model._original_module.fc1.weight.grad
     bias_grad_2 = model._original_module.fc1.bias.grad
     assert weight_grad_2 is not None
@@ -1537,7 +1546,7 @@ def test_model_initializer_requires_grad_changes_from_one_forward_to_next():
     output = model(x)
     loss = torch.sum(output)
     loss.backward()
-    training_session2 = model._training_session
+    training_session2 = model._execution_manager(model._is_training())._execution_agent
     weight_grad_3 = model._original_module.fc1.weight.grad
     bias_grad_3 = model._original_module.fc1.bias.grad
 
@@ -1724,3 +1733,64 @@ def test_buffers():
     buffers_ort = [buffer for buffer in ort_model.buffers()]
     assert len(buffers_ort) == 2
     assert torch.equal(buffers_ort[1], x)
+
+def test_eval_with_dropout():
+    class NeuralNetDropout(torch.nn.Module):
+        def __init__(self, input_size, hidden_size, num_classes):
+            super(NeuralNetDropout, self).__init__()
+
+            self.fc1 = torch.nn.Linear(input_size, hidden_size)
+            self.relu = torch.nn.ReLU()
+            self.fc2 = torch.nn.Linear(hidden_size, num_classes)
+            self.dropout = torch.nn.Dropout()
+
+        def forward(self, input1):
+            out = self.fc1(input1)
+            out = self.relu(out)
+            out = self.fc2(out)
+            out = self.dropout(out)
+            return out
+
+    device = 'cuda'
+
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = NeuralNetDropout(D_in, H, D_out).to(device)
+    model.eval()
+    ort_model = ORTModule(copy.deepcopy(model))
+    ort_model.eval()
+
+    x = torch.randn(N, D_in, device=device)
+    y = x.clone()
+
+    # Make sure model runs without any exception
+    output = ort_model(x)
+    output_pt = model(y)
+
+    assert output is not None
+    assert output_pt is not None
+    # Assert that the output from torch is the same as the one from ORTModule
+    assert torch.equal(output, output_pt)
+
+def test_with_torch_no_grad_context():
+    device = 'cuda'
+
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = NeuralNetSinglePositionalArgument(D_in, H, D_out).to(device)
+    ort_model = ORTModule(copy.deepcopy(model))
+
+    x = torch.randn(N, D_in, device=device)
+    y = x.clone()
+
+    # Make sure model runs without any exception
+    output = None
+    output_pt = None
+    with torch.no_grad():
+        output = ort_model(x)
+        output_pt = model(y)
+
+    assert output is not None
+    assert output_pt is not None
+    # Assert that the output from torch is the same as the one from ORTModule
+    assert torch.equal(output, output_pt)
+
+    assert output.grad is None and output_pt.grad is None


### PR DESCRIPTION
**Description**: So far, execution was off loaded to pytorch in two scenarios:
- When the model was executed in ```eval``` mode.
```python
class NeuralNet(torch.nn.Module):
    def __init__(self, input_size, num_classes):
        super(NeuralNet, self).__init__()
        self.fc1 = torch.nn.Linear(input_size, num_classes)

    def forward(self, input1):
        return self.fc1(input1)

model = ORTModule(NeuralNet(784, 10).to('cuda'))
model.eval()
x = torch.randn(N, D_in, device='cuda)
model(x) # execution offloaded to torch so far
```

- When the ```torch.no_grad()``` context was set before executing the complete model forward call.
```python
model = ORTModule(NeuralNet(784, 10).to('cuda'))
x = torch.randn(N, D_in, device='cuda)
with torch.no_grad():
    model(x) # execution offloaded to torch so far
```
With this pull request, we create an inference session that can execute these two scenarios. Changes in this pull request include:
- Create an inference session when needed.
  - when eval mode is ```True```.
  - When ```torch.no_grad()``` context is set (```torch.is_grad_enabled()``` is ```False```)
- The inference session uses an intermediate graph from the ```module_gradient_graph_builder``` as the inference graph to execute.
- Any "Dropout" nodes are dropped out :) by export when called with the ```torch.onnx.TrainingMode.EVAL``` ```training``` flag.
- Similarly, the ```BatchNorm``` node exported uses the testing version of the op when exported with the ```EVAL``` ```training``` flag.
- The ```ortmodule.py``` has been restructured to fit into the following architecture:
  - ```ORTModule``` owns two ```ExecutionManager```'s through an ```ExecutionManagerFactory```:
    - ```InferenceManager```: Responsible for building and running the inference model (exported with the ```torch.onnx.TrainingMode.EVAL``` ```training``` flag and then optimized through the ```ModuleGraphBuilder```.
    - ```TrainingManager```: Responsible for building and running the training model (forward + the gradient graph) (exported with the ```torch.onnx.TrainingMode.TRAINING``` ```training``` flag and then optimized (for gradient graph building) through the ```ModuleGraphBuilder```.
  - ```ORTModule``` does not have any implementation logic on graph building and only is an interface to the specialized ```torch.nn.Module```.
  - All graph building and execution is done by the ```ExecutionManager```s.