### PR TITLE
Remove useless reshape node in transformer optimizer

### DIFF
--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -185,6 +185,9 @@ class BertOnnxModel(OnnxModel):
         return
 
     def adjust_reshape_and_expand(self):
+        # Remove reshape nodes that having same shape of input and output based on symbolic shape inference.
+        FusionUtils.remove_useless_reshape_nodes(self)
+
         nodes_to_remove = []
         for node in self.nodes():
             if node.op_type == 'Reshape':


### PR DESCRIPTION
**Description**: 
Some model has useless reshape nodes, where the input and output have same shape. Remove those reshape nodes in graph.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
