### PR TITLE
Disable FastGelu Half2 Kernel by default

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/fast_gelu.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/fast_gelu.cc
@@ -34,7 +34,7 @@ using namespace ONNX_NAMESPACE;
 template <typename T>
 FastGelu<T>::FastGelu(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info) {
   const TransformerOptions* options = TransformerOptions::GetInstance();
-  use_half2_ = !options->DisableHalf2();
+  use_half2_ = options->EnableHalf2();
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cuda/bert/transformer_common.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/transformer_common.cc
@@ -25,7 +25,7 @@ const TransformerOptions* TransformerOptions::GetInstance() {
     if (value > 0)
       std::cout << "ORT_TRANSFORMER_OPTIONS: IsPrecisionMode=" << instance.IsPrecisionMode()
                 << ",DisablePersistentSoftmax=" << instance.DisablePersistentSoftmax()
-                << ",DisableHalf2=" << instance.DisableHalf2()
+                << ",EnableHalf2=" << instance.EnableHalf2()
                 << std::endl;
   }
 

--- a/onnxruntime/contrib_ops/cuda/bert/transformer_common.h
+++ b/onnxruntime/contrib_ops/cuda/bert/transformer_common.h
@@ -15,12 +15,12 @@ class TransformerOptions {
 
   bool DisablePersistentSoftmax() const { return disable_persistent_softmax_; }
 
-  bool DisableHalf2() const { return disable_half2_; }
+  bool EnableHalf2() const { return enable_half2_; }
 
   void Initialize(int value) {
     is_precision_mode_ = (value & 0x01) > 0;
     disable_persistent_softmax_ = (value & 0x02) > 0;
-    disable_half2_ = (value & 0x04) > 0;
+    enable_half2_ = (value & 0x04) > 0;
     initialized_ = true;
   }
 
@@ -31,8 +31,8 @@ class TransformerOptions {
   // Disable persistent softmax.
   bool disable_persistent_softmax_{false};
 
-  // Disable half2 kernel.
-  bool disable_half2_{false};
+  // Enable half2 kernel.
+  bool enable_half2_{false};
 
   bool initialized_{false};
 


### PR DESCRIPTION
**Description**:

FastGelu is widely used in GPT-2 model.  Its half2 kernel has negative impact on accuracy (top 1 mis-match rate 1.6% => 1.9%). Disable it by default. The impact on performance is small (< 0.1ms) for  GPT-2 model with 12 layer 768 hidden.

Option | average_latency (ms) | diff_50_percentile | diff_90_percentile | diff_95_percentile | diff_99_percentile | top1_match_rate
-- | -- | -- | -- | -- | -- | --
Baseline | 7.50 | 0.36256 | 1.2940 | 1.92666 | 5.23579 | 0.981
Disable Half2 | 7.58 | 0.36424 | 1.3632 | 1.99048 | 5.27358 | 0.984

The above test results are from T4 GPU like the following:
```
export ORT_CUDA_GEMM_OPTIONS=0
python gpt2_parity.py -m gpt2 --csv gpt2_parity.csv --runs 5 --use_gpu

export ORT_TRANSFORMER_OPTIONS=4
python gpt2_parity.py -m gpt2 --csv gpt2_parity.csv --runs 5 --use_gpu
```
**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.