### PR TITLE
Add build option to build MLAS as a standalone library

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -69,6 +69,7 @@ option(onnxruntime_USE_AVX512 "Use AVX512 instructions" OFF)
 
 option(onnxruntime_USE_OPENMP "Build with OpenMP support" OFF)
 option(onnxruntime_BUILD_SHARED_LIB "Build a shared library" OFF)
+option(onnxruntime_BUILD_STANDALONE_MLAS_LIB "Build MLAS as a standalone library" OFF)
 option(onnxruntime_BUILD_APPLE_FRAMEWORK "Build a macOS/iOS framework" OFF)
 option(onnxruntime_ENABLE_MICROSOFT_INTERNAL "Use this option to enable/disable microsoft internal only code" OFF)
 option(onnxruntime_USE_NUPHAR "Build with Nuphar" OFF)
@@ -453,9 +454,9 @@ if (onnxruntime_DISABLE_EXCEPTIONS)
   endif()
 endif()
 
-if (onnxruntime_BUILD_SHARED_MLAS_LIB)
-  add_compile_definitions(ORT_USE_MLAS_SHARED_LIB)
-endif ()
+if (onnxruntime_BUILD_STANDALONE_MLAS_LIB)
+  add_compile_definitions(MLAS_STANDALONE_LIB)
+endif()
 
 # We need to link with libatomic on systems that do not have built-in atomics, or
 # don't have built-in support for 8 byte atomics

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -453,6 +453,10 @@ if (onnxruntime_DISABLE_EXCEPTIONS)
   endif()
 endif()
 
+if (onnxruntime_BUILD_SHARED_MLAS_LIB)
+  add_compile_definitions(ORT_USE_MLAS_SHARED_LIB)
+endif ()
+
 # We need to link with libatomic on systems that do not have built-in atomics, or
 # don't have built-in support for 8 byte atomics
 # Derived from https://github.com/protocolbuffers/protobuf/blob/master/cmake/CMakeLists.txt

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -69,7 +69,6 @@ option(onnxruntime_USE_AVX512 "Use AVX512 instructions" OFF)
 
 option(onnxruntime_USE_OPENMP "Build with OpenMP support" OFF)
 option(onnxruntime_BUILD_SHARED_LIB "Build a shared library" OFF)
-option(onnxruntime_BUILD_STANDALONE_MLAS_LIB "Build MLAS as a standalone library" OFF)
 option(onnxruntime_BUILD_APPLE_FRAMEWORK "Build a macOS/iOS framework" OFF)
 option(onnxruntime_ENABLE_MICROSOFT_INTERNAL "Use this option to enable/disable microsoft internal only code" OFF)
 option(onnxruntime_USE_NUPHAR "Build with Nuphar" OFF)
@@ -452,10 +451,6 @@ if (onnxruntime_DISABLE_EXCEPTIONS)
   else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables")
   endif()
-endif()
-
-if (onnxruntime_BUILD_STANDALONE_MLAS_LIB)
-  add_compile_definitions(MLAS_STANDALONE_LIB)
 endif()
 
 # We need to link with libatomic on systems that do not have built-in atomics, or

--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -119,6 +119,10 @@ class Allocator;
 class ThreadPoolInterface;
 }  // namespace Eigen
 
