### PR TITLE
Improves NonMaxSuppression on CPU

### DIFF
--- a/onnxruntime/core/mlas/lib/convolve.cpp
+++ b/onnxruntime/core/mlas/lib/convolve.cpp
@@ -146,7 +146,6 @@ Return Value:
 
                 size_t InputX = InitialInputX;
                 const float* InputRow = &Input[InputY * InputWidth];
-                const float* tempInputRow;
 
                 do {
 
@@ -173,28 +172,6 @@ Return Value:
                         }
 
                         CountX -= CountCopyX;
-                        tempInputRow = &InputRow[InputX];
-
-                        while (CountCopyX >= 16) {
-                          MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(tempInputRow));
-                          ColumnBuffer += 4;
-                          tempInputRow += 4;
-
-                          MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(tempInputRow));
-                          ColumnBuffer += 4;
-                          tempInputRow += 4;
-
-                          MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(tempInputRow));
-                          ColumnBuffer += 4;
-                          tempInputRow += 4;
-
-                          MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(tempInputRow));
-                          ColumnBuffer += 4;
-                          tempInputRow += 4;
-
-                          InputX += 16;
-                          CountCopyX -= 16;
-                        }
 
                         while (CountCopyX >= 4) {
                             MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(&InputRow[InputX]));
@@ -232,22 +209,6 @@ Return Value:
                 //
 
                 MLAS_FLOAT32X4 ZeroFloat32x4 = MlasZeroFloat32x4();
