### PR TITLE
Save module output for backward if needed

### DIFF
--- a/orttraining/orttraining/core/framework/ortmodule_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/ortmodule_graph_builder.cc
@@ -361,7 +361,7 @@ void OrtModuleGraphBuilder::FindModuleOutputNeededForBackward() {
     for (const Node* n : consumer_nodes) {
       // If a module output has a consumer that is executed after the YieldOp, marked it needed for backward
       if (id_to_exec_order[n->Index()] > yield_node_order) {
-        graph_info_.module_output_indice_requires_save_for_backward.emplace_back(i);
+        graph_info_.module_output_indices_requires_save_for_backward.emplace_back(i);
         break;
       }
     }

--- a/orttraining/orttraining/core/framework/ortmodule_graph_builder.h
+++ b/orttraining/orttraining/core/framework/ortmodule_graph_builder.h
@@ -56,6 +56,9 @@ struct GraphInfo {
   // Indices of output grads that need to be materialized to full size all-0 tensor.
   // Otherwise, we can use scalar-0 tensor.
   std::vector<size_t> output_grad_indices_require_full_shape{};
+  // Indices of module output that are needed for backward computation
+  std::vector<size_t> module_output_indice_requires_save_for_backward{};
+  // Names of module outputs' gradient
   std::vector<std::string> module_output_gradient_name{};
 };
 
@@ -110,6 +113,9 @@ class OrtModuleGraphBuilder {
 
   // Reorder gradient graph outputs.
   void ReorderOutputs();
+
+  // Find the module output that are needed for backward computation
+  void FindModuleOutputNeededForBackward();
 
   std::shared_ptr<onnxruntime::Model> model_;
   std::shared_ptr<onnxruntime::Model> inference_optimized_model_;

--- a/orttraining/orttraining/core/framework/ortmodule_graph_builder.h
+++ b/orttraining/orttraining/core/framework/ortmodule_graph_builder.h
@@ -57,7 +57,7 @@ struct GraphInfo {
   // Otherwise, we can use scalar-0 tensor.
   std::vector<size_t> output_grad_indices_require_full_shape{};
   // Indices of module output that are needed for backward computation
-  std::vector<size_t> module_output_indice_requires_save_for_backward{};
+  std::vector<size_t> module_output_indices_requires_save_for_backward{};
   // Names of module outputs' gradient
   std::vector<std::string> module_output_gradient_name{};
 };

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -613,7 +613,7 @@ void addObjectMethodsForTraining(py::module& m) {
       .def_readwrite("user_output_names", &GraphInfo::user_output_names)
       .def_readwrite("output_grad_indices_non_differentiable", &GraphInfo::output_grad_indices_non_differentiable)
       .def_readwrite("output_grad_indices_require_full_shape", &GraphInfo::output_grad_indices_require_full_shape)
-      .def_readwrite("module_output_indice_requires_save_for_backward", &GraphInfo::module_output_indice_requires_save_for_backward)
+      .def_readwrite("module_output_indices_requires_save_for_backward", &GraphInfo::module_output_indices_requires_save_for_backward)
       .def_readwrite("module_output_gradient_name", &GraphInfo::module_output_gradient_name);
 
   py::class_<OrtModuleGraphBuilder> ortmodule_graph_builder(m, "OrtModuleGraphBuilder");

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -613,6 +613,7 @@ void addObjectMethodsForTraining(py::module& m) {
       .def_readwrite("user_output_names", &GraphInfo::user_output_names)
       .def_readwrite("output_grad_indices_non_differentiable", &GraphInfo::output_grad_indices_non_differentiable)
       .def_readwrite("output_grad_indices_require_full_shape", &GraphInfo::output_grad_indices_require_full_shape)
+      .def_readwrite("module_output_indice_requires_save_for_backward", &GraphInfo::module_output_indice_requires_save_for_backward)
       .def_readwrite("module_output_gradient_name", &GraphInfo::module_output_gradient_name);
 
   py::class_<OrtModuleGraphBuilder> ortmodule_graph_builder(m, "OrtModuleGraphBuilder");

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -115,6 +115,14 @@ class TrainingManager(GraphExecutionManager):
                 # converted to a tensor filled with zeros prior to calling backward.
                 # Save shape, device and type info to ctx for materializing tensor in backward if output grad is None.
                 ctx.set_materialize_grads(False)
+
+                # Mark the outputs tensors needed in backward computation
+                # ORT is NOT relying on save_for_backward() to actually save the tensor, 
+                # as this tensor is also kept in ORT's PartialGraphState
+                # This call is to invoke pytorch's version check to detect the potential inplace corruption
+                for idx in self._graph_info.module_output_indice_requires_save_for_backward:
+                    ctx.save_for_backward(user_outputs[idx])
+
                 return user_outputs
 
             @staticmethod
@@ -123,6 +131,9 @@ class TrainingManager(GraphExecutionManager):
 
                 assert ctx.run_info is not None, 'forward() or __call__() methods must be called before backward()'
                 _utils._check_same_device(self._device, "Input argument to backward", *grad_outputs)
+
+                # Unpack saved_tensor to trigger version detection that catches inplace corruption
+                _ = ctx.saved_tensors
 
                 # Use IO binding
                 # Push user output grads to ONNX backend.

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -120,7 +120,7 @@ class TrainingManager(GraphExecutionManager):
                 # ORT is NOT relying on save_for_backward() to actually save the tensor, 
                 # as this tensor is also kept in ORT's PartialGraphState
                 # This call is to invoke pytorch's version check to detect the potential inplace corruption
-                for idx in self._graph_info.module_output_indice_requires_save_for_backward:
+                for idx in self._graph_info.module_output_indices_requires_save_for_backward:
                     ctx.save_for_backward(user_outputs[idx])
 
                 return user_outputs

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -985,6 +985,42 @@ def test_input_requires_grad_backward_creates_input_grad_as_required0(device):
     # backward() is from y2, so grad of fc1.weight and fc1.bias will not be calculated.
     _test_helpers.assert_gradients_match_and_reset_gradient(ort_model, pt_model, none_pt_params=['fc1.weight', 'fc1.bias'])
 
+
+@pytest.mark.parametrize("device", ['cuda'])
+def test_model_output_with_inplace_update(device):
+    class NeuralNetWithGradNeedOutput(torch.nn.Module):
+        def __init__(self, input_size, hidden_size):
+            super(NeuralNetWithGradNeedOutput, self).__init__()
+            self.fc1_1 = torch.nn.Linear(input_size, hidden_size)
+            # Softmax's gradient is depending on its output
+            self.act = torch.nn.Softmax(dim=1)
+
+        def forward(self, input1):
+            out1 = self.act(self.fc1_1(input1))
+            return out1
+
+    def run_step(model, x1):
+        y1 = model(x1)
+        y1.add_(1)  # inplace update to module output
+        y1 = y1.sum()
+        y1.backward()
+        return y1
+
+    N, D_in, H = 32, 784, 500
+    pt_model = NeuralNetWithGradNeedOutput(D_in, H).to(device)
+    ort_model = ORTModule(copy.deepcopy(pt_model))
+
+    pt_x1 = torch.randn(N, D_in, device=device, requires_grad=True)
+    ort_x1 = pt_x1.clone()
+
+    with pytest.raises(Exception) as ex_info:
+        pt_y1 = run_step(pt_model, pt_x1)
+    assert "modified by an inplace operation" in str(ex_info.value)
+    
+    with pytest.raises(Exception) as ex_info:
+        ort_y1 = run_step(ort_model, ort_x1)
+    assert "modified by an inplace operation" in str(ex_info.value)
+
 @pytest.mark.parametrize("device", ['cuda'])
 def test_loss_combines_two_outputs_with_dependency(device):
 


### PR DESCRIPTION
If a module output is also used in backward graph, we add it into ctx.save_for_backward(), so that pytorch will be able to catch if there is any inplace corruption. 

Here's a sample pytorch error for catch such corruption: 

`
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor [32, 500]], which is output 0 of _ORTModuleFunctionBackward, is at version 1; expected version 0 instead. Hint: enable anomaly detection to find the operation that failed to compute its gradient, with torch.autograd.set_detect_anomaly(True). 
`
