### PR TITLE
Add iOS CoreML CI, and speedup iOS CI run

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1216,12 +1216,12 @@ def run_android_tests(args, source_dir, config, cwd):
 
 
 def run_ios_tests(args, source_dir, config, cwd):
-    cpr = run_subprocess(["xcodebuild", "test", "-project", "./onnxruntime.xcodeproj",
+    cpr = run_subprocess(["xcodebuild", "test-without-building", "-project", "./onnxruntime.xcodeproj",
                           "-configuration", config,
                           "-scheme",  "onnxruntime_test_all_xc", "-destination",
                           "platform=iOS Simulator,OS=latest,name=iPhone SE (2nd generation)"], cwd=cwd)
     if cpr.returncode == 0:
-        cpr = run_subprocess(["xcodebuild", "test", "-project", "./onnxruntime.xcodeproj",
+        cpr = run_subprocess(["xcodebuild", "test-without-building", "-project", "./onnxruntime.xcodeproj",
                               "-configuration", config,
                               "-scheme",  "onnxruntime_shared_lib_test_xc", "-destination",
                               "platform=iOS Simulator,OS=latest,name=iPhone SE (2nd generation)"], cwd=cwd)

--- a/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
@@ -5,6 +5,25 @@ jobs:
   timeoutInMinutes: 120
   steps:
     - script: |
-        sdkpath=`xcrun --sdk iphonesimulator --show-sdk-path`
-        python3 $(Build.SourcesDirectory)/tools/ci_build/build.py --build_dir iOS --ios --ios_sysroot $sdkpath --osx_arch x86_64 --apple_deploy_target 12.1 --use_xcode --config RelWithDebInfo --parallel
-      displayName: Build onnxruntime for iOS x86_64 and run tests using simulator
+        python3 $(Build.SourcesDirectory)/tools/ci_build/build.py \
+          --build_dir build/iOS_cpu \
+          --ios \
+          --ios_sysroot iphonesimulator  \
+          --osx_arch x86_64 \
+          --apple_deploy_target 12.1 \
+          --use_xcode \
+          --config RelWithDebInfo \
+          --parallel
+      displayName: (CPU EP) Build onnxruntime for iOS x86_64 and run tests using simulator
+    - script: |
+        python3 $(Build.SourcesDirectory)/tools/ci_build/build.py \
+          --build_dir build/iOS_coreml \
+          --use_coreml \
+          --ios \
+          --ios_sysroot iphonesimulator  \
+          --osx_arch x86_64 \
+          --apple_deploy_target 12.1 \
+          --use_xcode \
+          --config RelWithDebInfo \
+          --parallel
+      displayName: (CoreML EP) Build onnxruntime for iOS x86_64 and run tests using simulator


### PR DESCRIPTION
**Description**: Add iOS CoreML EP CI, and speedup iOS CI run

**Motivation and Context**
- Need add CI for CoreML EP for iOS
- Made a small change to the current iOS CI test run script to speed up the iOS CI run, by avoid double build in the build and test phases
