### PR TITLE
Fix setDimensions order issue in TensorRT EP

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1544,9 +1544,8 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<Node*>& fuse
               *trt_profile = trt_builder->createOptimizationProfile();
             }
             (*trt_profile)->setShapeValues(input_name.c_str(), nvinfer1::OptProfileSelector::kMIN, &shapes_min[0], shape_size);
-            (*trt_profile)->setShapeValues(input_name.c_str(), nvinfer1::OptProfileSelector::kOPT, &shapes_opt[0], shape_size);
             (*trt_profile)->setShapeValues(input_name.c_str(), nvinfer1::OptProfileSelector::kMAX, &shapes_max[0], shape_size);
-
+            (*trt_profile)->setShapeValues(input_name.c_str(), nvinfer1::OptProfileSelector::kOPT, &shapes_opt[0], shape_size);
           } else {  // Execution tensor
             nvinfer1::Dims dims_min(dims), dims_opt(dims), dims_max(dims);
             for (int j = 0, end = nb_dims; j < end; ++j) {
@@ -1576,8 +1575,8 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<Node*>& fuse
               *trt_profile = trt_builder->createOptimizationProfile();
             }
             (*trt_profile)->setDimensions(input_name.c_str(), nvinfer1::OptProfileSelector::kMIN, dims_min);
-            (*trt_profile)->setDimensions(input_name.c_str(), nvinfer1::OptProfileSelector::kOPT, dims_opt);
             (*trt_profile)->setDimensions(input_name.c_str(), nvinfer1::OptProfileSelector::kMAX, dims_max);
+            (*trt_profile)->setDimensions(input_name.c_str(), nvinfer1::OptProfileSelector::kOPT, dims_opt);
           }
           ort.ReleaseTensorTypeAndShapeInfo(tensor_info);
         }


### PR DESCRIPTION
- Why is this change required? What problem does it solve?
To solve memory leak issue, TensorRT profile is shared in this PR https://github.com/microsoft/onnxruntime/pull/7276. However after the change, the order to set profile values must be in MIN->MAX->OPT order. If it's still in MIN->OPT->MAX order as before, there might be a chance that new OPT value is bigger than old MAX value, which will cause setDimensions() API assertion failure.
This PR sets profile value in MIN->MAX->OPT order to solve the issue.

