### PR TITLE
Add support for dynamic positional/keyword inputs during training for ORTModule

### DIFF
--- a/orttraining/orttraining/python/training/_ortmodule_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/_ortmodule_graph_execution_manager.py
@@ -3,15 +3,15 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-from . import _utils, _ortmodule_utils, _ortmodule_output_transformation as _ortmodule_io
+from . import _ortmodule_utils as _utils, _ortmodule_io as _io
 from . import _ortmodule_logger as _logger
 
-from onnxruntime.capi.onnxruntime_inference_collection import OrtValue
 from onnxruntime.capi import _pybind_state as C
 
 from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
 
 from abc import ABC, abstractmethod
+import copy
 import io
 import inspect
 import onnx
@@ -21,12 +21,12 @@ from torch.utils.cpp_extension import ROCM_HOME
 
 ONNX_OPSET_VERSION = 12
 
+
 def _run_forward(execution_session, onnx_model, device, *inputs, **kwargs):
     """Runs the forward graph on execution_session with given model inputs and device"""
 
     # Assert that the input and model device match
-    _ortmodule_utils._check_same_device(
-        device, "Input argument to forward", *inputs)
+    _utils._check_same_device(device, "Input argument to forward", *inputs)
 
     # TODO: Try to reuse the output buffers as some of the output tensors are same sizes,
     #   especially the backward graph outputs.
@@ -34,24 +34,23 @@ def _run_forward(execution_session, onnx_model, device, *inputs, **kwargs):
     run_options = C.RunOptions()
 
     # Use IO binding
-    _ortmodule_utils._create_iobinding(io_binding, inputs, onnx_model, device)
+    _utils._create_iobinding(io_binding, inputs, onnx_model, device)
 
     # Run and return module outputs.
     ort_output = execution_session.run_forward(io_binding, run_options)
     forward_outputs, run_id = ort_output.ortvalues, ort_output.run_id
 
-    user_outputs = tuple(_ortmodule_utils._ortvalue_to_torch_tensor(
-        forward_output) for forward_output in forward_outputs)
+    user_outputs = tuple(_utils._ortvalue_to_torch_tensor(forward_output) for forward_output in forward_outputs)
 
     # Assert that the outputs and model device match
-    _ortmodule_utils._check_same_device(
-        device, "Output argument from forward", *user_outputs)
+    _utils._check_same_device(device, "Output argument from forward", *user_outputs)
 
     output_info = [(output.shape, output.device, output.dtype) for output in user_outputs]
     run_info = onnxruntime.training.RunStateInfo(run_id, run_options, io_binding, output_info)
 
     # Return user outputs and forward run information
     return user_outputs, run_info
+
 
 class GraphExecutionManager(ABC):
     def __init__(self, module):
@@ -70,7 +69,7 @@ class GraphExecutionManager(ABC):
 
         # Exported model
         self._onnx_model = None
-        
+
         # Model after inference optimization or gradient building.
         self._optimized_onnx_model = None
         self._graph_builder = None
@@ -92,9 +91,11 @@ class GraphExecutionManager(ABC):
         # default execution order is priority-based for both dynamic/static shape input for now
         # if we observe benefit of static shape, we can expose this flag to user
         self._use_static_shape = False
+
         # flag to enable symbolic shape inference for dynamic shape inputs to improve performance
         self._run_symbolic_shape_infer = False
-        self._input_names_require_grad = None
+
+        self._input_info = None
         self._module_output_schema = None
 
         # Log level
@@ -103,8 +104,7 @@ class GraphExecutionManager(ABC):
         # TODO: Single device support for now
         self._device = _utils.get_device_from_module(module)
 
-        self._module_parameters = inspect.signature(
-            self._original_module.forward).parameters.values()
+        self._module_parameters = inspect.signature(self._original_module.forward).parameters.values()
 
         # TODO: remove after PyTorch ONNX exporter supports VAR_KEYWORD parameters.
         for input_parameter in self._module_parameters:
@@ -112,14 +112,13 @@ class GraphExecutionManager(ABC):
                 raise NotImplementedError(
                     "The model's forward method has **kwargs parameter which is currently not supported.")
 
-        self.is_rocm_pytorch = (True if (
-            (torch.version.hip is not None) and (ROCM_HOME is not None)) else False)
+        self.is_rocm_pytorch = (True if ((torch.version.hip is not None) and (ROCM_HOME is not None)) else False)
 
         self._use_external_gpu_allocator = True
         if self._use_external_gpu_allocator:
             # CPP extension to get torch GPU allocator's alloc and free function addresses
-            self._torch_gpu_allocator = _ortmodule_utils._load_torch_gpu_allocator_cpp_extension(self._loglevel < _logger.LogLevel.WARNING,
-                                                                                                 self.is_rocm_pytorch)
+            self._torch_gpu_allocator = _utils._load_torch_gpu_allocator_cpp_extension(self._loglevel < _logger.LogLevel.WARNING,
+                                                                                       self.is_rocm_pytorch)
             self._torch_alloc = self._torch_gpu_allocator.gpu_caching_allocator_raw_alloc_address()
             self._torch_free = self._torch_gpu_allocator.gpu_caching_allocator_raw_delete_address()
 
@@ -134,16 +133,12 @@ class GraphExecutionManager(ABC):
 
     def _build_graph(self):
         if self._use_static_shape:
-            self._graph_builder.build(
-                self._current_input_shape)
+            self._graph_builder.build(self._input_info.shape)
         else:
             self._graph_builder.build()
 
-        self._optimized_onnx_model = onnx.load_model_from_string(
-            self._graph_builder.get_model())
-        self._graph_info = \
-            self._graph_builder.get_graph_info()
-
+        self._optimized_onnx_model = onnx.load_model_from_string(self._graph_builder.get_model())
+        self._graph_info = self._graph_builder.get_graph_info()
 
     def _get_session_config(self):
         """Creates and returns the session configuration to be used for the ExecutionAgent"""
@@ -151,12 +146,12 @@ class GraphExecutionManager(ABC):
         provider_options = None
         if self._device.type == 'cuda':
             # Configure the InferenceSessions to use the specific GPU on which the model is placed.
-            providers = (["ROCMExecutionProvider"] if self.is_rocm_pytorch else [
-                         "CUDAExecutionProvider"])
+            providers = (["ROCMExecutionProvider"] if self.is_rocm_pytorch else ["CUDAExecutionProvider"])
             providers.append("CPUExecutionProvider")
             if self._use_external_gpu_allocator:
-                provider_options = [{"device_id": str(self._device.index), "gpu_external_alloc": str(
-                    self._torch_alloc), "gpu_external_free": str(self._torch_free)}, {}]
+                provider_options = [{"device_id": str(self._device.index),
+                                     "gpu_external_alloc": str(self._torch_alloc),
+                                     "gpu_external_free": str(self._torch_free)}, {}]
             else:
                 provider_options = [{"device_id": str(self._device.index)}, {}]
         elif self._device.type == 'cpu':
@@ -179,9 +174,12 @@ class GraphExecutionManager(ABC):
 
     def _export_model(self, *inputs, **kwargs):
         # 1. Set the self._device from the user module
-        # 2. Export the user model under self._export_training_flag mode
+        # 2. Verify input schema matches schema used on previous model export
+        # 3. Export the user model under self._export_training_flag mode
         # Return True if the model needed to be exported, False if no export was required.
