### PR TITLE
Ignore invalid input argument to install_os_deps.sh

### DIFF
--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_gpu_training
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_gpu_training
@@ -6,7 +6,7 @@ ARG USE_CONDA=false
 
 ADD scripts /tmp/scripts
 RUN /tmp/scripts/install_ubuntu.sh -p $PYTHON_VERSION && \
-    /tmp/scripts/install_os_deps.sh -p $PYTHON_VERSION -d gpu $INSTALL_DEPS_EXTRA_ARGS
+    /tmp/scripts/install_os_deps.sh -d gpu $INSTALL_DEPS_EXTRA_ARGS
 
 # If USE_CONDA is false, use root to install python dependencies.
 RUN if [ "$USE_CONDA" = false ] ; \

--- a/tools/ci_build/github/linux/docker/scripts/install_os_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_os_deps.sh
@@ -4,11 +4,16 @@ set -e -x
 SCRIPT_DIR="$( dirname "${BASH_SOURCE[0]}" )"
 INSTALL_DEPS_DISTRIBUTED_SETUP=false
 
-while getopts d:m parameter_Option
+while getopts p:d:v:tmur parameter_Option
 do case "${parameter_Option}"
 in
+p) echo "Python version is no longer accepted as an input to this script. Ignoring the input argument -p.";;
 d) DEVICE_TYPE=${OPTARG};;
+v) echo "Cuda version is no longer accepted as an input to this script. Ignoring the input argument -v.";;
+t) echo "Installing python training dependencies argument is no longer accepted as an input to this script. Ignoring the input argument -t.";;
 m) INSTALL_DEPS_DISTRIBUTED_SETUP=true;;
+u) echo "Installing ortmodule python dependencies argument is no longer accepted as an input to this script. Ignoring the input argument -u.";;
+r) echo "Installing ROCM python dependencies argument is no longer accepted as an input to this script. Ignoring the input argument -r.";;
 esac
 done
 


### PR DESCRIPTION
**Description**: The arguments to ```install_os_deps.sh``` were trimmed but the script invoking this script was still passing those unused arguments.
As a result, ```getopts``` was exiting the loop without parsing all the valid arguments. This resulted in some of the dependencies not being installed (like ```openmpi```) and caused the ```orttraining-distributed``` pipeline failure.