+namespace mlas {
+class IThreadPool;
+}  // namespace mlas
+
 namespace onnxruntime {
 
 struct TensorOpCost {
@@ -136,6 +140,8 @@ class ThreadPoolTempl;
 class ExtendedThreadPoolInterface;
 class LoopCounter;
 class ThreadPoolParallelSection;
+
+class MlasThreadPoolAdapter;
 
 class ThreadPool {
  public:
@@ -384,6 +390,9 @@ class ThreadPool {
   static void StartProfiling(concurrency::ThreadPool* tp);
   static std::string StopProfiling(concurrency::ThreadPool* tp);
 
+  // convert to MLAS ThreadPool
+  mlas::IThreadPool* AsMlasThreadPool();
+
  private:
   friend class LoopCounter;
 
@@ -443,6 +452,8 @@ class ThreadPool {
 
   // If used, underlying_threadpool_ is instantiated and owned by the ThreadPool.
   std::unique_ptr<ThreadPoolTempl<Env> > extended_eigen_threadpool_;
+
+  std::unique_ptr<MlasThreadPoolAdapter> mlas_threadpool_adapter_;
 };
 
 }  // namespace concurrency

--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -119,7 +119,7 @@ class Allocator;
 class ThreadPoolInterface;
 }  // namespace Eigen
 
-#ifdef ORT_USE_MLAS_SHARED_LIB
+#ifdef MLAS_STANDALONE_LIB
 namespace mlas {
 class IThreadPool;
 }  // namespace mlas
@@ -143,7 +143,7 @@ class ExtendedThreadPoolInterface;
 class LoopCounter;
 class ThreadPoolParallelSection;
 
-#ifdef ORT_USE_MLAS_SHARED_LIB
+#ifdef MLAS_STANDALONE_LIB
 class MlasThreadPoolAdapter;
 #endif
 
@@ -154,7 +154,7 @@ class ThreadPool {
 #else
   using NAME_CHAR_TYPE = char;
 #endif
-#ifdef ORT_USE_MLAS_SHARED_LIB
+#ifdef MLAS_STANDALONE_LIB
   using MLAS_THREADPOOL_TYPE = mlas::IThreadPool;
 #else
   using MLAS_THREADPOOL_TYPE = ThreadPool;
@@ -473,7 +473,7 @@ class ThreadPool {
   // If used, underlying_threadpool_ is instantiated and owned by the ThreadPool.
   std::unique_ptr<ThreadPoolTempl<Env> > extended_eigen_threadpool_;
 
-#ifdef ORT_USE_MLAS_SHARED_LIB
+#ifdef MLAS_STANDALONE_LIB
   std::unique_ptr<MlasThreadPoolAdapter> mlas_threadpool_adapter_;
 #endif
 };

--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -400,7 +400,18 @@ class ThreadPool {
   static std::string StopProfiling(concurrency::ThreadPool* tp);
 
   // convert to MLAS ThreadPool
-  MLAS_THREADPOOL_TYPE* AsMlasThreadPool();
+  inline static MLAS_THREADPOOL_TYPE* AsMlasThreadPool(concurrency::ThreadPool* tp)
+  {
+#ifdef MLAS_STANDALONE_LIB
+    if (tp != nullptr) {
+      return reinterpret_cast<MLAS_THREADPOOL_TYPE*>(tp->mlas_threadpool_adapter_.get());
+    } else {
+      return nullptr;
+    }
+#else
+    return tp;
+#endif
+  }
 
  private:
   friend class LoopCounter;

--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -119,9 +119,11 @@ class Allocator;
 class ThreadPoolInterface;
 }  // namespace Eigen
 
+#ifdef ORT_USE_MLAS_SHARED_LIB
 namespace mlas {
 class IThreadPool;
 }  // namespace mlas
+#endif
 
 namespace onnxruntime {
 
@@ -141,7 +143,9 @@ class ExtendedThreadPoolInterface;
 class LoopCounter;
 class ThreadPoolParallelSection;
 
+#ifdef ORT_USE_MLAS_SHARED_LIB
 class MlasThreadPoolAdapter;
+#endif
 
 class ThreadPool {
  public:
@@ -149,6 +153,11 @@ class ThreadPool {
   using NAME_CHAR_TYPE = wchar_t;
 #else
   using NAME_CHAR_TYPE = char;
+#endif
+#ifdef ORT_USE_MLAS_SHARED_LIB
+  using MLAS_THREADPOOL_TYPE = mlas::IThreadPool;
+#else
+  using MLAS_THREADPOOL_TYPE = ThreadPool;
 #endif
   // Constructs a pool for running with with "degree_of_parallelism" threads with
   // specified "name". env->StartThread() is used to create individual threads
@@ -391,7 +400,7 @@ class ThreadPool {
   static std::string StopProfiling(concurrency::ThreadPool* tp);
 
   // convert to MLAS ThreadPool
-  mlas::IThreadPool* AsMlasThreadPool();
+  MLAS_THREADPOOL_TYPE* AsMlasThreadPool();
 
  private:
   friend class LoopCounter;
@@ -453,7 +462,9 @@ class ThreadPool {
   // If used, underlying_threadpool_ is instantiated and owned by the ThreadPool.
   std::unique_ptr<ThreadPoolTempl<Env> > extended_eigen_threadpool_;
 
+#ifdef ORT_USE_MLAS_SHARED_LIB
   std::unique_ptr<MlasThreadPoolAdapter> mlas_threadpool_adapter_;
+#endif
 };
 
 }  // namespace concurrency

--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -119,11 +119,9 @@ class Allocator;
 class ThreadPoolInterface;
 }  // namespace Eigen
 
-#ifdef MLAS_STANDALONE_LIB
 namespace mlas {
 class IThreadPool;
 }  // namespace mlas
-#endif
 
 namespace onnxruntime {
 
@@ -143,9 +141,7 @@ class ExtendedThreadPoolInterface;
 class LoopCounter;
 class ThreadPoolParallelSection;
 
-#ifdef MLAS_STANDALONE_LIB
 class MlasThreadPoolAdapter;
-#endif
 
 class ThreadPool {
  public:
@@ -154,11 +150,8 @@ class ThreadPool {
 #else
   using NAME_CHAR_TYPE = char;
 #endif
-#ifdef MLAS_STANDALONE_LIB
   using MLAS_THREADPOOL_TYPE = mlas::IThreadPool;
-#else
-  using MLAS_THREADPOOL_TYPE = ThreadPool;
-#endif
+
   // Constructs a pool for running with with "degree_of_parallelism" threads with
   // specified "name". env->StartThread() is used to create individual threads
   // with the given ThreadOptions. If "low_latency_hint" is true the thread pool
@@ -402,15 +395,11 @@ class ThreadPool {
   // convert to MLAS ThreadPool
   inline static MLAS_THREADPOOL_TYPE* AsMlasThreadPool(concurrency::ThreadPool* tp)
   {
-#ifdef MLAS_STANDALONE_LIB
     if (tp != nullptr) {
       return reinterpret_cast<MLAS_THREADPOOL_TYPE*>(tp->mlas_threadpool_adapter_.get());
     } else {
       return nullptr;
     }
-#else
-    return tp;
-#endif
   }
 
  private:
@@ -473,9 +462,7 @@ class ThreadPool {
   // If used, underlying_threadpool_ is instantiated and owned by the ThreadPool.
   std::unique_ptr<ThreadPoolTempl<Env> > extended_eigen_threadpool_;
 
-#ifdef MLAS_STANDALONE_LIB
   std::unique_ptr<MlasThreadPoolAdapter> mlas_threadpool_adapter_;
-#endif
 };
 
 }  // namespace concurrency

--- a/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
@@ -57,7 +57,7 @@ void ComputeAttentionSoftmaxInplace(T* score, int N, int D, ThreadPool* tp) {
 
 template <>
 inline void ComputeAttentionSoftmaxInplace(float* score, int N, int D, ThreadPool* tp) {
-  MlasComputeSoftmax(score, score, N, D, false, tp->AsMlasThreadPool());
+  MlasComputeSoftmax(score, score, N, D, false, concurrency::ThreadPool::AsMlasThreadPool(tp));
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
@@ -57,7 +57,7 @@ void ComputeAttentionSoftmaxInplace(T* score, int N, int D, ThreadPool* tp) {
 
 template <>
 inline void ComputeAttentionSoftmaxInplace(float* score, int N, int D, ThreadPool* tp) {
-  MlasComputeSoftmax(score, score, N, D, false, tp);
+  MlasComputeSoftmax(score, score, N, D, false, tp->AsMlasThreadPool());
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cpu/nchwc_ops.cc
+++ b/onnxruntime/contrib_ops/cpu/nchwc_ops.cc
@@ -213,7 +213,7 @@ Status NchwcConv::Compute(OpKernelContext* context) const {
       y_data,
       &activation_,
       Sum == nullptr,
-      context->GetOperatorThreadPool()->AsMlasThreadPool());
+      concurrency::ThreadPool::AsMlasThreadPool(context->GetOperatorThreadPool()));
 
   return Status::OK();
 }
@@ -238,7 +238,7 @@ Status NchwcPoolBase::NchwcPool(OpKernelContext* context, MLAS_POOLING_KIND kind
       output_dims.data(),
       X->template Data<float>(),
       Y->template MutableData<float>(),
-      context->GetOperatorThreadPool()->AsMlasThreadPool());
+      concurrency::ThreadPool::AsMlasThreadPool(context->GetOperatorThreadPool()));
 
   return Status::OK();
 }

--- a/onnxruntime/contrib_ops/cpu/nchwc_ops.cc
+++ b/onnxruntime/contrib_ops/cpu/nchwc_ops.cc
@@ -213,7 +213,7 @@ Status NchwcConv::Compute(OpKernelContext* context) const {
       y_data,
       &activation_,
       Sum == nullptr,
-      context->GetOperatorThreadPool());
+      context->GetOperatorThreadPool()->AsMlasThreadPool());
 
   return Status::OK();
 }
@@ -238,7 +238,7 @@ Status NchwcPoolBase::NchwcPool(OpKernelContext* context, MLAS_POOLING_KIND kind
       output_dims.data(),
       X->template Data<float>(),
       Y->template MutableData<float>(),
-      context->GetOperatorThreadPool());
+      context->GetOperatorThreadPool()->AsMlasThreadPool());
 
   return Status::OK();
 }

--- a/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
@@ -281,7 +281,7 @@ Status QAttention<T>::Compute(OpKernelContext* context) const {
       gemm_params.OutputProcessor = &(scale_bias_procs[i]);
     }
 
-    MlasGemmBatch(gemm_shape, gemm_data_vec.data(), loop_len, tp);
+    MlasGemmBatch(gemm_shape, gemm_data_vec.data(), loop_len, tp->AsMlasThreadPool());
   }
 
   // Compute the attention score and apply the score to V

--- a/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
@@ -281,7 +281,7 @@ Status QAttention<T>::Compute(OpKernelContext* context) const {
       gemm_params.OutputProcessor = &(scale_bias_procs[i]);
     }
 
-    MlasGemmBatch(gemm_shape, gemm_data_vec.data(), loop_len, tp->AsMlasThreadPool());
+    MlasGemmBatch(gemm_shape, gemm_data_vec.data(), loop_len, concurrency::ThreadPool::AsMlasThreadPool(tp));
   }
 
   // Compute the attention score and apply the score to V

--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
@@ -145,7 +145,7 @@ Status MatMulIntegerToFloatBase::ComputeCommon(OpKernelContext* ctx,
     params.ldc = gemm_shape.N;
   }
 
-  MlasGemmBatch(gemm_shape, gemm_data_vec.data(), num_gemms, ctx->GetOperatorThreadPool());
+  MlasGemmBatch(gemm_shape, gemm_data_vec.data(), num_gemms, ctx->GetOperatorThreadPool()->AsMlasThreadPool());
 
   return Status::OK();
 }

--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
@@ -145,7 +145,7 @@ Status MatMulIntegerToFloatBase::ComputeCommon(OpKernelContext* ctx,
     params.ldc = gemm_shape.N;
   }
 
-  MlasGemmBatch(gemm_shape, gemm_data_vec.data(), num_gemms, ctx->GetOperatorThreadPool()->AsMlasThreadPool());
+  MlasGemmBatch(gemm_shape, gemm_data_vec.data(), num_gemms, concurrency::ThreadPool::AsMlasThreadPool(ctx->GetOperatorThreadPool()));
 
   return Status::OK();
 }

