### PR TITLE
Update Dockerfile.cuda: remove compute capability 30

### DIFF
--- a/dockerfiles/Dockerfile.cuda
+++ b/dockerfiles/Dockerfile.cuda
@@ -12,7 +12,7 @@ ADD . /code
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-certificates g++ python3-numpy gcc make git python3-setuptools python3-wheel python3-pip aria2 && aria2c -q -d /tmp -o cmake-3.20.3-Linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.20.3/cmake-3.20.3-Linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.20.3-Linux-x86_64.tar.gz --strip=1 -C /usr
 
-RUN cd /code && /bin/bash ./build.sh --skip_submodule_sync --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_cuda --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 'CMAKE_CUDA_ARCHITECTURES=30;37;50;52;60;70'
+RUN cd /code && /bin/bash ./build.sh --skip_submodule_sync --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_cuda --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 'CMAKE_CUDA_ARCHITECTURES=37;50;52;60;70'
 
 FROM nvcr.io/nvidia/cuda:11.1.1-cudnn8-runtime-ubuntu18.04
 COPY --from=0 /code/build/Linux/Release/dist /root


### PR DESCRIPTION

**Description**: 

Update Dockerfile.cuda: remove compute capability 30

**Motivation and Context**
- Why is this change required? What problem does it solve?

The cuda file doesn't build. 30 is not supported in CUDA 11.1.

35,37,50 are deprecated.


- If it fixes an open issue, please link to the issue here.
