### PR TITLE
Exclude cpuid.h from Mac non x86 arch

### DIFF
--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -204,11 +204,13 @@ void ThreadPoolProfiler::LogRun(int thread_idx) {
 #ifdef _WIN32
       child_thread_stats_[thread_idx].core_ = GetCurrentProcessorNumber();
 #elif defined(__APPLE__)
+#if defined(__x86_64__) || defined(__i386__)
       uint32_t CPUInfo[4];
       __cpuid_count(1, 0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
       if ((CPUInfo[3] & (1 << 9)) != 0) {
         child_thread_stats_[thread_idx].core_ = (unsigned)CPUInfo[1] >> 24;
       }
+#endif
 #else
       child_thread_stats_[thread_idx].core_ = sched_getcpu();
 #endif

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -27,7 +27,9 @@ limitations under the License.
 #include <codecvt>
 #include <locale>
 #elif defined(__APPLE__)
+#if defined(__x86_64__) || defined(__i386__)
 #include <cpuid.h>
+#endif
 #else
 #include <sched.h>
 #endif
@@ -122,11 +124,13 @@ void ThreadPoolProfiler::MainThreadStat::LogCore() {
 #ifdef _WIN32
   core_ = GetCurrentProcessorNumber();
 #elif defined(__APPLE__)
+#if defined(__x86_64__) || defined(__i386__)
   uint32_t CPUInfo[4];
   __cpuid_count(1, 0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
   if ((CPUInfo[3] & (1 << 9)) != 0) {
     core_ = (unsigned)CPUInfo[1] >> 24;
   }
+#endif
 #else
   core_ = sched_getcpu();
 #endif


### PR DESCRIPTION
Exclude cpuid.h from Mac system when it is running on non x86 arch to address issue https://github.com/microsoft/onnxruntime/issues/7160.