### PR TITLE
Fix a 'Squeeze' related issue in symbolic_shape_infer.py

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1161,6 +1161,8 @@ class SymbolicShapeInference:
             for i in range(len(input_shape)):
                 if i not in axes:
                     output_shape.append(input_shape[i])
+                else:
+                    assert input_shape[i] == 1 or type(input_shape[i]) != int
 
         vi = self.known_vi_[node.output[0]]
         vi.CopyFrom(

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1144,17 +1144,26 @@ class SymbolicShapeInference:
 
     def _infer_Squeeze(self, node): 
         input_shape = self._get_shape(node, 0)
+        op_set = get_opset(self.out_mp_)
 
-        # Depending on op-version 'axes' are provided as attribute or via 2nd input      
-        axes = get_attribute(node, 'axes')
-        if axes == None:
+        # Depending on op-version 'axes' are provided as attribute or via 2nd input
+        if op_set < 13:    
+            axes = get_attribute(node, 'axes')
+            assert self._try_get_value(node, 1) is None
+        else:
             axes = self._try_get_value(node, 1)
+            assert get_attribute(node, 'axes') is None
 
-        if axes == None:
+        if axes is None:
             # No axes have been provided (neither via attribute nor via input).
             # In this case the 'Shape' op should remove all axis with dimension 1.
             # For symbolic dimensions we guess they are !=1.
             output_shape = [s for s in input_shape if s != 1]
+            if self.verbose_ > 0:
+                symbolic_dimensions = [s for s in input_shape if type(s) != int]
+                if len(symbolic_dimensions) > 0:
+                    print(f"Variable dimensions in input shape of op: '{node.op_type}' node: '{node.name}'. " +
+                          f"Assuming the following dimensions are never equal to 1: {symbolic_dimensions}")
         else:
             axes = [handle_negative_axis(a, len(input_shape)) for a in axes]
             output_shape = []

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1162,7 +1162,7 @@ class SymbolicShapeInference:
             if self.verbose_ > 0:
                 symbolic_dimensions = [s for s in input_shape if type(s) != int]
                 if len(symbolic_dimensions) > 0:
-                    print(f"Variable dimensions in input shape of op: '{node.op_type}' node: '{node.name}'. " +
+                    print(f"Symbolic dimensions in input shape of op: '{node.op_type}' node: '{node.name}'. " +
                           f"Assuming the following dimensions are never equal to 1: {symbolic_dimensions}")
         else:
             axes = [handle_negative_axis(a, len(input_shape)) for a in axes]
@@ -1172,6 +1172,9 @@ class SymbolicShapeInference:
                     output_shape.append(input_shape[i])
                 else:
                     assert input_shape[i] == 1 or type(input_shape[i]) != int
+                    if self.verbose_ > 0 and type(input_shape[i]) != int:
+                        print(f"Symbolic dimensions in input shape of op: '{node.op_type}' node: '{node.name}'. " +
+                              f"Assuming the dimension '{input_shape[i]}' at index {i} of the input to be equal to 1.")
 
         vi = self.known_vi_[node.output[0]]
         vi.CopyFrom(


### PR DESCRIPTION
For the Squeeze operation the shape-inference ins not working properly ***if no axes are provided***. In this case all the dimensions equal to 1 should be removed from the input-shape (see: [Squeeze](https://github.com/onnx/onnx/blob/master/docs/Operators.md#squeeze)), but currently all dimensions are removed by shape-inference, independent of their value. This is due to the ‘non-symbolic’ shape inference called in _onnx_infer_single_node(…) not working properly in this case. 

Fixes #7356

@KeDengMS 