### PR TITLE
Re-enable fp16-inception-v1 WinML model test

### DIFF
--- a/winml/test/model/skip_model_tests.h
+++ b/winml/test/model/skip_model_tests.h
@@ -130,7 +130,5 @@ std::unordered_map<std::string, std::string> disabledGpuTests(
 */
 std::unordered_map<std::string, std::pair<std::string, std::string>> disabledGpuAdapterTests(
     {
-      {"fp16_inception_v1_opset7", std::make_pair("AMD Radeon VII|Intel\\(R\\) (UHD )?Graphics|NVIDIA", "Bug 31144419: Results of fp16_inception_v1 opset7 and opset8 aren't accurate enough on AMD Radeon VII & Intel(R) UHD Graphics 630 & NVIDIA https://microsoft.visualstudio.com/OS/_workitems/edit/31144419")},
-      {"fp16_inception_v1_opset8", std::make_pair("AMD Radeon VII|Intel\\(R\\) (UHD )?Graphics|NVIDIA", "Bug 31144419: Results of fp16_inception_v1 opset7 and opset8 aren't accurate enough on AMD Radeon VII & Intel(R) UHD Graphics 630 & NVIDIA https://microsoft.visualstudio.com/OS/_workitems/edit/31144419")},
       {"candy_opset9", std::make_pair("Intel\\(R\\) (UHD )?Graphics", "Bug 31652854: Results of candy_opset9 aren't accurate enough on Intel Graphics https://microsoft.visualstudio.com/OS/_workitems/edit/31652854")},
     });


### PR DESCRIPTION
Ran the WinML test model "fp16-inception-v1" on all 3 anticipated graphics card (AMD Radeon VII & Intel(R) UHD Graphics 630 & NVIDIA) and the test successfully passed for opset 7 and opset 8 without any tolerance failure.
Thus re-enabling this test by removing it from the _skip_model_tests.h_  