### PR TITLE
python with DmlExecutionProvider : choose device_id in SessionOptions

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -617,7 +617,18 @@ static void RegisterExecutionProviders(InferenceSession* sess, const std::vector
 #endif
     } else if (type == kDmlExecutionProvider) {
 #ifdef USE_DML
-      RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_DML(0));
+      int device_id = 0;
+      auto it = provider_options_map.find(type);
+      if (it != provider_options_map.end()) {
+        for (auto option : it->second) {
+          if (option.first == "device_id") {
+            if (!option.second.empty()) {
+              device_id = std::stoi(option.second);
+            }
+          }
+        }
+      }
+      RegisterExecutionProvider(sess, *onnxruntime::CreateExecutionProviderFactory_DML(device_id));
 #endif
     } else if (type == kNnapiExecutionProvider) {
 #if defined(USE_NNAPI)


### PR DESCRIPTION
**Description**: python with DmlExecutionProvider : choose device_id in SessionOptions

**Motivation and Context**

- Why is this change required? What problem does it solve?

problem to choose DML device from python

- If it fixes an open issue, please link to the issue here.

https://github.com/microsoft/onnxruntime/issues/7963
