### PR TITLE
Fix the broken build on dev machines by replacing std::tuple with two…

### DIFF
--- a/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h
+++ b/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h
@@ -53,10 +53,10 @@ struct ATenOperatorConfig {
   std::vector<int> gradient_input_indices;
 
   ATenOperatorConfig(const std::string& _backward_op_name,
-                     const std::vector<std::tuple<ArgumentKind, std::string>>& _forward_argument_configs,
-                     const std::vector<std::tuple<ArgumentKind, std::string>>& _backward_argument_configs,
-                     const std::vector<std::tuple<BackwardInputSourceKind, int>>& _backward_input_source_configs,
-                     const std::vector<std::tuple<OutputTypeInferKind, int>>& _forward_output_type_infer_configs,
+                     const std::vector<std::pair<ArgumentKind, std::string>>& _forward_argument_configs,
+                     const std::vector<std::pair<ArgumentKind, std::string>>& _backward_argument_configs,
+                     const std::vector<std::pair<BackwardInputSourceKind, int>>& _backward_input_source_configs,
+                     const std::vector<std::pair<OutputTypeInferKind, int>>& _forward_output_type_infer_configs,
                      const std::vector<int>& _gradient_input_indices) {
     backward_op_name = _backward_op_name;
     forward_argument_configs.assign(_forward_argument_configs.begin(), _forward_argument_configs.end());


### PR DESCRIPTION
… arguments with std::pair

**Description**: Describe your changes.
On OrtTrainingDev3 and OrtTrainingDev4
using the latest master code with the build command 
`./build.sh --config RelWithDebInfo --use_cuda --enable_training --build_wheel --skip_tests --parallel`
I am getting the following errors
```
In file included from /bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/core/graph/gradient_builder.cc:19:0:
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::contrib::aten_ops::ArgumentKind, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::ArgumentKind; _U2 = const char (&)[7]; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::ArgumentKind; _T2 = std::__cxx11::basic_string<char>]’
                         {{GRAD_OUTPUT, 0}, {FORWARD_INPUT, 1}, {FORWARD_INPUT, 0}}, {{PROPAGATE_FROM_INPUT, 0}}, {0})},
                                                                                                                     ^
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::contrib::aten_ops::ArgumentKind, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::ArgumentKind; _U2 = const char (&)[8]; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::ArgumentKind; _T2 = std::__cxx11::basic_string<char>]’
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::c
ontrib::aten_ops::ArgumentKind, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::ArgumentKind; _U2 = const char (&)[12]; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::ArgumentKind; _T2 = std::__cxx11::basic_string<char>]’
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::contrib::aten_ops::ArgumentKind, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::ArgumentKind; _U2 = const char (&)[19]; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::ArgumentKind; _T2 = std::__cxx11::basic_string<char>]’
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::contrib::aten_ops::ArgumentKind, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::ArgumentKind; _U2 = const char (&)[7]; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::ArgumentKind; _T2 = std::__cxx11::basic_string<char>]’
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::contrib::aten_ops::ArgumentKind, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::ArgumentKind; _U2 = const char (&)[5]; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::ArgumentKind; _T2 = std::__cxx11::basic_string<char>]’
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::contrib::aten_ops::ArgumentKind, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::ArgumentKind; _U2 = const char (&)[8]; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::ArgumentKind; _T2 = std::__cxx11::basic_string<char>]’
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::contrib::aten_ops::ArgumentKind, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::ArgumentKind; _U2 = const char (&)[7]; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::ArgumentKind; _T2 = std::__cxx11::basic_string<char>]’
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::contrib::aten_ops::ArgumentKind, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::ArgumentKind; _U2 = const char (&)[12]; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::ArgumentKind; _T2 = std::__cxx11::basic_string<char>]’
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::contrib::aten_ops::ArgumentKind, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::ArgumentKind; _U2 = const char (&)[19]; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::ArgumentKind; _T2 = std::__cxx11::basic_string<char>]’
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::contrib::aten_ops::ArgumentKind, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::ArgumentKind; _U2 = const char (&)[7]; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::ArgumentKind; _T2 = std::__cxx11::basic_string<char>]’
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::contrib::aten_ops::BackwardInputSourceKind, int>’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::BackwardInputSourceKind; _U2 = int; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::BackwardInputSourceKind; _T2 = int]’
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::contrib::aten_ops::BackwardInputSourceKind, int>’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::BackwardInputSourceKind; _U2 = int; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::BackwardInputSourceKind; _T2 = int]’
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::contrib::aten_ops::BackwardInputSourceKind, int>’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::BackwardInputSourceKind; _U2 = int; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::BackwardInputSourceKind; _T2 = int]’
/bert_ort/sajandhy/ortmodule-api/onnxruntime/orttraining/orttraining/training_ops/cpu/aten_ops/aten_op_config.h:85:117: error: converting to ‘std::tuple<onnxruntime::contrib::aten_ops::OutputTypeInferKind, int>’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = onnxruntime::contrib::aten_ops::OutputTypeInferKind; _U2 = int; <template-parameter-2-3> = void; _T1 = onnxruntime::contrib::aten_ops::OutputTypeInferKind; _T2 = int]’
```
The fix is to replace std::tuple with two arguments with std::pair 
**Motivation and Context**
- Why is this change required? What problem does it solve?
The build is broken on dev machines, OrtTrainingDev3/4
- If it fixes an open issue, please link to the issue here.
