### PR TITLE
Add MLFloat16 support for SoftmaxCrossEntropyLoss for CUDA EP

### DIFF
--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
@@ -343,6 +343,7 @@ Status reduce_mean(
 
 #define INSTANTIATE_REDUCE_SUM(TIn, TOut) \
   template Status reduce_sum<TIn, TOut>(cudaStream_t stream, const TIn* input, TOut* output, int size, void* buffer, size_t buffer_size)
+INSTANTIATE_REDUCE_SUM(half, half);
 INSTANTIATE_REDUCE_SUM(half, float);
 INSTANTIATE_REDUCE_SUM(float, float);
 INSTANTIATE_REDUCE_SUM(double, double);

--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
@@ -343,7 +343,6 @@ Status reduce_mean(
 
 #define INSTANTIATE_REDUCE_SUM(TIn, TOut) \
   template Status reduce_sum<TIn, TOut>(cudaStream_t stream, const TIn* input, TOut* output, int size, void* buffer, size_t buffer_size)
-INSTANTIATE_REDUCE_SUM(half, half);
 INSTANTIATE_REDUCE_SUM(half, float);
 INSTANTIATE_REDUCE_SUM(float, float);
 INSTANTIATE_REDUCE_SUM(double, double);

--- a/onnxruntime/test/providers/compare_provider_test_utils.h
+++ b/onnxruntime/test/providers/compare_provider_test_utils.h
@@ -19,7 +19,8 @@ class CompareOpTester : public OpTester {
 
   void CompareWithCPU(const std::string& target_provider_type,
                       double per_sample_tolerance = 1e-4,
-                      double relative_per_sample_tolerance = 1e-4);
+                      double relative_per_sample_tolerance = 1e-4,
+                      const bool need_cpu_cast = false);
 };
 
 }  // namespace test

--- a/onnxruntime/test/util/compare_ortvalue.cc
+++ b/onnxruntime/test/util/compare_ortvalue.cc
@@ -129,6 +129,8 @@ std::pair<COMPARE_RESULT, std::string> CompareFloat16Result(const Tensor& outval
   const size_t size1 = static_cast<size_t>(expected_value.Shape().Size());
   const MLFloat16* expected_output = expected_value.template Data<MLFloat16>();
   const MLFloat16* real_output = outvalue.template Data<MLFloat16>();
+  std::ostringstream oss;
+  COMPARE_RESULT result = COMPARE_RESULT::SUCCESS;
   for (size_t di = 0; di != size1; ++di) {
     float expected = Eigen::half_impl::half_to_float(Eigen::half_impl::__half_raw(expected_output[di].val));
     float real = Eigen::half_impl::half_to_float(Eigen::half_impl::__half_raw(real_output[di].val));
@@ -136,13 +138,11 @@ std::pair<COMPARE_RESULT, std::string> CompareFloat16Result(const Tensor& outval
     const double diff = std::fabs(expected - real);
     const double rtol = per_sample_tolerance + relative_per_sample_tolerance * std::fabs(expected);
     if (!IsResultCloselyMatch<float>(real, expected, diff, rtol)) {
-      std::ostringstream oss;
-      oss << "expected " << expected << ", got " << real << ", diff: " << diff << ", tol=" << rtol;
-
-      return std::make_pair(COMPARE_RESULT::RESULT_DIFFERS, oss.str());
+      oss << "idx: " << di << "expected " << expected << ", got " << real << ", diff: " << diff << ", tol=" << rtol << "\n";
+      result = COMPARE_RESULT::RESULT_DIFFERS;
     }
   }
-  return std::make_pair(COMPARE_RESULT::SUCCESS, "");
+  return std::make_pair(result, oss.str());
 }
 
 std::pair<COMPARE_RESULT, std::string> CompareBFloat16Result(const Tensor& outvalue, const Tensor& expected_value,

--- a/orttraining/orttraining/test/training_ops/cuda/cross_entropy_test.cc
+++ b/orttraining/orttraining/test/training_ops/cuda/cross_entropy_test.cc
@@ -286,7 +286,8 @@ static void TestSoftmaxCrossEntropyLoss(const std::vector<int64_t>* X_dims,
                                         const std::vector<int64_t>* log_prob_dims,
                                         const std::string& reduction,
                                         const std::int64_t ignore_index = -1,
-                                        const bool test_fp16 = false) {
+                                        const bool test_fp16 = false,
+                                        const double error_tolerance = 1e-4) {
   CompareOpTester test("SoftmaxCrossEntropyLoss", 12, onnxruntime::kOnnxDomain);
   test.AddAttribute("reduction", reduction);
   test.AddAttribute("ignore_index", ignore_index);
@@ -322,19 +323,24 @@ static void TestSoftmaxCrossEntropyLoss(const std::vector<int64_t>* X_dims,
 
   if (test_fp16) {
     std::vector<MLFloat16> Y_data = FillZeros<MLFloat16>(*Y_dims);
-    std::vector<MLFloat16> log_prob_data = FillZeros<MLFloat16>(*log_prob_dims);
-
     test.AddOutput<MLFloat16>("output", *Y_dims, Y_data);
-    test.AddOutput<MLFloat16>("log_prob", *log_prob_dims, log_prob_data);
+
+    if (log_prob_dims) {
+      std::vector<MLFloat16> log_prob_data = FillZeros<MLFloat16>(*log_prob_dims);
+      test.AddOutput<MLFloat16>("log_prob", *log_prob_dims, log_prob_data);
+    }
+
+    test.CompareWithCPU(kGpuExecutionProvider, error_tolerance, error_tolerance, true);
   } else {
     std::vector<float> Y_data = FillZeros<float>(*Y_dims);
-    std::vector<float> log_prob_data = FillZeros<float>(*log_prob_dims);
-
     test.AddOutput<float>("output", *Y_dims, Y_data);
-    test.AddOutput<float>("log_prob", *log_prob_dims, log_prob_data);
-  }
 
-  test.CompareWithCPU(kGpuExecutionProvider);
+    if (log_prob_dims) {
+      std::vector<float> log_prob_data = FillZeros<float>(*log_prob_dims);
+      test.AddOutput<float>("log_prob", *log_prob_dims, log_prob_data);
+    }
+    test.CompareWithCPU(kGpuExecutionProvider);
+  }
 }
 
 TEST(CudaKernelTest, SoftmaxCrossEntropyLoss_TinySizeTensor) {
@@ -360,28 +366,31 @@ TEST(CudaKernelTest, SoftmaxCrossEntropyLoss_TinySizeTensor) {
   TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims_none, &log_prob_dims, "none", 0);
 }
 
-TEST(CudaKernelTest, SoftmaxCrossEntropyLoss_TinySizeTensor_half) {
+#if USE_CUDA
+// currently only supported for CUDA
+TEST(CudaKernelTest, SoftmaxCrossEntropyLoss_TinySizeTensor_half) { 
   std::vector<int64_t> X_dims{8, 2};
   std::vector<int64_t> index_dims{8};
   std::vector<int64_t> weight_dims{2};
   std::vector<int64_t> Y_dims{};
   std::vector<int64_t> Y_dims_none{8};
   std::vector<int64_t> log_prob_dims{8, 2};
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "mean", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "mean", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "sum", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "sum", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims_none, &log_prob_dims, "none", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims_none, &log_prob_dims, "none", -1, true);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "mean", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "mean", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "sum", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "sum", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims_none, &log_prob_dims, "none", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims_none, &log_prob_dims, "none", -1, true, 5e-2);
 
   // Just test ignore_index for small tensor because it will increase test time a lot with little verification gain.
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "mean", 0, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "mean", 0, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "sum", 0, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "sum", 0, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims_none, &log_prob_dims, "none", 0, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims_none, &log_prob_dims, "none", 0, true);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "mean", 0, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "mean", 0, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "sum", 0, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "sum", 0, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims_none, &log_prob_dims, "none", 0, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims_none, &log_prob_dims, "none", 0, true, 5e-2);
 }
