### PR TITLE
Auto forward non method attribute lookups to the user's model and bind custom methods to ORTModule

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -160,7 +160,7 @@ class GraphExecutionManager(GraphExecutionInterface):
 
         # Flag to re-export the model due to attribute change on original module.
         # Re-export will be avoided if _skip_check is enabled.
-        self._reexport = False
+        self._model_has_changed = False
 
     def _get_torch_gpu_allocator_function_addresses(self):
         if self._use_external_gpu_allocator and torch.cuda.is_available():
@@ -277,7 +277,7 @@ class GraphExecutionManager(GraphExecutionInterface):
 
         schema = _io._extract_schema(
             {'args': copy.copy(inputs), 'kwargs': copy.copy(kwargs)})
-        if self._onnx_models.exported_model and schema == self._input_info.schema and not self._reexport:
+        if self._onnx_models.exported_model and schema == self._input_info.schema and not self._model_has_changed:
             # All required models have already been exported previously
             return False
 
@@ -421,6 +421,6 @@ class GraphExecutionManager(GraphExecutionInterface):
         self._graph_initializers = [param for name, param in self._flattened_module.named_parameters()
                                     if name in self._graph_initializer_names]
 
-    def mark_for_reexport(self):
+    def signal_model_changed(self):
         """Signals the execution manager to re-export the model on the next forward call"""
-        self._reexport = True
+        self._model_has_changed = True

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -22,6 +22,7 @@ from onnxruntime.capi import _pybind_state as C
 from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
 from abc import ABC, abstractmethod
 import copy
+from functools import reduce
 import io
 import inspect
 import os
@@ -94,7 +95,10 @@ class GraphExecutionManager(GraphExecutionInterface):
         self._execution_agent = None
 
         # indicators of some logic have been executed previously thus could be skipped for faster training
-        self._skip_check = _SkipCheck.SKIP_CHECK_DISABLED
+        self._skip_check = reduce(lambda x, y: x | y,
+                                  [_SkipCheck[name] for name in
+                                    _utils.parse_os_env_skip_check_flags('ORTMODULE_SKIPCHECK_POLICY',
+                                                                         _SkipCheck.SKIP_CHECK_DISABLED.name)])
         self._first_skip_check_warning = True
 
         # Graph transformer config

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -160,7 +160,7 @@ class GraphExecutionManager(GraphExecutionInterface):
 
         # Flag to re-export the model due to attribute change on original module.
         # Re-export will be avoided if _skip_check is enabled.
-        self._model_has_changed = False
+        self._original_model_has_changed = False
 
     def _get_torch_gpu_allocator_function_addresses(self):
         if self._use_external_gpu_allocator and torch.cuda.is_available():
@@ -277,7 +277,7 @@ class GraphExecutionManager(GraphExecutionInterface):
 
         schema = _io._extract_schema(
             {'args': copy.copy(inputs), 'kwargs': copy.copy(kwargs)})
-        if self._onnx_models.exported_model and schema == self._input_info.schema and not self._model_has_changed:
+        if self._onnx_models.exported_model and schema == self._input_info.schema and not self._original_model_has_changed:
             # All required models have already been exported previously
             return False
 
@@ -423,4 +423,4 @@ class GraphExecutionManager(GraphExecutionInterface):
 
     def signal_model_changed(self):
         """Signals the execution manager to re-export the model on the next forward call"""
-        self._model_has_changed = True
+        self._original_model_has_changed = True

--- a/orttraining/orttraining/python/training/ortmodule/_torch_module_pytorch.py
+++ b/orttraining/orttraining/python/training/ortmodule/_torch_module_pytorch.py
@@ -92,4 +92,4 @@ class TorchModulePytorch(TorchModuleInterface):
 
     @TorchModuleInterface.module.getter
     def module(self):
-        return self._original_module.module
+        return self._original_module

--- a/orttraining/orttraining/python/training/ortmodule/_utils.py
+++ b/orttraining/orttraining/python/training/ortmodule/_utils.py
@@ -7,6 +7,7 @@ from onnxruntime.capi.onnxruntime_inference_collection import OrtValue
 from onnxruntime.capi import _pybind_state as C
 from ._fallback import _FallbackManager, ORTModuleFallbackException, ORTModuleDeviceException, wrap_exception
 
