### PR TITLE
[Android CI] Enable parallelism in build pipeline.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -1,81 +1,56 @@
 jobs:
-- job: Android_CI
-  pool:
-    vmImage: 'macOS-10.15'
-  timeoutInMinutes: 150
-  steps:
-  # Onnx has no 3.9 python package available yet, need to use python 3.8 to avoid build onnx package
-  # pythonVersion can be updated in Azure pipeline settings
-  # https://dev.azure.com/onnxruntime/onnxruntime/_build?definitionId=53
-  - task: UsePythonVersion@0
-    displayName: Use Python $(pythonVersion)
-    inputs:
-      versionSpec: $(pythonVersion)
+- template: templates/android-emulator-job.yml
+  parameters:
+    Name: Android_CI_CPU_EP
+    AndroidApiVersion: 29
+    AndroidAbi: x86_64
+    Steps:
+    - script: |
+        python3 tools/ci_build/build.py \
+          --android \
+          --build_dir build \
+          --android_sdk_path $ANDROID_HOME \
+          --android_ndk_path $ANDROID_NDK_HOME \
+          --android_abi=x86_64 \
+          --android_api=29 \
+          --skip_submodule_sync \
+          --parallel \
+          --cmake_generator=Ninja \
+          --build_java
+      displayName: CPU EP, Build and Test on Android Emulator
 
-  - script: brew install coreutils ninja
-    displayName: Install coreutils and ninja
+- template: templates/android-emulator-job.yml
+  parameters:
+    Name: Android_CI_NNAPI_EP_With_Code_Coverage
+    AndroidApiVersion: 29
+    AndroidAbi: x86_64
+    Steps:
+    - script: /bin/bash tools/ci_build/github/android/run_nnapi_code_coverage.sh $(pwd)
+      displayName: NNAPI EP, Build, Test and Get Code Coverage on Android Emulator
 
-  - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
-    displayName: Setup gradle wrapper to use gradle 6.8.3
+    - task: PublishPipelineArtifact@0
+      displayName: 'Publish code coverage report'
+      inputs:
+        artifactName: "coverage_rpt.txt"
+        targetPath: '$(Build.SourcesDirectory)/build_nnapi/Debug/coverage_rpt.txt'
+        publishLocation: 'pipeline'
 
-  - script: |
-      python3 tools/python/run_android_emulator.py \
-        --android-sdk-root ${ANDROID_SDK_ROOT} \
-        --create-avd --system-image "system-images;android-29;google_apis;x86_64" \
-        --start --emulator-extra-args="-partition-size 4096" \
-        --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
-    displayName: Start Android emulator
-
-  # Start switching to jdk 11 after the Android Emulator is started since Android SDK manager requires java 8
-  - task: JavaToolInstaller@0
-    displayName: Use jdk 11
-    inputs:
-      versionSpec: '11'
-      jdkArchitectureOption: 'x64'
-      jdkSourceOption: 'PreInstalled'
-
-  - script: |
-      python3 tools/ci_build/build.py \
-        --android \
-        --build_dir build \
-        --android_sdk_path $ANDROID_HOME \
-        --android_ndk_path $ANDROID_NDK_HOME \
-        --android_abi=x86_64 \
-        --android_api=29 \
-        --skip_submodule_sync \
-        --parallel \
-        --cmake_generator=Ninja \
-        --build_java
-    displayName: CPU EP, Build and Test on Android Emulator
-
-  - script: /bin/bash tools/ci_build/github/android/run_nnapi_code_coverage.sh $(pwd)
-    displayName: NNAPI EP, Build, Test and Get Code Coverage on Android Emulator
-
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish code coverage report'
-    inputs:
-      artifactName: "coverage_rpt.txt"
-      targetPath: '$(Build.SourcesDirectory)/build_nnapi/Debug/coverage_rpt.txt'
-      publishLocation: 'pipeline'
-
-  - script: /bin/bash tools/ci_build/github/linux/ort_minimal/nnapi_minimal_build_minimal_ort_and_run_tests.sh $(pwd)
-    # Build Minimal ORT with NNAPI and reduced Ops, run unit tests on Android Emulator
-    displayName: Build Minimal ORT with NNAPI and run tests
-
-  - script: |
-      python3 tools/python/run_android_emulator.py \
-        --android-sdk-root ${ANDROID_SDK_ROOT} \
-        --stop \
-        --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
-    displayName: Stop Android emulator
-    condition: always()
+- template: templates/android-emulator-job.yml
+  parameters:
+    Name: Android_CI_Minimal_NNAPI_EP
+    AndroidApiVersion: 29
+    AndroidAbi: x86_64
+    Steps:
+    - script: /bin/bash tools/ci_build/github/linux/ort_minimal/nnapi_minimal_build_minimal_ort_and_run_tests.sh $(pwd)
+      # Build Minimal ORT with NNAPI and reduced Ops, run unit tests on Android Emulator
+      displayName: Build Minimal ORT with NNAPI and run tests
 
 - job: Update_Dashboard
   workspace:
     clean: all
   pool:
     vmImage: 'ubuntu-latest'
