### PR TITLE
Fix an error in Nuget pipeline caused by merge conflict

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -437,7 +437,7 @@ jobs:
     parameters:
       NugetPath: '$(Build.ArtifactStagingDirectory)'
       NugetPackage: 'Microsoft.ML.OnnxRuntime.*nupkg'
-      PlatformsSupported: 'win-x64,win-x86,linux-x64,osx.10.13-x64'
+      PlatformsSupported: 'win-x64,win-x86,linux-x64,osx.10.14-x64'
       VerifyNugetSigning: false
 
   - task: PublishPipelineArtifact@0


### PR DESCRIPTION
**Description**: 

I submitted two PRs: Updating min macOS version from 10.13 to 10.14 and refactoring the Nuget packaging job. I tested them individually, they all passed. But I didn't realized they are related. So I left one place that still refers to 10.13. This PR is to fix that. 

**Motivation and Context**
- Why is this change required? What problem does it solve?



- If it fixes an open issue, please link to the issue here.
