### PR TITLE
Explicitly select flake8 error codes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+select = F,E,W
 max-line-length = 120
 per-file-ignores =
     __init__.py:F401


### PR DESCRIPTION
**Description**
Explicitly set the `flake8` error codes to consider during the build. While `F,E,W` (and `C90` but complexity is not checked anyway) is the default in flake8, the behavior of flake8 with regards to user plugins is different if the error codes are selected explicitly or if the default is used.

**Motivation and Context**
This avoids build failures in case the user has installed additional `flake8` plugins on the build node.

