### PR TITLE
[wasm] allows to specify MALLOC setting for webassembly build

### DIFF
--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -51,6 +51,7 @@ set_target_properties(onnxruntime_webassembly PROPERTIES LINK_FLAGS "           
                       -s LLD_REPORT_UNDEFINED                                                 \
                       -s VERBOSE=0                                                            \
                       -s NO_FILESYSTEM=1                                                      \
+                      -s MALLOC=${onnxruntime_WEBASSEMBLY_MALLOC}                             \
                       --no-entry")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -346,6 +346,8 @@ def parse_arguments():
     parser.add_argument(
         "--enable_wasm_debug_info", action='store_true',
         help="Build WebAssembly with DWARF format debug info")
+    parser.add_argument(
+        "--wasm_malloc", default="dlmalloc", help="Specify memory allocator for WebAssembly")
 
     # Arguments needed by CI
     parser.add_argument(
@@ -750,6 +752,7 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
                                                                   else "ON"),
         "-Donnxruntime_ENABLE_WEBASSEMBLY_THREADS=" + ("ON" if args.enable_wasm_threads else "OFF"),
         "-Donnxruntime_ENABLE_WEBASSEMBLY_DEBUG_INFO=" + ("ON" if args.enable_wasm_debug_info else "OFF"),
+        "-Donnxruntime_WEBASSEMBLY_MALLOC=" + args.wasm_malloc,
         "-Donnxruntime_ENABLE_EAGER_MODE=" + ("ON" if args.build_eager_mode else "OFF"),
     ]
 


### PR DESCRIPTION
**Description**: allow to specify emcc's setting MALLOC: https://github.com/emscripten-core/emscripten/blob/main/src/settings.js#L118-L138

example usage: `./build.sh --build_wasm --wasm_malloc=emmalloc`