### PR TITLE
Fuse attention for BERT without num_heads, hidden_size

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_attention.py
@@ -87,7 +87,7 @@ class FusionAttention(Fusion):
         self.hidden_size = hidden_size
         self.num_heads = num_heads
         self.attention_mask = attention_mask
-        
+
         # Flags to show warning only once
         self.num_heads_warning = True
         self.hidden_size_warning = True
@@ -120,13 +120,13 @@ class FusionAttention(Fusion):
         if self.num_heads > 0 and num_heads != self.num_heads:
             if self.num_heads_warning:
                 logger.warning(f"--num_heads is {self.num_heads}. Detected value is {num_heads}. Using detected value.")
-                self.num_heads_warning = False # Do not show the warning more than once
+                self.num_heads_warning = False  # Do not show the warning more than once
 
         if self.hidden_size > 0 and hidden_size != self.hidden_size:
             if self.hidden_size_warning:
                 logger.warning(
                     f"--hidden_size is {self.hidden_size}. Detected value is {hidden_size}. Using detected value.")
-                self.hidden_size_warning = False # Do not show the warning more than once
+                self.hidden_size_warning = False  # Do not show the warning more than once
 
         return num_heads, hidden_size
 
@@ -450,8 +450,8 @@ class FusionAttention(Fusion):
             # number of heads are same for all the paths, hence to create attention node, we pass the q_num_heads
             # the input_hidden_size represents the input hidden size, this is used as needed but hidden sizes for Q, K are extracted appropriately
             new_node = self.create_attention_node(mask_index, matmul_q, matmul_k, matmul_v, add_q, add_k, add_v,
-                                                  q_num_heads, q_hidden_size, root_input,
-                                                  attention_last_node.output[0], add_qk_str)
+                                                  q_num_heads, q_hidden_size, root_input, attention_last_node.output[0],
+                                                  add_qk_str)
             if new_node is None:
                 return
 

--- a/onnxruntime/python/tools/transformers/fusion_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_attention.py
@@ -87,6 +87,10 @@ class FusionAttention(Fusion):
         self.hidden_size = hidden_size
         self.num_heads = num_heads
         self.attention_mask = attention_mask
+        
+        # Flags to show warning only once
+        self.num_heads_warning = True
+        self.hidden_size_warning = True
 
     def get_num_heads_and_hidden_size(self, reshape_q: NodeProto) -> Tuple[int, int]:
         """ Detect num_heads and hidden_size from a reshape node.
@@ -114,11 +118,15 @@ class FusionAttention(Fusion):
         hidden_size = num_heads * head_size
 
         if self.num_heads > 0 and num_heads != self.num_heads:
-            logger.warning(f"--num_heads is {self.num_heads}. Detected value is {num_heads}. Using detected value.")
+            if self.num_heads_warning:
+                logger.warning(f"--num_heads is {self.num_heads}. Detected value is {num_heads}. Using detected value.")
+                self.num_heads_warning = False # Do not show the warning more than once
 
         if self.hidden_size > 0 and hidden_size != self.hidden_size:
-            logger.warning(
-                f"--hidden_size is {self.hidden_size}. Detected value is {hidden_size}. Using detected value.")
+            if self.hidden_size_warning:
+                logger.warning(
+                    f"--hidden_size is {self.hidden_size}. Detected value is {hidden_size}. Using detected value.")
+                self.hidden_size_warning = False # Do not show the warning more than once
 
         return num_heads, hidden_size
 
@@ -194,10 +202,9 @@ class FusionAttention(Fusion):
         assert qw_in_size == kw_in_size == vw_in_size
 
         if hidden_size > 0 and hidden_size != qw_in_size:
-            logger.debug(
+            logger.warning(
                 f"Input hidden size {hidden_size} is not same as weight matrix dimension of q,k,v paths {qw_in_size}, provide correct input hidden size or pass 0"
             )
-            return None
 
         is_qkv_diff_dims = False
         if qw.shape != vw.shape:
@@ -443,7 +450,7 @@ class FusionAttention(Fusion):
             # number of heads are same for all the paths, hence to create attention node, we pass the q_num_heads
             # the input_hidden_size represents the input hidden size, this is used as needed but hidden sizes for Q, K are extracted appropriately
             new_node = self.create_attention_node(mask_index, matmul_q, matmul_k, matmul_v, add_q, add_k, add_v,
-                                                  q_num_heads, self.hidden_size, root_input,
+                                                  q_num_heads, q_hidden_size, root_input,
                                                   attention_last_node.output[0], add_qk_str)
             if new_node is None:
                 return

--- a/onnxruntime/python/tools/transformers/fusion_utils.py
+++ b/onnxruntime/python/tools/transformers/fusion_utils.py
@@ -151,7 +151,7 @@ class FusionUtils:
                     self.model.replace_input_of_all_nodes(node.output[0], node.input[0])
                 self.model.remove_node(node)
         logger.info(f"Removed {len(nodes_to_remove)} Cast nodes with output type same as input")
-        
+
     def remove_useless_reshape_nodes(self):
         """Remove reshape node that is not needed based on symbolic shape inference: input and output has same shape
         """

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -740,8 +740,9 @@ class OnnxModel:
         for input in input_to_remove:
             self.model.graph.input.remove(input)
 
-        logger.info("Graph pruned: {} inputs, {} outputs and {} nodes are removed".format(
-            len(input_to_remove), len(output_to_remove), len(nodes_to_remove)))
+        if input_to_remove or output_to_remove or nodes_to_remove:
+            logger.info("Graph pruned: {} inputs, {} outputs and {} nodes are removed".format(
+                len(input_to_remove), len(output_to_remove), len(nodes_to_remove)))
 
         self.update_graph()
 
@@ -883,10 +884,13 @@ class OnnxModel:
                 # Show warnings of potential confliction of existing external data file.
                 if all_tensors_to_one_file:
                     if os.path.exists(location):
-                        logger.warning(f"External data file ({location}) existed. Please remove the file and try again.")
+                        logger.warning(
+                            f"External data file ({location}) existed. Please remove the file and try again.")
                 else:
                     if os.listdir(output_dir):
-                        logger.warning(f"Output directory ({output_dir}) for external data is not empty. Please try again with a new directory.")
+                        logger.warning(
+                            f"Output directory ({output_dir}) for external data is not empty. Please try again with a new directory."
+                        )
 
                 external_data_helper.convert_model_to_external_data(self.model,
                                                                     all_tensors_to_one_file=all_tensors_to_one_file,

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -248,7 +248,7 @@ def get_fusion_statistics(optimized_model_path: str) -> Dict[str, int]:
         A dictionary with operator type as key, and count as value
     """
     model = load_model(optimized_model_path, format=None, load_external_data=True)
