### PR TITLE
fix topo sort in quant tool

### DIFF
--- a/onnxruntime/python/tools/quantization/onnx_model.py
+++ b/onnxruntime/python/tools/quantization/onnx_model.py
@@ -260,38 +260,42 @@ class ONNXModel:
     def topological_sort(self):
         deps_count = [0]*len(self.nodes()) # dependency count of each node
         deps_to_nodes = {} # input to node indice
+        sorted_nodes = []  # initialize sorted_nodes
         for node_idx, node in enumerate(self.nodes()):
             # CANNOT use len(node.input) directly because input can be optional
             deps_count[node_idx] = sum(1 for _ in node.input if _ )
+            if deps_count[node_idx] == 0: # Constant doesn't depend on any inputs
+                sorted_nodes.append(self.nodes()[node_idx])
+                continue
+
             for input_name in node.input:
                 if input_name not in deps_to_nodes:
                     deps_to_nodes[input_name] = [node_idx]
                 else:
                     deps_to_nodes[input_name].append(node_idx)
 
-        # initialize sorted_nodes
-        sorted_nodes = []
-        for input in itertools.chain(self.initializer(), self.model.graph.input):
-            if input.name in deps_to_nodes:
-                for node_idx in deps_to_nodes[input.name]:
+        initializer_names = [init.name for init in self.initializer()]
+        graph_input_names = [input.name for input in self.model.graph.input]
+        for input_name in (set(initializer_names) | set(graph_input_names)):
+            if input_name in deps_to_nodes:
+                for node_idx in deps_to_nodes[input_name]:
                     deps_count[node_idx] = deps_count[node_idx] - 1
                     if deps_count[node_idx] == 0:
                         sorted_nodes.append(self.nodes()[node_idx])
 
-        s = 0
-        e = len(sorted_nodes)
+        start = 0
+        end = len(sorted_nodes)
 
-        while s < e:
-            for output in sorted_nodes[s].output:
+        while start < end:
+            for output in sorted_nodes[start].output:
                 if output in deps_to_nodes:
                     for node_idx in deps_to_nodes[output]:
                         deps_count[node_idx] = deps_count[node_idx] - 1
                         if deps_count[node_idx] == 0:
                             sorted_nodes.append(self.nodes()[node_idx])
-                            e = e + 1
-            s = s + 1
+                            end = end + 1
+            start = start + 1
 
-        assert(e == len(self.graph().node)), "Graph is not a DAG"
+        assert(end == len(self.graph().node)), "Graph is not a DAG"
         self.graph().ClearField('node')
         self.graph().node.extend(sorted_nodes)
-

--- a/onnxruntime/python/tools/quantization/onnx_model.py
+++ b/onnxruntime/python/tools/quantization/onnx_model.py
@@ -276,7 +276,14 @@ class ONNXModel:
 
         initializer_names = [init.name for init in self.initializer()]
         graph_input_names = [input.name for input in self.model.graph.input]
-        for input_name in (set(initializer_names) | set(graph_input_names)):
+        input_names = initializer_names + graph_input_names
+        input_names.sort()
+        prev_input_name = None
+        for input_name in input_names:
+            if prev_input_name == input_name:
+                continue
+
+            prev_input_name = input_name
             if input_name in deps_to_nodes:
                 for node_idx in deps_to_nodes[input_name]:
                     deps_count[node_idx] = deps_count[node_idx] - 1


### PR DESCRIPTION
**Description**: Describe your changes.
Constant op doesn't depend on any inputs/initializers. Should put it into the initial sorted nodes.
