### PR TITLE
[Mobile package] Update required operator config with additional ops for newer version of Wav2Vec 2.

### DIFF
--- a/tools/ci_build/github/android/mobile_package.required_operators.config
+++ b/tools/ci_build/github/android/mobile_package.required_operators.config
@@ -14,8 +14,8 @@ ai.onnx;12;Abs,Add,And,ArgMax,ArgMin,AveragePool,Cast,Ceil,Clip,Concat,ConstantO
 ai.onnx;13;Abs,Add,And,ArgMax,ArgMin,AveragePool,Cast,Ceil,Clip,Concat,ConstantOfShape,Conv,ConvTranspose,Cos,CumSum,DepthToSpace,DequantizeLinear,Div,DynamicQuantizeLinear,Elu,Equal,Exp,Expand,Flatten,Floor,Gather,GatherND,Gemm,Greater,GreaterOrEqual,Identity,If,LRN,LeakyRelu,Less,LessOrEqual,Log,LogSoftmax,Loop,MatMul,Max,MaxPool,Mean,Min,Mul,Neg,NonMaxSuppression,NonZero,Not,Or,PRelu,Pad,Pow,QuantizeLinear,Range,Reciprocal,ReduceMax,ReduceMean,ReduceMin,ReduceProd,ReduceSum,Relu,Reshape,Resize,ReverseSequence,Round,ScatterND,Shape,Sigmoid,Sin,Size,Slice,Softmax,SpaceToDepth,Split,Sqrt,Squeeze,Sub,Sum,Tanh,ThresholdedRelu,Tile,TopK,Transpose,Unique,Unsqueeze,Where
 
 # other ops found in test models 
-ai.onnx;12;GlobalAveragePool,MatMulInteger,QLinearConv,QLinearMatMul
-ai.onnx;13;GlobalAveragePool,MatMulInteger,QLinearConv,QLinearMatMul
+ai.onnx;12;Erf,GlobalAveragePool,InstanceNormalization,MatMulInteger,QLinearConv,QLinearMatMul
+ai.onnx;13;Erf,GlobalAveragePool,InstanceNormalization,MatMulInteger,QLinearConv,QLinearMatMul
 
 # Control flow ops
 #  - If and Loop are covered by the tflite converter list
@@ -24,7 +24,9 @@ ai.onnx;12;Scan
 ai.onnx;13;Scan
 
 # internal ops added by optimizers
-com.microsoft;1;DynamicQuantizeMatMul,FusedConv,FusedGemm,FusedMatMul,MatMulIntegerToFloat,NhwcMaxPool,QLinearAdd,QLinearAveragePool,QLinearConv,QLinearGlobalAveragePool,QLinearMul,QLinearSigmoid
+# Note: LayerNormalization is an internal op even though it is (incorrectly) registered in the ONNX domain.
+ai.onnx;1;LayerNormalization
+com.microsoft;1;DynamicQuantizeMatMul,FusedConv,FusedGemm,FusedMatMul,Gelu,MatMulIntegerToFloat,NhwcMaxPool,QLinearAdd,QLinearAveragePool,QLinearConv,QLinearGlobalAveragePool,QLinearMul,QLinearSigmoid
 # NHWC transformer also uses this, so assuming it's valuable enough to include 
 com.microsoft;1;QLinearLeakyRelu
 

--- a/tools/ci_build/github/android/mobile_package.required_operators.config
+++ b/tools/ci_build/github/android/mobile_package.required_operators.config
@@ -14,8 +14,8 @@ ai.onnx;12;Abs,Add,And,ArgMax,ArgMin,AveragePool,Cast,Ceil,Clip,Concat,ConstantO
 ai.onnx;13;Abs,Add,And,ArgMax,ArgMin,AveragePool,Cast,Ceil,Clip,Concat,ConstantOfShape,Conv,ConvTranspose,Cos,CumSum,DepthToSpace,DequantizeLinear,Div,DynamicQuantizeLinear,Elu,Equal,Exp,Expand,Flatten,Floor,Gather,GatherND,Gemm,Greater,GreaterOrEqual,Identity,If,LRN,LeakyRelu,Less,LessOrEqual,Log,LogSoftmax,Loop,MatMul,Max,MaxPool,Mean,Min,Mul,Neg,NonMaxSuppression,NonZero,Not,Or,PRelu,Pad,Pow,QuantizeLinear,Range,Reciprocal,ReduceMax,ReduceMean,ReduceMin,ReduceProd,ReduceSum,Relu,Reshape,Resize,ReverseSequence,Round,ScatterND,Shape,Sigmoid,Sin,Size,Slice,Softmax,SpaceToDepth,Split,Sqrt,Squeeze,Sub,Sum,Tanh,ThresholdedRelu,Tile,TopK,Transpose,Unique,Unsqueeze,Where
 
 # other ops found in test models 