--- a/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
@@ -104,7 +104,7 @@ class QGemm : protected GemmBase, public MatMulIntegerBase {
     std::unique_ptr<MLAS_QGEMM_REQUANT_OUTPUT_PROCESSOR> requant_proc_ptr;
     SetPostProcessor(y_zp, N, output_scales, y, gemm_param, scale_bias_proc_ptr, requant_proc_ptr);
 
-    MlasGemmBatch(gemm_shape, &gemm_param, 1, context->GetOperatorThreadPool()->AsMlasThreadPool());
+    MlasGemmBatch(gemm_shape, &gemm_param, 1, concurrency::ThreadPool::AsMlasThreadPool(context->GetOperatorThreadPool()));
     return Status::OK();
   }
 

--- a/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
@@ -104,7 +104,7 @@ class QGemm : protected GemmBase, public MatMulIntegerBase {
     std::unique_ptr<MLAS_QGEMM_REQUANT_OUTPUT_PROCESSOR> requant_proc_ptr;
     SetPostProcessor(y_zp, N, output_scales, y, gemm_param, scale_bias_proc_ptr, requant_proc_ptr);
 
-    MlasGemmBatch(gemm_shape, &gemm_param, 1, context->GetOperatorThreadPool());
+    MlasGemmBatch(gemm_shape, &gemm_param, 1, context->GetOperatorThreadPool()->AsMlasThreadPool());
     return Status::OK();
   }
 

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include "core/common/common.h"
 #include "core/common/cpuid_info.h"
 #include "core/common/eigen_common_wrapper.h"
+#include "core/mlas/inc/mlas.h"
 #include "core/platform/EigenNonBlockingThreadPool.h"
 #include "core/platform/ort_mutex.h"
 #if !defined(ORT_MINIMAL_BUILD)
