### PR TITLE
Add t-test to compare experiments in GPT-2 mixed precision conversion

### DIFF
--- a/onnxruntime/python/tools/transformers/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/convert_to_onnx.py
@@ -92,14 +92,22 @@ def parse_arguments(argv=None):
         type=Precision,
         default=Precision.FLOAT32,
         choices=list(Precision),
-        help="Precision of model to run. fp32 for full precision, fp16 for half precision, and int8 for quantization")
+        help=
+        "Precision of model to run. fp32 for full precision, fp16 for half or mixed precision, and int8 for quantization"
+    )
 
     parser.add_argument("-t",
                         "--test_cases",
                         required=False,
                         type=int,
                         default=1000,
-                        help="Number of test cases for parity")
+                        help="Number of test cases per run for parity")
+    parser.add_argument("-r",
+                        "--test_runs",
+                        required=False,
+                        type=int,
+                        default=10,
+                        help="Number of runs for parity. It is used for significance test.")
 
     parser.add_argument('--verbose', required=False, action='store_true')
     parser.set_defaults(verbose=False)
@@ -180,6 +188,13 @@ def parse_arguments(argv=None):
     return args
 
 
+def get_onnx_model_size(onnx_path: str, use_external_data_format: bool):
+    if not use_external_data_format:
+        return os.path.getsize(onnx_path)
+    else:
+        return sum([f.stat().st_size for f in Path(onnx_path).parent.rglob('*')])
+
+
 def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_results.csv"):
     result = {}
     from transformers import __version__ as transformers_version
@@ -216,6 +231,8 @@ def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_resu
         assert not args.output.endswith('.onnx'), "output shall be a directory for --use_external_data_format"
 
     model_class = MODEL_CLASSES[args.model_class][0]
+    use_padding = MODEL_CLASSES[args.model_class][2]
+
     if args.model_class == "GPT2LMHeadModel_BeamSearchStep":
         model_type = "beam_search_step"
     elif args.model_class == "GPT2LMHeadModel_ConfigurableOneStepSearch":
@@ -255,23 +272,26 @@ def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_resu
     if (not args.use_external_data_format) and (config.n_layer > 24):
         logger.info(f"Try --use_external_data_format when model size > 2GB")
 
-    onnx_model_paths = gpt2helper.get_onnx_paths(output_dir,
-                                                 args.model_name_or_path,
-                                                 args.model_class,
-                                                 new_folder=args.use_external_data_format)
+    onnx_model_paths = gpt2helper.get_onnx_paths(
+        output_dir,
+        args.model_name_or_path,
+        args.model_class,
+        new_folder=args.use_external_data_format,
+        remove_existing=["fp32", "fp16", "int8"])  # Do not remove raw model to save time in parity test
 
     raw_onnx_model = onnx_model_paths["raw"]
 
-    logger.info(f"Exporting ONNX model to {raw_onnx_model}")
-    use_padding = MODEL_CLASSES[args.model_class][2]
-
-    gpt2helper.export_onnx(model,
-                           device,
-                           raw_onnx_model,
-                           args.verbose,
-                           args.use_external_data_format,
-                           has_position_ids=use_padding,
-                           has_attention_mask=use_padding)
+    if os.path.exists(raw_onnx_model):
+        logger.warning(f"Skip exporting ONNX model since it existed: {raw_onnx_model}")
+    else:
+        logger.info(f"Exporting ONNX model to {raw_onnx_model}")
+        gpt2helper.export_onnx(model,
+                               device,
+                               raw_onnx_model,
+                               args.verbose,
+                               args.use_external_data_format,
+                               has_position_ids=use_padding,
+                               has_attention_mask=use_padding)
 
     fp16_params = {"keep_io_types": args.keep_io_types}
     if args.io_block_list:
@@ -308,6 +328,7 @@ def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_resu
         output_path = args.output
 
     logger.info(f"Output path: {output_path}")
+    model_size_in_MB = int(get_onnx_model_size(output_path, args.use_external_data_format) / 1024 / 1024)
 
     session = create_onnxruntime_session(output_path, args.use_gpu, enable_all_optimization=True, verbose=args.verbose)
     if args.model_class == "GPT2LMHeadModel" and session is not None:
