### PR TITLE
Remove ROCM workaround for half-to-double cast.

### DIFF
--- a/onnxruntime/core/providers/rocm/cu_inc/common.cuh
+++ b/onnxruntime/core/providers/rocm/cu_inc/common.cuh
@@ -144,18 +144,10 @@ __device__ __inline__ half2 _Tanh(half2 a) {
   return __float22half2_rn(tmp);
 }
 
-// TODO: temporary workaround for casting half-to-double, until ROCM/hipcc adds support.
-namespace {
-template <typename T>
-__device__ __inline__ double __cast_to_double(T x) { return static_cast<double>(x); }
-template <>
-__device__ __inline__ double __cast_to_double(half x) { return static_cast<double>(static_cast<float>(x)); }
-}  // namespace
-
 // Capture permutations of int32/64/float/double
 template <typename T, typename T1>
 __device__ __inline__ T _Pow(T a, T1 b) {
-  return static_cast<T>(pow(__cast_to_double(a), __cast_to_double(b)));
+  return static_cast<T>(pow(static_cast<double>(a), static_cast<double>(b)));
 }
 
 template <>


### PR DESCRIPTION
**Description**:
The following code caused a compiler error with `hipcc` in ROCM 4.0 and earlier:

```
half x = 0;
double y = static_cast<double>(x);
```

In ROCM 4.1, `hipcc` now supports this cast.  Remove ROCM compiler workaround in onnxruntime code.