### PR TITLE
[js/node] fix pacakge metadata of onnxruntime-node

### DIFF
--- a/js/node/.npmignore
+++ b/js/node/.npmignore
@@ -1,7 +1,6 @@
 /.vscode/
 /bin/
 /build/
-/examples/
 /prebuilds/
 /script/
 /src/
@@ -10,11 +9,8 @@
 /types/**/*.d.ts
 !/types/lib/**/*.d.ts
 
-/lib/**/*.ts
-/lib/**/*.js.map
+CMakeLists.txt
+tsconfig.json
+tsconfig.tsbuildinfo
 
-/.clang-format
-/.eslintrc.js
-/.gitmodules
-/CMakeLists.txt
-/tsconfig.json
+*.tgz

--- a/js/node/package-lock.json
+++ b/js/node/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "onnxruntime",
+  "name": "onnxruntime-node",
   "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/js/node/package-lock.json
+++ b/js/node/package-lock.json
@@ -1780,9 +1780,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.21.0.tgz",
-      "integrity": "sha512-smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.26.0.tgz",
+      "integrity": "sha512-ag/Vos/mXXpWLLAYWsAoQdgS+gW7IwvgMLOgqopm/DbzAjazLltzgzpVMsFlgmo9TzG5hGXeaBZx2AI731RIsQ==",
       "requires": {
         "semver": "^5.4.1"
       }
@@ -3104,9 +3104,9 @@
       "dev": true
     },
     "prebuild-install": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.1.tgz",
-      "integrity": "sha512-M+cKwofFlHa5VpTWub7GLg5RLcunYIcLqtY5pKcls/u7xaAb8FrXZ520qY8rkpYy5xw90tYCyMO0MP5ggzR3Sw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.2.tgz",
+      "integrity": "sha512-PzYWIKZeP+967WuKYXlTOhYBgGOvTRSfaKI89XnfJ0ansRAH7hDU45X+K+FZeI1Wb/7p/NnuctPH3g0IqKUuSQ==",
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",

--- a/js/node/package.json
+++ b/js/node/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "license": "MIT",
-  "name": "onnxruntime",
+  "name": "onnxruntime-node",
   "repository": {
     "url": "https://github.com/Microsoft/onnxruntime.git",
     "type": "git"
@@ -16,7 +16,7 @@
   "version": "1.7.0",
   "dependencies": {
     "onnxruntime-common": "file:../common",
-    "prebuild-install": "^6.0.1"
+    "prebuild-install": "^6.1.2"
   },
   "scripts": {
     "build": "tsc && node ./script/build",
@@ -62,5 +62,5 @@
     "linux"
   ],
   "types": "./types/lib/index.d.ts",
-  "description": "Node.js binding of ONNXRuntime"
+  "description": "ONNXRuntime Node.js binding"
 }

--- a/js/node/script/prepack.ts
+++ b/js/node/script/prepack.ts
@@ -9,13 +9,13 @@ import * as zlib from 'zlib';
 
 function updatePackageJson() {
   const commonPackageJsonPath = path.join(__dirname, '..', '..', 'common', 'package.json');
-  const nodePackageJsonPath = path.join(__dirname, '..', 'package.json');
-  console.log(`=== start to update package.json: ${nodePackageJsonPath}`);
+  const selfPackageJsonPath = path.join(__dirname, '..', 'package.json');
+  console.log(`=== start to update package.json: ${selfPackageJsonPath}`);
   const packageCommon = fs.readJSONSync(commonPackageJsonPath);
-  const packageNode = fs.readJSONSync(nodePackageJsonPath);
+  const packageSelf = fs.readJSONSync(selfPackageJsonPath);
   const version = packageCommon.version;
-  packageNode.dependencies['onnxruntime-common'] = version;
-  fs.writeJSONSync(nodePackageJsonPath, packageNode);
+  packageSelf.dependencies['onnxruntime-common'] = version;
+  fs.writeJSONSync(selfPackageJsonPath, packageSelf, {spaces: 2});
   console.log('=== finished updating package.json.');
 }
 

--- a/js/node/script/prepack.ts
+++ b/js/node/script/prepack.ts
@@ -14,7 +14,7 @@ function updatePackageJson() {
   const packageCommon = fs.readJSONSync(commonPackageJsonPath);
   const packageSelf = fs.readJSONSync(selfPackageJsonPath);
   const version = packageCommon.version;
-  packageSelf.dependencies['onnxruntime-common'] = version;
+  packageSelf.dependencies['onnxruntime-common'] = `~${version}`;
   fs.writeJSONSync(selfPackageJsonPath, packageSelf, {spaces: 2});
   console.log('=== finished updating package.json.');
 }


### PR DESCRIPTION
**Description**: fix pacakge metadata of `onnxruntime-node`.

- fix file manifest in `.npmignore`
- rename package name from `onnxruntime` to `onnxruntime-node` (pending document changes to `gh-pages`)
- upgrade dependency `prebuild-install`
- prepack.ts: update to pretty format of JSON.