### PR TITLE
Invertible ReluGrad

### DIFF
--- a/orttraining/orttraining/core/framework/gradient_graph_builder.h
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.h
@@ -71,7 +71,8 @@ static std::unordered_map<std::string, std::unordered_set<size_t>>
         {"Clip", {1, 2}},
         {"Pad", {1, 2}}};
 
-static std::unordered_set<std::string> INVERTIBLE_OPS{"LayerNormalization"};
+static std::unordered_set<std::string> INVERTIBLE_OPS{"LayerNormalization",
+                                                      "Relu"};
 
 class GradientGraphBuilder {
  public:

--- a/orttraining/orttraining/core/graph/gradient_builder.cc
+++ b/orttraining/orttraining/core/graph/gradient_builder.cc
@@ -783,9 +783,15 @@ IMPLEMENT_GRADIENT_BUILDER(GetGatherElementsGradient) {
 };
 
 IMPLEMENT_GRADIENT_BUILDER(GetReluGradient) {
+  ArgDef mask{};
+  if (IsTensorStashed(O(0, false).name)) {
+    mask = O(0);
+  } else {
+    mask = I(0);
+  }
   return std::vector<NodeDef>{
       NodeDef(OpDef{"ReluGrad", kMSDomain, 1},
-              {GO(0), O(0)},
+              {GO(0), mask},
               {GI(0)})};
 }
 

--- a/orttraining/orttraining/core/graph/gradient_builder.cc
+++ b/orttraining/orttraining/core/graph/gradient_builder.cc
@@ -783,12 +783,7 @@ IMPLEMENT_GRADIENT_BUILDER(GetGatherElementsGradient) {
 };
 
 IMPLEMENT_GRADIENT_BUILDER(GetReluGradient) {
-  ArgDef mask{};
-  if (IsTensorStashed(O(0, false).name)) {
-    mask = O(0);
-  } else {
-    mask = I(0);
-  }
+  ArgDef mask = IsTensorStashed(O(0, false).name) ? O(0) : I(0);
   return std::vector<NodeDef>{
       NodeDef(OpDef{"ReluGrad", kMSDomain, 1},
               {GO(0), mask},


### PR DESCRIPTION
ReluGrad can accept mask from either I(0) or O(0). 

def ReluGrad(dy, x_or_y) : return where((x_or_y > 0), dy, 0) 

Since x and y has the same sign, it's equivalent to pass x or y for the second input.
The amount of computation is also identical. 