### PR TITLE
Remove unnecessary cuda libraries referenced in cmake

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1402,7 +1402,6 @@ if (onnxruntime_USE_CUDA)
     list(APPEND ONNXRUNTIME_CUDA_LIBRARIES cublas cudnn curand cufft)
   endif()
 
-  list(APPEND onnxruntime_EXTERNAL_LIBRARIES ${ONNXRUNTIME_CUDA_LIBRARIES})
   if(NOT CMAKE_CUDA_ARCHITECTURES)
     if(CMAKE_LIBRARY_ARCHITECTURE STREQUAL "aarch64-linux-gnu")
       # Support for Jetson/Tegra ARM devices


### PR DESCRIPTION
**Description**: There was an extraneous line left in the cmake to add cuda libraries to the core onnxruntime library

**Motivation and Context**
This is unnecessary, and could be the cause of cuda dependencies being added to onnxruntime on CentOS, when no physical dependency exists. 