### PR TITLE
Disable Training Windows GPU Debug build because it is failing

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-win-gpu-ci-pipeline.yml
@@ -23,7 +23,7 @@ jobs:
     sln_platform: 'x64'
     CudaVersion: '10.2'
     OrtPackageId: 'Microsoft.ML.OnnxRuntime.Gpu'
-    BuildConfigurations: ['Debug', 'RelWithDebInfo']
+    BuildConfigurations: ['RelWithDebInfo']
     # Enable unreleased onnx opsets in CI builds
     # This facilitates testing the implementation for the new opsets
     AllowReleasedOpsetOnly: '0'


### PR DESCRIPTION
**Description**: 

Disable Training Windows GPU Debug build because it is failing. It is due to an internal bug of nvcc.  There is very little we can do.


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
