### PR TITLE
[js/web] fix karma launch with chrome headless

### DIFF
--- a/js/web/karma.conf.js
+++ b/js/web/karma.conf.js
@@ -77,7 +77,7 @@ module.exports = function (config) {
     browserSocketTimeout: 60000,
     hostname: getMachineIpAddress(),
     customLaunchers: {
-      ChromeTest: { base: 'Chrome', flags: ['--window-size=1,1', '--enable-features=SharedArrayBuffer'] },
+      ChromeTest: { base: 'ChromeHeadless', flags: ['--window-size=1,1', '--enable-features=SharedArrayBuffer'] },
       ChromeDebug: { debug: true, base: 'Chrome', flags: ['--remote-debugging-port=9333', '--enable-features=SharedArrayBuffer'] },
 
       //

--- a/tools/ci_build/github/azure-pipelines/win-wasm-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-wasm-ci-pipeline.yml
@@ -219,7 +219,7 @@ jobs:
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Run ort-web tests - unpacked mode'
   - script: |
-     npm test --  --webgl-texture-pack-mode -b=webgl
+     npm test -- --webgl-texture-pack-mode -b=webgl
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Run ort-web tests - packed mode'
   - script: |


### PR DESCRIPTION
**Description**: This change fixes ORT Web unittest when using Chrome v93. Change 'Chrome' to 'ChromeHeadless' as a workaround described in https://stackoverflow.com/questions/69042794/karma-fails-to-capture-chrome-v93-and-times-out-gives-up/.