### PR TITLE
Implement WINRT_IMPL_LoadLibraryW to avoid calling LoadLibraryW directly

### DIFF
--- a/winml/dll/module.cpp
+++ b/winml/dll/module.cpp
@@ -134,3 +134,7 @@ STDAPI DllGetActivationFactory(HSTRING classId, void** factory) {
 
   return ret;
 }
+
+void* __stdcall WINRT_IMPL_LoadLibraryW(wchar_t const* name) noexcept {
+  return LoadLibraryExW(name, nullptr, 0);
+}

--- a/winml/dll/module.cpp
+++ b/winml/dll/module.cpp
@@ -135,6 +135,7 @@ STDAPI DllGetActivationFactory(HSTRING classId, void** factory) {
   return ret;
 }
 
+// LoadLibraryW isn't support on Windows 8.1. This is a workaround so that CppWinRT calls this function for loading libraries
 void* __stdcall WINRT_IMPL_LoadLibraryW(wchar_t const* name) noexcept {
   return LoadLibraryExW(name, nullptr, 0);
 }


### PR DESCRIPTION
Calling LoadLibraryW directly brings in an apiset that isn't supported in Windows 8.1.

This change implements WINRT_IMPL_LoadLibraryW so that cppwinrt calls LoadLibraryExW (which is supported on Windows 8.1)