### PR TITLE
Fix cpuinfo initialization failure in mlas test

### DIFF
--- a/onnxruntime/core/common/cpuid_info.cc
+++ b/onnxruntime/core/common/cpuid_info.cc
@@ -11,8 +11,6 @@
 
 #if defined(CPUIDINFO_ARCH_X86)
 #include <memory>
-#include <mutex>
-
 #if defined(_MSC_VER)
 #include <intrin.h>
 #elif defined(__GNUC__)
@@ -20,6 +18,7 @@
 #endif
 #endif
 
+#include <mutex>
 #include "core/common/cpuid_info.h"
 
 #if defined(CPUIDINFO_ARCH_X86) || defined(CPUIDINFO_ARCH_ARM)
@@ -63,57 +62,67 @@ static inline int XGETBV() {
 
 CPUIDInfo CPUIDInfo::instance_;
 
+std::once_flag cpuidinit_flag;
 
 common::Status CPUIDInfo::Init() {
-
-#ifdef CPUINFO_INCLUDED
-  if (!cpuinfo_initialize()) {
-    // Unfortunately we can not capture cpuinfo log!!
-    return ORT_MAKE_STATUS(SYSTEM, FAIL, "Failed to initialize cpuinfo");
+  if (this != &instance_) {
+    return ORT_MAKE_STATUS(SYSTEM, FAIL, "Illegal CPUIDInfo instance detected!");
   }
+  std::call_once(cpuidinit_flag, [&]() {
+#ifdef CPUINFO_INCLUDED
+    if (!cpuinfo_initialize()) {
+      // Unfortunately we can not capture cpuinfo log!!
+      return;
+    }
 #endif
 
 #if defined(CPUIDINFO_ARCH_X86)
-  int data[4] = {-1};
-  GetCPUID(0, data);
+    int data[4] = {-1};
+    GetCPUID(0, data);
 
-  int num_IDs = data[0];
-  if (num_IDs >= 1) {
-    GetCPUID(1, data);
-    if (data[2] & (1 << 27)) {
-      const int AVX_MASK = 0x6;
-      const int AVX512_MASK = 0xE6;
-      int value = XGETBV();
-      bool has_sse2 = (data[3] & (1 << 26));
-      has_sse3_ = (data[2] & 0x1);
-      has_sse4_1_ = (data[2] & (1 << 19));
-      bool has_ssse3 = (data[2] & (1 << 9));
-      has_avx_ = has_sse2 && has_ssse3 && (data[2] & (1 << 28)) && ((value & AVX_MASK) == AVX_MASK);
-      bool has_avx512 = (value & AVX512_MASK) == AVX512_MASK;
-      has_f16c_ = has_avx_ && (data[2] & (1 << 29)) && (data[3] & (1 << 26));
+    int num_IDs = data[0];
+    if (num_IDs >= 1) {
+      GetCPUID(1, data);
+      if (data[2] & (1 << 27)) {
+        const int AVX_MASK = 0x6;
+        const int AVX512_MASK = 0xE6;
+        int value = XGETBV();
+        bool has_sse2 = (data[3] & (1 << 26));
+        has_sse3_ = (data[2] & 0x1);
+        has_sse4_1_ = (data[2] & (1 << 19));
+        bool has_ssse3 = (data[2] & (1 << 9));
+        has_avx_ = has_sse2 && has_ssse3 && (data[2] & (1 << 28)) && ((value & AVX_MASK) == AVX_MASK);
+        bool has_avx512 = (value & AVX512_MASK) == AVX512_MASK;
+        has_f16c_ = has_avx_ && (data[2] & (1 << 29)) && (data[3] & (1 << 26));
 
-      if (num_IDs >= 7) {
-        GetCPUID(7, data);
-        has_avx2_ = has_avx_ && (data[1] & (1 << 5));
-        has_avx512f_ = has_avx512 && (data[1] & (1 << 16));
-        // Add check for AVX512 Skylake since tensorization GEMM need intrinsics from avx512bw/avx512dq.
-        // avx512_skylake = avx512f | avx512vl | avx512cd | avx512bw | avx512dq
-        has_avx512_skylake_ = has_avx512 && (data[1] & ((1 << 16) | (1 << 17) | (1 << 28) | (1 << 30) | (1 << 31)));
-        is_hybrid_ = (data[3] & (1 << 15));
+        if (num_IDs >= 7) {
+          GetCPUID(7, data);
+          has_avx2_ = has_avx_ && (data[1] & (1 << 5));
+          has_avx512f_ = has_avx512 && (data[1] & (1 << 16));
+          // Add check for AVX512 Skylake since tensorization GEMM need intrinsics from avx512bw/avx512dq.
+          // avx512_skylake = avx512f | avx512vl | avx512cd | avx512bw | avx512dq
+          has_avx512_skylake_ = has_avx512 && (data[1] & ((1 << 16) | (1 << 17) | (1 << 28) | (1 << 30) | (1 << 31)));
+          is_hybrid_ = (data[3] & (1 << 15));
+        }
       }
     }
-  }
 #endif
 
 #if defined(CPUIDINFO_ARCH_ARM) && defined(CPUINFO_INCLUDED)
 
-  // only works on ARM linux or android, does not work on Windows
-  is_hybrid_ = cpuinfo_get_uarchs_count() > 1;
-  has_arm_neon_dot_ = cpuinfo_has_arm_neon_dot();
+    // only works on ARM linux or android, does not work on Windows
+    is_hybrid_ = cpuinfo_get_uarchs_count() > 1;
+    has_arm_neon_dot_ = cpuinfo_has_arm_neon_dot();
 
 #endif
-  initalized_ = true;
-  return common::Status();
+    initalized_ = true;
+  });
+
+  if (initalized_) {
+    return common::Status();
+  } else {
+    return ORT_MAKE_STATUS(SYSTEM, FAIL, "Failed to initialize cpuinfo");
+  }
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/common/cpuid_info.cc
+++ b/onnxruntime/core/common/cpuid_info.cc
@@ -62,17 +62,12 @@ static inline int XGETBV() {
 
 CPUIDInfo CPUIDInfo::instance_;
 
-std::once_flag cpuidinit_flag;
 
-common::Status CPUIDInfo::Init() {
-  if (this != &instance_) {
-    return ORT_MAKE_STATUS(SYSTEM, FAIL, "Illegal CPUIDInfo instance detected!");
-  }
-  std::call_once(cpuidinit_flag, [&]() {
+CPUIDInfo::CPUIDInfo() {
 #ifdef CPUINFO_INCLUDED
     if (!cpuinfo_initialize()) {
       // Unfortunately we can not capture cpuinfo log!!
-      return;
+      ORT_THROW("Failed to initialize CPU info.");
     }
 #endif
 
@@ -115,14 +110,7 @@ common::Status CPUIDInfo::Init() {
     has_arm_neon_dot_ = cpuinfo_has_arm_neon_dot();
 
 #endif
-    initalized_ = true;
-  });
 
-  if (initalized_) {
-    return common::Status();
-  } else {
-    return ORT_MAKE_STATUS(SYSTEM, FAIL, "Failed to initialize cpuinfo");
-  }
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/common/cpuid_info.h
+++ b/onnxruntime/core/common/cpuid_info.h
@@ -9,14 +9,9 @@ namespace onnxruntime {
 
 class CPUIDInfo {
  public:
-  static common::Status Initialize() {
-    return instance_.Init();
-  }
   static const CPUIDInfo& GetCPUIDInfo() {
-    if (!instance_.initalized_) {
-      ORT_THROW("CPUIDInfo used before initialization!");
-    }
-    return instance_;
+    static CPUIDInfo cpuid_info;
+    return cpuid_info;
   }
 
   bool HasAVX() const { return has_avx_; }
@@ -32,8 +27,7 @@ class CPUIDInfo {
   bool HasArmNeonDot() const { return has_arm_neon_dot_; }
 
  private:
-  common::Status Init();
-  bool initalized_{false};
+  CPUIDInfo();
   bool has_avx_{false};
   bool has_avx2_{false};
   bool has_avx512f_{false};

--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -5,7 +5,6 @@
 #include "core/framework/allocatormgr.h"
 #include "core/graph/constants.h"
 #include "core/graph/op.h"
-#include "core/common/cpuid_info.h"
 
 #if !defined(ORT_MINIMAL_BUILD)
 #include "onnx/defs/operator_sets.h"
@@ -137,7 +136,6 @@ Status Environment::CreateAndRegisterAllocator(const OrtMemoryInfo& mem_info, co
 Status Environment::Initialize(std::unique_ptr<logging::LoggingManager> logging_manager,
                                const OrtThreadingOptions* tp_options,
                                bool create_global_thread_pools) {
-  ORT_RETURN_IF_ERROR(CPUIDInfo::Initialize());
   auto status = Status::OK();
 
   logging_manager_ = std::move(logging_manager);

--- a/onnxruntime/test/mlas/unittest/test_util.h
+++ b/onnxruntime/test/mlas/unittest/test_util.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "mlas.h"
+#include "core/common/cpuid_info.h"
 #include "gtest/gtest.h"
 
 #include <stdio.h>
@@ -173,6 +174,10 @@ class MlasTestFixture : public testing::Test {
  public:
   static void SetUpTestSuite() {
     mlas_tester = new TMlasTester();
+    auto status = onnxruntime::CPUIDInfo::Initialize();
+    if (!status.IsOK()) {
+      FAIL() << "Failed to initialize cpu info!";
+    }
   };
 
   static void TearDownTestSuite() {

--- a/onnxruntime/test/mlas/unittest/test_util.h
+++ b/onnxruntime/test/mlas/unittest/test_util.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "mlas.h"
-#include "core/common/cpuid_info.h"
 #include "gtest/gtest.h"
 
 #include <stdio.h>
@@ -174,10 +173,6 @@ class MlasTestFixture : public testing::Test {
  public:
   static void SetUpTestSuite() {
     mlas_tester = new TMlasTester();
-    auto status = onnxruntime::CPUIDInfo::Initialize();
-    if (!status.IsOK()) {
-      FAIL() << "Failed to initialize cpu info!";
-    }
   };
 
   static void TearDownTestSuite() {


### PR DESCRIPTION
mlas test does not call environment initialization. so we need to manually initialize cpuinfo