### PR TITLE
Pinning pillow version to 8.2.0 to circumvent regression introduced by 8.3.0

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements-torch1.9.0_rocm.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements-torch1.9.0_rocm.txt
@@ -1,3 +1,5 @@
+# TODO: Remove pinned version of Pillow of 8.2.0 when 8.3.0 release regression issue https://github.com/python-pillow/Pillow/issues/5571 is resolved
+Pillow==8.2.0
 # transformers requires sklearn
 --pre
 -f https://download.pytorch.org/whl/torch_stable.html

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.9.0_cu10.2.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.9.0_cu10.2.txt
@@ -1,3 +1,5 @@
+# TODO: Remove pinned version of Pillow of 8.2.0 when 8.3.0 release regression issue https://github.com/python-pillow/Pillow/issues/5571 is resolved
+Pillow==8.2.0
 --pre
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.9.0+cu102


### PR DESCRIPTION
Pull request #8278 addresses the problem for pipeline torch 1.9.0+cu11.1. This PR addresses the problem in pipelines torch1.9.0+cu10.2.