### PR TITLE
add GetRunTimePath support for linux

### DIFF
--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -74,15 +74,15 @@ struct FileDescriptorTraits {
 };
 
 std::string where_am_i(){
-    Dl_info info;
-    if (dladdr((void*)&where_am_i, &info) != 0){
-        char path[PATH_MAX];
-        strcpy(path, info.dli_fname);
-        return std::string(dirname(path)) + "/"; 
-    }
-    else{
-        return "";
-    }
+  Dl_info info;
+  if (dladdr((void*)&where_am_i, &info) != 0){
+    char path[PATH_MAX];
+    strncpy(path, info.dli_fname, sizeof(path));
+    return std::string(dirname(path)) + "/"; 
+  }
+  else{
+    return "";
+  }
 }
 
 // Note: File descriptor cleanup may fail but this class doesn't expose a way to check if it failed.

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -78,7 +78,7 @@ std::string where_am_i(){
   if (dladdr((void*)&where_am_i, &info) != 0){
     char path[PATH_MAX];
     strncpy(path, info.dli_fname, PATH_MAX - 1);
-    path[PATH_MAX-1] = '\0'
+    path[PATH_MAX-1] = '\0';
     return std::string(dirname(path)) + "/"; 
   }
   else{

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -31,7 +31,6 @@ limitations under the License.
 #include <utility>  // for std::forward
 #include <vector>
 #include <assert.h>
-#include <link.h>
 #include <dlfcn.h>
 #include <libgen.h>
 

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -77,7 +77,8 @@ std::string where_am_i(){
   Dl_info info;
   if (dladdr((void*)&where_am_i, &info) != 0){
     char path[PATH_MAX];
-    strncpy(path, info.dli_fname, sizeof(path));
+    strncpy(path, info.dli_fname, PATH_MAX - 1);
+    path[PATH_MAX-1] = '\0'
     return std::string(dirname(path)) + "/"; 
   }
   else{


### PR DESCRIPTION
The rpath trick seems doesn't work for CentOS and other platform, use dladdr to implement the "GetRunTimePath" api.