### PR TITLE
Add qdq propagation support

### DIFF
--- a/onnxruntime/core/graph/graph_utils.h
+++ b/onnxruntime/core/graph/graph_utils.h
@@ -298,5 +298,32 @@ bool RemoveNodesWithOneOutputBottomUp(Graph& graph, const Node& node);
  * @returns NodeArg reference that contains the same TypeProto info as base_arg with generated different names.
 */
 NodeArg& CreateNodeArg(Graph& graph, const NodeArg& base_arg);
+
+// A class helps handle graph edges
+struct GraphEdge {
+  NodeIndex src_node;
+  NodeIndex dst_node;
+  int src_arg_index;
+  int dst_arg_index;
+  std::string arg_name;
+
+  GraphEdge(NodeIndex src_node, NodeIndex dst_node, int src_arg_index, int dst_arg_index, const std::string& arg_name);
+
+  // Constructs a GraphEdge given a node, an edge_end, and a boolean for the edge direction.
+  static GraphEdge CreateGraphEdge(const Node& node, const Node::EdgeEnd& edge_end, bool is_input_edge);
+
+  /** Returns a vector of the input GraphEdges of a node. */
+  static std::vector<GraphEdge> GetNodeInputEdges(const Node& node);
+
+  /** Returns a vector of the output GraphEdges of a node. */
+  static std::vector<GraphEdge> GetNodeOutputEdges(const Node& node);
+
+  /** Returns a vector of output GraphEdges of a node for the provided output index. */
+  static std::vector<GraphEdge> GetNodeOutputEdges(const Node& node, size_t index);
+
+  /** Removes a set of GraphEdges from the graph. */
+  static void RemoveGraphEdges(Graph& graph, const std::vector<GraphEdge>& edges);
+};
+
 }  // namespace graph_utils
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -39,6 +39,7 @@
 #include "core/optimizer/skip_layer_norm_fusion.h"
 #include "core/optimizer/slice_elimination.h"
 #include "core/optimizer/unsqueeze_elimination.h"
+#include "core/optimizer/qdq_transformer/qdq_propagation.h"
 #include "core/optimizer/qdq_transformer/qdq_s8_to_u8.h"
 #include "core/optimizer/qdq_transformer/qdq_transformer.h"
 #include "core/optimizer/qdq_transformer/relu_quantizelinear.h"
@@ -168,6 +169,7 @@ std::vector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
 
       if (!disable_quant_qdq) {
         transformers.emplace_back(onnxruntime::make_unique<QDQS8ToU8Transformer>(cpu_ep));
+        transformers.emplace_back(onnxruntime::make_unique<QDQPropagationTransformer>(cpu_ep));
         transformers.emplace_back(onnxruntime::make_unique<QDQTransformer>());
       }
 

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_conv.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_conv.cc
@@ -36,6 +36,16 @@ class QDQConvTransformer : public QDQOperatorTransformer {
 
     return true;
   }
+
+  bool Check(const std::vector<const Node*>& dq_nodes, const std::vector<const Node*>& q_nodes) const override {
+    if (!QDQOperatorTransformer::Check(dq_nodes, q_nodes)) {
+      return false;
+    }
+
+    // Currently QLinearConv only support activation type uint8_t
+    int32_t dt = dq_nodes[0]->InputDefs()[0]->TypeAsProto()->tensor_type().elem_type();
+    return dt == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT8;
+  }
 };
 
 DEFINE_QDQ_CREATOR(Conv, QDQConvTransformer)

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_matmul.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_matmul.cc
@@ -31,6 +31,16 @@ class QDQMatMulTransformer : public QDQOperatorTransformer {
         .SetExecutionProviderType(kCpuExecutionProvider);
     return true;
   }
