### PR TITLE
Clean up CPU kernel definition for opset 13 Pad

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/pad.cc
+++ b/onnxruntime/core/providers/cpu/tensor/pad.cc
@@ -121,10 +121,7 @@ ONNX_CPU_OPERATOR_KERNEL(
         .TypeConstraint(
             "T",
             BuildKernelDefConstraintsFromTypeList<Pad13Types>(),
-            BuildKernelDefConstraintsFromTypeList<EnabledPad13Types>())
-        .FixedTypeConstraintForHash(
-            "T",
-            BuildKernelDefConstraintsFromTypeList<Pad11Types>()),
+            BuildKernelDefConstraintsFromTypeList<EnabledPad13Types>()),
     Pad);
 
 // This is the general padding method to n-dimensionally do edge or reflection padding (based on the inputDelta values)

--- a/onnxruntime/test/testdata/kernel_def_hashes/onnx.cpu.json
+++ b/onnxruntime/test/testdata/kernel_def_hashes/onnx.cpu.json
@@ -1461,7 +1461,7 @@
     ],
     [
         "Pad ai.onnx CPUExecutionProvider",
-        9596174091174553032
+        12904240253005862936
     ],
     [
         "Pad ai.onnx CPUExecutionProvider",


### PR DESCRIPTION
**Description**: Since we don't guarantee backwards compat yet for kernel def hashes, for this release we cleanup types supported for opset -13 Pad CPU kernel and change expected hash value in the test

**Motivation and Context**
Based on offline discussion for comment in https://github.com/microsoft/onnxruntime/pull/7856
