### PR TITLE
Fix duplicated node name in transformer optimizer

### DIFF
--- a/onnxruntime/python/tools/quantization/onnx_model.py
+++ b/onnxruntime/python/tools/quantization/onnx_model.py
@@ -7,7 +7,6 @@ from pathlib import Path
 class ONNXModel:
     def __init__(self, model):
         self.model = model
-        self.node_name_counter = {}
 
     def nodes(self):
         return self.model.graph.node

--- a/onnxruntime/python/tools/transformers/fusion_layernorm.py
+++ b/onnxruntime/python/tools/transformers/fusion_layernorm.py
@@ -112,7 +112,7 @@ class FusionLayerNormalization(Fusion):
                                           inputs=[node.input[0], weight_input, bias_input],
                                           outputs=[last_add_node.output[0]],
                                           name=self.model.create_node_name("LayerNormalization",
-                                                                           name_prefix="SkipLayerNorm"))
+                                                                           name_prefix="LayerNorm"))
         normalize_node.attribute.extend([helper.make_attribute("epsilon", float(add_weight))])
         self.nodes_to_add.append(normalize_node)
         self.node_name_to_graph_name[normalize_node.name] = self.this_graph_name


### PR DESCRIPTION
**Description**:

Duplicated node name might be generated since create_node_name does not check whether the generated node name exists in graph. Update the logic to make sure node name is unique.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

We found that some optimized graph has duplicated node name "SkipLayerNorm1".