### PR TITLE
Resolve issue where a registered buffer was parsed incorrectly as a user input

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -102,7 +102,7 @@ def _combine_input_buffers_initializers(param_names, onnx_input_names, input_inf
                     input_idx = input_info.names.index(name)
                 inp = non_none_inputs[input_idx]
             except (IndexError, ValueError):
-                # input is not present in input_info.names.
+                # ONNX input name is not present in input_info.names.
                 pass
 
         if inp is None:
@@ -110,7 +110,7 @@ def _combine_input_buffers_initializers(param_names, onnx_input_names, input_inf
             try:
                 inp = buffer_names_dict[name]
             except KeyError:
-                # input is not present in the buffer dict.
+                # ONNX input name is not present in the registered buffer dict.
                 pass
 
         if inp is not None:

--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -264,7 +264,9 @@ def _parse_outputs_and_extract_names_and_dynamic_axes(module_output):
         if output is None:
             return
         elif isinstance(output, torch.Tensor):
-            output_name = f'output{output_idx[0]}'
+            # Naming the outputs with a hyphen ensures that there can be no input with the same
+            # name, preventing collisions with other NodeArgs (for example an input to forward called output0)
+            output_name = f'output-{output_idx[0]}'
             output_idx[0] += 1
             output_names.append(output_name)
             output_dynamic_axes[output_name] = {}

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -2328,3 +2328,37 @@ def test_changing_bool_input_re_exports_model(bool_arguments):
     exported_model2 = ort_model._execution_manager(ort_model._is_training())._onnx_model
 
     assert exported_model1 != exported_model2
+
+def test_model_with_registered_buffer_and_dropped_parameters():
+    class ModelWithBufferAndDroppedParameter(torch.nn.Module):
+        def __init__(self, input_size, hidden_size, num_classes):
+            super(ModelWithBufferAndDroppedParameter, self).__init__()
+
+            self.fc1 = torch.nn.Linear(input_size, hidden_size)
+            self.relu = torch.nn.ReLU()
+            self.fc2 = torch.nn.Linear(hidden_size, num_classes)
+            self.register_buffer("buffer", torch.ones(num_classes))
+
+        def forward(self, bool_argument, input1):
+            if bool_argument:
+                out = self.fc1(input1)
+                out = self.relu(out)
+                out = self.fc2(out)
+                out = out + self.buffer
+            else:
+                out = self.fc1(input1)
+                out = self.fc2(out)
+                out = self.relu(out)
+                out = out + self.buffer
+            return out
+
+    device = 'cuda'
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = ModelWithBufferAndDroppedParameter(D_in, H, D_out).to(device)
+    model = ORTModule(model)
+
+    bool_argument = torch.tensor(True)
+    x = torch.randn(N, D_in, device=device)
+
+    # Ensure that no exceptions are raised
+    out = model(bool_argument, x)


### PR DESCRIPTION
In the logic that was parsing user inputs, there was an incorrect assumption that there would be no dropped arguments to the forward method. Here is an example that highlights the subtle bug:
```py
class ModelWithBufferAndDroppedParameter(torch.nn.Module):
    def __init__(self, input_size, hidden_size, num_classes):
        super(ModelWithBufferAndDroppedParameter, self).__init__()

        self.fc1 = torch.nn.Linear(input_size, hidden_size)
        self.relu = torch.nn.ReLU()
        self.fc2 = torch.nn.Linear(hidden_size, num_classes)
        self.register_buffer("buffer", torch.ones(num_classes))

    def forward(self, bool_argument, input1):
        if bool_argument:
            out = self.fc1(input1)
            out = self.relu(out)
            out = self.fc2(out)
            out = out + self.buffer
        else:
            out = self.fc1(input1)
            out = self.fc2(out)
            out = self.relu(out)
            out = out + self.buffer
        return out
```

- When the model is exported, the ```bool_argument``` is dropped, so the ```onnx_input_names``` would be ```[input1, buffer]```.
- The ```input_info.names``` would contain all the user input names ```[bool_argument, input1]```.
- But because ```buffer``` is at the 1st position (0 indexed), the code is tricked into believing that it must find that input from the user inputs and not from the ```buffer_dict``` .

This pull request addresses this subtle bug.

In addition to this, this pull request also renames the outputs of the onnx graph from ```[output0, output1, output2...]``` to ```[output-0, output-1, output-2...]```. This helps in preventing name collisions with forward inputs that could have been named ```output0``` for example.