### PR TITLE
[CoreML EP] Add Int32<->Int64 handling around coreml ep

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/argmax_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/argmax_op_builder.cc
@@ -72,7 +72,7 @@ bool ArgMaxOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputPa
     return false;
   }
 
-  // Case where argmax has multiple succeeding nodes is not supported
+  // Case where argmax has multiple succeeding nodes(cast node among them) is not supported
   if (node.GetOutputEdgesCount() > 1) {
     // TODO: Check if the succeeding nodes contains cast
     // If Yes: Then not supported
@@ -80,7 +80,7 @@ bool ArgMaxOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputPa
     for (auto it = node.OutputEdgesBegin(), end = node.OutputEdgesEnd(); it != end; ++it) {
       const auto& op_type = it->GetNode().OpType();
       if (op_type == "Cast") {
-        LOGS(logger, VERBOSE) << "Multiple nodes consuming ArgMax's output";
+        LOGS(logger, VERBOSE) << "ArgMax has multiple output nodes including Cast";
         return false;
       }
     }

--- a/onnxruntime/core/providers/coreml/builders/impl/argmax_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/argmax_op_builder.cc
@@ -39,13 +39,21 @@ Status ArgMaxOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   coreml_argmax->set_axis(axis);
   coreml_argmax->set_removedim(removedim);
 
-  // Get ArgMax's next node(Cast)'s outputdefs
-  auto it = node.OutputEdgesBegin();
-  const auto* succ_node(graph_viewer.GetNode(it->GetNode().Index()));
+  // TODO: 1. Special Case 2. Otherwise
+  if (node.GetOutputEdgesCount() == 1) {
+    auto it = node.OutputEdgesBegin();
+    const auto* succ_node(graph_viewer.GetNode(it->GetNode().Index()));
+    if (succ_node->OpType() == "Cast") {
+      // Skip the cast's input/argmax's output
+      *layer->mutable_input()->Add() = node.InputDefs()[0]->Name();
+      *layer->mutable_output()->Add() = succ_node->OutputDefs()[0]->Name();
+      model_builder.AddLayer(std::move(layer));
+      return Status::OK();
+    } 
+  }
 
-  // Skip the cast's input/argmax's output
   *layer->mutable_input()->Add() = node.InputDefs()[0]->Name();
-  *layer->mutable_output()->Add() = succ_node->OutputDefs()[0]->Name();
+  *layer->mutable_output()->Add() = node.OutputDefs()[0]->Name();
 
   model_builder.AddLayer(std::move(layer));
   return Status::OK();
@@ -53,42 +61,29 @@ Status ArgMaxOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 // Operator support related
 
-bool ArgMaxOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+bool ArgMaxOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& /*input_params*/,
                                         const logging::Logger& logger) const {
-  // Check if Argmax's output is the graph output
-  const auto& graph_output_list = input_params.graph_viewer.GetOutputs();
-  std::unordered_set<const NodeArg*> graph_outputs(graph_output_list.cbegin(), graph_output_list.cend());
-  const auto& output_defs = node.OutputDefs();
-  for (const auto* output_def : output_defs) {
-    if (graph_outputs.count(output_def) != 0) {
-      LOGS(logger, VERBOSE) << "ArgMax not supported when it produces a graph output";
-      return false;
-    }
-  }
-
-  // Case where argmax has multiple succeeding nodes is not supported
-  if (node.GetOutputEdgesCount() > 1) {
-    LOGS(logger, VERBOSE) << "Multiple nodes consuming ArgMax's output";
-    return false;
-  }
-
-  const auto& succ_node = node.OutputEdgesBegin()->GetNode();
-
-  /*We're only handling the case: an ArgMax op followed by a Cast to int32 type right now so as to fuse
-  the int64 output (not a supported output type by CoreML model) of ArgMax.*/
-  if (succ_node.OpType() != "Cast") {
-    LOGS(logger, VERBOSE) << "ArgMax not supported when next node is not [Cast]"
-                          << "Current next node: [" << succ_node.OpType()
-                          << "]";
-    return false;
-  }
-
+  
   // Attribute `select_last_index` of ArgMax op is not supported
   NodeAttrHelper helper(node);
   const auto select_last_index = helper.Get("select_last_index", 0);
   if (select_last_index != 0) {
     LOGS(logger, VERBOSE) << "selected_last_index for ArgMax is not supported";
     return false;
+  }
+
+  // Case where argmax has multiple succeeding nodes is not supported
+  if (node.GetOutputEdgesCount() > 1) {
+    // TODO: Check if the succeeding nodes contains cast
+    // If Yes: Then not supported
+    // Otherwise: supported
+    for (auto it = node.OutputEdgesBegin(), end = node.OutputEdgesEnd(); it != end; ++it) {
+      const auto& op_type = it->GetNode().OpType();
+      if (op_type == "Cast") {
+        LOGS(logger, VERBOSE) << "Multiple nodes consuming ArgMax's output";
+        return false;
+      }
+    }
   }
 
   return true;

--- a/onnxruntime/core/providers/coreml/builders/impl/argmax_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/argmax_op_builder.cc
@@ -85,7 +85,7 @@ bool ArgMaxOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputPa
         NodeAttrHelper helper(it->GetNode());
         const auto cast_to_type = helper.Get("to", ONNX_NAMESPACE::TensorProto::UNDEFINED);
         if (cast_to_type == ONNX_NAMESPACE::TensorProto::INT32) {
-          LOGS(logger, VERBOSE) << "Argmax has both cast and other downstream nodes is not supported.";
+          LOGS(logger, VERBOSE) << "Argmax has both cast and other downstream nodes.";
           return false;
         }
       }

