### PR TITLE
Test parity of a new formula LayerNormalization

### DIFF
--- a/onnxruntime/test/python/transformers/test_parity_gelu.py
+++ b/onnxruntime/test/python/transformers/test_parity_gelu.py
@@ -74,7 +74,15 @@ def get_output_names():
     return outputs
 
 
-def run(batch_size, float16, optimized, hidden_size, device, test_cases, formula=0, sequence_length=2, fp32_gelu_op=True):
+def run(batch_size,
+        float16,
+        optimized,
+        hidden_size,
+        device,
+        test_cases,
+        formula=0,
+        sequence_length=2,
+        fp32_gelu_op=True):
     test_name = f"device={device}, float16={float16}, optimized={optimized}, batch_size={batch_size}, sequence_length={sequence_length}, hidden_size={hidden_size}, formula={formula}, fp32_gelu_op={fp32_gelu_op}"
     print(f"\nTesting: {test_name}")
 
@@ -91,13 +99,25 @@ def run(batch_size, float16, optimized, hidden_size, device, test_cases, formula
     if optimized:
         optimized_onnx_path = './temp/gelu_{}_opt_{}.onnx'.format(formula, "fp16" if float16 else "fp32")
         use_gpu = float16 and not fp32_gelu_op
-        optimize_onnx(onnx_model_path, optimized_onnx_path, Gelu.get_fused_op(formula), use_gpu=use_gpu, opt_level=2 if use_gpu else None)
+        optimize_onnx(onnx_model_path,
+                      optimized_onnx_path,
+                      Gelu.get_fused_op(formula),
+                      use_gpu=use_gpu,
+                      opt_level=2 if use_gpu else None)
         onnx_path = optimized_onnx_path
     else:
         onnx_path = onnx_model_path
 
-    num_failure = run_parity(model, onnx_path, batch_size, hidden_size, sequence_length, float16, device, optimized,
-                             test_cases, verbose=False)
+    num_failure = run_parity(model,
+                             onnx_path,
+                             batch_size,
+                             hidden_size,
+                             sequence_length,
+                             float16,
+                             device,
+                             optimized,
+                             test_cases,
+                             verbose=False)
 
     # clean up onnx file
     os.remove(onnx_model_path)
@@ -116,7 +136,15 @@ class TestGeluParity(unittest.TestCase):
         self.formula_to_test = [0, 1, 2, 3, 4, 5]
         self.formula_must_pass = [0, 1, 3, 4, 5]  # formula 2 cannot pass precision test.
 
-    def run_test(self, batch_size, float16, optimized, hidden_size, device, formula, enable_assert=True, fp32_gelu_op=True):
+    def run_test(self,
+                 batch_size,
+                 float16,
+                 optimized,
+                 hidden_size,
+                 device,
+                 formula,
+                 enable_assert=True,
+                 fp32_gelu_op=True):
         if float16 and device.type == 'cpu':  # CPU does not support FP16
             return
         num_failure, test_name = run(batch_size, float16, optimized, hidden_size, device, self.test_cases, formula,
@@ -151,7 +179,6 @@ class TestGeluParity(unittest.TestCase):
                           formula=formula,
                           enable_assert=formula in self.formula_must_pass,
                           fp32_gelu_op=False)
-
 
     def test_cpu(self):
         cpu = torch.device('cpu')

--- a/onnxruntime/test/python/transformers/test_parity_layernorm.py
+++ b/onnxruntime/test/python/transformers/test_parity_layernorm.py
@@ -18,35 +18,67 @@ else:
 
 
 class LayerNorm(nn.Module):
-    def __init__(self, hidden_size, epsilon, cast_fp16=True):
+    def __init__(self, hidden_size, epsilon, cast_fp16=True, formula=0):
         super().__init__()
         self.layer_norm = nn.LayerNorm(hidden_size, eps=epsilon)
         # initialize weights with random value
         self.layer_norm.bias.data.normal_(mean=0.0, std=0.1)
         self.layer_norm.weight.data.normal_(mean=0.0, std=0.5)
         self.cast_fp16 = cast_fp16
+        self.formula = formula
+        self.epsilon = epsilon
 
     @staticmethod
     def get_fused_op():
         return "LayerNormalization"
 
+    def my_layer_norm(self, x):
+        if self.formula == 0:
+            return self.layer_norm(x)
+
+        input_dtype = x.dtype
+        x = x.float()
+        u = x.mean(-1, keepdim=True)
+        y = x - u
+        s = y.pow(2).mean(-1, keepdim=True)
+        z = y / torch.sqrt(s + self.epsilon)
+        return self.layer_norm.weight.data * z.to(input_dtype) + self.layer_norm.bias.data
+
     def forward(self, x):
         if self.cast_fp16 and x.dtype == torch.float16:
-            y = self.layer_norm(x.to(torch.float32)).to(torch.float16)
-            return (y, )
-        y = self.layer_norm(x)
+            y = self.my_layer_norm(x.to(torch.float32)).to(torch.float16)
+        else:
+            y = self.my_layer_norm(x)
+
         return (y, )
+
+
+def get_weight(onnx_model):
+    last_mul_node = onnx_model.get_nodes_by_op_type('Mul')[-1]
+    i, value = onnx_model.get_constant_input(last_mul_node)
+    assert value is not None
+    weight_name = last_mul_node.input[i]
+    return weight_name
+
+
+def get_bias(onnx_model):
+    last_add_node = onnx_model.get_nodes_by_op_type('Add')[-1]
+    i, value = onnx_model.get_constant_input(last_add_node)
+    assert value is not None
+    bias_name = last_add_node.input[i]
+    return bias_name
 
 
 def optimize_fp16_onnx_with_cast(input_onnx_path, optimized_onnx_path, epsilon):
     m = onnx.load(input_onnx_path)
     onnx_model = OnnxModel(m)
-
-    nodes_to_remove = onnx_model.nodes()
+    weight_name = get_weight(onnx_model)
+    bias_name = get_bias(onnx_model)
+    nodes_to_remove = [n for n in onnx_model.nodes() if n.output[0] != weight_name and n.output[0] != bias_name]
     nodes_to_add = [
         onnx.helper.make_node("Cast", ["input"], ["fp32_input"], "cast_input", to=1),
-        onnx.helper.make_node("Cast", ["layer_norm.weight"], ["fp32_layer_norm.weight"], "cast_weight", to=1),
-        onnx.helper.make_node("Cast", ["layer_norm.bias"], ["fp32_layer_norm.bias"], "cast_bias", to=1),
+        onnx.helper.make_node("Cast", [weight_name], ["fp32_layer_norm.weight"], "cast_weight", to=1),
+        onnx.helper.make_node("Cast", [bias_name], ["fp32_layer_norm.bias"], "cast_bias", to=1),
         onnx.helper.make_node("LayerNormalization", ["fp32_input", "fp32_layer_norm.weight", "fp32_layer_norm.bias"],
                               ["fp32_output"],
                               "layer_norm",
@@ -64,9 +96,12 @@ def optimize_fp16_onnx_no_cast(input_onnx_path, optimized_onnx_path, epsilon):
     m = onnx.load(input_onnx_path)
     onnx_model = OnnxModel(m)
 
+    weight_name = get_weight(onnx_model)
+    bias_name = get_bias(onnx_model)
+    nodes_to_remove = [n for n in onnx_model.nodes() if n.output[0] != weight_name and n.output[0] != bias_name]
+
     nodes_to_remove = onnx_model.nodes()
-    node_to_add = onnx.helper.make_node("LayerNormalization", ["input", "layer_norm.weight", "layer_norm.bias"],
-                                        ["output"],
+    node_to_add = onnx.helper.make_node("LayerNormalization", ["input", weight_name, bias_name], ["output"],
                                         "layer_norm",
                                         epsilon=epsilon)
 
@@ -91,11 +126,12 @@ def run(batch_size,
         epsilon=0.00001,
         cast_fp16=True,
         cast_onnx_only=False,
+        formula=0,
         verbose=False):
-    test_name = f"device={device}, float16={float16}, optimized={optimized}, batch_size={batch_size}, sequence_length={sequence_length}, hidden_size={hidden_size}, epsilon={epsilon}, cast_fp16={cast_fp16}, cast_onnx_only={cast_onnx_only}"
+    test_name = f"device={device}, float16={float16}, optimized={optimized}, batch_size={batch_size}, sequence_length={sequence_length}, hidden_size={hidden_size}, epsilon={epsilon}, cast_fp16={cast_fp16}, cast_onnx_only={cast_onnx_only}, formula={formula}"
     print(f"\nTesting: {test_name}")
 
-    model = LayerNorm(hidden_size, epsilon, cast_fp16)
+    model = LayerNorm(hidden_size, epsilon, cast_fp16, formula)
     model.eval()
     model.to(device)
 
@@ -103,11 +139,11 @@ def run(batch_size,
         model.half()
 
     # Do not re-use onnx file from previous test since weights of model are random.
-    onnx_model_path = './temp/layer_norm_{}.onnx'.format("fp16" if float16 else "fp32")
+    onnx_model_path = './temp/layer_norm_{}_formula{}.onnx'.format("fp16" if float16 else "fp32", formula)
     export_onnx(model, onnx_model_path, float16, hidden_size, device)
 
     if optimized:
-        optimized_onnx_path = './temp/layer_norm_{}_opt.onnx'.format("fp16" if float16 else "fp32")
+        optimized_onnx_path = './temp/layer_norm_{}_formula{}_opt.onnx'.format("fp16" if float16 else "fp32", formula)
         if (not float16) or cast_fp16:
             optimize_onnx(onnx_model_path, optimized_onnx_path, expected_op=LayerNorm.get_fused_op())
         else:
@@ -145,7 +181,6 @@ class TestLayerNormParity(unittest.TestCase):
         self.test_cases = 100  # Number of test cases per test run
         self.sequence_length = 2
         self.hidden_size = 768
-        self.epsilon = 0.00001
         self.verbose = False
 
     def run_test(self,
@@ -156,6 +191,8 @@ class TestLayerNormParity(unittest.TestCase):
                  device,
                  cast_fp16=True,
                  cast_onnx_only=False,
+                 formula=0,
+                 epsilon=0.00001,
                  enable_assert=True):
         if float16 and device.type == 'cpu':  # CPU does not support FP16
             return
@@ -167,49 +204,68 @@ class TestLayerNormParity(unittest.TestCase):
                                      device,
                                      self.test_cases,
                                      self.sequence_length,
-                                     self.epsilon,
+                                     epsilon,
                                      cast_fp16,
                                      cast_onnx_only,
+                                     formula,
                                      verbose=self.verbose)
         if enable_assert:
             self.assertTrue(num_failure == 0, "Failed: " + test_name)
 
-    def run_one(self, optimized, device, hidden_size=768):
+    def run_one(self, optimized, device, hidden_size=768, run_extra_tests=False):
         for batch_size in [4]:
-            self.run_test(batch_size, float16=False, optimized=optimized, hidden_size=hidden_size, device=device)
+            for formula in [0, 1]:
+                for epsilon in [1e-5]:  #[1e-5, 1e-12]
+                    self.run_test(batch_size,
+                                  float16=False,
+                                  optimized=optimized,
+                                  hidden_size=hidden_size,
+                                  device=device,
+                                  formula=formula,
+                                  epsilon=epsilon)
 
-            self.run_test(
-                batch_size,
-                float16=True,
-                optimized=optimized,
-                hidden_size=hidden_size,
-                device=device,
-                cast_fp16=True,
-                cast_onnx_only=False,
-                enable_assert=False  # This setting has small chance to exceed tollerance threshold 0.001
-            )
+                    self.run_test(
+                        batch_size,
+                        float16=True,
+                        optimized=optimized,
+                        hidden_size=hidden_size,
+                        device=device,
+                        cast_fp16=True,
+                        cast_onnx_only=False,
+                        formula=formula,
+                        epsilon=epsilon,
+                        enable_assert=False  # This setting has small chance to exceed tollerance threshold 0.001
+                    )
 
-            self.run_test(
-                batch_size,
-                float16=True,
-                optimized=optimized,
-                hidden_size=hidden_size,
-                device=device,
-                cast_fp16=False,
-                cast_onnx_only=False,
-                enable_assert=False  # This setting cannot pass tollerance threshold
-            )
+                    if not run_extra_tests:
+                        continue
 
-            self.run_test(
-                batch_size,
-                float16=True,
-                optimized=optimized,
-                hidden_size=hidden_size,
-                device=device,
-                cast_fp16=False,
-                cast_onnx_only=True,
-                enable_assert=False  # This setting cannot pass tollerance threshold
-            )
+                    if device.type != 'cuda' or formula != 1:
+                        self.run_test(
+                            batch_size,
+                            float16=True,
+                            optimized=optimized,
+                            hidden_size=hidden_size,
+                            device=device,
+                            cast_fp16=False,
+                            cast_onnx_only=False,
+                            formula=formula,
+                            epsilon=epsilon,
+                            enable_assert=False  # This setting cannot pass tollerance threshold
+                        )
+
+                    self.run_test(
+                        batch_size,
+                        float16=True,
+                        optimized=optimized,
+                        hidden_size=hidden_size,
+                        device=device,
+                        cast_fp16=False,
+                        cast_onnx_only=True,
+                        formula=formula,
+                        epsilon=epsilon,
+                        enable_assert=False  # This setting cannot pass tollerance threshold
+                    )
 
     def test_cpu(self):
         cpu = torch.device('cpu')
@@ -221,7 +277,7 @@ class TestLayerNormParity(unittest.TestCase):
             pytest.skip('test requires GPU and torch+cuda')
         else:
             gpu = torch.device('cuda')
-            self.run_one(self.optimized, gpu, hidden_size=self.hidden_size)
+            self.run_one(self.optimized, gpu, hidden_size=self.hidden_size, run_extra_tests=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description**: 

Test a new form of LayerNorm (formula 1):
```
    def layer_norm(x ,weight, bias):
        input_dtype = x.dtype
        x = x.float()
        u = x.mean(-1, keepdim=True)
        y = x - u
        s = y.pow(2).mean(-1, keepdim=True)
        z = y / torch.sqrt(s + self.epsilon)
        return weight * z.to(input_dtype) + bias
```
Result shows that it could achieve same level of parity as nn.LayerNorm (formula 0) in ONNX.

Device | I/O | Layer Normalization Precision | MaxDiff     (Formula 0) | MaxDiff     (Formula 1)
-- | -- | -- | -- | --
CPU | FP32 | FP32 | 2.8e-6 | 2.4e-6
CUDA | FP32 | FP32 | 7.1e-7 | 9.5e-7
CUDA | FP16 | FP32 | 9.8e-4 | 9.8e-4
CUDA | FP16 | FP16 | 3.9e-3 | 3.9e-3



**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
