### PR TITLE
Fix non deterministic of --input_int32 of transformer optimizer

### DIFF
--- a/onnxruntime/python/tools/transformers/machine_info.py
+++ b/onnxruntime/python/tools/transformers/machine_info.py
@@ -113,8 +113,11 @@ class MachineInfo():
     def get_related_packages(self) -> List[str]:
         import pkg_resources
         installed_packages = pkg_resources.working_set
-        related_packages = ['onnxruntime-gpu', 'onnxruntime', 'ort-nightly-gpu', 'ort-nightly', 'onnx', 'transformers', 'protobuf', 'sympy', 'torch', 'tensorflow', 'flatbuffers', 'numpy', 'onnxconverter-common']
-        related_packages_list = {i.key : i.version for i in installed_packages if i.key in related_packages}
+        related_packages = [
+            'onnxruntime-gpu', 'onnxruntime', 'ort-nightly-gpu', 'ort-nightly', 'onnx', 'transformers', 'protobuf',
+            'sympy', 'torch', 'tensorflow', 'flatbuffers', 'numpy', 'onnxconverter-common'
+        ]
+        related_packages_list = {i.key: i.version for i in installed_packages if i.key in related_packages}
         return related_packages_list
 
     def get_onnxruntime_info(self) -> Dict:

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -485,7 +485,7 @@ class OnnxModel:
         return None
 
     @staticmethod
-    def get_node_attribute(node:NodeProto, attribute_name: str):
+    def get_node_attribute(node: NodeProto, attribute_name: str):
         for attr in node.attribute:
             if attr.name == attribute_name:
                 value = helper.get_attribute_value(attr)
@@ -551,8 +551,6 @@ class OnnxModel:
 
         fp16_model = convert_float_to_float16(model, **parameters)
         self.initialize(fp16_model)
-
-        
 
         # Convert_float_to_float16 might add Cast(to=10) --> Cast(to=1) when two consequent nodes are computed in FP32.
         # Below are post-processing that removes those Cast nodes.

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -10,7 +10,7 @@ import sys
 from pathlib import Path
 import numpy as np
 from collections import deque
-from onnx import onnx_pb, AttributeProto, ModelProto, TensorProto, numpy_helper, helper, external_data_helper, save_model
+from onnx import onnx_pb, AttributeProto, ModelProto, TensorProto, NodeProto, numpy_helper, helper, external_data_helper, save_model
 from shape_infer_helper import SymbolicShapeInferenceHelper
 
 logger = logging.getLogger(__name__)
@@ -484,6 +484,14 @@ class OnnxModel:
 
         return None
 
+    @staticmethod
+    def get_node_attribute(node:NodeProto, attribute_name: str):
+        for attr in node.attribute:
+            if attr.name == attribute_name:
+                value = helper.get_attribute_value(attr)
+                return value
+        return None
+
     def convert_model_float32_to_float16(self, cast_input_output=True):
         logger.warn(
             'The function convert_model_float32_to_float16 is deprecated. Use convert_float_to_float16 instead!')
@@ -544,12 +552,7 @@ class OnnxModel:
         fp16_model = convert_float_to_float16(model, **parameters)
         self.initialize(fp16_model)
 
-        def get_node_attribute(node, attribute_name: str):
-            for attr in node.attribute:
-                if attr.name == attribute_name:
-                    value = helper.get_attribute_value(attr)
-                    return value
-            return None
+        
 
         # Convert_float_to_float16 might add Cast(to=10) --> Cast(to=1) when two consequent nodes are computed in FP32.
         # Below are post-processing that removes those Cast nodes.
@@ -565,7 +568,7 @@ class OnnxModel:
 
         # Remove the second cast node.
         for node in self.nodes():
-            if node.op_type == "Cast" and get_node_attribute(node, "to") == int(TensorProto.FLOAT) and \
+            if node.op_type == "Cast" and OnnxModel.get_node_attribute(node, "to") == int(TensorProto.FLOAT) and \
                 self.get_dtype(node.input[0])  == int(TensorProto.FLOAT):
 
                 if self.find_graph_output(node.output[0]):

--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -136,7 +136,7 @@ class BertOnnxModel(OnnxModel):
         assert self.find_graph_input(graph_input.name)
 
         if graph_input.type.tensor_type.elem_type == int(new_type):
-            return None
+            return None, []
 
         new_cast_node = None
         nodes_to_remove = []

--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -5,7 +5,7 @@
 
 from logging import getLogger
 from typing import List
-from onnx import ModelProto, TensorProto, helper
+from onnx import GraphProto, ModelProto, TensorProto, ValueInfoProto, helper
 from onnx_model import OnnxModel
 from fusion_reshape import FusionReshape
 from fusion_layernorm import FusionLayerNormalization, FusionLayerNormalizationTF
@@ -116,44 +116,73 @@ class BertOnnxModel(OnnxModel):
         inputs += self.get_graph_inputs_from_node_type('Attention', [3], casted)
         return inputs
 