@@ -364,6 +365,35 @@ class alignas(CACHE_LINE_BYTES) LoopCounter {
 #pragma warning(pop) /* Padding added in LoopCounterShard, LoopCounter */
 #endif
 
+
+// Wrapper class for MlasThreadPool
+class MlasThreadPoolAdapter : public mlas::IThreadPool
+{
+public:
+  MlasThreadPoolAdapter(ThreadPool* tp) : tp_(tp) {}
+
+  virtual ~MlasThreadPoolAdapter() = default;
+
+  inline virtual void TrySimpleParallelFor(std::ptrdiff_t total, const std::function<void(std::ptrdiff_t)>& fn) override final
+  {
+    ThreadPool::TrySimpleParallelFor(tp_, total, fn);
+  }
+
+  inline virtual int DegreeOfParallelism() override final
+  {
+    return ThreadPool::DegreeOfParallelism(tp_);
+  }
+
+  inline virtual void TryBatchParallelFor(std::ptrdiff_t total, const std::function<void(std::ptrdiff_t)>& fn, std::ptrdiff_t num_batches) override final
+  {
+    ThreadPool::TryBatchParallelFor(tp_, total, fn, num_batches);
+  }
+
+private:
+  ThreadPool* tp_;
+};
+
+
 ThreadPool::ThreadPool(Env* env,
                        const ThreadOptions& thread_options,
                        const NAME_CHAR_TYPE* name,
@@ -384,6 +414,8 @@ ThreadPool::ThreadPool(Env* env,
                                                         thread_options_);
     underlying_threadpool_ = extended_eigen_threadpool_.get();
   }
+
+  mlas_threadpool_adapter_ = std::make_unique<MlasThreadPoolAdapter>(this);
 }
 
 ThreadPool::~ThreadPool() = default;
@@ -440,6 +472,14 @@ void ThreadPool::Schedule(std::function<void()> fn) {
     underlying_threadpool_->Schedule(std::move(fn));
   } else {
     fn();
+  }
+}
+
+mlas::IThreadPool* ThreadPool::AsMlasThreadPool() {
+  if (this != nullptr) {
+    return mlas_threadpool_adapter_.get();
+  } else {
+    return nullptr;
   }
 }
 

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -19,7 +19,7 @@ limitations under the License.
 #include "core/common/common.h"
 #include "core/common/cpuid_info.h"
 #include "core/common/eigen_common_wrapper.h"
-#ifdef ORT_USE_MLAS_SHARED_LIB
+#ifdef MLAS_STANDALONE_LIB
 #include "core/mlas/inc/mlas.h"
 #endif
 #include "core/platform/EigenNonBlockingThreadPool.h"
@@ -368,7 +368,7 @@ class alignas(CACHE_LINE_BYTES) LoopCounter {
 #endif
 
 
-#ifdef ORT_USE_MLAS_SHARED_LIB
+#ifdef MLAS_STANDALONE_LIB
 class MlasThreadPoolAdapter : public ThreadPool::MLAS_THREADPOOL_TYPE
 {
 public:
@@ -417,7 +417,7 @@ ThreadPool::ThreadPool(Env* env,
     underlying_threadpool_ = extended_eigen_threadpool_.get();
   }
 
-#ifdef ORT_USE_MLAS_SHARED_LIB
+#ifdef MLAS_STANDALONE_LIB
   mlas_threadpool_adapter_ = std::make_unique<MlasThreadPoolAdapter>(this);
 #endif
 }

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -493,18 +493,6 @@ std::string ThreadPool::StopProfiling() {
   }
 }
 
-ThreadPool::MLAS_THREADPOOL_TYPE* ThreadPool::AsMlasThreadPool() {
-#ifdef ORT_USE_MLAS_SHARED_LIB
-  if (this != nullptr) {
-    return reinterpret_cast<MLAS_THREADPOOL_TYPE*>(mlas_threadpool_adapter_.get());
-  } else {
-    return nullptr;
-  }
-#else
-  return this;
-#endif
-}
-
 thread_local ThreadPool::ParallelSection* ThreadPool::ParallelSection::current_parallel_section{nullptr};
 
 ThreadPool::ParallelSection::ParallelSection(ThreadPool* tp) {

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -19,9 +19,7 @@ limitations under the License.
 #include "core/common/common.h"
 #include "core/common/cpuid_info.h"
 #include "core/common/eigen_common_wrapper.h"
-#ifdef MLAS_STANDALONE_LIB
 #include "core/mlas/inc/mlas.h"
-#endif
 #include "core/platform/EigenNonBlockingThreadPool.h"
 #include "core/platform/ort_mutex.h"
 #if !defined(ORT_MINIMAL_BUILD)
@@ -368,7 +366,6 @@ class alignas(CACHE_LINE_BYTES) LoopCounter {
 #endif
 
 
-#ifdef MLAS_STANDALONE_LIB
 class MlasThreadPoolAdapter : public ThreadPool::MLAS_THREADPOOL_TYPE
 {
 public:
@@ -394,7 +391,6 @@ public:
 private:
   ThreadPool* tp_;
 };
-#endif
 
 ThreadPool::ThreadPool(Env* env,
                        const ThreadOptions& thread_options,
@@ -417,9 +413,7 @@ ThreadPool::ThreadPool(Env* env,
     underlying_threadpool_ = extended_eigen_threadpool_.get();
   }
 
-#ifdef MLAS_STANDALONE_LIB
   mlas_threadpool_adapter_ = std::make_unique<MlasThreadPoolAdapter>(this);
-#endif
 }
 
 ThreadPool::~ThreadPool() = default;

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -91,7 +91,7 @@ typedef enum { CblasNonUnit=131, CblasUnit=132 } CBLAS_DIAG;
 typedef enum { CblasLeft=141, CblasRight=142} CBLAS_SIDE;
 #endif
 
-#ifdef ORT_USE_MLAS_SHARED_LIB
+#ifdef MLAS_STANDALONE_LIB
 //
 // Abstract IThreadPool to remove dependencies for onnxruntime thread pool.
 //

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -91,6 +91,7 @@ typedef enum { CblasNonUnit=131, CblasUnit=132 } CBLAS_DIAG;
 typedef enum { CblasLeft=141, CblasRight=142} CBLAS_SIDE;
 #endif
 
+#ifdef ORT_USE_MLAS_SHARED_LIB
 //
 // Abstract IThreadPool to remove dependencies for onnxruntime thread pool.
 //
@@ -140,6 +141,22 @@ namespace mlas
 } // namespace mlas
 
 using MLAS_THREADPOOL = mlas::IThreadPool;
+#else
+//
+// Forward declare the thread pool implementation class.
+//
+// N.B. Avoid including ONNX Runtime headers here to keep the dependencies for
+// standalone MLAS test executables smaller.
+//
+
+namespace onnxruntime {
+    namespace concurrency {
+        class ThreadPool;
+    }
+}
+
+using MLAS_THREADPOOL = onnxruntime::concurrency::ThreadPool;
+#endif
 
 //
 // Platform routines.

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -91,7 +91,6 @@ typedef enum { CblasNonUnit=131, CblasUnit=132 } CBLAS_DIAG;
 typedef enum { CblasLeft=141, CblasRight=142} CBLAS_SIDE;
 #endif
 
-#ifdef MLAS_STANDALONE_LIB
 //
 // Abstract IThreadPool to remove dependencies for onnxruntime thread pool.
 //
@@ -141,22 +140,6 @@ namespace mlas
 } // namespace mlas
 
 using MLAS_THREADPOOL = mlas::IThreadPool;