@@ -320,7 +341,8 @@ def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_resu
                                                model_class=args.model_class,
                                                has_position_ids=use_padding,
                                                has_attention_mask=use_padding,
-                                               total_test_cases=args.test_cases,
+                                               test_cases_per_run=args.test_cases,
+                                               total_runs=args.test_runs,
                                                verbose=args.verbose)
 
         latency = gpt2helper.test_performance(session,
@@ -347,10 +369,10 @@ def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_resu
         with open(csv_filename, mode="a", newline='') as csv_file:
             column_names = [
                 "experiment", "run_id", "model_name", "model_class", "gpu", "precision", "optimizer", "test_cases",
-                "keep_io_types", "io_block_list", "op_block_list", "node_block_list", "force_fp16_initializers",
-                "ORT_TRANSFORMER_OPTIONS", "ORT_CUDA_GEMM_OPTIONS", "onnxruntime", latency_name, "diff_50_percentile",
-                "diff_90_percentile", "diff_95_percentile", "diff_99_percentile", "diff_pass_rate", "nan_rate",
-                "top1_match_rate", "onnx_size_in_MB"
+                "runs", "keep_io_types", "io_block_list", "op_block_list", "node_block_list", "force_fp16_initializers",
+                "ORT_TRANSFORMER_OPTIONS", "ORT_CUDA_GEMM_OPTIONS", "onnxruntime", latency_name, "top1_match_rate",
+                "onnx_size_in_MB", "diff_50_percentile", "diff_90_percentile", "diff_95_percentile",
+                "diff_99_percentile", "diff_pass_rate", "nan_rate", "top1_match_rate_per_run"
             ]
             csv_writer = csv.DictWriter(csv_file, fieldnames=column_names)
             if not csv_file_existed:
@@ -364,6 +386,7 @@ def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_resu
                 "precision": args.precision,
                 "optimizer": args.optimize_onnx,
                 "test_cases": args.test_cases,
+                "runs": args.test_runs,
                 "keep_io_types": args.keep_io_types,
                 "io_block_list": args.io_block_list,
                 "op_block_list": args.op_block_list,
@@ -380,7 +403,8 @@ def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_resu
                 "diff_pass_rate": parity_result["diff_pass_rate"],
                 "nan_rate": parity_result["nan_rate"],
                 "top1_match_rate": parity_result["top1_match_rate"],
-                "onnx_size_in_MB": "{}".format(int(os.path.getsize(output_path) / 1024 / 1024))
+                "top1_match_rate_per_run": parity_result["top1_match_rate_per_run"],
+                "onnx_size_in_MB": "{}".format(model_size_in_MB),
             }
             logger.info(f"result: {row}")
             result.update(row)

--- a/onnxruntime/python/tools/transformers/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/convert_to_onnx.py
@@ -195,6 +195,10 @@ def get_onnx_model_size(onnx_path: str, use_external_data_format: bool):
         return sum([f.stat().st_size for f in Path(onnx_path).parent.rglob('*')])
 
 
+def get_latency_name():
+    return "average_latency(batch_size=8,sequence_length=1,past_sequence_length=32)"
+
+
 def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_results.csv"):
     result = {}
     from transformers import __version__ as transformers_version
@@ -364,7 +368,7 @@ def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_resu
         # Write results to file
         import csv
         from onnxruntime import __version__ as ort_version
