### PR TITLE
Use single builder image across Python versions for ROCm wheels

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -239,14 +239,28 @@ stages:
           Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
           Context: tools/ci_build/github/linux/docker
           DockerBuildArgs: >-
+            --build-arg TORCH_VERSION=1.8.1
             --build-arg INSTALL_DEPS_EXTRA_ARGS=-tmur
             --build-arg BUILD_UID=$(id -u)
             --network=host --build-arg POLICY=manylinux2014 --build-arg PLATFORM=x86_64
             --build-arg DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-9/root 
             --build-arg PREPEND_PATH=/opt/rh/devtoolset-9/root/usr/bin: 
             --build-arg LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-9/root/usr/lib64:/opt/rh/devtoolset-9/root/usr/lib:/opt/rh/devtoolset-9/root/usr/lib64/dyninst:/opt/rh/devtoolset-9/root/usr/lib/dyninst:/usr/local/lib64
-          Repository: onnxruntimetrainingrocmbuild
- 
+          Repository: onnxruntimetrainingrocmbuild-torch1.8.1
+       - template: get-docker-image-steps.yml
+        parameters:
+          Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
+          Context: tools/ci_build/github/linux/docker
+          DockerBuildArgs: >-
+            --build-arg TORCH_VERSION=1.9.0
+            --build-arg INSTALL_DEPS_EXTRA_ARGS=-tmur
+            --build-arg BUILD_UID=$(id -u)
+            --network=host --build-arg POLICY=manylinux2014 --build-arg PLATFORM=x86_64
+            --build-arg DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-9/root 
+            --build-arg PREPEND_PATH=/opt/rh/devtoolset-9/root/usr/bin: 
+            --build-arg LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-9/root/usr/lib64:/opt/rh/devtoolset-9/root/usr/lib:/opt/rh/devtoolset-9/root/usr/lib64/dyninst:/opt/rh/devtoolset-9/root/usr/lib/dyninst:/usr/local/lib64
+          Repository: onnxruntimetrainingrocmbuild-torch1.9.0
+
     - job: ROCM_training_wheels
       timeoutInMinutes: 180
       displayName: 'Build ROCm wheels (inside container)'
@@ -303,11 +317,10 @@ stages:
               --volume $(Build.BinariesDirectory):/build \
               --workdir /onnxruntime_src \
               --entrypoint $(PythonManylinuxDir)/bin/python3 \
-              -e NVIDIA_VISIBLE_DEVICES=all \
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
               --user onnxruntimedev \
-              onnxruntimetrainingrocmbuild \
+              onnxruntimetrainingrocmbuild-torch$(TorchVersion) \
                 /onnxruntime_src/tools/ci_build/build.py \
                   --config Release \
                   --use_rocm \
@@ -362,7 +375,7 @@ stages:
             -e NIGHTLY_BUILD \
             -e BUILD_BUILDNUMBER \
             --user onnxruntimedev \
-            onnxruntimetrainingrocmbuild \
+            onnxruntimetrainingrocmbuild-torch$(TorchVersion) \
                /onnxruntime_src/tools/ci_build/github/pai/pai_test_launcher.sh
         displayName: 'Run onnxruntime unit tests (in container)'
       
@@ -385,7 +398,7 @@ stages:
             -e NIGHTLY_BUILD \
             -e BUILD_BUILDNUMBER \
             --user onnxruntimedev \
-            onnxruntimetrainingrocmbuild \
+            onnxruntimetrainingrocmbuild-torch$(TorchVersion) \
               orttraining/tools/ci_test/run_batch_size_test.py \
                 --binary_dir /build/Release \
                 --model_root training_e2e_test_data/models \
@@ -412,7 +425,7 @@ stages:
             -e NIGHTLY_BUILD \
             -e BUILD_BUILDNUMBER \
             --user onnxruntimedev \