-#else
-//
-// Forward declare the thread pool implementation class.
-//
-// N.B. Avoid including ONNX Runtime headers here to keep the dependencies for
-// standalone MLAS test executables smaller.
-//
-
-namespace onnxruntime {
-    namespace concurrency {
-        class ThreadPool;
-    }
-}
-
-using MLAS_THREADPOOL = onnxruntime::concurrency::ThreadPool;
-#endif
 
 //
 // Platform routines.

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -859,7 +859,7 @@ MlasGetMaximumThreadCount(
     return 1;
 #endif
 #else
-    return onnxruntime::concurrency::ThreadPool::DegreeOfParallelism(ThreadPool);
+    return MLAS_THREADPOOL::DegreeOfParallelism(ThreadPool);
 #endif
 }
 

--- a/onnxruntime/core/mlas/lib/pooling.cpp
+++ b/onnxruntime/core/mlas/lib/pooling.cpp
@@ -1297,7 +1297,7 @@ Return Value:
     //
     // Use an external thread pool if one is provided.
     // TODO: change to use MlasExecuteThreaded
-    onnxruntime::concurrency::ThreadPool::TryBatchParallelFor(ThreadPool, static_cast<ptrdiff_t>(TotalChannelCount), [&](ptrdiff_t c) {
+    MLAS_THREADPOOL::TryBatchParallelFor(ThreadPool, static_cast<ptrdiff_t>(TotalChannelCount), [&](ptrdiff_t c) {
       PoolKernelRoutine(&WorkBlock, 1, Input + c * InputSize, Output + c * OutputSize);
     }, 0);
     return;

--- a/onnxruntime/core/providers/cpu/math/gemm.cc
+++ b/onnxruntime/core/providers/cpu/math/gemm.cc
@@ -293,7 +293,7 @@ Status Gemm<float>::Compute(OpKernelContext* context) const {
         c_data != nullptr ? beta_ : 0.0f,
         y_data,
         static_cast<size_t>(N),
-        thread_pool);
+        thread_pool->AsMlasThreadPool());
   }
 
   ComputeActivation(y_data, M * N, thread_pool);

--- a/onnxruntime/core/providers/cpu/math/gemm.cc
+++ b/onnxruntime/core/providers/cpu/math/gemm.cc
@@ -293,7 +293,7 @@ Status Gemm<float>::Compute(OpKernelContext* context) const {
         c_data != nullptr ? beta_ : 0.0f,
         y_data,
         static_cast<size_t>(N),
-        thread_pool->AsMlasThreadPool());
+        concurrency::ThreadPool::AsMlasThreadPool(thread_pool));
   }
 
   ComputeActivation(y_data, M * N, thread_pool);

--- a/onnxruntime/core/providers/cpu/math/matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/matmul.cc
@@ -200,7 +200,7 @@ Status MatMul<float>::Compute(OpKernelContext* ctx) const {
     data[i].beta = 0.0f;
   }
   MlasGemmBatch(trans_a ? CblasTrans : CblasNoTrans, trans_b ? CblasTrans : CblasNoTrans,
-                M, N, K, data.data(), max_len, thread_pool->AsMlasThreadPool());
+                M, N, K, data.data(), max_len, concurrency::ThreadPool::AsMlasThreadPool(thread_pool));
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/math/matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/matmul.cc
@@ -200,7 +200,7 @@ Status MatMul<float>::Compute(OpKernelContext* ctx) const {
     data[i].beta = 0.0f;
   }
   MlasGemmBatch(trans_a ? CblasTrans : CblasNoTrans, trans_b ? CblasTrans : CblasNoTrans,
-                M, N, K, data.data(), max_len, thread_pool);
+                M, N, K, data.data(), max_len, thread_pool->AsMlasThreadPool());
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/math/matmul_integer.cc
+++ b/onnxruntime/core/providers/cpu/math/matmul_integer.cc
@@ -107,7 +107,7 @@ Status MatMulInteger::Compute(OpKernelContext* ctx) const {
     gemm_params.B = b_data + helper.RightOffsets()[batch];
     gemm_params.C = y_data + helper.OutputOffsets()[batch];
   }
-  MlasGemmBatch(gemm_shape, gemm_data_vec.data(), batch_size, ctx->GetOperatorThreadPool()->AsMlasThreadPool());
+  MlasGemmBatch(gemm_shape, gemm_data_vec.data(), batch_size, concurrency::ThreadPool::AsMlasThreadPool(ctx->GetOperatorThreadPool()));
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/math/matmul_integer.cc
+++ b/onnxruntime/core/providers/cpu/math/matmul_integer.cc
@@ -107,7 +107,7 @@ Status MatMulInteger::Compute(OpKernelContext* ctx) const {
     gemm_params.B = b_data + helper.RightOffsets()[batch];
     gemm_params.C = y_data + helper.OutputOffsets()[batch];
   }
-  MlasGemmBatch(gemm_shape, gemm_data_vec.data(), batch_size, ctx->GetOperatorThreadPool());
+  MlasGemmBatch(gemm_shape, gemm_data_vec.data(), batch_size, ctx->GetOperatorThreadPool()->AsMlasThreadPool());
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/math/quantize_linear_matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/quantize_linear_matmul.cc
@@ -142,7 +142,7 @@ Status QLinearMatMul::Compute(OpKernelContext* ctx) const {
     gemm_params[i].OutputProcessor = &(requant_procs[i]);
   }
 
