### PR TITLE
Fix variable names in BatchNorm and LayerNorm implementations

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -2771,8 +2771,8 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dd>3D output tensor with shape (batch_size, sequence_length, hidden_size)</dd>
 <dt><tt>mean</tt> (optional) : U</dt>
 <dd>Saved mean used during training to speed up gradient computation</dd>
-<dt><tt>inv_std_var</tt> (optional) : U</dt>
-<dd>Saved inverse standard variance used during training to speed up gradient computation.</dd>
+<dt><tt>inv_std</tt> (optional) : U</dt>
+<dd>Saved inverse standard deviation used during training to speed up gradient computation.</dd>
 </dl>
 
 #### Type Constraints
@@ -2781,7 +2781,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dt><tt>T</tt> : tensor(float), tensor(float16)</dt>
 <dd>Constrain input and output types to float or half tensors.</dd>
 <dt><tt>U</tt> : tensor(float)</dt>
-<dd>Constrain mean and inv_std_var to float tensors.</dd>
+<dd>Constrain mean and inv_std to float tensors.</dd>
 </dl>
 
 

--- a/docs/OperatorKernels.md
+++ b/docs/OperatorKernels.md
@@ -296,7 +296,7 @@ Do not modify directly.*
 |||[6, 12]|**T** = tensor(double), tensor(float)|
 |Sign|*in* input:**T**<br> *out* output:**T**|13+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
 |||[9, 12]|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
-|SimplifiedLayerNormalization|*in* X:**T**<br> *in* scale:**T**<br> *out* Y:**T**<br> *out* inv_std_var:**U**|1+|**T** = tensor(double), tensor(float)|
+|SimplifiedLayerNormalization|*in* X:**T**<br> *in* scale:**T**<br> *out* Y:**T**<br> *out* inv_std:**U**|1+|**T** = tensor(double), tensor(float)|
 |Sin|*in* input:**T**<br> *out* output:**T**|7+|**T** = tensor(double), tensor(float)|
 |Sinh|*in* input:**T**<br> *out* output:**T**|9+|**T** = tensor(float)|
 |Size|*in* data:**T**<br> *out* size:**T1**|13+|**T** = tensor(bool), tensor(double), tensor(float), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)<br/> **T1** = tensor(int64)|
@@ -414,7 +414,7 @@ Do not modify directly.*
 |QuantizeLinear|*in* x:**T1**<br> *in* y_scale:**T1**<br> *in* y_zero_point:**T2**<br> *out* y:**T2**|1+|**T1** = tensor(float)<br/> **T2** = tensor(int8), tensor(uint8)|
 |Range|*in* start:**T**<br> *in* limit:**T**<br> *in* delta:**T**<br> *out* Y:**T**|1+|**T** = tensor(double), tensor(float), tensor(int16), tensor(int32), tensor(int64)|
 |SampleOp|*in* X:**T**<br> *out* Y:**T**|1+|**T** = tensor(float)|
-|SkipLayerNormalization|*in* input:**T**<br> *in* skip:**T**<br> *in* gamma:**T**<br> *in* beta:**T**<br> *in* bias:**T**<br> *out* output:**T**<br> *out* mean:**U**<br> *out* inv_std_var:**U**|1+|**T** = tensor(double), tensor(float)|
+|SkipLayerNormalization|*in* input:**T**<br> *in* skip:**T**<br> *in* gamma:**T**<br> *in* beta:**T**<br> *in* bias:**T**<br> *out* output:**T**<br> *out* mean:**U**<br> *out* inv_std:**U**|1+|**T** = tensor(double), tensor(float)|
 |SparseToDenseMatMul|*in* A:**T**<br> *in* B:**T1**<br> *out* Y:**T1**|1+|**T** = sparse_tensor(double), sparse_tensor(float), sparse_tensor(int32), sparse_tensor(int64), sparse_tensor(uint32), sparse_tensor(uint64)<br/> **T1** = tensor(double), tensor(float), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)|
 |Tokenizer|*in* X:**T**<br> *out* Y:**T**|1+|**T** = tensor(string)|
 |TransposeMatMul|*in* A:**T**<br> *in* B:**T**<br> *out* Y:**T**|1+|**T** = tensor(float)|
