### PR TITLE
Clean up ROCm4.1 Dockerfile build directory

### DIFF
--- a/orttraining/tools/amdgpu/Dockerfile.rocm4.1.pytorch
+++ b/orttraining/tools/amdgpu/Dockerfile.rocm4.1.pytorch
@@ -73,7 +73,8 @@ RUN git clone https://github.com/openucx/ucx.git \
   && cd build \
   && ../contrib/configure-opt --prefix=$UCX_DIR --without-rocm --without-knem --without-cuda \
   && make -j"$(nproc)" \
-  && make install
+  && make install \
+  && make clean
 
 # OpenMPI
 # note: require --enable-orterun-prefix-by-default for Azure machine learning compute
@@ -93,6 +94,7 @@ RUN git clone --recursive https://github.com/open-mpi/ompi.git \
                   --enable-mca-no-build=btl-uct --disable-mpi-fortran \
   && make -j"$(nproc)" \
   && make install \
+  && make clean \
   && ldconfig \
   && test -f ${OPENMPI_DIR}/bin/mpic++
 
@@ -128,6 +130,7 @@ RUN git clone --recursive https://github.com/microsoft/onnxruntime.git \
     --enable_training \
   && test -f $ORT_DIR/build/RelWithDebInfo/onnxruntime_training_bert \
   && pip install $ORT_DIR/build/RelWithDebInfo/dist/*.whl \
+  && rm -rf $ORT_DIR/build \
   && ldconfig
 
 # ONNX Runtime Training Examples

--- a/orttraining/tools/amdgpu/Dockerfile.rocm4.1.pytorch
+++ b/orttraining/tools/amdgpu/Dockerfile.rocm4.1.pytorch
@@ -74,7 +74,8 @@ RUN git clone https://github.com/openucx/ucx.git \
   && ../contrib/configure-opt --prefix=$UCX_DIR --without-rocm --without-knem --without-cuda \
   && make -j"$(nproc)" \
   && make install \
-  && make clean
+  && cd .. \
+  && rm -rf build
 
 # OpenMPI
 # note: require --enable-orterun-prefix-by-default for Azure machine learning compute
@@ -94,7 +95,8 @@ RUN git clone --recursive https://github.com/open-mpi/ompi.git \
                   --enable-mca-no-build=btl-uct --disable-mpi-fortran \
   && make -j"$(nproc)" \
   && make install \
-  && make clean \
+  && cd .. \
+  && rm -rf build \
   && ldconfig \
   && test -f ${OPENMPI_DIR}/bin/mpic++
 


### PR DESCRIPTION
**Description**: This PR cleans up the build files for ucx, ompi and ort 

**Motivation and Context**
- Why is this change required? What problem does it solve?
The docker images generated with the current Dockerfile is quite large (39 GB). After cleaning those build temps we should be able to reduce the size down to 24 GB. 
- If it fixes an open issue, please link to the issue here.
