### PR TITLE
SDL Native Warning errors in DML ep

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/inc/MLOperatorAuthor.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/inc/MLOperatorAuthor.h
@@ -267,7 +267,7 @@ IMLOperatorKernelCreationContext : public IMLOperatorAttributes
     //! For kernels registered with MLOperatorExecutionType::D3D12, executionObject will
     //! support the ID3D12GraphicsCommandList interface.
     STDMETHOD_(void, GetExecutionInterface)(
-        _COM_Outptr_result_maybenull_ IUnknown** executionObject
+        _Outptr_result_maybenull_ IUnknown** executionObject
         ) const noexcept PURE;
 };
  
@@ -308,7 +308,7 @@ IMLOperatorTensor : IUnknown
     //! registered using MLOperatorExecutionType::D3D12.  The dataInterface
     //! object supports the ID3D12Resource interface, and is a GPU buffer.
     STDMETHOD_(void, GetDataInterface)(
-        _COM_Outptr_result_maybenull_ IUnknown** dataInterface
+        _Outptr_result_maybenull_ IUnknown** dataInterface
         ) noexcept PURE;
 };
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommandRecorder.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommandRecorder.cpp
@@ -166,7 +166,8 @@ void DmlCommandRecorder::ExecuteOperator(
     m_operationsRecordedInCurrentCommandList = true;
 
     // Barrier all outputs.
-    m_currentCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::UAV(nullptr));
+    #pragma warning(suppress: 6387)
+        m_currentCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::UAV(nullptr));
 }
 
 void DmlCommandRecorder::CopyBufferRegion(
@@ -234,7 +235,8 @@ void DmlCommandRecorder::FillBufferWithPattern(
     m_operationsRecordedInCurrentCommandList = true;
 
     // Barrier all outputs.
-    m_currentCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::UAV(nullptr));
+    #pragma warning(suppress: 6387)
+        m_currentCommandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::UAV(nullptr));
 }
 
 void DmlCommandRecorder::ExecuteCommandList(
@@ -296,7 +298,8 @@ void DmlCommandRecorder::ResourceBarrier(gsl::span<const D3D12_RESOURCE_BARRIER>
 
 void DmlCommandRecorder::AddUAVBarrier()
 {
-    auto barrier = CD3DX12_RESOURCE_BARRIER::UAV(nullptr);
+    #pragma warning(suppress: 6387)
+        auto barrier = CD3DX12_RESOURCE_BARRIER::UAV(nullptr);
     m_currentCommandList->ResourceBarrier(1, &barrier);
     m_operationsRecordedInCurrentCommandList = true; 
 }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -44,8 +44,8 @@ namespace Dml
     }
 
     static void CreateDmlKernelRegistry(
-        _Outptr_ std::shared_ptr<onnxruntime::KernelRegistry>* registry,
-        _Outptr_ std::shared_ptr<const InternalRegistrationInfoMap>* internalRegInfoMap)
+        _Out_ std::shared_ptr<onnxruntime::KernelRegistry>* registry,
+        _Out_ std::shared_ptr<const InternalRegistrationInfoMap>* internalRegInfoMap)
     {
         ComPtr<AbiCustomRegistry> abiRegistry = wil::MakeOrThrow<AbiCustomRegistry>();
         Dml::RegisterDmlOperators(abiRegistry.Get());
@@ -187,12 +187,16 @@ namespace Dml
 
     HRESULT __stdcall ExecutionProviderImpl::GetD3DDevice(_COM_Outptr_ ID3D12Device** d3dDevice) const noexcept
     {
-        return m_d3d12Device.CopyTo(d3dDevice);
+        m_d3d12Device.CopyTo(d3dDevice);
+        _Analysis_assume_(*d3dDevice != NULL);
+        return S_OK;
     }
 
     HRESULT __stdcall ExecutionProviderImpl::GetDmlDevice(_COM_Outptr_ IDMLDevice** dmlDevice) const noexcept
     {
-        return m_dmlDevice.CopyTo(dmlDevice);
+        m_dmlDevice.CopyTo(dmlDevice);
+        _Analysis_assume_(*dmlDevice != NULL);
+        return S_OK;
     }
 
     HRESULT __stdcall ExecutionProviderImpl::ExecuteCommandList(

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -188,14 +188,14 @@ namespace Dml
     HRESULT __stdcall ExecutionProviderImpl::GetD3DDevice(_COM_Outptr_ ID3D12Device** d3dDevice) const noexcept
     {
         m_d3d12Device.CopyTo(d3dDevice);
-        _Analysis_assume_(*d3dDevice != NULL);
+        _Analysis_assume_(*d3dDevice != nullptr);
         return S_OK;
     }
 
     HRESULT __stdcall ExecutionProviderImpl::GetDmlDevice(_COM_Outptr_ IDMLDevice** dmlDevice) const noexcept
     {
         m_dmlDevice.CopyTo(dmlDevice);
-        _Analysis_assume_(*dmlDevice != NULL);
+        _Analysis_assume_(*dmlDevice != nullptr);
         return S_OK;
     }
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/External/D3DX12/d3dx12.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/External/D3DX12/d3dx12.h
@@ -1,11 +1,7 @@
 //*********************************************************
 //
-// Copyright (c) Microsoft. All rights reserved.
-// This code is licensed under the MIT License (MIT).
-// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
-// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
-// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
-// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License (MIT).
 //
 //*********************************************************
 
@@ -20,28 +16,28 @@ struct CD3DX12_DEFAULT {};
 extern const DECLSPEC_SELECTANY CD3DX12_DEFAULT D3D12_DEFAULT;
 
 //------------------------------------------------------------------------------------------------
-inline bool operator==( const D3D12_VIEWPORT& l, const D3D12_VIEWPORT& r )
+inline bool operator==( const D3D12_VIEWPORT& l, const D3D12_VIEWPORT& r ) noexcept
 {
     return l.TopLeftX == r.TopLeftX && l.TopLeftY == r.TopLeftY && l.Width == r.Width &&
         l.Height == r.Height && l.MinDepth == r.MinDepth && l.MaxDepth == r.MaxDepth;
 }
 
 //------------------------------------------------------------------------------------------------
-inline bool operator!=( const D3D12_VIEWPORT& l, const D3D12_VIEWPORT& r )
+inline bool operator!=( const D3D12_VIEWPORT& l, const D3D12_VIEWPORT& r ) noexcept
 { return !( l == r ); }
 
 //------------------------------------------------------------------------------------------------
 struct CD3DX12_RECT : public D3D12_RECT
 {
     CD3DX12_RECT() = default;
-    explicit CD3DX12_RECT( const D3D12_RECT& o ) :
+    explicit CD3DX12_RECT( const D3D12_RECT& o ) noexcept :
         D3D12_RECT( o )
     {}
     explicit CD3DX12_RECT(
         LONG Left,
         LONG Top,
         LONG Right,
-        LONG Bottom )
+        LONG Bottom ) noexcept
     {
         left = Left;
         top = Top;
@@ -54,7 +50,7 @@ struct CD3DX12_RECT : public D3D12_RECT
 struct CD3DX12_VIEWPORT : public D3D12_VIEWPORT
 {
     CD3DX12_VIEWPORT() = default;
-    explicit CD3DX12_VIEWPORT( const D3D12_VIEWPORT& o ) :
+    explicit CD3DX12_VIEWPORT( const D3D12_VIEWPORT& o ) noexcept :
         D3D12_VIEWPORT( o )
     {}
     explicit CD3DX12_VIEWPORT(
@@ -63,7 +59,7 @@ struct CD3DX12_VIEWPORT : public D3D12_VIEWPORT
         FLOAT width,
         FLOAT height,
         FLOAT minDepth = D3D12_MIN_DEPTH,
-        FLOAT maxDepth = D3D12_MAX_DEPTH )
+        FLOAT maxDepth = D3D12_MAX_DEPTH ) noexcept
     {
         TopLeftX = topLeftX;
         TopLeftY = topLeftY;
@@ -78,7 +74,7 @@ struct CD3DX12_VIEWPORT : public D3D12_VIEWPORT
         FLOAT topLeftX = 0.0f,
         FLOAT topLeftY = 0.0f,
         FLOAT minDepth = D3D12_MIN_DEPTH,
-        FLOAT maxDepth = D3D12_MAX_DEPTH )
+        FLOAT maxDepth = D3D12_MAX_DEPTH ) noexcept
     {
         auto Desc = pResource->GetDesc();
         const UINT64 SubresourceWidth = Desc.Width >> mipSlice;
@@ -88,21 +84,21 @@ struct CD3DX12_VIEWPORT : public D3D12_VIEWPORT
         case D3D12_RESOURCE_DIMENSION_BUFFER:
             TopLeftX = topLeftX;
             TopLeftY = 0.0f;
-            Width = Desc.Width - topLeftX;
+            Width = float(Desc.Width) - topLeftX;
             Height = 1.0f;
             break;
         case D3D12_RESOURCE_DIMENSION_TEXTURE1D:
             TopLeftX = topLeftX;
             TopLeftY = 0.0f;
-            Width = (SubresourceWidth ? SubresourceWidth : 1.0f) - topLeftX;
+            Width = (SubresourceWidth ? float(SubresourceWidth) : 1.0f) - topLeftX;
             Height = 1.0f;
             break;
         case D3D12_RESOURCE_DIMENSION_TEXTURE2D:
         case D3D12_RESOURCE_DIMENSION_TEXTURE3D:
             TopLeftX = topLeftX;
             TopLeftY = topLeftY;
-            Width = (SubresourceWidth ? SubresourceWidth : 1.0f) - topLeftX;
-            Height = (SubresourceHeight ? SubresourceHeight: 1.0f) - topLeftY;
+            Width = (SubresourceWidth ? float(SubresourceWidth) : 1.0f) - topLeftX;
+            Height = (SubresourceHeight ? float(SubresourceHeight) : 1.0f) - topLeftY;
             break;
         default: break;
         }
@@ -116,17 +112,17 @@ struct CD3DX12_VIEWPORT : public D3D12_VIEWPORT
 struct CD3DX12_BOX : public D3D12_BOX
 {
     CD3DX12_BOX() = default;
-    explicit CD3DX12_BOX( const D3D12_BOX& o ) :
+    explicit CD3DX12_BOX( const D3D12_BOX& o ) noexcept :
         D3D12_BOX( o )
     {}
     explicit CD3DX12_BOX(
         LONG Left,
-        LONG Right )
+        LONG Right ) noexcept
     {
-        left = Left;
+        left = static_cast<UINT>(Left);
         top = 0;
         front = 0;
-        right = Right;
+        right = static_cast<UINT>(Right);
         bottom = 1;
         back = 1;
     }
@@ -134,13 +130,13 @@ struct CD3DX12_BOX : public D3D12_BOX
         LONG Left,
         LONG Top,
         LONG Right,
-        LONG Bottom )
+        LONG Bottom ) noexcept
     {
-        left = Left;
-        top = Top;
+        left = static_cast<UINT>(Left);
+        top = static_cast<UINT>(Top);
         front = 0;
-        right = Right;
-        bottom = Bottom;
+        right = static_cast<UINT>(Right);
+        bottom = static_cast<UINT>(Bottom);
         back = 1;
     }
     explicit CD3DX12_BOX(
@@ -149,32 +145,32 @@ struct CD3DX12_BOX : public D3D12_BOX
         LONG Front,
         LONG Right,
         LONG Bottom,
-        LONG Back )
+        LONG Back ) noexcept
     {
-        left = Left;
-        top = Top;
-        front = Front;
-        right = Right;
-        bottom = Bottom;
-        back = Back;
+        left = static_cast<UINT>(Left);
+        top = static_cast<UINT>(Top);
+        front = static_cast<UINT>(Front);
+        right = static_cast<UINT>(Right);
+        bottom = static_cast<UINT>(Bottom);
+        back = static_cast<UINT>(Back);
     }
 };
-inline bool operator==( const D3D12_BOX& l, const D3D12_BOX& r )
+inline bool operator==( const D3D12_BOX& l, const D3D12_BOX& r ) noexcept
 {
     return l.left == r.left && l.top == r.top && l.front == r.front &&
         l.right == r.right && l.bottom == r.bottom && l.back == r.back;
 }
