### PR TITLE
[js/web] add SharedArrayBuffer check for wasm multi-thread

### DIFF
--- a/js/web/lib/wasm/wasm-factory.ts
+++ b/js/web/lib/wasm/wasm-factory.ts
@@ -16,6 +16,11 @@ let aborted = false;
 
 const isMultiThreadSupported = (): boolean => {
   try {
+    // If 'SharedArrayBuffer' is not available, WebAssembly threads will not work.
+    if (typeof SharedArrayBuffer === 'undefined') {
+      return false;
+    }
+
     // Test for transferability of SABs (for browsers. needed for Firefox)
     // https://groups.google.com/forum/#!msg/mozilla.dev.platform/IHkBZlHETpA/dwsMNchWEQAJ
     if (typeof MessageChannel !== 'undefined') {


### PR DESCRIPTION
**Description**: Since Chrome 92, using `SharedArrayBuffer` requires explicit cross-origin isolation (https://developer.chrome.com/blog/enabling-shared-array-buffer/).

we check if `SharedArrayBuffer` is available in the current context; if not we disable the multi-thread feature for web assembly backend.