### PR TITLE
Remove path from telemetry strings

### DIFF
--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -41,6 +41,11 @@ namespace onnxruntime {
 
 namespace {
 
+std::wstring Basename(const std::wstring& path) {
+  auto basename_index = path.find_last_of(L"/\\") + 1;  // results in 0 if no separator is found
+  return path.substr(basename_index);
+}
+
 class WindowsThread : public EnvThread {
  private:
   struct Param {
@@ -192,12 +197,12 @@ class WindowsEnv : public Env {
 #endif
     if (file_handle.get() == INVALID_HANDLE_VALUE) {
       const auto error_code = GetLastError();
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "open file ", ToMBString(file_path), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "open file ", ToMBString(Basename(file_path)), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
     }
     LARGE_INTEGER filesize;
     if (!GetFileSizeEx(file_handle.get(), &filesize)) {
       const auto error_code = GetLastError();
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "GetFileSizeEx ", ToMBString(file_path), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "GetFileSizeEx ", ToMBString(Basename(file_path)), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
     }
     if (static_cast<ULONGLONG>(filesize.QuadPart) > std::numeric_limits<size_t>::max()) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "GetFileLength: File is too large");
@@ -244,7 +249,7 @@ class WindowsEnv : public Env {
 #endif
     if (file_handle.get() == INVALID_HANDLE_VALUE) {
       const auto error_code = GetLastError();
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "open file ", ToMBString(file_path), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "open file ", ToMBString(Basename(file_path)), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
     }
 
     if (length == 0)
@@ -255,7 +260,7 @@ class WindowsEnv : public Env {
       current_position.QuadPart = offset;
       if (!SetFilePointerEx(file_handle.get(), current_position, &current_position, FILE_BEGIN)) {
         const auto error_code = GetLastError();
-        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "SetFilePointerEx ", ToMBString(file_path), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "SetFilePointerEx ", ToMBString(Basename(file_path)), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
       }
     }
 
@@ -268,11 +273,11 @@ class WindowsEnv : public Env {
 
       if (!ReadFile(file_handle.get(), buffer.data() + total_bytes_read, bytes_to_read, &bytes_read, nullptr)) {
         const auto error_code = GetLastError();
-        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "ReadFile ", ToMBString(file_path), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "ReadFile ", ToMBString(Basename(file_path)), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
       }
 
       if (bytes_read != bytes_to_read) {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "ReadFile ", ToMBString(file_path), " fail: unexpected end");
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "ReadFile ", ToMBString(Basename(file_path)), " fail: unexpected end");
       }
 
       total_bytes_read += bytes_read;
@@ -348,7 +353,7 @@ class WindowsEnv : public Env {
               const auto error_code = GetLastError();
               final_status = ORT_MAKE_STATUS(
                   ONNXRUNTIME, FAIL,
-                  "DeleteFile() failed - path: ", ToMBString(child_path),
+                  "DeleteFile() failed - path: ", ToMBString(Basename(child_path)),
                   ", error code: ", error_code, " - ", std::system_category().message(error_code));
             }
           }
@@ -362,7 +367,7 @@ class WindowsEnv : public Env {
       const auto error_code = GetLastError();
       final_status = ORT_MAKE_STATUS(
           ONNXRUNTIME, FAIL,
-          "RemoveDirectory() failed - path: ", ToMBString(path),
+          "RemoveDirectory() failed - path: ", ToMBString(Basename(path)),
           ", error code: ", error_code, " - ", std::system_category().message(error_code));
     }
 
@@ -436,7 +441,7 @@ class WindowsEnv : public Env {
 
     if (file_handle.get() == INVALID_HANDLE_VALUE) {
       const auto error_code = GetLastError();
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "open file ", ToMBString(path), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "open file ", ToMBString(Basename(path)), " fail, errcode = ", error_code, " - ", std::system_category().message(error_code));
     }
 
     constexpr DWORD initial_buffer_size = MAX_PATH;


### PR DESCRIPTION
**Description**: Remove paths from telemetry to prevent user identifiable strings to show up (e.g. user profile name), fixes https://microsoft.visualstudio.com/OS/_workitems/edit/32673105
