### PR TITLE
Add ATenOp avg_pool2d and adaptive_avg_pool2d

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -186,9 +186,11 @@ class SymbolicShapeInference:
         }
         self.aten_op_dispatcher_ = {
             'aten::embedding': self._infer_Gather,
-            'aten::max_pool2d_with_indices': self._infer_aten_max_pool2d,
+            'aten::max_pool2d_with_indices': self._infer_aten_pool2d,
             'aten::unfold': self._infer_aten_unfold,
             'aten::argmax': self._infer_aten_argmax,
+            'aten::avg_pool2d': self._infer_aten_pool2d,
+            'aten::_adaptive_avg_pool2d': self._infer_aten_pool2d,
         }
         self.run_ = True
         self.suggested_merge_ = {}
@@ -1000,7 +1002,7 @@ class SymbolicShapeInference:
                 helper.make_tensor_value_info(o, vi.type.tensor_type.elem_type,
                                               get_shape_from_sympy_shape(sympy_shape)))
 
-    def _infer_aten_max_pool2d(self, node):
+    def _infer_aten_pool2d(self, node):
         sympy_shape = self._get_sympy_shape(node, 0)
         assert len(sympy_shape) == 4
         sympy_shape[-2:] = [self._new_symbolic_dim_from_output(node, 0, i) for i in [2, 3]]

--- a/orttraining/orttraining/python/training/ortmodule/_custom_gradient_registry.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_gradient_registry.py
@@ -102,3 +102,19 @@ def unfold_gradient():
         (('ATenOp', 'com.microsoft'), ['GO(0)', 'Shape_X', 'I(1)', 'I(2)', 'I(3)'], [
          'GI(0)'], {'name': {'value': 'aten::unfold_backward', 'dtype': 'string'}}),
     ]
+
+
+@register_gradient('com.microsoft', 'ATenOp', 'aten::avg_pool2d', '')
+def avg_pool2d_gradient():
+    return [
+        (('ATenOp', 'com.microsoft'), ['GO(0)', 'I(0)', 'I(1)', 'I(2)', 'I(3)', 'I(4)', 'I(5)', 'I(6)'], [
+         'GI(0)'], {'name': {'value': 'aten::avg_pool2d_backward', 'dtype': 'string'}}),
+    ]
+
+
+@register_gradient('com.microsoft', 'ATenOp', 'aten::_adaptive_avg_pool2d', '')
+def adaptive_avg_pool2d_gradient():
+    return [
+        (('ATenOp', 'com.microsoft'), ['GO(0)', 'I(0)'], [
+         'GI(0)'], {'name': {'value': 'aten::_adaptive_avg_pool2d_backward', 'dtype': 'string'}}),
+    ]

--- a/orttraining/orttraining/python/training/ortmodule/_custom_op_symbolic_registry.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_op_symbolic_registry.py
@@ -83,3 +83,14 @@ def unfold(g, input, dimension, size, step):
 @register_symbolic('argmax')
 def argmax(g, input, dim, keepdim):
     return g.op("com.microsoft::ATenOp", input, dim, keepdim, name_s='aten::argmax')
+
+
+@register_symbolic('avg_pool2d')
+def avg_pool2d(g, self, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override):
+    return g.op("com.microsoft::ATenOp", self, kernel_size, stride, padding, ceil_mode,
+                count_include_pad, divisor_override, name_s='aten::avg_pool2d')
+
+
+@register_symbolic('adaptive_avg_pool2d')
+def adaptive_avg_pool2d(g, self, output_size):
+    return g.op("com.microsoft::ATenOp", self, output_size, name_s='aten::_adaptive_avg_pool2d')

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -664,19 +664,25 @@ def test_gradient_correctness_cross_entropy_loss(use_fp16):
         _test_helpers.assert_values_are_close(ort_prediction, pt_prediction)
         _test_helpers.assert_gradients_match_and_reset_gradient(ort_model, pt_model, atol=1e-5)
 
-def test_gradient_correctness_maxpool2d():
-    class NeuralNetMaxPool2d(torch.nn.Module):
+@pytest.mark.parametrize("pool_type", ['MaxPool', 'AvgPool', 'AdaptiveAvgPool'])
+def test_gradient_correctness_pool2d(pool_type):
+    class NeuralNetPool2d(torch.nn.Module):
         def __init__(self):
-            super(NeuralNetMaxPool2d, self).__init__()
+            super(NeuralNetPool2d, self).__init__()
             self.conv = torch.nn.Conv2d(3, 64, kernel_size=7, stride=2, padding=3, bias=False)
-            self.maxpool = torch.nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+            if pool_type == 'MaxPool':
+                self.pool = torch.nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+            elif pool_type == 'AvgPool':
+                self.pool = torch.nn.AvgPool2d(kernel_size=3, stride=2, padding=1)
+            else:
+                self.pool = torch.nn.AdaptiveAvgPool2d((5, 7))
 
         def forward(self, input):
-            return self.maxpool(self.conv(input))
+            return self.pool(self.conv(input))
 
     N, C, H, W = 8, 3, 224, 224
     device = 'cuda'
-    pt_model = NeuralNetMaxPool2d().to(device)
+    pt_model = NeuralNetPool2d().to(device)
     ort_model = ORTModule(copy.deepcopy(pt_model))
 
     def run_step(model, input):


### PR DESCRIPTION
Add ATenOp avg_pool2d and adaptive_avg_pool2d to support torchvision models including Alexnet, VGG11_bn, Squeezenet, Densenet and Inception v3.