### PR TITLE
upgrade nightly packaging to cuda11.1 

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -274,7 +274,7 @@ stages:
                   --enable_onnx_tests \
                   ${{ parameters.build_py_parameters }} \
                   --cmake_extra_defines CMAKE_CUDA_HOST_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/cc  PYTHON_INCLUDE_DIR=$(PythonManylinuxIncludeDir) PYTHON_LIBRARY=/usr/lib64/librt.so \
-                  --use_cuda --cuda_version=10.2 --cuda_home=/usr/local/cuda-10.2 --cudnn_home=/usr/local/cuda-10.2
+                  --use_cuda --cuda_version=11.1 --cuda_home=/usr/local/cuda-11.1 --cudnn_home=/usr/local/cuda-11.1
           workingDirectory: $(Build.SourcesDirectory)
 
       - task: CopyFiles@2

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_gpu
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_gpu
@@ -1,6 +1,6 @@
 # TODO unify this with Dockerfile.manylinux2014_cuda10_2
 
-FROM nvcr.io/nvidia/cuda:10.2-cudnn8-devel-centos7
+FROM nvcr.io/nvidia/cuda:11.1-cudnn8-devel-centos7
 
 #We need both CUDA and manylinux. But the CUDA Toolkit End User License Agreement says NVIDIA CUDA Driver Libraries(libcuda.so, libnvidia-ptxjitcompiler.so) are only distributable in applications that meet this criteria:
 #1. The application was developed starting from a NVIDIA CUDA container obtained from Docker Hub or the NVIDIA GPU Cloud, and


### PR DESCRIPTION
**Description**: When working with torch ort, we want to work with the latest torch nightly package. We also want to work with the latest CUDA version supported by torch. Therefore we need to publish ort training package with CUDA11.1 support. 

TODO: to work with inferencing team to see if it is ok to upgrade its package as well. we otherwise need two docker files, one for CUDA10.2, the other for CUDA11.1.