### PR TITLE
Fix Microsoft.AI.MachineLearning .NET5 publishing and C# Store Release build

### DIFF
--- a/cmake/winml_cppwinrt.cmake
+++ b/cmake/winml_cppwinrt.cmake
@@ -144,6 +144,7 @@ function(target_cppwinrt
                 /metadata_dir ${sdk_metadata_directory}
                 /W1 /char signed /nomidl /nologo /winrt
                 /no_settings_comment /no_def_idir /target "NT60"
+                /I ${CMAKE_CURRENT_BINARY_DIR}/winml_api
                 /I ${idl_source_directory}
                 /I ${um_sdk_directory}
                 /I ${shared_sdk_directory}

--- a/csharp/src/Microsoft.AI.MachineLearning.Interop/Microsoft.AI.MachineLearning.targets
+++ b/csharp/src/Microsoft.AI.MachineLearning.Interop/Microsoft.AI.MachineLearning.targets
@@ -23,4 +23,8 @@
     <Message Text="$([System.String]::Format('$(WindowsAIBinplaceMessage)', '$(WindowsAIBinary)', '$(OnnxRuntimeBinary)'))" />
     <Copy SkipUnchangedFiles="True" SourceFiles="$(WindowsAIBinary);$(OnnxRuntimeBinary)" DestinationFolder="$(OutDir)" />
   </Target>
+
+  <ItemGroup>
+    <ReferenceCopyLocalPaths Include="$(WindowsAIBinary);$(OnnxRuntimeBinary)" />
+  </ItemGroup>
 </Project>

--- a/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
+++ b/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
@@ -3,15 +3,16 @@
 
 import "Windows.Foundation.idl";
 import "dualapipartitionattribute.idl";
-import "Windows.AI.MachineLearning.idl";
 
 #include <sdkddkver.h>
 
 #ifdef BUILD_INBOX
+import "Windows.AI.MachineLearning.idl";
 #define ROOT_NS Windows
 #define INBOX_ONLY(x) x
 #define OTB_ONLY(x)
 #else
+import "Microsoft.AI.MachineLearning.idl";
 #define INBOX_ONLY(x)
 #define OTB_ONLY(x) x
 #endif


### PR DESCRIPTION
There are 2 fixes in this change.

Issue #1: The Microsoft.AI.MachineLearning package does not publish native binaries to the package output directory automatically.  

Reason: This regressed when all of the nuget payload was moved into folders with non-canonical names. This was done to prevent nuget from performing automatic copies, as its logic was getting confused when multiple binaries are produced for the same TFM (static, dynamic crt for native binaries). After moving the files to non-canonical names, all project configuration is now performed by the package itself by including its own targets/props files in the build directory. The copy that was added into the targets file only copied out to the bin directory and not the publish directory, causing the regression.

Fix: The Fix is to call ReferenceCopyLocalPaths on the intended binaries, and that will configure the project to binplace and publish the native binaries.


Issue #2: C# UWP Applications cannot build release because Microsoft.AI.MachineLearning.Experimental.winmd references Windows.AI.MachineLearning.winmd.

Reason: This happened because the core Windows AI API is implemented in a single file Windows.AI.MachineLEarning.idl, and shared between the Inbox implementation and the Redist. However, dependent idls fail to work when referencing Windows.AI.MachineLearning.idl, as import statements are interpretted as winmd references. This causes Release builds to fail, as there is no Windows.AI.MachineLearning.winmd packaged in the redist package.

Fix: The fix is to copy the idls into a separate folder at build, and rename them to Microsoft.* files so that midlrt does not add erroneous winmd references.