### PR TITLE
Reduce Kernel Optimization

### DIFF
--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.cc
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.cc
@@ -105,6 +105,9 @@ ApplicableMatrixReduction get_applicable_matrix_reduction(
     return ApplicableMatrixReduction::None;
   }
 
+
+  // Remove all dims with value 1. This can help to optimize case like:
+  // dims=[2,3,1,4,1,5] and axes=[0,2,4], which is same as dims=[2,3,4,5] and axes=[0].
   std::vector<int64_t> new_dims;
   std::vector<int64_t> new_axes;
   const auto original_rank = gsl::narrow<int64_t>(dims.size());
@@ -113,8 +116,6 @@ ApplicableMatrixReduction get_applicable_matrix_reduction(
     original_axes_set.insert(HandleNegativeAxis(axis, original_rank));
   }
 
-  // Remove all dims with value 1. This can help to optimize case like:
-  // dims=[2,3,1,4,1,5] and axes=[0,2,4], which is same as dims=[2,3,4,5] and axes=[0].
   int64_t new_axis = 0;
   for (size_t i = 0; i < dims.size(); i++) {
     bool is_reduce_axis = original_axes_set.find(gsl::narrow<int64_t>(i)) != original_axes_set.end();

--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.cc
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.cc
@@ -133,7 +133,7 @@ ApplicableMatrixReduction get_applicable_matrix_reduction(
   }
 
   // If all dims are value 1, make sure it's not empty by adding a new dim.
-  if (new_dims.empty()) {
+  if (!dims.empty() && new_dims.empty()) {
     new_dims.emplace_back(1);
   }
 

--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.cc
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.cc
@@ -118,10 +118,11 @@ ApplicableMatrixReduction get_applicable_matrix_reduction(
 
   int64_t new_axis = 0;
   for (size_t i = 0; i < dims.size(); i++) {
-    bool is_reduce_axis = original_axes_set.find(gsl::narrow<int64_t>(i)) != original_axes_set.end();
     if (dims[i] != 1) {
       new_dims.emplace_back(dims[i]);
-      if (is_reduce_axis) new_axes.emplace_back(new_axis);
+      if (original_axes_set.find(gsl::narrow<int64_t>(i)) != original_axes_set.end()) {
+        new_axes.emplace_back(new_axis);
+      }
       new_axis++;
     }
   }

--- a/orttraining/orttraining/test/training_ops/cuda/reduce_sum_test.cc
+++ b/orttraining/orttraining/test/training_ops/cuda/reduce_sum_test.cc
@@ -19,7 +19,7 @@ static void TestReduceSum(const std::vector<int64_t>& X_dims,
                           double per_sample_tolerance = 2e-4,
                           double relative_per_sample_tolerance = 2e-4) {
   CompareOpTester test("ReduceSum");
-  test.AddAttribute("axes", axes);
+  if (!axes.empty()) test.AddAttribute("axes", axes);
   test.AddAttribute("keepdims", int64_t(keepdims));
 
   // create rand inputs
@@ -96,6 +96,30 @@ TEST(CudaKernelTest, ReduceSum_LargeTensorTrailingAxes) {
   std::vector<int64_t> X_dims{30528, 4, 512};
   std::vector<int64_t> Y_dims{30528};
   std::vector<int64_t> axes{1, 2};
+  bool keepdims = false;
+  TestReduceSum(X_dims, Y_dims, axes, keepdims);
+}
+
+TEST(CudaKernelTest, ReduceSum_OneDimsOptimization) {
+  std::vector<int64_t> X_dims{2, 3, 1, 4, 1, 5};
+  std::vector<int64_t> Y_dims{3, 4, 5};
+  std::vector<int64_t> axes{0, 2, 4};
+  bool keepdims = false;
+  TestReduceSum(X_dims, Y_dims, axes, keepdims);
+}
+
+TEST(CudaKernelTest, ReduceSum_ReduceOnOneDims) {
+  std::vector<int64_t> X_dims{2, 1, 1};
+  std::vector<int64_t> Y_dims{2};
+  std::vector<int64_t> axes{1, 2};
+  bool keepdims = false;
+  TestReduceSum(X_dims, Y_dims, axes, keepdims);
+}
+
+TEST(CudaKernelTest, ReduceSum_AllOneDims) {
+  std::vector<int64_t> X_dims{1, 1};
+  std::vector<int64_t> Y_dims{};
+  std::vector<int64_t> axes{};
   bool keepdims = false;
   TestReduceSum(X_dims, Y_dims, axes, keepdims);
 }

--- a/orttraining/orttraining/test/training_ops/cuda/reduce_sum_test.cc
+++ b/orttraining/orttraining/test/training_ops/cuda/reduce_sum_test.cc
@@ -38,90 +38,79 @@ static void TestReduceSum(const std::vector<int64_t>& X_dims,
 
 TEST(CudaKernelTest, ReduceSum_Scalar) {
   std::vector<int64_t> X_dims{1};
-  std::vector<int64_t> Y_dims{};
   std::vector<int64_t> axes{0};
-  bool keepdims = false;
-  TestReduceSum(X_dims, Y_dims, axes, keepdims);
+  TestReduceSum(X_dims, {}, axes, false);
+  TestReduceSum(X_dims, {1}, axes, true);
 }
 
 TEST(CudaKernelTest, ReduceSum_2DtoLastDim) {
   std::vector<int64_t> X_dims{16, 2};
-  std::vector<int64_t> Y_dims{2};
   std::vector<int64_t> axes{0};
-  bool keepdims = false;
-  TestReduceSum(X_dims, Y_dims, axes, keepdims);
+  TestReduceSum(X_dims, {2}, axes, false);
+  TestReduceSum(X_dims, {1, 2}, axes, true);
 }
 
 TEST(CudaKernelTest, ReduceSum_SmallTensor) {
   std::vector<int64_t> X_dims{2, 128, 128};
-  std::vector<int64_t> Y_dims{128};
   std::vector<int64_t> axes{0, 1};
-  bool keepdims = false;
-  TestReduceSum(X_dims, Y_dims, axes, keepdims);
+  TestReduceSum(X_dims, {128}, axes, false);
+  TestReduceSum(X_dims, {1, 1, 128}, axes, true);
 }
 
 TEST(CudaKernelTest, ReduceSum_MidTensor) {
   std::vector<int64_t> X_dims{2, 512, 3072};
-  std::vector<int64_t> Y_dims{3072};
   std::vector<int64_t> axes{0, 1};
-  bool keepdims = false;
-  TestReduceSum(X_dims, Y_dims, axes, keepdims);
+  TestReduceSum(X_dims, {3072}, axes, false);
+  TestReduceSum(X_dims, {1, 1, 3072}, axes, true);
 }
 
 TEST(CudaKernelTest, ReduceSum_LargeTensor) {
   std::vector<int64_t> X_dims{4, 512, 30528};
-  std::vector<int64_t> Y_dims{30528};
   std::vector<int64_t> axes{0, 1};
-  bool keepdims = false;
-  TestReduceSum(X_dims, Y_dims, axes, keepdims);
+  TestReduceSum(X_dims, {30528}, axes, false);
+  TestReduceSum(X_dims, {1, 1, 30528}, axes, true);
 }
 
 TEST(CudaKernelTest, ReduceSum_SmallTensorTrailingAxes) {
   std::vector<int64_t> X_dims{128, 2, 128};
-  std::vector<int64_t> Y_dims{128};
   std::vector<int64_t> axes{1, 2};
-  bool keepdims = false;
-  TestReduceSum(X_dims, Y_dims, axes, keepdims);
+  TestReduceSum(X_dims, {128}, axes, false);
+  TestReduceSum(X_dims, {128, 1, 1}, axes, true);
 }
 
 TEST(CudaKernelTest, ReduceSum_MidTensorTrailingAxes) {
   std::vector<int64_t> X_dims{3072, 2, 512};
-  std::vector<int64_t> Y_dims{3072};
   std::vector<int64_t> axes{1, 2};
-  bool keepdims = false;
-  TestReduceSum(X_dims, Y_dims, axes, keepdims);
+  TestReduceSum(X_dims, {3072}, axes, false);
+  TestReduceSum(X_dims, {3072, 1, 1}, axes, true);
 }
 
 TEST(CudaKernelTest, ReduceSum_LargeTensorTrailingAxes) {
   std::vector<int64_t> X_dims{30528, 4, 512};
-  std::vector<int64_t> Y_dims{30528};
   std::vector<int64_t> axes{1, 2};
-  bool keepdims = false;
-  TestReduceSum(X_dims, Y_dims, axes, keepdims);
+  TestReduceSum(X_dims, {30528}, axes, false);
+  TestReduceSum(X_dims, {30528, 1, 1}, axes, true);
 }
 
 TEST(CudaKernelTest, ReduceSum_OneDimsOptimization) {
   std::vector<int64_t> X_dims{2, 3, 1, 4, 1, 5};
-  std::vector<int64_t> Y_dims{3, 4, 5};
   std::vector<int64_t> axes{0, 2, 4};
-  bool keepdims = false;
-  TestReduceSum(X_dims, Y_dims, axes, keepdims);
+  TestReduceSum(X_dims, {3, 4, 5}, axes, false);
+  TestReduceSum(X_dims, {1, 3, 1, 4, 1, 5}, axes, true);
 }
 
 TEST(CudaKernelTest, ReduceSum_ReduceOnOneDims) {
   std::vector<int64_t> X_dims{2, 1, 1};
-  std::vector<int64_t> Y_dims{2};
   std::vector<int64_t> axes{1, 2};
-  bool keepdims = false;
-  TestReduceSum(X_dims, Y_dims, axes, keepdims);
+  TestReduceSum(X_dims, {2}, axes, false);
+  TestReduceSum(X_dims, {2, 1, 1}, axes, true);
 }
 
 TEST(CudaKernelTest, ReduceSum_AllOneDims) {
   std::vector<int64_t> X_dims{1, 1};
-  std::vector<int64_t> Y_dims{};
   std::vector<int64_t> axes{};
-  bool keepdims = false;
-  TestReduceSum(X_dims, Y_dims, axes, keepdims);
+  TestReduceSum(X_dims, {}, axes, false);
+  TestReduceSum(X_dims, {1, 1}, axes, true);
 }
 
 }  // namespace test


### PR DESCRIPTION
Our reduce kernel will check the reduce axes, if all the axes are contiguous, we will use our fast reduce kernel instead of the CUDNN implementation, which is much faster.

For some models exported from PyTorch with Torch.Tensor.repeat on first/last dim, we will use Tile Op for that, and the TileGrad is to reshape the GO to a shape combining input's shape and repeats, and then call ReduceSum on all even dims (start from 0). For example, if it's tensor's shape is [3,4,5] and call tensor.repeat(2,1,1), the ONNX gradient graph will reshape the GO to [2,3,1,4,1,5] and then call ReduceSum on axes [0,2,4], which is not contiguous. But actually we can remove all dims with value 1 from the shape as well as the corresponding axes from the attribute axes. In above example, ReduceSum to [2,3,1,4,1,5] on axes [0,2,4] is same as ReduceSum to [2,3,4,5] on axes [0]. With this change, we can use our fast reduce implementation.

This PR is to adjust the input shape and axes before kernel calculation.

With this fix, for DEBERTA model, it runs ~8% faster (from 3.17it/s to 3.41it/s for a certain config and env).