### PR TITLE
Narrow profiling scope

### DIFF
--- a/onnxruntime/core/common/profiler.cc
+++ b/onnxruntime/core/common/profiler.cc
@@ -224,11 +224,12 @@ void Profiler::EndTimeAndRecordEvent(EventCategory category,
 
 void Profiler::EndTimeAndRecordEvent(EventCategory category,
                                      const std::string& event_name,
-                                     long long dur, long long ts,
+                                     long long duration,         //duration of the op
+                                     long long time_from_start,  //time difference between op start time and profiler start time
                                      const std::initializer_list<std::pair<std::string, std::string>>& event_args,
                                      bool /*sync_gpu*/) {
   EventRecord event(category, logging::GetProcessId(),
-                    logging::GetThreadId(), event_name, ts, dur, {event_args.begin(), event_args.end()});
+                    logging::GetThreadId(), event_name, time_from_start, duration, {event_args.begin(), event_args.end()});
   if (profile_with_logger_) {
     custom_logger_->SendProfileEvent(event);
   } else {

--- a/onnxruntime/core/common/profiler.cc
+++ b/onnxruntime/core/common/profiler.cc
@@ -206,12 +206,27 @@ template void Profiler::StartProfiling<wchar_t>(const std::basic_string<wchar_t>
 
 void Profiler::EndTimeAndRecordEvent(EventCategory category,
                                      const std::string& event_name,
+                                     const TimePoint& start_time, const TimePoint& end_time,
+                                     const std::initializer_list<std::pair<std::string, std::string>>& event_args,
+                                     bool sync_gpu) {
+  EndTimeAndRecordEvent(category, event_name, TimeDiffMicroSeconds(start_time, end_time),
+                        TimeDiffMicroSeconds(profiling_start_time_, start_time), event_args, sync_gpu);
+}
+
+void Profiler::EndTimeAndRecordEvent(EventCategory category,
+                                     const std::string& event_name,
                                      const TimePoint& start_time,
                                      const std::initializer_list<std::pair<std::string, std::string>>& event_args,
-                                     bool /*sync_gpu*/) {
-  long long dur = TimeDiffMicroSeconds(start_time);
-  long long ts = TimeDiffMicroSeconds(profiling_start_time_, start_time);
+                                     bool sync_gpu) {
+  EndTimeAndRecordEvent(category, event_name, TimeDiffMicroSeconds(start_time),
+                        TimeDiffMicroSeconds(profiling_start_time_, start_time), event_args, sync_gpu);
+}
 
+void Profiler::EndTimeAndRecordEvent(EventCategory category,
+                                     const std::string& event_name,
+                                     long long dur, long long ts,
+                                     const std::initializer_list<std::pair<std::string, std::string>>& event_args,
+                                     bool /*sync_gpu*/) {
   EventRecord event(category, logging::GetProcessId(),
                     logging::GetThreadId(), event_name, ts, dur, {event_args.begin(), event_args.end()});
   if (profile_with_logger_) {

--- a/onnxruntime/core/common/profiler.cc
+++ b/onnxruntime/core/common/profiler.cc
@@ -157,7 +157,7 @@ profiling::Profiler::~Profiler() {
 }
 #endif
 
-::onnxruntime::TimePoint profiling::Profiler::StartTime() const {
+::onnxruntime::TimePoint profiling::Profiler::Now() const {
   ORT_ENFORCE(enabled_);
   return std::chrono::high_resolution_clock::now();
 }
@@ -180,7 +180,7 @@ void Profiler::StartProfiling(const logging::Logger* custom_logger) {
   enabled_ = true;
   profile_with_logger_ = true;
   custom_logger_ = custom_logger;
-  profiling_start_time_ = StartTime();
+  profiling_start_time_ = Now();
   DeviceProfiler* device_profiler = DeviceProfiler::GetDeviceProfiler();
   if (device_profiler) {
     device_profiler->StartProfiling(profiling_start_time_, logging::GetProcessId(), logging::GetThreadId());
@@ -192,7 +192,7 @@ void Profiler::StartProfiling(const std::basic_string<T>& file_name) {
   enabled_ = true;
   profile_stream_.open(file_name, std::ios::out | std::ios::trunc);
   profile_stream_file_ = ToMBString(file_name);
-  profiling_start_time_ = StartTime();
+  profiling_start_time_ = Now();
   DeviceProfiler* device_profiler = DeviceProfiler::GetDeviceProfiler();
   if (device_profiler) {
     device_profiler->StartProfiling(profiling_start_time_, logging::GetProcessId(), logging::GetThreadId());

--- a/onnxruntime/core/common/profiler.h
+++ b/onnxruntime/core/common/profiler.h
@@ -78,6 +78,17 @@ class Profiler {
                              const std::initializer_list<std::pair<std::string, std::string>>& event_args = {},
                              bool sync_gpu = false);
 
+  void EndTimeAndRecordEvent(EventCategory category,
+                             const std::string& event_name,
+                             const TimePoint& start_time, const TimePoint& end_time,
+                             const std::initializer_list<std::pair<std::string, std::string>>& event_args = {},
+                             bool sync_gpu = false);
+
+  void Profiler::EndTimeAndRecordEvent(EventCategory category,
+                                       const std::string& event_name,
+                                       long long dur, long long ts,
+                                       const std::initializer_list<std::pair<std::string, std::string>>& event_args,
+                                       bool sync_gpu = false);
   /*
   Write profile data to the given stream in chrome format defined below.
   https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#

--- a/onnxruntime/core/common/profiler.h
+++ b/onnxruntime/core/common/profiler.h
@@ -51,7 +51,7 @@ class Profiler {
   /*
   Produce current time point for any profiling action.
   */
-  TimePoint StartTime() const;
+  TimePoint Now() const;
 
   /*
   Whether data collection and output from this profiler is enabled.
@@ -84,11 +84,11 @@ class Profiler {
                              const std::initializer_list<std::pair<std::string, std::string>>& event_args = {},
                              bool sync_gpu = false);
 
-  void Profiler::EndTimeAndRecordEvent(EventCategory category,
-                                       const std::string& event_name,
-                                       long long dur, long long ts,
-                                       const std::initializer_list<std::pair<std::string, std::string>>& event_args,
-                                       bool sync_gpu = false);
+  void EndTimeAndRecordEvent(EventCategory category,
+                             const std::string& event_name,
+                             long long dur, long long ts,
+                             const std::initializer_list<std::pair<std::string, std::string>>& event_args,
+                             bool sync_gpu = false);
   /*
   Write profile data to the given stream in chrome format defined below.
   https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#

--- a/onnxruntime/core/common/profiler.h
+++ b/onnxruntime/core/common/profiler.h
@@ -84,11 +84,6 @@ class Profiler {
                              const std::initializer_list<std::pair<std::string, std::string>>& event_args = {},
                              bool sync_gpu = false);
 
-  void EndTimeAndRecordEvent(EventCategory category,
-                             const std::string& event_name,
-                             long long dur, long long ts,
-                             const std::initializer_list<std::pair<std::string, std::string>>& event_args,
-                             bool sync_gpu = false);
   /*
   Write profile data to the given stream in chrome format defined below.
   https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#
@@ -120,6 +115,13 @@ class Profiler {
   }
 
  private:
+  void EndTimeAndRecordEvent(EventCategory category,
+                             const std::string& event_name,
+                             long long duration,         //duration of the op
+                             long long time_from_start,  //time difference between op start time and profiler start time
+                             const std::initializer_list<std::pair<std::string, std::string>>& event_args,
+                             bool sync_gpu = false);
+
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(Profiler);
 
   /**

--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -136,7 +136,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
   size_t total_output_sizes = 0;
 
   if (is_profiler_enabled) {
-    tp = session_state.Profiler().StartTime();
+    tp = session_state.Profiler().Now();
   }
 
   ExecutionFrame frame{feed_mlvalue_idxs, feeds, fetch_mlvalue_idxs, fetches, fetch_allocators, session_state};
@@ -235,7 +235,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
     OpKernelContextInternal op_kernel_context(session_state, frame, *p_op_kernel, logger, terminate_flag_);
     // TODO: log kernel outputs?
     if (is_profiler_enabled) {
-      sync_time_begin = session_state.Profiler().StartTime();
+      sync_time_begin = session_state.Profiler().Now();
     }
 
     // sync before compute
@@ -289,7 +289,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
       // call compute on the kernel
       VLOGS(logger, 1) << "Computing kernel: " << node_name_for_profiling;
 
-      kernel_begin_time = session_state.Profiler().StartTime();
+      kernel_begin_time = session_state.Profiler().Now();
 
       // Calculate total input sizes for this operation.
       CalculateTotalInputSizes(&op_kernel_context, p_op_kernel,
@@ -357,7 +357,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
                 << "\n";
 #endif
 
-      kernel_end_time = std::chrono::high_resolution_clock::now();
+      kernel_end_time = session_state.Profiler().Now();
       session_state.Profiler().EndTimeAndRecordEvent(profiling::NODE_EVENT,
                                                      node_name_for_profiling + "_kernel_time",
                                                      kernel_begin_time, kernel_end_time,
@@ -372,7 +372,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
                                                          {"output_size", std::to_string(total_output_sizes)},
                                                          {"thread_scheduling_stats", concurrency::ThreadPool::StopProfiling(session_state.GetThreadPool())},
                                                      });
-      sync_time_begin = session_state.Profiler().StartTime();
+      sync_time_begin = session_state.Profiler().Now();
     }
 
     // sync after compute for outputs

--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -130,7 +130,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
   const bool is_profiler_enabled = session_state.Profiler().IsEnabled();
   TimePoint tp;
   TimePoint sync_time_begin;
-  TimePoint kernel_begin_time;
+  TimePoint kernel_begin_time, kernel_end_time;
   size_t input_activation_sizes = 0;
   size_t input_parameter_sizes = 0;
   size_t total_output_sizes = 0;
@@ -357,9 +357,10 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
                 << "\n";
 #endif
 
+      kernel_end_time = std::chrono::high_resolution_clock::now();
       session_state.Profiler().EndTimeAndRecordEvent(profiling::NODE_EVENT,
                                                      node_name_for_profiling + "_kernel_time",
-                                                     kernel_begin_time,
+                                                     kernel_begin_time, kernel_end_time,
                                                      // Log additional operation args / info.
                                                      {
                                                          {"op_name", p_op_kernel->KernelDef().OpName()},

--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -289,11 +289,10 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
       // call compute on the kernel
       VLOGS(logger, 1) << "Computing kernel: " << node_name_for_profiling;
 
-      kernel_begin_time = session_state.Profiler().Now();
-
       // Calculate total input sizes for this operation.
       CalculateTotalInputSizes(&op_kernel_context, p_op_kernel,
                                input_activation_sizes, input_parameter_sizes, node_name_for_profiling);
+      kernel_begin_time = session_state.Profiler().Now();
     }
 
     Status compute_status;
@@ -341,6 +340,7 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
     }
 
     if (is_profiler_enabled) {
+      kernel_end_time = session_state.Profiler().Now();
       // Calculate total output sizes for this operation.
       CalculateTotalOutputSizes(&op_kernel_context, total_output_sizes, node_name_for_profiling);
 
@@ -356,8 +356,6 @@ Status SequentialExecutor::Execute(const SessionState& session_state, const std:
                 << " Output_Size=" << total_output_sizes
                 << "\n";
 #endif
-
-      kernel_end_time = session_state.Profiler().Now();
       session_state.Profiler().EndTimeAndRecordEvent(profiling::NODE_EVENT,
                                                      node_name_for_profiling + "_kernel_time",
                                                      kernel_begin_time, kernel_end_time,

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -560,7 +560,7 @@ common::Status InferenceSession::Load(std::function<common::Status(std::shared_p
   Status status = Status::OK();
   TimePoint tp;
   if (session_profiler_.IsEnabled()) {
-    tp = session_profiler_.StartTime();
+    tp = session_profiler_.Now();
   }
   ORT_TRY {
     std::lock_guard<onnxruntime::OrtMutex> l(session_mutex_);
@@ -1114,7 +1114,7 @@ common::Status InferenceSession::Initialize() {
   Status status = Status::OK();
   TimePoint tp;
   if (session_profiler_.IsEnabled()) {
-    tp = session_profiler_.StartTime();
+    tp = session_profiler_.Now();
   }
 
   ORT_TRY {
@@ -1511,7 +1511,7 @@ Status InferenceSession::Run(const RunOptions& run_options,
                              const std::vector<OrtDevice>* p_fetches_device_info) {
   TimePoint tp;
   if (session_profiler_.IsEnabled()) {
-    tp = session_profiler_.StartTime();
+    tp = session_profiler_.Now();
   }
 
 #ifdef ONNXRUNTIME_ENABLE_INSTRUMENT


### PR DESCRIPTION
Collecting op end time earlier to avoid noise generated by thread pool profiler.