### PR TITLE
Update usage of generator expression $<COMPILE_LANGUAGE:L1,L2> which is not available in CMake 3.14.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -163,8 +163,9 @@ function(set_msvc_c_cpp_compiler_warning_level warning_level)
     set(warning_flag "/W${warning_level}")
     get_property(opts DIRECTORY PROPERTY COMPILE_OPTIONS)
     # only match the generator expression added by this function
-    list(FILTER opts EXCLUDE REGEX "^\\$<\\$<COMPILE_LANGUAGE:C,CXX>:/W[0-4]>$")
-    list(APPEND opts "$<$<COMPILE_LANGUAGE:C,CXX>:${warning_flag}>")
+    list(FILTER opts
+         EXCLUDE REGEX "^\\$<\\$<OR:\\$<COMPILE_LANGUAGE:C>,\\$<COMPILE_LANGUAGE:CXX>>:/W[0-4]>$")
+    list(APPEND opts "$<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:${warning_flag}>")
     set_property(DIRECTORY PROPERTY COMPILE_OPTIONS "${opts}")
   endif()
 endfunction()


### PR DESCRIPTION
**Description**
Update usage of generator expression $<COMPILE_LANGUAGE:L1,L2> which is not available in CMake 3.14.

**Motivation and Context**
Fix build for CMake 3.14 and below.