### PR TITLE
Use std::make_reverse_iterator directly

### DIFF
--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.cc
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.cc
@@ -16,15 +16,6 @@ namespace onnxruntime {
 namespace cuda {
 
 namespace {
-// std::make_reverse_iterator is not implemented in older versions of GCC
-#if !defined(__GNUC__) || __GNUC__ >= 5
-using std::make_reverse_iterator;
-#else
-template <typename It>
-std::reverse_iterator<It> make_reverse_iterator(It it) {
-  return std::reverse_iterator<It>(it);
-}
-#endif
 
 // gets min and max of single contiguous range of axes if available
 optional<std::pair<int64_t, int64_t>> GetMinAndMaxContiguousAxes(
@@ -78,7 +69,7 @@ optional<std::pair<int64_t, int64_t>> GetMinAndMaxContiguousAxes(
     // note that std::reverse_iterator(it) refers to the element at (it-1)
     // it -> reverse it: element offset of -1
     const auto before_min_given_axis_rit =
-        make_reverse_iterator(dims.begin() + min_given_axis);
+        std::make_reverse_iterator(dims.begin() + min_given_axis);
     const auto before_min_axis_rit =
         std::find_if_not(before_min_given_axis_rit, dims.rend(), is_dim_one);
     // reverse it -> it: element offset of +1


### PR DESCRIPTION
**Description**: 
Fix a build error under clang 11

```
/mnt/onnxruntime/onnxruntime/core/providers/cuda/reduction/reduction_functions.cc:81:9: error: call to 'make_reverse_iterator' is ambiguous
        make_reverse_iterator(dims.begin() + min_given_axis);
        ^~~~~~~~~~~~~~~~~~~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/stl_iterator.h:442:5: note: candidate function [with _Iterator = __gnu_cxx::__normal_iterator<const long *, std::vector<long>>]
    make_reverse_iterator(_Iterator __i)
    ^
/mnt/onnxruntime/onnxruntime/core/providers/cuda/reduction/reduction_functions.cc:24:27: note: candidate function [with It = __gnu_cxx::__normal_iterator<const long *, std::vector<long>>]
std::reverse_iterator<It> make_reverse_iterator(It it) {
                          ^
1 error generated.
```

It because we added some workaround code for GCC 4.8. Now we don't support GCC 4.8 anymore, so they can be removed.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
