### PR TITLE
Update Dnnl ConvGrad op to properly handle optional outputs

### DIFF
--- a/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
@@ -16,8 +16,7 @@ DnnlOpManager::DnnlOpManager() {
   dnnl_ops_map_.emplace(std::make_pair("Relu", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Sum", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));
 #if defined(ENABLE_TRAINING)
-  // TODO re-enable ConvGrad currently there is a bug in the ConvGrad code bug was not known till after PR7083
-  //dnnl_ops_map_.emplace(std::make_pair("ConvGrad", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("ConvGrad", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("ReluGrad", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("MaxPoolGrad", std::unique_ptr<DnnlNodeCapability>(new DnnlPoolNodeCapability())));
 #endif  // ENABLE_TRAINING

--- a/onnxruntime/core/providers/dnnl/subgraph/subgraph.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/subgraph.h
@@ -31,13 +31,17 @@ struct DnnlNode {
 #ifdef ENABLE_TRAINING
   int num_outputs = 0;  // how many outputs
   std::vector<std::string> output_names;
+  // num_outputs will equal the number of required outputs while is_ort_output_required
+  // will have a true or false entry for each ORT output. The number of true entries
+  // must equal the num_outputs.
+  std::vector<bool> is_ort_output_required;
 #endif  // ENABLE_TRAINING
   std::vector<size_t> parent_nodes;  // index to parents in vector mklnodes
 
 #ifdef ENABLE_TRAINING
-  onnxruntime::NodeIndex onnx_index; // the index of the onnx runtime node
+  onnxruntime::NodeIndex onnx_index;   // the index of the onnx runtime node
   std::vector<InputNode> input_nodes;  // index and node name of the onnx runtime input nodes to this node
-#endif  //ENABLE_TRAINING
+#endif  // ENABLE_TRAINING
 
   std::string ToString() const {
     std::string key;

--- a/orttraining/orttraining/test/gradient/gradient_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/gradient_ops_test.cc
@@ -1055,15 +1055,16 @@ void ConvGradientCheckerTest(std::vector<std::unique_ptr<IExecutionProvider>>* e
 
 TEST(GradientCheckerTest, ConvGrad) {
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+#ifdef USE_DNNL
+  // DNNL execution provider will not run unless it is listed before the cpu execution provider
+  execution_providers.push_back(DefaultDnnlExecutionProvider());
+#endif
+
   execution_providers.push_back(DefaultCpuExecutionProvider());
 
   if (HasCudaEnvironment(700)) {
     execution_providers.push_back(DefaultCudaExecutionProvider());
   }
-
-#ifdef USE_DNNL
-  execution_providers.push_back(DefaultDnnlExecutionProvider());
-#endif
 
   ConvGradientCheckerTest(&execution_providers);
 }


### PR DESCRIPTION
Signed-off-by: George Nash <george.nash@intel.com>

**Description**:
Update to properly handle Optional Outputs from ConvGrad operator. This fix was required after https://github.com/microsoft/onnxruntime/pull/7083.  The update fix ConvGrad but changed the behavior just enough that the Dnnl ConvGrad operator no longer worked.

This updates the Dnnl ConvGrad operator so it now detects and handles the optional outputs properly.

A change to the ConvGrad unit test added the CudeExecutionProvider to the test.  This changed the way the test ran.  To get the DnnlExecutionProvider to run it had to be pushed as the first ExecutionProvider.

**Motivation and Context**
- Why is this change required? What problem does it solve?
The DnnlExecutionProvider no longer worked after PR #7083. I helped revied the pull request so was aware it would break the Dnnl version of ConvGrad.  I agreed that the fix was required.  This is a delayed fix for that issue.

- If it fixes an open issue, please link to the issue here.
No issue was ever filed for this bug.
