### PR TITLE
POWER10: Additional check in cmake

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -215,6 +215,18 @@ else()
         COMPILES_P10
       )
       if(COMPILES_P10)
+        check_cxx_source_compiles("
+          #include <sys/auxv.h>
+          int main() {
+            unsigned long hwcap2 = getauxval(AT_HWCAP2);
+            bool HasP10 = ((hwcap2 & PPC_FEATURE2_MMA) && (hwcap2 & PPC_FEATURE2_ARCH_3_1));
+            return 0;
+          }"
+          HAS_P10_RUNTIME
+        )
+        if (HAS_P10_RUNTIME)
+          set_source_files_properties(${mlas_common_srcs} PROPERTIES COMPILE_FLAGS "-DPOWER10")
+        endif()
         set(mlas_platform_srcs_power10
           ${ONNXRUNTIME_ROOT}/core/mlas/lib/power/SgemmKernelPOWER10.cpp
         )

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -374,7 +374,7 @@ Return Value:
 #endif // MLAS_TARGET_ARM64
 #if defined(MLAS_TARGET_POWER)
   this->GemmFloatKernel = MlasSgemmKernel;
-#if defined(__linux__)
+#if defined(__linux__)  && defined(POWER10)
 #if (defined(__GNUC__) && ((__GNUC__ > 10) || (__GNUC__== 10 && __GNUC_MINOR__ >= 2))) || \
     (defined(__clang__) && (__clang_major__ >= 12))
   unsigned long hwcap2 = getauxval(AT_HWCAP2);


### PR DESCRIPTION
When compiling with newer GCC and older Glibc, there is a chance
for new POWER10 macros to be not available in hwcap.h. This patch
checks whether hwcap macros are available before using that in
platform.cpp.

