### PR TITLE
Remove some templated versions of functions that are no longer needed

### DIFF
--- a/include/onnxruntime/core/framework/kernel_def_builder.h
+++ b/include/onnxruntime/core/framework/kernel_def_builder.h
@@ -302,12 +302,6 @@ class KernelDefBuilder {
      Specify that this kernel requires an input arg
      in certain memory type (instead of the default, device memory).
   */
-  template <OrtMemType T>
-  KernelDefBuilder& InputMemoryType(int input_index) {
-    kernel_def_->input_memory_type_args_.insert(std::make_pair(input_index, T));
-    return *this;
-  }
-
   KernelDefBuilder& InputMemoryType(OrtMemType type, int input_index) {
     kernel_def_->input_memory_type_args_.insert(std::make_pair(input_index, type));
     return *this;
@@ -317,14 +311,6 @@ class KernelDefBuilder {
      Specify that this kernel requires input arguments
      in certain memory type (instead of the default, device memory).
   */
-  template <OrtMemType T>
-  KernelDefBuilder& InputMemoryType(const std::vector<int>& input_indexes) {
-    for (auto input_index : input_indexes) {
-      kernel_def_->input_memory_type_args_.insert(std::make_pair(input_index, T));
-    }
-    return *this;
-  }
-
   KernelDefBuilder& InputMemoryType(OrtMemType type, const std::vector<int>& input_indexes) {
     for (auto input_index : input_indexes) {
       kernel_def_->input_memory_type_args_.insert(std::make_pair(input_index, type));
@@ -336,12 +322,6 @@ class KernelDefBuilder {
      Specify that this kernel provides an output arg
      in certain memory type (instead of the default, device memory).
   */
-  template <OrtMemType T>
-  KernelDefBuilder& OutputMemoryType(int output_index) {
-    kernel_def_->output_memory_type_args_.insert(std::make_pair(output_index, T));
-    return *this;
-  }
-
   KernelDefBuilder& OutputMemoryType(OrtMemType type, int output_index) {
     kernel_def_->output_memory_type_args_.insert(std::make_pair(output_index, type));
     return *this;
@@ -351,10 +331,9 @@ class KernelDefBuilder {
      Specify that this kernel provides an output arguments
      in certain memory type (instead of the default, device memory).
   */
-  template <OrtMemType T>
-  KernelDefBuilder& OutputMemoryType(const std::vector<int>& output_indexes) {
+  KernelDefBuilder& OutputMemoryType(OrtMemType type, const std::vector<int>& output_indexes) {
     for (auto output_index : output_indexes) {
-      kernel_def_->output_memory_type_args_.insert(std::make_pair(output_index, T));
+      kernel_def_->output_memory_type_args_.insert(std::make_pair(output_index, type));
     }
     return *this;
   }

--- a/onnxruntime/core/framework/kernel_def_builder.cc
+++ b/onnxruntime/core/framework/kernel_def_builder.cc
@@ -76,7 +76,7 @@ void KernelDef::CalculateHash() {
 
 // TODO: Tell user why it has conflicts
 // TODO: Investigate why IsConflict() was not triggered when there were duplicate Tile CUDA
-// kernels registered. Removing `InputMemoryType<OrtMemTypeCPUInput>(1)` in the kernel definition
+// kernels registered. Removing `InputMemoryType(OrtMemTypeCPUInput, 1)` in the kernel definition
 // triggered the conflict.
 bool KernelDef::IsConflict(const KernelDef& other) const {
   if (op_name_ != other.OpName() || provider_type_ != other.Provider())

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/AbiCustomRegistry.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/AbiCustomRegistry.cpp
@@ -387,11 +387,11 @@ HRESULT STDMETHODCALLTYPE AbiCustomRegistry::RegisterOperatorKernel(
     std::string_view name(opKernel->name);
     if (name == "MemcpyToHost")
     {
-        builder.OutputMemoryType<::OrtMemType::OrtMemTypeCPUOutput>(0);
+        builder.OutputMemoryType(::OrtMemType::OrtMemTypeCPUOutput, 0);
     }
     else if (name == "MemcpyFromHost")
     {
-        builder.InputMemoryType<::OrtMemType::OrtMemTypeCPUInput>(0);
+        builder.InputMemoryType(::OrtMemType::OrtMemTypeCPUInput, 0);
     }
         
     std::vector<uint32_t> constantCpuInputCapture;
@@ -399,7 +399,7 @@ HRESULT STDMETHODCALLTYPE AbiCustomRegistry::RegisterOperatorKernel(
 
     for (uint32_t inputIndex : constantCpuInputCapture)
     {
-        builder.InputMemoryType<::OrtMemType::OrtMemTypeCPUInput>(inputIndex);
+        builder.InputMemoryType(::OrtMemType::OrtMemTypeCPUInput, inputIndex);
     }
 
     if (canAliasFirstInput)

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -42,7 +42,7 @@ ONNX_OPERATOR_KERNEL_EX(
     1,
     kMIGraphXExecutionProvider,
     KernelDefBuilder()
-        .InputMemoryType<OrtMemTypeCPUInput>(0)
+        .InputMemoryType(OrtMemTypeCPUInput, 0)
         .ExecQueueId(kHipStreamCopyIn)
         .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes()),
     Memcpy);
@@ -53,7 +53,7 @@ ONNX_OPERATOR_KERNEL_EX(
     1,
     kMIGraphXExecutionProvider,
     KernelDefBuilder()
-        .OutputMemoryType<OrtMemTypeCPUOutput>(0)
+        .OutputMemoryType(OrtMemTypeCPUOutput, 0)
         .ExecQueueId(kHipStreamCopyOut)
         .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes()),
     Memcpy);

--- a/onnxruntime/core/providers/rknpu/rknpu_execution_provider.cc
+++ b/onnxruntime/core/providers/rknpu/rknpu_execution_provider.cc
@@ -524,7 +524,7 @@ ONNX_OPERATOR_KERNEL_EX(
     1,
     kRknpuExecutionProvider,
     KernelDefBuilder()
-        .InputMemoryType<OrtMemTypeCPUInput>(0)
+        .InputMemoryType(OrtMemTypeCPUInput, 0)
         .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes()),
     Memcpy);
 
@@ -534,7 +534,7 @@ ONNX_OPERATOR_KERNEL_EX(
     1,
     kRknpuExecutionProvider,
     KernelDefBuilder()
-        .OutputMemoryType<OrtMemTypeCPUOutput>(0)
+        .OutputMemoryType(OrtMemTypeCPUOutput, 0)
         .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes()),
     Memcpy);
 

--- a/onnxruntime/core/providers/rocm/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/rocm/reduction/reduction_ops.cc
@@ -122,7 +122,7 @@ namespace rocm {
       T,                                                                        \
       kRocmExecutionProvider,                                                   \
       KernelDefBuilder()                                                        \
-          .InputMemoryType<OrtMemTypeCPUInput>(1)                               \
+          .InputMemoryType(OrtMemTypeCPUInput, 1)                               \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()),               \
       name<T>);
 

--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
@@ -40,7 +40,7 @@ ONNX_OPERATOR_KERNEL_EX(
     1,
     kRocmExecutionProvider,
     KernelDefBuilder()
-        .InputMemoryType<OrtMemTypeCPUInput>(0)
+        .InputMemoryType(OrtMemTypeCPUInput, 0)
         .ExecQueueId(kHipStreamCopyIn)
         .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes()),
     Memcpy);
@@ -51,7 +51,7 @@ ONNX_OPERATOR_KERNEL_EX(
     1,
     kRocmExecutionProvider,
     KernelDefBuilder()
-        .OutputMemoryType<OrtMemTypeCPUOutput>(0)
+        .OutputMemoryType(OrtMemTypeCPUOutput, 0)
         .ExecQueueId(kHipStreamCopyOut)
         .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes()),
     Memcpy);

--- a/orttraining/orttraining/training_ops/cpu/communication/recv.cc
+++ b/orttraining/orttraining/training_ops/cpu/communication/recv.cc
@@ -51,9 +51,9 @@ ONNX_OPERATOR_KERNEL_EX(
     1,
     kCpuExecutionProvider,
     KernelDefBuilder()
-        .InputMemoryType<OrtMemTypeDefault>(0)  /* CPU variable */
-        .InputMemoryType<OrtMemTypeDefault>(1)  /* CPU variable */
-        .OutputMemoryType<OrtMemTypeDefault>(0) /* CPU variable */
+        .InputMemoryType(OrtMemTypeDefault, 0)  /* CPU variable */
+        .InputMemoryType(OrtMemTypeDefault, 1)  /* CPU variable */
+        .OutputMemoryType(OrtMemTypeDefault, 0) /* CPU variable */
         .TypeConstraint("TBool", DataTypeImpl::GetTensorType<bool>())
         .TypeConstraint("TInt64", DataTypeImpl::GetTensorType<int64_t>())
         .TypeConstraint("V", DataTypeImpl::AllFixedSizeTensorTypes()),

--- a/orttraining/orttraining/training_ops/cpu/communication/send.cc
+++ b/orttraining/orttraining/training_ops/cpu/communication/send.cc
@@ -17,9 +17,9 @@ ONNX_OPERATOR_KERNEL_EX(
     1,
     kCpuExecutionProvider,
     KernelDefBuilder()
-        .InputMemoryType<OrtMemTypeDefault>(0)  /* CPU variable */
-        .InputMemoryType<OrtMemTypeDefault>(1)  /* CPU variable */
-        .OutputMemoryType<OrtMemTypeDefault>(0) /* CPU variable */
+        .InputMemoryType(OrtMemTypeDefault, 0)  /* CPU variable */
+        .InputMemoryType(OrtMemTypeDefault, 1)  /* CPU variable */
+        .OutputMemoryType(OrtMemTypeDefault, 0) /* CPU variable */
         .TypeConstraint("TBool", DataTypeImpl::GetTensorType<bool>())
         .TypeConstraint("TInt64", DataTypeImpl::GetTensorType<int64_t>())
         .TypeConstraint("V", DataTypeImpl::AllFixedSizeTensorTypes()),

--- a/orttraining/orttraining/training_ops/rocm/reduction/reduction_ops.cc
+++ b/orttraining/orttraining/training_ops/rocm/reduction/reduction_ops.cc
@@ -22,7 +22,7 @@ namespace rocm {
       T,                                                          \
       kRocmExecutionProvider,                                     \
       KernelDefBuilder()                                          \
-          .InputMemoryType<OrtMemTypeCPUInput>(1)                 \
+          .InputMemoryType(OrtMemTypeCPUInput, 1)                 \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
       name<T>);
 


### PR DESCRIPTION
**Description**: My previous shared provider changes mostly switched away from these templated functions, so there were only a few cases left to remove.

**Motivation and Context**
There was no real need for the templated version when the constant value could be passed as a parameter, so best to have just the single version.