-        if self._onnx_model:
+
+        schema = _io._extract_schema({'args': copy.copy(inputs), 'kwargs': copy.copy(kwargs)})
+        if self._onnx_model and schema == self._input_info.schema:
             # All required models have already been exported previously
             return False
 
@@ -200,13 +198,13 @@ class GraphExecutionManager(ABC):
         '''
 
         # Setup dynamic axes for onnx model
-        input_names, dynamic_axes, self._input_names_require_grad, _ = \
-            _ortmodule_io.parse_inputs_for_onnx_export(
-                self._module_parameters, None, *inputs, **kwargs)
+        self._input_info = _io.parse_inputs_for_onnx_export(self._module_parameters,
+                                                            None,
+                                                            inputs,
+                                                            kwargs)
         output_names, output_dynamic_axes, self._module_output_schema = \
-            _ortmodule_io.parse_outputs_for_onnx_export_and_extract_output_schema(
-                self._original_module, inputs, kwargs)
-        dynamic_axes.update(output_dynamic_axes)
+            _io.parse_outputs_for_onnx_export_and_extract_schema(self._original_module, inputs, kwargs)
+        self._input_info.dynamic_axes.update(output_dynamic_axes)
 
         # Export torch.nn.Module to ONNX
         f = io.BytesIO()
@@ -214,9 +212,7 @@ class GraphExecutionManager(ABC):
         # Deepcopy inputs, since input values may change after model run.
         # NOTE: Inputs may contain tensors that have attributes preventing their deepcopy (example grad_fn).
         # Therefore, deepcopy only the data component of the input tensors for export.
-        sample_inputs_copy, sample_kwargs_copy = \
-            _ortmodule_io.deepcopy_model_input(
-                *inputs, **kwargs)
+        sample_inputs_copy, sample_kwargs_copy = _io.deepcopy_model_input(*inputs, **kwargs)
 
         # Ops behaving differently under train/eval mode need to exported with the
         # correct training flag to reflect the expected behavior.
@@ -228,85 +224,42 @@ class GraphExecutionManager(ABC):
                 torch.onnx.export(self._flattened_module,
                                   sample_inputs_copy + (sample_kwargs_copy, ),
                                   f,
-                                  input_names=input_names,
+                                  input_names=self._input_info.names,
                                   output_names=output_names,
                                   opset_version=ONNX_OPSET_VERSION,
                                   do_constant_folding=False,
                                   training=self._export_mode,
-                                  dynamic_axes=dynamic_axes,
+                                  dynamic_axes=self._input_info.dynamic_axes,
                                   verbose=self._loglevel < _logger.LogLevel.WARNING,
                                   export_params=False,
                                   keep_initializers_as_inputs=True)
         except RuntimeError as e:
-            raise RuntimeError(
-                'There was an error while exporting the PyTorch model to ONNX: {}'.format(e))
+            raise RuntimeError('There was an error while exporting the PyTorch model to ONNX: {}'.format(e))
 
         return onnx.load_model_from_string(f.getvalue())
 
     def _set_device_from_module(self):
         """Get the device from the module and save it to self._device"""
 
-        device_from_module = _utils.get_device_from_module(
-            self._original_module)
+        device_from_module = _utils.get_device_from_module(self._original_module)
         if not self._device or self._device != device_from_module:
             self._device = device_from_module
             if not self._device:
-                raise RuntimeError(
-                    'A device must be specified in the model or data!')
-
-    def _convert_training_graph_input_to_list(self, *inputs, **kwargs):
-        '''Creates forward `*inputs` list from user input and PyTorch initializers
-
-        TODO: How IO binding model inputs and outputs affects initializer copies?
-
-        ONNX Runtime forward requires an ordered list of:
-            * User input: computed from forward InferenceSession
-            * Initializers: computed from original PyTorch model parameters
-        '''
-        # User inputs
-        non_none_inputs = [inp for inp in inputs if inp is not None]
-        named_buffers_iter = iter(self._flattened_module.named_buffers())
-        result = []
-        for input_idx, name in enumerate(self._graph_info.user_input_names):
-            inp = None
-            if input_idx < len(non_none_inputs):
-                inp = non_none_inputs[input_idx]
-            elif name in kwargs and kwargs[name] is not None:
-                inp = kwargs[name]
-            elif input_idx >= len(non_none_inputs):
-                # Registered buffers are translated to user_input+initializer in ONNX
-                # TODO: Check what happens when the number of inputs change form one call to the next
-                buffer_name, inp = next(named_buffers_iter)
-                assert buffer_name == name, f'Input name {name} expected, but {buffer_name} found!'
-
-            if inp is not None:
-                result.append(inp)
-            else:
-                # TODO: Re-export ONNX if any input from onnx_graphs_info.user_input_names is None.
-                raise RuntimeError(
-                    f'Input is present in ONNX graph but not provided: {name}.')
-
-        # Initializers
-        for param in self._flattened_module.named_parameters():
-            result.append(param[1])
-
-        return result
+                raise RuntimeError('A device must be specified in the model!')
 
     def _initialize_graph_builder(self, training):
         """Creates a new OrtModuleGraphBuilder, initializes it and saves it to self._graph_builder"""
 
         # TODO: PyTorch exporter bug: changes the initializer order in ONNX model
-        initializer_names = [name
-                             for name, _ in self._flattened_module.named_parameters()]
-        initializer_names_to_train = [name
-            for name, param in self._flattened_module.named_parameters() if param.requires_grad]
+        initializer_names = [name for name, _ in self._flattened_module.named_parameters()]
+        initializer_names_to_train = [name for name,
+                                      param in self._flattened_module.named_parameters() if param.requires_grad]
 
         # Build and optimize the full graph
         grad_builder_config = C.OrtModuleGraphBuilderConfiguration()
         grad_builder_config.initializer_names = initializer_names
         grad_builder_config.initializer_names_to_train = initializer_names_to_train
-        grad_builder_config.input_names_require_grad = self._input_names_require_grad
+        grad_builder_config.input_names_require_grad = self._input_info.require_grad_names
         grad_builder_config.build_gradient_graph = training
         self._graph_builder = C.OrtModuleGraphBuilder()
-        self._graph_builder.initialize(
-            self._onnx_model.SerializeToString(), grad_builder_config)
+        self._graph_builder.initialize(self._onnx_model.SerializeToString(), grad_builder_config)

--- a/orttraining/orttraining/python/training/_ortmodule_graph_execution_manager_factory.py
+++ b/orttraining/orttraining/python/training/_ortmodule_graph_execution_manager_factory.py
@@ -6,6 +6,7 @@
 from ._ortmodule_training_manager import TrainingManager
 from ._ortmodule_inference_manager import InferenceManager
 
+
 class GraphExecutionManagerFactory(object):
     def __init__(self, module):
         self._training_manager = TrainingManager(module)

--- a/orttraining/orttraining/python/training/_ortmodule_inference_manager.py
+++ b/orttraining/orttraining/python/training/_ortmodule_inference_manager.py
@@ -3,22 +3,24 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-from . import _utils, _ortmodule_utils, _ortmodule_output_transformation as _ortmodule_io
+from . import _ortmodule_utils as _utils, _ortmodule_io as _io
 from ._ortmodule_graph_execution_manager import GraphExecutionManager, _run_forward
 
+import copy
 import onnx
 import onnxruntime
 
 import torch
+
 
 class InferenceManager(GraphExecutionManager):
     """Concrete instance of GraphExecutionManager that is able to manage the inference model
 
     InferenceManager is resposible for building and running the forward graph of the inference model
     """
+
     def __init__(self, model):
         super().__init__(model)
-
         self._export_mode = torch.onnx.TrainingMode.EVAL
 
     def forward(self, *inputs, **kwargs):
@@ -30,19 +32,17 @@ class InferenceManager(GraphExecutionManager):
         '''
 
         # Exporting module to ONNX for the first time
