### PR TITLE
QDQ: type conversion and more ops support

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -42,10 +42,10 @@ static const char* const kOrtSessionOptionsConfigSaveModelFormat = "session.save
 static const char* const kOrtSessionOptionsConfigSetDenormalAsZero = "session.set_denormal_as_zero";
 
 // It controls to run quantization model in QDQ (QuantizelinearDeQuantizelinear) format or not.
-// "0": disable. ORT doesn't do fusion logic for QDQ format.
-// "1": enable. ORT does fusion logic for QDQ format.
-// Its default value is "1"
-static const char* const kOrtSessionOptionsEnableQuantQDQ = "session.enable_quant_qdq";
+// "0": enable. ORT does fusion logic for QDQ format.
+// "1": disable. ORT doesn't do fusion logic for QDQ format.
+// Its default value is "0"
+static const char* const kOrtSessionOptionsDisableQuantQDQ = "session.disable_quant_qdq";
 
 // Enable or disable gelu approximation in graph optimization. "0": disable; "1": enable. The default is "0".
 // GeluApproximation has side effects which may change the inference results. It is disabled by default due to this.

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -70,6 +70,7 @@ std::vector<std::unique_ptr<RewriteRule>> GenerateRewriteRules(
       rules.push_back(onnxruntime::make_unique<ConvAddFusion>());
       rules.push_back(onnxruntime::make_unique<ConvMulFusion>());
       rules.push_back(onnxruntime::make_unique<ConvBNFusion>());
+      rules.push_back(onnxruntime::make_unique<ReluQuantFusion>());
       break;
 
     case TransformerLevel::Level2:
@@ -139,10 +140,6 @@ std::vector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       transformers.emplace_back(onnxruntime::make_unique<ReshapeFusion>());
       transformers.emplace_back(onnxruntime::make_unique<FreeDimensionOverrideTransformer>(
           session_options.free_dimension_overrides));
-
-      if (!disable_quant_qdq) {
-        transformers.emplace_back(onnxruntime::make_unique<ReluQuantTransformer>());
-      }
 
       rule_transformer = GenerateRuleBasedGraphTransformer(level, rules_and_transformers_to_disable, {});
     } break;

