### PR TITLE
GatherGrad Bugfix

### DIFF
--- a/orttraining/orttraining/test/gradient/gradient_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/gradient_ops_test.cc
@@ -1880,6 +1880,22 @@ TEST(GradientCheckerTest, GatherGrad) {
                                           {MakeAttribute("axis", int64_t(0))});
     EXPECT_IS_TINY(max_error);
   }
+
+  // negative indices
+  {
+    TensorInfo x_info_2({4, 2});
+    TensorInfo indices_info({3}, false, nullptr, DataTypeImpl::GetTensorType<int64_t>());
+    std::vector<std::vector<float>> x_datas = {{1, 2, 3, 4, 5, 6, 7, 8}, {-1, 0, -2}};
+
+    TensorShape y_shape{x_info_2.shape};
+
+    int64_t axis = 0;
+    y_shape[axis] = 3;
+
+    gradient_checker.ComputeGradientError(op_def, {x_info_2, indices_info}, {y_shape}, &max_error, x_datas,
+                                          {MakeAttribute("axis", axis)});
+    EXPECT_IS_TINY(max_error);
+  }
 }
 
 void TestDropoutOp(float ratio, TensorShape& x_shape, bool default_ratio = true) {

--- a/orttraining/orttraining/test/training_ops/cpu/tensor/gather_grad_op_test.cc
+++ b/orttraining/orttraining/test/training_ops/cpu/tensor/gather_grad_op_test.cc
@@ -157,6 +157,22 @@ TEST(GatherGradOpTest, GatherGrad_axis0_indices2d_float) {
   test.Run();
 }
 
+TEST(GatherGradOpTest, GatherGrad_negative_indices) {
+  OpTester test("GatherGrad", 1, kMSDomain);
+  test.AddAttribute<int64_t>("axis", 0LL);
+  test.AddInput<int64_t>("shape", {2},
+                         {3, 3});
+  test.AddInput<int64_t>("indices", {2LL, 2LL},
+                         {0LL, -1LL,
+                          0LL, -2LL});
+
+  test.AddInput<float>("grad", {2, 2, 3},
+                       {0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5});
+  test.AddOutput<float>("output", {3, 3},
+                        {0, 2, 4, 3, 4, 5, 3, 4, 5});
+  test.Run();
+}
+
 TEST(GatherGradOpTest, Gather_axis1_float_impl2) {
   RunGatherGradTestWithRandomData<float>(1, {3, 4}, {6, 128});
 }

--- a/orttraining/orttraining/training_ops/cpu/tensor/gather_grad.cc
+++ b/orttraining/orttraining/training_ops/cpu/tensor/gather_grad.cc
@@ -82,7 +82,7 @@ Status GatherGrad::ComputeImpl(const TensorShape& data_shape, const Tensor& indi
     const int64_t indices_index = block_offset / block_size;
     const int64_t offset = block_offset % block_size;
     Tind idx = indices_data[indices_index];
-    if (idx < 0) idx += indices_max;
+    if (idx < 0) idx += static_cast<Tind>(indices_max);
     const int64_t input_index = input_block_index * input_block_size + idx * block_size + offset;
     //REVIEW(codemzs): This lock can become a performance bottleneck. An area for potential improvement.
     std::lock_guard<std::mutex> lck(mtx);


### PR DESCRIPTION
According to ONNX spec for Gather: all index values are expected to be within bounds [-s, s-1] along axis of size s. The Gather kernel handled negative indices case, but our GatherGrad didn't. This PR is to fix this.