-            onnxruntimetrainingrocmbuild \
+            onnxruntimetrainingrocmbuild-torch$(TorchVersion) \
               orttraining/tools/ci_test/run_bert_perf_test.py \
                 --binary_dir /build/Release \
                 --model_root training_e2e_test_data/models \
@@ -440,7 +453,7 @@ stages:
             -e NIGHTLY_BUILD \
             -e BUILD_BUILDNUMBER \
             --user onnxruntimedev \
-            onnxruntimetrainingrocmbuild \
+            onnxruntimetrainingrocmbuild-torch$(TorchVersion) \
               orttraining/tools/ci_test/run_convergence_test.py \
                 --binary_dir /build/Release \
                 --model_root training_e2e_test_data/models \
@@ -479,7 +492,7 @@ stages:
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
               -e PythonManylinuxDir=$(PythonManylinuxdir) \
-              onnxruntimetrainingrocmbuild \
+              onnxruntimetrainingrocmbuild-torch$(TorchVersion) \
                 /onnxruntime_src/tools/ci_build/github/pai/wrap_rocm_python_doc_publisher.sh
           workingDirectory: $(Build.SourcesDirectory)
 

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -247,7 +247,7 @@ stages:
             --build-arg PREPEND_PATH=/opt/rh/devtoolset-9/root/usr/bin: 
             --build-arg LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-9/root/usr/lib64:/opt/rh/devtoolset-9/root/usr/lib:/opt/rh/devtoolset-9/root/usr/lib64/dyninst:/opt/rh/devtoolset-9/root/usr/lib/dyninst:/usr/local/lib64
           Repository: onnxruntimetrainingrocmbuild-torch1.8.1
-       - template: get-docker-image-steps.yml
+      - template: get-docker-image-steps.yml
         parameters:
           Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
           Context: tools/ci_build/github/linux/docker

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -227,12 +227,33 @@ stages:
       - template: clean-agent-build-directory-step.yml
 
   - ${{ if eq(parameters.enable_linux_rocm_training, true) }}:
-    - job: Linux_py_ROCM_Wheels
+    - job: ROCm_build_environment
+      displayName: 'Construct container defining ROCm wheels build environment'
       timeoutInMinutes: 180
       workspace:
         clean: all
       pool: AMD-GPU
-      # pool: Onnxruntime-Linux-GPU
+      steps:
+      - template: set-python-manylinux-variables-step.yml
+      - template: get-docker-image-steps.yml
+        parameters:
+          Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
+          Context: tools/ci_build/github/linux/docker
+          DockerBuildArgs: >-
+            --build-arg INSTALL_DEPS_EXTRA_ARGS=-tmur
+            --build-arg BUILD_UID=$(id -u)
+            --network=host --build-arg POLICY=manylinux2014 --build-arg PLATFORM=x86_64
+            --build-arg DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-9/root 
+            --build-arg PREPEND_PATH=/opt/rh/devtoolset-9/root/usr/bin: 
+            --build-arg LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-9/root/usr/lib64:/opt/rh/devtoolset-9/root/usr/lib:/opt/rh/devtoolset-9/root/usr/lib64/dyninst:/opt/rh/devtoolset-9/root/usr/lib/dyninst:/usr/local/lib64
+          Repository: onnxruntimetrainingrocmbuild
+ 
+    - job: ROCM_training_wheels
+      timeoutInMinutes: 180
+      displayName: 'Build ROCm wheels inside container environment'
+      workspace:
+        clean: all
+      pool: AMD-GPU
       strategy:
         matrix:
           Python36 Torch181:
@@ -266,21 +287,6 @@ stages:
         submodules: recursive
 
       - template: set-python-manylinux-variables-step.yml
