### PR TITLE
do not post cuda version mismatch warning if cannot find local cudart…

### DIFF
--- a/onnxruntime/python/onnxruntime_validation.py
+++ b/onnxruntime/python/onnxruntime_validation.py
@@ -117,7 +117,7 @@ def validate_build_package_info():
                 # collection cuda library info from current environment.
                 from onnxruntime.capi.onnxruntime_collect_build_info import find_cudart_versions
                 local_cudart_versions = find_cudart_versions(build_env=False, build_cuda_version=cuda_version)
-                if cudart_version and cudart_version not in local_cudart_versions:
+                if cudart_version and local_cudart_versions and cudart_version not in local_cudart_versions:
                     print_build_package_info()
                     warnings.warn('WARNING: failed to find cudart version that matches onnxruntime build info')
                     warnings.warn('WARNING: found cudart versions: %s' % local_cudart_versions)


### PR DESCRIPTION
**Description**: It cannot always find local cudart version because cudart.so could be mapped to different names depending on how cuda is installed and the operation systems. We only want to warn the user when it does find local cudart versions and there is no match between local and ort build cuda version. In other cases we do not warn the user.