+    def change_graph_input_type(self,
+                                graph: GraphProto,
+                                graph_input: ValueInfoProto,
+                                new_type: int = TensorProto.INT32):
+        """Change graph input type, and add Cast node if needed.
+
+        Args:
+            graph (GraphProto): graph
+            graph_input (TensorProto): input of the graph
+            new_type (int, optional): new data type. Defaults to TensorProto.INT32.
+
+        Returns:
+            NodeProto: a new Cast node that added. None if Cast node is not added.
+        """
+        assert isinstance(graph, GraphProto)
+        assert isinstance(graph_input, ValueInfoProto)
+        assert self.find_graph_input(graph_input.name)
+
+        if graph_input.type.tensor_type.elem_type == int(new_type):
+            return None
+
+        new_cast_node = None
+        input_name_to_nodes = self.input_name_to_nodes()
+        if graph_input.name in input_name_to_nodes:
+            nodes = input_name_to_nodes[graph_input.name]
+
+            # For children that is not Cast node, insert a Cast node to convert int32 to original data type.
+            nodes_not_cast = [node for node in nodes if node.op_type != 'Cast']
+            if nodes_not_cast:
+                node_name = self.create_node_name('Cast')
+                output_name = node_name + '_' + graph_input.name
+                new_value_info = graph.value_info.add()
+                new_value_info.CopyFrom(graph_input)
+                new_value_info.name = output_name
+                new_cast_node = helper.make_node('Cast', [graph_input.name], [output_name],
+                                                 to=int(graph_input.type.tensor_type.elem_type),
+                                                 name=node_name)
+                graph.node.extend([new_cast_node])
+
+                for node in nodes_not_cast:
+                    OnnxModel.replace_node_input(node, graph_input.name, output_name)
+
+            # For children that is Cast node, no need to insert Cast.
+            # When the children is Cast to int32, we can remove that Cast node since input type is int32 now.
+            nodes_cast = [node for node in nodes if node.op_type == 'Cast']
+            nodes_to_remove = []
+            for node in nodes_cast:
+                if OnnxModel.get_node_attribute(node, "to") == int(new_type):
+                    self.replace_input_of_all_nodes(node.output[0], graph_input.name)
+                if not self.find_graph_output(node.output[0]):
+                    nodes_to_remove.append(node)
+            if nodes_to_remove:
+                self.remove_nodes(nodes_to_remove)
+
+        graph_input.type.tensor_type.elem_type = int(new_type)
+        return new_cast_node
+
     def change_graph_inputs_to_int32(self):
-        """Change graph input type to int32, and add Cast node if needed.
+        """Change data type of all graph inputs to int32 type, and add Cast node if needed.
         """
         graph = self.graph()
-        has_node_to_remove = False
-        for input in graph.input:
-            if input.type.tensor_type.elem_type != int(TensorProto.INT32):
-                input_name_to_nodes = self.input_name_to_nodes()
-                assert input.name in input_name_to_nodes
-
-                nodes = input_name_to_nodes[input.name]
-                
-                # For children that is not Cast node, insert a Cast node to convert int32 to original data type.
-                nodes_not_cast = [node for node in nodes if node.op_type != 'Cast']
-                if nodes_not_cast:
-                    node_name = self.create_node_name('Cast')
-                    output_name = node_name + '_' + input.name
-                    new_value_info = graph.value_info.add()
-                    new_value_info.CopyFrom(input)
-                    new_value_info.name = output_name
-                    new_node = [helper.make_node('Cast', [input.name], [output_name], to=int(input.type.tensor_type.elem_type), name=node_name)]
-                    graph.node.extend(new_node)
-
-                    for node in nodes_not_cast:
-                        OnnxModel.replace_node_input(node, input.name, output_name)
-
-                # For children that is Cast node, no need to insert Cast.
-                # When the children is Cast to int32, we can remove that Cast node since input type is int32 now.
-                nodes_cast = [node for node in nodes if node.op_type == 'Cast']    
-                for node in nodes_cast:
-                    if OnnxModel.get_node_attribute(node, "to") == int(TensorProto.INT32):
-                        self.replace_input_of_all_nodes(node.output[0], input.name)
-                        has_node_to_remove = True
-
-                input.type.tensor_type.elem_type = int(TensorProto.INT32)
-
-        if has_node_to_remove:
-            self.prune_graph()
+        new_cast_node_count = 0
+        for graph_input in graph.input:
+            new_cast_node = self.change_graph_input_type(graph, graph_input, TensorProto.INT32)
+            if new_cast_node:
+                new_cast_node_count += 1
+        logger.info(f"Graph inputs are changed to int32 and {new_cast_node_count} Cast nodes added.")
 
     def use_dynamic_axes(self, dynamic_batch_dim='batch_size', dynamic_seq_len='max_seq_len'):
         """

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -322,7 +322,7 @@ def main():
         optimizer.convert_float_to_float16(keep_io_types=True)
 
     if args.input_int32:
-        optimizer.change_input_to_int32()
+        optimizer.change_graph_inputs_to_int32()
 
     optimizer.save_model_to_file(args.output, args.use_external_data_format)
 


### PR DESCRIPTION
**Description**:
Previous implementation of --input_int32 is non deterministic. The result will depend on optimization result. For example, when EmbedLayerNormalization is not fused, input_ids will not be changed to int32. That confuses users.

Update the logic to always change graph inputs to int32.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

Related issue: https://github.com/microsoft/onnxruntime/issues/8853