### PR TITLE
[js/web] Integrate ONNX Runtime Web CI with BrowserStack

### DIFF
--- a/tools/ci_build/github/azure-pipelines/win-wasm-browserstack-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-wasm-browserstack-ci-pipeline.yml
@@ -1,0 +1,193 @@
+jobs:
+- job: build_onnxruntime_web_browserstack
+  pool: Onnxruntime-BrowserStack-for-Web
+  timeoutInMinutes: 30
+  workspace:
+    clean: all
+  steps:
+  - checkout: self
+    submodules: false
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: 'specific'
+      project: 'onnxruntime'
+      pipeline: 161
+      preferTriggeringPipeline: true
+      artifact: '__commit'
+      path: $(Pipeline.Workspace)
+    displayName: 'Get commit SHA'
+  - script: |
+     __commit__=$(<$(Pipeline.Workspace)/__commit.txt)
+     __commit__=${__commit__//[$'\t\r\n']}
+     git fetch origin $__commit__:refs/remotes/origin/$__commit__
+     git checkout --force $__commit__
+    workingDirectory: '$(Build.SourcesDirectory)'
+    displayName: 'Read commit SHA and checkout'
+  - script: |
+     git submodule sync -- cmake/external/onnx
+     git submodule update --init -- cmake/external/onnx
+    workingDirectory: '$(Build.SourcesDirectory)'
+    displayName: 'Checkout submodule onnx'
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '14.x'
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: 'specific'
+      project: 'onnxruntime'
+      pipeline: 161
+      preferTriggeringPipeline: true
+      patterns: 'Release_*/**/*'
+      path: $(Pipeline.Workspace)/artifacts
+    displayName: 'Download WebAssembly artifacts'
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)/artifacts
+      contents: |
+        **/*.wasm
+      targetFolder: $(Build.SourcesDirectory)/js/web/dist
+      flattenFolders: true
+    displayName: 'Binplace dist files'
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)/artifacts
+      contents: |
+        **/*.js
+      targetFolder: $(Build.SourcesDirectory)/js/web/lib/wasm/binding
+      flattenFolders: true
+    displayName: 'Binplace js files'
+  - script: |
+     npm ci
+    workingDirectory: '$(Build.SourcesDirectory)/js'
+    displayName: 'npm ci /js/'
+  - script: |
+     npm ci
+    workingDirectory: '$(Build.SourcesDirectory)/js/common'
+    displayName: 'npm ci /js/common/'
+  - script: |
+     npm ci
+    workingDirectory: '$(Build.SourcesDirectory)/js/web'
+    displayName: 'npm ci /js/web/'
+  - script: |
+     npm run build
+    workingDirectory: '$(Build.SourcesDirectory)/js/web'
+    displayName: 'Build ort-web'
+  - task: BrowserStackConfig@0
+    inputs:
+      BrowserStackServiceEndPoint: 'BrowserStack Connection'
+      browserstackLocal: true
+    displayName: 'BrowserStack configuration setup'
+    timeoutInMinutes: 20
+  - script: |
+      export ONNXJS_TEST_BS_BROWSERS=BS_MAC_11_Safari_14,BS_MAC_11_Chrome_91,BS_ANDROID_11_Pixel_5
+      npm test -- suite0 --env=bs --wasm-init-timeout=30000 --file-cache
+    workingDirectory: '$(Build.SourcesDirectory)/js/web'
+    displayName: 'npm test (Suite0, BS_ANDROID, BS_MAC)'
+    env:
+      BROWSERSTACK_ACCESS_KEY: $(BROWSERSTACK_ACCESS_KEY)
+      BROWSERSTACK_USERNAME: $(BROWSERSTACK_USERNAME)
+  - script: |
+      export ONNXJS_TEST_BS_BROWSERS=BS_IOS_14_iPhoneXS
+      npm test -- suite1 --env=bs --wasm-init-timeout=30000 --file-cache --backend=wasm
+    workingDirectory: '$(Build.SourcesDirectory)/js/web'
+    displayName: 'npm test (Suite1, BS_IOS)'
+    env:
+      BROWSERSTACK_ACCESS_KEY: $(BROWSERSTACK_ACCESS_KEY)
+      BROWSERSTACK_USERNAME: $(BROWSERSTACK_USERNAME)
+  - task: BrowserStackStopLocal@0
+  - task: BrowserStackResults@0
+    displayName: 'BrowserStack results'
+    continueOnError: true
+    timeoutInMinutes: 10
+  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+    displayName: 'Clean Agent Directories'
+    condition: always()
+
+- job: build_onnxruntime_web_windows
+  pool:
+    vmImage: windows-latest
+  timeoutInMinutes: 30
+  workspace:
+    clean: all
+  steps:
+  - checkout: self
+    submodules: false
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: 'specific'
+      project: 'onnxruntime'
+      pipeline: 161
+      preferTriggeringPipeline: true
+      artifact: '__commit'
+      path: $(Pipeline.Workspace)
+    displayName: 'Get commit SHA'
+  - script: |
+     set /p __commit__=<$(Pipeline.Workspace)\__commit.txt
+     git fetch origin +%__commit__%:refs/remotes/origin/%__commit__%
+     git checkout --force %__commit__%
+    workingDirectory: '$(Build.SourcesDirectory)'
+    displayName: 'Read commit SHA and checkout'
+  - script: |
+     git submodule sync -- cmake\external\onnx
+     git submodule update --init -- cmake\external\onnx
+    workingDirectory: '$(Build.SourcesDirectory)'
+    displayName: 'Checkout submodule onnx'
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '14.x'
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: 'specific'
+      project: 'onnxruntime'
+      pipeline: 161
+      preferTriggeringPipeline: true
+      patterns: 'Release_*/**/*'
+      path: $(Pipeline.Workspace)\artifacts
+    displayName: 'Download WebAssembly artifacts'
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)\artifacts
+      contents: |
+        **\*.wasm
+      targetFolder: $(Build.SourcesDirectory)\js\web\dist
+      flattenFolders: true
+    displayName: 'Binplace dist files'
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)\artifacts
+      contents: |
+        **\*.js
+      targetFolder: $(Build.SourcesDirectory)\js\web\lib\wasm\binding
+      flattenFolders: true
+    displayName: 'Binplace js files'
+  - script: |
+     npm ci
+    workingDirectory: '$(Build.SourcesDirectory)\js'
+    displayName: 'npm ci /js/'
+  - script: |
+     npm ci
+    workingDirectory: '$(Build.SourcesDirectory)\js\common'
+    displayName: 'npm ci /js/common/'
+  - script: |
+     npm ci
+    workingDirectory: '$(Build.SourcesDirectory)\js\web'
+    displayName: 'npm ci /js/web/'
+  - script: |
+     npm run build
+    workingDirectory: '$(Build.SourcesDirectory)\js\web'
+    displayName: 'Build ort-web'
+  - script: |
+      npm test -- suite0 --wasm-init-timeout=30000 --file-cache
+    workingDirectory: '$(Build.SourcesDirectory)\js\web'
+    displayName: 'npm test (Suite0, Chrome)'
+  - script: |
+      npm test -- suite0 --env=firefox --wasm-init-timeout=30000 --file-cache
+    workingDirectory: '$(Build.SourcesDirectory)\js\web'
+    displayName: 'npm test (Suite0, Firefox)'
+  - script: |
+      npm test -- suite0 --env=edge --wasm-init-timeout=30000 --file-cache
+    workingDirectory: '$(Build.SourcesDirectory)\js\web'
+    displayName: 'npm test (Suite0, Edge)'
+  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+    displayName: 'Clean Agent Directories'
+    condition: always()

