### PR TITLE
Fix macOS python shared_provider warning

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1610,7 +1610,7 @@ static struct {
 void addObjectMethodsForTraining(py::module& m);
 #endif
 
-void CreatePybindStateModule(py::module& m){
+void CreatePybindStateModule(py::module& m) {
   m.doc() = "pybind11 stateful interface to ONNX runtime";
   RegisterExceptions(m);
 
@@ -1671,7 +1671,8 @@ void CreatePybindStateModule(py::module& m){
   addOrtValueMethods(m);
   addIoBindingMethods(m);
 
-#if !defined(ENABLE_TRAINING) && (!defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS))
+#if !defined(ENABLE_TRAINING) && !defined(__APPLE__) && \
+    (!defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS))
   Ort::SessionOptions tmp_options;
   if (!InitProvidersSharedLibrary()) {
     const logging::Logger& default_logger = logging::LoggingManager::DefaultLogger();


### PR DESCRIPTION
**Description**: Describe your changes.

**Motivation and Context**
- We get warning when use ort 1.8.0 pypi package on macOS, 
```
2021-06-24 14:31:07.017979 [E:onnxruntime:Default, provider_bridge_ort.cc:902 Ensure] Failed to load library libonnxruntime_providers_shared.dylib with error: dlopen(libonnxruntime_providers_shared.dylib, 10): image not found
2021-06-24 14:31:07.018036 [W:onnxruntime:Default, onnxruntime_pybind_state.cc:1615 pybind11_init_onnxruntime_pybind11_state] Init provider bridge failed.
```
- This error is not fatal but very annoying
- There is no shared provider on macOS or iOS, disable it for all Apple products