@@ -676,7 +676,7 @@ Do not modify directly.*
 |Shrink|*in* input:**T**<br> *out* output:**T**|9+|**T** = tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
 |Sigmoid|*in* X:**T**<br> *out* Y:**T**|13+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)|
 |||[6, 12]|**T** = tensor(double), tensor(float), tensor(float16)|
-|SimplifiedLayerNormalization|*in* X:**T**<br> *in* scale:**T**<br> *out* Y:**T**<br> *out* inv_std_var:**U**|1+|**T** = tensor(double), tensor(float), tensor(float16)<br/> **U** = tensor(double), tensor(float)|
+|SimplifiedLayerNormalization|*in* X:**T**<br> *in* scale:**T**<br> *out* Y:**T**<br> *out* inv_std:**U**|1+|**T** = tensor(double), tensor(float), tensor(float16)<br/> **U** = tensor(double), tensor(float)|
 |Sin|*in* input:**T**<br> *out* output:**T**|7+|**T** = tensor(double), tensor(float), tensor(float16)|
 |Size|*in* data:**T**<br> *out* size:**T1**|13+|**T** = tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)<br/> **T1** = tensor(int64)|
 |||[1, 12]|**T** = tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)<br/> **T1** = tensor(int64)|
@@ -749,7 +749,7 @@ Do not modify directly.*
 |QAttention|*in* input:**T1**<br> *in* weight:**T2**<br> *in* bias:**T3**<br> *in* input_scale:**T3**<br> *in* weight_scale:**T3**<br> *in* mask_index:**T4**<br> *in* input_zero_point:**T1**<br> *in* weight_zero_point:**T2**<br> *in* past:**T3**<br> *out* output:**T3**<br> *out* present:**T3**|1+|**T1** = tensor(int8)<br/> **T2** = tensor(int8)<br/> **T3** = tensor(float), tensor(float16)<br/> **T4** = tensor(int32)|
 |QuantizeLinear|*in* x:**T1**<br> *in* y_scale:**T1**<br> *in* y_zero_point:**T2**<br> *out* y:**T2**|1+|**T1** = tensor(float16)<br/> **T2** = tensor(int8), tensor(uint8)|
 |Rfft|*in* X:**T**<br> *out* Y:**T**|1+|**T** = tensor(double), tensor(float), tensor(float16)|
-|SkipLayerNormalization|*in* input:**T**<br> *in* skip:**T**<br> *in* gamma:**T**<br> *in* beta:**T**<br> *in* bias:**T**<br> *out* output:**T**<br> *out* mean:**U**<br> *out* inv_std_var:**U**|1+|**T** = tensor(float), tensor(float16)|
+|SkipLayerNormalization|*in* input:**T**<br> *in* skip:**T**<br> *in* gamma:**T**<br> *in* beta:**T**<br> *in* bias:**T**<br> *out* output:**T**<br> *out* mean:**U**<br> *out* inv_std:**U**|1+|**T** = tensor(float), tensor(float16)|
 |TransposeMatMul|*in* A:**T**<br> *in* B:**T**<br> *out* Y:**T**|1+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)|
 |Trilu|*in* X:**T**<br> *in* k:**tensor(int64)**<br> *out* Y:**T**|1+|**T** = tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
 | |

--- a/onnxruntime/contrib_ops/cuda/layer_norm.cc
+++ b/onnxruntime/contrib_ops/cuda/layer_norm.cc
@@ -70,36 +70,36 @@ Status LayerNorm<T, U, simplified>::ComputeInternal(OpKernelContext* ctx) const 
   Tensor* Y = ctx->Output(0, x_shape);
   auto Y_data = reinterpret_cast<CudaT*>(Y->template MutableData<T>());
 
-  //Mean and variance
-  std::vector<int64_t> mean_inv_std_var_dim;
+  // Mean and standard deviation
+  std::vector<int64_t> mean_inv_std_dim;
   for (int i = 0; i < static_cast<int>(x_shape.NumDimensions()); ++i) {
     if (i < axis) {
-      mean_inv_std_var_dim.emplace_back(x_shape.GetDims()[i]);
+      mean_inv_std_dim.emplace_back(x_shape.GetDims()[i]);
     } else {
-      mean_inv_std_var_dim.emplace_back(1);
+      mean_inv_std_dim.emplace_back(1);
     }
   }
   int output_index = 1;
 
   CudaU* mean_data = nullptr;
   if (!simplified) {
-    Tensor* mean = ctx->Output(output_index++, TensorShape(mean_inv_std_var_dim));
+    Tensor* mean = ctx->Output(output_index++, TensorShape(mean_inv_std_dim));
     if (mean != nullptr) {
       mean_data = reinterpret_cast<CudaU*>(mean->template MutableData<U>());
     }
   }
 
