### PR TITLE
[WIP] Make Inference/TrainingAgents accept torch tensors

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
+++ b/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
@@ -5,7 +5,7 @@
 import onnxruntime
 from onnxruntime.capi import _pybind_state as C
 from onnxruntime.capi.onnxruntime_inference_collection import IOBinding, get_ort_device_type
-from onnxruntime.capi._pybind_state import TrainingAgent as C_TrainingAgent
+from onnxruntime.capi._pybind_state import TrainingAgent as C_TrainingAgent, GraphInfo
 
 from . import _utils
 from ._graph_execution_manager import RunStateInfo

--- a/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
+++ b/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
@@ -73,7 +73,7 @@ class InferenceAgent(ExecutionAgent):
 
         return IOBinding(self._inference_session)
 
-    def _prepare_inputs(self, inputs):
+    def _process_inputs(self, inputs):
         """Runs the forward graph on execution_session with given model inputs and device"""
 
         # Assert that the input and model device match
@@ -117,7 +117,7 @@ class InferenceAgent(ExecutionAgent):
 
     def forward(self, *inputs):
         run_options = C.RunOptions()
-        io_binding = self._prepare_inputs(inputs)
+        io_binding = self._process_inputs(inputs)
 
         # Run and return module outputs.
         ort_output = self._run_forward(io_binding, run_options)
@@ -182,7 +182,7 @@ class TrainingAgent(ExecutionAgent):
 
 
 
-    def _prepare_forward_inputs(self, inputs):
+    def _process_forward_inputs(self, inputs):
         """ Prepare feeds from torch tensors """
 
         # Assert that the input and model device match
@@ -208,14 +208,14 @@ class TrainingAgent(ExecutionAgent):
 
 
     def forward(self, *inputs):
-        feeds = self._prepare_forward_inputs(inputs)
+        feeds = self._process_forward_inputs(inputs)
         fetches = C.OrtValueVector()
         state = C.PartialGraphExecutionState()
         self._training_agent.run_forward(feeds, fetches, state)
         return self._process_forward_outputs(fetches, state)
 
 
-    def _prepare_backward_inputs(self, ctx, grad_outputs):
+    def _process_backward_inputs(self, ctx, grad_outputs):
         _utils._check_same_device(self._device, "Input argument to backward", *grad_outputs)
 
         # Use IO binding
@@ -254,7 +254,7 @@ class TrainingAgent(ExecutionAgent):
 
 
     def backward(self, ctx, *grad_outputs):
-        backward_inputs = self._prepare_backward_inputs(ctx, grad_outputs)
+        backward_inputs = self._process_backward_inputs(ctx, grad_outputs)
         # Run and get results
         backward_outputs = C.OrtValueVector()
         self._training_agent.run_backward(backward_inputs, backward_outputs, ctx.run_info.state)

--- a/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
+++ b/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
@@ -215,7 +215,7 @@ class TrainingAgent(ExecutionAgent):
         return self._process_forward_outputs(fetches, state)
 
 
-    def _process_backward_inputs(self, ctx, grad_outputs):
+    def _process_backward_inputs(self, run_info, grad_outputs):
         _utils._check_same_device(self._device, "Input argument to backward", *grad_outputs)
 
         # Use IO binding
@@ -233,7 +233,7 @@ class TrainingAgent(ExecutionAgent):
                 continue
 
             if grad_output is None:
-                shape, device, dtype = ctx.run_info.output_info[idx]
+                shape, device, dtype = run_info.output_info[idx]
                 if idx in self._graph_info.output_grad_indices_require_full_shape:
                     grad_output = torch.zeros(shape, device=device, dtype=dtype)
                 else:
@@ -253,9 +253,9 @@ class TrainingAgent(ExecutionAgent):
         ]
 
 
-    def backward(self, ctx, *grad_outputs):
-        backward_inputs = self._process_backward_inputs(ctx, grad_outputs)
+    def backward(self, run_info, *grad_outputs):
+        backward_inputs = self._process_backward_inputs(run_info, grad_outputs)
         # Run and get results
         backward_outputs = C.OrtValueVector()
-        self._training_agent.run_backward(backward_inputs, backward_outputs, ctx.run_info.state)
+        self._training_agent.run_backward(backward_inputs, backward_outputs, run_info.state)
         return self._process_backward_outputs(backward_outputs)