-
-                while (CountX >= 16) {
-                  MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
-                  ColumnBuffer += 4;
-
-                  MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
-                  ColumnBuffer += 4;
-
-                  MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
-                  ColumnBuffer += 4;
-
-                  MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
-                  ColumnBuffer += 4;
-
-                  CountX -= 16;
-                }
 
                 while (CountX >= 4) {
                     MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
@@ -566,8 +527,6 @@ Return Value:
     const size_t FilterCount = Parameters->FilterCount;
     const size_t OutputSize = Parameters->OutputSize;
     const size_t K = Parameters->K;
-    const size_t K2 = Parameters->K * 2;
-    const size_t SegmentCountN2 = SegmentCountN * 2;
 
     //
     // Compute the strides to step through slices of the local segment.
@@ -580,14 +539,14 @@ Return Value:
 
     if (SegmentCountN >= K) {
 
-        while (StrideK >= K2) {
+        while (StrideK / 2 >= K) {
             StrideN *= 2;
             StrideK /= 2;
         }
 
     } else {
 
-        while (StrideN > 16 && StrideN >= SegmentCountN2) {
+        while (StrideN > 16 && StrideN / 2 >= SegmentCountN) {
             StrideK *= 2;
             StrideN /= 2;
         }
@@ -601,12 +560,11 @@ Return Value:
 
     for (size_t n = 0; n < SegmentCountN; n += CountN) {
 
-        // CountN = SegmentCountN - n;
+        CountN = SegmentCountN - n;
 
-        CountN = SegmentCountN - n > StrideN ? StrideN : SegmentCountN - n;
-        // if (CountN > StrideN) {
-        //    CountN = StrideN;
-        //}
+        if (CountN > StrideN) {
+            CountN = StrideN;
+        }
 
         //
         // Step through each slice of the input tensor along the K dimension.
@@ -618,12 +576,11 @@ Return Value:
 
         for (size_t k = 0; k < K; k += CountK) {
 
-            // CountK = K - k;
+            CountK = K - k;
 
-            CountK = K - k > StrideK ? StrideK : K - k;
-            //if (CountK > StrideK) {
-            //    CountK = StrideK;
-            //}
+            if (CountK > StrideK) {
+                CountK = StrideK;
+            }
 
             if (Parameters->Dimensions == 2) {
                 MlasConvIm2Col(Parameters, Input, ColumnBuffer, k, CountK,

--- a/onnxruntime/core/providers/cpu/object_detection/non_max_suppression.cc
+++ b/onnxruntime/core/providers/cpu/object_detection/non_max_suppression.cc
@@ -132,67 +132,28 @@ Status NonMaxSuppression::Compute(OpKernelContext* ctx) const {
   const auto* const boxes_data = pc.boxes_data_;
   const auto* const scores_data = pc.scores_data_;
 
-  struct BoxInfo {
+  struct BoxInfoPtr {
     float score_{};
     int64_t index_{};
-    float box_[4]{};
-    float area_{};
 
-    BoxInfo() = default;
-    explicit BoxInfo(float score, int64_t idx, int64_t center_point_box, const float* box) : score_(score), index_(idx) {
-      if (0 == center_point_box) {
-        // boxes data format [y1, x1, y2, x2],
-        MaxMin(box[1], box[3], box_[1], box_[3]);
-        MaxMin(box[0], box[2], box_[0], box_[2]);
-        area_ = (box_[2] - box_[0]) * (box_[3] - box_[1]);
-      } else {
-        // boxes data format [x_center, y_center, width, height]
-        float box_width_half = box[2] / 2;
-        float box_height_half = box[3] / 2;
-        area_ = box[2] * box[3];
-        box_[1] = box[0] - box_width_half;
-        box_[3] = box[0] + box_width_half;
-        box_[0] = box[1] - box_height_half;
-        box_[2] = box[1] + box_height_half;
-      }
-    }
-
-    inline bool operator<(const BoxInfo& rhs) const {
+    BoxInfoPtr() = default;
+    explicit BoxInfoPtr(float score, int64_t idx) : score_(score), index_(idx) {}
+    inline bool operator<(const BoxInfoPtr& rhs) const {
       return score_ < rhs.score_ || (score_ == rhs.score_ && index_ > rhs.index_);
-    }
-
-    inline bool SuppressByIOU(const BoxInfo& rhs, float iou_threshold) const {
-      const float intersection_x_min = std::max(box_[1], rhs.box_[1]);
-      const float intersection_x_max = std::min(box_[3], rhs.box_[3]);
-      if (intersection_x_max <= intersection_x_min)
-        return false;
-      const float intersection_y_min = std::max(box_[0], rhs.box_[0]);
-      const float intersection_y_max = std::min(box_[2], rhs.box_[2]);
-      if (intersection_y_max <= intersection_y_min)
-        return false;
-
-      const float intersection_area = (intersection_x_max - intersection_x_min) *
-                                      (intersection_y_max - intersection_y_min);
-      if (intersection_area <= .0f) {
-        return false;
-      }
-      const float union_area = area_ + rhs.area_ - intersection_area;
-      const float intersection_over_union = intersection_area / union_area;
-      return intersection_over_union > iou_threshold;
     }
   };
 
   const auto center_point_box = GetCenterPointBox();
 
   std::vector<SelectedIndex> selected_indices;
-  std::vector<BoxInfo> selected_boxes_inside_class;
+  std::vector<BoxInfoPtr> selected_boxes_inside_class;
   selected_boxes_inside_class.reserve(std::min<size_t>(static_cast<size_t>(max_output_boxes_per_class), pc.num_boxes_));
 
   for (int64_t batch_index = 0; batch_index < pc.num_batches_; ++batch_index) {
     for (int64_t class_index = 0; class_index < pc.num_classes_; ++class_index) {
       int64_t box_score_offset = (batch_index * pc.num_classes_ + class_index) * pc.num_boxes_;
       const float* batch_boxes = boxes_data + (batch_index * pc.num_boxes_ * 4);
-      std::vector<BoxInfo> candidate_boxes;
+      std::vector<BoxInfoPtr> candidate_boxes;
       candidate_boxes.reserve(pc.num_boxes_);
 
       // Filter by score_threshold_
@@ -200,25 +161,25 @@ Status NonMaxSuppression::Compute(OpKernelContext* ctx) const {
       if (pc.score_threshold_ != nullptr) {
         for (int64_t box_index = 0; box_index < pc.num_boxes_; ++box_index, ++class_scores) {
           if (*class_scores > score_threshold) {
-            candidate_boxes.emplace_back(*class_scores, box_index, center_point_box, batch_boxes + (box_index * 4));
+            candidate_boxes.emplace_back(*class_scores, box_index);
           }
         }
       } else {
         for (int64_t box_index = 0; box_index < pc.num_boxes_; ++box_index, ++class_scores) {
-          candidate_boxes.emplace_back(*class_scores, box_index, center_point_box, batch_boxes + (box_index * 4));
+          candidate_boxes.emplace_back(*class_scores, box_index);
         }
       }
-      std::priority_queue<BoxInfo, std::vector<BoxInfo>> sorted_boxes(std::less<BoxInfo>(), std::move(candidate_boxes));
+      std::priority_queue<BoxInfoPtr, std::vector<BoxInfoPtr>> sorted_boxes(std::less<BoxInfoPtr>(), std::move(candidate_boxes));
 
       selected_boxes_inside_class.clear();
       // Get the next box with top score, filter by iou_threshold
       while (!sorted_boxes.empty() && static_cast<int64_t>(selected_boxes_inside_class.size()) < max_output_boxes_per_class) {
-        const BoxInfo& next_top_score = sorted_boxes.top();
+        const BoxInfoPtr& next_top_score = sorted_boxes.top();
 
         bool selected = true;
         // Check with existing selected boxes for this class, suppress if exceed the IOU (Intersection Over Union) threshold
         for (const auto& selected_index : selected_boxes_inside_class) {
-          if (next_top_score.SuppressByIOU(selected_index, iou_threshold)) {
+          if (SuppressByIOU(batch_boxes, next_top_score.index_, selected_index.index_, center_point_box, iou_threshold)) {
             selected = false;
             break;
           }


### PR DESCRIPTION
**Description**:

Improves NonMaxSuppression implementation. The change improves one function, it skipped some computations when the result is already known.

Measure on EfficientDet:

* 7.4 --> 5.7 (~15% improvment), image size=(1, 224, 224, 3), run 15 times on Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz, 2601 MHz, 2 cores, 4 logical processors

Total time spent in each operator in EfficientDet (before the change):

![image](https://user-images.githubusercontent.com/22452781/116908616-69a2df00-ac43-11eb-8873-8846f8268811.png)

Same graph after the change:

![image](https://user-images.githubusercontent.com/22452781/116991050-47a56d00-acd4-11eb-9764-aadd2f15f5f0.png)

**Motivation and Context**

Performance