### PR TITLE
Fix Where op type reduction processing

### DIFF
--- a/onnxruntime/core/providers/op_kernel_type_control.h
+++ b/onnxruntime/core/providers/op_kernel_type_control.h
@@ -3,15 +3,10 @@
 
 #pragma once
 
-#include <cstdint>
-#include <tuple>
-
 #include "boost/mp11.hpp"
 
 #include "core/common/type_list.h"
 #include "core/common/type_set_utils.h"
-
-#include "core/framework/data_types.h"
 
 /**
  * These utilities provide a way to control what types are enabled for an Op kernel implementation.
@@ -470,6 +465,11 @@ struct EnabledTypes {
  * // use MLTypeCallDispatcher to dispatch to implementations for enabled types
  * using Dispatcher = onnxruntime::utils::MLTypeCallDispatcherFromTypeList<MyOpFirstInputEnabledTypes>;
  */
+
+// includes for types that might be used in type specifications
+#include <cstdint>
+#include <string>
+#include "core/framework/float16.h"
 
 // all allowed type specifications should be contained in the following file
 #include "core/providers/op_kernel_type_control_overrides.inc"

--- a/onnxruntime/core/providers/op_kernel_type_control.h
+++ b/onnxruntime/core/providers/op_kernel_type_control.h
@@ -466,10 +466,7 @@ struct EnabledTypes {
  * using Dispatcher = onnxruntime::utils::MLTypeCallDispatcherFromTypeList<MyOpFirstInputEnabledTypes>;
  */
 
-// includes for types that might be used in type specifications
-#include <cstdint>
-#include <string>
-#include "core/framework/float16.h"
+#include "core/framework/data_types.h"  // for types that might be used in type specifications
 
 // all allowed type specifications should be contained in the following file
 #include "core/providers/op_kernel_type_control_overrides.inc"

--- a/tools/python/util/ort_format_model/operator_type_usage_processors.py
+++ b/tools/python/util/ort_format_model/operator_type_usage_processors.py
@@ -240,6 +240,19 @@ class DefaultTypeUsageProcessor(TypeUsageProcessor):
                 self._output_types[int(o_str)] = set(values)
 
 
+class Input1TypedRegistrationProcessor(DefaultTypeUsageProcessor):
+    '''
+    Processor for operators where the second input type is used in a typed kernel registration.
+    '''
+    def __init__(self, domain: str, optype: str):
+        # init with tracking of input 1 only.
+        super().__init__(domain, optype, inputs=[1], outputs=[])
+
+    def is_typed_registration_needed(self, type_in_registration: str,
+                                     globally_allowed_types: typing.Optional[typing.Set[str]]):
+        return self.is_input_type_enabled(type_in_registration, 1, globally_allowed_types)
+
+
 class Output0TypedRegistrationProcessor(DefaultTypeUsageProcessor):
     '''
     Processor for operators where the first output type is used in a typed kernel registration.
@@ -339,8 +352,7 @@ def _create_operator_type_usage_processors():
                                   'Scatter', 'ScatterElements', 'ScatterND', 'Shrink', 'Sigmoid', 'Sign', 'Sin',
                                   'Softmax', 'Split', 'SplitToSequence', 'Sqrt', 'Sum',
                                   'Tanh', 'TopK', 'Transpose',
-                                  'Unique',
-                                  'Where']
+                                  'Unique']
 
     # ops that are used to manipulate shapes or indices so require int32_t and int64_t to be available
     default_processor_onnx_ops_requiring_ints_for_input_0 = ['Add',
@@ -391,6 +403,9 @@ def _create_operator_type_usage_processors():
     # Random generator ops produce new data so we track the output type
     onnx_random_ops = ['RandomNormal', 'RandomNormalLike', 'RandomUniform', 'RandomUniformLike', 'Multinomial']
     [add(DefaultTypeUsageProcessor('ai.onnx', op, inputs=[], outputs=[0])) for op in onnx_random_ops]
+
+    # Where always has a boolean first input so track the second input type for typed registration
+    add(Input1TypedRegistrationProcessor('ai.onnx', 'Where'))
 
     # we only support 'float' as input for [Dynamic]QuantizeLinear so just track the output type
     # as that's what is used in the typed registration


### PR DESCRIPTION
**Description**
The Where op's first parameter is always boolean, so we should track the type of the remaining parameters for type reduction. The default op type reduction processing considers the first parameter.

In this change:
- Track Where's second input type instead of the first
- Some other clean up

**Motivation and Context**
Fix issue where the wrong input was being matched when excluding typed kernel implementations.
