### PR TITLE
optimize js package folder structure

### DIFF
--- a/js/common/.gitignore
+++ b/js/common/.gitignore
@@ -1,10 +1,4 @@
 node_modules/
-types/
 dist/
 
 tsconfig.tsbuildinfo
-
-lib/**/*.js
-lib/**/*.js.map
-
-*.d.ts

--- a/js/common/.npmignore
+++ b/js/common/.npmignore
@@ -2,6 +2,6 @@
 
 webpack.config.js
 tsconfig.json
-tsconfig.tsbuildinfo
+**/*.tsbuildinfo
 
 *.tgz

--- a/js/common/package.json
+++ b/js/common/package.json
@@ -23,8 +23,8 @@
     "webpack-cli": "^4.7.0"
   },
   "main": "dist/ort-common.node.js",
-  "types": "./types/index.d.ts",
+  "types": "dist/lib/index.d.ts",
   "jsdelivr": "dist/ort-common.min.js",
   "unpkg": "dist/ort-common.min.js",
-  "module": "./lib/index.js"
+  "module": "dist/lib/index.js"
 }

--- a/js/common/tsconfig.json
+++ b/js/common/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "declarationDir": "./types"
+    "outDir": "dist/lib",
   },
   "include": ["lib"]
 }

--- a/js/node/.gitignore
+++ b/js/node/.gitignore
@@ -1,12 +1,10 @@
 node_modules/
 /build/
 /bin/
+/dist/
 /prebuilds/
 /types/
 
 /lib/**/*.js
-/lib/**/*.js.map
 /script/**/*.js
-/script/**/*.js.map
 /test/**/*.js
-/test/**/*.js.map

--- a/js/node/.npmignore
+++ b/js/node/.npmignore
@@ -11,6 +11,6 @@
 
 CMakeLists.txt
 tsconfig.json
