### PR TITLE
Fix a bug of missing MPI in training packaging pipeline

### DIFF
--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_training_cuda10_2
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_training_cuda10_2
@@ -34,6 +34,7 @@ RUN cd /tmp/scripts && \
     /tmp/scripts/install_centos.sh && \
     /tmp/scripts/install_os_deps.sh -d gpu $INSTALL_DEPS_EXTRA_ARGS && \
     /tmp/scripts/install_ninja.sh && \
+    /tmp/scripts/install_openmpi.sh && \
     /tmp/scripts/install_python_deps.sh -d gpu -v 10.2 -p $PYTHON_VERSION $INSTALL_DEPS_EXTRA_ARGS && \
     rm -rf /tmp/scripts
 

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_training_cuda11_1
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_training_cuda11_1
@@ -34,6 +34,7 @@ RUN cd /tmp/scripts && \
     /tmp/scripts/install_centos.sh && \
     /tmp/scripts/install_os_deps.sh -d gpu $INSTALL_DEPS_EXTRA_ARGS && \
     /tmp/scripts/install_ninja.sh && \
+    /tmp/scripts/install_openmpi.sh && \
     /tmp/scripts/install_python_deps.sh -d gpu -v 11.1 -p $PYTHON_VERSION $INSTALL_DEPS_EXTRA_ARGS && \
     rm -rf /tmp/scripts
 


### PR DESCRIPTION
**Description**: Fix a bug of missing MPI in training packaging pipeline

**Motivation and Context**
OrtTrainer is still needed. There are use cases to use OrtTrainer in distributed training.