-ai.onnx;12;Erf,GlobalAveragePool,InstanceNormalization,MatMulInteger,QLinearConv,QLinearMatMul
-ai.onnx;13;Erf,GlobalAveragePool,InstanceNormalization,MatMulInteger,QLinearConv,QLinearMatMul
+ai.onnx;12;GlobalAveragePool,MatMulInteger,QLinearConv,QLinearMatMul
+ai.onnx;13;GlobalAveragePool,MatMulInteger,QLinearConv,QLinearMatMul
 
 # Control flow ops
 #  - If and Loop are covered by the tflite converter list
@@ -24,9 +24,7 @@ ai.onnx;12;Scan
 ai.onnx;13;Scan
 
 # internal ops added by optimizers
-# Note: LayerNormalization is an internal op even though it is (incorrectly) registered in the ONNX domain.
-ai.onnx;1;LayerNormalization
-com.microsoft;1;BiasGelu,DynamicQuantizeMatMul,FusedConv,FusedGemm,FusedMatMul,Gelu,MatMulIntegerToFloat,NhwcMaxPool,QLinearAdd,QLinearAveragePool,QLinearConv,QLinearGlobalAveragePool,QLinearMul,QLinearSigmoid,SkipLayerNormalization
+com.microsoft;1;DynamicQuantizeMatMul,FusedConv,FusedGemm,FusedMatMul,MatMulIntegerToFloat,NhwcMaxPool,QLinearAdd,QLinearAveragePool,QLinearConv,QLinearGlobalAveragePool,QLinearMul,QLinearSigmoid
 # NHWC transformer also uses this, so assuming it's valuable enough to include 
 com.microsoft;1;QLinearLeakyRelu
 

--- a/tools/ci_build/github/android/mobile_package.required_operators.readme.txt
+++ b/tools/ci_build/github/android/mobile_package.required_operators.readme.txt
@@ -77,3 +77,4 @@ Other
   - DeepLabV3 (https://pytorch.org/tutorials/beginner/deeplabv3_on_android.html)
   - EfficientNet (https://github.com/lukemelas/EfficientNet-PyTorch)
   - SSD Mobilenet V1 and V2 (https://github.com/qfgaohao/pytorch-ssd)
+  - Wav2Vec 2.0 (adapted from https://github.com/pytorch/ios-demo-app/blob/f2b9aa196821c136d3299b99c5dd592de1fa1776/SpeechRecognition/create_wav2vec2.py)

--- a/tools/ci_build/github/android/mobile_package.required_operators.readme.txt
+++ b/tools/ci_build/github/android/mobile_package.required_operators.readme.txt
@@ -77,4 +77,3 @@ Other
   - DeepLabV3 (https://pytorch.org/tutorials/beginner/deeplabv3_on_android.html)
   - EfficientNet (https://github.com/lukemelas/EfficientNet-PyTorch)
   - SSD Mobilenet V1 and V2 (https://github.com/qfgaohao/pytorch-ssd)
-  - wav2vec 2.0 (adapted from https://github.com/pytorch/ios-demo-app/blob/9845c51c2b417416ccd11277c46e54f9ab811d37/SpeechRecognition/create_wav2vec2.py)


### PR DESCRIPTION
**Description**
This is an update to https://github.com/microsoft/onnxruntime/pull/8079
The sample application motivating the original update changed to use an updated version of the model. Now, fewer ops are required. This PR removes the previously added ops which are no longer needed.

**Motivation and Context**
Mobile package model support.
