### PR TITLE
fix a typo in the bert_legacy_loss implementation

### DIFF
--- a/orttraining/orttraining/core/graph/loss_func/bert_loss_legacy.cc
+++ b/orttraining/orttraining/core/graph/loss_func/bert_loss_legacy.cc
@@ -94,7 +94,7 @@ GraphAugmenter::GraphDefs BertLossLegacy::operator()(const Graph& graph, const L
                                      {ONNX_NAMESPACE::MakeAttribute("axes", std::vector<int64_t>{static_cast<int64_t>(2)})},
                                      "Mask_LM_Positions_Unsqueezed"));
     } else {
-      auto t_proto = ONNX_NAMESPACE::ToTensor<int64_t>(1);
+      auto t_proto = ONNX_NAMESPACE::ToTensor<int64_t>(2);
       TypeProto* int64_t_proto = graph_defs.CreateTypeProto();
       int64_t_proto->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT64);
 
@@ -105,7 +105,7 @@ GraphAugmenter::GraphDefs BertLossLegacy::operator()(const Graph& graph, const L
                                      {ONNX_NAMESPACE::MakeAttribute("value", t_proto)}));
       new_nodes.emplace_back(NodeDef("Unsqueeze",
                                      {ArgDef(masked_lm_positions, masked_lm_int64_type_proto),
-                                      ArgDef("two_constant", int64_t_proto)},
+                                      ArgDef(two_constant, int64_t_proto)},
                                      {ArgDef("masked_lm_positions_unsqueezed")},
                                      NodeAttributes(),
                                      "Mask_LM_Positions_Unsqueezed"));


### PR DESCRIPTION
**Description**: There is a type in the bert_legacy_loss fix in last PR (use constant 1 instead of 2). this PR is to fix it.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