-inline bool operator!=( const D3D12_BOX& l, const D3D12_BOX& r )
+inline bool operator!=( const D3D12_BOX& l, const D3D12_BOX& r ) noexcept
 { return !( l == r ); }
 
 //------------------------------------------------------------------------------------------------
 struct CD3DX12_DEPTH_STENCIL_DESC : public D3D12_DEPTH_STENCIL_DESC
 {
     CD3DX12_DEPTH_STENCIL_DESC() = default;
-    explicit CD3DX12_DEPTH_STENCIL_DESC( const D3D12_DEPTH_STENCIL_DESC& o ) :
+    explicit CD3DX12_DEPTH_STENCIL_DESC( const D3D12_DEPTH_STENCIL_DESC& o ) noexcept :
         D3D12_DEPTH_STENCIL_DESC( o )
     {}
-    explicit CD3DX12_DEPTH_STENCIL_DESC( CD3DX12_DEFAULT )
+    explicit CD3DX12_DEPTH_STENCIL_DESC( CD3DX12_DEFAULT ) noexcept
     {
         DepthEnable = TRUE;
         DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
@@ -201,7 +197,7 @@ struct CD3DX12_DEPTH_STENCIL_DESC : public D3D12_DEPTH_STENCIL_DESC
         D3D12_STENCIL_OP backStencilFailOp,
         D3D12_STENCIL_OP backStencilDepthFailOp,
         D3D12_STENCIL_OP backStencilPassOp,
-        D3D12_COMPARISON_FUNC backStencilFunc )
+        D3D12_COMPARISON_FUNC backStencilFunc ) noexcept
     {
         DepthEnable = depthEnable;
         DepthWriteMask = depthWriteMask;
@@ -224,10 +220,10 @@ struct CD3DX12_DEPTH_STENCIL_DESC : public D3D12_DEPTH_STENCIL_DESC
 struct CD3DX12_DEPTH_STENCIL_DESC1 : public D3D12_DEPTH_STENCIL_DESC1
 {
     CD3DX12_DEPTH_STENCIL_DESC1() = default;
-    explicit CD3DX12_DEPTH_STENCIL_DESC1( const D3D12_DEPTH_STENCIL_DESC1& o ) :
+    explicit CD3DX12_DEPTH_STENCIL_DESC1( const D3D12_DEPTH_STENCIL_DESC1& o ) noexcept :
         D3D12_DEPTH_STENCIL_DESC1( o )
     {}
-    explicit CD3DX12_DEPTH_STENCIL_DESC1( const D3D12_DEPTH_STENCIL_DESC& o )
+    explicit CD3DX12_DEPTH_STENCIL_DESC1( const D3D12_DEPTH_STENCIL_DESC& o ) noexcept
     {
         DepthEnable                  = o.DepthEnable;
         DepthWriteMask               = o.DepthWriteMask;
@@ -245,7 +241,7 @@ struct CD3DX12_DEPTH_STENCIL_DESC1 : public D3D12_DEPTH_STENCIL_DESC1
         BackFace.StencilFunc         = o.BackFace.StencilFunc;
         DepthBoundsTestEnable        = FALSE;
     }
-    explicit CD3DX12_DEPTH_STENCIL_DESC1( CD3DX12_DEFAULT )
+    explicit CD3DX12_DEPTH_STENCIL_DESC1( CD3DX12_DEFAULT ) noexcept
     {
         DepthEnable = TRUE;
         DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
@@ -274,7 +270,7 @@ struct CD3DX12_DEPTH_STENCIL_DESC1 : public D3D12_DEPTH_STENCIL_DESC1
         D3D12_STENCIL_OP backStencilDepthFailOp,
         D3D12_STENCIL_OP backStencilPassOp,
         D3D12_COMPARISON_FUNC backStencilFunc,
-        BOOL depthBoundsTestEnable )
+        BOOL depthBoundsTestEnable ) noexcept
     {
         DepthEnable = depthEnable;
         DepthWriteMask = depthWriteMask;
@@ -292,7 +288,7 @@ struct CD3DX12_DEPTH_STENCIL_DESC1 : public D3D12_DEPTH_STENCIL_DESC1
         BackFace.StencilFunc = backStencilFunc;
         DepthBoundsTestEnable = depthBoundsTestEnable;
     }
-    operator D3D12_DEPTH_STENCIL_DESC() const
+    operator D3D12_DEPTH_STENCIL_DESC() const noexcept
     {
         D3D12_DEPTH_STENCIL_DESC D;
         D.DepthEnable                  = DepthEnable;
@@ -317,10 +313,10 @@ struct CD3DX12_DEPTH_STENCIL_DESC1 : public D3D12_DEPTH_STENCIL_DESC1
 struct CD3DX12_BLEND_DESC : public D3D12_BLEND_DESC
 {
     CD3DX12_BLEND_DESC() = default;
-    explicit CD3DX12_BLEND_DESC( const D3D12_BLEND_DESC& o ) :
+    explicit CD3DX12_BLEND_DESC( const D3D12_BLEND_DESC& o ) noexcept :
         D3D12_BLEND_DESC( o )
     {}
-    explicit CD3DX12_BLEND_DESC( CD3DX12_DEFAULT )
+    explicit CD3DX12_BLEND_DESC( CD3DX12_DEFAULT ) noexcept
     {
         AlphaToCoverageEnable = FALSE;
         IndependentBlendEnable = FALSE;
@@ -341,10 +337,10 @@ struct CD3DX12_BLEND_DESC : public D3D12_BLEND_DESC
 struct CD3DX12_RASTERIZER_DESC : public D3D12_RASTERIZER_DESC
 {
     CD3DX12_RASTERIZER_DESC() = default;
-    explicit CD3DX12_RASTERIZER_DESC( const D3D12_RASTERIZER_DESC& o ) :
+    explicit CD3DX12_RASTERIZER_DESC( const D3D12_RASTERIZER_DESC& o ) noexcept :
         D3D12_RASTERIZER_DESC( o )
     {}
-    explicit CD3DX12_RASTERIZER_DESC( CD3DX12_DEFAULT )
+    explicit CD3DX12_RASTERIZER_DESC( CD3DX12_DEFAULT ) noexcept
     {
         FillMode = D3D12_FILL_MODE_SOLID;
         CullMode = D3D12_CULL_MODE_BACK;
@@ -367,9 +363,9 @@ struct CD3DX12_RASTERIZER_DESC : public D3D12_RASTERIZER_DESC
         FLOAT slopeScaledDepthBias,
         BOOL depthClipEnable,
         BOOL multisampleEnable,
-        BOOL antialiasedLineEnable, 
-        UINT forcedSampleCount, 
-        D3D12_CONSERVATIVE_RASTERIZATION_MODE conservativeRaster)
+        BOOL antialiasedLineEnable,
+        UINT forcedSampleCount,
+        D3D12_CONSERVATIVE_RASTERIZATION_MODE conservativeRaster) noexcept
     {
         FillMode = fillMode;
         CullMode = cullMode;
@@ -389,12 +385,12 @@ struct CD3DX12_RASTERIZER_DESC : public D3D12_RASTERIZER_DESC
 struct CD3DX12_RESOURCE_ALLOCATION_INFO : public D3D12_RESOURCE_ALLOCATION_INFO
 {
     CD3DX12_RESOURCE_ALLOCATION_INFO() = default;
-    explicit CD3DX12_RESOURCE_ALLOCATION_INFO( const D3D12_RESOURCE_ALLOCATION_INFO& o ) :
+    explicit CD3DX12_RESOURCE_ALLOCATION_INFO( const D3D12_RESOURCE_ALLOCATION_INFO& o ) noexcept :
         D3D12_RESOURCE_ALLOCATION_INFO( o )
     {}
     CD3DX12_RESOURCE_ALLOCATION_INFO(
         UINT64 size,
-        UINT64 alignment )
+        UINT64 alignment ) noexcept
     {
         SizeInBytes = size;
         Alignment = alignment;
@@ -405,14 +401,14 @@ struct CD3DX12_RESOURCE_ALLOCATION_INFO : public D3D12_RESOURCE_ALLOCATION_INFO
 struct CD3DX12_HEAP_PROPERTIES : public D3D12_HEAP_PROPERTIES
 {
     CD3DX12_HEAP_PROPERTIES() = default;
-    explicit CD3DX12_HEAP_PROPERTIES(const D3D12_HEAP_PROPERTIES &o) :
+    explicit CD3DX12_HEAP_PROPERTIES(const D3D12_HEAP_PROPERTIES &o) noexcept :
         D3D12_HEAP_PROPERTIES(o)
     {}
-    CD3DX12_HEAP_PROPERTIES( 
-        D3D12_CPU_PAGE_PROPERTY cpuPageProperty, 
+    CD3DX12_HEAP_PROPERTIES(
+        D3D12_CPU_PAGE_PROPERTY cpuPageProperty,
         D3D12_MEMORY_POOL memoryPoolPreference,
-        UINT creationNodeMask = 1, 
-        UINT nodeMask = 1 )
+        UINT creationNodeMask = 1,
+        UINT nodeMask = 1 ) noexcept
     {
         Type = D3D12_HEAP_TYPE_CUSTOM;
         CPUPageProperty = cpuPageProperty;
@@ -420,10 +416,10 @@ struct CD3DX12_HEAP_PROPERTIES : public D3D12_HEAP_PROPERTIES
         CreationNodeMask = creationNodeMask;
         VisibleNodeMask = nodeMask;
     }
-    explicit CD3DX12_HEAP_PROPERTIES( 
-        D3D12_HEAP_TYPE type, 
-        UINT creationNodeMask = 1, 
-        UINT nodeMask = 1 )
+    explicit CD3DX12_HEAP_PROPERTIES(
+        D3D12_HEAP_TYPE type,
+        UINT creationNodeMask = 1,
+        UINT nodeMask = 1 ) noexcept
     {
         Type = type;
         CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
@@ -431,127 +427,128 @@ struct CD3DX12_HEAP_PROPERTIES : public D3D12_HEAP_PROPERTIES
         CreationNodeMask = creationNodeMask;
         VisibleNodeMask = nodeMask;
     }
-    bool IsCPUAccessible() const
+    bool IsCPUAccessible() const noexcept
     {
         return Type == D3D12_HEAP_TYPE_UPLOAD || Type == D3D12_HEAP_TYPE_READBACK || (Type == D3D12_HEAP_TYPE_CUSTOM &&
             (CPUPageProperty == D3D12_CPU_PAGE_PROPERTY_WRITE_COMBINE || CPUPageProperty == D3D12_CPU_PAGE_PROPERTY_WRITE_BACK));
     }
 };
-inline bool operator==( const D3D12_HEAP_PROPERTIES& l, const D3D12_HEAP_PROPERTIES& r )
+inline bool operator==( const D3D12_HEAP_PROPERTIES& l, const D3D12_HEAP_PROPERTIES& r ) noexcept
 {
-    return l.Type == r.Type && l.CPUPageProperty == r.CPUPageProperty && 
+    return l.Type == r.Type && l.CPUPageProperty == r.CPUPageProperty &&
         l.MemoryPoolPreference == r.MemoryPoolPreference &&
         l.CreationNodeMask == r.CreationNodeMask &&
         l.VisibleNodeMask == r.VisibleNodeMask;
 }
-inline bool operator!=( const D3D12_HEAP_PROPERTIES& l, const D3D12_HEAP_PROPERTIES& r )
+inline bool operator!=( const D3D12_HEAP_PROPERTIES& l, const D3D12_HEAP_PROPERTIES& r ) noexcept
 { return !( l == r ); }
 
 //------------------------------------------------------------------------------------------------
 struct CD3DX12_HEAP_DESC : public D3D12_HEAP_DESC
 {
     CD3DX12_HEAP_DESC() = default;
-    explicit CD3DX12_HEAP_DESC(const D3D12_HEAP_DESC &o) :
+    explicit CD3DX12_HEAP_DESC(const D3D12_HEAP_DESC &o) noexcept :
         D3D12_HEAP_DESC(o)
     {}
-    CD3DX12_HEAP_DESC( 
-        UINT64 size, 
-        D3D12_HEAP_PROPERTIES properties, 
-        UINT64 alignment = 0, 
-        D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_NONE )
+    CD3DX12_HEAP_DESC(
+        UINT64 size,
+        D3D12_HEAP_PROPERTIES properties,
+        UINT64 alignment = 0,
+        D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_NONE ) noexcept
     {
         SizeInBytes = size;
         Properties = properties;
         Alignment = alignment;
         Flags = flags;
     }
-    CD3DX12_HEAP_DESC( 
-        UINT64 size, 
-        D3D12_HEAP_TYPE type, 
-        UINT64 alignment = 0, 
-        D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_NONE )
+    CD3DX12_HEAP_DESC(
+        UINT64 size,
+        D3D12_HEAP_TYPE type,
+        UINT64 alignment = 0,
+        D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_NONE ) noexcept
     {
         SizeInBytes = size;
         Properties = CD3DX12_HEAP_PROPERTIES( type );
         Alignment = alignment;
         Flags = flags;
     }
-    CD3DX12_HEAP_DESC( 
-        UINT64 size, 
-        D3D12_CPU_PAGE_PROPERTY cpuPageProperty, 
-        D3D12_MEMORY_POOL memoryPoolPreference, 
-        UINT64 alignment = 0, 
-        D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_NONE )
+    CD3DX12_HEAP_DESC(
+        UINT64 size,
+        D3D12_CPU_PAGE_PROPERTY cpuPageProperty,
+        D3D12_MEMORY_POOL memoryPoolPreference,
+        UINT64 alignment = 0,
+        D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_NONE ) noexcept
     {
         SizeInBytes = size;
         Properties = CD3DX12_HEAP_PROPERTIES( cpuPageProperty, memoryPoolPreference );
         Alignment = alignment;
         Flags = flags;
     }
-    CD3DX12_HEAP_DESC( 
+    CD3DX12_HEAP_DESC(
         const D3D12_RESOURCE_ALLOCATION_INFO& resAllocInfo,
-        D3D12_HEAP_PROPERTIES properties, 
-        D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_NONE )
+        D3D12_HEAP_PROPERTIES properties,
+        D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_NONE ) noexcept
     {
         SizeInBytes = resAllocInfo.SizeInBytes;
         Properties = properties;
         Alignment = resAllocInfo.Alignment;
         Flags = flags;
     }
-    CD3DX12_HEAP_DESC( 
+    CD3DX12_HEAP_DESC(
         const D3D12_RESOURCE_ALLOCATION_INFO& resAllocInfo,
-        D3D12_HEAP_TYPE type, 
-        D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_NONE )
+        D3D12_HEAP_TYPE type,
+        D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_NONE ) noexcept
     {
         SizeInBytes = resAllocInfo.SizeInBytes;
         Properties = CD3DX12_HEAP_PROPERTIES( type );
         Alignment = resAllocInfo.Alignment;
         Flags = flags;
     }
-    CD3DX12_HEAP_DESC( 
+    CD3DX12_HEAP_DESC(
         const D3D12_RESOURCE_ALLOCATION_INFO& resAllocInfo,
-        D3D12_CPU_PAGE_PROPERTY cpuPageProperty, 
-        D3D12_MEMORY_POOL memoryPoolPreference, 
-        D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_NONE )
+        D3D12_CPU_PAGE_PROPERTY cpuPageProperty,
+        D3D12_MEMORY_POOL memoryPoolPreference,
+        D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_NONE ) noexcept
     {
         SizeInBytes = resAllocInfo.SizeInBytes;
         Properties = CD3DX12_HEAP_PROPERTIES( cpuPageProperty, memoryPoolPreference );
         Alignment = resAllocInfo.Alignment;
         Flags = flags;
     }
-    bool IsCPUAccessible() const
+    bool IsCPUAccessible() const noexcept
     { return static_cast< const CD3DX12_HEAP_PROPERTIES* >( &Properties )->IsCPUAccessible(); }
 };
-inline bool operator==( const D3D12_HEAP_DESC& l, const D3D12_HEAP_DESC& r )
+inline bool operator==( const D3D12_HEAP_DESC& l, const D3D12_HEAP_DESC& r ) noexcept
 {
     return l.SizeInBytes == r.SizeInBytes &&
-        l.Properties == r.Properties && 
+        l.Properties == r.Properties &&
         l.Alignment == r.Alignment &&
         l.Flags == r.Flags;
 }
-inline bool operator!=( const D3D12_HEAP_DESC& l, const D3D12_HEAP_DESC& r )
+inline bool operator!=( const D3D12_HEAP_DESC& l, const D3D12_HEAP_DESC& r ) noexcept
 { return !( l == r ); }
 
 //------------------------------------------------------------------------------------------------
 struct CD3DX12_CLEAR_VALUE : public D3D12_CLEAR_VALUE
 {
     CD3DX12_CLEAR_VALUE() = default;
-    explicit CD3DX12_CLEAR_VALUE(const D3D12_CLEAR_VALUE &o) :
+    explicit CD3DX12_CLEAR_VALUE(const D3D12_CLEAR_VALUE &o) noexcept :
         D3D12_CLEAR_VALUE(o)
     {}
-    CD3DX12_CLEAR_VALUE( 
-        DXGI_FORMAT format, 
-        const FLOAT color[4] )
+    CD3DX12_CLEAR_VALUE(
+        DXGI_FORMAT format,
+        const FLOAT color[4] ) noexcept
     {
         Format = format;
         memcpy( Color, color, sizeof( Color ) );
     }
-    CD3DX12_CLEAR_VALUE( 
-        DXGI_FORMAT format, 
+    CD3DX12_CLEAR_VALUE(
+        DXGI_FORMAT format,
         FLOAT depth,
-        UINT8 stencil )
+        UINT8 stencil ) noexcept
     {
         Format = format;
+        memset( &Color, 0, sizeof( Color ) );
         /* Use memcpy to preserve NAN values */
         memcpy( &DepthStencil.Depth, &depth, sizeof( depth ) );
         DepthStencil.Stencil = stencil;
@@ -562,12 +559,12 @@ struct CD3DX12_CLEAR_VALUE : public D3D12_CLEAR_VALUE
 struct CD3DX12_RANGE : public D3D12_RANGE
 {
     CD3DX12_RANGE() = default;
-    explicit CD3DX12_RANGE(const D3D12_RANGE &o) :
+    explicit CD3DX12_RANGE(const D3D12_RANGE &o) noexcept :
         D3D12_RANGE(o)
     {}
-    CD3DX12_RANGE( 
-        SIZE_T begin, 
-        SIZE_T end )
+    CD3DX12_RANGE(
+        SIZE_T begin,
+        SIZE_T end ) noexcept
     {
         Begin = begin;
         End = end;
@@ -578,12 +575,12 @@ struct CD3DX12_RANGE : public D3D12_RANGE
 struct CD3DX12_RANGE_UINT64 : public D3D12_RANGE_UINT64
 {
     CD3DX12_RANGE_UINT64() = default;
-    explicit CD3DX12_RANGE_UINT64(const D3D12_RANGE_UINT64 &o) :
+    explicit CD3DX12_RANGE_UINT64(const D3D12_RANGE_UINT64 &o) noexcept :
         D3D12_RANGE_UINT64(o)
     {}
-    CD3DX12_RANGE_UINT64( 
-        UINT64 begin, 
-        UINT64 end )
+    CD3DX12_RANGE_UINT64(
+        UINT64 begin,
+        UINT64 end ) noexcept
     {
         Begin = begin;
         End = end;
@@ -594,20 +591,20 @@ struct CD3DX12_RANGE_UINT64 : public D3D12_RANGE_UINT64
 struct CD3DX12_SUBRESOURCE_RANGE_UINT64 : public D3D12_SUBRESOURCE_RANGE_UINT64
 {
     CD3DX12_SUBRESOURCE_RANGE_UINT64() = default;
-    explicit CD3DX12_SUBRESOURCE_RANGE_UINT64(const D3D12_SUBRESOURCE_RANGE_UINT64 &o) :
+    explicit CD3DX12_SUBRESOURCE_RANGE_UINT64(const D3D12_SUBRESOURCE_RANGE_UINT64 &o) noexcept :
         D3D12_SUBRESOURCE_RANGE_UINT64(o)
     {}
-    CD3DX12_SUBRESOURCE_RANGE_UINT64( 
+    CD3DX12_SUBRESOURCE_RANGE_UINT64(
         UINT subresource,
-        const D3D12_RANGE_UINT64& range )
+        const D3D12_RANGE_UINT64& range ) noexcept
     {
         Subresource = subresource;
         Range = range;
     }
-    CD3DX12_SUBRESOURCE_RANGE_UINT64( 
+    CD3DX12_SUBRESOURCE_RANGE_UINT64(
         UINT subresource,
-        UINT64 begin, 
-        UINT64 end )
+        UINT64 begin,
+        UINT64 end ) noexcept
     {
         Subresource = subresource;
         Range.Begin = begin;
@@ -619,18 +616,18 @@ struct CD3DX12_SUBRESOURCE_RANGE_UINT64 : public D3D12_SUBRESOURCE_RANGE_UINT64
 struct CD3DX12_SHADER_BYTECODE : public D3D12_SHADER_BYTECODE
 {
     CD3DX12_SHADER_BYTECODE() = default;
-    explicit CD3DX12_SHADER_BYTECODE(const D3D12_SHADER_BYTECODE &o) :
+    explicit CD3DX12_SHADER_BYTECODE(const D3D12_SHADER_BYTECODE &o) noexcept :
         D3D12_SHADER_BYTECODE(o)
     {}
     CD3DX12_SHADER_BYTECODE(
-        _In_ ID3DBlob* pShaderBlob )
+        _In_ ID3DBlob* pShaderBlob ) noexcept
     {
         pShaderBytecode = pShaderBlob->GetBufferPointer();
         BytecodeLength = pShaderBlob->GetBufferSize();
     }
     CD3DX12_SHADER_BYTECODE(
         const void* _pShaderBytecode,
-        SIZE_T bytecodeLength )
+        SIZE_T bytecodeLength ) noexcept
     {
         pShaderBytecode = _pShaderBytecode;
         BytecodeLength = bytecodeLength;
@@ -641,14 +638,14 @@ struct CD3DX12_SHADER_BYTECODE : public D3D12_SHADER_BYTECODE
 struct CD3DX12_TILED_RESOURCE_COORDINATE : public D3D12_TILED_RESOURCE_COORDINATE
 {
     CD3DX12_TILED_RESOURCE_COORDINATE() = default;
-    explicit CD3DX12_TILED_RESOURCE_COORDINATE(const D3D12_TILED_RESOURCE_COORDINATE &o) :
+    explicit CD3DX12_TILED_RESOURCE_COORDINATE(const D3D12_TILED_RESOURCE_COORDINATE &o) noexcept :
         D3D12_TILED_RESOURCE_COORDINATE(o)
     {}
-    CD3DX12_TILED_RESOURCE_COORDINATE( 
-        UINT x, 
-        UINT y, 
-        UINT z, 
-        UINT subresource ) 
+    CD3DX12_TILED_RESOURCE_COORDINATE(
+        UINT x,
+        UINT y,
+        UINT z,
+        UINT subresource ) noexcept
     {
         X = x;
         Y = y;
@@ -661,15 +658,15 @@ struct CD3DX12_TILED_RESOURCE_COORDINATE : public D3D12_TILED_RESOURCE_COORDINAT
 struct CD3DX12_TILE_REGION_SIZE : public D3D12_TILE_REGION_SIZE
 {
     CD3DX12_TILE_REGION_SIZE() = default;
-    explicit CD3DX12_TILE_REGION_SIZE(const D3D12_TILE_REGION_SIZE &o) :
+    explicit CD3DX12_TILE_REGION_SIZE(const D3D12_TILE_REGION_SIZE &o) noexcept :
         D3D12_TILE_REGION_SIZE(o)
     {}
-    CD3DX12_TILE_REGION_SIZE( 
-        UINT numTiles, 
-        BOOL useBox, 
-        UINT width, 
-        UINT16 height, 
-        UINT16 depth ) 
+    CD3DX12_TILE_REGION_SIZE(
+        UINT numTiles,
+        BOOL useBox,
+        UINT width,
+        UINT16 height,
+        UINT16 depth ) noexcept
     {
         NumTiles = numTiles;
         UseBox = useBox;
@@ -683,14 +680,14 @@ struct CD3DX12_TILE_REGION_SIZE : public D3D12_TILE_REGION_SIZE
 struct CD3DX12_SUBRESOURCE_TILING : public D3D12_SUBRESOURCE_TILING
 {
     CD3DX12_SUBRESOURCE_TILING() = default;
-    explicit CD3DX12_SUBRESOURCE_TILING(const D3D12_SUBRESOURCE_TILING &o) :
+    explicit CD3DX12_SUBRESOURCE_TILING(const D3D12_SUBRESOURCE_TILING &o) noexcept :
         D3D12_SUBRESOURCE_TILING(o)
     {}
-    CD3DX12_SUBRESOURCE_TILING( 
-        UINT widthInTiles, 
-        UINT16 heightInTiles, 
-        UINT16 depthInTiles, 
-        UINT startTileIndexInOverallResource ) 
+    CD3DX12_SUBRESOURCE_TILING(
+        UINT widthInTiles,
+        UINT16 heightInTiles,
+        UINT16 depthInTiles,
+        UINT startTileIndexInOverallResource ) noexcept
     {
         WidthInTiles = widthInTiles;
         HeightInTiles = heightInTiles;
@@ -703,13 +700,13 @@ struct CD3DX12_SUBRESOURCE_TILING : public D3D12_SUBRESOURCE_TILING
 struct CD3DX12_TILE_SHAPE : public D3D12_TILE_SHAPE
 {
     CD3DX12_TILE_SHAPE() = default;
-    explicit CD3DX12_TILE_SHAPE(const D3D12_TILE_SHAPE &o) :
+    explicit CD3DX12_TILE_SHAPE(const D3D12_TILE_SHAPE &o) noexcept :
         D3D12_TILE_SHAPE(o)
     {}
-    CD3DX12_TILE_SHAPE( 
-        UINT widthInTexels, 
-        UINT heightInTexels, 
-        UINT depthInTexels ) 
+    CD3DX12_TILE_SHAPE(
+        UINT widthInTexels,
+        UINT heightInTexels,
+        UINT depthInTexels ) noexcept
     {
         WidthInTexels = widthInTexels;
         HeightInTexels = heightInTexels;
@@ -721,7 +718,7 @@ struct CD3DX12_TILE_SHAPE : public D3D12_TILE_SHAPE
 struct CD3DX12_RESOURCE_BARRIER : public D3D12_RESOURCE_BARRIER
 {
     CD3DX12_RESOURCE_BARRIER() = default;
-    explicit CD3DX12_RESOURCE_BARRIER(const D3D12_RESOURCE_BARRIER &o) :
+    explicit CD3DX12_RESOURCE_BARRIER(const D3D12_RESOURCE_BARRIER &o) noexcept :
         D3D12_RESOURCE_BARRIER(o)
     {}
     static inline CD3DX12_RESOURCE_BARRIER Transition(
@@ -729,7 +726,7 @@ struct CD3DX12_RESOURCE_BARRIER : public D3D12_RESOURCE_BARRIER
         D3D12_RESOURCE_STATES stateBefore,
         D3D12_RESOURCE_STATES stateAfter,
         UINT subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
-        D3D12_RESOURCE_BARRIER_FLAGS flags = D3D12_RESOURCE_BARRIER_FLAG_NONE)
+        D3D12_RESOURCE_BARRIER_FLAGS flags = D3D12_RESOURCE_BARRIER_FLAG_NONE) noexcept
     {
         CD3DX12_RESOURCE_BARRIER result = {};
         D3D12_RESOURCE_BARRIER &barrier = result;
@@ -743,7 +740,7 @@ struct CD3DX12_RESOURCE_BARRIER : public D3D12_RESOURCE_BARRIER
     }
     static inline CD3DX12_RESOURCE_BARRIER Aliasing(
         _In_ ID3D12Resource* pResourceBefore,
-        _In_ ID3D12Resource* pResourceAfter)
+        _In_ ID3D12Resource* pResourceAfter) noexcept
     {
         CD3DX12_RESOURCE_BARRIER result = {};
         D3D12_RESOURCE_BARRIER &barrier = result;
@@ -753,7 +750,7 @@ struct CD3DX12_RESOURCE_BARRIER : public D3D12_RESOURCE_BARRIER
         return result;
     }
     static inline CD3DX12_RESOURCE_BARRIER UAV(
-        _In_ ID3D12Resource* pResource)
+        _In_ ID3D12Resource* pResource) noexcept
     {
         CD3DX12_RESOURCE_BARRIER result = {};
         D3D12_RESOURCE_BARRIER &barrier = result;
@@ -767,14 +764,14 @@ struct CD3DX12_RESOURCE_BARRIER : public D3D12_RESOURCE_BARRIER
 struct CD3DX12_PACKED_MIP_INFO : public D3D12_PACKED_MIP_INFO
 {
     CD3DX12_PACKED_MIP_INFO() = default;
-    explicit CD3DX12_PACKED_MIP_INFO(const D3D12_PACKED_MIP_INFO &o) :
+    explicit CD3DX12_PACKED_MIP_INFO(const D3D12_PACKED_MIP_INFO &o) noexcept :
         D3D12_PACKED_MIP_INFO(o)
     {}
-    CD3DX12_PACKED_MIP_INFO( 
-        UINT8 numStandardMips, 
-        UINT8 numPackedMips, 
-        UINT numTilesForPackedMips, 
-        UINT startTileIndexInOverallResource ) 
+    CD3DX12_PACKED_MIP_INFO(
+        UINT8 numStandardMips,
+        UINT8 numPackedMips,
+        UINT numTilesForPackedMips,
+        UINT startTileIndexInOverallResource ) noexcept
     {
         NumStandardMips = numStandardMips;
         NumPackedMips = numPackedMips;
@@ -787,15 +784,15 @@ struct CD3DX12_PACKED_MIP_INFO : public D3D12_PACKED_MIP_INFO
 struct CD3DX12_SUBRESOURCE_FOOTPRINT : public D3D12_SUBRESOURCE_FOOTPRINT
 {
     CD3DX12_SUBRESOURCE_FOOTPRINT() = default;
-    explicit CD3DX12_SUBRESOURCE_FOOTPRINT(const D3D12_SUBRESOURCE_FOOTPRINT &o) :
+    explicit CD3DX12_SUBRESOURCE_FOOTPRINT(const D3D12_SUBRESOURCE_FOOTPRINT &o) noexcept :
         D3D12_SUBRESOURCE_FOOTPRINT(o)
     {}
-    CD3DX12_SUBRESOURCE_FOOTPRINT( 
-        DXGI_FORMAT format, 
-        UINT width, 
-        UINT height, 
-        UINT depth, 
-        UINT rowPitch ) 
+    CD3DX12_SUBRESOURCE_FOOTPRINT(
+        DXGI_FORMAT format,
+        UINT width,
+        UINT height,
+        UINT depth,
+        UINT rowPitch ) noexcept
     {
         Format = format;
         Width = width;
@@ -803,9 +800,9 @@ struct CD3DX12_SUBRESOURCE_FOOTPRINT : public D3D12_SUBRESOURCE_FOOTPRINT
         Depth = depth;
         RowPitch = rowPitch;
     }
-    explicit CD3DX12_SUBRESOURCE_FOOTPRINT( 
-        const D3D12_RESOURCE_DESC& resDesc, 
-        UINT rowPitch ) 
+    explicit CD3DX12_SUBRESOURCE_FOOTPRINT(
+        const D3D12_RESOURCE_DESC& resDesc,
+        UINT rowPitch ) noexcept
     {
         Format = resDesc.Format;
         Width = UINT( resDesc.Width );
@@ -817,36 +814,37 @@ struct CD3DX12_SUBRESOURCE_FOOTPRINT : public D3D12_SUBRESOURCE_FOOTPRINT
 
 //------------------------------------------------------------------------------------------------
 struct CD3DX12_TEXTURE_COPY_LOCATION : public D3D12_TEXTURE_COPY_LOCATION
-{ 
+{
     CD3DX12_TEXTURE_COPY_LOCATION() = default;
-    explicit CD3DX12_TEXTURE_COPY_LOCATION(const D3D12_TEXTURE_COPY_LOCATION &o) :
+    explicit CD3DX12_TEXTURE_COPY_LOCATION(const D3D12_TEXTURE_COPY_LOCATION &o) noexcept :
         D3D12_TEXTURE_COPY_LOCATION(o)
     {}
-    CD3DX12_TEXTURE_COPY_LOCATION(_In_ ID3D12Resource* pRes)
+    CD3DX12_TEXTURE_COPY_LOCATION(_In_ ID3D12Resource* pRes) noexcept
     {
         pResource = pRes;
         Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
         PlacedFootprint = {};
     }
-    CD3DX12_TEXTURE_COPY_LOCATION(_In_ ID3D12Resource* pRes, D3D12_PLACED_SUBRESOURCE_FOOTPRINT const& Footprint)
+    CD3DX12_TEXTURE_COPY_LOCATION(_In_ ID3D12Resource* pRes, D3D12_PLACED_SUBRESOURCE_FOOTPRINT const& Footprint) noexcept
     {
         pResource = pRes;
         Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
         PlacedFootprint = Footprint;
     }
-    CD3DX12_TEXTURE_COPY_LOCATION(_In_ ID3D12Resource* pRes, UINT Sub)
+    CD3DX12_TEXTURE_COPY_LOCATION(_In_ ID3D12Resource* pRes, UINT Sub) noexcept
     {
         pResource = pRes;
         Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+        PlacedFootprint = {};
         SubresourceIndex = Sub;
     }
-}; 
+};
 
 //------------------------------------------------------------------------------------------------
 struct CD3DX12_DESCRIPTOR_RANGE : public D3D12_DESCRIPTOR_RANGE
 {
     CD3DX12_DESCRIPTOR_RANGE() = default;
-    explicit CD3DX12_DESCRIPTOR_RANGE(const D3D12_DESCRIPTOR_RANGE &o) :
+    explicit CD3DX12_DESCRIPTOR_RANGE(const D3D12_DESCRIPTOR_RANGE &o) noexcept :
         D3D12_DESCRIPTOR_RANGE(o)
     {}
     CD3DX12_DESCRIPTOR_RANGE(
@@ -855,22 +853,22 @@ struct CD3DX12_DESCRIPTOR_RANGE : public D3D12_DESCRIPTOR_RANGE
         UINT baseShaderRegister,
         UINT registerSpace = 0,
         UINT offsetInDescriptorsFromTableStart =
-        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND)
+        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND) noexcept
     {
         Init(rangeType, numDescriptors, baseShaderRegister, registerSpace, offsetInDescriptorsFromTableStart);
     }
-    
+
     inline void Init(
         D3D12_DESCRIPTOR_RANGE_TYPE rangeType,
         UINT numDescriptors,
         UINT baseShaderRegister,
         UINT registerSpace = 0,
         UINT offsetInDescriptorsFromTableStart =
-        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND)
+        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND) noexcept
     {
         Init(*this, rangeType, numDescriptors, baseShaderRegister, registerSpace, offsetInDescriptorsFromTableStart);
     }
-    
+
     static inline void Init(
         _Out_ D3D12_DESCRIPTOR_RANGE &range,
         D3D12_DESCRIPTOR_RANGE_TYPE rangeType,
@@ -878,7 +876,7 @@ struct CD3DX12_DESCRIPTOR_RANGE : public D3D12_DESCRIPTOR_RANGE
         UINT baseShaderRegister,
         UINT registerSpace = 0,
         UINT offsetInDescriptorsFromTableStart =
-        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND)
+        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND) noexcept
     {
         range.RangeType = rangeType;
         range.NumDescriptors = numDescriptors;
@@ -892,27 +890,27 @@ struct CD3DX12_DESCRIPTOR_RANGE : public D3D12_DESCRIPTOR_RANGE
 struct CD3DX12_ROOT_DESCRIPTOR_TABLE : public D3D12_ROOT_DESCRIPTOR_TABLE
 {
     CD3DX12_ROOT_DESCRIPTOR_TABLE() = default;
-    explicit CD3DX12_ROOT_DESCRIPTOR_TABLE(const D3D12_ROOT_DESCRIPTOR_TABLE &o) :
+    explicit CD3DX12_ROOT_DESCRIPTOR_TABLE(const D3D12_ROOT_DESCRIPTOR_TABLE &o) noexcept :
         D3D12_ROOT_DESCRIPTOR_TABLE(o)
     {}
     CD3DX12_ROOT_DESCRIPTOR_TABLE(
         UINT numDescriptorRanges,
-        _In_reads_opt_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE* _pDescriptorRanges)
+        _In_reads_opt_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE* _pDescriptorRanges) noexcept
     {
         Init(numDescriptorRanges, _pDescriptorRanges);
     }
-    
+
     inline void Init(
         UINT numDescriptorRanges,
-        _In_reads_opt_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE* _pDescriptorRanges)
+        _In_reads_opt_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE* _pDescriptorRanges) noexcept
     {
         Init(*this, numDescriptorRanges, _pDescriptorRanges);
     }
-    
+
     static inline void Init(
         _Out_ D3D12_ROOT_DESCRIPTOR_TABLE &rootDescriptorTable,
         UINT numDescriptorRanges,
-        _In_reads_opt_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE* _pDescriptorRanges)
+        _In_reads_opt_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE* _pDescriptorRanges) noexcept
     {
         rootDescriptorTable.NumDescriptorRanges = numDescriptorRanges;
         rootDescriptorTable.pDescriptorRanges = _pDescriptorRanges;
@@ -923,30 +921,30 @@ struct CD3DX12_ROOT_DESCRIPTOR_TABLE : public D3D12_ROOT_DESCRIPTOR_TABLE
 struct CD3DX12_ROOT_CONSTANTS : public D3D12_ROOT_CONSTANTS
 {
     CD3DX12_ROOT_CONSTANTS() = default;
-    explicit CD3DX12_ROOT_CONSTANTS(const D3D12_ROOT_CONSTANTS &o) :
+    explicit CD3DX12_ROOT_CONSTANTS(const D3D12_ROOT_CONSTANTS &o) noexcept :
         D3D12_ROOT_CONSTANTS(o)
     {}
     CD3DX12_ROOT_CONSTANTS(
         UINT num32BitValues,
         UINT shaderRegister,
-        UINT registerSpace = 0)
+        UINT registerSpace = 0) noexcept
     {
         Init(num32BitValues, shaderRegister, registerSpace);
     }
-    
+
     inline void Init(
         UINT num32BitValues,
         UINT shaderRegister,
-        UINT registerSpace = 0)
+        UINT registerSpace = 0) noexcept
     {
         Init(*this, num32BitValues, shaderRegister, registerSpace);
     }
-    
+
     static inline void Init(
         _Out_ D3D12_ROOT_CONSTANTS &rootConstants,
         UINT num32BitValues,
         UINT shaderRegister,
-        UINT registerSpace = 0)
+        UINT registerSpace = 0) noexcept
     {
         rootConstants.Num32BitValues = num32BitValues;
         rootConstants.ShaderRegister = shaderRegister;
@@ -958,24 +956,24 @@ struct CD3DX12_ROOT_CONSTANTS : public D3D12_ROOT_CONSTANTS
 struct CD3DX12_ROOT_DESCRIPTOR : public D3D12_ROOT_DESCRIPTOR
 {
     CD3DX12_ROOT_DESCRIPTOR() = default;
-    explicit CD3DX12_ROOT_DESCRIPTOR(const D3D12_ROOT_DESCRIPTOR &o) :
+    explicit CD3DX12_ROOT_DESCRIPTOR(const D3D12_ROOT_DESCRIPTOR &o) noexcept :
         D3D12_ROOT_DESCRIPTOR(o)
     {}
     CD3DX12_ROOT_DESCRIPTOR(
         UINT shaderRegister,
-        UINT registerSpace = 0)
+        UINT registerSpace = 0) noexcept
     {
         Init(shaderRegister, registerSpace);
     }
-    
+
     inline void Init(
         UINT shaderRegister,
-        UINT registerSpace = 0)
+        UINT registerSpace = 0) noexcept
     {
         Init(*this, shaderRegister, registerSpace);
     }
-    
-    static inline void Init(_Out_ D3D12_ROOT_DESCRIPTOR &table, UINT shaderRegister, UINT registerSpace = 0)
+
+    static inline void Init(_Out_ D3D12_ROOT_DESCRIPTOR &table, UINT shaderRegister, UINT registerSpace = 0) noexcept
     {
         table.ShaderRegister = shaderRegister;
         table.RegisterSpace = registerSpace;
@@ -986,15 +984,15 @@ struct CD3DX12_ROOT_DESCRIPTOR : public D3D12_ROOT_DESCRIPTOR
 struct CD3DX12_ROOT_PARAMETER : public D3D12_ROOT_PARAMETER
 {
     CD3DX12_ROOT_PARAMETER() = default;
-    explicit CD3DX12_ROOT_PARAMETER(const D3D12_ROOT_PARAMETER &o) :
+    explicit CD3DX12_ROOT_PARAMETER(const D3D12_ROOT_PARAMETER &o) noexcept :
         D3D12_ROOT_PARAMETER(o)
     {}
-    
+
     static inline void InitAsDescriptorTable(
         _Out_ D3D12_ROOT_PARAMETER &rootParam,
         UINT numDescriptorRanges,
         _In_reads_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE* pDescriptorRanges,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         rootParam.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
         rootParam.ShaderVisibility = visibility;
@@ -1006,7 +1004,7 @@ struct CD3DX12_ROOT_PARAMETER : public D3D12_ROOT_PARAMETER
         UINT num32BitValues,
         UINT shaderRegister,
         UINT registerSpace = 0,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         rootParam.ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
         rootParam.ShaderVisibility = visibility;
@@ -1017,7 +1015,7 @@ struct CD3DX12_ROOT_PARAMETER : public D3D12_ROOT_PARAMETER
         _Out_ D3D12_ROOT_PARAMETER &rootParam,
         UINT shaderRegister,
         UINT registerSpace = 0,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         rootParam.ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
         rootParam.ShaderVisibility = visibility;
@@ -1028,7 +1026,7 @@ struct CD3DX12_ROOT_PARAMETER : public D3D12_ROOT_PARAMETER
         _Out_ D3D12_ROOT_PARAMETER &rootParam,
         UINT shaderRegister,
         UINT registerSpace = 0,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         rootParam.ParameterType = D3D12_ROOT_PARAMETER_TYPE_SRV;
         rootParam.ShaderVisibility = visibility;
@@ -1039,26 +1037,26 @@ struct CD3DX12_ROOT_PARAMETER : public D3D12_ROOT_PARAMETER
         _Out_ D3D12_ROOT_PARAMETER &rootParam,
         UINT shaderRegister,
         UINT registerSpace = 0,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         rootParam.ParameterType = D3D12_ROOT_PARAMETER_TYPE_UAV;
         rootParam.ShaderVisibility = visibility;
         CD3DX12_ROOT_DESCRIPTOR::Init(rootParam.Descriptor, shaderRegister, registerSpace);
     }
-    
+
     inline void InitAsDescriptorTable(
         UINT numDescriptorRanges,
         _In_reads_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE* pDescriptorRanges,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         InitAsDescriptorTable(*this, numDescriptorRanges, pDescriptorRanges, visibility);
     }
-    
+
     inline void InitAsConstants(
         UINT num32BitValues,
         UINT shaderRegister,
         UINT registerSpace = 0,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         InitAsConstants(*this, num32BitValues, shaderRegister, registerSpace, visibility);
     }
@@ -1066,7 +1064,7 @@ struct CD3DX12_ROOT_PARAMETER : public D3D12_ROOT_PARAMETER
     inline void InitAsConstantBufferView(
         UINT shaderRegister,
         UINT registerSpace = 0,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         InitAsConstantBufferView(*this, shaderRegister, registerSpace, visibility);
     }
@@ -1074,7 +1072,7 @@ struct CD3DX12_ROOT_PARAMETER : public D3D12_ROOT_PARAMETER
     inline void InitAsShaderResourceView(
         UINT shaderRegister,
         UINT registerSpace = 0,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         InitAsShaderResourceView(*this, shaderRegister, registerSpace, visibility);
     }
@@ -1082,7 +1080,7 @@ struct CD3DX12_ROOT_PARAMETER : public D3D12_ROOT_PARAMETER
     inline void InitAsUnorderedAccessView(
         UINT shaderRegister,
         UINT registerSpace = 0,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         InitAsUnorderedAccessView(*this, shaderRegister, registerSpace, visibility);
     }
@@ -1092,7 +1090,7 @@ struct CD3DX12_ROOT_PARAMETER : public D3D12_ROOT_PARAMETER
 struct CD3DX12_STATIC_SAMPLER_DESC : public D3D12_STATIC_SAMPLER_DESC
 {
     CD3DX12_STATIC_SAMPLER_DESC() = default;
-    explicit CD3DX12_STATIC_SAMPLER_DESC(const D3D12_STATIC_SAMPLER_DESC &o) :
+    explicit CD3DX12_STATIC_SAMPLER_DESC(const D3D12_STATIC_SAMPLER_DESC &o) noexcept :
         D3D12_STATIC_SAMPLER_DESC(o)
     {}
     CD3DX12_STATIC_SAMPLER_DESC(
@@ -1107,8 +1105,8 @@ struct CD3DX12_STATIC_SAMPLER_DESC : public D3D12_STATIC_SAMPLER_DESC
          D3D12_STATIC_BORDER_COLOR borderColor = D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE,
          FLOAT minLOD = 0.f,
          FLOAT maxLOD = D3D12_FLOAT32_MAX,
-         D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, 
-         UINT registerSpace = 0)
+         D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL,
+         UINT registerSpace = 0) noexcept
     {
         Init(
             shaderRegister,
@@ -1125,7 +1123,7 @@ struct CD3DX12_STATIC_SAMPLER_DESC : public D3D12_STATIC_SAMPLER_DESC
             shaderVisibility,
             registerSpace);
     }
-    
+
     static inline void Init(
         _Out_ D3D12_STATIC_SAMPLER_DESC &samplerDesc,
          UINT shaderRegister,
@@ -1139,8 +1137,8 @@ struct CD3DX12_STATIC_SAMPLER_DESC : public D3D12_STATIC_SAMPLER_DESC
          D3D12_STATIC_BORDER_COLOR borderColor = D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE,
          FLOAT minLOD = 0.f,
          FLOAT maxLOD = D3D12_FLOAT32_MAX,
-         D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, 
-         UINT registerSpace = 0)
+         D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL,
+         UINT registerSpace = 0) noexcept
     {
         samplerDesc.ShaderRegister = shaderRegister;
         samplerDesc.Filter = filter;
@@ -1168,8 +1166,8 @@ struct CD3DX12_STATIC_SAMPLER_DESC : public D3D12_STATIC_SAMPLER_DESC
          D3D12_STATIC_BORDER_COLOR borderColor = D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE,
          FLOAT minLOD = 0.f,
          FLOAT maxLOD = D3D12_FLOAT32_MAX,
-         D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL, 
-         UINT registerSpace = 0)
+         D3D12_SHADER_VISIBILITY shaderVisibility = D3D12_SHADER_VISIBILITY_ALL,
+         UINT registerSpace = 0) noexcept
     {
         Init(
             *this,
@@ -1187,14 +1185,14 @@ struct CD3DX12_STATIC_SAMPLER_DESC : public D3D12_STATIC_SAMPLER_DESC
             shaderVisibility,
             registerSpace);
     }
-    
+
 };
 
 //------------------------------------------------------------------------------------------------
 struct CD3DX12_ROOT_SIGNATURE_DESC : public D3D12_ROOT_SIGNATURE_DESC
 {
     CD3DX12_ROOT_SIGNATURE_DESC() = default;
-    explicit CD3DX12_ROOT_SIGNATURE_DESC(const D3D12_ROOT_SIGNATURE_DESC &o) :
+    explicit CD3DX12_ROOT_SIGNATURE_DESC(const D3D12_ROOT_SIGNATURE_DESC &o) noexcept :
         D3D12_ROOT_SIGNATURE_DESC(o)
     {}
     CD3DX12_ROOT_SIGNATURE_DESC(
@@ -1202,21 +1200,21 @@ struct CD3DX12_ROOT_SIGNATURE_DESC : public D3D12_ROOT_SIGNATURE_DESC
         _In_reads_opt_(numParameters) const D3D12_ROOT_PARAMETER* _pParameters,
         UINT numStaticSamplers = 0,
         _In_reads_opt_(numStaticSamplers) const D3D12_STATIC_SAMPLER_DESC* _pStaticSamplers = nullptr,
-        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE)
+        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE) noexcept
     {
         Init(numParameters, _pParameters, numStaticSamplers, _pStaticSamplers, flags);
     }
-    CD3DX12_ROOT_SIGNATURE_DESC(CD3DX12_DEFAULT)
+    CD3DX12_ROOT_SIGNATURE_DESC(CD3DX12_DEFAULT) noexcept
     {
         Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_NONE);
     }
-    
+
     inline void Init(
         UINT numParameters,
         _In_reads_opt_(numParameters) const D3D12_ROOT_PARAMETER* _pParameters,
         UINT numStaticSamplers = 0,
         _In_reads_opt_(numStaticSamplers) const D3D12_STATIC_SAMPLER_DESC* _pStaticSamplers = nullptr,
-        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE)
+        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE) noexcept
     {
         Init(*this, numParameters, _pParameters, numStaticSamplers, _pStaticSamplers, flags);
     }
@@ -1227,7 +1225,7 @@ struct CD3DX12_ROOT_SIGNATURE_DESC : public D3D12_ROOT_SIGNATURE_DESC
         _In_reads_opt_(numParameters) const D3D12_ROOT_PARAMETER* _pParameters,
         UINT numStaticSamplers = 0,
         _In_reads_opt_(numStaticSamplers) const D3D12_STATIC_SAMPLER_DESC* _pStaticSamplers = nullptr,
-        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE)
+        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE) noexcept
     {
         desc.NumParameters = numParameters;
         desc.pParameters = _pParameters;
@@ -1241,7 +1239,7 @@ struct CD3DX12_ROOT_SIGNATURE_DESC : public D3D12_ROOT_SIGNATURE_DESC
 struct CD3DX12_DESCRIPTOR_RANGE1 : public D3D12_DESCRIPTOR_RANGE1
 {
     CD3DX12_DESCRIPTOR_RANGE1() = default;
-    explicit CD3DX12_DESCRIPTOR_RANGE1(const D3D12_DESCRIPTOR_RANGE1 &o) :
+    explicit CD3DX12_DESCRIPTOR_RANGE1(const D3D12_DESCRIPTOR_RANGE1 &o) noexcept :
         D3D12_DESCRIPTOR_RANGE1(o)
     {}
     CD3DX12_DESCRIPTOR_RANGE1(
@@ -1251,11 +1249,11 @@ struct CD3DX12_DESCRIPTOR_RANGE1 : public D3D12_DESCRIPTOR_RANGE1
         UINT registerSpace = 0,
         D3D12_DESCRIPTOR_RANGE_FLAGS flags = D3D12_DESCRIPTOR_RANGE_FLAG_NONE,
         UINT offsetInDescriptorsFromTableStart =
-        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND)
+        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND) noexcept
     {
         Init(rangeType, numDescriptors, baseShaderRegister, registerSpace, flags, offsetInDescriptorsFromTableStart);
     }
-    
+
     inline void Init(
         D3D12_DESCRIPTOR_RANGE_TYPE rangeType,
         UINT numDescriptors,
@@ -1263,11 +1261,11 @@ struct CD3DX12_DESCRIPTOR_RANGE1 : public D3D12_DESCRIPTOR_RANGE1
         UINT registerSpace = 0,
         D3D12_DESCRIPTOR_RANGE_FLAGS flags = D3D12_DESCRIPTOR_RANGE_FLAG_NONE,
         UINT offsetInDescriptorsFromTableStart =
-        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND)
+        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND) noexcept
     {
         Init(*this, rangeType, numDescriptors, baseShaderRegister, registerSpace, flags, offsetInDescriptorsFromTableStart);
     }
-    
+
     static inline void Init(
         _Out_ D3D12_DESCRIPTOR_RANGE1 &range,
         D3D12_DESCRIPTOR_RANGE_TYPE rangeType,
@@ -1276,7 +1274,7 @@ struct CD3DX12_DESCRIPTOR_RANGE1 : public D3D12_DESCRIPTOR_RANGE1
         UINT registerSpace = 0,
         D3D12_DESCRIPTOR_RANGE_FLAGS flags = D3D12_DESCRIPTOR_RANGE_FLAG_NONE,
         UINT offsetInDescriptorsFromTableStart =
-        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND)
+        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND) noexcept
     {
         range.RangeType = rangeType;
         range.NumDescriptors = numDescriptors;
@@ -1291,27 +1289,27 @@ struct CD3DX12_DESCRIPTOR_RANGE1 : public D3D12_DESCRIPTOR_RANGE1
 struct CD3DX12_ROOT_DESCRIPTOR_TABLE1 : public D3D12_ROOT_DESCRIPTOR_TABLE1
 {
     CD3DX12_ROOT_DESCRIPTOR_TABLE1() = default;
-    explicit CD3DX12_ROOT_DESCRIPTOR_TABLE1(const D3D12_ROOT_DESCRIPTOR_TABLE1 &o) :
+    explicit CD3DX12_ROOT_DESCRIPTOR_TABLE1(const D3D12_ROOT_DESCRIPTOR_TABLE1 &o) noexcept :
         D3D12_ROOT_DESCRIPTOR_TABLE1(o)
     {}
     CD3DX12_ROOT_DESCRIPTOR_TABLE1(
         UINT numDescriptorRanges,
-        _In_reads_opt_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE1* _pDescriptorRanges)
+        _In_reads_opt_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE1* _pDescriptorRanges) noexcept
     {
         Init(numDescriptorRanges, _pDescriptorRanges);
     }
-    
+
     inline void Init(
         UINT numDescriptorRanges,
-        _In_reads_opt_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE1* _pDescriptorRanges)
+        _In_reads_opt_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE1* _pDescriptorRanges) noexcept
     {
         Init(*this, numDescriptorRanges, _pDescriptorRanges);
     }
-    
+
     static inline void Init(
         _Out_ D3D12_ROOT_DESCRIPTOR_TABLE1 &rootDescriptorTable,
         UINT numDescriptorRanges,
-        _In_reads_opt_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE1* _pDescriptorRanges)
+        _In_reads_opt_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE1* _pDescriptorRanges) noexcept
     {
         rootDescriptorTable.NumDescriptorRanges = numDescriptorRanges;
         rootDescriptorTable.pDescriptorRanges = _pDescriptorRanges;
@@ -1322,30 +1320,30 @@ struct CD3DX12_ROOT_DESCRIPTOR_TABLE1 : public D3D12_ROOT_DESCRIPTOR_TABLE1
 struct CD3DX12_ROOT_DESCRIPTOR1 : public D3D12_ROOT_DESCRIPTOR1
 {
     CD3DX12_ROOT_DESCRIPTOR1() = default;
-    explicit CD3DX12_ROOT_DESCRIPTOR1(const D3D12_ROOT_DESCRIPTOR1 &o) :
+    explicit CD3DX12_ROOT_DESCRIPTOR1(const D3D12_ROOT_DESCRIPTOR1 &o) noexcept :
         D3D12_ROOT_DESCRIPTOR1(o)
     {}
     CD3DX12_ROOT_DESCRIPTOR1(
         UINT shaderRegister,
         UINT registerSpace = 0,
-        D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE)
+        D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE) noexcept
     {
         Init(shaderRegister, registerSpace, flags);
     }
-    
+
     inline void Init(
         UINT shaderRegister,
         UINT registerSpace = 0,
-        D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE)
+        D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE) noexcept
     {
         Init(*this, shaderRegister, registerSpace, flags);
     }
-    
+
     static inline void Init(
-        _Out_ D3D12_ROOT_DESCRIPTOR1 &table, 
-        UINT shaderRegister, 
-        UINT registerSpace = 0, 
-        D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE)
+        _Out_ D3D12_ROOT_DESCRIPTOR1 &table,
+        UINT shaderRegister,
+        UINT registerSpace = 0,
+        D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE) noexcept
     {
         table.ShaderRegister = shaderRegister;
         table.RegisterSpace = registerSpace;
@@ -1357,15 +1355,15 @@ struct CD3DX12_ROOT_DESCRIPTOR1 : public D3D12_ROOT_DESCRIPTOR1
 struct CD3DX12_ROOT_PARAMETER1 : public D3D12_ROOT_PARAMETER1
 {
     CD3DX12_ROOT_PARAMETER1() = default;
-    explicit CD3DX12_ROOT_PARAMETER1(const D3D12_ROOT_PARAMETER1 &o) :
+    explicit CD3DX12_ROOT_PARAMETER1(const D3D12_ROOT_PARAMETER1 &o) noexcept :
         D3D12_ROOT_PARAMETER1(o)
     {}
-    
+
     static inline void InitAsDescriptorTable(
         _Out_ D3D12_ROOT_PARAMETER1 &rootParam,
         UINT numDescriptorRanges,
         _In_reads_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE1* pDescriptorRanges,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         rootParam.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
         rootParam.ShaderVisibility = visibility;
@@ -1377,7 +1375,7 @@ struct CD3DX12_ROOT_PARAMETER1 : public D3D12_ROOT_PARAMETER1
         UINT num32BitValues,
         UINT shaderRegister,
         UINT registerSpace = 0,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         rootParam.ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
         rootParam.ShaderVisibility = visibility;
@@ -1389,7 +1387,7 @@ struct CD3DX12_ROOT_PARAMETER1 : public D3D12_ROOT_PARAMETER1
         UINT shaderRegister,
         UINT registerSpace = 0,
         D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         rootParam.ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
         rootParam.ShaderVisibility = visibility;
@@ -1401,7 +1399,7 @@ struct CD3DX12_ROOT_PARAMETER1 : public D3D12_ROOT_PARAMETER1
         UINT shaderRegister,
         UINT registerSpace = 0,
         D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         rootParam.ParameterType = D3D12_ROOT_PARAMETER_TYPE_SRV;
         rootParam.ShaderVisibility = visibility;
@@ -1413,26 +1411,26 @@ struct CD3DX12_ROOT_PARAMETER1 : public D3D12_ROOT_PARAMETER1
         UINT shaderRegister,
         UINT registerSpace = 0,
         D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         rootParam.ParameterType = D3D12_ROOT_PARAMETER_TYPE_UAV;
         rootParam.ShaderVisibility = visibility;
         CD3DX12_ROOT_DESCRIPTOR1::Init(rootParam.Descriptor, shaderRegister, registerSpace, flags);
     }
-    
+
     inline void InitAsDescriptorTable(
         UINT numDescriptorRanges,
         _In_reads_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE1* pDescriptorRanges,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         InitAsDescriptorTable(*this, numDescriptorRanges, pDescriptorRanges, visibility);
     }
-    
+
     inline void InitAsConstants(
         UINT num32BitValues,
         UINT shaderRegister,
         UINT registerSpace = 0,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         InitAsConstants(*this, num32BitValues, shaderRegister, registerSpace, visibility);
     }
@@ -1441,7 +1439,7 @@ struct CD3DX12_ROOT_PARAMETER1 : public D3D12_ROOT_PARAMETER1
         UINT shaderRegister,
         UINT registerSpace = 0,
         D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         InitAsConstantBufferView(*this, shaderRegister, registerSpace, flags, visibility);
     }
@@ -1450,7 +1448,7 @@ struct CD3DX12_ROOT_PARAMETER1 : public D3D12_ROOT_PARAMETER1
         UINT shaderRegister,
         UINT registerSpace = 0,
         D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         InitAsShaderResourceView(*this, shaderRegister, registerSpace, flags, visibility);
     }
@@ -1459,7 +1457,7 @@ struct CD3DX12_ROOT_PARAMETER1 : public D3D12_ROOT_PARAMETER1
         UINT shaderRegister,
         UINT registerSpace = 0,
         D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE,
-        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept
     {
         InitAsUnorderedAccessView(*this, shaderRegister, registerSpace, flags, visibility);
     }
@@ -1469,15 +1467,15 @@ struct CD3DX12_ROOT_PARAMETER1 : public D3D12_ROOT_PARAMETER1
 struct CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC : public D3D12_VERSIONED_ROOT_SIGNATURE_DESC
 {
     CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC() = default;
-    explicit CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC &o) :
+    explicit CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC &o) noexcept :
         D3D12_VERSIONED_ROOT_SIGNATURE_DESC(o)
     {}
-    explicit CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC(const D3D12_ROOT_SIGNATURE_DESC &o)
+    explicit CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC(const D3D12_ROOT_SIGNATURE_DESC &o) noexcept
     {
         Version = D3D_ROOT_SIGNATURE_VERSION_1_0;
         Desc_1_0 = o;
     }
-    explicit CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC(const D3D12_ROOT_SIGNATURE_DESC1 &o)
+    explicit CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC(const D3D12_ROOT_SIGNATURE_DESC1 &o) noexcept
     {
         Version = D3D_ROOT_SIGNATURE_VERSION_1_1;
         Desc_1_1 = o;
@@ -1487,7 +1485,7 @@ struct CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC : public D3D12_VERSIONED_ROOT_SIGNA
         _In_reads_opt_(numParameters) const D3D12_ROOT_PARAMETER* _pParameters,
         UINT numStaticSamplers = 0,
         _In_reads_opt_(numStaticSamplers) const D3D12_STATIC_SAMPLER_DESC* _pStaticSamplers = nullptr,
-        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE)
+        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE) noexcept
     {
         Init_1_0(numParameters, _pParameters, numStaticSamplers, _pStaticSamplers, flags);
     }
@@ -1496,21 +1494,21 @@ struct CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC : public D3D12_VERSIONED_ROOT_SIGNA
         _In_reads_opt_(numParameters) const D3D12_ROOT_PARAMETER1* _pParameters,
         UINT numStaticSamplers = 0,
         _In_reads_opt_(numStaticSamplers) const D3D12_STATIC_SAMPLER_DESC* _pStaticSamplers = nullptr,
-        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE)
+        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE) noexcept
     {
         Init_1_1(numParameters, _pParameters, numStaticSamplers, _pStaticSamplers, flags);
     }
-    CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC(CD3DX12_DEFAULT)
+    CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC(CD3DX12_DEFAULT) noexcept
     {
         Init_1_1(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_NONE);
     }
-    
+
     inline void Init_1_0(
         UINT numParameters,
         _In_reads_opt_(numParameters) const D3D12_ROOT_PARAMETER* _pParameters,
         UINT numStaticSamplers = 0,
         _In_reads_opt_(numStaticSamplers) const D3D12_STATIC_SAMPLER_DESC* _pStaticSamplers = nullptr,
-        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE)
+        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE) noexcept
     {
         Init_1_0(*this, numParameters, _pParameters, numStaticSamplers, _pStaticSamplers, flags);
     }
@@ -1521,7 +1519,7 @@ struct CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC : public D3D12_VERSIONED_ROOT_SIGNA
         _In_reads_opt_(numParameters) const D3D12_ROOT_PARAMETER* _pParameters,
         UINT numStaticSamplers = 0,
         _In_reads_opt_(numStaticSamplers) const D3D12_STATIC_SAMPLER_DESC* _pStaticSamplers = nullptr,
-        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE)
+        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE) noexcept
     {
         desc.Version = D3D_ROOT_SIGNATURE_VERSION_1_0;
         desc.Desc_1_0.NumParameters = numParameters;
@@ -1536,7 +1534,7 @@ struct CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC : public D3D12_VERSIONED_ROOT_SIGNA
         _In_reads_opt_(numParameters) const D3D12_ROOT_PARAMETER1* _pParameters,
         UINT numStaticSamplers = 0,
         _In_reads_opt_(numStaticSamplers) const D3D12_STATIC_SAMPLER_DESC* _pStaticSamplers = nullptr,
-        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE)
+        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE) noexcept
     {
         Init_1_1(*this, numParameters, _pParameters, numStaticSamplers, _pStaticSamplers, flags);
     }
@@ -1547,7 +1545,7 @@ struct CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC : public D3D12_VERSIONED_ROOT_SIGNA
         _In_reads_opt_(numParameters) const D3D12_ROOT_PARAMETER1* _pParameters,
         UINT numStaticSamplers = 0,
         _In_reads_opt_(numStaticSamplers) const D3D12_STATIC_SAMPLER_DESC* _pStaticSamplers = nullptr,
-        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE)
+        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE) noexcept
     {
         desc.Version = D3D_ROOT_SIGNATURE_VERSION_1_1;
         desc.Desc_1_1.NumParameters = numParameters;
@@ -1562,60 +1560,60 @@ struct CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC : public D3D12_VERSIONED_ROOT_SIGNA
 struct CD3DX12_CPU_DESCRIPTOR_HANDLE : public D3D12_CPU_DESCRIPTOR_HANDLE
 {
     CD3DX12_CPU_DESCRIPTOR_HANDLE() = default;
-    explicit CD3DX12_CPU_DESCRIPTOR_HANDLE(const D3D12_CPU_DESCRIPTOR_HANDLE &o) :
+    explicit CD3DX12_CPU_DESCRIPTOR_HANDLE(const D3D12_CPU_DESCRIPTOR_HANDLE &o) noexcept :
         D3D12_CPU_DESCRIPTOR_HANDLE(o)
     {}
-    CD3DX12_CPU_DESCRIPTOR_HANDLE(CD3DX12_DEFAULT) { ptr = 0; }
-    CD3DX12_CPU_DESCRIPTOR_HANDLE(_In_ const D3D12_CPU_DESCRIPTOR_HANDLE &other, INT offsetScaledByIncrementSize)
+    CD3DX12_CPU_DESCRIPTOR_HANDLE(CD3DX12_DEFAULT) noexcept { ptr = 0; }
+    CD3DX12_CPU_DESCRIPTOR_HANDLE(_In_ const D3D12_CPU_DESCRIPTOR_HANDLE &other, INT offsetScaledByIncrementSize) noexcept
     {
         InitOffsetted(other, offsetScaledByIncrementSize);
     }
-    CD3DX12_CPU_DESCRIPTOR_HANDLE(_In_ const D3D12_CPU_DESCRIPTOR_HANDLE &other, INT offsetInDescriptors, UINT descriptorIncrementSize)
+    CD3DX12_CPU_DESCRIPTOR_HANDLE(_In_ const D3D12_CPU_DESCRIPTOR_HANDLE &other, INT offsetInDescriptors, UINT descriptorIncrementSize) noexcept
     {
         InitOffsetted(other, offsetInDescriptors, descriptorIncrementSize);
     }
-    CD3DX12_CPU_DESCRIPTOR_HANDLE& Offset(INT offsetInDescriptors, UINT descriptorIncrementSize)
-    { 
-        ptr += INT64(offsetInDescriptors) * UINT64(descriptorIncrementSize);
+    CD3DX12_CPU_DESCRIPTOR_HANDLE& Offset(INT offsetInDescriptors, UINT descriptorIncrementSize) noexcept
+    {
+        ptr = SIZE_T(INT64(ptr) + INT64(offsetInDescriptors) * INT64(descriptorIncrementSize));
         return *this;
     }
-    CD3DX12_CPU_DESCRIPTOR_HANDLE& Offset(INT offsetScaledByIncrementSize) 
-    { 
-        ptr += offsetScaledByIncrementSize;
+    CD3DX12_CPU_DESCRIPTOR_HANDLE& Offset(INT offsetScaledByIncrementSize) noexcept
+    {
+        ptr = SIZE_T(INT64(ptr) + INT64(offsetScaledByIncrementSize));
         return *this;
     }
-    bool operator==(_In_ const D3D12_CPU_DESCRIPTOR_HANDLE& other) const
+    bool operator==(_In_ const D3D12_CPU_DESCRIPTOR_HANDLE& other) const noexcept
     {
         return (ptr == other.ptr);
     }
-    bool operator!=(_In_ const D3D12_CPU_DESCRIPTOR_HANDLE& other) const
+    bool operator!=(_In_ const D3D12_CPU_DESCRIPTOR_HANDLE& other) const noexcept
     {
         return (ptr != other.ptr);
     }
-    CD3DX12_CPU_DESCRIPTOR_HANDLE &operator=(const D3D12_CPU_DESCRIPTOR_HANDLE &other)
+    CD3DX12_CPU_DESCRIPTOR_HANDLE &operator=(const D3D12_CPU_DESCRIPTOR_HANDLE &other) noexcept
     {
         ptr = other.ptr;
         return *this;
     }
 
-    inline void InitOffsetted(_In_ const D3D12_CPU_DESCRIPTOR_HANDLE &base, INT offsetScaledByIncrementSize)
+    inline void InitOffsetted(_In_ const D3D12_CPU_DESCRIPTOR_HANDLE &base, INT offsetScaledByIncrementSize) noexcept
     {
         InitOffsetted(*this, base, offsetScaledByIncrementSize);
     }
-    
-    inline void InitOffsetted(_In_ const D3D12_CPU_DESCRIPTOR_HANDLE &base, INT offsetInDescriptors, UINT descriptorIncrementSize)
+
+    inline void InitOffsetted(_In_ const D3D12_CPU_DESCRIPTOR_HANDLE &base, INT offsetInDescriptors, UINT descriptorIncrementSize) noexcept
     {
         InitOffsetted(*this, base, offsetInDescriptors, descriptorIncrementSize);
     }
-    
-    static inline void InitOffsetted(_Out_ D3D12_CPU_DESCRIPTOR_HANDLE &handle, _In_ const D3D12_CPU_DESCRIPTOR_HANDLE &base, INT offsetScaledByIncrementSize)
+
+    static inline void InitOffsetted(_Out_ D3D12_CPU_DESCRIPTOR_HANDLE &handle, _In_ const D3D12_CPU_DESCRIPTOR_HANDLE &base, INT offsetScaledByIncrementSize) noexcept
     {
-        handle.ptr = base.ptr + offsetScaledByIncrementSize;
+        handle.ptr = SIZE_T(INT64(base.ptr) + INT64(offsetScaledByIncrementSize));
     }
-    
-    static inline void InitOffsetted(_Out_ D3D12_CPU_DESCRIPTOR_HANDLE &handle, _In_ const D3D12_CPU_DESCRIPTOR_HANDLE &base, INT offsetInDescriptors, UINT descriptorIncrementSize)
+
+    static inline void InitOffsetted(_Out_ D3D12_CPU_DESCRIPTOR_HANDLE &handle, _In_ const D3D12_CPU_DESCRIPTOR_HANDLE &base, INT offsetInDescriptors, UINT descriptorIncrementSize) noexcept
     {
-        handle.ptr = static_cast<SIZE_T>(base.ptr + INT64(offsetInDescriptors) * UINT64(descriptorIncrementSize));
+        handle.ptr = SIZE_T(INT64(base.ptr) + INT64(offsetInDescriptors) * INT64(descriptorIncrementSize));
     }
 };
 
@@ -1623,72 +1621,72 @@ struct CD3DX12_CPU_DESCRIPTOR_HANDLE : public D3D12_CPU_DESCRIPTOR_HANDLE
 struct CD3DX12_GPU_DESCRIPTOR_HANDLE : public D3D12_GPU_DESCRIPTOR_HANDLE
 {
     CD3DX12_GPU_DESCRIPTOR_HANDLE() = default;
-    explicit CD3DX12_GPU_DESCRIPTOR_HANDLE(const D3D12_GPU_DESCRIPTOR_HANDLE &o) :
+    explicit CD3DX12_GPU_DESCRIPTOR_HANDLE(const D3D12_GPU_DESCRIPTOR_HANDLE &o) noexcept :
         D3D12_GPU_DESCRIPTOR_HANDLE(o)
     {}
-    CD3DX12_GPU_DESCRIPTOR_HANDLE(CD3DX12_DEFAULT) { ptr = 0; }
-    CD3DX12_GPU_DESCRIPTOR_HANDLE(_In_ const D3D12_GPU_DESCRIPTOR_HANDLE &other, INT offsetScaledByIncrementSize)
+    CD3DX12_GPU_DESCRIPTOR_HANDLE(CD3DX12_DEFAULT) noexcept { ptr = 0; }
+    CD3DX12_GPU_DESCRIPTOR_HANDLE(_In_ const D3D12_GPU_DESCRIPTOR_HANDLE &other, INT offsetScaledByIncrementSize) noexcept
     {
         InitOffsetted(other, offsetScaledByIncrementSize);
     }
-    CD3DX12_GPU_DESCRIPTOR_HANDLE(_In_ const D3D12_GPU_DESCRIPTOR_HANDLE &other, INT offsetInDescriptors, UINT descriptorIncrementSize)
+    CD3DX12_GPU_DESCRIPTOR_HANDLE(_In_ const D3D12_GPU_DESCRIPTOR_HANDLE &other, INT offsetInDescriptors, UINT descriptorIncrementSize) noexcept
     {
         InitOffsetted(other, offsetInDescriptors, descriptorIncrementSize);
     }
-    CD3DX12_GPU_DESCRIPTOR_HANDLE& Offset(INT offsetInDescriptors, UINT descriptorIncrementSize)
-    { 
-        ptr += INT64(offsetInDescriptors) * UINT64(descriptorIncrementSize);
+    CD3DX12_GPU_DESCRIPTOR_HANDLE& Offset(INT offsetInDescriptors, UINT descriptorIncrementSize) noexcept
+    {
+        ptr = UINT64(INT64(ptr) + INT64(offsetInDescriptors) * INT64(descriptorIncrementSize));
         return *this;
     }
-    CD3DX12_GPU_DESCRIPTOR_HANDLE& Offset(INT offsetScaledByIncrementSize) 
-    { 
-        ptr += offsetScaledByIncrementSize;
+    CD3DX12_GPU_DESCRIPTOR_HANDLE& Offset(INT offsetScaledByIncrementSize) noexcept
+    {
+        ptr = UINT64(INT64(ptr) + INT64(offsetScaledByIncrementSize));
         return *this;
     }
-    inline bool operator==(_In_ const D3D12_GPU_DESCRIPTOR_HANDLE& other) const
+    inline bool operator==(_In_ const D3D12_GPU_DESCRIPTOR_HANDLE& other) const noexcept
     {
         return (ptr == other.ptr);
     }
-    inline bool operator!=(_In_ const D3D12_GPU_DESCRIPTOR_HANDLE& other) const
+    inline bool operator!=(_In_ const D3D12_GPU_DESCRIPTOR_HANDLE& other) const noexcept
     {
         return (ptr != other.ptr);
     }
-    CD3DX12_GPU_DESCRIPTOR_HANDLE &operator=(const D3D12_GPU_DESCRIPTOR_HANDLE &other)
+    CD3DX12_GPU_DESCRIPTOR_HANDLE &operator=(const D3D12_GPU_DESCRIPTOR_HANDLE &other) noexcept
     {
         ptr = other.ptr;
         return *this;
     }
 
-    inline void InitOffsetted(_In_ const D3D12_GPU_DESCRIPTOR_HANDLE &base, INT offsetScaledByIncrementSize)
+    inline void InitOffsetted(_In_ const D3D12_GPU_DESCRIPTOR_HANDLE &base, INT offsetScaledByIncrementSize) noexcept
     {
         InitOffsetted(*this, base, offsetScaledByIncrementSize);
     }
-    
-    inline void InitOffsetted(_In_ const D3D12_GPU_DESCRIPTOR_HANDLE &base, INT offsetInDescriptors, UINT descriptorIncrementSize)
+
+    inline void InitOffsetted(_In_ const D3D12_GPU_DESCRIPTOR_HANDLE &base, INT offsetInDescriptors, UINT descriptorIncrementSize) noexcept
     {
         InitOffsetted(*this, base, offsetInDescriptors, descriptorIncrementSize);
     }
-    
-    static inline void InitOffsetted(_Out_ D3D12_GPU_DESCRIPTOR_HANDLE &handle, _In_ const D3D12_GPU_DESCRIPTOR_HANDLE &base, INT offsetScaledByIncrementSize)
+
+    static inline void InitOffsetted(_Out_ D3D12_GPU_DESCRIPTOR_HANDLE &handle, _In_ const D3D12_GPU_DESCRIPTOR_HANDLE &base, INT offsetScaledByIncrementSize) noexcept
     {
-        handle.ptr = base.ptr + offsetScaledByIncrementSize;
+        handle.ptr = UINT64(INT64(base.ptr) + INT64(offsetScaledByIncrementSize));
     }
-    
-    static inline void InitOffsetted(_Out_ D3D12_GPU_DESCRIPTOR_HANDLE &handle, _In_ const D3D12_GPU_DESCRIPTOR_HANDLE &base, INT offsetInDescriptors, UINT descriptorIncrementSize)
+
+    static inline void InitOffsetted(_Out_ D3D12_GPU_DESCRIPTOR_HANDLE &handle, _In_ const D3D12_GPU_DESCRIPTOR_HANDLE &base, INT offsetInDescriptors, UINT descriptorIncrementSize) noexcept
     {
-        handle.ptr = static_cast<UINT64>(base.ptr + INT64(offsetInDescriptors) * UINT64(descriptorIncrementSize));
+        handle.ptr = UINT64(INT64(base.ptr) + INT64(offsetInDescriptors) * INT64(descriptorIncrementSize));
     }
 };
 
 //------------------------------------------------------------------------------------------------
-inline UINT D3D12CalcSubresource( UINT MipSlice, UINT ArraySlice, UINT PlaneSlice, UINT MipLevels, UINT ArraySize )
-{ 
-    return MipSlice + ArraySlice * MipLevels + PlaneSlice * MipLevels * ArraySize; 
+inline constexpr UINT D3D12CalcSubresource( UINT MipSlice, UINT ArraySlice, UINT PlaneSlice, UINT MipLevels, UINT ArraySize ) noexcept
+{
+    return MipSlice + ArraySlice * MipLevels + PlaneSlice * MipLevels * ArraySize;
 }
 
 //------------------------------------------------------------------------------------------------
 template <typename T, typename U, typename V>
-inline void D3D12DecomposeSubresource( UINT Subresource, UINT MipLevels, UINT ArraySize, _Out_ T& MipSlice, _Out_ U& ArraySlice, _Out_ V& PlaneSlice )
+inline void D3D12DecomposeSubresource( UINT Subresource, UINT MipLevels, UINT ArraySize, _Out_ T& MipSlice, _Out_ U& ArraySlice, _Out_ V& PlaneSlice ) noexcept
 {
     MipSlice = static_cast<T>(Subresource % MipLevels);
     ArraySlice = static_cast<U>((Subresource / MipLevels) % ArraySize);
@@ -1699,7 +1697,7 @@ inline void D3D12DecomposeSubresource( UINT Subresource, UINT MipLevels, UINT Ar
 inline UINT8 D3D12GetFormatPlaneCount(
     _In_ ID3D12Device* pDevice,
     DXGI_FORMAT Format
-    )
+    ) noexcept
 {
     D3D12_FEATURE_DATA_FORMAT_INFO formatInfo = { Format, 0 };
     if (FAILED(pDevice->CheckFeatureSupport(D3D12_FEATURE_FORMAT_INFO, &formatInfo, sizeof(formatInfo))))
@@ -1713,10 +1711,10 @@ inline UINT8 D3D12GetFormatPlaneCount(
 struct CD3DX12_RESOURCE_DESC : public D3D12_RESOURCE_DESC
 {
     CD3DX12_RESOURCE_DESC() = default;
-    explicit CD3DX12_RESOURCE_DESC( const D3D12_RESOURCE_DESC& o ) :
+    explicit CD3DX12_RESOURCE_DESC( const D3D12_RESOURCE_DESC& o ) noexcept :
         D3D12_RESOURCE_DESC( o )
     {}
-    CD3DX12_RESOURCE_DESC( 
+    CD3DX12_RESOURCE_DESC(
         D3D12_RESOURCE_DIMENSION dimension,
         UINT64 alignment,
         UINT64 width,
@@ -1727,7 +1725,7 @@ struct CD3DX12_RESOURCE_DESC : public D3D12_RESOURCE_DESC
         UINT sampleCount,
         UINT sampleQuality,
         D3D12_TEXTURE_LAYOUT layout,
-        D3D12_RESOURCE_FLAGS flags )
+        D3D12_RESOURCE_FLAGS flags ) noexcept
     {
         Dimension = dimension;
         Alignment = alignment;
@@ -1741,34 +1739,34 @@ struct CD3DX12_RESOURCE_DESC : public D3D12_RESOURCE_DESC
         Layout = layout;
         Flags = flags;
     }
-    static inline CD3DX12_RESOURCE_DESC Buffer( 
+    static inline CD3DX12_RESOURCE_DESC Buffer(
         const D3D12_RESOURCE_ALLOCATION_INFO& resAllocInfo,
-        D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE )
+        D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE ) noexcept
     {
-        return CD3DX12_RESOURCE_DESC( D3D12_RESOURCE_DIMENSION_BUFFER, resAllocInfo.Alignment, resAllocInfo.SizeInBytes, 
+        return CD3DX12_RESOURCE_DESC( D3D12_RESOURCE_DIMENSION_BUFFER, resAllocInfo.Alignment, resAllocInfo.SizeInBytes,
             1, 1, 1, DXGI_FORMAT_UNKNOWN, 1, 0, D3D12_TEXTURE_LAYOUT_ROW_MAJOR, flags );
     }
-    static inline CD3DX12_RESOURCE_DESC Buffer( 
+    static inline CD3DX12_RESOURCE_DESC Buffer(
         UINT64 width,
         D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
-        UINT64 alignment = 0 )
+        UINT64 alignment = 0 ) noexcept
     {
-        return CD3DX12_RESOURCE_DESC( D3D12_RESOURCE_DIMENSION_BUFFER, alignment, width, 1, 1, 1, 
+        return CD3DX12_RESOURCE_DESC( D3D12_RESOURCE_DIMENSION_BUFFER, alignment, width, 1, 1, 1,
             DXGI_FORMAT_UNKNOWN, 1, 0, D3D12_TEXTURE_LAYOUT_ROW_MAJOR, flags );
     }
-    static inline CD3DX12_RESOURCE_DESC Tex1D( 
+    static inline CD3DX12_RESOURCE_DESC Tex1D(
         DXGI_FORMAT format,
         UINT64 width,
         UINT16 arraySize = 1,
         UINT16 mipLevels = 0,
         D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
         D3D12_TEXTURE_LAYOUT layout = D3D12_TEXTURE_LAYOUT_UNKNOWN,
-        UINT64 alignment = 0 )
+        UINT64 alignment = 0 ) noexcept
     {
-        return CD3DX12_RESOURCE_DESC( D3D12_RESOURCE_DIMENSION_TEXTURE1D, alignment, width, 1, arraySize, 
+        return CD3DX12_RESOURCE_DESC( D3D12_RESOURCE_DIMENSION_TEXTURE1D, alignment, width, 1, arraySize,
             mipLevels, format, 1, 0, layout, flags );
     }
-    static inline CD3DX12_RESOURCE_DESC Tex2D( 
+    static inline CD3DX12_RESOURCE_DESC Tex2D(
         DXGI_FORMAT format,
         UINT64 width,
         UINT height,
@@ -1778,12 +1776,12 @@ struct CD3DX12_RESOURCE_DESC : public D3D12_RESOURCE_DESC
         UINT sampleQuality = 0,
         D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
         D3D12_TEXTURE_LAYOUT layout = D3D12_TEXTURE_LAYOUT_UNKNOWN,
-        UINT64 alignment = 0 )
+        UINT64 alignment = 0 ) noexcept
     {
-        return CD3DX12_RESOURCE_DESC( D3D12_RESOURCE_DIMENSION_TEXTURE2D, alignment, width, height, arraySize, 
+        return CD3DX12_RESOURCE_DESC( D3D12_RESOURCE_DIMENSION_TEXTURE2D, alignment, width, height, arraySize,
             mipLevels, format, sampleCount, sampleQuality, layout, flags );
     }
-    static inline CD3DX12_RESOURCE_DESC Tex3D( 
+    static inline CD3DX12_RESOURCE_DESC Tex3D(
         DXGI_FORMAT format,
         UINT64 width,
         UINT height,
@@ -1791,23 +1789,23 @@ struct CD3DX12_RESOURCE_DESC : public D3D12_RESOURCE_DESC
         UINT16 mipLevels = 0,
         D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
         D3D12_TEXTURE_LAYOUT layout = D3D12_TEXTURE_LAYOUT_UNKNOWN,
-        UINT64 alignment = 0 )
+        UINT64 alignment = 0 ) noexcept
     {
-        return CD3DX12_RESOURCE_DESC( D3D12_RESOURCE_DIMENSION_TEXTURE3D, alignment, width, height, depth, 
+        return CD3DX12_RESOURCE_DESC( D3D12_RESOURCE_DIMENSION_TEXTURE3D, alignment, width, height, depth,
             mipLevels, format, 1, 0, layout, flags );
     }
-    inline UINT16 Depth() const
+    inline UINT16 Depth() const noexcept
     { return (Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D ? DepthOrArraySize : 1); }
-    inline UINT16 ArraySize() const
+    inline UINT16 ArraySize() const noexcept
     { return (Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE3D ? DepthOrArraySize : 1); }
-    inline UINT8 PlaneCount(_In_ ID3D12Device* pDevice) const
+    inline UINT8 PlaneCount(_In_ ID3D12Device* pDevice) const noexcept
     { return D3D12GetFormatPlaneCount(pDevice, Format); }
-    inline UINT Subresources(_In_ ID3D12Device* pDevice) const
+    inline UINT Subresources(_In_ ID3D12Device* pDevice) const noexcept
     { return MipLevels * ArraySize() * PlaneCount(pDevice); }
-    inline UINT CalcSubresource(UINT MipSlice, UINT ArraySlice, UINT PlaneSlice)
+    inline UINT CalcSubresource(UINT MipSlice, UINT ArraySlice, UINT PlaneSlice) noexcept
     { return D3D12CalcSubresource(MipSlice, ArraySlice, PlaneSlice, MipLevels, ArraySize()); }
 };
-inline bool operator==( const D3D12_RESOURCE_DESC& l, const D3D12_RESOURCE_DESC& r )
+inline bool operator==( const D3D12_RESOURCE_DESC& l, const D3D12_RESOURCE_DESC& r ) noexcept
 {
     return l.Dimension == r.Dimension &&
         l.Alignment == r.Alignment &&
@@ -1821,26 +1819,154 @@ inline bool operator==( const D3D12_RESOURCE_DESC& l, const D3D12_RESOURCE_DESC&
         l.Layout == r.Layout &&
         l.Flags == r.Flags;
 }
-inline bool operator!=( const D3D12_RESOURCE_DESC& l, const D3D12_RESOURCE_DESC& r )
+inline bool operator!=( const D3D12_RESOURCE_DESC& l, const D3D12_RESOURCE_DESC& r ) noexcept
+{ return !( l == r ); }
+
+//------------------------------------------------------------------------------------------------
+struct CD3DX12_RESOURCE_DESC1 : public D3D12_RESOURCE_DESC1
+{
+    CD3DX12_RESOURCE_DESC1() = default;
+    explicit CD3DX12_RESOURCE_DESC1( const D3D12_RESOURCE_DESC1& o ) noexcept :
+        D3D12_RESOURCE_DESC1( o )
+    {}
+    CD3DX12_RESOURCE_DESC1(
+        D3D12_RESOURCE_DIMENSION dimension,
+        UINT64 alignment,
+        UINT64 width,
+        UINT height,
+        UINT16 depthOrArraySize,
+        UINT16 mipLevels,
+        DXGI_FORMAT format,
+        UINT sampleCount,
+        UINT sampleQuality,
+        D3D12_TEXTURE_LAYOUT layout,
+        D3D12_RESOURCE_FLAGS flags,
+        UINT samplerFeedbackMipRegionWidth = 0,
+        UINT samplerFeedbackMipRegionHeight = 0,
+        UINT samplerFeedbackMipRegionDepth = 0) noexcept
+    {
+        Dimension = dimension;
+        Alignment = alignment;
+        Width = width;
+        Height = height;
+        DepthOrArraySize = depthOrArraySize;
+        MipLevels = mipLevels;
+        Format = format;
+        SampleDesc.Count = sampleCount;
+        SampleDesc.Quality = sampleQuality;
+        Layout = layout;
+        Flags = flags;
+        SamplerFeedbackMipRegion.Width = samplerFeedbackMipRegionWidth;
+        SamplerFeedbackMipRegion.Height = samplerFeedbackMipRegionHeight;
+        SamplerFeedbackMipRegion.Depth = samplerFeedbackMipRegionDepth;
+    }
+    static inline CD3DX12_RESOURCE_DESC1 Buffer(
+        const D3D12_RESOURCE_ALLOCATION_INFO& resAllocInfo,
+        D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE ) noexcept
+    {
+        return CD3DX12_RESOURCE_DESC1( D3D12_RESOURCE_DIMENSION_BUFFER, resAllocInfo.Alignment, resAllocInfo.SizeInBytes,
+            1, 1, 1, DXGI_FORMAT_UNKNOWN, 1, 0, D3D12_TEXTURE_LAYOUT_ROW_MAJOR, flags, 0, 0, 0 );
+    }
+    static inline CD3DX12_RESOURCE_DESC1 Buffer(
+        UINT64 width,
+        D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
+        UINT64 alignment = 0 ) noexcept
+    {
+        return CD3DX12_RESOURCE_DESC1( D3D12_RESOURCE_DIMENSION_BUFFER, alignment, width, 1, 1, 1,
+            DXGI_FORMAT_UNKNOWN, 1, 0, D3D12_TEXTURE_LAYOUT_ROW_MAJOR, flags, 0, 0, 0 );
+    }
+    static inline CD3DX12_RESOURCE_DESC1 Tex1D(
+        DXGI_FORMAT format,
+        UINT64 width,
+        UINT16 arraySize = 1,
+        UINT16 mipLevels = 0,
+        D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
+        D3D12_TEXTURE_LAYOUT layout = D3D12_TEXTURE_LAYOUT_UNKNOWN,
+        UINT64 alignment = 0 ) noexcept
+    {
+        return CD3DX12_RESOURCE_DESC1( D3D12_RESOURCE_DIMENSION_TEXTURE1D, alignment, width, 1, arraySize,
+            mipLevels, format, 1, 0, layout, flags, 0, 0, 0 );
+    }
+    static inline CD3DX12_RESOURCE_DESC1 Tex2D(
+        DXGI_FORMAT format,
+        UINT64 width,
+        UINT height,
+        UINT16 arraySize = 1,
+        UINT16 mipLevels = 0,
+        UINT sampleCount = 1,
+        UINT sampleQuality = 0,
+        D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
+        D3D12_TEXTURE_LAYOUT layout = D3D12_TEXTURE_LAYOUT_UNKNOWN,
+        UINT64 alignment = 0,
+        UINT samplerFeedbackMipRegionWidth = 0,
+        UINT samplerFeedbackMipRegionHeight = 0,
+        UINT samplerFeedbackMipRegionDepth = 0) noexcept
+    {
+        return CD3DX12_RESOURCE_DESC1( D3D12_RESOURCE_DIMENSION_TEXTURE2D, alignment, width, height, arraySize,
+            mipLevels, format, sampleCount, sampleQuality, layout, flags, samplerFeedbackMipRegionWidth,
+            samplerFeedbackMipRegionHeight, samplerFeedbackMipRegionDepth );
+    }
+    static inline CD3DX12_RESOURCE_DESC1 Tex3D(
+        DXGI_FORMAT format,
+        UINT64 width,
+        UINT height,
+        UINT16 depth,
+        UINT16 mipLevels = 0,
+        D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
+        D3D12_TEXTURE_LAYOUT layout = D3D12_TEXTURE_LAYOUT_UNKNOWN,
+        UINT64 alignment = 0 ) noexcept
+    {
+        return CD3DX12_RESOURCE_DESC1( D3D12_RESOURCE_DIMENSION_TEXTURE3D, alignment, width, height, depth,
+            mipLevels, format, 1, 0, layout, flags, 0, 0, 0 );
+    }
+    inline UINT16 Depth() const noexcept
+    { return (Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D ? DepthOrArraySize : 1); }
+    inline UINT16 ArraySize() const noexcept
+    { return (Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE3D ? DepthOrArraySize : 1); }
+    inline UINT8 PlaneCount(_In_ ID3D12Device* pDevice) const noexcept
+    { return D3D12GetFormatPlaneCount(pDevice, Format); }
+    inline UINT Subresources(_In_ ID3D12Device* pDevice) const noexcept
+    { return MipLevels * ArraySize() * PlaneCount(pDevice); }
+    inline UINT CalcSubresource(UINT MipSlice, UINT ArraySlice, UINT PlaneSlice) noexcept
+    { return D3D12CalcSubresource(MipSlice, ArraySlice, PlaneSlice, MipLevels, ArraySize()); }
+};
+inline bool operator==( const D3D12_RESOURCE_DESC1& l, const D3D12_RESOURCE_DESC1& r ) noexcept
+{
+    return l.Dimension == r.Dimension &&
+        l.Alignment == r.Alignment &&
+        l.Width == r.Width &&
+        l.Height == r.Height &&
+        l.DepthOrArraySize == r.DepthOrArraySize &&
+        l.MipLevels == r.MipLevels &&
+        l.Format == r.Format &&
+        l.SampleDesc.Count == r.SampleDesc.Count &&
+        l.SampleDesc.Quality == r.SampleDesc.Quality &&
+        l.Layout == r.Layout &&
+        l.Flags == r.Flags &&
+        l.SamplerFeedbackMipRegion.Width == r.SamplerFeedbackMipRegion.Width &&
+        l.SamplerFeedbackMipRegion.Height == r.SamplerFeedbackMipRegion.Height &&
+        l.SamplerFeedbackMipRegion.Depth == r.SamplerFeedbackMipRegion.Depth;
+}
+inline bool operator!=( const D3D12_RESOURCE_DESC1& l, const D3D12_RESOURCE_DESC1& r ) noexcept
 { return !( l == r ); }
 
 //------------------------------------------------------------------------------------------------
 struct CD3DX12_VIEW_INSTANCING_DESC : public D3D12_VIEW_INSTANCING_DESC
 {
     CD3DX12_VIEW_INSTANCING_DESC() = default;
-    explicit CD3DX12_VIEW_INSTANCING_DESC( const D3D12_VIEW_INSTANCING_DESC& o ) :
+    explicit CD3DX12_VIEW_INSTANCING_DESC( const D3D12_VIEW_INSTANCING_DESC& o ) noexcept :
         D3D12_VIEW_INSTANCING_DESC( o )
     {}
-    explicit CD3DX12_VIEW_INSTANCING_DESC( CD3DX12_DEFAULT )
+    explicit CD3DX12_VIEW_INSTANCING_DESC( CD3DX12_DEFAULT ) noexcept
     {
         ViewInstanceCount = 0;
         pViewInstanceLocations = nullptr;
         Flags = D3D12_VIEW_INSTANCING_FLAG_NONE;
     }
-    explicit CD3DX12_VIEW_INSTANCING_DESC( 
+    explicit CD3DX12_VIEW_INSTANCING_DESC(
         UINT InViewInstanceCount,
         const D3D12_VIEW_INSTANCE_LOCATION* InViewInstanceLocations,
-        D3D12_VIEW_INSTANCING_FLAGS InFlags)
+        D3D12_VIEW_INSTANCING_FLAGS InFlags) noexcept
     {
         ViewInstanceCount = InViewInstanceCount;
         pViewInstanceLocations = InViewInstanceLocations;
@@ -1855,17 +1981,40 @@ inline void MemcpySubresource(
     _In_ const D3D12_SUBRESOURCE_DATA* pSrc,
     SIZE_T RowSizeInBytes,
     UINT NumRows,
-    UINT NumSlices)
+    UINT NumSlices) noexcept
 {
     for (UINT z = 0; z < NumSlices; ++z)
     {
-        BYTE* pDestSlice = reinterpret_cast<BYTE*>(pDest->pData) + pDest->SlicePitch * z;
-        const BYTE* pSrcSlice = reinterpret_cast<const BYTE*>(pSrc->pData) + pSrc->SlicePitch * z;
+        auto pDestSlice = static_cast<BYTE*>(pDest->pData) + pDest->SlicePitch * z;
+        auto pSrcSlice = static_cast<const BYTE*>(pSrc->pData) + pSrc->SlicePitch * LONG_PTR(z);
         for (UINT y = 0; y < NumRows; ++y)
         {
             memcpy(pDestSlice + pDest->RowPitch * y,
-                   pSrcSlice + pSrc->RowPitch * y,
+                   pSrcSlice + pSrc->RowPitch * LONG_PTR(y),
                    RowSizeInBytes);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------
+// Row-by-row memcpy
+inline void MemcpySubresource(
+    _In_ const D3D12_MEMCPY_DEST* pDest,
+    _In_ const void* pResourceData,
+    _In_ const D3D12_SUBRESOURCE_INFO* pSrc,
+    SIZE_T RowSizeInBytes,
+    UINT NumRows,
+    UINT NumSlices) noexcept
+{
+    for (UINT z = 0; z < NumSlices; ++z)
+    {
+        auto pDestSlice = static_cast<BYTE*>(pDest->pData) + pDest->SlicePitch * z;
+        auto pSrcSlice = (static_cast<const BYTE*>(pResourceData) + pSrc->Offset) + pSrc->DepthPitch * ULONG_PTR(z);
+        for (UINT y = 0; y < NumRows; ++y)
+        {
+            memcpy(pDestSlice + pDest->RowPitch * y,
+                pSrcSlice + pSrc->RowPitch * ULONG_PTR(y),
+                RowSizeInBytes);
         }
     }
 }
@@ -1875,16 +2024,16 @@ inline void MemcpySubresource(
 inline UINT64 GetRequiredIntermediateSize(
     _In_ ID3D12Resource* pDestinationResource,
     _In_range_(0,D3D12_REQ_SUBRESOURCES) UINT FirstSubresource,
-    _In_range_(0,D3D12_REQ_SUBRESOURCES-FirstSubresource) UINT NumSubresources)
+    _In_range_(0,D3D12_REQ_SUBRESOURCES-FirstSubresource) UINT NumSubresources) noexcept
 {
     auto Desc = pDestinationResource->GetDesc();
     UINT64 RequiredSize = 0;
-    
+
     ID3D12Device* pDevice = nullptr;
-    pDestinationResource->GetDevice(__uuidof(*pDevice), reinterpret_cast<void**>(&pDevice));
+    pDestinationResource->GetDevice(IID_ID3D12Device, reinterpret_cast<void**>(&pDevice));
     pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, 0, nullptr, nullptr, nullptr, &RequiredSize);
     pDevice->Release();
-    
+
     return RequiredSize;
 }
 
@@ -1900,27 +2049,27 @@ inline UINT64 UpdateSubresources(
     _In_reads_(NumSubresources) const D3D12_PLACED_SUBRESOURCE_FOOTPRINT* pLayouts,
     _In_reads_(NumSubresources) const UINT* pNumRows,
     _In_reads_(NumSubresources) const UINT64* pRowSizesInBytes,
-    _In_reads_(NumSubresources) const D3D12_SUBRESOURCE_DATA* pSrcData)
+    _In_reads_(NumSubresources) const D3D12_SUBRESOURCE_DATA* pSrcData) noexcept
 {
     // Minor validation
     auto IntermediateDesc = pIntermediate->GetDesc();
     auto DestinationDesc = pDestinationResource->GetDesc();
-    if (IntermediateDesc.Dimension != D3D12_RESOURCE_DIMENSION_BUFFER || 
-        IntermediateDesc.Width < RequiredSize + pLayouts[0].Offset || 
-        RequiredSize > SIZE_T(-1) || 
-        (DestinationDesc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER && 
+    if (IntermediateDesc.Dimension != D3D12_RESOURCE_DIMENSION_BUFFER ||
+        IntermediateDesc.Width < RequiredSize + pLayouts[0].Offset ||
+        RequiredSize > SIZE_T(-1) ||
+        (DestinationDesc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER &&
             (FirstSubresource != 0 || NumSubresources != 1)))
     {
         return 0;
     }
-    
+
     BYTE* pData;
     HRESULT hr = pIntermediate->Map(0, nullptr, reinterpret_cast<void**>(&pData));
     if (FAILED(hr))
     {
         return 0;
     }
-    
+
     for (UINT i = 0; i < NumSubresources; ++i)
     {
         if (pRowSizesInBytes[i] > SIZE_T(-1)) return 0;
@@ -1928,7 +2077,66 @@ inline UINT64 UpdateSubresources(
         MemcpySubresource(&DestData, &pSrcData[i], static_cast<SIZE_T>(pRowSizesInBytes[i]), pNumRows[i], pLayouts[i].Footprint.Depth);
     }
     pIntermediate->Unmap(0, nullptr);
-    
+
+    if (DestinationDesc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
+    {
+        pCmdList->CopyBufferRegion(
+            pDestinationResource, 0, pIntermediate, pLayouts[0].Offset, pLayouts[0].Footprint.Width);
+    }
+    else
+    {
+        for (UINT i = 0; i < NumSubresources; ++i)
+        {
+            CD3DX12_TEXTURE_COPY_LOCATION Dst(pDestinationResource, i + FirstSubresource);
+            CD3DX12_TEXTURE_COPY_LOCATION Src(pIntermediate, pLayouts[i]);
+            pCmdList->CopyTextureRegion(&Dst, 0, 0, 0, &Src, nullptr);
+        }
+    }
+    return RequiredSize;
+}
+
+//------------------------------------------------------------------------------------------------
+// All arrays must be populated (e.g. by calling GetCopyableFootprints)
+inline UINT64 UpdateSubresources(
+    _In_ ID3D12GraphicsCommandList* pCmdList,
+    _In_ ID3D12Resource* pDestinationResource,
+    _In_ ID3D12Resource* pIntermediate,
+    _In_range_(0,D3D12_REQ_SUBRESOURCES) UINT FirstSubresource,
+    _In_range_(0,D3D12_REQ_SUBRESOURCES-FirstSubresource) UINT NumSubresources,
+    UINT64 RequiredSize,
+    _In_reads_(NumSubresources) const D3D12_PLACED_SUBRESOURCE_FOOTPRINT* pLayouts,
+    _In_reads_(NumSubresources) const UINT* pNumRows,
+    _In_reads_(NumSubresources) const UINT64* pRowSizesInBytes,
+    _In_ const void* pResourceData,
+    _In_reads_(NumSubresources) const D3D12_SUBRESOURCE_INFO* pSrcData) noexcept
+{
+    // Minor validation
+    auto IntermediateDesc = pIntermediate->GetDesc();
+    auto DestinationDesc = pDestinationResource->GetDesc();
+    if (IntermediateDesc.Dimension != D3D12_RESOURCE_DIMENSION_BUFFER ||
+        IntermediateDesc.Width < RequiredSize + pLayouts[0].Offset ||
+        RequiredSize > SIZE_T(-1) ||
+        (DestinationDesc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER &&
+            (FirstSubresource != 0 || NumSubresources != 1)))
+    {
+        return 0;
+    }
+
+    BYTE* pData;
+    HRESULT hr = pIntermediate->Map(0, nullptr, reinterpret_cast<void**>(&pData));
+    if (FAILED(hr))
+    {
+        return 0;
+    }
+
+    for (UINT i = 0; i < NumSubresources; ++i)
+    {
+        if (pRowSizesInBytes[i] > SIZE_T(-1)) return 0;
+        D3D12_MEMCPY_DEST DestData = { pData + pLayouts[i].Offset, pLayouts[i].Footprint.RowPitch, SIZE_T(pLayouts[i].Footprint.RowPitch) * SIZE_T(pNumRows[i]) };
+        MemcpySubresource(&DestData, pResourceData, &pSrcData[i], static_cast<SIZE_T>(pRowSizesInBytes[i]), pNumRows[i], pLayouts[i].Footprint.Depth);
+    }
+    pIntermediate->Unmap(0, nullptr);
+
     if (DestinationDesc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
     {
         pCmdList->CopyBufferRegion(
@@ -1948,17 +2156,17 @@ inline UINT64 UpdateSubresources(
 
 //------------------------------------------------------------------------------------------------
 // Heap-allocating UpdateSubresources implementation
-inline UINT64 UpdateSubresources( 
+inline UINT64 UpdateSubresources(
     _In_ ID3D12GraphicsCommandList* pCmdList,
     _In_ ID3D12Resource* pDestinationResource,
     _In_ ID3D12Resource* pIntermediate,
     UINT64 IntermediateOffset,
     _In_range_(0,D3D12_REQ_SUBRESOURCES) UINT FirstSubresource,
     _In_range_(0,D3D12_REQ_SUBRESOURCES-FirstSubresource) UINT NumSubresources,
-    _In_reads_(NumSubresources) D3D12_SUBRESOURCE_DATA* pSrcData)
+    _In_reads_(NumSubresources) const D3D12_SUBRESOURCE_DATA* pSrcData) noexcept
 {
     UINT64 RequiredSize = 0;
-    UINT64 MemToAlloc = static_cast<UINT64>(sizeof(D3D12_PLACED_SUBRESOURCE_FOOTPRINT) + sizeof(UINT) + sizeof(UINT64)) * NumSubresources;
+    auto MemToAlloc = static_cast<UINT64>(sizeof(D3D12_PLACED_SUBRESOURCE_FOOTPRINT) + sizeof(UINT) + sizeof(UINT64)) * NumSubresources;
     if (MemToAlloc > SIZE_MAX)
     {
        return 0;
@@ -1968,17 +2176,55 @@ inline UINT64 UpdateSubresources(
     {
        return 0;
     }
-    auto pLayouts = reinterpret_cast<D3D12_PLACED_SUBRESOURCE_FOOTPRINT*>(pMem);
-    UINT64* pRowSizesInBytes = reinterpret_cast<UINT64*>(pLayouts + NumSubresources);
-    UINT* pNumRows = reinterpret_cast<UINT*>(pRowSizesInBytes + NumSubresources);
-    
+    auto pLayouts = static_cast<D3D12_PLACED_SUBRESOURCE_FOOTPRINT*>(pMem);
+    auto pRowSizesInBytes = reinterpret_cast<UINT64*>(pLayouts + NumSubresources);
+    auto pNumRows = reinterpret_cast<UINT*>(pRowSizesInBytes + NumSubresources);
+
     auto Desc = pDestinationResource->GetDesc();
     ID3D12Device* pDevice = nullptr;
-    pDestinationResource->GetDevice(__uuidof(*pDevice), reinterpret_cast<void**>(&pDevice));
+    pDestinationResource->GetDevice(IID_ID3D12Device, reinterpret_cast<void**>(&pDevice));
     pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, pLayouts, pNumRows, pRowSizesInBytes, &RequiredSize);
     pDevice->Release();
-    
+
     UINT64 Result = UpdateSubresources(pCmdList, pDestinationResource, pIntermediate, FirstSubresource, NumSubresources, RequiredSize, pLayouts, pNumRows, pRowSizesInBytes, pSrcData);
+    HeapFree(GetProcessHeap(), 0, pMem);
+    return Result;
+}
+
+//------------------------------------------------------------------------------------------------
+// Heap-allocating UpdateSubresources implementation
+inline UINT64 UpdateSubresources(
+    _In_ ID3D12GraphicsCommandList* pCmdList,
+    _In_ ID3D12Resource* pDestinationResource,
+    _In_ ID3D12Resource* pIntermediate,
+    UINT64 IntermediateOffset,
+    _In_range_(0,D3D12_REQ_SUBRESOURCES) UINT FirstSubresource,
+    _In_range_(0,D3D12_REQ_SUBRESOURCES-FirstSubresource) UINT NumSubresources,
+    _In_ const void* pResourceData,
+    _In_reads_(NumSubresources) D3D12_SUBRESOURCE_INFO* pSrcData) noexcept
+{
+    UINT64 RequiredSize = 0;
+    auto MemToAlloc = static_cast<UINT64>(sizeof(D3D12_PLACED_SUBRESOURCE_FOOTPRINT) + sizeof(UINT) + sizeof(UINT64)) * NumSubresources;
+    if (MemToAlloc > SIZE_MAX)
+    {
+        return 0;
+    }
+    void* pMem = HeapAlloc(GetProcessHeap(), 0, static_cast<SIZE_T>(MemToAlloc));
+    if (pMem == nullptr)
+    {
+        return 0;
+    }
+    auto pLayouts = reinterpret_cast<D3D12_PLACED_SUBRESOURCE_FOOTPRINT*>(pMem);
+    auto pRowSizesInBytes = reinterpret_cast<UINT64*>(pLayouts + NumSubresources);
+    auto pNumRows = reinterpret_cast<UINT*>(pRowSizesInBytes + NumSubresources);
+
+    auto Desc = pDestinationResource->GetDesc();
+    ID3D12Device* pDevice = nullptr;
+    pDestinationResource->GetDevice(IID_ID3D12Device, reinterpret_cast<void**>(&pDevice));
+    pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, pLayouts, pNumRows, pRowSizesInBytes, &RequiredSize);
+    pDevice->Release();
+
+    UINT64 Result = UpdateSubresources(pCmdList, pDestinationResource, pIntermediate, FirstSubresource, NumSubresources, RequiredSize, pLayouts, pNumRows, pRowSizesInBytes, pResourceData, pSrcData);
     HeapFree(GetProcessHeap(), 0, pMem);
     return Result;
 }
@@ -1986,36 +2232,63 @@ inline UINT64 UpdateSubresources(
 //------------------------------------------------------------------------------------------------
 // Stack-allocating UpdateSubresources implementation
 template <UINT MaxSubresources>
-inline UINT64 UpdateSubresources( 
+inline UINT64 UpdateSubresources(
     _In_ ID3D12GraphicsCommandList* pCmdList,
     _In_ ID3D12Resource* pDestinationResource,
     _In_ ID3D12Resource* pIntermediate,
     UINT64 IntermediateOffset,
-    _In_range_(0, MaxSubresources) UINT FirstSubresource,
-    _In_range_(1, MaxSubresources - FirstSubresource) UINT NumSubresources,
-    _In_reads_(NumSubresources) D3D12_SUBRESOURCE_DATA* pSrcData)
+    _In_range_(0,MaxSubresources) UINT FirstSubresource,
+    _In_range_(1,MaxSubresources-FirstSubresource) UINT NumSubresources,
+    _In_reads_(NumSubresources) const D3D12_SUBRESOURCE_DATA* pSrcData) noexcept
 {
     UINT64 RequiredSize = 0;
     D3D12_PLACED_SUBRESOURCE_FOOTPRINT Layouts[MaxSubresources];
     UINT NumRows[MaxSubresources];
     UINT64 RowSizesInBytes[MaxSubresources];
-    
+
     auto Desc = pDestinationResource->GetDesc();
     ID3D12Device* pDevice = nullptr;
-    pDestinationResource->GetDevice(__uuidof(*pDevice), reinterpret_cast<void**>(&pDevice));
+    pDestinationResource->GetDevice(IID_ID3D12Device, reinterpret_cast<void**>(&pDevice));
     pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, Layouts, NumRows, RowSizesInBytes, &RequiredSize);
     pDevice->Release();
-    
+
     return UpdateSubresources(pCmdList, pDestinationResource, pIntermediate, FirstSubresource, NumSubresources, RequiredSize, Layouts, NumRows, RowSizesInBytes, pSrcData);
 }
 
 //------------------------------------------------------------------------------------------------
-inline bool D3D12IsLayoutOpaque( D3D12_TEXTURE_LAYOUT Layout )
+// Stack-allocating UpdateSubresources implementation
+template <UINT MaxSubresources>
+inline UINT64 UpdateSubresources(
+    _In_ ID3D12GraphicsCommandList* pCmdList,
+    _In_ ID3D12Resource* pDestinationResource,
+    _In_ ID3D12Resource* pIntermediate,
+    UINT64 IntermediateOffset,
+    _In_range_(0,MaxSubresources) UINT FirstSubresource,
+    _In_range_(1,MaxSubresources-FirstSubresource) UINT NumSubresources,
+    _In_ const void* pResourceData,
+    _In_reads_(NumSubresources) D3D12_SUBRESOURCE_INFO* pSrcData) noexcept
+{
+    UINT64 RequiredSize = 0;
+    D3D12_PLACED_SUBRESOURCE_FOOTPRINT Layouts[MaxSubresources];
+    UINT NumRows[MaxSubresources];
+    UINT64 RowSizesInBytes[MaxSubresources];
+
+    auto Desc = pDestinationResource->GetDesc();
+    ID3D12Device* pDevice = nullptr;
+    pDestinationResource->GetDevice(IID_ID3D12Device, reinterpret_cast<void**>(&pDevice));
+    pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, Layouts, NumRows, RowSizesInBytes, &RequiredSize);
+    pDevice->Release();
+
+    return UpdateSubresources(pCmdList, pDestinationResource, pIntermediate, FirstSubresource, NumSubresources, RequiredSize, Layouts, NumRows, RowSizesInBytes, pResourceData, pSrcData);
+}
+
+//------------------------------------------------------------------------------------------------
+inline constexpr bool D3D12IsLayoutOpaque( D3D12_TEXTURE_LAYOUT Layout ) noexcept
 { return Layout == D3D12_TEXTURE_LAYOUT_UNKNOWN || Layout == D3D12_TEXTURE_LAYOUT_64KB_UNDEFINED_SWIZZLE; }
 
 //------------------------------------------------------------------------------------------------
 template <typename t_CommandListType>
-inline ID3D12CommandList * const * CommandListCast(t_CommandListType * const * pp)
+inline ID3D12CommandList * const * CommandListCast(t_CommandListType * const * pp) noexcept
 {
     // This cast is useful for passing strongly typed command list pointers into
     // ExecuteCommandLists.
@@ -2033,7 +2306,7 @@ inline HRESULT D3DX12SerializeVersionedRootSignature(
     _In_ const D3D12_VERSIONED_ROOT_SIGNATURE_DESC* pRootSignatureDesc,
     D3D_ROOT_SIGNATURE_VERSION MaxVersion,
     _Outptr_ ID3DBlob** ppBlob,
-    _Always_(_Outptr_opt_result_maybenull_) ID3DBlob** ppErrorBlob)
+    _Always_(_Outptr_opt_result_maybenull_) ID3DBlob** ppErrorBlob) noexcept
 {
     if (ppErrorBlob != nullptr)
     {
@@ -2059,7 +2332,7 @@ inline HRESULT D3DX12SerializeVersionedRootSignature(
                     {
                         hr = E_OUTOFMEMORY;
                     }
-                    auto pParameters_1_0 = reinterpret_cast<D3D12_ROOT_PARAMETER*>(pParameters);
+                    auto pParameters_1_0 = static_cast<D3D12_ROOT_PARAMETER*>(pParameters);
 
                     if (SUCCEEDED(hr))
                     {
@@ -2093,7 +2366,7 @@ inline HRESULT D3DX12SerializeVersionedRootSignature(
                                 {
                                     hr = E_OUTOFMEMORY;
                                 }
-                                auto pDescriptorRanges_1_0 = reinterpret_cast<D3D12_DESCRIPTOR_RANGE*>(pDescriptorRanges);
+                                auto pDescriptorRanges_1_0 = static_cast<D3D12_DESCRIPTOR_RANGE*>(pDescriptorRanges);
 
                                 if (SUCCEEDED(hr))
                                 {
@@ -2127,7 +2400,8 @@ inline HRESULT D3DX12SerializeVersionedRootSignature(
                         {
                             if (desc_1_1.pParameters[n].ParameterType == D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
                             {
-                                HeapFree(GetProcessHeap(), 0, reinterpret_cast<void*>(const_cast<D3D12_DESCRIPTOR_RANGE*>(pParameters_1_0[n].DescriptorTable.pDescriptorRanges)));
+                                auto pDescriptorRanges_1_0 = pParameters_1_0[n].DescriptorTable.pDescriptorRanges;
+                                HeapFree(GetProcessHeap(), 0, reinterpret_cast<void*>(const_cast<D3D12_DESCRIPTOR_RANGE*>(pDescriptorRanges_1_0)));
                             }
                         }
                         HeapFree(GetProcessHeap(), 0, pParameters);
@@ -2148,10 +2422,10 @@ inline HRESULT D3DX12SerializeVersionedRootSignature(
 struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 {
     CD3DX12_RT_FORMAT_ARRAY() = default;
-    explicit CD3DX12_RT_FORMAT_ARRAY(const D3D12_RT_FORMAT_ARRAY& o)
+    explicit CD3DX12_RT_FORMAT_ARRAY(const D3D12_RT_FORMAT_ARRAY& o) noexcept
         : D3D12_RT_FORMAT_ARRAY(o)
     {}
-    explicit CD3DX12_RT_FORMAT_ARRAY(_In_reads_(NumFormats) const DXGI_FORMAT* pFormats, UINT NumFormats)
+    explicit CD3DX12_RT_FORMAT_ARRAY(_In_reads_(NumFormats) const DXGI_FORMAT* pFormats, UINT NumFormats) noexcept
     {
         NumRenderTargets = NumFormats;
         memcpy(RTFormats, pFormats, sizeof(RTFormats));
@@ -2166,8 +2440,8 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 //------------------------------------------------------------------------------------------------
 // Stream Subobjects, i.e. elements of a stream
 
-struct DefaultSampleMask { operator UINT() { return UINT_MAX; } };
-struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() { return DXGI_SAMPLE_DESC{1, 0}; } };
+struct DefaultSampleMask { operator UINT() noexcept { return UINT_MAX; } };
+struct DefaultSampleDesc { operator DXGI_SAMPLE_DESC() noexcept { return DXGI_SAMPLE_DESC{1, 0}; } };
 
 #pragma warning(push)
 #pragma warning(disable : 4324)
@@ -2179,10 +2453,12 @@ private:
     InnerStructType _Inner;
 public:
     CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT() noexcept : _Type(Type), _Inner(DefaultArg()) {}
-    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT(InnerStructType const& i) : _Type(Type), _Inner(i) {}
-    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT& operator=(InnerStructType const& i) { _Inner = i; return *this; }
-    operator InnerStructType() const { return _Inner; }
-    operator InnerStructType&() { return _Inner; }
+    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT(InnerStructType const& i) noexcept : _Type(Type), _Inner(i) {}
+    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT& operator=(InnerStructType const& i) noexcept { _Type = Type; _Inner = i; return *this; }
+    operator InnerStructType const&() const noexcept { return _Inner; }
+    operator InnerStructType&() noexcept { return _Inner; }
+    InnerStructType* operator&() noexcept { return &_Inner; }
+    InnerStructType const* operator&() const noexcept { return &_Inner; }
 };
 #pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;
@@ -2197,6 +2473,8 @@ typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_STREAM_OUTPUT_DESC,      
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_SHADER_BYTECODE,              D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_HS>                                CD3DX12_PIPELINE_STATE_STREAM_HS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_SHADER_BYTECODE,              D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DS>                                CD3DX12_PIPELINE_STATE_STREAM_DS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_SHADER_BYTECODE,              D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_PS>                                CD3DX12_PIPELINE_STATE_STREAM_PS;
+typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_SHADER_BYTECODE,              D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_AS>                                CD3DX12_PIPELINE_STATE_STREAM_AS;
+typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_SHADER_BYTECODE,              D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_MS>                                CD3DX12_PIPELINE_STATE_STREAM_MS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_SHADER_BYTECODE,              D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_CS>                                CD3DX12_PIPELINE_STATE_STREAM_CS;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< CD3DX12_BLEND_DESC,                 D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_BLEND,          CD3DX12_DEFAULT>   CD3DX12_PIPELINE_STATE_STREAM_BLEND_DESC;
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< CD3DX12_DEPTH_STENCIL_DESC,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL,  CD3DX12_DEFAULT>   CD3DX12_PIPELINE_STATE_STREAM_DEPTH_STENCIL;
@@ -2228,6 +2506,8 @@ struct ID3DX12PipelineParserCallbacks
     virtual void DSCb(const D3D12_SHADER_BYTECODE&) {}
     virtual void PSCb(const D3D12_SHADER_BYTECODE&) {}
     virtual void CSCb(const D3D12_SHADER_BYTECODE&) {}
+    virtual void ASCb(const D3D12_SHADER_BYTECODE&) {}
+    virtual void MSCb(const D3D12_SHADER_BYTECODE&) {}
     virtual void BlendStateCb(const D3D12_BLEND_DESC&) {}
     virtual void DepthStencilStateCb(const D3D12_DEPTH_STENCIL_DESC&) {}
     virtual void DepthStencilState1Cb(const D3D12_DEPTH_STENCIL_DESC1&) {}
@@ -2247,12 +2527,34 @@ struct ID3DX12PipelineParserCallbacks
     virtual ~ID3DX12PipelineParserCallbacks() = default;
 };
 
-// CD3DX12_PIPELINE_STATE_STREAM1 Works on RS3+ (where there is a new view instancing subobject).  
-// Use CD3DX12_PIPELINE_STATE_STREAM for RS2+ support.
-struct CD3DX12_PIPELINE_STATE_STREAM1
+struct D3DX12_MESH_SHADER_PIPELINE_STATE_DESC
 {
-    CD3DX12_PIPELINE_STATE_STREAM1() = default;
-    CD3DX12_PIPELINE_STATE_STREAM1(const D3D12_GRAPHICS_PIPELINE_STATE_DESC& Desc)
+    ID3D12RootSignature*          pRootSignature;
+    D3D12_SHADER_BYTECODE         AS;
+    D3D12_SHADER_BYTECODE         MS;
+    D3D12_SHADER_BYTECODE         PS;
+    D3D12_BLEND_DESC              BlendState;
+    UINT                          SampleMask;
+    D3D12_RASTERIZER_DESC         RasterizerState;
+    D3D12_DEPTH_STENCIL_DESC      DepthStencilState;
+    D3D12_PRIMITIVE_TOPOLOGY_TYPE PrimitiveTopologyType;
+    UINT                          NumRenderTargets;
+    DXGI_FORMAT                   RTVFormats[ D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT ];
+    DXGI_FORMAT                   DSVFormat;
+    DXGI_SAMPLE_DESC              SampleDesc;
+    UINT                          NodeMask;
+    D3D12_CACHED_PIPELINE_STATE   CachedPSO;
+    D3D12_PIPELINE_STATE_FLAGS    Flags;
+};
+
+// CD3DX12_PIPELINE_STATE_STREAM2 Works on OS Build 19041+ (where there is a new mesh shader pipeline).
+// Use CD3DX12_PIPELINE_STATE_STREAM1 for OS Build 16299+ (where there is a new view instancing subobject).
+// Use CD3DX12_PIPELINE_STATE_STREAM for OS Build 15063+ support.
+struct CD3DX12_PIPELINE_STATE_STREAM2
+{
+    CD3DX12_PIPELINE_STATE_STREAM2() = default;
+    // Mesh and amplification shaders must be set manually, since they do not have representation in D3D12_GRAPHICS_PIPELINE_STATE_DESC
+    CD3DX12_PIPELINE_STATE_STREAM2(const D3D12_GRAPHICS_PIPELINE_STATE_DESC& Desc) noexcept
         : Flags(Desc.Flags)
         , NodeMask(Desc.NodeMask)
         , pRootSignature(Desc.pRootSignature)
@@ -2275,7 +2577,141 @@ struct CD3DX12_PIPELINE_STATE_STREAM1
         , CachedPSO(Desc.CachedPSO)
         , ViewInstancingDesc(CD3DX12_VIEW_INSTANCING_DESC(CD3DX12_DEFAULT()))
     {}
-    CD3DX12_PIPELINE_STATE_STREAM1(const D3D12_COMPUTE_PIPELINE_STATE_DESC& Desc)
+    CD3DX12_PIPELINE_STATE_STREAM2(const D3DX12_MESH_SHADER_PIPELINE_STATE_DESC& Desc) noexcept
+        : Flags(Desc.Flags)
+        , NodeMask(Desc.NodeMask)
+        , pRootSignature(Desc.pRootSignature)
+        , PrimitiveTopologyType(Desc.PrimitiveTopologyType)
+        , PS(Desc.PS)
+        , AS(Desc.AS)
+        , MS(Desc.MS)
+        , BlendState(CD3DX12_BLEND_DESC(Desc.BlendState))
+        , DepthStencilState(CD3DX12_DEPTH_STENCIL_DESC1(Desc.DepthStencilState))
+        , DSVFormat(Desc.DSVFormat)
+        , RasterizerState(CD3DX12_RASTERIZER_DESC(Desc.RasterizerState))
+        , RTVFormats(CD3DX12_RT_FORMAT_ARRAY(Desc.RTVFormats, Desc.NumRenderTargets))
+        , SampleDesc(Desc.SampleDesc)
+        , SampleMask(Desc.SampleMask)
+        , CachedPSO(Desc.CachedPSO)
+        , ViewInstancingDesc(CD3DX12_VIEW_INSTANCING_DESC(CD3DX12_DEFAULT()))
+    {}
+    CD3DX12_PIPELINE_STATE_STREAM2(const D3D12_COMPUTE_PIPELINE_STATE_DESC& Desc) noexcept
+        : Flags(Desc.Flags)
+        , NodeMask(Desc.NodeMask)
+        , pRootSignature(Desc.pRootSignature)
+        , CS(CD3DX12_SHADER_BYTECODE(Desc.CS))
+        , CachedPSO(Desc.CachedPSO)
+    {
+        static_cast<D3D12_DEPTH_STENCIL_DESC1&>(DepthStencilState).DepthEnable = false;
+    }
+    CD3DX12_PIPELINE_STATE_STREAM_FLAGS Flags;
+    CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK NodeMask;
+    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE pRootSignature;
+    CD3DX12_PIPELINE_STATE_STREAM_INPUT_LAYOUT InputLayout;
+    CD3DX12_PIPELINE_STATE_STREAM_IB_STRIP_CUT_VALUE IBStripCutValue;
+    CD3DX12_PIPELINE_STATE_STREAM_PRIMITIVE_TOPOLOGY PrimitiveTopologyType;
+    CD3DX12_PIPELINE_STATE_STREAM_VS VS;
+    CD3DX12_PIPELINE_STATE_STREAM_GS GS;
+    CD3DX12_PIPELINE_STATE_STREAM_STREAM_OUTPUT StreamOutput;
+    CD3DX12_PIPELINE_STATE_STREAM_HS HS;
+    CD3DX12_PIPELINE_STATE_STREAM_DS DS;
+    CD3DX12_PIPELINE_STATE_STREAM_PS PS;
+    CD3DX12_PIPELINE_STATE_STREAM_AS AS;
+    CD3DX12_PIPELINE_STATE_STREAM_MS MS;
+    CD3DX12_PIPELINE_STATE_STREAM_CS CS;
+    CD3DX12_PIPELINE_STATE_STREAM_BLEND_DESC BlendState;
+    CD3DX12_PIPELINE_STATE_STREAM_DEPTH_STENCIL1 DepthStencilState;
+    CD3DX12_PIPELINE_STATE_STREAM_DEPTH_STENCIL_FORMAT DSVFormat;
+    CD3DX12_PIPELINE_STATE_STREAM_RASTERIZER RasterizerState;
+    CD3DX12_PIPELINE_STATE_STREAM_RENDER_TARGET_FORMATS RTVFormats;
+    CD3DX12_PIPELINE_STATE_STREAM_SAMPLE_DESC SampleDesc;
+    CD3DX12_PIPELINE_STATE_STREAM_SAMPLE_MASK SampleMask;
+    CD3DX12_PIPELINE_STATE_STREAM_CACHED_PSO CachedPSO;
+    CD3DX12_PIPELINE_STATE_STREAM_VIEW_INSTANCING ViewInstancingDesc;
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC GraphicsDescV0() const noexcept
+    {
+        D3D12_GRAPHICS_PIPELINE_STATE_DESC D;
+        D.Flags                 = this->Flags;
+        D.NodeMask              = this->NodeMask;
+        D.pRootSignature        = this->pRootSignature;
+        D.InputLayout           = this->InputLayout;
+        D.IBStripCutValue       = this->IBStripCutValue;
+        D.PrimitiveTopologyType = this->PrimitiveTopologyType;
+        D.VS                    = this->VS;
+        D.GS                    = this->GS;
+        D.StreamOutput          = this->StreamOutput;
+        D.HS                    = this->HS;
+        D.DS                    = this->DS;
+        D.PS                    = this->PS;
+        D.BlendState            = this->BlendState;
+        D.DepthStencilState     = CD3DX12_DEPTH_STENCIL_DESC1(D3D12_DEPTH_STENCIL_DESC1(this->DepthStencilState));
+        D.DSVFormat             = this->DSVFormat;
+        D.RasterizerState       = this->RasterizerState;
+        D.NumRenderTargets      = D3D12_RT_FORMAT_ARRAY(this->RTVFormats).NumRenderTargets;
+        memcpy(D.RTVFormats, D3D12_RT_FORMAT_ARRAY(this->RTVFormats).RTFormats, sizeof(D.RTVFormats));
+        D.SampleDesc            = this->SampleDesc;
+        D.SampleMask            = this->SampleMask;
+        D.CachedPSO             = this->CachedPSO;
+        return D;
+    }
+    D3D12_COMPUTE_PIPELINE_STATE_DESC ComputeDescV0() const noexcept
+    {
+        D3D12_COMPUTE_PIPELINE_STATE_DESC D;
+        D.Flags                 = this->Flags;
+        D.NodeMask              = this->NodeMask;
+        D.pRootSignature        = this->pRootSignature;
+        D.CS                    = this->CS;
+        D.CachedPSO             = this->CachedPSO;
+        return D;
+    }
+};
+
+// CD3DX12_PIPELINE_STATE_STREAM1 Works on OS Build 16299+ (where there is a new view instancing subobject).
+// Use CD3DX12_PIPELINE_STATE_STREAM for OS Build 15063+ support.
+struct CD3DX12_PIPELINE_STATE_STREAM1
+{
+    CD3DX12_PIPELINE_STATE_STREAM1() = default;
+    // Mesh and amplification shaders must be set manually, since they do not have representation in D3D12_GRAPHICS_PIPELINE_STATE_DESC
+    CD3DX12_PIPELINE_STATE_STREAM1(const D3D12_GRAPHICS_PIPELINE_STATE_DESC& Desc) noexcept
+        : Flags(Desc.Flags)
+        , NodeMask(Desc.NodeMask)
+        , pRootSignature(Desc.pRootSignature)
+        , InputLayout(Desc.InputLayout)
+        , IBStripCutValue(Desc.IBStripCutValue)
+        , PrimitiveTopologyType(Desc.PrimitiveTopologyType)
+        , VS(Desc.VS)
+        , GS(Desc.GS)
+        , StreamOutput(Desc.StreamOutput)
+        , HS(Desc.HS)
+        , DS(Desc.DS)
+        , PS(Desc.PS)
+        , BlendState(CD3DX12_BLEND_DESC(Desc.BlendState))
+        , DepthStencilState(CD3DX12_DEPTH_STENCIL_DESC1(Desc.DepthStencilState))
+        , DSVFormat(Desc.DSVFormat)
+        , RasterizerState(CD3DX12_RASTERIZER_DESC(Desc.RasterizerState))
+        , RTVFormats(CD3DX12_RT_FORMAT_ARRAY(Desc.RTVFormats, Desc.NumRenderTargets))
+        , SampleDesc(Desc.SampleDesc)
+        , SampleMask(Desc.SampleMask)
+        , CachedPSO(Desc.CachedPSO)
+        , ViewInstancingDesc(CD3DX12_VIEW_INSTANCING_DESC(CD3DX12_DEFAULT()))
+    {}
+    CD3DX12_PIPELINE_STATE_STREAM1(const D3DX12_MESH_SHADER_PIPELINE_STATE_DESC& Desc) noexcept
+        : Flags(Desc.Flags)
+        , NodeMask(Desc.NodeMask)
+        , pRootSignature(Desc.pRootSignature)
+        , PrimitiveTopologyType(Desc.PrimitiveTopologyType)
+        , PS(Desc.PS)
+        , BlendState(CD3DX12_BLEND_DESC(Desc.BlendState))
+        , DepthStencilState(CD3DX12_DEPTH_STENCIL_DESC1(Desc.DepthStencilState))
+        , DSVFormat(Desc.DSVFormat)
+        , RasterizerState(CD3DX12_RASTERIZER_DESC(Desc.RasterizerState))
+        , RTVFormats(CD3DX12_RT_FORMAT_ARRAY(Desc.RTVFormats, Desc.NumRenderTargets))
+        , SampleDesc(Desc.SampleDesc)
+        , SampleMask(Desc.SampleMask)
+        , CachedPSO(Desc.CachedPSO)
+        , ViewInstancingDesc(CD3DX12_VIEW_INSTANCING_DESC(CD3DX12_DEFAULT()))
+    {}
+    CD3DX12_PIPELINE_STATE_STREAM1(const D3D12_COMPUTE_PIPELINE_STATE_DESC& Desc) noexcept
         : Flags(Desc.Flags)
         , NodeMask(Desc.NodeMask)
         , pRootSignature(Desc.pRootSignature)
@@ -2306,7 +2742,7 @@ struct CD3DX12_PIPELINE_STATE_STREAM1
     CD3DX12_PIPELINE_STATE_STREAM_SAMPLE_MASK SampleMask;
     CD3DX12_PIPELINE_STATE_STREAM_CACHED_PSO CachedPSO;
     CD3DX12_PIPELINE_STATE_STREAM_VIEW_INSTANCING ViewInstancingDesc;
-    D3D12_GRAPHICS_PIPELINE_STATE_DESC GraphicsDescV0() const
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC GraphicsDescV0() const noexcept
     {
         D3D12_GRAPHICS_PIPELINE_STATE_DESC D;
         D.Flags                 = this->Flags;
@@ -2332,7 +2768,7 @@ struct CD3DX12_PIPELINE_STATE_STREAM1
         D.CachedPSO             = this->CachedPSO;
         return D;
     }
-    D3D12_COMPUTE_PIPELINE_STATE_DESC ComputeDescV0() const
+    D3D12_COMPUTE_PIPELINE_STATE_DESC ComputeDescV0() const noexcept
     {
         D3D12_COMPUTE_PIPELINE_STATE_DESC D;
         D.Flags                 = this->Flags;
@@ -2344,12 +2780,70 @@ struct CD3DX12_PIPELINE_STATE_STREAM1
     }
 };
 
-// CD3DX12_PIPELINE_STATE_STREAM works on RS2+ but does not support new subobject(s) added in RS3+.
+
+struct CD3DX12_PIPELINE_MESH_STATE_STREAM
+{
+    CD3DX12_PIPELINE_MESH_STATE_STREAM() = default;
+    CD3DX12_PIPELINE_MESH_STATE_STREAM(const D3DX12_MESH_SHADER_PIPELINE_STATE_DESC& Desc) noexcept
+        : Flags(Desc.Flags)
+        , NodeMask(Desc.NodeMask)
+        , pRootSignature(Desc.pRootSignature)
+        , PS(Desc.PS)
+        , AS(Desc.AS)
+        , MS(Desc.MS)
+        , BlendState(CD3DX12_BLEND_DESC(Desc.BlendState))
+        , DepthStencilState(CD3DX12_DEPTH_STENCIL_DESC1(Desc.DepthStencilState))
+        , DSVFormat(Desc.DSVFormat)
+        , RasterizerState(CD3DX12_RASTERIZER_DESC(Desc.RasterizerState))
+        , RTVFormats(CD3DX12_RT_FORMAT_ARRAY(Desc.RTVFormats, Desc.NumRenderTargets))
+        , SampleDesc(Desc.SampleDesc)
+        , SampleMask(Desc.SampleMask)
+        , CachedPSO(Desc.CachedPSO)
+        , ViewInstancingDesc(CD3DX12_VIEW_INSTANCING_DESC(CD3DX12_DEFAULT()))
+    {}
+    CD3DX12_PIPELINE_STATE_STREAM_FLAGS Flags;
+    CD3DX12_PIPELINE_STATE_STREAM_NODE_MASK NodeMask;
+    CD3DX12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE pRootSignature;
+    CD3DX12_PIPELINE_STATE_STREAM_PS PS;
+    CD3DX12_PIPELINE_STATE_STREAM_AS AS;
+    CD3DX12_PIPELINE_STATE_STREAM_MS MS;
+    CD3DX12_PIPELINE_STATE_STREAM_BLEND_DESC BlendState;
+    CD3DX12_PIPELINE_STATE_STREAM_DEPTH_STENCIL1 DepthStencilState;
+    CD3DX12_PIPELINE_STATE_STREAM_DEPTH_STENCIL_FORMAT DSVFormat;
+    CD3DX12_PIPELINE_STATE_STREAM_RASTERIZER RasterizerState;
+    CD3DX12_PIPELINE_STATE_STREAM_RENDER_TARGET_FORMATS RTVFormats;
+    CD3DX12_PIPELINE_STATE_STREAM_SAMPLE_DESC SampleDesc;
+    CD3DX12_PIPELINE_STATE_STREAM_SAMPLE_MASK SampleMask;
+    CD3DX12_PIPELINE_STATE_STREAM_CACHED_PSO CachedPSO;
+    CD3DX12_PIPELINE_STATE_STREAM_VIEW_INSTANCING ViewInstancingDesc;
+    D3DX12_MESH_SHADER_PIPELINE_STATE_DESC MeshShaderDescV0() const noexcept
+    {
+        D3DX12_MESH_SHADER_PIPELINE_STATE_DESC D;
+        D.Flags                 = this->Flags;
+        D.NodeMask              = this->NodeMask;
+        D.pRootSignature        = this->pRootSignature;
+        D.PS                    = this->PS;
+        D.AS                    = this->AS;
+        D.MS                    = this->MS;
+        D.BlendState            = this->BlendState;
+        D.DepthStencilState     = CD3DX12_DEPTH_STENCIL_DESC1(D3D12_DEPTH_STENCIL_DESC1(this->DepthStencilState));
+        D.DSVFormat             = this->DSVFormat;
+        D.RasterizerState       = this->RasterizerState;
+        D.NumRenderTargets      = D3D12_RT_FORMAT_ARRAY(this->RTVFormats).NumRenderTargets;
+        memcpy(D.RTVFormats, D3D12_RT_FORMAT_ARRAY(this->RTVFormats).RTFormats, sizeof(D.RTVFormats));
+        D.SampleDesc            = this->SampleDesc;
+        D.SampleMask            = this->SampleMask;
+        D.CachedPSO             = this->CachedPSO;
+        return D;
+    }
+};
+
+// CD3DX12_PIPELINE_STATE_STREAM works on OS Build 15063+ but does not support new subobject(s) added in OS Build 16299+.
 // See CD3DX12_PIPELINE_STATE_STREAM1 for instance.
 struct CD3DX12_PIPELINE_STATE_STREAM
 {
     CD3DX12_PIPELINE_STATE_STREAM() = default;
-    CD3DX12_PIPELINE_STATE_STREAM(const D3D12_GRAPHICS_PIPELINE_STATE_DESC& Desc)
+    CD3DX12_PIPELINE_STATE_STREAM(const D3D12_GRAPHICS_PIPELINE_STATE_DESC& Desc) noexcept
         : Flags(Desc.Flags)
         , NodeMask(Desc.NodeMask)
         , pRootSignature(Desc.pRootSignature)
@@ -2371,7 +2865,7 @@ struct CD3DX12_PIPELINE_STATE_STREAM
         , SampleMask(Desc.SampleMask)
         , CachedPSO(Desc.CachedPSO)
     {}
-    CD3DX12_PIPELINE_STATE_STREAM(const D3D12_COMPUTE_PIPELINE_STATE_DESC& Desc)
+    CD3DX12_PIPELINE_STATE_STREAM(const D3D12_COMPUTE_PIPELINE_STATE_DESC& Desc) noexcept
         : Flags(Desc.Flags)
         , NodeMask(Desc.NodeMask)
         , pRootSignature(Desc.pRootSignature)
@@ -2399,7 +2893,7 @@ struct CD3DX12_PIPELINE_STATE_STREAM
     CD3DX12_PIPELINE_STATE_STREAM_SAMPLE_DESC SampleDesc;
     CD3DX12_PIPELINE_STATE_STREAM_SAMPLE_MASK SampleMask;
     CD3DX12_PIPELINE_STATE_STREAM_CACHED_PSO CachedPSO;
-    D3D12_GRAPHICS_PIPELINE_STATE_DESC GraphicsDescV0() const
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC GraphicsDescV0() const noexcept
     {
         D3D12_GRAPHICS_PIPELINE_STATE_DESC D;
         D.Flags                 = this->Flags;
@@ -2425,7 +2919,7 @@ struct CD3DX12_PIPELINE_STATE_STREAM
         D.CachedPSO             = this->CachedPSO;
         return D;
     }
-    D3D12_COMPUTE_PIPELINE_STATE_DESC ComputeDescV0() const
+    D3D12_COMPUTE_PIPELINE_STATE_DESC ComputeDescV0() const noexcept
     {
         D3D12_COMPUTE_PIPELINE_STATE_DESC D;
         D.Flags                 = this->Flags;
@@ -2436,6 +2930,67 @@ struct CD3DX12_PIPELINE_STATE_STREAM
         return D;
     }
 };
+
+struct CD3DX12_PIPELINE_STATE_STREAM2_PARSE_HELPER : public ID3DX12PipelineParserCallbacks
+{
+    CD3DX12_PIPELINE_STATE_STREAM2 PipelineStream;
+    CD3DX12_PIPELINE_STATE_STREAM2_PARSE_HELPER() noexcept
+        : SeenDSS(false)
+    {
+        // Adjust defaults to account for absent members.
+        PipelineStream.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+
+        // Depth disabled if no DSV format specified.
+        static_cast<D3D12_DEPTH_STENCIL_DESC1&>(PipelineStream.DepthStencilState).DepthEnable = false;
+    }
+
+    // ID3DX12PipelineParserCallbacks
+    void FlagsCb(D3D12_PIPELINE_STATE_FLAGS Flags) override {PipelineStream.Flags = Flags;}
+    void NodeMaskCb(UINT NodeMask) override {PipelineStream.NodeMask = NodeMask;}
+    void RootSignatureCb(ID3D12RootSignature* pRootSignature) override {PipelineStream.pRootSignature = pRootSignature;}
+    void InputLayoutCb(const D3D12_INPUT_LAYOUT_DESC& InputLayout) override {PipelineStream.InputLayout = InputLayout;}
+    void IBStripCutValueCb(D3D12_INDEX_BUFFER_STRIP_CUT_VALUE IBStripCutValue) override {PipelineStream.IBStripCutValue = IBStripCutValue;}
+    void PrimitiveTopologyTypeCb(D3D12_PRIMITIVE_TOPOLOGY_TYPE PrimitiveTopologyType) override {PipelineStream.PrimitiveTopologyType = PrimitiveTopologyType;}
+    void VSCb(const D3D12_SHADER_BYTECODE& VS) override {PipelineStream.VS = VS;}
+    void GSCb(const D3D12_SHADER_BYTECODE& GS) override {PipelineStream.GS = GS;}
+    void StreamOutputCb(const D3D12_STREAM_OUTPUT_DESC& StreamOutput) override {PipelineStream.StreamOutput = StreamOutput;}
+    void HSCb(const D3D12_SHADER_BYTECODE& HS) override {PipelineStream.HS = HS;}
+    void DSCb(const D3D12_SHADER_BYTECODE& DS) override {PipelineStream.DS = DS;}
+    void PSCb(const D3D12_SHADER_BYTECODE& PS) override {PipelineStream.PS = PS;}
+    void CSCb(const D3D12_SHADER_BYTECODE& CS) override {PipelineStream.CS = CS;}
+    void ASCb(const D3D12_SHADER_BYTECODE& AS) override {PipelineStream.AS = AS;}
+    void MSCb(const D3D12_SHADER_BYTECODE& MS) override {PipelineStream.MS = MS;}
+    void BlendStateCb(const D3D12_BLEND_DESC& BlendState) override {PipelineStream.BlendState = CD3DX12_BLEND_DESC(BlendState);}
+    void DepthStencilStateCb(const D3D12_DEPTH_STENCIL_DESC& DepthStencilState) override
+    {
+        PipelineStream.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC1(DepthStencilState);
+        SeenDSS = true;
+    }
+    void DepthStencilState1Cb(const D3D12_DEPTH_STENCIL_DESC1& DepthStencilState) override
+    {
+        PipelineStream.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC1(DepthStencilState);
+        SeenDSS = true;
+    }
+    void DSVFormatCb(DXGI_FORMAT DSVFormat) override
+    {
+        PipelineStream.DSVFormat = DSVFormat;
+        if (!SeenDSS && DSVFormat != DXGI_FORMAT_UNKNOWN)
+        {
+            // Re-enable depth for the default state.
+            static_cast<D3D12_DEPTH_STENCIL_DESC1&>(PipelineStream.DepthStencilState).DepthEnable = true;
+        }
+    }
+    void RasterizerStateCb(const D3D12_RASTERIZER_DESC& RasterizerState) override {PipelineStream.RasterizerState = CD3DX12_RASTERIZER_DESC(RasterizerState);}
+    void RTVFormatsCb(const D3D12_RT_FORMAT_ARRAY& RTVFormats) override {PipelineStream.RTVFormats = RTVFormats;}
+    void SampleDescCb(const DXGI_SAMPLE_DESC& SampleDesc) override {PipelineStream.SampleDesc = SampleDesc;}
+    void SampleMaskCb(UINT SampleMask) override {PipelineStream.SampleMask = SampleMask;}
+    void ViewInstancingCb(const D3D12_VIEW_INSTANCING_DESC& ViewInstancingDesc) override {PipelineStream.ViewInstancingDesc = CD3DX12_VIEW_INSTANCING_DESC(ViewInstancingDesc);}
+    void CachedPSOCb(const D3D12_CACHED_PIPELINE_STATE& CachedPSO) override {PipelineStream.CachedPSO = CachedPSO;}
+
+private:
+    bool SeenDSS;
+};
+
 
 struct CD3DX12_PIPELINE_STATE_STREAM_PARSE_HELPER : public ID3DX12PipelineParserCallbacks
 {
@@ -2495,11 +3050,11 @@ private:
     bool SeenDSS;
 };
 
-inline D3D12_PIPELINE_STATE_SUBOBJECT_TYPE D3DX12GetBaseSubobjectType(D3D12_PIPELINE_STATE_SUBOBJECT_TYPE SubobjectType)
+inline D3D12_PIPELINE_STATE_SUBOBJECT_TYPE D3DX12GetBaseSubobjectType(D3D12_PIPELINE_STATE_SUBOBJECT_TYPE SubobjectType) noexcept
 {
     switch (SubobjectType)
     {
-    case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL1: 
+    case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL1:
         return D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL;
     default:
         return SubobjectType;
@@ -2528,7 +3083,7 @@ inline HRESULT D3DX12ParsePipelineStream(const D3D12_PIPELINE_STATE_STREAM_DESC&
         {
             pCallbacks->ErrorUnknownSubobject(SubobjectType);
             return E_INVALIDARG;
-        } 
+        }
         if (SubobjectSeen[D3DX12GetBaseSubobjectType(SubobjectType)])
         {
             pCallbacks->ErrorDuplicateSubobject(SubobjectType);
@@ -2537,7 +3092,7 @@ inline HRESULT D3DX12ParsePipelineStream(const D3D12_PIPELINE_STATE_STREAM_DESC&
         SubobjectSeen[SubobjectType] = true;
         switch (SubobjectType)
         {
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE:
             pCallbacks->RootSignatureCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::pRootSignature)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::pRootSignature);
             break;
@@ -2545,19 +3100,19 @@ inline HRESULT D3DX12ParsePipelineStream(const D3D12_PIPELINE_STATE_STREAM_DESC&
             pCallbacks->VSCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::VS)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::VS);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_PS: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_PS:
             pCallbacks->PSCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::PS)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::PS);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DS: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DS:
             pCallbacks->DSCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::DS)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::DS);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_HS: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_HS:
             pCallbacks->HSCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::HS)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::HS);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_GS: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_GS:
             pCallbacks->GSCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::GS)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::GS);
             break;
@@ -2565,59 +3120,67 @@ inline HRESULT D3DX12ParsePipelineStream(const D3D12_PIPELINE_STATE_STREAM_DESC&
             pCallbacks->CSCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::CS)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::CS);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_STREAM_OUTPUT: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_AS:
+            pCallbacks->ASCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM2::AS)*>(pStream));
+            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM2::AS);
+            break;
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_MS:
+            pCallbacks->MSCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM2::MS)*>(pStream));
+            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM2::MS);
+            break;
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_STREAM_OUTPUT:
             pCallbacks->StreamOutputCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::StreamOutput)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::StreamOutput);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_BLEND: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_BLEND:
             pCallbacks->BlendStateCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::BlendState)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::BlendState);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_SAMPLE_MASK: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_SAMPLE_MASK:
             pCallbacks->SampleMaskCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::SampleMask)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::SampleMask);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_RASTERIZER: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_RASTERIZER:
             pCallbacks->RasterizerStateCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::RasterizerState)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::RasterizerState);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL:
             pCallbacks->DepthStencilStateCb(*reinterpret_cast<CD3DX12_PIPELINE_STATE_STREAM_DEPTH_STENCIL*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM_DEPTH_STENCIL);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL1: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL1:
             pCallbacks->DepthStencilState1Cb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::DepthStencilState)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::DepthStencilState);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_INPUT_LAYOUT: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_INPUT_LAYOUT:
             pCallbacks->InputLayoutCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::InputLayout)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::InputLayout);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_IB_STRIP_CUT_VALUE: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_IB_STRIP_CUT_VALUE:
             pCallbacks->IBStripCutValueCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::IBStripCutValue)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::IBStripCutValue);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_PRIMITIVE_TOPOLOGY: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_PRIMITIVE_TOPOLOGY:
             pCallbacks->PrimitiveTopologyTypeCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::PrimitiveTopologyType)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::PrimitiveTopologyType);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_RENDER_TARGET_FORMATS: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_RENDER_TARGET_FORMATS:
             pCallbacks->RTVFormatsCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::RTVFormats)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::RTVFormats);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL_FORMAT: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL_FORMAT:
             pCallbacks->DSVFormatCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::DSVFormat)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::DSVFormat);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_SAMPLE_DESC: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_SAMPLE_DESC:
             pCallbacks->SampleDescCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::SampleDesc)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::SampleDesc);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK:
             pCallbacks->NodeMaskCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::NodeMask)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::NodeMask);
             break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_CACHED_PSO: 
