### PR TITLE
Fix user input order before ORTModule feed it to backend

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -18,6 +18,7 @@ class _InputInfo(object):
                  dynamic_axes=None,
                  schema=None,
                  num_positionals=0,
+                 num_positionals_non_none=0,
                  keyword_names=None):
         self.names = names
         self.shape = shape
@@ -25,17 +26,19 @@ class _InputInfo(object):
         self.dynamic_axes = dynamic_axes if dynamic_axes else {}
         self.schema = schema if schema else []
         self.num_positionals = num_positionals
+        self.num_positionals_non_none = num_positionals_non_none
         self.keyword_names = keyword_names
 
     def __repr__(self) -> str:
         return f'''_InputInfo class:
-            \tNames:            {self.names}
-            \tShape:            {self.shape}
-            \tRequire gradient: {self.require_grad_names}
-            \tDynamic axes:     {self.dynamic_axes}
-            \tSchema:           {self.schema}
-            \t#Positionals:     {self.num_positionals}
-            \tKeyword names:    {self.keyword_names}'''
+            \tNames:                   {self.names}
+            \tShape:                   {self.shape}
+            \tRequire gradient:        {self.require_grad_names}
+            \tDynamic axes:            {self.dynamic_axes}
+            \tSchema:                  {self.schema}
+            \t#Positionals:            {self.num_positionals}
+            \t#Positionals (non-None): {self.num_positionals_non_none}
+            \tKeyword names:           {self.keyword_names}'''
 
     def flatten(self, args, kwargs):
         '''Flatten args and kwargs in a single tuple of tensors with strict ordering'''
@@ -48,7 +51,7 @@ class _InputInfo(object):
         '''Unflatten tuple of tensors into args and kwargs'''
 
         args = tuple(flat_args[:self.num_positionals])
-        kwargs = {name: arg for name, arg in zip(self.names, flat_args[self.num_positionals:]) \
+        kwargs = {name: arg for name, arg in zip(self.names[self.num_positionals_non_none:], flat_args[self.num_positionals:]) \
             if name in self.keyword_names}
         return args, kwargs
 
@@ -356,6 +359,7 @@ def parse_inputs_for_onnx_export(all_input_parameters, onnx_graph, inputs, kwarg
                       dynamic_axes=dynamic_axes,
                       schema=schema,
                       num_positionals=len(inputs),
+                      num_positionals_non_none=len([i for i in inputs if i is not None]),
                       keyword_names=kwargs.keys())
 
 

--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -138,10 +138,10 @@ class _TensorStub(object):
         return result
 
     def __eq__(self, other):
-        if not isinstance(other, _TensorStub):
-            raise NotImplemented('_TensorStub must only be compared to another _TensorStub instance!')
-        elif not other:
+        if not other:
             return False
+        elif not isinstance(other, _TensorStub):
+            raise NotImplemented('_TensorStub must only be compared to another _TensorStub instance!')
         elif self.name != other.name:
             return False
         elif self.dtype != other.dtype:

--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -36,7 +36,7 @@ class _InputInfo(object):
             \tRequire gradient:        {self.require_grad_names}
             \tDynamic axes:            {self.dynamic_axes}
             \tSchema:                  {self.schema}
-            \t#Positionals:            {self.num_positionals}
+            \t#Positionals (total):    {self.num_positionals}
             \t#Positionals (non-None): {self.num_positionals_non_none}
             \tKeyword names:           {self.keyword_names}'''
 

--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -41,15 +41,15 @@ class _InputInfo(object):
         '''Flatten args and kwargs in a single tuple of tensors with strict ordering'''
 
         ret = list(args)
-        for _, kwarg in kwargs.items():
-            ret.append(kwarg)
-        return tuple(ret)
+        ret += [kwargs[name] for name in self.names if name in kwargs]
+        return ret
 
     def unflatten(self, flat_args):
         '''Unflatten tuple of tensors into args and kwargs'''
 
         args = tuple(flat_args[:self.num_positionals])