+import os
 import copy
 import inspect
 import torch
@@ -172,3 +173,8 @@ def check_for_name_collisions_and_bind_methods_to_ortmodule(ortmodule: torch.nn.
                 if attribute_name in ortmodule_attributes:
                     warnings.warn(f"User Module's attribute name {attribute_name} collides with ORTModule's attribute name. "
                     "User Module's attribute may not be returned when trying to retrieve the attribute through ORTModule.")
+
+def parse_os_env_skip_check_flags(env_name, default_skip_check_str):
+    """Returns a list of SkipChecks as defined by os env variable env_name or default provided"""
+
+    return os.getenv(env_name, default_skip_check_str).split('|')

--- a/orttraining/orttraining/python/training/ortmodule/_utils.py
+++ b/orttraining/orttraining/python/training/ortmodule/_utils.py
@@ -162,8 +162,8 @@ def check_for_name_collisions_and_bind_methods_to_ortmodule(ortmodule: torch.nn.
                         "User Module's method may not be called upon invocation through ORTModule.")
                 else:
                     # This is a custom method, copy it and bind the copy to ORTModule.
-                    # This is needed for cases where the user's custom method makes invokes
-                    # the forward method. It should go through ORTModule's forwrad implementation
+                    # This is needed for cases where the user's custom method invokes
+                    # the forward method. It should go through ORTModule's forward implementation
                     # and not go through the user defined forward method.
                     ortmodule.__dict__[attribute_name] = types.MethodType(copy.deepcopy(attribute.__func__), ortmodule)
         else:

--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -83,9 +83,10 @@ class ORTModule(torch.nn.Module):
             CustomOpSymbolicRegistry.register_all()
             CustomGradientRegistry.register_all()
 
-            # Make sure that the user defined model does not have any name collisions
-            # with the ORTModule attribute names.
-            _utils.check_for_name_collisions(self, module)
+            # Warn user if there are name collisions between user model's and ORTModule attributes
+            # And if there are custom methods defined on the user's model, copy and bind them to
+            # ORTModule.
+            _utils.check_for_name_collisions_and_bind_methods_to_ortmodule(self, module)
 
         except ORTModuleFallbackException as e:
             self._torch_module = TorchModulePytorch(module)

--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -299,7 +299,7 @@ class ORTModule(torch.nn.Module):
             # Re-export will be avoided if _skip_check is enabled.
             if isinstance(self._torch_module, TorchModuleORT):
                 for training_mode in [False, True]:
-                    self._torch_module._execution_manager(training_mode).mark_for_reexport()
+                    self._torch_module._execution_manager(training_mode).signal_model_changed()
 
         if isinstance(value, torch.nn.Parameter) or isinstance(value, torch.nn.Module) \
             or isinstance(value, torch.Tensor):

--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -35,6 +35,14 @@ class ORTModule(torch.nn.Module):
     """
 
     def __init__(self, module, debug_options=None):
+
+        # NOTE: torch.nn.Modules that call setattr on their internal attributes regularly
+        #       (for example PyTorch Lightning), will trigger regular re-exports. This is
+        #       because ORTModule auto detects such setattrs on the original module and
+        #       marks the model as stale. This is a known limitation. To disable repeated
+        #       re-export checks when not required, please set the environment variable
+        #       ORTMODULE_SKIPCHECK_POLICY to SKIP_CHECK_BUILD_GRADIENT|SKIP_CHECK_EXECUTION_AGENT
+
         # Set _is_initialized attribute first which starts off as False.
         # This variable will be used for comparing strings in __setattr__ and __getattr__
         # NOTE: Do not rename/move.

--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -294,7 +294,7 @@ class ORTModule(torch.nn.Module):
             assert '_torch_module' in self.__dict__, "ORTModule does not have a reference to the user's model"
             return getattr(self.module, name)
         else:
-            super(ORTModule, self).__getattr__(name)
+            return super(ORTModule, self).__getattr__(name)
 
     def __setattr__(self, name: str, value) -> None:
 

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -3513,7 +3513,7 @@ def test_ortmodule_setattr_ortmodule_attribute():
     assert '_torch_module' in ort_model.__dict__
     assert ort_model._torch_module == True
 
-def test_ortmodule_setattr_marks_model_for_reexport():
+def test_ortmodule_setattr_signals_model_changed():
     class UserNet(torch.nn.Module):
         def __init__(self, input_flag):
             super(UserNet, self).__init__()
@@ -3535,11 +3535,11 @@ def test_ortmodule_setattr_marks_model_for_reexport():
     exported_model1 = ort_model._torch_module._execution_manager(True)._onnx_models.exported_model
 
     for training_mode in [False, True]:
-        assert ort_model._torch_module._execution_manager(training_mode)._reexport == False
+        assert ort_model._torch_module._execution_manager(training_mode)._model_has_changed == False
     ort_model.input_flag = False
 
     for training_mode in [False, True]:
-        assert ort_model._torch_module._execution_manager(training_mode)._reexport == True
+        assert ort_model._torch_module._execution_manager(training_mode)._model_has_changed == True
 
     _ = ort_model(torch.randn(N, D_in, device=device))
     exported_model2 = ort_model._torch_module._execution_manager(True)._onnx_models.exported_model

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -3445,7 +3445,8 @@ def test_ortmodule_user_getattr_gets_successfully():
     pt_model = UserDefinedMethodsNet().to(device)
     ort_model = ORTModule(pt_model)
 
-    assert ort_model.custom_method_returns_input == pt_model.custom_method_returns_input
+    assert ort_model.custom_method_returns_input != pt_model.custom_method_returns_input
+    assert ort_model.custom_method_returns_input.__func__ == pt_model.custom_method_returns_input.__func__
     assert ort_model.dummy is pt_model.dummy
 
 @pytest.mark.parametrize("attribute", ['True', 'lambda x : x'])
@@ -3467,7 +3468,7 @@ def test_ortmodule_setattr_new_attribute(attribute):
     assert pt_model.a_new_attribute == attribute
     assert 'a_new_attribute' not in ort_model.__dict__
 
-def test_ortmodule_setattr_existing_attribute():
+def test_ortmodule_setattr_on_ortmodule_copied_user_model_attribute():
     class UserNet(torch.nn.Module):
         def __init__(self):
             super(UserNet, self).__init__()
@@ -3485,15 +3486,19 @@ def test_ortmodule_setattr_existing_attribute():
     device = 'cuda'
     pt_model = UserNet().to(device)
     ort_model = ORTModule(pt_model)
+    # custom_method is copied by ORTModule from the users model
+    # and bound to itself
     ort_model.custom_method = my_new_custom_method
+    # dummy is defined on pt model
     ort_model.dummy = torch.nn.Parameter(torch.FloatTensor([12]))
 
     assert hasattr(pt_model, 'dummy')
     assert torch.eq(pt_model.dummy, torch.nn.Parameter(torch.FloatTensor([12])))
-    assert hasattr(pt_model, 'custom_method')
-    assert pt_model.custom_method is my_new_custom_method
-
     assert 'dummy' not in ort_model.__dict__
+
+    assert hasattr(pt_model, 'custom_method')
+    assert pt_model.custom_method is not my_new_custom_method
+    assert ort_model.custom_method is my_new_custom_method
 
 def test_ortmodule_setattr_ortmodule_attribute():
     class UserNet(torch.nn.Module):
@@ -3546,7 +3551,7 @@ def test_ortmodule_setattr_signals_model_changed():
 
     assert exported_model1 != exported_model2
 
-def test_ortmodule_attribute_name_collision():
+def test_ortmodule_attribute_name_collision_warning():
     class UserNet(torch.nn.Module):
         def __init__(self):
             super(UserNet, self).__init__()
@@ -3567,3 +3572,43 @@ def test_ortmodule_attribute_name_collision():
     assert len(warning_record) == 2
     assert "_torch_module collides with ORTModule's attribute name." in warning_record[0].message.args[0]
     assert "load_state_dict collides with ORTModule's attribute name." in warning_record[1].message.args[0]
+
+def test_ortmodule_ortmodule_method_attribute_copy():
+    class UserNetWithSelfCallingForward(torch.nn.Module):
+        def __init__(self, input_size, hidden_size, num_classes):
+            super(UserNetWithSelfCallingForward, self).__init__()
+
+            self.fc1 = torch.nn.Linear(input_size, hidden_size)
+            self.relu = torch.nn.ReLU()
+            self.fc2 = torch.nn.Linear(hidden_size, num_classes)
+
+        def forward(self, input1):
+            out = self.fc1(input1)
+            out = self.relu(out)
+            out = self.fc2(out)
+            return out
+
+        def run_forward(self, *args, **kwargs):
+            return self(*args, **kwargs)
+
+    device = 'cuda'
+    N, D_in, H, D_out = 64, 784, 500, 10
+    pt_model = UserNetWithSelfCallingForward(D_in, H, D_out).to(device)
+    ort_model = ORTModule(copy.deepcopy(pt_model))
+
+    x_1 = torch.randn(N, D_in, device=device)
+    x_2 = copy.deepcopy(x_1)
+    x_3 = copy.deepcopy(x_1)
+    # Executed on ORTModule
+    out1 = ort_model(x_1)
+    # Executed on ORTModule even though run_forward is not defined on ORTModule
+    out2 = ort_model.run_forward(x_2)
+    # Executed on pytorch module since it is directly invoked from there
+    out3 = pt_model.run_forward(x_3)
+
+    assert torch.equal(out1, out2)
+    _test_helpers.assert_values_are_close(out2, out3)
+
+    assert type(out1.grad_fn).__name__ == '_ORTModuleFunctionBackward'
+    assert type(out2.grad_fn).__name__ == '_ORTModuleFunctionBackward'
+    assert type(out3.grad_fn).__name__ == 'AddmmBackward'

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -3535,11 +3535,11 @@ def test_ortmodule_setattr_signals_model_changed():
     exported_model1 = ort_model._torch_module._execution_manager(True)._onnx_models.exported_model
 
     for training_mode in [False, True]:
-        assert ort_model._torch_module._execution_manager(training_mode)._model_has_changed == False
+        assert ort_model._torch_module._execution_manager(training_mode)._original_model_has_changed == False
     ort_model.input_flag = False
 
     for training_mode in [False, True]:
-        assert ort_model._torch_module._execution_manager(training_mode)._model_has_changed == True
+        assert ort_model._torch_module._execution_manager(training_mode)._original_model_has_changed == True
 
     _ = ort_model(torch.randn(N, D_in, device=device))
     exported_model2 = ort_model._torch_module._execution_manager(True)._onnx_models.exported_model


### PR DESCRIPTION
This pull request:
1. For non methods attributes: auto forwards any call made to the user's original *```torch.nn.Module```* through ```ORTModule``` by implementing the methods:
   - ```__getattr__```: Implemented for attribute lookups that could not be found in ```ORTModule``` and so a lookup is performed on the user's ```torch.nn.Module```.
   - ```__setattr__```: Implemented so that users can set attributes on their original module with ease. All attributes are set on the user provided module instead of on ```ORTModule```. This is also used as a way to signal to ```ORTModule``` that the execution graph has changed and therefore a re-export must be done before the next forward call. This is done automatically by this implementation. The auto re-export can be controlled by enabling the skip check for re-building the graph, re creating the execution agent and so on.
2. For methods attributes: copies user defined methods and binds them to the ```ORTModule``` instance. This is done in order to prevent the problem where user defined methods invoke the forward on the model thereby calling the `PyTorch` module implementation of forward as opposed to ```ORTModule```'s implementation of forward.

Users can now seamlessly use their training script with ```ORTModule``` without needing to change how they invoke user defined methods on their original ```torch.nn.Module```. Here is an example:
```py
# User defined torch.nn.Module 
class UserDefinedMethodsNet(torch.nn.Module): 
    def __init__(self): 
        super(UserDefinedMethodsNet, self).__init__() 

    def forward(self, ...): 
        ... 

    def custom_user_method(self, ...): 
        return some_calculation()  

    def training_step(self, ...):
        out = self(...)
        ...

# Instantiation of ORTModule 
model = UserDefinedMethodsNet() 
model = ORTModule(model) 

# Invoke user defined function 
out = model.custom_user_method() # No AttributeError since ORTModule auto forwards the call to the original module 
model.training_step(...) # ORTModule's forward will be executed and not the user defined forward
```

In addition, ```ORTModule``` checks for any attribute name collisions between the user's model and ```ORTModule```.