### PR TITLE
Update minimum supported macOS version from 10.12 to 10.14

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -13,17 +13,6 @@ if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.20")
   cmake_policy(SET CMP0117 NEW)
 endif()
 
-# Support OS X versions 10.12+
-# This variable is ignored on non-Apple platforms and needs to be set prior to the first project(...) invocation
-# TODO: Make the miniumum deployment target MacOSX version configurable
-# If the CMAKE_OSX_DEPLOYMENT_TARGET was set (currently valid only for iOS build),
-# we will cache its value instead of the default "10.12"
-if (NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment version for ORT" FORCE)
-else()
-  set(CMAKE_OSX_DEPLOYMENT_TARGET ${CMAKE_OSX_DEPLOYMENT_TARGET} CACHE STRING "Minimum OS X deployment version for ORT" FORCE)
-endif()
-
 # Project
 project(onnxruntime C CXX)
 # Needed for Java

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1587,16 +1587,6 @@ def build_python_wheel(
         args = [sys.executable, os.path.join(source_dir, 'setup.py'),
                 'bdist_wheel']
 
-        # We explicitly override the platform tag in the name of the generated build wheel
-        # so that we can install the wheel on Mac OS X versions 10.12+.
-        # Without this explicit override, we will something like this while building on MacOS 10.14 -
-        # [WARNING] MACOSX_DEPLOYMENT_TARGET is set to a lower value (10.12)
-        # than the version on which the Python interpreter was compiled (10.14) and will be ignored.
-        # Since we need to support 10.12+, we explicitly override the platform tag.
-        # See PR #3626 for more details
-        if is_macOS():
-            args += ['-p', 'macosx_10_12_x86_64']
-
         # Any combination of the following arguments can be applied
         if nightly_build:
             args.append('--nightly_build')

--- a/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
@@ -2,6 +2,8 @@ jobs:
 - job: CoreML_CI
   pool:
     vmImage: 'macOS-10.15'
+  variables:
+    MACOSX_DEPLOYMENT_TARGET: '10.14'
   timeoutInMinutes: 120
   steps:
   - script: brew install coreutils ninja

--- a/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
@@ -2,6 +2,8 @@ jobs:
 - job: iOS_CI_on_Mac
   pool:
     vmImage: 'macOS-10.15'
+  variables:
+    MACOSX_DEPLOYMENT_TARGET: '10.14'
   timeoutInMinutes: 120
   steps:
     - script: |

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
@@ -31,7 +31,6 @@ jobs:
       packageFolder: '$(Build.BinariesDirectory)/nuget-artifact'
 
   - script: |
-     brew install libomp
      $(Build.SourcesDirectory)/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh \
                $(Build.BinariesDirectory)/nuget-artifact \
                $(Build.SourcesDirectory) \

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu-no-java.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu-no-java.yml
@@ -101,6 +101,8 @@ jobs:
   pool: 
     vmImage: 'macOS-10.15'
   timeoutInMinutes:  120
+  variables:
+    MACOSX_DEPLOYMENT_TARGET: '10.14'
   steps:
     - template: set-version-number-variables-step.yml
 
@@ -117,7 +119,6 @@ jobs:
         export CMAKE_ARGS="-DONNX_GEN_PB_TYPE_STUBS=OFF -DONNX_WERROR=OFF"
         sudo python3 -m pip install -r '$(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/requirements.txt'
         sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer
-        brew install libomp
         python3 $(Build.SourcesDirectory)/tools/ci_build/build.py ${{ parameters.AdditionalBuildFlags }} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --parallel --build_shared_lib --config Release
       displayName: 'Build and Test MacOS'
     - template: c-api-artifacts-package-and-publish-steps-posix.yml

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -108,6 +108,8 @@ jobs:
 - job: MacOS_C_API_Packaging_CPU_x64
   workspace:
     clean: all
+  variables:
+    MACOSX_DEPLOYMENT_TARGET: '10.14'
   pool: 
     vmImage: 'macOS-10.15'
   timeoutInMinutes:  120
@@ -698,7 +700,6 @@ jobs:
           wget https://oss.sonatype.org/service/local/repositories/releases/content/org/junit/platform/junit-platform-console-standalone/1.6.2/junit-platform-console-standalone-1.6.2.jar -P ./
           wget https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.9.2/protobuf-java-3.9.2.jar -P ./
           sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer
-          brew install libomp
           DYLD_LIBRARY_PATH=./test:${DYLD_LIBRARY_PATH}
           java -jar ./junit-platform-console-standalone-1.6.2.jar -cp .:./test:./protobuf-java-3.9.2.jar:./onnxruntime-$(OnnxRuntimeVersion).jar --scan-class-path --fail-if-no-tests --disable-banner
         workingDirectory: '$(Build.BinariesDirectory)/final-jar'

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -19,6 +19,7 @@ jobs:
   variables:
     BuildCommand: ${{ parameters.BuildCommand }}
     ALLOW_RELEASED_ONNX_OPSET_ONLY: ${{ parameters.AllowReleasedOpsetOnly }}
+    MACOSX_DEPLOYMENT_TARGET: '10.14'
   steps:
     - checkout: self
       ${{ if ne(parameters.SubmoduleCheckoutMode, '') }}:
@@ -34,12 +35,10 @@ jobs:
     - script: |
         set -e
         pushd .
-        brew install libomp ninja
-        export CMAKE_GENERATOR=Ninja
         cd $(Build.SourcesDirectory)/cmake/external/protobuf
         cmake ./cmake -DCMAKE_INSTALL_PREFIX=$(Build.BinariesDirectory)/protobuf -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Relwithdebinfo
-        ninja -j $(getconf _NPROCESSORS_ONLN)
-        ninja install
+        make -j $(getconf _NPROCESSORS_ONLN)
+        make install
         popd
         export PATH=$(Build.BinariesDirectory)/protobuf/bin:$PATH
         export ONNX_ML=1

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -1188,6 +1188,8 @@ stages:
         clean: all
       pool:
         vmImage: 'macOS-10.15'
+      variables:
+        MACOSX_DEPLOYMENT_TARGET: '10.14'
       strategy:
         matrix:
           Python36:


### PR DESCRIPTION
**Description**: 

1. Update minimum supported macOS version from 10.12 to 10.14. Because C++17 needs a feature that only exists in 10.14. macOS 10.14 has removed libstdc++ in favor of libc++. The old implementations are buggy. For more information please see the discussions in https://gitlab.kitware.com/cmake/cmake/-/issues/20054

2. Remove the dependency on brew.

Related: #3626

**Motivation and Context**
- Why is this change required? What problem does it solve?

For C++ 17 upgrade. Without this change, we can't use std::optional and some other features.

- If it fixes an open issue, please link to the issue here.
