### PR TITLE
Update CODEOWNERS with mobile team ownership of expected kernel def hash data files.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,3 +11,6 @@ onnxruntime/test/python/onnxruntime_test_ort_trainer_with_mixed_precision.py @th
 onnxruntime/test/python/onnxruntime_test_training_unit_tests.py @thiagocrepaldi @tlh20 @BowenBao @liqunfu @baijumeswani @SherlockNoMad
 onnxruntime/test/python/onnxruntime_test_training_unittest_utils.py @thiagocrepaldi @tlh20 @BowenBao @liqunfu @baijumeswani @SherlockNoMad
 samples/python/training/** @thiagocrepaldi @tlh20 @BowenBao @liqunfu @baijumeswani @SherlockNoMad
+
+# Mobile
+/onnxruntime/test/testdata/kernel_def_hashes/ @skottmckay @gwang-msft @YUNQIUGUO @edgchen1


### PR DESCRIPTION
**Description**
Adding to CODEOWNERS so that the mobile team is included on PRs which update the expected kernel def hash data.

**Motivation and Context**
We want to maintain stability of the kernel def hash values for eventual backwards compatibility guarantees (not guaranteed yet).