-  MlasGemmBatch(gemm_shape, gemm_params.data(), num_gemms, ctx->GetOperatorThreadPool()->AsMlasThreadPool());
+  MlasGemmBatch(gemm_shape, gemm_params.data(), num_gemms, concurrency::ThreadPool::AsMlasThreadPool(ctx->GetOperatorThreadPool()));
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/math/quantize_linear_matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/quantize_linear_matmul.cc
@@ -142,7 +142,7 @@ Status QLinearMatMul::Compute(OpKernelContext* ctx) const {
     gemm_params[i].OutputProcessor = &(requant_procs[i]);
   }
 
-  MlasGemmBatch(gemm_shape, gemm_params.data(), num_gemms, ctx->GetOperatorThreadPool());
+  MlasGemmBatch(gemm_shape, gemm_params.data(), num_gemms, ctx->GetOperatorThreadPool()->AsMlasThreadPool());
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/math/softmax_shared.cc
+++ b/onnxruntime/core/providers/cpu/math/softmax_shared.cc
@@ -97,7 +97,7 @@ common::Status SoftmaxCPU<float>(size_t N,
                                  float* Ydata,
                                  bool logarithmic,
                                  onnxruntime::concurrency::ThreadPool* thread_pool) {
-  MlasComputeSoftmax(Xdata, Ydata, N, D, logarithmic, thread_pool->AsMlasThreadPool());
+  MlasComputeSoftmax(Xdata, Ydata, N, D, logarithmic, concurrency::ThreadPool::AsMlasThreadPool(thread_pool));
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/cpu/math/softmax_shared.cc
+++ b/onnxruntime/core/providers/cpu/math/softmax_shared.cc
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <cmath>
 #include "core/providers/cpu/math/softmax_shared.h"
+#include "core/platform/threadpool.h"
 #include "core/util/math.h"
 #include "core/util/math_cpuonly.h"
 #include "core/mlas/inc/mlas.h"
@@ -96,7 +97,7 @@ common::Status SoftmaxCPU<float>(size_t N,
                                  float* Ydata,
                                  bool logarithmic,
                                  onnxruntime::concurrency::ThreadPool* thread_pool) {
-  MlasComputeSoftmax(Xdata, Ydata, N, D, logarithmic, thread_pool);
+  MlasComputeSoftmax(Xdata, Ydata, N, D, logarithmic, thread_pool->AsMlasThreadPool());
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/cpu/ml/ml_common.h
+++ b/onnxruntime/core/providers/cpu/ml/ml_common.h
@@ -446,7 +446,7 @@ void batched_update_scores_inplace(gsl::span<T> scores, int64_t num_batches_in, 
         }
 
         if (use_mlas) {
-          MlasComputeSoftmax(s, s, num_batches, batch_size, false, threadpool);
+          MlasComputeSoftmax(s, s, num_batches, batch_size, false, threadpool->AsMlasThreadPool());
         } else {
           while (s < s_end) {
             gsl::span<float> scores_for_batch(s, s + batch_size);

--- a/onnxruntime/core/providers/cpu/ml/ml_common.h
+++ b/onnxruntime/core/providers/cpu/ml/ml_common.h
@@ -446,7 +446,7 @@ void batched_update_scores_inplace(gsl::span<T> scores, int64_t num_batches_in, 
         }
 
         if (use_mlas) {
-          MlasComputeSoftmax(s, s, num_batches, batch_size, false, threadpool->AsMlasThreadPool());
+          MlasComputeSoftmax(s, s, num_batches, batch_size, false, concurrency::ThreadPool::AsMlasThreadPool(threadpool));
         } else {
           while (s < s_end) {
             gsl::span<float> scores_for_batch(s, s + batch_size);

--- a/onnxruntime/core/providers/cpu/nn/conv.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv.cc
@@ -215,7 +215,7 @@ Status Conv<float>::Compute(OpKernelContext* context) const {
                     static_cast<size_t>(M / conv_attrs_.group),
                     &activation_,
                     &WorkingBufferSize,
-                    thread_pool);
+                    thread_pool->AsMlasThreadPool());
 
     auto* working_data = WorkingBufferSize > 0 ? alloc->Alloc(SafeInt<size_t>(sizeof(float)) * WorkingBufferSize)
                                                : nullptr;
@@ -227,7 +227,7 @@ Status Conv<float>::Compute(OpKernelContext* context) const {
              Bdata,
              static_cast<float*>(working_buffer.get()),
              Ydata,
-             thread_pool);
+             thread_pool->AsMlasThreadPool());
   } else {
     const int64_t input_image_size = input_shape.Size();
     const int64_t output_image_size = output_shape.Size();

--- a/onnxruntime/core/providers/cpu/nn/conv.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv.cc
@@ -215,7 +215,7 @@ Status Conv<float>::Compute(OpKernelContext* context) const {
                     static_cast<size_t>(M / conv_attrs_.group),
                     &activation_,
                     &WorkingBufferSize,
-                    thread_pool->AsMlasThreadPool());
+                    concurrency::ThreadPool::AsMlasThreadPool(thread_pool));
 
     auto* working_data = WorkingBufferSize > 0 ? alloc->Alloc(SafeInt<size_t>(sizeof(float)) * WorkingBufferSize)
                                                : nullptr;
@@ -227,7 +227,7 @@ Status Conv<float>::Compute(OpKernelContext* context) const {
              Bdata,
              static_cast<float*>(working_buffer.get()),
              Ydata,
-             thread_pool->AsMlasThreadPool());
+             concurrency::ThreadPool::AsMlasThreadPool(thread_pool));
   } else {
     const int64_t input_image_size = input_shape.Size();
     const int64_t output_image_size = output_shape.Size();

--- a/onnxruntime/core/providers/cpu/nn/conv_integer.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv_integer.cc
@@ -164,7 +164,7 @@ Status ConvInteger::Compute(OpKernelContext* context) const {
       gemm_params.C = Ydata;
       gemm_params.ldc = static_cast<size_t>(output_image_size);
 
-      MlasGemm(gemm_shape, gemm_params, thread_pool);
+      MlasGemm(gemm_shape, gemm_params, thread_pool->AsMlasThreadPool());
 
       Xdata += X_offset;
       Ydata += Y_offset;

--- a/onnxruntime/core/providers/cpu/nn/conv_integer.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv_integer.cc
@@ -164,7 +164,7 @@ Status ConvInteger::Compute(OpKernelContext* context) const {
       gemm_params.C = Ydata;
       gemm_params.ldc = static_cast<size_t>(output_image_size);
 
-      MlasGemm(gemm_shape, gemm_params, thread_pool->AsMlasThreadPool());
+      MlasGemm(gemm_shape, gemm_params, concurrency::ThreadPool::AsMlasThreadPool(thread_pool));
 
       Xdata += X_offset;
       Ydata += Y_offset;

--- a/onnxruntime/core/providers/cpu/nn/pool.cc
+++ b/onnxruntime/core/providers/cpu/nn/pool.cc
@@ -144,7 +144,7 @@ Status PoolBase::Compute(OpKernelContext* context, MLAS_POOLING_KIND kind) const
            pool_attrs_.global_pooling ? nullptr : pool_attrs_.kernel_shape.data(),
            pool_attrs_.global_pooling ? nullptr : pads.data(),
            pool_attrs_.global_pooling ? nullptr : pool_attrs_.strides.data(), output_dims.data(),
-           X->template Data<float>(), Y->template MutableData<float>(), thread_pool->AsMlasThreadPool());
+           X->template Data<float>(), Y->template MutableData<float>(), concurrency::ThreadPool::AsMlasThreadPool(thread_pool));
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/nn/pool.cc
+++ b/onnxruntime/core/providers/cpu/nn/pool.cc
@@ -144,7 +144,7 @@ Status PoolBase::Compute(OpKernelContext* context, MLAS_POOLING_KIND kind) const
            pool_attrs_.global_pooling ? nullptr : pool_attrs_.kernel_shape.data(),
            pool_attrs_.global_pooling ? nullptr : pads.data(),
            pool_attrs_.global_pooling ? nullptr : pool_attrs_.strides.data(), output_dims.data(),
-           X->template Data<float>(), Y->template MutableData<float>(), thread_pool);
+           X->template Data<float>(), Y->template MutableData<float>(), thread_pool->AsMlasThreadPool());
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
@@ -229,7 +229,7 @@ void ComputeGemm(const int M,
         M, N, K, alpha,
         A, K,
         weights.buffer_, beta,
-        C, ldc, thread_pool);
+        C, ldc, thread_pool->AsMlasThreadPool());
   } else {
     ::onnxruntime::math::GemmEx<float>(
         CblasNoTrans, CblasTrans,
@@ -306,7 +306,7 @@ void ComputeGemm(const int M,
   gemm_params.ldc = ld_C_buffer;
   gemm_params.OutputProcessor = &output_processor;
 
-  MlasGemm(gemm_shape, gemm_params, thread_pool);
+  MlasGemm(gemm_shape, gemm_params, thread_pool->AsMlasThreadPool());
 }
 
 namespace deepcpu {

--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
@@ -229,7 +229,7 @@ void ComputeGemm(const int M,
         M, N, K, alpha,
         A, K,
         weights.buffer_, beta,
-        C, ldc, thread_pool->AsMlasThreadPool());
+        C, ldc, concurrency::ThreadPool::AsMlasThreadPool(thread_pool));
   } else {
     ::onnxruntime::math::GemmEx<float>(
         CblasNoTrans, CblasTrans,
@@ -306,7 +306,7 @@ void ComputeGemm(const int M,
   gemm_params.ldc = ld_C_buffer;
   gemm_params.OutputProcessor = &output_processor;
 
-  MlasGemm(gemm_shape, gemm_params, thread_pool->AsMlasThreadPool());
+  MlasGemm(gemm_shape, gemm_params, concurrency::ThreadPool::AsMlasThreadPool(thread_pool));
 }
 
 namespace deepcpu {

--- a/onnxruntime/core/util/math_cpu.cc
+++ b/onnxruntime/core/util/math_cpu.cc
@@ -16,6 +16,7 @@
 // Modifications Copyright (c) Microsoft.
 
 #include <algorithm>
+#include "core/platform/threadpool.h"
 #include "core/util/math.h"
 #include "core/util/math_cpuonly.h"
 #include "core/mlas/inc/mlas.h"
@@ -74,7 +75,7 @@ void Gemm<float, ThreadPool>(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, ptr
                              float* C, ThreadPool* threadpool) {
   int lda = static_cast<int>((TransA == CblasNoTrans) ? K : M);
   int ldb = static_cast<int>((TransB == CblasNoTrans) ? N : K);
-  MlasGemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, N, threadpool);
+  MlasGemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, N, threadpool->AsMlasThreadPool());
 }
 
 #ifdef MLAS_SUPPORTS_GEMM_DOUBLE
@@ -84,7 +85,7 @@ void Gemm<double, ThreadPool>(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, pt
                               double* C, ThreadPool* threadpool) {
   int lda = static_cast<int>((TransA == CblasNoTrans) ? K : M);
   int ldb = static_cast<int>((TransB == CblasNoTrans) ? N : K);
-  MlasGemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, N, threadpool);
+  MlasGemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, N, threadpool->AsMlasThreadPool());
 }
 #else
 template <>
