### PR TITLE
[ROCm] clear last status if hipErrorNotReady

### DIFF
--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
@@ -286,8 +286,8 @@ Status ROCMExecutionProvider::OnRunStart() {
         for (auto p : v.cpu_ptrs) {
           cpu_alloc->Free(p);
         }
-        it = deferred_release_cpu_ptr_.erase(it);
         HIP_RETURN_IF_ERROR(hipEventDestroy(e));
+        it = deferred_release_cpu_ptr_.erase(it);
       } else if (event_query_status == hipErrorNotReady) {
         // ignore and clear the error if not ready
         hipGetLastError();

--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
@@ -279,16 +279,16 @@ Status ROCMExecutionProvider::OnRunStart() {
   while (it != deferred_release_cpu_ptr_.end()) {
     auto& e = it->first;
     auto& v = it->second;
-    // note that hipEventQuery returns hipSucess before first hipEventRecord
+    // note that hipEventQuery returns hipSuccess before first hipEventRecord
     if (v.recorded) {
       auto event_query_status = hipEventQuery(e);
-      if (event_query_status == hipSucess) {
+      if (event_query_status == hipSuccess) {
         for (auto p : v.cpu_ptrs) {
           cpu_alloc->Free(p);
         }
         it = deferred_release_cpu_ptr_.erase(it);
         HIP_RETURN_IF_ERROR(hipEventDestroy(e));
-      } else if (event_query_status == hipErrorNotReady()) {
+      } else if (event_query_status == hipErrorNotReady) {
         // ignore and clear the error if not ready
         hipGetLastError();
         it++;

--- a/onnxruntime/core/providers/rocm/rocm_fence.cc
+++ b/onnxruntime/core/providers/rocm/rocm_fence.cc
@@ -13,8 +13,8 @@ ROCMFence::ROCMFence(const GPUDataTransfer* data_transfer) : data_transfer_(data
   // NOTE: hipEventBlockingSync may leads to longer wait time because of thread yield/switching in kernel
   // if lower CPU usage is more important than latency, we should use this flag to avoid spin-loop in WaitOnCPU
   int event_flags = /*hipEventBlockingSync |*/ hipEventDisableTiming;
-  HIP_CALL_THROW(hipEventCreateWithFlags(&read_event_));
-  HIP_CALL_THROW(hipEventCreateWithFlags(&write_event_));
+  HIP_CALL_THROW(hipEventCreateWithFlags(&read_event_, event_flags));
+  HIP_CALL_THROW(hipEventCreateWithFlags(&write_event_, event_flags));
 }
 
 ROCMFence::~ROCMFence() {
@@ -47,21 +47,21 @@ void ROCMFence::BeforeUsingAsOutput(onnxruntime::ProviderType provider_type, int
 
 bool ROCMFence::CanRelease() {
   hipError_t status;
-  status = hipEventQuery(read_event);
+  status = hipEventQuery(read_event_);
   if (status == hipErrorNotReady) {
       // ignore and clear the error if not ready
       hipGetLastError();
       return false;
   } else if (status != hipSuccess) {
-      RocmCall<hipError_t, true>(status, "hipEventQuery(read_event)", "HIP", hipSuccess);
+      RocmCall<hipError_t, true>(status, "hipEventQuery(read_event_)", "HIP", hipSuccess);
   }
-  status = hipEventQuery(write_event);
+  status = hipEventQuery(write_event_);
   if (status == hipErrorNotReady) {
       // ignore and clear the error if not ready
       hipGetLastError();
       return false;
   } else if (status != hipSuccess) {
-      RocmCall<hipError_t, true>(status, "hipEventQuery(write_event)", "HIP", hipSuccess);
+      RocmCall<hipError_t, true>(status, "hipEventQuery(write_event_)", "HIP", hipSuccess);
   }
   return true;
 }


### PR DESCRIPTION
If `hipEventQuery(event)` returns `hipErrorNotReady`, this will become the last HIP error reported by `hipGetLastError()`.  If the error is not immediately cleared by `hipGetLastError()`, it will propagate to the next location in the code where one might want to check the runtime status.

For example, running HuggingFace deberta with onnxruntime sometimes results in the failure:

Non-zero status code returned while running Reshape node. Name:'Reshape_8001_Grad/Reshape_1' Status Message: HIP error hipErrorNotReady:hipErrorNotReady