### PR TITLE
Disable InitProvidersSharedLibrary when training is enabled.

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1671,7 +1671,7 @@ void CreatePybindStateModule(py::module& m){
   addOrtValueMethods(m);
   addIoBindingMethods(m);
 
-#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
+#if !defined(ENABLE_TRAINING) && (!defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS))
   Ort::SessionOptions tmp_options;
   if (!InitProvidersSharedLibrary()) {
     const logging::Logger& default_logger = logging::LoggingManager::DefaultLogger();


### PR DESCRIPTION
**Description**: InitProvidersSharedLibrary is only used for a special case, and the test code using it for python is also disabled for training. This slipped by.

This is to fix issue #8111 