+        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_CACHED_PSO:
             pCallbacks->CachedPSOCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::CachedPSO)*>(pStream));
             SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::CachedPSO);
             break;
@@ -2632,7 +3195,6 @@ inline HRESULT D3DX12ParsePipelineStream(const D3D12_PIPELINE_STATE_STREAM_DESC&
         default:
             pCallbacks->ErrorUnknownSubobject(SubobjectType);
             return E_INVALIDARG;
-            break;
         }
     }
 
@@ -2640,7 +3202,7 @@ inline HRESULT D3DX12ParsePipelineStream(const D3D12_PIPELINE_STATE_STREAM_DESC&
 }
 
 //------------------------------------------------------------------------------------------------
-inline bool operator==( const D3D12_CLEAR_VALUE &a, const D3D12_CLEAR_VALUE &b)
+inline bool operator==( const D3D12_CLEAR_VALUE &a, const D3D12_CLEAR_VALUE &b) noexcept
 {
     if (a.Format != b.Format) return false;
     if (a.Format == DXGI_FORMAT_D24_UNORM_S8_UINT
@@ -2648,49 +3210,49 @@ inline bool operator==( const D3D12_CLEAR_VALUE &a, const D3D12_CLEAR_VALUE &b)
      || a.Format == DXGI_FORMAT_D32_FLOAT
      || a.Format == DXGI_FORMAT_D32_FLOAT_S8X24_UINT)
     {
-        return (a.DepthStencil.Depth == b.DepthStencil.Depth) && 
+        return (a.DepthStencil.Depth == b.DepthStencil.Depth) &&
           (a.DepthStencil.Stencil == b.DepthStencil.Stencil);
     } else {
-        return (a.Color[0] == b.Color[0]) && 
-               (a.Color[1] == b.Color[1]) && 
-               (a.Color[2] == b.Color[2]) && 
+        return (a.Color[0] == b.Color[0]) &&
+               (a.Color[1] == b.Color[1]) &&
+               (a.Color[2] == b.Color[2]) &&
                (a.Color[3] == b.Color[3]);
     }
 }