-    optimizer = BertOnnxModel(model, num_heads=12, hidden_size=768)
+    optimizer = BertOnnxModel(model)
     return optimizer.get_fused_operator_statistics()
 
 
@@ -272,24 +272,24 @@ def _parse_arguments():
         '--num_heads',
         required=False,
         type=int,
-        default=12,
+        default=0,
         help=
-        "number of attention heads. 12 for bert-base model and 16 for bert-large. For BERT, set it to 0 to detect automatically."
+        "number of attention heads like 12 for bert-base and 16 for bert-large. Default is 0 to detect automatically."
     )
 
     parser.add_argument(
         '--hidden_size',
         required=False,
         type=int,
-        default=768,
+        default=0,
         help=
-        "bert model hidden size. 768 for bert-base model and 1024 for bert-large. For BERT, set it to 0 to detect automatically."
+        "hidden size like 768 for bert-base and 1024 for bert-large. Default is 0 to detect automatically."
     )
 
     parser.add_argument('--input_int32',
                         required=False,
                         action='store_true',
-                        help="Use int32 (instead of int64) tensor as input to avoid unnecessary data cast.")
+                        help="Use int32 (instead of int64) tensor as BERT input. It could avoid unnecessary data cast when EmbedLayerNormalization is fused.")
     parser.set_defaults(input_int32=False)
 
     parser.add_argument(

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -274,7 +274,7 @@ def _parse_arguments():
         type=int,
         default=0,
         help=
-        "number of attention heads like 12 for bert-base and 16 for bert-large. Default is 0 to detect automatically."
+        "number of attention heads like 12 for bert-base and 16 for bert-large. Default is 0 to detect automatically for BERT. For other model type, this parameter need specify correctly."
     )
 
     parser.add_argument(
@@ -283,13 +283,16 @@ def _parse_arguments():
         type=int,
         default=0,
         help=
-        "hidden size like 768 for bert-base and 1024 for bert-large. Default is 0 to detect automatically."
+        "hidden size like 768 for bert-base and 1024 for bert-large. Default is 0 to detect automatically for BERT. For other model type, this parameter need specify correctly."
     )
 
-    parser.add_argument('--input_int32',
-                        required=False,
-                        action='store_true',
-                        help="Use int32 (instead of int64) tensor as BERT input. It could avoid unnecessary data cast when EmbedLayerNormalization is fused.")
+    parser.add_argument(
+        '--input_int32',
+        required=False,
+        action='store_true',
+        help=
+        "Use int32 (instead of int64) inputs. It could avoid unnecessary data cast when EmbedLayerNormalization is fused for BERT."
+    )
     parser.set_defaults(input_int32=False)
 
     parser.add_argument(
@@ -297,7 +300,7 @@ def _parse_arguments():
         required=False,
         action='store_true',
         help=
-        "If your target device is V100 or T4 GPU, try this to convert float32 to float16 for best performance (with potential loss in precision)."
+        "Convert all weights and nodes in float32 to float16. It has potential loss in precision compared to mixed precision conversion (see convert_float_to_float16)."
     )
     parser.set_defaults(float16=False)
 
