### PR TITLE
[Vitis AI EP] Fix build issue due to Python interpreter not being found

### DIFF
--- a/cmake/external/pyxir.cmake
+++ b/cmake/external/pyxir.cmake
@@ -3,8 +3,8 @@
 
 set(PYXIR_SHARED_LIB libpyxir.so)
 
-if(PYTHONINTERP_FOUND)
-  execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+if(Python_EXECUTABLE)
+  execute_process(COMMAND "${Python_EXECUTABLE}" "-c"
     "import pyxir as px; print(px.get_include_dir()); print(px.get_lib_dir());"
     RESULT_VARIABLE __result
     OUTPUT_VARIABLE __output
@@ -17,7 +17,7 @@ if(PYTHONINTERP_FOUND)
     list(GET __values 1 PYXIR_LIB_DIR)
   endif()
 else()
-  message(STATUS "To find Pyxir, Python interpretater is required to be found.")
+  message(STATUS "To find Pyxir, the Python Executable needs to be found.")
 endif()
 
 add_library(pyxir SHARED IMPORTED)


### PR DESCRIPTION
Fix Vitis AI build issue due to Python interpreter not being found. Fix by checking for Python_EXECUTABLE instead of PYTHONINTERP_FOUND in pyxir.cmake.