### PR TITLE
Fix some warnings in our CUDA code

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_allocator.h
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.h
@@ -28,7 +28,7 @@ class CUDAExternalAllocator : public CUDAAllocator {
   typedef void (*ExternalFree)(void* p);
 
  public:
-  CUDAExternalAllocator(OrtDevice::DeviceId device_id, const char* name, const void* alloc, const void* free)
+  CUDAExternalAllocator(OrtDevice::DeviceId device_id, const char* name, void* alloc, void* free)
       : CUDAAllocator(device_id, name) {
     alloc_ = reinterpret_cast<ExternalAlloc>(alloc);
     free_ = reinterpret_cast<ExternalFree>(free);

--- a/onnxruntime/core/providers/cuda/cuda_call.cc
+++ b/onnxruntime/core/providers/cuda/cuda_call.cc
@@ -17,7 +17,7 @@ namespace onnxruntime {
 using namespace common;
 
 template <typename ERRTYPE>
-const char* CudaErrString(ERRTYPE x) {
+const char* CudaErrString(ERRTYPE) {
   ORT_NOT_IMPLEMENTED();
 }
 

--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -95,7 +95,7 @@ inline bool CalculateFdmStrides(gsl::span<fast_divmod> p, const std::vector<int6
 
 class CublasMathModeSetter {
  public:
-  CublasMathModeSetter(const cudaDeviceProp& prop, cublasHandle_t handle, cublasMath_t mode) : prop_(prop), handle_(handle) {
+  CublasMathModeSetter(const cudaDeviceProp& prop, cublasHandle_t handle, cublasMath_t mode) : handle_(handle) {
 #if defined(CUDA_VERSION) && CUDA_VERSION < 11000    
     enable_ = (mode == CUBLAS_TENSOR_OP_MATH ? prop.major >= 7 : true );
 #else
@@ -118,7 +118,6 @@ class CublasMathModeSetter {
   }
 
  private:
-  const cudaDeviceProp& prop_;
   cublasHandle_t handle_;
   cublasMath_t mode_;
   bool enable_;

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider_info.h
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider_info.h
@@ -13,8 +13,8 @@
 namespace onnxruntime {
 // Information needed to construct CUDA execution providers.
 struct CUDAExecutionProviderExternalAllocatorInfo {
-  const void* alloc{nullptr};
-  const void* free{nullptr};
+  void* alloc{nullptr};
+  void* free{nullptr};
 
   CUDAExecutionProviderExternalAllocatorInfo() {
     alloc = nullptr;

--- a/onnxruntime/core/providers/cuda/cudnn_common.cc
+++ b/onnxruntime/core/providers/cuda/cudnn_common.cc
@@ -117,7 +117,7 @@ cudnnDataType_t CudnnTensor::GetDataType() {
   ORT_THROW("cuDNN engine currently supports only single/double/half/int8/uint8 precision data types. Got:",
     typeid(ElemType).name());
   // Not reachable but GCC complains
-  return 0;
+  return CUDNN_DATA_FLOAT;
 }
 
 template<>


### PR DESCRIPTION
**Description**: 

Fix some warnings in our CUDA code

For example, code like
```cpp
#include <iostream>

int main(){
  const void* alloc = NULL;
  typedef void* (*ExternalAlloc)(size_t size);
  auto alloc_ = reinterpret_cast<ExternalAlloc>(alloc);
  return 0;
}
```
will generate error of:
```
 error: reinterpret_cast from 'const void *' to 'ExternalAlloc' (aka 'void *(*)(unsigned long)') casts away qualifiers
  auto alloc_ = reinterpret_cast<ExternalAlloc>(alloc);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Because the alloc pointer should be "void*" instead of "const void*".

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
