### PR TITLE
Fix RoiAlign CPU EP issues

### DIFF
--- a/onnxruntime/core/providers/cpu/object_detection/roialign.cc
+++ b/onnxruntime/core/providers/cpu/object_detection/roialign.cc
@@ -162,8 +162,8 @@ void RoiAlignForward(const TensorShape& output_shape, const T* bottom_data, floa
       T roi_end_h = offset_bottom_rois[3] * spatial_scale;
 
       // Note that 0 size ROI's are legal, meaning the sample a single point in the input.
-      T roi_width = roi_end_w - roi_start_w;
-      T roi_height = roi_end_h - roi_start_h;
+      T roi_width = std::max(roi_end_w - roi_start_w, (T)0);
+      T roi_height = std::max(roi_end_h - roi_start_h, (T)0);
       T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
       T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
 


### PR DESCRIPTION
**Description**:
(1) pixel alignment is 0.5 off - the correct equation is `(x + 0.5) * scale - 0.5`, but the final 0.5 was missed `(x + 0.5) * scale` (see https://arxiv.org/abs/1703.06870). I know I'll get pushback on this one : ), but the other two are less contentious fixes.
(2) 0 size regions are valid and should be treated as sampled points, not forced to 1. This leads to test failures when sampling tiny points or slivers in our ONNX conformance tests. `bin_size_w` and `bin_size_h` are only multiplied anyway, not divided, and so an attempt to prevent division by zero (or whatever the original intention) is unnecessary.
(3) max mode should take the entire bilinear sample, not a fragment of it

**Motivation and Context**
- _Why is this change required? What problem does it solve?_ The DML/WinML ONNX conformance tests fail on CPU for a number of cases. https://github.com/onnx/onnx/issues/3428 
- _If it fixes an open issue, please link to the issue here._ https://github.com/microsoft/onnxruntime/issues/6921
