### PR TITLE
Support of sparse initializers with smaller indices data type

### DIFF
--- a/onnxruntime/test/framework/sparse_kernels_test.cc
+++ b/onnxruntime/test/framework/sparse_kernels_test.cc
@@ -651,8 +651,51 @@ static void CreateTensorWithExternalData(
   tensor_proto.set_data_type(type);
 }
 
+namespace {
+
+void insert_indices_data(bool indices_1D,
+                         size_t values_size, size_t shape_size,
+                         std::vector<int8_t>& indices_data,
+                         TensorProto& indices_tp) {
+  if (indices_1D) {
+    indices_data = {2, 5, 6, 10};
+    indices_tp.add_dims(indices_data.size());
+  } else {
+    // indices are shape {NNZ, rank} so convert flattened values of 2, 5, 6 and 10 to rank 3 values
+    indices_tp.add_dims(values_size);
+    indices_tp.add_dims(shape_size);
+    indices_data = {
+        0, 1, 0,
+        0, 2, 1,
+        1, 0, 0,
+        1, 2, 0};
+  }
+}
+
 template <typename T>
-static NodeProto CreateConstantNode(bool indices_1D,
+struct InsertIndices {
+  void operator()(bool indices_1D, size_t values_size, size_t shape_size, TensorProto& indices_tp) const {
+    static_assert(std::is_integral_v<T>, "indices data must be integral data type");
+    static_assert(std::is_signed_v<T>, "indices must be signed data type");
+    std::vector<int8_t> indices_data;
+    insert_indices_data(indices_1D, values_size, shape_size, indices_data, indices_tp);
+    indices_tp.set_data_type(utils::ToTensorProtoElementType<T>());
+    ORT_IF_CONSTEXPR (sizeof(T) == sizeof(int8_t)) {
+      indices_tp.mutable_raw_data()->assign(reinterpret_cast<const char*>(indices_data.data()), indices_data.size());
+    } else {
+      // Conversion on the fly to the target data type
+      std::vector<T> indices(indices_data.cbegin(), indices_data.cend());
+      indices_tp.mutable_raw_data()->assign(reinterpret_cast<const char*>(indices.data()), indices.size() * sizeof(T));
+    }
+  }
+};
+
+using SupportedIndicesTypeList = onnxruntime::TypeList<int8_t, int16_t, int32_t, int64_t>;
+
+}  // namespace
+
+template <typename T>
+static NodeProto CreateConstantNode(bool indices_1D, int32_t indices_type,
                                     std::function<void(const std::vector<T>& values, TensorProto& tp)> inserter,
                                     std::vector<T>& expected_data) {
   NodeProto constant_node;
@@ -660,7 +703,6 @@ static NodeProto CreateConstantNode(bool indices_1D,
   constant_node.add_output("dense_tensor_output");
 
   std::vector<T> values = CreateValues<T>();
-  std::vector<int64_t> indices;
   std::vector<int64_t> shape{2, 3, 2};
 
   AttributeProto& attrib = *constant_node.mutable_attribute()->Add();
@@ -668,26 +710,11 @@ static NodeProto CreateConstantNode(bool indices_1D,
   attrib.set_type(AttributeProto_AttributeType_SPARSE_TENSOR);
 
   SparseTensorProto& stp = *attrib.mutable_sparse_tensor();
-  TensorProto& indices_tp = *stp.mutable_indices();
-
   stp.mutable_dims()->Add(shape.cbegin(), shape.cend());
 
-  if (indices_1D) {
-    indices = {2, 5, 6, 10};
-    indices_tp.add_dims(indices.size());
-  } else {
-    // indices are shape {NNZ, rank} so convert flattened values of 2, 5, 6 and 10 to rank 3 values
-    indices_tp.add_dims(values.size());
-    indices_tp.add_dims(shape.size());
-    indices = {
-        0, 1, 0,
-        0, 2, 1,
-        1, 0, 0,
-        1, 2, 0};
-  }
-
-  indices_tp.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
-  indices_tp.mutable_int64_data()->Add(indices.cbegin(), indices.cend());
+  TensorProto& indices_tp = *stp.mutable_indices();
+  utils::MLTypeCallDispatcherFromTypeList<SupportedIndicesTypeList> type_disp(indices_type);
+  type_disp.Invoke<InsertIndices>(indices_1D, values.size(), shape.size(), indices_tp);
 
   expected_data.resize(2 * 3 * 2);
   expected_data[2] = values[0];
@@ -715,10 +742,9 @@ static NodeProto CreateConstantNodeAllZeros(bool indices_1D, std::vector<T>& exp
   attrib.set_type(AttributeProto_AttributeType_SPARSE_TENSOR);
 
   SparseTensorProto& stp = *attrib.mutable_sparse_tensor();
-  TensorProto& indices_tp = *stp.mutable_indices();
-
   stp.mutable_dims()->Add(shape.cbegin(), shape.cend());
 
+  TensorProto& indices_tp = *stp.mutable_indices();
   if (indices_1D) {
     indices_tp.add_dims(0);
   } else {
@@ -741,11 +767,11 @@ static NodeProto CreateConstantNodeAllZeros(bool indices_1D, std::vector<T>& exp
 }
 
 template <typename T>
-static void TestConversion(bool use_1D_indices,
+static void TestConversion(bool use_1D_indices, int32_t indices_type,
                            std::function<void(const std::vector<T>& values, TensorProto& tp)> inserter,
                            std::function<void(gsl::span<const T> expected, const TensorProto& actual)> checker) {
   std::vector<T> expected;
-  auto node = CreateConstantNode<T>(use_1D_indices, inserter, expected);
+  auto node = CreateConstantNode<T>(use_1D_indices, indices_type, inserter, expected);
 
   TensorProto dense;
   // Path is required for loading external data (if any)
@@ -775,8 +801,17 @@ template <typename T>
 static void TestConversion(
     std::function<void(const std::vector<T>& values, TensorProto& tp)> inserter,
     std::function<void(gsl::span<const T> expected, const TensorProto& actual)> checker) {
-  TestConversion(true, inserter, checker);
-  TestConversion(false, inserter, checker);
+  std::vector<TensorProto_DataType> indices_types{
+      TensorProto_DataType_INT8,
+      TensorProto_DataType_INT16,
+      TensorProto_DataType_INT32,
+      TensorProto_DataType_INT64
+  };
+
+  for (auto dt : indices_types) {
+    TestConversion(true, dt, inserter, checker);
+    TestConversion(false, dt, inserter, checker);
+  }
   TestConversionAllZeros(true, checker);
   TestConversionAllZeros(false, checker);
 }
@@ -802,7 +837,7 @@ static void RawDataChecker(gsl::span<const T> expected, const TensorProto& actua
   const T* raw_data = reinterpret_cast<const T*>(actual.raw_data().data());
   auto actual_span = gsl::make_span<const T>(raw_data, actual_size);
 
-  EXPECT_THAT(actual_span, testing::ContainerEq(expected));
+  ASSERT_THAT(actual_span, testing::ContainerEq(expected));
 }
 
 template <>
@@ -813,7 +848,7 @@ void RawDataChecker<MLFloat16>(gsl::span<const MLFloat16> expected_bfloat, const
   const uint16_t* raw_data = reinterpret_cast<const uint16_t*>(actual.raw_data().data());
   auto actual_span = gsl::make_span<const uint16_t>(raw_data, actual_size);
 
-  EXPECT_THAT(actual_span, testing::ContainerEq(expected));
+  ASSERT_THAT(actual_span, testing::ContainerEq(expected));
 }
 
 template <>
@@ -824,7 +859,7 @@ void RawDataChecker<BFloat16>(gsl::span<const BFloat16> expected_bfloat, const T
   const uint16_t* raw_data = reinterpret_cast<const uint16_t*>(actual.raw_data().data());
   auto actual_span = gsl::make_span<const uint16_t>(raw_data, actual_size);
 
-  EXPECT_THAT(actual_span, testing::ContainerEq(expected));
+  ASSERT_THAT(actual_span, testing::ContainerEq(expected));
 }
 
 TEST(SparseTensorConversionTests, TestConstantNodeConversion) {
@@ -920,6 +955,7 @@ TEST(SparseTensorConversionTests, TestConstantNodeConversion) {
   PathString tensor_filename(ORT_TSTR("tensor_XXXXXX"));
   TestConversion<float>(
       true,
+      TensorProto_DataType_INT64,
       [&tensor_filename](const std::vector<float>& values, TensorProto& tp) {
         CreateTensorWithExternalData<float>(TensorProto_DataType_FLOAT, values, tensor_filename, tp);
       },
@@ -931,8 +967,11 @@ TEST(SparseTensorConversionTests, TestConstantNodeConversion) {
 #if !defined(ORT_MINIMAL_BUILD)
 
 template <typename T>
-static std::vector<T> CreateSparseValues() {
-  return {0, 2, 3, 0};
+static std::vector<T> CreateSparseValues(size_t indices_start) {
+  std::vector<T> result(indices_start + 2);
+  result[indices_start] = 2;
+  result[indices_start + 1] = 3;
+  return result;
 }
 
 /* std::string support in the future
@@ -943,13 +982,19 @@ std::vector<std::string> CreateSparseValues<std::string>() {
 */
 
 template <>
-std::vector<BFloat16> CreateSparseValues<BFloat16>() {
-  return {BFloat16(0.f), BFloat16(2.f), BFloat16(3.f), BFloat16(0.f)};
+std::vector<BFloat16> CreateSparseValues<BFloat16>(size_t indices_start) {
+  std::vector<BFloat16> result(indices_start + 2);
+  result[indices_start] = BFloat16(2.f);
+  result[indices_start + 1] = BFloat16(3.f);
+  return result;
 }
 
 template <>
-std::vector<MLFloat16> CreateSparseValues<MLFloat16>() {
-  return {MLFloat16(0.f), MLFloat16(2.f), MLFloat16(3.f), MLFloat16(0.f)};
+std::vector<MLFloat16> CreateSparseValues<MLFloat16>(size_t indices_start) {
+  std::vector<MLFloat16> result(indices_start + 2);
+  result[indices_start] = MLFloat16(2.f);
+  result[indices_start + 1] = MLFloat16(3.f);
+  return result;
 }
 
 template <typename T>
@@ -968,11 +1013,13 @@ std::vector<MLFloat16> CreateSparseValuesAllZeros<MLFloat16>() {
 }
 
 template <typename T>
-TensorProto CreateDenseTensor(std::function<void(const std::vector<T>& values, TensorProto& tp)> inserter,
+TensorProto CreateDenseTensor(size_t indices_start,
+                              std::function<void(const std::vector<T>& values, TensorProto& tp)> inserter,
                               std::vector<T>& expected_values, std::vector<int64_t>& expected_indicies) {
   TensorProto result;
-  std::vector<T> values = CreateSparseValues<T>();
-  expected_indicies = {1, 2};
+  std::vector<T> values = CreateSparseValues<T>(indices_start);
+  auto ind_start = static_cast<int64_t>(indices_start); 
+  expected_indicies = {ind_start, ind_start + 1};
   for (const auto& ind : expected_indicies) {
     expected_values.push_back(values[ind]);
   }
@@ -1007,12 +1054,9 @@ static void RawSparseDataChecker(gsl::span<const T> expected_values,
   const T* raw_data = reinterpret_cast<const T*>(actual.values().raw_data().data());
   auto actual_span = gsl::make_span<const T>(raw_data, actual_size);
 
-  EXPECT_THAT(actual_span, testing::ContainerEq(expected_values));
+  ASSERT_THAT(actual_span, testing::ContainerEq(expected_values));
 
-  // Check indicies
-  EXPECT_THAT(actual.indices().data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-  auto actual_indicies = gsl::make_span<const int64_t>(actual.indices().int64_data().data(), actual.indices().int64_data_size());
-  EXPECT_THAT(actual_indicies, testing::ContainerEq(expected_indicies));
+  SparseIndicesChecker(actual.indices(), expected_indicies);
 }
 
 template <>
@@ -1026,11 +1070,8 @@ void RawSparseDataChecker<BFloat16>(gsl::span<const BFloat16> expected_bfloat,
   const uint16_t* raw_data = reinterpret_cast<const uint16_t*>(actual.values().raw_data().data());
   auto actual_span = gsl::make_span<const uint16_t>(raw_data, actual_size);
 
-  EXPECT_THAT(actual_span, testing::ContainerEq(expected));
-  // Check indicies
-  EXPECT_THAT(actual.indices().data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-  auto actual_indicies = gsl::make_span<const int64_t>(actual.indices().int64_data().data(), actual.indices().int64_data_size());
-  EXPECT_THAT(actual_indicies, testing::ContainerEq(expected_indicies));
+  ASSERT_THAT(actual_span, testing::ContainerEq(expected));
+  SparseIndicesChecker(actual.indices(), expected_indicies);
 }
 
 template <>
@@ -1044,15 +1085,12 @@ void RawSparseDataChecker<MLFloat16>(gsl::span<const MLFloat16> expected_bfloat,
   const uint16_t* raw_data = reinterpret_cast<const uint16_t*>(actual.values().raw_data().data());
   auto actual_span = gsl::make_span<const uint16_t>(raw_data, actual_size);
 
-  EXPECT_THAT(actual_span, testing::ContainerEq(expected));
-  // Check indicies
-  EXPECT_THAT(actual.indices().data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-  auto actual_indicies = gsl::make_span<const int64_t>(actual.indices().int64_data().data(), actual.indices().int64_data_size());
-  EXPECT_THAT(actual_indicies, testing::ContainerEq(expected_indicies));
+  ASSERT_THAT(actual_span, testing::ContainerEq(expected));
+  SparseIndicesChecker(actual.indices(), expected_indicies);
 }
 
 template <typename T>
-static void TestDenseToSparseConversionValues(
+static void TestDenseToSparseConversionValues(size_t indices_start,
     std::function<void(const std::vector<T>& values, TensorProto& tp)> inserter,
     std::function<void(gsl::span<const T> expected,
                        gsl::span<const int64_t> expected_indicies,
@@ -1063,7 +1101,7 @@ static void TestDenseToSparseConversionValues(
   // Path is required for loading external data
   // Using empty path here since the data is not external
   Path model_path;
-  TensorProto dense_tensor = CreateDenseTensor(inserter, expected_values, expected_indicies);
+  TensorProto dense_tensor = CreateDenseTensor(indices_start, inserter, expected_values, expected_indicies);
 
   SparseTensorProto sparse_tensor;
   utils::DenseTensorToSparseTensorProto(dense_tensor, model_path, sparse_tensor);
@@ -1098,17 +1136,21 @@ static void TestDenseAllZerosToSparseConversion(
 }
 
 template <typename T>
-static void TestDenseToSparseConversion(std::function<void(const std::vector<T>& values, TensorProto& tp)> inserter,
+static void TestDenseToSparseConversion(size_t indices_start,
+                                        std::function<void(const std::vector<T>& values, TensorProto& tp)> inserter,
                                         std::function<void(gsl::span<const T> expected,
                                                            gsl::span<const int64_t> expected_indicies,
                                                            const SparseTensorProto& actual)>
                                             checker) {
-  TestDenseToSparseConversionValues<T>(inserter, checker);
+  TestDenseToSparseConversionValues<T>(indices_start, inserter, checker);
   TestDenseAllZerosToSparseConversion<T>(inserter, checker);
 }
 
 TEST(SparseTensorConversionTests, TestDenseToSparseConversion) {
+  // This one will test indices that are less than max int8 value
+  // which should result in int8 indices
   TestDenseToSparseConversion<float>(
+      20U,
       [](const std::vector<float>& values, TensorProto& tp) {
         tp.set_data_type(TensorProto_DataType_FLOAT);
         tp.set_name("dense_float");
@@ -1116,7 +1158,10 @@ TEST(SparseTensorConversionTests, TestDenseToSparseConversion) {
       },
       RawSparseDataChecker<float>);
 
+  // This one will test indices that are max(int8) < ind < max(int16) value
+  // which should result in int16 indices
   TestDenseToSparseConversion<double>(
+      static_cast<size_t>(std::numeric_limits<int8_t>::max()) + 20U,
       [](const std::vector<double>& values, TensorProto& tp) {
         tp.set_data_type(TensorProto_DataType_DOUBLE);
         tp.set_name("dense_double");
@@ -1124,7 +1169,10 @@ TEST(SparseTensorConversionTests, TestDenseToSparseConversion) {
       },
       RawSparseDataChecker<double>);
 
+  // This one will test indices that are max(int16) < ind < max(int32) value
+  // which should result in int32 indices
   TestDenseToSparseConversion<BFloat16>(
+      static_cast<size_t>(std::numeric_limits<int16_t>::max()) + 20U,
       [](const std::vector<BFloat16>& values, TensorProto& tp) {
         tp.set_data_type(TensorProto_DataType_BFLOAT16);
         tp.set_name("dense_bfloat16");
@@ -1134,7 +1182,11 @@ TEST(SparseTensorConversionTests, TestDenseToSparseConversion) {
       },
       RawSparseDataChecker<BFloat16>);
 
+  // Protobuf can not hold anything more than 2Gb and it overflows. Can't test 64-bit indices
+  // on conversion unless explicitly created.
+  // which should result in int32 indices
   TestDenseToSparseConversion<MLFloat16>(
+      20U,
       [](const std::vector<MLFloat16>& values, TensorProto& tp) {
         tp.set_data_type(TensorProto_DataType_FLOAT16);
         tp.set_name("dense_float16");
@@ -1145,6 +1197,7 @@ TEST(SparseTensorConversionTests, TestDenseToSparseConversion) {
       RawSparseDataChecker<MLFloat16>);
 
   TestDenseToSparseConversion<int16_t>(
+      20U,
       [](const std::vector<int16_t>& values, TensorProto& tp) {
         tp.set_name("dense_int16");
         tp.set_data_type(TensorProto_DataType_INT16);
@@ -1153,6 +1206,7 @@ TEST(SparseTensorConversionTests, TestDenseToSparseConversion) {
       RawSparseDataChecker<int16_t>);
 
   TestDenseToSparseConversion<uint16_t>(
+      20U,
       [](const std::vector<uint16_t>& values, TensorProto& tp) {
         tp.set_name("dense_uint16");
         tp.set_data_type(TensorProto_DataType_UINT16);
@@ -1161,6 +1215,7 @@ TEST(SparseTensorConversionTests, TestDenseToSparseConversion) {
       RawSparseDataChecker<uint16_t>);
 
   TestDenseToSparseConversion<int32_t>(
+      20U,
       [](const std::vector<int32_t>& values, TensorProto& tp) {
         tp.set_name("dense_int32");
         tp.set_data_type(TensorProto_DataType_INT32);
@@ -1169,6 +1224,7 @@ TEST(SparseTensorConversionTests, TestDenseToSparseConversion) {
       RawSparseDataChecker<int32_t>);
 
   TestDenseToSparseConversion<uint32_t>(
+      20U,
       [](const std::vector<uint32_t>& values, TensorProto& tp) {
         tp.set_name("dense_uint32");
         tp.set_data_type(TensorProto_DataType_UINT32);
@@ -1177,6 +1233,7 @@ TEST(SparseTensorConversionTests, TestDenseToSparseConversion) {
       RawSparseDataChecker<uint32_t>);
 
   TestDenseToSparseConversion<int64_t>(
+      20U,
       [](const std::vector<int64_t>& values, TensorProto& tp) {
         tp.set_name("dense_int64");
         tp.set_data_type(TensorProto_DataType_INT64);
@@ -1185,6 +1242,7 @@ TEST(SparseTensorConversionTests, TestDenseToSparseConversion) {
       RawSparseDataChecker<int64_t>);
 
   TestDenseToSparseConversion<uint64_t>(
+      20U,
       [](const std::vector<uint64_t>& values, TensorProto& tp) {
         tp.set_name("dense_uint64");
         tp.set_data_type(TensorProto_DataType_UINT64);
@@ -1193,6 +1251,7 @@ TEST(SparseTensorConversionTests, TestDenseToSparseConversion) {
       RawSparseDataChecker<uint64_t>);
 
   TestDenseToSparseConversion<int8_t>(
+      20U,
       [](const std::vector<int8_t>& values, TensorProto& tp) {
         tp.set_name("dense_int8");
         tp.set_data_type(TensorProto_DataType_INT8);
@@ -1201,6 +1260,7 @@ TEST(SparseTensorConversionTests, TestDenseToSparseConversion) {
       RawSparseDataChecker<int8_t>);
 
   TestDenseToSparseConversion<uint8_t>(
+      20U,
       [](const std::vector<uint8_t>& values, TensorProto& tp) {
         tp.set_name("dense_int64");
         RawDataWriter(values, tp, TensorProto_DataType_UINT8);
@@ -1570,7 +1630,6 @@ TEST(SparseTensorConversionTests, CooConversion) {
     ASSERT_TRUE(std::equal(expected_linear_indices.cbegin(), expected_linear_indices.cend(), indices.cbegin(), indices.cend()));
   }
 
-
   {
     // test where both src and destination are on CPU. 2-D index
     SparseTensor dst;
@@ -1718,7 +1777,6 @@ TEST(SparseTensorConversionTests, BlockSparse) {
   const std::string expected_strings[] = {
       "1", "2", "3", "4", "5", "6", "7", "8"};
 
-
   const TensorShape indices_shape{2, 2};  // two blocks by two coordinates
   // (0, 0), (0,1)
   std::vector<int32_t> blocksparse_indices = {
@@ -1783,7 +1841,6 @@ TEST(SparseTensorConversionTests, BlockSparse) {
     auto indices_span = indices.DataAsSpan<int32_t>();
     ASSERT_TRUE(std::equal(blocksparse_indices.cbegin(), blocksparse_indices.cend(),
                            indices_span.cbegin(), indices_span.cend()));
-
   }
 }
 }  // namespace test

--- a/onnxruntime/test/framework/test_utils.h
+++ b/onnxruntime/test/framework/test_utils.h
@@ -97,5 +97,7 @@ void AllocateMLValue(AllocatorPtr alloc, const std::vector<int64_t>& dims, OrtVa
 // Helper function to check that the graph transformations have been successfully applied.
 std::map<std::string, int> CountOpsInGraph(const Graph& graph, bool recurse_into_subgraphs = true);
 
+void SparseIndicesChecker(const ONNX_NAMESPACE::TensorProto& indices_proto, gsl::span<const int64_t> expected_indicies);
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -10,6 +10,7 @@
 #include "gmock/gmock.h"
 #include "onnx/defs/function.h"
 #include "core/graph/function_impl.h"
+#include "test/framework/test_utils.h"
 
 #ifdef __GNUC__
 #define UNUSED __attribute__((unused))
@@ -233,6 +234,7 @@ static void ConstructSparseTensor(const std::string& name,
   std::copy(values.cbegin(), values.cend(), dest_span.begin());
 
   const std::vector<int64_t>& indices = sparse_details::indices;  // Not to exceed 59
+
   auto& m_indicies = *sparse_proto.mutable_indices();
   m_indicies.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
   *m_indicies.mutable_dims()->Add() = static_cast<int64_t>(indices.size());
@@ -264,10 +266,9 @@ static void ValidateSparseTensorProto(const SparseTensorProto& proto) {
     ++expected_begin;
   }
   // Check indices
-  EXPECT_EQ(proto.indices().data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
+  const auto& indices = proto.indices();
   auto expected_indices = gsl::make_span(sparse_details::indices);
-  auto actual_indices = gsl::make_span<const int64_t>(proto.indices().int64_data().data(), proto.indices().int64_data_size());
-  EXPECT_THAT(actual_indices, testing::ContainerEq(expected_indices));
+  SparseIndicesChecker(indices, expected_indices);
   // check shape
   const auto& dims = proto.dims();
   auto actual_shape = gsl::make_span<const int64_t>(dims.data(), dims.size());

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -4,6 +4,7 @@
 #include "test/util/include/test_utils.h"
 
 #include "core/framework/ort_value.h"
+#include "core/graph/onnx_protobuf.h"
 #include "core/session/inference_session.h"
 
 #include "test/util/include/asserts.h"
@@ -113,6 +114,60 @@ void RunAndVerifyOutputsWithEP(const ORTCHAR_T* model_path, const char* log_id,
   std::vector<OrtValue> fetches;
   ASSERT_STATUS_OK(session_object2.Run(run_options, feeds, output_names, &fetches));
   VerifyOutputs(output_names, expected_fetches, fetches);
+}
+
+void SparseIndicesChecker(const ONNX_NAMESPACE::TensorProto& indices_proto, gsl::span<const int64_t> expected_indicies) {
+  using namespace ONNX_NAMESPACE;
+  gsl::span<const int64_t> ind_span;
+  std::vector<int64_t> converted_indices;
+  TensorShape ind_shape(indices_proto.dims().data(), indices_proto.dims().size());
+  const auto elements = gsl::narrow<size_t>(ind_shape.Size());
+  const bool has_raw_data = indices_proto.has_raw_data();
+  switch (indices_proto.data_type()) {
+    case ONNX_NAMESPACE::TensorProto_DataType_INT64: {
+      if (has_raw_data) {
+        const auto& rd = indices_proto.raw_data();
+        ASSERT_EQ(rd.size(), elements * sizeof(int64_t));
+        ind_span = gsl::make_span(reinterpret_cast<const int64_t*>(rd.data()), elements);
+      } else {
+        ind_span = gsl::make_span(indices_proto.int64_data().cbegin(), indices_proto.int64_data().cend());
+      }
+      break;
+    }
+    case ONNX_NAMESPACE::TensorProto_DataType_INT32: {
+      if (has_raw_data) {
+        const auto& rd = indices_proto.raw_data();
+        ASSERT_EQ(rd.size(), elements * sizeof(int32_t));
+        auto int32_span = gsl::make_span(reinterpret_cast<const int32_t*>(rd.data()), elements);
+        converted_indices.insert(converted_indices.cend(), int32_span.cbegin(), int32_span.cend());
+      } else {
+        converted_indices.insert(converted_indices.cend(), indices_proto.int32_data().cbegin(), indices_proto.int32_data().cend());
+      }
+      ind_span = gsl::make_span(converted_indices);
+      break;
+    }
+    case ONNX_NAMESPACE::TensorProto_DataType_INT16: {
+      ASSERT_TRUE(has_raw_data);
+      const auto& rd = indices_proto.raw_data();
+      ASSERT_EQ(rd.size(), elements * sizeof(int16_t));
+      auto int16_span = gsl::make_span(reinterpret_cast<const int16_t*>(rd.data()), elements);
+      converted_indices.insert(converted_indices.cend(), int16_span.cbegin(), int16_span.cend());
+      ind_span = gsl::make_span(converted_indices);
+      break;
+    }
+    case ONNX_NAMESPACE::TensorProto_DataType_INT8: {
+      ASSERT_TRUE(has_raw_data);
+      const auto& rd = indices_proto.raw_data();
+      ASSERT_EQ(rd.size(), elements);
+      auto int8_span = gsl::make_span(reinterpret_cast<const int8_t*>(rd.data()), elements);
+      converted_indices.insert(converted_indices.cend(), int8_span.cbegin(), int8_span.cend());
+      ind_span = gsl::make_span(converted_indices);
+      break;
+    }
+    default:
+      ASSERT_TRUE(false);
+  }
+  ASSERT_THAT(ind_span, testing::ContainerEq(expected_indicies));
 }
 
 }  // namespace test

--- a/tools/python/sparsify_initializers.py
+++ b/tools/python/sparsify_initializers.py
@@ -26,7 +26,7 @@ def parse_arguments():
     parser.add_argument('--exclude', required=False, type=str,
                         help='semicolon separated list of initializer names to exclude')
     parser.add_argument('--tolerance', required=False, type=float, default=1e-6,
-                        help='FP absolute tolerance. If not given simple compare to 0')
+                        help='FP absolute tolerance.')
     parser.add_argument('--sparsity_threshold', required=False,
                         type=float, default=0.5,
                         help='convert to sparse initializers if sparsity is at least this much')
@@ -49,11 +49,13 @@ def setup_logging(verbose):  # type: (bool)  -> None
     logger.setLevel(logging_level)
 
 
-def convert_tensor_to_sparse(tensor, tolerance):  # type: (TensorProto) -> Tuple[SparseTensorProto, float]
+def convert_tensor_to_sparse(tensor,
+                             sparsity_threshold,
+                             tolerance):  # type: (TensorProto, float, float) -> Tuple[SparseTensorProto, float]
     """ returns a tuple of sparse_tensor and sparsity level
     """
     values = []
-    indicies = []
+    indices = []
     nnz_count = 0
     tensor_data = numpy_helper.to_array(tensor).flatten()
     data_len = len(tensor_data)
@@ -62,25 +64,76 @@ def convert_tensor_to_sparse(tensor, tolerance):  # type: (TensorProto) -> Tuple
             el = tensor_data[index]
             if abs(el) <= tolerance:
                 values.append(el)
-                indicies.append(index)
+                indices.append(index)
                 nnz_count += 1
     else:
         for index in range(data_len):
             el = tensor_data[index]
             if el != 0:
                 values.append(el)
-                indicies.append(index)
+                indices.append(index)
                 nnz_count += 1
 
     sparsity = float(1.) - float(nnz_count)/data_len
-    logger.debug(f"initializer={tensor.name}, dtype={tensor_data.dtype}, \
-                 len={data_len}, nnz={nnz_count}, sparsity={sparsity}")
 
-    values_tensor = onnx.helper.make_tensor(tensor.name, tensor.data_type,
-                                            [len(values)], np.array(values).astype(tensor_data.dtype))
+    ind_data_type = TensorProto.INT8
+    ind_dtype = np.int8
+    ind_len = len(indices)
+    max_indices_value = 0
+    if ind_len > 0:
+        max_indices_value = indices[-1]
+        if max_indices_value <= np.iinfo(np.int8).max:
+            ind_data_type = TensorProto.INT8
+            ind_dtype = np.int8
+        elif max_indices_value <= np.iinfo(np.int16).max:
+            ind_data_type = TensorProto.INT16
+            ind_dtype = np.int16
+        elif max_indices_value <= np.iinfo(np.int32).max:
+            ind_data_type = TensorProto.INT32
+            ind_dtype = np.int32
+        else:
+            ind_data_type = TensorProto.INT64
+            ind_dtype = np.int64
+
+    logger.debug(f"initializer={tensor.name}, dtype={tensor_data.dtype}, \
+                 data_len={data_len}, nnz={nnz_count}, sparsity={sparsity}, \
+                 max_indices_value={max_indices_value}, sparse_indices_type={ind_dtype}")
+
+    if sparsity < sparsity_threshold:
+        return (object(), sparsity)
+
+    tensor_data_bytes = tensor_data.nbytes
+    # create np array and cast data to the appropriate type    
+    np_values = np.array(values).astype(tensor_data.dtype)
+    # create np array and cast data to the inferred index type
+    np_indices = np.array(indices).astype(ind_dtype)
+    total_sparse_bytes = np_values.nbytes + np_indices.nbytes
+
+    logger.debug(f"initializer={tensor.name}, initializer_bytes={tensor_data_bytes}, \
+                sparse_initializer_bytes={total_sparse_bytes}")
+
+    # This check is usually useful for sparsity_threshold=0.5 where much
+    # depends on the size of the indices entries and the size of the original tensor.
+    # Big dense tensors command larger indices data type and for large float32 tensors
+    # int32 indices are often selected, thus we really want to guard against loosing
+    # rather than winning.
+    if tensor_data_bytes <= total_sparse_bytes:
+        sparsity = float(1.) - float(tensor_data_bytes)/total_sparse_bytes
+        logger.debug(f"initializer={tensor.name}, adjusted_sparsity={sparsity}")
+        return (object(), sparsity)
+
+    values_tensor = onnx.helper.make_tensor(tensor.name,
+                                            tensor.data_type,
+                                            [len(values)],
+                                            np_values.tobytes(),
+                                            raw=True)
+
     indicies_tensor = onnx.helper.make_tensor(tensor.name + '_indicies',
-                                              TensorProto.INT64,
-                                              [len(indicies)], np.array(indicies).astype(np.int64))
+                                              ind_data_type,
+                                              [ind_len], 
+                                              np_indices.tobytes(),
+                                              raw=True)
+
     sparse_tensor = onnx.helper.make_sparse_tensor(values_tensor, indicies_tensor, tensor.dims)
     return (sparse_tensor, sparsity)
 
@@ -88,7 +141,7 @@ def convert_tensor_to_sparse(tensor, tolerance):  # type: (TensorProto) -> Tuple
 def convert_initializers(model,
                          exclude_names,
                          sparsity_threshold,
-                         tolerance):  # type: (ModelProto, List[str], float) -> None
+                         tolerance):  # type: (ModelProto, List[str], float, float) -> None
     graph = model.graph
     converted_sparse = []
     remaining_initializers = []
@@ -100,7 +153,7 @@ def convert_initializers(model,
             logger.info(f"initializer={initializer.name} contains bool, not converted")
             remaining_initializers.append(initializer)
             continue
-        sparse_tensor, sparsity = convert_tensor_to_sparse(initializer, tolerance)
+        sparse_tensor, sparsity = convert_tensor_to_sparse(initializer, sparsity_threshold, tolerance)
         if sparsity >= sparsity_threshold:
             logger.info(f"initializer={initializer.name} converted. sparsity={sparsity}")
             converted_sparse.append(sparse_tensor)


### PR DESCRIPTION
**Description**: Describe your changes.
Support of sparse initializers with smaller indices data type to save disk space.
Make the script more efficient by selecting indices data type and checking resulting sparse bytes

**Motivation and Context**
int64_t indices size is often not required and wastes disk space. This PR will especially benefit small tensors
with quantized data.