### PR TITLE
Reduce templatization of C API and refactor for InitOrtValue

### DIFF
--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -37,7 +37,7 @@ namespace onnxruntime {
 class Tensor final {
  public:
   static std::unique_ptr<Tensor> Create(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAllocator> allocator) {
-    return std::make_unique<Tensor>(p_type, shape, allocator);
+    return std::make_unique<Tensor>(p_type, shape, std::move(allocator));
   }
   static std::unique_ptr<Tensor> Create(MLDataType p_type, const TensorShape& shape, void* p_data, const OrtMemoryInfo& alloc, ptrdiff_t offset = 0) {
     return std::make_unique<Tensor>(p_type, shape, p_data, alloc, offset);

--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -17,6 +17,8 @@
 #include "core/framework/data_types.h"
 #include "core/framework/data_types_internal.h"
 
+struct OrtValue;
+
 namespace onnxruntime {
 
 //TODO:ensure dtype_!=nullptr
@@ -56,11 +58,37 @@ class Tensor final {
   Tensor(MLDataType p_type, const TensorShape& shape, void* p_data, const OrtMemoryInfo& alloc,
          ptrdiff_t offset = 0);
 
+  /// <summary>
+  /// Creates an instance of Tensor on the heap using the appropriate __ctor and
+  /// initializes OrtValue with it.
+  /// </summary>
+  /// <param name="p_type"></param>
+  /// <param name="shape"></param>
+  /// <param name="p_data"></param>
+  /// <param name="info"></param>
+  /// <param name="offset"></param>
+  static void InitOrtValue(MLDataType p_type, const TensorShape& shape,
+                           void* p_data, const OrtMemoryInfo& location,
+                           OrtValue& ort_value);
+
   /**
    * Deprecated. The orginal design is this Tensor class won't do any allocation / release.
    * However, this function will allocate the buffer for the shape, and do placement new if p_type is string tensor.
    */
   Tensor(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAllocator> allocator);
+
+  /// <summary>
+  /// Creates an instance of Tensor on the heap using the appropriate __ctor and
+  /// initializes OrtValue with it.
+  /// </summary>
+  /// <param name="elt_type"></param>
+  /// <param name="shape"></param>
+  /// <param name="allocator"></param>
+  /// <param name="ort_value"></param>
+  static void InitOrtValue(MLDataType elt_type,
+                           const TensorShape& shape,
+                           std::shared_ptr<IAllocator> allocator,
+                           OrtValue& ort_value);
 
   /**
    * Create tensor with given type, shape, pre-allocated memory and allocator which will be used to free the pre-allocated memory.

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -275,10 +275,7 @@ void IExecutionFrame::Init(const std::vector<int>& feed_mlvalue_idxs, const std:
           // for a subgraph with an output of unknown shape that needs to be accumulated by the control flow node.
           // If the initializer is providing the output, the shape is known.
           AllocatorPtr allocator = GetAllocator(src.Location());
-
-          auto p_tensor = std::make_unique<Tensor>(src.DataType(), src.Shape(), allocator);
-          auto ml_tensor = DataTypeImpl::GetType<Tensor>();
-          dest.Init(p_tensor.release(), ml_tensor, ml_tensor->GetDeleteFunc());
+          Tensor::InitOrtValue(src.DataType(), src.Shape(), std::move(allocator), dest);
         }
         ORT_THROW_IF_ERROR(CopyTensor(src, *dest.GetMutable<Tensor>()));
       }
@@ -527,12 +524,7 @@ Status ExecutionFrame::AllocateMLValueTensorSelfOwnBufferHelper(OrtValue& ort_va
 
   //no memory pattern, or the pattern is not correct.
   if (!alloc) alloc = GetAllocator(location);
-  std::unique_ptr<Tensor> p_tensor = std::make_unique<Tensor>(element_type, shape, alloc);
-
-  {
-    auto ml_tensor = DataTypeImpl::GetType<Tensor>();
-    ort_value.Init(p_tensor.release(), ml_tensor, ml_tensor->GetDeleteFunc());
-  }
+  Tensor::InitOrtValue(element_type, shape, std::move(alloc), ort_value);
 
   // trace the memory allocation.
   // don't trace the memory allocation on string tensors, as it need
@@ -604,10 +596,7 @@ Status ExecutionFrame::AllocateTensorWithPreAllocateBufferHelper(OrtValue& ort_v
                                                                  MLDataType element_type,
                                                                  const OrtMemoryInfo& location,
                                                                  const TensorShape& shape) {
-  auto ml_tensor = DataTypeImpl::GetType<Tensor>();
-  auto p_tensor = std::make_unique<Tensor>(element_type, shape, pBuffer, location);
-  ort_value.Init(p_tensor.release(), ml_tensor, ml_tensor->GetDeleteFunc());
-
+  Tensor::InitOrtValue(element_type, shape, pBuffer, location, ort_value);
   return Status::OK();
 }
 

--- a/onnxruntime/core/framework/tensor_type_and_shape.h
+++ b/onnxruntime/core/framework/tensor_type_and_shape.h
@@ -22,3 +22,5 @@ struct OrtTensorTypeAndShapeInfo {
 
   OrtStatus* Clone(OrtTensorTypeAndShapeInfo** out);
 };
+
+ONNXTensorElementDataType TensorDataTypeToOnnxRuntimeTensorElementDataType(int32_t dtype);

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -135,11 +135,9 @@ static common::Status AllocateHelper(const AllocatorPtr& allocator,
 
   if (source_mlvalue.IsTensor()) {
     const Tensor& source_tensor = source_mlvalue.Get<Tensor>();
-    std::unique_ptr<Tensor> target_tensor = std::make_unique<Tensor>(source_tensor.DataType(),
-                                                                     source_tensor.Shape(),
-                                                                     allocator);
-    auto ml_tensor = DataTypeImpl::GetType<Tensor>();
-    target_mlvalue.Init(target_tensor.release(), ml_tensor, ml_tensor->GetDeleteFunc());
+    Tensor::InitOrtValue(source_tensor.DataType(),
+                         source_tensor.Shape(),
+                         allocator, target_mlvalue);
   } else if (source_mlvalue.IsSparseTensor()) {
     const SparseTensor& source_tensor = source_mlvalue.Get<SparseTensor>();
     auto p_tensor = std::make_unique<SparseTensor>(source_tensor.DataType(),

--- a/onnxruntime/core/optimizer/optimizer_execution_frame.cc
+++ b/onnxruntime/core/optimizer/optimizer_execution_frame.cc
@@ -171,13 +171,7 @@ Status OptimizerExecutionFrame::CreateNodeOutputMLValueImpl(OrtValue& ort_value,
   // tensors
   auto element_type = static_cast<const TensorTypeBase*>(ml_type)->GetElementType();
   AllocatorPtr allocator_ptr = info_.GetAllocator();
-  std::unique_ptr<Tensor> p_tensor = std::make_unique<Tensor>(element_type,
-                                                              *shape,
-                                                              allocator_ptr);
-
-  auto ml_tensor = DataTypeImpl::GetType<Tensor>();
-  ort_value.Init(p_tensor.release(), ml_tensor, ml_tensor->GetDeleteFunc());
-
+  Tensor::InitOrtValue(element_type, *shape, std::move(allocator_ptr), ort_value);
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
@@ -292,13 +292,9 @@ Status IterateSequence(OpKernelContextInternal& context, const SessionState& ses
 }
 
 OrtValue AllocateTensorInMLValue(const MLDataType data_type, const TensorShape& shape, AllocatorPtr& allocator) {
-  auto new_tensor = std::make_unique<Tensor>(data_type,
-                                                     shape,
-                                                     allocator);
-
-  auto ml_tensor = DataTypeImpl::GetType<Tensor>();
-  return OrtValue{new_tensor.release(), ml_tensor,
-                  ml_tensor->GetDeleteFunc()};
+  OrtValue ort_value;
+  Tensor::InitOrtValue(data_type, shape, allocator, ort_value);
+  return ort_value;
 };
 
 void CalculateTransposedShapeForInput(const TensorShape& original_shape, int64_t axis,

--- a/onnxruntime/core/providers/cpu/controlflow/utils.h
+++ b/onnxruntime/core/providers/cpu/controlflow/utils.h
@@ -19,16 +19,16 @@ namespace onnxruntime {
 // Creates a scalar MLValue based on given value and allocator.
 template <typename T>
 OrtValue MakeScalarMLValue(const AllocatorPtr& allocator, T value, bool is_1d) {
+  std::vector<int64_t> dims;
+  if (is_1d) {
+    dims.push_back(1);
+  }
+  TensorShape shape(std::move(dims));
   auto* data_type = DataTypeImpl::GetType<T>();
-  std::unique_ptr<Tensor> p_tensor = std::make_unique<Tensor>(data_type,
-                                                                      is_1d ? TensorShape({1}) : TensorShape({}),
-                                                                      allocator);
-
-  *p_tensor->MutableData<T>() = value;
-
-  auto ml_tensor = DataTypeImpl::GetType<Tensor>();
-  return OrtValue{p_tensor.release(), ml_tensor,
-                  ml_tensor->GetDeleteFunc()};
+  OrtValue ort_value;
+  Tensor::InitOrtValue(data_type, shape, allocator, ort_value);
+  *ort_value.GetMutable<Tensor>()->MutableData<T>() = value;
+  return ort_value;
 }
 
 namespace controlflow {

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -657,6 +657,9 @@ struct ProviderHost {
   virtual std::unique_ptr<Tensor> Tensor__construct(MLDataType p_type, const TensorShape& shape, void* p_data, const OrtMemoryInfo& alloc, ptrdiff_t offset) = 0;
   virtual void Tensor__operator_delete(Tensor* p) = 0;
 
+  virtual void Tensor__InitOrtValue(MLDataType elt_type, const TensorShape& shape, std::shared_ptr<IAllocator> allocator, OrtValue& ort_value) = 0;
+  virtual void Tensor__InitOrtValue(MLDataType p_type, const TensorShape& shape, void* p_data, const OrtMemoryInfo& location, OrtValue& ort_value) = 0;
+
   virtual bool* Tensor__MutableData_bool(Tensor* p) = 0;
   virtual int8_t* Tensor__MutableData_int8(Tensor* p) = 0;
   virtual uint8_t* Tensor__MutableData_uint8(Tensor* p) = 0;

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -792,10 +792,18 @@ class SessionState {
 };
 
 struct Tensor final {
-  static std::unique_ptr<Tensor> Create(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAllocator> allocator) { return g_host->Tensor__construct(p_type, shape, allocator); }
+  static std::unique_ptr<Tensor> Create(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAllocator> allocator) { return g_host->Tensor__construct(p_type, shape, std::move(allocator)); }
   static std::unique_ptr<Tensor> Create(MLDataType p_type, const TensorShape& shape, void* p_data, const OrtMemoryInfo& alloc, ptrdiff_t offset = 0) { return g_host->Tensor__construct(p_type, shape, p_data, alloc, offset); }
 
   static void operator delete(void* p) { g_host->Tensor__operator_delete(reinterpret_cast<Tensor*>(p)); }
+
+  static void InitOrtValue(MLDataType elt_type, const TensorShape& shape, std::shared_ptr<IAllocator> allocator, OrtValue& ort_value) {
+    g_host->Tensor__InitOrtValue(elt_type, shape, std::move(allocator), ort_value);
+  }
+
+  static void InitOrtValue(MLDataType p_type, const TensorShape& shape, void* p_data, const OrtMemoryInfo& location, OrtValue& ort_value) {
+    g_host->Tensor__InitOrtValue(p_type, shape, p_data, location, ort_value);
+  }
 
   template <typename T>
   T* MutableData();

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1126,15 +1126,6 @@ ORT_STATUS_PTR PopulateTensorWithData(Tensor& tensor, bool is_string, _In_ const
   return nullptr;
 }
 
-// Return status instead of throwing if unsupported type specified
-struct UnsupportedReturnFailStatus {
-  void operator()(int32_t dt_type, OrtStatusPtr& status) const {
-    std::string msg("Unsupported tensor element type in the input: ");
-    msg.append(std::to_string(dt_type));
-    status = OrtApis::CreateStatus(ORT_FAIL, msg.c_str());
-  }
-};
-
 ORT_STATUS_PTR CreateTensorAndPopulate(MLDataType element_type, const int64_t* shape, size_t shape_len,
                                        const void* data, size_t num_elements, _Inout_ OrtAllocator* allocator, OrtValue& result) {
   ORT_API_RETURN_IF_ERROR(CreateTensorImpl(element_type, shape, shape_len, allocator, result));

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -8,6 +8,7 @@
 #include "core/framework/allocator.h"
 #include "core/framework/error_code_helper.h"
 #include "core/framework/execution_provider.h"
+#include "core/framework/tensor_type_and_shape.h"
 #include "core/framework/utils.h"
 #include <cassert>
 #include <cstring>
@@ -152,30 +153,21 @@ ORT_API_STATUS_IMPL(OrtApis::DisableTelemetryEvents, _In_ const OrtEnv* ort_env)
 }
 
 ORT_STATUS_PTR CreateTensorImpl(MLDataType ml_type, const int64_t* shape, size_t shape_len,
-                                _Inout_ OrtAllocator* allocator, std::unique_ptr<Tensor>* out) {
-  std::vector<int64_t> shapes(shape_len);
-  for (size_t i = 0; i != shape_len; ++i) {
-    shapes[i] = shape[i];
-  }
-  std::shared_ptr<IAllocator> alloc_ptr = std::make_shared<onnxruntime::IAllocatorImplWrappingOrtAllocator>(allocator);
-  *out = std::make_unique<Tensor>(ml_type, onnxruntime::TensorShape(shapes), alloc_ptr);
+                                _Inout_ OrtAllocator* allocator, OrtValue& value) {
+  TensorShape tensor_shape(shape, shape_len);
+  AllocatorPtr alloc_ptr = std::make_shared<onnxruntime::IAllocatorImplWrappingOrtAllocator>(allocator);
+  Tensor::InitOrtValue(ml_type, tensor_shape, std::move(alloc_ptr), value);
   return nullptr;
 }
 
 ORT_STATUS_PTR CreateTensorImplForSeq(MLDataType elem_type, const int64_t* shape, size_t shape_len, Tensor& out) {
-  std::vector<int64_t> shapes(shape_len);
-  for (size_t i = 0; i != shape_len; ++i) {
-    shapes[i] = shape[i];
-  }
   OrtAllocator* allocator;
   // TODO(pranav): what allocator should be used to create the tensor here?
   // for the sake of simplicity of the API using the default one here
-  auto st = OrtApis::GetAllocatorWithDefaultOptions(&allocator);
-  if (st) {
-    return st;
-  }
-  std::shared_ptr<IAllocator> alloc_ptr = std::make_shared<onnxruntime::IAllocatorImplWrappingOrtAllocator>(allocator);
-  out = Tensor(elem_type, onnxruntime::TensorShape(shapes), alloc_ptr);
+  ORT_API_RETURN_IF_ERROR(OrtApis::GetAllocatorWithDefaultOptions(&allocator));
+  AllocatorPtr alloc_ptr = std::make_shared<onnxruntime::IAllocatorImplWrappingOrtAllocator>(allocator);
+  TensorShape tensor_shape(shape, shape_len);
+  out = Tensor(elem_type, tensor_shape, std::move(alloc_ptr));
   return nullptr;
 }
 
@@ -184,16 +176,13 @@ ORT_STATUS_PTR CreateTensorImplForSeq(MLDataType elem_type, const int64_t* shape
  * this function will create a copy of the allocator info
  */
 ORT_STATUS_PTR CreateTensorImpl(MLDataType ml_type, const int64_t* shape, size_t shape_len, const OrtMemoryInfo* info,
-                                void* p_data, size_t p_data_len, std::unique_ptr<Tensor>* out) {
-  size_t elem_count = 1;
-  std::vector<int64_t> shapes(shape_len);
-  for (size_t i = 0; i != shape_len; ++i) {
-    if (shape[i] < 0)
-      return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "tried creating tensor with negative value in shape");
-    elem_count *= static_cast<size_t>(shape[i]);
-    shapes[i] = shape[i];
+                                void* p_data, size_t p_data_len, OrtValue& ort_value) {
+  TensorShape tensor_shape(shape, shape_len);
+  if (std::any_of(tensor_shape.GetDims().cbegin(), tensor_shape.GetDims().cend(), [](int64_t v) { return v < 0; })) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "tried creating tensor with negative value in shape");
   }
 
+  auto elem_count = gsl::narrow<size_t>(tensor_shape.Size());
   size_t size_to_allocate;
   if (!IAllocator::CalcMemSizeForArray(ml_type->Size(), elem_count, &size_to_allocate)) {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "size overflow");
@@ -203,90 +192,17 @@ ORT_STATUS_PTR CreateTensorImpl(MLDataType ml_type, const int64_t* shape, size_t
     oss << "not enough space: expected " << size_to_allocate << ", got " << p_data_len;
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, oss.str().c_str());
   }
-  *out = std::make_unique<Tensor>(ml_type, onnxruntime::TensorShape(shapes), p_data, *info);
+  Tensor::InitOrtValue(ml_type, tensor_shape, p_data, *info, ort_value);
   return nullptr;
 }
-
-namespace c_api_internal {
-
-template <class T>
-inline ORT_STATUS_PTR CallCreateTensorImpl(const int64_t* shape, size_t shape_len, const OrtMemoryInfo* info,
-                                           void* p_data, size_t p_data_len, std::unique_ptr<Tensor>* out) {
-  auto ml_value = DataTypeImpl::GetType<T>();
-  return CreateTensorImpl(ml_value, shape, shape_len, info, p_data, p_data_len, out);
-}
-
-template <class T>
-inline ORT_STATUS_PTR CallCreateTensorImpl(const int64_t* shape, size_t shape_len, _Inout_ OrtAllocator* allocator,
-                                           std::unique_ptr<Tensor>* out) {
-  auto ml_type = DataTypeImpl::GetType<T>();
-  return CreateTensorImpl(ml_type, shape, shape_len, allocator, out);
-}
-
-}  // namespace c_api_internal
 
 ORT_API_STATUS_IMPL(OrtApis::CreateTensorWithDataAsOrtValue, _In_ const OrtMemoryInfo* info,
                     _Inout_ void* p_data, size_t p_data_len, _In_ const int64_t* shape, size_t shape_len,
                     ONNXTensorElementDataType type, _Outptr_ OrtValue** out) {
   API_IMPL_BEGIN
-  std::unique_ptr<Tensor> tensor;
-  switch (type) {
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<float>(shape, shape_len, info, p_data, p_data_len, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<uint8_t>(shape, shape_len, info, p_data, p_data_len, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<int8_t>(shape, shape_len, info, p_data, p_data_len, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<uint16_t>(shape, shape_len, info, p_data, p_data_len, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<int16_t>(shape, shape_len, info, p_data, p_data_len, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<int32_t>(shape, shape_len, info, p_data, p_data_len, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<uint32_t>(shape, shape_len, info, p_data, p_data_len, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<int64_t>(shape, shape_len, info, p_data, p_data_len, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<uint64_t>(shape, shape_len, info, p_data, p_data_len, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<std::string>(shape, shape_len, info, p_data, p_data_len, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<bool>(shape, shape_len, info, p_data, p_data_len, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<MLFloat16>(shape, shape_len, info, p_data, p_data_len, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<BFloat16>(shape, shape_len, info, p_data, p_data_len, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<double>(shape, shape_len, info, p_data, p_data_len, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64:
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128:
-    default: {
-      std::ostringstream oss;
-      oss << "type " << type << " is not supported in this function";
-      std::string errmsg = oss.str();
-      return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, errmsg.c_str());
-    }
-  }
+  auto ml_type = DataTypeImpl::TensorTypeFromONNXEnum(type)->GetElementType();
   auto value = std::make_unique<OrtValue>();
-  auto ml_tensor = DataTypeImpl::GetType<Tensor>();
-  value->Init(tensor.release(),
-              ml_tensor,
-              ml_tensor->GetDeleteFunc());
+  ORT_API_RETURN_IF_ERROR(CreateTensorImpl(ml_type, shape, shape_len, info, p_data, p_data_len, *value));
   *out = value.release();
   return nullptr;
   API_IMPL_END
@@ -296,64 +212,9 @@ ORT_API_STATUS_IMPL(OrtApis::CreateTensorAsOrtValue, _Inout_ OrtAllocator* alloc
                     _In_ const int64_t* shape, size_t shape_len, ONNXTensorElementDataType type,
                     _Outptr_ OrtValue** out) {
   API_IMPL_BEGIN
-  std::unique_ptr<Tensor> tensor;
-  switch (type) {
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<float>(shape, shape_len, allocator, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<uint8_t>(shape, shape_len, allocator, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<int8_t>(shape, shape_len, allocator, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<uint16_t>(shape, shape_len, allocator, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<int16_t>(shape, shape_len, allocator, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<int32_t>(shape, shape_len, allocator, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<uint32_t>(shape, shape_len, allocator, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<int64_t>(shape, shape_len, allocator, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<uint64_t>(shape, shape_len, allocator, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<std::string>(shape, shape_len, allocator, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<bool>(shape, shape_len, allocator, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<MLFloat16>(shape, shape_len, allocator, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<BFloat16>(shape, shape_len, allocator, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
-      ORT_API_RETURN_IF_ERROR(c_api_internal::CallCreateTensorImpl<double>(shape, shape_len, allocator, &tensor));
-      break;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64:
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128:
-    default: {
-      std::ostringstream oss;
-      oss << "type " << type << " is not supported in this function";
-      std::string errmsg = oss.str();
-      return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED, errmsg.c_str());
-    }
-  }
+  auto ml_type = DataTypeImpl::TensorTypeFromONNXEnum(type)->GetElementType();
   auto value = std::make_unique<OrtValue>();
-  auto ml_tensor = DataTypeImpl::GetType<Tensor>();
-  value->Init(tensor.release(),
-              ml_tensor,
-              ml_tensor->GetDeleteFunc());
+  ORT_API_RETURN_IF_ERROR(CreateTensorImpl(ml_type, shape, shape_len, allocator, *value));
   *out = value.release();
   return nullptr;
   API_IMPL_END
@@ -1179,13 +1040,6 @@ ORT_STATUS_PTR OrtGetNumSequenceElements(const OrtValue* p_ml_value, size_t* out
   return nullptr;
 }
 
-template <>
-ORT_STATUS_PTR OrtGetNumSequenceElements<TensorSeq>(const OrtValue* p_ml_value, size_t* out) {
-  auto& data = p_ml_value->Get<TensorSeq>();
-  *out = data.Size();
-  return nullptr;
-}
-
 #if !defined(DISABLE_ML_OPS)
 static const int NUM_MAP_INDICES = 2;
 #endif
@@ -1203,18 +1057,17 @@ static ORT_STATUS_PTR OrtGetValueCountImpl(const OrtValue* value, size_t* out) {
 #endif
   }
   if (value_type == ONNX_TYPE_SEQUENCE) {
-    auto v = reinterpret_cast<const OrtValue*>(value);
-    auto type = v->Type();
     // Note: keep these in sync with the registered types in data_types.h
-    if (type->IsTensorSequenceType()) {
-      return OrtGetNumSequenceElements<TensorSeq>(v, out);
+    if (value->IsTensorSequence()) {
+      *out = value->Get<TensorSeq>().Size();
+      return nullptr;
     } else {
 #if !defined(DISABLE_ML_OPS)
-      utils::ContainerChecker c_checker(type);
+      utils::ContainerChecker c_checker(value->Type());
       if (c_checker.IsSequenceOf<std::map<std::string, float>>()) {
-        return OrtGetNumSequenceElements<VectorMapStringToFloat>(v, out);
+        return OrtGetNumSequenceElements<VectorMapStringToFloat>(value, out);
       } else if (c_checker.IsSequenceOf<std::map<int64_t, float>>()) {
-        return OrtGetNumSequenceElements<VectorMapInt64ToFloat>(v, out);
+        return OrtGetNumSequenceElements<VectorMapInt64ToFloat>(value, out);
       } else {
         return OrtApis::CreateStatus(ORT_FAIL, "Input is not of one of the supported sequence types.");
       }
@@ -1232,6 +1085,8 @@ ORT_API_STATUS_IMPL(OrtApis::GetValueCount, _In_ const OrtValue* value, _Out_ si
   return OrtGetValueCountImpl(value, out);
   API_IMPL_END
 }
+
+namespace c_api_internal {
 
 #if !defined(DISABLE_ML_OPS)
 ///////////////////
@@ -1254,45 +1109,22 @@ static ORT_STATUS_PTR OrtGetValueImplSeqOfMap(const OrtValue* p_ml_value, int in
 }
 #endif
 
-ORT_STATUS_PTR PopulateTensorWithData(_Inout_ OrtValue* oval, _In_ const void* data_elem, size_t num_elems,
+ORT_STATUS_PTR PopulateTensorWithData(Tensor& tensor, bool is_string, _In_ const void* data_elem, size_t num_elems,
                                       size_t elem_size) {
-  void* raw_data = nullptr;
-  auto st = OrtApis::GetTensorMutableData(oval, &raw_data);
-  if (st) {
-    return st;
-  }
-  memcpy(raw_data, data_elem, elem_size * num_elems);
-  return nullptr;
-}
-
-ORT_STATUS_PTR PopulateTensorWithData(_Inout_ OrtValue* oval, _In_reads_(num_elems) const std::string* data_elem,
-                                      size_t num_elems, size_t /* elem_size */) {
-  auto v = reinterpret_cast<OrtValue*>(oval);
-  auto tensor = v->GetMutable<Tensor>();
-  auto* dst = tensor->MutableData<std::string>();
-  auto len = static_cast<size_t>(tensor->Shape().Size());
+  auto len = gsl::narrow<size_t>(tensor.Shape().Size());
   if (num_elems < len) {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "input array is too short");
   }
-  for (size_t i = 0; i < len; ++i) {
-    dst[i] = data_elem[i];
+  if (!is_string) {
+    memcpy(tensor.MutableDataRaw(), data_elem, elem_size * num_elems);
+  } else {
+    const std::string* strings = reinterpret_cast<const std::string*>(data_elem);
+    auto str_span = gsl::make_span(strings, num_elems);
+    auto* dst = tensor.MutableData<std::string>();
+    std::copy(str_span.cbegin(), str_span.cend(), dst);
   }
   return nullptr;
 }
-
-namespace c_api_internal {
-template <class TensorElemType>
-struct CallGetValueImpl {
-  ORT_STATUS_PTR operator()(_Inout_ OrtAllocator* allocator, const onnxruntime::Tensor& tensor,
-                            _Outptr_ OrtValue** out) const {
-    const auto& shape = tensor.Shape();
-    const auto* tensor_data = tensor.Data<TensorElemType>();
-    OrtStatus* st = OrtApis::CreateTensorAsOrtValue(allocator, shape.GetDims().data(), shape.NumDimensions(),
-                                                    onnxruntime::utils::GetONNXTensorElementDataType<TensorElemType>(), out);
-    //TODO: check overflow before doing static_cast
-    return st ? st : PopulateTensorWithData(*out, tensor_data, static_cast<size_t>(shape.Size()), sizeof(TensorElemType));
-  }
-};
 
 // Return status instead of throwing if unsupported type specified
 struct UnsupportedReturnFailStatus {
@@ -1302,22 +1134,33 @@ struct UnsupportedReturnFailStatus {
     status = OrtApis::CreateStatus(ORT_FAIL, msg.c_str());
   }
 };
+
+ORT_STATUS_PTR CreateTensorAndPopulate(MLDataType element_type, const int64_t* shape, size_t shape_len,
+                                       const void* data, size_t num_elements, _Inout_ OrtAllocator* allocator, OrtValue& result) {
+  ORT_API_RETURN_IF_ERROR(CreateTensorImpl(element_type, shape, shape_len, allocator, result));
+  ORT_API_RETURN_IF_ERROR(PopulateTensorWithData(*result.GetMutable<Tensor>(), utils::IsDataTypeString(element_type),
+                                                 data, num_elements, element_type->Size()));
+  return nullptr;
+}
+
 }  // namespace c_api_internal
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 6101)
 #endif
-ORT_STATUS_PTR OrtGetValueImplSeqOfTensors(_In_ const OrtValue* p_ml_value, int index, _In_opt_ OrtAllocator* allocator,
-                                           _Outptr_ OrtValue** out) {
-  auto& data = p_ml_value->Get<TensorSeq>();
-  auto& one_tensor = data.Get(index);
 
-  using namespace c_api_internal;
-  utils::MLTypeCallDispatcher<float, double, MLFloat16, BFloat16, bool, std::string,
-                              int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t>
-      t_disp(one_tensor.GetElementType());
-  return t_disp.template InvokeRetWithUnsupportedPolicy<OrtStatusPtr, CallGetValueImpl, UnsupportedReturnFailStatus>(
-      allocator, one_tensor, out);
+static ORT_STATUS_PTR OrtGetValueImplSeqOfTensors(_In_ const OrtValue* p_ml_value, int index, _Inout_ OrtAllocator* allocator,
+                                                  _Outptr_ OrtValue** out) {
+  const auto& data = p_ml_value->Get<TensorSeq>();
+  const auto& one_tensor = data.Get(index);
+  const auto& tensor_shape = one_tensor.Shape();
+  auto result = std::make_unique<OrtValue>();
+  ORT_API_RETURN_IF_ERROR(c_api_internal::CreateTensorAndPopulate(one_tensor.DataType(), tensor_shape.GetDims().data(),
+                                                                  tensor_shape.NumDimensions(), one_tensor.DataRaw(),
+                                                                  gsl::narrow<size_t>(one_tensor.Shape().Size()),
+                                                                  allocator, *result));
+  *out = result.release();
+  return nullptr;
 }
 
 #ifdef _MSC_VER
@@ -1326,18 +1169,16 @@ ORT_STATUS_PTR OrtGetValueImplSeqOfTensors(_In_ const OrtValue* p_ml_value, int 
 
 static ORT_STATUS_PTR OrtGetValueImplSeq(_In_ const OrtValue* value, int index, _Inout_ OrtAllocator* allocator,
                                          _Outptr_ OrtValue** out) {
-  auto p_ml_value = reinterpret_cast<const OrtValue*>(value);
-  auto type = p_ml_value->Type();
   // Note: keep these in sync with the registered types in data_types.h
-  if (type->IsTensorSequenceType()) {
-    return OrtGetValueImplSeqOfTensors(p_ml_value, index, allocator, out);
+  if (value->IsTensorSequence()) {
+    return OrtGetValueImplSeqOfTensors(value, index, allocator, out);
   } else {
 #if !defined(DISABLE_ML_OPS)
-    utils::ContainerChecker c_checker(type);
+    utils::ContainerChecker c_checker(value->Type());
     if (c_checker.IsSequenceOf<std::map<std::string, float>>()) {
-      return OrtGetValueImplSeqOfMap<VectorMapStringToFloat>(p_ml_value, index, out);
+      return c_api_internal::OrtGetValueImplSeqOfMap<VectorMapStringToFloat>(value, index, out);
     } else if (c_checker.IsSequenceOf<std::map<int64_t, float>>()) {
-      return OrtGetValueImplSeqOfMap<VectorMapInt64ToFloat>(p_ml_value, index, out);
+      return c_api_internal::OrtGetValueImplSeqOfMap<VectorMapInt64ToFloat>(value, index, out);
     } else {
       return OrtApis::CreateStatus(ORT_FAIL, "Input is not of one of the supported sequence types.");
     }
@@ -1359,32 +1200,35 @@ static ORT_STATUS_PTR OrtGetValueImplMapHelper(_In_ const OrtValue* p_ml_value, 
 #if defined(_WIN32) && !defined(_M_AMD64)
   ORT_ENFORCE(static_cast<uint64_t>(num_kv_pairs) < std::numeric_limits<size_t>::max());
 #endif
+  const std::vector<int64_t> dims{num_kv_pairs};
+  auto result = std::make_unique<OrtValue>();
+  std::vector<TKey> vec_keys;
+  std::vector<TVal> vec_vals;
+  const void* data_ptr;
+  size_t data_size;
+  MLDataType element_type;
   switch (index) {
     case 0: {  // user is requesting keys
-      std::vector<TKey> vec;
-      vec.reserve(static_cast<size_t>(num_kv_pairs));
-      for (const auto& kv : data) {
-        vec.push_back(kv.first);
-      }
-      std::vector<int64_t> dims{num_kv_pairs};
-      OrtStatus* st = OrtApis::CreateTensorAsOrtValue(allocator, dims.data(), dims.size(),
-                                                      GetONNXTensorElementDataType<TKey>(), out);
-      return st ? st : PopulateTensorWithData(*out, vec.data(), static_cast<size_t>(num_kv_pairs), sizeof(TKey));
-    }
+      element_type = DataTypeImpl::TensorTypeFromONNXEnum(GetONNXTensorElementDataType<TKey>())->GetElementType();
+      vec_keys.reserve(static_cast<size_t>(num_kv_pairs));
+      std::transform(data.cbegin(), data.cend(), std::back_inserter(vec_keys), [](const auto& k) { return k.first; });
+      data_ptr = vec_keys.data();
+      data_size = vec_keys.size();
+    } break;
     case 1: {  // user is requesting values
-      std::vector<TVal> vec;
-      vec.reserve(static_cast<size_t>(num_kv_pairs));
-      for (const auto& kv : data) {
-        vec.push_back(kv.second);
-      }
-      std::vector<int64_t> dims{num_kv_pairs};
-      OrtStatus* st = OrtApis::CreateTensorAsOrtValue(allocator, dims.data(), dims.size(),
-                                                      GetONNXTensorElementDataType<TVal>(), out);
-      return st ? st : PopulateTensorWithData(*out, vec.data(), static_cast<size_t>(num_kv_pairs), sizeof(TVal));
-    }
+      element_type = DataTypeImpl::TensorTypeFromONNXEnum(GetONNXTensorElementDataType<TVal>())->GetElementType();
+      vec_vals.reserve(static_cast<size_t>(num_kv_pairs));
+      std::transform(data.cbegin(), data.cend(), std::back_inserter(vec_vals), [](const auto& k) { return k.second; });
+      data_ptr = vec_vals.data();
+      data_size = vec_vals.size();
+    } break;
     default:
       return OrtApis::CreateStatus(ORT_FAIL, "Invalid index requested for map type.");
   }
+  ORT_API_RETURN_IF_ERROR(c_api_internal::CreateTensorAndPopulate(element_type, dims.data(), dims.size(), data_ptr,
+                                                                  data_size, allocator, *result));
+  *out = result.release();
+  return nullptr;
 }
 
 static ORT_STATUS_PTR OrtGetValueImplMap(_In_ const OrtValue* value, int index, _Inout_ OrtAllocator* allocator,
@@ -1447,8 +1291,8 @@ ORT_API_STATUS_IMPL(OrtApis::GetValue, _In_ const OrtValue* value, int index, _I
 
 #if !defined(DISABLE_ML_OPS)
 template <typename T>
-static OrtStatus* OrtCreateValueImplSeqHelperMap(const OrtValue* const* in, size_t num_values,
-                                                 _Outptr_ OrtValue** out) {
+static ORT_STATUS_PTR OrtCreateValueImplSeqHelperMap(const OrtValue* const* in, size_t num_values,
+                                                     _Outptr_ OrtValue** out) {
   using SeqType = std::vector<T>;
   auto seq_ptr = std::make_unique<SeqType>();
   seq_ptr->reserve(num_values);
@@ -1467,39 +1311,16 @@ static OrtStatus* OrtCreateValueImplSeqHelperMap(const OrtValue* const* in, size
 }
 #endif
 
-template <typename TensorElemType>
-static OrtStatus* OrtCreateValueImplSeqHelperTensor(const Tensor& tensor,
-                                                    Tensor& out) {
-  auto data = tensor.Data<TensorElemType>();
-  if (!data) {
-    return OrtApis::CreateStatus(ORT_FAIL, "Encountered nullptr.");
-  }
-
-  auto elem_type = DataTypeImpl::GetType<TensorElemType>();
-  OrtStatus* st = CreateTensorImplForSeq(elem_type, tensor.Shape().GetDims().data(), tensor.Shape().NumDimensions(), out);
-  if (st) {
-    return st;
-  }
-
-  //TODO: check the cast below
-  size_t num_elems = static_cast<size_t>(tensor.Shape().Size());
-  auto* out_data = out.MutableData<TensorElemType>();
-  for (size_t i = 0; i < num_elems; ++i) {
-    *out_data++ = *data++;
-  }
+static ORT_STATUS_PTR OrtCreateValueImplSeqHelperTensor(const Tensor& tensor, Tensor& out) {
+  auto data_type = tensor.DataType();
+  ORT_API_RETURN_IF_ERROR(CreateTensorImplForSeq(data_type,
+                                                 tensor.Shape().GetDims().data(), tensor.Shape().NumDimensions(),
+                                                 out));
+  size_t num_elements = gsl::narrow<size_t>(tensor.Shape().Size());
+  ORT_API_RETURN_IF_ERROR(c_api_internal::PopulateTensorWithData(out, tensor.IsDataTypeString(),
+                                                                 tensor.DataRaw(), num_elements, data_type->Size()));
   return nullptr;
 }
-
-namespace c_api_internal {
-
-template <class T>
-struct CallCreateValueImpl {
-  OrtStatus* operator()(const onnxruntime::Tensor& one_tensor, onnxruntime::Tensor& out) const {
-    return OrtCreateValueImplSeqHelperTensor<T>(one_tensor, out);
-  }
-};
-
-}  // namespace c_api_internal
 
 static ORT_STATUS_PTR OrtCreateValueImplSeqHelper(const OrtValue* const* in, size_t num_values,
                                                   _Outptr_ OrtValue** out) {
@@ -1519,18 +1340,9 @@ static ORT_STATUS_PTR OrtCreateValueImplSeqHelper(const OrtValue* const* in, siz
                                    "Sequences must have tensors of the same data type. There was at least one tensor in the input that was different.");
     }
 
-    OrtStatus* st{};
-    utils::MLTypeCallDispatcher<bool, float, double, std::string,
-                                MLFloat16, BFloat16, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t>
-        t_disp(one_tensor.GetElementType());
-
-    st = t_disp.InvokeRetWithUnsupportedPolicy<OrtStatus*, CallCreateValueImpl, UnsupportedReturnFailStatus>(
-        one_tensor, tensors[idx]);
-
-    if (st) {
-      return st;
-    }
+    ORT_API_RETURN_IF_ERROR(OrtCreateValueImplSeqHelperTensor(one_tensor, tensors[idx]));
   }
+
   // create OrtValue with this vector
   auto value = std::make_unique<OrtValue>();
   auto ml_type = DataTypeImpl::GetType<TensorSeq>();

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -736,9 +736,17 @@ struct ProviderHostImpl : ProviderHost {
   const DataTransferManager& SessionState__GetDataTransferMgr(const SessionState* p) override { return p->GetDataTransferMgr(); }
 
   // Tensor (wrapped)
-  std::unique_ptr<Tensor> Tensor__construct(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAllocator> allocator) override { return std::make_unique<Tensor>(p_type, shape, allocator); }
+  std::unique_ptr<Tensor> Tensor__construct(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAllocator> allocator) override { return std::make_unique<Tensor>(p_type, shape, std::move(allocator)); }
   std::unique_ptr<Tensor> Tensor__construct(MLDataType p_type, const TensorShape& shape, void* p_data, const OrtMemoryInfo& alloc, ptrdiff_t offset) override { return std::make_unique<Tensor>(p_type, shape, p_data, alloc, offset); }
   void Tensor__operator_delete(Tensor* p) override { delete p; }
+
+  void Tensor__InitOrtValue(MLDataType elt_type, const TensorShape& shape, std::shared_ptr<IAllocator> allocator, OrtValue& ort_value) override {
+    Tensor::InitOrtValue(elt_type, shape, std::move(allocator), ort_value);
+  }
+
+  void Tensor__InitOrtValue(MLDataType p_type, const TensorShape& shape, void* p_data, const OrtMemoryInfo& location, OrtValue& ort_value) override {
+    Tensor::InitOrtValue(p_type, shape, p_data, location, ort_value);
+  }
 
   bool* Tensor__MutableData_bool(Tensor* p) override { return p->MutableData<bool>(); }
   int8_t* Tensor__MutableData_int8(Tensor* p) override { return p->MutableData<int8_t>(); }

--- a/onnxruntime/python/onnxruntime_pybind_iobinding.cc
+++ b/onnxruntime/python/onnxruntime_pybind_iobinding.cc
@@ -70,13 +70,9 @@ void addIoBindingMethods(pybind11::module& m) {
         Py_DECREF(dtype);
 
         OrtMemoryInfo info(GetDeviceName(device), OrtDeviceAllocator, device, device.Id());
-        std::unique_ptr<Tensor> p_tensor =
-            std::make_unique<Tensor>(NumpyTypeToOnnxRuntimeType(type_num), shape, reinterpret_cast<void*>(data_ptr), info);
-
+        auto ml_type = NumpyTypeToOnnxRuntimeType(type_num);
         OrtValue ml_value;
-        ml_value.Init(p_tensor.release(),
-                      DataTypeImpl::GetType<Tensor>(),
-                      DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+        Tensor::InitOrtValue(ml_type, shape, reinterpret_cast<void*>(data_ptr), info, ml_value);
 
         auto status = io_binding->Get()->BindInput(name, ml_value);
         if (!status.IsOK()) {
@@ -121,13 +117,9 @@ void addIoBindingMethods(pybind11::module& m) {
         Py_DECREF(dtype);
 
         OrtMemoryInfo info(GetDeviceName(device), OrtDeviceAllocator, device, device.Id());
-
-        std::unique_ptr<Tensor> p_tensor = std::make_unique<Tensor>(NumpyTypeToOnnxRuntimeType(type_num), shape, reinterpret_cast<void*>(data_ptr), info);
-
+        auto ml_type = NumpyTypeToOnnxRuntimeType(type_num);
         OrtValue ml_value;
-        ml_value.Init(p_tensor.release(),
-                      DataTypeImpl::GetType<Tensor>(),
-                      DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+        Tensor::InitOrtValue(ml_type, shape, reinterpret_cast<void*>(data_ptr), info, ml_value);
 
         auto status = io_binding->Get()->BindOutput(name, ml_value);
         if (!status.IsOK()) {

--- a/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
@@ -87,39 +87,31 @@ void addOrtValueMethods(pybind11::module& m) {
           throw std::runtime_error("Creation of OrtValues is currently only supported from non-string numpy arrays");
         }
 
-        auto ml_value = std::make_unique<OrtValue>();
-
-        std::unique_ptr<Tensor> tensor;
-        // The tensor's memory is allocated on the CPU
+        AllocatorPtr allocator;
         if (strcmp(GetDeviceName(device), CPU) == 0) {
-          tensor = std::make_unique<Tensor>(NumpyTypeToOnnxRuntimeType(type_num), shape, GetAllocator());
+          allocator = GetAllocator();
         } else if (strcmp(GetDeviceName(device), CUDA) == 0) {
-      // The tensor's memory is allocated on CUDA
 #ifdef USE_CUDA
           if (!IsCudaDeviceIdValid(logging::LoggingManager::DefaultLogger(), device.Id())) {
             throw std::runtime_error("The provided device id doesn't match any available GPUs on the machine.");
           }
-
-          tensor = std::make_unique<Tensor>(NumpyTypeToOnnxRuntimeType(type_num), shape, GetCudaAllocator(device.Id()));
+          allocator = GetCudaAllocator(device.Id());
 #else
-      throw std::runtime_error(
-          "Can't allocate memory on the CUDA device using this package of OnnxRuntime. "
-          "Please use the CUDA package of OnnxRuntime to use this feature.");
+          throw std::runtime_error(
+              "Can't allocate memory on the CUDA device using this package of OnnxRuntime. "
+              "Please use the CUDA package of OnnxRuntime to use this feature.");
 #endif
         } else {
           throw std::runtime_error("Unsupported device: Cannot place the OrtValue on this device");
         }
 
-        auto ml_tensor = DataTypeImpl::GetType<Tensor>();
-        ml_value->Init(tensor.release(),
-                       ml_tensor,
-                       ml_tensor->GetDeleteFunc());
-
+        auto ml_value = std::make_unique<OrtValue>();
+        auto ml_type = NumpyTypeToOnnxRuntimeType(type_num);
+        Tensor::InitOrtValue(ml_type, shape, std::move(allocator), *ml_value);
         return ml_value;
       })
       // This will create a copy of OrtValue (cheap) and will return as a separate OrtValue object
-      .def_static("ort_value_from_sparse_tensor", 
-                  [](const PySparseTensor* py_sparse_tensor) -> std::unique_ptr<OrtValue> {
+      .def_static("ort_value_from_sparse_tensor", [](const PySparseTensor* py_sparse_tensor) -> std::unique_ptr<OrtValue> {
         return py_sparse_tensor->AsOrtValue();
       })
       // This will create a copy of OrtValue(cheap) and will return as a separate SparseTensor object

--- a/onnxruntime/test/contrib_ops/attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/attention_op_test.cc
@@ -1832,12 +1832,9 @@ TEST(AttentionTest, SharedPrepackedWeights) {
   tester.AddOutput<float>("output", output_dims, output_data);
   tester.AddInput<int32_t>("mask_index", mask_index_dims, mask_index_data);
 
-  auto p_tensor = std::make_unique<Tensor>(DataTypeImpl::GetType<float>(), TensorShape(weights_dims),
-                                           weight_data.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator));
   OrtValue weight;
-
-  weight.Init(p_tensor.release(), DataTypeImpl::GetType<Tensor>(),
-              DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape(weights_dims),
+                       weight_data.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator), weight);
 
   SessionOptions so;
 

--- a/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
@@ -885,13 +885,10 @@ TEST(QAttentionTest, SharedPrepackedWeights) {
   tester.AddInput<uint8_t>("input_zero_point", {1}, {128});
   tester.AddInput<uint8_t>("weight_zero_point", {1}, {128});
 
-  auto p_tensor = std::make_unique<Tensor>(DataTypeImpl::GetType<uint8_t>(), TensorShape(weights_dims),
-                                           weight_data_converted_to_int.data(),
-                                           OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator));
   OrtValue weight;
-
-  weight.Init(p_tensor.release(), DataTypeImpl::GetType<Tensor>(),
-              DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(DataTypeImpl::GetType<uint8_t>(), TensorShape(weights_dims),
+                       weight_data_converted_to_int.data(),
+                       OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator), weight);
 
   SessionOptions so;
 

--- a/onnxruntime/test/contrib_ops/quantize_lstm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_lstm_op_test.cc
@@ -452,19 +452,19 @@ TEST(DynamicQuantLSTMTest, SharedPrepackedWeights) {
   std::vector<int64_t> Y_c_dims{num_directions, batch_size, hidden_size};
   test.AddOutput<float>("Y_c", Y_c_dims, Y_c_data);
 
-  auto W_quant_tensor = std::make_unique<Tensor>(DataTypeImpl::GetType<int8_t>(), TensorShape(W_dims),
-                                                 w_quant.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator));
+  auto ml_int8 = DataTypeImpl::GetType<int8_t>();
+  OrtMemoryInfo cpu_info(CPU, OrtAllocatorType::OrtDeviceAllocator);
+
   OrtValue W;
+  Tensor::InitOrtValue(ml_int8, TensorShape(W_dims),
+                       w_quant.data(),
+                       cpu_info, W);
 
-  W.Init(W_quant_tensor.release(), DataTypeImpl::GetType<Tensor>(),
-         DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
-
-  auto R_quant_tensor = std::make_unique<Tensor>(DataTypeImpl::GetType<int8_t>(), TensorShape(R_dims),
-                                                 r_quant.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator));
   OrtValue R;
+  Tensor::InitOrtValue(ml_int8, TensorShape(R_dims),
+                       r_quant.data(),
+                       cpu_info, R);
 
-  R.Init(R_quant_tensor.release(), DataTypeImpl::GetType<Tensor>(),
-         DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
   SessionOptions so;
 
   // Set up weight(s) as a shared initializer to be shared between sessions

--- a/onnxruntime/test/framework/cuda/fence_cuda_test.cc
+++ b/onnxruntime/test/framework/cuda/fence_cuda_test.cc
@@ -77,8 +77,8 @@ CREATE_INITIALIZER_FUNC(int64_t, TensorProto_DataType_INT64, add_int64_data)
 // TO DO: Figure out a way to enable it again
 TEST(CUDAFenceTests, DISABLED_PartOnCPU) {
   std::unique_ptr<onnxruntime::Model> model = std::make_unique<onnxruntime::Model>("test",
-                                                                                           false,
-                                                                                           DefaultLoggingManager().DefaultLogger());
+                                                                                   false,
+                                                                                   DefaultLoggingManager().DefaultLogger());
   onnxruntime::Graph& graph = model->MainGraph();
   TypeProto tensor_float;
   tensor_float.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
@@ -108,15 +108,9 @@ TEST(CUDAFenceTests, DISABLED_PartOnCPU) {
   float data[4] = {-1, 2, 3, -4};
 
   //create fake ml value with owned buffer.
-  std::unique_ptr<Tensor> p_tensor = std::make_unique<Tensor>(
-      element_type,
-      shape,
-      cpu_allocator);
-  memcpy(p_tensor->MutableData<float>(), data, sizeof(data));
   OrtValue value;
-  value.Init(p_tensor.release(),
-             DataTypeImpl::GetType<Tensor>(),
-             DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(element_type, shape, cpu_allocator, value);
+  memcpy(value.GetMutable<Tensor>()->MutableData<float>(), data, sizeof(data));
 
   SessionOptions so;
   FenceCudaTestInferenceSession session(so, GetEnvironment());
@@ -161,16 +155,13 @@ TEST(CUDAFenceTests, TileWithInitializer) {
   float data[4] = {-1, 2, 3, -4};
 
   //create fake ml value with owned buffer.
-  std::unique_ptr<Tensor> p_tensor = std::make_unique<Tensor>(
-      element_type,
-      shape,
-      cpu_allocator);
-  memcpy(p_tensor->MutableData<float>(), data, sizeof(data));
-
   OrtValue value;
-  value.Init(p_tensor.release(),
-             DataTypeImpl::GetType<Tensor>(),
-             DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(element_type,
+                       shape,
+                       cpu_allocator,
+                       value);
+  memcpy(value.GetMutable<Tensor>()->MutableData<float>(), data, sizeof(data));
+
 
   SessionOptions so;
   FenceCudaTestInferenceSession session(so, GetEnvironment());
@@ -226,16 +217,12 @@ TEST(CUDAFenceTests, TileWithComputedInput) {
   float data[4] = {-1, 2, 3, -4};
 
   //create fake ml value with owned buffer.
-  std::unique_ptr<Tensor> p_tensor = std::make_unique<Tensor>(
-      element_type,
-      shape,
-      cpu_allocator);
-  memcpy(p_tensor->MutableData<float>(), data, sizeof(data));
-
   OrtValue value;
-  value.Init(p_tensor.release(),
-             DataTypeImpl::GetType<Tensor>(),
-             DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(element_type,
+                       shape,
+                       cpu_allocator,
+                       value);
+  memcpy(value.GetMutable<Tensor>()->MutableData<float>(), data, sizeof(data));
 
   SessionOptions so;
   FenceCudaTestInferenceSession session(so, GetEnvironment());

--- a/onnxruntime/test/framework/execution_frame_test.cc
+++ b/onnxruntime/test/framework/execution_frame_test.cc
@@ -174,11 +174,8 @@ TEST_F(ExecutionFrameTest, FeedInDataTest) {
   std::vector<float> fdata(static_cast<size_t>(shape.Size()));
   //create fake ml value with owned buffer.
   OrtMemoryInfo cpuinfo(kCpuExecutionProvider, OrtDeviceAllocator);
-  std::unique_ptr<Tensor> p_tensor = std::make_unique<Tensor>(element_type, shape, fdata.data(), cpuinfo);
   OrtValue value;
-  value.Init(p_tensor.release(),
-             DataTypeImpl::GetType<Tensor>(),
-             DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(element_type, shape, fdata.data(), cpuinfo, value);
 
   auto cpu_xp = CreateCPUExecutionProvider();
   auto xp_typ = cpu_xp->Type();
@@ -440,13 +437,12 @@ TEST(ExecutionFrameTestInit, InitializerAsOutput) {
     ASSERT_STATUS_OK(session.Initialize());
 
     auto allocator = test::AllocatorManager::Instance().GetAllocator(CPU);
-    auto p_tensor = std::make_unique<Tensor>(DataTypeImpl::GetType<float>(), TensorShape({5, 5}), allocator);
-    const void* orig_buffer = p_tensor->DataRaw();
-
     std::vector<OrtValue> results;
     results.resize(1);
-    results[0].Init(p_tensor.release(), DataTypeImpl::GetType<Tensor>(),
-                    DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+    Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({5, 5}), std::move(allocator), results[0]);
+
+    const void* orig_buffer = results[0].Get<Tensor>().DataRaw();
+
     RunOptions ro;
     ASSERT_STATUS_OK(session.Run(ro, {}, {}, {"values"}, &results, nullptr));
 

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -626,14 +626,9 @@ TEST(SessionStateTest, SharedInitalizersWithPrePackingTest) {
     // Enable shared initializer
     OrtMemoryInfo mem_info(CPU, OrtDeviceAllocator);
     std::vector<float> float_data(1, 1);
-    std::unique_ptr<Tensor> tensor =
-        std::make_unique<Tensor>(DataTypeImpl::GetType<float>(), TensorShape(std::vector<int64_t>{1}), reinterpret_cast<void*>(float_data.data()), mem_info, 0);
-
     auto value = std::make_unique<OrtValue>();
-    auto ml_tensor = DataTypeImpl::GetType<Tensor>();
-    value->Init(tensor.release(),
-                ml_tensor,
-                ml_tensor->GetDeleteFunc());
+    Tensor::InitOrtValue(DataTypeImpl::GetType<float>(),
+                         TensorShape(std::vector<int64_t>{1}), reinterpret_cast<void*>(float_data.data()), mem_info, *value);
 
     sess_options.AddInitializer("node_0_input_1", value.get());
 
@@ -701,14 +696,9 @@ TEST(SessionStateTest, SharedInitalizersWithPrePackingTest) {
     // Enable shared initializer
     OrtMemoryInfo mem_info(CPU, OrtDeviceAllocator);
     std::vector<float> float_data(1, 1);
-    std::unique_ptr<Tensor> tensor =
-        std::make_unique<Tensor>(DataTypeImpl::GetType<float>(), TensorShape(std::vector<int64_t>{1}), reinterpret_cast<void*>(float_data.data()), mem_info, 0);
-
     auto value = std::make_unique<OrtValue>();
-    auto ml_tensor = DataTypeImpl::GetType<Tensor>();
-    value->Init(tensor.release(),
-                ml_tensor,
-                ml_tensor->GetDeleteFunc());
+    Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape(std::vector<int64_t>{1}),
+                         reinterpret_cast<void*>(float_data.data()), mem_info, *value);
 
     sess_options.AddInitializer("node_0_input_1", value.get());
 

--- a/onnxruntime/test/framework/test_utils.h
+++ b/onnxruntime/test/framework/test_utils.h
@@ -69,16 +69,12 @@ void CreateMLValue(AllocatorPtr alloc, const std::vector<int64_t>& dims, const s
                    OrtValue* p_mlvalue) {
   TensorShape shape(dims);
   auto element_type = DataTypeImpl::GetType<T>();
-  std::unique_ptr<Tensor> p_tensor = std::make_unique<Tensor>(element_type,
-                                                                      shape,
-                                                                      alloc);
-  if (value.size() > 0) {
-    CopyVectorToTensor(value, *p_tensor);
-  }
+  Tensor::InitOrtValue(element_type, shape, std::move(alloc), *p_mlvalue);
 
-  p_mlvalue->Init(p_tensor.release(),
-                  DataTypeImpl::GetType<Tensor>(),
-                  DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  if (!value.empty()) {
+    Tensor& tensor = *p_mlvalue->GetMutable<Tensor>();
+    CopyVectorToTensor(value, tensor);
+  }
 }
 
 // Lifetime of data_buffer should be managed by the caller.
@@ -87,25 +83,14 @@ void CreateMLValue(const std::vector<int64_t>& dims, T* data_buffer, const OrtMe
                    OrtValue* p_mlvalue) {
   TensorShape shape(dims);
   auto element_type = DataTypeImpl::GetType<T>();
-  std::unique_ptr<Tensor> p_tensor = std::make_unique<Tensor>(element_type,
-                                                                      shape,
-                                                                      data_buffer,
-                                                                      info);
-  p_mlvalue->Init(p_tensor.release(),
-                  DataTypeImpl::GetType<Tensor>(),
-                  DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(element_type, shape, data_buffer, info, *p_mlvalue);
 }
 
 template <typename T>
 void AllocateMLValue(AllocatorPtr alloc, const std::vector<int64_t>& dims, OrtValue* p_mlvalue) {
   TensorShape shape(dims);
   auto element_type = DataTypeImpl::GetType<T>();
-  std::unique_ptr<Tensor> p_tensor = std::make_unique<Tensor>(element_type,
-                                                                      shape,
-                                                                      alloc);
-  p_mlvalue->Init(p_tensor.release(),
-                  DataTypeImpl::GetType<Tensor>(),
-                  DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(element_type, shape, std::move(alloc), *p_mlvalue);
 }
 
 // Returns a map with the number of occurrences of each operator in the graph.

--- a/onnxruntime/test/providers/cpu/math/gemm_test.cc
+++ b/onnxruntime/test/providers/cpu/math/gemm_test.cc
@@ -468,13 +468,9 @@ TEST(GemmOpTest, SharedPrepackedWeights) {
                         {11.0f, 11.0f, 11.0f,
                          -9.0f, -9.0f, -9.0f});
 
-  auto p_tensor = std::make_unique<Tensor>(DataTypeImpl::GetType<float>(), TensorShape({4, 3}),
-                                           b_init_values.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator));
-
   OrtValue b;
-
-  b.Init(p_tensor.release(), DataTypeImpl::GetType<Tensor>(),
-         DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({4, 3}),
+                       b_init_values.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator), b);
 
   SessionOptions so;
 

--- a/onnxruntime/test/providers/cpu/math/matmul_integer_test.cc
+++ b/onnxruntime/test/providers/cpu/math/matmul_integer_test.cc
@@ -396,12 +396,9 @@ TEST(MatmulIntegerOpTest, SharedPrepackedWeights) {
 
   std::vector<uint8_t> t2_init_values(1, 13);
 
-  auto p_tensor = std::make_unique<Tensor>(DataTypeImpl::GetType<uint8_t>(), TensorShape({1, 1}),
-                                           t2_init_values.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator));
   OrtValue t2;
-
-  t2.Init(p_tensor.release(), DataTypeImpl::GetType<Tensor>(),
-          DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(DataTypeImpl::GetType<uint8_t>(), TensorShape({1, 1}),
+                       t2_init_values.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator), t2);
 
   SessionOptions so;
   // Set up T2 as a shared initializer to be shared between sessions

--- a/onnxruntime/test/providers/cpu/math/matmul_test.cc
+++ b/onnxruntime/test/providers/cpu/math/matmul_test.cc
@@ -177,12 +177,9 @@ TEST(MathOpTest, MatMulSharedPrepackedWeights) {
                         {10.0f, 10.0f, 10.0f,
                          -10.0f, -10.0f, -10.0f});
 
-  auto p_tensor = std::make_unique<Tensor>(DataTypeImpl::GetType<float>(), TensorShape({4, 3}),
-                                           b_init_values.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator));
   OrtValue b;
-
-  b.Init(p_tensor.release(), DataTypeImpl::GetType<Tensor>(),
-         DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({4, 3}),
+                       b_init_values.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator), b);
 
   SessionOptions so;
   // Set up B as a shared initializer to be shared between sessions

--- a/onnxruntime/test/providers/cpu/nn/conv_transpose_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_transpose_op_test.cc
@@ -1237,12 +1237,9 @@ TEST(ConvTransposeTest, SharedPrepackedWeights) {
   };
   test.AddOutput<float>("Y", {1, 6, 4, 4}, expected_vals);
 
-  auto p_tensor = std::make_unique<Tensor>(DataTypeImpl::GetType<float>(), TensorShape({6, 3, 3, 3}),
-                                           W.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator));
   OrtValue w;
-
-  w.Init(p_tensor.release(), DataTypeImpl::GetType<Tensor>(),
-         DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({6, 3, 3, 3}),
+                       W.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator), w);
 
   SessionOptions so;
   // Set up W as a shared initializer to be shared between sessions

--- a/onnxruntime/test/providers/cpu/nn/qlinearconv_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/qlinearconv_op_test.cc
@@ -903,13 +903,9 @@ TEST(QLinearConvTest, SharedPrepackedWeights) {
   test.AddOutput<uint8_t>("y", {1, 1, 7, 7}, Y.quantized_);
 
   // W
-  auto W_tensor = std::make_unique<Tensor>(DataTypeImpl::GetType<uint8_t>(), TensorShape({1, 1, 1, 1}),
-                                           W.quantized_.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator));
-
   OrtValue W_ortvalue;
-
-  W_ortvalue.Init(W_tensor.release(), DataTypeImpl::GetType<Tensor>(),
-                  DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(DataTypeImpl::GetType<uint8_t>(), TensorShape({1, 1, 1, 1}),
+                       W.quantized_.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator), W_ortvalue);
 
   SessionOptions so;
 

--- a/onnxruntime/test/providers/cpu/rnn/deep_cpu_lstm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/deep_cpu_lstm_op_test.cc
@@ -1273,22 +1273,14 @@ TEST(LSTMTest, SharedPrepackedWeights) {
   test.AddOptionalOutputEdge<float>();
 
   // W
-  auto W_tensor = std::make_unique<Tensor>(DataTypeImpl::GetType<float>(), TensorShape(W_dims),
-                                           W_data.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator));
-
   OrtValue W;
-
-  W.Init(W_tensor.release(), DataTypeImpl::GetType<Tensor>(),
-         DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape(W_dims),
+                       W_data.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator), W);
 
   // R
-  auto R_tensor = std::make_unique<Tensor>(DataTypeImpl::GetType<float>(), TensorShape(R_dims),
-                                           R_data.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator));
-
   OrtValue R;
-
-  R.Init(R_tensor.release(), DataTypeImpl::GetType<Tensor>(),
-         DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
+  Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape(R_dims),
+                       R_data.data(), OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator), R);
 
   SessionOptions so;
 

--- a/onnxruntime/test/providers/memcpy_test.cc
+++ b/onnxruntime/test/providers/memcpy_test.cc
@@ -57,11 +57,10 @@ TEST(MemcpyTest, copy1) {
   AllocatorPtr allocator =
       execution_providers.Get(onnxruntime::kCpuExecutionProvider)->GetAllocator(0, OrtMemTypeDefault);
   auto* data_type = DataTypeImpl::GetType<float>();
-  std::unique_ptr<Tensor> p_tensor = std::make_unique<Tensor>(data_type, TensorShape({3, 2}), allocator);
+  OrtValue input;
+  Tensor::InitOrtValue(data_type, TensorShape({3, 2}), std::move(allocator), input);
   float data[] = {1.f, 1.f, 0.f, 1.f, 1.f, 1.f};
-  memcpy(p_tensor->MutableData<float>(), data, sizeof(data));
-  OrtValue input =
-      OrtValue{p_tensor.release(), DataTypeImpl::GetType<Tensor>(), DataTypeImpl::GetType<Tensor>()->GetDeleteFunc()};
+  memcpy(input.GetMutable<Tensor>()->MutableDataRaw(), data, sizeof(data));
 
   OrtValue output;
   st = utils::CopyOneInputAcrossDevices(s, "X", input, output);


### PR DESCRIPTION
Simplify API

**Description**: 
Introduce Tensor::InitOrtValue for a commonly used code pattern.
Reduce templatization of C API

**Motivation and Context**
Reduce binary footprint and simplify code.