### PR TITLE
Remove conditional compilation of std::is_trivially_copyable since we are no longer supporting GCC 4.

### DIFF
--- a/onnxruntime/core/framework/data_transfer_utils.h
+++ b/onnxruntime/core/framework/data_transfer_utils.h
@@ -45,10 +45,7 @@ common::Status CopyTensorDataToSpan(
     const DataTransferManager& data_transfer_manager,
     const Tensor& src_tensor,
     const OrtMemoryInfo& dst_alloc_info, gsl::span<TElement> dst_span) {
-// std::is_trivially_copyable is not implemented in older versions of GCC
-#if !defined(__GNUC__) || __GNUC__ >= 5
   static_assert(std::is_trivially_copyable<TElement>::value, "Element type must be trivially copyable.");
-#endif
   ORT_RETURN_IF_NOT(src_tensor.DataType() == DataTypeImpl::GetType<TElement>(), "Data type mismatch");
   ORT_RETURN_IF_NOT(src_tensor.SizeInBytes() == static_cast<size_t>(dst_span.size_bytes()), "src size != dst size");
   Tensor dst_tensor{src_tensor.DataType(), src_tensor.Shape(), dst_span.data(), dst_alloc_info};

--- a/onnxruntime/core/framework/endian_utils.h
+++ b/onnxruntime/core/framework/endian_utils.h
@@ -51,15 +51,11 @@ common::Status ReadLittleEndian(size_t element_size,
                                 gsl::span<unsigned char> destination_bytes);
 
 /**
- * Reads from a little-endian source with check that T is trivially copyable.
- * @remarks Check is skipped for if building with gcc v4
+ * Reads from a little-endian source.
  */
 template <typename T>
 common::Status ReadLittleEndian(gsl::span<const unsigned char> source_bytes, gsl::span<T> destination) {
-// std::is_trivially_copyable is not implemented in older versions of GCC
-#if !defined(__GNUC__) || __GNUC__ >= 5
   static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable");
-#endif
   const auto destination_bytes = gsl::make_span(reinterpret_cast<unsigned char*>(destination.data()),
                                                 destination.size_bytes());
   return ReadLittleEndian(sizeof(T), source_bytes, destination_bytes);
@@ -70,10 +66,7 @@ common::Status ReadLittleEndian(gsl::span<const unsigned char> source_bytes, gsl
  */
 template <typename T>
 common::Status WriteLittleEndian(gsl::span<const T> source, gsl::span<unsigned char> destination_bytes) {
-// std::is_trivially_copyable is not implemented in older versions of GCC
-#if !defined(__GNUC__) || __GNUC__ >= 5
   static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable");
-#endif
   const auto source_bytes = gsl::make_span(reinterpret_cast<const unsigned char*>(source.data()), source.size_bytes());
   return detail::CopyLittleEndian(sizeof(T), source_bytes, destination_bytes);
 }

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -111,10 +111,7 @@ static Status UnpackTensorWithRawDataImpl(const void* raw_data, size_t raw_data_
 template <typename T>
 Status UnpackTensorWithRawData(const void* raw_data, size_t raw_data_len, size_t expected_num_elements,
                                /*out*/ T* p_data) {
-  // std::is_trivially_copyable is not implemented in older versions of GCC
-#if !defined(__GNUC__) || __GNUC__ >= 5
   static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable");
-#endif
 
   return UnpackTensorWithRawDataImpl(raw_data, raw_data_len, expected_num_elements, sizeof(T),
                                      reinterpret_cast<unsigned char*>(p_data));
@@ -204,10 +201,7 @@ template <typename T>
 Status UnpackTensorWithExternalData(const ONNX_NAMESPACE::TensorProto& tensor,
                                     const ORTCHAR_T* tensor_proto_dir, size_t expected_num_elements,
                                     /*out*/ T* p_data) {
-  // std::is_trivially_copyable is not implemented in older versions of GCC
-#if !defined(__GNUC__) || __GNUC__ >= 5
   static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable");
-#endif
 
   return UnpackTensorWithExternalDataImpl(tensor, tensor_proto_dir, expected_num_elements, sizeof(T),
                                           reinterpret_cast<unsigned char*>(p_data));

--- a/onnxruntime/core/providers/cuda/shared_inc/cuda_utils.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/cuda_utils.h
@@ -60,10 +60,7 @@ struct TArray {
   }
 
   TArray(const std::vector<T>& vec) : TArray(static_cast<int32_t>(vec.size())) {
-// std::is_trivially_copyable is not implemented in older versions of GCC
-#if !defined(__GNUC__) || __GNUC__ >= 5
     static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable.");
-#endif
     memcpy(data_, vec.data(), vec.size() * sizeof(T));
   }
 


### PR DESCRIPTION
**Description**
Remove conditional compilation of std::is_trivially_copyable since we are no longer supporting GCC 4.

**Motivation and Context**
Clean up.
