### PR TITLE
Gradient Accumulation optimization verified for correctness

### DIFF
--- a/onnxruntime/core/framework/orttraining_partial_executor.cc
+++ b/onnxruntime/core/framework/orttraining_partial_executor.cc
@@ -233,6 +233,22 @@ Status PartialExecutor::Execute(const SessionState& session_state, const std::ve
     // construct OpKernelContext
     // TODO: log kernel inputs?
     OpKernelContextInternal op_kernel_context(session_state, frame, *p_op_kernel, logger, false);
+
+    // Cache lookup. Currently we only cache single-output nodes,
+    // to keep memory overhead impact in check. Hence we only look in cache
+    // if the current node has one output.
+    bool reuse_cached_value = false;
+    std::string cached_arg_name;
+#ifdef ENABLE_TRAINING
+    if (cache_.size() > 0 && p_op_kernel->Node().OutputDefs().size() == 1) {
+      cached_arg_name = p_op_kernel->Node().OutputDefs()[0]->Name();
+      if (cache_.count(cached_arg_name)) {  // found arg in cache_
+        VLOGS(logger, 1) << "Found OrtValue in cache for arg: " << cached_arg_name;
+        reuse_cached_value = true;
+      }
+    }
+#endif
+
     // TODO: log kernel outputs?
     if (is_profiler_enabled) {
       sync_time_begin = session_state.Profiler().StartTime();
@@ -312,7 +328,11 @@ Status PartialExecutor::Execute(const SessionState& session_state, const std::ve
           ORT_RETURN_IF_ERROR(utils::VerifyInputTensorsAllocatedContiguously(&op_kernel_context));
         }
 #endif
-        compute_status = p_op_kernel->Compute(&op_kernel_context);
+        if (!reuse_cached_value) {
+          compute_status = p_op_kernel->Compute(&op_kernel_context);
+        } else {
+          compute_status = op_kernel_context.SetOutputMLValue(0, cache_.at(cached_arg_name));
+        }
       }
       ORT_CATCH(const std::exception& ex) {
         ORT_HANDLE_EXCEPTION([&]() {

--- a/onnxruntime/core/framework/orttraining_partial_executor.cc
+++ b/onnxruntime/core/framework/orttraining_partial_executor.cc
@@ -240,11 +240,13 @@ Status PartialExecutor::Execute(const SessionState& session_state, const std::ve
     bool reuse_cached_value = false;
     std::string cached_arg_name;
 #ifdef ENABLE_TRAINING
-    if (cache_.size() > 0 && p_op_kernel->Node().OutputDefs().size() == 1) {
-      cached_arg_name = p_op_kernel->Node().OutputDefs()[0]->Name();
-      if (cache_.count(cached_arg_name)) {  // found arg in cache_
-        VLOGS(logger, 1) << "Found OrtValue in cache for arg: " << cached_arg_name;
-        reuse_cached_value = true;
+    if (cache_ != nullptr) {
+      if (cache_->size() > 0 && p_op_kernel->Node().OutputDefs().size() == 1) {
+        cached_arg_name = p_op_kernel->Node().OutputDefs()[0]->Name();
+        if (cache_->count(cached_arg_name)) {  // found arg in cache_
+          VLOGS(logger, 1) << "Found OrtValue in cache for arg: " << cached_arg_name;
+          reuse_cached_value = true;
+        }
       }
     }
 #endif
@@ -331,7 +333,7 @@ Status PartialExecutor::Execute(const SessionState& session_state, const std::ve
         if (!reuse_cached_value) {
           compute_status = p_op_kernel->Compute(&op_kernel_context);
         } else {
-          compute_status = op_kernel_context.SetOutputMLValue(0, cache_.at(cached_arg_name));
+          compute_status = op_kernel_context.SetOutputMLValue(0, cache_->at(cached_arg_name));
         }
       }
       ORT_CATCH(const std::exception& ex) {

--- a/onnxruntime/core/framework/orttraining_partial_executor.cc
+++ b/onnxruntime/core/framework/orttraining_partial_executor.cc
@@ -239,17 +239,15 @@ Status PartialExecutor::Execute(const SessionState& session_state, const std::ve
     // if the current node has one output.
     bool reuse_cached_value = false;
     std::string cached_arg_name;
-#ifdef ENABLE_TRAINING
-    if (cache_ != nullptr) {
-      if (cache_->size() > 0 && p_op_kernel->Node().OutputDefs().size() == 1) {
+    if (check_cache_) {
+      if (p_op_kernel->Node().OutputDefs().size() == 1) {
         cached_arg_name = p_op_kernel->Node().OutputDefs()[0]->Name();
-        if (cache_->count(cached_arg_name)) {  // found arg in cache_
+        if (cache_.count(cached_arg_name)) {  // found arg in cache_
           VLOGS(logger, 1) << "Found OrtValue in cache for arg: " << cached_arg_name;
           reuse_cached_value = true;
         }
       }
     }
-#endif
 
     // TODO: log kernel outputs?
     if (is_profiler_enabled) {
@@ -333,7 +331,7 @@ Status PartialExecutor::Execute(const SessionState& session_state, const std::ve
         if (!reuse_cached_value) {
           compute_status = p_op_kernel->Compute(&op_kernel_context);
         } else {
-          compute_status = op_kernel_context.SetOutputMLValue(0, cache_->at(cached_arg_name));
+          compute_status = op_kernel_context.SetOutputMLValue(0, cache_.at(cached_arg_name));
         }
       }
       ORT_CATCH(const std::exception& ex) {

--- a/onnxruntime/core/framework/orttraining_partial_executor.cc
+++ b/onnxruntime/core/framework/orttraining_partial_executor.cc
@@ -239,10 +239,10 @@ Status PartialExecutor::Execute(const SessionState& session_state, const std::ve
     // if the current node has one output.
     bool reuse_cached_value = false;
     std::string cached_arg_name;
-    if (check_cache_) {
+    if (cache_ != nullptr) {
       if (p_op_kernel->Node().OutputDefs().size() == 1) {
         cached_arg_name = p_op_kernel->Node().OutputDefs()[0]->Name();
-        if (cache_.count(cached_arg_name)) {  // found arg in cache_
+        if (cache_.get()->count(cached_arg_name)) {  // found arg in cache_
           VLOGS(logger, 1) << "Found OrtValue in cache for arg: " << cached_arg_name;
           reuse_cached_value = true;
         }
@@ -331,7 +331,7 @@ Status PartialExecutor::Execute(const SessionState& session_state, const std::ve
         if (!reuse_cached_value) {
           compute_status = p_op_kernel->Compute(&op_kernel_context);
         } else {
-          compute_status = op_kernel_context.SetOutputMLValue(0, cache_.at(cached_arg_name));
+          compute_status = op_kernel_context.SetOutputMLValue(0, cache_.get()->at(cached_arg_name));
         }
       }
       ORT_CATCH(const std::exception& ex) {

--- a/onnxruntime/core/framework/orttraining_partial_executor.h
+++ b/onnxruntime/core/framework/orttraining_partial_executor.h
@@ -20,7 +20,7 @@ namespace onnxruntime {
 class PartialExecutor : public IExecutor {
  public:
   PartialExecutor(PartialGraphExecutionState& state, 
-                  OrtValueCache& cache)
+                  OrtValueCache* cache)
       : state_{state},
         cache_{cache} {}
 
@@ -33,7 +33,7 @@ class PartialExecutor : public IExecutor {
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(PartialExecutor);
   PartialGraphExecutionState& state_;
-  OrtValueCache cache_;
+  OrtValueCache* cache_;
 };
 }  // namespace onnxruntime
 #endif

--- a/onnxruntime/core/framework/orttraining_partial_executor.h
+++ b/onnxruntime/core/framework/orttraining_partial_executor.h
@@ -19,8 +19,10 @@
 namespace onnxruntime {
 class PartialExecutor : public IExecutor {
  public:
-  PartialExecutor(PartialGraphExecutionState& state)
-      : state_{state} {}
+  PartialExecutor(PartialGraphExecutionState& state, 
+                  OrtValueCache& cache)
+      : state_{state},
+        cache_{cache} {}
 
   common::Status Execute(const SessionState& session_state, const std::vector<int>& feed_mlvalue_idxs,
                          const std::vector<OrtValue>& feeds, const std::vector<int>& fetch_mlvalue_idxs,
@@ -31,6 +33,7 @@ class PartialExecutor : public IExecutor {
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(PartialExecutor);
   PartialGraphExecutionState& state_;
+  OrtValueCache cache_;
 };
 }  // namespace onnxruntime
 #endif

--- a/onnxruntime/core/framework/orttraining_partial_executor.h
+++ b/onnxruntime/core/framework/orttraining_partial_executor.h
@@ -19,10 +19,15 @@
 namespace onnxruntime {
 class PartialExecutor : public IExecutor {
  public:
-  PartialExecutor(PartialGraphExecutionState& state, 
-                  OrtValueCache* cache)
+  PartialExecutor(PartialGraphExecutionState& state,
+                  const OrtValueCache& cache)
       : state_{state},
-        cache_{cache} {}
+        cache_{cache} {
+    if (cache.empty()) {
+      // To avoid checking the cache for each node if it is empty
+      check_cache_ = false;
+    }
+  }
 
   common::Status Execute(const SessionState& session_state, const std::vector<int>& feed_mlvalue_idxs,
                          const std::vector<OrtValue>& feeds, const std::vector<int>& fetch_mlvalue_idxs,
@@ -33,7 +38,8 @@ class PartialExecutor : public IExecutor {
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(PartialExecutor);
   PartialGraphExecutionState& state_;
-  OrtValueCache* cache_;
+  const OrtValueCache& cache_;
+  bool check_cache_ = true;
 };
 }  // namespace onnxruntime
 #endif

--- a/onnxruntime/core/framework/orttraining_partial_executor.h
+++ b/onnxruntime/core/framework/orttraining_partial_executor.h
@@ -20,14 +20,9 @@ namespace onnxruntime {
 class PartialExecutor : public IExecutor {
  public:
   PartialExecutor(PartialGraphExecutionState& state,
-                  const OrtValueCache& cache)
+                  const OrtValueCachePtr& cache)
       : state_{state},
-        cache_{cache} {
-    if (cache.empty()) {
-      // To avoid checking the cache for each node if it is empty
-      check_cache_ = false;
-    }
-  }
+        cache_{cache} {}
 
   common::Status Execute(const SessionState& session_state, const std::vector<int>& feed_mlvalue_idxs,
                          const std::vector<OrtValue>& feeds, const std::vector<int>& fetch_mlvalue_idxs,
@@ -38,8 +33,7 @@ class PartialExecutor : public IExecutor {
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(PartialExecutor);
   PartialGraphExecutionState& state_;
-  const OrtValueCache& cache_;
-  bool check_cache_ = true;
+  const OrtValueCachePtr& cache_;
 };
 }  // namespace onnxruntime
 #endif

--- a/onnxruntime/core/framework/partial_graph_execution_state.h
+++ b/onnxruntime/core/framework/partial_graph_execution_state.h
@@ -8,6 +8,39 @@
 #include "core/framework/execution_frame.h"
 
 namespace onnxruntime {
+
+class OrtValueCache {
+ public:
+  OrtValueCache() = default;
+
+  Status CacheOrtValue(std::string node_arg_name, OrtValue& value) {
+    cache_.emplace(node_arg_name, value);
+    return Status::OK();
+  }
+
+  Status GetCachedIds(std::vector<std::string>& keys) {
+    keys.reserve(cache_.size());
+    for(auto kv : cache_) {
+      keys.push_back(kv.first);
+    }
+    return Status::OK();
+  }
+
+  Status DeleteOrtValue(std::string node_arg_name) {
+    ORT_RETURN_IF(cache_.find(node_arg_name) == cache_.end(), "NodeArg not found in cache: ", node_arg_name);
+    cache_.erase(node_arg_name);
+    return Status::OK();
+  }
+
+  Status DeleteCache() {
+    cache_.clear();
+    return Status::OK();
+  }
+
+ private:
+  std::unordered_map<std::string, OrtValue> cache_;
+};
+
 struct PartialGraphExecutionState {
  public:
   PartialGraphExecutionState() {
@@ -28,7 +61,7 @@ struct PartialGraphExecutionState {
                                     const SessionState& session_state) {
     if (execution_frame_ == nullptr) {
       execution_frame_ = std::make_unique<ExecutionFrame>(feed_mlvalue_idxs, feeds, fetch_mlvalue_idxs, fetches,
-                                                                  fetch_allocators, session_state);
+                                                          fetch_allocators, session_state);
     } else {
       execution_frame_->UpdateFeeds(feed_mlvalue_idxs, feeds);
       execution_frame_->UpdateFetches(fetch_mlvalue_idxs, fetches, session_state.GetInitializedTensors());

--- a/onnxruntime/core/framework/partial_graph_execution_state.h
+++ b/onnxruntime/core/framework/partial_graph_execution_state.h
@@ -13,38 +13,38 @@ class OrtValueCache {
  public:
   OrtValueCache() = default;
 
-  size_t size(){
+  size_t size() const {
     return cache_.size();
   }
 
-  size_t count(std::string name){
+  size_t count(const std::string name) const {
     return cache_.count(name);
   }
 
-  OrtValue at(std::string name) {
+  OrtValue at(const std::string name) const {
     return cache_.at(name);
   }
 
-  Status CacheOrtValue(std::string node_arg_name, OrtValue& value) {
+  Status CacheOrtValue(const std::string node_arg_name, const OrtValue& value) {
     cache_.emplace(node_arg_name, value);
     return Status::OK();
   }
 
-  Status GetCachedIds(std::vector<std::string>& keys) {
-    keys.reserve(cache_.size());
+  Status GetCachedIds(std::vector<std::string>& output_keys) const {
+    output_keys.reserve(cache_.size());
     for(auto kv : cache_) {
-      keys.push_back(kv.first);
+      output_keys.push_back(kv.first);
     }
     return Status::OK();
   }
 
-  Status DeleteOrtValue(std::string node_arg_name) {
+  Status DeleteOrtValue(const std::string node_arg_name) {
     ORT_RETURN_IF(cache_.find(node_arg_name) == cache_.end(), "NodeArg not found in cache: ", node_arg_name);
     cache_.erase(node_arg_name);
     return Status::OK();
   }
 
-  Status DeleteCache() {
+  Status ClearCache() {
     cache_.clear();
     return Status::OK();
   }

--- a/onnxruntime/core/framework/partial_graph_execution_state.h
+++ b/onnxruntime/core/framework/partial_graph_execution_state.h
@@ -13,6 +13,18 @@ class OrtValueCache {
  public:
   OrtValueCache() = default;
 
+  size_t size(){
+    return cache_.size();
+  }
+
+  size_t count(std::string name){
+    return cache_.count(name);
+  }
+
+  OrtValue at(std::string name) {
+    return cache_.at(name);
+  }
+
   Status CacheOrtValue(std::string node_arg_name, OrtValue& value) {
     cache_.emplace(node_arg_name, value);
     return Status::OK();

--- a/onnxruntime/core/framework/partial_graph_execution_state.h
+++ b/onnxruntime/core/framework/partial_graph_execution_state.h
@@ -9,49 +9,8 @@
 
 namespace onnxruntime {
 
-class OrtValueCache {
- public:
-  OrtValueCache() = default;
+typedef std::unordered_map<std::string, OrtValue> OrtValueCache;
 
-  size_t size() const {
-    return cache_.size();
-  }
-
-  size_t count(const std::string name) const {
-    return cache_.count(name);
-  }
-
-  OrtValue at(const std::string name) const {
-    return cache_.at(name);
-  }
-
-  Status CacheOrtValue(const std::string node_arg_name, const OrtValue& value) {
-    cache_.emplace(node_arg_name, value);
-    return Status::OK();
-  }
-
-  Status GetCachedIds(std::vector<std::string>& output_keys) const {
-    output_keys.reserve(cache_.size());
-    for(auto kv : cache_) {
-      output_keys.push_back(kv.first);
-    }
-    return Status::OK();
-  }
-
-  Status DeleteOrtValue(const std::string node_arg_name) {
-    ORT_RETURN_IF(cache_.find(node_arg_name) == cache_.end(), "NodeArg not found in cache: ", node_arg_name);
-    cache_.erase(node_arg_name);
-    return Status::OK();
-  }
-
-  Status ClearCache() {
-    cache_.clear();
-    return Status::OK();
-  }
-
- private:
-  std::unordered_map<std::string, OrtValue> cache_;
-};
 
 struct PartialGraphExecutionState {
  public:

--- a/onnxruntime/core/framework/partial_graph_execution_state.h
+++ b/onnxruntime/core/framework/partial_graph_execution_state.h
@@ -10,7 +10,7 @@
 namespace onnxruntime {
 
 typedef std::unordered_map<std::string, OrtValue> OrtValueCache;
-
+typedef std::shared_ptr<OrtValueCache> OrtValueCachePtr;
 
 struct PartialGraphExecutionState {
  public:

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -632,7 +632,7 @@ common::Status ExecuteGraph(const SessionState& session_state,
 common::Status ExecutePartialGraph(const SessionState& session_state, FeedsFetchesManager& feeds_fetches_manager,
                                    const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                    const logging::Logger& logger, PartialGraphExecutionState& state,
-                                   OrtValueCache* cache) {
+                                   const OrtValueCache& cache) {
 
   // finalize the copy info using the provided feeds and fetches. will update device_copy_checks in the background
   FinalizeFeedFetchCopyInfo(feeds_fetches_manager, feeds, fetches);

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -632,7 +632,7 @@ common::Status ExecuteGraph(const SessionState& session_state,
 common::Status ExecutePartialGraph(const SessionState& session_state, FeedsFetchesManager& feeds_fetches_manager,
                                    const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                    const logging::Logger& logger, PartialGraphExecutionState& state,
-                                   OrtValueCache cache) {
+                                   OrtValueCache* cache) {
 
   // finalize the copy info using the provided feeds and fetches. will update device_copy_checks in the background
   FinalizeFeedFetchCopyInfo(feeds_fetches_manager, feeds, fetches);

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -631,10 +631,12 @@ common::Status ExecuteGraph(const SessionState& session_state,
 #ifdef ENABLE_TRAINING
 common::Status ExecutePartialGraph(const SessionState& session_state, FeedsFetchesManager& feeds_fetches_manager,
                                    const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                                   const logging::Logger& logger, PartialGraphExecutionState& state) {
+                                   const logging::Logger& logger, PartialGraphExecutionState& state,
+                                   OrtValueCache cache) {
+
   // finalize the copy info using the provided feeds and fetches. will update device_copy_checks in the background
   FinalizeFeedFetchCopyInfo(feeds_fetches_manager, feeds, fetches);
-  PartialExecutor executor{state};
+  PartialExecutor executor{state, cache};
   const auto& feeds_fetches_info = feeds_fetches_manager.GetFeedsFetchesInfo();
   const auto& device_copy_checks = feeds_fetches_manager.GetDeviceCopyChecks();
 

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -632,7 +632,7 @@ common::Status ExecuteGraph(const SessionState& session_state,
 common::Status ExecutePartialGraph(const SessionState& session_state, FeedsFetchesManager& feeds_fetches_manager,
                                    const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                    const logging::Logger& logger, PartialGraphExecutionState& state,
-                                   const OrtValueCache& cache) {
+                                   const OrtValueCachePtr& cache) {
 
   // finalize the copy info using the provided feeds and fetches. will update device_copy_checks in the background
   FinalizeFeedFetchCopyInfo(feeds_fetches_manager, feeds, fetches);

--- a/onnxruntime/core/framework/utils.h
+++ b/onnxruntime/core/framework/utils.h
@@ -95,7 +95,7 @@ common::Status ExecuteGraph(const SessionState& session_state, FeedsFetchesManag
 common::Status ExecutePartialGraph(const SessionState& session_state, FeedsFetchesManager& feeds_fetches_manager,
                                    const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                    const logging::Logger& logger, PartialGraphExecutionState& state,
-                                   OrtValueCache cache);
+                                   OrtValueCache* cache);
 #endif
 
 // Execute a subgraph. The feeds_fetches_manager should have been finalized prior to calling this function.

--- a/onnxruntime/core/framework/utils.h
+++ b/onnxruntime/core/framework/utils.h
@@ -94,7 +94,8 @@ common::Status ExecuteGraph(const SessionState& session_state, FeedsFetchesManag
 #ifdef ENABLE_TRAINING
 common::Status ExecutePartialGraph(const SessionState& session_state, FeedsFetchesManager& feeds_fetches_manager,
                                    const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                                   const logging::Logger& logger, PartialGraphExecutionState& state);
+                                   const logging::Logger& logger, PartialGraphExecutionState& state,
+                                   OrtValueCache cache);
 #endif
 
 // Execute a subgraph. The feeds_fetches_manager should have been finalized prior to calling this function.

--- a/onnxruntime/core/framework/utils.h
+++ b/onnxruntime/core/framework/utils.h
@@ -95,7 +95,7 @@ common::Status ExecuteGraph(const SessionState& session_state, FeedsFetchesManag
 common::Status ExecutePartialGraph(const SessionState& session_state, FeedsFetchesManager& feeds_fetches_manager,
                                    const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                    const logging::Logger& logger, PartialGraphExecutionState& state,
-                                   OrtValueCache* cache);
+                                   const OrtValueCache& cache);
 #endif
 
 // Execute a subgraph. The feeds_fetches_manager should have been finalized prior to calling this function.

--- a/onnxruntime/core/framework/utils.h
+++ b/onnxruntime/core/framework/utils.h
@@ -95,7 +95,7 @@ common::Status ExecuteGraph(const SessionState& session_state, FeedsFetchesManag
 common::Status ExecutePartialGraph(const SessionState& session_state, FeedsFetchesManager& feeds_fetches_manager,
                                    const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                    const logging::Logger& logger, PartialGraphExecutionState& state,
-                                   const OrtValueCache& cache);
+                                   const OrtValueCachePtr& cache);
 #endif
 
 // Execute a subgraph. The feeds_fetches_manager should have been finalized prior to calling this function.

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1651,7 +1651,7 @@ Status InferenceSession::PartialRun(onnxruntime::RunOptions& run_options,
                                     std::vector<OrtValue>& fetches,
                                     PartialGraphExecutionState& state,
                                     FeedsFetchesManager& feeds_fetches_manager,
-                                    OrtValueCache& cache) {
+                                    OrtValueCache* cache) {
   Status retval = Status::OK();
   std::vector<IExecutionProvider*> exec_providers_to_stop;
   exec_providers_to_stop.reserve(execution_providers_.NumProviders());

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1650,7 +1650,8 @@ Status InferenceSession::PartialRun(onnxruntime::RunOptions& run_options,
                                     const std::vector<OrtValue>& feeds,
                                     std::vector<OrtValue>& fetches,
                                     PartialGraphExecutionState& state,
-                                    FeedsFetchesManager& feeds_fetches_manager) {
+                                    FeedsFetchesManager& feeds_fetches_manager,
+                                    OrtValueCache& cache) {
   Status retval = Status::OK();
   std::vector<IExecutionProvider*> exec_providers_to_stop;
   exec_providers_to_stop.reserve(execution_providers_.NumProviders());
@@ -1691,7 +1692,7 @@ Status InferenceSession::PartialRun(onnxruntime::RunOptions& run_options,
 
     // execute the graph
     ORT_CHECK_AND_SET_RETVAL(utils::ExecutePartialGraph(*session_state_, feeds_fetches_manager, feeds, fetches,
-                                                        run_logger, state));
+                                                        run_logger, state, cache));
   }
   ORT_CATCH(const std::exception& e) {
     ORT_HANDLE_EXCEPTION([&]() {

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1651,7 +1651,7 @@ Status InferenceSession::PartialRun(onnxruntime::RunOptions& run_options,
                                     std::vector<OrtValue>& fetches,
                                     PartialGraphExecutionState& state,
                                     FeedsFetchesManager& feeds_fetches_manager,
-                                    OrtValueCache* cache) {
+                                    const OrtValueCache& cache) {
   Status retval = Status::OK();
   std::vector<IExecutionProvider*> exec_providers_to_stop;
   exec_providers_to_stop.reserve(execution_providers_.NumProviders());

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1651,7 +1651,7 @@ Status InferenceSession::PartialRun(onnxruntime::RunOptions& run_options,
                                     std::vector<OrtValue>& fetches,
                                     PartialGraphExecutionState& state,
                                     FeedsFetchesManager& feeds_fetches_manager,
-                                    const OrtValueCache& cache) {
+                                    const OrtValueCachePtr& cache) {
   Status retval = Status::OK();
   std::vector<IExecutionProvider*> exec_providers_to_stop;
   exec_providers_to_stop.reserve(execution_providers_.NumProviders());

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -316,13 +316,15 @@ class InferenceSession {
     * @param state State of the graph needed to resume partial graph run.
     * @param feeds_fetches_manager Contains feed/fetches name to internal indices mapping and information for device
     *                              copy/checks.
+    * @param cache Contains node arg name to OrtValue map stashed from previous run
+    *              for frontier tensors
   */
   common::Status PartialRun(onnxruntime::RunOptions& run_options,
                             const std::vector<OrtValue>& feeds,
                             std::vector<OrtValue>& fetches,
                             PartialGraphExecutionState& state,
                             FeedsFetchesManager& feeds_fetches_manager,
-                            OrtValueCache& cache);
+                            OrtValueCache* cache);
 #endif
 
   /**

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -321,7 +321,8 @@ class InferenceSession {
                             const std::vector<OrtValue>& feeds,
                             std::vector<OrtValue>& fetches,
                             PartialGraphExecutionState& state,
-                            FeedsFetchesManager& feeds_fetches_manager);
+                            FeedsFetchesManager& feeds_fetches_manager,
+                            OrtValueCache& cache);
 #endif
 
   /**

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -324,7 +324,7 @@ class InferenceSession {
                             std::vector<OrtValue>& fetches,
                             PartialGraphExecutionState& state,
                             FeedsFetchesManager& feeds_fetches_manager,
-                            OrtValueCache* cache);
+                            const OrtValueCache& cache);
 #endif
 
   /**

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -324,7 +324,7 @@ class InferenceSession {
                             std::vector<OrtValue>& fetches,
                             PartialGraphExecutionState& state,
                             FeedsFetchesManager& feeds_fetches_manager,
-                            const OrtValueCache& cache);
+                            const OrtValueCachePtr& cache);
 #endif
 
   /**

--- a/orttraining/orttraining/core/agent/training_agent.cc
+++ b/orttraining/orttraining/core/agent/training_agent.cc
@@ -85,21 +85,5 @@ void TrainingAgent::CreateAndInitializeFeedsFetchesManager(const SessionState& s
   ORT_ENFORCE(utils::InitializeFeedFetchCopyInfo(session_state, *feeds_fetches_manager) == Status::OK());
 }
 
-void TrainingAgent::GetFrontierTensors(const std::vector<std::string>& param_names,
-                                       std::unordered_map<std::string, std::string>& frontier_node_arg_map) {
-  const Graph& graph = inference_session_.GetSessionState().GetGraphViewer().GetGraph();
-  for (const auto& param : param_names) {
-    std::vector<const Node*> consumer_nodes = graph.GetConsumerNodes(param);
-    // Initial support is limited to caching Cast output. This can 
-    // be extended to accomodate more ops whose result depends only 
-    // on the weight tensor which is a WIP.
-    for (const Node* node : consumer_nodes) {
-      if (node != nullptr && node->OpType() == "Cast") {
-        frontier_node_arg_map[param] = node->OutputDefs()[0]->Name();
-      }
-    }
-  }
-}
-
 }  // namespace training
 }  // namespace onnxruntime

--- a/orttraining/orttraining/core/agent/training_agent.cc
+++ b/orttraining/orttraining/core/agent/training_agent.cc
@@ -50,25 +50,26 @@ TrainingAgent::TrainingAgent(InferenceSession& session,
 TrainingAgent::~TrainingAgent() = default;
 
 common::Status TrainingAgent::RunForward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                                         PartialGraphExecutionState& state) {
+                                         PartialGraphExecutionState& state, OrtValueCache& cache) {
   state.SetProgramCounterStart(0);
   state.SetProgramCounterEnd(fw_program_counter_end_);
-  return RunCore(feeds, fetches, state, *fw_feeds_fetches_manager_);
+  return RunCore(feeds, fetches, state, *fw_feeds_fetches_manager_, cache);
 }
 
 common::Status TrainingAgent::RunBackward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                                          PartialGraphExecutionState& state) {
+                                          PartialGraphExecutionState& state, OrtValueCache& cache) {
   state.SetProgramCounterStart(fw_program_counter_end_);
   state.SetProgramCounterEnd(bw_program_counter_end_);
-  return RunCore(feeds, fetches, state, *bw_feeds_fetches_manager_);
+  return RunCore(feeds, fetches, state, *bw_feeds_fetches_manager_, cache);
 }
 
 common::Status TrainingAgent::RunCore(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                                      PartialGraphExecutionState& state, FeedsFetchesManager& feeds_fetches_manager) {
+                                      PartialGraphExecutionState& state, FeedsFetchesManager& feeds_fetches_manager,
+                                      OrtValueCache& cache) {
   auto fetches_size = feeds_fetches_manager.GetFeedsFetchesInfo().output_names.size();
   fetches.resize(fetches_size, {});
   RunOptions run_options;
-  return inference_session_.PartialRun(run_options, feeds, fetches, state, feeds_fetches_manager);
+  return inference_session_.PartialRun(run_options, feeds, fetches, state, feeds_fetches_manager, cache);
 }
 
 void TrainingAgent::CreateAndInitializeFeedsFetchesManager(const SessionState& session_state,

--- a/orttraining/orttraining/core/agent/training_agent.cc
+++ b/orttraining/orttraining/core/agent/training_agent.cc
@@ -50,22 +50,22 @@ TrainingAgent::TrainingAgent(InferenceSession& session,
 TrainingAgent::~TrainingAgent() = default;
 
 common::Status TrainingAgent::RunForward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                                         PartialGraphExecutionState& state, OrtValueCache& cache) {
+                                         PartialGraphExecutionState& state, OrtValueCache* cache) {
   state.SetProgramCounterStart(0);
   state.SetProgramCounterEnd(fw_program_counter_end_);
   return RunCore(feeds, fetches, state, *fw_feeds_fetches_manager_, cache);
 }
 
 common::Status TrainingAgent::RunBackward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                                          PartialGraphExecutionState& state, OrtValueCache& cache) {
+                                          PartialGraphExecutionState& state) {
   state.SetProgramCounterStart(fw_program_counter_end_);
   state.SetProgramCounterEnd(bw_program_counter_end_);
-  return RunCore(feeds, fetches, state, *bw_feeds_fetches_manager_, cache);
+  return RunCore(feeds, fetches, state, *bw_feeds_fetches_manager_, nullptr);
 }
 
 common::Status TrainingAgent::RunCore(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                       PartialGraphExecutionState& state, FeedsFetchesManager& feeds_fetches_manager,
-                                      OrtValueCache& cache) {
+                                      OrtValueCache* cache) {
   auto fetches_size = feeds_fetches_manager.GetFeedsFetchesInfo().output_names.size();
   fetches.resize(fetches_size, {});
   RunOptions run_options;

--- a/orttraining/orttraining/core/agent/training_agent.cc
+++ b/orttraining/orttraining/core/agent/training_agent.cc
@@ -85,5 +85,21 @@ void TrainingAgent::CreateAndInitializeFeedsFetchesManager(const SessionState& s
   ORT_ENFORCE(utils::InitializeFeedFetchCopyInfo(session_state, *feeds_fetches_manager) == Status::OK());
 }
 
+void TrainingAgent::GetFrontierTensors(const std::vector<std::string>& param_names,
+                                       std::unordered_map<std::string, std::string>& frontier_node_arg_map) {
+  const Graph& graph = inference_session_.GetSessionState().GetGraphViewer().GetGraph();
+  for (const auto& param : param_names) {
+    std::vector<const Node*> consumer_nodes = graph.GetConsumerNodes(param);
+    // Initial support is limited to caching Cast output. This can 
+    // be extended to accomodate more ops whose result depends only 
+    // on the weight tensor which is a WIP.
+    for (const Node* node : consumer_nodes) {
+      if (node != nullptr && node->OpType() == "Cast") {
+        frontier_node_arg_map[param] = node->OutputDefs()[0]->Name();
+      }
+    }
+  }
+}
+
 }  // namespace training
 }  // namespace onnxruntime

--- a/orttraining/orttraining/core/agent/training_agent.cc
+++ b/orttraining/orttraining/core/agent/training_agent.cc
@@ -50,7 +50,7 @@ TrainingAgent::TrainingAgent(InferenceSession& session,
 TrainingAgent::~TrainingAgent() = default;
 
 common::Status TrainingAgent::RunForward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                                         PartialGraphExecutionState& state, OrtValueCache* cache) {
+                                         PartialGraphExecutionState& state, const OrtValueCache& cache) {
   state.SetProgramCounterStart(0);
   state.SetProgramCounterEnd(fw_program_counter_end_);
   return RunCore(feeds, fetches, state, *fw_feeds_fetches_manager_, cache);
@@ -60,12 +60,12 @@ common::Status TrainingAgent::RunBackward(const std::vector<OrtValue>& feeds, st
                                           PartialGraphExecutionState& state) {
   state.SetProgramCounterStart(fw_program_counter_end_);
   state.SetProgramCounterEnd(bw_program_counter_end_);
-  return RunCore(feeds, fetches, state, *bw_feeds_fetches_manager_, nullptr);
+  return RunCore(feeds, fetches, state, *bw_feeds_fetches_manager_, {});
 }
 
 common::Status TrainingAgent::RunCore(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                       PartialGraphExecutionState& state, FeedsFetchesManager& feeds_fetches_manager,
-                                      OrtValueCache* cache) {
+                                      const OrtValueCache& cache) {
   auto fetches_size = feeds_fetches_manager.GetFeedsFetchesInfo().output_names.size();
   fetches.resize(fetches_size, {});
   RunOptions run_options;

--- a/orttraining/orttraining/core/agent/training_agent.cc
+++ b/orttraining/orttraining/core/agent/training_agent.cc
@@ -50,7 +50,7 @@ TrainingAgent::TrainingAgent(InferenceSession& session,
 TrainingAgent::~TrainingAgent() = default;
 
 common::Status TrainingAgent::RunForward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                                         PartialGraphExecutionState& state, const OrtValueCache& cache) {
+                                         PartialGraphExecutionState& state, const OrtValueCachePtr& cache) {
   state.SetProgramCounterStart(0);
   state.SetProgramCounterEnd(fw_program_counter_end_);
   return RunCore(feeds, fetches, state, *fw_feeds_fetches_manager_, cache);
@@ -60,12 +60,12 @@ common::Status TrainingAgent::RunBackward(const std::vector<OrtValue>& feeds, st
                                           PartialGraphExecutionState& state) {
   state.SetProgramCounterStart(fw_program_counter_end_);
   state.SetProgramCounterEnd(bw_program_counter_end_);
-  return RunCore(feeds, fetches, state, *bw_feeds_fetches_manager_, {});
+  return RunCore(feeds, fetches, state, *bw_feeds_fetches_manager_, nullptr);
 }
 
 common::Status TrainingAgent::RunCore(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                                       PartialGraphExecutionState& state, FeedsFetchesManager& feeds_fetches_manager,
-                                      const OrtValueCache& cache) {
+                                      const OrtValueCachePtr& cache) {
   auto fetches_size = feeds_fetches_manager.GetFeedsFetchesInfo().output_names.size();
   fetches.resize(fetches_size, {});
   RunOptions run_options;

--- a/orttraining/orttraining/core/agent/training_agent.h
+++ b/orttraining/orttraining/core/agent/training_agent.h
@@ -41,6 +41,9 @@ class TrainingAgent {
                                               const std::vector<OrtDevice>& outputs_device_info,
                                               std::unique_ptr<FeedsFetchesManager>& feeds_fetches_manager);
 
+  void GetFrontierTensors(const std::vector<std::string>& param_names,
+                          std::unordered_map<std::string, std::string>& frontier_node_arg_map);
+
  private:
   // TrainingAgent runs on a InferenceSession under the hood
   InferenceSession& inference_session_;

--- a/orttraining/orttraining/core/agent/training_agent.h
+++ b/orttraining/orttraining/core/agent/training_agent.h
@@ -41,9 +41,6 @@ class TrainingAgent {
                                               const std::vector<OrtDevice>& outputs_device_info,
                                               std::unique_ptr<FeedsFetchesManager>& feeds_fetches_manager);
 
-  void GetFrontierTensors(const std::vector<std::string>& param_names,
-                          std::unordered_map<std::string, std::string>& frontier_node_arg_map);
-
  private:
   // TrainingAgent runs on a InferenceSession under the hood
   InferenceSession& inference_session_;

--- a/orttraining/orttraining/core/agent/training_agent.h
+++ b/orttraining/orttraining/core/agent/training_agent.h
@@ -25,14 +25,15 @@ class TrainingAgent {
   ~TrainingAgent();
   // For ORTModule.forward()
   common::Status RunForward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                            PartialGraphExecutionState& state) ORT_MUST_USE_RESULT;
+                            PartialGraphExecutionState& state, OrtValueCache& cache) ORT_MUST_USE_RESULT;
 
   // For ORTModule.backward()
   common::Status RunBackward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                             PartialGraphExecutionState& state) ORT_MUST_USE_RESULT;
+                             PartialGraphExecutionState& state, OrtValueCache& cache) ORT_MUST_USE_RESULT;
 
   common::Status RunCore(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                         PartialGraphExecutionState& state, FeedsFetchesManager& feeds_fetches_manager)
+                         PartialGraphExecutionState& state, FeedsFetchesManager& feeds_fetches_manager,
+                         OrtValueCache& cache)
       ORT_MUST_USE_RESULT;
 
   void CreateAndInitializeFeedsFetchesManager(const SessionState& session_state,

--- a/orttraining/orttraining/core/agent/training_agent.h
+++ b/orttraining/orttraining/core/agent/training_agent.h
@@ -25,15 +25,15 @@ class TrainingAgent {
   ~TrainingAgent();
   // For ORTModule.forward()
   common::Status RunForward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                            PartialGraphExecutionState& state, OrtValueCache& cache) ORT_MUST_USE_RESULT;
+                            PartialGraphExecutionState& state, OrtValueCache* cache) ORT_MUST_USE_RESULT;
 
   // For ORTModule.backward()
   common::Status RunBackward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                             PartialGraphExecutionState& state, OrtValueCache& cache) ORT_MUST_USE_RESULT;
+                             PartialGraphExecutionState& state) ORT_MUST_USE_RESULT;
 
   common::Status RunCore(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                          PartialGraphExecutionState& state, FeedsFetchesManager& feeds_fetches_manager,
-                         OrtValueCache& cache)
+                         OrtValueCache* cache)
       ORT_MUST_USE_RESULT;
 
   void CreateAndInitializeFeedsFetchesManager(const SessionState& session_state,

--- a/orttraining/orttraining/core/agent/training_agent.h
+++ b/orttraining/orttraining/core/agent/training_agent.h
@@ -25,7 +25,7 @@ class TrainingAgent {
   ~TrainingAgent();
   // For ORTModule.forward()
   common::Status RunForward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                            PartialGraphExecutionState& state, OrtValueCache* cache) ORT_MUST_USE_RESULT;
+                            PartialGraphExecutionState& state, const OrtValueCache& cache) ORT_MUST_USE_RESULT;
 
   // For ORTModule.backward()
   common::Status RunBackward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
@@ -33,7 +33,7 @@ class TrainingAgent {
 
   common::Status RunCore(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                          PartialGraphExecutionState& state, FeedsFetchesManager& feeds_fetches_manager,
-                         OrtValueCache* cache)
+                         const OrtValueCache& cache)
       ORT_MUST_USE_RESULT;
 
   void CreateAndInitializeFeedsFetchesManager(const SessionState& session_state,

--- a/orttraining/orttraining/core/agent/training_agent.h
+++ b/orttraining/orttraining/core/agent/training_agent.h
@@ -25,7 +25,7 @@ class TrainingAgent {
   ~TrainingAgent();
   // For ORTModule.forward()
   common::Status RunForward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
-                            PartialGraphExecutionState& state, const OrtValueCache& cache) ORT_MUST_USE_RESULT;
+                            PartialGraphExecutionState& state, const OrtValueCachePtr& cache) ORT_MUST_USE_RESULT;
 
   // For ORTModule.backward()
   common::Status RunBackward(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
@@ -33,7 +33,7 @@ class TrainingAgent {
 
   common::Status RunCore(const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches,
                          PartialGraphExecutionState& state, FeedsFetchesManager& feeds_fetches_manager,
-                         const OrtValueCache& cache)
+                         const OrtValueCachePtr& cache)
       ORT_MUST_USE_RESULT;
 
   void CreateAndInitializeFeedsFetchesManager(const SessionState& session_state,

--- a/orttraining/orttraining/core/framework/ortmodule_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/ortmodule_graph_builder.cc
@@ -308,7 +308,7 @@ void OrtModuleGraphBuilder::HandleOutputsAndGrads() {
   for (auto& iter : graph_info_.frontier_node_arg_map) {
     std::string name = iter.second;
     yield_input_node_args.emplace_back(gradient_graph.GetNodeArg(name));
-    graph_info_.cached_node_arg_name.emplace_back(name);
+    graph_info_.cached_node_arg_names.emplace_back(name);
   }
 
   const auto& frontier_tensors = graph_info_.frontier_node_arg_map;

--- a/orttraining/orttraining/core/framework/ortmodule_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/ortmodule_graph_builder.cc
@@ -263,15 +263,15 @@ void OrtModuleGraphBuilder::HandleOutputsAndGrads() {
 
   // YieldOps non_differentiable_outputs attribute specifies the indices of outputs that are not differentiable
   const auto& non_differentiable_indices = graph_info_.output_grad_indices_non_differentiable;
+  const std::string non_differentiable_outputs_name = "non_differentiable_outputs";
+  ONNX_NAMESPACE::AttributeProto non_differentiable_outputs;
+  non_differentiable_outputs.set_name(non_differentiable_outputs_name);
+  non_differentiable_outputs.set_type(ONNX_NAMESPACE::AttributeProto::INTS);
+
   if (non_differentiable_indices.size() > 0) {
-    ONNX_NAMESPACE::AttributeProto non_differentiable_outputs;
-    const std::string non_differentiable_outputs_name = "non_differentiable_outputs";
-    non_differentiable_outputs.set_name(non_differentiable_outputs_name);
-    non_differentiable_outputs.set_type(ONNX_NAMESPACE::AttributeProto::INTS);
     for (auto index : non_differentiable_indices) {
       non_differentiable_outputs.add_ints(index);
     }
-    attributes.insert({non_differentiable_outputs_name, non_differentiable_outputs});
   }
 
   // YieldOps full_shape_outputs attribute specifies the indices of outputs that must be full shape.
@@ -303,6 +303,26 @@ void OrtModuleGraphBuilder::HandleOutputsAndGrads() {
       graph_info_.module_output_gradient_name.emplace_back(grad_name);
     }
   }
+
+  size_t input_count = yield_input_node_args.size();
+  for (auto& iter : graph_info_.frontier_node_arg_map) {
+    std::string name = iter.second;
+    yield_input_node_args.emplace_back(gradient_graph.GetNodeArg(name));
+    graph_info_.cached_node_arg_name.emplace_back(name);
+  }
+
+  const auto& frontier_tensors = graph_info_.frontier_node_arg_map;
+  if (frontier_tensors.size() > 0) {
+    for (size_t index = input_count; index < input_count + frontier_tensors.size(); index++) {
+      non_differentiable_outputs.add_ints(index);
+    }
+  }
+
+  // YieldOps non_differentiable_outputs /attribute specifies the indices of outputs that are not differentiable
+  if (non_differentiable_indices.size() > 0 || frontier_tensors.size() > 0) {
+    attributes.insert({non_differentiable_outputs_name, non_differentiable_outputs});
+  }
+
   attributes.insert({full_shape_outputs_name, full_shape_outputs});
 
   // Handle potential duplciated output_gradient names

--- a/orttraining/orttraining/core/framework/ortmodule_graph_builder.h
+++ b/orttraining/orttraining/core/framework/ortmodule_graph_builder.h
@@ -61,8 +61,11 @@ struct GraphInfo {
   std::vector<size_t> module_output_indices_requires_save_for_backward{};
   // Names of module outputs' gradient
   std::vector<std::string> module_output_gradient_name{};
-
+  // Names of the frontier tensor corresponding to param
   std::unordered_map<std::string, std::string> frontier_node_arg_map{};
+  // Names of the frontier NodeArgs in the order in which they will 
+  // be retrieved in the forward pass
+  std::vector<std::string> cached_node_arg_name{};
 };
 
 class OrtModuleGraphBuilder {

--- a/orttraining/orttraining/core/framework/ortmodule_graph_builder.h
+++ b/orttraining/orttraining/core/framework/ortmodule_graph_builder.h
@@ -65,7 +65,7 @@ struct GraphInfo {
   std::unordered_map<std::string, std::string> frontier_node_arg_map{};
   // Names of the frontier NodeArgs in the order in which they will 
   // be retrieved in the forward pass
-  std::vector<std::string> cached_node_arg_name{};
+  std::vector<std::string> cached_node_arg_names{};
 };
 
 class OrtModuleGraphBuilder {

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -335,12 +335,15 @@ void addObjectMethodsForTraining(py::module& m) {
         cache.CacheOrtValue(node_arg_name, value);
       })
       .def("keys", [](OrtValueCache& cache) {
+        // TODO : current implementation will result in two copies:
+        // one to std::vector, and other when pybind converts to py::list
+        // Need to avoid one of the copies.
         std::vector<std::string> key_vec;
         cache.GetCachedIds(key_vec);
         return key_vec;
       })
-      .def("drop", [](OrtValueCache& cache) {
-        cache.DeleteCache();
+      .def("clear", [](OrtValueCache& cache) {
+        cache.ClearCache();
       })
       .def("count", [](OrtValueCache& cache, std::string node_arg_name) {
         return cache.count(node_arg_name);

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -530,11 +530,6 @@ void addObjectMethodsForTraining(py::module& m) {
         return std::make_unique<TrainingAgent>(*session->GetSessionHandle(), fw_feed_names, fw_outputs_device_info,
                                                bw_fetches_names, bw_outputs_device_info);
       }))
-      .def("get_frontier_tensors", [](TrainingAgent* agent, const std::vector<std::string>& param_names) {
-        std::unordered_map<std::string, std::string> frontier_node_arg_map;
-        agent->GetFrontierTensors(param_names, frontier_node_arg_map);
-        return frontier_node_arg_map;
-      })
       .def("run_forward", [](TrainingAgent* agent, const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state) -> void {
         Status status = agent->RunForward(feeds, fetches, *state);
         if (!status.IsOK()) {

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -530,6 +530,11 @@ void addObjectMethodsForTraining(py::module& m) {
         return std::make_unique<TrainingAgent>(*session->GetSessionHandle(), fw_feed_names, fw_outputs_device_info,
                                                bw_fetches_names, bw_outputs_device_info);
       }))
+      .def("get_frontier_tensors", [](TrainingAgent* agent, const std::vector<std::string>& param_names) {
+        std::unordered_map<std::string, std::string> frontier_node_arg_map;
+        agent->GetFrontierTensors(param_names, frontier_node_arg_map);
+        return frontier_node_arg_map;
+      })
       .def("run_forward", [](TrainingAgent* agent, const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state) -> void {
         Status status = agent->RunForward(feeds, fetches, *state);
         if (!status.IsOK()) {

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -329,6 +329,20 @@ void addObjectMethodsForTraining(py::module& m) {
         return py::reinterpret_steal<py::object>(ToDlpack(v->at(idx)));
       });
 
+  py::class_<OrtValueCache>(m, "OrtValueCache")
+      .def(py::init<>())
+      .def("insert", [](OrtValueCache& cache, std::string node_arg_name, OrtValue& value) {
+        cache.CacheOrtValue(node_arg_name, value);
+      })
+      .def("keys", [](OrtValueCache& cache) {
+        std::vector<std::string> key_vec;
+        cache.GetCachedIds(key_vec);
+        return key_vec;
+      })
+      .def("drop", [](OrtValueCache& cache) {
+        cache.DeleteCache();
+      });
+
   py::class_<TrainingParameters> parameters(m, "TrainingParameters", R"pbdoc(Configuration information for training.)pbdoc");
   parameters.def(py::init())
       .def_readwrite("loss_output_name", &TrainingParameters::loss_output_name)
@@ -619,6 +633,7 @@ void addObjectMethodsForTraining(py::module& m) {
       .def_readwrite("output_grad_indices_require_full_shape", &GraphInfo::output_grad_indices_require_full_shape)
       .def_readwrite("module_output_indices_requires_save_for_backward", &GraphInfo::module_output_indices_requires_save_for_backward)
       .def_readwrite("frontier_node_arg_map", &GraphInfo::frontier_node_arg_map)
+      .def_readwrite("cached_node_arg_name", &GraphInfo::cached_node_arg_name)
       .def_readwrite("module_output_gradient_name", &GraphInfo::module_output_gradient_name);
 
   py::class_<OrtModuleGraphBuilder> ortmodule_graph_builder(m, "OrtModuleGraphBuilder");

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -341,6 +341,12 @@ void addObjectMethodsForTraining(py::module& m) {
       })
       .def("drop", [](OrtValueCache& cache) {
         cache.DeleteCache();
+      })
+      .def("count", [](OrtValueCache& cache, std::string node_arg_name) {
+        return cache.count(node_arg_name);
+      })
+      .def("remove", [](OrtValueCache& cache, std::string node_arg_name) {
+        cache.DeleteOrtValue(node_arg_name);
       });
 
   py::class_<TrainingParameters> parameters(m, "TrainingParameters", R"pbdoc(Configuration information for training.)pbdoc");
@@ -544,14 +550,14 @@ void addObjectMethodsForTraining(py::module& m) {
         return std::make_unique<TrainingAgent>(*session->GetSessionHandle(), fw_feed_names, fw_outputs_device_info,
                                                bw_fetches_names, bw_outputs_device_info);
       }))
-      .def("run_forward", [](TrainingAgent* agent, const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state) -> void {
-        Status status = agent->RunForward(feeds, fetches, *state);
+      .def("run_forward", [](TrainingAgent* agent, const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state, OrtValueCache& cache) -> void {
+        Status status = agent->RunForward(feeds, fetches, *state, cache);
         if (!status.IsOK()) {
           throw std::runtime_error("Error in forward pass execution: " + status.ErrorMessage());
         }
       })
-      .def("run_backward", [](TrainingAgent* agent, const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state) -> void {
-        Status status = agent->RunBackward(feeds, fetches, *state);
+      .def("run_backward", [](TrainingAgent* agent, const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state, OrtValueCache& cache) -> void {
+        Status status = agent->RunBackward(feeds, fetches, *state, cache);
         if (!status.IsOK()) {
           throw std::runtime_error("Error in backward pass execution: " + status.ErrorMessage());
         }

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -553,14 +553,20 @@ void addObjectMethodsForTraining(py::module& m) {
         return std::make_unique<TrainingAgent>(*session->GetSessionHandle(), fw_feed_names, fw_outputs_device_info,
                                                bw_fetches_names, bw_outputs_device_info);
       }))
-      .def("run_forward", [](TrainingAgent* agent, const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state, OrtValueCache& cache) -> void {
-        Status status = agent->RunForward(feeds, fetches, *state, cache);
+      .def("run_forward", [](TrainingAgent* agent, const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state) -> void {
+        Status status = agent->RunForward(feeds, fetches, *state, nullptr);
         if (!status.IsOK()) {
           throw std::runtime_error("Error in forward pass execution: " + status.ErrorMessage());
         }
       })
-      .def("run_backward", [](TrainingAgent* agent, const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state, OrtValueCache& cache) -> void {
-        Status status = agent->RunBackward(feeds, fetches, *state, cache);
+      .def("run_forward", [](TrainingAgent* agent, const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state, OrtValueCache& cache) -> void {
+        Status status = agent->RunForward(feeds, fetches, *state, &cache);
+        if (!status.IsOK()) {
+          throw std::runtime_error("Error in forward pass execution: " + status.ErrorMessage());
+        }
+      })
+      .def("run_backward", [](TrainingAgent* agent, const std::vector<OrtValue>& feeds, std::vector<OrtValue>& fetches, PartialGraphExecutionState* state) -> void {
+        Status status = agent->RunBackward(feeds, fetches, *state);
         if (!status.IsOK()) {
           throw std::runtime_error("Error in backward pass execution: " + status.ErrorMessage());
         }
@@ -642,7 +648,7 @@ void addObjectMethodsForTraining(py::module& m) {
       .def_readwrite("output_grad_indices_require_full_shape", &GraphInfo::output_grad_indices_require_full_shape)
       .def_readwrite("module_output_indices_requires_save_for_backward", &GraphInfo::module_output_indices_requires_save_for_backward)
       .def_readwrite("frontier_node_arg_map", &GraphInfo::frontier_node_arg_map)
-      .def_readwrite("cached_node_arg_name", &GraphInfo::cached_node_arg_name)
+      .def_readwrite("cached_node_arg_names", &GraphInfo::cached_node_arg_names)
       .def_readwrite("module_output_gradient_name", &GraphInfo::module_output_gradient_name);
 
   py::class_<OrtModuleGraphBuilder> ortmodule_graph_builder(m, "OrtModuleGraphBuilder");

--- a/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
+++ b/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
@@ -133,17 +133,3 @@ class TrainingAgent(object):
          :param state: State of the graph that is used for executing partial graph runs.
         """
         self._training_agent.run_backward(feeds, fetches, state)
-
-    def _get_frontier_tensors(self, params):
-        """
-        Get "frontier" tensors - the output of series of operations 
-        that only depend on the param values, eg Casting a param
-        :params: Names of the parameters to get the frontier for.
-
-        The output contains a map from the param to the nodearg name of the 
-        corresponding "frontier".
-        The output may not contain a frontier for all the params passed to it,
-        as it would only return frontier for viable candidates for caching
-        of the tensor.
-        """
-        return self._training_agent.get_frontier_tensors(params)

--- a/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
+++ b/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
@@ -116,20 +116,24 @@ class TrainingAgent(object):
         self._training_agent = C_TrainingAgent(self._inference_session._sess, fw_feed_names, fw_outputs_device_info,
                                                bw_fetches_names, bw_outputs_device_info)
 
-    def run_forward(self, feeds, fetches, state, cache):
+    def run_forward(self, feeds, fetches, state, cache=None):
         """
          Compute the forward subgraph for given feeds and fetches.
          :param feeds: Inputs to the graph run.
          :param fetches: Outputs of the graph run.
          :param state: State of the graph that is used for executing partial graph runs.
+         :param cache: Cache to store stashed OrtValues for intermediate activations.
         """
-        self._training_agent.run_forward(feeds, fetches, state, cache)
+        if cache:
+            self._training_agent.run_forward(feeds, fetches, state, cache)
+        else:
+            self._training_agent.run_forward(feeds, fetches, state)
 
-    def run_backward(self, feeds, fetches, state, cache):
+    def run_backward(self, feeds, fetches, state):
         """
          Compute the backward subgraph for given feeds and fetches.
          :param feeds: Inputs to the graph run.
          :param fetches: Outputs of the graph run.
          :param state: State of the graph that is used for executing partial graph runs.
         """
-        self._training_agent.run_backward(feeds, fetches, state, cache)
+        self._training_agent.run_backward(feeds, fetches, state)

--- a/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
+++ b/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
@@ -116,20 +116,20 @@ class TrainingAgent(object):
         self._training_agent = C_TrainingAgent(self._inference_session._sess, fw_feed_names, fw_outputs_device_info,
                                                bw_fetches_names, bw_outputs_device_info)
 
-    def run_forward(self, feeds, fetches, state):
+    def run_forward(self, feeds, fetches, state, cache):
         """
          Compute the forward subgraph for given feeds and fetches.
          :param feeds: Inputs to the graph run.
          :param fetches: Outputs of the graph run.
          :param state: State of the graph that is used for executing partial graph runs.
         """
-        self._training_agent.run_forward(feeds, fetches, state)
+        self._training_agent.run_forward(feeds, fetches, state, cache)
 
-    def run_backward(self, feeds, fetches, state):
+    def run_backward(self, feeds, fetches, state, cache):
         """
          Compute the backward subgraph for given feeds and fetches.
          :param feeds: Inputs to the graph run.
          :param fetches: Outputs of the graph run.
          :param state: State of the graph that is used for executing partial graph runs.
         """
-        self._training_agent.run_backward(feeds, fetches, state)
+        self._training_agent.run_backward(feeds, fetches, state, cache)

--- a/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
+++ b/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
@@ -133,3 +133,17 @@ class TrainingAgent(object):
          :param state: State of the graph that is used for executing partial graph runs.
         """
         self._training_agent.run_backward(feeds, fetches, state)
+
+    def _get_frontier_tensors(self, params):
+        """
+        Get "frontier" tensors - the output of series of operations 
+        that only depend on the param values, eg Casting a param
+        :params: Names of the parameters to get the frontier for.
+
+        The output contains a map from the param to the nodearg name of the 
+        corresponding "frontier".
+        The output may not contain a frontier for all the params passed to it,
+        as it would only return frontier for viable candidates for caching
+        of the tensor.
+        """
+        return self._training_agent.get_frontier_tensors(params)

--- a/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
+++ b/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
@@ -124,10 +124,7 @@ class TrainingAgent(object):
          :param state: State of the graph that is used for executing partial graph runs.
          :param cache: Cache to store stashed OrtValues for intermediate activations.
         """
-        if cache:
-            self._training_agent.run_forward(feeds, fetches, state, cache)
-        else:
-            self._training_agent.run_forward(feeds, fetches, state)
+        self._training_agent.run_forward(feeds, fetches, state, cache)
 
     def run_backward(self, feeds, fetches, state):
         """

--- a/orttraining/orttraining/python/training/ortmodule/_gradient_accumulation_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_gradient_accumulation_manager.py
@@ -1,0 +1,80 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from . import _utils
+from onnxruntime.capi import _pybind_state as C
+
+class GradientAccumulationManager(object):
+    """
+    GradientAccumulationManager is resposible for handling Gradient accumulation optimization
+    during training
+    """
+    def __init__(self):
+        """
+        :param state: State of partial run that contains intermediate tensors needed to resume the run later.
+        :param output_info: Output info.
+        """
+        self.cache = C.OrtValueCache()
+        self._param_name_value_map = None
+        self._param_version_map = dict()
+        self._frontier_node_arg_map = dict()
+        self._enabled = False
+        self._update_cache = False
+
+    def initialize(self, module, graph_info) -> None:
+        """
+         Initialize the Gradient Accumulation optimization.
+         :param module: The torch.nn.module which is being trained.
+         :param graph_info: The ORT Graph Info object holding information about backend graph.
+        """
+        # Since named_parameters() is a generator function, need to avoid overhead and
+        # populate the params in memory to avoid generating the param map every
+        # step. This will not work if the user adds or removes params between steps
+        self._param_name_value_map = {name: param for name, param in module.named_parameters()}
+        self._frontier_node_arg_map = graph_info.frontier_node_arg_map
+        self._cached_node_arg_names = graph_info.cached_node_arg_names
+        self._cache_start = len(graph_info.user_output_names)
+        self._enabled = True
+    
+    @property
+    def enabled(self):
+        """
+        This property indicates whether gradient accumulation optimization is enabled.
+        """
+        return self._enabled
+
+    def update_cache_and_return_outputs(self, forward_outputs):
+        """
+         Convert the forward outputs to torch and maybe update cache
+         :param forward_outputs: OrtValue vector returned by forward function
+        """
+        if self._update_cache:
+            for i in range(self._cache_start, len(forward_outputs)):
+                self.cache.insert(self._cached_node_arg_names[i-self._cache_start], forward_outputs[i])
+            self._update_cache = False
+        return tuple(_utils._ortvalue_to_torch_tensor(forward_outputs[i]) for i in range(self._cache_start))
+
+    def update_cache_before_run(self):
+        """
+         Iterate over the model parameters to detect whether they have been updated
+         and modify the cache accordingly.
+        """
+        # The current implementation relies on param._version, which might not be
+        # updated in all cases(eg. inplace update)
+        # TODO: Make detection of parameter update robust
+        assert self.enabled, "Gradient accumulation optimization must be enabled by calling " + \
+                              "initialize() before this function"    
+
+        # parse param versions to detect change or no change
+        for name, arg_name in self._frontier_node_arg_map.items():
+            param = self._param_name_value_map[name]
+            if name not in self._param_version_map:
+                self._param_version_map[name] = param._version
+            elif param._version != self._param_version_map[name]:
+                # there is an updated param, so remove entry from cache
+                # in order to recompute the value
+                if self.cache.count(arg_name):
+                    self.cache.remove(arg_name)
+                self._update_cache = True
+                self._param_version_map[name] = param._version

--- a/orttraining/orttraining/python/training/ortmodule/_gradient_accumulation_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_gradient_accumulation_manager.py
@@ -5,66 +5,75 @@
 from . import _utils
 from onnxruntime.capi import _pybind_state as C
 
+
 class GradientAccumulationManager(object):
     """
-    GradientAccumulationManager is resposible for handling Gradient accumulation optimization
-    during training
+    Handles Gradient accumulation optimization during training
+
+    This feature must be enabled once before training and cannot be turned off within a training run.
     """
+    # TODO: enable switching the feature on/off in the middle of the training
+
     def __init__(self):
-        """
-        :param state: State of partial run that contains intermediate tensors needed to resume the run later.
-        :param output_info: Output info.
-        """
-        self.cache = C.OrtValueCache()
+        self.cache = None
         self._param_name_value_map = None
-        self._param_version_map = dict()
-        self._frontier_node_arg_map = dict()
+        self._param_version_map = None
+        self._frontier_node_arg_map = None
         self._enabled = False
         self._update_cache = False
 
-    def initialize(self, module, graph_info) -> None:
+    def initialize(self, enabled, module, graph_info) -> None:
+        """Initializes Gradient Accumulation optimization.
+
+        Args:
+            enabled (bool): Whether the optimization is enabled or disabled.
+            module (torch.nn.Module): Training model
+            graph_info (GraphInfo): The ORT Graph Info object holding information about backend graph.
         """
-         Initialize the Gradient Accumulation optimization.
-         :param module: The torch.nn.module which is being trained.
-         :param graph_info: The ORT Graph Info object holding information about backend graph.
-        """
-        # Since named_parameters() is a generator function, need to avoid overhead and
-        # populate the params in memory to avoid generating the param map every
-        # step. This will not work if the user adds or removes params between steps
-        self._param_name_value_map = {name: param for name, param in module.named_parameters()}
-        self._frontier_node_arg_map = graph_info.frontier_node_arg_map
-        self._cached_node_arg_names = graph_info.cached_node_arg_names
-        self._cache_start = len(graph_info.user_output_names)
-        self._enabled = True
-    
+        if enabled:
+            self._enabled = True
+            self.cache = C.OrtValueCache()
+            # Since named_parameters() is a generator function, need to avoid overhead and
+            # populate the params in memory to avoid generating the param map every
+            # step. This will not work if the user adds or removes params between steps
+            self._param_name_value_map = {
+                name: param for name, param in module.named_parameters()}
+            self._param_version_map = dict()
+            self._frontier_node_arg_map = graph_info.frontier_node_arg_map
+            self._cached_node_arg_names = graph_info.cached_node_arg_names
+            self._cache_start = len(graph_info.user_output_names)
+
     @property
     def enabled(self):
         """
-        This property indicates whether gradient accumulation optimization is enabled.
+        Indicates whether gradient accumulation optimization is enabled.
         """
         return self._enabled
 
     def update_cache_and_return_outputs(self, forward_outputs):
+        """Convert the forward outputs to torch and update cache, if needed
+
+        Args:
+            forward_outputs (OrtValueVector): List of outputs returned by forward function
         """
-         Convert the forward outputs to torch and maybe update cache
-         :param forward_outputs: OrtValue vector returned by forward function
-        """
+        if not self.enabled:
+            return
         if self._update_cache:
             for i in range(self._cache_start, len(forward_outputs)):
-                self.cache.insert(self._cached_node_arg_names[i-self._cache_start], forward_outputs[i])
+                self.cache.insert(
+                    self._cached_node_arg_names[i-self._cache_start], forward_outputs[i])
             self._update_cache = False
         return tuple(_utils._ortvalue_to_torch_tensor(forward_outputs[i]) for i in range(self._cache_start))
 
-    def update_cache_before_run(self):
+    def maybe_update_cache_before_run(self):
         """
-         Iterate over the model parameters to detect whether they have been updated
-         and modify the cache accordingly.
+         Update cache when model parameters are modified and optimization is enabled.
         """
         # The current implementation relies on param._version, which might not be
         # updated in all cases(eg. inplace update)
         # TODO: Make detection of parameter update robust
-        assert self.enabled, "Gradient accumulation optimization must be enabled by calling " + \
-                              "initialize() before this function"    
+        if not self.enabled:
+            return
 
         # parse param versions to detect change or no change
         for name, arg_name in self._frontier_node_arg_map.items():

--- a/orttraining/orttraining/python/training/ortmodule/_gradient_accumulation_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_gradient_accumulation_manager.py
@@ -50,14 +50,14 @@ class GradientAccumulationManager(object):
         """
         return self._enabled
 
-    def update_cache_and_return_outputs(self, forward_outputs):
-        """Convert the forward outputs to torch and update cache, if needed
+    def extract_outputs_and_maybe_update_cache(self, forward_outputs):
+        """Extract the user outputs from the forward outputs as torch tensor and update cache, if needed
 
         Args:
             forward_outputs (OrtValueVector): List of outputs returned by forward function
         """
         if not self.enabled:
-            return
+            return tuple(_utils._ortvalue_to_torch_tensor(forward_output) for forward_output in forward_outputs)
         if self._update_cache:
             for i in range(self._cache_start, len(forward_outputs)):
                 self.cache.insert(

--- a/orttraining/orttraining/python/training/ortmodule/_gradient_accumulation_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_gradient_accumulation_manager.py
@@ -7,8 +7,7 @@ from onnxruntime.capi import _pybind_state as C
 
 
 class GradientAccumulationManager(object):
-    """
-    Handles Gradient accumulation optimization during training
+    """Handles Gradient accumulation optimization during training
 
     This feature must be enabled once before training and cannot be turned off within a training run.
     """
@@ -45,8 +44,7 @@ class GradientAccumulationManager(object):
 
     @property
     def enabled(self):
-        """
-        Indicates whether gradient accumulation optimization is enabled.
+        """Indicates whether gradient accumulation optimization is enabled.
         """
         return self._enabled
 
@@ -66,8 +64,7 @@ class GradientAccumulationManager(object):
         return tuple(_utils._ortvalue_to_torch_tensor(forward_outputs[i]) for i in range(self._cache_start))
 
     def maybe_update_cache_before_run(self):
-        """
-         Update cache when model parameters are modified and optimization is enabled.
+        """Update cache when model parameters are modified and optimization is enabled.
         """
         # The current implementation relies on param._version, which might not be
         # updated in all cases(eg. inplace update)

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -176,6 +176,9 @@ class GraphExecutionManager(GraphExecutionInterface):
                                  TypeError("ORTModule is not compatible with torch.nn.DataParallel. "
                                            "Please use torch.nn.parallel.DistributedDataParallel instead."))
 
+        # WIP feature to enable caching in Gradient accumulation scenario.
+        self._enable_grad_acc_optimization = False
+
     @staticmethod
     def execution_session_run_forward(execution_session, onnx_model, device, *inputs):
         """Runs the forward pass on `execution_session` with given `onnx_model`, `device` and `inputs`

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -14,6 +14,7 @@ from ._fallback import (_FallbackManager,
                        ORTModuleONNXModelException,
                        ORTModuleTorchModelException,
                        wrap_exception)
+from ._gradient_accumulation_manager import GradientAccumulationManager
 from onnxruntime.training.ortmodule import ONNX_OPSET_VERSION
 
 from onnxruntime.capi import _pybind_state as C
@@ -152,8 +153,7 @@ class GraphExecutionManager(GraphExecutionInterface):
 
         # WIP feature to enable caching in Gradient accumulation scenario.
         self._enable_grad_acc_optimization = False
-        self._param_version_map = None
-        self._cache = C.OrtValueCache()
+        self._gradient_accumulation_manager = GradientAccumulationManager()
 
         # Memory aware gradient builder.
         self._use_memory_efficient_gradient = False

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -178,9 +178,6 @@ class GraphExecutionManager(GraphExecutionInterface):
                                  TypeError("ORTModule is not compatible with torch.nn.DataParallel. "
                                            "Please use torch.nn.parallel.DistributedDataParallel instead."))
 
-        # WIP feature to enable caching in Gradient accumulation scenario.
-        self._enable_grad_acc_optimization = False
-
     @staticmethod
     def execution_session_run_forward(execution_session, onnx_model, device, *inputs):
         """Runs the forward pass on `execution_session` with given `onnx_model`, `device` and `inputs`

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -152,6 +152,8 @@ class GraphExecutionManager(GraphExecutionInterface):
 
         # WIP feature to enable caching in Gradient accumulation scenario.
         self._enable_grad_acc_optimization = False
+        self._param_version_map = None
+        self._cache = C.OrtValueCache()
 
         # Memory aware gradient builder.
         self._use_memory_efficient_gradient = False

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -286,8 +286,6 @@ class TrainingManager(GraphExecutionManager):
                                               session_options,
                                               providers,
                                               provider_options)
-        if self._enable_grad_acc_optimization:
-            frontier_tensor_map = self._execution_agent._get_frontier_tensors(list(self._graph_initializer_names_to_train))
 
     def _reinitialize_graph_builder(self, input_info):
         """Return true if the module graph builder was reinitialized"""

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -26,7 +26,6 @@ class TrainingManager(GraphExecutionManager):
     def __init__(self, model, debug_options: DebugOptions, fallback_manager: _FallbackManager):
         super().__init__(model, debug_options, fallback_manager)
         self._export_mode = torch.onnx.TrainingMode.TRAINING
-        self._cache = None
 
     @staticmethod
     def execution_session_run_forward(execution_session, onnx_model, cache, cache_names, cache_start, *inputs):
@@ -44,7 +43,7 @@ class TrainingManager(GraphExecutionManager):
 
         forward_outputs = C.OrtValueVector()
         # Run and return module outputs.
-        execution_session.run_forward(forward_inputs, forward_outputs, state)
+        execution_session.run_forward(forward_inputs, forward_outputs, state, cache)
 
         user_outputs = []
         for i in range(len(forward_outputs)):

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -43,12 +43,8 @@ class TrainingManager(GraphExecutionManager):
 
         forward_outputs = C.OrtValueVector()
         # Run and return module outputs.
-        if gradient_accumulation_manager.enabled:
-            execution_session.run_forward(forward_inputs, forward_outputs, state, gradient_accumulation_manager.cache)
-            user_outputs = gradient_accumulation_manager.update_cache_and_return_outputs(forward_outputs)
-        else:
-            execution_session.run_forward(forward_inputs, forward_outputs, state)
-            user_outputs = tuple(_utils._ortvalue_to_torch_tensor(forward_output) for forward_output in forward_outputs)
+        execution_session.run_forward(forward_inputs, forward_outputs, state, gradient_accumulation_manager.cache)
+        user_outputs = gradient_accumulation_manager.extract_outputs_and_maybe_update_cache(forward_outputs)
 
         output_info = [(output.shape, output.device, output.dtype) for output in user_outputs]
         run_info = _RunStateInfo(state, output_info)

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -114,11 +114,9 @@ class TrainingManager(GraphExecutionManager):
                         warnings.warn("Fast path enabled - skipping checks for rebuilding gradient graph, execution agent creation, and device during training.",
                                       UserWarning)
                 
-                if self._enable_grad_acc_optimization:
-                self._gradient_accumulation_manager.initialize(self._flattened_module, self._graph_info)
+                self._gradient_accumulation_manager.initialize(self._enable_grad_acc_optimization, self._flattened_module, self._graph_info)
         
-            if self._enable_grad_acc_optimization:
-                self._gradient_accumulation_manager.update_cache_before_run()
+            self._gradient_accumulation_manager.maybe_update_cache_before_run()
 
             class _ORTModuleFunction(torch.autograd.Function):
                 '''Use a custom torch.autograd.Function to associate self.backward_graph as the

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -286,6 +286,8 @@ class TrainingManager(GraphExecutionManager):
                                               session_options,
                                               providers,
                                               provider_options)
+        if self._enable_grad_acc_optimization:
+            frontier_tensor_map = self._execution_agent._get_frontier_tensors(list(self._graph_initializer_names_to_train))
 
     def _reinitialize_graph_builder(self, input_info):
         """Return true if the module graph builder was reinitialized"""

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -44,15 +44,10 @@ class TrainingManager(GraphExecutionManager):
         forward_outputs = C.OrtValueVector()
         # Run and return module outputs.
         execution_session.run_forward(forward_inputs, forward_outputs, state, cache)
-
-        user_outputs = []
-        for i in range(len(forward_outputs)):
-            if i < cache_start:
-                user_outputs.append(_utils._ortvalue_to_torch_tensor(forward_outputs[i]))
-            elif cache !=None:
+        user_outputs = tuple(_utils._ortvalue_to_torch_tensor(forward_outputs[i]) for i in range(cache_start))
+        if cache != None:
+            for i in range(cache_start, len(forward_outputs)):
                 cache.insert(cache_names[i-cache_start], forward_outputs[i])
-
-        user_outputs = tuple(user_outputs)
 
         output_info = [(output.shape, output.device, output.dtype) for output in user_outputs]
         run_info = _RunStateInfo(state, output_info)

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -147,8 +147,12 @@ class TrainingManager(GraphExecutionManager):
                     # ORT is NOT relying on save_for_backward() to actually save the tensor,
                     # as this tensor is also kept in ORT's PartialGraphState
                     # This call is to invoke pytorch's version check to detect the potential inplace corruption
+                    # If ORT is caching tensors, the module_output_indices_requires_save_for_backward field
+                    # might also have indices of cached tensors that are not passed over to pytorch, and they don't 
+                    # need marking with save_for_backward()
                     for idx in self._graph_info.module_output_indices_requires_save_for_backward:
-                        ctx.save_for_backward(user_outputs[idx])
+                        if idx < len(self._graph_info.user_output_names):
+                            ctx.save_for_backward(user_outputs[idx])
 
                     # Mark the outputs tensors non-differentiable if requires_grad is False in _graph_info
                     # This will return torch the output tensors with correct requires_grad settings

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -3138,3 +3138,56 @@ def test_debug_options_log_level_validation_fails_on_type_mismatch():
     with pytest.raises(Exception) as ex_info:
         _ = DebugOptions(log_level=log_level)
     assert f"Expected log_level of type LogLevel, got {type(log_level)}." in str(ex_info.value)
+
+def test_ortmodule_GAOptimization_correctness():
+    class NeuralNetWithCast(torch.nn.Module):
+        def __init__(self, input_size, hidden_size, num_classes):
+            super(NeuralNetWithCast, self).__init__()
+
+            self.fc1 = torch.nn.Linear(input_size, hidden_size)
+            self.relu = torch.nn.ReLU()
+            self.fc2 = torch.nn.Linear(hidden_size, num_classes)
+
+        def forward(self, input1):
+            out = self.fc1(input1)
+            out = self.relu(out)
+            out = self.fc2(out)
+            return out
+    device = 'cuda'
+    N, D_in, H, D_out = 64, 784, 500, 10
+    pt_model = NeuralNetWithCast(D_in, H, D_out).to(device)
+
+    # baseline model with optimization disabled
+    tgt_model = ORTModule(pt_model)
+    tgt_optimizer = torch.optim.Adam(tgt_model.parameters())
+
+    # model with optimization enabled
+    opt_model = ORTModule(copy.deepcopy(pt_model))
+    opt_model._torch_module._execution_manager(is_training=True)._enable_grad_acc_optimization = True
+    opt_optimizer = torch.optim.Adam(opt_model.parameters())
+
+    def run_step(model, x):
+        with amp.autocast():
+            prediction = model(x)
+            loss = prediction.sum()
+        loss.backward()
+        return loss.detach()
+    
+    def run_optim_step(optimizer):
+        optimizer.step()
+        optimizer.zero_grad()
+    
+    GA_steps = 2
+    tgt_model.zero_grad()
+    opt_model.zero_grad()
+    
+    for step in range(10):
+        x = torch.randn(N, D_in, device=device)
+        tgt_loss = run_step(tgt_model, x)
+        opt_loss = run_step(opt_model, x)
+
+        # assert that loss values match
+        _test_helpers.assert_values_are_close(tgt_loss, opt_loss)
+        if step % GA_steps == 0:
+            run_optim_step(tgt_optimizer)
+            run_optim_step(opt_optimizer)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -3139,7 +3139,7 @@ def test_debug_options_log_level_validation_fails_on_type_mismatch():
         _ = DebugOptions(log_level=log_level)
     assert f"Expected log_level of type LogLevel, got {type(log_level)}." in str(ex_info.value)
 
-def test_ortmodule_GAOptimization_correctness():
+def test_ortmodule_gradient_accumulation_optimization_correctness():
     class NeuralNetWithCast(torch.nn.Module):
         def __init__(self, input_size, hidden_size, num_classes):
             super(NeuralNetWithCast, self).__init__()

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_bert_classifier_autocast.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_bert_classifier_autocast.py
@@ -322,7 +322,7 @@ def main():
                         help='disables ONNX Runtime training')
     parser.add_argument('--batch-size', type=int, default=32, metavar='N',
                         help='input batch size for training (default: 32)')
-    parser.add_argument('--do-val', action='store_true', default=True,
+    parser.add_argument('--do-val', action='store_true', default=False,
                         help='disables validation')
     parser.add_argument('--test-batch-size', type=int, default=64, metavar='N',
                         help='input batch size for testing (default: 64)')


### PR DESCRIPTION
Part[2/N] 
This PR adds the support for fetching the frontier tensors as outputs in the forward pass and adds them to a cache when GA optimization is enabled, using the cache to skip execution and using param versions to identify when to update cache v/s use it.
This is verified for correctness. Further PRs will focus on perf improvements based on investigations.
This is a WIP feature.
