### PR TITLE
Allow nonempty layout in the eager implementation of torch.empty

### DIFF
--- a/orttraining/orttraining/eager/ort_aten.cpp
+++ b/orttraining/orttraining/eager/ort_aten.cpp
@@ -161,7 +161,6 @@ at::Tensor empty__memory_format(
 
   assert(dtype_opt.has_value());
   assert(device_opt.has_value());
-  assert(!layout_opt.has_value());
 
   // TODO: validate options and memory format
   // TODO: figure out how to get the correct element type.


### PR DESCRIPTION
This PR removes the assertion that `layout` is empty in the eager implementation of `torch.empty`.
https://pytorch.org/docs/stable/generated/torch.empty.html

**Motivation and Context**

When attempting to use the eager extension (`torch_ort`) to run the forward and backward pass of a `torch.nn.GELU` model, the `empty_memory_format` op is invoked with layout `c10::Layout::Strided` in the backward pass. Thus, the assert was failing.

Call stack (abridged):

```
onnxruntime_pybind11_state.so!torch_ort::eager::aten::empty__memory_format(c10::IntArrayRef size, c10::optional<c10::ScalarType> dtype_opt, c10::optional<c10::Layout> layout_opt, c10::optional<c10::Device> device_opt, c10::optional<bool> pin_memory, c10::optional<c10::MemoryFormat> memory_format) (\onnxruntime\onnxruntime.git\orttraining\orttraining\eager\ort_aten.cpp:164)
...
libtorch_cpu.so!torch::autograd::Engine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&) (Unknown Source:0)
libtorch_python.so!torch::autograd::python::PythonEngine::execute(std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> > const&, bool, bool, bool, std::vector<torch::autograd::Edge, std::allocator<torch::autograd::Edge> > const&) (Unknown Source:0)
```
torch built from https://github.com/abock/pytorch/tree/dev/abock%2Fort-backend