### PR TITLE
Fix build failure on Jetpack 4.6

### DIFF
--- a/cgmanifests/submodules/cgmanifest.json
+++ b/cgmanifests/submodules/cgmanifest.json
@@ -255,7 +255,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "db78ac1d7716f56fc9f1b030b715f872f93964e4",
+          "commitHash": "c89e23c69b2e9ff997575b1c4ad38910080694f6",
           "repositoryUrl": "https://github.com/nlohmann/json"
         },
         "comments": "git submodule at cmake/external/json"


### PR DESCRIPTION
**Description**: 

Modify commit id of nlohmann/json to unblock jetpack 4.6 build for ORT 1.8.1

**Motivation and Context**
- Why is this change required? What problem does it solve?

I was attempting a build with a specific commit (d14b08d09cee43b42fa9ac361a78d1cbdbceddef) off master that enables TRT 8 support in ORT 1.8.1. This specific compilation issue is seen on a Jetson Xavier

```
In file included from /triton/onnxruntime/onnxruntime/test/providers/kernel_def_hash_test.cc:65:0:
/triton/onnxruntime/cmake/external/json/single_include/nlohmann/json.hpp: In member function ‘void nlohmann::detail::serializer<BasicJsonType>::dump_escaped(const string_t&, bool) [with BasicJsonType = nlohmann::basic_json<>]’:
/triton/onnxruntime/cmake/external/json/single_include/nlohmann/json.hpp:15817:10: error: ‘%.2X’ directive output may be truncated writing between 2 and 8 bytes into a region of size 3 [-Werror=format-truncation=]
     void dump_escaped(const string_t& s, const bool ensure_ascii)
          ^~~~~~~~~~~~
/triton/onnxruntime/cmake/external/json/single_include/nlohmann/json.hpp:15817:10: note: directive argument in the range [0, 2147483647]
In file included from /usr/include/stdio.h:862:0
```

- Fixes https://github.com/nlohmann/json/issues/2572

This is required by Triton Inference Server for supporting the Onnxruntime backend on Jetson.
cc @askhade