### PR TITLE
Fix for doxygen doc errors.

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs
@@ -25,10 +25,21 @@ namespace Microsoft.ML.OnnxRuntime
         /// A pointer to a underlying native instance of OrtSession
         /// </summary>
         protected IntPtr _nativeHandle;
+
         /// <summary>
-        /// Dictionaries that represent input/output/overridableInitializers metadata
+        /// Dictionary that represents input metadata
         /// </summary>
-        protected Dictionary<string, NodeMetadata> _inputMetadata, _outputMetadata, _overridableInitializerMetadata;
+        protected Dictionary<string, NodeMetadata> _inputMetadata;
+
+        /// <summary>
+        /// Dictionary that represent output metadata
+        /// </summary>
+        protected Dictionary<string, NodeMetadata> _outputMetadata;
+
+        /// <summary>
+        /// Dictionary that represents overridableInitializers metadata
+        /// </summary>
+        protected Dictionary<string, NodeMetadata> _overridableInitializerMetadata;
         private SessionOptions _builtInSessionOptions = null;
         private RunOptions _builtInRunOptions = null;
         private ModelMetadata _modelMetadata = null;


### PR DESCRIPTION
New version of doxygen is causing Windows GPU builds to fail with:

D:/a/_work/1/s/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.cs:31: error: Member _outputMetadata (variable) of class Microsoft::ML::OnnxRuntime::InferenceSession is not documented. (warning treated as error, aborting now)

Fixed it by adding doc strings for each variable.