### PR TITLE
Add Thread Spinning Session Option in WinML

### DIFF
--- a/winml/adapter/winml_adapter_apis.h
+++ b/winml/adapter/winml_adapter_apis.h
@@ -56,6 +56,7 @@ ORT_API_STATUS(SessionRegisterGraphTransformers, _In_ OrtSession* session);
 ORT_API_STATUS(SessionRegisterCustomRegistry, _In_ OrtSession* session, _In_ IMLOperatorRegistry* registry);
 ORT_API_STATUS(SessionCopyOneInputAcrossDevices, _In_ OrtSession* session, _In_ const char* const input_name, _In_ OrtValue* orig_value, _Outptr_ OrtValue** new_value);
 ORT_API_STATUS(SessionGetNumberOfIntraOpThreads, _In_ OrtSession* session, _Out_ uint32_t* num_threads);
+ORT_API_STATUS(SessionGetIntraOpThreadSpinningConfigEntry, _In_ OrtSession* session, _Out_ const char** allow_spinning);
 ORT_API_STATUS(SessionGetNamedDimensionsOverrides, _In_ OrtSession* session, _Out_ winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, uint32_t>& overrides);
 
 // Dml methods (TODO need to figure out how these need to move to session somehow...)

--- a/winml/adapter/winml_adapter_apis.h
+++ b/winml/adapter/winml_adapter_apis.h
@@ -56,7 +56,7 @@ ORT_API_STATUS(SessionRegisterGraphTransformers, _In_ OrtSession* session);
 ORT_API_STATUS(SessionRegisterCustomRegistry, _In_ OrtSession* session, _In_ IMLOperatorRegistry* registry);
 ORT_API_STATUS(SessionCopyOneInputAcrossDevices, _In_ OrtSession* session, _In_ const char* const input_name, _In_ OrtValue* orig_value, _Outptr_ OrtValue** new_value);
 ORT_API_STATUS(SessionGetNumberOfIntraOpThreads, _In_ OrtSession* session, _Out_ uint32_t* num_threads);
-ORT_API_STATUS(SessionGetIntraOpThreadSpinningConfigEntry, _In_ OrtSession* session, _Out_ const char** allow_spinning);
+ORT_API_STATUS(SessionGetIntraOpThreadSpinning, _In_ OrtSession* session, _Out_ bool* allow_spinning);
 ORT_API_STATUS(SessionGetNamedDimensionsOverrides, _In_ OrtSession* session, _Out_ winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, uint32_t>& overrides);
 
 // Dml methods (TODO need to figure out how these need to move to session somehow...)