-  Tensor* var = ctx->Output(output_index, TensorShape(mean_inv_std_var_dim));
-  CudaU* inv_var_data = nullptr;
-  if (var != nullptr) {
-    inv_var_data = reinterpret_cast<CudaU*>(var->template MutableData<U>());
+  Tensor* std = ctx->Output(output_index, TensorShape(mean_inv_std_dim));
+  CudaU* inv_std_data = nullptr;
+  if (std != nullptr) {
+    inv_std_data = reinterpret_cast<CudaU*>(std->template MutableData<U>());
   }
 
   if (x_shape.Size() == 0) {
     return Status::OK();
   }
 
-  HostApplyLayerNorm<CudaT, CudaU, simplified>(GetDeviceProp(), Stream(), Y_data, mean_data, inv_var_data, X_data, n1, n2, epsilon_, scale_data, bias_data);
+  HostApplyLayerNorm<CudaT, CudaU, simplified>(GetDeviceProp(), Stream(), Y_data, mean_data, inv_std_data, X_data, n1, n2, epsilon_, scale_data, bias_data);
   return Status::OK();
 }
 

--- a/onnxruntime/contrib_ops/cuda/layer_norm.cc
+++ b/onnxruntime/contrib_ops/cuda/layer_norm.cc
@@ -89,10 +89,10 @@ Status LayerNorm<T, U, simplified>::ComputeInternal(OpKernelContext* ctx) const 
     }
   }
 
-  Tensor* std = ctx->Output(output_index, TensorShape(mean_inv_std_dim));
+  Tensor* inv_std = ctx->Output(output_index, TensorShape(mean_inv_std_dim));
   CudaU* inv_std_data = nullptr;
-  if (std != nullptr) {
-    inv_std_data = reinterpret_cast<CudaU*>(std->template MutableData<U>());
+  if (inv_std != nullptr) {
+    inv_std_data = reinterpret_cast<CudaU*>(inv_std->template MutableData<U>());
   }
 
   if (x_shape.Size() == 0) {

--- a/onnxruntime/contrib_ops/cuda/layer_norm_impl.h
+++ b/onnxruntime/contrib_ops/cuda/layer_norm_impl.h
@@ -35,7 +35,7 @@ void HostApplyLayerNorm(
     cudaStream_t stream,
     T* output,
     U* mean,
-    U* invvar,
+    U* inv_std,
     const T* input,
     int n1,
     int n2,

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -1018,9 +1018,9 @@ GELU (Gaussian Error Linear Unit) approximation: Y=0.5*X*(1+tanh(0.797885*X+0.03
       .Input(4, "bias", "1D bias tensor with shape (hidden_size", "T", OpSchema::Optional)
       .Output(0, "output", "3D output tensor with shape (batch_size, sequence_length, hidden_size)", "T")
       .Output(1, "mean", "Saved mean used during training to speed up gradient computation", "U", OpSchema::Optional)
-      .Output(2, "inv_std_var", "Saved inverse standard variance used during training to speed up gradient computation.", "U", OpSchema::Optional)
+      .Output(2, "inv_std", "Saved inverse standard deviation used during training to speed up gradient computation.", "U", OpSchema::Optional)
       .TypeConstraint("T", {"tensor(float)", "tensor(float16)"}, "Constrain input and output types to float or half tensors.")
-      .TypeConstraint("U", {"tensor(float)"}, "Constrain mean and inv_std_var to float tensors.")
+      .TypeConstraint("U", {"tensor(float)"}, "Constrain mean and inv_std to float tensors.")
       .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput);
 
   static const char* NGramRepeatBlock_ver1_doc = R"DOC(
@@ -2638,7 +2638,7 @@ Example 4:
             "The epsilon value to use to avoid division by zero.",
             AttributeProto::FLOAT, 1e-5f)
       .Attr("stash_type",
-            "type used for stash mean/inv_std_var",
+            "type used for stash mean/inv_std",
             AttributeProto::INT, static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))
       .AllowUncheckedAttributes()
       .Input(0, "X", "Input data tensor from the previous layer.", "T")
@@ -2787,15 +2787,15 @@ Example 4:
       .Input(0, "X", "Input data tensor from the previous layer.", "T")
       .Input(1, "scale", "Scale tensor.", "T")
       .Output(0, "Y", "Output data tensor.", "T")
-      .Output(1, "inv_std_var", "Saved inverse standard variance used during training to speed up gradient computation.", "U", OpSchema::Optional)
+      .Output(1, "inv_std", "Saved inverse standard deviation used during training to speed up gradient computation.", "U", OpSchema::Optional)
       .TypeConstraint(
           "T",
           {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-          "Constrain input and output types (except mean and inv_std_var) to float tensors.")
+          "Constrain input and output types (except inv_std) to float tensors.")
       .TypeConstraint(
           "U",
           {"tensor(float)"},
-          "Constrain mean and inv_std_var to be float tensors.")
+          "Constrain inv_std to be float tensors.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         propagateShapeAndTypeFromFirstInput(ctx);
         propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -2814,9 +2814,9 @@ Example 4:
         }
 
         if (ctx.getNumOutputs() > 1) {
-          auto saved_inv_std_var_shape = ctx.getOutputType(1)->mutable_tensor_type()->mutable_shape();
-          saved_inv_std_var_shape->CopyFrom(input_shape);
-          saved_inv_std_var_shape->mutable_dim(static_cast<int>(axis))->set_dim_value(1);
+          auto saved_inv_std_shape = ctx.getOutputType(1)->mutable_tensor_type()->mutable_shape();
+          saved_inv_std_shape->CopyFrom(input_shape);
+          saved_inv_std_shape->mutable_dim(static_cast<int>(axis))->set_dim_value(1);
         }
       });
 

