### PR TITLE
Update build.py: change default cmake generator for Windows to VS2019

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -427,7 +427,7 @@ def parse_arguments():
     parser.add_argument(
         "--cmake_generator",
         choices=['Visual Studio 15 2017', 'Visual Studio 16 2019', 'Ninja'],
-        default='Visual Studio 15 2017' if is_windows() else None,
+        default='Visual Studio 16 2019' if is_windows() else None,
         help="Specify the generator that CMake invokes. "
         "This is only supported on Windows")
     parser.add_argument(


### PR DESCRIPTION
VS 2019 is well tested. VS 2017 is not. 

We should make "Visual Studio 16 2019" as the default to not confuse people.

**Description**: Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
