### PR TITLE
[wasm] bugfix for emscripten '--preload-file' under node.js

### DIFF
--- a/tools/ci_build/wasm/file_packager.py.patch
+++ b/tools/ci_build/wasm/file_packager.py.patch
@@ -524,8 +524,8 @@ def main():
       var PACKAGE_PATH = '';
       if (typeof window === 'object') {
         PACKAGE_PATH = window['encodeURIComponent'](window.location.pathname.toString().substring(0, window.location.pathname.toString().lastIndexOf('/')) + '/');
-      } else if (typeof location !== 'undefined') {
-        // worker
+      } else if (typeof process === 'undefined' && typeof location !== 'undefined') {
+        // web worker
         PACKAGE_PATH = encodeURIComponent(location.pathname.toString().substring(0, location.pathname.toString().lastIndexOf('/')) + '/');
       }
       var PACKAGE_NAME = '%s';


### PR DESCRIPTION
**Description**: This change update latest change https://github.com/emscripten-core/emscripten/pull/14372 of `file_packager.py.patch` as a patch to file `file_packager.py` from emsdk v2.0.23. This change fixes emscripten '--preload-file' under node.js for worker_threads.

This change fixes unit test in multi-threaded WebAssembly build.