### PR TITLE
Cosmetic change in test infrastructure

### DIFF
--- a/onnxruntime/test/contrib_ops/attention_lstm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/attention_lstm_op_test.cc
@@ -103,35 +103,35 @@ static void RunAttnLstmTest(
     std::vector<int64_t> B_dims = {num_directions, 8 * hidden_size};
     test.AddInput<float>("B", B_dims, *B_data);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   if (sequence_lengths) {
     std::vector<int64_t> sequence_lens_dims{batch_size};
     test.AddInput<int>("sequence_lens", sequence_lens_dims, *sequence_lengths);
   } else {
-    test.AddMissingOptionalInput<int>();
+    test.AddDataLessInput<int>();
   }
 
   if (initial_h_data && !initial_h_data->empty()) {
     std::vector<int64_t> initial_h_dims = {num_directions, batch_size, hidden_size};
     test.AddInput<float>("initial_h", initial_h_dims, *initial_h_data);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   if (initial_c_data && !initial_c_data->empty()) {
     std::vector<int64_t> initial_c_dims = {num_directions, batch_size, hidden_size};
     test.AddInput<float>("initial_c", initial_c_dims, *initial_c_data);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   if (P_data && !P_data->empty()) {
     std::vector<int64_t> P_dims = {num_directions, 3 * hidden_size};
     test.AddInput<float>("P", P_dims, *P_data);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   std::vector<int64_t> QW_dims{num_directions, hidden_size, am_attn_size};
@@ -150,14 +150,14 @@ static void RunAttnLstmTest(
     std::vector<int64_t> M_seq_dims{batch_size};
     test.AddInput<int>("memory_seq_lens", M_seq_dims, *memory_sequence_lengths);
   } else {
-    test.AddMissingOptionalInput<int>();
+    test.AddDataLessInput<int>();
   }
 
   if (attn_layer_weights) {
     std::vector<int64_t> attn_layer_weight_dims{num_directions, memory_depth + hidden_size, aw_attn_size};
     test.AddInput<float>("AW", attn_layer_weight_dims, *attn_layer_weights);
   } else {
-    test.AddMissingOptionalInput<int>();
+    test.AddDataLessInput<int>();
   }
 
   if (output_sequence != 0 && !Y_data.empty()) {
@@ -166,21 +166,21 @@ static void RunAttnLstmTest(
   } else {
     // add placeholder so node counts match as Y_h will always be the second Y_data,
     // so Y must exist as the first Y_data
-    test.AddMissingOptionalOutput<float>();
+    test.AddDataLessOutput<float>();
   }
 
   if (!Y_h_data.empty()) {
     std::vector<int64_t> Y_h_dims{num_directions, batch_size, hidden_size};
     test.AddOutput<float>("Y_h", Y_h_dims, Y_h_data);
   } else {
-    test.AddMissingOptionalOutput<float>();
+    test.AddDataLessOutput<float>();
   }
 
   if (!Y_c_data.empty()) {
     std::vector<int64_t> Y_c_dims{num_directions, batch_size, hidden_size};
     test.AddOutput<float>("Y_c", Y_c_dims, Y_c_data);
   } else {
-    test.AddMissingOptionalOutput<float>();
+    test.AddDataLessOutput<float>();
   }
 
   test.Run();

--- a/onnxruntime/test/contrib_ops/attention_lstm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/attention_lstm_op_test.cc
@@ -103,35 +103,35 @@ static void RunAttnLstmTest(
     std::vector<int64_t> B_dims = {num_directions, 8 * hidden_size};
     test.AddInput<float>("B", B_dims, *B_data);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   if (sequence_lengths) {
     std::vector<int64_t> sequence_lens_dims{batch_size};
     test.AddInput<int>("sequence_lens", sequence_lens_dims, *sequence_lengths);
   } else {
-    test.AddDataLessInput<int>();
+    test.AddOptionalInputEdge<int>();
   }
 
   if (initial_h_data && !initial_h_data->empty()) {
     std::vector<int64_t> initial_h_dims = {num_directions, batch_size, hidden_size};
     test.AddInput<float>("initial_h", initial_h_dims, *initial_h_data);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   if (initial_c_data && !initial_c_data->empty()) {
     std::vector<int64_t> initial_c_dims = {num_directions, batch_size, hidden_size};
     test.AddInput<float>("initial_c", initial_c_dims, *initial_c_data);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   if (P_data && !P_data->empty()) {
     std::vector<int64_t> P_dims = {num_directions, 3 * hidden_size};
     test.AddInput<float>("P", P_dims, *P_data);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   std::vector<int64_t> QW_dims{num_directions, hidden_size, am_attn_size};
@@ -150,14 +150,14 @@ static void RunAttnLstmTest(
     std::vector<int64_t> M_seq_dims{batch_size};
     test.AddInput<int>("memory_seq_lens", M_seq_dims, *memory_sequence_lengths);
   } else {
-    test.AddDataLessInput<int>();
+    test.AddOptionalInputEdge<int>();
   }
 
   if (attn_layer_weights) {
     std::vector<int64_t> attn_layer_weight_dims{num_directions, memory_depth + hidden_size, aw_attn_size};
     test.AddInput<float>("AW", attn_layer_weight_dims, *attn_layer_weights);
   } else {
-    test.AddDataLessInput<int>();
+    test.AddOptionalInputEdge<int>();
   }
 
   if (output_sequence != 0 && !Y_data.empty()) {
@@ -166,21 +166,21 @@ static void RunAttnLstmTest(
   } else {
     // add placeholder so node counts match as Y_h will always be the second Y_data,
     // so Y must exist as the first Y_data
-    test.AddDataLessOutput<float>();
+    test.AddOptionalOutputEdge<float>();
   }
 
   if (!Y_h_data.empty()) {
     std::vector<int64_t> Y_h_dims{num_directions, batch_size, hidden_size};
     test.AddOutput<float>("Y_h", Y_h_dims, Y_h_data);
   } else {
-    test.AddDataLessOutput<float>();
+    test.AddOptionalOutputEdge<float>();
   }
 
   if (!Y_c_data.empty()) {
     std::vector<int64_t> Y_c_dims{num_directions, batch_size, hidden_size};
     test.AddOutput<float>("Y_c", Y_c_dims, Y_c_data);
   } else {
-    test.AddDataLessOutput<float>();
+    test.AddOptionalOutputEdge<float>();
   }
 
   test.Run();

--- a/onnxruntime/test/contrib_ops/attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/attention_op_test.cc
@@ -105,7 +105,7 @@ static void RunAttentionTest(
     if (mask_index_data.size() > 0) {  // mask index is optional.
       tester.AddInput<int32_t>("mask_index", mask_index_dims, mask_index_data);
     } else {
-      tester.AddMissingOptionalInput<int32_t>();
+      tester.AddDataLessInput<int32_t>();
     }
 
     if (use_past_state) {
@@ -1483,7 +1483,7 @@ TEST(AttentionTest, AttentionPastState_dynamic) {
   test.AddInput<float>("input", input_dims, input_data);
   test.AddInput<float>("weight", weight_dims, weight_data);
   test.AddInput<float>("bias", bias_dims, bias_data);
-  test.AddMissingOptionalInput<int32_t>();
+  test.AddDataLessInput<int32_t>();
   test.AddInput<float>("past", past_dims, past_data);
 
   test.AddReferenceOutputs("testdata/attention_past_state.onnx");

--- a/onnxruntime/test/contrib_ops/attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/attention_op_test.cc
@@ -105,7 +105,7 @@ static void RunAttentionTest(
     if (mask_index_data.size() > 0) {  // mask index is optional.
       tester.AddInput<int32_t>("mask_index", mask_index_dims, mask_index_data);
     } else {
-      tester.AddDataLessInput<int32_t>();
+      tester.AddOptionalInputEdge<int32_t>();
     }
 
     if (use_past_state) {
@@ -1483,7 +1483,7 @@ TEST(AttentionTest, AttentionPastState_dynamic) {
   test.AddInput<float>("input", input_dims, input_data);
   test.AddInput<float>("weight", weight_dims, weight_data);
   test.AddInput<float>("bias", bias_dims, bias_data);
-  test.AddDataLessInput<int32_t>();
+  test.AddOptionalInputEdge<int32_t>();
   test.AddInput<float>("past", past_dims, past_data);
 
   test.AddReferenceOutputs("testdata/attention_past_state.onnx");

--- a/onnxruntime/test/contrib_ops/bias_dropout_op_test.cc
+++ b/onnxruntime/test/contrib_ops/bias_dropout_op_test.cc
@@ -5,7 +5,6 @@
 #pragma warning(disable : 4389)
 #endif
 
-
 #include <algorithm>
 #include <memory>
 #include <numeric>
@@ -23,7 +22,9 @@ namespace test {
 
 using namespace onnxruntime::test;
 
-enum TrainingMode { TrainingFalse, TrainingTrue, NoTraining };
+enum TrainingMode { TrainingFalse,
+                    TrainingTrue,
+                    NoTraining };
 
 // BiasDropout kernel is only implemented for CUDA/ROCM
 #if defined(USE_CUDA) || defined(USE_ROCM)
@@ -51,14 +52,14 @@ void RunBiasDropoutTest(const bool use_mask, const std::vector<int64_t>& input_s
     const std::vector<float> residual(residual_size, residual_value);
     t.AddInput("residual", input_shape, residual);
   } else {
-    t.AddMissingOptionalInput<float>();
+    t.AddDataLessInput<float>();
   }
 
   if (ratio == -1.0f) {
     if (use_float16_ratio) {
-      t.AddMissingOptionalInput<MLFloat16>();
+      t.AddDataLessInput<MLFloat16>();
     } else {
-      t.AddMissingOptionalInput<float>();
+      t.AddDataLessInput<float>();
     }
     // set ratio to default value
     ratio = 0.5f;
@@ -85,7 +86,7 @@ void RunBiasDropoutTest(const bool use_mask, const std::vector<int64_t>& input_s
     mask_buffer = std::make_unique<bool[]>(input_size);
     t.AddOutput<bool>("mask", input_shape, mask_buffer.get(), input_size);
   } else {
-    t.AddMissingOptionalOutput<bool>();
+    t.AddDataLessOutput<bool>();
   }
 
   auto output_verifier = [&](const std::vector<OrtValue>& fetches, const std::string& provider_type) {

--- a/onnxruntime/test/contrib_ops/bias_dropout_op_test.cc
+++ b/onnxruntime/test/contrib_ops/bias_dropout_op_test.cc
@@ -52,14 +52,14 @@ void RunBiasDropoutTest(const bool use_mask, const std::vector<int64_t>& input_s
     const std::vector<float> residual(residual_size, residual_value);
     t.AddInput("residual", input_shape, residual);
   } else {
-    t.AddDataLessInput<float>();
+    t.AddOptionalInputEdge<float>();
   }
 
   if (ratio == -1.0f) {
     if (use_float16_ratio) {
-      t.AddDataLessInput<MLFloat16>();
+      t.AddOptionalInputEdge<MLFloat16>();
     } else {
-      t.AddDataLessInput<float>();
+      t.AddOptionalInputEdge<float>();
     }
     // set ratio to default value
     ratio = 0.5f;
@@ -86,7 +86,7 @@ void RunBiasDropoutTest(const bool use_mask, const std::vector<int64_t>& input_s
     mask_buffer = std::make_unique<bool[]>(input_size);
     t.AddOutput<bool>("mask", input_shape, mask_buffer.get(), input_size);
   } else {
-    t.AddDataLessOutput<bool>();
+    t.AddOptionalOutputEdge<bool>();
   }
 
   auto output_verifier = [&](const std::vector<OrtValue>& fetches, const std::string& provider_type) {

--- a/onnxruntime/test/contrib_ops/dynamic_quantize_matmul_test.cc
+++ b/onnxruntime/test/contrib_ops/dynamic_quantize_matmul_test.cc
@@ -59,13 +59,13 @@ void TestDynamicQuantizeMatMul(const std::vector<int64_t>& A_dims,
   if (has_zp) {
     test.AddInput<T>("b_zero_point", {b_scale_zp_size}, B_zero_point);
   } else {
-    test.AddMissingOptionalInput<T>();
+    test.AddDataLessInput<T>();
   }
 
   if (has_bias) {
     test.AddInput<float>("bias", {B_dims.back()}, Bias);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   test.AddReferenceOutputs(reference_model);

--- a/onnxruntime/test/contrib_ops/dynamic_quantize_matmul_test.cc
+++ b/onnxruntime/test/contrib_ops/dynamic_quantize_matmul_test.cc
@@ -59,13 +59,13 @@ void TestDynamicQuantizeMatMul(const std::vector<int64_t>& A_dims,
   if (has_zp) {
     test.AddInput<T>("b_zero_point", {b_scale_zp_size}, B_zero_point);
   } else {
-    test.AddDataLessInput<T>();
+    test.AddOptionalInputEdge<T>();
   }
 
   if (has_bias) {
     test.AddInput<float>("bias", {B_dims.back()}, Bias);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   test.AddReferenceOutputs(reference_model);

--- a/onnxruntime/test/contrib_ops/embed_layer_norm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/embed_layer_norm_op_test.cc
@@ -57,7 +57,7 @@ static void RunTest(const embedlayernorm::OpData& data,
     OpTester tester("EmbedLayerNormalization", 1, onnxruntime::kMSDomain);
     tester.AddInput<int32_t>("input_ids", input_ids_dims, data.input_ids_data);
     if (!data.has_segment) {
-      tester.AddDataLessInput<int32_t>();
+      tester.AddOptionalInputEdge<int32_t>();
     } else {
       tester.AddInput<int32_t>("segment_ids", segment_ids_dims, data.segment_ids_data);
     }
@@ -71,7 +71,7 @@ static void RunTest(const embedlayernorm::OpData& data,
                                  ToFloat16(data.position_embedding_data),
                                  /*is_initializer=*/true);
       if (!data.has_segment) {
-        tester.AddDataLessInput<MLFloat16>();
+        tester.AddOptionalInputEdge<MLFloat16>();
       } else {
         tester.AddInput<MLFloat16>("segment_embedding",
                                    segment_embedding_dims,
@@ -101,7 +101,7 @@ static void RunTest(const embedlayernorm::OpData& data,
                              data.position_embedding_data,
                              /*is_initializer=*/true);
       if (!data.has_segment) {
-        tester.AddDataLessInput<MLFloat16>();
+        tester.AddOptionalInputEdge<MLFloat16>();
       } else {
         tester.AddInput<float>("segment_embedding",
                                segment_embedding_dims,

--- a/onnxruntime/test/contrib_ops/embed_layer_norm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/embed_layer_norm_op_test.cc
@@ -11,7 +11,7 @@ namespace onnxruntime {
 namespace test {
 
 static void RunTest(const embedlayernorm::OpData& data,
-                       bool use_float16 = false) {
+                    bool use_float16 = false) {
   int min_cuda_architecture = use_float16 ? 530 : 0;
 
   bool enable_cuda = HasCudaEnvironment(min_cuda_architecture);
@@ -57,7 +57,7 @@ static void RunTest(const embedlayernorm::OpData& data,
     OpTester tester("EmbedLayerNormalization", 1, onnxruntime::kMSDomain);
     tester.AddInput<int32_t>("input_ids", input_ids_dims, data.input_ids_data);
     if (!data.has_segment) {
-      tester.AddMissingOptionalInput<int32_t>();
+      tester.AddDataLessInput<int32_t>();
     } else {
       tester.AddInput<int32_t>("segment_ids", segment_ids_dims, data.segment_ids_data);
     }
@@ -71,7 +71,7 @@ static void RunTest(const embedlayernorm::OpData& data,
                                  ToFloat16(data.position_embedding_data),
                                  /*is_initializer=*/true);
       if (!data.has_segment) {
-        tester.AddMissingOptionalInput<MLFloat16>();
+        tester.AddDataLessInput<MLFloat16>();
       } else {
         tester.AddInput<MLFloat16>("segment_embedding",
                                    segment_embedding_dims,
@@ -101,7 +101,7 @@ static void RunTest(const embedlayernorm::OpData& data,
                              data.position_embedding_data,
                              /*is_initializer=*/true);
       if (!data.has_segment) {
-        tester.AddMissingOptionalInput<MLFloat16>();
+        tester.AddDataLessInput<MLFloat16>();
       } else {
         tester.AddInput<float>("segment_embedding",
                                segment_embedding_dims,

--- a/onnxruntime/test/contrib_ops/layer_norm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/layer_norm_op_test.cc
@@ -59,7 +59,7 @@ TEST(LayerNormTest, BERTLayerNorm_NoBias) {
   std::vector<float> scale_data = random.Uniform<float>(scale_dims, 0.0f, 1.0f);
   tester.AddInput<float>("Scale", scale_dims, scale_data);
 
-  tester.AddMissingOptionalInput<float>();
+  tester.AddDataLessInput<float>();
 
   tester.AddReferenceOutputs("testdata/layernorm_no_bias.onnx");
 

--- a/onnxruntime/test/contrib_ops/layer_norm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/layer_norm_op_test.cc
@@ -59,7 +59,7 @@ TEST(LayerNormTest, BERTLayerNorm_NoBias) {
   std::vector<float> scale_data = random.Uniform<float>(scale_dims, 0.0f, 1.0f);
   tester.AddInput<float>("Scale", scale_dims, scale_data);
 
-  tester.AddDataLessInput<float>();
+  tester.AddOptionalInputEdge<float>();
 
   tester.AddReferenceOutputs("testdata/layernorm_no_bias.onnx");
 

--- a/onnxruntime/test/contrib_ops/matmul_integer_to_float_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_integer_to_float_test.cc
@@ -69,14 +69,14 @@ void TestMatMulIntegerToFloat(const std::vector<int64_t>& A_dims,
     test.AddInput<uint8_t>("a_zero_point", {1}, A_zero_point);
     test.AddInput<T>("b_zero_point", {b_scale_zp_size}, B_zero_point);
   } else {
-    test.AddMissingOptionalInput<T>();
-    test.AddMissingOptionalInput<T>();
+    test.AddDataLessInput<T>();
+    test.AddDataLessInput<T>();
   }
 
   if (has_bias) {
     test.AddInput<float>("bias", {B_dims.back()}, Bias);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   test.AddReferenceOutputs(reference_model);

--- a/onnxruntime/test/contrib_ops/matmul_integer_to_float_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_integer_to_float_test.cc
@@ -69,14 +69,14 @@ void TestMatMulIntegerToFloat(const std::vector<int64_t>& A_dims,
     test.AddInput<uint8_t>("a_zero_point", {1}, A_zero_point);
     test.AddInput<T>("b_zero_point", {b_scale_zp_size}, B_zero_point);
   } else {
-    test.AddDataLessInput<T>();
-    test.AddDataLessInput<T>();
+    test.AddOptionalInputEdge<T>();
+    test.AddOptionalInputEdge<T>();
   }
 
   if (has_bias) {
     test.AddInput<float>("bias", {B_dims.back()}, Bias);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   test.AddReferenceOutputs(reference_model);

--- a/onnxruntime/test/contrib_ops/qembed_layer_norm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/qembed_layer_norm_op_test.cc
@@ -74,7 +74,7 @@ static void RunTest(const embedlayernorm::OpData& data,
   if (data.has_segment) {
     tester.AddInput<int32_t>("segment_ids", segment_ids_dims, data.segment_ids_data);
   } else {
-    tester.AddMissingOptionalInput<int32_t>();
+    tester.AddDataLessInput<int32_t>();
   }
 
   // Quantized initializer inputs:
@@ -92,7 +92,7 @@ static void RunTest(const embedlayernorm::OpData& data,
                              segment_embedding_data_quant,
                              /*is_initializer=*/true);
   } else {
-    tester.AddMissingOptionalInput<uint8_t>();
+    tester.AddDataLessInput<uint8_t>();
   }
   tester.AddInput<uint8_t>("gamma",
                            gamma_dims,
@@ -106,7 +106,7 @@ static void RunTest(const embedlayernorm::OpData& data,
     std::vector<int64_t> mask_dims = {data.batch_size, data.sequence_size};
     tester.AddInput<int32_t>("mask", mask_dims, data.mask_data);
   } else {
-    tester.AddMissingOptionalInput<int32_t>();
+    tester.AddDataLessInput<int32_t>();
   }
 
   // Quantized scales:
@@ -124,7 +124,7 @@ static void RunTest(const embedlayernorm::OpData& data,
                            {segment_embedding_scale},
                            /*is_initializer=*/true);
   } else {
-    tester.AddMissingOptionalInput<float>();
+    tester.AddDataLessInput<float>();
   }
   tester.AddInput<float>("gamma_scale",
                          /*dims=*/{},
@@ -150,7 +150,7 @@ static void RunTest(const embedlayernorm::OpData& data,
                              {segment_embedding_zero_point},
                              /*is_initializer=*/true);
   } else {
-    tester.AddMissingOptionalInput<uint8_t>();
+    tester.AddDataLessInput<uint8_t>();
   }
   tester.AddInput<uint8_t>("gamma_zero_point",
                            /*dims=*/{},

--- a/onnxruntime/test/contrib_ops/qembed_layer_norm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/qembed_layer_norm_op_test.cc
@@ -74,7 +74,7 @@ static void RunTest(const embedlayernorm::OpData& data,
   if (data.has_segment) {
     tester.AddInput<int32_t>("segment_ids", segment_ids_dims, data.segment_ids_data);
   } else {
-    tester.AddDataLessInput<int32_t>();
+    tester.AddOptionalInputEdge<int32_t>();
   }
 
   // Quantized initializer inputs:
@@ -92,7 +92,7 @@ static void RunTest(const embedlayernorm::OpData& data,
                              segment_embedding_data_quant,
                              /*is_initializer=*/true);
   } else {
-    tester.AddDataLessInput<uint8_t>();
+    tester.AddOptionalInputEdge<uint8_t>();
   }
   tester.AddInput<uint8_t>("gamma",
                            gamma_dims,
@@ -106,7 +106,7 @@ static void RunTest(const embedlayernorm::OpData& data,
     std::vector<int64_t> mask_dims = {data.batch_size, data.sequence_size};
     tester.AddInput<int32_t>("mask", mask_dims, data.mask_data);
   } else {
-    tester.AddDataLessInput<int32_t>();
+    tester.AddOptionalInputEdge<int32_t>();
   }
 
   // Quantized scales:
@@ -124,7 +124,7 @@ static void RunTest(const embedlayernorm::OpData& data,
                            {segment_embedding_scale},
                            /*is_initializer=*/true);
   } else {
-    tester.AddDataLessInput<float>();
+    tester.AddOptionalInputEdge<float>();
   }
   tester.AddInput<float>("gamma_scale",
                          /*dims=*/{},
@@ -150,7 +150,7 @@ static void RunTest(const embedlayernorm::OpData& data,
                              {segment_embedding_zero_point},
                              /*is_initializer=*/true);
   } else {
-    tester.AddDataLessInput<uint8_t>();
+    tester.AddOptionalInputEdge<uint8_t>();
   }
   tester.AddInput<uint8_t>("gamma_zero_point",
                            /*dims=*/{},

--- a/onnxruntime/test/contrib_ops/qlinear_lookup_table_test.cc
+++ b/onnxruntime/test/contrib_ops/qlinear_lookup_table_test.cc
@@ -18,7 +18,7 @@ TEST(QLinearLookupTableBasedOperatorTests, QLinearLeakyRelu_Int8) {
   std::vector<int64_t> dims = {16};
   test.AddInput<int8_t>("X", dims, {0, 16, 17, 18, 19, 90, 91, 127, -128, -110, -108, -100, -16, -17, -18, -1});
   test.AddInput<float>("X_scale", {}, {X_scale});
-  test.AddMissingOptionalInput<int8_t>();  // optional "X_zero_point" using default value here
+  test.AddDataLessInput<int8_t>();  // optional "X_zero_point" using default value here
   test.AddInput<float>("Y_scale", {}, {Y_scale});
   test.AddInput<int8_t>("Y_zero_point", {}, {Y_zero_point});
   test.AddOutput<int8_t>("Y", dims, {-100, -60, -58, -55, -52, 125, 127, 127, -128, -128, -127, -125, -104, -104, -104, -100});
@@ -59,7 +59,7 @@ TEST(QLinearLookupTableBasedOperatorTests, QLinearSigmoid_Int8) {
   std::vector<int64_t> dims = {16};
   test.AddInput<int8_t>("X", dims, {0, 16, 17, 18, 19, 90, 91, 127, -128, -110, -108, -100, -16, -17, -18, -1});
   test.AddInput<float>("X_scale", {}, {X_scale});
-  test.AddMissingOptionalInput<int8_t>();  // optional "X_zero_point" using default value here
+  test.AddDataLessInput<int8_t>();  // optional "X_zero_point" using default value here
   test.AddInput<float>("Y_scale", {}, {Y_scale});
   test.AddInput<int8_t>("Y_zero_point", {}, {Y_zero_point});
   test.AddOutput<int8_t>("Y", dims, {8, 33, 35, 36, 38, 112, 112, 126, -110, -105, -104, -101, -17, -19, -20, 6});

--- a/onnxruntime/test/contrib_ops/qlinear_lookup_table_test.cc
+++ b/onnxruntime/test/contrib_ops/qlinear_lookup_table_test.cc
@@ -18,7 +18,7 @@ TEST(QLinearLookupTableBasedOperatorTests, QLinearLeakyRelu_Int8) {
   std::vector<int64_t> dims = {16};
   test.AddInput<int8_t>("X", dims, {0, 16, 17, 18, 19, 90, 91, 127, -128, -110, -108, -100, -16, -17, -18, -1});
   test.AddInput<float>("X_scale", {}, {X_scale});
-  test.AddDataLessInput<int8_t>();  // optional "X_zero_point" using default value here
+  test.AddOptionalInputEdge<int8_t>();  // optional "X_zero_point" using default value here
   test.AddInput<float>("Y_scale", {}, {Y_scale});
   test.AddInput<int8_t>("Y_zero_point", {}, {Y_zero_point});
   test.AddOutput<int8_t>("Y", dims, {-100, -60, -58, -55, -52, 125, 127, 127, -128, -128, -127, -125, -104, -104, -104, -100});
@@ -59,7 +59,7 @@ TEST(QLinearLookupTableBasedOperatorTests, QLinearSigmoid_Int8) {
   std::vector<int64_t> dims = {16};
   test.AddInput<int8_t>("X", dims, {0, 16, 17, 18, 19, 90, 91, 127, -128, -110, -108, -100, -16, -17, -18, -1});
   test.AddInput<float>("X_scale", {}, {X_scale});
-  test.AddDataLessInput<int8_t>();  // optional "X_zero_point" using default value here
+  test.AddOptionalInputEdge<int8_t>();  // optional "X_zero_point" using default value here
   test.AddInput<float>("Y_scale", {}, {Y_scale});
   test.AddInput<int8_t>("Y_zero_point", {}, {Y_zero_point});
   test.AddOutput<int8_t>("Y", dims, {8, 33, 35, 36, 38, 112, 112, 126, -110, -105, -104, -101, -17, -19, -20, 6});

--- a/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
@@ -83,7 +83,7 @@ void RunQAttention(const std::vector<float>& input_data,         // input:      
     tester.AddInput<int32_t>("mask_index", mask_index_dims, mask_index_data);
   } else {
     // mask index is optional.
-    tester.AddDataLessInput<int32_t>();
+    tester.AddOptionalInputEdge<int32_t>();
   }
 
   tester.AddInput<QInput>("input_zero_point", {1}, {input_zero_point});
@@ -721,7 +721,7 @@ void TestQuantizedAttentionPastState(int64_t batch,
   test.AddInput<float>("bias", bias_dims, bias_data);
   test.AddInput<float>("input_scale", {1}, input_scale);
   test.AddInput<float>("weight_scale", {weight_scale_zp_size}, weight_scale);
-  test.AddDataLessInput<int32_t>();
+  test.AddOptionalInputEdge<int32_t>();
   test.AddInput<InputT>("input_zero_point", {1}, input_zero_point);
   test.AddInput<WeightT>("weight_zero_point", {weight_scale_zp_size}, weight_zero_point);
   test.AddInput<float>("past", past_dims, past_data);

--- a/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
@@ -83,7 +83,7 @@ void RunQAttention(const std::vector<float>& input_data,         // input:      
     tester.AddInput<int32_t>("mask_index", mask_index_dims, mask_index_data);
   } else {
     // mask index is optional.
-    tester.AddMissingOptionalInput<int32_t>();
+    tester.AddDataLessInput<int32_t>();
   }
 
   tester.AddInput<QInput>("input_zero_point", {1}, {input_zero_point});
@@ -721,7 +721,7 @@ void TestQuantizedAttentionPastState(int64_t batch,
   test.AddInput<float>("bias", bias_dims, bias_data);
   test.AddInput<float>("input_scale", {1}, input_scale);
   test.AddInput<float>("weight_scale", {weight_scale_zp_size}, weight_scale);
-  test.AddMissingOptionalInput<int32_t>();
+  test.AddDataLessInput<int32_t>();
   test.AddInput<InputT>("input_zero_point", {1}, input_zero_point);
   test.AddInput<WeightT>("weight_zero_point", {weight_scale_zp_size}, weight_zero_point);
   test.AddInput<float>("past", past_dims, past_data);

--- a/onnxruntime/test/contrib_ops/quantize_lstm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_lstm_op_test.cc
@@ -127,11 +127,11 @@ static void ComputeRefOutput(std::vector<float>& Y_data,
     std::vector<int64_t> B_dims = {num_directions, 8 * hidden_size};
     test.AddInput<float>("B", B_dims, *B_data);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   // sequence_lens
-  test.AddMissingOptionalInput<int>();
+  test.AddDataLessInput<int>();
 
   std::vector<int64_t> initial_h_dims = {num_directions, batch_size, hidden_size};
   test.AddInput<float>("initial_h", initial_h_dims, ApplyQDQ<uint8_t>(initial_h_data, num_directions));
@@ -143,7 +143,7 @@ static void ComputeRefOutput(std::vector<float>& Y_data,
     std::vector<int64_t> P_dims = {num_directions, 3 * hidden_size};
     test.AddInput<float>("P", P_dims, *P_data);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   size_t y_data_size = seq_length * num_directions * batch_size * hidden_size;
@@ -239,11 +239,11 @@ static void RunQuantLSTM(int64_t input_size,
 
     test.AddInput<float>("B", B_dims, B_data);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   // sequence_lens
-  test.AddMissingOptionalInput<int>();
+  test.AddDataLessInput<int>();
 
   // initial_h
   std::vector<int64_t> initial_h_dims = {num_directions, batch_size, hidden_size};
@@ -261,7 +261,7 @@ static void RunQuantLSTM(int64_t input_size,
     P_data = rand_gen.Gaussian<float>(P_dims, 0.0f, 0.25f);
     test.AddInput<float>("P", P_dims, P_data);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   std::vector<int64_t> per_tensor_dims = {num_directions};
@@ -408,10 +408,10 @@ TEST(DynamicQuantLSTMTest, SharedPrepackedWeights) {
   test.AddInput<int8_t>("R", R_dims, r_quant, true);  // Trigger pre-packing
 
   // B
-  test.AddMissingOptionalInput<float>();
+  test.AddDataLessInput<float>();
 
   // sequence_lens
-  test.AddMissingOptionalInput<int>();
+  test.AddDataLessInput<int>();
 
   // initial_h
   std::vector<int64_t> initial_h_dims = {num_directions, batch_size, hidden_size};
@@ -423,7 +423,7 @@ TEST(DynamicQuantLSTMTest, SharedPrepackedWeights) {
   std::vector<float> initial_c_data = rand_gen.Gaussian<float>(initial_c_dims, 0.0f, 0.25f);
   test.AddInput<float>("initial_c", initial_c_dims, initial_c_data);
 
-  test.AddMissingOptionalInput<float>();
+  test.AddDataLessInput<float>();
 
   std::vector<int64_t> per_tensor_dims = {num_directions};
   test.AddInput<float>("W_scale", per_tensor_dims, w_scale);

--- a/onnxruntime/test/contrib_ops/quantize_lstm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_lstm_op_test.cc
@@ -127,11 +127,11 @@ static void ComputeRefOutput(std::vector<float>& Y_data,
     std::vector<int64_t> B_dims = {num_directions, 8 * hidden_size};
     test.AddInput<float>("B", B_dims, *B_data);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   // sequence_lens
-  test.AddDataLessInput<int>();
+  test.AddOptionalInputEdge<int>();
 
   std::vector<int64_t> initial_h_dims = {num_directions, batch_size, hidden_size};
   test.AddInput<float>("initial_h", initial_h_dims, ApplyQDQ<uint8_t>(initial_h_data, num_directions));
@@ -143,7 +143,7 @@ static void ComputeRefOutput(std::vector<float>& Y_data,
     std::vector<int64_t> P_dims = {num_directions, 3 * hidden_size};
     test.AddInput<float>("P", P_dims, *P_data);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   size_t y_data_size = seq_length * num_directions * batch_size * hidden_size;
@@ -239,11 +239,11 @@ static void RunQuantLSTM(int64_t input_size,
 
     test.AddInput<float>("B", B_dims, B_data);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   // sequence_lens
-  test.AddDataLessInput<int>();
+  test.AddOptionalInputEdge<int>();
 
   // initial_h
   std::vector<int64_t> initial_h_dims = {num_directions, batch_size, hidden_size};
@@ -261,7 +261,7 @@ static void RunQuantLSTM(int64_t input_size,
     P_data = rand_gen.Gaussian<float>(P_dims, 0.0f, 0.25f);
     test.AddInput<float>("P", P_dims, P_data);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   std::vector<int64_t> per_tensor_dims = {num_directions};
@@ -408,10 +408,10 @@ TEST(DynamicQuantLSTMTest, SharedPrepackedWeights) {
   test.AddInput<int8_t>("R", R_dims, r_quant, true);  // Trigger pre-packing
 
   // B
-  test.AddDataLessInput<float>();
+  test.AddOptionalInputEdge<float>();
 
   // sequence_lens
-  test.AddDataLessInput<int>();
+  test.AddOptionalInputEdge<int>();
 
   // initial_h
   std::vector<int64_t> initial_h_dims = {num_directions, batch_size, hidden_size};
@@ -423,7 +423,7 @@ TEST(DynamicQuantLSTMTest, SharedPrepackedWeights) {
   std::vector<float> initial_c_data = rand_gen.Gaussian<float>(initial_c_dims, 0.0f, 0.25f);
   test.AddInput<float>("initial_c", initial_c_dims, initial_c_data);
 
-  test.AddDataLessInput<float>();
+  test.AddOptionalInputEdge<float>();
 
   std::vector<int64_t> per_tensor_dims = {num_directions};
   test.AddInput<float>("W_scale", per_tensor_dims, w_scale);

--- a/onnxruntime/test/contrib_ops/skiplayernorm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/skiplayernorm_op_test.cc
@@ -45,7 +45,7 @@ static void RunTest(
     if (!no_beta) {
       test.AddInput<float>("beta", beta_dims, beta_data);
     } else {
-      test.AddDataLessInput<float>();
+      test.AddOptionalInputEdge<float>();
     }
     test.AddAttribute("epsilon", epsilon);
     if (!bias_data.empty()) {
@@ -63,7 +63,7 @@ static void RunTest(
     if (!no_beta) {
       test.AddInput<MLFloat16>("beta", beta_dims, ToFloat16(beta_data));
     } else {
-      test.AddDataLessInput<float>();
+      test.AddOptionalInputEdge<float>();
     }
     test.AddAttribute("epsilon", epsilon);
     if (!bias_data.empty()) {

--- a/onnxruntime/test/contrib_ops/skiplayernorm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/skiplayernorm_op_test.cc
@@ -45,7 +45,7 @@ static void RunTest(
     if (!no_beta) {
       test.AddInput<float>("beta", beta_dims, beta_data);
     } else {
-      test.AddMissingOptionalInput<float>();
+      test.AddDataLessInput<float>();
     }
     test.AddAttribute("epsilon", epsilon);
     if (!bias_data.empty()) {
@@ -63,7 +63,7 @@ static void RunTest(
     if (!no_beta) {
       test.AddInput<MLFloat16>("beta", beta_dims, ToFloat16(beta_data));
     } else {
-      test.AddMissingOptionalInput<float>();
+      test.AddDataLessInput<float>();
     }
     test.AddAttribute("epsilon", epsilon);
     if (!bias_data.empty()) {
@@ -74,9 +74,9 @@ static void RunTest(
 
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     if (rocm_ep != nullptr) {
-        execution_providers.push_back(DefaultRocmExecutionProvider());
+      execution_providers.push_back(DefaultRocmExecutionProvider());
     } else {
-        execution_providers.push_back(DefaultCudaExecutionProvider());
+      execution_providers.push_back(DefaultCudaExecutionProvider());
     }
 
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);

--- a/onnxruntime/test/providers/cpu/controlflow/scan_test.cc
+++ b/onnxruntime/test/providers/cpu/controlflow/scan_test.cc
@@ -289,7 +289,7 @@ static void RunTest_v8(const std::string test_name, int64_t batch_size, int64_t 
   }
 
   if (sequence_lens == nullptr) {
-    test.AddMissingOptionalInput<int64_t>();
+    test.AddDataLessInput<int64_t>();
   } else {
     std::vector<int64_t> sequence_lens_dims{batch_size};
     test.AddInput<int64_t>("sequence_lens", sequence_lens_dims, *sequence_lens);
@@ -1076,7 +1076,7 @@ void MixedTypeInputs(bool is_v8) {
     seq_shape.insert(seq_shape.begin(), batch_size);
     state_shape.insert(state_shape.begin(), batch_size);
 
-    test.AddMissingOptionalInput<int64_t>();
+    test.AddDataLessInput<int64_t>();
   }
 
   test.AddAttribute("body", scan_body);
@@ -1138,7 +1138,7 @@ void UnknownDimInSubgraphOutput(bool is_v8, bool mixed_execution_providers = fal
     seq_shape.insert(seq_shape.begin(), batch_size);
     state_shape.insert(state_shape.begin(), batch_size);
 
-    test.AddMissingOptionalInput<int64_t>();
+    test.AddDataLessInput<int64_t>();
   }
 
   test.AddAttribute("body", scan_body);

--- a/onnxruntime/test/providers/cpu/controlflow/scan_test.cc
+++ b/onnxruntime/test/providers/cpu/controlflow/scan_test.cc
@@ -289,7 +289,7 @@ static void RunTest_v8(const std::string test_name, int64_t batch_size, int64_t 
   }
 
   if (sequence_lens == nullptr) {
-    test.AddDataLessInput<int64_t>();
+    test.AddOptionalInputEdge<int64_t>();
   } else {
     std::vector<int64_t> sequence_lens_dims{batch_size};
     test.AddInput<int64_t>("sequence_lens", sequence_lens_dims, *sequence_lens);
@@ -1076,7 +1076,7 @@ void MixedTypeInputs(bool is_v8) {
     seq_shape.insert(seq_shape.begin(), batch_size);
     state_shape.insert(state_shape.begin(), batch_size);
 
-    test.AddDataLessInput<int64_t>();
+    test.AddOptionalInputEdge<int64_t>();
   }
 
   test.AddAttribute("body", scan_body);
@@ -1138,7 +1138,7 @@ void UnknownDimInSubgraphOutput(bool is_v8, bool mixed_execution_providers = fal
     seq_shape.insert(seq_shape.begin(), batch_size);
     state_shape.insert(state_shape.begin(), batch_size);
 
-    test.AddDataLessInput<int64_t>();
+    test.AddOptionalInputEdge<int64_t>();
   }
 
   test.AddAttribute("body", scan_body);

--- a/onnxruntime/test/providers/cpu/rnn/deep_cpu_gru_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/deep_cpu_gru_op_test.cc
@@ -87,14 +87,14 @@ static void RunGruTest(const std::vector<float>& X_data,
     std::vector<int64_t> Y_dims = {seq_length, num_directions, batch_size, hidden_size};
     test.AddOutput<float>("Y", Y_dims, Y_data);
   } else {
-    test.AddDataLessOutput<float>();
+    test.AddOptionalOutputEdge<float>();
   }
 
   if (!Y_h_data.empty()) {
     std::vector<int64_t> Y_h_dims{num_directions, batch_size, hidden_size};
     test.AddOutput<float>("Y_h", Y_h_dims, Y_h_data);
   } else {
-    test.AddDataLessOutput<float>();
+    test.AddOptionalOutputEdge<float>();
   }
 
   // TensorRT failed on GRU tests

--- a/onnxruntime/test/providers/cpu/rnn/deep_cpu_gru_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/deep_cpu_gru_op_test.cc
@@ -87,14 +87,14 @@ static void RunGruTest(const std::vector<float>& X_data,
     std::vector<int64_t> Y_dims = {seq_length, num_directions, batch_size, hidden_size};
     test.AddOutput<float>("Y", Y_dims, Y_data);
   } else {
-    test.AddMissingOptionalOutput<float>();
+    test.AddDataLessOutput<float>();
   }
 
   if (!Y_h_data.empty()) {
     std::vector<int64_t> Y_h_dims{num_directions, batch_size, hidden_size};
     test.AddOutput<float>("Y_h", Y_h_dims, Y_h_data);
   } else {
-    test.AddMissingOptionalOutput<float>();
+    test.AddDataLessOutput<float>();
   }
 
   // TensorRT failed on GRU tests

--- a/onnxruntime/test/providers/cpu/rnn/deep_cpu_lstm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/deep_cpu_lstm_op_test.cc
@@ -89,35 +89,35 @@ static void RunLstmTest(const std::vector<float>& X_data,
     std::vector<int64_t> B_dims = {num_directions, 8 * hidden_size};
     test.AddInput<float>("B", B_dims, *B_data);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   if (sequence_lengths) {
     std::vector<int64_t> sequence_lens_dims{batch_size};
     test.AddInput<int>("sequence_lens", sequence_lens_dims, *sequence_lengths);
   } else {
-    test.AddDataLessInput<int>();
+    test.AddOptionalInputEdge<int>();
   }
 
   if (initial_h_data && !initial_h_data->empty()) {
     std::vector<int64_t> initial_h_dims = {num_directions, batch_size, hidden_size};
     test.AddInput<float>("initial_h", initial_h_dims, *initial_h_data);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   if (initial_c_data && !initial_c_data->empty()) {
     std::vector<int64_t> initial_c_dims = {num_directions, batch_size, hidden_size};
     test.AddInput<float>("initial_c", initial_c_dims, *initial_c_data);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   if (P_data && !P_data->empty()) {
     std::vector<int64_t> P_dims = {num_directions, 3 * hidden_size};
     test.AddInput<float>("P", P_dims, *P_data);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   if (output_sequence != 0 && !Y_data.empty()) {
@@ -126,21 +126,21 @@ static void RunLstmTest(const std::vector<float>& X_data,
   } else {
     // add placeholder so node counts match as Y_h will always be the second Y_data,
     // so Y must exist as the first Y_data
-    test.AddDataLessOutput<float>();
+    test.AddOptionalOutputEdge<float>();
   }
 
   if (!Y_h_data.empty()) {
     std::vector<int64_t> Y_h_dims{num_directions, batch_size, hidden_size};
     test.AddOutput<float>("Y_h", Y_h_dims, Y_h_data);
   } else {
-    test.AddDataLessOutput<float>();
+    test.AddOptionalOutputEdge<float>();
   }
 
   if (!Y_c_data.empty()) {
     std::vector<int64_t> Y_c_dims{num_directions, batch_size, hidden_size};
     test.AddOutput<float>("Y_c", Y_c_dims, Y_c_data);
   } else {
-    test.AddDataLessOutput<float>();
+    test.AddOptionalOutputEdge<float>();
   }
 
   // TensorRT failed on LSTM tests
@@ -1249,28 +1249,28 @@ TEST(LSTMTest, SharedPrepackedWeights) {
   test.AddInput<float>("R", R_dims, R_data, true);  // Trigger pre-packing
 
   // B data
-  test.AddDataLessInput<float>();
+  test.AddOptionalInputEdge<float>();
 
   // sequence
-  test.AddDataLessInput<int>();
+  test.AddOptionalInputEdge<int>();
 
   // initial_h
-  test.AddDataLessInput<float>();
+  test.AddOptionalInputEdge<float>();
 
   // initial_c
-  test.AddDataLessInput<float>();
+  test.AddOptionalInputEdge<float>();
 
   // P_data
-  test.AddDataLessInput<float>();
+  test.AddOptionalInputEdge<float>();
 
   std::vector<int64_t> Y_dims = {seq_length, num_directions, batch_size, hidden_size};
   test.AddOutput<float>("Y", Y_dims, Y_data);
 
   // Y_h
-  test.AddDataLessOutput<float>();
+  test.AddOptionalOutputEdge<float>();
 
   // Y_c
-  test.AddDataLessOutput<float>();
+  test.AddOptionalOutputEdge<float>();
 
   // W
   auto W_tensor = std::make_unique<Tensor>(DataTypeImpl::GetType<float>(), TensorShape(W_dims),

--- a/onnxruntime/test/providers/cpu/rnn/deep_cpu_lstm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/deep_cpu_lstm_op_test.cc
@@ -89,35 +89,35 @@ static void RunLstmTest(const std::vector<float>& X_data,
     std::vector<int64_t> B_dims = {num_directions, 8 * hidden_size};
     test.AddInput<float>("B", B_dims, *B_data);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   if (sequence_lengths) {
     std::vector<int64_t> sequence_lens_dims{batch_size};
     test.AddInput<int>("sequence_lens", sequence_lens_dims, *sequence_lengths);
   } else {
-    test.AddMissingOptionalInput<int>();
+    test.AddDataLessInput<int>();
   }
 
   if (initial_h_data && !initial_h_data->empty()) {
     std::vector<int64_t> initial_h_dims = {num_directions, batch_size, hidden_size};
     test.AddInput<float>("initial_h", initial_h_dims, *initial_h_data);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   if (initial_c_data && !initial_c_data->empty()) {
     std::vector<int64_t> initial_c_dims = {num_directions, batch_size, hidden_size};
     test.AddInput<float>("initial_c", initial_c_dims, *initial_c_data);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   if (P_data && !P_data->empty()) {
     std::vector<int64_t> P_dims = {num_directions, 3 * hidden_size};
     test.AddInput<float>("P", P_dims, *P_data);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   if (output_sequence != 0 && !Y_data.empty()) {
@@ -126,21 +126,21 @@ static void RunLstmTest(const std::vector<float>& X_data,
   } else {
     // add placeholder so node counts match as Y_h will always be the second Y_data,
     // so Y must exist as the first Y_data
-    test.AddMissingOptionalOutput<float>();
+    test.AddDataLessOutput<float>();
   }
 
   if (!Y_h_data.empty()) {
     std::vector<int64_t> Y_h_dims{num_directions, batch_size, hidden_size};
     test.AddOutput<float>("Y_h", Y_h_dims, Y_h_data);
   } else {
-    test.AddMissingOptionalOutput<float>();
+    test.AddDataLessOutput<float>();
   }
 
   if (!Y_c_data.empty()) {
     std::vector<int64_t> Y_c_dims{num_directions, batch_size, hidden_size};
     test.AddOutput<float>("Y_c", Y_c_dims, Y_c_data);
   } else {
-    test.AddMissingOptionalOutput<float>();
+    test.AddDataLessOutput<float>();
   }
 
   // TensorRT failed on LSTM tests
@@ -1249,28 +1249,28 @@ TEST(LSTMTest, SharedPrepackedWeights) {
   test.AddInput<float>("R", R_dims, R_data, true);  // Trigger pre-packing
 
   // B data
-  test.AddMissingOptionalInput<float>();
+  test.AddDataLessInput<float>();
 
   // sequence
-  test.AddMissingOptionalInput<int>();
+  test.AddDataLessInput<int>();
 
   // initial_h
-  test.AddMissingOptionalInput<float>();
+  test.AddDataLessInput<float>();
 
   // initial_c
-  test.AddMissingOptionalInput<float>();
+  test.AddDataLessInput<float>();
 
   // P_data
-  test.AddMissingOptionalInput<float>();
+  test.AddDataLessInput<float>();
 
   std::vector<int64_t> Y_dims = {seq_length, num_directions, batch_size, hidden_size};
   test.AddOutput<float>("Y", Y_dims, Y_data);
 
   // Y_h
-  test.AddMissingOptionalOutput<float>();
+  test.AddDataLessOutput<float>();
 
   // Y_c
-  test.AddMissingOptionalOutput<float>();
+  test.AddDataLessOutput<float>();
 
   // W
   auto W_tensor = std::make_unique<Tensor>(DataTypeImpl::GetType<float>(), TensorShape(W_dims),

--- a/onnxruntime/test/providers/cpu/rnn/rnn_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/rnn_op_test.cc
@@ -505,9 +505,9 @@ TEST(RNNTest, DISABLED_RNN_default_attributes_and_forward_direction) {
       std::vector<float> initial_h_data({0.0F, 0.0F, 0.0F});
       test.AddInput<float>("initial_h", initial_h_dims, initial_h_data);
     } else {
-      test.AddDataLessInput<float>();
-      test.AddDataLessInput<int>();
-      test.AddDataLessInput<float>();
+      test.AddOptionalInputEdge<float>();
+      test.AddOptionalInputEdge<int>();
+      test.AddOptionalInputEdge<float>();
     }
 
     if (outputOption == RNNOutputY || outputOption == RNNOutputBoth) {
@@ -519,7 +519,7 @@ TEST(RNNTest, DISABLED_RNN_default_attributes_and_forward_direction) {
                                  -0.74626476F, -0.07818383F, -0.75139415F});
       test.AddOutput<float>("Y", Y_dims, Y_data);
     } else {
-      test.AddDataLessOutput<float>();
+      test.AddOptionalOutputEdge<float>();
     }
 
     if (outputOption == RNNOutputY_h || outputOption == RNNOutputBoth) {
@@ -527,7 +527,7 @@ TEST(RNNTest, DISABLED_RNN_default_attributes_and_forward_direction) {
       std::vector<float> Y_h_data({-0.74626476F, -0.07818383F, -0.75139415F});
       test.AddOutput<float>("Y_h", Y_h_dims, Y_h_data);
     } else {
-      test.AddDataLessOutput<float>();
+      test.AddOptionalOutputEdge<float>();
     }
 
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
@@ -614,9 +614,9 @@ TEST(RNNTest, DISABLED_RNN_reverse_direction) {
       std::vector<float> initial_h_data({0.0F, 0.0F, 0.0F});
       test.AddInput<float>("initial_h", initial_h_dims, initial_h_data);
     } else {
-      test.AddDataLessInput<float>();
-      test.AddDataLessInput<int>();
-      test.AddDataLessInput<float>();
+      test.AddOptionalInputEdge<float>();
+      test.AddOptionalInputEdge<int>();
+      test.AddOptionalInputEdge<float>();
     }
 
     std::vector<int64_t> Y_dims = {seq_length, num_directions, batch_size, hidden_size};
@@ -628,7 +628,7 @@ TEST(RNNTest, DISABLED_RNN_reverse_direction) {
     if (outputOption == RNNOutputY || outputOption == RNNOutputBoth) {
       test.AddOutput<float>("Y", Y_dims, Y_data);
     } else {
-      test.AddDataLessOutput<float>();
+      test.AddOptionalOutputEdge<float>();
     }
 
     std::vector<int64_t> Y_h_dims{num_directions, batch_size, hidden_size};
@@ -636,7 +636,7 @@ TEST(RNNTest, DISABLED_RNN_reverse_direction) {
     if (outputOption == RNNOutputY_h || outputOption == RNNOutputBoth) {
       test.AddOutput<float>("Y_h", Y_h_dims, Y_h_data);
     } else {
-      test.AddDataLessOutput<float>();
+      test.AddOptionalOutputEdge<float>();
     }
 
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
@@ -729,7 +729,7 @@ TEST(RNNTest, RNN_invalid_sequence_lens) {
     test.AddInput<float>("initial_h", initial_h_dims, initial_h_data);
 
     // Y
-    test.AddDataLessOutput<float>();
+    test.AddOptionalOutputEdge<float>();
 
     std::vector<int64_t> Y_h_dims{num_directions, batch_size, hidden_size};
     std::vector<float> Y_h_data{0.f, 0.f, 0.f, 0.f, 0.f, 0.f};

--- a/onnxruntime/test/providers/cpu/rnn/rnn_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/rnn_op_test.cc
@@ -505,9 +505,9 @@ TEST(RNNTest, DISABLED_RNN_default_attributes_and_forward_direction) {
       std::vector<float> initial_h_data({0.0F, 0.0F, 0.0F});
       test.AddInput<float>("initial_h", initial_h_dims, initial_h_data);
     } else {
-      test.AddMissingOptionalInput<float>();
-      test.AddMissingOptionalInput<int>();
-      test.AddMissingOptionalInput<float>();
+      test.AddDataLessInput<float>();
+      test.AddDataLessInput<int>();
+      test.AddDataLessInput<float>();
     }
 
     if (outputOption == RNNOutputY || outputOption == RNNOutputBoth) {
@@ -519,7 +519,7 @@ TEST(RNNTest, DISABLED_RNN_default_attributes_and_forward_direction) {
                                  -0.74626476F, -0.07818383F, -0.75139415F});
       test.AddOutput<float>("Y", Y_dims, Y_data);
     } else {
-      test.AddMissingOptionalOutput<float>();
+      test.AddDataLessOutput<float>();
     }
 
     if (outputOption == RNNOutputY_h || outputOption == RNNOutputBoth) {
@@ -527,7 +527,7 @@ TEST(RNNTest, DISABLED_RNN_default_attributes_and_forward_direction) {
       std::vector<float> Y_h_data({-0.74626476F, -0.07818383F, -0.75139415F});
       test.AddOutput<float>("Y_h", Y_h_dims, Y_h_data);
     } else {
-      test.AddMissingOptionalOutput<float>();
+      test.AddDataLessOutput<float>();
     }
 
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
@@ -614,9 +614,9 @@ TEST(RNNTest, DISABLED_RNN_reverse_direction) {
       std::vector<float> initial_h_data({0.0F, 0.0F, 0.0F});
       test.AddInput<float>("initial_h", initial_h_dims, initial_h_data);
     } else {
-      test.AddMissingOptionalInput<float>();
-      test.AddMissingOptionalInput<int>();
-      test.AddMissingOptionalInput<float>();
+      test.AddDataLessInput<float>();
+      test.AddDataLessInput<int>();
+      test.AddDataLessInput<float>();
     }
 
     std::vector<int64_t> Y_dims = {seq_length, num_directions, batch_size, hidden_size};
@@ -628,7 +628,7 @@ TEST(RNNTest, DISABLED_RNN_reverse_direction) {
     if (outputOption == RNNOutputY || outputOption == RNNOutputBoth) {
       test.AddOutput<float>("Y", Y_dims, Y_data);
     } else {
-      test.AddMissingOptionalOutput<float>();
+      test.AddDataLessOutput<float>();
     }
 
     std::vector<int64_t> Y_h_dims{num_directions, batch_size, hidden_size};
@@ -636,7 +636,7 @@ TEST(RNNTest, DISABLED_RNN_reverse_direction) {
     if (outputOption == RNNOutputY_h || outputOption == RNNOutputBoth) {
       test.AddOutput<float>("Y_h", Y_h_dims, Y_h_data);
     } else {
-      test.AddMissingOptionalOutput<float>();
+      test.AddDataLessOutput<float>();
     }
 
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
@@ -729,7 +729,7 @@ TEST(RNNTest, RNN_invalid_sequence_lens) {
     test.AddInput<float>("initial_h", initial_h_dims, initial_h_data);
 
     // Y
-    test.AddMissingOptionalOutput<float>();
+    test.AddDataLessOutput<float>();
 
     std::vector<int64_t> Y_h_dims{num_directions, batch_size, hidden_size};
     std::vector<float> Y_h_data{0.f, 0.f, 0.f, 0.f, 0.f, 0.f};

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -1217,8 +1217,8 @@ TEST(ResizeOpTest, ResizeOp_MissingRoiAndMissingScalesOptionalInputs) {
       1.0f, 1.0f, 1.0f, 1.0f};
 
   test.AddInput<float>("X", {H, W}, X);
-  test.AddDataLessInput<float>();
-  test.AddDataLessInput<float>();
+  test.AddOptionalInputEdge<float>();
+  test.AddOptionalInputEdge<float>();
   test.AddInput<int64_t>("sizes", {2}, {4, 4});
 
   test.AddOutput<float>("Y", {H, W}, X);

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -1217,8 +1217,8 @@ TEST(ResizeOpTest, ResizeOp_MissingRoiAndMissingScalesOptionalInputs) {
       1.0f, 1.0f, 1.0f, 1.0f};
 
   test.AddInput<float>("X", {H, W}, X);
-  test.AddMissingOptionalInput<float>();
-  test.AddMissingOptionalInput<float>();
+  test.AddDataLessInput<float>();
+  test.AddDataLessInput<float>();
   test.AddInput<int64_t>("sizes", {2}, {4, 4});
 
   test.AddOutput<float>("Y", {H, W}, X);

--- a/onnxruntime/test/providers/cpu/tensor/slice_op.test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/slice_op.test.cc
@@ -559,7 +559,7 @@ TEST(SliceTest, OptionalAxesInputAloneMissing) {
   testv10.AddInput<float>("data", input_dims, input_vals);
   testv10.AddInput<int64_t>("starts", {static_cast<int64_t>(starts.size())}, starts);
   testv10.AddInput<int64_t>("ends", {static_cast<int64_t>(ends.size())}, ends);
-  testv10.AddMissingOptionalInput<int64_t>();
+  testv10.AddDataLessInput<int64_t>();
   testv10.AddInput<int64_t>("steps", {static_cast<int64_t>(steps.size())}, steps);
   testv10.AddOutput<float>("output", output_dims, output_vals);
   testv10.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});

--- a/onnxruntime/test/providers/cpu/tensor/slice_op.test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/slice_op.test.cc
@@ -559,7 +559,7 @@ TEST(SliceTest, OptionalAxesInputAloneMissing) {
   testv10.AddInput<float>("data", input_dims, input_vals);
   testv10.AddInput<int64_t>("starts", {static_cast<int64_t>(starts.size())}, starts);
   testv10.AddInput<int64_t>("ends", {static_cast<int64_t>(ends.size())}, ends);
-  testv10.AddDataLessInput<int64_t>();
+  testv10.AddOptionalInputEdge<int64_t>();
   testv10.AddInput<int64_t>("steps", {static_cast<int64_t>(steps.size())}, steps);
   testv10.AddOutput<float>("output", output_dims, output_vals);
   testv10.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});

--- a/onnxruntime/test/providers/cpu/tensor/split_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/split_op_test.cc
@@ -31,7 +31,7 @@ void RunTest(int64_t axis, const std::vector<int64_t> split_sizes, const ShapeAn
       test.AddAttribute("split", split_sizes);
     }
   } else if (!skip_split_if_empty) {
-    test.AddDataLessInput<int64_t>();
+    test.AddOptionalInputEdge<int64_t>();
   }
 
   int i = 0;

--- a/onnxruntime/test/providers/cpu/tensor/split_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/split_op_test.cc
@@ -31,7 +31,7 @@ void RunTest(int64_t axis, const std::vector<int64_t> split_sizes, const ShapeAn
       test.AddAttribute("split", split_sizes);
     }
   } else if (!skip_split_if_empty) {
-    test.AddMissingOptionalInput<int64_t>();
+    test.AddDataLessInput<int64_t>();
   }
 
   int i = 0;

--- a/onnxruntime/test/providers/provider_test_utils.h
+++ b/onnxruntime/test/providers/provider_test_utils.h
@@ -318,10 +318,11 @@ class OpTester {
   }
 
   /*
-  * Use this API to add an input *edge* to the node/op being tested that won't have any data passed into.
+  * Use this API to add an input *edge* to the node/op being tested that won't 
+  * have any data passed into.
   * Such an edge will have the qualifier OpSchema::Optional in the schema.
-  * This is exposed to ensure the op kernel implementations can be tested to handle presence of such
-  * "data-less" optional edges.
+  * This is exposed to ensure the op kernel implementations can be tested to handle 
+  * presence/absence of such "data-less" optional edges.
   */
   template <typename T>
   void AddDataLessInput() {
@@ -353,11 +354,11 @@ class OpTester {
   }
 
   /*
-  * Use this API to add an output *edge* to the node/op being tested that won't shouldn't have any 
+  * Use this API to add an output *edge* to the node/op being tested that shouldn't have any 
   * data produced into.
   * Such an edge will have the qualifier OpSchema::Optional in the schema.
-  * This is exposed to ensure the op kernel implementations can be tested to handle presence of such
-  * "data-less" optional edges.
+  * This is exposed to ensure the op kernel implementations can be tested to handle 
+  * presence/absence of such "data-less" optional edges.
   */
   template <typename T>
   void AddDataLessOutput() {

--- a/onnxruntime/test/providers/provider_test_utils.h
+++ b/onnxruntime/test/providers/provider_test_utils.h
@@ -317,8 +317,14 @@ class OpTester {
                                optional<float>(), optional<float>()));
   }
 
+  /*
+  * Use this API to add an input *edge* to the node/op being tested that won't have any data passed into.
+  * Such an edge will have the qualifier OpSchema::Optional in the schema.
+  * This is exposed to ensure the op kernel implementations can be tested to handle presence of such
+  * "data-less" optional edges.
+  */
   template <typename T>
-  void AddMissingOptionalInput() {
+  void AddDataLessInput() {
     std::string name;  // empty == input doesn't exist
     input_data_.push_back(Data(NodeArg(name, &TTensorType<T>::s_type_proto.proto), OrtValue(), optional<float>(),
                                optional<float>()));
@@ -346,9 +352,16 @@ class OpTester {
             sort_output, nullptr /* dim_params */, rel_error, abs_error);
   }
 
+  /*
+  * Use this API to add an output *edge* to the node/op being tested that won't shouldn't have any 
+  * data produced into.
+  * Such an edge will have the qualifier OpSchema::Optional in the schema.
+  * This is exposed to ensure the op kernel implementations can be tested to handle presence of such
+  * "data-less" optional edges.
+  */
   template <typename T>
-  void AddMissingOptionalOutput() {
-    std::string name;  // empty == input doesn't exist
+  void AddDataLessOutput() {
+    std::string name;  // empty == output doesn't exist
     output_data_.push_back(Data(NodeArg(name, &TTensorType<T>::s_type_proto.proto), OrtValue(), optional<float>(),
                                 optional<float>()));
   }

--- a/onnxruntime/test/providers/provider_test_utils.h
+++ b/onnxruntime/test/providers/provider_test_utils.h
@@ -322,10 +322,10 @@ class OpTester {
   * have any data passed into.
   * Such an edge will have the qualifier OpSchema::Optional in the schema.
   * This is exposed to ensure the op kernel implementations can be tested to handle 
-  * presence/absence of such "data-less" optional edges.
+  * presence/absence of such optional input edges.
   */
   template <typename T>
-  void AddDataLessInput() {
+  void AddOptionalInputEdge() {
     std::string name;  // empty == input doesn't exist
     input_data_.push_back(Data(NodeArg(name, &TTensorType<T>::s_type_proto.proto), OrtValue(), optional<float>(),
                                optional<float>()));
@@ -358,10 +358,10 @@ class OpTester {
   * data produced into.
   * Such an edge will have the qualifier OpSchema::Optional in the schema.
   * This is exposed to ensure the op kernel implementations can be tested to handle 
-  * presence/absence of such "data-less" optional edges.
+  * presence/absence of such optional output edges.
   */
   template <typename T>
-  void AddDataLessOutput() {
+  void AddOptionalOutputEdge() {
     std::string name;  // empty == output doesn't exist
     output_data_.push_back(Data(NodeArg(name, &TTensorType<T>::s_type_proto.proto), OrtValue(), optional<float>(),
                                 optional<float>()));

--- a/orttraining/orttraining/test/gradient/gradient_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/gradient_ops_test.cc
@@ -1962,7 +1962,7 @@ void TestDropoutGradOp(float ratio, TensorShape& x_shape, bool default_ratio = t
   if (!default_ratio) {
     test.AddInput<float>("ratio", {1}, ratio_data);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   test.AddInput("training_mode", {}, {true});

--- a/orttraining/orttraining/test/gradient/gradient_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/gradient_ops_test.cc
@@ -1962,7 +1962,7 @@ void TestDropoutGradOp(float ratio, TensorShape& x_shape, bool default_ratio = t
   if (!default_ratio) {
     test.AddInput<float>("ratio", {1}, ratio_data);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
 
   test.AddInput("training_mode", {}, {true});

--- a/orttraining/orttraining/test/gradient/optimizer_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/optimizer_ops_test.cc
@@ -25,7 +25,7 @@ TEST(OptimizerTest, SGDOptimizerTest_Gradient) {
   test.AddInput<float>("ETA", {}, {0.5f});
   test.AddInput<float>("W", {3}, {1, 2, 3});
   test.AddInput<float>("G", {3}, {4, 5, 6});
-  test.AddMissingOptionalOutput<float>();
+  test.AddDataLessOutput<float>();
   test.AddOutput<float>("G_New", {3}, {-2.f, -2.5f, -3.f});
   test.Run();
 }
@@ -118,7 +118,7 @@ TEST(OptimizerTest, AdamOptimizerTest_Gradient) {
   test.AddOutput<int64_t>("Update_Count_Out", {}, {4});
   test.AddOutput<float>("Moment_1_Out", {3}, data.m1_new);
   test.AddOutput<float>("Moment_2_Out", {3}, data.m2_new);
-  test.AddMissingOptionalOutput<float>();
+  test.AddDataLessOutput<float>();
   test.AddOutput<float>("G_Out", {3}, data.g_new);
 
   test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
@@ -294,7 +294,7 @@ TEST(OptimizerTest, AdamOptimizerMixPrecision_FP16Weight_Test) {
   test.AddOutput<MLFloat16>("Moment_1_Out", {3}, data.m1_new_half);
   test.AddOutput<MLFloat16>("Moment_2_Out", {3}, data.m2_new_half);
   test.AddOutput<float>("W_Out", {3}, data.w_new);
-  test.AddMissingOptionalOutput<MLFloat16>();
+  test.AddDataLessOutput<MLFloat16>();
   test.AddOutput<MLFloat16>("FP16_W_Out", {3}, data.w_new_half);
 
   test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
@@ -322,7 +322,7 @@ TEST(OptimizerTest, AdamOptimizerMixPrecision_FP16Weight_NoClipNorm_Test) {
   test.AddOutput<MLFloat16>("Moment_1_Out", {3}, data.m1_new_half);
   test.AddOutput<MLFloat16>("Moment_2_Out", {3}, data.m2_new_half);
   test.AddOutput<float>("W_Out", {3}, data.w_new);
-  test.AddMissingOptionalOutput<MLFloat16>();
+  test.AddDataLessOutput<MLFloat16>();
   test.AddOutput<MLFloat16>("FP16_W_Out", {3}, data.w_new_half);
 
   test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
@@ -364,7 +364,7 @@ TEST(OptimizerTest, AdamOptimizerMixPrecision_FP16Weight_ClipNorm_Test) {
   test.AddOutput<MLFloat16>("Moment_1_Out", {3}, m1_new_half);
   test.AddOutput<MLFloat16>("Moment_2_Out", {3}, m2_new_half);
   test.AddOutput<float>("W_Out", {3}, w_new);
-  test.AddMissingOptionalOutput<MLFloat16>();
+  test.AddDataLessOutput<MLFloat16>();
   test.AddOutput<MLFloat16>("FP16_W_Out", {3}, w_new_half);
 
   test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
@@ -394,7 +394,7 @@ TEST(OptimizerTest, AdamOptimizerMixPrecision_FP16Weight_SkipUpdate_Test) {
   test.AddOutput<MLFloat16>("Moment_1_Out", {3}, data.m1_half);
   test.AddOutput<MLFloat16>("Moment_2_Out", {3}, data.m2_half);
   test.AddOutput<float>("W_Out", {3}, data.w);
-  test.AddMissingOptionalOutput<MLFloat16>();
+  test.AddDataLessOutput<MLFloat16>();
   test.AddOutput<MLFloat16>("FP16_W_Out", {3}, data.w_half);
 
   test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
@@ -441,7 +441,7 @@ TEST(OptimizerTest, AdamOptimizerMixPrecisionTest_Gradient) {
   test.AddOutput<int64_t>("Update_Count_Out", {}, {4});
   test.AddOutput<MLFloat16>("Moment_1_Out", {3}, data.m1_new_half);
   test.AddOutput<MLFloat16>("Moment_2_Out", {3}, data.m2_new_half);
-  test.AddMissingOptionalOutput<float>();
+  test.AddDataLessOutput<float>();
   test.AddOutput<MLFloat16>("G_Out", {3}, data.g_new_half);
 
   test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
@@ -596,24 +596,24 @@ void run_lamb_test_with_baseline(
   if (step > 0) {
     test.AddOutput<int64_t>("Step_Out", {}, {do_update ? step + 1 : step});
   } else {
-    test.AddMissingOptionalOutput<int64_t>();
+    test.AddDataLessOutput<int64_t>();
   }
   if (!w_new.empty()) {
     test.AddOutput<T2>("W_Out", shape, w_new);
   } else {
-    test.AddMissingOptionalOutput<T2>();
+    test.AddDataLessOutput<T2>();
   }
   if (!g_new.empty()) {
     test.AddOutput<T3>("G_Out", shape, g_new);
   } else {
-    test.AddMissingOptionalOutput<T3>();
+    test.AddDataLessOutput<T3>();
   }
   test.AddOutput<T4>("Moment_1_Out", shape, m_new);
   test.AddOutput<T4>("Moment_2_Out", shape, v_new);
   if (!w_new_half.empty()) {
     test.AddOutput<MLFloat16>("FP16_W_Out", shape, w_new_half);
   } else {
-    test.AddMissingOptionalOutput<MLFloat16>();
+    test.AddDataLessOutput<MLFloat16>();
   }
 
   test.Run();
@@ -685,7 +685,7 @@ void run_multi_tensor_lamb_test_with_baseline(
     test.AddOutput<int64_t>("Step_Out", {}, {do_update ? step + 1 : step});
   } else {
     test.AddDataLessInput<int64_t>();
-    test.AddMissingOptionalOutput<int64_t>();
+    test.AddDataLessOutput<int64_t>();
   }
   for (int i = 0; i < group_count; ++i) {
     std::string w_name = "W_" + std::to_string(i);
@@ -712,19 +712,19 @@ void run_multi_tensor_lamb_test_with_baseline(
     if (!w_news.empty() && !w_news[i].empty()) {
       test.AddOutput<T2>(w_new_name.c_str(), shapes[i], w_news[i]);
     } else {
-      test.AddMissingOptionalOutput<T2>();
+      test.AddDataLessOutput<T2>();
     }
     if (!g_news.empty() && !g_news[i].empty()) {
       test.AddOutput<T3>(g_new_name.c_str(), shapes[i], g_news[i]);
     } else {
-      test.AddMissingOptionalOutput<T3>();
+      test.AddDataLessOutput<T3>();
     }
     test.AddOutput<T4>(m1_new_name.c_str(), shapes[i], m_news[i]);
     test.AddOutput<T4>(m2_new_name.c_str(), shapes[i], v_news[i]);
     if (!w_new_halfs.empty() && !w_new_halfs[i].empty()) {
       test.AddOutput<MLFloat16>(w_fp16_new_name.c_str(), shapes[i], w_new_halfs[i]);
     } else {
-      test.AddMissingOptionalOutput<MLFloat16>();
+      test.AddDataLessOutput<MLFloat16>();
     }
   }
 

--- a/orttraining/orttraining/test/gradient/optimizer_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/optimizer_ops_test.cc
@@ -25,7 +25,7 @@ TEST(OptimizerTest, SGDOptimizerTest_Gradient) {
   test.AddInput<float>("ETA", {}, {0.5f});
   test.AddInput<float>("W", {3}, {1, 2, 3});
   test.AddInput<float>("G", {3}, {4, 5, 6});
-  test.AddDataLessOutput<float>();
+  test.AddOptionalOutputEdge<float>();
   test.AddOutput<float>("G_New", {3}, {-2.f, -2.5f, -3.f});
   test.Run();
 }
@@ -118,7 +118,7 @@ TEST(OptimizerTest, AdamOptimizerTest_Gradient) {
   test.AddOutput<int64_t>("Update_Count_Out", {}, {4});
   test.AddOutput<float>("Moment_1_Out", {3}, data.m1_new);
   test.AddOutput<float>("Moment_2_Out", {3}, data.m2_new);
-  test.AddDataLessOutput<float>();
+  test.AddOptionalOutputEdge<float>();
   test.AddOutput<float>("G_Out", {3}, data.g_new);
 
   test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
@@ -294,7 +294,7 @@ TEST(OptimizerTest, AdamOptimizerMixPrecision_FP16Weight_Test) {
   test.AddOutput<MLFloat16>("Moment_1_Out", {3}, data.m1_new_half);
   test.AddOutput<MLFloat16>("Moment_2_Out", {3}, data.m2_new_half);
   test.AddOutput<float>("W_Out", {3}, data.w_new);
-  test.AddDataLessOutput<MLFloat16>();
+  test.AddOptionalOutputEdge<MLFloat16>();
   test.AddOutput<MLFloat16>("FP16_W_Out", {3}, data.w_new_half);
 
   test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
@@ -322,7 +322,7 @@ TEST(OptimizerTest, AdamOptimizerMixPrecision_FP16Weight_NoClipNorm_Test) {
   test.AddOutput<MLFloat16>("Moment_1_Out", {3}, data.m1_new_half);
   test.AddOutput<MLFloat16>("Moment_2_Out", {3}, data.m2_new_half);
   test.AddOutput<float>("W_Out", {3}, data.w_new);
-  test.AddDataLessOutput<MLFloat16>();
+  test.AddOptionalOutputEdge<MLFloat16>();
   test.AddOutput<MLFloat16>("FP16_W_Out", {3}, data.w_new_half);
 
   test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
@@ -364,7 +364,7 @@ TEST(OptimizerTest, AdamOptimizerMixPrecision_FP16Weight_ClipNorm_Test) {
   test.AddOutput<MLFloat16>("Moment_1_Out", {3}, m1_new_half);
   test.AddOutput<MLFloat16>("Moment_2_Out", {3}, m2_new_half);
   test.AddOutput<float>("W_Out", {3}, w_new);
-  test.AddDataLessOutput<MLFloat16>();
+  test.AddOptionalOutputEdge<MLFloat16>();
   test.AddOutput<MLFloat16>("FP16_W_Out", {3}, w_new_half);
 
   test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
@@ -394,7 +394,7 @@ TEST(OptimizerTest, AdamOptimizerMixPrecision_FP16Weight_SkipUpdate_Test) {
   test.AddOutput<MLFloat16>("Moment_1_Out", {3}, data.m1_half);
   test.AddOutput<MLFloat16>("Moment_2_Out", {3}, data.m2_half);
   test.AddOutput<float>("W_Out", {3}, data.w);
-  test.AddDataLessOutput<MLFloat16>();
+  test.AddOptionalOutputEdge<MLFloat16>();
   test.AddOutput<MLFloat16>("FP16_W_Out", {3}, data.w_half);
 
   test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
@@ -441,7 +441,7 @@ TEST(OptimizerTest, AdamOptimizerMixPrecisionTest_Gradient) {
   test.AddOutput<int64_t>("Update_Count_Out", {}, {4});
   test.AddOutput<MLFloat16>("Moment_1_Out", {3}, data.m1_new_half);
   test.AddOutput<MLFloat16>("Moment_2_Out", {3}, data.m2_new_half);
-  test.AddDataLessOutput<float>();
+  test.AddOptionalOutputEdge<float>();
   test.AddOutput<MLFloat16>("G_Out", {3}, data.g_new_half);
 
   test.AddAttribute("do_bias_correction", static_cast<int64_t>(0));
@@ -565,7 +565,7 @@ void run_lamb_test_with_baseline(
   test.AddInput<bool>("update_signal", {1}, {do_update});
   test.AddInput<T2>("loss_scale", {}, {loss_scale});
   if (p_g_norm == nullptr) {
-    test.AddDataLessInput<T2>();
+    test.AddOptionalInputEdge<T2>();
   } else {
     test.AddInput<T2>("gradient_norm", {}, {T2(*p_g_norm)});
   }
@@ -573,7 +573,7 @@ void run_lamb_test_with_baseline(
   if (step > 0) {
     test.AddInput<int64_t>("Step", {}, {step});
   } else {
-    test.AddDataLessInput<int64_t>();
+    test.AddOptionalInputEdge<int64_t>();
   }
   test.AddInput<T2>("W", shape, w);
   test.AddInput<T3>("G", shape, g);
@@ -582,7 +582,7 @@ void run_lamb_test_with_baseline(
   if (!w_half.empty()) {
     test.AddInput<MLFloat16>("FP16_W", shape, w_half);
   } else {
-    test.AddDataLessInput<MLFloat16>();
+    test.AddOptionalInputEdge<MLFloat16>();
   }
 
   test.AddAttribute("alpha", std::vector<float>(1, alpha));
@@ -596,24 +596,24 @@ void run_lamb_test_with_baseline(
   if (step > 0) {
     test.AddOutput<int64_t>("Step_Out", {}, {do_update ? step + 1 : step});
   } else {
-    test.AddDataLessOutput<int64_t>();
+    test.AddOptionalOutputEdge<int64_t>();
   }
   if (!w_new.empty()) {
     test.AddOutput<T2>("W_Out", shape, w_new);
   } else {
-    test.AddDataLessOutput<T2>();
+    test.AddOptionalOutputEdge<T2>();
   }
   if (!g_new.empty()) {
     test.AddOutput<T3>("G_Out", shape, g_new);
   } else {
-    test.AddDataLessOutput<T3>();
+    test.AddOptionalOutputEdge<T3>();
   }
   test.AddOutput<T4>("Moment_1_Out", shape, m_new);
   test.AddOutput<T4>("Moment_2_Out", shape, v_new);
   if (!w_new_half.empty()) {
     test.AddOutput<MLFloat16>("FP16_W_Out", shape, w_new_half);
   } else {
-    test.AddDataLessOutput<MLFloat16>();
+    test.AddOptionalOutputEdge<MLFloat16>();
   }
 
   test.Run();
@@ -675,7 +675,7 @@ void run_multi_tensor_lamb_test_with_baseline(
   test.AddInput<bool>("update_signal", {}, {do_update});
   test.AddInput<T2>("loss_scale", {}, {loss_scale});
   if (p_g_norm == nullptr) {
-    test.AddDataLessInput<T2>();
+    test.AddOptionalInputEdge<T2>();
   } else {
     test.AddInput<float>("gradient_norm", {}, {T2(*p_g_norm)});
   }
@@ -684,8 +684,8 @@ void run_multi_tensor_lamb_test_with_baseline(
     test.AddInput<int64_t>("Step", {}, {step});
     test.AddOutput<int64_t>("Step_Out", {}, {do_update ? step + 1 : step});
   } else {
-    test.AddDataLessInput<int64_t>();
-    test.AddDataLessOutput<int64_t>();
+    test.AddOptionalInputEdge<int64_t>();
+    test.AddOptionalOutputEdge<int64_t>();
   }
   for (int i = 0; i < group_count; ++i) {
     std::string w_name = "W_" + std::to_string(i);
@@ -706,25 +706,25 @@ void run_multi_tensor_lamb_test_with_baseline(
     if (!w_halfs.empty() && !w_halfs[i].empty()) {
       test.AddInput<MLFloat16>(w_fp16_name.c_str(), shapes[i], w_halfs[i]);
     } else {
-      test.AddDataLessInput<MLFloat16>();
+      test.AddOptionalInputEdge<MLFloat16>();
     }
 
     if (!w_news.empty() && !w_news[i].empty()) {
       test.AddOutput<T2>(w_new_name.c_str(), shapes[i], w_news[i]);
     } else {
-      test.AddDataLessOutput<T2>();
+      test.AddOptionalOutputEdge<T2>();
     }
     if (!g_news.empty() && !g_news[i].empty()) {
       test.AddOutput<T3>(g_new_name.c_str(), shapes[i], g_news[i]);
     } else {
-      test.AddDataLessOutput<T3>();
+      test.AddOptionalOutputEdge<T3>();
     }
     test.AddOutput<T4>(m1_new_name.c_str(), shapes[i], m_news[i]);
     test.AddOutput<T4>(m2_new_name.c_str(), shapes[i], v_news[i]);
     if (!w_new_halfs.empty() && !w_new_halfs[i].empty()) {
       test.AddOutput<MLFloat16>(w_fp16_new_name.c_str(), shapes[i], w_new_halfs[i]);
     } else {
-      test.AddDataLessOutput<MLFloat16>();
+      test.AddOptionalOutputEdge<MLFloat16>();
     }
   }
 

--- a/orttraining/orttraining/test/gradient/optimizer_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/optimizer_ops_test.cc
@@ -565,7 +565,7 @@ void run_lamb_test_with_baseline(
   test.AddInput<bool>("update_signal", {1}, {do_update});
   test.AddInput<T2>("loss_scale", {}, {loss_scale});
   if (p_g_norm == nullptr) {
-    test.AddMissingOptionalInput<T2>();
+    test.AddDataLessInput<T2>();
   } else {
     test.AddInput<T2>("gradient_norm", {}, {T2(*p_g_norm)});
   }
@@ -573,7 +573,7 @@ void run_lamb_test_with_baseline(
   if (step > 0) {
     test.AddInput<int64_t>("Step", {}, {step});
   } else {
-    test.AddMissingOptionalInput<int64_t>();
+    test.AddDataLessInput<int64_t>();
   }
   test.AddInput<T2>("W", shape, w);
   test.AddInput<T3>("G", shape, g);
@@ -582,7 +582,7 @@ void run_lamb_test_with_baseline(
   if (!w_half.empty()) {
     test.AddInput<MLFloat16>("FP16_W", shape, w_half);
   } else {
-    test.AddMissingOptionalInput<MLFloat16>();
+    test.AddDataLessInput<MLFloat16>();
   }
 
   test.AddAttribute("alpha", std::vector<float>(1, alpha));
@@ -675,7 +675,7 @@ void run_multi_tensor_lamb_test_with_baseline(
   test.AddInput<bool>("update_signal", {}, {do_update});
   test.AddInput<T2>("loss_scale", {}, {loss_scale});
   if (p_g_norm == nullptr) {
-    test.AddMissingOptionalInput<T2>();
+    test.AddDataLessInput<T2>();
   } else {
     test.AddInput<float>("gradient_norm", {}, {T2(*p_g_norm)});
   }
@@ -684,7 +684,7 @@ void run_multi_tensor_lamb_test_with_baseline(
     test.AddInput<int64_t>("Step", {}, {step});
     test.AddOutput<int64_t>("Step_Out", {}, {do_update ? step + 1 : step});
   } else {
-    test.AddMissingOptionalInput<int64_t>();
+    test.AddDataLessInput<int64_t>();
     test.AddMissingOptionalOutput<int64_t>();
   }
   for (int i = 0; i < group_count; ++i) {
@@ -706,7 +706,7 @@ void run_multi_tensor_lamb_test_with_baseline(
     if (!w_halfs.empty() && !w_halfs[i].empty()) {
       test.AddInput<MLFloat16>(w_fp16_name.c_str(), shapes[i], w_halfs[i]);
     } else {
-      test.AddMissingOptionalInput<MLFloat16>();
+      test.AddDataLessInput<MLFloat16>();
     }
 
     if (!w_news.empty() && !w_news[i].empty()) {
@@ -1641,6 +1641,6 @@ TEST(OptimizerTest, LambOptimizerMultiTensorRatio) {
       step, loss_scale, &scaled_g_norm);
 }
 #endif
-}
+}  // namespace
 }  // namespace test
 }  // namespace onnxruntime

--- a/orttraining/orttraining/test/training_ops/cpu/nn/dropout_op_test.cc
+++ b/orttraining/orttraining/test/training_ops/cpu/nn/dropout_op_test.cc
@@ -46,9 +46,9 @@ void RunDropoutTest(const bool use_mask, const std::vector<int64_t>& input_shape
 
   if (ratio == -1.0f) {
     if (use_float16_ratio) {
-      t.AddDataLessInput<MLFloat16>();
+      t.AddOptionalInputEdge<MLFloat16>();
     } else {
-      t.AddDataLessInput<float>();
+      t.AddOptionalInputEdge<float>();
     }
     // set ratio to default value
     ratio = 0.5f;
@@ -74,7 +74,7 @@ void RunDropoutTest(const bool use_mask, const std::vector<int64_t>& input_shape
     mask_buffer = std::make_unique<bool[]>(input_size);
     t.AddOutput<bool>("mask", input_shape, mask_buffer.get(), input_size);
   } else {
-    t.AddDataLessOutput<bool>();
+    t.AddOptionalOutputEdge<bool>();
   }
 
   auto output_verifier = [&](const std::vector<OrtValue>& fetches, const std::string& provider_type) {
@@ -185,7 +185,7 @@ void RunDropoutGradTest(float ratio, const std::vector<int64_t>& input_dims, boo
   if (!default_ratio) {
     test.AddInput<float>("ratio", {1}, ratio_data);
   } else {
-    test.AddDataLessInput<float>();
+    test.AddOptionalInputEdge<float>();
   }
 
   test.AddInput<bool>("training_mode", {}, {true});

--- a/orttraining/orttraining/test/training_ops/cpu/nn/dropout_op_test.cc
+++ b/orttraining/orttraining/test/training_ops/cpu/nn/dropout_op_test.cc
@@ -27,7 +27,9 @@ using namespace onnxruntime::test;
 namespace {
 constexpr auto k_dropout_opset_version = 12;
 
-enum TrainingMode { TrainingFalse, TrainingTrue, NoTraining };
+enum TrainingMode { TrainingFalse,
+                    TrainingTrue,
+                    NoTraining };
 
 void RunDropoutTest(const bool use_mask, const std::vector<int64_t>& input_shape, float ratio = -1.0f,
                     TrainingMode training_mode = TrainingTrue, bool use_float16_ratio = false) {
@@ -44,9 +46,9 @@ void RunDropoutTest(const bool use_mask, const std::vector<int64_t>& input_shape
 
   if (ratio == -1.0f) {
     if (use_float16_ratio) {
-      t.AddMissingOptionalInput<MLFloat16>();
+      t.AddDataLessInput<MLFloat16>();
     } else {
-      t.AddMissingOptionalInput<float>();
+      t.AddDataLessInput<float>();
     }
     // set ratio to default value
     ratio = 0.5f;
@@ -183,9 +185,9 @@ void RunDropoutGradTest(float ratio, const std::vector<int64_t>& input_dims, boo
   if (!default_ratio) {
     test.AddInput<float>("ratio", {1}, ratio_data);
   } else {
-    test.AddMissingOptionalInput<float>();
+    test.AddDataLessInput<float>();
   }
-  
+
   test.AddInput<bool>("training_mode", {}, {true});
   test.AddOutput<float>("dx", input_shape.GetDims(), dx_data);
   test.Run();

--- a/orttraining/orttraining/test/training_ops/cpu/nn/dropout_op_test.cc
+++ b/orttraining/orttraining/test/training_ops/cpu/nn/dropout_op_test.cc
@@ -74,7 +74,7 @@ void RunDropoutTest(const bool use_mask, const std::vector<int64_t>& input_shape
     mask_buffer = std::make_unique<bool[]>(input_size);
     t.AddOutput<bool>("mask", input_shape, mask_buffer.get(), input_size);
   } else {
-    t.AddMissingOptionalOutput<bool>();
+    t.AddDataLessOutput<bool>();
   }
 
   auto output_verifier = [&](const std::vector<OrtValue>& fetches, const std::string& provider_type) {

--- a/orttraining/orttraining/test/training_ops/cpu/tensor/concat_op_test.cc
+++ b/orttraining/orttraining/test/training_ops/cpu/tensor/concat_op_test.cc
@@ -80,7 +80,7 @@ TEST(ConcatTrainingOpTest, Concat2D_optional_output1) {
                          21.0f, 22.0f, 23.0f, 24.0f,
                          31.0f, 32.0f, 33.0f, 34.0f,
                          41.0f, 42.0f, 43.0f, 44.0f});
-  test.AddMissingOptionalOutput<int64_t>();
+  test.AddDataLessOutput<int64_t>();
   test.Run();
 }
 

--- a/orttraining/orttraining/test/training_ops/cpu/tensor/concat_op_test.cc
+++ b/orttraining/orttraining/test/training_ops/cpu/tensor/concat_op_test.cc
@@ -80,7 +80,7 @@ TEST(ConcatTrainingOpTest, Concat2D_optional_output1) {
                          21.0f, 22.0f, 23.0f, 24.0f,
                          31.0f, 32.0f, 33.0f, 34.0f,
                          41.0f, 42.0f, 43.0f, 44.0f});
-  test.AddDataLessOutput<int64_t>();
+  test.AddOptionalOutputEdge<int64_t>();
   test.Run();
 }
 


### PR DESCRIPTION
**Description**: Ahead of the "Optional" type support in ORT, this change tries to pre-emptively remove ambiguities in the test infrastructure because we will soon have the concepts of "optional edges" and  "optional types" co-existing. 

This change renames `AddMissingOptionalInput()` and `AddMissingOptionalOutput()` to `AddOptionalInputEdge()` and `AddOptionalOutputEdge()` in the `OpTester` class to help insert optional input/output edges (which are essentially data-less) with explanatory comments. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