-  dependsOn: Android_CI
+  dependsOn: Android_CI_NNAPI_EP_With_Code_Coverage
   # disable update dashboard of Android Code coverage until Azure CI machine cannot access database issue is resolved
   # condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
   condition: false

--- a/tools/ci_build/github/azure-pipelines/templates/android-emulator-job.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-emulator-job.yml
@@ -1,0 +1,59 @@
+parameters:
+- name: Name
+  type: string
+- name: TimeoutInMinutes
+  type: number
+  default: 90
+- name: AndroidApiVersion
+  type: string
+- name: AndroidAbi
+  type: string
+- name: Steps
+  type: stepList
+
+jobs:
+- job: ${{ parameters.Name }}
+
+  pool:
+    vmImage: 'macOS-10.15'
+
+  timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
+
+  steps:
+  - task: UsePythonVersion@0
+    displayName: Use Python 3.9
+    inputs:
+      versionSpec: 3.9
+
+  - script: brew install coreutils ninja
+    displayName: Install coreutils and ninja
+
+  - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
+    displayName: Setup gradle wrapper to use gradle 6.8.3
+
+  - script: |
+      python3 tools/python/run_android_emulator.py \
+        --android-sdk-root ${ANDROID_SDK_ROOT} \
+        --create-avd --system-image \
+          "system-images;android-${{ parameters.AndroidApiVersion }};google_apis;${{ parameters.AndroidAbi }}" \
+        --start --emulator-extra-args="-partition-size 4096" \
+        --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
+    displayName: Start Android emulator
+
+  # Start switching to jdk 11 after the Android Emulator is started since Android SDK manager requires java 8
+  - task: JavaToolInstaller@0
+    displayName: Use jdk 11
+    inputs:
+      versionSpec: '11'
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'
+
+  - ${{ parameters.Steps }}
+
+  - script: |
+      python3 tools/python/run_android_emulator.py \
+        --android-sdk-root ${ANDROID_SDK_ROOT} \
+        --stop \
+        --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
+    displayName: Stop Android emulator
+    condition: always()

--- a/tools/ci_build/github/linux/ort_minimal/nnapi_minimal_build_minimal_ort_and_run_tests.sh
+++ b/tools/ci_build/github/linux/ort_minimal/nnapi_minimal_build_minimal_ort_and_run_tests.sh
@@ -8,10 +8,6 @@ set -x
 ORT_ROOT=$1
 MIN_BUILD_DIR=$ORT_ROOT/build_nnapi_minimal
 
-# Remove builds from previous CPU and NNAPI full Android ORT build to free up disk space
-rm -rf $ORT_ROOT/build
-rm -rf $ORT_ROOT/build_nnapi
-
 # make sure flatbuffers is installed as it's required to parse required_ops_and_types.config
 python3 -m pip install --user flatbuffers
 


### PR DESCRIPTION
**Description**
Enable parallel jobs in build pipeline. Previously, ORT was being built sequentially in three different configurations.

https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=459646&view=results

**Motivation and Context**
Reduce overall build time if there are enough build agents available.
