### PR TITLE
improve the qlinear avg pool perf

### DIFF
--- a/onnxruntime/contrib_ops/cpu/qlinear_global_average_pool.cc
+++ b/onnxruntime/contrib_ops/cpu/qlinear_global_average_pool.cc
@@ -14,7 +14,7 @@ using onnxruntime::concurrency::ThreadPool;
 namespace onnxruntime {
 namespace contrib {
 
-Status ComputeAveragePool(
+Status ComputeQLinearGlobalAvgPool(
     const uint8_t* x,
     float x_scale,
     uint8_t x_zero_point,
@@ -112,7 +112,7 @@ Status QLinearGlobalAveragePool::Compute(OpKernelContext* context) const {
   auto dtype = X.GetElementType();
   switch (dtype) {
     case ONNX_NAMESPACE::TensorProto_DataType_UINT8:
-      return ComputeAveragePool(X.Data<uint8_t>(), x_scale, *(tensor_x_zero_point->Data<uint8_t>()),
+      return ComputeQLinearGlobalAvgPool(X.Data<uint8_t>(), x_scale, *(tensor_x_zero_point->Data<uint8_t>()),
                                 Y.MutableData<uint8_t>(), y_scale, *(tensor_y_zero_point->Data<uint8_t>()),
                                 N, C, image_size, channels_last_, tp);
     default:

--- a/onnxruntime/contrib_ops/cpu/qlinear_global_average_pool.h
+++ b/onnxruntime/contrib_ops/cpu/qlinear_global_average_pool.h
@@ -21,5 +21,18 @@ class QLinearGlobalAveragePool final : public OpKernel {
   bool channels_last_;
 };
 
+Status ComputeQLinearGlobalAvgPool(
+    const uint8_t* x,
+    float x_scale,
+    uint8_t x_zero_point,
+    uint8_t* y,
+    float y_scale,
+    uint8_t y_zero_point,
+    int64_t N,
+    int64_t C,
+    int64_t image_size,
+    bool channels_last,
+    concurrency::ThreadPool* tp);
+
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/qlinear_lookup_table.cc
+++ b/onnxruntime/contrib_ops/cpu/qlinear_lookup_table.cc
@@ -9,17 +9,18 @@
 namespace onnxruntime {
 namespace contrib {
 
-void QLinearLookupTableTransform(const uint8_t* x, const uint8_t* table, uint8_t* y, size_t n) {
+template <typename TOutput>
+void QLinearLookupTableTransform(const uint8_t* x, const TOutput* table, TOutput* y, size_t n) {
   for (; n >= 4; n -= 4) {
     const size_t x_value0 = x[0];
     const size_t x_value1 = x[1];
     const size_t x_value2 = x[2];
     const size_t x_value3 = x[3];
     x += 4;
-    const uint8_t table_value0 = table[x_value0];
-    const uint8_t table_value1 = table[x_value1];
-    const uint8_t table_value2 = table[x_value2];
-    const uint8_t table_value3 = table[x_value3];
+    const TOutput table_value0 = table[x_value0];
+    const TOutput table_value1 = table[x_value1];
+    const TOutput table_value2 = table[x_value2];
+    const TOutput table_value3 = table[x_value3];
 
     y[0] = table_value0;
     y[1] = table_value1;
@@ -29,10 +30,13 @@ void QLinearLookupTableTransform(const uint8_t* x, const uint8_t* table, uint8_t
   }
   for (; n != 0; --n) {
     const size_t x_value0 = *x++;
-    const uint8_t table_value0 = table[x_value0];
+    const TOutput table_value0 = table[x_value0];
     *y++ = table_value0;
   }
 }
+
+template void QLinearLookupTableTransform(const uint8_t* x, const uint8_t* table, uint8_t* y, size_t n);
+template void QLinearLookupTableTransform(const uint8_t* x, const float* table, float* y, size_t n);
 
 template <typename T>
 void QlinearBuildLookupTable(uint8_t* table,

--- a/onnxruntime/contrib_ops/cpu/qlinear_lookup_table.h
+++ b/onnxruntime/contrib_ops/cpu/qlinear_lookup_table.h
@@ -34,7 +34,8 @@ void QlinearBuildLookupTable(uint8_t* table,
                              const Tensor* tensor_y_zero_point,
                              const LookupTableScalarTransformer& value_transformer);
 
-void QLinearLookupTableTransform(const uint8_t* x, const uint8_t* table, uint8_t* y, size_t n);
+template <typename TOutput>
+void QLinearLookupTableTransform(const uint8_t* x, const TOutput* table, TOutput* y, size_t n);
 
 
 }  // namespace contrib

--- a/onnxruntime/test/contrib_ops/qlinear_pool_test.cc
+++ b/onnxruntime/test/contrib_ops/qlinear_pool_test.cc
@@ -420,5 +420,47 @@ TEST(QLinearPoolTest, AveragePool3D_IncludePadPixel_nhwc) {
       1);                  // count_include_pad
 }
 
+
+TEST(QLinearPoolTest, AveragePool2D_BigImage) {
+  RunQLinearAveragePoolNchwU8(
+      {1, 1, 32, 64},  // x shape
+      {1, 1, 32, 64},  // expected y shape
+      {3, 3},          // kernel shape
+      {1, 1},          // strides
+      {1, 1, 1, 1},    // pads
+      1);              // count_include_pad
+}
+
+TEST(QLinearPoolTest, AveragePool2D_BigImage_nhwc) {
+  RunQLinearAveragePoolNhwcU8(
+      {1, 1, 32, 64},  // x shape
+      {1, 1, 32, 64},  // expected y shape
+      {3, 3},          // kernel shape
+      {1, 1},          // strides
+      {1, 1, 1, 1},    // pads
+      1);              // count_include_pad
+}
+
+TEST(QLinearPoolTest, AveragePool2D_Global) {
+  RunQLinearAveragePoolNchwU8(
+      {1, 2, 32, 16},  // x shape
+      {1, 2, 1, 1},    // expected y shape
+      {32, 16},        // kernel shape
+      {1, 1},          // strides
+      {0, 0, 0, 0},    // pads
+      1);              // count_include_pad
+}
+
+TEST(QLinearPoolTest, AveragePool2D_Global_nhwc) {
+  RunQLinearAveragePoolNhwcU8(
+      {1, 2, 32, 16},  // x shape
+      {1, 2, 1, 1},    // expected y shape
+      {32, 16},        // kernel shape
+      {1, 1},          // strides
+      {0, 0, 0, 0},    // pads
+      1);              // count_include_pad
+}
+
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
    *) use context buffer allocator, remove init cost of vector
    *) using lookup table to dequantize large input
    *) fall back to global average pool if it is
    *) Update test case for above two case.

**Description**: Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
