### PR TITLE
Update Android AAR packaging pipeline script

### DIFF
--- a/tools/ci_build/github/android/build_aar_and_copy_artifacts.sh
+++ b/tools/ci_build/github/android/build_aar_and_copy_artifacts.sh
@@ -15,7 +15,7 @@ python3 /onnxruntime_src/tools/ci_build/github/android/build_aar_package.py \
     --config $BUILD_CONFIG \
     --android_sdk_path /android_home \
     --android_ndk_path /ndk_home \
-    --include_ops_by_config /onnxruntime_src/tools/ci_build/github/android/mobile_package.required_operators.config
+    --include_ops_by_config /onnxruntime_src/tools/ci_build/github/android/mobile_package.required_operators.config \
     /onnxruntime_src/tools/ci_build/github/android/default_mobile_aar_build_settings.json
 
 # Copy the built artifacts to give folder for publishing

--- a/tools/ci_build/github/android/build_aar_and_copy_artifacts.sh
+++ b/tools/ci_build/github/android/build_aar_and_copy_artifacts.sh
@@ -15,6 +15,7 @@ python3 /onnxruntime_src/tools/ci_build/github/android/build_aar_package.py \
     --config $BUILD_CONFIG \
     --android_sdk_path /android_home \
     --android_ndk_path /ndk_home \
+    --include_ops_by_config /onnxruntime_src/tools/ci_build/github/android/mobile_package.required_operators.config
     /onnxruntime_src/tools/ci_build/github/android/default_mobile_aar_build_settings.json
 
 # Copy the built artifacts to give folder for publishing

--- a/tools/ci_build/github/android/build_aar_package.py
+++ b/tools/ci_build/github/android/build_aar_package.py
@@ -20,12 +20,13 @@ from util import is_windows  # noqa: E402
 # We by default will build all 4 ABIs
 DEFAULT_BUILD_ABIS = ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
 
-# Android API levle 24 is the lowest API version officially supported, based on Microsoft 1CS
-# It is possible to build from source using API level 21 and higher as the minimal SDK version
-DEFAULT_ANDROID_MIN_SDK_VER = 24
+# Onnx Runtime native library is built against NDK API 21 by default
+# It is possible to build from source for Android API levels below 21, but it is not guaranteed
+DEFAULT_ANDROID_MIN_SDK_VER = 21
 
-# Android API 28 is the default target API version for Android builds
-DEFAULT_ANDROID_TARGET_SDK_VER = 28
+# Android API 24 is the default target API version for Android builds, based on Microsoft 1CS requirements
+# It is possible to build from source using API level 21 and higher as the target SDK version
+DEFAULT_ANDROID_TARGET_SDK_VER = 24
 
 
 def _parse_build_settings(args):

--- a/tools/ci_build/github/android/default_mobile_aar_build_settings.json
+++ b/tools/ci_build/github/android/default_mobile_aar_build_settings.json
@@ -5,8 +5,8 @@
         "x86",
         "x86_64"
     ],
-    "android_min_sdk_version": 24,
-    "android_target_sdk_version": 28,
+    "android_min_sdk_version": 21,
+    "android_target_sdk_version": 24,
     "build_params": [
         "--android",
         "--parallel",
@@ -17,6 +17,7 @@
         "--disable_rtti",
         "--disable_ml_ops",
         "--disable_exceptions",
+        "--enable_reduced_operator_type_support",
         "--use_nnapi",
         "--skip_tests"
     ]

--- a/tools/ci_build/op_registration_utils.py
+++ b/tools/ci_build/op_registration_utils.py
@@ -26,6 +26,7 @@ def map_ort_constant_to_domain(ort_constant_name: str):
     constant_to_domain_map = {'kOnnxDomain': 'ai.onnx',
                               'kMLDomain': 'ai.onnx.ml',
                               'kMSDomain': 'com.microsoft',
+                              'kMSExperimentalDomain': 'com.microsoft.experimental',
                               'kMSNchwcDomain': 'com.microsoft.nchwc',
                               'kMSFeaturizersDomain': 'com.microsoft.mlfeaturizers',
                               'kMSDmlDomain': 'com.microsoft.dml',


### PR DESCRIPTION
**Description**: Update Android AAR packaging pipeline script

**Motivation and Context**
- Use the latest included ops and types config file for Android Package
- Add missing kMSExperimentalDomain in reduction script
- Move the minimal Android deploy API level to 21 and target API level to 24

[Sample run artifacts page](https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=151342&view=artifacts&pathAsName=false&type=publishedArtifacts)

AAR size before this PR ~7MB (minimal build with all ops), after this PR ~5MB

