### PR TITLE
Support negative indices and fix bound checking in symbolic shape inference for Slice

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1055,6 +1055,9 @@ class SymbolicShapeInference:
             """ normalizes a negative index to be in [0, bound) """
             try:
                 if not less_equal(0, index):
+                    if is_literal(index) and index <= -self.int_max_:
+                        # this case is handled separately
+                        return index
                     return bound + index
             except TypeError:
                 print("Cannot determine if {} < 0".format(index))

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -624,7 +624,7 @@ class SymbolicShapeInference:
                                           output_shape))
 
     def _infer_Concat(self, node):
-        if any([i in self.sympy_data_ for i in node.input]):
+        if any([i in self.sympy_data_ or i in self.initializers_ for i in node.input]):
             values = self._get_int_values(node)
             if all([v is not None for v in values]):
                 assert 0 == get_attribute(node, 'axis')

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -81,13 +81,6 @@ def sympy_reduce_product(x):
         value = x
     return value
 
-def handle_negative_index(index, bound):
-    try:
-        if index < 0:
-            return bound + index
-    except TypeError:
-        print("Cannot determine if {} < 0".format(index))
-    return index
 
 class SymbolicShapeInference:
     def __init__(self, int_max, auto_merge, guess_output_rank, verbose):
@@ -1039,6 +1032,15 @@ class SymbolicShapeInference:
             helper.make_tensor_value_info(node.output[0], onnx.TensorProto.INT64, []))
 
     def _infer_Slice(self, node):
+        def handle_negative_index(index, bound):
+            """ normalizes a negative index to be in [0, bound) """
+            try:
+                if index < 0:
+                    return bound + index
+            except TypeError:
+                print("Cannot determine if {} < 0".format(index))
+            return index
+
         if get_opset(self.out_mp_) <= 9:
             axes = get_attribute(node, 'axes')
             starts = get_attribute(node, 'starts')

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -300,7 +300,7 @@ class SymbolicShapeInference:
         for d in self._get_shape(node, idx):
             if type(d) == str:
                 sympy_shape.append(self.symbolic_dims_[d] if d in
-                                   self.symbolic_dims_ else sympy.Symbol(d, integer=True, positive=True))
+                                   self.symbolic_dims_ else sympy.Symbol(d, integer=True, nonnegative=True))
             else:
                 assert None != d
                 sympy_shape.append(d)
@@ -459,7 +459,7 @@ class SymbolicShapeInference:
             v = self.suggested_merge_[new_dim]
             new_dim = sympy.Integer(int(v)) if is_literal(v) else v
         else:
-            self.symbolic_dims_[new_dim] = sympy.Symbol(new_dim, integer=True, positive=True)
+            self.symbolic_dims_[new_dim] = sympy.Symbol(new_dim, integer=True, nonnegative=True)
         return new_dim
 
     def _new_symbolic_dim_from_output(self, node, out_idx=0, dim=0):
@@ -1275,6 +1275,7 @@ class SymbolicShapeInference:
                 assert s_merge in self.symbolic_dims_
                 self.symbolic_dims_[s] = self.symbolic_dims_[s_merge]
             else:
+                # Since inputs are not produced by other ops, we can assume positivity
                 self.symbolic_dims_[s] = sympy.Symbol(s, integer=True, positive=True)
         # create a temporary ModelProto for single node inference
         # note that we remove initializer to have faster inference

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1122,7 +1122,7 @@ class SymbolicShapeInference:
                 if is_literal(new_sympy_shape[i]) and is_literal(s):
                     s = max(0, min(s, new_sympy_shape[i]))
 
-                new_sympy_shape[i] = (e - s + t + (-1 if t > 0 else 1)) // t
+                new_sympy_shape[i] = sympy.simplify((e - s + t + (-1 if t > 0 else 1)) // t)
 
             self._update_computed_dims(new_sympy_shape)
 

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1032,10 +1032,20 @@ class SymbolicShapeInference:
             helper.make_tensor_value_info(node.output[0], onnx.TensorProto.INT64, []))
 
     def _infer_Slice(self, node):
