### PR TITLE
[Objective-C] Enable static analysis, second try

### DIFF
--- a/objectivec/src/ort_session.mm
+++ b/objectivec/src/ort_session.mm
@@ -188,7 +188,9 @@ NS_ASSUME_NONNULL_BEGIN
 
     for (size_t i = 0; i < nameCount; ++i) {
       auto name = std::unique_ptr<char[], decltype(deleter)>{getName(i, allocator), deleter};
-      [result addObject:[NSString stringWithUTF8String:name.get()]];
+      NSString* nameNsstr = [NSString stringWithUTF8String:name.get()];
+      NSAssert(nameNsstr != nil, @"nameNsstr must not be nil");
+      [result addObject:nameNsstr];
     }
 
     return result;

--- a/objectivec/src/ort_session.mm
+++ b/objectivec/src/ort_session.mm
@@ -188,11 +188,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     for (size_t i = 0; i < nameCount; ++i) {
       auto name = std::unique_ptr<char[], decltype(deleter)>{getName(i, allocator), deleter};
-      NSString* nameNsstr = [NSString stringWithUTF8String:name.get()];
-      if (nameNsstr == nil) {
-        ORT_CXX_API_THROW("failed to create name NSString", ORT_FAIL);
-      }
-      [result addObject:nameNsstr];
+      [result addObject:[NSString stringWithUTF8String:name.get()]];
     }
 
     return result;

--- a/objectivec/src/ort_session.mm
+++ b/objectivec/src/ort_session.mm
@@ -188,7 +188,11 @@ NS_ASSUME_NONNULL_BEGIN
 
     for (size_t i = 0; i < nameCount; ++i) {
       auto name = std::unique_ptr<char[], decltype(deleter)>{getName(i, allocator), deleter};
-      [result addObject:[NSString stringWithUTF8String:name.get()]];
+      NSString* nameNsstr = [NSString stringWithUTF8String:name.get()];
+      if (nameNsstr == nil) {
+        ORT_CXX_API_THROW("failed to create name NSString", ORT_FAIL);
+      }
+      [result addObject:nameNsstr];
     }
 
     return result;

--- a/tools/ci_build/github/apple/objectivec/static_analysis/requirements.txt
+++ b/tools/ci_build/github/apple/objectivec/static_analysis/requirements.txt
@@ -1,2 +1,1 @@
-codechecker==6.16.0
 ninja==1.10.2

--- a/tools/ci_build/github/azure-pipelines/mac-objc-static-analysis-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-objc-static-analysis-ci-pipeline.yml
@@ -28,39 +28,11 @@ jobs:
     displayName: Generate compile_commands.json
 
   - script: |
-      set -e
-
-      LLVM_DIR="$(brew --prefix llvm)"
-      CODECHECKER_CONFIG_FILE="$(dirname $(which codechecker))/../share/codechecker/config/package_layout.json"
-
-      sed -i "" \
-        -e 's#"clangsa": "[^"]*"#"clangsa": "'"${LLVM_DIR}"'/bin/clang"#' \
-        -e 's#"clang-tidy": "[^"]*"#"clang-tidy": "'"${LLVM_DIR}"'/bin/clang-tidy"#' \
-        "${CODECHECKER_CONFIG_FILE}"
-
-      cat "${CODECHECKER_CONFIG_FILE}"
-    displayName: Update CodeChecker configuration
-
-  - script: |
-      codechecker analyze \
-        --file "$(Build.SourcesDirectory)/objectivec/*" \
-               "$(Build.SourcesDirectory)/onnxruntime/core/platform/apple/logging/apple_log_sink.mm" \
-               "$(Build.SourcesDirectory)/onnxruntime/core/providers/coreml/model/*.mm" \
-        --output "$(Build.BinariesDirectory)/codechecker.analyze.out" \
-        "$(Build.BinariesDirectory)/Debug/compile_commands.json"
-
-      CODECHECKER_ANALYZE_EXIT_CODE=$?
-      echo "codechecker analyze exited with code: ${CODECHECKER_ANALYZE_EXIT_CODE}"
-    displayName: Run CodeChecker analysis
-
-  - script: |
-      # skip results from external dependencies
-      echo "-$(Build.SourcesDirectory)/cmake/external/*" > "$(Build.BinariesDirectory)/codechecker.parse.skipfile"
-
-      codechecker parse \
-        --ignore "$(Build.BinariesDirectory)/codechecker.parse.skipfile" \
-        "$(Build.BinariesDirectory)/codechecker.analyze.out"
-
-      CODECHECKER_PARSE_EXIT_CODE=$?
-      echo "codechecker parse exited with code: ${CODECHECKER_PARSE_EXIT_CODE}"
-    displayName: Show CodeChecker analysis results
+      "$(brew --prefix llvm)/bin/clang-tidy" \
+        -p="$(Build.BinariesDirectory)/Debug" \
+        --checks="-*,clang-analyzer-*" \
+        --header-filter="objectivec/include|objectivec/src|onnxruntime/core" \
+        ./objectivec/src/*.mm \
+        ./onnxruntime/core/platform/apple/logging/apple_log_sink.mm \
+        ./onnxruntime/core/providers/coreml/model/*.mm
+    displayName: Analyze Objective-C/C++ source code

--- a/tools/ci_build/github/azure-pipelines/mac-objc-static-analysis-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-objc-static-analysis-ci-pipeline.yml
@@ -4,7 +4,7 @@ jobs:
   pool:
     vmImage: 'macOS-10.15'
   
-  timeoutInMinutes: 10
+  timeoutInMinutes: 60
 
   steps:
   - task: UsePythonVersion@0
@@ -24,7 +24,8 @@ jobs:
         --config Debug \
         --build_shared_lib --use_coreml --build_objc \
         --cmake_extra_defines CMAKE_EXPORT_COMPILE_COMMANDS=ON \
-        --update
+        --update \
+        --build --parallel
     displayName: Generate compile_commands.json
 
   - script: |


### PR DESCRIPTION
**Description**
The previous attempt to enable static analysis (#8842) didn't actually run the static analysis checks.

In this change:
Run clang-tidy directly.
Address some static analysis warnings.

**Motivation and Context**
Objective-C static analysis.