### PR TITLE
initialize generated_value_names with graph input

### DIFF
--- a/onnxruntime/python/tools/quantization/onnx_model.py
+++ b/onnxruntime/python/tools/quantization/onnx_model.py
@@ -47,6 +47,9 @@ class ONNXModel:
                 return tensor
         return None
 
+    def get_initializer_name_set(self):
+        return set(initializer.name for initializer in self.model.graph.initializer)
+
     def remove_initializer(self, tensor):
         if tensor in self.model.graph.initializer:
             self.model.graph.initializer.remove(tensor)
@@ -58,6 +61,14 @@ class ONNXModel:
     def remove_initializers(self, init_to_remove):
         for initializer in init_to_remove:
             self.remove_initializer(initializer)
+
+    def get_non_initializer_inputs(self):
+        initializer_names = self.get_initializer_name_set()
+        non_initializer_inputs = set()
+        for input in self.model.graph.input:
+            if input.name not in initializer_names:
+                non_initializer_inputs.add(input.name)
+        return non_initializer_inputs
 
     def input_name_to_nodes(self):
         input_name_to_nodes = {}

--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -83,7 +83,7 @@ class ONNXQuantizer:
         self.quantized_value_map = {}
         # some output from nodes will be quantized, yet itself should be treat as existing so
         # no dequantized will be applied when needed later
-        self.generated_value_names = {}
+        self.generated_value_names = self.model.get_non_initializer_inputs()
 
     def check_opset_version(self):
         ai_onnx_domain = [

--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -208,7 +208,7 @@ class ONNXQuantizer:
             op_quantizer.quantize()
             for i in range(number_of_existing_new_nodes, len(self.new_nodes)):
                 for output_name in self.new_nodes[i].output:
-                    self.generated_value_names.update({output_name : 1})
+                    self.generated_value_names.add(output_name)
 
         self._dequantize_outputs()
 


### PR DESCRIPTION
generated_value_names should be initialized with graph input, or it will add a dequantize for input, which is used by another op.
