### PR TITLE
Update onnxruntime training wheels for AMD to build in Rocm 4.2 environment

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -285,7 +285,7 @@ stages:
                 /onnxruntime_src/tools/ci_build/build.py \
                   --config Release \
                   --use_rocm \
-                    --rocm_version=4.1 \
+                    --rocm_version=4.2 \
                     --rocm_home=/opt/rocm \
                     --nccl_home=/opt/rocm \
                   --update \

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
@@ -1,4 +1,4 @@
-FROM rocm/pytorch:rocm4.1.1_centos7_py3.6_pytorch
+FROM rocm/pytorch:rocm4.2_centos7_py3.6_pytorch
 
 #Build manylinux2014 docker image begin
 ENV AUDITWHEEL_ARCH x86_64

--- a/tools/ci_build/github/linux/docker/scripts/install_python_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_python_deps.sh
@@ -58,7 +58,7 @@ if [ $DEVICE_TYPE = "gpu" ]; then
         ${PYTHON_EXE} -m pip install -r ${0/%install_python_deps.sh/training\/ortmodule\/stage2\/requirements.txt}
       else
         ${PYTHON_EXE} -m pip install \
-          --pre -f https://download.pytorch.org/whl/nightly/rocm4.1/torch_nightly.html \
+          --pre -f https://download.pytorch.org/whl/nightly/rocm4.2/torch_nightly.html \
           torch torchvision torchtext
         ${PYTHON_EXE} -m pip install -r ${0/%install_python_deps.sh/training\/ortmodule\/stage1\/requirements-rocm.txt}
         ${PYTHON_EXE} -m pip install fairscale


### PR DESCRIPTION
Build validation at https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=395733&view=results
Rocm 4.2 wheels at https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_nightly_rocm42.html
Consumed in Dockerfile visible at https://github.com/pytorch/ort/pull/27/files
Tested against HF-models we are targeting (HF-BERT, HF-DistilBERT, ...)