### PR TITLE
[js/web] fix npm test for webgl without wasm artifacts

### DIFF
--- a/js/web/webpack.config.js
+++ b/js/web/webpack.config.js
@@ -152,7 +152,11 @@ function buildTestRunnerConfig({
     resolve: {
       extensions: ['.ts', '.js'],
       aliasFields: [],
-      fallback: { './binding/ort-wasm-threaded.js': false, './binding/ort-wasm.js': false }
+      fallback: {
+        './binding/ort-wasm.js': false,
+        './binding/ort-wasm-threaded.js': false,
+        './binding/ort-wasm-threaded.worker.js': false
+      }
     },
     plugins: [
       new webpack.WatchIgnorePlugin({ paths: [/\.js$/, /\.d\.ts$/] }),


### PR DESCRIPTION
**Description**:  fix npm test for webgl without wasm artifacts

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
