### PR TITLE
handle a corner case in removing useless reshape

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_utils.py
+++ b/onnxruntime/python/tools/transformers/fusion_utils.py
@@ -120,10 +120,10 @@ class FusionUtils:
                         f"Remove reshape node {node.name} since its input shape is same as output: {input_shape}")
                     nodes_to_remove.append(node)
 
-        graph_output_names = model.get_graphs_output_name()
         if nodes_to_remove:
+            graph_output_names = set(model.get_graphs_output_name())
             for node in nodes_to_remove:
-                if bool(set(node.output) & set(graph_output_names)):
+                if bool(set(node.output) & graph_output_names):
                     model.replace_output_of_all_nodes(node.input[0], node.output[0])
                 else:
                     model.replace_input_of_all_nodes(node.output[0], node.input[0])

--- a/onnxruntime/python/tools/transformers/fusion_utils.py
+++ b/onnxruntime/python/tools/transformers/fusion_utils.py
@@ -121,10 +121,14 @@ class FusionUtils:
                     nodes_to_remove.append(node)
 
         if nodes_to_remove:
-            graph_output_names = set(model.get_graphs_output_name())
+            graph_input_names = set(model.get_graphs_input_names())
+            graph_output_names = set(model.get_graphs_output_names())
             for node in nodes_to_remove:
                 if bool(set(node.output) & graph_output_names):
-                    model.replace_output_of_all_nodes(node.input[0], node.output[0])
+                    if not bool(set(node.input) & graph_input_names):
+                        model.replace_output_of_all_nodes(node.input[0], node.output[0])
+                    else:
+                        continue
                 else:
                     model.replace_input_of_all_nodes(node.output[0], node.input[0])
                 model.remove_node(node)

--- a/onnxruntime/python/tools/transformers/fusion_utils.py
+++ b/onnxruntime/python/tools/transformers/fusion_utils.py
@@ -120,9 +120,13 @@ class FusionUtils:
                         f"Remove reshape node {node.name} since its input shape is same as output: {input_shape}")
                     nodes_to_remove.append(node)
 
+        graph_output_names = model.get_graphs_output_name()
         if nodes_to_remove:
             for node in nodes_to_remove:
-                model.replace_input_of_all_nodes(node.output[0], node.input[0])
+                if bool(set(node.output) & set(graph_output_names)):
+                    model.replace_output_of_all_nodes(node.input[0], node.output[0])
+                else:
+                    model.replace_input_of_all_nodes(node.output[0], node.input[0])
                 model.remove_node(node)
             model.prune_graph()
 

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -81,6 +81,13 @@ class OnnxModel:
                             graph_queue.append(g)
         return self.all_graphs
 
+    def get_graphs_output_name(self):
+        output_names = []
+        for graph in self.graphs():
+            for output in graph.output:
+                output_names.append(output.name)
+        return output_names
+
     def get_graph_by_node(self, node):
         for graph in self.graphs():
             if node in graph.node:

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -81,7 +81,14 @@ class OnnxModel:
                             graph_queue.append(g)
         return self.all_graphs
 
-    def get_graphs_output_name(self):
+    def get_graphs_input_names(self):
+        input_names = []
+        for graph in self.graphs():
+            for input in graph.input:
+                input_names.append(input.name)
+        return input_names
+
+    def get_graphs_output_names(self):
         output_names = []
         for graph in self.graphs():
             for output in graph.output:


### PR DESCRIPTION
**Description**: Describe your changes.

Found a case that if the reshape candidates share outputs with graph, removing that candidate will break the model. Handle this case in particular

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
