### PR TITLE
Exclude training specific logic from BatchNormalization to reduce binary size

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/batch_norm.h
+++ b/onnxruntime/core/providers/cpu/nn/batch_norm.h
@@ -31,19 +31,26 @@ namespace onnxruntime {
 template <typename T>
 class BatchNorm : public OpKernel {
  public:
-  explicit BatchNorm(const OpKernelInfo& op_kernel_info) : OpKernel(op_kernel_info),
-                                                           is_spatial_(op_kernel_info.GetAttrOrDefault<int64_t>("spatial", 1) == 1) {
+  explicit BatchNorm(const OpKernelInfo& op_kernel_info)
+      : OpKernel(op_kernel_info),
+        is_spatial_(op_kernel_info.GetAttrOrDefault<int64_t>("spatial", 1) == 1) {
     auto st = op_kernel_info.GetAttr<float>("epsilon", &epsilon_);
     ORT_ENFORCE(st.IsOK(), st.ErrorMessage());
-    auto mt = op_kernel_info.GetAttr<float>("momentum", &momentum_);
-    ORT_ENFORCE(mt.IsOK(), mt.ErrorMessage());
+
     // For opset 6-8, if spatial attribute exists, pick up the value (by default spatial == 1)
     // From opset 9 onwards, by default, only the spatial case (spatial == 1) is defined per spec
 
     // For opset 14 onwards, training is true iff we have optional outputs present
-    // For opset < 14, since no training attribute is present we assume optional outputs indicate training mode 
+    // For opset < 14, since no training attribute is present we assume optional outputs indicate training mode
     is_train_ = OpKernel::Node().OutputDefs().size() > 1;
+#if defined(ENABLE_TRAINING)
     ORT_ENFORCE(!is_train_ || is_spatial_, "Training mode does not support non-spatial BN");
+
+    auto mt = op_kernel_info.GetAttr<float>("momentum", &momentum_);
+    ORT_ENFORCE(mt.IsOK(), mt.ErrorMessage());
+#else
+    ORT_ENFORCE(!is_train_, "Training mode is not supported in this build.");
+#endif
   }
 
   Status Compute(OpKernelContext* p_op_kernel_context) const override {
@@ -71,14 +78,15 @@ class BatchNorm : public OpKernel {
     // calculate sample_size (including all channels)
     size_t sample_size_incl_all_channels = sample_size * C;
 
+#if defined(ENABLE_TRAINING)
     AllocatorPtr alloc;
     ORT_RETURN_IF_ERROR(p_op_kernel_context->GetTempSpaceAllocator(&alloc));
-    
+
     // Saved mean corresponds to the mean from this batch
     // If these optional outputs are present (opset <= 9 or internal BN op) we re-use the space for calculations
     // Note that with opset <= 9 we will be outputting saved_inv_std_dev instead of saved_var
-    Tensor *saved_mean = is_train_ ? p_op_kernel_context->Output(3, mean->Shape()) : nullptr;
-    Tensor *saved_inv_std = is_train_ ? p_op_kernel_context->Output(4, var->Shape()) : nullptr;
+    Tensor* saved_mean = is_train_ ? p_op_kernel_context->Output(3, mean->Shape()) : nullptr;
+    Tensor* saved_inv_std = is_train_ ? p_op_kernel_context->Output(4, var->Shape()) : nullptr;
     // With opset <= 9, both must be defined in training. If opset >= 14, neither should be defined in training
     ORT_ENFORCE(!is_train_ || ((!saved_mean && !saved_inv_std) || (saved_mean && saved_inv_std)), "Invalid number of outputs for BN training");
     Tensor saved_mean_allocated, saved_inv_std_allocated;
@@ -88,12 +96,15 @@ class BatchNorm : public OpKernel {
       saved_mean = &saved_mean_allocated;
       saved_inv_std = &saved_inv_std_allocated;
     }
+#endif
+
     ConstEigenArrayMap<T> X_arr(X->template Data<T>(),
                                 is_spatial_ ? sample_size : sample_size_incl_all_channels,
                                 is_spatial_ ? N * C : N);
     ConstEigenVectorArrayMap<T> scale_arr(scale->template Data<T>(), is_spatial_ ? C : sample_size_incl_all_channels);
     ConstEigenVectorArrayMap<T> bias_arr(B->template Data<T>(), is_spatial_ ? C : sample_size_incl_all_channels);
 
+#if defined(ENABLE_TRAINING)
     // Note that we only support spatial BN for training
     if (is_train_) {
       EigenVectorArrayMap<T> saved_mean_arr(saved_mean->template MutableData<T>(), C);
@@ -105,7 +116,7 @@ class BatchNorm : public OpKernel {
       for (size_t nc = 0; nc < N * C; ++nc) {
         saved_mean_arr(nc % C) += X_arr.col(nc).sum();
       }
-  
+
       saved_mean_arr /= static_cast<T>(N * sample_size);
       for (size_t nc = 0; nc < N * C; ++nc) {
         saved_var_arr(nc % C) += (X_arr.col(nc) - saved_mean_arr(nc % C)).matrix().squaredNorm();
@@ -132,6 +143,7 @@ class BatchNorm : public OpKernel {
       running_mean_arr = input_running_mean_arr * momentum_ + saved_mean_arr * (1. - momentum_);
       running_var_arr = input_running_var_arr * momentum_ + saved_var_arr * (1. - momentum_);
     }
+#endif
 
     // Regardless of training or testing, we will apply the estimated mean
     // and standard deviation to the input. For testing, they are
@@ -143,14 +155,21 @@ class BatchNorm : public OpKernel {
       ConstEigenVectorArrayMap<T> var_arr(var->template Data<T>(), is_spatial_ ? C : sample_size_incl_all_channels);
       inv_std = (var_arr + epsilon_).sqrt().inverse();
     } else {
+#if defined(ENABLE_TRAINING)
       EigenVectorArrayMap<T> saved_inv_std_arr(saved_inv_std->template MutableData<T>(), C);
       saved_inv_std_arr = (saved_inv_std_arr + epsilon_).inverse().sqrt();
       inv_std = saved_inv_std_arr;
+#endif
     }
 
     // If we're training, do batch normalization based on computation from this batch
     ConstEigenVectorArrayMap<T> mean_arr(
-        !is_train_ ? mean->template Data<T>() : saved_mean->template Data<T>(), is_spatial_ ? C : sample_size_incl_all_channels);
+#if defined(ENABLE_TRAINING)
+        !is_train_ ? mean->template Data<T>() : saved_mean->template Data<T>(),
+#else
+        mean->template Data<T>(),
+#endif
+        is_spatial_ ? C : sample_size_incl_all_channels);
 
     // We can fuse the output computation as follows:
     //   ((x - est_mean) * (inv_var) * scale + bias
@@ -176,7 +195,7 @@ class BatchNorm : public OpKernel {
 
  protected:
   float epsilon_;
-  float momentum_;
+  float momentum_{0};
   const bool is_spatial_;
   int64_t is_train_;
 };

--- a/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
@@ -1113,7 +1113,9 @@ TEST(NchwcOptimizerTests, BatchNormalization) {
   // should be skipped if the batch normalization node has the optional training
   // outputs supplied.
   test_case(false);
+#if defined(ENABLE_TRAINING)
   test_case(true);
+#endif
 }
 
 TEST(NchwcOptimizerTests, ConvReorderInputNhwc) {

--- a/onnxruntime/test/providers/cpu/nn/batch_norm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/batch_norm_op_test.cc
@@ -46,10 +46,10 @@ void TestBatchNorm(const unordered_map<string, vector<T>>& input_data_map,
     excluded_eps.insert(kOpenVINOExecutionProvider);
   }
 
-  // OpenVINO: Disabled due to software limitations
-  #if defined(OPENVINO_CONFIG_GPU_FP32) || defined(OPENVINO_CONFIG_GPU_FP16) || defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M) || defined(OPENVINO_CONFIG_CPU_FP32)
-    excluded_eps.insert(kOpenVINOExecutionProvider);
-  #endif
+// OpenVINO: Disabled due to software limitations
+#if defined(OPENVINO_CONFIG_GPU_FP32) || defined(OPENVINO_CONFIG_GPU_FP16) || defined(OPENVINO_CONFIG_MYRIAD) || defined(OPENVINO_CONFIG_VAD_M) || defined(OPENVINO_CONFIG_CPU_FP32)
+  excluded_eps.insert(kOpenVINOExecutionProvider);
+#endif
   test.Run(expect_result, err_str, excluded_eps);
 }
 
@@ -736,6 +736,7 @@ TEST(BatchNormTest, BatchNorm2d_fp16) {
 #endif
 
 // TODO fix flaky test for CUDA
+#if defined(ENABLE_TRAINING)
 TEST(BatchNormTest, ForwardTrainingTestWithSavedOutputsOpset9) {
   OpTester test("BatchNormalization", 9);
   float epsilon = 1e-05f;
@@ -789,6 +790,7 @@ TEST(BatchNormTest, ForwardTrainingTestOpset14) {
   // exclude TRT and OpenVINO for same reasons as seen in TestBatchNorm()
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kCudaExecutionProvider, kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
+#endif
 
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**: 
Exclude training specific logic from BatchNormalization to reduce binary size.

**Motivation and Context**
Non-training builds shouldn't include training specific code.