--- a/onnxruntime/core/optimizer/initializer.h
+++ b/onnxruntime/core/optimizer/initializer.h
@@ -26,7 +26,7 @@ class Initializer final {
     size_ = std::accumulate(dims_.begin(), dims_.end(), int64_t(1), std::multiplies<int64_t>{});
 
     switch (data_type_) {
-      case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:{
+      case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16: {
         float16_data_.assign(static_cast<size_t>(size_), math::floatToHalf(0.f));
         break;
       }
@@ -41,6 +41,14 @@ class Initializer final {
       }
       case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE: {
         double_data_.assign(static_cast<size_t>(size_), 0.0);
+        break;
+      }
+      case ONNX_NAMESPACE::TensorProto_DataType_INT8: {
+        int8_data_.assign(static_cast<size_t>(size_), 0);
+        break;
+      }
+      case ONNX_NAMESPACE::TensorProto_DataType_UINT8: {
+        uint8_data_.assign(static_cast<size_t>(size_), 0);
         break;
       }
       case ONNX_NAMESPACE::TensorProto_DataType_INT32: {
@@ -74,7 +82,7 @@ class Initializer final {
         raw_data_.assign(tensor_proto.raw_data().begin(), tensor_proto.raw_data().end());
       } else {
         switch (data_type_) {
-          case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16: 
+          case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
           case ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16: {
             int64_t size = tensor_proto.int32_data_size();
             ORT_ENFORCE(size_ == size, "size is different");
@@ -96,6 +104,22 @@ class Initializer final {
             ORT_ENFORCE(size_ == size, "size is different");
             for (int i = 0; i < size_; i++) {
               double_data_.push_back(tensor_proto.double_data(i));
+            }
+            break;
+          }
+          case ONNX_NAMESPACE::TensorProto_DataType_INT8: {
+            int64_t size = tensor_proto.int32_data_size();
+            ORT_ENFORCE(size_ == size, "size is different");
+            for (int i = 0; i < size_; i++) {
+              int8_data_.push_back(static_cast<int8_t>(tensor_proto.int32_data(i)));
+            }
+            break;
+          }
+          case ONNX_NAMESPACE::TensorProto_DataType_UINT8: {
+            int64_t size = tensor_proto.int32_data_size();
+            ORT_ENFORCE(size_ == size, "size is different");
+            for (int i = 0; i < size_; i++) {
+              uint8_data_.push_back(static_cast<uint8_t>(tensor_proto.int32_data(i)));
             }
             break;
           }
@@ -147,7 +171,7 @@ class Initializer final {
       tensor_proto.set_raw_data(raw_data_.data(), raw_data_.size());
     } else {
       switch (data_type_) {
-        case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16: 
+        case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
         case ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16: {
           tensor_proto.clear_int32_data();
           for (int i = 0; i < size_; i++) {
@@ -166,6 +190,20 @@ class Initializer final {
           tensor_proto.clear_double_data();
           for (int i = 0; i < size_; i++) {
             tensor_proto.add_double_data(double_data_[i]);
+          }
+          break;
+        }
+        case ONNX_NAMESPACE::TensorProto_DataType_INT8: {
+          tensor_proto.clear_int32_data();
+          for (int i = 0; i < size_; i++) {
+            tensor_proto.add_int32_data(int8_data_[i]);
+          }
+          break;
+        }
+        case ONNX_NAMESPACE::TensorProto_DataType_UINT8: {
+          tensor_proto.clear_int32_data();
+          for (int i = 0; i < size_; i++) {
+            tensor_proto.add_int32_data(uint8_data_[i]);
           }
           break;
         }
@@ -299,6 +337,14 @@ class Initializer final {
         return reinterpret_cast<T*>(double_data_.data());
         break;
       }
+      case ONNX_NAMESPACE::TensorProto_DataType_INT8: {
+        return reinterpret_cast<T*>(int8_data_.data());
+        break;
+      }
+      case ONNX_NAMESPACE::TensorProto_DataType_UINT8: {
+        return reinterpret_cast<T*>(uint8_data_.data());
+        break;
+      }
       case ONNX_NAMESPACE::TensorProto_DataType_INT32: {
         return reinterpret_cast<T*>(int32_data_.data());
         break;
@@ -331,6 +377,14 @@ class Initializer final {
       }
       case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE: {
         return reinterpret_cast<const T*>(double_data_.data());
+        break;
+      }
+      case ONNX_NAMESPACE::TensorProto_DataType_INT8: {
+        return reinterpret_cast<const T*>(int8_data_.data());
+        break;
+      }
+      case ONNX_NAMESPACE::TensorProto_DataType_UINT8: {
+        return reinterpret_cast<const T*>(uint8_data_.data());
         break;
       }
       case ONNX_NAMESPACE::TensorProto_DataType_INT32: {
@@ -752,6 +806,8 @@ class Initializer final {
   std::vector<float> float_data_;
   std::vector<uint16_t> float16_data_;
   std::vector<double> double_data_;
+  std::vector<int8_t> int8_data_;
+  std::vector<uint8_t> uint8_data_;
   std::vector<int32_t> int32_data_;
   std::vector<int64_t> int64_data_;
 };

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_binary_op.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_binary_op.cc
@@ -13,23 +13,23 @@ class QDQBinaryOpTransformer : public QDQOperatorTransformer {
   QDQBinaryOpTransformer(Node& node, Graph& graph) : QDQOperatorTransformer(node, graph) {}
 
  protected:
-  bool TransformImpl(const std::vector<const Node*>& parents, const std::vector<const Node*>& children) override {
-    std::vector<NodeArg*> input_defs(graph_.GetNode(parents[0]->Index())->MutableInputDefs());
-    Node* b = graph_.GetNode(parents[1]->Index());
+  bool TransformImpl(const std::vector<const Node*>& dq_nodes, const std::vector<const Node*>& q_nodes) override {
+    std::vector<NodeArg*> input_defs(graph_.GetNode(dq_nodes[0]->Index())->MutableInputDefs());
+    Node* b = graph_.GetNode(dq_nodes[1]->Index());
     input_defs.insert(input_defs.end(), b->MutableInputDefs().begin(), b->MutableInputDefs().end());
 
-    Node* q = graph_.GetNode(children[0]->Index());
+    Node* q = graph_.GetNode(q_nodes[0]->Index());
     input_defs.push_back(q->MutableInputDefs()[1]);
     input_defs.push_back(q->MutableInputDefs()[2]);
 
-    Node& qlinear_conv_node = graph_.AddNode(node_.Name(),
-                                             "QLinear" + node_.OpType(),
-                                             node_.Description(),
-                                             input_defs,
-                                             q->MutableOutputDefs(),
-                                             &node_.GetAttributes(),
-                                             kMSDomain);
-    qlinear_conv_node.SetExecutionProviderType(kCpuExecutionProvider);
+    graph_.AddNode(node_.Name(),
+                   "QLinear" + node_.OpType(),
+                   node_.Description(),
+                   input_defs,
+                   q->MutableOutputDefs(),
+                   &node_.GetAttributes(),
+                   kMSDomain)
+        .SetExecutionProviderType(kCpuExecutionProvider);
     return true;
   }
 };

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_binary_op.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_binary_op.cc
@@ -12,14 +12,8 @@ class QDQBinaryOpTransformer : public QDQOperatorTransformer {
  public:
   QDQBinaryOpTransformer(Node& node, Graph& graph) : QDQOperatorTransformer(node, graph) {}
 
-  bool Transform(const std::vector<const Node*>& parents, const std::vector<const Node*>& children) override {
-    if (children.size() != 1 || parents.size() != 2) {
-      return false;
-    }
-
-    FillQDQOptionalZeroPoint(parents);
-    FillQDQOptionalZeroPoint(children);
-
+ protected:
+  bool TransformImpl(const std::vector<const Node*>& parents, const std::vector<const Node*>& children) override {
     std::vector<NodeArg*> input_defs(graph_.GetNode(parents[0]->Index())->MutableInputDefs());
     Node* b = graph_.GetNode(parents[1]->Index());
     input_defs.insert(input_defs.end(), b->MutableInputDefs().begin(), b->MutableInputDefs().end());

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_conv.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_conv.cc
@@ -12,33 +12,27 @@ class QDQConvTransformer : public QDQOperatorTransformer {
  public:
   QDQConvTransformer(Node& node, Graph& graph) : QDQOperatorTransformer(node, graph) {}
 
-  bool Transform(const std::vector<const Node*>& parents, const std::vector<const Node*>& children) override {
-    if (parents.size() < 2 || children.size() != 1) {
-      return false;
-    }
-
-    FillQDQOptionalZeroPoint(parents);
-    FillQDQOptionalZeroPoint(children);
-
-    std::vector<NodeArg*> input_defs(graph_.GetNode(parents[0]->Index())->MutableInputDefs());
-    Node* weight = graph_.GetNode(parents[1]->Index());
+ protected:
+  bool TransformImpl(const std::vector<const Node*>& dq_nodes, const std::vector<const Node*>& q_nodes) override {
+    std::vector<NodeArg*> input_defs(graph_.GetNode(dq_nodes[0]->Index())->MutableInputDefs());
+    Node* weight = graph_.GetNode(dq_nodes[1]->Index());
     input_defs.insert(input_defs.end(), weight->MutableInputDefs().begin(), weight->MutableInputDefs().end());
 
-    Node* q = graph_.GetNode(children[0]->Index());
+    Node* q = graph_.GetNode(q_nodes[0]->Index());
     input_defs.push_back(q->MutableInputDefs()[1]);
     input_defs.push_back(q->MutableInputDefs()[2]);
-    if (parents.size() == 3) {
-      input_defs.push_back(graph_.GetNode(parents[2]->Index())->MutableInputDefs()[0]);
+    if (dq_nodes.size() == 3) {
+      input_defs.push_back(graph_.GetNode(dq_nodes[2]->Index())->MutableInputDefs()[0]);
     }
 
-    Node& qlinear_conv_node = graph_.AddNode(node_.Name(),
-                                             "QLinearConv",
-                                             node_.Description(),
-                                             input_defs,
-                                             q->MutableOutputDefs(),
-                                             &node_.GetAttributes(),
-                                             kOnnxDomain);
-    qlinear_conv_node.SetExecutionProviderType(kCpuExecutionProvider);
+    graph_.AddNode(node_.Name(),
+                   "QLinearConv",
+                   node_.Description(),
+                   input_defs,
+                   q->MutableOutputDefs(),
+                   &node_.GetAttributes(),
+                   kOnnxDomain)
+        .SetExecutionProviderType(kCpuExecutionProvider);
 
     return true;
   }

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_matmul.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_matmul.cc
@@ -12,12 +12,12 @@ class QDQMatMulTransformer : public QDQOperatorTransformer {
  public:
   QDQMatMulTransformer(Node& node, Graph& graph) : QDQOperatorTransformer(node, graph) {}
 
-  bool TransformImpl(const std::vector<const Node*>& parents, const std::vector<const Node*>& children) override {
-    std::vector<NodeArg*> input_defs(graph_.GetNode(parents[0]->Index())->MutableInputDefs());
-    Node* b = graph_.GetNode(parents[1]->Index());
+  bool TransformImpl(const std::vector<const Node*>& dq_nodes, const std::vector<const Node*>& q_nodes) override {
+    std::vector<NodeArg*> input_defs(graph_.GetNode(dq_nodes[0]->Index())->MutableInputDefs());
+    Node* b = graph_.GetNode(dq_nodes[1]->Index());
     input_defs.insert(input_defs.end(), b->MutableInputDefs().begin(), b->MutableInputDefs().end());
 
-    Node* q = graph_.GetNode(children[0]->Index());
+    Node* q = graph_.GetNode(q_nodes[0]->Index());
     input_defs.push_back(q->MutableInputDefs()[1]);
     input_defs.push_back(q->MutableInputDefs()[2]);
 

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_matmul.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_matmul.cc
@@ -12,14 +12,7 @@ class QDQMatMulTransformer : public QDQOperatorTransformer {
  public:
   QDQMatMulTransformer(Node& node, Graph& graph) : QDQOperatorTransformer(node, graph) {}
 
-  bool Transform(const std::vector<const Node*>& parents, const std::vector<const Node*>& children) override {
-    if (parents.size() != 2 || children.size() != 1) {
-      return false;
-    }
-
-    FillQDQOptionalZeroPoint(parents);
-    FillQDQOptionalZeroPoint(children);
-
+  bool TransformImpl(const std::vector<const Node*>& parents, const std::vector<const Node*>& children) override {
     std::vector<NodeArg*> input_defs(graph_.GetNode(parents[0]->Index())->MutableInputDefs());
     Node* b = graph_.GetNode(parents[1]->Index());
     input_defs.insert(input_defs.end(), b->MutableInputDefs().begin(), b->MutableInputDefs().end());

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_op_transformer.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_op_transformer.h
@@ -19,7 +19,7 @@ class QDQOperatorTransformer {
  public:
   QDQOperatorTransformer(Node& node, Graph& graph) : node_(node), graph_(graph) {}
   virtual ~QDQOperatorTransformer() {}
-  virtual bool Transform(const std::vector<const Node*>& dq_nodes, const std::vector<const Node*>& q_nodes) = 0;
+  bool Transform(const std::vector<const Node*>& dq_nodes, const std::vector<const Node*>& q_nodes);
 
   /* Determine whether to keep node_ itself or not.
            For operators that support int8, keep node_ and only change its input and output.
@@ -29,11 +29,23 @@ class QDQOperatorTransformer {
     return false;
   }
 
-  void FillQDQOptionalZeroPoint(const std::vector<const Node*>& parents);
-
  protected:
+  // A general check QDQ and Op fusion. It requires:
+  //   1. All inputs of Op come from DequantizeLinear
+  //   2. All outputs of Op flows to QuantizeLinear
+  //   3. Op outputs are not graph outputs
+  // Override this function if it is not case for certain op
+  virtual bool Check(const std::vector<const Node*>& dq_nodes, const std::vector<const Node*>& q_nodes) const;
+
+  // Implement the fusion process
+  // Prerequisites are handled in Transform. You can assume it is valid to fuse when implementing.
+  virtual bool TransformImpl(const std::vector<const Node*>& dq_nodes, const std::vector<const Node*>& q_nodes) = 0;
+
   Node& node_;
   Graph& graph_;
+
+ private:
+  void FillQDQOptionalZeroPoint(const std::vector<const Node*>& parents);
 
   static const ONNX_NAMESPACE::TensorProto optional_zero_point_int8_;
   static const ONNX_NAMESPACE::TensorProto optional_zero_point_uint8_;

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "qdq_s8_to_u8.h"
+
+#include "core/graph/graph_utils.h"
+#include "core/optimizer/initializer.h"
+#include "core/optimizer/utils.h"
+
+namespace onnxruntime {
+
+// Convert QuantizeLinear and DequantizeLinear pair with type int8_t to type uint8_t
+Status QDQS8ToU8Transformer::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
+  GraphViewer graph_viewer(graph);
+  const auto& node_topology_list = graph_viewer.GetNodesInTopologicalOrder();
+
+  for (auto node_index : node_topology_list) {
+    auto* q_node_ptr = graph.GetNode(node_index);
+    if (q_node_ptr == nullptr)
+      continue;  // node removed as part of an earlier fusion
+
+    // recognize Q + DQ
+    Node& q_node = *q_node_ptr;
+    ORT_RETURN_IF_ERROR(Recurse(q_node, modified, graph_level, logger));
+
+    if (q_node.OpType() != "QuantizeLinear" ||
+        !graph_utils::MatchesOpSetDomain(q_node, kOnnxDomain) ||
+        !graph_utils::IsSupportedProvider(q_node, GetCompatibleExecutionProviders()) ||
+        !optimizer_utils::CheckOutputEdges(graph, q_node, 1)) {
+      continue;
+    }
+
+    Node& dq_node = *graph.GetNode(q_node.OutputNodesBegin()->Index());
+    if (dq_node.OpType() != "DequantizeLinear" ||
+        !graph_utils::MatchesOpSetDomain(dq_node, kOnnxDomain) ||
+        !graph_utils::IsSupportedProvider(dq_node, GetCompatibleExecutionProviders())) {
+      continue;
+    }
+
+    std::vector<NodeArg*>& q_input_defs = q_node.MutableInputDefs();
+    std::vector<NodeArg*>& dq_input_defs = dq_node.MutableInputDefs();
+
+    constexpr size_t input_cnt_required = 3;
+    if (q_input_defs.size() != input_cnt_required ||
+        dq_input_defs.size() != input_cnt_required) {
+      continue;
+    }
+
+    constexpr size_t zp_idx = 2;
+    const ONNX_NAMESPACE::TensorProto* q_zp_tensor_proto = nullptr;
+    const ONNX_NAMESPACE::TensorProto* dq_zp_tensor_proto = nullptr;
+    if (!graph_utils::NodeArgIsConstant(graph, *q_input_defs[zp_idx]) ||
+        !graph_utils::NodeArgIsConstant(graph, *dq_input_defs[zp_idx]) ||
+        !graph.GetInitializedTensor(q_input_defs[zp_idx]->Name(), q_zp_tensor_proto) ||
+        !graph.GetInitializedTensor(dq_input_defs[zp_idx]->Name(), dq_zp_tensor_proto)) {
+      continue;
+    }
+
+    using ONNX_TENSOR_ELEM_TYPE = ONNX_NAMESPACE::TensorProto::DataType;
+    Initializer q_zero_point(*q_zp_tensor_proto, graph.ModelPath());
+    Initializer dq_zero_point(*dq_zp_tensor_proto, graph.ModelPath());
+    if (q_zero_point.size() != 1 ||
+        dq_zero_point.size() != 1 ||
+        q_zero_point.data_type() != ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_INT8 ||
+        dq_zero_point.data_type() != ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_INT8) {
+      continue;
+    }
+
+    uint8_t q_zp_value = *q_zero_point.data<int8_t>() + 128;
+    uint8_t dq_zp_value = *dq_zero_point.data<int8_t>() + 128;
+
+    if (q_zp_value != dq_zp_value) {
+      continue;  // zero points for Q and DQ are expected to be same
+    }
+
+    ONNX_NAMESPACE::TensorProto zp_tensor_proto_u8;
+    zp_tensor_proto_u8.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_UINT8);
+    zp_tensor_proto_u8.set_name(graph.GenerateNodeArgName("qdq_s8_to_u8_zp_conversion"));
+    zp_tensor_proto_u8.set_raw_data(&q_zp_value, sizeof(uint8_t));
+    zp_tensor_proto_u8.add_dims(1);
+    NodeArg* zp_u8_arg = &graph_utils::AddInitializer(graph, zp_tensor_proto_u8);
+
+    auto q_output_node_arg_name = graph.GenerateNodeArgName("qdq_s8_to_u8_quant");
+    NodeArg* q_output_arg = &graph.GetOrCreateNodeArg(q_output_node_arg_name, nullptr);
+
+    q_node.MutableOutputDefs()[0] = q_output_arg;
+    dq_input_defs[0] = q_output_arg;
+    q_input_defs[zp_idx] = zp_u8_arg;
+    dq_input_defs[zp_idx] = zp_u8_arg;
+
+    modified = true;
+  }
+
+  return Status::OK();
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
@@ -23,16 +23,14 @@ Status QDQS8ToU8Transformer::ApplyImpl(Graph& graph, bool& modified, int graph_l
     Node& q_node = *q_node_ptr;
     ORT_RETURN_IF_ERROR(Recurse(q_node, modified, graph_level, logger));
 
-    if (q_node.OpType() != "QuantizeLinear" ||
-        !graph_utils::MatchesOpSetDomain(q_node, kOnnxDomain) ||
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(q_node, "QuantizeLinear", {10, 13}) ||
         !graph_utils::IsSupportedProvider(q_node, GetCompatibleExecutionProviders()) ||
         !optimizer_utils::CheckOutputEdges(graph, q_node, 1)) {
       continue;
     }
 
     Node& dq_node = *graph.GetNode(q_node.OutputNodesBegin()->Index());
-    if (dq_node.OpType() != "DequantizeLinear" ||
-        !graph_utils::MatchesOpSetDomain(dq_node, kOnnxDomain) ||
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(dq_node, "DequantizeLinear", {10, 13}) ||
         !graph_utils::IsSupportedProvider(dq_node, GetCompatibleExecutionProviders())) {
       continue;
     }

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
@@ -77,7 +77,6 @@ Status QDQS8ToU8Transformer::ApplyImpl(Graph& graph, bool& modified, int graph_l
     zp_tensor_proto_u8.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_UINT8);
     zp_tensor_proto_u8.set_name(graph.GenerateNodeArgName("qdq_s8_to_u8_zp_conversion"));
     zp_tensor_proto_u8.set_raw_data(&q_zp_value, sizeof(uint8_t));
-    zp_tensor_proto_u8.add_dims(1);
     NodeArg* zp_u8_arg = &graph_utils::AddInitializer(graph, zp_tensor_proto_u8);
 
     auto q_output_node_arg_name = graph.GenerateNodeArgName("qdq_s8_to_u8_quant");

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/optimizer/graph_transformer.h"
+
+namespace onnxruntime {
+
+/**
+    @Class QDQS8ToU8Transformer
+
+    Convert QuantizeLinear and DequantizeLinear pair with type int8_t to type uint8_t
+    */
+class QDQS8ToU8Transformer : public GraphTransformer {
+ public:
+  QDQS8ToU8Transformer(const std::unordered_set<std::string>& compatible_execution_providers = {}) noexcept
+      : GraphTransformer("QDQS8ToU8Transformer", compatible_execution_providers) {}
+
+ private:
+  Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/qdq_transformer/registry.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/registry.cc
@@ -10,6 +10,7 @@ DECLARE_QDQ_CREATOR(Reshape, QDQReshapeTransformer)
 DECLARE_QDQ_CREATOR(Add, QDQBinaryOpTransformer)
 DECLARE_QDQ_CREATOR(Mul, QDQBinaryOpTransformer)
 DECLARE_QDQ_CREATOR(MatMul, QDQMatMulTransformer)
+DECLARE_QDQ_CREATOR(AveragePool, QDQAveragePoolTransformer)
 std::unordered_map<std::string, QDQRegistry::QDQTransformerCreator> QDQRegistry::qdqtransformer_creators_{
     REGISTER_QDQ_CREATOR(Conv, QDQConvTransformer),
     REGISTER_QDQ_CREATOR(MaxPool, QDQSimpleTransformer),
@@ -17,5 +18,6 @@ std::unordered_map<std::string, QDQRegistry::QDQTransformerCreator> QDQRegistry:
     REGISTER_QDQ_CREATOR(Add, QDQBinaryOpTransformer),
     REGISTER_QDQ_CREATOR(Mul, QDQBinaryOpTransformer),
     REGISTER_QDQ_CREATOR(MatMul, QDQMatMulTransformer),
+    REGISTER_QDQ_CREATOR(AveragePool, QDQAveragePoolTransformer),
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/qdq_transformer/registry.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/registry.cc
@@ -6,14 +6,14 @@
 namespace onnxruntime {
 DECLARE_QDQ_CREATOR(Conv, QDQConvTransformer)
 DECLARE_QDQ_CREATOR(MaxPool, QDQSimpleTransformer)
-DECLARE_QDQ_CREATOR(Reshape, QDQSimpleTransformer)
+DECLARE_QDQ_CREATOR(Reshape, QDQReshapeTransformer)
 DECLARE_QDQ_CREATOR(Add, QDQBinaryOpTransformer)
 DECLARE_QDQ_CREATOR(Mul, QDQBinaryOpTransformer)
 DECLARE_QDQ_CREATOR(MatMul, QDQMatMulTransformer)
 std::unordered_map<std::string, QDQRegistry::QDQTransformerCreator> QDQRegistry::qdqtransformer_creators_{
     REGISTER_QDQ_CREATOR(Conv, QDQConvTransformer),
     REGISTER_QDQ_CREATOR(MaxPool, QDQSimpleTransformer),
-    REGISTER_QDQ_CREATOR(Reshape, QDQSimpleTransformer),
+    REGISTER_QDQ_CREATOR(Reshape, QDQReshapeTransformer),
     REGISTER_QDQ_CREATOR(Add, QDQBinaryOpTransformer),
     REGISTER_QDQ_CREATOR(Mul, QDQBinaryOpTransformer),
     REGISTER_QDQ_CREATOR(MatMul, QDQMatMulTransformer),

--- a/onnxruntime/core/optimizer/qdq_transformer/relu_quantizelinear.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/relu_quantizelinear.cc
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/optimizer/initializer.h"
+#include "core/optimizer/qdq_transformer/relu_quantizelinear.h"
+#include "core/optimizer/utils.h"
+#include "core/graph/graph_utils.h"
+
+using namespace ONNX_NAMESPACE;
+using namespace onnxruntime::common;
+namespace onnxruntime {
+
+Status ReluQuantTransformer::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
+  GraphViewer graph_viewer(graph);
+  const auto& node_topology_list = graph_viewer.GetNodesInTopologicalOrder();
+
+  for (auto node_index : node_topology_list) {
+    auto* p_relu = graph.GetNode(node_index);
+    if (p_relu == nullptr)
+      continue;  // node removed as part of an earlier fusion
+
+    Node& relu = *p_relu;
+    ORT_RETURN_IF_ERROR(Recurse(relu, modified, graph_level, logger));
+
+    if (relu.OpType() != "Relu" ||
+        !graph_utils::MatchesOpSetDomain(relu, kOnnxDomain) ||
+        !graph_utils::IsSupportedProvider(relu, GetCompatibleExecutionProviders()) ||
+        !optimizer_utils::CheckOutputEdges(graph, relu, 1)) {
+      continue;
+    }
+
+    Node& q_node = *graph.GetNode(relu.OutputNodesBegin()->Index());
+    if (q_node.OpType() != "QuantizeLinear" ||
+        !graph_utils::MatchesOpSetDomain(q_node, kOnnxDomain) ||
+        !graph_utils::IsSupportedProvider(q_node, GetCompatibleExecutionProviders())) {
+      continue;
+    }
+
+    std::vector<NodeArg*>& q_input_defs = q_node.MutableInputDefs();
+
+    constexpr size_t q_input_cnt_required = 3;
+    if (q_input_defs.size() != q_input_cnt_required) {
+      continue;
+    }
+
+    constexpr size_t zp_idx = 2;
+    const ONNX_NAMESPACE::TensorProto* zp_tensor_proto = nullptr;
+    if (!graph_utils::NodeArgIsConstant(graph, *q_input_defs[zp_idx]) ||
+        !graph.GetInitializedTensor(q_input_defs[zp_idx]->Name(), zp_tensor_proto)) {
+      continue;
+    }
+
+    using ONNX_TENSOR_ELEM_TYPE = ONNX_NAMESPACE::TensorProto::DataType;
+    Initializer zero_point(*zp_tensor_proto, graph.ModelPath());
+    if (zero_point.size() != 1 ||
+        zero_point.data_type() == ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_INT8 && zero_point.data<int8_t>()[0] != -128 ||
+        zero_point.data_type() == ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_UINT8 && zero_point.data<uint8_t>()[0] != 0) {
+      continue;
+    }
+
+    graph_utils::RemoveNodeOutputEdges(graph, relu);
+    q_input_defs[0] = relu.MutableInputDefs()[0];
+    graph.RemoveNode(relu.Index());
+
+    modified = true;
+  }
+
+  return Status::OK();
+}
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/qdq_transformer/relu_quantizelinear.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/relu_quantizelinear.cc
@@ -10,59 +10,48 @@ using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::common;
 namespace onnxruntime {
 
-Status ReluQuantTransformer::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
-  GraphViewer graph_viewer(graph);
-  const auto& node_topology_list = graph_viewer.GetNodesInTopologicalOrder();
+bool ReluQuantFusion::SatisfyCondition(const Graph& graph, const Node& node, const logging::Logger& /*logger*/) const {
+  if (!graph_utils::IsSupportedOptypeVersionAndDomain(node, "Relu", {6, 13}) ||
+      !optimizer_utils::CheckOutputEdges(graph, node, 1)) {
+    return false;
+  }
 
-  for (auto node_index : node_topology_list) {
-    auto* p_relu = graph.GetNode(node_index);
-    if (p_relu == nullptr)
-      continue;  // node removed as part of an earlier fusion
+  // if Relu is followed by QuantizeLinear, it can be fused into QuantizeLinear potentially
+  const auto& next_node = *node.OutputNodesBegin();
+  if (!graph_utils::IsSupportedOptypeVersionAndDomain(next_node, "QuantizeLinear", {10, 13})) {
+    return false;
+  }
 
-    Node& relu = *p_relu;
-    ORT_RETURN_IF_ERROR(Recurse(relu, modified, graph_level, logger));
+  return true;
+}
 
-    if (relu.OpType() != "Relu" ||
-        !graph_utils::MatchesOpSetDomain(relu, kOnnxDomain) ||
-        !graph_utils::IsSupportedProvider(relu, GetCompatibleExecutionProviders()) ||
-        !optimizer_utils::CheckOutputEdges(graph, relu, 1)) {
-      continue;
-    }
+Status ReluQuantFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_effect, const logging::Logger&) const {
+  Node& q_node = *graph.GetNode(node.OutputNodesBegin()->Index());
 
-    Node& q_node = *graph.GetNode(relu.OutputNodesBegin()->Index());
-    if (q_node.OpType() != "QuantizeLinear" ||
-        !graph_utils::MatchesOpSetDomain(q_node, kOnnxDomain) ||
-        !graph_utils::IsSupportedProvider(q_node, GetCompatibleExecutionProviders())) {
-      continue;
-    }
+  std::vector<NodeArg*>& q_input_defs = q_node.MutableInputDefs();
 
-    std::vector<NodeArg*>& q_input_defs = q_node.MutableInputDefs();
+  constexpr size_t q_input_cnt_required = 3;
+  if (q_input_defs.size() != q_input_cnt_required) {
+    return Status::OK();
+  }
 
-    constexpr size_t q_input_cnt_required = 3;
-    if (q_input_defs.size() != q_input_cnt_required) {
-      continue;
-    }
+  constexpr size_t zp_idx = 2;
+  const ONNX_NAMESPACE::TensorProto* zp_tensor_proto = nullptr;
+  if (!graph_utils::NodeArgIsConstant(graph, *q_input_defs[zp_idx]) ||
+      !graph.GetInitializedTensor(q_input_defs[zp_idx]->Name(), zp_tensor_proto)) {
+    return Status::OK();
+  }
 
-    constexpr size_t zp_idx = 2;
-    const ONNX_NAMESPACE::TensorProto* zp_tensor_proto = nullptr;
-    if (!graph_utils::NodeArgIsConstant(graph, *q_input_defs[zp_idx]) ||
-        !graph.GetInitializedTensor(q_input_defs[zp_idx]->Name(), zp_tensor_proto)) {
-      continue;
-    }
+  using ONNX_TENSOR_ELEM_TYPE = ONNX_NAMESPACE::TensorProto::DataType;
+  Initializer zero_point(*zp_tensor_proto, graph.ModelPath());
+  if (zero_point.size() != 1 ||
+      zero_point.data_type() == ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_INT8 && zero_point.data<int8_t>()[0] != -128 ||
+      zero_point.data_type() == ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_UINT8 && zero_point.data<uint8_t>()[0] != 0) {
+    return Status::OK();
+  }
 
-    using ONNX_TENSOR_ELEM_TYPE = ONNX_NAMESPACE::TensorProto::DataType;
-    Initializer zero_point(*zp_tensor_proto, graph.ModelPath());
-    if (zero_point.size() != 1 ||
-        zero_point.data_type() == ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_INT8 && zero_point.data<int8_t>()[0] != -128 ||
-        zero_point.data_type() == ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_UINT8 && zero_point.data<uint8_t>()[0] != 0) {
-      continue;
-    }
-
-    graph_utils::RemoveNodeOutputEdges(graph, relu);
-    q_input_defs[0] = relu.MutableInputDefs()[0];
-    graph.RemoveNode(relu.Index());
-
-    modified = true;
+  if (graph_utils::RemoveNode(graph, node)) {
+    rule_effect = RewriteRuleEffect::kRemovedCurrentNode;
   }
 
   return Status::OK();

--- a/onnxruntime/core/optimizer/qdq_transformer/relu_quantizelinear.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/relu_quantizelinear.h
@@ -3,22 +3,27 @@
 
 #pragma once
 
-#include "core/common/common.h"
-#include "core/optimizer/graph_transformer.h"
+#include "core/optimizer/rewrite_rule.h"
 
 namespace onnxruntime {
 
 /**
-    @Class ReluQuantTransformer
+    @Class ReluQuantFusion
 
-    Transformer that fuse Relu into followed QuantizeLinear
-    */
-class ReluQuantTransformer : public GraphTransformer {
+    Rewrite rule that fuses Relu into followed QuantizeLinear
+ */
+class ReluQuantFusion : public RewriteRule {
  public:
-  ReluQuantTransformer() noexcept : GraphTransformer("ReluQuantTransformer") {}
+  ReluQuantFusion() noexcept : RewriteRule("ReluQuantRewrite") {}
+
+  std::vector<std::string> TargetOpTypes() const noexcept override {
+    return {"Relu"};
+  }
 
  private:
-  Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
+  bool SatisfyCondition(const Graph& graph, const Node& node, const logging::Logger& logger) const override;
+
+  Status Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_effect, const logging::Logger& logger) const override;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/qdq_transformer/relu_quantizelinear.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/relu_quantizelinear.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/optimizer/graph_transformer.h"
+
+namespace onnxruntime {
+
+/**
+    @Class ReluQuantTransformer
+
+    Transformer that fuse Relu into followed QuantizeLinear
+    */
+class ReluQuantTransformer : public GraphTransformer {
+ public:
+  ReluQuantTransformer() noexcept : GraphTransformer("ReluQuantTransformer") {}
+
+ private:
+  Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -358,12 +358,12 @@ TEST_F(GraphTransformationTests, ConstantFoldingWithDequantizeLinear) {
   // Check DequantizeLinear aren't constant folded for default setting.
   VerifyConstantFoldingWithDequantizeLinear(1, 3, 1, graph, session_options, *logger_);
 
-  // set SessionOptionsEnableQuantQDQ to enable it explicitly
-  session_options.AddConfigEntry(kOrtSessionOptionsEnableQuantQDQ, "1");
+  // set kOrtSessionOptionsDisableQuantQDQ to enable it explicitly
+  session_options.AddConfigEntry(kOrtSessionOptionsDisableQuantQDQ, "0");
   VerifyConstantFoldingWithDequantizeLinear(1, 3, 1, graph, session_options, *logger_);
 
   // set SessionOptionsEnableQuantQDQ to disable it
-  session_options.AddConfigEntry(kOrtSessionOptionsEnableQuantQDQ, "0");
+  session_options.AddConfigEntry(kOrtSessionOptionsDisableQuantQDQ, "1");
   VerifyConstantFoldingWithDequantizeLinear(1, 1, 1, graph, session_options, *logger_);
 }
 

--- a/onnxruntime/test/optimizer/graph_transform_test_builder.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_builder.cc
@@ -20,7 +20,9 @@ void TransformerTester(const std::function<void(ModelTestBuilder& helper)>& buil
                        const std::function<void(InferenceSessionWrapper& session)>& check_transformed_graph,
                        TransformerLevel baseline_level,
                        TransformerLevel target_level,
-                       int opset_version) {
+                       int opset_version,
+                       double per_sample_tolerance,
+                       double relative_per_sample_tolerance) {
   // Build the model for this test.
   std::unordered_map<std::string, int> domain_to_version;
   domain_to_version[kOnnxDomain] = opset_version;
@@ -68,8 +70,6 @@ void TransformerTester(const std::function<void(ModelTestBuilder& helper)>& buil
   ASSERT_TRUE(num_outputs == target_fetches.size());
 
   for (size_t i = 0; i < num_outputs; i++) {
-    double per_sample_tolerance = 0.0;
-    double relative_per_sample_tolerance = 0.0;
     std::pair<COMPARE_RESULT, std::string> ret =
         CompareOrtValue(target_fetches[i],
                         baseline_fetches[i],

--- a/onnxruntime/test/optimizer/graph_transform_test_builder.h
+++ b/onnxruntime/test/optimizer/graph_transform_test_builder.h
@@ -240,7 +240,9 @@ void TransformerTester(const std::function<void(ModelTestBuilder& helper)>& buil
                        const std::function<void(InferenceSessionWrapper& session)>& check_transformed_graph,
                        TransformerLevel baseline_level,
                        TransformerLevel target_level,
-                       int opset_version = 12);
+                       int opset_version = 12,
+                       double per_sample_tolerance = 0.0,
+                       double relative_per_sample_tolerance = 0.0);
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/initializer_test.cc
+++ b/onnxruntime/test/optimizer/initializer_test.cc
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <fstream>
 #include <numeric>
+#include <type_traits>
 
 #include "gsl/gsl"
 
@@ -105,5 +106,124 @@ TEST(OptimizerInitializerTest, LoadExternalData) {
     EXPECT_THROW(Initializer i(tensor_proto, tensor_data_dir_path), OnnxRuntimeException);
   }
 }
+
+template <typename T>
+ONNX_NAMESPACE::TensorProto_DataType GetTensorProtoDataType();
+
+#define CppTypeToTensorProto_DataType(CppType, TP_DataType)                \
+  template <>                                                              \
+  ONNX_NAMESPACE::TensorProto_DataType GetTensorProtoDataType<CppType>() { \
+    return ONNX_NAMESPACE::TP_DataType;                                    \
+  }
+
+CppTypeToTensorProto_DataType(int8_t, TensorProto_DataType_INT8)
+CppTypeToTensorProto_DataType(uint8_t, TensorProto_DataType_UINT8)
+CppTypeToTensorProto_DataType(int32_t, TensorProto_DataType_INT32)
+CppTypeToTensorProto_DataType(int64_t, TensorProto_DataType_INT64)
+CppTypeToTensorProto_DataType(uint16_t, TensorProto_DataType_FLOAT16)
+CppTypeToTensorProto_DataType(float, TensorProto_DataType_FLOAT)
+CppTypeToTensorProto_DataType(double, TensorProto_DataType_DOUBLE)
+
+template <typename T>
+void TestInitializerRawData() {
+  std::vector<T> data{
+      0, 1, 2, 3,
+      4, 5, 6, 7,
+      8, 9, 10, 11};
+
+  ONNX_NAMESPACE::TensorProto tensor_proto;
+  tensor_proto.set_data_type(GetTensorProtoDataType<T>());
+  tensor_proto.set_name("OptimizerInitializerTest_RawData");
+  tensor_proto.add_dims(3);
+  tensor_proto.add_dims(4);
+  tensor_proto.set_raw_data(data.data(), data.size() * sizeof(T));
+
+  Initializer init(tensor_proto, Path());
+
+  for (size_t idx = 0; idx < data.size(); idx++) {
+    EXPECT_EQ(data[idx], init.data<T>()[idx]);
+  }
+}
+
+TEST(OptimizerInitializerTest, RawData) {
+  TestInitializerRawData<int8_t>();
+  TestInitializerRawData<uint8_t>();
+  TestInitializerRawData<int32_t>();
+  TestInitializerRawData<int64_t>();
+  TestInitializerRawData<uint16_t>();
+  TestInitializerRawData<float>();
+  TestInitializerRawData<double>();
+}
+
+template <typename T>
+void TestInitializerDataField() {
+  std::vector<T> data{
+      0, 1, 2, 3,
+      4, 5, 6, 7,
+      8, 9, 10, 11};
+
+  auto dt = GetTensorProtoDataType<T>();
+  ONNX_NAMESPACE::TensorProto tensor_proto;
+  tensor_proto.set_data_type(GetTensorProtoDataType<T>());
+  tensor_proto.set_name("OptimizerInitializerTest_DataField");
+  tensor_proto.add_dims(3);
+  tensor_proto.add_dims(4);
+  for (size_t idx = 0; idx < data.size(); idx++) {
+    if (dt == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT8 ||
+        dt == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT8 ||
+        dt == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT32 ||
+        dt == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT16) {
+      tensor_proto.add_int32_data(data[idx]);
+    } else {
+      ORT_NOT_IMPLEMENTED("tensor type ", GetTensorProtoDataType<T>(), " is not supported");
+    }
+  }
+
+  Initializer init(tensor_proto, Path());
+
+  for (size_t idx = 0; idx < data.size(); idx++) {
+    EXPECT_EQ(data[idx], init.data<T>()[idx]);
+  }
+}
+
+#define TestInitializerDataFieldSpecialized(type)                \
+  template <>                                                    \
+  void TestInitializerDataField<type>() {                        \
+    std::vector<type> data{                                      \
+        0, 1, 2, 3,                                              \
+        4, 5, 6, 7,                                              \
+        8, 9, 10, 11};                                           \
+                                                                 \
+    ONNX_NAMESPACE::TensorProto tensor_proto;                    \
+    tensor_proto.set_data_type(GetTensorProtoDataType<type>());  \
+    tensor_proto.set_name("OptimizerInitializerTest_DataField"); \
+    tensor_proto.add_dims(3);                                    \
+    tensor_proto.add_dims(4);                                    \
+    for (size_t idx = 0; idx < data.size(); idx++) {             \
+      tensor_proto.add_##type##_data(data[idx]);                 \
+    }                                                            \
+                                                                 \
+    Initializer init(tensor_proto, Path());                      \
+                                                                 \
+    for (size_t idx = 0; idx < data.size(); idx++) {             \
+      EXPECT_EQ(data[idx], init.data<type>()[idx]);              \
+    }                                                            \
+  }
+
+typedef int64_t int64;
+TestInitializerDataFieldSpecialized(float)
+TestInitializerDataFieldSpecialized(double)
+TestInitializerDataFieldSpecialized(int64)
+
+TEST(OptimizerInitializerTest, DataField) {
+  TestInitializerDataField<int8_t>();
+  TestInitializerDataField<uint8_t>();
+  TestInitializerDataField<int32_t>();
+  TestInitializerDataField<int64_t>();
+  TestInitializerDataField<uint16_t>();
+  TestInitializerDataField<float>();
+  TestInitializerDataField<double>();
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -81,7 +81,7 @@ TEST(QDQTransformerTests, Conv) {
   test_case({1, 22, 11, 13, 15}, {30, 22, 5, 3, 3}, false);
 }
 
-TEST(QDQTransformerTests, ConvMaxPoolReshape) {
+TEST(QDQTransformerTests, ConvMaxPoolReshape_UInt8) {
   auto test_case = [&](const std::vector<int64_t>& input_shape, const std::vector<int64_t>& weights_shape) {
     auto build_test_case = [&](ModelTestBuilder& builder) {
       auto* input_arg = builder.MakeInput<float>(input_shape, -1.f, 1.f);
@@ -106,6 +106,57 @@ TEST(QDQTransformerTests, ConvMaxPoolReshape) {
 
       // add QDQ + Reshape
       auto* dq_reshape_output = AddQDQNodePair<uint8_t>(builder, maxpool_output, .0039f, 135);
+      auto* reshape_shape = builder.Make1DInitializer<int64_t>({-1});
+      auto* reshape_output = builder.MakeIntermediate();
+      builder.AddNode("Reshape", {dq_reshape_output, reshape_shape}, {reshape_output});
+
+      // add Q
+      builder.AddQuantizeLinearNode<uint8_t>(reshape_output, .0039f, 135, output_arg);
+    };
+
+    auto check_mp_reshape_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["QLinearConv"], 1);
+      EXPECT_EQ(op_to_count["MaxPool"], 1);
+      EXPECT_EQ(op_to_count["Reshape"], 1);
+      EXPECT_EQ(op_to_count["QuantizeLinear"], 1);
+      EXPECT_EQ(op_to_count["DequantizeLinear"], 0);
+    };
+
+    TransformerTester(build_test_case, check_mp_reshape_graph, TransformerLevel::Level1, TransformerLevel::Level2);
+  };
+
+  // Test the basic case of a single 1D/2D/3D convolution.
+  test_case({1, 12, 37}, {32, 12, 5});
+  test_case({1, 23, 13, 13}, {30, 23, 3, 3});
+  test_case({1, 22, 11, 13, 15}, {30, 22, 5, 3, 3});
+}
+
+TEST(QDQTransformerTests, ConvMaxPoolReshape_Int8) {
+  auto test_case = [&](const std::vector<int64_t>& input_shape, const std::vector<int64_t>& weights_shape) {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      auto* input_arg = builder.MakeInput<float>(input_shape, -1.f, 1.f);
+      auto* output_arg = builder.MakeOutput();
+      auto* weight = builder.MakeInitializer<uint8_t>(weights_shape, 0, 255);
+
+      // add QDQ + Conv
+      auto* dq_w_output = builder.MakeIntermediate();
+      auto* conv_output = builder.MakeIntermediate();
+      auto* dq_conv_output = AddQDQNodePair<int8_t>(builder, input_arg, .004f, 1);
+      builder.AddDequantizeLinearNode<uint8_t>(weight, .003f, 118, dq_w_output);
+      builder.AddConvNode(dq_conv_output, dq_w_output, conv_output);
+
+      // add QDQ + MaxPool
+      auto* dq_maxpool_output = AddQDQNodePair<int8_t>(builder, conv_output, .0039f, 7);
+      auto* maxpool_output = builder.MakeIntermediate();
+      Node& pool_node = builder.AddNode("MaxPool", {dq_maxpool_output}, {maxpool_output});
+      std::vector<int64_t> pads((weights_shape.size() - 2) * 2, 1);
+      pool_node.AddAttribute("pads", pads);
+      std::vector<int64_t> kernel_shape(weights_shape.size() - 2, 3);
+      pool_node.AddAttribute("kernel_shape", kernel_shape);
+
+      // add QDQ + Reshape
+      auto* dq_reshape_output = AddQDQNodePair<int8_t>(builder, maxpool_output, .0039f, 7);
       auto* reshape_shape = builder.Make1DInitializer<int64_t>({-1});
       auto* reshape_output = builder.MakeIntermediate();
       builder.AddNode("Reshape", {dq_reshape_output, reshape_shape}, {reshape_output});
@@ -262,6 +313,58 @@ TEST(QDQTransformerTests, MatMul_No_Fusion) {
   test_case({12, 37}, {37, 12});
   test_case({23, 13, 13}, {13, 13});
   test_case({22, 11, 13, 15}, {15, 13});
+}
+
+TEST(QDQTransformerTests, ConvRelu) {
+  auto test_case = [&](const std::vector<int64_t>& input_shape, const std::vector<int64_t>& weights_shape, bool is_zp_zero) {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      auto* input_arg = builder.MakeInput<float>(input_shape, -1.f, 1.f);
+      auto* output_arg = builder.MakeOutput();
+      auto* weight = builder.MakeInitializer<uint8_t>(weights_shape, 0, 255);
+
+      // add QDQ + Conv
+      auto* dq_w_output = builder.MakeIntermediate();
+      auto* conv_output = builder.MakeIntermediate();
+      auto* dq_conv_output = AddQDQNodePair<uint8_t>(builder, input_arg, .004f, 129);
+      builder.AddDequantizeLinearNode<uint8_t>(weight, .003f, 118, dq_w_output);
+      builder.AddConvNode(dq_conv_output, dq_w_output, conv_output);
+
+      // add Relu
+      auto* relu_output = builder.MakeIntermediate();
+      builder.AddNode("Relu", {conv_output}, {relu_output});
+
+      // add Q
+      builder.AddQuantizeLinearNode<uint8_t>(relu_output, .0039f, is_zp_zero ? 0 : 1, output_arg);
+    };
+
+    auto check_mp_reshape_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      if (is_zp_zero) {
+        EXPECT_EQ(op_to_count["QLinearConv"], 1);
+        EXPECT_EQ(op_to_count["Conv"], 0);
+        EXPECT_EQ(op_to_count["Relu"], 0);
+        EXPECT_EQ(op_to_count["QuantizeLinear"], 1);
+        EXPECT_EQ(op_to_count["DequantizeLinear"], 0);
+      } else {
+        EXPECT_EQ(op_to_count["QLinearConv"], 0);
+        EXPECT_EQ(op_to_count["Conv"], 0);
+        EXPECT_EQ(op_to_count["Relu"], 0);
+        EXPECT_EQ(op_to_count["com.microsoft.FusedConv"], 1);
+        EXPECT_EQ(op_to_count["QuantizeLinear"], 2);
+        EXPECT_EQ(op_to_count["DequantizeLinear"], 2);
+      }
+    };
+
+    TransformerTester(build_test_case, check_mp_reshape_graph, TransformerLevel::Level1, TransformerLevel::Level2);
+  };
+
+  // Test the basic case of a single 1D/2D/3D convolution.
+  test_case({1, 12, 37}, {32, 12, 5}, true);
+  test_case({1, 12, 37}, {32, 12, 5}, false);
+  test_case({1, 23, 13, 13}, {30, 23, 3, 3}, true);
+  test_case({1, 23, 13, 13}, {30, 23, 3, 3}, false);
+  test_case({1, 22, 11, 13, 15}, {30, 22, 5, 3, 3}, true);
+  test_case({1, 22, 11, 13, 15}, {30, 22, 5, 3, 3}, false);
 }
 
 #endif  // DISABLE_CONTRIB_OPS


### PR DESCRIPTION
As the title says, this pr:
1. Add int8_t to uint8_t conversion 
2. Add Relu fusion support
3. Add AveragePool support

In addition, refactor the code of qdq_transform.