-        kwargs = {kwarg_name: arg for kwarg_name, arg in zip(self.keyword_names, flat_args[self.num_positionals:])}
+        kwargs = {name: arg for name, arg in zip(self.names, flat_args[self.num_positionals:]) \
+            if name in self.keyword_names}
         return args, kwargs
 
 def _combine_input_buffers_initializers(param_names, onnx_input_names, input_info, buffer_names, inputs, kwargs):

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -2054,29 +2054,39 @@ def test_forward_call_default_input():
         else:
             model.eval()
 
+        # Force model (re)export to validate (un)flattening with new input
+        model._execution_manager(model._is_training())._onnx_model = None
         # Model only uses a,d out of a,b,c,d
         out = model(one, two, three, four)
         assert out.item() == 5.0
         if model.training:
             out.sum().backward()
 
+        # Force model (re)export to validate (un)flattening with new input
+        model._execution_manager(model._is_training())._onnx_model = None
         out = model(one, two, c=three, d=four)
         assert out.item() == 5.0
         if model.training:
             out.sum().backward()
 
+        # Force model (re)export to validate (un)flattening with new input
+        model._execution_manager(model._is_training())._onnx_model = None
         # Model only uses a,d,args[-1] out of a,b,c,d,*args
         out = model(one, two, three, four, *args)
         assert out.item() == 7.0
         if model.training:
             out.sum().backward()
 
+        # Force model (re)export to validate (un)flattening with new input
+        model._execution_manager(model._is_training())._onnx_model = None
         # Model only uses a,d,args[-1],kw_0 out of a,b,c,d,*args,kw_0
         out = model(one, two, three, four, *args, kw_0=kw_0)
         assert out.item() == 13.0
         if model.training:
             out.sum().backward()
 
+        # Force model (re)export to validate (un)flattening with new input
+        model._execution_manager(model._is_training())._onnx_model = None
         # Model only uses a,d,args[-1],kwargs['kwargs_1'] out of a,b,c,d,*args,kw_0,**kwargs
         out = model(one, two, three, four, *args, **kwargs)
         assert out.item() == 15.0
@@ -2123,7 +2133,9 @@ def test_forward_call_kwargs_input_unexpected_order():
         else:
             model.eval()
 
-        # This is expected to work because
+        # Force model (re)export to validate (un)flattening with new input
+        model._execution_manager(model._is_training())._onnx_model = None
+        # Must work because forward() and dict order match
         y1, y2 = model(**{'input1': input1, 'input2': input2})
         assert y1 is not None
         assert y2 is not None
@@ -2131,10 +2143,7 @@ def test_forward_call_kwargs_input_unexpected_order():
             loss = y1.sum() + y2.sum()
             loss.backward()
 
-        # Force model export to validate (un)flattening with new input
-        model._execution_manager(model._is_training())._onnx_model = None
-
-        # This is expected to work too
+        # Must work even when forward() and dict order mismatch
         y1, y2 = model(**{'input2': input2, 'input1': input1})
         assert y1 is not None
         assert y2 is not None

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -2098,15 +2098,11 @@ def test_forward_call_kwargs_input_unexpected_order():
     class OrderlyNet(torch.nn.Module):
         def __init__(self, input_size, hidden_size, num_classes):
             super(OrderlyNet, self).__init__()
-
             self.fc1 = torch.nn.Linear(input_size, hidden_size)
             self.relu = torch.nn.ReLU()
             self.fc2 = torch.nn.Linear(hidden_size, num_classes)
 
         def forward(self, input1=None, input2=None):
-            print(input1.shape)
-            print(input2.shape)
-            # import pdb; pdb.set_trace()
             assert input1.shape != input2.shape
             input2 = torch.transpose(input2, 0, 1)
             assert input1.shape == input2.shape
@@ -2143,6 +2139,8 @@ def test_forward_call_kwargs_input_unexpected_order():
             loss = y1.sum() + y2.sum()
             loss.backward()
 
+        # Force model (re)export to validate (un)flattening with new input
+        model._execution_manager(model._is_training())._onnx_model = None
         # Must work even when forward() and dict order mismatch
         y1, y2 = model(**{'input2': input2, 'input1': input1})
         assert y1 is not None
