### PR TITLE
Fix c_api warning

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -338,7 +338,7 @@ struct OrtApiBase {
   const OrtApi*(ORT_API_CALL* GetApi)(uint32_t version)NO_EXCEPTION;  // Pass in ORT_API_VERSION
   // nullptr will be returned if the version is unsupported, for example when using a runtime older than this header file
 
-  const char*(ORT_API_CALL* GetVersionString)() NO_EXCEPTION;
+  const char*(ORT_API_CALL* GetVersionString)(void)NO_EXCEPTION;
 };
 typedef struct OrtApiBase OrtApiBase;
 
@@ -1301,16 +1301,16 @@ struct OrtApi {
   * \param arena_config_values - values to configure the arena
   * \param num_keys - number of keys passed in
   * Supported keys are (See docs/C_API.md for details on what the following parameters mean and how to choose these values.):
-  * "max_mem": Maximum memory that can be allocated by the arena based allocator. 
+  * "max_mem": Maximum memory that can be allocated by the arena based allocator.
      Use 0 for ORT to pick the best value. Default is 0.
-  * "arena_extend_strategy": 0 = kNextPowerOfTwo, 1 = kSameAsRequested. 
+  * "arena_extend_strategy": 0 = kNextPowerOfTwo, 1 = kSameAsRequested.
      Use -1 to allow ORT to choose the default.
-  * "initial_chunk_size_bytes": (Possible) Size of the first allocation in the arena. 
+  * "initial_chunk_size_bytes": (Possible) Size of the first allocation in the arena.
      Only relevant if arena strategy is `kNextPowerOfTwo`. Use -1 to allow ORT to choose the default.
-     Ultimately, the first allocation size is determined by the allocation memory request. 
-  * "max_dead_bytes_per_chunk": Threshold of unused memory in an allocated chunk of arena memory after 
+     Ultimately, the first allocation size is determined by the allocation memory request.
+  * "max_dead_bytes_per_chunk": Threshold of unused memory in an allocated chunk of arena memory after
      crossing which the current chunk is chunked into 2.
-  * "initial_growth_chunk_size_bytes": (Possible) Size of the second allocation in the arena. 
+  * "initial_growth_chunk_size_bytes": (Possible) Size of the second allocation in the arena.
      Only relevant if arena strategy is `kNextPowerOfTwo`. Use -1 to allow ORT to choose the default.
      Ultimately, the allocation size is determined by the allocation memory request.
      Further allocation sizes are governed by the arena extend strategy.
@@ -1332,10 +1332,10 @@ struct OrtApi {
   /*
      * Creates an OrtPrepackedWeightsContainer instance.
      * This container will hold pre-packed buffers of shared initializers for sharing between sessions
-     * (i.e.) if there are shared initializers that can be shared between sessions, the pre-packed buffers 
+     * (i.e.) if there are shared initializers that can be shared between sessions, the pre-packed buffers
      * of these (if any) may possibly be shared to provide memory footprint savings. Pass this container
-     * to sessions that you would like to share pre-packed buffers of shared initializers at session 
-     * creation time. 
+     * to sessions that you would like to share pre-packed buffers of shared initializers at session
+     * creation time.
      *  \out - created OrtPrepackedWeightsContainer instance
     */
   ORT_API2_STATUS(CreatePrepackedWeightsContainer, _Outptr_ OrtPrepackedWeightsContainer** out);
@@ -1350,7 +1350,7 @@ struct OrtApi {
      * Same functionality offered by CreateSession() API except that a container that contains
      pre-packed weights' buffers is written into/read from by the created session.
      This is useful when used in conjunction with the AddInitializer() API which injects
-     shared initializer info into sessions. Wherever possible, the pre-packed versions of these 
+     shared initializer info into sessions. Wherever possible, the pre-packed versions of these
      shared initializers are cached in this container so that multiple sessions can just re-use
      these instead of duplicating these in memory.
      * \env - OrtEnv instance instance
@@ -1367,7 +1367,7 @@ struct OrtApi {
      * Same functionality offered by CreateSessionFromArray() API except that a container that contains
      pre-packed weights' buffers is written into/read from by the created session.
      This is useful when used in conjunction with the AddInitializer() API which injects
-     shared initializer info into sessions. Wherever possible, the pre-packed versions of these 
+     shared initializer info into sessions. Wherever possible, the pre-packed versions of these
      shared initializers are cached in this container so that multiple sessions can just re-use
      these instead of duplicating these in memory.
      * \env - OrtEnv instance instance


### PR DESCRIPTION
**Description**: Fix c_api warning

**Motivation and Context**
- When use ort c_api in XCode, we are always hit by the **warning: this function declaration is not a prototype [-Wstrict-prototypes]**, it is harmless, but very annoying to the user of ORT, this was discovered while adding framework package for iOS for 1.8