### PR TITLE
Fix assert that the tensor's device type is 'cpu'

### DIFF
--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -886,7 +886,7 @@ class ORTTrainer(object):
                 test_pt_device = torch.device(target_device)
             except:
                 #in this case, input/output must on CPU
-                assert(input.device == 'cpu')
+                assert(input.device.type == 'cpu')
                 target_device = 'cpu'
             
             torch_tensor = torch.zeros(output_desc.shape, device=target_device,


### PR DESCRIPTION
**Description**: Fix assert that the tensor's device type is 'cpu'

**Motivation and Context**
The ort trainer api was extended to support non-cuda devices in #7112; however, there is a small typo as described in issue #7247
