### PR TITLE
Enable type reduction for Scatter/ScatterElements CPU kernels

### DIFF
--- a/include/onnxruntime/core/framework/data_types_internal.h
+++ b/include/onnxruntime/core/framework/data_types_internal.h
@@ -350,10 +350,12 @@ class MLTypeCallDispatcher {
   }
 
   /**
-   * Invokes Fn<..., T> with leading template arguments and the specified arguments.
+   * Invokes Fn<..., T> with leading template arguments and the specified
+   * arguments.
    *
    * @tparam Fn The function object template.
-   * @tparam LeadingTemplateArgTypeList A type list of the leading template arguments.
+   * @tparam LeadingTemplateArgTypeList A type list of the leading template
+   *         arguments.
    * @tparam Args The argument types.
    */
   template <template <typename...> class Fn, typename LeadingTemplateArgTypeList, typename... Args>
@@ -403,11 +405,55 @@ class MLTypeCallDispatcher {
    */
   template <class Ret, template <typename...> class Fn, class UnsupportedPolicy, typename... Args>
   Ret InvokeRetWithUnsupportedPolicy(Args&&... args) const {
+    return InvokeRetWithUnsupportedPolicyAndLeadingTemplateArgs<
+        Ret, Fn, UnsupportedPolicy, TypeList<>>(
+        std::forward<Args>(args)...);
+  }
+
+  /**
+   * Invokes Fn<..., T> with leading template arguments and the specified
+   * arguments and returns the result.
+   *
+   * @tparam Ret The return type. Fn should return a type convertible to Ret.
+   * @tparam Fn The function object template.
+   * @tparam LeadingTemplateArgTypeList A type list of the leading template
+   *         arguments.
+   * @tparam Args The argument types.
+   */
+  template <class Ret, template <typename...> class Fn, typename LeadingTemplateArgTypeList, typename... Args>
+  Ret InvokeRetWithLeadingTemplateArgs(Args&&... args) const {
+    return InvokeRetWithUnsupportedPolicyAndLeadingTemplateArgs<
+        Ret, Fn, mltype_dispatcher_internal::UnsupportedTypeDefaultPolicy<Ret>, LeadingTemplateArgTypeList>(
+        std::forward<Args>(args)...);
+  }
+
+  /**
+   * Invokes Fn<..., T> with leading template arguments and the specified
+   * arguments and returns the result.
+   *
+   * @tparam Ret The return type. Fn should return a type convertible to Ret.
+   * @tparam Fn The function object template.
+   * @tparam UnsupportedPolicy The policy used to handle unsupported types.
+   *         See mltype_dispatcher_internal::UnsupportedTypeDefaultPolicy
+   *         for an example.
+   * @tparam LeadingTemplateArgTypeList A type list of the leading template
+   *         arguments.
+   * @tparam Args The argument types.
+   */
+  template <class Ret,
+            template <typename...> class Fn,
+            class UnsupportedPolicy,
+            typename LeadingTemplateArgTypeList,
+            typename... Args>
+  Ret InvokeRetWithUnsupportedPolicyAndLeadingTemplateArgs(Args&&... args) const {
     mltype_dispatcher_internal::CallableDispatchableRetHelper<Ret, UnsupportedPolicy> helper(dt_type_);
 
-    // call helper.Invoke() with Fn<T> for each T in Types
+    // given LeadingTemplateArgTypeList is a type list L<U1, U2, ...>,
+    //   call helper.Invoke() with Fn<U1, U2, ..., T> for each T in Types
     static_cast<void>(std::array<int, sizeof...(Types)>{
-        helper.template Invoke<Types>(Fn<Types>(), std::forward<Args>(args)...)...});
+        helper.template Invoke<Types>(
+            boost::mp11::mp_apply<Fn, boost::mp11::mp_push_back<LeadingTemplateArgTypeList, Types>>(),
+            std::forward<Args>(args)...)...});
 
     // avoid "unused parameter" warning for the case where Types is empty
     static_cast<void>(std::array<int, sizeof...(Args)>{(ORT_UNUSED_PARAMETER(args), 0)...});

--- a/onnxruntime/core/providers/cpu/tensor/pad.cc
+++ b/onnxruntime/core/providers/cpu/tensor/pad.cc
@@ -517,15 +517,21 @@ Status Pad::Compute(OpKernelContext* ctx) const {
     slices_to_use = &slices_;
   }
 
