### PR TITLE
Move iOS package from framework to xcframework

### DIFF
--- a/onnxruntime/test/platform/ios/ios_package_test/onnxruntime-mobile.podspec.template
+++ b/onnxruntime/test/platform/ios/ios_package_test/onnxruntime-mobile.podspec.template
@@ -14,6 +14,5 @@ Pod::Spec.new do |spec|
   spec.platform             = :ios, '13.0'
   # if you are going to use a file as the spec.source, add 'file:' before your file path
   spec.source               = { :http => '${ORT_BASE_FRAMEWORK_ARCHIVE}' }
-  spec.vendored_frameworks  = 'onnxruntime.framework'
-  spec.source_files         = 'onnxruntime.framework/Headers/*.h'
+  spec.vendored_frameworks  = '${ORT_FRAMEWORK_NAME}'
 end

--- a/tools/ci_build/github/apple/build_ios_framework.py
+++ b/tools/ci_build/github/apple/build_ios_framework.py
@@ -56,10 +56,8 @@ def _build_for_ios_sysroot(build_config, intermediates_dir, base_build_command, 
             '--build_dir=' + build_dir_current_arch
         ]
 
-        print(build_command)
-
         # the actual build process for current arch
-        # subprocess.run(build_command, shell=False, check=True, cwd=REPO_DIR)
+        subprocess.run(build_command, shell=False, check=True, cwd=REPO_DIR)
 
         # get the compiled lib path
         framework_dir = os.path.join(
@@ -111,6 +109,7 @@ def _build_package(args):
         framework_dir = _build_for_ios_sysroot(
             build_config, intermediates_dir, base_build_command, sysroot, build_settings['build_osx_archs'][sysroot])
         framework_dirs.append(framework_dir)
+        # podspec for each sysroot are the same, pick one of them
         if not podspec_path:
             podspec_path = os.path.join(os.path.dirname(framework_dir), 'onnxruntime-mobile-c.podspec')
 
@@ -131,7 +130,6 @@ def _build_package(args):
     for framework_dir in framework_dirs:
         build_xcframework_cmd.extend(['-framework', framework_dir])
 
-    print(build_xcframework_cmd)
     subprocess.run(build_xcframework_cmd, shell=False, check=True, cwd=REPO_DIR)
 
 

--- a/tools/ci_build/github/apple/build_ios_framework.py
+++ b/tools/ci_build/github/apple/build_ios_framework.py
@@ -16,10 +16,10 @@ REPO_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "..", "..", ".."))
 BUILD_PY = os.path.join(REPO_DIR, "tools", "ci_build", "build.py")
 
 # We by default will build below 2 archs
-DEFAULT_BUILD_OSX_ARCHS = [
-    {'sysroot': 'iphoneos', 'arch': 'arm64'},
-    {'sysroot': 'iphonesimulator', 'arch': 'x86_64'},
-]
+DEFAULT_BUILD_OSX_ARCHS = {
+    'iphoneos': ['arm64'],
+    'iphonesimulator': ['x86_64'],
+}
 
 
 def _parse_build_settings(args):
@@ -40,23 +40,15 @@ def _parse_build_settings(args):
     return build_settings
 
 
-def _build_package(args):
-    build_settings = _parse_build_settings(args)
-    build_dir = os.path.abspath(args.build_dir)
-
-    # Temp dirs to hold building results
-    intermediates_dir = os.path.join(build_dir, 'intermediates')
-    build_config = args.config
-    base_build_command = [sys.executable, BUILD_PY, '--config=' + build_config] + build_settings['build_params']
-
+# Build fat framework for all archs of a single sysroot
+# For example, arm64 and x86_64 for iphonesimulator
+def _build_for_ios_sysroot(build_config, intermediates_dir, base_build_command, sysroot, archs):
     # paths of the onnxruntime libraries for different archs
     ort_libs = []
     info_plist_path = ''
 
     # Build binary for each arch, one by one
-    for osx_arch in build_settings['build_osx_archs']:
-        sysroot = osx_arch['sysroot']
-        current_arch = osx_arch['arch']
+    for current_arch in archs:
         build_dir_current_arch = os.path.join(intermediates_dir, sysroot + "_" + current_arch)
         build_command = base_build_command + [
             '--ios_sysroot=' + sysroot,
@@ -64,28 +56,29 @@ def _build_package(args):
             '--build_dir=' + build_dir_current_arch
         ]
 
-        if args.include_ops_by_config is not None:
-            build_command += ['--include_ops_by_config=' + str(args.include_ops_by_config.resolve())]
+        print(build_command)
 
         # the actual build process for current arch