-        latency_name = "average_latency(batch_size=8,sequence_length=1,past_sequence_length=32)"
+        latency_name = get_latency_name()
         csv_file_existed = os.path.exists(csv_filename)
         with open(csv_filename, mode="a", newline='') as csv_file:
             column_names = [

--- a/onnxruntime/python/tools/transformers/gpt2_parity.py
+++ b/onnxruntime/python/tools/transformers/gpt2_parity.py
@@ -4,12 +4,23 @@
 # license information.
 # --------------------------------------------------------------------------
 
+# This script uses different configurations in mixed precision conversion for GPT-2 model, and
+# measures the inference latency, top 1 match rate (compared to PyTorch FP32 model) and ONNX model size.
+# It outputs a csv file with Mann-Whitney U test and T-Test on each pair of experiments, where
+# pvalue < 0.05 means two experiments have significant difference on top 1 match rate.
+# User could use this script to select the best mixed precision model according to these metrics.
+
 from convert_to_onnx import main
 import os
 import argparse
 import logging
-from gpt2_helper import PRETRAINED_GPT2_MODELS
+from gpt2_helper import PRETRAINED_GPT2_MODELS, Gpt2Helper
 from benchmark_helper import setup_logger
+from onnx_model import OnnxModel
+import onnx
+import csv
+import datetime
+import scipy.stats
 
 logger = logging.getLogger('')
 
@@ -32,8 +43,8 @@ def parse_arguments(argv=None):
     parser.add_argument('--runs',
                         required=False,
                         type=int,
-                        default=5,
-                        help="number of repeated runs to get median value of each metric")
+                        default=20,
+                        help="number of repeated runs")
 
     parser.add_argument('--use_gpu', required=False, action='store_true', help="use GPU for inference")
     parser.set_defaults(use_gpu=False)
@@ -55,81 +66,211 @@ def parse_arguments(argv=None):
 class ParityTask:
     def __init__(self, total_runs, csv_path):
         self.total_runs = total_runs
+        self.test_cases = 1000
         self.csv_path = csv_path
