### PR TITLE
Performance: skip device/input info checks when applicable

### DIFF
--- a/orttraining/orttraining/python/training/_ortmodule_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/_ortmodule_graph_execution_manager.py
@@ -23,11 +23,12 @@ from torch.utils.cpp_extension import ROCM_HOME
 ONNX_OPSET_VERSION = 12
 
 
-def _run_forward(execution_session, onnx_model, device, *inputs, **kwargs):
+def _run_forward(execution_session, onnx_model, device, skip_device_check, *inputs, **kwargs):
     """Runs the forward graph on execution_session with given model inputs and device"""
 
-    # Assert that the input and model device match
-    _utils._check_same_device(device, "Input argument to forward", *inputs)
+    if skip_device_check == False:
+        # Assert that the input and model device match
+        _utils._check_same_device(device, "Input argument to forward", *inputs)
 
     # TODO: Try to reuse the output buffers as some of the output tensors are same sizes,
     #   especially the backward graph outputs.
@@ -78,6 +79,10 @@ class GraphExecutionManager(ABC):
 
         # TrainingAgent or InferenceAgent
         self._execution_agent = None
+
+        # skip device or input info checks if there will be no change for the entire training
+        self._skip_device_check = False
+        self._skip_input_check = False
 
         # Debug flags
         self._save_onnx = False

--- a/orttraining/orttraining/python/training/_ortmodule_inference_manager.py
+++ b/orttraining/orttraining/python/training/_ortmodule_inference_manager.py
@@ -58,6 +58,7 @@ class InferenceManager(GraphExecutionManager):
         user_outputs, _ = _run_forward(self._execution_agent,
                                        self._optimized_onnx_model,
                                        self._device,
+                                       self._skip_device_check,
                                        *_io._convert_input_to_list(self._flattened_module.named_parameters(),
                                                                    self._graph_info.user_input_names,
                                                                    self._flattened_module.named_buffers(),

--- a/orttraining/orttraining/python/training/_ortmodule_training_manager.py
+++ b/orttraining/orttraining/python/training/_ortmodule_training_manager.py
@@ -35,24 +35,28 @@ class TrainingManager(GraphExecutionManager):
             # If model was exported, then initialize the graph builder
             self._initialize_graph_builder(training=True)
 
-        input_info = _io.parse_inputs_for_onnx_export(self._module_parameters,
-                                                      self._onnx_model,
-                                                      inputs,
-                                                      kwargs)
-
-        # Reinitialize graph builder if the inputs or initializers requiring gradient have changed.
-        build_gradient_graph = build_gradient_graph or self._reinitialize_graph_builder(input_info)
+        if self._skip_input_check == False:
+            input_info = _io.parse_inputs_for_onnx_export(self._module_parameters,
+                                                        self._onnx_model,
+                                                        inputs,
+                                                        kwargs)
+            # Reinitialize graph builder if the inputs or initializers requiring gradient have changed.
+            build_gradient_graph = build_gradient_graph or self._reinitialize_graph_builder(input_info)
 
         # Build the gradient graph
         if build_gradient_graph:
             self._build_graph()
 
-        module_device = _utils.get_device_from_module(self._original_module)
-        # The _training_session/_inference_session should be created every time
-        # the graph was built or if the device changed between calls to forward
-        create_execution_session = build_gradient_graph or self._device != module_device
-        if self._device != module_device:
-            self._device = module_device
+        if self._skip_device_check == False:
+            module_device = _utils.get_device_from_module(self._original_module)
+            # The _training_session/_inference_session should be created every time
+            # the graph was built or if the device changed between calls to forward
+            create_execution_session = build_gradient_graph or self._device != module_device
+            if self._device != module_device:
+                self._device = module_device
+        else:
+            create_execution_session = build_gradient_graph
+            
         if create_execution_session:
             # Create execution session creates the training_session
             self._create_execution_agent()
@@ -75,6 +79,7 @@ class TrainingManager(GraphExecutionManager):
                 user_outputs, ctx.run_info = _run_forward(self._execution_agent,
                                                           self._optimized_onnx_model,
                                                           self._device,
+                                                          self._skip_device_check,
                                                           *inputs,
                                                           **kwargs)
 


### PR DESCRIPTION
**Description**: When profiling ORTModule, we noticed a couple gaps, one right before next fw pass, one right after bw pass. After some CPU profiling, we identified there are a few places having redundant checks before fw pass. By disabling those checks, we observe the perf gain (e.g., on zcodev1 model) over torch reaches 4.6% (was 3.2%, on top of partial graph branch [https://github.com//pull/7324] + a few optimization fixes). Thus adding a new internal flag, by default the checks are still enabled.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

![image](https://user-images.githubusercontent.com/4484531/115822197-fe424d00-a3b8-11eb-8e29-776f31086425.png)