@@ -2150,3 +2148,77 @@ def test_forward_call_kwargs_input_unexpected_order():
         if model.training:
             loss = y1.sum() + y2.sum()
             loss.backward()
+
+
+def test_forward_call_lots_None():
+    class NoneNet(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.zeros = torch.nn.Parameter(torch.zeros(1,1))
+
+        def forward(self, a, b, c, d, e, f, y=None, z=None):
+            assert a is not None
+            result = self.zeros.sum() + a
+            if b is not None:
+                result += b
+            if c is not None:
+                result += c
+            if d is not None:
+                result += d
+            if e is not None:
+                result += e
+            if f is not None:
+                result += f
+            if y is not None:
+                result += y
+            if z is not None:
+                result += z
+            return result
+
+    def run_step(expected, a, b, c, d, e, f, y, z):
+        # Force model (re)export to validate (un)flattening with new input
+        model._execution_manager(model._is_training())._onnx_model = None
+        out = model(a,b,c,d,e,f,y,z)
+        assert out is not None
+        assert out.item() == expected
+        if model.training:
+            loss = out.sum()
+            loss.backward()
+
+    device = 'cuda'
+    model = NoneNet().to(device)
+    model = ORTModule(model)
+
+    a = torch.FloatTensor([1]).to(device)*1
+    b = torch.FloatTensor([1]).to(device)*10
+    c = torch.FloatTensor([1]).to(device)*100
+    d = torch.FloatTensor([1]).to(device)*1000
+    e = torch.FloatTensor([1]).to(device)*10000
+    f = torch.FloatTensor([1]).to(device)*100000
+    y = torch.FloatTensor([1]).to(device)*1000000
+    z = torch.FloatTensor([1]).to(device)*10000000
+
+    # Make sure model runs without any exception
+    for i in range(2):
+        # Test both train and inference mode
+        if i % 2 == 0:
+            model.train()
+        else:
+            model.eval()
+
+        run_step(a.item() + f.item(),
+                 a, None, None, None, None, f, None, None, )
+        run_step(a.item() + f.item(),
+                 **{'a': a, 'b': None, 'c': None, 'd': None, 'e': None, 'f': f, 'y': None, 'z': None})
+        run_step(a.item() + z.item(),
+                 a, None, None, None, None, None, None, z)
+        run_step(a.item() + z.item(),
+                 **{'a': a, 'b': None, 'c': None, 'd': None, 'e': None, 'f': None, 'y': None, 'z': z})
+        run_step(a.item() + c.item() + y.item(),
+                 a, None, c, None, None, None, y, None)
+        run_step(a.item() + c.item() + y.item(),
+                 **{'a': a, 'b': None, 'c': c, 'd': None, 'e': None, 'f': None, 'y': y, 'z': None})
+        run_step(a.item() + b.item() + c.item() + d.item() + e.item() + f.item() + y.item() + z.item(),
+                 a, b, c, d, e, f, y, z)
+        run_step(a.item() + b.item() + c.item() + d.item() + e.item() + f.item() + y.item() + z.item(),
+                 **{'a': a, 'b': b, 'c': c, 'd': d, 'e': e, 'f': f, 'y': y, 'z': z})


### PR DESCRIPTION
Currently `ORTModule` needs to flatten user input before passing it to ONNX exporter.
The flattening process transforms dictionary keys into keywords.

The issues is that `ORTModule` assumes that the "natural dictionary order" of user input can be passed to the exporter when positionals, keywords or **kwargs are specified as dicts.

Assuming the dummy model
```python
class OrderlyNet(torch.nn.Module):
   def forward(self, input1=None, input2=None):
      ...
```
`ORTModule` assumes a dictionary such as `**{'input1': input1, 'input2': input2}` would be provided.
However, if the user provided a valid input such as `**{'input2': input2, 'input1': input1}` instead, tensors would be swapped and exporting process would fail.

This PR changes input flattening and unflattening to process user data using the order from the `forward(self, ...)` method as reference as opposed to natural dict ordering.