### PR TITLE
Update machine info script for transformers notebooks

### DIFF
--- a/onnxruntime/python/tools/transformers/machine_info.py
+++ b/onnxruntime/python/tools/transformers/machine_info.py
@@ -45,10 +45,12 @@ class MachineInfo():
             "gpu": gpu_info,
             "cpu": self.get_cpu_info(),
             "memory": self.get_memory_info(),
-            "python": self._try_get(cpu_info, ["python_version"]),
             "os": platform.platform(),
+            "python": self._try_get(cpu_info, ["python_version"]),
+            "onnx": self.get_onnx_info(),
+            "onnxconverter_common": self.get_onnxconverter_common_info(),
             "onnxruntime": self.get_onnxruntime_info(),
-            "onnxruntime_tools": self.get_onnxruntime_tools_info(),
+            "transformers": self.get_transformers_info(),
             "pytorch": self.get_pytorch_info(),
             "tensorflow": self.get_tensorflow_info()
         }
@@ -62,7 +64,10 @@ class MachineInfo():
     def _try_get(self, cpu_info: Dict, names: List) -> str:
         for name in names:
             if name in cpu_info:
-                return cpu_info[name]
+                value = cpu_info[name]
+                if isinstance(value, (list, tuple)):
+                    return ",".join(value)
+                return value
         return ""
 
     def get_cpu_info(self) -> Dict:
@@ -107,6 +112,24 @@ class MachineInfo():
             result["cuda_visible"] = environ['CUDA_VISIBLE_DEVICES']
         return result
 
+    def get_onnx_info(self) -> Dict:
+        try:
+            import onnx
+            return {"version": onnx.__version__}
+        except ImportError as error:
+            if not self.silent:
+                self.logger.exception(error)
+            return None
+
+    def get_onnxconverter_common_info(self) -> Dict:
+        try:
+            import onnxconverter_common
+            return {"version": onnxconverter_common.__version__}
+        except ImportError as error:
+            if not self.silent:
+                self.logger.exception(error)
+            return None
+
     def get_onnxruntime_info(self) -> Dict:
         try:
             import onnxruntime
@@ -123,10 +146,10 @@ class MachineInfo():
                 self.logger.exception(exception, False)
             return None
 
-    def get_onnxruntime_tools_info(self) -> Dict:
+    def get_transformers_info(self) -> Dict:
         try:
-            import onnxruntime_tools
-            return {"version": onnxruntime_tools.__version__}
+            import transformers
+            return {"version": transformers.__version__}
         except ImportError as error:
             if not self.silent:
                 self.logger.exception(error)

--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -212,8 +212,10 @@ class BertOnnxModel(OnnxModel):
                             expand_shape_value) is 2 and len(
                                 shape_value) is 1 and expand_shape_value[1] == shape_value[0]:
                         node.input[0] = slice_node.output[0]
-        self.remove_nodes(nodes_to_remove)
-        logger.info(f"Removed Reshape and Expand count: {len(nodes_to_remove)}")
+
+        if nodes_to_remove:
+            self.remove_nodes(nodes_to_remove)
+            logger.info(f"Removed Reshape and Expand count: {len(nodes_to_remove)}")
 
     def clean_graph(self):
         output_name_to_node = self.output_name_to_node()

--- a/onnxruntime/python/tools/transformers/onnx_model_bert_keras.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert_keras.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class BertOnnxModelKeras(BertOnnxModelTF):
-    def __init(self, model, num_heads, hidden_size):
+    def __init__(self, model, num_heads, hidden_size):
         super().__init__(model, num_heads, hidden_size)
 
     def match_mask_path(self, add_or_sub_before_softmax):

--- a/onnxruntime/python/tools/transformers/onnx_model_bert_tf.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert_tf.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class BertOnnxModelTF(BertOnnxModel):
-    def __init(self, model, num_heads, hidden_size):
+    def __init__(self, model, num_heads, hidden_size):
         super().__init__(model, num_heads, hidden_size)
 
     def remove_identity(self):

--- a/onnxruntime/python/tools/transformers/onnx_model_gpt2.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_gpt2.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class Gpt2OnnxModel(BertOnnxModel):
-    def __init(self, model, num_heads, hidden_size):
+    def __init__(self, model, num_heads, hidden_size):
         super().__init__(model, num_heads, hidden_size)
 
     def fuse_attention(self):

--- a/onnxruntime/python/tools/transformers/shape_infer_helper.py
+++ b/onnxruntime/python/tools/transformers/shape_infer_helper.py
@@ -5,6 +5,7 @@
 
 import os
 import sys
+import onnx
 
 # In ORT Package the symbolic_shape_infer.py is in ../tools
 file_path = os.path.dirname(__file__)
@@ -12,7 +13,8 @@ if os.path.exists(os.path.join(file_path, "../tools/symbolic_shape_infer.py")):
     sys.path.append(os.path.join(file_path, '../tools'))
 else:
     sys.path.append(os.path.join(file_path, '..'))
-from symbolic_shape_infer import *
+
+from symbolic_shape_infer import SymbolicShapeInference, get_shape_from_type_proto, sympy
 
 
 class SymbolicShapeInferenceHelper(SymbolicShapeInference):
@@ -43,7 +45,7 @@ class SymbolicShapeInferenceHelper(SymbolicShapeInference):
         self.initializers_ = dict([(i.name, i) for i in self.out_mp_.graph.initializer])
         self.known_vi_ = dict([(i.name, i) for i in list(self.out_mp_.graph.input)])
         self.known_vi_.update(
-            dict([(i.name, helper.make_tensor_value_info(i.name, i.data_type, list(i.dims)))
+            dict([(i.name, onnx.helper.make_tensor_value_info(i.name, i.data_type, list(i.dims)))
                   for i in self.out_mp_.graph.initializer]))
 
     # Override _get_sympy_shape() in symbolic_shape_infer.py to ensure shape inference by giving the actual value of dynamic axis


### PR DESCRIPTION
**Description**: 
Update script to get machine information (for  jupyter notebooks):
(1) add versions of onnx, onnxconverter_common and transformers
(2) remove version of onnxruntime_tools since it is deprecated.
(3) convert a list of flags to a string separated by ","

Also some extra changes:
(1) fix typo of constructors (https://github.com/microsoft/onnxruntime/issues/8343)
(2) refine import of shape_infer_helper

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
