### PR TITLE
Enable Nuget C# GPU tests on Linux

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -29,7 +29,11 @@ if [ $RunTestCsharp = "true" ]; then
     exit 1
   fi
 
-  dotnet test $BUILD_SOURCESDIRECTORY/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj --no-restore --verbosity detailed
+  if [ $PACKAGENAME = "Microsoft.ML.OnnxRuntime.Gpu" ]; then
+    dotnet test -p:DefineConstants=USE_CUDA $BUILD_SOURCESDIRECTORY/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj --no-restore --verbosity detailed
+  else
+    dotnet test $BUILD_SOURCESDIRECTORY/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj --no-restore --verbosity detailed
+  fi
   if [ $? -ne 0 ]; then
     echo "Failed to build or execute the end-to-end test"
     exit 1

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs
@@ -186,10 +186,10 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             Assert.Equal("CPUExecutionProvider", providers[providers.Length - 1]);
 
 # if USE_CUDA
-            Assert.True(Array.Exists(providers, provider => provider == "CUDAExecutionProvider"););
+            Assert.True(Array.Exists(providers, provider => provider == "CUDAExecutionProvider"));
 #endif
 # if USE_ROCM
-            Assert.True(Array.Exists(providers, provider => provider == "ROCMExecutionProvider"););
+            Assert.True(Array.Exists(providers, provider => provider == "ROCMExecutionProvider"));
 #endif
 
         }


### PR DESCRIPTION
**Description**: 

Enable Nuget C# GPU tests on Linux, and fix a code error.

**Motivation and Context**
- Why is this change required? What problem does it solve?

So that we can know if the CUDA EP in the nuget package works well on Linux. Previously(1.8.0), the package misses some important files. By enabling the E2E test, we will catch that. 

- If it fixes an open issue, please link to the issue here.
