### PR TITLE
New S8S8 Neon kernel for arm64 only

### DIFF
--- a/onnxruntime/core/mlas/lib/qgemm.h
+++ b/onnxruntime/core/mlas/lib/qgemm.h
@@ -701,10 +701,9 @@ MlasGemmU8X8GetDispatch(
         GemmU8X8Dispatch = MlasPlatform.GemmU8U8Dispatch;
     }
 #elif defined(MLAS_TARGET_ARM64)
-    if (BIsSigned && USE_NEONS8_KERNEL) {
+    GemmU8X8Dispatch = MlasPlatform.GemmU8X8Dispatch;
+    if (USE_NEONS8_KERNEL && BIsSigned && GemmU8X8Dispatch == &MlasGemmU8X8DispatchNeon) {
         GemmU8X8Dispatch = &MlasGemmS8S8DispatchNeon;
-    } else {
-        GemmU8X8Dispatch = MlasPlatform.GemmU8X8Dispatch;
     }
 #elif defined(MLAS_TARGET_ARM64EC) || (defined(MLAS_TARGET_ARM) && !defined(_MSC_VER))
     GemmU8X8Dispatch = &MlasGemmU8X8DispatchNeon;

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_neon.cpp
@@ -497,7 +497,7 @@ const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchNeon = {
     MLAS_GEMM_U8X8_KERNEL_NEON::PackedStrides.K,
 };
 
-
+#if defined(MLAS_TARGET_ARM64)
 /*-------------------------
  * NEON kernel for signed int8
  */
@@ -970,3 +970,5 @@ const MLAS_GEMM_U8X8_DISPATCH MlasGemmS8S8DispatchNeon = {
     MLAS_GEMM_S8S8_KERNEL_NEON::PackedK,
     MLAS_GEMM_S8S8_KERNEL_NEON::PackedStrides.K,
 };
+
+#endif  //defined(MLAS_TARGET_ARM64)


### PR DESCRIPTION
New Neon s8s8 kernel should be restricted to arm64 only.

Pending test run on  Android_Java_API_AAR_Packaging_Pipeline