### PR TITLE
Fixing mlas unittest failures in POWER

### DIFF
--- a/onnxruntime/core/mlas/lib/logistic.cpp
+++ b/onnxruntime/core/mlas/lib/logistic.cpp
@@ -121,6 +121,11 @@ Return Value:
 
         float Value = *Input++;
 
+	// This odd "if test" exists to ensure an input value of NaN carries through
+        // without modification because "std::min" and "std::max" return unreliable results
+        // when NaNs are involved, and it's clear from the test's reference outputs that
+        // they want a NaN on output whenever the input is a NaN.
+        if (Value == Value)
         Value = std::min(MlasLogisticConstants.UpperRange, std::max(MlasLogisticConstants.LowerRange, Value));
 
         float ValueSquared = Value * Value;

--- a/onnxruntime/core/mlas/lib/logistic.cpp
+++ b/onnxruntime/core/mlas/lib/logistic.cpp
@@ -121,12 +121,13 @@ Return Value:
 
         float Value = *Input++;
 
-        // This odd "if test" exists to ensure an input value of NaN carries through
+        // This odd two-step process exists to ensure an input value of NaN carries through
         // without modification because "std::min" and "std::max" return unreliable results
         // when NaNs are involved, and it's clear from the test's reference outputs that
         // they want a NaN on output whenever the input is a NaN.
-        if (Value == Value)
-        Value = std::min(MlasLogisticConstants.UpperRange, std::max(MlasLogisticConstants.LowerRange, Value));
+        float v_tmp;
+        v_tmp = (Value < MlasLogisticConstants.LowerRange) ? MlasLogisticConstants.LowerRange : Value;
+        Value = (v_tmp > MlasLogisticConstants.UpperRange) ? MlasLogisticConstants.UpperRange : v_tmp;
 
         float ValueSquared = Value * Value;
 

--- a/onnxruntime/core/mlas/lib/logistic.cpp
+++ b/onnxruntime/core/mlas/lib/logistic.cpp
@@ -121,7 +121,7 @@ Return Value:
 
         float Value = *Input++;
 
-	// This odd "if test" exists to ensure an input value of NaN carries through
+        // This odd "if test" exists to ensure an input value of NaN carries through
         // without modification because "std::min" and "std::max" return unreliable results
         // when NaNs are involved, and it's clear from the test's reference outputs that
         // they want a NaN on output whenever the input is a NaN.

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1627,7 +1627,7 @@ MlasMaximumFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
 #elif defined(MLAS_SSE2_INTRINSICS)
     return _mm_max_ps(Vector1, Vector2);
 #elif defined(MLAS_VSX_INTRINSICS)
-    return vec_sel(Vector2, Vector1, vec_cmpgt(Vector1, Vector2));
+    return vec_sel(vec_sel(vec_sel(Vector2, Vector1, vec_cmpgt(Vector1, Vector2)), Vector1, vec_cmpne(Vector1, Vector1)), Vector2, vec_cmpne(Vector2, Vector2));
 #elif defined(MLAS_WASM_SIMD_INTRINSICS)
     return wasm_f32x4_max(Vector1, Vector2);
 #else
@@ -1644,7 +1644,7 @@ MlasMinimumFloat32x4(MLAS_FLOAT32X4 Vector1, MLAS_FLOAT32X4 Vector2)
 #elif defined(MLAS_SSE2_INTRINSICS)
     return _mm_min_ps(Vector1, Vector2);
 #elif defined(MLAS_VSX_INTRINSICS)
-    return vec_sel(Vector2, Vector1, vec_cmpgt(Vector2, Vector1));
+    return vec_sel(vec_sel(vec_sel(Vector2, Vector1, vec_cmpgt(Vector2, Vector1)), Vector1, vec_cmpne(Vector1, Vector1)), Vector2, vec_cmpne(Vector2, Vector2));
 #elif defined(MLAS_WASM_SIMD_INTRINSICS)
     return wasm_f32x4_min(Vector1, Vector2);
 #else

--- a/onnxruntime/core/mlas/lib/tanh.cpp
+++ b/onnxruntime/core/mlas/lib/tanh.cpp
@@ -119,7 +119,7 @@ Return Value:
 
         float Value = *Input++;
 
-	// This odd "if test" exists to ensure an input value of NaN carries through 
+        // This odd "if test" exists to ensure an input value of NaN carries through 
 	// without modification because "std::min" and "std::max" return unreliable results 
 	// when NaNs are involved, and it's clear from the test's reference outputs that 
 	// they want a NaN on output whenever the input is a NaN.

--- a/onnxruntime/core/mlas/lib/tanh.cpp
+++ b/onnxruntime/core/mlas/lib/tanh.cpp
@@ -119,6 +119,11 @@ Return Value:
 
         float Value = *Input++;
 
