### PR TITLE
Fix Matmul transpose fusion 

### DIFF
--- a/onnxruntime/core/optimizer/matmul_transpose_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_transpose_fusion.cc
@@ -142,13 +142,14 @@ static Node* ReorderCastAndTranspose(Graph& graph, Node* cast,
   const std::vector<NodeArg*> new_transpose_input_defs = {&new_cast_output};
   const std::vector<NodeArg*> new_transpose_output_defs = {cast_output};
 
-  (void)graph.AddNode(graph.GenerateNodeName(cast->Name() + "_transformed"),
+  Node& new_cast = graph.AddNode(graph.GenerateNodeName(cast->Name() + "_transformed"),
                       cast->OpType(),
                       "Created a new Cast node to interchange Cast and Transpose nodes",
                       new_cast_input_defs,
                       new_cast_output_defs,
                       &cast->GetAttributes(),
                       cast->Domain());
+  new_cast.SetExecutionProviderType(cast->GetExecutionProviderType());
 
   Node& new_transpose = graph.AddNode(graph.GenerateNodeName(transpose->Name() + "_transformed"),
                                       transpose->OpType(),
@@ -157,6 +158,7 @@ static Node* ReorderCastAndTranspose(Graph& graph, Node* cast,
                                       new_transpose_output_defs,
                                       &transpose->GetAttributes(),
                                       transpose->Domain());
+  new_transpose.SetExecutionProviderType(transpose->GetExecutionProviderType());
 
   size_t consumers = UpdateConsumerCount(graph, transpose->MutableOutputDefs()[0], consumer_count);
   graph_utils::RemoveNodeOutputEdges(graph, *cast);


### PR DESCRIPTION
One part of the transform swaps the order of Transpose and Cast in order to be able to fuse Matmul and Transpose. After adding new nodes to the graph, the execution provider must be set for these nodes as the transform may be called after the graph is partitioned according to execution provider, after which the expectation is that an EP is set for each node in the graph.


