### PR TITLE
Add fp16 support for BatchNormalization Forward/Backward

### DIFF
--- a/onnxruntime/core/providers/cuda/nn/batch_norm.cc
+++ b/onnxruntime/core/providers/cuda/nn/batch_norm.cc
@@ -19,6 +19,8 @@ namespace cuda {
       T,                                                             \
       kCudaExecutionProvider,                                        \
       KernelDefBuilder()                                             \
+          .Alias(3, 1)                                               \
+          .Alias(4, 2)                                               \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()),    \
       BatchNorm<T>);                                                 \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                     \
@@ -28,6 +30,8 @@ namespace cuda {
       T,                                                             \
       kCudaExecutionProvider,                                        \
       KernelDefBuilder()                                             \
+          .Alias(3, 1)                                               \
+          .Alias(4, 2)                                               \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()),    \
       BatchNorm<T>);
 
@@ -85,6 +89,43 @@ Status BatchNorm<T>::ComputeInternal(OpKernelContext* p_op_kernel_context) const
     Impl_Cast<CudaT, float>(Stream(), b_data, f_B.get(), C);
     Impl_Cast<CudaT, float>(Stream(), mean_data, f_mean.get(), C);
     Impl_Cast<CudaT, float>(Stream(), var_data, f_var.get(), C);
+
+    // in BatchNorm Forward Training mode if all 5 outputs present
+    if (running_mean && running_var && saved_mean && saved_var) {
+      auto f_saved_mean = GetScratchBuffer<float>(C);
+      auto f_saved_inv_var = GetScratchBuffer<float>(C);
+
+      auto running_mean_data = reinterpret_cast<CudaT*>(running_mean->template MutableData<T>());
+      auto running_var_data = reinterpret_cast<CudaT*>(running_var->template MutableData<T>());
+      auto saved_mean_data = reinterpret_cast<CudaT*>(saved_mean->template MutableData<T>());
+      auto saved_inv_var_data = reinterpret_cast<CudaT*>(saved_var->template MutableData<T>());
+
+      CUDNN_RETURN_IF_ERROR(cudnnBatchNormalizationForwardTraining(
+          CudnnHandle(),
+          cudnn_batch_norm_mode_,
+          &alpha,
+          &beta,
+          data_desc,
+          x_data,
+          data_desc,
+          y_data,
+          bn_tensor_desc,
+          f_scale.get(),
+          f_B.get(),
+          momentum_,
+          f_mean.get(),
+          f_var.get(),
+          epsilon_,
+          f_saved_mean.get(),
+          f_saved_inv_var.get()));
+
+      Impl_Cast<float, CudaT>(Stream(), f_mean.get(), running_mean_data, C);
+      Impl_Cast<float, CudaT>(Stream(), f_var.get(), running_var_data, C);
+      Impl_Cast<float, CudaT>(Stream(), f_saved_mean.get(), saved_mean_data, C);
+      Impl_Cast<float, CudaT>(Stream(), f_saved_inv_var.get(), saved_inv_var_data, C);
+
+      return Status::OK();
+    }
 
     CUDNN_RETURN_IF_ERROR(cudnnBatchNormalizationForwardInference(
         CudnnHandle(),

--- a/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
+++ b/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
@@ -64,6 +64,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, LogSoftmaxGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, BatchNormalizationGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, BatchNormalizationGrad);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, BatchNormalizationGrad);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, GatherGrad);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, DropoutGrad);
 
@@ -213,7 +214,7 @@ Status RegisterCudaTrainingKernels(KernelRegistry& kernel_registry) {
 
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, ZeroGradient)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, ZeroGradient)>,
-    
+
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, DropoutGrad)>,
 
     // TODO: decprecate GatherND-1 after updating training models to opset-12
@@ -236,6 +237,7 @@ Status RegisterCudaTrainingKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, int64_t, SoftmaxCrossEntropyLossGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, BatchNormalizationGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, BatchNormalizationGrad)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, BatchNormalizationGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, GatherGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, DivGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, DivGrad)>,

--- a/orttraining/orttraining/training_ops/cuda/nn/batch_norm_grad.cc
+++ b/orttraining/orttraining/training_ops/cuda/nn/batch_norm_grad.cc
@@ -56,7 +56,7 @@ Status BatchNormalizationGrad<T>::ComputeInternal(OpKernelContext* ctx) const {
   ORT_RETURN_IF_ERROR(scale_bias_tensor.Set(input_tensor, cudnn_batch_norm_mode_));
 
   if (X->IsDataType<MLFloat16>()) {
-    const int C = input_shape.GetDims()[1];
+    const int64_t C = input_shape.GetDims()[1];
     auto f_scale = GetScratchBuffer<float>(C);
     auto f_dScale = GetScratchBuffer<float>(C);
     auto f_dBias = GetScratchBuffer<float>(C);


### PR DESCRIPTION
**Description**
- Add fp16 support for BatchNormalization ForwardTraining/Backward
- Bind inputs `mean` and `var` with outputs `mean` and `var`, respectively

**Motivation and Context**
- Currently BatchNormalization does not support fp16 and should be kept in fp32 when training
- Fix the problem that `running_mean` and `running_var` do not change in training mode