### PR TITLE
constrain inputs for min/max grad UT

### DIFF
--- a/orttraining/orttraining/test/gradient/gradient_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/gradient_ops_test.cc
@@ -2503,19 +2503,24 @@ void GradientCheckerMinMaxGradHelper(const std::string op) {
     EXPECT_IS_TINY(max_error);
   }
 
+  // Fix below x values since too close x1 and x2 values (|difference| < 1e-3f) cause NumericJacobian incorrect.
+  // 1e-3f is the delta value of `ComputeNumericJacobianTranspose()`.
   {
     TensorInfo x1_info({2, 3}, true);
     TensorInfo x2_info({2, 3}, true);
+    std::vector<std::vector<float>> x_datas = {{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f},
+                                               {1.01f, 1.99f, 3.01f, 3.99f, 5.01f, 5.99f}};
     TensorInfo y_info({2, 3}, true);
-    gradient_checker.ComputeGradientError(op_def, {x1_info, x2_info}, {y_info}, &max_error);
+    gradient_checker.ComputeGradientError(op_def, {x1_info, x2_info}, {y_info}, &max_error, x_datas);
     EXPECT_IS_TINY(max_error);
   }
 
   {
     TensorInfo x1_info({2, 3}, true);
     TensorInfo x2_info({3}, true);
+    std::vector<std::vector<float>> x_datas = {{1.0f, 2.0f, 3.0f, 1.02f, 2.02f, 3.02f}, {1.01f, 2.01f, 3.01f}};
     TensorInfo y_info({2, 3}, true);
-    gradient_checker.ComputeGradientError(op_def, {x1_info, x2_info}, {y_info}, &max_error);
+    gradient_checker.ComputeGradientError(op_def, {x1_info, x2_info}, {y_info}, &max_error, x_datas);
     EXPECT_IS_TINY(max_error);
   }
 }


### PR DESCRIPTION
**Description**: Fix the input values for MinMaxGradient UT.

**Motivation and Context**
`Min(x1, x2)` is not smooth when `x1` equals `x2`. The original test case uses randomly generated inputs.
When the generated inputs are close enough (|difference| < 1e-3f, the delta value), calculating NumericJacobian will get wrong values, causing the UT to fail.
e.g. `x1=1.0, x2=1.0005, y=min(x1, x2)`. Gradient should be (1.0, 0.0), but the numeric gradient will be (0.75, 0.25):
- numeric gradient w.r.t. `x1` is: `[min(x1+0.001, x2) - min(x1-0.001, x2)]/0.002 = (1.0005-0.999)/0.002 = 0.75`
- numeric gradient w.r.t. `x2` is: `[min(x1, x2+0.001) - min(x1, x2-0.001)]/0.002 = (1.0-0.9995)/0.002 = 0.25`

Likewise for `Max(x1, x2)`.

This change is to avoid such cases and hence occasional CI failures.