### PR TITLE
Fix shape inference warning issue in TensorRT

### DIFF
--- a/onnxruntime/core/framework/provider_bridge_ort.cc
+++ b/onnxruntime/core/framework/provider_bridge_ort.cc
@@ -319,6 +319,7 @@ struct ProviderHostImpl : ProviderHost {
   void TensorShapeProto_Dimension__clear_dim_value(ONNX_NAMESPACE::TensorShapeProto_Dimension* p) override { return p->clear_dim_value(); }
   void TensorShapeProto_Dimension__set_dim_value(ONNX_NAMESPACE::TensorShapeProto_Dimension* p, int64_t value) override { return p->set_dim_value(value); }
   bool TensorShapeProto_Dimension__has_dim_value(const ONNX_NAMESPACE::TensorShapeProto_Dimension* p) override { return p->has_dim_value(); }
+  bool TensorShapeProto_Dimension__has_dim_param(const ONNX_NAMESPACE::TensorShapeProto_Dimension* p) override { return p->has_dim_param(); }
 
   // TensorShapeProto_Dimensions
   std::unique_ptr<TensorShapeProto_Dimension_Iterator> TensorShapeProto_Dimensions__begin(const ONNX_NAMESPACE::TensorShapeProto_Dimensions* p) override {

--- a/onnxruntime/core/framework/provider_bridge_ort.cc
+++ b/onnxruntime/core/framework/provider_bridge_ort.cc
@@ -318,6 +318,7 @@ struct ProviderHostImpl : ProviderHost {
   int64_t TensorShapeProto_Dimension__dim_value(const ONNX_NAMESPACE::TensorShapeProto_Dimension* p) override { return p->dim_value(); }
   void TensorShapeProto_Dimension__clear_dim_value(ONNX_NAMESPACE::TensorShapeProto_Dimension* p) override { return p->clear_dim_value(); }
   void TensorShapeProto_Dimension__set_dim_value(ONNX_NAMESPACE::TensorShapeProto_Dimension* p, int64_t value) override { return p->set_dim_value(value); }
+  bool TensorShapeProto_Dimension__has_dim_value(const ONNX_NAMESPACE::TensorShapeProto_Dimension* p) override { return p->has_dim_value(); }
 
   // TensorShapeProto_Dimensions
   std::unique_ptr<TensorShapeProto_Dimension_Iterator> TensorShapeProto_Dimensions__begin(const ONNX_NAMESPACE::TensorShapeProto_Dimensions* p) override {

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -255,6 +255,7 @@ struct ProviderHost {
   virtual const std::string& TensorShapeProto_Dimension__dim_param(const ONNX_NAMESPACE::TensorShapeProto_Dimension* p) = 0;
   virtual int64_t TensorShapeProto_Dimension__dim_value(const ONNX_NAMESPACE::TensorShapeProto_Dimension* p) = 0;
   virtual void TensorShapeProto_Dimension__set_dim_value(ONNX_NAMESPACE::TensorShapeProto_Dimension* p, int64_t value) = 0;
+  virtual bool TensorShapeProto_Dimension__has_dim_value(const ONNX_NAMESPACE::TensorShapeProto_Dimension* p) = 0;
   virtual void TensorShapeProto_Dimension__clear_dim_value(ONNX_NAMESPACE::TensorShapeProto_Dimension* p) = 0;
 
   // TensorShapeProto_Dimensions
@@ -626,6 +627,7 @@ struct TensorShapeProto_Dimension {
   const std::string& dim_param() const { return g_host->TensorShapeProto_Dimension__dim_param(this); }
   int64_t dim_value() const { return g_host->TensorShapeProto_Dimension__dim_value(this); }
   void set_dim_value(int64_t value) { return g_host->TensorShapeProto_Dimension__set_dim_value(this, value); }
+  bool has_dim_value() const { return g_host->TensorShapeProto_Dimension__has_dim_value(this); }
   void clear_dim_value() { return g_host->TensorShapeProto_Dimension__clear_dim_value(this); }
 
   PROVIDER_DISALLOW_ALL(TensorShapeProto_Dimension)

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -256,6 +256,7 @@ struct ProviderHost {
   virtual int64_t TensorShapeProto_Dimension__dim_value(const ONNX_NAMESPACE::TensorShapeProto_Dimension* p) = 0;
   virtual void TensorShapeProto_Dimension__set_dim_value(ONNX_NAMESPACE::TensorShapeProto_Dimension* p, int64_t value) = 0;
   virtual bool TensorShapeProto_Dimension__has_dim_value(const ONNX_NAMESPACE::TensorShapeProto_Dimension* p) = 0;
+  virtual bool TensorShapeProto_Dimension__has_dim_param(const ONNX_NAMESPACE::TensorShapeProto_Dimension* p) = 0;
   virtual void TensorShapeProto_Dimension__clear_dim_value(ONNX_NAMESPACE::TensorShapeProto_Dimension* p) = 0;
 
   // TensorShapeProto_Dimensions
@@ -628,6 +629,7 @@ struct TensorShapeProto_Dimension {
   int64_t dim_value() const { return g_host->TensorShapeProto_Dimension__dim_value(this); }
   void set_dim_value(int64_t value) { return g_host->TensorShapeProto_Dimension__set_dim_value(this, value); }
   bool has_dim_value() const { return g_host->TensorShapeProto_Dimension__has_dim_value(this); }
+  bool has_dim_param() const { return g_host->TensorShapeProto_Dimension__has_dim_param(this); }
   void clear_dim_value() { return g_host->TensorShapeProto_Dimension__clear_dim_value(this); }
 
   PROVIDER_DISALLOW_ALL(TensorShapeProto_Dimension)

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -858,21 +858,22 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
 
         // Check if input tensors have shapes
         if (iterations > 1) {
-          for (const auto* input_arg : graph_build.GetInputs()) {
-            bool has_dim_values = false;
+          auto graph_inputs = graph_build.GetInputs();
+          for (auto input_arg : graph_inputs) {
+            bool has_dim_value_or_param = true;
             auto input_shape = input_arg->Shape();
             if (input_shape != nullptr) {
-              auto dim_size = input_shape->dim_size(); 
+              auto dim_size = input_shape->dim_size();
               for (int i = 0; i < dim_size; ++i) {
                 auto &dim = input_shape->dim(i);
-                if (dim.has_dim_value()) {
-                  has_dim_values = true;
+                if (!dim.has_dim_value() and !dim.has_dim_param()) {
+                  has_dim_value_or_param = false;
                   break;
                 }
               }
             }
 
-            if (input_shape == nullptr || !has_dim_values) {
+            if (input_shape == nullptr || !has_dim_value_or_param) {
               ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
                                                  "TensorRT input: " + input_arg->Name() + " has no shape specified. " +
                                                      "Please run shape inference on the onnx model first. Details can be found in " +

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -859,7 +859,20 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
         // Check if input tensors have shapes
         if (iterations > 1) {
           for (const auto* input_arg : graph_build.GetInputs()) {
-            if (input_arg->Shape() == nullptr) {
+            bool has_dim_values = false;
+            auto input_shape = input_arg->Shape();
+            if (input_shape != nullptr) {
+              auto dim_size = input_shape->dim_size(); 
+              for (int i = 0; i < dim_size; ++i) {
+                auto &dim = input_shape->dim(i);
+                if (dim.has_dim_value()) {
+                  has_dim_values = true;
+                  break;
+                }
+              }
+            }
+
+            if (input_shape == nullptr || !has_dim_values) {
               ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
                                                  "TensorRT input: " + input_arg->Name() + " has no shape specified. " +
                                                      "Please run shape inference on the onnx model first. Details can be found in " +

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -876,7 +876,7 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
               ORT_THROW_IF_ERROR(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
                                                  "TensorRT input: " + input_arg->Name() + " has no shape specified. " +
                                                      "Please run shape inference on the onnx model first. Details can be found in " +
-                                                     "https://github.com/microsoft/onnxruntime/blob/master/docs/execution_providers/TensorRT-ExecutionProvider.md#shape-inference-for-tensorrt-subgraphs"));
+                                                     "https://www.onnxruntime.ai/docs/reference/execution-providers/TensorRT-ExecutionProvider.html#shape-inference-for-tensorrt-subgraphs"));
             }
           }
         }

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -866,7 +866,7 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
               auto dim_size = input_shape->dim_size();
               for (int i = 0; i < dim_size; ++i) {
                 auto &dim = input_shape->dim(i);
-                if (!dim.has_dim_value() and !dim.has_dim_param()) {
+                if (!dim.has_dim_value() && !dim.has_dim_param()) {
                   has_dim_value_or_param = false;
                   break;
                 }

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -309,28 +309,8 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
 
     if (enable_tensorrt) {
 #ifdef USE_TENSORRT
-      OrtTensorRTProviderOptions tensorrt_options{
-          0,
-          0,
-          nullptr,
-          1000,
-          1,
-          1 << 30,
-          0,
-          0,
-          nullptr,
-          0,
-          0,
-          0,
-          0,
-          0,
-          nullptr,
-          0,
-          nullptr,
-          0};
-
       OrtCUDAProviderOptions cuda_options{
-          0,
+          device_id,
           OrtCudnnConvAlgoSearch::EXHAUSTIVE,
           std::numeric_limits<size_t>::max(),
           0,
@@ -339,7 +319,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
           nullptr,
           nullptr};  // TODO: Support arena configuration for users of test runner
 
-      sf.AppendExecutionProvider_TensorRT(tensorrt_options);
+      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Tensorrt(sf, device_id));
       sf.AppendExecutionProvider_CUDA(cuda_options);
 #else
       fprintf(stderr, "TensorRT is not supported in this build");

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -236,7 +236,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
     session_options.AppendExecutionProvider_TensorRT(tensorrt_options);
 
     OrtCUDAProviderOptions cuda_options{
-        0,
+        device_id,
         static_cast<OrtCudnnConvAlgoSearch>(performance_test_config.run_config.cudnn_conv_algo),
         std::numeric_limits<size_t>::max(),
         0,


### PR DESCRIPTION
1. Fix the issue that TensorRT EP doesn't generate missing shape inference warning on yolov4 and fasterrcnn models
    The issue happened when graph's input shape dimension doesn't have either value or symbolic parameter.
2. Add TensorShapeProto_Dimension::has_dim_value() and has_dim_param() in provider interface. The functions will be needed in above fix
3. Use same device_id in TRT and CUDA EP in perftest
4. Add legacy TRT env variable support onnx_test_runner
