### PR TITLE
Fix bug where the output names were sorted lexicographically

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -309,4 +309,7 @@ class GraphExecutionManager(ABC):
         grad_builder_config.graph_transformer_config = self._get_graph_transformer_config()
         grad_builder_config.loglevel = _logger.ortmodule_loglevel_to_onnxruntime_c_loglevel(self._loglevel)
         self._graph_builder = C.OrtModuleGraphBuilder()
+
+        # It is assumed here that the order and names of the inputs and outputs are not modified by the backend in any way
+        # and are kept as they appear in the exported onnx model.
         self._graph_builder.initialize(self._onnx_model.SerializeToString(), grad_builder_config)

--- a/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
@@ -99,7 +99,6 @@ class InferenceManager(GraphExecutionManager):
                                                                              self._device))
 
         return _io.unflatten_user_output(self._module_output_schema,
-                                         self._graph_info.user_output_names,
                                          user_outputs)
 
     def _build_graph(self):

--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -184,7 +184,7 @@ class _TensorStub(object):
         return True
 
 
-def unflatten_user_output(output_schema, output_names, outputs):
+def unflatten_user_output(output_schema, outputs):
     """Follows the schema to generate an output that is expected by the user"""
 
     def _replace_stub_with_tensor_value(user_output, outputs, output_idx):
@@ -216,11 +216,11 @@ def unflatten_user_output(output_schema, output_names, outputs):
 
         return user_output
 
-    # Order the outputs according to the names so that the traversal order is consistent
-    outputs = [x for _, x in sorted(zip(output_names, outputs))]
-
     # Replace every _TensorStub value in the schema with the torch.Tensor outputs calculated
     output_schema_copy = copy.deepcopy(output_schema)
+
+    # It is expected that the outputs are ordered in the way defined in the exported onnx model
+    # which is the order in which the output schema was saved.
     output_idx = [0]
     user_output = _replace_stub_with_tensor_value(output_schema_copy, outputs, output_idx)
     return user_output

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -184,7 +184,6 @@ class TrainingManager(GraphExecutionManager):
                 return tuple(results)
 
         return _io.unflatten_user_output(self._module_output_schema,
-                                        self._graph_info.user_output_names,
                                         _ORTModuleFunction.apply(
                                             *_io._combine_input_buffers_initializers(
                                                 [param for name, param in self._flattened_module.named_parameters()


### PR DESCRIPTION
**Description**: There was a bug which led to reordering of the outputs from ```ORTModule```.

Consider the following example:
```py
class OutputOrderNet(torch.nn.Module):
    def __init__(self, input_size, hidden_size, num_classes):
        super(OutputOrderNet, self).__init__()

        self.fc1 = torch.nn.Linear(input_size, hidden_size)
        self.fc2 = torch.nn.Linear(input_size, hidden_size)
        self.fc3 = torch.nn.Linear(input_size, hidden_size)
        self.fc4 = torch.nn.Linear(input_size, hidden_size)
        self.fc5 = torch.nn.Linear(input_size, hidden_size)
        self.fc6 = torch.nn.Linear(input_size, hidden_size)
        self.fc7 = torch.nn.Linear(input_size, hidden_size)
        self.fc8 = torch.nn.Linear(input_size, hidden_size)
        self.fc9 = torch.nn.Linear(input_size, hidden_size)
        self.fc10 = torch.nn.Linear(input_size, hidden_size)
        self.fc11 = torch.nn.Linear(input_size, hidden_size)
        self.fc12 = torch.nn.Linear(input_size, hidden_size)

    def forward(self, input1, input2, input3, input4, input5, input6, input7, input8, input9, input10, input11, input12):
        return self.fc1(input1), self.fc2(input2), self.fc3(input3), \
            self.fc4(input4), self.fc5(input5), self.fc6(input6), \
            self.fc7(input7), self.fc8(input8), self.fc9(input9), \
            self.fc10(input10), self.fc11(input11), self.fc12(input12)
```

```ORTModule``` names the 12 outputs as ```["output-0", output-1", "output-2", ..., "output-10", "output-11"]```.
Before returning the results back to the user, these outputs are internally sorted (to match the output schema) based on the output names. But because these output names are strings, the sorting is lexicographical, i.e. the sorted output names look like:
```["output-0", output-1", "output-10", "output-11", "output-2", ..., "output-9"]```.

This results in the output order not aligning with what the user expected.

The solution is to avoid sorting based on output names. As long as the output order is respected by the backend  and kept consistent with the order as defined in the onnx graph, sorting is not required.