### PR TITLE
Adding interface for batched integer gemm

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -773,6 +773,7 @@ if(onnxruntime_BUILD_BENCHMARKS)
     ${BENCHMARK_DIR}/eigen.cc
     ${BENCHMARK_DIR}/gelu.cc
     ${BENCHMARK_DIR}/activation.cc
+    ${BENCHMARK_DIR}/quantize.cc
     ${BENCHMARK_DIR}/reduceminmax.cc)
   target_include_directories(onnxruntime_benchmark PRIVATE ${ONNXRUNTIME_ROOT} ${onnxruntime_graph_header} ${ONNXRUNTIME_ROOT}/core/mlas/inc)
   if(WIN32)

--- a/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
@@ -190,53 +190,56 @@ Status QAttention<T>::Compute(OpKernelContext* context) const {
     const auto* weights_data = packed_weights_ ? nullptr : static_cast<const uint8_t*>(weights->DataRaw());
     const bool weights_is_signed = packed_weights_ ? weights_is_signed_ : weights->IsDataType<int8_t>();
 
-    const double cost =
-        static_cast<double>(sequence_length) * static_cast<double>(head_size) * static_cast<double>(input_hidden_size);
-    ThreadPool::TryParallelFor(tp, loop_len, cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
-      for (std::ptrdiff_t i = begin; i != end; ++i) {
-        const int batch_index = static_cast<int>((i / 3) / num_heads_);
-        const int head_index = static_cast<int>((i / 3) % num_heads_);
-        const int qkv_index = static_cast<int>(i % 3);
+    MLAS_GEMM_U8X8_SHAPE_PARAMS gemm_shape;
+    gemm_shape.M = sequence_length;
+    gemm_shape.N = head_size;
+    gemm_shape.K = input_hidden_size;
+    gemm_shape.BIsSigned = weights_is_signed;
 
-        int input_offset = batch_index * sequence_length * input_hidden_size;
-        int weights_offset = qkv_index * hidden_size + head_index * head_size;
-        float* qkv_dest = QKV[qkv_index];
-        int qkv_offset = (batch_index * num_heads_ + head_index) * (sequence_length * head_size);
+    std::vector<MLAS_GEMM_U8X8_DATA_PARAMS> gemm_data_vec(loop_len);
+    std::vector<MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR> scale_bias_procs;
+    scale_bias_procs.reserve(loop_len);
 
-        //                   original           transposed            iteration
-        // A: input          (BxSxD)            (B.)S x D             S x D
-        // B: weights        (Dx3xNxH)          D  x (3.N.)H          D x H
-        // C: QKV[qkv_index] (3xBxNxSxH)        (3.B.N.)S x H         S x H
+    for (int i = 0; i < loop_len; i++) {
+      const int batch_index = static_cast<int>((i / 3) / num_heads_);
+      const int head_index = static_cast<int>((i / 3) % num_heads_);
+      const int qkv_index = static_cast<int>(i % 3);
 
-        MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR scale_bias_processor(qkv_dest + qkv_offset,
-                                                                    head_size,
-                                                                    &dequant_scale,
-                                                                    bias_data + weights_offset);
+      int input_offset = batch_index * sequence_length * input_hidden_size;
+      int weights_offset = qkv_index * hidden_size + head_index * head_size;
+      float* qkv_dest = QKV[qkv_index];
+      int qkv_offset = (batch_index * num_heads_ + head_index) * (sequence_length * head_size);
 
-        MLAS_GEMM_U8X8_PARAMETERS gemm_params;
-        gemm_params.M = sequence_length;
-        gemm_params.N = head_size;
-        gemm_params.K = input_hidden_size;
-        gemm_params.A = input_data + input_offset;
-        gemm_params.lda = input_hidden_size;
-        gemm_params.ZeroPointA = input_zero_point;
-        if (packed_weights_) {
-          const auto* packed_weight =
-              static_cast<const uint8_t*>(packed_weights_.get()) + packed_weights_size_ * (weights_offset / head_size);
-          gemm_params.B = packed_weight;
-          gemm_params.BIsPacked = true;
-        } else {
-          gemm_params.B = weights_data + weights_offset;
-          gemm_params.ldb = 3 * hidden_size;
-        }
-        gemm_params.ZeroPointB = &weight_zero_point;
-        gemm_params.BIsSigned = weights_is_signed;
-        gemm_params.C = reinterpret_cast<int32_t*>(qkv_dest + qkv_offset);
-        gemm_params.ldc = head_size;
-        gemm_params.OutputProcessor = &scale_bias_processor;
-        MlasGemm(&gemm_params, nullptr);
+      //                   original           transposed            iteration
+      // A: input          (BxSxD)            (B.)S x D             S x D
+      // B: weights        (Dx3xNxH)          D  x (3.N.)H          D x H
+      // C: QKV[qkv_index] (3xBxNxSxH)        (3.B.N.)S x H         S x H
+
+      scale_bias_procs.emplace_back(qkv_dest + qkv_offset,
+                                    head_size,
+                                    &dequant_scale,
+                                    bias_data + weights_offset);
+
+      auto& gemm_params = gemm_data_vec[i];
+      gemm_params.A = input_data + input_offset;
+      gemm_params.lda = input_hidden_size;
+      gemm_params.ZeroPointA = input_zero_point;
+      if (packed_weights_) {
+        const auto* packed_weight =
+            static_cast<const uint8_t*>(packed_weights_.get()) + packed_weights_size_ * (weights_offset / head_size);
+        gemm_params.B = packed_weight;
+        gemm_params.BIsPacked = true;
+      } else {
+        gemm_params.B = weights_data + weights_offset;
+        gemm_params.ldb = 3 * hidden_size;
       }
-    });
+      gemm_params.ZeroPointB = &weight_zero_point;
+      gemm_params.C = reinterpret_cast<int32_t*>(qkv_dest + qkv_offset);
+      gemm_params.ldc = head_size;
+      gemm_params.OutputProcessor = &(scale_bias_procs[i]);  
+    }
+
+    MlasGemmBatch(gemm_shape, gemm_data_vec.data(), loop_len, tp);
   }
 
   // Compute the attention score and apply the score to V

--- a/onnxruntime/core/mlas/.clang-format
+++ b/onnxruntime/core/mlas/.clang-format
@@ -1,0 +1,11 @@
+---
+
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 100
+AlwaysBreakAfterReturnType: TopLevel
+AlwaysBreakTemplateDeclarations: Yes
+BinPackParameters: false
+BreakBeforeBraces: Linux
+...
+

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -226,6 +226,8 @@ public:
         size_t,         // Supplies the element count per col to process
         size_t          // Supplies the leading dimension of matrix
         ) const = 0;
+
+    virtual ~MLAS_QGEMM_OUTPUT_PROCESSOR() {}
 };
 
 class MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR : public MLAS_QGEMM_OUTPUT_PROCESSOR {
@@ -278,10 +280,14 @@ private:
     MLAS_QUANTIZATION_GRANULARITY QuantGran_;
 };
 
