### PR TITLE
Replaced onnx build with pypi installation

### DIFF
--- a/dockerfiles/Dockerfile.openvino-csharp
+++ b/dockerfiles/Dockerfile.openvino-csharp
@@ -102,7 +102,7 @@ RUN apt update -y && \
     cd ${MY_ROOT} && \
     git clone --recursive -b ${ONNXRUNTIME_BRANCH} ${ONNXRUNTIME_REPO} && \
     /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh && \
-    cd onnxruntime/cmake/external/onnx && python3 setup.py install && \
+    pip install onnx==1.9 && \
     cd ${MY_ROOT}/onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino ${DEVICE} --build_nuget --build_shared_lib && \
     mv ${MY_ROOT}/onnxruntime/build/Linux/Release/nuget-artifacts ${MY_ROOT} && \
 # Clean-up unnecessary files


### PR DESCRIPTION
Building ONNX from source was leading to errors. Instead we directly install onnx from pypi library. 

**Motivation and Context**
- This change is required because building onnx and protobuf library from ORT leads to error 
- If it fixes an open issue, please link to the issue here.
