### PR TITLE
Improve performance of Pad CUDA kernel

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/pad.cc
+++ b/onnxruntime/core/providers/cuda/tensor/pad.cc
@@ -4,6 +4,7 @@
 #include "pad.h"
 #include "pad_impl.h"
 #include "core/providers/cpu/tensor/utils.h"
+#include <iostream>
 
 namespace onnxruntime {
 namespace cuda {
@@ -40,6 +41,30 @@ namespace cuda {
           .InputMemoryType(OrtMemTypeCPUInput, 2)                 \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
       Pad<T>);
+
+static bool IsNCHWInputWithPaddingAlongHAndW(size_t input_rank,
+                                             const TArray<int64_t>& lower_pads,
+                                             const TArray<int64_t>& upper_pads) {
+  if (input_rank == 2) {  // N = 1 and C = 1
+    return true;
+  }
+
+  // Is CHW input AND no padding along C dim
+  if (input_rank == 3 &&
+      lower_pads[0] == 0 &&  // start padding along C
+      upper_pads[0] == 0) {  // end padding along C
+    return true;
+  }
+
+  // Is NCHW input AND no padding along N and C dims
+  if (input_rank == 4 &&
+      lower_pads[0] == 0 && lower_pads[1] == 0 &&  // start padding along N and C
+      upper_pads[0] == 0 && upper_pads[1] == 0) {  // end padding along N and C
+    return true;
+  }
+
+  return false;
+}
 
 template <typename T>
 typename ToCudaType<T>::MappedType ToCudaValue(const T& value) {
@@ -119,6 +144,7 @@ Status Pad<T>::ComputeInternal(OpKernelContext* ctx) const {
     upper_pads[i] = (*p_pads)[i + dimension_count] + (*p_slices)[i + dimension_count];
     output_dims[i] += lower_pads[i] + upper_pads[i];
   }
+
   TensorShape output_shape(output_dims);
 
   // special case when there is a dim value of 0 in the shape. behavior depends on mode
@@ -127,6 +153,7 @@ Status Pad<T>::ComputeInternal(OpKernelContext* ctx) const {
   }
 
   auto& output_tensor = *ctx->Output(0, output_shape);
+
   if (std::all_of(p_pads->begin(), p_pads->end(), [](const int64_t v) { return v == 0; }) &&
       std::all_of(p_slices->begin(), p_slices->end(), [](const int64_t v) { return v == 0; }) &&
       output_shape.Size() > 0) {
@@ -134,6 +161,41 @@ Status Pad<T>::ComputeInternal(OpKernelContext* ctx) const {
         output_tensor.template MutableData<T>(), input_tensor.template Data<T>(),
         sizeof(typename ToCudaType<T>::MappedType) * output_shape.Size(),
         cudaMemcpyDeviceToDevice, Stream()));
+    return Status::OK();
+  }
+
+  if (IsNCHWInputWithPaddingAlongHAndW(static_cast<size_t>(dimension_count), lower_pads, upper_pads) &&
+      static_cast<int>(mode_) != 2) {
+    // If we have entered here, it means the input can only be 4-D (NCHW), 3-D (CHW), or 2-D (HW)
+
+    // NCHW input
+    int height_dim = 2;
+    int width_dim = 3;
+
+    if (dimension_count == 3) {  // CHW input
+      height_dim = 1;
+      width_dim = 2;
+    } else if (dimension_count == 2) {  // HW input
+      height_dim = 0;
+      width_dim = 1;
+    }
+
+    PadNCHWInputWithPaddingAlongHAndWImpl(
+        Stream(),
+        dimension_count == 4 ? input_dims[0] : 1,
+        dimension_count == 4 ? input_dims[1] : (dimension_count == 3 ? input_dims[0] : 1),
+        input_dims[height_dim],
+        output_dims[height_dim],
+        input_dims[width_dim],
+        output_dims[width_dim],
+        lower_pads[height_dim],
+        lower_pads[width_dim],
+        value,
+        static_cast<int>(mode_),
+        reinterpret_cast<const typename ToCudaType<T>::MappedType*>(input_tensor.template Data<T>()),
+        reinterpret_cast<typename ToCudaType<T>::MappedType*>(output_tensor.template MutableData<T>()),
+        output_tensor.Shape().Size());
+
     return Status::OK();
   }
 

--- a/onnxruntime/core/providers/cuda/tensor/pad.cc
+++ b/onnxruntime/core/providers/cuda/tensor/pad.cc
@@ -164,8 +164,7 @@ Status Pad<T>::ComputeInternal(OpKernelContext* ctx) const {
     return Status::OK();
   }
 
-  if (IsNCHWInputWithPaddingAlongHAndW(static_cast<size_t>(dimension_count), lower_pads, upper_pads) &&
-      static_cast<int>(mode_) != 2) {
+  if (IsNCHWInputWithPaddingAlongHAndW(static_cast<size_t>(dimension_count), lower_pads, upper_pads)) {
     // If we have entered here, it means the input can only be 4-D (NCHW), 3-D (CHW), or 2-D (HW)
 
     // NCHW input
@@ -211,7 +210,6 @@ Status Pad<T>::ComputeInternal(OpKernelContext* ctx) const {
       input_dims,
       input_strides,
       lower_pads,
-      upper_pads,
       value,
       static_cast<int>(mode_),
       reinterpret_cast<const typename ToCudaType<T>::MappedType*>(input_tensor.template Data<T>()),

--- a/onnxruntime/core/providers/cuda/tensor/pad.cc
+++ b/onnxruntime/core/providers/cuda/tensor/pad.cc
@@ -4,7 +4,6 @@
 #include "pad.h"
 #include "pad_impl.h"
 #include "core/providers/cpu/tensor/utils.h"
-#include <iostream>
 
 namespace onnxruntime {
 namespace cuda {

--- a/onnxruntime/core/providers/cuda/tensor/pad_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/pad_impl.cu
@@ -20,7 +20,6 @@ __global__ void _PadKernel(
     const TArray<int64_t> input_dims,
     const TArray<int64_t> input_strides,
     const TArray<int64_t> lower_pads,
-    const TArray<int64_t> upper_pads,
     const T pad_value,
     const T* input_data,
     const TArray<fast_divmod> fdm_output_strides,
@@ -59,7 +58,6 @@ __global__ void _PadKernel(
           in_coord = input_dims[dim] - 2 - (out_coord - (lower_pads[dim] + input_dims[dim]));
           break;
       }
-      use_pad_value = true;
     } else {
       in_coord = out_coord - lower_pads[dim];
     }
@@ -115,6 +113,18 @@ __global__ void _PadNCHWInputWithPaddingAlongHAndWKernel(
       break;
 
     case PadMode::Reflect:
+      current_input_height = std::max(current_input_height, -current_input_height);
+      current_input_height = std::min(static_cast<int>(current_input_height),
+                                      2 * static_cast<int>(input_height) - current_input_height - 2);
+
+      current_input_width = std::max(current_input_width, -current_input_width);
+      current_input_width = std::min(static_cast<int>(current_input_width),
+                                     2 * static_cast<int>(input_width) - current_input_width - 2);
+
+      output_data[id] = input_data[(nc_index * input_height +
+                                    current_input_height) *
+                                       input_width +
+                                   current_input_width];
       break;
   }
 }
@@ -126,7 +136,6 @@ void PadImpl(
     const TArray<int64_t>& input_dims,
     const TArray<int64_t>& input_strides,
     const TArray<int64_t>& lower_pads,
-    const TArray<int64_t>& upper_pads,
     const T pad_value,
     const int pad_mode,
     const T* input_data,
@@ -140,17 +149,17 @@ void PadImpl(
   switch (pad_mode) {
     case 0:
       _PadKernel<T, 0><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
-          shape_rank, input_dims, input_strides, lower_pads, upper_pads,
+          shape_rank, input_dims, input_strides, lower_pads,
           pad_value, input_data, fdm_output_strides, output_data, N);
       break;
     case 1:
       _PadKernel<T, 1><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
-          shape_rank, input_dims, input_strides, lower_pads, upper_pads,
+          shape_rank, input_dims, input_strides, lower_pads,
           pad_value, input_data, fdm_output_strides, output_data, N);
       break;
     case 2:
       _PadKernel<T, 2><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
-          shape_rank, input_dims, input_strides, lower_pads, upper_pads,
+          shape_rank, input_dims, input_strides, lower_pads,
           pad_value, input_data, fdm_output_strides, output_data, N);
       break;
   }
@@ -201,7 +210,7 @@ void PadNCHWInputWithPaddingAlongHAndWImpl(
 #define SPECIALIZED_IMPL(T)                                                                                       \
   template void PadImpl<T>(cudaStream_t stream, const size_t shape_rank,                                          \
                            const TArray<int64_t>& input_dims, const TArray<int64_t>& input_strides,               \
-                           const TArray<int64_t>& lower_pads, const TArray<int64_t>& upper_pads,                  \
+                           const TArray<int64_t>& lower_pads,                                                     \
                            const T pad_value,                                                                     \
                            const int pad_mode,                                                                    \
                            const T* input_data,                                                                   \

--- a/onnxruntime/core/providers/cuda/tensor/pad_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/pad_impl.h
@@ -9,6 +9,23 @@ namespace onnxruntime {
 namespace cuda {
 
 template <typename T>
+void PadNCHWInputWithPaddingAlongHAndWImpl(
+    cudaStream_t stream,
+    const int64_t n,  // Batch
+    const int64_t c,  // Channel
+    const int64_t input_height,
+    const int64_t output_height,
+    const int64_t input_width,
+    const int64_t output_width,
+    const int64_t pad_height_start,
+    const int64_t pad_width_start,
+    const T pad_value,
+    const int pad_mode,
+    const T* input_data,
+    T* output_data,
+    const size_t N);
+
+template <typename T>
 void PadImpl(
     cudaStream_t stream,
     const size_t shape_rank,

--- a/onnxruntime/core/providers/cuda/tensor/pad_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/pad_impl.h
@@ -32,7 +32,6 @@ void PadImpl(
     const TArray<int64_t>& input_dims,
     const TArray<int64_t>& input_strides,
     const TArray<int64_t>& lower_pads,
-    const TArray<int64_t>& upper_pads,
     const T pad_value,
     const int pad_mode,
     const T* input_data,


### PR DESCRIPTION
**Description**: 

Most image models use the `Pad` operation to pad only along the `height` and `width` dimensions (i.e.) they convert tensors of shape [N, C, H, W] to [N, C, H + pad_h, W +pad_w]. Our current implementation for Pad in CUDA is too "generic" (processes N-D tensors accounting for possible padding in all dims) to optimally process this often-occurring use-case. This change adds logic to recognize this special case and adds a specialized implementation (Torch-inspired) for the same.

This change closes the gap with Torch for model in https://github.com/microsoft/onnxruntime/issues/8166. These gains should be applicable to all image models using such padding patterns.

The existing unit tests for Pad are very exhaustive and there are a good number of tests using the new specialized code path. No new unit tests required for this change. 

**Motivation and Context**
Resolve https://github.com/microsoft/onnxruntime/issues/8166
Possibly provides good gains for models in https://github.com/microsoft/onnxruntime/issues/8362 and https://github.com/microsoft/onnxruntime/issues/7681 (they are encouraged to try with this commit)