### PR TITLE
Add HardSigmoid to mobile packages. Used by PyTorch MobileNet v3

### DIFF
--- a/tools/ci_build/github/android/mobile_package.required_operators.config
+++ b/tools/ci_build/github/android/mobile_package.required_operators.config
@@ -14,8 +14,8 @@ ai.onnx;12;Abs,Add,And,ArgMax,ArgMin,AveragePool,Cast,Ceil,Clip,Concat,ConstantO
 ai.onnx;13;Abs,Add,And,ArgMax,ArgMin,AveragePool,Cast,Ceil,Clip,Concat,ConstantOfShape,Conv,ConvTranspose,Cos,CumSum,DepthToSpace,DequantizeLinear,Div,DynamicQuantizeLinear,Elu,Equal,Exp,Expand,Flatten,Floor,Gather,GatherND,Gemm,Greater,GreaterOrEqual,Identity,If,LRN,LeakyRelu,Less,LessOrEqual,Log,LogSoftmax,Loop,MatMul,Max,MaxPool,Mean,Min,Mul,Neg,NonMaxSuppression,NonZero,Not,Or,PRelu,Pad,Pow,QuantizeLinear,Range,Reciprocal,ReduceMax,ReduceMean,ReduceMin,ReduceProd,ReduceSum,Relu,Reshape,Resize,ReverseSequence,Round,ScatterND,Shape,Sigmoid,Sin,Size,Slice,Softmax,SpaceToDepth,Split,Sqrt,Squeeze,Sub,Sum,Tanh,ThresholdedRelu,Tile,TopK,Transpose,Unique,Unsqueeze,Where
 
 # other ops found in test models 
-ai.onnx;12;Erf,GlobalAveragePool,InstanceNormalization,MatMulInteger,QLinearConv,QLinearMatMul
-ai.onnx;13;Erf,GlobalAveragePool,InstanceNormalization,MatMulInteger,QLinearConv,QLinearMatMul
+ai.onnx;12;Erf,GlobalAveragePool,InstanceNormalization,HardSigmoid,MatMulInteger,QLinearConv,QLinearMatMul
+ai.onnx;13;Erf,GlobalAveragePool,InstanceNormalization,HardSigmoid,MatMulInteger,QLinearConv,QLinearMatMul
 
 # Control flow ops
 #  - If and Loop are covered by the tflite converter list
@@ -27,6 +27,7 @@ ai.onnx;13;Scan
 # Note: LayerNormalization is an internal op even though it is (incorrectly) registered in the ONNX domain.
 ai.onnx;1;LayerNormalization
 com.microsoft;1;DynamicQuantizeMatMul,FusedConv,FusedGemm,FusedMatMul,Gelu,MatMulIntegerToFloat,NhwcMaxPool,QLinearAdd,QLinearAveragePool,QLinearConv,QLinearGlobalAveragePool,QLinearMul,QLinearSigmoid
+
 # NHWC transformer also uses this, so assuming it's valuable enough to include 
 com.microsoft;1;QLinearLeakyRelu
 

--- a/tools/ci_build/github/android/mobile_package.required_operators.readme.txt
+++ b/tools/ci_build/github/android/mobile_package.required_operators.readme.txt
@@ -68,9 +68,11 @@ Models from MLPerf Mobile
   - ssd_mobilenet_v2_300-qdq.onnx
 
 Other
-  Mobilenet v2 from pytorch
+  Mobilenet v2 and v3 from pytorch
+  - https://pytorch.org/vision/stable/models.html
   - pytorch.mobilenet_v2_float.onnx
   - pytorch.mobilenet_v2_uint8.onnx
+  - pytorch.mobilenet_v3_small.onnx
   Other assorted pytorch models
   - Huggingface mobilebert-uncased (https://huggingface.co/transformers/serialization.html, https://huggingface.co/google/mobilebert-uncased)
   - SuperResolution (https://pytorch.org/tutorials/advanced/super_resolution_with_onnxruntime.html)


### PR DESCRIPTION
**Description**: 
Add HardSigmoid to mobile packages. Used by PyTorch MobileNet v3

**Motivation and Context**
Support new model with pre-built mobile packages. 