### PR TITLE
Remove onnxruntime team from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,3 @@
-* @Microsoft/onnxruntime
-
 # Python frontend owners
 orttraining/*.py @thiagocrepaldi @tlh20 @BowenBao @liqunfu @baijumeswani @SherlockNoMad
 orttraining/orttraining/python/** @thiagocrepaldi @tlh20 @BowenBao @liqunfu @baijumeswani @SherlockNoMad


### PR DESCRIPTION
There are currently 98 members in the team. Requesting review from
all of them for every PR is too noisy. Individuals can subscribe to the
repo if they want to receive notifications for every PR.
