### PR TITLE
Improve Windows Platform system error messages

### DIFF
--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -190,13 +190,13 @@ class WindowsEnv : public Env {
         CreateFileW(file_path, FILE_READ_ATTRIBUTES, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL)};
 #endif
     if (file_handle.get() == INVALID_HANDLE_VALUE) {
-      const int err = GetLastError();
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "open file ", ToMBString(file_path), " fail, errcode = ", err);
+      const auto error_code = GetLastError();
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "open file ", ToMBString(file_path), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
     }
     LARGE_INTEGER filesize;
     if (!GetFileSizeEx(file_handle.get(), &filesize)) {
-      const int err = GetLastError();
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "GetFileSizeEx ", ToMBString(file_path), " fail, errcode = ", err);
+      const auto error_code = GetLastError();
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "GetFileSizeEx ", ToMBString(file_path), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
     }
     if (static_cast<ULONGLONG>(filesize.QuadPart) > std::numeric_limits<size_t>::max()) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "GetFileLength: File is too large");
@@ -242,8 +242,8 @@ class WindowsEnv : public Env {
         CreateFileW(file_path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL)};
 #endif
     if (file_handle.get() == INVALID_HANDLE_VALUE) {
-      const int err = GetLastError();
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "open file ", ToMBString(file_path), " fail, errcode = ", err);
+      const auto error_code = GetLastError();
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "open file ", ToMBString(file_path), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
     }
 
     if (length == 0)
@@ -253,8 +253,8 @@ class WindowsEnv : public Env {
       LARGE_INTEGER current_position;
       current_position.QuadPart = offset;
       if (!SetFilePointerEx(file_handle.get(), current_position, &current_position, FILE_BEGIN)) {
-        const int err = GetLastError();
-        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "SetFilePointerEx ", ToMBString(file_path), " fail, errcode = ", err);
+        const auto error_code = GetLastError();
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "SetFilePointerEx ", ToMBString(file_path), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
       }
     }
 
@@ -266,8 +266,8 @@ class WindowsEnv : public Env {
       DWORD bytes_read;
 
       if (!ReadFile(file_handle.get(), buffer.data() + total_bytes_read, bytes_to_read, &bytes_read, nullptr)) {
-        const int err = GetLastError();
-        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "ReadFile ", ToMBString(file_path), " fail, errcode = ", err);
+        const auto error_code = GetLastError();
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "ReadFile ", ToMBString(file_path), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
       }
 
       if (bytes_read != bytes_to_read) {
@@ -344,11 +344,11 @@ class WindowsEnv : public Env {
             }
           } else {  // not directory
             if (!DeleteFileW(child_path.c_str())) {
-              const auto err = GetLastError();
+              const auto error_code = GetLastError();
               final_status = ORT_MAKE_STATUS(
                   ONNXRUNTIME, FAIL,
                   "DeleteFile() failed - path: ", ToMBString(child_path),
-                  ", error code: ", err);
+                  ", error code: ", error_code, " - ", std::system_category().message(error_code));
             }
           }
 
@@ -358,11 +358,11 @@ class WindowsEnv : public Env {
     ORT_RETURN_IF_ERROR(final_status);
 
     if (!RemoveDirectoryW(path.c_str())) {
-      const auto err = GetLastError();
+      const auto error_code = GetLastError();
       final_status = ORT_MAKE_STATUS(
           ONNXRUNTIME, FAIL,
           "RemoveDirectory() failed - path: ", ToMBString(path),
-          ", error code: ", err);
+          ", error code: ", error_code, " - ", std::system_category().message(error_code));
     }
 
     return final_status;
@@ -434,8 +434,8 @@ class WindowsEnv : public Env {
 #endif
 
     if (file_handle.get() == INVALID_HANDLE_VALUE) {
-      const int err = GetLastError();
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "open file ", ToMBString(path), " fail, errcode = ", err);
+      const auto error_code = GetLastError();
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "open file ", ToMBString(path), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
     }
 
     constexpr DWORD initial_buffer_size = MAX_PATH;
@@ -502,7 +502,7 @@ class WindowsEnv : public Env {
 #endif
     if (!*handle) {
       const auto error_code = GetLastError();
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to load library, error code: ", error_code);
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "LoadLibrary failed with error ", error_code, " \"", std::system_category().message(error_code), "\" when trying to load \"", library_filename, "\"");
     }
     return Status::OK();
   }
@@ -510,7 +510,7 @@ class WindowsEnv : public Env {
   virtual Status UnloadDynamicLibrary(void* handle) const override {
     if (::FreeLibrary(reinterpret_cast<HMODULE>(handle)) == 0) {
       const auto error_code = GetLastError();
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to unload library, error code: ", error_code);
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "FreeLibrary failed with error ", error_code, " - ", std::system_category().message(error_code));
     }
     return Status::OK();
   }
@@ -519,8 +519,7 @@ class WindowsEnv : public Env {
     *symbol = ::GetProcAddress(reinterpret_cast<HMODULE>(handle), symbol_name.c_str());
     if (!*symbol) {
       const auto error_code = GetLastError();
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to find symbol in library, error code: ",
-                             error_code);
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to find symbol in library, error code: ", error_code, " - ", std::system_category().message(error_code));
     }
     return Status::OK();
   }


### PR DESCRIPTION
**Description**: Changes the WIndows platform error messages from things like this:

"2021-06-09 18:24:21.8575539 [E:onnxruntime:Default, provider_bridge_ort.cc:1000 onnxruntime::ProviderLibrary::Get] Failed to load library, error code: 126"

To this:

2021-06-09 18:54:17.7950730 [E:onnxruntime:Default, provider_bridge_ort.cc:1000 onnxruntime::ProviderLibrary::Get] LoadLibrary failed with error 126 "The specified module could not be found." when trying to load "C:\Code\Github\onnxruntime\build\Windows\Debug\Debug\onnxruntime\capi\onnxruntime_providers_cuda.dll"

It uses the system error messages to get the text, so it's nothing hardcoded. It will work for every error code the system has a description for.

**Motivation and Context**
The error messages are cryptic and minimal, this will save people a lot of time and confusion.