### PR TITLE
Fix bug in CPU force fallback logic 

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -654,6 +654,14 @@ class Graph {
   */
   const ONNX_NAMESPACE::TensorProto* GetConstantInitializer(const std::string& name, bool check_outer_scope) const;
 
+  /** returns the initializer's TensorProto if 'name' is an initializer (both constant and overridable). 
+  If the initializer is not found, a nullptr is returned.
+  @param check_outer_scope If true and the graph is a subgraph,
+         check ancestor graph/s for 'name' if not found in 'graph'.
+  @remarks check_outer_scope of true is not supported in a minimal build
+  */
+  const ONNX_NAMESPACE::TensorProto* GetInitializer(const std::string& name, bool check_outer_scope) const;
+
   /** Gets the Graph inputs excluding initializers.
   These are the required inputs to the Graph as the initializers can be optionally overridden via graph inputs.
   @remarks Contains no nullptr values. */

--- a/onnxruntime/core/framework/fallback_cpu_capability.cc
+++ b/onnxruntime/core/framework/fallback_cpu_capability.cc
@@ -17,9 +17,15 @@ namespace {
 const int64_t kSmallInitializerThreshold = 100;
 
 bool IsSmallInitializer(const onnxruntime::GraphViewer& graph, const NodeArg* arg) {
-  const ONNX_NAMESPACE::TensorProto* initializer_tensor;
-  if (!graph.GetInitializedTensor(arg->Name(), initializer_tensor))
+  // 'true' in the function call is to continue searching for the initializer
+  // in the outer scopes of the current (sub-)graph if applicable
+  const ONNX_NAMESPACE::TensorProto* initializer_tensor =
+      graph.GetGraph().GetConstantInitializer(arg->Name(), true);
+
+  if (initializer_tensor == nullptr) {
     return false;
+  }
+
   int64_t size = 1;
   for (auto& dim : initializer_tensor->dims()) {
     size *= dim;

--- a/onnxruntime/core/framework/fallback_cpu_capability.cc
+++ b/onnxruntime/core/framework/fallback_cpu_capability.cc
@@ -17,8 +17,8 @@ namespace {
 const int64_t kSmallInitializerThreshold = 100;
 
 bool IsSmallInitializer(const onnxruntime::GraphViewer& graph, const NodeArg* arg) {
-  // 'true' in the function call is to continue searching for the initializer
-  // in the outer scopes of the current (sub-)graph if applicable
+  // 'true' in the function call is to let the searching for the initializer
+  // continue in the outer scopes of the current (sub-)graph if applicable
   const ONNX_NAMESPACE::TensorProto* initializer_tensor =
       graph.GetGraph().GetConstantInitializer(arg->Name(), true);
 

--- a/onnxruntime/core/framework/fallback_cpu_capability.cc
+++ b/onnxruntime/core/framework/fallback_cpu_capability.cc
@@ -16,17 +16,18 @@ namespace onnxruntime {
 namespace {
 const int64_t kSmallInitializerThreshold = 100;
 
-bool IsSmallInitializer(const onnxruntime::GraphViewer& graph, const NodeArg* arg) {
+static bool IsSmallInitializer(const onnxruntime::GraphViewer& graph, const NodeArg* arg) {
   // 'true' in the function call is to let the searching for the initializer
   // continue in the outer scopes of the current (sub-)graph if applicable
   const ONNX_NAMESPACE::TensorProto* initializer_tensor =
-      graph.GetGraph().GetConstantInitializer(arg->Name(), true);
+      graph.GetGraph().GetInitializer(arg->Name(), true);
 
-  // Not a "constant" initializer or not an initializer at all
+  // Not an initializer at all
   if (initializer_tensor == nullptr) {
     return false;
   }
 
+  // Check if "small" enough
   int64_t size = 1;
   for (auto& dim : initializer_tensor->dims()) {
     size *= dim;

--- a/onnxruntime/core/framework/fallback_cpu_capability.cc
+++ b/onnxruntime/core/framework/fallback_cpu_capability.cc
@@ -22,6 +22,7 @@ bool IsSmallInitializer(const onnxruntime::GraphViewer& graph, const NodeArg* ar
   const ONNX_NAMESPACE::TensorProto* initializer_tensor =
       graph.GetGraph().GetConstantInitializer(arg->Name(), true);
 
+  // Not a "constant" initializer or not an initializer at all
   if (initializer_tensor == nullptr) {
     return false;
   }

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2784,7 +2784,7 @@ const ONNX_NAMESPACE::TensorProto* Graph::GetInitializer(const std::string& init
   } else if (check_outer_scope && IsSubgraph()) {
     // make sure there's not a local value with the same name. if there is it shadows any initializer in outer scope.
     if (IsOuterScopeValue(initializer_name)) {
-      initializer = parent_graph_->GetConstantInitializer(initializer_name, check_outer_scope);
+      initializer = parent_graph_->GetInitializer(initializer_name, check_outer_scope);
     }
   }
 

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2776,6 +2776,21 @@ const ONNX_NAMESPACE::TensorProto* Graph::GetConstantInitializer(const std::stri
   return initializer;
 }
 
+const ONNX_NAMESPACE::TensorProto* Graph::GetInitializer(const std::string& initializer_name,
+                                                         bool check_outer_scope) const {
+  const ONNX_NAMESPACE::TensorProto* initializer = nullptr;
+  if (GetInitializedTensor(initializer_name, initializer)) {
+    return initializer;
+  } else if (check_outer_scope && IsSubgraph()) {
+    // make sure there's not a local value with the same name. if there is it shadows any initializer in outer scope.
+    if (IsOuterScopeValue(initializer_name)) {
+      initializer = parent_graph_->GetConstantInitializer(initializer_name, check_outer_scope);
+    }
+  }
+
+  return initializer;
+}
+
 #if !defined(ORT_MINIMAL_BUILD)
 void Graph::AddValueInfo(const NodeArg* new_value_info) {
   NodeArg* node_arg = GetNodeArg(new_value_info->Name());


### PR DESCRIPTION
**Description**: While deciding if a node is a good candidate for forcing its execution on CPU, one of the criteria is that the node consumes all CPU inputs or "small initializers". While checking to see if an input to the node is an initializer, the search was limited just to the current scope (i.e.) if there was a good candidate for forcing onto CPU in a subgraph that was consuming an initializer from an outer scope, we would ignore such candidates just because we weren't looking in the outer scopes. This change fixes that. 

**Motivation and Context**
Found while tuning CUDA EP perf for a 1P model 