--- a/winml/adapter/winml_adapter_c_api.cpp
+++ b/winml/adapter/winml_adapter_c_api.cpp
@@ -57,6 +57,7 @@ static constexpr WinmlAdapterApi winml_adapter_api_1 = {
     &winmla::SessionEndProfiling,
     &winmla::SessionCopyOneInputAcrossDevices,
     &winmla::SessionGetNumberOfIntraOpThreads,
+    &winmla::SessionGetIntraOpThreadSpinningConfigEntry,
     &winmla::SessionGetNamedDimensionsOverrides,
 
     // Dml methods (TODO need to figure out how these need to move to session somehow...)

--- a/winml/adapter/winml_adapter_c_api.cpp
+++ b/winml/adapter/winml_adapter_c_api.cpp
@@ -57,7 +57,7 @@ static constexpr WinmlAdapterApi winml_adapter_api_1 = {
     &winmla::SessionEndProfiling,
     &winmla::SessionCopyOneInputAcrossDevices,
     &winmla::SessionGetNumberOfIntraOpThreads,
-    &winmla::SessionGetIntraOpThreadSpinningConfigEntry,
+    &winmla::SessionGetIntraOpThreadSpinning,
     &winmla::SessionGetNamedDimensionsOverrides,
 
     // Dml methods (TODO need to figure out how these need to move to session somehow...)

--- a/winml/adapter/winml_adapter_c_api.h
+++ b/winml/adapter/winml_adapter_c_api.h
@@ -302,6 +302,14 @@ struct WinmlAdapterApi {
     */
   OrtStatus*(ORT_API_CALL* SessionGetNumberOfIntraOpThreads)(_In_ OrtSession* session, _Out_ uint32_t* num_threads)NO_EXCEPTION;
 
+    /**
+    * SessionGetIntrapOpThreadSpinning
+     * This api returns the value of "session.intra_op.allow_spinning"
+    * 
+    * WinML uses this to determine that the intra op thread spin policy was set correctly through OrtSessionOptions
+    */
+  OrtStatus*(ORT_API_CALL* SessionGetIntraOpThreadSpinningConfigEntry)(_In_ OrtSession* session, _Out_ const char** allow_spinning)NO_EXCEPTION;
+
       /**
     * SessionGetNamedDimensionsOverrides
      * This api returns the named dimension overrides that are specified for this session

--- a/winml/adapter/winml_adapter_c_api.h
+++ b/winml/adapter/winml_adapter_c_api.h
@@ -304,11 +304,11 @@ struct WinmlAdapterApi {
 
     /**
     * SessionGetIntrapOpThreadSpinning
-     * This api returns the value of "session.intra_op.allow_spinning"
+     * This api returns false if the ort session options config entry "session.intra_op.allow_spinning" is set to "0", and true otherwise
     * 
     * WinML uses this to determine that the intra op thread spin policy was set correctly through OrtSessionOptions
     */
-  OrtStatus*(ORT_API_CALL* SessionGetIntraOpThreadSpinningConfigEntry)(_In_ OrtSession* session, _Out_ const char** allow_spinning)NO_EXCEPTION;
+  OrtStatus*(ORT_API_CALL* SessionGetIntraOpThreadSpinning)(_In_ OrtSession* session, _Out_ bool* allow_spinning)NO_EXCEPTION;
 
       /**
     * SessionGetNamedDimensionsOverrides

--- a/winml/adapter/winml_adapter_session.cpp
+++ b/winml/adapter/winml_adapter_session.cpp
@@ -255,6 +255,21 @@ ORT_API_STATUS_IMPL(winmla::SessionGetNumberOfIntraOpThreads, _In_ OrtSession* s
   API_IMPL_END
 }
 
+ORT_API_STATUS_IMPL(winmla::SessionGetIntraOpThreadSpinningConfigEntry, _In_ OrtSession* session, _Out_ const char** allow_spinning) {
+    API_IMPL_BEGIN
+    auto inference_session = reinterpret_cast<::onnxruntime::InferenceSession*>(session);
+    auto session_options = inference_session->GetSessionOptions();
+    auto iter = session_options.session_configurations.find("session.intra_op.allow_spinning");
+    if (iter != session_options.session_configurations.cend()) {
+      *allow_spinning = iter->second.c_str();
+    } 
+    else {
+      *allow_spinning = nullptr;
+    }
+    return nullptr;
+    API_IMPL_END
+}
+
 ORT_API_STATUS_IMPL(winmla::SessionGetNamedDimensionsOverrides, _In_ OrtSession* session, _Out_ winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, uint32_t>& named_dimension_overrides) {
   API_IMPL_BEGIN
   auto inference_session = reinterpret_cast<::onnxruntime::InferenceSession*>(session);

--- a/winml/adapter/winml_adapter_session.cpp
+++ b/winml/adapter/winml_adapter_session.cpp
@@ -260,7 +260,7 @@ ORT_API_STATUS_IMPL(winmla::SessionGetIntraOpThreadSpinning, _In_ OrtSession* se
     auto inference_session = reinterpret_cast<::onnxruntime::InferenceSession*>(session);
     auto session_options = inference_session->GetSessionOptions();
     auto iter = session_options.session_configurations.find("session.intra_op.allow_spinning");
-    *allow_spinning = iter != session_options.session_configurations.cend() && iter->second == "0";
+    *allow_spinning = iter == session_options.session_configurations.cend() || iter->second != "0";
     return nullptr;
     API_IMPL_END
 }

--- a/winml/adapter/winml_adapter_session.cpp
+++ b/winml/adapter/winml_adapter_session.cpp
@@ -255,17 +255,12 @@ ORT_API_STATUS_IMPL(winmla::SessionGetNumberOfIntraOpThreads, _In_ OrtSession* s
   API_IMPL_END
 }
 
-ORT_API_STATUS_IMPL(winmla::SessionGetIntraOpThreadSpinningConfigEntry, _In_ OrtSession* session, _Out_ const char** allow_spinning) {
+ORT_API_STATUS_IMPL(winmla::SessionGetIntraOpThreadSpinning, _In_ OrtSession* session, _Out_ bool* allow_spinning) {
     API_IMPL_BEGIN
     auto inference_session = reinterpret_cast<::onnxruntime::InferenceSession*>(session);
     auto session_options = inference_session->GetSessionOptions();
     auto iter = session_options.session_configurations.find("session.intra_op.allow_spinning");
-    if (iter != session_options.session_configurations.cend()) {
-      *allow_spinning = iter->second.c_str();
-    } 
-    else {
-      *allow_spinning = nullptr;
-    }
+    *allow_spinning = iter != session_options.session_configurations.cend() && iter->second == "0";
     return nullptr;
     API_IMPL_END
 }

--- a/winml/api/windows.ai.machinelearning.native.idl
+++ b/winml/api/windows.ai.machinelearning.native.idl
@@ -35,7 +35,7 @@ interface ILearningModelDeviceFactoryNative : IUnknown
     HRESULT CreateFromD3D12CommandQueue(ID3D12CommandQueue * value, [out] IUnknown ** result);
 };
 
-[uuid(5DA37A26-0526-414B-91E4-2A0FA3DDBA40), object, local]
+[uuid(5da37a26-0526-414b-91e4-2a0fa3ddba40), object, local]
 interface ILearningModelSessionOptionsNative : IUnknown
 {
     HRESULT SetIntraOpNumThreadsOverride(UINT32 intraOpNumThreads);

--- a/winml/api/windows.ai.machinelearning.native.idl
+++ b/winml/api/windows.ai.machinelearning.native.idl
@@ -35,11 +35,18 @@ interface ILearningModelDeviceFactoryNative : IUnknown
     HRESULT CreateFromD3D12CommandQueue(ID3D12CommandQueue * value, [out] IUnknown ** result);
 };
 
-[uuid(5da37a26-0526-414b-91e4-2a0fa3ddba40), object, local]
+[uuid(c71e953f-37b4-4564-8658-d8396866db0d), object, local]
 interface ILearningModelSessionOptionsNative : IUnknown
 {
     HRESULT SetIntraOpNumThreadsOverride(UINT32 intraOpNumThreads);
+};
+
+[uuid(5da37a26-0526-414b-91e4-2a0fa3ddba40), object, local]
+interface ILearningModelSessionOptionsNative1 : IUnknown
+{
     HRESULT SetIntraOpThreadSpinning(boolean allowSpinning);
 };
+
+
 
 cpp_quote("#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) */")

--- a/winml/api/windows.ai.machinelearning.native.idl
+++ b/winml/api/windows.ai.machinelearning.native.idl
@@ -46,7 +46,4 @@ interface ILearningModelSessionOptionsNative1 : IUnknown
 {
     HRESULT SetIntraOpThreadSpinning(boolean allowSpinning);
 };
-
-
-
 cpp_quote("#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) */")

--- a/winml/api/windows.ai.machinelearning.native.idl
+++ b/winml/api/windows.ai.machinelearning.native.idl
@@ -35,10 +35,11 @@ interface ILearningModelDeviceFactoryNative : IUnknown
     HRESULT CreateFromD3D12CommandQueue(ID3D12CommandQueue * value, [out] IUnknown ** result);
 };
 
-[uuid(c71e953f-37b4-4564-8658-d8396866db0d), object, local]
+[uuid(5DA37A26-0526-414B-91E4-2A0FA3DDBA40), object, local]
 interface ILearningModelSessionOptionsNative : IUnknown
 {
     HRESULT SetIntraOpNumThreadsOverride(UINT32 intraOpNumThreads);
+    HRESULT SetIntraOpThreadSpinning(boolean allowSpinning);
 };
 
 cpp_quote("#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) */")

--- a/winml/api/windows.ai.machinelearning.native.internal.idl
+++ b/winml/api/windows.ai.machinelearning.native.internal.idl
@@ -59,6 +59,11 @@ interface ILearningModelEvaluationResultNative : IUnknown
 interface ILearningModelSessionNative : IUnknown
 {
     HRESULT GetIntraOpNumThreads(UINT32* numThreads);
+};
+
+[uuid(995ec4b4-73fc-4b65-b544-3de1c9b9eba4), object, local]
+interface ILearningModelSessionNative1 : IUnknown
+{
     HRESULT GetIntraOpThreadSpinning(boolean* allowSpinning);
 };
 

--- a/winml/api/windows.ai.machinelearning.native.internal.idl
+++ b/winml/api/windows.ai.machinelearning.native.internal.idl
@@ -59,6 +59,7 @@ interface ILearningModelEvaluationResultNative : IUnknown
 interface ILearningModelSessionNative : IUnknown
 {
     HRESULT GetIntraOpNumThreads(UINT32* numThreads);
+    HRESULT GetIntraOpThreadSpinning(boolean* allowSpinning);
 };
 
 cpp_quote("#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) */")

--- a/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
@@ -1121,6 +1121,14 @@ HRESULT OnnxruntimeEngine::GetNumberOfIntraOpThreads(uint32_t* num_threads)
   return S_OK;
 }
 
+HRESULT OnnxruntimeEngine::GetIntraOpThreadSpinningConfigEntry(const char** allow_spinning) {
+  auto ort_api = engine_factory_->UseOrtApi();
+  auto winml_adapter_api = engine_factory_->UseWinmlAdapterApi();
+  RETURN_HR_IF_NOT_OK_MSG(winml_adapter_api->SessionGetIntraOpThreadSpinningConfigEntry(session_.get(), allow_spinning), ort_api);
+  return S_OK;
+}
+
+
 HRESULT OnnxruntimeEngine::GetNamedDimensionOverrides(wfc::IMapView<winrt::hstring, uint32_t>& overrides) {
   auto ort_api = engine_factory_->UseOrtApi();
   auto winml_adapter_api = engine_factory_->UseWinmlAdapterApi();

--- a/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
@@ -1121,10 +1121,10 @@ HRESULT OnnxruntimeEngine::GetNumberOfIntraOpThreads(uint32_t* num_threads)
   return S_OK;
 }
 
-HRESULT OnnxruntimeEngine::GetIntraOpThreadSpinningConfigEntry(const char** allow_spinning) {
+HRESULT OnnxruntimeEngine::GetIntraOpThreadSpinning(bool* allow_spinning) {
   auto ort_api = engine_factory_->UseOrtApi();
   auto winml_adapter_api = engine_factory_->UseWinmlAdapterApi();
-  RETURN_HR_IF_NOT_OK_MSG(winml_adapter_api->SessionGetIntraOpThreadSpinningConfigEntry(session_.get(), allow_spinning), ort_api);
+  RETURN_HR_IF_NOT_OK_MSG(winml_adapter_api->SessionGetIntraOpThreadSpinning(session_.get(), allow_spinning), ort_api);
   return S_OK;
 }
 

--- a/winml/lib/Api.Ort/OnnxruntimeEngine.h
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.h
@@ -116,8 +116,8 @@ class OnnxruntimeEngine : public Microsoft::WRL::RuntimeClass<
   STDMETHOD(GetNumberOfIntraOpThreads)
   (uint32_t* num_threads) override;
 
-  STDMETHOD(GetIntraOpThreadSpinningConfigEntry)
-  (const char** allow_spinning) override;
+  STDMETHOD(GetIntraOpThreadSpinning)
+  (bool* allow_spinning) override;
 
   STDMETHOD(GetNamedDimensionOverrides)
   (wfc::IMapView<winrt::hstring, uint32_t>& overrides) override;

--- a/winml/lib/Api.Ort/OnnxruntimeEngine.h
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.h
@@ -116,6 +116,9 @@ class OnnxruntimeEngine : public Microsoft::WRL::RuntimeClass<
   STDMETHOD(GetNumberOfIntraOpThreads)
   (uint32_t* num_threads) override;
 
+  STDMETHOD(GetIntraOpThreadSpinningConfigEntry)
+  (const char** allow_spinning) override;
+
   STDMETHOD(GetNamedDimensionOverrides)
   (wfc::IMapView<winrt::hstring, uint32_t>& overrides) override;
 

--- a/winml/lib/Api.Ort/OnnxruntimeEngineBuilder.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngineBuilder.cpp
@@ -50,6 +50,10 @@ STDMETHODIMP OnnxruntimeEngineBuilder::CreateEngine(_Outptr_ _winml::IEngine** o
 
   RETURN_HR_IF_NOT_OK_MSG(ort_api->SetIntraOpNumThreads(session_options.get(), intra_op_num_threads_override_), ort_api);
 
+  if (!allow_thread_spinning_) {
+    ort_api->AddSessionConfigEntry(session_options.get(), "session.intra_op.allow_spinning", "0");
+  }
+
   OrtSession* ort_session = nullptr;
   onnxruntime_session_builder->CreateSession(session_options.get(), &ort_session);
   auto session = UniqueOrtSession(ort_session, ort_api->ReleaseSession);
@@ -95,5 +99,10 @@ STDMETHODIMP OnnxruntimeEngineBuilder::SetNamedDimensionOverrides(wfc::IMapView<
   
 STDMETHODIMP OnnxruntimeEngineBuilder::SetIntraOpNumThreadsOverride(uint32_t intra_op_num_threads) {
   intra_op_num_threads_override_ = intra_op_num_threads;
+  return S_OK;
+}
+
+STDMETHODIMP OnnxruntimeEngineBuilder::SetIntraOpThreadSpinning(bool allow_spinning) {
+  allow_thread_spinning_ = allow_spinning;
   return S_OK;
 }

--- a/winml/lib/Api.Ort/OnnxruntimeEngineBuilder.h
+++ b/winml/lib/Api.Ort/OnnxruntimeEngineBuilder.h
@@ -32,6 +32,9 @@ class OnnxruntimeEngineBuilder : public Microsoft::WRL::RuntimeClass<
   STDMETHOD(SetIntraOpNumThreadsOverride)
   (uint32_t intra_op_num_threads);
 
+  STDMETHOD(SetIntraOpThreadSpinning)
+  (bool allow_spinning);
+
   STDMETHOD(CreateEngine)
   (_Outptr_ IEngine** out);
 
@@ -43,6 +46,7 @@ class OnnxruntimeEngineBuilder : public Microsoft::WRL::RuntimeClass<
   std::optional<uint32_t> batch_size_override_;
   wfc::IMapView<winrt::hstring, uint32_t> named_dimension_overrides_;
   uint32_t intra_op_num_threads_override_ = 0;
+  bool allow_thread_spinning_ = true;
 };
 
 }  // namespace _winml

--- a/winml/lib/Api/LearningModelSession.cpp
+++ b/winml/lib/Api/LearningModelSession.cpp
@@ -446,6 +446,19 @@ STDMETHODIMP LearningModelSession::GetIntraOpNumThreads(uint32_t* numThreads)
   return engine_->GetNumberOfIntraOpThreads(numThreads);
 }
 
+STDMETHODIMP LearningModelSession::GetIntraOpThreadSpinning(boolean *allowSpinning)
+{
+  const char* spinValue;
+  RETURN_IF_FAILED(engine_->GetIntraOpThreadSpinningConfigEntry(&spinValue));
+  std::string spinStr(spinValue);
+  if (spinStr == "0") {
+    *allowSpinning = false;
+  } else {
+    *allowSpinning = true;
+  }
+  return S_OK;
+}
+
 winml::LearningModelSession LearningModelSession::CreateInertSession(_winml::IEngine* engine) {
   return winrt::make<winmlp::LearningModelSession>(engine);
 }

--- a/winml/lib/Api/LearningModelSession.cpp
+++ b/winml/lib/Api/LearningModelSession.cpp
@@ -446,16 +446,10 @@ STDMETHODIMP LearningModelSession::GetIntraOpNumThreads(uint32_t* numThreads)
   return engine_->GetNumberOfIntraOpThreads(numThreads);
 }
 
