### PR TITLE
Add full iOS job in package pipeline

### DIFF
--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -324,8 +324,8 @@ class PlannerImpl {
 
     const optional<std::pair<int, int>>& variadic_alias_offsets = ci.kernel_def->VariadicAlias();
     if (variadic_alias_offsets.has_value()) {
-      int input_offset = variadic_alias_offsets.value().first;
-      int output_offset = variadic_alias_offsets.value().second;
+      int input_offset = variadic_alias_offsets->first;
+      int output_offset = variadic_alias_offsets->second;
       // we _must_ reuse this input to satisfy aliasing requirement: (e.g., for AllReduce)
       int alias_input_index = output_arg_num - output_offset + input_offset;
       if (alias_input_index >= 0 && static_cast<size_t>(alias_input_index) < input_args.size()) {

--- a/onnxruntime/core/framework/config_options.cc
+++ b/onnxruntime/core/framework/config_options.cc
@@ -17,7 +17,7 @@ bool ConfigOptions::TryGetConfigEntry(const std::string& config_key, std::string
   auto entry = GetConfigEntry(config_key);
   const bool found = entry.has_value();
   if (found) {
-    config_value = std::move(entry.value());
+    config_value = std::move(*entry);
   }
   return found;
 }

--- a/onnxruntime/core/optimizer/matmul_scale_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_scale_fusion.cc
@@ -76,7 +76,7 @@ optional<std::pair<float, int>> GetScaleFromNode(
 
     if (!divisor.has_value()) return {};
 
-    return {std::make_pair(1.0f / divisor.value(), scale_reciprocal_arg_index)};
+    return {std::make_pair(1.0f / *divisor, scale_reciprocal_arg_index)};
   }
 
   if (graph_utils::IsSupportedOptypeVersionAndDomain(scale_node, "Mul", {7, 13, 14})) {
@@ -93,7 +93,7 @@ optional<std::pair<float, int>> GetScaleFromNode(
 
       if (!multiplier.has_value()) continue;
 
-      return {std::make_pair(multiplier.value(), scale_arg_index)};
+      return {std::make_pair(*multiplier, scale_arg_index)};
     }
 
     return {};
@@ -128,12 +128,12 @@ std::vector<ScaleMergeInfo> GetInputNodeMerges(
     if (!scale_and_index.has_value()) continue;
 
     // assume scale nodes have 2 input defs, so to_scale_index == 1 - scale_index
-    ORT_ENFORCE(input_node.InputDefs().size() == 2 && scale_and_index.value().second < 2);
-    const int to_scale_index = 1 - scale_and_index.value().second;
+    ORT_ENFORCE(input_node.InputDefs().size() == 2 && scale_and_index->second < 2);
+    const int to_scale_index = 1 - scale_and_index->second;
 
     input_node_merges.push_back(
         {input_edge,
-         scale_and_index.value().first,
+         scale_and_index->first,
          to_scale_index,
          input_edge->GetDstArgIndex()});
   }
@@ -160,7 +160,7 @@ std::vector<ScaleMergeInfo> GetOutputNodeMerges(
 
     output_node_merges.push_back(
         {output_edge,
-         scale_and_index.value().first,
+         scale_and_index->first,
          scaled_index,
          output_edge->GetSrcArgIndex()});
   }

--- a/onnxruntime/core/platform/env_var_utils.h
+++ b/onnxruntime/core/platform/env_var_utils.h
@@ -38,7 +38,7 @@ template <typename T>
 T ParseEnvironmentVariableWithDefault(const std::string& name, const T& default_value) {
   const auto parsed = ParseEnvironmentVariable<T>(name);
   if (parsed.has_value()) {
-    return parsed.value();
+    return *parsed;
   }
 
   return default_value;

--- a/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
@@ -43,13 +43,13 @@ TensorOpCost ParallelReduceFastCost(int64_t n_row, int64_t n_col, int64_t elemen
   This only improves reduce function when reduced axes are contiguous:
   if len(shape) == 4, any single axis is ok, axes=(0, 1) or (1, 2) or (2, 3) is ok,
   axes=(0, 2) is not covered by this change, former implementation prevails.
-  In that case, the shape can be compressed into three cases: 
+  In that case, the shape can be compressed into three cases:
   (K = axis not reduced, R = reduced axis):
 
   *  KR - reduction on the last dimensions
   *  RK - reduction on the first dimensions
   *  KRK - reduction on the middle dimensions.
-   
+
   For these three configuration, the reduction may be optimized
   with vectors operations. Method WhichFastReduce() returns which case
   case be optimized for which aggregator.
@@ -630,7 +630,7 @@ class ReduceKernelBase {
     }
     int64_t keepdims = 1;
     if (keepdims_override.has_value()) {
-      keepdims = keepdims_override.value();
+      keepdims = *keepdims_override;
     } else {
       ORT_ENFORCE(info.GetAttr("keepdims", &keepdims).IsOK());
     }

--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.cc
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.cc
@@ -96,7 +96,6 @@ ApplicableMatrixReduction get_applicable_matrix_reduction(
     return ApplicableMatrixReduction::None;
   }
 
-
   // Remove all dims with value 1. This can help to optimize case like:
   // dims=[2,3,1,4,1,5] and axes=[0,2,4], which is same as dims=[2,3,4,5] and axes=[0].
   std::vector<int64_t> new_dims;
@@ -136,8 +135,8 @@ ApplicableMatrixReduction get_applicable_matrix_reduction(
     return ApplicableMatrixReduction::None;
   }
 
-  const auto& min_axis = min_and_max_axes.value().first;
-  const auto& max_axis = min_and_max_axes.value().second;
+  const auto& min_axis = min_and_max_axes->first;
+  const auto& max_axis = min_and_max_axes->second;
 
   // axes from beginning means row reduction, axes to end means column reduction
   // for axes from beginning to end, either works and we do row reduction

--- a/onnxruntime/test/common/path_test.cc
+++ b/onnxruntime/test/common/path_test.cc
@@ -229,7 +229,7 @@ TEST(PathTest, Concat) {
       [](const optional<std::string>& a, const std::string& b, const std::string& expected_a, bool expect_throw = false) {
         Path p_a{}, p_expected_a{};
         if (a.has_value()) {
-          ASSERT_STATUS_OK(Path::Parse(ToPathString(a.value()), p_a));
+          ASSERT_STATUS_OK(Path::Parse(ToPathString(*a), p_a));
         }
         ASSERT_STATUS_OK(Path::Parse(ToPathString(expected_a), p_expected_a));
 

--- a/onnxruntime/test/common/tensor_op_test_utils.cc
+++ b/onnxruntime/test/common/tensor_op_test_utils.cc
@@ -9,7 +9,7 @@ namespace test {
 
 RandomValueGenerator::RandomValueGenerator(optional<RandomSeedType> seed)
     : random_seed_{
-          seed.has_value() ? seed.value() : static_cast<RandomSeedType>(GetTestRandomSeed())},
+          seed.has_value() ? *seed : static_cast<RandomSeedType>(GetTestRandomSeed())},
       generator_{random_seed_},
       output_trace_{__FILE__, __LINE__, "ORT test random seed: " + std::to_string(random_seed_)} {
 }

--- a/onnxruntime/test/contrib_ops/layer_norm_test.cc
+++ b/onnxruntime/test/contrib_ops/layer_norm_test.cc
@@ -48,7 +48,7 @@ static void TestLayerNorm(const std::vector<int64_t>& x_dims,
   test.AddAttribute("axis", axis);
   test.AddAttribute("keep_dims", keep_dims);
   if (epsilon.has_value()) {
-    test.AddAttribute("epsilon", epsilon.value());
+    test.AddAttribute("epsilon", *epsilon);
   }
 
   // create rand inputs

--- a/onnxruntime/test/providers/cpu/nn/batch_norm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/batch_norm_op_test.cc
@@ -30,7 +30,7 @@ void TestBatchNorm(const unordered_map<string, vector<T>>& input_data_map,
                    int opset_version = 9) {
   OpTester test("BatchNormalization", opset_version);
   if (epsilon.has_value()) {
-    test.AddAttribute("epsilon", epsilon.value());
+    test.AddAttribute("epsilon", *epsilon);
   }
   if (opset_version < 9) {  // spatial is only defined for opset-8 and below in the spec
     test.AddAttribute("spatial", spatial_mode);

--- a/onnxruntime/test/providers/provider_test_utils.cc
+++ b/onnxruntime/test/providers/provider_test_utils.cc
@@ -117,13 +117,13 @@ struct TensorCheck<uint8_t> {
     // For any other EPs, we still expect an exact match for the results
     if (provider_type == kNnapiExecutionProvider && (has_abs_err || has_rel_err)) {
       double threshold = has_abs_err
-                             ? params.absolute_error_.value()
+                             ? *(params.absolute_error_)
                              : 0.0;
 
       for (int i = 0; i < size; ++i) {
         if (has_rel_err) {
           EXPECT_NEAR(expected[i], output[i],
-                      params.relative_error_.value() * expected[i])  // expected[i] is unsigned, can't be negative
+                      *(params.relative_error_) * expected[i])  // expected[i] is unsigned, can't be negative
               << "i:" << i << ", provider_type: " << provider_type;
         } else {  // has_abs_err
           EXPECT_NEAR(expected[i], output[i], threshold)
@@ -184,12 +184,12 @@ struct TensorCheck<double> {
         } else {
           if (has_abs_err) {
             ASSERT_NEAR(expected[i], output[i],
-                        params.absolute_error_.value())
+                        *(params.absolute_error_))
                 << "i:" << i << ", provider_type: " << provider_type;
           }
           if (has_rel_err) {
             ASSERT_NEAR(expected[i], output[i],
-                        params.relative_error_.value() *
+                        *(params.relative_error_) *
                             std::abs(expected[i]))
                 << "i:" << i << ", provider_type: " << provider_type;
           }
@@ -243,12 +243,12 @@ void InternalNumericalCheck(const Tensor& expected_tensor,
       } else {
         if (has_abs_err) {
           ASSERT_NEAR(expected[i], output[i],
-                      params.absolute_error_.value())
+                      *(params.absolute_error_))
               << "i:" << i << ", provider_type: " << provider_type;
         }
         if (has_rel_err) {
           ASSERT_NEAR(expected[i], output[i],
-                      params.relative_error_.value() *
+                      *(params.relative_error_) *
                           std::abs(expected[i]))
               << "i:" << i << ", provider_type: " << provider_type;
         }

--- a/onnxruntime/test/util/scoped_env_vars.cc
+++ b/onnxruntime/test/util/scoped_env_vars.cc
@@ -17,7 +17,7 @@ namespace {
 Status SetEnvironmentVar(const std::string& name, const optional<std::string>& value) {
   if (value.has_value()) {
     ORT_RETURN_IF_NOT(
-        setenv(name.c_str(), value.value().c_str(), 1) == 0,
+        setenv(name.c_str(), value->c_str(), 1) == 0,
         "setenv() failed: ", errno);
   } else {
     ORT_RETURN_IF_NOT(

--- a/onnxruntime/test/util/test_random_seed.cc
+++ b/onnxruntime/test/util/test_random_seed.cc
@@ -15,7 +15,7 @@ RandomSeedType GetTestRandomSeed() {
       ParseEnvironmentVariable<RandomSeedType>(test_random_seed_env_vars::kValue);
   if (fixed_random_seed.has_value()) {
     // use fixed value
-    return fixed_random_seed.value();
+    return *fixed_random_seed;
   }
 
   auto generate_from_time = []() {

--- a/tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
+++ b/tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
@@ -1,0 +1,20 @@
+{
+    "build_osx_archs": {
+        "iphoneos": [
+            "arm64"
+        ],
+        "iphonesimulator": [
+            "arm64",
+            "x86_64"
+        ]
+    },
+    "build_params": [
+        "--ios",
+        "--parallel",
+        "--use_xcode",
+        "--build_apple_framework",
+        "--use_coreml",
+        "--skip_tests",
+        "--apple_deploy_target=11.0"
+    ]
+}

--- a/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
@@ -12,7 +12,7 @@ jobs:
           --ios \
           --ios_sysroot iphonesimulator  \
           --osx_arch x86_64 \
-          --apple_deploy_target 12.1 \
+          --apple_deploy_target 11.0 \
           --use_xcode \
           --config RelWithDebInfo \
           --build_apple_framework \
@@ -25,7 +25,7 @@ jobs:
           --ios \
           --ios_sysroot iphonesimulator  \
           --osx_arch x86_64 \
-          --apple_deploy_target 12.1 \
+          --apple_deploy_target 11.0 \
           --use_xcode \
           --config RelWithDebInfo \
           --build_apple_framework \

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -195,6 +195,11 @@ jobs:
         python3 tools/ci_build/github/apple/build_ios_framework.py \
           --build_dir "$(Build.BinariesDirectory)/ios_framework" \
           tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
+        mkdir $(Build.BinariesDirectory)/artifacts
+        pushd $(Build.BinariesDirectory)/ios_framework/framework_out/
+        zip -vr $(Build.BinariesDirectory)/artifacts/onnxruntime_xcframework.zip onnxruntime.xcframework
+        popd
+      displayName: "Build iOS xcframework"
 
     - script: |
         python3 tools/ci_build/github/apple/test_ios_packages.py \
@@ -205,7 +210,7 @@ jobs:
 
     - task: PublishBuildArtifacts@1
       inputs:
-        pathtoPublish: '$(Build.BinariesDirectory)/ios_framework/framework_out'
+        pathtoPublish: '$(Build.BinariesDirectory)/artifacts'
         artifactName: 'onnxruntime-ios-full-xcframework'
 
 - template: win-ci.yml

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -183,6 +183,31 @@ jobs:
     artifactName: 'onnxruntime-android-full-aar'
     job_name_suffix: 'Full'
 
+- job: iOS_Full_xcframework
+  workspace:
+    clean: all
+  pool:
+    vmImage: 'macOS-10.15'
+  timeoutInMinutes:  180
+  steps:
+    - script: |
+        set -e -x
+        python3 tools/ci_build/github/apple/build_ios_framework.py \
+          --build_dir "$(Build.BinariesDirectory)/ios_framework" \
+          tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
+
+    - script: |
+        python3 tools/ci_build/github/apple/test_ios_packages.py \
+          --fail_if_cocoapods_missing \
+          --framework_info_file "$(Build.BinariesDirectory)/ios_framework/framework_info.json" \
+          --c_framework_dir "$(Build.BinariesDirectory)/ios_framework/framework_out"
+      displayName: "Test iOS framework"
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathtoPublish: '$(Build.BinariesDirectory)/ios_framework/framework_out'
+        artifactName: 'onnxruntime-ios-full-xcframework'
+
 - template: win-ci.yml
   parameters:
     DoCompliance: ${{ parameters.DoCompliance }}


### PR DESCRIPTION
**Description**: Add full Android job in package pipeline

**Motivation and Context**
- Nuget/Xamarin package need onnxruntime full instead of ORT-Moible, add a iOS full xcframework job in the packaging pipeline
- Move the current iOS CI to use iOS 11.0 as target
- `std::optional` does not have `value()` until iOS 12, change the usage from `std::optional::value()` to `*std::optional` in relevant code
- Test run, https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=174116&view=logs&j=511b6d5b-a43c-51a8-3008-242664c9ff2d