### PR TITLE
Lifhuan/force trt sequential

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -298,6 +298,7 @@ typedef struct OrtTensorRTProviderOptions {
   int trt_int8_enable;                            // enable TensorRT INT8 precision. Default 0 = false, nonzero = true
   const char* trt_int8_calibration_table_name;    // TensorRT INT8 calibration table name.
   int trt_int8_use_native_calibration_table;      // use native TensorRT generated calibration table. Default 0 = false, nonzero = true
+  int force_sequential_engine_build;              // force building TensorRT engine sequentially. Default 0 = false, nonzero = true
 } OrtTensorRTProviderOptions;
 
 /// <summary>

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -289,16 +289,16 @@ typedef struct OrtROCMProviderOptions {
 /// Options for the TensorRT provider that are passed to SessionOptionsAppendExecutionProvider_TensorRT
 /// </summary>
 typedef struct OrtTensorRTProviderOptions {
-  int device_id;                                  // cuda device id.
-  int has_user_compute_stream;                    // indicator of user specified CUDA compute stream.
-  void* user_compute_stream;                      // user specified CUDA compute stream.
-  int has_trt_options;                            // override environment variables with following TensorRT settings at runtime.
-  size_t trt_max_workspace_size;                  // maximum workspace size for TensorRT.
-  int trt_fp16_enable;                            // enable TensorRT FP16 precision. Default 0 = false, nonzero = true
-  int trt_int8_enable;                            // enable TensorRT INT8 precision. Default 0 = false, nonzero = true
-  const char* trt_int8_calibration_table_name;    // TensorRT INT8 calibration table name.
-  int trt_int8_use_native_calibration_table;      // use native TensorRT generated calibration table. Default 0 = false, nonzero = true
-  int force_sequential_engine_build;              // force building TensorRT engine sequentially. Default 0 = false, nonzero = true
+  int device_id;                                // cuda device id.
+  int has_user_compute_stream;                  // indicator of user specified CUDA compute stream.
+  void* user_compute_stream;                    // user specified CUDA compute stream.
+  int has_trt_options;                          // override environment variables with following TensorRT settings at runtime.
+  size_t trt_max_workspace_size;                // maximum workspace size for TensorRT.
+  int trt_fp16_enable;                          // enable TensorRT FP16 precision. Default 0 = false, nonzero = true
+  int trt_int8_enable;                          // enable TensorRT INT8 precision. Default 0 = false, nonzero = true
+  const char* trt_int8_calibration_table_name;  // TensorRT INT8 calibration table name.
+  int trt_int8_use_native_calibration_table;    // use native TensorRT generated calibration table. Default 0 = false, nonzero = true
+  int trt_force_sequential_engine_build;        // force building TensorRT engine sequentially. Default 0 = false, nonzero = true
 } OrtTensorRTProviderOptions;
 
 /// <summary>

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -187,8 +187,8 @@ class TensorrtExecutionProvider : public IExecutionProvider {
 
   /** 
   Get a unique_lock object to control the concurrency behavior of TensorRT engine building. When force_sequential_engine_build
-  is set to true, the lock object is associated with a globally shared mutex to force sequential engine build. Otherwise, the 
-  constructed unique_lock is not associated with any mutex thus no locking/unlocking will happen.
+  is set to true, the lock object is associated with a mutex shared across all providers to enforce sequential engine build. 
+  Otherwise, the constructed unique_lock is not associated with any mutex therefore no locking/unlocking will happen.
   */
   std::unique_lock<OrtMutex> GetEngineBuildLock() const;
 };

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -20,6 +20,7 @@ static const std::string kINT8UseNativeTensorrtCalibrationTable = "ORT_TENSORRT_
 static const std::string kDumpSubgraphs = "ORT_TENSORRT_DUMP_SUBGRAPHS";
 static const std::string kEngineCacheEnable = "ORT_TENSORRT_ENGINE_CACHE_ENABLE";
 static const std::string kCachePath = "ORT_TENSORRT_CACHE_PATH";
+static const std::string kForceSequentialEngineBuild= "ORT_TENSORRT_FORCE_SEQUENTIAL_ENGINE_BUILD";
 // Old env variable for backward compatibility
 static const std::string kEngineCachePath = "ORT_TENSORRT_ENGINE_CACHE_PATH";
 static const std::string kDecryptionEnable = "ORT_TENSORRT_ENGINE_DECRYPTION_ENABLE";
@@ -77,6 +78,7 @@ struct TensorrtExecutionProviderInfo {
   bool int8_enable{false}; 
   std::string int8_calibration_table_name{""};
   bool int8_use_native_calibration_table{false};
+  bool force_sequential_engine_build{false};
 };
 
 // Information to construct kernel function state.
@@ -144,6 +146,7 @@ class TensorrtExecutionProvider : public IExecutionProvider {
   size_t max_workspace_size_ = 1 << 30;  // 1GB
   bool fp16_enable_ = false;
   bool int8_enable_ = false;
+  bool force_sequential_engine_build_ = false;
   std::string int8_calibration_cache_name_ = "INT8_calibration_table";
   bool int8_use_native_tensorrt_calibration_table_ = false;
   bool dump_subgraphs_ = false;
@@ -153,7 +156,7 @@ class TensorrtExecutionProvider : public IExecutionProvider {
   OrtMutex tensorrt_mu_;
   int device_id_;
   AllocatorPtr allocator_;
-  mutable char model_path_[4096]; // Reserved for max path length
+  mutable char model_path_[4096];  // Reserved for max path length
   bool engine_decryption_enable_ = false;
   int (*engine_decryption_)(const char*, char*, size_t*);
 
@@ -181,5 +184,8 @@ class TensorrtExecutionProvider : public IExecutionProvider {
                                         const GraphViewer& graph, bool* early_termination) const;
 
   void RemoveTensorRTGraphCycles(SubGraphCollection_t& supported_nodes_vector, const GraphViewer& graph) const;
+
+  /** Get the shared mutex across all trt provider instances to force sequential engine build. */
+  std::unique_lock<OrtMutex> GetEngineBuildLock() const;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -185,7 +185,11 @@ class TensorrtExecutionProvider : public IExecutionProvider {
 
   void RemoveTensorRTGraphCycles(SubGraphCollection_t& supported_nodes_vector, const GraphViewer& graph) const;
 
-  /** Get the shared mutex across all trt provider instances to force sequential engine build. */
+  /** 
+  Get a unique_lock object to control the concurrency behavior of TensorRT engine building. When force_sequential_engine_build
+  is set to true, the lock object is associated with a globally shared mutex to force sequential engine build. Otherwise, the 
+  constructed unique_lock is not associated with any mutex thus no locking/unlocking will happen.
+  */
   std::unique_lock<OrtMutex> GetEngineBuildLock() const;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc
@@ -55,7 +55,7 @@ struct Tensorrt_Provider : Provider {
     info.int8_enable = options.trt_int8_enable;
     info.int8_calibration_table_name = options.trt_int8_calibration_table_name == nullptr ? "" : options.trt_int8_calibration_table_name;
     info.int8_use_native_calibration_table = options.trt_int8_use_native_calibration_table;
-    info.force_sequential_engine_build = options.force_sequential_engine_build;
+    info.force_sequential_engine_build = options.trt_force_sequential_engine_build;
     return std::make_shared<TensorrtProviderFactory>(info);
   }
 

--- a/onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc
@@ -55,6 +55,7 @@ struct Tensorrt_Provider : Provider {
     info.int8_enable = options.trt_int8_enable;
     info.int8_calibration_table_name = options.trt_int8_calibration_table_name == nullptr ? "" : options.trt_int8_calibration_table_name;
     info.int8_use_native_calibration_table = options.trt_int8_use_native_calibration_table;
+    info.force_sequential_engine_build = options.force_sequential_engine_build;
     return std::make_shared<TensorrtProviderFactory>(info);
   }
 

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -573,7 +573,7 @@ static void RegisterExecutionProviders(InferenceSession* sess, const std::vector
                                           sess->GetSessionOptions().enable_cpu_mem_arena));
     } else if (type == kTensorrtExecutionProvider) {
 #ifdef USE_TENSORRT
-      OrtTensorRTProviderOptions params{0, 0, nullptr, 0, 1 << 30, 0, 0, nullptr, 0};
+      OrtTensorRTProviderOptions params{0, 0, nullptr, 0, 1 << 30, 0, 0, nullptr, 0, 0};
       std::string trt_int8_calibration_table_name;
       auto it = provider_options_map.find(type);
       if (it != provider_options_map.end()) {

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -318,6 +318,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
           0,
           0,
           nullptr,
+          0,
           0};
 
       OrtCUDAProviderOptions cuda_options{

--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -70,8 +70,9 @@ namespace perftest {
       "\t    [TensorRT only] [trt_int8_enable]: Enable TensorRT INT8 precision.\n"
       "\t    [TensorRT only] [trt_int8_calibration_table_name]: Specify INT8 calibration table name.\n"
       "\t    [TensorRT only] [trt_int8_use_native_calibration_table]: Use Native TensorRT calibration table.\n"
+      "\t    [TensorRT only] [trt_force_sequential_engine_build]: Force TensorRT engines to be built sequentially.\n"
       "\t [Usage]: -e <provider_name> -i '<key1>|<value1> <key2>|<value2>'\n\n"
-      "\t [Example] [For TensorRT EP] -e tensorrt -i 'use_trt_options|true trt_fp16_enable|true trt_int8_enable|true trt_int8_calibration_table_name|calibration.flatbuffers trt_int8_use_native_calibration_table|false'\n"
+      "\t [Example] [For TensorRT EP] -e tensorrt -i 'use_trt_options|true trt_fp16_enable|true trt_int8_enable|true trt_int8_calibration_table_name|calibration.flatbuffers trt_int8_use_native_calibration_table|false trt_force_sequential_engine_build|false'\n"
       "\t-h: help\n");
 }
 #ifdef _WIN32

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -68,6 +68,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
     bool trt_int8_enable = false;
     std::string trt_int8_calibration_table_name = "";
     bool trt_int8_use_native_calibration_table = false;
+    bool trt_force_sequential_engine_build = false;
 
     #ifdef _MSC_VER
     std::string ov_string = ToMBString(performance_test_config.run_config.ep_runtime_config_string);
@@ -77,7 +78,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
     std::istringstream ss(ov_string);
     std::string token;
     while (ss >> token) {
-      if(token == "") {
+      if (token == "") {
         continue;
       }
       auto pos = token.find("|");
@@ -85,10 +86,10 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
         ORT_THROW("[ERROR] [TensorRT] Use a '|' to separate the key and value for the run-time option you are trying to use.\n");
       }
 
-      auto key = token.substr(0,pos);
-      auto value = token.substr(pos+1);
+      auto key = token.substr(0, pos);
+      auto value = token.substr(pos + 1);
       if (key == "has_trt_options") {
-        if(value == "true" || value == "True"){
+        if (value == "true" || value == "True") {
           has_trt_options = true;
         } else if (value == "false" || value == "False") {
           has_trt_options = false;
@@ -96,13 +97,13 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
           ORT_THROW("[ERROR] [TensorRT] The value for the key 'has_trt_options' should be a boolean i.e. true or false. Default value is false.\n");
         }
       } else if (key == "trt_max_workspace_size") {
-        if(!value.empty()) {
+        if (!value.empty()) {
           trt_max_workspace_size = std::stoull(value);
         } else {
           ORT_THROW("[ERROR] [TensorRT] The value for the key 'trt_max_workspace_size' should be a number.\n");
         }
       } else if (key == "trt_fp16_enable") {
-        if(value == "true" || value == "True"){
+        if (value == "true" || value == "True") {
           trt_fp16_enable = true;
         } else if (value == "false" || value == "False") {
           trt_fp16_enable = false;
@@ -110,7 +111,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
           ORT_THROW("[ERROR] [TensorRT] The value for the key 'trt_fp16_enable' should be a boolean i.e. true or false. Default value is false.\n");
         }
       } else if (key == "trt_int8_enable") {
-        if(value == "true" || value == "True"){
+        if (value == "true" || value == "True") {
           trt_int8_enable = true;
         } else if (value == "false" || value == "False") {
           trt_int8_enable = false;
@@ -118,21 +119,29 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
           ORT_THROW("[ERROR] [TensorRT] The value for the key 'trt_int8_enable' should be a boolean i.e. true or false. Default value is false.\n");
         }
       } else if (key == "trt_int8_calibration_table_name") {
-        if(!value.empty()) {
+        if (!value.empty()) {
           trt_int8_calibration_table_name = value;
         } else {
           ORT_THROW("[ERROR] [TensorRT] The value for the key 'trt_int8_calibration_table_name' should be a non-emtpy string.\n");
         }
       } else if (key == "trt_int8_use_native_calibration_table") {
-        if(value == "true" || value == "True"){
+        if (value == "true" || value == "True") {
           trt_int8_use_native_calibration_table = true;
         } else if (value == "false" || value == "False") {
           trt_int8_use_native_calibration_table = false;
         } else {
           ORT_THROW("[ERROR] [TensorRT] The value for the key 'trt_int8_use_native_calibration_table' should be a boolean i.e. true or false. Default value is false.\n");
         }
+      } else if (key == "trt_force_sequential_engine_build") {
+        if (value == "true" || value == "True") {
+          trt_force_sequential_engine_build = true;
+        } else if (value == "false" || value == "False") {
+          trt_force_sequential_engine_build = false;
+        } else {
+          ORT_THROW("[ERROR] [TensorRT] The value for the key 'trt_force_sequential_engine_build' should be a boolean i.e. true or false. Default value is false.\n");
+        }
       } else {
-          ORT_THROW("[ERROR] [TensorRT] wrong key type entered. Choose from the following runtime key options that are available for TensorRT. ['use_trt_options', 'trt_fp16_enable', 'trt_int8_enable', 'trt_int8_calibration_table_name', 'trt_int8_use_native_calibration_table'] \n");
+        ORT_THROW("[ERROR] [TensorRT] wrong key type entered. Choose from the following runtime key options that are available for TensorRT. ['use_trt_options', 'trt_fp16_enable', 'trt_int8_enable', 'trt_int8_calibration_table_name', 'trt_int8_use_native_calibration_table', 'trt_force_sequential_engine_build'] \n");
       }
     }
     OrtTensorRTProviderOptions tensorrt_options;
@@ -145,6 +154,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
     tensorrt_options.trt_int8_enable = trt_int8_enable;
     tensorrt_options.trt_int8_calibration_table_name = trt_int8_calibration_table_name.c_str();
     tensorrt_options.trt_int8_use_native_calibration_table = trt_int8_use_native_calibration_table;
+    tensorrt_options.trt_force_sequential_engine_build = trt_force_sequential_engine_build;
     session_options.AppendExecutionProvider_TensorRT(tensorrt_options);
 
     OrtCUDAProviderOptions cuda_options{

--- a/onnxruntime/test/util/default_providers.cc
+++ b/onnxruntime/test/util/default_providers.cc
@@ -43,7 +43,7 @@ std::unique_ptr<IExecutionProvider> DefaultCpuExecutionProvider(bool enable_aren
 
 std::unique_ptr<IExecutionProvider> DefaultTensorrtExecutionProvider() {
 #ifdef USE_TENSORRT
-  OrtTensorRTProviderOptions params{0, 0, nullptr, 0, 1 << 30, 0, 0, nullptr, 0};
+  OrtTensorRTProviderOptions params{0, 0, nullptr, 0, 1 << 30, 0, 0, nullptr, 0, 0};
   if (auto factory = CreateExecutionProviderFactory_Tensorrt(&params))
     return factory->CreateProvider();
 #endif


### PR DESCRIPTION
**Description**: 
Add a new option `force_sequential_engine_build` to `OrtTensorRTProviderOptions`  to allow caller to force sequential building of the TRT engine. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
1. There is an issue with parallel TenorRT engine build process in ORT, which causes crashes especially on multi-GPU machines. After investigation & trying multiple options with Xuan, we found that forcing sequential build is the only work-around before the issue is root-caused & resolved, which is not trivial.

2. This default-off option itself could be useful since it provides another knob for users to control the threading behavior while building engine.

- If it fixes an open issue, please link to the issue here.
https://github.com/microsoft/onnxruntime/issues/7322