### PR TITLE
CUDA UpsampleNearest performance improvement

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/upsample_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/upsample_impl.cu
@@ -179,14 +179,18 @@ void UpampleImpl(cudaStream_t stream,
     } else {
       ORT_THROW("Unsupported rank by the Upsample CUDA kernel");
     }
-  } else if (onnxruntime::UpsampleMode::LINEAR == upsample_mode && rank == 4) {
-    _UpampleBilinear4DInputKernel<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
-        input_dim2, input_pitches, output_div_pitches, scales_div,
-        input_data, output_data, N);
-  } else if (onnxruntime::UpsampleMode::LINEAR == upsample_mode && rank == 2) {
-    _UpampleBilinear2DInputKernel<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
-        input_dim2, input_pitches, output_div_pitches, scales_div,
-        input_data, output_data, N);
+  } else if (onnxruntime::UpsampleMode::LINEAR) {
+    if (rank == 4) {
+      _UpampleBilinear4DInputKernel<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+          input_dim2, input_pitches, output_div_pitches, scales_div,
+          input_data, output_data, N);
+    } else if (rank == 2) {
+      _UpampleBilinear2DInputKernel<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+          input_dim2, input_pitches, output_div_pitches, scales_div,
+          input_data, output_data, N);
+    } else {
+      ORT_THROW("Unsupported rank by the Upsample CUDA kernel");
+    }
   }
 }
 

--- a/onnxruntime/core/providers/cuda/tensor/upsample_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/upsample_impl.cu
@@ -11,8 +11,8 @@ template <typename T, int RANK>
 __global__ void _UpampleNearestKernel(const TArray<int64_t> input_pitches,
                                       const TArray<fast_divmod> output_div_pitches,
                                       const TArray<fast_divmod> scales_div,
-                                      const T* input_data,
-                                      T* output_data,
+                                      const T* __restrict__ input_data,
+                                      T* __restrict__ output_data,
                                       const size_t N) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(id, N);
   CUDA_LONG input_index = 0;
@@ -40,8 +40,8 @@ __global__ void _UpampleBilinear4DInputKernel(const int64_t input_dim2,
                                        const TArray<int64_t> input_pitches,
                                        const TArray<fast_divmod> output_div_pitches,
                                        const TArray<fast_divmod> scales_div,
-                                       const T* input_data,
-                                       T* output_data,
+                                       const T* __restrict__ input_data,
+                                       T* __restrict__ output_data,
                                        const size_t N) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(id, N);
   CUDA_LONG input_index = 0;
@@ -100,8 +100,8 @@ __global__ void _UpampleBilinear2DInputKernel(const int64_t input_dim0,
                                               const TArray<int64_t> input_pitches,
                                               const TArray<fast_divmod> output_div_pitches,
                                               const TArray<fast_divmod> scales_div,
-                                              const T* input_data,
-                                              T* output_data,
+                                              const T* __restrict__ input_data,
+                                              T* __restrict__ output_data,
                                               const size_t N) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(id, N);
   CUDA_LONG input_index = 0;

--- a/onnxruntime/core/providers/cuda/tensor/upsample_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/upsample_impl.cu
@@ -7,9 +7,8 @@
 namespace onnxruntime {
 namespace cuda {
 
-template <typename T>
-__global__ void _UpampleNearestKernel(const size_t rank,
-                                      const TArray<int64_t> input_pitches,
+template <typename T, int RANK>
+__global__ void _UpampleNearestKernel(const TArray<int64_t> input_pitches,
                                       const TArray<fast_divmod> output_div_pitches,
                                       const TArray<fast_divmod> scales_div,
                                       const T* input_data,
@@ -20,7 +19,7 @@ __global__ void _UpampleNearestKernel(const size_t rank,
   CUDA_LONG output_index = id;
 
   int div, mod;
-  for (int dim = 0; dim < rank; ++dim) {
+  for (int dim = 0; dim < RANK; ++dim) {
     output_div_pitches[dim].divmod(output_index, div, mod);
     output_index = mod;
     if (scales_div[dim].d_ != 1 && div > 0) {
@@ -161,9 +160,25 @@ void UpampleImpl(cudaStream_t stream,
                  const size_t N) {
   int blocksPerGrid = (int)(ceil(static_cast<float>(N) / GridDim::maxThreadsPerBlock));
   if (onnxruntime::UpsampleMode::NN == upsample_mode) {
-    _UpampleNearestKernel<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
-        rank, input_pitches, output_div_pitches, scales_div,
-        input_data, output_data, N);
+    if (rank == 4) {
+      _UpampleNearestKernel<T,4><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+          input_pitches, output_div_pitches, scales_div,
+          input_data, output_data, N);
+    } else if (rank == 3) {
+      _UpampleNearestKernel<T,3><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+          input_pitches, output_div_pitches, scales_div,
+          input_data, output_data, N);
+    } else if (rank == 2) {
+      _UpampleNearestKernel<T,2><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+          input_pitches, output_div_pitches, scales_div,
+          input_data, output_data, N);
+    } else if (rank == 1) {
+      _UpampleNearestKernel<T,1><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+          input_pitches, output_div_pitches, scales_div,
+          input_data, output_data, N);
+    } else {
+      ORT_THROW("Unsupported rank by the Upsample CUDA kernel");
+    }
   } else if (onnxruntime::UpsampleMode::LINEAR == upsample_mode && rank == 4) {
     _UpampleBilinear4DInputKernel<T><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
         input_dim2, input_pitches, output_div_pitches, scales_div,


### PR DESCRIPTION
**Description**: This PR improves the performance of the CUDA kernel for nearest neighbor upsampling. It does so by promoting a function parameter (the rank of the tensor) into a template parameter with explicit instanciations, enabling the compiler to better unroll the loop inside the kernel. It also adds the `__restrict__` keyword to the input and output buffers, telling the compiler that the pointers cannot alias, hence enabling further optimisation.

`nvprof` before the changes (on 1.7.2):
```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   69.28%  69.195ms         5  13.839ms  3.8302ms  30.768ms  void onnxruntime::cuda::_UpampleNearestKernel<float>(__int64, onnxruntime::cuda::TArray<__int64, int=8>, onnxruntime::cuda::_UpampleNearestKernel<float, onnxruntime::cuda::fast_divmod, int=8>, onnxruntime::cuda::fast_divmod, float const *, onnxruntime::cuda::_UpampleNearestKernel<float, onnxruntime::cuda::fast_divmod, int=8>*, __int64)
```
`nvprof` after the changes (still on 1.7.2):
```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:    4.90%  1.6331ms         5  326.61us  93.118us  722.00us  void onnxruntime::cuda::_UpampleNearestKernel<float, int=4>(onnxruntime::cuda::TArray<__int64, int=8>, onnxruntime::cuda::_UpampleNearestKernel<float, int=4, onnxruntime::cuda::fast_divmod, int=8>, onnxruntime::cuda::fast_divmod, float const *, onnxruntime::cuda::_UpampleNearestKernel<float, int=4, onnxruntime::cuda::fast_divmod, int=8>*, __int64)
```

Speed up: x42!

**Motivation and Context**
- This enables our models, exported from TensorFlow, to run at similar or better speed than when executed from within TensorFlow.
- Closes https://github.com/microsoft/onnxruntime/issues/7578.