-
-      - template: get-docker-image-steps.yml
-        parameters:
-          Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
-          Context: tools/ci_build/github/linux/docker
-          DockerBuildArgs: >-
-            --build-arg TORCH_VERSION=$(TorchVersion)
-            --build-arg PYTHON_VERSION=$(PythonVersion)
-            --build-arg INSTALL_DEPS_EXTRA_ARGS=-tmur
-            --build-arg BUILD_UID=$(id -u)
-            --network=host --build-arg POLICY=manylinux2014 --build-arg PLATFORM=x86_64
-            --build-arg DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-9/root 
-            --build-arg PREPEND_PATH=/opt/rh/devtoolset-9/root/usr/bin: 
-            --build-arg LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-9/root/usr/lib64:/opt/rh/devtoolset-9/root/usr/lib:/opt/rh/devtoolset-9/root/usr/lib64/dyninst:/opt/rh/devtoolset-9/root/usr/lib/dyninst:/usr/local/lib64
-          Repository: onnxruntimetrainingrocmbuild
 
       - task: CmdLine@2
         inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -247,7 +247,6 @@ stages:
             --build-arg PREPEND_PATH=/opt/rh/devtoolset-9/root/usr/bin: 
             --build-arg LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-9/root/usr/lib64:/opt/rh/devtoolset-9/root/usr/lib:/opt/rh/devtoolset-9/root/usr/lib64/dyninst:/opt/rh/devtoolset-9/root/usr/lib/dyninst:/usr/local/lib64
           Repository: onnxruntimetrainingrocmbuild
-        displayName: 'Create or fetch image defining ROCm build environment'
  
     - job: ROCM_training_wheels
       timeoutInMinutes: 180

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -228,7 +228,7 @@ stages:
 
   - ${{ if eq(parameters.enable_linux_rocm_training, true) }}:
     - job: ROCm_build_environment
-      displayName: 'Construct container defining ROCm wheels build environment'
+      displayName: 'Construct ROCm wheels environment'
       timeoutInMinutes: 180
       workspace:
         clean: all
@@ -247,13 +247,16 @@ stages:
             --build-arg PREPEND_PATH=/opt/rh/devtoolset-9/root/usr/bin: 
             --build-arg LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-9/root/usr/lib64:/opt/rh/devtoolset-9/root/usr/lib:/opt/rh/devtoolset-9/root/usr/lib64/dyninst:/opt/rh/devtoolset-9/root/usr/lib/dyninst:/usr/local/lib64
           Repository: onnxruntimetrainingrocmbuild
+        displayName: 'Create or fetch image defining ROCm build environment'
  
     - job: ROCM_training_wheels
       timeoutInMinutes: 180
-      displayName: 'Build ROCm wheels inside container environment'
+      displayName: 'Build ROCm wheels (inside container)'
       workspace:
         clean: all
       pool: AMD-GPU
+      dependsOn: 
+      - ROCm_build_environment
       strategy:
         matrix:
           Python36 Torch181:

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -234,7 +234,6 @@ stages:
         clean: all
       pool: AMD-GPU
       steps:
-      - template: set-python-manylinux-variables-step.yml
       - template: get-docker-image-steps.yml
         parameters:
           Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
@@ -179,7 +179,14 @@ ADD scripts /tmp/scripts
 RUN cd /tmp/scripts && \
     /tmp/scripts/manylinux/install_centos.sh && \
     /tmp/scripts/install_os_deps.sh -d gpu $INSTALL_DEPS_EXTRA_ARGS && \
