### PR TITLE
Add google benchmark as direct dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,9 @@
 [submodule "cmake/external/googletest"]
 	path = cmake/external/googletest
 	url = https://github.com/google/googletest.git
+[submodule "cmake/external/googlebenchmark"]
+	path = cmake/external/googlebenchmark
+	url = https://github.com/google/benchmark.git
 [submodule "cmake/external/onnx"]
 	path = cmake/external/onnx
 	url = https://github.com/onnx/onnx

--- a/cgmanifests/submodules/cgmanifest.json
+++ b/cgmanifests/submodules/cgmanifest.json
@@ -202,6 +202,16 @@
       "component": {
         "type": "git",
         "git": {
+          "commitHash": "7d0d9061d83b663ce05d9de5da3d5865a3845b79",
+          "repositoryUrl": "https://github.com/google/benchmark.git"
+        },
+        "comments": "git submodule at cmake/external/googlebenchmark"
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
           "commitHash": "703bd9caab50b139428cea1aaff9974ebee5742e",
           "repositoryUrl": "https://github.com/google/googletest.git"
         },

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -659,7 +659,7 @@ if(onnxruntime_BUILD_BENCHMARKS)
     set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Disable benchmark testing as we don't need it.")
     # We will not need to install benchmark since we link it statically.
     set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "Disable benchmark install to avoid overwriting vendor install.")
-    add_subdirectory(${PROJECT_SOURCE_DIR}/external/onnx/third_party/benchmark EXCLUDE_FROM_ALL)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/external/googlebenchmark EXCLUDE_FROM_ALL)
     add_library(benchmark::benchmark ALIAS benchmark)
   endif()
 endif()


### PR DESCRIPTION
**Description**: 
This change add google benchmark git repo as a submodule in onnxruntime repo.

**Motivation and Context**
Currently we have benchmarking code that depends on google benchmark. The version we are using has cross compilation issues for ARM CPUs. Recent changes in Google benchmark fixed these issues.

Another problem is that we now rely on ONNX to pull in Google benchmark, an indirect dependency. Updating ONNX involves complex steps and rightly so. However, updating Google benchmark dependency should not be hindered by these processes.

