### PR TITLE
Fixing MORE mlas unittest failures in POWER

### DIFF
--- a/onnxruntime/test/mlas/unittest/test_fgemm.h
+++ b/onnxruntime/test/mlas/unittest/test_fgemm.h
@@ -128,8 +128,6 @@ class FgemmPackedContext<float, true> {
       data[i].beta = beta;
     }
     MlasGemmBatch(TransA, TransB, M, N, K, data.data(), BatchSize, threadpool);
-
-    MlasGemm(TransA, M, N, K, alpha, A, lda, PackedB, beta, C, ldc, threadpool);
   }
 
  private:


### PR DESCRIPTION
We noted that "onnx_runtime_mlas_test --long" was reporting MILLIONS of errors on our Power servers.

After some analysis it looked like the incorrect answers being received are what would be expected if the
GEMM call were made twice in a row, with the C values from the first call plugged in as input to the second call.

We discovered what appears to be a cut-and-paste error in onnxruntime/test/mlas/unittest/test_fgemm.h, 
and when we removed the offending second line, the errors went away!
