### PR TITLE
revert cmake policy CMP0104 to OLD behavior for handling CMAKE_CUDA_ARCHITECTURES

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -12,6 +12,8 @@ cmake_policy(SET CMP0091 NEW)
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.20")
   cmake_policy(SET CMP0117 NEW)
 endif()
+# Don't let cmake set a default value for CMAKE_CUDA_ARCHITECTURES
+cmake_policy(SET CMP0104 OLD)
 
 # Project
 project(onnxruntime C CXX)


### PR DESCRIPTION
The if block under
https://github.com/microsoft/onnxruntime/blob/c117ac57b75735edfbbb57159371f6742405c9d1/cmake/CMakeLists.txt#L1487
never gets executed because of cmake policy CMP0104
cmake detects the cuda arch on the build system and select a default value for CMAKE_CUDA_ARCHITECTURES. 
Thus if(NOT CMAKE_CUDA_ARCHITECTURES) will always be false.

setting CMP0104 to OLD reverts to old behavior where CMAKE_CUDA_ARCHITECTURES is not set unless the user defines it.