### PR TITLE
[NNAPI/CoreML EP] Add Onnx opset 14 support

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/base_op_builder.h
+++ b/onnxruntime/core/providers/coreml/builders/impl/base_op_builder.h
@@ -40,7 +40,7 @@ class BaseOpBuilder : public IOpBuilder {
   virtual bool HasSupportedInputsImpl(const Node& node, const logging::Logger& logger) const;
 
   virtual int GetMinSupportedOpSet(const Node& /* node */) const { return 1; }
-  virtual int GetMaxSupportedOpSet(const Node& /* node */) const { return 13; }
+  virtual int GetMaxSupportedOpSet(const Node& /* node */) const { return 14; }
 
  private:
   bool HasSupportedOpSet(const Node& node, const logging::Logger& logger) const;

--- a/onnxruntime/core/providers/coreml/builders/impl/reshape_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/reshape_op_builder.cc
@@ -79,7 +79,9 @@ bool ReshapeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializer
     return false;
   }
 
-  const auto& perm_dims = initializers.at(perm_name)->dims();
+  const auto& shape_tensor = *initializers.at(perm_name);
+  const int64_t* raw_shape = GetTensorInt64Data(shape_tensor);
+  const auto perm_dims = shape_tensor.dims();
   if (perm_dims.empty() || perm_dims[0] == 0) {
     LOGS(logger, VERBOSE) << "New shape of reshape cannot be empty";
     return false;
@@ -92,6 +94,18 @@ bool ReshapeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializer
   if (input_shape.empty()) {
     LOGS(logger, VERBOSE) << "Reshape does not support empty input shape";
     return false;
+  }
+
+  // CoreML reshape does not support 0 as dimension
+  NodeAttrHelper helper(node);
+  bool allow_zero = helper.Get("allowzero ", 0) == 1;
+  if (allow_zero) {
+    for (int64_t i = 0; i < perm_dims[0]; i++) {
+      if (raw_shape[i] == 0) {
+        LOGS_DEFAULT(VERBOSE) << "Reshape doesn't suppport 0 reshape dimension when allowzero is enabled";
+        return false;
+      }
+    }
   }
 
   return true;

--- a/onnxruntime/core/providers/coreml/builders/impl/reshape_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/reshape_op_builder.cc
@@ -79,9 +79,9 @@ bool ReshapeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializer
     return false;
   }
 
-  const auto& shape_tensor = *initializers.at(perm_name);
-  const int64_t* raw_shape = GetTensorInt64Data(shape_tensor);
-  const auto perm_dims = shape_tensor.dims();
+  const auto& perm_tensor = *initializers.at(perm_name);
+  const int64_t* raw_perm = GetTensorInt64Data(perm_tensor);
+  const auto& perm_dims = perm_tensor.dims();
   if (perm_dims.empty() || perm_dims[0] == 0) {
     LOGS(logger, VERBOSE) << "New shape of reshape cannot be empty";
     return false;
@@ -98,11 +98,11 @@ bool ReshapeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializer
 
   // CoreML reshape does not support 0 as dimension
   NodeAttrHelper helper(node);
-  bool allow_zero = helper.Get("allowzero ", 0) == 1;
+  const bool allow_zero = helper.Get("allowzero ", 0) == 1;
   if (allow_zero) {
     for (int64_t i = 0; i < perm_dims[0]; i++) {
-      if (raw_shape[i] == 0) {
-        LOGS_DEFAULT(VERBOSE) << "Reshape doesn't suppport 0 reshape dimension when allowzero is enabled";
+      if (raw_perm[i] == 0) {
+        LOGS_DEFAULT(VERBOSE) << "Reshape doesn't support 0 reshape dimension when allowzero is enabled";
         return false;
       }
     }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -389,22 +389,22 @@ bool ReshapeOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& init
     return false;
   }
 
-  const auto& shape_tensor = *initializers.at(perm_name);
-  const int64_t* raw_shape = GetTensorInt64Data(shape_tensor);
-  const auto size = SafeInt<uint32_t>(shape_tensor.dims()[0]);
+  const auto& perm_tensor = *initializers.at(perm_name);
+  const int64_t* raw_perm = GetTensorInt64Data(perm_tensor);
+  const auto perm_size = SafeInt<uint32_t>(perm_tensor.dims()[0]);
 
   NodeAttrHelper helper(node);
-  bool allow_zero = helper.Get("allowzero ", 0) == 1;
-  for (uint32_t i = 0; i < size; i++) {
+  const bool allow_zero = helper.Get("allowzero ", 0) == 1;
+  for (uint32_t i = 0; i < perm_size; i++) {
     // NNAPI reshape does not support 0 as dimension
-    if (raw_shape[i] == 0) {
+    if (raw_perm[i] == 0) {
       if (i < input_shape.size() && input_shape[i] == 0) {
-        LOGS_DEFAULT(VERBOSE) << "Reshape doesn't suppport 0 reshape dimension on a dynamic dimension";
+        LOGS_DEFAULT(VERBOSE) << "Reshape doesn't support 0 reshape dimension on a dynamic dimension";
         return false;
       }
 
       if (allow_zero) {
-        LOGS_DEFAULT(VERBOSE) << "Reshape doesn't suppport 0 reshape dimension when allowzero is enabled";
+        LOGS_DEFAULT(VERBOSE) << "Reshape doesn't support 0 reshape dimension when allowzero is enabled";
         return false;
       }
     }
@@ -698,7 +698,7 @@ bool ConvOpSupportChecker::HasSupportedInputsImpl(const Node& node) const {
 bool ConvOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
                                              const OpSupportCheckParams& params) const {
   const auto& op_type = node.OpType();
-  bool is_qlinear_conv = (op_type == "QLinearConv");
+  const bool is_qlinear_conv = (op_type == "QLinearConv");
 
   // We don't support nhwc com.microsoft.QLinearConv for now
   if (is_qlinear_conv && node.Domain() == kMSDomain) {


### PR DESCRIPTION
**Description**: [NNAPI/CoreML EP] Add Onnx opset 14 support

**Motivation and Context**
- The only op need special handling (for NNAPI/CoreML EP) in Onnx opset 14 is ReShape with extra attributes "allowzero", detailed changes are here, https://github.com/onnx/onnx/wiki/Logistics-for-ONNX-Release-1.9
- Disable NNAPI for com.microsoft.QLinearConv which is nhwc QLinearConv which is not supported yet
