### PR TITLE
add emsdk to component detection ignore dir

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
@@ -12,4 +12,6 @@ steps:
           and(eq('${{parameters.condition}}', 'always'), always())),
           and(eq('${{parameters.condition}}', 'succeeded'), succeeded()))
   inputs:
-    ignoreDirectories: '$(Build.SourcesDirectory)/cmake/external/tvm/3rdparty/dmlc-core/tracker' # ignore dmlc-core tracker for its CI, which is not used in onnxruntime build
+    # ignore dmlc-core tracker for its CI, which is not used in onnxruntime build
+    # ignore emsdk. emsdk is used to prepare toolsets for building WebAssembly. It is not a part of onnxruntime source code.
+    ignoreDirectories: '$(Build.SourcesDirectory)/cmake/external/tvm/3rdparty/dmlc-core/tracker,$(Build.SourcesDirectory)/cmake/external/emsdk'

--- a/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
@@ -13,5 +13,5 @@ steps:
           and(eq('${{parameters.condition}}', 'succeeded'), succeeded()))
   inputs:
     # ignore dmlc-core tracker for its CI, which is not used in onnxruntime build
-    # ignore emsdk. emsdk is used to prepare toolsets for building WebAssembly. It is not a part of onnxruntime source code.
-    ignoreDirectories: '$(Build.SourcesDirectory)/cmake/external/tvm/3rdparty/dmlc-core/tracker,$(Build.SourcesDirectory)/cmake/external/emsdk'
+    # ignore unit tests in emscripten. emscripten unit tests are not used in onnxruntime build
+    ignoreDirectories: '$(Build.SourcesDirectory)/cmake/external/tvm/3rdparty/dmlc-core/tracker,$(Build.SourcesDirectory)/cmake/external/emsdk/upstream/emscripten/tests'


### PR DESCRIPTION
**Description**: currently folder `cmake/external/emsdk` is reported by Component Governance for security alerts in our CI. those security alerts are about out-of-dated NPM packages inside this folder, defined in the pacakge.json files. Those package.json files are downloaded by emsdk using `emsdk install <version>`:
( for emsdk v2.0.23, we have 2 alerts )
- ~y18n 4.0.0 : under  `cmake/external/emsdk/node/14.15.5_64bit/bin/node_modules/npm/node_modules/y18n/package.json`
  Node.js v14.15.5 is downloaded by emsdk for running emscripten (the compiler toolset for compiling ORT into WebAssembly). it is not a part of source code of ONNX Runtime.~ ( UPDATE: don't ignore this )
- ws 0.8.0: under `cmake/external/emsdk/upstream/emscripten/tests/sockets/ws/package.json`
  We don't run emscripten's test; we don't even build emscripten from source. we use the official emscripten prebuilt package.

In general, security alerts for folder `cmake/external/emsdk` does not apply to ORT and can be safely ignored.