### PR TITLE
Make some common macros safer to use.

### DIFF
--- a/include/onnxruntime/core/common/common.h
+++ b/include/onnxruntime/core/common/common.h
@@ -177,10 +177,13 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 // Check condition.
 // NOTE: The arguments get streamed into a string via ostringstream::operator<<
 // DO NOT use a printf format string, as that will not work as you expect.
-#define ORT_ENFORCE(condition, ...)                                           \
-  if (!(condition))                                                           \
-  throw ::onnxruntime::OnnxRuntimeException(ORT_WHERE_WITH_STACK, #condition, \
-                                            ::onnxruntime::MakeString(__VA_ARGS__))
+#define ORT_ENFORCE(condition, ...)                                                      \
+  do {                                                                                   \
+    if (!(condition)) {                                                                  \
+      throw ::onnxruntime::OnnxRuntimeException(ORT_WHERE_WITH_STACK, #condition,        \
+                                                ::onnxruntime::MakeString(__VA_ARGS__)); \
+    }                                                                                    \
+  } while (false)
 
 #define ORT_THROW_EX(ex, ...) \
   throw ex(__VA_ARGS__)
@@ -193,12 +196,14 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
                                 ::onnxruntime::MakeString(__VA_ARGS__))
 
 // Check condition. if met, return status.
-#define ORT_RETURN_IF(condition, ...)                                                                        \
-  if (condition) {                                                                                           \
-    return ::onnxruntime::common::Status(::onnxruntime::common::ONNXRUNTIME,                                 \
-                                         ::onnxruntime::common::FAIL,                                        \
-                                         ::onnxruntime::MakeString(ORT_WHERE.ToString(), " ", __VA_ARGS__)); \
-  }
+#define ORT_RETURN_IF(condition, ...)                                                                          \
+  do {                                                                                                         \
+    if (condition) {                                                                                           \
+      return ::onnxruntime::common::Status(::onnxruntime::common::ONNXRUNTIME,                                 \
+                                           ::onnxruntime::common::FAIL,                                        \
+                                           ::onnxruntime::MakeString(ORT_WHERE.ToString(), " ", __VA_ARGS__)); \
+    }                                                                                                          \
+  } while (false)
 
 // Check condition. if not met, return status.
 #define ORT_RETURN_IF_NOT(condition, ...) \

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -987,7 +987,7 @@ Status SessionState::LoadFromOrtFormat(const fbs::SessionState& fbs_session_stat
       if (kernel_create_info_map_.count(node.Index()) == 0) {
         auto hash_info = compiled_kernel_hashes.find(node.OpType());
         ORT_RETURN_IF(hash_info == compiled_kernel_hashes.cend(),
-                      "Unable to find compiled kernel hash for node '", node.Name(), "'.")
+                      "Unable to find compiled kernel hash for node '", node.Name(), "'.");
 
         ORT_RETURN_IF_ERROR(add_kernel_by_hash(node, hash_info->second));
       }

--- a/onnxruntime/core/providers/coreml/model/model.mm
+++ b/onnxruntime/core/providers/coreml/model/model.mm
@@ -270,7 +270,7 @@
           }
         }
         ORT_RETURN_IF_NOT(model_output_type == MLMultiArrayDataTypeInt32,
-                          "Coreml model_output_type is not MLMultiArrayDataTypeInt32 for the case")
+                          "Coreml model_output_type is not MLMultiArrayDataTypeInt32 for the case");
         break;
       default:
         return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -921,7 +921,7 @@ Status TrainingSession::BuildOptimizer(
     OptimizerOutputKeyMap<std::string>& opt_graph_outputs) {
   ORT_RETURN_IF_NOT(
       opt_configs.size() == weights_to_train_.size(),
-      "Number of optimizer configurations does not match number of weights to train.")
+      "Number of optimizer configurations does not match number of weights to train.");
 
   for (const auto& weight_name : weights_to_train_) {
     ORT_RETURN_IF_NOT(
@@ -1289,7 +1289,7 @@ Status TrainingSession::SetStateTensors(const NameMLValMap& state_tensors, bool 
     if (is_valid_state_tensor && is_tensor_present) {
       ORT_RETURN_IF_NOT(
           initializer_it->second.IsTensor() && state.second.IsTensor(),
-          "Non-tensor type as initializer is not expected.")
+          "Non-tensor type as initializer is not expected.");
 
       auto* initializer_tensor = initializer_it->second.GetMutable<Tensor>();
       auto& ckpt_tensor = state.second.Get<Tensor>();


### PR DESCRIPTION
**Description**
Some macros were defined like this: `#define MACRO(condition, ...) if (condition) do_something`.
This can be problematic if expanded in a context like this:
```
if (condition_1)
  MACRO(condition_2);
else
  // logic for !condition_1
```
The else will associate with MACRO's if and we get unexpected results, e.g., when `condition_1 && !condition_2`.

We can avoid this by wrapping MACRO in `do { ... } while(false)`.

**Motivation and Context**
Clean up code.