### PR TITLE
Fix bug in custom autograd function runner

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_runner.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_runner.py
@@ -111,7 +111,9 @@ def call_python_forward_function(
                 # (https://github.com/pytorch/pytorch/blob/15532595209d2daf34d35e10f8d3d3b64966aea2/torch/csrc/autograd/functions/accumulate_grad.cpp#L21).
                 # The next edges are stored in Node, with which we can get next gradient function.
                 # https://github.com/pytorch/pytorch/blob/15532595209d2daf34d35e10f8d3d3b64966aea2/torch/csrc/autograd/function.h#L527
-                torch_interop_utils.clear_grad_fns_for_next_edges(first_tensor_output, ctx.saved_tensors)
+                # filter out the None in the saved_tensors.
+                saved_tensors = [t for t in ctx.saved_tensors if t is not None]
+                torch_interop_utils.clear_grad_fns_for_next_edges(first_tensor_output, saved_tensors)
                 torch_interop_utils.register_grad_fn(id(ctx), first_tensor_output)
             else:
                 # Context must not present under non-training mode.


### PR DESCRIPTION
This PR filters out Nones from the ctx.saved_tensors as the clear_grad_fns_for_next_edges expects a vector of tensors only.

This fixed the following error in NLRv5 pretraining:
```

Traceback (most recent call last):
  File "/opt/conda/lib/python3.8/site-packages/onnxruntime/training/ortmodule/_custom_autograd_function_runner.py", line 148, in call_python_forward_function
    unwrapped_values = wrap_all_outputs(result, is_training_mode)
  File "/opt/conda/lib/python3.8/site-packages/onnxruntime/training/ortmodule/_custom_autograd_function_runner.py", line 122, in wrap_all_outputs
    ctx = register_context([result])
  File "/opt/conda/lib/python3.8/site-packages/onnxruntime/training/ortmodule/_custom_autograd_function_runner.py", line 114, in register_context
    torch_interop_utils.clear_grad_fns_for_next_edges(first_tensor_output, ctx.saved_tensors)
TypeError: clear_grad_fns_for_next_edges(): incompatible function arguments. The following argument types are supported:
    1. (arg0: at::Tensor, arg1: List[at::Tensor]) -> None

Invoked with: tensor([[[0.0019, 0.0027, 0.0018,  ..., 0.0000, 0.0000, 0.0000],
         [0.0016, 0.0022, 0.0022,  ..., 0.0000, 0.0000, 0.0000],
         [0.0024, 0.0018, 0.0026,  ..., 0.0000, 0.0000, 0.0000],
         ...,
         [0.0020, 0.0020, 0.0020,  ..., 0.0000, 0.0000, 0.0000],
         [0.0020, 0.0020, 0.0020,  ..., 0.0000, 0.0000, 0.0000],
         [0.0020, 0.0020, 0.0020,  ..., 0.0000, 0.0000, 0.0000]]],
       device='cuda:0', dtype=torch.float16,
       grad_fn=<SoftmaxDropoutFastBackward>), (tensor([[[0.0019, 0.0027, 0.0018,  ..., 0.0000, 0.0000, 0.0000],
         [0.0016, 0.0022, 0.0022,  ..., 0.0000, 0.0000, 0.0000],
         [0.0024, 0.0018, 0.0026,  ..., 0.0000, 0.0000, 0.0000],
         ...,
         [0.0020, 0.0020, 0.0020,  ..., 0.0000, 0.0000, 0.0000],
         [0.0020, 0.0020, 0.0020,  ..., 0.0000, 0.0000, 0.0000],
         [0.0020, 0.0020, 0.0020,  ..., 0.0000, 0.0000, 0.0000]]],
       device='cuda:0', dtype=torch.float16,
       grad_fn=<SoftmaxDropoutFastBackward>), None)
```