### PR TITLE
[WIP] Move session config creation to _utils.py

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
@@ -110,6 +110,5 @@ class InferenceManager(GraphExecutionManager):
     def _create_execution_agent(self):
         """Creates an InferenceAgent that can run forward graph on an inference model"""
 
-        session_options, providers, provider_options = self._get_session_config()
         self._execution_agent = InferenceAgent(self._optimized_onnx_model.SerializeToString(),
-                                               session_options, providers, provider_options)
+                                               self._get_session_config())

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -221,7 +221,6 @@ class TrainingManager(GraphExecutionManager):
     def _create_execution_agent(self):
         """Creates a TrainingAgent that can run the forward and backward graph on the training model"""
 
-        session_options, providers, provider_options = self._get_session_config()
         fw_feed_names = [input.name for input in self._optimized_onnx_model.graph.input]
         fw_outputs_device_info = [
             C.OrtDevice(get_ort_device_type(self._device.type),
@@ -241,9 +240,7 @@ class TrainingManager(GraphExecutionManager):
                                               fw_outputs_device_info,
                                               bw_fetches_names,
                                               bw_outputs_device_info,
-                                              session_options,
-                                              providers,
-                                              provider_options)
+                                              self._get_session_config())
 
     def _reinitialize_graph_builder(self, input_info):
         """Return true if the module graph builder was reinitialized"""

--- a/orttraining/orttraining/python/training/ortmodule/_utils.py
+++ b/orttraining/orttraining/python/training/ortmodule/_utils.py
@@ -139,7 +139,7 @@ class SessionConfigFactory:
         Args:
             device: torch device indicating where the computation should happen.
 
-        Currently onnxruntime inference session needs to be re-initialized when the priority of the
+        onnxruntime inference session needs to be re-initialized when the priority of the
         device to execute the computation changes. This is why this method takes a device.
         """
         providers = None

--- a/orttraining/orttraining/python/training/ortmodule/_utils.py
+++ b/orttraining/orttraining/python/training/ortmodule/_utils.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from typing import Dict, NamedTuple, Sequence, Tuple, Union
+
 import onnxruntime
 from onnxruntime.capi.onnxruntime_inference_collection import OrtValue
 from onnxruntime.capi import _pybind_state as C
@@ -99,8 +101,14 @@ def _create_iobinding(io_binding, inputs, model, device):
         io_binding.bind_output(value_info.name, device.type, device_id=get_device_index(device))
 
 
+class SessionConfig(NamedTuple):
+    session_options: onnxruntime.SessionOptions
+    providers: Sequence[Union[str, Tuple[str, Dict]]]
+    provider_options: Sequence[Dict]
+
+
 def get_session_config(device: torch.device, use_external_gpu_allocator: bool = True,
-                       is_rocm_pytorch: bool = False, loglevel: int = 2):
+                       is_rocm_pytorch: bool = False, loglevel: int = 2) -> SessionConfig:
     """Creates and returns the session configuration to be used for the ExecutionAgent"""
     providers = None
     provider_options = None
@@ -131,4 +139,4 @@ def get_session_config(device: torch.device, use_external_gpu_allocator: bool = 
     # 0:Verbose, 1:Info, 2:Warning. 3:Error, 4:Fatal. Default is 2.
     session_options.log_severity_level = int(loglevel)
 
-    return session_options, providers, provider_options
+    return SessionConfig(session_options, providers, provider_options)


### PR DESCRIPTION
**Description**: `session_options`, `providers` and `provider_options` are currently created in `GraphExecutionManager._get_session_config()` method. This PR moves this method to `_utils.py` so that it can be used from other places. This PR also introduces `SessionConfig` dataclass to keep the three attributes together and `SessionConfigFactory` to handle the logic of constructing SessionConfig.

**Motivation and Context**
- Why is this change required? What problem does it solve? It is convenient to create  `session_options`, `providers` and `provider_options` in one place (because they are usually used together) but so far there was no utility function to do this.
- If it fixes an open issue, please link to the issue here.
