### PR TITLE
[Nuphar] Do not handle MatMulInteger with zero-points

### DIFF
--- a/onnxruntime/core/providers/nuphar/nuphar_execution_provider.cc
+++ b/onnxruntime/core/providers/nuphar/nuphar_execution_provider.cc
@@ -321,6 +321,9 @@ NupharExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_vie
         return false;
       }
     }
+    if (node.OpType() == "MatMulInteger" && inputs.size() > 2) {
+      return false;  // do not support MatMulInteger with zero points
+    }
     return true;
   };
   GraphPartitioner graph_partitioner(is_supported_func);


### PR DESCRIPTION
This change fixes a crash in models with 4-input MatMulInteger nodes.

MatMulInteger can take zero-points as input, and Nuphar does not handle that yet. Fall back to CPU EP in that case.