+	// This odd "if test" exists to ensure an input value of NaN carries through 
+	// without modification because "std::min" and "std::max" return unreliable results 
+	// when NaNs are involved, and it's clear from the test's reference outputs that 
+	// they want a NaN on output whenever the input is a NaN.
+	if (Value == Value)
         Value = std::min(MlasTanhConstants.UpperRange, std::max(MlasTanhConstants.LowerRange, Value));
 
         float ValueSquared = Value * Value;

--- a/onnxruntime/core/mlas/lib/tanh.cpp
+++ b/onnxruntime/core/mlas/lib/tanh.cpp
@@ -120,10 +120,10 @@ Return Value:
         float Value = *Input++;
 
         // This odd "if test" exists to ensure an input value of NaN carries through 
-	// without modification because "std::min" and "std::max" return unreliable results 
-	// when NaNs are involved, and it's clear from the test's reference outputs that 
-	// they want a NaN on output whenever the input is a NaN.
-	if (Value == Value)
+        // without modification because "std::min" and "std::max" return unreliable results 
+        // when NaNs are involved, and it's clear from the test's reference outputs that 
+        // they want a NaN on output whenever the input is a NaN.
+        if (Value == Value)
         Value = std::min(MlasTanhConstants.UpperRange, std::max(MlasTanhConstants.LowerRange, Value));
 
         float ValueSquared = Value * Value;

--- a/onnxruntime/core/mlas/lib/tanh.cpp
+++ b/onnxruntime/core/mlas/lib/tanh.cpp
@@ -119,12 +119,13 @@ Return Value:
 
         float Value = *Input++;
 
-        // This odd "if test" exists to ensure an input value of NaN carries through 
+        // This odd two-step process exists to ensure an input value of NaN carries through 
         // without modification because "std::min" and "std::max" return unreliable results 
         // when NaNs are involved, and it's clear from the test's reference outputs that 
         // they want a NaN on output whenever the input is a NaN.
-        if (Value == Value)
-        Value = std::min(MlasTanhConstants.UpperRange, std::max(MlasTanhConstants.LowerRange, Value));
+        float v_tmp;
+        v_tmp = (Value < MlasTanhConstants.LowerRange) ? MlasTanhConstants.LowerRange : Value;
+        Value = (v_tmp > MlasTanhConstants.UpperRange) ? MlasTanhConstants.UpperRange : v_tmp;
 
         float ValueSquared = Value * Value;
 

--- a/onnxruntime/test/mlas/unittest/test_activation.cpp
+++ b/onnxruntime/test/mlas/unittest/test_activation.cpp
@@ -83,7 +83,8 @@ class MlasActivationTest : public MlasTestBase {
 
       for (unsigned i = 0; i < _countof(TestData); i++) {
         // Sensitive to comparing positive/negative zero and NaNs.
-        EXPECT_TRUE(Buffer[i].u == TestData[i][kind].u || Buffer[i].f == TestData[i][kind].f)
+        float error = std::min(std::fabs((Buffer[i].f - TestData[i][kind].f) / TestData[i][kind].f), std::fabs(Buffer[i].f - TestData[i][kind].f));
+        EXPECT_TRUE(Buffer[i].u == TestData[i][kind].u || Buffer[i].f == TestData[i][kind].f || error < 0.000001f)
             << ", Scalar Activation Kind:" << (int)kind << ", i=" << i << ", value:"
             << std::setw(8) << std::setfill('0') <<std::hex << Buffer[i].u << ", expecting:"
             << std::setw(8) << std::setfill('0') <<std::hex << TestData[i][kind].u;

--- a/onnxruntime/test/mlas/unittest/test_scaleoutput.cpp
+++ b/onnxruntime/test/mlas/unittest/test_scaleoutput.cpp
@@ -52,7 +52,7 @@ class MlasScaleOutputTest : public MlasTestBase {
     constexpr float epsilon = 1e-6f;
 
     for (size_t n = 0; n < M * N; n++) {
-      float diff = std::fabs(Output[n] - OutputRef[n]);
+      float diff = std::fabs((Output[n] - OutputRef[n]) / OutputRef[n]);
       ASSERT_LE(diff, epsilon)
           << " @[" << n / N << "," << n % N << "], total:[" << M << "," << N << "], got:"
           << Output[n] << ", expecting:" << OutputRef[n];


### PR DESCRIPTION
We noted that "onnx_runtime_mlas_test" was reporting errors on our Power servers.

We discovered some places where error tolerances were too tight.
In one case, the demand was an EXACT MATCH.
In another, the tolerance was 0.000001 on ABSOLUTE ERROR, even though the numbers being compared were > 10^5.

We also discovered problems in how NaNs were being processed, and we have created more robust code for that.

We hope you find these changes acceptable.