+        def less_equal(x, y):
+            try:
+                return bool(x <= y)
+            except TypeError:
+                pass
+            try:
+                return bool(y >= x)
+            except TypeError:
+                return bool(y - x >= 0)
+
         def handle_negative_index(index, bound):
             """ normalizes a negative index to be in [0, bound) """
             try:
-                if index < 0:
+                if not less_equal(0, index):
                     return bound + index
             except TypeError:
                 print("Cannot determine if {} < 0".format(index))
@@ -1092,7 +1102,7 @@ class SymbolicShapeInference:
                         e = sympy.Min(e, new_sympy_shape[i])
                     else:
                         try:
-                            if (e - new_sympy_shape[i]) >= 0:
+                            if less_equal(new_sympy_shape[i], e):
                                 e = new_sympy_shape[i]
                         except Exception:
                             print('Unable to determine if {} <= {}, treat as equal'.format(e, new_sympy_shape[i]))

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -3,10 +3,15 @@
 
 # -*- coding: UTF-8 -*-
 import onnx
+from onnx import AttributeProto, TensorProto, GraphProto
 import os
 from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
 from pathlib import Path
 import unittest
+
+def unique_element(lst):
+    assert len(lst) == 1
+    return lst[0]
 
 class TestSymbolicShapeInference(unittest.TestCase):
     def test_symbolic_shape_infer(self):
@@ -21,6 +26,25 @@ class TestSymbolicShapeInference(unittest.TestCase):
                 auto_merge=True,
                 int_max=100000,
                 guess_output_rank=True)
+
+class TestSymbolicShapeInferenceForSlice(unittest.TestCase):
+    def test_flip(self):
+        starts = onnx.helper.make_tensor("starts", TensorProto.INT64, [1], [-1])
+        ends = onnx.helper.make_tensor("ends", TensorProto.INT64, [1], [-2**32])
+        axes = onnx.helper.make_tensor("axes", TensorProto.INT64, [1], [0])
+        steps = onnx.helper.make_tensor("steps", TensorProto.INT64, [1], [-1])
+        node_def = onnx.helper.make_node(
+            "Slice",
+            ["data", "starts", "ends", "axes", "steps"], ["output"]
+        )
+        data = onnx.helper.make_tensor_value_info("data", TensorProto.FLOAT, ["N"])
+        output = onnx.helper.make_tensor_value_info("data", TensorProto.FLOAT, ["output_dim"])
+        graph_def = onnx.helper.make_graph([node_def], "graph", [data], [output], initializer=[starts, ends, axes, steps])
+        model = SymbolicShapeInference.infer_shapes(onnx.helper.make_model(graph_def))
+        output = unique_element(model.graph.output)
+        dim = unique_element(output.type.tensor_type.shape.dim)
+        self.assertEqual(dim.dim_param, "N")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -90,10 +90,10 @@ class TestSymbolicShapeInferenceForSlice(unittest.TestCase):
         self.check_slice_of_concat(["N", "N"], "zero", "intmax", "two", "N")
 
     def test_symbolic_step(self):
-        self.check_slice_of_concat(["N", "N"], "zero", "intmax", "N", "floor((3*N - 1)/N)")
+        self.check_slice_of_concat(["N", "N"], "zero", "intmax", "N", "floor(-1/N) + 3")
 
     def test_symbolic_negative_step(self):
-        self.check_slice_of_concat(["N", "N"], "-one", "-intmax", "-N", "floor(-(1 - 3*N)/N)")
+        self.check_slice_of_concat(["N", "N"], "-one", "-intmax", "-N", "floor(-1/N) + 3")
 
     def test_flip(self):
         self.check_slice_of_concat(["N"], "-one", "-intmax", "-one", "N")


### PR DESCRIPTION
**Description**: 
 * Add `positive=True` for all symbolic variables
 * Add support for negative index

**Motivation and Context**
Currently symbolic shape inference for Slice has the following issues:
1. It does not support bound checking for a symbolic index (e.g., for `x[:L]`, it cannot determine if `L <= len(x)` even if `len(x) = 2 * L`)
2. It does not handle symbolic negative index (e.g., `x[:-L]`)

