### PR TITLE
Update protobuf to the latest version

### DIFF
--- a/cgmanifests/submodules/cgmanifest.json
+++ b/cgmanifests/submodules/cgmanifest.json
@@ -162,10 +162,30 @@
       "component": {
         "type": "git",
         "git": {
+          "commitHash": "e1e11e0d555c08bec08a6c7773aa777dfcaae9da",
+          "repositoryUrl": "https://github.com/dmlc/dlpack.git"
+        },
+        "comments": "git submodule at cmake/external/dlpack"
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
           "commitHash": "d10b27fe37736d2944630ecd7557cefa95cf87c9",
           "repositoryUrl": "https://gitlab.com/libeigen/eigen.git"
         },
         "comments": "git submodule at cmake/external/eigen"
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "8b32b7def837a15e766039501630549149d3db41",
+          "repositoryUrl": "https://github.com/emscripten-core/emsdk.git"
+        },
+        "comments": "git submodule at cmake/external/emsdk"
       }
     },
     {
@@ -332,7 +352,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "498de9f761bef56a032815ee44b6e6dbe0892cc4",
+          "commitHash": "436bd7880e458532901c58f4d9d1ea23fa7edd52",
           "repositoryUrl": "https://github.com/protocolbuffers/protobuf.git"
         },
         "comments": "git submodule at cmake/external/protobuf"
@@ -446,16 +466,6 @@
           "repositoryUrl": "https://github.com/gabime/spdlog.git"
         },
         "comments": "git submodule at server/external/spdlog"
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "commitHash": "e1e11e0d555c08bec08a6c7773aa777dfcaae9da",
-          "repositoryUrl": "https://github.com/dmlc/dlpack.git"
-        },
-        "comments": "git submodule at cmake/external/dlpack"
       }
     }
   ]

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.11.3" />
+    <PackageReference Include="Google.Protobuf" Version="3.15.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/Microsoft.ML.OnnxRuntime.Tests.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/Microsoft.ML.OnnxRuntime.Tests.csproj
@@ -62,7 +62,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.Targets" Version="2.1.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
-    <PackageReference Include="Google.Protobuf" Version="3.11.3" />
+    <PackageReference Include="Google.Protobuf" Version="3.15.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />  

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -788,8 +788,8 @@ stages:
             sudo rm -rf /mnt/toolchains
             sudo mkdir /mnt/toolchains
             sudo tar -Jxf $(Build.BinariesDirectory)/toolchains.tar.xz -C /mnt/toolchains
-            aria2c -q https://github.com/protocolbuffers/protobuf/releases/download/v3.11.1/protoc-3.11.1-linux-x86_64.zip
-            unzip protoc-3.11.1-linux-x86_64.zip
+            aria2c -q https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip
+            unzip protoc-3.15.8-linux-x86_64.zip
             sudo cp /mnt/toolchains/manylinux2014_aarch64/usr/include/stdlib.h /mnt/toolchains/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu/aarch64-linux-gnu/libc/usr/include/
             #The PYTHON_EXECUTABLE cmake variable is only used for generating ONNX's protobuf definition file.(Invoking the onnx/gen_proto.py file in ONNX's source folder)
             cmake \

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_openvino
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_openvino
@@ -37,8 +37,8 @@ RUN wget https://github.com/intel/compute-runtime/releases/download/19.41.14441/
     sudo dpkg -i *.deb && rm -rf *.deb
 
 RUN mkdir -p /opt/cmake/bin && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.15.8/cmake-3.15.8-Linux-x86_64.tar.gz && \
-    tar -xf cmake-3.15.8-Linux-x86_64.tar.gz --strip 1 -C /opt/cmake && rm -rf /cmake-3.15.8-Linux-x86_64.tar.gz && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.13.2/cmake-3.13.2-Linux-x86_64.tar.gz && \
+    tar -xf cmake-3.13.2-Linux-x86_64.tar.gz --strip 1 -C /opt/cmake && rm -rf /cmake-3.13.2-Linux-x86_64.tar.gz && \
     ln -sf /opt/cmake/bin/* /usr/bin
 
 ARG BUILD_UID=1000

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_openvino
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_openvino
@@ -37,8 +37,8 @@ RUN wget https://github.com/intel/compute-runtime/releases/download/19.41.14441/
     sudo dpkg -i *.deb && rm -rf *.deb
 
 RUN mkdir -p /opt/cmake/bin && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.13.2/cmake-3.13.2-Linux-x86_64.tar.gz && \
-    tar -xf cmake-3.13.2-Linux-x86_64.tar.gz --strip 1 -C /opt/cmake && rm -rf /cmake-3.13.2-Linux-x86_64.tar.gz && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.15.8/cmake-3.15.8-Linux-x86_64.tar.gz && \
+    tar -xf cmake-3.15.8-Linux-x86_64.tar.gz --strip 1 -C /opt/cmake && rm -rf /cmake-3.15.8-Linux-x86_64.tar.gz && \
     ln -sf /opt/cmake/bin/* /usr/bin
 
 ARG BUILD_UID=1000

--- a/tools/ci_build/github/linux/docker/scripts/install_protobuf.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_protobuf.sh
@@ -34,9 +34,9 @@ function GetFile {
   return $?
 }
 
-GetFile https://github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz /tmp/src/v3.13.0.tar.gz
-tar -xf /tmp/src/v3.13.0.tar.gz -C /tmp/src
-cd /tmp/src/protobuf-3.13.0
+GetFile https://github.com/protocolbuffers/protobuf/archive/v3.15.8.tar.gz /tmp/src/v3.15.8.tar.gz
+tar -xf /tmp/src/v3.15.8.tar.gz -C /tmp/src
+cd /tmp/src/protobuf-3.15.8
 cmake ./cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Relwithdebinfo
 make -j$(getconf _NPROCESSORS_ONLN)
 make install

--- a/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_server_deps.sh
@@ -42,7 +42,7 @@ rm -rf /tmp/googletest
 echo "Installing protobuf from source"
 git clone https://github.com/protocolbuffers/protobuf.git
 cd protobuf
-git checkout v3.11.2
+git checkout v3.15.8
 mkdir b
 cd b
 cmake ../cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug


### PR DESCRIPTION
**Description**: 

Update protobuf to the latest version. The new one has an important change that it uses init_seg in MSVC to push initialization to an earlier phase. This will help ensure protobuf is fully initialized before onnxruntime's global variables get constructed.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- 
If without this change, onnxruntime either has memory leak, or crashes.

- If it fixes an open issue, please link to the issue here.
