### PR TITLE
Fix Python Packaging Pipeline (Training Torch 1.9.0 Cuda 11.4)

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-torch190-cuda114.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-torch190-cuda114.yml
@@ -6,7 +6,7 @@ stages:
     build_py_parameters: --enable_training --update --build
     torch_version: '1.9.0'
     cuda_version: '11.4'
-    gcc_version: 9
+    gcc_version: 10
     cmake_cuda_architectures: 37;50;52;60;61;70;75;80;86
     docker_file: Dockerfile.manylinux2014_training_cuda11_4
     agent_pool: Onnxruntime-Linux-GPU


### PR DESCRIPTION
**Description**: 

Fix Python Packaging Pipeline (Training Torch 1.9.0 Cuda 11.4)

**Motivation and Context**
- Why is this change required? What problem does it solve?

It is failing because of the changes I made in #8724.   I updated the GCC version in the image to 10, to be the same as the manylinux2014 official image. 
Sorry I didn't notice it. This is a new pipeline that was just created a few days ago. 

- If it fixes an open issue, please link to the issue here.
