### PR TITLE
Fix Zip-Nuget-Java Packaging Pipeline

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -1022,13 +1022,17 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             }
             catch (Exception ex)
             {
-                // If the exception is thrown because the opset version of the test model is
-                // not supported by ONNXRuntime yet, then ignore the and proceed.
-                // ORT allows commits from ONNX master and in such cases we do come across new opsets which are
-                // not supported in ORT yet. In order to force these tests to run set env var ALLOW_RELEASED_ONNX_OPSET_ONLY=0
-                if (!ex.Message.Contains("ONNX Runtime only *guarantees* support for models stamped with official released onnx opset versions"))
+                var msg = $"Opset {opset}, Model {modelName}: ModelFile = {onnxModelFileName} error = {ex.Message}";
+                if(ex.Message.Contains("ONNX Runtime only *guarantees* support for models stamped with official released onnx opset versions"))
                 {
-                    var msg = $"Opset {opset}, Model {modelName}: ModelFile = {onnxModelFileName} error = {ex.Message}";
+                    // If the exception is thrown because the opset version of the test model is
+                    // not supported by ONNXRuntime yet, then ignore the test and proceed.
+                    // ORT allows commits from ONNX master and in such cases we do come across new opsets which are
+                    // not supported in ORT yet. In order to force these tests to run set env var ALLOW_RELEASED_ONNX_OPSET_ONLY=0
+                    output.WriteLine("Skipping the model test as the latest ONNX opset is not supported yet. Error Message: " + msg);
+                }
+                else
+                {
                     throw new Exception(msg + "\n" + ex.StackTrace);
                 }
             }

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -1021,8 +1021,15 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             }
             catch (Exception ex)
             {
-                var msg = $"Opset {opset}, Model {modelName}: ModelFile = {onnxModelFileName} error = {ex.Message}";
-                throw new Exception(msg + "\n" + ex.StackTrace);
+                // If the exception is thrown because the opset version of the test model is
+                // not supported by ONNXRuntime yet, then ignore the and proceed.
+                // ORT allows commits from ONNX master and in such cases we do come across new opsets which are
+                // not supported in ORT yet. In order to force these tests to run set env var ALLOW_RELEASED_ONNX_OPSET_ONLY=0
+                if (!ex.Message.Contains("ONNX Runtime only *guarantees* support for models stamped with official released onnx opset versions"))
+                {
+                    var msg = $"Opset {opset}, Model {modelName}: ModelFile = {onnxModelFileName} error = {ex.Message}";
+                    throw new Exception(msg + "\n" + ex.StackTrace);
+                }
             }
         }
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -790,6 +790,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 { "test_training_dropout_default_mask", "node test error"},
                 { "test_min_int8", "node test error"},
                 { "test_cast_FLOAT_to_STRING", "node test error"},
+                { "test_identity_sequence", "data type not supported"}
             };
 
             // The following models fails on nocontribops win CI


### PR DESCRIPTION
**Description**: Updating csharp test to ignore errors generated because of unsupported opset versions. 


**Motivation and Context**
- Why is this change required? What problem does it solve?
- Fixing packaging pipeline
- If it fixes an open issue, please link to the issue here.
