### PR TITLE
Fix a problem that Windows GPU and TRT CI build pipelines still use CUDA 11.1 DLLs

### DIFF
--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -6,7 +6,7 @@ jobs:
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
     OnnxRuntimeBuildDirectory: '$(Build.BinariesDirectory)'
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    EnvSetupScript: setup_env_trt.bat
+    EnvSetupScript: setup_env_cuda_11.bat
     buildArch: x64
     setVcvars: true
     BuildConfig: 'RelWithDebInfo'

--- a/tools/ci_build/github/windows/setup_env_cuda_11.bat
+++ b/tools/ci_build/github/windows/setup_env_cuda_11.bat
@@ -1,2 +1,2 @@
-set PATH=C:\azcopy;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1\bin;%PATH%
+set PATH=C:\azcopy;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.4\bin;%PATH%
 set GRADLE_OPTS=-Dorg.gradle.daemon=false

--- a/tools/ci_build/github/windows/setup_env_trt.bat
+++ b/tools/ci_build/github/windows/setup_env_trt.bat
@@ -1,2 +1,0 @@
-set PATH=C:\azcopy;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1\bin;C:\local\cudnn-11.4-windows-x64-v8.2.2.26\cuda\bin;%PATH%
-set GRADLE_OPTS=-Dorg.gradle.daemon=false


### PR DESCRIPTION
**Description**:

Fix a problem that Windows GPU CI build still use CUDA 11.1 DLLs

The bat file I'm modifying is solely for C# tests.  We need one for TRT if we run C# tests with TRT. But it seems not?
**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
