### PR TITLE
NCHWc: avoid buffer reordering around Add nodes

### DIFF
--- a/onnxruntime/core/optimizer/nchwc_transformer.cc
+++ b/onnxruntime/core/optimizer/nchwc_transformer.cc
@@ -675,7 +675,8 @@ void NchwcTransformerImpl::TransformBinary(Node& node, bool add_node) {
     // using this code, however the common case here is multiplying a NxCxHxW
     // matrix by a NxCx1x1 vector. The implementation of Mul does not currently
     // vectorize well for the case of broadcasting a NCHWc sized channel block.
-    // This case is better served by a
+    // This case should be handled by a ScaleShift kernel that can broadcast a
+    // multiply/add vector (BatchNormalization can also be reimplemented with this).
     for (size_t n = 0; n < input_defs_count; n++) {
       std::string reshape_input_def_name = graph_.GenerateNodeArgName("reshape");
       auto* reshape_input_arg = &graph_.GetOrCreateNodeArg(reshape_input_def_name, nullptr);


### PR DESCRIPTION
**Description**: The NCHWc optimizer currently uses various source of shape data to recognize if the tensors from Add(A,B) have the identical shape. If they do, then the Add can use the NCHWc data from A and B directly. There are cases when the input shape is dynamic that the optimizer cannot verify at model load time that the shapes are identical: for example, a segment using Conv with strides[2,2] and then doing 2x upsampling. With this combination, if the input shape is too small, then the height/width can stick to 1 and should then be a broadcast.

To make Add work without needing expensive reorders, the optimizer now inserts Reshape nodes around the Add so that Add sees the true [N][C][H][W][c] tensor shape. The optimizer still requires that both inputs to the Add are NCHWc and the channel count must match but N/H/W can be flexible.

Now this particular optimization could support Mul as well. This comes up in models such as SENets where a matrix is transformed to a vector that is then multiplied with the original matrix. Doing this optimization now results in a performance loss because Mul is unable to broadcast the [c] vector compared to the reordered NCHW output where it could hit the scalar broadcast path for a given channel. This particular pattern could be handled better with a dedicated nchwc.Scale op to do the matrix/vector multiplication. Not needed yet.