### PR TITLE
symbolic shape inference improvements

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -335,14 +335,14 @@ class SymbolicShapeInference:
             # Some operators need initializers for shape inference. For example, Unsqueeze in opset 13 has axes in the second input.
             need_initializers = node.op_type in ['Unsqueeze']
 
-            # Only pass initializers that has impact on shape inference result for performance.
-            initializers = [self.initializers_[name] for name in node.input if name in self.initializers_] if need_initializers else []
+            # Only pass initializers with impact on shape inference result for performance.
+            initializers = [self.initializers_[name] for name in node.input
+                            if name in self.initializers_] if need_initializers else []
 
             # run single node inference with self.known_vi_ shapes
             tmp_graph = helper.make_graph(
                 [node], 'tmp', [self.known_vi_[i] for i in node.input if i],
-                [helper.make_tensor_value_info(i, onnx.TensorProto.UNDEFINED, None) for i in node.output],
-                initializers)
+                [helper.make_tensor_value_info(i, onnx.TensorProto.UNDEFINED, None) for i in node.output], initializers)
 
             self.tmp_mp_.graph.CopyFrom(tmp_graph)
             self.tmp_mp_ = shape_inference.infer_shapes(self.tmp_mp_)
@@ -1321,7 +1321,7 @@ class SymbolicShapeInference:
         word_embedding_shape = self._get_shape(node, 2)
         assert len(input_ids_shape) == 2 and len(word_embedding_shape) == 2
         output_shape = input_ids_shape + [word_embedding_shape[1]]
-        
+
         input_dtype = self.known_vi_[node.input[0]].type.tensor_type.elem_type
         vi = self.known_vi_[node.output[0]]
         vi.CopyFrom(helper.make_tensor_value_info(node.output[0], input_dtype, output_shape))

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -337,7 +337,8 @@ class SymbolicShapeInference:
 
         if not skip_infer:
             # Only pass initializers that satisfy the following condition:
-            # (1) Operator need value of some input for shape inference. For example, Unsqueeze in opset 13 uses axes input to calcuate output shape.
+            # (1) Operator need value of some input for shape inference.
+            #     For example, Unsqueeze in opset 13 uses the axes input to calculate shape of output.
             # (2) opset version >= 9. In older version, initializer is required in graph input by onnx spec.
             # (3) The initializer is not in graph input. The means the node input is "constant" in inference.
             initializers = []

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -7,7 +7,7 @@ from onnx import helper, AttributeProto, TensorProto, GraphProto
 import os
 
 if os.path.exists(os.path.join(os.path.dirname(__file__), '..', '..', 'python', 'tools', 'symbolic_shape_infer.py')):
-    # Running this test script without installing onnxruntime package.
+    # Allow running this test script without installing onnxruntime package.
     import sys
     sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'python', 'tools'))
     from symbolic_shape_infer import SymbolicShapeInference


### PR DESCRIPTION
**Description**: 
(1) Add EmbedLayerNormalization in shape inference
(2) Do not call onnx shape inference for contrib ops that defined inference function.
(3) Pass initializers for onnx shape inference that for Unsqueeze, so that we can remove custom shape inference code for the operator (as in https://github.com/microsoft/onnxruntime/pull/7560)
(4) Update unit test script so that we can run test without compiling and installing onnxruntime package. It helps developing.
(5) Fix a warning in Attention shape inference by converting float to int.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

When model has contrib op, symbolic shape inference output some warnings:
```
Warning: Unsupported operator LayerNormalization. No schema registered for this operator.
```
Need avoid calling onnx shape inference for contrib operators (some contrib ops are defined in onnx domain but they shall not).