### PR TITLE
Fix unused registered buffers issue on ORTModule

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -82,8 +82,10 @@ def _combine_input_buffers_initializers(param_names, onnx_input_names, input_inf
 
         elif input_idx >= len(non_none_inputs):
             # Registered buffers are translated to user_input+initializer in ONNX
-            assert name in buffer_names_dict, f'Buffer name {name} not found!'
-            inp = buffer_names_dict[name]
+            try:
+                inp = buffer_names_dict[name]
+            except KeyError:
+                raise KeyError(f'Registered buffer name {name} not found.')
 
         if inp is not None:
             result.append(inp)

--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -65,7 +65,7 @@ def _combine_input_buffers_initializers(param_names, onnx_input_names, input_inf
 
     # User inputs
     non_none_inputs = [inp for inp in inputs if inp is not None]
-    named_buffers_iter = iter(buffer_names)
+    buffer_names_dict = {buffer_name: inp for buffer_name, inp in buffer_names}
     result = []
 
     for input_idx, name in enumerate(onnx_input_names):
@@ -82,16 +82,15 @@ def _combine_input_buffers_initializers(param_names, onnx_input_names, input_inf
 
         elif input_idx >= len(non_none_inputs):
             # Registered buffers are translated to user_input+initializer in ONNX
-            buffer_name, inp = next(named_buffers_iter)
-            assert buffer_name == name, f'Input name {name} expected, but {buffer_name} found!'
+            assert name in buffer_names_dict, f'Buffer name {name} not found!'
+            inp = buffer_names_dict[name]
 
         if inp is not None:
             result.append(inp)
         else:
             raise RuntimeError(f'Input is present in ONNX graph but not provided: {name}.')
     # Initializers
-    for param in param_names:
-        result.append(param[1])
+    result.extend([param[1] for param in param_names])
     return result
 
 


### PR DESCRIPTION
ORTModule fails to export the model when it contains unused registered_buffers(). Unused buffers are dropped by ONNX exporter, so ORTModule also have to drop it before passing it through

This PR fixes this issue, thanks to @kit1980 who found the issue and provided a fix