-inline bool operator==( const D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS &a, const D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS &b)
+inline bool operator==( const D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS &a, const D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS &b) noexcept
 {
     return a.ClearValue == b.ClearValue;
 }
-inline bool operator==( const D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS &a, const D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS &b)
+inline bool operator==( const D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS &a, const D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS &b) noexcept
 {
     if (a.pSrcResource != b.pSrcResource) return false;
     if (a.pDstResource != b.pDstResource) return false;
     if (a.SubresourceCount != b.SubresourceCount) return false;
     if (a.Format != b.Format) return false;
-    if (a.ResolveMode != b.ResolveMode) return false; 
-    if (a.PreserveResolveSource != b.PreserveResolveSource) return false; 
+    if (a.ResolveMode != b.ResolveMode) return false;
+    if (a.PreserveResolveSource != b.PreserveResolveSource) return false;
     return true;
 }
-inline bool operator==( const D3D12_RENDER_PASS_BEGINNING_ACCESS &a, const D3D12_RENDER_PASS_BEGINNING_ACCESS &b)
+inline bool operator==( const D3D12_RENDER_PASS_BEGINNING_ACCESS &a, const D3D12_RENDER_PASS_BEGINNING_ACCESS &b) noexcept
 {
     if (a.Type != b.Type) return false;
-    if (a.Type == D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR && !(a.Clear == b.Clear)) return false; 
+    if (a.Type == D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR && !(a.Clear == b.Clear)) return false;
     return true;
 }
