### PR TITLE
Make Bad Names Good Again! 

### DIFF
--- a/orttraining/orttraining/core/agent/training_agent.h
+++ b/orttraining/orttraining/core/agent/training_agent.h
@@ -19,9 +19,7 @@ class TrainingAgent {
  public:
   explicit TrainingAgent(InferenceSession& session,
                          const std::vector<std::string>& fw_feed_names,
-                         const std::vector<std::string>& fw_fetches_names,
                          const std::vector<OrtDevice>& fw_outputs_device_info,
-                         const std::vector<std::string>& bw_feed_names,
                          const std::vector<std::string>& bw_fetches_names,
                          const std::vector<OrtDevice>& bw_outputs_device_info);
   ~TrainingAgent();

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -501,10 +501,11 @@ void addObjectMethodsForTraining(py::module& m) {
 
   py::class_<TrainingAgent>(m, "TrainingAgent", R"pbdoc(This is the main class used to run a ORTModule model.)pbdoc")
       .def(py::init([](PyInferenceSession* session, const std::vector<std::string>& fw_feed_names,
-                       const std::vector<std::string>& fw_fetches_names, const std::vector<OrtDevice>& fw_outputs_device_info,
-                       const std::vector<std::string>& bw_feed_names, const std::vector<std::string>& bw_fetches_names,
+                       const std::vector<OrtDevice>& fw_outputs_device_info,
+                       const std::vector<std::string>& bw_fetches_names,
                        const std::vector<OrtDevice>& bw_outputs_device_info) {
-        return std::make_unique<TrainingAgent>(*session->GetSessionHandle(), fw_feed_names, fw_fetches_names, fw_outputs_device_info, bw_feed_names, bw_fetches_names, bw_outputs_device_info);
+        return std::make_unique<TrainingAgent>(*session->GetSessionHandle(), fw_feed_names, fw_outputs_device_info,
+                                               bw_fetches_names, bw_outputs_device_info);
       }))
       .def("run_forward", [](TrainingAgent* agent, const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state) -> void {
         Status status = agent->RunForward(feeds, fetches, *state);

--- a/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
+++ b/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
@@ -77,15 +77,13 @@ class TrainingAgent(object):
     This is the main class used to run an ORTModule model training.
     """
 
-    def __init__(self, path_or_bytes, fw_feed_names, fw_fetches_names, fw_outputs_device_info,
-                 bw_feed_names, bw_fetches_names, bw_outputs_device_info, session_options=None,
+    def __init__(self, path_or_bytes, fw_feed_names, fw_outputs_device_info,
+                 bw_fetches_names, bw_outputs_device_info, session_options=None,
                  providers=None, provider_options=None):
         """
         :param path_or_bytes: filename or serialized ONNX or ORT format model in a byte string
         :param fw_feed_names: Feed names for foward pass.
-        :param fw_fetches_names: Fetch names for forward pass.
         :param fw_outputs_device_info: Device info for fetches in forward pass.
-        :param bw_feed_names: Feed names for backward pass.
         :param bw_fetches_names: Fetch names for backward pass.
         :param bw_outputs_device_info: Device info for fetches in backward pass.
         :param sess_options: session options
@@ -115,8 +113,8 @@ class TrainingAgent(object):
         self._inference_session = onnxruntime.InferenceSession(path_or_bytes, session_options,
                                                                providers, provider_options)
 
-        self._training_agent = C_TrainingAgent(self._inference_session._sess, fw_feed_names, fw_fetches_names,
-                                               fw_outputs_device_info, bw_feed_names, bw_fetches_names, bw_outputs_device_info)
+        self._training_agent = C_TrainingAgent(self._inference_session._sess, fw_feed_names, fw_outputs_device_info,
+                                               bw_fetches_names, bw_outputs_device_info)
 
     def run_forward(self, feeds, fetches, state):
         """

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -224,9 +224,7 @@ class TrainingManager(GraphExecutionManager):
 
         self._execution_agent = TrainingAgent(self._optimized_onnx_model.SerializeToString(),
                                               fw_feed_names,
-                                              self._graph_info.user_output_names,
                                               fw_outputs_device_info,
-                                              self._graph_info.module_output_gradient_name,
                                               bw_fetches_names,
                                               bw_outputs_device_info,
                                               session_options,


### PR DESCRIPTION
user_output_names and module_output_gradient_name should not be finalized in ortmodule_graph_builder.cc because they could change downstream in InferenceSession::Initialize() after ortmodule gradient graph is built due to graph transformations.

This a short-term fix to instead retrieve above stale values directly from the YieldOp. As it turns out refactoring graph transformation out of InferenceSession::Initialize() is tricky and will need more time and thinking but this bug is already blocking few people in the team.
