### PR TITLE
specify correct dependency for CI pipeline of nodejs binding

### DIFF
--- a/cmake/onnxruntime_nodejs.cmake
+++ b/cmake/onnxruntime_nodejs.cmake
@@ -45,7 +45,7 @@ add_custom_target(nodejs_binding_wrapper ALL
     COMMAND ${NPM_CLI} run build -- --onnxruntime-build-dir=${CMAKE_CURRENT_BINARY_DIR} --config=${CMAKE_BUILD_TYPE}
     WORKING_DIRECTORY ${JS_NODE_ROOT}
     COMMENT "Using cmake-js to build OnnxRuntime Node.js binding")
-add_dependencies(nodejs_binding_wrapper js_npm_ci)
+add_dependencies(js_common_npm_ci js_npm_ci)
 add_dependencies(nodejs_binding_wrapper js_common_npm_ci)
 add_dependencies(nodejs_binding_wrapper onnxruntime)
 endif()


### PR DESCRIPTION
**Description**: The old pipeline may fail when build with --parallel, because running multiple `npm ci` may cause failure. now specify dependency to make them run in sequence. (js_npm_ci --> js_common_npm_ci  -->  nodejs_binding_wrapper)