--- a/onnxruntime/core/optimizer/layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/layer_norm_fusion.cc
@@ -330,7 +330,7 @@ Status LayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
 #ifdef ENABLE_TRAINING
     // add two extra output defs, so we have 3 output defs that match what gradient builder expected
     layer_norm_node.MutableOutputDefs().push_back(&graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("saved_mean"), nullptr));
-    layer_norm_node.MutableOutputDefs().push_back(&graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("saved_inv_std_var"), nullptr));
+    layer_norm_node.MutableOutputDefs().push_back(&graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("saved_inv_std"), nullptr));
 #endif
 
     modified = true;
@@ -600,7 +600,7 @@ Status SimplifiedLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int gr
 
 #ifdef ENABLE_TRAINING
     // add one extra output def, so we have 2 output defs that match what gradient builder expected
-    layer_norm_node.MutableOutputDefs().push_back(&graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("saved_inv_std_var"), nullptr));
+    layer_norm_node.MutableOutputDefs().push_back(&graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("saved_inv_std"), nullptr));
 #endif
 
     modified = true;

--- a/onnxruntime/core/providers/cpu/nn/batch_norm.h
+++ b/onnxruntime/core/providers/cpu/nn/batch_norm.h
@@ -182,9 +182,9 @@ class BatchNorm : public OpKernel {
         is_spatial_ ? C : sample_size_incl_all_channels);
 
     // We can fuse the output computation as follows:
-    //   ((x - est_mean) * (inv_var) * scale + bias
+    //   ((x - est_mean) * (inv_std)) * scale + bias
     // to
