### PR TITLE
bumping up version for 1.8

### DIFF
--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2218,7 +2218,6 @@ static constexpr OrtApi ort_api_1_to_8 = {
     &OrtApis::GetCurrentGpuDeviceId,
     // End of Version 7 - DO NOT MODIFY ABOVE (see above text for more information)
 
-    // Version 8 - In development, feel free to add/remove/rearrange here
     &OrtApis::KernelInfoGetAttributeArray_float,
     &OrtApis::KernelInfoGetAttributeArray_int64,
     &OrtApis::CreateArenaCfgV2,
@@ -2227,6 +2226,9 @@ static constexpr OrtApi ort_api_1_to_8 = {
     &OrtApis::ReleasePrepackedWeightsContainer,
     &OrtApis::CreateSessionWithPrepackedWeightsContainer,
     &OrtApis::CreateSessionFromArrayWithPrepackedWeightsContainer,
+    // End of Version 8 - DO NOT MODIFY ABOVE (see above text for more information)
+
+    // Version 9 - In development, feel free to add/remove/rearrange here
 };
 
 // Assert to do a limited check to ensure Version 1 of OrtApi never changes (will detect an addition or deletion but not if they cancel out each other)


### PR DESCRIPTION
**Description**: 
Bump up API version for 1.8 release.

The change in onnxruntime_c_api.h for ORT_API_VERSION Macro has already been merged. 


**Motivation and Context** 
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