-inline bool operator==( const D3D12_RENDER_PASS_ENDING_ACCESS &a, const D3D12_RENDER_PASS_ENDING_ACCESS &b)
+inline bool operator==( const D3D12_RENDER_PASS_ENDING_ACCESS &a, const D3D12_RENDER_PASS_ENDING_ACCESS &b) noexcept
 {
     if (a.Type != b.Type) return false;
-    if (a.Type == D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_RESOLVE && !(a.Resolve == b.Resolve)) return false; 
+    if (a.Type == D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_RESOLVE && !(a.Resolve == b.Resolve)) return false;
     return true;
 }
-inline bool operator==( const D3D12_RENDER_PASS_RENDER_TARGET_DESC &a, const D3D12_RENDER_PASS_RENDER_TARGET_DESC &b)
+inline bool operator==( const D3D12_RENDER_PASS_RENDER_TARGET_DESC &a, const D3D12_RENDER_PASS_RENDER_TARGET_DESC &b) noexcept
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.BeginningAccess == b.BeginningAccess)) return false;
     if (!(a.EndingAccess == b.EndingAccess)) return false;
     return true;
 }
-inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &b)
+inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &b) noexcept
 {
     if (a.cpuDescriptor.ptr != b.cpuDescriptor.ptr) return false;
     if (!(a.DepthBeginningAccess == b.DepthBeginningAccess)) return false;
@@ -2705,50 +3267,60 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 
 //================================================================================================
 // D3DX12 State Object Creation Helpers
-// 
+//
 // Helper classes for creating new style state objects out of an arbitrary set of subobjects.
 // Uses STL
 //
 // Start by instantiating CD3DX12_STATE_OBJECT_DESC (see it's public methods).
 // One of its methods is CreateSubobject(), which has a comment showing a couple of options for
-// defining subobjects using the helper classes for each subobject (CD3DX12_DXIL_LIBRARY_SUBOBJECT 
-// etc.). The subobject helpers each have methods specific to the subobject for configuring it's 
+// defining subobjects using the helper classes for each subobject (CD3DX12_DXIL_LIBRARY_SUBOBJECT
+// etc.). The subobject helpers each have methods specific to the subobject for configuring it's
 // contents.
-// 
+//
 //================================================================================================
 #include <list>
-#include <vector>
-#include <string>
 #include <memory>
+#include <string>
+#include <vector>
+#ifndef D3DX12_USE_ATL
 #include <wrl/client.h>
+#define D3DX12_COM_PTR Microsoft::WRL::ComPtr
+#define D3DX12_COM_PTR_GET(x) x.Get()
+#define D3DX12_COM_PTR_ADDRESSOF(x) x.GetAddressOf()
+#else
+#include <atlbase.h>
+#define D3DX12_COM_PTR ATL::CComPtr
+#define D3DX12_COM_PTR_GET(x) x.p
+#define D3DX12_COM_PTR_ADDRESSOF(x) &x.p
+#endif
 
 //------------------------------------------------------------------------------------------------
 class CD3DX12_STATE_OBJECT_DESC
 {
 public:
-    CD3DX12_STATE_OBJECT_DESC()
+    CD3DX12_STATE_OBJECT_DESC() noexcept
     {
         Init(D3D12_STATE_OBJECT_TYPE_COLLECTION);
     }
-    CD3DX12_STATE_OBJECT_DESC(D3D12_STATE_OBJECT_TYPE Type)
+    CD3DX12_STATE_OBJECT_DESC(D3D12_STATE_OBJECT_TYPE Type) noexcept
     {
         Init(Type);
     }
-    void SetStateObjectType(D3D12_STATE_OBJECT_TYPE Type) { m_Desc.Type = Type; }
+    void SetStateObjectType(D3D12_STATE_OBJECT_TYPE Type) noexcept { m_Desc.Type = Type; }
     operator const D3D12_STATE_OBJECT_DESC&()
     {
         // Do final preparation work
         m_RepointedAssociations.clear();
         m_SubobjectArray.clear();
         m_SubobjectArray.reserve(m_Desc.NumSubobjects);
-        // Flatten subobjects into an array (each flattened subobject still has a 
+        // Flatten subobjects into an array (each flattened subobject still has a
         // member that's a pointer to it's desc that's not flattened)
         for (auto Iter = m_SubobjectList.begin();
             Iter != m_SubobjectList.end(); Iter++)
         {
             m_SubobjectArray.push_back(*Iter);
-            // Store new location in array so we can redirect pointers contained in subobjects 
-            Iter->pSubobjectArrayLocation = &m_SubobjectArray.back(); 
+            // Store new location in array so we can redirect pointers contained in subobjects
+            Iter->pSubobjectArrayLocation = &m_SubobjectArray.back();
         }
         // For subobjects with pointer fields, create a new copy of those subobject definitions
         // with fixed pointers
@@ -2756,10 +3328,10 @@ public:
         {
             if (m_SubobjectArray[i].Type == D3D12_STATE_SUBOBJECT_TYPE_SUBOBJECT_TO_EXPORTS_ASSOCIATION)
             {
-                auto pOriginalSubobjectAssociation = 
-                    reinterpret_cast<const D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION*>(m_SubobjectArray[i].pDesc);
+                auto pOriginalSubobjectAssociation =
+                    static_cast<const D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION*>(m_SubobjectArray[i].pDesc);
                 D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION Repointed = *pOriginalSubobjectAssociation;
-                auto pWrapper = 
+                auto pWrapper =
                     static_cast<const SUBOBJECT_WRAPPER*>(pOriginalSubobjectAssociation->pSubobjectToAssociate);
                 Repointed.pSubobjectToAssociate = pWrapper->pSubobjectArrayLocation;
                 m_RepointedAssociations.push_back(Repointed);
@@ -2767,7 +3339,7 @@ public:
             }
         }
         // Below: using ugly way to get pointer in case .data() is not defined
-        m_Desc.pSubobjects = m_Desc.NumSubobjects ? &m_SubobjectArray[0] : nullptr; 
+        m_Desc.pSubobjects = m_Desc.NumSubobjects ? &m_SubobjectArray[0] : nullptr;
         return m_Desc;
     }
     operator const D3D12_STATE_OBJECT_DESC*()
@@ -2776,28 +3348,28 @@ public:
         return &static_cast<const D3D12_STATE_OBJECT_DESC&>(*this);
     }
 
-    // CreateSubobject creates a sububject helper (e.g. CD3DX12_HIT_GROUP_SUBOBJECT) 
+    // CreateSubobject creates a sububject helper (e.g. CD3DX12_HIT_GROUP_SUBOBJECT)
     // whose lifetime is owned by this class.
-    // e.g. 
-    // 
+    // e.g.
+    //
     //    CD3DX12_STATE_OBJECT_DESC Collection1(D3D12_STATE_OBJECT_TYPE_COLLECTION);
     //    auto Lib0 = Collection1.CreateSubobject<CD3DX12_DXIL_LIBRARY_SUBOBJECT>();
     //    Lib0->SetDXILLibrary(&pMyAppDxilLibs[0]);
-    //    Lib0->DefineExport(L"rayGenShader0"); // in practice these export listings might be 
+    //    Lib0->DefineExport(L"rayGenShader0"); // in practice these export listings might be
     //                                          // data/engine driven
     //    etc.
     //
-    // Alternatively, users can instantiate sububject helpers explicitly, such as via local 
-    // variables instead, passing the state object desc that should point to it into the helper 
-    // constructor (or call mySubobjectHelper.AddToStateObject(Collection1)).  
-    // In this alternative scenario, the user must keep the subobject alive as long as the state 
+    // Alternatively, users can instantiate sububject helpers explicitly, such as via local
+    // variables instead, passing the state object desc that should point to it into the helper
+    // constructor (or call mySubobjectHelper.AddToStateObject(Collection1)).
+    // In this alternative scenario, the user must keep the subobject alive as long as the state
     // object it is associated with is alive, else it's pointer references will be stale.
     // e.g.
     //
     //    CD3DX12_STATE_OBJECT_DESC RaytracingState2(D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE);
     //    CD3DX12_DXIL_LIBRARY_SUBOBJECT LibA(RaytracingState2);
-    //    LibA.SetDXILLibrary(&pMyAppDxilLibs[4]); // not manually specifying exports 
-    //                                             // - meaning all exports in the libraries 
+    //    LibA.SetDXILLibrary(&pMyAppDxilLibs[4]); // not manually specifying exports
+    //                                             // - meaning all exports in the libraries
     //                                             // are exported
     //    etc.
 
@@ -2820,7 +3392,7 @@ private:
         m_Desc.NumSubobjects++;
         return &m_SubobjectList.back();
     }
