### PR TITLE
Increase test timeout from 1 hour to 2 hours

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1429,7 +1429,7 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
                      source_dir, 'cmake\\codeconv.runsettings')] + executables,
                 cwd=cwd2, dll_path=dll_path)
         else:
-            ctest_cmd = [ctest_path, "--build-config", config, "--verbose", "--timeout", "3600"]
+            ctest_cmd = [ctest_path, "--build-config", config, "--verbose", "--timeout", "7200"]
             run_subprocess(ctest_cmd, cwd=cwd, dll_path=dll_path)
 
         if args.enable_pybind:


### PR DESCRIPTION
**Description**: 

I saw a test timeout in our nodejs and python packaging pipeline. I'm not sure if it is because it ran slower than before or it's a deadlock issue. Increasing the timeout will be helpful for investigating such issues.  It will make things more clear.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
