### PR TITLE
Improves documentation, show InferenceSession contructor attributes

### DIFF
--- a/docs/python/inference/api_summary.rst
+++ b/docs/python/inference/api_summary.rst
@@ -158,19 +158,50 @@ Load and run a model
 The main class *InferenceSession* wraps these functionalities
 in a single place.
 
-.. autoclass:: onnxruntime.ModelMetadata
-    :members:
+Main class
+----------
 
 .. autoclass:: onnxruntime.InferenceSession
     :members:
+    :inherited-members:
 
-.. autoclass:: onnxruntime.NodeArg
-    :members:
+Options
+-------
 
 .. autoclass:: onnxruntime.RunOptions
     :members:
 
 .. autoclass:: onnxruntime.SessionOptions
+    :members:
+
+Data
+----
+
+.. autoclass:: onnxruntime.OrtValue
+    :members:
+
+.. autoclass:: onnxruntime.SparseTensor
+    :members:
+
+Devices
+-------
+
+.. autoclass:: onnxruntime.IOBinding
+    :members:
+
+.. autoclass:: onnxruntime.OrtDevice
+    :members:
+
+Internal classes
+----------------
+
+These classes cannot be instantiated by users but they are returned
+by methods or functions of this libary.
+
+.. autoclass:: onnxruntime.ModelMetadata
+    :members:
+
+.. autoclass:: onnxruntime.NodeArg
     :members:
 
 Backend

--- a/docs/python/inference/conf.py
+++ b/docs/python/inference/conf.py
@@ -46,6 +46,7 @@ master_doc = 'index'
 language = "en"
 exclude_patterns = []
 pygments_style = 'default'
+autoclass_content = 'both'
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/python/training/conf.py
+++ b/docs/python/training/conf.py
@@ -20,6 +20,7 @@ extensions = ['sphinx.ext.autodoc',
 ]
 templates_path = ['_templates']
 exclude_patterns = []
+autoclass_content = 'both'
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/onnxruntime/core/mlas/lib/convolve.cpp
+++ b/onnxruntime/core/mlas/lib/convolve.cpp
@@ -146,7 +146,6 @@ Return Value:
 
                 size_t InputX = InitialInputX;
                 const float* InputRow = &Input[InputY * InputWidth];
-                const float* tempInputRow;
 
                 do {
 
@@ -173,28 +172,6 @@ Return Value:
                         }
 
                         CountX -= CountCopyX;
