### PR TITLE
[Objective-C API] Ignore clang documentation warnings from C/C++ API header usage.

### DIFF
--- a/objectivec/src/cxx_api.h
+++ b/objectivec/src/cxx_api.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// wrapper for ORT C/C++ API headers
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+// ignore clang documentation-related warnings
+// instead, we will rely on Doxygen warnings for the C/C++ API headers
+#pragma clang diagnostic ignored "-Wdocumentation"
+#endif  // defined(__clang__)
+
+#include "onnxruntime_c_api.h"
+#include "onnxruntime_cxx_api.h"
+
+#if __has_include("coreml_provider_factory.h")
+#define ORT_OBJC_API_COREML_EP_AVAILABLE 1
+#else
+#define ORT_OBJC_API_COREML_EP_AVAILABLE 0
+#endif
+
+#if ORT_OBJC_API_COREML_EP_AVAILABLE
+#include "coreml_provider_factory.h"
+#endif
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif  // defined(__clang__)

--- a/objectivec/src/error_utils.h
+++ b/objectivec/src/error_utils.h
@@ -5,7 +5,7 @@
 
 #include <exception>
 
-#include "onnxruntime_cxx_api.h"
+#import "src/cxx_api.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/objectivec/src/ort_coreml_execution_provider.mm
+++ b/objectivec/src/ort_coreml_execution_provider.mm
@@ -3,16 +3,7 @@
 
 #import "ort_coreml_execution_provider.h"
 
-#if __has_include("coreml_provider_factory.h")
-#define ORT_OBJC_API_COREML_EP_AVAILABLE 1
-#else
-#define ORT_OBJC_API_COREML_EP_AVAILABLE 0
-#endif
-
-#if ORT_OBJC_API_COREML_EP_AVAILABLE
-#include "coreml_provider_factory.h"
-#endif
-
+#import "src/cxx_api.h"
 #import "src/error_utils.h"
 #import "src/ort_session_internal.h"
 

--- a/objectivec/src/ort_enums.mm
+++ b/objectivec/src/ort_enums.mm
@@ -5,7 +5,7 @@
 
 #include <algorithm>
 
-#include "onnxruntime_cxx_api.h"
+#import "src/cxx_api.h"
 
 namespace {
 

--- a/objectivec/src/ort_enums_internal.h
+++ b/objectivec/src/ort_enums_internal.h
@@ -3,7 +3,7 @@
 
 #import "ort_enums.h"
 
-#include "onnxruntime_c_api.h"
+#import "src/cxx_api.h"
 
 OrtLoggingLevel PublicToCAPILoggingLevel(ORTLoggingLevel logging_level);
 

--- a/objectivec/src/ort_env.mm
+++ b/objectivec/src/ort_env.mm
@@ -5,7 +5,7 @@
 
 #include <optional>
 
-#include "onnxruntime_cxx_api.h"
+#import "src/cxx_api.h"
 
 #import "src/error_utils.h"
 #import "src/ort_enums_internal.h"

--- a/objectivec/src/ort_env_internal.h
+++ b/objectivec/src/ort_env_internal.h
@@ -3,7 +3,7 @@
 
 #import "ort_env.h"
 
-#include "onnxruntime_cxx_api.h"
+#import "src/cxx_api.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/objectivec/src/ort_session.mm
+++ b/objectivec/src/ort_session.mm
@@ -6,8 +6,7 @@
 #include <optional>
 #include <vector>
 
-#include "onnxruntime_cxx_api.h"
-
+#import "src/cxx_api.h"
 #import "src/error_utils.h"
 #import "src/ort_enums_internal.h"
 #import "src/ort_env_internal.h"

--- a/objectivec/src/ort_session_internal.h
+++ b/objectivec/src/ort_session_internal.h
@@ -3,7 +3,7 @@
 
 #import "ort_session.h"
 
-#include "onnxruntime_cxx_api.h"
+#import "src/cxx_api.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/objectivec/src/ort_value.mm
+++ b/objectivec/src/ort_value.mm
@@ -7,8 +7,7 @@
 
 #include "safeint/SafeInt.hpp"
 
-#include "onnxruntime_cxx_api.h"
-
+#import "src/cxx_api.h"
 #import "src/error_utils.h"
 #import "src/ort_enums_internal.h"
 

--- a/objectivec/src/ort_value_internal.h
+++ b/objectivec/src/ort_value_internal.h
@@ -3,7 +3,7 @@
 
 #import "ort_value.h"
 
-#include "onnxruntime_cxx_api.h"
+#import "src/cxx_api.h"
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
**Description**
Ignore clang documentation warnings from C/C++ API header usage in the Objective-C API.

**Motivation and Context**
Recent C/C++ API header documentation updates result in documentation warnings from clang.
We choose to ignore these now. Doxygen will check and warn about documentation in those files instead.