-    void Init(D3D12_STATE_OBJECT_TYPE Type)
+    void Init(D3D12_STATE_OBJECT_TYPE Type) noexcept
     {
         SetStateObjectType(Type);
         m_Desc.pSubobjects = nullptr;
@@ -2831,16 +3403,16 @@ private:
     }
     typedef struct SUBOBJECT_WRAPPER : public D3D12_STATE_SUBOBJECT
     {
-        D3D12_STATE_SUBOBJECT* pSubobjectArrayLocation; // new location when flattened into array 
+        D3D12_STATE_SUBOBJECT* pSubobjectArrayLocation; // new location when flattened into array
                                                         // for repointing pointers in subobjects
     } SUBOBJECT_WRAPPER;
     D3D12_STATE_OBJECT_DESC m_Desc;
-    std::list<SUBOBJECT_WRAPPER>   m_SubobjectList; // Pointers to list nodes handed out so 
+    std::list<SUBOBJECT_WRAPPER>   m_SubobjectList; // Pointers to list nodes handed out so
                                                     // these can be edited live
     std::vector<D3D12_STATE_SUBOBJECT> m_SubobjectArray; // Built at the end, copying list contents
 
-    std::list<D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION> 
-            m_RepointedAssociations; // subobject type that contains pointers to other subobjects, 
+    std::list<D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION>
+            m_RepointedAssociations; // subobject type that contains pointers to other subobjects,
                                      // repointed to flattened array
 
     class StringContainer
