### PR TITLE
work around ort build failure for jetpack 4.6

### DIFF
--- a/onnxruntime/test/providers/kernel_def_hash_test.cc
+++ b/onnxruntime/test/providers/kernel_def_hash_test.cc
@@ -61,10 +61,15 @@
 #ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable : 28020)
+#elif __aarch64__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
 #endif
 #include "nlohmann/json.hpp"
 #ifdef _WIN32
 #pragma warning(pop)
+#elif __aarch64__
+#pragma GCC diagnostic pop
 #endif
 
 #include "asserts.h"


### PR DESCRIPTION
build warning resulting in error on Jetson (arm64) platform.

In file included from /triton/onnxruntime/onnxruntime/test/providers/kernel_def_hash_test.cc:65:0:
/triton/onnxruntime/cmake/external/json/single_include/nlohmann/json.hpp: In member function ‘void nlohmann::detail::serializer<BasicJsonType>::dump_escaped(const string_t&, bool) [with BasicJsonType = nlohmann::basic_json<>]’:
/triton/onnxruntime/cmake/external/json/single_include/nlohmann/json.hpp:15817:10: error: ‘%.2X’ directive output may be truncated writing between 2 and 8 bytes into a region of size 3 [-Werror=format-truncation=]
     void dump_escaped(const string_t& s, const bool ensure_ascii)
          ^~~~~~~~~~~~
/triton/onnxruntime/cmake/external/json/single_include/nlohmann/json.hpp:15817:10: note: directive argument in the range [0, 2147483647]
In file included from /usr/include/stdio.h:862:0

alternative approach to https://github.com/microsoft/onnxruntime/pull/8692 which requires advancing json submodule to unreleased version.
according to https://github.com/nlohmann/json/issues/2572 , the warning can be silenced.
tested on jetson xavier NX with JetPack 4.6