### PR TITLE
Enable Microsoft.Ai.MachineLearning package to work on .NET5 down to 17763 Windows SDK

### DIFF
--- a/csharp/src/Microsoft.AI.MachineLearning.Interop/Microsoft.AI.MachineLearning.Interop.csproj
+++ b/csharp/src/Microsoft.AI.MachineLearning.Interop/Microsoft.AI.MachineLearning.Interop.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.2.5" targetFramework="net5.0-windows10.0.17763.0" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.1.0" targetFramework="net5.0-windows10.0.17763.0" />
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.17763.1000" targetFramework="net5.0-windows10.0.17763.0" />
   </ItemGroup>
 

--- a/csharp/src/Microsoft.AI.MachineLearning.Interop/Microsoft.AI.MachineLearning.Interop.csproj
+++ b/csharp/src/Microsoft.AI.MachineLearning.Interop/Microsoft.AI.MachineLearning.Interop.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ProjectName>Microsoft.AI.MachineLearning.Interop</ProjectName>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.17763.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     
     <Platform>Any CPU</Platform>
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.0.1" targetFramework="net5.0-windows10.0.19041.0" />
-    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.19041.1" targetFramework="net5.0-windows10.0.19041.0" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.2.5" targetFramework="net5.0-windows10.0.17763.0" />
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.17763.1000" targetFramework="net5.0-windows10.0.17763.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/test/Microsoft.AI.MachineLearning.Tests.DotNet5_0/Microsoft.AI.MachineLearning.Tests.DotNet5_0.csproj.pp
+++ b/csharp/test/Microsoft.AI.MachineLearning.Tests.DotNet5_0/Microsoft.AI.MachineLearning.Tests.DotNet5_0.csproj.pp
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.17763.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/windowsai.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/windowsai.yml
@@ -630,12 +630,12 @@ jobs:
         popd
         
         Write-Host "Run Microsoft.AI.MachineLearning CSharp Tests (DotNet5_0)"
-        pushd .\Microsoft.AI.MachineLearning.Tests.DotNet5_0\bin\Debug\net5.0-windows10.0.19041.0
+        pushd .\Microsoft.AI.MachineLearning.Tests.DotNet5_0\bin\Debug\net5.0-windows10.0.17763.0
         .\Microsoft.AI.MachineLearning.Tests.DotNet5_0.exe
         popd
         
         Write-Host "Run Microsoft.AI.MachineLearning CSharp Tests (AnyCpu)"
-        pushd .\Microsoft.AI.MachineLearning.Tests.DotNet5_0\bin\x64\Debug\net5.0-windows10.0.19041.0
+        pushd .\Microsoft.AI.MachineLearning.Tests.DotNet5_0\bin\x64\Debug\net5.0-windows10.0.17763.0
         .\Microsoft.AI.MachineLearning.Tests.DotNet5_0.exe
         popd
         

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -288,11 +288,11 @@ def generate_files(list, args):
                                                             'microsoft.ai.machinelearning.experimental.winmd') +
                           '" target="winmds\\Microsoft.AI.MachineLearning.Experimental.winmd" />')
         if args.target_architecture == 'x64' and not args.is_store_build:
-            interop_dll_path = 'Microsoft.AI.MachineLearning.Interop\\net5.0-windows10.0.19041.0'
+            interop_dll_path = 'Microsoft.AI.MachineLearning.Interop\\net5.0-windows10.0.17763.0'
             interop_dll = interop_dll_path + '\\Microsoft.AI.MachineLearning.Interop.dll'
             files_list.append('<file src=' + '"' + os.path.join(args.native_build_path, interop_dll) +
                               '" target="lib\\net5.0\\Microsoft.AI.MachineLearning.Interop.dll" />')
-            interop_pdb_path = 'Microsoft.AI.MachineLearning.Interop\\net5.0-windows10.0.19041.0'
+            interop_pdb_path = 'Microsoft.AI.MachineLearning.Interop\\net5.0-windows10.0.17763.0'
             interop_pdb = interop_pdb_path + '\\Microsoft.AI.MachineLearning.Interop.pdb'
             files_list.append('<file src=' + '"' + os.path.join(args.native_build_path, interop_pdb) +
                               '" target="lib\\net5.0\\Microsoft.AI.MachineLearning.Interop.pdb" />')


### PR DESCRIPTION
Issue: Users cannot use the Microsoft.AI.MachineLearning package with .NET5 when their projects target older frameworks (17763).

Fix; This is due to the fact that the Microsoft.AI.MachineLearning.Interop dll depends on the 19041 SDK for its implementation. However, this is not needed and can be downgraded to 17763. In addition, the cswinrt version has been incremented to 1.1.0 which has been verified to not require a newer Windows SDK as well.