### PR TITLE
Bug fix for per layer ORTModule wrap in T5

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -137,6 +137,11 @@ class TrainingManager(GraphExecutionManager):
                 for idx in self._graph_info.module_output_indices_requires_save_for_backward:
                     ctx.save_for_backward(user_outputs[idx])
 
+                # Mark the outputs tensors non-differentiable if requires_grad is False in _graph_info
+                # This will return torch the output tensors with correct requires_grad settings
+                for idx in self._graph_info.output_grad_indices_non_differentiable:
+                    ctx.mark_non_differentiable(user_outputs[idx])
+
                 return user_outputs
 
             @staticmethod


### PR DESCRIPTION
**Description**: when wrapping T5 encoder/decoder by layer, ORTModule throws the error during training:
AssertionError: ORT found the 6-th module output 'output-6' is non-differentiable according to the onnx graph. However, the gradient value is still provided by PyTorch's autograd engine.

**Motivation and Context**
- The issue can be reproduced with 2 layers of encoders/decoders. And it's specific to decoders. Let's say we have two layers of decoders. In forward pass, an output (requires_grad=False) in the first layer becomes the input of second layer. But its requires_grad becomes True, which is inconsistent (thus incorrect) with Torch's behavior. Therefore it's causing the exception above later on in backward pass.

In most cases, this won't happen. But in some cases where the tensor has been manipulated (re-assign, overwritten, etc.) in the first layer, the requires_flag may be assigned to True by default with torch.autograd extension - see Torch's doc for more details - https://pytorch.org/docs/stable/notes/extending.html#extending-torch-autograd .

The solution is to check _graph_info.output_grad_indices_non_differentiable and mark the tensor with correct requires_grad flag by calling mark_non_differentiable() before the outputs returned back to torch.    

 

  