@@ -310,7 +313,7 @@ def _parse_arguments():
         '--use_gpu',
         required=False,
         action='store_true',
-        help="use GPU for inference. Set this flag if your model is intended for GPU and opt_level > 1.")
+        help="Use GPU for inference. Set this flag if your model is intended for GPU when opt_level > 1.")
     parser.set_defaults(use_gpu=False)
 
     parser.add_argument('--only_onnxruntime',
@@ -326,13 +329,13 @@ def _parse_arguments():
         choices=[0, 1, 2, 99],
         default=None,
         help=
-        "onnxruntime optimization level. 0 will disable onnxruntime graph optimization. Graph fusion in Python is not impacted by setting."
+        "onnxruntime optimization level. 0 will disable onnxruntime graph optimization. The recommended value is 1. When opt_level > 1 is used, optimized model for GPU might not run in CPU. Level 2 and 99 are intended for --only_onnxruntime."
     )
 
     parser.add_argument('--use_external_data_format',
                         required=False,
                         action='store_true',
-                        help="use external data format")
+                        help="use external data format to store large model (>2GB)")
     parser.set_defaults(use_external_data_format=False)
 
     args = parser.parse_args()

--- a/onnxruntime/test/python/transformers/model_loader.py
+++ b/onnxruntime/test/python/transformers/model_loader.py
@@ -14,6 +14,7 @@ if find_transformers_source():
 else:
     from onnxruntime.transformers.fusion_utils import NumpyHelper
 
+
 def fill_zeros_for_external_data(tensor: TensorProto):
     if tensor.HasField("raw_data"):  # already loaded
         return

--- a/onnxruntime/test/python/transformers/test_attention_fusion.py
+++ b/onnxruntime/test/python/transformers/test_attention_fusion.py
@@ -89,12 +89,14 @@ class TestFusion(unittest.TestCase):
         dir = '.'
         model_path = os.path.join(dir, "attention_with_varied_qkv.onnx")
         onnx.save(model, model_path)
-        optimized_model = optimize_model(model_path, 'bert', num_heads=8, hidden_size=8) #wrong num_heads and hidden_size
+
+        #wrong num_heads and hidden_size
+        optimized_model = optimize_model(model_path, 'bert', num_heads=8, hidden_size=8)
+
         os.remove(model_path)
 
         self.verify_fusion(optimized_model, 'attention_with_varied_qkv_opt.onnx')
-        
-        
+
     def test_3d_attention_fusion_tf2onnx_model(self):
         model = create_tf2onnx_attention_3d()
         dir = '.'

--- a/onnxruntime/test/python/transformers/test_attention_fusion.py
+++ b/onnxruntime/test/python/transformers/test_attention_fusion.py
@@ -81,6 +81,20 @@ class TestFusion(unittest.TestCase):
 
         self.verify_fusion(optimized_model, 'attention_with_varied_qkv_opt.onnx')
 
+    def test_attention_fusion_for_varied_qkv_dimensions_with_wrong_opt_parameters(self):
+        model = create_bert_attention(input_hidden_size=16,
+                                      num_heads=2,
+                                      pruned_qk_hidden_size=24,
+                                      pruned_v_hidden_size=16)
+        dir = '.'
+        model_path = os.path.join(dir, "attention_with_varied_qkv.onnx")
+        onnx.save(model, model_path)
+        optimized_model = optimize_model(model_path, 'bert', num_heads=8, hidden_size=8) #wrong num_heads and hidden_size
+        os.remove(model_path)
+
+        self.verify_fusion(optimized_model, 'attention_with_varied_qkv_opt.onnx')
+        
+        
     def test_3d_attention_fusion_tf2onnx_model(self):
         model = create_tf2onnx_attention_3d()
         dir = '.'


### PR DESCRIPTION
**Description**: 

Currently, when user specifies a wrong hidden_size, the optimizer will not fuse attention silently (there is debug log but not show by default). Update the handling to be more user friendly.

(1) Update attention fusion for BERT model to pass without user specified num_heads or hidden_size. If user specified wrong value, the tool will print warnings but still fuse the Attention node. Add a test case for this.
(2) Update the default value of num_heads and hidden_size to be 0. That's consistent with the default values in API. In this way, user need not specify these parameters for BERT model.
(3) Do not show same warning multiple times.
(4) Update help description for optimizer arguments.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
