### PR TITLE
NCHWc: Support "sizes" argument for Resize transform

### DIFF
--- a/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
@@ -10,6 +10,7 @@
 #include "test/test_environment.h"
 #include "test/framework/test_utils.h"
 #include "test/util/include/inference_session_wrapper.h"
+#include <cmath>
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
**Description**: Update the NCHWc transformer to support the optional "sizes" input for Resize. The output shape must be constant and must result in an integral multiplier, just as required of the existing "scales" input support.

Some internal models were heading down this alternate path and not getting fully optimized. Removing these unnecessary buffer reorderings and using the NCHWc Upsample shaved off .5ms from model inference time.