### PR TITLE
Docs: Add new package links

### DIFF
--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -37,8 +37,8 @@ The following build variants are available as officially supported packages. Oth
 |Java|CPU: [**com.microsoft.onnxruntime:onnxruntime**](https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime)|
 ||GPU: [**com.microsoft.onnxruntime:onnxruntime_gpu**](https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime_gpu)|
 |Android|[**com.microsoft.onnxruntime:onnxruntime-mobile**](https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime-mobile) ||
-|iOS (C/C++)|CocoaPods: `onnxruntime-mobile-c`||
-|Objective-C|CocoaPods: `onnxruntime-mobile-objc`||
+|iOS (C/C++)|CocoaPods: **onnxruntime-mobile-c**||
+|Objective-C|CocoaPods: **onnxruntime-mobile-objc**||
 |Node.js|[**onnxruntime-node**](https://www.npmjs.com/package/onnxruntime)|
 |Web|[**onnxruntime-web**](https://www.npmjs.com/package/onnxruntime-web)||
 

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -25,16 +25,23 @@ The following build variants are available as officially supported packages. Oth
 2. GPU Provider - NVIDIA CUDA
 3. GPU Provider - [DirectML](../reference/execution-providers/DirectML-ExecutionProvider.md) (Windows) - *recommended for optimized performance and compatibility with a broad set of GPUs on Windows devices*
 
-|Repository|Official build|Nightly build|
+||Official build|Nightly build|
 |---|---|---|
 |Python|If using pip, run `pip install --upgrade pip` prior to downloading.||
 ||CPU: [**onnxruntime**](https://pypi.org/project/onnxruntime)| [ort-nightly (dev)](https://test.pypi.org/project/ort-nightly)|
 ||GPU: [**onnxruntime-gpu**](https://pypi.org/project/onnxruntime-gpu) | [ort-gpu-nightly (dev)](https://test.pypi.org/project/ort-gpu-nightly)|
 |C#/C/C++|CPU: [**Microsoft.ML.OnnxRuntime**](https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime) | [ort-nightly (dev)](https://aiinfra.visualstudio.com/PublicPackages/_packaging?_a=feed&feed=ORT-Nightly)|
-||GPU: [**Microsoft.ML.OnnxRuntime.Gpu**](https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.gpu)|[ort-nightly (dev)](https://aiinfra.visualstudio.com/PublicPackages/_packaging?_a=feed&feed=ORT-Nightly)|
-|Java|CPU: [**com.microsoft.onnxruntime/onnxruntime**](https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime)|
-||GPU: [**com.microsoft.onnxruntime/onnxruntime_gpu**](https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime_gpu)|
-|nodejs|CPU: [**onnxruntime**](https://www.npmjs.com/package/onnxruntime)|
+||GPU - CUDA: [**Microsoft.ML.OnnxRuntime.Gpu**](https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.gpu)|[ort-nightly (dev)](https://aiinfra.visualstudio.com/PublicPackages/_packaging?_a=feed&feed=ORT-Nightly)|
+||GPU - DirectML: [**Microsoft.ML.OnnxRuntime.DirectML**](https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.DirectML)|[ort-nightly (dev)](https://aiinfra.visualstudio.com/PublicPackages/_packaging?_a=feed&feed=ORT-Nightly)|
+|WinML|[**Microsoft.AI.MachineLearning**](https://www.nuget.org/packages/Microsoft.AI.MachineLearning)||
+|Java|CPU: [**com.microsoft.onnxruntime:onnxruntime**](https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime)|
+||GPU: [**com.microsoft.onnxruntime:onnxruntime_gpu**](https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime_gpu)|
+|Android|[**com.microsoft.onnxruntime:onnxruntime-mobile**](https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime-mobile) ||
+|iOS (C/C++)|CocoaPods: `onnxruntime-mobile-c`||
+|Objective-C|CocoaPods: `onnxruntime-mobile-objc`||
+|Node.js|[**onnxruntime-node**](https://www.npmjs.com/package/onnxruntime)|
+|Web|[**onnxruntime-web**](https://www.npmjs.com/package/onnxruntime-web)||
+
 
 
 *Note: Dev builds created from the master branch are available for testing newer changes between official releases. Please use these at your own risk. We strongly advise against deploying these to production workloads as support is limited for dev builds.*
@@ -51,4 +58,8 @@ by running `locale-gen en_US.UTF-8` and `update-locale LANG=en_US.UTF-8`
 
 
 ## Training
-*COMING SOON*
+||Official build|Nightly build|
+|---|---|---|
+|PyTorch (CUDA 10.2)|[**onnxruntime-training**](https://pypi.org/project/onnxruntime-training)|[onnxruntime_nightly_cu102](https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_nightly_cu102.html)|
+|PyTorch (CUDA 11.1)|[**onnxruntime_stable_cu111**](https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_stable_cu111.html)|[onnxruntime_nightly_cu111](https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_nightly_cu111.html)|
+|[*Preview*] PyTorch (ROCm 4.2)|[**onnxruntime_stable_rocm42**](https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_stable_rocm42.html)|[onnxruntime_nightly_rocm42](https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_nightly_rocm42.html)|

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -58,6 +58,7 @@ by running `locale-gen en_US.UTF-8` and `update-locale LANG=en_US.UTF-8`
 
 
 ## Training
+ 
 ||Official build|Nightly build|
 |---|---|---|
 |PyTorch (CUDA 10.2)|[**onnxruntime-training**](https://pypi.org/project/onnxruntime-training)|[onnxruntime_nightly_cu102](https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_nightly_cu102.html)|

--- a/js/script.js
+++ b/js/script.js
@@ -1038,7 +1038,7 @@ var validCombos = {
         "Follow build instructions from <a href='https://aka.ms/build-ort-ios' target='_blank'>here</a>",
     
     "ios,objectivec,ARM64,DefaultCPU":
-        "<i>Coming soon!</i>",
+        "Add 'onnxruntime-mobile-objc' using CocoaPods",
     
     "windows,Python,X86,VitisAI":
         "Follow build instructions from <a href='https://aka.ms/build-ort-vitisai' target='_blank'>here</a>",


### PR DESCRIPTION
Adds new links to training packages: https://faxu.github.io/onnxruntime/docs/how-to/install.html#training

Adds objc cocoapods pkg name on install matrix: https://faxu.github.io/onnxruntime