### PR TITLE
clean up transformer optimizer

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_attention.py
@@ -9,7 +9,7 @@ from typing import Tuple, Union
 from onnx import helper, numpy_helper, TensorProto, NodeProto
 from onnx_model import OnnxModel
 from fusion_base import Fusion
-from fusion_utils import FusionUtils
+from fusion_utils import FusionUtils, NumpyHelper
 
 logger = getLogger(__name__)
 
@@ -107,7 +107,7 @@ class FusionAttention(Fusion):
             logger.debug(f"{reshape_q.input[1]} is not initializer.")
             return self.num_heads, self.hidden_size  # Fall back to user specified value
 
-        q_shape_value = numpy_helper.to_array(q_shape)
+        q_shape_value = NumpyHelper.to_array(q_shape)
         if len(q_shape_value) != 4 or (q_shape_value[2] <= 0 or q_shape_value[3] <= 0):
             logger.debug(f"q_shape_value={q_shape_value}. Expected value are like [0, 0, num_heads, head_size].")
             return self.num_heads, self.hidden_size  # Fall back to user specified value
@@ -145,7 +145,7 @@ class FusionAttention(Fusion):
         Returns:
             Union[NodeProto, None]: the node created or None if failed.
         """
-        assert num_heads > 0 or hidden_size > 0 or (hidden_size % num_heads) == 0
+        assert num_heads > 0 and hidden_size > 0 and (hidden_size % num_heads) == 0
 
         q_weight = self.model.get_initializer(q_matmul.input[1])
         k_weight = self.model.get_initializer(k_matmul.input[1])
@@ -159,9 +159,9 @@ class FusionAttention(Fusion):
             return None
         if not (k_weight and v_weight and q_bias and k_bias):
             return None
-        qw = numpy_helper.to_array(q_weight)
-        kw = numpy_helper.to_array(k_weight)
-        vw = numpy_helper.to_array(v_weight)
+        qw = NumpyHelper.to_array(q_weight)
+        kw = NumpyHelper.to_array(k_weight)
+        vw = NumpyHelper.to_array(v_weight)
 
         # Check if all matrices have the same shape
         assert qw.shape == kw.shape == vw.shape
@@ -173,9 +173,9 @@ class FusionAttention(Fusion):
 
         qkv_weight = np.stack((qw, kw, vw), axis=1)
 
-        qb = numpy_helper.to_array(q_bias)        
-        kb = numpy_helper.to_array(k_bias)
-        vb = numpy_helper.to_array(v_bias)
+        qb = NumpyHelper.to_array(q_bias)        
+        kb = NumpyHelper.to_array(k_bias)
+        vb = NumpyHelper.to_array(v_bias)
 
         # 1d bias shape: [outsize,]. 2d bias shape: [a, b] where a*b = out_size
         assert qb.shape == kb.shape == vb.shape
@@ -196,7 +196,7 @@ class FusionAttention(Fusion):
 
         # Sometimes weights and bias are stored in fp16
         if q_weight.data_type == 10:
-            weight.CopyFrom(numpy_helper.from_array(numpy_helper.to_array(weight).astype(np.float16), weight.name))
+            weight.CopyFrom(numpy_helper.from_array(NumpyHelper.to_array(weight).astype(np.float16), weight.name))
         self.model.add_initializer(weight)
 
         bias = helper.make_tensor(name=attention_node_name + '_qkv_bias',
@@ -204,7 +204,7 @@ class FusionAttention(Fusion):
                                   dims=[3 * out_size],
                                   vals=qkv_bias.flatten().tolist())
         if q_bias.data_type == 10:
-            bias.CopyFrom(numpy_helper.from_array(numpy_helper.to_array(bias).astype(np.float16), bias.name))
+            bias.CopyFrom(numpy_helper.from_array(NumpyHelper.to_array(bias).astype(np.float16), bias.name))
         self.model.add_initializer(bias)
 
         attention_inputs = [input, attention_node_name + '_qkv_weight', attention_node_name + '_qkv_bias']

--- a/onnxruntime/python/tools/transformers/fusion_biasgelu.py
+++ b/onnxruntime/python/tools/transformers/fusion_biasgelu.py
@@ -4,9 +4,10 @@
 #--------------------------------------------------------------------------
 
 from logging import getLogger
-from onnx import helper, numpy_helper
+from onnx import helper
 from onnx_model import OnnxModel
 from fusion_base import Fusion
+from fusion_utils import NumpyHelper
 
 logger = getLogger(__name__)
 
@@ -38,7 +39,7 @@ class FusionBiasGelu(Fusion):
             if initializer is None:
                 continue
             bias_index = i
-            bias_weight = numpy_helper.to_array(initializer)
+            bias_weight = NumpyHelper.to_array(initializer)
             break
         if bias_weight is None:
             return

--- a/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
+++ b/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
@@ -4,9 +4,10 @@
 #--------------------------------------------------------------------------
 
 from logging import getLogger
-from onnx import helper, numpy_helper
+from onnx import helper
 from onnx_model import OnnxModel
 from fusion_base import Fusion
+from fusion_utils import NumpyHelper
 
 logger = getLogger(__name__)
 
@@ -99,7 +100,7 @@ class FusionBiasSkipLayerNormalization(Fusion):
             if initializer is None:
                 continue
             bias_index = i
-            bias_weight = numpy_helper.to_array(initializer)
+            bias_weight = NumpyHelper.to_array(initializer)
             break
         if bias_weight is None:
             logger.debug(f"Bias weight not found")

--- a/onnxruntime/python/tools/transformers/fusion_utils.py
+++ b/onnxruntime/python/tools/transformers/fusion_utils.py
@@ -3,9 +3,10 @@
 # Licensed under the MIT License.
 #--------------------------------------------------------------------------
 from logging import getLogger
-from onnx_model import OnnxModel
 from typing import Tuple
-from onnx import helper, TensorProto
+from onnx import helper, numpy_helper, TensorProto
+from numpy import ndarray
+from onnx_model import OnnxModel
 
 logger = getLogger(__name__)
 
@@ -55,3 +56,14 @@ class FusionUtils:
                     output_name = node.output[0]
                     self.model.remove_node(node)
                     self.model.replace_input_of_all_nodes(output_name, input_name)
+
+class NumpyHelper:
+    @staticmethod    
+    def to_array(tensor:TensorProto, fill_zeros:bool = False) -> ndarray:
+        # When weights are in external data format but not presented, we can still test the optimizer with two changes:
+        # (1) set fill_zeros = True  (2) change load_external_data=False in optimizer.py
+        if fill_zeros:
+            from onnx import mapping
+            return ndarray(shape=tensor.dims, dtype=mapping.TENSOR_TYPE_TO_NP_TYPE[tensor.data_type])
+
+        return numpy_helper.to_array(tensor)


### PR DESCRIPTION
**Description**:
* catch symbolic shape inference exception.
* do not prune graph when graph has nodes of Loop/If/Scan.
* add an wrapper for numpy_helper.to_array so that we can debug onnx graph without external data.
* remove fuse_mask that is not used any more in onnx_model_bert_tf.py 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
