### PR TITLE
Add building minSdkVer for AAR and AndroidTest

### DIFF
--- a/cmake/onnxruntime_java.cmake
+++ b/cmake/onnxruntime_java.cmake
@@ -166,7 +166,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Android")
   add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:onnxruntime> ${ANDROID_PACKAGE_ABI_DIR}/$<TARGET_LINKER_FILE_NAME:onnxruntime>)
   add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:onnxruntime4j_jni> ${ANDROID_PACKAGE_ABI_DIR}/$<TARGET_LINKER_FILE_NAME:onnxruntime4j_jni>)
   # Generate the Android AAR package
-  add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${GRADLE_EXECUTABLE} -b build-android.gradle -c settings-android.gradle build -DjniLibsDir=${ANDROID_PACKAGE_JNILIBS_DIR} -DbuildDir=${ANDROID_PACKAGE_OUTPUT_DIR} WORKING_DIRECTORY ${JAVA_ROOT})
+  add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${GRADLE_EXECUTABLE} -b build-android.gradle -c settings-android.gradle build -DjniLibsDir=${ANDROID_PACKAGE_JNILIBS_DIR} -DbuildDir=${ANDROID_PACKAGE_OUTPUT_DIR} -DminSdkVer=${ANDROID_MIN_SDK} WORKING_DIRECTORY ${JAVA_ROOT})
 
   if (onnxruntime_BUILD_UNIT_TESTS)
     set(ANDROID_TEST_PACKAGE_ROOT ${JAVA_ROOT}/src/test/android)
@@ -180,6 +180,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Android")
     add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${CMAKE_COMMAND} -E create_symlink ${ANDROID_PACKAGE_OUTPUT_DIR}/outputs/aar/onnxruntime-debug.aar ${ANDROID_TEST_PACKAGE_LIB_DIR}/onnxruntime-debug.aar)
     # Build Android test apk for java package
     add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${GRADLE_EXECUTABLE} clean WORKING_DIRECTORY ${ANDROID_TEST_PACKAGE_DIR})
-    add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${GRADLE_EXECUTABLE} assembleDebug assembleDebugAndroidTest WORKING_DIRECTORY ${ANDROID_TEST_PACKAGE_DIR})
+    add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${GRADLE_EXECUTABLE} assembleDebug assembleDebugAndroidTest -DminSdkVer=${ANDROID_MIN_SDK} WORKING_DIRECTORY ${ANDROID_TEST_PACKAGE_DIR})
   endif()
 endif()

--- a/java/src/test/android/app/build.gradle
+++ b/java/src/test/android/app/build.gradle
@@ -3,13 +3,15 @@ plugins {
 	id 'kotlin-android'
 }
 
+def minSdkVer = System.properties.get("minSdkVer")?:24
+
 android {
 	compileSdkVersion 30
 	buildToolsVersion "30.0.3"
 
 	defaultConfig {
 		applicationId "ai.onnxruntime.example.javavalidator"
-		minSdkVersion 24
+		minSdkVersion minSdkVer
 		targetSdkVersion 30
 		versionCode 1
 		versionName "1.0"

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -828,7 +828,8 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
             "-DCMAKE_TOOLCHAIN_FILE=" + os.path.join(
                 args.android_ndk_path, 'build', 'cmake', 'android.toolchain.cmake'),
             "-DANDROID_PLATFORM=android-" + str(args.android_api),
-            "-DANDROID_ABI=" + str(args.android_abi)
+            "-DANDROID_ABI=" + str(args.android_abi),
+            "-DANDROID_MIN_SDK=" + str(args.android_api),
         ]
 
         if args.android_cpp_shared:


### PR DESCRIPTION
**Description**: Add minSdkVer for AAR and AndroidTest

**Motivation and Context**
- minSdkVer was hardcoded in build-android.gradle, #7229 moved the minSdkVer to a parameter, after that if you are building AAR for android using build script, this information is missing from the AAR/androidManifest.xml, this will make our AAR package valid for all Android versions. Fixed it to use the NDK build min API requirement (--android_api of build.py) as the minSdkVer
- Also move the AndroidTest minSdkVer to be the same as the building minSdkVer 
