### PR TITLE
Remove identity insertion before every output for passthrough inputs

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -10,52 +10,6 @@ import torch
 import warnings
 import gc
 
-class _OutputIdentityOp(torch.autograd.Function):
-    '''Internal class used to prepend Identity ops in model's outputs
-
-    This class is required to support ONNX models which passthrough [some of] the models's inputs
-    directly to the graph output. This is an issue because ONNX Runtime cannot build proper
-    gradient graph based on this pattern.
-
-    Adding a direct Identity Op to the user model doesn't work as the ONNX exporter would optimize it away,
-    resulting in the same issue.
-
-    Therefore a custom Autograd function was introduced to add an Identity right before the output
-    in a way the ONNX exporter will not optimize it away.
-
-    Given the model below
-
-    .. code-block:: python
-
-        class PassthroughNet(torch.nn.Module):
-            def __init__(self, input_size, hidden_size, num_classes):
-                super(PassthroughNet, self).__init__()
-                self.fc1_1 = torch.nn.Linear(input_size, hidden_size)
-                self.relu1 = torch.nn.ReLU()
-                self.fc1_2 = torch.nn.Linear(hidden_size, num_classes)
-            def forward(self, input1, passthrough_input):
-                out1 = self.fc1_2(self.relu1(self.fc1_1(input1)))
-                # use shape from passthrough_input
-                out1 = out1.view(passthrough_input.size()[0], -1)
-                return out1, passthrough_input
-
-    We can see `passthrough_input` is part of both model input and output and the resulting
-    ONNX subgraph would contain something like `output2 -> output2`.
-
-    By prepending each model output to an :class:`_OutputIdentityOp` op, the resulting
-    onnx subgraph for this example would be  `passthrough_input -> Identity -> output2`.
-
-    TODO: Remove once PyTorch 1.8.2 or newer is released
-    '''
-    @staticmethod
-    def forward(ctx, input):
-        return torch.nn.Identity()(input)
-    @staticmethod
-    def backward(ctx, grad_output):
-        return grad_output
-    @staticmethod
-    def symbolic(g, self):
-        return g.op("Identity", self)
 
 class _PrimitiveType(object):
     _primitive_types = {int, bool, float}
@@ -370,8 +324,7 @@ def _transform_output_to_flat_tuple(data):
         if data is None:
             return
         elif isinstance(data, torch.Tensor):
-            identity = _OutputIdentityOp.apply
-            flat_data.append(identity(data))
+            flat_data.append(data)
         elif isinstance(data, abc.Sequence):
             for value in data:
                 _flatten_data(value, flat_data)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -1264,7 +1264,8 @@ def test_input_requires_grad_backward_creates_input_grad_as_required1(x1_require
 
 
 @pytest.mark.parametrize("device", ['cuda'])
-def test_model_with_bypass_input(device):
+@pytest.mark.parametrize("training_mode", [True, False])
+def test_model_with_bypass_input(device, training_mode):
     class NeuralNetWithBypassInput(torch.nn.Module):
         def __init__(self, input_size, hidden_size, num_classes):
             super(NeuralNetWithBypassInput, self).__init__()
@@ -1288,6 +1289,9 @@ def test_model_with_bypass_input(device):
     N, D_in, H, D_out = 32, 784, 500, 10
     pt_model = NeuralNetWithBypassInput(D_in, H, D_out).to(device)
     ort_model = ORTModule(copy.deepcopy(pt_model))
+    if not training_mode:
+        pt_model.eval()
+        ort_model.eval()
 
     pt_x1 = torch.randn(N, D_in, device=device, requires_grad=True)
     pt_x2 = torch.randn(N, D_in, device=device, requires_grad=True)


### PR DESCRIPTION
In an earlier pull request #7694, we addressed the problem of passthrough inputs by introducing an ```Identity``` node before every output. After the release of ```PyTorch``` ```1.9.0```, the exporter introduces the ```Identity``` and it is no longer needed to do so on the ```ORTModule``` end. Removing redundant code.