### PR TITLE
[transformer optimizer] Match flexible input order of Add node in Attention fusion

### DIFF
--- a/onnxruntime/python/tools/transformers/test/test_attention_fusion.py
+++ b/onnxruntime/python/tools/transformers/test/test_attention_fusion.py
@@ -28,7 +28,21 @@ class TestFusion(unittest.TestCase):
                                            'pruned_attention_opt.onnx')
         expected = onnx.load(expected_model_path)
         self.assertEqual(str(optimized_model.model.graph), str(expected.graph))
-    
+
+    def test_attention_fusion_reverse_add_order(self):
+        model = create_bert_attention(switch_add_inputs=True)
+        dir = '.'
+        model_path = os.path.join(dir, "bert_attention_reverse_add_order.onnx")
+        onnx.save(model, model_path)
+        optimized_model = optimize_model(model_path)
+        os.remove(model_path)
+
+        # reverse add input order will get same optimized model
+        expected_model_path = os.path.join(os.path.dirname(__file__), 'test_data', 'fusion',
+                                           'pruned_attention_opt.onnx')
+        expected = onnx.load(expected_model_path)
+        self.assertEqual(str(optimized_model.model.graph), str(expected.graph))
+
     def test_3d_attention_fusion_tf2onnx_model(self):
         model = create_tf2onnx_attention_3d()
         dir = '.'


### PR DESCRIPTION
**Description**: 

The input order for Add operator does not matter. That is a + b will get same result as b + a. Here we match both orders in Attention fusion.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

PyTorch 1.9 nightly build generates different onnx graph for attention, where bias for Add becomes first input instead of the second one. That makes Attention fusion not working.