### PR TITLE
Increase unit tests timeout to 2 hours

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1380,7 +1380,7 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
                      source_dir, 'cmake\\codeconv.runsettings')] + executables,
                 cwd=cwd2, dll_path=dll_path)
         else:
-            ctest_cmd = [ctest_path, "--build-config", config, "--verbose", "--timeout", "3600"]
+            ctest_cmd = [ctest_path, "--build-config", config, "--verbose", "--timeout", "7200"]
             run_subprocess(ctest_cmd, cwd=cwd, dll_path=dll_path)
 
         if args.enable_pybind:

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-ci-pipeline.yml
@@ -3,7 +3,7 @@ jobs:
   pool: Linux-GPU-CUDA10
   variables:
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '1'
-  timeoutInMinutes: 90
+  timeoutInMinutes: 180
   steps:
     
     - template: templates/run-docker-build-steps.yml


### PR DESCRIPTION
Because TRT is timed out.

**Description**: Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
