### PR TITLE
Update torch litghning and re-enable test

### DIFF
--- a/orttraining/orttraining/test/python/orttraining_ortmodule_tests.py
+++ b/orttraining/orttraining/test/python/orttraining_ortmodule_tests.py
@@ -105,8 +105,7 @@ def main():
     run_ortmodule_hf_bert_for_sequence_classification_from_pretrained(cwd, log, no_cuda=True,
         data_dir=args.bert_data, transformers_cache=args.transformers_cache)
 
-    # TODO: flaky test. Temporary disabling for further investigation
-    # run_ortmodule_torch_lightning(cwd, log, args.mnist)
+    run_ortmodule_torch_lightning(cwd, log, args.mnist)
 
     # TODO: enable this once the PyTorch used for testing meets the requirements running
     # auto grad testing.

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
@@ -5,6 +5,6 @@ transformers==v4.4.2
 tensorboard>=2.2.0,<2.5.0
 h5py
 wget
-pytorch-lightning==1.3.3
+pytorch-lightning==1.3.8
 deepspeed==0.3.15
 fairscale


### PR DESCRIPTION
Pytorch lightning test was disabled due to previous instability

This PR updates the module to 1.3.8 and re-enable the test