### PR TITLE
Optimize sequence type usage on CUDA [1/n]

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/sequence_op.cc
+++ b/onnxruntime/core/providers/cuda/tensor/sequence_op.cc
@@ -12,6 +12,7 @@ ONNX_OPERATOR_KERNEL_EX(
     11,
     kCudaExecutionProvider,
     (*KernelDefBuilder::Create())
+        .InputMemoryType(OrtMemTypeCPUInput, 1)
         .TypeConstraint("S", DataTypeImpl::AllFixedSizeSequenceTensorTypes())
         .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
         .TypeConstraint("I", std::vector<MLDataType>{
@@ -44,6 +45,7 @@ ONNX_OPERATOR_KERNEL_EX(
     11,
     kCudaExecutionProvider,
     (*KernelDefBuilder::Create())
+        .OutputMemoryType(OrtMemTypeCPUInput, 0)
         .TypeConstraint("S", DataTypeImpl::AllFixedSizeSequenceTensorTypes())
         .TypeConstraint("I", DataTypeImpl::GetTensorType<int64_t>()),
     SequenceLength);
@@ -63,6 +65,7 @@ ONNX_OPERATOR_KERNEL_EX(
     11,
     kCudaExecutionProvider,
     (*KernelDefBuilder::Create())
+        .InputMemoryType(OrtMemTypeCPUInput, 1)
         .TypeConstraint("S", DataTypeImpl::AllFixedSizeSequenceTensorTypes())
         .TypeConstraint("I", std::vector<MLDataType>{
                                  DataTypeImpl::GetTensorType<int32_t>(),
@@ -75,13 +78,12 @@ ONNX_OPERATOR_KERNEL_EX(
     11,
     kCudaExecutionProvider,
     (*KernelDefBuilder::Create())
+        .InputMemoryType(OrtMemTypeCPUInput, 2)
         .TypeConstraint("S", DataTypeImpl::AllFixedSizeSequenceTensorTypes())
         .TypeConstraint("I", std::vector<MLDataType>{
                                  DataTypeImpl::GetTensorType<int32_t>(),
                                  DataTypeImpl::GetTensorType<int64_t>()}),
     SequenceInsert);
 
-} // namespace cuda
-} // namespace onnxruntime
-
-
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/tensor/sequence_op.h
+++ b/onnxruntime/core/providers/cuda/tensor/sequence_op.h
@@ -211,9 +211,6 @@ class SequenceInsert final : public CudaKernel {
     int64_t idx = S_size;
     const Tensor* I = context->Input<Tensor>(2);
     if (I != nullptr) {
-      ORT_ENFORCE(I->IsDataType<int32_t>() || I->IsDataType<int64_t>(),
-                  "Indices need to be of types int32 or int64");
-
       if (I->IsDataType<int32_t>()) {
         idx = static_cast<int64_t>(I->Data<int32_t>()[0]);
       } else {

--- a/onnxruntime/core/providers/cuda/tensor/sequence_op.h
+++ b/onnxruntime/core/providers/cuda/tensor/sequence_op.h
@@ -19,12 +19,15 @@ class SequenceAt final : public CudaKernel {
     const Tensor* I = context->Input<Tensor>(1);
     ORT_ENFORCE(I != nullptr, "SequenceAt GPU: Got nullptr input for index tensor.");
 
+    ORT_ENFORCE(I->IsDataType<int32_t>() || I->IsDataType<int64_t>(),
+                "Indices need to be of types int32 or int64");
+
     int64_t idx = -1;
 
     if (I->IsDataType<int32_t>()) {
       idx = I->Data<int32_t>()[0];
-    } else if (I->IsDataType<int64_t>()) {
-      idx = static_cast<int64_t>(I->Data<int64_t>()[0]);
+    } else {
+      idx = I->Data<int64_t>()[0];
     }
 
     int64_t sequence_size = static_cast<int64_t>(X->Size());
@@ -173,11 +176,15 @@ class SequenceErase final : public CudaKernel {
     int64_t idx = X_size - 1;
     const Tensor* I = context->Input<Tensor>(1);
     if (I != nullptr) {
+      ORT_ENFORCE(I->IsDataType<int32_t>() || I->IsDataType<int64_t>(),
+                  "Indices need to be of types int32 or int64");
+
       if (I->IsDataType<int32_t>()) {
         idx = I->Data<int32_t>()[0];
-      } else if (I->IsDataType<int64_t>()) {
-        idx = static_cast<int64_t>(I->Data<int64_t>()[0]);
+      } else {
+        idx = I->Data<int64_t>()[0];
       }
+
       if (idx < 0) {
         idx = X_size + idx;
       }
@@ -220,11 +227,17 @@ class SequenceInsert final : public CudaKernel {
     int64_t idx = S_size;
     const Tensor* I = context->Input<Tensor>(2);
     if (I != nullptr) {
+      ORT_ENFORCE(I->IsDataType<int32_t>() || I->IsDataType<int64_t>(),
+                  "Indices need to be of types int32 or int64");
+
+      int64_t idx = -1;
+
       if (I->IsDataType<int32_t>()) {
         idx = I->Data<int32_t>()[0];
-      } else if (I->IsDataType<int64_t>()) {
-        idx = static_cast<int64_t>(I->Data<int64_t>()[0]);
+      } else {
+        idx = I->Data<int64_t>()[0];
       }
+
       if (idx < 0) {
         idx = S_size + idx;
       }

--- a/onnxruntime/core/providers/cuda/tensor/sequence_op.h
+++ b/onnxruntime/core/providers/cuda/tensor/sequence_op.h
@@ -229,7 +229,6 @@ class SequenceInsert final : public CudaKernel {
       ORT_ENFORCE(I->IsDataType<int32_t>() || I->IsDataType<int64_t>(),
                   "Indices need to be of types int32 or int64");
 
-      int64_t idx = -1;
       if (I->IsDataType<int32_t>()) {
         idx = static_cast<int64_t>(I->Data<int32_t>()[0]);
       } else {

--- a/onnxruntime/core/providers/cuda/tensor/sequence_op.h
+++ b/onnxruntime/core/providers/cuda/tensor/sequence_op.h
@@ -15,12 +15,7 @@ class SequenceAt final : public CudaKernel {
   SequenceAt(const OpKernelInfo& info) : CudaKernel(info) {}
   Status ComputeInternal(OpKernelContext* context) const override {
     const TensorSeq* X = context->Input<TensorSeq>(0);
-    ORT_ENFORCE(X != nullptr, "SequenceAt GPU: Got nullptr for sequence input.");
     const Tensor* I = context->Input<Tensor>(1);
-    ORT_ENFORCE(I != nullptr, "SequenceAt GPU: Got nullptr input for index tensor.");
-
-    ORT_ENFORCE(I->IsDataType<int32_t>() || I->IsDataType<int64_t>(),
-                "Indices need to be of types int32 or int64");
 
     int64_t idx = -1;
     if (I->IsDataType<int32_t>()) {
@@ -58,7 +53,6 @@ class SequenceConstruct final : public CudaKernel {
   SequenceConstruct(const OpKernelInfo& info) : CudaKernel(info) {}
   Status ComputeInternal(OpKernelContext* context) const override {
     TensorSeq* Y = context->Output<TensorSeq>(0);
-    ORT_ENFORCE(Y != nullptr, "SequenceConstruct GPU: Got nullptr for output sequence.");
 
     AllocatorPtr alloc;
     ORT_ENFORCE(context->GetTempSpaceAllocator(&alloc).IsOK(),
@@ -92,7 +86,6 @@ class SequenceEmpty final : public CudaKernel {
   }
   Status ComputeInternal(OpKernelContext* context) const override {
     TensorSeq* Y = context->Output<TensorSeq>(0);
-    ORT_ENFORCE(Y != nullptr, "SequenceEmpty GPU: Failed to allocate output tensor sequence.");
 #ifdef SHARED_PROVIDER
     Y->SetType(DataTypeImpl::GetTypeFromOnnxType(static_cast<int>(dtype_)));
 #else
@@ -110,9 +103,7 @@ class SequenceLength final : public CudaKernel {
   SequenceLength(const OpKernelInfo& info) : CudaKernel(info) {}
   Status ComputeInternal(OpKernelContext* context) const override {
     const TensorSeq* X = context->Input<TensorSeq>(0);
-    ORT_ENFORCE(X != nullptr, "SequenceLength GPU: Input tensor sequence is nullptr.");
     Tensor* Y = context->Output(0, {});
-    ORT_ENFORCE(Y != nullptr, "SequenceLength GPU: Failed to allocate output tensor sequence.");
     Y->MutableData<int64_t>()[0] = static_cast<int64_t>(X->Size());
     return Status::OK();
   }
@@ -124,7 +115,6 @@ class ConcatFromSequence final : public CudaKernel, public ConcatBase {
 
   Status ComputeInternal(OpKernelContext* context) const override {
     const TensorSeq* X = context->Input<TensorSeq>(0);
-    ORT_ENFORCE(X != nullptr, "ConcatFromSequence GPU: Input tensor sequence is nullptr.");
     int64_t input_count = static_cast<int64_t>(X->Size());
     std::vector<const Tensor*> input_tensors;
     for (int64_t i = 0; i < input_count; ++i) {
@@ -170,14 +160,10 @@ class SequenceErase final : public CudaKernel {
 
   Status ComputeInternal(OpKernelContext* context) const override {
     const TensorSeq* X = context->Input<TensorSeq>(0);
-    ORT_ENFORCE(X != nullptr, "SequenceErase GPU: Got nullptr for sequence input.");
     int64_t X_size = static_cast<int64_t>(X->Size());
     int64_t idx = X_size - 1;
     const Tensor* I = context->Input<Tensor>(1);
     if (I != nullptr) {
-      ORT_ENFORCE(I->IsDataType<int32_t>() || I->IsDataType<int64_t>(),
-                  "Indices need to be of types int32 or int64");
-
       if (I->IsDataType<int32_t>()) {
         idx = static_cast<int64_t>(I->Data<int32_t>()[0]);
       } else {
@@ -221,7 +207,6 @@ class SequenceInsert final : public CudaKernel {
 
   Status ComputeInternal(OpKernelContext* context) const override {
     const TensorSeq* S = context->Input<TensorSeq>(0);
-    ORT_ENFORCE(S != nullptr, "SequenceInsert GPU: Got nullptr for sequence input.");
     int64_t S_size = static_cast<int64_t>(S->Size());
     int64_t idx = S_size;
     const Tensor* I = context->Input<Tensor>(2);

--- a/onnxruntime/core/providers/cuda/tensor/sequence_op.h
+++ b/onnxruntime/core/providers/cuda/tensor/sequence_op.h
@@ -23,7 +23,6 @@ class SequenceAt final : public CudaKernel {
                 "Indices need to be of types int32 or int64");
 
     int64_t idx = -1;
-
     if (I->IsDataType<int32_t>()) {
       idx = static_cast<int64_t>(I->Data<int32_t>()[0]);
     } else {
@@ -231,7 +230,6 @@ class SequenceInsert final : public CudaKernel {
                   "Indices need to be of types int32 or int64");
 
       int64_t idx = -1;
-
       if (I->IsDataType<int32_t>()) {
         idx = static_cast<int64_t>(I->Data<int32_t>()[0]);
       } else {

--- a/onnxruntime/core/providers/cuda/tensor/sequence_op.h
+++ b/onnxruntime/core/providers/cuda/tensor/sequence_op.h
@@ -25,7 +25,7 @@ class SequenceAt final : public CudaKernel {
     int64_t idx = -1;
 
     if (I->IsDataType<int32_t>()) {
-      idx = I->Data<int32_t>()[0];
+      idx = static_cast<int64_t>(I->Data<int32_t>()[0]);
     } else {
       idx = I->Data<int64_t>()[0];
     }
@@ -180,7 +180,7 @@ class SequenceErase final : public CudaKernel {
                   "Indices need to be of types int32 or int64");
 
       if (I->IsDataType<int32_t>()) {
-        idx = I->Data<int32_t>()[0];
+        idx = static_cast<int64_t>(I->Data<int32_t>()[0]);
       } else {
         idx = I->Data<int64_t>()[0];
       }
@@ -233,7 +233,7 @@ class SequenceInsert final : public CudaKernel {
       int64_t idx = -1;
 
       if (I->IsDataType<int32_t>()) {
-        idx = I->Data<int32_t>()[0];
+        idx = static_cast<int64_t>(I->Data<int32_t>()[0]);
       } else {
         idx = I->Data<int64_t>()[0];
       }


### PR DESCRIPTION
**Description**:

Generally speaking, we tend to keep inputs/outputs of CUDA operators that are "semantically" tied to shape/shape processing on CPU (for example, indices). The advantage is two-fold:

1) While specifying that such inputs/outputs be placed on CPU in the kernel definition, it helps the force fallback logic take such hints to place related neighboring shape nodes feeding/consuming such edges on CPU. This avoids introducing a copy to device.

2) After consuming such inputs (or while producing such outputs), the CUDA kernel internally does not need to do a copy to host to bring such data to the host (write such data to the host). This avoid introducing a copy to host.  

By not doing this, it a "double whammy" - we will see 2 copies - one to take such information "semantically" tied to the host to the device for the CUDA kernel and another copy within the kernel to take it back to the host at kernel processing time. This change avoids such inefficiencies.

**Motivation and Context**
Found while tuning CUDA EP perf for a 1P model