+#endif
 
 TEST(CudaKernelTest, SoftmaxCrossEntropyLoss_SmallSizeTensor) {
   std::vector<int64_t> X_dims{8, 20, 10};
@@ -398,6 +407,8 @@ TEST(CudaKernelTest, SoftmaxCrossEntropyLoss_SmallSizeTensor) {
   TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims_none, &log_prob_dims, "none");
 }
 
+#if USE_CUDA
+// currently only supported for CUDA
 TEST(CudaKernelTest, SoftmaxCrossEntropyLoss_SmallSizeTensor_half) {
   std::vector<int64_t> X_dims{8, 20, 10};
   std::vector<int64_t> index_dims{8, 10};
@@ -405,13 +416,14 @@ TEST(CudaKernelTest, SoftmaxCrossEntropyLoss_SmallSizeTensor_half) {
   std::vector<int64_t> Y_dims{};
   std::vector<int64_t> Y_dims_none{8, 10};
   std::vector<int64_t> log_prob_dims{8, 20, 10};
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "mean", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "mean", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "sum", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "sum", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims_none, &log_prob_dims, "none", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims_none, &log_prob_dims, "none", -1, true);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "mean", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "mean", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "sum", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "sum", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims_none, &log_prob_dims, "none", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims_none, &log_prob_dims, "none", -1, true, 5e-2);
 }
+#endif
 
 TEST(CudaKernelTest, SoftmaxCrossEntropyLoss_MediumSizeTensor) {
   std::vector<int64_t> X_dims{8, 1024};
@@ -428,6 +440,8 @@ TEST(CudaKernelTest, SoftmaxCrossEntropyLoss_MediumSizeTensor) {
   TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims_none, &log_prob_dims, "none");
 }
 
