### PR TITLE
[CoreML EP] Add Squeeze Op support 

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/squeeze_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/squeeze_op_builder.cc
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#include <core/common/safeint.h>
 
 #include "core/providers/common.h"
 #include "core/providers/shared/utils/utils.h"
@@ -43,7 +44,9 @@ void SqueezeOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const 
       const auto& initializers(model_builder.GetInitializerTensors());
       const auto& axes_tensor = *initializers.at(node.InputDefs()[1]->Name());
       const int64_t* raw_axes = GetTensorInt64Data(axes_tensor);
-      for (uint64_t i = 0; i < axes.size(); i++) {
+      const auto size = SafeInt<size_t>(axes_tensor.dims()[0]);
+      axes.resize(size);
+      for (size_t i = 0; i < size; i++) {
         axes[i] = raw_axes[i];
       }
     }

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
@@ -65,6 +65,10 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
     CreateClipOpBuilder("Clip", op_registrations);
   }
 
+  {  // Squeeze
+    CreateClipOpBuilder("Squeeze", op_registrations);
+  }
+
   return op_registrations;
 }
 

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
@@ -66,7 +66,7 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
   }
 
   {  // Squeeze
-    CreateClipOpBuilder("Squeeze", op_registrations);
+    CreateSqueezeOpBuilder("Squeeze", op_registrations);
   }
 
   return op_registrations;

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
@@ -30,6 +30,6 @@ void CreateClipOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_
 void CreateActivationOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreatePoolOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateGemmOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
-void CreateSqeeuzeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateSqueezeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 }  // namespace coreml
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
@@ -30,5 +30,6 @@ void CreateClipOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_
 void CreateActivationOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreatePoolOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateGemmOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateSqeeuzeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 }  // namespace coreml
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/squeeze_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/squeeze_op_test.cc
@@ -117,15 +117,20 @@ TEST(SqueezeOpTest, SqueezeNegAxis_2) {
 }
 
 TEST(SqueezeOpTest, Squeeze_2_axes_input) {
-  OpTester test("Squeeze", 13);
-  test.AddInput<float>("data", {1, 4, 1, 1, 2},
-                       std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
-  test.AddInput<int64_t>("axes", {3}, std::vector<int64_t>{0, 2, 3});
-  test.AddOutput<float>("squeezed", {4, 2},
+  auto run_test = [](bool axes_is_initializer) {
+    OpTester test("Squeeze", 13);
+    test.AddInput<float>("data", {1, 4, 1, 1, 2},
                         std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
-  // Incorrect precision for OpenVINO EP. Will be re-enabled after it's fixed
-  // TensorRT and OpenVINO dont support "axes" input in opset 13, re-enable after
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider, kTensorrtExecutionProvider});
+    test.AddInput<int64_t>("axes", {3}, std::vector<int64_t>{0, 2, 3}, axes_is_initializer);
+    test.AddOutput<float>("squeezed", {4, 2},
+                          std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
+    // Incorrect precision for OpenVINO EP. Will be re-enabled after it's fixed
+    // TensorRT and OpenVINO dont support "axes" input in opset 13, re-enable after
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider, kTensorrtExecutionProvider});
+  };
+
+  run_test(false);
+  run_test(true);  // COREML EP will need axes as an initializer
 }
 
 TEST(SqueezeOpTest, Squeeze_Empty_Axes_opset13) {
@@ -137,17 +142,23 @@ TEST(SqueezeOpTest, Squeeze_Empty_Axes_opset13) {
 }
 
 TEST(SqueezeOpTest, SqueezeNegAxis_axes_input) {
-  OpTester test("Squeeze", 13);
-  test.AddInput<float>("data", {1, 4, 1, 1, 2},
-                       std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
-
-  test.AddInput<int64_t>("axes", {3}, std::vector<int64_t>{0, -3, -2});
-  test.AddOutput<float>("squeezed", {4, 2},
+  auto run_test = [](bool axes_is_initializer) {
+    OpTester test("Squeeze", 13);
+    test.AddInput<float>("data", {1, 4, 1, 1, 2},
                         std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
 
-  // OpenVINO EP Incorrect precision. Will be re-enabled after its fixed
-  // TensorRT and OpenVINO dont support "axes" input in opset 13, re-enable after
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider, kTensorrtExecutionProvider});
+    test.AddInput<int64_t>("axes", {3}, std::vector<int64_t>{0, -3, -2}, axes_is_initializer);
+    test.AddOutput<float>("squeezed", {4, 2},
+                          std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
+
+    // OpenVINO EP Incorrect precision. Will be re-enabled after its fixed
+    // TensorRT and OpenVINO dont support "axes" input in opset 13, re-enable after
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider, kTensorrtExecutionProvider});
+  };
+
+  run_test(false);
+  run_test(true);  // COREML EP will need axes as an initializer
+
 }
 
 // Add 4d input shape test, since NNAPI supports up to 4d input shape

--- a/onnxruntime/test/providers/cpu/tensor/squeeze_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/squeeze_op_test.cc
@@ -120,7 +120,7 @@ TEST(SqueezeOpTest, Squeeze_2_axes_input) {
   auto run_test = [](bool axes_is_initializer) {
     OpTester test("Squeeze", 13);
     test.AddInput<float>("data", {1, 4, 1, 1, 2},
-                        std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
+                         std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
     test.AddInput<int64_t>("axes", {3}, std::vector<int64_t>{0, 2, 3}, axes_is_initializer);
     test.AddOutput<float>("squeezed", {4, 2},
                           std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
@@ -145,7 +145,7 @@ TEST(SqueezeOpTest, SqueezeNegAxis_axes_input) {
   auto run_test = [](bool axes_is_initializer) {
     OpTester test("Squeeze", 13);
     test.AddInput<float>("data", {1, 4, 1, 1, 2},
-                        std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
+                         std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
 
     test.AddInput<int64_t>("axes", {3}, std::vector<int64_t>{0, -3, -2}, axes_is_initializer);
     test.AddOutput<float>("squeezed", {4, 2},
@@ -158,7 +158,6 @@ TEST(SqueezeOpTest, SqueezeNegAxis_axes_input) {
 
   run_test(false);
   run_test(true);  // COREML EP will need axes as an initializer
-
 }
 
 // Add 4d input shape test, since NNAPI supports up to 4d input shape


### PR DESCRIPTION
**Description**: [CoreML EP] Add Squeeze Op support 

**Motivation and Context**
- Add squeeze operator support for CoreML EP which can be useful
- Modify some SqueezeOpTests to use 2nd input as an initializer
