### PR TITLE
Accept success codes other than S_OK in RoInitialize

### DIFF
--- a/winml/test/api/RawApiTests.cpp
+++ b/winml/test/api/RawApiTests.cpp
@@ -24,7 +24,7 @@ auto CreateModelAsBuffer(const wchar_t* model_path)
 }
 
 static void RawApiTestsApiTestsClassSetup() {
-  WINML_EXPECT_HRESULT_SUCCEEDED(RoInitialize(RO_INIT_TYPE::RO_INIT_SINGLETHREADED));
+  WINML_EXPECT_TRUE(SUCCEEDED(RoInitialize(RO_INIT_TYPE::RO_INIT_SINGLETHREADED)));
 }
 
 static void CreateModelFromFilePath() {

--- a/winml/test/api/RawApiTests.cpp
+++ b/winml/test/api/RawApiTests.cpp
@@ -24,7 +24,7 @@ auto CreateModelAsBuffer(const wchar_t* model_path)
 }
 
 static void RawApiTestsApiTestsClassSetup() {
-  WINML_EXPECT_TRUE(SUCCEEDED(RoInitialize(RO_INIT_TYPE::RO_INIT_SINGLETHREADED)));
+  WINML_EXPECT_HRESULT_SUCCEEDED(RoInitialize(RO_INIT_TYPE::RO_INIT_MULTITHREADED));
 }
 
 static void CreateModelFromFilePath() {

--- a/winml/test/api/RawApiTestsGpu.cpp
+++ b/winml/test/api/RawApiTestsGpu.cpp
@@ -101,7 +101,7 @@ ml::learning_model_device CreateDevice(DeviceType deviceType)
 }
 
 static void RawApiTestsGpuApiTestsClassSetup() {
-  WINML_EXPECT_HRESULT_SUCCEEDED(RoInitialize(RO_INIT_TYPE::RO_INIT_SINGLETHREADED));
+  WINML_EXPECT_HRESULT_SUCCEEDED(RoInitialize(RO_INIT_TYPE::RO_INIT_MULTITHREADED));
 }
 
 static void CreateDirectXDevice() {


### PR DESCRIPTION
There are test failures due to `RoInitialize` returning S_FALSE when the apartment was already initialized, if you ran other tests in the same process. This change makes both S_OK and S_FALSE pass.