### PR TITLE
Performance: enable faster training with skip checks config

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -84,7 +84,7 @@ class GraphExecutionManager(GraphExecutionInterface):
         self._execution_agent = None
 
         # indicators of some logic have been executed previously thus could be skipped for faster training
-        self._skip_check = _SkipCheck(1)
+        self._skip_check = _SkipCheck.SKIP_CHECK_DISABLED
 
         # Debug flags
         self._save_onnx = False

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -65,6 +65,12 @@ class GraphExecutionManager(GraphExecutionInterface):
         # TODO - move it to config API
         self._freeze = False
         # enabled only when _freeze is True and after execution session is created the first time
+        # when _fast_path is enabled, these checks will be turned off:
+        # - schema check in _export_model() to determine whether to build gradient graph again
+        #   -- since there is no need to rebuild gradient graph, the following two functions can be skipped as well:
+        #      parse_inputs_for_onnx_export() and _reinitialize_graph_builder()
+        # - logic to determine whether to create execution session again
+        # - further checks on device change in both forward and backward pass
         self._fast_path = False
 
         # Debug flags

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -96,9 +96,7 @@ class TrainingManager(GraphExecutionManager):
 
             # disable some checks after execution session is created the first time
             if self._skip_check.is_disabled() == False:
-                self._skip_check = self._skip_check.SKIP_CHECK_BUILD_GRADIENT | \
-                    self._skip_check.SKIP_CHECK_EXECUTION_AGENT | \
-                    self._skip_check.SKIP_CHECK_DEVICE
+                self._skip_check = _SkipCheck.SKIP_CHECK_BUILD_GRADIENT | _SkipCheck.SKIP_CHECK_EXECUTION_AGENT | _SkipCheck.SKIP_CHECK_DEVICE
 
                 if self._loglevel <= _logger.LogLevel.WARNING:
                     warnings.warn("Fast path enabled - skipping checks for rebuilding gradient graph, execution agent creation, and device during training.",

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -121,7 +121,7 @@ class TrainingManager(GraphExecutionManager):
 
                 if self._skip_check.skip_device_check == False:
                     # Assert that the input and model device match
-                    _utils._check_same_device(device, "Input argument to forward", *inputs)
+                    _utils._check_same_device(self._device, "Input argument to forward", *inputs)
 
                 user_outputs, ctx.run_info = TrainingManager.execution_session_run_forward(self._execution_agent,
                                                                                            self._optimized_onnx_model,


### PR DESCRIPTION
**Description**: When profiling ORTModule+ZCodeExpert model, there are some repeated logic could be skipped, given that model remains unchanged throughout the entire training process, to improve overall performance. The experiment with this code change shows that we are able to gain additional 2% by turning on fast path using _fast_path flag.

TODO - including the skip_check() api in the experimental/internal-facing API

In the tensorboard below:
       ortmodule+torch vs. torch  ~ 7.3%   (middle blueline vs. bottom red line)
       ortmodule+torch+_freeze  vs. torch  ~ 9.4%  (top orange line vs. bottom red line)

The experiment setup - using 1 gpu on local AML node (v100/32GB) and ran 300 steps 

![image](https://user-images.githubusercontent.com/4484531/125893660-d8c40a00-9e76-4da6-88a5-70bfc6327181.png)
