### PR TITLE
Create and move quantization tests to a shared Quantized utils file.

### DIFF
--- a/onnxruntime/test/common/quantization_test_utils.h
+++ b/onnxruntime/test/common/quantization_test_utils.h
@@ -13,7 +13,7 @@ namespace test {
 //
 // Rounds a float to the nearest representable value and returns the nearest integer value as a float.
 //
-static float RoundHalfToEven(float input) {
+inline float RoundHalfToEven(float input) {
   std::fesetround(FE_TONEAREST);
   auto result = std::nearbyintf(input);
   return result;
@@ -56,11 +56,24 @@ inline std::vector<Integer> QuantizeLinear(const std::vector<float>& data, float
 // Converts a given float vector to a quantized representation with a pre-calculated scale and zero point.
 //
 template <typename Integer, typename = typename std::enable_if<std::is_integral<Integer>::value, Integer>::type>
-inline std::vector<Integer> ToInteger(const std::vector<float>& data, float scale, Integer zero_point = 0) {
+inline std::vector<Integer> Quantize(const std::vector<float>& data, float scale, Integer zero_point = 0) {
   std::vector<Integer> result;
   result.reserve(data.size());
   for (size_t i = 0; i < data.size(); i++) {
     result.push_back(static_cast<Integer>(std::round(data[i] / scale) + zero_point));
+  }
+  return result;
+}
+
+//
+// Converts a quantized integer vector to floating point value with a pre-calculated scale and zero point.
+//
+template <typename Integer, typename = typename std::enable_if<std::is_integral<Integer>::value, Integer>::type>
+inline std::vector<float> Dequantize(const std::vector<Integer>& data, float scale, Integer zero_point = 0) {
+  std::vector<float> result;
+  result.reserve(data.size());
+  for (size_t i = 0; i < data.size(); i++) {
+    result.push_back((data[i] - zero_point) * scale);
   }
   return result;
 }

--- a/onnxruntime/test/common/quantization_test_utils.h
+++ b/onnxruntime/test/common/quantization_test_utils.h
@@ -13,7 +13,7 @@ namespace test {
 //
 // Rounds a float to the nearest representable value and returns the nearest integer value as a float.
 //
-inline float RoundHalfToEven(float input) {
+float RoundHalfToEven(float input) {
   std::fesetround(FE_TONEAREST);
   auto result = std::nearbyintf(input);
   return result;
@@ -60,9 +60,19 @@ inline std::vector<Integer> Quantize(const std::vector<float>& data, float scale
   std::vector<Integer> result;
   result.reserve(data.size());
   for (size_t i = 0; i < data.size(); i++) {
-    result.push_back(static_cast<Integer>(std::round(data[i] / scale) + zero_point));
+    //result.push_back(Quantize<Integer>(data[i], scale, zero_point));
+     result.push_back(static_cast<Integer>(std::round(data[i] / scale) + zero_point));
   }
   return result;
+}
+
+//
+// Converts a single float value to a quantized value with a pre-calculated scale and zero point.
+//
+template <typename Integer, typename = typename std::enable_if<std::is_integral<Integer>::value, Integer>::type>
+inline Integer Quantize(const float value, float scale, Integer zero_point = 0) {
+  // TODO(kreeger): use rounding?
+  return static_cast<Integer>(std::round(value / scale) + zero_point);
 }
 
 //

--- a/onnxruntime/test/common/quantization_test_utils.h
+++ b/onnxruntime/test/common/quantization_test_utils.h
@@ -13,7 +13,6 @@ namespace test {
 //
 // Rounds a float to the nearest representable value and returns the nearest integer value as a float.
 //
-// TODO(kreeger): Consider moving to a cc file.
 inline float RoundHalfToEven(float input) {
   std::fesetround(FE_TONEAREST);
   auto result = std::nearbyintf(input);
@@ -61,7 +60,7 @@ inline std::vector<Integer> Quantize(const std::vector<float>& data, float scale
 }
 
 //
-// Converts a single float value to a quantized value with a pre-calculated scale and zero point.
+// Converts a float value to a quantized value with a pre-calculated scale and zero point.
 //
 template <typename Integer, typename = typename std::enable_if<std::is_integral<Integer>::value, Integer>::type>
 inline Integer Quantize(const float value, float scale, Integer zero_point = 0) {
@@ -84,7 +83,7 @@ inline std::vector<float> Dequantize(const std::vector<Integer>& data, float sca
 }
 
 //
-// Converts a single quantized integer value to a floating point value with a pre-calculated scale and zero point.
+// Converts a quantized integer value to a floating point value with a pre-calculated scale and zero point.
 //
 template <typename Integer, typename = typename std::enable_if<std::is_integral<Integer>::value, Integer>::type>
 inline float Dequantize(const Integer value, float scale, Integer zero_point = 0) {

--- a/onnxruntime/test/common/quantization_test_utils.h
+++ b/onnxruntime/test/common/quantization_test_utils.h
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cfenv>
+#include <cmath>
+#include <vector>
+
+namespace onnxruntime {
+namespace test {
+
+//
+// Rounds a float to the nearest representable value and returns the nearest integer value as a float.
+//
+static float RoundHalfToEven(float input) {
+  std::fesetround(FE_TONEAREST);
+  auto result = std::nearbyintf(input);
+  return result;
+}
+
+//
+// Performs linear quantization on a given float vector.
+//
+template <typename Integer, bool symmetric, typename = typename std::enable_if<std::is_integral<Integer>::value, Integer>::type>
+inline std::vector<Integer> QuantizeLinear(const std::vector<float>& data, float& scale, Integer& zp) {
+  std::vector<Integer> result;
+  result.reserve(data.size());
+
+  // find quantization range min and max
+  float qmax = std::numeric_limits<Integer>::max();
+  float qmin = std::numeric_limits<Integer>::min();
+  // Adjust the int8 range to -127 to 127 so that zero point can be 0
+  if (qmin == -128) {
+    qmin = -127;
+  }
+
+  const auto minmax = std::minmax_element(data.begin(), data.end());
+  float min = std::min(*minmax.first, 0.0f);  // ensure the input range includes zero
+  float max = std::max(*minmax.second, 0.0f);
+  if (symmetric) {
+    scale = std::max(std::abs(max), std::abs(min)) / 127;
+    zp = 0;
+  } else {
+    scale = (max - min) / (qmax - qmin);
+    zp = static_cast<Integer>(RoundHalfToEven(std::max(qmin, std::min(qmax, qmin - min / scale))));
+  }
+
+  for (size_t i = 0; i < data.size(); i++) {
+    result.push_back(static_cast<Integer>(RoundHalfToEven(std::max(qmin, std::min(qmax, data[i] / scale + zp)))));
+  }
+  return result;
+}
+
+//
+// Converts a given float vector to a quantized representation with a pre-calculated scale and zero point.
+//
+template <typename Integer, typename = typename std::enable_if<std::is_integral<Integer>::value, Integer>::type>
+inline std::vector<Integer> ToInteger(const std::vector<float>& data, float scale, Integer zero_point = 0) {
+  std::vector<Integer> result;
+  result.reserve(data.size());
+  for (size_t i = 0; i < data.size(); i++) {
+    result.push_back(static_cast<Integer>(std::round(data[i] / scale) + zero_point));
+  }
+  return result;
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+

--- a/onnxruntime/test/common/quantization_test_utils.h
+++ b/onnxruntime/test/common/quantization_test_utils.h
@@ -65,8 +65,8 @@ inline std::vector<Integer> Quantize(const std::vector<float>& data, float scale
 //
 template <typename Integer, typename = typename std::enable_if<std::is_integral<Integer>::value, Integer>::type>
 inline Integer Quantize(const float value, float scale, Integer zero_point = 0) {
-  float qmax = std::numeric_limits<Integer>::max();
-  float qmin = std::numeric_limits<Integer>::min();
+  constexpr float qmax = std::numeric_limits<Integer>::max();
+  constexpr float qmin = std::numeric_limits<Integer>::min();
   return static_cast<Integer>(RoundHalfToEven(std::max(qmin, std::min(qmax, (value / scale) + zero_point))));
 }
 

--- a/onnxruntime/test/common/quantization_test_utils.h
+++ b/onnxruntime/test/common/quantization_test_utils.h
@@ -87,8 +87,8 @@ inline std::vector<float> Dequantize(const std::vector<Integer>& data, float sca
 // Converts a single quantized integer value to a floating point value with a pre-calculated scale and zero point.
 //
 template <typename Integer, typename = typename std::enable_if<std::is_integral<Integer>::value, Integer>::type>
-inline float Dequantize(const float value, float scale, Integer zero_point = 0) {
-  return (data[i] - zero_point) * scale;
+inline float Dequantize(const Integer value, float scale, Integer zero_point = 0) {
+  return (value - zero_point) * scale;
 }
 
 }  // namespace test

--- a/onnxruntime/test/contrib_ops/qlinear_binary_op_test.cc
+++ b/onnxruntime/test/contrib_ops/qlinear_binary_op_test.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "gtest/gtest.h"
+#include "test/common/quantization_test_utils.h"
 #include "test/providers/provider_test_utils.h"
 #include "core/providers/common.h"
 
@@ -66,18 +67,12 @@ void RunQLinearMathTestFromFloat(
   constexpr int qmin = std::numeric_limits<T>::min();
 
   OpTester test(op_name, 1, onnxruntime::kMSDomain);
-  std::vector<T> a_quantized(a.size());
-  for (size_t i = 0, sz = a.size(); i < sz; ++i) {
-    a_quantized[i] = clampi<T>(static_cast<int>(std::nearbyintf(a[i] / A_scale)) + A_zero_point, qmin, qmax);
-  }
+  std::vector<T> a_quantized = Quantize<T>(a, A_scale, A_zero_point);
   test.template AddInput<T>("A", a_shape_origin, a_quantized);
   test.AddInput<float>("A_scale", {}, {A_scale}, all_initializer_scale_zero_point);
   test.template AddInput<T>("A_zero_point", {}, {A_zero_point}, all_initializer_scale_zero_point);
 
-  std::vector<T> b_quantized(b.size());
-  for (size_t i = 0, sz = b.size(); i < sz; ++i) {
-    b_quantized[i] = clampi<T>(static_cast<int>(std::nearbyintf(b[i] / B_scale)) + B_zero_point, qmin, qmax);
-  }
+  std::vector<T> b_quantized = Quantize<T>(b, B_scale, B_zero_point);
   test.template AddInput<T>("B", b_shape_origin, b_quantized, input_b_is_initializer);
   test.AddInput<float>("B_scale", {}, {B_scale}, all_initializer_scale_zero_point);
   test.template AddInput<T>("B_zero_point", {}, {B_zero_point}, all_initializer_scale_zero_point);

--- a/onnxruntime/test/contrib_ops/qlinear_pool_test.cc
+++ b/onnxruntime/test/contrib_ops/qlinear_pool_test.cc
@@ -98,7 +98,7 @@ CalculateAvgPoolNchwU8(
             }
           }
           if (kernel_offset >= 0) {
-            y_value_sum += Quantize<uint8_t>(xbc[kernel_offset], x_scale, static_cast<uint8_t>(x_zero_point));
+            y_value_sum += Dequantize<uint8_t>(xbc[kernel_offset], x_scale, static_cast<uint8_t>(x_zero_point));
             ++count;
           } else {
             count += count_include_pad ? 1 : 0;
@@ -111,10 +111,6 @@ CalculateAvgPoolNchwU8(
     }
   }
 }
-
-//
-// TODO(kreeger): left off right here. I messed something up with the unit test in this file. The quantized values are jacked.
-//
 
 void RunQLinearAveragePoolNchwU8(
     const std::vector<int64_t> x_dims,

--- a/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
@@ -61,8 +61,8 @@ void RunQAttention(const std::vector<float>& input_data,         // input:      
   QInput input_zero_point = quantize_parameters.input_zero_point;
   QWeight weight_zero_point = quantize_parameters.weight_zero_point;
   if (input_scale != 0.0f) {
-    tester.AddInput<QInput>("input", input_dims, ToInteger<QInput>(input_data, input_scale, input_zero_point));
-    tester.AddInput<QWeight>("weight", weights_dims, ToInteger<QWeight>(weights_data, weight_scale, weight_zero_point));
+    tester.AddInput<QInput>("input", input_dims, Quantize<QInput>(input_data, input_scale, input_zero_point));
+    tester.AddInput<QWeight>("weight", weights_dims, Quantize<QWeight>(weights_data, weight_scale, weight_zero_point));
   } else {
     tester.AddInput<QInput>("input", input_dims, QuantizeLinear<QInput, ep == EP::CUDA>(input_data, input_scale, input_zero_point));
     tester.AddInput<QWeight>("weight", weights_dims, QuantizeLinear<QWeight, ep == EP::CUDA>(weights_data, weight_scale, weight_zero_point));
@@ -847,8 +847,8 @@ TEST(QAttentionTest, SharedPrepackedWeights) {
   OpTester tester("QAttention", 1, onnxruntime::kMSDomain);
   tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(number_of_heads));
 
-  tester.AddInput<uint8_t>("input", input_dims, ToInteger<uint8_t>(input_data, 0.1f, 128));
-  auto weight_data_converted_to_int = ToInteger<uint8_t>(weight_data, 0.1f, 128);
+  tester.AddInput<uint8_t>("input", input_dims, Quantize<uint8_t>(input_data, /*scale=*/0.1f, /*zero_point=*/128));
+  auto weight_data_converted_to_int = Quantize<uint8_t>(weight_data, /*scale=*/0.1f, /*zero_point=*/128);
   tester.AddInput<uint8_t>("weight", weights_dims, weight_data_converted_to_int, true);  // Trigger pre-packing
 
   tester.AddInput<float>("bias", bias_dims, bias_data);

--- a/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "gtest/gtest.h"
+#include "test/common/quantization_test_utils.h"
 #include "test/common/tensor_op_test_utils.h"
 #include "test/common/cuda_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"
@@ -13,52 +14,6 @@
 
 namespace onnxruntime {
 namespace test {
-
-static float RoundHalfToEven(float input) {
-  std::fesetround(FE_TONEAREST);
-  auto result = std::nearbyintf(input);
-  return result;
-}
-
-template <typename Integer, bool symmetric, typename = typename std::enable_if<std::is_integral<Integer>::value, Integer>::type>
-inline std::vector<Integer> QuantizeLinear(const std::vector<float>& data, float& scale, Integer& zp) {
-  std::vector<Integer> result;
-  result.reserve(data.size());
-
-  // find quantization range min and max
-  float qmax = std::numeric_limits<Integer>::max();
-  float qmin = std::numeric_limits<Integer>::min();
-  // Adjust the int8 range to -127 to 127 so that zero point can be 0
-  if (qmin == -128) {
-    qmin = -127;
-  }
-
-  const auto minmax = std::minmax_element(data.begin(), data.end());
-  float min = std::min(*minmax.first, 0.0f);  // ensure the input range includes zero
-  float max = std::max(*minmax.second, 0.0f);
-  if (symmetric) {
-    scale = std::max(std::abs(max), std::abs(min)) / 127;
-    zp = 0;
-  } else {
-    scale = (max - min) / (qmax - qmin);
-    zp = static_cast<Integer>(RoundHalfToEven(std::max(qmin, std::min(qmax, qmin - min / scale))));
-  }
-
-  for (size_t i = 0; i < data.size(); i++) {
-    result.push_back(static_cast<Integer>(RoundHalfToEven(std::max(qmin, std::min(qmax, data[i] / scale + zp)))));
-  }
-  return result;
-}
-
-template <typename Integer, typename = typename std::enable_if<std::is_integral<Integer>::value, Integer>::type>
-inline std::vector<Integer> ToInteger(const std::vector<float>& data, float scale, Integer zero_point = 0) {
-  std::vector<Integer> result;
-  result.reserve(data.size());
-  for (size_t i = 0; i < data.size(); i++) {
-    result.push_back(static_cast<Integer>(std::round(data[i] / scale) + zero_point));
-  }
-  return result;
-}
 
 enum class EP : char {
   CPU,


### PR DESCRIPTION
While working on a new quantized Op I noticed that each Op unit test had a variation of usage for quantization and dequantization techniques. To help simplify and prepare for more quantized Ops in the future I have moved and cleaned up the Quant/Dequant utility functions to a common test-only header.

NOTE: I did not update `quantize_lstm_op_test.cc` since it had some complicated writes in the feature vectors. I'm happy to spend more time there or add a TODO.