### PR TITLE
[WIP] Install onnxruntime wheel package before ORTModule tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -247,7 +247,8 @@ if enable_training:
     packages.extend(['onnxruntime.training',
                      'onnxruntime.training.amp',
                      'onnxruntime.training.optim',
-                     'onnxruntime.training.ortmodule'])
+                    #  'onnxruntime.training.ortmodule', # breaking on purpose to see if pipeline fails
+    ])
     requirements_file = "requirements-training.txt"
     # with training, we want to follow this naming convention:
     # stable:

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
@@ -50,7 +50,7 @@ jobs:
         --volume /hf_models_cache:/hf_models_cache \
         onnxruntime_ortmodule_tests_image \
             rm -rfv /build/RelWithDebInfo/onnxruntime/ && \
-            ls -lhR /build/RelWithDebInfo/ ; \
+            find /build -print && \
             pip install /build/RelWithDebInfo/dist/onnxruntime*.whl && \
             /build/RelWithDebInfo/launch_test.py \
             --cmd_line_with_args "python orttraining_ortmodule_tests.py --mnist /mnist --bert_data /bert_data/hf_data/glue_data/CoLA/original/raw --transformers_cache /hf_models_cache/huggingface/transformers" \

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
@@ -50,6 +50,7 @@ jobs:
         --volume /hf_models_cache:/hf_models_cache \
         onnxruntime_ortmodule_tests_image \
             rm -rfv /build/RelWithDebInfo/onnxruntime/ && \
+            ls -lhR /build/RelWithDebInfo/ ; \
             pip install /build/RelWithDebInfo/dist/onnxruntime*.whl && \
             /build/RelWithDebInfo/launch_test.py \
             --cmd_line_with_args "python orttraining_ortmodule_tests.py --mnist /mnist --bert_data /bert_data/hf_data/glue_data/CoLA/original/raw --transformers_cache /hf_models_cache/huggingface/transformers" \

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
@@ -49,8 +49,7 @@ jobs:
         --volume /bert_data:/bert_data \
         --volume /hf_models_cache:/hf_models_cache \
         onnxruntime_ortmodule_tests_image \
-            rm -rfv /build/RelWithDebInfo/onnxruntime/ && \
-            find /build -print && \
+            find / -print && \
             pip install /build/RelWithDebInfo/dist/onnxruntime*.whl && \
             /build/RelWithDebInfo/launch_test.py \
             --cmd_line_with_args "python orttraining_ortmodule_tests.py --mnist /mnist --bert_data /bert_data/hf_data/glue_data/CoLA/original/raw --transformers_cache /hf_models_cache/huggingface/transformers" \

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
@@ -49,10 +49,7 @@ jobs:
         --volume /bert_data:/bert_data \
         --volume /hf_models_cache:/hf_models_cache \
         onnxruntime_ortmodule_tests_image \
-            ls -lh /build && \
-            ls -lh /build/RelWithDebInfo && \
-            ls -lh /onnxruntime_src && \
-            rm -rfv /build/RelWithDebInfo/onnxruntime && \
+            rm -rfv /build/RelWithDebInfo/onnxruntime/ && \
             pip install /build/RelWithDebInfo/dist/onnxruntime*.whl && \
             /build/RelWithDebInfo/launch_test.py \
             --cmd_line_with_args "python orttraining_ortmodule_tests.py --mnist /mnist --bert_data /bert_data/hf_data/glue_data/CoLA/original/raw --transformers_cache /hf_models_cache/huggingface/transformers" \

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
@@ -49,11 +49,7 @@ jobs:
         --volume /bert_data:/bert_data \
         --volume /hf_models_cache:/hf_models_cache \
         onnxruntime_ortmodule_tests_image \
