### PR TITLE
Add UINT8 datatype support to Java

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OnnxJavaType.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxJavaType.java
@@ -16,9 +16,10 @@ public enum OnnxJavaType {
   INT64(6, long.class, 8),
   BOOL(7, boolean.class, 1),
   STRING(8, String.class, 4),
+  UINT8(9, byte.class, 1),
   UNKNOWN(0, Object.class, 0);
 
-  private static final OnnxJavaType[] values = new OnnxJavaType[9];
+  private static final OnnxJavaType[] values = new OnnxJavaType[10];
 
   static {
     for (OnnxJavaType ot : OnnxJavaType.values()) {
@@ -62,6 +63,7 @@ public enum OnnxJavaType {
   public static OnnxJavaType mapFromOnnxTensorType(OnnxTensorType onnxValue) {
     switch (onnxValue) {
       case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+        return OnnxJavaType.UINT8;
       case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
         return OnnxJavaType.INT8;
       case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:

--- a/java/src/main/java/ai/onnxruntime/OnnxMap.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxMap.java
@@ -77,6 +77,7 @@ public class OnnxMap implements OnnxValue {
           return OnnxMapValueType.LONG;
         case STRING:
           return OnnxMapValueType.STRING;
+        case UINT8:
         case INT8:
         case INT16:
         case INT32:

--- a/java/src/main/java/ai/onnxruntime/OnnxSequence.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxSequence.java
@@ -100,6 +100,7 @@ public class OnnxSequence implements OnnxValue {
           list.addAll(Arrays.asList(strings));
           return list;
         case BOOL:
+        case UINT8:
         case INT8:
         case INT16:
         case INT32:

--- a/java/src/main/java/ai/onnxruntime/OnnxTensor.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxTensor.java
@@ -78,6 +78,7 @@ public class OnnxTensor implements OnnxValue {
           return getFloat(OnnxRuntime.ortApiHandle, nativeHandle, info.onnxType.value);
         case DOUBLE:
           return getDouble(OnnxRuntime.ortApiHandle, nativeHandle);
+        case UINT8:
         case INT8:
           return getByte(OnnxRuntime.ortApiHandle, nativeHandle, info.onnxType.value);
         case INT16:
@@ -744,6 +745,7 @@ public class OnnxTensor implements OnnxValue {
         case DOUBLE:
           tmp = buffer.asDoubleBuffer().put((DoubleBuffer) data);
           break;
+        case UINT8:
         case INT8:
           // buffer is already a ByteBuffer, no cast needed.
           tmp = buffer.put((ByteBuffer) data);

--- a/java/src/main/java/ai/onnxruntime/OrtUtil.java
+++ b/java/src/main/java/ai/onnxruntime/OrtUtil.java
@@ -434,6 +434,7 @@ public final class OrtUtil {
         double[] doubleArr = new double[1];
         doubleArr[0] = (Double) data;
         return doubleArr;
+      case UINT8:
       case INT8:
         byte[] byteArr = new byte[1];
         byteArr[0] = (Byte) data;

--- a/java/src/main/java/ai/onnxruntime/TensorInfo.java
+++ b/java/src/main/java/ai/onnxruntime/TensorInfo.java
@@ -80,6 +80,8 @@ public class TensorInfo implements ValueInfo {
           return OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE;
         case INT8:
           return OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8;
+        case UINT8:
+          return OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
         case INT16:
           return OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16;
         case INT32:
@@ -179,6 +181,7 @@ public class TensorInfo implements ValueInfo {
         return OrtUtil.newFloatArray(shape);
       case DOUBLE:
         return OrtUtil.newDoubleArray(shape);
+      case UINT8:
       case INT8:
         return OrtUtil.newByteArray(shape);
       case INT16:

--- a/java/src/test/java/ai/onnxruntime/TensorCreationTest.java
+++ b/java/src/test/java/ai/onnxruntime/TensorCreationTest.java
@@ -4,6 +4,7 @@
  */
 package ai.onnxruntime;
 
+import java.nio.ByteBuffer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -109,6 +110,18 @@ public class TensorCreationTest {
         Assertions.assertArrayEquals(new long[] {2, 2, 3}, t.getInfo().shape);
         String[][][] output = (String[][][]) t.getValue();
         Assertions.assertArrayEquals(deepStringValues, output);
+      }
+    }
+  }
+
+  @Test
+  public void testUint8Creation() throws OrtException {
+    try (OrtEnvironment env = OrtEnvironment.getEnvironment()) {
+      byte[] buf = new byte[] {0, 1};
+      ByteBuffer data = ByteBuffer.wrap(buf);
+      long[] shape = new long[] {2};
+      try (OnnxTensor t = OnnxTensor.createTensor(env, data, shape, OnnxJavaType.UINT8)) {
+        Assertions.assertArrayEquals(buf, (byte[]) t.getValue());
       }
     }
   }


### PR DESCRIPTION
Current onnexruntime Java doesn't support uint8 datatype. See: https://github.com/microsoft/onnxruntime/issues/6261

The native part already have uint8 support, the memory in the native side actually are the same between uint8 and int8. We can use signed byte[] to create uint8 Tensor.

The uint8 on java side can be presented as byte[] and end user can manually convert it to unsigned if needed.

With this change user can run uint8 model without hacking the model itself.