--- a/tools/ci_build/github/azure-pipelines/win-wasm-multi-platform-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-wasm-multi-platform-ci-pipeline.yml
@@ -68,10 +68,6 @@ jobs:
      npm ci
     workingDirectory: '$(Build.SourcesDirectory)/js/web'
     displayName: 'npm ci /js/web/'
-  - script: |
-     npm run build
-    workingDirectory: '$(Build.SourcesDirectory)/js/web'
-    displayName: 'Build ort-web'
   - task: BrowserStackConfig@0
     inputs:
       BrowserStackServiceEndPoint: 'BrowserStack Connection'
@@ -172,10 +168,6 @@ jobs:
      npm ci
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'npm ci /js/web/'
-  - script: |
-     npm run build
-    workingDirectory: '$(Build.SourcesDirectory)\js\web'
-    displayName: 'Build ort-web'
   - script: |
       npm test -- suite0 --wasm-init-timeout=30000 --file-cache
     workingDirectory: '$(Build.SourcesDirectory)\js\web'


### PR DESCRIPTION
It adds ONNX Runtime Web testing on real-device, MacOS, Android and iOS using BrowserStack solution. New CI pipeline yaml is added, which will be triggered by build completion of ONNX Runtime Web CI pipeline. Currently, CI uses two separate parallel BrowserStack jobs due to iOS failure on WebGL. Once the issue is resolved, we can issue only one parallel BrowserStack jobs.
