### PR TITLE
ARM Neon S8S8 kernel for QGemm

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -48,6 +48,7 @@ elseif(MSVC)
 
       set(mlas_platform_preprocess_srcs
         ${ONNXRUNTIME_ROOT}/core/mlas/lib/arm64/QgemmU8X8KernelNeon.asm
+        ${ONNXRUNTIME_ROOT}/core/mlas/lib/arm64/QgemmS8S8KernelNeon.asm
         ${ONNXRUNTIME_ROOT}/core/mlas/lib/arm64/QgemmU8X8KernelUdot.asm
         ${ONNXRUNTIME_ROOT}/core/mlas/lib/arm64/SgemmKernelNeon.asm
       )
@@ -220,6 +221,7 @@ else()
 
     set(mlas_platform_srcs
       ${ONNXRUNTIME_ROOT}/core/mlas/lib/aarch64/QgemmU8X8KernelNeon.S
+      ${ONNXRUNTIME_ROOT}/core/mlas/lib/aarch64/QgemmS8S8KernelNeon.S
       ${ONNXRUNTIME_ROOT}/core/mlas/lib/aarch64/QgemmU8X8KernelUdot.S
       ${ONNXRUNTIME_ROOT}/core/mlas/lib/aarch64/SgemmKernelNeon.S
       ${ONNXRUNTIME_ROOT}/core/mlas/lib/aarch64/SgemvKernelNeon.S

--- a/onnxruntime/core/mlas/lib/aarch64/QgemmS8S8KernelNeon.S
+++ b/onnxruntime/core/mlas/lib/aarch64/QgemmS8S8KernelNeon.S
@@ -90,58 +90,52 @@ Return Value:
         ldr     x9,[sp,#.LGemmS8S8KernelFrame_ZeroPointB]
         ldrb    w13,[sp,#.LGemmS8S8KernelFrame_ZeroMode]
         mov     x14,x0
-        ld1     {v11.4s},[x7]
         mov     x15,x3
-        dup     v8.4s,v11.s[0]              // broadcast row fixups
         cmp     x4,#1                       // CountM == 1?
-        beq     .LGemmS8S8.M1.ProcessNextColumnLoop
-        dup     v9.4s,v11.s[1]
+        beq     .LGemmS8S8.M1.ProcessLoop
         cmp     x4,#4                       // CountM < 4?
-        blo     .LGemmS8S8.M2.ProcessNextColumnLoop
-        dup     v10.4s,v11.s[2]
-        dup     v11.4s,v11.s[3]
+        blo     .LGemmS8S8.M2.ProcessLoop
 
 //
 // Process 4 rows of the matrices.
-//
-// Column Sum v2.s[0] v2.s[4]
-// Each row sum replicated to all 4 elements of a vector register 
-// v8 ~ v11
-//                    Col Sum   v2.s[0]   v2.s[1]   v2.s[2]   v2.s[1]
-//                                      B 16x4
-//                             /--------------------------------------\
-//                             |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
-//                             |  ...                          ...    |
-//                             |v4.b[15]  v5.b[15]  v6.b[15]  v7.b[15]|
-//          A 4x16             \--------------------------------------/
-//     /--------------------\  /--------------------------------------\
-// v8  |v0.b[0] ... v0.b[15]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
-// v9  |v1.b[0] ... v1.b[15]|  |v20.4s    v21.4s    v22.4s    v23.4s  |
-// v10 |v0.b[0] ... v0.b[15]|  |v24.4s    v25.4s    v26.4s    v27.4s  |
-// v11 |v1.b[0] ... v1.b[15]|  |v28.4s    v29.4s    v30.4s    v31.4s  |
-//     \--------------------/  \--------------------------------------/
+//                                            B 16x4
+//                                      ----------------------------------------
+//                                      |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
+//                                      |  ...      ...        ...      ...    |
+//                                      |v4.b[7]   v5.b[7]   v6.b[7]   v7.b[7] |
+//                                      |v8.b[0]   v9.b[0]   v10.b[0]  v11.b[0]|
+//                                      |  ...      ...       ...       ...    |
+//                                      |v8.b[7]   v9.b[7]   v10.b[7]  v11.b[7]|
+//            A 4x16                    ----------------------------------------
+// -----------------------------------  ----------------------------------------
+// |v0.b[0]..v0.b[7] v2.b[0]..v2.b[7]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
+// |v1.b[0]..v1.b[7] v3.b[0]..v3.b[7]|  |v20.4s    v21.4s    v22.4s    v23.4s  |
+// |v0.b[0]..v0.b[7] v2.b[0]..v2.b[7]|  |v24.4s    v25.4s    v26.4s    v27.4s  |
+// |v1.b[0]..v1.b[7] v3.b[0]..v3.b[7]|  |v28.4s    v29.4s    v30.4s    v31.4s  |
+// -----------------------------------  ----------------------------------------
 //
 // Accumulators are horizontally aggregated to the left most register
 // for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
-
+//
 .LGemmS8S8.M4.ProcessNextColumnLoop:
         mov     x0,x14                      // reload matrix A
         mov     x3,x15                      // reload PackedCountK
-        ldr     q0,[x0],#64                 // A0
+        ldp     d0,d2,[x0],#64              // A0
         movi    v16.4s,#0
         movi    v17.4s,#0
-        ldr     q4,[x1],#64                 // B
+        ldp     d4,d8,[x1],#64              // B
         movi    v18.4s,#0
         movi    v19.4s,#0
-        ldr     q5,[x1,#-48]
+        ldp     d5,d9,[x1,#-48]
         movi    v20.4s,#0
         movi    v21.4s,#0
-        ldr     q6,[x1,#-32]
+        ldp     d6,d10,[x1,#-32]
         movi    v22.4s,#0
         movi    v23.4s,#0
-        ldr     q7,[x1,#-16]
+        ldp     d7,d11,[x1,#-16]
         movi    v24.4s,#0
         movi    v25.4s,#0
+        ldp     d1,d3,[x0,#-48]
         movi    v26.4s,#0
         movi    v27.4s,#0
         movi    v28.4s,#0
@@ -150,83 +144,93 @@ Return Value:
         movi    v31.4s,#0
 
 .LGemmS8S8.M4.ComputeBlockLoop:
-        ldr     q1,[x0,#-48]
         smull   v12.8h,v0.8b,v4.8b
         smull   v13.8h,v0.8b,v5.8b
         smull   v14.8h,v0.8b,v6.8b
         smull   v15.8h,v0.8b,v7.8b
-        smlal2  v12.8h,v0.16b,v4.16b
-        smlal2  v13.8h,v0.16b,v5.16b
-        smlal2  v14.8h,v0.16b,v6.16b
-        smlal2  v15.8h,v0.16b,v7.16b
+        smlal   v12.8h,v2.8b,v8.8b
+        smlal   v13.8h,v2.8b,v9.8b
+        smlal   v14.8h,v2.8b,v10.8b
+        smlal   v15.8h,v2.8b,v11.8b
+        ldp     d0,d2,[x0,#-32]
         sadalp  v16.4s,v12.8h
         sadalp  v17.4s,v13.8h
         sadalp  v18.4s,v14.8h
         sadalp  v19.4s,v15.8h
-        ldr     q0,[x0,#-32]
+        sub     x3,x3,#1
         smull   v12.8h,v1.8b,v4.8b
         smull   v13.8h,v1.8b,v5.8b
         smull   v14.8h,v1.8b,v6.8b
         smull   v15.8h,v1.8b,v7.8b
-        smlal2  v12.8h,v1.16b,v4.16b
-        smlal2  v13.8h,v1.16b,v5.16b
-        smlal2  v14.8h,v1.16b,v6.16b
-        smlal2  v15.8h,v1.16b,v7.16b
+        smlal   v12.8h,v3.8b,v8.8b
+        smlal   v13.8h,v3.8b,v9.8b
+        smlal   v14.8h,v3.8b,v10.8b
+        smlal   v15.8h,v3.8b,v11.8b
+        ldp     d1,d3,[x0,#-16]
         sadalp  v20.4s,v12.8h
         sadalp  v21.4s,v13.8h
         sadalp  v22.4s,v14.8h
         sadalp  v23.4s,v15.8h
-        ldr     q1,[x0,#-16]
+        cbz     x3,.LGemmS8S8.M4.ComputeBlockLoopFinish
         smull   v12.8h,v0.8b,v4.8b
         smull   v13.8h,v0.8b,v5.8b
         smull   v14.8h,v0.8b,v6.8b
         smull   v15.8h,v0.8b,v7.8b
-        smlal2  v12.8h,v0.16b,v4.16b
-        smlal2  v13.8h,v0.16b,v5.16b
-        smlal2  v14.8h,v0.16b,v6.16b
-        smlal2  v15.8h,v0.16b,v7.16b
+        smlal   v12.8h,v2.8b,v8.8b
+        smlal   v13.8h,v2.8b,v9.8b
+        smlal   v14.8h,v2.8b,v10.8b
+        smlal   v15.8h,v2.8b,v11.8b
+        ldp     d0,d2,[x0],#64
         sadalp  v24.4s,v12.8h
         sadalp  v25.4s,v13.8h
         sadalp  v26.4s,v14.8h
         sadalp  v27.4s,v15.8h
-
-        sub     x3,x3,#1
-        cbz     x3,.LGemmS8S8.M4.ComputeBlockLoopFinish
-
-        ldr     q0,[x0],#64
         smull   v12.8h,v1.8b,v4.8b
         smull   v13.8h,v1.8b,v5.8b
         smull   v14.8h,v1.8b,v6.8b
         smull   v15.8h,v1.8b,v7.8b
-        smlal2  v12.8h,v1.16b,v4.16b
-        smlal2  v13.8h,v1.16b,v5.16b
-        ldr     q4,[x1],#64                 // B
-        smlal2  v14.8h,v1.16b,v6.16b
-        smlal2  v15.8h,v1.16b,v7.16b
-        ldr     q5,[x1,#-48]
+        smlal   v12.8h,v3.8b,v8.8b
+        ldp     d4,d8,[x1],#64                 // B
+        smlal   v13.8h,v3.8b,v9.8b
+        ldp     d5,d9,[x1,#-48]
+        smlal   v14.8h,v3.8b,v10.8b
+        ldp     d6,d10,[x1,#-32]
+        smlal   v15.8h,v3.8b,v11.8b
+        ldp     d7,d11,[x1,#-16]
         sadalp  v28.4s,v12.8h
-        ldr     q6,[x1,#-32]
+        ldp     d1,d3,[x0,#-48]
         sadalp  v29.4s,v13.8h
-        ldr     q7,[x1,#-16]
         sadalp  v30.4s,v14.8h
         sadalp  v31.4s,v15.8h
         b       .LGemmS8S8.M4.ComputeBlockLoop
 
 .LGemmS8S8.M4.ComputeBlockLoopFinish:
-
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        ld1     {v0.4s},[x7]
+        smlal   v12.8h,v2.8b,v8.8b
+        smlal   v13.8h,v2.8b,v9.8b
+        smlal   v14.8h,v2.8b,v10.8b
+        smlal   v15.8h,v2.8b,v11.8b
+        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
+        sadalp  v24.4s,v12.8h
+        sadalp  v25.4s,v13.8h
+        sadalp  v26.4s,v14.8h
+        sadalp  v27.4s,v15.8h
         smull   v12.8h,v1.8b,v4.8b
         smull   v13.8h,v1.8b,v5.8b
         smull   v14.8h,v1.8b,v6.8b
         smull   v15.8h,v1.8b,v7.8b
-        smlal2  v12.8h,v1.16b,v4.16b
-        smlal2  v13.8h,v1.16b,v5.16b
-        smlal2  v14.8h,v1.16b,v6.16b
-        smlal2  v15.8h,v1.16b,v7.16b
+        smlal   v12.8h,v3.8b,v8.8b
+        smlal   v13.8h,v3.8b,v9.8b
+        smlal   v14.8h,v3.8b,v10.8b
+        smlal   v15.8h,v3.8b,v11.8b
         sadalp  v28.4s,v12.8h
         sadalp  v29.4s,v13.8h
         sadalp  v30.4s,v14.8h
         sadalp  v31.4s,v15.8h
-
         addp    v16.4s,v16.4s,v17.4s
         addp    v18.4s,v18.4s,v19.4s
         addp    v20.4s,v20.4s,v21.4s
@@ -235,18 +239,17 @@ Return Value:
         addp    v26.4s,v26.4s,v27.4s
         addp    v28.4s,v28.4s,v29.4s
         addp    v30.4s,v30.4s,v31.4s
-
         addp    v16.4s,v16.4s,v18.4s
         addp    v20.4s,v20.4s,v22.4s
         addp    v24.4s,v24.4s,v26.4s
         addp    v28.4s,v28.4s,v30.4s
-
-        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
+        dup     v8.4s,v0.s[0]              // broadcast row fixups
+        dup     v9.4s,v0.s[1]
+        dup     v10.4s,v0.s[2]
+        dup     v11.4s,v0.s[3]
         cbz     x9,.LGemmS8S8.M4.SkipScaleByZeroPointB
 
-        //
         // accumulator = zero point B * row sum A + column sum B
-        //
         ld1     {v30.4s},[x9],#16           // load ZeroPointB
         mul     v17.4s,v30.4s,v8.4s
         mul     v21.4s,v30.4s,v9.4s
@@ -263,9 +266,7 @@ Return Value:
         b .LGemmS8S8.M4.StoreOutput
 
 .LGemmS8S8.M4.SkipScaleByZeroPointB:
-        //
         // accumulator = row sum A + column sum B 
-        //
         add     v16.4s,v16.4s,v8.4s
         add     v20.4s,v20.4s,v9.4s
         add     v24.4s,v24.4s,v10.4s
@@ -279,7 +280,6 @@ Return Value:
         add     x10,x2,x6,lsl #2
         add     x11,x10,x6,lsl #2
         add     x12,x11,x6,lsl #2
-
         subs    x5,x5,#4                    // adjust CountN remaining
         blo     .LGemmS8S8.M4.StoreOutputPartial
         cbnz    x13,.LGemmS8S8.M4.SkipAccumulateOutput
@@ -369,102 +369,132 @@ Return Value:
 //
 // Column Sum v2.s[0] v2.s[4]
 // Each row sum replicated to all 4 elements of a vector register 
-// v8 v9
-//                    Col Sum   v2.s[0]   v2.s[1]   v2.s[2]   v2.s[1]
-//                                      B 16x4
-//                             /--------------------------------------\
-//                             |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
-//                             |  ...                          ...    |
-//                             |v4.b[15]  v5.b[15]  v6.b[15]  v7.b[15]|
-//          A 2x16             \--------------------------------------/
-//     /--------------------\  /--------------------------------------\
-// v8  |v0.b[0] ... v0.b[15]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
-// v9  |v0.b[0] ... v0.b[15]|  |v20.4s    v21.4s    v22.4s    v23.4s  |
-//     \--------------------/  \--------------------------------------/
+// v30 v31
+//                                            B 16x4
+//                                      ----------------------------------------
+//                                      |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
+//                                      |  ...      ...        ...      ...    |
+//                                      |v4.b[7]   v5.b[7]   v6.b[7]   v7.b[7] |
+//                                      |v24.b[0]  v25.b[0]  v26.b[0]  v27.b[0]|
+//                                      |  ...      ...       ...       ...    |
+//                                      |v24.b[7]  v25.b[7]  v26.b[7]  v27.b[7]|
+//            A 2x16                    ----------------------------------------
+// -----------------------------------  ----------------------------------------
+// |v0.b[0]..v0.b[7] v2.b[0]..v2.b[7]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
+// |v1.b[0]..v1.b[7] v3.b[0]..v3.b[7]|  |v20.4s    v21.4s    v22.4s    v23.4s  |
+// -----------------------------------  ----------------------------------------
 //
 // Accumulators are horizontally aggregated to the left most register
 // for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
 
+.LGemmS8S8.M2.ProcessLoop:
+
 .LGemmS8S8.M2.ProcessNextColumnLoop:
+        ldp     d4,d24,[x1],#16             // B
         mov     x0,x14                      // reload matrix A
         mov     x3,x15                      // reload PackedCountK
+        ldp     d0,d2,[x0],#16              // A0
         movi    v16.4s,#0
         movi    v17.4s,#0
+        ldp     d5,d25,[x1],#16
         movi    v18.4s,#0
         movi    v19.4s,#0
+        ldp     d6,d26,[x1],#16
         movi    v20.4s,#0
         movi    v21.4s,#0
+        ldp     d7,d27,[x1],#16
         movi    v22.4s,#0
         movi    v23.4s,#0
+        ldp     d1,d3,[x0],#16              // A1
 
 .LGemmS8S8.M2.ComputeBlockLoop:
-        ld1     {v4.16b},[x1],#16           // B
-        ld1     {v5.16b},[x1],#16
-        ld1     {v6.16b},[x1],#16
-        ld1     {v7.16b},[x1],#16
-
-        ld1     {v0.16b},[x0],#16           // A0
-        smull   v12.8h,v0.8b,v4.8b
-        smull   v13.8h,v0.8b,v5.8b
-        smull   v14.8h,v0.8b,v6.8b
-        smull   v15.8h,v0.8b,v7.8b
-        smlal2  v12.8h,v0.16b,v4.16b
-        smlal2  v13.8h,v0.16b,v5.16b
-        smlal2  v14.8h,v0.16b,v6.16b
-        smlal2  v15.8h,v0.16b,v7.16b
-        sadalp  v16.4s,v12.8h
-        sadalp  v17.4s,v13.8h
-        sadalp  v18.4s,v14.8h
-        sadalp  v19.4s,v15.8h
-
-        ld1     {v0.16b},[x0],#16           // A1
-        smull   v12.8h,v0.8b,v4.8b
-        smull   v13.8h,v0.8b,v5.8b
-        smull   v14.8h,v0.8b,v6.8b
-        smull   v15.8h,v0.8b,v7.8b
-        smlal2  v12.8h,v0.16b,v4.16b
-        smlal2  v13.8h,v0.16b,v5.16b
-        smlal2  v14.8h,v0.16b,v6.16b
-        smlal2  v15.8h,v0.16b,v7.16b
-        sadalp  v20.4s,v12.8h
-        sadalp  v21.4s,v13.8h
-        sadalp  v22.4s,v14.8h
-        sadalp  v23.4s,v15.8h
 
         sub     x3,x3,#1
-        cbnz    x3,.LGemmS8S8.M2.ComputeBlockLoop
+        smull   v28.8h,v0.8b,v4.8b
+        smull   v29.8h,v0.8b,v5.8b
+        smull   v30.8h,v0.8b,v6.8b
+        smull   v31.8h,v0.8b,v7.8b
+        cbz     x3,.LGemmS8S8.M2.ComputeBlockLoopFinish
+        smlal   v28.8h,v2.8b,v24.8b
+        smlal   v29.8h,v2.8b,v25.8b
+        smlal   v30.8h,v2.8b,v26.8b
+        smlal   v31.8h,v2.8b,v27.8b
+        ldp     d0,d2,[x0],#16              // A0
+        sadalp  v16.4s,v28.8h
+        sadalp  v17.4s,v29.8h
+        sadalp  v18.4s,v30.8h
+        sadalp  v19.4s,v31.8h
+        smull   v28.8h,v1.8b,v4.8b
+        smull   v29.8h,v1.8b,v5.8b
+        smull   v30.8h,v1.8b,v6.8b
+        smull   v31.8h,v1.8b,v7.8b
+        smlal   v28.8h,v3.8b,v24.8b
+        ldp     d4,d24,[x1],#16             // B
+        smlal   v29.8h,v3.8b,v25.8b
+        ldp     d5,d25,[x1],#16
+        smlal   v30.8h,v3.8b,v26.8b
+        ldp     d6,d26,[x1],#16
+        smlal   v31.8h,v3.8b,v27.8b
+        ldp     d7,d27,[x1],#16
+        sadalp  v20.4s,v28.8h
+        ldp     d1,d3,[x0],#16              // A1
+        sadalp  v21.4s,v29.8h
+        sadalp  v22.4s,v30.8h
+        sadalp  v23.4s,v31.8h
+        b       .LGemmS8S8.M2.ComputeBlockLoop
 
+.LGemmS8S8.M2.ComputeBlockLoopFinish:
+        ld1     {v0.4s},[x8],#16            // load ColumnSumBuffer[0]
+        smlal   v28.8h,v2.8b,v24.8b
+        smlal   v29.8h,v2.8b,v25.8b
+        smlal   v30.8h,v2.8b,v26.8b
+        smlal   v31.8h,v2.8b,v27.8b
+        ldr     d2,[x7]                     // load row sums
+        sadalp  v16.4s,v28.8h
+        sadalp  v17.4s,v29.8h
+        sadalp  v18.4s,v30.8h
+        sadalp  v19.4s,v31.8h
+        smull   v28.8h,v1.8b,v4.8b
+        smull   v29.8h,v1.8b,v5.8b
+        smull   v30.8h,v1.8b,v6.8b
+        smull   v31.8h,v1.8b,v7.8b
+        smlal   v28.8h,v3.8b,v24.8b
+        smlal   v29.8h,v3.8b,v25.8b
+        smlal   v30.8h,v3.8b,v26.8b
+        smlal   v31.8h,v3.8b,v27.8b
+        sadalp  v20.4s,v28.8h
+        sadalp  v21.4s,v29.8h
+        sadalp  v22.4s,v30.8h
+        sadalp  v23.4s,v31.8h
         addp    v16.4s,v16.4s,v17.4s
         addp    v18.4s,v18.4s,v19.4s
         addp    v20.4s,v20.4s,v21.4s
         addp    v22.4s,v22.4s,v23.4s
-
+        dup     v30.4s,v2.s[0]              // broadcast row fixups
+        dup     v31.4s,v2.s[1]              // broadcast row fixups
         addp    v16.4s,v16.4s,v18.4s
         addp    v20.4s,v20.4s,v22.4s
-
-        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
         cbz     x9,.LGemmS8S8.M2.SkipScaleByZeroPointB
 
         // accumulator = zero point B * row sum A + column sum B
-        ld1     {v30.4s},[x9],#16           // load ZeroPointB[0]
-        mul     v17.4s,v30.4s,v8.4s
-        mul     v21.4s,v30.4s,v9.4s
+        ld1     {v18.4s},[x9],#16           // load ZeroPointB[0]
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v0.4s
+        mul     v17.4s,v18.4s,v30.4s
+        mul     v21.4s,v18.4s,v31.4s
         add     v16.4s,v16.4s,v17.4s
         add     v20.4s,v20.4s,v21.4s
-        add     v16.4s,v16.4s,v2.4s
-        add     v20.4s,v20.4s,v2.4s
         b       .LGemmS8S8.M2.StoreOutput
 
 .LGemmS8S8.M2.SkipScaleByZeroPointB:
         // accumulator = row sum A + column sum B 
-        add     v16.4s,v16.4s,v8.4s
-        add     v20.4s,v20.4s,v9.4s
-        add     v16.4s,v16.4s,v2.4s
-        add     v20.4s,v20.4s,v2.4s
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v0.4s
+        add     v16.4s,v16.4s,v30.4s
+        add     v20.4s,v20.4s,v31.4s
 
 .LGemmS8S8.M2.StoreOutput:
         add     x10,x2,x6,lsl #2
-
         subs    x5,x5,#4                    // adjust CountN remaining
         blo     .LGemmS8S8.M2.StoreOutputPartial
         cbnz    x13,.LGemmS8S8.M2.SkipAccumulateOutput
@@ -528,70 +558,89 @@ Return Value:
 //
 // Column Sum v2.s[0] v2.s[4]
 // row sum replicated to all 4 elements of a vector register 
-// v8 
-//                    Col Sum   v2.s[0]   v2.s[1]   v2.s[2]   v2.s[1]
-//                                      B 16x4
-//                             /--------------------------------------\
-//                             |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
-//                             |  ...                          ...    |
-//                             |v4.b[15]  v5.b[15]  v6.b[15]  v7.b[15]|
-//          A 2x16             \--------------------------------------/
-//     /--------------------\  /--------------------------------------\
-// v8  |v0.b[0] ... v0.b[15]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
-//     \--------------------/  \--------------------------------------/
+// v31 
+//                                            B 16x4
+//                                      ----------------------------------------
+//                                      |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
+//                                      |  ...      ...        ...      ...    |
+//                                      |v4.b[7]   v5.b[7]   v6.b[7]   v7.b[7] |
+//                                      |v24.b[0]  v25.b[0]  v26.b[0]  v27.b[0]|
+//                                      |  ...      ...       ...       ...    |
+//                                      |v24.b[7]  v25.b[7]  v26.b[7]  v27.b[7]|
+//            A 1x16                    ----------------------------------------
+// -----------------------------------  ----------------------------------------
+// |v0.b[0]..v0.b[7] v2.b[0]..v2.b[7]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
+// -----------------------------------  ----------------------------------------
 //
 // Accumulators are horizontally aggregated to the left most register
 // for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
+//
+.LGemmS8S8.M1.ProcessLoop:
+        ldr     d31,[x7]
+        dup     v31.4s,v31.s[0]              // broadcast row fixups
 
 .LGemmS8S8.M1.ProcessNextColumnLoop:
+        ldp     d4,d24,[x1],#16             // B
+        ldp     d5,d25,[x1],#16
+        ldp     d6,d26,[x1],#16
+        ldp     d7,d27,[x1],#16
         mov     x0,x14                      // reload matrix A
         mov     x3,x15                      // reload PackedCountK
+        ldp     d0,d2,[x0],#16              // A0
         movi    v16.4s,#0
         movi    v17.4s,#0
         movi    v18.4s,#0
         movi    v19.4s,#0
 
 .LGemmS8S8.M1.ComputeBlockLoop:
-        ld1     {v4.16b},[x1],#16           // B
-        ld1     {v5.16b},[x1],#16
-        ld1     {v6.16b},[x1],#16
-        ld1     {v7.16b},[x1],#16
-
-        ld1     {v0.16b},[x0],#16           // A0
-        smull   v12.8h,v0.8b,v4.8b
-        smull   v13.8h,v0.8b,v5.8b
-        smull   v14.8h,v0.8b,v6.8b
-        smull   v15.8h,v0.8b,v7.8b
-        smlal2  v12.8h,v0.16b,v4.16b
-        smlal2  v13.8h,v0.16b,v5.16b
-        smlal2  v14.8h,v0.16b,v6.16b
-        smlal2  v15.8h,v0.16b,v7.16b
-        sadalp  v16.4s,v12.8h
-        sadalp  v17.4s,v13.8h
-        sadalp  v18.4s,v14.8h
-        sadalp  v19.4s,v15.8h
-
         sub     x3,x3,#1
-        cbnz    x3,.LGemmS8S8.M1.ComputeBlockLoop
+        smull   v20.8h,v0.8b,v4.8b
+        smull   v21.8h,v0.8b,v5.8b
+        cbz    x3,.LGemmS8S8.M1.ComputeBlockLoopFinish
+        smull   v22.8h,v0.8b,v6.8b
+        smull   v23.8h,v0.8b,v7.8b
+        smlal   v20.8h,v2.8b,v24.8b
+        ldp     d4,d24,[x1],#16             // B
+        smlal   v21.8h,v2.8b,v25.8b
+        ldp     d5,d25,[x1],#16
+        smlal   v22.8h,v2.8b,v26.8b
+        ldp     d6,d26,[x1],#16
+        smlal   v23.8h,v2.8b,v27.8b
+        ldp     d0,d2,[x0],#16              // A0
+        sadalp  v16.4s,v20.8h
+        sadalp  v17.4s,v21.8h
+        ldp     d7,d27,[x1],#16
+        sadalp  v18.4s,v22.8h
+        sadalp  v19.4s,v23.8h
+        b       .LGemmS8S8.M1.ComputeBlockLoop
 
+.LGemmS8S8.M1.ComputeBlockLoopFinish:
+        ld1     {v4.4s},[x8],#16            // load ColumnSumBuffer[0]
+        smull   v22.8h,v0.8b,v6.8b
+        smull   v23.8h,v0.8b,v7.8b
+        smlal   v20.8h,v2.8b,v24.8b
+        smlal   v21.8h,v2.8b,v25.8b
+        smlal   v22.8h,v2.8b,v26.8b
+        smlal   v23.8h,v2.8b,v27.8b
+        sadalp  v16.4s,v20.8h
+        sadalp  v17.4s,v21.8h
+        sadalp  v18.4s,v22.8h
+        sadalp  v19.4s,v23.8h
         addp    v16.4s,v16.4s,v17.4s
         addp    v18.4s,v18.4s,v19.4s
-
         addp    v16.4s,v16.4s,v18.4s
-
-        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
         cbz     x9,.LGemmS8S8.M1.SkipScaleByZeroPointB
 
         // accumulator = zero point B * row sum A + column sum B
         ld1     {v30.4s},[x9],#16           // load ZeroPointB[0]
-        mul     v17.4s,v30.4s,v8.4s
+        mul     v17.4s,v30.4s,v31.4s
         add     v16.4s,v16.4s,v17.4s
-        add     v16.4s,v16.4s,v2.4s
+        add     v16.4s,v16.4s,v4.4s
         b       .LGemmS8S8.M1.StoreOutput
 .LGemmS8S8.M1.SkipScaleByZeroPointB:
         // accumulator = row sum A + column sum B
-        add     v16.4s,v16.4s,v8.4s
-        add     v16.4s,v16.4s,v2.4s
+        add     v16.4s,v16.4s,v31.4s
+        add     v16.4s,v16.4s,v4.4s
 
 .LGemmS8S8.M1.StoreOutput:
         subs    x5,x5,#4                    // adjust CountN remaining

--- a/onnxruntime/core/mlas/lib/aarch64/QgemmS8S8KernelNeon.S
+++ b/onnxruntime/core/mlas/lib/aarch64/QgemmS8S8KernelNeon.S
@@ -1,0 +1,534 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    QgemmS8S8KernelNeon.s
+
+Abstract:
+
+    This module implements the kernels for the quantized integer matrix/matrix
+    multiply operation (QGEMM).
+
+--*/
+
+#include "asmmacro.h"
+
+//
+// Stack frame layout for the S8S8 kernel.
+//
+
+        .equ    .LGemmS8S8KernelFrame_SavedNeonRegisters, (4 * 8)
+        .equ    .LGemmS8S8KernelFrame_SavedRegisters, .LGemmS8S8KernelFrame_SavedNeonRegisters
+        .equ    .LGemmS8S8KernelFrame_ColumnSumBuffer, 0 + .LGemmS8S8KernelFrame_SavedRegisters
+        .equ    .LGemmS8S8KernelFrame_ZeroPointB, 8 + .LGemmS8S8KernelFrame_SavedRegisters
+        .equ    .LGemmS8S8KernelFrame_ZeroMode, 16 + .LGemmS8S8KernelFrame_SavedRegisters
+
+        .text
+
+/*++
+
+Routine Description:
+
+    This routine is an inner kernel to compute matrix multiplication for a
+    set of rows.
+
+Arguments:
+
+    A (x0) - Supplies the address of matrix A. The matrix data has been packed
+        using MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>.
+
+    B (x1) - Supplies the address of matrix B. The matrix data has been packed
+        using MlasGemmU8X8CopyPackB<MLAS_GEMM_S8S8_KERNEL_NEON>.
+
+    C (x2) - Supplies the address of matrix C.
+
+    PackedCountK (x3) - Supplies the number of packed columns from matrix A and
+        the number of packed rows from matrix B to iterate over.
+
+    CountM (x4) - Supplies the maximum number of rows that can be processed for
+        matrix A and matrix C. The actual number of rows handled for this
+        invocation depends on the kernel implementation.
+
+    CountN (x5) - Supplies the number of columns from matrix B and matrix C to
+        iterate over.
+
+    ldc (x6) - Supplies the first dimension of matrix C.
+
+    RowSumBuffer (x7) - Supplies the sum of each row from matrix A. These values
+        have been pre-scaled by the zero point offset of matrix B if the offset
+        is per-tensor (ZeroPointB is nullptr). Otherwise, these values must be
+        scaled by the per-column zero point offsets of matrix B. These values are
+        accumulated into every row of matrix C.
+
+    ColumnSumBuffer - Supplies the sum of each column from matrix B multiplied
+        by the zero point offset of matrix A. These values are accumulated into
+        every column of matrix C.
+
+    ZeroPointB - Optionally supplies the per-column zero point offsets of matrix
+        B, else nullptr if the matrix B is using per-tensor quantization.
+
+    ZeroMode - Supplies true if the output matrix must be zero initialized, else
+        false if the output matrix is accumulated into.
+
+Return Value:
+
+    Returns the number of rows handled.
+
+--*/
+
+        FUNCTION_ENTRY MlasGemmS8S8KernelNeon
+
+        stp     d8,d9,[sp,#-32]!
+        stp     d10,d11,[sp,#16]
+        ldr     x8,[sp,#.LGemmS8S8KernelFrame_ColumnSumBuffer]
+        ldr     x9,[sp,#.LGemmS8S8KernelFrame_ZeroPointB]
+        ldrb    w13,[sp,#.LGemmS8S8KernelFrame_ZeroMode]
+        mov     x14,x0
+        ld1     {v11.4s},[x7]
+        mov     x15,x3
+        dup     v8.4s,v11.s[0]             // broadcast row fixups
+        cmp     x4,#1                       // CountM == 1?
+        beq     .LGemmS8S8.M1.ProcessNextColumnLoop
+        dup     v9.4s,v11.s[1]
+        cmp     x4,#4                       // CountM < 4?
+        blo     .LGemmS8S8.M2.ProcessNextColumnLoop
+        dup     v10.4s,v11.s[2]
+        dup     v11.4s,v11.s[3]
+
+//
+// Process 4 rows of the matrices.
+//
+
+.LGemmS8S8.M4.ProcessNextColumnLoop:
+        mov     x0,x14                      // reload matrix A
+        mov     x3,x15                      // reload PackedCountK
+        ldr     q0,[x0],#64                 // A0
+        movi    v16.4s,#0
+        movi    v17.4s,#0
+        ldr     q4,[x1],#64                 // B
+        movi    v18.4s,#0
+        movi    v19.4s,#0
+        ldr     q5,[x1,#-48]
+        movi    v20.4s,#0
+        movi    v21.4s,#0
+        ldr     q6,[x1,#-32]
+        movi    v22.4s,#0
+        movi    v23.4s,#0
+        ldr     q7,[x1,#-16]
+        movi    v24.4s,#0
+        movi    v25.4s,#0
+        movi    v26.4s,#0
+        movi    v27.4s,#0
+        movi    v28.4s,#0
+        movi    v29.4s,#0
+        movi    v30.4s,#0
+        movi    v31.4s,#0
+
+.LGemmS8S8.M4.ComputeBlockLoop:
+        ldr     q1,[x0,#-48]
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        smlal2  v12.8h,v0.16b,v4.16b
+        smlal2  v13.8h,v0.16b,v5.16b
+        smlal2  v14.8h,v0.16b,v6.16b
+        smlal2  v15.8h,v0.16b,v7.16b
+        sadalp  v16.4s,v12.8h
+        sadalp  v17.4s,v13.8h
+        sadalp  v18.4s,v14.8h
+        sadalp  v19.4s,v15.8h
+        ldr     q0,[x0,#-32]
+        smull   v12.8h,v1.8b,v4.8b
+        smull   v13.8h,v1.8b,v5.8b
+        smull   v14.8h,v1.8b,v6.8b
+        smull   v15.8h,v1.8b,v7.8b
+        smlal2  v12.8h,v1.16b,v4.16b
+        smlal2  v13.8h,v1.16b,v5.16b
+        smlal2  v14.8h,v1.16b,v6.16b
+        smlal2  v15.8h,v1.16b,v7.16b
+        sadalp  v20.4s,v12.8h
+        sadalp  v21.4s,v13.8h
+        sadalp  v22.4s,v14.8h
+        sadalp  v23.4s,v15.8h
+        ldr     q1,[x0,#-16]
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        smlal2  v12.8h,v0.16b,v4.16b
+        smlal2  v13.8h,v0.16b,v5.16b
+        smlal2  v14.8h,v0.16b,v6.16b
+        smlal2  v15.8h,v0.16b,v7.16b
+        sadalp  v24.4s,v12.8h
+        sadalp  v25.4s,v13.8h
+        sadalp  v26.4s,v14.8h
+        sadalp  v27.4s,v15.8h
+
+        sub     x3,x3,#1
+        cbz     x3,.LGemmS8S8.M4.ComputeBlockLoopFinish
+
+        ldr     q0,[x0],#64
+        smull   v12.8h,v1.8b,v4.8b
+        smull   v13.8h,v1.8b,v5.8b
+        smull   v14.8h,v1.8b,v6.8b
+        smull   v15.8h,v1.8b,v7.8b
+        smlal2  v12.8h,v1.16b,v4.16b
+        smlal2  v13.8h,v1.16b,v5.16b
+        ldr     q4,[x1],#64                 // B
+        smlal2  v14.8h,v1.16b,v6.16b
+        smlal2  v15.8h,v1.16b,v7.16b
+        ldr     q5,[x1,#-48]
+        sadalp  v28.4s,v12.8h
+        ldr     q6,[x1,#-32]
+        sadalp  v29.4s,v13.8h
+        ldr     q7,[x1,#-16]
+        sadalp  v30.4s,v14.8h
+        sadalp  v31.4s,v15.8h
+        b       .LGemmS8S8.M4.ComputeBlockLoop
+
+.LGemmS8S8.M4.ComputeBlockLoopFinish:
+
+        smull   v12.8h,v1.8b,v4.8b
+        smull   v13.8h,v1.8b,v5.8b
+        smull   v14.8h,v1.8b,v6.8b
+        smull   v15.8h,v1.8b,v7.8b
+        smlal2  v12.8h,v1.16b,v4.16b
+        smlal2  v13.8h,v1.16b,v5.16b
+        smlal2  v14.8h,v1.16b,v6.16b
+        smlal2  v15.8h,v1.16b,v7.16b
+        sadalp  v28.4s,v12.8h
+        sadalp  v29.4s,v13.8h
+        sadalp  v30.4s,v14.8h
+        sadalp  v31.4s,v15.8h
+
+        addp    v16.4s,v16.4s,v17.4s
+        addp    v18.4s,v18.4s,v19.4s
+        addp    v20.4s,v20.4s,v21.4s
+        addp    v22.4s,v22.4s,v23.4s
+        addp    v24.4s,v24.4s,v25.4s
+        addp    v26.4s,v26.4s,v27.4s
+        addp    v28.4s,v28.4s,v29.4s
+        addp    v30.4s,v30.4s,v31.4s
+
+        addp    v16.4s,v16.4s,v18.4s
+        addp    v20.4s,v20.4s,v22.4s
+        addp    v24.4s,v24.4s,v26.4s
+        addp    v28.4s,v28.4s,v30.4s
+
+        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
+
+        add     v16.4s,v16.4s,v8.4s
+        add     v20.4s,v20.4s,v9.4s
+        add     v24.4s,v24.4s,v10.4s
+        add     v28.4s,v28.4s,v11.4s
+        add     v16.4s,v16.4s,v2.4s
+        add     v20.4s,v20.4s,v2.4s
+        add     v24.4s,v24.4s,v2.4s
+        add     v28.4s,v28.4s,v2.4s
+
+        add     x10,x2,x6,lsl #2
+        add     x11,x10,x6,lsl #2
+        add     x12,x11,x6,lsl #2
+
+        subs    x5,x5,#4                    // adjust CountN remaining
+        blo     .LGemmS8S8.M4.StoreOutputPartial
+        cbnz    x13,.LGemmS8S8.M4.SkipAccumulateOutput
+        ld1     {v0.4s},[x2]
+        ld1     {v1.4s},[x10]
+        ld1     {v2.4s},[x11]
+        ld1     {v3.4s},[x12]
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v1.4s
+        add     v24.4s,v24.4s,v2.4s
+        add     v28.4s,v28.4s,v3.4s
+
+.LGemmS8S8.M4.SkipAccumulateOutput:
+        st1     {v16.4s},[x2],#16
+        st1     {v20.4s},[x10]
+        st1     {v24.4s},[x11]
+        st1     {v28.4s},[x12]
+        cbnz    x5,.LGemmS8S8.M4.ProcessNextColumnLoop
+
+.LGemmS8S8.M4.ExitKernel:
+        mov     x0,#4                       // return number of rows handled
+        ldp     d10,d11,[sp,#16]
+        ldp     d8,d9,[sp],#32
+        ret
+
+.LGemmS8S8.M4.StoreOutputPartial:
+        cbz     x13,.LGemmS8S8.M4.StoreOutputPartial.AddMode
+
+.LGemmS8S8.M4.StoreOutputPartial.ZeroMode:
+        tbz     x5,#1,.LGemmS8S8.M4.StoreOutputPartial1.ZeroMode
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+        st1     {v20.2s},[x10],#8
+        dup     v20.4s,v20.s[2]
+        st1     {v24.2s},[x11],#8
+        dup     v24.4s,v24.s[2]
+        st1     {v28.2s},[x12],#8
+        dup     v28.4s,v28.s[2]
+
+.LGemmS8S8.M4.StoreOutputPartial1.ZeroMode:
+        tbz     x5,#0,.LGemmS8S8.M4.ExitKernel
+        st1     {v16.s}[0],[x2]
+        st1     {v20.s}[0],[x10]
+        st1     {v24.s}[0],[x11]
+        st1     {v28.s}[0],[x12]
+        b       .LGemmS8S8.M4.ExitKernel
+
+.LGemmS8S8.M4.StoreOutputPartial.AddMode:
+        tbz     x5,#1,.LGemmS8S8.M4.StoreOutputPartial1.AddMode
+        ld1     {v0.2s},[x2]
+        ld1     {v1.2s},[x10]
+        ld1     {v2.2s},[x11]
+        ld1     {v3.2s},[x12]
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v1.4s
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+        st1     {v20.2s},[x10],#8
+        dup     v20.4s,v20.s[2]
+        add     v24.4s,v24.4s,v2.4s
+        add     v28.4s,v28.4s,v3.4s
+        st1     {v24.2s},[x11],#8
+        dup     v24.4s,v24.s[2]
+        st1     {v28.2s},[x12],#8
+        dup     v28.4s,v28.s[2]
+
+.LGemmS8S8.M4.StoreOutputPartial1.AddMode:
+        tbz     x5,#0,.LGemmS8S8.M4.ExitKernel
+        ld1     {v0.s}[0],[x2]
+        ld1     {v1.s}[0],[x10]
+        add     v16.4s,v16.4s,v0.4s
+        ld1     {v2.s}[0],[x11]
+        add     v20.4s,v20.4s,v1.4s
+        ld1     {v3.s}[0],[x12]
+        add     v24.4s,v24.4s,v2.4s
+        st1     {v16.s}[0],[x2]
+        st1     {v20.s}[0],[x10]
+        add     v28.4s,v28.4s,v3.4s
+        st1     {v24.s}[0],[x11]
+        st1     {v28.s}[0],[x12]
+        b       .LGemmS8S8.M4.ExitKernel
+
+//
+// Process 2 rows of the matrices.
+//
+
+.LGemmS8S8.M2.ProcessNextColumnLoop:
+        mov     x0,x14                      // reload matrix A
+        mov     x3,x15                      // reload PackedCountK
+        movi    v16.4s,#0
+        movi    v17.4s,#0
+        movi    v18.4s,#0
+        movi    v19.4s,#0
+        movi    v20.4s,#0
+        movi    v21.4s,#0
+        movi    v22.4s,#0
+        movi    v23.4s,#0
+
+.LGemmS8S8.M2.ComputeBlockLoop:
+        ld1     {v4.16b},[x1],#16           // B
+        ld1     {v5.16b},[x1],#16
+        ld1     {v6.16b},[x1],#16
+        ld1     {v7.16b},[x1],#16
+
+        ld1     {v0.16b},[x0],#16           // A0
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        smlal2  v12.8h,v0.16b,v4.16b
+        smlal2  v13.8h,v0.16b,v5.16b
+        smlal2  v14.8h,v0.16b,v6.16b
+        smlal2  v15.8h,v0.16b,v7.16b
+        sadalp  v16.4s,v12.8h
+        sadalp  v17.4s,v13.8h
+        sadalp  v18.4s,v14.8h
+        sadalp  v19.4s,v15.8h
+
+        ld1     {v0.16b},[x0],#16           // A1
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        smlal2  v12.8h,v0.16b,v4.16b
+        smlal2  v13.8h,v0.16b,v5.16b
+        smlal2  v14.8h,v0.16b,v6.16b
+        smlal2  v15.8h,v0.16b,v7.16b
+        sadalp  v20.4s,v12.8h
+        sadalp  v21.4s,v13.8h
+        sadalp  v22.4s,v14.8h
+        sadalp  v23.4s,v15.8h
+
+        sub     x3,x3,#1
+        cbnz    x3,.LGemmS8S8.M2.ComputeBlockLoop
+
+        addp    v16.4s,v16.4s,v17.4s
+        addp    v18.4s,v18.4s,v19.4s
+        addp    v20.4s,v20.4s,v21.4s
+        addp    v22.4s,v22.4s,v23.4s
+
+        addp    v16.4s,v16.4s,v18.4s
+        addp    v20.4s,v20.4s,v22.4s
+
+        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
+
+        add     v16.4s,v16.4s,v8.4s
+        add     v20.4s,v20.4s,v9.4s
+        add     v16.4s,v16.4s,v2.4s
+        add     v20.4s,v20.4s,v2.4s
+
+        add     x10,x2,x6,lsl #2
+
+        subs    x5,x5,#4                    // adjust CountN remaining
+        blo     .LGemmS8S8.M2.StoreOutputPartial
+        cbnz    x13,.LGemmS8S8.M2.SkipAccumulateOutput
+        ld1     {v0.4s},[x2]
+        ld1     {v1.4s},[x10]
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v1.4s
+
+.LGemmS8S8.M2.SkipAccumulateOutput:
+        st1     {v16.4s},[x2],#16
+        st1     {v20.4s},[x10]
+        cbnz    x5,.LGemmS8S8.M2.ProcessNextColumnLoop
+
+.LGemmS8S8.M2.ExitKernel:
+        mov     x0,#2                       // return number of rows handled
+        ldp     d10,d11,[sp,#16]
+        ldp     d8,d9,[sp],#32
+        ret
+
+.LGemmS8S8.M2.StoreOutputPartial:
+        cbz     x13,.LGemmS8S8.M2.StoreOutputPartial.AddMode
+
+.LGemmS8S8.M2.StoreOutputPartial.ZeroMode:
+        tbz     x5,#1,.LGemmS8S8.M2.StoreOutputPartial1.ZeroMode
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+        st1     {v20.2s},[x10],#8
+        dup     v20.4s,v20.s[2]
+
+.LGemmS8S8.M2.StoreOutputPartial1.ZeroMode:
+        tbz     x5,#0,.LGemmS8S8.M2.ExitKernel
+        st1     {v16.s}[0],[x2]
+        st1     {v20.s}[0],[x10]
+        b       .LGemmS8S8.M2.ExitKernel
+
+.LGemmS8S8.M2.StoreOutputPartial.AddMode:
+        tbz     x5,#1,.LGemmS8S8.M2.StoreOutputPartial1.AddMode
+        ld1     {v0.2s},[x2]
+        ld1     {v1.2s},[x10]
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v1.4s
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+        st1     {v20.2s},[x10],#8
+        dup     v20.4s,v20.s[2]
+
+.LGemmS8S8.M2.StoreOutputPartial1.AddMode:
+        tbz     x5,#0,.LGemmS8S8.M2.ExitKernel
+        ld1     {v0.s}[0],[x2]
+        ld1     {v1.s}[0],[x10]
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v1.4s
+        st1     {v16.s}[0],[x2]
+        st1     {v20.s}[0],[x10]
+        b       .LGemmS8S8.M2.ExitKernel
+
+//
+// Process 1 row of the matrices.
+//
+
+.LGemmS8S8.M1.ProcessNextColumnLoop:
+        mov     x0,x14                      // reload matrix A
+        mov     x3,x15                      // reload PackedCountK
+        movi    v16.4s,#0
+        movi    v17.4s,#0
+        movi    v18.4s,#0
+        movi    v19.4s,#0
+
+.LGemmS8S8.M1.ComputeBlockLoop:
+        ld1     {v4.16b},[x1],#16           // B
+        ld1     {v5.16b},[x1],#16
+        ld1     {v6.16b},[x1],#16
+        ld1     {v7.16b},[x1],#16
+
+        ld1     {v0.16b},[x0],#16           // A0
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        smlal2  v12.8h,v0.16b,v4.16b
+        smlal2  v13.8h,v0.16b,v5.16b
+        smlal2  v14.8h,v0.16b,v6.16b
+        smlal2  v15.8h,v0.16b,v7.16b
+        sadalp  v16.4s,v12.8h
+        sadalp  v17.4s,v13.8h
+        sadalp  v18.4s,v14.8h
+        sadalp  v19.4s,v15.8h
+
+        sub     x3,x3,#1
+        cbnz    x3,.LGemmS8S8.M1.ComputeBlockLoop
+
+        addp    v16.4s,v16.4s,v17.4s
+        addp    v18.4s,v18.4s,v19.4s
+
+        addp    v16.4s,v16.4s,v18.4s
+
+        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
+
+        add     v16.4s,v16.4s,v8.4s
+        add     v16.4s,v16.4s,v2.4s
+
+        subs    x5,x5,#4                    // adjust CountN remaining
+        blo     .LGemmS8S8.M1.StoreOutputPartial
+        cbnz    x13,.LGemmS8S8.M1.SkipAccumulateOutput
+        ld1     {v0.4s},[x2]
+        add     v16.4s,v16.4s,v0.4s
+
+.LGemmS8S8.M1.SkipAccumulateOutput:
+        st1     {v16.4s},[x2],#16
+        cbnz    x5,.LGemmS8S8.M1.ProcessNextColumnLoop
+
+.LGemmS8S8.M1.ExitKernel:
+        mov     x0,#1                       // return number of rows handled
+        ldp     d10,d11,[sp,#16]
+        ldp     d8,d9,[sp],#32
+        ret
+
+.LGemmS8S8.M1.StoreOutputPartial:
+        cbz     x13,.LGemmS8S8.M1.StoreOutputPartial.AddMode
+
+.LGemmS8S8.M1.StoreOutputPartial.ZeroMode:
+        tbz     x5,#1,.LGemmS8S8.M1.StoreOutputPartial1.ZeroMode
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+
+.LGemmS8S8.M1.StoreOutputPartial1.ZeroMode:
+        tbz     x5,#0,.LGemmS8S8.M1.ExitKernel
+        st1     {v16.s}[0],[x2]
+        b       .LGemmS8S8.M1.ExitKernel
+
+.LGemmS8S8.M1.StoreOutputPartial.AddMode:
+        tbz     x5,#1,.LGemmS8S8.M1.StoreOutputPartial1.AddMode
+        ld1     {v0.2s},[x2]
+        add     v16.4s,v16.4s,v0.4s
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+
+.LGemmS8S8.M1.StoreOutputPartial1.AddMode:
+        tbz     x5,#0,.LGemmS8S8.M1.ExitKernel
+        ld1     {v0.s}[0],[x2]
+        add     v16.4s,v16.4s,v0.4s
+        st1     {v16.s}[0],[x2]
+        b       .LGemmS8S8.M1.ExitKernel
+
+        .end

--- a/onnxruntime/core/mlas/lib/aarch64/QgemmS8S8KernelNeon.S
+++ b/onnxruntime/core/mlas/lib/aarch64/QgemmS8S8KernelNeon.S
@@ -21,7 +21,7 @@ Abstract:
 // Stack frame layout for the S8S8 kernel.
 //
 
-        .equ    .LGemmS8S8KernelFrame_SavedNeonRegisters, (4 * 8)
+        .equ    .LGemmS8S8KernelFrame_SavedNeonRegisters, (8 * 8)
         .equ    .LGemmS8S8KernelFrame_SavedRegisters, .LGemmS8S8KernelFrame_SavedNeonRegisters
         .equ    .LGemmS8S8KernelFrame_ColumnSumBuffer, 0 + .LGemmS8S8KernelFrame_SavedRegisters
         .equ    .LGemmS8S8KernelFrame_ZeroPointB, 8 + .LGemmS8S8KernelFrame_SavedRegisters
@@ -82,15 +82,17 @@ Return Value:
 
         FUNCTION_ENTRY MlasGemmS8S8KernelNeon
 
-        stp     d8,d9,[sp,#-32]!
+        stp     d8,d9,[sp,#-64]!
         stp     d10,d11,[sp,#16]
+        stp     d12,d13,[sp,#32]
+        stp     d14,d15,[sp,#48]
         ldr     x8,[sp,#.LGemmS8S8KernelFrame_ColumnSumBuffer]
         ldr     x9,[sp,#.LGemmS8S8KernelFrame_ZeroPointB]
         ldrb    w13,[sp,#.LGemmS8S8KernelFrame_ZeroMode]
         mov     x14,x0
         ld1     {v11.4s},[x7]
         mov     x15,x3
-        dup     v8.4s,v11.s[0]             // broadcast row fixups
+        dup     v8.4s,v11.s[0]              // broadcast row fixups
         cmp     x4,#1                       // CountM == 1?
         beq     .LGemmS8S8.M1.ProcessNextColumnLoop
         dup     v9.4s,v11.s[1]
@@ -102,6 +104,25 @@ Return Value:
 //
 // Process 4 rows of the matrices.
 //
+// Column Sum v2.s[0] v2.s[4]
+// Each row sum replicated to all 4 elements of a vector register 
+// v8 ~ v11
+//                    Col Sum   v2.s[0]   v2.s[1]   v2.s[2]   v2.s[1]
+//                                      B 16x4
+//                             /--------------------------------------\
+//                             |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
+//                             |  ...                          ...    |
+//                             |v4.b[15]  v5.b[15]  v6.b[15]  v7.b[15]|
+//          A 4x16             \--------------------------------------/
+//     /--------------------\  /--------------------------------------\
+// v8  |v0.b[0] ... v0.b[15]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
+// v9  |v1.b[0] ... v1.b[15]|  |v20.4s    v21.4s    v22.4s    v23.4s  |
+// v10 |v0.b[0] ... v0.b[15]|  |v24.4s    v25.4s    v26.4s    v27.4s  |
+// v11 |v1.b[0] ... v1.b[15]|  |v28.4s    v29.4s    v30.4s    v31.4s  |
+//     \--------------------/  \--------------------------------------/
+//
+// Accumulators are horizontally aggregated to the left most register
+// for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
 
 .LGemmS8S8.M4.ProcessNextColumnLoop:
         mov     x0,x14                      // reload matrix A
@@ -221,7 +242,30 @@ Return Value:
         addp    v28.4s,v28.4s,v30.4s
 
         ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
+        cbz     x9,.LGemmS8S8.M4.SkipScaleByZeroPointB
 
+        //
+        // accumulator = zero point B * row sum A + column sum B
+        //
+        ld1     {v30.4s},[x9],#16           // load ZeroPointB
+        mul     v17.4s,v30.4s,v8.4s
+        mul     v21.4s,v30.4s,v9.4s
+        mul     v25.4s,v30.4s,v10.4s
+        mul     v29.4s,v30.4s,v11.4s
+        add     v16.4s,v16.4s,v17.4s
+        add     v20.4s,v20.4s,v21.4s
+        add     v24.4s,v24.4s,v25.4s
+        add     v28.4s,v28.4s,v29.4s
+        add     v16.4s,v16.4s,v2.4s
+        add     v20.4s,v20.4s,v2.4s
+        add     v24.4s,v24.4s,v2.4s
+        add     v28.4s,v28.4s,v2.4s
+        b .LGemmS8S8.M4.StoreOutput
+
+.LGemmS8S8.M4.SkipScaleByZeroPointB:
+        //
+        // accumulator = row sum A + column sum B 
+        //
         add     v16.4s,v16.4s,v8.4s
         add     v20.4s,v20.4s,v9.4s
         add     v24.4s,v24.4s,v10.4s
@@ -231,6 +275,7 @@ Return Value:
         add     v24.4s,v24.4s,v2.4s
         add     v28.4s,v28.4s,v2.4s
 
+.LGemmS8S8.M4.StoreOutput:
         add     x10,x2,x6,lsl #2
         add     x11,x10,x6,lsl #2
         add     x12,x11,x6,lsl #2
@@ -256,8 +301,10 @@ Return Value:
 
 .LGemmS8S8.M4.ExitKernel:
         mov     x0,#4                       // return number of rows handled
+        ldp     d14,d15,[sp,#48]
+        ldp     d12,d13,[sp,#32]
         ldp     d10,d11,[sp,#16]
-        ldp     d8,d9,[sp],#32
+        ldp     d8,d9,[sp],#64
         ret
 
 .LGemmS8S8.M4.StoreOutputPartial:
@@ -320,6 +367,23 @@ Return Value:
 //
 // Process 2 rows of the matrices.
 //
+// Column Sum v2.s[0] v2.s[4]
+// Each row sum replicated to all 4 elements of a vector register 
+// v8 v9
+//                    Col Sum   v2.s[0]   v2.s[1]   v2.s[2]   v2.s[1]
+//                                      B 16x4
+//                             /--------------------------------------\
+//                             |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
+//                             |  ...                          ...    |
+//                             |v4.b[15]  v5.b[15]  v6.b[15]  v7.b[15]|
+//          A 2x16             \--------------------------------------/
+//     /--------------------\  /--------------------------------------\
+// v8  |v0.b[0] ... v0.b[15]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
+// v9  |v0.b[0] ... v0.b[15]|  |v20.4s    v21.4s    v22.4s    v23.4s  |
+//     \--------------------/  \--------------------------------------/
+//
+// Accumulators are horizontally aggregated to the left most register
+// for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
 
 .LGemmS8S8.M2.ProcessNextColumnLoop:
         mov     x0,x14                      // reload matrix A
@@ -379,12 +443,26 @@ Return Value:
         addp    v20.4s,v20.4s,v22.4s
 
         ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
+        cbz     x9,.LGemmS8S8.M2.SkipScaleByZeroPointB
 
+        // accumulator = zero point B * row sum A + column sum B
+        ld1     {v30.4s},[x9],#16           // load ZeroPointB[0]
+        mul     v17.4s,v30.4s,v8.4s
+        mul     v21.4s,v30.4s,v9.4s
+        add     v16.4s,v16.4s,v17.4s
+        add     v20.4s,v20.4s,v21.4s
+        add     v16.4s,v16.4s,v2.4s
+        add     v20.4s,v20.4s,v2.4s
+        b       .LGemmS8S8.M2.StoreOutput
+
+.LGemmS8S8.M2.SkipScaleByZeroPointB:
+        // accumulator = row sum A + column sum B 
         add     v16.4s,v16.4s,v8.4s
         add     v20.4s,v20.4s,v9.4s
         add     v16.4s,v16.4s,v2.4s
         add     v20.4s,v20.4s,v2.4s
 
+.LGemmS8S8.M2.StoreOutput:
         add     x10,x2,x6,lsl #2
 
         subs    x5,x5,#4                    // adjust CountN remaining
@@ -402,8 +480,10 @@ Return Value:
 
 .LGemmS8S8.M2.ExitKernel:
         mov     x0,#2                       // return number of rows handled
+        ldp     d14,d15,[sp,#48]
+        ldp     d12,d13,[sp,#32]
         ldp     d10,d11,[sp,#16]
-        ldp     d8,d9,[sp],#32
+        ldp     d8,d9,[sp],#64
         ret
 
 .LGemmS8S8.M2.StoreOutputPartial:
@@ -446,6 +526,22 @@ Return Value:
 //
 // Process 1 row of the matrices.
 //
+// Column Sum v2.s[0] v2.s[4]
+// row sum replicated to all 4 elements of a vector register 
+// v8 
+//                    Col Sum   v2.s[0]   v2.s[1]   v2.s[2]   v2.s[1]
+//                                      B 16x4
+//                             /--------------------------------------\
+//                             |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
+//                             |  ...                          ...    |
+//                             |v4.b[15]  v5.b[15]  v6.b[15]  v7.b[15]|
+//          A 2x16             \--------------------------------------/
+//     /--------------------\  /--------------------------------------\
+// v8  |v0.b[0] ... v0.b[15]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
+//     \--------------------/  \--------------------------------------/
+//
+// Accumulators are horizontally aggregated to the left most register
+// for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
 
 .LGemmS8S8.M1.ProcessNextColumnLoop:
         mov     x0,x14                      // reload matrix A
@@ -484,10 +580,20 @@ Return Value:
         addp    v16.4s,v16.4s,v18.4s
 
         ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
+        cbz     x9,.LGemmS8S8.M1.SkipScaleByZeroPointB
 
+        // accumulator = zero point B * row sum A + column sum B
+        ld1     {v30.4s},[x9],#16           // load ZeroPointB[0]
+        mul     v17.4s,v30.4s,v8.4s
+        add     v16.4s,v16.4s,v17.4s
+        add     v16.4s,v16.4s,v2.4s
+        b       .LGemmS8S8.M1.StoreOutput
+.LGemmS8S8.M1.SkipScaleByZeroPointB:
+        // accumulator = row sum A + column sum B
         add     v16.4s,v16.4s,v8.4s
         add     v16.4s,v16.4s,v2.4s
 
+.LGemmS8S8.M1.StoreOutput:
         subs    x5,x5,#4                    // adjust CountN remaining
         blo     .LGemmS8S8.M1.StoreOutputPartial
         cbnz    x13,.LGemmS8S8.M1.SkipAccumulateOutput
@@ -500,8 +606,10 @@ Return Value:
 
 .LGemmS8S8.M1.ExitKernel:
         mov     x0,#1                       // return number of rows handled
+        ldp     d14,d15,[sp,#48]
+        ldp     d12,d13,[sp,#32]
         ldp     d10,d11,[sp,#16]
-        ldp     d8,d9,[sp],#32
+        ldp     d8,d9,[sp],#64
         ret
 
 .LGemmS8S8.M1.StoreOutputPartial:

--- a/onnxruntime/core/mlas/lib/arm64/QgemmS8S8KernelNeon.asm
+++ b/onnxruntime/core/mlas/lib/arm64/QgemmS8S8KernelNeon.asm
@@ -90,36 +90,31 @@ Return Value:
         ldr     x9,[sp,#GemmS8S8KernelFrame_ZeroPointB]
         ldrb    w13,[sp,#GemmS8S8KernelFrame_ZeroMode]
         mov     x14,x0
-        ld1     {v11.4s},[x7]
         mov     x15,x3
-        dup     v8.4s,v11.s[0]              // broadcast row fixups
         cmp     x4,#1                       // CountM == 1?
-        beq     GemmS8S8_M1_ProcessNextColumnLoop
-        dup     v9.4s,v11.s[1]
+        beq     GemmS8S8_M1_ProcessLoop
         cmp     x4,#4                       // CountM < 4?
-        blo     GemmS8S8_M2_ProcessNextColumnLoop
-        dup     v10.4s,v11.s[2]
-        dup     v11.4s,v11.s[3]
+        blo     GemmS8S8_M2_ProcessLoop
 
 //
 // Process 4 rows of the matrices.
 //
-// Column Sum v2.s[0] v2.s[4]
-// Each row sum replicated to all 4 elements of a vector register 
-// v8 ~ v11
-//                    Col Sum   v2.s[0]   v2.s[1]   v2.s[2]   v2.s[1]
-//                                      B 16x4
-//                             /--------------------------------------\
-//                             |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
-//                             |  ...                          ...    |
-//                             |v4.b[15]  v5.b[15]  v6.b[15]  v7.b[15]|
-//          A 4x16             \--------------------------------------/
-//     /--------------------\  /--------------------------------------\
-// v8  |v0.b[0] ... v0.b[15]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
-// v9  |v1.b[0] ... v1.b[15]|  |v20.4s    v21.4s    v22.4s    v23.4s  |
-// v10 |v0.b[0] ... v0.b[15]|  |v24.4s    v25.4s    v26.4s    v27.4s  |
-// v11 |v1.b[0] ... v1.b[15]|  |v28.4s    v29.4s    v30.4s    v31.4s  |
-//     \--------------------/  \--------------------------------------/
+//                                            B 16x4
+//                                      /--------------------------------------\
+//                                      |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
+//                                      |  ...      ...        ...      ...    |
+//                                      |v4.b[7]   v5.b[7]   v6.b[7]   v7.b[7] |
+//                                      |v8.b[0]   v9.b[0]   v10.b[0]  v11.b[0]|
+//                                      |  ...      ...       ...       ...    |
+//                                      |v8.b[7]   v9.b[7]   v10.b[7]  v11.b[7]|
+//            A 4x16                    \--------------------------------------/
+// /---------------------------------\  /--------------------------------------\
+// |v0.b[0]..v0.b[7] v2.b[0]..v2.b[7]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
+// |v1.b[0]..v1.b[7] v3.b[0]..v3.b[7]|  |v20.4s    v21.4s    v22.4s    v23.4s  |
+// |v0.b[0]..v0.b[7] v2.b[0]..v2.b[7]|  |v24.4s    v25.4s    v26.4s    v27.4s  |
+// |v1.b[0]..v1.b[7] v3.b[0]..v3.b[7]|  |v28.4s    v29.4s    v30.4s    v31.4s  |
+// \---------------------------------/  \--------------------------------------/
+//
 //
 // Accumulators are horizontally aggregated to the left most register
 // for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
@@ -127,21 +122,22 @@ Return Value:
 GemmS8S8_M4_ProcessNextColumnLoop
         mov     x0,x14                      // reload matrix A
         mov     x3,x15                      // reload PackedCountK
-        ldr     q0,[x0],#64                 // A0
+        ldp     d0,d2,[x0],#64              // A0
         movi    v16.4s,#0
         movi    v17.4s,#0
-        ldr     q4,[x1],#64                 // B
+        ldp     d4,d8,[x1],#64              // B
         movi    v18.4s,#0
         movi    v19.4s,#0
-        ldur    q5,[x1,#-48]
+        ldp     d5,d9,[x1,#-48]
         movi    v20.4s,#0
         movi    v21.4s,#0
-        ldur    q6,[x1,#-32]
+        ldp     d6,d10,[x1,#-32]
         movi    v22.4s,#0
         movi    v23.4s,#0
-        ldur    q7,[x1,#-16]
+        ldp     d7,d11,[x1,#-16]
         movi    v24.4s,#0
         movi    v25.4s,#0
+        ldp     d1,d3,[x0,#-48]
         movi    v26.4s,#0
         movi    v27.4s,#0
         movi    v28.4s,#0
@@ -150,83 +146,93 @@ GemmS8S8_M4_ProcessNextColumnLoop
         movi    v31.4s,#0
 
 GemmS8S8_M4_ComputeBlockLoop
-        ldur    q1,[x0,#-48]
         smull   v12.8h,v0.8b,v4.8b
         smull   v13.8h,v0.8b,v5.8b
         smull   v14.8h,v0.8b,v6.8b
         smull   v15.8h,v0.8b,v7.8b
-        smlal2  v12.8h,v0.16b,v4.16b
-        smlal2  v13.8h,v0.16b,v5.16b
-        smlal2  v14.8h,v0.16b,v6.16b
-        smlal2  v15.8h,v0.16b,v7.16b
+        smlal   v12.8h,v2.8b,v8.8b
+        smlal   v13.8h,v2.8b,v9.8b
+        smlal   v14.8h,v2.8b,v10.8b
+        smlal   v15.8h,v2.8b,v11.8b
+        ldp     d0,d2,[x0,#-32]
         sadalp  v16.4s,v12.8h
         sadalp  v17.4s,v13.8h
         sadalp  v18.4s,v14.8h
         sadalp  v19.4s,v15.8h
-        ldur    q0,[x0,#-32]
+        sub     x3,x3,#1
         smull   v12.8h,v1.8b,v4.8b
         smull   v13.8h,v1.8b,v5.8b
         smull   v14.8h,v1.8b,v6.8b
         smull   v15.8h,v1.8b,v7.8b
-        smlal2  v12.8h,v1.16b,v4.16b
-        smlal2  v13.8h,v1.16b,v5.16b
-        smlal2  v14.8h,v1.16b,v6.16b
-        smlal2  v15.8h,v1.16b,v7.16b
+        smlal   v12.8h,v3.8b,v8.8b
+        smlal   v13.8h,v3.8b,v9.8b
+        smlal   v14.8h,v3.8b,v10.8b
+        smlal   v15.8h,v3.8b,v11.8b
+        ldp     d1,d3,[x0,#-16]
         sadalp  v20.4s,v12.8h
         sadalp  v21.4s,v13.8h
         sadalp  v22.4s,v14.8h
         sadalp  v23.4s,v15.8h
-        ldur    q1,[x0,#-16]
+        cbz     x3,GemmS8S8_M4_ComputeBlockLoopFinish
         smull   v12.8h,v0.8b,v4.8b
         smull   v13.8h,v0.8b,v5.8b
         smull   v14.8h,v0.8b,v6.8b
         smull   v15.8h,v0.8b,v7.8b
-        smlal2  v12.8h,v0.16b,v4.16b
-        smlal2  v13.8h,v0.16b,v5.16b
-        smlal2  v14.8h,v0.16b,v6.16b
-        smlal2  v15.8h,v0.16b,v7.16b
+        smlal   v12.8h,v2.8b,v8.8b
+        smlal   v13.8h,v2.8b,v9.8b
+        smlal   v14.8h,v2.8b,v10.8b
+        smlal   v15.8h,v2.8b,v11.8b
+        ldp     d0,d2,[x0],#64
         sadalp  v24.4s,v12.8h
         sadalp  v25.4s,v13.8h
         sadalp  v26.4s,v14.8h
         sadalp  v27.4s,v15.8h
-
-        sub     x3,x3,#1
-        cbz     x3,GemmS8S8_M4_ComputeBlockLoopFinish
-
-        ldr     q0,[x0],#64
         smull   v12.8h,v1.8b,v4.8b
         smull   v13.8h,v1.8b,v5.8b
         smull   v14.8h,v1.8b,v6.8b
         smull   v15.8h,v1.8b,v7.8b
-        smlal2  v12.8h,v1.16b,v4.16b
-        smlal2  v13.8h,v1.16b,v5.16b
-        ldr     q4,[x1],#64                 // B
-        smlal2  v14.8h,v1.16b,v6.16b
-        smlal2  v15.8h,v1.16b,v7.16b
-        ldur    q5,[x1,#-48]
+        smlal   v12.8h,v3.8b,v8.8b
+        ldp     d4,d8,[x1],#64                 // B
+        smlal   v13.8h,v3.8b,v9.8b
+        ldp     d5,d9,[x1,#-48]
+        smlal   v14.8h,v3.8b,v10.8b
+        ldp     d6,d10,[x1,#-32]
+        smlal   v15.8h,v3.8b,v11.8b
+        ldp     d7,d11,[x1,#-16]
         sadalp  v28.4s,v12.8h
-        ldur    q6,[x1,#-32]
+        ldp     d1,d3,[x0,#-48]
         sadalp  v29.4s,v13.8h
-        ldur    q7,[x1,#-16]
         sadalp  v30.4s,v14.8h
         sadalp  v31.4s,v15.8h
         b       GemmS8S8_M4_ComputeBlockLoop
 
 GemmS8S8_M4_ComputeBlockLoopFinish
-
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        ld1     {v0.4s},[x7]
+        smlal   v12.8h,v2.8b,v8.8b
+        smlal   v13.8h,v2.8b,v9.8b
+        smlal   v14.8h,v2.8b,v10.8b
+        smlal   v15.8h,v2.8b,v11.8b
+        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
+        sadalp  v24.4s,v12.8h
+        sadalp  v25.4s,v13.8h
+        sadalp  v26.4s,v14.8h
+        sadalp  v27.4s,v15.8h
         smull   v12.8h,v1.8b,v4.8b
         smull   v13.8h,v1.8b,v5.8b
         smull   v14.8h,v1.8b,v6.8b
         smull   v15.8h,v1.8b,v7.8b
-        smlal2  v12.8h,v1.16b,v4.16b
-        smlal2  v13.8h,v1.16b,v5.16b
-        smlal2  v14.8h,v1.16b,v6.16b
-        smlal2  v15.8h,v1.16b,v7.16b
+        smlal   v12.8h,v3.8b,v8.8b
+        smlal   v13.8h,v3.8b,v9.8b
+        smlal   v14.8h,v3.8b,v10.8b
+        smlal   v15.8h,v3.8b,v11.8b
         sadalp  v28.4s,v12.8h
         sadalp  v29.4s,v13.8h
         sadalp  v30.4s,v14.8h
         sadalp  v31.4s,v15.8h
-
         addp    v16.4s,v16.4s,v17.4s
         addp    v18.4s,v18.4s,v19.4s
         addp    v20.4s,v20.4s,v21.4s
@@ -235,18 +241,17 @@ GemmS8S8_M4_ComputeBlockLoopFinish
         addp    v26.4s,v26.4s,v27.4s
         addp    v28.4s,v28.4s,v29.4s
         addp    v30.4s,v30.4s,v31.4s
-
         addp    v16.4s,v16.4s,v18.4s
         addp    v20.4s,v20.4s,v22.4s
         addp    v24.4s,v24.4s,v26.4s
         addp    v28.4s,v28.4s,v30.4s
-
-        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
+        dup     v8.4s,v0.s[0]              // broadcast row fixups
+        dup     v9.4s,v0.s[1]
+        dup     v10.4s,v0.s[2]
+        dup     v11.4s,v0.s[3]
         cbz     x9,GemmS8S8_M4_SkipScaleByZeroPointB
 
-        //
         // accumulator = zero point B * row sum A + column sum B
-        //
         ld1     {v30.4s},[x9],#16           // load ZeroPointB
         mul     v17.4s,v30.4s,v8.4s
         mul     v21.4s,v30.4s,v9.4s
@@ -263,9 +268,7 @@ GemmS8S8_M4_ComputeBlockLoopFinish
         b GemmS8S8_M4_StoreOutput
 
 GemmS8S8_M4_SkipScaleByZeroPointB
-        //
         // accumulator = row sum A + column sum B 
-        //
         add     v16.4s,v16.4s,v8.4s
         add     v20.4s,v20.4s,v9.4s
         add     v24.4s,v24.4s,v10.4s
@@ -279,7 +282,6 @@ GemmS8S8_M4_StoreOutput
         add     x10,x2,x6,lsl #2
         add     x11,x10,x6,lsl #2
         add     x12,x11,x6,lsl #2
-
         subs    x5,x5,#4                    // adjust CountN remaining
         blo     GemmS8S8_M4_StoreOutputPartial
         cbnz    x13,GemmS8S8_M4_SkipAccumulateOutput
@@ -370,102 +372,132 @@ GemmS8S8_M4_StoreOutputPartial1_AddMode
 //
 // Column Sum v2.s[0] v2.s[4]
 // Each row sum replicated to all 4 elements of a vector register 
-// v8 v9
-//                    Col Sum   v2.s[0]   v2.s[1]   v2.s[2]   v2.s[1]
-//                                      B 16x4
-//                             /--------------------------------------\
-//                             |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
-//                             |  ...                          ...    |
-//                             |v4.b[15]  v5.b[15]  v6.b[15]  v7.b[15]|
-//          A 2x16             \--------------------------------------/
-//     /--------------------\  /--------------------------------------\
-// v8  |v0.b[0] ... v0.b[15]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
-// v9  |v0.b[0] ... v0.b[15]|  |v20.4s    v21.4s    v22.4s    v23.4s  |
-//     \--------------------/  \--------------------------------------/
+// v30 v31
+//                                            B 16x4
+//                                      /--------------------------------------\
+//                                      |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
+//                                      |  ...      ...        ...      ...    |
+//                                      |v4.b[7]   v5.b[7]   v6.b[7]   v7.b[7] |
+//                                      |v24.b[0]  v25.b[0]  v26.b[0]  v27.b[0]|
+//                                      |  ...      ...       ...       ...    |
+//                                      |v24.b[7]  v25.b[7]  v26.b[7]  v27.b[7]|
+//            A 2x16                    \--------------------------------------/
+// /---------------------------------\  /--------------------------------------\
+// |v0.b[0]..v0.b[7] v2.b[0]..v2.b[7]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
+// |v1.b[0]..v1.b[7] v3.b[0]..v3.b[7]|  |v20.4s    v21.4s    v22.4s    v23.4s  |
+// \---------------------------------/  \--------------------------------------/
 //
 // Accumulators are horizontally aggregated to the left most register
 // for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
+//
+GemmS8S8_M2_ProcessLoop
 
 GemmS8S8_M2_ProcessNextColumnLoop
+        ldp     d4,d24,[x1],#16             // B
         mov     x0,x14                      // reload matrix A
         mov     x3,x15                      // reload PackedCountK
+        ldp     d0,d2,[x0],#16              // A0
         movi    v16.4s,#0
         movi    v17.4s,#0
+        ldp     d5,d25,[x1],#16
         movi    v18.4s,#0
         movi    v19.4s,#0
+        ldp     d6,d26,[x1],#16
         movi    v20.4s,#0
         movi    v21.4s,#0
+        ldp     d7,d27,[x1],#16
         movi    v22.4s,#0
         movi    v23.4s,#0
+        ldp     d1,d3,[x0],#16              // A1
 
 GemmS8S8_M2_ComputeBlockLoop
-        ld1     {v4.16b},[x1],#16           // B
-        ld1     {v5.16b},[x1],#16
-        ld1     {v6.16b},[x1],#16
-        ld1     {v7.16b},[x1],#16
-
-        ld1     {v0.16b},[x0],#16           // A0
-        smull   v12.8h,v0.8b,v4.8b
-        smull   v13.8h,v0.8b,v5.8b
-        smull   v14.8h,v0.8b,v6.8b
-        smull   v15.8h,v0.8b,v7.8b
-        smlal2  v12.8h,v0.16b,v4.16b
-        smlal2  v13.8h,v0.16b,v5.16b
-        smlal2  v14.8h,v0.16b,v6.16b
-        smlal2  v15.8h,v0.16b,v7.16b
-        sadalp  v16.4s,v12.8h
-        sadalp  v17.4s,v13.8h
-        sadalp  v18.4s,v14.8h
-        sadalp  v19.4s,v15.8h
-
-        ld1     {v0.16b},[x0],#16           // A1
-        smull   v12.8h,v0.8b,v4.8b
-        smull   v13.8h,v0.8b,v5.8b
-        smull   v14.8h,v0.8b,v6.8b
-        smull   v15.8h,v0.8b,v7.8b
-        smlal2  v12.8h,v0.16b,v4.16b
-        smlal2  v13.8h,v0.16b,v5.16b
-        smlal2  v14.8h,v0.16b,v6.16b
-        smlal2  v15.8h,v0.16b,v7.16b
-        sadalp  v20.4s,v12.8h
-        sadalp  v21.4s,v13.8h
-        sadalp  v22.4s,v14.8h
-        sadalp  v23.4s,v15.8h
 
         sub     x3,x3,#1
-        cbnz    x3,GemmS8S8_M2_ComputeBlockLoop
+        smull   v28.8h,v0.8b,v4.8b
+        smull   v29.8h,v0.8b,v5.8b
+        smull   v30.8h,v0.8b,v6.8b
+        smull   v31.8h,v0.8b,v7.8b
+        cbz     x3,GemmS8S8_M2_ComputeBlockLoopFinish
+        smlal   v28.8h,v2.8b,v24.8b
+        smlal   v29.8h,v2.8b,v25.8b
+        smlal   v30.8h,v2.8b,v26.8b
+        smlal   v31.8h,v2.8b,v27.8b
+        ldp     d0,d2,[x0],#16              // A0
+        sadalp  v16.4s,v28.8h
+        sadalp  v17.4s,v29.8h
+        sadalp  v18.4s,v30.8h
+        sadalp  v19.4s,v31.8h
+        smull   v28.8h,v1.8b,v4.8b
+        smull   v29.8h,v1.8b,v5.8b
+        smull   v30.8h,v1.8b,v6.8b
+        smull   v31.8h,v1.8b,v7.8b
+        smlal   v28.8h,v3.8b,v24.8b
+        ldp     d4,d24,[x1],#16             // B
+        smlal   v29.8h,v3.8b,v25.8b
+        ldp     d5,d25,[x1],#16
+        smlal   v30.8h,v3.8b,v26.8b
+        ldp     d6,d26,[x1],#16
+        smlal   v31.8h,v3.8b,v27.8b
+        ldp     d7,d27,[x1],#16
+        sadalp  v20.4s,v28.8h
+        ldp     d1,d3,[x0],#16              // A1
+        sadalp  v21.4s,v29.8h
+        sadalp  v22.4s,v30.8h
+        sadalp  v23.4s,v31.8h
+        b       GemmS8S8_M2_ComputeBlockLoop
 
+GemmS8S8_M2_ComputeBlockLoopFinish
+        ld1     {v0.4s},[x8],#16            // load ColumnSumBuffer[0]
+        smlal   v28.8h,v2.8b,v24.8b
+        smlal   v29.8h,v2.8b,v25.8b
+        smlal   v30.8h,v2.8b,v26.8b
+        smlal   v31.8h,v2.8b,v27.8b
+        ldr     d2,[x7]                     // load row sums
+        sadalp  v16.4s,v28.8h
+        sadalp  v17.4s,v29.8h
+        sadalp  v18.4s,v30.8h
+        sadalp  v19.4s,v31.8h
+        smull   v28.8h,v1.8b,v4.8b
+        smull   v29.8h,v1.8b,v5.8b
+        smull   v30.8h,v1.8b,v6.8b
+        smull   v31.8h,v1.8b,v7.8b
+        smlal   v28.8h,v3.8b,v24.8b
+        smlal   v29.8h,v3.8b,v25.8b
+        smlal   v30.8h,v3.8b,v26.8b
+        smlal   v31.8h,v3.8b,v27.8b
+        sadalp  v20.4s,v28.8h
+        sadalp  v21.4s,v29.8h
+        sadalp  v22.4s,v30.8h
+        sadalp  v23.4s,v31.8h
         addp    v16.4s,v16.4s,v17.4s
         addp    v18.4s,v18.4s,v19.4s
         addp    v20.4s,v20.4s,v21.4s
         addp    v22.4s,v22.4s,v23.4s
-
+        dup     v30.4s,v2.s[0]              // broadcast row fixups
+        dup     v31.4s,v2.s[1]              // broadcast row fixups
         addp    v16.4s,v16.4s,v18.4s
         addp    v20.4s,v20.4s,v22.4s
-
-        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
         cbz     x9,GemmS8S8_M2_SkipScaleByZeroPointB
 
         // accumulator = zero point B * row sum A + column sum B
-        ld1     {v30.4s},[x9],#16           // load ZeroPointB[0]
-        mul     v17.4s,v30.4s,v8.4s
-        mul     v21.4s,v30.4s,v9.4s
+        ld1     {v18.4s},[x9],#16           // load ZeroPointB[0]
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v0.4s
+        mul     v17.4s,v18.4s,v30.4s
+        mul     v21.4s,v18.4s,v31.4s
         add     v16.4s,v16.4s,v17.4s
         add     v20.4s,v20.4s,v21.4s
-        add     v16.4s,v16.4s,v2.4s
-        add     v20.4s,v20.4s,v2.4s
         b       GemmS8S8_M2_StoreOutput
 
 GemmS8S8_M2_SkipScaleByZeroPointB
         // accumulator = row sum A + column sum B 
-        add     v16.4s,v16.4s,v8.4s
-        add     v20.4s,v20.4s,v9.4s
-        add     v16.4s,v16.4s,v2.4s
-        add     v20.4s,v20.4s,v2.4s
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v0.4s
+        add     v16.4s,v16.4s,v30.4s
+        add     v20.4s,v20.4s,v31.4s
 
 GemmS8S8_M2_StoreOutput
         add     x10,x2,x6,lsl #2
-
         subs    x5,x5,#4                    // adjust CountN remaining
         blo     GemmS8S8_M2_StoreOutputPartial
         cbnz    x13,GemmS8S8_M2_SkipAccumulateOutput
@@ -486,7 +518,6 @@ GemmS8S8_M2_ExitKernel
         EPILOG_RESTORE_REG_PAIR d10,d11,#16
         EPILOG_RESTORE_REG_PAIR d8,d9,#64!
         EPILOG_RETURN
-
 
 GemmS8S8_M2_StoreOutputPartial
         cbz     x13,GemmS8S8_M2_StoreOutputPartial_AddMode
@@ -530,71 +561,89 @@ GemmS8S8_M2_StoreOutputPartial1_AddMode
 //
 // Column Sum v2.s[0] v2.s[4]
 // row sum replicated to all 4 elements of a vector register 
-// v8 
-//                    Col Sum   v2.s[0]   v2.s[1]   v2.s[2]   v2.s[1]
-//                                      B 16x4
-//                             /--------------------------------------\
-//                             |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
-//                             |  ...                          ...    |
-//                             |v4.b[15]  v5.b[15]  v6.b[15]  v7.b[15]|
-//          A 2x16             \--------------------------------------/
-//     /--------------------\  /--------------------------------------\
-// v8  |v0.b[0] ... v0.b[15]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
-//     \--------------------/  \--------------------------------------/
+// v31 
+//                                            B 16x4
+//                                      /--------------------------------------\
+//                                      |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
+//                                      |  ...      ...        ...      ...    |
+//                                      |v4.b[7]   v5.b[7]   v6.b[7]   v7.b[7] |
+//                                      |v24.b[0]  v25.b[0]  v26.b[0]  v27.b[0]|
+//                                      |  ...      ...       ...       ...    |
+//                                      |v24.b[7]  v25.b[7]  v26.b[7]  v27.b[7]|
+//            A 1x16                    \--------------------------------------/
+// /---------------------------------\  /--------------------------------------\
+// |v0.b[0]..v0.b[7] v2.b[0]..v2.b[7]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
+// \---------------------------------/  \--------------------------------------/
 //
 // Accumulators are horizontally aggregated to the left most register
 // for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
+//
+GemmS8S8_M1_ProcessLoop
+        ldr     d31,[x7]
+        dup     v31.4s,v31.s[0]              // broadcast row fixups
 
 GemmS8S8_M1_ProcessNextColumnLoop
+        ldp     d4,d24,[x1],#16             // B
+        ldp     d5,d25,[x1],#16
+        ldp     d6,d26,[x1],#16
+        ldp     d7,d27,[x1],#16
         mov     x0,x14                      // reload matrix A
         mov     x3,x15                      // reload PackedCountK
+        ldp     d0,d2,[x0],#16              // A0
         movi    v16.4s,#0
         movi    v17.4s,#0
         movi    v18.4s,#0
         movi    v19.4s,#0
 
 GemmS8S8_M1_ComputeBlockLoop
-        ld1     {v4.16b},[x1],#16           // B
-        ld1     {v5.16b},[x1],#16
-        ld1     {v6.16b},[x1],#16
-        ld1     {v7.16b},[x1],#16
-
-        ld1     {v0.16b},[x0],#16           // A0
-        smull   v12.8h,v0.8b,v4.8b
-        smull   v13.8h,v0.8b,v5.8b
-        smull   v14.8h,v0.8b,v6.8b
-        smull   v15.8h,v0.8b,v7.8b
-        smlal2  v12.8h,v0.16b,v4.16b
-        smlal2  v13.8h,v0.16b,v5.16b
-        smlal2  v14.8h,v0.16b,v6.16b
-        smlal2  v15.8h,v0.16b,v7.16b
-        sadalp  v16.4s,v12.8h
-        sadalp  v17.4s,v13.8h
-        sadalp  v18.4s,v14.8h
-        sadalp  v19.4s,v15.8h
-
         sub     x3,x3,#1
-        cbnz    x3,GemmS8S8_M1_ComputeBlockLoop
+        smull   v20.8h,v0.8b,v4.8b
+        smull   v21.8h,v0.8b,v5.8b
+        cbz     x3,GemmS8S8_M1_ComputeBlockLoopFinish
+        smull   v22.8h,v0.8b,v6.8b
+        smull   v23.8h,v0.8b,v7.8b
+        smlal   v20.8h,v2.8b,v24.8b
+        ldp     d4,d24,[x1],#16             // B
+        smlal   v21.8h,v2.8b,v25.8b
+        ldp     d5,d25,[x1],#16
+        smlal   v22.8h,v2.8b,v26.8b
+        ldp     d6,d26,[x1],#16
+        smlal   v23.8h,v2.8b,v27.8b
+        ldp     d0,d2,[x0],#16              // A0
+        sadalp  v16.4s,v20.8h
+        sadalp  v17.4s,v21.8h
+        ldp     d7,d27,[x1],#16
+        sadalp  v18.4s,v22.8h
+        sadalp  v19.4s,v23.8h
+        b       GemmS8S8_M1_ComputeBlockLoop
 
+GemmS8S8_M1_ComputeBlockLoopFinish
+        ld1     {v4.4s},[x8],#16            // load ColumnSumBuffer[0]
+        smull   v22.8h,v0.8b,v6.8b
+        smull   v23.8h,v0.8b,v7.8b
+        smlal   v20.8h,v2.8b,v24.8b
+        smlal   v21.8h,v2.8b,v25.8b
+        smlal   v22.8h,v2.8b,v26.8b
+        smlal   v23.8h,v2.8b,v27.8b
+        sadalp  v16.4s,v20.8h
+        sadalp  v17.4s,v21.8h
+        sadalp  v18.4s,v22.8h
+        sadalp  v19.4s,v23.8h
         addp    v16.4s,v16.4s,v17.4s
         addp    v18.4s,v18.4s,v19.4s
-
         addp    v16.4s,v16.4s,v18.4s
-
-        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
         cbz     x9,GemmS8S8_M1_SkipScaleByZeroPointB
 
         // accumulator = zero point B * row sum A + column sum B
         ld1     {v30.4s},[x9],#16           // load ZeroPointB[0]
-        mul     v17.4s,v30.4s,v8.4s
+        mul     v17.4s,v30.4s,v31.4s
         add     v16.4s,v16.4s,v17.4s
-        add     v16.4s,v16.4s,v2.4s
+        add     v16.4s,v16.4s,v4.4s
         b       GemmS8S8_M1_StoreOutput
-
 GemmS8S8_M1_SkipScaleByZeroPointB
-        // accumulator = row sum A + column sum B 
-        add     v16.4s,v16.4s,v8.4s
-        add     v16.4s,v16.4s,v2.4s
+        // accumulator = row sum A + column sum B
+        add     v16.4s,v16.4s,v31.4s
+        add     v16.4s,v16.4s,v4.4s
 
 GemmS8S8_M1_StoreOutput
         subs    x5,x5,#4                    // adjust CountN remaining

--- a/onnxruntime/core/mlas/lib/arm64/QgemmS8S8KernelNeon.asm
+++ b/onnxruntime/core/mlas/lib/arm64/QgemmS8S8KernelNeon.asm
@@ -1,0 +1,536 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    QgemmS8S8KernelNeon.asm
+
+Abstract:
+
+    This module implements the kernels for the quantized integer matrix/matrix
+    multiply operation (QGEMM).
+
+--*/
+
+#include "kxarm64.h"
+
+//
+// Stack frame layout for the S8S8 kernel.
+//
+
+#define  GemmS8S8KernelFrame_SavedNeonRegisters    (4 * 8)
+#define  GemmS8S8KernelFrame_SavedRegisters            GemmS8S8KernelFrame_SavedNeonRegisters
+#define  GemmS8S8KernelFrame_ColumnSumBuffer       0 + GemmS8S8KernelFrame_SavedRegisters
+#define  GemmS8S8KernelFrame_ZeroPointB            8 + GemmS8S8KernelFrame_SavedRegisters
+#define  GemmS8S8KernelFrame_ZeroMode             16 + GemmS8S8KernelFrame_SavedRegisters
+
+        TEXTAREA
+
+/*++
+
+Routine Description:
+
+    This routine is an inner kernel to compute matrix multiplication for a
+    set of rows.
+
+Arguments:
+
+    A (x0) - Supplies the address of matrix A. The matrix data has been packed
+        using MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>.
+
+    B (x1) - Supplies the address of matrix B. The matrix data has been packed
+        using MlasGemmU8X8CopyPackB<MLAS_GEMM_S8S8_KERNEL_NEON>.
+
+    C (x2) - Supplies the address of matrix C.
+
+    PackedCountK (x3) - Supplies the number of packed columns from matrix A and
+        the number of packed rows from matrix B to iterate over.
+
+    CountM (x4) - Supplies the maximum number of rows that can be processed for
+        matrix A and matrix C. The actual number of rows handled for this
+        invocation depends on the kernel implementation.
+
+    CountN (x5) - Supplies the number of columns from matrix B and matrix C to
+        iterate over.
+
+    ldc (x6) - Supplies the first dimension of matrix C.
+
+    RowSumBuffer (x7) - Supplies the sum of each row from matrix A. These values
+        have been pre-scaled by the zero point offset of matrix B if the offset
+        is per-tensor (ZeroPointB is nullptr). Otherwise, these values must be
+        scaled by the per-column zero point offsets of matrix B. These values are
+        accumulated into every row of matrix C.
+
+    ColumnSumBuffer - Supplies the sum of each column from matrix B multiplied
+        by the zero point offset of matrix A. These values are accumulated into
+        every column of matrix C.
+
+    ZeroPointB - Optionally supplies the per-column zero point offsets of matrix
+        B, else nullptr if the matrix B is using per-tensor quantization.
+
+    ZeroMode - Supplies true if the output matrix must be zero initialized, else
+        false if the output matrix is accumulated into.
+
+Return Value:
+
+    Returns the number of rows handled.
+
+--*/
+
+        LEAF_ENTRY MlasGemmS8S8KernelNeon
+
+        stp     d8,d9,[sp,#-32]!
+        stp     d10,d11,[sp,#16]
+        ldr     x8,[sp,#GemmS8S8KernelFrame_ColumnSumBuffer]
+        ldr     x9,[sp,#GemmS8S8KernelFrame_ZeroPointB]
+        ldrb    w13,[sp,#GemmS8S8KernelFrame_ZeroMode]
+        mov     x14,x0
+        ld1     {v11.4s},[x7]
+        mov     x15,x3
+        dup     v8.4s,v11.s[0]             // broadcast row fixups
+        cmp     x4,#1                       // CountM == 1?
+        beq     GemmS8S8_M1_ProcessNextColumnLoop
+        dup     v9.4s,v11.s[1]
+        cmp     x4,#4                       // CountM < 4?
+        blo     GemmS8S8_M2_ProcessNextColumnLoop
+        dup     v10.4s,v11.s[2]
+        dup     v11.4s,v11.s[3]
+
+//
+// Process 4 rows of the matrices.
+//
+
+GemmS8S8_M4_ProcessNextColumnLoop
+        mov     x0,x14                      // reload matrix A
+        mov     x3,x15                      // reload PackedCountK
+        ldr     q0,[x0],#64                 // A0
+        movi    v16.4s,#0
+        movi    v17.4s,#0
+        ldr     q4,[x1],#64                 // B
+        movi    v18.4s,#0
+        movi    v19.4s,#0
+        ldur    q5,[x1,#-48]
+        movi    v20.4s,#0
+        movi    v21.4s,#0
+        ldur    q6,[x1,#-32]
+        movi    v22.4s,#0
+        movi    v23.4s,#0
+        ldur    q7,[x1,#-16]
+        movi    v24.4s,#0
+        movi    v25.4s,#0
+        movi    v26.4s,#0
+        movi    v27.4s,#0
+        movi    v28.4s,#0
+        movi    v29.4s,#0
+        movi    v30.4s,#0
+        movi    v31.4s,#0
+
+GemmS8S8_M4_ComputeBlockLoop
+        ldur    q1,[x0,#-48]
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        smlal2  v12.8h,v0.16b,v4.16b
+        smlal2  v13.8h,v0.16b,v5.16b
+        smlal2  v14.8h,v0.16b,v6.16b
+        smlal2  v15.8h,v0.16b,v7.16b
+        sadalp  v16.4s,v12.8h
+        sadalp  v17.4s,v13.8h
+        sadalp  v18.4s,v14.8h
+        sadalp  v19.4s,v15.8h
+        ldur    q0,[x0,#-32]
+        smull   v12.8h,v1.8b,v4.8b
+        smull   v13.8h,v1.8b,v5.8b
+        smull   v14.8h,v1.8b,v6.8b
+        smull   v15.8h,v1.8b,v7.8b
+        smlal2  v12.8h,v1.16b,v4.16b
+        smlal2  v13.8h,v1.16b,v5.16b
+        smlal2  v14.8h,v1.16b,v6.16b
+        smlal2  v15.8h,v1.16b,v7.16b
+        sadalp  v20.4s,v12.8h
+        sadalp  v21.4s,v13.8h
+        sadalp  v22.4s,v14.8h
+        sadalp  v23.4s,v15.8h
+        ldur    q1,[x0,#-16]
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        smlal2  v12.8h,v0.16b,v4.16b
+        smlal2  v13.8h,v0.16b,v5.16b
+        smlal2  v14.8h,v0.16b,v6.16b
+        smlal2  v15.8h,v0.16b,v7.16b
+        sadalp  v24.4s,v12.8h
+        sadalp  v25.4s,v13.8h
+        sadalp  v26.4s,v14.8h
+        sadalp  v27.4s,v15.8h
+
+        sub     x3,x3,#1
+        cbz     x3,GemmS8S8_M4_ComputeBlockLoopFinish
+
+        ldr     q0,[x0],#64
+        smull   v12.8h,v1.8b,v4.8b
+        smull   v13.8h,v1.8b,v5.8b
+        smull   v14.8h,v1.8b,v6.8b
+        smull   v15.8h,v1.8b,v7.8b
+        smlal2  v12.8h,v1.16b,v4.16b
+        smlal2  v13.8h,v1.16b,v5.16b
+        ldr     q4,[x1],#64                 // B
+        smlal2  v14.8h,v1.16b,v6.16b
+        smlal2  v15.8h,v1.16b,v7.16b
+        ldur    q5,[x1,#-48]
+        sadalp  v28.4s,v12.8h
+        ldur    q6,[x1,#-32]
+        sadalp  v29.4s,v13.8h
+        ldur    q7,[x1,#-16]
+        sadalp  v30.4s,v14.8h
+        sadalp  v31.4s,v15.8h
+        b       GemmS8S8_M4_ComputeBlockLoop
+
+GemmS8S8_M4_ComputeBlockLoopFinish
+
+        smull   v12.8h,v1.8b,v4.8b
+        smull   v13.8h,v1.8b,v5.8b
+        smull   v14.8h,v1.8b,v6.8b
+        smull   v15.8h,v1.8b,v7.8b
+        smlal2  v12.8h,v1.16b,v4.16b
+        smlal2  v13.8h,v1.16b,v5.16b
+        smlal2  v14.8h,v1.16b,v6.16b
+        smlal2  v15.8h,v1.16b,v7.16b
+        sadalp  v28.4s,v12.8h
+        sadalp  v29.4s,v13.8h
+        sadalp  v30.4s,v14.8h
+        sadalp  v31.4s,v15.8h
+
+        addp    v16.4s,v16.4s,v17.4s
+        addp    v18.4s,v18.4s,v19.4s
+        addp    v20.4s,v20.4s,v21.4s
+        addp    v22.4s,v22.4s,v23.4s
+        addp    v24.4s,v24.4s,v25.4s
+        addp    v26.4s,v26.4s,v27.4s
+        addp    v28.4s,v28.4s,v29.4s
+        addp    v30.4s,v30.4s,v31.4s
+
+        addp    v16.4s,v16.4s,v18.4s
+        addp    v20.4s,v20.4s,v22.4s
+        addp    v24.4s,v24.4s,v26.4s
+        addp    v28.4s,v28.4s,v30.4s
+
+        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
+
+        add     v16.4s,v16.4s,v8.4s
+        add     v20.4s,v20.4s,v9.4s
+        add     v24.4s,v24.4s,v10.4s
+        add     v28.4s,v28.4s,v11.4s
+        add     v16.4s,v16.4s,v2.4s
+        add     v20.4s,v20.4s,v2.4s
+        add     v24.4s,v24.4s,v2.4s
+        add     v28.4s,v28.4s,v2.4s
+
+        add     x10,x2,x6,lsl #2
+        add     x11,x10,x6,lsl #2
+        add     x12,x11,x6,lsl #2
+
+        subs    x5,x5,#4                    // adjust CountN remaining
+        blo     GemmS8S8_M4_StoreOutputPartial
+        cbnz    x13,GemmS8S8_M4_SkipAccumulateOutput
+        ld1     {v0.4s},[x2]
+        ld1     {v1.4s},[x10]
+        ld1     {v2.4s},[x11]
+        ld1     {v3.4s},[x12]
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v1.4s
+        add     v24.4s,v24.4s,v2.4s
+        add     v28.4s,v28.4s,v3.4s
+
+GemmS8S8_M4_SkipAccumulateOutput
+        st1     {v16.4s},[x2],#16
+        st1     {v20.4s},[x10]
+        st1     {v24.4s},[x11]
+        st1     {v28.4s},[x12]
+        cbnz    x5,GemmS8S8_M4_ProcessNextColumnLoop
+
+GemmS8S8_M4_ExitKernel
+        mov     x0,#4                       // return number of rows handled
+        ldp     d10,d11,[sp,#16]
+        ldp     d8,d9,[sp],#32
+        ret
+
+GemmS8S8_M4_StoreOutputPartial
+        cbz     x13,GemmS8S8_M4_StoreOutputPartial_AddMode
+
+GemmS8S8_M4_StoreOutputPartial_ZeroMode
+        tbz     x5,#1,GemmS8S8_M4_StoreOutputPartial1_ZeroMode
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+        st1     {v20.2s},[x10],#8
+        dup     v20.4s,v20.s[2]
+        st1     {v24.2s},[x11],#8
+        dup     v24.4s,v24.s[2]
+        st1     {v28.2s},[x12],#8
+        dup     v28.4s,v28.s[2]
+
+GemmS8S8_M4_StoreOutputPartial1_ZeroMode
+        tbz     x5,#0,GemmS8S8_M4_ExitKernel
+        st1     {v16.s}[0],[x2]
+        st1     {v20.s}[0],[x10]
+        st1     {v24.s}[0],[x11]
+        st1     {v28.s}[0],[x12]
+        b       GemmS8S8_M4_ExitKernel
+
+GemmS8S8_M4_StoreOutputPartial_AddMode
+        tbz     x5,#1,GemmS8S8_M4_StoreOutputPartial1_AddMode
+        ld1     {v0.2s},[x2]
+        ld1     {v1.2s},[x10]
+        ld1     {v2.2s},[x11]
+        ld1     {v3.2s},[x12]
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v1.4s
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+        st1     {v20.2s},[x10],#8
+        dup     v20.4s,v20.s[2]
+        add     v24.4s,v24.4s,v2.4s
+        add     v28.4s,v28.4s,v3.4s
+        st1     {v24.2s},[x11],#8
+        dup     v24.4s,v24.s[2]
+        st1     {v28.2s},[x12],#8
+        dup     v28.4s,v28.s[2]
+
+GemmS8S8_M4_StoreOutputPartial1_AddMode
+        tbz     x5,#0,GemmS8S8_M4_ExitKernel
+        ld1     {v0.s}[0],[x2]
+        ld1     {v1.s}[0],[x10]
+        add     v16.4s,v16.4s,v0.4s
+        ld1     {v2.s}[0],[x11]
+        add     v20.4s,v20.4s,v1.4s
+        ld1     {v3.s}[0],[x12]
+        add     v24.4s,v24.4s,v2.4s
+        st1     {v16.s}[0],[x2]
+        st1     {v20.s}[0],[x10]
+        add     v28.4s,v28.4s,v3.4s
+        st1     {v24.s}[0],[x11]
+        st1     {v28.s}[0],[x12]
+        b       GemmS8S8_M4_ExitKernel
+
+//
+// Process 2 rows of the matrices.
+//
+
+GemmS8S8_M2_ProcessNextColumnLoop
+        mov     x0,x14                      // reload matrix A
+        mov     x3,x15                      // reload PackedCountK
+        movi    v16.4s,#0
+        movi    v17.4s,#0
+        movi    v18.4s,#0
+        movi    v19.4s,#0
+        movi    v20.4s,#0
+        movi    v21.4s,#0
+        movi    v22.4s,#0
+        movi    v23.4s,#0
+
+GemmS8S8_M2_ComputeBlockLoop
+        ld1     {v4.16b},[x1],#16           // B
+        ld1     {v5.16b},[x1],#16
+        ld1     {v6.16b},[x1],#16
+        ld1     {v7.16b},[x1],#16
+
+        ld1     {v0.16b},[x0],#16           // A0
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        smlal2  v12.8h,v0.16b,v4.16b
+        smlal2  v13.8h,v0.16b,v5.16b
+        smlal2  v14.8h,v0.16b,v6.16b
+        smlal2  v15.8h,v0.16b,v7.16b
+        sadalp  v16.4s,v12.8h
+        sadalp  v17.4s,v13.8h
+        sadalp  v18.4s,v14.8h
+        sadalp  v19.4s,v15.8h
+
+        ld1     {v0.16b},[x0],#16           // A1
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        smlal2  v12.8h,v0.16b,v4.16b
+        smlal2  v13.8h,v0.16b,v5.16b
+        smlal2  v14.8h,v0.16b,v6.16b
+        smlal2  v15.8h,v0.16b,v7.16b
+        sadalp  v20.4s,v12.8h
+        sadalp  v21.4s,v13.8h
+        sadalp  v22.4s,v14.8h
+        sadalp  v23.4s,v15.8h
+
+        sub     x3,x3,#1
+        cbnz    x3,GemmS8S8_M2_ComputeBlockLoop
+
+        addp    v16.4s,v16.4s,v17.4s
+        addp    v18.4s,v18.4s,v19.4s
+        addp    v20.4s,v20.4s,v21.4s
+        addp    v22.4s,v22.4s,v23.4s
+
+        addp    v16.4s,v16.4s,v18.4s
+        addp    v20.4s,v20.4s,v22.4s
+
+        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
+
+        add     v16.4s,v16.4s,v8.4s
+        add     v20.4s,v20.4s,v9.4s
+        add     v16.4s,v16.4s,v2.4s
+        add     v20.4s,v20.4s,v2.4s
+
+        add     x10,x2,x6,lsl #2
+
+        subs    x5,x5,#4                    // adjust CountN remaining
+        blo     GemmS8S8_M2_StoreOutputPartial
+        cbnz    x13,GemmS8S8_M2_SkipAccumulateOutput
+        ld1     {v0.4s},[x2]
+        ld1     {v1.4s},[x10]
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v1.4s
+
+GemmS8S8_M2_SkipAccumulateOutput
+        st1     {v16.4s},[x2],#16
+        st1     {v20.4s},[x10]
+        cbnz    x5,GemmS8S8_M2_ProcessNextColumnLoop
+
+GemmS8S8_M2_ExitKernel
+        mov     x0,#2                       // return number of rows handled
+        ldp     d10,d11,[sp,#16]
+        ldp     d8,d9,[sp],#32
+        ret
+
+GemmS8S8_M2_StoreOutputPartial
+        cbz     x13,GemmS8S8_M2_StoreOutputPartial_AddMode
+
+GemmS8S8_M2_StoreOutputPartial_ZeroMode
+        tbz     x5,#1,GemmS8S8_M2_StoreOutputPartial1_ZeroMode
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+        st1     {v20.2s},[x10],#8
+        dup     v20.4s,v20.s[2]
+
+GemmS8S8_M2_StoreOutputPartial1_ZeroMode
+        tbz     x5,#0,GemmS8S8_M2_ExitKernel
+        st1     {v16.s}[0],[x2]
+        st1     {v20.s}[0],[x10]
+        b       GemmS8S8_M2_ExitKernel
+
+GemmS8S8_M2_StoreOutputPartial_AddMode
+        tbz     x5,#1,GemmS8S8_M2_StoreOutputPartial1_AddMode
+        ld1     {v0.2s},[x2]
+        ld1     {v1.2s},[x10]
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v1.4s
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+        st1     {v20.2s},[x10],#8
+        dup     v20.4s,v20.s[2]
+
+GemmS8S8_M2_StoreOutputPartial1_AddMode
+        tbz     x5,#0,GemmS8S8_M2_ExitKernel
+        ld1     {v0.s}[0],[x2]
+        ld1     {v1.s}[0],[x10]
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v1.4s
+        st1     {v16.s}[0],[x2]
+        st1     {v20.s}[0],[x10]
+        b       GemmS8S8_M2_ExitKernel
+
+//
+// Process 1 row of the matrices.
+//
+
+GemmS8S8_M1_ProcessNextColumnLoop
+        mov     x0,x14                      // reload matrix A
+        mov     x3,x15                      // reload PackedCountK
+        movi    v16.4s,#0
+        movi    v17.4s,#0
+        movi    v18.4s,#0
+        movi    v19.4s,#0
+
+GemmS8S8_M1_ComputeBlockLoop
+        ld1     {v4.16b},[x1],#16           // B
+        ld1     {v5.16b},[x1],#16
+        ld1     {v6.16b},[x1],#16
+        ld1     {v7.16b},[x1],#16
+
+        ld1     {v0.16b},[x0],#16           // A0
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        smlal2  v12.8h,v0.16b,v4.16b
+        smlal2  v13.8h,v0.16b,v5.16b
+        smlal2  v14.8h,v0.16b,v6.16b
+        smlal2  v15.8h,v0.16b,v7.16b
+        sadalp  v16.4s,v12.8h
+        sadalp  v17.4s,v13.8h
+        sadalp  v18.4s,v14.8h
+        sadalp  v19.4s,v15.8h
+
+        sub     x3,x3,#1
+        cbnz    x3,GemmS8S8_M1_ComputeBlockLoop
+
+        addp    v16.4s,v16.4s,v17.4s
+        addp    v18.4s,v18.4s,v19.4s
+
+        addp    v16.4s,v16.4s,v18.4s
+
+        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
+
+        add     v16.4s,v16.4s,v8.4s
+        add     v16.4s,v16.4s,v2.4s
+
+        subs    x5,x5,#4                    // adjust CountN remaining
+        blo     GemmS8S8_M1_StoreOutputPartial
+        cbnz    x13,GemmS8S8_M1_SkipAccumulateOutput
+        ld1     {v0.4s},[x2]
+        add     v16.4s,v16.4s,v0.4s
+
+GemmS8S8_M1_SkipAccumulateOutput
+        st1     {v16.4s},[x2],#16
+        cbnz    x5,GemmS8S8_M1_ProcessNextColumnLoop
+
+GemmS8S8_M1_ExitKernel
+        mov     x0,#1                       // return number of rows handled
+        ldp     d10,d11,[sp,#16]
+        ldp     d8,d9,[sp],#32
+        ret
+
+GemmS8S8_M1_StoreOutputPartial
+        cbz     x13,GemmS8S8_M1_StoreOutputPartial_AddMode
+
+GemmS8S8_M1_StoreOutputPartial_ZeroMode:
+        tbz     x5,#1,GemmS8S8_M1_StoreOutputPartial1_ZeroMode
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+
+GemmS8S8_M1_StoreOutputPartial1_ZeroMode
+        tbz     x5,#0,GemmS8S8_M1_ExitKernel
+        st1     {v16.s}[0],[x2]
+        b       GemmS8S8_M1_ExitKernel
+
+GemmS8S8_M1_StoreOutputPartial_AddMode
+        tbz     x5,#1,GemmS8S8_M1_StoreOutputPartial1_AddMode
+        ld1     {v0.2s},[x2]
+        add     v16.4s,v16.4s,v0.4s
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+
+GemmS8S8_M1_StoreOutputPartial1_AddMode
+        tbz     x5,#0,GemmS8S8_M1_ExitKernel
+        ld1     {v0.s}[0],[x2]
+        add     v16.4s,v16.4s,v0.4s
+        st1     {v16.s}[0],[x2]
+        b       GemmS8S8_M1_ExitKernel
+
+        LEAF_END MlasGemmS8S8KernelNeon
+
+        END

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -660,6 +660,7 @@ extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8S8DispatchSse41;
 extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8S8DispatchAvx2;
 extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8U8DispatchAvx2;
 extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchNeon;
+extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmS8S8DispatchNeon;
 extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchUdot;
 extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchDefault;
 

--- a/onnxruntime/core/mlas/lib/qgemm.h
+++ b/onnxruntime/core/mlas/lib/qgemm.h
@@ -14,6 +14,7 @@ Abstract:
     quantized integer matrix/matrix multiply operation (QGEMM).
 
     To implement a new kernel, there needs to specialize template functions below:
+        MlasGemmU8X8FixupZeroPointA
         MlasGemmU8X8FixupZeroPointB
         MlasGemmU8X8CopyPackA
         MlasGemmU8X8CopyPackB
@@ -64,6 +65,13 @@ MlasGemmU8X8TryGemvKernel(
     MLAS_UNREFERENCED_PARAMETER(BIsSigned);
 
     return false;
+}
+
+template <typename KernelType>
+MLAS_FORCEINLINE int32_t
+MlasGemmU8X8FixupZeroPointA(int32_t ZeroPointA)
+{
+    return ZeroPointA;
 }
 
 template<typename KernelType>
@@ -250,6 +258,13 @@ Return Value:
             return;
         }
     }
+
+    //
+    // Fixup the sign bit of the per-matrix zero point offset of matrix A if the
+    // kernel requires signed data.
+    //
+
+    ZeroPointA = MlasGemmU8X8FixupZeroPointA<KernelType>(ZeroPointA);
 
     //
     // Fixup the sign bit of the per-matrix zero point offset of matrix B if the
@@ -466,6 +481,13 @@ Return Value:
     int32_t ZeroPointB = typename KernelType::OffsetBType(*Data->ZeroPointB);
 
     //
+    // Fixup the sign bit of the per-matrix zero point offset of matrix A if the
+    // kernel requires signed data.
+    //
+
+    ZeroPointA = MlasGemmU8X8FixupZeroPointA<KernelType>(ZeroPointA);
+
+    //
     // Fixup the sign bit of the per-matrix zero point offset of matrix B if the
     // data is the opposite format of the kernel implementation. This value is
     // ignored if per-column zero point offsets are used instead.
@@ -659,6 +681,8 @@ struct MLAS_GEMM_U8X8_DISPATCH {
     size_t PackedStrideK;
 };
 
+#define USE_NEONS8_KERNEL true
+
 MLAS_FORCEINLINE
 const MLAS_GEMM_U8X8_DISPATCH*
 MlasGemmU8X8GetDispatch(
@@ -677,7 +701,11 @@ MlasGemmU8X8GetDispatch(
         GemmU8X8Dispatch = MlasPlatform.GemmU8U8Dispatch;
     }
 #elif defined(MLAS_TARGET_ARM64)
-    GemmU8X8Dispatch = MlasPlatform.GemmU8X8Dispatch;
+    if (BIsSigned && USE_NEONS8_KERNEL) {
+        GemmU8X8Dispatch = &MlasGemmS8S8DispatchNeon;
+    } else {
+        GemmU8X8Dispatch = MlasPlatform.GemmU8X8Dispatch;
+    }
 #elif defined(MLAS_TARGET_ARM64EC) || (defined(MLAS_TARGET_ARM) && !defined(_MSC_VER))
     GemmU8X8Dispatch = &MlasGemmU8X8DispatchNeon;
 #else

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_neon.cpp
@@ -499,7 +499,7 @@ const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchNeon = {
 
 
 /*-------------------------
- * NEON kernel for signed int8,  
+ * NEON kernel for signed int8
  */
 
 extern "C" {

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_neon.cpp
@@ -83,8 +83,6 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
     int32_t* RowSumBuffer
     )
 {
-    uint8_t PaddedMatrixAData[16];
-
     //
     // Process four rows of matrix A in a loop.
     //
@@ -179,7 +177,7 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
             *reinterpret_cast<uint32_t*>(&D[8]) = v2;
             *reinterpret_cast<uint32_t*>(&D[12]) = v3;
 
-            RowSums = vpadalq_u16(RowSums, vpaddlq_u8(vld1q_u8(D)));
+            RowSums = vpadalq_u16(RowSums, vpaddlq_u8(vld1q_u8(&D[0])));
 
             D += 16;
             k -= 4;
@@ -191,9 +189,9 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
             // Copy the remaining bytes to the zero padded stack buffer.
             //
 
-            uint8_t* d = PaddedMatrixAData;
+            uint8_t* d = D;
 
-            vst1q_u8(PaddedMatrixAData, vmovq_n_u8(0));
+            vst1q_u8(&D[0], vmovq_n_u8(0));
 
             while (k > 0) {
 
@@ -206,10 +204,7 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
                 k -= 1;
             }
 
-            uint8x16_t PackedVector = vld1q_u8(PaddedMatrixAData);
-            vst1q_u8(D, PackedVector);
-
-            RowSums = vpadalq_u16(RowSums, vpaddlq_u8(PackedVector));
+            RowSums = vpadalq_u16(RowSums, vpaddlq_u8(vld1q_u8(&D[0])));
 
             D += 16;
         }
@@ -254,7 +249,7 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
             *reinterpret_cast<uint32_t*>(&D[0]) = v0;
             *reinterpret_cast<uint32_t*>(&D[4]) = v1;
 
-            RowSums = vpadal_u16(RowSums, vpaddl_u8(vld1_u8(D)));
+            RowSums = vpadal_u16(RowSums, vpaddl_u8(vld1_u8(&D[0])));
 
             D += 8;
             k -= 4;
@@ -266,9 +261,9 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
             // Copy the remaining bytes to the zero padded stack buffer.
             //
 
-            uint8_t* d = PaddedMatrixAData;
+            uint8_t* d = D;
 
-            vst1q_u8(PaddedMatrixAData, vmovq_n_u8(0));
+            vst1_u8(&D[0], vmov_n_u8(0));
 
             while (k > 0) {
 
@@ -279,10 +274,7 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
                 k -= 1;
             }
 
-            uint8x8_t PackedVector = vld1_u8(PaddedMatrixAData);
-            vst1_u8(D, PackedVector);
-
-            RowSums = vpadal_u16(RowSums, vpaddl_u8(PackedVector));
+            RowSums = vpadal_u16(RowSums, vpaddl_u8(vld1_u8(&D[0])));
 
             D += 8;
         }
@@ -291,7 +283,6 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
         RowSumBuffer += 2;
 
         A = A + lda * 2;
-        CountM -= 2;
     }
 
     //
@@ -333,16 +324,13 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
             // Copy the remaining bytes to the zero padded stack buffer.
             //
 
-            vst1q_u8(PaddedMatrixAData, vmovq_n_u8(0));
+            vst1q_u8(&D[0], vmovq_n_u8(0));
 
             for (size_t kk = 0; kk < k; kk++) {
-                PaddedMatrixAData[kk] = a[kk];
+                D[kk] = a[kk];
             }
 
-            uint8x16_t v = vld1q_u8(PaddedMatrixAData);
-            vst1q_u8(D, v);
-
-            RowSums = vpadalq_u16(RowSums, vpaddlq_u8(v));
+            RowSums = vpadalq_u16(RowSums, vpaddlq_u8(vld1q_u8(&D[0])));
         }
 
 #if defined(MLAS_NEON32_INTRINSICS)
@@ -507,4 +495,478 @@ const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchNeon = {
     MlasGemmU8X8CopyPackB<MLAS_GEMM_U8X8_KERNEL_NEON>,
     MLAS_GEMM_U8X8_KERNEL_NEON::PackedK,
     MLAS_GEMM_U8X8_KERNEL_NEON::PackedStrides.K,
+};
+
+
+/*-------------------------
+ * NEON kernel for signed int8,  
+ */
+
+extern "C" {
+    // Prototype of NEON s8 kernel in assembly
+
+    size_t
+    MLASCALL
+    MlasGemmS8S8KernelNeon(
+        const uint8_t* A,
+        const uint8_t* B,
+        int32_t* C,
+        size_t PackedCountK,
+        size_t CountM,
+        size_t CountN,
+        size_t ldc,
+        const int32_t* RowSumVector,
+        const int32_t* ColumnSumVector,
+        const int32_t* ZeroPointB,
+        bool ZeroMode
+        );
+}
+
+struct MLAS_GEMM_S8S8_KERNEL_NEON {
+    typedef uint8_t PackedAType;
+    typedef uint8_t PackedBType;
+    typedef int8_t OffsetBType;
+
+    static constexpr size_t PackedK = 16;
+    static constexpr MLAS_GEMM_U8X8_STRIDES Strides{24, 128, 256};
+    static constexpr MLAS_GEMM_U8X8_STRIDES PackedStrides{24, 128, 384};
+};
+
+constexpr size_t MLAS_GEMM_S8S8_KERNEL_NEON::PackedK;
+constexpr MLAS_GEMM_U8X8_STRIDES MLAS_GEMM_S8S8_KERNEL_NEON::Strides;
+constexpr MLAS_GEMM_U8X8_STRIDES MLAS_GEMM_S8S8_KERNEL_NEON::PackedStrides;
+
+template <>
+MLAS_FORCEINLINE int32_t
+MlasGemmU8X8FixupZeroPointA<MLAS_GEMM_S8S8_KERNEL_NEON>(int32_t ZeroPointA)
+{
+    return int8_t(ZeroPointA ^ 0x80);
+}
+
+template<>
+void
+MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>(
+    MLAS_GEMM_S8S8_KERNEL_NEON::PackedAType* D,
+    const uint8_t* A,
+    size_t lda,
+    size_t CountM,
+    size_t CountK,
+    int32_t* RowSumBuffer
+    )
+{
+
+    const uint8x16_t BitFlipVector = vdupq_n_u8(0x80);
+
+    //
+    // Process four rows of matrix A.
+    //
+
+    while (CountM >= 4) {
+
+        const uint8_t* a0 = A;
+        const uint8_t* a1 = a0 + lda;
+        const uint8_t* a2 = a1 + lda;
+        const uint8_t* a3 = a2 + lda;
+
+        size_t k = CountK;
+        int32x4_t RowSums0 = vdupq_n_s32(0);
+        int32x4_t RowSums1 = vdupq_n_s32(0);
+        int32x4_t RowSums2 = vdupq_n_s32(0);
+        int32x4_t RowSums3 = vdupq_n_s32(0);
+
+        while (k >= 16) {
+
+            int8x16_t v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a0), BitFlipVector));
+            a0 += 16;
+            int8x16_t v1 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a1), BitFlipVector));
+            a1 += 16;
+            int8x16_t v2 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a2), BitFlipVector));
+            a2 += 16;
+            int8x16_t v3 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a3), BitFlipVector));
+            a3 += 16;
+
+            RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(v0));
+            RowSums1 = vpadalq_s16(RowSums1, vpaddlq_s8(v1));
+            RowSums2 = vpadalq_s16(RowSums2, vpaddlq_s8(v2));
+            RowSums3 = vpadalq_s16(RowSums3, vpaddlq_s8(v3));
+
+            vst1q_u8(&D[0], vreinterpretq_u8_s8(v0));
+            vst1q_u8(&D[16], vreinterpretq_u8_s8(v1));
+            vst1q_u8(&D[32], vreinterpretq_u8_s8(v2));
+            vst1q_u8(&D[48], vreinterpretq_u8_s8(v3));
+
+            D += 64;
+            k -= 16;
+        }
+
+        if (k > 0) {
+
+            uint8_t* d = D;
+
+            vst1q_u8(&D[0], BitFlipVector);
+            vst1q_u8(&D[16], BitFlipVector);
+            vst1q_u8(&D[32], BitFlipVector);
+            vst1q_u8(&D[48], BitFlipVector);
+
+            if (k >= 8) {
+
+                vst1_u8(&d[0], vld1_u8(a0));
+                a0 += 8;
+                vst1_u8(&d[16], vld1_u8(a1));
+                a1 += 8;
+                vst1_u8(&d[32], vld1_u8(a2));
+                a2 += 8;
+                vst1_u8(&d[48], vld1_u8(a3));
+                a3 += 8;
+
+                d += 8;
+                k -= 8;
+            }
+
+            if (k >= 4) {
+
+                uint32_t v0 = *reinterpret_cast<const uint32_t*>(a0);
+                a0 += 4;
+                uint32_t v1 = *reinterpret_cast<const uint32_t*>(a1);
+                a1 += 4;
+                uint32_t v2 = *reinterpret_cast<const uint32_t*>(a2);
+                a2 += 4;
+                uint32_t v3 = *reinterpret_cast<const uint32_t*>(a3);
+                a3 += 4;
+
+                *reinterpret_cast<uint32_t*>(&d[0]) = v0;
+                *reinterpret_cast<uint32_t*>(&d[16]) = v1;
+                *reinterpret_cast<uint32_t*>(&d[32]) = v2;
+                *reinterpret_cast<uint32_t*>(&d[48]) = v3;
+
+                d += 4;
+                k -= 4;
+            }
+
+            while (k > 0) {
+
+                d[0] = *a0++;
+                d[16] = *a1++;
+                d[32] = *a2++;
+                d[48] = *a3++;
+
+                d += 1;
+                k -= 1;
+            }
+
+            int8x16_t v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[0]), BitFlipVector));
+            int8x16_t v1 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[16]), BitFlipVector));
+            int8x16_t v2 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[32]), BitFlipVector));
+            int8x16_t v3 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[48]), BitFlipVector));
+
+            RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(v0));
+            RowSums1 = vpadalq_s16(RowSums1, vpaddlq_s8(v1));
+            RowSums2 = vpadalq_s16(RowSums2, vpaddlq_s8(v2));
+            RowSums3 = vpadalq_s16(RowSums3, vpaddlq_s8(v3));
+
+            vst1q_u8(&D[0], vreinterpretq_u8_s8(v0));
+            vst1q_u8(&D[16], vreinterpretq_u8_s8(v1));
+            vst1q_u8(&D[32], vreinterpretq_u8_s8(v2));
+            vst1q_u8(&D[48], vreinterpretq_u8_s8(v3));
+
+            D += 64;
+        }
+
+        RowSums0 = vpaddq_s32(RowSums0, RowSums1);
+        RowSums2 = vpaddq_s32(RowSums2, RowSums3);
+        RowSums0 = vpaddq_s32(RowSums0, RowSums2);
+
+        vst1q_s32(&RowSumBuffer[0], RowSums0);
+        RowSumBuffer += 4;
+
+        A = A + lda * 4;
+        CountM -= 4;
+    }
+
+    //
+    // Process two rows of matrix A.
+    //
+
+    if ((CountM & 2) != 0) {
+
+        const uint8_t* a0 = A;
+        const uint8_t* a1 = a0 + lda;
+
+        size_t k = CountK;
+        int32x4_t RowSums0 = vdupq_n_s32(0);
+        int32x4_t RowSums1 = vdupq_n_s32(0);
+
+        while (k >= 16) {
+
+            int8x16_t v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a0), BitFlipVector));
+            a0 += 16;
+            int8x16_t v1 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a1), BitFlipVector));
+            a1 += 16;
+
+            RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(v0));
+            RowSums1 = vpadalq_s16(RowSums1, vpaddlq_s8(v1));
+
+            vst1q_u8(&D[0], vreinterpretq_u8_s8(v0));
+            vst1q_u8(&D[16], vreinterpretq_u8_s8(v1));
+
+            D += 32;
+            k -= 16;
+        }
+
+        if (k > 0) {
+
+            uint8_t* d = D;
+
+            vst1q_u8(&D[0], BitFlipVector);
+            vst1q_u8(&D[16], BitFlipVector);
+
+            while (k > 0) {
+
+                d[0] = *a0++;
+                d[16] = *a1++;
+
+                d += 1;
+                k -= 1;
+            }
+
+            int8x16_t v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[0]), BitFlipVector));
+            int8x16_t v1 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[16]), BitFlipVector));
+
+            RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(v0));
+            RowSums1 = vpadalq_s16(RowSums1, vpaddlq_s8(v1));
+
+            vst1q_u8(&D[0], vreinterpretq_u8_s8(v0));
+            vst1q_u8(&D[16], vreinterpretq_u8_s8(v1));
+
+            D += 32;
+        }
+
+        RowSums0 = vpaddq_s32(RowSums0, RowSums1);
+        RowSums0 = vpaddq_s32(RowSums0, RowSums0);
+
+        vst1_s32(RowSumBuffer, vget_low_s32(RowSums0));
+        RowSumBuffer += 2;
+
+        A = A + lda * 2;
+    }
+
+    //
+    // Process one row of matrix A.
+    //
+
+    if ((CountM & 1) != 0) {
+
+        const uint8_t* a0 = A;
+
+        size_t k = CountK;
+        int32x4_t RowSums0 = vdupq_n_s32(0);
+
+        while (k >= 16) {
+
+            int8x16_t v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a0), BitFlipVector));
+            a0 += 16;
+
+            RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(v0));
+
+            vst1q_u8(&D[0], vreinterpretq_u8_s8(v0));
+
+            D += 16;
+            k -= 16;
+        }
+
+        if (k > 0) {
+
+            uint8_t* d = D;
+
+            vst1q_u8(&D[0], BitFlipVector);
+
+            while (k > 0) {
+
+                d[0] = *a0++;
+
+                d += 1;
+                k -= 1;
+            }
+
+            int8x16_t v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[0]), BitFlipVector));
+
+            RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(v0));
+
+            vst1q_u8(&D[0], vreinterpretq_u8_s8(v0));
+
+            D += 16;
+        }
+
+#if defined(_M_ARM64)
+        // N.B. The workaround of defining a local vaddvq_u32 doesn't work here
+        // as VS2019 added new intrinsics to make the operation work. Also, not
+        // all build environments using VS2019 have the up-to-date arm64_neon.h,
+        // so fallback to pairwise addition.
+        RowSums0 = vpaddq_s32(RowSums0, RowSums0);
+        RowSums0 = vpaddq_s32(RowSums0, RowSums0);
+        vst1q_lane_s32(RowSumBuffer, RowSums0, 0);
+#else
+        *RowSumBuffer = vaddvq_s32(RowSums0);
+#endif
+    }
+}
+
+template<>
+void
+MlasGemmU8X8CopyPackB<MLAS_GEMM_S8S8_KERNEL_NEON>(
+    MLAS_GEMM_S8S8_KERNEL_NEON::PackedBType* D,
+    const uint8_t* B,
+    size_t ldb,
+    size_t CountN,
+    size_t CountK,
+    int32_t* ColumnSumBuffer,
+    bool BIsSigned
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(BIsSigned);
+
+    while (CountN >= 4) {
+
+        const uint8_t* b = B;
+        size_t k = CountK;
+        int32x4_t ColumnSums0 = vdupq_n_s32(0);
+        int32x4_t ColumnSums1 = vdupq_n_s32(0);
+        int32x4_t ColumnSums2 = vdupq_n_s32(0);
+        int32x4_t ColumnSums3 = vdupq_n_s32(0);
+
+        while (k >= 16) {
+
+            for (size_t nn = 0; nn < 4; nn++) {
+                for (size_t kk = 0; kk < 16; kk++) {
+                    D[nn * 16 + kk] = (b[kk * ldb + nn] );
+                }
+            }
+
+            ColumnSums0 = vpadalq_s16(ColumnSums0, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[0]))));
+            ColumnSums1 = vpadalq_s16(ColumnSums1, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[16]))));
+            ColumnSums2 = vpadalq_s16(ColumnSums2, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[32]))));
+            ColumnSums3 = vpadalq_s16(ColumnSums3, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[48]))));
+
+            b += 16 * ldb;
+            D += 64;
+            k -= 16;
+        }
+
+        if (k > 0) {
+
+            vst1q_u8(&D[0], vdupq_n_u8(0));
+            vst1q_u8(&D[16], vdupq_n_u8(0));
+            vst1q_u8(&D[32], vdupq_n_u8(0));
+            vst1q_u8(&D[48], vdupq_n_u8(0));
+
+            for (size_t nn = 0; nn < 4; nn++) {
+                for (size_t kk = 0; kk < k; kk++) {
+                    D[nn * 16 + kk] = (b[kk * ldb + nn] );
+                }
+            }
+
+            ColumnSums0 = vpadalq_s16(ColumnSums0, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[0]))));
+            ColumnSums1 = vpadalq_s16(ColumnSums1, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[16]))));
+            ColumnSums2 = vpadalq_s16(ColumnSums2, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[32]))));
+            ColumnSums3 = vpadalq_s16(ColumnSums3, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[48]))));
+
+            D += 64;
+        }
+
+        ColumnSums0 = vpaddq_s32(ColumnSums0, ColumnSums1);
+        ColumnSums2 = vpaddq_s32(ColumnSums2, ColumnSums3);
+        ColumnSums0 = vpaddq_s32(ColumnSums0, ColumnSums2);
+
+        vst1q_s32(&ColumnSumBuffer[0], ColumnSums0);
+        ColumnSumBuffer += 4;
+
+        B += 4;
+        CountN -= 4;
+    }
+
+    if (CountN > 0) {
+
+        const uint8_t* b = B;
+        size_t k = CountK;
+        int32x4_t ColumnSums0 = vdupq_n_s32(0);
+        int32x4_t ColumnSums1 = vdupq_n_s32(0);
+        int32x4_t ColumnSums2 = vdupq_n_s32(0);
+        int32x4_t ColumnSums3 = vdupq_n_s32(0);
+
+        while (k >= 16) {
+
+            for (size_t nn = 0; nn < CountN; nn++) {
+                for (size_t kk = 0; kk < 16; kk++) {
+                    D[nn * 16 + kk] = (b[kk * ldb + nn] );
+                }
+            }
+
+            ColumnSums0 = vpadalq_s16(ColumnSums0, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[0]))));
+            ColumnSums1 = vpadalq_s16(ColumnSums1, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[16]))));
+            ColumnSums2 = vpadalq_s16(ColumnSums2, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[32]))));
+            ColumnSums3 = vpadalq_s16(ColumnSums3, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[48]))));
+
+            b += 16 * ldb;
+            D += 64;
+            k -= 16;
+        }
+
+        if (k > 0) {
+
+            vst1q_u8(&D[0], vdupq_n_u8(0));
+            vst1q_u8(&D[16], vdupq_n_u8(0));
+            vst1q_u8(&D[32], vdupq_n_u8(0));
+            vst1q_u8(&D[48], vdupq_n_u8(0));
+
+            for (size_t nn = 0; nn < CountN; nn++) {
+                for (size_t kk = 0; kk < k; kk++) {
+                    D[nn * 16 + kk] = (b[kk * ldb + nn] );
+                }
+            }
+
+            ColumnSums0 = vpadalq_s16(ColumnSums0, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[0]))));
+            ColumnSums1 = vpadalq_s16(ColumnSums1, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[16]))));
+            ColumnSums2 = vpadalq_s16(ColumnSums2, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[32]))));
+            ColumnSums3 = vpadalq_s16(ColumnSums3, vpaddlq_s8(vreinterpretq_s8_u8(vld1q_u8(&D[48]))));
+
+            D += 64;
+        }
+
+        ColumnSums0 = vpaddq_s32(ColumnSums0, ColumnSums1);
+        ColumnSums2 = vpaddq_s32(ColumnSums2, ColumnSums3);
+        ColumnSums0 = vpaddq_s32(ColumnSums0, ColumnSums2);
+
+        vst1q_s32(&ColumnSumBuffer[0], ColumnSums0);
+        ColumnSumBuffer += 4;
+    }
+}
+
+template<>
+MLAS_FORCEINLINE
+size_t
+MlasGemmU8X8Kernel<MLAS_GEMM_S8S8_KERNEL_NEON>(
+    const MLAS_GEMM_S8S8_KERNEL_NEON::PackedAType* A,
+    const MLAS_GEMM_S8S8_KERNEL_NEON::PackedBType* B,
+    int32_t* C,
+    size_t PackedCountK,
+    size_t CountM,
+    size_t CountN,
+    size_t ldc,
+    const int32_t* RowSumBuffer,
+    const int32_t* ColumnSumBuffer,
+    const int32_t* ZeroPointB,
+    bool ZeroMode
+    )
+{
+    return MlasGemmS8S8KernelNeon(A, B, C, PackedCountK, CountM, CountN, ldc,
+        RowSumBuffer, ColumnSumBuffer, ZeroPointB, ZeroMode);
+}
+
+
+const MLAS_GEMM_U8X8_DISPATCH MlasGemmS8S8DispatchNeon = {
+    MlasGemmU8X8Operation<MLAS_GEMM_S8S8_KERNEL_NEON>,
+    MlasGemmU8X8PackedOperation<MLAS_GEMM_S8S8_KERNEL_NEON>,
+    MlasGemmU8X8CopyPackB<MLAS_GEMM_S8S8_KERNEL_NEON>,
+    MLAS_GEMM_S8S8_KERNEL_NEON::PackedK,
+    MLAS_GEMM_S8S8_KERNEL_NEON::PackedStrides.K,
 };

