### PR TITLE
Re-introduce saving of optimized onnx model

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -216,6 +216,10 @@ class GraphExecutionManager(GraphExecutionInterface):
 
         self._onnx_models.optimized_model = onnx.load_model_from_string(
             self._graph_builder.get_model())
+
+        self._onnx_models.optimized_no_grad_model = onnx.load_model_from_string(
+            self._graph_builder.get_inference_optimized_model())
+
         self._graph_info = self._graph_builder.get_graph_info()
 
     def _get_session_config(self):

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -217,7 +217,7 @@ class GraphExecutionManager(GraphExecutionInterface):
         self._onnx_models.optimized_model = onnx.load_model_from_string(
             self._graph_builder.get_model())
 
-        self._onnx_models.optimized_no_grad_model = onnx.load_model_from_string(
+        self._onnx_models.optimized_pre_grad_model = onnx.load_model_from_string(
             self._graph_builder.get_inference_optimized_model())
 
         self._graph_info = self._graph_builder.get_graph_info()

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -23,6 +23,7 @@ from abc import ABC, abstractmethod
 import copy
 import io
 import inspect
+import os
 import onnx
 import onnxruntime
 import torch
@@ -245,6 +246,13 @@ class GraphExecutionManager(GraphExecutionInterface):
         # 0:Verbose, 1:Info, 2:Warning. 3:Error, 4:Fatal. Default is 2.
         session_options.log_severity_level = int(
             self._debug_options.logging.log_level)
+
+        if self._debug_options.save_onnx_models.save:
+            session_options.optimized_model_filepath = \
+                os.path.join(self._debug_options.save_onnx_models.path,
+                             _onnx_models._get_onnx_file_name(
+                                 self._debug_options.save_onnx_models.name_prefix,
+                                 'execution_model', self._export_mode))
 
         return session_options, providers, provider_options
 

--- a/orttraining/orttraining/python/training/ortmodule/_onnx_models.py
+++ b/orttraining/orttraining/python/training/ortmodule/_onnx_models.py
@@ -20,7 +20,7 @@ class ONNXModels:
 
     1. exported_model: Model that is exported by torch.onnx.export
     2. optimized_model: Optimized model after gradients graph has been built.
-    3. optimized_no_grad_model: Optimized model before gradient graph is built.
+    3. optimized_pre_grad_model: Optimized model before gradient graph is built.
     4. In addition, ORTModule also saves the execution_model which is the model
        that is being executed by ORT. It has further optimizations done by the
        InferenceSession and is saved by the InferenceSession.
@@ -28,7 +28,7 @@ class ONNXModels:
 
     exported_model: onnx.ModelProto = None
     optimized_model: onnx.ModelProto = None
-    optimized_no_grad_model: onnx.ModelProto = None
+    optimized_pre_grad_model: onnx.ModelProto = None
 
     def save_exported_model(self, path, name_prefix, export_mode):
         # save the ortmodule exported model
@@ -39,5 +39,5 @@ class ONNXModels:
         # save the ortmodule optimized model
         _save_model(self.optimized_model,
                     os.path.join(path, _get_onnx_file_name(name_prefix, 'optimized', export_mode)))
-        _save_model(self.optimized_no_grad_model,
-                    os.path.join(path, _get_onnx_file_name(name_prefix, 'optimized_no_grad', export_mode)))
+        _save_model(self.optimized_pre_grad_model,
+                    os.path.join(path, _get_onnx_file_name(name_prefix, 'optimized_pre_grad', export_mode)))

--- a/orttraining/orttraining/python/training/ortmodule/_onnx_models.py
+++ b/orttraining/orttraining/python/training/ortmodule/_onnx_models.py
@@ -16,7 +16,15 @@ def _save_model(model: onnx.ModelProto, file_path: str):
 
 @dataclass
 class ONNXModels:
-    """Encapsulates all ORTModule onnx models."""
+    """Encapsulates all ORTModule onnx models.
+
+    1. exported_model: Model that is exported by torch.onnx.export
+    2. optimized_model: Optimized model after gradients graph has been built.
+    3. optimized_no_grad_model: Optimized model before gradient graph is built.
+    4. In addition, ORTModule also saves the execution_model which is the model
+       that is being executed by ORT. It has further optimizations done by the
+       InferenceSession and is saved by the InferenceSession.
+    """
 
     exported_model: onnx.ModelProto = None
     optimized_model: onnx.ModelProto = None

--- a/orttraining/orttraining/python/training/ortmodule/_onnx_models.py
+++ b/orttraining/orttraining/python/training/ortmodule/_onnx_models.py
@@ -20,13 +20,16 @@ class ONNXModels:
 
     exported_model: onnx.ModelProto = None
     optimized_model: onnx.ModelProto = None
+    optimized_no_grad_model: onnx.ModelProto = None
 
     def save_exported_model(self, path, name_prefix, export_mode):
         # save the ortmodule exported model
-        _save_model(self.exported_model, os.path.join(path,
-                                                      _get_onnx_file_name(name_prefix, 'torch_exported', export_mode)))
+        _save_model(self.exported_model,
+                    os.path.join(path, _get_onnx_file_name(name_prefix, 'torch_exported', export_mode)))
 
     def save_optimized_model(self, path, name_prefix, export_mode):
         # save the ortmodule optimized model
-        _save_model(self.optimized_model, os.path.join(path,
-                                                       _get_onnx_file_name(name_prefix, 'optimized', export_mode)))
+        _save_model(self.optimized_model,
+                    os.path.join(path, _get_onnx_file_name(name_prefix, 'optimized', export_mode)))
+        _save_model(self.optimized_no_grad_model,
+                    os.path.join(path, _get_onnx_file_name(name_prefix, 'optimized_no_grad', export_mode)))

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -3099,6 +3099,7 @@ def test_debug_options_save_onnx_models_os_environment(mode):
         # assert that the onnx models have been saved
         assert os.path.exists(os.path.join(temporary_dir, f"my_model_torch_exported_{mode}.onnx"))
         assert os.path.exists(os.path.join(temporary_dir, f"my_model_optimized_{mode}.onnx"))
+        assert os.path.exists(os.path.join(temporary_dir, f"my_model_optimized_no_grad_{mode}.onnx"))
         assert os.path.exists(os.path.join(temporary_dir, f"my_model_execution_model_{mode}.onnx"))
         del os.environ['ORTMODULE_SAVE_ONNX_PATH']
 
@@ -3117,10 +3118,12 @@ def test_debug_options_save_onnx_models_cwd(mode):
     # assert that the onnx models have been saved
     assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_torch_exported_{mode}.onnx"))
     assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_optimized_{mode}.onnx"))
+    assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_optimized_no_grad_{mode}.onnx"))
     assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_execution_model_{mode}.onnx"))
 
     os.remove(os.path.join(os.getcwd(), f"my_cwd_model_torch_exported_{mode}.onnx"))
     os.remove(os.path.join(os.getcwd(), f"my_cwd_model_optimized_{mode}.onnx"))
+    os.remove(os.path.join(os.getcwd(), f"my_cwd_model_optimized_no_grad_{mode}.onnx"))
     os.remove(os.path.join(os.getcwd(), f"my_cwd_model_execution_model_{mode}.onnx"))
 
 def test_debug_options_save_onnx_models_validate_fail_on_non_writable_dir():

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -3099,6 +3099,7 @@ def test_debug_options_save_onnx_models_os_environment(mode):
         # assert that the onnx models have been saved
         assert os.path.exists(os.path.join(temporary_dir, f"my_model_torch_exported_{mode}.onnx"))
         assert os.path.exists(os.path.join(temporary_dir, f"my_model_optimized_{mode}.onnx"))
+        assert os.path.exists(os.path.join(temporary_dir, f"my_model_execution_model_{mode}.onnx"))
         del os.environ['ORTMODULE_SAVE_ONNX_PATH']
 
 @pytest.mark.parametrize("mode", ['training', 'inference'])
@@ -3116,9 +3117,11 @@ def test_debug_options_save_onnx_models_cwd(mode):
     # assert that the onnx models have been saved
     assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_torch_exported_{mode}.onnx"))
     assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_optimized_{mode}.onnx"))
+    assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_execution_model_{mode}.onnx"))
 
     os.remove(os.path.join(os.getcwd(), f"my_cwd_model_torch_exported_{mode}.onnx"))
     os.remove(os.path.join(os.getcwd(), f"my_cwd_model_optimized_{mode}.onnx"))
+    os.remove(os.path.join(os.getcwd(), f"my_cwd_model_execution_model_{mode}.onnx"))
 
 def test_debug_options_save_onnx_models_validate_fail_on_non_writable_dir():
 

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -3099,7 +3099,7 @@ def test_debug_options_save_onnx_models_os_environment(mode):
         # assert that the onnx models have been saved
         assert os.path.exists(os.path.join(temporary_dir, f"my_model_torch_exported_{mode}.onnx"))
         assert os.path.exists(os.path.join(temporary_dir, f"my_model_optimized_{mode}.onnx"))
-        assert os.path.exists(os.path.join(temporary_dir, f"my_model_optimized_no_grad_{mode}.onnx"))
+        assert os.path.exists(os.path.join(temporary_dir, f"my_model_optimized_pre_grad_{mode}.onnx"))
         assert os.path.exists(os.path.join(temporary_dir, f"my_model_execution_model_{mode}.onnx"))
         del os.environ['ORTMODULE_SAVE_ONNX_PATH']
 
@@ -3118,12 +3118,12 @@ def test_debug_options_save_onnx_models_cwd(mode):
     # assert that the onnx models have been saved
     assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_torch_exported_{mode}.onnx"))
     assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_optimized_{mode}.onnx"))
-    assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_optimized_no_grad_{mode}.onnx"))
+    assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_optimized_pre_grad_{mode}.onnx"))
     assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_execution_model_{mode}.onnx"))
 
     os.remove(os.path.join(os.getcwd(), f"my_cwd_model_torch_exported_{mode}.onnx"))
     os.remove(os.path.join(os.getcwd(), f"my_cwd_model_optimized_{mode}.onnx"))
-    os.remove(os.path.join(os.getcwd(), f"my_cwd_model_optimized_no_grad_{mode}.onnx"))
+    os.remove(os.path.join(os.getcwd(), f"my_cwd_model_optimized_pre_grad_{mode}.onnx"))
     os.remove(os.path.join(os.getcwd(), f"my_cwd_model_execution_model_{mode}.onnx"))
 
 def test_debug_options_save_onnx_models_validate_fail_on_non_writable_dir():


### PR DESCRIPTION
`ORTModule` must save 4 onnx models per training mode (training and inference):
- exported model
- no grad optimized model
- grad optimized model
- execution model

This pull request re-introduces the second and fourth models in the above list.