### PR TITLE
js/web/add-fetch-options

### DIFF
--- a/js/common/lib/inference-session-impl.ts
+++ b/js/common/lib/inference-session-impl.ts
@@ -115,13 +115,13 @@ export class InferenceSession implements InferenceSessionInterface {
     return returnValue;
   }
 
-  static create(path: string, options?: SessionOptions): Promise<InferenceSessionInterface>;
+  static create(path: string, options?: SessionOptions & { fetchOptions?: RequestInit }): Promise<InferenceSessionInterface>;
   static create(buffer: ArrayBufferLike, options?: SessionOptions): Promise<InferenceSessionInterface>;
   static create(buffer: ArrayBufferLike, byteOffset: number, byteLength?: number, options?: SessionOptions):
       Promise<InferenceSessionInterface>;
   static create(buffer: Uint8Array, options?: SessionOptions): Promise<InferenceSessionInterface>;
   static async create(
-      arg0: string|ArrayBufferLike|Uint8Array, arg1?: SessionOptions|number, arg2?: number,
+      arg0: string|ArrayBufferLike|Uint8Array, arg1?: SessionOptions & { fetchOptions?: RequestInit }|number, arg2?: number,
       arg3?: SessionOptions): Promise<InferenceSessionInterface> {
     // either load from a file or buffer
     let filePathOrUint8Array: string|Uint8Array;

--- a/js/common/lib/inference-session.ts
+++ b/js/common/lib/inference-session.ts
@@ -338,7 +338,7 @@ export interface InferenceSessionFactory {
    * @param options - specify configuration for creating a new inference session.
    * @returns A promise that resolves to an InferenceSession object.
    */
-  create(uri: string, options?: InferenceSession.SessionOptions): Promise<InferenceSession>;
+  create(uri: string, options?: InferenceSession.SessionOptions & { fetchOptions?: RequestInit }): Promise<InferenceSession>;
 
   /**
    * Create a new inference session and load model asynchronously from an array bufer.

--- a/js/web/lib/backend-onnxjs.ts
+++ b/js/web/lib/backend-onnxjs.ts
@@ -10,7 +10,7 @@ class OnnxjsBackend implements Backend {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   async init(): Promise<void> {}
 
-  async createSessionHandler(pathOrBuffer: string|Uint8Array, options?: InferenceSession.SessionOptions):
+  async createSessionHandler(pathOrBuffer: string|Uint8Array, options?: InferenceSession.SessionOptions & { fetchOptions?: RequestInit }):
       Promise<SessionHandler> {
     // NOTE: Session.Config(from onnx.js) is not compatible with InferenceSession.SessionOptions(from
     // onnxruntime-common).
@@ -20,7 +20,7 @@ class OnnxjsBackend implements Backend {
 
     // typescript cannot merge method override correctly (so far in 4.2.3). need if-else to call the method.
     if (typeof pathOrBuffer === 'string') {
-      await session.loadModel(pathOrBuffer);
+      await session.loadModel(pathOrBuffer, options?.fetchOptions ?? {});
     } else {
       await session.loadModel(pathOrBuffer);
     }

--- a/js/web/lib/backend-wasm.ts
+++ b/js/web/lib/backend-wasm.ts
@@ -42,9 +42,9 @@ class OnnxruntimeWebAssemblyBackend implements Backend {
     // init wasm
     await initWasm();
   }
-  createSessionHandler(path: string, options?: InferenceSession.SessionOptions): Promise<SessionHandler>;
+  createSessionHandler(path: string, options?: InferenceSession.SessionOptions & { fetchOptions?: RequestInit }): Promise<SessionHandler>;
   createSessionHandler(buffer: Uint8Array, options?: InferenceSession.SessionOptions): Promise<SessionHandler>;
-  async createSessionHandler(pathOrBuffer: string|Uint8Array, options?: InferenceSession.SessionOptions):
+  async createSessionHandler(pathOrBuffer: string|Uint8Array, options?: InferenceSession.SessionOptions & { fetchOptions?: RequestInit }):
       Promise<SessionHandler> {
     let buffer: Uint8Array;
     if (typeof pathOrBuffer === 'string') {
@@ -53,7 +53,7 @@ class OnnxruntimeWebAssemblyBackend implements Backend {
         buffer = await promisify(readFile)(pathOrBuffer);
       } else {
         // browser
-        const response = await fetch(pathOrBuffer);
+        const response = await fetch(pathOrBuffer, options?.fetchOptions ?? {});
         const arrayBuffer = await response.arrayBuffer();
         buffer = new Uint8Array(arrayBuffer);
       }

--- a/js/web/lib/onnxjs/session.ts
+++ b/js/web/lib/onnxjs/session.ts
@@ -48,10 +48,10 @@ export class Session {
     this.profiler.stop();
   }
 
-  async loadModel(uri: string): Promise<void>;
+  async loadModel(uri: string, fetchOptions?: RequestInit): Promise<void>;
   async loadModel(buffer: ArrayBuffer, byteOffset?: number, length?: number): Promise<void>;
   async loadModel(buffer: Uint8Array): Promise<void>;
-  async loadModel(arg: string|ArrayBuffer|Uint8Array, byteOffset?: number, length?: number): Promise<void> {
+  async loadModel(arg: string|ArrayBuffer|Uint8Array, arg1?: RequestInit | number, length?: number): Promise<void> {
     await this.profiler.event('session', 'Session.loadModel', async () => {
       // resolve backend and session handler
       const backend = await resolveBackend(this.backendHint);
@@ -66,13 +66,13 @@ export class Session {
           this.initialize(Buffer.from(buf), isOrtFormat);
         } else {
           // browser
-          const response = await fetch(arg);
+          const response = await fetch(arg, (arg1 ?? {}) as RequestInit);
           const buf = await response.arrayBuffer();
           this.initialize(new Uint8Array(buf), isOrtFormat);
         }
       } else if (!ArrayBuffer.isView(arg)) {
         // load model from ArrayBuffer
-        const arr = new Uint8Array(arg, byteOffset || 0, length || arg.byteLength);
+        const arr = new Uint8Array(arg, (arg1 || 0) as number, length || arg.byteLength);
         this.initialize(arr);
       } else {
         // load model from Uint8array


### PR DESCRIPTION
i've changed the first override of the loadSession functions that accepts a uri to also accept an optional parameter that is a RequestInit type. 
this object will be the configurations needed for fetch to perform

**Motivation and Context**
- there is a need to send fetch config options in order to get fetch to send credentials and other things
- issue #9031 