### PR TITLE
Remove thread pool's cancel method and suppress some warnings

### DIFF
--- a/onnxruntime/core/platform/env.h
+++ b/onnxruntime/core/platform/env.h
@@ -48,7 +48,6 @@ using FileOffsetType = off_t;
 
 class EnvThread {
  public:
-  virtual void OnCancel() = 0;
   virtual ~EnvThread() = default;
 };
 

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -154,11 +154,6 @@ class PosixThread : public EnvThread {
 #endif
   }
 
-  // This function is called when the threadpool is cancelled.
-  // TODO: Find a way to avoid calling TerminateThread
-  void OnCancel() override {
-  }
-
  private:
   static void* ThreadMain(void* param) {
     std::unique_ptr<Param> p((Param*)param);
@@ -167,7 +162,7 @@ class PosixThread : public EnvThread {
       p->start_address(p->index, p->param);
     }
     ORT_CATCH(const std::exception&) {
-      p->param->Cancel();
+      //ignore any exceptions
     }
     return nullptr;
   }

--- a/onnxruntime/core/platform/windows/debug_alloc.cc
+++ b/onnxruntime/core/platform/windows/debug_alloc.cc
@@ -77,7 +77,7 @@ struct SymbolHelper {
       return;
     }
 
-    _snprintf_s(buffer, _TRUNCATE, "%s(%d): %s", line.FileName, line.LineNumber, symbol.Name);
+    _snprintf_s(buffer, _TRUNCATE, "%s(%d): %s", line.FileName, static_cast<int>(line.LineNumber), symbol.Name);
     string.append(buffer);
   }
 
@@ -233,7 +233,7 @@ Memory_LeakCheck::~Memory_LeakCheck() {
 
     std::string string;
     char buffer[1024];
-    _snprintf_s(buffer, _TRUNCATE, "%d bytes of memory leaked in %d allocations", leaked_bytes, leak_count);
+    _snprintf_s(buffer, _TRUNCATE, "%d bytes of memory leaked in %d allocations", static_cast<int>(leaked_bytes), static_cast<int>(leak_count));
     string.append(buffer);
 
     std::cout << "\n----- MEMORY LEAKS: " << string.c_str() << "\n";

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -64,16 +64,12 @@ class WindowsThread : public EnvThread {
     FAIL_FAST_LAST_ERROR_IF(waitStatus == WAIT_FAILED);
   }
 
-  // This function is called when the threadpool is cancelled.
-  // TODO: Find a way to avoid calling TerminateThread
-  void OnCancel() {
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-    TerminateThread(hThread.get(), 1);
-#endif
-  }
 
  private:
   typedef HRESULT(WINAPI* SetThreadDescriptionFunc)(HANDLE hThread, PCWSTR lpThreadDescription);
+
+#pragma warning(push)
+#pragma warning(disable : 6387)
   static unsigned __stdcall ThreadMain(void* param) {
     std::unique_ptr<Param> p((Param*)param);
     // TODO: should I try to use SetThreadSelectedCpuSets?
@@ -82,9 +78,11 @@ class WindowsThread : public EnvThread {
 #if WINVER >= _WIN32_WINNT_WIN10
     constexpr SetThreadDescriptionFunc pSetThrDesc = SetThreadDescription;
 #elif WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+    HMODULE kernelModule = GetModuleHandle(TEXT("kernel32.dll"));
     // kernel32.dll is always loaded
+    assert(kernelModule != nullptr);
     auto pSetThrDesc =
-        (SetThreadDescriptionFunc)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "SetThreadDescription");
+        (SetThreadDescriptionFunc)GetProcAddress(kernelModule, "SetThreadDescription");
 #else
     constexpr SetThreadDescriptionFunc pSetThrDesc = nullptr;
 #endif
@@ -107,6 +105,8 @@ class WindowsThread : public EnvThread {
     }
     return ret;
   }
+#pragma warning(pop)
+
   unsigned threadID = 0;
   wil::unique_handle hThread;
 };

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -782,9 +782,8 @@ void ResizeImpl(
             reinterpret_cast<LinearMappingInfo*>(dims_mapping));
         return;
       }
-
+      ORT_THROW("Only bilinear/trilinear and bicubic modes are supported in Resize");
       break;
-
     case UpsampleMode::CUBIC:
       if (is_2D) {
         _ResizeCubicCoordinateMapping<T><<<blocksPerDimsMappingGrid, 32, 0, stream>>>(
@@ -804,6 +803,9 @@ void ResizeImpl(
             reinterpret_cast<CubicMappingInfo*>(dims_mapping));
         return;
       }
+      ORT_THROW("Only bilinear/trilinear and bicubic modes are supported in Resize");
+    case UpsampleMode::NN:
+      ORT_THROW("Only bilinear/trilinear and bicubic modes are supported in Resize");
   }
 }
 

--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -8,8 +8,17 @@
 #include <mutex>
 #include "core/providers/shared/common.h"
 
+#ifndef _Ret_notnull_
+#define _Ret_notnull_
+#endif
+
+
+#ifndef _Post_writable_byte_size_
+#define _Post_writable_byte_size_(n)
+#endif
+
 // Override default new/delete so that we match the host's allocator
-void* operator new(size_t n) { return Provider_GetHost()->HeapAllocate(n); }
+_Ret_notnull_ _Post_writable_byte_size_(n) void* operator new(size_t n) { return Provider_GetHost()->HeapAllocate(n); }
 void operator delete(void* p) { return Provider_GetHost()->HeapFree(p); }
 void operator delete(void* p, size_t /*size*/) { return Provider_GetHost()->HeapFree(p); }
 


### PR DESCRIPTION
**Description**: 

Remove thread pool's cancel method and suppress some warnings

**Motivation and Context**
- Why is this change required? What problem does it solve?

No one uses the cancel method, and it is only partially implemented. It was added by me. 

And fix some warnings so that I can add VC static analyzer to our CI build.

- If it fixes an open issue, please link to the issue here.
