### PR TITLE
Added virtual destructor to adasum_interface.h

### DIFF
--- a/orttraining/orttraining/core/framework/adasum/adasum_interface.h
+++ b/orttraining/orttraining/core/framework/adasum/adasum_interface.h
@@ -60,6 +60,8 @@ class AdasumInterface {
 
   virtual const Communicator_type* GetReductionComms() = 0;
 
+  virtual ~AdasumInterface() = default;
+
  protected:
   // Communication primitives required for Adasum algorithm
   virtual void PointToPointSendRecv(void* input_data_buffer,


### PR DESCRIPTION
**Description**: Added Virtual destructor to AdasumInterface

**Motivation and Context**
When building on Ubuntu 20.04 with --mpi_home and --use_mpi flags this warning is firing. Since I have warnings as errors it is failing my build.

In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/memory:83:
/usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/unique_ptr.h:85:2: error: delete called on non-final 'onnxruntime::training::AdasumMPI' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/unique_ptr.h:361:4: note: in instantiation of member function 'std::default_delete<onnxruntime::training::AdasumMPI>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/chandru/repos/onnxruntime-pytorch/external/onnxruntime/orttraining/orttraining/training_ops/cpu/collective/adasum_kernels.h:14:3: note: in instantiation of member function 'std::unique_ptr<onnxruntime::training::AdasumMPI, std::default_delete<onnxruntime::training::AdasumMPI> >::~unique_ptr' requested here
  AdasumAllReduce(const OpKernelInfo& info) : OpKernel(info) {
  ^
1 error generated.