### PR TITLE
Fix <iconurl> error in nuget package

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -67,10 +67,6 @@ def generate_tags(list, tags):
     list.append('<tags>' + tags + '</tags>')
 
 
-def generate_icon_url(list, icon_url):
-    list.append('<icon>' + icon_url + '</icon>')
-
-
 def generate_license(list):
     list.append('<license type="file">LICENSE.txt</license>')
 

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -68,7 +68,7 @@ def generate_tags(list, tags):
 
 
 def generate_icon_url(list, icon_url):
-    list.append('<iconUrl>' + icon_url + '</iconUrl>')
+    list.append('<icon>' + icon_url + '</icon>')
 
 
 def generate_license(list):

--- a/tools/nuget/template.nuspec
+++ b/tools/nuget/template.nuspec
@@ -21,7 +21,7 @@
         <projectUrl>https://github.com/onnx/onnxruntime</projectUrl>
 
         <!-- The icon is used in Visual Studio's package manager UI -->
-        <iconUrl>http://github.com/contoso/UsefulStuff/nuget_icon.png</iconUrl>
+        <icon>http://github.com/contoso/UsefulStuff/nuget_icon.png</icon>
 
         <!--
             If true, this value prompts the user to accept the license when

--- a/tools/nuget/template.nuspec
+++ b/tools/nuget/template.nuspec
@@ -18,11 +18,9 @@
 
          <!-- License and project URLs provide links for the gallery -->
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
-        <projectUrl>https://github.com/onnx/onnxruntime</projectUrl>
+        <projectUrl>https://github.com/microsoft/onnxruntime</projectUrl>
 
-        <!-- The icon is used in Visual Studio's package manager UI -->
-        <icon>http://github.com/contoso/UsefulStuff/nuget_icon.png</icon>
-
+ 
         <!--
             If true, this value prompts the user to accept the license when
             installing the package.


### PR DESCRIPTION
https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5048

'iconurl' is deprecated and the replacement is 'icon'