### PR TITLE
Fix Python `SyntaxWarning`

### DIFF
--- a/onnxruntime/python/tools/transformers/convert_tf_models_to_pytorch.py
+++ b/onnxruntime/python/tools/transformers/convert_tf_models_to_pytorch.py
@@ -94,9 +94,9 @@ def init_pytorch_model(model_name, tf_checkpoint_path):
 
     parent_path = tf_checkpoint_path.rpartition('/')[0]
     config_path = glob.glob(parent_path + "/*config.json")
-    config = model_config() if len(config_path) is 0 else model_config.from_json_file(str(config_path[0]))
+    config = model_config() if len(config_path) == 0 else model_config.from_json_file(str(config_path[0]))
 
-    if TFMODELS[model_name][2] is "":
+    if TFMODELS[model_name][2] == "":
         from transformers import AutoModelForPreTraining
         init_model = AutoModelForPreTraining.from_config(config)
     else:
@@ -115,7 +115,7 @@ def convert_tf_checkpoint_to_pytorch(model_name, config, init_model, tf_checkpoi
     if is_tf2 is False:
         load_tf_weight_func = getattr(module, load_tf_weight_func_name)
     else:
-        if TFMODELS[model_name][0] is not "bert":
+        if TFMODELS[model_name][0] != "bert":
             raise NotImplementedError("Only support tf2 ckeckpoint for Bert model")
         from transformers import convert_bert_original_tf2_checkpoint_to_pytorch
         load_tf_weight_func = convert_bert_original_tf2_checkpoint_to_pytorch.load_tf2_weights_in_bert

--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -209,8 +209,8 @@ class BertOnnxModel(OnnxModel):
 
                     slice_node = reshape_path[-1]
                     if expand_shape_value is not None and shape_value is not None and len(
-                            expand_shape_value) is 2 and len(
-                                shape_value) is 1 and expand_shape_value[1] == shape_value[0]:
+                            expand_shape_value) == 2 and len(
+                                shape_value) == 1 and expand_shape_value[1] == shape_value[0]:
                         node.input[0] = slice_node.output[0]
 
         if nodes_to_remove:


### PR DESCRIPTION
**Description**:
Python 3.8 adds a new SyntaxWarning if `is` or `is not` is used where `==` or `!=` is correct. This fixes `SyntaxWarning: "is" with a literal. Did you mean "=="?` and similar warnings.

**Motivation and Context**
This change fixes the following warning output when compiling `.py` files:
```
/usr/lib/python3/dist-packages/onnxruntime/transformers/convert_tf_models_to_pytorch.py:97: SyntaxWarning: "is" with a literal. Did you mean "=="?
  config = model_config() if len(config_path) is 0 else model_config.from_json_file(str(config_path[0]))
/usr/lib/python3/dist-packages/onnxruntime/transformers/convert_tf_models_to_pytorch.py:99: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if TFMODELS[model_name][2] is "":
/usr/lib/python3/dist-packages/onnxruntime/transformers/convert_tf_models_to_pytorch.py:118: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if TFMODELS[model_name][0] is not "bert":
/usr/lib/python3/dist-packages/onnxruntime/transformers/onnx_model_bert.py:211: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if expand_shape_value is not None and shape_value is not None and len(
/usr/lib/python3/dist-packages/onnxruntime/transformers/onnx_model_bert.py:212: SyntaxWarning: "is" with a literal. Did you mean "=="?
  expand_shape_value) is 2 and len(
```

My particular use-case is using [wheel2deb](https://github.com/upciti/wheel2deb) to create a Debian package for the Python wheel. This tool adds a post-installation step for compiling all of the Python files, which generates the warnings on installation for all users.

Command for reference:
```
py3compile -p python3-onnxruntime
```
