### PR TITLE
Fix _ld_preload.py population for ROCm libraries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,8 @@ try:
                     args.append(dest)
                     if len(args) > 3:
                         subprocess.run(args, check=True, stdout=subprocess.PIPE)
-                    self._rewrite_ld_preload(to_preload)
+
+                self._rewrite_ld_preload(to_preload)
             _bdist_wheel.run(self)
             if is_manylinux:
                 file = glob(path.join(self.dist_dir, '*linux*.whl'))[0]


### PR DESCRIPTION
The _ld_preload.py section was not populating for ROCm libraries. This seems to be the cause for failing _import onnxruntime_. Tested with a wheel created at https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=433865&view=results