### PR TITLE
Update cross_entropy_loss symbolic for new argument from upstream torch update

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_custom_op_symbolic_registry.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_op_symbolic_registry.py
@@ -30,8 +30,12 @@ def register_symbolic(name, domain=''):
 
 
 @register_symbolic('cross_entropy_loss')
-@parse_args('v', 'v', 'v', 'i', 'v')
-def cross_entropy_loss(g, self, target, weight, reduction, ignore_index):
+@parse_args('v', 'v', 'v', 'i', 'v', 'v')
+def cross_entropy_loss(g, self, target, weight, reduction, ignore_index, label_smoothing=0.0):
+    label_smoothing = sym_help._maybe_get_const(label_smoothing, "f")
+    if label_smoothing > 0.0:
+        raise RuntimeError("Unsupported: ONNX does not support label_smoothing")
+
     # reduction: 0->none, 1->mean, 2->sum
     reduction = sym_help._maybe_get_const(reduction, 'i')
     reduction_vals = ['none', 'mean', 'sum']


### PR DESCRIPTION
In torch 1.10, `label_smoothing` is added as additional input to `cross_entropy_loss`. Update the symbolic function to handle this change.