### PR TITLE
Change initialization of ort environment to be static.

### DIFF
--- a/include/onnxruntime/core/eager/ort_kernel_invoker.h
+++ b/include/onnxruntime/core/eager/ort_kernel_invoker.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "core/common/common.h"
+#include "core/common/logging/sinks/clog_sink.h"
 #include "core/framework/allocator.h"
 #include "core/framework/tensor.h"
 #include "core/framework/execution_provider.h"
@@ -37,6 +38,23 @@ class ORTInvoker {
 
  private:
   std::unique_ptr<IExecutionProvider> execution_provider_;
+
+  struct EnvironmentManager {
+    EnvironmentManager() {
+      std::string logger_id{"ORTInvoker"};
+      auto logging_manager = onnxruntime::make_unique<logging::LoggingManager>(
+        std::unique_ptr<logging::ISink>{new logging::CLogSink{}},
+        logging::Severity::kVERBOSE, false,
+        logging::LoggingManager::InstanceType::Default,
+        &logger_id);
+      Environment::Create(std::move(logging_manager), ort_env_);
+    }
+
+    std::unique_ptr<Environment> ort_env_;
+    friend class ORTInvoker;
+  };
+
+  static EnvironmentManager env_manager_;
 };
 
 #ifdef __GNUC__


### PR DESCRIPTION
Currently ort_kernel_invoker uses a singleton environment which is used for logging and initialized the first time ort_kernel_invoker is constructed. This revealed an issue with Apollo ExecutionProvider integration. During creation of EP, it uses the logger which fails due to it being null. Hence switching this to be a static so it is initialized before the constructor. 
