### PR TITLE
Add CPU_ONLY runtime option to NNAPI EP

### DIFF
--- a/include/onnxruntime/core/providers/nnapi/nnapi_provider_factory.h
+++ b/include/onnxruntime/core/providers/nnapi/nnapi_provider_factory.h
@@ -45,7 +45,7 @@ enum NNAPIFlags {
   // and NNAPI_FLAG_CPU_ONLY flags are set
   NNAPI_FLAG_CPU_ONLY = 0x008,
 
-  // Keep NNAPI_FLAG_MAX at the end of the enum definition
+  // Keep NNAPI_FLAG_LAST at the end of the enum definition
   // And assign the last NNAPIFlag to it
   NNAPI_FLAG_LAST = NNAPI_FLAG_CPU_ONLY,
 };

--- a/include/onnxruntime/core/providers/nnapi/nnapi_provider_factory.h
+++ b/include/onnxruntime/core/providers/nnapi/nnapi_provider_factory.h
@@ -33,11 +33,21 @@ enum NNAPIFlags {
   //
   // For NNAPI device assignments, see https://developer.android.com/ndk/guides/neuralnetworks#device-assignment
   // For NNAPI CPU fallback, see https://developer.android.com/ndk/guides/neuralnetworks#cpu-fallback
+  //
+  // Please note, the NNAPI EP will return error status if both NNAPI_FLAG_CPU_DISABLED
+  // and NNAPI_FLAG_CPU_ONLY flags are set
   NNAPI_FLAG_CPU_DISABLED = 0x004,
+
+  // Using CPU only in NNAPI EP, this may decrease the perf but will provide
+  // reference output value without precision loss, which is useful for validation
+  //
+  // Please note, the NNAPI EP will return error status if both NNAPI_FLAG_CPU_DISABLED
+  // and NNAPI_FLAG_CPU_ONLY flags are set
+  NNAPI_FLAG_CPU_ONLY = 0x008,
 
   // Keep NNAPI_FLAG_MAX at the end of the enum definition
   // And assign the last NNAPIFlag to it
-  NNAPI_FLAG_LAST = NNAPI_FLAG_CPU_DISABLED,
+  NNAPI_FLAG_LAST = NNAPI_FLAG_CPU_ONLY,
 };
 
 #ifdef __cplusplus

--- a/java/src/main/java/ai/onnxruntime/providers/NNAPIFlags.java
+++ b/java/src/main/java/ai/onnxruntime/providers/NNAPIFlags.java
@@ -8,7 +8,7 @@ package ai.onnxruntime.providers;
 public enum NNAPIFlags implements OrtFlags {
   USE_FP16(1), // NNAPI_FLAG_USE_FP16(0x001)
   USE_NCHW(2), // NNAPI_FLAG_USE_NCHW(0x002)
-  CPU_DISABLED(4); // NNAPI_FLAG_CPU_DISABLED(0x004)
+  CPU_DISABLED(4), // NNAPI_FLAG_CPU_DISABLED(0x004)
   CPU_ONLY(8); // NNAPI_FLAG_CPU_ONLY(0x008)
 
   public final int value;

--- a/java/src/main/java/ai/onnxruntime/providers/NNAPIFlags.java
+++ b/java/src/main/java/ai/onnxruntime/providers/NNAPIFlags.java
@@ -9,6 +9,7 @@ public enum NNAPIFlags implements OrtFlags {
   USE_FP16(1), // NNAPI_FLAG_USE_FP16(0x001)
   USE_NCHW(2), // NNAPI_FLAG_USE_NCHW(0x002)
   CPU_DISABLED(4); // NNAPI_FLAG_CPU_DISABLED(0x004)
+  CPU_ONLY(8); // NNAPI_FLAG_CPU_ONLY(0x008)
 
   public final int value;
 

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
@@ -235,8 +235,15 @@ common::Status NnapiExecutionProvider::Compile(const std::vector<FusedNodeAndGra
     nnapi::ModelBuilder builder(graph_viewer);
     builder.SetUseNCHW(nnapi_flags_ & NNAPI_FLAG_USE_NCHW);
     builder.SetUseFp16(nnapi_flags_ & NNAPI_FLAG_USE_FP16);
-    if (nnapi_flags_ & NNAPI_FLAG_CPU_DISABLED) {
+
+    bool cpu_disabled = nnapi_flags_ & NNAPI_FLAG_CPU_DISABLED;
+    bool cpu_only = nnapi_flags_ & NNAPI_FLAG_CPU_ONLY;
+    if (cpu_disabled && cpu_only) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Both NNAPI_FLAG_CPU_DISABLED and NNAPI_FLAG_CPU_ONLY are set");
+    } else if (cpu_disabled) {
       builder.SetTargetDeviceOption(nnapi::ModelBuilder::TargetDeviceOption::CPU_DISABLED);
+    } else if (cpu_only) {
+      builder.SetTargetDeviceOption(nnapi::ModelBuilder::TargetDeviceOption::CPU_ONLY);
     }
 
     std::unique_ptr<nnapi::Model> nnapi_model;

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
@@ -25,6 +25,7 @@ parameters:
   default: ''
 
 - name: publish_executables
+  # The executables will only be published if the publish_executables is set to "1"
   displayName: Publish executables such as onnxruntime_perf_test, ...
   type: string
   default: '0'


### PR DESCRIPTION
**Description**: Add CPU_ONLY runtime option to NNAPI EP

**Motivation and Context**
- We sometimes may need enable CPU ONLY option to root-cause the accuracy issue, such as  #9039,
- Add the missing comment for my previous PR
