### PR TITLE
[js/web] fix perf mode in test

### DIFF
--- a/js/web/webpack.config.js
+++ b/js/web/webpack.config.js
@@ -175,7 +175,9 @@ function buildTestRunnerConfig({
     },
     plugins: [
       new webpack.WatchIgnorePlugin({ paths: [/\.js$/, /\.d\.ts$/] }),
-      new NodePolyfillPlugin(),
+      new NodePolyfillPlugin({
+        excludeAliases: ["console"]
+      }),
     ],
     module: {
       rules: [{


### PR DESCRIPTION
**Description**: This change fixes ONNX Runtime Web test when launched with "-P" flag.

bundler rewrite symbol "console" in exported function OrtWasmModule. This causes Function.toString() missed definition in closure for a polyfilled console variable.