### PR TITLE
Upgrade tf 2.4.1 to 2.4.2 for component governance

### DIFF
--- a/docs/python/requirements.txt
+++ b/docs/python/requirements.txt
@@ -7,7 +7,7 @@ sphinx-gallery
 sphinxcontrib.imagesvg
 sphinx_rtd_theme
 pyquickhelper
-tensorflow>=2.2.0,<2.5.0
+tensorflow>=2.4.2,<2.5.0
 tf2onnx
 pandas
 pydot

--- a/docs/python/requirements.txt
+++ b/docs/python/requirements.txt
@@ -7,7 +7,7 @@ sphinx-gallery
 sphinxcontrib.imagesvg
 sphinx_rtd_theme
 pyquickhelper
-tensorflow>=2.4.2,<2.5.0
+tensorflow==2.5.0
 tf2onnx
 pandas
 pydot


### PR DESCRIPTION
**Description**: Upgrade tf version for component governance

**Motivation and Context**
- necessary for compliance of MacOS CI, MacOS NoContribops CI