### PR TITLE
Fix attention perf regression

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
@@ -60,7 +60,7 @@ class AttentionCPUBase : public AttentionBase {
     }
     BufferUniquePtr mask_data_buffer(mask_data, BufferDeleter(allocator));
 
-    bool* undir_mask = nullptr;
+    void* undir_mask = nullptr;
     if (has_unidirectional) {
       size_t undir_mask_bytes = SafeInt<size_t>(sequence_length) * all_sequence_length * sizeof(bool);
       undir_mask = allocator->Alloc(undir_mask_bytes);
@@ -79,7 +79,7 @@ class AttentionCPUBase : public AttentionBase {
     }
 
     ComputeAttentionProbs<T>(static_cast<T*>(attention_probs), Q, K,
-                             mask_index_data, mask_index_dims, static_cast<T*>(mask_data), undir_mask, has_unidirectional,
+                             mask_index_data, mask_index_dims, static_cast<T*>(mask_data), static_cast<bool*>(undir_mask),
                              batch_size, sequence_length, past_sequence_length, qk_head_size == 0 ? v_head_size : qk_head_size,
                              past_data, present_data, tp, extra_add_qk_data);
 

--- a/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
@@ -18,18 +18,18 @@ class AttentionCPUBase : public AttentionBase {
   AttentionCPUBase(const OpKernelInfo& info) : AttentionBase(info) {}
 
   template <typename T>
-  Status ApplyAttention(const T* Q,                // Q data. Its size is BxNxSxH
-                        const T* K,                // K data. Its size is BxNxSxH
-                        const T* V,                // V value with size BxNxSxH
-                        const Tensor* mask_index,  // mask index. nullptr if no mask or its size is B
-                        const Tensor* past,        // past state
-                        Tensor* output,            // output tensor
-                        int batch_size,            // batch size
-                        int sequence_length,       // sequence length
-                        int qk_head_size,          // qk_head_size
-                        int v_head_size,           // head_size
-                        int v_hidden_size,         // hidden_size
-                        const Tensor* extra_add_qk,// extra add in QK. Its size is BxNxSxS
+  Status ApplyAttention(const T* Q,                  // Q data. Its size is BxNxSxH
+                        const T* K,                  // K data. Its size is BxNxSxH
+                        const T* V,                  // V value with size BxNxSxH
+                        const Tensor* mask_index,    // mask index. nullptr if no mask or its size is B
+                        const Tensor* past,          // past state
+                        Tensor* output,              // output tensor
+                        int batch_size,              // batch size
+                        int sequence_length,         // sequence length
+                        int qk_head_size,            // qk_head_size
+                        int v_head_size,             // head_size
+                        int v_hidden_size,           // hidden_size
+                        const Tensor* extra_add_qk,  // extra add in QK. Its size is BxNxSxS
                         OpKernelContext* context) const {
     AllocatorPtr allocator;
     ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&allocator));
@@ -50,13 +50,23 @@ class AttentionCPUBase : public AttentionBase {
     auto attention_probs = allocator->Alloc(attention_probs_bytes);
     BufferUniquePtr scratch_buffer(attention_probs, BufferDeleter(allocator));
 
+    bool has_unidirectional = (is_unidirectional_ && sequence_length > 1);
+
     void* mask_data = nullptr;
-    if (mask_index != nullptr || (is_unidirectional_ && sequence_length > 1)) {
+    if (mask_index != nullptr || has_unidirectional) {
       size_t mask_data_bytes = SafeInt<size_t>(batch_size) * sequence_length * all_sequence_length * sizeof(T);
       mask_data = allocator->Alloc(mask_data_bytes);
       memset(mask_data, 0, mask_data_bytes);
     }
     BufferUniquePtr mask_data_buffer(mask_data, BufferDeleter(allocator));
+
+    bool* undir_mask = nullptr;
+    if (has_unidirectional) {
+      size_t undir_mask_bytes = SafeInt<size_t>(sequence_length) * all_sequence_length * sizeof(bool);
+      undir_mask = allocator->Alloc(undir_mask_bytes);
+      memset(undir_mask, 0, undir_mask_bytes);
+    }
+    BufferUniquePtr undir_mask_buffer(undir_mask, BufferDeleter(allocator));
 
     const int32_t* mask_index_data = mask_index != nullptr ? mask_index->template Data<int32_t>() : nullptr;
     const std::vector<int64_t>* mask_index_dims = mask_index != nullptr ? &(mask_index->Shape().GetDims()) : nullptr;
@@ -69,7 +79,7 @@ class AttentionCPUBase : public AttentionBase {
     }
 
     ComputeAttentionProbs<T>(static_cast<T*>(attention_probs), Q, K,
-                             mask_index_data, mask_index_dims, static_cast<T*>(mask_data),
+                             mask_index_data, mask_index_dims, static_cast<T*>(mask_data), undir_mask, has_unidirectional,
                              batch_size, sequence_length, past_sequence_length, qk_head_size == 0 ? v_head_size : qk_head_size,
                              past_data, present_data, tp, extra_add_qk_data);
 
@@ -91,20 +101,22 @@ class AttentionCPUBase : public AttentionBase {
   //                                    1 x mask_data(B, N, S, S*)
   //  II.attention_probs(B, N, S, S*) = Softmax(attention_probs)
   template <typename T>
-  void ComputeAttentionProbs(T* attention_probs,                           // output buffer for the attention probs. Its size is BxNxSxS
+  void ComputeAttentionProbs(T* attention_probs,                           // output buffer for the attention probs. Its size is BxNxSxS*
                              const T* Q,                                   // Q data. Its size is BxNxSxH
                              const T* K,                                   // k data. Its size is BxNxSxH
                              const int32_t* mask_index,                    // mask index. nullptr if no mask or its size is B
                              const std::vector<int64_t>* mask_index_dims,  // mask index shape
-                             T* mask_data,                                 // buffer for mask data. It is nullptr if mask_index is nullptr, otherwise its shape is BxSxS*
+                             T* mask_data,                                 // buffer for mask data. It is nullptr if mask_index is nullptr and not unidirectional, otherwise its shape is BxSxS*
+                             bool* undir_mask,                             // unidirectional mask. It is nullptr without unidirectional, otherwise its shape is SxS*
                              int batch_size,                               // batch size of self-attention
                              int sequence_length,                          // sequence length of self-attention
                              int past_sequence_length,                     // sequence length of past state
                              int head_size,                                // head size of self-attention
                              const T* past,                                // past state
                              T* present,                                   // present state
-                             ThreadPool* tp,
-                             const T* extra_add_qk_data) const {
+                             ThreadPool* tp,                               // thread pool
+                             const T* extra_add_qk_data                    // extra add matrix with shape BxNxSxS*
+  ) const {
     const int all_sequence_length = past_sequence_length + sequence_length;                  // S* = S' + S
     const size_t past_chunk_length = static_cast<size_t>(past_sequence_length) * head_size;  // S' x H
     const size_t input_chunk_length = static_cast<size_t>(sequence_length) * head_size;      // S x H
@@ -112,7 +124,7 @@ class AttentionCPUBase : public AttentionBase {
 
     {
       if (mask_data != nullptr) {
-        PrepareMask(mask_index, mask_index_dims, mask_data, is_unidirectional_, batch_size, sequence_length, past_sequence_length);
+        PrepareMask(mask_index, mask_index_dims, mask_data, undir_mask, batch_size, sequence_length, past_sequence_length);
       } else {  // no any mask
         memset(attention_probs, 0, static_cast<size_t>(batch_size) * num_heads_ * sequence_length * all_sequence_length * sizeof(T));
       }
@@ -125,13 +137,15 @@ class AttentionCPUBase : public AttentionBase {
 
       ThreadPool::TryParallelFor(tp, loop_len, cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
         for (std::ptrdiff_t i = begin; i != end; ++i) {
-          const std::ptrdiff_t batch_index = i / num_heads_;
+          const int batch_index = static_cast<int>(i) / num_heads_;
+
+          const int output_offset = static_cast<int>(i) * sequence_length * all_sequence_length;
+          const int mask_offset = batch_index * sequence_length * all_sequence_length;
+          T* output = attention_probs + output_offset;
 
           // broadcast mask data: (Bx)SxS* -> (BxNx)SxS*
           if (mask_data != nullptr) {
-            const T* broadcast_data_src = reinterpret_cast<T*>(mask_data) + batch_index * sequence_length * all_sequence_length;
-            T* broadcast_data_dest = reinterpret_cast<T*>(attention_probs) + sequence_length * all_sequence_length * i;
-            memcpy(broadcast_data_dest, broadcast_data_src, sequence_length * all_sequence_length * sizeof(T));
+            memcpy(output, mask_data + mask_offset, sequence_length * all_sequence_length * sizeof(T));
           }
 
           const T* k = K + input_chunk_length * i;
@@ -147,12 +161,19 @@ class AttentionCPUBase : public AttentionBase {
           // C: attention_probs  (B x N x) S x S*         (B x N x) S x S*       S x S*
           math::Gemm<T, ThreadPool>(CblasNoTrans, CblasTrans, sequence_length, all_sequence_length, head_size, alpha,
                                     Q + input_chunk_length * i, k, 1.0,
-                                    reinterpret_cast<T*>(attention_probs) + sequence_length * all_sequence_length * i, nullptr);
+                                    output, nullptr);
+
+          // Fix unidirectional mask
+          if (undir_mask != nullptr) {
+            for (int j = 0; j < sequence_length * all_sequence_length; j++) {
+              if (undir_mask[j])
+                output[j] = mask_data[mask_offset + j];
+            }
+          }
 
           if (extra_add_qk_data != nullptr) {
-            int extra_add_qk_offset = static_cast<int>(i) * sequence_length * all_sequence_length;
-            for (int j = 0; j < sequence_length * all_sequence_length ; j++) {
-              attention_probs[extra_add_qk_offset+j] += extra_add_qk_data[extra_add_qk_offset + j];
+            for (int j = 0; j < sequence_length * all_sequence_length; j++) {
+              output[j] += extra_add_qk_data[output_offset + j];
             }
           }
         }

--- a/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
@@ -112,11 +112,10 @@ class AttentionCPUBase : public AttentionBase {
 
     {
       if (mask_data != nullptr) {
-        // Convert attention mask data from int to float (0 to -10000.0f). The mask_data shape is BxSxS*.
-        PrepareMask(mask_index, mask_index_dims, mask_data, batch_size, sequence_length, past_sequence_length);
+        PrepareMask(mask_index, mask_index_dims, mask_data, is_unidirectional_, batch_size, sequence_length, past_sequence_length);
+      } else {  // no any mask
+        memset(attention_probs, 0, static_cast<size_t>(batch_size) * num_heads_ * sequence_length * all_sequence_length * sizeof(T));
       }
-
-      memset(attention_probs, 0, static_cast<size_t>(batch_size) * num_heads_ * sequence_length * all_sequence_length * sizeof(T));
 
       const int loop_len = batch_size * num_heads_;
       const float alpha = 1.0f / sqrt(static_cast<float>(head_size));
@@ -128,45 +127,32 @@ class AttentionCPUBase : public AttentionBase {
         for (std::ptrdiff_t i = begin; i != end; ++i) {
           const std::ptrdiff_t batch_index = i / num_heads_;
 
+          // broadcast mask data: (Bx)SxS* -> (BxNx)SxS*
+          if (mask_data != nullptr) {
+            const T* broadcast_data_src = reinterpret_cast<T*>(mask_data) + batch_index * sequence_length * all_sequence_length;
+            T* broadcast_data_dest = reinterpret_cast<T*>(attention_probs) + sequence_length * all_sequence_length * i;
+            memcpy(broadcast_data_dest, broadcast_data_src, sequence_length * all_sequence_length * sizeof(T));
+          }
+
           const T* k = K + input_chunk_length * i;
           if (nullptr != present) {
-            // Concatenate past_K and K : (BxNx)S'xH, (BxNx)SxH -> (BxNx)S*xH
+            // concatenate past_K and K : (BxNx)S'xH, (BxNx)SxH -> (BxNx)S*xH
             k = ConcatStateChunk(past, k, present, past_chunk_length, present_chunk_length, i);
           }
 
-          int offset = sequence_length * all_sequence_length * static_cast<int>(i);
-          T* output = reinterpret_cast<T*>(attention_probs) + offset;
-
-          // Compute Q*K'
+          // gemm
           //                     original                 transposed             each iteration
           // A: Q                (B x N x) S x H          (B x N x) S x H        S x H
           // B: K'               (B x N x) S* x H         (B x N x) H x S*       H x S*
           // C: attention_probs  (B x N x) S x S*         (B x N x) S x S*       S x S*
           math::Gemm<T, ThreadPool>(CblasNoTrans, CblasTrans, sequence_length, all_sequence_length, head_size, alpha,
                                     Q + input_chunk_length * i, k, 1.0,
-                                    output, nullptr);
-
-          // Apply unidirectional mask and set future words to -10000.0f.
-          if (is_unidirectional_) {
-            for (int s = 0; s < sequence_length - 1; s++) {
-              for (int t = past_sequence_length + s + 1; t < all_sequence_length; t++) {
-                output[s * all_sequence_length + t] = static_cast<T>(-10000.0f);
-              }
-            }
-          }
-
-          // Apply attention mask
-          if (mask_data != nullptr) {
-            const T* attention_mask = reinterpret_cast<T*>(mask_data) + batch_index * sequence_length * all_sequence_length;
-            for (int j = 0; j < sequence_length * all_sequence_length ; j++) {
-              output[j] += attention_mask[j];
-            }
-          }
+                                    reinterpret_cast<T*>(attention_probs) + sequence_length * all_sequence_length * i, nullptr);
 
           if (extra_add_qk_data != nullptr) {
-            const T* extra = extra_add_qk_data + offset;
+            int extra_add_qk_offset = static_cast<int>(i) * sequence_length * all_sequence_length;
             for (int j = 0; j < sequence_length * all_sequence_length ; j++) {
-              output[j] += extra[j];
+              attention_probs[extra_add_qk_offset+j] += extra_add_qk_data[extra_add_qk_offset + j];
             }
           }
         }

--- a/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
@@ -135,18 +135,18 @@ class AttentionCPUBase : public AttentionBase {
           const int mask_offset = batch_index * sequence_length * all_sequence_length;
           T* output = attention_probs + output_offset;
 
-          // broadcast mask data: (Bx)SxS* -> (BxNx)SxS*
+          // Broadcast mask data: (Bx)SxS* -> (BxNx)SxS*
           if (mask_data != nullptr) {
             memcpy(output, mask_data + mask_offset, sequence_length * all_sequence_length * sizeof(T));
           }
 
           const T* k = K + input_chunk_length * i;
           if (nullptr != present) {
-            // concatenate past_K and K : (BxNx)S'xH, (BxNx)SxH -> (BxNx)S*xH
+            // Concatenate past_K and K : (BxNx)S'xH, (BxNx)SxH -> (BxNx)S*xH
             k = ConcatStateChunk(past, k, present, past_chunk_length, present_chunk_length, i);
           }
 
-          // gemm
+          // Compute Q*K' + AttentionMask
           //                     original                 transposed             each iteration
           // A: Q                (B x N x) S x H          (B x N x) S x H        S x H
           // B: K'               (B x N x) S* x H         (B x N x) H x S*       H x S*

--- a/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
@@ -64,7 +64,7 @@ template <typename T>
 void PrepareMask(const int32_t* mask_index,
                  const std::vector<int64_t>* mask_index_dims,
                  T* mask_data,
-                 bool* undir_mask,
+                 bool is_unidirectional,
                  int batch_size,
                  int sequence_length,
                  int past_sequence_length) {
@@ -77,15 +77,6 @@ void PrepareMask(const int32_t* mask_index,
   if (nullptr != mask_index_dims && mask_index_dims->size() == 4) {
     ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED, "4D mask in attention cpu kernel is not supported");
     return;
-  }
-
-  const bool is_unidirectional = (undir_mask != nullptr);
-  if (is_unidirectional) {
-    for (int s_i = 0; s_i < sequence_length - 1; s_i++) {
-      for (int m_i = past_sequence_length + s_i + 1; m_i < all_sequence_length; m_i++) {
-        undir_mask[s_i * all_sequence_length + m_i] = true;
-      }
-    }
   }
 
   // For 3D mask, convert values 0 to -10000.0, and 1 to 0.0, then apply unidirectional mask if any.

--- a/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
@@ -64,7 +64,7 @@ template <typename T>
 void PrepareMask(const int32_t* mask_index,
                  const std::vector<int64_t>* mask_index_dims,
                  T* mask_data,
-                 bool is_unidirectional,
+                 bool* undir_mask,
                  int batch_size,
                  int sequence_length,
                  int past_sequence_length) {
@@ -77,6 +77,15 @@ void PrepareMask(const int32_t* mask_index,
   if (nullptr != mask_index_dims && mask_index_dims->size() == 4) {
     ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED, "4D mask in attention cpu kernel is not supported");
     return;
+  }
+
+  const bool is_unidirectional = (undir_mask != nullptr);
+  if (is_unidirectional) {
+    for (int s_i = 0; s_i < sequence_length - 1; s_i++) {
+      for (int m_i = past_sequence_length + s_i + 1; m_i < all_sequence_length; m_i++) {
+        undir_mask[s_i * all_sequence_length + m_i] = true;
+      }
+    }
   }
 
   // For 3D mask, convert values 0 to -10000.0, and 1 to 0.0, then apply unidirectional mask if any.

--- a/onnxruntime/contrib_ops/cuda/bert/attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_impl.cu
@@ -178,11 +178,10 @@ bool LaunchAttentionKernel(
     const void* past,
     void* present) {
 
-  // GPT-2 model is more sensitive on parity since error will accumulate in text generation. 
-  // So use persistent softmax for GPT-2 model by default.
-  // For testing, environment variable ORT_TRANSFORMER_OPTIONS=1 or 2 could enable or disable it explicitly.
+  
+  // For testing, environment variable ORT_TRANSFORMER_OPTIONS=1 could enable persistent softmax
   const TransformerOptions* options = TransformerOptions::GetInstance();
-  bool use_persistent_softmax = (is_unidirectional || options->IsPrecisionMode()) && !options->DisablePersistentSoftmax();
+  bool use_persistent_softmax = options->IsPrecisionMode() && !options->DisablePersistentSoftmax();
 
   if (element_size == 2) {
     return QkvToContext(prop, cublas, stream,


### PR DESCRIPTION
**Description**: 
Fix perf regression on BERT/GPT-2 model caused by https://github.com/microsoft/onnxruntime/pull/8549.
(1) Undo change of cpu attention kernel, and add a post processing that won't impact BERT performance.
(2) Disable persistent softmax by default in CUDA kernel.

Tested with bert-base-cased, batch_size=2, sequence_length 128 shows that majority perf loss is recovered.
| ORT | Avg CPU latency (ms) |
|---|---|
|Before 8549| 130.67|
|After 8549| 131.35|
|Now| 130.80|


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
