### PR TITLE
fix build break on windows arm64

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -37,12 +37,15 @@ if (onnxruntime_BUILD_WEBASSEMBLY)
   endif()
 elseif(MSVC)
   if(onnxruntime_target_platform STREQUAL "ARM64")
+    set(mlas_platform_srcs
+      ${ONNXRUNTIME_ROOT}/core/mlas/lib/qgemm_kernel_neon.cpp
+      ${ONNXRUNTIME_ROOT}/core/mlas/lib/qgemm_kernel_udot.cpp
+    )
+
     set(mlas_platform_preprocess_srcs
       ${ONNXRUNTIME_ROOT}/core/mlas/lib/arm64/QgemmU8X8KernelNeon.asm
       ${ONNXRUNTIME_ROOT}/core/mlas/lib/arm64/QgemmU8X8KernelUdot.asm
       ${ONNXRUNTIME_ROOT}/core/mlas/lib/arm64/SgemmKernelNeon.asm
-      ${ONNXRUNTIME_ROOT}/core/mlas/lib/qgemm_kernel_neon.cpp
-      ${ONNXRUNTIME_ROOT}/core/mlas/lib/qgemm_kernel_udot.cpp
     )
 
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")


### PR DESCRIPTION
qgemm_kernel_neon.cpp and qgemm_kernel_udot.cpp should not go through c precompile process.