+#if USE_CUDA
+// currently only supported for CUDA
 TEST(CudaKernelTest, SoftmaxCrossEntropyLoss_MediumSizeTensor_half) {
   std::vector<int64_t> X_dims{8, 1024};
   std::vector<int64_t> index_dims{8};
@@ -435,13 +449,14 @@ TEST(CudaKernelTest, SoftmaxCrossEntropyLoss_MediumSizeTensor_half) {
   std::vector<int64_t> Y_dims{};
   std::vector<int64_t> Y_dims_none{8};
   std::vector<int64_t> log_prob_dims{8, 1024};
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "mean", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "mean", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "sum", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "sum", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims_none, &log_prob_dims, "none", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims_none, &log_prob_dims, "none", -1, true);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "mean", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "mean", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "sum", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "sum", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims_none, &log_prob_dims, "none", -1, true, 5e-2);
+  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims_none, &log_prob_dims, "none", -1, true, 5e-2);
 }
+#endif
 
 // TODO fix flaky test
 // failing random seed: 2873512643
@@ -458,21 +473,6 @@ TEST(CudaKernelTest, DISABLED_SoftmaxCrossEntropyLoss_LargeSizeTensor) {
   TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "sum");
   TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims_none, &log_prob_dims, "none");
   TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims_none, &log_prob_dims, "none");
-}
-
-TEST(CudaKernelTest, SoftmaxCrossEntropyLoss_LargeSizeTensor_half) {
-  std::vector<int64_t> X_dims{4, 512, 30528};
-  std::vector<int64_t> index_dims{4, 30528};
-  std::vector<int64_t> weight_dims{512};
-  std::vector<int64_t> Y_dims{};
-  std::vector<int64_t> Y_dims_none{4, 30528};
-  std::vector<int64_t> log_prob_dims{4, 512, 30528};
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "mean", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "mean", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims, &log_prob_dims, "sum", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims, &log_prob_dims, "sum", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, &weight_dims, &Y_dims_none, &log_prob_dims, "none", -1, true);
-  TestSoftmaxCrossEntropyLoss(&X_dims, &index_dims, nullptr, &Y_dims_none, &log_prob_dims, "none", -1, true);
 }
 
 static void TestSoftmaxCrossEntropyLossGrad(const std::vector<int64_t>& dY_dims,

--- a/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
+++ b/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
@@ -55,6 +55,7 @@ class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDom
 class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 9, float, int64_t, SparseSoftmaxCrossEntropyGrad);
 class ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, 12, MLFloat16, int64_t, SoftmaxCrossEntropyLoss);
 class ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, 12, float, int64_t, SoftmaxCrossEntropyLoss);
+class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, MLFloat16, int64_t, SoftmaxCrossEntropyLoss);
 class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, float, int64_t, SoftmaxCrossEntropyLoss);
 class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, int64_t, SoftmaxCrossEntropyLossGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, SoftmaxGrad);
@@ -257,6 +258,7 @@ Status RegisterCudaTrainingKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, LogSoftmaxGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, 12, MLFloat16, int64_t, SoftmaxCrossEntropyLoss)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, 12, float, int64_t, SoftmaxCrossEntropyLoss)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, MLFloat16, int64_t, SoftmaxCrossEntropyLoss)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, float, int64_t, SoftmaxCrossEntropyLoss)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, int64_t, SoftmaxCrossEntropyLossGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, BatchNormalizationGrad)>,

--- a/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
+++ b/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
@@ -58,6 +58,7 @@ class ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider
 class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, MLFloat16, int64_t, SoftmaxCrossEntropyLoss);
 class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, float, int64_t, SoftmaxCrossEntropyLoss);
 class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, int64_t, SoftmaxCrossEntropyLossGrad);
+class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, int64_t, SoftmaxCrossEntropyLossGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, SoftmaxGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, SoftmaxGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, SoftmaxGrad);
@@ -261,6 +262,7 @@ Status RegisterCudaTrainingKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, MLFloat16, int64_t, SoftmaxCrossEntropyLoss)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, float, int64_t, SoftmaxCrossEntropyLoss)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, int64_t, SoftmaxCrossEntropyLossGrad)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, int64_t, SoftmaxCrossEntropyLossGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, BatchNormalizationGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, BatchNormalizationGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, ConvGrad)>,

--- a/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
+++ b/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
@@ -53,6 +53,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1
 class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 9, float, int64_t, SparseSoftmaxCrossEntropy);
 // class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 9, float, int32_t, SparseSoftmaxCrossEntropyGrad);
 class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 9, float, int64_t, SparseSoftmaxCrossEntropyGrad);
+class ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, 12, MLFloat16, int64_t, SoftmaxCrossEntropyLoss);
 class ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, 12, float, int64_t, SoftmaxCrossEntropyLoss);
 class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, float, int64_t, SoftmaxCrossEntropyLoss);
 class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, int64_t, SoftmaxCrossEntropyLossGrad);
