### PR TITLE
Increase timeouts for Mac CI builds.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
@@ -4,7 +4,7 @@ jobs:
     vmImage: 'macOS-10.15'
   variables:
     MACOSX_DEPLOYMENT_TARGET: '10.14'
-  timeoutInMinutes: 120
+  timeoutInMinutes: 150
   steps:
     - script: |
         python3 $(Build.SourcesDirectory)/tools/ci_build/build.py \

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -13,7 +13,7 @@ jobs:
 - job: ${{ parameters.JobName }}
   workspace:
     clean: all
-  timeoutInMinutes:  120
+  timeoutInMinutes:  150
   pool:
     vmImage: 'macOS-10.15'
   variables:


### PR DESCRIPTION
**Description**
Increase timeouts for "orttraining-mac-ci-pipeline" and "iOS CI Pipeline" CI builds.

**Motivation and Context**
Build failures due to timeout are not uncommon for these two builds.