### PR TITLE
Handle duplicated outputs in eval mode and under torch.no_grad context

### DIFF
--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -248,6 +248,17 @@ class UnusedBeginParameterNet(torch.nn.Module):
         out = out + self.buffer
         return out
 
+class DuplicatedOutputNet(torch.nn.Module):
+    def __init__(self, input_size, num_classes):
+        super(DuplicatedOutputNet, self).__init__()
+
+        self.fc1 = torch.nn.Linear(input_size, num_classes)
+
+    def forward(self, input1):
+        out = self.fc1(input1)
+        out2 = input1+20
+        return tuple([out, {'inner_states': [out2, out]}])
+
 class UnusedMiddleParameterNet(torch.nn.Module):
     def __init__(self, input_size, hidden_size1, hidden_size2, num_classes):
         super(UnusedMiddleParameterNet, self).__init__()
@@ -3131,3 +3142,36 @@ def test_debug_options_log_level_validation_fails_on_type_mismatch():
     with pytest.raises(Exception) as ex_info:
         _ = DebugOptions(log_level=log_level)
     assert f"Expected log_level of type LogLevel, got {type(log_level)}." in str(ex_info.value)
+
+def test_duplicated_output_eval():
+    device = 'cuda'
+    N, D_in, H, D_out = 64, 784, 500, 10
+    pt_model = DuplicatedOutputNet(D_in, D_out).to(device)
+    pt_model.eval()
+    ort_model = ORTModule(copy.deepcopy(pt_model), DebugOptions(save_onnx=True, onnx_prefix='my_dummy_model'))
+    ort_model.eval()
+    x = torch.randn(N, D_in, device=device)
+    y = copy.deepcopy(x)
+
+    pt_out = pt_model(x)
+    ort_out = ort_model(y)
+
+    _test_helpers.assert_values_are_close(ort_out[0], pt_out[0])
+    _test_helpers.assert_values_are_close(ort_out[1]['inner_states'][0], pt_out[1]['inner_states'][0])
+    _test_helpers.assert_values_are_close(ort_out[1]['inner_states'][1], pt_out[1]['inner_states'][1])
+
+def test_duplicated_output_no_grad():
+    device = 'cuda'
+    N, D_in, H, D_out = 64, 784, 500, 10
+    pt_model = DuplicatedOutputNet(D_in, D_out).to(device)
+    ort_model = ORTModule(copy.deepcopy(pt_model), DebugOptions(save_onnx=True, onnx_prefix='my_dummy_model'))
+    x = torch.randn(N, D_in, device=device)
+    y = copy.deepcopy(x)
+
+    with torch.no_grad():
+        pt_out = pt_model(x)
+        ort_out = ort_model(y)
+
+        _test_helpers.assert_values_are_close(ort_out[0], pt_out[0])
+        _test_helpers.assert_values_are_close(ort_out[1]['inner_states'][0], pt_out[1]['inner_states'][0])
+        _test_helpers.assert_values_are_close(ort_out[1]['inner_states'][1], pt_out[1]['inner_states'][1])


### PR DESCRIPTION
In ```eval``` mode and under ```torch.no_grad()``` context, ```ORTModule``` uses the ```inference_agent``` which uses ```IOBinding``` to execute the graph. ```IOBinding``` only registers a single output for duplicate output names. As a result, when the model has duplicated outputs, the returned values from the ORT backend will only correspond to the ones registered through ```IOBinding```.

This pull request introduces a mapping for output names to the index of the ORT outputs. And so adds support for duplicated outputs in the user model.