### PR TITLE
[Android] Output error message to android log instead of stderr

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -859,11 +859,11 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
       )
     add_executable(onnxruntime_eager_mode_test ${onnxruntime_eager_mode_test_src})
     target_include_directories(onnxruntime_eager_mode_test PRIVATE ${ONNXRUNTIME_ROOT}
-            ${onnxruntime_graph_header} 
+            ${onnxruntime_graph_header}
             ${onnxruntime_exec_src_dir}
             ${CMAKE_CURRENT_BINARY_DIR}
             "${TEST_SRC_DIR}/util/include")
-    set(onnxruntime_eager_mode_libs 
+    set(onnxruntime_eager_mode_libs
             onnxruntime_eager
             onnxruntime_session
             onnxruntime_optimizer
@@ -871,11 +871,11 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
             onnxruntime_util
             onnxruntime_framework
             flatbuffers
-            onnxruntime_graph 
+            onnxruntime_graph
             onnxruntime_common
             onnxruntime_mlas
-            onnx 
-            onnx_proto 
+            onnx
+            onnx_proto
             ${PROTOBUF_LIB}
             GTest::gtest
             re2::re2
@@ -883,7 +883,7 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
             ${CMAKE_DL_LIBS}
             )
     if(onnxruntime_ENABLE_TRAINING)
-      list(APPEND onnxruntime_eager_mode_libs onnxruntime_training tensorboard) 
+      list(APPEND onnxruntime_eager_mode_libs onnxruntime_training tensorboard)
     endif()
     IF(NOT WIN32)
       list(APPEND onnxruntime_eager_mode_libs nsync_cpp)
@@ -1074,6 +1074,9 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
   if(NOT WIN32)
     list(APPEND onnxruntime_mlas_test_libs nsync_cpp ${CMAKE_DL_LIBS})
   endif()
+  if (CMAKE_SYSTEM_NAME STREQUAL "Android")
+    list(APPEND onnxruntime_mlas_test_libs ${android_shared_libs})
+  endif()
   if (onnxruntime_USE_OPENMP)
     list(APPEND onnxruntime_mlas_test_libs OpenMP::OpenMP_CXX)
   endif()
@@ -1144,7 +1147,7 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
   endif()
 
   # limit to only test on windows first, due to a runtime path issue on linux
-  if (NOT onnxruntime_MINIMAL_BUILD AND NOT onnxruntime_EXTENDED_MINIMAL_BUILD 
+  if (NOT onnxruntime_MINIMAL_BUILD AND NOT onnxruntime_EXTENDED_MINIMAL_BUILD
                                     AND NOT onnxruntime_ENABLE_TRAINING
                                     AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin|iOS"
                                     AND NOT (CMAKE_SYSTEM_NAME STREQUAL "Android")

--- a/include/onnxruntime/core/common/common.h
+++ b/include/onnxruntime/core/common/common.h
@@ -40,14 +40,6 @@
 #include <mimalloc.h>
 #endif
 
-#ifdef ORT_NO_EXCEPTIONS
-#if defined(__ANDROID__)
-#include <android/log.h>
-#else
-#include <iostream>
-#endif
-#endif
-
 namespace onnxruntime {
 
 using TimePoint = std::chrono::high_resolution_clock::time_point;
@@ -81,18 +73,12 @@ using common::Status;
 #define ORT_ATTRIBUTE_UNUSED
 #endif
 
-// ORT_PRINT_ERROR_MSG
-// Print the given error message, the message must be a null terminated char*
+#ifdef ORT_NO_EXCEPTIONS
+// Print the given final message, the message must be a null terminated char*
+// ORT will abort after printing the message.
 // For Android, will print to Android system log
 // For other platforms, will print to stderr
-#ifdef ORT_NO_EXCEPTIONS
-#if defined(__ANDROID__)
-#define ORT_PRINT_ERROR_MSG(msg) \
-  __android_log_print(ANDROID_LOG_ERROR, "onnxruntime", "%s", msg);
-#else
-#define ORT_PRINT_ERROR_MSG(msg) \
-  std::cerr << msg << std::endl;
-#endif
+void PrintFinalMessage(const char* msg);
 #endif
 
 // macro to explicitly ignore the return value from a function call so Code Analysis doesn't complain
@@ -128,17 +114,12 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 // a lambda function. otherwise the exception referred will be undefined and cause build break
 #define ORT_HANDLE_EXCEPTION(func)
 
-// TODO, consider changing the output of the error message from std::cerr to logging when the
-// exceptions are disabled, since using std::cerr might increase binary size, and std::cerr output
-// might not be easily accesible on some systems such as mobile
-// TODO, see if we need to change the output of the error message from std::cerr to NSLog for iOS
-
 // Throw an exception with optional message.
 // NOTE: The arguments get streamed into a string via ostringstream::operator<<
 // DO NOT use a printf format string, as that will not work as you expect.
 #define ORT_THROW(...)                                                    \
   do {                                                                    \
-    ORT_PRINT_ERROR_MSG(                                                  \
+    PrintErrorMessage(                                                    \
         ::onnxruntime::OnnxRuntimeException(                              \
             ORT_WHERE_WITH_STACK, ::onnxruntime::MakeString(__VA_ARGS__)) \
             .what());                                                     \
@@ -148,7 +129,7 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 // Just in order to mark things as not implemented. Do not use in final code.
 #define ORT_NOT_IMPLEMENTED(...)                                                       \
   do {                                                                                 \
-    ORT_PRINT_ERROR_MSG(                                                               \
+    PrintErrorMessage(                                                                 \
         ::onnxruntime::NotImplementedException(::onnxruntime::MakeString(__VA_ARGS__)) \
             .what());                                                                  \
     abort();                                                                           \
@@ -160,7 +141,7 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 #define ORT_ENFORCE(condition, ...)                                                   \
   do {                                                                                \
     if (!(condition)) {                                                               \
-      ORT_PRINT_ERROR_MSG(                                                            \
+      PrintErrorMessage(                                                              \
           ::onnxruntime::OnnxRuntimeException(ORT_WHERE_WITH_STACK, #condition,       \
                                               ::onnxruntime::MakeString(__VA_ARGS__)) \
               .what());                                                               \
@@ -170,7 +151,7 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 
 #define ORT_THROW_EX(ex, ...)                                                                      \
   do {                                                                                             \
-    ORT_PRINT_ERROR_MSG(                                                                           \
+    PrintErrorMessage(                                                                             \
         ::onnxruntime::MakeString(#ex, "(", ::onnxruntime::MakeString(__VA_ARGS__), ")").c_str()); \
     abort();                                                                                       \
   } while (false)

--- a/include/onnxruntime/core/common/common.h
+++ b/include/onnxruntime/core/common/common.h
@@ -119,7 +119,7 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 // DO NOT use a printf format string, as that will not work as you expect.
 #define ORT_THROW(...)                                                    \
   do {                                                                    \
-    PrintErrorMessage(                                                    \
+    PrintFinalMessage(                                                    \
         ::onnxruntime::OnnxRuntimeException(                              \
             ORT_WHERE_WITH_STACK, ::onnxruntime::MakeString(__VA_ARGS__)) \
             .what());                                                     \
@@ -129,7 +129,7 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 // Just in order to mark things as not implemented. Do not use in final code.
 #define ORT_NOT_IMPLEMENTED(...)                                                       \
   do {                                                                                 \
-    PrintErrorMessage(                                                                 \
+    PrintFinalMessage(                                                                 \
         ::onnxruntime::NotImplementedException(::onnxruntime::MakeString(__VA_ARGS__)) \
             .what());                                                                  \
     abort();                                                                           \
@@ -141,7 +141,7 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 #define ORT_ENFORCE(condition, ...)                                                   \
   do {                                                                                \
     if (!(condition)) {                                                               \
-      PrintErrorMessage(                                                              \
+      PrintFinalMessage(                                                              \
           ::onnxruntime::OnnxRuntimeException(ORT_WHERE_WITH_STACK, #condition,       \
                                               ::onnxruntime::MakeString(__VA_ARGS__)) \
               .what());                                                               \
@@ -151,7 +151,7 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 
 #define ORT_THROW_EX(ex, ...)                                                                      \
   do {                                                                                             \
-    PrintErrorMessage(                                                                             \
+    PrintFinalMessage(                                                                             \
         ::onnxruntime::MakeString(#ex, "(", ::onnxruntime::MakeString(__VA_ARGS__), ")").c_str()); \
     abort();                                                                                       \
   } while (false)

--- a/include/onnxruntime/core/common/common.h
+++ b/include/onnxruntime/core/common/common.h
@@ -119,7 +119,7 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 // DO NOT use a printf format string, as that will not work as you expect.
 #define ORT_THROW(...)                                                    \
   do {                                                                    \
-    PrintFinalMessage(                                                    \
+    ::onnxruntime::PrintFinalMessage(                                     \
         ::onnxruntime::OnnxRuntimeException(                              \
             ORT_WHERE_WITH_STACK, ::onnxruntime::MakeString(__VA_ARGS__)) \
             .what());                                                     \
@@ -129,7 +129,7 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 // Just in order to mark things as not implemented. Do not use in final code.
 #define ORT_NOT_IMPLEMENTED(...)                                                       \
   do {                                                                                 \
-    PrintFinalMessage(                                                                 \
+    ::onnxruntime::PrintFinalMessage(                                                  \
         ::onnxruntime::NotImplementedException(::onnxruntime::MakeString(__VA_ARGS__)) \
             .what());                                                                  \
     abort();                                                                           \
@@ -141,7 +141,7 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 #define ORT_ENFORCE(condition, ...)                                                   \
   do {                                                                                \
     if (!(condition)) {                                                               \
-      PrintFinalMessage(                                                              \
+      ::onnxruntime::PrintFinalMessage(                                               \
           ::onnxruntime::OnnxRuntimeException(ORT_WHERE_WITH_STACK, #condition,       \
                                               ::onnxruntime::MakeString(__VA_ARGS__)) \
               .what());                                                               \
@@ -151,7 +151,7 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 
 #define ORT_THROW_EX(ex, ...)                                                                      \
   do {                                                                                             \
-    PrintFinalMessage(                                                                             \
+    ::onnxruntime::PrintFinalMessage(                                                              \
         ::onnxruntime::MakeString(#ex, "(", ::onnxruntime::MakeString(__VA_ARGS__), ")").c_str()); \
     abort();                                                                                       \
   } while (false)

--- a/onnxruntime/core/common/helper.cc
+++ b/onnxruntime/core/common/helper.cc
@@ -1,11 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#ifdef _WIN32
+
 #include "core/common/common.h"
+
+#ifdef _WIN32
 #include <Windows.h>
 #include <assert.h>
+#endif
+
+#ifdef ORT_NO_EXCEPTIONS
+#if defined(__ANDROID__)
+#include <android/log.h>
+#else
+#include <iostream>
+#endif
+#endif
 
 namespace onnxruntime {
+#ifdef _WIN32
 std::string ToMBString(const std::wstring& s) {
   if (s.size() >= static_cast<size_t>(std::numeric_limits<int>::max()))
     ORT_THROW("length overflow");
@@ -31,6 +43,21 @@ std::wstring ToWideString(const std::string& s) {
   assert(len == r);
   return ret;
 }
+#endif  //#ifdef _WIN32
+
+#ifdef ORT_NO_EXCEPTIONS
+void PrintFinalMessage(const char* msg) {
+#if defined(__ANDROID__)
+  __android_log_print(ANDROID_LOG_ERROR, "onnxruntime", "%s", msg);
+#else
+  // TODO, consider changing the output of the error message from std::cerr to logging when the
+  // exceptions are disabled, since using std::cerr might increase binary size, and std::cerr output
+  // might not be easily accesible on some systems such as mobile
+  // TODO, see if we need to change the output of the error message from std::cerr to NSLog for iOS
+  std::cerr << msg << std::endl
+            << std::flush;
+#endif
+}
+#endif  //#ifdef ORT_NO_EXCEPTIONS
 
 }  // namespace onnxruntime
-#endif

--- a/onnxruntime/core/common/helper.cc
+++ b/onnxruntime/core/common/helper.cc
@@ -54,8 +54,7 @@ void PrintFinalMessage(const char* msg) {
   // exceptions are disabled, since using std::cerr might increase binary size, and std::cerr output
   // might not be easily accesible on some systems such as mobile
   // TODO, see if we need to change the output of the error message from std::cerr to NSLog for iOS
-  std::cerr << msg << std::endl
-            << std::flush;
+  std::cerr << msg << std::endl;
 #endif
 }
 #endif  //#ifdef ORT_NO_EXCEPTIONS


### PR DESCRIPTION
**Description**: [Android] Output error message to android log instead of stderr

**Motivation and Context**
- When use minimal build with exception disabled on Android, the error messages of ORT_THROW/ORT_NOT_IMPLEMENTED/ORT_ENFORCE/ORT_THROW_EX are output to stderr, if the APP using ORT triggers these, the App will crash and usually we cannot see the error message, change the output of the error message to Android System log which will be captured by logcat
- For now seems iOS will redirect stderr/stdout to XCode console, so we probably don't need to change the output of error message on iOS to NSLog for now, added TODO in the code
