### PR TITLE
[wasm] enable DWARF format debug info for ORT WASM

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -151,7 +151,7 @@ option(onnxruntime_USE_MPI "Build with MPI support" OFF)
 option(onnxruntime_BUILD_WEBASSEMBLY "Enable this option to create WebAssembly byte codes" OFF)
 option(onnxruntime_ENABLE_WEBASSEMBLY_THREADS "Enable this option to create WebAssembly byte codes with multi-threads support" OFF)
 option(onnxruntime_ENABLE_WEBASSEMBLY_EXCEPTION_CATCHING "Enable this option to turn on exception catching" OFF)
-option(onnxruntime_ENABLE_WEBASSEMBLY_SOURCEMAP "Enable this option to turn on sourcemap" OFF)
+option(onnxruntime_ENABLE_WEBASSEMBLY_DEBUG_INFO "Enable this option to turn on DWARF format debug info" OFF)
 
 # Enable bitcode for iOS
 option(onnxruntime_ENABLE_BITCODE "Enable bitcode for iOS only" OFF)
@@ -285,12 +285,12 @@ if (onnxruntime_BUILD_WEBASSEMBLY)
     string(APPEND CMAKE_CXX_FLAGS " -flto")
   endif()
 
-  if (onnxruntime_ENABLE_WEBASSEMBLY_SOURCEMAP)
-    # Build with sourcemap support
-    set(CMAKE_CXX_FLAGS_DEBUG "-g4 --source-map-base ${onnxruntime_WEBASSEMBLY_SOURCEMAP_BASE}")
+  if (onnxruntime_ENABLE_WEBASSEMBLY_DEBUG_INFO)
+    # "-g3" generates DWARF format debug info.
+    set(CMAKE_CXX_FLAGS_DEBUG "-g3")
   else()
-    # override default "-g3" as it generates super huge (1GB+) WASM targets which fails to load
-    set(CMAKE_CXX_FLAGS_DEBUG "-g2")
+    # do not generate any debug info. This helps to accelerate building process and reduce binary size.
+    set(CMAKE_CXX_FLAGS_DEBUG "-g0")
   endif()
 
   # Build WebAssembly with multi-threads support.

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -287,6 +287,7 @@ if (onnxruntime_BUILD_WEBASSEMBLY)
 
   if (onnxruntime_ENABLE_WEBASSEMBLY_DEBUG_INFO)
     # "-g3" generates DWARF format debug info.
+    # NOTE: With debug info enabled, web assembly artifacts will be very huge (>1GB). So we offer an option to build without debug info.
     set(CMAKE_CXX_FLAGS_DEBUG "-g3")
   else()
     # do not generate any debug info. This helps to accelerate building process and reduce binary size.

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1867,8 +1867,8 @@ def main():
         if args.test and args.disable_wasm_exception_catching and not args.minimal_build:
             raise BuildError("WebAssembly tests need exception catching enabled to run if it's not minimal build")
         if args.test and args.enable_wasm_debug_info:
-            # With flag --enable_wasm_debug_info, onnxruntime_test_all.wasm will be very huge (>1GB). This will fail Node.js when trying to load
-            # the .wasm file.
+            # With flag --enable_wasm_debug_info, onnxruntime_test_all.wasm will be very huge (>1GB). This will fail
+            # Node.js when trying to load the .wasm file.
             # To debug ONNX Runtime WebAssembly, use ONNX Runtime Web to debug ort-wasm.wasm in browsers.
             raise BuildError("WebAssembly tests cannot be enabled with flag --enable_wasm_debug_info")
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -343,11 +343,8 @@ def parse_arguments():
         "--enable_wasm_threads", action='store_true',
         help="Enable WebAssembly multi-threads support")
     parser.add_argument(
-        "--enable_wasm_sourcemap", action='store_true',
-        help="Build WebAssembly with source map")
-    parser.add_argument(
-        "--wasm_sourcemap_base", default="http://localhost:9876/onnxruntime/",
-        help="Set base URL of the source map")
+        "--enable_wasm_debug_info", action='store_true',
+        help="Build WebAssembly with DWARF format debug info")
 
     # Arguments needed by CI
     parser.add_argument(
@@ -746,9 +743,8 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
         "-Donnxruntime_ENABLE_WEBASSEMBLY_EXCEPTION_CATCHING=" + ("OFF" if args.disable_wasm_exception_catching
                                                                   else "ON"),
         "-Donnxruntime_ENABLE_WEBASSEMBLY_THREADS=" + ("ON" if args.enable_wasm_threads else "OFF"),
+        "-Donnxruntime_ENABLE_WEBASSEMBLY_DEBUG_INFO=" + ("ON" if args.enable_wasm_debug_info else "OFF"),
         "-Donnxruntime_ENABLE_EAGER_MODE=" + ("ON" if args.build_eager_mode else "OFF"),
-        "-Donnxruntime_ENABLE_WEBASSEMBLY_SOURCEMAP=" + ("ON" if args.enable_wasm_sourcemap else "OFF"),
-        "-Donnxruntime_WEBASSEMBLY_SOURCEMAP_BASE=" + (args.wasm_sourcemap_base if args.enable_wasm_sourcemap else ""),
     ]
 
     if acl_home and os.path.exists(acl_home):
@@ -1870,6 +1866,11 @@ def main():
             args.disable_wasm_exception_catching = True
         if args.test and args.disable_wasm_exception_catching and not args.minimal_build:
             raise BuildError("WebAssembly tests need exception catching enabled to run if it's not minimal build")
+        if args.test and args.enable_wasm_debug_info:
+            # With flag --enable_wasm_debug_info, onnxruntime_test_all.wasm will be very huge (>1GB). This will fail Node.js when trying to load
+            # the .wasm file.
+            # To debug ONNX Runtime WebAssembly, use ONNX Runtime Web to debug ort-wasm.wasm in browsers.
+            raise BuildError("WebAssembly tests cannot be enabled with flag --enable_wasm_debug_info")
 
     if args.code_coverage and not args.android:
         raise BuildError("Using --code_coverage requires --android")


### PR DESCRIPTION
**Description**: This change enables DWARF format debug info for ORT WASM.

there is one restriction: generating DWARF debug info will significantly increase the binary size. for example, onnxruntime_test_all.wasm will increase to >1GB, which cannot be loaded in Node.js. So we report an error when both test and debuginfo are enabled. ort-wasm.wasm is around ~750MB so it can still work (although it takes a while for chrome to load)