### PR TITLE
Update SessionOptions.cs

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.ML.OnnxRuntime
             catch (Exception e)
             {
                 options.Dispose();
-                throw;
+                throw e;
             }
         }
 


### PR DESCRIPTION
Fix compile warning, as well as made this catch function be consistent with our other C# code.