### PR TITLE
Allow custom loaders in inference session for loading Models (for testing)

### DIFF
--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -452,6 +452,9 @@ class InferenceSession {
     */
   common::Status Load(std::unique_ptr<ONNX_NAMESPACE::ModelProto> p_model_proto) ORT_MUST_USE_RESULT;
 
+  common::Status Load(std::function<common::Status(std::shared_ptr<Model>&)> loader,
+                      const std::string& event_name) ORT_MUST_USE_RESULT;
+
   common::Status DoPostLoadProcessing(onnxruntime::Model& model) ORT_MUST_USE_RESULT;
 
 #endif  // !defined(ORT_MINIMAL_BUILD)
@@ -497,8 +500,6 @@ class InferenceSession {
   common::Status SaveModelMetadata(const onnxruntime::Model& model) ORT_MUST_USE_RESULT;
 
 #if !defined(ORT_MINIMAL_BUILD)
-  common::Status Load(std::function<common::Status(std::shared_ptr<Model>&)> loader,
-                      const std::string& event_name) ORT_MUST_USE_RESULT;
 
   template <typename T>
   common::Status Load(const std::basic_string<T>& model_uri) ORT_MUST_USE_RESULT;


### PR DESCRIPTION
**Description**: Describe your changes.
Changing visibility of the custom-loader api from private: to protected: so that we can invoke it from a derived class , thus allowing for custom loaders for loading models into a inference session.

This should improve testability for execution providers or custom-ops by not limiting models in an inference session to be explicitly loaded through an onnx file or a protobuf stream of onnx file.

Having custom loader would allow for easier on-the-fly runtime creation of graphs that can contain custom ops in non-onnx domains.

**Motivation and Context**
- Why is this change required? What problem does it solve?
Improves testability

- If it fixes an open issue, please link to the issue here.
