### PR TITLE
Add ability to allocate initialized tensor memory from non-arena memory

### DIFF
--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -63,9 +63,11 @@ class Tensor final {
   /**
    * Create tensor with given type, shape, pre-allocated memory and allocator info.
    * This function won't check if the preallocated buffer(p_data) has enough room for the shape.
-   * \param data A preallocated buffer. Can be NULL if the shape is empty.
+   * \param p_type Data type of the tensor
+   * \param shape Shape of the tensor
+   * \param p_data A preallocated buffer. Can be NULL if the shape is empty.
    *              Tensor does not own the data and will not delete it
-   * \param alloc Where the buffer('data') was allocated from
+   * \param alloc Where the buffer('p_data') was allocated from
    * \param offset Offset in bytes to start of Tensor within p_data. 
    */
   Tensor(MLDataType p_type, const TensorShape& shape, void* p_data, const OrtMemoryInfo& alloc,
@@ -76,6 +78,20 @@ class Tensor final {
    * However, this function will allocate the buffer for the shape, and do placement new if p_type is string tensor.
    */
   Tensor(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAllocator> allocator);
+
+  /**
+   * Create tensor with given type, shape, pre-allocated memory and allocator which will be used to free the pre-allocated memory.
+   * This function won't check if the preallocated buffer(p_data) has enough room for the shape.
+   * However, this function will de-allocate the buffer upon the tensor getting destructed.
+   * \param p_type Data type of the tensor
+   * \param shape Shape of the tensor
+   * \param p_data A preallocated buffer. Can be NULL if the shape is empty.
+   *              Tensor does not own the data and will not delete it
+   * \param allocator Allocator used to free the pre-allocated memory
+   * \param offset Offset in bytes to start of Tensor within p_data. 
+   */
+  Tensor(MLDataType p_type, const TensorShape& shape, void* p_data, std::shared_ptr<IAllocator> allocator,
+         ptrdiff_t offset = 0);
 
   ~Tensor();
 

--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -87,10 +87,10 @@ class Tensor final {
    * \param shape Shape of the tensor
    * \param p_data A preallocated buffer. Can be NULL if the shape is empty.
    *              Tensor does not own the data and will not delete it
-   * \param allocator Allocator used to free the pre-allocated memory
+   * \param deleter Allocator used to free the pre-allocated memory
    * \param offset Offset in bytes to start of Tensor within p_data. 
    */
-  Tensor(MLDataType p_type, const TensorShape& shape, void* p_data, std::shared_ptr<IAllocator> allocator,
+  Tensor(MLDataType p_type, const TensorShape& shape, void* p_data, std::shared_ptr<IAllocator> deleter,
          ptrdiff_t offset = 0);
 
   ~Tensor();

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -52,6 +52,8 @@ static const char* const kOrtSessionOptionsEnableQuantQDQ = "session.enable_quan
 static const char* const kOrtSessionOptionsEnableGeluApproximation = "optimization.enable_gelu_approximation";
 
 // Enable or disable using device allocator for allocating initialized tensor memory. "1": enable; "0": disable. The default is "0".
+// Using device allocators means the memory allocation is made "directly" using the appropriate system call
+// (by-passing any arena if any).
 static const char* const kOrtSessionOptionsUseDeviceAllocatorForInitializers = "session.use_device_allocator_for_initializers";
 
 // Configure whether to allow the inter_op/intra_op threads spinning a number of times before blocking

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -52,7 +52,7 @@ static const char* const kOrtSessionOptionsEnableQuantQDQ = "session.enable_quan
 static const char* const kOrtSessionOptionsEnableGeluApproximation = "optimization.enable_gelu_approximation";
 
 // Enable or disable using arena for allocating initialized tensor memory. "1": disable; "0": enable. The default is "0".
-static const char* const kOrtSessionOptionsDisableArenaForInitializedTensorMemory = "optimization.disable_arena_for_initialized_tensor_memory";
+static const char* const kOrtSessionOptionsUseDeviceAllocatorForInitializers = "session.use_device_allocator_for_initializers";
 
 // Configure whether to allow the inter_op/intra_op threads spinning a number of times before blocking
 // "0": thread will block if found no job to run

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -52,8 +52,7 @@ static const char* const kOrtSessionOptionsEnableQuantQDQ = "session.enable_quan
 static const char* const kOrtSessionOptionsEnableGeluApproximation = "optimization.enable_gelu_approximation";
 
 // Enable or disable using device allocator for allocating initialized tensor memory. "1": enable; "0": disable. The default is "0".
-// Using device allocators means the memory allocation is made "directly" using the appropriate system call
-// (by-passing any arena if any).
+// Using device allocators means the memory allocation is made using malloc/new.
 static const char* const kOrtSessionOptionsUseDeviceAllocatorForInitializers = "session.use_device_allocator_for_initializers";
 
 // Configure whether to allow the inter_op/intra_op threads spinning a number of times before blocking

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -51,7 +51,7 @@ static const char* const kOrtSessionOptionsEnableQuantQDQ = "session.enable_quan
 // GeluApproximation has side effects which may change the inference results. It is disabled by default due to this.
 static const char* const kOrtSessionOptionsEnableGeluApproximation = "optimization.enable_gelu_approximation";
 
-// Enable or disable using arena for allocating initialized tensor memory. "1": disable; "0": enable. The default is "0".
+// Enable or disable using device allocator for allocating initialized tensor memory. "1": enable; "0": disable. The default is "0".
 static const char* const kOrtSessionOptionsUseDeviceAllocatorForInitializers = "session.use_device_allocator_for_initializers";
 
 // Configure whether to allow the inter_op/intra_op threads spinning a number of times before blocking

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -51,6 +51,9 @@ static const char* const kOrtSessionOptionsEnableQuantQDQ = "session.enable_quan
 // GeluApproximation has side effects which may change the inference results. It is disabled by default due to this.
 static const char* const kOrtSessionOptionsEnableGeluApproximation = "optimization.enable_gelu_approximation";
 
+// Enable or disable using arena for allocating initialized tensor memory. "1": disable; "0": enable. The default is "0".
+static const char* const kOrtSessionOptionsDisableArenaForInitializedTensorMemory = "optimization.disable_arena_for_initialized_tensor_memory";
+
 // Configure whether to allow the inter_op/intra_op threads spinning a number of times before blocking
 // "0": thread will block if found no job to run
 // "1": default, thread will spin a number of times before blocking

--- a/onnxruntime/core/framework/arena.h
+++ b/onnxruntime/core/framework/arena.h
@@ -34,7 +34,7 @@ using ArenaPtr = std::shared_ptr<IArenaAllocator>;
 
 // Runtime statistics collected by an allocator.
 struct AllocatorStats {
-  int64_t num_allocs;             // Number of allocations. (Number of calls to Alloc())
+  int64_t num_allocs;             // Number of allocations.
   int64_t num_reserves;           // Number of reserves. (Number of calls to Reserve() in arena-based allocators)
   int64_t bytes_in_use;           // Number of bytes in use.
   int64_t total_allocated_bytes;  // The total number of allocated bytes by the allocator.

--- a/onnxruntime/core/framework/arena.h
+++ b/onnxruntime/core/framework/arena.h
@@ -34,7 +34,8 @@ using ArenaPtr = std::shared_ptr<IArenaAllocator>;
 
 // Runtime statistics collected by an allocator.
 struct AllocatorStats {
-  int64_t num_allocs;             // Number of allocations.
+  int64_t num_allocs;             // Number of allocations. (Number of calls to Alloc())
+  int64_t num_reserves;           // Number of reserves. (Number of calls to Reserve() in arena-based allocators)
   int64_t bytes_in_use;           // Number of bytes in use.
   int64_t total_allocated_bytes;  // The total number of allocated bytes by the allocator.
   int64_t max_bytes_in_use;       // The maximum bytes in use.
@@ -48,6 +49,7 @@ struct AllocatorStats {
 
   void Clear() {
     this->num_allocs = 0;
+    this->num_reserves = 0;
     this->bytes_in_use = 0;
     this->max_bytes_in_use = 0;
     this->max_alloc_size = 0;
@@ -62,6 +64,7 @@ struct AllocatorStats {
        << "TotalAllocated: " << this->total_allocated_bytes << "\n"
        << "MaxInUse:       " << this->max_bytes_in_use << "\n"
        << "NumAllocs:      " << this->num_allocs << "\n"
+       << "NumReserves:    " << this->num_reserves << "\n"
        << "MaxAllocSize:   " << this->max_alloc_size << "\n";
     return ss.str();
   }

--- a/onnxruntime/core/framework/bfc_arena.cc
+++ b/onnxruntime/core/framework/bfc_arena.cc
@@ -238,6 +238,7 @@ void* BFCArena::Reserve(size_t size) {
   reserved_chunks_.insert(std::pair<void*, size_t>(ptr, size));
   stats_.bytes_in_use += size;
   stats_.num_reserves += 1;
+  stats_.num_allocs += 1;
   stats_.max_alloc_size = std::max<size_t>(static_cast<size_t>(stats_.max_alloc_size), size);
   stats_.max_bytes_in_use = std::max<int64_t>(static_cast<int64_t>(stats_.max_bytes_in_use), stats_.bytes_in_use);
   stats_.total_allocated_bytes += size;

--- a/onnxruntime/core/framework/bfc_arena.cc
+++ b/onnxruntime/core/framework/bfc_arena.cc
@@ -237,7 +237,7 @@ void* BFCArena::Reserve(size_t size) {
   ORT_ENFORCE(reserved_chunks_.find(ptr) == reserved_chunks_.end());
   reserved_chunks_.insert(std::pair<void*, size_t>(ptr, size));
   stats_.bytes_in_use += size;
-  stats_.num_allocs += 1;
+  stats_.num_reserves += 1;
   stats_.max_alloc_size = std::max<size_t>(static_cast<size_t>(stats_.max_alloc_size), size);
   stats_.max_bytes_in_use = std::max<int64_t>(static_cast<int64_t>(stats_.max_bytes_in_use), stats_.bytes_in_use);
   stats_.total_allocated_bytes += size;

--- a/onnxruntime/core/framework/bfc_arena.cc
+++ b/onnxruntime/core/framework/bfc_arena.cc
@@ -231,7 +231,7 @@ void* BFCArena::Reserve(size_t size) {
 
   std::lock_guard<OrtMutex> lock(lock_);
 
-  LOGS_DEFAULT(WARNING) << "Reserving memory in BFCArena for " << device_allocator_->Info().name << " size: " << size;
+  LOGS_DEFAULT(INFO) << "Reserving memory in BFCArena for " << device_allocator_->Info().name << " size: " << size;
 
   void* ptr = device_allocator_->Alloc(size);
   ORT_ENFORCE(reserved_chunks_.find(ptr) == reserved_chunks_.end());

--- a/onnxruntime/core/framework/bfc_arena.cc
+++ b/onnxruntime/core/framework/bfc_arena.cc
@@ -230,6 +230,9 @@ void* BFCArena::Reserve(size_t size) {
     return nullptr;
 
   std::lock_guard<OrtMutex> lock(lock_);
+
+  LOGS_DEFAULT(WARNING) << "Reserving memory in BFCArena for " << device_allocator_->Info().name << " size: " << size;
+
   void* ptr = device_allocator_->Alloc(size);
   ORT_ENFORCE(reserved_chunks_.find(ptr) == reserved_chunks_.end());
   reserved_chunks_.insert(std::pair<void*, size_t>(ptr, size));

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -39,13 +39,13 @@ static common::Status ReserveUsingArenaFromShapeAndType(const TensorShape& tenso
 
   int64_t shape_size = tensor_shape.Size();
   if (shape_size < 0)
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "shape.Size() must >=0");
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "shape.Size() must >=0");
 
   p_data = nullptr;
   if (shape_size > 0) {
     SafeInt<size_t> mem_size = 0;
     if (!arena_alloc->CalcMemSizeForArray(SafeInt<size_t>(shape_size), type->Size(), &mem_size))
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Failed memory size calculation");
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed memory size calculation");
 
     p_data = static_cast<IArenaAllocator*>(arena_alloc.get())->Reserve(mem_size);
   }

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -71,7 +71,7 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
                              p_tensor->SizeInBytes(), ", Got ", m->GetLen());
     }
   } else {
-    if (alloc->Info().alloc_type == OrtArenaAllocator && disable_arena_for_initialized_tensor_memory_allocation) {
+    if (disable_arena_for_initialized_tensor_memory_allocation && alloc->Info().alloc_type == OrtArenaAllocator) {
       // Arena has a specific way to store static memory (interface Reserve()) - The arena does not reuse static memory allocated by Reserve.
       p_tensor = onnxruntime::make_unique<Tensor>(type, tensor_shape, ReserveUsingArenaFromShapeAndType(tensor_shape, type, alloc), alloc);
     } else {
@@ -92,7 +92,7 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
 
     // deserialize to CPU first for non-CPU allocator, then copy
     std::unique_ptr<Tensor> p_deserialize_tensor;
-    if (alloc->Info().alloc_type == OrtArenaAllocator && disable_arena_for_initialized_tensor_memory_allocation) {
+    if (disable_arena_for_initialized_tensor_memory_allocation && default_cpu_alloc->Info().alloc_type == OrtArenaAllocator) {
       // Arena has a specific way to store static memory (interface Reserve()) - The arena does not reuse static memory allocated by Reserve.
       p_deserialize_tensor = onnxruntime::make_unique<Tensor>(type, tensor_shape,
                                                               ReserveUsingArenaFromShapeAndType(tensor_shape, type, default_cpu_alloc), default_cpu_alloc);

--- a/onnxruntime/core/framework/tensor.cc
+++ b/onnxruntime/core/framework/tensor.cc
@@ -36,6 +36,13 @@ Tensor::Tensor(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAll
   Init(p_type, shape, p_data, allocator);
 }
 
+Tensor::Tensor(MLDataType p_type, const TensorShape& shape, void* p_data, std::shared_ptr<IAllocator> deleter,
+               ptrdiff_t offset)
+    : alloc_info_(deleter->Info()) {
+  ORT_ENFORCE(p_type != nullptr);
+  Init(p_type, shape, p_data, deleter, offset);
+}
+
 size_t Tensor::SizeInBytes() const {
   size_t ret;
   if (!IAllocator::CalcMemSizeForArray(SafeInt<size_t>(shape_.Size()), dtype_->Size(), &ret)) {

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -175,6 +175,9 @@ TEST_P(SessionStateTestP, TestInitializerProcessing) {
 
 // Test that we allocate memory for an initializer from non-arena memory even if we provide an arena-based allocator
 // if the relevant session option config flag is set
+// For this test we need to enable the arena-based allocator which is not supported on x86 builds, so
+// enable this test only on x64 builds
+#if (defined(__amd64__) || defined(_M_AMD64) || defined(__aarch64__) || defined(_M_ARM64))
 TEST(SessionStateTest, TestInitializerMemoryAllocatedUsingNonArenaMemory) {
   std::basic_ostringstream<ORTCHAR_T> oss;
   oss << ORT_TSTR("testdata/mul_1.onnx");
@@ -223,6 +226,8 @@ TEST(SessionStateTest, TestInitializerMemoryAllocatedUsingNonArenaMemory) {
   ASSERT_EQ(alloc_stats.num_allocs, 0);    // no calls to Alloc()
   ASSERT_EQ(alloc_stats.num_reserves, 1);  // one call to Reserve() for the sole initializer in the model
 }
+
+#endif
 
 INSTANTIATE_TEST_SUITE_P(SessionStateTests, SessionStateTestP, testing::ValuesIn(param_list));
 

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1444,7 +1444,7 @@ TEST(CApiTest, allocate_initializers_from_non_arena_memory) {
 #endif
 
   // disable using arena for the sole initializer in the model
-  session_options.AddConfigEntry(kOrtSessionOptionsDisableArenaForInitializedTensorMemory, "1");
+  session_options.AddConfigEntry(kOrtSessionOptionsUseDeviceAllocatorForInitializers, "1");
 
   // This is mostly an usage example - if the logging level for the default logger is made INFO (by default it is at WARNING)
   // when the Ort::Env instance is instantiated, logs pertaining to initializer memory being allocated from non-arena memory

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1446,5 +1446,8 @@ TEST(CApiTest, allocate_initializers_from_non_arena_memory) {
   // disable using arena for the sole initializer in the model
   session_options.AddConfigEntry(kOrtSessionOptionsDisableArenaForInitializedTensorMemory, "1");
 
+  // This is mostly an usage example - if the logging level for the default logger is made INFO (by default it is at WARNING)
+  // when the Ort::Env instance is instantiated, logs pertaining to initializer memory being allocated from non-arena memory
+  // can be confirmed by seeing logs like "Reserving memory in BFCArena...".
   Ort::Session session(*ort_env, MODEL_URI, session_options);
 }

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1432,3 +1432,19 @@ TEST(CApiTest, TestIncorrectInputTypeToModel_SequenceTensors) {
   ASSERT_TRUE(exception_thrown);
 }
 #endif
+
+TEST(CApiTest, allocate_initializers_from_non_arena_memory) {
+  Ort::SessionOptions session_options;
+
+#ifdef USE_CUDA
+  Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_CUDA(session_options, 0));
+#else
+  // arena is enabled but the sole initializer will still be allocated from non-arena memory
+  Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_CPU(session_options, 1));
+#endif
+
+  // disable using arena for the sole initializer in the model
+  session_options.AddConfigEntry(kOrtSessionOptionsDisableArenaForInitializedTensorMemory, "1");
+
+  Ort::Session session(*ort_env, MODEL_URI, session_options);
+}


### PR DESCRIPTION
**Description**: This is part-1 (of 2 changes) requested by an internal team to keep the growth of the CUDA memory arena in check. Currently, we do not expose all the arena configuration parameters to configure the CUDA memory arena and for some models with default arena configuration, the arena could have grown quite a bit when it is done with initialized tensor memory allocation and since the arena never shrinks, the growth is permanent and this "extra memory" being held may or may not be used while allocating memory required to process a Run() request. The initial idea was to provide the user configuration knobs to the arena (second part of the change) so that they are able to select a "reasonable" initial chunk to accommodate initializers + memory required to service almost all Run requests and we can avoid arena growth altogether by tuning these knobs. But the initial chunk is shared by all the per-thread CUDA allocators and the other allocators which do not allocate initialized tensor memory need not hold such a large initial chunk forever in its life-cycle. So, the idea is to allow users to by-pass the arena when allocating initialized tensor memory and set a large enough chunk for the arena that is needed just to process each Run request (this value is common to all per-thread allocators) so that they can avoid arena growth altogether. 

**Motivation and Context**
Used a branch that holds 2 sets of changes that was tried by the internal team and they are happy with the logic in that branch. Splitting the changes in that branch into 2 PRs so that it is easy to review.
