### PR TITLE
Chang how numpy version is handled.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1372,7 +1372,14 @@ if (onnxruntime_USE_VITISAI)
 endif()
 
 configure_file(onnxruntime_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/onnxruntime_config.h)
-configure_file(../requirements.txt.in ${CMAKE_CURRENT_BINARY_DIR}/requirements.txt)
+if(WIN32)
+  configure_file(../requirements.txt.in ${CMAKE_CURRENT_BINARY_DIR}/Debug/requirements.txt)
+  configure_file(../requirements.txt.in ${CMAKE_CURRENT_BINARY_DIR}/Release/requirements.txt)
+  configure_file(../requirements.txt.in ${CMAKE_CURRENT_BINARY_DIR}/RelWithDebInfo/requirements.txt)
+  configure_file(../requirements.txt.in ${CMAKE_CURRENT_BINARY_DIR}/MinSizeRel/requirements.txt)
+else()
+  configure_file(../requirements.txt.in ${CMAKE_CURRENT_BINARY_DIR}/requirements.txt)
+endif()
 
 if (onnxruntime_USE_CUDA)
   #The following 6 lines are copied from https://gitlab.kitware.com/cmake/cmake/issues/17559

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1372,6 +1372,7 @@ if (onnxruntime_USE_VITISAI)
 endif()
 
 configure_file(onnxruntime_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/onnxruntime_config.h)
+configure_file(../requirements.txt.in ${CMAKE_CURRENT_BINARY_DIR}/requirements.txt)
 
 if (onnxruntime_USE_CUDA)
   #The following 6 lines are copied from https://gitlab.kitware.com/cmake/cmake/issues/17559

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-numpy >= 1.16.6
-protobuf
-flatbuffers

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -1,0 +1,3 @@
+numpy >= @Python_NumPy_VERSION@
+protobuf
+flatbuffers

--- a/setup.py
+++ b/setup.py
@@ -396,14 +396,6 @@ with open(requirements_path) as f:
     install_requires = f.read().splitlines()
 
 
-if is_manylinux:
-    AUDITWHEEL_PLAT = environ.get('AUDITWHEEL_PLAT', None)
-    if AUDITWHEEL_PLAT == 'manylinux2014_aarch64':
-        for i in range(len(install_requires)):
-            req = install_requires[i]
-            if req.startswith("numpy"):
-                install_requires[i] = "numpy >= 1.19.5"
-
 if enable_training:
     def save_build_and_package_info(package_name, version_number, cuda_version):
 


### PR DESCRIPTION
**Description**:

First, numpy has binary compatibility, which means "binaries compiled against a given version of NumPy will still run correctly with newer NumPy versions, but not with older versions." So, if an onnx runtime package was built with numpy version A, then at run time it requires numpy version >=A.  

In the past, we let A = "1.16.6". However, there are two exceptions:
1. Training packages require a newer version of numpy. We build the package with numpy 1.19.5, but onnxruntime claims it requires 'numpy>=1.16.6'. So it's wrong.  If a user really got a numpy version < 1.19, it could crash. At least NumPy can't guarantee it would work.
2. Numpy 1.16.6 doesn't have a prebuilt package for ARM devices(people need to build it from source). So our ARM python packaging pipeline uses a newer version of it. 

In this change, we read numpy version from the installed packages at build time, to avoid manually keeping the build time/runtime consistency.  Now you are free to choose any numpy version you want. 


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
