### PR TITLE
Restrict ConvGrad to __CUDA_ARCH__>=700

### DIFF
--- a/orttraining/orttraining/test/gradient/gradient_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/gradient_ops_test.cc
@@ -17,6 +17,7 @@
 #include "orttraining/test/gradient/gradient_checker.h"
 #include "orttraining/test/gradient/gradient_op_test_utils.h"
 #include "test/util/include/default_providers.h"
+#include "test/common/cuda_op_test_utils.h"
 
 #include "onnx/defs/attr_proto_util.h"
 
@@ -1044,7 +1045,7 @@ TEST(GradientCheckerTest, ConvGrad) {
   execution_providers.push_back(DefaultCpuExecutionProvider());
 
   if (HasCudaEnvironment(700)) {
-    execution_providers.push_back(DefaultCUDAExecutionProvider());
+    execution_providers.push_back(DefaultCudaExecutionProvider());
   }
 
 #ifdef USE_DNNL

--- a/orttraining/orttraining/test/gradient/gradient_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/gradient_ops_test.cc
@@ -1040,13 +1040,18 @@ void ConvGradientCheckerTest(std::vector<std::unique_ptr<IExecutionProvider>>* e
 }
 
 TEST(GradientCheckerTest, ConvGrad) {
-  ConvGradientCheckerTest(nullptr);
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+
+  if (HasCudaEnvironment(700)) {
+    execution_providers.push_back(DefaultCUDAExecutionProvider());
+  }
 
 #ifdef USE_DNNL
-  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(DefaultDnnlExecutionProvider());
-  ConvGradientCheckerTest(&execution_providers);
 #endif
+
+  ConvGradientCheckerTest(&execution_providers);
 }
 
 static void TestConcatOpGrad(const std::string& op_type,

--- a/orttraining/orttraining/training_ops/cuda/nn/conv_grad.h
+++ b/orttraining/orttraining/training_ops/cuda/nn/conv_grad.h
@@ -29,6 +29,9 @@ class ConvGrad final : public CudaKernel {
   using CudaT = typename ToCudaType<T>::MappedType;
 
   ConvGrad(const OpKernelInfo& info) : CudaKernel(info), conv_attrs_(info) {
+#if (defined(CUDA_VERSION) && (CUDA_VERSION < 10000) || (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)))
+    ORT_THROW("ConvGrad CUDA kernel is not yet tested on __CUDA_ARCH__ lower than 700");
+#endif
     auto pads_size = conv_attrs_.pads.size();
     ORT_ENFORCE(pads_size % 2 == 0);
   }


### PR DESCRIPTION
ConvGrad is not yet tested on non-V100 device. 