### PR TITLE
Add Einsum and Reciprocal op support in symbolic shape inference

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -826,7 +826,7 @@ class SymbolicShapeInference:
         terms = left_equation.split(b',')
         for term in terms:
             ellipsis_index = term.find(b'...')
-            shape = self._get_sympy_shape(node, num_operands)
+            shape = self._get_shape(node, num_operands)
             rank = len(shape)
             if ellipsis_index != -1:
                 if num_ellipsis == 0:
@@ -834,7 +834,7 @@ class SymbolicShapeInference:
                 num_ellipsis = num_ellipsis + 1
             for i in range(1, rank + 1):
                 letter = term[-i]
-                if letter != b'.':
+                if letter != 46: # letter != b'.'
                     dim = shape[-i]
                     if letter not in letter_to_dim.keys():
                         letter_to_dim[letter] = dim
@@ -852,13 +852,13 @@ class SymbolicShapeInference:
                 for i in range(num_ellipsis_indices):
                     new_sympy_shape.append(shape[i])
             for c in right_equation:
-                if c != b'.':
+                if c != 46: # c != b'.'
                     new_sympy_shape.append(letter_to_dim[c])
         else:
             for i in range(num_ellipsis_indices):
                 new_sympy_shape.append(shape[i])
             for c in left_equation:
-                if c != b',' and c != b'.':
+                if c != 44 and c != 46: # c != b',' and c != b'.':
                     if c in num_letter_occurrences:
                         num_letter_occurrences[c] = num_letter_occurrences[c] + 1
                     else:

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -383,6 +383,7 @@ class SymbolicShapeInference:
             'If', 'Loop', 'Scan', 'SplitToSequence', 'ZipMap', \
             # contrib ops
 
+
             'Attention', 'BiasGelu', \
             'EmbedLayerNormalization', \
             'FastGelu', 'Gelu', 'LayerNormalization', \
@@ -811,7 +812,7 @@ class SymbolicShapeInference:
 
     def _infer_Einsum(self, node):
         # ref:https://github.com/onnx/onnx/blob/623dfaa0151b2e4ce49779c3ec31cbd78c592b80/onnx/defs/math/defs.cc#L3275
-        equation = get_attribute(node, 'equation') 
+        equation = get_attribute(node, 'equation')
         equation = equation.replace(b' ', b'')
         mid_index = equation.find(b'->')
         left_equation = equation[:mid_index] if mid_index != -1 else equation
@@ -819,7 +820,7 @@ class SymbolicShapeInference:
         num_operands = 0
         num_ellipsis = 0
         num_ellipsis_indices = 0
- 
+
         letter_to_dim = {}
 
         terms = left_equation.split(b',')
@@ -839,7 +840,7 @@ class SymbolicShapeInference:
                         letter_to_dim[letter] = dim
                     elif type(dim) != sympy.Symbol:
                         letter_to_dim[letter] = dim
-            num_operands =  num_operands + 1     
+            num_operands = num_operands + 1
 
         new_sympy_shape = []
         from collections import OrderedDict

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -398,11 +398,10 @@ class SymbolicShapeInference:
             # (3) The initializer is not in graph input. The means the node input is "constant" in inference.
             initializers = []
             if (get_opset(self.out_mp_) >= 9) and node.op_type in ['Unsqueeze']:
