### PR TITLE
Suppress tracer warnings from onnx export in ORTModule

### DIFF
--- a/orttraining/orttraining/python/training/_ortmodule_logger.py
+++ b/orttraining/orttraining/python/training/_ortmodule_logger.py
@@ -7,7 +7,6 @@ from contextlib import contextmanager
 from enum import IntEnum
 import io
 import sys
-import tempfile
 import warnings
 
 class LogLevel(IntEnum):
@@ -31,21 +30,22 @@ def suppress_os_stream_output(suppress_stdout=True, suppress_stderr=True, log_le
 
     suppress_logs = log_level >= LogLevel.WARNING
 
-    with tempfile.TemporaryFile(mode='w') as fo:
-        try:
-            if suppress_stdout and suppress_logs:
-                sys.stdout = fo
-            if suppress_stderr and suppress_logs:
-                sys.stderr = fo
-            yield
-        finally:
-            if suppress_stdout:
-                sys.stdout = stdout
-            if suppress_stderr:
-                sys.stderr = stderr
+    fo = io.StringIO()
 
-            if fo.tell() > 0 and suppress_logs:
-                # If anything was captured in fo, raise a single user warning letting users know that there was
-                # some warning or error that was raised
-                warnings.warn("There were one or more warnings or errors raised while exporting the PyTorch "
-                "model. Please enable INFO level logging to view all warnings and errors", UserWarning)
+    try:
+        if suppress_stdout and suppress_logs:
+            sys.stdout = fo
+        if suppress_stderr and suppress_logs:
+            sys.stderr = fo
+        yield
+    finally:
+        if suppress_stdout:
+            sys.stdout = stdout
+        if suppress_stderr:
+            sys.stderr = stderr
+
+        if fo.tell() > 0 and suppress_logs:
+            # If anything was captured in fo, raise a single user warning letting users know that there was
+            # some warning or error that was raised
+            warnings.warn("There were one or more warnings or errors raised while exporting the PyTorch "
+            "model. Please enable INFO level logging to view all warnings and errors.", UserWarning)

--- a/orttraining/orttraining/python/training/_ortmodule_logger.py
+++ b/orttraining/orttraining/python/training/_ortmodule_logger.py
@@ -1,0 +1,51 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+from contextlib import contextmanager
+from enum import IntEnum
+import io
+import sys
+import tempfile
+import warnings
+
+class LogLevel(IntEnum):
+    VERBOSE = 0
+    INFO = 1
+    WARNING = 2
+    ERROR = 3
+    FATAL = 4
+
+
+@contextmanager 
+def suppress_os_stream_output(suppress_stdout=True, suppress_stderr=True, log_level=LogLevel.WARNING):
+    """Supress output from being printed to stdout and stderr if log_level is WARNING or higher.
+
+    If there is any output detected, a single warning is issued at of the context
+    """
+
+    # stdout and stderr is written to a tempfile instead
+    stdout = sys.stdout
+    stderr = sys.stderr
+
+    suppress_logs = log_level >= LogLevel.WARNING
+
+    with tempfile.TemporaryFile(mode='w') as fo:
+        try:
+            if suppress_stdout and suppress_logs:
+                sys.stdout = fo
+            if suppress_stderr and suppress_logs:
+                sys.stderr = fo
+            yield
+        finally:
+            if suppress_stdout:
+                sys.stdout = stdout
+            if suppress_stderr:
+                sys.stderr = stderr
+
+            if fo.tell() > 0 and suppress_logs:
+                # If anything was captured in fo, raise a single user warning letting users know that there was
+                # some warning or error that was raised
+                warnings.warn("There were one or more warnings or errors raised while exporting the PyTorch "
+                "model. Please enable INFO level logging to view all warnings and errors", UserWarning)


### PR DESCRIPTION
**Description**: When exporting the PyTorch model to ONNX, the exporter threw some warning log lines such as:

```
TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  assert batch_size > 0, "batch_size has to be defined and > 0"
```

This could appear to the end user as being something serious where as it might not be. This pull request suppresses these warnings and writes them to ```os.devnull``` when exporting the onnx model.