### PR TITLE
[Java] Fixing the creation of OnnxTensors from scalars, adding tests

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OnnxTensor.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxTensor.java
@@ -316,8 +316,7 @@ public class OnnxTensor implements OnnxValue {
 
   /**
    * Create a Tensor from a Java primitive, String, primitive multidimensional array or String
-   * multidimensional array. The shape is inferred from the object using reflection. The default
-   * allocator is used.
+   * multidimensional array. The shape is inferred from the object using reflection.
    *
    * @param env The current OrtEnvironment.
    * @param allocator The allocator to use.
@@ -350,7 +349,7 @@ public class OnnxTensor implements OnnxValue {
           data = OrtUtil.convertBoxedPrimitiveToArray(info.type, data);
           if (data == null) {
             throw new OrtException(
-                "Failed to convert a boxed primitive to an array, this is an error with ORT itself, please report it. JavaType = "
+                "Failed to convert a boxed primitive to an array, this is an error with the ORT Java API, please report this message & stack trace. JavaType = "
                     + info.type
                     + ", object = "
                     + data);

--- a/java/src/main/java/ai/onnxruntime/OnnxTensor.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxTensor.java
@@ -301,8 +301,9 @@ public class OnnxTensor implements OnnxValue {
   }
 
   /**
-   * Create a Tensor from a Java primitive or String multidimensional array. The shape is inferred
-   * from the array using reflection. The default allocator is used.
+   * Create a Tensor from a Java primitive, primitive multidimensional array or String
+   * multidimensional array. The shape is inferred from the object using reflection. The default
+   * allocator is used.
    *
    * @param env The current OrtEnvironment.
    * @param data The data to store in a tensor.
@@ -314,8 +315,9 @@ public class OnnxTensor implements OnnxValue {
   }
 
   /**
-   * Create a Tensor from a Java primitive or String multidimensional array. The shape is inferred
-   * from the array using reflection.
+   * Create a Tensor from a Java primitive, String, primitive multidimensional array or String
+   * multidimensional array. The shape is inferred from the object using reflection. The default
+   * allocator is used.
    *
    * @param env The current OrtEnvironment.
    * @param allocator The allocator to use.
@@ -345,7 +347,14 @@ public class OnnxTensor implements OnnxValue {
         }
       } else {
         if (info.shape.length == 0) {
-          data = OrtUtil.convertBoxedPrimitiveToArray(data);
+          data = OrtUtil.convertBoxedPrimitiveToArray(info.type, data);
+          if (data == null) {
+            throw new OrtException(
+                "Failed to convert a boxed primitive to an array, this is an error with ORT itself, please report it. JavaType = "
+                    + info.type
+                    + ", object = "
+                    + data);
+          }
         }
         return new OnnxTensor(
             createTensor(

--- a/java/src/main/java/ai/onnxruntime/OrtUtil.java
+++ b/java/src/main/java/ai/onnxruntime/OrtUtil.java
@@ -383,15 +383,48 @@ public final class OrtUtil {
   }
 
   /**
-   * Stores a boxed primitive in a single element array of the boxed type. Otherwise returns the
-   * input.
+   * Stores a boxed primitive in a single element array of the unboxed type.
    *
+   * <p>If it's not a boxed primitive then it returns null.
+   *
+   * @param javaType The type of the boxed primitive.
    * @param data The boxed primitive.
-   * @return The boxed primitive in an array.
+   * @return The primitive in an array.
    */
-  static Object convertBoxedPrimitiveToArray(Object data) {
-    Object array = Array.newInstance(data.getClass(), 1);
-    Array.set(array, 0, data);
-    return array;
+  static Object convertBoxedPrimitiveToArray(OnnxJavaType javaType, Object data) {
+    switch (javaType) {
+      case FLOAT:
+        float[] floatArr = new float[1];
+        floatArr[0] = (Float) data;
+        return floatArr;
+      case DOUBLE:
+        double[] doubleArr = new double[1];
+        doubleArr[0] = (Double) data;
+        return doubleArr;
+      case INT8:
+        byte[] byteArr = new byte[1];
+        byteArr[0] = (Byte) data;
+        return byteArr;
+      case INT16:
+        short[] shortArr = new short[1];
+        shortArr[0] = (Short) data;
+        return shortArr;
+      case INT32:
+        int[] intArr = new int[1];
+        intArr[0] = (Integer) data;
+        return intArr;
+      case INT64:
+        long[] longArr = new long[1];
+        longArr[0] = (Long) data;
+        return longArr;
+      case BOOL:
+        boolean[] booleanArr = new boolean[1];
+        booleanArr[0] = (Boolean) data;
+        return booleanArr;
+      case STRING:
+      case UNKNOWN:
+      default:
+        return null;
+    }
   }
 }

--- a/java/src/main/java/ai/onnxruntime/TensorInfo.java
+++ b/java/src/main/java/ai/onnxruntime/TensorInfo.java
@@ -204,8 +204,16 @@ public class TensorInfo implements ValueInfo {
    */
   public static TensorInfo constructFromJavaArray(Object obj) throws OrtException {
     Class<?> objClass = obj.getClass();
-    if (!objClass.isArray() && !objClass.isPrimitive() && !objClass.equals(String.class)) {
-      throw new OrtException("Cannot convert " + objClass + " to a OnnxTensor.");
+    // Check if it's an array or a scalar.
+    if (!objClass.isArray()) {
+      // Check if it's a valid non-array type
+      OnnxJavaType javaType = OnnxJavaType.mapFromClass(objClass);
+      if (javaType == OnnxJavaType.UNKNOWN) {
+        throw new OrtException("Cannot convert " + objClass + " to a OnnxTensor.");
+      } else {
+        // scalar primitive
+        return new TensorInfo(new long[0], javaType, OnnxTensorType.mapFromJavaType(javaType));
+      }
     }
     // Figure out base type and number of dimensions.
     int dimensions = 0;

--- a/java/src/test/java/ai/onnxruntime/TensorCreationTest.java
+++ b/java/src/test/java/ai/onnxruntime/TensorCreationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the MIT License.
+ */
+package ai.onnxruntime;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TensorCreationTest {
+
+  @Test
+  public void testScalarCreation() throws OrtException {
+    try (OrtEnvironment env = OrtEnvironment.getEnvironment()) {
+      String[] stringValues = new String[] {"true", "false"};
+      for (String s : stringValues) {
+        try (OnnxTensor t = OnnxTensor.createTensor(env, s)) {
+          Assertions.assertEquals(s, t.getValue());
+        }
+      }
+
+      boolean[] boolValues = new boolean[] {true, false};
+      for (boolean b : boolValues) {
+        try (OnnxTensor t = OnnxTensor.createTensor(env, b)) {
+          Assertions.assertEquals(b, t.getValue());
+        }
+      }
+
+      int[] intValues =
+          new int[] {-1, 0, 1, 12345678, -12345678, Integer.MAX_VALUE, Integer.MIN_VALUE};
+      for (int i : intValues) {
+        try (OnnxTensor t = OnnxTensor.createTensor(env, i)) {
+          Assertions.assertEquals(i, t.getValue());
+        }
+      }
+
+      long[] longValues =
+          new long[] {-1L, 0L, 1L, 12345678L, -12345678L, Long.MAX_VALUE, Long.MIN_VALUE};
+      for (long l : longValues) {
+        try (OnnxTensor t = OnnxTensor.createTensor(env, l)) {
+          Assertions.assertEquals(l, t.getValue());
+        }
+      }
+
+      float[] floatValues =
+          new float[] {
+            -1.0f,
+            0.0f,
+            -0.0f,
+            1.0f,
+            1234.5678f,
+            -1234.5678f,
+            (float) Math.PI,
+            (float) Math.E,
+            Float.MAX_VALUE,
+            Float.MIN_VALUE
+          };
+      for (float f : floatValues) {
+        try (OnnxTensor t = OnnxTensor.createTensor(env, f)) {
+          Assertions.assertEquals(f, t.getValue());
+        }
+      }
+
+      double[] doubleValues =
+          new double[] {
+            -1.0,
+            0.0,
+            -0.0,
+            1.0,
+            1234.5678,
+            -1234.5678,
+            Math.PI,
+            Math.E,
+            Double.MAX_VALUE,
+            Double.MIN_VALUE
+          };
+      for (double d : doubleValues) {
+        try (OnnxTensor t = OnnxTensor.createTensor(env, d)) {
+          Assertions.assertEquals(d, t.getValue());
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Description**:
Previously while you could get a scalar as an output from an ONNX model, you couldn't build one to supply as an input. This PR fixes that, and adds a test for this behaviour (as it did work in the past but was broken at some point).

**Motivation and Context**
- Why is this change required? What problem does it solve? Allows the creation of scalar tensors.
- If it fixes an open issue, please link to the issue here. Fixes #7358.
