### PR TITLE
Add support for ORTModule to execute the graph when ONNX drops unused…

### DIFF
--- a/orttraining/orttraining/python/training/_checkpoint_storage.py
+++ b/orttraining/orttraining/python/training/_checkpoint_storage.py
@@ -1,6 +1,7 @@
+# -------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-# _checkpoint_storage.py
+# --------------------------------------------------------------------------
 
 import h5py
 from collections.abc import Mapping

--- a/orttraining/orttraining/python/training/_ortmodule_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/_ortmodule_graph_execution_manager.py
@@ -231,6 +231,7 @@ class GraphExecutionManager(ABC):
         # NOTE: Inputs may contain tensors that have attributes preventing their deepcopy (example grad_fn).
         # Therefore, deepcopy only the data component of the input tensors for export.
         sample_inputs_copy, sample_kwargs_copy = _io.deepcopy_model_input(*inputs, **kwargs)
+        # NOTE: Flattening the input will change the 'input schema', resulting in a re-export
         sample_inputs_as_tuple = tuple(self._input_info.flatten(sample_inputs_copy, sample_kwargs_copy))
         # Ops behaving differently under train/eval mode need to exported with the
         # correct training flag to reflect the expected behavior.

--- a/orttraining/orttraining/python/training/_ortmodule_inference_manager.py
+++ b/orttraining/orttraining/python/training/_ortmodule_inference_manager.py
@@ -58,15 +58,17 @@ class InferenceManager(GraphExecutionManager):
         user_outputs, _ = _run_forward(self._execution_agent,
                                        self._optimized_onnx_model,
                                        self._device,
-                                       *_io._convert_input_to_list(self._flattened_module.named_parameters(),
-                                                                   self._graph_info.user_input_names,
-                                                                   self._flattened_module.named_buffers(),
-                                                                   inputs,
-                                                                   kwargs))
+                                       *_io._combine_input_buffers_initializers(
+                                           self._flattened_module.named_parameters(),
+                                           self._graph_info.user_input_names,
+                                           self._input_info,
+                                           self._flattened_module.named_buffers(),
+                                           inputs,
+                                           kwargs))
 
-        return _io.populate_user_output_from_schema_and_outputs(self._module_output_schema,
-                                                                self._graph_info.user_output_names,
-                                                                user_outputs)
+        return _io.unflatten_user_output(self._module_output_schema,
+                                         self._graph_info.user_output_names,
+                                         user_outputs)
 
     def _build_graph(self):
         """Build an optimized inference graph using the module_graph_builder"""

--- a/orttraining/orttraining/python/training/_ortmodule_io.py
+++ b/orttraining/orttraining/python/training/_ortmodule_io.py
@@ -1,3 +1,8 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
 from collections import abc
 import copy
 import inspect
@@ -33,17 +38,21 @@ class _InputInfo(object):
             \tKeyword names:    {self.keyword_names}'''
 
     def flatten(self, args, kwargs):
+        '''Flatten args and kwargs in a single tuple of tensors with strict ordering'''
+
         ret = list(args)
         for _, kwarg in kwargs.items():
             ret.append(kwarg)
         return tuple(ret)
 
     def unflatten(self, flat_args):
+        '''Unflatten tuple of tensors into args and kwargs'''
+
         args = tuple(flat_args[:self.num_positionals])
         kwargs = {kwarg_name: arg for kwarg_name, arg in zip(self.keyword_names, flat_args[self.num_positionals:])}
         return args, kwargs
 
-def _convert_input_to_list(param_names, user_input_names, buffer_names, inputs, kwargs):
+def _combine_input_buffers_initializers(param_names, onnx_input_names, input_info, buffer_names, inputs, kwargs):
     '''Creates forward `*inputs` list from user input and PyTorch initializers
 
     ONNX Runtime forward requires an ordered list of:
