### PR TITLE
Update C++ API comment to resolve warning.

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -569,7 +569,6 @@ struct ArenaCfg : Base<OrtArenaCfg> {
   * \param arena_extend_strategy -  use -1 to allow ORT to choose the default, 0 = kNextPowerOfTwo, 1 = kSameAsRequested
   * \param initial_chunk_size_bytes - use -1 to allow ORT to choose the default
   * \param max_dead_bytes_per_chunk - use -1 to allow ORT to choose the default
-  * \return an instance of ArenaCfg
   * See docs/C_API.md for details on what the following parameters mean and how to choose these values
   */
   ArenaCfg(size_t max_mem, int arena_extend_strategy, int initial_chunk_size_bytes, int max_dead_bytes_per_chunk);


### PR DESCRIPTION
**Description**
Update comment to resolve warning from Objective-C API build:

ERROR | xcodebuild:  onnxruntime/onnxruntime.framework/Headers/onnxruntime_cxx_api.h:569:6: error: '\return' command used in a comment that is attached to a constructor [-Werror,-Wdocumentation]

**Motivation and Context**
Fix a warning.
