### PR TITLE
User/sheilk/add api usage telemetry

### DIFF
--- a/winml/lib/Api.Experimental/LearningModelBuilder.cpp
+++ b/winml/lib/Api.Experimental/LearningModelBuilder.cpp
@@ -11,6 +11,8 @@
 namespace WINML_EXPERIMENTALP {
 
 LearningModelBuilder::LearningModelBuilder(int64_t opset) : inputs_(nullptr), outputs_(nullptr), operators_(nullptr), inert_session_(nullptr) {
+  telemetry_helper.LogApiUsage("LearningModelBuilder::LearningModelBuilder");
+
   WINML_THROW_IF_FAILED(CreateOnnxruntimeEngineFactory(engine_factory_.put()));
   WINML_THROW_IF_FAILED(engine_factory_->CreateEmptyModel(opset, model_.put()));
   inputs_ = winrt::make<winml_experimentalp::LearningModelInputs>(*this);
@@ -44,12 +46,16 @@ winml_experimental::LearningModelOperatorSet LearningModelBuilder::Operators() {
 }
 
 winml::LearningModel LearningModelBuilder::CreateModel() {
+  telemetry_helper.LogApiUsage("LearningModelBuilder::CreateModel");
+
   com_ptr<_winml::IModel> model_clone;
   model_->CloneModel(model_clone.put());
   return winrt::make<winmlp::LearningModel>(engine_factory_.get(), model_clone.get(), nullptr);
 }
 
 void LearningModelBuilder::Save(const winrt::hstring& file_name) {
+  telemetry_helper.LogApiUsage("LearningModelBuilder::Save");
+
   model_->SaveModel(file_name.c_str(), file_name.size());
 }
 

--- a/winml/lib/Api.Experimental/LearningModelSessionOptionsExperimental.cpp
+++ b/winml/lib/Api.Experimental/LearningModelSessionOptionsExperimental.cpp
@@ -12,6 +12,8 @@ LearningModelSessionOptionsExperimental::LearningModelSessionOptionsExperimental
 }
 
 wfc::IMapView<winrt::hstring, uint32_t> LearningModelSessionOptionsExperimental::GetNamedDimensionOverrides() {
+  telemetry_helper.LogApiUsage("LearningModelSessionOptionsExperimental::GetNamedDimensionOverrides");
+
   return overrides_;
 }
 

--- a/winml/lib/Common/inc/WinMLTelemetryHelper.h
+++ b/winml/lib/Common/inc/WinMLTelemetryHelper.h
@@ -36,6 +36,7 @@ class Profiler;
 #define WINML_TLM_RUNTIME_PERF_VERSION 0
 #define WINML_TLM_NATIVE_API_INTRAOP_THREADS_VERSION 0
 #define WINML_TLM_NAMED_DIMENSION_OVERRIDE_VERSION 0
+#define WINML_TLM_EXPERIMENTAL_API_VERSION 0
 
 #define WinMLTraceLoggingWrite(hProvider, EventName, ...)                \
   TraceLoggingWrite(hProvider,                                           \
@@ -82,6 +83,7 @@ class WinMLTelemetryHelper {
     TraceLoggingUnregister(provider_);
   }
 
+  void LogApiUsage(const char* name);
   void LogWinMLShutDown();
   void LogWinMLSuspended();
   void LogRuntimeError(HRESULT hr, std::string message, PCSTR file, PCSTR function, int line);

--- a/winml/lib/Telemetry/WinMLTelemetryHelper.cpp
+++ b/winml/lib/Telemetry/WinMLTelemetryHelper.cpp
@@ -16,6 +16,22 @@ WinMLTelemetryHelper::WinMLTelemetryHelper()
 WinMLTelemetryHelper::~WinMLTelemetryHelper() {
 }
 
+void WinMLTelemetryHelper::LogApiUsage(const char* name){
+  if (!telemetry_enabled_)
+    return;
+  WinMLTraceLoggingWrite(
+      provider_,
+      "SetNamedDimensionOverride",
+      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+      //Telemetry info
+      TraceLoggingUInt8(WINML_TLM_EXPERIMENTAL_API_VERSION, "schemaVersion"),
+      // named dimension override info
+      TraceLoggingString(name, "name"),
+      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+}
+
+
 void WinMLTelemetryHelper::LogWinMLShutDown() {
   std::string message = BINARY_NAME;
   message += " is unloaded";

--- a/winml/lib/Telemetry/WinMLTelemetryHelper.cpp
+++ b/winml/lib/Telemetry/WinMLTelemetryHelper.cpp
@@ -21,11 +21,11 @@ void WinMLTelemetryHelper::LogApiUsage(const char* name){
     return;
   WinMLTraceLoggingWrite(
       provider_,
-      "SetNamedDimensionOverride",
+      "ApiUsage",
       TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
       TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
       //Telemetry info
-      TraceLoggingUInt8(WINML_TLM_EXPERIMENTAL_API_VERSION, "schemaVersion"),
+      TraceLoggingUInt8(WINML_TLM_EXPERIMENTAL_API_VERSION, "experimentalSchemaVersion"),
       // named dimension override info
       TraceLoggingString(name, "name"),
       TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));


### PR DESCRIPTION
Add telemetry to track experimental api usage:
1) LearningModelBuilder::LearningModelBuilder
2) LearningModelBuilder::CreateModel
3) LearningModelBuilder::Save
4) LearningModelSessionOptionsExperimental::GetNamedDimensionOverrides