-        subprocess.run(build_command, shell=False, check=True, cwd=REPO_DIR)
+        # subprocess.run(build_command, shell=False, check=True, cwd=REPO_DIR)
 
         # get the compiled lib path
         framework_dir = os.path.join(
             build_dir_current_arch, build_config, build_config + "-" + sysroot, 'onnxruntime.framework')
         ort_libs.append(os.path.join(framework_dir, 'onnxruntime'))
 
-        # We actually only need to define the Info.plist and headers once since they are all the same
+        # We actually only need to define the Info.plist, podspec file and headers once since they are all the same
         if not info_plist_path:
             info_plist_path = os.path.join(build_dir_current_arch, build_config, 'Info.plist')
+            podspec_path = os.path.join(build_dir_current_arch, build_config, 'onnxruntime-mobile-c.podspec')
             headers = glob.glob(os.path.join(framework_dir, 'Headers', '*.h'))
 
     # manually create the fat framework
-    framework_dir = os.path.join(build_dir, 'framework_out', 'onnxruntime.framework')
+    framework_dir = os.path.join(intermediates_dir, 'frameworks', sysroot, 'onnxruntime.framework')
     pathlib.Path(framework_dir).mkdir(parents=True, exist_ok=True)
 
-    # copy the header files and Info.plist
+    # copy the header files, podspec file and Info.plist
     shutil.copy(info_plist_path, framework_dir)
+    shutil.copy(podspec_path, os.path.dirname(framework_dir))
     header_dir = os.path.join(framework_dir, 'Headers')
     pathlib.Path(header_dir).mkdir(parents=True, exist_ok=True)
     for _header in headers:
@@ -97,14 +90,58 @@ def _build_package(args):
     lipo_command += ['-output', os.path.join(framework_dir, 'onnxruntime')]
     subprocess.run(lipo_command, shell=False, check=True)
 
