### PR TITLE
Loosen validation checks in Concat to unblock execution of model in #8020

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/concat.cc
+++ b/onnxruntime/core/providers/cpu/tensor/concat.cc
@@ -30,8 +30,10 @@ ONNX_CPU_OPERATOR_KERNEL(
     Concat);
 
 static bool DimsAllZero(const std::vector<int64_t>& dims) {
-  if (dims.size() == 0)
-    return false;  // scalar is not all zeros
+  if (dims.size() == 0) {
+    // scalar is not all zeros
+    return false;
+  }
 
   for (auto dim : dims) {
     if (dim != 0) {

--- a/onnxruntime/core/providers/cpu/tensor/concat.cc
+++ b/onnxruntime/core/providers/cpu/tensor/concat.cc
@@ -71,9 +71,10 @@ Status ConcatBase::PrepareForCompute(OpKernelContext* ctx,
   }
 
   if (all_inputs_are_empty) {
-    // Reference dim (used to compute output shape downstream)
-    // and reference rank(used to validate ranks across all inputs)
-    // can just come from the first input
+    // Reference dim and reference rank can just come from the first input
+    // No shape/rank validations will be done (as all inputs are empty).
+    // But the rest of the execution flow (filling in the Prepare instance - p)
+    // can use this info.
     reference_dims = input_tensors[0]->Shape().GetDims();
     reference_rank = reference_dims.size();
   }

--- a/onnxruntime/core/providers/cpu/tensor/gather_nd.cc
+++ b/onnxruntime/core/providers/cpu/tensor/gather_nd.cc
@@ -136,6 +136,11 @@ Status GatherND::Compute(OpKernelContext* context) const {
   const auto& input_shape = input_tensor->Shape();
   const auto& indices_shape = indices_tensor->Shape();
 
+  if (Node().Name() == "StatefulPartitionedCall/mask_rcnn/roi_align_mask/GatherNd_3") {
+    double d = 2.34;
+    ORT_IGNORE_RETURN_VALUE(d);
+  }
+
   int64_t last_indices_dimension = batch_dims_ + indices_shape[indices_shape.NumDimensions() - 1];
   if (last_indices_dimension > static_cast<int64_t>(input_shape.NumDimensions())) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
@@ -147,6 +152,11 @@ Status GatherND::Compute(OpKernelContext* context) const {
                input_shape.GetDims().end());
 
   auto* output_tensor = context->Output(0, TensorShape(std::move(shape)));
+
+  // Bail out early in case the output is going to be empty
+  if (output_tensor->Shape().Size() == 0) {
+    return Status::OK();
+  }
 
   Prepare p;
   concurrency::ThreadPool* tp = context->GetOperatorThreadPool();

--- a/onnxruntime/core/providers/cpu/tensor/gather_nd.cc
+++ b/onnxruntime/core/providers/cpu/tensor/gather_nd.cc
@@ -136,11 +136,6 @@ Status GatherND::Compute(OpKernelContext* context) const {
   const auto& input_shape = input_tensor->Shape();
   const auto& indices_shape = indices_tensor->Shape();
 
-  if (Node().Name() == "StatefulPartitionedCall/mask_rcnn/roi_align_mask/GatherNd_3") {
-    double d = 2.34;
-    ORT_IGNORE_RETURN_VALUE(d);
-  }
-
   int64_t last_indices_dimension = batch_dims_ + indices_shape[indices_shape.NumDimensions() - 1];
   if (last_indices_dimension > static_cast<int64_t>(input_shape.NumDimensions())) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,

--- a/onnxruntime/core/providers/cuda/tensor/gather_nd.cc
+++ b/onnxruntime/core/providers/cuda/tensor/gather_nd.cc
@@ -193,6 +193,11 @@ Status GatherND<TIndex>::ComputeInternal(OpKernelContext* context) const {
 
   auto output_tensor = context->Output(0, TensorShape(shape));
 
+  // Bail out early in case the output is going to be empty
+  if (output_tensor->Shape().Size() == 0) {
+    return Status::OK();
+  }
+
   // Compute
   int64_t num_slices;
   int64_t slice_size;

--- a/onnxruntime/test/providers/cpu/tensor/concat_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/concat_op_test.cc
@@ -111,49 +111,9 @@ TEST(ConcatOpTest, Concat2D_3) {
             kNnapiExecutionProvider});   // NNAPI: concat does not support 0 size input
 }
 
-// Context GH issue: 8020
-// Test looser validation of the check proposed in the Concat ONNX spec
-// that says all dim values of axes not concatenated on MUST be equal.
-// In some family of models, Loops feed into Concat and some Loops have
-// iteration counts of 0s, which means the dims of the some inputs getting
-// concatenated are all zeros: [0, ..., 0].
-// The Concat implementation we have is permissive to these "mis-matches" alone.
-// This test is currently not enabled because shape inference "catches" the mis-match
-// in dim values along axis = 0. Enable the test if we the test infrastructure allows us
-// to ignore shape inference failures.
-
-/*
-TEST(ConcatOpTest, Concat2D_4) {
-  OpTester test("Concat");
-  test.AddAttribute("axis", int64_t{1});
-
-  test.AddInput<float>("input1", {1, 0}, {});
-  // axis '0' has a value of 0 which doesn't match 1 seen in the other inputs
-  test.AddInput<float>("input2", {0, 0}, {});
-  test.AddInput<float>("input3", {1, 0}, {});
-  test.AddOutput<float>("concat_result", {1, 0}, {});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider,  //TensorRT: no support for dynamic shape tensor
-            kNnapiExecutionProvider});   // NNAPI: concat does not support 0 size input
-}
-*/
-TEST(ConcatOpTest, Concat2D_5) {
-  OpTester test("Concat");
-  test.AddAttribute("axis", int64_t{1});
-
-  // Check concatenating inputs with all 0 dims
-  test.AddInput<float>("input1", {0, 0}, {});
-  test.AddInput<float>("input2", {0, 0}, {});
-  test.AddInput<float>("input3", {0, 0}, {});
-  test.AddOutput<float>("concat_result", {0, 0}, {});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider,  //TensorRT: no support for dynamic shape tensor
-            kNnapiExecutionProvider});   // NNAPI: concat does not support 0 size input
-}
-
 // Test Concat of tensors when one of them has dynamic shape
 // This is useful for testing EP's own shape inferencing, such as NNAPI EP
-TEST(ConcatOpTest, Concat2D_6) {
+TEST(ConcatOpTest, Concat2D_4) {
   OpTester test("Concat");
   test.AddAttribute("axis", int64_t{1});
 


### PR DESCRIPTION
**Description**: 

If the Loop operator has an iteration count of zero, the pedantic way to deal with it would be to execute the subgraph and obtain the output shapes of the scan outputs and pre-pend their shapes with 0. This preserves the "right" shape information for downstream operators to work with these empty outputs from Loop. In our implementation of Loop, we avoid executing the subgraph (as an optimization to save execution cycles - since the scan outputs of Loop with an iteration count of 0 are going to be empty anyway). We do the best we can with respect to the shape(s) of these empty scan outputs. We use the ONNX shape inference information to compose the shape(s) of these scan outputs. If we encounter symbolic dimensions, we use '0' instead (trying to compose a shape that has the same rank as the ONNX shape inferred shape atleast). In case, no rank information is available, we log a warning and just use a shape of {0} for these scan outputs. The "lossy" nature of this shape composition process means downstream node checks need to be less pedantic in their shape validations as well. This change loosens one such pedantic check in `Concat`.

In the OP's model in #8020, multiple Loops feed into a Concat, and in some cases, atleast one Loop feeding into the Concat has an iteration count of zero and the runtime check in Concat fails when trying to concatenate inputs like this (simplified for illustration only): [2, y1, y2, y3] and [0, 0, 0, 0] on axis = 0. The check complains that the axes not being concatenated on are not the equal. We make this check less restrictive. 

This PR may seem a bit hacky but this is quite an uncommon graph structure and there is nothing to lose by making a check less restrictive in one operator to unblock model execution.

The corner case handling in `GatherND` is needed for this model as well. With these changes, the model runs fine on CPU and CUDA.

**Motivation and Context**
Resolve https://github.com/microsoft/onnxruntime/issues/8020