### PR TITLE
[Web/JS] Fixing two bugs in reshape_pack and im2col_pack

### DIFF
--- a/js/web/lib/onnxjs/backends/webgl/ops/conv-pack.ts
+++ b/js/web/lib/onnxjs/backends/webgl/ops/conv-pack.ts
@@ -16,6 +16,10 @@ import {WebGLReshapePacked} from './reshape-packed';
 export class WebGLConvPacked extends Conv {
   protected artifacts: Artifact[];
   protected programInfo: ProgramInfo[];
+  private kernelReshape = new WebGLReshapePacked();
+  private im2col: WebGLIm2ColPacked;
+  private matmul = new WebGLMatMulPacked();
+  private outputReshape = new WebGLReshapePacked();
 
   run(inferenceHandler: WebGLInferenceHandler, inputs: Tensor[]): Tensor[] {
     const programManager = inferenceHandler.session.programManager;
@@ -35,35 +39,35 @@ export class WebGLConvPacked extends Conv {
             this.kernelShape}, pads:${this.pads}, strides:${this.strides}`);
 
     const outputShape = WebGLConv.calcOutputShape(xshape, kshape, this.dilations, this.pads, this.strides);
-    const im2col = new WebGLIm2ColPacked(outputShape, kshape, this.dilations, this.pads, this.strides);
-    const matmul = new WebGLMatMulPacked();
+    if (this.im2col === undefined){
+     this.im2col = new WebGLIm2ColPacked(outputShape, kshape, this.dilations, this.pads, this.strides);
+    }
     if (this.activation) {
       const attributes = new Attribute(undefined);
       attributes.set('__internal_activation', 'string', (this.activation));
-      matmul.initialize(attributes);
+      this.matmul.initialize(attributes);
     }
-    const reshape = new WebGLReshapePacked();
     // shape for kernel reshape
     const shape =
         new Tensor([2], 'int32', undefined, undefined, new Int32Array([kshape[0], kshape[1] * kshape[2] * kshape[3]]));
     if (!this.artifacts) {
       this.artifacts = [];
       this.programInfo = [];
-      this.programInfo[0] = im2col.createProgramInfo(inferenceHandler, [inputs[0], inputs[1]]);
+      this.programInfo[0] = this.im2col.createProgramInfo(inferenceHandler, [inputs[0], inputs[1]]);
       this.artifacts[0] = programManager.build(this.programInfo[0]);
 
-      this.programInfo[1] = reshape.createProgramInfo(inferenceHandler, [inputs[1], shape]);
+      this.programInfo[1] = this.kernelReshape.createProgramInfo(inferenceHandler, [inputs[1], shape]);
       this.artifacts[1] = programManager.build(this.programInfo[1]);
     }
 
     // run im2col
-    const runDataIm2col = im2col.createRunData(inferenceHandler, this.programInfo[0], [inputs[0], inputs[1]]);
+    const runDataIm2col = this.im2col.createRunData(inferenceHandler, this.programInfo[0], [inputs[0], inputs[1]]);
     inferenceHandler.checkAndUpdateTextureForm(this.artifacts[0], runDataIm2col);
     programManager.run(this.artifacts[0], runDataIm2col);
     const im2colOutput = runDataIm2col.outputTextureData.tensor;
 
     // reshape kernel
-    const runDataKernelReshape = reshape.createRunData(inferenceHandler, this.programInfo[1], [inputs[1], shape]);
+    const runDataKernelReshape = this.kernelReshape.createRunData(inferenceHandler, this.programInfo[1], [inputs[1], shape]);
     inferenceHandler.checkAndUpdateTextureForm(this.artifacts[1], runDataKernelReshape);
     programManager.run(this.artifacts[1], runDataKernelReshape);
     const kernelReshaped = runDataKernelReshape.outputTextureData.tensor;
@@ -72,11 +76,11 @@ export class WebGLConvPacked extends Conv {
     const hasBias = (inputs.length === 3);
     assert(this.artifacts.length > 1, () => 'expect at least 2 artifacts created');
     if (this.artifacts.length === 2) {
-      this.programInfo[2] = matmul.createProgramInfo(
+      this.programInfo[2] = this.matmul.createProgramInfo(
           inferenceHandler, hasBias ? [kernelReshaped, im2colOutput, inputs[2]] : [kernelReshaped, im2colOutput]);
       this.artifacts[2] = programManager.build(this.programInfo[2]);
     }
-    const runDataMatmul = matmul.createRunData(
+    const runDataMatmul = this.matmul.createRunData(
         inferenceHandler, this.programInfo[2],
         hasBias ? [kernelReshaped, im2colOutput, inputs[2]] : [kernelReshaped, im2colOutput]);
     inferenceHandler.checkAndUpdateTextureForm(this.artifacts[2], runDataMatmul);
@@ -90,11 +94,11 @@ export class WebGLConvPacked extends Conv {
 
     assert(this.artifacts.length > 2, () => 'expect at least 3 artifacts created');
     if (this.artifacts.length === 3) {
-      this.programInfo[3] = reshape.createProgramInfo(inferenceHandler, [matmulOutput, outputShapeTensor]);
+      this.programInfo[3] = this.outputReshape.createProgramInfo(inferenceHandler, [matmulOutput, outputShapeTensor]);
       this.artifacts[3] = programManager.build(this.programInfo[3]);
     }
     const runDataOutputReshape =
-        reshape.createRunData(inferenceHandler, this.programInfo[3], [matmulOutput, outputShapeTensor]);
+        this.outputReshape.createRunData(inferenceHandler, this.programInfo[3], [matmulOutput, outputShapeTensor]);
     inferenceHandler.checkAndUpdateTextureForm(this.artifacts[3], runDataOutputReshape);
     programManager.run(this.artifacts[3], runDataOutputReshape);
     return [runDataOutputReshape.outputTextureData.tensor];

--- a/js/web/lib/onnxjs/backends/webgl/ops/conv-pack.ts
+++ b/js/web/lib/onnxjs/backends/webgl/ops/conv-pack.ts
@@ -39,8 +39,8 @@ export class WebGLConvPacked extends Conv {
             this.kernelShape}, pads:${this.pads}, strides:${this.strides}`);
 
     const outputShape = WebGLConv.calcOutputShape(xshape, kshape, this.dilations, this.pads, this.strides);
-    if (this.im2col === undefined){
-     this.im2col = new WebGLIm2ColPacked(outputShape, kshape, this.dilations, this.pads, this.strides);
+    if (this.im2col === undefined) {
+      this.im2col = new WebGLIm2ColPacked(outputShape, kshape, this.dilations, this.pads, this.strides);
     }
     if (this.activation) {
       const attributes = new Attribute(undefined);
@@ -67,7 +67,8 @@ export class WebGLConvPacked extends Conv {
     const im2colOutput = runDataIm2col.outputTextureData.tensor;
 
     // reshape kernel
-    const runDataKernelReshape = this.kernelReshape.createRunData(inferenceHandler, this.programInfo[1], [inputs[1], shape]);
+    const runDataKernelReshape =
+        this.kernelReshape.createRunData(inferenceHandler, this.programInfo[1], [inputs[1], shape]);
     inferenceHandler.checkAndUpdateTextureForm(this.artifacts[1], runDataKernelReshape);
     programManager.run(this.artifacts[1], runDataKernelReshape);
     const kernelReshaped = runDataKernelReshape.outputTextureData.tensor;

--- a/js/web/lib/onnxjs/backends/webgl/ops/im2col-pack.ts
+++ b/js/web/lib/onnxjs/backends/webgl/ops/im2col-pack.ts
@@ -48,12 +48,11 @@ export class WebGLIm2ColPacked implements WebGLOperator {
 
           if(blockIndex < ${im2colShape[1]} && pos < ${im2colShape[0]}) {
             offsetY = int(blockIndex / (${this.convOutputShape[rank - 1]})) * ${this.strides[0]} - ${this.pads[1]};
-            d0 = offsetY + ${this.dilations[0]} * (int(mod(float(pos), ${kernelSize}.)) / ${wshape[2]} );
+            d0 = offsetY + ${this.dilations[0]} * (imod(pos, ${kernelSize}) / ${wshape[2]});
 
             if(d0 < ${xshape[rowDim]} && d0 >= 0) {
-              offsetX = int(mod(float(blockIndex), ${this.convOutputShape[rank - 1]}.) * ${this.strides[1]}. - ${
-            this.pads[0]}.);
-              d1 = offsetX + ${this.dilations[1]} * (int(mod(mod(float(pos), ${kernelSize}.), ${wshape[2]}.)));
+              offsetX = imod(blockIndex, ${this.convOutputShape[rank - 1]}) * ${this.strides[1]} - ${this.pads[0]};
+              d1 = offsetX + ${this.dilations[1]} * imod(imod(pos, ${kernelSize}), ${wshape[2]});
 
               if(d1 < ${xshape[colDim]} && d1 >= 0) {
 

--- a/js/web/lib/onnxjs/backends/webgl/ops/reshape-packed.ts
+++ b/js/web/lib/onnxjs/backends/webgl/ops/reshape-packed.ts
@@ -9,7 +9,7 @@ import {WebGLInferenceHandler} from '../inference-handler';
 import {ProgramInfo, RunData, TextureData, WebGLOperator} from '../types';
 import {TextureLayout} from '../types';
 
-import {unpackFromChannel} from './packing_utils';
+import {unpackFromChannel} from './packing-utils';
 
 export class WebGLReshapePacked extends Reshape implements WebGLOperator {
   run(inferenceHandler: WebGLInferenceHandler, inputs: Tensor[]): Tensor[] {

--- a/js/web/lib/onnxjs/backends/webgl/ops/reshape-packed.ts
+++ b/js/web/lib/onnxjs/backends/webgl/ops/reshape-packed.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import {Reshape} from '../../../ops/reshape';
 import {Tensor} from '../../../tensor';
 import {ShapeUtil} from '../../../util';
 import {getGlsl} from '../glsl-source';
 import {WebGLInferenceHandler} from '../inference-handler';
-import {ProgramInfo, RunData, WebGLOperator} from '../types';
+import {ProgramInfo, RunData, TextureData, WebGLOperator} from '../types';
 import {TextureLayout} from '../types';
 
-import {unpackFromChannel} from './packing-utils';
+import {unpackFromChannel} from './packing_utils';
 
 export class WebGLReshapePacked extends Reshape implements WebGLOperator {
   run(inferenceHandler: WebGLInferenceHandler, inputs: Tensor[]): Tensor[] {
@@ -17,7 +17,7 @@ export class WebGLReshapePacked extends Reshape implements WebGLOperator {
   }
   createProgramInfo(handler: WebGLInferenceHandler, inputs: Tensor[]): ProgramInfo {
     if (inputs.length !== 2) {
-      throw new Error('resize kernel should have input tensor count to 2.');
+      throw new Error(`resize kernel should have input tensor count to 2.`);
     }
 
     // For packed reshape, we need to re-arrange texel data for output shape.
@@ -32,14 +32,18 @@ export class WebGLReshapePacked extends Reshape implements WebGLOperator {
     // the same between input shape and output shape, the packed reshape can be
     // treated as no-op.
     const originInputShape = inputs[0].dims;
-    const inputShape3D = processDims3D(inputs[0].dims);
+    this.inputShape3D = processDims3D(inputs[0].dims);
     let inputLayout: TextureLayout;
-    if (originInputShape.length === 3) {
-      inputLayout = handler.getOrCreateTextureLayout(inputs[0], 4, true, originInputShape, true);
-    } else {
+    inputLayout = handler.getOrCreateTextureLayout(inputs[0], 4, true, originInputShape, true);
+    if (originInputShape.length !== 3) {
+      const originalInputLayout = inputLayout;
       // if originShape is not a 3D shape, create texture layout from the processed shape.
-      inputLayout =
-          handler.createTextureLayoutFromShape(inputShape3D, 4, inputShape3D, {isPacked: true, reverseWH: true});
+      inputLayout = handler.createTextureLayoutFromShape(
+          this.inputShape3D, 4, this.inputShape3D, {isPacked: true, reverseWH: true});
+      // if the processed input shape produces texture layout differnt from the original
+      // one, the run data has to use the processed (3D) input shape later.
+      this.needSqueezeInputData =
+          (inputLayout.height !== originalInputLayout.height) || (inputLayout.width !== originalInputLayout.width);
     }
 
     this.outputShape = ShapeUtil.calculateReshapedDims(originInputShape, inputs[1].integerData);
@@ -50,21 +54,21 @@ export class WebGLReshapePacked extends Reshape implements WebGLOperator {
     this.originalOutputLayout =
         handler.createTextureLayoutFromShape(this.outputShape, 4, this.outputShape, {isPacked: true, reverseWH: true});
 
-    let mainLoop = '';
+    let mainLoop = ``;
     for (let i = 0; i < 4; i++) {
       let outputCoords = '';
       switch (i) {
         case 0:
-          outputCoords = 'outputCoords = rc;';
+          outputCoords = `outputCoords = rc;`;
           break;
         case 1:
-          outputCoords = 'outputCoords = ivec3(rc.x, rc.y+1, rc.z);';
+          outputCoords = `outputCoords = ivec3(rc.x, rc.y+1, rc.z);`;
           break;
         case 2:
-          outputCoords = 'outputCoords = ivec3(rc.x, rc.y, rc.z+1);';
+          outputCoords = `outputCoords = ivec3(rc.x, rc.y, rc.z+1);`;
           break;
         case 3:
-          outputCoords = 'outputCoords = ivec3(rc.x, rc.y+1, rc.z+1);';
+          outputCoords = `outputCoords = ivec3(rc.x, rc.y+1, rc.z+1);`;
           break;
         default:
           throw new Error();
@@ -72,7 +76,7 @@ export class WebGLReshapePacked extends Reshape implements WebGLOperator {
 
       mainLoop += `
         ${outputCoords}
-        ${i > 0 ? 'if(outputCoords.y < rows && outputCoords.z < cols){' : ''}
+        ${i > 0 ? `if(outputCoords.y < rows && outputCoords.z < cols){` : ''}
           int flattenedIndex = getFlattenedIndex(outputCoords);
 
           ivec3 inputRC = inputCoordsFromReshapedOutCoords(flattenedIndex);
@@ -86,9 +90,10 @@ export class WebGLReshapePacked extends Reshape implements WebGLOperator {
     const glsl = getGlsl(handler.session.backend.glContext.version);
 
     const shaderSource = `
-      ${getReshapedInputCoords(inputShape3D)}
+      ${getReshapedInputCoords(this.inputShape3D)}
       ${getFlattenedIndexFrom3D(squeezedOutputShape)}
       ${unpackFromChannel()}
+
       void main() {
         ivec3 rc = getOutputCoords();
 
@@ -99,7 +104,6 @@ export class WebGLReshapePacked extends Reshape implements WebGLOperator {
         int cols = ${squeezedOutputShape[1]};
 
         ${mainLoop}
-
         ${glsl.output} = result;
       }
     `;
@@ -115,8 +119,26 @@ export class WebGLReshapePacked extends Reshape implements WebGLOperator {
     };
   }
   createRunData(handler: WebGLInferenceHandler, programInfo: ProgramInfo, inputs: Tensor[]): RunData {
-    const inputTDs =
-        [handler.getOrCreateTextureData(inputs[0], handler.getOrCreateTextureLayout(inputs[0], 1, false, [], false))];
+    let inputTDs: [TextureData];
+    const originalInputLayout = handler.getOrCreateTextureLayout(inputs[0], 1, false, [], false);
+    const originalInputTD = handler.getOrCreateTextureData(inputs[0], originalInputLayout, false);
+
+    if (this.needSqueezeInputData) {
+      const squeezedInputLayout: TextureLayout = {
+        channels: 1,
+        height: originalInputLayout.height,
+        width: originalInputLayout.width,
+        shape: this.inputShape3D,
+        strides: ShapeUtil.computeStrides(this.inputShape3D),
+        unpackedShape: this.inputShape3D,
+      };
+      const squeezedInputTD =
+          handler.createSharedTextureData(squeezedInputLayout, inputs[0].type, originalInputTD.texture);
+      inputTDs = [squeezedInputTD];
+
+    } else {
+      inputTDs = [originalInputTD];
+    }
     let outputLayout = this.originalOutputLayout;
     if (outputLayout === undefined) {
       const originInputShape = inputs[0].dims;
@@ -131,11 +153,13 @@ export class WebGLReshapePacked extends Reshape implements WebGLOperator {
       uniformData: {}
     };
   }
-  protected outputShape: readonly number[];
+  protected outputShape: ReadonlyArray<number>;
   private originalOutputLayout: TextureLayout;
+  private inputShape3D: [number, number, number];
+  private needSqueezeInputData = false;
 }
 
-function processDims3D(shape: readonly number[]|readonly number[]|Tensor.IntegerType): [number, number, number] {
+function processDims3D(shape: readonly number[]|ReadonlyArray<number>|Tensor.IntegerType): [number, number, number] {
   if (shape.length === 0) {
     return [1, 1, 1];
   }

--- a/js/web/lib/onnxjs/backends/webgl/ops/reshape-packed.ts
+++ b/js/web/lib/onnxjs/backends/webgl/ops/reshape-packed.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
+// Licensed under the MIT License.
 
 import {Reshape} from '../../../ops/reshape';
 import {Tensor} from '../../../tensor';
@@ -8,7 +8,6 @@ import {getGlsl} from '../glsl-source';
 import {WebGLInferenceHandler} from '../inference-handler';
 import {ProgramInfo, RunData, TextureData, WebGLOperator} from '../types';
 import {TextureLayout} from '../types';
-
 import {unpackFromChannel} from './packing-utils';
 
 export class WebGLReshapePacked extends Reshape implements WebGLOperator {
@@ -17,7 +16,7 @@ export class WebGLReshapePacked extends Reshape implements WebGLOperator {
   }
   createProgramInfo(handler: WebGLInferenceHandler, inputs: Tensor[]): ProgramInfo {
     if (inputs.length !== 2) {
-      throw new Error(`resize kernel should have input tensor count to 2.`);
+      throw new Error('resize kernel should have input tensor count to 2.');
     }
 
     // For packed reshape, we need to re-arrange texel data for output shape.
@@ -52,21 +51,21 @@ export class WebGLReshapePacked extends Reshape implements WebGLOperator {
     this.outputLayout = handler.createTextureLayoutFromShape(
         squeezedOutputShape, 4, squeezedOutputShape, {isPacked: true, reverseWH: true});
 
-    let mainLoop = ``;
+    let mainLoop = '';
     for (let i = 0; i < 4; i++) {
       let outputCoords = '';
       switch (i) {
         case 0:
-          outputCoords = `outputCoords = rc;`;
+          outputCoords = 'outputCoords = rc;';
           break;
         case 1:
-          outputCoords = `outputCoords = ivec3(rc.x, rc.y+1, rc.z);`;
+          outputCoords = 'outputCoords = ivec3(rc.x, rc.y+1, rc.z);';
           break;
         case 2:
-          outputCoords = `outputCoords = ivec3(rc.x, rc.y, rc.z+1);`;
+          outputCoords = 'outputCoords = ivec3(rc.x, rc.y, rc.z+1);';
           break;
         case 3:
-          outputCoords = `outputCoords = ivec3(rc.x, rc.y+1, rc.z+1);`;
+          outputCoords = 'outputCoords = ivec3(rc.x, rc.y+1, rc.z+1);';
           break;
         default:
           throw new Error();
@@ -74,7 +73,7 @@ export class WebGLReshapePacked extends Reshape implements WebGLOperator {
 
       mainLoop += `
         ${outputCoords}
-        ${i > 0 ? `if(outputCoords.y < rows && outputCoords.z < cols){` : ''}
+        ${i > 0 ? 'if(outputCoords.y < rows && outputCoords.z < cols){' : ''}
           int flattenedIndex = getFlattenedIndex(outputCoords);
 
           ivec3 inputRC = inputCoordsFromReshapedOutCoords(flattenedIndex);
@@ -149,13 +148,13 @@ export class WebGLReshapePacked extends Reshape implements WebGLOperator {
       uniformData: {}
     };
   }
-  protected outputShape: ReadonlyArray<number>;
+  protected outputShape: readonly number[];
   private inputShape3D: [number, number, number];
   private needSqueezeInputData = false;
   private outputLayout: TextureLayout;
 }
 
-function processDims3D(shape: readonly number[]|ReadonlyArray<number>|Tensor.IntegerType): [number, number, number] {
+function processDims3D(shape: readonly number[]|readonly number[]|Tensor.IntegerType): [number, number, number] {
   if (shape.length === 0) {
     return [1, 1, 1];
   }

--- a/js/web/test/unittests/backends/webgl/test-reshape-packed.ts
+++ b/js/web/test/unittests/backends/webgl/test-reshape-packed.ts
@@ -90,6 +90,11 @@ function getTestData(): TestData[] {
       inputShape: [2, 2, 2, 4],
       outputShape: [2, 1, 4, 4],
     },
+    {
+      elementCount: 18432,
+      inputShape: [512, 36, 1, 1],
+      outputShape: [512, 36],
+    },
   ];
 }
 


### PR DESCRIPTION
**Description**: Describe your changes.
This PR fixes the follow bugs:
1. A bug in im2col_pack caused by a strange mod() related error. Here is the repro shader code:
 int tmp = 54;
 vec2 result = (mod(float(tmp+1), 55.0), float(imod(tmp+1, 55)))
 
The result will be [55.0, 0.0].
Apparently, the mod() function goes wrong here, so replace it with imod().

2. One bug in reshape_pack:
In the kernel reshape_pack, it will reshape any input tensor to a 3D one. In some cases, the 3D tensor produces a packed texture layout different from what the original input tensor does. A texture layout mismatch occurs which leads to wrong results. This issue is similar to [PR 7678](https://github.com/microsoft/onnxruntime/pull/7678).

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
