### PR TITLE
Fix implicit-exception-spec-mismatch warning.

### DIFF
--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -19,7 +19,10 @@
 
 // Override default new/delete so that we match the host's allocator
 _Ret_notnull_ _Post_writable_byte_size_(n) void* operator new(size_t n) { return Provider_GetHost()->HeapAllocate(n); }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wimplicit-exception-spec-mismatch"
 void operator delete(void* p) { return Provider_GetHost()->HeapFree(p); }
+#pragma clang diagnostic pop
 void operator delete(void* p, size_t /*size*/) { return Provider_GetHost()->HeapFree(p); }
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -17,12 +17,13 @@
 #define _Post_writable_byte_size_(n)
 #endif
 
+#ifndef _GLIBCXX_USE_NOEXCEPT 
+#define _GLIBCXX_USE_NOEXCEPT 
+#endif
+
 // Override default new/delete so that we match the host's allocator
 _Ret_notnull_ _Post_writable_byte_size_(n) void* operator new(size_t n) { return Provider_GetHost()->HeapAllocate(n); }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wimplicit-exception-spec-mismatch"
-void operator delete(void* p) { return Provider_GetHost()->HeapFree(p); }
-#pragma clang diagnostic pop
+void operator delete(void* p) _GLIBCXX_USE_NOEXCEPT { return Provider_GetHost()->HeapFree(p); }
 void operator delete(void* p, size_t /*size*/) { return Provider_GetHost()->HeapFree(p); }
 
 namespace onnxruntime {


### PR DESCRIPTION
My build is failing on WSL2 - Ubuntu 20.04 with:

 error: function previously declared with an explicit exception specification redeclared with an implicit exception specification [-Werror,-Wimplicit-exception-spec-mismatch]

This marks the function as NOEXCEPT if defined.