@@ -2866,7 +3438,7 @@ private:
                 return nullptr;
             }
         }
-        void clear() { m_Strings.clear(); }
+        void clear() noexcept { m_Strings.clear(); }
     private:
         std::list<std::wstring> m_Strings;
     };
@@ -2874,16 +3446,16 @@ private:
     class SUBOBJECT_HELPER_BASE
     {
     public:
-        SUBOBJECT_HELPER_BASE() { Init(); };
-        virtual ~SUBOBJECT_HELPER_BASE() {};
-        virtual D3D12_STATE_SUBOBJECT_TYPE Type() const = 0;
+        SUBOBJECT_HELPER_BASE() noexcept { Init(); }
+        virtual ~SUBOBJECT_HELPER_BASE() = default;
+        virtual D3D12_STATE_SUBOBJECT_TYPE Type() const noexcept = 0;
         void AddToStateObject(CD3DX12_STATE_OBJECT_DESC& ContainingStateObject)
         {
             m_pSubobject = ContainingStateObject.TrackSubobject(Type(), Data());
         }
     protected:
-        virtual void* Data() = 0;
-        void Init() { m_pSubobject = nullptr; }
+        virtual void* Data() noexcept = 0;
+        void Init() noexcept { m_pSubobject = nullptr; }
         D3D12_STATE_SUBOBJECT* m_pSubobject;
     };
 
@@ -2893,7 +3465,7 @@ private:
     class OWNED_HELPER
     {
     public:
-        OWNED_HELPER(const SUBOBJECT_HELPER_BASE* pHelper) { m_pHelper = pHelper; }
+        OWNED_HELPER(const SUBOBJECT_HELPER_BASE* pHelper) noexcept { m_pHelper = pHelper; }
         ~OWNED_HELPER() { delete m_pHelper; }
         const SUBOBJECT_HELPER_BASE* m_pHelper;
     };
@@ -2908,6 +3480,7 @@ private:
     friend class CD3DX12_HIT_GROUP_SUBOBJECT;
     friend class CD3DX12_RAYTRACING_SHADER_CONFIG_SUBOBJECT;
     friend class CD3DX12_RAYTRACING_PIPELINE_CONFIG_SUBOBJECT;
+    friend class CD3DX12_RAYTRACING_PIPELINE_CONFIG1_SUBOBJECT;
     friend class CD3DX12_GLOBAL_ROOT_SIGNATURE_SUBOBJECT;
     friend class CD3DX12_LOCAL_ROOT_SIGNATURE_SUBOBJECT;
     friend class CD3DX12_STATE_OBJECT_CONFIG_SUBOBJECT;
@@ -2915,11 +3488,11 @@ private:
 };
 
 //------------------------------------------------------------------------------------------------
-class CD3DX12_DXIL_LIBRARY_SUBOBJECT 
+class CD3DX12_DXIL_LIBRARY_SUBOBJECT
     : public CD3DX12_STATE_OBJECT_DESC::SUBOBJECT_HELPER_BASE
 {
 public:
-    CD3DX12_DXIL_LIBRARY_SUBOBJECT()
+    CD3DX12_DXIL_LIBRARY_SUBOBJECT() noexcept
     {
         Init();
     }
@@ -2928,14 +3501,14 @@ public:
         Init();
         AddToStateObject(ContainingStateObject);
     }
-    void SetDXILLibrary(D3D12_SHADER_BYTECODE*pCode) 
-    { 
-        static const D3D12_SHADER_BYTECODE Default = {}; 
-        m_Desc.DXILLibrary = pCode ? *pCode : Default; 
+    void SetDXILLibrary(const D3D12_SHADER_BYTECODE* pCode) noexcept
+    {
+        static const D3D12_SHADER_BYTECODE Default = {};
+        m_Desc.DXILLibrary = pCode ? *pCode : Default;
     }
     void DefineExport(
-        LPCWSTR Name, 
-        LPCWSTR ExportToRename = nullptr, 
+        LPCWSTR Name,
+        LPCWSTR ExportToRename = nullptr,
         D3D12_EXPORT_FLAGS Flags = D3D12_EXPORT_FLAG_NONE)
     {
         D3D12_EXPORT_DESC Export;
@@ -2954,39 +3527,39 @@ public:
             DefineExport(Exports[i]);
         }
     }
-    void DefineExports(LPCWSTR* Exports, UINT N)
+    void DefineExports(const LPCWSTR* Exports, UINT N)
     {
         for (UINT i = 0; i < N; i++)
         {
             DefineExport(Exports[i]);
         }
-    }    
-    D3D12_STATE_SUBOBJECT_TYPE Type() const 
-    { 
-        return D3D12_STATE_SUBOBJECT_TYPE_DXIL_LIBRARY; 
     }
-    operator const D3D12_STATE_SUBOBJECT&() const { return *m_pSubobject; }
-    operator const D3D12_DXIL_LIBRARY_DESC&() const { return m_Desc; }
+    D3D12_STATE_SUBOBJECT_TYPE Type() const noexcept override
+    {
+        return D3D12_STATE_SUBOBJECT_TYPE_DXIL_LIBRARY;
+    }
+    operator const D3D12_STATE_SUBOBJECT&() const noexcept { return *m_pSubobject; }
+    operator const D3D12_DXIL_LIBRARY_DESC&() const noexcept { return m_Desc; }
 private:
-    void Init()
+    void Init() noexcept
     {
         SUBOBJECT_HELPER_BASE::Init();
         m_Desc = {};
         m_Strings.clear();
         m_Exports.clear();
     }
-    void* Data() { return &m_Desc; }
+    void* Data() noexcept override { return &m_Desc; }
     D3D12_DXIL_LIBRARY_DESC m_Desc;
     CD3DX12_STATE_OBJECT_DESC::StringContainer m_Strings;
     std::vector<D3D12_EXPORT_DESC> m_Exports;
 };
 
 //------------------------------------------------------------------------------------------------
-class CD3DX12_EXISTING_COLLECTION_SUBOBJECT 
+class CD3DX12_EXISTING_COLLECTION_SUBOBJECT
     : public CD3DX12_STATE_OBJECT_DESC::SUBOBJECT_HELPER_BASE
 {
 public:
-    CD3DX12_EXISTING_COLLECTION_SUBOBJECT()
+    CD3DX12_EXISTING_COLLECTION_SUBOBJECT() noexcept
     {
         Init();
     }
@@ -2995,14 +3568,14 @@ public:
         Init();
         AddToStateObject(ContainingStateObject);
     }
-    void SetExistingCollection(ID3D12StateObject*pExistingCollection) 
-    { 
-        m_Desc.pExistingCollection = pExistingCollection; 
-        m_CollectionRef = pExistingCollection; 
+    void SetExistingCollection(ID3D12StateObject*pExistingCollection) noexcept
+    {
+        m_Desc.pExistingCollection = pExistingCollection;
+        m_CollectionRef = pExistingCollection;
     }
     void DefineExport(
-        LPCWSTR Name, 
-        LPCWSTR ExportToRename = nullptr, 
+        LPCWSTR Name,
+        LPCWSTR ExportToRename = nullptr,
         D3D12_EXPORT_FLAGS Flags = D3D12_EXPORT_FLAG_NONE)
     {
         D3D12_EXPORT_DESC Export;
@@ -3021,21 +3594,21 @@ public:
             DefineExport(Exports[i]);
         }
     }
-    void DefineExports(LPCWSTR* Exports, UINT N)
+    void DefineExports(const LPCWSTR* Exports, UINT N)
     {
         for (UINT i = 0; i < N; i++)
         {
             DefineExport(Exports[i]);
         }
-    }    
-    D3D12_STATE_SUBOBJECT_TYPE Type() const
-    { 
-        return D3D12_STATE_SUBOBJECT_TYPE_EXISTING_COLLECTION; 
     }
-    operator const D3D12_STATE_SUBOBJECT&() const { return *m_pSubobject; }
-    operator const D3D12_EXISTING_COLLECTION_DESC&() const { return m_Desc; }
+    D3D12_STATE_SUBOBJECT_TYPE Type() const noexcept override
+    {
+        return D3D12_STATE_SUBOBJECT_TYPE_EXISTING_COLLECTION;
+    }
+    operator const D3D12_STATE_SUBOBJECT&() const noexcept { return *m_pSubobject; }
+    operator const D3D12_EXISTING_COLLECTION_DESC&() const noexcept { return m_Desc; }
 private:
-    void Init()
+    void Init() noexcept
     {
         SUBOBJECT_HELPER_BASE::Init();
         m_Desc = {};
@@ -3043,19 +3616,19 @@ private:
         m_Strings.clear();
         m_Exports.clear();
     }
-    void* Data() { return &m_Desc; }
+    void* Data() noexcept override { return &m_Desc; }
     D3D12_EXISTING_COLLECTION_DESC m_Desc;
-    Microsoft::WRL::ComPtr<ID3D12StateObject> m_CollectionRef;
+    D3DX12_COM_PTR<ID3D12StateObject> m_CollectionRef;
     CD3DX12_STATE_OBJECT_DESC::StringContainer m_Strings;
     std::vector<D3D12_EXPORT_DESC> m_Exports;
 };
 
 //------------------------------------------------------------------------------------------------
-class CD3DX12_SUBOBJECT_TO_EXPORTS_ASSOCIATION_SUBOBJECT 
+class CD3DX12_SUBOBJECT_TO_EXPORTS_ASSOCIATION_SUBOBJECT
     : public CD3DX12_STATE_OBJECT_DESC::SUBOBJECT_HELPER_BASE
 {
 public:
-    CD3DX12_SUBOBJECT_TO_EXPORTS_ASSOCIATION_SUBOBJECT()
+    CD3DX12_SUBOBJECT_TO_EXPORTS_ASSOCIATION_SUBOBJECT() noexcept
     {
         Init();
     }
@@ -3064,9 +3637,9 @@ public:
         Init();
         AddToStateObject(ContainingStateObject);
     }
-    void SetSubobjectToAssociate(const D3D12_STATE_SUBOBJECT& SubobjectToAssociate) 
-    { 
-        m_Desc.pSubobjectToAssociate = &SubobjectToAssociate; 
+    void SetSubobjectToAssociate(const D3D12_STATE_SUBOBJECT& SubobjectToAssociate) noexcept
+    {
+        m_Desc.pSubobjectToAssociate = &SubobjectToAssociate;
     }
     void AddExport(LPCWSTR Export)
     {
@@ -3082,39 +3655,39 @@ public:
             AddExport(Exports[i]);
         }
     }
-    void AddExports(LPCWSTR* Exports, UINT N)
+    void AddExports(const LPCWSTR* Exports, UINT N)
     {
         for (UINT i = 0; i < N; i++)
         {
             AddExport(Exports[i]);
         }
-    }    
-    D3D12_STATE_SUBOBJECT_TYPE Type() const 
-    { 
-        return D3D12_STATE_SUBOBJECT_TYPE_SUBOBJECT_TO_EXPORTS_ASSOCIATION; 
     }
-    operator const D3D12_STATE_SUBOBJECT&() const { return *m_pSubobject; }
-    operator const D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION&() const { return m_Desc; }
+    D3D12_STATE_SUBOBJECT_TYPE Type() const noexcept override
+    {
+        return D3D12_STATE_SUBOBJECT_TYPE_SUBOBJECT_TO_EXPORTS_ASSOCIATION;
+    }
+    operator const D3D12_STATE_SUBOBJECT&() const noexcept { return *m_pSubobject; }
+    operator const D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION&() const noexcept { return m_Desc; }
 private:
-    void Init()
+    void Init() noexcept
     {
         SUBOBJECT_HELPER_BASE::Init();
         m_Desc = {};
         m_Strings.clear();
         m_Exports.clear();
     }
-    void* Data() { return &m_Desc; }
+    void* Data() noexcept override { return &m_Desc; }
     D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION m_Desc;
     CD3DX12_STATE_OBJECT_DESC::StringContainer m_Strings;
     std::vector<LPCWSTR> m_Exports;
 };
 
 //------------------------------------------------------------------------------------------------
-class CD3DX12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION 
+class CD3DX12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION
     : public CD3DX12_STATE_OBJECT_DESC::SUBOBJECT_HELPER_BASE
 {
 public:
-    CD3DX12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION()
+    CD3DX12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION() noexcept
     {
         Init();
     }
@@ -3123,9 +3696,9 @@ public:
         Init();
         AddToStateObject(ContainingStateObject);
     }
-    void SetSubobjectNameToAssociate(LPCWSTR SubobjectToAssociate) 
+    void SetSubobjectNameToAssociate(LPCWSTR SubobjectToAssociate)
     {
-        m_Desc.SubobjectToAssociate = m_SubobjectName.LocalCopy(SubobjectToAssociate, true); 
+        m_Desc.SubobjectToAssociate = m_SubobjectName.LocalCopy(SubobjectToAssociate, true);
     }
     void AddExport(LPCWSTR Export)
     {
@@ -3141,21 +3714,21 @@ public:
             AddExport(Exports[i]);
         }
     }
-    void AddExports(LPCWSTR* Exports, UINT N)
+    void AddExports(const LPCWSTR* Exports, UINT N)
     {
         for (UINT i = 0; i < N; i++)
         {
             AddExport(Exports[i]);
         }
-    }    
-    D3D12_STATE_SUBOBJECT_TYPE Type() const
-    { 
-        return D3D12_STATE_SUBOBJECT_TYPE_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION; 
     }
-    operator const D3D12_STATE_SUBOBJECT&() const { return *m_pSubobject; }
-    operator const D3D12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION&() const { return m_Desc; }
+    D3D12_STATE_SUBOBJECT_TYPE Type() const noexcept override
+    {
+        return D3D12_STATE_SUBOBJECT_TYPE_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION;
+    }
+    operator const D3D12_STATE_SUBOBJECT&() const noexcept { return *m_pSubobject; }
+    operator const D3D12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION&() const noexcept { return m_Desc; }
 private:
-    void Init()
+    void Init() noexcept
     {
         SUBOBJECT_HELPER_BASE::Init();
         m_Desc = {};
@@ -3163,7 +3736,7 @@ private:
         m_SubobjectName.clear();
         m_Exports.clear();
     }
-    void* Data() { return &m_Desc; }
+    void* Data() noexcept override { return &m_Desc; }
     D3D12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION m_Desc;
     CD3DX12_STATE_OBJECT_DESC::StringContainer m_Strings;
     CD3DX12_STATE_OBJECT_DESC::StringContainer m_SubobjectName;
@@ -3171,11 +3744,11 @@ private:
 };
 
 //------------------------------------------------------------------------------------------------
-class CD3DX12_HIT_GROUP_SUBOBJECT 
+class CD3DX12_HIT_GROUP_SUBOBJECT
     : public CD3DX12_STATE_OBJECT_DESC::SUBOBJECT_HELPER_BASE
 {
 public:
-    CD3DX12_HIT_GROUP_SUBOBJECT()
+    CD3DX12_HIT_GROUP_SUBOBJECT() noexcept
     {
         Init();
     }
@@ -3185,30 +3758,30 @@ public:
         AddToStateObject(ContainingStateObject);
     }
     void SetHitGroupExport(LPCWSTR exportName)
