### PR TITLE
[WIP] Support custom ops ONNX schema specification using prebuilt onnxruntime

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -842,7 +842,7 @@ include(eigen)
 #onnxruntime_EXTERNAL_LIBRARIES could contain onnx, onnx_proto,libprotobuf, cuda/cudnn,
 # dnnl/mklml, onnxruntime_codegen_tvm, tvm, nnvm_compiler and pthread
 # pthread is always at the last
-set(onnxruntime_EXTERNAL_LIBRARIES -Wl,--no-as-needed onnx onnx_proto ${PROTOBUF_LIB} -Wl,--as-needed re2::re2)
+set(onnxruntime_EXTERNAL_LIBRARIES -Wl,--whole-archive onnx onnx_proto ${PROTOBUF_LIB} -Wl,--no-whole-archive re2::re2)
 
 
 set(onnxruntime_LINK_DIRS )

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -842,7 +842,7 @@ include(eigen)
 #onnxruntime_EXTERNAL_LIBRARIES could contain onnx, onnx_proto,libprotobuf, cuda/cudnn,
 # dnnl/mklml, onnxruntime_codegen_tvm, tvm, nnvm_compiler and pthread
 # pthread is always at the last
-set(onnxruntime_EXTERNAL_LIBRARIES onnx onnx_proto ${PROTOBUF_LIB} re2::re2)
+set(onnxruntime_EXTERNAL_LIBRARIES -Wl,--no-as-needed onnx onnx_proto ${PROTOBUF_LIB} -Wl,--as-needed re2::re2)
 
 
 set(onnxruntime_LINK_DIRS )

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -842,7 +842,7 @@ include(eigen)
 #onnxruntime_EXTERNAL_LIBRARIES could contain onnx, onnx_proto,libprotobuf, cuda/cudnn,
 # dnnl/mklml, onnxruntime_codegen_tvm, tvm, nnvm_compiler and pthread
 # pthread is always at the last
-set(onnxruntime_EXTERNAL_LIBRARIES -Wl,--whole-archive onnx onnx_proto ${PROTOBUF_LIB} -Wl,--no-whole-archive re2::re2)
+set(onnxruntime_EXTERNAL_LIBRARIES -Wl,--no-as-needed onnx onnx_proto ${PROTOBUF_LIB} -Wl,--as-needed re2::re2)
 
 
 set(onnxruntime_LINK_DIRS )

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -842,7 +842,11 @@ include(eigen)
 #onnxruntime_EXTERNAL_LIBRARIES could contain onnx, onnx_proto,libprotobuf, cuda/cudnn,
 # dnnl/mklml, onnxruntime_codegen_tvm, tvm, nnvm_compiler and pthread
 # pthread is always at the last
-set(onnxruntime_EXTERNAL_LIBRARIES -Wl,--no-as-needed onnx onnx_proto ${PROTOBUF_LIB} -Wl,--as-needed re2::re2)
+if (UNIX)
+  set(onnxruntime_EXTERNAL_LIBRARIES -Wl,--no-as-needed onnx onnx_proto ${PROTOBUF_LIB} -Wl,--as-needed re2::re2)
+else()
+  set(onnxruntime_EXTERNAL_LIBRARIES onnx onnx_proto ${PROTOBUF_LIB} re2::re2)
+endif()
 
 
 set(onnxruntime_LINK_DIRS )

--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -226,6 +226,12 @@ else()
   )
 endif()
 
