### PR TITLE
MLAS: enable SSE 4.1 path for x86 build

### DIFF
--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -704,6 +704,8 @@ struct MLAS_PLATFORM {
 
 #if defined(MLAS_TARGET_AMD64_IX86)
     MLAS_GEMM_FLOAT_KERNEL* GemmFloatKernel;
+    const MLAS_GEMM_U8X8_DISPATCH* GemmU8S8Dispatch;
+    const MLAS_GEMM_U8X8_DISPATCH* GemmU8U8Dispatch;
 #endif
 
 #if defined(MLAS_TARGET_AMD64)
@@ -711,10 +713,8 @@ struct MLAS_PLATFORM {
     MLAS_SGEMM_KERNEL_M1_ROUTINE* KernelM1TransposeBRoutine;
     MLAS_SGEMM_TRANSPOSE_PACKB_BLOCK_ROUTINE* TransposePackB16x4Routine;
     MLAS_GEMM_DOUBLE_KERNEL* GemmDoubleKernel;
-    const MLAS_GEMM_U8X8_DISPATCH* GemmU8S8Dispatch;
     MLAS_GEMM_U8S8_KERNEL* GemmU8S8Kernel;
     MLAS_GEMV_U8S8_KERNEL* GemvU8S8Kernel;
-    const MLAS_GEMM_U8X8_DISPATCH* GemmU8U8Dispatch;
     MLAS_GEMM_U8U8_KERNEL* GemmU8U8Kernel;
     MLAS_CONV_FLOAT_KERNEL* ConvNchwFloatKernel;
     MLAS_CONV_FLOAT_KERNEL* ConvNchwcFloatKernel;

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -126,13 +126,13 @@ Return Value:
     //
 
     this->GemmFloatKernel = MlasGemmFloatKernelSse;
+    this->GemmU8S8Dispatch = &MlasGemmU8X8DispatchSse;
+    this->GemmU8U8Dispatch = &MlasGemmU8X8DispatchSse;
 
 #if defined(MLAS_TARGET_AMD64)
 
     this->TransposePackB16x4Routine = MlasSgemmTransposePackB16x4Sse;
     this->GemmDoubleKernel = MlasGemmDoubleKernelSse;
-    this->GemmU8S8Dispatch = &MlasGemmU8X8DispatchSse;
-    this->GemmU8U8Dispatch = &MlasGemmU8X8DispatchSse;
     this->ConvNchwFloatKernel = MlasConvNchwFloatKernelSse;
     this->ConvNchwcFloatKernel = MlasConvNchwcFloatKernelSse;
     this->ConvDepthwiseFloatKernel = MlasConvDepthwiseFloatKernelSse;
@@ -170,7 +170,7 @@ Return Value:
     __cpuid(1, Cpuid1[0], Cpuid1[1], Cpuid1[2], Cpuid1[3]);
 #endif
 
-#if defined(MLAS_TARGET_AMD64) && defined(_MSC_VER)
+#if defined(_MSC_VER)
 
     //
     // Check if the processor supports SSE 4.1 instructions.

--- a/onnxruntime/core/mlas/lib/qgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm.cpp
@@ -61,14 +61,12 @@ MlasGemmU8X8GetDispatch(
 
     MLAS_UNREFERENCED_PARAMETER(BIsSigned);
 
-#if defined(MLAS_TARGET_AMD64)
+#if defined(MLAS_TARGET_AMD64_IX86)
     if (BIsSigned) {
         GemmU8X8Dispatch = MlasPlatform.GemmU8S8Dispatch;
     } else {
         GemmU8X8Dispatch = MlasPlatform.GemmU8U8Dispatch;
     }
-#elif defined(MLAS_SSE2_INTRINSICS)
-    GemmU8X8Dispatch = &MlasGemmU8X8DispatchSse;
 #elif defined(MLAS_NEON64_INTRINSICS)
     GemmU8X8Dispatch = MlasPlatform.GemmU8X8Dispatch;
 #elif defined(MLAS_NEON32_INTRINSICS) && !defined(_MSC_VER)


### PR DESCRIPTION
**Description**: Support using the existing SSE 4.1 kernel path for the Windows x86 build of onnxruntime.dll. This indirectly enables the prepacking path for u8s8 GEMMs.