### PR TITLE
Fix iOS packaging pipeline failure

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
@@ -53,6 +53,7 @@ jobs:
   - script: |
       python tools/ci_build/github/apple/test_ios_packages.py \
         --fail_if_cocoapods_missing \
+        --framework_info_file "$(Build.BinariesDirectory)/ios_framework/framework_info.json" \
         --c_framework_dir "$(Build.BinariesDirectory)/ios_framework/framework_out"
     displayName: "Test iOS framework"
 
@@ -89,7 +90,7 @@ jobs:
         --output "$(Build.BinariesDirectory)/staging/objc_api_docs" \
         --module-version ${ORT_POD_VERSION}
     displayName: "Generate Objective-C API docs"
-  
+
   - task: AzureCLI@2
     inputs:
       azureSubscription: 'AIInfraBuildOnnxRuntimeOSS'


### PR DESCRIPTION
**Description**: Fix iOS packaging pipeline failure

**Motivation and Context**
- The `Test iOS framework` was not updated in my previous PR #8357, update it here
- Test run result, https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=165083&view=logs&j=3dddc1c0-aa94-54cd-5783-bde40a38081c&t=5af72d05-75bc-5e24-7285-3f8460ebe114