+
+  bool Check(const std::vector<const Node*>& dq_nodes, const std::vector<const Node*>& q_nodes) const override {
+    if (!QDQOperatorTransformer::Check(dq_nodes, q_nodes)) {
+      return false;
+    }
+
+    // Currently QLinearConv only support activation type uint8_t
+    int32_t dt = dq_nodes[0]->InputDefs()[0]->TypeAsProto()->tensor_type().elem_type();
+    return dt == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT8;
+  }
 };
 
 DEFINE_QDQ_CREATOR(MatMul, QDQMatMulTransformer)

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.cc
@@ -1,0 +1,279 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "qdq_propagation.h"
+
+#include <deque>
+
+#include "core/graph/graph_utils.h"
+#include "core/optimizer/initializer.h"
+#include "core/optimizer/utils.h"
+
+namespace onnxruntime {
+
+static constexpr size_t QDQInputCountRequired = 3;
+static constexpr size_t QDQInputScaleIdx = 1;
+static constexpr size_t QDQInputZeroPointIdex = 2;
+
+static bool CanNodePropagate(const Node& node) {
+  return graph_utils::IsSupportedOptypeVersionAndDomain(node, "MaxPool", {12}) ||
+         graph_utils::IsSupportedOptypeVersionAndDomain(node, "Reshape", {5, 13}) ||
+         graph_utils::IsSupportedOptypeVersionAndDomain(node, "Transpose", {1, 13});
+}
+
+static bool TryCancelOutDQQPair(Graph& graph, Node& dq_node, Node& q_node) {
+  std::vector<NodeArg*>& dq_input_defs = dq_node.MutableInputDefs();
+  std::vector<NodeArg*>& q_input_defs = q_node.MutableInputDefs();
+  if (dq_input_defs.size() != QDQInputCountRequired ||
+      q_input_defs.size() != QDQInputCountRequired ||
+      !graph.GetNodeOutputsInGraphOutputs(q_node).empty()) {
+    return false;
+  }
+
+  const ONNX_NAMESPACE::TensorProto* dq_scale_tensor_proto = nullptr;
+  const ONNX_NAMESPACE::TensorProto* q_scale_tensor_proto = nullptr;
+  const ONNX_NAMESPACE::TensorProto* dq_zp_tensor_proto = nullptr;
+  const ONNX_NAMESPACE::TensorProto* q_zp_tensor_proto = nullptr;
+  if (!graph_utils::NodeArgIsConstant(graph, *dq_input_defs[QDQInputScaleIdx]) ||
+      !graph_utils::NodeArgIsConstant(graph, *q_input_defs[QDQInputScaleIdx]) ||
+      !graph_utils::NodeArgIsConstant(graph, *dq_input_defs[QDQInputZeroPointIdex]) ||
+      !graph_utils::NodeArgIsConstant(graph, *q_input_defs[QDQInputZeroPointIdex]) ||
+      !graph.GetInitializedTensor(dq_input_defs[QDQInputScaleIdx]->Name(), dq_scale_tensor_proto) ||
+      !graph.GetInitializedTensor(q_input_defs[QDQInputScaleIdx]->Name(), q_scale_tensor_proto) ||
+      !graph.GetInitializedTensor(dq_input_defs[QDQInputZeroPointIdex]->Name(), dq_zp_tensor_proto) ||
+      !graph.GetInitializedTensor(q_input_defs[QDQInputZeroPointIdex]->Name(), q_zp_tensor_proto)) {
+    return false;
+  }
+
+  Initializer q_zp(*q_zp_tensor_proto, graph.ModelPath());
+  Initializer q_scale(*q_scale_tensor_proto, graph.ModelPath());
+  Initializer dq_zp(*dq_zp_tensor_proto, graph.ModelPath());
+  Initializer dq_scale(*dq_scale_tensor_proto, graph.ModelPath());
+
+  if (*q_zp.data<int8_t>() != *dq_zp.data<int8_t>() ||
+      *q_scale.data<float>() != *dq_scale.data<float>() ||
+      dq_node.GetOutputEdgesCount() != 1) {
+    return false;
+  }
+
+  // remove edge between parent of DQ to DQ
+  std::pair<NodeIndex, int> input_edge_info{0, -1};
+  auto* dq_input_edge_0 = graph_utils::GetInputEdge(dq_node, 0);
+  if (dq_input_edge_0) {
+    input_edge_info.first = dq_input_edge_0->GetNode().Index();
+    input_edge_info.second = dq_input_edge_0->GetSrcArgIndex();
+    graph.RemoveEdge(dq_input_edge_0->GetNode().Index(), dq_node.Index(), dq_input_edge_0->GetSrcArgIndex(), dq_input_edge_0->GetDstArgIndex());
+  }
+
+  graph_utils::RemoveNodeOutputEdges(graph, dq_node);  // Remove DQ node output edges
+
+  auto output_edges = graph_utils::GraphEdge::GetNodeOutputEdges(q_node, 0);
+  graph_utils::RemoveNodeOutputEdges(graph, q_node);  // Remove Q node output edges
+  for (auto& output_edge : output_edges) {
+    // set input NodeArg of Q's children to the 1st input of DQ
+    graph.GetNode(output_edge.dst_node)->MutableInputDefs()[output_edge.dst_arg_index] = dq_input_defs[0];
+
+    // add edge between parent of DQ to children of Q
+    if (input_edge_info.second != -1) {
+      graph.AddEdge(input_edge_info.first, output_edge.dst_node, input_edge_info.second, output_edge.dst_arg_index);
+    }
+  }
+
+  graph.RemoveNode(dq_node.Index());
+  graph.RemoveNode(q_node.Index());
+  return true;
+}
+
+// A helper function that swap the relationship of 2 nodes.
+// @param up_node The original parent node
+// @param down_node The original child node
+// after calling the function, the up_node will become the child of down_node
+// Assumptions of this function are:
+// 1. up_node only has one Edge that points to down_node and its output is not graph output.
+// 2. NodeArg slots of the edge between up_node and down_node are (0, 0)
+static void SwapAdjacentNodes(Graph& graph, Node& up_node, Node& down_node) {
+  ORT_ENFORCE(optimizer_utils::CheckOutputEdges(graph, up_node, 1),
+              "up_node should have only one Edge that points to down_node and its output is not graph output");
+
+  auto edge_it = up_node.OutputEdgesBegin();
+  ORT_ENFORCE(edge_it->GetDstArgIndex() == 0 &&
+                  edge_it->GetSrcArgIndex() == 0 &&
+                  edge_it->GetNode().Index() == down_node.Index(),
+              "up_node should be parent of down_node and NodeArg slots of the edge between up_node and down_node should be (0, 0).");
+
+  // ************** Remove edges **************
+  // Remove the edge between parent of up_node and up_node, and keep the info of parent of up_node
+  std::pair<NodeIndex, int> up_node_input_edge_info{0, -1};
+  auto* up_node_input_edge_0 = graph_utils::GetInputEdge(up_node, 0);
+  if (up_node_input_edge_0) {
+    up_node_input_edge_info.first = up_node_input_edge_0->GetNode().Index();
+    up_node_input_edge_info.second = up_node_input_edge_0->GetSrcArgIndex();
+    graph.RemoveEdge(up_node_input_edge_0->GetNode().Index(),
+                     up_node.Index(),
+                     up_node_input_edge_0->GetSrcArgIndex(),
+                     up_node_input_edge_0->GetDstArgIndex());
+  }
+
+  auto down_node_output_edges_info = graph_utils::GraphEdge::GetNodeOutputEdges(down_node);
+  graph_utils::RemoveNodeOutputEdges(graph, up_node);
+  graph_utils::RemoveNodeOutputEdges(graph, down_node);
+
+  // *********** Rebuild NodeArg ****************/
+  down_node.MutableInputDefs()[0] = up_node.MutableInputDefs()[0];
+  up_node.MutableOutputDefs()[0] = down_node.MutableOutputDefs()[0];
+
+  NodeArg* new_node_arg = &graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("SwapAdjacentNodes"), nullptr);
+  down_node.MutableOutputDefs()[0] = new_node_arg;
+  up_node.MutableInputDefs()[0] = new_node_arg;
+
+  // *********** Rebuild Edges ****************/
+  if (up_node_input_edge_info.second >= 0) {
+    graph.AddEdge(up_node_input_edge_info.first, down_node.Index(), up_node_input_edge_info.second, 0);
+  }
+
+  graph.AddEdge(down_node.Index(), up_node.Index(), 0, 0);
+
+  for (auto output_edge_info : down_node_output_edges_info) {
+    graph.AddEdge(up_node.Index(), output_edge_info.dst_node, 0, output_edge_info.dst_arg_index);
+  }
+}
+
+bool QDQPropagationTransformer::PropagateDQForward(Graph& graph) const {
+  bool is_modified = false;
+
+  GraphViewer graph_viewer(graph);
+  const auto& node_topology_list = graph_viewer.GetNodesInTopologicalOrder();
+
+  for (auto node_index : node_topology_list) {
+    auto* dq_node_ptr = graph.GetNode(node_index);
+    if (dq_node_ptr == nullptr)
+      continue;  // node removed as part of an earlier fusion
+
+    Node& dq_node = *dq_node_ptr;
+
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(dq_node, "DequantizeLinear", {10, 13}) ||
+        !graph_utils::IsSupportedProvider(dq_node, GetCompatibleExecutionProviders()) ||
+        !optimizer_utils::CheckOutputEdges(graph, dq_node, 1)) {
+      continue;
+    }
+
+    std::vector<NodeArg*>& dq_input_defs = dq_node.MutableInputDefs();
+    if (dq_input_defs.size() != QDQInputCountRequired) {
+      continue;
+    }
+
+    const ONNX_NAMESPACE::TensorProto* dq_zp_tensor_proto = nullptr;
+    const ONNX_NAMESPACE::TensorProto* dq_scale_tensor_proto = nullptr;
+    if (!graph_utils::NodeArgIsConstant(graph, *dq_input_defs[QDQInputScaleIdx]) ||
+        !graph_utils::NodeArgIsConstant(graph, *dq_input_defs[QDQInputZeroPointIdex]) ||
+        !graph.GetInitializedTensor(dq_input_defs[QDQInputScaleIdx]->Name(), dq_scale_tensor_proto) ||
+        !graph.GetInitializedTensor(dq_input_defs[QDQInputZeroPointIdex]->Name(), dq_zp_tensor_proto)) {
+      continue;
+    }
+
+    do {
+      Node& next_node = *graph.GetNode(dq_node.OutputNodesBegin()->Index());
+      if (!CanNodePropagate(next_node)) {
+        break;
+      }
+      SwapAdjacentNodes(graph, dq_node, next_node);
+      is_modified = true;
+    } while (optimizer_utils::CheckOutputEdges(graph, dq_node, 1));
+
+    // Cancel out DQ/Q pair
+    Node& q_node = *graph.GetNode(dq_node.OutputNodesBegin()->Index());
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(q_node, "QuantizeLinear", {10, 13}) ||
+        !graph_utils::IsSupportedProvider(q_node, GetCompatibleExecutionProviders())) {
+      continue;
+    }
+
+    is_modified = is_modified || TryCancelOutDQQPair(graph, dq_node, q_node);
+  }
+
+  return is_modified;
+}
+
+bool QDQPropagationTransformer::PropagateQBackward(Graph& graph) const {
+  bool is_modified = false;
+
+  GraphViewer graph_viewer(graph);
+  const auto& node_topology_list = graph_viewer.GetNodesInTopologicalOrder();
+
+  for (auto node_index : node_topology_list) {
+    auto* q_node_ptr = graph.GetNode(node_index);
+    if (q_node_ptr == nullptr)
+      continue;  // node removed as part of an earlier fusion
+
+    Node& q_node = *q_node_ptr;
+
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(q_node, "QuantizeLinear", {10, 13}) ||
+        !graph_utils::IsSupportedProvider(q_node, GetCompatibleExecutionProviders())) {
+      continue;
+    }
+
+    std::vector<NodeArg*>& q_input_defs = q_node.MutableInputDefs();
+    if (q_input_defs.size() != QDQInputCountRequired) {
+      continue;
+    }
+
+    const ONNX_NAMESPACE::TensorProto* q_zp_tensor_proto = nullptr;
+    const ONNX_NAMESPACE::TensorProto* q_scale_tensor_proto = nullptr;
+    if (!graph_utils::NodeArgIsConstant(graph, *q_input_defs[QDQInputScaleIdx]) ||
+        !graph_utils::NodeArgIsConstant(graph, *q_input_defs[QDQInputZeroPointIdex]) ||
+        !graph.GetInitializedTensor(q_input_defs[QDQInputScaleIdx]->Name(), q_scale_tensor_proto) ||
+        !graph.GetInitializedTensor(q_input_defs[QDQInputZeroPointIdex]->Name(), q_zp_tensor_proto)) {
+      continue;
+    }
+
+    do {
+      if (q_node.InputNodesBegin() == q_node.InputNodesEnd()) {
+        break;
+      }
+      Node& prev_node = *graph.GetNode(q_node.InputNodesBegin()->Index());
+      if (!optimizer_utils::CheckOutputEdges(graph, prev_node, 1) ||
+          !CanNodePropagate(prev_node)) {
+        break;
+      }
+
+      SwapAdjacentNodes(graph, prev_node, q_node);
+      is_modified = true;
+    } while (true);
+
+    // Cancel out DQ/Q pair
+    if (q_node.InputNodesBegin() == q_node.InputNodesEnd()) {
+      continue;
+    }
+    Node& dq_node = *graph.GetNode(q_node.InputNodesBegin()->Index());
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(dq_node, "DequantizeLinear", {10, 13}) ||
+        !graph_utils::IsSupportedProvider(dq_node, GetCompatibleExecutionProviders()) ||
+        !optimizer_utils::CheckOutputEdges(graph, dq_node, 1)) {
+      continue;
+    }
+
+    is_modified = is_modified || TryCancelOutDQQPair(graph, dq_node, q_node);
+  }
+
+  return is_modified;
+}
+
+Status QDQPropagationTransformer::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
+  GraphViewer graph_viewer(graph);
+  const auto& node_topology_list = graph_viewer.GetNodesInTopologicalOrder();
+
+  for (auto node_index : node_topology_list) {
+    auto* node_ptr = graph.GetNode(node_index);
+    if (node_ptr == nullptr)
+      continue;  // node removed as part of an earlier fusion
+
+    ORT_RETURN_IF_ERROR(Recurse(*node_ptr, modified, graph_level, logger));
+  }
+
+  while (PropagateQBackward(graph) || PropagateDQForward(graph)) {
+  }
+
+  modified = true;
+
+  return Status::OK();
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/optimizer/graph_transformer.h"
+
+namespace onnxruntime {
+
+/**
+    @Class QDQPropagationTransformer
+
+    Propagate Q backward, DQ forward and remove DQ/Q pair
+*/
+class QDQPropagationTransformer : public GraphTransformer {
+ public:
+  QDQPropagationTransformer(const std::unordered_set<std::string>& compatible_execution_providers = {}) noexcept
+      : GraphTransformer("QDQPropagationTransformer", compatible_execution_providers) {
+  }
+
+ private:
+  Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
+  bool PropagateDQForward(Graph& graph) const;
+  bool PropagateQBackward(Graph& graph) const;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/graph_transform_test_builder.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_builder.cc
@@ -43,13 +43,17 @@ void TransformerTester(const std::function<void(ModelTestBuilder& helper)>& buil
     session_options.graph_optimization_level = level;
     InferenceSessionWrapper session{session_options, GetEnvironment()};
     ASSERT_TRUE(session.Load(model_data.data(), static_cast<int>(model_data.size())).IsOK());
-    ASSERT_TRUE(session.Initialize().IsOK());
+    auto status = session.Initialize();
+    if (!status.IsOK()) {
+      std::cout << "Model initialized failed with status message: " << status.ErrorMessage() << std::endl;
+    }
+    ASSERT_TRUE(status.IsOK());
 
     RunOptions run_options;
-    auto status = session.Run(run_options,
-                              helper.feeds_,
-                              helper.output_names_,
-                              &fetches);
+    status = session.Run(run_options,
+                         helper.feeds_,
+                         helper.output_names_,
+                         &fetches);
     if (!status.IsOK()) {
       std::cout << "Run failed with status message: " << status.ErrorMessage() << std::endl;
     }

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -315,6 +315,43 @@ TEST(QDQTransformerTests, MatMul_No_Fusion) {
   test_case({22, 11, 13, 15}, {15, 13});
 }
 
+TEST(QDQTransformerTests, MatMul_1st_Input_Int8) {
+  auto test_case = [&](const std::vector<int64_t>& input1_shape, const std::vector<int64_t>& input2_shape) {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      auto* input1_arg = builder.MakeInput<int8_t>(input1_shape, -128, 127);
+      auto* input2_arg = builder.MakeInput<float>(input2_shape, -1.f, 1.f);
+      auto* output_arg = builder.MakeOutput();
+
+      // add DQ with type int8
+      auto* dq_output_1 = builder.MakeIntermediate();
+      builder.AddDequantizeLinearNode<int8_t>(input1_arg, .004f, 1, dq_output_1);
+
+      // add QDQ + MatMul
+      auto* matmul_output = builder.MakeIntermediate();
+      auto* dq_matmul_output2 = AddQDQNodePair<uint8_t>(builder, input2_arg, .004f, 129);
+      builder.AddNode("MatMul", {dq_output_1, dq_matmul_output2}, {matmul_output});
+
+      // add Q
+      builder.AddQuantizeLinearNode<uint8_t>(matmul_output, .0039f, 135, output_arg);
+    };
+
+    auto check_matmul_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["MatMul"], 1);
+      EXPECT_EQ(op_to_count["QLinearMatMul"], 0);
+      EXPECT_EQ(op_to_count["QuantizeLinear"], 2);
+      EXPECT_EQ(op_to_count["DequantizeLinear"], 2);
+    };
+
+    TransformerTester(build_test_case, check_matmul_graph, TransformerLevel::Level1, TransformerLevel::Level2);
+  };
+
+  // Test the basic case of a single 1D/2D/3D convolution.
+  test_case({12, 37}, {37, 12});
+  test_case({23, 13, 13}, {13, 13});
+  test_case({22, 11, 13, 15}, {15, 13});
+}
+
 TEST(QDQTransformerTests, ConvRelu) {
   auto test_case = [&](const std::vector<int64_t>& input_shape, const std::vector<int64_t>& weights_shape, bool is_zp_zero) {
     auto build_test_case = [&](ModelTestBuilder& builder) {
@@ -468,6 +505,67 @@ TEST(QDQTransformerTests, ConvAveragePoolReshape_Int8) {
       EXPECT_EQ(op_to_count["Reshape"], 1);
       EXPECT_EQ(op_to_count["QuantizeLinear"], 1);
       EXPECT_EQ(op_to_count["DequantizeLinear"], 1);
+    };
+
+    TransformerTester(build_test_case,
+                      check_mp_reshape_graph,
+                      TransformerLevel::Level1,
+                      TransformerLevel::Level2,
+                      12 /*opset_version*/,
+                      0.01f /*per_sample_tolerance*/,
+                      0.01f /*relative_per_sample_tolerance*/);
+  };
+
+  // Test the basic case of a single 1D/2D/3D convolution.
+  test_case({1, 12, 37}, {32, 12, 5});
+  test_case({1, 23, 13, 13}, {30, 23, 3, 3});
+  test_case({1, 22, 11, 13, 15}, {30, 22, 5, 3, 3});
+}
+
+TEST(QDQTransformerTests, ConvAveragePoolReshape_Int8_Fail) {
+  auto test_case = [&](const std::vector<int64_t>& input_shape, const std::vector<int64_t>& weights_shape) {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      auto* input_arg = builder.MakeInput<int8_t>(input_shape, -128, 127);
+      auto* output_arg = builder.MakeOutput();
+      auto* weight = builder.MakeInitializer<uint8_t>(weights_shape, 0, 255);
+
+      // add DQ + Conv
+      auto* dq_output = builder.MakeIntermediate();
+      auto* dq_w_output = builder.MakeIntermediate();
+      auto* conv_output = builder.MakeIntermediate();
+      builder.AddDequantizeLinearNode<int8_t>(input_arg, .004f, 1, dq_output);
+      builder.AddDequantizeLinearNode<uint8_t>(weight, .003f, 118, dq_w_output);
+      builder.AddConvNode(dq_output, dq_w_output, conv_output);
+
+      // add QDQ + AveragePool
+      auto* dq_maxpool_output = AddQDQNodePair<int8_t>(builder, conv_output, .0035f, 7);
+      auto* maxpool_output = builder.MakeIntermediate();
+      Node& pool_node = builder.AddNode("AveragePool", {dq_maxpool_output}, {maxpool_output});
+      std::vector<int64_t> pads((weights_shape.size() - 2) * 2, 1);
+      pool_node.AddAttribute("pads", pads);
+      std::vector<int64_t> kernel_shape(weights_shape.size() - 2, 3);
+      pool_node.AddAttribute("kernel_shape", kernel_shape);
+
+      // add QDQ + Reshape
+      auto* dq_reshape_output = AddQDQNodePair<int8_t>(builder, maxpool_output, .0035f, 7);
+      auto* reshape_shape = builder.Make1DInitializer<int64_t>({-1});
+      auto* reshape_output = builder.MakeIntermediate();
+      builder.AddNode("Reshape", {dq_reshape_output, reshape_shape}, {reshape_output});
+
+      // add Q + DQ
+      auto* q_output = builder.MakeIntermediate();
+      builder.AddQuantizeLinearNode<uint8_t>(reshape_output, .0035f, 135, q_output);
+      builder.AddDequantizeLinearNode<uint8_t>(q_output, .0035f, 135, output_arg);
+    };
+
+    auto check_mp_reshape_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["Conv"], 1);
+      EXPECT_EQ(op_to_count["QLinearConv"], 0);
+      EXPECT_EQ(op_to_count["com.microsoft.QLinearAveragePool"], 1);
+      EXPECT_EQ(op_to_count["Reshape"], 1);
+      EXPECT_EQ(op_to_count["QuantizeLinear"], 1);
+      EXPECT_EQ(op_to_count["DequantizeLinear"], 3);
     };
 
     TransformerTester(build_test_case,
@@ -742,6 +840,45 @@ TEST(QDQTransformerTests, QDQPropagation_QDQCancelOut) {
 
   // Test the basic case of a single 1D/2D/3D convolution.
   test_case({1, 13, 13, 23}, 4, {0, 3, 1, 2});
+}
+
+TEST(QDQTransformerTests, QDQPropagation_QDQ_CancelOut_More) {
+  auto test_case = [&](const std::vector<int64_t>& input_shape, bool same_scale, bool same_zp) {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      auto* input_arg = builder.MakeInput<float>(input_shape, -1.f, 1.f);
+      auto* output_arg = builder.MakeOutput();
+
+      // add QDQ
+      auto* qdq_output = AddQDQNodePair<uint8_t>(builder, input_arg, .004f, 129);
+
+      // Reshape
+      auto* reshape_output = builder.MakeIntermediate();
+      auto* reshape_shape = builder.Make1DInitializer<int64_t>({-1, 0});
+      builder.AddNode("Reshape", {qdq_output, reshape_shape}, {reshape_output});
+
+      // add Q
+      builder.AddQuantizeLinearNode<uint8_t>(reshape_output, same_scale ? .004f : .0039f, same_zp ? 129 : 128, output_arg);
+    };
+
+    auto check_mp_reshape_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["Reshape"], 1);
+      EXPECT_EQ(op_to_count["QuantizeLinear"], same_scale && same_zp ? 1 : 2);
+      EXPECT_EQ(op_to_count["DequantizeLinear"], same_scale && same_zp ? 0 : 1);
+    };
+
+    TransformerTester(build_test_case,
+                      check_mp_reshape_graph,
+                      TransformerLevel::Level1,
+                      TransformerLevel::Level2,
+                      12 /*opset_version*/);
+  };
+
+  // Test the basic case of a single 1D/2D/3D convolution.
+  test_case({1, 13, 13, 23}, false, false);
+  test_case({1, 13, 13, 23}, false, true);
+  test_case({1, 13, 13, 23}, true, false);
+  test_case({1, 13, 13, 23}, true, true);
 }
 
 #endif  // DISABLE_CONTRIB_OPS


### PR DESCRIPTION
**Description**: Describe your changes.
Add qdq propagation support. It will propagate Q backward and DQ forward on operators: MaxPool, Reshape, Transpose. More operators can be added as we support more and more linear quantized ops.
