### PR TITLE
Add pluggable EP shared libraries to manylinux python wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -165,12 +165,9 @@ except ImportError as error:
 # Additional binaries
 if platform.system() == 'Linux':
   libs = ['onnxruntime_pybind11_state.so', 'libdnnl.so.2', 'libmklml_intel.so', 'libmklml_gnu.so', 'libiomp5.so', 'mimalloc.so']
+  dl_libs = ['libonnxruntime_providers_shared.so', 'libonnxruntime_providers_dnnl.so', 'libonnxruntime_providers_tensorrt.so', 'libonnxruntime_providers_openvino.so']
   # DNNL, TensorRT & OpenVINO EPs are built as shared libs
-  libs.extend(['libonnxruntime_providers_shared.so'])
-  libs.extend(['libonnxruntime_providers_dnnl.so'])
-  libs.extend(['libonnxruntime_providers_tensorrt.so'])
-  libs.extend(['libonnxruntime_providers_openvino.so'])
-  libs.extend(['libonnxruntime_providers_cuda.so'])
+  libs += dl_libs
   # Nuphar Libs
   libs.extend(['libtvm.so.0.5.1'])
   if nightly_build:
@@ -181,7 +178,6 @@ elif platform.system() == "Darwin":
   libs.extend(['libonnxruntime_providers_shared.dylib'])
   libs.extend(['libonnxruntime_providers_dnnl.dylib'])
   libs.extend(['libonnxruntime_providers_tensorrt.dylib'])
-  libs.extend(['libonnxruntime_providers_cuda.dylib'])
   if nightly_build:
     libs.extend(['libonnxruntime_pywrapper.dylib'])
 else:
@@ -191,7 +187,6 @@ else:
   libs.extend(['onnxruntime_providers_dnnl.dll'])
   libs.extend(['onnxruntime_providers_tensorrt.dll'])
   libs.extend(['onnxruntime_providers_openvino.dll'])
-  libs.extend(['onnxruntime_providers_cuda.dll'])
   # DirectML Libs
   libs.extend(['DirectML.dll'])
   # Nuphar Libs
@@ -201,6 +196,7 @@ else:
 
 if is_manylinux:
     data = ['capi/libonnxruntime_pywrapper.so'] if nightly_build else []
+    data += [path.join('capi', x) for x in dl_libs if path.isfile(path.join('onnxruntime', 'capi', x))]
     ext_modules = [
         Extension(
             'onnxruntime.capi.onnxruntime_pybind11_state',

--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,7 @@ except ImportError as error:
 # Additional binaries
 if platform.system() == 'Linux':
   libs = ['onnxruntime_pybind11_state.so', 'libdnnl.so.2', 'libmklml_intel.so', 'libmklml_gnu.so', 'libiomp5.so', 'mimalloc.so']
-  dl_libs = ['libonnxruntime_providers_shared.so', 'libonnxruntime_providers_dnnl.so', 'libonnxruntime_providers_tensorrt.so', 'libonnxruntime_providers_openvino.so']
+  dl_libs = ['libonnxruntime_providers_shared.so', 'libonnxruntime_providers_dnnl.so', 'libonnxruntime_providers_tensorrt.so', 'libonnxruntime_providers_openvino.so', 'libonnxruntime_providers_cuda.so']
   # DNNL, TensorRT & OpenVINO EPs are built as shared libs
   libs += dl_libs
   # Nuphar Libs

--- a/setup.py
+++ b/setup.py
@@ -178,6 +178,7 @@ elif platform.system() == "Darwin":
   libs.extend(['libonnxruntime_providers_shared.dylib'])
   libs.extend(['libonnxruntime_providers_dnnl.dylib'])
   libs.extend(['libonnxruntime_providers_tensorrt.dylib'])
+  libs.extend(['libonnxruntime_providers_cuda.dylib'])
   if nightly_build:
     libs.extend(['libonnxruntime_pywrapper.dylib'])
 else:
@@ -187,6 +188,7 @@ else:
   libs.extend(['onnxruntime_providers_dnnl.dll'])
   libs.extend(['onnxruntime_providers_tensorrt.dll'])
   libs.extend(['onnxruntime_providers_openvino.dll'])
+  libs.extend(['onnxruntime_providers_cuda.dll'])
   # DirectML Libs
   libs.extend(['DirectML.dll'])
   # Nuphar Libs


### PR DESCRIPTION
**Description**: 
Add pluggable EP shared libraries to manylinux python wheel


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
