### PR TITLE
Revert "disable half2 kernel by default (#9034)"

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/fast_gelu.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/fast_gelu.cc
@@ -34,7 +34,7 @@ using namespace ONNX_NAMESPACE;
 template <typename T>
 FastGelu<T>::FastGelu(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info) {
   const TransformerOptions* options = TransformerOptions::GetInstance();
-  use_half2_ = options->EnableHalf2();
+  use_half2_ = !options->DisableHalf2();
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cuda/bert/transformer_common.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/transformer_common.cc
@@ -25,7 +25,7 @@ const TransformerOptions* TransformerOptions::GetInstance() {
     if (value > 0)
       std::cout << "ORT_TRANSFORMER_OPTIONS: IsPrecisionMode=" << instance.IsPrecisionMode()
                 << ",DisablePersistentSoftmax=" << instance.DisablePersistentSoftmax()
-                << ",EnableHalf2=" << instance.EnableHalf2()
+                << ",DisableHalf2=" << instance.DisableHalf2()
                 << std::endl;
   }
 

--- a/onnxruntime/contrib_ops/cuda/bert/transformer_common.h
+++ b/onnxruntime/contrib_ops/cuda/bert/transformer_common.h
@@ -15,12 +15,12 @@ class TransformerOptions {
 
   bool DisablePersistentSoftmax() const { return disable_persistent_softmax_; }
 
-  bool EnableHalf2() const { return enable_half2_; }
+  bool DisableHalf2() const { return disable_half2_; }
 
   void Initialize(int value) {
     is_precision_mode_ = (value & 0x01) > 0;
     disable_persistent_softmax_ = (value & 0x02) > 0;
-    enable_half2_ = (value & 0x04) > 0;
+    disable_half2_ = (value & 0x04) > 0;
     initialized_ = true;
   }
 
@@ -31,8 +31,8 @@ class TransformerOptions {
   // Disable persistent softmax.
   bool disable_persistent_softmax_{false};
 
-  // Enable half2 kernel.
-  bool enable_half2_{false};
+  // Disable half2 kernel.
+  bool disable_half2_{false};
 
   bool initialized_{false};
 


### PR DESCRIPTION
**Description**: This reverts commit 289999af351e3fea1568c2f8b97b9d3847f3ce82.

Previously, we disabled the half2 kernel based on experiments that it has negative impact on GPT-2 top 1 match rate. Later, we added [U-Test](https://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U_test) and [T-Test](https://en.wikipedia.org/wiki/Student%27s_t-test) in https://github.com/microsoft/onnxruntime/pull/9042, and the result shows that the difference is not significant. For example, 30 runs (each run has 1000 samples) have p_value=0.1484 in T-Test and p_value=0.1965 in U-Test. Usually, we need p_value < 0.05 to tell that two results have significant difference.

So we undo the change and keep half2 kernel since it has benefit on performance.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.