### PR TITLE
Drop std::count_if() in *EmbedLayerNorm Ops.

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/embed_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/embed_layer_norm.cc
@@ -133,14 +133,15 @@ Status EmbedLayerNorm<T>::Compute(OpKernelContext* context) const {
 
   // Calculate mask
   if (nullptr != mask) {
-    // TODO: Consider summing the values in the mask and measure performance.
     const int32_t* mask_data = mask->template Data<int32_t>();
     int32_t* mask_index_data = mask_index->template MutableData<int32_t>();
     for (int b = 0; b < batch_size; b++) {
-      mask_index_data[b] =
-          static_cast<int32_t>(std::count_if(mask_data + (static_cast<int64_t>(b) * sequence_length),
-                                             mask_data + (static_cast<int64_t>(b) * sequence_length) + sequence_length,
-                                             [](int v) { return v == 1; }));
+      int32_t cur_sum = 0;
+      const int32_t* cur_mask_data = mask_data + (static_cast<int64_t>(b) * sequence_length);
+      for (int s = 0; s < sequence_length; ++s) {
+        cur_sum += cur_mask_data[s];
+      }
+      mask_index_data[b] = cur_sum;
     }
   } else {
     memset(mask_index->template MutableData<int32_t>(), 0, batch_size * sizeof(int32_t));

--- a/onnxruntime/contrib_ops/cpu/bert/embed_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/embed_layer_norm.cc
@@ -139,7 +139,9 @@ Status EmbedLayerNorm<T>::Compute(OpKernelContext* context) const {
       int32_t cur_sum = 0;
       const int32_t* cur_mask_data = mask_data + (static_cast<int64_t>(b) * sequence_length);
       for (int s = 0; s < sequence_length; ++s) {
-        cur_sum += cur_mask_data[s];
+        if (cur_mask_data[s] == 1) {
+          cur_sum += cur_mask_data[s];
+        }
       }
       mask_index_data[b] = cur_sum;
     }

--- a/onnxruntime/contrib_ops/cpu/bert/qembed_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/qembed_layer_norm.cc
@@ -180,7 +180,9 @@ Status ComputeInternal(OpKernelContext* context, float epsilon) {
       int32_t cur_sum = 0;
       const int32_t* cur_mask_data = mask_data + (static_cast<int64_t>(b) * sequence_length);
       for (int s = 0; s < sequence_length; ++s) {
-        cur_sum += cur_mask_data[s];
+        if (cur_mask_data[s] == 1) {
+          cur_sum += cur_mask_data[s];
+        }
       }
       mask_index_data[b] = cur_sum;
     }

--- a/onnxruntime/contrib_ops/cpu/bert/qembed_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/qembed_layer_norm.cc
@@ -174,14 +174,15 @@ Status ComputeInternal(OpKernelContext* context, float epsilon) {
 
   // Calculate mask
   if (nullptr != mask) {
-    // TODO: Consider summing the values in the mask and measure performance.
     const int32_t* mask_data = mask->template Data<int32_t>();
     int32_t* mask_index_data = mask_index->template MutableData<int32_t>();
     for (int b = 0; b < batch_size; b++) {
-      mask_index_data[b] =
-          static_cast<int32_t>(std::count_if(mask_data + (static_cast<int64_t>(b) * sequence_length),
-                                             mask_data + (static_cast<int64_t>(b) * sequence_length) + sequence_length,
-                                             [](int v) { return v == 1; }));
+      int32_t cur_sum = 0;
+      const int32_t* cur_mask_data = mask_data + (static_cast<int64_t>(b) * sequence_length);
+      for (int s = 0; s < sequence_length; ++s) {
+        cur_sum += cur_mask_data[s];
+      }
+      mask_index_data[b] = cur_sum;
     }
   } else {
     memset(mask_index->template MutableData<int32_t>(), 0, batch_size * sizeof(int32_t));


### PR DESCRIPTION
Profiling has shown that summing up the vector using the std function
can be 2x slower than just a simple plain vector sum loop.

Sample profiling code here: https://gist.github.com/nkreeger/271960c43966e937f7cb979ce3242995

Resutlts:
```
std::count_if duration (ns): 98
std::count_if2 duration (ns): 96
sum vector duration (ns): 55
```