### PR TITLE
[js/web] fix webpack config for onnxruntime-web

### DIFF
--- a/js/web/package.json
+++ b/js/web/package.json
@@ -73,12 +73,5 @@
   "jsdelivr": "dist/ort.min.js",
   "unpkg": "dist/ort.min.js",
   "module": "./lib/index.js",
-  "browser": {
-    "fs": false,
-    "path": false,
-    "util": false,
-    "worker_threads": false,
-    "perf_hooks": false,
-    "os": false
-  }
+  "browser": "dist/ort-web.min.js"
 }

--- a/js/web/webpack.config.js
+++ b/js/web/webpack.config.js
@@ -160,6 +160,10 @@ function buildTestRunnerConfig({
       '../../node': '../../node'
     },
     resolve: {
+      alias: {
+        // make sure to refer to original source files instead of generated bundle in test-main.
+        '..$': '../lib/index'
+      },
       extensions: ['.ts', '.js'],
       fallback: {
         './binding/ort-wasm.js': false,

--- a/js/web/webpack.config.js
+++ b/js/web/webpack.config.js
@@ -43,7 +43,20 @@ function buildConfig({ filename, format, target, mode, devtool }) {
         type: format
       }
     },
-    resolve: { extensions: ['.ts', '.js'] },
+    resolve: {
+      extensions: ['.ts', '.js'],
+      alias: {
+        "util": false,
+      },
+      fallback: {
+        "fs": false,
+        "path": false,
+        "util": false,
+        "os": false,
+        "worker_threads": false,
+        "perf_hooks": false,
+      }
+    },
     plugins: [new webpack.WatchIgnorePlugin({ paths: [/\.js$/, /\.d\.ts$/] })],
     module: {
       rules: [{
@@ -66,10 +79,9 @@ function buildConfig({ filename, format, target, mode, devtool }) {
   };
 
   if (mode === 'production') {
-    config.resolve.alias = {
-      './binding/ort-wasm-threaded.js': './binding/ort-wasm-threaded.min.js',
-      './binding/ort-wasm-threaded.worker.js': './binding/ort-wasm-threaded.min.worker.js'
-    };
+    config.resolve.alias['./binding/ort-wasm-threaded.js'] = './binding/ort-wasm-threaded.min.js';
+    config.resolve.alias['./binding/ort-wasm-threaded.worker.js'] = './binding/ort-wasm-threaded.min.worker.js';
+
     const options = defaultTerserPluginOptions();
     options.terserOptions.format.preamble = COPYRIGHT_BANNER;
     config.plugins.push(new TerserPlugin(options));
@@ -90,8 +102,6 @@ function buildOrtConfig({
   const config = buildConfig({ filename: `ort${suffix}.js`, format: 'umd', target, mode, devtool });
   // set global name 'ort'
   config.output.library.name = 'ort';
-  // do not use those node builtin modules in browser
-  config.resolve.fallback = { path: false, fs: false, util: false };
   return config;
 }
 

--- a/js/web/webpack.config.js
+++ b/js/web/webpack.config.js
@@ -70,7 +70,7 @@ function buildConfig({ filename, format, target, mode, devtool }) {
           }
         ]
       }, {
-        test: /\.worker.js$/,
+        test: /^ort-wasm.*\.worker\.js$/,
         type: 'asset/source'
       }]
     },

--- a/js/web/webpack.config.js
+++ b/js/web/webpack.config.js
@@ -70,7 +70,7 @@ function buildConfig({ filename, format, target, mode, devtool }) {
           }
         ]
       }, {
-        test: /^ort-wasm.*\.worker\.js$/,
+        test: /ort-wasm.*\.worker\.js$/,
         type: 'asset/source'
       }]
     },

--- a/js/web/webpack.config.js
+++ b/js/web/webpack.config.js
@@ -161,7 +161,6 @@ function buildTestRunnerConfig({
     },
     resolve: {
       extensions: ['.ts', '.js'],
-      aliasFields: [],
       fallback: {
         './binding/ort-wasm.js': false,
         './binding/ort-wasm-threaded.js': false,
@@ -184,7 +183,7 @@ function buildTestRunnerConfig({
           }
         ]
       }, {
-        test: /\.worker\.js$/,
+        test: /ort-wasm.*\.worker\.js$/,
         type: 'asset/source'
       }]
     },


### PR DESCRIPTION
**Description**: This change fixes bundling failure if user consumes npm package `onnxruntime-web` and use bundler to make their own bundle files.

This should resolve the `require("ort-wasm-threaded.worker.js")` issue described in https://github.com/microsoft/onnxruntime-inference-examples/issues/4.