### PR TITLE
MLAS: activate udot kernel on Windows ARM64

### DIFF
--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -17,7 +17,13 @@ Abstract:
 
 #include "mlasi.h"
 
-#if defined(MLAS_TARGET_ARM64) && defined(__linux__)
+#if defined(MLAS_TARGET_ARM64)
+#if defined(_WIN32)
+// N.B. Support building with downlevel versions of the Windows SDK.
+#ifndef PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE
+#define PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE 43
+#endif
+#elif defined(__linux__)
 #include <sys/auxv.h>
 #include <asm/hwcap.h>
 // N.B. Support building with older versions of asm/hwcap.h that do not define
@@ -26,6 +32,7 @@ Abstract:
 #define HWCAP_ASIMDDP (1 << 20)
 #endif
 #endif
+#endif // MLAS_TARGET_ARM64
 
 //
 // Stores the platform information.
@@ -330,19 +337,25 @@ Return Value:
 
     this->GemmU8X8Dispatch = &MlasGemmU8X8DispatchNeon;
 
-#if defined(__linux__)
-
     //
     // Check if the processor supports ASIMD dot product instructions.
     //
 
-    if ((getauxval(AT_HWCAP) & HWCAP_ASIMDDP) != 0) {
+    bool HasDotProductInstructions;
+
+#if defined(_WIN32)
+    HasDotProductInstructions = (IsProcessorFeaturePresent(PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE) != 0);
+#elif defined(__linux__)
+    HasDotProductInstructions = ((getauxval(AT_HWCAP) & HWCAP_ASIMDDP) != 0);
+#else
+    HasDotProductInstructions = false;
+#endif
+
+    if (HasDotProductInstructions) {
         this->GemmU8X8Dispatch = &MlasGemmU8X8DispatchUdot;
     }
 
-#endif
-
-#endif
+#endif // MLAS_TARGET_ARM64
 
 }
 


### PR DESCRIPTION
**Description**: Use IsProcessorFeaturePresent(PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE) to detect if a Windows ARM64 device has the int8 dot product instructions. This new bit is supported by an upcoming release of Windows and is set on devices such as Surface X.