### PR TITLE
Add the missing source file to the target onnxruntime_test_debug_node…

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1022,8 +1022,8 @@ if(onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS)
     SOURCES
       "${TEST_SRC_DIR}/debug_node_inputs_outputs/debug_node_inputs_outputs_utils_test.cc"
       "${TEST_SRC_DIR}/framework/TestAllocatorManager.cc"
-      "${TEST_SRC_DIR}/providers/provider_test_utils.cc"
       "${TEST_SRC_DIR}/framework/test_utils.cc"
+      "${TEST_SRC_DIR}/providers/provider_test_utils.cc"
       ${onnxruntime_unittest_main_src}
     LIBS ${onnxruntime_test_providers_libs} ${onnxruntime_test_common_libs}
     DEPENDS ${all_dependencies}

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1023,6 +1023,7 @@ if(onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS)
       "${TEST_SRC_DIR}/debug_node_inputs_outputs/debug_node_inputs_outputs_utils_test.cc"
       "${TEST_SRC_DIR}/framework/TestAllocatorManager.cc"
       "${TEST_SRC_DIR}/providers/provider_test_utils.cc"
+      "${TEST_SRC_DIR}/framework/test_utils.cc"
       ${onnxruntime_unittest_main_src}
     LIBS ${onnxruntime_test_providers_libs} ${onnxruntime_test_common_libs}
     DEPENDS ${all_dependencies}


### PR DESCRIPTION
…_inputs_outputs

**Description**: Describe your changes.
For the build command
`./build.sh --config Debug --use_cuda --enable_training --build_wheel --skip_tests --parallel --cmake_extra_defines onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS=2`
got the following error:
```
Makefile:162: recipe for target 'all' failed
make: *** [all] Error 2
Traceback (most recent call last):
  File "/bert_ort/sajandhy/onnxruntime/tools/ci_build/build.py", line 2139, in <module>
    sys.exit(main())
  File "/bert_ort/sajandhy/onnxruntime/tools/ci_build/build.py", line 2065, in main
    build_targets(args, cmake_path, build_dir, configs, num_parallel_jobs, args.target)
  File "/bert_ort/sajandhy/onnxruntime/tools/ci_build/build.py", line 1070, in build_targets
    run_subprocess(cmd_args, env=env)
  File "/bert_ort/sajandhy/onnxruntime/tools/ci_build/build.py", line 584, in run_subprocess
    return run(*args, cwd=cwd, capture_stdout=capture_stdout, shell=shell, env=my_env)
  File "/bert_ort/sajandhy/onnxruntime/tools/python/util/run.py", line 44, in run
    env=env, shell=shell)
  File "/data/anaconda/envs/sajandhy_37/lib/python3.7/subprocess.py", line 487, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/usr/bin/cmake', '--build', '/bert_ort/sajandhy/onnxruntime/build/Linux/RelWithDebInfo', '--config', 'RelWithDebInfo', '--', '-j128']' returned non-zero exit status 2.
```
The actual link error is as follows
```
<unsigned char>(onnxruntime::Tensor const&, onnxruntime::Tensor&, onnxruntime::Tensor const&, onnxruntime::Tensor&)':
/bert_ort/sajandhy/onnxruntime/onnxruntime/test/providers/provider_test_utils.cc:43: undefined reference to `onnxruntime::test::TestCPUExecutionProvider()'
CMakeFiles/onnxruntime_test_debug_node_inputs_outputs.dir/bert_ort/sajandhy/onnxruntime/onnxruntime/test/providers/provider_test_utils.cc.o: In function `void onnxruntime::test::sort_expected_and_actual_buffers<double>(onnxruntime::Tensor const&, onnxruntime::Tensor&, onnxruntime::Tensor const&, onnxruntime::Tensor&)':
/bert_ort/sajandhy/onnxruntime/onnxruntime/test/providers/provider_test_utils.cc:43: undefined reference to `onnxruntime::test::TestCPUExecutionProvider()'
CMakeFiles/onnxruntime_test_debug_node_inputs_outputs.dir/bert_ort/sajandhy/onnxruntime/onnxruntime/test/providers/provider_test_utils.cc.o: In function `void onnxruntime::test::sort_expected_and_actual_buffers<float>(onnxruntime::Tensor const&, onnxruntime::Tensor&, onnxruntime::Tensor const&, onnxruntime::Tensor&)':
/bert_ort/sajandhy/onnxruntime/onnxruntime/test/providers/provider_test_utils.cc:43: undefined reference to `onnxruntime::test::TestCPUExecutionProvider()'
CMakeFiles/onnxruntime_test_debug_node_inputs_outputs.dir/bert_ort/sajandhy/onnxruntime/onnxruntime/test/providers/provider_test_utils.cc.o: In function `void onnxruntime::test::sort_expected_and_actual_buffers<bool>(onnxruntime::Tensor const&, onnxruntime::Tensor&, onnxruntime::Tensor const&, onnxruntime::Tensor&)':
/bert_ort/sajandhy/onnxruntime/onnxruntime/test/providers/provider_test_utils.cc:43: undefined reference to `onnxruntime::test::TestCPUExecutionProvider()'
CMakeFiles/onnxruntime_test_debug_node_inputs_outputs.dir/bert_ort/sajandhy/onnxruntime/onnxruntime/test/providers/provider_test_utils.cc.o: In function `void onnxruntime::test::sort_expected_and_actual_buffers<unsigned short>(onnxruntime::Tensor const&, onnxruntime::Tensor&, onnxruntime::Tensor const&, onnxruntime::Tensor&)':
/bert_ort/sajandhy/onnxruntime/onnxruntime/test/providers/provider_test_utils.cc:43: undefined reference to `onnxruntime::test::TestCPUExecutionProvider()'
CMakeFiles/onnxruntime_test_debug_node_inputs_outputs.dir/bert_ort/sajandhy/onnxruntime/onnxruntime/test/providers/provider_test_utils.cc.o:/bert_ort/sajandhy/onnxruntime/onnxruntime/test/providers/provider_test_utils.cc:43: more undefined references to `onnxruntime::test::TestCPUExecutionProvider()' follow
collect2: error: ld returned 1 exit status
CMakeFiles/onnxruntime_test_debug_node_inputs_outputs.dir/build.make:207: recipe for target 'onnxruntime_test_debug_node_inputs_outputs' failed
make[2]: *** [onnxruntime_test_debug_node_inputs_outputs] Error 1
CMakeFiles/Makefile2:376: recipe for target 'CMakeFiles/onnxruntime_test_debug_node_inputs_outputs.dir/all' failed
make[1]: *** [CMakeFiles/onnxruntime_test_debug_node_inputs_outputs.dir/all] Error 2
Makefile:162: recipe for target 'all' failed
make: *** [all] Error 2
```
This error is probably caused by (understandably as this cmake_extra_flags is not used in the build pipeline)
https://github.com/microsoft/onnxruntime/commit/8b6602ae687925a8125029cdd123a4ec8c235ca7

Added the missing source file, onxruntime/test/framework/test_utils.cc, to build the target onnxruntime_test_debug_node_inputs_outputs
**Motivation and Context**
- Why is this change required? What problem does it solve?
The target onnxruntime_test_debug_node_inputs_outputs fails to build with the following build command
` ./build.sh --config Debug --use_cuda --enable_training --build_wheel --skip_tests --parallel --cmake_extra_defines onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS=2`
- If it fixes an open issue, please link to the issue here.