+  Status pad_status{};
   switch (element_size) {
     case sizeof(uint32_t):
-      return PadImpl<uint32_t>(ctx, *pads_to_use, *slices_to_use, mode_, value.u32);
+      pad_status = PadImpl<uint32_t>(ctx, *pads_to_use, *slices_to_use, mode_, value.u32);
+      break;
     case sizeof(uint64_t):
-      return PadImpl<uint64_t>(ctx, *pads_to_use, *slices_to_use, mode_, value.u64);
+      pad_status = PadImpl<uint64_t>(ctx, *pads_to_use, *slices_to_use, mode_, value.u64);
+      break;
     case sizeof(uint8_t):
-      return PadImpl<uint8_t>(ctx, *pads_to_use, *slices_to_use, mode_, value.u8);
+      pad_status = PadImpl<uint8_t>(ctx, *pads_to_use, *slices_to_use, mode_, value.u8);
+      break;
     default:
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Unsupported input data type of ", data_type);
+      pad_status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Unsupported input data type of ", data_type);
+      break;
   }
+  return pad_status;
 }
 };  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/tensor/scatter.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter.cc
@@ -305,7 +305,7 @@ Status Scatter<EnabledDataTypes>::Compute(OpKernelContext* context) const {
   const auto data_type = data_input->GetElementType();
 
   utils::MLTypeCallDispatcherFromTypeList<EnabledDataTypes> dispatcher{data_type};
-  status = dispatcher.InvokeRet<Status, CopyScatterDataDispatchTarget>(
+  status = dispatcher.template InvokeRet<Status, CopyScatterDataDispatchTarget>(
       data_input, indices_data, updates_input, axis, data_output);
 
   return status;

--- a/onnxruntime/core/providers/cpu/tensor/scatter.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter.cc
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 
 //https://github.com/onnx/onnx/blob/master/docs/Operators.md#Scatter
+#include <type_traits>
+
+#include "gsl/gsl"
+
 #include "core/common/common.h"
 #include "core/framework/element_type_lists.h"
 #include "core/framework/op_kernel.h"

--- a/onnxruntime/core/providers/cpu/tensor/scatter.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter.cc
@@ -48,13 +48,6 @@ class Scatter final : public OpKernel {
   Status Compute(OpKernelContext* context) const override;
 
  private:
-  template <typename T>
-  Status CopyInt32Index(const Tensor* data_input, const Tensor* indices_input, const Tensor* updates_input,
-                        const int64_t axis, Tensor* data_output) const;
-  template <typename T>
-  Status CopyInt64Index(const Tensor* data_input, const Tensor* indices_input, const Tensor* updates_input,
-                        const int64_t axis, Tensor* data_output) const;
-
   int64_t axis_;
 };
 

--- a/tools/python/util/ort_format_model/operator_type_usage_processors.py
+++ b/tools/python/util/ort_format_model/operator_type_usage_processors.py
@@ -337,8 +337,8 @@ def _create_operator_type_usage_processors():
                                   'Range', 'Reciprocal', 'ReduceL1', 'ReduceL2', 'ReduceLogSum', 'ReduceLogSumExp',
                                   'ReduceMax', 'ReduceMean', 'ReduceMin', 'ReduceProd', 'ReduceSum', 'ReduceSumSquare',
                                   'Relu', 'Resize', 'ReverseSequence', 'RoiAlign', 'Round',
-                                  'ScatterND', 'Shrink', 'Sigmoid', 'Sign', 'Sin', 'Softmax', 'Split',
-                                  'SplitToSequence', 'Sqrt', 'Sum',
+                                  'Scatter', 'ScatterElements', 'ScatterND', 'Shrink', 'Sigmoid', 'Sign', 'Sin',
+                                  'Softmax', 'Split', 'SplitToSequence', 'Sqrt', 'Sum',
                                   'Tanh', 'TopK', 'Transpose',
                                   'Unique',
                                   'Where']


### PR DESCRIPTION
**Description**
Enable type reduction for Scatter/ScatterElements CPU kernels. Some refactoring to reduce binary size.
Add MLTypeCallDispatcher methods.
Minor cleanup for Pad CPU kernel.

**Motivation and Context**
Binary size reduction.
