### PR TITLE
[js/react-native] bump up the version of mobile package to 1.8.1

### DIFF
--- a/js/react_native/android/gradle.properties
+++ b/js/react_native/android/gradle.properties
@@ -16,4 +16,4 @@ android.useAndroidX=true
 OnnxruntimeModule_buildToolsVersion=29.0.2
 OnnxruntimeModule_compileSdkVersion=29
 OnnxruntimeModule_targetSdkVersion=29
-Onnxruntime_mobileVersion=1.8.0
+Onnxruntime_mobileVersion=1.8.1


### PR DESCRIPTION
Since a mobile package will be released as 1.8.1, react native package needs to be updated accordingly.

