### PR TITLE
Add version lock to manylinux build scripts

### DIFF
--- a/tools/ci_build/github/linux/docker/manylinux2014_build_scripts/build.sh
+++ b/tools/ci_build/github/linux/docker/manylinux2014_build_scripts/build.sh
@@ -3,7 +3,8 @@
 
 # Stop at any error, show all commands
 set -ex
-
+yum install -y yum-plugin-versionlock
+yum versionlock cuda* libcudnn*
 # Set build environment variables
 MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 . $MY_DIR/build_env.sh


### PR DESCRIPTION
**Description**: 

Add version lock to manylinux build scripts. Otherwise we may use wrong cudnn version.


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
