### PR TITLE
Add new option to disable cpu sync for tensors 

### DIFF
--- a/winml/lib/Api/impl/TensorBase.h
+++ b/winml/lib/Api/impl/TensorBase.h
@@ -352,7 +352,10 @@ struct TensorBase : TBase {
 
     bool is_cpu;
     bool isCpuOutput = SUCCEEDED(value->IsCpu(&is_cpu)) && is_cpu;
-    bool disableCopyGpuInputsToCpu = !isCpuOutput && context.properties != nullptr && context.properties.HasKey(L"SuppressCpuCopyback");
+    bool hasProperties = context.properties != nullptr;
+    bool disableCopyGpuInputsToCpu = !isCpuOutput &&
+                                     hasProperties &&
+                                     context.properties.HasKey(L"DisableTensorCpuSync");
 
     // make sure we always have a CPU resource
     if (!disableCopyGpuInputsToCpu && CpuTensor() == nullptr) {

--- a/winml/lib/Api/impl/TensorBase.h
+++ b/winml/lib/Api/impl/TensorBase.h
@@ -350,7 +350,7 @@ struct TensorBase : TBase {
     // get the shape
     RETURN_IF_FAILED_MSG(value->GetTensorShape(shape_), "Failed to get the tensor shape from resource!");
 
-    bool disableCopyGpuInputsToCpu = context.properties.HasKey(L"SuppressCpuCopyback");
+    bool disableCopyGpuInputsToCpu = context.properties != nullptr && context.properties.HasKey(L"SuppressCpuCopyback");
 
     // make sure we always have a CPU resource
     if (!disableCopyGpuInputsToCpu && CpuTensor() == nullptr) {

--- a/winml/lib/Api/impl/TensorBase.h
+++ b/winml/lib/Api/impl/TensorBase.h
@@ -350,15 +350,16 @@ struct TensorBase : TBase {
     // get the shape
     RETURN_IF_FAILED_MSG(value->GetTensorShape(shape_), "Failed to get the tensor shape from resource!");
 
-    bool disableCopyGpuInputsToCpu = context.properties != nullptr && context.properties.HasKey(L"SuppressCpuCopyback");
+    bool is_cpu;
+    bool isCpuOutput = SUCCEEDED(value->IsCpu(&is_cpu)) && is_cpu;
+    bool disableCopyGpuInputsToCpu = !isCpuOutput && context.properties != nullptr && context.properties.HasKey(L"SuppressCpuCopyback");
 
     // make sure we always have a CPU resource
     if (!disableCopyGpuInputsToCpu && CpuTensor() == nullptr) {
       CpuTensor() = std::make_shared<_winml::Tensor<T>>(shape_);
     }
 
-    bool is_cpu;
-    if (SUCCEEDED(value->IsCpu(&is_cpu)) && is_cpu) {
+    if (isCpuOutput) {
       // Get the data pointer and size
       auto buffer = CpuTensor()->buffer(false);
 


### PR DESCRIPTION
Add new option to disable cpu sync for tensors

Issue: When chaining tensors, there is no need to require output tensors to be copied back from gpu resources to the cpu. It only slows down and introduces another unnecessary copy. While is is normally desired so that the tensor object has cpu accessors that are able to quickly return results, for chaining this is not desired.

Fix: Add a bind option to disable tensors cpu sync.