-tsconfig.tsbuildinfo
+**/*.tsbuildinfo
 
 *.tgz

--- a/js/node/package.json
+++ b/js/node/package.json
@@ -21,8 +21,8 @@
     "rebuildd": "tsc && node ./script/build --rebuild --config=Debug",
     "rebuildr": "tsc && node ./script/build --rebuild --config=RelWithDebInfo",
     "install": "prebuild-install -r napi || (tsc && node ./script/build)",
-    "prepare": "tsc",
-    "test": "mocha ./test/test-main",
+    "prepare": "tsc --build script && tsc",
+    "test": "tsc --build test && mocha ./test/test-main",
     "prepack": "node ./script/prepack"
   },
   "dependencies": {
@@ -50,8 +50,8 @@
     "typedoc": "^0.20.25",
     "typescript": "^4.2.4"
   },
-  "main": "./lib/index.js",
-  "types": "./types/lib/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "os": [
     "win32",
     "darwin",

--- a/js/node/script/tsconfig.json
+++ b/js/node/script/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.tools.json"
+}

--- a/js/node/test/e2e/inference-session-run.ts
+++ b/js/node/test/e2e/inference-session-run.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {InferenceSession} from 'onnxruntime-common';
+import {InferenceSession, Tensor} from 'onnxruntime-common';
 import * as path from 'path';
 
-import {Tensor} from '../../lib';
 import {SQUEEZENET_INPUT0_DATA, SQUEEZENET_OUTPUT0_DATA, TEST_DATA_ROOT} from '../test-utils';
 import {assertTensorEqual} from '../test-utils';
 

--- a/js/node/test/e2e/simple-e2e-tests.ts
+++ b/js/node/test/e2e/simple-e2e-tests.ts
@@ -2,10 +2,9 @@
 // Licensed under the MIT License.
 
 import assert from 'assert';
-import {InferenceSession} from 'onnxruntime-common';
+import {InferenceSession, Tensor} from 'onnxruntime-common';
 import * as path from 'path';
 
-import {Tensor} from '../../lib';
 import {assertDataEqual, TEST_DATA_ROOT} from '../test-utils';
 
 

--- a/js/node/test/test-main.ts
+++ b/js/node/test/test-main.ts
@@ -3,6 +3,9 @@
 
 import {NODE_TESTS_ROOT, warmup} from './test-utils';
 
+// require onnxruntime-node.
+require('..');
+
 // warmup
 //
 // for unknown reason, the first call to native InferenceSession::Run() is very slow.

--- a/js/node/test/test-runner.ts
+++ b/js/node/test/test-runner.ts
@@ -2,9 +2,8 @@
 // Licensed under the MIT License.
 
 import * as fs from 'fs-extra';
-import * as path from 'path';
-
 import {InferenceSession, Tensor} from 'onnxruntime-common';
+import * as path from 'path';
 
 import {assertTensorEqual, loadTensorFromFile, shouldSkipModel} from './test-utils';
 

--- a/js/node/test/test-runner.ts
+++ b/js/node/test/test-runner.ts
@@ -4,7 +4,7 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
-import {InferenceSession, Tensor} from '../lib';
+import {InferenceSession, Tensor} from 'onnxruntime-common';
 
 import {assertTensorEqual, loadTensorFromFile, shouldSkipModel} from './test-utils';
 

--- a/js/node/test/test-utils.ts
+++ b/js/node/test/test-utils.ts
@@ -5,10 +5,8 @@ import assert from 'assert';
 import * as fs from 'fs-extra';
 import {jsonc} from 'jsonc';
 import * as onnx_proto from 'onnx-proto';
-import {Tensor} from 'onnxruntime-common';
+import {InferenceSession, Tensor} from 'onnxruntime-common';
 import * as path from 'path';
-
-import {binding} from '../lib/binding';
 
 export const TEST_ROOT = __dirname;
 export const TEST_DATA_ROOT = path.join(TEST_ROOT, 'testdata');
@@ -72,13 +70,16 @@ export function createTestTensor(type: Tensor.Type, lengthOrDims?: number|number
 
 // call the addon directly to make sure DLL is loaded
 export function warmup(): void {
-  // we have test cases to verify correctness in other place, so do no check here.
-  try {
-    const session = new binding.InferenceSession();
-    session.loadModel(path.join(TEST_DATA_ROOT, 'test_types_INT32.pb'), {});
-    session.run({input: new Tensor(new Float32Array(5), [1, 5])}, {output: null}, {});
-  } catch (e) {
-  }
+  describe('Warmup', async function() {
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(0);
+    // we have test cases to verify correctness in other place, so do no check here.
+    try {
+      const session = await InferenceSession.create(path.join(TEST_DATA_ROOT, 'test_types_INT32.pb'));
+      await session.run({input: new Tensor(new Float32Array(5), [1, 5])}, {output: null}, {});
+    } catch (e) {
+    }
+  });
 }
 
 export function assertFloatEqual(

--- a/js/node/test/tsconfig.json
+++ b/js/node/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.tools.json"
+}

--- a/js/node/test/unittests/lib/inference-session.ts
+++ b/js/node/test/unittests/lib/inference-session.ts
@@ -3,10 +3,9 @@
 
 import assert from 'assert';
 import * as fs from 'fs';
-import {InferenceSession} from 'onnxruntime-common';
+import {InferenceSession, Tensor, TypedTensor} from 'onnxruntime-common';
 import * as path from 'path';
 
-import {Tensor, TypedTensor} from '../../../lib';
 import {assertTensorEqual} from '../../test-utils';
 
 const SQUEEZENET_INPUT0_DATA = require(path.join(__dirname, '../../testdata/squeezenet.input0.json'));

--- a/js/node/tsconfig.json
+++ b/js/node/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "declarationDir": "./types"
+    "outDir": "dist"
   },
-  "include": ["lib", "script", "test"]
+  "include": ["lib"]
 }

--- a/js/tsconfig.tools.json
+++ b/js/tsconfig.tools.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "declaration": false,
+    "sourceMap": false
+  }
+}


### PR DESCRIPTION
**Description**: This change resolves #7949.

all generated .js files are put in dist/ folder for package onnxruntime-common and onnxruntime-node now. this approach avoids putting .js files together with .ts files which confused ts-loader, and at the same time preserved .ts and .map files for debugging.