-    /tmp/scripts/install_python_deps.sh -d gpu -p $PYTHON_VERSION -h $TORCH_VERSION $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_python_deps.sh -d gpu -p 3.6 -h 1.8.1 $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_python_deps.sh -d gpu -p 3.7 -h 1.8.1 $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_python_deps.sh -d gpu -p 3.8 -h 1.8.1 $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_python_deps.sh -d gpu -p 3.9 -h 1.8.1 $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_python_deps.sh -d gpu -p 3.6 -h 1.9.0 $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_python_deps.sh -d gpu -p 3.7 -h 1.9.0 $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_python_deps.sh -d gpu -p 3.8 -h 1.9.0 $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_python_deps.sh -d gpu -p 3.9 -h 1.9.0 $INSTALL_DEPS_EXTRA_ARGS && \
     rm -rf /tmp/scripts
 
 ARG BUILD_UID=1001

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
@@ -183,7 +183,7 @@ RUN cd /tmp/scripts && \
     /tmp/scripts/install_python_deps.sh -d gpu -p 3.7 -h ${TORCH_VERSION} $INSTALL_DEPS_EXTRA_ARGS && \
     /tmp/scripts/install_python_deps.sh -d gpu -p 3.8 -h ${TORCH_VERSION} $INSTALL_DEPS_EXTRA_ARGS && \
     /tmp/scripts/install_python_deps.sh -d gpu -p 3.9 -h ${TORCH_VERSION} $INSTALL_DEPS_EXTRA_ARGS && \
-    rm -rf /tmp/scripts
+     rm -rf /tmp/scripts
 
 ARG BUILD_UID=1001
 ARG BUILD_USER=onnxruntimedev

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
@@ -179,14 +179,10 @@ ADD scripts /tmp/scripts
 RUN cd /tmp/scripts && \
     /tmp/scripts/manylinux/install_centos.sh && \
     /tmp/scripts/install_os_deps.sh -d gpu $INSTALL_DEPS_EXTRA_ARGS && \
-    /tmp/scripts/install_python_deps.sh -d gpu -p 3.6 -h 1.8.1 $INSTALL_DEPS_EXTRA_ARGS && \
-    /tmp/scripts/install_python_deps.sh -d gpu -p 3.7 -h 1.8.1 $INSTALL_DEPS_EXTRA_ARGS && \
-    /tmp/scripts/install_python_deps.sh -d gpu -p 3.8 -h 1.8.1 $INSTALL_DEPS_EXTRA_ARGS && \
-    /tmp/scripts/install_python_deps.sh -d gpu -p 3.9 -h 1.8.1 $INSTALL_DEPS_EXTRA_ARGS && \
-    /tmp/scripts/install_python_deps.sh -d gpu -p 3.6 -h 1.9.0 $INSTALL_DEPS_EXTRA_ARGS && \
-    /tmp/scripts/install_python_deps.sh -d gpu -p 3.7 -h 1.9.0 $INSTALL_DEPS_EXTRA_ARGS && \
-    /tmp/scripts/install_python_deps.sh -d gpu -p 3.8 -h 1.9.0 $INSTALL_DEPS_EXTRA_ARGS && \
-    /tmp/scripts/install_python_deps.sh -d gpu -p 3.9 -h 1.9.0 $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_python_deps.sh -d gpu -p 3.6 -h ${TORCH_VERSION} $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_python_deps.sh -d gpu -p 3.7 -h ${TORCH_VERSION} $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_python_deps.sh -d gpu -p 3.8 -h ${TORCH_VERSION} $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_python_deps.sh -d gpu -p 3.9 -h ${TORCH_VERSION} $INSTALL_DEPS_EXTRA_ARGS && \
     rm -rf /tmp/scripts
 
 ARG BUILD_UID=1001

--- a/tools/ci_build/github/linux/docker/scripts/install_python_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_python_deps.sh
@@ -61,13 +61,14 @@ if [ $DEVICE_TYPE = "gpu" ]; then
       else
         ${PYTHON_EXE} -m pip install -r ${0/%install_python_deps.sh/training\/ortmodule\/stage1\/requirements-torch${TORCH_VERSION}_rocm.txt}
         ${PYTHON_EXE} -m pip install fairscale
+	# remove DeepSpeed until it's required for testing purposes
 	# remove triton requirement from getting triggered in requirements-sparse_attn.txt
