### PR TITLE
NCHWc: ReorderInput improvements

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -2938,6 +2938,13 @@ This version of the operator has been available since version 1 of the 'com.micr
 
 This version of the operator has been available since version 1 of the 'com.microsoft.nchwc' operator set.
 
+#### Attributes
+
+<dl>
+<dt><tt>channels_last</tt> : int</dt>
+<dd></dd>
+</dl>
+
 #### Inputs
 
 <dl>

--- a/onnxruntime/contrib_ops/cpu/nchwc_ops.cc
+++ b/onnxruntime/contrib_ops/cpu/nchwc_ops.cc
@@ -7,90 +7,128 @@
 namespace onnxruntime {
 namespace contrib {
 
-#define ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(name, ver, type, builder, ...) \
-  ONNX_OPERATOR_TYPED_KERNEL_EX(name, kMSNchwcDomain, ver, type, kCpuExecutionProvider, builder, __VA_ARGS__)
-
-ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
-    ReorderInput,
-    1,
-    float,
-    KernelDefBuilder()
-        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
-    ReorderInput);
-
-ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
-    ReorderOutput,
-    1,
-    float,
-    KernelDefBuilder()
-        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
-    ReorderOutput);
-
-ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
-    Conv,
-    1,
-    float,
-    KernelDefBuilder()
-        .MayInplace(3, 0)
-        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
-    NchwcConv);
-
-ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
-    MaxPool,
-    1,
-    float,
-    KernelDefBuilder()
-        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
-    NchwcMaxPool);
-
-ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
-    GlobalMaxPool,
-    1,
-    float,
-    KernelDefBuilder()
-        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
-    NchwcMaxPool);
-
-ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
-    AveragePool,
-    1,
-    float,
-    KernelDefBuilder()
-        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
-    NchwcAveragePool);
-
-ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
-    GlobalAveragePool,
-    1,
-    float,
-    KernelDefBuilder()
-        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
-    NchwcAveragePool);
-
-ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
-    Upsample,
-    1,
-    float,
-    KernelDefBuilder()
-        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
-    NchwcUpsample);
-
 Status ReorderInput::Compute(OpKernelContext* context) const {
   const auto* X = context->Input<Tensor>(0);
-  const auto& X_shape = X->Shape();
-  ORT_ENFORCE(X_shape.NumDimensions() == 4);
-  ORT_ENFORCE((X_shape[1] % MlasNchwcGetBlockSize()) == 0);
+  const auto& X_shape = X->Shape().GetDims();
+  const auto X_rank = X_shape.size();
+  ORT_ENFORCE(X_rank >= 2);
 
-  auto* Y = context->Output(0, X_shape);
-  MlasReorderInput(X_shape.GetDims().data(), X->template Data<float>(), Y->template MutableData<float>());
+  const int64_t batch_count = X_shape[0];
+  const int64_t channels = X_shape[channels_last_ ? X_rank - 1 : 1];
+  const auto* X_spatial_dims = X_shape.data() + (channels_last_ ? 1 : 2);
+
+  // The current implementation of MlasReorderInputNchw does not work for channels that
+  // are not a multiple of 4.
+  ORT_ENFORCE((channels % 4) == 0);
+
+  const int64_t nchwc_block_size = static_cast<int64_t>(MlasNchwcGetBlockSize());
+  const int64_t nchwc_channels = (channels + nchwc_block_size - 1) & ~(nchwc_block_size - 1);
+
+  std::vector<int64_t> Y_shape(X_rank);
+  Y_shape[0] = batch_count;
+  Y_shape[1] = nchwc_channels;
+  int64_t spatial_size = 1;
+  for (size_t i = 0; i < X_rank - 2; i++) {
+    const int64_t spatial_dim = X_spatial_dims[i];
+    spatial_size *= spatial_dim;
+    Y_shape[2 + i] = spatial_dim;
+  }
+
+  auto* Y = context->Output(0, Y_shape);
+
+  // Bail out early if one of the dimensions is zero.
+  if (Y->Shape().Size() == 0) {
+    return Status::OK();
+  }
+
+  // Compute the total amount of work depending on NCHW or NHWC format and estimate
+  // a number of workers to use.
+  ptrdiff_t total_work;
+  ptrdiff_t worker_count;
+
+  if (channels_last_) {
+    total_work = static_cast<ptrdiff_t>(batch_count * spatial_size);
+    // Partition the work with the goal of reordering the following number of
+    // elements, so that operations involving a smaller number of channels will
+    // process more rows per worker.
+    constexpr ptrdiff_t worker_goal = 48 * 1024;
+    ptrdiff_t work_per_worker = worker_goal / nchwc_channels;
+    if (work_per_worker == 0) {
+      work_per_worker = 1;
+    }
+    worker_count = total_work / work_per_worker;
+    if (worker_count == 0) {
+      worker_count = 1;
+    }
+  } else {
+    // Each iteration produces one spatial_size chunk of NCHWc blocks.
+    total_work = static_cast<ptrdiff_t>(batch_count * (nchwc_channels / nchwc_block_size));
+    worker_count = total_work;
+  }
+
+  const auto* x_data = X->template Data<float>();
+  auto* y_data = Y->template MutableData<float>();
+
+  auto reorder_worker = [&](ptrdiff_t batch) {
+    auto work = concurrency::ThreadPool::PartitionWork(batch, worker_count, total_work);
+
+    if (channels_last_) {
+      int64_t work_index = static_cast<int64_t>(work.start);
+      int64_t work_remaining = static_cast<int64_t>(work.end - work.start);
+
+      while (work_remaining > 0) {
+        const int64_t batch_index = work_index / spatial_size;
+        const int64_t spatial_index = work_index % spatial_size;
+        const int64_t rows_this_iteration = std::min(work_remaining, spatial_size - spatial_index);
+
+        MlasReorderInputNhwc(
+            x_data + ((batch_index * spatial_size) + spatial_index) * channels,
+            y_data + (batch_index * spatial_size * nchwc_channels) + (spatial_index * nchwc_block_size),
+            static_cast<size_t>(channels),
+            static_cast<size_t>(rows_this_iteration),
+            static_cast<size_t>(spatial_size));
+
+        work_index += rows_this_iteration;
+        work_remaining -= rows_this_iteration;
+      }
+    } else {
+      int64_t work_index = static_cast<int64_t>(work.start) * nchwc_block_size;
+      int64_t work_remaining = static_cast<int64_t>(work.end - work.start) * nchwc_block_size;
+
+      while (work_remaining > 0) {
+        const int64_t batch_index = work_index / nchwc_channels;
+        const int64_t channel_index = work_index % nchwc_channels;
+        const int64_t channels_this_iteration = std::min(work_remaining, channels - channel_index);
+
+        MlasReorderInputNchw(
+            x_data + ((batch_index * channels) + channel_index) * spatial_size,
+            y_data + ((batch_index * nchwc_channels) + channel_index) * spatial_size,
+            static_cast<size_t>(channels_this_iteration),
+            static_cast<size_t>(spatial_size));
+
+        const int64_t nchwc_channels_this_iteration = std::min(work_remaining, nchwc_channels - channel_index);
+        work_index += nchwc_channels_this_iteration;
+        work_remaining -= nchwc_channels_this_iteration;
+      }
+    }
+  };
+
+  concurrency::ThreadPool* thread_pool = context->GetOperatorThreadPool();
+
+  // Handle the work in a single batch if only a single thread is available.
+  if (concurrency::ThreadPool::DegreeOfParallelism(thread_pool) == 1) {
+    worker_count = 1;
+  }
+
+  concurrency::ThreadPool::TrySimpleParallelFor(thread_pool, worker_count, reorder_worker);
 
   return Status::OK();
 }
 
 Status ReorderOutput::Compute(OpKernelContext* context) const {
   const auto* X = context->Input<Tensor>(0);
-  const auto& X_shape = X->Shape();
-  const auto X_rank = X_shape.NumDimensions();
+  const auto& X_shape = X->Shape().GetDims();
+  const auto X_rank = X_shape.size();
   ORT_ENFORCE(X_rank == 4);
   ORT_ENFORCE(channels_ <= X_shape[1]);
 
@@ -234,6 +272,74 @@ Status NchwcUpsample::Compute(OpKernelContext* context) const {
 
   return Status::OK();
 }
+
+#define ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(name, ver, type, builder, ...) \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(name, kMSNchwcDomain, ver, type, kCpuExecutionProvider, builder, __VA_ARGS__)
+
+ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
+    ReorderInput,
+    1,
+    float,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    ReorderInput);
+
+ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
+    ReorderOutput,
+    1,
+    float,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    ReorderOutput);
+
+ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
+    Conv,
+    1,
+    float,
+    KernelDefBuilder()
+        .MayInplace(3, 0)
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NchwcConv);
+
+ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
+    MaxPool,
+    1,
+    float,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NchwcMaxPool);
+
+ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
+    GlobalMaxPool,
+    1,
+    float,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NchwcMaxPool);
+
+ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
+    AveragePool,
+    1,
+    float,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NchwcAveragePool);
+
+ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
+    GlobalAveragePool,
+    1,
+    float,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NchwcAveragePool);
+
+ONNX_CPU_OPERATOR_TYPED_NCHWC_KERNEL(
+    Upsample,
+    1,
+    float,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    NchwcUpsample);
 
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/nchwc_ops.cc
+++ b/onnxruntime/contrib_ops/cpu/nchwc_ops.cc
@@ -11,7 +11,7 @@ Status ReorderInput::Compute(OpKernelContext* context) const {
   const auto* X = context->Input<Tensor>(0);
   const auto& X_shape = X->Shape().GetDims();
   const auto X_rank = X_shape.size();
-  ORT_ENFORCE(X_rank >= 2);
+  ORT_ENFORCE(X_rank == 4);
 
   const int64_t batch_count = X_shape[0];
   const int64_t channels = X_shape[channels_last_ ? X_rank - 1 : 1];

--- a/onnxruntime/contrib_ops/cpu/nchwc_ops.h
+++ b/onnxruntime/contrib_ops/cpu/nchwc_ops.h
@@ -15,9 +15,13 @@ namespace contrib {
 class ReorderInput : public OpKernel {
  public:
   ReorderInput(const OpKernelInfo& info) : OpKernel(info) {
+    ORT_ENFORCE(info.GetAttr<int64_t>("channels_last", &channels_last_).IsOK());
   }
 
   Status Compute(OpKernelContext* context) const override;
+
+ private:
+  int64_t channels_last_;
 };
 
 class ReorderOutput : public OpKernel {

--- a/onnxruntime/core/graph/contrib_ops/nchwc_schema_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/nchwc_schema_defs.cc
@@ -4,6 +4,7 @@
 #include "core/framework/tensorprotoutils.h"
 #include "core/graph/constants.h"
 #include "core/graph/contrib_ops/contrib_defs.h"
+#include "core/mlas/inc/mlas.h"
 
 namespace ONNX_NAMESPACE {
 void convPoolShapeInference(
@@ -58,10 +59,45 @@ void RegisterNchwcSchemas() {
       .SetDomain(kMSNchwcDomain)
       .SinceVersion(1)
       .SetDoc(R"DOC(For internal use.)DOC")
+      .Attr("channels_last", "", AttributeProto::INT, static_cast<int64_t>(0))
       .Input(0, "X", "", "T")
       .Output(0, "Y", "", "T")
       .TypeConstraint("T", {"tensor(float)"}, "Constrain input and output types to float tensors")
-      .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput);
+      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+        ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        if (!hasNInputShapes(ctx, 1)) {
+          return;
+        }
+
+        const auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
+        auto* output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+
+        auto input_rank = input_shape.dim_size();
+        if (input_rank < 2) {
+          fail_shape_inference("tensor rank too small");
+        }
+
+        auto channels_last = getAttribute(ctx, "channels_last", 0);
+
+        // Copy the batch dimension.
+        *output_shape->add_dim() = input_shape.dim(0);
+
+        // Block align the channel dimension.
+        const auto& input_channel_dim = input_shape.dim((channels_last == 0) ? 1 : input_rank - 1);
+        auto* output_channel_dim = output_shape->add_dim();
+        if (input_channel_dim.has_dim_value()) {
+          const int64_t channels = input_channel_dim.dim_value();
+          const int64_t nchwc_block_size = static_cast<int64_t>(MlasNchwcGetBlockSize());
+          int64_t nchwc_channels = (channels + nchwc_block_size - 1) & ~(nchwc_block_size - 1);
+          output_channel_dim->set_dim_value(nchwc_channels);
+        }
+
+        // Copy the spatial dimensions.
+        int first_spatial_dim = (channels_last == 0) ? 2 : 1;
+        for (int i = 0; i < input_rank - 2; i++) {
+          *output_shape->add_dim() = input_shape.dim(first_spatial_dim + i);
+        }
+      });
 
   ONNX_CONTRIB_OPERATOR_SCHEMA(ReorderOutput)
       .SetDomain(kMSNchwcDomain)
@@ -78,8 +114,8 @@ void RegisterNchwcSchemas() {
           return;
         }
 
-        auto input_shape = ctx.getInputType(0)->tensor_type().shape();
-        auto output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+        const auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
+        auto* output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
 
         auto input_rank = input_shape.dim_size();
         if (input_rank < 2) {
@@ -92,7 +128,7 @@ void RegisterNchwcSchemas() {
           fail_shape_inference("invalid channel count");
         }
 
-        // Copy batch dimension.
+        // Copy the batch dimension.
         *output_shape->add_dim() = input_shape.dim(0);
 
         auto channels_last = getAttribute(ctx, "channels_last", 0);
@@ -100,7 +136,7 @@ void RegisterNchwcSchemas() {
           output_shape->add_dim()->set_dim_value(channels);
         }
 
-        // Copy spatial dimensions.
+        // Copy the spatial dimensions.
         for (int i = 0; i < input_rank - 2; i++) {
           *output_shape->add_dim() = input_shape.dim(2 + i);
         }
@@ -161,8 +197,8 @@ void RegisterNchwcSchemas() {
           return;
         }
 
-        auto input_shape = ctx.getInputType(0)->tensor_type().shape();
-        auto output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+        const auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
+        auto* output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
 
         auto input_rank = input_shape.dim_size();
         if (input_rank < 2) {

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -552,12 +552,12 @@ MlasGemm(
     MLAS_THREADPOOL* ThreadPool
     );
 
-/** 
- * @brief Batched GEMM, for multiplying multiple pairs of matrices. 
+/**
+ * @brief Batched GEMM, for multiplying multiple pairs of matrices.
  * Note:  We only support uniform batching, so shapes and types of the
  *        input must be same: M, N, K, BIsSigned must be the
- *        same across all parameter blocks. 
- * 
+ *        same across all parameter blocks.
+ *
  * @param [IN]  Shape        A single shape descriptor for all the multiplications
  * @param [IN]  DataParams   Array of data descriptors for the matrices.
  * @param [IN]  BatchN       Size of the parameters array, also number of multiplications to perform
@@ -834,10 +834,21 @@ MlasTranspose(
 
 void
 MLASCALL
-MlasReorderInput(
-    const int64_t* InputShape,
+MlasReorderInputNchw(
     const float* S,
-    float* D
+    float* D,
+    size_t InputChannels,
+    size_t InputSize
+    );
+
+void
+MLASCALL
+MlasReorderInputNhwc(
+    const float* S,
+    float* D,
+    size_t InputChannels,
+    size_t RowCount,
+    size_t FullRowCount
     );
 
 void

--- a/onnxruntime/test/mlas/unittest/test_conv2d_nchwc.h
+++ b/onnxruntime/test/mlas/unittest/test_conv2d_nchwc.h
@@ -105,7 +105,7 @@ class MlasNchwcConv2DTest : public MlasConv2DTest<Threaded> {
     if (DoReorderInput) {
       size_t NchwcInputElements = BatchCount * NchwcInputChannels * InputHeight * InputWidth;
       float* NchwcInput = BufferNchwcInput.GetBuffer(NchwcInputElements);
-      MlasReorderInput(InputShape, Input, NchwcInput);
+      ReorderInputNchw(InputShape, Input, NchwcInput);
       Input = NchwcInput;
       InputShape[1] = NchwcInputChannels;
     }

--- a/onnxruntime/test/mlas/unittest/test_pool2d_nchwc.h
+++ b/onnxruntime/test/mlas/unittest/test_pool2d_nchwc.h
@@ -36,7 +36,7 @@ class MlasNchwcPool2DTest : public MlasPool2DTest<PoolingKind, Threaded> {
     size_t NchwcOutputElements = size_t(NchwcOutputShape[0]) * size_t(NchwcOutputShape[1]) * size_t(NchwcOutputShape[2]) * size_t(NchwcOutputShape[3]);
     float* NchwcOutput = BufferNchwcOutput.GetBuffer(NchwcOutputElements);
 
-    MlasReorderInput(InputShape, Input, NchwcInput);
+    ReorderInputNchw(InputShape, Input, NchwcInput);
 
     MlasNchwcPool(PoolingKind,
                   NchwcInputShape,

--- a/onnxruntime/test/mlas/unittest/test_util.h
+++ b/onnxruntime/test/mlas/unittest/test_util.h
@@ -211,7 +211,7 @@ class MlasLongExecuteTests : public MlasTestFixture<TMlasTester> {
   }
 };
 
-// Some short Execute may not need to distinguish each parameters, 
+// Some short Execute may not need to distinguish each parameters,
 // because they finish quickly, and may disturb others by inject too many small tests.
 // Register it as whole using following helper.
 template <typename TMlasTester>
@@ -237,3 +237,16 @@ class MlasDirectShortExecuteTests : public MlasTestFixture<TMlasTester> {
   }
 };
 
+inline
+void ReorderInputNchw(const int64_t* input_shape, const float* S, float* D) {
+  const int64_t nchwc_block_size = static_cast<int64_t>(MlasNchwcGetBlockSize());
+  int64_t batch_count = input_shape[0];
+  int64_t channel_count = input_shape[1];
+  int64_t nchwc_channel_count = (channel_count + nchwc_block_size - 1) & ~(nchwc_block_size - 1);
+  int64_t spatial_count = input_shape[2] * input_shape[3];
+  for (int64_t n = 0; n < batch_count; n++) {
+    MlasReorderInputNchw(S, D, static_cast<size_t>(channel_count), static_cast<size_t>(spatial_count));
+    S += spatial_count * channel_count;
+    D += spatial_count * nchwc_channel_count;
+  }
+}


### PR DESCRIPTION
**Description**: 
Implement various improvements related to reordering a tensor for use by NCHWc operations:
1. Relax the requirement that the input channel count must be a multiple of the NCHWc block size (either 8 or 16 depending on ISA). The requirement now is that the channel count must be a multiple of 4. The implementation of MlasReorderInputNchw would need further work to support relaxing this further, but I don't have any models where I've observed this to be necessary yet.
2. Support fusing a Transpose(NHWC->NCHW) into a following ReorderInput. ReorderInput now has a channels_last attribute as was done in the past for ReorderOutput. This helps with models converted from TF where the converter is unable to remove all Transpose operations.
3. Add threading support to ReorderInput to accelerate performance (ReorderOutput will come later).