### PR TITLE
increase timeout for nodejs binding test

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1482,7 +1482,7 @@ def nuphar_run_python_tests(build_dir, configs):
 
 
 def run_nodejs_tests(nodejs_binding_dir):
-    args = ['npm', 'test', '--', '--timeout=2000']
+    args = ['npm', 'test', '--', '--timeout=10000']
     if is_windows():
         args = ['cmd', '/c'] + args
     run_subprocess(args, cwd=nodejs_binding_dir)


### PR DESCRIPTION
**Description**: recent change updated onnx to v14, enables node spec tests (test_tril* and test_triu*) for operator `Trilu`. Currently triu implementation is slow, causing running test_triu* tests close to old 2 second timeout, which generate some build failure due to timeout. This change increased the timeout for each test in node spec test.