--- a/onnxruntime/core/providers/coreml/builders/impl/argmax_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/argmax_op_builder.cc
@@ -40,8 +40,9 @@ Status ArgMaxOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   coreml_argmax->set_removedim(removedim);
 
   // There are two cases here:
-  // 1. Special Case (ArgMax-Cast) we fuse the Argmax's output/Cast's input
-  // 2. Otherwise, we add Argma's layer normally
+  // 1. Special Case (ArgMax-Cast), we fuse the Argmax's output/Cast's input
+  // (We still have this special case here because CoreML model does not have Cast)
+  // 2. Otherwise, we add Argmax layer normally
   if (node.GetOutputEdgesCount() == 1) {
     auto it = node.OutputEdgesBegin();
     const auto* succ_node(graph_viewer.GetNode(it->GetNode().Index()));
@@ -75,7 +76,7 @@ bool ArgMaxOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputPa
 
   // Case where argmax has multiple succeeding nodes(cast node among them) is not supported
   if (node.GetOutputEdgesCount() > 1) {
-    // Check if the succeeding nodes contains cast;If yes, not supported
+    // Check if Argmax's succeeding nodes contain Cast;If yes, not supported
     // Otherwise, supported
     for (auto it = node.OutputEdgesBegin(), end = node.OutputEdgesEnd(); it != end; ++it) {
       const auto& op_type = it->GetNode().OpType();

--- a/onnxruntime/core/providers/coreml/builders/impl/cast_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/cast_op_builder.cc
@@ -28,9 +28,9 @@ class CastOpBuilder : public BaseOpBuilder {
 Status CastOpBuilder::AddToModelBuilderImpl(ModelBuilder& /* model_builder */,
                                             const Node& /* node */,
                                             const logging::Logger& /* logger */) const {
-  // Right now we're only handling an ArgMax op followed by a Cast to int32 type.
-  // This can fuse the ArgMax's int64 output type which is not supported in CoreML model.
-  // And that ArgMax fused with the cast node produces an int32 output, so we're skipping adding the Cast node here.
+  // This is a special handling case for ArgMax Op, where argmax is followed by a cast to int32 type.
+  // The ArgMax is fused with the Cast node and produces an int32 output.
+  // Cast node is not provided in CoreML model, so we're skipping adding the Cast node here.
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/coreml/builders/model_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/model_builder.cc
@@ -157,7 +157,7 @@ Status ModelBuilder::RegisterModelInputOutput(const NodeArg& node_arg, bool is_i
       case ONNX_NAMESPACE::TensorProto_DataType_INT64:
         if (!is_input) {
           // If we have an int64 output type, since COREML_SPEC:ArrayFeatureType does not support INT64
-          // We assgin it to be INT32 here
+          // we assign it to be INT32 here
           multi_array->set_datatype(COREML_SPEC::ArrayFeatureType::INT32);
           // Record the output names and we need to change them back to Int64 when CoreML EP returns these values to ORT
           AddInt64Output(name);

--- a/onnxruntime/core/providers/coreml/builders/model_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/model_builder.cc
@@ -154,6 +154,14 @@ Status ModelBuilder::RegisterModelInputOutput(const NodeArg& node_arg, bool is_i
       case ONNX_NAMESPACE::TensorProto_DataType_INT32:
         multi_array->set_datatype(COREML_SPEC::ArrayFeatureType::INT32);
         break;
+      case ONNX_NAMESPACE::TensorProto_DataType_INT64:
+        if (!is_input) {
+          // set -> int32(ArrayFeatureType)
+          multi_array->set_datatype(COREML_SPEC::ArrayFeatureType::INT32);
+          // we need to change these outputs back to Int64 when CoreML EP returns these values to ORT
+          AddInt64Output(name);
+        }
+        break;
       default: {
         // TODO: support other type
         return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
@@ -203,6 +211,7 @@ Status ModelBuilder::Compile(std::unique_ptr<Model>& model, const std::string& p
   ORT_RETURN_IF_ERROR(SaveCoreMLModel(path));
   model.reset(new Model(path, logger_, coreml_flags_));
   model->SetScalarOutputs(std::move(scalar_outputs_));
+  model->SetInt64Outputs(std::move(int64_outputs_));
   model->SetInputOutputInfo(std::move(input_output_info_));
   return model->LoadModel();
 }
@@ -223,6 +232,10 @@ Status ModelBuilder::SaveCoreMLModel(const std::string& path) {
 
 void ModelBuilder::AddScalarOutput(const std::string& output_name) {
   scalar_outputs_.insert(output_name);
+}
+
+void ModelBuilder::AddInt64Output(const std::string& output_name) {
+  int64_outputs_.insert(output_name);
 }
 
 void ModelBuilder::AddLayer(std::unique_ptr<COREML_SPEC::NeuralNetworkLayer> layer) {

--- a/onnxruntime/core/providers/coreml/builders/model_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/model_builder.cc
@@ -156,9 +156,10 @@ Status ModelBuilder::RegisterModelInputOutput(const NodeArg& node_arg, bool is_i
         break;
       case ONNX_NAMESPACE::TensorProto_DataType_INT64:
         if (!is_input) {
-          // set -> int32(ArrayFeatureType)
+          // If we have an int64 output type, since COREML_SPEC:ArrayFeatureType does not support INT64
+          // We assgin it to be INT32 here
           multi_array->set_datatype(COREML_SPEC::ArrayFeatureType::INT32);
-          // we need to change these outputs back to Int64 when CoreML EP returns these values to ORT
+          // Record the output names and we need to change them back to Int64 when CoreML EP returns these values to ORT
           AddInt64Output(name);
         }
         break;

--- a/onnxruntime/core/providers/coreml/builders/model_builder.h
+++ b/onnxruntime/core/providers/coreml/builders/model_builder.h
@@ -45,6 +45,7 @@ class ModelBuilder {
 
   std::unique_ptr<CoreML::Specification::Model> coreml_model_;
   std::unordered_set<std::string> scalar_outputs_;
+  std::unordered_set<std::string> int64_outputs_;
   std::unordered_map<std::string, OnnxTensorInfo> input_output_info_;
 
   std::unordered_set<std::string> skipped_initializers_;
@@ -69,6 +70,9 @@ class ModelBuilder {
 
   // Record the onnx scalar output names
   void AddScalarOutput(const std::string& output_name);
+
+  // Record the onnx int64 type output names
+  void AddInt64Output(const std::string& output_name);
 
   static const IOpBuilder* GetOpBuilder(const Node& node);
 };

--- a/onnxruntime/core/providers/coreml/coreml_execution_provider.cc
+++ b/onnxruntime/core/providers/coreml/coreml_execution_provider.cc
@@ -206,7 +206,6 @@ common::Status CoreMLExecutionProvider::Compile(const std::vector<FusedNodeAndGr
       std::vector<std::string> onnx_output_names(output_defs.size());
       for (size_t i = 0, end = output_defs.size(); i < end; ++i) {
         onnx_output_names[i] = output_defs[i]->Name();
-        // TODO: Node output int64 handling?
       }
       coreml_model->SetOutputs(std::move(onnx_output_names));
     }
@@ -279,7 +278,8 @@ common::Status CoreMLExecutionProvider::Compile(const std::vector<FusedNodeAndGr
           if (model->IsScalarOutput(output_name))
             output_shape.clear();
 
-          // TODO: Model output(isint32 and requires int64 output for onnx) -> cast from int32->int64
+          // Since CoreML EP only accepts int32 output type and onnx requires int64 output,
+          // We are going to set the model output (from int32) ->int64
           if (model->IsInt64Output(output_name))
             output_type = ONNX_NAMESPACE::TensorProto_DataType_INT64;
 
@@ -294,7 +294,6 @@ common::Status CoreMLExecutionProvider::Compile(const std::vector<FusedNodeAndGr
             case ONNX_NAMESPACE::TensorProto_DataType_INT32:
               output_buffer = ort.GetTensorMutableData<int32_t>(output_tensor);
               break;
-            // TODO: add an int64 model output support
             case ONNX_NAMESPACE::TensorProto_DataType_INT64:
               output_buffer = ort.GetTensorMutableData<int64_t>(output_tensor);
               break;

--- a/onnxruntime/core/providers/coreml/model/model.h
+++ b/onnxruntime/core/providers/coreml/model/model.h
@@ -32,6 +32,8 @@ class Model {
                                       const std::unordered_map<std::string, OnnxTensorData>& outputs);
 
   bool IsScalarOutput(const std::string& output_name) const;
+  
+  bool IsInt64Output(const std::string& output_name) const;
 
   // Mutex for exclusive lock to this model object
   OrtMutex& GetMutex() { return mutex_; }
@@ -48,6 +50,7 @@ class Model {
  private:
   std::unique_ptr<Execution> execution_;
   std::unordered_set<std::string> scalar_outputs_;
+  std::unordered_set<std::string> int64_outputs_;
 
   std::vector<std::string> inputs_;
   std::vector<std::string> outputs_;
@@ -65,6 +68,11 @@ class Model {
 
   void SetScalarOutputs(std::unordered_set<std::string>&& scalar_outputs) {
     scalar_outputs_ = std::move(scalar_outputs);
+  }
+  
+  // TODO:Investigate
+  void SetInt64Outputs(std::unordered_set<std::string>&& int64_outputs) {
+    int64_outputs_ = std::move(int64_outputs);
   }
 };
 

--- a/onnxruntime/core/providers/coreml/model/model.h
+++ b/onnxruntime/core/providers/coreml/model/model.h
@@ -32,7 +32,7 @@ class Model {
                                       const std::unordered_map<std::string, OnnxTensorData>& outputs);
 
   bool IsScalarOutput(const std::string& output_name) const;
-  
+
   bool IsInt64Output(const std::string& output_name) const;
 
   // Mutex for exclusive lock to this model object
@@ -69,8 +69,7 @@ class Model {
   void SetScalarOutputs(std::unordered_set<std::string>&& scalar_outputs) {
     scalar_outputs_ = std::move(scalar_outputs);
   }
-  
-  // TODO:Investigate
+
   void SetInt64Outputs(std::unordered_set<std::string>&& int64_outputs) {
     int64_outputs_ = std::move(int64_outputs);
   }

--- a/onnxruntime/core/providers/coreml/model/model.mm
+++ b/onnxruntime/core/providers/coreml/model/model.mm
@@ -237,7 +237,7 @@
                              [output_name cStringUsingEncoding:NSUTF8StringEncoding]);
     }
 
-    auto model_output_type = data.dataType;  // MLMultiArrayDataType
+    auto model_output_type = data.dataType;
 
     auto& output_tensor = output.second;
     size_t num_elements =
@@ -260,11 +260,10 @@
       case ONNX_NAMESPACE::TensorProto_DataType_INT64:
         output_data_byte_size = num_elements * sizeof(int64_t);
         if (model_output_type == MLMultiArrayDataTypeInt32) {
-          // TO Investigate a better way
           int32_t* model_output_data_prime = static_cast<int32_t*>(model_output_data);
           int64_t* output_tensor_buffer_prime = static_cast<int64_t*>(output_tensor.buffer);
           for (size_t i = 0; i < num_elements; i++) {
-            *(output_tensor_buffer_prime + i * sizeof(int64_t)) = static_cast<int64_t>(*(model_output_data_prime + i * sizeof(int32_t)));
+            output_tensor_buffer_prime[i] = model_output_data_prime[i];
           }
         }
         break;
@@ -273,7 +272,6 @@
                                "Output data type is not supported, actual type: ",
                                type);
     }
-    // memcpy(output_tensor.buffer, model_output_data, output_data_byte_size);
   }
 
   return onnxruntime::common::Status::OK();

--- a/onnxruntime/core/providers/coreml/model/model.mm
+++ b/onnxruntime/core/providers/coreml/model/model.mm
@@ -257,6 +257,9 @@
         output_data_byte_size = num_elements * sizeof(int32_t);
         memcpy(output_tensor.buffer, model_output_data, output_data_byte_size);
         break;
+      // For this case, since Coreml Spec only uses int32 for model output while onnx provides
+      // int64 for model output data type. We are doing a type casting (int32 -> int64) here 
+      // when copying the model to ORT
       case ONNX_NAMESPACE::TensorProto_DataType_INT64:
         output_data_byte_size = num_elements * sizeof(int64_t);
         if (model_output_type == MLMultiArrayDataTypeInt32) {
@@ -266,6 +269,8 @@
             output_tensor_buffer_prime[i] = model_output_data_prime[i];
           }
         }
+        ORT_RETURN_IF_NOT(model_output_type == MLMultiArrayDataTypeInt32,
+                          "Coreml model_output_type is not MLMultiArrayDataTypeInt32 for the case")
         break;
       default:
         return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,


### PR DESCRIPTION
**Description**: Describe your changes.
1. add int32<->int64 handling.
2. more general support for argmax op
 - ArgMax + Cast  supported
 - ArgMax as graph output supported
 - ArgMax with multiple child nodes supported
 - ArgMax with multiple child nodes while cast is one of them is not supported



**Motivation and Context**
CoreML Spec only uses int32 while ONNX uses int64. We need to add conversion between the types.
