### PR TITLE
Fix test_DynamicQuantizedLinear_max_adjusted_expanded by allowing Identity operator to run on non-float inputs

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
@@ -248,6 +248,7 @@ namespace Dml::GraphDescBuilder
             const onnxruntime::NodeArg* graphOutput = graph.GetNodeArg(
                 GraphKernelHelper::GetFusedNodeArgNameMatchingGraph(fusedNodeOutputDefs[outputIndex]->Name()));
 
+            THROW_HR_IF_NULL_MSG(FWP_E_NULL_POINTER, graphOutput, "Output tensor arg of a fused node is not present");
             const auto& outputNodeAndIndex = nameToNodeAndIndexMap.at(graphOutput->Name());
 
             DML_OUTPUT_GRAPH_EDGE_DESC edge = {};

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/OperatorRegistration.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/OperatorRegistration.cpp
@@ -325,7 +325,7 @@ constexpr auto requiredConstantCpuInputs(Args... args)
 // element-wise identity operators in the graph for striding support, but issue actual copies 
 // outside the graph.  Element-wise identity currently only supports floating point types.  
 #define REG_INFO_ID(version, operatorName, ...) \
-    #operatorName, OnnxOperatorSet##version::sc_sinceVer_##operatorName, onnxruntime::kOnnxDomain, CreateCopy, ShapeInferenceFunction<ShapeInferenceHelper_##operatorName>, true, true, ##__VA_ARGS__, 
+    #operatorName, OnnxOperatorSet##version::sc_sinceVer_##operatorName, onnxruntime::kOnnxDomain, CreateCopy, ShapeInferenceFunction<ShapeInferenceHelper_##operatorName>, true, false, ##__VA_ARGS__, 
 
 // MS-domain operators
 #define REG_INFO_MS(version, operatorName, ...) \


### PR DESCRIPTION
Motivation:
As part of the OnnxConformance Backend tests, DynamicQuantizedLinear_max_adjusted_expanded is failing. 

Root Cause:

- The test model has `Identity `operator as one of the node. The input of this node is of non-float data type. 
- In DML Identity operator is registered as operator which requires floating input. 
- As per `DirectMLSchema.h`, support for non-float input has been added for Identity operator in DML but the same has not been reflected in the `OperatorRegistration.cpp`.

Changes:

- Changed the `requiresFloatFormatsForGraph` flag to false for Identity and it's related operator.
- Added null check for the `graphOutput` nodeArg in `GraphDescBuilder.cpp` to stop the crash of the test.
