### PR TITLE
Update C# examples

### DIFF
--- a/csharp/sample/Microsoft.ML.OnnxRuntime.FasterRcnnSample/Microsoft.ML.OnnxRuntime.FasterRcnnSample.csproj
+++ b/csharp/sample/Microsoft.ML.OnnxRuntime.FasterRcnnSample/Microsoft.ML.OnnxRuntime.FasterRcnnSample.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.4.0" />
-    <PackageReference Include="Sixlabors.ImageSharp" Version="1.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0010" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.7.0" />
+    <PackageReference Include="Sixlabors.ImageSharp" Version="1.0.3" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />
   </ItemGroup>
 
 </Project>

--- a/csharp/sample/Microsoft.ML.OnnxRuntime.FasterRcnnSample/Program.cs
+++ b/csharp/sample/Microsoft.ML.OnnxRuntime.FasterRcnnSample/Program.cs
@@ -22,13 +22,11 @@ namespace Microsoft.ML.OnnxRuntime.FasterRcnnSample
             string outImageFilePath = args[2];
 
             // Read image
-            using Image<Rgb24> image = Image.Load<Rgb24>(imageFilePath, out IImageFormat format);
+            using Image<Rgb24> image = Image.Load<Rgb24>(imageFilePath);
 
             // Resize image
             float ratio = 800f / Math.Min(image.Width, image.Height);
-            using Stream imageStream = new MemoryStream();
             image.Mutate(x => x.Resize((int)(ratio * image.Width), (int)(ratio * image.Height)));
-            image.Save(imageStream, format);
 
             // Preprocess image
             var paddedHeight = (int)(Math.Ceiling(image.Height / 32f) * 32f);
@@ -101,7 +99,7 @@ namespace Microsoft.ML.OnnxRuntime.FasterRcnnSample
                     x.DrawText($"{p.Label}, {p.Confidence:0.00}", font, Color.White, new PointF(p.Box.Xmin, p.Box.Ymin));
                 });
             }
-            image.Save(outputImage, format);
+            image.SaveAsJpeg(outputImage);
         }
     }
 }

--- a/csharp/sample/Microsoft.ML.OnnxRuntime.ResNet50v2Sample/Microsoft.ML.OnnxRuntime.ResNet50v2Sample.csproj
+++ b/csharp/sample/Microsoft.ML.OnnxRuntime.ResNet50v2Sample/Microsoft.ML.OnnxRuntime.ResNet50v2Sample.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.4.0" />
-    <PackageReference Include="Sixlabors.ImageSharp" Version="1.0.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.7.0" />
+    <PackageReference Include="Sixlabors.ImageSharp" Version="1.0.3" />
   </ItemGroup>
 
 </Project>

--- a/csharp/sample/Microsoft.ML.OnnxRuntime.ResNet50v2Sample/Program.cs
+++ b/csharp/sample/Microsoft.ML.OnnxRuntime.ResNet50v2Sample/Program.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
@@ -19,10 +17,9 @@ namespace Microsoft.ML.OnnxRuntime.ResNet50v2Sample
             string imageFilePath = args[1];
 
             // Read image
-            using Image<Rgb24> image = Image.Load<Rgb24>(imageFilePath, out IImageFormat format);
+            using Image<Rgb24> image = Image.Load<Rgb24>(imageFilePath);
 
             // Resize image
-            using Stream imageStream = new MemoryStream();
             image.Mutate(x =>
             {
                 x.Resize(new ResizeOptions
@@ -31,7 +28,6 @@ namespace Microsoft.ML.OnnxRuntime.ResNet50v2Sample
                     Mode = ResizeMode.Crop
                 });
             });
-            image.Save(imageStream, format);
 
             // Preprocess image
             Tensor<float> input = new DenseTensor<float>(new[] { 1, 3, 224, 224 });


### PR DESCRIPTION
**Description**: 

Removes an unnecessary encoding step from the C# examples.

**Motivation and Context**
- Why is this change required? What problem does it solve?

The encoding step seems unnecessary, the memory stream is not used.

- If it fixes an open issue, please link to the issue here.
