### PR TITLE
Update requirements.txt: a quick fix to help the training team overcome numpy version mismatch problem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy >= 1.16.6
+numpy >= 1.19.5
 protobuf
 flatbuffers


### PR DESCRIPTION
**Description**: 

If your code was built with numpy version A, then at runtime it requires at least number version >=A. It's like if your code was built with CUDA 11.2, then we need to tell our customer it requires CUDA version >=11.2. And 11.1 doesn't work. Otherwise it could crash.


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
