### PR TITLE
[Symbolic Shape Infer] Bump up required onnx ver

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -9,7 +9,7 @@ from onnx import helper, numpy_helper, shape_inference
 import sympy
 
 from packaging import version
-assert version.parse(onnx.__version__) >= version.parse("1.5.0")
+assert version.parse(onnx.__version__) >= version.parse("1.8.0")
 
 
 def get_attribute(node, attr_name, default_value=None):

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1576,9 +1576,6 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
 
 
 def nuphar_run_python_tests(build_dir, configs):
-    """nuphar temporary function for running python tests separately
-    as it requires ONNX 1.5.0
-    """
     for config in configs:
         if config == 'Debug':
             continue
@@ -2138,7 +2135,6 @@ def main():
     if args.test:
         run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs)
 
-        # run nuphar python tests last, as it installs ONNX 1.5.0
         if args.enable_pybind and not args.skip_onnx_tests and args.use_nuphar:
             nuphar_run_python_tests(build_dir, configs)
 


### PR DESCRIPTION
And remove some stale comments in build.py

There was an error in symbolic shape infer with onnx 1.7.0 when running HF GPT-2.