### PR TITLE
Update Openvino docker files

### DIFF
--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -21,14 +21,15 @@ ENV InferenceEngine_DIR=${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/
 ENV ngraph_DIR=${INTEL_OPENVINO_DIR}/deployment_tools/ngraph/cmake
 
 USER root
-RUN apt update; apt install -y git protobuf-compiler libprotobuf-dev
-RUN git clone --recursive -b ${ONNXRUNTIME_BRANCH} ${ONNXRUNTIME_REPO} 
-RUN /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh
-RUN ln -s cmake-* cmake-dir
-RUN python3 -m pip install wheel
 ENV PATH=${WORKDIR_PATH}/cmake-dir/bin:$PATH
-RUN pip3 install onnx
-RUN cd onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino ${DEVICE} --build_shared_lib --build_wheel 
+RUN apt update; apt install -y git
+RUN git clone --recursive -b ${ONNXRUNTIME_BRANCH} ${ONNXRUNTIME_REPO} && \
+    onnxruntime/dockerfiles/scripts/install_common_deps_openvino.sh && \
+    python3 -m pip install wheel && \
+    onnxruntime/tools/ci_build/github/linux/docker/scripts/install_protobuf.sh && \
+    cd onnxruntime/cmake/external/onnx && python3 setup.py install && \
+    xargs rm < /tmp/src/protobuf-3.16.0/install_manifest.txt ; rm -rf /tmp/src && \
+    cd /home/openvino/onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino ${DEVICE} --build_shared_lib --build_wheel 
 
 #Steps to download sources
 RUN cat /etc/apt/sources.list | sed 's/^# deb-src/deb-src/g' > ./temp; mv temp /etc/apt/sources.list

--- a/dockerfiles/Dockerfile.openvino-csharp
+++ b/dockerfiles/Dockerfile.openvino-csharp
@@ -12,7 +12,7 @@ ARG ONNXRUNTIME_BRANCH=master
 WORKDIR /code
 ARG MY_ROOT=/code
 
-ENV PATH /opt/miniconda/bin:/code/cmake-3.21.0-linux-x86_64/bin:$PATH
+ENV PATH /opt/miniconda/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/miniconda/lib:/usr/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 
 ENV INTEL_OPENVINO_DIR=/opt/intel/openvino_2021.4.689
@@ -28,7 +28,7 @@ ENV LANG en_US.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt update -y && \
-    apt -y install --no-install-recommends apt-transport-https ca-certificates python3 python3-pip gnupg udev zip unzip x11-apps lsb-core wget curl cpio sudo libboost-python-dev libpng-dev zlib1g-dev git libnuma1 ocl-icd-libopencl1 clinfo libboost-filesystem1.65-dev libboost-thread1.65-dev protobuf-compiler libprotoc-dev autoconf automake libtool libjson-c-dev unattended-upgrades && \
+    apt -y install --no-install-recommends apt-transport-https ca-certificates python3 python3-pip gnupg udev zip unzip x11-apps lsb-core wget curl cpio sudo libboost-python-dev libpng-dev zlib1g-dev git libnuma1 ocl-icd-libopencl1 clinfo libboost-filesystem1.65-dev libboost-thread1.65-dev autoconf automake libtool libjson-c-dev unattended-upgrades && \
     unattended-upgrade && \
     rm -rf /var/lib/apt/lists/* && \
 # libusb from source
@@ -101,15 +101,18 @@ RUN apt update -y && \
 # Download and build ONNX Runtime
     cd ${MY_ROOT} && \
     git clone --recursive -b ${ONNXRUNTIME_BRANCH} ${ONNXRUNTIME_REPO} && \
-    /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh && \
+    apt-get remove -y cmake cmake-data && \
+    onnxruntime/dockerfiles/scripts/install_common_deps_openvino.sh && \
+    onnxruntime/tools/ci_build/github/linux/docker/scripts/install_protobuf.sh && \
     cd onnxruntime/cmake/external/onnx && python3 setup.py install && \
+    xargs rm < /tmp/src/protobuf-3.16.0/install_manifest.txt ; rm -rf /tmp/src && \
     cd ${MY_ROOT}/onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino ${DEVICE} --build_nuget --build_shared_lib && \
     mv ${MY_ROOT}/onnxruntime/build/Linux/Release/nuget-artifacts ${MY_ROOT} && \
 # Clean-up unnecessary files
-    rm -rf ${MY_ROOT}/cmake* /opt/cmake ${MY_ROOT}/onnxruntime && \
+    cd / && rm -rf ${MY_ROOT}/onnxruntime && \
     rm -rf /opt/miniconda && \
     rm -rf /opt/v1.0.22.zip && \
-    apt remove -y git && apt autoremove -y  && apt remove -y cmake && \
+    apt remove -y git && apt autoremove -y  && \
     cd /usr/lib/ && rm -rf python2.7 python3.7 python3.8  && \
     cd && rm -rf .cache && \
     cd /usr/share/python-wheels/ && rm -rf *.whl

--- a/dockerfiles/scripts/install_common_deps_openvino.sh
+++ b/dockerfiles/scripts/install_common_deps_openvino.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e -x
+DEBIAN_FRONTEND=noninteractive
+apt-get update && apt-get install -y --no-install-recommends \
+        wget \
+        zip \
+        ca-certificates \
+        curl \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        python3-dev
+
+# Dependencies: conda
+wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O ~/miniconda.sh --no-check-certificate && /bin/bash ~/miniconda.sh -b -p /opt/miniconda
+rm ~/miniconda.sh
+/opt/miniconda/bin/conda clean -ya
+/opt/miniconda/bin/conda install -c anaconda cmake==3.19.6 gcc_linux-64 gxx_linux-64 numpy
+rm -rf /opt/miniconda/pkgs


### PR DESCRIPTION
**Description**: 

Update Openvino docker files

**Motivation and Context**
- Why is this change required? What problem does it solve?
Avoid errors like:

```
/usr/bin/ld: /usr/lib/x86_64-linux-gnu/libprotobuf.a(arena.o): relocation R_X86_64_TPOFF32 against hidden symbol `_ZN6google8protobuf5Arena13thread_cache_E' can not be used when making a shared object
/usr/bin/ld: /usr/lib/x86_64-linux-gnu/libprotobuf.a(descriptor.o): relocation R_X86_64_PC32 against symbol `_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EED1Ev' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
```



- If it fixes an open issue, please link to the issue here.
