### PR TITLE
[Objective-C API] Fix ORTIsCoreMLExecutionProviderAvailable link error when used from Swift.

### DIFF
--- a/objectivec/include/ort_coreml_execution_provider.h
+++ b/objectivec/include/ort_coreml_execution_provider.h
@@ -5,12 +5,20 @@
 
 #import "ort_session.h"
 
-NS_ASSUME_NONNULL_BEGIN
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * Gets whether the CoreML execution provider is available.
  */
 BOOL ORTIsCoreMLExecutionProviderAvailable(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Options for configuring the CoreML execution provider.


### PR DESCRIPTION
**Description**
Linker error when ORTIsCoreMLExecutionProviderAvailable() is called from Swift:
```
Undefined symbols for architecture x86_64:
  "_ORTIsCoreMLExecutionProviderAvailable"
```

Fixed by declaring that function with `extern "C"`.

A workaround to detect the presence of the CoreML EP is to try to [append the CoreML EP to the session options](https://github.com/microsoft/onnxruntime/blob/10142f95107a15d5f8228a9ae9fe4c58db82ed7a/objectivec/src/ort_coreml_execution_provider.mm#L31) and see if it fails.

**Motivation and Context**
Fix bug.
