### PR TITLE
Better error message when ORTModule used with torch.DataParallel

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -133,3 +133,7 @@ class ORTModule(torch.nn.Module):
     def named_buffers(self, prefix: str = '', recurse: bool = True) -> Iterator[Tuple[str, torch.Tensor]]:
         """Override original method to delegate execution to the base module"""
         yield from self._flattened_module._base_module.named_buffers(prefix=prefix, recurse=recurse)
+
+    def _replicate_for_data_parallel(self):
+        raise NotImplementedError("ORTModule is not compatible with torch.nn.DataParallel. "
+                                  "Please use torch.nn.parallel.DistributedDataParallel instead.")


### PR DESCRIPTION
Display a better error message when ```ORTModule``` is used with ```torch.DataParallel``` than the vague error message:
```sh
RuntimeError: Input, output and indices must be on the current device
```

The new error message displayed will be:
```sh
NotImplementedError: ORTModule is not compatible with torch.nn.DataParallel. Please use torch.nn.parallel.DistributedDataParallel instead.
```


```torch.nn.DataParallel``` requires the model to be replicated across multiple devices, and in this process, ```ORTModule``` tries to export the model to onnx on multiple devices with the same sample input. Because of this multiple device export with the same sample input, torch throws an exception that reads: "RuntimeError: Input, output and indices must be on the current device" which can be vague to the user since they might not be aware of what happens behind the scene.

We therefore try to preemptively catch use of ```ORTModule``` with ```torch.nn.DataParallel``` and throw a more meaningful exception.

Users must use ```torch.nn.parallel.DistributedDataParallel``` instead of ```torch.nn.DataParallel``` which does not need model replication and is also recommended by torch to use instead.