-struct MLAS_GEMM_U8X8_PARAMETERS {
+struct MLAS_GEMM_U8X8_SHAPE_PARAMS {
     size_t M = 0;
     size_t N = 0;
     size_t K = 0;
+    bool BIsSigned = false;
+};
+
+struct MLAS_GEMM_U8X8_DATA_PARAMS {
     const uint8_t* A = nullptr;
     size_t lda = 0;
     uint8_t ZeroPointA = 0;
@@ -289,7 +295,6 @@ struct MLAS_GEMM_U8X8_PARAMETERS {
     size_t ldb = 0;
     const uint8_t* ZeroPointB = nullptr;
     bool BIsPacked = false;
-    bool BIsSigned = false;
     bool PerColumnZeroPoints = false;
     int32_t* C = nullptr;
     size_t ldc = 0;
@@ -300,7 +305,8 @@ struct MLAS_GEMM_U8X8_PARAMETERS {
 void
 MLASCALL
 MlasGemm(
-    const MLAS_GEMM_U8X8_PARAMETERS* Parameters,
+    const MLAS_GEMM_U8X8_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_U8X8_DATA_PARAMS& DataParams,
     MLAS_THREADPOOL* ThreadPool
     );
 
@@ -310,16 +316,17 @@ MlasGemm(
  * Note:  We only support uniform batching, so shapes and types of the
  *        input must be same: M, N, K, BIsPacked, BIsSigned must be the
  *        same across all parameter blocks. 
- *        TODO!! consider split the parameter blocks into shape/type part and data part?
  * 
- * @param [IN]  Parameters   Starting address of the parameters array.
+ * @param [IN]  Shape        A single shape descriptor for all the multiplications
+ * @param [IN]  Parameters   Data descriptor for the matrices.
  * @param [IN]  BatchN       Size of the parameters array, also number of multiplications to perform
  * @param [IN]  ThreadPool   optional thread pool for parallel processing
  */
 void
 MLASCALL
 MlasGemmBatch(
-    const MLAS_GEMM_U8X8_PARAMETERS* Parameters,
+    const MLAS_GEMM_U8X8_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_U8X8_DATA_PARAMS* DataParams,
     const size_t BatchN,
     MLAS_THREADPOOL* ThreadPool);
 

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -311,14 +311,13 @@ MlasGemm(
     );
 
 /** 
- * Batched GEMM, takes an array of MLAS_GEMM_U8X8_PARAMETERS
- * for multiplying multiple pairs of matrices. 
+ * @brief Batched GEMM, for multiplying multiple pairs of matrices. 
  * Note:  We only support uniform batching, so shapes and types of the
- *        input must be same: M, N, K, BIsPacked, BIsSigned must be the
+ *        input must be same: M, N, K, BIsSigned must be the
  *        same across all parameter blocks. 
  * 
  * @param [IN]  Shape        A single shape descriptor for all the multiplications
- * @param [IN]  Parameters   Data descriptor for the matrices.
+ * @param [IN]  DataParams   Array of data descriptors for the matrices.
  * @param [IN]  BatchN       Size of the parameters array, also number of multiplications to perform
  * @param [IN]  ThreadPool   optional thread pool for parallel processing
  */

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -327,7 +327,8 @@ MlasGemmBatch(
     const MLAS_GEMM_U8X8_SHAPE_PARAMS& Shape,
     const MLAS_GEMM_U8X8_DATA_PARAMS* DataParams,
     const size_t BatchN,
-    MLAS_THREADPOOL* ThreadPool);
+    MLAS_THREADPOOL* ThreadPool
+    );
 
 //
 // Buffer packing routines.

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -296,12 +296,32 @@ struct MLAS_GEMM_U8X8_PARAMETERS {
     const MLAS_QGEMM_OUTPUT_PROCESSOR* OutputProcessor = nullptr;
 };
 
+
 void
 MLASCALL
 MlasGemm(
     const MLAS_GEMM_U8X8_PARAMETERS* Parameters,
     MLAS_THREADPOOL* ThreadPool
     );
+
+/** 
+ * Batched GEMM, takes an array of MLAS_GEMM_U8X8_PARAMETERS
+ * for multiplying multiple pairs of matrices. 
+ * Note:  We only support uniform batching, so shapes and types of the
+ *        input must be same: M, N, K, BIsPacked, BIsSigned must be the
+ *        same across all parameter blocks. 
+ *        TODO!! consider split the parameter blocks into shape/type part and data part?
+ * 
+ * @param [IN]  Parameters   Starting address of the parameters array.
+ * @param [IN]  BatchN       Size of the parameters array, also number of multiplications to perform
+ * @param [IN]  ThreadPool   optional thread pool for parallel processing
+ */
+void
+MLASCALL
+MlasGemmBatch(
+    const MLAS_GEMM_U8X8_PARAMETERS* Parameters,
+    const size_t BatchN,
+    MLAS_THREADPOOL* ThreadPool);
 
 //
 // Buffer packing routines.

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -24,6 +24,7 @@ Abstract:
 #include <cmath>
 #include <type_traits>
 #include <stdexcept>
+#include <functional>
 
 #if defined(_WIN32)
 #ifndef WIN32_LEAN_AND_MEAN
@@ -102,8 +103,6 @@ Abstract:
 
 #if !defined(MLAS_NO_ONNXRUNTIME_THREADPOOL)
 #include "core/platform/threadpool.h"
-#else
-#include  <functional>
 #endif
 
 #if defined(_OPENMP)
@@ -780,7 +779,8 @@ void
 MlasTrySimpleParallel(
     MLAS_THREADPOOL* ThreadPool,
     const std::ptrdiff_t Iterations,
-    const std::function<void(std::ptrdiff_t tid)>& Work);
+    const std::function<void(std::ptrdiff_t tid)>& Work
+    );
 
 inline
 ptrdiff_t

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -102,6 +102,8 @@ Abstract:
 
 #if !defined(MLAS_NO_ONNXRUNTIME_THREADPOOL)
 #include "core/platform/threadpool.h"
+#else
+#include  <functional>
 #endif
 
 #if defined(_OPENMP)
@@ -766,6 +768,21 @@ MlasExecuteThreaded(
     ptrdiff_t Iterations,
     MLAS_THREADPOOL* ThreadPool
     );
+
+/**
+ * @brief Distribute multiple iteration of work over a thread pool if supported
+ * 
+ * @param ThreadPool [IN]          Optional thread pool. Ignored when using OpenMP
+ * @param Iterations [IN]          Total number of iterations
+ * @param CostOfCyclePerIter [IN]  Estimated cost of cycles per iteration
+ * @param Work [IN]                Logic for computing a range of iterations [begin, end)
+ */
+void
+MlasTryParallel(
+    MLAS_THREADPOOL* ThreadPool,
+    const std::ptrdiff_t Iterations,
+    const double CostOfCyclePerIter,
+    const std::function<void(std::ptrdiff_t begin, std::ptrdiff_t end)>& Work);
 
 inline
 ptrdiff_t

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -770,19 +770,17 @@ MlasExecuteThreaded(
     );
 
 /**
- * @brief Distribute multiple iteration of work over a thread pool if supported
+ * @brief Distribute multiple iterations of work over a thread pool if supported
  * 
  * @param ThreadPool [IN]          Optional thread pool. Ignored when using OpenMP
  * @param Iterations [IN]          Total number of iterations
- * @param CostOfCyclePerIter [IN]  Estimated cost of cycles per iteration
  * @param Work [IN]                Logic for computing a range of iterations [begin, end)
  */
 void
-MlasTryParallel(
+MlasTrySimpleParallel(
     MLAS_THREADPOOL* ThreadPool,
     const std::ptrdiff_t Iterations,
-    const double CostOfCyclePerIter,
-    const std::function<void(std::ptrdiff_t begin, std::ptrdiff_t end)>& Work);
+    const std::function<void(std::ptrdiff_t tid)>& Work);
 
 inline
 ptrdiff_t

--- a/onnxruntime/core/mlas/lib/qgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm.cpp
@@ -2820,8 +2820,9 @@ MlasGemmBatch(
     MLAS_GEMM_U8X8_WORK_BLOCK WorkBlock;
 
     if (N > M) {
-        const size_t BlockedN =
-            (N + MLAS_QGEMM_STRIDEN_THREAD_ALIGN - 1) / MLAS_QGEMM_STRIDEN_THREAD_ALIGN;
+
+        const size_t BlockedN = (N + MLAS_QGEMM_STRIDEN_THREAD_ALIGN - 1) /
+            MLAS_QGEMM_STRIDEN_THREAD_ALIGN;
 
         if (size_t(ThreadsPerGemm) > BlockedN) {
             ThreadsPerGemm = ptrdiff_t(BlockedN);
@@ -2831,6 +2832,7 @@ MlasGemmBatch(
         WorkBlock.ThreadCountN = ThreadsPerGemm;
 
     } else {
+
         if (size_t(ThreadsPerGemm) > M) {
             ThreadsPerGemm = ptrdiff_t(M);
         }
@@ -2838,6 +2840,7 @@ MlasGemmBatch(
         WorkBlock.ThreadCountM = ThreadsPerGemm;
         WorkBlock.ThreadCountN = 1;
     }
+    TargetThreadCount = ThreadsPerGemm * BatchN;
 
     const double cost = double(M) * double(N) * double(K) / ThreadsPerGemm;
     MlasTryParallel(ThreadPool, TargetThreadCount, cost, [&](ptrdiff_t begin, ptrdiff_t end) {

--- a/onnxruntime/core/mlas/lib/threading.cpp
+++ b/onnxruntime/core/mlas/lib/threading.cpp
@@ -89,7 +89,7 @@ MlasTrySimpleParallel(
 #pragma omp parallel for
 #endif
         
-    for (ptrdiff_t tid = 0; tid < Iterations; tid ++) {
+    for (ptrdiff_t tid = 0; tid < Iterations; tid++) {
         Work(tid);
     }
 #else

--- a/onnxruntime/core/providers/cpu/math/quantize_linear_matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/quantize_linear_matmul.cc
@@ -87,24 +87,26 @@ Status QLinearMatMul::Compute(OpKernelContext* ctx) const {
   BufferUniquePtr gemm_output_buffer(gemm_output_data, BufferDeleter(alloc));
   auto* gemm_output = static_cast<int32_t*>(gemm_output_buffer.get());
 
-  MLAS_GEMM_U8X8_PARAMETERS gemm_params;
-  gemm_params.M = static_cast<size_t>(helper.M());
-  gemm_params.N = static_cast<size_t>(helper.N());
-  gemm_params.K = static_cast<size_t>(helper.K());
-  gemm_params.lda = gemm_params.K;
+  MLAS_GEMM_U8X8_SHAPE_PARAMS gemm_shape;
+  gemm_shape.M = static_cast<size_t>(helper.M());
+  gemm_shape.N = static_cast<size_t>(helper.N());
+  gemm_shape.K = static_cast<size_t>(helper.K());
+  gemm_shape.BIsSigned = b_is_signed;
+
+  MLAS_GEMM_U8X8_DATA_PARAMS gemm_params;
+  gemm_params.lda = gemm_shape.K;
   gemm_params.ZeroPointA = *a_offset->template Data<uint8_t>();
-  gemm_params.ldb = gemm_params.N;
+  gemm_params.ldb = gemm_shape.N;
   gemm_params.ZeroPointB = static_cast<const uint8_t*>(b_offset->DataRaw());
   gemm_params.C = gemm_output;
-  gemm_params.ldc = gemm_params.N;
+  gemm_params.ldc = gemm_shape.N;
   gemm_params.BIsPacked = bool(packed_b_);
-  gemm_params.BIsSigned = b_is_signed;
 
   for (size_t i = 0; i < helper.OutputOffsets().size(); i++) {
     gemm_params.A = a->template Data<uint8_t>() + helper.LeftOffsets()[i];
     gemm_params.B = b_data + helper.RightOffsets()[i];
 
-    MlasGemm(&gemm_params, ctx->GetOperatorThreadPool());
+    MlasGemm(gemm_shape, gemm_params, ctx->GetOperatorThreadPool());
 
     MlasRequantizeOutput(gemm_output,
                          y->template MutableData<uint8_t>() + helper.OutputOffsets()[i],

--- a/onnxruntime/core/providers/cpu/nn/conv_integer.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv_integer.cc
@@ -149,10 +149,12 @@ Status ConvInteger::Compute(OpKernelContext* context) const {
         }
       }
 
-      MLAS_GEMM_U8X8_PARAMETERS gemm_params;
-      gemm_params.M = static_cast<size_t>(M / conv_attrs_.group);
-      gemm_params.N = static_cast<size_t>(output_image_size);
-      gemm_params.K = static_cast<size_t>(kernel_dim);
+      MLAS_GEMM_U8X8_SHAPE_PARAMS gemm_shape;
+      gemm_shape.M = static_cast<size_t>(M / conv_attrs_.group);
+      gemm_shape.N = static_cast<size_t>(output_image_size);
+      gemm_shape.K = static_cast<size_t>(kernel_dim);
+      
+      MLAS_GEMM_U8X8_DATA_PARAMS gemm_params;
       gemm_params.A = Wdata + group_id * W_offset;
       gemm_params.lda = static_cast<size_t>(kernel_dim);
       gemm_params.ZeroPointA = filter_offset;
@@ -161,7 +163,8 @@ Status ConvInteger::Compute(OpKernelContext* context) const {
       gemm_params.ZeroPointB = &input_offset;
       gemm_params.C = Ydata;
       gemm_params.ldc = static_cast<size_t>(output_image_size);
-      MlasGemm(&gemm_params, thread_pool);
+
+      MlasGemm(gemm_shape, gemm_params, thread_pool);
 
       Xdata += X_offset;
       Ydata += Y_offset;

--- a/onnxruntime/core/providers/cpu/nn/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/nn/qlinearconv.cc
@@ -500,10 +500,13 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
             worker_gemm_input = input_data + output_start * kernel_dim;
           }
 
-          MLAS_GEMM_U8X8_PARAMETERS gemm_params;
-          gemm_params.M = static_cast<size_t>(output_count);
-          gemm_params.N = static_cast<size_t>(group_output_channels);
-          gemm_params.K = static_cast<size_t>(kernel_dim);
+          MLAS_GEMM_U8X8_SHAPE_PARAMS gemm_shape;
+          gemm_shape.M = static_cast<size_t>(output_count);
+          gemm_shape.N = static_cast<size_t>(group_output_channels);
+          gemm_shape.K = static_cast<size_t>(kernel_dim);
+          gemm_shape.BIsSigned = is_W_signed;
+
+          MLAS_GEMM_U8X8_DATA_PARAMS gemm_params;
           gemm_params.A = worker_gemm_input;
           gemm_params.lda = static_cast<size_t>(kernel_dim);
           gemm_params.ZeroPointA = X_zero_point_value;
@@ -515,10 +518,9 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
             gemm_params.ldb = static_cast<size_t>(M);
           }
           gemm_params.ZeroPointB = &W_zero_point_value;
-          gemm_params.BIsSigned = is_W_signed;
           gemm_params.C = worker_gemm_output + group_id * group_output_channels;
           gemm_params.ldc = static_cast<size_t>(M);
-          MlasGemm(&gemm_params, nullptr);
+          MlasGemm(gemm_shape, gemm_params, nullptr);
         }
       }
 

--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
@@ -287,10 +287,13 @@ void ComputeGemm(const int M,
       beta == 1.0f ? MLAS_QGEMM_OUTPUT_MODE::AccumulateMode : MLAS_QGEMM_OUTPUT_MODE::ZeroMode,
       scale_multiplier.size() == 1 ? MLAS_QUANTIZATION_GRANULARITY::PerMatrix : MLAS_QUANTIZATION_GRANULARITY::PerColumn);
 
-  MLAS_GEMM_U8X8_PARAMETERS gemm_params;
-  gemm_params.M = static_cast<size_t>(M);
-  gemm_params.N = static_cast<size_t>(N);
-  gemm_params.K = static_cast<size_t>(K);
+  MLAS_GEMM_U8X8_SHAPE_PARAMS gemm_shape;
+  gemm_shape.M = static_cast<size_t>(M);
+  gemm_shape.N = static_cast<size_t>(N);
+  gemm_shape.K = static_cast<size_t>(K);
+  gemm_shape.BIsSigned = b_is_signed;
+  
+  MLAS_GEMM_U8X8_DATA_PARAMS gemm_params;
   gemm_params.A = a_data_quant;
   gemm_params.lda = static_cast<size_t>(K);
   gemm_params.ZeroPointA = a_zero_point;
@@ -298,11 +301,11 @@ void ComputeGemm(const int M,
   gemm_params.ldb = static_cast<size_t>(N);
   gemm_params.ZeroPointB = &b_zero_point;
   gemm_params.BIsPacked = weights.is_prepacked_;
-  gemm_params.BIsSigned = b_is_signed;
   gemm_params.C = C_buffer;
   gemm_params.ldc = ld_C_buffer;
   gemm_params.OutputProcessor = &output_processor;
-  MlasGemm(&gemm_params, thread_pool);
+
+  MlasGemm(gemm_shape, gemm_params, thread_pool);
 }
 
 namespace deepcpu {

--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
@@ -258,12 +258,12 @@ void ComputeGemm(const int M,
 
   float a_scale;
   uint8_t a_zero_point;
-  GetQuantizationParameter(A, M * K, a_scale, a_zero_point);
+  GetQuantizationParameter(A, M * K, a_scale, a_zero_point, thread_pool);
 
   uint8_t* a_data_quant = static_cast<uint8_t*>(allocator->Alloc(SafeInt<size_t>(M * K) * sizeof(uint8_t)));
   BufferUniquePtr a_buffer_quant_holder(a_data_quant, BufferDeleter(allocator));
   // quantize the data
-  MlasQuantizeLinear(A, a_data_quant, M * K, a_scale, a_zero_point);
+  ParQuantizeLinear(A, a_data_quant, M * K, a_scale, a_zero_point, thread_pool);
 
   bool b_is_signed = weights.quant_para_->is_signed;
   uint8_t b_zero_point = weights.quant_para_->zero_point ? *static_cast<const uint8_t*>(weights.quant_para_->zero_point) : 0;

--- a/onnxruntime/core/providers/cpu/tensor/dynamicquantizelinear.cc
+++ b/onnxruntime/core/providers/cpu/tensor/dynamicquantizelinear.cc
@@ -32,35 +32,19 @@ Status DynamicQuantizeLinear<T>::Compute(OpKernelContext* ctx) const {
   auto& y_scale = *ctx->Output(1, shape);
   auto& y_zeropoint = *ctx->Output(2, shape);
 
-  // find quantization range min and max
-  float qmax = std::numeric_limits<T>::max();
-  float qmin = std::numeric_limits<T>::min();
-  // Adjust the int8 range to -127 to 127 so that zero point can be 0
-  if (qmin == -128) {
-    qmin = -127;
-  }
+  float scale;
+  T zero_point;
+  GetQuantizationParameter(x_data, num_of_elements, scale, zero_point, ctx->GetOperatorThreadPool());
 
-  // find input range min and max
-  float min, max;
-  MlasFindMinMaxElement(x_data, &min, &max, num_of_elements);
-
-  // ensure the input range includes zero
-  min = std::min(min, 0.0f);
-  max = std::max(max, 0.0f);
-
-  // find scale and zero point
-  auto scale = (max - min) / (qmax - qmin);
   auto* output_scale = y_scale.template MutableData<float>();
   *output_scale = scale;
 
-  const auto initial_zero_point = qmin - min / scale;
-  auto zero_point = static_cast<T>(RoundHalfToEven(std::max(qmin, std::min(qmax, initial_zero_point))));
   auto* output_zp = y_zeropoint.template MutableData<T>();
   *output_zp = zero_point;
 
   // quantize the data
   auto* output = y.template MutableData<T>();
-  MlasQuantizeLinear(x_data, output, num_of_elements, scale, zero_point);
+  ParQuantizeLinear(x_data, output, num_of_elements, scale, zero_point, ctx->GetOperatorThreadPool());
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/tensor/quantize_linear.cc
+++ b/onnxruntime/core/providers/cpu/tensor/quantize_linear.cc
@@ -4,6 +4,7 @@
 #include "core/providers/cpu/tensor/quantize_linear.h"
 #include "core/providers/common.h"
 #include "core/mlas/inc/mlas.h"
+#include "core/util/qmath.h"
 
 namespace onnxruntime {
 
@@ -155,7 +156,7 @@ Status QuantizeLinear<T>::Compute(OpKernelContext* ctx) const {
   for (size_t n = 0; n < static_cast<size_t>(N); n++) {
     for (size_t bd = 0; bd < static_cast<size_t>(broadcast_dim); bd++) {
       T zp = zero_point != nullptr ? zero_point[bd] : 0;
-      MlasQuantizeLinear(input, output, static_cast<size_t>(block_size), scale[bd], zp);
+      ParQuantizeLinear(input, output, static_cast<size_t>(block_size), scale[bd], zp, ctx->GetOperatorThreadPool());
       input += block_size;
       output += block_size;
     }

--- a/onnxruntime/core/util/qmath.h
+++ b/onnxruntime/core/util/qmath.h
@@ -26,16 +26,57 @@ struct is_quant_type<int8_t> : std::true_type {};
 template <>
 struct is_quant_type<uint8_t> : std::true_type {};
 
+// Define max number of parallel threads for computing min max values
+// This is hacky. Ideally we should let the thread pool handle work partition.
+// Unfortunately I can't find an elegant way for aggregation at this point.
+#define MAX_DEGREE_OF_PAR_FOR_MINMAX 32
+
+struct FloatMinMax {
+  float min;
+  float max;
+};
+
 // ReduceRange and Symmetric is for test only
 template <typename QType,
           bool ReduceRange = false,
           bool Symmetric = false,
           typename std::enable_if<is_quant_type<QType>::value, int>::type = 0>
-void GetQuantizationParameter(const float* data, int64_t num_of_elements, float& scale, QType& zp) {
-  // find input range min and max
-  float min, max;
-  MlasFindMinMaxElement(data, &min, &max, num_of_elements);
+void GetQuantizationParameter(const float* data, int64_t num_of_elements, float& scale, QType& zp, concurrency::ThreadPool* thread_pool) {
+  FloatMinMax aggregate[MAX_DEGREE_OF_PAR_FOR_MINMAX];
 
+  // Min max operation granularity: AVX512 can potentially handle 64 ~ 128 floats
+  // per iteration.
+  const size_t granularity = 128;
+  std::ptrdiff_t block_size;
+  std::ptrdiff_t num_blocks;
+  if (concurrency::ThreadPool::ShouldParallelize(thread_pool) && num_of_elements > granularity) {
+    block_size = (num_of_elements + MAX_DEGREE_OF_PAR_FOR_MINMAX - 1) / MAX_DEGREE_OF_PAR_FOR_MINMAX;
+    block_size = (block_size + granularity - 1) / granularity * granularity;
+    num_blocks = (num_of_elements + block_size - 1) / block_size;
+  } else {
+    num_blocks = 1;
+    block_size = num_of_elements;
+  }
+
+  for (int i = 0; i < num_blocks;  i++) {
+    aggregate[i].min = std::numeric_limits<float>::max();
+    aggregate[i].max = std::numeric_limits<float>::lowest();
+  }
+
+  const TensorOpCost unit_cost{static_cast<double>(block_size * sizeof(float)), 0, 0};
+  concurrency::ThreadPool::TryParallelFor(thread_pool, num_blocks, unit_cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+    auto begin_idx = begin * block_size;
+    auto end_idx = std::min(num_of_elements, end * block_size);
+    auto agg_idx = begin / num_blocks;
+    MlasFindMinMaxElement(&(data[begin_idx]), &aggregate[agg_idx].min, &aggregate[agg_idx].max, end_idx - begin_idx);
+  });
+
+  float& min = aggregate[0].min;
+  float& max = aggregate[0].max;
+  for (int i = 1; i < num_blocks; i++) {
+    min = std::min(min, aggregate[i].min);
+    max = std::max(max, aggregate[i].max);
+  }
   // ensure the input range includes zero
   min = std::min(min, 0.0f);
   max = std::max(max, 0.0f);
@@ -61,5 +102,87 @@ void GetQuantizationParameter(const float* data, int64_t num_of_elements, float&
   float initial_zero_point = qmin - min / scale;
   zp = static_cast<QType>(RoundHalfToEven(std::max(float(qmin), std::min(float(qmax), initial_zero_point))));
 }
+
+/**
+ * @brief Run MlasQuantizeLinear in parallel, with provided thread pool 
+*/
+template <typename OutputType>
+void ParQuantizeLinear(const float* Input,
+                       OutputType* Output,
+                       size_t N,
+                       float Scale,
+                       OutputType ZeroPoint,
+                       concurrency::ThreadPool* thread_pool) {
+  const std::ptrdiff_t block_size = 128;
+  const std::ptrdiff_t num_blocks = (N + block_size - 1) / block_size;
+  const TensorOpCost unit_cost{static_cast<double>(block_size * sizeof(float)), static_cast<double>(block_size * sizeof(uint8_t)), 0};
+  concurrency::ThreadPool::TryParallelFor(thread_pool, num_blocks, unit_cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+    auto begin_idx = begin * block_size;
+    auto end_idx = std::min(static_cast<std::ptrdiff_t>(N), end * block_size);
+    MlasQuantizeLinear(&(Input[begin_idx]), &(Output[begin_idx]), end_idx - begin_idx, Scale, ZeroPoint);
+  });
+}
+
+
+/**
+ * Encapsulating the batched GEMM operation, including parameter preparation
+ * and invoking the MLAS GEMM function. 
+ * 
+ * Note that we only support uniform batch (same shapes) at this point
+ */
+class MLAS_GEMM_U8X8_BATCH_CALLER {
+ public:
+  MLAS_GEMM_U8X8_BATCH_CALLER(
+      size_t M, size_t N, size_t K,
+      bool b_is_packed, bool b_is_signed,
+      size_t batch_size = 0) {
+    if (batch_size > 0) {
+      parameters_.reserve(batch_size);
+    }
+    parameters_.emplace_back();
+    auto& param = parameters_[0];
+    param.M = M;
+    param.N = N;
+    param.K = K;
+    param.BIsPacked = b_is_packed;
+    param.BIsSigned = b_is_signed;
+  }
+
+  void AddData(
+      const uint8_t* A, size_t lda, uint8_t zero_point_a,
+      const void* B, size_t ldb, const uint8_t* zero_point_b,
+      bool per_col_zero_points,
+      int32_t* C, size_t ldc,
+      const MLAS_QGEMM_OUTPUT_PROCESSOR* output_processor = nullptr) {
+    auto* ptr = &(parameters_[0]);
+    if (ptr->A) {
+      parameters_.emplace_back();
+      ptr = &(parameters_[parameters_.size() - 1]);
+      ptr->M = parameters_[0].M;
+      ptr->N = parameters_[0].N;
+      ptr->K = parameters_[0].K;
+      ptr->BIsPacked = parameters_[0].BIsPacked;
+      ptr->BIsSigned = parameters_[0].BIsSigned;
+    }
+
+    ptr->A = A;
+    ptr->lda = lda;
+    ptr->ZeroPointA = zero_point_a;
+    ptr->B = B;
+    ptr->ldb = ldb;
+    ptr->ZeroPointB = zero_point_b;
+    ptr->PerColumnZeroPoints = per_col_zero_points;
+    ptr->C = C;
+    ptr->ldc = ldc;
+    ptr->OutputProcessor = output_processor;
+  }
+
+  void Run(MLAS_THREADPOOL* ThreadPool) {
+    MlasGemmBatch(parameters_.data(), parameters_.size(), ThreadPool);
+  }
+
+ private:
+  std::vector<MLAS_GEMM_U8X8_PARAMETERS> parameters_;
+};
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/util/qmath.h
+++ b/onnxruntime/core/util/qmath.h
@@ -64,7 +64,7 @@ void GetQuantizationParameter(const float* data, int64_t num_of_elements, float&
     aggregate[i].max = std::numeric_limits<float>::lowest();
   }
 
-  const TensorOpCost unit_cost{static_cast<double>(block_size * sizeof(float)), 0, 0};
+  const TensorOpCost unit_cost{static_cast<double>(block_size * sizeof(float)), 2.0, static_cast<double>(block_size)};
   concurrency::ThreadPool::TryParallelFor(thread_pool, num_blocks, unit_cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
     auto begin_idx = begin * block_size;
     auto end_idx = std::min(std::ptrdiff_t(num_of_elements), end * block_size);
@@ -116,7 +116,7 @@ void ParQuantizeLinear(const float* Input,
                        concurrency::ThreadPool* thread_pool) {
   const std::ptrdiff_t block_size = 128;
   const std::ptrdiff_t num_blocks = (N + block_size - 1) / block_size;
-  const TensorOpCost unit_cost{static_cast<double>(block_size * sizeof(float)), static_cast<double>(block_size * sizeof(uint8_t)), 0};
+  const TensorOpCost unit_cost{static_cast<double>(block_size * sizeof(float)), static_cast<double>(block_size * sizeof(uint8_t)), static_cast<double>(block_size) * 2.0};
   concurrency::ThreadPool::TryParallelFor(thread_pool, num_blocks, unit_cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
     auto begin_idx = begin * block_size;
     auto end_idx = std::min(static_cast<std::ptrdiff_t>(N), end * block_size);

--- a/onnxruntime/test/contrib_ops/quantize_lstm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_lstm_op_test.cc
@@ -24,9 +24,9 @@ static std::vector<float> ApplyQDQ(const std::vector<float>& data, size_t channe
     float scale = 1.0f;
     const float* data_buf = data.data() + size_per_dir * dir_idx;
     if (per_channel) {
-      GetQuantizationParameter<QType, true, true>(data_buf, size_per_dir, scale, zp);
+      GetQuantizationParameter<QType, true, true>(data_buf, size_per_dir, scale, zp, nullptr);
     } else {
-      GetQuantizationParameter<QType, true, false>(data_buf, size_per_dir, scale, zp);
+      GetQuantizationParameter<QType, true, false>(data_buf, size_per_dir, scale, zp, nullptr);
     }
 
     std::vector<QType> quant_data(size_per_dir);
@@ -62,9 +62,9 @@ void QuantizeWeight(std::vector<QType>& w_quant,
 
   for (size_t quant_param_idx = 0; quant_param_idx < quant_param_size; quant_param_idx++) {
     if (per_channel) {
-      GetQuantizationParameter<QType, true, true>(w.data() + quant_param_idx * quant_span, quant_span, scale[quant_param_idx], zp[quant_param_idx]);
+      GetQuantizationParameter<QType, true, true>(w.data() + quant_param_idx * quant_span, quant_span, scale[quant_param_idx], zp[quant_param_idx], nullptr);
     } else {
-      GetQuantizationParameter<QType, true, false>(w.data() + quant_param_idx * quant_span, quant_span, scale[quant_param_idx], zp[quant_param_idx]);
+      GetQuantizationParameter<QType, true, false>(w.data() + quant_param_idx * quant_span, quant_span, scale[quant_param_idx], zp[quant_param_idx], nullptr);
     }
 
     MlasQuantizeLinear(w.data() + quant_param_idx * quant_span,

--- a/onnxruntime/test/mlas/bench/bench_qgemm.cpp
+++ b/onnxruntime/test/mlas/bench/bench_qgemm.cpp
@@ -73,8 +73,9 @@ void QGEMM(benchmark::State& state, bool pack_b) {
       gemm_params.B = (void*)(pack_b_holder.data() + packed_b_size * i);
     }
   }
-
-  MlasGemmBatch(gemm_shape, gemm_data_vec.data(), batch, tp.get());
+  for (auto _ : state) {
+    MlasGemmBatch(gemm_shape, gemm_data_vec.data(), batch, tp.get());
+  }
 }
 
 static void QGemmSize(benchmark::internal::Benchmark* b) {

--- a/onnxruntime/test/mlas/bench/bench_qgemm.cpp
+++ b/onnxruntime/test/mlas/bench/bench_qgemm.cpp
@@ -42,42 +42,39 @@ void QGEMM(benchmark::State& state, bool pack_b) {
   std::vector<int32_t> C_holder(static_cast<size_t>(M * N * batch));
   std::vector<uint8_t> pack_b_holder;
 
-  MLAS_GEMM_U8X8_PARAMETERS gemm_params;
-
-  gemm_params.M = static_cast<size_t>(M);
-  gemm_params.N = static_cast<size_t>(N);
-  gemm_params.K = static_cast<size_t>(K);
-  gemm_params.lda = gemm_params.K;
-  gemm_params.ZeroPointA = a_zero_point;
-  gemm_params.ZeroPointB = &b_zero_point;
-  gemm_params.BIsSigned = b_is_signed;
-  gemm_params.C = C_holder.data();
-  gemm_params.ldc = gemm_params.N;
-
   size_t packed_b_size = 0;
   if (pack_b) {
     packed_b_size = MlasGemmPackBSize(N, K, b_is_signed);
     pack_b_holder.resize(packed_b_size * batch);
-    for (int i = 0; i < batch; i++) {
-      MlasGemmPackB(N, K, B_holder.data() + N * K * i, N, b_is_signed, (void*)(pack_b_holder.data() + packed_b_size * i));
-    }
-    gemm_params.BIsPacked = true;
-  } else {
-    gemm_params.ldb = gemm_params.N;
   }
 
-  for (auto _ : state) {
-    for (int i = 0; i < batch; i++) {
-      gemm_params.A = A_holder.data() + M * K * i;
-      gemm_params.C = C_holder.data() + M * N * i;
-      if (pack_b) {
-        gemm_params.B = (void*)(pack_b_holder.data() + packed_b_size * i);
-      } else {
-        gemm_params.B = B_holder.data() + N * K * i;
-      }
-      MlasGemm(&gemm_params, tp.get());
+  MLAS_GEMM_U8X8_SHAPE_PARAMS gemm_shape;
+
+  gemm_shape.M = static_cast<size_t>(M);
+  gemm_shape.N = static_cast<size_t>(N);
+  gemm_shape.K = static_cast<size_t>(K);
+  gemm_shape.BIsSigned = b_is_signed;
+
+
+  std::vector<MLAS_GEMM_U8X8_DATA_PARAMS> gemm_data_vec(batch);
+  for (int i = 0; i < batch; i++) {
+    auto& gemm_params = gemm_data_vec[i];
+    gemm_params.lda = gemm_shape.K;
+    gemm_params.ZeroPointA = a_zero_point;
+    gemm_params.ZeroPointB = &b_zero_point;
+    gemm_params.ldc = gemm_shape.N;
+    gemm_params.A = A_holder.data() + M * K * i;
+    gemm_params.B = B_holder.data() + N * K * i;
+    gemm_params.ldb = gemm_shape.N;
+    gemm_params.C = C_holder.data() + M * N * i;
+    if (pack_b) {
+      MlasGemmPackB(N, K, (const uint8_t*)gemm_params.B, N, b_is_signed, (void*)(pack_b_holder.data() + packed_b_size * i));
+      gemm_params.BIsPacked = true;
+      gemm_params.B = (void*)(pack_b_holder.data() + packed_b_size * i);
     }
   }
+
+  MlasGemmBatch(gemm_shape, gemm_data_vec.data(), batch, tp.get());
 }
 
 static void QGemmSize(benchmark::internal::Benchmark* b) {

--- a/onnxruntime/test/mlas/unittest/test_qgemm.h
+++ b/onnxruntime/test/mlas/unittest/test_qgemm.h
@@ -23,6 +23,7 @@ class MlasQgemmU8X8U8X8TestBase : public MlasTestBase {
   void TestGemm(size_t M,
                 size_t N,
                 size_t K,
+                size_t BatchSize,
                 const uint8_t* A,
                 size_t lda,
                 uint8_t offa,
@@ -32,33 +33,40 @@ class MlasQgemmU8X8U8X8TestBase : public MlasTestBase {
                 bool BIsSigned,
                 int32_t* C,
                 size_t ldc) {
-    MLAS_GEMM_U8X8_PARAMETERS GemmParameters;
+    MLAS_GEMM_U8X8_SHAPE_PARAMS GemmShape;
+    GemmShape.M = M;
+    GemmShape.N = N;
+    GemmShape.K = K;
+    GemmShape.BIsSigned = BIsSigned;
 
-    GemmParameters.M = M;
-    GemmParameters.N = N;
-    GemmParameters.K = K;
-    GemmParameters.A = A;
-    GemmParameters.lda = lda;
-    GemmParameters.ZeroPointA = offa;
-    GemmParameters.ZeroPointB = &offb;
-    GemmParameters.BIsSigned = BIsSigned;
-    GemmParameters.C = C;
-    GemmParameters.ldc = ldc;
+    std::vector<MLAS_GEMM_U8X8_DATA_PARAMS> GemmParameters(BatchSize);
 
-    if (Packed) {
-      GemmParameters.B = PackB(N, K, B, ldb, BIsSigned);
-      GemmParameters.BIsPacked = true;
-    } else {
-      GemmParameters.B = B;
-      GemmParameters.ldb = ldb;
+    for (size_t i = 0; i < GemmParameters.size(); i++) {
+      auto& params = GemmParameters[i];
+      params.A = A + (M * K * i);
+      params.lda = lda;
+      params.ZeroPointA = offa;
+      params.ZeroPointB = &offb;
+      params.C = C + (M * N * i);
+      params.ldc = ldc;
+
+      if (Packed) {
+        ASSERT_EQ(BatchSize, size_t(1)) << "Packing B not supported in batching yet!";
+        params.B = PackB(N, K, B, ldb, BIsSigned);
+        params.BIsPacked = true;
+      } else {
+        params.B = B + (K * N * i);
+        params.ldb = ldb;
+      }
     }
 
-    MlasGemm(&GemmParameters, threadpool_);
+    MlasGemmBatch(GemmShape, GemmParameters.data(), BatchSize, threadpool_);
   }
 
   void TestGemm(size_t M,
                 size_t N,
                 size_t K,
+                size_t BatchSize,
                 const uint8_t* A,
                 size_t lda,
                 uint8_t offa,
@@ -68,34 +76,41 @@ class MlasQgemmU8X8U8X8TestBase : public MlasTestBase {
                 bool BIsSigned,
                 int32_t* C,
                 size_t ldc) {
-    MLAS_GEMM_U8X8_PARAMETERS GemmParameters;
+    MLAS_GEMM_U8X8_SHAPE_PARAMS GemmShape;
+    GemmShape.M = M;
+    GemmShape.N = N;
+    GemmShape.K = K;
+    GemmShape.BIsSigned = BIsSigned;
 
-    GemmParameters.M = M;
-    GemmParameters.N = N;
-    GemmParameters.K = K;
-    GemmParameters.A = A;
-    GemmParameters.lda = lda;
-    GemmParameters.ZeroPointA = offa;
-    GemmParameters.ZeroPointB = offb;
-    GemmParameters.BIsSigned = BIsSigned;
-    GemmParameters.PerColumnZeroPoints = true;
-    GemmParameters.C = C;
-    GemmParameters.ldc = ldc;
+    std::vector<MLAS_GEMM_U8X8_DATA_PARAMS> GemmParameters(BatchSize);
 
-    if (Packed) {
-      GemmParameters.B = PackB(N, K, B, ldb, BIsSigned);
-      GemmParameters.BIsPacked = true;
-    } else {
-      GemmParameters.B = B;
-      GemmParameters.ldb = ldb;
+    for (size_t i = 0; i < GemmParameters.size(); i++) {
+      auto& params = GemmParameters[i];
+      params.A = A + M * K * i;
+      params.lda = lda;
+      params.ZeroPointA = offa;
+      params.ZeroPointB = offb;
+      params.PerColumnZeroPoints = true;
+      params.C = C + M * N * i;
+      params.ldc = ldc;
+
+      if (Packed) {
+        ASSERT_EQ(BatchSize, size_t(1)) << "Packing B not supported in batching yet!";
+        params.B = PackB(N, K, B, ldb, BIsSigned);
+        params.BIsPacked = true;
+      } else {
+        params.B = B + K * N * i;
+        params.ldb = ldb;
+      }
     }
 
-    MlasGemm(&GemmParameters, threadpool_);
+    MlasGemmBatch(GemmShape, GemmParameters.data(), BatchSize, threadpool_);
   }
 
   void TestGemm(size_t M,
                 size_t N,
                 size_t K,
+                size_t BatchSize,
                 const uint8_t* A,
                 size_t lda,
                 uint8_t offa,
@@ -107,31 +122,39 @@ class MlasQgemmU8X8U8X8TestBase : public MlasTestBase {
                 size_t ldc,
                 float CScale,
                 const float* Bias) {
-    MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR ScaleBiasProcessor(C, ldc, &CScale, Bias);
+    MLAS_GEMM_U8X8_SHAPE_PARAMS GemmShape;
+    GemmShape.M = M;
+    GemmShape.N = N;
+    GemmShape.K = K;
+    GemmShape.BIsSigned = BIsSigned;
 
-    MLAS_GEMM_U8X8_PARAMETERS GemmParameters;
+    std::vector<MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR> ScaleBiasProcessors;
+    ScaleBiasProcessors.reserve(BatchSize);
 
-    GemmParameters.M = M;
-    GemmParameters.N = N;
-    GemmParameters.K = K;
-    GemmParameters.A = A;
-    GemmParameters.lda = lda;
-    GemmParameters.ZeroPointA = offa;
-    GemmParameters.ZeroPointB = &offb;
-    GemmParameters.BIsSigned = BIsSigned;
-    GemmParameters.C = reinterpret_cast<int32_t*>(C);
-    GemmParameters.ldc = ldc;
-    GemmParameters.OutputProcessor = &ScaleBiasProcessor;
+    std::vector<MLAS_GEMM_U8X8_DATA_PARAMS> GemmParameters(BatchSize);
 
-    if (Packed) {
-      GemmParameters.B = PackB(N, K, B, ldb, BIsSigned);
-      GemmParameters.BIsPacked = true;
-    } else {
-      GemmParameters.B = B;
-      GemmParameters.ldb = ldb;
+    for (size_t i = 0; i < BatchSize; i++) {
+      auto& params = GemmParameters[i];
+      params.A = A + M * K * i;
+      params.lda = lda;
+      params.ZeroPointA = offa;
+      params.ZeroPointB = &offb;
+      params.C = reinterpret_cast<int32_t*>(C + M * N * i);
+      params.ldc = ldc;
+
+      if (Packed) {
+        // Packed B not supported in batching yet
+        params.B = PackB(N, K, B, ldb, BIsSigned);
+        params.BIsPacked = true;
+      } else {
+        params.B = B + K * N * i;
+        params.ldb = ldb;
+      }
+      ScaleBiasProcessors.emplace_back(C + M * N * i, ldc, &CScale, Bias);
+      params.OutputProcessor = &(ScaleBiasProcessors[i]);
     }
 
-    MlasGemm(&GemmParameters, threadpool_);
+    MlasGemmBatch(GemmShape, GemmParameters.data(), BatchSize, threadpool_);
   }
 
  private:
@@ -144,28 +167,29 @@ class MlasQgemmU8X8Test;
 template <typename xint8_t, bool Packed, bool Threaded>
 class MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded> : public MlasQgemmU8X8U8X8TestBase<Packed, Threaded> {
  public:
-  void Test(size_t M, size_t N, size_t K, uint8_t offa, uint8_t offb) {
-    const uint8_t* A = BufferA.GetBuffer(K * M);
-    const uint8_t* B = BufferB.GetBuffer(N * K);
-    int32_t* C = BufferC.GetBuffer(N * M);
-    int32_t* CReference = BufferCReference.GetBuffer(N * M);
+  void Test(size_t M, size_t N, size_t K, size_t BatchSize, uint8_t offa, uint8_t offb) {
+    const uint8_t* A = BufferA.GetBuffer(K * M * BatchSize);
+    const uint8_t* B = BufferB.GetBuffer(N * K * BatchSize);
+    int32_t* C = BufferC.GetBuffer(N * M * BatchSize);
+    int32_t* CReference = BufferCReference.GetBuffer(N * M * BatchSize);
 
-    Test(M, N, K, A, K, offa, B, N, offb, C, CReference, N);
+    Test(M, N, K, BatchSize, A, K, offa, B, N, offb, C, CReference, N);
   }
 
-  void Test(size_t M, size_t N, size_t K, uint8_t offa) {
-    const uint8_t* A = BufferA.GetBuffer(K * M);
-    const uint8_t* B = BufferB.GetBuffer(N * K);
+  void Test(size_t M, size_t N, size_t K, size_t BatchSize, uint8_t offa) {
+    const uint8_t* A = BufferA.GetBuffer(K * M * BatchSize);
+    const uint8_t* B = BufferB.GetBuffer(N * K * BatchSize);
     const uint8_t* ZeroPointB = BufferZeroPointB.GetBuffer(N);
-    int32_t* C = BufferC.GetBuffer(N * M);
-    int32_t* CReference = BufferCReference.GetBuffer(N * M);
+    int32_t* C = BufferC.GetBuffer(N * M * BatchSize);
+    int32_t* CReference = BufferCReference.GetBuffer(N * M * BatchSize);
 
-    Test(M, N, K, A, K, offa, B, N, ZeroPointB, C, CReference, N);
+    Test(M, N, K, BatchSize, A, K, offa, B, N, ZeroPointB, C, CReference, N);
   }
 
   void Test(size_t M,
             size_t N,
             size_t K,
+            size_t BatchSize,
             const uint8_t* A,
             size_t lda,
             uint8_t offa,
@@ -175,17 +199,19 @@ class MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded> : public MlasQgemmU8
             int32_t* C,
             int32_t* CReference,
             size_t ldc) {
-    std::fill_n(C, M * N, -1);
-    std::fill_n(CReference, M * N, -1);
+    std::fill_n(C, M * N * BatchSize, -1);
+    std::fill_n(CReference, M * N * BatchSize, -1);
 
-    this->TestGemm(M, N, K, A, lda, offa, B, ldb, offb, BIsSigned, C, ldc);
-    ReferenceQgemm(M, N, K, A, lda, offa, (const xint8_t*)B, ldb, (xint8_t)offb, CReference, ldc);
+    this->TestGemm(M, N, K, BatchSize, A, lda, offa, B, ldb, offb, BIsSigned, C, ldc);
+    ReferenceQgemm(M, N, K, BatchSize, A, lda, offa, (const xint8_t*)B, ldb, (xint8_t)offb, CReference, ldc);
 
-    for (size_t m = 0, f = 0; m < M; m++) {
-      for (size_t n = 0; n < N; n++, f++) {
-        ASSERT_EQ(C[f], CReference[f]) << "@[" << m << "x" << n << "], "
-                                       << "M=" << M << ", N=" << N << ", K=" << K
-                                       << ", offa=" << int(offa) << ", offb=" << offb;
+    for (size_t batch = 0, f = 0; batch < BatchSize; batch++) {
+      for (size_t m = 0; m < M; m++) {
+        for (size_t n = 0; n < N; n++, f++) {
+          ASSERT_EQ(C[f], CReference[f]) << "@[" << batch << "x" << m << "x" << n << "], "
+                                         << "Batch=" << BatchSize << "M=" << M << ", N=" << N << ", K=" << K
+                                         << ", offa=" << int(offa) << ", offb=" << offb;
+        }
       }
     }
   }
@@ -193,6 +219,7 @@ class MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded> : public MlasQgemmU8
   void Test(size_t M,
             size_t N,
             size_t K,
+            size_t BatchSize,
             const uint8_t* A,
             size_t lda,
             uint8_t offa,
@@ -202,16 +229,19 @@ class MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded> : public MlasQgemmU8
             int32_t* C,
             int32_t* CReference,
             size_t ldc) {
-    std::fill_n(C, M * N, -1);
-    std::fill_n(CReference, M * N, -1);
+    std::fill_n(C, M * N * BatchSize, -1);
+    std::fill_n(CReference, M * N * BatchSize, -1);
 
-    this->TestGemm(M, N, K, A, lda, offa, B, ldb, offb, BIsSigned, C, ldc);
-    ReferenceQgemm(M, N, K, A, lda, offa, (const xint8_t*)B, ldb, (const xint8_t*)offb, CReference, ldc);
+    this->TestGemm(M, N, K, BatchSize, A, lda, offa, B, ldb, offb, BIsSigned, C, ldc);
+    ReferenceQgemm(M, N, K, BatchSize, A, lda, offa, (const xint8_t*)B, ldb, (const xint8_t*)offb, CReference, ldc);
 
-    for (size_t m = 0, f = 0; m < M; m++) {
-      for (size_t n = 0; n < N; n++, f++) {
-        ASSERT_EQ(C[f], CReference[f]) << "@[" << m << "x" << n << "], "
-                                       << "M=" << M << ", N=" << N << ", K=" << K << ", offa=" << int(offa);
+    for (size_t batch = 0, f = 0; batch < BatchSize; batch++) {
+      for (size_t m = 0; m < M; m++) {
+        for (size_t n = 0; n < N; n++, f++) {
+          ASSERT_EQ(C[f], CReference[f]) << "@[" << batch << "x" << m << "x" << n << "], "
+                                         << "Batch=" << BatchSize << "M=" << M << ", N=" << N << ", K=" << K
+                                         << ", offa=" << int(offa) << ", offb=" << offb;
+        }
       }
     }
   }
@@ -220,6 +250,7 @@ class MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded> : public MlasQgemmU8
   void ReferenceQgemm(size_t M,
                       size_t N,
                       size_t K,
+                      size_t BatchSize,
                       const uint8_t* A,
                       size_t lda,
                       uint8_t offa,
@@ -228,20 +259,22 @@ class MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded> : public MlasQgemmU8
                       xint8_t offb,
                       int32_t* C,
                       size_t ldc) {
-    for (size_t m = 0; m < M; m++) {
-      for (size_t n = 0; n < N; n++) {
-        const uint8_t* a = A + (m * lda);
-        const xint8_t* b = B + n;
-        int32_t* c = C + (m * ldc) + n;
-        int32_t sum = 0;
+    for (size_t batch = 0; batch < BatchSize; batch++) {
+      for (size_t m = 0; m < M; m++) {
+        for (size_t n = 0; n < N; n++) {
+          const uint8_t* a = A + (M * K * batch) + (m * lda);
+          const xint8_t* b = B + (K * N * batch) + n;
+          int32_t* c = C + (M * N * batch) + (m * ldc) + n;
+          int32_t sum = 0;
 
-        for (size_t k = 0; k < K; k++) {
-          sum += ((int32_t(*b) - offb) * (int32_t(*a) - offa));
-          b += ldb;
-          a += 1;
+          for (size_t k = 0; k < K; k++) {
+            sum += ((int32_t(*b) - offb) * (int32_t(*a) - offa));
+            b += ldb;
+            a += 1;
+          }
+
+          *c = sum;
         }
-
-        *c = sum;
       }
     }
   }
@@ -249,6 +282,7 @@ class MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded> : public MlasQgemmU8
   void ReferenceQgemm(size_t M,
                       size_t N,
                       size_t K,
+                      size_t BatchSize,
                       const uint8_t* A,
                       size_t lda,
                       uint8_t offa,
@@ -257,20 +291,22 @@ class MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded> : public MlasQgemmU8
                       const xint8_t* offb,
                       int32_t* C,
                       size_t ldc) {
-    for (size_t m = 0; m < M; m++) {
-      for (size_t n = 0; n < N; n++) {
-        const uint8_t* a = A + (m * lda);
-        const xint8_t* b = B + n;
-        int32_t* c = C + (m * ldc) + n;
-        int32_t sum = 0;
+    for (size_t batch = 0; batch < BatchSize; batch++) {
+      for (size_t m = 0; m < M; m++) {
+        for (size_t n = 0; n < N; n++) {
+          const uint8_t* a = A + (M * K * batch) + (m * lda);
+          const xint8_t* b = B + (K * N * batch) + n;
+          int32_t* c = C + (M * N * batch) + (m * ldc) + n;
+          int32_t sum = 0;
 
-        for (size_t k = 0; k < K; k++) {
-          sum += ((int32_t(*b) - offb[n]) * (int32_t(*a) - offa));
-          b += ldb;
-          a += 1;
+          for (size_t k = 0; k < K; k++) {
+            sum += ((int32_t(*b) - offb[n]) * (int32_t(*a) - offa));
+            b += ldb;
+            a += 1;
+          }
+
+          *c = sum;
         }
-
-        *c = sum;
       }
     }
   }
@@ -306,21 +342,29 @@ class MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded> : public MlasQgemmU8
             for (size_t k = 0; k < _countof(ks); k++) {
               size_t K = ks[k];
 
-              Test(M, N, K, offa, offb);
-              Test(M + 1, N, K, offa, offb);
-              Test(M, N + 1, K, offa, offb);
-              Test(M + 1, N + 1, K, offa, offb);
-              Test(M + 3, N + 2, K, offa, offb);
-              Test(M + 4, N, K, offa, offb);
-              Test(M, N + 4, K, offa, offb);
-              Test(M + 4, N + 4, K, offa, offb);
-              Test(M + 3, N + 7, K, offa, offb);
-              Test(M + 8, N, K, offa, offb);
-              Test(M, N + 8, K, offa, offb);
-              Test(M + 12, N + 12, K, offa, offb);
-              Test(M + 13, N, K, offa, offb);
-              Test(M, N + 15, K, offa, offb);
-              Test(M + 15, N + 15, K, offa, offb);
+              Test(M, N, K, 1, offa, offb);
+              Test(M + 1, N, K, 1, offa, offb);
+              Test(M, N + 1, K, 1, offa, offb);
+              Test(M + 1, N + 1, K, 1, offa, offb);
+              Test(M + 3, N + 2, K, 1, offa, offb);
+              Test(M + 4, N, K, 1, offa, offb);
+              Test(M, N + 4, K, 1, offa, offb);
+              Test(M + 4, N + 4, K, 1, offa, offb);
+              Test(M + 3, N + 7, K, 1, offa, offb);
+              Test(M + 8, N, K, 1, offa, offb);
+              Test(M, N + 8, K, 1, offa, offb);
+              Test(M + 12, N + 12, K, 1, offa, offb);
+              Test(M + 13, N, K, 1, offa, offb);
+              Test(M, N + 15, K, 1, offa, offb);
+              Test(M + 15, N + 15, K, 1, offa, offb);
+              if (!Packed) {
+                Test(M, N, K, 7 + a, offa, offb);
+                Test(M + 3, N, K, 7 + a, offa, offb);
+                Test(M, N + 1, K, 7 + a, offa, offb);
+                Test(M + 12, N, K, 7 + a, offa, offb);
+                Test(M, N + 15, K, 7 + a, offa, offb);
+                Test(M + 15, N + 15, K,7 + a, offa, offb);
+              }
             }
           }
           printf("a %zd/%zd b %zd/%zd M %zd\n", a, _countof(zero_points), b, _countof(zero_points), M);
@@ -331,7 +375,7 @@ class MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded> : public MlasQgemmU8
     for (size_t M = 1; M < 160; M++) {
       for (size_t N = 1; N < 160; N++) {
         for (size_t K = 1; K < 160; K++) {
-          Test(M, N, K, 18, 24);
+          Test(M, N, K, 1, 18, 24);
         }
       }
       printf("M %zd\n", M);
@@ -340,10 +384,10 @@ class MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded> : public MlasQgemmU8
     for (size_t M = 160; M < 320; M += 24) {
       for (size_t N = 112; N < 320; N += 24) {
         for (size_t K = 1; K < 16; K++) {
-          Test(M, N, K, 1, 3);
+          Test(M, N, K, 1, 1, 3);
         }
         for (size_t K = 16; K < 160; K += 32) {
-          Test(M, N, K, 5, 7);
+          Test(M, N, K, 1, 5, 7);
         }
       }
       printf("M %zd\n", M);
@@ -354,30 +398,35 @@ class MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded> : public MlasQgemmU8
 template <typename xint8_t, bool Packed, bool Threaded>
 class MlasQgemmU8X8Test<xint8_t, float, Packed, Threaded> : public MlasQgemmU8X8U8X8TestBase<Packed, Threaded> {
  public:
-  void Test(size_t M, size_t N, size_t K, uint8_t offa, uint8_t offb) {
-    const uint8_t* A = BufferA.GetBuffer(K * M);
-    const uint8_t* B = BufferB.GetBuffer(N * K);
-    float* C = BufferC.GetBuffer(N * M);
-    float* CReference = BufferCReference.GetBuffer(N * M);
+  void Test(size_t M, size_t N, size_t K, size_t BatchSize, uint8_t offa, uint8_t offb) {
+    const uint8_t* A = BufferA.GetBuffer(K * M * BatchSize);
+    const uint8_t* B = BufferB.GetBuffer(N * K * BatchSize);
+    float* C = BufferC.GetBuffer(N * M * BatchSize);
+    float* CReference = BufferCReference.GetBuffer(N * M * BatchSize);
     const float* Bias = BufferBias.GetBuffer(N);
 
     const float AScale = 0.5f;
-    float* AFloat = BufferAFloat.GetBuffer(K * M);
-    DequantizeLinear(A, AFloat, K * M, AScale, offa);
+    float* AFloat = BufferAFloat.GetBuffer(K * M * BatchSize);
+    for (size_t b = 0; b < BatchSize; b++) {
+      DequantizeLinear(A + K * M * b, AFloat + K * M * b, K * M, AScale, offa);
+    }
 
     const float BScale = 0.25f;
-    float* BFloat = BufferBFloat.GetBuffer(N * K);
-    DequantizeLinear((xint8_t*)B, BFloat, N * K, BScale, xint8_t(offb));
+    float* BFloat = BufferBFloat.GetBuffer(N * K * BatchSize);
+    for (size_t b = 0; b < BatchSize; b++) {
+      DequantizeLinear((xint8_t*)(B + N * K * b), BFloat + N * K * b, N * K, BScale, xint8_t(offb));
+    }
 
     const float CScale = AScale * BScale;
 
-    Test(M, N, K, A, AFloat, K, offa, B, BFloat, N, offb, C, CReference, N, CScale, nullptr);
-    Test(M, N, K, A, AFloat, K, offa, B, BFloat, N, offb, C, CReference, N, CScale, Bias);
+    Test(M, N, K, BatchSize, A, AFloat, K, offa, B, BFloat, N, offb, C, CReference, N, CScale, nullptr);
+    Test(M, N, K, BatchSize, A, AFloat, K, offa, B, BFloat, N, offb, C, CReference, N, CScale, Bias);
   }
 
   void Test(size_t M,
             size_t N,
             size_t K,
+            size_t BatchSize,
             const uint8_t* A,
             const float* AFloat,
             size_t lda,
@@ -391,26 +440,34 @@ class MlasQgemmU8X8Test<xint8_t, float, Packed, Threaded> : public MlasQgemmU8X8
             size_t ldc,
             float CScale,
             const float* Bias) {
-    MlasGemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.0f, AFloat, lda, BFloat, ldb, 0.0f,
-             CReference, ldc, MlasQgemmU8X8U8X8TestBase<Packed, Threaded>::threadpool_);
+    for (size_t b = 0; b < BatchSize; b++) {
+      MlasGemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.0f,
+               AFloat + K * M * b, lda,
+               BFloat + N * K * b, ldb, 0.0f,
+               CReference + N * M * b, ldc, 
+          MlasQgemmU8X8U8X8TestBase<Packed, Threaded>::threadpool_);
+    }
 
     if (Bias != nullptr) {
-      for (size_t m = 0; m < M; m++) {
-        for (size_t n = 0; n < N; n++) {
-          CReference[m * ldc + n] += Bias[n];
+      for (size_t b = 0; b < BatchSize; b++) {
+        for (size_t m = 0; m < M; m++) {
+          for (size_t n = 0; n < N; n++) {
+            CReference[N * M * b + m * ldc + n] += Bias[n];
+          }
         }
       }
     }
 
-    this->TestGemm(M, N, K, A, lda, offa, B, ldb, offb, BIsSigned, C, ldc, CScale, Bias);
+    this->TestGemm(M, N, K, BatchSize, A, lda, offa, B, ldb, offb, BIsSigned, C, ldc, CScale, Bias);
 
-    for (size_t m = 0, f = 0; m < M; m++) {
-      for (size_t n = 0; n < N; n++, f++) {
-        // Sensitive to comparing positive/negative zero.
-        ASSERT_EQ(C[f], CReference[f]) << "@[" << m << "x" << n << "], "
-                                       << "M=" << M << ", N=" << N << ", K=" << K
-                                       << ", offa=" << int(offa)
-                                       << ", offb=" << int(offb);
+    for (size_t batch = 0, f = 0; batch < BatchSize; batch++) {
+      for (size_t m = 0; m < M; m++) {
+        for (size_t n = 0; n < N; n++, f++) {
+          // Sensitive to comparing positive/negative zero.
+          ASSERT_EQ(C[f], CReference[f]) << "@[" << batch << "x" << m << "x" << n << "], "
+                                         << "Batch=" << BatchSize << "M=" << M << ", N=" << N << ", K=" << K
+                                         << ", offa=" << int(offa) << ", offb=" << offb;
+        }
       }
     }
   }

--- a/onnxruntime/test/mlas/unittest/test_qgemm_fixture.h
+++ b/onnxruntime/test/mlas/unittest/test_qgemm_fixture.h
@@ -29,7 +29,7 @@ class QgemmShortExecuteTest<xint8_t, int32_t, Packed, Threaded> : public MlasTes
 
   static size_t RegisterSingleTest(bool use_offb, size_t M, size_t N, size_t K, size_t Batch, uint8_t offa, uint8_t offb) {
     std::stringstream ss;
-    ss << "Batch" << Batch << "M" << M << "xN" << N << "xK" << K << "/"
+    ss << "Batch" << Batch << "/M" << M << "xN" << N << "xK" << K << "/"
        << "offa" << (unsigned)offa << "/"
        << "offb";
     if (use_offb) {

--- a/onnxruntime/test/mlas/unittest/test_qgemm_fixture.h
+++ b/onnxruntime/test/mlas/unittest/test_qgemm_fixture.h
@@ -15,19 +15,19 @@ class QgemmShortExecuteTest;
 template <typename xint8_t, bool Packed, bool Threaded>
 class QgemmShortExecuteTest<xint8_t, int32_t, Packed, Threaded> : public MlasTestFixture<MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded>> {
  public:
-  explicit QgemmShortExecuteTest(bool use_offb, size_t M, size_t N, size_t K, uint8_t offa, uint8_t offb)
-      : use_offb_(use_offb), M_(M), N_(N), K_(K), offa_(offa), offb_(offb) {
+  explicit QgemmShortExecuteTest(bool use_offb, size_t M, size_t N, size_t K, size_t Batch, uint8_t offa, uint8_t offb)
+      : use_offb_(use_offb), M_(M), N_(N), K_(K), Batch_(Batch), offa_(offa), offb_(offb) {
   }
 
   void TestBody() override {
     if (use_offb_) {
-      MlasTestFixture<MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded>>::mlas_tester->Test(M_, N_, K_, offa_, offb_);
+      MlasTestFixture<MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded>>::mlas_tester->Test(M_, N_, K_, Batch_, offa_, offb_);
     } else {
-      MlasTestFixture<MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded>>::mlas_tester->Test(M_, N_, K_, offa_);
+      MlasTestFixture<MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded>>::mlas_tester->Test(M_, N_, K_, Batch_, offa_);
     }
   }
 
-  static size_t RegisterSingleTest(bool use_offb, size_t M, size_t N, size_t K, uint8_t offa, uint8_t offb) {
+  static size_t RegisterSingleTest(bool use_offb, size_t M, size_t N, size_t K, size_t Batch, uint8_t offa, uint8_t offb) {
     std::stringstream ss;
     ss << "M" << M << "xN" << N << "xK" << K << "/"
        << "offa" << (unsigned)offa << "/"
@@ -49,53 +49,65 @@ class QgemmShortExecuteTest<xint8_t, int32_t, Packed, Threaded> : public MlasTes
         // Important to use the fixture type as the return type here.
         [=]() -> MlasTestFixture<MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded>>* {
           return new QgemmShortExecuteTest<xint8_t, int32_t, Packed, Threaded>(
-              use_offb, M, N, K, offa, offb);
+              use_offb, M, N, K, Batch, offa, offb);
         });
 
     return 1;
   }
 
-  static size_t RegisterSingleTest(size_t M, size_t N, size_t K, uint8_t offa, uint8_t offb) {
-    return RegisterSingleTest(true, M, N, K, offa, offb);
+  static size_t RegisterSingleTest(size_t M, size_t N, size_t K, size_t Batch, uint8_t offa, uint8_t offb) {
+    return RegisterSingleTest(true, M, N, K, Batch, offa, offb);
   }
 
-  static size_t RegisterSingleTest(size_t M, size_t N, size_t K, uint8_t offa) {
-    return RegisterSingleTest(false, M, N, K, offa, 0);
+  static size_t RegisterSingleTest(size_t M, size_t N, size_t K, size_t Batch, uint8_t offa) {
+    return RegisterSingleTest(false, M, N, K, Batch, offa, 0);
   }
 
   static size_t RegisterShortExecuteTests() {
     size_t test_registered = 0;
     
     for (size_t b = 1; b < 16; b++) {
-      test_registered += RegisterSingleTest(b, b, b, 14, 211);
-      test_registered += RegisterSingleTest(b, b, b, 21);
+      test_registered += RegisterSingleTest(b, b, b, 1, 14, 211);
+      test_registered += RegisterSingleTest(b, b, b, 1, 21);
+      if (!Packed) {
+        test_registered += RegisterSingleTest(b, b, b, 3 + b / 4, 14, 211);
+        test_registered += RegisterSingleTest(b, b, b, 2 + b / 4, 21);
+      }
     }
     for (size_t b = 1; b < 16; b++) {
-      test_registered += RegisterSingleTest(b, b, b, 14, 211);
-      test_registered += RegisterSingleTest(b, b, b, 17);
+      test_registered += RegisterSingleTest(b, b, b, 1, 14, 211);
+      test_registered += RegisterSingleTest(b, b, b, 1, 17);
     }
     for (size_t b = 16; b <= 256; b <<= 1) {
-      test_registered += RegisterSingleTest(b, b, b, 34, 1);
-      test_registered += RegisterSingleTest(b, b, b, 1);
+      test_registered += RegisterSingleTest(b, b, b, 1, 34, 1);
+      test_registered += RegisterSingleTest(b, b, b, 1, 1);
     }
     for (size_t b = 256; b < 320; b += 32) {
-      test_registered += RegisterSingleTest(b, b, b, 85, 173);
+      test_registered += RegisterSingleTest(b, b, b, 1, 85, 173);
     }
     for (size_t b = 1; b < 96; b++) {
-      test_registered += RegisterSingleTest(1, b, 32, 0, 0);
-      test_registered += RegisterSingleTest(1, 32, b, 0, 0);
-      test_registered += RegisterSingleTest(1, b, b, 0, 0);
+      test_registered += RegisterSingleTest(1, b, 32, 1, 0, 0);
+      test_registered += RegisterSingleTest(1, 32, b, 1, 0, 0);
+      test_registered += RegisterSingleTest(1, b, b, 1, 0, 0);
+      if (!Packed) {
+        test_registered += RegisterSingleTest(1, b, 32, 3, 0, 0);
+        test_registered += RegisterSingleTest(1, 32, b, 5, 0, 0);      
+      }
     }
-    test_registered += RegisterSingleTest(43, 500, 401, 183, 223);
-    test_registered += RegisterSingleTest(1023, 1023, 1023, 5, 8);
-    test_registered += RegisterSingleTest(1023, 1023, 1023, 7);
+    test_registered += RegisterSingleTest(43, 500, 401, 1, 183, 223);
+    test_registered += RegisterSingleTest(1023, 1023, 1023, 1, 5, 8);
+    test_registered += RegisterSingleTest(1023, 1023, 1023, 1, 7);
+    if (!Packed) {
+      test_registered += RegisterSingleTest(43, 500, 401, 7, 183, 223);
+      test_registered += RegisterSingleTest(1023, 1023, 1023, 3, 5, 8);
+    }
 
     return test_registered;
   }
 
  private:
   bool use_offb_;
-  size_t M_, N_, K_;
+  size_t M_, N_, K_, Batch_;
   uint8_t offa_, offb_;
 };
 
@@ -107,7 +119,8 @@ class QgemmShortExecuteTest<xint8_t, float, Packed, Threaded> : public MlasTestF
   }
 
   void TestBody() override {
-    MlasTestFixture<MlasQgemmU8X8Test<xint8_t, float, Packed, Threaded>>::mlas_tester->Test(M_, N_, K_, offa_, offb_);
+    // Batching code is agnostic to result type. Only cover batches above, not here.
+    MlasTestFixture<MlasQgemmU8X8Test<xint8_t, float, Packed, Threaded>>::mlas_tester->Test(M_, N_, K_, 1, offa_, offb_);
   }
 
   static size_t RegisterSingleTest(size_t M, size_t N, size_t K, uint8_t offa, uint8_t offb) {

--- a/onnxruntime/test/mlas/unittest/test_qgemm_fixture.h
+++ b/onnxruntime/test/mlas/unittest/test_qgemm_fixture.h
@@ -29,7 +29,7 @@ class QgemmShortExecuteTest<xint8_t, int32_t, Packed, Threaded> : public MlasTes
 
   static size_t RegisterSingleTest(bool use_offb, size_t M, size_t N, size_t K, size_t Batch, uint8_t offa, uint8_t offb) {
     std::stringstream ss;
-    ss << "M" << M << "xN" << N << "xK" << K << "/"
+    ss << "Batch" << Batch << "M" << M << "xN" << N << "xK" << K << "/"
        << "offa" << (unsigned)offa << "/"
        << "offb";
     if (use_offb) {

--- a/onnxruntime/test/onnx/microbenchmark/quantize.cc
+++ b/onnxruntime/test/onnx/microbenchmark/quantize.cc
@@ -2,7 +2,15 @@
 
 #include <benchmark/benchmark.h>
 #include "core/util/qmath.h"
+#include "core/util/thread_utils.h"
 
+static void BenchSize(benchmark::internal::Benchmark* b) {
+  for (int size : {80000, 160000, 320000, 640000, 1280000}) {
+    for (int threads : {2, 4, 6, 8}) {
+      b->Args({size, threads});
+    }
+  }
+}
 
 // qmath.h GetQuantizationParameter
 struct quant_params {
@@ -10,18 +18,27 @@ struct quant_params {
   uint8_t zero;
 };
 
-static quant_params GetQuantParams(const float* data, const int64_t data_size) {
+static quant_params GetQuantParams(const float* data, const int64_t data_size, onnxruntime::concurrency::ThreadPool* tp) {
   quant_params params;
-  onnxruntime::GetQuantizationParameter<uint8_t>(data, data_size, params.scale, params.zero);
+  onnxruntime::GetQuantizationParameter<uint8_t>(data, data_size, params.scale, params.zero, tp);
   return params;
 }
 
 static void BM_GetQuantParams(benchmark::State& state) {
   const int64_t batch_size = state.range(0);
+  const int64_t threads = state.range(1);
+
   float* data = GenerateArrayWithRandomValue<float>(batch_size, -1, 1);
 
+  OrtThreadPoolParams tpo;
+  tpo.thread_pool_size = int(threads);
+  tpo.auto_set_affinity = true;
+  std::unique_ptr<onnxruntime::concurrency::ThreadPool> tp(
+      onnxruntime::concurrency::CreateThreadPool(&onnxruntime::Env::Default(),
+                                                 tpo, onnxruntime::concurrency::ThreadPoolType::INTRA_OP));
+
   for (auto _ : state) {
-    benchmark::DoNotOptimize(GetQuantParams(data, batch_size));
+    benchmark::DoNotOptimize(GetQuantParams(data, batch_size, tp.get()));
   }
   aligned_free(data);
 }
@@ -29,24 +46,27 @@ static void BM_GetQuantParams(benchmark::State& state) {
 BENCHMARK(BM_GetQuantParams)
     ->UseRealTime()
     ->Unit(benchmark::TimeUnit::kNanosecond)
-    ->Arg(40000)
-    ->Arg(80000)
-    ->Arg(98304)
-    ->Arg(160000)
-    ->Arg(320000)
-    ->Arg(640000)
-    ->Arg(1280000);
+    ->Apply(BenchSize);
 
 static void BM_Quantize(benchmark::State& state) {
   const int64_t batch_size = state.range(0);
+  const int64_t threads = state.range(1);
   float* a_data = GenerateArrayWithRandomValue<float>(batch_size, -1, 1);
   uint8_t* a_data_quant = static_cast<uint8_t*>(aligned_alloc(sizeof(uint8_t) * batch_size, 64));
+
+  OrtThreadPoolParams tpo;
+  tpo.thread_pool_size = int(threads);
+  tpo.auto_set_affinity = true;
+  std::unique_ptr<onnxruntime::concurrency::ThreadPool> tp(
+      onnxruntime::concurrency::CreateThreadPool(&onnxruntime::Env::Default(),
+                                                 tpo, onnxruntime::concurrency::ThreadPoolType::INTRA_OP));
+
   float scale = 1.23456f;
   uint8_t zero = 129;
 
   for (auto _ : state) {
     benchmark::DoNotOptimize(a_data_quant);
-    MlasQuantizeLinear(a_data, a_data_quant, batch_size, scale, zero);
+    onnxruntime::ParQuantizeLinear(a_data, a_data_quant, batch_size, scale, zero, tp.get());
     benchmark::ClobberMemory();
   }
   aligned_free(a_data_quant);
@@ -56,10 +76,4 @@ static void BM_Quantize(benchmark::State& state) {
 BENCHMARK(BM_Quantize)
     ->UseRealTime()
     ->Unit(benchmark::TimeUnit::kNanosecond)
-    ->Arg(40000)
-    ->Arg(80000)
-    ->Arg(98304)
-    ->Arg(160000)
-    ->Arg(320000)
-    ->Arg(640000)
-    ->Arg(1280000);
+    ->Apply(BenchSize);

--- a/onnxruntime/test/onnx/microbenchmark/quantize.cc
+++ b/onnxruntime/test/onnx/microbenchmark/quantize.cc
@@ -1,0 +1,65 @@
+#include "common.h"
+
+#include <benchmark/benchmark.h>
+#include "core/util/qmath.h"
+
+
+// qmath.h GetQuantizationParameter
+struct quant_params {
+  float scale;
+  uint8_t zero;
+};
+
+static quant_params GetQuantParams(const float* data, const int64_t data_size) {
+  quant_params params;
+  onnxruntime::GetQuantizationParameter<uint8_t>(data, data_size, params.scale, params.zero);
+  return params;
+}
+
+static void BM_GetQuantParams(benchmark::State& state) {
+  const int64_t batch_size = state.range(0);
+  float* data = GenerateArrayWithRandomValue<float>(batch_size, -1, 1);
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(GetQuantParams(data, batch_size));
+  }
+  aligned_free(data);
+}
+
+BENCHMARK(BM_GetQuantParams)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(40000)
+    ->Arg(80000)
+    ->Arg(98304)
+    ->Arg(160000)
+    ->Arg(320000)
+    ->Arg(640000)
+    ->Arg(1280000);
+
+static void BM_Quantize(benchmark::State& state) {
+  const int64_t batch_size = state.range(0);
+  float* a_data = GenerateArrayWithRandomValue<float>(batch_size, -1, 1);
+  uint8_t* a_data_quant = static_cast<uint8_t*>(aligned_alloc(sizeof(uint8_t) * batch_size, 64));
+  float scale = 1.23456f;
+  uint8_t zero = 129;
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(a_data_quant);
+    MlasQuantizeLinear(a_data, a_data_quant, batch_size, scale, zero);
+    benchmark::ClobberMemory();
+  }
+  aligned_free(a_data_quant);
+  aligned_free(a_data);
+}
+
+BENCHMARK(BM_Quantize)
+    ->UseRealTime()
+    ->Unit(benchmark::TimeUnit::kNanosecond)
+    ->Arg(40000)
+    ->Arg(80000)
+    ->Arg(98304)
+    ->Arg(160000)
+    ->Arg(320000)
+    ->Arg(640000)
+    ->Arg(1280000);

--- a/onnxruntime/test/onnx/microbenchmark/reduceminmax.cc
+++ b/onnxruntime/test/onnx/microbenchmark/reduceminmax.cc
@@ -3,6 +3,7 @@
 #include <benchmark/benchmark.h>
 #include "core/mlas/lib/mlasi.h"
 #include "core/util/math_cpuonly.h"
+#include "core/util/qmath.h"
 
 // vanilla implementation of FindMinMax
 static void BM_FindMinMaxPlainLoop(benchmark::State& state) {
@@ -114,3 +115,4 @@ BENCHMARK(BM_FindMinMaxMlasAvx)
     ->Arg(80000)
     ->Arg(98304)
     ->Arg(160000);
+


### PR DESCRIPTION
**Description**: Parallelize MinMax, Quantize and batched quantize GEMM

**Motivation and Context**
Performance problem identified in T5 decoder model (quantized).  DynamicMatMul operator is identified as the culprit. This operator spend time on getting MinMax of a Tensor, quantize a tensor, and perform a batched gemm. All of these can be parallelized.

Currently GEMM is parallelized. However, in batched GEMM, we sequentially call GEMM multiple times. This causes multiple starting and ending of parallel sections, which can be slow sometimes.  We made the following changes:

1. Parallel task partition no longer depends on degree of parallelism, only on shape of the matrices.
2. In a single GEMM, perform 2D partition of the multiplication, along panel lines, to reduce repeated packing.
3. For batched GEMM, all parallel tasks are executed in a single parallel section, reducing the cost of starting threads and waiting for them to finish.

 In GetQuantizeParameters function, MinMax was executed sequentially.  In this change, minmax was parallelized: (all time unit ns, benchmark parameters {array_size, threads}

Baseline | --       | New Implementation | --
--------- | -------: | ------ | --------------:
BM_GetQuantParams/80000/real_time | 6,525 | -- | --
-- | -- | BM_GetQuantParams/80000/2/real_time | 6,696
-- | -- | BM_GetQuantParams/80000/4/real_time | 6,727
-- | -- | BM_GetQuantParams/80000/6/real_time | 6,753
-- | -- | BM_GetQuantParams/80000/8/real_time | 6,716
BM_GetQuantParams/160000/real_time | 13,033 | -- | --
-- | -- | BM_GetQuantParams/160000/2/real_time | 8,281
-- | -- | BM_GetQuantParams/160000/4/real_time | 6,146
-- | -- | BM_GetQuantParams/160000/6/real_time | 6,073
-- | -- | BM_GetQuantParams/160000/8/real_time | 8,457
BM_GetQuantParams/320000/real_time | 34,508 | -- | --
-- | -- | BM_GetQuantParams/320000/2/real_time | 14,693
-- | -- | BM_GetQuantParams/320000/4/real_time | 9,863
-- | -- | BM_GetQuantParams/320000/6/real_time | 9,648
-- | -- | BM_GetQuantParams/320000/8/real_time | 9,439
BM_GetQuantParams/640000/real_time | 97,008 | -- | --
-- | -- | BM_GetQuantParams/640000/2/real_time | 37,335
-- | -- | BM_GetQuantParams/640000/4/real_time | 16,848
-- | -- | BM_GetQuantParams/640000/6/real_time | 14,924
-- | -- | BM_GetQuantParams/640000/8/real_time | 13,268
BM_GetQuantParams/1280000/real_time | 193,904 | -- | --
-- | -- | BM_GetQuantParams/1280000/2/real_time | 99,008
-- | -- | BM_GetQuantParams/1280000/4/real_time | 43,086
-- | -- | BM_GetQuantParams/1280000/6/real_time | 31,400
-- | -- | BM_GetQuantParams/1280000/8/real_time | 23,842



Parallelization of Quantization function:  (all time unit ns, benchmark parameters {size, threads})


Baseline | ns | New Implementation | ns
-- | --: | -- | --:
BM_Quantize/80000/real_time | 14,982 | BM_Quantize/80000/2/real_time | 9,244
  |   | BM_Quantize/80000/4/real_time | 9,642
  |   | BM_Quantize/80000/6/real_time | 7,043
  |   | BM_Quantize/80000/8/real_time | 7,677
BM_Quantize/160000/real_time | 29,869 | BM_Quantize/160000/2/real_time | 16,680
  |   | BM_Quantize/160000/4/real_time | 10,958
  |   | BM_Quantize/160000/6/real_time | 10,217
  |   | BM_Quantize/160000/8/real_time | 10,917
BM_Quantize/320000/real_time | 63,170 | BM_Quantize/320000/2/real_time | 31,690
  |   | BM_Quantize/320000/4/real_time | 18,806
  |   | BM_Quantize/320000/6/real_time | 15,859
  |   | BM_Quantize/320000/8/real_time | 14,871
BM_Quantize/640000/real_time | 126,762 | BM_Quantize/640000/2/real_time | 64,959
  |   | BM_Quantize/640000/4/real_time | 34,477
  |   | BM_Quantize/640000/6/real_time | 26,650
  |   | BM_Quantize/640000/8/real_time | 22,863
BM_Quantize/1280000/real_time | 256,442 | BM_Quantize/1280000/2/real_time | 132,517
  |   | BM_Quantize/1280000/4/real_time | 70,511
  |   | BM_Quantize/1280000/6/real_time | 50,509
  |   | BM_Quantize/1280000/8/real_time | 38,917



Batched QGemm. Existing implementation: multiple multiplication operations are executed sequentially, while each matric multiplication maybe parallelized. In the new implementation, we tried to parallelize the whole batch. Benchmark shows speedup of batched gemm, especially when B is not pre-packed, and when number of threads is high.


  | Baseline | New
-- | --: | --:
QGEMM/PackB/M:512/N:64/K:512/Batch:12/Threads:4 | 266821 | 223233
QGEMM/PackB/M:512/N:512/K:64/Batch:12/Threads:4 | 352279 | 333067
QGEMM/PackB/M:128/N:768/K:2304/Batch:1/Threads:4 | 255532 | 250407
QGEMM/PackB/M:128/N:768/K:2304/Batch:6/Threads:4 | 1717200 | 1763590
QGEMM/PackB/M:128/N:1024/K:4096/Batch:1/Threads:4 | 682238 | 630677
QGEMM/PackB/M:128/N:1024/K:4096/Batch:6/Threads:4 | 4184540 | 4355130
QGEMM/PackB/M:512/N:64/K:512/Batch:12/Threads:8 | 189041 | 169766
QGEMM/PackB/M:512/N:512/K:64/Batch:12/Threads:8 | 239872 | 231030
QGEMM/PackB/M:128/N:768/K:2304/Batch:1/Threads:8 | 195874 | 196617
QGEMM/PackB/M:128/N:768/K:2304/Batch:6/Threads:8 | 1184220 | 998407
QGEMM/PackB/M:128/N:1024/K:4096/Batch:1/Threads:8 | 307591 | 310912
QGEMM/PackB/M:128/N:1024/K:4096/Batch:6/Threads:8 | 2873200 | 2397180
QGEMM/PackB/M:512/N:64/K:512/Batch:12/Threads:16 | 205724 | 113060
QGEMM/PackB/M:512/N:512/K:64/Batch:12/Threads:16 | 228505 | 173621
QGEMM/PackB/M:128/N:768/K:2304/Batch:1/Threads:16 | 98155 | 96369.3
QGEMM/PackB/M:128/N:768/K:2304/Batch:6/Threads:16 | 875479 | 730881
QGEMM/PackB/M:128/N:1024/K:4096/Batch:1/Threads:16 | 223546 | 219434
QGEMM/PackB/M:128/N:1024/K:4096/Batch:6/Threads:16 | 2046790 | 1687330
-- | --: | --:
QGEMM/NoPackB/M:512/N:64/K:512/Batch:12/Threads:4 | 297499 | 246691
QGEMM/NoPackB/M:512/N:512/K:64/Batch:12/Threads:4 | 371799 | 329250
QGEMM/NoPackB/M:128/N:768/K:2304/Batch:1/Threads:4 | 416085 | 430584
QGEMM/NoPackB/M:128/N:768/K:2304/Batch:6/Threads:4 | 3214770 | 2056690
QGEMM/NoPackB/M:128/N:1024/K:4096/Batch:1/Threads:4 | 962293 | 959191
QGEMM/NoPackB/M:128/N:1024/K:4096/Batch:6/Threads:4 | 7631920 | 4983940
QGEMM/NoPackB/M:512/N:64/K:512/Batch:12/Threads:8 | 240266 | 184689
QGEMM/NoPackB/M:512/N:512/K:64/Batch:12/Threads:8 | 279545 | 237145
QGEMM/NoPackB/M:128/N:768/K:2304/Batch:1/Threads:8 | 188994 | 186943
QGEMM/NoPackB/M:128/N:768/K:2304/Batch:6/Threads:8 | 2341790 | 1155460
QGEMM/NoPackB/M:128/N:1024/K:4096/Batch:1/Threads:8 | 435023 | 422203
QGEMM/NoPackB/M:128/N:1024/K:4096/Batch:6/Threads:8 | 6108640 | 2771390
QGEMM/NoPackB/M:512/N:64/K:512/Batch:12/Threads:16 | 253414 | 122915
QGEMM/NoPackB/M:512/N:512/K:64/Batch:12/Threads:16 | 279043 | 182560
QGEMM/NoPackB/M:128/N:768/K:2304/Batch:1/Threads:16 | 126859 | 120570
QGEMM/NoPackB/M:128/N:768/K:2304/Batch:6/Threads:16 | 1895960 | 1074540
QGEMM/NoPackB/M:128/N:1024/K:4096/Batch:1/Threads:16 | 313716 | 299089
QGEMM/NoPackB/M:128/N:1024/K:4096/Batch:6/Threads:16 | 4511390 | 2323350

