### PR TITLE
Update logic in props.xml to account for shared provider library changes

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/props.xml
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/props.xml
@@ -45,6 +45,36 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime_providers_shared.dll"
+          Condition="Exists('$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime_providers_shared.dll')">
+      <Link>onnxruntime_providers_shared.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime_providers_cuda.dll"
+          Condition="Exists('$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime_providers_cuda.dll')">
+      <Link>onnxruntime_providers_cuda.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime_providers_dnnl.dll"
+          Condition="Exists('$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime_providers_dnnl.dll')">
+      <Link>onnxruntime_providers_dnnl.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime_providers_tensorrt.dll"
+          Condition="Exists('$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime_providers_tensorrt.dll')">
+      <Link>onnxruntime_providers_tensorrt.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime_providers_openvino.dll"
+          Condition="Exists('$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime_providers_openvino.dll')">
+      <Link>onnxruntime_providers_openvino.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
     <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\dnnl.dll"
           Condition="('$(PlatformTarget)' == 'x64' OR ('$(PlatformTarget)' == 'AnyCPU' AND '$(Prefer32Bit)' != 'true')) AND
                      Exists('$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\dnnl.dll')">

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -53,7 +53,8 @@ def generate_description(list, package_name):
     if package_name == 'Microsoft.AI.MachineLearning':
         description = 'This package contains Windows ML binaries.'
     elif 'Microsoft.ML.OnnxRuntime' in package_name:  # This is a Microsoft.ML.OnnxRuntime.* package
-        description = 'This package contains native shared library artifacts for all supported platforms of ONNX Runtime.'
+        description = 'This package contains native shared library artifacts ' \
+                      'for all supported platforms of ONNX Runtime.'
 
     list.append('<description>' + description + '</description>')
 

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -184,6 +184,7 @@ def generate_files(list, args):
     is_dml_package = args.package_name == 'Microsoft.ML.OnnxRuntime.DirectML'
     is_windowsai_package = args.package_name == 'Microsoft.AI.MachineLearning'
 
+    includes_cuda = is_cuda_gpu_package or is_cpu_package  # Why does the CPU package ship the cuda provider headers?	
     includes_winml = is_windowsai_package
     includes_directml = (is_dml_package or is_windowsai_package) and not args.is_store_build and (
         args.target_architecture == 'x64' or args.target_architecture == 'x86')
@@ -245,7 +246,7 @@ def generate_files(list, args):
                                    'include\\onnxruntime\\core\\providers\\cpu\\cpu_provider_factory.h') +
                       '" target="build\\native\\include" />')
 
-    if args.execution_provider == "cuda" or is_cuda_gpu_package:
+    if includes_cuda:
         files_list.append('<file src=' + '"' +
                           os.path.join(args.sources_path,
                                        'include\\onnxruntime\\core\\providers\\cuda\\cuda_provider_factory.h') +

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -184,7 +184,7 @@ def generate_files(list, args):
     is_dml_package = args.package_name == 'Microsoft.ML.OnnxRuntime.DirectML'
     is_windowsai_package = args.package_name == 'Microsoft.AI.MachineLearning'
 
-    includes_cuda = is_cuda_gpu_package or is_cpu_package  # Why does the CPU package ship the cuda provider headers?	
+    includes_cuda = is_cuda_gpu_package or is_cpu_package  # Why does the CPU package ship the cuda provider headers?
     includes_winml = is_windowsai_package
     includes_directml = (is_dml_package or is_windowsai_package) and not args.is_store_build and (
         args.target_architecture == 'x64' or args.target_architecture == 'x86')

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -48,15 +48,15 @@ def generate_owners(list, owners):
 
 
 def generate_description(list, package_name):
-	description = ''
+    description = ''
 
-	if package_name == 'Microsoft.AI.MachineLearning':
-		description = 'This package contains Windows ML binaries.'
+    if package_name == 'Microsoft.AI.MachineLearning':
+        description = 'This package contains Windows ML binaries.'
+    elif 'Microsoft.ML.OnnxRuntime' in package_name:  # This is a Microsoft.ML.OnnxRuntime.* package
+        description = 'This package contains native shared library artifacts for all supported platforms of ONNX Runtime.'
 
-	elif 'Microsoft.ML.OnnxRuntime' in package_name:  # This is a Microsoft.ML.OnnxRuntime.* package 
-		description = 'This package contains native shared library artifacts for all supported platforms of ONNX Runtime.'
+    list.append('<description>' + description + '</description>')
 
-	list.append('<description>' + description + '</description>')
 
 def generate_copyright(list, copyright):
     list.append('<copyright>' + copyright + '</copyright>')

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -47,9 +47,16 @@ def generate_owners(list, owners):
     list.append('<owners>' + owners + '</owners>')
 
 
-def generate_description(list, description):
-    list.append('<description>' + description + '</description>')
+def generate_description(list, package_name):
+	description = ''
 
+	if package_name == 'Microsoft.AI.MachineLearning':
+		description = 'This package contains Windows ML binaries.'
+
+	elif 'Microsoft.ML.OnnxRuntime' in package_name:  # This is a Microsoft.ML.OnnxRuntime.* package 
+		description = 'This package contains native shared library artifacts for all supported platforms of ONNX Runtime.'
+
+	list.append('<description>' + description + '</description>')
 
 def generate_copyright(list, copyright):
     list.append('<copyright>' + copyright + '</copyright>')
@@ -153,8 +160,7 @@ def generate_metadata(list, args):
     generate_version(metadata_list, args.package_version)
     generate_authors(metadata_list, 'Microsoft')
     generate_owners(metadata_list, 'Microsoft')
-    generate_description(metadata_list, 'This package contains native shared library artifacts '
-                                        'for all supported platforms of ONNX Runtime.')
+    generate_description(metadata_list, args.package_name)
     generate_copyright(metadata_list, '\xc2\xa9 ' + 'Microsoft Corporation. All rights reserved.')
     generate_tags(metadata_list, 'ONNX ONNX Runtime Machine Learning')
     generate_icon_url(metadata_list, 'https://go.microsoft.com/fwlink/?linkid=2049168')
@@ -177,7 +183,6 @@ def generate_files(list, args):
     is_dml_package = args.package_name == 'Microsoft.ML.OnnxRuntime.DirectML'
     is_windowsai_package = args.package_name == 'Microsoft.AI.MachineLearning'
 
-    includes_cuda = is_cuda_gpu_package or is_cpu_package  # Why does the CPU package ship the cuda provider headers?
     includes_winml = is_windowsai_package
     includes_directml = (is_dml_package or is_windowsai_package) and not args.is_store_build and (
         args.target_architecture == 'x64' or args.target_architecture == 'x86')
@@ -239,7 +244,7 @@ def generate_files(list, args):
                                    'include\\onnxruntime\\core\\providers\\cpu\\cpu_provider_factory.h') +
                       '" target="build\\native\\include" />')
 
-    if includes_cuda:
+    if args.execution_provider == "cuda" or is_cuda_gpu_package:
         files_list.append('<file src=' + '"' +
                           os.path.join(args.sources_path,
                                        'include\\onnxruntime\\core\\providers\\cuda\\cuda_provider_factory.h') +


### PR DESCRIPTION
**Description**: 
Add logic in props.xml to copy over the provider dlls to the binary folder so that onnxruntime.dll can explicitly load the necessary dlls.

**Motivation and Context**
Reported by an internal team
