### PR TITLE
Fix GCC build error in quantization tests

### DIFF
--- a/onnxruntime/core/quantization/quantization.h
+++ b/onnxruntime/core/quantization/quantization.h
@@ -28,9 +28,7 @@ namespace quantization {
 template <typename T>
 struct Params {
  public:
-  Params() {
-    Params(/*scale=*/0.0f, /*zero_point=*/0);
-  }
+  Params() : Params(/*scale=*/0.0f, /*zero_point=*/0) {}
 
   Params(float scale, T zero_point) : scale(scale), zero_point(zero_point) {
     ORT_STATIC_ASSERT_QUANTIZATION_TYPES(T)


### PR DESCRIPTION
**Description**: Fixes the following build error in the quantization tests:
```
onnxruntime/onnxruntime/test/contrib_ops/qembed_layer_norm_op_test.cc: In function ‘void onnxruntime::test::{anonymous}::RunTest(const onnxruntime::test::embedlayernorm::OpData&, float)’:
onnxruntime/onnxruntime/test/contrib_ops/qembed_layer_norm_op_test.cc:140:29: error: ‘segment_embedding_params.onnxruntime::quantization::Params<unsigned char>::zero_point’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  140 |     tester.AddInput<uint8_t>("segment_embedding_zero_point",
      |     ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  141 |                              /*dims=*/{},
      |                              ~~~~~~~~~~~~
  142 |                              {segment_embedding_params.zero_point},
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  143 |                              /*is_initializer=*/true);
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~
onnxruntime/onnxruntime/test/contrib_ops/qembed_layer_norm_op_test.cc:114:27: error: ‘segment_embedding_params.onnxruntime::quantization::Params<unsigned char>::scale’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  114 |     tester.AddInput<float>("segment_embedding_scale",
      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
  115 |                            /*dims=*/{},
      |                            ~~~~~~~~~~~~
  116 |                            {segment_embedding_params.scale},
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  117 |                            /*is_initializer=*/true);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```