-        self.latency_name = "average_latency(batch_size=8,sequence_length=1,past_sequence_length=32)"
-        self.metric_names = [
-            self.latency_name, "diff_50_percentile", "diff_90_percentile", "diff_95_percentile", "diff_99_percentile",
-            "diff_pass_rate", "nan_rate", "top1_match_rate", "onnx_size_in_MB"
+        self.results = []
+        self.run_id = 0
+
+    def run(self, argv, experiment_name):
+        start_time = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+        run_id = f"{start_time}_{self.run_id}"
+        self.run_id += 1
+
+        try:
+            result = main(argv + ["-t", f"{self.test_cases}", "-r", f"{self.total_runs}"],
+                          experiment_name=experiment_name,
+                          run_id=run_id,
+                          csv_filename=self.csv_path)
+        except:
+            logger.exception(f"Failed to run experiment {experiment_name}")
+
+        if result:
+            self.results.append(result)
+
+
+def load_results_from_csv(csv_path):
+    rows = []
+    import csv
+    with open(csv_path, newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            rows.append(row)
+    return rows
+
+
+def run_significance_test(rows, output_csv_path):
+    """Run U test and T test.
+    """
+    with open(output_csv_path, 'w', newline='') as csvfile:
+        column_names = [
+            'model_name', 'run_id_1', 'experiment_1', 'top1_match_rate_1', 'run_id_2', 'experiment_2',
+            'top1_match_rate_2', 'U_statistic', 'U_pvalue', "T_statistic", "T_pvalue"
         ]
 
-    def run(self, argv, name):
-        results = []
-        experiment_name = name
-        for i in range(self.total_runs):
-            try:
-                result = main(argv, experiment_name=experiment_name, run_id=i, csv_filename=self.csv_path)
-            except:
-                logger.error(f"Failed to run experiment{experiment_name}")
-                continue
-            if result:
-                results.append(result)
+        writer = csv.DictWriter(csvfile, fieldnames=column_names, delimiter="\t")
+        writer.writeheader()
 
-        if len(results) == 0:
-            return
+        required_match_columns = ["model_name", "test_cases", "runs"]
+        num_results = len(rows)
+        for i in range(num_results - 1):
+            result1 = rows[i]
+            for j in range(i + 1, num_results, 1):
+                result2 = rows[j]
 
-        # Calculate median value per metric
-        all_results = {}
-        for name in self.metric_names:
-            all_results[name] = []
+                all_matched = True
+                for column in required_match_columns:
+                    if (result1[column] != result2[column]):
+                        all_matched = False
+                        break
+                if not all_matched:
+                    continue
 
-        for result in results:
-            for name in self.metric_names:
-                if name in result:
-                    all_results[name].append(result[name])
+                if isinstance(result1["top1_match_rate_per_run"], str):
+                    import json
+                    a = json.loads(result1["top1_match_rate_per_run"])
+                    b = json.loads(result2["top1_match_rate_per_run"])
+                else:
+                    a = result1["top1_match_rate_per_run"]
+                    b = result2["top1_match_rate_per_run"]
 
-        import statistics
-        median_result = results[0]
-        for name in self.metric_names:
-            median_result[name] = statistics.median(all_results[name])
+                try:
+                    utest_statistic, utest_pvalue = scipy.stats.mannwhitneyu(
+                        a, b, use_continuity=True, alternative="two-sided"
+                    )  #TODO: shall we use one-sided: less or greater according to "top1_match_rate"
+                except ValueError:  #ValueError: All numbers are identical in mannwhitneyu
+                    utest_statistic = None
+                    utest_pvalue = None
+                ttest_statistic, ttest_pvalue = scipy.stats.ttest_ind(a, b, axis=None, equal_var=True)
 
-        self.save_result(median_result)
+                row = {
+                    'model_name': result1["model_name"],
+                    'run_id_1': result1["run_id"],
+                    'experiment_1': result1["experiment"],
+                    'top1_match_rate_1': float(result1["top1_match_rate"]),
+                    "run_id_2": result2["run_id"],
+                    "experiment_2": result2["experiment"],
+                    'top1_match_rate_2': float(result2["top1_match_rate"]),
+                    'U_statistic': utest_statistic,
+                    'U_pvalue': utest_pvalue,
+                    'T_statistic': ttest_statistic,
+                    'T_pvalue': ttest_pvalue
+                }
 
-    def save_result(self, result):
-        import csv
-        csv_filename = self.csv_path
+                print(row)
 
-        csv_file_existed = os.path.exists(csv_filename)
-        with open(csv_filename, mode="a", newline='') as csv_file:
-            column_names = [
-                "experiment", "run_id", "model_name", "model_class", "gpu", "precision", "optimizer", "test_cases",
-                "keep_io_types", "io_block_list", "op_block_list", "node_block_list", "force_fp16_initializers",
-                "ORT_TRANSFORMER_OPTIONS", "ORT_CUDA_GEMM_OPTIONS", "onnxruntime"
-            ] + self.metric_names
-
-            csv_writer = csv.DictWriter(csv_file, fieldnames=column_names)
-            if not csv_file_existed:
-                csv_writer.writeheader()
-
-            row = {}
-            for name in column_names:
-                row[name] = result[name]
-
-            row["run_id"] = "median"
-
-            csv_writer.writerow(row)
-            logger.info(f"result saved to {csv_filename}: {row}")
+                writer.writerow(row)
 
 
-def run_parity(args):
-    task = ParityTask(args.runs, args.csv)
+def get_last_matmul_node_name(raw_onnx_model: str):
+    model = onnx.load(raw_onnx_model)
+    onnx_model = OnnxModel(model)
+    output_name_to_node = onnx_model.output_name_to_node()
 
+    assert model.graph.output[0].name in output_name_to_node
+    node = output_name_to_node[model.graph.output[0].name]
+    if node.op_type == "MatMul":
+        logger.info(f"Found last MatMul node for logits: {node.name}")
+        return node.name
+
+    logger.warning(f"Failed to find MatMul node for logits. Found {node.op_type} of node {node.name}")
+    return None
+
+
+def get_mixed_precision_parameters(args, last_matmul_node_name, op_block_list):
+    model = args.model_name_or_path
+    parameters = f"-m {model} -o --use_gpu -p fp16".split()
+    if args.use_external_data_format:
+        parameters.append("--use_external_data_format")
+    parameters += ["--io_block_list", "logits", "--node_block_list", last_matmul_node_name]
+
+    if op_block_list:
+        parameters.extend(["--op_block_list"] + op_block_list)
+
+    return parameters
+
+
+def run_candidate(task: ParityTask, args, last_matmul_node_name, op_block_list=["FastGelu", "LayerNormalization"]):
+    model = args.model_name_or_path
+    parameters = get_mixed_precision_parameters(args, last_matmul_node_name, op_block_list)
+    name = f"Mixed precision baseline plus {op_block_list} in FP32" if op_block_list else "Mixed precision baseline"
+    task.run(parameters, name)
+
+
+def get_baselines(args):
     model = args.model_name_or_path
     fp32_baseline = f"-m {model} -o -p fp32".split()
     if args.use_gpu:
         fp32_baseline.append("--use_gpu")
-
     if args.use_external_data_format:
         fp32_baseline.append("--use_external_data_format")
+
+    fp16_baseline = f"-m {model} -o --use_gpu -p fp16".split()
+    if args.use_external_data_format:
+        fp16_baseline.append("--use_external_data_format")
+
+    return fp32_baseline, fp16_baseline
+
+
+def get_all_operators():
+    """All operators in the optimized model"""
+    return "Attention Gather Add LayerNormalization FastGelu MatMul".split()
+
+
+def run_tuning_step0(task, fp16_baseline):
+    """Step 0 is to check which operator in FP16 causes most loss"""
+    fp32_logits = ["--io_block_list", "logits"]
+    task.run(fp16_baseline + fp32_logits, "fp16 except logits")
+
+    fp32_io = ["--keep_io_types"]
+    task.run(fp16_baseline + fp32_io, "Graph I/O FP32, Other FP16")
+
+    op_list = get_all_operators()
+    #task.run(fp16_baseline + fp32_io + ["--op_block_list"] + [o for o in op_list], "Everthing in FP32")
+
+    # Only weights in FP16
+    task.run(fp16_baseline + fp32_io + ["--op_block_list"] + [o for o in op_list] + ['--force_fp16_initializers'],
+             "FP32 except weights in FP16")
+
+    for op in op_list:
+        op_block_list = ["--op_block_list"] + [o for o in op_list if o != op]
+        task.run(fp16_baseline + fp32_io + op_block_list, f"FP32 except {op} in fp16")
+
+
+def run_tuning_step1(task, mixed_precision_baseline):
+    """Step 1 is to figure out which operator in FP32 could benefit most"""
+    for op in get_all_operators():
+        op_block_list = ["--op_block_list", op]
+        task.run(mixed_precision_baseline + op_block_list, f"Mixed precison baseline + {op} in fp32")
+
+
+def run_tuning_step2(task, mixed_precision_baseline):
+    """Assumed that you have run step 1 to figure out that Logits FP32 and Add FP32 is important,
+    Step 2 is to figure out a combination of two operators (one is Add from step one) to get better result
+    """
+    for op in get_all_operators():
+        if op not in ['Add']:
+            op_block_list = ["--op_block_list", 'Add', op]
+            task.run(mixed_precision_baseline + op_block_list, f"Mixed precison baseline + Add, {op} in fp32")
+
+
+def run_parity_disable_half2(task: ParityTask, args):
+    onnx_model_paths = Gpt2Helper.get_onnx_paths('onnx_models',
+                                                 args.model_name_or_path,
+                                                 new_folder=args.use_external_data_format,
+                                                 remove_existing=[])
+    last_matmul_node_name = get_last_matmul_node_name(onnx_model_paths["raw"])
+    run_candidate(task, args, last_matmul_node_name, op_block_list=[])
+    run_candidate(task, args, last_matmul_node_name, op_block_list=["Add"])
+    run_candidate(task, args, last_matmul_node_name, op_block_list=["LayerNormalization", "Add"])
+
+
+def run_parity(task: ParityTask, args):
+    onnx_model_paths = Gpt2Helper.get_onnx_paths('onnx_models',
+                                                 args.model_name_or_path,
+                                                 new_folder=args.use_external_data_format,
+                                                 remove_existing=[])
+
+    fp32_baseline, fp16_baseline = get_baselines(args)
 
     task.run(fp32_baseline, "fp32 baseline")
 
@@ -138,40 +279,47 @@ def run_parity(args):
         logger.info("skip mixed precision since --use_gpu is not specified")
         return
 
-    baseline = f"-m {model} -o --use_gpu -p fp16".split()
-    if args.use_external_data_format:
-        baseline.append("--use_external_data_format")
-    task.run(baseline, "fp16 baseline")
+    task.run(fp16_baseline, "fp16 baseline")
 
-    if not args.all:
-        logger.info("skip remaining combinations since --all is not specified")
-        return
+    last_matmul_node_name = get_last_matmul_node_name(onnx_model_paths["raw"])
 
-    fp32_logits = ["--io_block_list", "logits"]
-    task.run(baseline + fp32_logits, "fp16 except logits")
+    # Mixed precision baseline
+    run_candidate(task, args, last_matmul_node_name, op_block_list=[])
 
-    fp32_io = ["--keep_io_types"]
-    task.run(baseline + fp32_io, "Graph I/O FP32, Other FP16")
+    # Result from tuning step 1
+    run_candidate(task, args, last_matmul_node_name, op_block_list=["Add"])
 
-    op_list = "Attention Gather Add LayerNormalization FastGelu MatMul".split()
-    task.run(baseline + fp32_io + ["--op_block_list"] + [o for o in op_list], "Everthing in FP32")
+    if args.all:
+        run_tuning_step0(task, fp16_baseline)
+        mixed_precision_baseline = get_mixed_precision_parameters(args, last_matmul_node_name, op_block_list=[])
+        run_tuning_step1(task, mixed_precision_baseline)
+        run_tuning_step2(task, mixed_precision_baseline)
+    else:
+        run_candidate(task, args, last_matmul_node_name, op_block_list=["LayerNormalization", "Add"])
+        run_candidate(task, args, last_matmul_node_name, op_block_list=["FastGelu", "Add"])
 
-    for op in op_list:
-        op_block_list = ["--op_block_list"] + [o for o in op_list if o != op]
-        task.run(baseline + fp32_io + op_block_list, f"FP32 except {op} in fp16")
-
-    for op in op_list:
-        op_block_list = ["--op_block_list", op]
-        task.run(baseline + op_block_list, f"FP16 except {op} in fp32")
-
-    op_block_list = ["--op_block_list", "LayerNormalization", "FastGelu"]
-    task.run(baseline + op_block_list, f"FP16 except LayerNormalization and FastGelu in fp32")
-
-    task.run(baseline + op_block_list + fp32_logits, f"FP16 except logits, LayerNormalization and FastGelu in fp32")
+    # Run a few good candidates
+    run_candidate(task, args, last_matmul_node_name, op_block_list=["FastGelu", "LayerNormalization", "Add"])
+    run_candidate(task, args, last_matmul_node_name, op_block_list=["FastGelu", "LayerNormalization", "Add", "Gather"])
+    run_candidate(task, args, last_matmul_node_name, \
+                  op_block_list=["FastGelu", "LayerNormalization", "Add", "Gather", "MatMul"])
 
 
 if __name__ == '__main__':
     args = parse_arguments()
     setup_logger(args.verbose)
+    task = ParityTask(args.runs, args.csv)
 
-    run_parity(args)
+    if (os.getenv('ORT_CUDA_GEMM_OPTIONS') == "4" and args.use_gpu):
+        run_parity_disable_half2(task, args)
+    else:
+        run_parity(task, args)
+
+    try:
+        rows = load_results_from_csv(task.csv_path)
+    except:
+        logger.exception(f"Failed to load csv {task.csv_path}")
+        rows = task.results
+
+    summary_csv = task.csv_path.replace('.csv', ".stats.csv")
+    run_significance_test(rows, summary_csv)

--- a/onnxruntime/python/tools/transformers/gpt2_parity.py
+++ b/onnxruntime/python/tools/transformers/gpt2_parity.py
@@ -136,9 +136,11 @@ def print_wins(wins, rows, test_name):
         for row in rows:
             if row["run_id"] == key:
                 logger.info(
-                    "{:02d}: WINs={:02d}, run_id={}, latency={:5.2f} top1_match={:.4f} size={}_MB experiment={}".format(
+                    "{:02d}: WINs={:02d}, run_id={}, latency={:5.2f} top1_match={:.4f} size={}_MB experiment={} {}".
+                    format(
                         rank, value, key, float(row[get_latency_name()]), float(row["top1_match_rate"]),
-                        row["onnx_size_in_MB"], row["experiment"]))
+                        row["onnx_size_in_MB"], row["experiment"], " (Half2 Disabled)" if
+                        (row['ORT_CUDA_GEMM_OPTIONS'] == "4" and "Half2" not in row["experiment"]) else ""))
                 break
 
 
@@ -158,7 +160,7 @@ def run_significance_test(rows, output_csv_path):
             'top1_match_rate_2', 'U_statistic', 'U_pvalue', "T_statistic", "T_pvalue"
         ]
 