@@ -254,6 +255,7 @@ Status RegisterCudaTrainingKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, LogSoftmaxGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, double, LogSoftmaxGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, LogSoftmaxGrad)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, 12, MLFloat16, int64_t, SoftmaxCrossEntropyLoss)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 12, 12, float, int64_t, SoftmaxCrossEntropyLoss)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, float, int64_t, SoftmaxCrossEntropyLoss)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, int64_t, SoftmaxCrossEntropyLossGrad)>,

--- a/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cc
+++ b/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cc
@@ -292,6 +292,7 @@ Status SoftmaxCrossEntropyLossGrad<T, Tin>::ComputeInternal(OpKernelContext* ctx
 SPECIALIZED_VERSIONED_COMPUTE_SPARSE(SoftmaxCrossEntropyLoss, float, int64_t, kOnnxDomain, 12, 12)
 SPECIALIZED_VERSIONED_COMPUTE_SPARSE(SoftmaxCrossEntropyLoss, MLFloat16, int64_t, kOnnxDomain, 12, 12)
 SPECIALIZED_COMPUTE_SPARSE(SoftmaxCrossEntropyLoss, float, int64_t, kOnnxDomain, 13)
+SPECIALIZED_COMPUTE_SPARSE(SoftmaxCrossEntropyLoss, MLFloat16, int64_t, kOnnxDomain, 13)
 SPECIALIZED_COMPUTE_SPARSE(SoftmaxCrossEntropyLossGrad, float, int64_t, kMSDomain, 1)
 
 }  // namespace cuda

--- a/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cc
+++ b/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cc
@@ -165,26 +165,13 @@ Status SoftmaxCrossEntropyLoss<T, Tin>::ComputeInternal(OpKernelContext* ctx) co
 
   if (reduction_ != ReductionType::NONE) {
     // ReduceSum on loss_per_sample
-    if (!std::is_same<T, TBuf>::value) {
-      ORT_RETURN_IF_ERROR(reduce_sum(
-          Stream(),
-          reinterpret_cast<CudaT*>(tmp_loss_sample_buffer),
-          normalize_factor_data.get(),
-          static_cast<int>(N_D),
-          reduction_buffer.get(),
-          buffer_size));
-      // Convert from accumulation type to output type
-      // Need a better way to do this cast as this is a single element cast
-      Impl_Cast<TBuf, CudaT>(Stream(), normalize_factor_data.get(), reinterpret_cast<CudaT*>(total_loss_data), 1);
-    } else {
-      ORT_RETURN_IF_ERROR(reduce_sum(
-          Stream(),
-          reinterpret_cast<CudaT*>(tmp_loss_sample_buffer),
-          total_loss_data,
-          static_cast<int>(N_D),
-          reduction_buffer.get(),
-          buffer_size));
-    }
+    ORT_RETURN_IF_ERROR(reduce_sum(
+        Stream(),
+        reinterpret_cast<CudaT*>(tmp_loss_sample_buffer),
+        reinterpret_cast<CudaT*>(total_loss_data),
+        static_cast<int>(N_D),
+        reduction_buffer.get(),
+        buffer_size));
   }
 
   return Status::OK();
