### PR TITLE
Decrease lock contention in qlstm by memory allocation.

### DIFF
--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.h
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.h
@@ -227,7 +227,8 @@ void ComputeGemm(const int M,
                  float* C,
                  float* C_end,
                  const int ldc,
-                 AllocatorPtr /*allocator*/,
+                 uint8_t* /* quantized_A_buffer */,
+                 int32_t* /* quantize_agg_C_buffer */,
                  concurrency::ThreadPool* thread_pool);
 
 void ComputeGemm(const int M,
@@ -241,7 +242,8 @@ void ComputeGemm(const int M,
                  float* C,
                  float* C_end,
                  const int ldc,
-                 AllocatorPtr allocator,
+                 uint8_t* quantized_A_buffer,
+                 int32_t* quantize_agg_C_buffer,
                  concurrency::ThreadPool* thread_pool);
 
 // helper to convert a span to a raw pointer

--- a/onnxruntime/core/providers/cpu/rnn/uni_directional_lstm.cc
+++ b/onnxruntime/core/providers/cpu/rnn/uni_directional_lstm.cc
@@ -333,7 +333,7 @@ void UniDirectionalLstm<T>::Compute(const gsl::span<const T>& inputs_arg,
                   beta, step_out_IOFC, output_iofc_.end(),  // input contains Xt*(W[iofc]^T)
                   hidden_size_x4,
                   quantized_input_or_a_.begin() + (seq_start * hidden_size_),
-                  quantize_agg_C_.begin() + (seq_start + hidden_size_x4),
+                  quantize_agg_C_.begin() + (seq_start * hidden_size_x4),
                   ttp);
 
       DumpMatrix("Xt*(W[iofc]^T) + Ht-t*R[iofc]" + row_str, &*step_out_IOFC, num_seq_to_compute_adjusted, hidden_size_x4);

--- a/onnxruntime/core/providers/cpu/rnn/uni_directional_lstm.cc
+++ b/onnxruntime/core/providers/cpu/rnn/uni_directional_lstm.cc
@@ -79,7 +79,6 @@ UniDirectionalLstm<T>::UniDirectionalLstm(
     LoadBias(bias);
 }
 
-
 template <typename T>
 void UniDirectionalLstm<T>::AllocateBuffers() {
   // allocate and fill with zeroes
@@ -209,7 +208,7 @@ void UniDirectionalLstm<T>::AllocateQuantizeBuffers(int max_sequence_length) {
 
     int input_or_a_size = std::max(total_rows * input_size_, batch_size_ * hidden_size_);
     quantized_input_or_a_ = Allocate(allocator_, input_or_a_size, quantized_input_or_a_ptr_, false);
-    quantize_agg_C_ = Allocate(allocator_, batch_size_ * hidden_size_x4, quantize_agg_C_ptr_, false);
+    quantized_C_buffer_ = Allocate(allocator_, batch_size_ * hidden_size_x4, quantized_C_buffer_ptr_, false);
   }
 }
 
@@ -333,7 +332,7 @@ void UniDirectionalLstm<T>::Compute(const gsl::span<const T>& inputs_arg,
                   beta, step_out_IOFC, output_iofc_.end(),  // input contains Xt*(W[iofc]^T)
                   hidden_size_x4,
                   quantized_input_or_a_.begin() + (seq_start * hidden_size_),
-                  quantize_agg_C_.begin() + (seq_start * hidden_size_x4),
+                  quantized_C_buffer_.begin() + (seq_start * hidden_size_x4),
                   ttp);
 
       DumpMatrix("Xt*(W[iofc]^T) + Ht-t*R[iofc]" + row_str, &*step_out_IOFC, num_seq_to_compute_adjusted, hidden_size_x4);

--- a/onnxruntime/core/providers/cpu/rnn/uni_directional_lstm.h
+++ b/onnxruntime/core/providers/cpu/rnn/uni_directional_lstm.h
@@ -109,6 +109,17 @@ class UniDirectionalLstm {
   ActivationInfo<deepcpu::LstmMergeGatesFuncPtr> activation_h_;
 
   concurrency::ThreadPool* thread_pool_;
+
+  // Quantized operation related allocation members
+  template <typename WeightT>
+  void AllocateQuantizeBuffers(int max_sequence_length);
+
+  // Buffer shared for quantized input whole, and quantized a each sequence step
+  IAllocatorUniquePtr<uint8_t> quantized_input_or_a_ptr_;
+  gsl::span<uint8_t> quantized_input_or_a_;
+
+  IAllocatorUniquePtr<int32_t> quantize_agg_C_ptr_;
+  gsl::span<int32_t> quantize_agg_C_;
 };
 
 }  // namespace lstm

--- a/onnxruntime/core/providers/cpu/rnn/uni_directional_lstm.h
+++ b/onnxruntime/core/providers/cpu/rnn/uni_directional_lstm.h
@@ -118,8 +118,8 @@ class UniDirectionalLstm {
   IAllocatorUniquePtr<uint8_t> quantized_input_or_a_ptr_;
   gsl::span<uint8_t> quantized_input_or_a_;
 
-  IAllocatorUniquePtr<int32_t> quantize_agg_C_ptr_;
-  gsl::span<int32_t> quantize_agg_C_;
+  IAllocatorUniquePtr<int32_t> quantized_C_buffer_ptr_;
+  gsl::span<int32_t> quantized_C_buffer_;
 };
 
 }  // namespace lstm


### PR DESCRIPTION
 * Remove memory allocation in the per sequence index level.
 
