### PR TITLE
Fix a compile error in InferenceTest.cs

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -186,10 +186,10 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             Assert.Equal("CPUExecutionProvider", providers[providers.Length - 1]);
 
 # if USE_CUDA
-            Assert.True(Array.Exists(providers, provider => provider == "CUDAExecutionProvider"););
+            Assert.True(Array.Exists(providers, provider => provider == "CUDAExecutionProvider"));
 #endif
 # if USE_ROCM
-            Assert.True(Array.Exists(providers, provider => provider == "ROCMExecutionProvider"););
+            Assert.True(Array.Exists(providers, provider => provider == "ROCMExecutionProvider"));
 #endif
 
         }


### PR DESCRIPTION
**Description**: 

Fix a compile error in InferenceTest.cs. Introduced in #5608.

**Motivation and Context**
- Why is this change required? What problem does it solve?

To enable C# GPU tests. I will put the pipeline changes in another PR.

- If it fixes an open issue, please link to the issue here.
