### PR TITLE
Use RTLD_GLOBAL for onnxrutime_providers_shared on unix

### DIFF
--- a/onnxruntime/core/framework/ex_lib_loader.cc
+++ b/onnxruntime/core/framework/ex_lib_loader.cc
@@ -38,7 +38,7 @@ common::Status ExLibLoader::LoadExternalLib(const std::string& dso_file_path,
     }
 
     void* lib_handle = nullptr;
-    ORT_RETURN_IF_ERROR(Env::Default().LoadDynamicLibrary(dso_file_path, &lib_handle));
+    ORT_RETURN_IF_ERROR(Env::Default().LoadDynamicLibrary(dso_file_path, false, &lib_handle));
     dso_name_data_map_[dso_file_path] = lib_handle;
     *handle = lib_handle;
     return Status::OK();

--- a/onnxruntime/core/framework/provider_bridge_ort.cc
+++ b/onnxruntime/core/framework/provider_bridge_ort.cc
@@ -896,7 +896,7 @@ struct ProviderSharedLibrary {
       return true;
 
     std::string full_path = Env::Default().GetRuntimePath() + std::string(LIBRARY_PREFIX "onnxruntime_providers_shared" LIBRARY_EXTENSION);
-    auto error = Env::Default().LoadDynamicLibrary(full_path, &handle_);
+    auto error = Env::Default().LoadDynamicLibrary(full_path, true /*shared_globals on unix*/, &handle_);
     if (!error.IsOK()) {
       LOGS_DEFAULT(ERROR) << error.ErrorMessage();
       return false;
@@ -947,7 +947,7 @@ struct ProviderLibrary {
       return nullptr;
 
     std::string full_path = Env::Default().GetRuntimePath() + std::string(filename_);
-    auto error = Env::Default().LoadDynamicLibrary(full_path, &handle_);
+    auto error = Env::Default().LoadDynamicLibrary(full_path, false, &handle_);
     if (!error.IsOK()) {
       LOGS_DEFAULT(ERROR) << error.ErrorMessage();
       return nullptr;

--- a/onnxruntime/core/platform/env.h
+++ b/onnxruntime/core/platform/env.h
@@ -193,11 +193,13 @@ class Env {
   // loading a library.  The rules for determining the exact location of the
   // library are platform-specific and are not documented here.
   //
+  // global_symbols only has an effect on unix, where a value of true means to load with RTLD_GLOBAL vs RTLD_LOCAL
+  // 
   // On success, returns a handle to the library in "*handle" and returns
   // OK from the function.
   // Otherwise returns nullptr in "*handle" and an error status from the
   // function.
-  virtual common::Status LoadDynamicLibrary(const std::string& library_filename, void** handle) const = 0;
+  virtual common::Status LoadDynamicLibrary(const std::string& library_filename, bool global_symbols, void** handle) const = 0;
 
   virtual common::Status UnloadDynamicLibrary(void* handle) const = 0;
 

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -411,9 +411,9 @@ class PosixEnv : public Env {
     return Status::OK();
   }
 
-  common::Status LoadDynamicLibrary(const std::string& library_filename, void** handle) const override {
+  common::Status LoadDynamicLibrary(const std::string& library_filename, bool global_symbols, void** handle) const override {
     dlerror();  // clear any old error_str
-    *handle = dlopen(library_filename.c_str(), RTLD_NOW | RTLD_LOCAL);
+    *handle = dlopen(library_filename.c_str(), RTLD_NOW | (global_symbols ? RTLD_GLOBAL : RTLD_LOCAL));
     char* error_str = dlerror();
     if (!*handle) {
       return common::Status(common::ONNXRUNTIME, common::FAIL,

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -494,7 +494,7 @@ class WindowsEnv : public Env {
     return path.substr(0, slash_index + 1);
   }
 
-  virtual Status LoadDynamicLibrary(const std::string& library_filename, void** handle) const override {
+  virtual Status LoadDynamicLibrary(const std::string& library_filename, bool /*global_symbols*/, void** handle) const override {
 #if WINAPI_FAMILY == WINAPI_FAMILY_PC_APP
     *handle = ::LoadPackagedLibrary(ToWideString(library_filename).c_str(), 0);
 #else

--- a/onnxruntime/core/providers/nuphar/common/nuphar_tvm_utils.cc
+++ b/onnxruntime/core/providers/nuphar/common/nuphar_tvm_utils.cc
@@ -69,7 +69,7 @@ static bool GetCacheSoFilePath(std::string& so_path) {
 
 static void* GetFuncFromLibrary(const std::string& so_path, const std::string& func_name, bool throw_if_not_found = true) {
   void* so_handle;
-  ORT_ENFORCE(Env::Default().LoadDynamicLibrary(so_path, &so_handle).IsOK());
+  ORT_ENFORCE(Env::Default().LoadDynamicLibrary(so_path, false, &so_handle).IsOK());
   void* func = nullptr;
   Status s = Env::Default().GetSymbolFromLibrary(so_handle, func_name, &func);
   if (throw_if_not_found && !s.IsOK())

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -389,7 +389,7 @@ ORT_API_STATUS_IMPL(OrtApis::AddCustomOpDomain, _Inout_ OrtSessionOptions* optio
 ORT_API_STATUS_IMPL(OrtApis::RegisterCustomOpsLibrary, _Inout_ OrtSessionOptions* options, _In_ const char* library_path, void** library_handle) {
   API_IMPL_BEGIN
 
-  Env::Default().LoadDynamicLibrary(library_path, library_handle);
+  Env::Default().LoadDynamicLibrary(library_path, false, library_handle);
   if (!*library_handle)
     return OrtApis::CreateStatus(ORT_FAIL, "RegisterCustomOpsLibrary: Failed to load library");
 

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -252,7 +252,7 @@ static Env& platform_env = Env::Default();
 
 CustomOpLibrary::CustomOpLibrary(const char* library_path, OrtSessionOptions& ort_so) {
   {
-    OrtPybindThrowIfError(platform_env.LoadDynamicLibrary(library_path, &library_handle_));
+    OrtPybindThrowIfError(platform_env.LoadDynamicLibrary(library_path, false, &library_handle_));
 
     OrtStatus*(ORT_API_CALL * RegisterCustomOps)(OrtSessionOptions * options, const OrtApiBase* api);
 
@@ -455,7 +455,7 @@ static std::unique_ptr<onnxruntime::IExecutionProvider> LoadExecutionProvider(
     const std::string& ep_shared_lib_path,
     const ProviderOptions& provider_options = {}) {
   void* handle;
-  auto error = Env::Default().LoadDynamicLibrary(ep_shared_lib_path, &handle);
+  auto error = Env::Default().LoadDynamicLibrary(ep_shared_lib_path, false, &handle);
   if (!error.IsOK()) {
     throw std::runtime_error(error.ErrorMessage());
   }


### PR DESCRIPTION
**Description**: On Unix, we want to make shared providers not directly link with libonnxruntime_providers_shared.so, instead we can just load libonnxrutime_providers_shared.so with RTLD_GLOBAL on unix OS's and this will provide the symbols to the shared providers.

**Motivation and Context**
- Why is this change required? What problem does it solve?
A complex linking issue during packaging where extra dependencies causes the packaging to get confused, resulting in symbols not found during load time. This removes the extra dependencies to avoid this problem.