@@ -134,13 +135,13 @@ void Gemm<double, ThreadPool>(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, pt
 
 template <>
 void MatMul<float>(ptrdiff_t M, ptrdiff_t N, ptrdiff_t K, const float* A, const float* B, float* C, ThreadPool* threadpool) {
-  MlasGemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.f, A, K, B, N, 0.f, C, N, threadpool);
+  MlasGemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.f, A, K, B, N, 0.f, C, N, threadpool->AsMlasThreadPool());
 }
 
 #ifdef MLAS_SUPPORTS_GEMM_DOUBLE
 template <>
 void MatMul<double>(ptrdiff_t M, ptrdiff_t N, ptrdiff_t K, const double* A, const double* B, double* C, ThreadPool* threadpool) {
-  MlasGemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.f, A, K, B, N, 0.f, C, N, threadpool);
+  MlasGemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.f, A, K, B, N, 0.f, C, N, threadpool->AsMlasThreadPool());
 }
 #else
 EIGEN_MATMUL_FUNCTION(double)
@@ -150,7 +151,7 @@ template <>
 void GemmEx<float, ThreadPool>(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, ptrdiff_t M, ptrdiff_t N, ptrdiff_t K,
                                float alpha, const float* A, int lda, const float* B, int ldb, float beta, float* C,
                                int ldc, ThreadPool* threadpool) {
-  MlasGemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc, threadpool);
+  MlasGemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc, threadpool->AsMlasThreadPool());
 }
 
 template <typename T, class Provider>