-STDMETHODIMP LearningModelSession::GetIntraOpThreadSpinning(boolean *allowSpinning)
-{
-  const char* spinValue;
-  RETURN_IF_FAILED(engine_->GetIntraOpThreadSpinningConfigEntry(&spinValue));
-  std::string spinStr(spinValue);
-  if (spinStr == "0") {
-    *allowSpinning = false;
-  } else {
-    *allowSpinning = true;
-  }
+STDMETHODIMP LearningModelSession::GetIntraOpThreadSpinning(boolean* allowSpinning) {
+  bool allowSpinningBool;
+  RETURN_IF_FAILED(engine_->GetIntraOpThreadSpinning(&allowSpinningBool));
+  *allowSpinning = static_cast<boolean>(allowSpinningBool);
   return S_OK;
 }
 

--- a/winml/lib/Api/LearningModelSession.cpp
+++ b/winml/lib/Api/LearningModelSession.cpp
@@ -125,16 +125,20 @@ void LearningModelSession::Initialize() {
     if (session_options_.BatchSizeOverride() != 0) {
       WINML_THROW_IF_FAILED(engine_builder->SetBatchSizeOverride(session_options_.BatchSizeOverride()));
     }
+
+    com_ptr<winmlp::LearningModelSessionOptions> session_options_impl = session_options_.as<winmlp::LearningModelSessionOptions>();
+
     // Make Onnxruntime apply the number of intra op threads
-    uint32_t numIntraOpThreads = session_options_.as<WINMLP::LearningModelSessionOptions>()->GetIntraOpNumThreads();
-    WINML_THROW_IF_FAILED(engine_builder->SetIntraOpNumThreadsOverride(numIntraOpThreads)
-    );
+    uint32_t numIntraOpThreads = session_options_impl->GetIntraOpNumThreads();
+    WINML_THROW_IF_FAILED(engine_builder->SetIntraOpNumThreadsOverride(numIntraOpThreads));
     
     // Make onnxruntime apply named dimension overrides, if any
-    com_ptr<winmlp::LearningModelSessionOptions> session_options_impl = session_options_.as<winmlp::LearningModelSessionOptions>();
     if (session_options_impl && session_options_impl->NamedDimensionOverrides().Size() > 0) {
       WINML_THROW_IF_FAILED(engine_builder->SetNamedDimensionOverrides(session_options_impl->NamedDimensionOverrides()));
     }
+    bool allowSpinning = session_options_impl->GetIntraOpThreadSpinning();
+    WINML_THROW_IF_FAILED(engine_builder->SetIntraOpThreadSpinning(allowSpinning));
+
   } else {
     // Onnxruntime will use half the number of concurrent threads supported on the system
     // by default. This causes MLAS to not exercise every logical core.

--- a/winml/lib/Api/LearningModelSession.h
+++ b/winml/lib/Api/LearningModelSession.h
@@ -13,7 +13,7 @@
 
 namespace WINMLP {
 
-struct LearningModelSession : LearningModelSessionT<LearningModelSession, ILearningModelSessionNative> {
+struct LearningModelSession : LearningModelSessionT<LearningModelSession, ILearningModelSessionNative, ILearningModelSessionNative1> {
   /* LearningModelSession constructors (MachineLearningContract 1). */
   LearningModelSession(_winml::IEngine* engine);
 
@@ -70,7 +70,6 @@ struct LearningModelSession : LearningModelSessionT<LearningModelSession, ILearn
 
   STDMETHOD(GetIntraOpThreadSpinning)
   (boolean* allowSpinning);
-
 
  public:
   /* Non-ABI methods */

--- a/winml/lib/Api/LearningModelSession.h
+++ b/winml/lib/Api/LearningModelSession.h
@@ -68,6 +68,10 @@ struct LearningModelSession : LearningModelSessionT<LearningModelSession, ILearn
   STDMETHOD(GetIntraOpNumThreads)
   (uint32_t* numThreads);
 
+  STDMETHOD(GetIntraOpThreadSpinning)
+  (boolean* allowSpinning);
+
+
  public:
   /* Non-ABI methods */
 

--- a/winml/lib/Api/LearningModelSessionOptions.cpp
+++ b/winml/lib/Api/LearningModelSessionOptions.cpp
@@ -47,9 +47,9 @@ bool LearningModelSessionOptions::GetIntraOpThreadSpinning() {
   return allow_thread_spinning_;
 }
 
-STDMETHODIMP LearningModelSessionOptions::SetIntraOpThreadSpinning(bool allowSpinning) noexcept {
+STDMETHODIMP LearningModelSessionOptions::SetIntraOpThreadSpinning(boolean allowSpinning) noexcept {
   allow_thread_spinning_ = allowSpinning;
-  // TODO: set telemetry
+  telemetry_helper.SetIntraOpThreadSpinning(allowSpinning);
   return S_OK;
 }
 

--- a/winml/lib/Api/LearningModelSessionOptions.cpp
+++ b/winml/lib/Api/LearningModelSessionOptions.cpp
@@ -42,4 +42,16 @@ STDMETHODIMP LearningModelSessionOptions::SetIntraOpNumThreadsOverride(uint32_t 
   telemetry_helper.SetIntraOpNumThreadsOverride(intraOpNumThreads);
   return S_OK;
 }
+
+bool LearningModelSessionOptions::GetIntraOpThreadSpinning() {
+  return allow_thread_spinning_;
+}
+
+STDMETHODIMP LearningModelSessionOptions::SetIntraOpThreadSpinning(bool allowSpinning) noexcept {
+  allow_thread_spinning_ = allowSpinning;
+  // TODO: set telemetry
+  return S_OK;
+}
+
+
 }  // namespace WINMLP

--- a/winml/lib/Api/LearningModelSessionOptions.cpp
+++ b/winml/lib/Api/LearningModelSessionOptions.cpp
@@ -52,6 +52,4 @@ STDMETHODIMP LearningModelSessionOptions::SetIntraOpThreadSpinning(boolean allow
   telemetry_helper.SetIntraOpThreadSpinning(allowSpinning);
   return S_OK;
 }
-
-
 }  // namespace WINMLP

--- a/winml/lib/Api/LearningModelSessionOptions.h
+++ b/winml/lib/Api/LearningModelSessionOptions.h
@@ -7,7 +7,7 @@
 #include <thread>
 namespace WINMLP {
 
-struct LearningModelSessionOptions : LearningModelSessionOptionsT<LearningModelSessionOptions, ILearningModelSessionOptionsNative> {
+struct LearningModelSessionOptions : LearningModelSessionOptionsT<LearningModelSessionOptions, ILearningModelSessionOptionsNative, ILearningModelSessionOptionsNative1> {
   LearningModelSessionOptions() = default;
 
   LearningModelSessionOptions(const LearningModelSessionOptions& options);

--- a/winml/lib/Api/LearningModelSessionOptions.h
+++ b/winml/lib/Api/LearningModelSessionOptions.h
@@ -27,7 +27,7 @@ struct LearningModelSessionOptions : LearningModelSessionOptionsT<LearningModelS
   uint32_t GetIntraOpNumThreads();
 
   STDMETHOD(SetIntraOpThreadSpinning)
-  (bool allowSpinning);
+  (boolean allowSpinning);
 
   bool GetIntraOpThreadSpinning();
 

--- a/winml/lib/Api/LearningModelSessionOptions.h
+++ b/winml/lib/Api/LearningModelSessionOptions.h
@@ -26,6 +26,11 @@ struct LearningModelSessionOptions : LearningModelSessionOptionsT<LearningModelS
 
   uint32_t GetIntraOpNumThreads();
 
+  STDMETHOD(SetIntraOpThreadSpinning)
+  (bool allowSpinning);
+
+  bool GetIntraOpThreadSpinning();
+
  private:
   // The batch size override property is used to inform the engine when the developer
   // wants to explicitly set the batch size of a model to a fixed batch size.
@@ -61,6 +66,8 @@ struct LearningModelSessionOptions : LearningModelSessionOptionsT<LearningModelS
   // The default value here is the maximum number of logical cores to ensure that the default behavior of WinML always runs the fastest.
   // WARNING: Setting a number higher than the maximum number of logical cores may result in an inefficient threadpool
   uint32_t intra_op_num_threads_override_ = std::thread::hardware_concurrency();
+
+  bool allow_thread_spinning_ = true;
 };
 
 }  // namespace WINMLP

--- a/winml/lib/Common/inc/WinMLTelemetryHelper.h
+++ b/winml/lib/Common/inc/WinMLTelemetryHelper.h
@@ -35,6 +35,7 @@ class Profiler;
 #define WINML_TLM_RUNTIME_ERROR_VERSION 0
 #define WINML_TLM_RUNTIME_PERF_VERSION 0
 #define WINML_TLM_NATIVE_API_INTRAOP_THREADS_VERSION 0
+#define WINML_TLM_NATIVE_API_INTRAOP_THREAD_SPINNING_VERSION 0
 #define WINML_TLM_NAMED_DIMENSION_OVERRIDE_VERSION 0
 #define WINML_TLM_EXPERIMENTAL_API_VERSION 0
 
@@ -101,6 +102,8 @@ class WinMLTelemetryHelper {
       uint32_t default_attribute_count);
   void SetIntraOpNumThreadsOverride(
       uint32_t num_threads);
+  void SetIntraOpThreadSpinning(
+      bool allow_spinning);
   void SetNamedDimensionOverride(
       winrt::hstring name,
       uint32_t value);

--- a/winml/lib/Common/inc/iengine.h
+++ b/winml/lib/Common/inc/iengine.h
@@ -187,8 +187,8 @@ IEngine : IUnknown {
   STDMETHOD(GetNumberOfIntraOpThreads)
   (uint32_t * num_threads) PURE;
 
-  STDMETHOD(GetIntraOpThreadSpinningConfigEntry)
-  (const char** allow_spinning) PURE;
+  STDMETHOD(GetIntraOpThreadSpinning)
+  (bool* allow_spinning) PURE;
 
   STDMETHOD(GetNamedDimensionOverrides)
   (wfc::IMapView<winrt::hstring, uint32_t>& overrides) PURE;

--- a/winml/lib/Common/inc/iengine.h
+++ b/winml/lib/Common/inc/iengine.h
@@ -187,6 +187,9 @@ IEngine : IUnknown {
   STDMETHOD(GetNumberOfIntraOpThreads)
   (uint32_t * num_threads) PURE;
 
+  STDMETHOD(GetIntraOpThreadSpinningConfigEntry)
+  (const char** allow_spinning) PURE;
+
   STDMETHOD(GetNamedDimensionOverrides)
   (wfc::IMapView<winrt::hstring, uint32_t>& overrides) PURE;
 };

--- a/winml/lib/Common/inc/iengine.h
+++ b/winml/lib/Common/inc/iengine.h
@@ -214,6 +214,9 @@ IEngineBuilder : IUnknown {
   STDMETHOD(SetIntraOpNumThreadsOverride)
   (uint32_t intra_op_num_threads) PURE;
 
+  STDMETHOD(SetIntraOpThreadSpinning)
+  (bool allow_spinning) PURE;
+
   STDMETHOD(CreateEngine)
   (IEngine **out) PURE;
 };

--- a/winml/lib/Telemetry/WinMLTelemetryHelper.cpp
+++ b/winml/lib/Telemetry/WinMLTelemetryHelper.cpp
@@ -147,6 +147,22 @@ void WinMLTelemetryHelper::SetIntraOpNumThreadsOverride(
       TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
 }
 
+void WinMLTelemetryHelper::SetIntraOpThreadSpinning(
+    bool allow_spinning) {
+    if (!telemetry_enabled_) 
+      return;
+    WinMLTraceLoggingWrite(
+        provider_,
+        "SetIntraOpThreadSpinning",
+        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        //Telemetry info
+        TraceLoggingUInt8(WINML_TLM_NATIVE_API_INTRAOP_THREAD_SPINNING_VERSION, "schemaVersion"),
+        // thread spinning info
+        TraceLoggingBoolean(allow_spinning, "threadSpinningAllowed"),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+}
+
 void WinMLTelemetryHelper::SetNamedDimensionOverride(
     winrt::hstring name, uint32_t value) {
   if (!telemetry_enabled_)

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -1012,7 +1012,7 @@ static void SetIntraOpThreadSpinning() {
     auto tensor_input = TensorFloat::CreateFromArray(shape, input);
 
     auto spinDisabled = LearningModelSessionOptions();
-    auto spinDisabledNative = spinDisabled.as<ILearningModelSessionOptionsNative>();
+    auto spinDisabledNative = spinDisabled.as<ILearningModelSessionOptionsNative1>();
     spinDisabledNative->SetIntraOpThreadSpinning(false);
 
     // ensure disabled thread spin is internally disabled and can evaluate without error
@@ -1029,7 +1029,7 @@ static void SetIntraOpThreadSpinning() {
 
     // ensure enabled thread spin is internally enabled and can evaluate without error
     auto spinEnabled = LearningModelSessionOptions();
-    auto spinEnabledNative = spinEnabled.as<ILearningModelSessionOptionsNative>();
+    auto spinEnabledNative = spinEnabled.as<ILearningModelSessionOptionsNative1>();
     spinEnabledNative->SetIntraOpThreadSpinning(false);
 
     LearningModelSession sessionSpinEnabled = nullptr;

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -1001,10 +1001,8 @@ static void SetIntraOpNumThreads() {
  }
 
 static void SetIntraOpThreadSpinning() {
-    LearningModel learningModel = nullptr;
     auto device = LearningModelDevice(LearningModelDeviceKind::Cpu);
     auto shape = std::vector<int64_t>{1, 1000};
-
     auto model = ProtobufHelpers::CreateModel(TensorKind::Float, shape, 1000);
     
     std::vector<float> input(1000);
@@ -1017,7 +1015,7 @@ static void SetIntraOpThreadSpinning() {
 
     // ensure disabled thread spin is internally disabled and can evaluate without error
     LearningModelSession sessionSpinDisabled = nullptr;
-    WINML_EXPECT_NO_THROW(sessionSpinDisabled = LearningModelSession(learningModel, device, spinDisabled));
+    WINML_EXPECT_NO_THROW(sessionSpinDisabled = LearningModelSession(model, device, spinDisabled));
     auto nativeSessionSpinDisabled = sessionSpinDisabled.as<ILearningModelSessionNative>();
     boolean allowSpinning = true;
     nativeSessionSpinDisabled->GetIntraOpThreadSpinning(&allowSpinning);
@@ -1030,10 +1028,10 @@ static void SetIntraOpThreadSpinning() {
     // ensure enabled thread spin is internally enabled and can evaluate without error
     auto spinEnabled = LearningModelSessionOptions();
     auto spinEnabledNative = spinEnabled.as<ILearningModelSessionOptionsNative1>();
-    spinEnabledNative->SetIntraOpThreadSpinning(false);
+    spinEnabledNative->SetIntraOpThreadSpinning(true);
 
     LearningModelSession sessionSpinEnabled = nullptr;
-    WINML_EXPECT_NO_THROW(sessionSpinEnabled = LearningModelSession(learningModel, device, spinEnabled));
+    WINML_EXPECT_NO_THROW(sessionSpinEnabled = LearningModelSession(model, device, spinEnabled));
     auto nativeSessionSpinEnabled = sessionSpinEnabled.as<ILearningModelSessionNative>();
     nativeSessionSpinEnabled->GetIntraOpThreadSpinning(&allowSpinning);
     WINML_EXPECT_TRUE(allowSpinning);
@@ -1045,7 +1043,7 @@ static void SetIntraOpThreadSpinning() {
     // ensure options by default allow spinning
     auto spinDefault = LearningModelSessionOptions();
     LearningModelSession sessionSpinDefault = nullptr;
-    WINML_EXPECT_NO_THROW(sessionSpinDefault = LearningModelSession(learningModel, device, spinDefault));
+    WINML_EXPECT_NO_THROW(sessionSpinDefault = LearningModelSession(model, device, spinDefault));
     auto nativeSessionSpinDefault = sessionSpinDefault.as<ILearningModelSessionNative>();
     allowSpinning = false;
     nativeSessionSpinDefault->GetIntraOpThreadSpinning(&allowSpinning);

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -1016,7 +1016,7 @@ static void SetIntraOpThreadSpinning() {
     // ensure disabled thread spin is internally disabled and can evaluate without error
     LearningModelSession sessionSpinDisabled = nullptr;
     WINML_EXPECT_NO_THROW(sessionSpinDisabled = LearningModelSession(model, device, spinDisabled));
-    auto nativeSessionSpinDisabled = sessionSpinDisabled.as<ILearningModelSessionNative>();
+    auto nativeSessionSpinDisabled = sessionSpinDisabled.as<ILearningModelSessionNative1>();
     boolean allowSpinning = true;
     nativeSessionSpinDisabled->GetIntraOpThreadSpinning(&allowSpinning);
     WINML_EXPECT_FALSE(allowSpinning);
@@ -1032,7 +1032,7 @@ static void SetIntraOpThreadSpinning() {
 
     LearningModelSession sessionSpinEnabled = nullptr;
     WINML_EXPECT_NO_THROW(sessionSpinEnabled = LearningModelSession(model, device, spinEnabled));
-    auto nativeSessionSpinEnabled = sessionSpinEnabled.as<ILearningModelSessionNative>();
+    auto nativeSessionSpinEnabled = sessionSpinEnabled.as<ILearningModelSessionNative1>();
     nativeSessionSpinEnabled->GetIntraOpThreadSpinning(&allowSpinning);
     WINML_EXPECT_TRUE(allowSpinning);
 
@@ -1044,7 +1044,7 @@ static void SetIntraOpThreadSpinning() {
     auto spinDefault = LearningModelSessionOptions();
     LearningModelSession sessionSpinDefault = nullptr;
     WINML_EXPECT_NO_THROW(sessionSpinDefault = LearningModelSession(model, device, spinDefault));
-    auto nativeSessionSpinDefault = sessionSpinDefault.as<ILearningModelSessionNative>();
+    auto nativeSessionSpinDefault = sessionSpinDefault.as<ILearningModelSessionNative1>();
     allowSpinning = false;
     nativeSessionSpinDefault->GetIntraOpThreadSpinning(&allowSpinning);
     WINML_EXPECT_TRUE(allowSpinning);

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -1073,6 +1073,7 @@ const LearningModelSessionAPITestsApi& getapi() {
     NamedDimensionOverride,
     CloseSession,
     SetIntraOpNumThreads,
+    SetIntraOpThreadSpinning,
     ModelBuilding_Gemm,
     ModelBuilding_StandardDeviationNormalization,
     ModelBuilding_DynamicMatmul,

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -1019,7 +1019,7 @@ static void SetIntraOpThreadSpinning() {
     LearningModelSession sessionSpinDisabled = nullptr;
     WINML_EXPECT_NO_THROW(sessionSpinDisabled = LearningModelSession(learningModel, device, spinDisabled));
     auto nativeSessionSpinDisabled = sessionSpinDisabled.as<ILearningModelSessionNative>();
-    boolean allowSpinning;
+    boolean allowSpinning = true;
     nativeSessionSpinDisabled->GetIntraOpThreadSpinning(&allowSpinning);
     WINML_EXPECT_FALSE(allowSpinning);
 
@@ -1047,6 +1047,7 @@ static void SetIntraOpThreadSpinning() {
     LearningModelSession sessionSpinDefault = nullptr;
     WINML_EXPECT_NO_THROW(sessionSpinDefault = LearningModelSession(learningModel, device, spinDefault));
     auto nativeSessionSpinDefault = sessionSpinDefault.as<ILearningModelSessionNative>();
+    allowSpinning = false;
     nativeSessionSpinDefault->GetIntraOpThreadSpinning(&allowSpinning);
     WINML_EXPECT_TRUE(allowSpinning);
  }

--- a/winml/test/api/LearningModelSessionAPITest.h
+++ b/winml/test/api/LearningModelSessionAPITest.h
@@ -21,6 +21,7 @@ struct LearningModelSessionAPITestsApi {
   VoidTest OverrideNamedDimension;
   VoidTest CloseSession;
   VoidTest SetIntraOpNumThreads;
+  VoidTest SetIntraOpThreadSpinning;
   VoidTest ModelBuilding_Gemm;
   VoidTest ModelBuilding_StandardDeviationNormalization;
   VoidTest ModelBuilding_DynamicMatmul;
@@ -55,6 +56,7 @@ WINML_TEST(LearningModelSessionAPITests, AdapterIdAndDevice)
 WINML_TEST(LearningModelSessionAPITests, OverrideNamedDimension)
 WINML_TEST(LearningModelSessionAPITests, CloseSession)
 WINML_TEST(LearningModelSessionAPITests, SetIntraOpNumThreads)
+WINML_TEST(LearningModelSessionAPITests, SetIntraOpThreadSpinning)
 WINML_TEST(LearningModelSessionAPITests, ModelBuilding_Gemm)
 WINML_TEST(LearningModelSessionAPITests, ModelBuilding_StandardDeviationNormalization)
 WINML_TEST(LearningModelSessionAPITests, ModelBuilding_DynamicMatmul)


### PR DESCRIPTION
**Description**: Plumb through an API to WinML in SessionOptions to toggle the thread spinning Ort Session Option Config Entry. Includes tests as well which utilize a new adapter api to extract the internal config entry.

**Motivation and Context**
Allows clients to disable thread spinning in the case that they need to prioritize other CPU workloads.