-        writer = csv.DictWriter(csvfile, fieldnames=column_names, delimiter="\t")
+        writer = csv.DictWriter(csvfile, fieldnames=column_names)
         writer.writeheader()
 
         required_match_columns = ["model_name", "test_cases", "runs"]

--- a/onnxruntime/python/tools/transformers/requirements.txt
+++ b/onnxruntime/python/tools/transformers/requirements.txt
@@ -6,6 +6,7 @@ py-cpuinfo
 py3nvml
 packaging
 transformers >= 4.0
+scipy
 
 # please follow https://pytorch.org/ to install PyTorch for your OS
 torch >= 1.8


### PR DESCRIPTION
**Description**: 

Include the following changes:
(1) Model size include externa data.
(2) Add an option --test_runs in convert_to_onnx.py
(3) Do not clean the raw ONNX model to speed up mixed precision conversion experiments.
(4) Order output columns so that most important columns are close to each other.
(5) Update mixed precision conversion script gpt2_parity.py:
* Add a default mixed precision baseline with FP32 logits and last MatMul node (pooling) in FP32.
* Test a different set of configurations when ORT_CUDA_GEMM_OPTIONS=4
* Run U-Test and T-Test on top 1 match rate of each pair of experiment
* Output the pair-wise significance test result to another csv file.
* Multiple runs is handled in convert_to_onnx, so remove related code here
* Add ranking results based on pair-wise wins and a scoring function

