### PR TITLE
cuda_mem_limit has been renamed to gpu_mem_limit

### DIFF
--- a/docs/reference/execution-providers/CUDA-ExecutionProvider.md
+++ b/docs/reference/execution-providers/CUDA-ExecutionProvider.md
@@ -41,7 +41,7 @@ The device ID.
 
 Default value: 0
 
-### cuda_mem_limit
+### gpu_mem_limit
 The size limit of the device memory arena in bytes. This size limit is only for the execution provider's arena. The total device memory usage may be higher.
 
 Default value: max value of C++ size_t type (effectively unlimited)
@@ -85,7 +85,7 @@ providers = [
     ('CUDAExecutionProvider', {
         'device_id': 0,
         'arena_extend_strategy': 'kNextPowerOfTwo',
-        'cuda_mem_limit': 2 * 1024 * 1024 * 1024,
+        'gpu_mem_limit': 2 * 1024 * 1024 * 1024,
         'cudnn_conv_algo_search': 'EXHAUSTIVE',
         'do_copy_in_default_stream': True,
     }),
@@ -103,7 +103,7 @@ OrtSessionOptions* session_options = /* ... */;
 OrtCUDAProviderOptions options;
 options.device_id = 0;
 options.arena_extend_strategy = 0;
-options.cuda_mem_limit = 2 * 1024 * 1024 * 1024;
+options.gpu_mem_limit = 2 * 1024 * 1024 * 1024;
 options.cudnn_conv_algo_search = OrtCudnnConvAlgoSearch::EXHAUSTIVE;
 options.do_copy_in_default_stream = 1;
 


### PR DESCRIPTION
`cuda_mem_limit` was renamed to `gpu_mem_limit` in nighlty build `nightly-1.7.0.dev202104231`.

Fixes:
https://github.com/microsoft/onnxruntime/issues/7457
