### PR TITLE
Documentation: fix link, nav, minor update

### DIFF
--- a/docs/how-to/add-execution-provider.md
+++ b/docs/how-to/add-execution-provider.md
@@ -47,3 +47,16 @@ Example:
   OrtReleaseObject(factory);
   OrtCreateSession(env, model_path, session_option, &session);
 ```
+
+## Test the Execution Provider
+
+To ease the testing of your execution provider, you can add a new case for it to the `onnx_test_runner` command,
+do this by adding it to `onnxruntime/test/onnx/main.cc` file, following the pattern for other existing providers.
+
+Once you have this in place, you can run the `onnx_test_runner`, like this:
+
+```
+$ cd build/PLATFORM/CONFIGURATION
+$ ./onnx_test_runner -e YOUR_BACKEND ./testdata/ort_minimal_e2e_test_data/
+$ ./onnx_test_runner -e YOUR_BACKEND ./testdata/gemm_activation_fusion/
+```

--- a/docs/how-to/build/eps.md
+++ b/docs/how-to/build/eps.md
@@ -178,7 +178,7 @@ These instructions are for JetPack SDK 4.4.
 
 ## oneDNN
 
-See more information on ondDNN (formerly DNNL) [here](../reference/execution-providers/DNNL-ExecutionProvider.md).
+See more information on ondDNN (formerly DNNL) [here](../../reference/execution-providers/DNNL-ExecutionProvider.md).
 
 ### Build Instructions
 {: .no_toc }
@@ -290,7 +290,7 @@ For more information on OpenVINO Execution Provider&#39;s ONNX Layer support, To
 ---
 
 ## NUPHAR
-See more information on the Nuphar Execution Provider [here](../reference/execution-providers/Nuphar-ExecutionProvider.md).
+See more information on the Nuphar Execution Provider [here](../../reference/execution-providers/Nuphar-ExecutionProvider.md).
 
 ### Prerequisites
 {: .no_toc }
@@ -370,7 +370,7 @@ Dockerfile instructions are available [here](https://github.com/microsoft/onnxru
 ---
 
 ## DirectML
-See more information on the DirectML execution provider [here](../reference/execution-providers/DirectML-ExecutionProvider.md).
+See more information on the DirectML execution provider [here](../../reference/execution-providers/DirectML-ExecutionProvider.md).
 ### Windows
 {: .no_toc }
 
@@ -385,7 +385,7 @@ The DirectML execution provider supports building for both x64 and x86 architect
 ---
 
 ## ARM Compute Library
-See more information on the ACL Execution Provider [here](../reference/execution-providers/ACL-ExecutionProvider.md).
+See more information on the ACL Execution Provider [here](../../reference/execution-providers/ACL-ExecutionProvider.md).
 
 ### Prerequisites
 {: .no_toc }
@@ -452,7 +452,7 @@ onnxruntime_test_all
 
 ## ArmNN
 
-See more information on the ArmNN Execution Provider [here](../reference/execution-providers/ArmNN-ExecutionProvider.md).
+See more information on the ArmNN Execution Provider [here](../../reference/execution-providers/ArmNN-ExecutionProvider.md).
 
 ### Prerequisites
 {: .no_toc }
@@ -500,7 +500,7 @@ The ARM Compute Library home directory and build directory must also be availabl
 ---
 
 ## RKNPU
-See more information on the RKNPU Execution Provider [here](../reference/execution-providers/RKNPU-ExecutionProvider.md).
+See more information on the RKNPU Execution Provider [here](../../reference/execution-providers/RKNPU-ExecutionProvider.md).
 
 ### Prerequisites
 {: .no_toc }
@@ -539,9 +539,9 @@ set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
 ---
 
 ## Vitis-AI
-See more information on the Xilinx Vitis-AI execution provider [here](../reference/execution-providers/Vitis-AI-ExecutionProvider.md).
+See more information on the Xilinx Vitis-AI execution provider [here](../../reference/execution-providers/Vitis-AI-ExecutionProvider.md).
 
-For instructions to setup the hardware environment: [Hardware setup](../reference/execution-providers/Vitis-AI-ExecutionProvider.md#Hardware-setup)
+For instructions to setup the hardware environment: [Hardware setup](../../reference/execution-providers/Vitis-AI-ExecutionProvider.md#Hardware-setup)
 
 ### Linux
 {: .no_toc }
@@ -560,7 +560,7 @@ The Vitis-AI execution provider is only supported on Linux.
 
 ## AMD MIGraphX
 
-See more information on the MIGraphX Execution Provider [here](../reference/execution-providers/MIGraphX-ExecutionProvider.md).
+See more information on the MIGraphX Execution Provider [here](../../reference/execution-providers/MIGraphX-ExecutionProvider.md).
 
 ### Prerequisites
 {: .no_toc }

--- a/docs/reference/api/c-api.md
+++ b/docs/reference/api/c-api.md
@@ -2,6 +2,7 @@
 title: C API
 parent: API docs
 grand_parent: Reference
+nav_order: 1
 ---
 
 # ONNX Runtime C API

--- a/docs/reference/api/cpp-api.md
+++ b/docs/reference/api/cpp-api.md
@@ -2,6 +2,7 @@
 title: C++ API
 parent: API docs
 grand_parent: Reference
+nav_order: 2
 ---
 
 # ONNX Runtime C++ API

--- a/docs/reference/api/csharp-api.md
+++ b/docs/reference/api/csharp-api.md
@@ -2,6 +2,7 @@
 title: C# API
 parent: API docs
 grand_parent: Reference
+nav_order: 3
 ---
 
 # ONNX Runtime C# API

--- a/docs/reference/api/java-api.md
+++ b/docs/reference/api/java-api.md
@@ -2,6 +2,7 @@
 title: Java API
 parent: API docs
 grand_parent: Reference
+nav_order: 4
 ---
 
 # ONNX Runtime Java API

--- a/docs/reference/api/js-api.md
+++ b/docs/reference/api/js-api.md
@@ -2,6 +2,7 @@
 title: JavaScript API
 parent: API docs
 grand_parent: Reference
+nav_order: 5
 ---
 
 # ONNX Runtime JavaScript API

--- a/docs/reference/api/objectivec-api.md
+++ b/docs/reference/api/objectivec-api.md
@@ -2,6 +2,7 @@
 title: Objective-C API
 parent: API docs
 grand_parent: Reference
+nav_order: 6
 ---
 
 # ONNX Runtime Objective-C API

--- a/docs/reference/api/other-apis.md
+++ b/docs/reference/api/other-apis.md
@@ -1,7 +1,8 @@
 ---
-title: Other APIs
+title: Other Inference APIs
 parent: API docs
 grand_parent: Reference
+nav_order: 9
 ---
 
 # Other APIs

--- a/docs/reference/api/python-api.md
+++ b/docs/reference/api/python-api.md
@@ -2,6 +2,7 @@
 title: Python API
 parent: API docs
 grand_parent: Reference
+nav_order: 7
 ---
 
 # ONNX Runtime Python API

--- a/docs/reference/api/training-pytorch.md
+++ b/docs/reference/api/training-pytorch.md
@@ -2,6 +2,7 @@
 title: Training API
 parent: API docs
 grand_parent: Reference
+nav_order: 10
 ---
 
 # Training API (PyTorch)

--- a/docs/reference/api/winrt-api.md
+++ b/docs/reference/api/winrt-api.md
@@ -2,6 +2,7 @@
 title: WinRT API
 parent: API docs
 grand_parent: Reference
+nav_order: 8
 ---
 
 # Windows Machine Learning WinRT API


### PR DESCRIPTION
Staged: https://faxu.github.io/onnxruntime/docs/how-to/build/eps.html

Changes:
- fix broken links on Build with EPs page - #8595
- Update nav order for APIs to list "others" and "training" at the end instead of fully alphabetical
- also adds minor update to "how to add ep" doc, originally from https://github.com/microsoft/onnxruntime/pull/6266