### PR TITLE
Add error message for assertion error in ort_test_dir_utils

### DIFF
--- a/tools/python/ort_test_dir_utils.py
+++ b/tools/python/ort_test_dir_utils.py
@@ -218,7 +218,7 @@ def run_test_dir(model_or_dir):
             # e.g. ONNX test models 20190729\opset8\tf_mobilenet_v2_1.4_224
             if len(output_names) == 1 and output_names[0] == '':
                 output_names = [o.name for o in sess.get_outputs()]
-                assert(len(output_names) == 1)
+                assert len(output_names) == 1, 'There should be single output_name.'
                 expected_outputs[output_names[0]] = expected_outputs['']
                 expected_outputs.pop('')
 


### PR DESCRIPTION
**Description**
Add detailed reason why this assertion error happens.

**Motivation and Context**
While running ORT backend test for ONNX Model Zoo https://github.com/onnx/models/pull/384, ort_test_dir_utils.py fails without error message.