### PR TITLE
Cleanup reference holding logic while trying to binding model inputs using numpy objects

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -355,7 +355,7 @@ class IOBinding:
     '''
     def __init__(self, session):
         self._iobinding = C.SessionIOBinding(session._sess)
-        self._numpy_obj_references = []
+        self._numpy_obj_references = {}
 
     def bind_cpu_input(self, name, arr_on_cpu):
         '''
@@ -366,7 +366,7 @@ class IOBinding:
         # Hold a reference to the numpy object as the bound OrtValue is backed
         # directly by the data buffer of the numpy object and so the numpy object
         # must be around until this IOBinding instance is around
-        self._numpy_obj_references.append(arr_on_cpu)
+        self._numpy_obj_references[name] = arr_on_cpu
         self._iobinding.bind_input(name, arr_on_cpu)
 
     def bind_input(self, name, device_type, device_id, element_type, shape, buffer_ptr):


### PR DESCRIPTION
**Description**: While binding model inputs with numpy objects using `bind_cpu_input()` we hold onto a reference to the numpy object because the underlying OrtValue may be backed directly by the numpy object's data buffer and we want to tie the lifetime of the numpy object to atleast the lifetime of the IOBinding instance. These references are held in a list. The problem with this is that if the same model input is re-bound to another numpy object, we still hold onto the earlier numpy object's reference which would keep the earlier numpy object around until the lifetime of the IOBinding instance even if unused elsewhere. This change uses a dictionary to hold references instead of a list and the scenario of re-binding of the same input is better handled now.

**Motivation and Context**
Small takeaway from https://github.com/microsoft/onnxruntime/issues/7611 