-        # Flag to indicate whether the graph needs to be built
-        # It should be built every time the module graph builder is initialized
-        build_graph = \
-            self._get_exported_model_and_init_graph_builder(
-                *inputs, **kwargs)
+        build_graph = self._export_model(*inputs, **kwargs)
+        if build_graph:
+            # If model was exported, then initialize the graph builder
+            self._initialize_graph_builder(training=False)
 
-        _, _, _, new_input_shape = \
-            _ortmodule_io.parse_inputs_for_onnx_export(
-                self._module_parameters, self._onnx_model, *inputs, **kwargs)
+            # Save the onnx model if the model was exported
+            if self._save_onnx:
+                onnx.save(self._onnx_model, self._save_onnx_prefix + '_exported_inference_model.onnx')
 
         # Build the inference graph
         if build_graph:
-            self._current_input_shape = new_input_shape
             self._build_graph()
 
         module_device = _utils.get_device_from_module(self._original_module)
@@ -51,52 +51,33 @@ class InferenceManager(GraphExecutionManager):
         create_execution_session = build_graph or self._device != module_device
         if self._device != module_device:
             self._device = module_device
-
         if create_execution_session:
             # Create execution session creates the inference_session
             self._create_execution_agent()
 
-        user_outputs, _ = _run_forward(
-            self._execution_agent, self._optimized_onnx_model, self._device,
-            *self._convert_training_graph_input_to_list(*inputs, **kwargs))
+        user_outputs, _ = _run_forward(self._execution_agent,
+                                       self._optimized_onnx_model,
+                                       self._device,
+                                       *_io._convert_input_to_list(self._flattened_module.named_parameters(),
+                                                                   self._graph_info.user_input_names,
+                                                                   self._flattened_module.named_buffers(),
+                                                                   inputs,
+                                                                   kwargs))
 
-        return _ortmodule_io.populate_user_output_from_schema_and_outputs(
-            self._module_output_schema,
-            self._graph_info.user_output_names,
-            user_outputs)
+        return _io.populate_user_output_from_schema_and_outputs(self._module_output_schema,
+                                                                self._graph_info.user_output_names,
+                                                                user_outputs)
 
     def _build_graph(self):
         """Build an optimized inference graph using the module_graph_builder"""
 
         super()._build_graph()
-
         if self._save_onnx:
-            onnx.save(self._optimized_onnx_model,
-                      self._save_onnx_prefix + '_inference.onnx')
-
-    def _get_exported_model_and_init_graph_builder(self, *inputs, **kwargs):
-        """Export the pytorch model in inference mode
-
-        Returns True if model was exported and False if it has already been previously exported
-        """
-
-        did_export = self._export_model(*inputs, **kwargs)
-
-        if did_export:
-            # If model was exported, then initialize the graph builder
-            self._initialize_graph_builder(training=False)
-
-            # Save the onnx model if the model was exported
-            if self._save_onnx:
-                onnx.save(self._onnx_model,
-                        self._save_onnx_prefix + '_exported_inference_model.onnx')
-
-        return did_export
+            onnx.save(self._optimized_onnx_model, self._save_onnx_prefix + '_inference.onnx')
 
     def _create_execution_agent(self):
         """Creates an InferenceAgent that can run forward graph on an inference model"""
 
         session_options, providers, provider_options = self._get_session_config()
-        self._execution_agent = onnxruntime.training.InferenceAgent(
-            self._optimized_onnx_model.SerializeToString(),
-            session_options, providers, provider_options)
+        self._execution_agent = onnxruntime.training.InferenceAgent(self._optimized_onnx_model.SerializeToString(),
+                                                                    session_options, providers, provider_options)

--- a/orttraining/orttraining/python/training/_ortmodule_io.py
+++ b/orttraining/orttraining/python/training/_ortmodule_io.py
@@ -5,6 +5,49 @@ import inspect
 import torch
 import warnings
 
+
+class _InputInfo(object):
+    def __init__(self, names, shape, require_grad_names=None, dynamic_axes=None, schema=None):
+        self.names = names
+        self.shape = shape
+        self.require_grad_names = require_grad_names if require_grad_names else []
+        self.dynamic_axes = dynamic_axes if dynamic_axes else {}
+        self.schema = schema if schema else []
+
+
+def _convert_input_to_list(param_names, user_input_names, buffer_names, inputs, kwargs):
+    '''Creates forward `*inputs` list from user input and PyTorch initializers
+
+    ONNX Runtime forward requires an ordered list of:
+        * User input: computed from forward InferenceSession
+        * Initializers: computed from original PyTorch model parameters
+    '''
+
+    # User inputs
+    non_none_inputs = [inp for inp in inputs if inp is not None]
+    named_buffers_iter = iter(buffer_names)
+    result = []
+    for input_idx, name in enumerate(user_input_names):
+        inp = None
+        if input_idx < len(non_none_inputs):
+            inp = non_none_inputs[input_idx]
+        elif name in kwargs and kwargs[name] is not None:
+            inp = kwargs[name]
+        elif input_idx >= len(non_none_inputs):
+            # Registered buffers are translated to user_input+initializer in ONNX
+            buffer_name, inp = next(named_buffers_iter)
+            assert buffer_name == name, f'Input name {name} expected, but {buffer_name} found!'
+
+        if inp is not None:
+            result.append(inp)
+        else:
+            raise RuntimeError(f'Input is present in ONNX graph but not provided: {name}.')
+    # Initializers
+    for param in param_names:
+        result.append(param[1])
+    return result
+
+
 def deepcopy_model_input(*inputs, **kwargs):
     sample_inputs_copy = []
     for model_input in inputs:
@@ -18,9 +61,50 @@ def deepcopy_model_input(*inputs, **kwargs):
 
     return sample_inputs_copy, sample_kwargs_copy
 
-class _TensorStub:
-    # Stub for a torch.Tensor value to be used to formulate the output schema
-    pass
+
+class _TensorStub(object):
+    '''Tensor stub class used to represent model's input or output'''
+
+    def __init__(self, name=None, dtype=None, shape=None, shape_dims=None):
+        self.name = name
+        self.dtype = dtype
+        self.shape = shape
+        self.shape_dims = shape_dims
+
+    def __repr__(self) -> str:
+        result = '_TensorStub('
+        if self.name is not None:
+            result += f'name={self.name}'
+        if self.dtype is not None:
+            if result[-1] != '(':
+                result += ', '
+            result += f'dtype={self.dtype}'
+        if self.shape is not None:
+            if result[-1] != '(':
+                result += ', '
+            result += f'shape={self.shape}'
+        if self.shape_dims is not None:
+            if result[-1] != '(':
+                result += ', '
+            result += f'shape_dims={self.shape_dims}'
+        result += ')'
+        return result
+
+    def __eq__(self, other):
+        if not isinstance(other, _TensorStub):
+            raise NotImplemented('_TensorStub must only be compared to another _TensorStub instance!')
+        elif not other:
+            return False
+        elif self.name != other.name:
+            return False
+        elif self.dtype != other.dtype:
+            return False
+        elif self.shape != other.shape:
+            return False
+        elif self.shape_dims != other.shape_dims:
+            return False
+        return True
+
 
 def populate_user_output_from_schema_and_outputs(output_schema, output_names, outputs):
     """Follows the schema to generate an output that is expected by the user"""
