### PR TITLE
Add int64 as a required type to ConstantOfShape 

### DIFF
--- a/onnxruntime/core/providers/cpu/generator/constant_of_shape.cc
+++ b/onnxruntime/core/providers/cpu/generator/constant_of_shape.cc
@@ -10,7 +10,13 @@ namespace op_kernel_type_control {
 ORT_SPECIFY_OP_KERNEL_ARG_DEFAULT_TYPE_LIST_ALL_OPSETS(
     kCpuExecutionProvider, kOnnxDomain, ConstantOfShape, Output, 0,
     ConstantOfShapeDefaultOutputTypes);
-}
+
+// pytorch converter uses ConstantOfShape with int64 to create Pad input
+// https://github.com/pytorch/pytorch/blob/044b519a80459f6787f6723c1c091a18b153d184/torch/onnx/symbolic_opset11.py#L449
+ORT_SPECIFY_OP_KERNEL_ARG_REQUIRED_TYPES_ALL_OPSETS(
+    kCpuExecutionProvider, kOnnxDomain, ConstantOfShape, Output, 0,
+    int64_t);
+}  // namespace op_kernel_type_control
 
 namespace {
 


### PR DESCRIPTION
**Description**: 
Add int64 as a required type to ConstantOfShape as it's used by the pytorch converter for Pad.

It's also used pointlessly for torch.tensor.repeat (although that usage should always be able to be constant folded). https://github.com/pytorch/pytorch/issues/60496 has details of that.

**Motivation and Context**
Support models converted from pytorch in pre-built package.