### PR TITLE
GatherElements CUDA Kernel Optimization

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/gather_elements_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/gather_elements_impl.h
@@ -14,11 +14,11 @@ void GatherElementsImpl(
     const int64_t rank,  // both inputs have same rank and this is validated in the main Compute
     const void* input_data,
     const int64_t input_dim_along_axis,
-    const TArray<int64_t>& input_strides,
+    const int64_t input_stride_along_axis,
+    const TArray<int64_t>& masked_input_strides,
     const void* indices_data,
     const int64_t indices_size,
     const TArray<fast_divmod>& indices_strides,
-    const int64_t axis,
     void* output_data,
     size_t element_size,
     size_t index_element_size);


### PR DESCRIPTION
Optimize the GatherElements CUDA kernel using loop unrolling and also removing some IF statments from the loop.

Using HF DEBERTA as example, before the fix, _GatherElementsKernel takes 4.1% of total time, while after the fix, it takes 1.3% of total time. For the single kernel, it's 3x faster than the old implementation in this model.