### PR TITLE
[java] Fix codeql warning

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
@@ -99,7 +99,7 @@ final class OnnxRuntime {
       providers = initialiseProviders(ortApiHandle);
       loaded = true;
     } finally {
-      if (!isAndroid()) {
+      if (tempDirectory != null) {
         cleanUp(tempDirectory.toFile());
       }
     }

--- a/java/src/main/java/ai/onnxruntime/OnnxTensor.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxTensor.java
@@ -19,7 +19,6 @@ import java.nio.ShortBuffer;
  * returned as outputs.
  */
 public class OnnxTensor implements OnnxValue {
-
   static {
     try {
       OnnxRuntime.init();
@@ -558,7 +557,6 @@ public class OnnxTensor implements OnnxValue {
       OrtEnvironment env, OrtAllocator allocator, ByteBuffer data, long[] shape, OnnxJavaType type)
       throws OrtException {
     if ((!env.isClosed()) && (!allocator.isClosed())) {
-      int bufferSize = data.capacity();
       return createTensor(type, allocator, data, shape);
     } else {
       throw new IllegalStateException("Trying to create an OnnxTensor on a closed OrtAllocator.");


### PR DESCRIPTION
**Description**: [java] Fix codeql warning

**Motivation and Context**
- Scan using codeql on ort java api, base on the requirements of Microsoft 1CS for shipping Android java package
- Here are the 1 warning and 1 recommendation
```
"Unread local variable","A local variable that is never read is redundant.","recommendation","Variable 'int bufferSize' is never read.","/java/src/main/java/ai/onnxruntime/OnnxTensor.java","561","7","561","39"
"Dereferenced variable may be null","Dereferencing a variable whose value may be 'null' may cause a 'NullPointerException'.","warning","Variable [[""tempDirectory""|""relative:///java/src/main/java/ai/onnxruntime/OnnxRuntime.java:94:5:94:92""]] may be null here because of [[""this""|""relative:///java/src/main/java/ai/onnxruntime/OnnxRuntime.java:94:10:94:91""]] assignment.","/java/src/main/java/ai/onnxruntime/OnnxRuntime.java","103","17","103","29"
```
- Fix the warning and the recommandation
