### PR TITLE
Add log to allow serving platforms to quantify ORT usage.

### DIFF
--- a/include/onnxruntime/core/common/logging/severity.h
+++ b/include/onnxruntime/core/common/logging/severity.h
@@ -14,10 +14,9 @@ enum class Severity {
   kWARNING = 2,
   kERROR = 3,
   kFATAL = 4,
-  kTELEM = 5,
 };
 
-constexpr const char* SEVERITY_PREFIX = "VIWEFT";
+constexpr const char* SEVERITY_PREFIX = "VIWEF";
 
 }  // namespace logging
 }  // namespace onnxruntime

--- a/include/onnxruntime/core/common/logging/severity.h
+++ b/include/onnxruntime/core/common/logging/severity.h
@@ -13,10 +13,11 @@ enum class Severity {
   kINFO = 1,
   kWARNING = 2,
   kERROR = 3,
-  kFATAL = 4
+  kFATAL = 4,
+  kTELEM = 5,
 };
 
-constexpr const char* SEVERITY_PREFIX = "VIWEF";
+constexpr const char* SEVERITY_PREFIX = "VIWEFT";
 
 }  // namespace logging
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -298,15 +298,23 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
   // To avoid flooding the test logs, this is done for non-debug mode only
   // TODO: plug-in a platform specific telemetry provider to send the telemetry to
 #ifdef NDEBUG
+#ifdef _WIN32
+  std::wostringstream ostr;
+#else
   std::ostringstream ostr;
-  // Format: "ORT Telemetry: Version = 1.7.0; Event = EventName (event_attr1: foo.onnx, event_attr2: 400us)"
-  // Format: "ORT Telemetry: Version = 1.7.0; Event = SessionCreation (model: foo.onnx, ts: 400us)"
+#endif
+  // Format: "ORT Telemetry: Ver = 1.7.0; Event = EventName (event_attr1: foo.onnx, event_attr2: 400us)"
+  // Format: "ORT Telemetry: Ver = 1.7.0; Event = SessionCreation (model: foo.onnx, ts: 400us)"
   ostr << "ORT Telemetry: "
        << "Ver = " << ORT_VERSION << "; Event = SessionCreation";
   if (!model_location_.empty()) {
     ostr << " (model: " << model_location_ << ")";
   }
-  LOGS(*session_logger_, TELEM) << ostr.str();
+#ifdef _WIN32
+  std::wcout << ostr.str() << "\n";
+#else
+  std::cout << ostr.str() << "\n";
+#endif
 #endif
 }
 


### PR DESCRIPTION
**Description**: Add log to allow serving platforms to quantify ORT usage.

**Motivation and Context**
Some of our internal serving platforms are interested in quantifying ORT usage.