### PR TITLE
fix quant weight cleanup bug

### DIFF
--- a/onnxruntime/python/tools/quantization/qdq_quantizer.py
+++ b/onnxruntime/python/tools/quantization/qdq_quantizer.py
@@ -84,7 +84,7 @@ class QDQQuantizer(ONNXQuantizer):
         self.quantize_weights_per_channel()
         self.quantize_bias_tensors()
         self.remove_nodes()
-        self.model.remove_unused_constant()
+        self.remove_quantized_weights()
 
         self.model.model.producer_name = __producer__
         self.model.model.producer_version = __version__


### PR DESCRIPTION
**Description**: Describe your changes.
Fix several quant weight cleanup bugs:
1. fix bug #7300. A weight can be used by subgraph implicitly. The unused constant check is invalid.
2. if weight is quantized and dequantized back, the original one should be removed.