+file(GLOB onnxruntime_capi_headers CMAKE_CONFIGURE_DEPENDS
+  "${REPO_ROOT}/include/onnxruntime/core/session/onnxruntime_c_api.h"
+  "${REPO_ROOT}/include/onnxruntime/core/session/onnxruntime_cxx_api.h"
+  "${REPO_ROOT}/include/onnxruntime/core/session/onnxruntime_cxx_inline.h"
+)
+
 if (onnxruntime_BUILD_UNIT_TESTS)
   file(GLOB onnxruntime_python_test_srcs CONFIGURE_DEPENDS
       "${ONNXRUNTIME_ROOT}/test/python/*.py"
@@ -292,6 +298,7 @@ add_custom_command(
   TARGET onnxruntime_pybind11_state POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/backend
   COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/include
   COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/training
   COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/datasets
   COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/tools
@@ -329,6 +336,9 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E copy
       ${onnxruntime_python_capi_training_srcs}
       $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/training/
+  COMMAND ${CMAKE_COMMAND} -E copy
+      ${onnxruntime_capi_headers}
+      $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/include/
   COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_FILE:onnxruntime_pybind11_state>
       $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -24,50 +24,6 @@
 #include "orttraining/training_ops/cpu/aten_ops/aten_op_executor.h"
 #endif
 
-namespace ONNX_NAMESPACE {
-std::ostream& operator<<(std::ostream& out, const TensorShapeProto& shape_proto) {
-  std::string result;
-  result.reserve(128);
-
-  result.append("{");
-  bool first = true;
-  for (auto& dim : shape_proto.dim()) {
-    if (!first) {
-      result.append(",");
-    }
-
-    if (onnxruntime::utils::HasDimValue(dim))
-      result.append(std::to_string(dim.dim_value()));
-    else if (onnxruntime::utils::HasDimParam(dim))
-      result.append(dim.dim_param());
-
-    first = false;
-  }
-  result.append("}");
-
-  return (out << result);
-}
-
-std::ostream& operator<<(std::ostream& out, const TensorProto& tensor_proto) {
-  std::string result;
-  result.reserve(128);
-
-  result.append("{");
-  bool first = true;
-  for (auto& dim : tensor_proto.dims()) {
-    if (!first) {
-      result.append(",");
-    }
-
-    result.append(std::to_string(dim));
-    first = false;
-  }
-  result.append("}");
-
-  return (out << result);
-}
-}  // namespace ONNX_NAMESPACE
-
 namespace onnxruntime {
 namespace utils {
 void* DefaultAlloc(size_t size) {

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -24,6 +24,50 @@
 #include "orttraining/training_ops/cpu/aten_ops/aten_op_executor.h"
 #endif
 
+namespace ONNX_NAMESPACE {
+std::ostream& operator<<(std::ostream& out, const TensorShapeProto& shape_proto) {
+  std::string result;
+  result.reserve(128);
+
+  result.append("{");
+  bool first = true;
+  for (auto& dim : shape_proto.dim()) {
+    if (!first) {
+      result.append(",");
+    }
+
+    if (onnxruntime::utils::HasDimValue(dim))
+      result.append(std::to_string(dim.dim_value()));
+    else if (onnxruntime::utils::HasDimParam(dim))
+      result.append(dim.dim_param());
+
+    first = false;
+  }
+  result.append("}");
+
+  return (out << result);
+}
+
+std::ostream& operator<<(std::ostream& out, const TensorProto& tensor_proto) {
+  std::string result;
+  result.reserve(128);
+
+  result.append("{");
+  bool first = true;
+  for (auto& dim : tensor_proto.dims()) {
+    if (!first) {
+      result.append(",");
+    }
+
+    result.append(std::to_string(dim));
+    first = false;
+  }
+  result.append("}");
+
+  return (out << result);
+}
+}  // namespace ONNX_NAMESPACE
+
 namespace onnxruntime {
 namespace utils {
 void* DefaultAlloc(size_t size) {

--- a/onnxruntime/python/version_script.lds
+++ b/onnxruntime/python/version_script.lds
@@ -1,7 +1,10 @@
 #_init and _fini should be local
 VERS_1.0 {
   global:
-    PyInit_onnxruntime_pybind11_state;    
+    PyInit_onnxruntime_pybind11_state;
+    extern "C++" {
+       onnx::*;
+    };
 
   # Hide everything else.
   local:

--- a/setup.py
+++ b/setup.py
@@ -249,13 +249,12 @@ with open(README) as f:
 
 # Include files
 header_files = ["onnxruntime_cxx_api.h", "onnxruntime_c_api.h", "onnxruntime_cxx_inline.h"]
-headers = [path.join('include', x) for x in header_files]
+extra += [path.join('capi',path.join('include', x)) for x in header_files]
 
 packages = [
     'onnxruntime',
     'onnxruntime.backend',
     'onnxruntime.capi',
-    'onnxruntime.capi.include',
     'onnxruntime.capi.training',
     'onnxruntime.datasets',
     'onnxruntime.tools',
@@ -379,7 +378,7 @@ if featurizers_build:
         packages.append("onnxruntime.FeaturizersLibrary.Data.{}".format(item))
         package_data[packages[-1]] = listdir(path.join(featurizer_dest_dir, item))
 
-package_data["onnxruntime"] = data + examples + extra + headers
+package_data["onnxruntime"] = data + examples + extra
 
 version_number = ''
 with open('VERSION_NUMBER') as f:

--- a/setup.py
+++ b/setup.py
@@ -247,10 +247,15 @@ if not path.exists(README):
 with open(README) as f:
     long_description = f.read()
 
+# Include files
+header_files = ["onnxruntime_cxx_api.h", "onnxruntime_c_api.h", "onnxruntime_cxx_inline.h"]
+headers = [path.join('include', x) for x in header_files]
+
 packages = [
     'onnxruntime',
     'onnxruntime.backend',
     'onnxruntime.capi',
+    'onnxruntime.capi.include',
     'onnxruntime.capi.training',
     'onnxruntime.datasets',
     'onnxruntime.tools',
@@ -374,7 +379,7 @@ if featurizers_build:
         packages.append("onnxruntime.FeaturizersLibrary.Data.{}".format(item))
         package_data[packages[-1]] = listdir(path.join(featurizer_dest_dir, item))
 
-package_data["onnxruntime"] = data + examples + extra
+package_data["onnxruntime"] = data + examples + extra + headers
 
 version_number = ''
 with open('VERSION_NUMBER') as f:


### PR DESCRIPTION
**Description**: 
The purpose of this PR is to provide a way to define ONNX schema and register such schemas in to onnxruntime in python environment. The onnx::* symbols used in the custom ops shared library need to be resolved at load time from the onnx, onnx_proto libraries. The custom ops shared library (implemented as a shared library may be implemented in C/C++) may be loaded and resolved in a couple of ways:

1. Using session_options.register_custom_ops_library function (https://dev.azure.com/sajandhy/custom_ops/_git/custom_ops)
- Requires adding onnxruntime_c_api.h, onnxruntime_cxx_api.h and onnxruntime_cxx_inline.h files to the wheel
- Requires exposing onnx::* symbols through the onnxruntime_pybind11_state shared library

2. As a python module (https://dev.azure.com/sajandhy/custom_ops/_git/custom_ops_python)
- Requires exposing onnx::* symbols through the onnxruntime_pybind11_state shared library
- No header files are required to be added to wheel
*I will split this PR into two so that it is easier to review.*
I am trying to modify the PR to 
1. Only effect onnxruntime_pybind11_state.so size
2. Currently the changes only work for Ubuntu (UNIX). I will make changes to work on Windows/Apple
**Motivation and Context**

- Our 1P user wants to be able to not have to build onnxruntime in their dev workflow.

- The 1P execution provider is not built in to onnxruntime.