-            find / -print && \
-            pip install /build/RelWithDebInfo/dist/onnxruntime*.whl && \
-            /build/RelWithDebInfo/launch_test.py \
-            --cmd_line_with_args "python orttraining_ortmodule_tests.py --mnist /mnist --bert_data /bert_data/hf_data/glue_data/CoLA/original/raw --transformers_cache /hf_models_cache/huggingface/transformers" \
-            --cwd /build/RelWithDebInfo \
+            bash -c "rm -rfv /build/RelWithDebInfo/onnxruntime ; find /build -print ; python3 -m pip install /build/RelWithDebInfo/dist/onnxruntime*.whl ; /build/RelWithDebInfo/launch_test.py --cmd_line_with_args 'python orttraining_ortmodule_tests.py --mnist /mnist --bert_data /bert_data/hf_data/glue_data/CoLA/original/raw --transformers_cache /hf_models_cache/huggingface/transformers' --cwd /build/RelWithDebInfo" \
     displayName: 'Run orttraining_ortmodule_tests.py'
     condition: succeededOrFailed()
     timeoutInMinutes: 60

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
@@ -50,9 +50,10 @@ jobs:
         --volume /hf_models_cache:/hf_models_cache \
         onnxruntime_ortmodule_tests_image \
             ls -lh /build && \
+            ls -lh /build/RelWithDebInfo && \
             ls -lh /onnxruntime_src && \
-            rm -rfv /build/onnxruntime && \
-            pip install /build/dist/onnxruntime*.whl && \
+            rm -rfv /build/RelWithDebInfo/onnxruntime && \
+            pip install /build/RelWithDebInfo/dist/onnxruntime*.whl && \
             /build/RelWithDebInfo/launch_test.py \
             --cmd_line_with_args "python orttraining_ortmodule_tests.py --mnist /mnist --bert_data /bert_data/hf_data/glue_data/CoLA/original/raw --transformers_cache /hf_models_cache/huggingface/transformers" \
             --cwd /build/RelWithDebInfo \

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
@@ -49,8 +49,12 @@ jobs:
         --volume /bert_data:/bert_data \
         --volume /hf_models_cache:/hf_models_cache \
         onnxruntime_ortmodule_tests_image \
-          /build/RelWithDebInfo/launch_test.py \
-            --cmd_line_with_args "rm -rfv /build/onnxruntime && pip install /build/dist/onnxruntime*.whl && python orttraining_ortmodule_tests.py --mnist /mnist --bert_data /bert_data/hf_data/glue_data/CoLA/original/raw --transformers_cache /hf_models_cache/huggingface/transformers" \
+            ls -lh /build && \
+            ls -lh /onnxruntime_src && \
+            rm -rfv /build/onnxruntime && \
+            pip install /build/dist/onnxruntime*.whl && \
+            /build/RelWithDebInfo/launch_test.py \
+            --cmd_line_with_args "python orttraining_ortmodule_tests.py --mnist /mnist --bert_data /bert_data/hf_data/glue_data/CoLA/original/raw --transformers_cache /hf_models_cache/huggingface/transformers" \
             --cwd /build/RelWithDebInfo \
     displayName: 'Run orttraining_ortmodule_tests.py'
     condition: succeededOrFailed()

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-ci-pipeline.yml
@@ -50,7 +50,7 @@ jobs:
         --volume /hf_models_cache:/hf_models_cache \
         onnxruntime_ortmodule_tests_image \
           /build/RelWithDebInfo/launch_test.py \
-            --cmd_line_with_args "python orttraining_ortmodule_tests.py --mnist /mnist --bert_data /bert_data/hf_data/glue_data/CoLA/original/raw --transformers_cache /hf_models_cache/huggingface/transformers" \
+            --cmd_line_with_args "rm -rfv /build/onnxruntime && pip install /build/dist/onnxruntime*.whl && python orttraining_ortmodule_tests.py --mnist /mnist --bert_data /bert_data/hf_data/glue_data/CoLA/original/raw --transformers_cache /hf_models_cache/huggingface/transformers" \
             --cwd /build/RelWithDebInfo \
     displayName: 'Run orttraining_ortmodule_tests.py'
     condition: succeededOrFailed()


### PR DESCRIPTION
Pipelines use onnxruntime files from build folder as onnxruntime package. That prevents us to find out issues with the packaging itself

This PR will delete the onnxruntime folder from the build directory and install the wheel package, forcing the CI to use the created package for tests