### PR TITLE
Fix boost download url

### DIFF
--- a/cgmanifests/cgmanifest.json
+++ b/cgmanifests/cgmanifest.json
@@ -171,7 +171,7 @@
             "Other": {
                "Name": "Boost",
                "Version": "1.69.0",
-               "DownloadUrl": "http://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2"
+               "DownloadUrl": "https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.bz2"
             }
          }
       },
@@ -462,12 +462,12 @@
       },
       {
          "component": {
-           "type": "git",
-           "git": {
-             "commitHash": "e1e11e0d555c08bec08a6c7773aa777dfcaae9da",
-             "repositoryUrl": "https://github.com/dmlc/dlpack.git"
-           },
-           "comments": "dlpack"
+            "type": "git",
+            "git": {
+               "commitHash": "e1e11e0d555c08bec08a6c7773aa777dfcaae9da",
+               "repositoryUrl": "https://github.com/dmlc/dlpack.git"
+            },
+            "comments": "dlpack"
          }
       }
    ],

--- a/server/get_boost.cmake
+++ b/server/get_boost.cmake
@@ -70,7 +70,7 @@ macro(DOWNLOAD_BOOST)
   include(ExternalProject)
   ExternalProject_Add(
       Boost
-      URL http://dl.bintray.com/boostorg/release/${BOOST_REQUESTED_VERSION}/source/boost_${BOOST_REQUESTED_VERSION_UNDERSCORE}.tar.bz2
+      URL https://boostorg.jfrog.io/artifactory/main/release/${BOOST_REQUESTED_VERSION}/source/boost_${BOOST_REQUESTED_VERSION_UNDERSCORE}.tar.bz2
       URL_HASH SHA256=${BOOST_SHA1}
       DOWNLOAD_DIR ${BOOST_ROOT_DIR}
       SOURCE_DIR ${BOOST_ROOT_DIR}


### PR DESCRIPTION
**Description**: Fix boost download url

**Motivation and Context**
- Bintray is being decommissioned, this will case build failure of ORT in the future, move boost download url to new official address, see https://www.boost.org/users/news/boost_has_moved_downloads_to_jfr.html
