### PR TITLE
Rewrite dockerfiles/Dockerfile.arm32v7

### DIFF
--- a/dockerfiles/Dockerfile.arm32v7
+++ b/dockerfiles/Dockerfile.arm32v7
@@ -1,59 +1,17 @@
-# Import info for 32-bit Qemu based build
-# There are also raspberry pi 4 and 64-bit images available so adjust as required
-FROM balenalib/raspberrypi3-python:latest-stretch-build
+# --------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------
+# Dockerfile to run ONNXRuntime with source build for CPU
 
-ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
-ARG ONNXRUNTIME_SERVER_BRANCH=master
+FROM arm32v7/fedora:34
+MAINTAINER Changming Sun "chasun@microsoft.com"
+ADD . /code
 
-# Enforces cross-compilation through Qemu.
-RUN [ "cross-build-start" ]
 
-RUN install_packages \
-    sudo \
-    build-essential \
-    curl \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    wget \
-    python3 \
-    python3-dev \
-    git \
-    tar \
-    libatlas-base-dev
+RUN /code/dockerfiles/scripts/install_fedora_arm32.sh && cd /code && ./build.sh --skip_submodule_sync --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 
 
-# Carefully install the latest version of pip 
-WORKDIR /pip
-RUN wget https://bootstrap.pypa.io/get-pip.py
-RUN python3 get-pip.py
-RUN pip3 install --upgrade setuptools
-RUN pip3 install --upgrade wheel
-RUN pip3 install numpy
-
-# Build the latest cmake
-WORKDIR /code
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0.tar.gz
-RUN tar zxf cmake-3.21.0.tar.gz 
-
-WORKDIR /code/cmake-3.21.0
-RUN ./configure --system-curl
-RUN make
-RUN sudo make install
-
-# Set up build args
-ARG BUILDTYPE=MinSizeRel
-# if doing a 64-bit build change '--arm' to '--arm64'
-ARG BUILDARGS="--config ${BUILDTYPE} --arm"
-
-# Prepare onnxruntime Repo
-WORKDIR /code
-RUN git clone --single-branch --branch ${ONNXRUNTIME_SERVER_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime
-
-# Build ORT including the shared lib and python bindings
-WORKDIR /code/onnxruntime
-RUN ./build.sh ${BUILDARGS} --update --build --build_shared_lib --build_wheel
-
-# Build Output
-RUN ls -l /code/onnxruntime/build/Linux/${BUILDTYPE}/*.so
-RUN ls -l /code/onnxruntime/build/Linux/${BUILDTYPE}/dist/*.whl
-
-RUN [ "cross-build-end" ]
+FROM arm64v8/centos:7
+COPY --from=0 /code/build/Linux/Release/dist /root
+COPY --from=0 /code/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt
+RUN yum install -y python3-wheel python3-pip && python3 -m pip install --upgrade pip && python3 -m pip install /root/*.whl && rm -rf /root/*.whl

--- a/dockerfiles/Dockerfile.arm64
+++ b/dockerfiles/Dockerfile.arm64
@@ -14,4 +14,4 @@ RUN /code/dockerfiles/scripts/install_centos_arm64.sh && cd /code && CC=/opt/rh/
 FROM arm64v8/centos:7
 COPY --from=0 /code/build/Linux/Release/dist /root
 COPY --from=0 /code/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt
-RUN yum install -y python3-wheel python3-pip && python3 -m pip install /root/*.whl && rm -rf /root/*.whl
+RUN yum install -y python3-wheel python3-pip && python3 -m pip install --upgrade pip && python3 -m pip install /root/*.whl && rm -rf /root/*.whl

--- a/dockerfiles/Dockerfile.arm64
+++ b/dockerfiles/Dockerfile.arm64
@@ -1,0 +1,17 @@
+# --------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------
+# Dockerfile to run ONNXRuntime with source build for CPU
+
+FROM arm64v8/centos:7
+MAINTAINER Changming Sun "chasun@microsoft.com"
+ADD . /code
+
+
+RUN /code/dockerfiles/scripts/install_centos_arm64.sh && cd /code && CC=/opt/rh/devtoolset-10/root/usr/bin/gcc CXX=/opt/rh/devtoolset-10/root/usr/bin/g++ ./build.sh --skip_submodule_sync --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 
+
+FROM arm64v8/centos:7
+COPY --from=0 /code/build/Linux/Release/dist /root
+COPY --from=0 /code/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt
+RUN yum install -y python3-wheel python3-pip && python3 -m pip install /root/*.whl && rm -rf /root/*.whl

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -38,7 +38,7 @@ Use `docker pull` with any of the images and tags below to pull an image and try
 # Building and using Docker images
 
 ## CPU
-**Ubuntu 16.04, CPU, Python Bindings**
+**Ubuntu 18.04, CPU, Python Bindings**
 
 1. Build the docker image from the Dockerfile in this repository.
   ```
@@ -209,60 +209,23 @@ If the `device_type` runtime config option is not explicitly specified, CPU will
 
 3. Run the docker image as mentioned in the above steps
 
-## ARM 32v7
-*Public Preview*
+## ARM 32/64
 
-The Dockerfile used in these instructions specifically targets Raspberry Pi 3/3+ running Raspbian Stretch. The same approach should work for other ARM devices, but may require some changes to the Dockerfile such as choosing a different base image (Line 0: `FROM ...`).
+The build instructions are similar to x86 CPU. But if you want to build them on a x86 machine, you need to install qemu-user-static system package (outside of docker instances) first. Then
+	
+1. Build the docker image from the Dockerfile in this repository.
+  ```bash
+  docker build -t onnxruntime-source -f Dockerfile.arm64 ..
+  ```
 
-1. Install dependencies:
+2. Run the Docker image
 
-- DockerCE on your development machine by following the instructions [here](https://docs.docker.com/install/)
-- ARM emulator: `sudo apt-get install -y qemu-user-static`
+  ```bash
+  docker run -it onnxruntime-source
+  ```
 
-2. Create an empty local directory
-    ```bash
-    mkdir onnx-build
-    cd onnx-build
-    ```
-3. Save the Dockerfile from this repo to your new directory: [Dockerfile.arm32v7](./Dockerfile.arm32v7)
-4. Run docker build
-
-    This will build all the dependencies first, then build ONNX Runtime and its Python bindings. This will take several hours.
-    ```bash
-    docker build -t onnxruntime-arm32v7 -f Dockerfile.arm32v7 .
-    ```
-5. Note the full path of the `.whl` file
-
-    - Reported at the end of the build, after the `# Build Output` line.
-    - It should follow the format `onnxruntime-0.3.0-cp35-cp35m-linux_armv7l.whl`, but version number may have changed. You'll use this path to extract the wheel file later.
-6. Check that the build succeeded
-
-    Upon completion, you should see an image tagged `onnxruntime-arm32v7` in your list of docker images:
-    ```bash
-    docker images
-    ```
-7. Extract the Python wheel file from the docker image
-
-    (Update the path/version of the `.whl` file with the one noted in step 5)
-    ```bash
-    docker create -ti --name onnxruntime_temp onnxruntime-arm32v7 bash
-    docker cp onnxruntime_temp:/code/onnxruntime/build/Linux/MinSizeRel/dist/onnxruntime-0.3.0-cp35-cp35m-linux_armv7l.whl .
-    docker rm -fv onnxruntime_temp
-    ```
-    This will save a copy of the wheel file, `onnxruntime-0.3.0-cp35-cp35m-linux_armv7l.whl`, to your working directory on your host machine.
-8. Copy the wheel file (`onnxruntime-0.3.0-cp35-cp35m-linux_armv7l.whl`) to your Raspberry Pi or other ARM device
-9. On device, install the ONNX Runtime wheel file
-    ```bash
-    sudo apt-get update
-    sudo apt-get install -y python3 python3-pip
-    pip3 install numpy
-
-    # Install ONNX Runtime
-    # Important: Update path/version to match the name and location of your .whl file
-    pip3 install onnxruntime-0.3.0-cp35-cp35m-linux_armv7l.whl
-    ```
-10. Test installation by following the instructions [here](https://microsoft.github.io/onnxruntime/)
-
+For ARM32, please use Dockerfile.arm32v7 instead of Dockerfile.arm64.
+	
 ## NVIDIA Jetson TX1/TX2/Nano/Xavier:
 
 These instructions are for [JetPack SDK 4.4](https://developer.nvidia.com/embedded/jetpack).

--- a/dockerfiles/scripts/install_centos_arm64.sh
+++ b/dockerfiles/scripts/install_centos_arm64.sh
@@ -1,0 +1,10 @@
+yum-config-manager --enable extras
+yum -y install centos-release-scl-rh
+# EPEL support (for yasm)
+if ! rpm -q --quiet epel-release ; then
+  yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+fi
+yum install -y devtoolset-10-binutils devtoolset-10-gcc devtoolset-10-gcc-c++ devtoolset-10-gcc aria2 python3-pip python3-wheel git python3-devel
+aria2c -q -d /tmp -o cmake-3.21.1-linux-aarch64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1-linux-aarch64.tar.gz && tar -zxf /tmp/cmake-3.21.1-linux-aarch64.tar.gz --strip=1 -C /usr
+python3 -m pip install --upgrade pip
+python3 -m pip install numpy

--- a/dockerfiles/scripts/install_centos_arm64.sh
+++ b/dockerfiles/scripts/install_centos_arm64.sh
@@ -5,6 +5,18 @@ if ! rpm -q --quiet epel-release ; then
   yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 fi
 yum install -y devtoolset-10-binutils devtoolset-10-gcc devtoolset-10-gcc-c++ devtoolset-10-gcc aria2 python3-pip python3-wheel git python3-devel
-aria2c -q -d /tmp -o cmake-3.21.1-linux-aarch64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1-linux-aarch64.tar.gz && tar -zxf /tmp/cmake-3.21.1-linux-aarch64.tar.gz --strip=1 -C /usr
+ARCH=`uname -m`
+if [ "$ARCH" = "aarch64" ]; then
+    aria2c -q -d /tmp -o cmake-3.21.1-linux-aarch64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1-linux-aarch64.tar.gz && tar -zxf /tmp/cmake-3.21.1-linux-aarch64.tar.gz --strip=1 -C /usr
+else
+    aria2c -q -d /tmp https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1.tar.gz
+    cd /tmp
+    mkdir cmake
+    cd cmake
+    tar --strip=1 -zxvf /tmp/cmake-3.21.1.tar.gz
+    ./configure --prefix=/usr --parallel=$(nproc)
+    make -j$(nproc)
+    make install
+fi
 python3 -m pip install --upgrade pip
 python3 -m pip install numpy

--- a/dockerfiles/scripts/install_fedora_arm32.sh
+++ b/dockerfiles/scripts/install_fedora_arm32.sh
@@ -1,0 +1,3 @@
+dnf install -y binutils gcc gcc-c++ aria2 python3-pip python3-wheel git python3-devel
+python3 -m pip install --upgrade pip
+python3 -m pip install numpy


### PR DESCRIPTION
**Description**: 

Rewrite dockerfiles/Dockerfile.arm32v7 and add an extra one for arm64.

Raspberry pi users would want to have a python package for their 32 bits Raspberry PIs, but unfortunately we can't provide it at this time.  I'm waiting a user tells me which OS he is using and where to find the **official** docker images for that OS.  Then I can add one for it(not in this PR). 

**Motivation and Context**
- Why is this change required? What problem does it solve?

The old one is out of maintain. 

- If it fixes an open issue, please link to the issue here.
#8426 #7920