### PR TITLE
use stable onnx.ir_version in test

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_python_nuphar.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_nuphar.py
@@ -101,7 +101,7 @@ def generate_gemm_inputs_initializers(graph, config, added_inputs_initializers={
 
 def generate_gemm_model(model_name, config):
     model = onnx.ModelProto()
-    model.ir_version = onnx.IR_VERSION
+    model.ir_version = 7 # use stable onnx ir version
     opset = model.opset_import.add()
     opset.version = 11
 
@@ -179,7 +179,7 @@ def generate_gemm_node_subgraph(scan_body, scan_node_inputs, postfix, config, ad
 
 def generate_gemm_scan_model(model_name, config1, config2):
     model = onnx.ModelProto()
-    model.ir_version = onnx.IR_VERSION
+    model.ir_version = 7 # use stable onnx ir version
     opset = model.opset_import.add()
     opset.version = 11
 

--- a/onnxruntime/test/python/quantization/test_op_gavgpool.py
+++ b/onnxruntime/test/python/quantization/test_op_gavgpool.py
@@ -69,7 +69,7 @@ class TestOpGlobalAveragePool(unittest.TestCase):
         graph = helper.make_graph([gavgpool_node_1, expand_node, conv_node, gavgpool_node_2], graph_name,
                                   [input_tensor], [output_tensor], initializer=initializers)
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
-        model.ir_version = onnx.IR_VERSION
+        model.ir_version = 7 # use stable onnx ir version
 
         onnx.save(model, output_model_path)
 

--- a/onnxruntime/test/python/quantization/test_op_gemm.py
+++ b/onnxruntime/test/python/quantization/test_op_gemm.py
@@ -71,7 +71,7 @@ class TestOpGEMM(unittest.TestCase):
         graph = helper.make_graph([gemm1_node, clip_node, gemm2_node], graph_name,
                                   [input_tensor], [output_tensor], initializer=initializers)
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
-        model.ir_version = onnx.IR_VERSION
+        model.ir_version = 7 # use stable onnx ir version
 
         onnx.save(model, output_model_path)
 

--- a/onnxruntime/test/python/quantization/test_op_maxpool.py
+++ b/onnxruntime/test/python/quantization/test_op_maxpool.py
@@ -54,7 +54,7 @@ class TestOpMaxPool(unittest.TestCase):
         graph = helper.make_graph([conv_node, identity_node, maxpool_node], 'TestOpQuantizerMaxPool_test_model',
                                   [input_tensor], [identity_out, output_tensor], initializer=initializers)
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 12)])
-        model.ir_version = onnx.IR_VERSION
+        model.ir_version = 7 # use stable onnx ir version
         onnx.save(model, output_model_path)
 
     def test_quantize_maxpool(self):

--- a/onnxruntime/test/python/quantization/test_op_pad.py
+++ b/onnxruntime/test/python/quantization/test_op_pad.py
@@ -51,7 +51,7 @@ class TestOpQuatizerPad(unittest.TestCase):
         graph = helper.make_graph([pad_node], 'TestOpQuantizerPad_test_model',
                                   [input_tensor], [output_tensor], initializer=initializers)
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
-        model.ir_version = onnx.IR_VERSION
+        model.ir_version = 7 # use stable onnx ir version
 
         onnx.save(model, output_model_path)
 
@@ -91,7 +91,7 @@ class TestOpQuatizerPad(unittest.TestCase):
         graph = helper.make_graph([conv_node, identity_node, pad_node], 'TestOpQuantizerPad_test_model',
                                   [input_tensor], [identity_out, output_tensor], initializer=initializers)
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
-        model.ir_version = onnx.IR_VERSION
+        model.ir_version = 7 # use stable onnx ir version
         onnx.save(model, output_model_path)
 
     def quantize_model(self, model_fp32_path, model_i8_path, data_reader=None):

--- a/onnxruntime/test/python/quantization/test_op_pooling.py
+++ b/onnxruntime/test/python/quantization/test_op_pooling.py
@@ -54,7 +54,7 @@ class TestOpAveragePool(unittest.TestCase):
         graph = helper.make_graph([conv_node, identity_node, avgpool_node], 'TestOpQuantizerAveragePool_test_model',
                                   [input_tensor], [identity_out, output_tensor], initializer=initializers)
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 12)])
-        model.ir_version = onnx.IR_VERSION
+        model.ir_version = 7 # use stable onnx ir version
         onnx.save(model, output_model_path)
 
     def test_quantize_avgpool(self):

--- a/onnxruntime/test/python/quantization/test_op_reshape.py
+++ b/onnxruntime/test/python/quantization/test_op_reshape.py
@@ -63,7 +63,7 @@ class TestOpReshape(unittest.TestCase):
         graph = helper.make_graph([matmul_node, reshape_node], graph_name,
                                   [input_tensor], [output_tensor], initializer=initializers)
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 11)])
-        model.ir_version = onnx.IR_VERSION
+        model.ir_version = 7 # use stable onnx ir version
 
         onnx.save(model, output_model_path)
 

