### PR TITLE
Rename embedlayernorm_op_test.cc to embed_layer_norm_op_test.cc

### DIFF
--- a/onnxruntime/test/contrib_ops/embed_layer_norm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/embed_layer_norm_op_test.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// TODO(kreeger): rename this file "embed_layer_norm_op_test.cc" to match existing styles.
 #include "embed_layer_norm_test_vectors.h"
 #include "gtest/gtest.h"
 #include "test/common/tensor_op_test_utils.h"


### PR DESCRIPTION
Matches existing style of other unit test files.

Cleanup from https://github.com/microsoft/onnxruntime/pull/8124