--- a/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
+++ b/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
@@ -208,6 +208,9 @@ class TrainingAgent(ExecutionAgent):
 
         The list of providers is ordered by precedence. For example ['CUDAExecutionProvider', 'CPUExecutionProvider']
         means execute a node using CUDAExecutionProvider if capable, otherwise execute using CPUExecutionProvider.
+
+       Raises:
+            YieldOpNotFound: when the model doesn't have a YieldOp node        
         """
         super().__init__(onnx_model, device)
         self._info = YieldOpInfo.from_training_model(onnx_model)

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -25,32 +25,6 @@ class TrainingManager(GraphExecutionManager):
         super().__init__(model)
         self._export_mode = torch.onnx.TrainingMode.TRAINING
 
-    @staticmethod
-    def execution_session_run_forward(execution_session, onnx_model, device, *inputs):
-        """Runs the forward graph on execution_session with given model inputs and device"""
-
-        # Assert that the input and model device match
-        _utils._check_same_device(device, "Input argument to forward", *inputs)
-
-        # TODO: Try to reuse the output buffers as some of the output tensors are same sizes,
-        #   especially the backward graph outputs.
-        # REVIEW(codemzs): Consolidate Training Agent with InferenceAgent on C++ side to not
-        # have the need for passing IOBinding.
-        state = C.PartialGraphExecutionState()
-        forward_inputs = C.OrtValueVector()
-        forward_inputs.reserve(len(inputs))
-        for input in inputs:
-            forward_inputs.push_back(to_dlpack(input), input.dtype == torch.bool)
-
-        forward_outputs = C.OrtValueVector()
-        # Run and return module outputs.
-        execution_session.run_forward(forward_inputs, forward_outputs, state)
-        user_outputs = tuple(_utils._ortvalue_to_torch_tensor(forward_output) for forward_output in forward_outputs)
-
-        output_info = [(output.shape, output.device, output.dtype) for output in user_outputs]
-        run_info = RunStateInfo(state, output_info)
-        # Return user outputs and forward run information
-        return user_outputs, run_info
 
     def forward(self, *inputs, **kwargs):
         '''Forward pass starts here and continues at `_ORTModuleFunction.forward`
@@ -106,10 +80,7 @@ class TrainingManager(GraphExecutionManager):
                 Module outputs are returned to the user
                 '''
 
-                user_outputs, ctx.run_info = TrainingManager.execution_session_run_forward(self._execution_agent,
-                                                                                           self._optimized_onnx_model,
-                                                                                           self._device,
-                                                                                           *inputs)
+                user_outputs, ctx.run_info = self._execution_agent.forward(*inputs)
 
                 # Disable materializing grads then None object will not be
                 # converted to a tensor filled with zeros prior to calling backward.
@@ -130,39 +101,12 @@ class TrainingManager(GraphExecutionManager):
                 '''Performs backward pass based on grad wrt module output'''
 
                 assert ctx.run_info is not None, 'forward() or __call__() methods must be called before backward()'
-                _utils._check_same_device(self._device, "Input argument to backward", *grad_outputs)
 
                 # Unpack saved_tensor to trigger version detection that catches inplace corruption
                 _ = ctx.saved_tensors
 
-                # Use IO binding
-                # Push user output grads to ONNX backend.
-                backward_inputs = C.OrtValueVector()
-                # Preallocate length of the vector. And then delete as required towards the end.
-                backward_inputs.reserve(len(grad_outputs))
-                for idx, grad_output in enumerate(grad_outputs):
-                    if idx in self._graph_info.output_grad_indices_non_differentiable:
-                        assert grad_output is None, "ORT found the {}-th module output '{}' is " \
-                                                    "non-differentiable according to the onnx graph. " \
-                                                    "However, the gradient value is still provided by " \
-                                                    "PyTorch's autograd engine." \
-                                                    .format(idx, self._graph_info.user_output_names[idx])
-                        continue
+                backward_outputs = self._execution_agent.backward(ctx, *grad_outputs)
 
-                    if grad_output is None:
-                        shape, device, dtype = ctx.run_info.output_info[idx]
-                        if idx in self._graph_info.output_grad_indices_require_full_shape:
-                            grad_output = torch.zeros(shape, device=device, dtype=dtype)
-                        else:
-                            grad_output = torch.tensor(0., device=device, dtype=dtype)
-                    elif not grad_output.is_contiguous():
-                        grad_output = grad_output.contiguous()
-                    backward_inputs.push_back(to_dlpack(grad_output), grad_output.dtype == torch.bool)
-                backward_inputs.shrink_to_fit()
-
-                # Run and get results
-                backward_outputs = C.OrtValueVector()
-                self._execution_agent.run_backward(backward_inputs, backward_outputs, ctx.run_info.state)
                 # Destroy the state immediately (as opposed to be at the mercy of garbage collector) so it does not
                 # affect peak memory usage in a subsequent graph run.
                 del ctx.run_info.state
@@ -174,9 +118,7 @@ class TrainingManager(GraphExecutionManager):
                 for input_name in self._graph_info.user_input_names:
                     # Append to the results the backward output for each input that required grad
                     if input_name in require_grad_names_set:
-                        results.append(_utils._torch_tensor_from_dl_pack(
-                            backward_outputs.dlpack_at(require_grad_names_index),
-                            backward_outputs[require_grad_names_index]))
+                        results.append(backward_outputs[require_grad_names_index])
                         require_grad_names_index += 1
                     else:
                         # input_name is not found in the self._input_info.require_grad_names list
@@ -188,9 +130,7 @@ class TrainingManager(GraphExecutionManager):
                 initializer_index = num_user_input_grads
                 for initializer_name in self._graph_info.initializer_names:
                     if initializer_name in self._graph_initializer_names_to_train:
-                        results.append(_utils._torch_tensor_from_dl_pack(
-                            backward_outputs.dlpack_at(initializer_index),
-                            backward_outputs[initializer_index]))
+                        results.append(backward_outputs[initializer_index])
                         initializer_index += 1
                     else:
                         results.append(None)
@@ -222,25 +162,9 @@ class TrainingManager(GraphExecutionManager):
         """Creates a TrainingAgent that can run the forward and backward graph on the training model"""
 
         session_options, providers, provider_options = self._get_session_config()
-        fw_feed_names = [input.name for input in self._optimized_onnx_model.graph.input]
-        fw_outputs_device_info = [
-            C.OrtDevice(get_ort_device_type(self._device.type),
-                        C.OrtDevice.default_memory(),
-                        _utils.get_device_index(self._device)
-            )] * len(self._graph_info.user_output_names)
-
-        bw_fetches_names = [output.name for output in self._optimized_onnx_model.graph.output]
-        bw_outputs_device_info = [
-            C.OrtDevice(get_ort_device_type(self._device.type),
-                        C.OrtDevice.default_memory(),
-                        _utils.get_device_index(self._device)
-            )] * len(bw_fetches_names)
-
-        self._execution_agent = TrainingAgent(self._optimized_onnx_model.SerializeToString(),
-                                              fw_feed_names,
-                                              fw_outputs_device_info,
-                                              bw_fetches_names,
-                                              bw_outputs_device_info,
+        self._execution_agent = TrainingAgent(self._optimized_onnx_model,
+                                              self._device,
+                                              self._graph_info,
                                               session_options,
                                               providers,
                                               provider_options)

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -124,7 +124,7 @@ class TrainingManager(GraphExecutionManager):
                         # input_name is not found in the self._input_info.require_grad_names list
                         # Append None to results for each input that did not require grad
                         results.append(None)
-
+                assert require_grad_names_index == num_user_input_grads
                 # Append gradients of initializer to results
                 # Go over each initializer, check if it required grad and append to results accordingly
                 initializer_index = num_user_input_grads
@@ -134,7 +134,7 @@ class TrainingManager(GraphExecutionManager):
                         initializer_index += 1
                     else:
                         results.append(None)
-
+                assert initializer_index == len(backward_outputs)
                 return tuple(results)
 
         return _io.unflatten_user_output(self._module_output_schema,
@@ -164,7 +164,6 @@ class TrainingManager(GraphExecutionManager):
         session_options, providers, provider_options = self._get_session_config()
         self._execution_agent = TrainingAgent(self._optimized_onnx_model,
                                               self._device,
-                                              self._graph_info,
                                               session_options,
                                               providers,
                                               provider_options)

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -105,7 +105,7 @@ class TrainingManager(GraphExecutionManager):
                 # Unpack saved_tensor to trigger version detection that catches inplace corruption
                 _ = ctx.saved_tensors
 
-                backward_outputs = self._execution_agent.backward(ctx, *grad_outputs)
+                backward_outputs = self._execution_agent.backward(ctx.run_info, *grad_outputs)
 
                 # Destroy the state immediately (as opposed to be at the mercy of garbage collector) so it does not
                 # affect peak memory usage in a subsequent graph run.

--- a/orttraining/orttraining/test/python/orttraining_ortmodule_tests.py
+++ b/orttraining/orttraining/test/python/orttraining_ortmodule_tests.py
@@ -85,6 +85,13 @@ def run_ortmodule_custom_autograd_tests(cwd, log):
 
     run_subprocess(command, cwd=cwd, log=log).check_returncode()
 
+def run_ortmodule_execution_agent_tests(cwd, log):
+    log.debug('Running: ORTModule-InferenceAgent/TrainingAgent tests')
+
+    command = [sys.executable, '-m', 'pytest', '-sv', 'orttraining_test_ortmodule_execution_agents.py']
+
+    run_subprocess(command, cwd=cwd, log=log).check_returncode()
+
 
 
 def main():
@@ -111,6 +118,8 @@ def main():
     # TODO: enable this once the PyTorch used for testing meets the requirements running
     # auto grad testing.
     #run_ortmodule_custom_autograd_tests(cwd, log)
+
+    run_ortmodule_execution_agent_tests(cwd, log)
     return 0
 
 

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_execution_agents.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_execution_agents.py
@@ -9,7 +9,6 @@ import onnxruntime
 from onnxruntime.training.ortmodule._execution_agent import (
     InferenceAgent,
     TrainingAgent,
-    GraphInfo,
 )
 
 
@@ -96,18 +95,7 @@ def test_onnx_graph_forward():
 
 def test_onnx_graph_forward_backward():
     model = make_training_model()
-    graph_info = GraphInfo()
-    graph_info.user_input_names = ["x", "y"]
-    graph_info.user_input_grad_names = {"x": "x_grad", "y": "y_grad"}
-    graph_info.initializer_names = ["bias"]
-    graph_info.initializer_names_to_train = ["bias"]
-    graph_info.user_output_names = ["add"]
-    graph_info.output_grad_indices_non_differentiable = []
-    graph_info.output_grad_indices_require_full_shape = [0]
-    graph_info.module_output_indices_requires_save_for_backward = []
-    training_agent = execution_agent_factory(TrainingAgent)(
-        model, torch.device("cpu"), graph_info
-    )
+    training_agent = execution_agent_factory(TrainingAgent)(model, torch.device("cpu"))
     x = torch.randn(2, 3)
     y = torch.randn(2, 3)
     bias = torch.randn(3)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_execution_agents.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_execution_agents.py
@@ -1,0 +1,124 @@
+import numpy as np
+from onnx import TensorProto
+from onnx import helper
+
+import torch
+
+import onnxruntime
+
+from onnxruntime.training.ortmodule._execution_agent import (
+    InferenceAgent,
+    TrainingAgent,
+    GraphInfo,
+)
+
+
+def make_inference_model():
+    inputs = [
+        helper.make_tensor_value_info("x", TensorProto.FLOAT, [2, 3]),
+        helper.make_tensor_value_info("y", TensorProto.FLOAT, [2, 3]),
+        helper.make_tensor_value_info("bias", TensorProto.FLOAT, [3]),
+    ]
+    mul_node = helper.make_node("Mul", ["x", "y"], ["mul"])
+    add_node = helper.make_node("Add", ["mul", "bias"], ["add"])
+    outputs = [helper.make_tensor_value_info("add", TensorProto.FLOAT, [2, 3])]
+    graph_def = helper.make_graph([mul_node, add_node], "graph", inputs, outputs)
+    return helper.make_model(graph_def)
+
+
+def make_training_model():
+    inputs = [
+        helper.make_tensor_value_info("x", TensorProto.FLOAT, [2, 3]),
+        helper.make_tensor_value_info("y", TensorProto.FLOAT, [2, 3]),
+        helper.make_tensor_value_info("bias", TensorProto.FLOAT, [3]),
+    ]
+    mul_node = helper.make_node("Mul", ["x", "y"], ["mul"])
+    add_node = helper.make_node("Add", ["mul", "bias"], ["add"])
+    yield_node = helper.make_node(
+        "YieldOp", ["add"], ["add_grad"], full_shape_outputs=[0], domain="com.microsoft"
+    )
+    x_grad_node = helper.make_node("Mul", ["add_grad", "y"], ["x_grad"])
+    y_grad_node = helper.make_node("Mul", ["x", "add_grad"], ["y_grad"])
+    axes_tensor = helper.make_tensor("axes", TensorProto.INT64, [1], [0])
+    bias_grad_node = helper.make_node(
+        "ReduceSum", ["add_grad", "axes"], ["bias_grad"], keepdims=0
+    )
+    outputs = [
+        helper.make_tensor_value_info("x_grad", TensorProto.FLOAT, [2, 3]),
+        helper.make_tensor_value_info("y_grad", TensorProto.FLOAT, [2, 3]),
+        helper.make_tensor_value_info("bias_grad", TensorProto.FLOAT, [3]),
+    ]
+    graph_def = helper.make_graph(
+        [mul_node, add_node, yield_node, x_grad_node, y_grad_node, bias_grad_node],
+        "graph",
+        inputs,
+        outputs,
+        initializer=[axes_tensor],
+    )
+    return helper.make_model(graph_def)
+
+
+def assert_tensors_allclose(*args, **kwargs):
+    assert len(args) == 2
+    args = [t.detach().numpy() if isinstance(t, torch.Tensor) else t for t in args]
+    np.testing.assert_allclose(*args, **kwargs)
+
+
+def execution_agent_factory(cls):
+    session_options = onnxruntime.SessionOptions()
+    providers = ["CPUExecutionProvider"]
+    provider_options = [{}]
+
+    def body(*args, **kwargs):
+        return cls(
+            *args,
+            session_options=session_options,
+            providers=providers,
+            provider_options=provider_options,
+            **kwargs
+        )
+
+    return body
+
+
+def test_onnx_graph_forward():
+    model = make_inference_model()
+    inference_agent = execution_agent_factory(InferenceAgent)(
+        model, torch.device("cpu")
+    )
+    x = torch.randn(2, 3)
+    y = torch.randn(2, 3)
+    bias = torch.randn(3)
+    expected_output = x * y + bias
+    outputs, _ = inference_agent.forward(x, y, bias)
+    assert_tensors_allclose(outputs[0], expected_output)
+
+
+def test_onnx_graph_forward_backward():
+    model = make_training_model()
+    graph_info = GraphInfo()
+    graph_info.user_input_names = ["x", "y"]
+    graph_info.user_input_grad_names = {"x": "x_grad", "y": "y_grad"}
+    graph_info.initializer_names = ["bias"]
+    graph_info.initializer_names_to_train = ["bias"]
+    graph_info.user_output_names = ["add"]
+    graph_info.output_grad_indices_non_differentiable = []
+    graph_info.output_grad_indices_require_full_shape = [0]
+    graph_info.module_output_indices_requires_save_for_backward = []
+    training_agent = execution_agent_factory(TrainingAgent)(
+        model, torch.device("cpu"), graph_info
+    )
+    x = torch.randn(2, 3)
+    y = torch.randn(2, 3)
+    bias = torch.randn(3)
+    x.requires_grad = y.requires_grad = bias.requires_grad = True
+    expected_output = x * y + bias
+    add_grad = torch.randn(2, 3)
+    expected_output.backward(add_grad)
+    expected_grads = [x.grad.clone(), y.grad.clone(), bias.grad.clone()]
+    x.grad = y.grad = bias.grad = None
+    outputs, run_info = training_agent.forward(x, y, bias)
+    grads = training_agent.backward(run_info, add_grad)
+    assert_tensors_allclose(outputs[0], expected_output)
+    for grad, expected_grad in zip(grads, expected_grads):
+        assert_tensors_allclose(grad, expected_grad)


### PR DESCRIPTION
**Description**: This PR is an attempt to make the separation of responsibilities between Inference/TrainingManagers and Inference/TrainingAgents clearer.

In the proposed change, Inference/TrainingManagers are responsible for mapping the torch module parameters, buffers, inputs and outputs to onnx model initializers, inputs and outputs. However it does not perform any data type conversion.

On the other hand, Inference/TrainingAgents are responsible for converting data type between torch tensors and ORTValues.

This PR removes the possibility to pass a path to an onnx file when we construct Inference/TrainingAgents but I believe that is minor because it is easy to load the file first and then pass the model to the constructor. Other than that the PR should not change any behavior.

**Motivation and Context**
- Why is this change required? What problem does it solve? This change allows users to wrap arbitrary ONNX model in Inference/TrainingAgents. For example,
```python
import onnx
import torch
model = onnx.load_model("my_model.onnx")
device = torch.device("cpu")
agent = InferenceAgent(model, device)
inputs = [torch.randn(16, 784)]
outputs, run_info = agent.forward(*inputs)
```
- If it fixes an open issue, please link to the issue here.
