### PR TITLE
Drop unused functions from math.h

### DIFF
--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_conv.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_conv.h
@@ -10,18 +10,6 @@
 namespace onnxruntime {
 namespace ort_dnnl {
 
-namespace {
-
-// Rounds a up to the next highest multiple of b, which is power-of-2. User must be careful
-// to ensure that there is no overflow or underflow in the calculation
-// of divUp.
-template <typename T, T b>
-constexpr T roundUpPow2(T a) {
-  return (a + (b - 1)) & (~(b - 1));
-}
-
-}  // namespace
-
 // helper function
 template <bool ForceSymmetricAutoPadding>
 Status ComputePadAndOutputShape(
@@ -54,7 +42,7 @@ Status ComputePadAndOutputShape(
         // make sure padding is symmetric
         if (ForceSymmetricAutoPadding) {
           // Round up to the next highest multiple of b, which is power-of-2.
-          pad_needed = (pad_needed + (2 - 1)) & (~(2 - 1))
+          pad_needed = (pad_needed + (2 - 1)) & (~(2 - 1));
         }
 
         if (pad_type == AutoPadType::SAME_LOWER) {

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_conv.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_conv.h
@@ -10,6 +10,18 @@
 namespace onnxruntime {
 namespace ort_dnnl {
 
+namespace {
+
+// Rounds a up to the next highest multiple of b, which is power-of-2. User must be careful
+// to ensure that there is no overflow or underflow in the calculation
+// of divUp.
+template <typename T, T b>
+constexpr T roundUpPow2(T a) {
+  return (a + (b - 1)) & (~(b - 1));
+}
+
+}  // namespace
+
 // helper function
 template <bool ForceSymmetricAutoPadding>
 Status ComputePadAndOutputShape(
@@ -40,8 +52,10 @@ Status ComputePadAndOutputShape(
         *out_dim = (in_dim + pad_needed - dkernel) / stride + 1;
 
         // make sure padding is symmetric
-        if (ForceSymmetricAutoPadding)
-          pad_needed = math::roundUpPow2<int64_t, 2>(pad_needed);
+        if (ForceSymmetricAutoPadding) {
+          // Round up to the next highest multiple of b, which is power-of-2.
+          pad_needed = (pad_needed + (2 - 1)) & (~(2 - 1))
+        }
 
         if (pad_type == AutoPadType::SAME_LOWER) {
           *pad_head = (pad_needed + 1) / 2;

--- a/onnxruntime/core/util/math.h
+++ b/onnxruntime/core/util/math.h
@@ -349,43 +349,13 @@ constexpr T roundUp(T a, T b) {
   return divUp<T>(a, b) * b;
 }
 
-// Returns true if the given integer type is a power-of-2 (positive only)
-// Note(jiayq): windows reported an error per
-//     https://github.com/caffe2/caffe2/issues/997
-// and as a result will make it a macro.
-#ifdef _MSC_VER
-#define integerIsPowerOf2(v) ((v) && !((v) & ((v)-1)))
-#else   // _MSC_VER
-template <typename T>
-constexpr bool integerIsPowerOf2(T v) {
-  return (v && !(v & (v - 1)));
-}
-#endif  // _MSC_VER
-
-// Returns log2(n) for a positive integer type
-template <typename T>
-constexpr int integerLog2(T n, int p = 0) {
-  return (n <= 1) ? p : integerLog2(n / 2, p + 1);
-}
-
-// Returns the next highest power-of-2 for an integer type
-template <typename T>
-constexpr T integerNextHighestPowerOf2(T v) {
-  return (integerIsPowerOf2(v) ? (T)2 * v : ((T)1 << (integerLog2(v) + 1)));
-}
-
-// Rounds a up to the next highest multiple of b, which is power-of-2. User must be careful
-// to ensure that there is no overflow or underflow in the calculation
-// of divUp.
-template <typename T, T b>
-constexpr T roundUpPow2(T a) {
-  return (a + (b - 1)) & (~(b - 1));
-}
-
+// Converts a float32 to a float16 value.
 uint16_t floatToHalf(float f);
 
+// Converts a double (float64) to a float16 value.
 uint16_t doubleToHalf(double f);
 
+// Converts a float16 to a float32 value.
 float halfToFloat(uint16_t h);
 
 }  // namespace math


### PR DESCRIPTION
I've noticed that various quantization and math code is spread out throughout the codebase. This PR is part of some cleanup I'm doing while writing new quantized kernels. No logic changes - simply tidying up a bit.