Example Commands:
```
export ORT_CUDA_GEMM_OPTIONS=0
python gpt2_parity.py -m gpt2 --use_gpu --csv gpt2_parity_v3.csv --all --test_cases 1000 --runs 30
export ORT_CUDA_GEMM_OPTIONS=4
python gpt2_parity.py -m gpt2 --use_gpu --csv gpt2_parity_v3.csv --test_cases 1000 --runs 30
```
The output from Azure Standard_NC4as_T4_v3:
```
Based on T-Test wins and a scoring function, the ranking:
00: WINs=29, run_id=20210914052110_0, latency=10.91 top1_match=1.0000 size=621_MB experiment=FP32 baseline
01: WINs=28, run_id=20210914070232_8, latency=11.06 top1_match=0.9996 size=546_MB experiment=FP32 except Gather in FP16
02: WINs=24, run_id=20210914105042_26, latency= 8.15 top1_match=0.9969 size=581_MB experiment=Mixed precision baseline + Add,FastGelu,Gather,LayerNormalization,MatMul in FP32
02: WINs=24, run_id=20210914063930_6, latency=11.12 top1_match=0.9971 size=311_MB experiment=FP32 except weights in FP16
02: WINs=24, run_id=20210914065102_7, latency=10.87 top1_match=0.9969 size=581_MB experiment=FP32 except Attention in FP16
02: WINs=24, run_id=20210914073706_11, latency=11.08 top1_match=0.9971 size=621_MB experiment=FP32 except FastGelu in FP16
06: WINs=23, run_id=20210914072533_10, latency=11.18 top1_match=0.9950 size=621_MB experiment=FP32 except LayerNormalization in FP16
07: WINs=17, run_id=20210914103739_25, latency= 7.54 top1_match=0.9929 size=459_MB experiment=Mixed precision baseline + Add,FastGelu,Gather,LayerNormalization in FP32
07: WINs=17, run_id=20210914113123_2, latency= 8.01 top1_match=0.9938 size=384_MB experiment=Mixed precision baseline + Add,LayerNormalization in FP32 (Half2 Disabled)
07: WINs=17, run_id=20210914111758_1, latency= 8.03 top1_match=0.9931 size=384_MB experiment=Mixed precision baseline + Add in FP32 (Half2 Disabled)
07: WINs=17, run_id=20210914101109_23, latency= 8.25 top1_match=0.9933 size=506_MB experiment=Mixed precision baseline + Add,MatMul in FP32
11: WINs=15, run_id=20210914102438_24, latency= 7.64 top1_match=0.9927 size=384_MB experiment=Mixed precision baseline + Add,FastGelu,LayerNormalization in FP32
12: WINs=12, run_id=20210914094504_21, latency= 7.56 top1_match=0.9923 size=384_MB experiment=Mixed precision baseline + Add,LayerNormalization in FP32
12: WINs=12, run_id=20210914093201_20, latency= 7.51 top1_match=0.9912 size=459_MB experiment=Mixed precision baseline + Add,Gather in FP32
12: WINs=12, run_id=20210914082617_15, latency= 7.58 top1_match=0.9909 size=384_MB experiment=Mixed precision baseline + Add in FP32
12: WINs=12, run_id=20210914095801_22, latency= 7.66 top1_match=0.9916 size=384_MB experiment=Mixed precision baseline + Add,FastGelu in FP32
12: WINs=12, run_id=20210914091841_19, latency= 8.23 top1_match=0.9915 size=425_MB experiment=Mixed precision baseline + Add,Attention in FP32
17: WINs=11, run_id=20210914060210_3, latency= 7.63 top1_match=0.9908 size=384_MB experiment=Mixed precision baseline + Add in FP32
18: WINs=10, run_id=20210914071403_9, latency=11.15 top1_match=0.9892 size=621_MB experiment=FP32 except Add in FP16
19: WINs=04, run_id=20210914090520_18, latency= 8.21 top1_match=0.9876 size=506_MB experiment=Mixed precision baseline + MatMul in FP32
20: WINs=03, run_id=20210914085222_17, latency= 7.46 top1_match=0.9868 size=384_MB experiment=Mixed precision baseline + FastGelu in FP32
20: WINs=03, run_id=20210914081320_14, latency= 7.41 top1_match=0.9864 size=459_MB experiment=Mixed precision baseline + Gather in FP32
20: WINs=03, run_id=20210914054910_2, latency= 7.46 top1_match=0.9855 size=384_MB experiment=Mixed precision baseline (logits output and last MatMul node MatMul_2402 in FP32)
20: WINs=03, run_id=20210914083923_16, latency= 7.57 top1_match=0.9858 size=384_MB experiment=Mixed precision baseline + LayerNormalization in FP32
20: WINs=03, run_id=20210914110426_0, latency= 7.96 top1_match=0.9858 size=384_MB experiment=Mixed precision baseline (logits output and last MatMul node MatMul_2402 in FP32) (Half2 Disabl$
20: WINs=03, run_id=20210914080010_13, latency= 8.01 top1_match=0.9864 size=425_MB experiment=Mixed precision baseline + Attention in FP32
20: WINs=03, run_id=20210914074839_12, latency=10.66 top1_match=0.9870 size=426_MB experiment=FP32 except MatMul in FP16
27: WINs=00, run_id=20210914061512_4, latency= 7.47 top1_match=0.9823 size=311_MB experiment=FP16 except logits
27: WINs=00, run_id=20210914053256_1, latency= 7.52 top1_match=0.9826 size=311_MB experiment=FP16 baseline
27: WINs=00, run_id=20210914062820_5, latency=10.14 top1_match=0.9823 size=311_MB experiment=Graph I/O FP32, Other FP16
```

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

Two experiments have different top 1 match rate, but there is no way to tell whether the difference is significant enough. It could lead to wrong conclusion without significance test.