### PR TITLE
Remove build_java from mac CI pipeline because it is unstable

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ci-pipeline.yml
@@ -10,7 +10,6 @@ jobs:
       --skip_submodule_sync
       --parallel
       --build_shared_lib
-      --build_java
       --build_nodejs
       --build_objc
       --enable_language_interop_ops


### PR DESCRIPTION
**Description**:

Remove build_java from mac CI pipeline because it is unstable

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
