### PR TITLE
Include pytorch_export_contrib_ops in inference builds

### DIFF
--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -19,11 +19,11 @@ endif()
 file(GLOB onnxruntime_pybind_srcs CONFIGURE_DEPENDS
   ${onnxruntime_pybind_srcs_pattern}
   )
-  
+
 if(NOT onnxruntime_PYBIND_EXPORT_OPSCHEMA)
   list(REMOVE_ITEM onnxruntime_pybind_srcs  ${ONNXRUNTIME_ROOT}/python/onnxruntime_pybind_schema.cc)
 endif()
-  
+
 if(onnxruntime_ENABLE_TRAINING)
   list(REMOVE_ITEM onnxruntime_pybind_srcs  ${ONNXRUNTIME_ROOT}/python/onnxruntime_pybind_module.cc)
 endif()
@@ -38,11 +38,11 @@ if (onnxruntime_ENABLE_EAGER_MODE)
     )
 
   if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
-    list(APPEND onnxruntime_eager_extension_srcs 
+    list(APPEND onnxruntime_eager_extension_srcs
               "${ORTTRAINING_ROOT}/orttraining/core/framework/torch/dlpack_python.cc")
   endif()
 
-  list(APPEND onnxruntime_pybind_srcs 
+  list(APPEND onnxruntime_pybind_srcs
               ${onnxruntime_eager_extension_srcs})
 endif()
 
@@ -270,9 +270,6 @@ if (onnxruntime_ENABLE_TRAINING)
   )
   file(GLOB onnxruntime_python_ortmodule_torch_cpp_ext_torch_gpu_allocator_srcs CONFIGURE_DEPENDS
     "${ORTTRAINING_SOURCE_DIR}/python/training/ortmodule/torch_cpp_extensions/torch_gpu_allocator/*"
-  )
-  file(GLOB onnxruntime_python_train_tools_srcs CONFIGURE_DEPENDS
-    "${REPO_ROOT}/tools/python/register_custom_ops_pytorch_exporter.py"
   )
 else()
   file(GLOB onnxruntime_python_capi_training_srcs CONFIGURE_DEPENDS
@@ -535,9 +532,6 @@ if (onnxruntime_ENABLE_TRAINING)
     COMMAND ${CMAKE_COMMAND} -E copy
         ${onnxruntime_python_ortmodule_torch_cpp_ext_torch_gpu_allocator_srcs}
         $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions/torch_gpu_allocator/
-    COMMAND ${CMAKE_COMMAND} -E copy
-        ${onnxruntime_python_train_tools_srcs}
-        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/
   )
 endif()
 

--- a/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
+++ b/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
@@ -1,15 +1,15 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-#
-# Test export of pytorch operators using ONNX Runtime contrib ops
+
+"""Test export of PyTorch operators using ONNX Runtime contrib ops."""
 
 import torch
 import onnxruntime
+from onnxruntime.tools import pytorch_export_contrib_ops
 import numpy as np
 import unittest
 import io
 import copy
-from python.register_custom_ops_pytorch_exporter import register_custom_op
 
 
 def ort_test_with_input(ort_sess, input, output, rtol, atol):
@@ -35,9 +35,8 @@ def ort_test_with_input(ort_sess, input, output, rtol, atol):
     [np.testing.assert_allclose(out, ort_out, rtol=rtol, atol=atol) for out, ort_out in zip(outputs, ort_outs)]
 
 
-# These set of tests verify ONNX model export and compare onnxruntime outputs to pytorch.
-# To register custom ops and run the tests, you should set PYTHONPATH as:
-# PYTHONPATH=<path_to_onnxruntime/tools> python -m pytest -v test_custom_ops_pytorch_exporter.py
+# These set of tests verify ONNX model export and compares outputs between
+# PyTorch and ORT.
 class ONNXExporterTest(unittest.TestCase):
     from torch.onnx.symbolic_helper import _export_onnx_opset_version
     opset_version = _export_onnx_opset_version
@@ -45,7 +44,7 @@ class ONNXExporterTest(unittest.TestCase):
 
     def setUp(self):
         torch.manual_seed(0)
-        register_custom_op()
+        pytorch_export_contrib_ops.register()
 
     def run_test(self, model, input=None,
                  custom_opsets=None,
@@ -103,12 +102,12 @@ class ONNXExporterTest(unittest.TestCase):
                 return torch.inverse(x) + x
 
         x = torch.randn(2, 3, 3)
-        self.run_test(CustomInverse(), x, custom_opsets={'com.microsoft': 1})
+        self.run_test(CustomInverse(), x, custom_opsets={"com.microsoft": 1})
 
     def test_gelu(self):
         model = torch.nn.GELU()
         x = torch.randn(3, 3)
-        self.run_test(model, x, custom_opsets={'com.microsoft': 1})
+        self.run_test(model, x, custom_opsets={"com.microsoft": 1})
 
     def test_triu(self):
         for i in range(-5, 5):
@@ -118,13 +117,13 @@ class ONNXExporterTest(unittest.TestCase):
 
             model = Module()
             x = torch.randn(5, 4, 7, dtype=torch.float32)
-            self.run_test(model, x, custom_opsets={'com.microsoft': 1})
+            self.run_test(model, x, custom_opsets={"com.microsoft": 1})
 
             x = torch.randn(5, 4, 0, dtype=torch.float32)
-            self.run_test(model, x, custom_opsets={'com.microsoft': 1})
+            self.run_test(model, x, custom_opsets={"com.microsoft": 1})
 
             x = torch.randn(5, 0, 0, dtype=torch.float32)
-            self.run_test(model, x, custom_opsets={'com.microsoft': 1})
+            self.run_test(model, x, custom_opsets={"com.microsoft": 1})
 
         for i in range(-5, 5):
             class Module2D(torch.nn.Module):
@@ -133,13 +132,13 @@ class ONNXExporterTest(unittest.TestCase):
 
             model = Module2D()
             x = torch.randn(4, 7, dtype=torch.float32)
-            self.run_test(model, x, custom_opsets={'com.microsoft': 1})
+            self.run_test(model, x, custom_opsets={"com.microsoft": 1})
 
             x = torch.randn(0, 7, dtype=torch.float32)
-            self.run_test(model, x, custom_opsets={'com.microsoft': 1})
+            self.run_test(model, x, custom_opsets={"com.microsoft": 1})
 
             x = torch.randn(0, 0, dtype=torch.float32)
-            self.run_test(model, x, custom_opsets={'com.microsoft': 1})
+            self.run_test(model, x, custom_opsets={"com.microsoft": 1})
 
     def test_tril(self):
         for i in range(-5, 5):
@@ -149,13 +148,13 @@ class ONNXExporterTest(unittest.TestCase):
 
             model = Module()
             x = torch.randn(5, 4, 7, dtype=torch.float32)
-            self.run_test(model, x, custom_opsets={'com.microsoft': 1})
+            self.run_test(model, x, custom_opsets={"com.microsoft": 1})
 
             x = torch.randn(5, 4, 0, dtype=torch.float32)
-            self.run_test(model, x, custom_opsets={'com.microsoft': 1})
+            self.run_test(model, x, custom_opsets={"com.microsoft": 1})
 
             x = torch.randn(5, 0, 0, dtype=torch.float32)
-            self.run_test(model, x, custom_opsets={'com.microsoft': 1})
+            self.run_test(model, x, custom_opsets={"com.microsoft": 1})
 
         for i in range(-5, 5):
             class Module2D(torch.nn.Module):
@@ -164,13 +163,13 @@ class ONNXExporterTest(unittest.TestCase):
 
             model = Module2D()
             x = torch.randn(4, 7, dtype=torch.float32)
-            self.run_test(model, x, custom_opsets={'com.microsoft': 1})
+            self.run_test(model, x, custom_opsets={"com.microsoft": 1})
 
             x = torch.randn(0, 7, dtype=torch.float32)
-            self.run_test(model, x, custom_opsets={'com.microsoft': 1})
+            self.run_test(model, x, custom_opsets={"com.microsoft": 1})
 
             x = torch.randn(0, 0, dtype=torch.float32)
-            self.run_test(model, x, custom_opsets={'com.microsoft': 1})
+            self.run_test(model, x, custom_opsets={"com.microsoft": 1})
 
 
 # opset 9 tests, with keep_initializers_as_inputs=False for
@@ -181,5 +180,5 @@ ONNXExporterTest_opset9_IRv4 = type(str("TestONNXRuntime_opset9_IRv4"),
                                          keep_initializers_as_inputs=False))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -355,8 +355,8 @@ def convert_model_loss_fn_to_onnx(model, loss_fn, model_desc, device, inputs, op
     sample_inputs_copy = copy.deepcopy(sample_inputs)
 
     # Enable contrib ops export from PyTorch
-    from onnxruntime.training import register_custom_ops_pytorch_exporter
-    register_custom_ops_pytorch_exporter.register_custom_op()
+    from onnxruntime.tools import pytorch_export_contrib_ops
+    pytorch_export_contrib_ops.register()
 
     torch.onnx._export(model, tuple(sample_inputs_copy), f,
                        input_names=input_names,

--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -10,7 +10,7 @@ from ._custom_gradient_registry import CustomGradientRegistry
 from .debug_options import DebugOptions
 from ._fallback import _FallbackManager, _FallbackPolicy, ORTModuleFallbackException, ORTModuleTorchModelException, wrap_exception
 from . import _FALLBACK_INIT_EXCEPTION, MINIMUM_RUNTIME_PYTORCH_VERSION_STR, ORTMODULE_FALLBACK_POLICY, ORTMODULE_FALLBACK_RETRY
-from onnxruntime.training import register_custom_ops_pytorch_exporter
+from onnxruntime.tools import pytorch_export_contrib_ops
 
 import functools
 import torch
@@ -71,7 +71,7 @@ class ORTModule(torch.nn.Module):
             super(ORTModule, self).__init__()
 
             # Support contrib OPs
-            register_custom_ops_pytorch_exporter.register_custom_op()
+            pytorch_export_contrib_ops.register()
             CustomOpSymbolicRegistry.register_all()
             CustomGradientRegistry.register_all()
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1436,6 +1436,9 @@ def run_training_python_frontend_tests(cwd):
 
     run_subprocess([
         sys.executable, '-m', 'pytest', '-sv', 'orttraining_test_orttrainer_checkpoint_functions.py'], cwd=cwd)
+    # Not technically training related, but it needs torch to be installed.
+    run_subprocess([
+        sys.executable, '-m', 'pytest', '-sv', 'test_pytorch_export_contrib_ops.py'], cwd=cwd)
 
 
 def run_training_python_frontend_e2e_tests(cwd):


### PR DESCRIPTION
Rename / move it from tools/python/register_custom_ops_pytorch_exporter
to onnxruntime/python/tools/pytorch_export_contrib_ops.

Rationale for inclusion in inference builds:
This code is potentially useful for anyone using ORT, not just training.

Rationale for new name:
"Contrib op" is the nomenclature used within ORT to refer to the set of
ops that are not in the standard op set but are included by default with
ORT. This is more specific than "custom op", which is what the PyTorch
exporter uses to refer to any non-standard op.

Step 1 of addressing #8818. After this is merged I will update the docs.