### PR TITLE
CUDA: Enable parallel compilation

### DIFF
--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -340,6 +340,11 @@ if (onnxruntime_USE_CUDA)
   foreach(ORT_FLAG ${ORT_WARNING_FLAGS})
       target_compile_options(onnxruntime_providers_cuda PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler \"${ORT_FLAG}\">")
   endforeach()
+  # CUDA 11.3+ supports parallel compilation
+  # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-guiding-compiler-driver-threads
+  if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.3)
+    target_compile_options(onnxruntime_providers_cuda PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--threads \"${onnxruntime_PARALLEL}\">")
+  endif()
   if (onnxruntime_DEV_MODE)
 	  if (UNIX)
 		target_compile_options(onnxruntime_providers_cuda PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wno-reorder>"

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -140,7 +140,7 @@ def parse_arguments():
         help="Configuration(s) to build.")
     parser.add_argument(
         "--update", action='store_true', help="Update makefiles.")
-    parser.add_argument("--build", action='store_true', help="Build.")
+    parser.add_argument("--build", action='store_true', help="Build.")g
     parser.add_argument(
         "--clean", action='store_true',
         help="Run 'cmake --build --target clean' for the selected config/s.")
@@ -800,6 +800,7 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
         "-Donnxruntime_ENABLE_EAGER_MODE=" + ("ON" if args.build_eager_mode else "OFF"),
         "-Donnxruntime_ENABLE_EXTERNAL_CUSTOM_OP_SCHEMAS=" + ("ON" if args.enable_external_custom_op_schemas
                                                               else "OFF"),
+        "-Donnxruntime_PARALLEL=" + args.parallel,
     ]
     # It should be default ON in CI build pipelines, and OFF in packaging pipelines.
     # And OFF for the people who are not actively developing onnx runtime.


### PR DESCRIPTION
This PR enables parallel compilation for CUDA. The already existing `--parallel <0-n>` option is passed on to nvcc as `--threads <0-n>`.

This feature is available starting with CUDA 11.3: https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-guiding-compiler-driver-threads

**Motivation and Context**
- This option cuts down the compilation time quite heavily when compiling for multiple architectures. On my machine, I am seeing around 25-50% faster build times when building for `CMAKE_CUDA_ARCHITECTURES=50;52;60;70;80`.
- The option is passed through as `onnxruntime_PARALLEL` without making any assumptions (e.g. `parallel=0 == os.cpu_count()`) to make it reusable for other EPs down the line.
