### PR TITLE
Fix cmake POWER10 detection

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -299,7 +299,7 @@ else()
               HAS_P10_RUNTIME
             )
             if (HAS_P10_RUNTIME)
-              set_source_files_properties(${mlas_common_srcs} PROPERTIES COMPILE_FLAGS "-DPOWER10")
+              set_source_files_properties(${MLAS_SRC_DIR}/platform.cpp PROPERTIES COMPILE_FLAGS "-DPOWER10")
             endif()
             set(mlas_platform_srcs_power10
               ${MLAS_SRC_DIR}/power/SgemmKernelPOWER10.cpp


### PR DESCRIPTION
Recent commit 60c98a8 changed variable mlas_common_srcs which affects
POWER10 detection.


