### PR TITLE
fixed libcupt library not found error

### DIFF
--- a/dockerfiles/Dockerfile.cuda
+++ b/dockerfiles/Dockerfile.cuda
@@ -14,8 +14,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-
 
 RUN cd /code && /bin/bash ./build.sh --skip_submodule_sync --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_cuda --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 'CMAKE_CUDA_ARCHITECTURES=30;37;50;52;60;70'
 
-FROM nvidia/cuda:10.2-cudnn8-runtime
-COPY --from=0 /code/build/Linux/Release/dist /root
-COPY --from=0 /code/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt
+RUN cp /code/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y --no-install-recommends libstdc++6 ca-certificates python3-setuptools python3-wheel python3-pip unattended-upgrades && unattended-upgrade && python3 -m pip install /root/*.whl && rm -rf /root/*.whl
+RUN apt-get update && apt-get install -y --no-install-recommends libstdc++6 unattended-upgrades && unattended-upgrade && python3 -m pip install /code/build/Linux/Release/dist/*.whl


### PR DESCRIPTION
**Description**: Describe your changes.
Removed `nvidia/cuda:10.2-cudnn8-runtime` as the base  image.

**Motivation and Context**
- Why is this change required? What problem does it solve?
Current build gave an error `ImportError: libcupti.so.10.2: cannot open shared object file: No such file or directory` when tried to import onnxruntime. This library is there in cudnn8-devel but not in cudnn8-runtime.
- If it fixes an open issue, please link to the issue here.
None
