### PR TITLE
Add warning message for combined trt +cuda python pkg

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -346,10 +346,8 @@ class InferenceSession(Session):
                                                                         provider_options,
                                                                         available_providers)
 
-        if providers == [] and 'CUDAExecutionProvider' in available_providers:
-            warnings.warn("Starting from next ORT release, user needs to explicitly set providers to include 'CUDAExecutionProvider' when instantiating InferenceSession. " +
-                          "Please see https://onnxruntime.ai/python/api_summary.html#onnxruntime.InferenceSession for detail. " +
-                          "For example, onnxruntime.InferenceSession(..., providers=[\"CUDAExecutionProvider\"], ...).")
+        if providers == [] and len(available_providers) > 1:
+            warnings.warn("Deprecation warning. This ORT build has [{}] enabled. The next release (ORT 1.10) will require explicitly setting the providers parameter (as opposed to the current behavior of providers getting set/registered by default based on the build flags) when instantiating InferenceSession.".format(available_providers) + "For example, onnxruntime.InferenceSession(..., providers=[\"CUDAExecutionProvider\"], ...).")
 
         session_options = self._sess_options if self._sess_options else C.get_default_session_options()
         if self._model_path:

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -347,7 +347,11 @@ class InferenceSession(Session):
                                                                         available_providers)
 
         if providers == [] and len(available_providers) > 1:
-            warnings.warn("Deprecation warning. This ORT build has [{}] enabled. The next release (ORT 1.10) will require explicitly setting the providers parameter (as opposed to the current behavior of providers getting set/registered by default based on the build flags) when instantiating InferenceSession.".format(available_providers) + "For example, onnxruntime.InferenceSession(..., providers=[\"CUDAExecutionProvider\"], ...).")
+            warnings.warn("Deprecation warning. This ORT build has {} enabled.".format(available_providers) +
+            " The next release (ORT 1.10) will require" +
+            " explicitly setting the providers parameter (as opposed to the current behavior of providers" +
+            " getting set/registered by default based on the build flags) when instantiating InferenceSession."
+            " For example, onnxruntime.InferenceSession(..., providers=[\"CUDAExecutionProvider\"], ...).")
 
         session_options = self._sess_options if self._sess_options else C.get_default_session_options()
         if self._model_path:

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -347,11 +347,11 @@ class InferenceSession(Session):
                                                                         available_providers)
 
         if providers == [] and len(available_providers) > 1:
-            warnings.warn("Deprecation warning. This ORT build has {} enabled.".format(available_providers) +
-            " The next release (ORT 1.10) will require" +
-            " explicitly setting the providers parameter (as opposed to the current behavior of providers" +
-            " getting set/registered by default based on the build flags) when instantiating InferenceSession."
-            " For example, onnxruntime.InferenceSession(..., providers=[\"CUDAExecutionProvider\"], ...).")
+            warnings.warn("Deprecation warning. This ORT build has {} enabled. ".format(available_providers) +
+                          "The next release (ORT 1.10) will require explicitly setting the providers parameter " +
+                          "(as opposed to the current behavior of providers getting set/registered by default " +
+                          "based on the build flags) when instantiating InferenceSession."
+                          "For example, onnxruntime.InferenceSession(..., providers=[\"CUDAExecutionProvider\"], ...)")
 
         session_options = self._sess_options if self._sess_options else C.get_default_session_options()
         if self._model_path:

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -346,6 +346,11 @@ class InferenceSession(Session):
                                                                         provider_options,
                                                                         available_providers)
 
+        if providers == [] and 'CUDAExecutionProvider' in available_providers:
+            warnings.warn("Starting from next ORT release, user needs to explicitly set providers to include 'CUDAExecutionProvider' when instantiating InferenceSession. " +
+                          "Please see https://onnxruntime.ai/python/api_summary.html#onnxruntime.InferenceSession for detail. " +
+                          "For example, onnxruntime.InferenceSession(..., providers=[\"CUDAExecutionProvider\"], ...).")
+
         session_options = self._sess_options if self._sess_options else C.get_default_session_options()
         if self._model_path:
             sess = C.InferenceSession(session_options, self._model_path, True, self._read_config_from_model)


### PR DESCRIPTION
We aren’t changing anything for python gpu package for ORT 1.9 release.
But for next release, we are going to include trt. It's going to be a behavior change for python package.
Therefore, we do want to inform users beforehand and show the warning message.
Users will need to explicitly setting the providers parameter for ORT 1.10 release, for example, onnxruntime.InferenceSession(..., providers=[\"CUDAExecutionProvider\"], ...)

