### PR TITLE
update install instruction and update 404 links

### DIFF
--- a/docs/how-to/build/training.md
+++ b/docs/how-to/build/training.md
@@ -66,7 +66,6 @@ These dependency versions should reflect what is in [Dockerfile.training](https:
     export PATH=<location for openmpi/bin/>:$PATH
     export LD_LIBRARY_PATH=<location for openmpi/lib/>:$LD_LIBRARY_PATH
     export MPI_CXX_INCLUDE_PATH=<location for openmpi/include/>
-    source <location of the mpivars script> # e.g. /data/intel/impi/2018.3.222/intel64/bin/mpivars.sh
     ```
 
 3. Create the ONNX Runtime wheel

--- a/docs/tutorials/training/ort-training.md
+++ b/docs/tutorials/training/ort-training.md
@@ -4,13 +4,16 @@ grand_parent: Tutorials
 parent: Training
 nav_order: 1
 ---
-# Accelerate PyTorch model training
+# ORTModule Examples
+* [Use ORTModule with HuggingFace Models](https://github.com/microsoft/onnxruntime-training-examples/tree/master/huggingface)
+
+# (deprecated) ORTTrainer Examples
 {: .no_toc }
 
-* [Get Started: Basic PyTorch transformer model](https://github.com/microsoft/onnxruntime-training-examples/tree/master/getting-started)
+* [Get Started: Basic PyTorch transformer model](https://github.com/microsoft/onnxruntime-training-examples/tree/master/orttrainer/getting-started)
 
-* [Accelerate pre-training of large BERT model](https://github.com/microsoft/onnxruntime-training-examples/tree/master/nvidia-bert)
+* [Accelerate pre-training of large BERT model](https://github.com/microsoft/onnxruntime-training-examples/tree/master/orttrainer/nvidia-bert)
 
-* [Accelerate fine tuning of Huggingface GPT2 model](https://github.com/microsoft/onnxruntime-training-examples/tree/master/huggingface-gpt2)
+* [Accelerate fine tuning of Huggingface GPT2 model](https://github.com/microsoft/onnxruntime-training-examples/tree/master/orttrainer/huggingface-gpt2)
 
 * *More coming soon!*


### PR DESCRIPTION
**Description**: This is to address this github issue https://github.com/microsoft/onnxruntime/issues/8049 with a thread in Teams ORT DRI channel. Details for this change in the thread. Also updated example links.

I cannot find settings > pages, as described in https://github.com/microsoft/onnxruntime/wiki/Update-ONNX-Runtime-Docs#preview-change. Nor did I receive an email saying page is built. But I previewed the changes locally.