@@ -192,6 +179,7 @@ Status SoftmaxCrossEntropyLoss<T, Tin>::ComputeInternal(OpKernelContext* ctx) co
 
 template <typename T, typename Tin>
 Status SoftmaxCrossEntropyLossGrad<T, Tin>::ComputeInternal(OpKernelContext* ctx) const {
+  typedef typename ToCudaType<T>::MappedType CudaT;
   const Tensor& dY = *ctx->Input<Tensor>(0);
   const Tensor& log_prob = *ctx->Input<Tensor>(1);
   const Tensor& label = *ctx->Input<Tensor>(2);
@@ -233,37 +221,43 @@ Status SoftmaxCrossEntropyLossGrad<T, Tin>::ComputeInternal(OpKernelContext* ctx
   IAllocatorUniquePtr<T> weight_data_nd = GetScratchBuffer<T>(N_D);
   T* weight_data_nd_data = weight_data_nd.get();
   CUDA_RETURN_IF_ERROR(cudaMemsetAsync(weight_data_nd_data, 0, N_D * sizeof(T), Stream()));
-  ComputeWeightsSoftmaxCrossEntropyImpl(Stream(), label_data, weight_data, N_D, C, ignore_index_, weight_data_nd_data);
-  auto normalize_factor_data = GetScratchBuffer<T>(1);
+  ComputeWeightsSoftmaxCrossEntropyImpl(Stream(),
+                                        label_data,
+                                        reinterpret_cast<const CudaT*>(weight_data),
+                                        N_D, C,
+                                        ignore_index_,
+                                        reinterpret_cast<CudaT*>(weight_data_nd_data));
+  typedef AccumulationType_t<CudaT> TBuf;
+  auto normalize_factor_data = GetScratchBuffer<TBuf>(1);
   if (reduction_ == ReductionType::MEAN) {
     // Compute buffer size in byte for reduction APIs.
     const auto buffer_size =
-        compute_reduction_buffer_size<T>(static_cast<int>(N_D));
+        compute_reduction_buffer_size<CudaT>(static_cast<int>(N_D));
     // Allocate reduction buffer whose size is buffer_size bytes.
     IAllocatorUniquePtr<void> reduction_buffer = GetScratchBuffer<void>(
         buffer_size);
     ORT_RETURN_IF_ERROR(reduce_sum(
         Stream(),
-        weight_data_nd_data,
+        reinterpret_cast<const CudaT*>(weight_data_nd_data),
         normalize_factor_data.get(),
         static_cast<int>(N_D),
         reduction_buffer.get(),
         buffer_size));
   } else {
-    const T normalize_factor = static_cast<T>(1.0f);
-    CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(normalize_factor_data.get(), &normalize_factor, sizeof(T), cudaMemcpyHostToDevice, Stream()));
+    const TBuf normalize_factor = static_cast<TBuf>(1.0f);
+    CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(normalize_factor_data.get(), &normalize_factor, sizeof(TBuf), cudaMemcpyHostToDevice, Stream()));
   }
 
   SoftmaxCrossEntropyLossGradImpl(Stream(),
-                                  dY_data,
-                                  log_prob_data,
+                                  reinterpret_cast<const CudaT*>(dY_data),
+                                  reinterpret_cast<const CudaT*>(log_prob_data),
                                   label_data,
-                                  weight_data_nd_data,
+                                  reinterpret_cast<const CudaT*>(weight_data_nd_data),
                                   normalize_factor_data.get(),
                                   N_D,
                                   C,
                                   ReductionType::NONE == reduction_,
-                                  d_logit_data);
+                                  reinterpret_cast<CudaT*>(d_logit_data));
 
   // Transpose logit from [N, D1, D2...Dk, C] to [N, C, D1, D2 .. Dk]
   if (probability_shape.NumDimensions() > 2) {
@@ -282,18 +276,19 @@ Status SoftmaxCrossEntropyLossGrad<T, Tin>::ComputeInternal(OpKernelContext* ctx
   return Status::OK();
 }
 
-#define SPECIALIZED_VERSIONED_COMPUTE_SPARSE(Class, T, Tin, domain, startver, endvar) \
+#define INSTANTIATE_VERSIONED_COMPUTE_SPARSE(Class, T, Tin, domain, startver, endvar) \
   REGISTER_KERNEL_VERSIONED_TYPED_TWO_TYPES(Class, T, Tin, domain, startver, endvar)
 
-#define SPECIALIZED_COMPUTE_SPARSE(Class, T, Tin, domain, version) \
+#define INSTANTIATE_COMPUTE_SPARSE(Class, T, Tin, domain, version) \
   REGISTER_KERNEL_TYPED_TWO_TYPES(Class, T, Tin, domain, version)  \
   template Status Class<T, Tin>::ComputeInternal(OpKernelContext* ctx) const;
 
-SPECIALIZED_VERSIONED_COMPUTE_SPARSE(SoftmaxCrossEntropyLoss, float, int64_t, kOnnxDomain, 12, 12)
-SPECIALIZED_VERSIONED_COMPUTE_SPARSE(SoftmaxCrossEntropyLoss, MLFloat16, int64_t, kOnnxDomain, 12, 12)
-SPECIALIZED_COMPUTE_SPARSE(SoftmaxCrossEntropyLoss, float, int64_t, kOnnxDomain, 13)
-SPECIALIZED_COMPUTE_SPARSE(SoftmaxCrossEntropyLoss, MLFloat16, int64_t, kOnnxDomain, 13)
-SPECIALIZED_COMPUTE_SPARSE(SoftmaxCrossEntropyLossGrad, float, int64_t, kMSDomain, 1)
+INSTANTIATE_VERSIONED_COMPUTE_SPARSE(SoftmaxCrossEntropyLoss, float, int64_t, kOnnxDomain, 12, 12)
+INSTANTIATE_VERSIONED_COMPUTE_SPARSE(SoftmaxCrossEntropyLoss, MLFloat16, int64_t, kOnnxDomain, 12, 12)
+INSTANTIATE_COMPUTE_SPARSE(SoftmaxCrossEntropyLoss, float, int64_t, kOnnxDomain, 13)
+INSTANTIATE_COMPUTE_SPARSE(SoftmaxCrossEntropyLoss, MLFloat16, int64_t, kOnnxDomain, 13)
+INSTANTIATE_COMPUTE_SPARSE(SoftmaxCrossEntropyLossGrad, float, int64_t, kMSDomain, 1)
+INSTANTIATE_COMPUTE_SPARSE(SoftmaxCrossEntropyLossGrad, MLFloat16, int64_t, kMSDomain, 1)
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cu
+++ b/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cu
@@ -17,10 +17,10 @@ __global__ void _ComputeWeightsSoftmaxCrossEntropy(
     CUDA_LONG C,
     CUDA_LONG ignore_index) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(i, N_D);
-  T w = static_cast<T>(1.0f);
+  const T ONE_T = 1;
   if (label_data[i] != ignore_index) {
     CUDA_KERNEL_ASSERT(label_data[i] >= 0 && label_data[i] < C);
-    weight_data_nd[i] = weight_data != nullptr ? weight_data[label_data[i]] : w;
+    weight_data_nd[i] = weight_data != nullptr ? weight_data[label_data[i]] : ONE_T;
   }
 }
 
