### PR TITLE
Fixed initialization order in ORT kernel invoker

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -798,7 +798,6 @@ set(onnxruntime_eager_mode_libs
         onnxruntime_providers
         onnxruntime_util
         onnxruntime_framework
-        onnxruntime_flatbuffers
         flatbuffers
         onnxruntime_graph 
         onnxruntime_common
@@ -808,6 +807,7 @@ set(onnxruntime_eager_mode_libs
         protobuf::libprotobuf
         GTest::gtest
         re2::re2
+        onnxruntime_flatbuffers
         ${CMAKE_DL_LIBS}
         )
 if(onnxruntime_ENABLE_TRAINING)

--- a/include/onnxruntime/core/eager/ort_kernel_invoker.h
+++ b/include/onnxruntime/core/eager/ort_kernel_invoker.h
@@ -21,7 +21,9 @@ namespace onnxruntime {
 
 class ORTInvoker {
  public:
-  ORTInvoker(std::unique_ptr<IExecutionProvider> execution_provider);
+  ORTInvoker(std::unique_ptr<IExecutionProvider> execution_provider, const logging::Logger& logger) : 
+      execution_provider_(std::move(execution_provider)), logger_(logger) {
+  }
 
   IExecutionProvider& GetCurrentExecutionProvider() {
     return *execution_provider_;
@@ -37,6 +39,7 @@ class ORTInvoker {
 
  private:
   std::unique_ptr<IExecutionProvider> execution_provider_;
+  const logging::Logger& logger_;
 };
 
 #ifdef __GNUC__

--- a/onnxruntime/core/eager/ort_kernel_invoker.cc
+++ b/onnxruntime/core/eager/ort_kernel_invoker.cc
@@ -4,28 +4,11 @@
 #include "core/eager/ort_kernel_invoker.h"
 #include "core/optimizer/optimizer_execution_frame.h"
 #include "core/common/logging/logging.h"
-#include "core/common/logging/sinks/clog_sink.h"
 #include "core/graph/model.h"
 #include "core/framework/op_kernel.h"
 #include "core/session/ort_env.h"
 
 namespace onnxruntime {
-
-std::once_flag init_flag;
-std::unique_ptr<Environment> ort_env;
-
-ORTInvoker::ORTInvoker(std::unique_ptr<IExecutionProvider> execution_provider)
-  : execution_provider_(std::move(execution_provider)) {
-  std::call_once(init_flag, [&]{
-    std::string logger_id{"ORTInvoker"};
-    auto logging_manager = onnxruntime::make_unique<logging::LoggingManager>(
-      std::unique_ptr<logging::ISink>{new logging::CLogSink{}},
-      logging::Severity::kVERBOSE, false,
-      logging::LoggingManager::InstanceType::Default,
-      &logger_id);
-    Environment::Create(std::move(logging_manager), ort_env);
-  });
-}
 
 common::Status ORTInvoker::Invoke(const std::string& op_name,
                                   //optional inputs / outputs?
@@ -35,7 +18,7 @@ common::Status ORTInvoker::Invoke(const std::string& op_name,
                                   const std::string domain,
                                   const int /*version*/) {
   //create a graph
-  Model model("test", false, ort_env->GetLoggingManager()->DefaultLogger());
+  Model model("test", false, logger_);
 
   std::vector<onnxruntime::NodeArg*> input_args;
   std::vector<onnxruntime::NodeArg*> output_args;
@@ -81,7 +64,7 @@ common::Status ORTInvoker::Invoke(const std::string& op_name,
   }
 
   OptimizerExecutionFrame frame(info, fetch_mlvalue_idxs, outputs);
-  OpKernelContext op_kernel_context(&frame, kernel.get(), nullptr, ort_env->GetLoggingManager()->DefaultLogger());
+  OpKernelContext op_kernel_context(&frame, kernel.get(), nullptr, logger_);
   ORT_RETURN_IF_ERROR(kernel->Compute(&op_kernel_context));
 
   return frame.GetOutputs(outputs);

--- a/onnxruntime/test/eager/ort_invoker_test.cc
+++ b/onnxruntime/test/eager/ort_invoker_test.cc
@@ -18,7 +18,9 @@ TEST(InvokerTest, Basic) {
       logging::Severity::kVERBOSE, false,
       logging::LoggingManager::InstanceType::Default,
       &logger_id); 
-  ORTInvoker kernel_invoker(std::move(cpu_execution_provider), logging_manager->DefaultLogger());
+  std::unique_ptr<Environment> env;
+  Environment::Create(std::move(logging_manager), env);
+  ORTInvoker kernel_invoker(std::move(cpu_execution_provider), env->GetLoggingManager()->DefaultLogger());
 
   std::vector<int64_t> dims_mul_x = {3, 2};
   std::vector<float> values_mul_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};

--- a/onnxruntime/test/eager/ort_invoker_test.cc
+++ b/onnxruntime/test/eager/ort_invoker_test.cc
@@ -3,6 +3,7 @@
 
 #include "gtest/gtest.h"
 #include "core/eager/ort_kernel_invoker.h"
+#include "core/common/logging/sinks/clog_sink.h"
 #include "core/providers/cpu/cpu_execution_provider.h"
 #include "test/framework/test_utils.h"
 
@@ -11,7 +12,13 @@ namespace test {
 
 TEST(InvokerTest, Basic) {
   std::unique_ptr<IExecutionProvider> cpu_execution_provider = onnxruntime::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo(false));
-  ORTInvoker kernel_invoker(std::move(cpu_execution_provider));
+  const std::string logger_id{"InvokerTest"};
+  auto logging_manager = onnxruntime::make_unique<logging::LoggingManager>(
+      std::unique_ptr<logging::ISink>{new logging::CLogSink{}},
+      logging::Severity::kVERBOSE, false,
+      logging::LoggingManager::InstanceType::Default,
+      &logger_id); 
+  ORTInvoker kernel_invoker(std::move(cpu_execution_provider), logging_manager->DefaultLogger());
 
   std::vector<int64_t> dims_mul_x = {3, 2};
   std::vector<float> values_mul_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};


### PR DESCRIPTION
Currently ort_kernel_invoker uses a singleton environment which is used for logging and initialized the first time ort_kernel_invoker is constructed. This revealed an issue with Apollo ExecutionProvider integration. During creation of EP, it uses the logger which fails due to it being null. I am switching this so that ort_kernel_invoker simply takes a logger for construction. The environment will be maintained by the caller in this case torch_ort module.