### PR TITLE
ROCm optimized layernorm for MI100

### DIFF
--- a/onnxruntime/contrib_ops/cuda/layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/layer_norm_impl.cu
@@ -365,6 +365,10 @@ void HostApplyLayerNorm(
   ORT_ENFORCE(warp_size == GPU_WARP_SIZE);
 
   const dim3 threads(warp_size, 4, 1);
+#ifdef HIP_VERSION
+  // Optimization for ROCm MI100
+  threads.y = 2;
+#endif
   const dim3 blocks(1, std::min<unsigned int>(n1, maxGridY), 1);
   int nshared =
       threads.y > 1 ? threads.y * sizeof(U) + (threads.y / 2) * sizeof(U) : 0;

--- a/onnxruntime/contrib_ops/cuda/layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/layer_norm_impl.cu
@@ -367,7 +367,7 @@ void HostApplyLayerNorm(
   dim3 threads(warp_size, 4, 1);
 #ifdef HIP_VERSION
   // Optimization for ROCm MI100
-  threads.y = 2;
+  threads.y = 1;
 #endif
   const dim3 blocks(1, std::min<unsigned int>(n1, maxGridY), 1);
   int nshared =

--- a/onnxruntime/contrib_ops/cuda/layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/layer_norm_impl.cu
@@ -364,7 +364,7 @@ void HostApplyLayerNorm(
   const int warp_size = prop.warpSize;
   ORT_ENFORCE(warp_size == GPU_WARP_SIZE);
 
-  const dim3 threads(warp_size, 4, 1);
+  dim3 threads(warp_size, 4, 1);
 #ifdef HIP_VERSION
   // Optimization for ROCm MI100
   threads.y = 2;

--- a/orttraining/orttraining/training_ops/cuda/nn/layer_norm_impl.cu
+++ b/orttraining/orttraining/training_ops/cuda/nn/layer_norm_impl.cu
@@ -537,7 +537,11 @@ void HostLayerNormGradient(
   // compute grad_input
   const uint64_t maxGridY = prop.maxGridSize[1];
   const dim3 blocks1(1, std::min<unsigned int>(static_cast<unsigned int>(n1), static_cast<unsigned int>(maxGridY)), 1);
-  const dim3 threads1(warp_size, 4, 1);
+  dim3 threads1(warp_size, 4, 1);
+#ifdef HIP_VERSION
+  // Optimization for ROCm MI100
+  threads1.y = 2;
+#endif
   int nshared =
       threads1.y > 1 ? threads1.y * threads1.x * sizeof(U) : 0;
   if (mean == nullptr && !simplified) {


### PR DESCRIPTION
**Description**: Describe your changes.
- Optimized block size on MI100 for layerNorm implementation
- Optimized global mem reads on MI100 for gradient of layerNorm

**Motivation and Context**
- Why is this change required? What problem does it solve?
- https://ontrack.amd.com/browse/MSRCHA-102 : LayerNorm kernel and its grad is slower on MI100 than on V100.

- If it fixes an open issue, please link to the issue here.
