### PR TITLE
Disable fallback for ortmodule api tests

### DIFF
--- a/orttraining/orttraining/test/python/_test_helpers.py
+++ b/orttraining/orttraining/test/python/_test_helpers.py
@@ -27,6 +27,9 @@ def is_all_or_nothing_fallback_enabled(model, policy=None):
     from onnxruntime.training.ortmodule import ORTMODULE_FALLBACK_POLICY
     from onnxruntime.training.ortmodule._fallback import _FallbackPolicy
 
+    if os.getenv('ORTMODULE_FALLBACK_POLICY') == 'FALLBACK_DISABLE':
+        return False
+
     if not policy:
         policy = _FallbackPolicy.FALLBACK_DISABLE
 

--- a/orttraining/orttraining/test/python/_test_helpers.py
+++ b/orttraining/orttraining/test/python/_test_helpers.py
@@ -27,7 +27,7 @@ def is_all_or_nothing_fallback_enabled(model, policy=None):
     from onnxruntime.training.ortmodule import ORTMODULE_FALLBACK_POLICY
     from onnxruntime.training.ortmodule._fallback import _FallbackPolicy
 
-    if os.getenv('ORTMODULE_FALLBACK_POLICY') == 'FALLBACK_DISABLE':
+    if os.getenv('ORTMODULE_FALLBACK_POLICY') == _FallbackPolicy.FALLBACK_DISABLE.name:
         return False
 
     if not policy:


### PR DESCRIPTION
This pull request disables fallback for the ortmodule api tests as these tests were intended to be run without fallback.