### PR TITLE
Fix initializer counts when used as graph output

### DIFF
--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -928,6 +928,12 @@ static void ComputeConstantInitializerUseCount(const Graph& graph, std::unordere
       }
     }
   }
+  // Initializers can be used as graph outputs
+  for (const auto* arg : graph.GetOutputs()) {
+    if (arg->Exists() && graph.GetConstantInitializer(arg->Name(), true /*check_outer_scope*/)) {
+      constant_initializers_use_count[arg->Name()]++;
+    }
+  }
 }
 
 Status SessionState::FinalizeSessionState(const std::basic_string<PATH_CHAR_TYPE>& graph_location,


### PR DESCRIPTION
Signed-off-by: Tom Wildenhain <tomwi@microsoft.com>

**Description**: Change the usage count of initializers to include the graph outputs.

**Motivation and Context**
When an initializer is used as a graph output (and nowhere else) it might be removed if the count is 0.  The count should include the times the initializer appears as an output.