### PR TITLE
Fix android CI failure after gradle updated to 7.0

### DIFF
--- a/tools/ci_build/github/android/setup_gradle_wrapper.sh
+++ b/tools/ci_build/github/android/setup_gradle_wrapper.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script will setup gradlew to use gradle version 6.8.3 for Android CI,
+# since the macOS pipeline is using gradle 7.0 which will fail the java build
+# See, https://github.com/actions/virtual-environments/issues/3195
+
+set -e
+set -x
+
+if [ $# -ne 1 ]; then
+    echo "One command line argument, the ORT root directory, is expected"
+fi
+
+ORT_ROOT=$1
+
+pushd ${ORT_ROOT}/java
+gradle wrapper --gradle-version 6.8.3 --no-daemon --no-watch-fs
+./gradlew --version
+popd

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -15,6 +15,9 @@ jobs:
   - script: brew install coreutils ninja
     displayName: Install coreutils and ninja
 
+  - script: /bin/bash tools/ci_build/github/macos/setup_gradle_wrapper.sh $(pwd)
+    displayName: Setup gradle wrapper to use gradle 6.8.3
+
   - script: |
       python3 tools/python/run_android_emulator.py \
         --android-sdk-root ${ANDROID_SDK_ROOT} \

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -15,7 +15,7 @@ jobs:
   - script: brew install coreutils ninja
     displayName: Install coreutils and ninja
 
-  - script: /bin/bash tools/ci_build/github/macos/setup_gradle_wrapper.sh $(pwd)
+  - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
     displayName: Setup gradle wrapper to use gradle 6.8.3
 
   - script: |


### PR DESCRIPTION
**Description**: Fix android CI failure after gradle updated to 7.0

**Motivation and Context**
- MacOS CI pipeline image updated gradle to 7.0, caused Android CI to fail
  - https://github.com/actions/virtual-environments/issues/3195
  - https://github.com/gradle/gradle/issues/16802
- Use gradle wrapper to use gradle 6.8.3 which is known good
- macOS CI will also see this exception, but seems will not cause any failure, not fixing it here