-                        tempInputRow = &InputRow[InputX];
-
-                        while (CountCopyX >= 16) {
-                          MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(tempInputRow));
-                          ColumnBuffer += 4;
-                          tempInputRow += 4;
-
-                          MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(tempInputRow));
-                          ColumnBuffer += 4;
-                          tempInputRow += 4;
-
-                          MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(tempInputRow));
-                          ColumnBuffer += 4;
-                          tempInputRow += 4;
-
-                          MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(tempInputRow));
-                          ColumnBuffer += 4;
-                          tempInputRow += 4;
-
-                          InputX += 16;
-                          CountCopyX -= 16;
-                        }
 
                         while (CountCopyX >= 4) {
                             MlasStoreFloat32x4(ColumnBuffer, MlasLoadFloat32x4(&InputRow[InputX]));
@@ -232,22 +209,6 @@ Return Value:
                 //
 
                 MLAS_FLOAT32X4 ZeroFloat32x4 = MlasZeroFloat32x4();
-
-                while (CountX >= 16) {
-                  MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
-                  ColumnBuffer += 4;
-
-                  MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
-                  ColumnBuffer += 4;
-
-                  MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
-                  ColumnBuffer += 4;
-
-                  MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
-                  ColumnBuffer += 4;
-
-                  CountX -= 16;
-                }
 
                 while (CountX >= 4) {
                     MlasStoreFloat32x4(ColumnBuffer, ZeroFloat32x4);
@@ -566,8 +527,6 @@ Return Value:
     const size_t FilterCount = Parameters->FilterCount;
     const size_t OutputSize = Parameters->OutputSize;
     const size_t K = Parameters->K;
-    const size_t K2 = Parameters->K * 2;
-    const size_t SegmentCountN2 = SegmentCountN * 2;
 
     //
     // Compute the strides to step through slices of the local segment.
@@ -580,14 +539,14 @@ Return Value:
 
     if (SegmentCountN >= K) {
 
-        while (StrideK >= K2) {
+        while (StrideK / 2 >= K) {
             StrideN *= 2;
             StrideK /= 2;
         }
 
     } else {
 
-        while (StrideN > 16 && StrideN >= SegmentCountN2) {
+        while (StrideN > 16 && StrideN / 2 >= SegmentCountN) {
             StrideK *= 2;
             StrideN /= 2;
         }
@@ -601,12 +560,11 @@ Return Value:
 
     for (size_t n = 0; n < SegmentCountN; n += CountN) {
 
-        // CountN = SegmentCountN - n;
+        CountN = SegmentCountN - n;
 
-        CountN = SegmentCountN - n > StrideN ? StrideN : SegmentCountN - n;
-        // if (CountN > StrideN) {
-        //    CountN = StrideN;
-        //}
+        if (CountN > StrideN) {
+            CountN = StrideN;
+        }
 
         //
         // Step through each slice of the input tensor along the K dimension.
@@ -618,12 +576,11 @@ Return Value:
 
         for (size_t k = 0; k < K; k += CountK) {
 
-            // CountK = K - k;
+            CountK = K - k;
 
-            CountK = K - k > StrideK ? StrideK : K - k;
-            //if (CountK > StrideK) {
-            //    CountK = StrideK;
-            //}
+            if (CountK > StrideK) {
+                CountK = StrideK;
+            }
 
             if (Parameters->Dimensions == 2) {
                 MlasConvIm2Col(Parameters, Input, ColumnBuffer, k, CountK,

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -205,7 +205,7 @@ class Session:
         :param input_feed: dictionary ``{ input_name: input_ort_value }``
          See ``OrtValue`` class how to create OrtValue from numpy array or SparseTensor
         :param run_options: See :class:`onnxruntime.RunOptions`.
-        :return an array of OrtValues
+        :return: an array of OrtValues
         ::
 
             sess.run([output_name], {input_name: x})
@@ -669,7 +669,7 @@ class SparseTensor:
          have a 1-D shape when it contains a linear index of non-zero values and its length must be equal to
          that of the values. It can also be of 2-D shape, in which has it contains pairs of coordinates for
          each of the nnz values and its length must be exactly twice of the values length.
-        :param ort_device - describes the backing memory owned by the supplied nummpy arrays. Only CPU memory is
+        :param ort_device: - describes the backing memory owned by the supplied nummpy arrays. Only CPU memory is
          suppored for non-numeric data types.
 
          For primitive types, the method will map values and coo_indices arrays into native memory and will use
@@ -693,7 +693,7 @@ class SparseTensor:
          Its length must be equal to that of the values.
         :param outer_indices:  contiguous 1-D numpy array(int64) that contains CSR outer indices for the tensor.
          Its length must be equal to the number of rows + 1.
-        :param ort_device - describes the backing memory owned by the supplied nummpy arrays. Only CPU memory is
+        :param ort_device: - describes the backing memory owned by the supplied nummpy arrays. Only CPU memory is
          suppored for non-numeric data types.
 
          For primitive types, the method will map values and indices arrays into native memory and will use them as
@@ -747,7 +747,7 @@ class SparseTensor:
     def to_cuda(self, ort_device):
         '''
         Returns a copy of this instance on the specified cuda device
-        :param ort_device with name 'cuda' and valid gpu device id
+        :param ort_device: with name 'cuda' and valid gpu device id
         The method will throw if:
         - this instance contains strings
         - this instance is already on GPU. Cross GPU copy is not supported


### PR DESCRIPTION
**Description**:

Addresses issue #8465.

* show constructor attributes
* show all public methods for InferenceSession
* exposes more classes (SparseTensor, OrtValue)

Small screenshot of the changes:

![image](https://user-images.githubusercontent.com/22452781/126969586-bf17696b-6265-42ad-91fa-8f0a8d8ce910.png)


**Motivation and Context**
Documentation quality dropped after added a base class to InferenceSession.
