### PR TITLE
Override ORTModule named_modules to support extra arg

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -182,10 +182,12 @@ class ORTModule(torch.nn.Module):
 
         yield from self._module_metadata.original_module.modules()
 
-    def named_modules(self, memo: Optional[Set['Module']] = None, prefix: str = ''):
+    def named_modules(self, memo: Optional[Set['Module']] = None, prefix: str = '', **kwargs):
         """Override original method to delegate execution to the original PyTorch user module"""
 
-        yield from self._module_metadata.original_module.named_modules(memo, prefix)
+        # PyTorch >1.8.1 has an extra arg remove_duplicate that is not present in 1.8.1
+        # To support both, use kwargs
+        yield from self._module_metadata.original_module.named_modules(memo, prefix, **kwargs)
 
     def add_module(self, name: str, module: Optional['Module']) -> None:
         """Raises a NotImplementedError exception since ORTModule does not support adding modules to it"""

--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -182,12 +182,12 @@ class ORTModule(torch.nn.Module):
 
         yield from self._module_metadata.original_module.modules()
 
-    def named_modules(self, memo: Optional[Set['Module']] = None, prefix: str = '', **kwargs):
+    def named_modules(self, *args, **kwargs):
         """Override original method to delegate execution to the original PyTorch user module"""
 
         # PyTorch >1.8.1 has an extra arg remove_duplicate that is not present in 1.8.1
-        # To support both, use kwargs
-        yield from self._module_metadata.original_module.named_modules(memo, prefix, **kwargs)
+        # To support both, use args and kwargs (since user can call the method with only positional args or kwargs)
+        yield from self._module_metadata.original_module.named_modules(*args, **kwargs)
 
     def add_module(self, name: str, module: Optional['Module']) -> None:
         """Raises a NotImplementedError exception since ORTModule does not support adding modules to it"""


### PR DESCRIPTION
```PyTorch``` > 1.8.1 introduced another argument in ```named_modules``` called ```remove_duplicate```. It is possible that the user might call this method (or PyTorch itself might depend on this method) requiring the extra arg.
A recent example that @ytaous provided was where the ```named_modules``` was being called by proving the inputs as only positional arguments (although they are defined as keyword args). This would result in an exception being raised:
```sh
TypeError: named_modules() takes from 1 to 3 positional arguments but 4 were given
```

To resolve this and support versions >= 1.8.1, we use ```*args, **kwargs``` in the method signature.