### PR TITLE
Fix logs getting skipped in single-line conditionals.

### DIFF
--- a/onnxruntime/core/providers/coreml/coreml_execution_provider.cc
+++ b/onnxruntime/core/providers/coreml/coreml_execution_provider.cc
@@ -172,10 +172,11 @@ CoreMLExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_vie
 
   // If the graph is partitioned in multiple subgraphs, and this may impact performance,
   // we want to give users a summary message at warning level.
-  if (num_of_partitions > 1)
+  if (num_of_partitions > 1) {
     LOGS_DEFAULT(WARNING) << summary_msg;
-  else
+  } else {
     LOGS_DEFAULT(INFO) << summary_msg;
+  }
 
   return result;
 }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
@@ -205,10 +205,11 @@ NnapiExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_view
 
   // If the graph is partitioned in multiple subgraphs, and this may impact performance,
   // we want to give users a summary message at warning level.
-  if (num_of_partitions > 1)
+  if (num_of_partitions > 1) {
     LOGS_DEFAULT(WARNING) << summary_msg;
-  else
+  } else {
     LOGS_DEFAULT(INFO) << summary_msg;
+  }
 
   return result;
 }

--- a/onnxruntime/test/common/logging/logging_test.cc
+++ b/onnxruntime/test/common/logging/logging_test.cc
@@ -286,7 +286,7 @@ TEST_F(LoggingTestsFixture, TestStreamMacroFromConditionalWithoutCompoundStateme
 
   auto logger = manager.CreateLogger(logger_id, min_log_level, filter_user_data);
 
-  auto log_from_conditional_without_compound_statement = [&logger](bool condition) {
+  auto log_from_conditional_without_compound_statement = [&logger, true_message, false_message](bool condition) {
     if (condition)
       LOGS(*logger, VERBOSE) << true_message;
     else

--- a/onnxruntime/test/common/logging/logging_test.cc
+++ b/onnxruntime/test/common/logging/logging_test.cc
@@ -286,7 +286,7 @@ TEST_F(LoggingTestsFixture, TestStreamMacroFromConditionalWithoutCompoundStateme
 
   auto logger = manager.CreateLogger(logger_id, min_log_level, filter_user_data);
 
-  auto log_from_conditional_without_compound_statement = [&logger, true_message, false_message](bool condition) {
+  auto log_from_conditional_without_compound_statement = [&](bool condition) {
     if (condition)
       LOGS(*logger, VERBOSE) << true_message;
     else


### PR DESCRIPTION
**Description**
Fix an issue where a log message got skipped.

A log call like this:
```
LOGS(...) << "message";
```
expands to something like this:
```
if (<output enabled>)
  logging::Capture(...).Stream() << "message";
```

This if statement without brackets is handy for logging arbitrary arguments with the `<<` operator. However, it has other drawbacks like possibly associating with a subsequent `else`.

```
if (cond)
  LOGS(...) << "a";
else
  <do something> // not run when !cond

// equivalently:
if (cond)
  if (<output enabled>)
    logging::Capture(...).Stream() << "a";
  else
    <do something> // not run when !cond
```

Updated the logging macros to handle this case by replacing `if (<enabled>) logging::Capture(...).Stream()` with `if (!<enabled>) {} else logging::Capture(...).Stream()`.

Thanks @tlh20 for the idea for the fix!

**Motivation and Context**
Unexpected log output.
