### PR TITLE
Clarify name: Graph::GetNodeProvidesGraphOutput -> NodeProducesGraphOutput

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -1,3 +1,4 @@
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
@@ -684,7 +685,7 @@ class Graph {
   /** Returns true if one or more of the Node outputs are Graph outputs. 
   @remarks Cheaper than calling GetNodeOutputsInGraphOutputs.
   */
-  bool GetNodeProvidesGraphOutput(const Node& node) const {
+  bool NodeProducesGraphOutput(const Node& node) const {
     auto end_outputs = graph_outputs_.cend();
     for (auto output_def : node.OutputDefs()) {
       if (std::find(graph_outputs_.cbegin(), end_outputs, output_def) != end_outputs) {

--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -323,7 +323,7 @@ bool CanRemoveNode(const Graph& graph, const Node& node, const logging::Logger& 
   // This would allow removal of a node that is providing a graph output, as that output name would come from updating
   // the upstream node. This should also enable removal if CanUpdateImplicitInputNameInSubgraphs returns false.
 
-  if (graph.GetNodeProvidesGraphOutput(node)) {
+  if (graph.NodeProducesGraphOutput(node)) {
     return false;
   }
 
@@ -762,7 +762,7 @@ bool RemoveNodesWithOneOutputBottomUp(Graph& graph, const Node& start_node) {
     // Each eligible node in the subgraph must have less than one output edge and no output should be
     // the graph output
     const Node& cur_node = *graph.GetNode(cur_node_index);
-    if (cur_node.GetOutputEdgesCount() > 1 || graph.GetNodeProvidesGraphOutput(cur_node)) {
+    if (cur_node.GetOutputEdgesCount() > 1 || graph.NodeProducesGraphOutput(cur_node)) {
       continue;
     }
 

--- a/onnxruntime/core/optimizer/bias_dropout_fusion.cc
+++ b/onnxruntime/core/optimizer/bias_dropout_fusion.cc
@@ -25,7 +25,7 @@ void FuseResidualAddIfAny(Graph& graph, const Node& dropout_node,
   // To be able to fuse the residual Add,
   // the Dropout's output must not be a graph output and
   // there must be only one consumer of the Dropout's first output.
-  if (dropout_consumers_count < 2 && !graph.GetNodeProvidesGraphOutput(dropout_node)) {
+  if (dropout_consumers_count < 2 && !graph.NodeProducesGraphOutput(dropout_node)) {
     for (auto last_node_itr = dropout_node.OutputNodesBegin(); last_node_itr != dropout_node.OutputNodesEnd(); ++last_node_itr) {
       const Node& last_node = (*last_node_itr);
 
@@ -139,7 +139,7 @@ Status BiasDropoutFusion::ApplyImpl(Graph& graph, bool& modified, int graph_leve
       continue;
     }
 
-    if (graph.GetNodeProvidesGraphOutput(node)) {
+    if (graph.NodeProducesGraphOutput(node)) {
       continue;
     }
 

--- a/onnxruntime/core/optimizer/bias_gelu_fusion.cc
+++ b/onnxruntime/core/optimizer/bias_gelu_fusion.cc
@@ -76,7 +76,7 @@ Status BiasGeluFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level, 
       continue;
     }
 
-    if (graph.GetNodeProvidesGraphOutput(node)) {
+    if (graph.NodeProducesGraphOutput(node)) {
       continue;
     }
 

--- a/onnxruntime/core/optimizer/conv_activation_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_activation_fusion.cc
@@ -96,7 +96,7 @@ Status ConvActivationFusion::ApplyImpl(Graph& graph, bool& modified, int graph_l
       continue;
     }
 
-    if (graph.GetNodeProvidesGraphOutput(*node)) {
+    if (graph.NodeProducesGraphOutput(*node)) {
       continue;
     }
 

--- a/onnxruntime/core/optimizer/conv_add_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_add_fusion.cc
@@ -125,7 +125,7 @@ bool ConvAddFusion::SatisfyCondition(const Graph& graph, const Node& node, const
     return false;
   }
 
-  if (graph.GetNodeProvidesGraphOutput(node)) {
+  if (graph.NodeProducesGraphOutput(node)) {
     return false;
   }
 

--- a/onnxruntime/core/optimizer/conv_bn_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_bn_fusion.cc
@@ -177,7 +177,7 @@ bool ConvBNFusion::SatisfyCondition(const Graph& graph, const Node& node, const 
     }
   }
 
-  if (graph.GetNodeProvidesGraphOutput(node)) {
+  if (graph.NodeProducesGraphOutput(node)) {
     return false;
   }
 

--- a/onnxruntime/core/optimizer/conv_mul_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_mul_fusion.cc
@@ -133,7 +133,7 @@ bool ConvMulFusion::SatisfyCondition(const Graph& graph, const Node& node, const
     return false;
   }
 
-  if (graph.GetNodeProvidesGraphOutput(node)) {
+  if (graph.NodeProducesGraphOutput(node)) {
     return false;
   }
 

--- a/onnxruntime/core/optimizer/div_mul_fusion.cc
+++ b/onnxruntime/core/optimizer/div_mul_fusion.cc
@@ -74,7 +74,7 @@ bool DivMulFusion::SatisfyCondition(const Graph& graph, const Node& node, const 
       return false;
   }
 
-  if (graph.GetNodeProvidesGraphOutput(node)) {
+  if (graph.NodeProducesGraphOutput(node)) {
     return false;
   }
 

--- a/onnxruntime/core/optimizer/fast_gelu_fusion.cc
+++ b/onnxruntime/core/optimizer/fast_gelu_fusion.cc
@@ -31,7 +31,7 @@ static bool CheckNode(Graph& graph, const Node& node, const std::string& op_name
          node.GetExecutionProviderType() == provider &&
          IsSupportedDataType(node) &&
          (!require_single_output || node.GetOutputEdgesCount() == 1) &&
-         !graph.GetNodeProvidesGraphOutput(node);
+         !graph.NodeProducesGraphOutput(node);
 }
 
 MatchResult FastGeluFusion::CheckFirstFormula(Graph& graph, Node& mul1_node,

--- a/onnxruntime/core/optimizer/gemm_activation_fusion.cc
+++ b/onnxruntime/core/optimizer/gemm_activation_fusion.cc
@@ -61,7 +61,7 @@ Status GemmActivationFusion::ApplyImpl(Graph& graph, bool& modified, int graph_l
       continue;
     }
 
-    if (graph.GetNodeProvidesGraphOutput(node)) {
+    if (graph.NodeProducesGraphOutput(node)) {
       continue;
     }
 

--- a/onnxruntime/core/optimizer/gemm_transpose_fusion.cc
+++ b/onnxruntime/core/optimizer/gemm_transpose_fusion.cc
@@ -83,7 +83,7 @@ bool GemmTransposeFusion::SatisfyCondition(const Graph& graph, const Node& node,
   for (auto node_it = node.InputNodesBegin(); node_it != node.InputNodesEnd(); ++node_it) {
     if (graph_utils::IsSupportedOptypeVersionAndDomain(*node_it, "Transpose", {1, 13}) &&
         node_it->GetOutputEdgesCount() == 1 &&
-        !graph.GetNodeProvidesGraphOutput(*node_it) &&
+        !graph.NodeProducesGraphOutput(*node_it) &&
         // Make sure the two nodes do not span execution providers.
         node_it->GetExecutionProviderType() == node.GetExecutionProviderType()) {
       return true;
@@ -94,7 +94,7 @@ bool GemmTransposeFusion::SatisfyCondition(const Graph& graph, const Node& node,
   // by the rule (AB)' = B'A' provided that C is missing
   // Supported for Opset >=11 as earlier opsets have C as a required input
   if (!graph_utils::IsSupportedOptypeVersionAndDomain(node, "Gemm", {11, 13}) ||
-      graph.GetNodeProvidesGraphOutput(node) ||
+      graph.NodeProducesGraphOutput(node) ||
       // verify that C is missing
       node.InputDefs().size() > 2) {
     return false;

--- a/onnxruntime/core/optimizer/identity_elimination.cc
+++ b/onnxruntime/core/optimizer/identity_elimination.cc
@@ -40,7 +40,7 @@ namespace onnxruntime {
       X (def0/arg0) ---> Identity ---> Y
  */
 Status EliminateIdentity::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_effect, const logging::Logger&) const {
-  if (!graph.GetNodeProvidesGraphOutput(node)) {
+  if (!graph.NodeProducesGraphOutput(node)) {
     if (graph_utils::RemoveNode(graph, node)) {
       rule_effect = RewriteRuleEffect::kRemovedCurrentNode;
     }
@@ -65,7 +65,7 @@ bool EliminateIdentity::SatisfyCondition(const Graph& graph, const Node& node, c
     return true;
   }
 
-  bool node_output_is_graph_output = graph.GetNodeProvidesGraphOutput(node);
+  bool node_output_is_graph_output = graph.NodeProducesGraphOutput(node);
 
   // relax the condition if Identity is connecting to graph output
   if (node.GetOutputEdgesCount() != 0 ||

--- a/onnxruntime/core/optimizer/insert_cast_transformer.cc
+++ b/onnxruntime/core/optimizer/insert_cast_transformer.cc
@@ -94,7 +94,7 @@ static bool IsIsolatedFp16NodeOnCpu(const onnxruntime::Node& node, onnxruntime::
   //    and is assigned to the CPU EP (we have fp32 implementations of all kernels so forcing to fp32 is safe)
   if (node.GetInputEdgesCount() > 0 &&
       !node.ContainsSubgraph() &&
-      !graph.GetNodeProvidesGraphOutput(node) &&
+      !graph.NodeProducesGraphOutput(node) &&
       node.GetExecutionProviderType() == kCpuExecutionProvider) {
     do {
       // find the number of fp16 inputs as we need to make sure they're all coming from nodes that will be cast

--- a/onnxruntime/core/optimizer/isinf_reducesum_fusion.cc
+++ b/onnxruntime/core/optimizer/isinf_reducesum_fusion.cc
@@ -35,7 +35,7 @@ Status IsInfReduceSumFusion::ApplyImpl(Graph& graph, bool& modified, int graph_l
 
     if (!graph_utils::IsSupportedOptypeVersionAndDomain(isinf_node, "IsInf", {10}) ||
         isinf_node.GetOutputEdgesCount() != 1 ||
-        graph.GetNodeProvidesGraphOutput(isinf_node)) {
+        graph.NodeProducesGraphOutput(isinf_node)) {
       continue;
     }
 
@@ -67,7 +67,7 @@ Status IsInfReduceSumFusion::ApplyImpl(Graph& graph, bool& modified, int graph_l
     Node& cast2_node = *graph.GetNode(cast2_node_itr->Index());
     if (!graph_utils::IsSupportedOptypeVersionAndDomain(cast2_node, "Cast", {9, 13}) ||
         cast2_node.GetOutputEdgesCount() != 1 ||
-        graph.GetNodeProvidesGraphOutput(cast2_node)) {
+        graph.NodeProducesGraphOutput(cast2_node)) {
       continue;
     }
     nodes_to_remove.push_back(cast2_node);
@@ -80,7 +80,7 @@ Status IsInfReduceSumFusion::ApplyImpl(Graph& graph, bool& modified, int graph_l
     Node& reduce_sum_node = *graph.GetNode(reduce_sum_node_itr->Index());
     if (!graph_utils::IsSupportedOptypeVersionAndDomain(reduce_sum_node, "ReduceSum", {1, 11, 13}) ||
         reduce_sum_node.GetOutputEdgesCount() != 1 ||
-        graph.GetNodeProvidesGraphOutput(reduce_sum_node)) {
+        graph.NodeProducesGraphOutput(reduce_sum_node)) {
       continue;
     }
     nodes_to_remove.push_back(reduce_sum_node);

--- a/onnxruntime/core/optimizer/layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/layer_norm_fusion.cc
@@ -79,7 +79,7 @@ Status LayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
     if (!graph_utils::IsSupportedOptypeVersionAndDomain(reduce_mean_node, "ReduceMean", {1, 11, 13}) ||
         !graph_utils::IsSupportedProvider(reduce_mean_node, GetCompatibleExecutionProviders()) ||
         (reduce_mean_node.GetOutputEdgesCount() != 1 && reduce_mean_node.GetOutputEdgesCount() != 2) ||
-        graph.GetNodeProvidesGraphOutput(reduce_mean_node) ||
+        graph.NodeProducesGraphOutput(reduce_mean_node) ||
         !IsSupportedDataType(reduce_mean_node)) {
       continue;
     }
@@ -377,7 +377,7 @@ Status SimplifiedLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int gr
     if (!graph_utils::IsSupportedOptypeVersionAndDomain(pow_node, "Pow", {7, 12, 13}) ||
         !graph_utils::IsSupportedProvider(pow_node, GetCompatibleExecutionProviders()) ||
         !optimizer_utils::CheckOutputEdges(graph, pow_node, 1) ||
-        graph.GetNodeProvidesGraphOutput(pow_node) ||
+        graph.NodeProducesGraphOutput(pow_node) ||
         !IsSupportedDataType(pow_node)) {
       continue;
     }

--- a/onnxruntime/core/optimizer/matmul_add_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_add_fusion.cc
@@ -30,7 +30,7 @@ Status MatMulAddFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
       continue;
     }
 
-    if (graph.GetNodeProvidesGraphOutput(node)) {
+    if (graph.NodeProducesGraphOutput(node)) {
       continue;
     }
 

--- a/onnxruntime/core/optimizer/matmul_transpose_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_transpose_fusion.cc
@@ -39,7 +39,7 @@ static Node* GetTransposeNodeFromOutput(Graph& graph, NodeArg& node_arg) {
   }
 
   // if the node has Graph output, skip it too
-  if (graph.GetNodeProvidesGraphOutput(*trans_node)) {
+  if (graph.NodeProducesGraphOutput(*trans_node)) {
     return nullptr;
   }
 

--- a/onnxruntime/core/optimizer/nchwc_transformer.cc
+++ b/onnxruntime/core/optimizer/nchwc_transformer.cc
@@ -164,7 +164,7 @@ size_t NchwcTransformerImpl::RemoveOutputEdges(Node& node) {
   }
   // Bias the edge count to handle the case of a node that produces a graph
   // output.
-  if (graph_.GetNodeProvidesGraphOutput(node)) {
+  if (graph_.NodeProducesGraphOutput(node)) {
     output_edges_count++;
   }
   return output_edges_count;
@@ -1145,7 +1145,7 @@ void NchwcTransformerImpl::TrackTransposeFromNhwc(Node& node) {
 
   // Verify that the node does not produce a graph output and produces output
   // for a single node.
-  if (graph_.GetNodeProvidesGraphOutput(node) || node.GetOutputEdgesCount() != 1) {
+  if (graph_.NodeProducesGraphOutput(node) || node.GetOutputEdgesCount() != 1) {
     return;
   }
 

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.cc
@@ -26,7 +26,7 @@ static bool TryCancelOutDQQPair(Graph& graph, Node& dq_node, Node& q_node) {
   // check if dq_node has only one output edge and,
   // dq_node and q_node output are not graph outputs
   if (!optimizer_utils::CheckOutputEdges(graph, dq_node, 1) ||
-      graph.GetNodeProvidesGraphOutput(q_node)) {
+      graph.NodeProducesGraphOutput(q_node)) {
     return false;
   }
 

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_transformer.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_transformer.cc
@@ -62,8 +62,8 @@ class QDQTransformerImpl {
       // Add to nodes_to_remove_ directly if it is QuantizeLinear
       if (it == dq_output_edges_count_.end()) {
         nodes_to_remove_.insert(node->Index());
-      } else if (it->second == 0 &&                                     // node has no edges
-                 graph_.GetNodeOutputsInGraphOutputs(*node).empty()) {  // node outputs are not graph outputs
+      } else if (it->second == 0 &&                         // node has no edges
+                 !graph_.NodeProducesGraphOutput(*node)) {  // node outputs are not graph outputs
         nodes_to_remove_.insert(node->Index());
       }
     }

--- a/onnxruntime/core/optimizer/skip_layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/skip_layer_norm_fusion.cc
@@ -173,8 +173,8 @@ Status SkipLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int graph_le
 
       if (CheckFirstAdd(*p_add1, ln_node.GetExecutionProviderType()) &&
           CheckSecondAdd(graph, *p_add2, ln_node.GetExecutionProviderType()) &&
-          !graph.GetNodeProvidesGraphOutput(*p_add1) &&
-          !graph.GetNodeProvidesGraphOutput(*p_add2)) {
+          !graph.NodeProducesGraphOutput(*p_add1) &&
+          !graph.NodeProducesGraphOutput(*p_add2)) {
         matched_format = Format::Format1;
       }
     }
@@ -191,8 +191,8 @@ Status SkipLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int graph_le
 
         if (CheckFirstAdd(*p_add1, ln_node.GetExecutionProviderType()) &&
             CheckSecondAdd(graph, *p_add2, ln_node.GetExecutionProviderType()) &&
-            !graph.GetNodeProvidesGraphOutput(*p_add1) &&
-            !graph.GetNodeProvidesGraphOutput(*p_add2)) {
+            !graph.NodeProducesGraphOutput(*p_add1) &&
+            !graph.NodeProducesGraphOutput(*p_add2)) {
           matched_format = Format::Format2;
         }
       }
@@ -207,7 +207,7 @@ Status SkipLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int graph_le
         p_add1 = const_cast<Node*>(&edges[0]->GetNode());
 
         if (CheckFirstAdd(*p_add1, ln_node.GetExecutionProviderType()) &&
-            graph.GetNodeOutputsInGraphOutputs(*p_add1).empty()) {
+            !graph.NodeProducesGraphOutput(*p_add1)) {
           matched_format = Format::Format3;
         }
       }

--- a/onnxruntime/core/optimizer/utils.cc
+++ b/onnxruntime/core/optimizer/utils.cc
@@ -267,7 +267,7 @@ int32_t IndexOfNodeOutput(const Node& node, const NodeArg& node_arg) {
 }
 
 bool CheckOutputEdges(const Graph& graph, const Node& node, size_t expected_output_edges) {
-  if (graph.GetNodeProvidesGraphOutput(node)) {
+  if (graph.NodeProducesGraphOutput(node)) {
     return false;
   }
 


### PR DESCRIPTION
**Description**: 
Clarify name of new helper. The 'GetNode' prefix is confusing as it returns a bool.

Update a couple more places where GetNodeOutputsInGraphOutputs was being used unnecessarily.

**Motivation and Context**
Clarity