--- a/onnxruntime/test/mlas/bench/bench_qgemm.cpp
+++ b/onnxruntime/test/mlas/bench/bench_qgemm.cpp
@@ -57,7 +57,7 @@ void QGEMM(benchmark::State& state, bool pack_b) {
 
 
   std::vector<MLAS_GEMM_U8X8_DATA_PARAMS> gemm_data_vec(batch);
-  for (int i = 0; i < batch; i++) {
+  for (size_t i = 0; i < batch; i++) {
     auto& gemm_params = gemm_data_vec[i];
     gemm_params.lda = gemm_shape.K;
     gemm_params.ZeroPointA = a_zero_point;
@@ -81,27 +81,34 @@ void QGEMM(benchmark::State& state, bool pack_b) {
 static void QGemmSize(benchmark::internal::Benchmark* b) {
   b->ArgNames(qgemm_arg_names);
   // Args for  "M", "N", "K", "Batch",
-  std::vector<std::vector<int64_t>> mnk_batch = {
-      {512, 64, 512, 12},
-      {512, 512, 64, 12},
-      {512, 768, 768, 1},
-      {512, 768, 3072, 1},
-      {128, 768, 2304, 1},
-      {128, 768, 2304, 6},
-      {128, 1024, 4096, 1},
-      {128, 1024, 4096, 6},
-      {128, 2048, 8192, 1},
-      {128, 4096, 16384, 1}
-  };
 
-  // Args for Threads
-  for (int64_t threads : {2, 4, 8, 16}) {
-    for (auto& shape : mnk_batch) {
-      std::vector<int64_t> copy(shape);
-      copy.push_back(threads);
-      b->Args(copy);
-    }
-  }
+  b->Args({512, 32128, 768, 1, 1});
+  b->Args({512, 32128, 768, 1, 4});
+  b->Args({512, 32128, 768, 1, 6});
+
+  b->Args({512, 3072, 768, 1, 1});
+  b->Args({512, 3072, 768, 1, 4});
+  b->Args({512, 3072, 768, 1, 6});
+
+  b->Args({512, 768, 3072, 1, 1});
+  b->Args({512, 768, 3072, 1, 4});
+  b->Args({512, 768, 3072, 1, 6});
+
+  b->Args({512, 768, 768, 1, 1});
+  b->Args({512, 768, 768, 1, 4});
+  b->Args({512, 768, 768, 1, 6});
+
+  b->Args({512, 64, 512, 1, 1});
+  b->Args({512, 64, 512, 1, 4});
+  b->Args({512, 64, 512, 1, 6});
+
+  b->Args({512, 512, 64, 12, 1});
+  b->Args({512, 512, 64, 12, 4});
+  b->Args({512, 512, 64, 12, 6});
+
+  b->Args({512, 64, 512, 12, 1});
+  b->Args({512, 64, 512, 12, 4});
+  b->Args({512, 64, 512, 12, 6});
 }
 
 


### PR DESCRIPTION
Using signed int, qgemm kernel avoids extending uint8 to int16 while computing matrix multiplication, achieving higher performance.  We also find that by using only lower 64b of vector registers to load A and B matrix, we can get further performance improvements.   We also experimented with using ldp to load two 64b in one shot, vs using two ldr to load one 64b at a time, in both Big and little cores, there is no noticeable differences.

Submitting the LDP version. At this point we don't need to choose kernel based on micro-architecture. 

Inference time of resnet50, thread count 2

Big Core on Pixel 3a
Current master:               292.947 ms
First iteration S8S8:         188.239 ms
LDP load two 64b reg:    178.715 ms
LDR load one 64b reg:    179.536 ms

Little Core 
Master:                            546.317 ms
S8S8:                               513.332 ms
LDP:                                 489.19 ms
LDR:                                 497.865 ms

Raspberry Pi 3B+
Master:                            660.08 ms
S8S8:                               608.577 ms
LDP:                                 603.675 ms
LDR                                 602.075 ms
