### PR TITLE
Windows protobuf CMake fix for PREFER_SYSTEM_LIB with DEV_MODE

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -742,7 +742,7 @@ if(UNIX AND onnxruntime_ENABLE_LTO AND NOT onnxruntime_PREFER_SYSTEM_LIB)
   target_link_options(protoc PRIVATE "-Wl,--no-as-needed")
 endif()
 
-if(MSVC AND onnxruntime_DEV_MODE)
+if(MSVC AND onnxruntime_DEV_MODE AND NOT onnxruntime_PREFER_SYSTEM_LIB)
   target_compile_options(${PROTOBUF_LIB} PRIVATE "/wd5054")
 endif()
 


### PR DESCRIPTION
Description: You cannot set a PRIVATE option on a system library, so this adds a check to avoid setting a warning on protobuf when `onnxruntime_PREFER_SYSTEM_LIBS` is set, very similar to the UNIX condition above.
Motivation: Trying to set `target_compile_options` on a system library results in a CMake failure.