### PR TITLE
Partially revert PR #7348

### DIFF
--- a/onnxruntime/core/providers/cuda/nn/conv.cc
+++ b/onnxruntime/core/providers/cuda/nn/conv.cc
@@ -205,17 +205,14 @@ Status Conv<T>::UpdateState(OpKernelContext* context, bool bias_expected) const 
     std::vector<int64_t> x_dims_cudnn = x_dims;
     std::vector<int64_t> y_dims_cudnn = !post_slicing_required ? y_dims : y_dims_with_adjusted_pads;
     if (rank < 2) {
-      // cudnn only takes 4D or 5D input, so pad dimensions if needed
-      // If input shape is [N, C, D], we pad the shape to [N, C, 1, D], as it results in
-      // more efficient algorithm than padding to [N, C, D, 1]
-      x_dims_cudnn.insert(x_dims_cudnn.begin() + 2, 1);
-      y_dims_cudnn.insert(y_dims_cudnn.begin() + 2, 1);
-      w_dims.insert(w_dims.begin() + 2, 1);
-      pads.insert(pads.begin(), 0);
-      pads.insert(pads.begin() + 2, 0);
-      kernel_shape.insert(kernel_shape.begin(), 1);
-      strides.insert(strides.begin(), 1);
-      dilations.insert(dilations.begin(), 1);
+      x_dims_cudnn.push_back(1);
+      y_dims_cudnn.push_back(1);
+      w_dims.push_back(1);
+      pads.insert(pads.begin() + rank, 0);
+      pads.insert(pads.end(), 0);
+      kernel_shape.push_back(1);
+      strides.push_back(1);
+      dilations.push_back(1);
     }
 
     if (w_dims_changed) {

--- a/onnxruntime/core/providers/cuda/nn/conv.cc
+++ b/onnxruntime/core/providers/cuda/nn/conv.cc
@@ -205,6 +205,11 @@ Status Conv<T>::UpdateState(OpKernelContext* context, bool bias_expected) const 
     std::vector<int64_t> x_dims_cudnn = x_dims;
     std::vector<int64_t> y_dims_cudnn = !post_slicing_required ? y_dims : y_dims_with_adjusted_pads;
     if (rank < 2) {
+      // TODO: Explore padding the provided input shape [N, C, D] to [N, C, 1, D]
+      // especially for EXHAUSTIVE algo search which may result in a better algo selection.
+      // Currently, we are padding it to [N, C, D, 1] as this seems to be the sweet spot
+      // for all algo search options: EXHAUSTIVE, HEURISTIC, and DEFAULT.
+      // See PR #7348 for more context.
       x_dims_cudnn.push_back(1);
       y_dims_cudnn.push_back(1);
       w_dims.push_back(1);


### PR DESCRIPTION
**Description**: 

Partially revert changes in https://github.com/microsoft/onnxruntime/pull/7348 specifically the tweak on how we deal with 1D Conv. Before this change, a 1D Conv's input [N, C, D] is padded to [N, C, D, 1]. The change tweaked it to be padded to [N, C, 1, D]. This causes a perf regression in a partner's model (2.5x) that has 62 1-D Conv nodes. They are using the Conv search algo: HEURISTIC. I think this tweak with the Conv algo search of HEURISTIC leads to CuDNN picking a very sub-optimal algorithm. 

The model's perf is back to normal with this partial revert.

Maybe we can conditionally perform this tweak if the Conv algo search option is EXHAUSTIVE (if that gives a perf boost for certain models) and keep status quo (i.e.) don't do this tweak for all other Conv algo search options. This is up for discussion.

**Motivation and Context**
Fix perf regression
