### PR TITLE
fix cpuinfo compilation flag usage

### DIFF
--- a/onnxruntime/core/common/cpuid_info.cc
+++ b/onnxruntime/core/common/cpuid_info.cc
@@ -95,7 +95,7 @@ CPUIDInfo::CPUIDInfo() {
     }
 #endif
 
-#if defined(CPUIDINFO_ARCH_ARM) && defined(CPUINFO_INCLUDED)
+#if defined(CPUIDINFO_ARCH_ARM) && defined(CPUINFO_SUPPORTED)
 
     // only works on ARM linux or android, does not work on Windows
     is_hybrid_ = cpuinfo_get_uarchs_count() > 1;


### PR DESCRIPTION
Bug was introduced from PR https://github.com/microsoft/onnxruntime/pull/8716

When restricting cpuinfo to only known platforms, compilation flag change was not thorough, which accidentally turned off hybrid core detection for ARM systems.

This PR fixes this bug