--- a/onnxruntime/core/util/math_cpu.cc
+++ b/onnxruntime/core/util/math_cpu.cc
@@ -75,7 +75,7 @@ void Gemm<float, ThreadPool>(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, ptr
                              float* C, ThreadPool* threadpool) {
   int lda = static_cast<int>((TransA == CblasNoTrans) ? K : M);
   int ldb = static_cast<int>((TransB == CblasNoTrans) ? N : K);
-  MlasGemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, N, threadpool->AsMlasThreadPool());
+  MlasGemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, N, concurrency::ThreadPool::AsMlasThreadPool(threadpool));
 }
 
 #ifdef MLAS_SUPPORTS_GEMM_DOUBLE
@@ -85,7 +85,7 @@ void Gemm<double, ThreadPool>(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, pt
                               double* C, ThreadPool* threadpool) {
   int lda = static_cast<int>((TransA == CblasNoTrans) ? K : M);
   int ldb = static_cast<int>((TransB == CblasNoTrans) ? N : K);
-  MlasGemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, N, threadpool->AsMlasThreadPool());
+  MlasGemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, N, concurrency::ThreadPool::AsMlasThreadPool(threadpool));
 }
 #else
 template <>
@@ -135,13 +135,13 @@ void Gemm<double, ThreadPool>(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, pt
 
 template <>
 void MatMul<float>(ptrdiff_t M, ptrdiff_t N, ptrdiff_t K, const float* A, const float* B, float* C, ThreadPool* threadpool) {
-  MlasGemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.f, A, K, B, N, 0.f, C, N, threadpool->AsMlasThreadPool());
+  MlasGemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.f, A, K, B, N, 0.f, C, N, concurrency::ThreadPool::AsMlasThreadPool(threadpool));
 }
 
 #ifdef MLAS_SUPPORTS_GEMM_DOUBLE
 template <>
 void MatMul<double>(ptrdiff_t M, ptrdiff_t N, ptrdiff_t K, const double* A, const double* B, double* C, ThreadPool* threadpool) {
-  MlasGemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.f, A, K, B, N, 0.f, C, N, threadpool->AsMlasThreadPool());
+  MlasGemm(CblasNoTrans, CblasNoTrans, M, N, K, 1.f, A, K, B, N, 0.f, C, N, concurrency::ThreadPool::AsMlasThreadPool(threadpool));
 }
 #else
 EIGEN_MATMUL_FUNCTION(double)
@@ -151,7 +151,7 @@ template <>
 void GemmEx<float, ThreadPool>(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, ptrdiff_t M, ptrdiff_t N, ptrdiff_t K,
                                float alpha, const float* A, int lda, const float* B, int ldb, float beta, float* C,
                                int ldc, ThreadPool* threadpool) {
-  MlasGemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc, threadpool->AsMlasThreadPool());
+  MlasGemm(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc, concurrency::ThreadPool::AsMlasThreadPool(threadpool));
 }
 
 template <typename T, class Provider>

--- a/onnxruntime/test/mlas/unittest/test_main.cpp
+++ b/onnxruntime/test/mlas/unittest/test_main.cpp
@@ -9,9 +9,9 @@
 #if !defined(MLAS_NO_ONNXRUNTIME_THREADPOOL)
 
 MLAS_THREADPOOL* GetMlasThreadPool(void) {
-  static MLAS_THREADPOOL* threadpool = new onnxruntime::concurrency::ThreadPool(
+  static onnxruntime::concurrency::ThreadPool* threadpool = new onnxruntime::concurrency::ThreadPool(
       &onnxruntime::Env::Default(), onnxruntime::ThreadOptions(), nullptr, 2, true);
-  return threadpool;
+  return threadpool->AsMlasThreadPool();
 }
 
 #else

--- a/onnxruntime/test/mlas/unittest/test_main.cpp
+++ b/onnxruntime/test/mlas/unittest/test_main.cpp
@@ -11,7 +11,7 @@
 MLAS_THREADPOOL* GetMlasThreadPool(void) {
   static onnxruntime::concurrency::ThreadPool* threadpool = new onnxruntime::concurrency::ThreadPool(
       &onnxruntime::Env::Default(), onnxruntime::ThreadOptions(), nullptr, 2, true);
-  return threadpool->AsMlasThreadPool();
+  return onnxruntime::concurrency::ThreadPool::AsMlasThreadPool(threadpool);
 }
 
 #else


### PR DESCRIPTION
**Description**: Add build option to build MLAS as a shared library.
- Break mlas dependencies for ort thread pool:
  - Add abstract class mlas::IThreadPool to break mlas dependencies for ort thread pool;
  - Add class MlasThreadPoolAdapter to adapt ort tp to mlas tp;
  - Add func AsMlasThreadPool to get a mlas tp pointer.
 - Convert ort tp to mlas tp before calling mlas funcs;
 - Add preprocessor to ensure non-shared mlas works exactly same as the original;
 - Add build option to build mlas as a standalone lib:
   - ~~Always build mlas as static library in Win32 (requires more changes) and Apple (Not tested).~~

**Motivation and Context**
- Why is this change required? What problem does it solve?

We want to use MLAS outside onnxruntime for custom operator implementation. However, currently it's not convenient for this. MLAS is built as a static lib and also has strong dependencies for the ThreadPool.

This change breaks MLAS dependencies for ort ThreadPool and adds a build option to make mlas as a standalone lib.
