### PR TITLE
Add option to disable FastGelu half2 cuda kernel

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/fast_gelu.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/fast_gelu.cc
@@ -6,6 +6,7 @@
 #include "fast_gelu.h"
 #include "fast_gelu_impl.h"
 #include "contrib_ops/cpu/bert/bias_gelu_helper.h"
+#include "transformer_common.h"
 
 namespace onnxruntime {
 namespace contrib {
@@ -32,6 +33,8 @@ using namespace ONNX_NAMESPACE;
 
 template <typename T>
 FastGelu<T>::FastGelu(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info) {
+  const TransformerOptions* options = TransformerOptions::GetInstance();
+  use_half2_ = options->UseHalf2();
 }
 
 template <typename T>
@@ -45,13 +48,15 @@ Status FastGelu<T>::ComputeInternal(OpKernelContext* context) const {
   int64_t input_length = input->Shape().Size();
   int64_t bias_length = (nullptr == bias) ? 0 : bias->Shape().Size();
   typedef typename ToCudaType<T>::MappedType CudaT;
+
   if (!LaunchFastGeluKernel<CudaT>(GetDeviceProp(),
                                    Stream(),
                                    static_cast<int>(input_length),
                                    static_cast<int>(bias_length),
                                    reinterpret_cast<const CudaT*>(input->template Data<T>()),
                                    (nullptr != bias) ? reinterpret_cast<const CudaT*>(bias->template Data<T>()) : nullptr,
-                                   reinterpret_cast<CudaT*>(output->template MutableData<T>()))) {
+                                   reinterpret_cast<CudaT*>(output->template MutableData<T>()),
+                                   use_half2_)) {
     CUDA_CALL(cudaGetLastError());
     return Status(common::ONNXRUNTIME, common::FAIL);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/fast_gelu.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/fast_gelu.cc
@@ -34,7 +34,7 @@ using namespace ONNX_NAMESPACE;
 template <typename T>
 FastGelu<T>::FastGelu(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info) {
   const TransformerOptions* options = TransformerOptions::GetInstance();
-  use_half2_ = options->UseHalf2();
+  use_half2_ = !options->DisableHalf2();
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cuda/bert/fast_gelu.h
+++ b/onnxruntime/contrib_ops/cuda/bert/fast_gelu.h
@@ -16,6 +16,9 @@ class FastGelu final : public CudaKernel {
  public:
   FastGelu(const OpKernelInfo& op_kernel_info);
   Status ComputeInternal(OpKernelContext* ctx) const override;
+  
+ private:
+  bool use_half2_;
 };
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/fast_gelu_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/fast_gelu_impl.cu
@@ -53,17 +53,13 @@ __global__ void FastGeluKernel(const T a, const T b, const T c, int input_length
 
 template <unsigned TPB>
 __global__ void FastGeluKernel2(const half2 a, const half2 b, const half2 c, int input_length, int bias_length, const half2* input, const half2* bias, half2* output) {
-// half2 arithmetic functions requires cuda architecture >= 5.3
-#if __CUDA_ARCH__ >= 530
   const int idx = blockIdx.x * TPB + threadIdx.x;
-
   if (idx < input_length) {
     const half2 x = input[idx];
     const half2 in = (bias == nullptr) ? x : (x + bias[idx % bias_length]);
     const half2 cdf = a + a * _Tanh(in * (c * in * in + b));
     output[idx] = in * cdf;
   }
-#endif
 }
 
 template <>

--- a/onnxruntime/contrib_ops/cuda/bert/fast_gelu_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/fast_gelu_impl.cu
@@ -67,7 +67,7 @@ __global__ void FastGeluKernel2(const half2 a, const half2 b, const half2 c, int
 }
 
 template <>
-bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length, const float* input, const float* bias, float* output) {
+bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length, const float* input, const float* bias, float* output, bool /*use_half2*/) {
   constexpr int blockSize = 256;
   const int gridSize = (input_length + blockSize - 1) / blockSize;
   FastGeluKernel<float, blockSize><<<gridSize, blockSize, 0, stream>>>(A, B, C, input_length, bias_length, input, bias, output);
@@ -76,10 +76,9 @@ bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int i
 }
 
 template <>
-bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length, const half* input, const half* bias, half* output) {
+bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length, const half* input, const half* bias, half* output, bool use_half2) {
   constexpr int blockSize = 256;
-
-  if (0 == (bias_length & 1) && prop.major >= 7) {
+  if (use_half2 && 0 == (bias_length & 1) && prop.major >= 7) {
     const int n = input_length / 2;
     const int gridSize = (n + blockSize - 1) / blockSize;
     const half2 A2 = __floats2half2_rn(A, A);
@@ -113,7 +112,7 @@ __global__ void FastGeluKernel2(const nv_bfloat162 a, const nv_bfloat162 b, cons
 }
 
 template <>
-bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length, const nv_bfloat16* input, const nv_bfloat16* bias, nv_bfloat16* output) {
+bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length, const nv_bfloat16* input, const nv_bfloat16* bias, nv_bfloat16* output, bool /*use_half2*/) {
   constexpr int blockSize = 256;
 
   if (0 == (bias_length & 1) && prop.major >= 7) {

--- a/onnxruntime/contrib_ops/cuda/bert/fast_gelu_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/fast_gelu_impl.h
@@ -8,7 +8,7 @@ namespace contrib {
 namespace cuda {
 
 template <typename T>
-bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length, const T* input, const T* bias, T* output);
+bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length, const T* input, const T* bias, T* output, bool use_half2);
 
 }  // namespace cuda
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cuda/bert/transformer_common.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/transformer_common.cc
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include <iostream>
-#include "core/providers/shared_library/provider_api.h" // Include this otherwise Windows build complains Env::Default() missing
+#include "core/providers/shared_library/provider_api.h"  // Include this otherwise Windows build complains Env::Default() missing
 #include "core/platform/env_var_utils.h"
 #include "transformer_common.h"
 
@@ -24,7 +24,9 @@ const TransformerOptions* TransformerOptions::GetInstance() {
 
     if (value > 0)
       std::cout << "ORT_TRANSFORMER_OPTIONS: IsPrecisionMode=" << instance.IsPrecisionMode()
-                << ",DisablePersistentSoftmax=" << instance.DisablePersistentSoftmax() << std::endl;
+                << ",DisablePersistentSoftmax=" << instance.DisablePersistentSoftmax()
+                << ",UseHalf2=" << instance.UseHalf2()
+                << std::endl;
   }
 
   return &instance;

--- a/onnxruntime/contrib_ops/cuda/bert/transformer_common.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/transformer_common.cc
@@ -25,7 +25,7 @@ const TransformerOptions* TransformerOptions::GetInstance() {
     if (value > 0)
       std::cout << "ORT_TRANSFORMER_OPTIONS: IsPrecisionMode=" << instance.IsPrecisionMode()
                 << ",DisablePersistentSoftmax=" << instance.DisablePersistentSoftmax()
-                << ",UseHalf2=" << instance.UseHalf2()
+                << ",DisableHalf2=" << instance.DisableHalf2()
                 << std::endl;
   }
 

--- a/onnxruntime/contrib_ops/cuda/bert/transformer_common.h
+++ b/onnxruntime/contrib_ops/cuda/bert/transformer_common.h
@@ -15,9 +15,12 @@ class TransformerOptions {
 
   bool DisablePersistentSoftmax() const { return disable_persistent_softmax_; }
 
+  bool UseHalf2() const { return use_half2_; }
+
   void Initialize(int value) {
     is_precision_mode_ = (value & 0x01) > 0;
     disable_persistent_softmax_ = (value & 0x02) > 0;
+    use_half2_ = (value & 0x04) > 0;
     initialized_ = true;
   }
 
@@ -27,6 +30,9 @@ class TransformerOptions {
 
   // Disable persistent softmax.
   bool disable_persistent_softmax_{false};
+
+  // Enable half2 kernel.
+  bool use_half2_{false};
 
   bool initialized_{false};
 

--- a/onnxruntime/contrib_ops/cuda/bert/transformer_common.h
+++ b/onnxruntime/contrib_ops/cuda/bert/transformer_common.h
@@ -15,12 +15,12 @@ class TransformerOptions {
 
   bool DisablePersistentSoftmax() const { return disable_persistent_softmax_; }
 
-  bool UseHalf2() const { return use_half2_; }
+  bool DisableHalf2() const { return disable_half2_; }
 
   void Initialize(int value) {
     is_precision_mode_ = (value & 0x01) > 0;
     disable_persistent_softmax_ = (value & 0x02) > 0;
-    use_half2_ = (value & 0x04) > 0;
+    disable_half2_ = (value & 0x04) > 0;
     initialized_ = true;
   }
 
@@ -31,8 +31,8 @@ class TransformerOptions {
   // Disable persistent softmax.
   bool disable_persistent_softmax_{false};
 
-  // Enable half2 kernel.
-  bool use_half2_{false};
+  // Disable half2 kernel.
+  bool disable_half2_{false};
 
   bool initialized_{false};
 

--- a/onnxruntime/core/providers/cuda/cu_inc/common.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/common.cuh
@@ -73,6 +73,12 @@ __device__ __forceinline__ bool operator>(const half& lh, const half& rh) { retu
 __device__ __forceinline__ bool operator<(const half& lh, const half& rh) { return (float)lh < (float)rh; }
 __device__ __forceinline__ bool operator>=(const half& lh, const half& rh) { return (float)lh >= (float)rh; }
 __device__ __forceinline__ bool operator<=(const half& lh, const half& rh) { return (float)lh <= (float)rh; }
+
+// support half2 arithmetic for cuda architecture < 5.3
+__device__ __forceinline__ half2 operator+(const half2& lh, const half2& rh) { half2 r; r.x = lh.x + rh.x; r.y = lh.y + rh.y; return r; }
+__device__ __forceinline__ half2 operator-(const half2& lh, const half2& rh) { half2 r; r.x = lh.x - rh.x; r.y = lh.y - rh.y; return r; }
+__device__ __forceinline__ half2 operator*(const half2& lh, const half2& rh) { half2 r; r.x = lh.x * rh.x; r.y = lh.y * rh.y; return r; }
+__device__ __forceinline__ half2 operator/(const half2& lh, const half2& rh) { half2 r; r.x = lh.x / rh.x; r.y = lh.y / rh.y; return r; }
 #endif
 
 template <typename T>

--- a/onnxruntime/python/tools/transformers/fusion_fastgelu.py
+++ b/onnxruntime/python/tools/transformers/fusion_fastgelu.py
@@ -271,7 +271,7 @@ class FusionFastGelu(Fusion):
         mul_7978 = self.model.match_parent(mul_before_tanh, 'Mul', None, output_name_to_node)
         if mul_7978 is None:
             return
-        k = self.model.find_constant_input(mul_7978, 0.79788456)
+        k = self.model.find_constant_input(mul_7978, 0.7978, delta=0.0001)
         if k < 0:
             return
         if mul_7978.input[0 if k == 1 else 1] != root_input:
@@ -291,7 +291,7 @@ class FusionFastGelu(Fusion):
         mul_0447 = self.model.match_parent(mul_before_add_1, 'Mul', another, output_name_to_node)
         if mul_0447 is None:
             return
-        m = self.model.find_constant_input(mul_0447, 0.044715)
+        m = self.model.find_constant_input(mul_0447, 0.0447, delta=0.0001)
         if m < 0:
             return
 

--- a/onnxruntime/test/python/transformers/test_parity_gelu.py
+++ b/onnxruntime/test/python/transformers/test_parity_gelu.py
@@ -32,9 +32,10 @@ from parity_utilities import *
 
 
 class Gelu(nn.Module):
-    def __init__(self, formula=4):
+    def __init__(self, formula=4, fp32_gelu_op=False):
         super().__init__()
         self.formula = formula
+        self.fp32_gelu_op = True
 
     def gelu(self, x):
         if self.formula == 0:
@@ -59,13 +60,13 @@ class Gelu(nn.Module):
         return "Gelu" if formula in [0, 1, 2] else "FastGelu"
 
     def forward(self, x):
-        if x.dtype == torch.float16:
+        if self.fp32_gelu_op and x.dtype == torch.float16:
             # This test only evaluates FP32 kernels so add data type cast for input and output.
-            fp16_gelu = self.gelu(x.to(torch.float32)).to(torch.float16)
-            return (fp16_gelu, )
+            casted_output = self.gelu(x.to(torch.float32)).to(torch.float16)
+            return (casted_output, )
         else:
-            fp32_gelu = self.gelu(x)
-            return (fp32_gelu, )
+            output = self.gelu(x)
+            return (output, )
 
 
 def get_output_names():
@@ -73,11 +74,11 @@ def get_output_names():
     return outputs
 
 
-def run(batch_size, float16, optimized, hidden_size, device, test_cases, formula=0, sequence_length=2):
-    test_name = f"device={device}, float16={float16}, optimized={optimized}, batch_size={batch_size}, sequence_length={sequence_length}, hidden_size={hidden_size}, formula={formula}"
+def run(batch_size, float16, optimized, hidden_size, device, test_cases, formula=0, sequence_length=2, fp32_gelu_op=True):
+    test_name = f"device={device}, float16={float16}, optimized={optimized}, batch_size={batch_size}, sequence_length={sequence_length}, hidden_size={hidden_size}, formula={formula}, fp32_gelu_op={fp32_gelu_op}"
     print(f"\nTesting: {test_name}")
 
-    model = Gelu(formula=formula)
+    model = Gelu(formula=formula, fp32_gelu_op=fp32_gelu_op)
     model.eval()
     model.to(device)
     if float16:
@@ -89,13 +90,14 @@ def run(batch_size, float16, optimized, hidden_size, device, test_cases, formula
 
     if optimized:
         optimized_onnx_path = './temp/gelu_{}_opt_{}.onnx'.format(formula, "fp16" if float16 else "fp32")
-        optimize_onnx(onnx_model_path, optimized_onnx_path, Gelu.get_fused_op(formula))
+        use_gpu = float16 and not fp32_gelu_op
+        optimize_onnx(onnx_model_path, optimized_onnx_path, Gelu.get_fused_op(formula), use_gpu=use_gpu, opt_level=2 if use_gpu else None)
         onnx_path = optimized_onnx_path
     else:
         onnx_path = onnx_model_path
 
     num_failure = run_parity(model, onnx_path, batch_size, hidden_size, sequence_length, float16, device, optimized,
-                             test_cases)
+                             test_cases, verbose=False)
 
     # clean up onnx file
     os.remove(onnx_model_path)
@@ -114,11 +116,11 @@ class TestGeluParity(unittest.TestCase):
         self.formula_to_test = [0, 1, 2, 3, 4, 5]
         self.formula_must_pass = [0, 1, 3, 4, 5]  # formula 2 cannot pass precision test.
 
-    def run_test(self, batch_size, float16, optimized, hidden_size, device, formula, enable_assert=True):
+    def run_test(self, batch_size, float16, optimized, hidden_size, device, formula, enable_assert=True, fp32_gelu_op=True):
         if float16 and device.type == 'cpu':  # CPU does not support FP16
             return
         num_failure, test_name = run(batch_size, float16, optimized, hidden_size, device, self.test_cases, formula,
-                                     self.sequence_length)
+                                     self.sequence_length, fp32_gelu_op)
         if enable_assert:
             self.assertTrue(num_failure == 0, "Failed: " + test_name)
 
@@ -138,7 +140,18 @@ class TestGeluParity(unittest.TestCase):
                           hidden_size=hidden_size,
                           device=device,
                           formula=formula,
-                          enable_assert=formula in self.formula_must_pass)
+                          enable_assert=formula in self.formula_must_pass,
+                          fp32_gelu_op=True)
+
+            self.run_test(batch_size,
+                          float16=True,
+                          optimized=optimized,
+                          hidden_size=hidden_size,
+                          device=device,
+                          formula=formula,
+                          enable_assert=formula in self.formula_must_pass,
+                          fp32_gelu_op=False)
+
 
     def test_cpu(self):
         cpu = torch.device('cpu')


### PR DESCRIPTION
**Description**:

* Allow FastGelu half2 kernel to build without `--cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=xx`
* Add environment variable `ORT_TRANSFORMER_OPTIONS=4` to disable half2 FastGelu kernel for testing purpose
* Test parity of FastGelu operator with fp16 inputs.

Average latency (ms) of bert-base-cased in T4 GPU for different batch size (b) and sequence length (s):

FastGelu kernel | b1_s4 | b1_s8 | b1_s16 | b1_s32 | b1_s64 | b1_s128 | b1_s256
-- | -- | -- | -- | -- | -- | -- | --
half|	1.49|	1.52|	1.58|	1.68|	1.95|	2.53|	3.90
half2|1.49|	1.52|	1.58|	1.69|	1.93|	2.50|	3.82

Result on GPT-2 model on T4 GPU, latency is measured with batch_size=8,sequence_length=1,past_sequence_length=32. Difference/Top1_Match is compared to PyTorch model:

FastGelu kernel | average_latency (ms) | top1_match_rate
-- | -- | -- 
float | 11.22 |  1
half2 | 7.54 | 0.974
half | 7.45 | 0.978

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
