### PR TITLE
iOS Coacopods spec fix

### DIFF
--- a/tools/ci_build/github/apple/c/onnxruntime-mobile-c.podspec.template
+++ b/tools/ci_build/github/apple/c/onnxruntime-mobile-c.podspec.template
@@ -16,8 +16,10 @@ Pod::Spec.new do |spec|
     A pod for the ONNX Runtime Mobile C/C++ library.
                                     DESC
     spec.library                 = "c++"
-    spec.user_target_xcconfig    = {
+    spec.pod_target_xcconfig     = {
         "OTHER_CPLUSPLUSFLAGS" => "-fvisibility=hidden -fvisibility-inlines-hidden",
+    }
+    spec.user_target_xcconfig    = {
         # TODO workaround - support arm64 iphonesimulator later
         "EXCLUDED_ARCHS[sdk=iphonesimulator*]" => "arm64"
     }

--- a/tools/ci_build/github/apple/objectivec/onnxruntime-mobile-objc.podspec.template
+++ b/tools/ci_build/github/apple/objectivec/onnxruntime-mobile-objc.podspec.template
@@ -29,6 +29,7 @@ Pod::Spec.new do |s|
 
     core.pod_target_xcconfig = {
       "HEADER_SEARCH_PATHS" => include_dirs.join(" "),
+      "OTHER_CPLUSPLUSFLAGS" => "-fvisibility=hidden -fvisibility-inlines-hidden",
       "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "arm64",
     }
 

--- a/tools/ci_build/github/apple/objectivec/onnxruntime-mobile-objc.podspec.template
+++ b/tools/ci_build/github/apple/objectivec/onnxruntime-mobile-objc.podspec.template
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
     core.pod_target_xcconfig = {
       "HEADER_SEARCH_PATHS" => include_dirs.join(" "),
       "OTHER_CPLUSPLUSFLAGS" => "-fvisibility=hidden -fvisibility-inlines-hidden",
-      "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "arm64",
+      "EXCLUDED_ARCHS[sdk=iphonesimulator*]" => "arm64",
     }
 
     core.public_header_files = [


### PR DESCRIPTION
**Description**: iOS Coacopods spec fix

**Motivation and Context**
- The current onnxruntime-mobile-c.podspec will enable symbol hidden setting for the target instead of the pod itself, for a project with App and Test targets, while the App using ORT works fine, it may happen that the Test won't see the App's symbol
- Move symbol hidden setting from user_target_xcconfig to pod_target_xcconfig
