### PR TITLE
fix issue with cmake path

### DIFF
--- a/dockerfiles/Dockerfile.migraphx
+++ b/dockerfiles/Dockerfile.migraphx
@@ -29,7 +29,7 @@ RUN apt-get update &&\
 # Install rbuild
 RUN pip3 install https://github.com/RadeonOpenCompute/rbuild/archive/master.tar.gz
 
-ENV PATH /opt/miniconda/bin:/code/cmake-3.20.3-Linux-x86_64/bin:${PATH}
+ENV PATH /opt/miniconda/bin:/code/cmake-3.20.3-linux-x86_64/bin:${PATH}
 
 # Install MIGraphX from source
 RUN mkdir -p /migraphx

--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -12,7 +12,7 @@ ARG ONNXRUNTIME_BRANCH=master
 WORKDIR /code
 ARG MY_ROOT=/code
 
-ENV PATH /opt/miniconda/bin:/code/cmake-3.20.3-Linux-x86_64/bin:$PATH
+ENV PATH /opt/miniconda/bin:/code/cmake-3.20.3-linux-x86_64/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/miniconda/lib:/usr/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 
 ENV INTEL_OPENVINO_DIR=/opt/intel/openvino_2021.3.394

--- a/dockerfiles/Dockerfile.openvino-csharp
+++ b/dockerfiles/Dockerfile.openvino-csharp
@@ -12,7 +12,7 @@ ARG ONNXRUNTIME_BRANCH=master
 WORKDIR /code
 ARG MY_ROOT=/code
 
-ENV PATH /opt/miniconda/bin:/code/cmake-3.20.3-Linux-x86_64/bin:$PATH
+ENV PATH /opt/miniconda/bin:/code/cmake-3.20.3-linux-x86_64/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/miniconda/lib:/usr/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 
 ENV INTEL_OPENVINO_DIR=/opt/intel/openvino_2021.3.394

--- a/dockerfiles/Dockerfile.rocm
+++ b/dockerfiles/Dockerfile.rocm
@@ -29,7 +29,7 @@ RUN apt-get update &&\
 # Install yapf
 RUN pip3 install yapf==0.28.0
 
-ENV PATH /opt/miniconda/bin:/code/cmake-3.20.3-Linux-x86_64/bin:${PATH}
+ENV PATH /opt/miniconda/bin:/code/cmake-3.20.3-linux-x86_64/bin:${PATH}
 
 # Install dependencies
 COPY ./scripts/install_rocm_deps.sh /

--- a/dockerfiles/Dockerfile.tensorrt
+++ b/dockerfiles/Dockerfile.tensorrt
@@ -15,7 +15,7 @@ RUN apt-get update &&\
 RUN unattended-upgrade
 
 WORKDIR /code
-ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/code/cmake-3.20.3-Linux-x86_64/bin:/opt/miniconda/bin:${PATH}
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/code/cmake-3.20.3-linux-x86_64/bin:/opt/miniconda/bin:${PATH}
 
 # Prepare onnxruntime repository & build onnxruntime with TensorRT
 RUN git clone --single-branch --branch ${ONNXRUNTIME_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime &&\

--- a/dockerfiles/Dockerfile.vitisai
+++ b/dockerfiles/Dockerfile.vitisai
@@ -22,7 +22,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ENV PATH /code/cmake-3.20.3-Linux-x86_64/bin:$PATH
+ENV PATH /code/cmake-3.20.3-linux-x86_64/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/xilinx/xrt/lib:$LD_LIBRARY_PATH
 
 WORKDIR /code


### PR DESCRIPTION
https://github.com/microsoft/onnxruntime/pull/7933 updated cmake to 3.20 for many of our Dockerfiles.
The problem is for cmake 3.20.x cmake tarball packages, even though the filename has Linux capitalized,
the archived directory actually has lowercase linux, so we add a non-existing directory to the path
and the build fails.