@@ -61,36 +145,36 @@ def populate_user_output_from_schema_and_outputs(output_schema, output_names, ou
     output_schema_copy = copy.deepcopy(output_schema)
     output_idx = [0]
     user_output = _replace_stub_with_tensor_value(output_schema_copy, outputs, output_idx)
-
     return user_output
 
-def _extract_output_schema(output):
-    """Extract the output schema by replacing every torch.Tensor value with _TensorStub"""
 
-    if output is None:
+def _extract_schema(data):
+    """Extract the data schema by replacing every torch.Tensor value with _TensorStub"""
+
+    if data is None:
         return None
-    # Depth first traversal to iterate over the output to replace every tensor with a stub
-    elif isinstance(output, torch.Tensor):
-        return _TensorStub()
+    # Depth first traversal to iterate over the data to replace every tensor with a stub
+    elif isinstance(data, torch.Tensor):
+        return _TensorStub(dtype=str(data.dtype), shape_dims=len(data.size()))
 
-    if isinstance(output, abc.Sequence):
-        sequence_type = type(output)
-        output = list(output)
-        for idx in range(len(output)):
-            output[idx] = _extract_output_schema(output[idx])
+    if isinstance(data, abc.Sequence):
+        sequence_type = type(data)
+        data = list(data)
+        for idx in range(len(data)):
+            data[idx] = _extract_schema(data[idx])
         try:
             # namedtuple can be created by passing the list sequence to method _make
-            output = sequence_type._make(output)
+            data = sequence_type._make(data)
         except AttributeError:
             # If attribute error encountered, create the sequence directly
-            output = sequence_type(output)
-    elif isinstance(output, abc.Mapping):
-        for key in sorted(output):
-            output[key] = _extract_output_schema(output[key])
+            data = sequence_type(data)
+    elif isinstance(data, abc.Mapping):
+        for key in sorted(data):
+            data[key] = _extract_schema(data[key])
     else:
-        raise TypeError(f'ORTModule does not support the following model output type {type(output)}')
+        raise TypeError(f'ORTModule does not support the following model data type {type(data)}')
+    return data
 
-    return output
 
 def _parse_outputs_and_extract_names_and_dynamic_axes(module_output):
     """Parses through the module output and returns output names and dynamic axes"""
@@ -125,7 +209,8 @@ def _parse_outputs_and_extract_names_and_dynamic_axes(module_output):
 
     return output_names, output_dynamic_axes
 
-def get_flattened_output_module(original_module):
+
+def get_flattened_module(original_module):
     """Returns a torch.nn.Module that flattens the output of the original module in its forward method"""
 
     def _transform_output_to_flat_tuple(output):
@@ -168,7 +253,8 @@ def get_flattened_output_module(original_module):
 
     return FlattenedOutputModule(original_module)
 
-def parse_inputs_for_onnx_export(all_input_parameters, onnx_graph, *inputs, **kwargs):
+
+def parse_inputs_for_onnx_export(all_input_parameters, onnx_graph, inputs, kwargs):
     # Ignore optional inputs explicitly specified as None
     # ONNX exporter may remove unused inputs
     onnx_graph_input_names = []
@@ -182,13 +268,13 @@ def parse_inputs_for_onnx_export(all_input_parameters, onnx_graph, *inputs, **kw
 
     for input_idx, input_parameter in enumerate(all_input_parameters):
         if input_parameter.kind == inspect.Parameter.VAR_POSITIONAL:
-            # Looking at VAR_POSITIONAL parameter (*args) in the original forward method.
-            # All the rest positional inputs go into this parameter.
+            # VAR_POSITIONAL parameter carries all *args parameters from original forward method
             var_positional_idx = 0
-            for i in range(input_idx, len(inputs)):
+            for args_i in range(input_idx, len(inputs)):
                 name = f'var_positional_{input_parameter.name}{var_positional_idx}'
+
                 var_positional_idx += 1
-                inp = inputs[i]
+                inp = inputs[args_i]
                 if inp is not None and (onnx_graph is None or name in onnx_graph_input_names):
                     if inp.requires_grad:
                         # input_names_require_grad holds all input tensors that have requires_grad
@@ -197,10 +283,11 @@ def parse_inputs_for_onnx_export(all_input_parameters, onnx_graph, *inputs, **kw
                     input_names.append(name)
                     dynamic_axes[name] = {}
                     for dim_idx in range(len(inp.shape)):
-                        dynamic_axes[name].update({dim_idx : f'input{input_idx}_dim{dim_idx}'})
+                        dynamic_axes[name].update({dim_idx: f'input{input_idx}_dim{dim_idx}'})
 
                     input_shape.append(list(inp.size()))
         else:
+            # All positional non-*args are processed here
             name = input_parameter.name
             inp = None
             if input_idx < len(inputs) and inputs[input_idx] is not None:
@@ -215,12 +302,21 @@ def parse_inputs_for_onnx_export(all_input_parameters, onnx_graph, *inputs, **kw
                 input_names.append(name)
                 dynamic_axes[name] = {}
                 for dim_idx in range(len(inp.shape)):
-                    dynamic_axes[name].update({dim_idx : f'input{input_idx}_dim{dim_idx}'})
+                    dynamic_axes[name].update({dim_idx: f'input{input_idx}_dim{dim_idx}'})
 
                 input_shape.append(list(inp.size()))
-    return input_names, dynamic_axes, input_names_require_grad, input_shape
 
-def parse_outputs_for_onnx_export_and_extract_output_schema(module, inputs, kwargs):
+    # Shallow copy is ok as we need the data structure, not the content
+    schema = _extract_schema({'args': copy.copy(inputs), 'kwargs': copy.copy(kwargs)})
+
+    return _InputInfo(names=input_names,
+                      shape=input_shape,
+                      require_grad_names=input_names_require_grad,
+                      dynamic_axes=dynamic_axes,
+                      schema=schema)
+
+
+def parse_outputs_for_onnx_export_and_extract_schema(module, inputs, kwargs):
 
     #   Do an inference to grab outputs
     is_train_mode = module.training
@@ -235,16 +331,16 @@ def parse_outputs_for_onnx_export_and_extract_output_schema(module, inputs, kwar
             model_copy = copy.deepcopy(module)
         except Exception:
             model_copy = module
-            warnings.warn("This model cannot be deep copied (or pickled), which is a required step for stateful models to be properly exported to ONNX."
-                            " Compute will continue, but unexpected results may occur!")
+            warnings.warn("This model cannot be deep copied (or pickled), "
+                          "which is a required step for stateful models to be properly exported to ONNX."
+                          " Compute will continue, but unexpected results may occur!")
 
         sample_outputs = model_copy(*sample_inputs_copy, **sample_kwargs_copy)
 
         # Parse the output and extract the output_names and output_dynamic_axes to be used for onnx export
-        output_names, output_dynamic_axes = \
-            _parse_outputs_and_extract_names_and_dynamic_axes(sample_outputs)
+        output_names, output_dynamic_axes = _parse_outputs_and_extract_names_and_dynamic_axes(sample_outputs)
     if is_train_mode:
         module.train()
 
     # Return output names, output dynamic axes and output schema
-    return output_names, output_dynamic_axes, _extract_output_schema(sample_outputs)
+    return output_names, output_dynamic_axes, _extract_schema(sample_outputs)

--- a/orttraining/orttraining/python/training/_ortmodule_training_manager.py
+++ b/orttraining/orttraining/python/training/_ortmodule_training_manager.py
@@ -3,22 +3,22 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-from . import _utils, _ortmodule_utils, _ortmodule_output_transformation as _ortmodule_io
+from . import _ortmodule_utils as _utils, _ortmodule_io as _io
 from ._ortmodule_graph_execution_manager import GraphExecutionManager, _run_forward
 
 import onnx
 import onnxruntime
-
 import torch
+
 
 class TrainingManager(GraphExecutionManager):
     """Concrete instance of GraphExecutionManager that is able to manage the training model
 
     TrainingManager is resposible for building and running the forward and backward graph of the training model
     """
+
     def __init__(self, model):
         super().__init__(model)
-
         self._export_mode = torch.onnx.TrainingMode.TRAINING
 
     def forward(self, *inputs, **kwargs):
@@ -30,32 +30,33 @@ class TrainingManager(GraphExecutionManager):
         '''
 
         # Exporting module to ONNX for the first time
-        # Flag to indicate whether the gradient graph needs to be built
-        # It should be built every time the module graph builder is initialized
-        build_gradient_graph = \
-            self._get_exported_model_and_init_graph_builder(
-                *inputs, **kwargs)
+        build_gradient_graph = self._export_model(*inputs, **kwargs)
+        if build_gradient_graph:
+            # If model was exported, then initialize the graph builder
+            self._initialize_graph_builder(training=True)
 
-        _, _, input_names_require_grad, new_input_shape = \
-            _ortmodule_io.parse_inputs_for_onnx_export(
-                self._module_parameters, self._onnx_model, *inputs, **kwargs)
+            # Save the onnx model if the model was exported
+            if self._save_onnx:
+                onnx.save(self._onnx_model, self._save_onnx_prefix + '_exported_training_model.onnx')
+
+        input_info = _io.parse_inputs_for_onnx_export(self._module_parameters,
+                                                      self._onnx_model,
+                                                      inputs,
+                                                      kwargs)
+
         # Reinitialize graph builder if the inputs or initializers requiring gradient have changed.
-        build_gradient_graph = build_gradient_graph or \
-            self._reinitialize_graph_builder(input_names_require_grad)
+        build_gradient_graph = build_gradient_graph or self._reinitialize_graph_builder(input_info)
 
         # Build the gradient graph
         if build_gradient_graph:
-            self._current_input_shape = new_input_shape
             self._build_graph()
 
         module_device = _utils.get_device_from_module(self._original_module)
         # The _training_session/_inference_session should be created every time
         # the graph was built or if the device changed between calls to forward
-        create_execution_session = \
-            build_gradient_graph or self._device != module_device
+        create_execution_session = build_gradient_graph or self._device != module_device
         if self._device != module_device:
             self._device = module_device
-
         if create_execution_session:
             # Create execution session creates the training_session
             self._create_execution_agent()
@@ -84,41 +85,37 @@ class TrainingManager(GraphExecutionManager):
                 # Disable materializing grads then None object will not be converted to a tensor filled with zeros prior to calling backward.
                 # Also save shape, device and type info to ctx for materializing tensor in backward if output grad is None.
                 ctx.set_materialize_grads(False)
-
                 return user_outputs
 
             @staticmethod
             def backward(ctx, *grad_outputs):
-                '''Performs backward pass based on grad wrt module output
-                '''
-                assert ctx.run_info is not None, 'forward() or __call__() methods must be called before backward()'
+                '''Performs backward pass based on grad wrt module output'''
 
-                # Assert that the grad_outputs and model device match
-                _ortmodule_utils._check_same_device(
-                    self._device, "Input argument to backward", *grad_outputs)
+                assert ctx.run_info is not None, 'forward() or __call__() methods must be called before backward()'
+                _utils._check_same_device(self._device, "Input argument to backward", *grad_outputs)
 
                 # Use IO binding
                 # Push user output grads to ONNX backend.
                 contiguous_grad_outputs = []
                 for idx, grad_output in enumerate(grad_outputs):
                     if idx in self._graph_info.output_grad_indices_non_differentiable:
-                        assert grad_output is None, "ORT found the {}-th module output '{}' is non-differentiable according to the onnx graph. " \
-                                                    "However, the gradient value is still provided by torch's autograd engine." \
-                                                    .format(idx, self._graph_info.user_output_names[idx]) 
+                        assert grad_output is None, "ORT found the {}-th module output '{}' is " \
+                                                    "non-differentiable according to the onnx graph. " \
+                                                    "However, the gradient value is still provided by " \
+                                                    "PyTorch's autograd engine." \
+                                                    .format(idx, self._graph_info.user_output_names[idx])
                         continue
-                    
+
                     if grad_output is None:
                         shape, device, dtype = ctx.run_info.output_info[idx]
                         if idx in self._graph_info.output_grad_indices_require_full_shape:
-                            grad_output = torch.zeros(
-                                shape, device=device, dtype=dtype)
+                            grad_output = torch.zeros(shape, device=device, dtype=dtype)
                         else:
-                            grad_output = torch.tensor(
-                                0., device=device, dtype=dtype)
+                            grad_output = torch.tensor(0., device=device, dtype=dtype)
                     elif not grad_output.is_contiguous():
                         grad_output = grad_output.contiguous()
                     contiguous_grad_outputs.append(grad_output)
-                backward_grad_output_ortvalue = [_ortmodule_utils._ortvalue_from_torch_tensor(
+                backward_grad_output_ortvalue = [_utils._ortvalue_from_torch_tensor(
                     grad_output) for grad_output in contiguous_grad_outputs]
 
                 # Run and get results
@@ -128,16 +125,18 @@ class TrainingManager(GraphExecutionManager):
                 backward_outputs = training_io_binding.get_outputs()
 
                 # Return input and initializer gradients
-                num_user_input_grads = len(self._input_names_require_grad)
+                num_user_input_grads = len(self._input_info.require_grad_names)
 
                 results = []
+                require_grad_names_set = set(self._input_info.require_grad_names)
+                require_grad_names_index = 0
                 for input_name in self._graph_info.user_input_names:
-                    try:
-                        # Append to the results the backward output for each input that required grad
-                        results.append(_ortmodule_utils._ortvalue_to_torch_tensor(
-                            backward_outputs[self._input_names_require_grad.index(input_name)]))
-                    except ValueError:
-                        # input_name is not found in the self._input_names_require_grad list
+                    # Append to the results the backward output for each input that required grad
+                    if input_name in require_grad_names_set:
+                        results.append(_utils._ortvalue_to_torch_tensor(backward_outputs[require_grad_names_index]))
+                        require_grad_names_index += 1
+                    else:
+                        # input_name is not found in the self._input_info.require_grad_names list
                         # Append None to results for each input that did not require grad
                         results.append(None)
 
@@ -147,7 +146,7 @@ class TrainingManager(GraphExecutionManager):
                 initializer_index = num_user_input_grads
                 for initializer_name in self._graph_info.initializer_names:
                     if initializer_name in initializer_names_to_train_set:
-                        results.append(_ortmodule_utils._ortvalue_to_torch_tensor(backward_outputs[initializer_index]))
+                        results.append(_utils._ortvalue_to_torch_tensor(backward_outputs[initializer_index]))
                         initializer_index += 1
                     else:
                         results.append(None)
@@ -155,15 +154,20 @@ class TrainingManager(GraphExecutionManager):
                 # The OrtValue has a shared_ptr to the data.
                 # At this point there are two shared_ptrs to the data, one through the
                 # OrtValue in the output iobinding, and the other through the copy in OrtDLManagedTensor.
-                # The following call clears the iobinding output, reducing the use_count to 1, so that once torch finishes computation
-                # on the DLpack tensors, the memory can be freed.
+                # The following call clears the iobinding output, reducing the use_count to 1,
+                # so that once torch finishes computation on the DLpack tensors, the memory can be freed.
                 training_io_binding.clear_binding_outputs()
                 return tuple(results)
 
-        return _ortmodule_io.populate_user_output_from_schema_and_outputs(
-            self._module_output_schema,
-            self._graph_info.user_output_names,
-            _ORTModuleFunction.apply(*self._convert_training_graph_input_to_list(*inputs, **kwargs)))
+        return _io.populate_user_output_from_schema_and_outputs(self._module_output_schema,
+                                                                self._graph_info.user_output_names,
+                                                                _ORTModuleFunction.apply(
+                                                                    *_io._convert_input_to_list(
+                                                                        self._flattened_module.named_parameters(),
+                                                                        self._graph_info.user_input_names,
+                                                                        self._flattened_module.named_buffers(),
+                                                                        inputs,
+                                                                        kwargs)))
 
     def _build_graph(self):
         """Build an optimized gradient graph using the module_graph_builder"""
@@ -171,33 +175,9 @@ class TrainingManager(GraphExecutionManager):
         super()._build_graph()
 
         if self._save_onnx:
-            onnx.save(self._optimized_onnx_model,
-                      self._save_onnx_prefix + '_training.onnx')
-
-            inference_optimized_model = onnx.load_model_from_string(
-                self._graph_builder.get_inference_optimized_model())
-
-            onnx.save(inference_optimized_model,
-                      self._save_onnx_prefix + '_inference_optimized.onnx')
-
-    def _get_exported_model_and_init_graph_builder(self, *inputs, **kwargs):
-        """Export the pytorch model in training mode
-
-        Returns True if model was exported and False if it has already been previously exported
-        """
-
-        did_export = self._export_model(*inputs, **kwargs)
-
-        if did_export:
-            # If model was exported, then initialize the graph builder
-            self._initialize_graph_builder(training=True)
-
-            # Save the onnx model if the model was exported
-            if self._save_onnx:
-                onnx.save(self._onnx_model,
-                        self._save_onnx_prefix + '_exported_training_model.onnx')
-
-        return did_export
+            onnx.save(self._optimized_onnx_model, self._save_onnx_prefix + '_training.onnx')
+            inference_optimized_model = onnx.load_model_from_string(self._graph_builder.get_inference_optimized_model())
+            onnx.save(inference_optimized_model, self._save_onnx_prefix + '_inference_optimized.onnx')
 
     def _create_execution_agent(self):
         """Creates a TrainingAgent that can run the forward and backward graph on the training model"""
@@ -206,21 +186,19 @@ class TrainingManager(GraphExecutionManager):
         self._execution_agent = onnxruntime.training.TrainingAgent(self._optimized_onnx_model.SerializeToString(),
                                                                    session_options, providers, provider_options)
 
-    def _reinitialize_graph_builder(self, input_names_require_grad):
+    def _reinitialize_graph_builder(self, input_info):
         """Return true if the module graph builder was reinitialized"""
 
         initializer_names_to_train_set_user_model = {name for name, param in
-            self._flattened_module.named_parameters() if param.requires_grad}
+                                                     self._flattened_module.named_parameters() if param.requires_grad}
         initializer_names_to_train_set_onnx_graph = set(self._graph_info.initializer_names_to_train) \
             if self._graph_info else None
 
         # If inputs requiring gradient change from forward to the next, the module_gradient_graph_builder
         # needs to be reinitialized so it can compute the backward output for the new inputs that require_grad
-        if input_names_require_grad != self._input_names_require_grad or \
-            initializer_names_to_train_set_user_model != initializer_names_to_train_set_onnx_graph:
-            self._input_names_require_grad = input_names_require_grad
+        if input_info.require_grad_names != self._input_info.require_grad_names or \
+                initializer_names_to_train_set_user_model != initializer_names_to_train_set_onnx_graph:
+            self._input_info = input_info
             self._initialize_graph_builder(training=True)
-
             return True
-
         return False

--- a/orttraining/orttraining/python/training/_ortmodule_utils.py
+++ b/orttraining/orttraining/python/training/_ortmodule_utils.py
@@ -5,13 +5,13 @@
 
 from . import _utils
 
-import onnxruntime
 from onnxruntime.capi.onnxruntime_inference_collection import OrtValue
 from onnxruntime.capi import _pybind_state as C
 
 import torch
 from torch.utils.dlpack import from_dlpack, to_dlpack
 from torch.utils.cpp_extension import load_inline
+
 
 def _ortvalue_to_torch_tensor(ortvalue):
     # PyTorch's to_dlpack() uses same config for both torch.bool and torch.uint8,
@@ -20,20 +20,22 @@ def _ortvalue_to_torch_tensor(ortvalue):
     torch_tensor = from_dlpack(ortvalue._ortvalue.to_dlpack())
     return torch_tensor.to(torch.bool) if ortvalue.data_type() == 'tensor(bool)' else torch_tensor
 
+
 def _ortvalue_from_torch_tensor(torch_tensor):
     return OrtValue(C.OrtValue.from_dlpack(to_dlpack(torch_tensor), torch_tensor.dtype == torch.bool))
+
 
 def _load_torch_gpu_allocator_cpp_extension(verbosity, is_rocm_pytorch):
     gpu_identifier = "hip" if is_rocm_pytorch else "cuda"
     gpu_allocator_header = "HIPCachingAllocator" if is_rocm_pytorch else "CUDACachingAllocator"
     torch_gpu_allocator_addresses_cpp_source = f"#include <torch/extension.h>\n" \
-    f"#include <c10/{gpu_identifier}/{gpu_allocator_header}.h>\n" \
-    f"size_t gpu_caching_allocator_raw_alloc_address() {{\n" \
-    f"    return reinterpret_cast<size_t>(&c10::{gpu_identifier}::{gpu_allocator_header}::raw_alloc);\n" \
-    f"}}\n" \
-    f"size_t gpu_caching_allocator_raw_delete_address() {{\n" \
-    f"    return reinterpret_cast<size_t>(&c10::{gpu_identifier}::{gpu_allocator_header}::raw_delete);\n" \
-    f"}}\n"
+        f"#include <c10/{gpu_identifier}/{gpu_allocator_header}.h>\n" \
+        f"size_t gpu_caching_allocator_raw_alloc_address() {{\n" \
+        f"    return reinterpret_cast<size_t>(&c10::{gpu_identifier}::{gpu_allocator_header}::raw_alloc);\n" \
+        f"}}\n" \
+        f"size_t gpu_caching_allocator_raw_delete_address() {{\n" \
+        f"    return reinterpret_cast<size_t>(&c10::{gpu_identifier}::{gpu_allocator_header}::raw_delete);\n" \
+        f"}}\n"
 
     return load_inline(name='inline_extension', cpp_sources=[torch_gpu_allocator_addresses_cpp_source],
                        extra_cflags=['-D__HIP_PLATFORM_HCC__=1' if is_rocm_pytorch else ''],
@@ -41,9 +43,11 @@ def _load_torch_gpu_allocator_cpp_extension(verbosity, is_rocm_pytorch):
                                   'gpu_caching_allocator_raw_delete_address'],
                        verbose=verbosity, with_cuda=True)
 
+
 def _check_same_device(device, argument_str, *args):
     '''Check that all tensor arguments in *args reside on the same device as the input device'''
 
+    assert isinstance(device, torch.device), '`device` must be a valid `torch.device` object'
     for arg in args:
         if arg is not None and isinstance(arg, torch.Tensor):
             arg_device = torch.device(arg.device)
@@ -51,12 +55,25 @@ def _check_same_device(device, argument_str, *args):
                 raise RuntimeError(
                     f"{argument_str} found on device {arg_device}, but expected it to be on module device {device}.")
 
+
+def get_device_from_module(module):
+    '''Returns the first device found in the `module`'s parameters or None'''
+    device = None
+    try:
+        device = next(module.parameters()).device
+        for param in module.parameters():
+            if param.device != device:
+                raise RuntimeError('ORTModule supports a single device per model for now')
+    except StopIteration:
+        # Model doesn't have a device set to any of the model parameters
+        pass
+    return device
+
+
 def _create_iobinding(io_binding, inputs, model, device):
     '''Creates IO binding for a `model` inputs and output'''
     for idx, value_info in enumerate(model.graph.input):
-        io_binding.bind_ortvalue_input(
-            value_info.name, _ortvalue_from_torch_tensor(inputs[idx]))
+        io_binding.bind_ortvalue_input(value_info.name, _ortvalue_from_torch_tensor(inputs[idx]))
 
     for value_info in model.graph.output:
-        io_binding.bind_output(value_info.name, device.type,
-                               device_id=_utils.get_device_index(device))
+        io_binding.bind_output(value_info.name, device.type, device_id=_utils.get_device_index(device))

--- a/orttraining/orttraining/python/training/_utils.py
+++ b/orttraining/orttraining/python/training/_utils.py
@@ -16,6 +16,7 @@ def get_device_index(device):
         return device
     return 0 if device.index is None else device.index
 
+
 def get_device_index_from_input(input):
     '''Returns device index from a input PyTorch Tensor'''
 
@@ -25,18 +26,6 @@ def get_device_index_from_input(input):
         device_index = get_device_index(input.device)
     return device_index
 
-def get_device_from_module(module):
-    '''Returns the first device found in the `module`'s parameters or None'''
-    device = None
-    try:
-        device = next(module.parameters()).device
-        for param in module.parameters():
-            if param.device != device:
-                raise RuntimeError('ORTModule supports a single device per model for now')
-    except StopIteration:
-        # Model doesn't have a device set to any of the model parameters
-        pass
-    return device
 
 def get_device_str(device):
     if isinstance(device, str):
@@ -53,6 +42,7 @@ def get_device_str(device):
     else:
         raise RuntimeError('Unsupported device type')
     return device
+
 
 def get_all_gradients_finite_name_from_session(session):
     '''Find all_gradients_finite node on Session graph and return its name'''
@@ -90,7 +80,7 @@ def dtype_torch_to_numpy(torch_dtype):
         # NOTE: numpy doesn't support bfloat16
         return np.float16
     elif torch_dtype == torch.int64 or torch_dtype == torch.long:
-        return np.longlong # np.int64 doesn't work!?
+        return np.longlong  # np.int64 doesn't work!?
     elif torch_dtype == torch.int32 or torch_dtype == torch.int:
         return np.int32
     elif torch_dtype == torch.int16 or torch_dtype == torch.short:
@@ -208,35 +198,42 @@ def import_module_from_file(file_path, module_name=None):
     spec.loader.exec_module(module)
     return module
 
+
 def state_dict_model_key():
     """Returns the model key name in the state dictionary"""
 
     return 'model'
+
 
 def state_dict_optimizer_key():
     """Returns the optimizer key name in the state dictionary"""
 
     return 'optimizer'
 
+
 def state_dict_partition_info_key():
     """Returns the partition info key name in the state dictionary"""
 
     return 'partition_info'
+
 
 def state_dict_trainer_options_key():
     """Returns the trainer options key name in the state dictionary"""
 
     return 'trainer_options'
 
+
 def state_dict_full_precision_key():
     """Returns the full precision key name in the state dictionary"""
 
     return 'full_precision'
 
+
 def state_dict_original_dimension_key():
     """Returns the original dimension key name in the state dictionary"""
 
     return 'original_dim'
+
 
 def state_dict_sharded_optimizer_keys():
     """Returns the optimizer key names that can be sharded in the state dictionary"""
@@ -246,40 +243,48 @@ def state_dict_sharded_optimizer_keys():
         'Moment_2'
     }
 
+
 def state_dict_user_dict_key():
     """Returns the user dict key name in the state dictionary"""
 
     return 'user_dict'
+
 
 def state_dict_trainer_options_mixed_precision_key():
     """Returns the trainer options mixed precision key name in the state dictionary"""
 
     return 'mixed_precision'
 
+
 def state_dict_trainer_options_zero_stage_key():
     """Returns the trainer options zero_stage key name in the state dictionary"""
 
     return 'zero_stage'
+
 
 def state_dict_trainer_options_world_rank_key():
     """Returns the trainer options world_rank key name in the state dictionary"""
 
     return 'world_rank'
 
+
 def state_dict_trainer_options_world_size_key():
     """Returns the trainer options world_size key name in the state dictionary"""
 
     return 'world_size'
+
 
 def state_dict_trainer_options_data_parallel_size_key():
     """Returns the trainer options data_parallel_size key name in the state dictionary"""
 
     return 'data_parallel_size'
 
+
 def state_dict_trainer_options_horizontal_parallel_size_key():
     """Returns the trainer options horizontal_parallel_size key name in the state dictionary"""
 
     return 'horizontal_parallel_size'
+
 
 def state_dict_trainer_options_optimizer_name_key():
     """Returns the trainer options optimizer_name key name in the state dictionary"""

--- a/orttraining/orttraining/python/training/model_desc_validation.py
+++ b/orttraining/orttraining/python/training/model_desc_validation.py
@@ -42,7 +42,6 @@ class _ORTTrainerModelDesc(object):
         self._OutputDescriptionTyped = namedtuple('OutputDescriptionTyped',
                                                   ['name', 'shape', 'is_loss', 'dtype', 'dtype_amp'])
         for idx, output in enumerate(self._validated['outputs']):
-            # import pdb; pdb.set_trace()
             if len(output) == 2:
                 self._validated['outputs'][idx] = self._OutputDescription(*output, False)
             else:

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -3,11 +3,12 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-from . import _ortmodule_output_transformation as _ortmodule_io
+from . import _ortmodule_io as _io
 from ._ortmodule_graph_execution_manager_factory import GraphExecutionManagerFactory
 
 from onnxruntime.training import register_custom_ops_pytorch_exporter
 
+import copy
 import functools
 import torch
 from typing import Iterator, Optional, Tuple, TypeVar
@@ -71,26 +72,25 @@ class ORTModule(torch.nn.Module):
         # User module is wrapped to use its initializers and save computed gradients
         self._original_module = module
         # Get the module that flattens the output from the original module into a tuple
-        self._flattened_output_module = \
-            _ortmodule_io.get_flattened_output_module(self._original_module)
+        self._flattened_module = _io.get_flattened_module(self._original_module)
 
-        self._execution_manager = GraphExecutionManagerFactory(self._flattened_output_module)
+        self._execution_manager = GraphExecutionManagerFactory(self._flattened_module)
 
     def _is_training(self):
-        return self._flattened_output_module.training and torch.is_grad_enabled()
+        return self._flattened_module.training and torch.is_grad_enabled()
 
     def eval(self: T) -> T:
-        self._flattened_output_module.eval()
+        self._flattened_module.eval()
 
     def train(self: T, mode: bool = True) -> T:
-        self._flattened_output_module.train(mode)
+        self._flattened_module.train(mode)
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):
         """Override original method to delegate execution to the base module"""
 
         # Override the state_dict() method so that the state dict key names
-        # do not contain the _flattened_output_module._base_module prefix
-        return self._flattened_output_module._base_module.state_dict(
+        # do not contain the _flattened_module._base_module prefix
+        return self._flattened_module._base_module.state_dict(
             destination=destination, prefix=prefix, keep_vars=keep_vars)
 
     def load_state_dict(self, state_dict: 'OrderedDict[str, Tensor]',
@@ -98,38 +98,38 @@ class ORTModule(torch.nn.Module):
         """Override original method to delegate execution to the base module"""
 
         # Override the load_state_dict() method so that the loaded state dict
-        # key names does not need to contain the _flattened_output_module._base_module prefix
-        return self._flattened_output_module._base_module.load_state_dict(
+        # key names does not need to contain the _flattened_module._base_module prefix
+        return self._flattened_module._base_module.load_state_dict(
             state_dict, strict=strict)
 
     def register_buffer(self, name: str, tensor: Optional[torch.Tensor], persistent: bool = True) -> None:
         """Override original method to delegate execution to the base module"""
-        self._flattened_output_module._base_module.register_buffer(name, tensor, persistent=persistent)
+        self._flattened_module._base_module.register_buffer(name, tensor, persistent=persistent)
 
     def register_parameter(self, name: str, param: Optional[torch.nn.Parameter]) -> None:
         """Override original method to delegate execution to the base module"""
-        self._flattened_output_module._base_module.register_parameter(name, param)
+        self._flattened_module._base_module.register_parameter(name, param)
 
     def get_parameter(self, target: str) -> torch.nn.Parameter:
         """Override original method to delegate execution to the base module"""
-        return self._flattened_output_module._base_module.get_parameter(target)
+        return self._flattened_module._base_module.get_parameter(target)
 
     def get_buffer(self, target: str) -> torch.Tensor:
         """Override original method to delegate execution to the base module"""
-        return self._flattened_output_module._base_module.get_buffer(target)
+        return self._flattened_module._base_module.get_buffer(target)
 
     def parameters(self, recurse: bool = True) -> Iterator[torch.nn.Parameter]:
         """Override original method to delegate execution to the base module"""
-        yield from self._flattened_output_module._base_module.parameters(recurse=recurse)
+        yield from self._flattened_module._base_module.parameters(recurse=recurse)
 
     def named_parameters(self, prefix: str = '', recurse: bool = True) -> Iterator[Tuple[str, torch.nn.Parameter]]:
         """Override original method to delegate execution to the base module"""
-        yield from self._flattened_output_module._base_module.named_parameters(prefix=prefix, recurse=recurse)
+        yield from self._flattened_module._base_module.named_parameters(prefix=prefix, recurse=recurse)
 
     def buffers(self, recurse: bool = True) -> Iterator[torch.Tensor]:
         """Override original method to delegate execution to the base module"""
-        yield from self._flattened_output_module._base_module.buffers(recurse=recurse)
+        yield from self._flattened_module._base_module.buffers(recurse=recurse)
 
     def named_buffers(self, prefix: str = '', recurse: bool = True) -> Iterator[Tuple[str, torch.Tensor]]:
         """Override original method to delegate execution to the base module"""
-        yield from self._flattened_output_module._base_module.named_buffers(prefix=prefix, recurse=recurse)
+        yield from self._flattened_module._base_module.named_buffers(prefix=prefix, recurse=recurse)

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -1281,7 +1281,6 @@ def testLossScalerLegacyAndExperimentalFullCycle():
             old_ls.update_loss_scale(train_step_info.all_finite)
             old_loss_scale = old_ls.loss_scale_
             assert new_ls._stable_steps_count == old_ls.stable_steps_
-            # import pdb; pdb.set_trace()
             assert_allclose(new_loss_scale, old_loss_scale)
 
         # 2000th update without overflow doubles the loss and zero stable steps until max_loss_scale is reached


### PR DESCRIPTION
Because ORTModule uses tracing for exporting `torch.nn.Module` models to ONNX, the graph has static input signature. That means the number of inputs and their types during the first feed forward will be expected to be respected throughout training. 

Many models, on the other hand, changes the number of input arguments, or their type/shape, during the course of training.

One class of mutating inputs are related to variable positional arguments (*args): 
Suppose the first call to `model(input1, *args)` in the training script is `model(torch.randn(2,3,dtype=torch.float32))`. That would result in a graph being created with a single input, with type float and shape (2,3). However, during training input could change to `model(torch.randn(2,2))` or `model(torch.randn(2,3, dtype=torch.half) or even `model(torch.randn(2,3), torch.randn(1,2,3,dtype=torch.half))`


A second class of mutating inpust are related to variable keyword arguments (**kwargs):
Suppose the first call to `model(input1=None,input2=None,input3=None)` in the training script is `model(input1=torch.randn(2,3,dtype=torch.float32))`. That would result in a graph being created with a single input called input1, with type float and shape (2,3). However, during training input could change to `model(input1=torch.randn(2,2))` or `model(input1=torch.randn(2,3, dtype=torch.half) or even `model(input1=torch.randn(2,3), input2=torch.randn(1,2,3,dtype=torch.half),input3=torch.ones(3,4))`

ORT would either failing executing such graph as the expected input does not match the actual input received during training or it would execute the graph ignoring the extra input.

Today, ORTModule supports training when the model takes completely static inputs or dynamic `*args`/`**kwrags` as input, but the number of arguments, their type must match in all batches, from the first iteration to the last. Shape-wise, the value of each dimension can be different during training, but the number of dimensions must match the first forward call!

This PR add support for scenarios in which there might be different number of arguments for both positional and keyword inputs or their types and shapes may change from one forward call to next, as exemplified above

The solution is basically building and keeping a schema for all the *args and **kwargs during model export and compare to the schema of the new incoming data. If a change is detected, model is re-exported. The schema only contains name (for dicts), type and number of dimensions (as opposed to shape). We do not consider the shape itself as we support dynamic axis and if the number of dimensions are same, we dont care about their actual values

Tests include scenarios with both varying positional and keyword arguments in both training and evaluation mode