### PR TITLE
Remove CUDNN dir from setup_env_cuda.bat

### DIFF
--- a/tools/ci_build/github/windows/setup_env_cuda.bat
+++ b/tools/ci_build/github/windows/setup_env_cuda.bat
@@ -1,2 +1,2 @@
-set PATH=C:\azcopy;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\bin;C:\local\cudnn-10.2-windows10-x64-v8.0.3.33\cuda\bin;%PATH%
+set PATH=C:\azcopy;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\bin;%PATH%
 set GRADLE_OPTS=-Dorg.gradle.daemon=false

--- a/tools/ci_build/github/windows/setup_env_cuda_11.bat
+++ b/tools/ci_build/github/windows/setup_env_cuda_11.bat
@@ -1,2 +1,2 @@
-set PATH=C:\azcopy;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1\bin;C:\local\cudnn-11.1-windows-x64-v8.0.5.39\cuda\bin;%PATH%
+set PATH=C:\azcopy;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1\bin;%PATH%
 set GRADLE_OPTS=-Dorg.gradle.daemon=false


### PR DESCRIPTION
**Description**: 

1. Remove CUDNN dir from setup_env_cuda.bat. Because when I setup the build machines, I copied all the files to CUDA's installation dir. So we don't need to add them to PATH. I copied the file because that what CUDNN's installation guide recommended. 
2. ~Set CUDA version to 11.4~

**Motivation and Context**
- Why is this change required? What problem does it solve?

To avoid confusion. 

- If it fixes an open issue, please link to the issue here.