-        git clone https://github.com/ROCmSoftwarePlatform/DeepSpeed
-        cd DeepSpeed &&\
-          rm requirements/requirements-sparse_attn.txt &&\
-          ${PYTHON_EXE} setup.py bdist_wheel &&\
-          ${PYTHON_EXE} -m pip install dist/deepspeed*.whl &&\
-	  cd .. && rm -fr DeepSpeed
+        # git clone https://github.com/ROCmSoftwarePlatform/DeepSpeed
+        # cd DeepSpeed &&\
+        #   rm requirements/requirements-sparse_attn.txt &&\
+        #   ${PYTHON_EXE} setup.py bdist_wheel &&\
+        #   ${PYTHON_EXE} -m pip install dist/deepspeed*.whl &&\
+ 	#   cd .. && rm -fr DeepSpeed
       fi
     fi
   fi

--- a/tools/ci_build/github/linux/docker/scripts/install_python_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_python_deps.sh
@@ -61,13 +61,13 @@ if [ $DEVICE_TYPE = "gpu" ]; then
       else
         ${PYTHON_EXE} -m pip install -r ${0/%install_python_deps.sh/training\/ortmodule\/stage1\/requirements-torch${TORCH_VERSION}_rocm.txt}
         ${PYTHON_EXE} -m pip install fairscale
-	      # remove triton requirement from getting triggered in requirements-sparse_attn.txt
+	# remove triton requirement from getting triggered in requirements-sparse_attn.txt
         git clone https://github.com/ROCmSoftwarePlatform/DeepSpeed
         cd DeepSpeed &&\
           rm requirements/requirements-sparse_attn.txt &&\
           ${PYTHON_EXE} setup.py bdist_wheel &&\
           ${PYTHON_EXE} -m pip install dist/deepspeed*.whl &&\
-	      cd ..
+	  cd .. && rm -fr DeepSpeed
       fi
     fi
   fi

--- a/tools/ci_build/github/linux/docker/scripts/install_python_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_python_deps.sh
@@ -59,9 +59,6 @@ if [ $DEVICE_TYPE = "gpu" ]; then
         # Due to a [bug on DeepSpeed](https://github.com/microsoft/DeepSpeed/issues/663), we install it separately through ortmodule/stage2/requirements.txt
         ${PYTHON_EXE} -m pip install -r ${0/%install_python_deps.sh/training\/ortmodule\/stage2\/requirements.txt}
       else
-        ${PYTHON_EXE} -m pip install \
-          --pre -f https://download.pytorch.org/whl/nightly/rocm4.2/torch_nightly.html \
-          torch torchvision torchtext
         ${PYTHON_EXE} -m pip install -r ${0/%install_python_deps.sh/training\/ortmodule\/stage1\/requirements-torch${TORCH_VERSION}_rocm.txt}
         ${PYTHON_EXE} -m pip install fairscale
 	      # remove triton requirement from getting triggered in requirements-sparse_attn.txt

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements-torch1.8.1_rocm.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements-torch1.8.1_rocm.txt
@@ -1,9 +1,7 @@
 # transformers requires sklearn
 --pre
--f https://download.pytorch.org/whl/torch_stable.html
-torch==1.8.1+cu111
-torchvision==0.9.1+cu111
-torchtext==0.9.1
+-f https://download.pytorch.org/whl/rocm4.2/torch_stable.html
+torch==1.8.1
 pandas
 sklearn
 numpy==1.19.5

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements-torch1.9.0_rocm.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements-torch1.9.0_rocm.txt
@@ -1,9 +1,7 @@
 # transformers requires sklearn
 --pre
--f https://download.pytorch.org/whl/torch_stable.html
-torch==1.9.0+cu111
-torchvision==0.10.0+cu111
-torchtext==0.10.0
+-f https://download.pytorch.org/whl/rocm4.2/torch_stable.html
+torch==1.9.0
 pandas
 sklearn
 numpy==1.19.5


### PR DESCRIPTION
- Creating a build image for each Python version is wasteful and leads to race conditions
- Also fix incorrect dependencies in ROCm Python requirements file

Passing build:
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=434600&view=results