### PR TITLE
Add link to sample repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,14 @@
 
 ## Get Started
 
-**http://onnxruntime.ai/**
-* [Overview](https://www.onnxruntime.ai/docs/)
-* [Tutorials](https://www.onnxruntime.ai/docs/tutorials/)
-  * [Inferencing](https://www.onnxruntime.ai/docs/tutorials/inferencing/)
-  * [Training](https://www.onnxruntime.ai/docs/tutorials/training/)
-* [How To](https://www.onnxruntime.ai/docs/how-to)
-  * [Install](https://www.onnxruntime.ai/docs/how-to/install.html)
-  * [Build](https://www.onnxruntime.ai/docs/how-to/build/)
-  * [Tune performance](https://www.onnxruntime.ai/docs/how-to/tune-performance.html)
-  * [Quantize models](https://www.onnxruntime.ai/docs/how-to/quantization.html)
-  * [Deploy on mobile](https://www.onnxruntime.ai/docs/how-to/deploy-on-mobile.html)
-  * [Use custom ops](https://www.onnxruntime.ai/docs/how-to/add-custom-op.html)
-  * [Add a new EP](https://www.onnxruntime.ai/docs/how-to/add-execution-provider.html)
-* [Reference](https://www.onnxruntime.ai/docs/reference)
-  * [API documentation](https://www.onnxruntime.ai/docs/reference/api/)
-  * [Execution Providers](https://www.onnxruntime.ai/docs/reference/execution-providers/)
-  * [Releases and servicing](https://www.onnxruntime.ai/docs/reference/releases-servicing.html)
-  * [Citing](https://www.onnxruntime.ai/docs/reference/citing.html)
-* [Additional resources](https://www.onnxruntime.ai/docs/resources/)
+**https://onnxruntime.ai/**
+
+**Usage documention and tutorials** can be found on [onnxruntime.ai/docs](https://onnxruntime.ai/docs).
+
+Companion sample repositories: 
+- ORT Inferencing: [microsoft/onnxruntime-inference-examples](https://github.com/microsoft/onnxruntime-inference-examples)
+- ORT Training: [microsoft/onnxruntime-training-examples](https://github.com/microsoft/onnxruntime-training-examples)
+
 
 ## Build Pipeline Status
 |System|CPU|GPU|EPs|

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 
 ## Get Started
 
-**https://onnxruntime.ai/**
+**General Information**: [onnxruntime.ai](https://onnxruntime.ai)
 
-**Usage documention and tutorials** can be found on [onnxruntime.ai/docs](https://onnxruntime.ai/docs).
+**Usage documention and tutorials**: [onnxruntime.ai/docs](https://onnxruntime.ai/docs)
 
-Companion sample repositories: 
-- ORT Inferencing: [microsoft/onnxruntime-inference-examples](https://github.com/microsoft/onnxruntime-inference-examples)
-- ORT Training: [microsoft/onnxruntime-training-examples](https://github.com/microsoft/onnxruntime-training-examples)
+**Companion sample repositories**: 
+- ONNX Runtime Inferencing: [microsoft/onnxruntime-inference-examples](https://github.com/microsoft/onnxruntime-inference-examples)
+- ONNX Runtime Training: [microsoft/onnxruntime-training-examples](https://github.com/microsoft/onnxruntime-training-examples)
 
 
 ## Build Pipeline Status

--- a/samples/readme.md
+++ b/samples/readme.md
@@ -1,0 +1,4 @@
+**Please refer to these repositories for ONNX Runtime samples:**
+
+- ONNX Runtime Inferencing: [microsoft/onnxruntime-inference-examples](https://github.com/microsoft/onnxruntime-inference-examples)
+- ONNX Runtime Training: [microsoft/onnxruntime-training-examples](https://github.com/microsoft/onnxruntime-training-examples)


### PR DESCRIPTION
Changes:
- simplify get started section to directly point to documentation site
- add links to sample repos for inf and training