-    { 
-        m_Desc.HitGroupExport = m_Strings[0].LocalCopy(exportName, true); 
+    {
+        m_Desc.HitGroupExport = m_Strings[0].LocalCopy(exportName, true);
     }
-    void SetHitGroupType(D3D12_HIT_GROUP_TYPE Type) { m_Desc.Type = Type; }
+    void SetHitGroupType(D3D12_HIT_GROUP_TYPE Type) noexcept { m_Desc.Type = Type; }
     void SetAnyHitShaderImport(LPCWSTR importName)
-    { 
-        m_Desc.AnyHitShaderImport = m_Strings[1].LocalCopy(importName, true); 
+    {
+        m_Desc.AnyHitShaderImport = m_Strings[1].LocalCopy(importName, true);
     }
     void SetClosestHitShaderImport(LPCWSTR importName)
-    { 
-        m_Desc.ClosestHitShaderImport = m_Strings[2].LocalCopy(importName, true); 
+    {
+        m_Desc.ClosestHitShaderImport = m_Strings[2].LocalCopy(importName, true);
     }
     void SetIntersectionShaderImport(LPCWSTR importName)
     {
-        m_Desc.IntersectionShaderImport = m_Strings[3].LocalCopy(importName, true); 
+        m_Desc.IntersectionShaderImport = m_Strings[3].LocalCopy(importName, true);
     }
-    D3D12_STATE_SUBOBJECT_TYPE Type() const
+    D3D12_STATE_SUBOBJECT_TYPE Type() const noexcept override
     {
-        return D3D12_STATE_SUBOBJECT_TYPE_HIT_GROUP; 
+        return D3D12_STATE_SUBOBJECT_TYPE_HIT_GROUP;
     }
-    operator const D3D12_STATE_SUBOBJECT&() const { return *m_pSubobject; }
-    operator const D3D12_HIT_GROUP_DESC&() const { return m_Desc; }
+    operator const D3D12_STATE_SUBOBJECT&() const noexcept { return *m_pSubobject; }
+    operator const D3D12_HIT_GROUP_DESC&() const noexcept { return m_Desc; }
 private:
-    void Init()
+    void Init() noexcept
     {
         SUBOBJECT_HELPER_BASE::Init();
         m_Desc = {};
@@ -3217,19 +3790,19 @@ private:
             m_Strings[i].clear();
         }
     }
-    void* Data() { return &m_Desc; }
+    void* Data() noexcept override { return &m_Desc; }
     D3D12_HIT_GROUP_DESC m_Desc;
     static const UINT m_NumStrings = 4;
-    CD3DX12_STATE_OBJECT_DESC::StringContainer 
+    CD3DX12_STATE_OBJECT_DESC::StringContainer
         m_Strings[m_NumStrings]; // one string for every entrypoint name
 };
 
 //------------------------------------------------------------------------------------------------
-class CD3DX12_RAYTRACING_SHADER_CONFIG_SUBOBJECT 
+class CD3DX12_RAYTRACING_SHADER_CONFIG_SUBOBJECT
     : public CD3DX12_STATE_OBJECT_DESC::SUBOBJECT_HELPER_BASE
 {
 public:
-    CD3DX12_RAYTRACING_SHADER_CONFIG_SUBOBJECT()
+    CD3DX12_RAYTRACING_SHADER_CONFIG_SUBOBJECT() noexcept
     {
         Init();
     }
@@ -3238,33 +3811,33 @@ public:
         Init();
         AddToStateObject(ContainingStateObject);
     }
-    void Config(UINT MaxPayloadSizeInBytes, UINT MaxAttributeSizeInBytes)
+    void Config(UINT MaxPayloadSizeInBytes, UINT MaxAttributeSizeInBytes) noexcept
     {
         m_Desc.MaxPayloadSizeInBytes = MaxPayloadSizeInBytes;
         m_Desc.MaxAttributeSizeInBytes = MaxAttributeSizeInBytes;
     }
-    D3D12_STATE_SUBOBJECT_TYPE Type() const
-    { 
-        return D3D12_STATE_SUBOBJECT_TYPE_RAYTRACING_SHADER_CONFIG; 
+    D3D12_STATE_SUBOBJECT_TYPE Type() const noexcept override
+    {
+        return D3D12_STATE_SUBOBJECT_TYPE_RAYTRACING_SHADER_CONFIG;
     }
-    operator const D3D12_STATE_SUBOBJECT&() const { return *m_pSubobject; }
-    operator const D3D12_RAYTRACING_SHADER_CONFIG&() const { return m_Desc; }
+    operator const D3D12_STATE_SUBOBJECT&() const noexcept { return *m_pSubobject; }
+    operator const D3D12_RAYTRACING_SHADER_CONFIG&() const noexcept { return m_Desc; }
 private:
-    void Init()
+    void Init() noexcept
     {
         SUBOBJECT_HELPER_BASE::Init();
         m_Desc = {};
     }
-    void* Data() { return &m_Desc; }
+    void* Data() noexcept override { return &m_Desc; }
     D3D12_RAYTRACING_SHADER_CONFIG m_Desc;
 };
 
 //------------------------------------------------------------------------------------------------
-class CD3DX12_RAYTRACING_PIPELINE_CONFIG_SUBOBJECT 
+class CD3DX12_RAYTRACING_PIPELINE_CONFIG_SUBOBJECT
     : public CD3DX12_STATE_OBJECT_DESC::SUBOBJECT_HELPER_BASE
 {
 public:
-    CD3DX12_RAYTRACING_PIPELINE_CONFIG_SUBOBJECT()
+    CD3DX12_RAYTRACING_PIPELINE_CONFIG_SUBOBJECT() noexcept
     {
         Init();
     }
@@ -3273,32 +3846,67 @@ public:
         Init();
         AddToStateObject(ContainingStateObject);
     }
-    void Config(UINT MaxTraceRecursionDepth)
+    void Config(UINT MaxTraceRecursionDepth) noexcept
     {
         m_Desc.MaxTraceRecursionDepth = MaxTraceRecursionDepth;
     }
-    D3D12_STATE_SUBOBJECT_TYPE Type() const
-    { 
-        return D3D12_STATE_SUBOBJECT_TYPE_RAYTRACING_PIPELINE_CONFIG; 
+    D3D12_STATE_SUBOBJECT_TYPE Type() const noexcept override
+    {
+        return D3D12_STATE_SUBOBJECT_TYPE_RAYTRACING_PIPELINE_CONFIG;
     }
-    operator const D3D12_STATE_SUBOBJECT&() const { return *m_pSubobject; }
-    operator const D3D12_RAYTRACING_PIPELINE_CONFIG&() const { return m_Desc; }
+    operator const D3D12_STATE_SUBOBJECT&() const noexcept { return *m_pSubobject; }
+    operator const D3D12_RAYTRACING_PIPELINE_CONFIG&() const noexcept { return m_Desc; }
 private:
-    void Init()
+    void Init() noexcept
     {
         SUBOBJECT_HELPER_BASE::Init();
         m_Desc = {};
     }
-    void* Data() { return &m_Desc; }
+    void* Data() noexcept override { return &m_Desc; }
     D3D12_RAYTRACING_PIPELINE_CONFIG m_Desc;
 };
 
 //------------------------------------------------------------------------------------------------
-class CD3DX12_GLOBAL_ROOT_SIGNATURE_SUBOBJECT 
+class CD3DX12_RAYTRACING_PIPELINE_CONFIG1_SUBOBJECT
     : public CD3DX12_STATE_OBJECT_DESC::SUBOBJECT_HELPER_BASE
 {
 public:
-    CD3DX12_GLOBAL_ROOT_SIGNATURE_SUBOBJECT()
+    CD3DX12_RAYTRACING_PIPELINE_CONFIG1_SUBOBJECT() noexcept
+    {
+        Init();
+    }
+    CD3DX12_RAYTRACING_PIPELINE_CONFIG1_SUBOBJECT(CD3DX12_STATE_OBJECT_DESC& ContainingStateObject)
+    {
+        Init();
+        AddToStateObject(ContainingStateObject);
+    }
+    void Config(UINT MaxTraceRecursionDepth, D3D12_RAYTRACING_PIPELINE_FLAGS Flags) noexcept
+    {
+        m_Desc.MaxTraceRecursionDepth = MaxTraceRecursionDepth;
+        m_Desc.Flags = Flags;
+    }
+    D3D12_STATE_SUBOBJECT_TYPE Type() const noexcept override
+    {
+        return D3D12_STATE_SUBOBJECT_TYPE_RAYTRACING_PIPELINE_CONFIG1;
+    }
+    operator const D3D12_STATE_SUBOBJECT&() const noexcept { return *m_pSubobject; }
+    operator const D3D12_RAYTRACING_PIPELINE_CONFIG1&() const noexcept { return m_Desc; }
+private:
+    void Init() noexcept
+    {
+        SUBOBJECT_HELPER_BASE::Init();
+        m_Desc = {};
+    }
+    void* Data() noexcept override { return &m_Desc; }
+    D3D12_RAYTRACING_PIPELINE_CONFIG1 m_Desc;
+};
+
+//------------------------------------------------------------------------------------------------
+class CD3DX12_GLOBAL_ROOT_SIGNATURE_SUBOBJECT
+    : public CD3DX12_STATE_OBJECT_DESC::SUBOBJECT_HELPER_BASE
+{
+public:
+    CD3DX12_GLOBAL_ROOT_SIGNATURE_SUBOBJECT() noexcept
     {
         Init();
     }
@@ -3307,32 +3915,32 @@ public:
         Init();
         AddToStateObject(ContainingStateObject);
     }
-    void SetRootSignature(ID3D12RootSignature* pRootSig)
+    void SetRootSignature(ID3D12RootSignature* pRootSig) noexcept
     {
         m_pRootSig = pRootSig;
     }
-    D3D12_STATE_SUBOBJECT_TYPE Type() const
-    { 
-        return D3D12_STATE_SUBOBJECT_TYPE_GLOBAL_ROOT_SIGNATURE; 
+    D3D12_STATE_SUBOBJECT_TYPE Type() const noexcept override
+    {
+        return D3D12_STATE_SUBOBJECT_TYPE_GLOBAL_ROOT_SIGNATURE;
     }
-    operator const D3D12_STATE_SUBOBJECT&() const { return *m_pSubobject; }
-    operator ID3D12RootSignature*() const { return m_pRootSig.Get(); }
+    operator const D3D12_STATE_SUBOBJECT&() const noexcept { return *m_pSubobject; }
+    operator ID3D12RootSignature*() const noexcept { return D3DX12_COM_PTR_GET(m_pRootSig); }
 private:
-    void Init()
+    void Init() noexcept
     {
         SUBOBJECT_HELPER_BASE::Init();
         m_pRootSig = nullptr;
     }
-    void* Data() { return m_pRootSig.GetAddressOf(); }
-    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_pRootSig;
+    void* Data() noexcept override { return D3DX12_COM_PTR_ADDRESSOF(m_pRootSig); }
+    D3DX12_COM_PTR<ID3D12RootSignature> m_pRootSig;
 };
 
 //------------------------------------------------------------------------------------------------
-class CD3DX12_LOCAL_ROOT_SIGNATURE_SUBOBJECT 
+class CD3DX12_LOCAL_ROOT_SIGNATURE_SUBOBJECT
     : public CD3DX12_STATE_OBJECT_DESC::SUBOBJECT_HELPER_BASE
 {
 public:
-    CD3DX12_LOCAL_ROOT_SIGNATURE_SUBOBJECT()
+    CD3DX12_LOCAL_ROOT_SIGNATURE_SUBOBJECT() noexcept
     {
         Init();
     }
@@ -3341,32 +3949,32 @@ public:
         Init();
         AddToStateObject(ContainingStateObject);
     }
-    void SetRootSignature(ID3D12RootSignature* pRootSig)
+    void SetRootSignature(ID3D12RootSignature* pRootSig) noexcept
     {
         m_pRootSig = pRootSig;
     }
-    D3D12_STATE_SUBOBJECT_TYPE Type() const
-    { 
-        return D3D12_STATE_SUBOBJECT_TYPE_LOCAL_ROOT_SIGNATURE; 
+    D3D12_STATE_SUBOBJECT_TYPE Type() const noexcept override
+    {
+        return D3D12_STATE_SUBOBJECT_TYPE_LOCAL_ROOT_SIGNATURE;
     }
-    operator const D3D12_STATE_SUBOBJECT&() const { return *m_pSubobject; }
-    operator ID3D12RootSignature*() const { return m_pRootSig.Get(); }
+    operator const D3D12_STATE_SUBOBJECT&() const noexcept { return *m_pSubobject; }
+    operator ID3D12RootSignature*() const noexcept { return D3DX12_COM_PTR_GET(m_pRootSig); }
 private:
-    void Init()
+    void Init() noexcept
     {
         SUBOBJECT_HELPER_BASE::Init();
         m_pRootSig = nullptr;
     }
-    void* Data() { return m_pRootSig.GetAddressOf(); }
-    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_pRootSig;
+    void* Data() noexcept override { return D3DX12_COM_PTR_ADDRESSOF(m_pRootSig); }
+    D3DX12_COM_PTR<ID3D12RootSignature> m_pRootSig;
 };
 
 //------------------------------------------------------------------------------------------------
-class CD3DX12_STATE_OBJECT_CONFIG_SUBOBJECT 
+class CD3DX12_STATE_OBJECT_CONFIG_SUBOBJECT
     : public CD3DX12_STATE_OBJECT_DESC::SUBOBJECT_HELPER_BASE
 {
 public:
-    CD3DX12_STATE_OBJECT_CONFIG_SUBOBJECT()
+    CD3DX12_STATE_OBJECT_CONFIG_SUBOBJECT() noexcept
     {
         Init();
     }
@@ -3375,32 +3983,32 @@ public:
         Init();
         AddToStateObject(ContainingStateObject);
     }
-    void SetFlags(D3D12_STATE_OBJECT_FLAGS Flags)
+    void SetFlags(D3D12_STATE_OBJECT_FLAGS Flags) noexcept
     {
         m_Desc.Flags = Flags;
     }
-    D3D12_STATE_SUBOBJECT_TYPE Type() const
-    { 
-        return D3D12_STATE_SUBOBJECT_TYPE_STATE_OBJECT_CONFIG; 
+    D3D12_STATE_SUBOBJECT_TYPE Type() const noexcept override
+    {
+        return D3D12_STATE_SUBOBJECT_TYPE_STATE_OBJECT_CONFIG;
     }
-    operator const D3D12_STATE_SUBOBJECT&() const { return *m_pSubobject; }
-    operator const D3D12_STATE_OBJECT_CONFIG&() const { return m_Desc; }
+    operator const D3D12_STATE_SUBOBJECT&() const noexcept { return *m_pSubobject; }
+    operator const D3D12_STATE_OBJECT_CONFIG&() const noexcept { return m_Desc; }
 private:
-    void Init()
+    void Init() noexcept
     {
         SUBOBJECT_HELPER_BASE::Init();
         m_Desc = {};
     }
-    void* Data() { return &m_Desc; }
+    void* Data() noexcept override { return &m_Desc; }
     D3D12_STATE_OBJECT_CONFIG m_Desc;
 };
 
 //------------------------------------------------------------------------------------------------
-class CD3DX12_NODE_MASK_SUBOBJECT 
+class CD3DX12_NODE_MASK_SUBOBJECT
     : public CD3DX12_STATE_OBJECT_DESC::SUBOBJECT_HELPER_BASE
 {
 public:
-    CD3DX12_NODE_MASK_SUBOBJECT()
+    CD3DX12_NODE_MASK_SUBOBJECT() noexcept
     {
         Init();
     }
@@ -3409,30 +4017,32 @@ public:
         Init();
         AddToStateObject(ContainingStateObject);
     }
-    void SetNodeMask(UINT NodeMask)
+    void SetNodeMask(UINT NodeMask) noexcept
     {
         m_Desc.NodeMask = NodeMask;
     }
-    D3D12_STATE_SUBOBJECT_TYPE Type() const
-    { 
-        return D3D12_STATE_SUBOBJECT_TYPE_NODE_MASK; 
+    D3D12_STATE_SUBOBJECT_TYPE Type() const noexcept override
+    {
+        return D3D12_STATE_SUBOBJECT_TYPE_NODE_MASK;
     }
-    operator const D3D12_STATE_SUBOBJECT&() const { return *m_pSubobject; }
-    operator const D3D12_NODE_MASK&() const { return m_Desc; }
+    operator const D3D12_STATE_SUBOBJECT&() const noexcept { return *m_pSubobject; }
+    operator const D3D12_NODE_MASK&() const noexcept { return m_Desc; }
 private:
-    void Init()
+    void Init() noexcept
     {
         SUBOBJECT_HELPER_BASE::Init();
         m_Desc = {};
     }
-    void* Data() { return &m_Desc; }
+    void* Data() noexcept override { return &m_Desc; }
     D3D12_NODE_MASK m_Desc;
 };
 
+#undef D3DX12_COM_PTR
+#undef D3DX12_COM_PTR_GET
+#undef D3DX12_COM_PTR_ADDRESSOF
 #endif // #ifndef D3DX12_NO_STATE_OBJECT_HELPERS
 
 #endif // defined( __cplusplus )
 
 #endif //__D3DX12_H__
-
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/External/D3DX12/d3dx12.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/External/D3DX12/d3dx12.h
@@ -2030,7 +2030,7 @@ inline UINT64 GetRequiredIntermediateSize(
     UINT64 RequiredSize = 0;
 
     ID3D12Device* pDevice = nullptr;
-    pDestinationResource->GetDevice(IID_ID3D12Device, reinterpret_cast<void**>(&pDevice));
+    pDestinationResource->GetDevice(__uuidof(*pDevice), reinterpret_cast<void**>(&pDevice));
     pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, 0, nullptr, nullptr, nullptr, &RequiredSize);
     pDevice->Release();
 
@@ -2182,7 +2182,7 @@ inline UINT64 UpdateSubresources(
 
     auto Desc = pDestinationResource->GetDesc();
     ID3D12Device* pDevice = nullptr;
-    pDestinationResource->GetDevice(IID_ID3D12Device, reinterpret_cast<void**>(&pDevice));
+    pDestinationResource->GetDevice(__uuidof(*pDevice), reinterpret_cast<void**>(&pDevice));
     pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, pLayouts, pNumRows, pRowSizesInBytes, &RequiredSize);
     pDevice->Release();
 
@@ -2220,7 +2220,7 @@ inline UINT64 UpdateSubresources(
 
     auto Desc = pDestinationResource->GetDesc();
     ID3D12Device* pDevice = nullptr;
-    pDestinationResource->GetDevice(IID_ID3D12Device, reinterpret_cast<void**>(&pDevice));
+    pDestinationResource->GetDevice(__uuidof(*pDevice), reinterpret_cast<void**>(&pDevice));
     pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, pLayouts, pNumRows, pRowSizesInBytes, &RequiredSize);
     pDevice->Release();
 
@@ -2248,7 +2248,7 @@ inline UINT64 UpdateSubresources(
 
     auto Desc = pDestinationResource->GetDesc();
     ID3D12Device* pDevice = nullptr;
-    pDestinationResource->GetDevice(IID_ID3D12Device, reinterpret_cast<void**>(&pDevice));
+    pDestinationResource->GetDevice(__uuidof(*pDevice), reinterpret_cast<void**>(&pDevice));
     pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, Layouts, NumRows, RowSizesInBytes, &RequiredSize);
     pDevice->Release();
 
@@ -2275,7 +2275,7 @@ inline UINT64 UpdateSubresources(
 
     auto Desc = pDestinationResource->GetDesc();
     ID3D12Device* pDevice = nullptr;
-    pDestinationResource->GetDevice(IID_ID3D12Device, reinterpret_cast<void**>(&pDevice));
+    pDestinationResource->GetDevice(__uuidof(*pDevice), reinterpret_cast<void**>(&pDevice));
     pDevice->GetCopyableFootprints(&Desc, FirstSubresource, NumSubresources, IntermediateOffset, Layouts, NumRows, RowSizesInBytes, &RequiredSize);
     pDevice->Release();
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphKernelHelper.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphKernelHelper.cpp
@@ -141,11 +141,11 @@ namespace GraphKernelHelper
         const Dml::GraphDescBuilder::GraphDesc& graphDesc,
         const onnxruntime::ConstPointerContainer<std::vector<onnxruntime::NodeArg*>>& fusedNodeInputDefs,
         _Out_ std::vector<bool>& inputsUsed,
-        _Out_ std::vector<DML_BUFFER_BINDING>& initInputBindings,
-        _Out_ std::vector<ComPtr<ID3D12Resource>>& initInputResources,
-        _Out_ std::vector<ComPtr<ID3D12Resource>>& nonOwnedGraphInputsFromInitializers,
-        _Out_ std::vector<ComPtr<ID3D12Resource>>& initializeResourceRefs,
-        _Out_opt_ std::vector<std::vector<std::byte>>* inputRawData,
+        _Inout_ std::vector<DML_BUFFER_BINDING>& initInputBindings,
+        _Inout_ std::vector<ComPtr<ID3D12Resource>>& initInputResources,
+        _Inout_ std::vector<ComPtr<ID3D12Resource>>& nonOwnedGraphInputsFromInitializers,
+        _Inout_ std::vector<ComPtr<ID3D12Resource>>& initializeResourceRefs,
+        _Inout_opt_ std::vector<std::vector<std::byte>>* inputRawData,
         _Inout_ std::unordered_map<std::string, onnx::TensorProto>& transferredInitializerMap)
     {
         const uint32_t graphInputCount = kernelInfo.GetInputCount();
@@ -279,11 +279,11 @@ namespace GraphKernelHelper
         const Dml::GraphDescBuilder::GraphDesc& graphDesc,
         _Out_ DML_GRAPH_DESC& dmlGraphDesc,
         const onnxruntime::OpKernelInfo& kernelInfo,
-        _Out_ std::vector<DML_OPERATOR_GRAPH_NODE_DESC>& dmlOperatorGraphNodes,
-        _Out_ std::vector<DML_GRAPH_NODE_DESC>& dmlGraphNodes,
-        _Out_ std::vector<DML_GRAPH_EDGE_DESC>& dmlInputEdges,
-        _Out_ std::vector<DML_GRAPH_EDGE_DESC>& dmlOutputEdges,
-        _Out_ std::vector<DML_GRAPH_EDGE_DESC>& dmlIntermediateEdges)
+        _Inout_ std::vector<DML_OPERATOR_GRAPH_NODE_DESC>& dmlOperatorGraphNodes,
+        _Inout_ std::vector<DML_GRAPH_NODE_DESC>& dmlGraphNodes,
+        _Inout_ std::vector<DML_GRAPH_EDGE_DESC>& dmlInputEdges,
+        _Inout_ std::vector<DML_GRAPH_EDGE_DESC>& dmlOutputEdges,
+        _Inout_ std::vector<DML_GRAPH_EDGE_DESC>& dmlIntermediateEdges)
     {
         const uint32_t graphInputCount = kernelInfo.GetInputCount();
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphKernelHelper.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphKernelHelper.h
@@ -52,22 +52,22 @@ namespace GraphKernelHelper
         const Dml::GraphDescBuilder::GraphDesc& graphDesc,
         const onnxruntime::ConstPointerContainer<std::vector<onnxruntime::NodeArg*>>& fusedNodeInputDefs,
         _Out_ std::vector<bool>& inputsUsed,
-        _Out_ std::vector<DML_BUFFER_BINDING>& initInputBindings,
-        _Out_ std::vector<ComPtr<ID3D12Resource>>& initInputResources,
-        _Out_ std::vector<ComPtr<ID3D12Resource>>& nonOwnedGraphInputsFromInitializers,
-        _Out_ std::vector<ComPtr<ID3D12Resource>>& initializeResourceRefs,
-        _Out_opt_ std::vector<std::vector<std::byte>>* inputRawData,
+        _Inout_ std::vector<DML_BUFFER_BINDING>& initInputBindings,
+        _Inout_ std::vector<ComPtr<ID3D12Resource>>& initInputResources,
+        _Inout_ std::vector<ComPtr<ID3D12Resource>>& nonOwnedGraphInputsFromInitializers,
+        _Inout_ std::vector<ComPtr<ID3D12Resource>>& initializeResourceRefs,
+        _Inout_opt_ std::vector<std::vector<std::byte>>* inputRawData,
         _Inout_ std::unordered_map<std::string, onnx::TensorProto>& transferredInitializerMap);
 
     void ConvertGraphDesc(
         const Dml::GraphDescBuilder::GraphDesc& graphDesc,
         _Out_ DML_GRAPH_DESC& dmlGraphDesc,
         const onnxruntime::OpKernelInfo& kernelInfo,
-        _Out_ std::vector<DML_OPERATOR_GRAPH_NODE_DESC>& dmlOperatorGraphNodes,
-        _Out_ std::vector<DML_GRAPH_NODE_DESC>& dmlGraphNodes,
-        _Out_ std::vector<DML_GRAPH_EDGE_DESC>& dmlInputEdges,
-        _Out_ std::vector<DML_GRAPH_EDGE_DESC>& dmlOutputEdges,
-        _Out_ std::vector<DML_GRAPH_EDGE_DESC>& dmlIntermediateEdges);
+        _Inout_ std::vector<DML_OPERATOR_GRAPH_NODE_DESC>& dmlOperatorGraphNodes,
+        _Inout_ std::vector<DML_GRAPH_NODE_DESC>& dmlGraphNodes,
+        _Inout_ std::vector<DML_GRAPH_EDGE_DESC>& dmlInputEdges,
+        _Inout_ std::vector<DML_GRAPH_EDGE_DESC>& dmlOutputEdges,
+        _Inout_ std::vector<DML_GRAPH_EDGE_DESC>& dmlIntermediateEdges);
 
     std::string GetFusedNodeArgNameMatchingGraph(const std::string& fusedNodeArgeName);
     

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
@@ -1091,13 +1091,13 @@ namespace OperatorHelper
 
             ML_CHECK_VALID_ARGUMENT(inputShape.size() == dimensionCount, "Mismatch between input tensor shape and string equation label count.");
 
-            for (uint32_t i = 0; i < dimensionCount; ++i)
+            for (uint32_t j = 0; j < dimensionCount; ++j)
             {
                 // If this is the first time seeing this label, then record the size.
                 // Otherwise any following occurrences of the label must match sizes.
                 // e.g. Given "ij,ji", both i's and both j's must match dimension sizes.
-                uint32_t dimensionSize = inputShape[i];
-                uint32_t labelIndex = labelIndices[i];
+                uint32_t dimensionSize = inputShape[j];
+                uint32_t labelIndex = labelIndices[j];
                 assert(labelIndex < labelSizes.size());
 
                 if (labelSizes[labelIndex] == INT_MIN)

--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -148,7 +148,7 @@ API_IMPL_END
 }
 
 ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProviderEx_DML, _In_ OrtSessionOptions* options,
-                    IDMLDevice* dml_device, ID3D12CommandQueue* cmd_queue) {
+                    _In_ IDMLDevice* dml_device, _In_ ID3D12CommandQueue* cmd_queue) {
 API_IMPL_BEGIN
   options->provider_factories.push_back(onnxruntime::CreateExecutionProviderFactory_DML(dml_device,
                                                                                         cmd_queue));


### PR DESCRIPTION
Motivation:
There were 10 bugs related to SDL Native warning errors which occurred while building ORT with DML ep using _--cmake_extra_defines onnxruntime_ENABLE_STATIC_ANALYSIS=ON_ , Ref: below is the entire build command.

`.\build.bat --config RelWithDebInfo --skip_tests --cmake_generator "Visual Studio 16 2019" --enable_pybind --parallel --use_dml --cmake_extra_defines onnxruntime_ENABLE_STATIC_ANALYSIS=ON --enable_wcos --build_shared_lib`

Bugs list:
[1239451](https://msdata.visualstudio.com/Vienna/_workitems/edit/1239451), [1239443](https://msdata.visualstudio.com/Vienna/_workitems/edit/1239443), [1239444](https://msdata.visualstudio.com/Vienna/_workitems/edit/1239444), [1239445](https://msdata.visualstudio.com/Vienna/_workitems/edit/1239445), [1239446](https://msdata.visualstudio.com/Vienna/_workitems/edit/1239446), [1239447](https://msdata.visualstudio.com/Vienna/_workitems/edit/1239447), [1239448](https://msdata.visualstudio.com/Vienna/_workitems/edit/1239448), [1239449](https://msdata.visualstudio.com/Vienna/_workitems/edit/1239449), [1239450](https://msdata.visualstudio.com/Vienna/_workitems/edit/1239450), [1239452](https://msdata.visualstudio.com/Vienna/_workitems/edit/1239452)

Note: Usage of "onnxruntime_ENABLE_STATIC_ANALYSIS=ON" flag is necessary to publish the ORT-DML python wheel in PyPi package.

Changes:

- Update d3dx12.h with the latest change in the DirectX-Header repo. [https://github.com/microsoft/DirectX-Headers/blob/main/include/directx/d3dx12.h]
- Updated SDL notation and renamed overridden variables
- Surpassed few warnings which are not relevant.
