### PR TITLE
Disable update database for Android code coverage

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -76,7 +76,9 @@ jobs:
   pool:
     vmImage: 'ubuntu-latest'
   dependsOn: Android_CI
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+  # disable update dashboard of Android Code coverage until Azure CI machine cannot access database issue is resolved
+  # condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+  condition: false
   steps:
   - task: DownloadPipelineArtifact@0
     displayName: 'Download code coverage report'


### PR DESCRIPTION
**Description**: Disable update database for Android code coverage

**Motivation and Context**
- The new security requirements block the access to our metric database from Android CI machine
- Disable Android Code Coverage report until the issue is resolved
