### PR TITLE
[js/web] check session ID in releaseSession()

### DIFF
--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -84,7 +84,7 @@ export const createSession =
 export const releaseSession = (sessionId: number): void => {
   const wasm = getInstance();
   const session = activeSessions[sessionId];
-  if (!session) {
+  if (!Number.isSafeInteger(sessionId) || !session) {
     throw new Error('invalid session id');
   }
   const sessionHandle = session[0];


### PR DESCRIPTION
**Description**: this change fixes CodeQL warning SM02384: js/remote-property-injection.

By checking type of sessionID, this will avoid possible property injection.