### PR TITLE
Trim InferenceSession binary size.

### DIFF
--- a/onnxruntime/core/framework/session_state_flatbuffers_utils.cc
+++ b/onnxruntime/core/framework/session_state_flatbuffers_utils.cc
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/framework/session_state_flatbuffers_utils.h"
+
+namespace onnxruntime::experimental::utils {
+
+std::string GetSubgraphId(const NodeIndex node_idx, const std::string& attr_name) {
+  return std::to_string(node_idx) + "_" + attr_name;
+}
+
+FbsSessionStateViewer::FbsSessionStateViewer(const fbs::SessionState& fbs_session_state)
+    : fbs_session_state_{fbs_session_state} {
+}
+
+Status FbsSessionStateViewer::Validate() const {
+  if (fbs_session_state_.sub_graph_session_states() == nullptr) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "SessionState for subgraphs is null. Invalid ORT format model.");
+  }
+
+  const auto* const fbs_kcis = fbs_session_state_.kernels();
+  if (fbs_kcis == nullptr) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Kernel create info is null. Invalid ORT format model.");
+  }
+
+  const auto* const fbs_node_indices = fbs_kcis->node_indices();
+  if (fbs_node_indices == nullptr) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Kernel create info node indices are null. Invalid ORT format model.");
+  }
+
+  const auto* const fbs_kernel_def_hashes = fbs_kcis->kernel_def_hashes();
+  if (fbs_kernel_def_hashes == nullptr) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Kernel create info hashes are null. Invalid ORT format model.");
+  }
+
+  if (fbs_node_indices->size() != fbs_kernel_def_hashes->size()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "Size mismatch for kernel create info node indexes and hashes. Invalid ORT format model.",
+                           fbs_node_indices->size(), " != ", fbs_kernel_def_hashes->size());
+  }
+
+  return Status::OK();
+}
+
+FbsSessionStateViewer::NodeKernelInfo FbsSessionStateViewer::GetNodeKernelInfo(Index idx) const {
+  const auto* const fbs_kcis = fbs_session_state_.kernels();
+  const auto* const fbs_node_indices = fbs_kcis->node_indices();
+  const auto* const fbs_kernel_def_hashes = fbs_kcis->kernel_def_hashes();
+
+  return {fbs_node_indices->Get(idx), fbs_kernel_def_hashes->Get(idx)};
+}
+
+FbsSessionStateViewer::Index FbsSessionStateViewer::GetNumNodeKernelInfos() const {
+  return fbs_session_state_.kernels()->node_indices()->size();
+}
+
+Status FbsSessionStateViewer::GetSubgraphSessionState(NodeIndex node_idx, const std::string& attr_name,
+                                                      const fbs::SessionState*& fbs_subgraph_session_state_out) const {
+  const auto key = GetSubgraphId(node_idx, attr_name);
+  const auto* const fbs_subgraph_session_state_entry =
+      fbs_session_state_.sub_graph_session_states()->LookupByKey(key.c_str());
+  if (fbs_subgraph_session_state_entry == nullptr) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "Subgraph SessionState entry for ", key, " is missing. Invalid ORT format model.");
+  }
+
+  const auto* const fbs_subgraph_session_state = fbs_subgraph_session_state_entry->session_state();
+  if (fbs_subgraph_session_state == nullptr) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                           "Subgraph SessionState for ", key, " is null. Invalid ORT format model.");
+  }
+
+  fbs_subgraph_session_state_out = fbs_subgraph_session_state;
+  return Status::OK();
+}
+
+}  // namespace onnxruntime::experimental::utils

--- a/onnxruntime/core/framework/session_state_flatbuffers_utils.h
+++ b/onnxruntime/core/framework/session_state_flatbuffers_utils.h
@@ -5,6 +5,8 @@
 
 #include <string>
 
+#include "core/common/common.h"
+#include "core/flatbuffers/schema/ort.fbs.h"
 #include "core/graph/basic_types.h"
 
 namespace onnxruntime::experimental::utils {
@@ -16,8 +18,64 @@ namespace onnxruntime::experimental::utils {
  * @param attr_name The name of the node attribute that contains the subgraph.
  * @return The subgraph key.
  */
-inline std::string GetSubGraphId(const NodeIndex node_idx, const std::string& attr_name) {
-  return std::to_string(node_idx) + "_" + attr_name;
-}
+std::string GetSubgraphId(const NodeIndex node_idx, const std::string& attr_name);
+
+/**
+ * Provides read-only helper functions for a fbs::SessionState instance.
+ */
+class FbsSessionStateViewer {
+ public:
+  /**
+   * Creates an instance.
+   * Validation is not performed here, but in Validate().
+   *
+   * @param fbs_session_state The fbs::SessionState instance.
+   */
+  FbsSessionStateViewer(const fbs::SessionState& fbs_session_state);
+
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(FbsSessionStateViewer);
+
+  /**
+   * Validates the underlying fbs::SessionState instance.
+   * WARNING: Other methods assume that the fbs::SessionState is valid!
+   *
+   * @return Whether the fbs::SessionState instance is valid.
+   */
+  Status Validate() const;
+
+  using Index = flatbuffers::uoffset_t;
+
+  struct NodeKernelInfo {
+    NodeIndex node_index;
+    uint64_t kernel_def_hash;
+  };
+
+  /**
+   * Retrieves the node kernel info element.
+   *
+   * @param index The index of the node kernel info element.
+   * @return The node kernel info element.
+   */
+  NodeKernelInfo GetNodeKernelInfo(Index idx) const;
+
+  /**
+   * Gets the number of node kernel info elements.
+   */
+  Index GetNumNodeKernelInfos() const;
+
+  /**
+   * Retrieves the subgraph session state from the fbs::SessionState instance.
+   * 
+   * @param node_idx The index of the node containing the subgraph.
+   * @param attr_name The name of the attribute containing the subgraph.
+   * @param[out] fbs_subgraph_session_state The subgraph session state. Non-null if successful.
+   * @return Whether the retrieval was successful.
+   */
+  Status GetSubgraphSessionState(NodeIndex node_idx, const std::string& attr_name,
+                                 const fbs::SessionState*& fbs_subgraph_session_state) const;
+
+ private:
+  const fbs::SessionState& fbs_session_state_;
+};
 
 }  // namespace onnxruntime::experimental::utils


### PR DESCRIPTION
**Description**
- Move flatbuffers SessionState access code into helper functions instead of duplicating them between InferenceSession and SessionState.
- Trim VerifyEachNodeIsAssignedToAnEp(), e.g., disable verbose log output in a minimal build.

**Motivation and Context**
Reduce binary size.
