### PR TITLE
preparing release 1.9.0 to target torch182, and remove torch181 support

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-torch182-cuda102.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-torch182-cuda102.yml
@@ -4,7 +4,7 @@ stages:
 - template: templates/py-packaging-training-cuda-stage.yml
   parameters:
     build_py_parameters: --enable_training --update --build
-    torch_version: '1.8.1'
+    torch_version: '1.8.2'
     cuda_version: '10.2'
     gcc_version: 8
     cmake_cuda_architectures: 35;37;50;52;60;61;70

--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-torch182-cuda111.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-torch182-cuda111.yml
@@ -4,7 +4,7 @@ stages:
 - template: templates/py-packaging-training-cuda-stage.yml
   parameters:
     build_py_parameters: --enable_training --update --build
-    torch_version: '1.8.1'
+    torch_version: '1.8.2'
     cuda_version: '11.1'
     gcc_version: 9
     cmake_cuda_architectures: 37;50;52;60;61;70;75;80

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.8.1_cu10.2.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.8.1_cu10.2.txt
@@ -1,6 +1,0 @@
---pre
--f https://download.pytorch.org/whl/torch_stable.html
-torch==1.8.1+cu102
-torchvision==0.9.1+cu102
-torchtext==0.9.1
-setuptools>=41.4.0

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.8.1_cu11.1.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.8.1_cu11.1.txt
@@ -1,6 +1,0 @@
---pre
--f https://download.pytorch.org/whl/torch_stable.html
-torch==1.8.1+cu111
-torchvision==0.9.1+cu111
-torchtext==0.9.1
-setuptools>=41.4.0

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.8.2_cu10.2.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.8.2_cu10.2.txt
@@ -1,0 +1,6 @@
+--pre
+-f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+torch==1.8.2+cu102
+torchvision==0.9.2+cu102
+torchtext==0.9.2
+setuptools>=41.4.0

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.8.2_cu11.1.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.8.2_cu11.1.txt
@@ -1,0 +1,6 @@
+--pre
+-f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+torch==1.8.2+cu111
+torchvision==0.9.2+cu111
+torchtext==0.9.2
+setuptools>=41.4.0


### PR DESCRIPTION
**Description**: torch LTS version is 1.8.2. we will support torch 1.8.2 in onnxruntime-training 1.9.0 release 
