### PR TITLE
Limit work items to available threads, upgrade checks from assert to ORT_ENFORCE

### DIFF
--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -1192,6 +1192,7 @@ void RunInParallelSection(ThreadPoolParallelSection &ps,
                           std::function<void(unsigned idx)> fn,
                           unsigned n,
                           std::ptrdiff_t block_size) override {
+  ORT_ENFORCE(n <= num_threads_+1, "More work items than threads");
   profiler_.LogStartAndCoreAndBlock(block_size);
   PerThread* pt = GetPerThread();
   assert(pt->leading_par_section && "RunInParallel, but not in parallel section");
@@ -1249,6 +1250,7 @@ void RunInParallelSection(ThreadPoolParallelSection &ps,
 // For all other threads:
 //  1. run fn(...);
 void RunInParallel(std::function<void(unsigned idx)> fn, unsigned n, std::ptrdiff_t block_size) override {
+  ORT_ENFORCE(n <= num_threads_+1, "More work items than threads");
   profiler_.LogStartAndCoreAndBlock(block_size);
   PerThread* pt = GetPerThread();
   ThreadPoolParallelSection ps;

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -408,7 +408,8 @@ void ThreadPool::ParallelForFixedBlockSizeScheduling(const std::ptrdiff_t total,
   // hence we need at most one for each thread, even if the numberof blocks of iterations is larger.
   auto d_of_p = DegreeOfParallelism(this);
   auto num_blocks = total / block_size;
-  int num_work_items = static_cast<int>(std::min(static_cast<std::ptrdiff_t>(d_of_p), num_blocks));
+  auto num_threads_inc_main = NumThreads() + 1;
+  int num_work_items = static_cast<int>(std::min(static_cast<std::ptrdiff_t>(num_threads_inc_main), num_blocks));
   assert(num_work_items > 0);
 
   LoopCounter lc(total, d_of_p, block_size);


### PR DESCRIPTION
For CPUs with mixed core types we divide work into a larger number of smaller pieces (4N pieces of work with N threads).  This over-partitioning helps avoid load imbalance by letting the more capable cores pick multiple pieces of work, while less capable cores pick up single pieces.  This PR fixes a case we missed where we should use the actual number of threads (N) rather than the increased number (4N).  Prior to the PR, we could see assert-fails on out-of-bounds access to a std::vector used when distributing work.