### PR TITLE
Trim MakeStringImpl binary size for C++17

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1472,6 +1472,9 @@ if (onnxruntime_USE_CUDA)
   else()
     #CUDA 10.2 on Linux doesn't support C++17
     set(CMAKE_CUDA_STANDARD 14)
+    # set a project wide compile definition to select a pre-C++17 implementation
+    # TODO get rid of this when we build everything with C++17 or greater
+    add_compile_definitions(ORT_USE_PRE_CXX17_IMPL)
   endif()
   file(TO_CMAKE_PATH ${onnxruntime_CUDNN_HOME} onnxruntime_CUDNN_HOME)
   set(ONNXRUNTIME_CUDA_LIBRARIES ${CUDA_LIBRARIES})

--- a/include/onnxruntime/core/common/make_string.h
+++ b/include/onnxruntime/core/common/make_string.h
@@ -28,7 +28,9 @@ namespace detail {
 inline void MakeStringImpl(std::ostringstream& /*ss*/) noexcept {
 }
 
-#if 0
+// we get some binary size savings with the C++17 implementation
+#if defined(ORT_USE_PRE_CXX17_IMPL)
+
 template <typename T>
 inline void MakeStringImpl(std::ostringstream& ss, const T& t) noexcept {
   ss << t;
@@ -39,12 +41,15 @@ inline void MakeStringImpl(std::ostringstream& ss, const T& t, const Args&... ar
   MakeStringImpl(ss, t);
   MakeStringImpl(ss, args...);
 }
+
 #else
+
 template <typename... Args>
 inline void MakeStringImpl(std::ostringstream& ss, const Args&... args) noexcept {
   (ss << ... << args);
 }
-#endif
+
+#endif  // defined(ORT_USE_PRE_CXX17_IMPL)
 
 // see MakeString comments for explanation of why this is necessary
 template <typename... Args>

--- a/include/onnxruntime/core/common/make_string.h
+++ b/include/onnxruntime/core/common/make_string.h
@@ -28,6 +28,7 @@ namespace detail {
 inline void MakeStringImpl(std::ostringstream& /*ss*/) noexcept {
 }
 
+#if 0
 template <typename T>
 inline void MakeStringImpl(std::ostringstream& ss, const T& t) noexcept {
   ss << t;
@@ -38,6 +39,12 @@ inline void MakeStringImpl(std::ostringstream& ss, const T& t, const Args&... ar
   MakeStringImpl(ss, t);
   MakeStringImpl(ss, args...);
 }
+#else
+template <typename... Args>
+inline void MakeStringImpl(std::ostringstream& ss, const Args&... args) noexcept {
+  (ss << ... << args);
+}
+#endif
 
 // see MakeString comments for explanation of why this is necessary
 template <typename... Args>


### PR DESCRIPTION
**Description**
Add C++17 implementation of MakeStringImpl() using a fold expression instead of recursive template functions. Keep old implementation since some builds still require pre-C++17 compatibility.

**Motivation and Context**
Decrease binary size.
