### PR TITLE
Fix check for contiguous tensors on DLPack interface between PyTorch and ORTModule

### DIFF
--- a/onnxruntime/python/dlpack/dlpack_converter.cc
+++ b/onnxruntime/python/dlpack/dlpack_converter.cc
@@ -181,7 +181,11 @@ bool IsContiguousTensor(const DLTensor& tensor) {
 
   int64_t running_size = 1;
   for (int i = tensor.ndim - 1; i >= 0; i--) {
-    if (tensor.strides[i] != running_size) {
+    if (tensor.shape[i] == 0) {
+      return true;
+    }
+
+    if (tensor.shape[i] != 1 && tensor.strides[i] != running_size) {
       return false;
     }
 

--- a/orttraining/orttraining/python/training/_ortmodule_io.py
+++ b/orttraining/orttraining/python/training/_ortmodule_io.py
@@ -272,7 +272,6 @@ class _FlattenedModule(torch.nn.Module):
         self._input_info = None
 
     def forward(self, *args):
-        # TODO: Convert *args into *args + **kwars andd call _original_module with it
         new_args, new_kwargs = self._input_info.unflatten(args)
         return _transform_output_to_flat_tuple(self._original_module(*new_args, **new_kwargs))
 


### PR DESCRIPTION
In some cases, PyTorch tensors with a single dimension (e.g. `torch.FloatTensor([1])`) would present stride[0]=0 as opposed to stride[0]=1.

Because this discrepancie, ORT contiguous checks would fail.
This PR adds a corner case condition to ignore this