--- a/onnxruntime/test/python/quantization/test_op_resize.py
+++ b/onnxruntime/test/python/quantization/test_op_resize.py
@@ -78,7 +78,7 @@ class TestOpResize(unittest.TestCase):
         graph = helper.make_graph([conv_node, identity_node, resize_node], 'TestOpQuantizerResize_test_model',
                                   [input_tensor], [identity_out, output_tensor], initializer=initializers)
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
-        model.ir_version = onnx.IR_VERSION
+        model.ir_version = 7 # use stable onnx ir version
         onnx.save(model, output_model_path)
 
     def test_quantize_resize(self):

--- a/onnxruntime/test/python/quantization/test_op_squeeze_unsqueeze.py
+++ b/onnxruntime/test/python/quantization/test_op_squeeze_unsqueeze.py
@@ -79,7 +79,7 @@ class TestOpSqueezeUnsqueeze(unittest.TestCase):
         graph = helper.make_graph([conv1_node, conv2_node, conv3_node, squeeze1_node, squeeze2_node, add1_node, unsqueeze_node, add2_node],
                                   'TestOpSuqeezes_test_model', [input_tensor], [output_tensor], initializer=initializers)
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", opset)])
-        model.ir_version = onnx.IR_VERSION
+        model.ir_version = 7 # use stable onnx ir version
         onnx.save(model, output_model_path)
 
     def run_quantize_squeezes_of_opset(self, opset = 13):

--- a/onnxruntime/test/python/quantization/test_op_transpose.py
+++ b/onnxruntime/test/python/quantization/test_op_transpose.py
@@ -58,7 +58,7 @@ class TestOpTranspose(unittest.TestCase):
         graph = helper.make_graph([matmul_node, transpose_node], graph_name,
                                   [input_tensor], [output_tensor], initializer=initializers)
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 11)])
-        model.ir_version = onnx.IR_VERSION
+        model.ir_version = 7 # use stable onnx ir version
 
         onnx.save(model, output_model_path)
 

--- a/onnxruntime/test/python/quantization/test_qat.py
+++ b/onnxruntime/test/python/quantization/test_qat.py
@@ -81,7 +81,7 @@ def generate_qat_model(model_names):
     graph.initializer.add().CopyFrom(input_bias_1)
 
     model_1 = onnx.helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
-    model_1.ir_version = onnx.IR_VERSION
+    model_1.ir_version = 7 # use stable onnx ir version
     onnx.save(model_1, model_names[0])
 
     test_models.extend([model_1])
@@ -153,7 +153,7 @@ def generate_qat_model(model_names):
     graph.initializer.add().CopyFrom(conv_bias_1)
 
     model_2 = onnx.helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
-    model_2.ir_version = onnx.IR_VERSION
+    model_2.ir_version = 7 # use stable onnx ir version
     onnx.save(model_2, model_names[1])
 
     test_models.extend([model_2])
@@ -202,7 +202,7 @@ def generate_qat_support_model(model_names, test_initializers):
         graph.initializer.add().CopyFrom(init)
 
     model_1 = onnx.ModelProto()
-    model_1.ir_version = onnx.IR_VERSION
+    model_1.ir_version = 7 # use stable onnx ir version
     model_1 = onnx.helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
     onnx.save(model_1, model_names[0])
 
@@ -243,7 +243,7 @@ def generate_qat_support_model(model_names, test_initializers):
         graph.initializer.add().CopyFrom(init)
 
     model_2 = onnx.ModelProto()
-    model_2.ir_version = onnx.IR_VERSION
+    model_2.ir_version = 7 # use stable onnx ir version
     model_2 = onnx.helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
     onnx.save(model_1, model_names[1])
 

--- a/onnxruntime/test/python/quantization/test_qdq.py
+++ b/onnxruntime/test/python/quantization/test_qdq.py
@@ -56,7 +56,7 @@ class TestQDQFormatConv(TestQDQFormat):
         graph = helper.make_graph([conv_node], graph_name,
                                   [input_tensor], [output_tensor], initializer=initializers)
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
-        model.ir_version = onnx.IR_VERSION
+        model.ir_version = 7 # use stable onnx ir version
 
         onnx.save(model, output_model_path)
 
@@ -141,7 +141,7 @@ class TestQDQFormatConvClip(TestQDQFormat):
         graph = helper.make_graph([conv_node, clip_node], graph_name,
                                   [input_tensor], [output_tensor], initializer=initializers)
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
-        model.ir_version = onnx.IR_VERSION
+        model.ir_version = 7 # use stable onnx ir version
 
         onnx.save(model, output_model_path)
 


### PR DESCRIPTION
**Description**: Describe your changes.
use stable onnx.ir_version to avoid test failure with onnx built from latest master

To solve the issue that is discussed [here](https://github.com/microsoft/onnxruntime/discussions/7603). The poster built his onnx from master branch, which just has an update of ir_version recently. ORT uses stable onnx 1.9.1, thus can not recognize the updated ir_version. 