-                #initializers = [
-                #    self.initializers_[name] for name in node.input
-                #    if (name in self.initializers_ and name not in self.graph_inputs_)
-                #]
-                initializers = []
+                initializers = [
+                    self.initializers_[name] for name in node.input
+                    if (name in self.initializers_ and name not in self.graph_inputs_)
+                ]
 
             # run single node inference with self.known_vi_ shapes
             tmp_graph = helper.make_graph(

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -135,7 +135,6 @@ class SymbolicShapeInference:
             'GatherElements': self._infer_GatherElements,
             'GatherND': self._infer_GatherND,
             'Gelu': self._pass_on_shape_and_type,
-            'GlobalAveragePool': self._infer_GlobalAveragePool,
             'If': self._infer_If,
             'Loop': self._infer_Loop,
             'MatMul': self._infer_MatMul,
@@ -857,15 +856,6 @@ class SymbolicShapeInference:
         vi.CopyFrom(
             helper.make_tensor_value_info(node.output[0], self.known_vi_[node.input[0]].type.tensor_type.elem_type,
                                           new_shape))
-
-    def _infer_GlobalAveragePool(self, node):
-        shape = self._get_shape(node, 0)
-        assert len(shape) == 4
-        shape[2] = 1
-        shape[3] = 1
-        output_dtype = self.known_vi_[node.input[0]].type.tensor_type.elem_type
-        vi = self.known_vi_[node.output[0]]
-        vi.CopyFrom(helper.make_tensor_value_info(node.output[0], output_dtype, shape))
 
     def _infer_If(self, node):
         # special case for constant condition, in case there are mismatching shape from the non-executed branch

--- a/onnxruntime/python/tools/transformers/shape_infer_helper.py
+++ b/onnxruntime/python/tools/transformers/shape_infer_helper.py
@@ -42,6 +42,7 @@ class SymbolicShapeInferenceHelper(SymbolicShapeInference):
     # override _preprocess() to avoid unnecessary model copy since ctor copies the model
     def _preprocess(self, in_mp):
         self.out_mp_ = in_mp
+        self.graph_inputs_ = dict([(i.name, i) for i in list(self.out_mp_.graph.input)])
         self.initializers_ = dict([(i.name, i) for i in self.out_mp_.graph.initializer])
         self.known_vi_ = dict([(i.name, i) for i in list(self.out_mp_.graph.input)])
         self.known_vi_.update(

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -161,6 +161,64 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
         ]
         self._check_shapes(graph, inferred.graph, expected_shapes)
 
+    def _test_einsum_one_input_impl(self, input_0_shape, output_0_shape, eqn):
+        nodes = [
+            helper.make_node("Einsum", ["input_0"], ["output_0"], "einsum_0", equation=eqn),
+        ]
+        inputs = [
+            helper.make_tensor_value_info('input_0', TensorProto.FLOAT, input_0_shape),
+        ]
+        outputs = [
+            helper.make_tensor_value_info('output_0', TensorProto.FLOAT, None),
+        ]
+        graph = helper.make_graph(nodes, "Einsum_Test", inputs, outputs, [])
+        model = helper.make_model(graph)
+
+        inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
+        expected_shapes = [
+            helper.make_tensor_value_info('output_0', TensorProto.FLOAT, output_0_shape)
+        ]
+        self._check_shapes(graph, inferred.graph, expected_shapes)
+
+    def _test_einsum_two_inputs_impl(self, input_0_shape, input_1_shape, output_0_shape, eqn):
+        nodes = [
+            helper.make_node("Einsum", ["input_0", "input_1"], ["output_0"], "einsum_0", equation=eqn),
+        ]
+        inputs = [
+            helper.make_tensor_value_info('input_0', TensorProto.FLOAT, input_0_shape),
+            helper.make_tensor_value_info('input_1', TensorProto.FLOAT, input_1_shape),
+        ]
+        outputs = [
+            helper.make_tensor_value_info('output_0', TensorProto.FLOAT, None),
+        ]
+        graph = helper.make_graph(nodes, "Einsum_Test", inputs, outputs, [])
+        model = helper.make_model(graph)
+
+        inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
+        expected_shapes = [
+            helper.make_tensor_value_info('output_0', TensorProto.FLOAT, output_0_shape)
+        ]
+        self._check_shapes(graph, inferred.graph, expected_shapes)
+
+    def test_einsum_matmul(self):
+        self._test_einsum_two_inputs_impl([1, 'b', 8], [2, 12, 'n'], [1, 'b', 12, 'n'], "abc, cde -> abde")
+
+    def test_einsum_batch_matmul(self):
+        self._test_einsum_two_inputs_impl([5, 2, 3], [5, 3, 4], [5, 2, 4], "bij, bjk -> bik")
+
+    def test_einsum_inner_prod(self):
+        self._test_einsum_two_inputs_impl([5], [5], [], "i, i")
+
+    def test_einsum_batch_diagonal(self):
+       self._test_einsum_one_input_impl([3, 5, 5], [3, 5], "...ii ->...i")
+
+    def test_einsum_sum(self):
+        self._test_einsum_one_input_impl(['a', 'b'], ['a'], "ij -> i")
+
+    def test_einsum_transpose(self):
+        self._test_einsum_one_input_impl(['a', 'b'], ['b', 'a'], "ij -> ji")
+        
+
 class TestSymbolicShapeInferenceForSlice(unittest.TestCase):
     def check_slice_of_concat(self, input_dims, start, end, step, expected_output_dim):
         _dimstrmap = {dim: f"dim{i}" for i, dim in enumerate(input_dims)}


### PR DESCRIPTION
**Description**: Describe your changes.
fix a bug in shape_infer_helper.py
add support for reciprocal, einsum op

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
the failure occurred in notebook: https://github.com/microsoft/onnxruntime/pull/8898