-    //   (x * inv_var * scale) + (bias - est_mean * inv_var * scale)
+    //   (x * inv_std * scale) + (bias - est_mean * inv_std * scale)
     Eigen::Array<T, Eigen::Dynamic, 1> new_scale = inv_std * scale_arr;
     Eigen::Array<T, Eigen::Dynamic, 1> new_bias = bias_arr - mean_arr * new_scale;
     EigenArrayMap<T> Y_arr(Y->template MutableData<T>(),

--- a/onnxruntime/test/onnx/microbenchmark/batchnorm2.cc
+++ b/onnxruntime/test/onnx/microbenchmark/batchnorm2.cc
@@ -72,9 +72,9 @@ static void BM_BatchNormOldEigen(benchmark::State& state) {
     inv_std = (var_arr + epsilon_).sqrt().inverse();
     ConstEigenVectorArrayMap<T> mean_arr(mean->Data<T>(), is_spatial_ ? C : sample_size_incl_all_channels);
     // We can fuse the output computation as follows:
-    //   ((x - est_mean) * (inv_var) * scale + bias
+    //   ((x - est_mean) * (inv_std)) * scale + bias
     // to
-    //   (x * inv_var * scale) + (bias - est_mean * inv_var * scale)
+    //   (x * inv_std * scale) + (bias - est_mean * inv_std * scale)
     Eigen::Array<T, Eigen::Dynamic, 1> new_scale = inv_std * scale_arr;
     Eigen::Array<T, Eigen::Dynamic, 1> new_bias = bias_arr - mean_arr * new_scale;
     EigenArrayMap<T> Y_arr(Y->template MutableData<T>(), is_spatial_ ? sample_size : sample_size_incl_all_channels,

--- a/onnxruntime/test/testdata/transform/computation_reduction.py
+++ b/onnxruntime/test/testdata/transform/computation_reduction.py
@@ -42,7 +42,7 @@ gather_indice_initializer = numpy_helper.from_array(gather_indice_np_vals, "gath
 nodes=[]
 layer_norm1 = helper.make_node('LayerNormalization', 
                                ['input', layer_norm1_weight_initializer.name, layer_norm1_bias_initializer.name],
-                               ['layer_norm1', 'saved_mean1', 'saved_inv_std_var1'],
+                               ['layer_norm1', 'saved_mean1', 'saved_inv_std1'],
                                name='layer_norm_1', epsilon=9.999999960041972e-13, axis=-1)
 nodes.append(layer_norm1)
 
@@ -60,7 +60,7 @@ nodes.append(gelu1)
 
 layer_norm2 = helper.make_node('LayerNormalization',
                                ['gelu1', layer_norm2_weight_initializer.name, layer_norm2_bias_initializer.name],
-                               ['layer_norm2', 'saved_mean2', 'saved_inv_std_var2'],
+                               ['layer_norm2', 'saved_mean2', 'saved_inv_std2'],
                                name='layer_norm_2', epsilon=9.999999960041972e-13, axis=-1)
 nodes.append(layer_norm2)
 

--- a/onnxruntime/test/testdata/transform/computation_reduction/e2e.py
+++ b/onnxruntime/test/testdata/transform/computation_reduction/e2e.py
@@ -42,7 +42,7 @@ gather_indice_initializer = numpy_helper.from_array(gather_indice_np_vals, "gath
 nodes=[]
 layer_norm1 = helper.make_node('LayerNormalization', 
                                ['input', layer_norm1_weight_initializer.name, layer_norm1_bias_initializer.name],
-                               ['layer_norm1', 'saved_mean1', 'saved_inv_std_var1'],
+                               ['layer_norm1', 'saved_mean1', 'saved_inv_std1'],
                                name='layer_norm_1', epsilon=9.999999960041972e-13, axis=-1)
 nodes.append(layer_norm1)
 
@@ -60,7 +60,7 @@ nodes.append(gelu1)
 
 layer_norm2 = helper.make_node('LayerNormalization',
                                ['gelu1', layer_norm2_weight_initializer.name, layer_norm2_bias_initializer.name],
-                               ['layer_norm2', 'saved_mean2', 'saved_inv_std_var2'],
+                               ['layer_norm2', 'saved_mean2', 'saved_inv_std2'],
                                name='layer_norm_2', epsilon=9.999999960041972e-13, axis=-1)
 nodes.append(layer_norm2)
 

--- a/onnxruntime/test/testdata/transform/computation_reduction/gathernd_layernormalization.py
+++ b/onnxruntime/test/testdata/transform/computation_reduction/gathernd_layernormalization.py
@@ -18,7 +18,7 @@ layer_norm1_bias_initializer = numpy_helper.from_array(layer_norm1_bias_np_vals,
 nodes=[]
 layer_norm1 = helper.make_node('LayerNormalization', 
                                ['input', layer_norm1_weight_initializer.name, layer_norm1_bias_initializer.name],
-                               ['layer_norm1', 'saved_mean1', 'saved_inv_std_var1'],
+                               ['layer_norm1', 'saved_mean1', 'saved_inv_std1'],
                                name='layer_norm_1', epsilon=9.999999960041972e-13, axis=-1)
 nodes.append(layer_norm1)
 

--- a/orttraining/orttraining/core/graph/training_op_defs.cc
+++ b/orttraining/orttraining/core/graph/training_op_defs.cc
@@ -2191,18 +2191,18 @@ Example 4:
       .Input(1, "X", "Input data tensor from the forward path", "T")
       .Input(2, "scale", "Scale tensor.", "T")
       .Input(3, "mean", "mean of X.", "U")
-      .Input(4, "inv_std_dev", "inverse std deviation of X.", "U")
+      .Input(4, "inv_std", "inverse standard deviation of X.", "U")
       .Output(0, "X_grad", "Gradient of the input.", "T")
       .Output(1, "scale_grad", "Gradient of the scale.", "T")
       .Output(2, "bias_grad", "Gradient of the bias.", "T")
       .TypeConstraint(
           "T",
           {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-          "Constrain input and output types (except mean and inv_std_var) to float tensors.")
+          "Constrain input and output types (except mean and inv_std) to float tensors.")
       .TypeConstraint(
           "U",
           {"tensor(float)", "tensor(bfloat16)"},
-          "Constrain mean and inv_std_var to float tensors.")
+          "Constrain mean and inv_std to float tensors.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         propagateElemTypeFromInputToOutput(ctx, 1, 0);
         propagateShapeFromInputToOutput(ctx, 1, 0);
@@ -2277,23 +2277,23 @@ Example 4:
       .Input(0, "Y_grad", "The gradient tensor from output.", "T")
       .Input(1, "X", "Input data tensor from the forward path", "T")
       .Input(2, "scale", "Scale tensor.", "T")
-      .Input(3, "inv_std_var", "inverse std variance of X.", "U")
+      .Input(3, "inv_std", "inverse standard deviation of X.", "U")
       .Output(0, "X_grad", "Gradient of the input.", "T")
       .Output(1, "scale_grad", "Gradient of the scale.", "T")
       .TypeConstraint(
           "T",
           {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-          "Constrain input and output types (except mean and inv_std_var) to float tensors.")
+          "Constrain input and output types (except inv_std) to float tensors.")
       .TypeConstraint(
           "U",
           {"tensor(float)"},
-          "Constrain mean and inv_std_var to float tensors.");
+          "Constrain inv_std to float tensors.");
 
   ONNX_CONTRIB_OPERATOR_SCHEMA(InvertibleLayerNormalizationGrad)
       .SetDomain(kMSDomain)
       .SinceVersion(1)
       .SetSupportLevel(OpSchema::SupportType::EXPERIMENTAL)
-      .SetDoc("LayerNormalizationGrad")
+      .SetDoc("InvertibleLayerNormalizationGrad")
       .Attr("axis",
             "The first normalization dimension: normalization will be performed along dimensions axis : rank(inputs).",
             AttributeProto::INT, static_cast<int64_t>(-1))
@@ -2302,18 +2302,18 @@ Example 4:
       .Input(1, "Y", "Output data tensor from the forward path", "T")
       .Input(2, "scale", "Scale tensor.", "T")
       .Input(3, "bias", "Bias tensor.", "T")
-      .Input(4, "inv_std_var", "inverse std variance of X.", "U")
+      .Input(4, "inv_std", "inverse standard deviation of X.", "U")
       .Output(0, "X_grad", "Gradient of the input.", "T")
       .Output(1, "scale_grad", "Gradient of the scale.", "T")
       .Output(2, "bias_grad", "Gradient of the bias.", "T")
       .TypeConstraint(
           "T",
           {"tensor(float16)", "tensor(float)", "tensor(double)"},
-          "Constrain input and output types (except mean and inv_std_var) to float tensors.")
+          "Constrain input and output types (except mean and inv_std) to float tensors.")
       .TypeConstraint(
           "U",
           {"tensor(float)"},
-          "Constrain mean and inv_std_var to float tensors.");
+          "Constrain mean and inv_std to float tensors.");
 
   ONNX_CONTRIB_OPERATOR_SCHEMA(BatchNormalizationGrad)
       .SetDomain(kMSDomain)

--- a/orttraining/orttraining/python/training/postprocess.py
+++ b/orttraining/orttraining/python/training/postprocess.py
@@ -341,7 +341,7 @@ def layer_norm_transform(model):
             layer_norm_output.append(div.output[0])
 
         layer_norm_output.append('saved_mean_' + str(id))
-        layer_norm_output.append('saved_inv_std_var_' + str(id))
+        layer_norm_output.append('saved_inv_std_' + str(id))
 
         epsilon_node = find_input_node(model, add.input[1])
         epsilon = epsilon_node.attribute[0].t.raw_data

--- a/orttraining/orttraining/test/python/orttraining_test_layer_norm_transform.py
+++ b/orttraining/orttraining/test/python/orttraining_test_layer_norm_transform.py
@@ -149,7 +149,7 @@ def layer_norm_transform(model_proto):
         id = id + 1
         layer_norm_output.append('saved_mean_' + str(id))
         id = id + 1
-        layer_norm_output.append('saved_inv_std_var_' + str(id))
+        layer_norm_output.append('saved_inv_std_' + str(id))
         layer_norm = onnx.helper.make_node("LayerNormalization",
                                         layer_norm_input,
                                         layer_norm_output,

--- a/orttraining/orttraining/training_ops/cuda/nn/layer_norm.cc
+++ b/orttraining/orttraining/training_ops/cuda/nn/layer_norm.cc
@@ -64,13 +64,13 @@ Status LayerNormGrad<T, U, simplified>::ComputeInternal(OpKernelContext* p_op_ke
   if (!simplified) {
     mean = p_op_kernel_context->Input<Tensor>(input_index++);
   }
-  const Tensor* inv_std_var = p_op_kernel_context->Input<Tensor>(input_index);
+  const Tensor* inv_std = p_op_kernel_context->Input<Tensor>(input_index);
 
   auto Y_grad_data = reinterpret_cast<const CudaT*>(Y_grad->template Data<T>());
   auto X_data = reinterpret_cast<const CudaT*>(X->template Data<T>());
   auto scale_data = reinterpret_cast<const CudaT*>(scale->template Data<T>());
   auto mean_data = simplified ? nullptr : reinterpret_cast<const CudaU*>(mean->template Data<U>());
-  auto inv_std_var_data = reinterpret_cast<const CudaU*>(inv_std_var->template Data<U>());
+  auto inv_std_data = reinterpret_cast<const CudaU*>(inv_std->template Data<U>());
 
   const TensorShape& x_shape = X->Shape();
   const int64_t axis = HandleNegativeAxis(axis_, x_shape.NumDimensions());
@@ -94,7 +94,7 @@ Status LayerNormGrad<T, U, simplified>::ComputeInternal(OpKernelContext* p_op_ke
   auto part_grad_beta = GetScratchBuffer<CudaU>(part_size * n2);
 
   HostLayerNormGradient<CudaT, CudaU, simplified>(GetDeviceProp(), Stream(), Y_grad_data, X_data, reinterpret_cast<const CudaT*>(NULL),
-                                                  scale_data, reinterpret_cast<const CudaT*>(NULL), mean_data, inv_std_var_data, n1, n2,
+                                                  scale_data, reinterpret_cast<const CudaT*>(NULL), mean_data, inv_std_data, n1, n2,
                                                   X_grad_data, scale_grad_data, bias_grad_data,
                                                   part_grad_gamma.get(), part_grad_beta.get(), part_size);
   return Status::OK();
@@ -114,13 +114,13 @@ Status InvertibleLayerNormGrad<T, U>::ComputeInternal(OpKernelContext* p_op_kern
   const Tensor* Y = p_op_kernel_context->Input<Tensor>(1);
   const Tensor* scale = p_op_kernel_context->Input<Tensor>(2);
   const Tensor* bias = p_op_kernel_context->Input<Tensor>(3);
-  const Tensor* inv_std_var = p_op_kernel_context->Input<Tensor>(4);
+  const Tensor* inv_std = p_op_kernel_context->Input<Tensor>(4);
 
   auto Y_grad_data = reinterpret_cast<const CudaT*>(Y_grad->template Data<T>());
   auto Y_data = reinterpret_cast<const CudaT*>(Y->template Data<T>());
   auto scale_data = reinterpret_cast<const CudaT*>(scale->template Data<T>());
   auto bias_data = reinterpret_cast<const CudaT*>(bias->template Data<T>());
-  auto inv_std_var_data = reinterpret_cast<const CudaU*>(inv_std_var->template Data<U>());
+  auto inv_std_data = reinterpret_cast<const CudaU*>(inv_std->template Data<U>());
 
   const TensorShape& y_shape = Y->Shape();
   const TensorShape& x_shape = y_shape;
@@ -143,7 +143,7 @@ Status InvertibleLayerNormGrad<T, U>::ComputeInternal(OpKernelContext* p_op_kern
   auto part_grad_beta = GetScratchBuffer<CudaU>(part_size * n2);
 
   HostLayerNormGradient<CudaT, CudaU, false>(GetDeviceProp(), Stream(), Y_grad_data, reinterpret_cast<const CudaT*>(NULL), Y_data,
-                                             scale_data, bias_data, reinterpret_cast<const CudaU*>(NULL), inv_std_var_data, n1, n2,
+                                             scale_data, bias_data, reinterpret_cast<const CudaU*>(NULL), inv_std_data, n1, n2,
                                              X_grad_data, scale_grad_data, bias_grad_data,
                                              part_grad_gamma.get(), part_grad_beta.get(), part_size);
   return Status::OK();

--- a/orttraining/orttraining/training_ops/cuda/nn/layer_norm_impl.cu
+++ b/orttraining/orttraining/training_ops/cuda/nn/layer_norm_impl.cu
@@ -341,7 +341,7 @@ __global__ void cuComputeGradInput(
         sum_loss1 += c_loss * U( gamma_idx );
         if (use_mean) {
           const U c_h = static_cast<U>( (idx<n2)?k_input[ idx ]:T(0) );
-          sum_loss2 += c_loss * U(gamma_idx) * (c_h - c_mean) * c_invvar;
+          sum_loss2 += c_loss * U(gamma_idx) * (c_h - c_mean) * c_inv_std;
         } else {
           const U c_output = static_cast<U>( (idx<n2)?k_output[idx]:T(0) );
           sum_loss2 += c_loss * (c_output - U( (idx<n2)?beta[idx]:T(0) ));
@@ -383,7 +383,7 @@ __global__ void cuComputeGradInput(
           sum_loss1 += c_loss;
           if (use_mean) {
             const U c_h = static_cast<U>((idx<n2)?k_input[idx]:T(0));
-            sum_loss2 += c_loss * (c_h - c_mean) * c_invvar;
+            sum_loss2 += c_loss * (c_h - c_mean) * c_inv_std;
           } else {
             const U c_output = static_cast<U>((idx<n2)?k_output[idx]:T(0));
             sum_loss2 += c_loss * c_output;

--- a/orttraining/orttraining/training_ops/cuda/nn/layer_norm_impl.h
+++ b/orttraining/orttraining/training_ops/cuda/nn/layer_norm_impl.h
@@ -38,7 +38,7 @@ void HostLayerNormGradient(
     const T* gamma,
     const T* beta,
     const U* mean,
-    const U* invvar,
+    const U* inv_std,
     int64_t n1,
     int64_t n2,
     T* grad_input,

--- a/orttraining/tools/scripts/layer_norm_transform.py
+++ b/orttraining/tools/scripts/layer_norm_transform.py
@@ -116,7 +116,7 @@ def main():
         id = id + 1
         layer_norm_output.append('saved_mean_' + str(id))
         id = id + 1
-        layer_norm_output.append('saved_inv_std_var_' + str(id))
+        layer_norm_output.append('saved_inv_std_' + str(id))
         layer_norm = helper.make_node("LayerNormalization",
                                         layer_norm_input,
                                         layer_norm_output,


### PR DESCRIPTION
**Description**: Describe your changes.

* Use actual variable names in comments
* Make parentheses balanced

**Motivation and Context**

I was studying how onnxruntime implements BatchNorm, and got confused by comments. I found similar issues in comments for LayerNorm, so I fixed them all in this PR. Hopefully it makes the code clearer.