### PR TITLE
[js/web] only apply max thread number when it's omitted

### DIFF
--- a/js/web/lib/backend-wasm.ts
+++ b/js/web/lib/backend-wasm.ts
@@ -20,11 +20,10 @@ export const initializeFlags = (): void => {
     env.wasm.initTimeout = 0;
   }
 
-  if (typeof env.wasm.numThreads !== 'number' || !Number.isInteger(env.wasm.numThreads) || env.wasm.numThreads < 0) {
+  if (typeof env.wasm.numThreads !== 'number' || !Number.isInteger(env.wasm.numThreads) || env.wasm.numThreads <= 0) {
     const numCpuLogicalCores = typeof navigator === 'undefined' ? cpus().length : navigator.hardwareConcurrency;
-    env.wasm.numThreads = Math.ceil((numCpuLogicalCores || 1) / 2);
+    env.wasm.numThreads = Math.min(4, Math.ceil((numCpuLogicalCores || 1) / 2));
   }
-  env.wasm.numThreads = Math.min(4, env.wasm.numThreads);
 };
 
 class OnnxruntimeWebAssemblyBackend implements Backend {


### PR DESCRIPTION
**Description**: we apply max thread number (4) to the `numThreads` for web assembly backend. This should only apply when this flag is not set manually. When user specify a bigger integer explicitly we should not apply the max.

This also fixes the behavior when user set `ort.env.wasm.numThreads` to `0`. as described in https://github.com/microsoft/onnxruntime/blob/master/js/common/lib/env.ts#L7-L13