### PR TITLE
disable logging for WASM in inference session constructor

### DIFF
--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -297,7 +297,7 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
   // Add log to allow serving platforms to quantify ORT usage.
   // To avoid flooding the test logs, this is done for non-debug mode only
   // TODO: plug-in a platform specific telemetry provider to send the telemetry to
-#ifdef NDEBUG
+#if defined(NDEBUG) && !defined(__wasm__)
 #ifdef _WIN32
   std::wostringstream ostr;
 #else


### PR DESCRIPTION
**Description**: Logging telemetry for inference session creation is not a requirement for WebAssembly. In browser, console logging should only be used when error occurs. This change disables this feature for WebAssembly build.