### PR TITLE
[wasm] fix test report generation

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -87,8 +87,14 @@ function(AddTest)
   set(TEST_ARGS)
   if (onnxruntime_GENERATE_TEST_REPORTS)
     # generate a report file next to the test program
-    list(APPEND TEST_ARGS
-      "--gtest_output=xml:$<SHELL_PATH:$<TARGET_FILE:${_UT_TARGET}>.$<CONFIG>.results.xml>")
+    if (onnxruntime_BUILD_WEBASSEMBLY)
+      # WebAssembly use a memory file system, so we do not use full path
+      list(APPEND TEST_ARGS
+        "--gtest_output=xml:$<TARGET_FILE_NAME:${_UT_TARGET}>.$<CONFIG>.results.xml")
+    else()
+      list(APPEND TEST_ARGS
+        "--gtest_output=xml:$<SHELL_PATH:$<TARGET_FILE:${_UT_TARGET}>.$<CONFIG>.results.xml>")
+    endif()
   endif(onnxruntime_GENERATE_TEST_REPORTS)
 
   if (${CMAKE_SYSTEM_NAME} STREQUAL "iOS")
@@ -663,10 +669,10 @@ if (onnxruntime_USE_ROCM)
   target_include_directories(onnxruntime_test_all PRIVATE  ${onnxruntime_ROCM_HOME}/hipfft/include ${onnxruntime_ROCM_HOME}/include ${onnxruntime_ROCM_HOME}/hiprand/include ${onnxruntime_ROCM_HOME}/rocrand/include ${CMAKE_CURRENT_BINARY_DIR}/amdgpu/onnxruntime ${CMAKE_CURRENT_BINARY_DIR}/amdgpu/orttraining)
 endif()
 if (onnxruntime_BUILD_WEBASSEMBLY)
+  set_target_properties(onnxruntime_test_all PROPERTIES LINK_DEPENDS ${TEST_SRC_DIR}/wasm/dump-test-result-in-nodejs.js)
+  set_target_properties(onnxruntime_test_all PROPERTIES LINK_FLAGS "-s ALLOW_MEMORY_GROWTH=1 --pre-js \"${TEST_SRC_DIR}/wasm/dump-test-result-in-nodejs.js\" -s \"EXPORTED_RUNTIME_METHODS=['FS']\" --preload-file ${CMAKE_CURRENT_BINARY_DIR}/testdata@/testdata -s EXIT_RUNTIME=1")
   if (onnxruntime_ENABLE_WEBASSEMBLY_THREADS)
-    set_target_properties(onnxruntime_test_all PROPERTIES LINK_FLAGS "-s ALLOW_MEMORY_GROWTH=1 --preload-file ${CMAKE_CURRENT_BINARY_DIR}/testdata@/testdata -s USE_PTHREADS=1 -s PROXY_TO_PTHREAD=1 -s EXIT_RUNTIME=1")
-  else()
-    set_target_properties(onnxruntime_test_all PROPERTIES LINK_FLAGS "-s ALLOW_MEMORY_GROWTH=1 --preload-file ${CMAKE_CURRENT_BINARY_DIR}/testdata@/testdata -s EXIT_RUNTIME=1")
+    set_property(TARGET onnxruntime_test_all APPEND_STRING PROPERTY LINK_FLAGS " -s USE_PTHREADS=1 -s PROXY_TO_PTHREAD=1")
   endif()
 endif()
 

--- a/onnxruntime/test/wasm/dump-test-result-in-nodejs.js
+++ b/onnxruntime/test/wasm/dump-test-result-in-nodejs.js
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// This file is used to be injected into "onnxruntime_test_all" as specified by flag "--pre-js" by emcc.
+// It dumps the test report file from emscripten's MEMFS to real file system
+
+// Module is predefined for scripts injected from "--pre-js"
+(function () {
+    if (typeof process !== 'undefined') {
+        // check for flag "--gtest_output=xml:"
+        const argGtestOutputPrefix = '--gtest_output=xml:';
+
+        for (const arg of process.argv) {
+            if (arg.startsWith(argGtestOutputPrefix)) {
+                const filename = arg.substring(argGtestOutputPrefix.length);
+                if (filename) {
+                    Module["onExit"] = function () {
+                        // read test output from MEMFS and write to real file system.
+                        const filedata = Module.FS.readFile(filename);
+                        require('fs').writeFileSync(filename, filedata);
+                    };
+                }
+                break;
+            }
+        }
+    }
+})();
+

--- a/tools/ci_build/github/azure-pipelines/win-wasm-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-wasm-ci-pipeline.yml
@@ -103,7 +103,7 @@ jobs:
       testResultsFiles: '**/*.results.xml'
       searchFolder: '$(Build.BinariesDirectory)'
       testRunTitle: 'Unit Test Run'
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), eq(variables['BuildConfig'], 'Debug'))
   - template: templates/component-governance-component-detection-steps.yml
     parameters :
       condition : 'succeeded'


### PR DESCRIPTION
**Description**: Fixes test report generation for `onnxruntime_test_all` in WebAssembly build.

background: WebAssembly cannot access real file system, so emscripten implemented a memory file system (MEMFS) as a simulation of filesystem. This works with a feature called "preload file", which packs all test data into one file (onnxruntime_test_all.data) and load it in runtime to use test data. However, this system does not output the test report to real file system.

this change uses a js file to inject into the generated test javascript source, using "--pre-js" of emcc. In this js file, we write the test report stored in MEMFS and write it to real file system in Node.js. for browser, this is a no-op.