### PR TITLE
Add azure kusto and pandas to Linux CPU manylinux docker image

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -182,7 +182,7 @@ jobs:
     displayName: 'Azure CLI'
     condition: and (succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
-      azureSubscription: AIInfraBuildOnnxRuntimeOSS
+      azureSubscription: AIInfraBuild
       scriptLocation: inlineScript
       scriptType: batch
       inlineScript: |

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -177,6 +177,18 @@ jobs:
             /bin/bash /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
       workingDirectory: $(Build.SourcesDirectory)
 
+
+  - task: AzureCLI@2
+    displayName: 'Azure CLI'
+    condition: and (succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    inputs:
+      azureSubscription: AIInfraBuildOnnxRuntimeOSS
+      scriptLocation: inlineScript
+      scriptType: batch
+      inlineScript: |
+        /usr/bin/python3 $(Build.SourcesDirectory)/tools/ci_build/github/windows/post_binary_sizes_to_dashboard.py --commit_hash=$(Build.SourceVersion) --size_data_file=$(Build.BinariesDirectory)/MinSizeRel/binary_size_data.txt --build_project=onnxruntime --build_id=$(Build.BuildId)
+      workingDirectory: '$(Build.BinariesDirectory)'
+
   - task: PublishTestResults@2
     displayName: 'Publish unit test results'
     inputs:

--- a/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
@@ -35,24 +35,5 @@ python3 /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/check_build_bin
     --threshold=$BINARY_SIZE_LIMIT_IN_BYTES \
     /build/MinSizeRel/libonnxruntime.so
 
-# Post the binary size info to ort mysql DB
-# The report script's DB connection failure will not fail the pipeline
-# To reduce noise, we only report binary size for Continuous integration (a merge to master)
-if [[ $BUILD_REASON == "IndividualCI" || $BUILD_REASON == "BatchedCI" ]] && [[ $BUILD_BRANCH == "refs/heads/master" ]]; then
-    # Install the mysql connector
-    python3 -m pip install --user mysql-connector-python
-
-    python3 /onnxruntime_src/tools/ci_build/github/windows/post_binary_sizes_to_dashboard.py \
-        --ignore_db_error \
-        --commit_hash=$BUILD_SOURCEVERSION \
-        --size_data_file=/build/MinSizeRel/binary_size_data.txt \
-        --build_project=onnxruntime \
-        --build_id=$BUILD_ID
-else
-    echo "No binary size report for build reason: [$BUILD_REASON] and build branch: [$BUILD_BRANCH]"
-    echo "The content of binary_size_data.txt"
-    cat /build/MinSizeRel/binary_size_data.txt
-fi
-
 # Clear the build
 rm -rf /build/MinSizeRel


### PR DESCRIPTION
**Description**: 

Add binary size reporting back  for the minimal build pipeline.

Test run: https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=483973&view=results

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
