### PR TITLE
decouple the python module construction from pybind_state

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_module.cc
+++ b/onnxruntime/python/onnxruntime_pybind_module.cc
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <pybind11/pybind11.h>
+
+namespace onnxruntime {
+namespace python {
+namespace py = pybind11;
+
+void CreatePybindStateModule(py::module& m);
+
+PYBIND11_MODULE(onnxruntime_pybind11_state, m) {
+  CreatePybindStateModule(m);
+}
+}
+}

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1547,7 +1547,7 @@ static struct {
 void addObjectMethodsForTraining(py::module& m);
 #endif
 
-PYBIND11_MODULE(onnxruntime_pybind11_state, m) {
+void CreatePybindStateModule(py::module& m){
   m.doc() = "pybind11 stateful interface to ONNX runtime";
   RegisterExceptions(m);
 

--- a/onnxruntime/test/eager/ort_invoker_test.cc
+++ b/onnxruntime/test/eager/ort_invoker_test.cc
@@ -11,9 +11,9 @@ namespace onnxruntime {
 namespace test {
 
 TEST(InvokerTest, Basic) {
-  std::unique_ptr<IExecutionProvider> cpu_execution_provider = onnxruntime::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo(false));
+  std::unique_ptr<IExecutionProvider> cpu_execution_provider = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo(false));
   const std::string logger_id{"InvokerTest"};
-  auto logging_manager = onnxruntime::make_unique<logging::LoggingManager>(
+  auto logging_manager = std::make_unique<logging::LoggingManager>(
       std::unique_ptr<logging::ISink>{new logging::CLogSink{}},
       logging::Severity::kVERBOSE, false,
       logging::LoggingManager::InstanceType::Default,
@@ -44,9 +44,9 @@ TEST(InvokerTest, Basic) {
 }
 
 TEST(InvokerTest, Inplace) {
-  std::unique_ptr<IExecutionProvider> cpu_execution_provider = onnxruntime::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo(false));
+  std::unique_ptr<IExecutionProvider> cpu_execution_provider = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo(false));
   const std::string logger_id{"InvokerTest"};
-  auto logging_manager = onnxruntime::make_unique<logging::LoggingManager>(
+  auto logging_manager = std::make_unique<logging::LoggingManager>(
       std::unique_ptr<logging::ISink>{new logging::CLogSink{}},
       logging::Severity::kVERBOSE, false,
       logging::LoggingManager::InstanceType::Default,


### PR DESCRIPTION
**Description**: decouple the python module construction from pybind_state, so we can have the flexibility to customize the python module.
