### PR TITLE
Fix a warning in pool.cc

### DIFF
--- a/onnxruntime/core/providers/cuda/nn/pool.cc
+++ b/onnxruntime/core/providers/cuda/nn/pool.cc
@@ -164,7 +164,7 @@ Status Pool<T, PoolType>::ComputeInternal(OpKernelContext* context) const {
   }
 
   cudnnPoolingMode_t mode = CUDNN_POOLING_MAX;
-  if (PoolType::type == onnxruntime::PoolType::kAveragePool) {
+  if constexpr (PoolType::type == onnxruntime::PoolType::kAveragePool) {
     mode = pool_attrs_.count_include_pad ? CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING
                                          : CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING;
   }


### PR DESCRIPTION
**Description**: 

The warning is:
"Potential comparison of a constant with another constant. at D:\a\_work\1\s\onnxruntime\core\providers\cuda\nn\\pool.cc@167,21". 

It was found by VS static code analyzer in our CUDA EP.

**Motivation and Context**
- Why is this change required? What problem does it solve?

This change is related to #8041. Because we are in C++17 now, we should use "if constexpr" when applicable.


- If it fixes an open issue, please link to the issue here.
