### PR TITLE
Use CUDA_HOME and CUDNN_HOME from the environment if they are not spe…

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -782,8 +782,8 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
         add_cmake_define_without_override(cmake_extra_defines, "onnxruntime_USE_CUDA", "ON")
         add_cmake_define_without_override(cmake_extra_defines, "onnxruntime_CUDA_VERSION", args.cuda_version)
         # TODO: this variable is not really needed
-        add_cmake_define_without_override(cmake_extra_defines, "onnxruntime_CUDA_HOME", args.cuda_home)
-        add_cmake_define_without_override(cmake_extra_defines, "onnxruntime_CUDNN_HOME", args.cudnn_home)
+        add_cmake_define_without_override(cmake_extra_defines, "onnxruntime_CUDA_HOME", cuda_home)
+        add_cmake_define_without_override(cmake_extra_defines, "onnxruntime_CUDNN_HOME", cudnn_home)
 
     if is_windows():
         if args.enable_msvc_static_runtime:


### PR DESCRIPTION
…cified on the command line.

**Description**: Describe your changes.
Due to the recent change, the build fails CUDA_HOME and CUDNN_HOME are not specified on the command-line
**Motivation and Context**
- Why is this change required? What problem does it solve?
The users/dev should be able to build onnxruntime without specifying the CUDA_HOME and CUDNN_HOME on the command line, using the environment variables.
- If it fixes an open issue, please link to the issue here.
