### PR TITLE
Pin version of Pillow to 8.2.0 to circumvent non-compatibility with numpy

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.9.0_cu11.1.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.9.0_cu11.1.txt
@@ -1,3 +1,5 @@
+# TODO: Remove pinned version of Pillow of 8.2.0 when 8.3.0 release regression issue https://github.com/python-pillow/Pillow/issues/5571 is resolved
+Pillow==8.2.0
 --pre
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.9.0+cu111


### PR DESCRIPTION
**Description**: Latest Pillow release ```8.3.0``` introduced a regression which causes build failures in our CI pipeline:

```sh

Traceback (most recent call last):
  File "orttraining_test_ortmodule_poc.py", line 211, in <module>
    main()
  File "orttraining_test_ortmodule_poc.py", line 188, in main
    total_training_time += train(args, model, device, optimizer, my_loss, train_loader, epoch)
  File "orttraining_test_ortmodule_poc.py", line 36, in train
    for iteration, (data, target) in enumerate(train_loader):
  File "/opt/python/cp38-cp38/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 521, in __next__
    data = self._next_data()
  File "/opt/python/cp38-cp38/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 561, in _next_data
    data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
  File "/opt/python/cp38-cp38/lib/python3.8/site-packages/torch/utils/data/_utils/fetch.py", line 44, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/opt/python/cp38-cp38/lib/python3.8/site-packages/torch/utils/data/_utils/fetch.py", line 44, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/opt/python/cp38-cp38/lib/python3.8/site-packages/torchvision/datasets/mnist.py", line 134, in __getitem__
    img = self.transform(img)
  File "/opt/python/cp38-cp38/lib/python3.8/site-packages/torchvision/transforms/transforms.py", line 60, in __call__
    img = t(img)
  File "/opt/python/cp38-cp38/lib/python3.8/site-packages/torchvision/transforms/transforms.py", line 97, in __call__
    return F.to_tensor(pic)
  File "/opt/python/cp38-cp38/lib/python3.8/site-packages/torchvision/transforms/functional.py", line 129, in to_tensor
    np.array(pic, mode_to_nptype.get(pic.mode, np.uint8), copy=True)
TypeError: __array__() takes 1 positional argument but 2 were given
```

Pin version of Pillow to ```8.2.0``` for now until the issue https://github.com/python-pillow/Pillow/issues/5571 is resolved.