### PR TITLE
Fix invalid access in log call.

### DIFF
--- a/onnxruntime/core/optimizer/concat_slice_elimination.cc
+++ b/onnxruntime/core/optimizer/concat_slice_elimination.cc
@@ -30,7 +30,6 @@ Status ConcatSliceElimination::ApplyImpl(Graph& graph, bool& modified, int graph
 
     if (ConcatSliceElimination::FuseConcatSliceSubgraph(concat, graph, logger)) {
       fused_count++;
-      LOGS(logger, INFO) << "Fused concat node: " << concat.OutputDefs()[0]->Name();
       modified = true;
     }
   }
@@ -244,6 +243,8 @@ bool ConcatSliceElimination::FuseConcatSliceSubgraph(Node& concat, Graph& graph,
     replace_cnt++;
   }
   if (replace_cnt == 3) {
+    LOGS(logger, INFO) << "Fused concat node: " << concat.OutputDefs()[0]->Name();
+
     //delete the slice nodes and concat node
     graph_utils::RemoveNodeOutputEdges(graph, concat);
     graph.RemoveNode(concat.Index());


### PR DESCRIPTION
**Description**
Fix bug that shows up when running tests (in particular, GraphTransformationTests.ConcatSliceEliminationTest) with more verbose logging level.

There is a log statement that doesn't get evaluated at the default test logging level (warning). It was accessing the first element of an empty vector. This change moves that log statement before the point where that vector is cleared.

It would probably be useful to have at least one CI build that runs tests at a more verbose logging level to catch something like this in the future.

**Motivation and Context**
Fix bug.