@@ -61,7 +61,8 @@ __global__ void _WeightedSoftmaxCrossEntropyLoss(
     output_data[i] = 0;
   } else {
     CUDA_KERNEL_ASSERT(label_data[i] >= 0 && label_data[i] < C);
-    output_data[i] = static_cast<T>(static_cast<TAcc>(-log_prob_data[i * C + label_data[i]] * weight_data[i]) / *normalize_factor_data);
+    output_data[i] = static_cast<T>(static_cast<TAcc>(-log_prob_data[i * C + label_data[i]] * weight_data[i]) /
+                                    *normalize_factor_data);
   }
 }
 
@@ -91,29 +92,29 @@ void SoftmaxCrossEntropyLossImpl(
       II);
 }
 
-#define SPECIALIZED_IMPL_SoftMaxEntropyLossImpl(T, TAcc, Tin) \
-  template void SoftmaxCrossEntropyLossImpl(            \
-      cudaStream_t stream,                              \
-      const T* log_prob,                                \
-      const Tin* label,                                 \
-      const T* weight,                                  \
-      const TAcc* normalize_factor,                        \
-      size_t count,                                     \
-      size_t label_depth,                               \
-      int64_t ignore_index,                             \
+#define INSTANTIATE_IMPL_SoftMaxEntropyLossImpl(T, TAcc, Tin) \
+  template void SoftmaxCrossEntropyLossImpl(                  \
+      cudaStream_t stream,                                    \
+      const T* log_prob,                                      \
+      const Tin* label,                                       \
+      const T* weight,                                        \
+      const TAcc* normalize_factor,                           \
+      size_t count,                                           \
+      size_t label_depth,                                     \
+      int64_t ignore_index,                                   \
       T* output_data);
 
-SPECIALIZED_IMPL_SoftMaxEntropyLossImpl(float, float, int32_t)
-SPECIALIZED_IMPL_SoftMaxEntropyLossImpl(float, float, int64_t)
-SPECIALIZED_IMPL_SoftMaxEntropyLossImpl(half, float, int64_t)
+INSTANTIATE_IMPL_SoftMaxEntropyLossImpl(float, float, int32_t)
+INSTANTIATE_IMPL_SoftMaxEntropyLossImpl(float, float, int64_t)
+INSTANTIATE_IMPL_SoftMaxEntropyLossImpl(half, float, int64_t)
 
-template <typename T, typename Tin>
+template <typename T, typename TAcc, typename Tin>
 __global__ void _WeightedSoftmaxCrossEntropyLossGrad(
     const T* dY,
     const T* log_prob,
     const Tin* label,
     const T* weight,
-    const T* normalize_factor,
+    const TAcc* normalize_factor,
     T* output_data,
     CUDA_LONG N_D,
     CUDA_LONG C) {
@@ -121,24 +122,29 @@ __global__ void _WeightedSoftmaxCrossEntropyLossGrad(
 
   int row = i / C;
   int d = i % C;
-  CUDA_KERNEL_ASSERT(weight[row] == 0 || (label[row] >= 0 && label[row] < C));
-  if(0 == *normalize_factor){
-    // normalize_factor is sum of labels' weights. Because zero 
-    // sum implies all weights are 0, the loss function should 
+  const T ZERO_T = 0;
+  const TAcc ZERO_TAcc = 0;
+  const TAcc ONE_TAcc = 1;
+  CUDA_KERNEL_ASSERT(weight[row] == ZERO_T || (label[row] >= 0 && label[row] < C));
+  if (ZERO_TAcc == *normalize_factor) {
+    // normalize_factor is sum of labels' weights. Because zero
+    // sum implies all weights are 0, the loss function should
     // be constant 0 and its corresponding gradient should be 0 as well.
-    output_data[i] = 0;
+    output_data[i] = ZERO_T;
   } else {
-    output_data[i] = (*dY) * weight[row] * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
+    output_data[i] = static_cast<T>(static_cast<TAcc>((*dY) * weight[row]) *
+                                    (_Exp(static_cast<TAcc>(log_prob[i])) - ONE_TAcc * (TAcc)(d == label[row])) /
+                                    (*normalize_factor));
   }
 }
 
-template <typename T, typename Tin>
+template <typename T, typename TAcc, typename Tin>
 __global__ void _WeightedReductionNoneSoftmaxCrossEntropyLossGrad(
     const T* dY,
     const T* log_prob,
     const Tin* label,
     const T* weight,
-    const T* normalize_factor,
+    const TAcc* normalize_factor,
     T* output_data,
     CUDA_LONG N_D,
     CUDA_LONG C) {
@@ -146,25 +152,30 @@ __global__ void _WeightedReductionNoneSoftmaxCrossEntropyLossGrad(
 
   int row = i / C;
   int d = i % C;
-  CUDA_KERNEL_ASSERT(weight[row] == 0 || (label[row] >= 0 && label[row] < C));
-  if(0 == *normalize_factor){
-    // normalize_factor is sum of labels' weights. Because zero 
-    // sum implies all weights are 0, the loss function should 
+  const T ZERO_T = 0;
+  const TAcc ZERO_TAcc = 0;
+  const TAcc ONE_TAcc = 1;
+  CUDA_KERNEL_ASSERT(weight[row] == ZERO_T || (label[row] >= 0 && label[row] < C));
+  if (ZERO_TAcc == *normalize_factor) {
+    // normalize_factor is sum of labels' weights. Because zero
+    // sum implies all weights are 0, the loss function should
     // be constant 0 and its corresponding gradient should be 0 as well.
-    output_data[i] = 0;
+    output_data[i] = ZERO_T;
   } else {
-    output_data[i] = dY[row] * weight[row] * (_Exp(log_prob[i]) - 1.0 * (d == label[row])) / (*normalize_factor);
+    output_data[i] = static_cast<T>(static_cast<TAcc>(dY[row] * weight[row]) *
+                                    (_Exp(static_cast<TAcc>(log_prob[i])) - ONE_TAcc * (TAcc)(d == label[row])) /
+                                    (*normalize_factor));
   }
 }
 
-template <typename T, typename Tin>
+template <typename T, typename TAcc, typename Tin>
 void SoftmaxCrossEntropyLossGradImpl(
     cudaStream_t stream,
     const T* dY,
     const T* log_prob,
     const Tin* label,
     const T* weight,
-    const T* normalize_factor,
+    const TAcc* normalize_factor,
     size_t count,
     size_t label_depth,
     bool reduction_none,
@@ -173,7 +184,7 @@ void SoftmaxCrossEntropyLossGradImpl(
   CUDA_LONG C = static_cast<CUDA_LONG>(label_depth);
   int blocksPerGrid = (int)(ceil(static_cast<float>(N_D * C) / GridDim::maxThreadsPerBlock));
   if (reduction_none) {
-    _WeightedReductionNoneSoftmaxCrossEntropyLossGrad<T, Tin><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+    _WeightedReductionNoneSoftmaxCrossEntropyLossGrad<T, TAcc, Tin><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
         dY,
         log_prob,
         label,
@@ -183,7 +194,7 @@ void SoftmaxCrossEntropyLossGradImpl(
         N_D,
         C);
   } else {
-    _WeightedSoftmaxCrossEntropyLossGrad<T, Tin><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+    _WeightedSoftmaxCrossEntropyLossGrad<T, TAcc, Tin><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
         dY,
         log_prob,
         label,
@@ -195,23 +206,24 @@ void SoftmaxCrossEntropyLossGradImpl(
   }
 }
 
-#define SPECIALIZED_IMPL_SoftMaxEntropyLossGradImpl(T, Tin) \
-  template void SoftmaxCrossEntropyLossGradImpl(            \
-      cudaStream_t stream,                                  \
-      const T* dY,                                          \
-      const T* log_prob,                                    \
-      const Tin* label,                                     \
-      const T* weight,                                      \
-      const T* normalize_factor,                            \
-      size_t count,                                         \
-      size_t label_depth,                                   \
-      bool reducation_none,                                 \
+#define INSTANTIATE_IMPL_SoftMaxEntropyLossGradImpl(T, TAcc, Tin) \
+  template void SoftmaxCrossEntropyLossGradImpl(                  \
+      cudaStream_t stream,                                        \
+      const T* dY,                                                \
+      const T* log_prob,                                          \
+      const Tin* label,                                           \
+      const T* weight,                                            \
+      const TAcc* normalize_factor,                               \
+      size_t count,                                               \
+      size_t label_depth,                                         \
+      bool reducation_none,                                       \
       T* output_data);
 
-SPECIALIZED_IMPL_SoftMaxEntropyLossGradImpl(float, int32_t)
-SPECIALIZED_IMPL_SoftMaxEntropyLossGradImpl(float, int64_t)
+INSTANTIATE_IMPL_SoftMaxEntropyLossGradImpl(float, float, int32_t)
+INSTANTIATE_IMPL_SoftMaxEntropyLossGradImpl(float, float, int64_t)
+INSTANTIATE_IMPL_SoftMaxEntropyLossGradImpl(half, float, int64_t)
 
-#define SPECIALIZED_IMPL_ComputeWeightsSoftmaxCrossEntropyImpl(T, Tin) \
+#define INSTANTIATE_IMPL_ComputeWeightsSoftmaxCrossEntropyImpl(T, Tin) \
   template void ComputeWeightsSoftmaxCrossEntropyImpl(                 \
       cudaStream_t stream,                                             \
       const Tin* label,                                                \
@@ -221,9 +233,9 @@ SPECIALIZED_IMPL_SoftMaxEntropyLossGradImpl(float, int64_t)
       int64_t ignore_index,                                            \
       T* weight_data_nd);
 
-SPECIALIZED_IMPL_ComputeWeightsSoftmaxCrossEntropyImpl(float, int32_t)
-SPECIALIZED_IMPL_ComputeWeightsSoftmaxCrossEntropyImpl(float, int64_t)
-SPECIALIZED_IMPL_ComputeWeightsSoftmaxCrossEntropyImpl(half, int64_t)
+INSTANTIATE_IMPL_ComputeWeightsSoftmaxCrossEntropyImpl(float, int32_t)
+INSTANTIATE_IMPL_ComputeWeightsSoftmaxCrossEntropyImpl(float, int64_t)
+INSTANTIATE_IMPL_ComputeWeightsSoftmaxCrossEntropyImpl(half, int64_t)
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cu
+++ b/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cu
@@ -61,7 +61,7 @@ __global__ void _WeightedSoftmaxCrossEntropyLoss(
     output_data[i] = 0;
   } else {
     CUDA_KERNEL_ASSERT(label_data[i] >= 0 && label_data[i] < C);
-    output_data[i] = -log_prob_data[i * C + label_data[i]] * weight_data[i] / static_cast<T>(*normalize_factor_data);
+    output_data[i] = static_cast<T>(static_cast<TAcc>(-log_prob_data[i * C + label_data[i]] * weight_data[i]) / *normalize_factor_data);
   }
 }
 

--- a/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.h
+++ b/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.h
@@ -22,14 +22,14 @@ void SoftmaxCrossEntropyLossImpl(
     int64_t ignore_index,
     T* output_data);
 
-template <typename T, typename Tin>
+template <typename T, typename TAcc, typename Tin>
 void SoftmaxCrossEntropyLossGradImpl(
     cudaStream_t stream,
     const T* dY,
     const T* log_prob,
     const Tin* label,
     const T* weight,
-    const T* normalize_factor,
+    const TAcc* normalize_factor,
     size_t count,
     size_t label_depth,
     bool reduction_none,

--- a/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.h
+++ b/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.h
@@ -10,13 +10,13 @@
 namespace onnxruntime {
 namespace cuda {
 
-template <typename T, typename Tin>
+template <typename T, typename TAcc, typename Tin>
 void SoftmaxCrossEntropyLossImpl(
     cudaStream_t stream,
     const T* log_prob,
     const Tin* label,
     const T* weight,
-    const T* normalize_factor,
+    const TAcc* normalize_factor,
     size_t count,
     size_t label_depth,
     int64_t ignore_index,

--- a/orttraining/orttraining/training_ops/rocm/rocm_training_kernels.cc
+++ b/orttraining/orttraining/training_ops/rocm/rocm_training_kernels.cc
@@ -52,8 +52,11 @@ class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDom
 // class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 9, float, int32_t, SparseSoftmaxCrossEntropyGrad);
 class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 9, float, int64_t, SparseSoftmaxCrossEntropyGrad);
 class ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 12, 12, float, int64_t, SoftmaxCrossEntropyLoss);
+class ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 12, 12, MLFloat16, int64_t, SoftmaxCrossEntropyLoss);
 class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 13, float, int64_t, SoftmaxCrossEntropyLoss);
+class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 13, MLFloat16, int64_t, SoftmaxCrossEntropyLoss);
 class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, int64_t, SoftmaxCrossEntropyLossGrad);
+class ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, int64_t, SoftmaxCrossEntropyLossGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, SoftmaxGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, double, SoftmaxGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, SoftmaxGrad);
@@ -193,8 +196,11 @@ Status RegisterRocmTrainingKernels(KernelRegistry& kernel_registry) {
     // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, double, LogSoftmaxGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, LogSoftmaxGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 12, 12, float, int64_t, SoftmaxCrossEntropyLoss)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 12, 12, MLFloat16, int64_t, SoftmaxCrossEntropyLoss)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 13, float, int64_t, SoftmaxCrossEntropyLoss)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 13, MLFloat16, int64_t, SoftmaxCrossEntropyLoss)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, int64_t, SoftmaxCrossEntropyLossGrad)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, int64_t, SoftmaxCrossEntropyLossGrad)>,
     // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, BatchNormalizationGrad)>,
     // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, double, BatchNormalizationGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, GatherGrad)>,


### PR DESCRIPTION
This PR adds support for float16 type for SoftmaxCrossEntropyLoss and SoftmaxCrossEntropyLossGrad which is required for some Huggingface models. 

This PR needs the ONNX commit to be advanced to include the function body fix for NLLLoss and SCELoss
https://github.com/onnx/onnx/pull/3486 
https://github.com/onnx/onnx/pull/3487