### PR TITLE
update pt lightning version

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
@@ -5,6 +5,6 @@ transformers==v4.3.2
 tensorboard
 h5py
 wget
-pytorch-lightning==1.2.5
+pytorch-lightning==1.3.1
 deepspeed==0.3.15
 fairscale


### PR DESCRIPTION
**Description**: 
Update pytorch-lightning to a newer version. pytorch-lightning depends on PyYAML. And a vulnerability was discovered in the PyYAML library in versions before 5.4, where it is susceptible to arbitrary code execution when it processes untrusted YAML files through the full_load method or with the FullLoader loader. Applications that use the library to process untrusted input may be vulnerable to this flaw. This flaw allows an attacker to execute arbitrary code on the system by abusing the python/object/new constructor. This flaw is due to an incomplete fix for CVE-2020-1747.