### PR TITLE
Add default C++ initialization to OrtCUDAProviderOptions

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -336,6 +336,10 @@ typedef enum OrtCudnnConvAlgoSearch {
 * \see OrtApi::SessionOptionsAppendExecutionProvider_CUDA
 */
 typedef struct OrtCUDAProviderOptions {
+#ifdef __cplusplus
+  OrtCUDAProviderOptions() : device_id{}, cudnn_conv_algo_search{EXHAUSTIVE}, gpu_mem_limit{SIZE_MAX}, arena_extend_strategy{}, do_copy_in_default_stream{}, has_user_compute_stream{}, user_compute_stream{}, default_memory_arena_cfg{} {}
+#endif
+
   int device_id;  ///< CUDA device id (0 = default device)
   OrtCudnnConvAlgoSearch cudnn_conv_algo_search;
 

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -310,16 +310,10 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
 
     if (enable_tensorrt) {
 #ifdef USE_TENSORRT
-      OrtCUDAProviderOptions cuda_options{
-          device_id,
-          OrtCudnnConvAlgoSearch::EXHAUSTIVE,
-          std::numeric_limits<size_t>::max(),
-          0,
-          true,
-          0,
-          nullptr,
-          nullptr};  // TODO: Support arena configuration for users of test runner
-
+      OrtCUDAProviderOptions cuda_options;
+      cuda_options.device_id=device_id;
+      cuda_options.do_copy_in_default_stream=true;
+      // TODO: Support arena configuration for users of test runner
       Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Tensorrt(sf, device_id));
       sf.AppendExecutionProvider_CUDA(cuda_options);
 #else

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -339,15 +339,9 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     }
     if (enable_cuda) {
 #ifdef USE_CUDA
-      OrtCUDAProviderOptions cuda_options{
-          0,
-          OrtCudnnConvAlgoSearch::EXHAUSTIVE,
-          std::numeric_limits<size_t>::max(),
-          0,
-          true,
-          0,
-          nullptr,
-          nullptr};  // TODO: Support arena configuration for users of test runner
+      OrtCUDAProviderOptions cuda_options;
+      cuda_options.do_copy_in_default_stream=true;
+      // TODO: Support arena configuration for users of test runner
       sf.AppendExecutionProvider_CUDA(cuda_options);
 #else
       fprintf(stderr, "CUDA is not supported in this build");

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -230,15 +230,11 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
     tensorrt_options.trt_force_sequential_engine_build = trt_force_sequential_engine_build;
     session_options.AppendExecutionProvider_TensorRT(tensorrt_options);
 
-    OrtCUDAProviderOptions cuda_options{
-        device_id,
-        static_cast<OrtCudnnConvAlgoSearch>(performance_test_config.run_config.cudnn_conv_algo),
-        std::numeric_limits<size_t>::max(),
-        0,
-        !performance_test_config.run_config.do_cuda_copy_in_separate_stream,
-        0,
-        nullptr,
-        nullptr};  // TODO: Support arena configuration for users of perf test
+    OrtCUDAProviderOptions cuda_options;
+    cuda_options.device_id=device_id;
+    cuda_options.cudnn_conv_algo_search=static_cast<OrtCudnnConvAlgoSearch>(performance_test_config.run_config.cudnn_conv_algo);
+    cuda_options.do_copy_in_default_stream=!performance_test_config.run_config.do_cuda_copy_in_separate_stream;
+    // TODO: Support arena configuration for users of perf test
     session_options.AppendExecutionProvider_CUDA(cuda_options);
 #else
     ORT_THROW("TensorRT is not supported in this build\n");

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -42,15 +42,10 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
 #endif
   } else if (provider_name == onnxruntime::kCudaExecutionProvider) {
 #ifdef USE_CUDA
-    OrtCUDAProviderOptions cuda_options{
-        0,
-        static_cast<OrtCudnnConvAlgoSearch>(performance_test_config.run_config.cudnn_conv_algo),
-        std::numeric_limits<size_t>::max(),
-        0,
-        !performance_test_config.run_config.do_cuda_copy_in_separate_stream,
-        0,
-        nullptr,
-        nullptr};  // TODO: Support arena configuration for users of perf test
+    OrtCUDAProviderOptions cuda_options;
+    cuda_options.cudnn_conv_algo_search = static_cast<OrtCudnnConvAlgoSearch>(performance_test_config.run_config.cudnn_conv_algo);
+    cuda_options.do_copy_in_default_stream = !performance_test_config.run_config.do_cuda_copy_in_separate_stream;
+    // TODO: Support arena configuration for users of perf test
     session_options.AppendExecutionProvider_CUDA(cuda_options);
 #else
     ORT_THROW("CUDA is not supported in this build\n");

--- a/onnxruntime/test/shared_lib/utils.cc
+++ b/onnxruntime/test/shared_lib/utils.cc
@@ -2,17 +2,11 @@
 // Licensed under the MIT License.
 
 #include "utils.h"
-#include <limits>
 
 OrtCUDAProviderOptions CreateDefaultOrtCudaProviderOptionsWithCustomStream(void* cuda_compute_stream) {
-  OrtCUDAProviderOptions cuda_options{
-      0,
-      OrtCudnnConvAlgoSearch::EXHAUSTIVE,
-      std::numeric_limits<size_t>::max(),
-      0,
-      true,
-      cuda_compute_stream != nullptr ? 1 : 0,
-      cuda_compute_stream != nullptr ? cuda_compute_stream : nullptr,
-      nullptr};
+  OrtCUDAProviderOptions cuda_options;
+  cuda_options.do_copy_in_default_stream = true;
+  cuda_options.has_user_compute_stream = cuda_compute_stream != nullptr ? 1 : 0;
+  cuda_options.user_compute_stream = cuda_compute_stream;
   return cuda_options;
 }

--- a/orttraining/orttraining/models/bert/main.cc
+++ b/orttraining/orttraining/models/bert/main.cc
@@ -609,15 +609,9 @@ void setup_training_params(BertParameters& params) {
 
 #ifdef USE_CUDA
   {
-    OrtCUDAProviderOptions info{
-        gsl::narrow<OrtDevice::DeviceId>(MPIContext::GetInstance().GetLocalRank()),
-        OrtCudnnConvAlgoSearch::EXHAUSTIVE,
-        std::numeric_limits<size_t>::max(),
-        0,
-        true,
-        0,
-        nullptr,
-        nullptr};
+    OrtCUDAProviderOptions info;
+    info.device_id = gsl::narrow<OrtDevice::DeviceId>(MPIContext::GetInstance().GetLocalRank());
+    info.do_copy_in_default_stream = true;
 
     if (params.gpu_mem_limit_in_gb > 0) {
       info.gpu_mem_limit = gsl::narrow<size_t>(params.gpu_mem_limit_in_gb * 1024 * 1024 * 1024);

--- a/orttraining/orttraining/models/gpt2/main.cc
+++ b/orttraining/orttraining/models/gpt2/main.cc
@@ -352,16 +352,9 @@ void setup_training_params(GPT2Parameters& params) {
 
 #ifdef USE_CUDA
   {
-    OrtCUDAProviderOptions info{
-        gsl::narrow<OrtDevice::DeviceId>(MPIContext::GetInstance().GetLocalRank()),
-        OrtCudnnConvAlgoSearch::EXHAUSTIVE,
-        std::numeric_limits<size_t>::max(),
-        0,
-        true,
-        0,
-        nullptr,
-        nullptr};
-
+    OrtCUDAProviderOptions info;
+    info.device_id=gsl::narrow<OrtDevice::DeviceId>(MPIContext::GetInstance().GetLocalRank());
+    info.do_copy_in_default_stream=true;
     params.providers.emplace(kCudaExecutionProvider, CreateExecutionProviderFactory_Cuda(&info));
     params.input_allocator = CreateCUDAPinnedAllocator(info.device_id, CUDA_PINNED);
   }

--- a/orttraining/orttraining/models/mnist/main.cc
+++ b/orttraining/orttraining/models/mnist/main.cc
@@ -169,16 +169,8 @@ Status ParseArguments(int argc, char* argv[], MnistParameters& params) {
 #ifdef USE_CUDA
     bool use_cuda = flags.count("use_cuda") > 0;
     if (use_cuda) {
-      OrtCUDAProviderOptions info{
-          0,
-          OrtCudnnConvAlgoSearch::EXHAUSTIVE,
-          std::numeric_limits<size_t>::max(),
-          0,
-          true,
-          0,
-          nullptr,
-          nullptr};
-
+      OrtCUDAProviderOptions info;
+      info.do_copy_in_default_stream = true;
       params.providers.emplace(kCudaExecutionProvider, CreateExecutionProviderFactory_Cuda(&info));
     }
 #endif


### PR DESCRIPTION
**Description**: Adds a C++ default initializer to prevent accidental uninitialized fields. Especially for new fields added between versions.

This will prevent this issue from this user from happening again:
https://github.com/microsoft/onnxruntime/issues/9038