+    return framework_dir
+
+
+def _build_package(args):
+    build_settings = _parse_build_settings(args)
+    build_dir = os.path.abspath(args.build_dir)
+
+    # Temp dirs to hold building results
+    intermediates_dir = os.path.join(build_dir, 'intermediates')
+    build_config = args.config
+    base_build_command = [sys.executable, BUILD_PY, '--config=' + build_config] + build_settings['build_params']
+    if args.include_ops_by_config is not None:
+        base_build_command += ['--include_ops_by_config=' + str(args.include_ops_by_config.resolve())]
+
+    # build framework for individual sysroot
+    framework_dirs = []
+    podspec_path = ''
+    for sysroot in build_settings['build_osx_archs']:
+        framework_dir = _build_for_ios_sysroot(
+            build_config, intermediates_dir, base_build_command, sysroot, build_settings['build_osx_archs'][sysroot])
+        framework_dirs.append(framework_dir)
+        if not podspec_path:
+            podspec_path = os.path.join(os.path.dirname(framework_dir), 'onnxruntime-mobile-c.podspec')
+
+    # create the folder for xcframework and copy the LICENSE and podspec file
+    xcframework_dir = os.path.join(build_dir, 'framework_out')
+    pathlib.Path(xcframework_dir).mkdir(parents=True, exist_ok=True)
+    shutil.copy(os.path.join(REPO_DIR, 'LICENSE'), xcframework_dir)
+    shutil.copy(podspec_path, xcframework_dir)
+
+    # remove existing xcframework if any
+    xcframework_path = os.path.join(xcframework_dir, 'onnxruntime.xcframework')
+    if os.path.exists(xcframework_path):
+        shutil.rmtree(xcframework_path)
+
+    # Assemble the final xcframework
+    build_xcframework_cmd = ['xcrun', 'xcodebuild', '-create-xcframework',
+                             '-output', xcframework_path]
+    for framework_dir in framework_dirs:
+        build_xcframework_cmd.extend(['-framework', framework_dir])
+
+    print(build_xcframework_cmd)
+    subprocess.run(build_xcframework_cmd, shell=False, check=True, cwd=REPO_DIR)
+
 
 def parse_args():
     parser = argparse.ArgumentParser(
         os.path.basename(__file__),
-        description='''Create iOS framework and podspec for one or more osx_archs (fat framework)
+        description='''Create iOS framework and podspec for one or more osx_archs (xcframework)
         and building properties specified in the given build config file, see
         tools/ci_build/github/apple/default_mobile_ios_framework_build_settings.json for details.
-        The output of the final framework and podspec can be found under [build_dir]/framework_out.
+        The output of the final xcframework and podspec can be found under [build_dir]/framework_out.
         Please note, this building script will only work on macOS.
         '''
     )

--- a/tools/ci_build/github/apple/default_mobile_ios_framework_build_settings.json
+++ b/tools/ci_build/github/apple/default_mobile_ios_framework_build_settings.json
@@ -1,14 +1,12 @@
 {
-    "build_osx_archs": [
-        {
-            "sysroot": "iphoneos",
-            "arch": "arm64"
-        },
-        {
-            "sysroot": "iphonesimulator",
-            "arch": "x86_64"
-        }
-    ],
+    "build_osx_archs": {
+        "iphoneos": [
+            "arm64"
+        ],
+        "iphonesimulator": [
+            "x86_64"
+        ]
+    },
     "build_params": [
         "--ios",
         "--parallel",

--- a/tools/ci_build/github/apple/onnxruntime-mobile-c.podspec.template
+++ b/tools/ci_build/github/apple/onnxruntime-mobile-c.podspec.template
@@ -2,14 +2,18 @@ Pod::Spec.new do |spec|
     spec.name                   = "onnxruntime-mobile-c"
     spec.version                = "${ORT_VERSION}"
     spec.authors                = { "ONNX Runtime" => "onnxruntime@microsoft.com" }
-    spec.license                = { :type => "MIT" }
+    spec.license                = { :type => "MIT", :file => 'LICENSE' }
     spec.homepage               = "https://github.com/microsoft/onnxruntime"
     spec.source                 = { :http => "_ORT_DOWNLOAD_URL_" }
     spec.summary                = "ONNX Runtime Mobile C/C++ Pod"
     spec.platform               = :ios, "${CMAKE_OSX_DEPLOYMENT_TARGET}"
-    spec.vendored_frameworks    = "onnxruntime.framework"
+    spec.vendored_frameworks    = "onnxruntime.xcframework"
     spec.weak_framework         = 'CoreML'
-    spec.source_files           = 'onnxruntime.framework/Headers/*.h'
+
+    # arm64 iphonesimulator is not supported in this release
+    spec.pod_target_xcconfig    = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+    spec.user_target_xcconfig   = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+
     spec.description            = <<-DESC
     A preview pod for ONNX Runtime Mobile C/C++ library. Pods for Objective-C and Swift coming soon.
                                     DESC

--- a/tools/ci_build/github/apple/test_ios_packages.py
+++ b/tools/ci_build/github/apple/test_ios_packages.py
@@ -27,9 +27,17 @@ def _test_ios_packages(args):
     if not c_framework_dir.is_dir():
         raise FileNotFoundError('c_framework_dir {} is not a folder.'.format(c_framework_dir))
 
-    framework_path = os.path.join(c_framework_dir, 'onnxruntime.framework')
-    if not pathlib.Path(framework_path).exists():
-        raise FileNotFoundError('{} does not have onnxruntime.framework'.format(c_framework_dir))
+    has_framework = pathlib.Path(os.path.join(c_framework_dir, 'onnxruntime.framework')).exists()
+    has_xcframework = pathlib.Path(os.path.join(c_framework_dir, 'onnxruntime.xcframework')).exists()
+
+    if not has_framework and not has_xcframework:
+        raise FileNotFoundError('{} does not have onnxruntime.framework/xcframework'.format(c_framework_dir))
+
+    if has_framework and has_xcframework:
+        raise ValueError('Cannot proceed when both onnxruntime.framework '
+                         'and onnxruntime.xcframework exist')
+
+    framework_name = 'onnxruntime.framework' if has_framework else 'onnxruntime.xcframework'
 
     # create a temp folder
     import tempfile
@@ -41,7 +49,7 @@ def _test_ios_packages(args):
         # shutil.make_archive require target file as full path without extension
         zip_base_filename = os.path.join(local_pods_dir, 'onnxruntime-mobile')
         zip_file_path = zip_base_filename + '.zip'
-        shutil.make_archive(zip_base_filename, 'zip', root_dir=c_framework_dir, base_dir='onnxruntime.framework')
+        shutil.make_archive(zip_base_filename, 'zip', root_dir=c_framework_dir, base_dir=framework_name)
 
         # copy the test project to the temp_dir
         test_proj_path = os.path.join(REPO_DIR, 'onnxruntime', 'test', 'platform', 'ios', 'ios_package_test')
@@ -56,6 +64,7 @@ def _test_ios_packages(args):
 
         # replace the target strings
         file_data = file_data.replace('${ORT_BASE_FRAMEWORK_ARCHIVE}', 'file:' + zip_file_path)
+        file_data = file_data.replace('${ORT_FRAMEWORK_NAME}', framework_name)
         with open(os.path.join(REPO_DIR, 'VERSION_NUMBER')) as version_file:
             file_data = file_data.replace('${ORT_VERSION}', version_file.readline().strip())
 


### PR DESCRIPTION
**Description**: Move iOS package from framework to xcframework

**Motivation and Context**
- If we use framework, we cannot ship arm64 arch for both iphoneos and iphonesimulator at the same time due to the limitation of the framework, switch to xcframework for future release package
- This probably will need some additional changes in the objc package
- The E2E test was updated using framework or xcframework, (but not both at same time)
