### PR TITLE
LayerNormGrad function body and LayerNorm inference/body fix

### DIFF
--- a/onnxruntime/core/graph/contrib_ops/onnx_function_util.h
+++ b/onnxruntime/core/graph/contrib_ops/onnx_function_util.h
@@ -9,6 +9,7 @@
 #include "onnx/onnx-operators_pb.h"
 #include "onnx/defs/schema.h"
 #include "onnx/defs/function.h"
+#include "onnx/defs/parser.h"
 
 namespace ONNX_NAMESPACE {
 
@@ -20,4 +21,55 @@ inline static FunctionBodyHelper::NodeDef Const(const std::string& name, double 
   return FunctionBodyHelper::NodeDef{
       {name}, "Constant", {}, {{"value", ToTensor(value, elem_type)}}};
 }
+
+class FunctionBuilder {
+ public:
+  FunctionBuilder(FunctionProto& funProto_) : funProto(funProto_) {}
+
+  FunctionBuilder& Add(const char* nodes_txt) {
+    OnnxParser parser(nodes_txt);
+    auto& nodes = *funProto.mutable_node();
+
+    while (!parser.EndOfInput()) {
+      auto status = parser.Parse(*nodes.Add());
+      if (!status.IsOK())
+        ONNX_THROW_EX(std::logic_error("Error parsing node:" + status.ErrorMessage()));
+    }
+
+    return *this;
+  }
+
+  FunctionBuilder& Add(const char* node_txt, const AttributeProto& attr) {
+    OnnxParser parser(node_txt);
+    auto& node = *funProto.add_node();
+    auto status = parser.Parse(node);
+    if (!status.IsOK()) {
+      ONNX_THROW_EX(std::logic_error("Error parsing node:" + status.ErrorMessage()));
+    }
+
+    if (!parser.EndOfInput()) {
+      ONNX_THROW_EX(std::logic_error("Error unexpected extra input in node:" + status.ErrorMessage()));
+    }
+
+    *node.add_attribute() = attr;
+
+    return *this;
+  }
+
+  template <typename T>
+  FunctionBuilder& Add(const char* node_txt, const std::string& attr_name, T attr_value) {
+    return Add (node_txt, MakeAttribute(attr_name, attr_value));
+  }
+
+  FunctionBuilder& AddOpset(const char* domain, int version) {
+    auto* opset = funProto.add_opset_import();
+    opset->set_domain(domain);
+    opset->set_version(version);
+    return *this;
+  }
+
+ private:
+  FunctionProto& funProto;
+};
+
 }  // namespace ONNX_NAMESPACE

--- a/onnxruntime/test/contrib_ops/function_ops_test.cc
+++ b/onnxruntime/test/contrib_ops/function_ops_test.cc
@@ -27,10 +27,8 @@ class ContribFunExpansionTest : public ::testing::Test {
 };
 
 template <typename T, typename U, bool RunTest>
-void CheckLayerNorm(bool compute_mean = true, bool compute_isd = true) {
+void CheckLayerNorm(bool compute_mean = true, bool compute_isd = true, std::vector<int64_t> shape1 = {8, 16}, std::vector<int64_t> shape2 = {16}, int64_t axis = -1) {
   FunctionTestCase testCase("LayerNormalization", kOnnxDomain);
-  std::vector<int64_t> shape1{8, 16};
-  std::vector<int64_t> shape2{16};
 
   testCase.AddInput<T, RunTest>("x", shape1);
   testCase.AddInput<T, RunTest>("scale", shape2);
@@ -39,6 +37,8 @@ void CheckLayerNorm(bool compute_mean = true, bool compute_isd = true) {
   testCase.AddOutput(compute_mean ? "mean" : "");
   testCase.AddOutput(compute_isd ? "invstddev" : "");
   testCase.AddAttribute("stash_type", data_types_internal::ToTensorDataType<U>());
+  if (axis != -1)
+    testCase.AddAttribute("axis", axis);
   if (RunTest)
     testCase.RunTest();
   else
@@ -57,6 +57,11 @@ TEST_F(ContribFunExpansionTest, LayerNorm_OptionalOutputs) {
   CheckLayerNorm<float, float, true>(false, false);
   CheckLayerNorm<float, float, true>(false, true);
   CheckLayerNorm<float, float, true>(true, false);
+}
+
+TEST_F(ContribFunExpansionTest, LayerNorm_OtherShapes) {
+  // Test expand-and-run
+  CheckLayerNorm<float, float, true>(true, true, {4, 2, 8}, {2, 8}, 1);
 }
 
 template <typename T>


### PR DESCRIPTION
**Description**:
(1) Add function body for LayerNormGrad op
(2) Fix shape-inference bug and function-body bug in LayerNorm to handle multiple normalization dims
(3) Add FunctionBuilder class to simplify function-body definitions.

**Motivation and Context**
Adding a function-body reduces the need for a backend to explicitly implement the op. It also allows us to export models containing this op to ONNX-MLIR for compilation using the MLIR stack.