@@ -55,12 +64,19 @@ def _convert_input_to_list(param_names, user_input_names, buffer_names, inputs, 
     non_none_inputs = [inp for inp in inputs if inp is not None]
     named_buffers_iter = iter(buffer_names)
     result = []
-    for input_idx, name in enumerate(user_input_names):
+
+    for input_idx, name in enumerate(onnx_input_names):
         inp = None
-        if input_idx < len(non_none_inputs):
-            inp = non_none_inputs[input_idx]
-        elif name in kwargs and kwargs[name] is not None:
+        if name in kwargs and kwargs[name] is not None:
+            # Only use keywords coming from user that are expected by ONNX model
             inp = kwargs[name]
+        elif input_idx < len(non_none_inputs):
+            # Only use positionals coming from user that are expected by ONNX model
+            if name != input_info.names[input_idx]:
+                # When ONNX drops unused inputs, get correct index from user input
+                input_idx = input_info.names.index(name)
+            inp = non_none_inputs[input_idx]
+
         elif input_idx >= len(non_none_inputs):
             # Registered buffers are translated to user_input+initializer in ONNX
             buffer_name, inp = next(named_buffers_iter)
@@ -134,7 +150,7 @@ class _TensorStub(object):
         return True
 
 
-def populate_user_output_from_schema_and_outputs(output_schema, output_names, outputs):
+def unflatten_user_output(output_schema, output_names, outputs):
     """Follows the schema to generate an output that is expected by the user"""
 
     def _replace_stub_with_tensor_value(user_output, outputs, output_idx):

--- a/orttraining/orttraining/python/training/_ortmodule_training_manager.py
+++ b/orttraining/orttraining/python/training/_ortmodule_training_manager.py
@@ -155,15 +155,16 @@ class TrainingManager(GraphExecutionManager):
                 training_io_binding.clear_binding_outputs()
                 return tuple(results)
 
-        return _io.populate_user_output_from_schema_and_outputs(self._module_output_schema,
-                                                                self._graph_info.user_output_names,
-                                                                _ORTModuleFunction.apply(
-                                                                    *_io._convert_input_to_list(
-                                                                        self._flattened_module.named_parameters(),
-                                                                        self._graph_info.user_input_names,
-                                                                        self._flattened_module.named_buffers(),
-                                                                        inputs,
-                                                                        kwargs)))
+        return _io.unflatten_user_output(self._module_output_schema,
+                                        self._graph_info.user_output_names,
+                                        _ORTModuleFunction.apply(
+                                            *_io._combine_input_buffers_initializers(
+                                                self._flattened_module.named_parameters(),
+                                                self._graph_info.user_input_names,
+                                                self._input_info,
+                                                self._flattened_module.named_buffers(),
+                                                inputs,
+                                                kwargs)))
 
     def _build_graph(self):
         """Build an optimized gradient graph using the module_graph_builder"""

--- a/orttraining/orttraining/python/training/_utils.py
+++ b/orttraining/orttraining/python/training/_utils.py
@@ -1,3 +1,8 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
 import importlib.util
 import numpy as np
 import os

--- a/orttraining/orttraining/python/training/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule.py
@@ -79,12 +79,6 @@ class ORTModule(torch.nn.Module):
     def _is_training(self):
         return self._flattened_module.training and torch.is_grad_enabled()
 
-    def eval(self: T) -> T:
-        self._flattened_module.eval()
-
-    def train(self: T, mode: bool = True) -> T:
-        self._flattened_module.train(mode)
-
     def state_dict(self, destination=None, prefix='', keep_vars=False):
         """Override original method to delegate execution to the base module"""
 


### PR DESCRIPTION
Currently ORTModule expects that all user *positional* inputs are used in the model

That assumption is broken by ONNX exporter, which drops unused inputs from the forward signature, leading to a mismatch between the user input order and the forward signature.

In the example below
```python
    class NumberNet(torch.nn.Module):
        def __init__(self):
            super().__init__()
            self.zeros = torch.nn.Parameter(torch.zeros(1,1))

        def forward(self, a, b, c, d):
            return a + d + self.zeros.sum()
```
the PyTorch user  will feed `a,b,c,d`, but ORTModule ONNX model will expect for `a,d` only, as `b` and `c` are unused and dropped by the exporter. 

This PR fixes this issue
