### PR TITLE
[Android] Move add header files into AAR to using Gradle

### DIFF
--- a/cmake/onnxruntime_java.cmake
+++ b/cmake/onnxruntime_java.cmake
@@ -174,7 +174,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Android")
   add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:onnxruntime> ${ANDROID_PACKAGE_ABI_DIR}/$<TARGET_LINKER_FILE_NAME:onnxruntime>)
   add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:onnxruntime4j_jni> ${ANDROID_PACKAGE_ABI_DIR}/$<TARGET_LINKER_FILE_NAME:onnxruntime4j_jni>)
   # Generate the Android AAR package
-  add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${GRADLE_EXECUTABLE} -b build-android.gradle -c settings-android.gradle build -DjniLibsDir=${ANDROID_PACKAGE_JNILIBS_DIR} -DbuildDir=${ANDROID_PACKAGE_OUTPUT_DIR} -DminSdkVer=${ANDROID_MIN_SDK} WORKING_DIRECTORY ${JAVA_ROOT})
+  add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${GRADLE_EXECUTABLE} -b build-android.gradle -c settings-android.gradle build -DjniLibsDir=${ANDROID_PACKAGE_JNILIBS_DIR} -DbuildDir=${ANDROID_PACKAGE_OUTPUT_DIR} -DminSdkVer=${ANDROID_MIN_SDK} -DheadersDir=${ANDROID_HEADERS_DIR} WORKING_DIRECTORY ${JAVA_ROOT})
 
   if (onnxruntime_BUILD_UNIT_TESTS)
     set(ANDROID_TEST_PACKAGE_ROOT ${JAVA_ROOT}/src/test/android)

--- a/java/build-android.gradle
+++ b/java/build-android.gradle
@@ -167,28 +167,28 @@ publishing {
 // Add ORT C and C++ API headers to the AAR package, after task bundleDebugAar or bundleReleaseAar
 // Such that developers using ORT native API can extract libraries and headers from AAR package without building ORT
 tasks.whenTaskAdded { task ->
-  if (task.name.startsWith("bundle") && task.name.endsWith("Aar")) {
-    doLast {
-      addFolderToAar("addHeadersTo" + task.name, task.archivePath, headersDir, 'headers')
-    }
-  }
+	if (task.name.startsWith("bundle") && task.name.endsWith("Aar")) {
+		doLast {
+			addFolderToAar("addHeadersTo" + task.name, task.archivePath, headersDir, 'headers')
+		}
+	}
 }
 
 def addFolderToAar(taskName, aarPath, folderPath, folderPathInAar) {
-    def tmpDir = file("${buildDir}/${taskName}")
-    tmpDir.mkdir()
-    def tmpDirFolder = file("${tmpDir.path}/${folderPathInAar}")
-    tmpDirFolder.mkdir()
-    copy {
-      from zipTree(aarPath)
-      into tmpDir
-    }
-    copy {
-      from fileTree(folderPath)
-      into tmpDirFolder
-    }
-    ant.zip(destfile: aarPath) {
-      fileset(dir: tmpDir.path)
-    }
-    delete tmpDir
+	def tmpDir = file("${buildDir}/${taskName}")
+	tmpDir.mkdir()
+	def tmpDirFolder = file("${tmpDir.path}/${folderPathInAar}")
+	tmpDirFolder.mkdir()
+	copy {
+		from zipTree(aarPath)
+		into tmpDir
+	}
+	copy {
+		from fileTree(folderPath)
+		into tmpDirFolder
+	}
+	ant.zip(destfile: aarPath) {
+		fileset(dir: tmpDir.path)
+	}
+	delete tmpDir
 }

--- a/java/build-android.gradle
+++ b/java/build-android.gradle
@@ -3,6 +3,7 @@ apply plugin: 'maven-publish'
 
 def jniLibsDir = System.properties['jniLibsDir']
 def buildDir = System.properties['buildDir']
+def headersDir = System.properties['headersDir']
 def publishDir = System.properties['publishDir']
 def minSdkVer = System.properties['minSdkVer']
 def targetSdkVer = System.properties['targetSdkVer']
@@ -161,4 +162,33 @@ publishing {
 			url "$publishDir"
 		}
 	}
+}
+
+// Add ORT C and C++ API headers to the AAR package, after task bundleDebugAar or bundleReleaseAar
+// Such that developers using ORT native API can extract libraries and headers from AAR package without building ORT
+tasks.whenTaskAdded { task ->
+  if (task.name.startsWith("bundle") && task.name.endsWith("Aar")) {
+    doLast {
+      addFolderToAar("addHeadersTo" + task.name, task.archivePath, headersDir, 'headers')
+    }
+  }
+}
+
+def addFolderToAar(taskName, aarPath, folderPath, folderPathInAar) {
+    def tmpDir = file("${buildDir}/${taskName}")
+    tmpDir.mkdir()
+    def tmpDirFolder = file("${tmpDir.path}/${folderPathInAar}")
+    tmpDirFolder.mkdir()
+    copy {
+      from zipTree(aarPath)
+      into tmpDir
+    }
+    copy {
+      from fileTree(folderPath)
+      into tmpDirFolder
+    }
+    ant.zip(destfile: aarPath) {
+      fileset(dir: tmpDir.path)
+    }
+    delete tmpDir
 }


### PR DESCRIPTION
**Description**: [Android] Move add header files into AAR to using Gradle

**Motivation and Context**
- For now we use the shutil in python to add header files into AAR package in the python script, move this into the build-android.gradle to simplify the process
- Some minor updates to the build_aar_package.py for better variable naming
