### PR TITLE
Add netstandard2.0 target to OnnxRuntime.Managed package

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.csproj
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <Platforms>AnyCPU;x86</Platforms>
     <LangVersion>7.2</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
**Description**: Add netstandard2.0 as a target framework for the `Microsoft.ML.OnnxRuntime.Managed` package.

**Motivation and Context**
- Why is this change required? What problem does it solve?

  * Targeting `netstandard2.0` additionally is recommended [by the corresponding docs](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#which-net-standard-version-to-target)
  * Simplify the dependency graph


This seems to be a quite easy change, so I'm not sure if it wasn't made for a reason. I tried searching for related PRs/issues but did not find any.