### PR TITLE
eager: fix build against latest PyTorch master

### DIFF
--- a/orttraining/orttraining/eager/README.md
+++ b/orttraining/orttraining/eager/README.md
@@ -1,11 +1,17 @@
 # ONNX Runtime Eager Mode Support for PyTorch
 
-## Build Instrcutions
+* Until the ONNX Runtime Eager Mode backend is merged in PyTorch upstream ([PR #58248](https://github.com/pytorch/pytorch/pull/58248)), build PyTorch from [abock/pytorch](https://github.com/abock/pytorch/tree/dev/abock/ort-backend) (branch: `dev/abock/ort-backend`):
 
-* Build Pytorch with commit: 0834a368181d18c8fd2429614fafca50fb412ce1
-* Install the pytorch build to your current environment
-* Build onnxruntime, make sure you enable training and python build together with eager mode:
+  ```bash
+  $ git clone https://github.com/abock/pytorch -b dev/abock/ort-backend --recursive
+  $ cd pytorch
+  $ python setup.py develop --user
+  ```
 
-```bash
-./build.sh --enable_training --enalbe_pybind --build_eager_mode
-```
+* If not build as noted above, ensure the eager-mode enabled PyTorch build is installed in the current environment.
+
+* Build ONNX Runtime, making sure you enable training and python build together with eager mode:
+
+  ```bash
+  ./build.sh --cmake_generator=Ninja --enable_training --enable_pybind --build_eager_mode
+  ```

--- a/orttraining/orttraining/eager/ort_tensor.h
+++ b/orttraining/orttraining/eager/ort_tensor.h
@@ -13,10 +13,7 @@ class ORTTensorImpl final : public c10::TensorImpl {
  public:
   explicit ORTTensorImpl(OrtValue tensor, const at::TensorOptions& options)
     : c10::TensorImpl(
-        c10::DispatchKeySet {
-          c10::DispatchKey::ORT,
-          c10::DispatchKey::AutogradORT
-        },
+        c10::DispatchKeySet{c10::DispatchKey::ORT},
         options.dtype(),
         options.device()) {
     set_tensor(tensor);


### PR DESCRIPTION
* Fixes the eager mode build to work against the [latest PyTorch changes](https://github.com/pytorch/pytorch/pull/58248).
* Clean up the README for eager a bit as well