### PR TITLE
Fix a compile warning in EigenNonBlockingThreadPool.h

### DIFF
--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -1024,7 +1024,7 @@ void InitializePreferredWorkers(std::vector<int> &preferred_workers) {
 void UpdatePreferredWorker(std::vector<int> &preferred_workers,
                            unsigned par_idx) {
   unsigned ran_on_idx = GetPerThread()->thread_id;
-  assert(ran_on_idx >= 0 && ran_on_idx < num_threads_);
+  assert(ran_on_idx < num_threads_);
   assert(par_idx < preferred_workers.size());
   preferred_workers[par_idx] = ran_on_idx;
 }


### PR DESCRIPTION
**Description**: 

In PR #7599, @ankurverma85 found we have some warnings like:

```
~/src/onnxruntime/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h:1027:21: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
 1027 |   assert(ran_on_idx >= 0 && ran_on_idx < num_threads_);
```

**Motivation and Context**

- Why is this change required? What problem does it solve?
Resolve #7583 

- If it fixes an open issue, please link to the issue here.
