### PR TITLE
Support for saving and loading pytorch compatible state dictionaries

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -503,3 +503,17 @@ class ORTModule(torch.nn.Module):
                 'There was an error while exporting the PyTorch model to ONNX: {}'.format(e))
 
         return onnx.load_model_from_string(f.getvalue())
+
+    def state_dict(self, destination=None, prefix='', keep_vars=False):
+        # Override the state_dict() method so that the state dict key names
+        # do not contain the _flattened_output_module._base_module prefix
+        return self._flattened_output_module._base_module.state_dict(
+            destination=destination, prefix=prefix, keep_vars=keep_vars)
+
+    def load_state_dict(self, state_dict: 'OrderedDict[str, Tensor]',
+                        strict: bool = True):
+        # Override the load_state_dict() method so that the loaded state dict
+        # key names does not need to contain the _flattened_output_module._base_module prefix
+        return self._flattened_output_module._base_module.load_state_dict(
+            state_dict, strict=strict)
+

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -18,6 +18,7 @@ import torch
 import inspect
 from inspect import signature
 from enum import IntEnum
+from typing import Iterator, Optional, Tuple
 
 from torch.utils.dlpack import from_dlpack, to_dlpack
 from torch.utils.cpp_extension import load_inline
@@ -517,3 +518,26 @@ class ORTModule(torch.nn.Module):
         return self._flattened_output_module._base_module.load_state_dict(
             state_dict, strict=strict)
 
+    def register_buffer(self, name: str, tensor: Optional[torch.Tensor], persistent: bool = True) -> None:
+        self._flattened_output_module._base_module.register_buffer(name, tensor, persistent=persistent)
+
+    def register_parameter(self, name: str, param: Optional[torch.nn.Parameter]) -> None:
+        self._flattened_output_module._base_module.register_parameter(name, param)
+
+    def get_parameter(self, target: str) -> torch.nn.Parameter:
+        return self._flattened_output_module._base_module.get_parameter(target)
+
+    def get_buffer(self, target: str) -> torch.Tensor:
+        return self._flattened_output_module._base_module.get_buffer(target)
+
+    def parameters(self, recurse: bool = True) -> Iterator[torch.nn.Parameter]:
+        yield from self._flattened_output_module._base_module.parameters(recurse=recurse)
+
+    def named_parameters(self, prefix: str = '', recurse: bool = True) -> Iterator[Tuple[str, torch.nn.Parameter]]:
+        yield from self._flattened_output_module._base_module.named_parameters(prefix=prefix, recurse=recurse)
+
+    def buffers(self, recurse: bool = True) -> Iterator[torch.Tensor]:
+        yield from self._flattened_output_module._base_module.buffers(recurse=recurse)
+
+    def named_buffers(self, prefix: str = '', recurse: bool = True) -> Iterator[Tuple[str, torch.Tensor]]:
+        yield from self._flattened_output_module._base_module.named_buffers(prefix=prefix, recurse=recurse)

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -519,25 +519,33 @@ class ORTModule(torch.nn.Module):
             state_dict, strict=strict)
 
     def register_buffer(self, name: str, tensor: Optional[torch.Tensor], persistent: bool = True) -> None:
+        """Override original method to delegate execution to the base module"""
         self._flattened_output_module._base_module.register_buffer(name, tensor, persistent=persistent)
 
     def register_parameter(self, name: str, param: Optional[torch.nn.Parameter]) -> None:
+        """Override original method to delegate execution to the base module"""
         self._flattened_output_module._base_module.register_parameter(name, param)
 
     def get_parameter(self, target: str) -> torch.nn.Parameter:
+        """Override original method to delegate execution to the base module"""
         return self._flattened_output_module._base_module.get_parameter(target)
 
     def get_buffer(self, target: str) -> torch.Tensor:
+        """Override original method to delegate execution to the base module"""
         return self._flattened_output_module._base_module.get_buffer(target)
 
     def parameters(self, recurse: bool = True) -> Iterator[torch.nn.Parameter]:
+        """Override original method to delegate execution to the base module"""
         yield from self._flattened_output_module._base_module.parameters(recurse=recurse)
 
     def named_parameters(self, prefix: str = '', recurse: bool = True) -> Iterator[Tuple[str, torch.nn.Parameter]]:
+        """Override original method to delegate execution to the base module"""
         yield from self._flattened_output_module._base_module.named_parameters(prefix=prefix, recurse=recurse)
 
     def buffers(self, recurse: bool = True) -> Iterator[torch.Tensor]:
+        """Override original method to delegate execution to the base module"""
         yield from self._flattened_output_module._base_module.buffers(recurse=recurse)
 
     def named_buffers(self, prefix: str = '', recurse: bool = True) -> Iterator[Tuple[str, torch.Tensor]]:
