### PR TITLE
Pin version of pytorch to 1.8.1 for ORTModule CI pipeline

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements.txt
@@ -1,4 +1,5 @@
 --pre
+-f https://download.pytorch.org/whl/torch_stable.html
 # transformers requires sklearn
 pandas
 sklearn
@@ -10,5 +11,4 @@ torchtext==0.9.1
 tensorboard==v2.0.0
 h5py
 wget
-# PyTorch Lightning (nightly) is used for CI tests only
-https://github.com/PyTorchLightning/pytorch-lightning/archive/master.zip
+pytorch-lightning==1.2.5

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements.txt
@@ -1,13 +1,12 @@
 --pre
--f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
 # transformers requires sklearn
 pandas
 sklearn
 numpy==1.19.5
 transformers==v4.3.2
-torch
-torchvision
-torchtext
+torch==1.8.1+cu102
+torchvision==0.9.1+cu102
+torchtext==0.9.1
 tensorboard==v2.0.0
 h5py
 wget

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements.txt
@@ -5,8 +5,8 @@ pandas
 sklearn
 numpy==1.19.5
 transformers==v4.3.2
-torch==1.8.1+cu102
-torchvision==0.9.1+cu102
+torch==1.8.1+cu101
+torchvision==0.9.1+cu101
 torchtext==0.9.1
 tensorboard==v2.0.0
 h5py


### PR DESCRIPTION
**Description**: Pin the version of torch to 1.8.1 for ```ORTModule``` CI pipelines.