### PR TITLE
[js/web] enable 'use_ort_model_bytes_directly' by default

### DIFF
--- a/js/web/lib/wasm/session-options.ts
+++ b/js/web/lib/wasm/session-options.ts
@@ -33,12 +33,27 @@ const getExecutionMode = (executionMode: 'sequential'|'parallel'): number => {
   }
 };
 
+const appendDefaultOptions = (options: InferenceSession.SessionOptions): void => {
+  if (!options.extra) {
+    options.extra = {};
+  }
+  if (!options.extra.session) {
+    options.extra.session = {};
+  }
+  const session = options.extra.session as Record<string, string>;
+  if (!session.use_ort_model_bytes_directly) {
+    // eslint-disable-next-line camelcase
+    session.use_ort_model_bytes_directly = '1';
+  }
+};
+
 export const setSessionOptions = (options?: InferenceSession.SessionOptions): [number, number[]] => {
   const wasm = getInstance();
   let sessionOptionsHandle = 0;
   const allocs: number[] = [];
 
   const sessionOptions: InferenceSession.SessionOptions = options || {};
+  appendDefaultOptions(sessionOptions);
 
   try {
     if (options?.graphOptimizationLevel === undefined) {


### PR DESCRIPTION
**Description**: this change enables 'session.use_ort_model_bytes_directly' in session options by default, for WebAssembly backend in ORT web.