### PR TITLE
[iOS] Packaging pipeline improvements.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
@@ -32,13 +32,20 @@ jobs:
         VERSION="${BASE_VERSION}-dev"
       fi
 
-      echo "##vso[task.setvariable variable=ORT_POD_VERSION]${VERSION}"
-      echo "Version number: ${VERSION}"
-    displayName: "Set version number"
+      set_var() {
+        local VAR_NAME=${1:?}
+        local VAR_VALUE=${2:?}
+        echo "##vso[task.setvariable variable=${VAR_NAME}]${VAR_VALUE}"
+        echo "${VAR_NAME}: ${VAR_VALUE}"
+      }
+
+      set_var "ORT_POD_VERSION" "${VERSION}"
+      set_var "ORT_SHOULD_UPLOAD_ARCHIVES" "${IS_RELEASE_BUILD}"
+    displayName: "Set variables"
 
   - script: |
       python tools/ci_build/github/apple/build_ios_framework.py \
-        --build_dir $(Build.BinariesDirectory)/ios_framework \
+        --build_dir "$(Build.BinariesDirectory)/ios_framework" \
         --include_ops_by_config tools/ci_build/github/android/mobile_package.required_operators.config \
         tools/ci_build/github/apple/default_mobile_ios_framework_build_settings.json
     displayName: "Build iOS framework"
@@ -46,15 +53,15 @@ jobs:
   - script: |
       python tools/ci_build/github/apple/test_ios_packages.py \
         --fail_if_cocoapods_missing \
-        --c_framework_dir $(Build.BinariesDirectory)/ios_framework/framework_out
+        --c_framework_dir "$(Build.BinariesDirectory)/ios_framework/framework_out"
     displayName: "Test iOS framework"
 
   - script: |
       python tools/ci_build/github/apple/c/assemble_c_pod_package.py \
-        --staging-dir $(Build.BinariesDirectory)/staging/onnxruntime-mobile-c \
+        --staging-dir "$(Build.BinariesDirectory)/staging/onnxruntime-mobile-c" \
         --pod-version ${ORT_POD_VERSION} \
-        --framework-info-file $(Build.BinariesDirectory)/ios_framework/framework_info.json \
-        --framework-dir $(Build.BinariesDirectory)/ios_framework/framework_out/onnxruntime.framework
+        --framework-info-file "$(Build.BinariesDirectory)/ios_framework/framework_info.json" \
+        --framework-dir "$(Build.BinariesDirectory)/ios_framework/framework_out/onnxruntime.framework"
     displayName: "Assemble onnxruntime-mobile-c pod files"
 
   - script: |
@@ -64,14 +71,14 @@ jobs:
 
   - script: |
       python tools/ci_build/github/apple/objectivec/assemble_objc_pod_package.py \
-        --staging-dir $(Build.BinariesDirectory)/staging/onnxruntime-mobile-objc \
+        --staging-dir "$(Build.BinariesDirectory)/staging/onnxruntime-mobile-objc" \
         --pod-version ${ORT_POD_VERSION} \
-        --framework-info-file $(Build.BinariesDirectory)/ios_framework/framework_info.json
+        --framework-info-file "$(Build.BinariesDirectory)/ios_framework/framework_info.json"
     displayName: "Assemble onnxruntime-mobile-objc pod files"
 
   - script: |
       pod lib lint --verbose \
-        --include-podspecs=$(Build.BinariesDirectory)/staging/onnxruntime-mobile-c/onnxruntime-mobile-c.podspec
+        --include-podspecs="$(Build.BinariesDirectory)/staging/onnxruntime-mobile-c/onnxruntime-mobile-c.podspec"
     workingDirectory: "$(Build.BinariesDirectory)/staging/onnxruntime-mobile-objc"
     displayName: "Check onnxruntime-mobile-objc pod"
 
@@ -79,7 +86,7 @@ jobs:
       set -e
       gem install jazzy
       jazzy --config objectivec/docs/jazzy_config.yaml \
-        --output $(Build.BinariesDirectory)/staging/objc_api_docs \
+        --output "$(Build.BinariesDirectory)/staging/objc_api_docs" \
         --module-version ${ORT_POD_VERSION}
     displayName: "Generate Objective-C API docs"
   
@@ -89,9 +96,13 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'scriptPath'
       scriptPath: 'tools/ci_build/github/apple/assemble_ios_packaging_artifacts.sh'
-      arguments: '"$(Build.BinariesDirectory)/staging" "$(Build.ArtifactStagingDirectory)" "$(ORT_POD_VERSION)"'
+      arguments: >-
+        "$(Build.BinariesDirectory)/staging"
+        "$(Build.ArtifactStagingDirectory)"
+        "$(ORT_POD_VERSION)"
+        "$(ORT_SHOULD_UPLOAD_ARCHIVES)"
     displayName: "Assemble artifacts"
 
-  - publish: $(Build.ArtifactStagingDirectory)
+  - publish: "$(Build.ArtifactStagingDirectory)"
     artifact: ios_packaging_artifacts
     displayName: "Publish artifacts"


### PR DESCRIPTION
**Description**
Updates to the iOS packaging pipeline:
- Make it harder to overwrite package archives accidentally when uploading (fails if the archive already exists)
- Only upload package archives for release builds
- Some clean up

**Motivation and Context**
Packaging pipeline improvements.