+        """Override original method to delegate execution to the base module"""
         yield from self._flattened_output_module._base_module.named_buffers(prefix=prefix, recurse=recurse)

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -506,6 +506,8 @@ class ORTModule(torch.nn.Module):
         return onnx.load_model_from_string(f.getvalue())
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):
+        """Override original method to delegate execution to the base module"""
+
         # Override the state_dict() method so that the state dict key names
         # do not contain the _flattened_output_module._base_module prefix
         return self._flattened_output_module._base_module.state_dict(
@@ -513,6 +515,8 @@ class ORTModule(torch.nn.Module):
 
     def load_state_dict(self, state_dict: 'OrderedDict[str, Tensor]',
                         strict: bool = True):
+        """Override original method to delegate execution to the base module"""
+
         # Override the load_state_dict() method so that the loaded state dict
         # key names does not need to contain the _flattened_output_module._base_module prefix
         return self._flattened_output_module._base_module.load_state_dict(

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -1628,3 +1628,60 @@ def test_load_state_dict():
         assert param_name in state_dict_ort
         assert torch.equal(param_value, state_dict_ort[param_name])
 
+def test_named_parameters():
+    device = 'cuda'
+    N, D_in, H, D_out = 64, 784, 500, 10
+    pt_model = NeuralNetSinglePositionalArgument(D_in, H, D_out).to(device)
+    ort_model = ORTModule(copy.deepcopy(pt_model))
+    named_parameters_pt = [name for name, _ in pt_model.named_parameters()]
+    named_parameters_ort = [name for name, _ in ort_model.named_parameters()]
+
+    assert len(named_parameters_pt) > 0
+    assert named_parameters_pt == named_parameters_ort
+
+def test_parameters():
+    device = 'cuda'
+    N, D_in, H, D_out = 64, 784, 500, 10
+    pt_model = NeuralNetSinglePositionalArgument(D_in, H, D_out).to(device)
+    ort_model = ORTModule(copy.deepcopy(pt_model))
+    parameters_pt = [param for param in pt_model.parameters()]
+    parameters_ort = [param for param in ort_model.parameters()]
+
+    assert len(parameters_pt) > 0
+    assert len(parameters_pt) == len(parameters_ort)
+    assert all(torch.equal(parameters_pt[i], parameters_ort[i]) for i in range(len(parameters_pt)))
+
+def test_named_buffers():
+    device = 'cuda'
+    N, D_in, H, D_out = 64, 784, 500, 10
+    pt_model = NeuralNetSinglePositionalArgument(D_in, H, D_out).to(device)
+    pt_model.register_buffer('sample_buffer_pt', torch.tensor(torch.randn(N, D_in, device=device)))
+    ort_model = ORTModule(copy.deepcopy(pt_model))
+    named_buffers_pt = [name for name, _ in pt_model.named_buffers()]
+    named_buffers_ort = [name for name, _ in ort_model.named_buffers()]
+
+    assert len(named_buffers_pt) > 0
+    assert named_buffers_pt == named_buffers_ort
+
+    ort_model.register_buffer('sample_buffer_ort', torch.tensor(torch.randn(N, D_in, device=device)))
+    named_buffers_ort = [name for name, _ in ort_model.named_buffers()]
+    assert named_buffers_ort == ['sample_buffer_pt', 'sample_buffer_ort']
+
+def test_buffers():
+    device = 'cuda'
+    N, D_in, H, D_out = 64, 784, 500, 10
+    pt_model = NeuralNetSinglePositionalArgument(D_in, H, D_out).to(device)
+    pt_model.register_buffer('sample_buffer_pt', torch.tensor(torch.randn(N, D_in, device=device)))
+    ort_model = ORTModule(copy.deepcopy(pt_model))
+    buffers_pt = [buffer for buffer in pt_model.buffers()]
+    buffers_ort = [buffer for buffer in ort_model.buffers()]
+
+    assert len(buffers_pt) > 0
+    assert len(buffers_pt) == len(buffers_ort)
+    assert all(torch.equal(buffers_pt[i], buffers_ort[i]) for i in range(len(buffers_pt)))
+
+    x = torch.tensor(torch.randn(N, D_in, device=device))
+    ort_model.register_buffer('sample_buffer_ort', x)
+    buffers_ort = [buffer for buffer in ort_model.buffers()]
+    assert len(buffers_ort) == 2
+    assert torch.equal(buffers_ort[1], x)


### PR DESCRIPTION
**Description**: When retrieving the ```state_dict``` from ```ORTModule```, the key names had the ```_flattened_output_module._base_module``` prefix for all states (because of the specialized module inside ```ORTModule``` called ```self._flattened_output_module._base_module```). As a result, the loading of the state dictionary from a pytorch model also failed (since ```ORTModule``` expected the prefix to be there for all states).

This pull request overrides the ```state_dict()``` and the ```load_state_dict()``` methods and calls the same methods on the underlying specialized ```torch.nn.Module```.