### PR TITLE
[Objective-C API] Add ORTSession methods to get input and output names.

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -507,7 +507,8 @@ struct OrtApi {
                   _Outptr_ OrtTypeInfo** type_info);
 
   /**
-   * \param value  is set to a null terminated string allocated using 'allocator'. The caller is responsible for freeing it.
+   * \param value is set to a null terminated UTF-8 encoded string allocated using 'allocator'.
+   *              The caller is responsible for freeing it.
    */
   ORT_API2_STATUS(SessionGetInputName, _In_ const OrtSession* sess, size_t index, _Inout_ OrtAllocator* allocator,
                   _Outptr_ char** value);

--- a/objectivec/include/ort_session.h
+++ b/objectivec/include/ort_session.h
@@ -73,12 +73,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSArray<NSString*>*)inputNamesWithError:(NSError**)error;
 
 /**
- * Gets the model's overrideable initializer names.
+ * Gets the model's overridable initializer names.
  *
  * @param[out] error Optional error information set if an error occurs.
- * @return An array of overrideable initializer names, or nil if an error occurs.
+ * @return An array of overridable initializer names, or nil if an error occurs.
  */
-- (nullable NSArray<NSString*>*)overrideableInitializerNamesWithError:(NSError**)error;
+- (nullable NSArray<NSString*>*)overridableInitializerNamesWithError:(NSError**)error;
 
 /**
  * Gets the model's output names.

--- a/objectivec/include/ort_session.h
+++ b/objectivec/include/ort_session.h
@@ -64,6 +64,22 @@ NS_ASSUME_NONNULL_BEGIN
                                                    runOptions:(nullable ORTRunOptions*)runOptions
                                                         error:(NSError**)error;
 
+/**
+ * Gets the model's input names.
+ *
+ * @param[out] error Optional error information set if an error occurs.
+ * @return An array of input names, or nil if an error occurs.
+ */
+- (nullable NSArray<NSString*>*)inputNamesWithError:(NSError**)error;
+
+/**
+ * Gets the model's output names.
+ *
+ * @param[out] error Optional error information set if an error occurs.
+ * @return An array of output names, or nil if an error occurs.
+ */
+- (nullable NSArray<NSString*>*)outputNamesWithError:(NSError**)error;
+
 @end
 
 /**

--- a/objectivec/include/ort_session.h
+++ b/objectivec/include/ort_session.h
@@ -73,6 +73,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSArray<NSString*>*)inputNamesWithError:(NSError**)error;
 
 /**
+ * Gets the model's overrideable initializer names.
+ *
+ * @param[out] error Optional error information set if an error occurs.
+ * @return An array of overrideable initializer names, or nil if an error occurs.
+ */
+- (nullable NSArray<NSString*>*)overrideableInitializerNamesWithError:(NSError**)error;
+
+/**
  * Gets the model's output names.
  *
  * @param[out] error Optional error information set if an error occurs.

--- a/objectivec/src/ort_session.mm
+++ b/objectivec/src/ort_session.mm
@@ -16,7 +16,7 @@
 namespace {
 enum class NamedValueType {
   Input,
-  OverrideableInitializer,
+  OverridableInitializer,
   Output,
 };
 }  // namespace
@@ -144,8 +144,8 @@ NS_ASSUME_NONNULL_BEGIN
   return [self namesWithType:NamedValueType::Input error:error];
 }
 
-- (nullable NSArray<NSString*>*)overrideableInitializerNamesWithError:(NSError**)error {
-  return [self namesWithType:NamedValueType::OverrideableInitializer error:error];
+- (nullable NSArray<NSString*>*)overridableInitializerNamesWithError:(NSError**)error {
+  return [self namesWithType:NamedValueType::OverridableInitializer error:error];
 }
 
 - (nullable NSArray<NSString*>*)outputNamesWithError:(NSError**)error {
@@ -160,7 +160,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto getCount = [&session = *_session, namedValueType]() {
       if (namedValueType == NamedValueType::Input) {
         return session.GetInputCount();
-      } else if (namedValueType == NamedValueType::OverrideableInitializer) {
+      } else if (namedValueType == NamedValueType::OverridableInitializer) {
         return session.GetOverridableInitializerCount();
       } else {
         return session.GetOutputCount();
@@ -170,7 +170,7 @@ NS_ASSUME_NONNULL_BEGIN
     auto getName = [&session = *_session, namedValueType](size_t i, OrtAllocator* allocator) {
       if (namedValueType == NamedValueType::Input) {
         return session.GetInputName(i, allocator);
-      } else if (namedValueType == NamedValueType::OverrideableInitializer) {
+      } else if (namedValueType == NamedValueType::OverridableInitializer) {
         return session.GetOverridableInitializerName(i, allocator);
       } else {
         return session.GetOutputName(i, allocator);

--- a/objectivec/test/ort_session_test.mm
+++ b/objectivec/test/ort_session_test.mm
@@ -147,7 +147,7 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertEqual(cActual, cExpected);
 }
 
-- (void)testGetInputAndOutputNamesOk {
+- (void)testGetNamesOk {
   NSError* err = nil;
   ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
                                               modelPath:[ORTSessionTest getAddModelPath]

--- a/objectivec/test/ort_session_test.mm
+++ b/objectivec/test/ort_session_test.mm
@@ -161,10 +161,10 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertNil(err);
   XCTAssertEqualObjects(inputNames, (@[ @"A", @"B" ]));
 
-  NSArray<NSString*>* overrideableInitializerNames = [session overrideableInitializerNamesWithError:&err];
-  XCTAssertNotNil(overrideableInitializerNames);
+  NSArray<NSString*>* overridableInitializerNames = [session overridableInitializerNamesWithError:&err];
+  XCTAssertNotNil(overridableInitializerNames);
   XCTAssertNil(err);
-  XCTAssertEqualObjects(overrideableInitializerNames, (@[]));
+  XCTAssertEqualObjects(overridableInitializerNames, (@[]));
 
   NSArray<NSString*>* outputNames = [session outputNamesWithError:&err];
   XCTAssertNotNil(outputNames);

--- a/objectivec/test/ort_session_test.mm
+++ b/objectivec/test/ort_session_test.mm
@@ -147,6 +147,28 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertEqual(cActual, cExpected);
 }
 
+- (void)testGetInputAndOutputNamesOk {
+  NSError* err = nil;
+  ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
+                                              modelPath:[ORTSessionTest getAddModelPath]
+                                         sessionOptions:[ORTSessionTest makeSessionOptions]
+                                                  error:&err];
+  XCTAssertNotNil(session);
+  XCTAssertNil(err);
+
+  NSArray<NSString*>* inputNames = [session inputNamesWithError:&err];
+  XCTAssertNotNil(inputNames);
+  XCTAssertNil(err);
+
+  XCTAssertEqualObjects(inputNames, (@[ @"A", @"B" ]));
+
+  NSArray<NSString*>* outputNames = [session outputNamesWithError:&err];
+  XCTAssertNotNil(outputNames);
+  XCTAssertNil(err);
+
+  XCTAssertEqualObjects(outputNames, (@[ @"C" ]));
+}
+
 - (void)testInitFailsWithInvalidPath {
   NSString* invalidModelPath = [ORTSessionTest getTestDataWithRelativePath:@"/invalid/path/to/model.onnx"];
   NSError* err = nil;

--- a/objectivec/test/ort_session_test.mm
+++ b/objectivec/test/ort_session_test.mm
@@ -159,13 +159,16 @@ NS_ASSUME_NONNULL_BEGIN
   NSArray<NSString*>* inputNames = [session inputNamesWithError:&err];
   XCTAssertNotNil(inputNames);
   XCTAssertNil(err);
-
   XCTAssertEqualObjects(inputNames, (@[ @"A", @"B" ]));
+
+  NSArray<NSString*>* overrideableInitializerNames = [session overrideableInitializerNamesWithError:&err];
+  XCTAssertNotNil(overrideableInitializerNames);
+  XCTAssertNil(err);
+  XCTAssertEqualObjects(overrideableInitializerNames, (@[]));
 
   NSArray<NSString*>* outputNames = [session outputNamesWithError:&err];
   XCTAssertNotNil(outputNames);
   XCTAssertNil(err);
-
   XCTAssertEqualObjects(outputNames, (@[ @"C" ]));
 }
 


### PR DESCRIPTION
**Description**
Add ORTSession methods to get input and output names.

**Motivation and Context**
API usability.