### PR TITLE
Update iOS packaging script to default build static framework, disable bitcode

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -330,8 +330,6 @@ def parse_arguments():
         help="Specify the minimum version of the target platform "
         "(e.g. macOS or iOS)"
         "This is only supported on MacOS")
-    parser.add_argument("--apple_disable_bitcode", action='store_true',
-                        help="Disable bitcode for iOS, bitcode is by default enabled for iOS.")
 
     # WebAssembly build
     parser.add_argument("--build_wasm", action='store_true', help="Build for WebAssembly")
@@ -909,7 +907,6 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
                 "-DCMAKE_OSX_DEPLOYMENT_TARGET=" + args.apple_deploy_target,
                 # we do not need protoc binary for ios cross build
                 "-Dprotobuf_BUILD_PROTOC_BINARIES=OFF",
-                "-Donnxruntime_ENABLE_BITCODE=" + ("OFF" if args.apple_disable_bitcode else "ON"),
                 "-DCMAKE_TOOLCHAIN_FILE=" + (
                     args.ios_toolchain_file if args.ios_toolchain_file
                     else "../cmake/onnxruntime_ios.toolchain.cmake")

--- a/tools/ci_build/github/apple/build_ios_framework.py
+++ b/tools/ci_build/github/apple/build_ios_framework.py
@@ -72,7 +72,9 @@ def _build_package(args):
 
         # get the compiled lib path
         framework_dir = os.path.join(
-            build_dir_current_arch, build_config, build_config + "-" + sysroot, 'onnxruntime.framework')
+            build_dir_current_arch, build_config, build_config + "-" + sysroot,
+            '' if args.build_dynamic_framework else 'static_framework',
+            'onnxruntime.framework')
         ort_libs.append(os.path.join(framework_dir, 'onnxruntime'))
 
         # We only need to copy Info.plist, framework_info.json, and headers once since they are the same
@@ -124,6 +126,9 @@ def parse_args():
 
     parser.add_argument('build_settings_file', type=pathlib.Path,
                         help='Provide the file contains settings for building iOS framework')
+
+    parser.add_argument("--build_dynamic_framework", action='store_true',
+                        help="Build Dynamic Framework (default is build static framework).")
 
     args = parser.parse_args()
 

--- a/tools/ci_build/github/apple/build_ios_framework.py
+++ b/tools/ci_build/github/apple/build_ios_framework.py
@@ -73,8 +73,8 @@ def _build_package(args):
         # get the compiled lib path
         framework_dir = os.path.join(
             build_dir_current_arch, build_config, build_config + "-" + sysroot,
-            '' if args.build_dynamic_framework else 'static_framework',
-            'onnxruntime.framework')
+            'onnxruntime.framework' if args.build_dynamic_framework
+            else os.path.join('static_framework', 'onnxruntime.framework'))
         ort_libs.append(os.path.join(framework_dir, 'onnxruntime'))
 
         # We only need to copy Info.plist, framework_info.json, and headers once since they are the same

--- a/tools/ci_build/github/apple/c/onnxruntime-mobile-c.podspec.template
+++ b/tools/ci_build/github/apple/c/onnxruntime-mobile-c.podspec.template
@@ -8,6 +8,7 @@ Pod::Spec.new do |spec|
     spec.summary                = "ONNX Runtime Mobile C/C++ Pod"
     spec.platform               = :ios, "@IOS_DEPLOYMENT_TARGET@"
     spec.vendored_frameworks    = "onnxruntime.framework"
+    spec.static_framework       = true
     spec.weak_framework         = [ @WEAK_FRAMEWORK@ ]
     spec.source_files           = "onnxruntime.framework/Headers/*.h"
     spec.preserve_paths         = [ @LICENSE_FILE@ ]

--- a/tools/ci_build/github/apple/objectivec/onnxruntime-mobile-objc.podspec.template
+++ b/tools/ci_build/github/apple/objectivec/onnxruntime-mobile-objc.podspec.template
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '@IOS_DEPLOYMENT_TARGET@'
   s.preserve_paths = [ @LICENSE_FILE@ ]
   s.default_subspec = "Core"
+  s.static_framework = true
 
   s.subspec "Core" do |core|
     core.dependency "onnxruntime-mobile-c", "#{s.version}"


### PR DESCRIPTION
**Description**: Update iOS packaging script to default build static framework, disable bitcode

**Motivation and Context**
- Last part needed for a patch release,
- Build static framework instead of dynamic framework
- Disable bitcode in build, see #8190
