### PR TITLE
Fix path used in check for cudnn library

### DIFF
--- a/onnxruntime/python/_pybind_state.py
+++ b/onnxruntime/python/_pybind_state.py
@@ -33,8 +33,10 @@ if platform.system() == "Windows":
                 raise ImportError(f"CUDA Toolkit {cuda_version_major}.x not installed on the machine.")
 
         cuda_bin_dir = os.path.join(os.environ[cuda_env_variable], "bin")
-        if not os.path.isfile(os.path.join(cuda_bin_dir, f"cudnn64_{version_info.cudnn_version}.dll")):
-            raise ImportError(f"cuDNN {version_info.cudnn_version} not installed in {cuda_bin_dir}.")
+        cudnn_bin_dir = os.path.join(os.environ["CUDNN_HOME"], "bin")
+
+        if not os.path.isfile(os.path.join(cudnn_bin_dir, f"cudnn64_{version_info.cudnn_version}.dll")):
+            raise ImportError(f"cuDNN {version_info.cudnn_version} not installed in {cudnn_bin_dir}.")
 
         if sys.version_info >= (3, 8):
             # Python 3.8 (and later) doesn't search system PATH when loading DLLs, so the CUDA location needs to be

--- a/onnxruntime/python/_pybind_state.py
+++ b/onnxruntime/python/_pybind_state.py
@@ -33,10 +33,16 @@ if platform.system() == "Windows":
                 raise ImportError(f"CUDA Toolkit {cuda_version_major}.x not installed on the machine.")
 
         cuda_bin_dir = os.path.join(os.environ[cuda_env_variable], "bin")
-        cudnn_bin_dir = os.path.join(os.environ["CUDNN_HOME"], "bin")
+
+        # prefer CUDNN_HOME if set. fallback to the CUDA install directory (would have required user to manually
+        # copy the cudnn dll there
+        cudnn_path = os.environ["CUDNN_HOME"] if "CUDNN_HOME" in os.environ else os.environ[cuda_env_variable]
+        cudnn_bin_dir = os.path.join(cudnn_path, "bin")
 
         if not os.path.isfile(os.path.join(cudnn_bin_dir, f"cudnn64_{version_info.cudnn_version}.dll")):
-            raise ImportError(f"cuDNN {version_info.cudnn_version} not installed in {cudnn_bin_dir}.")
+            raise ImportError(f"cuDNN {version_info.cudnn_version} not installed in {cudnn_bin_dir}. "
+                              f"Set the CUDNN_HOME environment variable to the path of the 'cuda' directory "
+                              f"in your CUDNN installation if necessary.")
 
         if sys.version_info >= (3, 8):
             # Python 3.8 (and later) doesn't search system PATH when loading DLLs, so the CUDA location needs to be


### PR DESCRIPTION
**Description**: 
There are separate paths for CUDA and CUDNN as they are not guarantee…d to be in the same location on a Windows machine. Use the CUDNN path when looking for the CUDNN library.

**Motivation and Context**
Python load fails on Windows when the CUDA path is used to try and find the CUDNN dll.