### PR TITLE
Add better model test error messaging

### DIFF
--- a/winml/test/model/model_tests.cpp
+++ b/winml/test/model/model_tests.cpp
@@ -143,6 +143,10 @@ std::string GetTestDataPath() {
     auto hardcodedModelPath = parentPath.string() + "\\models";
     if (std::filesystem::exists(hardcodedModelPath) && hardcodedModelPath.length() <= MAX_PATH) {
       return hardcodedModelPath;
+    } else {
+      std::string errorStr = "WINML_TEST_DATA_PATH environment variable path not found and \"models\" folder not found in same directory as test exe.\n";
+      std::cerr << errorStr;
+      throw std::exception(errorStr.c_str());
     }
   }
   const std::string testDataPathFolderName = "\\testData\\";


### PR DESCRIPTION
This change adds an error message that prints when a model test collateral folder cannot be found from one of these 2 ways:

- WINML_TEST_DATA_PATH environment variable being set
- Local "models" folder that is contained next to the test executable.
