### PR TITLE
[js/web] support override wasm file path

### DIFF
--- a/js/common/lib/env.ts
+++ b/js/common/lib/env.ts
@@ -3,6 +3,12 @@
 
 import {EnvImpl} from './env-impl';
 export declare namespace Env {
+  export type WasmPrefixOrFilePaths = string|{
+    'ort-wasm.wasm'?: string;
+    'ort-wasm-threaded.wasm'?: string;
+    'ort-wasm-simd.wasm'?: string;
+    'ort-wasm-simd-threaded.wasm'?: string;
+  };
   export interface WebAssemblyFlags {
     /**
      * set or get number of thread(s). If omitted or set to 0, number of thread(s) will be determined by system. If set
@@ -24,6 +30,12 @@ export declare namespace Env {
      * value indicates no timeout is set. (default is 0)
      */
     initTimeout?: number;
+
+    /**
+     * Set a custom URL prefix to the .wasm files or a set of overrides for each .wasm file. The override path should be
+     * an absolute path.
+     */
+    wasmPaths?: WasmPrefixOrFilePaths;
   }
 
   export interface WebGLFlags {

--- a/js/web/test/e2e/browser-test-wasm-path-override-filename.js
+++ b/js/web/test/e2e/browser-test-wasm-path-override-filename.js
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+it('Browser E2E testing - WebAssembly backend (path override filename)', async function () {
+  // disable SIMD and multi-thread
+  ort.env.wasm.numThreads = 1;
+  ort.env.wasm.simd = false;
+
+  // override .wasm file path for 'ort-wasm.wasm'
+  ort.env.wasm.wasmPaths = {
+    'ort-wasm.wasm': new URL('./test-wasm-path-override/renamed.wasm', document.baseURI).href
+  };
+
+  await testFunction(ort, { executionProviders: ['wasm'] });
+});

--- a/js/web/test/e2e/browser-test-wasm-path-override-prefix.js
+++ b/js/web/test/e2e/browser-test-wasm-path-override-prefix.js
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+it('Browser E2E testing - WebAssembly backend (path override prefix)', async function () {
+
+  // disable SIMD and multi-thread
+  ort.env.wasm.numThreads = 1;
+  ort.env.wasm.simd = false;
+
+  // override .wasm file path prefix
+  ort.env.wasm.wasmPaths = new URL('./test-wasm-path-override/', document.baseURI).href;
+
+  await testFunction(ort, { executionProviders: ['wasm'] });
+});

--- a/js/web/test/e2e/karma.conf.js
+++ b/js/web/test/e2e/karma.conf.js
@@ -20,11 +20,13 @@ module.exports = function (config) {
       { pattern: distPrefix + 'ort.js' },
       { pattern: './common.js' },
       { pattern: TEST_MAIN },
-      { pattern: './node_modules/onnxruntime-web/dist/**/*', included: false, nocache: true },
+      { pattern: './node_modules/onnxruntime-web/dist/*.wasm', included: false, nocache: true },
       { pattern: './model.onnx', included: false }
     ],
     proxies: {
       '/model.onnx': '/base/model.onnx',
+      '/test-wasm-path-override/ort-wasm.wasm': '/base/node_modules/onnxruntime-web/dist/ort-wasm.wasm',
+      '/test-wasm-path-override/renamed.wasm': '/base/node_modules/onnxruntime-web/dist/ort-wasm.wasm',
     },
     client: { captureConsole: true, mocha: { expose: ['body'], timeout: 60000 } },
     reporters: ['mocha'],

--- a/js/web/test/e2e/node-test-main-no-threads.js
+++ b/js/web/test/e2e/node-test-main-no-threads.js
@@ -4,7 +4,7 @@
 const ort = require('onnxruntime-web');
 const testFunction = require('./common');
 
-it('Browser E2E testing - WebAssembly backend', async function () {
+it('Node.js E2E testing - WebAssembly backend (no threads)', async function () {
   ort.env.wasm.numThreads = 1;
   await testFunction(ort, { executionProviders: ['wasm'] });
 });

--- a/js/web/test/e2e/node-test-main.js
+++ b/js/web/test/e2e/node-test-main.js
@@ -4,7 +4,7 @@
 const ort = require('onnxruntime-web');
 const testFunction = require('./common');
 
-it('Browser E2E testing - WebAssembly backend', async function () {
+it('Node.js E2E testing - WebAssembly backend', async function () {
   await testFunction(ort, { executionProviders: ['wasm'] });
 
   process.exit();

--- a/js/web/test/e2e/node-test-wasm-path-override-filename.js
+++ b/js/web/test/e2e/node-test-wasm-path-override-filename.js
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const path = require('path');
+const ort = require('onnxruntime-web');
+const testFunction = require('./common');
+
+it('Node.js E2E testing - WebAssembly backend (path override filename)', async function () {
+  // disable SIMD and multi-thread
+  ort.env.wasm.numThreads = 1;
+  ort.env.wasm.simd = false;
+
+  // override .wasm file path for 'ort-wasm.wasm'
+  ort.env.wasm.wasmPaths = {
+    'ort-wasm.wasm': path.join(__dirname, 'test-wasm-path-override/renamed.wasm')
+  };
+
+  await testFunction(ort, { executionProviders: ['wasm'] });
+});

--- a/js/web/test/e2e/node-test-wasm-path-override-prefix.js
+++ b/js/web/test/e2e/node-test-wasm-path-override-prefix.js
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const path = require('path');
+const ort = require('onnxruntime-web');
+const testFunction = require('./common');
+
+it('Node.js E2E testing - WebAssembly backend (path override prefix)', async function () {
+  // disable SIMD and multi-thread
+  ort.env.wasm.numThreads = 1;
+  ort.env.wasm.simd = false;
+
+  // override .wasm file path prefix
+  ort.env.wasm.wasmPaths = path.join(__dirname, 'test-wasm-path-override/');
+
+  await testFunction(ort, { executionProviders: ['wasm'] });
+});

--- a/js/web/test/e2e/run.js
+++ b/js/web/test/e2e/run.js
@@ -46,6 +46,9 @@ async function main() {
   // npm install with "--cache" to install packed packages with an empty cache folder
   await runInShell(`npm install --cache "${NPM_CACHE_FOLDER}" "${ORT_COMMON_PACKED_FILEPATH}" "${ORT_WEB_PACKED_FILEPATH}"`);
 
+  // prepare .wasm files for path override testing
+  prepareWasmPathOverrideFiles();
+
   // test case run in Node.js
   await testAllNodejsCases();
 
@@ -60,17 +63,29 @@ async function main() {
   process.exit(0);
 }
 
+function prepareWasmPathOverrideFiles() {
+  const folder = path.join(TEST_E2E_RUN_FOLDER, 'test-wasm-path-override');
+  const sourceFile = path.join(TEST_E2E_RUN_FOLDER, 'node_modules', 'onnxruntime-web', 'dist', 'ort-wasm.wasm');
+  fs.emptyDirSync(folder);
+  fs.copyFileSync(sourceFile, path.join(folder, 'ort-wasm.wasm'));
+  fs.copyFileSync(sourceFile, path.join(folder, 'renamed.wasm'));
+}
+
 async function testAllNodejsCases() {
   await runInShell('node ./node_modules/mocha/bin/mocha ./node-test-main-no-threads.js');
   await runInShell('node ./node_modules/mocha/bin/mocha ./node-test-main.js');
   await runInShell('node --experimental-wasm-threads --experimental-wasm-bulk-memory ./node_modules/mocha/bin/mocha ./node-test-main-no-threads.js');
   await runInShell('node --experimental-wasm-threads --experimental-wasm-bulk-memory ./node_modules/mocha/bin/mocha ./node-test-main.js');
+  await runInShell('node ./node_modules/mocha/bin/mocha ./node-test-wasm-path-override-filename.js');
+  await runInShell('node ./node_modules/mocha/bin/mocha ./node-test-wasm-path-override-prefix.js');
 }
 
 async function testAllBrowserCases({ hostInKarma }) {
   await runKarma({ hostInKarma, main: './browser-test-webgl.js', browser: 'Chrome_default' });
   await runKarma({ hostInKarma, main: './browser-test-wasm.js', browser: 'Chrome_default' });
   await runKarma({ hostInKarma, main: './browser-test-wasm-no-threads.js', browser: 'Chrome_default' });
+  await runKarma({ hostInKarma, main: './browser-test-wasm-path-override-filename.js', browser: 'Chrome_default' });
+  await runKarma({ hostInKarma, main: './browser-test-wasm-path-override-prefix.js', browser: 'Chrome_default' });
 }
 
 async function runKarma({ hostInKarma, main, browser }) {

--- a/js/web/test/e2e/simple-http-server.js
+++ b/js/web/test/e2e/simple-http-server.js
@@ -8,11 +8,15 @@ var http = require('http');
 var fs = require('fs');
 var path = require('path');
 
+var simpleProxies = {
+  './ort-wasm.wasm': './ort-wasm.wasm'
+};
+
 module.exports = function (dir) {
   http.createServer(function (request, response) {
     console.log('request ', request.url);
 
-    var filePath = '.' + request.url;
+    var filePath = '.' + (simpleProxies[request.url] ?? request.url);
 
     var extname = String(path.extname(filePath)).toLowerCase();
     var mimeTypes = {


### PR DESCRIPTION
**Description**: This change adds a config into `ort.env.wasm.wasmPaths` to enable users to customize .wasm file path at runtime.

The default behavior is always looking up at the file `ort-*.wasm`(4 in total) in "current folder". Sometimes users want to put the .wasm files in different folders to the .js files.

The config `ort.env.wasm.wasmPaths` can be set to either:

- a string. In this case, it indicates the prefix on which the file name (`ort-*.wasm`) appends. Should end with a path splitter.
- an object. In this case, each of the 4 .wasm files can be customized. key is the file name and value is the override file full path.

This feature should not affect existing behavior or break existing usage.

This feature should be used in both browsers and node.js.