### PR TITLE
Change keepdims of ReduceMax/ReduceMin to always 1 when using quatization calibration MinMax approach

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -164,7 +164,7 @@ class MinMaxCalibrater(CalibraterBase):
 
         for tensor in tensors:
 
-            # When doing Reducemax/ReduceMin, ORT can't reduce on dim with value of 0 if 'keepdims' is false.
+            # When doing ReduceMax/ReduceMin, ORT can't reduce on dim with value of 0 if 'keepdims' is false.
             # To make the code simple, we always let keepdims to be 1.
             keepdims = 1
             dim = value_infos[tensor].type.tensor_type.shape.dim

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -164,23 +164,22 @@ class MinMaxCalibrater(CalibraterBase):
 
         for tensor in tensors:
 
-            # When doing ReduceMax/ReduceMin, keep dimension if tensor contains dim with value of 0,
-            # for example:
-            #     dim = [ dim_value: 0 ] 
-            #  
-            # otherwise, don't keep dimension. 
-            #
+            # When doing Reducemax/ReduceMin, ORT can't reduce on dim with value of 0 if 'keepdims' is false.
+            # To make the code simple, we always let keepdims to be 1.
+            keepdims = 1
             dim = value_infos[tensor].type.tensor_type.shape.dim
-            keepdims = 0
-            shape = ()
+            dim_len = 0
+
+            # dim could be:
+            #   [dim_param: "batch_size", dim_value: 256, dim_value: 36, dim_value: 64],
+            #   [dim_value: 0],
+            #   ...
+            # Please see the definition of TensorShapeProto https://github.com/onnx/onnx/blob/master/onnx/onnx.proto#L651
             for d in dim:
-                # A dimension can be either an integer value or a symbolic variable.
-                # Dimension with integer value and value of 0 is what we are looking for to keep dimension. 
-                # Please see the def of TensorShapeProto https://github.com/onnx/onnx/blob/master/onnx/onnx.proto#L630
-                if d.WhichOneof('value') == 'dim_value' and d.dim_value == 0:
-                    keepdims = 1
-                    shape = (1,) if len(dim) == 1 else list(1 for i in range(len(dim)))
-                    break
+                if d.WhichOneof('value') == 'dim_value':
+                    dim_len += 1
+
+            shape = (1,) if dim_len == 1 else tuple(1 for i in range(dim_len))
 
             # Adding ReduceMin nodes
             reduce_min_name = tensor + '_ReduceMin'

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -167,19 +167,14 @@ class MinMaxCalibrater(CalibraterBase):
             # When doing ReduceMax/ReduceMin, ORT can't reduce on dim with value of 0 if 'keepdims' is false.
             # To make the code simple, we always let keepdims to be 1.
             keepdims = 1
-            dim = value_infos[tensor].type.tensor_type.shape.dim
-            dim_len = 0
 
             # dim could be:
             #   [dim_param: "batch_size", dim_value: 256, dim_value: 36, dim_value: 64],
             #   [dim_value: 0],
             #   ...
             # Please see the definition of TensorShapeProto https://github.com/onnx/onnx/blob/master/onnx/onnx.proto#L651
-            for d in dim:
-                if d.WhichOneof('value') == 'dim_value':
-                    dim_len += 1
-
-            shape = (1,) if dim_len == 1 else tuple(1 for i in range(dim_len))
+            dim = value_infos[tensor].type.tensor_type.shape.dim
+            shape = (1,) if len(dim) == 1 else tuple(1 for i in range(len(dim)))
 
             # Adding ReduceMin nodes
             reduce_min_name = tensor + '_ReduceMin'


### PR DESCRIPTION
When doing Reducemax/ReduceMin, ORT can't reduce on dim with value of 0 if 'keepdims' is false.
Currently quantization script still faces some situations where it reduces the dim that it shouldn't.
To make the code simple, we always let keepdims to be 1
