### PR TITLE
Add graphviz into Dockerfile images for Python API documentation

### DIFF
--- a/docs/python/requirements.txt
+++ b/docs/python/requirements.txt
@@ -7,7 +7,7 @@ sphinx-gallery
 sphinxcontrib.imagesvg
 sphinx_rtd_theme
 pyquickhelper
-tensorflow
+tensorflow>=2.2.0,<2.5.0
 tf2onnx
 pandas
 pydot

--- a/orttraining/orttraining/python/training/ortmodule/__init__.py
+++ b/orttraining/orttraining/python/training/ortmodule/__init__.py
@@ -39,8 +39,8 @@ elif not os.access(python_package_dir, os.X_OK | os.W_OK):
 if not os.path.exists(TORCH_CPP_BUILD_DIR):
     os.makedirs(TORCH_CPP_BUILD_DIR, exist_ok = True)
 elif os.path.exists(os.path.join(TORCH_CPP_BUILD_DIR,'lock')):
-    print("WARNING: ORTModule detected PyTorch CPP extension's lock file during initialization, "
-          "which can cause unexpected hangs. "
+    print("WARNING: ORTModule detected PyTorch's CPP extension lock file during initialization, "
+          "which can cause the script to stop responding. "
           f"Delete {os.path.join(TORCH_CPP_BUILD_DIR,'lock')} if a hang occurs.")
 
 # Verify proper PyTorch is installed before proceding to ONNX Runtime initialization

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -132,7 +132,7 @@ stages:
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
               onnxruntimecpubuild \
-                bash -c " $(PythonManylinuxDir)/bin/python3 -m pip install /build/Release/dist/onnxruntime*.whl ; /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release " ;
+                bash -c " $(PythonManylinuxDir)/bin/python3 -m pip install /build/Release/dist/onnxruntime*.whl && /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release " ;
           workingDirectory: $(Build.SourcesDirectory)
 
       - task: CopyFiles@2
@@ -451,7 +451,7 @@ stages:
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
               onnxruntimetrainingrocmbuild \
-                bash -c " $(PythonManylinuxDir)/bin/python3 -m pip install /build/Release/dist/onnxruntime*.whl ; /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release " ;
+                bash -c " $(PythonManylinuxDir)/bin/python3 -m pip install /build/Release/dist/onnxruntime*.whl && /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release " ;
           workingDirectory: $(Build.SourcesDirectory)
 
       - task: CopyFiles@2
@@ -613,7 +613,7 @@ stages:
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
               onnxruntimetraininggpubuild \
-                bash -c " $(PythonManylinuxDir)/bin/python3 -m pip install /build/Release/dist/onnxruntime*.whl ; /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release " ;
+                bash -c " $(PythonManylinuxDir)/bin/python3 -m pip install /build/Release/dist/onnxruntime*.whl && /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release " ;
           workingDirectory: $(Build.SourcesDirectory)
 
       - task: CopyFiles@2
@@ -788,7 +788,7 @@ stages:
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
               onnxruntimetraininggpubuild \
-                bash -c " $(PythonManylinuxDir)/bin/python3 -m pip install /build/Release/dist/onnxruntime*.whl ; /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release " ;
+                bash -c " $(PythonManylinuxDir)/bin/python3 -m pip install /build/Release/dist/onnxruntime*.whl && /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release " ;
           workingDirectory: $(Build.SourcesDirectory)
 
       - task: CopyFiles@2

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -132,7 +132,7 @@ stages:
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
               onnxruntimecpubuild \
-                bash /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release
+                bash -c " $(PythonManylinuxDir)/bin/python3 -m pip install /build/Release/dist/onnxruntime*.whl ; /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release " ;
           workingDirectory: $(Build.SourcesDirectory)
 
       - task: CopyFiles@2
@@ -436,13 +436,22 @@ stages:
           script: |
             mkdir -p $HOME/.onnx
             docker run --rm \
+              --device=/dev/kfd \
+              --device=/dev/dri \
+              --group-add $(video) \
+              --group-add $(render) \
+              --privileged \
+              --ipc=host \
+              --network=host \
+              --cap-add=SYS_PTRACE \
+              --security-opt seccomp=unconfined \
               --volume $(Build.SourcesDirectory):/onnxruntime_src \
               --volume $(Build.BinariesDirectory):/build \
+              -e HIP_VISIBLE_DEVICES \
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
-              --entrypoint /bin/bash \
               onnxruntimetrainingrocmbuild \
-                /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release
+                bash -c " $(PythonManylinuxDir)/bin/python3 -m pip install /build/Release/dist/onnxruntime*.whl ; /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release " ;
           workingDirectory: $(Build.SourcesDirectory)
 
       - task: CopyFiles@2
@@ -594,6 +603,8 @@ stages:
           script: |
             mkdir -p $HOME/.onnx
             docker run --rm \
+              --gpus all \
+              -e NVIDIA_VISIBLE_DEVICES=all \
               --volume /data/onnx:/data/onnx:ro \
               --volume $(Build.SourcesDirectory):/onnxruntime_src \
               --volume $(Build.BinariesDirectory):/build \
@@ -602,7 +613,7 @@ stages:
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
               onnxruntimetraininggpubuild \
-                bash /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release
+                bash -c " $(PythonManylinuxDir)/bin/python3 -m pip install /build/Release/dist/onnxruntime*.whl ; /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release " ;
           workingDirectory: $(Build.SourcesDirectory)
 
       - task: CopyFiles@2
@@ -767,6 +778,8 @@ stages:
           script: |
             mkdir -p $HOME/.onnx
             docker run --rm \
+              --gpus all \
+              -e NVIDIA_VISIBLE_DEVICES=all \
               --volume /data/onnx:/data/onnx:ro \
               --volume $(Build.SourcesDirectory):/onnxruntime_src \
               --volume $(Build.BinariesDirectory):/build \
@@ -775,7 +788,7 @@ stages:
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
               onnxruntimetraininggpubuild \
-                bash /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release
+                bash -c " $(PythonManylinuxDir)/bin/python3 -m pip install /build/Release/dist/onnxruntime*.whl ; /onnxruntime_src/tools/doc/builddoc.sh $(PythonManylinuxDir)/bin/ /onnxruntime_src /build Release " ;
           workingDirectory: $(Build.SourcesDirectory)
 
       - task: CopyFiles@2

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cpu
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cpu
@@ -3,9 +3,6 @@ FROM quay.io/pypa/manylinux2014_x86_64:latest
 ADD scripts /tmp/scripts
 RUN cd /tmp/scripts && /tmp/scripts/manylinux/install_centos.sh && /tmp/scripts/manylinux/install_deps.sh && rm -rf /tmp/scripts
 
-# graphviz is used by the documentation pipeline
-RUN yum -y install graphviz
-
 ARG BUILD_UID=1001
 ARG BUILD_USER=onnxruntimedev
 RUN adduser --uid $BUILD_UID $BUILD_USER

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cpu
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cpu
@@ -3,6 +3,9 @@ FROM quay.io/pypa/manylinux2014_x86_64:latest
 ADD scripts /tmp/scripts
 RUN cd /tmp/scripts && /tmp/scripts/manylinux/install_centos.sh && /tmp/scripts/manylinux/install_deps.sh && rm -rf /tmp/scripts
 
+# graphviz is used by the documentation pipeline
+RUN yum -y install graphviz
+
 ARG BUILD_UID=1001
 ARG BUILD_USER=onnxruntimedev
 RUN adduser --uid $BUILD_UID $BUILD_USER

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_training_cuda10_2
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_training_cuda10_2
@@ -19,7 +19,7 @@ ENV LD_LIBRARY_PATH $DEVTOOLSET_ROOTPATH/usr/lib64:$DEVTOOLSET_ROOTPATH/usr/lib:
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
 
 COPY manylinux2014_build_scripts /manylinux2014_build_scripts
-RUN bash /manylinux2014_build_scripts/build.sh 8 && rm -r manylinux2014_build_scripts && yum downgrade  -y glibc-2.17-317.el7 glibc-common-2.17-317.el7 glibc-devel-2.17-317.el7 glibc-headers-2.17-317.el7
+RUN bash /manylinux2014_build_scripts/build.sh 8 && rm -r manylinux2014_build_scripts && yum downgrade -y glibc-2.17-317.el7 glibc-common-2.17-317.el7 glibc-devel-2.17-317.el7 glibc-headers-2.17-317.el7
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem
 

--- a/tools/ci_build/github/linux/docker/manylinux2014_build_scripts/build.sh
+++ b/tools/ci_build/github/linux/docker/manylinux2014_build_scripts/build.sh
@@ -88,7 +88,6 @@ yum -y install \
     ${TOOLCHAIN_DEPS} \
     diffutils \
     gettext \
-    graphviz \
     file \
     kernel-devel \
     libffi-devel \

--- a/tools/ci_build/github/linux/docker/scripts/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_centos.sh
@@ -17,3 +17,5 @@ yum install -y lttng-ust openssl-libs krb5-libs libicu libuuid
 yum install -y https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm
 yum install -y dotnet-sdk-2.2 java-1.8.0-openjdk-devel ccache gcc gcc-c++ python3 python3-devel python3-pip
 
+# install automatic documentation generation dependencies
+yum install -y graphviz

--- a/tools/ci_build/github/linux/docker/scripts/install_os_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_os_deps.sh
@@ -19,7 +19,11 @@ done
 
 DEVICE_TYPE=${DEVICE_TYPE:=Normal}
 
-#Download a file from internet
+# Development tools and libraries
+apt install -y \
+    graphviz
+
+# Download a file from internet
 function GetFile {
   local uri=$1
   local path=$2

--- a/tools/ci_build/github/linux/docker/scripts/install_os_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_os_deps.sh
@@ -19,10 +19,6 @@ done
 
 DEVICE_TYPE=${DEVICE_TYPE:=Normal}
 
-# Development tools and libraries
-apt install -y \
-    graphviz
-
 # Download a file from internet
 function GetFile {
   local uri=$1

--- a/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh
@@ -53,7 +53,8 @@ if [ "$OS_VERSION" = "18.04" ]; then
         zip \
         rsync libunwind8 libpng-dev libexpat1-dev \
         python3-setuptools python3-numpy python3-wheel python python3-pip python3-pytest \
-        openjdk-11-jdk"
+        openjdk-11-jdk \
+        graphviz"
 else # ubuntu20.04
     PACKAGE_LIST="autotools-dev \
         automake \
@@ -85,7 +86,8 @@ else # ubuntu20.04
         zip \
         rsync libunwind8 libpng-dev libexpat1-dev \
         python3-setuptools python3-numpy python3-wheel python python3-pip python3-pytest \
-        openjdk-11-jdk"
+        openjdk-11-jdk \
+        graphviz"
 fi
 
 if [ $DEVICE_TYPE = "Normal" ]; then

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/install_centos.sh
@@ -21,7 +21,10 @@ fi
 
 yum install -y java-11-openjdk-devel
 
-#If the /opt/python folder exists, we assume this is the manylinux docker image
+# If the /opt/python folder exists, we assume this is the manylinux docker image
 if [ ! -d "/opt/python/cp37-cp37m" ]; then
   yum install -y ccache gcc gcc-c++ python3 python3-devel python3-pip
 fi
+
+# install automatic documentation generation dependencies
+yum install -y graphviz

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/install_deps.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -e -x
 
-#Download a file from internet
+# Development tools and libraries
+yum -y install \
+    graphviz
+
+# Download a file from internet
 function GetFile {
   local uri=$1
   local path=$2

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements-rocm.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements-rocm.txt
@@ -3,6 +3,6 @@ pandas
 sklearn
 numpy==1.19.5
 transformers==v4.3.2
-tensorboard==2.2.0
+tensorboard>=2.2.0,<2.5.0
 h5py
 wget

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements-rocm.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements-rocm.txt
@@ -3,6 +3,6 @@ pandas
 sklearn
 numpy==1.19.5
 transformers==v4.3.2
-tensorboard
+tensorboard==2.2.0
 h5py
 wget

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
@@ -2,7 +2,7 @@ pandas
 sklearn
 numpy==1.19.5
 transformers==v4.3.2
-tensorboard==2.2.0
+tensorboard>=2.2.0,<2.5.0
 h5py
 wget
 pytorch-lightning==1.3.3

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
@@ -2,7 +2,7 @@ pandas
 sklearn
 numpy==1.19.5
 transformers==v4.3.2
-tensorboard
+tensorboard==2.2.0
 h5py
 wget
 pytorch-lightning==1.3.3

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
@@ -5,6 +5,6 @@ transformers==v4.3.2
 tensorboard
 h5py
 wget
-pytorch-lightning==1.3.1
+pytorch-lightning==1.3.3
 deepspeed==0.3.15
 fairscale

--- a/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
@@ -2,7 +2,7 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 # transformers requires sklearn
 sklearn
-numpy
+numpy==1.19.5
 transformers==v2.10.0
 torch==1.8.1+cu102
 torchvision==0.9.1+cu102

--- a/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
@@ -7,5 +7,5 @@ transformers==v2.10.0
 torch==1.8.1+cu102
 torchvision==0.9.1+cu102
 torchtext==0.9.1
-tensorboard==v2.0.0
+tensorboard==2.2.0
 h5py

--- a/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
@@ -2,10 +2,10 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 # transformers requires sklearn
 sklearn
-numpy==1.16.6
+numpy
 transformers==v2.10.0
 torch==1.8.1+cu102
 torchvision==0.9.1+cu102
 torchtext==0.9.1
-tensorboard==2.2.0
+tensorboard>=2.2.0,<2.5.0
 h5py

--- a/tools/doc/builddoc.sh
+++ b/tools/doc/builddoc.sh
@@ -6,7 +6,7 @@
 # $4 build config
 
 # Fail the document generation if anything goes wrong in the process
-set -e
+set -e -x
 
 # Install doc generation tools
 $1/python -m pip install -r $2/docs/python/requirements.txt

--- a/tools/doc/builddoc.sh
+++ b/tools/doc/builddoc.sh
@@ -5,6 +5,9 @@
 # $3 build folder
 # $4 build config
 
+# Fail the document generation if anything goes wrong in the process
+set -e
+
 # Install doc generation tools
 $1/python -m pip install -r $2/docs/python/requirements.txt
 


### PR DESCRIPTION
tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml requires graphviz, which is installed during Docker image creation

*IMPORTANT* numpy version was upgraded from 1.16 to 1.19 in this PR. 

*NOT IMPORTANT FOR RELEASE 1.8*